### PR TITLE
Align public docs with core branch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ That delegation does not allow:
 
 - Issue closure without explicit human approval
 - changing the scoped Issue set by assumption
-- declaring wizard-complete / milestone-complete by implication
+- declaring milestone-complete by implication
 
 ## Canonical Source Order
 
@@ -54,12 +54,10 @@ Current repository execution note:
 - when the user explicitly fixes the active implementation window to specific
   Issues, treat only those Issues as in-scope for implementation until the user
   re-opens the broader active-Issue set
-- the historical `#210` / `#207` setup-wizard window is closed; do not keep
-  treating that bounded window as the current implementation scope after the
-  owner redefines the goal
-- for the current Day0 setup-wizard redesign, the active implementation scope
-  must be re-established explicitly before runtime edits begin; do not inherit
-  old setup-wizard assumptions by default
+- the historical setup-wizard line is archived; do not treat it as active
+  implementation scope on this branch unless the user explicitly re-activates it
+- this public/core branch does not use the setup wizard by default; do not
+  inherit old wizard assumptions into current runtime or docs work
 
 If any active Issue is intentionally deferred, record it explicitly as deferred with reason.
 Never treat "not implemented yet" as "done".
@@ -106,11 +104,9 @@ boundary, or partial compliance state:
 Do not treat "this probably should be fixed now" as sufficient justification to
 continue implementation.
 
-For the current Day0 setup-wizard redesign, the bounded change contract must
-also state:
+For this public/core branch, the bounded change contract must also state when relevant:
 
-- whether the change assumes an existing user-owned Cloudflare runtime, or
-  creates one as part of the flow
+- whether any archived wizard artifact is being changed, removed, or referenced
 - whether any personal/operator-specific runtime URL, account identifier, or
   bootstrap value is touched, removed, or still referenced
 - whether the change is safe for a repo intended to be usable by people other
@@ -175,37 +171,27 @@ MVP completion claim is allowed only when the matrix shows complete coverage for
 - High-risk credential is short-lived and approval-bound.
 - Memory excludes secrets and raw sensitive material.
 - Reviewer role does not get execution credentials.
-- Public-facing setup flow must not embed the owner's personal Cloudflare
+- Public-facing docs and runtime must not embed the owner's personal Cloudflare
   runtime URL or equivalent operator-specific runtime destination.
-- Setup flow for shared/public use must converge on user-owned GitHub,
-  Cloudflare, Gemini, and ChatGPT accounts rather than the owner's accounts.
+- Shared/public use must converge on user-owned GitHub, Cloudflare, Gemini,
+  and ChatGPT accounts rather than the owner's accounts.
 - Existing operator-specific bootstrap/runtime assumptions must not be silently
-  carried into Day0 wizard work.
+  carried into current main-line work.
 
-## Day0 Wizard Redesign Guardrails
+## Archived Wizard Boundary
 
-When the owner states that VTDD must be usable by people other than the owner,
-interpret that as a shared-use Day0 wizard requirement, not as an incremental
-polish request on the legacy bootstrap flow.
+The setup-wizard line is historical on this branch.
+Treat wizard-specific docs, tests, and behavior as archived research unless the
+user explicitly re-activates them with a bounded Issue/spec.
 
-For that redesign:
+On this branch:
 
-- an existing personal Cloudflare Worker/runtime is not a valid default target
-- creating or resolving a user-owned Cloudflare runtime inside the wizard is a
-  required behavior, not optional polish
-- the first shared-use Cloudflare connection path is API Token based unless the
-  canonical spec is explicitly changed
-- worker/runtime URL may be created or resolved inside wizard state, but must
-  not be rendered as a raw public-facing setup value by default
-- Cloudflare API Token accepted from wizard input must stay in bounded
-  temporary server-controlled setup state only; do not place it in URLs, normal
-  JSON output, or shared troubleshooting logs
-- GitHub-side setup must be described in terms of the user's own control plane,
-  not the owner's private bootstrap environment
-- if the code only supports bounded bootstrap into an already-existing runtime,
-  report that as incomplete rather than stretching definitions
-- do not claim wizard-complete while runtime creation, user-owned control, or
-  post-setup GPT entry remain missing
+- do not reintroduce setup wizard behavior, API shape, or completion claims by
+  implication
+- do not keep wizard-era docs as active canonical references when the files or
+  runtime paths no longer exist
+- if historical wizard material is kept for comparison, mark it explicitly as
+  archive/historical rather than active scope
 
 If the repository still contains owner-specific identifiers, links, script
 names, URLs, or environment assumptions that would make the flow owner-only:
@@ -217,7 +203,7 @@ names, URLs, or environment assumptions that would make the flow owner-only:
 If the owner delegates implementation while away from the keyboard, that
 delegation still does not authorize speculative gap-filling. The assistant may
 continue through PR creation and merge only while the current step remains
-inside an explicitly stated Day0 wizard contract. Stop when:
+inside an explicitly stated contract. Stop when:
 
 - a required platform capability is unknown or cannot be verified
 - GitHub / Cloudflare / ChatGPT ownership semantics become ambiguous
@@ -251,6 +237,10 @@ It must not be interpreted as a blanket prohibition for non-RAG operational logs
 ## Change Size and PR Discipline
 
 - Prefer one bounded Issue slice per PR.
+- Do not develop directly on `main`.
+- Start by syncing the latest `main`, then create a topic branch before making changes.
+- Do implementation work on the topic branch, push that branch to remote, and open a PR targeting `main`.
+- If work has already started on `main`, stop and move the in-progress changes onto a topic branch before continuing.
 - No "while we are here" edits.
 - No unrelated refactors in implementation PRs.
 - Keep docs-only PRs and runtime PRs separable when possible.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,12 +22,15 @@ bounded Issue window, that delegation allows:
 - PR creation
 - PR review response and iteration
 - merge only after scoped criteria, tests, and mapped E2E evidence are all present
+- post-merge Issue closure and merged-branch deletion only after the same
+  scoped criteria, tests, and mapped E2E evidence are all present
 
 That delegation does not allow:
 
-- Issue closure without explicit human approval
 - changing the scoped Issue set by assumption
 - declaring milestone-complete by implication
+- deploy, credential mutation, permission mutation, or destructive operation
+  without `GO + passkey`
 
 ## Canonical Source Order
 
@@ -126,11 +129,11 @@ Issue closure is allowed only when all are true:
 1. Code implementing the scoped criteria is merged.
 2. Required tests pass.
 3. Mapped E2E scenario(s) pass with evidence.
-4. Human explicitly approves closure.
+4. A human has explicitly delegated or approved closure for the scoped work
+   (for example via `GO` in a bounded execution window).
 
-Even when the user delegates merge authority, keep Issue closure and milestone
-completion judgment human-approved unless the user explicitly delegates closure
-for the specific Issue.
+Even when the user delegates merge authority, keep milestone completion judgment
+human-approved unless the user explicitly delegates that judgment.
 
 Manual closure without these four conditions is prohibited.
 
@@ -167,6 +170,8 @@ MVP completion claim is allowed only when the matrix shows complete coverage for
 - No default repository.
 - Unresolved target blocks execution.
 - High-risk actions require GO + passkey.
+- Merge, post-merge Issue closure, and merged-branch deletion require explicit
+  `GO`, not silent inference.
 - Credential model is GitHub App.
 - High-risk credential is short-lived and approval-bound.
 - Memory excludes secrets and raw sensitive material.
@@ -209,6 +214,30 @@ inside an explicitly stated contract. Stop when:
 - GitHub / Cloudflare / ChatGPT ownership semantics become ambiguous
 - a change would expose or depend on owner-specific runtime state
 - Issue / spec coverage for the current implementation slice is missing
+
+## Authority Boundary
+
+- `GO` may authorize bounded execution work including PR creation/update,
+  merge, post-merge Issue closure, and merged-branch deletion.
+- `GO` does not authorize deploy, credential mutation, permission mutation, or
+  destructive/high-blast-radius operations.
+- `GO + passkey` is required for deploy, credential mutation, permission
+  mutation, destructive operations, and other high-risk external effects.
+- Issue closure is allowed only after merge and only when scoped criteria,
+  tests, and mapped E2E evidence are all present.
+- Merged-branch deletion is allowed only for the branch merged by that scoped
+  PR, not for unrelated branches.
+
+## Public Repo Collaboration Boundary
+
+- For a public repository owned by a personal account, do not add human
+  collaborators by default.
+- Default external contribution path is fork + PR, not direct collaborator
+  write access.
+- Preserve owner-only administration for Actions settings, GitHub App setup,
+  secrets, and other repository administration surfaces whenever possible.
+- If a human collaborator is ever added, treat that as an explicit policy
+  change and re-evaluate Issue close, secret, and execution-boundary risk.
 
 ## RAG Memory Capture and Cost Boundary
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -227,6 +227,16 @@ inside an explicitly stated contract. Stop when:
   tests, and mapped E2E evidence are all present.
 - Merged-branch deletion is allowed only for the branch merged by that scoped
   PR, not for unrelated branches.
+- GitHub-side approval boundaries are canonicalized in
+  `docs/security/consent-approval-model.md`.
+- Treat GitHub App capability as execution ability, not as standing permission.
+- Require `GO + passkey` for GitHub-side secret/variable mutation, GitHub App
+  install or permission mutation, repository settings mutation, ruleset/branch
+  protection mutation, collaborator mutation, repository archive/delete/transfer,
+  and destructive cleanup outside the bounded post-merge path.
+- Never auto-execute milestone completion judgment, unscoped Issue closure,
+  repository administration mutation, or broad cleanup from repository state
+  alone even if the GitHub App could technically perform it.
 
 ## Public Repo Collaboration Boundary
 

--- a/docs/mvp/e2e/e2e-05-decision-proposal-durability.md
+++ b/docs/mvp/e2e/e2e-05-decision-proposal-durability.md
@@ -19,7 +19,7 @@ Goal:
 Command:
 
 ```sh
-node --test test/decision-log.test.js test/proposal-log.test.js test/worker.test.js
+node --test test/decision-log-model.test.js test/proposal-log-model.test.js test/decision-log-runtime.test.js test/proposal-log-runtime.test.js test/log-store.test.js test/worker.test.js
 ```
 
 Observed result on 2026-04-17:
@@ -33,7 +33,7 @@ Observed result on 2026-04-17:
 Command:
 
 ```sh
-node --test test/decision-log.test.js test/proposal-log.test.js test/worker.test.js
+node --test test/decision-log-model.test.js test/proposal-log-model.test.js test/decision-log-runtime.test.js test/proposal-log-runtime.test.js test/log-store.test.js test/worker.test.js
 ```
 
 Observed result on 2026-04-17:
@@ -44,8 +44,11 @@ Observed result on 2026-04-17:
 
 ## Evidence Files
 
-- `test/decision-log.test.js`
-- `test/proposal-log.test.js`
+- `test/decision-log-model.test.js`
+- `test/proposal-log-model.test.js`
+- `test/decision-log-runtime.test.js`
+- `test/proposal-log-runtime.test.js`
+- `test/log-store.test.js`
 - `test/worker.test.js`
 - `docs/decision-log-model.md`
 - `docs/proposal-log-model.md`

--- a/docs/mvp/e2e/e2e-13-parent-readiness.md
+++ b/docs/mvp/e2e/e2e-13-parent-readiness.md
@@ -43,7 +43,7 @@ As of 2026-04-17:
 ## Evidence Files
 
 - `docs/mvp/issue-13-rewrite-draft.md`
-- `docs/mvp/bootstrap-plan.md`
+- `README.md`
 - `docs/mvp/next-step-handoff.md`
 - `docs/mvp/issue-to-e2e-matrix.md`
 - `docs/mvp/e2e/e2e-01-canonical-docs-reference-integrity.md`

--- a/docs/mvp/issue-13-rewrite-draft.md
+++ b/docs/mvp/issue-13-rewrite-draft.md
@@ -78,7 +78,7 @@ VTDD V2 の MVP 実装を開始するための統合親 Issue を確定する。
 
 - GitHub App is the credential model
 - Credential boundary is segmented by role/risk
-- High-risk actions require `GO + passkey`
+- Merge uses explicit `GO`; high-risk actions require `GO + passkey`
 - Destructive path is separated and audited
 
 ### 4. Memory Backbone and Safety
@@ -109,6 +109,7 @@ VTDD V2 の MVP 実装を開始するための統合親 Issue を確定する。
 - Butler can resolve context safely and refuse unsafe execution
 - Repository mis-targeting risk is reduced by alias + no-default + confirmation path
 - High-risk operations are gated by `GO + passkey` and short-lived credentials
+- Merge and bounded post-merge completion use explicit `GO`
 - Production deploy can be executed under governed approval
 
 ## Execution Notes

--- a/docs/mvp/issue-13-rewrite-draft.md
+++ b/docs/mvp/issue-13-rewrite-draft.md
@@ -54,7 +54,8 @@ VTDD V2 の MVP 実装を開始するための統合親 Issue を確定する。
 - `docs/memory/rag-memory-philosophy.md`
 - `docs/security/threat-model.md`
 - `docs/security/go-passkey-approval-model.md`
-- `docs/mvp/bootstrap-plan.md`
+- `README.md`
+- `docs/mvp/next-step-handoff.md`
 - `docs/mvp/issue-triage-plan.md`
 
 ## MVP Scope (Must Hold Together)

--- a/docs/mvp/issue-to-e2e-matrix.md
+++ b/docs/mvp/issue-to-e2e-matrix.md
@@ -26,10 +26,11 @@ Status values used below:
   - parent issue is not misread as completed while repository status remains partial
 - Implementation evidence:
   - `docs/mvp/issue-13-rewrite-draft.md`
-  - `docs/mvp/bootstrap-plan.md`
+  - `README.md`
   - `docs/mvp/next-step-handoff.md`
 - Test evidence:
-  - `test/bootstrap-plan-current-state.test.js`
+  - `test/e2e-13-parent-readiness.test.js`
+  - `test/issue-triage-plan-current-state.test.js`
 - Run evidence:
   - `docs/mvp/e2e/e2e-13-parent-readiness.md`
 - Status: `e2e_evidenced_pending_human_closure`
@@ -122,8 +123,11 @@ Status values used below:
   - `docs/proposal-log-model.md`
   - `src/worker.js`
 - Test evidence:
-  - `test/decision-log.test.js`
-  - `test/proposal-log.test.js`
+  - `test/decision-log-model.test.js`
+  - `test/proposal-log-model.test.js`
+  - `test/decision-log-runtime.test.js`
+  - `test/proposal-log-runtime.test.js`
+  - `test/log-store.test.js`
   - `test/worker.test.js`
 - Run evidence:
   - `docs/mvp/e2e/e2e-05-decision-proposal-durability.md`
@@ -169,25 +173,6 @@ Status values used below:
   - `test/worker.test.js`
 - Run evidence:
   - `docs/mvp/e2e/e2e-07-butler-constitution-first-judgment.md`
-- Status: `e2e_evidenced_pending_human_closure`
-
-## E2E-08 Repo resolution safety + conversation switch confirm
-
-- Issues: `#21 #39 #41`
-- Happy path:
-  - iPhone-accessible setup wizard returns conversation-ready onboarding with no default repo, copy-ready setup output, full Instructions replacement guidance, schema import URL for Custom GPT action setup, machine-auth setting names, repository switch confirmation flow, and no generic secret input prompts outside the passcode-authenticated GitHub App bootstrap step
-- Boundary path:
-  - unresolved repo, generic secret input, or ambiguous switch blocks execution or setup acceptance
-- Implementation evidence:
-  - `src/core/setup-wizard.js`
-  - `src/worker.js`
-  - `docs/mvp/iphone-first-setup.md`
-- Test evidence:
-  - `test/setup-wizard.test.js`
-  - `test/worker.test.js`
-  - `test/butler-orchestrator.test.js`
-- Run evidence:
-  - `docs/mvp/e2e/e2e-08-iphone-setup-and-repo-safety.md`
 - Status: `e2e_evidenced_pending_human_closure`
 
 ## E2E-09 Memory safety exclusions
@@ -288,36 +273,10 @@ Status values used below:
   - `docs/mvp/e2e/e2e-13-reviewer-operational-loop.md`
 - Status: `e2e_evidenced_pending_human_closure`
 
-## E2E-14 Setup wizard approval-bound path
-
-- Issues: `#207 #210 #477`
-- Happy path:
-  - setup wizard carries one approval-bound installation-binding flow through to
-    Worker runtime write and same-flow live readiness proof without manual ID or
-    secret transport across GitHub and Cloudflare surfaces, and reports
-    setup-complete readiness only when VTDD required runtime settings are present
-- Boundary path:
-  - missing Cloudflare prerequisites, missing current `GO + passkey` request,
-    deferred approval-bound issuance, or missing required runtime settings remain
-    explicit fail-closed states with recovery guidance inside the same setup narrative
-- Implementation evidence:
-  - `src/worker.js`
-  - `docs/mvp/setup-wizard-current-and-target-flow.md`
-  - `docs/mvp/setup-wizard-approval-bound-runtime-checkpoint.md`
-  - `docs/security/setup-wizard-approval-bound-automation-path.md`
-- Test evidence:
-  - `test/worker.test.js`
-  - `test/setup-wizard-current-and-target-flow.test.js`
-  - `test/setup-wizard-approval-bound-automation-path.test.js`
-  - `test/e2e-14-setup-wizard-approval-bound-path.test.js`
-- Run evidence:
-  - `docs/mvp/e2e/e2e-14-setup-wizard-approval-bound-path.md`
-- Status: `e2e_evidenced_pending_human_closure`
-
 ## Current Completion Reading
 
 - Repository completion status: `partial`
 - Main reason:
-  - mapped E2E evidence now exists across the matrix
+  - mapped E2E evidence now exists across the active main-line matrix
   - issue closure must remain human-gated
   - parent/spec issues remain intentionally open until the owner judges closure

--- a/docs/mvp/next-step-handoff.md
+++ b/docs/mvp/next-step-handoff.md
@@ -8,7 +8,7 @@ This file exists so work can resume in a fresh thread without re-deriving the cu
 - historical MVP core runtime/evidence work is already in repo
 - `docs/mvp/issue-to-e2e-matrix.md` remains the canonical tracker for the completed MVP-core issue set
 - wizard research has been archived onto `wizard-ready`
-- current main-line work is `#486`: remove the hosted wizard line from `main` and keep only VTDD core
+- current main-line direction is to keep `main` honest as the VTDD core line in this public repo
 
 ## What Remains Open
 
@@ -26,7 +26,7 @@ Re-check open Issues first.
 1. sync local `main` with `origin/main`
 2. check open Issues
 3. choose exactly one bounded target Issue
-4. if the target is `#486`, remove only hosted wizard surfaces and keep VTDD core intact
+4. keep hosted wizard assumptions out of current `main` unless explicitly re-activated
 5. write a bounded change contract before runtime edits
 6. update the Issue-to-E2E matrix only when actual runtime behavior or evidence lands
 

--- a/docs/mvp/production-deploy-path.md
+++ b/docs/mvp/production-deploy-path.md
@@ -10,7 +10,7 @@ Status note:
 
 - this is the current GitHub Actions centered MVP path
 - deploy authority branching alternatives are tracked in
-  [deploy-authority-branching.md](/Users/shuhei/hibou_works/vtdd-v2/docs/mvp/deploy-authority-branching.md)
+  `docs/mvp/deploy-authority-branching.md`
 
 ## Required GitHub Settings
 

--- a/docs/security/consent-approval-model.md
+++ b/docs/security/consent-approval-model.md
@@ -75,6 +75,53 @@ level as `merge`:
 These tasks are not authorized by category consent alone and must not be
 inferred without explicit scoped `GO`.
 
+## GitHub Operation Matrix
+
+The GitHub App may hold broad repository capabilities, but VTDD must still
+separate "can execute" from "may execute now." The following matrix is the
+canonical approval boundary for GitHub-side actions.
+
+### `GO`
+
+Bounded repository workflow operations may proceed with explicit scoped `GO`:
+
+- branch creation for scoped work
+- commit / push on the scoped topic branch
+- PR creation, update, label, assignee, and review-response work
+- PR comment and scoped review iteration
+- merge, when scoped criteria, tests, and mapped E2E evidence are present
+- post-merge issue close for the scoped work
+- deletion of the merged topic branch tied to that scoped PR
+
+### `GO + passkey`
+
+High-risk or administration-bearing GitHub operations require explicit scoped
+`GO + passkey`:
+
+- production deploy or deploy-triggering repository operation
+- repository / environment secret creation, update, or deletion
+- repository / environment variable creation, update, or deletion
+- GitHub App installation, token, credential, or permission mutation
+- repository settings mutation
+- ruleset, branch protection, environment protection, or merge-policy mutation
+- collaborator / team / permission mutation
+- repository archive, delete, transfer, visibility change, or equivalent
+- destructive branch, tag, release, environment, or workflow mutation outside
+  the bounded post-merge branch cleanup path
+- external publish or externally visible integration enablement
+
+### `Never Auto`
+
+The following must never be inferred or auto-executed from repository state
+alone, even when the GitHub App technically has the capability:
+
+- milestone completion judgment
+- issue closure without bounded scope linkage to the merged work
+- repository administration or permission mutation without explicit high-risk approval
+- destructive operation without explicit scoped `GO + passkey`
+- broad cleanup outside the currently scoped branch / PR / issue window
+- policy reinterpretation from "the app can do it" to "the app may do it now"
+
 ## Destructive Handling
 
 - Destructive operations must pass the `destructive` consent category.

--- a/docs/security/consent-approval-model.md
+++ b/docs/security/consent-approval-model.md
@@ -31,6 +31,7 @@ action on this specific scope proceed now?"
 - `approvalPhrase` is required whenever approval level is not `none`.
 - Approval must be bound to the target scope.
 - High-risk operations require `GO + passkey`.
+- Merge and bounded post-merge completion tasks require explicit `GO`.
 
 ## Canonical Action Mapping
 
@@ -57,10 +58,22 @@ action on this specific scope proceed now?"
 - `pr_comment` -> `none`
 - `pr_review_submit` -> `go`
 - `pr_operation` -> `go`
-- `merge` -> `go_passkey`
+- `merge` -> `go`
 - `deploy_production` -> `go_passkey`
 - `destructive` -> `go_passkey`
 - `external_publish` -> `go_passkey`
+
+## Operational Extension
+
+The canonical action table above covers the current execution action types.
+The following bounded post-merge completion tasks follow the same `go` approval
+level as `merge`:
+
+- issue close for the scoped work that was just merged
+- deletion of the merged topic branch tied to that PR
+
+These tasks are not authorized by category consent alone and must not be
+inferred without explicit scoped `GO`.
 
 ## Destructive Handling
 

--- a/docs/security/go-passkey-approval-model.md
+++ b/docs/security/go-passkey-approval-model.md
@@ -7,6 +7,8 @@ For the full canonical consent / approval model, see
 ## Intent
 
 High-risk actions should require both explicit intent and strong user authentication.
+Merge and bounded post-merge completion tasks remain explicit `GO` actions, but
+they are not part of the `GO + passkey` set.
 
 ## Approval Levels
 
@@ -23,13 +25,17 @@ No explicit approval required.
 - issue creation
 - branch / PR operations
 - normal execution
+- merge
+- post-merge issue close for the scoped work
+- merged-branch deletion for the scoped PR
 
 Requires `GO`.
 
 ### Level 3
 
-- merge
 - production deploy
+- credential mutation
+- permission mutation
 - destructive actions
 - external publish
 

--- a/docs/security/go-passkey-approval-model.md
+++ b/docs/security/go-passkey-approval-model.md
@@ -41,6 +41,33 @@ Requires `GO`.
 
 Requires `GO + passkey`.
 
+## GitHub-side High-risk Examples
+
+When the execution surface is GitHub, `GO + passkey` includes at least:
+
+- repository or environment secret / variable mutation
+- GitHub App installation, credential, token, or permission mutation
+- repository settings mutation
+- ruleset / branch protection / environment protection mutation
+- collaborator / team / permission mutation
+- repository archive / delete / transfer / visibility change
+- destructive workflow, release, branch, tag, or environment mutation outside
+  the bounded post-merge cleanup path
+
+These operations may be technically possible for the GitHub App, but VTDD must
+still block them until explicit scoped `GO + passkey` succeeds.
+
+## Never-auto Boundary
+
+`GO + passkey` is a required unlock for high-risk execution, but it does not
+convert GitHub state changes into auto-permitted behavior. VTDD must still
+forbid automatic:
+
+- milestone completion judgment
+- issue closure without scoped linkage to merged work
+- repository administration changes inferred from convenience
+- destructive cleanup outside the currently scoped work window
+
 ## Approval Components
 
 - `GO` confirms human intent.

--- a/docs/security/reviewer-policy.md
+++ b/docs/security/reviewer-policy.md
@@ -59,7 +59,7 @@ The reviewer contract must stay compatible with registry-based adapter replaceme
 
 - Butler treats reviewer output as a blocking risk signal when critical findings or serious risks are present.
 - Butler may summarize or structure reviewer output, but must not erase meaningful reviewer objections.
-- Human remains the final authority for revision GO and merge GO.
+- Human remains the final authority for revision GO and for GO/GO+passkey authority delegation.
 
 ## Security Boundary
 

--- a/src/core/approval.js
+++ b/src/core/approval.js
@@ -4,11 +4,11 @@ const GO_REQUIRED_ACTIONS = new Set([
   ActionType.ISSUE_CREATE,
   ActionType.BUILD,
   ActionType.PR_REVIEW_SUBMIT,
-  ActionType.PR_OPERATION
+  ActionType.PR_OPERATION,
+  ActionType.MERGE
 ]);
 
 const GO_PASSKEY_REQUIRED_ACTIONS = new Set([
-  ActionType.MERGE,
   ActionType.DEPLOY_PRODUCTION,
   ActionType.DESTRUCTIVE,
   ActionType.EXTERNAL_PUBLISH
@@ -36,7 +36,7 @@ export const APPROVAL_REQUIREMENTS = Object.freeze({
   [ActionType.PR_COMMENT]: ApprovalLevel.NONE,
   [ActionType.PR_REVIEW_SUBMIT]: ApprovalLevel.GO,
   [ActionType.PR_OPERATION]: ApprovalLevel.GO,
-  [ActionType.MERGE]: ApprovalLevel.GO_PASSKEY,
+  [ActionType.MERGE]: ApprovalLevel.GO,
   [ActionType.DEPLOY_PRODUCTION]: ApprovalLevel.GO_PASSKEY,
   [ActionType.DESTRUCTIVE]: ApprovalLevel.GO_PASSKEY,
   [ActionType.EXTERNAL_PUBLISH]: ApprovalLevel.GO_PASSKEY

--- a/test/approval-model.test.js
+++ b/test/approval-model.test.js
@@ -24,7 +24,7 @@ test("approval requirements map matches expected action levels", () => {
   assert.equal(APPROVAL_REQUIREMENTS[ActionType.READ], ApprovalLevel.NONE);
   assert.equal(APPROVAL_REQUIREMENTS[ActionType.BUILD], ApprovalLevel.GO);
   assert.equal(APPROVAL_REQUIREMENTS[ActionType.PR_REVIEW_SUBMIT], ApprovalLevel.GO);
-  assert.equal(APPROVAL_REQUIREMENTS[ActionType.MERGE], ApprovalLevel.GO_PASSKEY);
+  assert.equal(APPROVAL_REQUIREMENTS[ActionType.MERGE], ApprovalLevel.GO);
   assert.equal(APPROVAL_REQUIREMENTS[ActionType.DESTRUCTIVE], ApprovalLevel.GO_PASSKEY);
 });
 

--- a/test/core-policy.test.js
+++ b/test/core-policy.test.js
@@ -163,6 +163,26 @@ test("high-risk action requires GO + passkey", () => {
   assert.equal(result.requiredApproval, "go_passkey");
 });
 
+test("merge requires explicit GO but not passkey", () => {
+  const result = evaluateExecutionPolicy({
+    actionType: ActionType.MERGE,
+    mode: TaskMode.EXECUTION,
+    repositoryInput: "ledger",
+    aliasRegistry: registry,
+    targetConfirmed: true,
+    constitutionConsulted: true,
+    runtimeTruth: { runtimeAvailable: true },
+    credential: highRiskCredential,
+    consent: fullConsent,
+    ...approvalContext,
+    issueTraceable: true,
+    go: true,
+    passkey: false
+  });
+  assert.equal(result.allowed, true);
+  assert.equal(result.requiredApproval, "go");
+});
+
 test("guarded absence mode blocks merge even with GO + passkey", () => {
   const result = evaluateExecutionPolicy({
     actionType: ActionType.MERGE,

--- a/test/e2e-13-parent-readiness.test.js
+++ b/test/e2e-13-parent-readiness.test.js
@@ -19,4 +19,5 @@ test("matrix references parent execution anchor readiness track", () => {
   assert.equal(doc.includes("## E2E-00 Parent execution anchor readiness"), true);
   assert.equal(doc.includes("docs/mvp/e2e/e2e-13-parent-readiness.md"), true);
   assert.equal(doc.includes("Issues: `#13`"), true);
+  assert.equal(doc.includes("README.md"), true);
 });

--- a/test/issue-to-e2e-matrix.test.js
+++ b/test/issue-to-e2e-matrix.test.js
@@ -9,6 +9,7 @@ test("issue-to-e2e matrix defines all canonical E2E tracks", () => {
   const doc = fs.readFileSync(MATRIX_PATH, "utf8");
 
   for (const id of [
+    "E2E-00",
     "E2E-01",
     "E2E-02",
     "E2E-03",
@@ -16,13 +17,11 @@ test("issue-to-e2e matrix defines all canonical E2E tracks", () => {
     "E2E-05",
     "E2E-06",
     "E2E-07",
-    "E2E-08",
     "E2E-09",
     "E2E-10",
     "E2E-11",
     "E2E-12",
-    "E2E-13",
-    "E2E-14"
+    "E2E-13"
   ]) {
     assert.equal(doc.includes(`## ${id}`), true);
   }
@@ -40,5 +39,5 @@ test("issue-to-e2e matrix records happy path, boundary path, evidence, and updat
   assert.equal(doc.includes("implemented_pending_e2e"), true);
   assert.equal(doc.includes("partial"), true);
   assert.equal(doc.includes("Repository completion status: `partial`"), true);
-  assert.equal(doc.includes("mapped E2E evidence now exists across the matrix"), true);
+  assert.equal(doc.includes("mapped E2E evidence now exists across the active main-line matrix"), true);
 });


### PR DESCRIPTION
## This PR satisfies Intent

- align `AGENTS.md` and related policy/docs with the current public repository reality
- remove active setup-wizard assumptions from the current public/core line and keep historical references clearly non-canonical
- make branch/approval/collaborator/GitHub App operating boundaries explicit for this public repo

## Satisfied Success Criteria

- [x] `AGENTS.md` no longer treats the archived setup-wizard window as active current-line implementation scope
- [x] active canonical docs no longer point at removed setup-wizard/bootstrap artifacts as if they were current runtime paths
- [x] public-repo operating rules now state topic-branch-first workflow and prohibit default human collaborator use on personal-account public repos
- [x] `GO` / `GO + passkey` / `never auto` GitHub operation boundaries are documented in canonical security docs

## Unsatisfied Success Criteria

None.

## Non-goal violations

None.

## Verification Evidence

- Unit: `npm test`
- Integration: docs/policy alignment reviewed against `.github/pull_request_template.md`, `docs/pr-template-model.md`, and guarded-policy workflow expectations
- E2E: N/A for this docs/policy slice
- Manual: verified PR body markers required by `guarded-autonomy-required-checks.yml`; reviewed updated canonical docs and `AGENTS.md`
- Evidence path/link: `AGENTS.md`, `docs/security/consent-approval-model.md`, `docs/security/go-passkey-approval-model.md`, `docs/security/reviewer-policy.md`, `docs/mvp/issue-13-rewrite-draft.md`

## Related Constitution Rules

- no silent scope downscoping
- issue closure remains human-approved unless explicitly delegated
- high-risk actions require `GO + passkey`
- docs-first / evidence-first repository discipline

## Out-of-scope but NOT implemented

- runtime behavior changes for approval enforcement beyond the already-landed bounded mapping updates in this branch
- GitHub App private key generation / installation flow
- any revival of setup-wizard runtime work

## Extra changes (if any)

None.
