### PR TITLE
Ignore local GitHub App credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+credentials/


### PR DESCRIPTION
## This PR satisfies Intent

Keep the locally stored GitHub App private key inside the repository workspace without risking accidental git tracking.

## Satisfied Success Criteria

- [x] A repo-local credential directory can hold the downloaded GitHub App private key.
- [x] Git ignores that credential directory so the private key is not tracked.

## Unsatisfied Success Criteria

None.

## Non-goal violations

None.

## Verification Evidence

- Unit: Not run (docs/gitignore-only change).
- Integration: Verified with `git check-ignore -v credentials/github-app/vtdd-codex.2026-04-22.private-key.pem`.
- E2E: Not run (not applicable).
- Manual: Verified the key moved from `~/Downloads` to `credentials/github-app/` and is ignored by git.
- Evidence path/link: `.gitignore`, local `credentials/github-app/`.

## Related Constitution Rules

- Evidence Discipline
- Change Size and PR Discipline

## Out-of-scope but NOT implemented

- No runtime code or workflow changes.
- No credential rotation or key regeneration.

## Extra changes (if any)

None.
