### PR TITLE
Fix GitHub App live repository resolution on Worker

### DIFF
--- a/src/core/github-app-repository-index.js
+++ b/src/core/github-app-repository-index.js
@@ -2,6 +2,7 @@ const GITHUB_API_BASE_URL = "https://api.github.com";
 const INSTALLATION_REPOSITORIES_PATH = "/installation/repositories";
 const INSTALLATION_ACCESS_TOKEN_PATH = "/app/installations";
 const GITHUB_API_VERSION = "2022-11-28";
+const GITHUB_API_USER_AGENT = "vtdd-v2-github-app-index";
 const REPOSITORIES_PER_PAGE = 100;
 const MAX_REPOSITORY_PAGES = 10;
 const GITHUB_APP_JWT_LIFETIME_SECONDS = 9 * 60;
@@ -161,6 +162,7 @@ async function mintInstallationToken({
         authorization: `Bearer ${appJwt.token}`,
         accept: "application/vnd.github+json",
         "x-github-api-version": GITHUB_API_VERSION,
+        "user-agent": GITHUB_API_USER_AGENT,
         "content-type": "application/json; charset=utf-8"
       },
       body: JSON.stringify({})
@@ -252,6 +254,7 @@ async function fetchGitHubInstallationRepositories({ token, fetchImpl, apiBaseUr
         headers: {
           authorization: `Bearer ${token}`,
           accept: "application/vnd.github+json",
+          "user-agent": GITHUB_API_USER_AGENT,
           "x-github-api-version": GITHUB_API_VERSION
         }
       });
@@ -293,14 +296,28 @@ async function fetchGitHubInstallationRepositories({ token, fetchImpl, apiBaseUr
 
 async function readJsonSafe(response) {
   try {
-    return await response.json();
+    const text = await response.text();
+    if (!normalizeText(text)) {
+      return {};
+    }
+    try {
+      return JSON.parse(text);
+    } catch {
+      return {
+        __rawText: sanitizeApiBodySnippet(text)
+      };
+    }
   } catch {
     return {};
   }
 }
 
 function classifyApiFailure(response, body) {
-  const message = normalizeText(body?.message) || `github api returned status ${response.status}`;
+  const message =
+    normalizeText(body?.message) ||
+    normalizeText(body?.error) ||
+    normalizeText(body?.__rawText) ||
+    buildStatusFallbackMessage(response);
   const remaining = normalizeText(response.headers.get("x-ratelimit-remaining"));
   const retryAfter = normalizeText(response.headers.get("retry-after"));
 
@@ -334,6 +351,23 @@ function classifyApiFailure(response, body) {
     error: "api_error",
     reason: message
   };
+}
+
+function buildStatusFallbackMessage(response) {
+  const status = Number(response?.status);
+  const statusText = normalizeText(response?.statusText);
+  if (statusText) {
+    return `github api returned status ${status} (${statusText})`;
+  }
+  return `github api returned status ${status}`;
+}
+
+function sanitizeApiBodySnippet(value) {
+  const normalized = normalizeText(value).replace(/\s+/g, " ");
+  if (!normalized) {
+    return "";
+  }
+  return normalized.slice(0, 200);
 }
 
 function buildRepositoryIndexWarning(result) {

--- a/test/github-app-repository-index.test.js
+++ b/test/github-app-repository-index.test.js
@@ -201,8 +201,10 @@ test("github app index can mint installation token from github app credentials",
   assert.equal(calls.length, 2);
   assert.equal(calls[0].url.includes("/app/installations/98765/access_tokens"), true);
   assert.equal(calls[0].init.headers.authorization, "Bearer app_jwt_token_for_tests");
+  assert.equal(calls[0].init.headers["user-agent"], "vtdd-v2-github-app-index");
   assert.equal(calls[1].url.includes("/installation/repositories"), true);
   assert.equal(calls[1].init.headers.authorization, "Bearer ghs_minted_installation_token");
+  assert.equal(calls[1].init.headers["user-agent"], "vtdd-v2-github-app-index");
 });
 
 test("github app index reuses cached minted token until refresh margin", async () => {
@@ -371,4 +373,33 @@ test("github app index can enforce minted-token mode and block static token fall
   assert.equal(result.aliasRegistry.length, 1);
   assert.equal(result.warnings.length, 1);
   assert.equal(result.warnings[0].includes("disabled by GITHUB_APP_ENFORCE_MINTED_INSTALLATION_TOKEN"), true);
+});
+
+test("github app index surfaces non-json installation token mint failure details", async () => {
+  const result = await resolveGatewayAliasRegistryFromGitHubApp({
+    policyInput: { aliasRegistry: [] },
+    env: {
+      GITHUB_APP_ID: "55555",
+      GITHUB_APP_INSTALLATION_ID: "44444",
+      GITHUB_APP_PRIVATE_KEY: "-----BEGIN PRIVATE KEY-----\nplaceholder\n-----END PRIVATE KEY-----",
+      GITHUB_APP_JWT_PROVIDER: async () => "app_jwt_token_for_tests",
+      GITHUB_API_FETCH: async (url) => {
+        if (String(url).includes("/app/installations/44444/access_tokens")) {
+          return new Response("<html><body>Request forbidden by upstream policy</body></html>", {
+            status: 403,
+            statusText: "Forbidden",
+            headers: { "content-type": "text/html; charset=utf-8" }
+          });
+        }
+        throw new Error("repositories fetch should not run after mint failure");
+      }
+    }
+  });
+
+  assert.equal(result.source, "provided");
+  assert.equal(result.warnings.length, 1);
+  assert.equal(
+    result.warnings[0].includes("<html><body>Request forbidden by upstream policy</body></html>"),
+    true
+  );
 });


### PR DESCRIPTION
## This PR satisfies Intent

Restore GitHub App backed live repository resolution from the deployed Worker so `/v2/gateway` can resolve the installed repository instead of failing during installation token mint.

## Satisfied Success Criteria

- [x] Worker-side GitHub App installation token mint requests send the required `User-Agent` header to GitHub API.
- [x] GitHub App repository-index warnings preserve useful non-JSON failure details without exposing secrets.

## Unsatisfied Success Criteria

None.

## Non-goal violations

None.

## Verification Evidence

- Unit: `node --test test/github-app-repository-index.test.js`
- Integration: Production deploy succeeded with version `f29f8214-4fd8-4aa2-b9d2-e8bfd325987a`.
- E2E: Verified authenticated `POST current owner-operated Cloudflare Worker origin/v2/gateway` returns `allowed: true` and resolves `repository: marushu/vtdd-v2-p`.
- Manual: Confirmed prior failure warning pointed to missing GitHub API `User-Agent`, then confirmed warning disappeared after fix.
- Evidence path/link: `src/core/github-app-repository-index.js`, `test/github-app-repository-index.test.js`

## Related Constitution Rules

- Evidence Discipline
- Safety Invariants

## Out-of-scope but NOT implemented

- No GitHub App permission changes
- No approval model changes
- No memory provider enablement work

## Extra changes (if any)

None.

