### PR TITLE
Add resume-first Codex PR revision loop contract

### DIFF
--- a/docs/butler/codex-pr-revision-loop.md
+++ b/docs/butler/codex-pr-revision-loop.md
@@ -1,0 +1,94 @@
+# Butler-Codex PR Revision Loop
+
+This document is the canonical runtime contract for Issue #4.
+
+## Core Reading
+
+VTDD execution keeps three layers separate:
+
+- Issue is the canonical execution spec
+- GitHub state is the canonical runtime truth for current progress
+- handoff is a Butler-triggered bridge only when execution must move across Codex contexts
+
+`git diff` may be runtime truth for current progress.
+It is not the execution spec.
+
+## Default Flow
+
+The canonical execution path is:
+
+`Butler -> Codex -> PR -> Gemini review comments -> Butler summary -> human decision`
+
+Codex's bounded goal for this slice is PR creation and PR revision work.
+Merge remains a human `GO` decision.
+
+## Resume-first Rule
+
+Before creating a handoff, Butler must first read GitHub runtime truth:
+
+- target Issue
+- active branch
+- current diff / commits
+- existing PR, if any
+- review comments
+- unresolved review state
+
+If the same bounded work can safely continue from GitHub runtime truth, the
+system should resume without creating a handoff.
+
+## Handoff-when-needed Rule
+
+Explicit handoff is required only for Butler-mediated execution transfer.
+
+Typical cases:
+
+- iPhone-side Butler conversation must bridge into another Codex execution context
+- GitHub runtime truth alone is not enough to resume safely
+- approval scope or issue traceability needs to be restated before execution
+
+The handoff must preserve:
+
+- issue traceability
+- approval scope
+- non-goals
+- bounded execution intent
+
+## PR Revision Loop
+
+After Codex creates a PR:
+
+1. Gemini returns critical review as PR comments
+2. Butler summarizes PR state and review comments for the human
+3. Butler suggests the next safe action
+4. Codex performs bounded PR updates and PR comment responses as directed
+5. Gemini re-runs critical review when the PR changes or new comments arrive
+6. Butler re-summarizes the updated PR state for the human
+7. merge remains blocked until the human gives `GO`
+
+## Role Boundaries
+
+### Butler
+
+- reads runtime truth
+- decides `resume` vs `handoff required`
+- summarizes PR and review comments
+- suggests the next safe action
+
+### Codex
+
+- performs bounded coding work
+- creates and updates the PR
+- responds on the PR within approved scope
+
+### Gemini
+
+- provides critical review through PR comments
+- does not execute fixes
+- does not decide merge
+
+## Invariants
+
+- no speculative coding beyond Issue scope
+- no treating handoff as canonical spec
+- no merge without explicit human `GO`
+- no erasing meaningful reviewer objections in Butler summaries

--- a/src/core/execution-continuity.js
+++ b/src/core/execution-continuity.js
@@ -1,0 +1,234 @@
+import { ActorRole, TaskMode } from "./types.js";
+
+export const ExecutionTransferMode = Object.freeze({
+  RESUME: "resume",
+  HANDOFF_READY: "handoff_ready"
+});
+
+export const CodexGoal = Object.freeze({
+  OPEN_PR: "open_pr",
+  REVISE_PR: "revise_pr",
+  RESPOND_TO_REVIEW: "respond_to_review",
+  WAIT_FOR_REVIEW: "wait_for_review"
+});
+
+export function evaluateExecutionContinuity(input = {}) {
+  const mode = normalizeMode(input?.mode);
+  if (mode === TaskMode.READ_ONLY) {
+    return { ok: true, value: null };
+  }
+
+  const actorRole = normalizeActorRole(input?.actorRole);
+  const continuation = normalizeContinuationContext(input?.continuationContext);
+  const handoffValidation = validateHandoffRequirement({
+    actorRole,
+    continuation
+  });
+  if (!handoffValidation.ok) {
+    return handoffValidation;
+  }
+
+  const github = normalizeGitHubRuntime(input?.runtimeTruth?.runtimeState);
+  const pullRequest = github.pullRequest;
+  const review = buildReviewState(pullRequest);
+  const codexGoal = determineCodexGoal({ pullRequest, review });
+
+  return {
+    ok: true,
+    value: {
+      sourceOfTruth: "github_runtime_truth",
+      transferMode:
+        continuation.requiresHandoff && actorRole === ActorRole.BUTLER
+          ? ExecutionTransferMode.HANDOFF_READY
+          : ExecutionTransferMode.RESUME,
+      handoffRequired: continuation.requiresHandoff && actorRole === ActorRole.BUTLER,
+      codexGoal,
+      activeBranch: github.activeBranch,
+      pullRequest: {
+        exists: pullRequest.exists,
+        number: pullRequest.number,
+        url: pullRequest.url,
+        state: pullRequest.state
+      },
+      reviewLoop: {
+        reviewer: review.reviewer,
+        reviewCommentsCount: review.reviewCommentsCount,
+        unresolvedReviewCommentsCount: review.unresolvedReviewCommentsCount,
+        criticalReviewPending: review.criticalReviewPending,
+        rerunReviewer: review.rerunReviewer,
+        mergeRequiresHumanGo: true
+      },
+      butlerSummary: {
+        summarizePullRequest: pullRequest.exists,
+        summarizeReviewComments: pullRequest.exists,
+        suggestNextAction: true
+      },
+      nextSuggestedActions: buildNextSuggestedActions({
+        pullRequest,
+        review,
+        codexGoal
+      })
+    }
+  };
+}
+
+function validateHandoffRequirement({ actorRole, continuation }) {
+  const handoffRequired = continuation.requiresHandoff && actorRole === ActorRole.BUTLER;
+  if (!handoffRequired) {
+    return { ok: true };
+  }
+
+  const handoff = continuation.handoff;
+  if (!handoff.present) {
+    return deny(
+      "butler_handoff_required_for_execution_transfer",
+      "Butler-mediated execution transfer requires a handoff contract before execution can continue"
+    );
+  }
+  if (!handoff.issueTraceable) {
+    return deny(
+      "handoff_must_be_issue_traceable",
+      "handoff contract must include issue-traceable scope before execution can continue"
+    );
+  }
+  if (!handoff.approvalScopeMatched) {
+    return deny(
+      "handoff_must_preserve_approval_scope",
+      "handoff contract must preserve scoped approval before execution can continue"
+    );
+  }
+
+  return { ok: true };
+}
+
+function buildReviewState(pullRequest) {
+  const reviewCommentsCount = pullRequest.reviewCommentsCount;
+  const unresolvedReviewCommentsCount = pullRequest.unresolvedReviewCommentsCount;
+  const reviewer = pullRequest.reviewer;
+  const criticalReviewPending =
+    pullRequest.exists && reviewCommentsCount > 0 && unresolvedReviewCommentsCount > 0;
+  const rerunReviewer =
+    pullRequest.exists && (pullRequest.updatedSinceReview || unresolvedReviewCommentsCount > 0);
+
+  return {
+    reviewer,
+    reviewCommentsCount,
+    unresolvedReviewCommentsCount,
+    criticalReviewPending,
+    rerunReviewer
+  };
+}
+
+function determineCodexGoal({ pullRequest, review }) {
+  if (!pullRequest.exists) {
+    return CodexGoal.OPEN_PR;
+  }
+  if (review.unresolvedReviewCommentsCount > 0) {
+    return CodexGoal.REVISE_PR;
+  }
+  if (review.reviewCommentsCount > 0) {
+    return CodexGoal.RESPOND_TO_REVIEW;
+  }
+  return CodexGoal.WAIT_FOR_REVIEW;
+}
+
+function buildNextSuggestedActions({ pullRequest, review, codexGoal }) {
+  if (!pullRequest.exists) {
+    return ["continue_bounded_coding", "open_pull_request", "request_gemini_review"];
+  }
+
+  if (codexGoal === CodexGoal.REVISE_PR) {
+    return ["apply_pr_feedback", "reply_on_pull_request", "rerun_gemini_review"];
+  }
+
+  if (codexGoal === CodexGoal.RESPOND_TO_REVIEW) {
+    return ["reply_on_pull_request", "rerun_gemini_review"];
+  }
+
+  if (review.rerunReviewer) {
+    return ["rerun_gemini_review", "summarize_for_human"];
+  }
+
+  return ["summarize_for_human", "wait_for_human_go"];
+}
+
+function normalizeContinuationContext(value) {
+  const input = value && typeof value === "object" ? value : {};
+  const handoff = input.handoff && typeof input.handoff === "object" ? input.handoff : {};
+  return {
+    requiresHandoff: input.requiresHandoff === true,
+    handoff: {
+      present: Boolean(handoff && Object.keys(handoff).length > 0),
+      issueTraceable: handoff.issueTraceable === true,
+      approvalScopeMatched: handoff.approvalScopeMatched === true
+    }
+  };
+}
+
+function normalizeGitHubRuntime(value) {
+  const runtime = value && typeof value === "object" ? value : {};
+  const pullRequestInput =
+    runtime.pullRequest && typeof runtime.pullRequest === "object" ? runtime.pullRequest : {};
+
+  return {
+    activeBranch: normalizeText(runtime.activeBranch) || null,
+    pullRequest: {
+      exists: Boolean(
+        normalizeText(pullRequestInput.url) ||
+          Number.isInteger(Number(pullRequestInput.number)) ||
+          normalizeText(pullRequestInput.state)
+      ),
+      number: normalizeNumber(pullRequestInput.number),
+      url: normalizeText(pullRequestInput.url) || null,
+      state: normalizeText(pullRequestInput.state) || null,
+      reviewCommentsCount: normalizeCount(pullRequestInput.reviewCommentsCount),
+      unresolvedReviewCommentsCount: normalizeCount(
+        pullRequestInput.unresolvedReviewCommentsCount
+      ),
+      updatedSinceReview: pullRequestInput.updatedSinceReview === true,
+      reviewer: normalizeText(pullRequestInput.reviewer) || "gemini"
+    }
+  };
+}
+
+function normalizeMode(value) {
+  const normalized = String(value ?? TaskMode.EXECUTION)
+    .trim()
+    .toLowerCase();
+  return normalized === TaskMode.READ_ONLY ? TaskMode.READ_ONLY : TaskMode.EXECUTION;
+}
+
+function normalizeActorRole(value) {
+  const normalized = String(value ?? ActorRole.EXECUTOR)
+    .trim()
+    .toLowerCase();
+  return Object.values(ActorRole).includes(normalized) ? normalized : ActorRole.EXECUTOR;
+}
+
+function normalizeCount(value) {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric) || numeric < 0) {
+    return 0;
+  }
+  return Math.floor(numeric);
+}
+
+function normalizeNumber(value) {
+  const numeric = Number(value);
+  if (!Number.isInteger(numeric) || numeric <= 0) {
+    return null;
+  }
+  return numeric;
+}
+
+function normalizeText(value) {
+  return String(value ?? "").trim();
+}
+
+function deny(rule, reason) {
+  return {
+    ok: false,
+    rule,
+    reason
+  };
+}

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -104,6 +104,11 @@ export {
 } from "./surface-independence.js";
 export { evaluateExecutionPolicy } from "./policy.js";
 export { evaluateButlerExecution } from "./butler-orchestrator.js";
+export {
+  CodexGoal,
+  ExecutionTransferMode,
+  evaluateExecutionContinuity
+} from "./execution-continuity.js";
 export { runMvpGateway } from "./mvp-gateway.js";
 export { resolveGatewayAliasRegistryFromGitHubApp } from "./github-app-repository-index.js";
 export {

--- a/src/core/mvp-gateway.js
+++ b/src/core/mvp-gateway.js
@@ -1,5 +1,6 @@
 import { evaluateButlerExecution } from "./butler-orchestrator.js";
 import { buildConversationAssist } from "./conversation-assist.js";
+import { evaluateExecutionContinuity } from "./execution-continuity.js";
 import { evaluateExecutionPolicy } from "./policy.js";
 import { buildRetrievalPlan } from "./retrieval-contract.js";
 import { evaluateMemorySafety, sanitizeMemoryPayload } from "./memory-safety.js";
@@ -74,6 +75,21 @@ export function runMvpGateway(input) {
     });
   }
 
+  const continuity = evaluateExecutionContinuity({
+    actorRole,
+    mode: policyInput?.mode,
+    runtimeTruth: policyInput?.runtimeTruth,
+    continuationContext: input?.continuationContext
+  });
+  if (!continuity.ok) {
+    return deny(continuity.rule, continuity.reason, {
+      retrievalPlan,
+      repositoryCandidates,
+      conversationAssist: deniedConversationAssist,
+      workflowState: workflowDecision.state
+    });
+  }
+
   return {
     allowed: true,
     retrievalPlan,
@@ -85,6 +101,7 @@ export function runMvpGateway(input) {
       repository: execution.repository,
       repositoryCandidates
     }),
+    executionContinuity: continuity.value,
     autonomyMode: execution.autonomyMode ?? policyInput.autonomyMode ?? null,
     requiredApproval: execution.requiredApproval ?? null,
     memoryWrite: memoryPlan.value
@@ -143,6 +160,7 @@ function prepareMemoryPlan(memoryRecord) {
     }
   };
 }
+
 
 function deny(rule, reason, detail = {}) {
   return {

--- a/test/execution-continuity.test.js
+++ b/test/execution-continuity.test.js
@@ -1,0 +1,71 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  ActorRole,
+  CodexGoal,
+  ExecutionTransferMode,
+  TaskMode,
+  evaluateExecutionContinuity
+} from "../src/core/index.js";
+
+test("execution continuity resumes by default and aims for PR creation when no PR exists", () => {
+  const result = evaluateExecutionContinuity({
+    actorRole: ActorRole.EXECUTOR,
+    mode: TaskMode.EXECUTION,
+    runtimeTruth: {
+      runtimeState: {
+        activeBranch: "codex/issue-4",
+        pullRequest: {}
+      }
+    }
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.value.transferMode, ExecutionTransferMode.RESUME);
+  assert.equal(result.value.codexGoal, CodexGoal.OPEN_PR);
+  assert.equal(result.value.nextSuggestedActions.includes("open_pull_request"), true);
+});
+
+test("execution continuity requires handoff for Butler-mediated transfer when bridge data is missing", () => {
+  const result = evaluateExecutionContinuity({
+    actorRole: ActorRole.BUTLER,
+    mode: TaskMode.EXECUTION,
+    continuationContext: {
+      requiresHandoff: true
+    },
+    runtimeTruth: {
+      runtimeState: {
+        activeBranch: "codex/issue-4"
+      }
+    }
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.rule, "butler_handoff_required_for_execution_transfer");
+});
+
+test("execution continuity returns PR revision loop guidance when unresolved review comments exist", () => {
+  const result = evaluateExecutionContinuity({
+    actorRole: ActorRole.BUTLER,
+    mode: TaskMode.EXECUTION,
+    runtimeTruth: {
+      runtimeState: {
+        activeBranch: "codex/issue-4",
+        pullRequest: {
+          number: 42,
+          url: "https://github.com/example/repo/pull/42",
+          state: "open",
+          reviewCommentsCount: 3,
+          unresolvedReviewCommentsCount: 2,
+          updatedSinceReview: true,
+          reviewer: "gemini"
+        }
+      }
+    }
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.value.codexGoal, CodexGoal.REVISE_PR);
+  assert.equal(result.value.reviewLoop.rerunReviewer, true);
+  assert.equal(result.value.nextSuggestedActions.includes("apply_pr_feedback"), true);
+});

--- a/test/mvp-gateway.test.js
+++ b/test/mvp-gateway.test.js
@@ -6,6 +6,7 @@ import {
   ConsentCategory,
   CredentialTier,
   JudgmentStep,
+  TaskMode,
   WorkflowEvent,
   WorkflowStage,
   runMvpGateway
@@ -317,4 +318,86 @@ test("gateway asks clarification when recall conversation mentions multiple issu
     result.conversationAssist.confirmationPrompt.includes("#22"),
     true
   );
+});
+
+test("gateway returns execution continuity guidance for PR-reaching execution", () => {
+  const result = runMvpGateway({
+    phase: "execution",
+    actorRole: ActorRole.BUTLER,
+    surfaceContext: {
+      surface: "custom_gpt",
+      judgmentModelId: "vtdd-butler-core-v1"
+    },
+    judgmentTrace: validJudgmentTrace,
+    policyInput: {
+      actionType: ActionType.ISSUE_CREATE,
+      mode: TaskMode.EXECUTION,
+      repositoryInput: "vtdd",
+      aliasRegistry: registry,
+      targetConfirmed: true,
+      constitutionConsulted: true,
+      runtimeTruth: {
+        runtimeAvailable: true,
+        runtimeState: {
+          activeBranch: "codex/issue-4",
+          pullRequest: {
+            number: 42,
+            url: "https://github.com/example/repo/pull/42",
+            state: "open",
+            reviewCommentsCount: 2,
+            unresolvedReviewCommentsCount: 1,
+            updatedSinceReview: true,
+            reviewer: "gemini"
+          }
+        }
+      },
+      credential: { model: "github_app", tier: CredentialTier.EXECUTE },
+      consent: fullConsent,
+      ...approvalContext,
+      issueTraceable: true,
+      go: true,
+      passkey: false
+    }
+  });
+
+  assert.equal(result.allowed, true);
+  assert.equal(result.executionContinuity.codexGoal, "revise_pr");
+  assert.equal(result.executionContinuity.reviewLoop.rerunReviewer, true);
+  assert.equal(
+    result.executionContinuity.nextSuggestedActions.includes("rerun_gemini_review"),
+    true
+  );
+});
+
+test("gateway surfaces blocked continuity when Butler-mediated handoff is required but missing", () => {
+  const result = runMvpGateway({
+    phase: "execution",
+    actorRole: ActorRole.BUTLER,
+    surfaceContext: {
+      surface: "custom_gpt",
+      judgmentModelId: "vtdd-butler-core-v1"
+    },
+    judgmentTrace: validJudgmentTrace,
+    continuationContext: {
+      requiresHandoff: true
+    },
+    policyInput: {
+      actionType: ActionType.ISSUE_CREATE,
+      mode: TaskMode.EXECUTION,
+      repositoryInput: "vtdd",
+      aliasRegistry: registry,
+      targetConfirmed: true,
+      constitutionConsulted: true,
+      runtimeTruth: { runtimeAvailable: true },
+      credential: { model: "github_app", tier: CredentialTier.EXECUTE },
+      consent: fullConsent,
+      ...approvalContext,
+      issueTraceable: true,
+      go: true,
+      passkey: false
+    }
+  });
+
+  assert.equal(result.allowed, false);
+  assert.equal(result.blockedByRule, "butler_handoff_required_for_execution_transfer");
 });

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -129,6 +129,62 @@ test("worker gateway allows butler path when deterministic judgment order is sat
   assert.equal(body.repository, "sample-org/vtdd-v2");
 });
 
+test("worker gateway returns PR revision loop guidance for Butler summaries", async () => {
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/gateway", {
+      method: "POST",
+      headers: gatewayAuthHeaders,
+      body: JSON.stringify({
+        phase: "execution",
+        actorRole: ActorRole.BUTLER,
+        surfaceContext: {
+          surface: "custom_gpt",
+          judgmentModelId: "vtdd-butler-core-v1"
+        },
+        judgmentTrace: validButlerJudgmentTrace,
+        policyInput: {
+          actionType: ActionType.ISSUE_CREATE,
+          mode: TaskMode.EXECUTION,
+          repositoryInput: "vtdd",
+          aliasRegistry,
+          targetConfirmed: true,
+          constitutionConsulted: true,
+          runtimeTruth: {
+            runtimeAvailable: true,
+            runtimeState: {
+              activeBranch: "codex/issue-4",
+              pullRequest: {
+                number: 42,
+                url: "https://github.com/example/repo/pull/42",
+                state: "open",
+                reviewCommentsCount: 3,
+                unresolvedReviewCommentsCount: 2,
+                updatedSinceReview: true,
+                reviewer: "gemini"
+              }
+            }
+          },
+          credential: { model: "github_app", tier: CredentialTier.EXECUTE },
+          consent: { grantedCategories: [ConsentCategory.PROPOSE] },
+          approvalPhrase: "GO issue create",
+          approvalScopeMatched: true,
+          issueTraceable: true,
+          go: true,
+          passkey: false
+        }
+      })
+    }),
+    gatewayAuthEnv
+  );
+
+  assert.equal(response.status, 200);
+  const body = await response.json();
+  assert.equal(body.allowed, true);
+  assert.equal(body.executionContinuity.codexGoal, "revise_pr");
+  assert.equal(body.executionContinuity.reviewLoop.unresolvedReviewCommentsCount, 2);
+  assert.equal(body.executionContinuity.nextSuggestedActions.includes("rerun_gemini_review"), true);
+});
+
 test("worker gateway blocks butler path when judgment order is invalid", async () => {
   const response = await worker.fetch(
     new Request("https://example.com/v2/gateway", {


### PR DESCRIPTION
## This PR satisfies Intent

- Butler が `resume-first / handoff-when-needed` で Codex 実行継続を判断する contract を追加する
- Codex の一旦のゴールを `PR 作成 / PR revision work` に固定する
- Gemini review comments と Butler summary loop の接続前提を runtime contract として明示する

## Satisfied Success Criteria

- Butler が `resume possible` と `handoff required` を判定する contract を追加
- Butler-mediated execution transfer で handoff が必須な場合は block する境界を追加
- GitHub runtime truth から PR 状態と review comment 状態を読み、Codex の次ゴールを返す contract を追加
- Butler が人間向け summary と次アクション提案を返すための gateway/worker 応答を追加
- canonical doc と unit/integration テストを追加

## Unsatisfied Success Criteria

- Butler -> Remote Codex の実 transport 接続そのものは未実装
- Gemini review を GitHub 上で実起動する runtime 接続は未実装
- Butler -> Remote Codex -> Gemini -> Butler の full pipe は未接続
- merge automation は未実装

## Verification Evidence

Executed:

```sh
node --test test/execution-continuity.test.js test/mvp-gateway.test.js test/worker.test.js test/core-policy.test.js test/reviewer-registry.test.js test/role-separation.test.js
```

Observed:
- 78 tests passed
- 0 failed

Evidence files:
- `docs/butler/codex-pr-revision-loop.md`
- `src/core/execution-continuity.js`
- `src/core/mvp-gateway.js`
- `test/execution-continuity.test.js`
- `test/mvp-gateway.test.js`
- `test/worker.test.js`

## Scope

Refs #4

This PR implements the bounded runtime-contract slice for:
- Butler deciding `resume` vs `handoff required`
- Codex aiming for PR creation / PR revision work
- Gemini review flowing through PR comments
- Butler summarizing PR state and suggesting next safe actions

## Notes

- merge automation is intentionally out of scope
- issue auto-close keyword is intentionally omitted because the broader loop still needs human review and follow-on runtime connection reading
