### PR TITLE
Clarify public repo and per-user setup model in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,41 @@
 # vtdd-v2
 VTDD V2: memory-first architecture with pluggable sockets and GitHub-first but non-lock-in design
 
+## Repository Use Model
+
+This repository is the public canonical VTDD V2 core maintained by
+[`@marushu`](https://github.com/marushu).
+
+It is public so other people can study it, fork it, and run it.
+It is not a shared hosted runtime.
+
+If you want to use VTDD yourself, the expected path is:
+
+- fork this repository, or clone it into your own repository/account
+- configure your own GitHub, Cloudflare, OpenAI, Gemini, and ChatGPT assets
+- create and operate your own Butler / Custom GPT surface
+
+The canonical repository remains owner-maintained.
+User operation should happen in user-owned forks, repositories, and service
+accounts.
+
+## Ownership Boundary
+
+This repository does not expect users to share the owner's secrets, GitHub App,
+Cloudflare account, Gemini key, or ChatGPT surface.
+
+Instead:
+
+- workflow and runtime code reference secret names only
+- each user is expected to set secrets in their own GitHub/Cloudflare/runtime
+  environment
+- each user is expected to connect their own Butler / Custom GPT to their own
+  VTDD deployment
+
+No setup wizard is assumed on this branch.
+VTDD runtime is expected to run in a setup-complete environment owned by the
+person using it.
+
 ## MVP Core (initial implementation)
 
 Current code starts with deterministic governance gates:


### PR DESCRIPTION
## This PR satisfies Intent

Clarify in the canonical README that this public repository is owner-maintained but intended to be used through user-owned forks/clones, user-owned service accounts, and user-owned Butler / Custom GPT surfaces.

## Satisfied Success Criteria

- [x] README states that the canonical repository is public and owner-maintained rather than a shared hosted runtime.
- [x] README states that users are expected to fork/clone and use their own GitHub, Cloudflare, OpenAI, Gemini, and ChatGPT accounts.
- [x] README states that users are expected to create and operate their own Butler / Custom GPT surface.
- [x] README states that workflow/runtime code references secret names only and does not assume shared owner secrets.

## Unsatisfied Success Criteria

None.

## Non-goal violations

None.

## Verification Evidence

- Unit: Not run (docs-only change)
- Integration: Not run (docs-only change)
- E2E: Not run (docs-only change)
- Manual: Reviewed README diff and rendered section order locally
- Evidence path/link: `/Users/shuhei/hibou_works/vtdd-v2-p/README.md`

## Related Constitution Rules

- Public-facing docs and runtime must not embed the owner's personal runtime destination.
- Shared/public use must converge on user-owned GitHub, Cloudflare, Gemini, and ChatGPT accounts.

## Out-of-scope but NOT implemented

- Setup instructions for per-user secrets and services are not added in this PR.
- Remote Codex / Gemini / Butler runtime implementation is not changed in this PR.

## Extra changes (if any)

None.
