### PR TITLE
Add PR-triggered Gemini critical review comments

### DIFF
--- a/.github/workflows/gemini-pr-review.yml
+++ b/.github/workflows/gemini-pr-review.yml
@@ -1,0 +1,50 @@
+name: gemini-pr-review
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+  issue_comment:
+    types:
+      - created
+  pull_request_review:
+    types:
+      - submitted
+      - edited
+  pull_request_review_comment:
+    types:
+      - created
+      - edited
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: write
+
+concurrency:
+  group: gemini-pr-review-${{ github.repository }}-${{ github.event.pull_request.number || github.event.issue.number || github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Run Gemini PR review
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          GEMINI_REVIEW_MODEL: ${{ vars.GEMINI_REVIEW_MODEL }}
+        run: node scripts/run-gemini-pr-review.mjs

--- a/docs/butler/gemini-pr-review-comments.md
+++ b/docs/butler/gemini-pr-review-comments.md
@@ -1,0 +1,72 @@
+# PR-triggered Gemini Review Comments
+
+This document is the canonical runtime contract for Issue #9.
+
+## Purpose
+
+After Remote Codex reaches PR creation/update, VTDD must be able to run Gemini
+as the critical reviewer and return that critique to GitHub as PR comments.
+
+This slice does not summarize review output for the human yet.
+Its purpose is to make the `PR -> Gemini` part of the loop runnable and
+traceable.
+
+## Canonical Shape
+
+`Remote Codex -> PR create/update -> Gemini review workflow -> PR comment`
+
+This review comment then becomes the GitHub-centered reviewer surface that
+Butler will later read and synthesize.
+
+## Trigger Boundary
+
+Gemini review must run when:
+
+- a PR is opened
+- a PR is updated
+- a PR becomes ready for review
+- new PR comments or review comments arrive
+
+The workflow must ignore its own marker comment so that reviewer reruns do not
+create an infinite comment loop.
+
+## Reviewer Input Boundary
+
+Gemini receives:
+
+- PR diff
+- bounded PR context
+- recent PR and review comments
+
+Gemini does not receive:
+
+- execution credentials
+- merge authority
+- deployment authority
+
+## Reviewer Output Boundary
+
+Gemini output must remain compatible with the existing reviewer contract:
+
+- `critical_findings[]`
+- `risks[]`
+- `recommended_action`
+
+For this slice, the canonical return surface is a PR comment carrying that
+structured critique in a human-readable format.
+
+## Upsert Rule
+
+Gemini reruns must update the existing VTDD Gemini review comment when one is
+already present.
+
+The goal is to keep one current critical-review surface on the PR rather than
+creating uncontrolled repeated comments.
+
+## Setup Boundary
+
+This workflow is designed for public/per-user use:
+
+- each user configures `GEMINI_API_KEY` in their own repository settings
+- reviewer runtime remains user-owned
+- the canonical repo does not embed owner-specific reviewer secrets

--- a/scripts/run-gemini-pr-review.mjs
+++ b/scripts/run-gemini-pr-review.mjs
@@ -1,0 +1,147 @@
+import fs from "node:fs/promises";
+import {
+  DEFAULT_GEMINI_REVIEW_MODEL,
+  buildGeminiReviewRequestBody,
+  buildPullRequestDiff,
+  buildPullRequestReviewContext,
+  extractReviewerResponseFromGemini,
+  findExistingGeminiReviewComment,
+  formatGeminiReviewComment,
+  resolveGeminiReviewTrigger
+} from "../src/core/index.js";
+
+async function main() {
+  const eventName = mustGetEnv("GITHUB_EVENT_NAME");
+  const repository = mustGetEnv("GITHUB_REPOSITORY");
+  const eventPath = mustGetEnv("GITHUB_EVENT_PATH");
+  const githubToken = mustGetEnv("GITHUB_TOKEN");
+  const payload = JSON.parse(await fs.readFile(eventPath, "utf8"));
+
+  const triggerResult = resolveGeminiReviewTrigger({ eventName, payload });
+  if (!triggerResult.ok) {
+    throw new Error(triggerResult.issues?.join(", ") || "failed to resolve Gemini review trigger");
+  }
+  if (!triggerResult.value.shouldReview) {
+    console.log(`Skipping Gemini PR review: ${triggerResult.value.reason}`);
+    return;
+  }
+
+  const apiBaseUrl = process.env.GITHUB_API_URL || "https://api.github.com";
+  const githubFetch = createGitHubFetch({ apiBaseUrl, token: githubToken });
+  const prNumber = triggerResult.value.pullRequestNumber;
+
+  const pullRequest = await githubFetch(`/repos/${repository}/pulls/${prNumber}`);
+  const files = await githubFetch(`/repos/${repository}/pulls/${prNumber}/files?per_page=100`);
+  const issueComments = await githubFetch(`/repos/${repository}/issues/${prNumber}/comments?per_page=100`);
+  const reviewComments = await githubFetch(`/repos/${repository}/pulls/${prNumber}/comments?per_page=100`);
+  const reviews = await githubFetch(`/repos/${repository}/pulls/${prNumber}/reviews?per_page=100`);
+
+  if (!process.env.GEMINI_API_KEY) {
+    console.log("Skipping Gemini PR review: GEMINI_API_KEY is not configured.");
+    return;
+  }
+
+  const prDiff = buildPullRequestDiff(files);
+  const context = buildPullRequestReviewContext({
+    repository,
+    trigger: triggerResult.value.trigger,
+    pullRequest,
+    files,
+    issueComments,
+    reviewComments,
+    reviews
+  });
+
+  const model = process.env.GEMINI_REVIEW_MODEL || DEFAULT_GEMINI_REVIEW_MODEL;
+  const requestBody = buildGeminiReviewRequestBody({ prDiff, context });
+  const geminiResponse = await callGemini({
+    apiKey: process.env.GEMINI_API_KEY,
+    model,
+    body: requestBody
+  });
+  const reviewResult = extractReviewerResponseFromGemini(geminiResponse);
+  if (!reviewResult.ok) {
+    throw new Error(reviewResult.issues.join(", "));
+  }
+
+  const commentBody = formatGeminiReviewComment({
+    review: reviewResult.review,
+    trigger: triggerResult.value.trigger,
+    model
+  });
+  const existingComment = findExistingGeminiReviewComment(issueComments);
+
+  if (existingComment) {
+    await githubFetch(`/repos/${repository}/issues/comments/${existingComment.id}`, {
+      method: "PATCH",
+      body: { body: commentBody }
+    });
+    console.log(`Updated Gemini review comment on PR #${prNumber}.`);
+    return;
+  }
+
+  await githubFetch(`/repos/${repository}/issues/${prNumber}/comments`, {
+    method: "POST",
+    body: { body: commentBody }
+  });
+  console.log(`Created Gemini review comment on PR #${prNumber}.`);
+}
+
+function createGitHubFetch({ apiBaseUrl, token }) {
+  return async (path, options = {}) => {
+    const response = await fetch(`${apiBaseUrl}${path}`, {
+      method: options.method || "GET",
+      headers: {
+        authorization: `Bearer ${token}`,
+        accept: "application/vnd.github+json",
+        "content-type": "application/json; charset=utf-8",
+        "x-github-api-version": "2022-11-28",
+        "user-agent": "vtdd-v2-gemini-reviewer"
+      },
+      body: options.body ? JSON.stringify(options.body) : undefined
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`GitHub API request failed (${response.status}): ${text}`);
+    }
+
+    if (response.status === 204) {
+      return null;
+    }
+
+    return response.json();
+  };
+}
+
+async function callGemini({ apiKey, model, body }) {
+  const response = await fetch(
+    `https://generativelanguage.googleapis.com/v1beta/models/${encodeURIComponent(model)}:generateContent?key=${encodeURIComponent(apiKey)}`,
+    {
+      method: "POST",
+      headers: {
+        "content-type": "application/json; charset=utf-8"
+      },
+      body: JSON.stringify(body)
+    }
+  );
+
+  const json = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    throw new Error(json?.error?.message || `Gemini API request failed with status ${response.status}`);
+  }
+  return json;
+}
+
+function mustGetEnv(name) {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`${name} is required`);
+  }
+  return value;
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/src/core/gemini-pr-review.js
+++ b/src/core/gemini-pr-review.js
@@ -1,0 +1,359 @@
+import { validateReviewerResponse } from "./reviewer-contract.js";
+
+export const GEMINI_PR_REVIEW_MARKER = "<!-- vtdd:reviewer=gemini -->";
+export const DEFAULT_GEMINI_REVIEW_MODEL = "gemini-2.5-flash";
+export const MAX_DIFF_CHARACTERS = 60000;
+export const MAX_CONTEXT_COMMENTS = 10;
+
+export function resolveGeminiReviewTrigger(input = {}) {
+  const eventName = normalizeText(input.eventName);
+  const payload = normalizeObject(input.payload);
+
+  if (eventName === "pull_request_target") {
+    const action = normalizeText(payload.action);
+    const pullRequest = normalizeObject(payload.pull_request);
+    if (!["opened", "reopened", "synchronize", "ready_for_review"].includes(action)) {
+      return skip("unsupported_pull_request_action");
+    }
+    if (pullRequest.draft === true && action !== "ready_for_review") {
+      return skip("draft_pull_request");
+    }
+    return {
+      ok: true,
+      value: {
+        shouldReview: true,
+        trigger: `pull_request_target:${action}`,
+        pullRequestNumber: normalizePositiveInteger(pullRequest.number)
+      }
+    };
+  }
+
+  if (eventName === "issue_comment") {
+    const issue = normalizeObject(payload.issue);
+    const comment = normalizeObject(payload.comment);
+    if (!issue.pull_request) {
+      return skip("issue_comment_not_for_pull_request");
+    }
+    if (isBotTriggered(payload) || containsMarker(comment.body)) {
+      return skip("bot_or_marker_comment");
+    }
+    return {
+      ok: true,
+      value: {
+        shouldReview: true,
+        trigger: "issue_comment:created",
+        pullRequestNumber: normalizePositiveInteger(issue.number)
+      }
+    };
+  }
+
+  if (eventName === "pull_request_review") {
+    const review = normalizeObject(payload.review);
+    const pullRequest = normalizeObject(payload.pull_request);
+    if (!["submitted", "edited"].includes(normalizeText(payload.action))) {
+      return skip("unsupported_pull_request_review_action");
+    }
+    if (isBotTriggered(payload) || containsMarker(review.body)) {
+      return skip("bot_or_marker_review");
+    }
+    return {
+      ok: true,
+      value: {
+        shouldReview: true,
+        trigger: `pull_request_review:${normalizeText(payload.action)}`,
+        pullRequestNumber: normalizePositiveInteger(pullRequest.number)
+      }
+    };
+  }
+
+  if (eventName === "pull_request_review_comment") {
+    const comment = normalizeObject(payload.comment);
+    const pullRequest = normalizeObject(payload.pull_request);
+    if (!["created", "edited"].includes(normalizeText(payload.action))) {
+      return skip("unsupported_pull_request_review_comment_action");
+    }
+    if (isBotTriggered(payload) || containsMarker(comment.body)) {
+      return skip("bot_or_marker_review_comment");
+    }
+    return {
+      ok: true,
+      value: {
+        shouldReview: true,
+        trigger: `pull_request_review_comment:${normalizeText(payload.action)}`,
+        pullRequestNumber: normalizePositiveInteger(pullRequest.number)
+      }
+    };
+  }
+
+  return skip("unsupported_event");
+}
+
+export function buildPullRequestDiff(files = [], options = {}) {
+  const maxCharacters = normalizePositiveInteger(options.maxCharacters) || MAX_DIFF_CHARACTERS;
+  const chunks = [];
+
+  for (const file of files) {
+    const name = normalizeText(file?.filename) || "unknown";
+    const status = normalizeText(file?.status) || "modified";
+    const patch = normalizeText(file?.patch);
+    const fileChunk = [
+      `diff --git a/${name} b/${name}`,
+      `status: ${status}`,
+      patch || "[patch unavailable]"
+    ].join("\n");
+    chunks.push(fileChunk);
+  }
+
+  const joined = chunks.join("\n\n");
+  if (joined.length <= maxCharacters) {
+    return joined;
+  }
+  return `${joined.slice(0, maxCharacters)}\n\n[diff truncated]`;
+}
+
+export function buildPullRequestReviewContext(input = {}) {
+  const repository = normalizeText(input.repository) || "unknown/unknown";
+  const trigger = normalizeText(input.trigger) || "unknown";
+  const pullRequest = normalizeObject(input.pullRequest);
+  const files = Array.isArray(input.files) ? input.files : [];
+  const issueComments = summarizeComments(input.issueComments);
+  const reviewComments = summarizeComments(input.reviewComments);
+  const reviews = summarizeReviews(input.reviews);
+
+  const fileSummary = files.map((file) => {
+    const filename = normalizeText(file?.filename) || "unknown";
+    const status = normalizeText(file?.status) || "modified";
+    return `- ${filename} (${status})`;
+  });
+
+  return [
+    `Repository: ${repository}`,
+    `Trigger: ${trigger}`,
+    `PR: #${normalizePositiveInteger(pullRequest.number) || "unknown"} ${normalizeText(pullRequest.title)}`,
+    `PR state: ${normalizeText(pullRequest.state) || "open"}`,
+    `Base <- Head: ${normalizeText(pullRequest.base?.ref)} <- ${normalizeText(pullRequest.head?.ref)}`,
+    `Author: ${normalizeText(pullRequest.user?.login) || "unknown"}`,
+    "",
+    "PR body:",
+    normalizeMultilineText(pullRequest.body) || "[no body]",
+    "",
+    "Changed files:",
+    fileSummary.length > 0 ? fileSummary.join("\n") : "[no changed files]",
+    "",
+    "Recent PR comments:",
+    issueComments.length > 0 ? issueComments.join("\n") : "[no recent PR comments]",
+    "",
+    "Recent review comments:",
+    reviewComments.length > 0 ? reviewComments.join("\n") : "[no recent review comments]",
+    "",
+    "Recent reviews:",
+    reviews.length > 0 ? reviews.join("\n") : "[no recent reviews]"
+  ].join("\n");
+}
+
+export function buildGeminiReviewRequestBody(input = {}) {
+  const prDiff = normalizeMultilineText(input.prDiff);
+  const context = normalizeMultilineText(input.context);
+  if (!prDiff) {
+    throw new Error("prDiff is required");
+  }
+  if (!context) {
+    throw new Error("context is required");
+  }
+
+  return {
+    systemInstruction: {
+      parts: [
+        {
+          text: [
+            "You are VTDD's Gemini reviewer.",
+            "You are critique-only.",
+            "You do not execute fixes, decide merge, or erase uncertainty.",
+            "Return JSON only.",
+            "The JSON must contain criticalFindings[], risks[], and recommendedAction.",
+            "recommendedAction must be one of: approve, request_changes, manual_review.",
+            "If there are no critical findings, keep criticalFindings empty and put at least one residual risk in risks."
+          ].join(" ")
+        }
+      ]
+    },
+    contents: [
+      {
+        role: "user",
+        parts: [
+          {
+            text: `PR diff:\n${prDiff}\n\nPR context:\n${context}`
+          }
+        ]
+      }
+    ],
+    generationConfig: {
+      responseMimeType: "application/json",
+      responseSchema: {
+        type: "OBJECT",
+        required: ["criticalFindings", "risks", "recommendedAction"],
+        properties: {
+          criticalFindings: {
+            type: "ARRAY",
+            items: { type: "STRING" }
+          },
+          risks: {
+            type: "ARRAY",
+            items: { type: "STRING" }
+          },
+          recommendedAction: {
+            type: "STRING",
+            enum: ["approve", "request_changes", "manual_review"]
+          }
+        }
+      }
+    }
+  };
+}
+
+export function extractReviewerResponseFromGemini(input = {}) {
+  const candidateText =
+    normalizeText(input?.candidates?.[0]?.content?.parts?.[0]?.text) || normalizeText(input?.text);
+  if (!candidateText) {
+    return {
+      ok: false,
+      issues: ["Gemini response did not contain text output"]
+    };
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(candidateText);
+  } catch {
+    return {
+      ok: false,
+      issues: ["Gemini response was not valid JSON"]
+    };
+  }
+
+  const validated = validateReviewerResponse(parsed);
+  if (!validated.ok) {
+    return validated;
+  }
+
+  return {
+    ok: true,
+    review: validated.response
+  };
+}
+
+export function formatGeminiReviewComment(input = {}) {
+  const review = normalizeObject(input.review);
+  const trigger = normalizeText(input.trigger) || "unknown";
+  const model = normalizeText(input.model) || DEFAULT_GEMINI_REVIEW_MODEL;
+  const criticalFindings = normalizeStringArray(review.criticalFindings);
+  const risks = normalizeStringArray(review.risks);
+  const recommendedAction = normalizeText(review.recommendedAction) || "manual_review";
+
+  return [
+    GEMINI_PR_REVIEW_MARKER,
+    "## VTDD Gemini Critical Review",
+    "",
+    `- Trigger: \`${trigger}\``,
+    `- Model: \`${model}\``,
+    `- Recommended action: \`${recommendedAction}\``,
+    "",
+    "### Critical Findings",
+    formatListOrFallback(criticalFindings, "- None reported."),
+    "",
+    "### Risks",
+    formatListOrFallback(risks, "- None reported."),
+    "",
+    "_Reviewer remains critique-only. Human keeps revision GO / merge GO authority._"
+  ].join("\n");
+}
+
+export function findExistingGeminiReviewComment(comments = []) {
+  return (
+    comments.find((comment) => containsMarker(comment?.body)) ??
+    null
+  );
+}
+
+function summarizeComments(comments) {
+  const list = Array.isArray(comments) ? comments : [];
+  return list
+    .filter((comment) => !containsMarker(comment?.body))
+    .slice(-MAX_CONTEXT_COMMENTS)
+    .map((comment) => {
+      const author = normalizeText(comment?.user?.login) || "unknown";
+      const body = normalizeInlineText(comment?.body) || "[empty]";
+      return `- ${author}: ${body}`;
+    });
+}
+
+function summarizeReviews(reviews) {
+  const list = Array.isArray(reviews) ? reviews : [];
+  return list
+    .slice(-MAX_CONTEXT_COMMENTS)
+    .map((review) => {
+      const author = normalizeText(review?.user?.login) || "unknown";
+      const state = normalizeText(review?.state) || "commented";
+      const body = normalizeInlineText(review?.body) || "[empty]";
+      return `- ${author} (${state}): ${body}`;
+    });
+}
+
+function normalizeStringArray(value) {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value
+    .map((entry) => normalizeText(entry))
+    .filter(Boolean);
+}
+
+function formatListOrFallback(values, fallback) {
+  if (!values.length) {
+    return fallback;
+  }
+  return values.map((value) => `- ${value}`).join("\n");
+}
+
+function isBotTriggered(payload) {
+  const senderLogin = normalizeText(payload?.sender?.login);
+  return senderLogin.endsWith("[bot]");
+}
+
+function containsMarker(value) {
+  return normalizeText(value).includes(GEMINI_PR_REVIEW_MARKER);
+}
+
+function normalizeInlineText(value) {
+  return normalizeMultilineText(value).replace(/\s+/g, " ").trim();
+}
+
+function normalizeMultilineText(value) {
+  return String(value ?? "").trim();
+}
+
+function normalizeText(value) {
+  return String(value ?? "").trim();
+}
+
+function normalizePositiveInteger(value) {
+  const numeric = Number(value);
+  if (!Number.isInteger(numeric) || numeric <= 0) {
+    return null;
+  }
+  return numeric;
+}
+
+function normalizeObject(value) {
+  return value && typeof value === "object" ? value : {};
+}
+
+function skip(reason) {
+  return {
+    ok: true,
+    value: {
+      shouldReview: false,
+      reason
+    }
+  };
+}

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -116,6 +116,19 @@ export {
   dispatchRemoteCodexExecution,
   retrieveRemoteCodexExecutionProgress
 } from "./remote-codex-executor.js";
+export {
+  DEFAULT_GEMINI_REVIEW_MODEL,
+  GEMINI_PR_REVIEW_MARKER,
+  MAX_CONTEXT_COMMENTS,
+  MAX_DIFF_CHARACTERS,
+  buildGeminiReviewRequestBody,
+  buildPullRequestDiff,
+  buildPullRequestReviewContext,
+  extractReviewerResponseFromGemini,
+  findExistingGeminiReviewComment,
+  formatGeminiReviewComment,
+  resolveGeminiReviewTrigger
+} from "./gemini-pr-review.js";
 export { runMvpGateway } from "./mvp-gateway.js";
 export { resolveGatewayAliasRegistryFromGitHubApp } from "./github-app-repository-index.js";
 export {

--- a/test/gemini-pr-review.test.js
+++ b/test/gemini-pr-review.test.js
@@ -1,0 +1,167 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  GEMINI_PR_REVIEW_MARKER,
+  buildGeminiReviewRequestBody,
+  buildPullRequestDiff,
+  buildPullRequestReviewContext,
+  extractReviewerResponseFromGemini,
+  findExistingGeminiReviewComment,
+  formatGeminiReviewComment,
+  resolveGeminiReviewTrigger
+} from "../src/core/index.js";
+
+test("pull_request_target opened event triggers Gemini review", () => {
+  const result = resolveGeminiReviewTrigger({
+    eventName: "pull_request_target",
+    payload: {
+      action: "opened",
+      pull_request: {
+        number: 12,
+        draft: false
+      }
+    }
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.value.shouldReview, true);
+  assert.equal(result.value.pullRequestNumber, 12);
+});
+
+test("issue_comment on PR from bot marker is skipped", () => {
+  const result = resolveGeminiReviewTrigger({
+    eventName: "issue_comment",
+    payload: {
+      issue: {
+        number: 12,
+        pull_request: {
+          url: "https://api.github.com/repos/example/repo/pulls/12"
+        }
+      },
+      comment: {
+        body: `${GEMINI_PR_REVIEW_MARKER}\nhello`
+      },
+      sender: {
+        login: "github-actions[bot]"
+      }
+    }
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.value.shouldReview, false);
+});
+
+test("buildPullRequestDiff truncates large diffs", () => {
+  const diff = buildPullRequestDiff(
+    [
+      {
+        filename: "src/index.js",
+        status: "modified",
+        patch: "x".repeat(200)
+      }
+    ],
+    { maxCharacters: 80 }
+  );
+
+  assert.equal(diff.includes("[diff truncated]"), true);
+});
+
+test("buildPullRequestReviewContext includes bounded PR metadata", () => {
+  const context = buildPullRequestReviewContext({
+    repository: "sample/repo",
+    trigger: "pull_request_target:opened",
+    pullRequest: {
+      number: 5,
+      title: "Implement reviewer loop",
+      body: "Adds runtime review path.",
+      state: "open",
+      base: { ref: "main" },
+      head: { ref: "codex/issue-9" },
+      user: { login: "codex-user" }
+    },
+    files: [{ filename: "src/core/reviewer.js", status: "added" }],
+    issueComments: [{ user: { login: "owner" }, body: "Please re-check this path." }],
+    reviewComments: [{ user: { login: "reviewer" }, body: "This branch needs another look." }],
+    reviews: [{ user: { login: "reviewer" }, state: "COMMENTED", body: "Overall risky." }]
+  });
+
+  assert.equal(context.includes("Repository: sample/repo"), true);
+  assert.equal(context.includes("Please re-check this path."), true);
+  assert.equal(context.includes("Overall risky."), true);
+});
+
+test("buildGeminiReviewRequestBody requires diff and context", () => {
+  assert.throws(
+    () => buildGeminiReviewRequestBody({ prDiff: "", context: "x" }),
+    /prDiff is required/
+  );
+  assert.throws(
+    () => buildGeminiReviewRequestBody({ prDiff: "x", context: "" }),
+    /context is required/
+  );
+});
+
+test("extractReviewerResponseFromGemini validates JSON output", () => {
+  const result = extractReviewerResponseFromGemini({
+    candidates: [
+      {
+        content: {
+          parts: [
+            {
+              text: JSON.stringify({
+                criticalFindings: ["Potential regression in approval boundary."],
+                risks: [],
+                recommendedAction: "request_changes"
+              })
+            }
+          ]
+        }
+      }
+    ]
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.review.recommendedAction, "request_changes");
+});
+
+test("extractReviewerResponseFromGemini rejects non-json output", () => {
+  const result = extractReviewerResponseFromGemini({
+    candidates: [
+      {
+        content: {
+          parts: [{ text: "not json" }]
+        }
+      }
+    ]
+  });
+
+  assert.equal(result.ok, false);
+});
+
+test("formatGeminiReviewComment renders marker and sections", () => {
+  const body = formatGeminiReviewComment({
+    trigger: "pull_request_target:opened",
+    model: "gemini-2.5-flash",
+    review: {
+      criticalFindings: ["Scope drift around issue traceability."],
+      risks: ["Human should confirm non-goals remain bounded."],
+      recommendedAction: "request_changes"
+    }
+  });
+
+  assert.equal(body.includes(GEMINI_PR_REVIEW_MARKER), true);
+  assert.equal(body.includes("VTDD Gemini Critical Review"), true);
+  assert.equal(body.includes("request_changes"), true);
+});
+
+test("findExistingGeminiReviewComment locates prior marker comment", () => {
+  const comment = findExistingGeminiReviewComment([
+    { id: 1, body: "ordinary comment" },
+    { id: 2, body: `${GEMINI_PR_REVIEW_MARKER}\nexisting review` }
+  ]);
+
+  assert.deepEqual(comment, {
+    id: 2,
+    body: `${GEMINI_PR_REVIEW_MARKER}\nexisting review`
+  });
+});


### PR DESCRIPTION
## This PR satisfies Intent

Implements Issue #9 by connecting the next runnable segment after Remote Codex: PR creation/update and PR-side follow-up comments can now trigger a Gemini critical-review workflow that reads bounded PR context and writes a traceable PR comment back to GitHub.

## Satisfied Success Criteria

- [x] A runnable GitHub workflow exists for Gemini reviewer execution on PR creation/update.
- [x] The workflow can also re-run when new PR comments or review comments arrive.
- [x] The workflow reads PR diff and bounded PR context without giving the reviewer execution credentials.
- [x] Gemini review output is validated against the existing vendor-neutral reviewer contract.
- [x] Gemini review output is written back to the PR as a traceable GitHub comment.
- [x] Re-runs update the existing VTDD Gemini review comment by marker instead of creating uncontrolled repeated comments.
- [x] The implementation assumes user-owned `GEMINI_API_KEY` configuration rather than owner-specific secrets.
- [x] Tests cover trigger selection, response validation, comment formatting, and helper behavior.

## Unsatisfied Success Criteria

- Live GitHub/Gemini E2E evidence is not yet recorded in this PR.

## Non-goal violations

None.

## Verification Evidence

- Unit: `node --test test/gemini-pr-review.test.js test/reviewer-registry.test.js`
- Integration: `node --test test/gemini-pr-review.test.js test/reviewer-registry.test.js test/worker.test.js test/remote-codex-executor.test.js`
- E2E: Not run yet against a live PR + configured `GEMINI_API_KEY`
- Manual: Read workflow, script, and canonical doc diff to confirm scope remains `PR -> Gemini comment`
- Evidence path/link: `/Users/shuhei/hibou_works/vtdd-v2-p/.github/workflows/gemini-pr-review.yml`, `/Users/shuhei/hibou_works/vtdd-v2-p/scripts/run-gemini-pr-review.mjs`, `/Users/shuhei/hibou_works/vtdd-v2-p/src/core/gemini-pr-review.js`, `/Users/shuhei/hibou_works/vtdd-v2-p/docs/butler/gemini-pr-review-comments.md`

## Related Constitution Rules

- Reviewer role does not get execution credentials.
- Shared/public use must converge on user-owned GitHub, Cloudflare, Gemini, and ChatGPT accounts.
- Butler must not erase meaningful reviewer objections.

## Out-of-scope but NOT implemented

- Butler synthesis of PR + reviewer output for human decision
- Live E2E execution evidence against a real PR
- Merge automation or reviewer-driven merge judgment

## Extra changes (if any)

None.
