### PR TITLE
Add reality guard to AGENTS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,12 @@ If current code only partially satisfies an Issue or contract, do not
 "complete it on the fly" without first surfacing the mismatch explicitly.
 When in doubt, stop and reconcile with the owner instead of pushing through.
 
+Before proposing a new spec, runtime path, or missing-capability explanation,
+re-read the relevant existing docs, tests, and source files in this repository.
+Do not talk about executor / handoff / reviewer / claim behavior as if it were
+missing from scratch until you have explicitly checked for an existing contract,
+draft, test, or implementation anchor in-repo.
+
 ## Active-Issue Coverage Policy
 
 Default assumption: implementation scope covers all active Issues unless the user explicitly narrows scope.
@@ -285,6 +291,15 @@ It must not be interpreted as a blanket prohibition for non-RAG operational logs
 - Keep docs-only PRs and runtime PRs separable when possible.
 - If a new guardrail or process correction is needed, land it in its own PR
   rather than mixing it into an implementation slice.
+
+## Current Reality Guard
+
+- Do not overclaim VTDD end-to-end completion from partial adapter success.
+- If Butler can read repositories through GitHub App, describe that exactly as
+  GitHub App-backed repository read/repository resolution, not as full VTDD
+  executor/reviewer loop completion.
+- Keep partial success statements narrow and explicit about what is still not
+  connected.
 
 ## Evidence Discipline
 


### PR DESCRIPTION
## This PR satisfies Intent

Formalize two guardrails in `AGENTS.md`: re-read relevant docs/tests/source before claiming executor/reviewer/handoff capability gaps, and avoid overclaiming VTDD end-to-end completion from partial adapter success.

## Satisfied Success Criteria

- [x] `AGENTS.md` requires re-reading relevant docs/tests/source before proposing missing-capability explanations.
- [x] `AGENTS.md` explicitly forbids overclaiming full VTDD loop completion from partial adapter success.
- [x] The change is isolated to `AGENTS.md`.
- [x] This PR is suitable for live `PR opened -> Gemini review` verification.

## Unsatisfied Success Criteria

- Live Gemini reviewer completion is not guaranteed yet because external Gemini capacity is outside repo control.

## Non-goal violations

None.

## Verification Evidence

- Unit: Not run (`AGENTS.md` only)
- Integration: Not run (`AGENTS.md` only)
- E2E: PR open is used as live reviewer trigger for canonical `PR -> Gemini` path
- Manual: Reviewed `git diff -- AGENTS.md`
- Evidence path/link: `/Users/shuhei/hibou_works/vtdd-v2-p/AGENTS.md`

## Related Constitution Rules

- Keep partial success statements narrow and explicit about what is still not connected.
- Do not treat partial adapter success as full VTDD completion.

## Out-of-scope but NOT implemented

- Runtime behavior changes
- Workflow changes
- Butler synthesis
- Merge

## Extra changes (if any)

None.
