### PR TITLE
Issue #14: add WebAuthn passkey runtime slice

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+node_modules/
 credentials/

--- a/docs/security/go-passkey-approval-model.md
+++ b/docs/security/go-passkey-approval-model.md
@@ -10,6 +10,14 @@ High-risk actions should require both explicit intent and strong user authentica
 Merge and bounded post-merge completion tasks remain explicit `GO` actions, but
 they are not part of the `GO + passkey` set.
 
+## Drift Note
+
+Historically, the repo used phrase-based `passkey` confirmation inside policy
+payloads. That phrase gate is not itself a real passkey ceremony.
+
+The executable runtime path for real WebAuthn/passkey verification is tracked in
+[webauthn-passkey-runtime.md](./webauthn-passkey-runtime.md).
+
 ## Approval Levels
 
 ### Level 1

--- a/docs/security/webauthn-passkey-runtime.md
+++ b/docs/security/webauthn-passkey-runtime.md
@@ -1,0 +1,75 @@
+# WebAuthn Passkey Runtime
+
+This document defines the executable runtime path introduced for Issue #14.
+
+## Current Reality
+
+The repository historically used `GO + passkey` language while runtime policy
+only received a phrase-bound `passkey: true/false` flag.
+
+That temporary phrase gate is not a real passkey ceremony.
+
+## Runtime Goal
+
+High-risk operations must be unlocked through a real WebAuthn/passkey
+challenge, verified by the worker runtime, and converted into a short-lived
+approval grant that Butler can use on the next high-risk request.
+
+## Current Endpoints
+
+- `POST /v2/approval/passkey/register/options`
+- `POST /v2/approval/passkey/register/verify`
+- `POST /v2/approval/passkey/challenge`
+- `POST /v2/approval/passkey/verify`
+
+All four routes use the same machine-auth boundary as the other `/v2/*`
+endpoints.
+
+## Runtime Shape
+
+### 1. Register passkey
+
+The worker generates registration options, verifies the browser response, and
+stores the resulting passkey material as a non-secret registry record.
+
+### 2. Request high-risk approval
+
+Butler/runtime asks the worker for a passkey approval challenge with the
+intended target scope:
+
+- `actionType`
+- `repositoryInput`
+- `issueNumber`
+- `relatedIssue`
+- `phase`
+
+### 3. Verify WebAuthn response
+
+The worker verifies the authenticator response and writes an `approval_log`
+grant with:
+
+- `approvalId`
+- `verifiedAt`
+- `expiresAt`
+- scope snapshot
+
+### 4. Execute high-risk action
+
+The caller sends `approvalGrantId` on the next `/v2/gateway` high-risk request.
+The worker resolves that grant from memory and binds it back into policy
+evaluation.
+
+## Safety Notes
+
+- phrase-only `passkey=true` is a temporary compatibility path, not the final
+  security model
+- high-risk grant expiry is short-lived by design
+- grant scope must match the current target
+- reviewer never receives execution credentials or passkey registry material
+
+## Non-goals of This Slice
+
+- full Butler browser-return UX
+- passkey autofill UI
+- production-grade operator enrollment UX
+- replacing the existing `GO` requirement

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,270 @@
+{
+  "name": "vtdd-v2",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "vtdd-v2",
+      "version": "0.1.0",
+      "dependencies": {
+        "@simplewebauthn/server": "^13.3.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@hexagon/base64": {
+      "version": "1.1.28",
+      "resolved": "https://registry.npmjs.org/@hexagon/base64/-/base64-1.1.28.tgz",
+      "integrity": "sha512-lhqDEAvWixy3bZ+UOYbPwUbBkwBq5C1LAJ/xPC8Oi+lL54oyakv/npbA0aU2hgCsx/1NUd4IBvV03+aUBWxerw==",
+      "license": "MIT"
+    },
+    "node_modules/@levischuck/tiny-cbor": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@levischuck/tiny-cbor/-/tiny-cbor-0.2.11.tgz",
+      "integrity": "sha512-llBRm4dT4Z89aRsm6u2oEZ8tfwL/2l6BwpZ7JcyieouniDECM5AqNgr/y08zalEIvW3RSK4upYyybDcmjXqAow==",
+      "license": "MIT"
+    },
+    "node_modules/@peculiar/asn1-android": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-android/-/asn1-android-2.6.0.tgz",
+      "integrity": "sha512-cBRCKtYPF7vJGN76/yG8VbxRcHLPF3HnkoHhKOZeHpoVtbMYfY9ROKtH3DtYUY9m8uI1Mh47PRhHf2hSK3xcSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-cms": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.6.1.tgz",
+      "integrity": "sha512-vdG4fBF6Lkirkcl53q6eOdn3XYKt+kJTG59edgRZORlg/3atWWEReRCx5rYE1ZzTTX6vLK5zDMjHh7vbrcXGtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "@peculiar/asn1-x509-attr": "^2.6.1",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-csr": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-csr/-/asn1-csr-2.6.1.tgz",
+      "integrity": "sha512-WRWnKfIocHyzFYQTka8O/tXCiBquAPSrRjXbOkHbO4qdmS6loffCEGs+rby6WxxGdJCuunnhS2duHURhjyio6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-ecc": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.6.1.tgz",
+      "integrity": "sha512-+Vqw8WFxrtDIN5ehUdvlN2m73exS2JVG0UAyfVB31gIfor3zWEAQPD+K9ydCxaj3MLen9k0JhKpu9LqviuCE1g==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pfx": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pfx/-/asn1-pfx-2.6.1.tgz",
+      "integrity": "sha512-nB5jVQy3MAAWvq0KY0R2JUZG8bO/bTLpnwyOzXyEh/e54ynGTatAR+csOnXkkVD9AFZ2uL8Z7EV918+qB1qDvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.6.1",
+        "@peculiar/asn1-pkcs8": "^2.6.1",
+        "@peculiar/asn1-rsa": "^2.6.1",
+        "@peculiar/asn1-schema": "^2.6.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pkcs8": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.6.1.tgz",
+      "integrity": "sha512-JB5iQ9Izn5yGMw3ZG4Nw3Xn/hb/G38GYF3lf7WmJb8JZUydhVGEjK/ZlFSWhnlB7K/4oqEs8HnfFIKklhR58Tw==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pkcs9": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.6.1.tgz",
+      "integrity": "sha512-5EV8nZoMSxeWmcxWmmcolg22ojZRgJg+Y9MX2fnE2bGRo5KQLqV5IL9kdSQDZxlHz95tHvIq9F//bvL1OeNILw==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.6.1",
+        "@peculiar/asn1-pfx": "^2.6.1",
+        "@peculiar/asn1-pkcs8": "^2.6.1",
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "@peculiar/asn1-x509-attr": "^2.6.1",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-rsa": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.6.1.tgz",
+      "integrity": "sha512-1nVMEh46SElUt5CB3RUTV4EG/z7iYc7EoaDY5ECwganibQPkZ/Y2eMsTKB/LeyrUJ+W/tKoD9WUqIy8vB+CEdA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-schema": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.6.0.tgz",
+      "integrity": "sha512-xNLYLBFTBKkCzEZIw842BxytQQATQv+lDTCEMZ8C196iJcJJMBUZxrhSTxLaohMyKK8QlzRNTRkUmanucnDSqg==",
+      "license": "MIT",
+      "dependencies": {
+        "asn1js": "^3.0.6",
+        "pvtsutils": "^1.3.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-x509": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.6.1.tgz",
+      "integrity": "sha512-O9jT5F1A2+t3r7C4VT7LYGXqkGLK7Kj1xFpz7U0isPrubwU5PbDoyYtx6MiGst29yq7pXN5vZbQFKRCP+lLZlA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "asn1js": "^3.0.6",
+        "pvtsutils": "^1.3.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-x509-attr": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.6.1.tgz",
+      "integrity": "sha512-tlW6cxoHwgcQghnJwv3YS+9OO1737zgPogZ+CgWRUK4roEwIPzRH4JEiG770xe5HX2ATfCpmX60gurfWIF9dcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/x509": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/@peculiar/x509/-/x509-1.14.3.tgz",
+      "integrity": "sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.6.0",
+        "@peculiar/asn1-csr": "^2.6.0",
+        "@peculiar/asn1-ecc": "^2.6.0",
+        "@peculiar/asn1-pkcs9": "^2.6.0",
+        "@peculiar/asn1-rsa": "^2.6.0",
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.0",
+        "pvtsutils": "^1.3.6",
+        "reflect-metadata": "^0.2.2",
+        "tslib": "^2.8.1",
+        "tsyringe": "^4.10.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@simplewebauthn/server": {
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/@simplewebauthn/server/-/server-13.3.0.tgz",
+      "integrity": "sha512-MLHYFrYG8/wK2i+86XMhiecK72nMaHKKt4bo+7Q1TbuG9iGjlSdfkPWKO5ZFE/BX+ygCJ7pr8H/AJeyAj1EaTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hexagon/base64": "^1.1.27",
+        "@levischuck/tiny-cbor": "^0.2.2",
+        "@peculiar/asn1-android": "^2.6.0",
+        "@peculiar/asn1-ecc": "^2.6.1",
+        "@peculiar/asn1-rsa": "^2.6.1",
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "@peculiar/x509": "^1.14.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/asn1js": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.10.tgz",
+      "integrity": "sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "pvtsutils": "^1.3.6",
+        "pvutils": "^1.1.5",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/pvtsutils": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
+      "integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/pvutils": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.5.tgz",
+      "integrity": "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/reflect-metadata": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/tsyringe": {
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/tsyringe/-/tsyringe-4.10.0.tgz",
+      "integrity": "sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/tsyringe/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -8,5 +8,8 @@
   },
   "engines": {
     "node": ">=20"
+  },
+  "dependencies": {
+    "@simplewebauthn/server": "^13.3.0"
   }
 }

--- a/src/core/approval.js
+++ b/src/core/approval.js
@@ -1,3 +1,4 @@
+import { evaluateApprovalGrant } from "./passkey-approval.js";
 import { ActionType, ApprovalLevel, ConsentCategory } from "./types.js";
 
 const GO_REQUIRED_ACTIONS = new Set([
@@ -78,6 +79,8 @@ export function evaluateApproval({
   actionType,
   go,
   passkey,
+  approvalGrant,
+  approvalScope,
   approvalPhrase,
   approvalScopeMatched = false
 }) {
@@ -111,13 +114,19 @@ export function evaluateApproval({
           reason: "explicit GO is required before execution"
         };
   }
-  if (go && passkey) {
+  const grantResult = evaluateApprovalGrant({
+    approvalGrant,
+    scope: approvalScope
+  });
+  if (go && (passkey || grantResult.ok)) {
     return { ok: true, required };
   }
   return {
     ok: false,
     required,
-    reason: "high-risk action requires GO + passkey"
+    reason: passkey
+      ? "high-risk action requires GO + passkey"
+      : grantResult.reason || "high-risk action requires GO + passkey"
   };
 }
 

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -22,6 +22,23 @@ export {
   evaluateConsent,
   evaluateApproval
 } from "./approval.js";
+export {
+  DEFAULT_PASSKEY_GRANT_TTL_MS,
+  DEFAULT_PASSKEY_SESSION_TTL_MS,
+  PASSKEY_APPROVAL_KIND,
+  PASSKEY_GRANT_TAG,
+  PASSKEY_REGISTRATION_KIND,
+  PASSKEY_REGISTRY_TAG,
+  PASSKEY_SESSION_TAG,
+  createPasskeyApprovalOptions,
+  createPasskeyRegistrationOptions,
+  dedupePasskeys,
+  defaultPasskeyAdapter,
+  evaluateApprovalGrant,
+  normalizeScopeSnapshot,
+  verifyPasskeyApproval,
+  verifyPasskeyRegistration
+} from "./passkey-approval.js";
 export { requiredCredentialTier, evaluateCredentialBoundary } from "./credential-boundary.js";
 export { resolveRepositoryTarget } from "./repository-resolution.js";
 export { evaluateTargetConfirmationBoundary } from "./target-confirmation.js";

--- a/src/core/passkey-approval.js
+++ b/src/core/passkey-approval.js
@@ -1,0 +1,496 @@
+import {
+  generateAuthenticationOptions,
+  generateRegistrationOptions,
+  verifyAuthenticationResponse,
+  verifyRegistrationResponse
+} from "@simplewebauthn/server";
+import { createMemoryRecord, MemoryRecordType } from "./memory-schema.js";
+
+export const PASSKEY_REGISTRY_TAG = "passkey_registry";
+export const PASSKEY_SESSION_TAG = "passkey_session";
+export const PASSKEY_GRANT_TAG = "passkey_grant";
+export const PASSKEY_REGISTRATION_KIND = "passkey_registration";
+export const PASSKEY_APPROVAL_KIND = "passkey_approval";
+export const DEFAULT_PASSKEY_SESSION_TTL_MS = 5 * 60 * 1000;
+export const DEFAULT_PASSKEY_GRANT_TTL_MS = 2 * 60 * 1000;
+
+export const defaultPasskeyAdapter = Object.freeze({
+  generateRegistrationOptions,
+  verifyRegistrationResponse,
+  generateAuthenticationOptions,
+  verifyAuthenticationResponse
+});
+
+export async function createPasskeyRegistrationOptions(input = {}) {
+  const adapter = resolvePasskeyAdapter(input.adapter);
+  const rpID = normalizeText(input.rpID);
+  const rpName = normalizeText(input.rpName) || "VTDD";
+  const origin = normalizeText(input.origin);
+  const operatorId = normalizeText(input.operatorId) || "vtdd-operator";
+  const operatorLabel = normalizeText(input.operatorLabel) || "VTDD Operator";
+  const sessionTtlMs = normalizePositiveInt(
+    input.sessionTtlMs,
+    DEFAULT_PASSKEY_SESSION_TTL_MS
+  );
+
+  if (!rpID || !origin) {
+    return {
+      ok: false,
+      issues: ["rpID and origin are required for passkey registration"]
+    };
+  }
+
+  const sessionId = randomId("passkey-reg");
+  const challenge = randomId("challenge");
+  const optionsJSON = await adapter.generateRegistrationOptions({
+    rpName,
+    rpID,
+    challenge,
+    userName: operatorId,
+    userDisplayName: operatorLabel,
+    userID: isoBytes(sessionId),
+    timeout: sessionTtlMs,
+    attestationType: "none",
+    authenticatorSelection: {
+      residentKey: "required",
+      userVerification: "required"
+    }
+  });
+
+  const expiresAt = new Date(Date.now() + sessionTtlMs).toISOString();
+  const sessionRecord = createMemoryRecord({
+    id: sessionId,
+    type: MemoryRecordType.APPROVAL_LOG,
+    content: {
+      kind: PASSKEY_REGISTRATION_KIND,
+      status: "pending",
+      challenge: optionsJSON.challenge,
+      rpID,
+      origin,
+      expiresAt,
+      operatorId,
+      operatorLabel
+    },
+    metadata: {
+      source: "passkey_registration_options",
+      operatorId,
+      operatorLabel
+    },
+    priority: 92,
+    tags: [PASSKEY_SESSION_TAG, PASSKEY_REGISTRATION_KIND],
+    createdAt: new Date().toISOString()
+  });
+
+  if (!sessionRecord.ok) {
+    return sessionRecord;
+  }
+
+  return {
+    ok: true,
+    sessionRecord: sessionRecord.record,
+    optionsJSON
+  };
+}
+
+export async function verifyPasskeyRegistration(input = {}) {
+  const adapter = resolvePasskeyAdapter(input.adapter);
+  const sessionRecord = input.sessionRecord ?? null;
+  const response = input.response ?? null;
+  const rpID = normalizeText(input.rpID || sessionRecord?.content?.rpID);
+  const origin = normalizeText(input.origin || sessionRecord?.content?.origin);
+  const expectedChallenge = normalizeText(
+    input.expectedChallenge || sessionRecord?.content?.challenge
+  );
+
+  if (!sessionRecord || !response || !rpID || !origin || !expectedChallenge) {
+    return {
+      ok: false,
+      issues: ["sessionRecord, response, rpID, origin, and expectedChallenge are required"]
+    };
+  }
+
+  const verification = await adapter.verifyRegistrationResponse({
+    response,
+    expectedChallenge,
+    expectedOrigin: origin,
+    expectedRPID: rpID,
+    requireUserVerification: true
+  });
+
+  if (!verification.verified || !verification.registrationInfo) {
+    return {
+      ok: false,
+      issues: ["passkey registration verification failed"]
+    };
+  }
+
+  const { registrationInfo } = verification;
+  const credentialId = base64UrlEncode(registrationInfo.credential.id);
+  const passkeyRecord = createMemoryRecord({
+    id: `passkey:${credentialId}`,
+    type: MemoryRecordType.WORKING_MEMORY,
+    content: {
+      kind: PASSKEY_REGISTRY_TAG,
+      credentialId,
+      publicKey: base64UrlEncode(registrationInfo.credential.publicKey),
+      counter: registrationInfo.credential.counter,
+      transports: response.response?.transports ?? [],
+      aaguid: registrationInfo.aaguid,
+      deviceType: registrationInfo.credentialDeviceType,
+      backedUp: registrationInfo.credentialBackedUp === true
+    },
+    metadata: {
+      source: "passkey_registration_verify",
+      rpID,
+      origin,
+      operatorId: normalizeText(sessionRecord?.content?.operatorId)
+    },
+    priority: 86,
+    tags: [PASSKEY_REGISTRY_TAG],
+    createdAt: new Date().toISOString()
+  });
+
+  const completedSessionRecord = createMemoryRecord({
+    id: `${sessionRecord.id}:verified`,
+    type: MemoryRecordType.APPROVAL_LOG,
+    content: {
+      kind: PASSKEY_REGISTRATION_KIND,
+      status: "verified",
+      sessionId: sessionRecord.id,
+      credentialId
+    },
+    metadata: {
+      source: "passkey_registration_verify",
+      rpID,
+      origin
+    },
+    priority: 90,
+    tags: [PASSKEY_SESSION_TAG, PASSKEY_REGISTRATION_KIND, "verified"],
+    createdAt: new Date().toISOString()
+  });
+
+  if (!passkeyRecord.ok) {
+    return passkeyRecord;
+  }
+  if (!completedSessionRecord.ok) {
+    return completedSessionRecord;
+  }
+
+  return {
+    ok: true,
+    verification,
+    passkeyRecord: passkeyRecord.record,
+    completedSessionRecord: completedSessionRecord.record
+  };
+}
+
+export async function createPasskeyApprovalOptions(input = {}) {
+  const adapter = resolvePasskeyAdapter(input.adapter);
+  const rpID = normalizeText(input.rpID);
+  const origin = normalizeText(input.origin);
+  const passkeys = dedupePasskeys(input.passkeys);
+  const scope = normalizeScopeSnapshot(input.scope);
+  const sessionTtlMs = normalizePositiveInt(
+    input.sessionTtlMs,
+    DEFAULT_PASSKEY_SESSION_TTL_MS
+  );
+
+  if (!rpID || !origin) {
+    return {
+      ok: false,
+      issues: ["rpID and origin are required for passkey approval"]
+    };
+  }
+  if (passkeys.length === 0) {
+    return {
+      ok: false,
+      issues: ["at least one registered passkey is required"]
+    };
+  }
+
+  const sessionId = randomId("passkey-auth");
+  const challenge = randomId("challenge");
+  const optionsJSON = await adapter.generateAuthenticationOptions({
+    rpID,
+    challenge,
+    timeout: sessionTtlMs,
+    userVerification: "required",
+    allowCredentials: passkeys.map((passkey) => ({
+      id: passkey.credentialId,
+      transports: Array.isArray(passkey.transports) ? passkey.transports : []
+    }))
+  });
+
+  const expiresAt = new Date(Date.now() + sessionTtlMs).toISOString();
+  const sessionRecord = createMemoryRecord({
+    id: sessionId,
+    type: MemoryRecordType.APPROVAL_LOG,
+    content: {
+      kind: PASSKEY_APPROVAL_KIND,
+      status: "pending",
+      challenge: optionsJSON.challenge,
+      rpID,
+      origin,
+      expiresAt,
+      scope
+    },
+    metadata: {
+      source: "passkey_approval_options",
+      scopeKey: stableStringify(scope)
+    },
+    priority: 94,
+    tags: [PASSKEY_SESSION_TAG, PASSKEY_APPROVAL_KIND],
+    createdAt: new Date().toISOString()
+  });
+
+  if (!sessionRecord.ok) {
+    return sessionRecord;
+  }
+
+  return {
+    ok: true,
+    sessionRecord: sessionRecord.record,
+    optionsJSON
+  };
+}
+
+export async function verifyPasskeyApproval(input = {}) {
+  const adapter = resolvePasskeyAdapter(input.adapter);
+  const sessionRecord = input.sessionRecord ?? null;
+  const response = input.response ?? null;
+  const passkeys = dedupePasskeys(input.passkeys);
+  const rpID = normalizeText(input.rpID || sessionRecord?.content?.rpID);
+  const origin = normalizeText(input.origin || sessionRecord?.content?.origin);
+  const expectedChallenge = normalizeText(
+    input.expectedChallenge || sessionRecord?.content?.challenge
+  );
+  const grantTtlMs = normalizePositiveInt(
+    input.grantTtlMs,
+    DEFAULT_PASSKEY_GRANT_TTL_MS
+  );
+
+  if (!sessionRecord || !response || !rpID || !origin || !expectedChallenge) {
+    return {
+      ok: false,
+      issues: ["sessionRecord, response, rpID, origin, and expectedChallenge are required"]
+    };
+  }
+
+  const credentialId = normalizeText(response.id);
+  const passkey = passkeys.find((item) => item.credentialId === credentialId);
+  if (!passkey) {
+    return {
+      ok: false,
+      issues: ["matching registered passkey not found"]
+    };
+  }
+
+  const verification = await adapter.verifyAuthenticationResponse({
+    response,
+    expectedChallenge,
+    expectedOrigin: origin,
+    expectedRPID: rpID,
+    credential: {
+      id: passkey.credentialId,
+      publicKey: base64UrlDecode(passkey.publicKey),
+      counter: Number(passkey.counter ?? 0),
+      transports: Array.isArray(passkey.transports) ? passkey.transports : []
+    },
+    requireUserVerification: true
+  });
+
+  if (!verification.verified) {
+    return {
+      ok: false,
+      issues: ["passkey approval verification failed"]
+    };
+  }
+
+  const approvalId = randomId("approval");
+  const verifiedAt = new Date().toISOString();
+  const expiresAt = new Date(Date.now() + grantTtlMs).toISOString();
+  const scope = normalizeScopeSnapshot(sessionRecord?.content?.scope);
+
+  const updatedPasskeyRecord = createMemoryRecord({
+    id: `passkey:${credentialId}`,
+    type: MemoryRecordType.WORKING_MEMORY,
+    content: {
+      ...passkey,
+      kind: PASSKEY_REGISTRY_TAG,
+      counter:
+        verification.authenticationInfo?.newCounter ?? Number(passkey.counter ?? 0)
+    },
+    metadata: {
+      source: "passkey_approval_verify",
+      rpID,
+      origin
+    },
+    priority: 86,
+    tags: [PASSKEY_REGISTRY_TAG],
+    createdAt: verifiedAt
+  });
+
+  const grantRecord = createMemoryRecord({
+    id: approvalId,
+    type: MemoryRecordType.APPROVAL_LOG,
+    content: {
+      kind: PASSKEY_GRANT_TAG,
+      status: "verified",
+      approvalId,
+      credentialId,
+      verifiedAt,
+      expiresAt,
+      scope
+    },
+    metadata: {
+      source: "passkey_approval_verify",
+      scopeKey: stableStringify(scope)
+    },
+    priority: 96,
+    tags: [PASSKEY_GRANT_TAG, PASSKEY_APPROVAL_KIND, "verified"],
+    createdAt: verifiedAt
+  });
+
+  if (!updatedPasskeyRecord.ok) {
+    return updatedPasskeyRecord;
+  }
+  if (!grantRecord.ok) {
+    return grantRecord;
+  }
+
+  return {
+    ok: true,
+    verification,
+    updatedPasskeyRecord: updatedPasskeyRecord.record,
+    grantRecord: grantRecord.record,
+    approvalGrant: {
+      approvalId,
+      verified: true,
+      expiresAt,
+      scope
+    }
+  };
+}
+
+export function evaluateApprovalGrant(input = {}) {
+  const approvalGrant = input.approvalGrant ?? null;
+  const now = input.now ?? new Date();
+  const scope = normalizeScopeSnapshot(input.scope);
+  if (!approvalGrant || approvalGrant.verified !== true) {
+    return {
+      ok: false,
+      reason: "real passkey approval grant is required"
+    };
+  }
+
+  const expiresAt = normalizeText(approvalGrant.expiresAt);
+  if (!expiresAt || Date.parse(expiresAt) <= now.valueOf()) {
+    return {
+      ok: false,
+      reason: "approval grant expired"
+    };
+  }
+
+  if (stableStringify(normalizeScopeSnapshot(approvalGrant.scope)) !== stableStringify(scope)) {
+    return {
+      ok: false,
+      reason: "approval grant scope does not match current target"
+    };
+  }
+
+  return { ok: true };
+}
+
+export function normalizeScopeSnapshot(scope = {}) {
+  return {
+    actionType: normalizeText(scope.actionType),
+    repositoryInput: normalizeText(scope.repositoryInput),
+    issueNumber: normalizeText(scope.issueNumber),
+    relatedIssue: normalizeText(scope.relatedIssue),
+    phase: normalizeText(scope.phase)
+  };
+}
+
+export function dedupePasskeys(records = []) {
+  const latest = new Map();
+  const sorted = Array.isArray(records)
+    ? [...records].sort((a, b) => String(b?.createdAt ?? "").localeCompare(String(a?.createdAt ?? "")))
+    : [];
+
+  for (const record of sorted) {
+    const content = record?.content ?? record;
+    const credentialId = normalizeText(content?.credentialId);
+    if (!credentialId || latest.has(credentialId)) {
+      continue;
+    }
+    latest.set(credentialId, {
+      credentialId,
+      publicKey: normalizeText(content?.publicKey),
+      counter: Number(content?.counter ?? 0),
+      transports: Array.isArray(content?.transports) ? content.transports : []
+    });
+  }
+
+  return [...latest.values()].filter(
+    (item) => item.credentialId && item.publicKey
+  );
+}
+
+function resolvePasskeyAdapter(adapter) {
+  return adapter && typeof adapter === "object" ? adapter : defaultPasskeyAdapter;
+}
+
+function normalizePositiveInt(value, fallback) {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric) || numeric <= 0) {
+    return fallback;
+  }
+  return Math.floor(numeric);
+}
+
+function normalizeText(value) {
+  return String(value ?? "").trim();
+}
+
+function randomId(prefix) {
+  return `${prefix}:${crypto.randomUUID()}`;
+}
+
+function isoBytes(value) {
+  return new TextEncoder().encode(String(value ?? ""));
+}
+
+function base64UrlEncode(input) {
+  const bytes = input instanceof Uint8Array ? input : new Uint8Array(input);
+  let text = "";
+  for (const byte of bytes) {
+    text += String.fromCharCode(byte);
+  }
+  return btoa(text).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+}
+
+function base64UrlDecode(text) {
+  const base64 = String(text ?? "")
+    .replace(/-/g, "+")
+    .replace(/_/g, "/")
+    .padEnd(Math.ceil(String(text ?? "").length / 4) * 4, "=");
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+  return bytes;
+}
+
+function stableStringify(value) {
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableStringify(item)).join(",")}]`;
+  }
+  if (value && typeof value === "object") {
+    return `{${Object.keys(value)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value ?? null);
+}

--- a/src/core/policy.js
+++ b/src/core/policy.js
@@ -25,6 +25,8 @@ export function evaluateExecutionPolicy(input) {
     credential,
     consent,
     approvalPhrase,
+    approvalGrant,
+    approvalScope,
     approvalScopeMatched = false,
     issueTraceable,
     issueTraceability,
@@ -112,6 +114,8 @@ export function evaluateExecutionPolicy(input) {
     actionType,
     go,
     passkey,
+    approvalGrant,
+    approvalScope,
     approvalPhrase,
     approvalScopeMatched
   });

--- a/src/worker.js
+++ b/src/worker.js
@@ -3,11 +3,15 @@ import {
   MemoryRecordType,
   appendDecisionLogFromGateway,
   appendProposalLogFromGateway,
+  createPasskeyApprovalOptions,
+  createPasskeyRegistrationOptions,
   createMemoryRecord,
   createRemoteCodexExecutionRequest,
+  dedupePasskeys,
   dispatchRemoteCodexExecution,
   inferRelatedIssueFromGatewayInput,
   inferRelatedIssueFromProposalGatewayInput,
+  normalizeScopeSnapshot,
   normalizeAutonomyMode,
   retrieveRemoteCodexExecutionProgress,
   retrieveCrossIssueMemoryIndex,
@@ -16,7 +20,9 @@ import {
   retrieveConstitution,
   resolveGatewayAliasRegistryFromGitHubApp,
   runMvpGateway,
-  validateMemoryProvider
+  validateMemoryProvider,
+  verifyPasskeyApproval,
+  verifyPasskeyRegistration
 } from "./core/index.js";
 
 const JSON_HEADERS = {
@@ -147,6 +153,70 @@ export default {
         ok: true,
         progress: progress.progress
       });
+    }
+
+    if (request.method === "POST" && isApiPath(url.pathname, "/approval/passkey/register/options")) {
+      const auth = authorizeGatewayRequest({
+        request,
+        env,
+        apiSuffix: "/approval/passkey/register/options"
+      });
+      if (!auth.ok) {
+        return json(auth.status, {
+          ok: false,
+          error: "unauthorized",
+          reason: auth.reason
+        });
+      }
+      return handlePasskeyRegistrationOptionsRequest(request, env);
+    }
+
+    if (request.method === "POST" && isApiPath(url.pathname, "/approval/passkey/register/verify")) {
+      const auth = authorizeGatewayRequest({
+        request,
+        env,
+        apiSuffix: "/approval/passkey/register/verify"
+      });
+      if (!auth.ok) {
+        return json(auth.status, {
+          ok: false,
+          error: "unauthorized",
+          reason: auth.reason
+        });
+      }
+      return handlePasskeyRegistrationVerifyRequest(request, env);
+    }
+
+    if (request.method === "POST" && isApiPath(url.pathname, "/approval/passkey/challenge")) {
+      const auth = authorizeGatewayRequest({
+        request,
+        env,
+        apiSuffix: "/approval/passkey/challenge"
+      });
+      if (!auth.ok) {
+        return json(auth.status, {
+          ok: false,
+          error: "unauthorized",
+          reason: auth.reason
+        });
+      }
+      return handlePasskeyApprovalOptionsRequest(request, env);
+    }
+
+    if (request.method === "POST" && isApiPath(url.pathname, "/approval/passkey/verify")) {
+      const auth = authorizeGatewayRequest({
+        request,
+        env,
+        apiSuffix: "/approval/passkey/verify"
+      });
+      if (!auth.ok) {
+        return json(auth.status, {
+          ok: false,
+          error: "unauthorized",
+          reason: auth.reason
+        });
+      }
+      return handlePasskeyApprovalVerifyRequest(request, env);
     }
 
     if (request.method === "GET" && isApiPath(url.pathname, "/retrieve/constitution")) {
@@ -361,17 +431,219 @@ async function prepareGatewayPayload({ payload, env }) {
     warnings.push("runtime forces guarded absence mode; payload autonomyMode override was ignored");
   }
 
+  const resolvedApprovalGrant = await resolveApprovalGrant({
+    payload: basePayload,
+    policyInput: basePolicyInput,
+    env
+  });
+  if (resolvedApprovalGrant.warning) {
+    warnings.push(resolvedApprovalGrant.warning);
+  }
+
   return {
     payload: {
       ...basePayload,
       policyInput: {
         ...basePolicyInput,
         aliasRegistry: resolvedAliasRegistry.aliasRegistry,
-        autonomyMode: effectiveAutonomyMode
+        autonomyMode: effectiveAutonomyMode,
+        approvalGrant: resolvedApprovalGrant.approvalGrant,
+        approvalScope: buildApprovalScopeSnapshot({
+          payload: basePayload,
+          policyInput: basePolicyInput
+        })
       }
     },
     warnings
   };
+}
+
+async function handlePasskeyRegistrationOptionsRequest(request, env) {
+  const provider = env?.MEMORY_PROVIDER ?? null;
+  const validation = validateMemoryProvider(provider);
+  if (!validation.ok) {
+    return json(503, {
+      ok: false,
+      error: "memory_provider_unavailable",
+      reason: "valid memory provider is required for passkey registration"
+    });
+  }
+
+  const body = await readJson(request);
+  const created = await createPasskeyRegistrationOptions({
+    adapter: env?.PASSKEY_ADAPTER,
+    rpID: env?.VTDD_PASSKEY_RP_ID || new URL(request.url).hostname,
+    rpName: env?.VTDD_PASSKEY_RP_NAME || "VTDD",
+    origin: env?.VTDD_PASSKEY_ORIGIN || new URL(request.url).origin,
+    operatorId: normalizeText(body?.operatorId) || "vtdd-operator",
+    operatorLabel: normalizeText(body?.operatorLabel) || "VTDD Operator"
+  });
+
+  if (!created.ok) {
+    return json(422, {
+      ok: false,
+      error: "passkey_registration_options_invalid",
+      issues: created.issues ?? []
+    });
+  }
+
+  const stored = await provider.store(created.sessionRecord);
+  if (!stored?.ok) {
+    return json(503, {
+      ok: false,
+      error: "memory_write_failed",
+      reason: "failed to persist pending registration session"
+    });
+  }
+
+  return json(200, {
+    ok: true,
+    sessionId: created.sessionRecord.id,
+    optionsJSON: created.optionsJSON
+  });
+}
+
+async function handlePasskeyRegistrationVerifyRequest(request, env) {
+  const provider = env?.MEMORY_PROVIDER ?? null;
+  const validation = validateMemoryProvider(provider);
+  if (!validation.ok) {
+    return json(503, {
+      ok: false,
+      error: "memory_provider_unavailable",
+      reason: "valid memory provider is required for passkey registration verify"
+    });
+  }
+
+  const body = await readJson(request);
+  const sessionId = normalizeText(body?.sessionId);
+  const sessionRecord = await findApprovalRecordById(provider, sessionId);
+  if (!sessionRecord) {
+    return json(404, {
+      ok: false,
+      error: "passkey_session_not_found",
+      reason: "registration session not found"
+    });
+  }
+
+  const verified = await verifyPasskeyRegistration({
+    adapter: env?.PASSKEY_ADAPTER,
+    sessionRecord,
+    response: body?.response,
+    rpID: env?.VTDD_PASSKEY_RP_ID || new URL(request.url).hostname,
+    origin: env?.VTDD_PASSKEY_ORIGIN || new URL(request.url).origin
+  });
+
+  if (!verified.ok) {
+    return json(422, {
+      ok: false,
+      error: "passkey_registration_verify_failed",
+      issues: verified.issues ?? []
+    });
+  }
+
+  await provider.store(verified.passkeyRecord);
+  await provider.store(verified.completedSessionRecord);
+
+  return json(200, {
+    ok: true,
+    credentialId: verified.passkeyRecord.content.credentialId
+  });
+}
+
+async function handlePasskeyApprovalOptionsRequest(request, env) {
+  const provider = env?.MEMORY_PROVIDER ?? null;
+  const validation = validateMemoryProvider(provider);
+  if (!validation.ok) {
+    return json(503, {
+      ok: false,
+      error: "memory_provider_unavailable",
+      reason: "valid memory provider is required for passkey approval"
+    });
+  }
+
+  const body = await readJson(request);
+  const passkeys = await retrieveRegisteredPasskeys(provider);
+  const created = await createPasskeyApprovalOptions({
+    adapter: env?.PASSKEY_ADAPTER,
+    rpID: env?.VTDD_PASSKEY_RP_ID || new URL(request.url).hostname,
+    origin: env?.VTDD_PASSKEY_ORIGIN || new URL(request.url).origin,
+    passkeys,
+    scope: buildApprovalScopeSnapshot({
+      payload: body,
+      policyInput: body?.policyInput
+    })
+  });
+
+  if (!created.ok) {
+    return json(422, {
+      ok: false,
+      error: "passkey_approval_options_invalid",
+      issues: created.issues ?? []
+    });
+  }
+
+  const stored = await provider.store(created.sessionRecord);
+  if (!stored?.ok) {
+    return json(503, {
+      ok: false,
+      error: "memory_write_failed",
+      reason: "failed to persist pending passkey approval session"
+    });
+  }
+
+  return json(200, {
+    ok: true,
+    sessionId: created.sessionRecord.id,
+    optionsJSON: created.optionsJSON
+  });
+}
+
+async function handlePasskeyApprovalVerifyRequest(request, env) {
+  const provider = env?.MEMORY_PROVIDER ?? null;
+  const validation = validateMemoryProvider(provider);
+  if (!validation.ok) {
+    return json(503, {
+      ok: false,
+      error: "memory_provider_unavailable",
+      reason: "valid memory provider is required for passkey approval verify"
+    });
+  }
+
+  const body = await readJson(request);
+  const sessionId = normalizeText(body?.sessionId);
+  const sessionRecord = await findApprovalRecordById(provider, sessionId);
+  if (!sessionRecord) {
+    return json(404, {
+      ok: false,
+      error: "passkey_session_not_found",
+      reason: "approval session not found"
+    });
+  }
+
+  const verified = await verifyPasskeyApproval({
+    adapter: env?.PASSKEY_ADAPTER,
+    sessionRecord,
+    response: body?.response,
+    passkeys: await retrieveRegisteredPasskeys(provider),
+    rpID: env?.VTDD_PASSKEY_RP_ID || new URL(request.url).hostname,
+    origin: env?.VTDD_PASSKEY_ORIGIN || new URL(request.url).origin
+  });
+
+  if (!verified.ok) {
+    return json(422, {
+      ok: false,
+      error: "passkey_approval_verify_failed",
+      issues: verified.issues ?? []
+    });
+  }
+
+  await provider.store(verified.updatedPasskeyRecord);
+  await provider.store(verified.grantRecord);
+
+  return json(200, {
+    ok: true,
+    approvalGrant: verified.approvalGrant
+  });
 }
 
 function appendWarnings(result, warnings) {
@@ -386,6 +658,73 @@ function appendWarnings(result, warnings) {
     ...result,
     warnings: [...merged]
   };
+}
+
+async function resolveApprovalGrant({ payload, policyInput, env }) {
+  const provider = env?.MEMORY_PROVIDER ?? null;
+  const validation = validateMemoryProvider(provider);
+  if (!validation.ok) {
+    return { approvalGrant: null };
+  }
+
+  const approvalId = normalizeText(policyInput?.approvalGrantId);
+  if (!approvalId) {
+    return { approvalGrant: null };
+  }
+
+  const record = await findApprovalRecordById(provider, approvalId);
+  if (!record || record?.content?.kind !== "passkey_grant") {
+    return {
+      approvalGrant: null,
+      warning: "approval grant id was provided but no matching passkey grant was found"
+    };
+  }
+
+  return {
+    approvalGrant: {
+      approvalId,
+      verified: record.content.status === "verified",
+      expiresAt: record.content.expiresAt,
+      scope: record.content.scope
+    }
+  };
+}
+
+function buildApprovalScopeSnapshot({ payload, policyInput }) {
+  const issueContext = normalizeObject(payload?.issueContext);
+  const traceability = normalizeObject(policyInput?.issueTraceability);
+  return normalizeScopeSnapshot({
+    actionType: policyInput?.actionType,
+    repositoryInput: policyInput?.repositoryInput,
+    issueNumber: issueContext.issueNumber,
+    relatedIssue: traceability.relatedIssue ?? issueContext.issueNumber,
+    phase: payload?.phase
+  });
+}
+
+async function retrieveRegisteredPasskeys(provider) {
+  const records = await provider.retrieve({
+    type: MemoryRecordType.WORKING_MEMORY,
+    tags: ["passkey_registry"]
+  });
+  return dedupePasskeys(records);
+}
+
+async function findApprovalRecordById(provider, recordId) {
+  if (!recordId) {
+    return null;
+  }
+  const records = await provider.query({
+    type: MemoryRecordType.APPROVAL_LOG,
+    text: recordId,
+    limit: 50
+  });
+  return (
+    records.find((record) => normalizeText(record?.id) === recordId) ??
+    records.find((record) => normalizeText(record?.content?.approvalId) === recordId) ??
+    records.find((record) => normalizeText(record?.content?.sessionId) === recordId) ??
+    null
+  );
 }
 
 async function appendGuardedAbsenceExecutionLog({ payload, gatewayOutcome, env }) {

--- a/test/passkey-approval.test.js
+++ b/test/passkey-approval.test.js
@@ -1,0 +1,182 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  createPasskeyApprovalOptions,
+  createPasskeyRegistrationOptions,
+  dedupePasskeys,
+  evaluateApprovalGrant,
+  verifyPasskeyApproval,
+  verifyPasskeyRegistration
+} from "../src/core/index.js";
+
+const mockAdapter = {
+  async generateRegistrationOptions(input) {
+    return {
+      challenge: input.challenge,
+      rp: {
+        id: input.rpID,
+        name: input.rpName
+      }
+    };
+  },
+  async verifyRegistrationResponse() {
+    return {
+      verified: true,
+      registrationInfo: {
+        credential: {
+          id: new Uint8Array([1, 2, 3, 4]),
+          publicKey: new Uint8Array([5, 6, 7, 8]),
+          counter: 1
+        },
+        credentialDeviceType: "singleDevice",
+        credentialBackedUp: true,
+        aaguid: "test-aaguid"
+      }
+    };
+  },
+  async generateAuthenticationOptions(input) {
+    return {
+      challenge: input.challenge,
+      allowCredentials: input.allowCredentials
+    };
+  },
+  async verifyAuthenticationResponse() {
+    return {
+      verified: true,
+      authenticationInfo: {
+        newCounter: 2
+      }
+    };
+  }
+};
+
+test("passkey registration options create pending session record", async () => {
+  const result = await createPasskeyRegistrationOptions({
+    adapter: mockAdapter,
+    rpID: "example.com",
+    rpName: "VTDD",
+    origin: "https://example.com"
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.sessionRecord.type, "approval_log");
+  assert.equal(result.sessionRecord.content.kind, "passkey_registration");
+  assert.match(result.optionsJSON.challenge, /^challenge:/);
+});
+
+test("passkey registration verify creates passkey registry record", async () => {
+  const session = await createPasskeyRegistrationOptions({
+    adapter: mockAdapter,
+    rpID: "example.com",
+    rpName: "VTDD",
+    origin: "https://example.com"
+  });
+
+  const result = await verifyPasskeyRegistration({
+    adapter: mockAdapter,
+    sessionRecord: session.sessionRecord,
+    response: {
+      id: "ignored",
+      response: {
+        transports: ["internal"]
+      }
+    }
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.passkeyRecord.type, "working_memory");
+  assert.equal(result.passkeyRecord.tags.includes("passkey_registry"), true);
+});
+
+test("passkey approval verify creates approval grant bound to scope", async () => {
+  const options = await createPasskeyApprovalOptions({
+    adapter: mockAdapter,
+    rpID: "example.com",
+    origin: "https://example.com",
+    passkeys: [
+      {
+        credentialId: "AQIDBA",
+        publicKey: "BQYHCA",
+        counter: 1,
+        transports: ["internal"]
+      }
+    ],
+    scope: {
+      actionType: "deploy_production",
+      repositoryInput: "sample-org/vtdd-v2",
+      issueNumber: 14,
+      relatedIssue: 14,
+      phase: "execution"
+    }
+  });
+
+  const verified = await verifyPasskeyApproval({
+    adapter: mockAdapter,
+    sessionRecord: options.sessionRecord,
+    response: {
+      id: "AQIDBA",
+      response: {}
+    },
+    passkeys: [
+      {
+        credentialId: "AQIDBA",
+        publicKey: "BQYHCA",
+        counter: 1,
+        transports: ["internal"]
+      }
+    ]
+  });
+
+  assert.equal(verified.ok, true);
+  assert.equal(verified.grantRecord.content.kind, "passkey_grant");
+  assert.equal(verified.approvalGrant.scope.actionType, "deploy_production");
+});
+
+test("approval grant rejects mismatched scope", () => {
+  const result = evaluateApprovalGrant({
+    approvalGrant: {
+      verified: true,
+      expiresAt: "2099-01-01T00:00:00.000Z",
+      scope: {
+        actionType: "deploy_production",
+        repositoryInput: "sample-org/vtdd-v2",
+        issueNumber: "14",
+        relatedIssue: "14",
+        phase: "execution"
+      }
+    },
+    scope: {
+      actionType: "destructive",
+      repositoryInput: "sample-org/vtdd-v2",
+      issueNumber: "14",
+      relatedIssue: "14",
+      phase: "execution"
+    }
+  });
+
+  assert.equal(result.ok, false);
+});
+
+test("dedupePasskeys keeps latest credential record", () => {
+  const records = dedupePasskeys([
+    {
+      createdAt: "2026-04-24T00:00:00.000Z",
+      content: {
+        credentialId: "abc",
+        publicKey: "old",
+        counter: 1
+      }
+    },
+    {
+      createdAt: "2026-04-25T00:00:00.000Z",
+      content: {
+        credentialId: "abc",
+        publicKey: "new",
+        counter: 2
+      }
+    }
+  ]);
+
+  assert.equal(records.length, 1);
+  assert.equal(records[0].publicKey, "new");
+});

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -36,6 +36,41 @@ const gatewayAuthEnv = {
   VTDD_GATEWAY_BEARER_TOKEN: "test-token"
 };
 
+const passkeyAdapter = {
+  async generateRegistrationOptions(input) {
+    return { challenge: input.challenge };
+  },
+  async verifyRegistrationResponse() {
+    return {
+      verified: true,
+      registrationInfo: {
+        credential: {
+          id: new Uint8Array([1, 2, 3, 4]),
+          publicKey: new Uint8Array([5, 6, 7, 8]),
+          counter: 1
+        },
+        credentialDeviceType: "singleDevice",
+        credentialBackedUp: true,
+        aaguid: "test-aaguid"
+      }
+    };
+  },
+  async generateAuthenticationOptions(input) {
+    return {
+      challenge: input.challenge,
+      allowCredentials: input.allowCredentials
+    };
+  },
+  async verifyAuthenticationResponse() {
+    return {
+      verified: true,
+      authenticationInfo: {
+        newCounter: 2
+      }
+    };
+  }
+};
+
 test("worker returns health", async () => {
   const response = await worker.fetch(new Request("https://example.com/health"));
   assert.equal(response.status, 200);
@@ -256,6 +291,167 @@ test("worker dispatches remote Codex execution", async () => {
   assert.equal(body.ok, true);
   assert.equal(body.execution.issueNumber, 6);
   assert.equal(calls.length, 2);
+});
+
+test("worker serves passkey registration and approval flow routes", async () => {
+  const provider = createInMemoryMemoryProvider();
+
+  const registerOptions = await worker.fetch(
+    new Request("https://example.com/v2/approval/passkey/register/options", {
+      method: "POST",
+      headers: gatewayAuthHeaders,
+      body: JSON.stringify({
+        operatorId: "owner",
+        operatorLabel: "Owner"
+      })
+    }),
+    {
+      ...gatewayAuthEnv,
+      MEMORY_PROVIDER: provider,
+      PASSKEY_ADAPTER: passkeyAdapter
+    }
+  );
+  assert.equal(registerOptions.status, 200);
+  const registrationBody = await registerOptions.json();
+  assert.equal(registrationBody.ok, true);
+
+  const registerVerify = await worker.fetch(
+    new Request("https://example.com/v2/approval/passkey/register/verify", {
+      method: "POST",
+      headers: gatewayAuthHeaders,
+      body: JSON.stringify({
+        sessionId: registrationBody.sessionId,
+        response: {
+          id: "ignored",
+          response: { transports: ["internal"] }
+        }
+      })
+    }),
+    {
+      ...gatewayAuthEnv,
+      MEMORY_PROVIDER: provider,
+      PASSKEY_ADAPTER: passkeyAdapter
+    }
+  );
+  assert.equal(registerVerify.status, 200);
+
+  const approvalOptions = await worker.fetch(
+    new Request("https://example.com/v2/approval/passkey/challenge", {
+      method: "POST",
+      headers: gatewayAuthHeaders,
+      body: JSON.stringify({
+        phase: "execution",
+        issueContext: { issueNumber: 14 },
+        policyInput: {
+          actionType: ActionType.DEPLOY_PRODUCTION,
+          repositoryInput: "vtdd"
+        }
+      })
+    }),
+    {
+      ...gatewayAuthEnv,
+      MEMORY_PROVIDER: provider,
+      PASSKEY_ADAPTER: passkeyAdapter
+    }
+  );
+  assert.equal(approvalOptions.status, 200);
+  const approvalOptionsBody = await approvalOptions.json();
+  assert.equal(approvalOptionsBody.ok, true);
+
+  const approvalVerify = await worker.fetch(
+    new Request("https://example.com/v2/approval/passkey/verify", {
+      method: "POST",
+      headers: gatewayAuthHeaders,
+      body: JSON.stringify({
+        sessionId: approvalOptionsBody.sessionId,
+        response: {
+          id: "AQIDBA",
+          response: {}
+        }
+      })
+    }),
+    {
+      ...gatewayAuthEnv,
+      MEMORY_PROVIDER: provider,
+      PASSKEY_ADAPTER: passkeyAdapter
+    }
+  );
+  assert.equal(approvalVerify.status, 200);
+  const approvalVerifyBody = await approvalVerify.json();
+  assert.equal(approvalVerifyBody.ok, true);
+  assert.equal(Boolean(approvalVerifyBody.approvalGrant.approvalId), true);
+});
+
+test("worker gateway accepts high-risk approval grant resolved from memory", async () => {
+  const provider = createInMemoryMemoryProvider();
+  await provider.store({
+    id: "approval-123",
+    type: MemoryRecordType.APPROVAL_LOG,
+    content: {
+      kind: "passkey_grant",
+      status: "verified",
+      approvalId: "approval-123",
+      expiresAt: "2099-01-01T00:00:00.000Z",
+      scope: {
+        actionType: "deploy_production",
+        repositoryInput: "vtdd",
+        issueNumber: "14",
+        relatedIssue: "14",
+        phase: "execution"
+      }
+    },
+    metadata: { source: "test" },
+    priority: 90,
+    tags: ["passkey_grant"],
+    createdAt: "2026-04-25T00:00:00.000Z"
+  });
+
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/gateway", {
+      method: "POST",
+      headers: gatewayAuthHeaders,
+      body: JSON.stringify({
+        phase: "execution",
+        actorRole: ActorRole.EXECUTOR,
+        surfaceContext: {
+          surface: "custom_gpt",
+          judgmentModelId: "vtdd-butler-core-v1"
+        },
+        judgmentTrace: validButlerJudgmentTrace,
+        issueContext: { issueNumber: 14 },
+        policyInput: {
+          actionType: ActionType.DEPLOY_PRODUCTION,
+          mode: TaskMode.EXECUTION,
+          repositoryInput: "vtdd",
+          aliasRegistry,
+          targetConfirmed: true,
+          constitutionConsulted: true,
+          runtimeTruth: { runtimeAvailable: true },
+          credential: {
+            model: "github_app",
+            tier: CredentialTier.HIGH_RISK,
+            shortLived: true,
+            boundApprovalId: "approval-123"
+          },
+          consent: { grantedCategories: [ConsentCategory.EXECUTE] },
+          approvalPhrase: "GO deploy request",
+          approvalScopeMatched: true,
+          approvalGrantId: "approval-123",
+          issueTraceable: true,
+          go: true,
+          passkey: false
+        }
+      })
+    }),
+    {
+      ...gatewayAuthEnv,
+      MEMORY_PROVIDER: provider
+    }
+  );
+
+  assert.equal(response.status, 200);
+  const body = await response.json();
+  assert.equal(body.allowed, true);
 });
 
 test("worker returns remote Codex execution progress", async () => {


### PR DESCRIPTION
## This PR satisfies Intent
- add a real WebAuthn/passkey runtime slice so high-risk approval is no longer represented only as a phrase-bound `passkey=true/false` flag
- create a worker-executable challenge/verify path that can issue short-lived approval grants bound to target scope
- separate the temporary phrase gate from the intended real passkey runtime in canonical security docs

## Satisfied Success Criteria
- worker/core now expose real WebAuthn/passkey registration and approval challenge/verify runtime paths
- high-risk approval can be represented as a short-lived approval grant and resolved back into gateway policy evaluation
- docs explicitly distinguish the historical phrase gate from the new WebAuthn runtime path

## Unsatisfied Success Criteria
- Butler browser-return UX is not implemented in this PR
- GitHub App secret sync execution under the new passkey approval path is not implemented in this PR
- legacy phrase-only compatibility path is still present
- human device E2E evidence for iPhone/browser flow is not yet present

## Verification Evidence
- Tests: `node --test test/approval-model.test.js test/mvp-gateway.test.js test/passkey-approval.test.js test/worker.test.js test/core-policy.test.js`
- Code paths:
  - `/Users/shuhei/hibou_works/vtdd-v2-p/src/core/passkey-approval.js`
  - `/Users/shuhei/hibou_works/vtdd-v2-p/src/worker.js`
  - `/Users/shuhei/hibou_works/vtdd-v2-p/docs/security/webauthn-passkey-runtime.md`
- E2E: not yet satisfied in this PR
- Evidence path/link: local test execution in this branch plus PR diff above

## Target Issue
- Refs #14
