### PR TITLE
Issue #14/#15: bind GitHub App secret sync to passkey grant

### DIFF
--- a/docs/security/webauthn-passkey-runtime.md
+++ b/docs/security/webauthn-passkey-runtime.md
@@ -21,8 +21,9 @@ approval grant that Butler can use on the next high-risk request.
 - `POST /v2/approval/passkey/register/verify`
 - `POST /v2/approval/passkey/challenge`
 - `POST /v2/approval/passkey/verify`
+- `GET /v2/retrieve/approval-grant?approvalId=...`
 
-All four routes use the same machine-auth boundary as the other `/v2/*`
+All five routes use the same machine-auth boundary as the other `/v2/*`
 endpoints.
 
 ## Runtime Shape
@@ -58,6 +59,11 @@ grant with:
 The caller sends `approvalGrantId` on the next `/v2/gateway` high-risk request.
 The worker resolves that grant from memory and binds it back into policy
 evaluation.
+
+For local operator bootstrap flows, the local runtime may also retrieve the
+grant through `/v2/retrieve/approval-grant` and validate a scoped
+`highRiskKind` before mutating external high-risk surfaces such as GitHub
+Actions secrets.
 
 ## Safety Notes
 

--- a/docs/setup/github-app-secret-sync.md
+++ b/docs/setup/github-app-secret-sync.md
@@ -43,14 +43,32 @@ node scripts/sync-github-app-actions-secrets.mjs --repo marushu/vtdd-v2-p
 
 ## Execute
 
-Perform the sync only with explicit approval:
+Perform the sync only after a real passkey approval grant has been issued by
+the worker runtime for this exact high-risk operation.
+
+The approval challenge should be requested with a scope that includes:
+
+- `repositoryInput=<target repo>`
+- `highRiskKind=github_app_secret_sync`
+
+Then execute the local bootstrap with the returned `approvalGrantId`:
 
 ```bash
 node scripts/sync-github-app-actions-secrets.mjs \
   --repo marushu/vtdd-v2-p \
   --execute \
-  --approval GO+passkey
+  --runtime-url https://<your-runtime-host> \
+  --approval-grant-id <approvalGrantId>
 ```
+
+The script retrieves the approval grant from the worker runtime using machine
+auth, verifies that:
+
+- the grant is real and unexpired
+- the grant scope matches the target repository
+- `highRiskKind` is `github_app_secret_sync`
+
+and only then performs GitHub Actions secret mutation.
 
 ## Non-goals
 

--- a/scripts/sync-github-app-actions-secrets.mjs
+++ b/scripts/sync-github-app-actions-secrets.mjs
@@ -2,7 +2,8 @@ import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import {
   buildGitHubAppSecretSyncPlan,
-  loadGitHubAppSecretSource
+  loadGitHubAppSecretSource,
+  validateGitHubAppSecretSyncApprovalGrant
 } from "../src/core/index.js";
 
 const execFileAsync = promisify(execFile);
@@ -34,9 +35,20 @@ async function main() {
     return;
   }
 
-  const gate = String(args.approval || "").trim();
-  if (gate !== "GO+passkey") {
-    throw new Error("execute mode requires --approval GO+passkey");
+  const approvalGrant = await resolveApprovalGrant({
+    runtimeUrl: args.runtimeUrl || process.env.VTDD_RUNTIME_URL,
+    approvalGrantId: args.approvalGrantId,
+    bearerToken:
+      args.gatewayBearerToken ||
+      process.env.VTDD_GATEWAY_BEARER_TOKEN ||
+      sourceResult.source.gatewayBearerToken
+  });
+  const approvalValidation = validateGitHubAppSecretSyncApprovalGrant({
+    approvalGrant,
+    repo
+  });
+  if (!approvalValidation.ok) {
+    throw new Error(approvalValidation.issues.join(", "));
   }
 
   for (const secret of plan.secrets) {
@@ -59,6 +71,9 @@ function printDryRun(plan, source) {
   console.log(`app id: ${source.appId}`);
   console.log(`installation id: ${source.installationId}`);
   console.log(`private key path: ${source.privateKeyPath}`);
+  console.log(
+    `gateway bearer token path: ${source.gatewayBearerTokenPath || "[not configured in load-env.sh]"}`
+  );
   console.log("secrets to sync:");
   for (const secret of plan.secrets) {
     const detail =
@@ -67,7 +82,9 @@ function printDryRun(plan, source) {
         : secret.value;
     console.log(`- ${secret.name}: ${detail}`);
   }
-  console.log("This is a high-risk operation. Re-run with --execute --approval GO+passkey to perform sync.");
+  console.log(
+    "This is a high-risk operation. Re-run with --execute --runtime-url <url> --approval-grant-id <id> after real passkey approval."
+  );
 }
 
 function parseArgs(args) {
@@ -88,12 +105,57 @@ function parseArgs(args) {
       index += 1;
       continue;
     }
-    if (current === "--approval") {
-      parsed.approval = args[index + 1];
+    if (current === "--runtime-url") {
+      parsed.runtimeUrl = args[index + 1];
+      index += 1;
+      continue;
+    }
+    if (current === "--approval-grant-id") {
+      parsed.approvalGrantId = args[index + 1];
+      index += 1;
+      continue;
+    }
+    if (current === "--gateway-bearer-token") {
+      parsed.gatewayBearerToken = args[index + 1];
       index += 1;
     }
   }
   return parsed;
+}
+
+async function resolveApprovalGrant(input = {}) {
+  const approvalGrantId = String(input.approvalGrantId ?? "").trim();
+  const runtimeUrl = String(input.runtimeUrl ?? "").trim();
+  const bearerToken = String(input.bearerToken ?? "").trim();
+
+  if (!approvalGrantId) {
+    throw new Error("execute mode requires --approval-grant-id");
+  }
+  if (!runtimeUrl) {
+    throw new Error("execute mode requires --runtime-url or VTDD_RUNTIME_URL");
+  }
+  if (!bearerToken) {
+    throw new Error(
+      "execute mode requires gateway bearer token via --gateway-bearer-token, VTDD_GATEWAY_BEARER_TOKEN, or load-env.sh"
+    );
+  }
+
+  const endpoint = new URL("/v2/retrieve/approval-grant", runtimeUrl);
+  endpoint.searchParams.set("approvalId", approvalGrantId);
+  const response = await fetch(endpoint, {
+    headers: {
+      authorization: `Bearer ${bearerToken}`
+    }
+  });
+
+  const body = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    throw new Error(body.reason || `approval grant retrieval failed with status ${response.status}`);
+  }
+  if (!body?.approvalGrant) {
+    throw new Error("approval grant retrieval returned no approvalGrant");
+  }
+  return body.approvalGrant;
 }
 
 main().catch((error) => {

--- a/src/core/github-app-secret-sync.js
+++ b/src/core/github-app-secret-sync.js
@@ -16,7 +16,11 @@ export async function loadGitHubAppSecretSource(input = {}) {
   const appId = normalizeText(variables.GITHUB_APP_ID);
   const privateKeyPath = normalizeText(variables.GITHUB_APP_PRIVATE_KEY_PATH);
   const installationId = normalizeText(variables.GITHUB_APP_INSTALLATION_ID);
+  const gatewayBearerTokenPath = normalizeText(variables.VTDD_GATEWAY_BEARER_TOKEN_PATH);
   const privateKey = privateKeyPath ? await fs.readFile(privateKeyPath, "utf8") : "";
+  const gatewayBearerToken = gatewayBearerTokenPath
+    ? normalizeText(await fs.readFile(gatewayBearerTokenPath, "utf8"))
+    : "";
 
   const issues = [];
   if (!appId) {
@@ -43,7 +47,9 @@ export async function loadGitHubAppSecretSource(input = {}) {
       appId,
       installationId,
       privateKeyPath,
-      privateKey
+      privateKey,
+      gatewayBearerTokenPath,
+      gatewayBearerToken
     }
   };
 }
@@ -112,6 +118,44 @@ export async function executeGitHubAppSecretSync(input = {}) {
       synced: results
     }
   };
+}
+
+export function validateGitHubAppSecretSyncApprovalGrant(input = {}) {
+  const approvalGrant = input.approvalGrant ?? null;
+  const repo = normalizeText(input.repo);
+  const now = new Date(input.now ?? Date.now());
+
+  if (!approvalGrant || approvalGrant.verified !== true) {
+    return {
+      ok: false,
+      issues: ["real approvalGrant is required for GitHub App secret sync"]
+    };
+  }
+
+  const expiresAt = normalizeText(approvalGrant.expiresAt);
+  if (!expiresAt || Number.isNaN(Date.parse(expiresAt)) || Date.parse(expiresAt) <= now.valueOf()) {
+    return {
+      ok: false,
+      issues: ["approvalGrant is expired or invalid"]
+    };
+  }
+
+  const scope = approvalGrant.scope ?? {};
+  if (normalizeText(scope.repositoryInput) !== repo) {
+    return {
+      ok: false,
+      issues: ["approvalGrant scope.repositoryInput must match target repo"]
+    };
+  }
+
+  if (normalizeText(scope.highRiskKind) !== "github_app_secret_sync") {
+    return {
+      ok: false,
+      issues: ["approvalGrant scope.highRiskKind must be github_app_secret_sync"]
+    };
+  }
+
+  return { ok: true };
 }
 
 function parseExportedShellVariables(content) {

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -137,7 +137,8 @@ export {
   DEFAULT_GITHUB_APP_ENV_PATH,
   buildGitHubAppSecretSyncPlan,
   executeGitHubAppSecretSync,
-  loadGitHubAppSecretSource
+  loadGitHubAppSecretSource,
+  validateGitHubAppSecretSyncApprovalGrant
 } from "./github-app-secret-sync.js";
 export {
   DEFAULT_GEMINI_REVIEW_MODEL,

--- a/src/core/passkey-approval.js
+++ b/src/core/passkey-approval.js
@@ -404,6 +404,7 @@ export function evaluateApprovalGrant(input = {}) {
 export function normalizeScopeSnapshot(scope = {}) {
   return {
     actionType: normalizeText(scope.actionType),
+    highRiskKind: normalizeText(scope.highRiskKind),
     repositoryInput: normalizeText(scope.repositoryInput),
     issueNumber: normalizeText(scope.issueNumber),
     relatedIssue: normalizeText(scope.relatedIssue),

--- a/src/worker.js
+++ b/src/worker.js
@@ -155,6 +155,18 @@ export default {
       });
     }
 
+    if (request.method === "GET" && isApiPath(url.pathname, "/retrieve/approval-grant")) {
+      const auth = authorizeGatewayRequest({ request, env, apiSuffix: "/retrieve/approval-grant" });
+      if (!auth.ok) {
+        return json(auth.status, {
+          ok: false,
+          error: "unauthorized",
+          reason: auth.reason
+        });
+      }
+      return handleRetrieveApprovalGrantRequest(url, env);
+    }
+
     if (request.method === "POST" && isApiPath(url.pathname, "/approval/passkey/register/options")) {
       const auth = authorizeGatewayRequest({
         request,
@@ -403,6 +415,47 @@ async function handleRetrieveCrossIssueRequest(url, env) {
     primaryReference: retrieved.primaryReference,
     referencesBySource: retrieved.referencesBySource,
     orderedReferences: retrieved.orderedReferences
+  });
+}
+
+async function handleRetrieveApprovalGrantRequest(url, env) {
+  const provider = env?.MEMORY_PROVIDER ?? null;
+  const validation = validateMemoryProvider(provider);
+  if (!validation.ok) {
+    return json(503, {
+      ok: false,
+      error: "memory_provider_unavailable",
+      reason: "valid memory provider is required for approval grant retrieval"
+    });
+  }
+
+  const approvalId = normalizeText(url.searchParams.get("approvalId"));
+  if (!approvalId) {
+    return json(422, {
+      ok: false,
+      error: "approval_id_required",
+      reason: "approvalId query parameter is required"
+    });
+  }
+
+  const record = await findApprovalRecordById(provider, approvalId);
+  if (!record || normalizeText(record?.content?.kind) !== "passkey_grant") {
+    return json(404, {
+      ok: false,
+      error: "approval_grant_not_found",
+      reason: "matching passkey approval grant was not found"
+    });
+  }
+
+  return json(200, {
+    ok: true,
+    approvalGrant: {
+      approvalId: normalizeText(record.content.approvalId) || record.id,
+      verified: record.content.status === "verified",
+      verifiedAt: normalizeText(record.content.verifiedAt) || null,
+      expiresAt: normalizeText(record.content.expiresAt) || null,
+      scope: normalizeScopeSnapshot(record.content.scope)
+    }
   });
 }
 
@@ -695,6 +748,7 @@ function buildApprovalScopeSnapshot({ payload, policyInput }) {
   const traceability = normalizeObject(policyInput?.issueTraceability);
   return normalizeScopeSnapshot({
     actionType: policyInput?.actionType,
+    highRiskKind: payload?.highRiskKind ?? policyInput?.highRiskKind,
     repositoryInput: policyInput?.repositoryInput,
     issueNumber: issueContext.issueNumber,
     relatedIssue: traceability.relatedIssue ?? issueContext.issueNumber,

--- a/test/github-app-secret-sync.test.js
+++ b/test/github-app-secret-sync.test.js
@@ -6,25 +6,29 @@ import path from "node:path";
 import {
   buildGitHubAppSecretSyncPlan,
   executeGitHubAppSecretSync,
-  loadGitHubAppSecretSource
+  loadGitHubAppSecretSource,
+  validateGitHubAppSecretSyncApprovalGrant
 } from "../src/core/index.js";
 
 test("loadGitHubAppSecretSource reads app id and private key from existing env file", async () => {
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "vtdd-app-sync-"));
   const keyPath = path.join(tempDir, "app.pem");
   const envPath = path.join(tempDir, "load-env.sh");
+  const tokenPath = path.join(tempDir, "gateway-token.txt");
 
   await fs.writeFile(
     keyPath,
     "-----BEGIN PRIVATE KEY-----\nexample\n-----END PRIVATE KEY-----\n",
     "utf8"
   );
+  await fs.writeFile(tokenPath, "test-bearer-token\n", "utf8");
   await fs.writeFile(
     envPath,
     [
       'export GITHUB_APP_ID="3467409"',
       'export GITHUB_APP_INSTALLATION_ID="126180737"',
-      `export GITHUB_APP_PRIVATE_KEY_PATH="${keyPath}"`
+      `export GITHUB_APP_PRIVATE_KEY_PATH="${keyPath}"`,
+      `export VTDD_GATEWAY_BEARER_TOKEN_PATH="${tokenPath}"`
     ].join("\n"),
     "utf8"
   );
@@ -34,6 +38,7 @@ test("loadGitHubAppSecretSource reads app id and private key from existing env f
   assert.equal(result.source.appId, "3467409");
   assert.equal(result.source.installationId, "126180737");
   assert.equal(result.source.privateKey.includes("BEGIN PRIVATE KEY"), true);
+  assert.equal(result.source.gatewayBearerToken, "test-bearer-token");
 });
 
 test("buildGitHubAppSecretSyncPlan targets actions secrets from source of truth", () => {
@@ -68,4 +73,32 @@ test("executeGitHubAppSecretSync calls runner for each target secret", async () 
 
   assert.equal(result.ok, true);
   assert.deepEqual(calls, ["VTDD_GITHUB_APP_ID", "VTDD_GITHUB_APP_PRIVATE_KEY"]);
+});
+
+test("GitHub App secret sync approval grant must match repo and high-risk kind", () => {
+  const ok = validateGitHubAppSecretSyncApprovalGrant({
+    repo: "marushu/vtdd-v2-p",
+    approvalGrant: {
+      verified: true,
+      expiresAt: "2099-01-01T00:00:00.000Z",
+      scope: {
+        repositoryInput: "marushu/vtdd-v2-p",
+        highRiskKind: "github_app_secret_sync"
+      }
+    }
+  });
+  assert.equal(ok.ok, true);
+
+  const bad = validateGitHubAppSecretSyncApprovalGrant({
+    repo: "marushu/vtdd-v2-p",
+    approvalGrant: {
+      verified: true,
+      expiresAt: "2099-01-01T00:00:00.000Z",
+      scope: {
+        repositoryInput: "marushu/vtdd-v2-p",
+        highRiskKind: "deploy"
+      }
+    }
+  });
+  assert.equal(bad.ok, false);
 });

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -454,6 +454,49 @@ test("worker gateway accepts high-risk approval grant resolved from memory", asy
   assert.equal(body.allowed, true);
 });
 
+test("worker returns approval grant through retrieve route", async () => {
+  const provider = createInMemoryMemoryProvider();
+  await provider.store({
+    id: "approval-xyz",
+    type: MemoryRecordType.APPROVAL_LOG,
+    content: {
+      kind: "passkey_grant",
+      status: "verified",
+      approvalId: "approval-xyz",
+      verifiedAt: "2026-04-25T00:00:00.000Z",
+      expiresAt: "2099-01-01T00:00:00.000Z",
+      scope: {
+        actionType: "destructive",
+        repositoryInput: "sample-org/vtdd-v2-p",
+        issueNumber: "15",
+        relatedIssue: "15",
+        phase: "execution",
+        highRiskKind: "github_app_secret_sync"
+      }
+    },
+    metadata: { source: "test" },
+    priority: 90,
+    tags: ["passkey_grant"],
+    createdAt: "2026-04-25T00:00:00.000Z"
+  });
+
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/retrieve/approval-grant?approvalId=approval-xyz", {
+      headers: gatewayAuthHeaders
+    }),
+    {
+      ...gatewayAuthEnv,
+      MEMORY_PROVIDER: provider
+    }
+  );
+
+  assert.equal(response.status, 200);
+  const body = await response.json();
+  assert.equal(body.ok, true);
+  assert.equal(body.approvalGrant.approvalId, "approval-xyz");
+  assert.equal(body.approvalGrant.scope.repositoryInput, "sample-org/vtdd-v2-p");
+});
+
 test("worker returns remote Codex execution progress", async () => {
   const response = await worker.fetch(
     new Request("https://example.com/v2/action/progress?executionId=remote-codex-issue6-abcd12", {


### PR DESCRIPTION
## This PR satisfies Intent
- connect the real WebAuthn/passkey runtime from #14 to the GitHub App secret sync bootstrap from #15
- require a real approval grant for GitHub Actions secret mutation instead of the old phrase gate
- keep the local credential source of truth while verifying approval grant scope through the worker runtime

## Satisfied Success Criteria
- GitHub App secret sync bootstrap now requires a real approval grant before `--execute`
- the bootstrap retrieves approval grant state from the worker runtime and validates expiry, target repo, and `highRiskKind=github_app_secret_sync`
- worker exposes approval grant retrieval for bounded operator bootstrap use
- docs now describe grant-based execution instead of `--approval GO+passkey`

## Unsatisfied Success Criteria
- Butler browser-return UX is still not implemented
- the bootstrap is not yet executed live in this PR
- `#14` remains partial because device E2E and full Butler continuation are not complete
- `#15` remains partial until live sync execution evidence is captured

## Verification Evidence
- Tests: `node --test test/github-app-secret-sync.test.js test/passkey-approval.test.js test/worker.test.js test/core-policy.test.js`
- Dry-run: `node scripts/sync-github-app-actions-secrets.mjs --repo marushu/vtdd-v2-p`
- Code paths:
  - `/Users/shuhei/hibou_works/vtdd-v2-p/scripts/sync-github-app-actions-secrets.mjs`
  - `/Users/shuhei/hibou_works/vtdd-v2-p/src/core/github-app-secret-sync.js`
  - `/Users/shuhei/hibou_works/vtdd-v2-p/src/worker.js`
- E2E: not yet satisfied in this PR
- Evidence path/link: local test execution in this branch plus PR diff above

## Target Issue
- Refs #14
- Refs #15
