### PR TITLE
Issue #14: add passkey operator helper page

### DIFF
--- a/docs/security/webauthn-passkey-runtime.md
+++ b/docs/security/webauthn-passkey-runtime.md
@@ -22,8 +22,9 @@ approval grant that Butler can use on the next high-risk request.
 - `POST /v2/approval/passkey/challenge`
 - `POST /v2/approval/passkey/verify`
 - `GET /v2/retrieve/approval-grant?approvalId=...`
+- `GET /v2/approval/passkey/operator`
 
-All five routes use the same machine-auth boundary as the other `/v2/*`
+All six routes use the same machine-auth boundary as the other `/v2/*`
 endpoints.
 
 ## Runtime Shape
@@ -65,6 +66,17 @@ grant through `/v2/retrieve/approval-grant` and validate a scoped
 `highRiskKind` before mutating external high-risk surfaces such as GitHub
 Actions secrets.
 
+### 5. Operator helper page
+
+`/v2/approval/passkey/operator` returns a same-origin HTML helper that can:
+
+- register a passkey
+- request a high-risk approval challenge
+- verify the authenticator response
+- display the resulting `approvalGrantId`
+
+This is the minimum browser/iPhone execution surface for the real passkey flow.
+
 ## Safety Notes
 
 - phrase-only `passkey=true` is a temporary compatibility path, not the final
@@ -72,6 +84,7 @@ Actions secrets.
 - high-risk grant expiry is short-lived by design
 - grant scope must match the current target
 - reviewer never receives execution credentials or passkey registry material
+- operator page must not hard-code owner-specific runtime URLs
 
 ## Non-goals of This Slice
 

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -39,6 +39,7 @@ export {
   verifyPasskeyApproval,
   verifyPasskeyRegistration
 } from "./passkey-approval.js";
+export { renderPasskeyOperatorPage } from "./passkey-operator-page.js";
 export { requiredCredentialTier, evaluateCredentialBoundary } from "./credential-boundary.js";
 export { resolveRepositoryTarget } from "./repository-resolution.js";
 export { evaluateTargetConfirmationBoundary } from "./target-confirmation.js";

--- a/src/core/passkey-operator-page.js
+++ b/src/core/passkey-operator-page.js
@@ -1,0 +1,335 @@
+export function renderPasskeyOperatorPage(input = {}) {
+  const origin = escapeHtml(input.origin || "");
+  const registrationDefaultOperatorId = escapeHtml(input.operatorId || "vtdd-operator");
+  const registrationDefaultOperatorLabel = escapeHtml(input.operatorLabel || "VTDD Operator");
+  const repoDefault = escapeHtml(input.repositoryInput || "");
+  const issueDefault = escapeHtml(input.issueNumber || "");
+  const phaseDefault = escapeHtml(input.phase || "execution");
+  const highRiskKindDefault = escapeHtml(input.highRiskKind || "github_app_secret_sync");
+
+  return `<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>VTDD Passkey Operator</title>
+    <style>
+      :root {
+        color-scheme: light;
+        --bg: #f3efe6;
+        --panel: #fffdf7;
+        --ink: #17212b;
+        --muted: #5e6b75;
+        --line: #d9d0c1;
+        --accent: #0f5f4b;
+        --accent-2: #b66a24;
+      }
+      body {
+        margin: 0;
+        font-family: "Hiragino Sans", "Yu Gothic", sans-serif;
+        background: linear-gradient(180deg, #f6f0e3 0%, #ebe4d6 100%);
+        color: var(--ink);
+      }
+      main {
+        max-width: 980px;
+        margin: 0 auto;
+        padding: 32px 20px 48px;
+      }
+      h1, h2 {
+        margin: 0 0 12px;
+      }
+      p {
+        line-height: 1.6;
+      }
+      .hero {
+        background: radial-gradient(circle at top left, #fff7dc 0%, var(--panel) 60%);
+        border: 1px solid var(--line);
+        border-radius: 20px;
+        padding: 24px;
+        margin-bottom: 24px;
+        box-shadow: 0 14px 30px rgba(23, 33, 43, 0.08);
+      }
+      .grid {
+        display: grid;
+        gap: 20px;
+      }
+      @media (min-width: 900px) {
+        .grid {
+          grid-template-columns: 1fr 1fr;
+        }
+      }
+      section {
+        background: var(--panel);
+        border: 1px solid var(--line);
+        border-radius: 18px;
+        padding: 20px;
+        box-shadow: 0 10px 24px rgba(23, 33, 43, 0.06);
+      }
+      label {
+        display: block;
+        font-size: 14px;
+        color: var(--muted);
+        margin-bottom: 6px;
+      }
+      input {
+        width: 100%;
+        box-sizing: border-box;
+        padding: 10px 12px;
+        border-radius: 10px;
+        border: 1px solid var(--line);
+        margin-bottom: 12px;
+        font: inherit;
+        background: #fff;
+      }
+      button {
+        appearance: none;
+        border: none;
+        border-radius: 999px;
+        padding: 11px 16px;
+        font: inherit;
+        cursor: pointer;
+        background: var(--accent);
+        color: white;
+      }
+      button.secondary {
+        background: var(--accent-2);
+      }
+      pre {
+        white-space: pre-wrap;
+        word-break: break-word;
+        background: #f7f4ed;
+        border: 1px solid var(--line);
+        border-radius: 12px;
+        padding: 12px;
+        min-height: 64px;
+      }
+      .muted {
+        color: var(--muted);
+        font-size: 14px;
+      }
+      .row {
+        display: flex;
+        gap: 10px;
+        flex-wrap: wrap;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <div class="hero">
+        <h1>VTDD Passkey Operator</h1>
+        <p>このページは real WebAuthn/passkey approval 用の operator helper です。登録と high-risk approval の両方を same-origin で実行し、最終的に <code>approvalGrantId</code> を取得できます。</p>
+        <p class="muted">origin: ${origin || "[same-origin]"}</p>
+      </div>
+
+      <div class="grid">
+        <section>
+          <h2>1. Passkey 登録</h2>
+          <label for="operator-id">Operator ID</label>
+          <input id="operator-id" value="${registrationDefaultOperatorId}" />
+          <label for="operator-label">Operator Label</label>
+          <input id="operator-label" value="${registrationDefaultOperatorLabel}" />
+          <div class="row">
+            <button id="register-button">Register passkey</button>
+          </div>
+          <p class="muted">登録は 1 回で十分です。複数デバイスを使う場合は必要に応じて追加登録します。</p>
+          <pre id="register-output"></pre>
+        </section>
+
+        <section>
+          <h2>2. High-risk Approval</h2>
+          <label for="repo-input">Repository</label>
+          <input id="repo-input" value="${repoDefault}" placeholder="marushu/vtdd-v2-p" />
+          <label for="issue-input">Issue Number</label>
+          <input id="issue-input" value="${issueDefault}" placeholder="15" />
+          <label for="phase-input">Phase</label>
+          <input id="phase-input" value="${phaseDefault}" />
+          <label for="risk-kind-input">High-risk Kind</label>
+          <input id="risk-kind-input" value="${highRiskKindDefault}" />
+          <div class="row">
+            <button class="secondary" id="approve-button">Approve high-risk action</button>
+          </div>
+          <p class="muted">GitHub App secret sync 用なら <code>highRiskKind=github_app_secret_sync</code> を使います。</p>
+          <pre id="approve-output"></pre>
+        </section>
+      </div>
+    </main>
+
+    <script>
+      const registerOutput = document.getElementById("register-output");
+      const approveOutput = document.getElementById("approve-output");
+
+      document.getElementById("register-button").addEventListener("click", async () => {
+        try {
+          registerOutput.textContent = "register options request...";
+          const optionsResponse = await fetch("/v2/approval/passkey/register/options", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({
+              operatorId: document.getElementById("operator-id").value,
+              operatorLabel: document.getElementById("operator-label").value
+            })
+          });
+          const optionsBody = await optionsResponse.json();
+          if (!optionsResponse.ok) {
+            throw new Error(optionsBody.reason || optionsBody.error || "register options failed");
+          }
+
+          const publicKey = decodeRegistrationOptions(optionsBody.optionsJSON);
+          const credential = await navigator.credentials.create({ publicKey });
+          const verifyResponse = await fetch("/v2/approval/passkey/register/verify", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({
+              sessionId: optionsBody.sessionId,
+              response: encodeRegistrationCredential(credential)
+            })
+          });
+          const verifyBody = await verifyResponse.json();
+          if (!verifyResponse.ok) {
+            throw new Error(verifyBody.reason || verifyBody.error || "register verify failed");
+          }
+          registerOutput.textContent = JSON.stringify(verifyBody, null, 2);
+        } catch (error) {
+          registerOutput.textContent = String(error);
+        }
+      });
+
+      document.getElementById("approve-button").addEventListener("click", async () => {
+        try {
+          approveOutput.textContent = "approval challenge request...";
+          const challengeResponse = await fetch("/v2/approval/passkey/challenge", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({
+              phase: document.getElementById("phase-input").value || "execution",
+              highRiskKind: document.getElementById("risk-kind-input").value,
+              issueContext: {
+                issueNumber: Number(document.getElementById("issue-input").value || 0) || null
+              },
+              policyInput: {
+                actionType: "destructive",
+                repositoryInput: document.getElementById("repo-input").value,
+                highRiskKind: document.getElementById("risk-kind-input").value
+              }
+            })
+          });
+          const challengeBody = await challengeResponse.json();
+          if (!challengeResponse.ok) {
+            throw new Error(challengeBody.reason || challengeBody.error || "approval challenge failed");
+          }
+
+          const publicKey = decodeAuthenticationOptions(challengeBody.optionsJSON);
+          const assertion = await navigator.credentials.get({ publicKey });
+          const verifyResponse = await fetch("/v2/approval/passkey/verify", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({
+              sessionId: challengeBody.sessionId,
+              response: encodeAuthenticationAssertion(assertion)
+            })
+          });
+          const verifyBody = await verifyResponse.json();
+          if (!verifyResponse.ok) {
+            throw new Error(verifyBody.reason || verifyBody.error || "approval verify failed");
+          }
+          approveOutput.textContent = JSON.stringify(verifyBody, null, 2);
+        } catch (error) {
+          approveOutput.textContent = String(error);
+        }
+      });
+
+      function decodeRegistrationOptions(options) {
+        return {
+          ...options,
+          challenge: base64UrlToBuffer(options.challenge),
+          user: {
+            ...options.user,
+            id: base64UrlToBuffer(options.user.id)
+          },
+          excludeCredentials: Array.isArray(options.excludeCredentials)
+            ? options.excludeCredentials.map((item) => ({
+                ...item,
+                id: base64UrlToBuffer(item.id)
+              }))
+            : []
+        };
+      }
+
+      function decodeAuthenticationOptions(options) {
+        return {
+          ...options,
+          challenge: base64UrlToBuffer(options.challenge),
+          allowCredentials: Array.isArray(options.allowCredentials)
+            ? options.allowCredentials.map((item) => ({
+                ...item,
+                id: base64UrlToBuffer(item.id)
+              }))
+            : []
+        };
+      }
+
+      function encodeRegistrationCredential(credential) {
+        return {
+          id: credential.id,
+          rawId: bufferToBase64Url(credential.rawId),
+          type: credential.type,
+          response: {
+            attestationObject: bufferToBase64Url(credential.response.attestationObject),
+            clientDataJSON: bufferToBase64Url(credential.response.clientDataJSON),
+            transports: typeof credential.response.getTransports === "function"
+              ? credential.response.getTransports()
+              : []
+          }
+        };
+      }
+
+      function encodeAuthenticationAssertion(assertion) {
+        return {
+          id: assertion.id,
+          rawId: bufferToBase64Url(assertion.rawId),
+          type: assertion.type,
+          response: {
+            authenticatorData: bufferToBase64Url(assertion.response.authenticatorData),
+            clientDataJSON: bufferToBase64Url(assertion.response.clientDataJSON),
+            signature: bufferToBase64Url(assertion.response.signature),
+            userHandle: assertion.response.userHandle
+              ? bufferToBase64Url(assertion.response.userHandle)
+              : null
+          }
+        };
+      }
+
+      function base64UrlToBuffer(value) {
+        const base64 = String(value)
+          .replace(/-/g, "+")
+          .replace(/_/g, "/")
+          .padEnd(Math.ceil(String(value).length / 4) * 4, "=");
+        const binary = atob(base64);
+        const bytes = new Uint8Array(binary.length);
+        for (let index = 0; index < binary.length; index += 1) {
+          bytes[index] = binary.charCodeAt(index);
+        }
+        return bytes;
+      }
+
+      function bufferToBase64Url(buffer) {
+        const bytes = new Uint8Array(buffer);
+        let text = "";
+        for (const byte of bytes) {
+          text += String.fromCharCode(byte);
+        }
+        return btoa(text).replace(/\\+/g, "-").replace(/\\//g, "_").replace(/=+$/g, "");
+      }
+    </script>
+  </body>
+</html>`;
+}
+
+function escapeHtml(value) {
+  return String(value ?? "")
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}

--- a/src/worker.js
+++ b/src/worker.js
@@ -18,6 +18,7 @@ import {
   retrieveDecisionLogReferences,
   retrieveProposalLogReferences,
   retrieveConstitution,
+  renderPasskeyOperatorPage,
   resolveGatewayAliasRegistryFromGitHubApp,
   runMvpGateway,
   validateMemoryProvider,
@@ -45,6 +46,22 @@ export default {
         mode: "v2",
         autonomyMode: resolveRuntimeAutonomyMode(env)
       });
+    }
+
+    if (request.method === "GET" && isApiPath(url.pathname, "/approval/passkey/operator")) {
+      const auth = authorizeGatewayRequest({
+        request,
+        env,
+        apiSuffix: "/approval/passkey/operator"
+      });
+      if (!auth.ok) {
+        return json(auth.status, {
+          ok: false,
+          error: "unauthorized",
+          reason: auth.reason
+        });
+      }
+      return handlePasskeyOperatorPageRequest(request);
     }
 
     if (request.method === "POST" && isApiPath(url.pathname, "/gateway")) {
@@ -455,6 +472,26 @@ async function handleRetrieveApprovalGrantRequest(url, env) {
       verifiedAt: normalizeText(record.content.verifiedAt) || null,
       expiresAt: normalizeText(record.content.expiresAt) || null,
       scope: normalizeScopeSnapshot(record.content.scope)
+    }
+  });
+}
+
+function handlePasskeyOperatorPageRequest(request) {
+  const url = new URL(request.url);
+  const html = renderPasskeyOperatorPage({
+    origin: url.origin,
+    repositoryInput: url.searchParams.get("repositoryInput"),
+    issueNumber: url.searchParams.get("issueNumber"),
+    phase: url.searchParams.get("phase") || "execution",
+    highRiskKind: url.searchParams.get("highRiskKind") || "github_app_secret_sync",
+    operatorId: url.searchParams.get("operatorId") || "vtdd-operator",
+    operatorLabel: url.searchParams.get("operatorLabel") || "VTDD Operator"
+  });
+
+  return new Response(html, {
+    status: 200,
+    headers: {
+      "content-type": "text/html; charset=utf-8"
     }
   });
 }

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -382,6 +382,25 @@ test("worker serves passkey registration and approval flow routes", async () => 
   assert.equal(Boolean(approvalVerifyBody.approvalGrant.approvalId), true);
 });
 
+test("worker serves passkey operator page", async () => {
+  const response = await worker.fetch(
+    new Request(
+      "https://example.com/v2/approval/passkey/operator?repositoryInput=marushu%2Fvtdd-v2-p&issueNumber=15&highRiskKind=github_app_secret_sync",
+      {
+        headers: gatewayAuthHeaders
+      }
+    ),
+    gatewayAuthEnv
+  );
+
+  assert.equal(response.status, 200);
+  assert.equal(response.headers.get("content-type"), "text/html; charset=utf-8");
+  const html = await response.text();
+  assert.equal(html.includes("VTDD Passkey Operator"), true);
+  assert.equal(html.includes("/v2/approval/passkey/challenge"), true);
+  assert.equal(html.includes("github_app_secret_sync"), true);
+});
+
 test("worker gateway accepts high-risk approval grant resolved from memory", async () => {
   const provider = createInMemoryMemoryProvider();
   await provider.store({


### PR DESCRIPTION
## This PR satisfies Intent
- add a minimum browser/iPhone execution surface for the real WebAuthn/passkey runtime
- expose a same-origin operator page that can register passkeys, request high-risk approval challenges, verify responses, and show `approvalGrantId`
- keep the runtime user-owned and avoid hard-coded owner-specific URLs

## Satisfied Success Criteria
- worker now serves a passkey operator page route
- operator page can drive registration and approval challenge/verify against the existing same-origin runtime endpoints
- docs now state that the operator page is the minimum browser/iPhone execution surface for passkey approval

## Unsatisfied Success Criteria
- Butler browser-return UX is still not implemented
- automatic handoff from operator page into subsequent high-risk command execution is not implemented
- live device/browser E2E evidence is not yet captured in this PR
- issue #14 remains partial until those runtime continuations exist

## Verification Evidence
- Tests: `node --test test/passkey-approval.test.js test/github-app-secret-sync.test.js test/worker.test.js test/core-policy.test.js`
- Code paths:
  - `/Users/shuhei/hibou_works/vtdd-v2-p/src/core/passkey-operator-page.js`
  - `/Users/shuhei/hibou_works/vtdd-v2-p/src/worker.js`
  - `/Users/shuhei/hibou_works/vtdd-v2-p/docs/security/webauthn-passkey-runtime.md`
- E2E: not yet satisfied in this PR
- Evidence path/link: local test execution in this branch plus PR diff above

## Target Issue
- Refs #14
