### PR TITLE
Add local passkey operator helper

### DIFF
--- a/docs/security/webauthn-passkey-runtime.md
+++ b/docs/security/webauthn-passkey-runtime.md
@@ -77,6 +77,11 @@ Actions secrets.
 
 This is the minimum browser/iPhone execution surface for the real passkey flow.
 
+For explicit local operator execution, the repository may also serve the same
+page through `scripts/run-passkey-operator-helper.mjs`, which proxies the real
+`/v2/approval/passkey/*` runtime without introducing a new worker-side setup
+wizard path.
+
 ## Safety Notes
 
 - phrase-only `passkey=true` is a temporary compatibility path, not the final

--- a/docs/setup/github-app-secret-sync.md
+++ b/docs/setup/github-app-secret-sync.md
@@ -70,6 +70,27 @@ auth, verifies that:
 
 and only then performs GitHub Actions secret mutation.
 
+## Optional Operator Helper
+
+For explicit operator execution without manual API calls, use the local helper:
+
+```bash
+node scripts/run-passkey-operator-helper.mjs \
+  --runtime-url https://<your-runtime-host> \
+  --repo marushu/vtdd-v2-p \
+  --issue-number 15
+```
+
+This helper:
+
+- serves a local browser page for passkey registration and approval
+- proxies the real `/v2/approval/passkey/*` runtime with machine auth
+- executes `scripts/sync-github-app-actions-secrets.mjs` only after a real
+  `approvalGrantId` has been issued
+
+It is an explicit operator helper, not a setup wizard and not a background
+sync path.
+
 ## Non-goals
 
 - replacing the local GitHub App source of truth

--- a/scripts/run-passkey-operator-helper.mjs
+++ b/scripts/run-passkey-operator-helper.mjs
@@ -1,0 +1,268 @@
+import { execFile } from "node:child_process";
+import http from "node:http";
+import path from "node:path";
+import { promisify } from "node:util";
+import { loadGitHubAppSecretSource, renderPasskeyOperatorPage } from "../src/core/index.js";
+
+const execFileAsync = promisify(execFile);
+const SCRIPT_DIR = path.dirname(new URL(import.meta.url).pathname);
+const SYNC_SCRIPT_PATH = path.join(SCRIPT_DIR, "sync-github-app-actions-secrets.mjs");
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const runtimeUrl = normalizeText(args.runtimeUrl || process.env.VTDD_RUNTIME_URL);
+  if (!runtimeUrl) {
+    throw new Error("--runtime-url or VTDD_RUNTIME_URL is required");
+  }
+
+  const sourceResult = await loadGitHubAppSecretSource({
+    envPath: args.envPath
+  });
+  if (!sourceResult.ok) {
+    throw new Error(sourceResult.issues.join(", "));
+  }
+  const bearerToken = normalizeText(
+    args.gatewayBearerToken ||
+      process.env.VTDD_GATEWAY_BEARER_TOKEN ||
+      sourceResult.source.gatewayBearerToken
+  );
+  if (!bearerToken) {
+    throw new Error(
+      "gateway bearer token is required via --gateway-bearer-token, VTDD_GATEWAY_BEARER_TOKEN, or load-env.sh"
+    );
+  }
+
+  const bind = normalizeText(args.bind || "127.0.0.1");
+  const port = Number(args.port || 8789);
+  if (!Number.isFinite(port) || port <= 0) {
+    throw new Error("port must be a positive number");
+  }
+
+  const state = {
+    runtimeUrl,
+    bearerToken,
+    repo: normalizeText(args.repo || "marushu/vtdd-v2-p"),
+    issueNumber: normalizeText(args.issueNumber || "15"),
+    highRiskKind: normalizeText(args.highRiskKind || "github_app_secret_sync"),
+    envPath: normalizeText(args.envPath || sourceResult.source.envPath)
+  };
+
+  const server = http.createServer((request, response) =>
+    handleRequest({ request, response, state }).catch((error) => {
+      writeJson(response, 500, {
+        ok: false,
+        error: "operator_helper_unhandled_error",
+        reason: error instanceof Error ? error.message : String(error)
+      });
+    })
+  );
+
+  await new Promise((resolve) => server.listen(port, bind, resolve));
+  const localUrl = `http://${bind}:${port}`;
+  console.log(`VTDD passkey operator helper listening on ${localUrl}`);
+  console.log(`runtime: ${state.runtimeUrl}`);
+  console.log(`repo: ${state.repo}`);
+  console.log(`issue: ${state.issueNumber}`);
+  console.log("Open the URL above in a browser or on the same network if you intentionally expose it.");
+}
+
+async function handleRequest({ request, response, state }) {
+  const url = new URL(request.url, `http://${request.headers.host || "localhost"}`);
+
+  if (request.method === "GET" && url.pathname === "/") {
+    const html = renderPasskeyOperatorPage({
+      origin: `${url.protocol}//${url.host}`,
+      apiBase: "/api",
+      repositoryInput: state.repo,
+      issueNumber: state.issueNumber,
+      highRiskKind: state.highRiskKind,
+      syncEnabled: true
+    });
+    response.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+    response.end(html);
+    return;
+  }
+
+  if (url.pathname.startsWith("/api/approval/passkey/")) {
+    await proxyPasskeyApi({ request, response, state, pathname: url.pathname.replace("/api", "/v2") });
+    return;
+  }
+
+  if (request.method === "POST" && url.pathname === "/api/github-app-secret-sync/execute") {
+    const body = await readJson(request);
+    const approvalGrantId = normalizeText(body.approvalGrantId);
+    const repo = normalizeText(body.repositoryInput || state.repo);
+    if (!approvalGrantId) {
+      writeJson(response, 422, {
+        ok: false,
+        error: "approval_grant_id_required",
+        reason: "approvalGrantId is required"
+      });
+      return;
+    }
+
+    const args = [
+      SYNC_SCRIPT_PATH,
+      "--repo",
+      repo,
+      "--execute",
+      "--runtime-url",
+      state.runtimeUrl,
+      "--approval-grant-id",
+      approvalGrantId
+    ];
+    if (state.envPath) {
+      args.push("--env-path", state.envPath);
+    }
+
+    const result = await execFileAsync(process.execPath, args, {
+      cwd: process.cwd(),
+      maxBuffer: 10 * 1024 * 1024
+    }).catch((error) => ({
+      ok: false,
+      stdout: error.stdout || "",
+      stderr: error.stderr || "",
+      reason: error instanceof Error ? error.message : String(error)
+    }));
+
+    if (result.ok === false) {
+      writeJson(response, 500, {
+        ok: false,
+        error: "github_app_secret_sync_failed",
+        reason: result.reason,
+        stdout: normalizeText(result.stdout),
+        stderr: normalizeText(result.stderr)
+      });
+      return;
+    }
+
+    writeJson(response, 200, {
+      ok: true,
+      stdout: normalizeText(result.stdout),
+      stderr: normalizeText(result.stderr)
+    });
+    return;
+  }
+
+  if (request.method === "GET" && url.pathname === "/api/retrieve/approval-grant") {
+    const endpoint = new URL("/v2/retrieve/approval-grant", state.runtimeUrl);
+    if (url.searchParams.has("approvalId")) {
+      endpoint.searchParams.set("approvalId", url.searchParams.get("approvalId"));
+    }
+    const proxied = await fetch(endpoint, {
+      headers: {
+        authorization: `Bearer ${state.bearerToken}`
+      }
+    });
+    const body = await proxied.text();
+    response.writeHead(proxied.status, {
+      "content-type": proxied.headers.get("content-type") || "application/json; charset=utf-8"
+    });
+    response.end(body);
+    return;
+  }
+
+  writeJson(response, 404, {
+    ok: false,
+    error: "not_found"
+  });
+}
+
+async function proxyPasskeyApi({ request, response, state, pathname }) {
+  const endpoint = new URL(pathname, state.runtimeUrl);
+  const body =
+    request.method === "GET" || request.method === "HEAD" ? undefined : await readBody(request);
+  const proxied = await fetch(endpoint, {
+    method: request.method,
+    headers: {
+      authorization: `Bearer ${state.bearerToken}`,
+      "content-type": request.headers["content-type"] || "application/json"
+    },
+    body
+  });
+  const text = await proxied.text();
+  response.writeHead(proxied.status, {
+    "content-type": proxied.headers.get("content-type") || "application/json; charset=utf-8"
+  });
+  response.end(text);
+}
+
+function parseArgs(args) {
+  const parsed = {};
+  for (let index = 0; index < args.length; index += 1) {
+    const current = args[index];
+    if (current === "--runtime-url") {
+      parsed.runtimeUrl = args[index + 1];
+      index += 1;
+      continue;
+    }
+    if (current === "--gateway-bearer-token") {
+      parsed.gatewayBearerToken = args[index + 1];
+      index += 1;
+      continue;
+    }
+    if (current === "--repo") {
+      parsed.repo = args[index + 1];
+      index += 1;
+      continue;
+    }
+    if (current === "--issue-number") {
+      parsed.issueNumber = args[index + 1];
+      index += 1;
+      continue;
+    }
+    if (current === "--high-risk-kind") {
+      parsed.highRiskKind = args[index + 1];
+      index += 1;
+      continue;
+    }
+    if (current === "--bind") {
+      parsed.bind = args[index + 1];
+      index += 1;
+      continue;
+    }
+    if (current === "--port") {
+      parsed.port = args[index + 1];
+      index += 1;
+      continue;
+    }
+    if (current === "--env-path") {
+      parsed.envPath = args[index + 1];
+      index += 1;
+    }
+  }
+  return parsed;
+}
+
+function readBody(request) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    request.on("data", (chunk) => chunks.push(chunk));
+    request.on("end", () => resolve(Buffer.concat(chunks)));
+    request.on("error", reject);
+  });
+}
+
+async function readJson(request) {
+  const body = await readBody(request);
+  if (body.length === 0) {
+    return {};
+  }
+  return JSON.parse(body.toString("utf8"));
+}
+
+function writeJson(response, status, body) {
+  response.writeHead(status, {
+    "content-type": "application/json; charset=utf-8"
+  });
+  response.end(JSON.stringify(body));
+}
+
+function normalizeText(value) {
+  return String(value ?? "").trim();
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/src/core/passkey-operator-page.js
+++ b/src/core/passkey-operator-page.js
@@ -1,11 +1,13 @@
 export function renderPasskeyOperatorPage(input = {}) {
   const origin = escapeHtml(input.origin || "");
+  const apiBase = escapeHtml(input.apiBase || "/v2");
   const registrationDefaultOperatorId = escapeHtml(input.operatorId || "vtdd-operator");
   const registrationDefaultOperatorLabel = escapeHtml(input.operatorLabel || "VTDD Operator");
   const repoDefault = escapeHtml(input.repositoryInput || "");
   const issueDefault = escapeHtml(input.issueNumber || "");
   const phaseDefault = escapeHtml(input.phase || "execution");
   const highRiskKindDefault = escapeHtml(input.highRiskKind || "github_app_secret_sync");
+  const syncEnabled = input.syncEnabled === true;
 
   return `<!doctype html>
 <html lang="ja">
@@ -152,17 +154,29 @@ export function renderPasskeyOperatorPage(input = {}) {
           <p class="muted">GitHub App secret sync 用なら <code>highRiskKind=github_app_secret_sync</code> を使います。</p>
           <pre id="approve-output"></pre>
         </section>
+
+        <section>
+          <h2>3. GitHub App Secret Sync</h2>
+          <p class="muted">real passkey approval 後、この helper から <code>#15</code> の explicit operator bootstrap を実行します。</p>
+          <div class="row">
+            <button id="sync-button"${syncEnabled ? "" : " disabled"}>Sync GitHub App secrets</button>
+          </div>
+          <p class="muted">${syncEnabled ? "approvalGrantId が取得済みなら実行できます。" : "この surface では secret sync endpoint が有効化されていません。"}</p>
+          <pre id="sync-output"></pre>
+        </section>
       </div>
     </main>
 
     <script>
       const registerOutput = document.getElementById("register-output");
       const approveOutput = document.getElementById("approve-output");
+      const syncOutput = document.getElementById("sync-output");
+      let latestApprovalGrantId = "";
 
       document.getElementById("register-button").addEventListener("click", async () => {
         try {
           registerOutput.textContent = "register options request...";
-          const optionsResponse = await fetch("/v2/approval/passkey/register/options", {
+          const optionsResponse = await fetch("${apiBase}/approval/passkey/register/options", {
             method: "POST",
             headers: { "content-type": "application/json" },
             body: JSON.stringify({
@@ -177,7 +191,7 @@ export function renderPasskeyOperatorPage(input = {}) {
 
           const publicKey = decodeRegistrationOptions(optionsBody.optionsJSON);
           const credential = await navigator.credentials.create({ publicKey });
-          const verifyResponse = await fetch("/v2/approval/passkey/register/verify", {
+          const verifyResponse = await fetch("${apiBase}/approval/passkey/register/verify", {
             method: "POST",
             headers: { "content-type": "application/json" },
             body: JSON.stringify({
@@ -198,7 +212,7 @@ export function renderPasskeyOperatorPage(input = {}) {
       document.getElementById("approve-button").addEventListener("click", async () => {
         try {
           approveOutput.textContent = "approval challenge request...";
-          const challengeResponse = await fetch("/v2/approval/passkey/challenge", {
+          const challengeResponse = await fetch("${apiBase}/approval/passkey/challenge", {
             method: "POST",
             headers: { "content-type": "application/json" },
             body: JSON.stringify({
@@ -221,7 +235,7 @@ export function renderPasskeyOperatorPage(input = {}) {
 
           const publicKey = decodeAuthenticationOptions(challengeBody.optionsJSON);
           const assertion = await navigator.credentials.get({ publicKey });
-          const verifyResponse = await fetch("/v2/approval/passkey/verify", {
+          const verifyResponse = await fetch("${apiBase}/approval/passkey/verify", {
             method: "POST",
             headers: { "content-type": "application/json" },
             body: JSON.stringify({
@@ -233,9 +247,34 @@ export function renderPasskeyOperatorPage(input = {}) {
           if (!verifyResponse.ok) {
             throw new Error(verifyBody.reason || verifyBody.error || "approval verify failed");
           }
+          latestApprovalGrantId = verifyBody?.approvalGrant?.approvalId || "";
           approveOutput.textContent = JSON.stringify(verifyBody, null, 2);
         } catch (error) {
           approveOutput.textContent = String(error);
+        }
+      });
+
+      document.getElementById("sync-button").addEventListener("click", async () => {
+        try {
+          if (!latestApprovalGrantId) {
+            throw new Error("approvalGrantId is required before secret sync");
+          }
+          syncOutput.textContent = "github app secret sync request...";
+          const syncResponse = await fetch("${apiBase}/github-app-secret-sync/execute", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({
+              approvalGrantId: latestApprovalGrantId,
+              repositoryInput: document.getElementById("repo-input").value
+            })
+          });
+          const syncBody = await syncResponse.json();
+          if (!syncResponse.ok) {
+            throw new Error(syncBody.reason || syncBody.error || "github app secret sync failed");
+          }
+          syncOutput.textContent = JSON.stringify(syncBody, null, 2);
+        } catch (error) {
+          syncOutput.textContent = String(error);
         }
       });
 

--- a/test/passkey-operator-page.test.js
+++ b/test/passkey-operator-page.test.js
@@ -1,0 +1,27 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { renderPasskeyOperatorPage } from "../src/core/index.js";
+
+test("passkey operator page can target explicit api base and sync endpoint", () => {
+  const html = renderPasskeyOperatorPage({
+    apiBase: "/api",
+    repositoryInput: "marushu/vtdd-v2-p",
+    issueNumber: 15,
+    highRiskKind: "github_app_secret_sync",
+    syncEnabled: true
+  });
+
+  assert.equal(html.includes('fetch("/api/approval/passkey/challenge"'), true);
+  assert.equal(html.includes('fetch("/api/github-app-secret-sync/execute"'), true);
+  assert.equal(html.includes("Sync GitHub App secrets"), true);
+});
+
+test("passkey operator page keeps sync disabled message when helper endpoint is absent", () => {
+  const html = renderPasskeyOperatorPage({
+    apiBase: "/v2",
+    syncEnabled: false
+  });
+
+  assert.equal(html.includes("secret sync endpoint が有効化されていません"), true);
+  assert.equal(html.includes("disabled"), true);
+});


### PR DESCRIPTION
## This PR satisfies Intent

This PR adds an explicit local operator helper that lets a human execute the existing real WebAuthn/passkey runtime and then run the Issue #15 GitHub App secret sync without introducing a new worker-side `/setup/*` path or reintroducing the setup wizard line.

## Satisfied Success Criteria

- Adds an explicit operator helper path for real passkey execution that stays inside Issues #14 and #15.
- Keeps the worker-side runtime on the existing `/v2/approval/passkey/*` path rather than adding a new `/setup/*` route.
- Connects `approvalGrantId` to the existing GitHub App secret sync bootstrap through a local explicit helper flow.
- Preserves the existing local GitHub App credential source of truth under `credentials/github-app/`.
- Adds page-level test coverage for the explicit helper API surface.

## Unsatisfied Success Criteria

- Live E2E evidence for real passkey approval followed by actual GitHub App secret sync is still not included in this PR.
- `Remote Codex -> Gemini -> Butler` is still incomplete; Butler synthesis is not part of this slice.
- iPhone live evidence is still missing even though this slice does not exclude it.

## Verification Evidence

- `node --test test/passkey-operator-page.test.js test/passkey-approval.test.js test/github-app-secret-sync.test.js test/worker.test.js`
- `node --check scripts/run-passkey-operator-helper.mjs`
- Local smoke run:
  - `node scripts/run-passkey-operator-helper.mjs --runtime-url https://example.com --repo marushu/vtdd-v2-p --issue-number 15 --port 8791`
  - helper reached listen state and was then stopped manually

## Scope / Drift Notes

- This PR intentionally does **not** add `/setup/*` routes.
- This PR intentionally does **not** revive the archived setup wizard line.
- This PR is partial progress for Issues #14 and #15 and does not close them.
