### PR TITLE
Add Butler review synthesis

### DIFF
--- a/docs/butler/codex-pr-revision-loop.md
+++ b/docs/butler/codex-pr-revision-loop.md
@@ -72,6 +72,7 @@ After Codex creates a PR:
 - reads runtime truth
 - decides `resume` vs `handoff required`
 - summarizes PR and review comments
+- returns deterministic synthesis that preserves reviewer objections and next safe actions
 - suggests the next safe action
 
 ### Codex

--- a/src/core/butler-review-synthesis.js
+++ b/src/core/butler-review-synthesis.js
@@ -1,0 +1,165 @@
+export function buildButlerReviewSynthesis(input = {}) {
+  const pullRequest = normalizePullRequest(input.pullRequest);
+  if (!pullRequest.exists) {
+    return {
+      available: false,
+      headline: "No active PR is available for Butler synthesis.",
+      nextSuggestedActions: normalizeStringArray(input.nextSuggestedActions)
+    };
+  }
+
+  const reviewLoop = normalizeReviewLoop(input.reviewLoop);
+  const codexGoal = normalizeText(input.codexGoal) || "wait_for_review";
+  const nextSuggestedActions = normalizeStringArray(input.nextSuggestedActions);
+  const recentSignals = collectRecentSignals(pullRequest);
+
+  return {
+    available: true,
+    headline: buildHeadline({ pullRequest, reviewLoop }),
+    prState: {
+      number: pullRequest.number,
+      url: pullRequest.url,
+      state: pullRequest.state,
+      title: pullRequest.title,
+      baseRef: pullRequest.baseRef,
+      headRef: pullRequest.headRef
+    },
+    reviewerSignal: {
+      reviewer: reviewLoop.reviewer,
+      reviewCommentsCount: reviewLoop.reviewCommentsCount,
+      unresolvedReviewCommentsCount: reviewLoop.unresolvedReviewCommentsCount,
+      criticalReviewPending: reviewLoop.criticalReviewPending,
+      updatedSinceReview: pullRequest.updatedSinceReview,
+      recentIssueComments: recentSignals.issueComments,
+      recentReviewComments: recentSignals.reviewComments,
+      recentReviews: recentSignals.reviews
+    },
+    humanDecisionFocus: buildHumanDecisionFocus({
+      pullRequest,
+      reviewLoop,
+      codexGoal
+    }),
+    nextSuggestedActions
+  };
+}
+
+function buildHeadline({ pullRequest, reviewLoop }) {
+  const base = `PR #${pullRequest.number} is ${pullRequest.state || "open"}.`;
+  if (reviewLoop.unresolvedReviewCommentsCount > 0) {
+    return `${base} ${reviewLoop.unresolvedReviewCommentsCount} unresolved reviewer objections remain.`;
+  }
+  if (reviewLoop.reviewCommentsCount > 0) {
+    return `${base} Reviewer feedback exists and should be checked before human GO.`;
+  }
+  return `${base} No reviewer objections are currently recorded.`;
+}
+
+function buildHumanDecisionFocus({ pullRequest, reviewLoop, codexGoal }) {
+  const focus = [];
+
+  if (reviewLoop.unresolvedReviewCommentsCount > 0) {
+    focus.push("Meaningful reviewer objections remain unresolved; do not issue merge GO yet.");
+  }
+  if (pullRequest.updatedSinceReview) {
+    focus.push("The PR changed after the last review signal; Gemini should re-evaluate current diff state.");
+  }
+  if (codexGoal === "revise_pr") {
+    focus.push("Codex should apply bounded PR revisions before Butler asks for merge judgment.");
+  }
+  if (codexGoal === "respond_to_review") {
+    focus.push("Codex should respond on the PR without treating reviewer comments as resolved by silence.");
+  }
+  if (reviewLoop.reviewCommentsCount === 0) {
+    focus.push("Gemini review evidence is not yet present on the PR.");
+  }
+  focus.push("Human remains the final authority for revision GO and merge GO.");
+
+  return focus;
+}
+
+function collectRecentSignals(pullRequest) {
+  return {
+    issueComments: summarizeComments(pullRequest.issueComments),
+    reviewComments: summarizeComments(pullRequest.reviewComments),
+    reviews: summarizeReviews(pullRequest.reviews)
+  };
+}
+
+function summarizeComments(comments) {
+  const list = Array.isArray(comments) ? comments : [];
+  return list
+    .slice(-3)
+    .map((item) => {
+      const author = normalizeText(item?.user?.login) || normalizeText(item?.author) || "unknown";
+      const body = normalizeText(item?.body);
+      return body ? `${author}: ${body}` : null;
+    })
+    .filter(Boolean);
+}
+
+function summarizeReviews(reviews) {
+  const list = Array.isArray(reviews) ? reviews : [];
+  return list
+    .slice(-3)
+    .map((item) => {
+      const author = normalizeText(item?.user?.login) || "unknown";
+      const state = normalizeText(item?.state) || "COMMENTED";
+      const body = normalizeText(item?.body);
+      return body ? `${author} (${state}): ${body}` : `${author} (${state})`;
+    })
+    .filter(Boolean);
+}
+
+function normalizePullRequest(value) {
+  const input = value && typeof value === "object" ? value : {};
+  return {
+    exists:
+      Boolean(normalizeNumber(input.number)) ||
+      Boolean(normalizeText(input.url)) ||
+      Boolean(normalizeText(input.state)),
+    number: normalizeNumber(input.number),
+    url: normalizeText(input.url) || null,
+    state: normalizeText(input.state) || "open",
+    title: normalizeText(input.title) || null,
+    baseRef: normalizeText(input.baseRef) || normalizeText(input.base?.ref) || null,
+    headRef: normalizeText(input.headRef) || normalizeText(input.head?.ref) || null,
+    updatedSinceReview: input.updatedSinceReview === true,
+    issueComments: Array.isArray(input.issueComments) ? input.issueComments : [],
+    reviewComments: Array.isArray(input.reviewComments) ? input.reviewComments : [],
+    reviews: Array.isArray(input.reviews) ? input.reviews : []
+  };
+}
+
+function normalizeReviewLoop(value) {
+  const input = value && typeof value === "object" ? value : {};
+  return {
+    reviewer: normalizeText(input.reviewer) || "gemini",
+    reviewCommentsCount: normalizeCount(input.reviewCommentsCount),
+    unresolvedReviewCommentsCount: normalizeCount(input.unresolvedReviewCommentsCount),
+    criticalReviewPending: input.criticalReviewPending === true
+  };
+}
+
+function normalizeStringArray(value) {
+  return (Array.isArray(value) ? value : []).map(normalizeText).filter(Boolean);
+}
+
+function normalizeText(value) {
+  return String(value ?? "").trim();
+}
+
+function normalizeCount(value) {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric) || numeric < 0) {
+    return 0;
+  }
+  return Math.floor(numeric);
+}
+
+function normalizeNumber(value) {
+  const numeric = Number(value);
+  if (!Number.isInteger(numeric) || numeric <= 0) {
+    return null;
+  }
+  return numeric;
+}

--- a/src/core/execution-continuity.js
+++ b/src/core/execution-continuity.js
@@ -1,3 +1,4 @@
+import { buildButlerReviewSynthesis } from "./butler-review-synthesis.js";
 import { ActorRole, TaskMode } from "./types.js";
 
 export const ExecutionTransferMode = Object.freeze({
@@ -63,6 +64,21 @@ export function evaluateExecutionContinuity(input = {}) {
         summarizeReviewComments: pullRequest.exists,
         suggestNextAction: true
       },
+      butlerReviewSynthesis: buildButlerReviewSynthesis({
+        pullRequest,
+        reviewLoop: {
+          reviewer: review.reviewer,
+          reviewCommentsCount: review.reviewCommentsCount,
+          unresolvedReviewCommentsCount: review.unresolvedReviewCommentsCount,
+          criticalReviewPending: review.criticalReviewPending
+        },
+        codexGoal,
+        nextSuggestedActions: buildNextSuggestedActions({
+          pullRequest,
+          review,
+          codexGoal
+        })
+      }),
       nextSuggestedActions: buildNextSuggestedActions({
         pullRequest,
         review,
@@ -181,12 +197,18 @@ function normalizeGitHubRuntime(value) {
       number: normalizeNumber(pullRequestInput.number),
       url: normalizeText(pullRequestInput.url) || null,
       state: normalizeText(pullRequestInput.state) || null,
+      title: normalizeText(pullRequestInput.title) || null,
+      baseRef: normalizeText(pullRequestInput.baseRef) || normalizeText(pullRequestInput.base?.ref) || null,
+      headRef: normalizeText(pullRequestInput.headRef) || normalizeText(pullRequestInput.head?.ref) || null,
       reviewCommentsCount: normalizeCount(pullRequestInput.reviewCommentsCount),
       unresolvedReviewCommentsCount: normalizeCount(
         pullRequestInput.unresolvedReviewCommentsCount
       ),
       updatedSinceReview: pullRequestInput.updatedSinceReview === true,
-      reviewer: normalizeText(pullRequestInput.reviewer) || "gemini"
+      reviewer: normalizeText(pullRequestInput.reviewer) || "gemini",
+      issueComments: Array.isArray(pullRequestInput.issueComments) ? pullRequestInput.issueComments : [],
+      reviewComments: Array.isArray(pullRequestInput.reviewComments) ? pullRequestInput.reviewComments : [],
+      reviews: Array.isArray(pullRequestInput.reviews) ? pullRequestInput.reviews : []
     }
   };
 }

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -40,6 +40,7 @@ export {
   verifyPasskeyRegistration
 } from "./passkey-approval.js";
 export { renderPasskeyOperatorPage } from "./passkey-operator-page.js";
+export { buildButlerReviewSynthesis } from "./butler-review-synthesis.js";
 export { requiredCredentialTier, evaluateCredentialBoundary } from "./credential-boundary.js";
 export { resolveRepositoryTarget } from "./repository-resolution.js";
 export { evaluateTargetConfirmationBoundary } from "./target-confirmation.js";

--- a/test/butler-review-synthesis.test.js
+++ b/test/butler-review-synthesis.test.js
@@ -1,0 +1,46 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { buildButlerReviewSynthesis } from "../src/core/index.js";
+
+test("butler review synthesis preserves unresolved reviewer objections and next actions", () => {
+  const result = buildButlerReviewSynthesis({
+    pullRequest: {
+      number: 42,
+      url: "https://github.com/example/repo/pull/42",
+      state: "open",
+      title: "Connect reviewer loop",
+      updatedSinceReview: true,
+      issueComments: [{ user: { login: "owner" }, body: "Please check the runtime contract." }],
+      reviewComments: [{ user: { login: "gemini" }, body: "The blocking loop still looks incomplete." }],
+      reviews: [{ user: { login: "gemini" }, state: "COMMENTED", body: "Needs another pass." }]
+    },
+    reviewLoop: {
+      reviewer: "gemini",
+      reviewCommentsCount: 2,
+      unresolvedReviewCommentsCount: 1,
+      criticalReviewPending: true
+    },
+    codexGoal: "revise_pr",
+    nextSuggestedActions: ["apply_pr_feedback", "rerun_gemini_review"]
+  });
+
+  assert.equal(result.available, true);
+  assert.equal(result.headline.includes("unresolved reviewer objections"), true);
+  assert.equal(
+    result.humanDecisionFocus.includes(
+      "Meaningful reviewer objections remain unresolved; do not issue merge GO yet."
+    ),
+    true
+  );
+  assert.deepEqual(result.nextSuggestedActions, ["apply_pr_feedback", "rerun_gemini_review"]);
+  assert.equal(result.reviewerSignal.recentReviewComments[0].includes("gemini:"), true);
+});
+
+test("butler review synthesis reports missing PR state plainly", () => {
+  const result = buildButlerReviewSynthesis({
+    nextSuggestedActions: ["open_pull_request"]
+  });
+
+  assert.equal(result.available, false);
+  assert.equal(result.headline, "No active PR is available for Butler synthesis.");
+});

--- a/test/execution-continuity.test.js
+++ b/test/execution-continuity.test.js
@@ -55,10 +55,12 @@ test("execution continuity returns PR revision loop guidance when unresolved rev
           number: 42,
           url: "https://github.com/example/repo/pull/42",
           state: "open",
+          title: "Connect reviewer loop",
           reviewCommentsCount: 3,
           unresolvedReviewCommentsCount: 2,
           updatedSinceReview: true,
-          reviewer: "gemini"
+          reviewer: "gemini",
+          reviewComments: [{ user: { login: "gemini" }, body: "Still blocked on reviewer objections." }]
         }
       }
     }
@@ -68,4 +70,9 @@ test("execution continuity returns PR revision loop guidance when unresolved rev
   assert.equal(result.value.codexGoal, CodexGoal.REVISE_PR);
   assert.equal(result.value.reviewLoop.rerunReviewer, true);
   assert.equal(result.value.nextSuggestedActions.includes("apply_pr_feedback"), true);
+  assert.equal(result.value.butlerReviewSynthesis.available, true);
+  assert.equal(
+    result.value.butlerReviewSynthesis.headline.includes("unresolved reviewer objections"),
+    true
+  );
 });

--- a/test/mvp-gateway.test.js
+++ b/test/mvp-gateway.test.js
@@ -336,21 +336,23 @@ test("gateway returns execution continuity guidance for PR-reaching execution", 
       aliasRegistry: registry,
       targetConfirmed: true,
       constitutionConsulted: true,
-      runtimeTruth: {
-        runtimeAvailable: true,
-        runtimeState: {
-          activeBranch: "codex/issue-4",
-          pullRequest: {
-            number: 42,
-            url: "https://github.com/example/repo/pull/42",
-            state: "open",
-            reviewCommentsCount: 2,
-            unresolvedReviewCommentsCount: 1,
-            updatedSinceReview: true,
-            reviewer: "gemini"
+        runtimeTruth: {
+          runtimeAvailable: true,
+          runtimeState: {
+            activeBranch: "codex/issue-4",
+            pullRequest: {
+              number: 42,
+              url: "https://github.com/example/repo/pull/42",
+              state: "open",
+              title: "Connect reviewer loop",
+              reviewCommentsCount: 2,
+              unresolvedReviewCommentsCount: 1,
+              updatedSinceReview: true,
+              reviewer: "gemini",
+              reviewComments: [{ user: { login: "gemini" }, body: "Please address the unresolved loop risk." }]
+            }
           }
-        }
-      },
+        },
       credential: { model: "github_app", tier: CredentialTier.EXECUTE },
       consent: fullConsent,
       ...approvalContext,
@@ -363,6 +365,13 @@ test("gateway returns execution continuity guidance for PR-reaching execution", 
   assert.equal(result.allowed, true);
   assert.equal(result.executionContinuity.codexGoal, "revise_pr");
   assert.equal(result.executionContinuity.reviewLoop.rerunReviewer, true);
+  assert.equal(result.executionContinuity.butlerReviewSynthesis.available, true);
+  assert.equal(
+    result.executionContinuity.butlerReviewSynthesis.humanDecisionFocus.includes(
+      "Meaningful reviewer objections remain unresolved; do not issue merge GO yet."
+    ),
+    true
+  );
   assert.equal(
     result.executionContinuity.nextSuggestedActions.includes("rerun_gemini_review"),
     true

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -192,10 +192,14 @@ test("worker gateway returns PR revision loop guidance for Butler summaries", as
                 number: 42,
                 url: "https://github.com/example/repo/pull/42",
                 state: "open",
+                title: "Connect reviewer loop",
                 reviewCommentsCount: 3,
                 unresolvedReviewCommentsCount: 2,
                 updatedSinceReview: true,
-                reviewer: "gemini"
+                reviewer: "gemini",
+                reviewComments: [
+                  { user: { login: "gemini" }, body: "The reviewer loop still has unresolved objections." }
+                ]
               }
             }
           },
@@ -217,6 +221,13 @@ test("worker gateway returns PR revision loop guidance for Butler summaries", as
   assert.equal(body.allowed, true);
   assert.equal(body.executionContinuity.codexGoal, "revise_pr");
   assert.equal(body.executionContinuity.reviewLoop.unresolvedReviewCommentsCount, 2);
+  assert.equal(body.executionContinuity.butlerReviewSynthesis.available, true);
+  assert.equal(
+    body.executionContinuity.butlerReviewSynthesis.reviewerSignal.recentReviewComments[0].includes(
+      "gemini:"
+    ),
+    true
+  );
   assert.equal(body.executionContinuity.nextSuggestedActions.includes("rerun_gemini_review"), true);
 });
 


### PR DESCRIPTION
## This PR satisfies Intent

This PR implements the Butler-side deterministic review synthesis slice from Issue #4 so Butler can summarize PR state and reviewer comments for a human without erasing meaningful reviewer objections.

## Satisfied Success Criteria

- Butler can aggregate PR state and reviewer comments into a deterministic synthesis object.
- Butler can surface next safe actions alongside reviewer objections.
- Butler can re-summarize updated review state because synthesis is derived from runtime truth rather than a one-off comment string.

## Unsatisfied Success Criteria

- Live `Remote Codex -> PR -> Gemini comment` evidence is still pending because GitHub App secret sync execution has not yet been run.
- Butler synthesis is still deterministic runtime output only; Custom GPT presentation wiring is not part of this slice.
- Merge remains human-only and no merge automation is added.

## Verification Evidence

- `node --test test/butler-review-synthesis.test.js test/execution-continuity.test.js test/mvp-gateway.test.js test/worker.test.js`

## Scope / Drift Notes

- This PR stays inside Issue #4 Butler summary/suggestion scope.
- It does not change secret sync, passkey runtime, Gemini workflow triggering, or remote Codex transport.
- It does not close Issue #4 because live end-to-end loop evidence is still incomplete.
