### PR TITLE
Require real deploy approval grant

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -7,10 +7,14 @@ on:
         description: "Type GO to approve production deploy"
         required: true
         type: string
-      passkey_verified:
-        description: "Set true after passkey-based operator approval"
+      runtime_url:
+        description: "Worker runtime URL used to validate the real passkey approval grant"
         required: true
-        type: boolean
+        type: string
+      approval_grant_id:
+        description: "Real WebAuthn/passkey approval grant id for deploy_production"
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -32,8 +36,12 @@ jobs:
             echo "Approval phrase must be GO for production deploy."
             exit 1
           fi
-          if [ "${{ github.event.inputs.passkey_verified }}" != "true" ]; then
-            echo "passkey_verified must be true for production deploy."
+          if [ -z "${{ github.event.inputs.runtime_url }}" ]; then
+            echo "runtime_url is required for production deploy."
+            exit 1
+          fi
+          if [ -z "${{ github.event.inputs.approval_grant_id }}" ]; then
+            echo "approval_grant_id is required for production deploy."
             exit 1
           fi
 
@@ -44,6 +52,18 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Validate real passkey approval grant
+        env:
+          VTDD_GATEWAY_BEARER_TOKEN: ${{ secrets.VTDD_GATEWAY_BEARER_TOKEN }}
+        run: |
+          node scripts/validate-deploy-approval-grant.mjs \
+            --runtime-url "${{ github.event.inputs.runtime_url }}" \
+            --approval-grant-id "${{ github.event.inputs.approval_grant_id }}" \
+            --repository "${{ github.repository }}"
 
       - name: Run tests
         run: npm test

--- a/docs/mvp/production-deploy-path.md
+++ b/docs/mvp/production-deploy-path.md
@@ -34,17 +34,25 @@ The token should be scoped to minimum required Worker deploy permissions.
 `deploy-production` workflow is manual (`workflow_dispatch`) and requires:
 
 - `approval_phrase=GO`
-- `passkey_verified=true`
+- `runtime_url=<user-owned worker runtime>`
+- `approval_grant_id=<real passkey approval grant id>`
 - environment approval on `production`
 
 This encodes the MVP high-risk policy as:
 
 1. explicit GO phrase
-2. passkey-verified operator intent
+2. real WebAuthn/passkey approval grant validated against the worker runtime
 3. protected environment confirmation
+
+The workflow validates the grant through `/v2/retrieve/approval-grant` using
+`VTDD_GATEWAY_BEARER_TOKEN`, and the grant scope must match:
+
+- `actionType=deploy_production`
+- `highRiskKind=deploy_production`
+- `repositoryInput=<target repo>`
 
 ## Notes
 
 - Branch restriction: deploy job runs only when ref is `main`
-- Pre-deploy check: `npm test` must pass
+- Pre-deploy checks: approval grant validation and `npm test`
 - Future hardening (out-of-scope for MVP): external passkey attestation service, staged rollout, rollback automation

--- a/docs/security/webauthn-passkey-runtime.md
+++ b/docs/security/webauthn-passkey-runtime.md
@@ -45,6 +45,11 @@ intended target scope:
 - `relatedIssue`
 - `phase`
 
+For example:
+
+- GitHub App secret sync -> `actionType=destructive`, `highRiskKind=github_app_secret_sync`
+- production deploy -> `actionType=deploy_production`, `highRiskKind=deploy_production`
+
 ### 3. Verify WebAuthn response
 
 The worker verifies the authenticator response and writes an `approval_log`

--- a/scripts/validate-deploy-approval-grant.mjs
+++ b/scripts/validate-deploy-approval-grant.mjs
@@ -1,0 +1,86 @@
+import { validateDeployApprovalGrant } from "../src/core/index.js";
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const approvalGrantId = normalizeText(args.approvalGrantId);
+  const runtimeUrl = normalizeText(args.runtimeUrl || process.env.VTDD_RUNTIME_URL);
+  const repositoryInput = normalizeText(args.repository || process.env.GITHUB_REPOSITORY);
+  const bearerToken = normalizeText(
+    args.gatewayBearerToken || process.env.VTDD_GATEWAY_BEARER_TOKEN
+  );
+
+  if (!approvalGrantId) {
+    throw new Error("--approval-grant-id is required");
+  }
+  if (!runtimeUrl) {
+    throw new Error("--runtime-url or VTDD_RUNTIME_URL is required");
+  }
+  if (!repositoryInput) {
+    throw new Error("--repository or GITHUB_REPOSITORY is required");
+  }
+  if (!bearerToken) {
+    throw new Error("--gateway-bearer-token or VTDD_GATEWAY_BEARER_TOKEN is required");
+  }
+
+  const endpoint = new URL("/v2/retrieve/approval-grant", runtimeUrl);
+  endpoint.searchParams.set("approvalId", approvalGrantId);
+
+  const response = await fetch(endpoint, {
+    headers: {
+      authorization: `Bearer ${bearerToken}`
+    }
+  });
+  const body = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    throw new Error(body.reason || `approval grant retrieval failed with status ${response.status}`);
+  }
+  if (!body?.approvalGrant) {
+    throw new Error("approval grant retrieval returned no approvalGrant");
+  }
+
+  const validation = validateDeployApprovalGrant({
+    approvalGrant: body.approvalGrant,
+    repositoryInput
+  });
+  if (!validation.ok) {
+    throw new Error(validation.issues.join(", "));
+  }
+
+  console.log("deploy approval grant validated");
+}
+
+function parseArgs(args) {
+  const parsed = {};
+  for (let index = 0; index < args.length; index += 1) {
+    const current = args[index];
+    if (current === "--approval-grant-id") {
+      parsed.approvalGrantId = args[index + 1];
+      index += 1;
+      continue;
+    }
+    if (current === "--runtime-url") {
+      parsed.runtimeUrl = args[index + 1];
+      index += 1;
+      continue;
+    }
+    if (current === "--repository") {
+      parsed.repository = args[index + 1];
+      index += 1;
+      continue;
+    }
+    if (current === "--gateway-bearer-token") {
+      parsed.gatewayBearerToken = args[index + 1];
+      index += 1;
+    }
+  }
+  return parsed;
+}
+
+function normalizeText(value) {
+  return String(value ?? "").trim();
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/src/core/deploy-approval-grant.js
+++ b/src/core/deploy-approval-grant.js
@@ -1,0 +1,50 @@
+import { ActionType } from "./types.js";
+
+export function validateDeployApprovalGrant(input = {}) {
+  const approvalGrant = input.approvalGrant ?? null;
+  const repositoryInput = normalizeText(input.repositoryInput);
+  const now = new Date(input.now ?? Date.now());
+
+  if (!approvalGrant || approvalGrant.verified !== true) {
+    return {
+      ok: false,
+      issues: ["real approvalGrant is required for deploy_production"]
+    };
+  }
+
+  const expiresAt = normalizeText(approvalGrant.expiresAt);
+  if (!expiresAt || Number.isNaN(Date.parse(expiresAt)) || Date.parse(expiresAt) <= now.valueOf()) {
+    return {
+      ok: false,
+      issues: ["approvalGrant is expired or invalid"]
+    };
+  }
+
+  const scope = approvalGrant.scope ?? {};
+  if (normalizeText(scope.actionType) !== ActionType.DEPLOY_PRODUCTION) {
+    return {
+      ok: false,
+      issues: ["approvalGrant scope.actionType must be deploy_production"]
+    };
+  }
+
+  if (normalizeText(scope.highRiskKind) !== ActionType.DEPLOY_PRODUCTION) {
+    return {
+      ok: false,
+      issues: ["approvalGrant scope.highRiskKind must be deploy_production"]
+    };
+  }
+
+  if (normalizeText(scope.repositoryInput) !== repositoryInput) {
+    return {
+      ok: false,
+      issues: ["approvalGrant scope.repositoryInput must match target repo"]
+    };
+  }
+
+  return { ok: true };
+}
+
+function normalizeText(value) {
+  return String(value ?? "").trim();
+}

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -41,6 +41,7 @@ export {
 } from "./passkey-approval.js";
 export { renderPasskeyOperatorPage } from "./passkey-operator-page.js";
 export { buildButlerReviewSynthesis } from "./butler-review-synthesis.js";
+export { validateDeployApprovalGrant } from "./deploy-approval-grant.js";
 export { requiredCredentialTier, evaluateCredentialBoundary } from "./credential-boundary.js";
 export { resolveRepositoryTarget } from "./repository-resolution.js";
 export { evaluateTargetConfirmationBoundary } from "./target-confirmation.js";

--- a/src/core/passkey-operator-page.js
+++ b/src/core/passkey-operator-page.js
@@ -6,6 +6,7 @@ export function renderPasskeyOperatorPage(input = {}) {
   const repoDefault = escapeHtml(input.repositoryInput || "");
   const issueDefault = escapeHtml(input.issueNumber || "");
   const phaseDefault = escapeHtml(input.phase || "execution");
+  const actionTypeDefault = escapeHtml(input.actionType || "destructive");
   const highRiskKindDefault = escapeHtml(input.highRiskKind || "github_app_secret_sync");
   const syncEnabled = input.syncEnabled === true;
 
@@ -146,12 +147,14 @@ export function renderPasskeyOperatorPage(input = {}) {
           <input id="issue-input" value="${issueDefault}" placeholder="15" />
           <label for="phase-input">Phase</label>
           <input id="phase-input" value="${phaseDefault}" />
+          <label for="action-type-input">Action Type</label>
+          <input id="action-type-input" value="${actionTypeDefault}" />
           <label for="risk-kind-input">High-risk Kind</label>
           <input id="risk-kind-input" value="${highRiskKindDefault}" />
           <div class="row">
             <button class="secondary" id="approve-button">Approve high-risk action</button>
           </div>
-          <p class="muted">GitHub App secret sync 用なら <code>highRiskKind=github_app_secret_sync</code> を使います。</p>
+          <p class="muted">GitHub App secret sync なら <code>actionType=destructive</code> / <code>highRiskKind=github_app_secret_sync</code>、production deploy なら <code>actionType=deploy_production</code> / <code>highRiskKind=deploy_production</code> を使います。</p>
           <pre id="approve-output"></pre>
         </section>
 
@@ -222,7 +225,7 @@ export function renderPasskeyOperatorPage(input = {}) {
                 issueNumber: Number(document.getElementById("issue-input").value || 0) || null
               },
               policyInput: {
-                actionType: "destructive",
+                actionType: document.getElementById("action-type-input").value,
                 repositoryInput: document.getElementById("repo-input").value,
                 highRiskKind: document.getElementById("risk-kind-input").value
               }

--- a/test/deploy-approval-grant.test.js
+++ b/test/deploy-approval-grant.test.js
@@ -1,0 +1,41 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { validateDeployApprovalGrant } from "../src/core/index.js";
+
+test("deploy approval grant requires deploy_production scoped real passkey grant", () => {
+  const result = validateDeployApprovalGrant({
+    repositoryInput: "marushu/vtdd-v2-p",
+    approvalGrant: {
+      verified: true,
+      expiresAt: "2099-01-01T00:00:00.000Z",
+      scope: {
+        actionType: "deploy_production",
+        highRiskKind: "deploy_production",
+        repositoryInput: "marushu/vtdd-v2-p"
+      }
+    }
+  });
+
+  assert.equal(result.ok, true);
+});
+
+test("deploy approval grant rejects mismatched scope", () => {
+  const result = validateDeployApprovalGrant({
+    repositoryInput: "marushu/vtdd-v2-p",
+    approvalGrant: {
+      verified: true,
+      expiresAt: "2099-01-01T00:00:00.000Z",
+      scope: {
+        actionType: "destructive",
+        highRiskKind: "github_app_secret_sync",
+        repositoryInput: "marushu/vtdd-v2-p"
+      }
+    }
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(
+    result.issues.includes("approvalGrant scope.actionType must be deploy_production"),
+    true
+  );
+});

--- a/test/passkey-operator-page.test.js
+++ b/test/passkey-operator-page.test.js
@@ -5,6 +5,7 @@ import { renderPasskeyOperatorPage } from "../src/core/index.js";
 test("passkey operator page can target explicit api base and sync endpoint", () => {
   const html = renderPasskeyOperatorPage({
     apiBase: "/api",
+    actionType: "deploy_production",
     repositoryInput: "marushu/vtdd-v2-p",
     issueNumber: 15,
     highRiskKind: "github_app_secret_sync",
@@ -14,6 +15,7 @@ test("passkey operator page can target explicit api base and sync endpoint", () 
   assert.equal(html.includes('fetch("/api/approval/passkey/challenge"'), true);
   assert.equal(html.includes('fetch("/api/github-app-secret-sync/execute"'), true);
   assert.equal(html.includes("Sync GitHub App secrets"), true);
+  assert.equal(html.includes('id="action-type-input" value="deploy_production"'), true);
 });
 
 test("passkey operator page keeps sync disabled message when helper endpoint is absent", () => {

--- a/test/production-deploy-path.test.js
+++ b/test/production-deploy-path.test.js
@@ -19,7 +19,11 @@ test("production deploy doc defines the governed GitHub Actions deploy path", ()
   assert.equal(doc.includes("`wrangler deploy --env production`"), true);
   assert.equal(doc.includes("GitHub Environment `production`"), true);
   assert.equal(doc.includes("`approval_phrase=GO`"), true);
-  assert.equal(doc.includes("`passkey_verified=true`"), true);
+  assert.equal(doc.includes("`approval_grant_id=<real passkey approval grant id>`"), true);
+  assert.equal(doc.includes("`runtime_url=<user-owned worker runtime>`"), true);
+  assert.equal(doc.includes("`VTDD_GATEWAY_BEARER_TOKEN`"), true);
+  assert.equal(doc.includes("`actionType=deploy_production`"), true);
+  assert.equal(doc.includes("`highRiskKind=deploy_production`"), true);
   assert.equal(doc.includes("`CLOUDFLARE_API_TOKEN`"), true);
   assert.equal(doc.includes("`CLOUDFLARE_ACCOUNT_ID`"), true);
 });
@@ -31,7 +35,14 @@ test("deploy-production workflow enforces the MVP production deploy boundary", (
   assert.equal(workflow.includes("if: github.ref == 'refs/heads/main'"), true);
   assert.equal(workflow.includes("environment: production"), true);
   assert.equal(workflow.includes('github.event.inputs.approval_phrase }}" != "GO"'), true);
-  assert.equal(workflow.includes('github.event.inputs.passkey_verified }}" != "true"'), true);
+  assert.equal(workflow.includes('github.event.inputs.runtime_url'), true);
+  assert.equal(workflow.includes('github.event.inputs.approval_grant_id'), true);
+  assert.equal(workflow.includes("Validate real passkey approval grant"), true);
+  assert.equal(
+    workflow.includes('VTDD_GATEWAY_BEARER_TOKEN: ${{ secrets.VTDD_GATEWAY_BEARER_TOKEN }}'),
+    true
+  );
+  assert.equal(workflow.includes("scripts/validate-deploy-approval-grant.mjs"), true);
   assert.equal(workflow.includes("apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}"), true);
   assert.equal(
     workflow.includes("CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}"),


### PR DESCRIPTION
## This PR satisfies Intent

This PR removes the fake `passkey_verified=true` deploy gate and replaces it with a real approval grant validation path for `deploy_production`.

## Satisfied Success Criteria

- `deploy-production` no longer treats a boolean input as if it were a real passkey.
- Production deploy workflow now requires `runtime_url` and `approval_grant_id`.
- The workflow validates the approval grant against the worker runtime before deploy.
- Deploy approval grant validation is scoped to `actionType=deploy_production`, `highRiskKind=deploy_production`, and the target repository.
- The existing passkey operator page can now request deploy-specific approval scope by setting `actionType=deploy_production`.

## Unsatisfied Success Criteria

- This PR does not deploy latest `main` to production.
- This PR does not provide live E2E evidence yet.
- This PR does not solve the stale production runtime by itself; it only makes the deploy path canonical for the next execution.

## Verification Evidence

- `node --test test/deploy-approval-grant.test.js test/production-deploy-path.test.js test/passkey-operator-page.test.js`
- `node --check scripts/validate-deploy-approval-grant.mjs`

## Scope / Drift Notes

- This PR only changes the production deploy high-risk approval path for Issue #14.
- It does not touch Gemini reviewer execution, Butler synthesis, or GitHub App secret sync runtime.
- It does not close Issue #14 because live passkey-backed deploy evidence is still missing.
