### PR TITLE
fix: keep node-only GitHub App secret sync code out of worker bundle

### DIFF
--- a/scripts/run-passkey-operator-helper.mjs
+++ b/scripts/run-passkey-operator-helper.mjs
@@ -2,7 +2,8 @@ import { execFile } from "node:child_process";
 import http from "node:http";
 import path from "node:path";
 import { promisify } from "node:util";
-import { loadGitHubAppSecretSource, renderPasskeyOperatorPage } from "../src/core/index.js";
+import { loadGitHubAppSecretSource } from "../src/core/github-app-secret-sync.js";
+import { renderPasskeyOperatorPage } from "../src/core/index.js";
 
 const execFileAsync = promisify(execFile);
 const SCRIPT_DIR = path.dirname(new URL(import.meta.url).pathname);

--- a/scripts/sync-github-app-actions-secrets.mjs
+++ b/scripts/sync-github-app-actions-secrets.mjs
@@ -4,7 +4,7 @@ import {
   buildGitHubAppSecretSyncPlan,
   loadGitHubAppSecretSource,
   validateGitHubAppSecretSyncApprovalGrant
-} from "../src/core/index.js";
+} from "../src/core/github-app-secret-sync.js";
 
 const execFileAsync = promisify(execFile);
 

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -137,13 +137,6 @@ export {
   retrieveRemoteCodexExecutionProgress
 } from "./remote-codex-executor.js";
 export {
-  DEFAULT_GITHUB_APP_ENV_PATH,
-  buildGitHubAppSecretSyncPlan,
-  executeGitHubAppSecretSync,
-  loadGitHubAppSecretSource,
-  validateGitHubAppSecretSyncApprovalGrant
-} from "./github-app-secret-sync.js";
-export {
   DEFAULT_GEMINI_REVIEW_MODEL,
   GEMINI_PR_REVIEW_MARKER,
   MAX_CONTEXT_COMMENTS,

--- a/test/github-app-secret-sync.test.js
+++ b/test/github-app-secret-sync.test.js
@@ -8,7 +8,7 @@ import {
   executeGitHubAppSecretSync,
   loadGitHubAppSecretSource,
   validateGitHubAppSecretSyncApprovalGrant
-} from "../src/core/index.js";
+} from "../src/core/github-app-secret-sync.js";
 
 test("loadGitHubAppSecretSource reads app id and private key from existing env file", async () => {
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "vtdd-app-sync-"));


### PR DESCRIPTION
## This PR satisfies Intent
Prevent Node-only GitHub App secret sync code from being bundled into the Cloudflare Worker so latest `main` remains deployable to production. This is partial progress for `#14`, `#15`, and `#22` and does not itself deploy production or complete the live passkey/sync loop.

## Satisfied Success Criteria
- Worker bundle no longer imports `src/core/github-app-secret-sync.js` through `src/core/index.js`
- CLI/scripts and tests still use the GitHub App secret sync helpers directly
- `npx wrangler deploy --env production --dry-run` succeeds again on this branch
- `npm test` remains green

## Unsatisfied Success Criteria
- production deploy has not yet been executed
- production `/v2/approval/passkey/*` live verification is not yet re-run
- GitHub App secret sync actual mutation is not yet executed
- Gemini live rerun is not yet re-run

## Verification Evidence
- `node --test test/github-app-secret-sync.test.js test/production-deploy-path.test.js test/passkey-approval.test.js test/passkey-operator-page.test.js`
- `npm test`
- `npx wrangler deploy --env production --dry-run`

## Scope Contract
- Target Issues: `#14`, `#15`, `#22`
- Non-goals: passkey runtime redesign, deploy authority redesign, localhost helper canonicalization, Gemini/Butler/Remote Codex changes
- Changed files:
  - `src/core/index.js`
  - `scripts/sync-github-app-actions-secrets.mjs`
  - `scripts/run-passkey-operator-helper.mjs`
  - `test/github-app-secret-sync.test.js`

## Drift Check
- No setup wizard path was reintroduced
- No owner-specific runtime URL was added to code or workflow
- This change is safe for per-user/public repo use because it only narrows import boundaries between Worker runtime and Node-only operator code
