### PR TITLE
Worker URL 上の passkey bootstrap と cleanup を接続

### DIFF
--- a/docs/security/webauthn-passkey-runtime.md
+++ b/docs/security/webauthn-passkey-runtime.md
@@ -24,8 +24,17 @@ approval grant that Butler can use on the next high-risk request.
 - `GET /v2/retrieve/approval-grant?approvalId=...`
 - `GET /v2/approval/passkey/operator`
 
-All six routes use the same machine-auth boundary as the other `/v2/*`
-endpoints.
+Current boundary:
+
+- `/v2/retrieve/approval-grant` stays machine-auth only
+- `GET /v2/approval/passkey/operator` is the human/browser surface on the
+  user-owned Worker URL
+- same-origin browser POSTs to the passkey routes are allowed so the Worker URL
+  can execute the ceremony directly
+- browser bootstrap registration is allowed only while no passkey has been
+  registered yet
+- later registration expansion needs a separate bounded Issue; this slice does
+  not open public multi-enrollment forever
 
 ## Runtime Shape
 
@@ -73,7 +82,8 @@ Actions secrets.
 
 ### 5. Operator helper page
 
-`/v2/approval/passkey/operator` returns a same-origin HTML helper that can:
+`/v2/approval/passkey/operator` returns a same-origin HTML helper on the
+Worker URL itself. It can:
 
 - register a passkey
 - request a high-risk approval challenge
@@ -81,11 +91,20 @@ Actions secrets.
 - display the resulting `approvalGrantId`
 
 This is the minimum browser/iPhone execution surface for the real passkey flow.
+The Worker URL is canonical. Local helper/proxy paths are not the canonical
+surface for shared/public use.
 
-For explicit local operator execution, the repository may also serve the same
-page through `scripts/run-passkey-operator-helper.mjs`, which proxies the real
-`/v2/approval/passkey/*` runtime without introducing a new worker-side setup
-wizard path.
+## Record Retention
+
+The worker persists four kinds of passkey-related records:
+
+- passkey registry records: durable until explicit revoke/removal
+- registration sessions: short-lived and cleanup-eligible
+- approval sessions: short-lived and cleanup-eligible
+- approval grants: short-lived and cleanup-eligible
+
+Expired session/grant records must be purged by the runtime so D1 does not
+accumulate passkey ceremony garbage indefinitely.
 
 ## Safety Notes
 

--- a/src/core/cloudflare-provider.js
+++ b/src/core/cloudflare-provider.js
@@ -90,6 +90,13 @@ export function createCloudflareMemoryProvider(input = {}) {
 
     async validateRecord(inputRecord) {
       return validateMemoryRecord(inputRecord);
+    },
+
+    async deleteRecords(input = {}) {
+      if (!d1 || typeof d1.deleteRecords !== "function") {
+        return { ok: false, reason: "d1.deleteRecords is required" };
+      }
+      return d1.deleteRecords(input);
     }
   };
 }

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -26,6 +26,7 @@ export {
   DEFAULT_PASSKEY_GRANT_TTL_MS,
   DEFAULT_PASSKEY_SESSION_TTL_MS,
   PASSKEY_APPROVAL_KIND,
+  PASSKEY_EPHEMERAL_KINDS,
   PASSKEY_GRANT_TAG,
   PASSKEY_REGISTRATION_KIND,
   PASSKEY_REGISTRY_TAG,
@@ -35,6 +36,7 @@ export {
   dedupePasskeys,
   defaultPasskeyAdapter,
   evaluateApprovalGrant,
+  isExpiredPasskeyEphemeralRecord,
   normalizeScopeSnapshot,
   verifyPasskeyApproval,
   verifyPasskeyRegistration

--- a/src/core/memory-provider.js
+++ b/src/core/memory-provider.js
@@ -80,6 +80,21 @@ export function createInMemoryMemoryProvider() {
 
     async validateRecord(input) {
       return validateMemoryRecord(input);
+    },
+
+    async deleteRecords(input = {}) {
+      const ids = normalizeIds(input.ids);
+      if (ids.length === 0) {
+        return { ok: true, deletedCount: 0 };
+      }
+      let deletedCount = 0;
+      for (let index = records.length - 1; index >= 0; index -= 1) {
+        if (ids.includes(records[index]?.id)) {
+          records.splice(index, 1);
+          deletedCount += 1;
+        }
+      }
+      return { ok: true, deletedCount };
     }
   };
 }
@@ -104,5 +119,14 @@ function normalizeTags(value) {
   }
   return value
     .map((item) => normalize(item))
+    .filter(Boolean);
+}
+
+function normalizeIds(value) {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value
+    .map((item) => String(item ?? "").trim())
     .filter(Boolean);
 }

--- a/src/core/passkey-approval.js
+++ b/src/core/passkey-approval.js
@@ -13,6 +13,11 @@ export const PASSKEY_REGISTRATION_KIND = "passkey_registration";
 export const PASSKEY_APPROVAL_KIND = "passkey_approval";
 export const DEFAULT_PASSKEY_SESSION_TTL_MS = 5 * 60 * 1000;
 export const DEFAULT_PASSKEY_GRANT_TTL_MS = 2 * 60 * 1000;
+export const PASSKEY_EPHEMERAL_KINDS = Object.freeze([
+  PASSKEY_REGISTRATION_KIND,
+  PASSKEY_APPROVAL_KIND,
+  PASSKEY_GRANT_TAG
+]);
 
 export const defaultPasskeyAdapter = Object.freeze({
   generateRegistrationOptions,
@@ -101,6 +106,10 @@ export async function verifyPasskeyRegistration(input = {}) {
   const expectedChallenge = normalizeText(
     input.expectedChallenge || sessionRecord?.content?.challenge
   );
+  const sessionTtlMs = normalizePositiveInt(
+    input.sessionTtlMs,
+    DEFAULT_PASSKEY_SESSION_TTL_MS
+  );
 
   if (!sessionRecord || !response || !rpID || !origin || !expectedChallenge) {
     return {
@@ -126,6 +135,8 @@ export async function verifyPasskeyRegistration(input = {}) {
 
   const { registrationInfo } = verification;
   const credentialId = base64UrlEncode(registrationInfo.credential.id);
+  const verifiedAt = new Date().toISOString();
+  const expiresAt = new Date(Date.now() + sessionTtlMs).toISOString();
   const passkeyRecord = createMemoryRecord({
     id: `passkey:${credentialId}`,
     type: MemoryRecordType.WORKING_MEMORY,
@@ -147,7 +158,7 @@ export async function verifyPasskeyRegistration(input = {}) {
     },
     priority: 86,
     tags: [PASSKEY_REGISTRY_TAG],
-    createdAt: new Date().toISOString()
+    createdAt: verifiedAt
   });
 
   const completedSessionRecord = createMemoryRecord({
@@ -157,7 +168,8 @@ export async function verifyPasskeyRegistration(input = {}) {
       kind: PASSKEY_REGISTRATION_KIND,
       status: "verified",
       sessionId: sessionRecord.id,
-      credentialId
+      credentialId,
+      expiresAt
     },
     metadata: {
       source: "passkey_registration_verify",
@@ -166,7 +178,7 @@ export async function verifyPasskeyRegistration(input = {}) {
     },
     priority: 90,
     tags: [PASSKEY_SESSION_TAG, PASSKEY_REGISTRATION_KIND, "verified"],
-    createdAt: new Date().toISOString()
+    createdAt: verifiedAt
   });
 
   if (!passkeyRecord.ok) {
@@ -435,6 +447,22 @@ export function dedupePasskeys(records = []) {
   return [...latest.values()].filter(
     (item) => item.credentialId && item.publicKey
   );
+}
+
+export function isExpiredPasskeyEphemeralRecord(record, now = new Date()) {
+  const kind = normalizeText(record?.content?.kind);
+  if (!PASSKEY_EPHEMERAL_KINDS.includes(kind)) {
+    return false;
+  }
+  const expiresAt = normalizeText(record?.content?.expiresAt);
+  if (!expiresAt) {
+    return false;
+  }
+  const expiresAtMs = Date.parse(expiresAt);
+  if (!Number.isFinite(expiresAtMs)) {
+    return false;
+  }
+  return expiresAtMs <= now.valueOf();
 }
 
 function resolvePasskeyAdapter(adapter) {

--- a/src/worker.js
+++ b/src/worker.js
@@ -12,6 +12,7 @@ import {
   dispatchRemoteCodexExecution,
   inferRelatedIssueFromGatewayInput,
   inferRelatedIssueFromProposalGatewayInput,
+  isExpiredPasskeyEphemeralRecord,
   normalizeScopeSnapshot,
   normalizeAutonomyMode,
   retrieveRemoteCodexExecutionProgress,
@@ -57,18 +58,7 @@ export default {
     }
 
     if (request.method === "GET" && isApiPath(url.pathname, "/approval/passkey/operator")) {
-      const auth = authorizeGatewayRequest({
-        request,
-        env,
-        apiSuffix: "/approval/passkey/operator"
-      });
-      if (!auth.ok) {
-        return json(auth.status, {
-          ok: false,
-          error: "unauthorized",
-          reason: auth.reason
-        });
-      }
+      await purgeExpiredPasskeyArtifacts(resolveMemoryProvider(env));
       return handlePasskeyOperatorPageRequest(request);
     }
 
@@ -193,7 +183,8 @@ export default {
     }
 
     if (request.method === "POST" && isApiPath(url.pathname, "/approval/passkey/register/options")) {
-      const auth = authorizeGatewayRequest({
+      await purgeExpiredPasskeyArtifacts(resolveMemoryProvider(env));
+      const auth = await authorizePasskeyRegistrationRequest({
         request,
         env,
         apiSuffix: "/approval/passkey/register/options"
@@ -209,7 +200,8 @@ export default {
     }
 
     if (request.method === "POST" && isApiPath(url.pathname, "/approval/passkey/register/verify")) {
-      const auth = authorizeGatewayRequest({
+      await purgeExpiredPasskeyArtifacts(resolveMemoryProvider(env));
+      const auth = await authorizePasskeyRegistrationRequest({
         request,
         env,
         apiSuffix: "/approval/passkey/register/verify"
@@ -225,7 +217,8 @@ export default {
     }
 
     if (request.method === "POST" && isApiPath(url.pathname, "/approval/passkey/challenge")) {
-      const auth = authorizeGatewayRequest({
+      await purgeExpiredPasskeyArtifacts(resolveMemoryProvider(env));
+      const auth = authorizePasskeyBrowserOrMachineRequest({
         request,
         env,
         apiSuffix: "/approval/passkey/challenge"
@@ -241,7 +234,8 @@ export default {
     }
 
     if (request.method === "POST" && isApiPath(url.pathname, "/approval/passkey/verify")) {
-      const auth = authorizeGatewayRequest({
+      await purgeExpiredPasskeyArtifacts(resolveMemoryProvider(env));
+      const auth = authorizePasskeyBrowserOrMachineRequest({
         request,
         env,
         apiSuffix: "/approval/passkey/verify"
@@ -445,6 +439,7 @@ async function handleRetrieveCrossIssueRequest(url, env) {
 
 async function handleRetrieveApprovalGrantRequest(url, env) {
   const provider = resolveMemoryProvider(env);
+  await purgeExpiredPasskeyArtifacts(provider);
   const validation = validateMemoryProvider(provider);
   if (!validation.ok) {
     return json(503, {
@@ -807,6 +802,27 @@ async function retrieveRegisteredPasskeys(provider) {
     tags: ["passkey_registry"]
   });
   return dedupePasskeys(records);
+}
+
+async function purgeExpiredPasskeyArtifacts(provider) {
+  if (!provider || typeof provider.retrieve !== "function" || typeof provider.deleteRecords !== "function") {
+    return { ok: true, deletedCount: 0 };
+  }
+
+  const records = await provider.retrieve({
+    type: MemoryRecordType.APPROVAL_LOG,
+    limit: MAX_MEMORY_LIMIT
+  });
+  const expiredIds = records
+    .filter((record) => isExpiredPasskeyEphemeralRecord(record))
+    .map((record) => normalizeText(record?.id))
+    .filter(Boolean);
+
+  if (expiredIds.length === 0) {
+    return { ok: true, deletedCount: 0 };
+  }
+
+  return provider.deleteRecords({ ids: expiredIds });
 }
 
 async function findApprovalRecordById(provider, recordId) {
@@ -1315,6 +1331,25 @@ function createD1MemoryIndexAdapter(d1) {
       }
 
       return records.slice(0, limit);
+    },
+
+    async deleteRecords(input = {}) {
+      await ensureSchema();
+
+      const ids = Array.isArray(input?.ids)
+        ? input.ids.map((item) => normalizeText(item)).filter(Boolean)
+        : [];
+      if (ids.length === 0) {
+        return { ok: true, deletedCount: 0 };
+      }
+
+      const placeholders = ids.map(() => "?").join(", ");
+      await d1
+        .prepare(`DELETE FROM vtdd_memory_records WHERE id IN (${placeholders})`)
+        .bind(...ids)
+        .run();
+
+      return { ok: true, deletedCount: ids.length };
     }
   };
 
@@ -1323,20 +1358,14 @@ function createD1MemoryIndexAdapter(d1) {
 
   function ensureSchema() {
     if (!schemaPromise) {
-      schemaPromise = d1.exec(
-        `CREATE TABLE IF NOT EXISTS vtdd_memory_records (
-           id TEXT PRIMARY KEY,
-           type TEXT NOT NULL,
-           content_json TEXT,
-           content_ref TEXT,
-           metadata_json TEXT NOT NULL,
-           priority INTEGER NOT NULL,
-           tags_json TEXT NOT NULL,
-           created_at TEXT NOT NULL
-         );
-         CREATE INDEX IF NOT EXISTS idx_vtdd_memory_records_type_priority_created_at
-           ON vtdd_memory_records (type, priority DESC, created_at DESC);`
-      );
+      schemaPromise = (async () => {
+        await d1.exec(
+          "CREATE TABLE IF NOT EXISTS vtdd_memory_records (id TEXT PRIMARY KEY, type TEXT NOT NULL, content_json TEXT, content_ref TEXT, metadata_json TEXT NOT NULL, priority INTEGER NOT NULL, tags_json TEXT NOT NULL, created_at TEXT NOT NULL);"
+        );
+        await d1.exec(
+          "CREATE INDEX IF NOT EXISTS idx_vtdd_memory_records_type_priority_created_at ON vtdd_memory_records (type, priority DESC, created_at DESC);"
+        );
+      })();
     }
     return schemaPromise;
   }
@@ -1552,6 +1581,68 @@ function authorizeGatewayRequest({ request, env, apiSuffix = "/gateway" }) {
     status: 503,
     reason: `machine auth runtime is not configured for ${routeLabel}`
   };
+}
+
+async function authorizePasskeyRegistrationRequest({ request, env, apiSuffix }) {
+  const machineAuth = authorizeGatewayRequest({ request, env, apiSuffix });
+  if (machineAuth.ok) {
+    return machineAuth;
+  }
+
+  const browserAuth = authorizePasskeyBrowserOrMachineRequest({ request, env, apiSuffix });
+  if (!browserAuth.ok) {
+    return browserAuth;
+  }
+
+  const provider = resolveMemoryProvider(env);
+  const validation = validateMemoryProvider(provider);
+  if (!validation.ok) {
+    return browserAuth;
+  }
+
+  const passkeys = await retrieveRegisteredPasskeys(provider);
+  if (passkeys.length === 0) {
+    return browserAuth;
+  }
+
+  return {
+    ok: false,
+    status: 403,
+    reason: "browser bootstrap registration is allowed only before the first passkey is registered"
+  };
+}
+
+function authorizePasskeyBrowserOrMachineRequest({ request, env, apiSuffix }) {
+  const machineAuth = authorizeGatewayRequest({ request, env, apiSuffix });
+  if (machineAuth.ok) {
+    return machineAuth;
+  }
+  if (isSameOriginBrowserRequest(request)) {
+    return { ok: true };
+  }
+  return machineAuth;
+}
+
+function isSameOriginBrowserRequest(request) {
+  const originHeader = normalizeText(request.headers.get("origin"));
+  const fetchSite = normalize(request.headers.get("sec-fetch-site"));
+  const contentType = normalize(request.headers.get("content-type"));
+  if (!originHeader) {
+    return false;
+  }
+
+  const requestUrl = new URL(request.url);
+  const requestOrigin = `${requestUrl.protocol}//${requestUrl.host}`;
+  if (originHeader !== requestOrigin) {
+    return false;
+  }
+  if (fetchSite && fetchSite !== "same-origin" && fetchSite !== "same-site") {
+    return false;
+  }
+  if (request.method === "POST" && !contentType.includes("application/json")) {
+    return false;
+  }
+  return true;
 }
 
 async function readJson(request) {

--- a/test/passkey-approval.test.js
+++ b/test/passkey-approval.test.js
@@ -5,6 +5,7 @@ import {
   createPasskeyRegistrationOptions,
   dedupePasskeys,
   evaluateApprovalGrant,
+  isExpiredPasskeyEphemeralRecord,
   verifyPasskeyApproval,
   verifyPasskeyRegistration
 } from "../src/core/index.js";
@@ -179,4 +180,31 @@ test("dedupePasskeys keeps latest credential record", () => {
 
   assert.equal(records.length, 1);
   assert.equal(records[0].publicKey, "new");
+});
+
+test("completed registration session expires and becomes cleanup target", async () => {
+  const session = await createPasskeyRegistrationOptions({
+    adapter: mockAdapter,
+    rpID: "example.com",
+    rpName: "VTDD",
+    origin: "https://example.com",
+    sessionTtlMs: 1
+  });
+
+  const result = await verifyPasskeyRegistration({
+    adapter: mockAdapter,
+    sessionRecord: session.sessionRecord,
+    response: {
+      id: "ignored",
+      response: {
+        transports: ["internal"]
+      }
+    },
+    sessionTtlMs: 1
+  });
+
+  assert.equal(
+    isExpiredPasskeyEphemeralRecord(result.completedSessionRecord, new Date(Date.now() + 10)),
+    true
+  );
 });

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -463,10 +463,7 @@ test("worker can resolve passkey memory provider from Cloudflare D1 binding fall
 test("worker serves passkey operator page", async () => {
   const response = await worker.fetch(
     new Request(
-      "https://example.com/v2/approval/passkey/operator?repositoryInput=marushu%2Fvtdd-v2-p&issueNumber=15&highRiskKind=github_app_secret_sync",
-      {
-        headers: gatewayAuthHeaders
-      }
+      "https://example.com/v2/approval/passkey/operator?repositoryInput=marushu%2Fvtdd-v2-p&issueNumber=15&highRiskKind=github_app_secret_sync"
     ),
     gatewayAuthEnv
   );
@@ -477,6 +474,216 @@ test("worker serves passkey operator page", async () => {
   assert.equal(html.includes("VTDD Passkey Operator"), true);
   assert.equal(html.includes("/v2/approval/passkey/challenge"), true);
   assert.equal(html.includes("github_app_secret_sync"), true);
+});
+
+test("worker allows same-origin browser bootstrap registration before first passkey exists", async () => {
+  const provider = createInMemoryMemoryProvider();
+
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/approval/passkey/register/options", {
+      method: "POST",
+      headers: {
+        origin: "https://example.com",
+        "sec-fetch-site": "same-origin",
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({
+        operatorId: "owner",
+        operatorLabel: "Owner"
+      })
+    }),
+    {
+      ...gatewayAuthEnv,
+      MEMORY_PROVIDER: provider,
+      PASSKEY_ADAPTER: passkeyAdapter
+    }
+  );
+
+  assert.equal(response.status, 200);
+  const body = await response.json();
+  assert.equal(body.ok, true);
+  assert.equal(Boolean(body.sessionId), true);
+});
+
+test("worker blocks browser registration after first passkey already exists", async () => {
+  const provider = createInMemoryMemoryProvider();
+  await provider.store({
+    id: "passkey:existing",
+    type: MemoryRecordType.WORKING_MEMORY,
+    content: {
+      kind: "passkey_registry",
+      credentialId: "existing",
+      publicKey: "pub",
+      counter: 1,
+      transports: ["internal"]
+    },
+    metadata: { source: "test" },
+    priority: 80,
+    tags: ["passkey_registry"],
+    createdAt: "2026-04-25T00:00:00.000Z"
+  });
+
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/approval/passkey/register/options", {
+      method: "POST",
+      headers: {
+        origin: "https://example.com",
+        "sec-fetch-site": "same-origin",
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({
+        operatorId: "owner",
+        operatorLabel: "Owner"
+      })
+    }),
+    {
+      ...gatewayAuthEnv,
+      MEMORY_PROVIDER: provider,
+      PASSKEY_ADAPTER: passkeyAdapter
+    }
+  );
+
+  assert.equal(response.status, 403);
+});
+
+test("worker purges expired passkey session records before issuing challenge", async () => {
+  const provider = createInMemoryMemoryProvider();
+  await provider.store({
+    id: "passkey-auth:expired",
+    type: MemoryRecordType.APPROVAL_LOG,
+    content: {
+      kind: "passkey_approval",
+      status: "pending",
+      challenge: "challenge:old",
+      rpID: "example.com",
+      origin: "https://example.com",
+      expiresAt: "2000-01-01T00:00:00.000Z",
+      scope: {}
+    },
+    metadata: { source: "test" },
+    priority: 90,
+    tags: ["passkey_session", "passkey_approval"],
+    createdAt: "2000-01-01T00:00:00.000Z"
+  });
+  await provider.store({
+    id: "passkey:AQIDBA",
+    type: MemoryRecordType.WORKING_MEMORY,
+    content: {
+      kind: "passkey_registry",
+      credentialId: "AQIDBA",
+      publicKey: "BQYHCA",
+      counter: 1,
+      transports: ["internal"]
+    },
+    metadata: { source: "test" },
+    priority: 80,
+    tags: ["passkey_registry"],
+    createdAt: "2026-04-25T00:00:00.000Z"
+  });
+
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/approval/passkey/challenge", {
+      method: "POST",
+      headers: gatewayAuthHeaders,
+      body: JSON.stringify({
+        phase: "execution",
+        issueContext: { issueNumber: 14 },
+        policyInput: {
+          actionType: ActionType.DEPLOY_PRODUCTION,
+          repositoryInput: "vtdd"
+        }
+      })
+    }),
+    {
+      ...gatewayAuthEnv,
+      MEMORY_PROVIDER: provider,
+      PASSKEY_ADAPTER: passkeyAdapter
+    }
+  );
+
+  assert.equal(response.status, 200);
+  const remaining = await provider.query({
+    type: MemoryRecordType.APPROVAL_LOG,
+    text: "passkey-auth:expired",
+    limit: 10
+  });
+  assert.equal(remaining.length, 0);
+});
+
+test("worker allows same-origin browser approval flow after passkey exists", async () => {
+  const provider = createInMemoryMemoryProvider();
+  await provider.store({
+    id: "passkey:AQIDBA",
+    type: MemoryRecordType.WORKING_MEMORY,
+    content: {
+      kind: "passkey_registry",
+      credentialId: "AQIDBA",
+      publicKey: "BQYHCA",
+      counter: 1,
+      transports: ["internal"]
+    },
+    metadata: { source: "test" },
+    priority: 80,
+    tags: ["passkey_registry"],
+    createdAt: "2026-04-25T00:00:00.000Z"
+  });
+
+  const challenge = await worker.fetch(
+    new Request("https://example.com/v2/approval/passkey/challenge", {
+      method: "POST",
+      headers: {
+        origin: "https://example.com",
+        "sec-fetch-site": "same-origin",
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({
+        phase: "execution",
+        issueContext: { issueNumber: 15 },
+        policyInput: {
+          actionType: ActionType.DESTRUCTIVE,
+          repositoryInput: "marushu/vtdd-v2-p",
+          highRiskKind: "github_app_secret_sync"
+        }
+      })
+    }),
+    {
+      ...gatewayAuthEnv,
+      MEMORY_PROVIDER: provider,
+      PASSKEY_ADAPTER: passkeyAdapter
+    }
+  );
+
+  assert.equal(challenge.status, 200);
+  const challengeBody = await challenge.json();
+  assert.equal(challengeBody.ok, true);
+
+  const verify = await worker.fetch(
+    new Request("https://example.com/v2/approval/passkey/verify", {
+      method: "POST",
+      headers: {
+        origin: "https://example.com",
+        "sec-fetch-site": "same-origin",
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({
+        sessionId: challengeBody.sessionId,
+        response: {
+          id: "AQIDBA",
+          response: {}
+        }
+      })
+    }),
+    {
+      ...gatewayAuthEnv,
+      MEMORY_PROVIDER: provider,
+      PASSKEY_ADAPTER: passkeyAdapter
+    }
+  );
+
+  assert.equal(verify.status, 200);
+  const verifyBody = await verify.json();
+  assert.equal(verifyBody.ok, true);
+  assert.equal(Boolean(verifyBody.approvalGrant.approvalId), true);
 });
 
 test("worker gateway accepts high-risk approval grant resolved from memory", async () => {


### PR DESCRIPTION
## This PR satisfies Intent
Issue #14 の live gap のうち、Worker URL 上で人間が passkey 登録/approval を始められる surface と、passkey ceremony garbage が D1 に残り続ける問題を縮める。localhost helper や新しい local runtime を本筋にせず、worker canonical のまま same-origin browser surface と expired record cleanup を接続する。

## Satisfied Success Criteria
- `/v2/approval/passkey/operator` を Worker URL 上の human/browser surface として扱えるようにした
- same-origin browser POST から passkey registration / challenge / verify を通せるようにした
- browser bootstrap registration は first passkey 前だけ許可し、登録済み passkey がある後は閉じるようにした
- expired な passkey registration session / approval session / approval grant を runtime で purge できるようにした
- owner-specific な Worker URL / D1 id は repo に埋め込んでいない

## Unsatisfied Success Criteria
- production への live deploy はまだ未実行
- Worker URL 上で real passkey を実登録した E2E evidence はまだない
- approvalGrant を使った GitHub App secret sync 実行はまだ未実行
- Gemini rerun / Butler synthesis の live end-to-end はまだ未実行

## Verification Evidence
- `node --test test/passkey-approval.test.js test/worker.test.js`
- `npm test`

## Scope Boundary
- Target Issue: #14
- Non-goals:
  - GitHub App secret sync 実行そのもの
  - Gemini / Butler / Remote Codex の変更
  - setup wizard の復活
  - owner-specific bootstrap 値の repo 追加

## Notes
- `/v2/retrieve/approval-grant` は引き続き machine-auth only のままです
- Worker-hosted operator page を docs の reality に合わせて更新しています
- This PR is partial progress only. It does not close #14.
