### PR TITLE
Fix live passkey registration and approval scope wiring

### DIFF
--- a/.github/workflows/gemini-pr-review.yml
+++ b/.github/workflows/gemini-pr-review.yml
@@ -77,6 +77,11 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
+          cache: npm
+
+      - name: Install reviewer dependencies
+        if: ${{ steps.app_secrets.outputs.configured == 'true' }}
+        run: npm ci
 
       - name: Run Gemini PR review
         if: ${{ steps.app_secrets.outputs.configured == 'true' }}

--- a/src/core/passkey-approval.js
+++ b/src/core/passkey-approval.js
@@ -490,6 +490,10 @@ function isoBytes(value) {
 }
 
 function base64UrlEncode(input) {
+  if (typeof input === "string") {
+    const normalized = normalizeText(input);
+    return normalized;
+  }
   const bytes = input instanceof Uint8Array ? input : new Uint8Array(input);
   let text = "";
   for (const byte of bytes) {

--- a/src/core/passkey-operator-page.js
+++ b/src/core/passkey-operator-page.js
@@ -221,6 +221,8 @@ export function renderPasskeyOperatorPage(input = {}) {
             body: JSON.stringify({
               phase: document.getElementById("phase-input").value || "execution",
               highRiskKind: document.getElementById("risk-kind-input").value,
+              repositoryInput: document.getElementById("repo-input").value,
+              issueNumber: Number(document.getElementById("issue-input").value || 0) || null,
               issueContext: {
                 issueNumber: Number(document.getElementById("issue-input").value || 0) || null
               },

--- a/src/worker.js
+++ b/src/worker.js
@@ -789,9 +789,9 @@ function buildApprovalScopeSnapshot({ payload, policyInput }) {
   return normalizeScopeSnapshot({
     actionType: policyInput?.actionType,
     highRiskKind: payload?.highRiskKind ?? policyInput?.highRiskKind,
-    repositoryInput: policyInput?.repositoryInput,
-    issueNumber: issueContext.issueNumber,
-    relatedIssue: traceability.relatedIssue ?? issueContext.issueNumber,
+    repositoryInput: policyInput?.repositoryInput ?? payload?.repositoryInput,
+    issueNumber: issueContext.issueNumber ?? payload?.issueNumber,
+    relatedIssue: traceability.relatedIssue ?? issueContext.issueNumber ?? payload?.relatedIssue,
     phase: payload?.phase
   });
 }

--- a/test/passkey-approval.test.js
+++ b/test/passkey-approval.test.js
@@ -208,3 +208,45 @@ test("completed registration session expires and becomes cleanup target", async 
     true
   );
 });
+
+test("registration verify preserves string credential id from runtime adapter", async () => {
+  const stringIdAdapter = {
+    ...mockAdapter,
+    async verifyRegistrationResponse() {
+      return {
+        verified: true,
+        registrationInfo: {
+          credential: {
+            id: "runtime-string-credential-id",
+            publicKey: new Uint8Array([5, 6, 7, 8]),
+            counter: 1
+          },
+          credentialDeviceType: "singleDevice",
+          credentialBackedUp: true,
+          aaguid: "test-aaguid"
+        }
+      };
+    }
+  };
+
+  const session = await createPasskeyRegistrationOptions({
+    adapter: stringIdAdapter,
+    rpID: "example.com",
+    rpName: "VTDD",
+    origin: "https://example.com"
+  });
+
+  const result = await verifyPasskeyRegistration({
+    adapter: stringIdAdapter,
+    sessionRecord: session.sessionRecord,
+    response: {
+      id: "ignored",
+      response: {
+        transports: ["internal"]
+      }
+    }
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.passkeyRecord.content.credentialId, "runtime-string-credential-id");
+});

--- a/test/passkey-operator-page.test.js
+++ b/test/passkey-operator-page.test.js
@@ -16,6 +16,8 @@ test("passkey operator page can target explicit api base and sync endpoint", () 
   assert.equal(html.includes('fetch("/api/github-app-secret-sync/execute"'), true);
   assert.equal(html.includes("Sync GitHub App secrets"), true);
   assert.equal(html.includes('id="action-type-input" value="deploy_production"'), true);
+  assert.equal(html.includes('repositoryInput: document.getElementById("repo-input").value'), true);
+  assert.equal(html.includes('issueNumber: Number(document.getElementById("issue-input").value || 0) || null'), true);
 });
 
 test("passkey operator page keeps sync disabled message when helper endpoint is absent", () => {

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -684,6 +684,9 @@ test("worker allows same-origin browser approval flow after passkey exists", asy
   const verifyBody = await verify.json();
   assert.equal(verifyBody.ok, true);
   assert.equal(Boolean(verifyBody.approvalGrant.approvalId), true);
+  assert.equal(verifyBody.approvalGrant.scope.repositoryInput, "marushu/vtdd-v2-p");
+  assert.equal(verifyBody.approvalGrant.scope.issueNumber, "15");
+  assert.equal(verifyBody.approvalGrant.scope.relatedIssue, "15");
 });
 
 test("worker gateway accepts high-risk approval grant resolved from memory", async () => {


### PR DESCRIPTION
## This PR satisfies Intent
Use this PR as the next live integration step for Issue #14 while also fixing two real Worker URL bugs discovered during live passkey testing: registration stored an empty credential id for runtime string ids, and approval grant scope dropped repository/issue fields from the Worker operator flow.

## Satisfied Success Criteria
- passkey registration preserves runtime string credential ids instead of storing an empty credential id
- Worker operator approval flow preserves `repositoryInput`, `issueNumber`, and `relatedIssue` in the approval grant scope
- targeted worker/passkey tests cover the live bugs that were reproduced on the production Worker URL
- this PR is suitable as the next open PR to trigger Gemini reviewer live on GitHub

## Unsatisfied Success Criteria
- GitHub App secret sync section `3` on the Worker page is still not connected to the canonical execution path
- Gemini reviewer live comment and Butler synthesis live evidence are not yet recorded in this PR body
- this PR does not close #14, #15, #9, #12, or #4

## Verification Evidence
- `node --test test/passkey-approval.test.js test/passkey-operator-page.test.js test/worker.test.js`
- live production evidence before this PR:
  - passkey registration succeeded on Worker URL
  - approval grant succeeded on Worker URL
  - approval grant scope was observed empty before this fix
  - GitHub App secret sync actual execution already succeeded through the Issue #15 bootstrap path

## Scope Boundary
- Target Issues: #14
- Related live loop follow-up: #9, #12, #4
- Non-goals:
  - connecting Worker page section `3`
  - changing the GitHub App secret source of truth
  - changing Gemini reviewer or Butler synthesis logic in this PR

## Notes
This is partial progress only. The immediate purpose is to create the next live PR so Gemini reviewer can run against an actual open PR while carrying the smallest real passkey bugfixes discovered from production evidence.
