### PR TITLE
Add test PR note for live Gemini review

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ Current code starts with deterministic governance gates:
 - reconcile hold state (`reconcile_required`) for runtime/memory conflicts
 - guarded semi-automation mode (`normal` / `guarded_absence`) with ambiguity-stop boundaries and execution-log traceability
 
+Live end-to-end completion still requires explicit PR/review/runtime evidence.
+
 Code lives in `src/core/`, with tests in `test/`.
 Worker entry lives in `src/worker.js`.
 


### PR DESCRIPTION
## Intent
Create a bounded docs-only PR so the live Gemini reviewer path can be exercised against the latest `main` workflow.

## This PR satisfies Intent
- It creates a minimal open PR for live Gemini reviewer verification.

## Satisfied Success Criteria
- A minimal docs-only change exists for an open test PR.
- The change does not modify runtime behavior.

## Unsatisfied Success Criteria
- Gemini reviewer live writeback is not proven by this diff alone.
- Butler synthesis live chaining is not yet proven.

## Verification Evidence
- `README.md` updated with a narrow note about live E2E evidence.
- No runtime files changed.
