### PR TITLE
Treat approve-only Gemini reviews as non-blocking

### DIFF
--- a/src/core/execution-continuity.js
+++ b/src/core/execution-continuity.js
@@ -1,4 +1,5 @@
 import { buildButlerReviewSynthesis } from "./butler-review-synthesis.js";
+import { parseGeminiReviewComment } from "./gemini-pr-review.js";
 import { ActorRole, TaskMode } from "./types.js";
 
 export const ExecutionTransferMode = Object.freeze({
@@ -118,8 +119,13 @@ function validateHandoffRequirement({ actorRole, continuation }) {
 }
 
 function buildReviewState(pullRequest) {
-  const reviewCommentsCount = pullRequest.reviewCommentsCount;
-  const unresolvedReviewCommentsCount = pullRequest.unresolvedReviewCommentsCount;
+  const parsedGeminiSignals = collectGeminiReviewerSignals(pullRequest);
+  const reviewCommentsCount =
+    parsedGeminiSignals.totalCount > 0 ? parsedGeminiSignals.totalCount : pullRequest.reviewCommentsCount;
+  const unresolvedReviewCommentsCount =
+    parsedGeminiSignals.totalCount > 0
+      ? parsedGeminiSignals.blockingCount
+      : pullRequest.unresolvedReviewCommentsCount;
   const reviewer = pullRequest.reviewer;
   const criticalReviewPending =
     pullRequest.exists && reviewCommentsCount > 0 && unresolvedReviewCommentsCount > 0;
@@ -135,15 +141,25 @@ function buildReviewState(pullRequest) {
   };
 }
 
+function collectGeminiReviewerSignals(pullRequest) {
+  const comments = [
+    ...(Array.isArray(pullRequest.issueComments) ? pullRequest.issueComments : []),
+    ...(Array.isArray(pullRequest.reviewComments) ? pullRequest.reviewComments : [])
+  ];
+  const parsed = comments.map(parseGeminiReviewComment).filter(Boolean);
+
+  return {
+    totalCount: parsed.length,
+    blockingCount: parsed.filter((signal) => signal.blocking).length
+  };
+}
+
 function determineCodexGoal({ pullRequest, review }) {
   if (!pullRequest.exists) {
     return CodexGoal.OPEN_PR;
   }
   if (review.unresolvedReviewCommentsCount > 0) {
     return CodexGoal.REVISE_PR;
-  }
-  if (review.reviewCommentsCount > 0) {
-    return CodexGoal.RESPOND_TO_REVIEW;
   }
   return CodexGoal.WAIT_FOR_REVIEW;
 }

--- a/src/core/gemini-pr-review.js
+++ b/src/core/gemini-pr-review.js
@@ -275,6 +275,24 @@ export function findExistingGeminiReviewComment(comments = []) {
   );
 }
 
+export function parseGeminiReviewComment(comment = {}) {
+  const body = normalizeText(typeof comment === "string" ? comment : comment?.body);
+  if (!body || !containsMarker(body)) {
+    return null;
+  }
+
+  const recommendedActionMatch = body.match(/^- Recommended action:\s*`([^`]+)`/m);
+  const recommendedAction = normalizeText(recommendedActionMatch?.[1]).toLowerCase() || "manual_review";
+
+  return {
+    reviewer: "gemini",
+    recommendedAction,
+    blocking:
+      recommendedAction === "request_changes" || recommendedAction === "manual_review",
+    body
+  };
+}
+
 function summarizeComments(comments) {
   const list = Array.isArray(comments) ? comments : [];
   return list

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -149,6 +149,7 @@ export {
   extractReviewerResponseFromGemini,
   findExistingGeminiReviewComment,
   formatGeminiReviewComment,
+  parseGeminiReviewComment,
   resolveGeminiReviewTrigger
 } from "./gemini-pr-review.js";
 export { runMvpGateway } from "./mvp-gateway.js";

--- a/test/butler-review-synthesis.test.js
+++ b/test/butler-review-synthesis.test.js
@@ -44,3 +44,37 @@ test("butler review synthesis reports missing PR state plainly", () => {
   assert.equal(result.available, false);
   assert.equal(result.headline, "No active PR is available for Butler synthesis.");
 });
+
+test("butler review synthesis does not present approve-only Gemini review as unresolved objection", () => {
+  const result = buildButlerReviewSynthesis({
+    pullRequest: {
+      number: 28,
+      url: "https://github.com/example/repo/pull/28",
+      state: "open",
+      title: "Live Gemini review test",
+      issueComments: [
+        {
+          user: { login: "vtdd-codex[bot]" },
+          body: "<!-- vtdd:reviewer=gemini -->\n## VTDD Gemini Critical Review\n\n- Recommended action: `approve`"
+        }
+      ]
+    },
+    reviewLoop: {
+      reviewer: "gemini",
+      reviewCommentsCount: 1,
+      unresolvedReviewCommentsCount: 0,
+      criticalReviewPending: false
+    },
+    codexGoal: "respond_to_review",
+    nextSuggestedActions: ["summarize_for_human", "wait_for_human_go"]
+  });
+
+  assert.equal(result.available, true);
+  assert.equal(result.headline, "PR #28 is open. Reviewer feedback exists and should be checked before human GO.");
+  assert.equal(
+    result.humanDecisionFocus.includes(
+      "Meaningful reviewer objections remain unresolved; do not issue merge GO yet."
+    ),
+    false
+  );
+});

--- a/test/execution-continuity.test.js
+++ b/test/execution-continuity.test.js
@@ -76,3 +76,39 @@ test("execution continuity returns PR revision loop guidance when unresolved rev
     true
   );
 });
+
+test("execution continuity treats approve-only Gemini reviewer comment as non-blocking", () => {
+  const result = evaluateExecutionContinuity({
+    actorRole: ActorRole.BUTLER,
+    mode: TaskMode.EXECUTION,
+    runtimeTruth: {
+      runtimeState: {
+        activeBranch: "codex/test-pr-for-gemini-live",
+        pullRequest: {
+          number: 28,
+          url: "https://github.com/example/repo/pull/28",
+          state: "open",
+          title: "Live Gemini review test",
+          reviewer: "gemini",
+          issueComments: [
+            {
+              user: { login: "vtdd-codex[bot]" },
+              body: "<!-- vtdd:reviewer=gemini -->\n## VTDD Gemini Critical Review\n\n- Recommended action: `approve`"
+            }
+          ]
+        }
+      }
+    }
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.value.reviewLoop.reviewCommentsCount, 1);
+  assert.equal(result.value.reviewLoop.unresolvedReviewCommentsCount, 0);
+  assert.equal(result.value.reviewLoop.criticalReviewPending, false);
+  assert.equal(result.value.codexGoal, CodexGoal.WAIT_FOR_REVIEW);
+  assert.equal(
+    result.value.butlerReviewSynthesis.headline,
+    "PR #28 is open. Reviewer feedback exists and should be checked before human GO."
+  );
+  assert.deepEqual(result.value.nextSuggestedActions, ["summarize_for_human", "wait_for_human_go"]);
+});

--- a/test/gemini-pr-review.test.js
+++ b/test/gemini-pr-review.test.js
@@ -8,6 +8,7 @@ import {
   extractReviewerResponseFromGemini,
   findExistingGeminiReviewComment,
   formatGeminiReviewComment,
+  parseGeminiReviewComment,
   resolveGeminiReviewTrigger
 } from "../src/core/index.js";
 
@@ -163,6 +164,23 @@ test("findExistingGeminiReviewComment locates prior marker comment", () => {
   assert.deepEqual(comment, {
     id: 2,
     body: `${GEMINI_PR_REVIEW_MARKER}\nexisting review`
+  });
+});
+
+test("parseGeminiReviewComment treats approve as non-blocking reviewer evidence", () => {
+  const parsed = parseGeminiReviewComment(`${GEMINI_PR_REVIEW_MARKER}
+## VTDD Gemini Critical Review
+
+- Recommended action: \`approve\``);
+
+  assert.deepEqual(parsed, {
+    reviewer: "gemini",
+    recommendedAction: "approve",
+    blocking: false,
+    body: `${GEMINI_PR_REVIEW_MARKER}
+## VTDD Gemini Critical Review
+
+- Recommended action: \`approve\``
   });
 });
 


### PR DESCRIPTION
## Intent
Fix Butler/Gemini reviewer interpretation so an approve-only Gemini PR comment remains reviewer evidence without being counted as an unresolved reviewer objection.

## This PR satisfies Intent
- It parses Gemini reviewer comments for `recommendedAction`.
- It treats `approve` as non-blocking reviewer evidence.
- It preserves `request_changes` / `manual_review` as blocking reviewer objections.

## Satisfied Success Criteria
- Butler review synthesis no longer reports unresolved reviewer objections for approve-only Gemini output.
- Execution continuity returns `wait_for_review` with `summarize_for_human` / `wait_for_human_go` for approve-only Gemini output.
- Existing blocking reviewer paths remain covered by tests.

## Unsatisfied Success Criteria
- No new live PR comment was created by this PR itself.
- Worker UI section 3 secret sync mismatch remains out of scope (#26).

## Verification Evidence
- `node --test test/gemini-pr-review.test.js test/butler-review-synthesis.test.js test/execution-continuity.test.js`
- Live PR #28 data re-run through `evaluateExecutionContinuity(...)` now returns:
  - `codexGoal = wait_for_review`
  - `nextSuggestedActions = ["summarize_for_human", "wait_for_human_go"]`
