### PR TITLE
Clarify no-extra-API-cost execution boundary

### DIFF
--- a/.github/workflows/remote-codex-executor.yml
+++ b/.github/workflows/remote-codex-executor.yml
@@ -1,5 +1,10 @@
 name: remote-codex-executor
 
+# Optional API-backed runner.
+# This workflow uses OPENAI_API_KEY and may create separate API billing from a
+# ChatGPT/Codex subscription. It is not the default no-extra-API-cost executor
+# path described in docs/butler/remote-codex-cli-executor.md.
+
 on:
   workflow_dispatch:
     inputs:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ It is not a shared hosted runtime.
 If you want to use VTDD yourself, the expected path is:
 
 - fork this repository, or clone it into your own repository/account
-- configure your own GitHub, Cloudflare, OpenAI, Gemini, and ChatGPT assets
+- configure your own GitHub, Cloudflare, ChatGPT/Codex, and reviewer assets
 - create and operate your own Butler / Custom GPT surface
 
 The canonical repository remains owner-maintained.
@@ -22,7 +22,7 @@ accounts.
 ## Ownership Boundary
 
 This repository does not expect users to share the owner's secrets, GitHub App,
-Cloudflare account, Gemini key, or ChatGPT surface.
+Cloudflare account, reviewer keys, Codex account, or ChatGPT surface.
 
 Instead:
 
@@ -35,6 +35,19 @@ Instead:
 No setup wizard is assumed on this branch.
 VTDD runtime is expected to run in a setup-complete environment owned by the
 person using it.
+
+## Cost And Account Boundary
+
+VTDD should not silently turn an existing ChatGPT/Codex subscription into a
+separate OpenAI API billing path.
+
+The default operator expectation is user-owned ChatGPT/Codex access, GitHub,
+Cloudflare, and reviewer configuration. Any GitHub Actions runner that uses
+`OPENAI_API_KEY` for Codex CLI is an explicit opt-in API-backed executor, not
+the default no-extra-API-cost path.
+
+Likewise, a reviewer workflow that uses `GEMINI_API_KEY` is an optional
+provider-backed reviewer path. Reviewer choice remains pluggable.
 
 ## MVP Core (initial implementation)
 

--- a/docs/butler/remote-codex-cli-executor.md
+++ b/docs/butler/remote-codex-cli-executor.md
@@ -22,12 +22,28 @@ This slice exists specifically so the loop can continue into:
 
 ## Transport Principle
 
-The first implementation path is GitHub Actions centered.
+The implementation must preserve a no-extra-API-cost default for operators who
+already use Codex through a ChatGPT/Codex subscription.
+
+The GitHub Actions Codex CLI runner is an optional `api_key_runner`, not the
+default account model. It requires `OPENAI_API_KEY` and may create separate API
+billing from a ChatGPT/Codex subscription.
+
+The default operator path is GitHub-centered resume/delegation through the
+operator's own Codex surface or future Codex cloud delegation surface when that
+surface is available to the operator without separate API-key billing.
+
+## Optional API-backed Runner
+
+The first machine-runner implementation path is GitHub Actions centered.
 
 - Butler triggers a VTDD-managed workflow dispatch
 - the workflow runs Codex CLI remotely
 - the workflow operates on the target repository and branch
 - progress is observed through GitHub Actions run state plus VTDD execution logs
+
+This path must remain explicit opt-in because it depends on `OPENAI_API_KEY`.
+Do not present it as the only VTDD remote executor path.
 
 ## Required Inputs
 
@@ -70,3 +86,7 @@ The bounded goal of this executor slice is:
 - start remote Codex CLI from VTDD
 - reach PR creation or PR update
 - expose enough progress for Butler to continue the loop
+
+When using the optional API-backed runner, completion evidence must state that
+the run used the API-backed path. When using a no-extra-API-cost path,
+completion evidence must state the Codex surface used for execution.

--- a/docs/security/reviewer-policy.md
+++ b/docs/security/reviewer-policy.md
@@ -17,6 +17,8 @@ The reviewer is a critical evaluation role.
 - Gemini is the initial reviewer for VTDD V2.
 - Reviewer integration must remain pluggable and vendor-independent.
 - The initial choice must not hard-code the long-term reviewer architecture.
+- Any reviewer path that requires a provider API key must be treated as an
+  explicit opt-in cost/account choice, not a silent default.
 
 ## Fallback Position
 
@@ -31,12 +33,16 @@ Reviewer candidates must be evaluated on all of the following axes:
 
 - review quality
 - operating cost
+- whether the operator already has access through an existing subscription
 - fit with revision loop
 - learning-use risk
 - data handling conditions
 - non-lock-in portability
 
 No reviewer choice should be justified by cost alone.
+No reviewer choice should silently add a new paid API dependency when a
+subscription-backed or already-owned reviewer surface is the intended operator
+path.
 
 ## Pluggable Contract
 

--- a/test/cost-account-boundary.test.js
+++ b/test/cost-account-boundary.test.js
@@ -1,0 +1,28 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const read = (path) => fs.readFileSync(path, "utf8");
+
+test("README states API-key Codex runner is not the no-extra-cost default", () => {
+  const readme = read("README.md");
+
+  assert.equal(readme.includes("Cost And Account Boundary"), true);
+  assert.equal(readme.includes("OPENAI_API_KEY"), true);
+  assert.equal(readme.includes("explicit opt-in API-backed executor"), true);
+});
+
+test("remote Codex docs keep API-backed runner optional", () => {
+  const doc = read("docs/butler/remote-codex-cli-executor.md");
+
+  assert.equal(doc.includes("no-extra-API-cost default"), true);
+  assert.equal(doc.includes("optional `api_key_runner`"), true);
+  assert.equal(doc.includes("Do not present it as the only VTDD remote executor path."), true);
+});
+
+test("reviewer policy requires explicit cost/account choice for API-key reviewers", () => {
+  const doc = read("docs/security/reviewer-policy.md");
+
+  assert.equal(doc.includes("explicit opt-in cost/account choice"), true);
+  assert.equal(doc.includes("silently add a new paid API dependency"), true);
+});

--- a/test/remote-codex-workflow.test.js
+++ b/test/remote-codex-workflow.test.js
@@ -24,3 +24,9 @@ test("remote Codex workflow avoids embedding dispatch inputs inside shell heredo
   assert.equal(workflow.includes("Handoff JSON: ${{ github.event.inputs.handoff_json }}"), false);
   assert.equal(workflow.includes("git push origin \"${{ github.event.inputs.target_branch }}\""), false);
 });
+
+test("remote Codex workflow marks OPENAI_API_KEY runner as explicit opt-in", () => {
+  assert.equal(workflow.includes("Optional API-backed runner."), true);
+  assert.equal(workflow.includes("may create separate API billing"), true);
+  assert.equal(workflow.includes("OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}"), true);
+});


### PR DESCRIPTION
## Summary
- Clarify that `OPENAI_API_KEY` Codex CLI execution is an explicit opt-in API-backed runner, not the default VTDD executor path.
- Document that VTDD must not silently convert an existing ChatGPT/Codex subscription into separate OpenAI API billing.
- Clarify reviewer provider keys such as `GEMINI_API_KEY` as optional provider-backed reviewer choices, not mandatory architecture.

## Issue Mapping
- Related to #6: remote Codex executor contract must preserve the canonical execution boundary.
- Related to #9: reviewer provider choice must remain explicit and pluggable.
- Related to #4: PR revision loop remains in scope, but this PR does not claim end-to-end no-extra-cost execution.

## Non-goals
- Does not implement a no-extra-API-cost Codex remote executor.
- Does not automate ChatGPT/Codex Pro authentication.
- Does not mutate secrets, deploy, or change permissions.

## Verification
- `node --test test/cost-account-boundary.test.js test/remote-codex-workflow.test.js test/reviewer-policy.test.js`
- `npm test`

## E2E Status
- Not an E2E completion PR. This is a boundary correction so the next executor slice does not require new API billing by default.
