### PR TITLE
Add no-extra-API-cost Codex Cloud GitHub executor

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ Cloudflare, and reviewer configuration. Any GitHub Actions runner that uses
 `OPENAI_API_KEY` for Codex CLI is an explicit opt-in API-backed executor, not
 the default no-extra-API-cost path.
 
+The default no-extra-API-cost executor path delegates through GitHub by posting
+a bounded `@codex` Issue/PR comment for the operator's own Codex Cloud GitHub
+integration to pick up. That path uses the operator's ChatGPT/Codex account and
+does not require an OpenAI API key in GitHub Actions.
+
 Likewise, a reviewer workflow that uses `GEMINI_API_KEY` is an optional
 provider-backed reviewer path. Reviewer choice remains pluggable.
 

--- a/docs/butler/remote-codex-cli-executor.md
+++ b/docs/butler/remote-codex-cli-executor.md
@@ -29,13 +29,32 @@ The GitHub Actions Codex CLI runner is an optional `api_key_runner`, not the
 default account model. It requires `OPENAI_API_KEY` and may create separate API
 billing from a ChatGPT/Codex subscription.
 
-The default operator path is GitHub-centered resume/delegation through the
-operator's own Codex surface or future Codex cloud delegation surface when that
-surface is available to the operator without separate API-key billing.
+The default operator path is GitHub-centered Codex Cloud delegation through the
+operator's own ChatGPT/Codex GitHub integration.
+
+VTDD expresses that delegation as a bounded GitHub Issue or PR comment that
+mentions `@codex`. This lets the operator's existing Codex Cloud entitlement
+pick up the work through GitHub without requiring `OPENAI_API_KEY`.
+
+This path depends on the operator having connected Codex Cloud to GitHub in
+their own ChatGPT/Codex account. VTDD must surface that as operator-owned
+configuration, not as a repository secret owned by this public repo.
+
+## Default Codex Cloud GitHub Comment Runner
+
+The default no-extra-API-cost runner is:
+
+- Butler builds a bounded execution contract from Issue and GitHub runtime truth
+- VTDD posts that contract as a GitHub comment containing `@codex`
+- Codex Cloud, running under the operator's ChatGPT/Codex account, picks up the task
+- Codex creates or updates a PR
+- Butler tracks progress from the delegation comment, branch, and PR state
+
+This runner does not use `OPENAI_API_KEY`.
 
 ## Optional API-backed Runner
 
-The first machine-runner implementation path is GitHub Actions centered.
+The optional machine-runner implementation path is GitHub Actions centered.
 
 - Butler triggers a VTDD-managed workflow dispatch
 - the workflow runs Codex CLI remotely

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -133,6 +133,7 @@ export {
 } from "./execution-continuity.js";
 export {
   REMOTE_CODEX_WORKFLOW_FILE,
+  RemoteCodexExecutorTransport,
   RemoteCodexExecutionStatus,
   createRemoteCodexExecutionRequest,
   dispatchRemoteCodexExecution,

--- a/src/core/remote-codex-executor.js
+++ b/src/core/remote-codex-executor.js
@@ -2,6 +2,11 @@ import { ActorRole } from "./types.js";
 
 export const REMOTE_CODEX_WORKFLOW_FILE = "remote-codex-executor.yml";
 
+export const RemoteCodexExecutorTransport = Object.freeze({
+  CODEX_CLOUD_GITHUB_COMMENT: "codex_cloud_github_comment",
+  API_KEY_RUNNER: "api_key_runner"
+});
+
 export const RemoteCodexExecutionStatus = Object.freeze({
   QUEUED: "queued",
   IN_PROGRESS: "in_progress",
@@ -107,7 +112,16 @@ export async function dispatchRemoteCodexExecution(input = {}) {
     };
   }
 
-  const controlRepository = resolveControlRepository(input?.env);
+  const transport = resolveExecutorTransport(input);
+  if (transport === RemoteCodexExecutorTransport.CODEX_CLOUD_GITHUB_COMMENT) {
+    return dispatchCodexCloudGitHubComment({ request, token: token.value, env: input?.env });
+  }
+
+  return dispatchApiBackedWorkflow({ request, token: token.value, env: input?.env });
+}
+
+async function dispatchApiBackedWorkflow({ request, token, env }) {
+  const controlRepository = resolveControlRepository(env);
   if (!controlRepository) {
     return {
       ok: false,
@@ -118,11 +132,10 @@ export async function dispatchRemoteCodexExecution(input = {}) {
   }
 
   const workflowFile =
-    normalizeText(input?.env?.REMOTE_CODEX_WORKFLOW_FILE) || REMOTE_CODEX_WORKFLOW_FILE;
-  const workflowRef = normalizeText(input?.env?.REMOTE_CODEX_WORKFLOW_REF) || "main";
-  const apiBaseUrl = normalizeText(input?.env?.GITHUB_API_BASE_URL) || "https://api.github.com";
-  const fetchImpl =
-    typeof input?.env?.GITHUB_API_FETCH === "function" ? input.env.GITHUB_API_FETCH.bind(input.env) : fetch;
+    normalizeText(env?.REMOTE_CODEX_WORKFLOW_FILE) || REMOTE_CODEX_WORKFLOW_FILE;
+  const workflowRef = normalizeText(env?.REMOTE_CODEX_WORKFLOW_REF) || "main";
+  const apiBaseUrl = normalizeText(env?.GITHUB_API_BASE_URL) || "https://api.github.com";
+  const fetchImpl = typeof env?.GITHUB_API_FETCH === "function" ? env.GITHUB_API_FETCH.bind(env) : fetch;
 
   const dispatchUrl = `${apiBaseUrl}/repos/${encodeURIComponentRepository(
     controlRepository
@@ -146,7 +159,7 @@ export async function dispatchRemoteCodexExecution(input = {}) {
     response = await fetchImpl(dispatchUrl, {
       method: "POST",
       headers: {
-        authorization: `Bearer ${token.value}`,
+        authorization: `Bearer ${token}`,
         accept: "application/vnd.github+json",
         "content-type": "application/json; charset=utf-8",
         "x-github-api-version": "2022-11-28",
@@ -211,7 +224,23 @@ export async function retrieveRemoteCodexExecutionProgress(input = {}) {
     };
   }
 
-  const controlRepository = resolveControlRepository(input?.env);
+  const transport = resolveExecutorTransport(input);
+  if (transport === RemoteCodexExecutorTransport.CODEX_CLOUD_GITHUB_COMMENT) {
+    return retrieveCodexCloudGitHubCommentProgress({
+      executionId,
+      repository: normalizeText(input?.repository),
+      issueNumber: normalizePositiveInteger(input?.issueNumber),
+      branch: normalizeText(input?.branch),
+      token: token.value,
+      env: input?.env
+    });
+  }
+
+  return retrieveApiBackedWorkflowProgress({ executionId, token: token.value, env: input?.env });
+}
+
+async function retrieveApiBackedWorkflowProgress({ executionId, token, env }) {
+  const controlRepository = resolveControlRepository(env);
   if (!controlRepository) {
     return {
       ok: false,
@@ -222,10 +251,9 @@ export async function retrieveRemoteCodexExecutionProgress(input = {}) {
   }
 
   const workflowFile =
-    normalizeText(input?.env?.REMOTE_CODEX_WORKFLOW_FILE) || REMOTE_CODEX_WORKFLOW_FILE;
-  const apiBaseUrl = normalizeText(input?.env?.GITHUB_API_BASE_URL) || "https://api.github.com";
-  const fetchImpl =
-    typeof input?.env?.GITHUB_API_FETCH === "function" ? input.env.GITHUB_API_FETCH.bind(input.env) : fetch;
+    normalizeText(env?.REMOTE_CODEX_WORKFLOW_FILE) || REMOTE_CODEX_WORKFLOW_FILE;
+  const apiBaseUrl = normalizeText(env?.GITHUB_API_BASE_URL) || "https://api.github.com";
+  const fetchImpl = typeof env?.GITHUB_API_FETCH === "function" ? env.GITHUB_API_FETCH.bind(env) : fetch;
   const progressUrl = `${apiBaseUrl}/repos/${encodeURIComponentRepository(
     controlRepository
   )}/actions/workflows/${encodeURIComponent(workflowFile)}/runs?event=workflow_dispatch&per_page=30`;
@@ -235,7 +263,7 @@ export async function retrieveRemoteCodexExecutionProgress(input = {}) {
     response = await fetchImpl(progressUrl, {
       method: "GET",
       headers: {
-        authorization: `Bearer ${token.value}`,
+        authorization: `Bearer ${token}`,
         accept: "application/vnd.github+json",
         "x-github-api-version": "2022-11-28",
         "user-agent": "vtdd-v2-remote-codex-executor"
@@ -287,6 +315,246 @@ export async function retrieveRemoteCodexExecutionProgress(input = {}) {
       updatedAt: normalizeText(run.updated_at) || null
     }
   };
+}
+
+async function dispatchCodexCloudGitHubComment({ request, token, env }) {
+  const apiBaseUrl = normalizeText(env?.GITHUB_API_BASE_URL) || "https://api.github.com";
+  const fetchImpl = typeof env?.GITHUB_API_FETCH === "function" ? env.GITHUB_API_FETCH.bind(env) : fetch;
+  const commentUrl = `${apiBaseUrl}/repos/${encodeURIComponentRepository(
+    request.repository
+  )}/issues/${encodeURIComponent(String(request.issueNumber))}/comments`;
+  const body = buildCodexCloudGitHubComment({ request });
+
+  let response;
+  try {
+    response = await fetchImpl(commentUrl, {
+      method: "POST",
+      headers: githubJsonHeaders({ token }),
+      body: JSON.stringify({ body })
+    });
+  } catch {
+    return {
+      ok: false,
+      status: 503,
+      error: "remote_codex_dispatch_failed",
+      reason: "failed to post Codex Cloud GitHub delegation comment"
+    };
+  }
+
+  const responseBody = await readJsonSafe(response);
+  if (!response.ok) {
+    return {
+      ok: false,
+      status: response.status,
+      error: "remote_codex_dispatch_failed",
+      reason: normalizeText(responseBody?.message) || "GitHub issue comment creation failed"
+    };
+  }
+
+  return {
+    ok: true,
+    execution: {
+      executionId: request.executionId,
+      transport: RemoteCodexExecutorTransport.CODEX_CLOUD_GITHUB_COMMENT,
+      targetRepository: request.repository,
+      issueNumber: request.issueNumber,
+      branch: request.branch,
+      baseRef: request.baseRef,
+      codexGoal: request.codexGoal,
+      commentId: normalizePositiveInteger(responseBody?.id),
+      commentUrl: normalizeText(responseBody?.html_url) || null,
+      status: RemoteCodexExecutionStatus.QUEUED
+    }
+  };
+}
+
+async function retrieveCodexCloudGitHubCommentProgress({
+  executionId,
+  repository,
+  issueNumber,
+  branch,
+  token,
+  env
+}) {
+  if (!repository || !issueNumber) {
+    return {
+      ok: false,
+      status: 422,
+      error: "remote_codex_progress_scope_required",
+      reason: "repository and issueNumber are required for Codex Cloud GitHub comment progress"
+    };
+  }
+
+  const apiBaseUrl = normalizeText(env?.GITHUB_API_BASE_URL) || "https://api.github.com";
+  const fetchImpl = typeof env?.GITHUB_API_FETCH === "function" ? env.GITHUB_API_FETCH.bind(env) : fetch;
+  const commentsUrl = `${apiBaseUrl}/repos/${encodeURIComponentRepository(
+    repository
+  )}/issues/${encodeURIComponent(String(issueNumber))}/comments?per_page=100`;
+
+  let commentsResponse;
+  try {
+    commentsResponse = await fetchImpl(commentsUrl, {
+      method: "GET",
+      headers: githubJsonHeaders({ token })
+    });
+  } catch {
+    return {
+      ok: false,
+      status: 503,
+      error: "remote_codex_progress_failed",
+      reason: "failed to read Codex Cloud delegation comments"
+    };
+  }
+
+  const commentsBody = await readJsonSafe(commentsResponse);
+  if (!commentsResponse.ok) {
+    return {
+      ok: false,
+      status: commentsResponse.status,
+      error: "remote_codex_progress_failed",
+      reason: normalizeText(commentsBody?.message) || "GitHub issue comments lookup failed"
+    };
+  }
+
+  const comments = Array.isArray(commentsBody) ? commentsBody : [];
+  const delegationComment = comments.find((comment) =>
+    normalizeText(comment?.body).includes(`vtdd:remote-codex-execution:${executionId}`)
+  );
+  if (!delegationComment) {
+    return {
+      ok: false,
+      status: 404,
+      error: "remote_codex_execution_not_found",
+      reason: "no Codex Cloud GitHub delegation comment matched executionId"
+    };
+  }
+
+  const pullRequest = branch
+    ? await findPullRequestForBranch({ repository, branch, token, env })
+    : { ok: true, pullRequest: null };
+  if (!pullRequest.ok) {
+    return pullRequest;
+  }
+
+  return {
+    ok: true,
+    progress: {
+      executionId,
+      transport: RemoteCodexExecutorTransport.CODEX_CLOUD_GITHUB_COMMENT,
+      targetRepository: repository,
+      issueNumber,
+      branch: branch || null,
+      delegationCommentId: normalizePositiveInteger(delegationComment.id),
+      delegationCommentUrl: normalizeText(delegationComment.html_url) || null,
+      status: pullRequest.pullRequest
+        ? RemoteCodexExecutionStatus.COMPLETED
+        : RemoteCodexExecutionStatus.QUEUED,
+      pullRequest: pullRequest.pullRequest
+    }
+  };
+}
+
+async function findPullRequestForBranch({ repository, branch, token, env }) {
+  const apiBaseUrl = normalizeText(env?.GITHUB_API_BASE_URL) || "https://api.github.com";
+  const fetchImpl = typeof env?.GITHUB_API_FETCH === "function" ? env.GITHUB_API_FETCH.bind(env) : fetch;
+  const [owner] = repository.split("/");
+  const pullsUrl = `${apiBaseUrl}/repos/${encodeURIComponentRepository(
+    repository
+  )}/pulls?state=all&head=${encodeURIComponent(`${owner}:${branch}`)}&per_page=10`;
+
+  let response;
+  try {
+    response = await fetchImpl(pullsUrl, {
+      method: "GET",
+      headers: githubJsonHeaders({ token })
+    });
+  } catch {
+    return {
+      ok: false,
+      status: 503,
+      error: "remote_codex_progress_failed",
+      reason: "failed to read pull requests for Codex Cloud delegation"
+    };
+  }
+
+  const body = await readJsonSafe(response);
+  if (!response.ok) {
+    return {
+      ok: false,
+      status: response.status,
+      error: "remote_codex_progress_failed",
+      reason: normalizeText(body?.message) || "GitHub pull request lookup failed"
+    };
+  }
+
+  const pull = Array.isArray(body) ? body[0] : null;
+  return {
+    ok: true,
+    pullRequest: pull
+      ? {
+          number: normalizePositiveInteger(pull.number),
+          url: normalizeText(pull.html_url) || null,
+          state: normalizeText(pull.state) || null,
+          title: normalizeText(pull.title) || null
+        }
+      : null
+  };
+}
+
+function buildCodexCloudGitHubComment({ request }) {
+  const lines = [
+    `<!-- vtdd:remote-codex-execution:${request.executionId} -->`,
+    "@codex",
+    "",
+    "VTDD-managed Codex Cloud delegation request.",
+    "",
+    "Bounded execution contract:",
+    `- Repository: ${request.repository}`,
+    `- Issue: #${request.issueNumber}`,
+    `- Branch: ${request.branch}`,
+    `- Base ref: ${request.baseRef}`,
+    `- Goal: ${request.codexGoal}`,
+    "- Canonical spec: this GitHub Issue",
+    "- Runtime truth: current GitHub branch / diff / PR / review comments",
+    "- Completion target: create or update a pull request",
+    "",
+    "Rules:",
+    "- Do not expand scope beyond the Issue.",
+    "- Do not merge.",
+    "- Do not deploy.",
+    "- Preserve reviewer objections for Butler/human judgment.",
+    "- If the Issue or runtime truth is insufficient, stop and comment with the blocked reason."
+  ];
+
+  if (request.handoff) {
+    lines.push("", "Handoff:", fencedJson(request.handoff));
+  }
+
+  return lines.join("\n");
+}
+
+function resolveExecutorTransport(input = {}) {
+  const value = normalizeText(
+    input?.executorTransport ?? input?.env?.REMOTE_CODEX_EXECUTOR_TRANSPORT
+  );
+  if (value === RemoteCodexExecutorTransport.API_KEY_RUNNER) {
+    return RemoteCodexExecutorTransport.API_KEY_RUNNER;
+  }
+  return RemoteCodexExecutorTransport.CODEX_CLOUD_GITHUB_COMMENT;
+}
+
+function githubJsonHeaders({ token }) {
+  return {
+    authorization: `Bearer ${token}`,
+    accept: "application/vnd.github+json",
+    "content-type": "application/json; charset=utf-8",
+    "x-github-api-version": "2022-11-28",
+    "user-agent": "vtdd-v2-remote-codex-executor"
+  };
+}
+
+function fencedJson(value) {
+  return ["```json", JSON.stringify(value, null, 2), "```"].join("\n");
 }
 
 async function resolveGitHubExecutionToken(env) {

--- a/src/worker.js
+++ b/src/worker.js
@@ -154,6 +154,9 @@ export default {
 
       const progress = await retrieveRemoteCodexExecutionProgress({
         executionId: url.searchParams.get("executionId"),
+        repository: url.searchParams.get("repository"),
+        issueNumber: url.searchParams.get("issueNumber"),
+        branch: url.searchParams.get("branch"),
         env
       });
       if (!progress.ok) {

--- a/test/cost-account-boundary.test.js
+++ b/test/cost-account-boundary.test.js
@@ -10,12 +10,15 @@ test("README states API-key Codex runner is not the no-extra-cost default", () =
   assert.equal(readme.includes("Cost And Account Boundary"), true);
   assert.equal(readme.includes("OPENAI_API_KEY"), true);
   assert.equal(readme.includes("explicit opt-in API-backed executor"), true);
+  assert.equal(readme.includes("bounded `@codex` Issue/PR comment"), true);
 });
 
 test("remote Codex docs keep API-backed runner optional", () => {
   const doc = read("docs/butler/remote-codex-cli-executor.md");
 
   assert.equal(doc.includes("no-extra-API-cost default"), true);
+  assert.equal(doc.includes("Default Codex Cloud GitHub Comment Runner"), true);
+  assert.equal(doc.includes("This runner does not use `OPENAI_API_KEY`."), true);
   assert.equal(doc.includes("optional `api_key_runner`"), true);
   assert.equal(doc.includes("Do not present it as the only VTDD remote executor path."), true);
 });

--- a/test/remote-codex-executor.test.js
+++ b/test/remote-codex-executor.test.js
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import {
   ActorRole,
+  RemoteCodexExecutorTransport,
   RemoteCodexExecutionStatus,
   createRemoteCodexExecutionRequest,
   dispatchRemoteCodexExecution,
@@ -40,7 +41,7 @@ test("remote Codex execution request is built from gateway result and payload", 
   assert.equal(result.request.codexGoal, "open_pr");
 });
 
-test("remote Codex execution dispatch posts workflow_dispatch to GitHub", async () => {
+test("remote Codex execution default dispatch posts bounded @codex GitHub comment", async () => {
   const calls = [];
   const dispatched = await dispatchRemoteCodexExecution({
     payload: {
@@ -64,6 +65,58 @@ test("remote Codex execution dispatch posts workflow_dispatch to GitHub", async 
       }
     },
     env: {
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_dispatch_token",
+      GITHUB_API_FETCH: async (url, init) => {
+        calls.push({ url, init });
+        return new Response(
+          JSON.stringify({
+            id: 123,
+            html_url: "https://github.com/sample-org/vtdd-v2/issues/6#issuecomment-123"
+          }),
+          { status: 201, headers: { "content-type": "application/json" } }
+        );
+      }
+    }
+  });
+
+  assert.equal(dispatched.ok, true);
+  assert.equal(dispatched.execution.transport, RemoteCodexExecutorTransport.CODEX_CLOUD_GITHUB_COMMENT);
+  assert.equal(dispatched.execution.status, RemoteCodexExecutionStatus.QUEUED);
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].url.includes("/repos/sample-org/vtdd-v2/issues/6/comments"), true);
+  assert.equal(calls[0].init.method, "POST");
+  const body = JSON.parse(calls[0].init.body).body;
+  assert.equal(body.includes("@codex"), true);
+  assert.equal(body.includes("Completion target: create or update a pull request"), true);
+  assert.equal(body.includes("Do not merge."), true);
+  assert.equal(body.includes("OPENAI_API_KEY"), false);
+});
+
+test("remote Codex API-backed execution dispatch posts workflow_dispatch to GitHub", async () => {
+  const calls = [];
+  const dispatched = await dispatchRemoteCodexExecution({
+    payload: {
+      actorRole: ActorRole.BUTLER,
+      issueContext: { issueNumber: 6 },
+      policyInput: {
+        approvalPhrase: "GO",
+        targetConfirmed: true,
+        approvalScopeMatched: true,
+        runtimeTruth: {
+          runtimeState: {
+            activeBranch: "codex/issue-6"
+          }
+        }
+      }
+    },
+    gatewayResult: {
+      repository: "sample-org/vtdd-v2",
+      executionContinuity: {
+        codexGoal: "open_pr"
+      }
+    },
+    env: {
+      REMOTE_CODEX_EXECUTOR_TRANSPORT: RemoteCodexExecutorTransport.API_KEY_RUNNER,
       VTDD_GITHUB_ACTIONS_REPOSITORY: "sample-org/vtdd-v2-p",
       GITHUB_APP_INSTALLATION_TOKEN: "ghs_dispatch_token",
       GITHUB_API_FETCH: async (url, init) => {
@@ -80,10 +133,11 @@ test("remote Codex execution dispatch posts workflow_dispatch to GitHub", async 
   assert.equal(calls[0].init.method, "POST");
 });
 
-test("remote Codex execution progress reads matching workflow run", async () => {
+test("remote Codex API-backed execution progress reads matching workflow run", async () => {
   const progress = await retrieveRemoteCodexExecutionProgress({
     executionId: "remote-codex-issue6-abcd12",
     env: {
+      REMOTE_CODEX_EXECUTOR_TRANSPORT: RemoteCodexExecutorTransport.API_KEY_RUNNER,
       VTDD_GITHUB_ACTIONS_REPOSITORY: "sample-org/vtdd-v2-p",
       GITHUB_APP_INSTALLATION_TOKEN: "ghs_progress_token",
       GITHUB_API_FETCH: async () =>
@@ -111,4 +165,49 @@ test("remote Codex execution progress reads matching workflow run", async () => 
   assert.equal(progress.ok, true);
   assert.equal(progress.progress.workflowRunId, 101);
   assert.equal(progress.progress.status, RemoteCodexExecutionStatus.IN_PROGRESS);
+});
+
+test("remote Codex comment transport progress reads delegation comment and PR state", async () => {
+  const calls = [];
+  const progress = await retrieveRemoteCodexExecutionProgress({
+    executionId: "remote-codex-issue6-abcd12",
+    repository: "sample-org/vtdd-v2",
+    issueNumber: 6,
+    branch: "codex/issue-6",
+    env: {
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_progress_token",
+      GITHUB_API_FETCH: async (url, init) => {
+        calls.push({ url, init });
+        if (String(url).includes("/issues/6/comments")) {
+          return new Response(
+            JSON.stringify([
+              {
+                id: 123,
+                html_url: "https://github.com/sample-org/vtdd-v2/issues/6#issuecomment-123",
+                body: "<!-- vtdd:remote-codex-execution:remote-codex-issue6-abcd12 -->\n@codex"
+              }
+            ]),
+            { status: 200, headers: { "content-type": "application/json" } }
+          );
+        }
+        return new Response(
+          JSON.stringify([
+            {
+              number: 44,
+              html_url: "https://github.com/sample-org/vtdd-v2/pull/44",
+              state: "open",
+              title: "VTDD remote Codex execution for issue #6"
+            }
+          ]),
+          { status: 200, headers: { "content-type": "application/json" } }
+        );
+      }
+    }
+  });
+
+  assert.equal(progress.ok, true);
+  assert.equal(progress.progress.transport, RemoteCodexExecutorTransport.CODEX_CLOUD_GITHUB_COMMENT);
+  assert.equal(progress.progress.status, RemoteCodexExecutionStatus.COMPLETED);
+  assert.equal(progress.progress.pullRequest.number, 44);
+  assert.equal(calls.length, 2);
 });

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -336,7 +336,13 @@ test("worker dispatches remote Codex execution", async () => {
             { status: 200, headers: { "content-type": "application/json" } }
           );
         }
-        return new Response(null, { status: 204 });
+        return new Response(
+          JSON.stringify({
+            id: 123,
+            html_url: "https://github.com/sample-org/vtdd-v2/issues/6#issuecomment-123"
+          }),
+          { status: 201, headers: { "content-type": "application/json" } }
+        );
       }
     }
   );
@@ -345,6 +351,7 @@ test("worker dispatches remote Codex execution", async () => {
   const body = await response.json();
   assert.equal(body.ok, true);
   assert.equal(body.execution.issueNumber, 6);
+  assert.equal(body.execution.transport, "codex_cloud_github_comment");
   assert.equal(calls.length, 2);
 });
 
@@ -813,6 +820,7 @@ test("worker returns remote Codex execution progress", async () => {
     }),
     {
       ...gatewayAuthEnv,
+      REMOTE_CODEX_EXECUTOR_TRANSPORT: "api_key_runner",
       VTDD_GITHUB_ACTIONS_REPOSITORY: "sample-org/vtdd-v2-p",
       GITHUB_APP_INSTALLATION_TOKEN: "ghs_progress_token",
       GITHUB_API_FETCH: async () =>


### PR DESCRIPTION
## Summary
- Add the default no-extra-API-cost remote Codex transport: VTDD posts a bounded `@codex` GitHub Issue/PR comment for the operator-owned Codex Cloud GitHub integration to pick up.
- Keep the existing GitHub Actions Codex CLI runner as explicit `api_key_runner` opt-in only.
- Extend progress lookup for the GitHub comment transport by finding the delegation comment and the PR created from the target branch.
- Document the account/cost boundary in README and the remote Codex executor contract.

## Issue Mapping
- #6 Success Criteria: VTDD can initiate a GitHub-centered remote Codex execution request without requiring `OPENAI_API_KEY`; payload remains bounded by repository, Issue, branch, goal, approval scope, and optional handoff; progress can be read from GitHub runtime truth.
- #4 Alignment: preserves resume-first / handoff-when-needed and keeps PR creation/update as the Codex slice goal.

## Non-goals
- Does not automate ChatGPT/Codex account login.
- Does not guarantee Codex Cloud will respond unless the operator has connected Codex Cloud to GitHub.
- Does not mutate secrets, deploy, merge, or change permissions.
- Does not replace Gemini/Butler synthesis.

## Verification
- `node --test test/remote-codex-executor.test.js test/worker.test.js test/cost-account-boundary.test.js`
- `npm test`

## E2E Status
- Code/integration path is verified locally.
- Live external E2E is still pending: call `/v2/action/execute`, confirm the `@codex` delegation comment appears, then confirm Codex Cloud responds/creates or updates a PR under the operator-owned ChatGPT/Codex GitHub integration.
