### PR TITLE
Preflight production deploy credentials

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -45,6 +45,31 @@ jobs:
             exit 1
           fi
 
+      - name: Preflight deploy credentials
+        env:
+          VTDD_GATEWAY_BEARER_TOKEN: ${{ secrets.VTDD_GATEWAY_BEARER_TOKEN }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        shell: bash
+        run: |
+          missing=0
+          if [ -z "$VTDD_GATEWAY_BEARER_TOKEN" ]; then
+            echo "Missing required Actions secret: VTDD_GATEWAY_BEARER_TOKEN"
+            missing=1
+          fi
+          if [ -z "$CLOUDFLARE_API_TOKEN" ]; then
+            echo "Missing required Actions secret: CLOUDFLARE_API_TOKEN"
+            missing=1
+          fi
+          if [ -z "$CLOUDFLARE_ACCOUNT_ID" ]; then
+            echo "Missing required Actions secret: CLOUDFLARE_ACCOUNT_ID"
+            missing=1
+          fi
+          if [ "$missing" -ne 0 ]; then
+            echo "Configure the missing secrets before requesting GO + passkey for production deploy."
+            exit 1
+          fi
+
       - name: Checkout
         uses: actions/checkout@v4
 

--- a/docs/mvp/production-deploy-path.md
+++ b/docs/mvp/production-deploy-path.md
@@ -26,8 +26,13 @@ Set repository or environment secrets:
 
 - `CLOUDFLARE_API_TOKEN`
 - `CLOUDFLARE_ACCOUNT_ID`
+- `VTDD_GATEWAY_BEARER_TOKEN`
 
 The token should be scoped to minimum required Worker deploy permissions.
+
+These secrets are hard prerequisites. The workflow must check them before
+validating the passkey grant or running tests so a missing deploy credential is
+reported before operator approval time is wasted.
 
 ## Approval Boundary (`GO + passkey`)
 

--- a/test/production-deploy-path.test.js
+++ b/test/production-deploy-path.test.js
@@ -26,6 +26,8 @@ test("production deploy doc defines the governed GitHub Actions deploy path", ()
   assert.equal(doc.includes("`highRiskKind=deploy_production`"), true);
   assert.equal(doc.includes("`CLOUDFLARE_API_TOKEN`"), true);
   assert.equal(doc.includes("`CLOUDFLARE_ACCOUNT_ID`"), true);
+  assert.equal(doc.includes("`VTDD_GATEWAY_BEARER_TOKEN`"), true);
+  assert.equal(doc.includes("hard prerequisites"), true);
 });
 
 test("deploy-production workflow enforces the MVP production deploy boundary", () => {
@@ -37,6 +39,10 @@ test("deploy-production workflow enforces the MVP production deploy boundary", (
   assert.equal(workflow.includes('github.event.inputs.approval_phrase }}" != "GO"'), true);
   assert.equal(workflow.includes('github.event.inputs.runtime_url'), true);
   assert.equal(workflow.includes('github.event.inputs.approval_grant_id'), true);
+  assert.equal(workflow.includes("Preflight deploy credentials"), true);
+  assert.equal(workflow.includes("Missing required Actions secret: VTDD_GATEWAY_BEARER_TOKEN"), true);
+  assert.equal(workflow.includes("Missing required Actions secret: CLOUDFLARE_API_TOKEN"), true);
+  assert.equal(workflow.includes("Missing required Actions secret: CLOUDFLARE_ACCOUNT_ID"), true);
   assert.equal(workflow.includes("Validate real passkey approval grant"), true);
   assert.equal(
     workflow.includes('VTDD_GATEWAY_BEARER_TOKEN: ${{ secrets.VTDD_GATEWAY_BEARER_TOKEN }}'),


### PR DESCRIPTION
## Summary
- Add an early `deploy-production` preflight for `VTDD_GATEWAY_BEARER_TOKEN`, `CLOUDFLARE_API_TOKEN`, and `CLOUDFLARE_ACCOUNT_ID`.
- Document these as hard prerequisites before requesting `GO + passkey`.
- Extend production deploy path tests so this failure mode is explicit.

## Issue Mapping
- Fixes #33.

## Non-goals
- Does not create Cloudflare API tokens.
- Does not mutate secrets.
- Does not deploy production.
- Does not weaken `GO + passkey`.

## Verification
- `node --test test/production-deploy-path.test.js`
- `npm test`

## Live Finding That Triggered This
- `deploy-production` run 24929205731 passed passkey validation and tests, then failed at Cloudflare deploy because `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` were missing. This PR makes that missing setup fail before approval validation/tests/deploy work.
