### PR TITLE
Add Cloudflare deploy secret sync bootstrap

### DIFF
--- a/docs/mvp/production-deploy-path.md
+++ b/docs/mvp/production-deploy-path.md
@@ -34,6 +34,10 @@ These secrets are hard prerequisites. The workflow must check them before
 validating the passkey grant or running tests so a missing deploy credential is
 reported before operator approval time is wasted.
 
+Use `docs/setup/cloudflare-deploy-secret-sync.md` as the canonical operator
+sync path. Do not treat Worker runtime secrets as equivalent to GitHub Actions
+secrets.
+
 ## Approval Boundary (`GO + passkey`)
 
 `deploy-production` workflow is manual (`workflow_dispatch`) and requires:

--- a/docs/setup/cloudflare-deploy-secret-sync.md
+++ b/docs/setup/cloudflare-deploy-secret-sync.md
@@ -1,0 +1,55 @@
+# Cloudflare Deploy Secret Sync
+
+This document defines the explicit operator bootstrap path for Issue #35.
+
+## Problem
+
+Cloudflare Worker secrets and GitHub Actions secrets are different runtime
+surfaces.
+
+Uploading `CLOUDFLARE_API_TOKEN` as a Worker secret does not make it available
+to the GitHub Actions `deploy-production` workflow.
+
+## Required Actions Secrets
+
+Production deploy requires:
+
+- `CLOUDFLARE_API_TOKEN`
+- `CLOUDFLARE_ACCOUNT_ID`
+
+## Canonical Sync Command
+
+After creating a Cloudflare API token, sync it into GitHub Actions secrets with:
+
+```bash
+printf '%s' "$CLOUDFLARE_API_TOKEN" | node scripts/sync-cloudflare-actions-secrets.mjs \
+  --repo marushu/vtdd-v2-p \
+  --cloudflare-account-id "$CLOUDFLARE_ACCOUNT_ID" \
+  --stdin \
+  --runtime-url https://vtdd-v2-mvp.polished-tree-da7c.workers.dev \
+  --approval-grant-id "$APPROVAL_GRANT_ID"
+```
+
+The script also accepts:
+
+- `--cloudflare-api-token-path <path>`
+- `CLOUDFLARE_API_TOKEN`
+- `CLOUDFLARE_ACCOUNT_ID`
+
+The script must not print the token value.
+
+## Approval Boundary
+
+This is credential mutation.
+
+It requires a real passkey approval grant with:
+
+- `actionType=deploy_production`
+- `highRiskKind=deploy_production`
+- `repositoryInput=<target repo>`
+
+## Non-goals
+
+- creating a Cloudflare API token without an existing Cloudflare credential
+- reading back an already-created Cloudflare token value
+- production deploy itself

--- a/scripts/sync-cloudflare-actions-secrets.mjs
+++ b/scripts/sync-cloudflare-actions-secrets.mjs
@@ -1,0 +1,169 @@
+import fs from "node:fs/promises";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { executeCloudflareDeploySecretSync } from "../src/core/index.js";
+
+const execFileAsync = promisify(execFile);
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const repo = normalizeText(args.repo || process.env.GITHUB_REPOSITORY || "marushu/vtdd-v2-p");
+  const source = {
+    cloudflareApiToken: await resolveApiToken(args),
+    cloudflareAccountId: normalizeText(
+      args.cloudflareAccountId ||
+        process.env.CLOUDFLARE_ACCOUNT_ID ||
+        "bd82bbc79ce38442976432eaa409e48c"
+    )
+  };
+
+  const approvalGrant = await resolveApprovalGrant({
+    runtimeUrl: args.runtimeUrl || process.env.VTDD_RUNTIME_URL,
+    approvalGrantId: args.approvalGrantId,
+    bearerToken: args.gatewayBearerToken || process.env.VTDD_GATEWAY_BEARER_TOKEN
+  });
+
+  const result = await executeCloudflareDeploySecretSync({
+    repo,
+    source,
+    approvalGrant,
+    runner: async (secret) => {
+      await execFileAsync(
+        "gh",
+        ["secret", "set", secret.name, "--repo", repo, "--app", "actions"],
+        {
+          input: secret.value,
+          maxBuffer: 10 * 1024 * 1024
+        }
+      );
+      console.log(`synced ${secret.name}`);
+      return { name: secret.name, synced: true };
+    }
+  });
+
+  if (!result.ok) {
+    throw new Error(result.issues.join(", "));
+  }
+}
+
+async function resolveApiToken(args) {
+  const fromArg = normalizeText(args.cloudflareApiToken);
+  if (fromArg) {
+    return fromArg;
+  }
+
+  const fromEnv = normalizeText(process.env.CLOUDFLARE_API_TOKEN);
+  if (fromEnv) {
+    return fromEnv;
+  }
+
+  const tokenPath = normalizeText(args.cloudflareApiTokenPath);
+  if (tokenPath) {
+    return normalizeText(await fs.readFile(tokenPath, "utf8"));
+  }
+
+  if (args.stdin === true) {
+    return normalizeText(await readStdin());
+  }
+
+  return "";
+}
+
+async function resolveApprovalGrant(input = {}) {
+  const approvalGrantId = normalizeText(input.approvalGrantId);
+  const runtimeUrl = normalizeText(input.runtimeUrl);
+  const bearerToken = normalizeText(input.bearerToken);
+
+  if (!approvalGrantId) {
+    throw new Error("--approval-grant-id is required");
+  }
+  if (!runtimeUrl) {
+    throw new Error("--runtime-url or VTDD_RUNTIME_URL is required");
+  }
+  if (!bearerToken) {
+    throw new Error("--gateway-bearer-token or VTDD_GATEWAY_BEARER_TOKEN is required");
+  }
+
+  const endpoint = new URL("/v2/retrieve/approval-grant", runtimeUrl);
+  endpoint.searchParams.set("approvalId", approvalGrantId);
+  const response = await fetch(endpoint, {
+    headers: {
+      authorization: `Bearer ${bearerToken}`
+    }
+  });
+  const body = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    throw new Error(body.reason || `approval grant retrieval failed with status ${response.status}`);
+  }
+  if (!body?.approvalGrant) {
+    throw new Error("approval grant retrieval returned no approvalGrant");
+  }
+  return body.approvalGrant;
+}
+
+function parseArgs(args) {
+  const parsed = {};
+  for (let index = 0; index < args.length; index += 1) {
+    const current = args[index];
+    if (current === "--repo") {
+      parsed.repo = args[index + 1];
+      index += 1;
+      continue;
+    }
+    if (current === "--cloudflare-api-token") {
+      parsed.cloudflareApiToken = args[index + 1];
+      index += 1;
+      continue;
+    }
+    if (current === "--cloudflare-api-token-path") {
+      parsed.cloudflareApiTokenPath = args[index + 1];
+      index += 1;
+      continue;
+    }
+    if (current === "--cloudflare-account-id") {
+      parsed.cloudflareAccountId = args[index + 1];
+      index += 1;
+      continue;
+    }
+    if (current === "--stdin") {
+      parsed.stdin = true;
+      continue;
+    }
+    if (current === "--runtime-url") {
+      parsed.runtimeUrl = args[index + 1];
+      index += 1;
+      continue;
+    }
+    if (current === "--approval-grant-id") {
+      parsed.approvalGrantId = args[index + 1];
+      index += 1;
+      continue;
+    }
+    if (current === "--gateway-bearer-token") {
+      parsed.gatewayBearerToken = args[index + 1];
+      index += 1;
+    }
+  }
+  return parsed;
+}
+
+function readStdin() {
+  return new Promise((resolve, reject) => {
+    let data = "";
+    process.stdin.setEncoding("utf8");
+    process.stdin.on("data", (chunk) => {
+      data += chunk;
+    });
+    process.stdin.on("end", () => resolve(data));
+    process.stdin.on("error", reject);
+  });
+}
+
+function normalizeText(value) {
+  return String(value ?? "").trim();
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/src/core/cloudflare-deploy-secret-sync.js
+++ b/src/core/cloudflare-deploy-secret-sync.js
@@ -1,0 +1,83 @@
+import { validateDeployApprovalGrant } from "./deploy-approval-grant.js";
+
+export const CLOUDFLARE_DEPLOY_ACTIONS_SECRETS = Object.freeze([
+  "CLOUDFLARE_API_TOKEN",
+  "CLOUDFLARE_ACCOUNT_ID"
+]);
+
+export function buildCloudflareDeploySecretSyncPlan(input = {}) {
+  const repo = normalizeText(input.repo);
+  const source = input.source ?? {};
+  const apiToken = normalizeText(source.cloudflareApiToken);
+  const accountId = normalizeText(source.cloudflareAccountId);
+  const issues = [];
+
+  if (!repo) {
+    issues.push("repo is required");
+  }
+  if (!apiToken) {
+    issues.push("source.cloudflareApiToken is required");
+  }
+  if (!accountId) {
+    issues.push("source.cloudflareAccountId is required");
+  }
+
+  if (issues.length > 0) {
+    return { ok: false, issues };
+  }
+
+  return {
+    ok: true,
+    plan: {
+      repo,
+      secrets: [
+        {
+          name: "CLOUDFLARE_API_TOKEN",
+          value: apiToken
+        },
+        {
+          name: "CLOUDFLARE_ACCOUNT_ID",
+          value: accountId
+        }
+      ]
+    }
+  };
+}
+
+export async function executeCloudflareDeploySecretSync(input = {}) {
+  const planResult = buildCloudflareDeploySecretSyncPlan(input);
+  if (!planResult.ok) {
+    return planResult;
+  }
+
+  const approvalValidation = validateDeployApprovalGrant({
+    approvalGrant: input.approvalGrant,
+    repositoryInput: input.repo,
+    now: input.now
+  });
+  if (!approvalValidation.ok) {
+    return approvalValidation;
+  }
+
+  const runner = input.runner;
+  if (typeof runner !== "function") {
+    return { ok: false, issues: ["runner is required"] };
+  }
+
+  const synced = [];
+  for (const secret of planResult.plan.secrets) {
+    synced.push(await runner(secret));
+  }
+
+  return {
+    ok: true,
+    result: {
+      repo: planResult.plan.repo,
+      synced
+    }
+  };
+}
+
+function normalizeText(value) {
+  return String(value ?? "").trim();
+}

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -44,6 +44,11 @@ export {
 export { renderPasskeyOperatorPage } from "./passkey-operator-page.js";
 export { buildButlerReviewSynthesis } from "./butler-review-synthesis.js";
 export { validateDeployApprovalGrant } from "./deploy-approval-grant.js";
+export {
+  CLOUDFLARE_DEPLOY_ACTIONS_SECRETS,
+  buildCloudflareDeploySecretSyncPlan,
+  executeCloudflareDeploySecretSync
+} from "./cloudflare-deploy-secret-sync.js";
 export { requiredCredentialTier, evaluateCredentialBoundary } from "./credential-boundary.js";
 export { resolveRepositoryTarget } from "./repository-resolution.js";
 export { evaluateTargetConfirmationBoundary } from "./target-confirmation.js";

--- a/test/cloudflare-deploy-secret-sync.test.js
+++ b/test/cloudflare-deploy-secret-sync.test.js
@@ -1,0 +1,95 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import {
+  buildCloudflareDeploySecretSyncPlan,
+  executeCloudflareDeploySecretSync
+} from "../src/core/index.js";
+
+const validApprovalGrant = {
+  verified: true,
+  expiresAt: "2099-01-01T00:00:00.000Z",
+  scope: {
+    actionType: "deploy_production",
+    highRiskKind: "deploy_production",
+    repositoryInput: "marushu/vtdd-v2-p"
+  }
+};
+
+test("cloudflare deploy secret sync plan targets Actions deploy secrets", () => {
+  const result = buildCloudflareDeploySecretSyncPlan({
+    repo: "marushu/vtdd-v2-p",
+    source: {
+      cloudflareApiToken: "cf-token-redacted",
+      cloudflareAccountId: "bd82bbc79ce38442976432eaa409e48c"
+    }
+  });
+
+  assert.equal(result.ok, true);
+  assert.deepEqual(
+    result.plan.secrets.map((secret) => secret.name),
+    ["CLOUDFLARE_API_TOKEN", "CLOUDFLARE_ACCOUNT_ID"]
+  );
+});
+
+test("cloudflare deploy secret sync plan fails without token source", () => {
+  const result = buildCloudflareDeploySecretSyncPlan({
+    repo: "marushu/vtdd-v2-p",
+    source: {
+      cloudflareAccountId: "bd82bbc79ce38442976432eaa409e48c"
+    }
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.issues.includes("source.cloudflareApiToken is required"), true);
+});
+
+test("cloudflare deploy secret sync requires deploy_production approval grant", async () => {
+  const result = await executeCloudflareDeploySecretSync({
+    repo: "marushu/vtdd-v2-p",
+    source: {
+      cloudflareApiToken: "cf-token-redacted",
+      cloudflareAccountId: "bd82bbc79ce38442976432eaa409e48c"
+    },
+    approvalGrant: {
+      ...validApprovalGrant,
+      scope: { ...validApprovalGrant.scope, highRiskKind: "github_app_secret_sync" }
+    },
+    runner: async () => ({ synced: true })
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(
+    result.issues.includes("approvalGrant scope.highRiskKind must be deploy_production"),
+    true
+  );
+});
+
+test("cloudflare deploy secret sync calls runner without exposing token", async () => {
+  const calls = [];
+  const result = await executeCloudflareDeploySecretSync({
+    repo: "marushu/vtdd-v2-p",
+    source: {
+      cloudflareApiToken: "cf-token-redacted",
+      cloudflareAccountId: "bd82bbc79ce38442976432eaa409e48c"
+    },
+    approvalGrant: validApprovalGrant,
+    runner: async (secret) => {
+      calls.push(secret);
+      return { name: secret.name, synced: true };
+    }
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(calls.length, 2);
+  assert.equal(calls[0].name, "CLOUDFLARE_API_TOKEN");
+  assert.equal(calls[0].value, "cf-token-redacted");
+});
+
+test("cloudflare deploy secret sync docs distinguish Worker and Actions secrets", () => {
+  const doc = fs.readFileSync("docs/setup/cloudflare-deploy-secret-sync.md", "utf8");
+
+  assert.equal(doc.includes("Worker secrets and GitHub Actions secrets are different"), true);
+  assert.equal(doc.includes("does not make it available"), true);
+  assert.equal(doc.includes("scripts/sync-cloudflare-actions-secrets.mjs"), true);
+});

--- a/test/production-deploy-path.test.js
+++ b/test/production-deploy-path.test.js
@@ -28,6 +28,8 @@ test("production deploy doc defines the governed GitHub Actions deploy path", ()
   assert.equal(doc.includes("`CLOUDFLARE_ACCOUNT_ID`"), true);
   assert.equal(doc.includes("`VTDD_GATEWAY_BEARER_TOKEN`"), true);
   assert.equal(doc.includes("hard prerequisites"), true);
+  assert.equal(doc.includes("docs/setup/cloudflare-deploy-secret-sync.md"), true);
+  assert.equal(doc.includes("Worker runtime secrets"), true);
 });
 
 test("deploy-production workflow enforces the MVP production deploy boundary", () => {


### PR DESCRIPTION
## Summary
- Add an explicit operator bootstrap path to sync Cloudflare deploy credentials into GitHub Actions secrets.
- Syncs `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` without printing the token.
- Requires a real `deploy_production` passkey approval grant before secret mutation.
- Documents that Worker runtime secrets and GitHub Actions secrets are different surfaces.

## Issue Mapping
- Fixes #35.

## Non-goals
- Does not create Cloudflare API tokens without an existing Cloudflare credential.
- Does not read back an already-created Cloudflare token value.
- Does not deploy production.
- Does not weaken `GO + passkey`.

## Verification
- `node --test test/cloudflare-deploy-secret-sync.test.js test/production-deploy-path.test.js`
- `npm test`

## Live Context
- Existing logs show `CLOUDFLARE_API_TOKEN` was uploaded as a Worker secret, but that does not make it available to GitHub Actions. This PR creates the missing Actions-secret sync path so future tokens are not stranded on the Worker runtime surface.
