### PR TITLE
Restore production D1 memory binding

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -50,6 +50,7 @@ jobs:
           VTDD_GATEWAY_BEARER_TOKEN: ${{ secrets.VTDD_GATEWAY_BEARER_TOKEN }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_D1_DATABASE_ID: ${{ secrets.CLOUDFLARE_D1_DATABASE_ID }}
         shell: bash
         run: |
           missing=0
@@ -63,6 +64,10 @@ jobs:
           fi
           if [ -z "$CLOUDFLARE_ACCOUNT_ID" ]; then
             echo "Missing required Actions secret: CLOUDFLARE_ACCOUNT_ID"
+            missing=1
+          fi
+          if [ -z "$CLOUDFLARE_D1_DATABASE_ID" ]; then
+            echo "Missing required Actions secret: CLOUDFLARE_D1_DATABASE_ID"
             missing=1
           fi
           if [ "$missing" -ne 0 ]; then
@@ -93,6 +98,21 @@ jobs:
       - name: Run tests
         run: npm test
 
+      - name: Generate production Wrangler config
+        env:
+          CLOUDFLARE_D1_DATABASE_ID: ${{ secrets.CLOUDFLARE_D1_DATABASE_ID }}
+          CLOUDFLARE_D1_DATABASE_NAME: ${{ vars.CLOUDFLARE_D1_DATABASE_NAME || 'vtdd-memory' }}
+        shell: bash
+        run: |
+          cp wrangler.toml wrangler.production.generated.toml
+          cat >> wrangler.production.generated.toml <<EOF
+
+          [[env.production.d1_databases]]
+          binding = "VTDD_MEMORY_D1"
+          database_name = "$CLOUDFLARE_D1_DATABASE_NAME"
+          database_id = "$CLOUDFLARE_D1_DATABASE_ID"
+          EOF
+
       - name: Deploy to Cloudflare Workers
         uses: cloudflare/wrangler-action@v3
         env:
@@ -100,4 +120,4 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           wranglerVersion: "4.83.0"
-          command: deploy --env production
+          command: deploy --config wrangler.production.generated.toml --env production

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 node_modules/
 credentials/
+wrangler.local.toml
+wrangler.*.local.toml
+wrangler.production.generated.toml

--- a/docs/mvp/production-deploy-path.md
+++ b/docs/mvp/production-deploy-path.md
@@ -47,6 +47,11 @@ persistence, and approval grant retrieval. A production deploy that drops this
 binding breaks `GO + passkey` issuance and therefore blocks high-risk runtime
 operations.
 
+Because this repository is public and reusable, owner-specific Cloudflare
+resource identifiers must not be committed to the shared `wrangler.toml`.
+Each operator must bind their own D1 database in their deployment configuration
+before deploying production.
+
 ## Approval Boundary (`GO + passkey`)
 
 `deploy-production` workflow is manual (`workflow_dispatch`) and requires:

--- a/docs/mvp/production-deploy-path.md
+++ b/docs/mvp/production-deploy-path.md
@@ -38,6 +38,15 @@ Use `docs/setup/cloudflare-deploy-secret-sync.md` as the canonical operator
 sync path. Do not treat Worker runtime secrets as equivalent to GitHub Actions
 secrets.
 
+### 3. Worker Bindings
+
+Production must bind the VTDD memory D1 database as `VTDD_MEMORY_D1`.
+
+This binding is required for real passkey registration, approval challenge
+persistence, and approval grant retrieval. A production deploy that drops this
+binding breaks `GO + passkey` issuance and therefore blocks high-risk runtime
+operations.
+
 ## Approval Boundary (`GO + passkey`)
 
 `deploy-production` workflow is manual (`workflow_dispatch`) and requires:

--- a/docs/mvp/production-deploy-path.md
+++ b/docs/mvp/production-deploy-path.md
@@ -26,6 +26,7 @@ Set repository or environment secrets:
 
 - `CLOUDFLARE_API_TOKEN`
 - `CLOUDFLARE_ACCOUNT_ID`
+- `CLOUDFLARE_D1_DATABASE_ID`
 - `VTDD_GATEWAY_BEARER_TOKEN`
 
 The token should be scoped to minimum required Worker deploy permissions.
@@ -51,6 +52,11 @@ Because this repository is public and reusable, owner-specific Cloudflare
 resource identifiers must not be committed to the shared `wrangler.toml`.
 Each operator must bind their own D1 database in their deployment configuration
 before deploying production.
+
+For local/operator deploys, store owner-specific bindings in an ignored file
+such as `wrangler.production.local.toml`. For GitHub Actions deploys, store the
+D1 database id in `CLOUDFLARE_D1_DATABASE_ID`; the workflow generates an
+uncommitted `wrangler.production.generated.toml` at deploy time.
 
 ## Approval Boundary (`GO + passkey`)
 

--- a/test/production-deploy-path.test.js
+++ b/test/production-deploy-path.test.js
@@ -11,6 +11,7 @@ const WORKFLOW_PATH = path.join(
   "deploy-production.yml"
 );
 const WRANGLER_PATH = path.join(process.cwd(), "wrangler.toml");
+const OWNER_D1_DATABASE_ID = "a544d950-4a6a-4c6f-87e7-4671fe87b70d";
 
 test("production deploy doc defines the governed GitHub Actions deploy path", () => {
   const doc = fs.readFileSync(DOC_PATH, "utf8");
@@ -32,6 +33,8 @@ test("production deploy doc defines the governed GitHub Actions deploy path", ()
   assert.equal(doc.includes("Worker runtime secrets"), true);
   assert.equal(doc.includes("`VTDD_MEMORY_D1`"), true);
   assert.equal(doc.includes("real passkey registration"), true);
+  assert.equal(doc.includes("owner-specific Cloudflare"), true);
+  assert.equal(doc.includes("must not be committed"), true);
 });
 
 test("deploy-production workflow enforces the MVP production deploy boundary", () => {
@@ -66,11 +69,6 @@ test("wrangler config fixes worker runtime entry and production environment", ()
   assert.equal(wrangler.includes('main = "src/worker.js"'), true);
   assert.equal(wrangler.includes("[env.production]"), true);
   assert.equal(wrangler.includes('name = "vtdd-v2-mvp"'), true);
-  assert.equal(wrangler.includes("[[env.production.d1_databases]]"), true);
-  assert.equal(wrangler.includes('binding = "VTDD_MEMORY_D1"'), true);
-  assert.equal(wrangler.includes('database_name = "vtdd-memory"'), true);
-  assert.equal(
-    wrangler.includes('database_id = "a544d950-4a6a-4c6f-87e7-4671fe87b70d"'),
-    true
-  );
+  assert.equal(wrangler.includes(OWNER_D1_DATABASE_ID), false);
+  assert.equal(wrangler.includes("database_id"), false);
 });

--- a/test/production-deploy-path.test.js
+++ b/test/production-deploy-path.test.js
@@ -11,6 +11,7 @@ const WORKFLOW_PATH = path.join(
   "deploy-production.yml"
 );
 const WRANGLER_PATH = path.join(process.cwd(), "wrangler.toml");
+const GITIGNORE_PATH = path.join(process.cwd(), ".gitignore");
 const OWNER_D1_DATABASE_ID = "a544d950-4a6a-4c6f-87e7-4671fe87b70d";
 
 test("production deploy doc defines the governed GitHub Actions deploy path", () => {
@@ -27,6 +28,7 @@ test("production deploy doc defines the governed GitHub Actions deploy path", ()
   assert.equal(doc.includes("`highRiskKind=deploy_production`"), true);
   assert.equal(doc.includes("`CLOUDFLARE_API_TOKEN`"), true);
   assert.equal(doc.includes("`CLOUDFLARE_ACCOUNT_ID`"), true);
+  assert.equal(doc.includes("`CLOUDFLARE_D1_DATABASE_ID`"), true);
   assert.equal(doc.includes("`VTDD_GATEWAY_BEARER_TOKEN`"), true);
   assert.equal(doc.includes("hard prerequisites"), true);
   assert.equal(doc.includes("docs/setup/cloudflare-deploy-secret-sync.md"), true);
@@ -35,6 +37,8 @@ test("production deploy doc defines the governed GitHub Actions deploy path", ()
   assert.equal(doc.includes("real passkey registration"), true);
   assert.equal(doc.includes("owner-specific Cloudflare"), true);
   assert.equal(doc.includes("must not be committed"), true);
+  assert.equal(doc.includes("`wrangler.production.local.toml`"), true);
+  assert.equal(doc.includes("`wrangler.production.generated.toml`"), true);
 });
 
 test("deploy-production workflow enforces the MVP production deploy boundary", () => {
@@ -50,6 +54,7 @@ test("deploy-production workflow enforces the MVP production deploy boundary", (
   assert.equal(workflow.includes("Missing required Actions secret: VTDD_GATEWAY_BEARER_TOKEN"), true);
   assert.equal(workflow.includes("Missing required Actions secret: CLOUDFLARE_API_TOKEN"), true);
   assert.equal(workflow.includes("Missing required Actions secret: CLOUDFLARE_ACCOUNT_ID"), true);
+  assert.equal(workflow.includes("Missing required Actions secret: CLOUDFLARE_D1_DATABASE_ID"), true);
   assert.equal(workflow.includes("Validate real passkey approval grant"), true);
   assert.equal(
     workflow.includes('VTDD_GATEWAY_BEARER_TOKEN: ${{ secrets.VTDD_GATEWAY_BEARER_TOKEN }}'),
@@ -61,7 +66,14 @@ test("deploy-production workflow enforces the MVP production deploy boundary", (
     workflow.includes("CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}"),
     true
   );
-  assert.equal(workflow.includes('command: deploy --env production'), true);
+  assert.equal(workflow.includes("Generate production Wrangler config"), true);
+  assert.equal(workflow.includes("[[env.production.d1_databases]]"), true);
+  assert.equal(workflow.includes('binding = "VTDD_MEMORY_D1"'), true);
+  assert.equal(workflow.includes('database_id = "$CLOUDFLARE_D1_DATABASE_ID"'), true);
+  assert.equal(
+    workflow.includes("command: deploy --config wrangler.production.generated.toml --env production"),
+    true
+  );
 });
 
 test("wrangler config fixes worker runtime entry and production environment", () => {
@@ -71,4 +83,11 @@ test("wrangler config fixes worker runtime entry and production environment", ()
   assert.equal(wrangler.includes('name = "vtdd-v2-mvp"'), true);
   assert.equal(wrangler.includes(OWNER_D1_DATABASE_ID), false);
   assert.equal(wrangler.includes("database_id"), false);
+});
+
+test("owner-specific wrangler config files are ignored", () => {
+  const gitignore = fs.readFileSync(GITIGNORE_PATH, "utf8");
+  assert.equal(gitignore.includes("wrangler.local.toml"), true);
+  assert.equal(gitignore.includes("wrangler.*.local.toml"), true);
+  assert.equal(gitignore.includes("wrangler.production.generated.toml"), true);
 });

--- a/test/production-deploy-path.test.js
+++ b/test/production-deploy-path.test.js
@@ -30,6 +30,8 @@ test("production deploy doc defines the governed GitHub Actions deploy path", ()
   assert.equal(doc.includes("hard prerequisites"), true);
   assert.equal(doc.includes("docs/setup/cloudflare-deploy-secret-sync.md"), true);
   assert.equal(doc.includes("Worker runtime secrets"), true);
+  assert.equal(doc.includes("`VTDD_MEMORY_D1`"), true);
+  assert.equal(doc.includes("real passkey registration"), true);
 });
 
 test("deploy-production workflow enforces the MVP production deploy boundary", () => {
@@ -64,4 +66,11 @@ test("wrangler config fixes worker runtime entry and production environment", ()
   assert.equal(wrangler.includes('main = "src/worker.js"'), true);
   assert.equal(wrangler.includes("[env.production]"), true);
   assert.equal(wrangler.includes('name = "vtdd-v2-mvp"'), true);
+  assert.equal(wrangler.includes("[[env.production.d1_databases]]"), true);
+  assert.equal(wrangler.includes('binding = "VTDD_MEMORY_D1"'), true);
+  assert.equal(wrangler.includes('database_name = "vtdd-memory"'), true);
+  assert.equal(
+    wrangler.includes('database_id = "a544d950-4a6a-4c6f-87e7-4671fe87b70d"'),
+    true
+  );
 });

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -4,8 +4,3 @@ compatibility_date = "2026-04-15"
 
 [env.production]
 name = "vtdd-v2-mvp"
-
-[[env.production.d1_databases]]
-binding = "VTDD_MEMORY_D1"
-database_name = "vtdd-memory"
-database_id = "a544d950-4a6a-4c6f-87e7-4671fe87b70d"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -4,3 +4,8 @@ compatibility_date = "2026-04-15"
 
 [env.production]
 name = "vtdd-v2-mvp"
+
+[[env.production.d1_databases]]
+binding = "VTDD_MEMORY_D1"
+database_name = "vtdd-memory"
+database_id = "a544d950-4a6a-4c6f-87e7-4671fe87b70d"


### PR DESCRIPTION
## Summary
- Keep owner-specific Cloudflare D1 IDs out of public `wrangler.toml`.
- Add ignored local Wrangler config support for operator-owned production bindings.
- Require `CLOUDFLARE_D1_DATABASE_ID` in the production deploy workflow and generate an uncommitted Wrangler config at deploy time.
- Document that `VTDD_MEMORY_D1` is required for real passkey registration/approval grant persistence.

## Issue / Scope
- Supports #35 production runtime recovery for `GO + passkey` and deploy-bound execution.
- This PR is config/docs/test only. It does not deploy, mutate secrets, or claim end-to-end VTDD completion.

## Verification
- `npm test`
- 289 pass / 0 fail

## E2E Status
- Not yet re-run live. After merge, set `CLOUDFLARE_D1_DATABASE_ID` as a GitHub Actions secret, run production deploy, then verify `/v2/approval/passkey/operator` and `/v2/action/execute` live.