### PR TITLE
Mint GitHub App token for remote executor

### DIFF
--- a/src/core/github-app-repository-index.js
+++ b/src/core/github-app-repository-index.js
@@ -14,7 +14,7 @@ export async function resolveGatewayAliasRegistryFromGitHubApp({ policyInput, en
   const providedAliasRegistry = normalizeAliasRegistry(policyInput?.aliasRegistry);
   const fetchImpl = resolveGitHubFetch(env);
   const apiBaseUrl = normalizeApiBaseUrl(env?.GITHUB_API_BASE_URL);
-  const tokenResolution = await resolveInstallationToken({ env, fetchImpl, apiBaseUrl });
+  const tokenResolution = await resolveGitHubAppInstallationToken({ env, fetchImpl, apiBaseUrl });
   if (!tokenResolution.ok) {
     return {
       aliasRegistry: providedAliasRegistry,
@@ -46,7 +46,9 @@ export async function resolveGatewayAliasRegistryFromGitHubApp({ policyInput, en
   };
 }
 
-async function resolveInstallationToken({ env, fetchImpl, apiBaseUrl }) {
+export async function resolveGitHubAppInstallationToken({ env, fetchImpl, apiBaseUrl } = {}) {
+  const resolvedFetchImpl = fetchImpl ?? resolveGitHubFetch(env);
+  const resolvedApiBaseUrl = normalizeApiBaseUrl(apiBaseUrl ?? env?.GITHUB_API_BASE_URL);
   const enforceMintedToken = toBoolean(env?.GITHUB_APP_ENFORCE_MINTED_INSTALLATION_TOKEN);
   const appId = normalizeText(env?.GITHUB_APP_ID);
   const installationId = normalizeText(env?.GITHUB_APP_INSTALLATION_ID);
@@ -75,8 +77,8 @@ async function resolveInstallationToken({ env, fetchImpl, apiBaseUrl }) {
       installationId,
       privateKey,
       env,
-      fetchImpl,
-      apiBaseUrl,
+      fetchImpl: resolvedFetchImpl,
+      apiBaseUrl: resolvedApiBaseUrl,
       nowSeconds
     });
     if (!minted.ok) {

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -159,7 +159,10 @@ export {
   resolveGeminiReviewTrigger
 } from "./gemini-pr-review.js";
 export { runMvpGateway } from "./mvp-gateway.js";
-export { resolveGatewayAliasRegistryFromGitHubApp } from "./github-app-repository-index.js";
+export {
+  resolveGatewayAliasRegistryFromGitHubApp,
+  resolveGitHubAppInstallationToken
+} from "./github-app-repository-index.js";
 export {
   WorkflowStage,
   WorkflowEvent,

--- a/src/core/remote-codex-executor.js
+++ b/src/core/remote-codex-executor.js
@@ -1,4 +1,5 @@
 import { ActorRole } from "./types.js";
+import { resolveGitHubAppInstallationToken } from "./github-app-repository-index.js";
 
 export const REMOTE_CODEX_WORKFLOW_FILE = "remote-codex-executor.yml";
 
@@ -563,6 +564,21 @@ async function resolveGitHubExecutionToken(env) {
   );
   if (directToken) {
     return { ok: true, value: directToken };
+  }
+
+  const mintedToken = await resolveGitHubAppInstallationToken({
+    env,
+    fetchImpl: typeof env?.GITHUB_API_FETCH === "function" ? env.GITHUB_API_FETCH.bind(env) : fetch,
+    apiBaseUrl: normalizeText(env?.GITHUB_API_BASE_URL) || "https://api.github.com"
+  });
+  if (mintedToken.ok) {
+    return { ok: true, value: mintedToken.token };
+  }
+  if (mintedToken.warning) {
+    return {
+      ok: false,
+      reason: mintedToken.warning
+    };
   }
 
   const provider = env?.GITHUB_APP_INSTALLATION_TOKEN_PROVIDER;

--- a/test/remote-codex-executor.test.js
+++ b/test/remote-codex-executor.test.js
@@ -92,6 +92,65 @@ test("remote Codex execution default dispatch posts bounded @codex GitHub commen
   assert.equal(body.includes("OPENAI_API_KEY"), false);
 });
 
+test("remote Codex execution mints GitHub App installation token from worker runtime credentials", async () => {
+  const calls = [];
+  const dispatched = await dispatchRemoteCodexExecution({
+    payload: {
+      actorRole: ActorRole.BUTLER,
+      issueContext: { issueNumber: 6 },
+      policyInput: {
+        approvalPhrase: "GO",
+        targetConfirmed: true,
+        approvalScopeMatched: true,
+        runtimeTruth: {
+          runtimeState: {
+            activeBranch: "codex/issue-6"
+          }
+        }
+      }
+    },
+    gatewayResult: {
+      repository: "sample-org/vtdd-v2",
+      executionContinuity: {
+        codexGoal: "open_pr"
+      }
+    },
+    env: {
+      GITHUB_APP_ID: "67890",
+      GITHUB_APP_INSTALLATION_ID: "24680",
+      GITHUB_APP_PRIVATE_KEY: "-----BEGIN PRIVATE KEY-----\nplaceholder\n-----END PRIVATE KEY-----",
+      GITHUB_APP_JWT_PROVIDER: async () => "app_jwt_token_for_tests",
+      GITHUB_API_FETCH: async (url, init) => {
+        calls.push({ url, init });
+        if (String(url).includes("/app/installations/24680/access_tokens")) {
+          return new Response(
+            JSON.stringify({
+              token: "ghs_minted_executor_token",
+              expires_at: "2026-04-25T15:00:00Z"
+            }),
+            { status: 201, headers: { "content-type": "application/json" } }
+          );
+        }
+        return new Response(
+          JSON.stringify({
+            id: 123,
+            html_url: "https://github.com/sample-org/vtdd-v2/issues/6#issuecomment-123"
+          }),
+          { status: 201, headers: { "content-type": "application/json" } }
+        );
+      }
+    }
+  });
+
+  assert.equal(dispatched.ok, true);
+  assert.equal(dispatched.execution.transport, RemoteCodexExecutorTransport.CODEX_CLOUD_GITHUB_COMMENT);
+  assert.equal(calls.length, 2);
+  assert.equal(calls[0].url.includes("/app/installations/24680/access_tokens"), true);
+  assert.equal(calls[0].init.headers.authorization, "Bearer app_jwt_token_for_tests");
+  assert.equal(calls[1].url.includes("/repos/sample-org/vtdd-v2/issues/6/comments"), true);
+  assert.equal(calls[1].init.headers.authorization, "Bearer ghs_minted_executor_token");
+});
+
 test("remote Codex API-backed execution dispatch posts workflow_dispatch to GitHub", async () => {
   const calls = [];
   const dispatched = await dispatchRemoteCodexExecution({


### PR DESCRIPTION
## Summary
- Reuse the GitHub App installation token minting path for remote Codex execution.
- Let `/v2/action/execute` use Worker runtime `GITHUB_APP_ID`, `GITHUB_APP_INSTALLATION_ID`, and `GITHUB_APP_PRIVATE_KEY` instead of requiring a pre-provided installation token.
- Add regression coverage for Codex Cloud GitHub comment dispatch using a minted GitHub App token.

## Issue / Scope
- Supports #6 remote Codex executor runtime connection.
- This PR does not deploy, mutate secrets, merge, or claim end-to-end completion.

## Verification
- `npm test`
- 290 pass / 0 fail

## E2E Status
- Not yet live verified. After merge and production deploy, rerun `/v2/action/execute` and confirm the GitHub Issue delegation comment is created.