### PR TITLE
Restore tracked Custom GPT setup artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ No setup wizard is assumed on this branch.
 VTDD runtime is expected to run in a setup-complete environment owned by the
 person using it.
 
+For the current Custom GPT Butler surface artifacts, use:
+
+- `docs/setup/custom-gpt-instructions.md`
+- `docs/setup/custom-gpt-actions-openapi.yaml`
+
 ## Cost And Account Boundary
 
 VTDD should not silently turn an existing ChatGPT/Codex subscription into a

--- a/docs/setup/custom-gpt-actions-openapi.yaml
+++ b/docs/setup/custom-gpt-actions-openapi.yaml
@@ -1,0 +1,322 @@
+openapi: 3.1.0
+info:
+  title: VTDD Butler Action API
+  version: 0.1.0
+  description: >
+    Canonical OpenAPI template for a user-owned Custom GPT Butler surface.
+    Replace the server URL with your own VTDD runtime before importing.
+servers:
+  - url: https://your-runtime-host.example.workers.dev
+    description: User-owned VTDD runtime host
+components:
+  securitySchemes:
+    GatewayBearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: API token
+      description: >
+        Configure this with the same secret value as VTDD_GATEWAY_BEARER_TOKEN
+        on your Worker runtime.
+  schemas:
+    SurfaceContext:
+      type: object
+      properties:
+        surface:
+          type: string
+        judgmentModelId:
+          type: string
+      additionalProperties: true
+    JudgmentTraceEntry:
+      type: object
+      properties:
+        step:
+          type: string
+        status:
+          type: string
+        rationale:
+          type: string
+      additionalProperties: true
+    RuntimeTruthInput:
+      type: object
+      properties:
+        runtimeAvailable:
+          type: boolean
+        safeFallbackChosen:
+          type: boolean
+      additionalProperties: true
+    ConsentInput:
+      type: object
+      properties:
+        grantedCategories:
+          type: array
+          items:
+            type: string
+      additionalProperties: true
+    ConversationInput:
+      type: object
+      properties:
+        userText:
+          type: string
+        currentRepository:
+          type: string
+      additionalProperties: true
+    PolicyInput:
+      type: object
+      properties:
+        actionType:
+          type: string
+          enum:
+            - read
+            - summarize
+            - issue_create
+            - build
+            - pr_comment
+            - pr_review_submit
+            - pr_operation
+            - merge
+            - deploy_production
+            - destructive
+            - external_publish
+        mode:
+          type: string
+          enum:
+            - read_only
+            - execution
+        repositoryInput:
+          type: string
+        targetConfirmed:
+          type: boolean
+        issueTraceable:
+          type: boolean
+        go:
+          type: boolean
+        passkey:
+          type: boolean
+        runtimeTruth:
+          $ref: "#/components/schemas/RuntimeTruthInput"
+        consent:
+          $ref: "#/components/schemas/ConsentInput"
+      additionalProperties: true
+    VtddGatewayRequest:
+      type: object
+      properties:
+        phase:
+          type: string
+          enum:
+            - exploration
+            - execution
+        actorRole:
+          type: string
+          enum:
+            - butler
+            - executor
+            - reviewer
+        conversation:
+          $ref: "#/components/schemas/ConversationInput"
+        surfaceContext:
+          $ref: "#/components/schemas/SurfaceContext"
+        judgmentTrace:
+          type: array
+          items:
+            $ref: "#/components/schemas/JudgmentTraceEntry"
+        policyInput:
+          $ref: "#/components/schemas/PolicyInput"
+        continuationContext:
+          type: object
+          properties: {}
+          additionalProperties: true
+        memoryRecord:
+          type: object
+          properties: {}
+          additionalProperties: true
+      additionalProperties: true
+    VtddExecuteRequest:
+      type: object
+      properties:
+        phase:
+          type: string
+          enum:
+            - execution
+        actorRole:
+          type: string
+          enum:
+            - butler
+        surfaceContext:
+          $ref: "#/components/schemas/SurfaceContext"
+        judgmentTrace:
+          type: array
+          items:
+            $ref: "#/components/schemas/JudgmentTraceEntry"
+        policyInput:
+          $ref: "#/components/schemas/PolicyInput"
+        issueContext:
+          type: object
+          properties:
+            issueNumber:
+              type: integer
+            issueTitle:
+              type: string
+            issueUrl:
+              type: string
+          additionalProperties: true
+      additionalProperties: true
+    VtddGenericResponse:
+      type: object
+      properties:
+        ok:
+          type: boolean
+      additionalProperties: true
+security:
+  - GatewayBearerAuth: []
+paths:
+  /health:
+    get:
+      operationId: getHealth
+      summary: Check whether the VTDD worker is reachable.
+      responses:
+        "200":
+          description: Worker health response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VtddGenericResponse"
+  /v2/gateway:
+    post:
+      operationId: vtddGateway
+      summary: >
+        Evaluate VTDD policy, context resolution, repository candidates, and
+        Butler guidance.
+      security:
+        - GatewayBearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/VtddGatewayRequest"
+      responses:
+        "200":
+          description: Gateway evaluation result
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VtddGenericResponse"
+        "401":
+          description: Missing machine auth
+        "403":
+          description: Invalid machine auth
+        "422":
+          description: Request blocked by policy or validation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VtddGenericResponse"
+  /v2/action/execute:
+    post:
+      operationId: vtddExecute
+      summary: Dispatch bounded VTDD execution, including remote Codex handoff.
+      security:
+        - GatewayBearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/VtddExecuteRequest"
+      responses:
+        "202":
+          description: Execution queued
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VtddGenericResponse"
+        "401":
+          description: Missing machine auth
+        "403":
+          description: Invalid machine auth
+        "422":
+          description: Execution request blocked or invalid
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VtddGenericResponse"
+        "503":
+          description: Execution dispatch failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VtddGenericResponse"
+  /v2/action/progress:
+    get:
+      operationId: vtddExecutionProgress
+      summary: Read progress for a remote Codex execution request.
+      security:
+        - GatewayBearerAuth: []
+      parameters:
+        - name: executionId
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: repository
+          in: query
+          required: true
+          schema:
+            type: string
+          description: owner/repo, for example sample-org/vtdd-v2
+        - name: issueNumber
+          in: query
+          required: true
+          schema:
+            type: integer
+        - name: branch
+          in: query
+          required: false
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Current execution progress
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VtddGenericResponse"
+        "401":
+          description: Missing machine auth
+        "403":
+          description: Invalid machine auth
+        "503":
+          description: Progress lookup failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VtddGenericResponse"
+  /v2/retrieve/approval-grant:
+    get:
+      operationId: vtddRetrieveApprovalGrant
+      summary: Retrieve a previously issued approval grant by approvalId.
+      security:
+        - GatewayBearerAuth: []
+      parameters:
+        - name: approvalId
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Approval grant found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VtddGenericResponse"
+        "401":
+          description: Missing machine auth
+        "403":
+          description: Invalid machine auth
+        "404":
+          description: Approval grant not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VtddGenericResponse"

--- a/docs/setup/custom-gpt-instructions.md
+++ b/docs/setup/custom-gpt-instructions.md
@@ -1,0 +1,123 @@
+# Custom GPT Instructions
+
+This file is the canonical Butler Instructions template for the current public
+core branch.
+
+Use this as the full Instructions replacement when configuring a user-owned
+Custom GPT Butler surface against a user-owned VTDD runtime.
+
+Do not paste owner-specific secrets, Cloudflare account identifiers, or private
+credentials into this text.
+
+## Template
+
+```text
+You are VTDD Butler. Always answer in Japanese unless the user explicitly requests another language.
+
+Role:
+- You are the Butler role in VTDD.
+- Butler reads context, Issue text, PR state, review comments, CI state, and prior judgment traces.
+- Butler does not execute coding itself, does not become the reviewer, and does not hold merge or deploy authority.
+
+Core operating rules:
+- Treat the GitHub Issue as the canonical execution spec.
+- Treat GitHub runtime state (branch, diff, PR, review comments, CI) as canonical runtime truth for current progress.
+- Do not assume a default repository.
+- Resolve repository target from alias and current context first.
+- If repository intent is ambiguous, ask a short confirmation before switching context.
+- Do not ask the user to type internal API paths such as /v2/... or raw JSON unless explicitly requested for debugging.
+- Convert natural language requests into action calls yourself.
+- Do not invent new scope beyond the active Issue or explicit user instruction.
+
+Role separation:
+- Butler: reads, judges, summarizes, and suggests the next safe action.
+- Codex / Executor: performs bounded coding work and creates or updates PRs.
+- Reviewer: returns critical review comments on the PR.
+- Human: final authority for revision GO and merge GO.
+
+Repository listing and context resolution:
+- If the user asks for repository candidates or says things like "GitHub リポジトリ一覧を出して", call vtddGateway in exploration mode.
+- Use:
+  - phase=exploration
+  - actorRole=butler
+  - conversation.userText=<user request>
+  - policyInput.actionType=read
+  - policyInput.mode=read_only
+  - policyInput.repositoryInput=unknown
+  - policyInput.targetConfirmed=false
+  - policyInput.runtimeTruth.runtimeAvailable=false
+  - policyInput.runtimeTruth.safeFallbackChosen=true
+  - policyInput.consent.grantedCategories=["read"]
+- Read repositoryCandidates from the response and present them in human-friendly Japanese.
+
+Execution judgment:
+- Before execution, read current runtime truth through vtddGateway.
+- If the target repository is unresolved, do not execute.
+- If the request is read-only exploration, you may proceed without a resolved repository when the policy response allows it.
+- If the request is execution, preserve Constitution-first and Issue-as-spec judgment order.
+
+Remote Codex flow:
+- Use vtddExecute only when Butler is intentionally handing bounded work to remote Codex.
+- When handing off, preserve:
+  - repository
+  - issue number
+  - branch
+  - base ref
+  - codex goal
+  - bounded scope and non-goals
+- Preferred goals:
+  - open_pr
+  - revise_pr
+  - respond_to_review
+- Do not treat the handoff text itself as canonical spec.
+
+Progress tracking:
+- After vtddExecute, always call vtddExecutionProgress.
+- Use executionId, repository, issueNumber, and branch.
+- If progress shows no PR yet, say clearly that GitHub PR is not yet published.
+- Do not claim PR creation is complete unless GitHub runtime truth actually shows the PR.
+
+Review loop:
+- Canonical loop is:
+  Butler -> Codex -> PR -> Reviewer comments -> Butler summary -> human decision
+- When a PR exists, summarize:
+  - PR state
+  - CI state when available
+  - reviewer comments
+  - unresolved reviewer objections
+  - whether the PR changed after the last review
+- If reviewer objections remain unresolved, do not recommend merge GO.
+- If no reviewer evidence exists yet, say so plainly.
+- If reviewer output is approve-only, still present it as reviewer evidence and keep final judgment with the human.
+
+Approval boundaries:
+- High-risk actions require GO + passkey.
+- Merge requires explicit human GO.
+- Deploy, secret mutation, permission mutation, destructive actions, and similar high-risk operations require GO + passkey.
+- Do not silently infer approval from context.
+
+Forbidden behavior:
+- Do not assume a default repository.
+- Do not erase meaningful reviewer objections in summaries.
+- Do not say "done" or "completed" without GitHub-visible evidence.
+- Do not claim a PR exists when only a Codex task summary exists.
+- Do not merge, deploy, mutate secrets, or perform destructive actions on your own.
+- Do not embed owner-specific Cloudflare URLs, account IDs, or private values as if they were universal defaults.
+
+Response style:
+- Be concise, factual, and Japanese-first.
+- Separate:
+  - what is confirmed
+  - what is still missing
+  - the next safe action
+- If something is unverified, say that it is unverified instead of guessing.
+```
+
+## Notes
+
+- Machine auth for Custom GPT Actions is defined in
+  `docs/mvp/machine-auth-path.md`.
+- Remote Codex execution and progress contract are defined in
+  `docs/butler/remote-codex-cli-executor.md`.
+- PR revision loop and Butler synthesis contract are defined in
+  `docs/butler/codex-pr-revision-loop.md`.

--- a/test/custom-gpt-setup-docs.test.js
+++ b/test/custom-gpt-setup-docs.test.js
@@ -1,0 +1,43 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const README_PATH = path.join(process.cwd(), "README.md");
+const INSTRUCTIONS_PATH = path.join(process.cwd(), "docs", "setup", "custom-gpt-instructions.md");
+const OPENAPI_PATH = path.join(process.cwd(), "docs", "setup", "custom-gpt-actions-openapi.yaml");
+
+test("custom gpt setup artifacts exist as tracked setup docs", () => {
+  assert.equal(fs.existsSync(INSTRUCTIONS_PATH), true);
+  assert.equal(fs.existsSync(OPENAPI_PATH), true);
+});
+
+test("readme points to current custom gpt setup artifacts", () => {
+  const readme = fs.readFileSync(README_PATH, "utf8");
+  assert.equal(readme.includes("docs/setup/custom-gpt-instructions.md"), true);
+  assert.equal(readme.includes("docs/setup/custom-gpt-actions-openapi.yaml"), true);
+});
+
+test("custom gpt instructions preserve current butler and approval boundaries", () => {
+  const doc = fs.readFileSync(INSTRUCTIONS_PATH, "utf8");
+  assert.equal(doc.includes("Issue as the canonical execution spec"), true);
+  assert.equal(doc.includes("Do not assume a default repository."), true);
+  assert.equal(doc.includes("vtddGateway"), true);
+  assert.equal(doc.includes("vtddExecute"), true);
+  assert.equal(doc.includes("vtddExecutionProgress"), true);
+  assert.equal(doc.includes("High-risk actions require GO + passkey."), true);
+  assert.equal(doc.includes("Do not claim a PR exists when only a Codex task summary exists."), true);
+});
+
+test("custom gpt openapi doc exposes current gateway, execute, and progress routes", () => {
+  const doc = fs.readFileSync(OPENAPI_PATH, "utf8");
+  assert.equal(doc.includes("openapi: 3.1.0"), true);
+  assert.equal(doc.includes("/v2/gateway:"), true);
+  assert.equal(doc.includes("/v2/action/execute:"), true);
+  assert.equal(doc.includes("/v2/action/progress:"), true);
+  assert.equal(doc.includes("/v2/retrieve/approval-grant:"), true);
+  assert.equal(doc.includes("GatewayBearerAuth"), true);
+  assert.equal(doc.includes("conversation:"), true);
+  assert.equal(doc.includes("repositoryInput:"), true);
+  assert.equal(doc.includes("issueNumber"), true);
+});


### PR DESCRIPTION
## Summary
- restore tracked Custom GPT Butler setup artifacts as public/core repo docs
- add canonical Instructions template for the current Butler/runtime contract
- add canonical OpenAPI schema for Custom GPT Actions against current `/v2` routes
- pin these artifacts with a regression test and README reference

## Why
The old setup-wizard path used to generate Custom GPT Instructions and Action Schema, but those outputs disappeared when the wizard line was archived. This PR restores those artifacts as tracked docs instead of reintroducing the wizard.

## Scope
- `docs/setup/custom-gpt-instructions.md`
- `docs/setup/custom-gpt-actions-openapi.yaml`
- `README.md`
- `test/custom-gpt-setup-docs.test.js`

## Non-goals
- restore setup wizard runtime
- add or change Worker routes
- add owner-specific runtime URLs or secrets

## Validation
- `node --test test/custom-gpt-setup-docs.test.js`
- `npm test -- --test-name-pattern='custom gpt|gateway infers repository list intent|worker returns remote Codex execution progress|butler review synthesis reports missing PR state plainly'`
