### PR TITLE
Harden Custom GPT action schema import

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ For the current Custom GPT Butler surface artifacts, use:
 
 - `docs/setup/custom-gpt-instructions.md`
 - `docs/setup/custom-gpt-actions-openapi.yaml`
+- `docs/setup/custom-gpt-actions-openapi.json`
+
+If the Custom GPT importer rejects the YAML form, use the JSON form instead.
 
 ## Cost And Account Boundary
 

--- a/docs/setup/custom-gpt-actions-openapi.json
+++ b/docs/setup/custom-gpt-actions-openapi.json
@@ -1,0 +1,688 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "VTDD Butler Action API",
+    "version": "0.1.0",
+    "description": "Canonical OpenAPI template for a user-owned Custom GPT Butler surface. Replace the server URL with your own VTDD runtime before importing.\n"
+  },
+  "servers": [
+    {
+      "url": "https://your-runtime-host.example.workers.dev",
+      "description": "User-owned VTDD runtime host"
+    }
+  ],
+  "components": {
+    "securitySchemes": {
+      "GatewayBearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "API token",
+        "description": "Configure this with the same secret value as VTDD_GATEWAY_BEARER_TOKEN on your Worker runtime.\n"
+      }
+    },
+    "schemas": {
+      "SurfaceContext": {
+        "type": "object",
+        "properties": {
+          "surface": {
+            "type": "string"
+          },
+          "judgmentModelId": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": true
+      },
+      "JudgmentTraceEntry": {
+        "type": "object",
+        "properties": {
+          "step": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "rationale": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": true
+      },
+      "RuntimeTruthInput": {
+        "type": "object",
+        "properties": {
+          "runtimeAvailable": {
+            "type": "boolean"
+          },
+          "safeFallbackChosen": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": true
+      },
+      "ConsentInput": {
+        "type": "object",
+        "properties": {
+          "grantedCategories": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "additionalProperties": true
+      },
+      "ConversationInput": {
+        "type": "object",
+        "properties": {
+          "userText": {
+            "type": "string"
+          },
+          "currentRepository": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": true
+      },
+      "PolicyInput": {
+        "type": "object",
+        "properties": {
+          "actionType": {
+            "type": "string",
+            "enum": [
+              "read",
+              "summarize",
+              "issue_create",
+              "build",
+              "pr_comment",
+              "pr_review_submit",
+              "pr_operation",
+              "merge",
+              "deploy_production",
+              "destructive",
+              "external_publish"
+            ]
+          },
+          "mode": {
+            "type": "string",
+            "enum": [
+              "read_only",
+              "execution"
+            ]
+          },
+          "repositoryInput": {
+            "type": "string"
+          },
+          "targetConfirmed": {
+            "type": "boolean"
+          },
+          "issueTraceable": {
+            "type": "boolean"
+          },
+          "go": {
+            "type": "boolean"
+          },
+          "passkey": {
+            "type": "boolean"
+          },
+          "runtimeTruth": {
+            "$ref": "#/components/schemas/RuntimeTruthInput"
+          },
+          "consent": {
+            "$ref": "#/components/schemas/ConsentInput"
+          }
+        },
+        "additionalProperties": true
+      },
+      "VtddGatewayRequest": {
+        "type": "object",
+        "properties": {
+          "phase": {
+            "type": "string",
+            "enum": [
+              "exploration",
+              "execution"
+            ]
+          },
+          "actorRole": {
+            "type": "string",
+            "enum": [
+              "butler",
+              "executor",
+              "reviewer"
+            ]
+          },
+          "conversation": {
+            "type": "object",
+            "properties": {
+              "userText": {
+                "type": "string"
+              },
+              "currentRepository": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": true
+          },
+          "surfaceContext": {
+            "type": "object",
+            "properties": {
+              "surface": {
+                "type": "string"
+              },
+              "judgmentModelId": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": true
+          },
+          "judgmentTrace": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "step": {
+                  "type": "string"
+                },
+                "status": {
+                  "type": "string"
+                },
+                "rationale": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": true
+            }
+          },
+          "policyInput": {
+            "type": "object",
+            "properties": {
+              "actionType": {
+                "type": "string",
+                "enum": [
+                  "read",
+                  "summarize",
+                  "issue_create",
+                  "build",
+                  "pr_comment",
+                  "pr_review_submit",
+                  "pr_operation",
+                  "merge",
+                  "deploy_production",
+                  "destructive",
+                  "external_publish"
+                ]
+              },
+              "mode": {
+                "type": "string",
+                "enum": [
+                  "read_only",
+                  "execution"
+                ]
+              },
+              "repositoryInput": {
+                "type": "string"
+              },
+              "targetConfirmed": {
+                "type": "boolean"
+              },
+              "issueTraceable": {
+                "type": "boolean"
+              },
+              "go": {
+                "type": "boolean"
+              },
+              "passkey": {
+                "type": "boolean"
+              },
+              "runtimeTruth": {
+                "type": "object",
+                "properties": {
+                  "runtimeAvailable": {
+                    "type": "boolean"
+                  },
+                  "safeFallbackChosen": {
+                    "type": "boolean"
+                  }
+                },
+                "additionalProperties": true
+              },
+              "consent": {
+                "type": "object",
+                "properties": {
+                  "grantedCategories": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "additionalProperties": true
+              }
+            },
+            "additionalProperties": true
+          },
+          "continuationContext": {
+            "type": "object",
+            "properties": {
+            },
+            "additionalProperties": true
+          },
+          "memoryRecord": {
+            "type": "object",
+            "properties": {
+            },
+            "additionalProperties": true
+          }
+        },
+        "additionalProperties": true
+      },
+      "VtddExecuteRequest": {
+        "type": "object",
+        "properties": {
+          "phase": {
+            "type": "string",
+            "enum": [
+              "execution"
+            ]
+          },
+          "actorRole": {
+            "type": "string",
+            "enum": [
+              "butler"
+            ]
+          },
+          "surfaceContext": {
+            "type": "object",
+            "properties": {
+              "surface": {
+                "type": "string"
+              },
+              "judgmentModelId": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": true
+          },
+          "judgmentTrace": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "step": {
+                  "type": "string"
+                },
+                "status": {
+                  "type": "string"
+                },
+                "rationale": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": true
+            }
+          },
+          "policyInput": {
+            "type": "object",
+            "properties": {
+              "actionType": {
+                "type": "string",
+                "enum": [
+                  "read",
+                  "summarize",
+                  "issue_create",
+                  "build",
+                  "pr_comment",
+                  "pr_review_submit",
+                  "pr_operation",
+                  "merge",
+                  "deploy_production",
+                  "destructive",
+                  "external_publish"
+                ]
+              },
+              "mode": {
+                "type": "string",
+                "enum": [
+                  "read_only",
+                  "execution"
+                ]
+              },
+              "repositoryInput": {
+                "type": "string"
+              },
+              "targetConfirmed": {
+                "type": "boolean"
+              },
+              "issueTraceable": {
+                "type": "boolean"
+              },
+              "go": {
+                "type": "boolean"
+              },
+              "passkey": {
+                "type": "boolean"
+              },
+              "runtimeTruth": {
+                "type": "object",
+                "properties": {
+                  "runtimeAvailable": {
+                    "type": "boolean"
+                  },
+                  "safeFallbackChosen": {
+                    "type": "boolean"
+                  }
+                },
+                "additionalProperties": true
+              },
+              "consent": {
+                "type": "object",
+                "properties": {
+                  "grantedCategories": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "additionalProperties": true
+              }
+            },
+            "additionalProperties": true
+          },
+          "issueContext": {
+            "type": "object",
+            "properties": {
+              "issueNumber": {
+                "type": "integer"
+              },
+              "issueTitle": {
+                "type": "string"
+              },
+              "issueUrl": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": true
+          }
+        },
+        "additionalProperties": true
+      },
+      "VtddGenericResponse": {
+        "type": "object",
+        "properties": {
+          "ok": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": true
+      }
+    }
+  },
+  "security": [
+    {
+      "GatewayBearerAuth": [
+
+      ]
+    }
+  ],
+  "paths": {
+    "/health": {
+      "get": {
+        "operationId": "getHealth",
+        "summary": "Check whether the VTDD worker is reachable.",
+        "responses": {
+          "200": {
+            "description": "Worker health response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VtddGenericResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/gateway": {
+      "post": {
+        "operationId": "vtddGateway",
+        "summary": "Evaluate VTDD policy, context resolution, repository candidates, and Butler guidance.\n",
+        "security": [
+          {
+            "GatewayBearerAuth": [
+
+            ]
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VtddGatewayRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Gateway evaluation result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VtddGenericResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing machine auth"
+          },
+          "403": {
+            "description": "Invalid machine auth"
+          },
+          "422": {
+            "description": "Request blocked by policy or validation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VtddGenericResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/action/execute": {
+      "post": {
+        "operationId": "vtddExecute",
+        "summary": "Dispatch bounded VTDD execution, including remote Codex handoff.",
+        "security": [
+          {
+            "GatewayBearerAuth": [
+
+            ]
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VtddExecuteRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "202": {
+            "description": "Execution queued",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VtddGenericResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing machine auth"
+          },
+          "403": {
+            "description": "Invalid machine auth"
+          },
+          "422": {
+            "description": "Execution request blocked or invalid",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VtddGenericResponse"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Execution dispatch failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VtddGenericResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/action/progress": {
+      "get": {
+        "operationId": "vtddExecutionProgress",
+        "summary": "Read progress for a remote Codex execution request.",
+        "security": [
+          {
+            "GatewayBearerAuth": [
+
+            ]
+          }
+        ],
+        "parameters": [
+          {
+            "name": "executionId",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "repository",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "owner/repo, for example sample-org/vtdd-v2"
+          },
+          {
+            "name": "issueNumber",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "branch",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Current execution progress",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VtddGenericResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing machine auth"
+          },
+          "403": {
+            "description": "Invalid machine auth"
+          },
+          "503": {
+            "description": "Progress lookup failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VtddGenericResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/retrieve/approval-grant": {
+      "get": {
+        "operationId": "vtddRetrieveApprovalGrant",
+        "summary": "Retrieve a previously issued approval grant by approvalId.",
+        "security": [
+          {
+            "GatewayBearerAuth": [
+
+            ]
+          }
+        ],
+        "parameters": [
+          {
+            "name": "approvalId",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Approval grant found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VtddGenericResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing machine auth"
+          },
+          "403": {
+            "description": "Invalid machine auth"
+          },
+          "404": {
+            "description": "Approval grant not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VtddGenericResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/setup/custom-gpt-actions-openapi.yaml
+++ b/docs/setup/custom-gpt-actions-openapi.yaml
@@ -5,6 +5,8 @@ info:
   description: >
     Canonical OpenAPI template for a user-owned Custom GPT Butler surface.
     Replace the server URL with your own VTDD runtime before importing.
+# If the Custom GPT importer rejects YAML, use the JSON sibling file:
+# docs/setup/custom-gpt-actions-openapi.json
 servers:
   - url: https://your-runtime-host.example.workers.dev
     description: User-owned VTDD runtime host
@@ -112,15 +114,82 @@ components:
             - executor
             - reviewer
         conversation:
-          $ref: "#/components/schemas/ConversationInput"
+          type: object
+          properties:
+            userText:
+              type: string
+            currentRepository:
+              type: string
+          additionalProperties: true
         surfaceContext:
-          $ref: "#/components/schemas/SurfaceContext"
+          type: object
+          properties:
+            surface:
+              type: string
+            judgmentModelId:
+              type: string
+          additionalProperties: true
         judgmentTrace:
           type: array
           items:
-            $ref: "#/components/schemas/JudgmentTraceEntry"
+            type: object
+            properties:
+              step:
+                type: string
+              status:
+                type: string
+              rationale:
+                type: string
+            additionalProperties: true
         policyInput:
-          $ref: "#/components/schemas/PolicyInput"
+          type: object
+          properties:
+            actionType:
+              type: string
+              enum:
+                - read
+                - summarize
+                - issue_create
+                - build
+                - pr_comment
+                - pr_review_submit
+                - pr_operation
+                - merge
+                - deploy_production
+                - destructive
+                - external_publish
+            mode:
+              type: string
+              enum:
+                - read_only
+                - execution
+            repositoryInput:
+              type: string
+            targetConfirmed:
+              type: boolean
+            issueTraceable:
+              type: boolean
+            go:
+              type: boolean
+            passkey:
+              type: boolean
+            runtimeTruth:
+              type: object
+              properties:
+                runtimeAvailable:
+                  type: boolean
+                safeFallbackChosen:
+                  type: boolean
+              additionalProperties: true
+            consent:
+              type: object
+              properties:
+                grantedCategories:
+                  type: array
+                  items:
+                    type: string
+              additionalProperties: true
+          additionalProperties: true
         continuationContext:
           type: object
           properties: {}
@@ -142,13 +211,74 @@ components:
           enum:
             - butler
         surfaceContext:
-          $ref: "#/components/schemas/SurfaceContext"
+          type: object
+          properties:
+            surface:
+              type: string
+            judgmentModelId:
+              type: string
+          additionalProperties: true
         judgmentTrace:
           type: array
           items:
-            $ref: "#/components/schemas/JudgmentTraceEntry"
+            type: object
+            properties:
+              step:
+                type: string
+              status:
+                type: string
+              rationale:
+                type: string
+            additionalProperties: true
         policyInput:
-          $ref: "#/components/schemas/PolicyInput"
+          type: object
+          properties:
+            actionType:
+              type: string
+              enum:
+                - read
+                - summarize
+                - issue_create
+                - build
+                - pr_comment
+                - pr_review_submit
+                - pr_operation
+                - merge
+                - deploy_production
+                - destructive
+                - external_publish
+            mode:
+              type: string
+              enum:
+                - read_only
+                - execution
+            repositoryInput:
+              type: string
+            targetConfirmed:
+              type: boolean
+            issueTraceable:
+              type: boolean
+            go:
+              type: boolean
+            passkey:
+              type: boolean
+            runtimeTruth:
+              type: object
+              properties:
+                runtimeAvailable:
+                  type: boolean
+                safeFallbackChosen:
+                  type: boolean
+              additionalProperties: true
+            consent:
+              type: object
+              properties:
+                grantedCategories:
+                  type: array
+                  items:
+                    type: string
+              additionalProperties: true
+          additionalProperties: true
         issueContext:
           type: object
           properties:

--- a/test/custom-gpt-setup-docs.test.js
+++ b/test/custom-gpt-setup-docs.test.js
@@ -6,16 +6,24 @@ import path from "node:path";
 const README_PATH = path.join(process.cwd(), "README.md");
 const INSTRUCTIONS_PATH = path.join(process.cwd(), "docs", "setup", "custom-gpt-instructions.md");
 const OPENAPI_PATH = path.join(process.cwd(), "docs", "setup", "custom-gpt-actions-openapi.yaml");
+const OPENAPI_JSON_PATH = path.join(
+  process.cwd(),
+  "docs",
+  "setup",
+  "custom-gpt-actions-openapi.json"
+);
 
 test("custom gpt setup artifacts exist as tracked setup docs", () => {
   assert.equal(fs.existsSync(INSTRUCTIONS_PATH), true);
   assert.equal(fs.existsSync(OPENAPI_PATH), true);
+  assert.equal(fs.existsSync(OPENAPI_JSON_PATH), true);
 });
 
 test("readme points to current custom gpt setup artifacts", () => {
   const readme = fs.readFileSync(README_PATH, "utf8");
   assert.equal(readme.includes("docs/setup/custom-gpt-instructions.md"), true);
   assert.equal(readme.includes("docs/setup/custom-gpt-actions-openapi.yaml"), true);
+  assert.equal(readme.includes("docs/setup/custom-gpt-actions-openapi.json"), true);
 });
 
 test("custom gpt instructions preserve current butler and approval boundaries", () => {
@@ -40,4 +48,33 @@ test("custom gpt openapi doc exposes current gateway, execute, and progress rout
   assert.equal(doc.includes("conversation:"), true);
   assert.equal(doc.includes("repositoryInput:"), true);
   assert.equal(doc.includes("issueNumber"), true);
+});
+
+test("custom gpt openapi request schemas do not use nested refs for importer-fragile fields", () => {
+  const doc = fs.readFileSync(OPENAPI_PATH, "utf8");
+  assert.equal(
+    doc.includes("VtddExecuteRequest:\n      type: object"),
+    true
+  );
+  assert.equal(
+    doc.includes("VtddGatewayRequest:\n      type: object"),
+    true
+  );
+  assert.equal(
+    doc.includes("VtddExecuteRequest:\n      type: object\n      properties:\n        phase:"),
+    true
+  );
+  assert.equal(doc.includes("policyInput:\n          $ref:"), false);
+  assert.equal(doc.includes("surfaceContext:\n          $ref:"), false);
+  assert.equal(doc.includes("conversation:\n          $ref:"), false);
+  assert.equal(doc.includes("items:\n            $ref:"), false);
+});
+
+test("custom gpt openapi json parses and exposes paths as an object", () => {
+  const doc = JSON.parse(fs.readFileSync(OPENAPI_JSON_PATH, "utf8"));
+  assert.equal(typeof doc.paths, "object");
+  assert.notEqual(doc.paths, null);
+  assert.equal(typeof doc.paths["/v2/gateway"], "object");
+  assert.equal(typeof doc.paths["/v2/action/execute"], "object");
+  assert.equal(typeof doc.paths["/v2/action/progress"], "object");
 });


### PR DESCRIPTION
## Summary
- remove importer-fragile nested refs from the Custom GPT action request schemas
- add a tracked JSON sibling for the Custom GPT OpenAPI schema
- document the JSON fallback and lock it with tests

## Verification
- npx --yes swagger-cli validate docs/setup/custom-gpt-actions-openapi.yaml
- npx --yes swagger-cli validate docs/setup/custom-gpt-actions-openapi.json
- node --test test/custom-gpt-setup-docs.test.js
