### PR TITLE
Make Custom GPT action schema importable

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ For the current Custom GPT Butler surface artifacts, use:
 - `docs/setup/custom-gpt-actions-openapi.yaml`
 - `docs/setup/custom-gpt-actions-openapi.json`
 
+The Action schema is intentionally kept importer-safe:
+
+- OpenAPI `3.1.0`
+- explicit `components.schemas`
+- no nested `$ref` inside request object fields
+
 If the Custom GPT importer rejects the YAML form, use the JSON form instead.
 
 ## Cost And Account Boundary

--- a/docs/setup/custom-gpt-actions-openapi.json
+++ b/docs/setup/custom-gpt-actions-openapi.json
@@ -3,12 +3,18 @@
   "info": {
     "title": "VTDD Butler Action API",
     "version": "0.1.0",
-    "description": "Canonical OpenAPI template for a user-owned Custom GPT Butler surface. Replace the server URL with your own VTDD runtime before importing.\n"
+    "description": "Canonical OpenAPI template for a user-owned VTDD Butler surface."
   },
   "servers": [
     {
-      "url": "https://your-runtime-host.example.workers.dev",
-      "description": "User-owned VTDD runtime host"
+      "url": "https://your-runtime-host.example.workers.dev"
+    }
+  ],
+  "security": [
+    {
+      "GatewayBearerAuth": [
+
+      ]
     }
   ],
   "components": {
@@ -16,120 +22,33 @@
       "GatewayBearerAuth": {
         "type": "http",
         "scheme": "bearer",
-        "bearerFormat": "API token",
-        "description": "Configure this with the same secret value as VTDD_GATEWAY_BEARER_TOKEN on your Worker runtime.\n"
+        "bearerFormat": "API token"
       }
     },
     "schemas": {
-      "SurfaceContext": {
+      "HealthResponse": {
         "type": "object",
         "properties": {
-          "surface": {
-            "type": "string"
-          },
-          "judgmentModelId": {
-            "type": "string"
-          }
-        },
-        "additionalProperties": true
-      },
-      "JudgmentTraceEntry": {
-        "type": "object",
-        "properties": {
-          "step": {
-            "type": "string"
-          },
-          "status": {
-            "type": "string"
-          },
-          "rationale": {
-            "type": "string"
-          }
-        },
-        "additionalProperties": true
-      },
-      "RuntimeTruthInput": {
-        "type": "object",
-        "properties": {
-          "runtimeAvailable": {
+          "ok": {
             "type": "boolean"
           },
-          "safeFallbackChosen": {
-            "type": "boolean"
-          }
-        },
-        "additionalProperties": true
-      },
-      "ConsentInput": {
-        "type": "object",
-        "properties": {
-          "grantedCategories": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
-        },
-        "additionalProperties": true
-      },
-      "ConversationInput": {
-        "type": "object",
-        "properties": {
-          "userText": {
+          "service": {
             "type": "string"
-          },
-          "currentRepository": {
-            "type": "string"
-          }
-        },
-        "additionalProperties": true
-      },
-      "PolicyInput": {
-        "type": "object",
-        "properties": {
-          "actionType": {
-            "type": "string",
-            "enum": [
-              "read",
-              "summarize",
-              "issue_create",
-              "build",
-              "pr_comment",
-              "pr_review_submit",
-              "pr_operation",
-              "merge",
-              "deploy_production",
-              "destructive",
-              "external_publish"
-            ]
           },
           "mode": {
-            "type": "string",
-            "enum": [
-              "read_only",
-              "execution"
-            ]
-          },
-          "repositoryInput": {
             "type": "string"
           },
-          "targetConfirmed": {
+          "autonomyMode": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": true
+      },
+      "VtddGenericResponse": {
+        "type": "object",
+        "properties": {
+          "ok": {
             "type": "boolean"
-          },
-          "issueTraceable": {
-            "type": "boolean"
-          },
-          "go": {
-            "type": "boolean"
-          },
-          "passkey": {
-            "type": "boolean"
-          },
-          "runtimeTruth": {
-            "$ref": "#/components/schemas/RuntimeTruthInput"
-          },
-          "consent": {
-            "$ref": "#/components/schemas/ConsentInput"
           }
         },
         "additionalProperties": true
@@ -265,12 +184,18 @@
           "continuationContext": {
             "type": "object",
             "properties": {
+              "executionId": {
+                "type": "string"
+              }
             },
             "additionalProperties": true
           },
           "memoryRecord": {
             "type": "object",
             "properties": {
+              "type": {
+                "type": "string"
+              }
             },
             "additionalProperties": true
           }
@@ -407,25 +332,9 @@
           }
         },
         "additionalProperties": true
-      },
-      "VtddGenericResponse": {
-        "type": "object",
-        "properties": {
-          "ok": {
-            "type": "boolean"
-          }
-        },
-        "additionalProperties": true
       }
     }
   },
-  "security": [
-    {
-      "GatewayBearerAuth": [
-
-      ]
-    }
-  ],
   "paths": {
     "/health": {
       "get": {
@@ -437,7 +346,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/VtddGenericResponse"
+                  "$ref": "#/components/schemas/HealthResponse"
                 }
               }
             }
@@ -448,14 +357,7 @@
     "/v2/gateway": {
       "post": {
         "operationId": "vtddGateway",
-        "summary": "Evaluate VTDD policy, context resolution, repository candidates, and Butler guidance.\n",
-        "security": [
-          {
-            "GatewayBearerAuth": [
-
-            ]
-          }
-        ],
+        "summary": "Evaluate VTDD policy, repository candidates, and Butler guidance.",
         "requestBody": {
           "required": true,
           "content": {
@@ -500,13 +402,6 @@
       "post": {
         "operationId": "vtddExecute",
         "summary": "Dispatch bounded VTDD execution, including remote Codex handoff.",
-        "security": [
-          {
-            "GatewayBearerAuth": [
-
-            ]
-          }
-        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -561,13 +456,6 @@
       "get": {
         "operationId": "vtddExecutionProgress",
         "summary": "Read progress for a remote Codex execution request.",
-        "security": [
-          {
-            "GatewayBearerAuth": [
-
-            ]
-          }
-        ],
         "parameters": [
           {
             "name": "executionId",
@@ -583,8 +471,7 @@
             "required": true,
             "schema": {
               "type": "string"
-            },
-            "description": "owner/repo, for example sample-org/vtdd-v2"
+            }
           },
           {
             "name": "issueNumber",
@@ -637,13 +524,6 @@
       "get": {
         "operationId": "vtddRetrieveApprovalGrant",
         "summary": "Retrieve a previously issued approval grant by approvalId.",
-        "security": [
-          {
-            "GatewayBearerAuth": [
-
-            ]
-          }
-        ],
         "parameters": [
           {
             "name": "approvalId",

--- a/docs/setup/custom-gpt-actions-openapi.yaml
+++ b/docs/setup/custom-gpt-actions-openapi.yaml
@@ -2,102 +2,35 @@ openapi: 3.1.0
 info:
   title: VTDD Butler Action API
   version: 0.1.0
-  description: >
-    Canonical OpenAPI template for a user-owned Custom GPT Butler surface.
-    Replace the server URL with your own VTDD runtime before importing.
-# If the Custom GPT importer rejects YAML, use the JSON sibling file:
-# docs/setup/custom-gpt-actions-openapi.json
+  description: Canonical OpenAPI template for a user-owned VTDD Butler surface.
 servers:
   - url: https://your-runtime-host.example.workers.dev
-    description: User-owned VTDD runtime host
+security:
+  - GatewayBearerAuth: []
 components:
   securitySchemes:
     GatewayBearerAuth:
       type: http
       scheme: bearer
       bearerFormat: API token
-      description: >
-        Configure this with the same secret value as VTDD_GATEWAY_BEARER_TOKEN
-        on your Worker runtime.
   schemas:
-    SurfaceContext:
+    HealthResponse:
       type: object
       properties:
-        surface:
-          type: string
-        judgmentModelId:
-          type: string
-      additionalProperties: true
-    JudgmentTraceEntry:
-      type: object
-      properties:
-        step:
-          type: string
-        status:
-          type: string
-        rationale:
-          type: string
-      additionalProperties: true
-    RuntimeTruthInput:
-      type: object
-      properties:
-        runtimeAvailable:
+        ok:
           type: boolean
-        safeFallbackChosen:
-          type: boolean
-      additionalProperties: true
-    ConsentInput:
-      type: object
-      properties:
-        grantedCategories:
-          type: array
-          items:
-            type: string
-      additionalProperties: true
-    ConversationInput:
-      type: object
-      properties:
-        userText:
+        service:
           type: string
-        currentRepository:
-          type: string
-      additionalProperties: true
-    PolicyInput:
-      type: object
-      properties:
-        actionType:
-          type: string
-          enum:
-            - read
-            - summarize
-            - issue_create
-            - build
-            - pr_comment
-            - pr_review_submit
-            - pr_operation
-            - merge
-            - deploy_production
-            - destructive
-            - external_publish
         mode:
           type: string
-          enum:
-            - read_only
-            - execution
-        repositoryInput:
+        autonomyMode:
           type: string
-        targetConfirmed:
+      additionalProperties: true
+    VtddGenericResponse:
+      type: object
+      properties:
+        ok:
           type: boolean
-        issueTraceable:
-          type: boolean
-        go:
-          type: boolean
-        passkey:
-          type: boolean
-        runtimeTruth:
-          $ref: "#/components/schemas/RuntimeTruthInput"
-        consent:
-          $ref: "#/components/schemas/ConsentInput"
       additionalProperties: true
     VtddGatewayRequest:
       type: object
@@ -192,11 +125,15 @@ components:
           additionalProperties: true
         continuationContext:
           type: object
-          properties: {}
+          properties:
+            executionId:
+              type: string
           additionalProperties: true
         memoryRecord:
           type: object
-          properties: {}
+          properties:
+            type:
+              type: string
           additionalProperties: true
       additionalProperties: true
     VtddExecuteRequest:
@@ -290,14 +227,6 @@ components:
               type: string
           additionalProperties: true
       additionalProperties: true
-    VtddGenericResponse:
-      type: object
-      properties:
-        ok:
-          type: boolean
-      additionalProperties: true
-security:
-  - GatewayBearerAuth: []
 paths:
   /health:
     get:
@@ -309,15 +238,11 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/VtddGenericResponse"
+                $ref: "#/components/schemas/HealthResponse"
   /v2/gateway:
     post:
       operationId: vtddGateway
-      summary: >
-        Evaluate VTDD policy, context resolution, repository candidates, and
-        Butler guidance.
-      security:
-        - GatewayBearerAuth: []
+      summary: Evaluate VTDD policy, repository candidates, and Butler guidance.
       requestBody:
         required: true
         content:
@@ -345,8 +270,6 @@ paths:
     post:
       operationId: vtddExecute
       summary: Dispatch bounded VTDD execution, including remote Codex handoff.
-      security:
-        - GatewayBearerAuth: []
       requestBody:
         required: true
         content:
@@ -380,8 +303,6 @@ paths:
     get:
       operationId: vtddExecutionProgress
       summary: Read progress for a remote Codex execution request.
-      security:
-        - GatewayBearerAuth: []
       parameters:
         - name: executionId
           in: query
@@ -393,7 +314,6 @@ paths:
           required: true
           schema:
             type: string
-          description: owner/repo, for example sample-org/vtdd-v2
         - name: issueNumber
           in: query
           required: true
@@ -425,8 +345,6 @@ paths:
     get:
       operationId: vtddRetrieveApprovalGrant
       summary: Retrieve a previously issued approval grant by approvalId.
-      security:
-        - GatewayBearerAuth: []
       parameters:
         - name: approvalId
           in: query

--- a/test/custom-gpt-setup-docs.test.js
+++ b/test/custom-gpt-setup-docs.test.js
@@ -50,20 +50,15 @@ test("custom gpt openapi doc exposes current gateway, execute, and progress rout
   assert.equal(doc.includes("issueNumber"), true);
 });
 
-test("custom gpt openapi request schemas do not use nested refs for importer-fragile fields", () => {
+test("custom gpt openapi keeps components.schemas while avoiding nested field refs", () => {
   const doc = fs.readFileSync(OPENAPI_PATH, "utf8");
-  assert.equal(
-    doc.includes("VtddExecuteRequest:\n      type: object"),
-    true
-  );
-  assert.equal(
-    doc.includes("VtddGatewayRequest:\n      type: object"),
-    true
-  );
-  assert.equal(
-    doc.includes("VtddExecuteRequest:\n      type: object\n      properties:\n        phase:"),
-    true
-  );
+  assert.equal(doc.includes("components:"), true);
+  assert.equal(doc.includes("schemas:"), true);
+  assert.equal(doc.includes("VtddGenericResponse:"), true);
+  assert.equal(doc.includes('#/components/schemas/VtddGatewayRequest'), true);
+  assert.equal(doc.includes("requestBody:"), true);
+  assert.equal(doc.includes("policyInput:"), true);
+  assert.equal(doc.includes("conversation:"), true);
   assert.equal(doc.includes("policyInput:\n          $ref:"), false);
   assert.equal(doc.includes("surfaceContext:\n          $ref:"), false);
   assert.equal(doc.includes("conversation:\n          $ref:"), false);
@@ -72,9 +67,13 @@ test("custom gpt openapi request schemas do not use nested refs for importer-fra
 
 test("custom gpt openapi json parses and exposes paths as an object", () => {
   const doc = JSON.parse(fs.readFileSync(OPENAPI_JSON_PATH, "utf8"));
+  assert.equal(doc.openapi, "3.1.0");
   assert.equal(typeof doc.paths, "object");
   assert.notEqual(doc.paths, null);
   assert.equal(typeof doc.paths["/v2/gateway"], "object");
   assert.equal(typeof doc.paths["/v2/action/execute"], "object");
   assert.equal(typeof doc.paths["/v2/action/progress"], "object");
+  assert.equal(typeof doc.paths["/v2/retrieve/approval-grant"], "object");
+  assert.equal(typeof doc.components.schemas, "object");
+  assert.equal(doc.components.securitySchemes.GatewayBearerAuth.scheme, "bearer");
 });


### PR DESCRIPTION
## Summary
- align the Custom GPT action schema with the importer constraints that were verified live
- keep VTDD routes and approval boundaries while removing importer-fragile schema structure
- regenerate the JSON sibling and update docs/tests to lock the importer-safe contract

## Verification
- npx --yes swagger-cli validate docs/setup/custom-gpt-actions-openapi.yaml
- npx --yes swagger-cli validate docs/setup/custom-gpt-actions-openapi.json
- node --test test/custom-gpt-setup-docs.test.js
- live import check in the Custom GPT editor
