### PR TITLE
Define desktop bootstrap vault under ~/.vtdd

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,22 @@ The Action schema is intentionally kept importer-safe:
 
 If the Custom GPT importer rejects the YAML form, use the JSON form instead.
 
+## Local Desktop Bootstrap Vault
+
+Operator-owned root credential material is expected to live outside the
+repository under:
+
+- `~/.vtdd/credentials/manifest.json`
+
+See:
+
+- `docs/setup/desktop-bootstrap-vault.md`
+- `docs/setup/github-app-secret-sync.md`
+- `docs/setup/cloudflare-deploy-secret-sync.md`
+
+This repository must not contain committed secret values or repository-local
+bootstrap credential blobs.
+
 ## Cost And Account Boundary
 
 VTDD should not silently turn an existing ChatGPT/Codex subscription into a

--- a/docs/setup/cloudflare-deploy-secret-sync.md
+++ b/docs/setup/cloudflare-deploy-secret-sync.md
@@ -1,6 +1,7 @@
 # Cloudflare Deploy Secret Sync
 
-This document defines the explicit operator bootstrap path for Issue #35.
+This document defines the explicit operator bootstrap path for Issue #35 and
+the desktop bootstrap vault path from Issue #43.
 
 ## Problem
 
@@ -26,7 +27,7 @@ printf '%s' "$CLOUDFLARE_API_TOKEN" | node scripts/sync-cloudflare-actions-secre
   --repo marushu/vtdd-v2-p \
   --cloudflare-account-id "$CLOUDFLARE_ACCOUNT_ID" \
   --stdin \
-  --runtime-url https://vtdd-v2-mvp.polished-tree-da7c.workers.dev \
+  --runtime-url https://<your-runtime-host> \
   --approval-grant-id "$APPROVAL_GRANT_ID"
 ```
 
@@ -35,6 +36,11 @@ The script also accepts:
 - `--cloudflare-api-token-path <path>`
 - `CLOUDFLARE_API_TOKEN`
 - `CLOUDFLARE_ACCOUNT_ID`
+
+By default, the script can also read Cloudflare and gateway credential paths
+from:
+
+- `~/.vtdd/credentials/manifest.json`
 
 The script must not print the token value.
 

--- a/docs/setup/desktop-bootstrap-vault.md
+++ b/docs/setup/desktop-bootstrap-vault.md
@@ -1,0 +1,128 @@
+# Desktop Bootstrap Credential Vault
+
+This document is the canonical desktop bootstrap contract for Issue #43.
+
+## Purpose
+
+VTDD needs an operator-owned local credential root that:
+
+- lives outside the repository
+- can be reused for runtime secret sync and self-recovery
+- does not store short-lived execution tokens
+- can degrade cleanly into `desktop maintenance required` when iPhone-only
+  operation cannot continue
+
+The canonical local path is:
+
+- `~/.vtdd/credentials/manifest.json`
+
+## Boundary
+
+This vault is:
+
+- local-only
+- operator-owned
+- not repository-tracked
+- not D1-backed
+- not a setup wizard revival
+
+Short-lived execution credentials must not be stored here.
+
+That includes:
+
+- GitHub App JWTs
+- GitHub installation tokens
+- one-shot execution tokens
+- other derived runtime tokens intended to be minted and discarded
+
+## Layout
+
+Recommended layout:
+
+```text
+~/.vtdd/
+  credentials/
+    manifest.json
+    github-app/
+      private-key.pem
+    cloudflare/
+      api-token.txt
+    gateway/
+      bearer-token.txt
+    reviewer/
+      gemini-api-key.txt
+```
+
+## Manifest Schema
+
+`manifest.json` stores references and metadata, not one giant inline secret blob.
+
+Example:
+
+```json
+{
+  "version": 1,
+  "githubApp": {
+    "appId": "3467409",
+    "installationId": "126180737",
+    "privateKeyPath": "github-app/private-key.pem"
+  },
+  "cloudflare": {
+    "accountId": "your-cloudflare-account-id",
+    "apiTokenPath": "cloudflare/api-token.txt"
+  },
+  "gateway": {
+    "bearerTokenPath": "gateway/bearer-token.txt"
+  },
+  "reviewer": {
+    "geminiApiKeyPath": "reviewer/gemini-api-key.txt"
+  }
+}
+```
+
+Relative paths are resolved from `~/.vtdd/credentials/`.
+
+## Required Coverage
+
+At minimum, the vault contract covers:
+
+- GitHub App root material
+  - `appId`
+  - `installationId`
+  - private key path
+- Cloudflare root material
+  - `accountId`
+  - API token path
+- VTDD gateway bearer token path
+- reviewer credential path(s), if configured
+
+## Security Rules
+
+- no secret values are committed to the repository
+- VTDD runtime must not log secret contents
+- file permissions should remain operator-only where possible
+- D1 stores audit / scope / metadata only, not root secret values
+- this vault is for root credential references and local secret files, not for
+  short-lived execution tokens
+
+## Desktop Maintenance Required
+
+When VTDD is operating from an iPhone-only or otherwise non-desktop surface and
+a required root credential is missing, invalid, expired, or needs rotation,
+Butler must stop and surface:
+
+- `desktop maintenance required`
+
+The response should also include a concrete reason such as:
+
+- `github_app_private_key_invalid`
+- `cloudflare_api_token_invalid`
+- `gateway_bearer_token_missing`
+- `reviewer_api_key_invalid`
+
+## Non-goals
+
+- setup wizard resurrection
+- storing short-lived execution tokens in D1
+- repository-tracked secret values
+- full encryption / KMS rollout in the same issue

--- a/docs/setup/github-app-secret-sync.md
+++ b/docs/setup/github-app-secret-sync.md
@@ -1,12 +1,12 @@
 # GitHub App Secret Sync Bootstrap
 
-This document is the canonical bootstrap contract for Issue #15.
+This document is the canonical bootstrap contract for Issue #15 and Issue #43.
 
 ## Purpose
 
-VTDD already holds local GitHub App credential material under
-`credentials/github-app/`, but runtime paths such as remote executor and Gemini
-reviewer also require GitHub Actions secrets.
+VTDD keeps local GitHub App root material in the operator-owned desktop
+bootstrap vault under `~/.vtdd/credentials/`, but runtime paths such as remote
+executor and reviewer flows also require GitHub Actions secrets.
 
 This bootstrap path exists to sync that local source of truth into GitHub
 Actions secrets through an explicit operator action instead of ad hoc manual
@@ -16,8 +16,8 @@ copying.
 
 The local source of truth is:
 
-- `credentials/github-app/load-env.sh`
-- the private key path referenced from that file
+- `~/.vtdd/credentials/manifest.json`
+- the private key path referenced from that manifest
 
 The sync target is GitHub Actions secrets:
 
@@ -70,6 +70,13 @@ auth, verifies that:
 
 and only then performs GitHub Actions secret mutation.
 
+By default, the script reads:
+
+- `~/.vtdd/credentials/manifest.json`
+
+Use `--manifest-path <path>` only if you intentionally keep the operator-owned
+desktop bootstrap vault somewhere else.
+
 ## Optional Operator Helper
 
 For explicit operator execution without manual API calls, use the local helper:
@@ -93,7 +100,7 @@ sync path.
 
 ## Non-goals
 
-- replacing the local GitHub App source of truth
+- replacing the desktop bootstrap vault as the local GitHub App source of truth
 - silent periodic sync
 - weakening high-risk approval boundaries
 - presenting the current phrase-based `passkey` gate as if it were already real

--- a/scripts/run-passkey-operator-helper.mjs
+++ b/scripts/run-passkey-operator-helper.mjs
@@ -17,7 +17,7 @@ async function main() {
   }
 
   const sourceResult = await loadGitHubAppSecretSource({
-    envPath: args.envPath
+    manifestPath: args.manifestPath
   });
   if (!sourceResult.ok) {
     throw new Error(sourceResult.issues.join(", "));
@@ -29,7 +29,7 @@ async function main() {
   );
   if (!bearerToken) {
     throw new Error(
-      "gateway bearer token is required via --gateway-bearer-token, VTDD_GATEWAY_BEARER_TOKEN, or load-env.sh"
+      "gateway bearer token is required via --gateway-bearer-token, VTDD_GATEWAY_BEARER_TOKEN, or ~/.vtdd/credentials/manifest.json"
     );
   }
 
@@ -45,7 +45,7 @@ async function main() {
     repo: normalizeText(args.repo || "marushu/vtdd-v2-p"),
     issueNumber: normalizeText(args.issueNumber || "15"),
     highRiskKind: normalizeText(args.highRiskKind || "github_app_secret_sync"),
-    envPath: normalizeText(args.envPath || sourceResult.source.envPath)
+    manifestPath: normalizeText(args.manifestPath || sourceResult.source.manifestPath)
   };
 
   const server = http.createServer((request, response) =>
@@ -112,8 +112,8 @@ async function handleRequest({ request, response, state }) {
       "--approval-grant-id",
       approvalGrantId
     ];
-    if (state.envPath) {
-      args.push("--env-path", state.envPath);
+    if (state.manifestPath) {
+      args.push("--manifest-path", state.manifestPath);
     }
 
     const result = await execFileAsync(process.execPath, args, {
@@ -227,8 +227,8 @@ function parseArgs(args) {
       index += 1;
       continue;
     }
-    if (current === "--env-path") {
-      parsed.envPath = args[index + 1];
+    if (current === "--manifest-path") {
+      parsed.manifestPath = args[index + 1];
       index += 1;
     }
   }

--- a/scripts/sync-cloudflare-actions-secrets.mjs
+++ b/scripts/sync-cloudflare-actions-secrets.mjs
@@ -1,26 +1,28 @@
 import fs from "node:fs/promises";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
-import { executeCloudflareDeploySecretSync } from "../src/core/index.js";
+import { executeCloudflareDeploySecretSync, loadDesktopBootstrapVault } from "../src/core/index.js";
 
 const execFileAsync = promisify(execFile);
 
 async function main() {
   const args = parseArgs(process.argv.slice(2));
   const repo = normalizeText(args.repo || process.env.GITHUB_REPOSITORY || "marushu/vtdd-v2-p");
+  const vault = await resolveVault(args);
   const source = {
     cloudflareApiToken: await resolveApiToken(args),
     cloudflareAccountId: normalizeText(
-      args.cloudflareAccountId ||
-        process.env.CLOUDFLARE_ACCOUNT_ID ||
-        "bd82bbc79ce38442976432eaa409e48c"
+      args.cloudflareAccountId || process.env.CLOUDFLARE_ACCOUNT_ID || vault?.cloudflare?.accountId
     )
   };
 
   const approvalGrant = await resolveApprovalGrant({
     runtimeUrl: args.runtimeUrl || process.env.VTDD_RUNTIME_URL,
     approvalGrantId: args.approvalGrantId,
-    bearerToken: args.gatewayBearerToken || process.env.VTDD_GATEWAY_BEARER_TOKEN
+    bearerToken:
+      args.gatewayBearerToken ||
+      process.env.VTDD_GATEWAY_BEARER_TOKEN ||
+      vault?.gateway?.bearerToken
   });
 
   const result = await executeCloudflareDeploySecretSync({
@@ -57,6 +59,12 @@ async function resolveApiToken(args) {
     return fromEnv;
   }
 
+  const vault = await resolveVault(args);
+  const fromVault = normalizeText(vault?.cloudflare?.apiToken);
+  if (fromVault) {
+    return fromVault;
+  }
+
   const tokenPath = normalizeText(args.cloudflareApiTokenPath);
   if (tokenPath) {
     return normalizeText(await fs.readFile(tokenPath, "utf8"));
@@ -67,6 +75,19 @@ async function resolveApiToken(args) {
   }
 
   return "";
+}
+
+let cachedVaultResult;
+async function resolveVault(args) {
+  if (cachedVaultResult !== undefined) {
+    return cachedVaultResult;
+  }
+  const manifestPath = normalizeText(args.manifestPath);
+  const result = await loadDesktopBootstrapVault({
+    manifestPath: manifestPath || undefined
+  });
+  cachedVaultResult = result.ok ? result.vault : null;
+  return cachedVaultResult;
 }
 
 async function resolveApprovalGrant(input = {}) {
@@ -122,6 +143,11 @@ function parseArgs(args) {
     }
     if (current === "--cloudflare-account-id") {
       parsed.cloudflareAccountId = args[index + 1];
+      index += 1;
+      continue;
+    }
+    if (current === "--manifest-path") {
+      parsed.manifestPath = args[index + 1];
       index += 1;
       continue;
     }

--- a/scripts/sync-github-app-actions-secrets.mjs
+++ b/scripts/sync-github-app-actions-secrets.mjs
@@ -14,7 +14,7 @@ async function main() {
   const execute = args.execute === true;
 
   const sourceResult = await loadGitHubAppSecretSource({
-    envPath: args.envPath
+    manifestPath: args.manifestPath
   });
   if (!sourceResult.ok) {
     throw new Error(sourceResult.issues.join(", "));
@@ -67,12 +67,12 @@ async function main() {
 function printDryRun(plan, source) {
   console.log("GitHub App secret sync dry-run");
   console.log(`repo: ${plan.repo}`);
-  console.log(`env source: ${source.envPath}`);
+  console.log(`vault manifest: ${source.manifestPath}`);
   console.log(`app id: ${source.appId}`);
   console.log(`installation id: ${source.installationId}`);
   console.log(`private key path: ${source.privateKeyPath}`);
   console.log(
-    `gateway bearer token path: ${source.gatewayBearerTokenPath || "[not configured in load-env.sh]"}`
+    `gateway bearer token path: ${source.gatewayBearerTokenPath || "[not configured in vault manifest]"}`
   );
   console.log("secrets to sync:");
   for (const secret of plan.secrets) {
@@ -100,8 +100,8 @@ function parseArgs(args) {
       index += 1;
       continue;
     }
-    if (current === "--env-path") {
-      parsed.envPath = args[index + 1];
+    if (current === "--manifest-path") {
+      parsed.manifestPath = args[index + 1];
       index += 1;
       continue;
     }
@@ -136,7 +136,7 @@ async function resolveApprovalGrant(input = {}) {
   }
   if (!bearerToken) {
     throw new Error(
-      "execute mode requires gateway bearer token via --gateway-bearer-token, VTDD_GATEWAY_BEARER_TOKEN, or load-env.sh"
+      "execute mode requires gateway bearer token via --gateway-bearer-token, VTDD_GATEWAY_BEARER_TOKEN, or ~/.vtdd/credentials/manifest.json"
     );
   }
 

--- a/src/core/desktop-bootstrap-vault.js
+++ b/src/core/desktop-bootstrap-vault.js
@@ -1,0 +1,132 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+export const DEFAULT_VTDD_HOME_PATH = path.join(os.homedir(), ".vtdd");
+export const DEFAULT_VTDD_CREDENTIALS_DIR = path.join(DEFAULT_VTDD_HOME_PATH, "credentials");
+export const DEFAULT_VTDD_VAULT_MANIFEST_PATH = path.join(
+  DEFAULT_VTDD_CREDENTIALS_DIR,
+  "manifest.json"
+);
+
+export async function loadDesktopBootstrapVault(input = {}) {
+  const manifestPath = normalizeText(input.manifestPath) || DEFAULT_VTDD_VAULT_MANIFEST_PATH;
+  const manifestDir = path.dirname(manifestPath);
+  const issues = [];
+
+  let manifest;
+  try {
+    const content = await fs.readFile(manifestPath, "utf8");
+    manifest = JSON.parse(content);
+  } catch (error) {
+    return {
+      ok: false,
+      issues: [
+        error?.code === "ENOENT"
+          ? `desktop bootstrap vault manifest not found: ${manifestPath}`
+          : `desktop bootstrap vault manifest is unreadable: ${manifestPath}`
+      ]
+    };
+  }
+
+  if (Number(manifest?.version) !== 1) {
+    issues.push("desktop bootstrap vault manifest version must be 1");
+  }
+
+  const githubApp = manifest?.githubApp ?? {};
+  const cloudflare = manifest?.cloudflare ?? {};
+  const gateway = manifest?.gateway ?? {};
+  const reviewer = manifest?.reviewer ?? {};
+
+  const githubAppPrivateKeyPath = resolveReferencedPath(manifestDir, githubApp.privateKeyPath);
+  const cloudflareApiTokenPath = resolveReferencedPath(manifestDir, cloudflare.apiTokenPath);
+  const gatewayBearerTokenPath = resolveReferencedPath(manifestDir, gateway.bearerTokenPath);
+  const geminiApiKeyPath = resolveReferencedPath(manifestDir, reviewer.geminiApiKeyPath);
+
+  const githubAppPrivateKey = await readOptionalTextFile(githubAppPrivateKeyPath, issues);
+  const cloudflareApiToken = await readOptionalTextFile(cloudflareApiTokenPath, issues);
+  const gatewayBearerToken = await readOptionalTextFile(gatewayBearerTokenPath, issues);
+  const geminiApiKey = await readOptionalTextFile(geminiApiKeyPath, issues);
+
+  if (!normalizeText(githubApp.appId)) {
+    issues.push("githubApp.appId is required in desktop bootstrap vault manifest");
+  }
+  if (!normalizeText(githubApp.installationId)) {
+    issues.push("githubApp.installationId is required in desktop bootstrap vault manifest");
+  }
+  if (!normalizeText(githubApp.privateKeyPath)) {
+    issues.push("githubApp.privateKeyPath is required in desktop bootstrap vault manifest");
+  }
+  if (normalizeText(githubApp.privateKeyPath) && !normalizeText(githubAppPrivateKey)) {
+    issues.push("desktop bootstrap vault GitHub App private key file is empty or unreadable");
+  }
+  if (normalizeText(cloudflare.apiTokenPath) && !normalizeText(cloudflareApiToken)) {
+    issues.push("desktop bootstrap vault Cloudflare API token file is empty or unreadable");
+  }
+  if (normalizeText(gateway.bearerTokenPath) && !normalizeText(gatewayBearerToken)) {
+    issues.push("desktop bootstrap vault gateway bearer token file is empty or unreadable");
+  }
+  if (normalizeText(reviewer.geminiApiKeyPath) && !normalizeText(geminiApiKey)) {
+    issues.push("desktop bootstrap vault reviewer API key file is empty or unreadable");
+  }
+
+  if (issues.length > 0) {
+    return { ok: false, issues };
+  }
+
+  return {
+    ok: true,
+    vault: {
+      manifestPath,
+      manifestDir,
+      githubApp: {
+        appId: normalizeText(githubApp.appId),
+        installationId: normalizeText(githubApp.installationId),
+        privateKeyPath: githubAppPrivateKeyPath,
+        privateKey: githubAppPrivateKey
+      },
+      cloudflare: {
+        accountId: normalizeText(cloudflare.accountId),
+        apiTokenPath: cloudflareApiTokenPath,
+        apiToken: cloudflareApiToken
+      },
+      gateway: {
+        bearerTokenPath: gatewayBearerTokenPath,
+        bearerToken: gatewayBearerToken
+      },
+      reviewer: {
+        geminiApiKeyPath,
+        geminiApiKey
+      }
+    }
+  };
+}
+
+function resolveReferencedPath(manifestDir, referencedPath) {
+  const normalized = normalizeText(referencedPath);
+  if (!normalized) {
+    return "";
+  }
+  if (path.isAbsolute(normalized)) {
+    return normalized;
+  }
+  return path.join(manifestDir, normalized);
+}
+
+async function readOptionalTextFile(filePath, issues) {
+  const normalizedPath = normalizeText(filePath);
+  if (!normalizedPath) {
+    return "";
+  }
+
+  try {
+    return normalizeText(await fs.readFile(normalizedPath, "utf8"));
+  } catch {
+    issues.push(`desktop bootstrap vault referenced file is unreadable: ${normalizedPath}`);
+    return "";
+  }
+}
+
+function normalizeText(value) {
+  return String(value ?? "").trim();
+}

--- a/src/core/github-app-secret-sync.js
+++ b/src/core/github-app-secret-sync.js
@@ -1,55 +1,27 @@
-import fs from "node:fs/promises";
-import path from "node:path";
-
-export const DEFAULT_GITHUB_APP_ENV_PATH = path.join(
-  process.cwd(),
-  "credentials",
-  "github-app",
-  "load-env.sh"
-);
+import {
+  DEFAULT_VTDD_VAULT_MANIFEST_PATH,
+  loadDesktopBootstrapVault
+} from "./desktop-bootstrap-vault.js";
 
 export async function loadGitHubAppSecretSource(input = {}) {
-  const envPath = input.envPath || DEFAULT_GITHUB_APP_ENV_PATH;
-  const content = await fs.readFile(envPath, "utf8");
-  const variables = parseExportedShellVariables(content);
-
-  const appId = normalizeText(variables.GITHUB_APP_ID);
-  const privateKeyPath = normalizeText(variables.GITHUB_APP_PRIVATE_KEY_PATH);
-  const installationId = normalizeText(variables.GITHUB_APP_INSTALLATION_ID);
-  const gatewayBearerTokenPath = normalizeText(variables.VTDD_GATEWAY_BEARER_TOKEN_PATH);
-  const privateKey = privateKeyPath ? await fs.readFile(privateKeyPath, "utf8") : "";
-  const gatewayBearerToken = gatewayBearerTokenPath
-    ? normalizeText(await fs.readFile(gatewayBearerTokenPath, "utf8"))
-    : "";
-
-  const issues = [];
-  if (!appId) {
-    issues.push("GITHUB_APP_ID is missing from load-env.sh");
-  }
-  if (!installationId) {
-    issues.push("GITHUB_APP_INSTALLATION_ID is missing from load-env.sh");
-  }
-  if (!privateKeyPath) {
-    issues.push("GITHUB_APP_PRIVATE_KEY_PATH is missing from load-env.sh");
-  }
-  if (!normalizeText(privateKey)) {
-    issues.push("GitHub App private key file is empty or unreadable");
+  const manifestPath = input.manifestPath || DEFAULT_VTDD_VAULT_MANIFEST_PATH;
+  const vaultResult = await loadDesktopBootstrapVault({ manifestPath });
+  if (!vaultResult.ok) {
+    return vaultResult;
   }
 
-  if (issues.length > 0) {
-    return { ok: false, issues };
-  }
-
+  const vault = vaultResult.vault;
   return {
     ok: true,
     source: {
-      envPath,
-      appId,
-      installationId,
-      privateKeyPath,
-      privateKey,
-      gatewayBearerTokenPath,
-      gatewayBearerToken
+      sourceType: "desktop_bootstrap_vault",
+      manifestPath: vault.manifestPath,
+      appId: vault.githubApp.appId,
+      installationId: vault.githubApp.installationId,
+      privateKeyPath: vault.githubApp.privateKeyPath,
+      privateKey: vault.githubApp.privateKey,
+      gatewayBearerTokenPath: vault.gateway.bearerTokenPath,
+      gatewayBearerToken: vault.gateway.bearerToken
     }
   };
 }
@@ -156,19 +128,6 @@ export function validateGitHubAppSecretSyncApprovalGrant(input = {}) {
   }
 
   return { ok: true };
-}
-
-function parseExportedShellVariables(content) {
-  const exports = {};
-  const lines = String(content ?? "").split("\n");
-  for (const line of lines) {
-    const match = line.match(/^export\s+([A-Z0-9_]+)=\"?(.*?)\"?$/);
-    if (!match) {
-      continue;
-    }
-    exports[match[1]] = match[2];
-  }
-  return exports;
 }
 
 function normalizeText(value) {

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -9,6 +9,12 @@ export {
 } from "./types.js";
 export { evaluateAutonomyModeBoundary, normalizeAutonomyMode } from "./autonomy-mode.js";
 export {
+  DEFAULT_VTDD_CREDENTIALS_DIR,
+  DEFAULT_VTDD_HOME_PATH,
+  DEFAULT_VTDD_VAULT_MANIFEST_PATH,
+  loadDesktopBootstrapVault
+} from "./desktop-bootstrap-vault.js";
+export {
   DeployAuthorityPath,
   DeployAuthorityPreference,
   ProtectionSignalStatus,

--- a/test/cloudflare-deploy-secret-sync.test.js
+++ b/test/cloudflare-deploy-secret-sync.test.js
@@ -21,7 +21,7 @@ test("cloudflare deploy secret sync plan targets Actions deploy secrets", () => 
     repo: "marushu/vtdd-v2-p",
     source: {
       cloudflareApiToken: "cf-token-redacted",
-      cloudflareAccountId: "bd82bbc79ce38442976432eaa409e48c"
+      cloudflareAccountId: "account-123"
     }
   });
 
@@ -36,7 +36,7 @@ test("cloudflare deploy secret sync plan fails without token source", () => {
   const result = buildCloudflareDeploySecretSyncPlan({
     repo: "marushu/vtdd-v2-p",
     source: {
-      cloudflareAccountId: "bd82bbc79ce38442976432eaa409e48c"
+      cloudflareAccountId: "account-123"
     }
   });
 
@@ -49,7 +49,7 @@ test("cloudflare deploy secret sync requires deploy_production approval grant", 
     repo: "marushu/vtdd-v2-p",
     source: {
       cloudflareApiToken: "cf-token-redacted",
-      cloudflareAccountId: "bd82bbc79ce38442976432eaa409e48c"
+      cloudflareAccountId: "account-123"
     },
     approvalGrant: {
       ...validApprovalGrant,
@@ -71,7 +71,7 @@ test("cloudflare deploy secret sync calls runner without exposing token", async 
     repo: "marushu/vtdd-v2-p",
     source: {
       cloudflareApiToken: "cf-token-redacted",
-      cloudflareAccountId: "bd82bbc79ce38442976432eaa409e48c"
+      cloudflareAccountId: "account-123"
     },
     approvalGrant: validApprovalGrant,
     runner: async (secret) => {

--- a/test/desktop-bootstrap-vault.test.js
+++ b/test/desktop-bootstrap-vault.test.js
@@ -1,0 +1,87 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fsSync from "node:fs";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+  DEFAULT_VTDD_VAULT_MANIFEST_PATH,
+  loadDesktopBootstrapVault
+} from "../src/core/desktop-bootstrap-vault.js";
+
+test("desktop bootstrap vault loads referenced root credential files", async () => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "vtdd-vault-"));
+  const credentialsDir = path.join(tempDir, "credentials");
+  await fs.mkdir(path.join(credentialsDir, "github-app"), { recursive: true });
+  await fs.mkdir(path.join(credentialsDir, "cloudflare"), { recursive: true });
+  await fs.mkdir(path.join(credentialsDir, "gateway"), { recursive: true });
+  await fs.mkdir(path.join(credentialsDir, "reviewer"), { recursive: true });
+
+  const keyPath = path.join(credentialsDir, "github-app", "private-key.pem");
+  const cloudflareTokenPath = path.join(credentialsDir, "cloudflare", "api-token.txt");
+  const gatewayTokenPath = path.join(credentialsDir, "gateway", "bearer-token.txt");
+  const reviewerTokenPath = path.join(credentialsDir, "reviewer", "gemini-api-key.txt");
+  const manifestPath = path.join(credentialsDir, "manifest.json");
+
+  await fs.writeFile(keyPath, "-----BEGIN PRIVATE KEY-----\nexample\n-----END PRIVATE KEY-----\n");
+  await fs.writeFile(cloudflareTokenPath, "cf-token-example\n");
+  await fs.writeFile(gatewayTokenPath, "gateway-token-example\n");
+  await fs.writeFile(reviewerTokenPath, "gemini-token-example\n");
+  await fs.writeFile(
+    manifestPath,
+    JSON.stringify(
+      {
+        version: 1,
+        githubApp: {
+          appId: "3467409",
+          installationId: "126180737",
+          privateKeyPath: "github-app/private-key.pem"
+        },
+        cloudflare: {
+          accountId: "account-123",
+          apiTokenPath: "cloudflare/api-token.txt"
+        },
+        gateway: {
+          bearerTokenPath: "gateway/bearer-token.txt"
+        },
+        reviewer: {
+          geminiApiKeyPath: "reviewer/gemini-api-key.txt"
+        }
+      },
+      null,
+      2
+    )
+  );
+
+  const result = await loadDesktopBootstrapVault({ manifestPath });
+  assert.equal(result.ok, true);
+  assert.equal(result.vault.manifestPath, manifestPath);
+  assert.equal(result.vault.githubApp.appId, "3467409");
+  assert.equal(result.vault.githubApp.installationId, "126180737");
+  assert.equal(result.vault.cloudflare.accountId, "account-123");
+  assert.equal(result.vault.cloudflare.apiToken, "cf-token-example");
+  assert.equal(result.vault.gateway.bearerToken, "gateway-token-example");
+  assert.equal(result.vault.reviewer.geminiApiKey, "gemini-token-example");
+});
+
+test("desktop bootstrap vault reports missing canonical manifest", async () => {
+  const result = await loadDesktopBootstrapVault({
+    manifestPath: path.join(os.tmpdir(), "vtdd-missing-manifest", "manifest.json")
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.issues[0].includes("desktop bootstrap vault manifest not found"), true);
+});
+
+test("desktop bootstrap vault constants point to ~/.vtdd by default", () => {
+  assert.equal(DEFAULT_VTDD_VAULT_MANIFEST_PATH.endsWith(".vtdd/credentials/manifest.json"), true);
+});
+
+test("desktop bootstrap vault doc defines canonical path and desktop maintenance state", () => {
+  const docPath = path.join(process.cwd(), "docs", "setup", "desktop-bootstrap-vault.md");
+  const doc = fsSync.readFileSync(docPath, "utf8");
+
+  assert.equal(doc.includes("~/.vtdd/credentials/manifest.json"), true);
+  assert.equal(doc.includes("desktop maintenance required"), true);
+  assert.equal(doc.includes("Short-lived execution credentials must not be stored here."), true);
+});

--- a/test/github-app-secret-sync.test.js
+++ b/test/github-app-secret-sync.test.js
@@ -10,31 +10,40 @@ import {
   validateGitHubAppSecretSyncApprovalGrant
 } from "../src/core/github-app-secret-sync.js";
 
-test("loadGitHubAppSecretSource reads app id and private key from existing env file", async () => {
+test("loadGitHubAppSecretSource reads app id and private key from desktop bootstrap vault", async () => {
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "vtdd-app-sync-"));
-  const keyPath = path.join(tempDir, "app.pem");
-  const envPath = path.join(tempDir, "load-env.sh");
-  const tokenPath = path.join(tempDir, "gateway-token.txt");
+  const credentialsDir = path.join(tempDir, "credentials");
+  await fs.mkdir(path.join(credentialsDir, "github-app"), { recursive: true });
+  await fs.mkdir(path.join(credentialsDir, "gateway"), { recursive: true });
+  const keyPath = path.join(credentialsDir, "github-app", "private-key.pem");
+  const tokenPath = path.join(credentialsDir, "gateway", "bearer-token.txt");
+  const manifestPath = path.join(credentialsDir, "manifest.json");
 
-  await fs.writeFile(
-    keyPath,
-    "-----BEGIN PRIVATE KEY-----\nexample\n-----END PRIVATE KEY-----\n",
-    "utf8"
-  );
+  await fs.writeFile(keyPath, "-----BEGIN PRIVATE KEY-----\nexample\n-----END PRIVATE KEY-----\n", "utf8");
   await fs.writeFile(tokenPath, "test-bearer-token\n", "utf8");
   await fs.writeFile(
-    envPath,
-    [
-      'export GITHUB_APP_ID="3467409"',
-      'export GITHUB_APP_INSTALLATION_ID="126180737"',
-      `export GITHUB_APP_PRIVATE_KEY_PATH="${keyPath}"`,
-      `export VTDD_GATEWAY_BEARER_TOKEN_PATH="${tokenPath}"`
-    ].join("\n"),
+    manifestPath,
+    JSON.stringify(
+      {
+        version: 1,
+        githubApp: {
+          appId: "3467409",
+          installationId: "126180737",
+          privateKeyPath: "github-app/private-key.pem"
+        },
+        gateway: {
+          bearerTokenPath: "gateway/bearer-token.txt"
+        }
+      },
+      null,
+      2
+    ),
     "utf8"
   );
 
-  const result = await loadGitHubAppSecretSource({ envPath });
+  const result = await loadGitHubAppSecretSource({ manifestPath });
   assert.equal(result.ok, true);
+  assert.equal(result.source.sourceType, "desktop_bootstrap_vault");
   assert.equal(result.source.appId, "3467409");
   assert.equal(result.source.installationId, "126180737");
   assert.equal(result.source.privateKey.includes("BEGIN PRIVATE KEY"), true);


### PR DESCRIPTION
## Intent
- implement Issue #43 by defining `~/.vtdd/credentials/manifest.json` as the canonical desktop bootstrap vault
- switch GitHub App and Cloudflare secret sync bootstrap paths to read operator-owned local vault material instead of repo-local bootstrap blobs
- document `desktop maintenance required` as the runtime degradation when iPhone-only operation cannot continue

## Success Criteria Addressed
- `~/.vtdd/` is defined as the canonical local bootstrap vault path
- a vault manifest schema is defined and documented
- manifest stores references/metadata, not short-lived execution tokens
- GitHub App / Cloudflare / gateway / reviewer root credential references are covered
- `desktop maintenance required` state is defined in canonical docs

## Non-goals
- setup wizard revival
- vault encryption/KMS rollout
- D1 secret storage
- GitHub read plane implementation (#46)

## Files Changed
- `src/core/desktop-bootstrap-vault.js`
- `src/core/github-app-secret-sync.js`
- `scripts/sync-github-app-actions-secrets.mjs`
- `scripts/run-passkey-operator-helper.mjs`
- `scripts/sync-cloudflare-actions-secrets.mjs`
- `docs/setup/desktop-bootstrap-vault.md`
- `docs/setup/github-app-secret-sync.md`
- `docs/setup/cloudflare-deploy-secret-sync.md`
- `README.md`
- `test/desktop-bootstrap-vault.test.js`
- `test/github-app-secret-sync.test.js`
- `test/cloudflare-deploy-secret-sync.test.js`

## Validation
- `node --test test/desktop-bootstrap-vault.test.js test/github-app-secret-sync.test.js test/cloudflare-deploy-secret-sync.test.js`
- `npm test -- --test-name-pattern='desktop bootstrap vault|GitHub App secret sync|cloudflare deploy secret sync|custom gpt setup docs'`

## Evidence
- vault contract is documented in `docs/setup/desktop-bootstrap-vault.md`
- GitHub App sync dry-run/execute now read `~/.vtdd/credentials/manifest.json` by default
- Cloudflare secret sync can read Cloudflare/gateway material from the same vault
- no owner-specific runtime URL remains in the touched public-facing docs

Related: #43
