### PR TITLE
Define Butler Codex Human authority model

### DIFF
--- a/docs/butler/authority-model.md
+++ b/docs/butler/authority-model.md
@@ -1,0 +1,162 @@
+# Butler-Codex-Human Authority Model
+
+This document is the canonical authority model for Issue #45.
+
+## Purpose
+
+VTDD must preserve a clear authority split:
+
+- Codex is the executor
+- Butler is the judgment and authority gateway
+- Human is the final authority
+
+This model exists so Codex can act with high freedom inside bounded Issue
+scope without silently taking authority actions such as merge or issue close.
+
+## Core Definition
+
+- Issue is the canonical execution spec.
+- GitHub runtime truth is the canonical current-state surface.
+- Codex is free inside bounded Issue scope.
+- Codex is not the spec authority.
+- Codex does not merge or close issues directly.
+- Butler performs authority-gated GitHub actions after human approval.
+- Human remains the final authority for merge, close, deploy, permission, and
+  credential decisions.
+
+## Role Definitions
+
+### Butler
+
+Butler:
+
+- reads Issue, PR, review comments, CI, and runtime truth
+- decides whether execution may continue safely
+- summarizes reviewer objections and unresolved risk
+- requests human approval when authority boundaries are reached
+- executes Butler-side GitHub authority actions through GitHub App after the
+  required approval tier succeeds
+
+Butler is the only role in this model that may bridge human approval into
+GitHub authority actions.
+
+### Codex
+
+Codex:
+
+- performs bounded coding work inside approved Issue scope
+- creates and updates branches, commits, and PRs within that scope
+- responds to review comments within approved scope
+- may choose implementation details freely inside that scope
+
+Codex must not:
+
+- redefine spec
+- silently widen Issue scope
+- merge
+- close issues
+- perform Butler-side authority actions
+
+### Human
+
+Human:
+
+- approves execution continuation when needed
+- approves merge and issue close through Butler
+- completes real passkey/WebAuthn approval for high-risk actions
+- remains the final authority for milestone judgment
+
+## Codex Default Path
+
+The default Codex executor path is:
+
+- ChatGPT Pro / Codex Cloud
+
+The canonical remote path is GitHub-centered delegation through the operator's
+own Codex Cloud GitHub integration.
+
+`OPENAI_API_KEY`-backed runners are optional opt-in machine paths, not the
+default VTDD executor model.
+
+## Authority Return Contract
+
+Codex does not return to Butler through an invisible private chat channel.
+
+Codex returns control through GitHub-observable runtime truth that Butler can
+read. Canonical return surfaces are:
+
+- PR state
+- Issue comments
+- PR comments
+- review replies
+- structured delegation/progress comments
+
+When Codex reaches a boundary that requires Butler/human action, it must leave
+GitHub-observable evidence that Butler can read and summarize.
+
+## Canonical Return Markers
+
+At minimum, the authority return contract recognizes these marker states:
+
+- `approval_required`
+- `scope_ambiguous`
+- `review_response_needed`
+- `blocked_by_missing_runtime_state`
+
+Meaning:
+
+- `approval_required`
+  Codex has reached a boundary that requires Butler to obtain human approval
+  before continuing.
+- `scope_ambiguous`
+  Codex cannot continue safely because Issue scope or bounded intent is not
+  clear enough.
+- `review_response_needed`
+  reviewer objections or PR discussion require Butler/human judgment before the
+  next bounded execution step.
+- `blocked_by_missing_runtime_state`
+  Codex cannot continue because required GitHub/runtime truth is missing,
+  unreadable, or inconsistent.
+
+## Merge And Close Authority
+
+Merge and issue close are Butler-side authority actions.
+
+Canonical path:
+
+1. Codex creates or updates the PR
+2. reviewer returns critique
+3. Butler summarizes PR / review / CI state
+4. human requests merge or close
+5. Butler verifies approval tier
+6. Butler uses GitHub App short-lived execution ability to perform the action
+
+Codex does not perform merge directly.
+
+## Approval Boundary
+
+- read-only GitHub observation does not require merge authority
+- normal bounded execution follows the normal execution approval tier
+- merge and bounded issue close require explicit `GO`
+- deploy, credential mutation, permission mutation, and destructive actions
+  require `GO + real passkey`
+
+`passkey` in this model means real WebAuthn/passkey authentication, not a chat
+phrase.
+
+## Desktop Maintenance Required
+
+If required operator-owned root credential maintenance can only continue from
+desktop bootstrap state, Butler must stop and surface:
+
+- `desktop maintenance required`
+
+This is not a Codex-side authority return marker. It is a Butler runtime state
+that blocks further authority action until the desktop bootstrap path is used.
+
+## Non-goals
+
+- replacing GitHub runtime truth with Codex summaries
+- allowing Codex to merge directly
+- making API-backed Codex runners the default path
+- collapsing Butler and Codex into one authority role

--- a/docs/butler/codex-pr-revision-loop.md
+++ b/docs/butler/codex-pr-revision-loop.md
@@ -21,6 +21,8 @@ The canonical execution path is:
 
 Codex's bounded goal for this slice is PR creation and PR revision work.
 Merge remains a human `GO` decision.
+Codex authority return remains GitHub-observable and Butler-mediated, not a
+private chat backchannel.
 
 ## Resume-first Rule
 
@@ -80,6 +82,8 @@ After Codex creates a PR:
 - performs bounded coding work
 - creates and updates the PR
 - responds on the PR within approved scope
+- returns control through GitHub-observable state when approval, scope, review,
+  or runtime-truth boundaries are reached
 
 ### Gemini
 
@@ -93,3 +97,5 @@ After Codex creates a PR:
 - no treating handoff as canonical spec
 - no merge without explicit human `GO`
 - no erasing meaningful reviewer objections in Butler summaries
+- no invisible Codex-to-Butler authority channel outside GitHub-observable
+  runtime truth

--- a/docs/butler/remote-codex-cli-executor.md
+++ b/docs/butler/remote-codex-cli-executor.md
@@ -40,6 +40,9 @@ This path depends on the operator having connected Codex Cloud to GitHub in
 their own ChatGPT/Codex account. VTDD must surface that as operator-owned
 configuration, not as a repository secret owned by this public repo.
 
+Codex Cloud is the default account-backed executor path. `OPENAI_API_KEY`
+runners are optional opt-in machine paths only.
+
 ## Default Codex Cloud GitHub Comment Runner
 
 The default no-extra-API-cost runner is:
@@ -97,6 +100,9 @@ Progress must be reconstructable from:
 - GitHub Actions run state
 - VTDD execution log
 - branch / PR state in GitHub runtime truth
+
+When Codex reaches an approval or scope boundary, the observable return path is
+GitHub state that Butler can read, not a hidden direct Codex-to-Butler channel.
 
 ## One-slice Goal
 

--- a/docs/butler/role-separation.md
+++ b/docs/butler/role-separation.md
@@ -2,6 +2,9 @@
 
 This document is the canonical role separation model for Issue #25.
 
+For the Butler/Codex/Human authority boundary used by the current GitHub-first
+execution loop, also read [authority-model.md](./authority-model.md).
+
 ## Goal
 
 Butler, Executor, and Reviewer must remain structurally separated even when the same underlying AI product is used during a transition period.
@@ -27,7 +30,9 @@ Output:
 - execution judgment
 - reviewer summary for human decision
 
-Butler does not directly hold merge authority or deployment authority.
+Butler does not grant itself authority silently. Merge, issue close, deploy,
+credential mutation, and other authority actions remain approval-bound as
+described in [authority-model.md](./authority-model.md).
 
 ### Executor
 
@@ -45,7 +50,9 @@ Output:
 - PR artifacts
 - execution logs
 
-Executor is the only role that may perform implementation-side execution within the approved boundary.
+Executor is the only role that may perform implementation-side execution within
+the approved boundary, but it does not become the authority role for merge or
+close.
 
 ### Reviewer
 

--- a/test/authority-model.test.js
+++ b/test/authority-model.test.js
@@ -1,0 +1,35 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const read = (filePath) => fs.readFileSync(filePath, "utf8");
+
+test("authority model defines Codex freedom inside Issue scope and Butler-side merge authority", () => {
+  const doc = read("docs/butler/authority-model.md");
+
+  assert.equal(doc.includes("Codex is free inside bounded Issue scope."), true);
+  assert.equal(doc.includes("Codex does not merge or close issues directly."), true);
+  assert.equal(doc.includes("Merge and issue close are Butler-side authority actions."), true);
+  assert.equal(doc.includes("ChatGPT Pro / Codex Cloud"), true);
+  assert.equal(doc.includes("`OPENAI_API_KEY`-backed runners are optional opt-in machine paths"), true);
+});
+
+test("authority model defines GitHub-observable Codex return markers", () => {
+  const doc = read("docs/butler/authority-model.md");
+
+  assert.equal(doc.includes("Codex does not return to Butler through an invisible private chat channel."), true);
+  assert.equal(doc.includes("approval_required"), true);
+  assert.equal(doc.includes("scope_ambiguous"), true);
+  assert.equal(doc.includes("review_response_needed"), true);
+  assert.equal(doc.includes("blocked_by_missing_runtime_state"), true);
+});
+
+test("loop and role docs reference Butler-mediated authority return", () => {
+  const roleDoc = read("docs/butler/role-separation.md");
+  const loopDoc = read("docs/butler/codex-pr-revision-loop.md");
+  const remoteDoc = read("docs/butler/remote-codex-cli-executor.md");
+
+  assert.equal(roleDoc.includes("authority-model.md"), true);
+  assert.equal(loopDoc.includes("private chat backchannel"), true);
+  assert.equal(remoteDoc.includes("hidden direct Codex-to-Butler channel"), true);
+});


### PR DESCRIPTION
## Intent
- implement the Issue #45 docs contract for Butler / Codex / Human authority boundaries
- define Codex freedom inside bounded Issue scope without allowing Codex to take merge/close authority
- define `Codex -> Butler authority return` as GitHub-observable runtime truth, not a hidden private channel

## Success Criteria Addressed
- canonical authority model doc exists for Butler / Codex / Human
- doc states Codex is free within bounded Issue scope
- doc states Codex returns control on approval/high-risk/scope/runtime boundaries
- doc states merge / issue close are Butler-side authority actions
- marker contract includes `approval_required`, `scope_ambiguous`, `review_response_needed`, and `blocked_by_missing_runtime_state`
- doc states ChatGPT Pro / Codex Cloud is the default Codex path and `OPENAI_API_KEY` runners are optional opt-in

## Non-goals
- GitHub read plane implementation
- merge automation by Codex
- runtime route additions
- treating docs-only progress as end-to-end completion

## Files Changed
- `docs/butler/authority-model.md`
- `docs/butler/role-separation.md`
- `docs/butler/codex-pr-revision-loop.md`
- `docs/butler/remote-codex-cli-executor.md`
- `test/authority-model.test.js`

## Validation
- `node --test test/authority-model.test.js test/cost-account-boundary.test.js`

## Evidence
- authority model is now explicit in `docs/butler/authority-model.md`
- existing Butler/Codex docs now reference Butler-mediated authority return and Butler-side merge authority
- no runtime completion claim is made; this PR is definition/contract only

Related: #45
