### PR TITLE
Implement GitHub read plane for Butler runtime truth

### DIFF
--- a/docs/setup/custom-gpt-actions-openapi.json
+++ b/docs/setup/custom-gpt-actions-openapi.json
@@ -520,6 +520,127 @@
         }
       }
     },
+    "/v2/retrieve/github": {
+      "get": {
+        "operationId": "vtddRetrieveGitHub",
+        "summary": "Read GitHub runtime truth through the VTDD GitHub read plane.",
+        "parameters": [
+          {
+            "name": "resource",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "repositories",
+                "issues",
+                "issue_comments",
+                "pulls",
+                "pull_reviews",
+                "pull_review_comments",
+                "checks",
+                "workflow_runs",
+                "branches"
+              ]
+            }
+          },
+          {
+            "name": "repository",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "issueNumber",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "pullNumber",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "branch",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "ref",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "state",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "GitHub runtime truth read result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VtddGenericResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing machine auth"
+          },
+          "403": {
+            "description": "Invalid machine auth"
+          },
+          "422": {
+            "description": "GitHub read request blocked or invalid",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VtddGenericResponse"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "GitHub read route unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VtddGenericResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v2/retrieve/approval-grant": {
       "get": {
         "operationId": "vtddRetrieveApprovalGrant",

--- a/docs/setup/custom-gpt-actions-openapi.yaml
+++ b/docs/setup/custom-gpt-actions-openapi.yaml
@@ -341,6 +341,84 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/VtddGenericResponse"
+  /v2/retrieve/github:
+    get:
+      operationId: vtddRetrieveGitHub
+      summary: Read GitHub runtime truth through the VTDD GitHub read plane.
+      parameters:
+        - name: resource
+          in: query
+          required: true
+          schema:
+            type: string
+            enum:
+              - repositories
+              - issues
+              - issue_comments
+              - pulls
+              - pull_reviews
+              - pull_review_comments
+              - checks
+              - workflow_runs
+              - branches
+        - name: repository
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: issueNumber
+          in: query
+          required: false
+          schema:
+            type: integer
+        - name: pullNumber
+          in: query
+          required: false
+          schema:
+            type: integer
+        - name: branch
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: ref
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: state
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: GitHub runtime truth read result
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VtddGenericResponse"
+        "401":
+          description: Missing machine auth
+        "403":
+          description: Invalid machine auth
+        "422":
+          description: GitHub read request blocked or invalid
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VtddGenericResponse"
+        "503":
+          description: GitHub read route unavailable
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VtddGenericResponse"
   /v2/retrieve/approval-grant:
     get:
       operationId: vtddRetrieveApprovalGrant

--- a/docs/setup/custom-gpt-instructions.md
+++ b/docs/setup/custom-gpt-instructions.md
@@ -50,6 +50,33 @@ Repository listing and context resolution:
   - policyInput.consent.grantedCategories=["read"]
 - Read repositoryCandidates from the response and present them in human-friendly Japanese.
 
+GitHub runtime truth read plane:
+- When the user asks Butler to read GitHub runtime truth directly, use vtddRetrieveGitHub.
+- Use vtddRetrieveGitHub for:
+  - repository list
+  - Issue list / Issue detail
+  - Issue comments
+  - PR list / PR detail
+  - PR reviews
+  - PR review comments
+  - checks
+  - workflow runs
+  - branches
+- Map natural language into resource names yourself:
+  - repositories
+  - issues
+  - issue_comments
+  - pulls
+  - pull_reviews
+  - pull_review_comments
+  - checks
+  - workflow_runs
+  - branches
+- For read requests, prefer vtddRetrieveGitHub over speculative explanation.
+- If the route returns unsupported, answer that the current Butler surface is未対応 for that exact read.
+- If the route returns unauthorized or invalid machine auth, answer that the read failed due to 認証失敗.
+- Do not infer "Issue may not exist" or similar from an unsupported or failed read.
+
 Execution judgment:
 - Before execution, read current runtime truth through vtddGateway.
 - If the target repository is unresolved, do not execute.
@@ -89,6 +116,7 @@ Review loop:
 - If reviewer objections remain unresolved, do not recommend merge GO.
 - If no reviewer evidence exists yet, say so plainly.
 - If reviewer output is approve-only, still present it as reviewer evidence and keep final judgment with the human.
+- Prefer vtddRetrieveGitHub for PR state, reviews, review comments, checks, workflow runs, and branches when those facts are needed for a summary.
 
 Approval boundaries:
 - High-risk actions require GO + passkey.
@@ -101,6 +129,7 @@ Forbidden behavior:
 - Do not erase meaningful reviewer objections in summaries.
 - Do not say "done" or "completed" without GitHub-visible evidence.
 - Do not claim a PR exists when only a Codex task summary exists.
+- Do not claim that Issues/PRs/comments are absent when the read path is unsupported, unauthorized, or unverified.
 - Do not merge, deploy, mutate secrets, or perform destructive actions on your own.
 - Do not embed owner-specific Cloudflare URLs, account IDs, or private values as if they were universal defaults.
 

--- a/src/core/github-read-plane.js
+++ b/src/core/github-read-plane.js
@@ -1,0 +1,426 @@
+import { resolveGitHubAppInstallationToken } from "./github-app-repository-index.js";
+
+const GITHUB_API_BASE_URL = "https://api.github.com";
+const GITHUB_API_VERSION = "2022-11-28";
+const GITHUB_API_USER_AGENT = "vtdd-v2-github-read-plane";
+const INSTALLATION_REPOSITORIES_PATH = "/installation/repositories";
+
+export const GitHubReadResource = Object.freeze({
+  REPOSITORIES: "repositories",
+  ISSUES: "issues",
+  ISSUE_COMMENTS: "issue_comments",
+  PULLS: "pulls",
+  PULL_REVIEWS: "pull_reviews",
+  PULL_REVIEW_COMMENTS: "pull_review_comments",
+  CHECKS: "checks",
+  WORKFLOW_RUNS: "workflow_runs",
+  BRANCHES: "branches"
+});
+
+export async function retrieveGitHubReadPlane(input = {}) {
+  const resource = normalizeText(input.resource);
+  const repository = normalizeText(input.repository);
+  const issueNumber = normalizePositiveInteger(input.issueNumber);
+  const pullNumber = normalizePositiveInteger(input.pullNumber);
+  const branch = normalizeText(input.branch);
+  const ref = normalizeText(input.ref) || branch;
+  const state = normalizeText(input.state) || "open";
+  const limit = normalizeLimit(input.limit, 20);
+  const env = input.env ?? {};
+  const fetchImpl = typeof env?.GITHUB_API_FETCH === "function" ? env.GITHUB_API_FETCH.bind(env) : fetch;
+  const apiBaseUrl = normalizeApiBaseUrl(env?.GITHUB_API_BASE_URL);
+
+  const tokenResolution = await resolveGitHubAppInstallationToken({ env, fetchImpl, apiBaseUrl });
+  if (!tokenResolution.ok) {
+    return {
+      ok: false,
+      status: 503,
+      error: "github_read_unavailable",
+      reason: tokenResolution.warning || "GitHub App installation token is unavailable"
+    };
+  }
+
+  const validation = validateGitHubReadRequest({
+    resource,
+    repository,
+    issueNumber,
+    pullNumber,
+    ref
+  });
+  if (!validation.ok) {
+    return {
+      ok: false,
+      status: 422,
+      error: "github_read_request_invalid",
+      reason: validation.issues.join(", "),
+      issues: validation.issues
+    };
+  }
+
+  return fetchGitHubReadResource({
+    resource,
+    repository,
+    issueNumber,
+    pullNumber,
+    ref,
+    branch,
+    state,
+    limit,
+    token: tokenResolution.token,
+    fetchImpl,
+    apiBaseUrl
+  });
+}
+
+function validateGitHubReadRequest({ resource, repository, issueNumber, pullNumber, ref }) {
+  const issues = [];
+  if (!Object.values(GitHubReadResource).includes(resource)) {
+    issues.push("resource is unsupported");
+  }
+
+  if (resource !== GitHubReadResource.REPOSITORIES && !repository) {
+    issues.push("repository is required");
+  }
+
+  if (resource === GitHubReadResource.ISSUE_COMMENTS && !issueNumber) {
+    issues.push("issueNumber is required for issue_comments");
+  }
+
+  if (
+    (resource === GitHubReadResource.PULL_REVIEWS ||
+      resource === GitHubReadResource.PULL_REVIEW_COMMENTS) &&
+    !pullNumber
+  ) {
+    issues.push("pullNumber is required for pull review resources");
+  }
+
+  if (resource === GitHubReadResource.CHECKS && !ref) {
+    issues.push("ref or branch is required for checks");
+  }
+
+  return issues.length > 0 ? { ok: false, issues } : { ok: true };
+}
+
+async function fetchGitHubReadResource(input) {
+  const {
+    resource,
+    repository,
+    issueNumber,
+    pullNumber,
+    ref,
+    branch,
+    state,
+    limit,
+    token,
+    fetchImpl,
+    apiBaseUrl
+  } = input;
+
+  const request = buildGitHubReadRequest({
+    resource,
+    repository,
+    issueNumber,
+    pullNumber,
+    ref,
+    branch,
+    state,
+    limit,
+    apiBaseUrl
+  });
+
+  let response;
+  try {
+    response = await fetchImpl(request.url, {
+      method: "GET",
+      headers: {
+        authorization: `Bearer ${token}`,
+        accept: "application/vnd.github+json",
+        "x-github-api-version": GITHUB_API_VERSION,
+        "user-agent": GITHUB_API_USER_AGENT
+      }
+    });
+  } catch {
+    return {
+      ok: false,
+      status: 503,
+      error: "github_read_failed",
+      reason: `failed to read GitHub resource: ${resource}`
+    };
+  }
+
+  const body = await readJsonSafe(response);
+  if (!response.ok) {
+    return {
+      ok: false,
+      status: response.status,
+      error: "github_read_failed",
+      reason: normalizeText(body?.message) || `GitHub read failed for ${resource}`
+    };
+  }
+
+  return {
+    ok: true,
+    read: {
+      resource,
+      repository: repository || null,
+      issueNumber: issueNumber || null,
+      pullNumber: pullNumber || null,
+      branch: branch || null,
+      ref: ref || null,
+      state,
+      records: normalizeGitHubReadRecords(resource, body)
+    }
+  };
+}
+
+function buildGitHubReadRequest({
+  resource,
+  repository,
+  issueNumber,
+  pullNumber,
+  ref,
+  branch,
+  state,
+  limit,
+  apiBaseUrl
+}) {
+  const encodedRepository = repository ? encodeURIComponentRepository(repository) : "";
+
+  if (resource === GitHubReadResource.REPOSITORIES) {
+    return {
+      url: `${apiBaseUrl}${INSTALLATION_REPOSITORIES_PATH}?per_page=${limit}`
+    };
+  }
+
+  if (resource === GitHubReadResource.ISSUES) {
+    if (issueNumber) {
+      return {
+        url: `${apiBaseUrl}/repos/${encodedRepository}/issues/${issueNumber}`
+      };
+    }
+    return {
+      url: `${apiBaseUrl}/repos/${encodedRepository}/issues?state=${encodeURIComponent(state)}&per_page=${limit}`
+    };
+  }
+
+  if (resource === GitHubReadResource.ISSUE_COMMENTS) {
+    return {
+      url: `${apiBaseUrl}/repos/${encodedRepository}/issues/${issueNumber}/comments?per_page=${limit}`
+    };
+  }
+
+  if (resource === GitHubReadResource.PULLS) {
+    if (pullNumber) {
+      return {
+        url: `${apiBaseUrl}/repos/${encodedRepository}/pulls/${pullNumber}`
+      };
+    }
+    return {
+      url: `${apiBaseUrl}/repos/${encodedRepository}/pulls?state=${encodeURIComponent(state)}&per_page=${limit}`
+    };
+  }
+
+  if (resource === GitHubReadResource.PULL_REVIEWS) {
+    return {
+      url: `${apiBaseUrl}/repos/${encodedRepository}/pulls/${pullNumber}/reviews?per_page=${limit}`
+    };
+  }
+
+  if (resource === GitHubReadResource.PULL_REVIEW_COMMENTS) {
+    return {
+      url: `${apiBaseUrl}/repos/${encodedRepository}/pulls/${pullNumber}/comments?per_page=${limit}`
+    };
+  }
+
+  if (resource === GitHubReadResource.CHECKS) {
+    return {
+      url: `${apiBaseUrl}/repos/${encodedRepository}/commits/${encodeURIComponent(ref)}/check-runs?per_page=${limit}`
+    };
+  }
+
+  if (resource === GitHubReadResource.WORKFLOW_RUNS) {
+    const url = new URL(`${apiBaseUrl}/repos/${encodedRepository}/actions/runs`);
+    url.searchParams.set("per_page", String(limit));
+    if (branch) {
+      url.searchParams.set("branch", branch);
+    }
+    return { url: url.toString() };
+  }
+
+  if (resource === GitHubReadResource.BRANCHES) {
+    if (branch) {
+      return {
+        url: `${apiBaseUrl}/repos/${encodedRepository}/branches/${encodeURIComponent(branch)}`
+      };
+    }
+    return {
+      url: `${apiBaseUrl}/repos/${encodedRepository}/branches?per_page=${limit}`
+    };
+  }
+
+  return { url: `${apiBaseUrl}/repos/${encodedRepository}` };
+}
+
+function normalizeGitHubReadRecords(resource, body) {
+  if (resource === GitHubReadResource.REPOSITORIES) {
+    return normalizeRepositories(body?.repositories ?? []);
+  }
+  if (resource === GitHubReadResource.ISSUES) {
+    if (Array.isArray(body)) {
+      return body.filter((item) => !item?.pull_request).map(normalizeIssue);
+    }
+    return body?.pull_request ? [] : [normalizeIssue(body)];
+  }
+  if (resource === GitHubReadResource.ISSUE_COMMENTS) {
+    return Array.isArray(body) ? body.map(normalizeIssueComment) : [];
+  }
+  if (resource === GitHubReadResource.PULLS) {
+    return Array.isArray(body) ? body.map(normalizePullRequest) : [normalizePullRequest(body)];
+  }
+  if (resource === GitHubReadResource.PULL_REVIEWS) {
+    return Array.isArray(body) ? body.map(normalizePullReview) : [];
+  }
+  if (resource === GitHubReadResource.PULL_REVIEW_COMMENTS) {
+    return Array.isArray(body) ? body.map(normalizePullReviewComment) : [];
+  }
+  if (resource === GitHubReadResource.CHECKS) {
+    return Array.isArray(body?.check_runs) ? body.check_runs.map(normalizeCheckRun) : [];
+  }
+  if (resource === GitHubReadResource.WORKFLOW_RUNS) {
+    return Array.isArray(body?.workflow_runs) ? body.workflow_runs.map(normalizeWorkflowRun) : [];
+  }
+  if (resource === GitHubReadResource.BRANCHES) {
+    return Array.isArray(body) ? body.map(normalizeBranch) : [normalizeBranch(body)];
+  }
+  return [];
+}
+
+function normalizeRepositories(items) {
+  return items.map((item) => ({
+    fullName: normalizeText(item?.full_name),
+    name: normalizeText(item?.name),
+    visibility: item?.private === true ? "private" : "public",
+    defaultBranch: normalizeText(item?.default_branch),
+    htmlUrl: normalizeText(item?.html_url)
+  }));
+}
+
+function normalizeIssue(item) {
+  return {
+    number: normalizePositiveInteger(item?.number),
+    title: normalizeText(item?.title),
+    state: normalizeText(item?.state),
+    htmlUrl: normalizeText(item?.html_url),
+    author: normalizeText(item?.user?.login)
+  };
+}
+
+function normalizeIssueComment(item) {
+  return {
+    id: normalizePositiveInteger(item?.id),
+    body: normalizeText(item?.body),
+    author: normalizeText(item?.user?.login),
+    createdAt: normalizeText(item?.created_at),
+    htmlUrl: normalizeText(item?.html_url)
+  };
+}
+
+function normalizePullRequest(item) {
+  return {
+    number: normalizePositiveInteger(item?.number),
+    title: normalizeText(item?.title),
+    state: normalizeText(item?.state),
+    draft: item?.draft === true,
+    headRef: normalizeText(item?.head?.ref),
+    baseRef: normalizeText(item?.base?.ref),
+    htmlUrl: normalizeText(item?.html_url)
+  };
+}
+
+function normalizePullReview(item) {
+  return {
+    id: normalizePositiveInteger(item?.id),
+    state: normalizeText(item?.state),
+    body: normalizeText(item?.body),
+    author: normalizeText(item?.user?.login),
+    submittedAt: normalizeText(item?.submitted_at),
+    htmlUrl: normalizeText(item?.html_url)
+  };
+}
+
+function normalizePullReviewComment(item) {
+  return {
+    id: normalizePositiveInteger(item?.id),
+    path: normalizeText(item?.path),
+    body: normalizeText(item?.body),
+    author: normalizeText(item?.user?.login),
+    createdAt: normalizeText(item?.created_at),
+    htmlUrl: normalizeText(item?.html_url)
+  };
+}
+
+function normalizeCheckRun(item) {
+  return {
+    id: normalizePositiveInteger(item?.id),
+    name: normalizeText(item?.name),
+    status: normalizeText(item?.status),
+    conclusion: normalizeText(item?.conclusion),
+    htmlUrl: normalizeText(item?.html_url)
+  };
+}
+
+function normalizeWorkflowRun(item) {
+  return {
+    id: normalizePositiveInteger(item?.id),
+    name: normalizeText(item?.name),
+    status: normalizeText(item?.status),
+    conclusion: normalizeText(item?.conclusion),
+    headBranch: normalizeText(item?.head_branch),
+    htmlUrl: normalizeText(item?.html_url)
+  };
+}
+
+function normalizeBranch(item) {
+  return {
+    name: normalizeText(item?.name),
+    protected: item?.protected === true,
+    sha: normalizeText(item?.commit?.sha),
+    htmlUrl: normalizeText(item?.commit?.url)
+  };
+}
+
+function readJsonSafe(response) {
+  return response
+    .json()
+    .catch(async () => ({ message: normalizeText(await response.text().catch(() => "")) }));
+}
+
+function encodeURIComponentRepository(repository) {
+  return String(repository ?? "")
+    .trim()
+    .split("/")
+    .map((segment) => encodeURIComponent(segment))
+    .join("/");
+}
+
+function normalizeApiBaseUrl(value) {
+  const text = normalizeText(value);
+  return text ? text.replace(/\/+$/, "") : GITHUB_API_BASE_URL;
+}
+
+function normalizeLimit(value, fallback) {
+  const parsed = Number.parseInt(String(value ?? ""), 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return fallback;
+  }
+  return Math.min(parsed, 100);
+}
+
+function normalizePositiveInteger(value) {
+  const parsed = Number.parseInt(String(value ?? ""), 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+}
+
+function normalizeText(value) {
+  return String(value ?? "").trim();
+}

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -169,6 +169,7 @@ export {
   resolveGatewayAliasRegistryFromGitHubApp,
   resolveGitHubAppInstallationToken
 } from "./github-app-repository-index.js";
+export { GitHubReadResource, retrieveGitHubReadPlane } from "./github-read-plane.js";
 export {
   WorkflowStage,
   WorkflowEvent,

--- a/src/worker.js
+++ b/src/worker.js
@@ -22,6 +22,7 @@ import {
   retrieveConstitution,
   renderPasskeyOperatorPage,
   resolveGatewayAliasRegistryFromGitHubApp,
+  retrieveGitHubReadPlane,
   runMvpGateway,
   validateMemoryProvider,
   verifyPasskeyApproval,
@@ -301,6 +302,18 @@ export default {
       return handleRetrieveCrossIssueRequest(url, env);
     }
 
+    if (request.method === "GET" && isApiPath(url.pathname, "/retrieve/github")) {
+      const auth = authorizeGatewayRequest({ request, env, apiSuffix: "/retrieve/github" });
+      if (!auth.ok) {
+        return json(auth.status, {
+          ok: false,
+          error: "unauthorized",
+          reason: auth.reason
+        });
+      }
+      return handleRetrieveGitHubReadPlaneRequest(url, env);
+    }
+
     return json(404, {
       ok: false,
       error: "not_found"
@@ -479,6 +492,34 @@ async function handleRetrieveApprovalGrantRequest(url, env) {
       expiresAt: normalizeText(record.content.expiresAt) || null,
       scope: normalizeScopeSnapshot(record.content.scope)
     }
+  });
+}
+
+async function handleRetrieveGitHubReadPlaneRequest(url, env) {
+  const retrieved = await retrieveGitHubReadPlane({
+    resource: url.searchParams.get("resource"),
+    repository: url.searchParams.get("repository"),
+    issueNumber: url.searchParams.get("issueNumber"),
+    pullNumber: url.searchParams.get("pullNumber"),
+    branch: url.searchParams.get("branch"),
+    ref: url.searchParams.get("ref"),
+    state: url.searchParams.get("state"),
+    limit: url.searchParams.get("limit"),
+    env
+  });
+
+  if (!retrieved.ok) {
+    return json(retrieved.status ?? 503, {
+      ok: false,
+      error: retrieved.error ?? "github_read_failed",
+      reason: retrieved.reason,
+      issues: retrieved.issues ?? []
+    });
+  }
+
+  return json(200, {
+    ok: true,
+    read: retrieved.read
   });
 }
 

--- a/test/custom-gpt-setup-docs.test.js
+++ b/test/custom-gpt-setup-docs.test.js
@@ -33,8 +33,13 @@ test("custom gpt instructions preserve current butler and approval boundaries", 
   assert.equal(doc.includes("vtddGateway"), true);
   assert.equal(doc.includes("vtddExecute"), true);
   assert.equal(doc.includes("vtddExecutionProgress"), true);
+  assert.equal(doc.includes("vtddRetrieveGitHub"), true);
   assert.equal(doc.includes("High-risk actions require GO + passkey."), true);
   assert.equal(doc.includes("Do not claim a PR exists when only a Codex task summary exists."), true);
+  assert.equal(
+    doc.includes("Do not claim that Issues/PRs/comments are absent when the read path is unsupported, unauthorized, or unverified."),
+    true
+  );
 });
 
 test("custom gpt openapi doc exposes current gateway, execute, and progress routes", () => {
@@ -43,11 +48,14 @@ test("custom gpt openapi doc exposes current gateway, execute, and progress rout
   assert.equal(doc.includes("/v2/gateway:"), true);
   assert.equal(doc.includes("/v2/action/execute:"), true);
   assert.equal(doc.includes("/v2/action/progress:"), true);
+  assert.equal(doc.includes("/v2/retrieve/github:"), true);
   assert.equal(doc.includes("/v2/retrieve/approval-grant:"), true);
   assert.equal(doc.includes("GatewayBearerAuth"), true);
   assert.equal(doc.includes("conversation:"), true);
   assert.equal(doc.includes("repositoryInput:"), true);
   assert.equal(doc.includes("issueNumber"), true);
+  assert.equal(doc.includes("pullNumber"), true);
+  assert.equal(doc.includes("workflow_runs"), true);
 });
 
 test("custom gpt openapi keeps components.schemas while avoiding nested field refs", () => {
@@ -73,6 +81,7 @@ test("custom gpt openapi json parses and exposes paths as an object", () => {
   assert.equal(typeof doc.paths["/v2/gateway"], "object");
   assert.equal(typeof doc.paths["/v2/action/execute"], "object");
   assert.equal(typeof doc.paths["/v2/action/progress"], "object");
+  assert.equal(typeof doc.paths["/v2/retrieve/github"], "object");
   assert.equal(typeof doc.paths["/v2/retrieve/approval-grant"], "object");
   assert.equal(typeof doc.components.schemas, "object");
   assert.equal(doc.components.securitySchemes.GatewayBearerAuth.scheme, "bearer");

--- a/test/github-read-plane.test.js
+++ b/test/github-read-plane.test.js
@@ -1,0 +1,220 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { GitHubReadResource, retrieveGitHubReadPlane } from "../src/core/index.js";
+
+test("github read plane lists repositories through GitHub App token", async () => {
+  const calls = [];
+  const result = await retrieveGitHubReadPlane({
+    resource: GitHubReadResource.REPOSITORIES,
+    env: {
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_repo_read",
+      GITHUB_API_FETCH: async (url, init) => {
+        calls.push({ url, init });
+        return new Response(
+          JSON.stringify({
+            repositories: [
+              {
+                full_name: "sample-org/vtdd-v2-p",
+                name: "vtdd-v2-p",
+                private: false,
+                default_branch: "main",
+                html_url: "https://github.com/sample-org/vtdd-v2-p"
+              }
+            ]
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        );
+      }
+    }
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.read.resource, "repositories");
+  assert.equal(result.read.records[0].fullName, "sample-org/vtdd-v2-p");
+  assert.equal(calls[0].init.headers.authorization, "Bearer ghs_repo_read");
+});
+
+test("github read plane lists issues and filters pull request-shaped issue results", async () => {
+  const result = await retrieveGitHubReadPlane({
+    resource: GitHubReadResource.ISSUES,
+    repository: "sample-org/vtdd-v2-p",
+    env: {
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_issue_read",
+      GITHUB_API_FETCH: async () =>
+        new Response(
+          JSON.stringify([
+            {
+              number: 42,
+              title: "Real issue",
+              state: "open",
+              html_url: "https://github.com/sample-org/vtdd-v2-p/issues/42",
+              user: { login: "marushu" }
+            },
+            {
+              number: 43,
+              title: "PR-shaped issue row",
+              state: "open",
+              html_url: "https://github.com/sample-org/vtdd-v2-p/pull/43",
+              user: { login: "marushu" },
+              pull_request: { url: "https://api.github.com/repos/sample-org/vtdd-v2-p/pulls/43" }
+            }
+          ]),
+          { status: 200, headers: { "content-type": "application/json" } }
+        )
+    }
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.read.records.length, 1);
+  assert.equal(result.read.records[0].number, 42);
+});
+
+test("github read plane reads pull reviews, review comments, checks, workflow runs, and branches", async () => {
+  const responses = new Map([
+    [
+      "/repos/sample-org/vtdd-v2-p/pulls/5/reviews?per_page=20",
+      [
+        {
+          id: 1001,
+          state: "COMMENTED",
+          body: "please revisit",
+          user: { login: "gemini-reviewer" },
+          submitted_at: "2026-04-26T00:00:00Z",
+          html_url: "https://github.com/sample-org/vtdd-v2-p/pull/5#pullrequestreview-1001"
+        }
+      ]
+    ],
+    [
+      "/repos/sample-org/vtdd-v2-p/pulls/5/comments?per_page=20",
+      [
+        {
+          id: 2002,
+          path: "src/app.js",
+          body: "nit",
+          user: { login: "gemini-reviewer" },
+          created_at: "2026-04-26T00:01:00Z",
+          html_url: "https://github.com/sample-org/vtdd-v2-p/pull/5#discussion_r2002"
+        }
+      ]
+    ],
+    [
+      "/repos/sample-org/vtdd-v2-p/commits/codex%2Fissue-6/check-runs?per_page=20",
+      {
+        check_runs: [
+          {
+            id: 3003,
+            name: "test",
+            status: "completed",
+            conclusion: "success",
+            html_url: "https://github.com/sample-org/vtdd-v2-p/actions/runs/3003"
+          }
+        ]
+      }
+    ],
+    [
+      "/repos/sample-org/vtdd-v2-p/actions/runs?per_page=20&branch=codex%2Fissue-6",
+      {
+        workflow_runs: [
+          {
+            id: 4004,
+            name: "ci",
+            status: "completed",
+            conclusion: "success",
+            head_branch: "codex/issue-6",
+            html_url: "https://github.com/sample-org/vtdd-v2-p/actions/runs/4004"
+          }
+        ]
+      }
+    ],
+    [
+      "/repos/sample-org/vtdd-v2-p/branches/codex%2Fissue-6",
+      {
+        name: "codex/issue-6",
+        protected: false,
+        commit: {
+          sha: "abc123",
+          url: "https://api.github.com/repos/sample-org/vtdd-v2-p/commits/abc123"
+        }
+      }
+    ]
+  ]);
+
+  const env = {
+    GITHUB_APP_INSTALLATION_TOKEN: "ghs_read",
+    GITHUB_API_FETCH: async (url) => {
+      const parsed = new URL(url);
+      const key = `${parsed.pathname}${parsed.search}`;
+      const body = responses.get(key);
+      if (!body) {
+        return new Response(JSON.stringify({ message: `unexpected ${key}` }), { status: 404 });
+      }
+      return new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { "content-type": "application/json" }
+      });
+    }
+  };
+
+  const reviews = await retrieveGitHubReadPlane({
+    resource: GitHubReadResource.PULL_REVIEWS,
+    repository: "sample-org/vtdd-v2-p",
+    pullNumber: 5,
+    env
+  });
+  const reviewComments = await retrieveGitHubReadPlane({
+    resource: GitHubReadResource.PULL_REVIEW_COMMENTS,
+    repository: "sample-org/vtdd-v2-p",
+    pullNumber: 5,
+    env
+  });
+  const checks = await retrieveGitHubReadPlane({
+    resource: GitHubReadResource.CHECKS,
+    repository: "sample-org/vtdd-v2-p",
+    branch: "codex/issue-6",
+    env
+  });
+  const workflowRuns = await retrieveGitHubReadPlane({
+    resource: GitHubReadResource.WORKFLOW_RUNS,
+    repository: "sample-org/vtdd-v2-p",
+    branch: "codex/issue-6",
+    env
+  });
+  const branches = await retrieveGitHubReadPlane({
+    resource: GitHubReadResource.BRANCHES,
+    repository: "sample-org/vtdd-v2-p",
+    branch: "codex/issue-6",
+    env
+  });
+
+  assert.equal(reviews.ok, true);
+  assert.equal(reviews.read.records[0].state, "COMMENTED");
+  assert.equal(reviewComments.ok, true);
+  assert.equal(reviewComments.read.records[0].path, "src/app.js");
+  assert.equal(checks.ok, true);
+  assert.equal(checks.read.records[0].conclusion, "success");
+  assert.equal(workflowRuns.ok, true);
+  assert.equal(workflowRuns.read.records[0].headBranch, "codex/issue-6");
+  assert.equal(branches.ok, true);
+  assert.equal(branches.read.records[0].sha, "abc123");
+});
+
+test("github read plane rejects unsupported resources and missing required identifiers", async () => {
+  const unsupported = await retrieveGitHubReadPlane({
+    resource: "milestones",
+    env: {
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_read"
+    }
+  });
+  assert.equal(unsupported.ok, false);
+  assert.equal(unsupported.status, 422);
+
+  const missingPullNumber = await retrieveGitHubReadPlane({
+    resource: GitHubReadResource.PULL_REVIEWS,
+    repository: "sample-org/vtdd-v2-p",
+    env: {
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_read"
+    }
+  });
+  assert.equal(missingPullNumber.ok, false);
+  assert.equal(missingPullNumber.reason.includes("pullNumber is required"), true);
+});

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -811,6 +811,89 @@ test("worker returns approval grant through retrieve route", async () => {
   assert.equal(body.approvalGrant.scope.repositoryInput, "sample-org/vtdd-v2-p");
 });
 
+test("worker returns GitHub repositories through read plane route", async () => {
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/retrieve/github?resource=repositories&limit=5", {
+      headers: gatewayAuthHeaders
+    }),
+    {
+      ...gatewayAuthEnv,
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_repo_read",
+      GITHUB_API_FETCH: async () =>
+        new Response(
+          JSON.stringify({
+            repositories: [
+              {
+                full_name: "sample-org/vtdd-v2-p",
+                name: "vtdd-v2-p",
+                private: false,
+                default_branch: "main",
+                html_url: "https://github.com/sample-org/vtdd-v2-p"
+              }
+            ]
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        )
+    }
+  );
+
+  assert.equal(response.status, 200);
+  const body = await response.json();
+  assert.equal(body.ok, true);
+  assert.equal(body.read.resource, "repositories");
+  assert.equal(body.read.records[0].fullName, "sample-org/vtdd-v2-p");
+});
+
+test("worker returns GitHub issues through read plane route", async () => {
+  const response = await worker.fetch(
+    new Request(
+      "https://example.com/v2/retrieve/github?resource=issues&repository=sample-org/vtdd-v2-p&state=open&limit=5",
+      {
+        headers: gatewayAuthHeaders
+      }
+    ),
+    {
+      ...gatewayAuthEnv,
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_issue_read",
+      GITHUB_API_FETCH: async () =>
+        new Response(
+          JSON.stringify([
+            {
+              number: 46,
+              title: "Implement GitHub read plane",
+              state: "open",
+              html_url: "https://github.com/sample-org/vtdd-v2-p/issues/46",
+              user: { login: "marushu" }
+            }
+          ]),
+          { status: 200, headers: { "content-type": "application/json" } }
+        )
+    }
+  );
+
+  assert.equal(response.status, 200);
+  const body = await response.json();
+  assert.equal(body.ok, true);
+  assert.equal(body.read.records[0].number, 46);
+});
+
+test("worker returns unsupported for unknown GitHub read resources", async () => {
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/retrieve/github?resource=milestones", {
+      headers: gatewayAuthHeaders
+    }),
+    {
+      ...gatewayAuthEnv,
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_issue_read"
+    }
+  );
+
+  assert.equal(response.status, 422);
+  const body = await response.json();
+  assert.equal(body.ok, false);
+  assert.equal(body.error, "github_read_request_invalid");
+});
+
 test("worker returns remote Codex execution progress", async () => {
   const response = await worker.fetch(
     new Request("https://example.com/v2/action/progress?executionId=remote-codex-issue6-abcd12", {


### PR DESCRIPTION
## Summary
- implement a GitHub read plane route for Butler runtime truth under `/v2/retrieve/github`
- cover repositories, issues, issue comments, pulls, reviews, review comments, checks, workflow runs, and branches
- expose the new read route through the Custom GPT Action schema and Butler Instructions

## Verification
- `node --test test/github-read-plane.test.js test/worker.test.js test/custom-gpt-setup-docs.test.js`
- `npx --yes swagger-cli validate docs/setup/custom-gpt-actions-openapi.yaml`
- `npx --yes swagger-cli validate docs/setup/custom-gpt-actions-openapi.json`
