### PR TITLE
Define human-observable live verified contract

### DIFF
--- a/docs/mvp/issue-to-e2e-matrix.md
+++ b/docs/mvp/issue-to-e2e-matrix.md
@@ -10,7 +10,17 @@ Repository status must be treated as partial until every listed E2E scenario has
 - mapped boundary/failure-path result
 - human approval for closure when applicable
 
+This matrix sits above the `live_verified` contract in
+`docs/mvp/live-verified-contract.md`.
+Human-observable runtime evidence is the floor; mapped E2E evidence and human
+closure judgment remain required for milestone completion.
+
 Status values used below:
+
+- `docs_only`: docs/spec/contracts exist, but no connected runtime/code path exists yet
+- `code_only`: code and/or tests exist, but no connected Butler/worker surface exists yet
+- `surface_connected`: a worker/Butler/action path exists, but human-observable external evidence is still missing
+- `live_verified`: the intended behavior is connected and a human can observe the relevant external effect
 
 - `implemented_pending_e2e`: code and tests exist, but mapped E2E evidence is still pending
 - `e2e_evidenced_pending_human_closure`: implementation, tests, and mapped E2E run evidence exist, but human closure judgment is still pending

--- a/docs/mvp/live-verified-contract.md
+++ b/docs/mvp/live-verified-contract.md
@@ -1,0 +1,126 @@
+# Live Verified Contract
+
+This document is the canonical completion contract for Issue #44.
+
+## Intent
+
+`live_verified` must mean human-observable external evidence.
+
+Completion must not be claimed from local files, task summaries, invisible
+runtime flags, or docs-only contract work alone.
+
+## Core Rule
+
+`live_verified` is reached only when a human can observe the relevant external
+state that proves the behavior actually works.
+
+For VTDD, valid external evidence includes GitHub-visible state, Worker-visible
+state, or other operator-observable platform state tied to the scoped behavior.
+
+## Insufficient On Their Own
+
+The following are insufficient on their own and must never be treated as
+`live_verified`:
+
+- a file existing in the repository
+- code that compiles or tests locally without external observable effect
+- a Codex task summary
+- an internal runtime flag
+- a docs-only contract
+- an unpublished branch-local change
+
+## Status Vocabulary
+
+Use the following status vocabulary when reporting progress for a scoped VTDD
+slice:
+
+- `docs_only`
+  - docs/spec/contracts exist, but no connected runtime/code path exists yet
+- `code_only`
+  - code and/or tests exist, but no connected Butler/worker surface exists yet
+- `surface_connected`
+  - a worker/Butler/action path exists, but the intended behavior is not yet
+    evidenced through human-observable external state
+- `live_verified`
+  - the intended behavior is connected and a human can observe the relevant
+    external effect
+
+Do not collapse these states into "done."
+
+## Canonical Evidence Mapping
+
+### Repository listing
+
+- Not enough:
+  - repository index code exists
+  - Butler claims repositories were found
+- `live_verified` evidence:
+  - a human can see the repository list returned through Butler or the worker
+    route, and the names match actual GitHub repositories
+
+### Issue listing/detail
+
+- Not enough:
+  - issue retrieval code exists
+  - Butler speculates that no issues exist
+- `live_verified` evidence:
+  - a human can see returned Issue list/detail data that matches GitHub state
+
+### PR create/update
+
+- Not enough:
+  - Codex reports PR creation in a task summary
+  - branch-local diff exists without a published PR
+- `live_verified` evidence:
+  - a human can see the GitHub PR or its updated state
+
+### Review comment arrival
+
+- Not enough:
+  - reviewer code path exists
+  - Butler says reviewer likely commented
+- `live_verified` evidence:
+  - a human can see the PR review comments on GitHub
+
+### Butler synthesis over PR/review/CI truth
+
+- Not enough:
+  - synthesis code exists
+  - Butler summarizes from stale or partial memory only
+- `live_verified` evidence:
+  - a human can see Butler summarize the current PR/review/CI state from
+    GitHub-observable runtime truth
+
+### Merge
+
+- Not enough:
+  - merge route exists
+  - Butler says merge should be possible
+- `live_verified` evidence:
+  - a human can see the PR merged state on GitHub
+
+### Issue close
+
+- Not enough:
+  - close logic exists
+  - Butler says closure was attempted
+- `live_verified` evidence:
+  - a human can see the Issue closed state on GitHub
+
+## Relationship To E2E Evidence
+
+`live_verified` is the minimum completion floor for user-observable runtime
+behavior.
+
+Milestone completion still requires mapped E2E evidence and human closure
+judgment. `live_verified` does not replace the Issue-to-E2E matrix.
+
+## Forbidden Completion Claims
+
+The following are prohibited:
+
+- claiming completion from docs-only or code-only progress
+- claiming GitHub state changed when only an internal task summary exists
+- claiming absence of Issues/PRs/comments from unsupported or failed reads
+- using "skeleton", "point solution", or similar partial wording as if it were
+  completion

--- a/docs/vision/vtdd-v2-overview.md
+++ b/docs/vision/vtdd-v2-overview.md
@@ -12,6 +12,8 @@ It externalizes structure, memory, approval boundaries, and runtime truth so tha
 
 As of 2026-04-17, VTDD V2 is **partial / in-progress**.
 The repository has broad runtime and contract coverage, but overall completion still depends on mapped E2E evidence and human closure judgment.
+`live_verified` in this repository means human-observable external evidence, not
+just local files, docs, task summaries, or internal runtime flags.
 
 ## Core Principles
 

--- a/test/issue-to-e2e-matrix.test.js
+++ b/test/issue-to-e2e-matrix.test.js
@@ -35,6 +35,11 @@ test("issue-to-e2e matrix records happy path, boundary path, evidence, and updat
   assert.equal(doc.includes("- Test evidence:"), true);
   assert.equal(doc.includes("- Run evidence:"), true);
   assert.equal(doc.includes("- Status:"), true);
+  assert.equal(doc.includes("docs/mvp/live-verified-contract.md"), true);
+  assert.equal(doc.includes("docs_only"), true);
+  assert.equal(doc.includes("code_only"), true);
+  assert.equal(doc.includes("surface_connected"), true);
+  assert.equal(doc.includes("live_verified"), true);
   assert.equal(doc.includes("e2e_evidenced_pending_human_closure"), true);
   assert.equal(doc.includes("implemented_pending_e2e"), true);
   assert.equal(doc.includes("partial"), true);

--- a/test/live-verified-contract.test.js
+++ b/test/live-verified-contract.test.js
@@ -1,0 +1,44 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const CONTRACT_PATH = path.join(process.cwd(), "docs", "mvp", "live-verified-contract.md");
+const OVERVIEW_PATH = path.join(process.cwd(), "docs", "vision", "vtdd-v2-overview.md");
+
+test("live verified contract defines human-observable completion and insufficient evidence", () => {
+  const doc = fs.readFileSync(CONTRACT_PATH, "utf8");
+
+  assert.equal(doc.includes("`live_verified` must mean human-observable external evidence."), true);
+  assert.equal(doc.includes("- a file existing in the repository"), true);
+  assert.equal(doc.includes("- a Codex task summary"), true);
+  assert.equal(doc.includes("- an internal runtime flag"), true);
+  assert.equal(doc.includes("- a docs-only contract"), true);
+});
+
+test("live verified contract fixes canonical status vocabulary", () => {
+  const doc = fs.readFileSync(CONTRACT_PATH, "utf8");
+
+  assert.equal(doc.includes("`docs_only`"), true);
+  assert.equal(doc.includes("`code_only`"), true);
+  assert.equal(doc.includes("`surface_connected`"), true);
+  assert.equal(doc.includes("`live_verified`"), true);
+});
+
+test("live verified contract covers human-observable evidence for key VTDD operations", () => {
+  const doc = fs.readFileSync(CONTRACT_PATH, "utf8");
+
+  assert.equal(doc.includes("### Repository listing"), true);
+  assert.equal(doc.includes("### Issue listing/detail"), true);
+  assert.equal(doc.includes("### PR create/update"), true);
+  assert.equal(doc.includes("### Review comment arrival"), true);
+  assert.equal(doc.includes("### Butler synthesis over PR/review/CI truth"), true);
+  assert.equal(doc.includes("### Merge"), true);
+  assert.equal(doc.includes("### Issue close"), true);
+});
+
+test("overview points current completion reading at human-observable live verification", () => {
+  const doc = fs.readFileSync(OVERVIEW_PATH, "utf8");
+
+  assert.equal(doc.includes("`live_verified` in this repository means human-observable external evidence"), true);
+});


### PR DESCRIPTION
## Summary
- define `live_verified` as human-observable external evidence
- fix repository status vocabulary to distinguish docs/code/surface/live states
- connect the completion contract to the overview and Issue-to-E2E matrix

## Verification
- `node --test test/live-verified-contract.test.js test/issue-to-e2e-matrix.test.js test/approval-model.test.js`
