### PR TITLE
Implement GitHub normal write plane

### DIFF
--- a/docs/setup/custom-gpt-actions-openapi.json
+++ b/docs/setup/custom-gpt-actions-openapi.json
@@ -452,6 +452,125 @@
         }
       }
     },
+    "/v2/action/github": {
+      "post": {
+        "operationId": "vtddWriteGitHub",
+        "summary": "Execute scoped normal-tier GitHub write operations through VTDD.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "operation": {
+                    "type": "string",
+                    "enum": [
+                      "issue_comment_create",
+                      "issue_comment_update",
+                      "branch_create",
+                      "pull_create",
+                      "pull_update",
+                      "pull_comment_create"
+                    ]
+                  },
+                  "repository": {
+                    "type": "string"
+                  },
+                  "issueNumber": {
+                    "type": "integer"
+                  },
+                  "pullNumber": {
+                    "type": "integer"
+                  },
+                  "commentId": {
+                    "type": "integer"
+                  },
+                  "branch": {
+                    "type": "string"
+                  },
+                  "baseRef": {
+                    "type": "string"
+                  },
+                  "head": {
+                    "type": "string"
+                  },
+                  "title": {
+                    "type": "string"
+                  },
+                  "body": {
+                    "type": "string"
+                  },
+                  "issueContext": {
+                    "type": "object",
+                    "properties": {
+                      "issueNumber": {
+                        "type": "integer"
+                      }
+                    },
+                    "additionalProperties": true
+                  },
+                  "policyInput": {
+                    "type": "object",
+                    "properties": {
+                      "approvalPhrase": {
+                        "type": "string"
+                      },
+                      "targetConfirmed": {
+                        "type": "boolean"
+                      },
+                      "approvalScopeMatched": {
+                        "type": "boolean"
+                      }
+                    },
+                    "additionalProperties": true
+                  }
+                },
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "GitHub normal write executed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VtddGenericResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing machine auth"
+          },
+          "403": {
+            "description": "Invalid machine auth"
+          },
+          "422": {
+            "description": "GitHub write request blocked or invalid",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VtddGenericResponse"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "GitHub write route unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VtddGenericResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v2/action/progress": {
       "get": {
         "operationId": "vtddExecutionProgress",

--- a/docs/setup/custom-gpt-actions-openapi.yaml
+++ b/docs/setup/custom-gpt-actions-openapi.yaml
@@ -299,6 +299,84 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/VtddGenericResponse"
+  /v2/action/github:
+    post:
+      operationId: vtddWriteGitHub
+      summary: Execute scoped normal-tier GitHub write operations through VTDD.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                operation:
+                  type: string
+                  enum:
+                    - issue_comment_create
+                    - issue_comment_update
+                    - branch_create
+                    - pull_create
+                    - pull_update
+                    - pull_comment_create
+                repository:
+                  type: string
+                issueNumber:
+                  type: integer
+                pullNumber:
+                  type: integer
+                commentId:
+                  type: integer
+                branch:
+                  type: string
+                baseRef:
+                  type: string
+                head:
+                  type: string
+                title:
+                  type: string
+                body:
+                  type: string
+                issueContext:
+                  type: object
+                  properties:
+                    issueNumber:
+                      type: integer
+                  additionalProperties: true
+                policyInput:
+                  type: object
+                  properties:
+                    approvalPhrase:
+                      type: string
+                    targetConfirmed:
+                      type: boolean
+                    approvalScopeMatched:
+                      type: boolean
+                  additionalProperties: true
+              additionalProperties: true
+      responses:
+        "200":
+          description: GitHub normal write executed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VtddGenericResponse"
+        "401":
+          description: Missing machine auth
+        "403":
+          description: Invalid machine auth
+        "422":
+          description: GitHub write request blocked or invalid
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VtddGenericResponse"
+        "503":
+          description: GitHub write route unavailable
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VtddGenericResponse"
   /v2/action/progress:
     get:
       operationId: vtddExecutionProgress

--- a/docs/setup/custom-gpt-instructions.md
+++ b/docs/setup/custom-gpt-instructions.md
@@ -98,6 +98,25 @@ Remote Codex flow:
   - respond_to_review
 - Do not treat the handoff text itself as canonical spec.
 
+GitHub normal write plane:
+- Use vtddWriteGitHub for scoped GitHub normal write operations that stay inside the `GO` tier.
+- Use vtddWriteGitHub for:
+  - issue comment create or update
+  - branch creation for scoped work
+  - pull request create or update
+  - pull request comment create
+- Only use vtddWriteGitHub when:
+  - repository is resolved
+  - the request is traceable to the active Issue
+  - `GO` has been given for the bounded execution step
+- Do not use vtddWriteGitHub for:
+  - merge
+  - issue close
+  - deploy
+  - secret/settings/permission mutation
+  - destructive cleanup
+- Those remain approval-bound authority actions outside this normal write plane.
+
 Progress tracking:
 - After vtddExecute, always call vtddExecutionProgress.
 - Use executionId, repository, issueNumber, and branch.
@@ -131,6 +150,7 @@ Forbidden behavior:
 - Do not claim a PR exists when only a Codex task summary exists.
 - Do not claim that Issues/PRs/comments are absent when the read path is unsupported, unauthorized, or unverified.
 - Do not merge, deploy, mutate secrets, or perform destructive actions on your own.
+- Do not route merge, issue close, deploy, or destructive GitHub actions through vtddWriteGitHub.
 - Do not embed owner-specific Cloudflare URLs, account IDs, or private values as if they were universal defaults.
 
 Response style:

--- a/src/core/github-write-plane.js
+++ b/src/core/github-write-plane.js
@@ -1,0 +1,387 @@
+import { resolveGitHubAppInstallationToken } from "./github-app-repository-index.js";
+
+const GITHUB_API_BASE_URL = "https://api.github.com";
+const GITHUB_API_VERSION = "2022-11-28";
+const GITHUB_API_USER_AGENT = "vtdd-v2-github-write-plane";
+
+export const GitHubWriteOperation = Object.freeze({
+  ISSUE_COMMENT_CREATE: "issue_comment_create",
+  ISSUE_COMMENT_UPDATE: "issue_comment_update",
+  BRANCH_CREATE: "branch_create",
+  PULL_CREATE: "pull_create",
+  PULL_UPDATE: "pull_update",
+  PULL_COMMENT_CREATE: "pull_comment_create"
+});
+
+export async function executeGitHubWritePlane(input = {}) {
+  const operation = normalizeText(input.operation);
+  const repository = normalizeText(input.repository);
+  const issueNumber = normalizePositiveInteger(input.issueNumber);
+  const pullNumber = normalizePositiveInteger(input.pullNumber);
+  const commentId = normalizePositiveInteger(input.commentId);
+  const branch = normalizeText(input.branch);
+  const baseRef = normalizeText(input.baseRef) || "main";
+  const title = normalizeText(input.title);
+  const body = normalizeBody(input.body);
+  const head = normalizeText(input.head) || branch;
+  const env = input.env ?? {};
+  const fetchImpl = typeof env?.GITHUB_API_FETCH === "function" ? env.GITHUB_API_FETCH.bind(env) : fetch;
+  const apiBaseUrl = normalizeApiBaseUrl(env?.GITHUB_API_BASE_URL);
+
+  const validation = validateGitHubWriteRequest({
+    operation,
+    repository,
+    issueNumber,
+    pullNumber,
+    commentId,
+    branch,
+    head,
+    title,
+    body,
+    approvalPhrase: normalizeText(input.approvalPhrase),
+    targetConfirmed: input.targetConfirmed === true,
+    approvalScopeMatched: input.approvalScopeMatched === true
+  });
+  if (!validation.ok) {
+    return {
+      ok: false,
+      status: 422,
+      error: "github_write_request_invalid",
+      reason: validation.issues.join(", "),
+      issues: validation.issues
+    };
+  }
+
+  const tokenResolution = await resolveGitHubAppInstallationToken({ env, fetchImpl, apiBaseUrl });
+  if (!tokenResolution.ok) {
+    return {
+      ok: false,
+      status: 503,
+      error: "github_write_unavailable",
+      reason: tokenResolution.warning || "GitHub App installation token is unavailable"
+    };
+  }
+
+  return dispatchGitHubWrite({
+    operation,
+    repository,
+    issueNumber,
+    pullNumber,
+    commentId,
+    branch,
+    baseRef,
+    title,
+    body,
+    head,
+    token: tokenResolution.token,
+    fetchImpl,
+    apiBaseUrl
+  });
+}
+
+function validateGitHubWriteRequest(input) {
+  const issues = [];
+  if (!Object.values(GitHubWriteOperation).includes(input.operation)) {
+    issues.push("operation is unsupported");
+  }
+  if (!input.repository) {
+    issues.push("repository is required");
+  }
+  if (!input.targetConfirmed) {
+    issues.push("targetConfirmed must be true");
+  }
+  if (!input.approvalScopeMatched) {
+    issues.push("approvalScopeMatched must be true");
+  }
+  if (normalizeText(input.approvalPhrase).toUpperCase() !== "GO") {
+    issues.push("approvalPhrase must be GO");
+  }
+
+  if (
+    (input.operation === GitHubWriteOperation.ISSUE_COMMENT_CREATE ||
+      input.operation === GitHubWriteOperation.ISSUE_COMMENT_UPDATE) &&
+    !input.issueNumber
+  ) {
+    issues.push("issueNumber is required for issue comment operations");
+  }
+
+  if (input.operation === GitHubWriteOperation.ISSUE_COMMENT_UPDATE && !input.commentId) {
+    issues.push("commentId is required for issue comment update");
+  }
+
+  if (
+    (input.operation === GitHubWriteOperation.ISSUE_COMMENT_CREATE ||
+      input.operation === GitHubWriteOperation.ISSUE_COMMENT_UPDATE ||
+      input.operation === GitHubWriteOperation.PULL_CREATE ||
+      input.operation === GitHubWriteOperation.PULL_COMMENT_CREATE) &&
+    !input.body
+  ) {
+    issues.push("body is required for this operation");
+  }
+
+  if (input.operation === GitHubWriteOperation.BRANCH_CREATE && !input.branch) {
+    issues.push("branch is required for branch creation");
+  }
+
+  if (input.operation === GitHubWriteOperation.PULL_CREATE) {
+    if (!input.title) {
+      issues.push("title is required for pull creation");
+    }
+    if (!input.head) {
+      issues.push("head or branch is required for pull creation");
+    }
+  }
+
+  if (input.operation === GitHubWriteOperation.PULL_UPDATE) {
+    if (!input.pullNumber) {
+      issues.push("pullNumber is required for pull update");
+    }
+    if (!input.title && !input.body) {
+      issues.push("title or body is required for pull update");
+    }
+  }
+
+  if (input.operation === GitHubWriteOperation.PULL_COMMENT_CREATE && !input.pullNumber) {
+    issues.push("pullNumber is required for pull comment creation");
+  }
+
+  return issues.length > 0 ? { ok: false, issues } : { ok: true };
+}
+
+async function dispatchGitHubWrite(input) {
+  const request = await buildGitHubWriteRequest(input);
+  if (!request.ok) {
+    return request;
+  }
+
+  let response;
+  try {
+    response = await input.fetchImpl(request.url, {
+      method: request.method,
+      headers: githubJsonHeaders({ token: input.token }),
+      body: request.body ? JSON.stringify(request.body) : undefined
+    });
+  } catch {
+    return {
+      ok: false,
+      status: 503,
+      error: "github_write_failed",
+      reason: `failed to execute GitHub write operation: ${input.operation}`
+    };
+  }
+
+  const responseBody = await readJsonSafe(response);
+  if (!response.ok) {
+    return {
+      ok: false,
+      status: response.status,
+      error: "github_write_failed",
+      reason: normalizeText(responseBody?.message) || `GitHub write failed for ${input.operation}`
+    };
+  }
+
+  return {
+    ok: true,
+    write: normalizeGitHubWriteResult({
+      operation: input.operation,
+      repository: input.repository,
+      issueNumber: input.issueNumber,
+      pullNumber: input.pullNumber,
+      branch: input.branch,
+      baseRef: input.baseRef,
+      responseBody
+    })
+  };
+}
+
+async function buildGitHubWriteRequest(input) {
+  const encodedRepository = encodeURIComponentRepository(input.repository);
+
+  if (input.operation === GitHubWriteOperation.ISSUE_COMMENT_CREATE) {
+    return {
+      ok: true,
+      method: "POST",
+      url: `${input.apiBaseUrl}/repos/${encodedRepository}/issues/${input.issueNumber}/comments`,
+      body: { body: input.body }
+    };
+  }
+
+  if (input.operation === GitHubWriteOperation.ISSUE_COMMENT_UPDATE) {
+    return {
+      ok: true,
+      method: "PATCH",
+      url: `${input.apiBaseUrl}/repos/${encodedRepository}/issues/comments/${input.commentId}`,
+      body: { body: input.body }
+    };
+  }
+
+  if (input.operation === GitHubWriteOperation.BRANCH_CREATE) {
+    const resolvedSha = await resolveRefSha({
+      repository: input.repository,
+      ref: input.baseRef,
+      token: input.token,
+      fetchImpl: input.fetchImpl,
+      apiBaseUrl: input.apiBaseUrl
+    });
+    if (!resolvedSha.ok) {
+      return resolvedSha;
+    }
+
+    return {
+      ok: true,
+      method: "POST",
+      url: `${input.apiBaseUrl}/repos/${encodedRepository}/git/refs`,
+      body: {
+        ref: `refs/heads/${input.branch}`,
+        sha: resolvedSha.sha
+      }
+    };
+  }
+
+  if (input.operation === GitHubWriteOperation.PULL_CREATE) {
+    return {
+      ok: true,
+      method: "POST",
+      url: `${input.apiBaseUrl}/repos/${encodedRepository}/pulls`,
+      body: {
+        title: input.title,
+        body: input.body,
+        head: input.head,
+        base: input.baseRef
+      }
+    };
+  }
+
+  if (input.operation === GitHubWriteOperation.PULL_UPDATE) {
+    return {
+      ok: true,
+      method: "PATCH",
+      url: `${input.apiBaseUrl}/repos/${encodedRepository}/pulls/${input.pullNumber}`,
+      body: {
+        ...(input.title ? { title: input.title } : {}),
+        ...(input.body ? { body: input.body } : {})
+      }
+    };
+  }
+
+  if (input.operation === GitHubWriteOperation.PULL_COMMENT_CREATE) {
+    return {
+      ok: true,
+      method: "POST",
+      url: `${input.apiBaseUrl}/repos/${encodedRepository}/issues/${input.pullNumber}/comments`,
+      body: { body: input.body }
+    };
+  }
+
+  return {
+    ok: false,
+    status: 422,
+    error: "github_write_request_invalid",
+    reason: "operation is unsupported"
+  };
+}
+
+async function resolveRefSha({ repository, ref, token, fetchImpl, apiBaseUrl }) {
+  const encodedRepository = encodeURIComponentRepository(repository);
+  let response;
+  try {
+    response = await fetchImpl(
+      `${apiBaseUrl}/repos/${encodedRepository}/git/ref/heads/${encodeURIComponent(ref)}`,
+      {
+        method: "GET",
+        headers: githubJsonHeaders({ token })
+      }
+    );
+  } catch {
+    return {
+      ok: false,
+      status: 503,
+      error: "github_write_failed",
+      reason: `failed to resolve base ref sha for ${ref}`
+    };
+  }
+
+  const body = await readJsonSafe(response);
+  if (!response.ok) {
+    return {
+      ok: false,
+      status: response.status,
+      error: "github_write_failed",
+      reason: normalizeText(body?.message) || `failed to resolve base ref sha for ${ref}`
+    };
+  }
+
+  const sha = normalizeText(body?.object?.sha);
+  if (!sha) {
+    return {
+      ok: false,
+      status: 503,
+      error: "github_write_failed",
+      reason: `base ref ${ref} did not return a sha`
+    };
+  }
+
+  return { ok: true, sha };
+}
+
+function normalizeGitHubWriteResult(input) {
+  const responseBody = input.responseBody ?? {};
+  return {
+    operation: input.operation,
+    repository: input.repository,
+    issueNumber: input.issueNumber ?? null,
+    pullNumber: normalizePositiveInteger(responseBody?.number) ?? input.pullNumber ?? null,
+    branch: input.branch || null,
+    baseRef: input.baseRef || null,
+    commentId: normalizePositiveInteger(responseBody?.id),
+    nodeId: normalizeText(responseBody?.node_id) || null,
+    url: normalizeText(responseBody?.html_url) || null,
+    state: normalizeText(responseBody?.state) || null,
+    title: normalizeText(responseBody?.title) || null,
+    ref: normalizeText(responseBody?.ref) || null
+  };
+}
+
+function githubJsonHeaders({ token }) {
+  return {
+    authorization: `Bearer ${token}`,
+    accept: "application/vnd.github+json",
+    "content-type": "application/json; charset=utf-8",
+    "x-github-api-version": GITHUB_API_VERSION,
+    "user-agent": GITHUB_API_USER_AGENT
+  };
+}
+
+async function readJsonSafe(response) {
+  try {
+    return await response.json();
+  } catch {
+    return null;
+  }
+}
+
+function normalizeText(value) {
+  return String(value ?? "").trim();
+}
+
+function normalizeBody(value) {
+  const text = typeof value === "string" ? value : String(value ?? "");
+  return text.trim();
+}
+
+function normalizePositiveInteger(value) {
+  const number = Number.parseInt(String(value ?? ""), 10);
+  return Number.isInteger(number) && number > 0 ? number : null;
+}
+
+function normalizeApiBaseUrl(value) {
+  const normalized = normalizeText(value);
+  return normalized || GITHUB_API_BASE_URL;
+}
+
+function encodeURIComponentRepository(repository) {
+  return repository
+    .split("/")
+    .map((segment) => encodeURIComponent(segment))
+    .join("/");
+}

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -170,6 +170,7 @@ export {
   resolveGitHubAppInstallationToken
 } from "./github-app-repository-index.js";
 export { GitHubReadResource, retrieveGitHubReadPlane } from "./github-read-plane.js";
+export { GitHubWriteOperation, executeGitHubWritePlane } from "./github-write-plane.js";
 export {
   WorkflowStage,
   WorkflowEvent,

--- a/src/worker.js
+++ b/src/worker.js
@@ -23,6 +23,7 @@ import {
   renderPasskeyOperatorPage,
   resolveGatewayAliasRegistryFromGitHubApp,
   retrieveGitHubReadPlane,
+  executeGitHubWritePlane,
   runMvpGateway,
   validateMemoryProvider,
   verifyPasskeyApproval,
@@ -141,6 +142,19 @@ export default {
         allowed: true,
         execution: dispatched.execution
       });
+    }
+
+    if (request.method === "POST" && isApiPath(url.pathname, "/action/github")) {
+      const auth = authorizeGatewayRequest({ request, env, apiSuffix: "/action/github" });
+      if (!auth.ok) {
+        return json(auth.status, {
+          ok: false,
+          error: "unauthorized",
+          reason: auth.reason
+        });
+      }
+
+      return handleGitHubWritePlaneRequest(request, env);
     }
 
     if (request.method === "GET" && isApiPath(url.pathname, "/action/progress")) {
@@ -520,6 +534,53 @@ async function handleRetrieveGitHubReadPlaneRequest(url, env) {
   return json(200, {
     ok: true,
     read: retrieved.read
+  });
+}
+
+async function handleGitHubWritePlaneRequest(request, env) {
+  const payload = await readJson(request);
+  if (!payload || typeof payload !== "object") {
+    return json(422, {
+      ok: false,
+      error: "request_body_required",
+      reason: "valid JSON request body is required"
+    });
+  }
+
+  const policyInput =
+    payload.policyInput && typeof payload.policyInput === "object" ? payload.policyInput : {};
+  const issueContext =
+    payload.issueContext && typeof payload.issueContext === "object" ? payload.issueContext : {};
+
+  const executed = await executeGitHubWritePlane({
+    operation: payload.operation,
+    repository: payload.repository,
+    issueNumber: payload.issueNumber ?? issueContext.issueNumber,
+    pullNumber: payload.pullNumber,
+    commentId: payload.commentId,
+    branch: payload.branch,
+    baseRef: payload.baseRef,
+    head: payload.head,
+    title: payload.title,
+    body: payload.body,
+    approvalPhrase: policyInput.approvalPhrase,
+    targetConfirmed: policyInput.targetConfirmed,
+    approvalScopeMatched: policyInput.approvalScopeMatched,
+    env
+  });
+
+  if (!executed.ok) {
+    return json(executed.status ?? 503, {
+      ok: false,
+      error: executed.error ?? "github_write_failed",
+      reason: executed.reason,
+      issues: executed.issues ?? []
+    });
+  }
+
+  return json(200, {
+    ok: true,
+    write: executed.write
   });
 }
 

--- a/test/custom-gpt-setup-docs.test.js
+++ b/test/custom-gpt-setup-docs.test.js
@@ -32,6 +32,7 @@ test("custom gpt instructions preserve current butler and approval boundaries", 
   assert.equal(doc.includes("Do not assume a default repository."), true);
   assert.equal(doc.includes("vtddGateway"), true);
   assert.equal(doc.includes("vtddExecute"), true);
+  assert.equal(doc.includes("vtddWriteGitHub"), true);
   assert.equal(doc.includes("vtddExecutionProgress"), true);
   assert.equal(doc.includes("vtddRetrieveGitHub"), true);
   assert.equal(doc.includes("High-risk actions require GO + passkey."), true);
@@ -47,6 +48,7 @@ test("custom gpt openapi doc exposes current gateway, execute, and progress rout
   assert.equal(doc.includes("openapi: 3.1.0"), true);
   assert.equal(doc.includes("/v2/gateway:"), true);
   assert.equal(doc.includes("/v2/action/execute:"), true);
+  assert.equal(doc.includes("/v2/action/github:"), true);
   assert.equal(doc.includes("/v2/action/progress:"), true);
   assert.equal(doc.includes("/v2/retrieve/github:"), true);
   assert.equal(doc.includes("/v2/retrieve/approval-grant:"), true);
@@ -80,6 +82,7 @@ test("custom gpt openapi json parses and exposes paths as an object", () => {
   assert.notEqual(doc.paths, null);
   assert.equal(typeof doc.paths["/v2/gateway"], "object");
   assert.equal(typeof doc.paths["/v2/action/execute"], "object");
+  assert.equal(typeof doc.paths["/v2/action/github"], "object");
   assert.equal(typeof doc.paths["/v2/action/progress"], "object");
   assert.equal(typeof doc.paths["/v2/retrieve/github"], "object");
   assert.equal(typeof doc.paths["/v2/retrieve/approval-grant"], "object");

--- a/test/github-write-plane.test.js
+++ b/test/github-write-plane.test.js
@@ -1,0 +1,183 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { executeGitHubWritePlane, GitHubWriteOperation } from "../src/core/index.js";
+
+test("github write plane creates scoped issue comments with GO approval", async () => {
+  const calls = [];
+  const result = await executeGitHubWritePlane({
+    operation: GitHubWriteOperation.ISSUE_COMMENT_CREATE,
+    repository: "sample-org/vtdd-v2-p",
+    issueNumber: 52,
+    body: "scoped comment",
+    approvalPhrase: "GO",
+    targetConfirmed: true,
+    approvalScopeMatched: true,
+    env: {
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_write",
+      GITHUB_API_FETCH: async (url, init) => {
+        calls.push({ url, init });
+        return new Response(
+          JSON.stringify({
+            id: 101,
+            html_url: "https://github.com/sample-org/vtdd-v2-p/issues/52#issuecomment-101"
+          }),
+          { status: 201, headers: { "content-type": "application/json" } }
+        );
+      }
+    }
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.write.operation, GitHubWriteOperation.ISSUE_COMMENT_CREATE);
+  assert.equal(calls[0].url.includes("/repos/sample-org/vtdd-v2-p/issues/52/comments"), true);
+  assert.equal(calls[0].init.method, "POST");
+});
+
+test("github write plane creates a branch by resolving the base ref sha", async () => {
+  const calls = [];
+  const result = await executeGitHubWritePlane({
+    operation: GitHubWriteOperation.BRANCH_CREATE,
+    repository: "sample-org/vtdd-v2-p",
+    branch: "codex/issue-52",
+    baseRef: "main",
+    approvalPhrase: "GO",
+    targetConfirmed: true,
+    approvalScopeMatched: true,
+    env: {
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_write",
+      GITHUB_API_FETCH: async (url, init) => {
+        calls.push({ url, init });
+        if (String(url).includes("/git/ref/heads/main")) {
+          return new Response(
+            JSON.stringify({
+              object: { sha: "abc123" }
+            }),
+            { status: 200, headers: { "content-type": "application/json" } }
+          );
+        }
+        return new Response(
+          JSON.stringify({
+            ref: "refs/heads/codex/issue-52",
+            node_id: "REF_node"
+          }),
+          { status: 201, headers: { "content-type": "application/json" } }
+        );
+      }
+    }
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(calls[0].url.includes("/git/ref/heads/main"), true);
+  assert.equal(calls[1].url.includes("/git/refs"), true);
+  assert.equal(JSON.parse(calls[1].init.body).sha, "abc123");
+});
+
+test("github write plane creates and updates pull requests and posts PR comments", async () => {
+  const calls = [];
+  const env = {
+    GITHUB_APP_INSTALLATION_TOKEN: "ghs_write",
+    GITHUB_API_FETCH: async (url, init) => {
+      calls.push({ url, init });
+      if (init.method === "POST" && String(url).includes("/pulls")) {
+        return new Response(
+          JSON.stringify({
+            number: 88,
+            title: "Implement normal write plane",
+            state: "open",
+            html_url: "https://github.com/sample-org/vtdd-v2-p/pull/88"
+          }),
+          { status: 201, headers: { "content-type": "application/json" } }
+        );
+      }
+      if (init.method === "PATCH") {
+        return new Response(
+          JSON.stringify({
+            number: 88,
+            title: "Updated PR title",
+            state: "open",
+            html_url: "https://github.com/sample-org/vtdd-v2-p/pull/88"
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        );
+      }
+      return new Response(
+        JSON.stringify({
+          id: 303,
+          html_url: "https://github.com/sample-org/vtdd-v2-p/issues/88#issuecomment-303"
+        }),
+        { status: 201, headers: { "content-type": "application/json" } }
+      );
+    }
+  };
+
+  const created = await executeGitHubWritePlane({
+    operation: GitHubWriteOperation.PULL_CREATE,
+    repository: "sample-org/vtdd-v2-p",
+    branch: "codex/issue-52",
+    baseRef: "main",
+    title: "Implement normal write plane",
+    body: "Creates the Butler/Executor write plane.",
+    approvalPhrase: "GO",
+    targetConfirmed: true,
+    approvalScopeMatched: true,
+    env
+  });
+  const updated = await executeGitHubWritePlane({
+    operation: GitHubWriteOperation.PULL_UPDATE,
+    repository: "sample-org/vtdd-v2-p",
+    pullNumber: 88,
+    title: "Updated PR title",
+    approvalPhrase: "GO",
+    targetConfirmed: true,
+    approvalScopeMatched: true,
+    env
+  });
+  const commented = await executeGitHubWritePlane({
+    operation: GitHubWriteOperation.PULL_COMMENT_CREATE,
+    repository: "sample-org/vtdd-v2-p",
+    pullNumber: 88,
+    body: "Please review this update.",
+    approvalPhrase: "GO",
+    targetConfirmed: true,
+    approvalScopeMatched: true,
+    env
+  });
+
+  assert.equal(created.ok, true);
+  assert.equal(created.write.pullNumber, 88);
+  assert.equal(updated.ok, true);
+  assert.equal(updated.write.title, "Updated PR title");
+  assert.equal(commented.ok, true);
+  assert.equal(commented.write.commentId, 303);
+});
+
+test("github write plane rejects missing GO approval scope or unsupported operations", async () => {
+  const denied = await executeGitHubWritePlane({
+    operation: GitHubWriteOperation.ISSUE_COMMENT_CREATE,
+    repository: "sample-org/vtdd-v2-p",
+    issueNumber: 52,
+    body: "no go",
+    approvalPhrase: "",
+    targetConfirmed: false,
+    approvalScopeMatched: false,
+    env: {
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_write"
+    }
+  });
+  const unsupported = await executeGitHubWritePlane({
+    operation: "merge",
+    repository: "sample-org/vtdd-v2-p",
+    approvalPhrase: "GO",
+    targetConfirmed: true,
+    approvalScopeMatched: true,
+    env: {
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_write"
+    }
+  });
+
+  assert.equal(denied.ok, false);
+  assert.equal(denied.status, 422);
+  assert.equal(denied.reason.includes("approvalPhrase must be GO"), true);
+  assert.equal(unsupported.ok, false);
+  assert.equal(unsupported.reason.includes("operation is unsupported"), true);
+});

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -894,6 +894,79 @@ test("worker returns unsupported for unknown GitHub read resources", async () =>
   assert.equal(body.error, "github_read_request_invalid");
 });
 
+test("worker executes scoped GitHub issue comments through the normal write plane", async () => {
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/action/github", {
+      method: "POST",
+      headers: {
+        ...gatewayAuthHeaders,
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({
+        operation: "issue_comment_create",
+        repository: "sample-org/vtdd-v2-p",
+        issueContext: {
+          issueNumber: 52
+        },
+        body: "scoped comment",
+        policyInput: {
+          approvalPhrase: "GO",
+          targetConfirmed: true,
+          approvalScopeMatched: true
+        }
+      })
+    }),
+    {
+      ...gatewayAuthEnv,
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_write",
+      GITHUB_API_FETCH: async () =>
+        new Response(
+          JSON.stringify({
+            id: 101,
+            html_url: "https://github.com/sample-org/vtdd-v2-p/issues/52#issuecomment-101"
+          }),
+          { status: 201, headers: { "content-type": "application/json" } }
+        )
+    }
+  );
+
+  assert.equal(response.status, 200);
+  const body = await response.json();
+  assert.equal(body.ok, true);
+  assert.equal(body.write.operation, "issue_comment_create");
+  assert.equal(body.write.commentId, 101);
+});
+
+test("worker rejects unsupported high-risk GitHub write operations on the normal write plane", async () => {
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/action/github", {
+      method: "POST",
+      headers: {
+        ...gatewayAuthHeaders,
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({
+        operation: "merge",
+        repository: "sample-org/vtdd-v2-p",
+        policyInput: {
+          approvalPhrase: "GO",
+          targetConfirmed: true,
+          approvalScopeMatched: true
+        }
+      })
+    }),
+    {
+      ...gatewayAuthEnv,
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_write"
+    }
+  );
+
+  assert.equal(response.status, 422);
+  const body = await response.json();
+  assert.equal(body.ok, false);
+  assert.equal(body.error, "github_write_request_invalid");
+});
+
 test("worker returns remote Codex execution progress", async () => {
   const response = await worker.fetch(
     new Request("https://example.com/v2/action/progress?executionId=remote-codex-issue6-abcd12", {


### PR DESCRIPTION
## Summary
- implement the first GitHub normal write plane slice under `/v2/action/github`
- support scoped `GO`-tier issue comments, branch creation, PR create/update, and PR comments through GitHub App short-lived execution
- expose the new write route in the Custom GPT Action schema and Butler Instructions

## Scope
This is partial progress for #52.
It does not implement merge, issue close, deploy, secret/settings mutation, or any `GO + real passkey` path.

## Verification
- `node --test test/github-write-plane.test.js test/worker.test.js test/custom-gpt-setup-docs.test.js`
- `npx --yes swagger-cli validate docs/setup/custom-gpt-actions-openapi.yaml`
- `npx --yes swagger-cli validate docs/setup/custom-gpt-actions-openapi.json`
