### PR TITLE
Add E2E evidence for GitHub normal write plane

### DIFF
--- a/docs/mvp/e2e/e2e-14-github-normal-write-plane.md
+++ b/docs/mvp/e2e/e2e-14-github-normal-write-plane.md
@@ -1,0 +1,61 @@
+# E2E-14 GitHub Normal Write Plane Evidence
+
+This document records concrete run evidence for the E2E-14 track.
+
+## Scope
+
+Issues:
+- `#52`
+- parent anchor: `#13`
+
+Goal:
+- confirm the normal write plane executes scoped `GO`-tier GitHub workflow mutations
+- confirm the path stays GitHub App-backed and short-lived
+- confirm high-risk actions remain blocked outside this plane
+
+## Happy-path Run
+
+Command:
+
+```sh
+node --test test/github-write-plane.test.js test/worker.test.js test/custom-gpt-setup-docs.test.js
+```
+
+Observed result on 2026-04-26:
+- passed
+- confirms `issue_comment_create` executes through `/v2/action/github`
+- confirms `branch_create` resolves the base ref SHA and creates the scoped branch
+- confirms `pull_create`, `pull_update`, and `pull_comment_create` execute through the GitHub normal write plane
+- confirms Butler-facing Custom GPT artifacts expose `vtddWriteGitHub`
+
+## Boundary-path Run
+
+Command:
+
+```sh
+node --test test/github-write-plane.test.js test/worker.test.js test/custom-gpt-setup-docs.test.js
+```
+
+Observed result on 2026-04-26:
+- passed
+- confirms missing `GO` / missing scope match is rejected by the normal write plane
+- confirms unsupported high-risk operations such as `merge` are rejected with `github_write_request_invalid`
+- confirms the normal write plane does not silently cross into merge / issue close / deploy / destructive territory
+
+## Evidence Files
+
+- `src/core/github-write-plane.js`
+- `src/worker.js`
+- `docs/setup/custom-gpt-actions-openapi.yaml`
+- `docs/setup/custom-gpt-actions-openapi.json`
+- `docs/setup/custom-gpt-instructions.md`
+- `test/github-write-plane.test.js`
+- `test/worker.test.js`
+- `test/custom-gpt-setup-docs.test.js`
+
+## Current Reading
+
+E2E-14 now has recorded happy-path and boundary-path run evidence in-repo.
+
+This still does not imply repository completion or high-risk GitHub authority completion.
+Merge, issue close, and `GO + real passkey` paths remain separate work.

--- a/docs/mvp/issue-to-e2e-matrix.md
+++ b/docs/mvp/issue-to-e2e-matrix.md
@@ -283,6 +283,26 @@ Status values used below:
   - `docs/mvp/e2e/e2e-13-reviewer-operational-loop.md`
 - Status: `e2e_evidenced_pending_human_closure`
 
+## E2E-14 GitHub normal write plane
+
+- Issues: `#52`
+- Happy path:
+  - scoped `GO`-tier issue comments, branch creation, PR create/update, and PR comments execute through the GitHub normal write plane
+- Boundary path:
+  - missing `GO`, missing scope match, or unsupported high-risk operations are rejected instead of silently executing
+- Implementation evidence:
+  - `src/core/github-write-plane.js`
+  - `src/worker.js`
+  - `docs/setup/custom-gpt-actions-openapi.yaml`
+  - `docs/setup/custom-gpt-instructions.md`
+- Test evidence:
+  - `test/github-write-plane.test.js`
+  - `test/worker.test.js`
+  - `test/custom-gpt-setup-docs.test.js`
+- Run evidence:
+  - `docs/mvp/e2e/e2e-14-github-normal-write-plane.md`
+- Status: `e2e_evidenced_pending_human_closure`
+
 ## Current Completion Reading
 
 - Repository completion status: `partial`

--- a/test/e2e-14-github-normal-write-plane.test.js
+++ b/test/e2e-14-github-normal-write-plane.test.js
@@ -1,0 +1,28 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const DOC_PATH = path.join(
+  process.cwd(),
+  "docs",
+  "mvp",
+  "e2e",
+  "e2e-14-github-normal-write-plane.md"
+);
+const MATRIX_PATH = path.join(process.cwd(), "docs", "mvp", "issue-to-e2e-matrix.md");
+
+test("E2E-14 evidence doc records happy-path and boundary-path runs", () => {
+  const doc = fs.readFileSync(DOC_PATH, "utf8");
+  assert.equal(doc.includes("node --test test/github-write-plane.test.js test/worker.test.js test/custom-gpt-setup-docs.test.js"), true);
+  assert.equal(doc.includes("issue_comment_create"), true);
+  assert.equal(doc.includes("branch_create"), true);
+  assert.equal(doc.includes("pull_create"), true);
+  assert.equal(doc.includes("unsupported high-risk operations such as `merge` are rejected"), true);
+});
+
+test("issue-to-e2e matrix references E2E-14 run evidence", () => {
+  const doc = fs.readFileSync(MATRIX_PATH, "utf8");
+  assert.equal(doc.includes("## E2E-14 GitHub normal write plane"), true);
+  assert.equal(doc.includes("docs/mvp/e2e/e2e-14-github-normal-write-plane.md"), true);
+});


### PR DESCRIPTION
## Summary
- record happy-path and boundary-path run evidence for the GitHub normal write plane
- map #52 into the Issue-to-E2E matrix as E2E-14
- keep this slice docs/evidence-only so completion claims stay explicit

## Scope
This PR does not add runtime behavior.
It records human-observable worker-visible evidence for the normal write plane that landed in #53.

## Verification
- `node --test test/e2e-14-github-normal-write-plane.test.js test/issue-to-e2e-matrix.test.js`
