### PR TITLE
Align merge authority docs with real passkey boundary

### DIFF
--- a/docs/butler/authority-model.md
+++ b/docs/butler/authority-model.md
@@ -137,7 +137,7 @@ Codex does not perform merge directly.
 
 - read-only GitHub observation does not require merge authority
 - normal bounded execution follows the normal execution approval tier
-- merge and bounded issue close require explicit `GO`
+- merge and bounded issue close require explicit `GO + real passkey`
 - deploy, credential mutation, permission mutation, and destructive actions
   require `GO + real passkey`
 

--- a/docs/butler/codex-pr-revision-loop.md
+++ b/docs/butler/codex-pr-revision-loop.md
@@ -65,7 +65,7 @@ After Codex creates a PR:
 4. Codex performs bounded PR updates and PR comment responses as directed
 5. Gemini re-runs critical review when the PR changes or new comments arrive
 6. Butler re-summarizes the updated PR state for the human
-7. merge remains blocked until the human gives `GO`
+7. merge remains blocked until the human gives `GO + real passkey`
 
 ## Role Boundaries
 
@@ -95,7 +95,7 @@ After Codex creates a PR:
 
 - no speculative coding beyond Issue scope
 - no treating handoff as canonical spec
-- no merge without explicit human `GO`
+- no merge without explicit human `GO + real passkey`
 - no erasing meaningful reviewer objections in Butler summaries
 - no invisible Codex-to-Butler authority channel outside GitHub-observable
   runtime truth

--- a/docs/butler/role-separation.md
+++ b/docs/butler/role-separation.md
@@ -90,7 +90,7 @@ Reviewer is restricted to critical evaluation and does not execute changes.
 
 ### Human -> Final Authority
 
-- Human remains the final authority for revision GO and merge GO.
+- Human remains the final authority for revision GO and merge GO + real passkey.
 - No role may silently replace human approval on high-risk or closure decisions.
 
 ## Security Boundary

--- a/docs/mvp/issue-13-rewrite-draft.md
+++ b/docs/mvp/issue-13-rewrite-draft.md
@@ -109,7 +109,7 @@ VTDD V2 の MVP 実装を開始するための統合親 Issue を確定する。
 - Butler can resolve context safely and refuse unsafe execution
 - Repository mis-targeting risk is reduced by alias + no-default + confirmation path
 - High-risk operations are gated by `GO + passkey` and short-lived credentials
-- Merge and bounded post-merge completion use explicit `GO`
+- Merge and bounded post-merge completion use explicit `GO + real passkey`
 - Production deploy can be executed under governed approval
 
 ## Execution Notes

--- a/docs/security/consent-approval-model.md
+++ b/docs/security/consent-approval-model.md
@@ -34,7 +34,7 @@ action on this specific scope proceed now?"
 - `approvalPhrase` is required whenever approval level is not `none`.
 - Approval must be bound to the target scope.
 - High-risk operations require `GO + passkey`.
-- Merge and bounded post-merge completion tasks require explicit `GO`.
+- Merge and bounded post-merge completion tasks require explicit `GO + passkey`.
 
 ## Canonical Action Mapping
 
@@ -61,7 +61,7 @@ action on this specific scope proceed now?"
 - `pr_comment` -> `none`
 - `pr_review_submit` -> `go`
 - `pr_operation` -> `go`
-- `merge` -> `go`
+- `merge` -> `go_passkey`
 - `deploy_production` -> `go_passkey`
 - `destructive` -> `go_passkey`
 - `external_publish` -> `go_passkey`
@@ -69,14 +69,14 @@ action on this specific scope proceed now?"
 ## Operational Extension
 
 The canonical action table above covers the current execution action types.
-The following bounded post-merge completion tasks follow the same `go` approval
+The following bounded post-merge completion tasks follow the same `go_passkey` approval
 level as `merge`:
 
 - issue close for the scoped work that was just merged
 - deletion of the merged topic branch tied to that PR
 
 These tasks are not authorized by category consent alone and must not be
-inferred without explicit scoped `GO`.
+inferred without explicit scoped `GO + passkey`.
 
 ## GitHub Operation Matrix
 
@@ -93,8 +93,6 @@ Bounded repository workflow operations may proceed with explicit scoped `GO`:
 - commit / push on the scoped topic branch
 - PR creation, update, label, assignee, and review-response work
 - PR comment and scoped review iteration
-- merge, when scoped criteria, tests, and mapped E2E evidence are present
-- post-merge issue close for the scoped work
 - deletion of the merged topic branch tied to that scoped PR
 
 ### `GO + passkey`
@@ -102,6 +100,8 @@ Bounded repository workflow operations may proceed with explicit scoped `GO`:
 High-risk or administration-bearing GitHub operations require explicit scoped
 `GO + passkey`:
 
+- merge, when scoped criteria, tests, and mapped E2E evidence are present
+- post-merge issue close for the scoped work
 - production deploy or deploy-triggering repository operation
 - repository / environment secret creation, update, or deletion
 - repository / environment variable creation, update, or deletion

--- a/docs/security/github-operation-plane.md
+++ b/docs/security/github-operation-plane.md
@@ -103,14 +103,14 @@ Normal bounded execution includes at least:
 - commit and push on the scoped topic branch
 - PR creation and update
 - PR comment and bounded review-response work
-- merge
-- bounded issue close after merged scoped work
 - deletion of the merged topic branch tied to that scoped PR
 
 ### `GO + real passkey`
 
 High-risk GitHub execution includes at least:
 
+- merge
+- bounded issue close after merged scoped work
 - repository or environment secret mutation
 - repository or environment variable mutation
 - GitHub App install, credential, token, or permission mutation

--- a/docs/security/go-passkey-approval-model.md
+++ b/docs/security/go-passkey-approval-model.md
@@ -7,8 +7,8 @@ For the full canonical consent / approval model, see
 ## Intent
 
 High-risk actions should require both explicit intent and strong user authentication.
-Merge and bounded post-merge completion tasks remain explicit `GO` actions, but
-they are not part of the `GO + passkey` set.
+Merge and bounded post-merge completion tasks are part of the high-risk set and
+must follow the same `GO + passkey` path as other authority-bearing actions.
 
 ## Drift Note
 
@@ -33,14 +33,14 @@ No explicit approval required.
 - issue creation
 - branch / PR operations
 - normal execution
-- merge
-- post-merge issue close for the scoped work
 - merged-branch deletion for the scoped PR
 
 Requires `GO`.
 
 ### Level 3
 
+- merge
+- post-merge issue close for the scoped work
 - production deploy
 - credential mutation
 - permission mutation
@@ -53,6 +53,8 @@ Requires `GO + passkey`.
 
 When the execution surface is GitHub, `GO + passkey` includes at least:
 
+- pull request merge
+- bounded issue close for the scoped merged work
 - repository or environment secret / variable mutation
 - GitHub App installation, credential, token, or permission mutation
 - repository settings mutation

--- a/docs/setup/custom-gpt-instructions.md
+++ b/docs/setup/custom-gpt-instructions.md
@@ -33,7 +33,7 @@ Role separation:
 - Butler: reads, judges, summarizes, and suggests the next safe action.
 - Codex / Executor: performs bounded coding work and creates or updates PRs.
 - Reviewer: returns critical review comments on the PR.
-- Human: final authority for revision GO and merge GO.
+- Human: final authority for revision GO and merge GO + real passkey.
 
 Repository listing and context resolution:
 - If the user asks for repository candidates or says things like "GitHub リポジトリ一覧を出して", call vtddGateway in exploration mode.
@@ -132,14 +132,14 @@ Review loop:
   - reviewer comments
   - unresolved reviewer objections
   - whether the PR changed after the last review
-- If reviewer objections remain unresolved, do not recommend merge GO.
+- If reviewer objections remain unresolved, do not recommend merge GO + real passkey.
 - If no reviewer evidence exists yet, say so plainly.
 - If reviewer output is approve-only, still present it as reviewer evidence and keep final judgment with the human.
 - Prefer vtddRetrieveGitHub for PR state, reviews, review comments, checks, workflow runs, and branches when those facts are needed for a summary.
 
 Approval boundaries:
 - High-risk actions require GO + passkey.
-- Merge requires explicit human GO.
+- Merge requires explicit human GO + real passkey.
 - Deploy, secret mutation, permission mutation, destructive actions, and similar high-risk operations require GO + passkey.
 - Do not silently infer approval from context.
 

--- a/test/authority-model.test.js
+++ b/test/authority-model.test.js
@@ -12,6 +12,7 @@ test("authority model defines Codex freedom inside Issue scope and Butler-side m
   assert.equal(doc.includes("Merge and issue close are Butler-side authority actions."), true);
   assert.equal(doc.includes("ChatGPT Pro / Codex Cloud"), true);
   assert.equal(doc.includes("`OPENAI_API_KEY`-backed runners are optional opt-in machine paths"), true);
+  assert.equal(doc.includes("merge and bounded issue close require explicit `GO + real passkey`"), true);
 });
 
 test("authority model defines GitHub-observable Codex return markers", () => {

--- a/test/custom-gpt-setup-docs.test.js
+++ b/test/custom-gpt-setup-docs.test.js
@@ -36,6 +36,7 @@ test("custom gpt instructions preserve current butler and approval boundaries", 
   assert.equal(doc.includes("vtddExecutionProgress"), true);
   assert.equal(doc.includes("vtddRetrieveGitHub"), true);
   assert.equal(doc.includes("High-risk actions require GO + passkey."), true);
+  assert.equal(doc.includes("Merge requires explicit human GO + real passkey."), true);
   assert.equal(doc.includes("Do not claim a PR exists when only a Codex task summary exists."), true);
   assert.equal(
     doc.includes("Do not claim that Issues/PRs/comments are absent when the read path is unsupported, unauthorized, or unverified."),

--- a/test/github-operation-plane.test.js
+++ b/test/github-operation-plane.test.js
@@ -38,5 +38,8 @@ test("github operation plane keeps Butler-side authority and GitHub App credenti
   assert.equal(doc.includes("Long-lived PAT-style execution tokens must not be introduced as the default."), true);
   assert.equal(doc.includes("Codex does not merge or close issues directly."), true);
   assert.equal(doc.includes("Merge and issue close remain Butler-side authority actions."), true);
+  assert.equal(doc.includes("### `GO + real passkey`"), true);
+  assert.equal(doc.includes("- merge"), true);
+  assert.equal(doc.includes("- bounded issue close after merged scoped work"), true);
   assert.equal(approvalDoc.includes("github-operation-plane.md"), true);
 });


### PR DESCRIPTION
## This PR satisfies Intent

- #55 の前提として、merge と bounded issue close の authority boundary を canonical docs 上で `GO + real passkey` に揃える。
- stale な `GO` wording を残したまま high-risk runtime 実装へ進まないようにする。

## Satisfied Success Criteria

- [x] canonical docs 上で merge が `GO + real passkey` に揃っている
- [x] canonical docs 上で bounded issue close が `GO + real passkey` に揃っている
- [x] Butler / Codex / Custom GPT instructions 側の authority wording が同じ境界に揃っている
- [x] docs-only 変更として関連テストが通っている

## Unsatisfied Success Criteria

- [ ] #55 の runtime high-risk plane 実装
- [ ] human-observable E2E evidence for merge / bounded issue close

## Non-goal violations

None.

## Verification Evidence

- Unit: `node --test test/authority-model.test.js test/github-operation-plane.test.js test/custom-gpt-setup-docs.test.js test/approval-model.test.js`
- Integration: None.
- E2E: None. Docs alignment only; integration-facing behavior remains follow-up in #55.
- Manual: Reviewed updated canonical docs and authority wording.
- Evidence path/link: `docs/security/consent-approval-model.md`, `docs/security/go-passkey-approval-model.md`, `docs/security/github-operation-plane.md`, `docs/butler/authority-model.md`

## Related Constitution Rules

- Canonical Source Order
- Drift Stop Protocol
- Authority Boundary
- Current Reality Guard

## Out-of-scope but NOT implemented

- GitHub merge runtime path
- bounded issue close runtime path
- approval grant validation runtime changes
- worker/action surface changes for high-risk GitHub authority actions

## Extra changes (if any)

None.
