### PR TITLE
Add PR body guardrail helpers

### DIFF
--- a/.github/workflows/remote-codex-executor.yml
+++ b/.github/workflows/remote-codex-executor.yml
@@ -204,9 +204,27 @@ jobs:
             exit 1
           fi
 
+          node scripts/render-pr-body.mjs \
+            --output /tmp/vtdd-remote-codex-pr-body.md \
+            --issue "${TARGET_ISSUE_NUMBER}" \
+            --intent "Remote Codex execution result for issue #${TARGET_ISSUE_NUMBER} is being opened as a bounded PR for review." \
+            --satisfied "Codex produced branch changes for the bounded issue scope." \
+            --unsatisfied "Human review, CI review, and merge judgment remain pending." \
+            --unit "None." \
+            --integration "None." \
+            --e2e "None. Remote Codex handoff opens the PR; repository-specific evidence is added in follow-up iteration." \
+            --manual "GitHub PR creation path triggered from remote Codex workflow." \
+            --evidencePath ".github/workflows/remote-codex-executor.yml" \
+            --rules "Current Reality Guard\nEvidence Discipline\nChange Size and PR Discipline" \
+            --outOfScope "Merge\nIssue closure\nDeploy\nCredential mutation" \
+            --executionId "${EXECUTION_ID}" \
+            --codexGoal "${CODEX_GOAL}"
+
+          node scripts/validate-pr-body.mjs /tmp/vtdd-remote-codex-pr-body.md
+
           gh pr create \
             --repo "$TARGET_REPOSITORY" \
             --base "$BASE_REF" \
             --head "$TARGET_BRANCH" \
             --title "VTDD remote Codex execution for issue #${TARGET_ISSUE_NUMBER}" \
-            --body "Remote Codex execution for issue #${TARGET_ISSUE_NUMBER}.\n\nExecution ID: ${EXECUTION_ID}\nGoal: ${CODEX_GOAL}"
+            --body-file /tmp/vtdd-remote-codex-pr-body.md

--- a/docs/pr-template-model.md
+++ b/docs/pr-template-model.md
@@ -56,6 +56,13 @@ Call out any extra changes that were necessary, or state `None.` when there are 
 The PR template should make spec alignment and drift visible. It should not
 attempt to automate code quality judgment or prescribe implementation style.
 
+## Guardrail Usage
+
+Use `scripts/render-pr-body.mjs` to generate a valid starting body instead of
+hand-writing the headings. Validate the result locally with
+`node scripts/validate-pr-body.mjs <path>` before `gh pr create` or
+`gh pr edit --body-file`.
+
 ## Non-goals
 
 This model does not define:

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "node --test"
+    "test": "node --test",
+    "pr-body:validate": "node scripts/validate-pr-body.mjs .github/pull_request_template.md"
   },
   "engines": {
     "node": ">=20"

--- a/scripts/render-pr-body.mjs
+++ b/scripts/render-pr-body.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+
+function parseArgs(argv) {
+  const result = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (!arg.startsWith("--")) {
+      continue;
+    }
+    const key = arg.slice(2);
+    const next = argv[index + 1];
+    if (!next || next.startsWith("--")) {
+      result[key] = "true";
+      continue;
+    }
+    result[key] = next;
+    index += 1;
+  }
+  return result;
+}
+
+function bulletize(value, fallback = "None.") {
+  if (!value) {
+    return fallback;
+  }
+  const lines = String(value)
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+  if (lines.length === 0) {
+    return fallback;
+  }
+  if (lines.length === 1 && (lines[0] === "None." || lines[0] === "None")) {
+    return "None.";
+  }
+  return lines.map((line) => `- ${line.replace(/^- /, "")}`).join("\n");
+}
+
+function renderPrBody(options = {}) {
+  const issue = options.issue ? `#${options.issue}` : null;
+  const issueLink = issue ? ` ${issue}` : "";
+  const executionId = options.executionId || "Not provided.";
+  const codexGoal = options.codexGoal || "Not provided.";
+  const evidencePath = options.evidencePath || "Not provided.";
+
+  return `## This PR satisfies Intent
+
+${bulletize(
+  options.intent,
+  issue
+    ? `- Partial progress for ${issue}. Replace this line with the scoped Intent mapping before merge.`
+    : "- Replace this line with the scoped Intent mapping before merge.",
+)}
+
+## Satisfied Success Criteria
+
+${bulletize(options.satisfied, "- None yet.")}
+
+## Unsatisfied Success Criteria
+
+${bulletize(options.unsatisfied, "None.")}
+
+## Non-goal violations
+
+${options.nonGoals || "None."}
+
+## Verification Evidence
+
+- Unit: ${options.unit || "None."}
+- Integration: ${options.integration || "None."}
+- E2E: ${options.e2e || "None."}
+- Manual: ${options.manual || "None."}
+- Evidence path/link: ${evidencePath}
+
+## Related Constitution Rules
+
+${bulletize(options.rules, "- Add the governing Constitution rules here.")}
+
+## Out-of-scope but NOT implemented
+
+${bulletize(options.outOfScope, "None.")}
+
+## Extra changes (if any)
+
+${options.extra || "None."}
+
+<!-- VTDD metadata -->
+- Issue:${issueLink}
+- Execution ID: ${executionId}
+- Goal: ${codexGoal}
+`;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const args = parseArgs(process.argv.slice(2));
+  const body = renderPrBody(args);
+
+  if (args.output) {
+    fs.writeFileSync(args.output, body);
+  } else {
+    process.stdout.write(body);
+  }
+}
+
+export { renderPrBody };

--- a/scripts/validate-pr-body.mjs
+++ b/scripts/validate-pr-body.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+
+const REQUIRED_MARKERS = [
+  "## This PR satisfies Intent",
+  "## Satisfied Success Criteria",
+  "## Unsatisfied Success Criteria",
+  "## Verification Evidence",
+];
+
+function validatePrBody(body) {
+  const errors = [];
+  for (const marker of REQUIRED_MARKERS) {
+    if (!body.includes(marker)) {
+      errors.push(`Missing PR template marker: ${marker}`);
+    }
+  }
+
+  if (/Closes #[0-9]+/i.test(body)) {
+    if (!/E2E:/i.test(body)) {
+      errors.push("PR uses Closes but E2E slot is missing.");
+    }
+    if (!/Evidence path\/link:/i.test(body)) {
+      errors.push("PR uses Closes but evidence path/link slot is missing.");
+    }
+  }
+
+  return {
+    ok: errors.length === 0,
+    errors,
+  };
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const inputPath = process.argv[2];
+  if (!inputPath) {
+    console.error("Usage: node scripts/validate-pr-body.mjs <path>");
+    process.exit(1);
+  }
+
+  const body = fs.readFileSync(inputPath, "utf8");
+  const result = validatePrBody(body);
+  if (!result.ok) {
+    for (const error of result.errors) {
+      console.error(error);
+    }
+    process.exit(1);
+  }
+
+  console.log("PR body template validation passed.");
+}
+
+export { REQUIRED_MARKERS, validatePrBody };

--- a/test/pr-body-guardrail.test.js
+++ b/test/pr-body-guardrail.test.js
@@ -1,0 +1,60 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+
+import { renderPrBody } from "../scripts/render-pr-body.mjs";
+import { validatePrBody } from "../scripts/validate-pr-body.mjs";
+
+test("renderPrBody includes all guarded-policy headings", () => {
+  const body = renderPrBody({
+    issue: "57",
+    intent: "Prevent repeated PR body guard failures.",
+    satisfied: "Helper generates all required sections.",
+  });
+
+  assert.match(body, /## This PR satisfies Intent/);
+  assert.match(body, /## Satisfied Success Criteria/);
+  assert.match(body, /## Unsatisfied Success Criteria/);
+  assert.match(body, /## Verification Evidence/);
+});
+
+test("validatePrBody fails when required markers are missing", () => {
+  const result = validatePrBody("## Summary\n\nNot enough.");
+  assert.equal(result.ok, false);
+  assert.match(result.errors.join("\n"), /Missing PR template marker/);
+});
+
+test("validatePrBody accepts rendered body", () => {
+  const body = renderPrBody({
+    issue: "57",
+    intent: "Prevent repeated PR body guard failures.",
+    satisfied: "Helper generates all required sections.",
+    unit: "`node --test test/pr-body-guardrail.test.js`",
+    evidencePath: "docs/pr-template-model.md",
+  });
+  const result = validatePrBody(body);
+  assert.equal(result.ok, true);
+});
+
+test("validate-pr-body CLI passes on rendered file", () => {
+  const tmpdir = fs.mkdtempSync(path.join(os.tmpdir(), "vtdd-pr-body-"));
+  const file = path.join(tmpdir, "body.md");
+  fs.writeFileSync(
+    file,
+    renderPrBody({
+      issue: "57",
+      intent: "Prevent repeated PR body guard failures.",
+      satisfied: "Helper generates all required sections.",
+      evidencePath: "docs/pr-template-model.md",
+    }),
+  );
+
+  const output = execFileSync("node", ["scripts/validate-pr-body.mjs", file], {
+    cwd: process.cwd(),
+    encoding: "utf8",
+  });
+  assert.match(output, /PR body template validation passed/);
+});

--- a/test/remote-codex-workflow.test.js
+++ b/test/remote-codex-workflow.test.js
@@ -11,6 +11,9 @@ test("remote Codex workflow commits, pushes, and creates or updates a PR", () =>
   assert.equal(workflow.includes("name: Create or update pull request"), true);
   assert.equal(workflow.includes("gh pr view"), true);
   assert.equal(workflow.includes("gh pr create"), true);
+  assert.equal(workflow.includes("node scripts/render-pr-body.mjs"), true);
+  assert.equal(workflow.includes("node scripts/validate-pr-body.mjs"), true);
+  assert.equal(workflow.includes("--body-file /tmp/vtdd-remote-codex-pr-body.md"), true);
 });
 
 test("remote Codex workflow fails instead of pretending PR creation succeeded with no changes", () => {


### PR DESCRIPTION
## This PR satisfies Intent

- #57 の目的どおり、PR 本文テンプレ違反で `guarded-policy` を無駄に落とす流れをローカル helper と workflow 側の自動生成で止める。
- remote Codex executor が ad hoc な PR body を投げず、required markers を満たす本文を使うようにする。

## Satisfied Success Criteria

- [x] required markers を含む PR body を自動生成する helper を追加した
- [x] PR body をローカル検証する validator を追加した
- [x] remote Codex workflow が helper 生成の `--body-file` を使うようになった
- [x] helper/validator/workflow usage を test でカバーした

## Unsatisfied Success Criteria

None.

## Non-goal violations

None.

## Verification Evidence

- Unit: `node --test test/pr-body-guardrail.test.js test/remote-codex-workflow.test.js test/pr-template-model.test.js`
- Integration: `node scripts/render-pr-body.mjs --issue 57 --intent "Prevent repeated PR body guard failures." --satisfied "Helper generates all required sections." --evidencePath "docs/pr-template-model.md" >/tmp/vtdd-pr-body-smoke.md && node scripts/validate-pr-body.mjs /tmp/vtdd-pr-body-smoke.md`
- E2E: None. This is a process guardrail slice, not an integration-facing runtime slice.
- Manual: Reviewed the generated PR body shape and the workflow `gh pr create --body-file` path.
- Evidence path/link: `scripts/render-pr-body.mjs`, `scripts/validate-pr-body.mjs`, `.github/workflows/remote-codex-executor.yml`, `test/pr-body-guardrail.test.js`

## Related Constitution Rules

- Drift Stop Protocol
- Change Size and PR Discipline
- Evidence Discipline
- Current Reality Guard

## Out-of-scope but NOT implemented

- guarded-policy workflow requirement changes
- runtime behavior changes
- merge/high-risk authority changes

## Extra changes (if any)

None.
