### PR TITLE
Implement GitHub high-risk authority plane

### DIFF
--- a/docs/setup/custom-gpt-actions-openapi.json
+++ b/docs/setup/custom-gpt-actions-openapi.json
@@ -12,9 +12,7 @@
   ],
   "security": [
     {
-      "GatewayBearerAuth": [
-
-      ]
+      "GatewayBearerAuth": []
     }
   ],
   "components": {
@@ -793,6 +791,117 @@
           },
           "404": {
             "description": "Approval grant not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VtddGenericResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/action/github-authority": {
+      "post": {
+        "operationId": "vtddGitHubAuthority",
+        "summary": "Execute approval-bound GitHub authority actions that require GO plus real passkey.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "operation": {
+                    "type": "string",
+                    "enum": [
+                      "pull_merge",
+                      "issue_close"
+                    ]
+                  },
+                  "repository": {
+                    "type": "string"
+                  },
+                  "issueNumber": {
+                    "type": "integer"
+                  },
+                  "pullNumber": {
+                    "type": "integer"
+                  },
+                  "mergeMethod": {
+                    "type": "string",
+                    "enum": [
+                      "merge",
+                      "squash",
+                      "rebase"
+                    ]
+                  },
+                  "commitTitle": {
+                    "type": "string"
+                  },
+                  "commitMessage": {
+                    "type": "string"
+                  },
+                  "issueContext": {
+                    "type": "object",
+                    "properties": {
+                      "issueNumber": {
+                        "type": "integer"
+                      }
+                    },
+                    "additionalProperties": true
+                  },
+                  "policyInput": {
+                    "type": "object",
+                    "properties": {
+                      "approvalPhrase": {
+                        "type": "string"
+                      },
+                      "approvalGrantId": {
+                        "type": "string"
+                      },
+                      "targetConfirmed": {
+                        "type": "boolean"
+                      }
+                    },
+                    "additionalProperties": true
+                  }
+                },
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "GitHub authority action executed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VtddGenericResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing machine auth"
+          },
+          "403": {
+            "description": "Invalid machine auth"
+          },
+          "422": {
+            "description": "GitHub authority action blocked or invalid",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VtddGenericResponse"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "GitHub authority route unavailable",
             "content": {
               "application/json": {
                 "schema": {

--- a/docs/setup/custom-gpt-actions-openapi.yaml
+++ b/docs/setup/custom-gpt-actions-openapi.yaml
@@ -377,6 +377,78 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/VtddGenericResponse"
+  /v2/action/github-authority:
+    post:
+      operationId: vtddGitHubAuthority
+      summary: Execute approval-bound GitHub authority actions that require GO plus real passkey.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                operation:
+                  type: string
+                  enum:
+                    - pull_merge
+                    - issue_close
+                repository:
+                  type: string
+                issueNumber:
+                  type: integer
+                pullNumber:
+                  type: integer
+                mergeMethod:
+                  type: string
+                  enum:
+                    - merge
+                    - squash
+                    - rebase
+                commitTitle:
+                  type: string
+                commitMessage:
+                  type: string
+                issueContext:
+                  type: object
+                  properties:
+                    issueNumber:
+                      type: integer
+                  additionalProperties: true
+                policyInput:
+                  type: object
+                  properties:
+                    approvalPhrase:
+                      type: string
+                    approvalGrantId:
+                      type: string
+                    targetConfirmed:
+                      type: boolean
+                  additionalProperties: true
+              additionalProperties: true
+      responses:
+        "200":
+          description: GitHub authority action executed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VtddGenericResponse"
+        "401":
+          description: Missing machine auth
+        "403":
+          description: Invalid machine auth
+        "422":
+          description: GitHub authority action blocked or invalid
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VtddGenericResponse"
+        "503":
+          description: GitHub authority route unavailable
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VtddGenericResponse"
   /v2/action/progress:
     get:
       operationId: vtddExecutionProgress

--- a/docs/setup/custom-gpt-instructions.md
+++ b/docs/setup/custom-gpt-instructions.md
@@ -117,6 +117,22 @@ GitHub normal write plane:
   - destructive cleanup
 - Those remain approval-bound authority actions outside this normal write plane.
 
+GitHub high-risk authority plane:
+- Use vtddGitHubAuthority for GitHub authority actions that require `GO + real passkey`.
+- Use vtddGitHubAuthority for:
+  - merge of a bounded PR
+  - bounded issue close after merged scoped work
+- Before vtddGitHubAuthority:
+  - retrieve or confirm the approval grant
+  - ensure repository and Issue scope are explicit
+  - ensure the user has explicitly requested the action
+- For merge:
+  - operation=`pull_merge`
+- For bounded issue close:
+  - operation=`issue_close`
+  - include the merged PR number used to prove bounded post-merge scope
+- Do not route deploy, secret mutation, permission mutation, or other destructive provider actions through vtddGitHubAuthority.
+
 Progress tracking:
 - After vtddExecute, always call vtddExecutionProgress.
 - Use executionId, repository, issueNumber, and branch.
@@ -151,6 +167,7 @@ Forbidden behavior:
 - Do not claim that Issues/PRs/comments are absent when the read path is unsupported, unauthorized, or unverified.
 - Do not merge, deploy, mutate secrets, or perform destructive actions on your own.
 - Do not route merge, issue close, deploy, or destructive GitHub actions through vtddWriteGitHub.
+- Do not claim high-risk GitHub authority execution succeeded unless the GitHub-visible merged/closed state is returned.
 - Do not embed owner-specific Cloudflare URLs, account IDs, or private values as if they were universal defaults.
 
 Response style:

--- a/src/core/approval.js
+++ b/src/core/approval.js
@@ -5,11 +5,11 @@ const GO_REQUIRED_ACTIONS = new Set([
   ActionType.ISSUE_CREATE,
   ActionType.BUILD,
   ActionType.PR_REVIEW_SUBMIT,
-  ActionType.PR_OPERATION,
-  ActionType.MERGE
+  ActionType.PR_OPERATION
 ]);
 
 const GO_PASSKEY_REQUIRED_ACTIONS = new Set([
+  ActionType.MERGE,
   ActionType.DEPLOY_PRODUCTION,
   ActionType.DESTRUCTIVE,
   ActionType.EXTERNAL_PUBLISH
@@ -37,7 +37,7 @@ export const APPROVAL_REQUIREMENTS = Object.freeze({
   [ActionType.PR_COMMENT]: ApprovalLevel.NONE,
   [ActionType.PR_REVIEW_SUBMIT]: ApprovalLevel.GO,
   [ActionType.PR_OPERATION]: ApprovalLevel.GO,
-  [ActionType.MERGE]: ApprovalLevel.GO,
+  [ActionType.MERGE]: ApprovalLevel.GO_PASSKEY,
   [ActionType.DEPLOY_PRODUCTION]: ApprovalLevel.GO_PASSKEY,
   [ActionType.DESTRUCTIVE]: ApprovalLevel.GO_PASSKEY,
   [ActionType.EXTERNAL_PUBLISH]: ApprovalLevel.GO_PASSKEY

--- a/src/core/butler-review-synthesis.js
+++ b/src/core/butler-review-synthesis.js
@@ -58,7 +58,7 @@ function buildHumanDecisionFocus({ pullRequest, reviewLoop, codexGoal }) {
   const focus = [];
 
   if (reviewLoop.unresolvedReviewCommentsCount > 0) {
-    focus.push("Meaningful reviewer objections remain unresolved; do not issue merge GO yet.");
+    focus.push("Meaningful reviewer objections remain unresolved; do not issue merge GO + real passkey yet.");
   }
   if (pullRequest.updatedSinceReview) {
     focus.push("The PR changed after the last review signal; Gemini should re-evaluate current diff state.");
@@ -72,7 +72,7 @@ function buildHumanDecisionFocus({ pullRequest, reviewLoop, codexGoal }) {
   if (reviewLoop.reviewCommentsCount === 0) {
     focus.push("Gemini review evidence is not yet present on the PR.");
   }
-  focus.push("Human remains the final authority for revision GO and merge GO.");
+  focus.push("Human remains the final authority for revision GO and merge GO + real passkey.");
 
   return focus;
 }

--- a/src/core/gemini-pr-review.js
+++ b/src/core/gemini-pr-review.js
@@ -264,7 +264,7 @@ export function formatGeminiReviewComment(input = {}) {
     "### Risks",
     formatListOrFallback(risks, "- None reported."),
     "",
-    "_Reviewer remains critique-only. Human keeps revision GO / merge GO authority._"
+    "_Reviewer remains critique-only. Human keeps revision GO / merge GO + real passkey authority._"
   ].join("\n");
 }
 

--- a/src/core/github-high-risk-plane.js
+++ b/src/core/github-high-risk-plane.js
@@ -1,0 +1,321 @@
+import { evaluateApprovalGrant } from "./passkey-approval.js";
+import { resolveGitHubAppInstallationToken } from "./github-app-repository-index.js";
+
+const GITHUB_API_BASE_URL = "https://api.github.com";
+const GITHUB_API_VERSION = "2022-11-28";
+const GITHUB_API_USER_AGENT = "vtdd-v2-github-high-risk-plane";
+
+export const GitHubHighRiskOperation = Object.freeze({
+  PULL_MERGE: "pull_merge",
+  ISSUE_CLOSE: "issue_close"
+});
+
+export async function executeGitHubHighRiskPlane(input = {}) {
+  const operation = normalizeText(input.operation);
+  const repository = normalizeText(input.repository);
+  const issueNumber = normalizePositiveInteger(input.issueNumber);
+  const pullNumber = normalizePositiveInteger(input.pullNumber);
+  const mergeMethod = normalizeMergeMethod(input.mergeMethod);
+  const commitTitle = normalizeText(input.commitTitle);
+  const commitMessage = normalizeBody(input.commitMessage);
+  const approvalPhrase = normalizeText(input.approvalPhrase);
+  const targetConfirmed = input.targetConfirmed === true;
+  const approvalScope = input.approvalScope ?? null;
+  const approvalGrant = input.approvalGrant ?? null;
+  const env = input.env ?? {};
+  const fetchImpl = typeof env?.GITHUB_API_FETCH === "function" ? env.GITHUB_API_FETCH.bind(env) : fetch;
+  const apiBaseUrl = normalizeApiBaseUrl(env?.GITHUB_API_BASE_URL);
+
+  const validation = validateGitHubHighRiskRequest({
+    operation,
+    repository,
+    issueNumber,
+    pullNumber,
+    mergeMethod,
+    approvalPhrase,
+    targetConfirmed,
+    approvalGrant,
+    approvalScope
+  });
+  if (!validation.ok) {
+    return {
+      ok: false,
+      status: 422,
+      error: "github_high_risk_request_invalid",
+      reason: validation.issues.join(", "),
+      issues: validation.issues
+    };
+  }
+
+  const tokenResolution = await resolveGitHubAppInstallationToken({ env, fetchImpl, apiBaseUrl });
+  if (!tokenResolution.ok) {
+    return {
+      ok: false,
+      status: 503,
+      error: "github_high_risk_unavailable",
+      reason: tokenResolution.warning || "GitHub App installation token is unavailable"
+    };
+  }
+
+  return dispatchGitHubHighRisk({
+    operation,
+    repository,
+    issueNumber,
+    pullNumber,
+    mergeMethod,
+    commitTitle,
+    commitMessage,
+    token: tokenResolution.token,
+    fetchImpl,
+    apiBaseUrl
+  });
+}
+
+function validateGitHubHighRiskRequest(input) {
+  const issues = [];
+
+  if (!Object.values(GitHubHighRiskOperation).includes(input.operation)) {
+    issues.push("operation is unsupported");
+  }
+  if (!input.repository) {
+    issues.push("repository is required");
+  }
+  if (!input.targetConfirmed) {
+    issues.push("targetConfirmed must be true");
+  }
+  if (normalizeText(input.approvalPhrase).toUpperCase() !== "GO") {
+    issues.push("approvalPhrase must be GO");
+  }
+  if (!input.issueNumber) {
+    issues.push("issueNumber is required to bind the approval scope");
+  }
+  if (!input.pullNumber) {
+    issues.push("pullNumber is required");
+  }
+  if (
+    input.operation === GitHubHighRiskOperation.PULL_MERGE &&
+    input.mergeMethod &&
+    !["merge", "squash", "rebase"].includes(input.mergeMethod)
+  ) {
+    issues.push("mergeMethod must be merge, squash, or rebase");
+  }
+
+  const grantResult = evaluateApprovalGrant({
+    approvalGrant: input.approvalGrant,
+    scope: input.approvalScope
+  });
+  if (!grantResult.ok) {
+    issues.push(grantResult.reason);
+  }
+
+  return issues.length > 0 ? { ok: false, issues } : { ok: true };
+}
+
+async function dispatchGitHubHighRisk(input) {
+  if (input.operation === GitHubHighRiskOperation.PULL_MERGE) {
+    return executePullMerge(input);
+  }
+
+  if (input.operation === GitHubHighRiskOperation.ISSUE_CLOSE) {
+    return executeBoundedIssueClose(input);
+  }
+
+  return {
+    ok: false,
+    status: 422,
+    error: "github_high_risk_request_invalid",
+    reason: "operation is unsupported"
+  };
+}
+
+async function executePullMerge(input) {
+  const encodedRepository = encodeURIComponentRepository(input.repository);
+  let response;
+  try {
+    response = await input.fetchImpl(
+      `${input.apiBaseUrl}/repos/${encodedRepository}/pulls/${input.pullNumber}/merge`,
+      {
+        method: "PUT",
+        headers: githubJsonHeaders({ token: input.token }),
+        body: JSON.stringify(
+          compactObject({
+            merge_method: input.mergeMethod || "squash",
+            commit_title: input.commitTitle || undefined,
+            commit_message: input.commitMessage || undefined
+          })
+        )
+      }
+    );
+  } catch {
+    return {
+      ok: false,
+      status: 503,
+      error: "github_high_risk_failed",
+      reason: "failed to execute GitHub merge"
+    };
+  }
+
+  const responseBody = await readJsonSafe(response);
+  if (!response.ok) {
+    return {
+      ok: false,
+      status: response.status,
+      error: "github_high_risk_failed",
+      reason: normalizeText(responseBody?.message) || "GitHub merge failed"
+    };
+  }
+
+  return {
+    ok: true,
+    authorityAction: {
+      operation: input.operation,
+      repository: input.repository,
+      pullNumber: input.pullNumber,
+      merged: responseBody?.merged === true,
+      sha: normalizeText(responseBody?.sha) || null,
+      message: normalizeText(responseBody?.message) || null,
+      htmlUrl: `https://github.com/${input.repository}/pull/${input.pullNumber}`
+    }
+  };
+}
+
+async function executeBoundedIssueClose(input) {
+  const encodedRepository = encodeURIComponentRepository(input.repository);
+
+  let prResponse;
+  try {
+    prResponse = await input.fetchImpl(
+      `${input.apiBaseUrl}/repos/${encodedRepository}/pulls/${input.pullNumber}`,
+      {
+        method: "GET",
+        headers: githubJsonHeaders({ token: input.token })
+      }
+    );
+  } catch {
+    return {
+      ok: false,
+      status: 503,
+      error: "github_high_risk_failed",
+      reason: "failed to verify merged pull request state"
+    };
+  }
+
+  const prBody = await readJsonSafe(prResponse);
+  if (!prResponse.ok) {
+    return {
+      ok: false,
+      status: prResponse.status,
+      error: "github_high_risk_failed",
+      reason: normalizeText(prBody?.message) || "failed to read pull request before issue close"
+    };
+  }
+
+  if (!normalizeText(prBody?.merged_at)) {
+    return {
+      ok: false,
+      status: 422,
+      error: "github_high_risk_request_invalid",
+      reason: "bounded issue close requires a merged pull request"
+    };
+  }
+
+  let closeResponse;
+  try {
+    closeResponse = await input.fetchImpl(
+      `${input.apiBaseUrl}/repos/${encodedRepository}/issues/${input.issueNumber}`,
+      {
+        method: "PATCH",
+        headers: githubJsonHeaders({ token: input.token }),
+        body: JSON.stringify({ state: "closed" })
+      }
+    );
+  } catch {
+    return {
+      ok: false,
+      status: 503,
+      error: "github_high_risk_failed",
+      reason: "failed to execute bounded issue close"
+    };
+  }
+
+  const closeBody = await readJsonSafe(closeResponse);
+  if (!closeResponse.ok) {
+    return {
+      ok: false,
+      status: closeResponse.status,
+      error: "github_high_risk_failed",
+      reason: normalizeText(closeBody?.message) || "GitHub issue close failed"
+    };
+  }
+
+  return {
+    ok: true,
+    authorityAction: {
+      operation: input.operation,
+      repository: input.repository,
+      issueNumber: input.issueNumber,
+      pullNumber: input.pullNumber,
+      issueState: normalizeText(closeBody?.state) || "closed",
+      mergedAt: normalizeText(prBody?.merged_at) || null,
+      htmlUrl:
+        normalizeText(closeBody?.html_url) || `https://github.com/${input.repository}/issues/${input.issueNumber}`
+    }
+  };
+}
+
+function githubJsonHeaders({ token }) {
+  return {
+    authorization: `Bearer ${token}`,
+    accept: "application/vnd.github+json",
+    "content-type": "application/json",
+    "x-github-api-version": GITHUB_API_VERSION,
+    "user-agent": GITHUB_API_USER_AGENT
+  };
+}
+
+function compactObject(input = {}) {
+  return Object.fromEntries(Object.entries(input).filter(([, value]) => value !== undefined));
+}
+
+function normalizePositiveInteger(value) {
+  const parsed = Number.parseInt(String(value ?? ""), 10);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
+}
+
+function normalizeMergeMethod(value) {
+  const text = normalizeText(value).toLowerCase();
+  return text || null;
+}
+
+function normalizeBody(value) {
+  const text = String(value ?? "");
+  return text.trim() ? text : "";
+}
+
+function normalizeApiBaseUrl(value) {
+  const normalized = normalizeText(value);
+  return normalized ? normalized.replace(/\/+$/, "") : GITHUB_API_BASE_URL;
+}
+
+function encodeURIComponentRepository(repository) {
+  return repository
+    .split("/")
+    .map((part) => encodeURIComponent(part))
+    .join("/");
+}
+
+async function readJsonSafe(response) {
+  const text = await response.text();
+  if (!text) {
+    return null;
+  }
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+function normalizeText(value) {
+  return String(value ?? "").trim();
+}

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -171,6 +171,7 @@ export {
 } from "./github-app-repository-index.js";
 export { GitHubReadResource, retrieveGitHubReadPlane } from "./github-read-plane.js";
 export { GitHubWriteOperation, executeGitHubWritePlane } from "./github-write-plane.js";
+export { GitHubHighRiskOperation, executeGitHubHighRiskPlane } from "./github-high-risk-plane.js";
 export {
   WorkflowStage,
   WorkflowEvent,

--- a/src/worker.js
+++ b/src/worker.js
@@ -10,6 +10,7 @@ import {
   createRemoteCodexExecutionRequest,
   dedupePasskeys,
   dispatchRemoteCodexExecution,
+  executeGitHubHighRiskPlane,
   inferRelatedIssueFromGatewayInput,
   inferRelatedIssueFromProposalGatewayInput,
   isExpiredPasskeyEphemeralRecord,
@@ -22,6 +23,7 @@ import {
   retrieveConstitution,
   renderPasskeyOperatorPage,
   resolveGatewayAliasRegistryFromGitHubApp,
+  GitHubHighRiskOperation,
   retrieveGitHubReadPlane,
   executeGitHubWritePlane,
   runMvpGateway,
@@ -155,6 +157,19 @@ export default {
       }
 
       return handleGitHubWritePlaneRequest(request, env);
+    }
+
+    if (request.method === "POST" && isApiPath(url.pathname, "/action/github-authority")) {
+      const auth = authorizeGatewayRequest({ request, env, apiSuffix: "/action/github-authority" });
+      if (!auth.ok) {
+        return json(auth.status, {
+          ok: false,
+          error: "unauthorized",
+          reason: auth.reason
+        });
+      }
+
+      return handleGitHubHighRiskPlaneRequest(request, env);
     }
 
     if (request.method === "GET" && isApiPath(url.pathname, "/action/progress")) {
@@ -584,6 +599,97 @@ async function handleGitHubWritePlaneRequest(request, env) {
   });
 }
 
+async function handleGitHubHighRiskPlaneRequest(request, env) {
+  const payload = await readJson(request);
+  if (!payload || typeof payload !== "object") {
+    return json(422, {
+      ok: false,
+      error: "request_body_required",
+      reason: "valid JSON request body is required"
+    });
+  }
+
+  const policyInput =
+    payload.policyInput && typeof payload.policyInput === "object" ? payload.policyInput : {};
+  const issueContext =
+    payload.issueContext && typeof payload.issueContext === "object" ? payload.issueContext : {};
+  const operation = normalizeText(payload.operation);
+  const repository = normalizeText(payload.repository);
+  const scopedIssueNumber = issueContext.issueNumber ?? payload.issueNumber ?? null;
+  const phase = normalizeText(payload.phase) || "execution";
+  const highRiskKind = operation;
+  const actionType = mapGitHubHighRiskOperationToActionType(operation);
+  const approvalScope = buildApprovalScopeSnapshot({
+    payload: {
+      phase,
+      highRiskKind,
+      repositoryInput: repository,
+      issueNumber: scopedIssueNumber,
+      issueContext
+    },
+    policyInput: {
+      ...policyInput,
+      actionType,
+      repositoryInput: repository,
+      highRiskKind,
+      issueTraceability: {
+        relatedIssue: issueContext.issueNumber ?? payload.issueNumber ?? null
+      }
+    }
+  });
+  const resolvedApprovalGrant = await resolveApprovalGrant({
+    payload: {
+      phase,
+      highRiskKind,
+      repositoryInput: repository,
+      issueNumber: scopedIssueNumber,
+      issueContext
+    },
+    policyInput: {
+      ...policyInput,
+      actionType,
+      repositoryInput: repository,
+      highRiskKind,
+      issueTraceability: {
+        relatedIssue: issueContext.issueNumber ?? payload.issueNumber ?? null
+      }
+    },
+    env
+  });
+
+  const executed = await executeGitHubHighRiskPlane({
+    operation,
+    repository,
+    issueNumber: scopedIssueNumber,
+    pullNumber: payload.pullNumber,
+    mergeMethod: payload.mergeMethod,
+    commitTitle: payload.commitTitle,
+    commitMessage: payload.commitMessage,
+    approvalPhrase: policyInput.approvalPhrase,
+    targetConfirmed: policyInput.targetConfirmed,
+    approvalGrant:
+      payload.approvalGrant ??
+      policyInput.approvalGrant ??
+      resolvedApprovalGrant.approvalGrant,
+    approvalScope,
+    env
+  });
+
+  if (!executed.ok) {
+    return json(executed.status ?? 503, {
+      ok: false,
+      error: executed.error ?? "github_high_risk_failed",
+      reason: executed.reason,
+      issues: executed.issues ?? []
+    });
+  }
+
+  return json(200, {
+    ok: true,
+    authorityAction: executed.authorityAction
+  });
+}
+
 function handlePasskeyOperatorPageRequest(request) {
   const url = new URL(request.url);
   const html = renderPasskeyOperatorPage({
@@ -899,6 +1005,16 @@ function buildApprovalScopeSnapshot({ payload, policyInput }) {
     relatedIssue: traceability.relatedIssue ?? issueContext.issueNumber ?? payload?.relatedIssue,
     phase: payload?.phase
   });
+}
+
+function mapGitHubHighRiskOperationToActionType(operation) {
+  if (operation === GitHubHighRiskOperation.PULL_MERGE) {
+    return "merge";
+  }
+  if (operation === GitHubHighRiskOperation.ISSUE_CLOSE) {
+    return "destructive";
+  }
+  return normalizeText(operation);
 }
 
 async function retrieveRegisteredPasskeys(provider) {

--- a/test/approval-model.test.js
+++ b/test/approval-model.test.js
@@ -24,7 +24,7 @@ test("approval requirements map matches expected action levels", () => {
   assert.equal(APPROVAL_REQUIREMENTS[ActionType.READ], ApprovalLevel.NONE);
   assert.equal(APPROVAL_REQUIREMENTS[ActionType.BUILD], ApprovalLevel.GO);
   assert.equal(APPROVAL_REQUIREMENTS[ActionType.PR_REVIEW_SUBMIT], ApprovalLevel.GO);
-  assert.equal(APPROVAL_REQUIREMENTS[ActionType.MERGE], ApprovalLevel.GO);
+  assert.equal(APPROVAL_REQUIREMENTS[ActionType.MERGE], ApprovalLevel.GO_PASSKEY);
   assert.equal(APPROVAL_REQUIREMENTS[ActionType.DESTRUCTIVE], ApprovalLevel.GO_PASSKEY);
 });
 

--- a/test/butler-review-synthesis.test.js
+++ b/test/butler-review-synthesis.test.js
@@ -28,7 +28,7 @@ test("butler review synthesis preserves unresolved reviewer objections and next 
   assert.equal(result.headline.includes("unresolved reviewer objections"), true);
   assert.equal(
     result.humanDecisionFocus.includes(
-      "Meaningful reviewer objections remain unresolved; do not issue merge GO yet."
+      "Meaningful reviewer objections remain unresolved; do not issue merge GO + real passkey yet."
     ),
     true
   );
@@ -73,7 +73,7 @@ test("butler review synthesis does not present approve-only Gemini review as unr
   assert.equal(result.headline, "PR #28 is open. Reviewer feedback exists and should be checked before human GO.");
   assert.equal(
     result.humanDecisionFocus.includes(
-      "Meaningful reviewer objections remain unresolved; do not issue merge GO yet."
+      "Meaningful reviewer objections remain unresolved; do not issue merge GO + real passkey yet."
     ),
     false
   );

--- a/test/core-policy.test.js
+++ b/test/core-policy.test.js
@@ -163,7 +163,7 @@ test("high-risk action requires GO + passkey", () => {
   assert.equal(result.requiredApproval, "go_passkey");
 });
 
-test("merge requires explicit GO but not passkey", () => {
+test("merge requires explicit GO + passkey approval", () => {
   const result = evaluateExecutionPolicy({
     actionType: ActionType.MERGE,
     mode: TaskMode.EXECUTION,
@@ -179,8 +179,8 @@ test("merge requires explicit GO but not passkey", () => {
     go: true,
     passkey: false
   });
-  assert.equal(result.allowed, true);
-  assert.equal(result.requiredApproval, "go");
+  assert.equal(result.allowed, false);
+  assert.equal(result.requiredApproval, "go_passkey");
 });
 
 test("guarded absence mode blocks merge even with GO + passkey", () => {

--- a/test/custom-gpt-setup-docs.test.js
+++ b/test/custom-gpt-setup-docs.test.js
@@ -33,6 +33,7 @@ test("custom gpt instructions preserve current butler and approval boundaries", 
   assert.equal(doc.includes("vtddGateway"), true);
   assert.equal(doc.includes("vtddExecute"), true);
   assert.equal(doc.includes("vtddWriteGitHub"), true);
+  assert.equal(doc.includes("vtddGitHubAuthority"), true);
   assert.equal(doc.includes("vtddExecutionProgress"), true);
   assert.equal(doc.includes("vtddRetrieveGitHub"), true);
   assert.equal(doc.includes("High-risk actions require GO + passkey."), true);
@@ -50,6 +51,7 @@ test("custom gpt openapi doc exposes current gateway, execute, and progress rout
   assert.equal(doc.includes("/v2/gateway:"), true);
   assert.equal(doc.includes("/v2/action/execute:"), true);
   assert.equal(doc.includes("/v2/action/github:"), true);
+  assert.equal(doc.includes("/v2/action/github-authority:"), true);
   assert.equal(doc.includes("/v2/action/progress:"), true);
   assert.equal(doc.includes("/v2/retrieve/github:"), true);
   assert.equal(doc.includes("/v2/retrieve/approval-grant:"), true);
@@ -84,6 +86,7 @@ test("custom gpt openapi json parses and exposes paths as an object", () => {
   assert.equal(typeof doc.paths["/v2/gateway"], "object");
   assert.equal(typeof doc.paths["/v2/action/execute"], "object");
   assert.equal(typeof doc.paths["/v2/action/github"], "object");
+  assert.equal(typeof doc.paths["/v2/action/github-authority"], "object");
   assert.equal(typeof doc.paths["/v2/action/progress"], "object");
   assert.equal(typeof doc.paths["/v2/retrieve/github"], "object");
   assert.equal(typeof doc.paths["/v2/retrieve/approval-grant"], "object");

--- a/test/github-high-risk-plane.test.js
+++ b/test/github-high-risk-plane.test.js
@@ -1,0 +1,247 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  evaluateExecutionPolicy,
+  GitHubHighRiskOperation,
+  ActionType,
+  ApprovalLevel,
+  ConsentCategory,
+  CredentialTier,
+  TaskMode,
+  executeGitHubHighRiskPlane
+} from "../src/core/index.js";
+
+const aliasRegistry = [
+  {
+    canonicalRepo: "sample-org/vtdd-v2-p",
+    productName: "VTDD",
+    aliases: ["vtdd"]
+  }
+];
+
+const mergeGrant = {
+  approvalId: "approval-merge-123",
+  verified: true,
+  expiresAt: "2099-01-01T00:00:00.000Z",
+  scope: {
+    actionType: "merge",
+    highRiskKind: "pull_merge",
+    repositoryInput: "sample-org/vtdd-v2-p",
+    issueNumber: "55",
+    relatedIssue: "55",
+    phase: "execution"
+  }
+};
+
+test("merge now requires GO + passkey approval level in core policy", () => {
+  const denied = evaluateExecutionPolicy({
+    actionType: ActionType.MERGE,
+    mode: TaskMode.EXECUTION,
+    repositoryInput: "vtdd",
+    aliasRegistry,
+    targetConfirmed: true,
+    constitutionConsulted: true,
+    runtimeTruth: { runtimeAvailable: true },
+    credential: {
+      model: "github_app",
+      tier: CredentialTier.HIGH_RISK,
+      shortLived: true,
+      boundApprovalId: "approval-merge-123"
+    },
+    consent: {
+      grantedCategories: [ConsentCategory.EXECUTE]
+    },
+    approvalPhrase: "GO merge request",
+    approvalScopeMatched: true,
+    issueTraceable: true,
+    go: true,
+    passkey: false
+  });
+  const allowed = evaluateExecutionPolicy({
+    actionType: ActionType.MERGE,
+    mode: TaskMode.EXECUTION,
+    repositoryInput: "vtdd",
+    aliasRegistry,
+    targetConfirmed: true,
+    constitutionConsulted: true,
+    runtimeTruth: { runtimeAvailable: true },
+    credential: {
+      model: "github_app",
+      tier: CredentialTier.HIGH_RISK,
+      shortLived: true,
+      boundApprovalId: "approval-merge-123"
+    },
+    consent: {
+      grantedCategories: [ConsentCategory.EXECUTE]
+    },
+    approvalPhrase: "GO merge request",
+    approvalGrant: mergeGrant,
+    approvalScope: mergeGrant.scope,
+    approvalScopeMatched: true,
+    issueTraceable: true,
+    go: true,
+    passkey: false
+  });
+
+  assert.equal(denied.allowed, false);
+  assert.equal(denied.requiredApproval, ApprovalLevel.GO_PASSKEY);
+  assert.equal(allowed.allowed, true);
+  assert.equal(allowed.requiredApproval, ApprovalLevel.GO_PASSKEY);
+});
+
+test("github high-risk plane merges a pull request with scoped approval grant", async () => {
+  const calls = [];
+  const result = await executeGitHubHighRiskPlane({
+    operation: GitHubHighRiskOperation.PULL_MERGE,
+    repository: "sample-org/vtdd-v2-p",
+    issueNumber: 55,
+    pullNumber: 21,
+    approvalPhrase: "GO",
+    targetConfirmed: true,
+    approvalGrant: mergeGrant,
+    approvalScope: mergeGrant.scope,
+    env: {
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_high_risk",
+      GITHUB_API_FETCH: async (url, init) => {
+        calls.push({ url, init });
+        return new Response(
+          JSON.stringify({
+            sha: "abc123",
+            merged: true,
+            message: "Pull Request successfully merged"
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        );
+      }
+    }
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.authorityAction.operation, "pull_merge");
+  assert.equal(result.authorityAction.merged, true);
+  assert.equal(calls[0].init.method, "PUT");
+});
+
+test("github high-risk plane closes bounded issue only after merged pull verification", async () => {
+  const calls = [];
+  const result = await executeGitHubHighRiskPlane({
+    operation: GitHubHighRiskOperation.ISSUE_CLOSE,
+    repository: "sample-org/vtdd-v2-p",
+    issueNumber: 55,
+    pullNumber: 21,
+    approvalPhrase: "GO",
+    targetConfirmed: true,
+    approvalGrant: {
+      approvalId: "approval-close-123",
+      verified: true,
+      expiresAt: "2099-01-01T00:00:00.000Z",
+      scope: {
+        actionType: "destructive",
+        highRiskKind: "issue_close",
+        repositoryInput: "sample-org/vtdd-v2-p",
+        issueNumber: "55",
+        relatedIssue: "55",
+        phase: "execution"
+      }
+    },
+    approvalScope: {
+      actionType: "destructive",
+      highRiskKind: "issue_close",
+      repositoryInput: "sample-org/vtdd-v2-p",
+      issueNumber: "55",
+      relatedIssue: "55",
+      phase: "execution"
+    },
+    env: {
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_high_risk",
+      GITHUB_API_FETCH: async (url, init) => {
+        calls.push({ url, init });
+        if (calls.length === 1) {
+          return new Response(
+            JSON.stringify({
+              number: 21,
+              merged_at: "2026-04-26T12:00:00Z"
+            }),
+            { status: 200, headers: { "content-type": "application/json" } }
+          );
+        }
+        return new Response(
+          JSON.stringify({
+            number: 55,
+            state: "closed",
+            html_url: "https://github.com/sample-org/vtdd-v2-p/issues/55"
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        );
+      }
+    }
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.authorityAction.operation, "issue_close");
+  assert.equal(result.authorityAction.issueState, "closed");
+  assert.equal(calls[0].init.method, "GET");
+  assert.equal(calls[1].init.method, "PATCH");
+});
+
+test("github high-risk plane rejects missing approval grant or unmerged bounded close", async () => {
+  const missingGrant = await executeGitHubHighRiskPlane({
+    operation: GitHubHighRiskOperation.PULL_MERGE,
+    repository: "sample-org/vtdd-v2-p",
+    issueNumber: 55,
+    pullNumber: 21,
+    approvalPhrase: "GO",
+    targetConfirmed: true,
+    approvalGrant: null,
+    approvalScope: mergeGrant.scope,
+    env: {
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_high_risk"
+    }
+  });
+
+  const unmergedClose = await executeGitHubHighRiskPlane({
+    operation: GitHubHighRiskOperation.ISSUE_CLOSE,
+    repository: "sample-org/vtdd-v2-p",
+    issueNumber: 55,
+    pullNumber: 21,
+    approvalPhrase: "GO",
+    targetConfirmed: true,
+    approvalGrant: {
+      approvalId: "approval-close-123",
+      verified: true,
+      expiresAt: "2099-01-01T00:00:00.000Z",
+      scope: {
+        actionType: "destructive",
+        highRiskKind: "issue_close",
+        repositoryInput: "sample-org/vtdd-v2-p",
+        issueNumber: "55",
+        relatedIssue: "55",
+        phase: "execution"
+      }
+    },
+    approvalScope: {
+      actionType: "destructive",
+      highRiskKind: "issue_close",
+      repositoryInput: "sample-org/vtdd-v2-p",
+      issueNumber: "55",
+      relatedIssue: "55",
+      phase: "execution"
+    },
+    env: {
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_high_risk",
+      GITHUB_API_FETCH: async () =>
+        new Response(
+          JSON.stringify({
+            number: 21,
+            merged_at: null
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        )
+    }
+  });
+
+  assert.equal(missingGrant.ok, false);
+  assert.equal(missingGrant.reason.includes("real passkey approval grant is required"), true);
+  assert.equal(unmergedClose.ok, false);
+  assert.equal(unmergedClose.reason, "bounded issue close requires a merged pull request");
+});

--- a/test/mvp-gateway.test.js
+++ b/test/mvp-gateway.test.js
@@ -368,7 +368,7 @@ test("gateway returns execution continuity guidance for PR-reaching execution", 
   assert.equal(result.executionContinuity.butlerReviewSynthesis.available, true);
   assert.equal(
     result.executionContinuity.butlerReviewSynthesis.humanDecisionFocus.includes(
-      "Meaningful reviewer objections remain unresolved; do not issue merge GO yet."
+      "Meaningful reviewer objections remain unresolved; do not issue merge GO + real passkey yet."
     ),
     true
   );

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -967,6 +967,142 @@ test("worker rejects unsupported high-risk GitHub write operations on the normal
   assert.equal(body.error, "github_write_request_invalid");
 });
 
+test("worker executes GitHub merge on the high-risk authority plane with approval grant id", async () => {
+  const provider = createInMemoryMemoryProvider();
+  await provider.store({
+    id: "approval-merge-123",
+    type: MemoryRecordType.APPROVAL_LOG,
+    content: {
+      kind: "passkey_grant",
+      status: "verified",
+      approvalId: "approval-merge-123",
+      expiresAt: "2099-01-01T00:00:00.000Z",
+      scope: {
+        actionType: "merge",
+        highRiskKind: "pull_merge",
+        repositoryInput: "sample-org/vtdd-v2-p",
+        issueNumber: "55",
+        relatedIssue: "55",
+        phase: "execution"
+      }
+    },
+    metadata: { source: "test" },
+    priority: 90,
+    tags: ["passkey_grant"],
+    createdAt: "2026-04-26T00:00:00.000Z"
+  });
+
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/action/github-authority", {
+      method: "POST",
+      headers: {
+        ...gatewayAuthHeaders,
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({
+        operation: "pull_merge",
+        repository: "sample-org/vtdd-v2-p",
+        pullNumber: 21,
+        issueContext: {
+          issueNumber: 55
+        },
+        policyInput: {
+          approvalPhrase: "GO",
+          approvalGrantId: "approval-merge-123",
+          targetConfirmed: true
+        }
+      })
+    }),
+    {
+      ...gatewayAuthEnv,
+      MEMORY_PROVIDER: provider,
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_high_risk",
+      GITHUB_API_FETCH: async () =>
+        new Response(
+          JSON.stringify({
+            sha: "abc123",
+            merged: true,
+            message: "Pull Request successfully merged"
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        )
+    }
+  );
+
+  assert.equal(response.status, 200);
+  const body = await response.json();
+  assert.equal(body.ok, true);
+  assert.equal(body.authorityAction.operation, "pull_merge");
+  assert.equal(body.authorityAction.merged, true);
+});
+
+test("worker blocks bounded issue close on the high-risk authority plane when merged pull proof is missing", async () => {
+  const provider = createInMemoryMemoryProvider();
+  await provider.store({
+    id: "approval-close-123",
+    type: MemoryRecordType.APPROVAL_LOG,
+    content: {
+      kind: "passkey_grant",
+      status: "verified",
+      approvalId: "approval-close-123",
+      expiresAt: "2099-01-01T00:00:00.000Z",
+      scope: {
+        actionType: "destructive",
+        highRiskKind: "issue_close",
+        repositoryInput: "sample-org/vtdd-v2-p",
+        issueNumber: "55",
+        relatedIssue: "55",
+        phase: "execution"
+      }
+    },
+    metadata: { source: "test" },
+    priority: 90,
+    tags: ["passkey_grant"],
+    createdAt: "2026-04-26T00:00:00.000Z"
+  });
+
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/action/github-authority", {
+      method: "POST",
+      headers: {
+        ...gatewayAuthHeaders,
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({
+        operation: "issue_close",
+        repository: "sample-org/vtdd-v2-p",
+        pullNumber: 21,
+        issueContext: {
+          issueNumber: 55
+        },
+        policyInput: {
+          approvalPhrase: "GO",
+          approvalGrantId: "approval-close-123",
+          targetConfirmed: true
+        }
+      })
+    }),
+    {
+      ...gatewayAuthEnv,
+      MEMORY_PROVIDER: provider,
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_high_risk",
+      GITHUB_API_FETCH: async () =>
+        new Response(
+          JSON.stringify({
+            number: 21,
+            merged_at: null
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        )
+    }
+  );
+
+  assert.equal(response.status, 422);
+  const body = await response.json();
+  assert.equal(body.ok, false);
+  assert.equal(body.reason, "bounded issue close requires a merged pull request");
+});
+
 test("worker returns remote Codex execution progress", async () => {
   const response = await worker.fetch(
     new Request("https://example.com/v2/action/progress?executionId=remote-codex-issue6-abcd12", {


### PR DESCRIPTION
## This PR satisfies Intent

- #55 の runtime slice として、Butler-side GitHub high-risk authority plane を追加し、`pull_merge` と bounded `issue_close` を `GO + real passkey` approval grant 前提で実行できるようにする。
- canonical docs で揃えた authority boundary を worker / core policy / Custom GPT action surface に接続する。

## Satisfied Success Criteria

- [x] VTDD exposes a GitHub high-risk authority plane for pull request merge
- [x] VTDD exposes a GitHub high-risk authority plane for bounded issue close for scoped merged work
- [x] the high-risk plane requires Butler-side authority action and a real approval grant resolved from passkey runtime
- [x] the high-risk plane uses GitHub App-backed short-lived execution ability
- [x] merge and issue close routes return GitHub-visible authority action results in the worker response

## Unsatisfied Success Criteria

- [ ] human-observable live evidence for at least one happy-path flow on GitHub
- [ ] human-observable live evidence for at least one blocked/boundary flow on GitHub

## Non-goal violations

None.

## Verification Evidence

- Unit: `node --test test/github-high-risk-plane.test.js test/core-policy.test.js test/butler-review-synthesis.test.js test/mvp-gateway.test.js`
- Integration: `node --test test/worker.test.js test/custom-gpt-setup-docs.test.js`
- E2E: None yet. This PR is runtime partial progress for #55 and does not claim live human-observable GitHub evidence.
- Manual: `npx --yes swagger-cli validate docs/setup/custom-gpt-actions-openapi.yaml && npx --yes swagger-cli validate docs/setup/custom-gpt-actions-openapi.json`
- Evidence path/link: `src/core/github-high-risk-plane.js`, `src/worker.js`, `docs/setup/custom-gpt-actions-openapi.yaml`, `test/github-high-risk-plane.test.js`, `test/worker.test.js`

## Related Constitution Rules

- Authority Boundary
- Drift Stop Protocol
- Current Reality Guard
- Evidence Discipline
- Butler and Reviewer as Stop Roles

## Out-of-scope but NOT implemented

- deploy
- secret / variable / settings mutation
- collaborator / ruleset / branch protection mutation
- merged-branch deletion
- live GitHub E2E evidence capture

## Extra changes (if any)

- Butler / Gemini merge authority strings were updated from `merge GO` to `merge GO + real passkey` so runtime messaging matches the canonical docs.
