### PR TITLE
Connect Worker passkey page to desktop secret sync bridge

### DIFF
--- a/docs/setup/github-app-secret-sync.md
+++ b/docs/setup/github-app-secret-sync.md
@@ -98,6 +98,30 @@ This helper:
 It is an explicit operator helper, not a setup wizard and not a background
 sync path.
 
+## Worker URL Bridge
+
+The canonical passkey ceremony surface remains the Worker URL:
+
+- `GET /v2/approval/passkey/operator`
+
+When you want section `3. GitHub App Secret Sync` on that Worker-hosted page to
+execute the real desktop bootstrap path, first start the local helper and then
+open the Worker URL with an explicit desktop bridge base:
+
+```text
+https://<your-runtime-host>/v2/approval/passkey/operator?repositoryInput=<owner/repo>&issueNumber=15&highRiskKind=github_app_secret_sync&syncApiBase=http%3A%2F%2F127.0.0.1%3A8789%2Fapi
+```
+
+Current contract:
+
+- if `syncApiBase` points at a running desktop helper bridge, section `3`
+  executes the real local bootstrap path
+- if `syncApiBase` is absent or invalid, the Worker page must surface
+  `desktop maintenance required` and keep the sync action disabled
+- the Worker runtime does not read `~/.vtdd` directly
+- the desktop helper remains the only component that reads the local bootstrap
+  vault and executes the GitHub Actions secret mutation path
+
 ## Non-goals
 
 - replacing the desktop bootstrap vault as the local GitHub App source of truth

--- a/scripts/run-passkey-operator-helper.mjs
+++ b/scripts/run-passkey-operator-helper.mjs
@@ -69,6 +69,13 @@ async function main() {
 
 async function handleRequest({ request, response, state }) {
   const url = new URL(request.url, `http://${request.headers.host || "localhost"}`);
+  const corsHeaders = buildCorsHeaders(request.headers.origin);
+
+  if (request.method === "OPTIONS" && url.pathname === "/api/github-app-secret-sync/execute") {
+    response.writeHead(204, corsHeaders);
+    response.end();
+    return;
+  }
 
   if (request.method === "GET" && url.pathname === "/") {
     const html = renderPasskeyOperatorPage({
@@ -98,7 +105,7 @@ async function handleRequest({ request, response, state }) {
         ok: false,
         error: "approval_grant_id_required",
         reason: "approvalGrantId is required"
-      });
+      }, corsHeaders);
       return;
     }
 
@@ -133,7 +140,7 @@ async function handleRequest({ request, response, state }) {
         reason: result.reason,
         stdout: normalizeText(result.stdout),
         stderr: normalizeText(result.stderr)
-      });
+      }, corsHeaders);
       return;
     }
 
@@ -141,7 +148,7 @@ async function handleRequest({ request, response, state }) {
       ok: true,
       stdout: normalizeText(result.stdout),
       stderr: normalizeText(result.stderr)
-    });
+    }, corsHeaders);
     return;
   }
 
@@ -166,7 +173,7 @@ async function handleRequest({ request, response, state }) {
   writeJson(response, 404, {
     ok: false,
     error: "not_found"
-  });
+  }, corsHeaders);
 }
 
 async function proxyPasskeyApi({ request, response, state, pathname }) {
@@ -252,18 +259,37 @@ async function readJson(request) {
   return JSON.parse(body.toString("utf8"));
 }
 
-function writeJson(response, status, body) {
+function writeJson(response, status, body, extraHeaders = {}) {
   response.writeHead(status, {
-    "content-type": "application/json; charset=utf-8"
+    "content-type": "application/json; charset=utf-8",
+    ...extraHeaders
   });
   response.end(JSON.stringify(body));
+}
+
+function buildCorsHeaders(origin) {
+  const allowOrigin = normalizeText(origin) || "*";
+  return {
+    "access-control-allow-origin": allowOrigin,
+    "access-control-allow-methods": "POST, GET, OPTIONS",
+    "access-control-allow-headers": "content-type",
+    vary: "Origin"
+  };
 }
 
 function normalizeText(value) {
   return String(value ?? "").trim();
 }
 
-main().catch((error) => {
-  console.error(error instanceof Error ? error.message : String(error));
-  process.exitCode = 1;
-});
+if (isDirectRun()) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}
+
+function isDirectRun() {
+  return Boolean(process.argv[1]) && path.resolve(process.argv[1]) === path.resolve(new URL(import.meta.url).pathname);
+}
+
+export { buildCorsHeaders, handleRequest };

--- a/src/core/passkey-operator-page.js
+++ b/src/core/passkey-operator-page.js
@@ -1,6 +1,7 @@
 export function renderPasskeyOperatorPage(input = {}) {
   const origin = escapeHtml(input.origin || "");
   const apiBase = escapeHtml(input.apiBase || "/v2");
+  const syncApiBase = escapeHtml(input.syncApiBase || "");
   const registrationDefaultOperatorId = escapeHtml(input.operatorId || "vtdd-operator");
   const registrationDefaultOperatorLabel = escapeHtml(input.operatorLabel || "VTDD Operator");
   const repoDefault = escapeHtml(input.repositoryInput || "");
@@ -9,6 +10,12 @@ export function renderPasskeyOperatorPage(input = {}) {
   const actionTypeDefault = escapeHtml(input.actionType || "destructive");
   const highRiskKindDefault = escapeHtml(input.highRiskKind || "github_app_secret_sync");
   const syncEnabled = input.syncEnabled === true;
+  const syncMessage = escapeHtml(
+    input.syncMessage ||
+      (syncEnabled
+        ? "approvalGrantId が取得済みなら実行できます。desktop helper bridge に接続します。"
+        : "desktop maintenance required: local secret sync bridge が未接続です。")
+  );
 
   return `<!doctype html>
 <html lang="ja">
@@ -164,7 +171,7 @@ export function renderPasskeyOperatorPage(input = {}) {
           <div class="row">
             <button id="sync-button"${syncEnabled ? "" : " disabled"}>Sync GitHub App secrets</button>
           </div>
-          <p class="muted">${syncEnabled ? "approvalGrantId が取得済みなら実行できます。" : "この surface では secret sync endpoint が有効化されていません。"}</p>
+          <p class="muted">${syncMessage}</p>
           <pre id="sync-output"></pre>
         </section>
       </div>
@@ -264,8 +271,11 @@ export function renderPasskeyOperatorPage(input = {}) {
           if (!latestApprovalGrantId) {
             throw new Error("approvalGrantId is required before secret sync");
           }
+          if (!"${syncApiBase}") {
+            throw new Error("desktop maintenance required: local secret sync bridge is not configured");
+          }
           syncOutput.textContent = "github app secret sync request...";
-          const syncResponse = await fetch("${apiBase}/github-app-secret-sync/execute", {
+          const syncResponse = await fetch("${syncApiBase}/github-app-secret-sync/execute", {
             method: "POST",
             headers: { "content-type": "application/json" },
             body: JSON.stringify({

--- a/src/worker.js
+++ b/src/worker.js
@@ -692,14 +692,21 @@ async function handleGitHubHighRiskPlaneRequest(request, env) {
 
 function handlePasskeyOperatorPageRequest(request) {
   const url = new URL(request.url);
+  const syncApiBase = normalizeOptionalHttpUrl(url.searchParams.get("syncApiBase"));
+  const syncEnabled = Boolean(syncApiBase);
   const html = renderPasskeyOperatorPage({
     origin: url.origin,
+    syncApiBase,
     repositoryInput: url.searchParams.get("repositoryInput"),
     issueNumber: url.searchParams.get("issueNumber"),
     phase: url.searchParams.get("phase") || "execution",
     highRiskKind: url.searchParams.get("highRiskKind") || "github_app_secret_sync",
     operatorId: url.searchParams.get("operatorId") || "vtdd-operator",
-    operatorLabel: url.searchParams.get("operatorLabel") || "VTDD Operator"
+    operatorLabel: url.searchParams.get("operatorLabel") || "VTDD Operator",
+    syncEnabled,
+    syncMessage: syncEnabled
+      ? "approvalGrantId が取得済みなら実行できます。desktop helper bridge に接続します。"
+      : "desktop maintenance required: local secret sync bridge が未接続です。"
   });
 
   return new Response(html, {
@@ -708,6 +715,23 @@ function handlePasskeyOperatorPageRequest(request) {
       "content-type": "text/html; charset=utf-8"
     }
   });
+}
+
+function normalizeOptionalHttpUrl(value) {
+  const text = normalizeText(value);
+  if (!text) {
+    return "";
+  }
+
+  try {
+    const url = new URL(text);
+    if (url.protocol !== "http:" && url.protocol !== "https:") {
+      return "";
+    }
+    return url.href.replace(/\/$/, "");
+  } catch {
+    return "";
+  }
 }
 
 async function prepareGatewayPayload({ payload, env }) {

--- a/test/passkey-operator-helper.test.js
+++ b/test/passkey-operator-helper.test.js
@@ -1,0 +1,13 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { buildCorsHeaders } from "../scripts/run-passkey-operator-helper.mjs";
+
+test("desktop helper bridge returns CORS headers for worker-hosted sync requests", () => {
+  const headers = buildCorsHeaders("https://vtdd-v2-mvp.polished-tree-da7c.workers.dev");
+  assert.equal(
+    headers["access-control-allow-origin"],
+    "https://vtdd-v2-mvp.polished-tree-da7c.workers.dev"
+  );
+  assert.equal(headers["access-control-allow-methods"], "POST, GET, OPTIONS");
+  assert.equal(headers["access-control-allow-headers"], "content-type");
+});

--- a/test/passkey-operator-page.test.js
+++ b/test/passkey-operator-page.test.js
@@ -5,6 +5,7 @@ import { renderPasskeyOperatorPage } from "../src/core/index.js";
 test("passkey operator page can target explicit api base and sync endpoint", () => {
   const html = renderPasskeyOperatorPage({
     apiBase: "/api",
+    syncApiBase: "http://127.0.0.1:8789/api",
     actionType: "deploy_production",
     repositoryInput: "marushu/vtdd-v2-p",
     issueNumber: 15,
@@ -13,7 +14,7 @@ test("passkey operator page can target explicit api base and sync endpoint", () 
   });
 
   assert.equal(html.includes('fetch("/api/approval/passkey/challenge"'), true);
-  assert.equal(html.includes('fetch("/api/github-app-secret-sync/execute"'), true);
+  assert.equal(html.includes('fetch("http://127.0.0.1:8789/api/github-app-secret-sync/execute"'), true);
   assert.equal(html.includes("Sync GitHub App secrets"), true);
   assert.equal(html.includes('id="action-type-input" value="deploy_production"'), true);
   assert.equal(html.includes('repositoryInput: document.getElementById("repo-input").value'), true);
@@ -26,6 +27,6 @@ test("passkey operator page keeps sync disabled message when helper endpoint is 
     syncEnabled: false
   });
 
-  assert.equal(html.includes("secret sync endpoint が有効化されていません"), true);
+  assert.equal(html.includes("desktop maintenance required"), true);
   assert.equal(html.includes("disabled"), true);
 });

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -483,6 +483,20 @@ test("worker serves passkey operator page", async () => {
   assert.equal(html.includes("github_app_secret_sync"), true);
 });
 
+test("worker passkey operator page enables desktop secret sync bridge when syncApiBase is provided", async () => {
+  const response = await worker.fetch(
+    new Request(
+      "https://example.com/v2/approval/passkey/operator?repositoryInput=marushu%2Fvtdd-v2-p&issueNumber=15&highRiskKind=github_app_secret_sync&syncApiBase=http%3A%2F%2F127.0.0.1%3A8789%2Fapi"
+    ),
+    gatewayAuthEnv
+  );
+
+  assert.equal(response.status, 200);
+  const html = await response.text();
+  assert.equal(html.includes('fetch("http://127.0.0.1:8789/api/github-app-secret-sync/execute"'), true);
+  assert.equal(html.includes("desktop helper bridge に接続します"), true);
+});
+
 test("worker allows same-origin browser bootstrap registration before first passkey exists", async () => {
   const provider = createInMemoryMemoryProvider();
 


### PR DESCRIPTION
## This PR satisfies Intent

- Connect the Worker-hosted passkey operator page to the canonical desktop bootstrap/update secret sync bridge without implying a Worker-only steady-state path.

## Satisfied Success Criteria

- The local helper bridge serves CORS-safe POST/OPTIONS responses so the Worker-hosted page can call the real bootstrap/update secret sync execution path.

## Unsatisfied Success Criteria

- Issue #26 closure judgment remains pending.

## Non-goal violations

None.

## Verification Evidence

- Unit: None.
- Integration: None.
- E2E: None.
- Manual: None.
- Evidence path/link: scripts/run-passkey-operator-helper.mjs

## Related Constitution Rules

- Add the governing Constitution rules here.

## Out-of-scope but NOT implemented

None.

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: #26
- Execution ID: Not provided.
- Goal: Not provided.
