### PR TITLE
Redefine ~/.vtdd as bootstrap-only vault

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,15 @@ See:
 This repository must not contain committed secret values or repository-local
 bootstrap credential blobs.
 
+The desktop vault is for:
+
+- initial bootstrap
+- later credential update / rotation / repair
+
+It is not intended to be a steady-state runtime dependency. Normal VTDD
+operation should rely on Worker/runtime secrets and short-lived derived tokens
+so iPhone-only operation can continue until bootstrap/update/repair is needed.
+
 ## Cost And Account Boundary
 
 VTDD should not silently turn an existing ChatGPT/Codex subscription into a

--- a/docs/butler/authority-model.md
+++ b/docs/butler/authority-model.md
@@ -146,13 +146,15 @@ phrase.
 
 ## Desktop Maintenance Required
 
-If required operator-owned root credential maintenance can only continue from
+If required operator-owned root credential bootstrap/update/repair work can only continue from
 desktop bootstrap state, Butler must stop and surface:
 
 - `desktop maintenance required`
 
 This is not a Codex-side authority return marker. It is a Butler runtime state
 that blocks further authority action until the desktop bootstrap path is used.
+It should appear only for bootstrap/update/repair needs, not as a steady-state
+requirement for normal iPhone-only operation.
 
 ## Non-goals
 

--- a/docs/setup/desktop-bootstrap-vault.md
+++ b/docs/setup/desktop-bootstrap-vault.md
@@ -7,10 +7,14 @@ This document is the canonical desktop bootstrap contract for Issue #43.
 VTDD needs an operator-owned local credential root that:
 
 - lives outside the repository
-- can be reused for runtime secret sync and self-recovery
+- is used for initial bootstrap and later update/repair work
 - does not store short-lived execution tokens
 - can degrade cleanly into `desktop maintenance required` when iPhone-only
   operation cannot continue
+
+This vault is not the steady-state operational source for normal VTDD runtime.
+Steady-state operation is expected to use already-synced Worker/runtime secrets
+and minted short-lived execution tokens.
 
 The canonical local path is:
 
@@ -25,6 +29,7 @@ This vault is:
 - not repository-tracked
 - not D1-backed
 - not a setup wizard revival
+- not a steady-state runtime dependency
 
 Short-lived execution credentials must not be stored here.
 
@@ -96,6 +101,18 @@ At minimum, the vault contract covers:
 - VTDD gateway bearer token path
 - reviewer credential path(s), if configured
 
+## Operational Model
+
+The canonical model is:
+
+- `~/.vtdd/*` is used during initial bootstrap
+- `~/.vtdd/*` is used again only when update, rotation, or repair requires
+  operator-owned root credential material
+- steady-state VTDD operation should not require the local desktop vault to be
+  mounted or reachable
+- normal Butler / Worker execution should rely on Worker/runtime secrets plus
+  short-lived derived tokens instead
+
 ## Security Rules
 
 - no secret values are committed to the repository
@@ -108,8 +125,8 @@ At minimum, the vault contract covers:
 ## Desktop Maintenance Required
 
 When VTDD is operating from an iPhone-only or otherwise non-desktop surface and
-a required root credential is missing, invalid, expired, or needs rotation,
-Butler must stop and surface:
+update/rotation/repair cannot continue without operator-owned root credential
+material, Butler must stop and surface:
 
 - `desktop maintenance required`
 
@@ -120,9 +137,15 @@ The response should also include a concrete reason such as:
 - `gateway_bearer_token_missing`
 - `reviewer_api_key_invalid`
 
+This state is expected only when bootstrap/update/repair work is needed.
+It must not be treated as the normal steady-state requirement for everyday VTDD
+operation.
+
 ## Non-goals
 
 - setup wizard resurrection
 - storing short-lived execution tokens in D1
 - repository-tracked secret values
 - full encryption / KMS rollout in the same issue
+- making the local desktop vault a mandatory dependency for steady-state
+  iPhone-only operation

--- a/docs/setup/github-app-secret-sync.md
+++ b/docs/setup/github-app-secret-sync.md
@@ -5,16 +5,17 @@ This document is the canonical bootstrap contract for Issue #15 and Issue #43.
 ## Purpose
 
 VTDD keeps local GitHub App root material in the operator-owned desktop
-bootstrap vault under `~/.vtdd/credentials/`, but runtime paths such as remote
-executor and reviewer flows also require GitHub Actions secrets.
+bootstrap vault under `~/.vtdd/credentials/`, but steady-state runtime paths
+such as remote executor and reviewer flows are expected to use already-synced
+runtime secrets instead of reading the local vault directly.
 
 This bootstrap path exists to sync that local source of truth into GitHub
-Actions secrets through an explicit operator action instead of ad hoc manual
-copying.
+Actions/runtime secrets through an explicit operator action instead of ad hoc
+manual copying.
 
 ## Source of Truth
 
-The local source of truth is:
+The local bootstrap/update source of truth is:
 
 - `~/.vtdd/credentials/manifest.json`
 - the private key path referenced from that manifest
@@ -51,7 +52,8 @@ The approval challenge should be requested with a scope that includes:
 - `repositoryInput=<target repo>`
 - `highRiskKind=github_app_secret_sync`
 
-Then execute the local bootstrap with the returned `approvalGrantId`:
+Then execute the local bootstrap/update path with the returned
+`approvalGrantId`:
 
 ```bash
 node scripts/sync-github-app-actions-secrets.mjs \
@@ -95,8 +97,11 @@ This helper:
 - executes `scripts/sync-github-app-actions-secrets.mjs` only after a real
   `approvalGrantId` has been issued
 
-It is an explicit operator helper, not a setup wizard and not a background
-sync path.
+It is an explicit operator helper for bootstrap/update/repair, not a setup
+wizard, not a background sync path, and not a steady-state runtime dependency.
+
+Steady-state iPhone-only VTDD operation is expected to continue without
+`~/.vtdd/*` until a bootstrap/update/repair event is required.
 
 ## Non-goals
 

--- a/test/desktop-bootstrap-vault.test.js
+++ b/test/desktop-bootstrap-vault.test.js
@@ -84,4 +84,6 @@ test("desktop bootstrap vault doc defines canonical path and desktop maintenance
   assert.equal(doc.includes("~/.vtdd/credentials/manifest.json"), true);
   assert.equal(doc.includes("desktop maintenance required"), true);
   assert.equal(doc.includes("Short-lived execution credentials must not be stored here."), true);
+  assert.equal(doc.includes("not the steady-state operational source"), true);
+  assert.equal(doc.includes("steady-state VTDD operation should not require the local desktop vault"), true);
 });


### PR DESCRIPTION
## This PR satisfies Intent

- Redefine ~/.vtdd as a bootstrap/update/repair-only vault instead of a steady-state runtime dependency.

## Satisfied Success Criteria

- Issue #43 was updated to match the bootstrap-only contract.

## Unsatisfied Success Criteria

- Runtime/helper changes that still assume a steadier ~/.vtdd role must be reconciled separately.

## Non-goal violations

None.

## Verification Evidence

- Unit: None.
- Integration: None.
- E2E: None.
- Manual: None.
- Evidence path/link: README.md

## Related Constitution Rules

- Add the governing Constitution rules here.

## Out-of-scope but NOT implemented

None.

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: #43
- Execution ID: Not provided.
- Goal: Not provided.
