### PR TITLE
Add Gemini reviewer writeback E2E evidence

### DIFF
--- a/docs/mvp/e2e/e2e-18-gemini-pr-review-comment-writeback.md
+++ b/docs/mvp/e2e/e2e-18-gemini-pr-review-comment-writeback.md
@@ -1,0 +1,62 @@
+# E2E-18 Gemini PR Review Comment Writeback Evidence
+
+This document records concrete run evidence for the E2E-18 track.
+
+## Scope
+
+Issues:
+- `#9`
+- `#12`
+- parent anchor: `#13`
+
+Goal:
+- confirm the runnable `PR -> Gemini review comment` path is connected
+- confirm PR comment writeback uses the GitHub App credential model instead of an inaccessible return token path
+- confirm reruns update the VTDD Gemini review comment surface without giving the reviewer execution or merge authority
+
+## Happy-path Run
+
+Observed live evidence on 2026-04-25:
+
+- PR: [#28 Add test PR note for live Gemini review](https://github.com/marushu/vtdd-v2-p/pull/28)
+- Gemini review comment:
+  - [vtdd-codex reviewer comment](https://github.com/marushu/vtdd-v2-p/pull/28#issuecomment-4317590536)
+- Workflow run:
+  - [gemini-pr-review / review](https://github.com/marushu/vtdd-v2-p/actions/runs/24920443157/job/72980775527)
+
+Observed result:
+- the reviewer workflow completed successfully on `pull_request_target`
+- the PR received a traceable Gemini review comment carrying the VTDD reviewer marker
+- the review comment shows `Trigger: pull_request_target:opened`
+- the reviewer remained critique-only and did not gain merge or execution authority
+
+## Boundary-path Run
+
+Command:
+
+```sh
+node --test test/gemini-pr-review-workflow.test.js test/gemini-pr-review.test.js
+```
+
+Observed result on 2026-04-26:
+- passed
+- confirms the workflow skips when `VTDD_GITHUB_APP_ID` / `VTDD_GITHUB_APP_PRIVATE_KEY` are not configured
+- confirms the workflow mints a GitHub App token and passes it as `GITHUB_TOKEN` to `scripts/run-gemini-pr-review.mjs`
+- confirms rerun triggers ignore the reviewer marker to avoid uncontrolled comment loops
+- confirms reviewer output remains PR-comment writeback only and does not grant execution credentials or merge authority
+
+## Evidence Files
+
+- `.github/workflows/gemini-pr-review.yml`
+- `scripts/run-gemini-pr-review.mjs`
+- `docs/butler/gemini-pr-review-comments.md`
+- `test/gemini-pr-review-workflow.test.js`
+- `test/gemini-pr-review.test.js`
+
+## Current Reading
+
+E2E-18 now has recorded live happy-path evidence and in-repo boundary-path
+evidence.
+
+This confirms the reviewer runtime is connected through the GitHub App token
+writeback path without collapsing the reviewer role into execution authority.

--- a/docs/mvp/issue-to-e2e-matrix.md
+++ b/docs/mvp/issue-to-e2e-matrix.md
@@ -145,7 +145,7 @@ Status values used below:
 
 ## E2E-06 Policy/consent/approval/state machine
 
-- Issues: `#8 #9 #10 #12`
+- Issues: `#8 #10`
 - Happy path:
   - valid execution proceeds only after deterministic policy, consent, approval, and state transitions align
 - Boundary path:
@@ -362,6 +362,24 @@ Status values used below:
   - `test/worker.test.js`
 - Run evidence:
   - `docs/mvp/e2e/e2e-17-github-app-secret-sync-bootstrap.md`
+- Status: `e2e_evidenced_pending_human_closure`
+
+## E2E-18 Gemini PR review comment writeback
+
+- Issues: `#9 #12`
+- Happy path:
+  - a PR-triggered Gemini reviewer workflow writes a traceable VTDD Gemini review comment back to the PR through the GitHub App token path
+- Boundary path:
+  - missing GitHub App reviewer secrets or self-marker reruns do not silently write comments or create uncontrolled comment loops
+- Implementation evidence:
+  - `.github/workflows/gemini-pr-review.yml`
+  - `scripts/run-gemini-pr-review.mjs`
+  - `docs/butler/gemini-pr-review-comments.md`
+- Test evidence:
+  - `test/gemini-pr-review-workflow.test.js`
+  - `test/gemini-pr-review.test.js`
+- Run evidence:
+  - `docs/mvp/e2e/e2e-18-gemini-pr-review-comment-writeback.md`
 - Status: `e2e_evidenced_pending_human_closure`
 
 ## Current Completion Reading

--- a/test/e2e-18-gemini-pr-review-comment-writeback.test.js
+++ b/test/e2e-18-gemini-pr-review-comment-writeback.test.js
@@ -1,0 +1,34 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const DOC_PATH = path.join(
+  process.cwd(),
+  "docs",
+  "mvp",
+  "e2e",
+  "e2e-18-gemini-pr-review-comment-writeback.md"
+);
+const MATRIX_PATH = path.join(process.cwd(), "docs", "mvp", "issue-to-e2e-matrix.md");
+
+test("E2E-18 evidence doc records live Gemini reviewer writeback and boundary tests", () => {
+  const doc = fs.readFileSync(DOC_PATH, "utf8");
+  assert.equal(doc.includes("pull/28#issuecomment-4317590536"), true);
+  assert.equal(doc.includes("actions/runs/24920443157/job/72980775527"), true);
+  assert.equal(doc.includes("Trigger: pull_request_target:opened"), true);
+  assert.equal(
+    doc.includes("node --test test/gemini-pr-review-workflow.test.js test/gemini-pr-review.test.js"),
+    true
+  );
+  assert.equal(doc.includes("VTDD_GITHUB_APP_ID"), true);
+  assert.equal(doc.includes("VTDD_GITHUB_APP_PRIVATE_KEY"), true);
+  assert.equal(doc.includes("uncontrolled comment loops"), true);
+});
+
+test("issue-to-e2e matrix references E2E-18 run evidence", () => {
+  const doc = fs.readFileSync(MATRIX_PATH, "utf8");
+  assert.equal(doc.includes("## E2E-18 Gemini PR review comment writeback"), true);
+  assert.equal(doc.includes("docs/mvp/e2e/e2e-18-gemini-pr-review-comment-writeback.md"), true);
+  assert.equal(doc.includes("- Issues: `#9 #12`"), true);
+});

--- a/test/gemini-pr-review-workflow.test.js
+++ b/test/gemini-pr-review-workflow.test.js
@@ -1,0 +1,21 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const workflow = fs.readFileSync(".github/workflows/gemini-pr-review.yml", "utf8");
+
+test("Gemini review workflow skips when GitHub App secrets are not configured", () => {
+  assert.equal(workflow.includes("name: Detect GitHub App secret availability"), true);
+  assert.equal(
+    workflow.includes("Skipping Gemini review because VTDD_GITHUB_APP_ID / VTDD_GITHUB_APP_PRIVATE_KEY are not configured."),
+    true
+  );
+});
+
+test("Gemini review workflow mints a GitHub App token and passes it to reviewer writeback", () => {
+  assert.equal(workflow.includes("name: Mint GitHub App token"), true);
+  assert.equal(workflow.includes("uses: actions/create-github-app-token@v1"), true);
+  assert.equal(workflow.includes("token: ${{ steps.app-token.outputs.token }}"), true);
+  assert.equal(workflow.includes("GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}"), true);
+  assert.equal(workflow.includes("run: node scripts/run-gemini-pr-review.mjs"), true);
+});

--- a/test/issue-to-e2e-matrix.test.js
+++ b/test/issue-to-e2e-matrix.test.js
@@ -25,7 +25,8 @@ test("issue-to-e2e matrix defines all canonical E2E tracks", () => {
     "E2E-14",
     "E2E-15",
     "E2E-16",
-    "E2E-17"
+    "E2E-17",
+    "E2E-18"
   ]) {
     assert.equal(doc.includes(`## ${id}`), true);
   }


### PR DESCRIPTION
## This PR satisfies Intent

- Adds dedicated mapped E2E evidence for the PR-triggered Gemini reviewer writeback path and fixes the issue-to-e2e mapping drift for Issues #9 and #12.

## Satisfied Success Criteria

- Dedicated E2E-18 happy-path and boundary-path evidence is added for Issues #9 and #12.
- The matrix now maps reviewer writeback to its own E2E track instead of the generic policy/state-machine track.
- A workflow-level test now fixes the GitHub App token mint and reviewer writeback path.

## Unsatisfied Success Criteria

- Human closure judgment for Issues #9 and #12 is still pending.

## Non-goal violations

No runtime reviewer logic changes.
No Butler synthesis changes.
No merge or deploy automation changes.

## Verification Evidence

- Unit: node --test test/gemini-pr-review-workflow.test.js test/gemini-pr-review.test.js test/e2e-18-gemini-pr-review-comment-writeback.test.js test/issue-to-e2e-matrix.test.js
- Integration: None.
- E2E: docs/mvp/e2e/e2e-18-gemini-pr-review-comment-writeback.md
- Manual: Live happy-path evidence references PR #28 and its successful Gemini review workflow run.
- Evidence path/link: docs/mvp/e2e/e2e-18-gemini-pr-review-comment-writeback.md

## Related Constitution Rules

- Do not overclaim VTDD end-to-end completion from partial adapter success.
- Reviewer role does not get execution credentials.
- Issue closure requires mapped E2E evidence before completion.

## Out-of-scope but NOT implemented

- Issue closure.
- Reviewer line-by-line suggestion features.
- Remote Codex executor changes.

## Extra changes (if any)

This PR also corrects the matrix drift that previously grouped Issues #9 and #12 under E2E-06.

<!-- VTDD metadata -->
- Issue: #12
- Execution ID: Not provided.
- Goal: Not provided.
