### PR TITLE
Add open issue current reality audit

### DIFF
--- a/docs/mvp/close-readiness-audit.md
+++ b/docs/mvp/close-readiness-audit.md
@@ -5,28 +5,16 @@ This document records the current close-readiness reading for the remaining open
 It does not close any Issue automatically.
 Human judgment is still required.
 
-## Current Open Issues
+For the broader open-issue vs current-reality mismatch inventory, also read:
 
-- `#13` parent execution anchor
+- `docs/mvp/open-issue-current-reality-audit.md`
+
+## Current Open Parent / Historical Issues
+
 - `#4` current loop parent
 - `#6` historical execution-slice issue
-- `#1` top-level VTDD V2 draft
 
 ## Current Reading
-
-### `#13`
-
-`#13` is now close-ready for owner review in the narrow sense that:
-
-- canonical parent/child routing is established
-- mapped E2E run evidence exists across the matrix
-- parent companion docs read from current state instead of pre-implementation planning state
-
-`#13` is still intentionally open because:
-
-- parent closure is human-gated
-- the owner may want `#13` to remain open until the broader parent/spec reading is finalized
-- this repository must not infer closure from evidence presence alone
 
 ### `#4`
 
@@ -48,12 +36,6 @@ satisfied that:
 - `#4` and current canonical docs fully cover the current loop authority
 - the historical execution-spine role of `#6` no longer needs to remain visible
   in the open set
-
-### `#1`
-
-`#1` remains the top-level VTDD V2 draft / vision issue.
-It still functions as parent/spec context rather than a direct implementation slice.
-It may remain open until the owner decides the top-level draft is no longer needed as a live umbrella reference.
 
 ## Non-claim
 

--- a/docs/mvp/open-issue-current-reality-audit.md
+++ b/docs/mvp/open-issue-current-reality-audit.md
@@ -1,0 +1,107 @@
+# Open Issue Current-Reality Audit
+
+This document records the current mismatch reading between the GitHub open issue
+set and the repository's merged/runtime reality.
+
+It does not close any issue automatically.
+It exists to prevent drift between:
+
+- what is still open on GitHub
+- what is already implemented/evidenced in-repo
+- what still lacks direct close-ready mapping
+
+## Audit Date
+
+- 2026-04-27
+
+## Current Reading
+
+The repository has broad implementation and mapped E2E coverage across the
+main-line runtime.
+
+However, the open issue set still contains three different kinds of items:
+
+1. issues that are already implemented and mapped to E2E evidence, awaiting only
+   human closure judgment
+2. issues that are substantially reflected in docs/runtime, but still lack a
+   direct issue-to-E2E mapping entry
+3. historical/context issues that remain open for human judgment rather than
+   active implementation
+
+## Open Issues With Direct Mapped E2E Evidence
+
+These issues already have code/runtime evidence, test evidence, and direct
+mapped E2E evidence in `docs/mvp/issue-to-e2e-matrix.md`.
+
+- `#4`
+  - mapped by `E2E-19`
+- `#15`
+  - mapped by `E2E-17`
+- `#26`
+  - mapped by `E2E-16`
+- `#52`
+  - mapped by `E2E-14`
+- `#55`
+  - mapped by `E2E-15`
+- `#9` and `#12`
+  - jointly mapped by `E2E-18`
+
+Current reading:
+- these are not the main source of implementation uncertainty anymore
+- they are best read as `e2e_evidenced_pending_human_closure`
+
+## Open Issues Still Missing Direct Matrix Mapping
+
+These issues remain open, and current repository reality suggests they are
+either implemented or substantially canonicalized, but the current matrix does
+not yet point to them directly as issue-level tracks.
+
+- `#42`
+  - canonicalized GitHub operation plane
+- `#43`
+  - canonicalized desktop bootstrap vault
+- `#44`
+  - canonicalized `live_verified` completion contract
+- `#45`
+  - canonicalized Butler-Codex-Human authority model
+- `#46`
+  - GitHub read plane runtime
+- `#57`
+  - PR body guardrail / helper path
+
+Current reading:
+- these are the main remaining mismatch set between open issues and current repo
+  status
+- they should either:
+  - gain direct mapped issue-to-E2E/audit coverage, or
+  - be treated by the owner as close-ready based on narrower evidence
+
+## Historical / Human-Judgment Open Issue
+
+- `#6`
+
+Current reading:
+- `#6` is historical execution-spine context
+- `#4` is the current parent authority for the loop
+- `#6` should not be treated as the current implementation parent
+
+## Resolved Drift Already Observed
+
+The following older readings must not be reintroduced:
+
+- treating `#13` as a currently open issue
+- treating `#1` as a currently open issue
+- treating `#6` as the current parent authority for the loop
+- treating open issue count alone as proof that major runtime work is still
+  unimplemented
+
+## Recommended Next Step
+
+The next highest-value cleanup is:
+
+- reconcile the open spec/runtime issues that lack direct matrix mapping
+  (`#42 #43 #44 #45 #46 #57`)
+
+This is likely more important than adding new runtime features, because the
+repository already has broad runnable coverage but still carries issue/reality
+drift at the close-readiness layer.

--- a/test/close-readiness-audit.test.js
+++ b/test/close-readiness-audit.test.js
@@ -7,10 +7,11 @@ const DOC_PATH = path.join(process.cwd(), "docs", "mvp", "close-readiness-audit.
 
 test("close-readiness audit distinguishes close-ready from auto-closed", () => {
   const doc = fs.readFileSync(DOC_PATH, "utf8");
-  assert.equal(doc.includes("#13` is now close-ready for owner review"), true);
   assert.equal(doc.includes("It does not close any Issue automatically"), true);
   assert.equal(doc.includes("human-gated" ) || doc.includes("Human judgment is still required"), true);
+  assert.equal(doc.includes("docs/mvp/open-issue-current-reality-audit.md"), true);
   assert.equal(doc.includes("`#4` is the current parent contract for the Butler-Codex-Gemini revision loop"), true);
   assert.equal(doc.includes("`#6` remains a historical execution-slice issue"), true);
-  assert.equal(doc.includes("#1` remains the top-level VTDD V2 draft"), true);
+  assert.equal(doc.includes("`#13` parent execution anchor"), false);
+  assert.equal(doc.includes("`#1` top-level VTDD V2 draft"), false);
 });

--- a/test/open-issue-current-reality-audit.test.js
+++ b/test/open-issue-current-reality-audit.test.js
@@ -1,0 +1,45 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const DOC_PATH = path.join(
+  process.cwd(),
+  "docs",
+  "mvp",
+  "open-issue-current-reality-audit.md"
+);
+const CLOSE_AUDIT_PATH = path.join(process.cwd(), "docs", "mvp", "close-readiness-audit.md");
+
+test("open issue current-reality audit distinguishes mapped, unmapped, and historical open issues", () => {
+  const doc = fs.readFileSync(DOC_PATH, "utf8");
+  assert.equal(doc.includes("`#4`"), true);
+  assert.equal(doc.includes("`#15`"), true);
+  assert.equal(doc.includes("`#26`"), true);
+  assert.equal(doc.includes("`#52`"), true);
+  assert.equal(doc.includes("`#55`"), true);
+  assert.equal(doc.includes("`#9` and `#12`"), true);
+  assert.equal(doc.includes("`#42`"), true);
+  assert.equal(doc.includes("`#43`"), true);
+  assert.equal(doc.includes("`#44`"), true);
+  assert.equal(doc.includes("`#45`"), true);
+  assert.equal(doc.includes("`#46`"), true);
+  assert.equal(doc.includes("`#57`"), true);
+  assert.equal(doc.includes("`#6`"), true);
+});
+
+test("open issue current-reality audit records resolved stale readings", () => {
+  const doc = fs.readFileSync(DOC_PATH, "utf8");
+  assert.equal(doc.includes("treating `#13` as a currently open issue"), true);
+  assert.equal(doc.includes("treating `#1` as a currently open issue"), true);
+  assert.equal(doc.includes("treating `#6` as the current parent authority"), true);
+});
+
+test("close-readiness audit points readers to open issue current-reality audit", () => {
+  const doc = fs.readFileSync(CLOSE_AUDIT_PATH, "utf8");
+  assert.equal(doc.includes("docs/mvp/open-issue-current-reality-audit.md"), true);
+  assert.equal(doc.includes("`#4` current loop parent"), true);
+  assert.equal(doc.includes("`#6` historical execution-slice issue"), true);
+  assert.equal(doc.includes("`#13` parent execution anchor"), false);
+  assert.equal(doc.includes("`#1` top-level VTDD V2 draft"), false);
+});


### PR DESCRIPTION
## This PR satisfies Intent

- Add an open-issue current-reality audit so current open issues are distinguished from already implemented/evidenced work and stale open-issue readings are removed from close-readiness docs.

## Satisfied Success Criteria

- A dedicated open-issue current-reality audit document now classifies open issues into directly mapped, unmapped, and historical categories.
- Close-readiness docs now point to that audit and no longer describe #13 or #1 as currently open issues.
- Tests now lock the new reading so stale open-issue descriptions do not reappear silently.

## Unsatisfied Success Criteria

- The unmapped open issue set (#42 #43 #44 #45 #46 #57) still needs either direct matrix mapping or owner closure judgment.

## Non-goal violations

No runtime behavior changes.
No issue closures.
No new E2E tracks in this slice.

## Verification Evidence

- Unit: node --test test/open-issue-current-reality-audit.test.js test/close-readiness-audit.test.js
- Integration: None.
- E2E: None. Audit/docs-only slice.
- Manual: Validated against the current GitHub open issue list and current matrix state.
- Evidence path/link: docs/mvp/open-issue-current-reality-audit.md

## Related Constitution Rules

- Never resolve source conflicts by assumption.
- Do not overclaim end-to-end completion from partial adapter success.
- Definition-only PRs must not imply milestone completion.

## Out-of-scope but NOT implemented

- Issue closure.
- Matrix remapping for #42/#43/#44/#45/#46/#57.
- Runtime implementation changes.

## Extra changes (if any)

This PR also fixes stale close-readiness references that still treated #13 and #1 as currently open issues.

<!-- VTDD metadata -->
- Issue: #57
- Execution ID: Not provided.
- Goal: Not provided.
