### PR TITLE
Add Butler self-parity check for setup artifacts

### DIFF
--- a/docs/setup/custom-gpt-actions-openapi.json
+++ b/docs/setup/custom-gpt-actions-openapi.json
@@ -912,6 +912,133 @@
           }
         }
       }
+    },
+    "/v2/retrieve/setup-artifact": {
+      "get": {
+        "operationId": "vtddRetrieveSetupArtifact",
+        "summary": "Retrieve canonical Custom GPT setup artifacts from the repository source of truth.",
+        "parameters": [
+          {
+            "name": "artifact",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "instructions",
+                "openapi_yaml",
+                "openapi_json"
+              ]
+            }
+          },
+          {
+            "name": "repository",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "ref",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Canonical setup artifact retrieval result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VtddGenericResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing machine auth"
+          },
+          "403": {
+            "description": "Invalid machine auth"
+          },
+          "422": {
+            "description": "Setup artifact request blocked or invalid",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VtddGenericResponse"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Setup artifact retrieval unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VtddGenericResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/retrieve/self-parity": {
+      "get": {
+        "operationId": "vtddRetrieveSelfParity",
+        "summary": "Evaluate Butler self-parity against canonical setup artifacts and deployed runtime capability.",
+        "parameters": [
+          {
+            "name": "repository",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "ref",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Butler self-parity evaluation result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VtddGenericResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing machine auth"
+          },
+          "403": {
+            "description": "Invalid machine auth"
+          },
+          "503": {
+            "description": "Butler self-parity evaluation unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VtddGenericResponse"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/docs/setup/custom-gpt-actions-openapi.yaml
+++ b/docs/setup/custom-gpt-actions-openapi.yaml
@@ -569,6 +569,85 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/VtddGenericResponse"
+  /v2/retrieve/setup-artifact:
+    get:
+      operationId: vtddRetrieveSetupArtifact
+      summary: Retrieve canonical Custom GPT setup artifacts from the repository source of truth.
+      parameters:
+        - name: artifact
+          in: query
+          required: true
+          schema:
+            type: string
+            enum:
+              - instructions
+              - openapi_yaml
+              - openapi_json
+        - name: repository
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: ref
+          in: query
+          required: false
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Canonical setup artifact retrieval result
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VtddGenericResponse"
+        "401":
+          description: Missing machine auth
+        "403":
+          description: Invalid machine auth
+        "422":
+          description: Setup artifact request blocked or invalid
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VtddGenericResponse"
+        "503":
+          description: Setup artifact retrieval unavailable
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VtddGenericResponse"
+  /v2/retrieve/self-parity:
+    get:
+      operationId: vtddRetrieveSelfParity
+      summary: Evaluate Butler self-parity against canonical setup artifacts and deployed runtime capability.
+      parameters:
+        - name: repository
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: ref
+          in: query
+          required: false
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Butler self-parity evaluation result
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VtddGenericResponse"
+        "401":
+          description: Missing machine auth
+        "403":
+          description: Invalid machine auth
+        "503":
+          description: Butler self-parity evaluation unavailable
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VtddGenericResponse"
   /v2/retrieve/approval-grant:
     get:
       operationId: vtddRetrieveApprovalGrant

--- a/docs/setup/custom-gpt-instructions.md
+++ b/docs/setup/custom-gpt-instructions.md
@@ -77,6 +77,30 @@ GitHub runtime truth read plane:
 - If the route returns unauthorized or invalid machine auth, answer that the read failed due to 認証失敗.
 - Do not infer "Issue may not exist" or similar from an unsupported or failed read.
 
+Butler self-parity and setup artifact recovery:
+- When the user asks whether Butler itself is stale, outdated, or misaligned with the repository/runtime, use vtddRetrieveSelfParity.
+- Use vtddRetrieveSelfParity to compare:
+  - repo canonical setup artifacts
+  - deployed runtime actual capability
+  - Butler-facing setup expectations
+- Use vtddRetrieveSelfParity with:
+  - repository=<resolved repository>
+  - ref=main unless a different ref is explicitly intended
+- Interpret parity outcomes conservatively:
+  - if runtimeParity is `cloudflare_deploy_update_required`, say `Cloudflare deploy update required`
+  - if runtimeParity is `in_sync` but Butler still cannot use the expected feature set, say `Action Schema update required` and/or `Instructions update required`
+  - if parity cannot be checked, say `未検証` or `認証失敗` as appropriate
+- When the user needs the canonical artifact itself for copy-paste, use vtddRetrieveSetupArtifact.
+- Use vtddRetrieveSetupArtifact for:
+  - canonical Custom GPT Instructions
+  - canonical Action Schema YAML
+  - canonical Action Schema JSON
+- Map natural language into artifact names yourself:
+  - instructions
+  - openapi_yaml
+  - openapi_json
+- When returning canonical setup artifacts, make it clear they are the repository canonical source, not proof that the current Custom GPT editor is already updated.
+
 Execution judgment:
 - Before execution, read current runtime truth through vtddGateway.
 - If the target repository is unresolved, do not execute.

--- a/src/core/custom-gpt-setup-artifacts.js
+++ b/src/core/custom-gpt-setup-artifacts.js
@@ -1,0 +1,320 @@
+import { resolveGitHubAppInstallationToken } from "./github-app-repository-index.js";
+
+const GITHUB_API_BASE_URL = "https://api.github.com";
+const GITHUB_API_VERSION = "2022-11-28";
+const GITHUB_API_USER_AGENT = "vtdd-v2-custom-gpt-setup-artifacts";
+
+export const CustomGptSetupArtifact = Object.freeze({
+  INSTRUCTIONS: "instructions",
+  OPENAPI_YAML: "openapi_yaml",
+  OPENAPI_JSON: "openapi_json"
+});
+
+const SETUP_ARTIFACT_SPECS = Object.freeze({
+  [CustomGptSetupArtifact.INSTRUCTIONS]: {
+    path: "docs/setup/custom-gpt-instructions.md",
+    contentType: "text/plain; charset=utf-8"
+  },
+  [CustomGptSetupArtifact.OPENAPI_YAML]: {
+    path: "docs/setup/custom-gpt-actions-openapi.yaml",
+    contentType: "text/yaml; charset=utf-8"
+  },
+  [CustomGptSetupArtifact.OPENAPI_JSON]: {
+    path: "docs/setup/custom-gpt-actions-openapi.json",
+    contentType: "application/json; charset=utf-8"
+  }
+});
+
+const RUNTIME_SETUP_MANIFEST = Object.freeze({
+  routes: [
+    "/health",
+    "/v2/gateway",
+    "/v2/action/execute",
+    "/v2/action/github",
+    "/v2/action/github-authority",
+    "/v2/action/progress",
+    "/v2/retrieve/github",
+    "/v2/retrieve/approval-grant",
+    "/v2/retrieve/setup-artifact",
+    "/v2/retrieve/self-parity"
+  ],
+  operationIds: [
+    "getHealth",
+    "vtddGateway",
+    "vtddExecute",
+    "vtddWriteGitHub",
+    "vtddGitHubAuthority",
+    "vtddExecutionProgress",
+    "vtddRetrieveGitHub",
+    "vtddRetrieveApprovalGrant",
+    "vtddRetrieveSetupArtifact",
+    "vtddRetrieveSelfParity"
+  ],
+  instructionTokens: [
+    "vtddGateway",
+    "vtddExecute",
+    "vtddWriteGitHub",
+    "vtddGitHubAuthority",
+    "vtddExecutionProgress",
+    "vtddRetrieveGitHub",
+    "vtddRetrieveSetupArtifact",
+    "vtddRetrieveSelfParity",
+    "Action Schema update required",
+    "Instructions update required",
+    "Cloudflare deploy update required"
+  ]
+});
+
+export async function retrieveCustomGptSetupArtifact(input = {}) {
+  const artifact = normalizeText(input.artifact);
+  const repository = normalizeText(input.repository);
+  const ref = normalizeText(input.ref) || "main";
+  const env = input.env ?? {};
+  const fetchImpl = typeof env?.GITHUB_API_FETCH === "function" ? env.GITHUB_API_FETCH.bind(env) : fetch;
+  const apiBaseUrl = normalizeApiBaseUrl(env?.GITHUB_API_BASE_URL);
+
+  const validation = validateCustomGptSetupArtifactRequest({ artifact, repository });
+  if (!validation.ok) {
+    return {
+      ok: false,
+      status: 422,
+      error: "custom_gpt_setup_artifact_request_invalid",
+      reason: validation.issues.join(", "),
+      issues: validation.issues
+    };
+  }
+
+  const tokenResolution = await resolveGitHubAppInstallationToken({ env, fetchImpl, apiBaseUrl });
+  if (!tokenResolution.ok) {
+    return {
+      ok: false,
+      status: 503,
+      error: "custom_gpt_setup_artifact_unavailable",
+      reason: tokenResolution.warning || "GitHub App installation token is unavailable"
+    };
+  }
+
+  const spec = SETUP_ARTIFACT_SPECS[artifact];
+  const endpoint = `${apiBaseUrl}/repos/${encodeRepository(repository)}/contents/${spec.path}?ref=${encodeURIComponent(ref)}`;
+
+  let response;
+  try {
+    response = await fetchImpl(endpoint, {
+      method: "GET",
+      headers: {
+        authorization: `Bearer ${tokenResolution.token}`,
+        accept: "application/vnd.github+json",
+        "x-github-api-version": GITHUB_API_VERSION,
+        "user-agent": GITHUB_API_USER_AGENT
+      }
+    });
+  } catch {
+    return {
+      ok: false,
+      status: 503,
+      error: "custom_gpt_setup_artifact_unavailable",
+      reason: `failed to retrieve canonical setup artifact: ${artifact}`
+    };
+  }
+
+  const body = await readJsonSafe(response);
+  if (!response.ok) {
+    return {
+      ok: false,
+      status: response.status,
+      error: "custom_gpt_setup_artifact_unavailable",
+      reason: normalizeText(body?.message) || `GitHub read failed for setup artifact: ${artifact}`
+    };
+  }
+
+  const content = decodeGitHubFileContent(body?.content, body?.encoding);
+  if (!content) {
+    return {
+      ok: false,
+      status: 503,
+      error: "custom_gpt_setup_artifact_unavailable",
+      reason: `GitHub returned an unreadable setup artifact: ${artifact}`
+    };
+  }
+
+  return {
+    ok: true,
+    artifact: {
+      artifact,
+      repository,
+      ref,
+      path: spec.path,
+      sha: normalizeText(body?.sha) || null,
+      contentType: spec.contentType,
+      content
+    }
+  };
+}
+
+export async function evaluateButlerSelfParity(input = {}) {
+  const repository = normalizeText(input.repository);
+  const ref = normalizeText(input.ref) || "main";
+  const env = input.env ?? {};
+
+  const instructions = await retrieveCustomGptSetupArtifact({
+    artifact: CustomGptSetupArtifact.INSTRUCTIONS,
+    repository,
+    ref,
+    env
+  });
+  const openapi = await retrieveCustomGptSetupArtifact({
+    artifact: CustomGptSetupArtifact.OPENAPI_YAML,
+    repository,
+    ref,
+    env
+  });
+
+  if (!instructions.ok || !openapi.ok) {
+    const failed = [instructions, openapi].find((result) => !result.ok);
+    return {
+      ok: false,
+      status: failed?.status ?? 503,
+      error: failed?.error ?? "custom_gpt_self_parity_unavailable",
+      reason: failed?.reason ?? "failed to evaluate Butler self-parity"
+    };
+  }
+
+  const canonicalRoutes = extractOpenApiRoutes(openapi.artifact.content);
+  const canonicalOperationIds = extractOperationIds(openapi.artifact.content);
+  const canonicalInstructionTokens = extractInstructionTokens(
+    instructions.artifact.content,
+    RUNTIME_SETUP_MANIFEST.operationIds
+  );
+
+  const runtimeMissingRoutes = canonicalRoutes.filter(
+    (route) => !RUNTIME_SETUP_MANIFEST.routes.includes(route)
+  );
+  const runtimeMissingOperationIds = canonicalOperationIds.filter(
+    (operationId) => !RUNTIME_SETUP_MANIFEST.operationIds.includes(operationId)
+  );
+  const runtimeMissingInstructionTokens = canonicalInstructionTokens.filter(
+    (token) => !RUNTIME_SETUP_MANIFEST.instructionTokens.includes(token)
+  );
+
+  const runtimeParity =
+    runtimeMissingRoutes.length > 0 ||
+    runtimeMissingOperationIds.length > 0 ||
+    runtimeMissingInstructionTokens.length > 0
+      ? "cloudflare_deploy_update_required"
+      : "in_sync";
+
+  const recommendedActions =
+    runtimeParity === "in_sync"
+      ? [
+          "If Butler cannot use the expected feature set from the current surface, Action Schema update required.",
+          "If Butler cannot follow the expected behavior from the current surface, Instructions update required."
+        ]
+      : ["Cloudflare deploy update required."];
+
+  return {
+    ok: true,
+    selfParity: {
+      repository,
+      ref,
+      runtimeParity,
+      runtimeManifest: RUNTIME_SETUP_MANIFEST,
+      canonical: {
+        routes: canonicalRoutes,
+        operationIds: canonicalOperationIds,
+        instructionTokens: canonicalInstructionTokens,
+        artifacts: {
+          instructions: {
+            path: instructions.artifact.path,
+            sha: instructions.artifact.sha
+          },
+          openapiYaml: {
+            path: openapi.artifact.path,
+            sha: openapi.artifact.sha
+          }
+        }
+      },
+      runtimeMissingRoutes,
+      runtimeMissingOperationIds,
+      runtimeMissingInstructionTokens,
+      recommendedActions
+    }
+  };
+}
+
+function validateCustomGptSetupArtifactRequest({ artifact, repository }) {
+  const issues = [];
+  if (!SETUP_ARTIFACT_SPECS[artifact]) {
+    issues.push("artifact is unsupported");
+  }
+  if (!repository) {
+    issues.push("repository is required");
+  }
+  return issues.length > 0 ? { ok: false, issues } : { ok: true };
+}
+
+function extractOpenApiRoutes(content) {
+  return [...content.matchAll(/^ {2}(\/[^:\n]+):$/gm)].map((match) => match[1]);
+}
+
+function extractOperationIds(content) {
+  return [...content.matchAll(/^\s+operationId:\s+([^\s]+)\s*$/gm)].map((match) => match[1]);
+}
+
+function extractInstructionTokens(content, operationIds) {
+  const requiredTokens = [
+    ...operationIds,
+    "Action Schema update required",
+    "Instructions update required",
+    "Cloudflare deploy update required"
+  ];
+  return requiredTokens.filter((token) => content.includes(token));
+}
+
+function decodeGitHubFileContent(content, encoding) {
+  const normalizedEncoding = normalizeText(encoding) || "base64";
+  if (normalizedEncoding !== "base64") {
+    return null;
+  }
+
+  const normalizedContent = normalizeText(content)?.replace(/\n/g, "");
+  if (!normalizedContent) {
+    return null;
+  }
+
+  if (typeof atob === "function") {
+    return decodeURIComponent(
+      Array.from(atob(normalizedContent), (character) =>
+        `%${character.charCodeAt(0).toString(16).padStart(2, "0")}`
+      ).join("")
+    );
+  }
+
+  return Buffer.from(normalizedContent, "base64").toString("utf8");
+}
+
+function normalizeApiBaseUrl(value) {
+  const normalized = normalizeText(value);
+  return normalized ? normalized.replace(/\/+$/, "") : GITHUB_API_BASE_URL;
+}
+
+function encodeRepository(repository) {
+  return repository
+    .split("/")
+    .map((segment) => encodeURIComponent(segment))
+    .join("/");
+}
+
+function normalizeText(value) {
+  if (typeof value !== "string") {
+    return "";
+  }
+  return value.trim();
+}
+
+async function readJsonSafe(response) {
+  try {
+    return await response.json();
+  } catch {
+    return null;
+  }
+}

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -169,6 +169,11 @@ export {
   resolveGatewayAliasRegistryFromGitHubApp,
   resolveGitHubAppInstallationToken
 } from "./github-app-repository-index.js";
+export {
+  CustomGptSetupArtifact,
+  evaluateButlerSelfParity,
+  retrieveCustomGptSetupArtifact
+} from "./custom-gpt-setup-artifacts.js";
 export { GitHubReadResource, retrieveGitHubReadPlane } from "./github-read-plane.js";
 export { GitHubWriteOperation, executeGitHubWritePlane } from "./github-write-plane.js";
 export { GitHubHighRiskOperation, executeGitHubHighRiskPlane } from "./github-high-risk-plane.js";

--- a/src/worker.js
+++ b/src/worker.js
@@ -10,6 +10,7 @@ import {
   createRemoteCodexExecutionRequest,
   dedupePasskeys,
   dispatchRemoteCodexExecution,
+  evaluateButlerSelfParity,
   executeGitHubHighRiskPlane,
   inferRelatedIssueFromGatewayInput,
   inferRelatedIssueFromProposalGatewayInput,
@@ -21,6 +22,7 @@ import {
   retrieveDecisionLogReferences,
   retrieveProposalLogReferences,
   retrieveConstitution,
+  retrieveCustomGptSetupArtifact,
   renderPasskeyOperatorPage,
   resolveGatewayAliasRegistryFromGitHubApp,
   GitHubHighRiskOperation,
@@ -343,6 +345,30 @@ export default {
       return handleRetrieveGitHubReadPlaneRequest(url, env);
     }
 
+    if (request.method === "GET" && isApiPath(url.pathname, "/retrieve/setup-artifact")) {
+      const auth = authorizeGatewayRequest({ request, env, apiSuffix: "/retrieve/setup-artifact" });
+      if (!auth.ok) {
+        return json(auth.status, {
+          ok: false,
+          error: "unauthorized",
+          reason: auth.reason
+        });
+      }
+      return handleRetrieveCustomGptSetupArtifactRequest(url, env);
+    }
+
+    if (request.method === "GET" && isApiPath(url.pathname, "/retrieve/self-parity")) {
+      const auth = authorizeGatewayRequest({ request, env, apiSuffix: "/retrieve/self-parity" });
+      if (!auth.ok) {
+        return json(auth.status, {
+          ok: false,
+          error: "unauthorized",
+          reason: auth.reason
+        });
+      }
+      return handleRetrieveButlerSelfParityRequest(url, env);
+    }
+
     return json(404, {
       ok: false,
       error: "not_found"
@@ -549,6 +575,50 @@ async function handleRetrieveGitHubReadPlaneRequest(url, env) {
   return json(200, {
     ok: true,
     read: retrieved.read
+  });
+}
+
+async function handleRetrieveCustomGptSetupArtifactRequest(url, env) {
+  const retrieved = await retrieveCustomGptSetupArtifact({
+    artifact: normalizeText(url.searchParams.get("artifact")),
+    repository: normalizeText(url.searchParams.get("repository")),
+    ref: normalizeText(url.searchParams.get("ref")),
+    env
+  });
+
+  if (!retrieved.ok) {
+    return json(retrieved.status ?? 503, {
+      ok: false,
+      error: retrieved.error ?? "custom_gpt_setup_artifact_unavailable",
+      reason: retrieved.reason,
+      issues: retrieved.issues ?? []
+    });
+  }
+
+  return json(200, {
+    ok: true,
+    artifact: retrieved.artifact
+  });
+}
+
+async function handleRetrieveButlerSelfParityRequest(url, env) {
+  const parity = await evaluateButlerSelfParity({
+    repository: normalizeText(url.searchParams.get("repository")),
+    ref: normalizeText(url.searchParams.get("ref")),
+    env
+  });
+
+  if (!parity.ok) {
+    return json(parity.status ?? 503, {
+      ok: false,
+      error: parity.error ?? "custom_gpt_self_parity_unavailable",
+      reason: parity.reason
+    });
+  }
+
+  return json(200, {
+    ok: true,
+    selfParity: parity.selfParity
   });
 }
 

--- a/test/custom-gpt-setup-artifacts.test.js
+++ b/test/custom-gpt-setup-artifacts.test.js
@@ -1,0 +1,107 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  CustomGptSetupArtifact,
+  evaluateButlerSelfParity,
+  retrieveCustomGptSetupArtifact
+} from "../src/core/index.js";
+
+function encodeContent(text) {
+  return Buffer.from(text, "utf8").toString("base64");
+}
+
+test("retrieveCustomGptSetupArtifact returns canonical setup artifact content from GitHub", async () => {
+  const result = await retrieveCustomGptSetupArtifact({
+    artifact: CustomGptSetupArtifact.INSTRUCTIONS,
+    repository: "sample-org/vtdd-v2-p",
+    ref: "main",
+    env: {
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_setup_read",
+      GITHUB_API_FETCH: async (url) => {
+        const parsed = new URL(url);
+        assert.equal(
+          parsed.pathname,
+          "/repos/sample-org/vtdd-v2-p/contents/docs/setup/custom-gpt-instructions.md"
+        );
+        assert.equal(parsed.searchParams.get("ref"), "main");
+        return new Response(
+          JSON.stringify({
+            sha: "abc123",
+            encoding: "base64",
+            content: encodeContent("vtddRetrieveSelfParity\nAction Schema update required")
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        );
+      }
+    }
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.artifact.artifact, "instructions");
+  assert.equal(result.artifact.path, "docs/setup/custom-gpt-instructions.md");
+  assert.equal(result.artifact.sha, "abc123");
+  assert.equal(result.artifact.content.includes("vtddRetrieveSelfParity"), true);
+});
+
+test("retrieveCustomGptSetupArtifact rejects unsupported artifacts", async () => {
+  const result = await retrieveCustomGptSetupArtifact({
+    artifact: "pdf_bundle",
+    repository: "sample-org/vtdd-v2-p",
+    env: { GITHUB_APP_INSTALLATION_TOKEN: "ghs_setup_read" }
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.status, 422);
+  assert.equal(result.error, "custom_gpt_setup_artifact_request_invalid");
+});
+
+test("evaluateButlerSelfParity reports deploy update required when canonical setup expects missing runtime features", async () => {
+  const canonicalInstructions = [
+    "vtddGateway",
+    "vtddRetrieveGitHub",
+    "vtddRetrieveSetupArtifact",
+    "vtddRetrieveSelfParity",
+    "Action Schema update required",
+    "Instructions update required",
+    "Cloudflare deploy update required"
+  ].join("\n");
+  const canonicalOpenApi = [
+    "paths:",
+    "  /v2/gateway:",
+    "  /v2/retrieve/github:",
+    "  /v2/retrieve/setup-artifact:",
+    "  /v2/retrieve/self-parity:",
+    "    get:",
+    "      operationId: vtddGateway",
+    "      operationId: vtddRetrieveGitHub",
+    "      operationId: vtddRetrieveSetupArtifact",
+    "      operationId: vtddRetrieveSelfParity",
+    "      operationId: vtddBrandNewParityRoute"
+  ].join("\n");
+
+  const result = await evaluateButlerSelfParity({
+    repository: "sample-org/vtdd-v2-p",
+    ref: "main",
+    env: {
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_setup_read",
+      GITHUB_API_FETCH: async (url) => {
+        const parsed = new URL(url);
+        const isInstructions = parsed.pathname.endsWith("/docs/setup/custom-gpt-instructions.md");
+        return new Response(
+          JSON.stringify({
+            sha: isInstructions ? "instructions-sha" : "openapi-sha",
+            encoding: "base64",
+            content: encodeContent(isInstructions ? canonicalInstructions : canonicalOpenApi)
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        );
+      }
+    }
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.selfParity.runtimeParity, "cloudflare_deploy_update_required");
+  assert.equal(result.selfParity.runtimeMissingOperationIds.includes("vtddBrandNewParityRoute"), true);
+  assert.equal(result.selfParity.recommendedActions.includes("Cloudflare deploy update required."), true);
+});

--- a/test/custom-gpt-setup-docs.test.js
+++ b/test/custom-gpt-setup-docs.test.js
@@ -36,8 +36,13 @@ test("custom gpt instructions preserve current butler and approval boundaries", 
   assert.equal(doc.includes("vtddGitHubAuthority"), true);
   assert.equal(doc.includes("vtddExecutionProgress"), true);
   assert.equal(doc.includes("vtddRetrieveGitHub"), true);
+  assert.equal(doc.includes("vtddRetrieveSetupArtifact"), true);
+  assert.equal(doc.includes("vtddRetrieveSelfParity"), true);
   assert.equal(doc.includes("High-risk actions require GO + passkey."), true);
   assert.equal(doc.includes("Merge requires explicit human GO + real passkey."), true);
+  assert.equal(doc.includes("Action Schema update required"), true);
+  assert.equal(doc.includes("Instructions update required"), true);
+  assert.equal(doc.includes("Cloudflare deploy update required"), true);
   assert.equal(doc.includes("Do not claim a PR exists when only a Codex task summary exists."), true);
   assert.equal(
     doc.includes("Do not claim that Issues/PRs/comments are absent when the read path is unsupported, unauthorized, or unverified."),
@@ -54,6 +59,8 @@ test("custom gpt openapi doc exposes current gateway, execute, and progress rout
   assert.equal(doc.includes("/v2/action/github-authority:"), true);
   assert.equal(doc.includes("/v2/action/progress:"), true);
   assert.equal(doc.includes("/v2/retrieve/github:"), true);
+  assert.equal(doc.includes("/v2/retrieve/setup-artifact:"), true);
+  assert.equal(doc.includes("/v2/retrieve/self-parity:"), true);
   assert.equal(doc.includes("/v2/retrieve/approval-grant:"), true);
   assert.equal(doc.includes("GatewayBearerAuth"), true);
   assert.equal(doc.includes("conversation:"), true);
@@ -89,6 +96,8 @@ test("custom gpt openapi json parses and exposes paths as an object", () => {
   assert.equal(typeof doc.paths["/v2/action/github-authority"], "object");
   assert.equal(typeof doc.paths["/v2/action/progress"], "object");
   assert.equal(typeof doc.paths["/v2/retrieve/github"], "object");
+  assert.equal(typeof doc.paths["/v2/retrieve/setup-artifact"], "object");
+  assert.equal(typeof doc.paths["/v2/retrieve/self-parity"], "object");
   assert.equal(typeof doc.paths["/v2/retrieve/approval-grant"], "object");
   assert.equal(typeof doc.components.schemas, "object");
   assert.equal(doc.components.securitySchemes.GatewayBearerAuth.scheme, "bearer");

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -908,6 +908,97 @@ test("worker returns unsupported for unknown GitHub read resources", async () =>
   assert.equal(body.error, "github_read_request_invalid");
 });
 
+test("worker returns canonical Custom GPT setup artifacts", async () => {
+  const response = await worker.fetch(
+    new Request(
+      "https://example.com/v2/retrieve/setup-artifact?artifact=instructions&repository=sample-org/vtdd-v2-p&ref=main",
+      {
+        headers: gatewayAuthHeaders
+      }
+    ),
+    {
+      ...gatewayAuthEnv,
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_setup_read",
+      GITHUB_API_FETCH: async () =>
+        new Response(
+          JSON.stringify({
+            sha: "instructions-sha",
+            encoding: "base64",
+            content: Buffer.from("vtddRetrieveSetupArtifact\nvtddRetrieveSelfParity", "utf8").toString(
+              "base64"
+            )
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        )
+    }
+  );
+
+  assert.equal(response.status, 200);
+  const body = await response.json();
+  assert.equal(body.ok, true);
+  assert.equal(body.artifact.artifact, "instructions");
+  assert.equal(body.artifact.path, "docs/setup/custom-gpt-instructions.md");
+  assert.equal(body.artifact.content.includes("vtddRetrieveSelfParity"), true);
+});
+
+test("worker returns Butler self-parity summary", async () => {
+  const response = await worker.fetch(
+    new Request(
+      "https://example.com/v2/retrieve/self-parity?repository=sample-org/vtdd-v2-p&ref=main",
+      {
+        headers: gatewayAuthHeaders
+      }
+    ),
+    {
+      ...gatewayAuthEnv,
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_setup_read",
+      GITHUB_API_FETCH: async (url) => {
+        const parsed = new URL(url);
+        const isInstructions = parsed.pathname.endsWith("/docs/setup/custom-gpt-instructions.md");
+        return new Response(
+          JSON.stringify({
+            sha: isInstructions ? "instructions-sha" : "openapi-sha",
+            encoding: "base64",
+            content: Buffer.from(
+              isInstructions
+                ? [
+                    "vtddGateway",
+                    "vtddRetrieveGitHub",
+                    "vtddRetrieveSetupArtifact",
+                    "vtddRetrieveSelfParity",
+                    "Action Schema update required",
+                    "Instructions update required",
+                    "Cloudflare deploy update required"
+                  ].join("\n")
+                : [
+                    "paths:",
+                    "  /v2/gateway:",
+                    "  /v2/retrieve/github:",
+                    "  /v2/retrieve/setup-artifact:",
+                    "  /v2/retrieve/self-parity:",
+                    "    get:",
+                    "      operationId: vtddGateway",
+                    "      operationId: vtddRetrieveGitHub",
+                    "      operationId: vtddRetrieveSetupArtifact",
+                    "      operationId: vtddRetrieveSelfParity"
+                  ].join("\n"),
+              "utf8"
+            ).toString("base64")
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        );
+      }
+    }
+  );
+
+  assert.equal(response.status, 200);
+  const body = await response.json();
+  assert.equal(body.ok, true);
+  assert.equal(body.selfParity.runtimeParity, "in_sync");
+  assert.equal(body.selfParity.runtimeMissingRoutes.length, 0);
+  assert.equal(body.selfParity.canonical.artifacts.instructions.path, "docs/setup/custom-gpt-instructions.md");
+});
+
 test("worker executes scoped GitHub issue comments through the normal write plane", async () => {
   const response = await worker.fetch(
     new Request("https://example.com/v2/action/github", {


### PR DESCRIPTION
## This PR satisfies Intent

- Add a Butler-readable retrieval path for canonical Custom GPT setup artifacts.
- Add a Butler self-parity check path that compares repo canonical setup artifacts against deployed runtime capability.
- Let Butler report deploy/setup drift in Japanese without speculative narration.

## Satisfied Success Criteria

- Added /v2/retrieve/setup-artifact.
- Added /v2/retrieve/self-parity.
- Added runtime comparison against canonical setup artifacts fetched through GitHub App.
- Updated canonical Custom GPT Instructions and OpenAPI artifacts for the new routes.
- Added worker/core/setup-doc tests for the new paths.

## Unsatisfied Success Criteria

- Full Custom GPT editor-state introspection is still not implemented.
- Mapped E2E evidence for Issue #70 is still pending.
- Human closure judgment for #70 is still pending.

## Non-goal violations

No automatic mutation of the Custom GPT editor. No setup wizard revival. No owner-specific secret exposure.

## Verification Evidence

- Unit: `node --test test/custom-gpt-setup-artifacts.test.js test/custom-gpt-setup-docs.test.js test/worker.test.js`
- Integration: `npx --yes swagger-cli validate docs/setup/custom-gpt-actions-openapi.yaml && npx --yes swagger-cli validate docs/setup/custom-gpt-actions-openapi.json`
- E2E: None.
- Manual: None.
- Evidence path/link: src/core/custom-gpt-setup-artifacts.js, docs/setup/custom-gpt-instructions.md, docs/setup/custom-gpt-actions-openapi.yaml

## Related Constitution Rules

- AGENTS.md Canonical Source Order
- AGENTS.md Issue Lifecycle Gate
- AGENTS.md Current Reality Guard
- AGENTS.md Evidence Discipline

## Out-of-scope but NOT implemented

- Proving the current Custom GPT editor already matches the canonical artifacts.
- Closing Issue #70 in this PR.

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: #70
- Execution ID: Not provided.
- Goal: Not provided.
