### PR TITLE
Add proactive Butler self-parity guidance

### DIFF
--- a/docs/setup/custom-gpt-instructions.md
+++ b/docs/setup/custom-gpt-instructions.md
@@ -79,6 +79,11 @@ GitHub runtime truth read plane:
 
 Butler self-parity and setup artifact recovery:
 - When the user asks whether Butler itself is stale, outdated, or misaligned with the repository/runtime, use vtddRetrieveSelfParity.
+- Before the first significant GitHub/runtime action in a session, you may proactively run vtddRetrieveSelfParity when the user is clearly starting VTDD work.
+- Significant VTDD work includes at minimum:
+  - repository/Issue/PR exploration intended to lead into active work
+  - execution handoff to Codex
+  - merge or issue-close preparation
 - Use vtddRetrieveSelfParity to compare:
   - repo canonical setup artifacts
   - deployed runtime actual capability
@@ -90,6 +95,16 @@ Butler self-parity and setup artifact recovery:
   - if runtimeParity is `cloudflare_deploy_update_required`, say `Cloudflare deploy update required`
   - if runtimeParity is `in_sync` but Butler still cannot use the expected feature set, say `Action Schema update required` and/or `Instructions update required`
   - if parity cannot be checked, say `未検証` or `認証失敗` as appropriate
+- Also trigger vtddRetrieveSelfParity when a Butler-facing action fails in a way that suggests stale setup or deploy drift, for example:
+  - expected route or capability appears unavailable
+  - runtime behavior is missing a capability that the canonical repository artifacts describe
+  - setup artifact retrieval is needed after a deploy/runtime mismatch suspicion
+- On those failures, prefer saying one of:
+  - `Cloudflare deploy update required`
+  - `Action Schema update required`
+  - `Instructions update required`
+  - `未検証`
+  instead of speculating.
 - When the user needs the canonical artifact itself for copy-paste, use vtddRetrieveSetupArtifact.
 - Use vtddRetrieveSetupArtifact for:
   - canonical Custom GPT Instructions
@@ -100,6 +115,7 @@ Butler self-parity and setup artifact recovery:
   - openapi_yaml
   - openapi_json
 - When returning canonical setup artifacts, make it clear they are the repository canonical source, not proof that the current Custom GPT editor is already updated.
+- If a self-parity check says runtime is in sync, do not overclaim that the current Custom GPT editor is also in sync; editor-side drift can still require Action Schema or Instructions refresh.
 
 Execution judgment:
 - Before execution, read current runtime truth through vtddGateway.

--- a/test/custom-gpt-setup-docs.test.js
+++ b/test/custom-gpt-setup-docs.test.js
@@ -38,11 +38,13 @@ test("custom gpt instructions preserve current butler and approval boundaries", 
   assert.equal(doc.includes("vtddRetrieveGitHub"), true);
   assert.equal(doc.includes("vtddRetrieveSetupArtifact"), true);
   assert.equal(doc.includes("vtddRetrieveSelfParity"), true);
+  assert.equal(doc.includes("Before the first significant GitHub/runtime action in a session"), true);
+  assert.equal(doc.includes("Cloudflare deploy update required"), true);
   assert.equal(doc.includes("High-risk actions require GO + passkey."), true);
   assert.equal(doc.includes("Merge requires explicit human GO + real passkey."), true);
   assert.equal(doc.includes("Action Schema update required"), true);
   assert.equal(doc.includes("Instructions update required"), true);
-  assert.equal(doc.includes("Cloudflare deploy update required"), true);
+  assert.equal(doc.includes("runtime is in sync, do not overclaim that the current Custom GPT editor is also in sync"), true);
   assert.equal(doc.includes("Do not claim a PR exists when only a Codex task summary exists."), true);
   assert.equal(
     doc.includes("Do not claim that Issues/PRs/comments are absent when the read path is unsupported, unauthorized, or unverified."),


### PR DESCRIPTION
## This PR satisfies Intent

- Make Butler proactively run self-parity checks at the start of significant VTDD work.
- Make Butler retry through self-parity when stale setup or deploy drift is suspected from action/runtime failures.

## Satisfied Success Criteria

- Added proactive self-parity guidance to the canonical Butler Instructions.
- Added explicit stale/deploy-drift failure triggers that should cause Butler to run vtddRetrieveSelfParity.
- Added test coverage for the new proactive/parity wording.

## Unsatisfied Success Criteria

- Full background or scheduled drift monitoring is still not implemented.
- Full Custom GPT editor-state introspection is still not implemented.
- Mapped E2E evidence for Issue #70 is still pending.

## Non-goal violations

No runtime route changes in this PR. No automatic editor mutation. No scheduled monitor/automation.

## Verification Evidence

- Unit: `node --test test/custom-gpt-setup-docs.test.js`
- Integration: None.
- E2E: None.
- Manual: None.
- Evidence path/link: docs/setup/custom-gpt-instructions.md

## Related Constitution Rules

- AGENTS.md Drift Stop Protocol
- AGENTS.md Current Reality Guard
- AGENTS.md Evidence Discipline

## Out-of-scope but NOT implemented

- Closing Issue #70.
- Proving the editor-side setup is already current without an explicit parity/read check.

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: #70
- Execution ID: Not provided.
- Goal: Not provided.
