### PR TITLE
Add reviewer fallback for Gemini quota exhaustion

### DIFF
--- a/docs/butler/gemini-pr-review-comments.md
+++ b/docs/butler/gemini-pr-review-comments.md
@@ -27,6 +27,11 @@ Gemini review must run when:
 - a PR becomes ready for review
 - new PR comments or review comments arrive
 
+If Gemini is temporarily unavailable because of quota or rate-limit
+exhaustion, VTDD may upsert a GitHub-visible Codex fallback review request
+comment (`@codex review`) instead of hard-failing the PR solely for reviewer
+quota reasons.
+
 The workflow must ignore its own marker comment so that reviewer reruns do not
 create an infinite comment loop.
 
@@ -62,6 +67,10 @@ already present.
 
 The goal is to keep one current critical-review surface on the PR rather than
 creating uncontrolled repeated comments.
+
+When Gemini becomes available again after a fallback request, VTDD should
+return to Gemini-first behavior and clear the stale Codex fallback request
+state.
 
 ## Setup Boundary
 

--- a/docs/mvp/open-issue-current-reality-audit.md
+++ b/docs/mvp/open-issue-current-reality-audit.md
@@ -23,7 +23,9 @@ However, the open issue set still contains three different kinds of items:
 
 1. issues that are already implemented and mapped to E2E evidence, awaiting only
    human closure judgment
-2. historical/context issues that remain open for human judgment rather than
+2. issues that now have partial runtime progress but do not yet have direct
+   mapped E2E closure evidence
+3. historical/context issues that remain open for human judgment rather than
    active implementation
 
 ## Open Issues With Direct Mapped E2E Evidence
@@ -62,6 +64,15 @@ mapped E2E evidence in `docs/mvp/issue-to-e2e-matrix.md`.
 Current reading:
 - these are not the main source of implementation uncertainty anymore
 - they are best read as `e2e_evidenced_pending_human_closure`
+
+## Open Issue With Partial Runtime Progress
+
+- `#74`
+
+Current reading:
+- runtime fallback behavior is being connected
+- direct mapped E2E evidence does not exist yet
+- this remains an active implementation slice, not close-ready
 
 ## Historical / Human-Judgment Open Issue
 

--- a/docs/security/reviewer-policy.md
+++ b/docs/security/reviewer-policy.md
@@ -22,6 +22,10 @@ The reviewer is a critical evaluation role.
 
 ## Fallback Position
 
+- Codex GitHub review may be requested as an emergency fallback when Gemini is
+  temporarily unavailable because of quota or rate-limit exhaustion.
+- This fallback remains critique-only and depends on the operator's Codex
+  GitHub integration, not on repository-owned execution credentials.
 - Antigravity is not the normal reviewer path.
 - Antigravity may be used only as an emergency fallback.
 - Emergency fallback use assumes learning-use is disabled in its service settings.

--- a/scripts/run-gemini-pr-review.mjs
+++ b/scripts/run-gemini-pr-review.mjs
@@ -1,11 +1,15 @@
 import fs from "node:fs/promises";
 import {
+  classifyGeminiReviewFailure,
   DEFAULT_GEMINI_REVIEW_MODEL,
+  GeminiReviewFailureKind,
   buildGeminiReviewRequestBody,
   buildPullRequestDiff,
   buildPullRequestReviewContext,
   extractReviewerResponseFromGemini,
+  findExistingCodexReviewFallbackComment,
   findExistingGeminiReviewComment,
+  formatCodexReviewFallbackComment,
   formatGeminiReviewComment,
   resolveGeminiReviewTrigger
 } from "../src/core/index.js";
@@ -35,6 +39,7 @@ async function main() {
   const issueComments = await githubFetch(`/repos/${repository}/issues/${prNumber}/comments?per_page=100`);
   const reviewComments = await githubFetch(`/repos/${repository}/pulls/${prNumber}/comments?per_page=100`);
   const reviews = await githubFetch(`/repos/${repository}/pulls/${prNumber}/reviews?per_page=100`);
+  const existingFallbackComment = findExistingCodexReviewFallbackComment(issueComments);
 
   if (!process.env.GEMINI_API_KEY) {
     console.log("Skipping Gemini PR review: GEMINI_API_KEY is not configured.");
@@ -58,11 +63,38 @@ async function main() {
 
   const model = process.env.GEMINI_REVIEW_MODEL || DEFAULT_GEMINI_REVIEW_MODEL;
   const requestBody = buildGeminiReviewRequestBody({ prDiff, context });
-  const geminiResponse = await callGemini({
-    apiKey: process.env.GEMINI_API_KEY,
-    model,
-    body: requestBody
-  });
+  let geminiResponse;
+  try {
+    geminiResponse = await callGemini({
+      apiKey: process.env.GEMINI_API_KEY,
+      model,
+      body: requestBody
+    });
+  } catch (error) {
+    const failure = classifyGeminiReviewFailure(error instanceof Error ? error : {});
+    if (failure.kind === GeminiReviewFailureKind.QUOTA_OR_RATE_LIMIT) {
+      const fallbackBody = formatCodexReviewFallbackComment({
+        trigger: triggerResult.value.trigger,
+        reason: "gemini_quota_or_rate_limit"
+      });
+      if (existingFallbackComment) {
+        await githubFetch(`/repos/${repository}/issues/comments/${existingFallbackComment.id}`, {
+          method: "PATCH",
+          body: { body: fallbackBody }
+        });
+        console.log(`Updated Codex reviewer fallback request on PR #${prNumber}.`);
+        return;
+      }
+
+      await githubFetch(`/repos/${repository}/issues/${prNumber}/comments`, {
+        method: "POST",
+        body: { body: fallbackBody }
+      });
+      console.log(`Requested Codex reviewer fallback on PR #${prNumber}.`);
+      return;
+    }
+    throw error;
+  }
   const reviewResult = extractReviewerResponseFromGemini(geminiResponse);
   if (!reviewResult.ok) {
     throw new Error(reviewResult.issues.join(", "));
@@ -74,6 +106,13 @@ async function main() {
     model
   });
   const existingComment = findExistingGeminiReviewComment(issueComments);
+
+  if (existingFallbackComment) {
+    await githubFetch(`/repos/${repository}/issues/comments/${existingFallbackComment.id}`, {
+      method: "DELETE"
+    });
+    console.log(`Cleared Codex reviewer fallback request on PR #${prNumber}.`);
+  }
 
   if (existingComment) {
     await githubFetch(`/repos/${repository}/issues/comments/${existingComment.id}`, {
@@ -132,7 +171,10 @@ async function callGemini({ apiKey, model, body }) {
 
   const json = await response.json().catch(() => ({}));
   if (!response.ok) {
-    throw new Error(json?.error?.message || `Gemini API request failed with status ${response.status}`);
+    const error = new Error(json?.error?.message || `Gemini API request failed with status ${response.status}`);
+    error.status = response.status;
+    error.providerStatus = json?.error?.status;
+    throw error;
   }
   return json;
 }

--- a/src/core/butler-review-synthesis.js
+++ b/src/core/butler-review-synthesis.js
@@ -26,6 +26,7 @@ export function buildButlerReviewSynthesis(input = {}) {
     },
     reviewerSignal: {
       reviewer: reviewLoop.reviewer,
+      reviewerStatus: reviewLoop.reviewerStatus,
       reviewCommentsCount: reviewLoop.reviewCommentsCount,
       unresolvedReviewCommentsCount: reviewLoop.unresolvedReviewCommentsCount,
       criticalReviewPending: reviewLoop.criticalReviewPending,
@@ -45,13 +46,16 @@ export function buildButlerReviewSynthesis(input = {}) {
 
 function buildHeadline({ pullRequest, reviewLoop }) {
   const base = `PR #${pullRequest.number} is ${pullRequest.state || "open"}.`;
+  if (reviewLoop.reviewerStatus === "codex_review_requested") {
+    return `${base} Gemini is temporarily unavailable and Codex fallback review has been requested.`;
+  }
   if (reviewLoop.unresolvedReviewCommentsCount > 0) {
     return `${base} ${reviewLoop.unresolvedReviewCommentsCount} unresolved reviewer objections remain.`;
   }
   if (reviewLoop.reviewCommentsCount > 0) {
     return `${base} Reviewer feedback exists and should be checked before human GO.`;
   }
-  return `${base} No reviewer objections are currently recorded.`;
+  return `${base} Reviewer evidence is not yet available.`;
 }
 
 function buildHumanDecisionFocus({ pullRequest, reviewLoop, codexGoal }) {
@@ -60,8 +64,11 @@ function buildHumanDecisionFocus({ pullRequest, reviewLoop, codexGoal }) {
   if (reviewLoop.unresolvedReviewCommentsCount > 0) {
     focus.push("Meaningful reviewer objections remain unresolved; do not issue merge GO + real passkey yet.");
   }
+  if (reviewLoop.reviewerStatus === "codex_review_requested") {
+    focus.push("Gemini is temporarily unavailable; Codex fallback review has been requested and should arrive before human GO.");
+  }
   if (pullRequest.updatedSinceReview) {
-    focus.push("The PR changed after the last review signal; Gemini should re-evaluate current diff state.");
+    focus.push("The PR changed after the last review signal; reviewer evidence should be refreshed against the current diff.");
   }
   if (codexGoal === "revise_pr") {
     focus.push("Codex should apply bounded PR revisions before Butler asks for merge judgment.");
@@ -69,8 +76,8 @@ function buildHumanDecisionFocus({ pullRequest, reviewLoop, codexGoal }) {
   if (codexGoal === "respond_to_review") {
     focus.push("Codex should respond on the PR without treating reviewer comments as resolved by silence.");
   }
-  if (reviewLoop.reviewCommentsCount === 0) {
-    focus.push("Gemini review evidence is not yet present on the PR.");
+  if (reviewLoop.reviewCommentsCount === 0 && reviewLoop.reviewerStatus !== "codex_review_requested") {
+    focus.push("Reviewer evidence is not yet present on the PR.");
   }
   focus.push("Human remains the final authority for revision GO and merge GO + real passkey.");
 
@@ -134,6 +141,7 @@ function normalizeReviewLoop(value) {
   const input = value && typeof value === "object" ? value : {};
   return {
     reviewer: normalizeText(input.reviewer) || "gemini",
+    reviewerStatus: normalizeText(input.reviewerStatus) || "review_unavailable",
     reviewCommentsCount: normalizeCount(input.reviewCommentsCount),
     unresolvedReviewCommentsCount: normalizeCount(input.unresolvedReviewCommentsCount),
     criticalReviewPending: input.criticalReviewPending === true

--- a/src/core/codex-review-fallback.js
+++ b/src/core/codex-review-fallback.js
@@ -1,0 +1,47 @@
+export const CODEX_REVIEW_FALLBACK_MARKER = "<!-- vtdd:reviewer=codex-fallback -->";
+
+export function formatCodexReviewFallbackComment(input = {}) {
+  const trigger = normalizeText(input.trigger) || "unknown";
+  const reason = normalizeText(input.reason) || "gemini_quota_or_rate_limit";
+
+  return [
+    CODEX_REVIEW_FALLBACK_MARKER,
+    "@codex review",
+    "",
+    "## VTDD Codex Reviewer Fallback Request",
+    "",
+    `- Trigger: \`${trigger}\``,
+    `- Reason: \`${reason}\``,
+    "",
+    "Gemini critical review is temporarily unavailable.",
+    "Please provide critique-only PR feedback.",
+    "",
+    "_Reviewer remains critique-only. Human keeps revision GO / merge GO + real passkey authority._"
+  ].join("\n");
+}
+
+export function findExistingCodexReviewFallbackComment(comments = []) {
+  return comments.find((comment) => containsMarker(comment?.body)) ?? null;
+}
+
+export function parseCodexReviewFallbackComment(comment = {}) {
+  const body = normalizeText(typeof comment === "string" ? comment : comment?.body);
+  if (!body || !containsMarker(body)) {
+    return null;
+  }
+
+  return {
+    reviewer: "codex",
+    status: "requested",
+    blocking: false,
+    body
+  };
+}
+
+function containsMarker(value) {
+  return normalizeText(value).includes(CODEX_REVIEW_FALLBACK_MARKER);
+}
+
+function normalizeText(value) {
+  return String(value ?? "").trim();
+}

--- a/src/core/execution-continuity.js
+++ b/src/core/execution-continuity.js
@@ -1,4 +1,5 @@
 import { buildButlerReviewSynthesis } from "./butler-review-synthesis.js";
+import { parseCodexReviewFallbackComment } from "./codex-review-fallback.js";
 import { parseGeminiReviewComment } from "./gemini-pr-review.js";
 import { ActorRole, TaskMode } from "./types.js";
 
@@ -54,6 +55,7 @@ export function evaluateExecutionContinuity(input = {}) {
       },
       reviewLoop: {
         reviewer: review.reviewer,
+        reviewerStatus: review.reviewerStatus,
         reviewCommentsCount: review.reviewCommentsCount,
         unresolvedReviewCommentsCount: review.unresolvedReviewCommentsCount,
         criticalReviewPending: review.criticalReviewPending,
@@ -69,6 +71,7 @@ export function evaluateExecutionContinuity(input = {}) {
         pullRequest,
         reviewLoop: {
           reviewer: review.reviewer,
+          reviewerStatus: review.reviewerStatus,
           reviewCommentsCount: review.reviewCommentsCount,
           unresolvedReviewCommentsCount: review.unresolvedReviewCommentsCount,
           criticalReviewPending: review.criticalReviewPending
@@ -120,20 +123,31 @@ function validateHandoffRequirement({ actorRole, continuation }) {
 
 function buildReviewState(pullRequest) {
   const parsedGeminiSignals = collectGeminiReviewerSignals(pullRequest);
+  const codexFallback = collectCodexFallbackSignals(pullRequest);
   const reviewCommentsCount =
     parsedGeminiSignals.totalCount > 0 ? parsedGeminiSignals.totalCount : pullRequest.reviewCommentsCount;
   const unresolvedReviewCommentsCount =
     parsedGeminiSignals.totalCount > 0
       ? parsedGeminiSignals.blockingCount
       : pullRequest.unresolvedReviewCommentsCount;
-  const reviewer = pullRequest.reviewer;
+  const reviewerStatus = codexFallback.requested
+    ? "codex_review_requested"
+    : reviewCommentsCount > 0
+      ? "gemini_review_available"
+      : "review_unavailable";
+  const reviewer = reviewerStatus === "codex_review_requested" ? "codex" : pullRequest.reviewer;
   const criticalReviewPending =
-    pullRequest.exists && reviewCommentsCount > 0 && unresolvedReviewCommentsCount > 0;
+    pullRequest.exists &&
+    (reviewerStatus === "codex_review_requested" ||
+      (reviewCommentsCount > 0 && unresolvedReviewCommentsCount > 0));
   const rerunReviewer =
-    pullRequest.exists && (pullRequest.updatedSinceReview || unresolvedReviewCommentsCount > 0);
+    pullRequest.exists &&
+    reviewerStatus !== "codex_review_requested" &&
+    (pullRequest.updatedSinceReview || unresolvedReviewCommentsCount > 0);
 
   return {
     reviewer,
+    reviewerStatus,
     reviewCommentsCount,
     unresolvedReviewCommentsCount,
     criticalReviewPending,
@@ -154,6 +168,15 @@ function collectGeminiReviewerSignals(pullRequest) {
   };
 }
 
+function collectCodexFallbackSignals(pullRequest) {
+  const comments = [...(Array.isArray(pullRequest.issueComments) ? pullRequest.issueComments : [])];
+  const parsed = comments.map(parseCodexReviewFallbackComment).filter(Boolean);
+
+  return {
+    requested: parsed.length > 0
+  };
+}
+
 function determineCodexGoal({ pullRequest, review }) {
   if (!pullRequest.exists) {
     return CodexGoal.OPEN_PR;
@@ -169,6 +192,10 @@ function buildNextSuggestedActions({ pullRequest, review, codexGoal }) {
     return ["continue_bounded_coding", "open_pull_request", "request_gemini_review"];
   }
 
+  if (review.reviewerStatus === "codex_review_requested") {
+    return ["wait_for_codex_review", "summarize_for_human"];
+  }
+
   if (codexGoal === CodexGoal.REVISE_PR) {
     return ["apply_pr_feedback", "reply_on_pull_request", "rerun_gemini_review"];
   }
@@ -178,6 +205,10 @@ function buildNextSuggestedActions({ pullRequest, review, codexGoal }) {
   }
 
   if (review.rerunReviewer) {
+    return ["rerun_gemini_review", "summarize_for_human"];
+  }
+
+  if (review.reviewerStatus === "review_unavailable") {
     return ["rerun_gemini_review", "summarize_for_human"];
   }
 

--- a/src/core/gemini-review-failure.js
+++ b/src/core/gemini-review-failure.js
@@ -1,0 +1,29 @@
+export const GeminiReviewFailureKind = Object.freeze({
+  QUOTA_OR_RATE_LIMIT: "quota_or_rate_limit",
+  OTHER: "other"
+});
+
+export function classifyGeminiReviewFailure(input = {}) {
+  const status = normalizeNumber(input?.status);
+  const providerStatus = normalizeText(input?.providerStatus || input?.errorStatus).toLowerCase();
+  const message = normalizeText(input?.message);
+
+  if (
+    status === 429 ||
+    providerStatus === "resource_exhausted" ||
+    /quota exceeded|rate limit|resource_exhausted|too many requests/i.test(message)
+  ) {
+    return { kind: GeminiReviewFailureKind.QUOTA_OR_RATE_LIMIT };
+  }
+
+  return { kind: GeminiReviewFailureKind.OTHER };
+}
+
+function normalizeText(value) {
+  return String(value ?? "").trim();
+}
+
+function normalizeNumber(value) {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : null;
+}

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -164,6 +164,16 @@ export {
   parseGeminiReviewComment,
   resolveGeminiReviewTrigger
 } from "./gemini-pr-review.js";
+export {
+  CODEX_REVIEW_FALLBACK_MARKER,
+  findExistingCodexReviewFallbackComment,
+  formatCodexReviewFallbackComment,
+  parseCodexReviewFallbackComment
+} from "./codex-review-fallback.js";
+export {
+  GeminiReviewFailureKind,
+  classifyGeminiReviewFailure
+} from "./gemini-review-failure.js";
 export { runMvpGateway } from "./mvp-gateway.js";
 export {
   resolveGatewayAliasRegistryFromGitHubApp,

--- a/test/butler-review-synthesis.test.js
+++ b/test/butler-review-synthesis.test.js
@@ -78,3 +78,35 @@ test("butler review synthesis does not present approve-only Gemini review as unr
     false
   );
 });
+
+test("butler review synthesis surfaces Codex fallback review requests plainly", () => {
+  const result = buildButlerReviewSynthesis({
+    pullRequest: {
+      number: 74,
+      url: "https://github.com/example/repo/pull/74",
+      state: "open",
+      title: "Reviewer fallback"
+    },
+    reviewLoop: {
+      reviewer: "codex",
+      reviewerStatus: "codex_review_requested",
+      reviewCommentsCount: 0,
+      unresolvedReviewCommentsCount: 0,
+      criticalReviewPending: true
+    },
+    codexGoal: "wait_for_review",
+    nextSuggestedActions: ["wait_for_codex_review", "summarize_for_human"]
+  });
+
+  assert.equal(
+    result.headline,
+    "PR #74 is open. Gemini is temporarily unavailable and Codex fallback review has been requested."
+  );
+  assert.equal(result.reviewerSignal.reviewerStatus, "codex_review_requested");
+  assert.equal(
+    result.humanDecisionFocus.includes(
+      "Gemini is temporarily unavailable; Codex fallback review has been requested and should arrive before human GO."
+    ),
+    true
+  );
+});

--- a/test/codex-review-fallback.test.js
+++ b/test/codex-review-fallback.test.js
@@ -1,0 +1,44 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  CODEX_REVIEW_FALLBACK_MARKER,
+  findExistingCodexReviewFallbackComment,
+  formatCodexReviewFallbackComment,
+  parseCodexReviewFallbackComment
+} from "../src/core/index.js";
+
+test("formatCodexReviewFallbackComment renders marker and @codex request", () => {
+  const body = formatCodexReviewFallbackComment({
+    trigger: "pull_request_target:synchronize",
+    reason: "gemini_quota_or_rate_limit"
+  });
+
+  assert.equal(body.includes(CODEX_REVIEW_FALLBACK_MARKER), true);
+  assert.equal(body.includes("@codex review"), true);
+  assert.equal(body.includes("gemini_quota_or_rate_limit"), true);
+});
+
+test("findExistingCodexReviewFallbackComment locates prior fallback request", () => {
+  const comment = findExistingCodexReviewFallbackComment([
+    { id: 1, body: "ordinary comment" },
+    { id: 2, body: `${CODEX_REVIEW_FALLBACK_MARKER}\n@codex review` }
+  ]);
+
+  assert.deepEqual(comment, {
+    id: 2,
+    body: `${CODEX_REVIEW_FALLBACK_MARKER}\n@codex review`
+  });
+});
+
+test("parseCodexReviewFallbackComment exposes requested fallback reviewer state", () => {
+  const parsed = parseCodexReviewFallbackComment(`${CODEX_REVIEW_FALLBACK_MARKER}
+@codex review`);
+
+  assert.deepEqual(parsed, {
+    reviewer: "codex",
+    status: "requested",
+    blocking: false,
+    body: `${CODEX_REVIEW_FALLBACK_MARKER}
+@codex review`
+  });
+});

--- a/test/execution-continuity.test.js
+++ b/test/execution-continuity.test.js
@@ -112,3 +112,34 @@ test("execution continuity treats approve-only Gemini reviewer comment as non-bl
   );
   assert.deepEqual(result.value.nextSuggestedActions, ["summarize_for_human", "wait_for_human_go"]);
 });
+
+test("execution continuity exposes Codex fallback requested when Gemini quota blocks review", () => {
+  const result = evaluateExecutionContinuity({
+    actorRole: ActorRole.BUTLER,
+    mode: TaskMode.EXECUTION,
+    runtimeTruth: {
+      runtimeState: {
+        activeBranch: "codex/issue-74",
+        pullRequest: {
+          number: 74,
+          url: "https://github.com/example/repo/pull/74",
+          state: "open",
+          title: "Reviewer fallback",
+          issueComments: [
+            {
+              user: { login: "vtdd-codex[bot]" },
+              body: "<!-- vtdd:reviewer=codex-fallback -->\n@codex review"
+            }
+          ]
+        }
+      }
+    }
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.value.reviewLoop.reviewer, "codex");
+  assert.equal(result.value.reviewLoop.reviewerStatus, "codex_review_requested");
+  assert.equal(result.value.reviewLoop.criticalReviewPending, true);
+  assert.equal(result.value.codexGoal, CodexGoal.WAIT_FOR_REVIEW);
+  assert.deepEqual(result.value.nextSuggestedActions, ["wait_for_codex_review", "summarize_for_human"]);
+});

--- a/test/gemini-pr-review-workflow.test.js
+++ b/test/gemini-pr-review-workflow.test.js
@@ -19,3 +19,9 @@ test("Gemini review workflow mints a GitHub App token and passes it to reviewer 
   assert.equal(workflow.includes("GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}"), true);
   assert.equal(workflow.includes("run: node scripts/run-gemini-pr-review.mjs"), true);
 });
+
+test("Gemini review workflow still routes reviewer execution through the script entrypoint", () => {
+  assert.equal(workflow.includes("name: Run Gemini PR review"), true);
+  assert.equal(workflow.includes("GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}"), true);
+  assert.equal(workflow.includes("GEMINI_REVIEW_MODEL: ${{ vars.GEMINI_REVIEW_MODEL }}"), true);
+});

--- a/test/gemini-review-failure.test.js
+++ b/test/gemini-review-failure.test.js
@@ -1,0 +1,23 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { GeminiReviewFailureKind, classifyGeminiReviewFailure } from "../src/core/index.js";
+
+test("classifyGeminiReviewFailure treats quota exhaustion as retryable reviewer unavailability", () => {
+  const result = classifyGeminiReviewFailure({
+    status: 429,
+    providerStatus: "RESOURCE_EXHAUSTED",
+    message: "Quota exceeded for metric"
+  });
+
+  assert.deepEqual(result, { kind: GeminiReviewFailureKind.QUOTA_OR_RATE_LIMIT });
+});
+
+test("classifyGeminiReviewFailure keeps unexpected failures as hard errors", () => {
+  const result = classifyGeminiReviewFailure({
+    status: 500,
+    providerStatus: "INTERNAL",
+    message: "upstream error"
+  });
+
+  assert.deepEqual(result, { kind: GeminiReviewFailureKind.OTHER });
+});

--- a/test/open-issue-current-reality-audit.test.js
+++ b/test/open-issue-current-reality-audit.test.js
@@ -25,6 +25,7 @@ test("open issue current-reality audit distinguishes mapped and historical open 
   assert.equal(doc.includes("`#55`"), true);
   assert.equal(doc.includes("`#57`"), true);
   assert.equal(doc.includes("`#70`"), true);
+  assert.equal(doc.includes("`#74`"), true);
   assert.equal(doc.includes("`#9` and `#12`"), true);
   assert.equal(doc.includes("`#6`"), true);
   assert.equal(doc.includes("Still Missing Direct Matrix Mapping"), false);


### PR DESCRIPTION
## This PR satisfies Intent

- Keep the reviewer loop critique-only when Gemini free-tier quota is exhausted by gracefully requesting Codex GitHub review fallback instead of hard-failing the PR.

## Satisfied Success Criteria

- Gemini remains primary when available.
- Gemini quota/rate-limit exhaustion no longer hard-fails reviewer execution.
- VTDD can upsert a Codex fallback review request comment on the PR.
- Butler runtime truth can distinguish Gemini review available, Codex review requested, and review unavailable states.

## Unsatisfied Success Criteria

- Direct mapped E2E evidence for #74 is not added in this PR.
- Repo-side automation still cannot prove that Codex GitHub integration actually posted critique comments.

## Non-goal violations

- No merge/deploy/passkey boundary changes.
- No executor self-review authority.
- No replacement of Gemini as canonical primary reviewer.

## Verification Evidence

- Unit: node --test test/codex-review-fallback.test.js test/gemini-review-failure.test.js test/gemini-pr-review.test.js test/gemini-pr-review-workflow.test.js test/execution-continuity.test.js test/butler-review-synthesis.test.js test/reviewer-registry.test.js test/open-issue-current-reality-audit.test.js
- Integration: node --test test/custom-gpt-setup-docs.test.js test/worker.test.js
- E2E: None yet (partial progress for #74).
- Manual: Not run.
- Evidence path/link: docs/security/reviewer-policy.md

## Related Constitution Rules

- Reviewer role remains critique-only.
- Reviewer does not receive execution credentials.
- Butler must not erase reviewer availability state.

## Out-of-scope but NOT implemented

- Actual Codex critique delivery still depends on operator-owned Codex GitHub integration.
- Historical issue #6 remains untouched.

## Extra changes (if any)

Updated open-issue current-reality audit so #74 is tracked as active partial runtime progress.

<!-- VTDD metadata -->
- Issue: #74
- Execution ID: Not provided.
- Goal: Not provided.
