### PR TITLE
Handle transient Gemini reviewer unavailability

### DIFF
--- a/docs/butler/gemini-pr-review-comments.md
+++ b/docs/butler/gemini-pr-review-comments.md
@@ -27,10 +27,11 @@ Gemini review must run when:
 - a PR becomes ready for review
 - new PR comments or review comments arrive
 
-If Gemini is temporarily unavailable because of quota or rate-limit
-exhaustion, VTDD may upsert a GitHub-visible Codex fallback review request
-comment (`@codex review`) instead of hard-failing the PR solely for reviewer
-quota reasons.
+If Gemini is temporarily unavailable because of quota exhaustion, rate
+limiting, or transient provider high demand / temporary unavailability, VTDD
+may upsert a GitHub-visible Codex fallback review request comment (`@codex
+review`) instead of hard-failing the PR solely for reviewer availability
+reasons.
 
 The workflow must ignore its own marker comment so that reviewer reruns do not
 create an infinite comment loop.

--- a/docs/security/reviewer-policy.md
+++ b/docs/security/reviewer-policy.md
@@ -23,7 +23,8 @@ The reviewer is a critical evaluation role.
 ## Fallback Position
 
 - Codex GitHub review may be requested as an emergency fallback when Gemini is
-  temporarily unavailable because of quota or rate-limit exhaustion.
+  temporarily unavailable because of quota, rate-limit exhaustion, or transient
+  provider high demand / temporary unavailability.
 - This fallback remains critique-only and depends on the operator's Codex
   GitHub integration, not on repository-owned execution credentials.
 - Antigravity is not the normal reviewer path.

--- a/scripts/run-gemini-pr-review.mjs
+++ b/scripts/run-gemini-pr-review.mjs
@@ -72,10 +72,10 @@ async function main() {
     });
   } catch (error) {
     const failure = classifyGeminiReviewFailure(error instanceof Error ? error : {});
-    if (failure.kind === GeminiReviewFailureKind.QUOTA_OR_RATE_LIMIT) {
+    if (failure.kind === GeminiReviewFailureKind.TEMPORARY_UNAVAILABLE) {
       const fallbackBody = formatCodexReviewFallbackComment({
         trigger: triggerResult.value.trigger,
-        reason: "gemini_quota_or_rate_limit"
+        reason: "gemini_temporarily_unavailable"
       });
       if (existingFallbackComment) {
         await githubFetch(`/repos/${repository}/issues/comments/${existingFallbackComment.id}`, {

--- a/src/core/codex-review-fallback.js
+++ b/src/core/codex-review-fallback.js
@@ -2,7 +2,7 @@ export const CODEX_REVIEW_FALLBACK_MARKER = "<!-- vtdd:reviewer=codex-fallback -
 
 export function formatCodexReviewFallbackComment(input = {}) {
   const trigger = normalizeText(input.trigger) || "unknown";
-  const reason = normalizeText(input.reason) || "gemini_quota_or_rate_limit";
+  const reason = normalizeText(input.reason) || "gemini_temporarily_unavailable";
 
   return [
     CODEX_REVIEW_FALLBACK_MARKER,

--- a/src/core/gemini-review-failure.js
+++ b/src/core/gemini-review-failure.js
@@ -1,5 +1,5 @@
 export const GeminiReviewFailureKind = Object.freeze({
-  QUOTA_OR_RATE_LIMIT: "quota_or_rate_limit",
+  TEMPORARY_UNAVAILABLE: "temporary_unavailable",
   OTHER: "other"
 });
 
@@ -11,9 +11,11 @@ export function classifyGeminiReviewFailure(input = {}) {
   if (
     status === 429 ||
     providerStatus === "resource_exhausted" ||
-    /quota exceeded|rate limit|resource_exhausted|too many requests/i.test(message)
+    /quota exceeded|rate limit|resource_exhausted|too many requests|currently experiencing high demand|try again later|temporarily unavailable/i.test(
+      message
+    )
   ) {
-    return { kind: GeminiReviewFailureKind.QUOTA_OR_RATE_LIMIT };
+    return { kind: GeminiReviewFailureKind.TEMPORARY_UNAVAILABLE };
   }
 
   return { kind: GeminiReviewFailureKind.OTHER };

--- a/test/codex-review-fallback.test.js
+++ b/test/codex-review-fallback.test.js
@@ -10,12 +10,12 @@ import {
 test("formatCodexReviewFallbackComment renders marker and @codex request", () => {
   const body = formatCodexReviewFallbackComment({
     trigger: "pull_request_target:synchronize",
-    reason: "gemini_quota_or_rate_limit"
+    reason: "gemini_temporarily_unavailable"
   });
 
   assert.equal(body.includes(CODEX_REVIEW_FALLBACK_MARKER), true);
   assert.equal(body.includes("@codex review"), true);
-  assert.equal(body.includes("gemini_quota_or_rate_limit"), true);
+  assert.equal(body.includes("gemini_temporarily_unavailable"), true);
 });
 
 test("findExistingCodexReviewFallbackComment locates prior fallback request", () => {

--- a/test/execution-continuity.test.js
+++ b/test/execution-continuity.test.js
@@ -113,7 +113,7 @@ test("execution continuity treats approve-only Gemini reviewer comment as non-bl
   assert.deepEqual(result.value.nextSuggestedActions, ["summarize_for_human", "wait_for_human_go"]);
 });
 
-test("execution continuity exposes Codex fallback requested when Gemini quota blocks review", () => {
+test("execution continuity exposes Codex fallback requested when Gemini is temporarily unavailable", () => {
   const result = evaluateExecutionContinuity({
     actorRole: ActorRole.BUTLER,
     mode: TaskMode.EXECUTION,

--- a/test/gemini-review-failure.test.js
+++ b/test/gemini-review-failure.test.js
@@ -9,7 +9,17 @@ test("classifyGeminiReviewFailure treats quota exhaustion as retryable reviewer 
     message: "Quota exceeded for metric"
   });
 
-  assert.deepEqual(result, { kind: GeminiReviewFailureKind.QUOTA_OR_RATE_LIMIT });
+  assert.deepEqual(result, { kind: GeminiReviewFailureKind.TEMPORARY_UNAVAILABLE });
+});
+
+test("classifyGeminiReviewFailure treats high-demand unavailability as retryable reviewer unavailability", () => {
+  const result = classifyGeminiReviewFailure({
+    status: 503,
+    providerStatus: "UNAVAILABLE",
+    message: "This model is currently experiencing high demand. Please try again later."
+  });
+
+  assert.deepEqual(result, { kind: GeminiReviewFailureKind.TEMPORARY_UNAVAILABLE });
 });
 
 test("classifyGeminiReviewFailure keeps unexpected failures as hard errors", () => {


### PR DESCRIPTION
## This PR satisfies Intent

- Extend the reviewer fallback slice so transient Gemini high-demand / temporary-unavailable failures also degrade safely to a Codex review request instead of hard-failing the PR.

## Satisfied Success Criteria

- Gemini reviewer failure classification now covers quota, rate-limit, and temporary unavailability/high-demand messages.
- Reviewer workflow degrades to Codex fallback request for those temporary availability failures.
- Reviewer docs now describe temporary unavailability fallback, not only quota exhaustion.

## Unsatisfied Success Criteria

- External live proof that Codex GitHub integration posted a critique comment is still not claimed from repo evidence alone.
- Direct mapped E2E for #74 still lives on the separate docs/test PR path.

## Non-goal violations

- No merge/deploy/passkey boundary changes.
- No executor authority changes.
- No closure judgment for #4 or #6.

## Verification Evidence

- Unit: node --test test/gemini-review-failure.test.js test/codex-review-fallback.test.js test/execution-continuity.test.js test/butler-review-synthesis.test.js test/gemini-pr-review-workflow.test.js
- Integration: None.
- E2E: None in this PR (runtime follow-up for #74).
- Manual: Inspected failing Actions log for PR #76 and matched the provider message to temporary high demand.
- Evidence path/link: docs/security/reviewer-policy.md

## Related Constitution Rules

- Reviewer role remains critique-only.
- Review absence must be surfaced explicitly rather than hidden.
- Fallback must not grant execution credentials.

## Out-of-scope but NOT implemented

- Historical issue #6 remains untouched.
- Parent issue #4 remains open as loop authority.

## Extra changes (if any)

This PR is a narrow runtime follow-up to make the new reviewer fallback handle the real high-demand failure mode seen in GitHub Actions.

<!-- VTDD metadata -->
- Issue: #74
- Execution ID: Not provided.
- Goal: Not provided.
