### PR TITLE
Fix Worker deploy bundle for desktop vault

### DIFF
--- a/scripts/sync-cloudflare-actions-secrets.mjs
+++ b/scripts/sync-cloudflare-actions-secrets.mjs
@@ -1,7 +1,8 @@
 import fs from "node:fs/promises";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
-import { executeCloudflareDeploySecretSync, loadDesktopBootstrapVault } from "../src/core/index.js";
+import { executeCloudflareDeploySecretSync } from "../src/core/index.js";
+import { loadDesktopBootstrapVault } from "../src/core/desktop-bootstrap-vault.js";
 
 const execFileAsync = promisify(execFile);
 

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -9,12 +9,6 @@ export {
 } from "./types.js";
 export { evaluateAutonomyModeBoundary, normalizeAutonomyMode } from "./autonomy-mode.js";
 export {
-  DEFAULT_VTDD_CREDENTIALS_DIR,
-  DEFAULT_VTDD_HOME_PATH,
-  DEFAULT_VTDD_VAULT_MANIFEST_PATH,
-  loadDesktopBootstrapVault
-} from "./desktop-bootstrap-vault.js";
-export {
   DeployAuthorityPath,
   DeployAuthorityPreference,
   ProtectionSignalStatus,


### PR DESCRIPTION
## This PR satisfies Intent
Fix the Cloudflare Worker deploy bundle so the steady-state worker no longer pulls in desktop-only Node modules from the bootstrap vault path.

## Satisfied Success Criteria
- Worker bundle no longer imports desktop-only node:* modules through src/core/index.js.
- Desktop bootstrap vault remains available to local helper/update scripts.
- wrangler production dry-run succeeds without the node:fs/promises module error.

## Unsatisfied Success Criteria
- Production deploy has not been executed from this PR itself.
- iPhone Butler post-deploy verification is still pending.

## Verification Evidence
- `node --test test/desktop-bootstrap-vault.test.js test/passkey-operator-helper.test.js test/worker.test.js`
- `npx wrangler deploy --config wrangler.production.local.toml --env production --dry-run`
