### PR TITLE
Improve Butler self-parity trigger language

### DIFF
--- a/docs/setup/custom-gpt-instructions.md
+++ b/docs/setup/custom-gpt-instructions.md
@@ -35,6 +35,10 @@ Role separation:
 - Reviewer: returns critical review comments on the PR.
 - Human: final authority for revision GO and merge GO + real passkey.
 
+Self-reference default:
+- In this Custom GPT, when the user says `君`, `自分`, `Butler`, `VTDD`, or `このGPT` without clearly naming another target, interpret it as this VTDD Butler surface itself.
+- Do not force the user to restate that they are talking about Butler when the surrounding context is already about this Custom GPT.
+
 Repository listing and context resolution:
 - If the user asks for repository candidates or says things like "GitHub リポジトリ一覧を出して", call vtddGateway in exploration mode.
 - Use:
@@ -79,6 +83,16 @@ GitHub runtime truth read plane:
 
 Butler self-parity and setup artifact recovery:
 - When the user asks whether Butler itself is stale, outdated, or misaligned with the repository/runtime, use vtddRetrieveSelfParity.
+- Treat natural self-reference and update-check language as a self-parity request by default when no different target is clearly named.
+- Examples include:
+  - `君自身のアップデートある？`
+  - `古くなってない？`
+  - `最新？`
+  - `反映されてる？`
+  - `Action Schema ズレてない？`
+  - `Instructions ズレてない？`
+  - `Worker 反映されてる？`
+- For those requests, prefer vtddRetrieveSelfParity over general model-capability disclaimers.
 - Before the first significant GitHub/runtime action in a session, you may proactively run vtddRetrieveSelfParity when the user is clearly starting VTDD work.
 - Significant VTDD work includes at minimum:
   - repository/Issue/PR exploration intended to lead into active work

--- a/test/custom-gpt-setup-docs.test.js
+++ b/test/custom-gpt-setup-docs.test.js
@@ -38,6 +38,10 @@ test("custom gpt instructions preserve current butler and approval boundaries", 
   assert.equal(doc.includes("vtddRetrieveGitHub"), true);
   assert.equal(doc.includes("vtddRetrieveSetupArtifact"), true);
   assert.equal(doc.includes("vtddRetrieveSelfParity"), true);
+  assert.equal(doc.includes("when the user says `君`, `自分`, `Butler`, `VTDD`, or `このGPT`"), true);
+  assert.equal(doc.includes("`君自身のアップデートある？`"), true);
+  assert.equal(doc.includes("`古くなってない？`"), true);
+  assert.equal(doc.includes("prefer vtddRetrieveSelfParity over general model-capability disclaimers"), true);
   assert.equal(doc.includes("Before the first significant GitHub/runtime action in a session"), true);
   assert.equal(doc.includes("Cloudflare deploy update required"), true);
   assert.equal(doc.includes("High-risk actions require GO + passkey."), true);


### PR DESCRIPTION
## This PR satisfies Intent
Improve Butler self-reference handling so natural update-check language maps to VTDD self-parity instead of generic model disclaimers.

## Satisfied Success Criteria
- Canonical Butler Instructions define `君`/`自分`/`Butler`/`VTDD`/`このGPT` as default self-reference for this Custom GPT surface.
- Natural update-check phrases such as `君自身のアップデートある？` and `古くなってない？` are explicitly mapped to `vtddRetrieveSelfParity`.
- Setup-doc tests pin the new self-reference and natural trigger language.

## Unsatisfied Success Criteria
- iPhone Butler runtime behavior after instruction refresh is not yet re-verified.
- Deploy-trigger execution from stale parity is not part of this PR.

## Verification Evidence
- `node --test test/custom-gpt-setup-docs.test.js`
