### PR TITLE
Add governed deploy plane for Butler parity recovery

### DIFF
--- a/docs/setup/custom-gpt-actions-openapi.json
+++ b/docs/setup/custom-gpt-actions-openapi.json
@@ -913,6 +913,84 @@
         }
       }
     },
+    "/v2/action/deploy": {
+      "post": {
+        "operationId": "vtddDeployProduction",
+        "summary": "Dispatch governed production deploy after GO plus real passkey approval.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "repository": {
+                    "type": "string"
+                  },
+                  "runtimeUrl": {
+                    "type": "string"
+                  },
+                  "phase": {
+                    "type": "string"
+                  },
+                  "policyInput": {
+                    "type": "object",
+                    "properties": {
+                      "approvalPhrase": {
+                        "type": "string"
+                      },
+                      "approvalGrantId": {
+                        "type": "string"
+                      }
+                    },
+                    "additionalProperties": true
+                  }
+                },
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "responses": {
+          "202": {
+            "description": "Production deploy dispatched",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VtddGenericResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing machine auth"
+          },
+          "403": {
+            "description": "Invalid machine auth"
+          },
+          "422": {
+            "description": "Deploy request blocked or invalid",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VtddGenericResponse"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Deploy dispatch failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VtddGenericResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v2/retrieve/setup-artifact": {
       "get": {
         "operationId": "vtddRetrieveSetupArtifact",

--- a/docs/setup/custom-gpt-actions-openapi.yaml
+++ b/docs/setup/custom-gpt-actions-openapi.yaml
@@ -449,6 +449,55 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/VtddGenericResponse"
+  /v2/action/deploy:
+    post:
+      operationId: vtddDeployProduction
+      summary: Dispatch governed production deploy after GO plus real passkey approval.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                repository:
+                  type: string
+                runtimeUrl:
+                  type: string
+                phase:
+                  type: string
+                policyInput:
+                  type: object
+                  properties:
+                    approvalPhrase:
+                      type: string
+                    approvalGrantId:
+                      type: string
+                  additionalProperties: true
+              additionalProperties: true
+      responses:
+        "202":
+          description: Production deploy dispatched
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VtddGenericResponse"
+        "401":
+          description: Missing machine auth
+        "403":
+          description: Invalid machine auth
+        "422":
+          description: Deploy request blocked or invalid
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VtddGenericResponse"
+        "503":
+          description: Deploy dispatch failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VtddGenericResponse"
   /v2/action/progress:
     get:
       operationId: vtddExecutionProgress

--- a/docs/setup/custom-gpt-instructions.md
+++ b/docs/setup/custom-gpt-instructions.md
@@ -187,6 +187,15 @@ GitHub high-risk authority plane:
   - include the merged PR number used to prove bounded post-merge scope
 - Do not route deploy, secret mutation, permission mutation, or other destructive provider actions through vtddGitHubAuthority.
 
+Deploy plane:
+- Use vtddDeployProduction for governed production deploy execution after Butler determines that runtime deploy parity is stale and the human explicitly requests deploy.
+- vtddDeployProduction requires:
+  - resolved repository
+  - explicit `GO`
+  - real passkey approval grant scoped to `deploy_production`
+- When self-parity indicates `Cloudflare deploy update required`, you may suggest deploy as the next safe high-risk action.
+- After vtddDeployProduction, tell the user deploy was dispatched and then re-check self-parity before claiming runtime is updated.
+
 Progress tracking:
 - After vtddExecute, always call vtddExecutionProgress.
 - Use executionId, repository, issueNumber, and branch.

--- a/src/core/deploy-production-plane.js
+++ b/src/core/deploy-production-plane.js
@@ -1,0 +1,160 @@
+import { resolveGitHubAppInstallationToken } from "./github-app-repository-index.js";
+import { validateDeployApprovalGrant } from "./deploy-approval-grant.js";
+
+const GITHUB_API_VERSION = "2022-11-28";
+const GITHUB_API_USER_AGENT = "vtdd-v2-deploy-production-plane";
+const DEFAULT_DEPLOY_WORKFLOW_FILE = "deploy-production.yml";
+const DEFAULT_DEPLOY_WORKFLOW_REF = "main";
+
+export async function executeDeployProductionPlane(input = {}) {
+  const repository = normalizeText(input.repository);
+  const runtimeUrl = normalizeText(input.runtimeUrl);
+  const approvalPhrase = normalizeText(input.approvalPhrase);
+  const approvalGrant = input.approvalGrant ?? null;
+  const approvalGrantId =
+    normalizeText(input.approvalGrantId) || normalizeText(approvalGrant?.approvalId);
+  const env = input.env ?? {};
+  const fetchImpl = typeof env?.GITHUB_API_FETCH === "function" ? env.GITHUB_API_FETCH.bind(env) : fetch;
+  const apiBaseUrl = normalizeApiBaseUrl(env?.GITHUB_API_BASE_URL);
+
+  const validation = validateDeployProductionRequest({
+    repository,
+    runtimeUrl,
+    approvalPhrase,
+    approvalGrant,
+    approvalGrantId
+  });
+  if (!validation.ok) {
+    return {
+      ok: false,
+      status: 422,
+      error: "deploy_request_invalid",
+      reason: validation.issues.join(", "),
+      issues: validation.issues
+    };
+  }
+
+  const tokenResolution = await resolveGitHubAppInstallationToken({ env, fetchImpl, apiBaseUrl });
+  if (!tokenResolution.ok) {
+    return {
+      ok: false,
+      status: 503,
+      error: "deploy_unavailable",
+      reason: tokenResolution.warning || "GitHub App installation token is unavailable for deploy dispatch"
+    };
+  }
+
+  const workflowRepository =
+    normalizeText(env?.DEPLOY_WORKFLOW_REPOSITORY) ||
+    normalizeText(env?.VTDD_GITHUB_ACTIONS_REPOSITORY) ||
+    repository;
+  const workflowFile = normalizeText(env?.DEPLOY_WORKFLOW_FILE) || DEFAULT_DEPLOY_WORKFLOW_FILE;
+  const workflowRef = normalizeText(env?.DEPLOY_WORKFLOW_REF) || DEFAULT_DEPLOY_WORKFLOW_REF;
+
+  const dispatchUrl = `${apiBaseUrl}/repos/${encodeURIComponentRepository(
+    workflowRepository
+  )}/actions/workflows/${encodeURIComponent(workflowFile)}/dispatches`;
+  const dispatchBody = {
+    ref: workflowRef,
+    inputs: {
+      approval_phrase: "GO",
+      runtime_url: runtimeUrl,
+      approval_grant_id: approvalGrantId
+    }
+  };
+
+  let response;
+  try {
+    response = await fetchImpl(dispatchUrl, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${tokenResolution.token}`,
+        accept: "application/vnd.github+json",
+        "content-type": "application/json; charset=utf-8",
+        "x-github-api-version": GITHUB_API_VERSION,
+        "user-agent": GITHUB_API_USER_AGENT
+      },
+      body: JSON.stringify(dispatchBody)
+    });
+  } catch {
+    return {
+      ok: false,
+      status: 503,
+      error: "deploy_dispatch_failed",
+      reason: "failed to dispatch deploy workflow"
+    };
+  }
+
+  if (!response.ok) {
+    const body = await readJsonSafe(response);
+    return {
+      ok: false,
+      status: response.status,
+      error: "deploy_dispatch_failed",
+      reason: normalizeText(body?.message) || "GitHub deploy workflow dispatch failed"
+    };
+  }
+
+  return {
+    ok: true,
+    deploy: {
+      repository,
+      workflowRepository,
+      workflowFile,
+      workflowRef,
+      approvalGrantId,
+      runtimeUrl,
+      status: "dispatched"
+    }
+  };
+}
+
+function validateDeployProductionRequest({
+  repository,
+  runtimeUrl,
+  approvalPhrase,
+  approvalGrant,
+  approvalGrantId
+}) {
+  const issues = [];
+  if (!repository) {
+    issues.push("repository is required");
+  }
+  if (!runtimeUrl) {
+    issues.push("runtimeUrl is required");
+  }
+  if (approvalPhrase !== "GO") {
+    issues.push("approvalPhrase must be GO");
+  }
+  if (!approvalGrantId) {
+    issues.push("approvalGrantId is required");
+  }
+
+  const approvalValidation = validateDeployApprovalGrant({
+    approvalGrant,
+    repositoryInput: repository
+  });
+  if (!approvalValidation.ok) {
+    issues.push(...approvalValidation.issues);
+  }
+
+  return issues.length > 0 ? { ok: false, issues } : { ok: true };
+}
+
+function encodeURIComponentRepository(repository) {
+  const [owner = "", name = ""] = normalizeText(repository).split("/");
+  return `${encodeURIComponent(owner)}/${encodeURIComponent(name)}`;
+}
+
+async function readJsonSafe(response) {
+  return response.json().catch(() => ({}));
+}
+
+function normalizeApiBaseUrl(value) {
+  const normalized = normalizeText(value);
+  return normalized || "https://api.github.com";
+}
+
+function normalizeText(value) {
+  return String(value ?? "").trim();
+}

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -169,6 +169,7 @@ export {
   classifyGeminiReviewFailure
 } from "./gemini-review-failure.js";
 export { runMvpGateway } from "./mvp-gateway.js";
+export { executeDeployProductionPlane } from "./deploy-production-plane.js";
 export {
   resolveGatewayAliasRegistryFromGitHubApp,
   resolveGitHubAppInstallationToken

--- a/src/worker.js
+++ b/src/worker.js
@@ -10,6 +10,7 @@ import {
   createRemoteCodexExecutionRequest,
   dedupePasskeys,
   dispatchRemoteCodexExecution,
+  executeDeployProductionPlane,
   evaluateButlerSelfParity,
   executeGitHubHighRiskPlane,
   inferRelatedIssueFromGatewayInput,
@@ -172,6 +173,19 @@ export default {
       }
 
       return handleGitHubHighRiskPlaneRequest(request, env);
+    }
+
+    if (request.method === "POST" && isApiPath(url.pathname, "/action/deploy")) {
+      const auth = authorizeGatewayRequest({ request, env, apiSuffix: "/action/deploy" });
+      if (!auth.ok) {
+        return json(auth.status, {
+          ok: false,
+          error: "unauthorized",
+          reason: auth.reason
+        });
+      }
+
+      return handleDeployProductionRequest(request, env);
     }
 
     if (request.method === "GET" && isApiPath(url.pathname, "/action/progress")) {
@@ -757,6 +771,57 @@ async function handleGitHubHighRiskPlaneRequest(request, env) {
   return json(200, {
     ok: true,
     authorityAction: executed.authorityAction
+  });
+}
+
+async function handleDeployProductionRequest(request, env) {
+  const payload = await readJson(request);
+  if (!payload || typeof payload !== "object") {
+    return json(422, {
+      ok: false,
+      error: "request_body_required",
+      reason: "valid JSON request body is required"
+    });
+  }
+
+  const policyInput =
+    payload.policyInput && typeof payload.policyInput === "object" ? payload.policyInput : {};
+  const resolvedApprovalGrant = await resolveApprovalGrant({
+    payload: {
+      phase: normalizeText(payload.phase) || "execution",
+      highRiskKind: "deploy_production",
+      repositoryInput: payload.repository
+    },
+    policyInput: {
+      ...policyInput,
+      actionType: "deploy_production",
+      repositoryInput: payload.repository,
+      highRiskKind: "deploy_production"
+    },
+    env
+  });
+
+  const executed = await executeDeployProductionPlane({
+    repository: payload.repository,
+    runtimeUrl: payload.runtimeUrl || new URL(request.url).origin,
+    approvalPhrase: policyInput.approvalPhrase,
+    approvalGrantId: policyInput.approvalGrantId,
+    approvalGrant: payload.approvalGrant ?? policyInput.approvalGrant ?? resolvedApprovalGrant.approvalGrant,
+    env
+  });
+
+  if (!executed.ok) {
+    return json(executed.status ?? 503, {
+      ok: false,
+      error: executed.error ?? "deploy_failed",
+      reason: executed.reason,
+      issues: executed.issues ?? []
+    });
+  }
+
+  return json(202, {
+    ok: true,
+    deploy: executed.deploy
   });
 }
 

--- a/test/custom-gpt-setup-docs.test.js
+++ b/test/custom-gpt-setup-docs.test.js
@@ -34,6 +34,7 @@ test("custom gpt instructions preserve current butler and approval boundaries", 
   assert.equal(doc.includes("vtddExecute"), true);
   assert.equal(doc.includes("vtddWriteGitHub"), true);
   assert.equal(doc.includes("vtddGitHubAuthority"), true);
+  assert.equal(doc.includes("vtddDeployProduction"), true);
   assert.equal(doc.includes("vtddExecutionProgress"), true);
   assert.equal(doc.includes("vtddRetrieveGitHub"), true);
   assert.equal(doc.includes("vtddRetrieveSetupArtifact"), true);
@@ -63,6 +64,7 @@ test("custom gpt openapi doc exposes current gateway, execute, and progress rout
   assert.equal(doc.includes("/v2/action/execute:"), true);
   assert.equal(doc.includes("/v2/action/github:"), true);
   assert.equal(doc.includes("/v2/action/github-authority:"), true);
+  assert.equal(doc.includes("/v2/action/deploy:"), true);
   assert.equal(doc.includes("/v2/action/progress:"), true);
   assert.equal(doc.includes("/v2/retrieve/github:"), true);
   assert.equal(doc.includes("/v2/retrieve/setup-artifact:"), true);
@@ -100,6 +102,7 @@ test("custom gpt openapi json parses and exposes paths as an object", () => {
   assert.equal(typeof doc.paths["/v2/action/execute"], "object");
   assert.equal(typeof doc.paths["/v2/action/github"], "object");
   assert.equal(typeof doc.paths["/v2/action/github-authority"], "object");
+  assert.equal(typeof doc.paths["/v2/action/deploy"], "object");
   assert.equal(typeof doc.paths["/v2/action/progress"], "object");
   assert.equal(typeof doc.paths["/v2/retrieve/github"], "object");
   assert.equal(typeof doc.paths["/v2/retrieve/setup-artifact"], "object");

--- a/test/deploy-production-plane.test.js
+++ b/test/deploy-production-plane.test.js
@@ -1,0 +1,55 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { executeDeployProductionPlane } from "../src/core/index.js";
+
+test("deploy production plane dispatches governed workflow with GO + passkey inputs", async () => {
+  const calls = [];
+  const result = await executeDeployProductionPlane({
+    repository: "sample-org/vtdd-v2-p",
+    runtimeUrl: "https://sample-user-vtdd.example.workers.dev",
+    approvalPhrase: "GO",
+    approvalGrantId: "approval-deploy-123",
+    approvalGrant: {
+      approvalId: "approval-deploy-123",
+      verified: true,
+      expiresAt: "2099-01-01T00:00:00.000Z",
+      scope: {
+        actionType: "deploy_production",
+        highRiskKind: "deploy_production",
+        repositoryInput: "sample-org/vtdd-v2-p"
+      }
+    },
+    env: {
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_deploy",
+      GITHUB_API_FETCH: async (url, init) => {
+        calls.push({ url: String(url), init });
+        return new Response(null, { status: 204 });
+      }
+    }
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.deploy.status, "dispatched");
+  assert.equal(calls[0].url.includes("/actions/workflows/deploy-production.yml/dispatches"), true);
+  const body = JSON.parse(calls[0].init.body);
+  assert.equal(body.inputs.approval_phrase, "GO");
+  assert.equal(body.inputs.approval_grant_id, "approval-deploy-123");
+  assert.equal(body.inputs.runtime_url, "https://sample-user-vtdd.example.workers.dev");
+});
+
+test("deploy production plane blocks missing GO + passkey inputs", async () => {
+  const result = await executeDeployProductionPlane({
+    repository: "sample-org/vtdd-v2-p",
+    runtimeUrl: "",
+    approvalPhrase: "NO",
+    approvalGrantId: "",
+    approvalGrant: null,
+    env: {}
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.error, "deploy_request_invalid");
+  assert.equal(result.issues.includes("runtimeUrl is required"), true);
+  assert.equal(result.issues.includes("approvalPhrase must be GO"), true);
+  assert.equal(result.issues.includes("real approvalGrant is required for deploy_production"), true);
+});

--- a/test/passkey-operator-helper.test.js
+++ b/test/passkey-operator-helper.test.js
@@ -3,11 +3,8 @@ import assert from "node:assert/strict";
 import { buildCorsHeaders } from "../scripts/run-passkey-operator-helper.mjs";
 
 test("desktop helper bridge returns CORS headers for worker-hosted sync requests", () => {
-  const headers = buildCorsHeaders("https://vtdd-v2-mvp.polished-tree-da7c.workers.dev");
-  assert.equal(
-    headers["access-control-allow-origin"],
-    "https://vtdd-v2-mvp.polished-tree-da7c.workers.dev"
-  );
+  const headers = buildCorsHeaders("https://sample-user-vtdd.example.workers.dev");
+  assert.equal(headers["access-control-allow-origin"], "https://sample-user-vtdd.example.workers.dev");
   assert.equal(headers["access-control-allow-methods"], "POST, GET, OPTIONS");
   assert.equal(headers["access-control-allow-headers"], "content-type");
 });

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -1208,6 +1208,70 @@ test("worker blocks bounded issue close on the high-risk authority plane when me
   assert.equal(body.reason, "bounded issue close requires a merged pull request");
 });
 
+test("worker dispatches governed production deploy using the request origin as the default runtime url", async () => {
+  const provider = createInMemoryMemoryProvider();
+  const calls = [];
+  await provider.store({
+    id: "approval-deploy-123",
+    type: MemoryRecordType.APPROVAL_LOG,
+    content: {
+      kind: "passkey_grant",
+      status: "verified",
+      approvalId: "approval-deploy-123",
+      expiresAt: "2099-01-01T00:00:00.000Z",
+      scope: {
+        actionType: "deploy_production",
+        highRiskKind: "deploy_production",
+        repositoryInput: "sample-org/vtdd-v2-p",
+        issueNumber: "82",
+        relatedIssue: "82",
+        phase: "execution"
+      }
+    },
+    metadata: { source: "test" },
+    priority: 90,
+    tags: ["passkey_grant"],
+    createdAt: "2026-04-27T00:00:00.000Z"
+  });
+
+  const response = await worker.fetch(
+    new Request("https://sample-user-vtdd.example.workers.dev/v2/action/deploy", {
+      method: "POST",
+      headers: {
+        ...gatewayAuthHeaders,
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({
+        repository: "sample-org/vtdd-v2-p",
+        policyInput: {
+          approvalPhrase: "GO",
+          approvalGrantId: "approval-deploy-123"
+        }
+      })
+    }),
+    {
+      ...gatewayAuthEnv,
+      MEMORY_PROVIDER: provider,
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_deploy",
+      GITHUB_API_FETCH: async (url, init) => {
+        calls.push({ url: String(url), init });
+        return new Response(null, { status: 204 });
+      }
+    }
+  );
+
+  assert.equal(response.status, 202);
+  const body = await response.json();
+  assert.equal(body.ok, true);
+  assert.equal(body.deploy.status, "dispatched");
+  assert.equal(body.deploy.runtimeUrl, "https://sample-user-vtdd.example.workers.dev");
+  const dispatchBody = JSON.parse(calls[0].init.body);
+  assert.equal(
+    dispatchBody.inputs.runtime_url,
+    "https://sample-user-vtdd.example.workers.dev"
+  );
+});
+
 test("worker returns remote Codex execution progress", async () => {
   const response = await worker.fetch(
     new Request("https://example.com/v2/action/progress?executionId=remote-codex-issue6-abcd12", {


### PR DESCRIPTION
## This PR satisfies Intent

- Adds a governed Butler deploy plane for Issue #82 so stale self-parity can lead into a GitHub App-backed production deploy path after explicit `GO` plus real passkey approval.

## Satisfied Success Criteria

- Adds `POST /v2/action/deploy` and `vtddDeployProduction` so Butler has a bounded high-risk deploy surface instead of falling back to manual shell guidance.
- Dispatches `.github/workflows/deploy-production.yml` through the GitHub App using a deploy approval grant scoped to `deploy_production`.
- Defaults `runtimeUrl` to the calling Worker origin, so deploy commands target each user's Worker URL instead of an owner-specific runtime.
- Updates Custom GPT instructions and OpenAPI artifacts so Butler can invoke the deploy plane and re-check self-parity after dispatch.
- Adds unit and worker coverage proving request-origin runtime propagation and governed dispatch behavior.

## Unsatisfied Success Criteria

- Butler still does not automatically turn a natural-language iPhone `GO` into deploy execution end-to-end; this slice exposes the governed deploy plane, but follow-up natural-language orchestration is still needed.

## Non-goal violations

None.

## Verification Evidence

- Unit: `node --test test/deploy-production-plane.test.js test/custom-gpt-setup-docs.test.js test/worker.test.js test/production-deploy-path.test.js test/deploy-authority.test.js test/passkey-operator-helper.test.js`
- Integration: `npx --yes swagger-cli validate docs/setup/custom-gpt-actions-openapi.yaml`
- Integration: `npx --yes swagger-cli validate docs/setup/custom-gpt-actions-openapi.json`
- E2E: None in this slice.
- Manual: None.
- Evidence path/link: `test/deploy-production-plane.test.js`
- Evidence path/link: `test/worker.test.js`
- Evidence path/link: `docs/setup/custom-gpt-actions-openapi.yaml`

## Related Constitution Rules

- High-risk actions require `GO + passkey`.
- Public-facing docs and runtime must not embed the owner's personal Cloudflare runtime URL.
- Treat GitHub App capability as execution ability, not as standing permission.

## Out-of-scope but NOT implemented

- Automatic deploy initiation from natural-language Butler responses on iPhone.
- Reworking the deploy-production workflow itself.
- Action Schema / Instructions editor introspection.

## Extra changes (if any)

- Neutralizes one helper test to use a sample user-owned Worker URL instead of the owner's runtime URL.

<!-- VTDD metadata -->
- Issue: #82
- Execution ID: Not provided.
- Goal: parity-driven governed deploy dispatch.
