### PR TITLE
Implement governed deploy from the passkey operator

### DIFF
--- a/docs/mvp/close-readiness-audit.md
+++ b/docs/mvp/close-readiness-audit.md
@@ -14,13 +14,13 @@ For the broader open-issue vs current-reality mismatch inventory, also read:
 ## Current Human-judgment / Parent / Historical Issues
 
 - `#80` self-parity natural-language trigger improvement
+- `#82` governed stale-parity production deploy
 - `#4` current loop parent
 - `#6` historical execution-slice issue
 
 The following open issues are intentionally not treated as close-readiness-only
 items here because they still represent active implementation/spec work:
 
-- `#82`
 - `#84`
 
 ## Current Reading
@@ -64,6 +64,25 @@ Keep it open if:
 - the owner still sees meaningful gaps in Butler self-reference / update-check
   handling that belong to `#80` itself
 - follow-up behavior changes are expected before judging the issue complete
+
+### `#82`
+
+`#82` now has merged/runtime progress for governed deploy dispatch plus
+same-origin passkey-operator execution evidence.
+
+It may be close-ready if the owner agrees that:
+
+- stale parity can now advance into an iPhone-usable governed deploy path
+- `GO + real passkey` remains explicit and approval-bound
+- any remaining deploy confusion is now drift or operator setup outside `#82`
+  rather than missing deploy-orchestration scope
+
+Keep it open if:
+
+- the owner still sees meaningful gaps in Butler deploy guidance or
+  passkey-operator execution for mobile deploy recovery
+- additional Butler-side natural-language deploy handling is expected before
+  judging the issue complete
 
 ## Non-claim
 

--- a/docs/mvp/e2e/e2e-26-governed-production-deploy-from-passkey-operator.md
+++ b/docs/mvp/e2e/e2e-26-governed-production-deploy-from-passkey-operator.md
@@ -1,0 +1,64 @@
+# E2E-26 Governed Production Deploy From Passkey Operator
+
+This document records concrete run evidence for the E2E-26 track.
+
+## Scope
+
+Issues:
+- `#82`
+
+Goal:
+- confirm deploy stale can advance into a governed production deploy execution path from the Worker-owned passkey operator surface
+- confirm the same-origin operator path preserves the current Worker origin as `runtime_url`
+- confirm deploy remains blocked without a real deploy-scoped approval grant or deploy credentials
+
+## Happy-path Run
+
+Command:
+
+```sh
+node --test test/deploy-production-plane.test.js test/passkey-operator-page.test.js test/worker.test.js test/custom-gpt-setup-docs.test.js
+```
+
+Observed result on 2026-04-27:
+- passed
+- confirms the passkey operator page exposes a dedicated `Dispatch production deploy` action
+- confirms same-origin browser POST to `/v2/action/deploy` succeeds when a real deploy-scoped `approvalGrantId` exists
+- confirms the governed deploy dispatch uses the current Worker origin as `runtime_url`
+- confirms Butler instructions point humans at the canonical same-origin operator helper path before claiming deploy can proceed
+
+## Boundary-path Run
+
+Command:
+
+```sh
+node --test test/deploy-production-plane.test.js test/worker.test.js
+```
+
+Observed result on 2026-04-27:
+- passed
+- confirms deploy is rejected when `GO` or a real deploy-scoped approval grant is missing
+- confirms invalid grant scope is rejected instead of silently dispatching deploy
+- confirms missing deploy credentials return the explicit `deploy_unavailable` category
+
+## Evidence Files
+
+- `src/worker.js`
+- `src/core/deploy-production-plane.js`
+- `src/core/passkey-operator-page.js`
+- `docs/security/webauthn-passkey-runtime.md`
+- `docs/setup/custom-gpt-instructions.md`
+- `test/deploy-production-plane.test.js`
+- `test/passkey-operator-page.test.js`
+- `test/worker.test.js`
+- `test/custom-gpt-setup-docs.test.js`
+
+## Current Reading
+
+E2E-26 now has recorded happy-path and boundary-path run evidence in-repo.
+
+This confirms Issue `#82` is connected to a governed deploy execution path that
+can be reached from the Worker-owned passkey operator surface on iPhone/mobile.
+It does not claim that deploy can proceed without explicit human `GO + real
+passkey`, nor that editor-side Custom GPT configuration can be auto-updated by
+the same path.

--- a/docs/mvp/issue-to-e2e-matrix.md
+++ b/docs/mvp/issue-to-e2e-matrix.md
@@ -532,6 +532,28 @@ Status values used below:
   - `docs/mvp/e2e/e2e-25-reviewer-fallback-gemini-codex.md`
 - Status: `e2e_evidenced_pending_human_closure`
 
+## E2E-26 Governed production deploy from passkey operator
+
+- Issues: `#82`
+- Happy path:
+  - Butler/runtime can move from deploy stale detection into a governed production deploy execution path, and the Worker-owned passkey operator can dispatch that path with a real deploy-scoped approval grant
+- Boundary path:
+  - missing `GO`, missing/invalid deploy-scoped approval grant, or missing deploy credentials block deploy with explicit failure categories instead of silently mutating runtime state
+- Implementation evidence:
+  - `src/worker.js`
+  - `src/core/deploy-production-plane.js`
+  - `src/core/passkey-operator-page.js`
+  - `docs/security/webauthn-passkey-runtime.md`
+  - `docs/setup/custom-gpt-instructions.md`
+- Test evidence:
+  - `test/deploy-production-plane.test.js`
+  - `test/passkey-operator-page.test.js`
+  - `test/worker.test.js`
+  - `test/custom-gpt-setup-docs.test.js`
+- Run evidence:
+  - `docs/mvp/e2e/e2e-26-governed-production-deploy-from-passkey-operator.md`
+- Status: `e2e_evidenced_pending_human_closure`
+
 ## Current Completion Reading
 
 - Repository completion status: `partial`

--- a/docs/mvp/open-issue-current-reality-audit.md
+++ b/docs/mvp/open-issue-current-reality-audit.md
@@ -30,11 +30,7 @@ However, the open issue set now contains four different kinds of items:
 
 ## Current Active Implementation Issues
 
-- `#82`
-  - merged progress exists through PRs `#83` and `#85`
-  - current reading: the governed deploy plane and self-parity deploy manifest
-    landed, but natural-language Butler orchestration from stale parity into
-    `GO + real passkey` deploy is still incomplete
+- none at the moment
 
 ## Current Active Spec / Boundary Issues
 
@@ -52,6 +48,12 @@ However, the open issue set now contains four different kinds of items:
   - current reading: self-reference and natural self-parity trigger mapping are
     implemented; remaining work is mainly human closure judgment unless new
     gaps are found
+- `#82`
+  - merged/runtime progress exists through PRs `#83`, `#85`, and `#87`
+  - current reading: governed deploy plane, self-parity manifest alignment, and
+    same-origin passkey-operator deploy dispatch are implemented with mapped
+    E2E evidence; remaining work is mainly human closure judgment unless new
+    mobile deploy gaps are found
 - `#4`
   - mapped by `E2E-19`
   - current reading: remains the live parent authority for the
@@ -79,8 +81,7 @@ The following older readings must not be reintroduced:
   fallback is already solved
 - treating open issue count alone as proof that major runtime work is still
   unimplemented
-- treating the remaining work as mostly close-readiness while `#82` and `#84`
-  are still active implementation/spec gaps
+- treating no-manual reviewer fallback as solved while `#84` remains active
 
 ## Recommended Next Step
 
@@ -88,10 +89,10 @@ The next highest-value cleanup is:
 
 - keep `#82` and `#84` visible as current active work rather than reading the
   repo as mostly closure-ready
-- decide whether `#80` is ready for human closure judgment
+- decide whether `#80` and `#82` are ready for human closure judgment
 - keep `#6` separate as historical/human-judgment context rather than treating
   it as active implementation uncertainty
 
 The repository still has broad runnable coverage, but the remaining drift is no
-longer only at the owner close-readiness layer; it also includes active deploy
-orchestration and reviewer-fallback boundary work.
+longer only at the owner close-readiness layer; it now concentrates mainly on
+the unresolved no-manual reviewer-fallback boundary tracked by `#84`.

--- a/docs/security/webauthn-passkey-runtime.md
+++ b/docs/security/webauthn-passkey-runtime.md
@@ -89,6 +89,8 @@ Worker URL itself. It can:
 - request a high-risk approval challenge
 - verify the authenticator response
 - display the resulting `approvalGrantId`
+- dispatch a governed production deploy after a deploy-scoped
+  `approvalGrantId` has been issued
 
 This is the minimum browser/iPhone execution surface for the real passkey flow.
 The Worker URL is canonical. Local helper/proxy paths are not the canonical

--- a/docs/setup/custom-gpt-instructions.md
+++ b/docs/setup/custom-gpt-instructions.md
@@ -193,6 +193,9 @@ Deploy plane:
   - resolved repository
   - explicit `GO`
   - real passkey approval grant scoped to `deploy_production`
+- If no deploy-scoped approval grant is available yet, direct the human to the canonical same-origin operator helper path:
+  - `/v2/approval/passkey/operator?repositoryInput=<resolved repo>&issueNumber=<active issue when relevant>&actionType=deploy_production&highRiskKind=deploy_production`
+- If the human is on the same-origin passkey operator page, that operator page may also dispatch the governed deploy path after it obtains a deploy-scoped `approvalGrantId`.
 - When self-parity indicates `Cloudflare deploy update required`, you may suggest deploy as the next safe high-risk action.
 - After vtddDeployProduction, tell the user deploy was dispatched and then re-check self-parity before claiming runtime is updated.
 

--- a/src/core/passkey-operator-page.js
+++ b/src/core/passkey-operator-page.js
@@ -174,6 +174,16 @@ export function renderPasskeyOperatorPage(input = {}) {
           <p class="muted">${syncMessage}</p>
           <pre id="sync-output"></pre>
         </section>
+
+        <section>
+          <h2>4. Production Deploy</h2>
+          <p class="muted">deploy stale を検知したあと、取得済みの <code>approvalGrantId</code> を使って same-origin の governed deploy path を dispatch します。</p>
+          <div class="row">
+            <button id="deploy-button">Dispatch production deploy</button>
+          </div>
+          <p class="muted">この Worker origin を <code>runtimeUrl</code> として使います。実行後は Butler で self-parity を再確認してください。</p>
+          <pre id="deploy-output"></pre>
+        </section>
       </div>
     </main>
 
@@ -181,6 +191,7 @@ export function renderPasskeyOperatorPage(input = {}) {
       const registerOutput = document.getElementById("register-output");
       const approveOutput = document.getElementById("approve-output");
       const syncOutput = document.getElementById("sync-output");
+      const deployOutput = document.getElementById("deploy-output");
       let latestApprovalGrantId = "";
 
       document.getElementById("register-button").addEventListener("click", async () => {
@@ -290,6 +301,34 @@ export function renderPasskeyOperatorPage(input = {}) {
           syncOutput.textContent = JSON.stringify(syncBody, null, 2);
         } catch (error) {
           syncOutput.textContent = String(error);
+        }
+      });
+
+      document.getElementById("deploy-button").addEventListener("click", async () => {
+        try {
+          if (!latestApprovalGrantId) {
+            throw new Error("approvalGrantId is required before production deploy");
+          }
+          deployOutput.textContent = "production deploy request...";
+          const deployResponse = await fetch("${apiBase}/action/deploy", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({
+              repository: document.getElementById("repo-input").value,
+              issueNumber: Number(document.getElementById("issue-input").value || 0) || null,
+              policyInput: {
+                approvalPhrase: "GO",
+                approvalGrantId: latestApprovalGrantId
+              }
+            })
+          });
+          const deployBody = await deployResponse.json();
+          if (!deployResponse.ok) {
+            throw new Error(deployBody.reason || deployBody.error || "production deploy failed");
+          }
+          deployOutput.textContent = JSON.stringify(deployBody, null, 2);
+        } catch (error) {
+          deployOutput.textContent = String(error);
         }
       });
 

--- a/src/worker.js
+++ b/src/worker.js
@@ -176,7 +176,11 @@ export default {
     }
 
     if (request.method === "POST" && isApiPath(url.pathname, "/action/deploy")) {
-      const auth = authorizeGatewayRequest({ request, env, apiSuffix: "/action/deploy" });
+      const auth = authorizePasskeyBrowserOrMachineRequest({
+        request,
+        env,
+        apiSuffix: "/action/deploy"
+      });
       if (!auth.ok) {
         return json(auth.status, {
           ok: false,

--- a/test/deploy-production-plane.test.js
+++ b/test/deploy-production-plane.test.js
@@ -53,3 +53,27 @@ test("deploy production plane blocks missing GO + passkey inputs", async () => {
   assert.equal(result.issues.includes("approvalPhrase must be GO"), true);
   assert.equal(result.issues.includes("real approvalGrant is required for deploy_production"), true);
 });
+
+test("deploy production plane returns explicit unavailable category when deploy credentials are missing", async () => {
+  const result = await executeDeployProductionPlane({
+    repository: "sample-org/vtdd-v2-p",
+    runtimeUrl: "https://sample-user-vtdd.example.workers.dev",
+    approvalPhrase: "GO",
+    approvalGrantId: "approval-deploy-123",
+    approvalGrant: {
+      approvalId: "approval-deploy-123",
+      verified: true,
+      expiresAt: "2099-01-01T00:00:00.000Z",
+      scope: {
+        actionType: "deploy_production",
+        highRiskKind: "deploy_production",
+        repositoryInput: "sample-org/vtdd-v2-p"
+      }
+    },
+    env: {}
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.error, "deploy_unavailable");
+  assert.equal(result.reason.includes("installation token"), true);
+});

--- a/test/e2e-26-governed-production-deploy-from-passkey-operator.test.js
+++ b/test/e2e-26-governed-production-deploy-from-passkey-operator.test.js
@@ -1,0 +1,38 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const DOC_PATH = path.join(
+  process.cwd(),
+  "docs",
+  "mvp",
+  "e2e",
+  "e2e-26-governed-production-deploy-from-passkey-operator.md"
+);
+const MATRIX_PATH = path.join(process.cwd(), "docs", "mvp", "issue-to-e2e-matrix.md");
+
+test("E2E-26 evidence doc records governed deploy runs from the passkey operator", () => {
+  const doc = fs.readFileSync(DOC_PATH, "utf8");
+  assert.equal(
+    doc.includes(
+      "node --test test/deploy-production-plane.test.js test/passkey-operator-page.test.js test/worker.test.js test/custom-gpt-setup-docs.test.js"
+    ),
+    true
+  );
+  assert.equal(doc.includes("Dispatch production deploy"), true);
+  assert.equal(doc.includes("/v2/action/deploy"), true);
+  assert.equal(doc.includes("runtime_url"), true);
+  assert.equal(doc.includes("deploy_unavailable"), true);
+  assert.equal(doc.includes("Worker-owned passkey operator surface"), true);
+});
+
+test("issue-to-e2e matrix references E2E-26 run evidence", () => {
+  const doc = fs.readFileSync(MATRIX_PATH, "utf8");
+  assert.equal(doc.includes("## E2E-26 Governed production deploy from passkey operator"), true);
+  assert.equal(
+    doc.includes("docs/mvp/e2e/e2e-26-governed-production-deploy-from-passkey-operator.md"),
+    true
+  );
+  assert.equal(doc.includes("- Issues: `#82`"), true);
+});

--- a/test/issue-to-e2e-matrix.test.js
+++ b/test/issue-to-e2e-matrix.test.js
@@ -33,7 +33,8 @@ test("issue-to-e2e matrix defines all canonical E2E tracks", () => {
     "E2E-22",
     "E2E-23",
     "E2E-24",
-    "E2E-25"
+    "E2E-25",
+    "E2E-26"
   ]) {
     assert.equal(doc.includes(`## ${id}`), true);
   }

--- a/test/passkey-operator-page.test.js
+++ b/test/passkey-operator-page.test.js
@@ -15,7 +15,9 @@ test("passkey operator page can target explicit api base and sync endpoint", () 
 
   assert.equal(html.includes('fetch("/api/approval/passkey/challenge"'), true);
   assert.equal(html.includes('fetch("http://127.0.0.1:8789/api/github-app-secret-sync/execute"'), true);
+  assert.equal(html.includes('fetch("/api/action/deploy"'), true);
   assert.equal(html.includes("Sync GitHub App secrets"), true);
+  assert.equal(html.includes("Dispatch production deploy"), true);
   assert.equal(html.includes('id="action-type-input" value="deploy_production"'), true);
   assert.equal(html.includes('repositoryInput: document.getElementById("repo-input").value'), true);
   assert.equal(html.includes('issueNumber: Number(document.getElementById("issue-input").value || 0) || null'), true);

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -1275,6 +1275,71 @@ test("worker dispatches governed production deploy using the request origin as t
   );
 });
 
+test("worker allows same-origin browser governed production deploy with a real approval grant", async () => {
+  const provider = createInMemoryMemoryProvider();
+  const calls = [];
+  await provider.store({
+    id: "approval-deploy-browser-123",
+    type: MemoryRecordType.APPROVAL_LOG,
+    content: {
+      kind: "passkey_grant",
+      status: "verified",
+      approvalId: "approval-deploy-browser-123",
+      expiresAt: "2099-01-01T00:00:00.000Z",
+      scope: {
+        actionType: "deploy_production",
+        highRiskKind: "deploy_production",
+        repositoryInput: "sample-org/vtdd-v2-p",
+        issueNumber: "82",
+        relatedIssue: "82",
+        phase: "execution"
+      }
+    },
+    metadata: { source: "test" },
+    priority: 90,
+    tags: ["passkey_grant"],
+    createdAt: "2026-04-27T00:00:00.000Z"
+  });
+
+  const response = await worker.fetch(
+    new Request("https://sample-user-vtdd.example.workers.dev/v2/action/deploy", {
+      method: "POST",
+      headers: {
+        origin: "https://sample-user-vtdd.example.workers.dev",
+        "sec-fetch-site": "same-origin",
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({
+        repository: "sample-org/vtdd-v2-p",
+        policyInput: {
+          approvalPhrase: "GO",
+          approvalGrantId: "approval-deploy-browser-123"
+        }
+      })
+    }),
+    {
+      ...gatewayAuthEnv,
+      MEMORY_PROVIDER: provider,
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_deploy",
+      GITHUB_API_FETCH: async (url, init) => {
+        calls.push({ url: String(url), init });
+        return new Response(null, { status: 204 });
+      }
+    }
+  );
+
+  assert.equal(response.status, 202);
+  const body = await response.json();
+  assert.equal(body.ok, true);
+  assert.equal(body.deploy.status, "dispatched");
+  assert.equal(body.deploy.runtimeUrl, "https://sample-user-vtdd.example.workers.dev");
+  const dispatchBody = JSON.parse(calls[0].init.body);
+  assert.equal(
+    dispatchBody.inputs.runtime_url,
+    "https://sample-user-vtdd.example.workers.dev"
+  );
+});
+
 test("worker returns remote Codex execution progress", async () => {
   const response = await worker.fetch(
     new Request("https://example.com/v2/action/progress?executionId=remote-codex-issue6-abcd12", {


### PR DESCRIPTION
## This PR satisfies Intent

- Advances Issue #82 by connecting stale-parity deploy recovery to a governed, iPhone-usable Worker URL path.
- Keeps deploy under explicit `GO + real passkey` while allowing the same-origin passkey operator surface to dispatch the governed production deploy path.

## Satisfied Success Criteria

- Butler/runtime can move from deploy stale detection into a governed production deploy execution path.
- A human with explicit `GO` and a real deploy-scoped approval grant can proceed through VTDD to production deploy.
- Deploy execution remains bound to the existing governed deploy contract.
- Mapped E2E happy-path and boundary-path evidence now exist for Issue #82.
- Deploy unsupported / missing-credential paths return explicit failure categories instead of silent success.

## Unsatisfied Success Criteria

- Natural-language Butler orchestration quality on the editor side still depends on the Custom GPT Instructions being updated/published by the operator.

## Non-goal violations

None.

## Verification Evidence

- Unit: `node --test test/deploy-production-plane.test.js test/passkey-operator-page.test.js test/worker.test.js test/custom-gpt-setup-docs.test.js test/e2e-26-governed-production-deploy-from-passkey-operator.test.js test/issue-to-e2e-matrix.test.js test/open-issue-current-reality-audit.test.js test/close-readiness-audit.test.js`
- Integration: same command as above covers worker route + operator page + setup docs integration.
- E2E: `docs/mvp/e2e/e2e-26-governed-production-deploy-from-passkey-operator.md`
- Manual: not run in this PR.
- Evidence path/link: `docs/mvp/e2e/e2e-26-governed-production-deploy-from-passkey-operator.md`

## Related Constitution Rules

- context-first Butler behavior
- no default repository
- high-risk actions require `GO + passkey`
- public/shared runtime must stay user-owned and origin-scoped

## Out-of-scope but NOT implemented

- Issue #84 no-manual Codex fallback
- automatic Custom GPT editor introspection/update
- deploy authority model redesign

## Extra changes (if any)

- Updated current-reality / close-readiness docs so #82 is no longer described with stale pre-operator status after merge.

<!-- VTDD metadata -->
- Issue: #82
- Execution ID: Not provided.
- Goal: governed deploy from stale parity via GO + real passkey
