### PR TITLE
Implement no-manual Codex reviewer fallback

### DIFF
--- a/.github/workflows/codex-pr-review-fallback.yml
+++ b/.github/workflows/codex-pr-review-fallback.yml
@@ -1,0 +1,100 @@
+name: codex-pr-review-fallback
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_repository:
+        description: "owner/repo to review"
+        required: true
+        type: string
+      pull_request_number:
+        description: "Target pull request number"
+        required: true
+        type: string
+      head_ref:
+        description: "PR head ref to review"
+        required: true
+        type: string
+      base_ref:
+        description: "PR base ref"
+        required: true
+        type: string
+      trigger:
+        description: "Original reviewer trigger"
+        required: true
+        type: string
+      reason:
+        description: "Fallback reason"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    env:
+      TARGET_REPOSITORY: ${{ github.event.inputs.target_repository }}
+      TARGET_PR_NUMBER: ${{ github.event.inputs.pull_request_number }}
+      TARGET_HEAD_REF: ${{ github.event.inputs.head_ref }}
+      TARGET_BASE_REF: ${{ github.event.inputs.base_ref }}
+      CODEX_FALLBACK_TRIGGER: ${{ github.event.inputs.trigger }}
+      CODEX_FALLBACK_REASON: ${{ github.event.inputs.reason }}
+    steps:
+      - name: Validate Codex fallback inputs
+        shell: bash
+        run: |
+          if ! [[ "$TARGET_REPOSITORY" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
+            echo "target_repository must be owner/repo."
+            exit 1
+          fi
+          if ! [[ "$TARGET_PR_NUMBER" =~ ^[0-9]+$ ]]; then
+            echo "pull_request_number must be numeric."
+            exit 1
+          fi
+          if ! [[ "$TARGET_HEAD_REF" =~ ^[A-Za-z0-9._/-]+$ ]]; then
+            echo "head_ref contains unsupported characters."
+            exit 1
+          fi
+          if ! [[ "$TARGET_BASE_REF" =~ ^[A-Za-z0-9._/-]+$ ]]; then
+            echo "base_ref contains unsupported characters."
+            exit 1
+          fi
+
+      - name: Mint GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.VTDD_GITHUB_APP_ID }}
+          private-key: ${{ secrets.VTDD_GITHUB_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Checkout target repository
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.TARGET_REPOSITORY }}
+          ref: ${{ env.TARGET_HEAD_REF }}
+          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 0
+
+      - name: Fetch base ref
+        shell: bash
+        run: git fetch origin "$TARGET_BASE_REF":"refs/remotes/origin/$TARGET_BASE_REF"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install Codex CLI
+        shell: bash
+        run: npm install -g @openai/codex
+
+      - name: Run non-manual Codex fallback review
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: node scripts/run-codex-pr-review-fallback.mjs

--- a/.github/workflows/gemini-pr-review.yml
+++ b/.github/workflows/gemini-pr-review.yml
@@ -21,8 +21,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
-  issues: write
 
 concurrency:
   group: gemini-pr-review-${{ github.repository }}-${{ github.event.pull_request.number || github.event.issue.number || github.run_id }}

--- a/.github/workflows/gemini-pr-review.yml
+++ b/.github/workflows/gemini-pr-review.yml
@@ -21,8 +21,8 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
-  issues: read
+  pull-requests: write
+  issues: write
 
 concurrency:
   group: gemini-pr-review-${{ github.repository }}-${{ github.event.pull_request.number || github.event.issue.number || github.run_id }}
@@ -89,4 +89,5 @@ jobs:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           GEMINI_REVIEW_MODEL: ${{ vars.GEMINI_REVIEW_MODEL }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: node scripts/run-gemini-pr-review.mjs

--- a/docs/butler/gemini-pr-review-comments.md
+++ b/docs/butler/gemini-pr-review-comments.md
@@ -29,17 +29,21 @@ Gemini review must run when:
 
 If Gemini is temporarily unavailable because of quota exhaustion, rate
 limiting, or transient provider high demand / temporary unavailability, VTDD
-may upsert a GitHub-visible Codex fallback review request comment (`@codex
-review`) instead of hard-failing the PR solely for reviewer availability
-reasons.
+must not hard-fail the PR solely for reviewer availability reasons.
+
+Preferred fallback:
+
+- VTDD dispatches a non-manual Codex fallback review workflow
+- that workflow runs Codex in critique-only reviewer mode
+- VTDD writes the resulting fallback review comment back to the PR through the
+  GitHub App token path
 
 Current limitation:
 
-- a VTDD bot-authored `@codex review` request is not yet guaranteed to produce
-  the same result as an owner-authored Codex request
-- therefore this slice proves request-state visibility, not a completed
-  no-manual Codex fallback design
-- the unresolved no-manual fallback path is tracked by `#84`
+- if reviewer runtime credentials/configuration for the non-manual Codex
+  fallback are absent, VTDD can only surface an explicit fallback blocker state
+- a VTDD bot-authored `@codex review` request is not treated as the canonical
+  no-manual solution path
 
 The workflow must ignore its own marker comment so that reviewer reruns do not
 create an infinite comment loop.

--- a/docs/butler/gemini-pr-review-comments.md
+++ b/docs/butler/gemini-pr-review-comments.md
@@ -45,6 +45,20 @@ Current limitation:
 - a VTDD bot-authored `@codex review` request is not treated as the canonical
   no-manual solution path
 
+## Operator Prerequisite
+
+For the non-manual Codex fallback to reach a `completed` reviewer state, the
+target repository must provide reviewer runtime credentials/configuration for
+that workflow path.
+
+Current canonical requirement:
+
+- `OPENAI_API_KEY` must be configured in the repository where the fallback
+  workflow will run
+
+If that prerequisite is missing, VTDD must preserve an explicit `blocked`
+fallback state rather than pretending the no-manual path completed.
+
 The workflow must ignore its own marker comment so that reviewer reruns do not
 create an infinite comment loop.
 

--- a/docs/mvp/close-readiness-audit.md
+++ b/docs/mvp/close-readiness-audit.md
@@ -22,6 +22,10 @@ The following open issues are intentionally not treated as close-readiness-only
 items here because they still represent active implementation/spec work:
 
 - `#84`
+  - current reading: runtime/docs progress exists for VTDD-managed non-manual
+    fallback workflow dispatch and explicit blocked-state signaling
+  - keep open until the owner judges whether that path is an acceptable
+    no-manual fallback answer
 
 ## Current Reading
 

--- a/docs/mvp/e2e/e2e-25-reviewer-fallback-gemini-codex.md
+++ b/docs/mvp/e2e/e2e-25-reviewer-fallback-gemini-codex.md
@@ -1,4 +1,4 @@
-# E2E-25 Reviewer Fallback From Gemini To Codex Request
+# E2E-25 Reviewer Fallback Request-State Preservation
 
 This document records concrete run evidence for the E2E-25 track.
 
@@ -11,7 +11,7 @@ Issues:
 Goal:
 - confirm Gemini remains the primary reviewer when available
 - confirm Gemini quota/rate-limit exhaustion does not hard-fail the PR solely for reviewer quota reasons
-- confirm VTDD can upsert a GitHub-visible `@codex review` fallback request while preserving critique-only reviewer separation
+- confirm VTDD can preserve an explicit GitHub-visible Codex fallback request-state while preserving critique-only reviewer separation
 
 ## Happy-path Run
 
@@ -24,7 +24,7 @@ node --test test/codex-review-fallback.test.js test/gemini-review-failure.test.j
 Observed result on 2026-04-27:
 - passed
 - confirms quota/rate-limit failures are classified as reviewer unavailability rather than generic hard failure
-- confirms VTDD can format and detect a GitHub-visible Codex fallback request comment carrying `@codex review`
+- confirms VTDD can format and detect a GitHub-visible Codex fallback request-state comment
 - confirms execution continuity and Butler synthesis expose `codex_review_requested` distinctly from `gemini_review_available`
 - confirms Gemini-first behavior remains canonical when reviewer evidence is available again
 
@@ -66,6 +66,5 @@ This confirms Issue `#74` is connected to a repo-side fallback request path
 that keeps Gemini as primary, records Codex fallback request state, and
 preserves critique-only reviewer boundaries.
 
-It does not claim that a VTDD bot-authored `@codex review` request is already a
-solved no-manual fallback path on a live PR.
-That unresolved platform/UX boundary is now tracked by open Issue `#84`.
+It does not claim that request-state alone solves the no-manual fallback path.
+The non-manual delivered/blocker path is tracked by open Issue `#84`.

--- a/docs/mvp/e2e/e2e-27-no-manual-codex-reviewer-fallback.md
+++ b/docs/mvp/e2e/e2e-27-no-manual-codex-reviewer-fallback.md
@@ -1,0 +1,70 @@
+# E2E-27 No-Manual Codex Reviewer Fallback
+
+This document records concrete run evidence for the E2E-27 track.
+
+## Scope
+
+Issues:
+- `#84`
+- parent anchor: `#4`
+
+Goal:
+- confirm Gemini unavailable can advance into a non-manual Codex reviewer fallback path
+- confirm VTDD can represent requested, completed, and blocked Codex fallback reviewer states without requiring owner PR-comment paste
+- confirm Butler summary can consume those states without treating request-state as delivered review
+- confirm VTDD does not degrade to manual PR-comment paste as the normal fallback answer
+
+## Happy-path Run
+
+Command:
+
+```sh
+node --test test/codex-review-fallback.test.js test/gemini-review-failure.test.js test/gemini-pr-review-workflow.test.js test/execution-continuity.test.js test/butler-review-synthesis.test.js test/reviewer-policy.test.js
+```
+
+Observed result on 2026-04-27:
+- passed
+- confirms Gemini temporary unavailability can dispatch a non-manual Codex fallback workflow instead of relying on bot-authored `@codex review`
+- confirms VTDD can format and parse `requested` and `completed` fallback reviewer states
+- confirms Butler synthesis treats completed Codex fallback review as reviewer evidence rather than request-state only
+
+## Boundary-path Run
+
+Command:
+
+```sh
+node --test test/codex-review-fallback.test.js test/gemini-pr-review-workflow.test.js test/execution-continuity.test.js test/butler-review-synthesis.test.js test/reviewer-policy.test.js
+```
+
+Observed result on 2026-04-27:
+- passed
+- confirms missing reviewer runtime credentials/configuration are surfaced as explicit `blocked` fallback state
+- confirms Butler summary preserves the platform blocker instead of degrading to manual comment-paste as the normal answer
+- confirms reviewer fallback remains critique-only and does not gain merge or deploy authority
+
+## Evidence Files
+
+- `.github/workflows/gemini-pr-review.yml`
+- `.github/workflows/codex-pr-review-fallback.yml`
+- `scripts/run-gemini-pr-review.mjs`
+- `scripts/run-codex-pr-review-fallback.mjs`
+- `src/core/codex-review-fallback.js`
+- `src/core/execution-continuity.js`
+- `src/core/butler-review-synthesis.js`
+- `docs/security/reviewer-policy.md`
+- `docs/butler/gemini-pr-review-comments.md`
+- `test/codex-review-fallback.test.js`
+- `test/gemini-pr-review-workflow.test.js`
+- `test/execution-continuity.test.js`
+- `test/butler-review-synthesis.test.js`
+- `test/reviewer-policy.test.js`
+
+## Current Reading
+
+E2E-27 now has recorded happy-path and boundary-path run evidence in-repo.
+
+This confirms Issue `#84` is connected to a VTDD-managed no-manual reviewer
+fallback design: when Gemini is unavailable, VTDD can either dispatch a
+non-manual Codex fallback review workflow or explicitly surface the runtime
+blocker. It does not claim live provider credentials are configured in every
+operator repository by default.

--- a/docs/mvp/e2e/e2e-27-no-manual-codex-reviewer-fallback.md
+++ b/docs/mvp/e2e/e2e-27-no-manual-codex-reviewer-fallback.md
@@ -68,3 +68,8 @@ fallback design: when Gemini is unavailable, VTDD can either dispatch a
 non-manual Codex fallback review workflow or explicitly surface the runtime
 blocker. It does not claim live provider credentials are configured in every
 operator repository by default.
+
+Operator prerequisite for live `completed` state:
+
+- configure `OPENAI_API_KEY` in the target repository so the Codex fallback
+  workflow can run critique-only review instead of remaining `blocked`

--- a/docs/mvp/issue-to-e2e-matrix.md
+++ b/docs/mvp/issue-to-e2e-matrix.md
@@ -506,11 +506,11 @@ Status values used below:
   - `docs/mvp/e2e/e2e-24-butler-self-parity-setup-artifacts.md`
 - Status: `e2e_evidenced_pending_human_closure`
 
-## E2E-25 Reviewer fallback from Gemini to Codex request
+## E2E-25 Reviewer fallback request-state preservation
 
 - Issues: `#74`
 - Happy path:
-  - Gemini remains the primary reviewer when available, and quota exhaustion falls back to a GitHub-visible `@codex review` request without hard-failing the PR
+  - Gemini remains the primary reviewer when available, and temporary reviewer failure still leaves a GitHub-visible Codex fallback request-state without hard-failing the PR
 - Boundary path:
   - fallback request state remains critique-only, does not overclaim delivered critique, and does not hide reviewer absence
 - Implementation evidence:
@@ -530,6 +530,33 @@ Status values used below:
   - `test/butler-review-synthesis.test.js`
 - Run evidence:
   - `docs/mvp/e2e/e2e-25-reviewer-fallback-gemini-codex.md`
+- Status: `e2e_evidenced_pending_human_closure`
+
+## E2E-27 No-manual Codex reviewer fallback
+
+- Issues: `#84`
+- Happy path:
+  - Gemini unavailable can advance into a VTDD-managed non-manual Codex reviewer fallback path, and Butler can consume the resulting delivered reviewer state
+- Boundary path:
+  - missing fallback reviewer runtime credentials/configuration surfaces an explicit blocker state instead of degrading to manual PR comment paste as the normal answer
+- Implementation evidence:
+  - `.github/workflows/gemini-pr-review.yml`
+  - `.github/workflows/codex-pr-review-fallback.yml`
+  - `scripts/run-gemini-pr-review.mjs`
+  - `scripts/run-codex-pr-review-fallback.mjs`
+  - `src/core/codex-review-fallback.js`
+  - `src/core/execution-continuity.js`
+  - `src/core/butler-review-synthesis.js`
+  - `docs/security/reviewer-policy.md`
+  - `docs/butler/gemini-pr-review-comments.md`
+- Test evidence:
+  - `test/codex-review-fallback.test.js`
+  - `test/gemini-pr-review-workflow.test.js`
+  - `test/execution-continuity.test.js`
+  - `test/butler-review-synthesis.test.js`
+  - `test/reviewer-policy.test.js`
+- Run evidence:
+  - `docs/mvp/e2e/e2e-27-no-manual-codex-reviewer-fallback.md`
 - Status: `e2e_evidenced_pending_human_closure`
 
 ## E2E-26 Governed production deploy from passkey operator

--- a/docs/mvp/open-issue-current-reality-audit.md
+++ b/docs/mvp/open-issue-current-reality-audit.md
@@ -32,14 +32,18 @@ However, the open issue set now contains four different kinds of items:
 
 - none at the moment
 
-## Current Active Spec / Boundary Issues
+## Current Active Implementation / Boundary Issues
 
 - `#84`
+  - runtime/docs progress now exists for VTDD-managed no-manual Codex fallback
+    workflow dispatch plus explicit blocked-state handling
   - current reading: bot-authored `@codex review` fallback is not equivalent to
     owner-authored Codex invocation
   - manual copy-paste fallback is explicitly not the desired steady-state
     answer
-  - this remains active design work, not close-ready evidence-only work
+  - remaining work is no longer "missing design from scratch"; it is human
+    judgment on whether the VTDD-managed workflow path is the acceptable
+    no-manual fallback answer
 
 ## Open Issues With Merged Runtime / Docs Progress And Likely Human Closure Work
 
@@ -87,12 +91,14 @@ The following older readings must not be reintroduced:
 
 The next highest-value cleanup is:
 
-- keep `#82` and `#84` visible as current active work rather than reading the
-  repo as mostly closure-ready
-- decide whether `#80` and `#82` are ready for human closure judgment
+- keep `#84` visible as a boundary-sensitive open issue even after runtime/docs
+  progress lands, because owner judgment is still needed on the no-manual
+  fallback answer
+- decide whether `#80`, `#82`, and `#84` are ready for human closure judgment
 - keep `#6` separate as historical/human-judgment context rather than treating
   it as active implementation uncertainty
 
 The repository still has broad runnable coverage, but the remaining drift is no
 longer only at the owner close-readiness layer; it now concentrates mainly on
-the unresolved no-manual reviewer-fallback boundary tracked by `#84`.
+judging whether the VTDD-managed no-manual reviewer-fallback path for `#84`
+meets the intended operational bar.

--- a/docs/security/reviewer-policy.md
+++ b/docs/security/reviewer-policy.md
@@ -22,15 +22,16 @@ The reviewer is a critical evaluation role.
 
 ## Fallback Position
 
-- Codex GitHub review may be requested as an emergency fallback when Gemini is
-  temporarily unavailable because of quota, rate-limit exhaustion, or transient
-  provider high demand / temporary unavailability.
-- This fallback remains critique-only and depends on the operator's Codex
-  GitHub integration, not on repository-owned execution credentials.
+- Non-manual Codex fallback should prefer VTDD-managed workflow execution over
+  bot-authored `@codex review` comments when Gemini is temporarily unavailable.
+- This fallback remains critique-only and uses explicit reviewer runtime
+  credentials/configuration, not merge/deploy authority.
 - A bot-authored `@codex review` request must not be assumed equivalent to an
   owner-authored Codex review invocation.
-- No-manual Codex fallback remains active work under `#84`; the current repo
-  only proves the request-state path, not a solved no-manual fallback loop.
+- If non-manual Codex fallback cannot start because required reviewer runtime
+  credentials/configuration are absent, VTDD must surface that blocker
+  explicitly rather than degrading to manual PR comment paste as the normal
+  answer.
 - Antigravity is not the normal reviewer path.
 - Antigravity may be used only as an emergency fallback.
 - Emergency fallback use assumes learning-use is disabled in its service settings.

--- a/scripts/run-codex-pr-review-fallback.mjs
+++ b/scripts/run-codex-pr-review-fallback.mjs
@@ -1,0 +1,174 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import {
+  ReviewerRecommendedAction,
+  formatCodexReviewFallbackComment
+} from "../src/core/index.js";
+
+const execFileAsync = promisify(execFile);
+
+async function main() {
+  const repository = mustGetEnv("TARGET_REPOSITORY");
+  const prNumber = mustGetEnv("TARGET_PR_NUMBER");
+  const baseRef = mustGetEnv("TARGET_BASE_REF");
+  const trigger = mustGetEnv("CODEX_FALLBACK_TRIGGER");
+  const reason = mustGetEnv("CODEX_FALLBACK_REASON");
+  const githubToken = mustGetEnv("GITHUB_TOKEN");
+
+  if (!process.env.OPENAI_API_KEY) {
+    throw new Error("OPENAI_API_KEY is required for non-manual Codex fallback review");
+  }
+
+  const prompt = [
+    "You are the VTDD fallback reviewer.",
+    "Act only as a critique-only reviewer.",
+    "Do not propose merge or execution.",
+    "Review the current branch diff against the provided base branch.",
+    "Return strict JSON with these fields only:",
+    '{',
+    '  "criticalFindings": ["..."],',
+    '  "risks": ["..."],',
+    '  "recommendedAction": "approve|request_changes|manual_review"',
+    '}',
+    "If there are no major issues, set criticalFindings to [\"No major blocking issues found.\"], risks to [\"Human should still verify the PR before GO.\"], and recommendedAction to \"approve\"."
+  ].join("\n");
+
+  const review = await runCodexReview({ baseRef, prompt });
+  const parsed = parseReviewerJson(review.stdout);
+  const normalizedReview = normalizeReviewerResult(parsed, review.stdout);
+
+  const body = formatCodexReviewFallbackComment({
+    status: "completed",
+    trigger,
+    reason,
+    deliveryMode: "workflow_dispatch_codex_cli",
+    recommendedAction: normalizedReview.recommendedAction,
+    criticalFindings: normalizedReview.criticalFindings,
+    risks: normalizedReview.risks,
+    rawReview: review.stdout
+  });
+
+  const apiBaseUrl = process.env.GITHUB_API_URL || "https://api.github.com";
+  const githubFetch = createGitHubFetch({ apiBaseUrl, token: githubToken });
+  const existingComments = await githubFetch(`/repos/${repository}/issues/${prNumber}/comments?per_page=100`);
+  const existing = existingComments.find((comment) =>
+    String(comment?.body || "").includes("<!-- vtdd:reviewer=codex-fallback -->")
+  );
+
+  if (existing) {
+    await githubFetch(`/repos/${repository}/issues/comments/${existing.id}`, {
+      method: "PATCH",
+      body: { body }
+    });
+    console.log(`Updated Codex fallback review comment on PR #${prNumber}.`);
+    return;
+  }
+
+  await githubFetch(`/repos/${repository}/issues/${prNumber}/comments`, {
+    method: "POST",
+    body: { body }
+  });
+  console.log(`Created Codex fallback review comment on PR #${prNumber}.`);
+}
+
+async function runCodexReview({ baseRef, prompt }) {
+  return execFileAsync("codex", ["review", "--base", baseRef, "-"], {
+    cwd: process.cwd(),
+    env: process.env,
+    input: prompt,
+    maxBuffer: 1024 * 1024 * 8
+  });
+}
+
+function parseReviewerJson(output) {
+  const text = String(output ?? "").trim();
+  if (!text) {
+    return null;
+  }
+
+  const fenced = text.match(/```(?:json)?\s*([\s\S]*?)```/i);
+  const candidate = fenced?.[1] || text;
+  try {
+    return JSON.parse(candidate);
+  } catch {
+    return null;
+  }
+}
+
+function normalizeReviewerResult(parsed, rawOutput) {
+  const criticalFindings = normalizeStringArray(parsed?.criticalFindings);
+  const risks = normalizeStringArray(parsed?.risks);
+  const recommendedAction = normalizeRecommendedAction(parsed?.recommendedAction);
+
+  if (criticalFindings.length > 0 || risks.length > 0) {
+    return {
+      criticalFindings,
+      risks,
+      recommendedAction
+    };
+  }
+
+  return {
+    criticalFindings: ["Codex fallback review returned unstructured output."],
+    risks: [
+      "Human should inspect the raw Codex review output before revision GO or merge GO + real passkey."
+    ],
+    recommendedAction: ReviewerRecommendedAction.MANUAL_REVIEW
+  };
+}
+
+function normalizeRecommendedAction(value) {
+  const normalized = String(value ?? "").trim().toLowerCase();
+  return Object.values(ReviewerRecommendedAction).includes(normalized)
+    ? normalized
+    : ReviewerRecommendedAction.MANUAL_REVIEW;
+}
+
+function normalizeStringArray(value) {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value
+    .map((item) => String(item ?? "").trim())
+    .filter(Boolean);
+}
+
+function createGitHubFetch({ apiBaseUrl, token }) {
+  return async (path, options = {}) => {
+    const response = await fetch(`${apiBaseUrl}${path}`, {
+      method: options.method || "GET",
+      headers: {
+        authorization: `Bearer ${token}`,
+        accept: "application/vnd.github+json",
+        "content-type": "application/json; charset=utf-8",
+        "x-github-api-version": "2022-11-28",
+        "user-agent": "vtdd-v2-codex-fallback-reviewer"
+      },
+      body: options.body ? JSON.stringify(options.body) : undefined
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`GitHub API request failed (${response.status}): ${text}`);
+    }
+
+    if (response.status === 204) {
+      return null;
+    }
+
+    return response.json();
+  };
+}
+
+function mustGetEnv(name) {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`${name} is required`);
+  }
+  return value;
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/scripts/run-gemini-pr-review.mjs
+++ b/scripts/run-gemini-pr-review.mjs
@@ -73,24 +73,64 @@ async function main() {
   } catch (error) {
     const failure = classifyGeminiReviewFailure(error instanceof Error ? error : {});
     if (failure.kind === GeminiReviewFailureKind.TEMPORARY_UNAVAILABLE) {
+      if (!process.env.OPENAI_API_KEY) {
+        const fallbackBody = formatCodexReviewFallbackComment({
+          status: "blocked",
+          trigger: triggerResult.value.trigger,
+          reason: "gemini_temporarily_unavailable",
+          deliveryMode: "workflow_dispatch_codex_cli",
+          blocker: "openai_api_key_not_configured"
+        });
+        if (existingFallbackComment) {
+          await githubFetch(`/repos/${repository}/issues/comments/${existingFallbackComment.id}`, {
+            method: "PATCH",
+            body: { body: fallbackBody }
+          });
+          console.log(`Updated Codex fallback blocker state on PR #${prNumber}.`);
+          return;
+        }
+
+        await githubFetch(`/repos/${repository}/issues/${prNumber}/comments`, {
+          method: "POST",
+          body: { body: fallbackBody }
+        });
+        console.log(`Recorded Codex fallback blocker state on PR #${prNumber}.`);
+        return;
+      }
+
       const fallbackBody = formatCodexReviewFallbackComment({
+        status: "requested",
         trigger: triggerResult.value.trigger,
-        reason: "gemini_temporarily_unavailable"
+        reason: "gemini_temporarily_unavailable",
+        deliveryMode: "workflow_dispatch_codex_cli"
       });
       if (existingFallbackComment) {
         await githubFetch(`/repos/${repository}/issues/comments/${existingFallbackComment.id}`, {
           method: "PATCH",
           body: { body: fallbackBody }
         });
-        console.log(`Updated Codex reviewer fallback request on PR #${prNumber}.`);
-        return;
+      } else {
+        await githubFetch(`/repos/${repository}/issues/${prNumber}/comments`, {
+          method: "POST",
+          body: { body: fallbackBody }
+        });
       }
 
-      await githubFetch(`/repos/${repository}/issues/${prNumber}/comments`, {
+      await githubFetch(`/repos/${repository}/actions/workflows/codex-pr-review-fallback.yml/dispatches`, {
         method: "POST",
-        body: { body: fallbackBody }
+        body: {
+          ref: pullRequest.base.ref,
+          inputs: {
+            target_repository: repository,
+            pull_request_number: String(prNumber),
+            head_ref: pullRequest.head.ref,
+            base_ref: pullRequest.base.ref,
+            trigger: triggerResult.value.trigger,
+            reason: "gemini_temporarily_unavailable"
+          }
+        }
       });
-      console.log(`Requested Codex reviewer fallback on PR #${prNumber}.`);
+      console.log(`Dispatched non-manual Codex reviewer fallback on PR #${prNumber}.`);
       return;
     }
     throw error;

--- a/src/core/butler-review-synthesis.js
+++ b/src/core/butler-review-synthesis.js
@@ -46,8 +46,14 @@ export function buildButlerReviewSynthesis(input = {}) {
 
 function buildHeadline({ pullRequest, reviewLoop }) {
   const base = `PR #${pullRequest.number} is ${pullRequest.state || "open"}.`;
+  if (reviewLoop.reviewerStatus === "codex_review_blocked") {
+    return `${base} Gemini is temporarily unavailable and non-manual Codex fallback is currently blocked by platform or repository configuration.`;
+  }
   if (reviewLoop.reviewerStatus === "codex_review_requested") {
     return `${base} Gemini is temporarily unavailable and Codex fallback review has been requested.`;
+  }
+  if (reviewLoop.reviewerStatus === "codex_review_available") {
+    return `${base} Codex fallback reviewer evidence is available and should be checked before human GO.`;
   }
   if (reviewLoop.unresolvedReviewCommentsCount > 0) {
     return `${base} ${reviewLoop.unresolvedReviewCommentsCount} unresolved reviewer objections remain.`;
@@ -66,6 +72,9 @@ function buildHumanDecisionFocus({ pullRequest, reviewLoop, codexGoal }) {
   }
   if (reviewLoop.reviewerStatus === "codex_review_requested") {
     focus.push("Gemini is temporarily unavailable; Codex fallback review has been requested and should arrive before human GO.");
+  }
+  if (reviewLoop.reviewerStatus === "codex_review_blocked") {
+    focus.push("Gemini is temporarily unavailable and non-manual Codex fallback is blocked; do not treat reviewer coverage as satisfied.");
   }
   if (pullRequest.updatedSinceReview) {
     focus.push("The PR changed after the last review signal; reviewer evidence should be refreshed against the current diff.");

--- a/src/core/codex-review-fallback.js
+++ b/src/core/codex-review-fallback.js
@@ -1,23 +1,44 @@
 export const CODEX_REVIEW_FALLBACK_MARKER = "<!-- vtdd:reviewer=codex-fallback -->";
 
+export const CodexReviewFallbackStatus = Object.freeze({
+  REQUESTED: "requested",
+  COMPLETED: "completed",
+  BLOCKED: "blocked"
+});
+
 export function formatCodexReviewFallbackComment(input = {}) {
   const trigger = normalizeText(input.trigger) || "unknown";
   const reason = normalizeText(input.reason) || "gemini_temporarily_unavailable";
+  const status = normalizeFallbackStatus(input.status) || CodexReviewFallbackStatus.REQUESTED;
+  const deliveryMode = normalizeText(input.deliveryMode) || "workflow_dispatch";
+  const blocker = normalizeText(input.blocker);
+  const recommendedAction = normalizeText(input.recommendedAction) || "manual_review";
+  const criticalFindings = normalizeStringArray(input.criticalFindings);
+  const risks = normalizeStringArray(input.risks);
+  const rawReview = normalizeText(input.rawReview);
 
-  return [
+  const lines = [
     CODEX_REVIEW_FALLBACK_MARKER,
-    "@codex review",
-    "",
     "## VTDD Codex Reviewer Fallback Request",
     "",
+    `- Status: \`${status}\``,
     `- Trigger: \`${trigger}\``,
     `- Reason: \`${reason}\``,
+    `- Delivery mode: \`${deliveryMode}\``,
     "",
-    "Gemini critical review is temporarily unavailable.",
-    "Please provide critique-only PR feedback.",
+    ...buildStatusSection({
+      status,
+      blocker,
+      recommendedAction,
+      criticalFindings,
+      risks,
+      rawReview
+    }),
     "",
     "_Reviewer remains critique-only. Human keeps revision GO / merge GO + real passkey authority._"
-  ].join("\n");
+  ];
+
+  return lines.join("\n");
 }
 
 export function findExistingCodexReviewFallbackComment(comments = []) {
@@ -30,16 +51,108 @@ export function parseCodexReviewFallbackComment(comment = {}) {
     return null;
   }
 
+  const status =
+    extractBacktickedValue(body, "Status") ||
+    (body.includes("@codex review") ? CodexReviewFallbackStatus.REQUESTED : "");
+  const recommendedAction = extractBacktickedValue(body, "Recommended action");
+  const blocker = extractBacktickedValue(body, "Blocker");
+
   return {
     reviewer: "codex",
-    status: "requested",
-    blocking: false,
+    status: normalizeFallbackStatus(status) || CodexReviewFallbackStatus.REQUESTED,
+    blocking: determineBlocking({
+      status,
+      recommendedAction,
+      blocker
+    }),
+    recommendedAction: recommendedAction || null,
+    blocker: blocker || null,
     body
   };
 }
 
 function containsMarker(value) {
   return normalizeText(value).includes(CODEX_REVIEW_FALLBACK_MARKER);
+}
+
+function buildStatusSection({
+  status,
+  blocker,
+  recommendedAction,
+  criticalFindings,
+  risks,
+  rawReview
+}) {
+  if (status === CodexReviewFallbackStatus.BLOCKED) {
+    return [
+      `- Blocker: \`${blocker || "codex_fallback_unavailable"}\``,
+      "",
+      "Gemini critical review is temporarily unavailable, and non-manual Codex fallback could not be started from the current repository/runtime configuration."
+    ];
+  }
+
+  if (status === CodexReviewFallbackStatus.COMPLETED) {
+    return [
+      `- Recommended action: \`${recommendedAction}\``,
+      "",
+      "### Critical Findings",
+      ...formatListOrFallback(criticalFindings, "- None reported."),
+      "",
+      "### Risks",
+      ...formatListOrFallback(risks, "- None reported."),
+      ...(rawReview
+        ? ["", "### Raw Codex Output", "", "```text", rawReview, "```"]
+        : [])
+    ];
+  }
+
+  return [
+    "Gemini critical review is temporarily unavailable.",
+    "Non-manual Codex fallback review has been dispatched through VTDD-managed workflow execution."
+  ];
+}
+
+function determineBlocking({ status, recommendedAction, blocker }) {
+  const normalizedStatus = normalizeFallbackStatus(status);
+  if (normalizedStatus === CodexReviewFallbackStatus.BLOCKED) {
+    return true;
+  }
+  if (normalizedStatus === CodexReviewFallbackStatus.REQUESTED) {
+    return true;
+  }
+  if (blocker) {
+    return true;
+  }
+  return normalizeText(recommendedAction) !== "approve";
+}
+
+function formatListOrFallback(values, fallbackLine) {
+  if (!Array.isArray(values) || values.length === 0) {
+    return [fallbackLine];
+  }
+  return values.map((value) => `- ${value}`);
+}
+
+function extractBacktickedValue(body, label) {
+  const pattern = new RegExp(`- ${escapeRegExp(label)}: \\\`([^\\\`]+)\\\``);
+  const match = body.match(pattern);
+  return normalizeText(match?.[1]);
+}
+
+function escapeRegExp(value) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function normalizeFallbackStatus(value) {
+  const normalized = normalizeText(value).toLowerCase();
+  return Object.values(CodexReviewFallbackStatus).includes(normalized) ? normalized : "";
+}
+
+function normalizeStringArray(value) {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.map(normalizeText).filter(Boolean);
 }
 
 function normalizeText(value) {

--- a/src/core/execution-continuity.js
+++ b/src/core/execution-continuity.js
@@ -125,24 +125,37 @@ function buildReviewState(pullRequest) {
   const parsedGeminiSignals = collectGeminiReviewerSignals(pullRequest);
   const codexFallback = collectCodexFallbackSignals(pullRequest);
   const reviewCommentsCount =
-    parsedGeminiSignals.totalCount > 0 ? parsedGeminiSignals.totalCount : pullRequest.reviewCommentsCount;
+    parsedGeminiSignals.totalCount > 0
+      ? parsedGeminiSignals.totalCount
+      : codexFallback.completed
+        ? 1
+        : pullRequest.reviewCommentsCount;
   const unresolvedReviewCommentsCount =
     parsedGeminiSignals.totalCount > 0
       ? parsedGeminiSignals.blockingCount
-      : pullRequest.unresolvedReviewCommentsCount;
-  const reviewerStatus = codexFallback.requested
-    ? "codex_review_requested"
-    : reviewCommentsCount > 0
-      ? "gemini_review_available"
-      : "review_unavailable";
-  const reviewer = reviewerStatus === "codex_review_requested" ? "codex" : pullRequest.reviewer;
+      : codexFallback.completed
+        ? (codexFallback.blocking ? 1 : 0)
+        : pullRequest.unresolvedReviewCommentsCount;
+  const reviewerStatus = codexFallback.completed
+    ? "codex_review_available"
+    : codexFallback.blocked
+      ? "codex_review_blocked"
+      : codexFallback.requested
+        ? "codex_review_requested"
+        : reviewCommentsCount > 0
+          ? "gemini_review_available"
+          : "review_unavailable";
+  const reviewer =
+    reviewerStatus.startsWith("codex_review") ? "codex" : pullRequest.reviewer;
   const criticalReviewPending =
     pullRequest.exists &&
     (reviewerStatus === "codex_review_requested" ||
+      reviewerStatus === "codex_review_blocked" ||
       (reviewCommentsCount > 0 && unresolvedReviewCommentsCount > 0));
   const rerunReviewer =
     pullRequest.exists &&
     reviewerStatus !== "codex_review_requested" &&
+    reviewerStatus !== "codex_review_blocked" &&
     (pullRequest.updatedSinceReview || unresolvedReviewCommentsCount > 0);
 
   return {
@@ -171,9 +184,13 @@ function collectGeminiReviewerSignals(pullRequest) {
 function collectCodexFallbackSignals(pullRequest) {
   const comments = [...(Array.isArray(pullRequest.issueComments) ? pullRequest.issueComments : [])];
   const parsed = comments.map(parseCodexReviewFallbackComment).filter(Boolean);
+  const latest = parsed.at(-1) ?? null;
 
   return {
-    requested: parsed.length > 0
+    requested: latest?.status === "requested",
+    completed: latest?.status === "completed",
+    blocked: latest?.status === "blocked",
+    blocking: latest?.blocking === true
   };
 }
 
@@ -194,6 +211,10 @@ function buildNextSuggestedActions({ pullRequest, review, codexGoal }) {
 
   if (review.reviewerStatus === "codex_review_requested") {
     return ["wait_for_codex_review", "summarize_for_human"];
+  }
+
+  if (review.reviewerStatus === "codex_review_blocked") {
+    return ["surface_reviewer_platform_blocker", "summarize_for_human"];
   }
 
   if (codexGoal === CodexGoal.REVISE_PR) {

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -160,6 +160,7 @@ export {
 } from "./gemini-pr-review.js";
 export {
   CODEX_REVIEW_FALLBACK_MARKER,
+  CodexReviewFallbackStatus,
   findExistingCodexReviewFallbackComment,
   formatCodexReviewFallbackComment,
   parseCodexReviewFallbackComment

--- a/test/butler-review-synthesis.test.js
+++ b/test/butler-review-synthesis.test.js
@@ -110,3 +110,34 @@ test("butler review synthesis surfaces Codex fallback review requests plainly", 
     true
   );
 });
+
+test("butler review synthesis surfaces Codex fallback blocker plainly", () => {
+  const result = buildButlerReviewSynthesis({
+    pullRequest: {
+      number: 84,
+      url: "https://github.com/example/repo/pull/84",
+      state: "open",
+      title: "No-manual reviewer fallback"
+    },
+    reviewLoop: {
+      reviewer: "codex",
+      reviewerStatus: "codex_review_blocked",
+      reviewCommentsCount: 0,
+      unresolvedReviewCommentsCount: 0,
+      criticalReviewPending: true
+    },
+    codexGoal: "wait_for_review",
+    nextSuggestedActions: ["surface_reviewer_platform_blocker", "summarize_for_human"]
+  });
+
+  assert.equal(
+    result.headline,
+    "PR #84 is open. Gemini is temporarily unavailable and non-manual Codex fallback is currently blocked by platform or repository configuration."
+  );
+  assert.equal(
+    result.humanDecisionFocus.includes(
+      "Gemini is temporarily unavailable and non-manual Codex fallback is blocked; do not treat reviewer coverage as satisfied."
+    ),
+    true
+  );
+});

--- a/test/codex-review-fallback.test.js
+++ b/test/codex-review-fallback.test.js
@@ -7,38 +7,78 @@ import {
   parseCodexReviewFallbackComment
 } from "../src/core/index.js";
 
-test("formatCodexReviewFallbackComment renders marker and @codex request", () => {
+test("formatCodexReviewFallbackComment renders marker and requested fallback state", () => {
   const body = formatCodexReviewFallbackComment({
+    status: "requested",
     trigger: "pull_request_target:synchronize",
     reason: "gemini_temporarily_unavailable"
   });
 
   assert.equal(body.includes(CODEX_REVIEW_FALLBACK_MARKER), true);
-  assert.equal(body.includes("@codex review"), true);
+  assert.equal(body.includes("- Status: `requested`"), true);
+  assert.equal(body.includes("workflow execution"), true);
   assert.equal(body.includes("gemini_temporarily_unavailable"), true);
 });
 
 test("findExistingCodexReviewFallbackComment locates prior fallback request", () => {
   const comment = findExistingCodexReviewFallbackComment([
     { id: 1, body: "ordinary comment" },
-    { id: 2, body: `${CODEX_REVIEW_FALLBACK_MARKER}\n@codex review` }
+    { id: 2, body: `${CODEX_REVIEW_FALLBACK_MARKER}\n- Status: \`requested\`` }
   ]);
 
   assert.deepEqual(comment, {
     id: 2,
-    body: `${CODEX_REVIEW_FALLBACK_MARKER}\n@codex review`
+    body: `${CODEX_REVIEW_FALLBACK_MARKER}\n- Status: \`requested\``
   });
 });
 
 test("parseCodexReviewFallbackComment exposes requested fallback reviewer state", () => {
-  const parsed = parseCodexReviewFallbackComment(`${CODEX_REVIEW_FALLBACK_MARKER}
-@codex review`);
+  const body = `${CODEX_REVIEW_FALLBACK_MARKER}
+- Status: \`requested\``;
+  const parsed = parseCodexReviewFallbackComment(body);
 
   assert.deepEqual(parsed, {
     reviewer: "codex",
     status: "requested",
+    blocking: true,
+    recommendedAction: null,
+    blocker: null,
+    body
+  });
+});
+
+test("parseCodexReviewFallbackComment exposes completed fallback reviewer state", () => {
+  const body = `${CODEX_REVIEW_FALLBACK_MARKER}
+## VTDD Codex Reviewer Fallback Request
+
+- Status: \`completed\`
+- Recommended action: \`approve\``;
+  const parsed = parseCodexReviewFallbackComment(body);
+
+  assert.deepEqual(parsed, {
+    reviewer: "codex",
+    status: "completed",
     blocking: false,
-    body: `${CODEX_REVIEW_FALLBACK_MARKER}
-@codex review`
+    recommendedAction: "approve",
+    blocker: null,
+    body
+  });
+});
+
+test("parseCodexReviewFallbackComment exposes blocked fallback reviewer state", () => {
+  const body = `${CODEX_REVIEW_FALLBACK_MARKER}
+## VTDD Codex Reviewer Fallback Request
+
+- Status: \`blocked\`
+- Blocker: \`openai_api_key_not_configured\``;
+  const parsed = parseCodexReviewFallbackComment(body);
+
+  assert.deepEqual(parsed, {
+    reviewer: "codex",
+    status: "blocked",
+    blocking: true,
+    recommendedAction: null,
+    blocker: "openai_api_key_not_configured",
+    body
   });
 });

--- a/test/e2e-25-reviewer-fallback-gemini-codex.test.js
+++ b/test/e2e-25-reviewer-fallback-gemini-codex.test.js
@@ -15,17 +15,16 @@ const MATRIX_PATH = path.join(process.cwd(), "docs", "mvp", "issue-to-e2e-matrix
 test("E2E-25 evidence doc records reviewer fallback runs", () => {
   const doc = fs.readFileSync(DOC_PATH, "utf8");
   assert.equal(doc.includes("`#74`"), true);
-  assert.equal(doc.includes("@codex review"), true);
+  assert.equal(doc.includes("request-state"), true);
   assert.equal(doc.includes("Gemini remains the primary reviewer"), true);
   assert.equal(doc.includes("does not overclaim"), true);
-  assert.equal(doc.includes("VTDD bot-authored `@codex review` request"), true);
-  assert.equal(doc.includes("solved no-manual fallback path on a live PR"), true);
+  assert.equal(doc.includes("request-state alone solves"), true);
   assert.equal(doc.includes("tracked by open Issue `#84`"), true);
 });
 
 test("issue-to-e2e matrix references E2E-25 run evidence", () => {
   const doc = fs.readFileSync(MATRIX_PATH, "utf8");
-  assert.equal(doc.includes("## E2E-25 Reviewer fallback from Gemini to Codex request"), true);
+  assert.equal(doc.includes("## E2E-25 Reviewer fallback request-state preservation"), true);
   assert.equal(doc.includes("docs/mvp/e2e/e2e-25-reviewer-fallback-gemini-codex.md"), true);
   assert.equal(doc.includes("- Issues: `#74`"), true);
 });

--- a/test/e2e-27-no-manual-codex-reviewer-fallback.test.js
+++ b/test/e2e-27-no-manual-codex-reviewer-fallback.test.js
@@ -1,0 +1,30 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const DOC_PATH = path.join(
+  process.cwd(),
+  "docs",
+  "mvp",
+  "e2e",
+  "e2e-27-no-manual-codex-reviewer-fallback.md"
+);
+const MATRIX_PATH = path.join(process.cwd(), "docs", "mvp", "issue-to-e2e-matrix.md");
+
+test("E2E-27 evidence doc records no-manual Codex fallback runs", () => {
+  const doc = fs.readFileSync(DOC_PATH, "utf8");
+  assert.equal(doc.includes("`#84`"), true);
+  assert.equal(doc.includes("non-manual Codex fallback workflow"), true);
+  assert.equal(doc.includes("requested"), true);
+  assert.equal(doc.includes("completed"), true);
+  assert.equal(doc.includes("blocked"), true);
+  assert.equal(doc.includes("manual PR-comment paste"), true);
+});
+
+test("issue-to-e2e matrix references E2E-27 run evidence", () => {
+  const doc = fs.readFileSync(MATRIX_PATH, "utf8");
+  assert.equal(doc.includes("## E2E-27 No-manual Codex reviewer fallback"), true);
+  assert.equal(doc.includes("docs/mvp/e2e/e2e-27-no-manual-codex-reviewer-fallback.md"), true);
+  assert.equal(doc.includes("- Issues: `#84`"), true);
+});

--- a/test/execution-continuity.test.js
+++ b/test/execution-continuity.test.js
@@ -128,7 +128,7 @@ test("execution continuity exposes Codex fallback requested when Gemini is tempo
           issueComments: [
             {
               user: { login: "vtdd-codex[bot]" },
-              body: "<!-- vtdd:reviewer=codex-fallback -->\n@codex review"
+              body: "<!-- vtdd:reviewer=codex-fallback -->\n- Status: `requested`"
             }
           ]
         }
@@ -142,4 +142,63 @@ test("execution continuity exposes Codex fallback requested when Gemini is tempo
   assert.equal(result.value.reviewLoop.criticalReviewPending, true);
   assert.equal(result.value.codexGoal, CodexGoal.WAIT_FOR_REVIEW);
   assert.deepEqual(result.value.nextSuggestedActions, ["wait_for_codex_review", "summarize_for_human"]);
+});
+
+test("execution continuity exposes Codex fallback review as available when VTDD posts a completed fallback comment", () => {
+  const result = evaluateExecutionContinuity({
+    actorRole: ActorRole.BUTLER,
+    mode: TaskMode.EXECUTION,
+    runtimeTruth: {
+      runtimeState: {
+        activeBranch: "codex/issue-84",
+        pullRequest: {
+          number: 84,
+          url: "https://github.com/example/repo/pull/84",
+          state: "open",
+          title: "No-manual reviewer fallback",
+          issueComments: [
+            {
+              user: { login: "vtdd-codex[bot]" },
+              body: "<!-- vtdd:reviewer=codex-fallback -->\n## VTDD Codex Reviewer Fallback Request\n\n- Status: `completed`\n- Recommended action: `approve`"
+            }
+          ]
+        }
+      }
+    }
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.value.reviewLoop.reviewer, "codex");
+  assert.equal(result.value.reviewLoop.reviewerStatus, "codex_review_available");
+  assert.equal(result.value.reviewLoop.criticalReviewPending, false);
+  assert.deepEqual(result.value.nextSuggestedActions, ["summarize_for_human", "wait_for_human_go"]);
+});
+
+test("execution continuity surfaces Codex fallback blocker when non-manual review cannot start", () => {
+  const result = evaluateExecutionContinuity({
+    actorRole: ActorRole.BUTLER,
+    mode: TaskMode.EXECUTION,
+    runtimeTruth: {
+      runtimeState: {
+        activeBranch: "codex/issue-84",
+        pullRequest: {
+          number: 84,
+          url: "https://github.com/example/repo/pull/84",
+          state: "open",
+          title: "No-manual reviewer fallback",
+          issueComments: [
+            {
+              user: { login: "vtdd-codex[bot]" },
+              body: "<!-- vtdd:reviewer=codex-fallback -->\n## VTDD Codex Reviewer Fallback Request\n\n- Status: `blocked`\n- Blocker: `openai_api_key_not_configured`"
+            }
+          ]
+        }
+      }
+    }
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.value.reviewLoop.reviewerStatus, "codex_review_blocked");
+  assert.equal(result.value.reviewLoop.criticalReviewPending, true);
+  assert.deepEqual(result.value.nextSuggestedActions, ["surface_reviewer_platform_blocker", "summarize_for_human"]);
 });

--- a/test/gemini-pr-review-workflow.test.js
+++ b/test/gemini-pr-review-workflow.test.js
@@ -3,6 +3,10 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 
 const workflow = fs.readFileSync(".github/workflows/gemini-pr-review.yml", "utf8");
+const fallbackWorkflow = fs.readFileSync(
+  ".github/workflows/codex-pr-review-fallback.yml",
+  "utf8"
+);
 
 test("Gemini review workflow skips when GitHub App secrets are not configured", () => {
   assert.equal(workflow.includes("name: Detect GitHub App secret availability"), true);
@@ -24,4 +28,19 @@ test("Gemini review workflow still routes reviewer execution through the script 
   assert.equal(workflow.includes("name: Run Gemini PR review"), true);
   assert.equal(workflow.includes("GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}"), true);
   assert.equal(workflow.includes("GEMINI_REVIEW_MODEL: ${{ vars.GEMINI_REVIEW_MODEL }}"), true);
+  assert.equal(workflow.includes("OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}"), true);
+  assert.equal(workflow.includes("pull-requests: write"), true);
+  assert.equal(workflow.includes("issues: write"), true);
+});
+
+test("Codex fallback workflow runs reviewer-only Codex CLI and writes back via GitHub App token", () => {
+  assert.equal(fallbackWorkflow.includes("name: codex-pr-review-fallback"), true);
+  assert.equal(fallbackWorkflow.includes("pull_request_number"), true);
+  assert.equal(fallbackWorkflow.includes("head_ref"), true);
+  assert.equal(fallbackWorkflow.includes("base_ref"), true);
+  assert.equal(fallbackWorkflow.includes("name: Install Codex CLI"), true);
+  assert.equal(fallbackWorkflow.includes("npm install -g @openai/codex"), true);
+  assert.equal(fallbackWorkflow.includes("run: node scripts/run-codex-pr-review-fallback.mjs"), true);
+  assert.equal(fallbackWorkflow.includes("OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}"), true);
+  assert.equal(fallbackWorkflow.includes("GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}"), true);
 });

--- a/test/gemini-pr-review-workflow.test.js
+++ b/test/gemini-pr-review-workflow.test.js
@@ -29,8 +29,9 @@ test("Gemini review workflow still routes reviewer execution through the script 
   assert.equal(workflow.includes("GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}"), true);
   assert.equal(workflow.includes("GEMINI_REVIEW_MODEL: ${{ vars.GEMINI_REVIEW_MODEL }}"), true);
   assert.equal(workflow.includes("OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}"), true);
-  assert.equal(workflow.includes("pull-requests: write"), true);
-  assert.equal(workflow.includes("issues: write"), true);
+  assert.equal(workflow.includes("contents: read"), true);
+  assert.equal(workflow.includes("pull-requests: write"), false);
+  assert.equal(workflow.includes("issues: write"), false);
 });
 
 test("Codex fallback workflow runs reviewer-only Codex CLI and writes back via GitHub App token", () => {

--- a/test/issue-to-e2e-matrix.test.js
+++ b/test/issue-to-e2e-matrix.test.js
@@ -34,7 +34,8 @@ test("issue-to-e2e matrix defines all canonical E2E tracks", () => {
     "E2E-23",
     "E2E-24",
     "E2E-25",
-    "E2E-26"
+    "E2E-26",
+    "E2E-27"
   ]) {
     assert.equal(doc.includes(`## ${id}`), true);
   }

--- a/test/reviewer-policy.test.js
+++ b/test/reviewer-policy.test.js
@@ -28,5 +28,6 @@ test("reviewer policy defines vendor-neutral contract and no execution authority
 test("reviewer policy does not overclaim no-manual Codex fallback", () => {
   const doc = fs.readFileSync(DOC_PATH, "utf8");
   assert.equal(doc.includes("bot-authored `@codex review` request"), true);
-  assert.equal(doc.includes("No-manual Codex fallback remains active work under `#84`"), true);
+  assert.equal(doc.includes("VTDD-managed workflow execution"), true);
+  assert.equal(doc.includes("manual PR comment paste as the normal"), true);
 });


### PR DESCRIPTION
## This PR satisfies Intent

- Implements Issue `#84` as a VTDD-managed no-manual reviewer fallback path when Gemini is temporarily unavailable.
- Preserves Gemini as the primary reviewer while replacing bot-authored `@codex review` fallback with workflow-dispatched critique-only Codex review or an explicit blocked state.

## Satisfied Success Criteria

- Gemini temporary unavailability now records a VTDD-managed fallback state instead of treating manual PR-comment paste as the normal answer.
- VTDD can dispatch a non-manual Codex fallback workflow that runs critique-only review and writes the result back through the GitHub App token path.
- Butler continuity and synthesis can distinguish `requested`, `completed`, and `blocked` Codex fallback states.
- Canonical reviewer docs and issue/E2E mapping now reflect the no-manual fallback path and its blocker boundary.
- Added mapped E2E evidence for Issue `#84` in `E2E-27`.

## Unsatisfied Success Criteria

- Live operator repositories still need their own `OPENAI_API_KEY` configured for the non-manual Codex fallback workflow to complete instead of surfacing the blocked state.
- This PR does not prove platform-native bot-authored `@codex review` equivalence; that remains explicitly unsupported.

## Non-goal violations

None.

## Verification Evidence

- Unit: `node --test test/codex-review-fallback.test.js test/gemini-review-failure.test.js test/gemini-pr-review.test.js test/execution-continuity.test.js test/butler-review-synthesis.test.js test/reviewer-policy.test.js`
- Integration: `node --test test/gemini-pr-review-workflow.test.js test/worker.test.js`
- E2E: `node --test test/e2e-25-reviewer-fallback-gemini-codex.test.js test/e2e-27-no-manual-codex-reviewer-fallback.test.js test/issue-to-e2e-matrix.test.js test/open-issue-current-reality-audit.test.js test/close-readiness-audit.test.js`
- Manual: None.
- Evidence path/link: `docs/mvp/e2e/e2e-27-no-manual-codex-reviewer-fallback.md`

## Related Constitution Rules

- Context-first VTDD review loop remains Gemini-primary and critique-only.
- Reviewer must not receive execution credentials, merge authority, or deployment authority.
- Manual PR-comment paste must not silently become the steady-state fallback answer.

## Out-of-scope but NOT implemented

- Natural-language Butler deploy orchestration beyond the governed deploy plane already landed under `#82`.
- Automatic resolution of operator-level reviewer credential provisioning.

## Extra changes (if any)

- Updated current-reality and close-readiness audits so `#84` is no longer described with stale pre-implementation wording.

<!-- VTDD metadata -->
- Issue: #84
- Execution ID: Not provided.
- Goal: no-manual Codex reviewer fallback
