### PR TITLE
Add Butler repository nickname registry

### DIFF
--- a/docs/butler/context-resolution.md
+++ b/docs/butler/context-resolution.md
@@ -37,6 +37,23 @@ Alias records may include:
 - nicknames
 - short description
 
+User-defined repository nicknames are valid alias-registry inputs.
+
+When the user explicitly says things like:
+
+- `この repo は 公開VTDD って呼んで`
+- `vtdd-v2-p を VTDD公開版 で覚えて`
+
+Butler should persist that nickname through the runtime nickname registry rather
+than treating it as temporary session-only wording.
+
+Persistent nickname recall must still preserve repository safety:
+
+- nickname storage does not create a default repository
+- ambiguous nickname matches must block execution and ask for confirmation
+- Butler should prefer canonical repository readback when showing what a saved
+  nickname currently resolves to
+
 ## Repository Safety Rule
 
 Butler must not assume a default repository.

--- a/docs/mvp/close-readiness-audit.md
+++ b/docs/mvp/close-readiness-audit.md
@@ -13,19 +13,16 @@ For the broader open-issue vs current-reality mismatch inventory, also read:
 
 ## Current Human-judgment / Parent / Historical Issues
 
-- `#80` self-parity natural-language trigger improvement
-- `#82` governed stale-parity production deploy
 - `#4` current loop parent
-- `#6` historical execution-slice issue
 
 The following open issues are intentionally not treated as close-readiness-only
 items here because they still represent active implementation/spec work:
 
-- `#84`
-  - current reading: runtime/docs progress exists for VTDD-managed non-manual
-    fallback workflow dispatch and explicit blocked-state signaling
-  - keep open until the owner judges whether that path is an acceptable
-    no-manual fallback answer
+- `#89`
+  - current reading: active implementation is still required for persistent
+    user-defined repository nicknames
+  - keep open until runtime/docs/E2E for nickname storage and safe resolution
+    land on `main`
 
 ## Current Reading
 
@@ -38,55 +35,6 @@ It should remain open while:
 - the owner still wants one live parent for runtime-loop judgment
 - loop-level completion or authority wording may still be refined
 - child execution/reviewer/synthesis slices are still being reviewed for final closure
-
-### `#6`
-
-`#6` remains a historical execution-slice issue.
-It should not compete with `#4` as a current parent authority.
-Its execution-spine behavior is already directly evidenced through `E2E-19`.
-It may remain open as comparison context or be closed when the owner is
-satisfied that:
-
-- `#4` and current canonical docs fully cover the current loop authority
-- the historical execution-spine role of `#6` no longer needs to remain visible
-  in the open set
-
-### `#80`
-
-`#80` has merged implementation progress for self-reference and natural
-self-parity trigger mapping.
-
-It may be close-ready if the owner agrees that:
-
-- the merged Instructions path is sufficient for the desired Butler self-parity
-  behavior
-- any remaining self-parity confusion is now implementation drift elsewhere,
-  not missing `#80` scope
-
-Keep it open if:
-
-- the owner still sees meaningful gaps in Butler self-reference / update-check
-  handling that belong to `#80` itself
-- follow-up behavior changes are expected before judging the issue complete
-
-### `#82`
-
-`#82` now has merged/runtime progress for governed deploy dispatch plus
-same-origin passkey-operator execution evidence.
-
-It may be close-ready if the owner agrees that:
-
-- stale parity can now advance into an iPhone-usable governed deploy path
-- `GO + real passkey` remains explicit and approval-bound
-- any remaining deploy confusion is now drift or operator setup outside `#82`
-  rather than missing deploy-orchestration scope
-
-Keep it open if:
-
-- the owner still sees meaningful gaps in Butler deploy guidance or
-  passkey-operator execution for mobile deploy recovery
-- additional Butler-side natural-language deploy handling is expected before
-  judging the issue complete
 
 ## Non-claim
 

--- a/docs/mvp/e2e/e2e-28-repository-nickname-context-resolution.md
+++ b/docs/mvp/e2e/e2e-28-repository-nickname-context-resolution.md
@@ -1,0 +1,68 @@
+# E2E-28 Repository Nickname Context Resolution
+
+This document records concrete run evidence for the E2E-28 track.
+
+## Scope
+
+Issues:
+- `#89`
+- parent anchor: `#4`
+
+Goal:
+- confirm Butler can persist explicit user-defined repository nicknames at runtime
+- confirm stored nicknames are merged with the GitHub App live repository index
+- confirm Butler can resolve those nicknames without weakening `no default repository`
+- confirm ambiguous nickname matches remain blocking instead of silently executing against the wrong repository
+
+## Happy-path Run
+
+Command:
+
+```sh
+node --test test/repository-nickname-registry.test.js test/worker.test.js test/core-policy.test.js test/custom-gpt-setup-docs.test.js
+```
+
+Observed result on 2026-04-27:
+- passed
+- confirms Butler can store explicit repository nicknames such as `公開VTDD`
+- confirms stored nickname records are returned through `/v2/retrieve/repository-nicknames`
+- confirms gateway resolution can merge stored nicknames with the live GitHub App repository index and resolve `公開VTDD` back to `marushu/vtdd-v2-p`
+- confirms Custom GPT docs now expose the canonical nickname save/read operations
+
+## Boundary-path Run
+
+Command:
+
+```sh
+node --test test/repository-nickname-registry.test.js test/core-policy.test.js test/worker.test.js
+```
+
+Observed result on 2026-04-27:
+- passed
+- confirms nickname writes are rejected when the target repository cannot be resolved against the full live alias registry
+- confirms ambiguous nickname matches remain blocking and surface `target repository nickname is ambiguous`
+- confirms execution mode still blocks unresolved/ambiguous nickname targets rather than reintroducing a default repository
+
+## Evidence Files
+
+- `src/core/repository-nickname-registry.js`
+- `src/core/repository-resolution.js`
+- `src/core/github-app-repository-index.js`
+- `src/worker.js`
+- `docs/butler/context-resolution.md`
+- `docs/setup/custom-gpt-actions-openapi.yaml`
+- `docs/setup/custom-gpt-instructions.md`
+- `test/repository-nickname-registry.test.js`
+- `test/core-policy.test.js`
+- `test/worker.test.js`
+- `test/custom-gpt-setup-docs.test.js`
+
+## Current Reading
+
+E2E-28 now has recorded happy-path and boundary-path run evidence in-repo.
+
+This confirms Issue `#89` is connected to a runtime nickname path that makes
+Butler more operator-friendly without weakening the `no default repository`
+invariant. It does not claim free-form natural language will always resolve
+without ambiguity, nor that nickname memory overrides canonical repository
+confirmation for risky execution.

--- a/docs/mvp/issue-to-e2e-matrix.md
+++ b/docs/mvp/issue-to-e2e-matrix.md
@@ -559,6 +559,30 @@ Status values used below:
   - `docs/mvp/e2e/e2e-27-no-manual-codex-reviewer-fallback.md`
 - Status: `e2e_evidenced_pending_human_closure`
 
+## E2E-28 Repository nickname context resolution
+
+- Issues: `#89`
+- Happy path:
+  - Butler can persist an explicit user-defined repository nickname, retrieve it later, and resolve it through the live GitHub App repository index without requiring the owner to repeat the full canonical `owner/repo`
+- Boundary path:
+  - ambiguous or unresolved nickname matches remain blocking and do not silently weaken `no default repository`
+- Implementation evidence:
+  - `src/core/repository-nickname-registry.js`
+  - `src/core/repository-resolution.js`
+  - `src/core/github-app-repository-index.js`
+  - `src/worker.js`
+  - `docs/butler/context-resolution.md`
+  - `docs/setup/custom-gpt-actions-openapi.yaml`
+  - `docs/setup/custom-gpt-instructions.md`
+- Test evidence:
+  - `test/repository-nickname-registry.test.js`
+  - `test/core-policy.test.js`
+  - `test/worker.test.js`
+  - `test/custom-gpt-setup-docs.test.js`
+- Run evidence:
+  - `docs/mvp/e2e/e2e-28-repository-nickname-context-resolution.md`
+- Status: `e2e_evidenced_pending_human_closure`
+
 ## E2E-26 Governed production deploy from passkey operator
 
 - Issues: `#82`

--- a/docs/mvp/issue-triage-plan.md
+++ b/docs/mvp/issue-triage-plan.md
@@ -12,11 +12,11 @@ As of 2026-04-27:
 - the major triage/creation wave has already been executed
 - `#13` has already been rewritten as the MVP execution anchor
 - `#4` is the current parent contract for the Butler-Codex-Gemini loop
-- `#6` remains a historical execution-slice and must not compete with `#4` as a parent authority
+- `#6` has been closed as historical execution-slice context and must not be
+  re-opened as a competing parent authority
 - the repository now has broad runtime + contract coverage, but overall status is still `partial / in-progress`
-- the remaining work is not only close-readiness; it also includes active
-  deploy-orchestration work (`#82`) and active reviewer-fallback boundary work
-  (`#84`)
+- the remaining active implementation work is now repository nickname/context
+  resolution improvement (`#89`)
 
 ## Compatibility Notes for Historical `#1-#20`
 
@@ -57,8 +57,8 @@ The following historical directions were already resolved into the current repo 
 - role separation was split out and implemented
 - setup / deploy / guarded absence / reviewer / bootstrap follow-up issues were created as needed
 - newer follow-up issues such as `#80`, `#82`, and `#84` must be read directly
-  from their current GitHub text rather than inferred from this historical
-  triage file
+  from their historical GitHub text rather than inferred from this historical
+  triage file; the current active follow-up is `#89`
 
 ## Completion Reminder
 

--- a/docs/mvp/open-issue-current-reality-audit.md
+++ b/docs/mvp/open-issue-current-reality-audit.md
@@ -19,60 +19,30 @@ It exists to prevent drift between:
 The repository has broad implementation and mapped E2E coverage across the
 main-line runtime.
 
-However, the open issue set now contains four different kinds of items:
+However, the open issue set now contains three different kinds of items:
 
 1. current active implementation work
-2. current active spec / boundary-definition work
-3. open issues whose implementation landed and are now mainly waiting on human
+2. open issues whose implementation landed and are now mainly waiting on human
    closure judgment
-4. historical/context issues that remain open for human judgment rather than
+3. historical/context issues that remain open for human judgment rather than
    active implementation
 
 ## Current Active Implementation Issues
 
-- none at the moment
-
-## Current Active Implementation / Boundary Issues
-
-- `#84`
-  - runtime/docs progress now exists for VTDD-managed no-manual Codex fallback
-    workflow dispatch plus explicit blocked-state handling
-  - current reading: bot-authored `@codex review` fallback is not equivalent to
-    owner-authored Codex invocation
-  - manual copy-paste fallback is explicitly not the desired steady-state
-    answer
-  - remaining work is no longer "missing design from scratch"; it is human
-    judgment on whether the VTDD-managed workflow path is the acceptable
-    no-manual fallback answer
+- `#89`
+  - current reading: user-defined repository nickname support is the new active
+    implementation slice
+  - existing alias/context-first resolution already works, but Butler still
+    lacks a persistent user-owned nickname registry for repo calls such as
+    `公開VTDD`
+  - this remains active runtime/docs/E2E work rather than closure judgment
 
 ## Open Issues With Merged Runtime / Docs Progress And Likely Human Closure Work
 
-- `#80`
-  - merged via PR `#81`
-  - current reading: self-reference and natural self-parity trigger mapping are
-    implemented; remaining work is mainly human closure judgment unless new
-    gaps are found
-- `#82`
-  - merged/runtime progress exists through PRs `#83`, `#85`, and `#87`
-  - current reading: governed deploy plane, self-parity manifest alignment, and
-    same-origin passkey-operator deploy dispatch are implemented with mapped
-    E2E evidence; remaining work is mainly human closure judgment unless new
-    mobile deploy gaps are found
 - `#4`
   - mapped by `E2E-19`
   - current reading: remains the live parent authority for the
     Butler-Codex-Gemini loop
-
-## Historical / Human-Judgment Open Issue
-
-- `#6`
-
-Current reading:
-- `#6` is historical execution-spine context
-- `#4` is the current parent authority for the loop
-- `#6` should not be treated as the current implementation parent
-- `#6` is directly evidenced through `E2E-19`, but should still be judged as
-  historical context rather than a competing live parent
 
 ## Resolved Drift Already Observed
 
@@ -81,24 +51,21 @@ The following older readings must not be reintroduced:
 - treating `#13` as a currently open issue
 - treating `#1` as a currently open issue
 - treating `#6` as the current parent authority for the loop
+- treating closed issue `#6` as still-open implementation uncertainty
+- treating closed issues `#80`, `#82`, and `#84` as still-open active work
 - treating closed reviewer-fallback issue `#74` as proof that no-manual Codex
   fallback is already solved
 - treating open issue count alone as proof that major runtime work is still
   unimplemented
-- treating no-manual reviewer fallback as solved while `#84` remains active
 
 ## Recommended Next Step
 
 The next highest-value cleanup is:
 
-- keep `#84` visible as a boundary-sensitive open issue even after runtime/docs
-  progress lands, because owner judgment is still needed on the no-manual
-  fallback answer
-- decide whether `#80`, `#82`, and `#84` are ready for human closure judgment
-- keep `#6` separate as historical/human-judgment context rather than treating
-  it as active implementation uncertainty
+- implement `#89` without weakening `no default repository`
+- keep `#4` as the live parent contract while child slices continue landing
 
 The repository still has broad runnable coverage, but the remaining drift is no
-longer only at the owner close-readiness layer; it now concentrates mainly on
-judging whether the VTDD-managed no-manual reviewer-fallback path for `#84`
-meets the intended operational bar.
+longer concentrated on reviewer/deploy rescue slices. It is now concentrated on
+making Butler's repository context resolution more operator-friendly without
+reintroducing default-repository risk.

--- a/docs/mvp/owner-closure-guide.md
+++ b/docs/mvp/owner-closure-guide.md
@@ -6,50 +6,29 @@ are plausible human closure candidates.
 It does not authorize automatic closure.
 It exists so the owner can close or keep open each issue deliberately.
 
-## Issue `#80`
+## Issue `#89`
 
 ### Recommended reading
 
-`#80` is the strongest current non-parent close candidate.
+`#89` is the current active non-parent implementation issue.
 
 Why:
-- merged implementation exists via PR `#81`
-- the Butler Instructions now include the self-reference and natural
-  self-parity mapping added for this issue
-- current remaining friction is more strongly tied to deploy/runtime drift or
-  active fallback design than to `#80`'s core intent
+- Butler already has alias/context-first repository resolution
+- the remaining friction is user-owned nickname persistence and recall, not
+  loop/reviewer/deploy foundations
+- this issue is the current place to improve repo naming UX without weakening
+  `no default repository`
 
 ### Close only if the owner agrees all of these are true
 
-- `#80` has finished serving as the self-reference / natural self-parity
-  improvement issue
-- no additional behavior in that specific slice still needs to land before the
-  owner is comfortable closing it
+- user-defined repository nickname storage and retrieval are merged
+- Butler can safely resolve those nicknames in practice
+- no meaningful gap remains in this specific nickname slice
 
 ### Keep open if any of these are still useful
 
-- the owner still sees unresolved behavior that belongs to self-reference or
-  natural self-parity mapping itself
-- the owner wants to validate that behavior in more live iPhone Butler use
-  before closing
-
-## Issue `#6`
-
-### Recommended reading
-
-`#6` is historical execution-transport context.
-It is not the current parent authority anymore; `#4` now holds that role.
-The underlying execution-spine behavior is already evidenced through `E2E-19`.
-
-### Close only if the owner agrees all of these are true
-
-- `#4` and current canonical docs fully supersede the current authority role `#6` once approximated
-- the owner no longer needs `#6` as a historical execution-spine marker
-
-### Keep open if any of these are still useful
-
-- the owner wants to preserve historical comparison context in the open set for now
-- there is still value in explicitly seeing the earlier execution-spine slice while final parent/spec cleanup is underway
+- the owner still sees Butler forcing too much canonical owner/repo spelling
+- nickname persistence, retrieval, or ambiguity handling still needs work
 
 ## Issue `#4`
 
@@ -68,7 +47,7 @@ The underlying execution-spine behavior is already evidenced through `E2E-19`.
 
 - the owner wants one still-open parent issue for the loop
 - parent-level wording or acceptance boundaries may still be refined while
-  `#82` and `#84` are active
+  `#89` is active
 
 ## Non-claim
 

--- a/docs/setup/custom-gpt-actions-openapi.json
+++ b/docs/setup/custom-gpt-actions-openapi.json
@@ -991,6 +991,82 @@
         }
       }
     },
+    "/v2/action/repository-nickname": {
+      "post": {
+        "operationId": "vtddUpsertRepositoryNickname",
+        "summary": "Save or update a user-defined repository nickname in the VTDD alias registry.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "repository": {
+                    "type": "string"
+                  },
+                  "nickname": {
+                    "type": "string"
+                  },
+                  "nicknames": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "mode": {
+                    "type": "string",
+                    "enum": [
+                      "append",
+                      "replace"
+                    ]
+                  }
+                },
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Repository nickname persisted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VtddGenericResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing machine auth"
+          },
+          "403": {
+            "description": "Invalid machine auth"
+          },
+          "422": {
+            "description": "Repository nickname request blocked or invalid",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VtddGenericResponse"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Repository nickname persistence unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VtddGenericResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v2/retrieve/setup-artifact": {
       "get": {
         "operationId": "vtddRetrieveSetupArtifact",
@@ -1107,6 +1183,40 @@
           },
           "503": {
             "description": "Butler self-parity evaluation unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VtddGenericResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/retrieve/repository-nicknames": {
+      "get": {
+        "operationId": "vtddRetrieveRepositoryNicknames",
+        "summary": "Read stored user-defined repository nicknames from the VTDD alias registry.",
+        "responses": {
+          "200": {
+            "description": "Repository nickname registry retrieval result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VtddGenericResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing machine auth"
+          },
+          "403": {
+            "description": "Invalid machine auth"
+          },
+          "503": {
+            "description": "Repository nickname retrieval unavailable",
             "content": {
               "application/json": {
                 "schema": {

--- a/docs/setup/custom-gpt-actions-openapi.yaml
+++ b/docs/setup/custom-gpt-actions-openapi.yaml
@@ -498,6 +498,54 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/VtddGenericResponse"
+  /v2/action/repository-nickname:
+    post:
+      operationId: vtddUpsertRepositoryNickname
+      summary: Save or update a user-defined repository nickname in the VTDD alias registry.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                repository:
+                  type: string
+                nickname:
+                  type: string
+                nicknames:
+                  type: array
+                  items:
+                    type: string
+                mode:
+                  type: string
+                  enum:
+                    - append
+                    - replace
+              additionalProperties: true
+      responses:
+        "200":
+          description: Repository nickname persisted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VtddGenericResponse"
+        "401":
+          description: Missing machine auth
+        "403":
+          description: Invalid machine auth
+        "422":
+          description: Repository nickname request blocked or invalid
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VtddGenericResponse"
+        "503":
+          description: Repository nickname persistence unavailable
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VtddGenericResponse"
   /v2/action/progress:
     get:
       operationId: vtddExecutionProgress
@@ -614,6 +662,27 @@ paths:
                 $ref: "#/components/schemas/VtddGenericResponse"
         "503":
           description: GitHub read route unavailable
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VtddGenericResponse"
+  /v2/retrieve/repository-nicknames:
+    get:
+      operationId: vtddRetrieveRepositoryNicknames
+      summary: Read stored user-defined repository nicknames from the VTDD alias registry.
+      responses:
+        "200":
+          description: Repository nickname registry retrieval result
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VtddGenericResponse"
+        "401":
+          description: Missing machine auth
+        "403":
+          description: Invalid machine auth
+        "503":
+          description: Repository nickname retrieval unavailable
           content:
             application/json:
               schema:

--- a/docs/setup/custom-gpt-instructions.md
+++ b/docs/setup/custom-gpt-instructions.md
@@ -53,6 +53,12 @@ Repository listing and context resolution:
   - policyInput.runtimeTruth.safeFallbackChosen=true
   - policyInput.consent.grantedCategories=["read"]
 - Read repositoryCandidates from the response and present them in human-friendly Japanese.
+- If the user wants Butler to remember a repository nickname, use vtddUpsertRepositoryNickname.
+- If the user asks what repository nicknames Butler already knows, use vtddRetrieveRepositoryNicknames.
+- Repository nickname writes must stay explicit:
+  - resolve the target repository first
+  - preserve canonical owner/repo as the execution target of record
+  - do not invent a default repository from nickname memory alone
 
 GitHub runtime truth read plane:
 - When the user asks Butler to read GitHub runtime truth directly, use vtddRetrieveGitHub.
@@ -80,6 +86,17 @@ GitHub runtime truth read plane:
 - If the route returns unsupported, answer that the current Butler surface is未対応 for that exact read.
 - If the route returns unauthorized or invalid machine auth, answer that the read failed due to 認証失敗.
 - Do not infer "Issue may not exist" or similar from an unsupported or failed read.
+
+Repository nickname memory:
+- Use vtddUpsertRepositoryNickname when the user says things like:
+  - `この repo を 公開VTDD って呼ぶことにして`
+  - `vtdd-v2-p に nickname を付けて`
+  - `このリポジトリを 公開版VTDD として覚えて`
+- Use vtddRetrieveRepositoryNicknames when the user asks:
+  - `覚えている repo nickname 一覧を見せて`
+  - `この GPT が覚えている repo の呼び名は？`
+- Nickname memory is explicit user-owned alias registry data, not permission to assume a default repository.
+- If nickname resolution is ambiguous, say so plainly and ask a short confirmation before execution.
 
 Butler self-parity and setup artifact recovery:
 - When the user asks whether Butler itself is stale, outdated, or misaligned with the repository/runtime, use vtddRetrieveSelfParity.

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -51,6 +51,13 @@ export {
 } from "./cloudflare-deploy-secret-sync.js";
 export { requiredCredentialTier, evaluateCredentialBoundary } from "./credential-boundary.js";
 export { resolveRepositoryTarget } from "./repository-resolution.js";
+export {
+  RepositoryNicknameMode,
+  mergeAliasRegistries,
+  normalizeAliasRegistry,
+  retrieveStoredAliasRegistry,
+  upsertRepositoryNickname
+} from "./repository-nickname-registry.js";
 export { evaluateTargetConfirmationBoundary } from "./target-confirmation.js";
 export { evaluateRoleBoundary } from "./role-boundary.js";
 export { evaluateRuntimeTruthPrecondition } from "./runtime-truth.js";

--- a/src/core/repository-nickname-registry.js
+++ b/src/core/repository-nickname-registry.js
@@ -1,0 +1,231 @@
+import { MemoryRecordType } from "./memory-schema.js";
+import { validateMemoryProvider } from "./memory-provider.js";
+
+export const RepositoryNicknameMode = Object.freeze({
+  APPEND: "append",
+  REPLACE: "replace"
+});
+
+export async function retrieveStoredAliasRegistry(provider) {
+  const validation = validateMemoryProvider(provider);
+  if (!validation.ok) {
+    return {
+      ok: false,
+      status: 503,
+      error: "memory_provider_unavailable",
+      reason: "valid memory provider is required for repository nickname retrieval"
+    };
+  }
+
+  const records = await provider.retrieve({
+    type: MemoryRecordType.ALIAS_REGISTRY,
+    limit: 200
+  });
+
+  return {
+    ok: true,
+    aliasRegistry: normalizeAliasRegistry(records.map((record) => record?.content)),
+    records
+  };
+}
+
+export async function upsertRepositoryNickname(input = {}) {
+  const provider = input.provider;
+  const validation = validateMemoryProvider(provider);
+  if (!validation.ok) {
+    return {
+      ok: false,
+      status: 503,
+      error: "memory_provider_unavailable",
+      reason: "valid memory provider is required for repository nickname persistence"
+    };
+  }
+
+  const registry = normalizeAliasRegistry(input.aliasRegistry);
+  const repositoryInput = normalizeCanonicalRepo(input.repository);
+  if (!repositoryInput) {
+    return {
+      ok: false,
+      status: 422,
+      error: "repository_nickname_request_invalid",
+      issues: ["repository must be a canonical owner/repo string"]
+    };
+  }
+
+  const registryRecord = registry.find((item) => item.canonicalRepo === repositoryInput);
+  if (!registryRecord) {
+    return {
+      ok: false,
+      status: 422,
+      error: "repository_nickname_request_invalid",
+      issues: ["repository must resolve from the current alias registry before nickname write"]
+    };
+  }
+
+  const mode = normalizeNicknameMode(input.mode);
+  if (!mode) {
+    return {
+      ok: false,
+      status: 422,
+      error: "repository_nickname_request_invalid",
+      issues: ["mode must be append or replace"]
+    };
+  }
+
+  const nextNicknames = normalizeAliasList(input.nicknames ?? [input.nickname]);
+  if (nextNicknames.length === 0) {
+    return {
+      ok: false,
+      status: 422,
+      error: "repository_nickname_request_invalid",
+      issues: ["at least one nickname is required"]
+    };
+  }
+
+  const stored = await retrieveStoredAliasRegistry(provider);
+  if (!stored.ok) {
+    return stored;
+  }
+
+  const existing = stored.aliasRegistry.find((item) => item.canonicalRepo === repositoryInput);
+  const aliases =
+    mode === RepositoryNicknameMode.REPLACE
+      ? nextNicknames
+      : mergeAliasList(existing?.aliases, nextNicknames);
+
+  const record = {
+    id: buildRepositoryNicknameRecordId(repositoryInput),
+    type: MemoryRecordType.ALIAS_REGISTRY,
+    content: {
+      canonicalRepo: repositoryInput,
+      productName: existing?.productName ?? registryRecord.productName ?? null,
+      visibility: registryRecord.visibility ?? existing?.visibility ?? "unknown",
+      aliases
+    },
+    metadata: {
+      canonicalRepo: repositoryInput,
+      source: "user_defined_repository_nickname",
+      mode
+    },
+    priority: 60,
+    tags: ["alias_registry", repositoryInput, "repository_nickname"],
+    createdAt: new Date().toISOString()
+  };
+
+  if (typeof provider.deleteRecords === "function") {
+    await provider.deleteRecords({ ids: [record.id] });
+  }
+
+  const persisted = await provider.store(record);
+  if (!persisted?.ok) {
+    return {
+      ok: false,
+      status: 503,
+      error: "memory_write_failed",
+      reason: "failed to persist repository nickname"
+    };
+  }
+
+  return {
+    ok: true,
+    record: persisted.record,
+    aliasEntry: record.content
+  };
+}
+
+export function mergeAliasRegistries(...groups) {
+  const byCanonical = new Map();
+
+  for (const group of groups) {
+    for (const record of normalizeAliasRegistry(group)) {
+      const existing = byCanonical.get(record.canonicalRepo);
+      if (!existing) {
+        byCanonical.set(record.canonicalRepo, record);
+        continue;
+      }
+
+      byCanonical.set(record.canonicalRepo, {
+        canonicalRepo: record.canonicalRepo,
+        productName: existing.productName ?? record.productName ?? null,
+        visibility: existing.visibility !== "unknown" ? existing.visibility : record.visibility,
+        aliases: mergeAliasList(existing.aliases, record.aliases)
+      });
+    }
+  }
+
+  return [...byCanonical.values()].sort((a, b) => a.canonicalRepo.localeCompare(b.canonicalRepo));
+}
+
+export function normalizeAliasRegistry(records) {
+  if (!Array.isArray(records)) {
+    return [];
+  }
+
+  return records
+    .map((item) => {
+      const canonicalRepo = normalizeCanonicalRepo(item?.canonicalRepo);
+      if (!canonicalRepo) {
+        return null;
+      }
+
+      return {
+        canonicalRepo,
+        productName: normalizeOptionalText(item?.productName),
+        visibility: normalizeVisibility(item?.visibility),
+        aliases: normalizeAliasList(item?.aliases)
+      };
+    })
+    .filter(Boolean);
+}
+
+function buildRepositoryNicknameRecordId(canonicalRepo) {
+  return `alias_registry:${canonicalRepo}`;
+}
+
+function normalizeNicknameMode(value) {
+  const normalized = normalizeOptionalText(value)?.toLowerCase() || RepositoryNicknameMode.APPEND;
+  return Object.values(RepositoryNicknameMode).includes(normalized) ? normalized : "";
+}
+
+function mergeAliasList(...groups) {
+  const deduped = new Map();
+  for (const group of groups) {
+    for (const alias of normalizeAliasList(group)) {
+      const key = alias.toLowerCase().replace(/[^a-z0-9\u3040-\u30ff\u4e00-\u9faf]+/g, "");
+      if (!key || deduped.has(key)) {
+        continue;
+      }
+      deduped.set(key, alias);
+    }
+  }
+  return [...deduped.values()];
+}
+
+function normalizeAliasList(value) {
+  if (!Array.isArray(value)) {
+    return normalizeOptionalText(value) ? [normalizeOptionalText(value)] : [];
+  }
+
+  return value.map(normalizeOptionalText).filter(Boolean);
+}
+
+function normalizeCanonicalRepo(value) {
+  const normalized = normalizeOptionalText(value)?.toLowerCase() || "";
+  if (!normalized.includes("/")) {
+    return "";
+  }
+  return normalized;
+}
+
+function normalizeVisibility(value) {
+  const normalized = normalizeOptionalText(value)?.toLowerCase() || "unknown";
+  if (["public", "private", "internal"].includes(normalized)) {
+    return normalized;
+  }
+  return "unknown";
+}
+
+function normalizeOptionalText(value) {
+  const text = String(value ?? "").trim();
+  return text.length > 0 ? text : "";
+}

--- a/src/core/repository-resolution.js
+++ b/src/core/repository-resolution.js
@@ -29,21 +29,33 @@ export function resolveRepositoryTarget({ input, mode, aliasRegistry }) {
     }
   }
 
+  const aliasMatches = [];
   for (const record of registry) {
     const names = [record.productName, ...(record.aliases ?? [])].map(normalize).filter(Boolean);
     if (names.includes(normalizedInput)) {
-      return { resolved: true, repository: record.canonicalRepo, via: "alias" };
+      aliasMatches.push(record.canonicalRepo);
     }
+  }
+
+  if (aliasMatches.length === 1) {
+    return { resolved: true, repository: aliasMatches[0], via: "alias" };
+  }
+
+  if (aliasMatches.length > 1) {
+    return unresolved(mode, "target repository nickname is ambiguous", {
+      ambiguous: true,
+      candidates: aliasMatches
+    });
   }
 
   return unresolved(mode, "target repository could not be resolved from alias registry");
 }
 
-function unresolved(mode, reason) {
+function unresolved(mode, reason, detail = {}) {
   if (mode === TaskMode.READ_ONLY) {
-    return { resolved: false, safeToProceedReadOnly: true, reason };
+    return { resolved: false, safeToProceedReadOnly: true, reason, ...detail };
   }
-  return { resolved: false, safeToProceedReadOnly: false, reason };
+  return { resolved: false, safeToProceedReadOnly: false, reason, ...detail };
 }
 
 function normalize(value) {

--- a/src/worker.js
+++ b/src/worker.js
@@ -25,11 +25,17 @@ import {
   retrieveConstitution,
   retrieveCustomGptSetupArtifact,
   renderPasskeyOperatorPage,
+  RepositoryNicknameMode,
   resolveGatewayAliasRegistryFromGitHubApp,
+  resolveRepositoryTarget,
   GitHubHighRiskOperation,
+  mergeAliasRegistries,
+  retrieveStoredAliasRegistry,
   retrieveGitHubReadPlane,
+  TaskMode,
   executeGitHubWritePlane,
   runMvpGateway,
+  upsertRepositoryNickname,
   validateMemoryProvider,
   verifyPasskeyApproval,
   verifyPasskeyRegistration
@@ -190,6 +196,23 @@ export default {
       }
 
       return handleDeployProductionRequest(request, env);
+    }
+
+    if (request.method === "POST" && isApiPath(url.pathname, "/action/repository-nickname")) {
+      const auth = authorizeGatewayRequest({
+        request,
+        env,
+        apiSuffix: "/action/repository-nickname"
+      });
+      if (!auth.ok) {
+        return json(auth.status, {
+          ok: false,
+          error: "unauthorized",
+          reason: auth.reason
+        });
+      }
+
+      return handleRepositoryNicknameUpsertRequest(request, env);
     }
 
     if (request.method === "GET" && isApiPath(url.pathname, "/action/progress")) {
@@ -385,6 +408,22 @@ export default {
         });
       }
       return handleRetrieveButlerSelfParityRequest(url, env);
+    }
+
+    if (request.method === "GET" && isApiPath(url.pathname, "/retrieve/repository-nicknames")) {
+      const auth = authorizeGatewayRequest({
+        request,
+        env,
+        apiSuffix: "/retrieve/repository-nicknames"
+      });
+      if (!auth.ok) {
+        return json(auth.status, {
+          ok: false,
+          error: "unauthorized",
+          reason: auth.reason
+        });
+      }
+      return handleRetrieveRepositoryNicknamesRequest(env);
     }
 
     return json(404, {
@@ -640,6 +679,25 @@ async function handleRetrieveButlerSelfParityRequest(url, env) {
   });
 }
 
+async function handleRetrieveRepositoryNicknamesRequest(env) {
+  const provider = resolveMemoryProvider(env);
+  const retrieved = await retrieveStoredAliasRegistry(provider);
+  if (!retrieved.ok) {
+    return json(retrieved.status ?? 503, {
+      ok: false,
+      error: retrieved.error,
+      reason: retrieved.reason
+    });
+  }
+
+  return json(200, {
+    ok: true,
+    recordType: MemoryRecordType.ALIAS_REGISTRY,
+    recordCount: retrieved.aliasRegistry.length,
+    aliasRegistry: retrieved.aliasRegistry
+  });
+}
+
 async function handleGitHubWritePlaneRequest(request, env) {
   const payload = await readJson(request);
   if (!payload || typeof payload !== "object") {
@@ -886,8 +944,15 @@ async function prepareGatewayPayload({ payload, env }) {
       ? AutonomyMode.GUARDED_ABSENCE
       : requestedAutonomyMode;
 
+  const combinedAliasRegistry = await resolveRuntimeAliasRegistry({
+    baseAliasRegistry: basePolicyInput.aliasRegistry,
+    env
+  });
   const resolvedAliasRegistry = await resolveGatewayAliasRegistryFromGitHubApp({
-    policyInput: basePolicyInput,
+    policyInput: {
+      ...basePolicyInput,
+      aliasRegistry: combinedAliasRegistry
+    },
     env
   });
   const warnings = [...(resolvedAliasRegistry.warnings ?? [])];
@@ -923,6 +988,68 @@ async function prepareGatewayPayload({ payload, env }) {
     },
     warnings
   };
+}
+
+async function resolveRuntimeAliasRegistry({ baseAliasRegistry, env }) {
+  const provider = resolveMemoryProvider(env);
+  const stored = await retrieveStoredAliasRegistry(provider);
+  return mergeAliasRegistries(
+    baseAliasRegistry,
+    stored.ok ? stored.aliasRegistry : []
+  );
+}
+
+async function handleRepositoryNicknameUpsertRequest(request, env) {
+  const provider = resolveMemoryProvider(env);
+  const body = await readJson(request);
+  const runtimeAliasRegistry = await resolveRuntimeAliasRegistry({
+    baseAliasRegistry: [],
+    env
+  });
+  const resolvedAliasRegistry = await resolveGatewayAliasRegistryFromGitHubApp({
+    policyInput: {
+      aliasRegistry: runtimeAliasRegistry
+    },
+    env
+  });
+  const resolution = resolveRepositoryTarget({
+    input: body?.repository ?? body?.repositoryInput,
+    mode: TaskMode.EXECUTION,
+    aliasRegistry: resolvedAliasRegistry.aliasRegistry
+  });
+
+  if (!resolution.resolved) {
+    return json(422, {
+      ok: false,
+      error: "repository_nickname_request_invalid",
+      reason: resolution.reason,
+      candidates: resolution.candidates ?? []
+    });
+  }
+
+  const result = await upsertRepositoryNickname({
+    provider,
+    repository: resolution.repository,
+    nickname: body?.nickname,
+    nicknames: body?.nicknames,
+    mode: body?.mode || RepositoryNicknameMode.APPEND,
+    aliasRegistry: resolvedAliasRegistry.aliasRegistry
+  });
+
+  if (!result.ok) {
+    return json(result.status ?? 422, {
+      ok: false,
+      error: result.error,
+      reason: result.reason,
+      issues: result.issues ?? []
+    });
+  }
+
+  return json(200, {
+    ok: true,
+    repository: resolution.repository,
+    aliasEntry: result.aliasEntry
+  });
 }
 
 async function handlePasskeyRegistrationOptionsRequest(request, env) {

--- a/test/close-readiness-audit.test.js
+++ b/test/close-readiness-audit.test.js
@@ -10,10 +10,8 @@ test("close-readiness audit distinguishes close-ready from auto-closed", () => {
   assert.equal(doc.includes("It does not close any Issue automatically"), true);
   assert.equal(doc.includes("human-gated" ) || doc.includes("Human judgment is still required"), true);
   assert.equal(doc.includes("docs/mvp/open-issue-current-reality-audit.md"), true);
-  assert.equal(doc.includes("`#80` has merged implementation progress"), true);
   assert.equal(doc.includes("`#4` is the current parent contract for the Butler-Codex-Gemini revision loop"), true);
-  assert.equal(doc.includes("`#6` remains a historical execution-slice issue"), true);
-  assert.equal(doc.includes("Its execution-spine behavior is already directly evidenced through `E2E-19`."), true);
-  assert.equal(doc.includes("`#82`"), true);
-  assert.equal(doc.includes("`#84`"), true);
+  assert.equal(doc.includes("`#89`"), true);
+  assert.equal(doc.includes("user-defined repository nicknames"), true);
+  assert.equal(doc.includes("keep open until runtime/docs/E2E"), true);
 });

--- a/test/core-policy.test.js
+++ b/test/core-policy.test.js
@@ -143,6 +143,39 @@ test("execution mode allows alias-resolved target after explicit confirmation", 
   assert.equal(result.repository, "sample-org/accounting-app");
 });
 
+test("execution mode blocks ambiguous repository nickname", () => {
+  const result = evaluateExecutionPolicy({
+    actionType: ActionType.BUILD,
+    mode: TaskMode.EXECUTION,
+    repositoryInput: "公開VTDD",
+    aliasRegistry: [
+      ...registry,
+      {
+        canonicalRepo: "sample-org/vtdd-v2-p",
+        productName: "VTDD Public",
+        aliases: ["公開VTDD"]
+      },
+      {
+        canonicalRepo: "sample-org/vtdd-public",
+        productName: "VTDD Public Alt",
+        aliases: ["公開VTDD"]
+      }
+    ],
+    targetConfirmed: true,
+    constitutionConsulted: true,
+    runtimeTruth: { runtimeAvailable: true },
+    credential: executeCredential,
+    consent: fullConsent,
+    ...approvalContext,
+    issueTraceable: true,
+    go: true,
+    passkey: false
+  });
+
+  assert.equal(result.allowed, false);
+  assert.equal(result.blockedByRule, "unresolved_target_blocks_execution");
+});
+
 test("high-risk action requires GO + passkey", () => {
   const result = evaluateExecutionPolicy({
     actionType: ActionType.DEPLOY_PRODUCTION,

--- a/test/custom-gpt-setup-docs.test.js
+++ b/test/custom-gpt-setup-docs.test.js
@@ -37,11 +37,14 @@ test("custom gpt instructions preserve current butler and approval boundaries", 
   assert.equal(doc.includes("vtddDeployProduction"), true);
   assert.equal(doc.includes("vtddExecutionProgress"), true);
   assert.equal(doc.includes("vtddRetrieveGitHub"), true);
+  assert.equal(doc.includes("vtddUpsertRepositoryNickname"), true);
+  assert.equal(doc.includes("vtddRetrieveRepositoryNicknames"), true);
   assert.equal(doc.includes("vtddRetrieveSetupArtifact"), true);
   assert.equal(doc.includes("vtddRetrieveSelfParity"), true);
   assert.equal(doc.includes("when the user says `君`, `自分`, `Butler`, `VTDD`, or `このGPT`"), true);
   assert.equal(doc.includes("`君自身のアップデートある？`"), true);
   assert.equal(doc.includes("`古くなってない？`"), true);
+  assert.equal(doc.includes("Nickname memory is explicit user-owned alias registry data"), true);
   assert.equal(doc.includes("prefer vtddRetrieveSelfParity over general model-capability disclaimers"), true);
   assert.equal(doc.includes("Before the first significant GitHub/runtime action in a session"), true);
   assert.equal(doc.includes("Cloudflare deploy update required"), true);
@@ -65,8 +68,10 @@ test("custom gpt openapi doc exposes current gateway, execute, and progress rout
   assert.equal(doc.includes("/v2/action/github:"), true);
   assert.equal(doc.includes("/v2/action/github-authority:"), true);
   assert.equal(doc.includes("/v2/action/deploy:"), true);
+  assert.equal(doc.includes("/v2/action/repository-nickname:"), true);
   assert.equal(doc.includes("/v2/action/progress:"), true);
   assert.equal(doc.includes("/v2/retrieve/github:"), true);
+  assert.equal(doc.includes("/v2/retrieve/repository-nicknames:"), true);
   assert.equal(doc.includes("/v2/retrieve/setup-artifact:"), true);
   assert.equal(doc.includes("/v2/retrieve/self-parity:"), true);
   assert.equal(doc.includes("/v2/retrieve/approval-grant:"), true);
@@ -103,8 +108,10 @@ test("custom gpt openapi json parses and exposes paths as an object", () => {
   assert.equal(typeof doc.paths["/v2/action/github"], "object");
   assert.equal(typeof doc.paths["/v2/action/github-authority"], "object");
   assert.equal(typeof doc.paths["/v2/action/deploy"], "object");
+  assert.equal(typeof doc.paths["/v2/action/repository-nickname"], "object");
   assert.equal(typeof doc.paths["/v2/action/progress"], "object");
   assert.equal(typeof doc.paths["/v2/retrieve/github"], "object");
+  assert.equal(typeof doc.paths["/v2/retrieve/repository-nicknames"], "object");
   assert.equal(typeof doc.paths["/v2/retrieve/setup-artifact"], "object");
   assert.equal(typeof doc.paths["/v2/retrieve/self-parity"], "object");
   assert.equal(typeof doc.paths["/v2/retrieve/approval-grant"], "object");

--- a/test/e2e-28-repository-nickname-context-resolution.test.js
+++ b/test/e2e-28-repository-nickname-context-resolution.test.js
@@ -1,0 +1,30 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const DOC_PATH = path.join(
+  process.cwd(),
+  "docs",
+  "mvp",
+  "e2e",
+  "e2e-28-repository-nickname-context-resolution.md"
+);
+const MATRIX_PATH = path.join(process.cwd(), "docs", "mvp", "issue-to-e2e-matrix.md");
+
+test("E2E-28 evidence doc records repository nickname runtime and boundary runs", () => {
+  const doc = fs.readFileSync(DOC_PATH, "utf8");
+  assert.equal(doc.includes("`#89`"), true);
+  assert.equal(doc.includes("`公開VTDD`"), true);
+  assert.equal(doc.includes("/v2/retrieve/repository-nicknames"), true);
+  assert.equal(doc.includes("GitHub App repository index"), true);
+  assert.equal(doc.includes("target repository nickname is ambiguous"), true);
+  assert.equal(doc.includes("no default repository"), true);
+});
+
+test("issue-to-e2e matrix references E2E-28 run evidence", () => {
+  const doc = fs.readFileSync(MATRIX_PATH, "utf8");
+  assert.equal(doc.includes("## E2E-28 Repository nickname context resolution"), true);
+  assert.equal(doc.includes("docs/mvp/e2e/e2e-28-repository-nickname-context-resolution.md"), true);
+  assert.equal(doc.includes("- Issues: `#89`"), true);
+});

--- a/test/issue-to-e2e-matrix.test.js
+++ b/test/issue-to-e2e-matrix.test.js
@@ -35,7 +35,8 @@ test("issue-to-e2e matrix defines all canonical E2E tracks", () => {
     "E2E-24",
     "E2E-25",
     "E2E-26",
-    "E2E-27"
+    "E2E-27",
+    "E2E-28"
   ]) {
     assert.equal(doc.includes(`## ${id}`), true);
   }

--- a/test/issue-triage-plan-current-state.test.js
+++ b/test/issue-triage-plan-current-state.test.js
@@ -9,10 +9,10 @@ test("issue triage plan reflects current reading and deprecated boundary", () =>
   const doc = fs.readFileSync(DOC_PATH, "utf8");
   assert.equal(doc.includes("`#13` has already been rewritten as the MVP execution anchor"), true);
   assert.equal(doc.includes("`#4` is the current parent contract for the Butler-Codex-Gemini loop"), true);
-  assert.equal(doc.includes("`#6` remains a historical execution-slice and must not compete with `#4` as a parent authority"), true);
+  assert.equal(doc.includes("`#6` has been closed as historical execution-slice context and must not be"), true);
   assert.equal(doc.includes("overall status is still `partial / in-progress`"), true);
-  assert.equal(doc.includes("deploy-orchestration work (`#82`)"), true);
-  assert.equal(doc.includes("reviewer-fallback boundary work"), true);
+  assert.equal(doc.includes("repository nickname/context"), true);
+  assert.equal(doc.includes("(`#89`)"), true);
   assert.equal(doc.includes("`docs/mvp/issue-to-e2e-matrix.md`"), true);
 });
 
@@ -23,6 +23,7 @@ test("issue triage plan no longer reads like pending issue-creation instructions
   assert.equal(doc.includes("role separation was split out and implemented"), true);
   assert.equal(doc.includes("`#4` for current Butler-Codex-Gemini loop parent authority"), true);
   assert.equal(doc.includes("`#80`, `#82`, and `#84`"), true);
+  assert.equal(doc.includes("the current active follow-up is `#89`"), true);
   assert.equal(doc.includes("docs/mvp/open-issue-current-reality-audit.md"), true);
   assert.equal(doc.includes("active open Issues only for remaining bounded work"), true);
 });

--- a/test/open-issue-current-reality-audit.test.js
+++ b/test/open-issue-current-reality-audit.test.js
@@ -14,11 +14,10 @@ const CLOSE_AUDIT_PATH = path.join(process.cwd(), "docs", "mvp", "close-readines
 test("open issue current-reality audit distinguishes mapped and historical open issues", () => {
   const doc = fs.readFileSync(DOC_PATH, "utf8");
   assert.equal(doc.includes("`#4`"), true);
-  assert.equal(doc.includes("`#80`"), true);
-  assert.equal(doc.includes("`#82`"), true);
-  assert.equal(doc.includes("`#84`"), true);
-  assert.equal(doc.includes("`#6`"), true);
-  assert.equal(doc.includes("`#6` is directly evidenced through `E2E-19`"), true);
+  assert.equal(doc.includes("`#89`"), true);
+  assert.equal(doc.includes("`公開VTDD`"), true);
+  assert.equal(doc.includes("persistent user-owned nickname registry"), true);
+  assert.equal(doc.includes("`#4`"), true);
   assert.equal(doc.includes("Still Missing Direct Matrix Mapping"), false);
 });
 
@@ -27,6 +26,8 @@ test("open issue current-reality audit records resolved stale readings", () => {
   assert.equal(doc.includes("treating `#13` as a currently open issue"), true);
   assert.equal(doc.includes("treating `#1` as a currently open issue"), true);
   assert.equal(doc.includes("treating `#6` as the current parent authority"), true);
+  assert.equal(doc.includes("treating closed issue `#6` as still-open implementation uncertainty"), true);
+  assert.equal(doc.includes("treating closed issues `#80`, `#82`, and `#84` as still-open active work"), true);
   assert.equal(doc.includes("treating closed reviewer-fallback issue `#74` as proof that no-manual Codex"), true);
   assert.equal(doc.includes("fallback is already solved"), true);
 });
@@ -35,8 +36,7 @@ test("close-readiness audit points readers to open issue current-reality audit",
   const doc = fs.readFileSync(CLOSE_AUDIT_PATH, "utf8");
   assert.equal(doc.includes("docs/mvp/open-issue-current-reality-audit.md"), true);
   assert.equal(doc.includes("`#4` current loop parent"), true);
-  assert.equal(doc.includes("`#6` historical execution-slice issue"), true);
-  assert.equal(doc.includes("`#80` self-parity natural-language trigger improvement"), true);
-  assert.equal(doc.includes("`#82`"), true);
-  assert.equal(doc.includes("`#84`"), true);
+  assert.equal(doc.includes("`#89`"), true);
+  assert.equal(doc.includes("persistent"), true);
+  assert.equal(doc.includes("nickname"), true);
 });

--- a/test/owner-closure-guide.test.js
+++ b/test/owner-closure-guide.test.js
@@ -5,19 +5,18 @@ import path from "node:path";
 
 const DOC_PATH = path.join(process.cwd(), "docs", "mvp", "owner-closure-guide.md");
 
-test("owner closure guide distinguishes #80 as the strongest current close candidate without auto-closing", () => {
+test("owner closure guide treats #89 as the current active non-parent implementation issue", () => {
   const doc = fs.readFileSync(DOC_PATH, "utf8");
-  assert.equal(doc.includes("`#80` is the strongest current non-parent close candidate"), true);
+  assert.equal(doc.includes("`#89` is the current active non-parent implementation issue"), true);
   assert.equal(doc.includes("It does not authorize automatic closure"), true);
   assert.equal(doc.includes("Close only if the owner agrees"), true);
   assert.equal(doc.includes("Keep open if any of these are still useful"), true);
+  assert.equal(doc.includes("nickname persistence and recall"), true);
 });
 
-test("owner closure guide keeps #4 and #6 as human judgment calls", () => {
+test("owner closure guide keeps #4 as the human judgment parent issue", () => {
   const doc = fs.readFileSync(DOC_PATH, "utf8");
-  assert.equal(doc.includes("`#6` is historical execution-transport context"), true);
-  assert.equal(doc.includes("`#4` now holds that role"), true);
-  assert.equal(doc.includes("The underlying execution-spine behavior is already evidenced through `E2E-19`."), true);
   assert.equal(doc.includes("`#4` remains the live parent authority for the Butler-Codex-Gemini loop"), true);
+  assert.equal(doc.includes("`#89` is active"), true);
   assert.equal(doc.includes("This guide does not say any issue must be closed now"), true);
 });

--- a/test/repository-nickname-registry.test.js
+++ b/test/repository-nickname-registry.test.js
@@ -1,0 +1,103 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  RepositoryNicknameMode,
+  createInMemoryMemoryProvider,
+  mergeAliasRegistries,
+  retrieveStoredAliasRegistry,
+  upsertRepositoryNickname
+} from "../src/core/index.js";
+
+test("repository nickname registry stores and retrieves user-defined nicknames", async () => {
+  const provider = createInMemoryMemoryProvider();
+  const result = await upsertRepositoryNickname({
+    provider,
+    repository: "sample-org/vtdd-v2-p",
+    nickname: "公開VTDD",
+    aliasRegistry: [
+      {
+        canonicalRepo: "sample-org/vtdd-v2-p",
+        productName: "vtdd-v2-p",
+        visibility: "public",
+        aliases: ["vtdd-v2-p"]
+      }
+    ]
+  });
+
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.aliasEntry.aliases, ["公開VTDD"]);
+
+  const retrieved = await retrieveStoredAliasRegistry(provider);
+  assert.equal(retrieved.ok, true);
+  assert.equal(retrieved.aliasRegistry.length, 1);
+  assert.equal(retrieved.aliasRegistry[0].canonicalRepo, "sample-org/vtdd-v2-p");
+  assert.deepEqual(retrieved.aliasRegistry[0].aliases, ["公開VTDD"]);
+});
+
+test("repository nickname registry can replace prior user-defined nicknames", async () => {
+  const provider = createInMemoryMemoryProvider();
+  const aliasRegistry = [
+    {
+      canonicalRepo: "sample-org/vtdd-v2-p",
+      productName: "vtdd-v2-p",
+      visibility: "public",
+      aliases: ["vtdd-v2-p"]
+    }
+  ];
+
+  await upsertRepositoryNickname({
+    provider,
+    repository: "sample-org/vtdd-v2-p",
+    nickname: "公開VTDD",
+    aliasRegistry
+  });
+  const result = await upsertRepositoryNickname({
+    provider,
+    repository: "sample-org/vtdd-v2-p",
+    nicknames: ["公開V2"],
+    mode: RepositoryNicknameMode.REPLACE,
+    aliasRegistry
+  });
+
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.aliasEntry.aliases, ["公開V2"]);
+});
+
+test("repository nickname registry rejects unknown canonical repositories", async () => {
+  const provider = createInMemoryMemoryProvider();
+  const result = await upsertRepositoryNickname({
+    provider,
+    repository: "sample-org/unknown-repo",
+    nickname: "unknown",
+    aliasRegistry: []
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.status, 422);
+  assert.equal(result.error, "repository_nickname_request_invalid");
+});
+
+test("mergeAliasRegistries combines live aliases and stored nicknames", () => {
+  const merged = mergeAliasRegistries(
+    [
+      {
+        canonicalRepo: "sample-org/vtdd-v2-p",
+        productName: "vtdd-v2-p",
+        visibility: "public",
+        aliases: ["vtdd-v2-p"]
+      }
+    ],
+    [
+      {
+        canonicalRepo: "sample-org/vtdd-v2-p",
+        productName: "vtdd-v2-p",
+        visibility: "unknown",
+        aliases: ["公開VTDD"]
+      }
+    ]
+  );
+
+  assert.equal(merged.length, 1);
+  assert.equal(merged[0].visibility, "public");
+  assert.deepEqual(merged[0].aliases, ["vtdd-v2-p", "公開VTDD"]);
+});

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -858,6 +858,202 @@ test("worker returns GitHub repositories through read plane route", async () => 
   assert.equal(body.read.records[0].fullName, "sample-org/vtdd-v2-p");
 });
 
+test("worker stores and retrieves repository nicknames", async () => {
+  const provider = createInMemoryMemoryProvider();
+  const env = {
+    ...gatewayAuthEnv,
+    MEMORY_PROVIDER: provider,
+    GITHUB_APP_INSTALLATION_TOKEN: "ghs_repo_read",
+    GITHUB_API_FETCH: async () =>
+      new Response(
+        JSON.stringify({
+          total_count: 1,
+          repositories: [
+            {
+              full_name: "sample-org/vtdd-v2-p",
+              name: "vtdd-v2-p",
+              private: false
+            }
+          ]
+        }),
+        { status: 200, headers: { "content-type": "application/json" } }
+      )
+  };
+
+  const writeResponse = await worker.fetch(
+    new Request("https://example.com/v2/action/repository-nickname", {
+      method: "POST",
+      headers: gatewayAuthHeaders,
+      body: JSON.stringify({
+        repository: "vtdd-v2-p",
+        nickname: "公開VTDD"
+      })
+    }),
+    env
+  );
+
+  assert.equal(writeResponse.status, 200);
+  const writeBody = await writeResponse.json();
+  assert.equal(writeBody.ok, true);
+  assert.equal(writeBody.repository, "sample-org/vtdd-v2-p");
+  assert.deepEqual(writeBody.aliasEntry.aliases, ["公開VTDD"]);
+
+  const retrieveResponse = await worker.fetch(
+    new Request("https://example.com/v2/retrieve/repository-nicknames", {
+      headers: gatewayAuthHeaders
+    }),
+    env
+  );
+
+  assert.equal(retrieveResponse.status, 200);
+  const retrieveBody = await retrieveResponse.json();
+  assert.equal(retrieveBody.ok, true);
+  assert.equal(retrieveBody.aliasRegistry.length, 1);
+  assert.equal(retrieveBody.aliasRegistry[0].canonicalRepo, "sample-org/vtdd-v2-p");
+  assert.deepEqual(retrieveBody.aliasRegistry[0].aliases, ["公開VTDD"]);
+});
+
+test("worker gateway can resolve stored repository nickname against live repository index", async () => {
+  const provider = createInMemoryMemoryProvider();
+  await provider.store({
+    id: "alias_registry:sample-org/vtdd-v2-p",
+    type: MemoryRecordType.ALIAS_REGISTRY,
+    content: {
+      canonicalRepo: "sample-org/vtdd-v2-p",
+      productName: "vtdd-v2-p",
+      visibility: "public",
+      aliases: ["公開VTDD"]
+    },
+    metadata: { source: "test" },
+    priority: 60,
+    tags: ["alias_registry", "sample-org/vtdd-v2-p"],
+    createdAt: "2026-04-27T00:00:00.000Z"
+  });
+
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/gateway", {
+      method: "POST",
+      headers: gatewayAuthHeaders,
+      body: JSON.stringify({
+        phase: "execution",
+        actorRole: ActorRole.EXECUTOR,
+        policyInput: {
+          actionType: ActionType.BUILD,
+          mode: TaskMode.EXECUTION,
+          repositoryInput: "公開VTDD",
+          targetConfirmed: true,
+          constitutionConsulted: true,
+          runtimeTruth: { runtimeAvailable: true },
+          credential: { model: "github_app", tier: CredentialTier.EXECUTE },
+          consent: { grantedCategories: [ConsentCategory.EXECUTE] },
+          approvalPhrase: "GO build",
+          approvalScopeMatched: true,
+          issueTraceable: true,
+          go: true,
+          passkey: false
+        }
+      })
+    }),
+    {
+      ...gatewayAuthEnv,
+      MEMORY_PROVIDER: provider,
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_repo_read",
+      GITHUB_API_FETCH: async () =>
+        new Response(
+          JSON.stringify({
+            total_count: 1,
+            repositories: [
+              {
+                full_name: "sample-org/vtdd-v2-p",
+                name: "vtdd-v2-p",
+                private: false
+              }
+            ]
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        )
+    }
+  );
+
+  assert.equal(response.status, 200);
+  const body = await response.json();
+  assert.equal(body.allowed, true);
+  assert.equal(body.repository, "sample-org/vtdd-v2-p");
+});
+
+test("worker blocks repository nickname write when nickname target is ambiguous", async () => {
+  const provider = createInMemoryMemoryProvider();
+  await provider.store({
+    id: "alias_registry:sample-org/vtdd-v2-p",
+    type: MemoryRecordType.ALIAS_REGISTRY,
+    content: {
+      canonicalRepo: "sample-org/vtdd-v2-p",
+      productName: "vtdd-v2-p",
+      visibility: "public",
+      aliases: ["公開VTDD"]
+    },
+    metadata: { source: "test" },
+    priority: 60,
+    tags: ["alias_registry", "sample-org/vtdd-v2-p"],
+    createdAt: "2026-04-27T00:00:00.000Z"
+  });
+  await provider.store({
+    id: "alias_registry:sample-org/vtdd-public",
+    type: MemoryRecordType.ALIAS_REGISTRY,
+    content: {
+      canonicalRepo: "sample-org/vtdd-public",
+      productName: "vtdd-public",
+      visibility: "public",
+      aliases: ["公開VTDD"]
+    },
+    metadata: { source: "test" },
+    priority: 60,
+    tags: ["alias_registry", "sample-org/vtdd-public"],
+    createdAt: "2026-04-27T00:00:01.000Z"
+  });
+
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/action/repository-nickname", {
+      method: "POST",
+      headers: gatewayAuthHeaders,
+      body: JSON.stringify({
+        repository: "公開VTDD",
+        nickname: "公開本命"
+      })
+    }),
+    {
+      ...gatewayAuthEnv,
+      MEMORY_PROVIDER: provider,
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_repo_read",
+      GITHUB_API_FETCH: async () =>
+        new Response(
+          JSON.stringify({
+            total_count: 2,
+            repositories: [
+              {
+                full_name: "sample-org/vtdd-v2-p",
+                name: "vtdd-v2-p",
+                private: false
+              },
+              {
+                full_name: "sample-org/vtdd-public",
+                name: "vtdd-public",
+                private: false
+              }
+            ]
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        )
+    }
+  );
+
+  assert.equal(response.status, 422);
+  const body = await response.json();
+  assert.equal(body.ok, false);
+  assert.equal(body.error, "repository_nickname_request_invalid");
+  assert.equal(body.reason, "target repository nickname is ambiguous");
+});
+
 test("worker returns GitHub issues through read plane route", async () => {
   const response = await worker.fetch(
     new Request(


### PR DESCRIPTION
## This PR satisfies Intent

- Satisfies Issue #89 by adding an explicit user-owned repository nickname registry so Butler can remember names like `公開VTDD` without weakening `no default repository`.
- Connects stored nicknames to the GitHub App live repository index so existing repos and future repo reads can resolve through Butler context-first repository resolution.

## Satisfied Success Criteria

- Added runtime write/read routes for repository nicknames: `/v2/action/repository-nickname` and `/v2/retrieve/repository-nicknames`.
- Added persistent nickname registry storage and merge logic with the live GitHub App-backed alias registry.
- Updated repository resolution so ambiguous nickname matches remain blocking with explicit candidate output.
- Updated Custom GPT Actions and Instructions so Butler can save and recall repository nicknames through the supported surface.
- Added `E2E-28` and updated current-reality / close-readiness docs for Issue #89.

## Unsatisfied Success Criteria

None.

## Non-goal violations

None.

## Verification Evidence

- Unit: `node --test test/repository-nickname-registry.test.js test/core-policy.test.js test/custom-gpt-setup-docs.test.js`
- Integration: `node --test test/worker.test.js test/open-issue-current-reality-audit.test.js test/close-readiness-audit.test.js test/issue-triage-plan-current-state.test.js test/owner-closure-guide.test.js`
- E2E: `node --test test/issue-to-e2e-matrix.test.js test/e2e-28-repository-nickname-context-resolution.test.js`
- Manual: Not run.
- Evidence path/link: `docs/mvp/e2e/e2e-28-repository-nickname-context-resolution.md`

## Related Constitution Rules

- Preserve `no default repository`.
- Unresolved or ambiguous repository targets must block execution.
- Butler remains context-first, but executes conservatively.

## Out-of-scope but NOT implemented

- Free-form automatic guessing of owner/repo from `marushu/***` without explicit nickname registration.
- Repository rename / transfer management.
- Any default-repository behavior.

## Extra changes (if any)

- Updated current-reality / triage / owner-closure docs so the repo reads `#89` as the active implementation slice and maps it to `E2E-28`.

<!-- VTDD metadata -->
- Issue: #89
- Execution ID: Not provided.
- Goal: open_pr
