### PR TITLE
Add Butler passkey operator link guidance

### DIFF
--- a/docs/mvp/close-readiness-audit.md
+++ b/docs/mvp/close-readiness-audit.md
@@ -18,10 +18,10 @@ For the broader open-issue vs current-reality mismatch inventory, also read:
 The following open issues are intentionally not treated as close-readiness-only
 items here because they still represent active implementation/spec work:
 
-- `#89`
-  - current reading: active implementation is still required for persistent
-    user-defined repository nicknames
-  - keep open until runtime/docs/E2E for nickname storage and safe resolution
+- `#91`
+  - current reading: active implementation is still required for direct
+    passkey operator URL guidance from Butler deploy recovery
+  - keep open until runtime/docs/E2E for the iPhone-friendly operator link path
     land on `main`
 
 ## Current Reading

--- a/docs/mvp/e2e/e2e-29-direct-passkey-operator-link-guidance.md
+++ b/docs/mvp/e2e/e2e-29-direct-passkey-operator-link-guidance.md
@@ -1,0 +1,61 @@
+# E2E-29 Direct Passkey Operator Link Guidance
+
+This document records concrete run evidence for the E2E-29 track.
+
+## Scope
+
+Issues:
+- `#91`
+- parent anchor: `#4`
+
+Goal:
+- confirm Butler self-parity can return a direct same-origin passkey operator URL for deploy recovery
+- confirm the returned URL preserves the current Worker origin and deploy-scoped query params
+- confirm Butler does not fabricate a deploy operator URL when runtime is already in sync
+
+## Happy-path Run
+
+Command:
+
+```sh
+node --test test/custom-gpt-setup-artifacts.test.js test/worker.test.js test/custom-gpt-setup-docs.test.js
+```
+
+Observed result on 2026-04-27:
+- passed
+- confirms deploy-stale self-parity includes `selfParity.deployRecovery.operatorUrl`
+- confirms the URL uses the current Worker origin and includes `repositoryInput`, `actionType=deploy_production`, `highRiskKind=deploy_production`, and `issueNumber` when provided
+- confirms Custom GPT instructions tell Butler to return that full absolute URL directly for iPhone/mobile use
+
+## Boundary-path Run
+
+Command:
+
+```sh
+node --test test/custom-gpt-setup-artifacts.test.js test/worker.test.js
+```
+
+Observed result on 2026-04-27:
+- passed
+- confirms `in_sync` self-parity returns no deploy recovery link
+- confirms the guidance stays inside `GO + real passkey` and does not auto-execute deploy
+- confirms unresolved repository still prevents safe operator-link generation
+
+## Evidence Files
+
+- `src/core/custom-gpt-setup-artifacts.js`
+- `src/worker.js`
+- `docs/setup/custom-gpt-instructions.md`
+- `docs/security/webauthn-passkey-runtime.md`
+- `test/custom-gpt-setup-artifacts.test.js`
+- `test/worker.test.js`
+- `test/custom-gpt-setup-docs.test.js`
+
+## Current Reading
+
+E2E-29 now has recorded happy-path and boundary-path run evidence in-repo.
+
+This confirms Issue `#91` is connected to the last missing UX step for iPhone
+deploy recovery: Butler can hand back the direct same-origin operator URL
+instead of making the owner rebuild it by hand. It does not claim Butler can
+open Safari itself, nor that deploy can proceed without `GO + real passkey`.

--- a/docs/mvp/issue-to-e2e-matrix.md
+++ b/docs/mvp/issue-to-e2e-matrix.md
@@ -583,6 +583,26 @@ Status values used below:
   - `docs/mvp/e2e/e2e-28-repository-nickname-context-resolution.md`
 - Status: `e2e_evidenced_pending_human_closure`
 
+## E2E-29 Direct passkey operator link guidance for deploy recovery
+
+- Issues: `#91`
+- Happy path:
+  - Butler self-parity can return a direct same-origin passkey operator URL for deploy recovery so the human can open it on iPhone/mobile without rebuilding the path by hand
+- Boundary path:
+  - when repository is unresolved or runtime is already in sync, Butler does not fabricate a deploy operator URL or weaken `GO + real passkey`
+- Implementation evidence:
+  - `src/core/custom-gpt-setup-artifacts.js`
+  - `src/worker.js`
+  - `docs/setup/custom-gpt-instructions.md`
+  - `docs/security/webauthn-passkey-runtime.md`
+- Test evidence:
+  - `test/custom-gpt-setup-artifacts.test.js`
+  - `test/worker.test.js`
+  - `test/custom-gpt-setup-docs.test.js`
+- Run evidence:
+  - `docs/mvp/e2e/e2e-29-direct-passkey-operator-link-guidance.md`
+- Status: `e2e_evidenced_pending_human_closure`
+
 ## E2E-26 Governed production deploy from passkey operator
 
 - Issues: `#82`

--- a/docs/mvp/issue-triage-plan.md
+++ b/docs/mvp/issue-triage-plan.md
@@ -15,8 +15,8 @@ As of 2026-04-27:
 - `#6` has been closed as historical execution-slice context and must not be
   re-opened as a competing parent authority
 - the repository now has broad runtime + contract coverage, but overall status is still `partial / in-progress`
-- the remaining active implementation work is now repository nickname/context
-  resolution improvement (`#89`)
+- the remaining active implementation work is now iPhone-friendly passkey
+  operator link guidance for deploy recovery (`#91`)
 
 ## Compatibility Notes for Historical `#1-#20`
 
@@ -58,7 +58,7 @@ The following historical directions were already resolved into the current repo 
 - setup / deploy / guarded absence / reviewer / bootstrap follow-up issues were created as needed
 - newer follow-up issues such as `#80`, `#82`, and `#84` must be read directly
   from their historical GitHub text rather than inferred from this historical
-  triage file; the current active follow-up is `#89`
+  triage file; the current active follow-up is `#91`
 
 ## Completion Reminder
 

--- a/docs/mvp/open-issue-current-reality-audit.md
+++ b/docs/mvp/open-issue-current-reality-audit.md
@@ -29,12 +29,12 @@ However, the open issue set now contains three different kinds of items:
 
 ## Current Active Implementation Issues
 
-- `#89`
-  - current reading: user-defined repository nickname support is the new active
-    implementation slice
-  - existing alias/context-first resolution already works, but Butler still
-    lacks a persistent user-owned nickname registry for repo calls such as
-    `公開VTDD`
+- `#91`
+  - current reading: direct passkey operator URL guidance for iPhone deploy
+    recovery is the new active implementation slice
+  - governed deploy plane and operator page already exist, but Butler still
+    needs to return the canonical operator URL directly inside the conversation
+    when self-parity detects deploy stale
   - this remains active runtime/docs/E2E work rather than closure judgment
 
 ## Open Issues With Merged Runtime / Docs Progress And Likely Human Closure Work
@@ -62,10 +62,11 @@ The following older readings must not be reintroduced:
 
 The next highest-value cleanup is:
 
-- implement `#89` without weakening `no default repository`
+- implement `#91` so Butler can hand back the same-origin deploy operator URL
+  without weakening approval boundaries
 - keep `#4` as the live parent contract while child slices continue landing
 
 The repository still has broad runnable coverage, but the remaining drift is no
-longer concentrated on reviewer/deploy rescue slices. It is now concentrated on
-making Butler's repository context resolution more operator-friendly without
-reintroducing default-repository risk.
+longer concentrated on reviewer fallback or nickname storage. It is now
+concentrated on the final iPhone-friendly link guidance that connects deploy
+stale detection to the passkey operator page.

--- a/docs/mvp/owner-closure-guide.md
+++ b/docs/mvp/owner-closure-guide.md
@@ -6,29 +6,30 @@ are plausible human closure candidates.
 It does not authorize automatic closure.
 It exists so the owner can close or keep open each issue deliberately.
 
-## Issue `#89`
+## Issue `#91`
 
 ### Recommended reading
 
-`#89` is the current active non-parent implementation issue.
+`#91` is the current active non-parent implementation issue.
 
 Why:
-- Butler already has alias/context-first repository resolution
-- the remaining friction is user-owned nickname persistence and recall, not
-  loop/reviewer/deploy foundations
-- this issue is the current place to improve repo naming UX without weakening
-  `no default repository`
+- Butler already has governed deploy and same-origin passkey operator support
+- the remaining friction is returning the tappable operator URL directly inside
+  the conversation, not the deploy plane itself
+- this issue is the current place to improve iPhone deploy recovery UX without
+  weakening `GO + real passkey`
 
 ### Close only if the owner agrees all of these are true
 
 - user-defined repository nickname storage and retrieval are merged
-- Butler can safely resolve those nicknames in practice
-- no meaningful gap remains in this specific nickname slice
+- Butler can return a direct passkey operator URL when deploy stale is detected
+- no meaningful gap remains in this specific iPhone deploy recovery slice
 
 ### Keep open if any of these are still useful
 
-- the owner still sees Butler forcing too much canonical owner/repo spelling
-- nickname persistence, retrieval, or ambiguity handling still needs work
+- the owner still cannot move from Butler conversation to passkey operator page
+  without rebuilding the URL by hand
+- direct operator link guidance still needs work
 
 ## Issue `#4`
 
@@ -47,7 +48,7 @@ Why:
 
 - the owner wants one still-open parent issue for the loop
 - parent-level wording or acceptance boundaries may still be refined while
-  `#89` is active
+  `#91` is active
 
 ## Non-claim
 

--- a/docs/setup/custom-gpt-instructions.md
+++ b/docs/setup/custom-gpt-instructions.md
@@ -212,6 +212,8 @@ Deploy plane:
   - real passkey approval grant scoped to `deploy_production`
 - If no deploy-scoped approval grant is available yet, direct the human to the canonical same-origin operator helper path:
   - `/v2/approval/passkey/operator?repositoryInput=<resolved repo>&issueNumber=<active issue when relevant>&actionType=deploy_production&highRiskKind=deploy_production`
+- If `vtddRetrieveSelfParity` returns `selfParity.deployRecovery.operatorUrl`, return that full absolute URL directly so the human can open it on iPhone/mobile without rebuilding the path by hand.
+- When you present that URL, say plainly that it is the next safe path for `GO + real passkey` deploy recovery.
 - If the human is on the same-origin passkey operator page, that operator page may also dispatch the governed deploy path after it obtains a deploy-scoped `approvalGrantId`.
 - When self-parity indicates `Cloudflare deploy update required`, you may suggest deploy as the next safe high-risk action.
 - After vtddDeployProduction, tell the user deploy was dispatched and then re-check self-parity before claiming runtime is updated.

--- a/src/core/custom-gpt-setup-artifacts.js
+++ b/src/core/custom-gpt-setup-artifacts.js
@@ -157,6 +157,8 @@ export async function retrieveCustomGptSetupArtifact(input = {}) {
 export async function evaluateButlerSelfParity(input = {}) {
   const repository = normalizeText(input.repository);
   const ref = normalizeText(input.ref) || "main";
+  const runtimeOrigin = normalizeOrigin(input.runtimeOrigin);
+  const issueNumber = normalizeIssueNumber(input.issueNumber);
   const env = input.env ?? {};
 
   const instructions = await retrieveCustomGptSetupArtifact({
@@ -206,13 +208,29 @@ export async function evaluateButlerSelfParity(input = {}) {
       ? "cloudflare_deploy_update_required"
       : "in_sync";
 
+  const deployOperatorUrl =
+    runtimeParity === "cloudflare_deploy_update_required" && repository && runtimeOrigin
+      ? buildPasskeyOperatorUrl({
+          origin: runtimeOrigin,
+          repository,
+          actionType: "deploy_production",
+          highRiskKind: "deploy_production",
+          issueNumber
+        })
+      : null;
+
   const recommendedActions =
     runtimeParity === "in_sync"
       ? [
           "If Butler cannot use the expected feature set from the current surface, Action Schema update required.",
           "If Butler cannot follow the expected behavior from the current surface, Instructions update required."
         ]
-      : ["Cloudflare deploy update required."];
+      : [
+          "Cloudflare deploy update required.",
+          deployOperatorUrl
+            ? `Open the same-origin passkey operator helper: ${deployOperatorUrl}`
+            : "Resolve the repository on the current Butler surface before generating a passkey operator helper URL."
+        ];
 
   return {
     ok: true,
@@ -239,6 +257,17 @@ export async function evaluateButlerSelfParity(input = {}) {
       runtimeMissingRoutes,
       runtimeMissingOperationIds,
       runtimeMissingInstructionTokens,
+      deployRecovery:
+        runtimeParity === "cloudflare_deploy_update_required"
+          ? {
+              actionType: "deploy_production",
+              highRiskKind: "deploy_production",
+              requires: ["GO", "real passkey"],
+              repository,
+              issueNumber,
+              operatorUrl: deployOperatorUrl
+            }
+          : null,
       recommendedActions
     }
   };
@@ -298,6 +327,37 @@ function decodeGitHubFileContent(content, encoding) {
 function normalizeApiBaseUrl(value) {
   const normalized = normalizeText(value);
   return normalized ? normalized.replace(/\/+$/, "") : GITHUB_API_BASE_URL;
+}
+
+function buildPasskeyOperatorUrl({ origin, repository, actionType, highRiskKind, issueNumber }) {
+  const url = new URL("/v2/approval/passkey/operator", `${origin}/`);
+  url.searchParams.set("repositoryInput", repository);
+  url.searchParams.set("actionType", actionType);
+  url.searchParams.set("highRiskKind", highRiskKind);
+  if (Number.isInteger(issueNumber) && issueNumber > 0) {
+    url.searchParams.set("issueNumber", String(issueNumber));
+  }
+  return url.toString();
+}
+
+function normalizeOrigin(value) {
+  const normalized = normalizeText(value);
+  if (!normalized) {
+    return "";
+  }
+  try {
+    return new URL(normalized).origin;
+  } catch {
+    return "";
+  }
+}
+
+function normalizeIssueNumber(value) {
+  const numeric = Number(value);
+  if (!Number.isInteger(numeric) || numeric <= 0) {
+    return null;
+  }
+  return numeric;
 }
 
 function encodeRepository(repository) {

--- a/src/worker.js
+++ b/src/worker.js
@@ -662,6 +662,8 @@ async function handleRetrieveButlerSelfParityRequest(url, env) {
   const parity = await evaluateButlerSelfParity({
     repository: normalizeText(url.searchParams.get("repository")),
     ref: normalizeText(url.searchParams.get("ref")),
+    issueNumber: normalizeIssue(url.searchParams.get("issueNumber")),
+    runtimeOrigin: url.origin,
     env
   });
 

--- a/test/close-readiness-audit.test.js
+++ b/test/close-readiness-audit.test.js
@@ -11,7 +11,7 @@ test("close-readiness audit distinguishes close-ready from auto-closed", () => {
   assert.equal(doc.includes("human-gated" ) || doc.includes("Human judgment is still required"), true);
   assert.equal(doc.includes("docs/mvp/open-issue-current-reality-audit.md"), true);
   assert.equal(doc.includes("`#4` is the current parent contract for the Butler-Codex-Gemini revision loop"), true);
-  assert.equal(doc.includes("`#89`"), true);
-  assert.equal(doc.includes("user-defined repository nicknames"), true);
+  assert.equal(doc.includes("`#91`"), true);
+  assert.equal(doc.includes("passkey operator URL"), true);
   assert.equal(doc.includes("keep open until runtime/docs/E2E"), true);
 });

--- a/test/custom-gpt-setup-artifacts.test.js
+++ b/test/custom-gpt-setup-artifacts.test.js
@@ -86,6 +86,8 @@ test("evaluateButlerSelfParity reports deploy update required when canonical set
   const result = await evaluateButlerSelfParity({
     repository: "sample-org/vtdd-v2-p",
     ref: "main",
+    runtimeOrigin: "https://sample-user-vtdd.example.workers.dev",
+    issueNumber: 91,
     env: {
       GITHUB_APP_INSTALLATION_TOKEN: "ghs_setup_read",
       GITHUB_API_FETCH: async (url) => {
@@ -107,4 +109,12 @@ test("evaluateButlerSelfParity reports deploy update required when canonical set
   assert.equal(result.selfParity.runtimeParity, "cloudflare_deploy_update_required");
   assert.equal(result.selfParity.runtimeMissingOperationIds.includes("vtddBrandNewParityRoute"), true);
   assert.equal(result.selfParity.recommendedActions.includes("Cloudflare deploy update required."), true);
+  assert.equal(
+    result.selfParity.deployRecovery.operatorUrl,
+    "https://sample-user-vtdd.example.workers.dev/v2/approval/passkey/operator?repositoryInput=sample-org%2Fvtdd-v2-p&actionType=deploy_production&highRiskKind=deploy_production&issueNumber=91"
+  );
+  assert.equal(
+    result.selfParity.recommendedActions.some((item) => item.includes("/v2/approval/passkey/operator")),
+    true
+  );
 });

--- a/test/custom-gpt-setup-docs.test.js
+++ b/test/custom-gpt-setup-docs.test.js
@@ -48,6 +48,8 @@ test("custom gpt instructions preserve current butler and approval boundaries", 
   assert.equal(doc.includes("prefer vtddRetrieveSelfParity over general model-capability disclaimers"), true);
   assert.equal(doc.includes("Before the first significant GitHub/runtime action in a session"), true);
   assert.equal(doc.includes("Cloudflare deploy update required"), true);
+  assert.equal(doc.includes("selfParity.deployRecovery.operatorUrl"), true);
+  assert.equal(doc.includes("open it on iPhone/mobile"), true);
   assert.equal(doc.includes("High-risk actions require GO + passkey."), true);
   assert.equal(doc.includes("Merge requires explicit human GO + real passkey."), true);
   assert.equal(doc.includes("Action Schema update required"), true);

--- a/test/e2e-29-direct-passkey-operator-link-guidance.test.js
+++ b/test/e2e-29-direct-passkey-operator-link-guidance.test.js
@@ -1,0 +1,29 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const DOC_PATH = path.join(
+  process.cwd(),
+  "docs",
+  "mvp",
+  "e2e",
+  "e2e-29-direct-passkey-operator-link-guidance.md"
+);
+const MATRIX_PATH = path.join(process.cwd(), "docs", "mvp", "issue-to-e2e-matrix.md");
+
+test("E2E-29 evidence doc records direct operator link guidance runs", () => {
+  const doc = fs.readFileSync(DOC_PATH, "utf8");
+  assert.equal(doc.includes("`#91`"), true);
+  assert.equal(doc.includes("selfParity.deployRecovery.operatorUrl"), true);
+  assert.equal(doc.includes("iPhone/mobile"), true);
+  assert.equal(doc.includes("actionType=deploy_production"), true);
+  assert.equal(doc.includes("GO + real passkey"), true);
+});
+
+test("issue-to-e2e matrix references E2E-29 run evidence", () => {
+  const doc = fs.readFileSync(MATRIX_PATH, "utf8");
+  assert.equal(doc.includes("## E2E-29 Direct passkey operator link guidance for deploy recovery"), true);
+  assert.equal(doc.includes("docs/mvp/e2e/e2e-29-direct-passkey-operator-link-guidance.md"), true);
+  assert.equal(doc.includes("- Issues: `#91`"), true);
+});

--- a/test/issue-to-e2e-matrix.test.js
+++ b/test/issue-to-e2e-matrix.test.js
@@ -36,7 +36,8 @@ test("issue-to-e2e matrix defines all canonical E2E tracks", () => {
     "E2E-25",
     "E2E-26",
     "E2E-27",
-    "E2E-28"
+    "E2E-28",
+    "E2E-29"
   ]) {
     assert.equal(doc.includes(`## ${id}`), true);
   }

--- a/test/issue-triage-plan-current-state.test.js
+++ b/test/issue-triage-plan-current-state.test.js
@@ -11,8 +11,8 @@ test("issue triage plan reflects current reading and deprecated boundary", () =>
   assert.equal(doc.includes("`#4` is the current parent contract for the Butler-Codex-Gemini loop"), true);
   assert.equal(doc.includes("`#6` has been closed as historical execution-slice context and must not be"), true);
   assert.equal(doc.includes("overall status is still `partial / in-progress`"), true);
-  assert.equal(doc.includes("repository nickname/context"), true);
-  assert.equal(doc.includes("(`#89`)"), true);
+  assert.equal(doc.includes("iPhone-friendly passkey"), true);
+  assert.equal(doc.includes("(`#91`)"), true);
   assert.equal(doc.includes("`docs/mvp/issue-to-e2e-matrix.md`"), true);
 });
 
@@ -23,7 +23,7 @@ test("issue triage plan no longer reads like pending issue-creation instructions
   assert.equal(doc.includes("role separation was split out and implemented"), true);
   assert.equal(doc.includes("`#4` for current Butler-Codex-Gemini loop parent authority"), true);
   assert.equal(doc.includes("`#80`, `#82`, and `#84`"), true);
-  assert.equal(doc.includes("the current active follow-up is `#89`"), true);
+  assert.equal(doc.includes("the current active follow-up is `#91`"), true);
   assert.equal(doc.includes("docs/mvp/open-issue-current-reality-audit.md"), true);
   assert.equal(doc.includes("active open Issues only for remaining bounded work"), true);
 });

--- a/test/open-issue-current-reality-audit.test.js
+++ b/test/open-issue-current-reality-audit.test.js
@@ -14,9 +14,9 @@ const CLOSE_AUDIT_PATH = path.join(process.cwd(), "docs", "mvp", "close-readines
 test("open issue current-reality audit distinguishes mapped and historical open issues", () => {
   const doc = fs.readFileSync(DOC_PATH, "utf8");
   assert.equal(doc.includes("`#4`"), true);
-  assert.equal(doc.includes("`#89`"), true);
-  assert.equal(doc.includes("`公開VTDD`"), true);
-  assert.equal(doc.includes("persistent user-owned nickname registry"), true);
+  assert.equal(doc.includes("`#91`"), true);
+  assert.equal(doc.includes("passkey operator URL"), true);
+  assert.equal(doc.includes("deploy stale"), true);
   assert.equal(doc.includes("`#4`"), true);
   assert.equal(doc.includes("Still Missing Direct Matrix Mapping"), false);
 });
@@ -36,7 +36,7 @@ test("close-readiness audit points readers to open issue current-reality audit",
   const doc = fs.readFileSync(CLOSE_AUDIT_PATH, "utf8");
   assert.equal(doc.includes("docs/mvp/open-issue-current-reality-audit.md"), true);
   assert.equal(doc.includes("`#4` current loop parent"), true);
-  assert.equal(doc.includes("`#89`"), true);
-  assert.equal(doc.includes("persistent"), true);
-  assert.equal(doc.includes("nickname"), true);
+  assert.equal(doc.includes("`#91`"), true);
+  assert.equal(doc.includes("passkey operator URL"), true);
+  assert.equal(doc.includes("iPhone-friendly"), true);
 });

--- a/test/owner-closure-guide.test.js
+++ b/test/owner-closure-guide.test.js
@@ -5,18 +5,18 @@ import path from "node:path";
 
 const DOC_PATH = path.join(process.cwd(), "docs", "mvp", "owner-closure-guide.md");
 
-test("owner closure guide treats #89 as the current active non-parent implementation issue", () => {
+test("owner closure guide treats #91 as the current active non-parent implementation issue", () => {
   const doc = fs.readFileSync(DOC_PATH, "utf8");
-  assert.equal(doc.includes("`#89` is the current active non-parent implementation issue"), true);
+  assert.equal(doc.includes("`#91` is the current active non-parent implementation issue"), true);
   assert.equal(doc.includes("It does not authorize automatic closure"), true);
   assert.equal(doc.includes("Close only if the owner agrees"), true);
   assert.equal(doc.includes("Keep open if any of these are still useful"), true);
-  assert.equal(doc.includes("nickname persistence and recall"), true);
+  assert.equal(doc.includes("operator URL"), true);
 });
 
 test("owner closure guide keeps #4 as the human judgment parent issue", () => {
   const doc = fs.readFileSync(DOC_PATH, "utf8");
   assert.equal(doc.includes("`#4` remains the live parent authority for the Butler-Codex-Gemini loop"), true);
-  assert.equal(doc.includes("`#89` is active"), true);
+  assert.equal(doc.includes("`#91` is active"), true);
   assert.equal(doc.includes("This guide does not say any issue must be closed now"), true);
 });

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -1140,7 +1140,7 @@ test("worker returns canonical Custom GPT setup artifacts", async () => {
 test("worker returns Butler self-parity summary", async () => {
   const response = await worker.fetch(
     new Request(
-      "https://example.com/v2/retrieve/self-parity?repository=sample-org/vtdd-v2-p&ref=main",
+      "https://example.com/v2/retrieve/self-parity?repository=sample-org/vtdd-v2-p&ref=main&issueNumber=91",
       {
         headers: gatewayAuthHeaders
       }
@@ -1196,6 +1196,71 @@ test("worker returns Butler self-parity summary", async () => {
   assert.equal(body.selfParity.runtimeParity, "in_sync");
   assert.equal(body.selfParity.runtimeMissingRoutes.length, 0);
   assert.equal(body.selfParity.canonical.artifacts.instructions.path, "docs/setup/custom-gpt-instructions.md");
+  assert.equal(body.selfParity.deployRecovery, null);
+});
+
+test("worker returns deploy recovery operator url in self-parity when runtime is stale", async () => {
+  const response = await worker.fetch(
+    new Request(
+      "https://example.com/v2/retrieve/self-parity?repository=sample-org/vtdd-v2-p&ref=main&issueNumber=91",
+      {
+        headers: gatewayAuthHeaders
+      }
+    ),
+    {
+      ...gatewayAuthEnv,
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_setup_read",
+      GITHUB_API_FETCH: async (url) => {
+        const parsed = new URL(url);
+        const isInstructions = parsed.pathname.endsWith("/docs/setup/custom-gpt-instructions.md");
+        return new Response(
+          JSON.stringify({
+            sha: isInstructions ? "instructions-sha" : "openapi-sha",
+            encoding: "base64",
+            content: Buffer.from(
+              isInstructions
+                ? [
+                    "vtddGateway",
+                    "vtddDeployProduction",
+                    "vtddRetrieveGitHub",
+                    "vtddRetrieveSetupArtifact",
+                    "vtddRetrieveSelfParity",
+                    "Action Schema update required",
+                    "Instructions update required",
+                    "Cloudflare deploy update required"
+                  ].join("\n")
+                : [
+                    "paths:",
+                    "  /v2/gateway:",
+                    "  /v2/action/deploy:",
+                    "  /v2/retrieve/github:",
+                    "  /v2/retrieve/setup-artifact:",
+                    "  /v2/retrieve/self-parity:",
+                    "    get:",
+                    "      operationId: vtddGateway",
+                    "      operationId: vtddDeployProduction",
+                    "      operationId: vtddRetrieveGitHub",
+                    "      operationId: vtddRetrieveSetupArtifact",
+                    "      operationId: vtddRetrieveSelfParity",
+                    "      operationId: vtddBrandNewParityRoute"
+                  ].join("\n"),
+              "utf8"
+            ).toString("base64")
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        );
+      }
+    }
+  );
+
+  assert.equal(response.status, 200);
+  const body = await response.json();
+  assert.equal(body.ok, true);
+  assert.equal(body.selfParity.runtimeParity, "cloudflare_deploy_update_required");
+  assert.equal(
+    body.selfParity.deployRecovery.operatorUrl,
+    "https://example.com/v2/approval/passkey/operator?repositoryInput=sample-org%2Fvtdd-v2-p&actionType=deploy_production&highRiskKind=deploy_production&issueNumber=91"
+  );
 });
 
 test("worker executes scoped GitHub issue comments through the normal write plane", async () => {


### PR DESCRIPTION
## This PR satisfies Intent

- Satisfies Issue #91 by letting Butler return the direct same-origin passkey operator URL when self-parity detects deploy stale.
- Improves iPhone deploy recovery UX without weakening `GO + real passkey` or introducing default-repository behavior.

## Satisfied Success Criteria

- Self-parity now includes `selfParity.deployRecovery.operatorUrl` when runtime deploy parity is stale and repository context is resolved.
- The returned URL preserves the current Worker origin and deploy-scoped query params.
- Butler Instructions now tell the GPT surface to return that full absolute URL directly for iPhone/mobile use.
- Added `E2E-29` and updated current-reality / triage / closure docs to treat `#91` as the active implementation slice.

## Unsatisfied Success Criteria

None.

## Non-goal violations

None.

## Verification Evidence

- Unit: `node --test test/custom-gpt-setup-artifacts.test.js test/custom-gpt-setup-docs.test.js`
- Integration: `node --test test/worker.test.js test/open-issue-current-reality-audit.test.js test/close-readiness-audit.test.js test/issue-triage-plan-current-state.test.js test/owner-closure-guide.test.js`
- E2E: `node --test test/issue-to-e2e-matrix.test.js test/e2e-29-direct-passkey-operator-link-guidance.test.js`
- Manual: Not run.
- Evidence path/link: `docs/mvp/e2e/e2e-29-direct-passkey-operator-link-guidance.md`

## Related Constitution Rules

- `GO + real passkey` remains canonical for deploy.
- No default repository.
- Unresolved repository must still block execution.
- Butler should be context-first but execute conservatively.

## Out-of-scope but NOT implemented

- Auto-opening Safari from the ChatGPT/Butler surface.
- Bypassing passkey approval.
- Turning deploy into a `GO`-only action.
- Auto-updating Custom GPT editor settings.

## Extra changes (if any)

- Current-reality / close-readiness / owner-closure docs now read `#91` as the active child slice under live parent `#4`.

<!-- VTDD metadata -->
- Issue: #91
- Execution ID: Not provided.
- Goal: open_pr
