### PR TITLE
docs: surface structured Butler action failures

### DIFF
--- a/docs/setup/custom-gpt-instructions-short.md
+++ b/docs/setup/custom-gpt-instructions-short.md
@@ -48,6 +48,8 @@ Repository listing and nickname memory:
 - If the user asks what repo nicknames Butler knows, use vtddRetrieveRepositoryNicknames.
 - Nickname memory is explicit user-owned alias registry data, not permission to assume a default repository.
 - If nickname resolution is ambiguous, say so plainly and ask a short confirmation before execution.
+- If nickname save/read fails, surface the returned error/reason/issues plainly in Japanese.
+- Do not replace nickname failures with vague summaries like `認証または接続系の可能性`.
 
 GitHub read plane:
 - Use vtddRetrieveGitHub for repositories, issues, issue_comments, pulls, pull_reviews, pull_review_comments, checks, workflow_runs, branches.
@@ -72,6 +74,7 @@ Self-parity and setup recovery:
 - If runtimeParity is `cloudflare_deploy_update_required`, say `Cloudflare deploy update required`.
 - If runtimeParity is `in_sync` but Butler still lacks expected features, say `Action Schema update required` and/or `Instructions update required`.
 - If parity cannot be checked, say `未検証` or `認証失敗`.
+- If any action returns structured failure fields such as error, reason, or issues, summarize those exact fields in Japanese instead of masking them with generic guesses.
 - Use vtddRetrieveSetupArtifact when the user needs canonical setup artifacts:
   - instructions
   - openapi_yaml
@@ -116,6 +119,7 @@ Deploy plane:
 - If vtddRetrieveSelfParity returns selfParity.deployRecovery.operatorUrl, return that full absolute URL directly so the human can open it on iPhone/mobile.
 - When you present that URL, say plainly that it is the next safe path for GO + real passkey deploy recovery.
 - After vtddDeployProduction, say deploy was dispatched, then re-check self-parity before claiming runtime is updated.
+- If vtddDeployProduction fails, say the exact deploy error/reason/issues and whether the blocker is missing approval grant, auth, memory, or runtime drift.
 
 Progress tracking:
 - After vtddExecute, always call vtddExecutionProgress.

--- a/docs/setup/custom-gpt-instructions.md
+++ b/docs/setup/custom-gpt-instructions.md
@@ -97,6 +97,8 @@ Repository nickname memory:
   - `この GPT が覚えている repo の呼び名は？`
 - Nickname memory is explicit user-owned alias registry data, not permission to assume a default repository.
 - If nickname resolution is ambiguous, say so plainly and ask a short confirmation before execution.
+- If nickname save/read fails, surface the returned `error`, `reason`, and `issues` plainly in Japanese.
+- Do not collapse nickname failures into vague guesses such as `認証または接続系の可能性` when the runtime returned a more specific reason.
 
 Butler self-parity and setup artifact recovery:
 - When the user asks whether Butler itself is stale, outdated, or misaligned with the repository/runtime, use vtddRetrieveSelfParity.
@@ -147,6 +149,8 @@ Butler self-parity and setup artifact recovery:
   - openapi_json
 - When returning canonical setup artifacts, make it clear they are the repository canonical source, not proof that the current Custom GPT editor is already updated.
 - If a self-parity check says runtime is in sync, do not overclaim that the current Custom GPT editor is also in sync; editor-side drift can still require Action Schema or Instructions refresh.
+- If any Butler action returns structured failure fields such as `error`, `reason`, or `issues`, summarize those exact fields in Japanese before proposing the next step.
+- Do not hide specific runtime failures behind generic summaries if the worker already returned a concrete cause.
 
 Execution judgment:
 - Before execution, read current runtime truth through vtddGateway.
@@ -217,6 +221,7 @@ Deploy plane:
 - If the human is on the same-origin passkey operator page, that operator page may also dispatch the governed deploy path after it obtains a deploy-scoped `approvalGrantId`.
 - When self-parity indicates `Cloudflare deploy update required`, you may suggest deploy as the next safe high-risk action.
 - After vtddDeployProduction, tell the user deploy was dispatched and then re-check self-parity before claiming runtime is updated.
+- If vtddDeployProduction fails, tell the user the exact deploy `error`, `reason`, and `issues`, including whether the blocker is missing approval grant, auth, memory, or runtime drift.
 
 Progress tracking:
 - After vtddExecute, always call vtddExecutionProgress.

--- a/test/custom-gpt-setup-docs.test.js
+++ b/test/custom-gpt-setup-docs.test.js
@@ -63,6 +63,9 @@ test("custom gpt instructions preserve current butler and approval boundaries", 
   assert.equal(doc.includes("Action Schema update required"), true);
   assert.equal(doc.includes("Instructions update required"), true);
   assert.equal(doc.includes("runtime is in sync, do not overclaim that the current Custom GPT editor is also in sync"), true);
+  assert.equal(doc.includes("surface the returned `error`, `reason`, and `issues` plainly in Japanese"), true);
+  assert.equal(doc.includes("Do not collapse nickname failures into vague guesses"), true);
+  assert.equal(doc.includes("If vtddDeployProduction fails, tell the user the exact deploy `error`, `reason`, and `issues`"), true);
   assert.equal(doc.includes("Do not claim a PR exists when only a Codex task summary exists."), true);
   assert.equal(
     doc.includes("Do not claim that Issues/PRs/comments are absent when the read path is unsupported, unauthorized, or unverified."),
@@ -81,11 +84,14 @@ test("short custom gpt instructions stay under editor limits while preserving cr
   assert.equal(doc.includes("vtddUpsertRepositoryNickname"), true);
   assert.equal(doc.includes("vtddRetrieveRepositoryNicknames"), true);
   assert.equal(doc.includes("Nickname memory is explicit user-owned alias registry data"), true);
+  assert.equal(doc.includes("surface the returned error/reason/issues plainly in Japanese"), true);
+  assert.equal(doc.includes("Do not replace nickname failures with vague summaries"), true);
   assert.equal(doc.includes("Cloudflare deploy update required"), true);
   assert.equal(doc.includes("Action Schema update required"), true);
   assert.equal(doc.includes("Instructions update required"), true);
   assert.equal(doc.includes("selfParity.deployRecovery.operatorUrl"), true);
   assert.equal(doc.includes("GO + real passkey"), true);
+  assert.equal(doc.includes("If vtddDeployProduction fails, say the exact deploy error/reason/issues"), true);
 });
 
 test("custom gpt openapi doc exposes current gateway, execute, and progress routes", () => {


### PR DESCRIPTION
## This PR satisfies Intent
- Butler revision loop quality by making action failures observable instead of vague
- nickname save/read failures surface runtime-returned details in Japanese
- deploy failures surface exact blocker classes in Japanese

## Satisfied Success Criteria
- Butler canonical instructions require surfacing action `error` / `reason` / `issues` in Japanese
- nickname failures must not be summarized as `認証または接続系の可能性`
- deploy failures must report exact blocker classes such as approval grant, auth, memory, or runtime drift
- short Custom GPT instructions remain under the 8000 character editor limit

## Unsatisfied Success Criteria
- live Custom GPT session behavior is not proven by this PR alone until the updated short instructions are re-applied in the GPT editor

## Verification Evidence
- `node --test test/custom-gpt-setup-docs.test.js`
- `wc -m docs/setup/custom-gpt-instructions-short.md` -> `7906`
