### PR TITLE
Expose Butler action auth failure bodies

### DIFF
--- a/docs/setup/custom-gpt-actions-openapi.json
+++ b/docs/setup/custom-gpt-actions-openapi.json
@@ -1039,10 +1039,24 @@
             }
           },
           "401": {
-            "description": "Missing machine auth"
+            "description": "Missing machine auth",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VtddGenericResponse"
+                }
+              }
+            }
           },
           "403": {
-            "description": "Invalid machine auth"
+            "description": "Invalid machine auth",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VtddGenericResponse"
+                }
+              }
+            }
           },
           "422": {
             "description": "Repository nickname request blocked or invalid",
@@ -1176,10 +1190,24 @@
             }
           },
           "401": {
-            "description": "Missing machine auth"
+            "description": "Missing machine auth",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VtddGenericResponse"
+                }
+              }
+            }
           },
           "403": {
-            "description": "Invalid machine auth"
+            "description": "Invalid machine auth",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VtddGenericResponse"
+                }
+              }
+            }
           },
           "503": {
             "description": "Butler self-parity evaluation unavailable",
@@ -1210,10 +1238,24 @@
             }
           },
           "401": {
-            "description": "Missing machine auth"
+            "description": "Missing machine auth",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VtddGenericResponse"
+                }
+              }
+            }
           },
           "403": {
-            "description": "Invalid machine auth"
+            "description": "Invalid machine auth",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VtddGenericResponse"
+                }
+              }
+            }
           },
           "503": {
             "description": "Repository nickname retrieval unavailable",

--- a/docs/setup/custom-gpt-actions-openapi.yaml
+++ b/docs/setup/custom-gpt-actions-openapi.yaml
@@ -532,8 +532,16 @@ paths:
                 $ref: "#/components/schemas/VtddGenericResponse"
         "401":
           description: Missing machine auth
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VtddGenericResponse"
         "403":
           description: Invalid machine auth
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VtddGenericResponse"
         "422":
           description: Repository nickname request blocked or invalid
           content:
@@ -679,8 +687,16 @@ paths:
                 $ref: "#/components/schemas/VtddGenericResponse"
         "401":
           description: Missing machine auth
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VtddGenericResponse"
         "403":
           description: Invalid machine auth
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VtddGenericResponse"
         "503":
           description: Repository nickname retrieval unavailable
           content:
@@ -758,8 +774,16 @@ paths:
                 $ref: "#/components/schemas/VtddGenericResponse"
         "401":
           description: Missing machine auth
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VtddGenericResponse"
         "403":
           description: Invalid machine auth
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VtddGenericResponse"
         "503":
           description: Butler self-parity evaluation unavailable
           content:

--- a/docs/setup/custom-gpt-instructions-short.md
+++ b/docs/setup/custom-gpt-instructions-short.md
@@ -3,7 +3,7 @@
 This file is the canonical paste-ready Butler Instructions template for Custom
 GPT surfaces with an 8000-character limit.
 
-Use this file when the editor cannot accept the full template in
+Use when the editor cannot accept the full template in
 `docs/setup/custom-gpt-instructions.md`.
 
 ```text
@@ -50,6 +50,7 @@ Repository listing and nickname memory:
 - If nickname resolution is ambiguous, say so plainly and ask a short confirmation before execution.
 - If nickname save/read fails, surface the returned error/reason/issues plainly in Japanese.
 - Do not replace nickname failures with vague summaries like `認証または接続系の可能性`.
+- If an Action returns `ClientResponseError`, state action name, visible HTTP status/body fields, and missing error/reason/issues.
 
 GitHub read plane:
 - Use vtddRetrieveGitHub for repositories, issues, issue_comments, pulls, pull_reviews, pull_review_comments, checks, workflow_runs, branches.
@@ -60,21 +61,14 @@ GitHub read plane:
 
 Self-parity and setup recovery:
 - If the user asks whether Butler itself is stale, outdated, old, reflected, or aligned, use vtddRetrieveSelfParity.
-- Examples:
-  - `君自身のアップデートある？`
-  - `古くなってない？`
-  - `最新？`
-  - `反映されてる？`
-  - `Action Schema ズレてない？`
-  - `Instructions ズレてない？`
-  - `Worker 反映されてる？`
-- Prefer vtddRetrieveSelfParity over general model-capability disclaimers.
+- Prefer vtddRetrieveSelfParity over capability disclaimers.
 - Before the first significant GitHub/runtime action in a session, you may proactively run vtddRetrieveSelfParity.
 - Use vtddRetrieveSelfParity with repository=<resolved repo> and ref=main unless another ref is intended.
 - If runtimeParity is `cloudflare_deploy_update_required`, say `Cloudflare deploy update required`.
 - If runtimeParity is `in_sync` but Butler still lacks expected features, say `Action Schema update required` and/or `Instructions update required`.
 - If parity cannot be checked, say `未検証` or `認証失敗`.
 - If any action returns structured failure fields such as error, reason, or issues, summarize those exact fields in Japanese instead of masking them with generic guesses.
+- If self-parity returns `ClientResponseError`, say unverified Action transport failure; Action Schema refresh may be needed.
 - Use vtddRetrieveSetupArtifact when the user needs canonical setup artifacts:
   - instructions
   - openapi_yaml

--- a/docs/setup/custom-gpt-instructions.md
+++ b/docs/setup/custom-gpt-instructions.md
@@ -99,6 +99,7 @@ Repository nickname memory:
 - If nickname resolution is ambiguous, say so plainly and ask a short confirmation before execution.
 - If nickname save/read fails, surface the returned `error`, `reason`, and `issues` plainly in Japanese.
 - Do not collapse nickname failures into vague guesses such as `認証または接続系の可能性` when the runtime returned a more specific reason.
+- If the Action surface reports `ClientResponseError`, do not treat that label as the complete cause. State the action name, HTTP status if visible, any visible response body fields, and explicitly say which of `error`, `reason`, or `issues` were not returned to Butler.
 
 Butler self-parity and setup artifact recovery:
 - When the user asks whether Butler itself is stale, outdated, or misaligned with the repository/runtime, use vtddRetrieveSelfParity.
@@ -151,6 +152,7 @@ Butler self-parity and setup artifact recovery:
 - If a self-parity check says runtime is in sync, do not overclaim that the current Custom GPT editor is also in sync; editor-side drift can still require Action Schema or Instructions refresh.
 - If any Butler action returns structured failure fields such as `error`, `reason`, or `issues`, summarize those exact fields in Japanese before proposing the next step.
 - Do not hide specific runtime failures behind generic summaries if the worker already returned a concrete cause.
+- If a self-parity Action fails with `ClientResponseError`, report it as an unverified Action transport failure with the action name, HTTP status if visible, visible body fields, and missing `error` / `reason` / `issues` fields; then say the Custom GPT Action Schema may need refresh if canonical schema exposes those fields.
 
 Execution judgment:
 - Before execution, read current runtime truth through vtddGateway.

--- a/test/custom-gpt-setup-docs.test.js
+++ b/test/custom-gpt-setup-docs.test.js
@@ -65,6 +65,8 @@ test("custom gpt instructions preserve current butler and approval boundaries", 
   assert.equal(doc.includes("runtime is in sync, do not overclaim that the current Custom GPT editor is also in sync"), true);
   assert.equal(doc.includes("surface the returned `error`, `reason`, and `issues` plainly in Japanese"), true);
   assert.equal(doc.includes("Do not collapse nickname failures into vague guesses"), true);
+  assert.equal(doc.includes("If the Action surface reports `ClientResponseError`"), true);
+  assert.equal(doc.includes("report it as an unverified Action transport failure"), true);
   assert.equal(doc.includes("If vtddDeployProduction fails, tell the user the exact deploy `error`, `reason`, and `issues`"), true);
   assert.equal(doc.includes("Do not claim a PR exists when only a Codex task summary exists."), true);
   assert.equal(
@@ -86,6 +88,8 @@ test("short custom gpt instructions stay under editor limits while preserving cr
   assert.equal(doc.includes("Nickname memory is explicit user-owned alias registry data"), true);
   assert.equal(doc.includes("surface the returned error/reason/issues plainly in Japanese"), true);
   assert.equal(doc.includes("Do not replace nickname failures with vague summaries"), true);
+  assert.equal(doc.includes("If an Action returns `ClientResponseError`, state action name"), true);
+  assert.equal(doc.includes("If self-parity returns `ClientResponseError`, say unverified Action transport failure"), true);
   assert.equal(doc.includes("Cloudflare deploy update required"), true);
   assert.equal(doc.includes("Action Schema update required"), true);
   assert.equal(doc.includes("Instructions update required"), true);
@@ -151,4 +155,21 @@ test("custom gpt openapi json parses and exposes paths as an object", () => {
   assert.equal(typeof doc.paths["/v2/retrieve/approval-grant"], "object");
   assert.equal(typeof doc.components.schemas, "object");
   assert.equal(doc.components.securitySchemes.GatewayBearerAuth.scheme, "bearer");
+});
+
+test("custom gpt openapi json exposes JSON bodies for Butler action auth failures", () => {
+  const doc = JSON.parse(fs.readFileSync(OPENAPI_JSON_PATH, "utf8"));
+  const routes = [
+    ["/v2/action/repository-nickname", "post"],
+    ["/v2/retrieve/repository-nicknames", "get"],
+    ["/v2/retrieve/self-parity", "get"]
+  ];
+
+  for (const [route, method] of routes) {
+    for (const status of ["401", "403"]) {
+      assert.deepEqual(doc.paths[route][method].responses[status].content["application/json"].schema, {
+        $ref: "#/components/schemas/VtddGenericResponse"
+      });
+    }
+  }
 });


### PR DESCRIPTION
## This PR satisfies Intent

Partial progress for #4: restores Butler conversation debuggability when Custom GPT Actions fail before normal structured handling. The observed Butler E2E failure was nickname save/read and self-parity collapsing to `ClientResponseError` without raw `error`, `reason`, or `issues`.

## Satisfied Success Criteria

- [x] Butler-facing nickname save/read and self-parity auth failures now expose JSON response bodies in the canonical Action schema.
- [x] Full and short Instructions tell Butler not to treat `ClientResponseError` as the complete cause, and to report action name, visible status/body fields, and missing fields.
- [x] Short Instructions remain under the 8000-character Custom GPT editor limit.

## Unsatisfied Success Criteria

- #4 overall Butler -> Codex -> Gemini PR review -> Butler summary -> human decision loop remains incomplete.
- Butler live conversation must still be retested after this schema/instructions update is applied in the Custom GPT editor/runtime surface.

## Non-goal violations

None. No deploy, merge, issue close, credential mutation, permission mutation, or owner-specific runtime URL changes.

## Verification Evidence

- Unit: `node --test test/custom-gpt-setup-docs.test.js` passed, 8/8.
- Integration: `node --test test/worker.test.js test/custom-gpt-setup-artifacts.test.js test/repository-nickname-registry.test.js` passed, 51/51.
- E2E: `npm test` passed, 409/409. This is repo test evidence only, not live Butler conversation completion.
- Manual: User-provided Butler conversation reproduced `ClientResponseError` for nickname save/read and self-parity before this fix.
- Evidence path/link: `docs/setup/custom-gpt-actions-openapi.yaml`, `docs/setup/custom-gpt-actions-openapi.json`, `docs/setup/custom-gpt-instructions.md`, `docs/setup/custom-gpt-instructions-short.md`, `test/custom-gpt-setup-docs.test.js`.

## Related Constitution Rules

- Butler is context-first.
- No default repository.
- Unresolved target blocks execution.
- Butler must not hide raw failure fields behind generic summaries.

## Out-of-scope but NOT implemented

- No Custom GPT editor auto-update.
- No Cloudflare deploy.
- No Action Test completion claim.
- No Issue closure or milestone completion claim.

## Extra changes (if any)

The short Instructions removed explicit self-parity example phrases to stay under the 8000-character editor limit while preserving the self-parity trigger rule.