### PR TITLE
Expose issue bodies in GitHub read plane

### DIFF
--- a/src/core/github-read-plane.js
+++ b/src/core/github-read-plane.js
@@ -309,6 +309,7 @@ function normalizeIssue(item) {
   return {
     number: normalizePositiveInteger(item?.number),
     title: normalizeText(item?.title),
+    body: normalizeText(item?.body),
     state: normalizeText(item?.state),
     htmlUrl: normalizeText(item?.html_url),
     author: normalizeText(item?.user?.login)

--- a/test/github-read-plane.test.js
+++ b/test/github-read-plane.test.js
@@ -46,6 +46,7 @@ test("github read plane lists issues and filters pull request-shaped issue resul
             {
               number: 42,
               title: "Real issue",
+              body: "## Intent\nUse Issue text as the execution spec.",
               state: "open",
               html_url: "https://github.com/sample-org/vtdd-v2-p/issues/42",
               user: { login: "marushu" }
@@ -67,6 +68,38 @@ test("github read plane lists issues and filters pull request-shaped issue resul
   assert.equal(result.ok, true);
   assert.equal(result.read.records.length, 1);
   assert.equal(result.read.records[0].number, 42);
+  assert.equal(result.read.records[0].body, "## Intent\nUse Issue text as the execution spec.");
+});
+
+test("github read plane includes issue body when reading a specific issue", async () => {
+  const calls = [];
+  const result = await retrieveGitHubReadPlane({
+    resource: GitHubReadResource.ISSUES,
+    repository: "sample-org/vtdd-v2-p",
+    issueNumber: 4,
+    env: {
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_issue_read",
+      GITHUB_API_FETCH: async (url) => {
+        calls.push(url);
+        return new Response(
+          JSON.stringify({
+            number: 4,
+            title: "Parent execution loop",
+            body: "## Intent\nButler reads the canonical Issue before execution.",
+            state: "open",
+            html_url: "https://github.com/sample-org/vtdd-v2-p/issues/4",
+            user: { login: "marushu" }
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        );
+      }
+    }
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(calls[0].endsWith("/repos/sample-org/vtdd-v2-p/issues/4"), true);
+  assert.equal(result.read.issueNumber, 4);
+  assert.equal(result.read.records[0].body, "## Intent\nButler reads the canonical Issue before execution.");
 });
 
 test("github read plane reads pull reviews, review comments, checks, workflow runs, and branches", async () => {

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -1071,6 +1071,7 @@ test("worker returns GitHub issues through read plane route", async () => {
             {
               number: 46,
               title: "Implement GitHub read plane",
+              body: "## Intent\nExpose Issue text to Butler.",
               state: "open",
               html_url: "https://github.com/sample-org/vtdd-v2-p/issues/46",
               user: { login: "marushu" }
@@ -1085,6 +1086,7 @@ test("worker returns GitHub issues through read plane route", async () => {
   const body = await response.json();
   assert.equal(body.ok, true);
   assert.equal(body.read.records[0].number, 46);
+  assert.equal(body.read.records[0].body, "## Intent\nExpose Issue text to Butler.");
 });
 
 test("worker returns unsupported for unknown GitHub read resources", async () => {


### PR DESCRIPTION
## This PR satisfies Intent

This PR keeps Issue text usable as the canonical execution spec from the Butler surface by preserving GitHub Issue `body` in the `issues` read-plane response.

The observed Butler failure was not a transport failure: `vtddRetrieveGitHub` returned `ok: true`, but the Issue record for TOMIO #2 only included metadata (`number`, `title`, `state`, `htmlUrl`, `author`) and omitted `body`. Butler correctly refused to summarize or hand off implementation because Intent / Success Criteria / Non-goals were unavailable.

## Satisfied Success Criteria

- Scoped Issue: #4
- Butler can receive GitHub runtime truth that includes Issue body text for `resource=issues`.
- Specific Issue reads preserve body text, so Issue-as-spec can be summarized from runtime truth.
- Issue listing continues to filter pull-request-shaped issue rows while preserving body text for real Issues.
- Worker route evidence confirms the Butler-facing `/v2/retrieve/github` route returns Issue `body`.

## Unsatisfied Success Criteria

- This does not complete #4.
- This does not start TOMIO implementation.
- This does not prove iPhone Butler live E2E yet; deploy is required before live Butler can observe this runtime change.
- This does not close any Issue.

## Surface Update Checklist

- Cloudflare deploy: Required after merge, because this changes worker runtime behavior.
- Custom GPT Action Schema update: Not required; `/v2/retrieve/github` already returns generic JSON with `additionalProperties`.
- Custom GPT Instructions update: Not required for this slice; live Butler already stopped correctly when `body` was absent.
- iPhone Butler live E2E: Required after deploy. Re-run: `TOMIO の #2 を読んで、Issue本文の Intent / Success Criteria / Non-goals をそのまま根拠にして要約して。本文が取れない場合は実装判断せず、取得できなかった raw failure を出して。まだ Codex に渡さないで。`

## Verification Evidence

- `node --test test/github-read-plane.test.js test/worker.test.js test/pr-body-guardrail.test.js` -> 53/53 passed
- `npm test` -> 411/411 passed

E2E: Not yet complete. This PR requires merge, Cloudflare deploy, and iPhone Butler live E2E before claiming the Butler flow is restored.

Evidence path/link:
- `src/core/github-read-plane.js`
- `test/github-read-plane.test.js`
- `test/worker.test.js`
