### PR TITLE
Require clickable passkey operator URLs

### DIFF
--- a/docs/setup/custom-gpt-instructions-short.md
+++ b/docs/setup/custom-gpt-instructions-short.md
@@ -108,10 +108,8 @@ Deploy plane:
   - resolved repository
   - explicit GO
   - real passkey approval grant scoped to deploy_production
-- If no deploy-scoped approval grant exists yet, direct the human to:
-  - /v2/approval/passkey/operator?repositoryInput=<resolved repo>&issueNumber=<active issue when relevant>&actionType=deploy_production&highRiskKind=deploy_production
-- If vtddRetrieveSelfParity returns selfParity.deployRecovery.operatorUrl, return that full absolute URL directly so the human can open it on iPhone/mobile.
-- When you present that URL, say plainly that it is the next safe path for GO + real passkey deploy recovery.
+- If no deploy approval grant exists, show a full clickable absolute passkey operator URL; never only `/v2/approval/passkey/operator...`.
+- Prefer selfParity.deployRecovery.operatorUrl. If constructing from Action origin, show full https://... URL as Markdown link, not code.
 - After vtddDeployProduction, say deploy was dispatched, then re-check self-parity before claiming runtime is updated.
 - If vtddDeployProduction fails, say the exact deploy error/reason/issues and whether the blocker is missing approval grant, auth, memory, or runtime drift.
 

--- a/docs/setup/custom-gpt-instructions.md
+++ b/docs/setup/custom-gpt-instructions.md
@@ -216,9 +216,9 @@ Deploy plane:
   - resolved repository
   - explicit `GO`
   - real passkey approval grant scoped to `deploy_production`
-- If no deploy-scoped approval grant is available yet, direct the human to the canonical same-origin operator helper path:
-  - `/v2/approval/passkey/operator?repositoryInput=<resolved repo>&issueNumber=<active issue when relevant>&actionType=deploy_production&highRiskKind=deploy_production`
-- If `vtddRetrieveSelfParity` returns `selfParity.deployRecovery.operatorUrl`, return that full absolute URL directly so the human can open it on iPhone/mobile without rebuilding the path by hand.
+- If no deploy-scoped approval grant is available yet, direct the human to the passkey operator helper as a full clickable absolute URL. Never show only the relative `/v2/approval/passkey/operator...` path in normal Butler conversation.
+- Prefer calling `vtddRetrieveSelfParity` and using `selfParity.deployRecovery.operatorUrl`; return that full absolute URL directly so the human can open it on iPhone/mobile without rebuilding the path by hand.
+- If you must construct the helper URL yourself from the Action server origin, present the complete `https://.../v2/approval/passkey/operator?repositoryInput=<resolved repo>&issueNumber=<active issue when relevant>&actionType=deploy_production&highRiskKind=deploy_production` URL as a clickable Markdown link, not an inline code block.
 - When you present that URL, say plainly that it is the next safe path for `GO + real passkey` deploy recovery.
 - If the human is on the same-origin passkey operator page, that operator page may also dispatch the governed deploy path after it obtains a deploy-scoped `approvalGrantId`.
 - When self-parity indicates `Cloudflare deploy update required`, you may suggest deploy as the next safe high-risk action.

--- a/test/custom-gpt-setup-docs.test.js
+++ b/test/custom-gpt-setup-docs.test.js
@@ -58,6 +58,8 @@ test("custom gpt instructions preserve current butler and approval boundaries", 
   assert.equal(doc.includes("Cloudflare deploy update required"), true);
   assert.equal(doc.includes("selfParity.deployRecovery.operatorUrl"), true);
   assert.equal(doc.includes("open it on iPhone/mobile"), true);
+  assert.equal(doc.includes("Never show only the relative `/v2/approval/passkey/operator...` path"), true);
+  assert.equal(doc.includes("clickable Markdown link, not an inline code block"), true);
   assert.equal(doc.includes("High-risk actions require GO + passkey."), true);
   assert.equal(doc.includes("Merge requires explicit human GO + real passkey."), true);
   assert.equal(doc.includes("Action Schema update required"), true);
@@ -94,6 +96,9 @@ test("short custom gpt instructions stay under editor limits while preserving cr
   assert.equal(doc.includes("Action Schema update required"), true);
   assert.equal(doc.includes("Instructions update required"), true);
   assert.equal(doc.includes("selfParity.deployRecovery.operatorUrl"), true);
+  assert.equal(doc.includes("show a full clickable absolute passkey operator URL"), true);
+  assert.equal(doc.includes("never only `/v2/approval/passkey/operator...`"), true);
+  assert.equal(doc.includes("Markdown link, not code"), true);
   assert.equal(doc.includes("GO + real passkey"), true);
   assert.equal(doc.includes("If vtddDeployProduction fails, say the exact deploy error/reason/issues"), true);
 });


### PR DESCRIPTION
## This PR satisfies Intent

This PR fixes the observed Butler deploy approval guidance failure where Butler returned only the internal relative path `/v2/approval/passkey/operator...` instead of an iPhone-openable URL.

Butler should present passkey approval recovery as a full clickable absolute URL, preferably from `selfParity.deployRecovery.operatorUrl`, and must not ask the human to rebuild an internal API path by hand.

## Satisfied Success Criteria

- Scoped Issue: #4
- Butler guidance now says to show a full clickable absolute passkey operator URL when deploy approval is missing.
- Full Instructions explicitly forbid showing only the relative `/v2/approval/passkey/operator...` path in normal Butler conversation.
- Short Instructions preserve the same rule while staying under the 8000-character editor limit.
- Tests pin the clickable absolute URL / Markdown link guidance.

## Unsatisfied Success Criteria

- This does not execute deploy.
- This does not mutate credentials or approval grants.
- This does not complete #4.
- This does not prove live iPhone Butler behavior until the updated Instructions are pasted into the Custom GPT editor and re-tested.

## Surface Update Checklist

- Cloudflare deploy: Not required; this is Instructions-only.
- Custom GPT Action Schema update: Not required.
- Custom GPT Instructions update: Required. Paste the updated short/full Instructions into the Custom GPT editor.
- iPhone Butler live E2E: Required after Instructions update. Re-run the deploy approval request and confirm Butler returns a clickable `https://.../v2/approval/passkey/operator?...` link, not a relative path or code block.

## Verification Evidence

- `node --test test/custom-gpt-setup-docs.test.js test/custom-gpt-setup-artifacts.test.js test/worker.test.js` -> 55/55 passed
- `npm test` -> 411/411 passed

E2E: Not yet complete. Live Butler must be updated and re-tested from iPhone.

Evidence path/link:
- `docs/setup/custom-gpt-instructions.md`
- `docs/setup/custom-gpt-instructions-short.md`
- `test/custom-gpt-setup-docs.test.js`
