### PR TITLE
Verify deploy dispatch workflow runs

### DIFF
--- a/src/core/deploy-production-plane.js
+++ b/src/core/deploy-production-plane.js
@@ -50,6 +50,14 @@ export async function executeDeployProductionPlane(input = {}) {
     repository;
   const workflowFile = normalizeText(env?.DEPLOY_WORKFLOW_FILE) || DEFAULT_DEPLOY_WORKFLOW_FILE;
   const workflowRef = normalizeText(env?.DEPLOY_WORKFLOW_REF) || DEFAULT_DEPLOY_WORKFLOW_REF;
+  const deployBase = {
+    repository,
+    workflowRepository,
+    workflowFile,
+    workflowRef,
+    approvalGrantId,
+    runtimeUrl
+  };
 
   const dispatchUrl = `${apiBaseUrl}/repos/${encodeURIComponentRepository(
     workflowRepository
@@ -63,6 +71,7 @@ export async function executeDeployProductionPlane(input = {}) {
     }
   };
 
+  const dispatchedAt = new Date().toISOString();
   let response;
   try {
     response = await fetchImpl(dispatchUrl, {
@@ -91,21 +100,114 @@ export async function executeDeployProductionPlane(input = {}) {
       ok: false,
       status: response.status,
       error: "deploy_dispatch_failed",
-      reason: normalizeText(body?.message) || "GitHub deploy workflow dispatch failed"
+      reason: normalizeText(body?.message) || "GitHub deploy workflow dispatch failed",
+      deploy: {
+        ...deployBase,
+        status: "dispatch_failed"
+      }
+    };
+  }
+
+  const observedRun = await verifyDeployWorkflowRun({
+    apiBaseUrl,
+    workflowRepository,
+    workflowFile,
+    workflowRef,
+    dispatchedAt,
+    token: tokenResolution.token,
+    fetchImpl,
+    env
+  });
+  if (!observedRun.ok) {
+    return {
+      ok: false,
+      status: 503,
+      error: "deploy_dispatch_unverified",
+      reason: observedRun.reason,
+      deploy: {
+        ...deployBase,
+        status: "dispatch_unverified"
+      }
     };
   }
 
   return {
     ok: true,
     deploy: {
-      repository,
-      workflowRepository,
-      workflowFile,
-      workflowRef,
-      approvalGrantId,
-      runtimeUrl,
-      status: "dispatched"
+      ...deployBase,
+      status: "dispatched",
+      runId: observedRun.run.id,
+      runUrl: observedRun.run.htmlUrl,
+      runStatus: observedRun.run.status,
+      runConclusion: observedRun.run.conclusion
     }
+  };
+}
+
+async function verifyDeployWorkflowRun({
+  apiBaseUrl,
+  workflowRepository,
+  workflowFile,
+  workflowRef,
+  dispatchedAt,
+  token,
+  fetchImpl,
+  env
+}) {
+  const attempts = normalizePositiveInteger(env?.DEPLOY_DISPATCH_VERIFY_ATTEMPTS, 3);
+  const delayMs = normalizeNonNegativeInteger(env?.DEPLOY_DISPATCH_VERIFY_DELAY_MS, 1000);
+  const runsUrl = new URL(`${apiBaseUrl}/repos/${encodeURIComponentRepository(
+    workflowRepository
+  )}/actions/workflows/${encodeURIComponent(
+    workflowFile
+  )}/runs`);
+  runsUrl.searchParams.set("branch", workflowRef);
+  runsUrl.searchParams.set("event", "workflow_dispatch");
+  runsUrl.searchParams.set("created", `>=${dispatchedAt}`);
+  runsUrl.searchParams.set("per_page", "10");
+
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    let response;
+    try {
+      response = await fetchImpl(runsUrl.toString(), {
+        method: "GET",
+        headers: {
+          authorization: `Bearer ${token}`,
+          accept: "application/vnd.github+json",
+          "x-github-api-version": GITHUB_API_VERSION,
+          "user-agent": GITHUB_API_USER_AGENT
+        }
+      });
+    } catch {
+      return {
+        ok: false,
+        reason: "GitHub accepted deploy dispatch, but workflow run verification failed"
+      };
+    }
+
+    const body = await readJsonSafe(response);
+    if (!response.ok) {
+      return {
+        ok: false,
+        reason:
+          normalizeText(body?.message) ||
+          "GitHub accepted deploy dispatch, but workflow runs could not be read"
+      };
+    }
+
+    const run = normalizeWorkflowRun(body?.workflow_runs?.[0]);
+    if (run) {
+      return { ok: true, run };
+    }
+
+    if (attempt < attempts && delayMs > 0) {
+      await sleep(delayMs);
+    }
+  }
+
+  return {
+    ok: false,
+    reason: "GitHub accepted deploy dispatch, but no deploy-production workflow run was observed"
   };
 }
 
@@ -146,6 +248,20 @@ function encodeURIComponentRepository(repository) {
   return `${encodeURIComponent(owner)}/${encodeURIComponent(name)}`;
 }
 
+function normalizeWorkflowRun(run) {
+  const id = normalizePositiveInteger(run?.id, null);
+  const htmlUrl = normalizeText(run?.html_url);
+  if (!id || !htmlUrl) {
+    return null;
+  }
+  return {
+    id,
+    htmlUrl,
+    status: normalizeText(run?.status),
+    conclusion: normalizeText(run?.conclusion)
+  };
+}
+
 async function readJsonSafe(response) {
   return response.json().catch(() => ({}));
 }
@@ -155,6 +271,20 @@ function normalizeApiBaseUrl(value) {
   return normalized || "https://api.github.com";
 }
 
+function normalizePositiveInteger(value, fallback) {
+  const numeric = Number(value);
+  return Number.isInteger(numeric) && numeric > 0 ? numeric : fallback;
+}
+
+function normalizeNonNegativeInteger(value, fallback) {
+  const numeric = Number(value);
+  return Number.isInteger(numeric) && numeric >= 0 ? numeric : fallback;
+}
+
 function normalizeText(value) {
   return String(value ?? "").trim();
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/src/worker.js
+++ b/src/worker.js
@@ -879,7 +879,8 @@ async function handleDeployProductionRequest(request, env) {
       ok: false,
       error: executed.error ?? "deploy_failed",
       reason: executed.reason,
-      issues: executed.issues ?? []
+      issues: executed.issues ?? [],
+      deploy: executed.deploy
     });
   }
 

--- a/test/deploy-production-plane.test.js
+++ b/test/deploy-production-plane.test.js
@@ -21,8 +21,24 @@ test("deploy production plane dispatches governed workflow with GO + passkey inp
     },
     env: {
       GITHUB_APP_INSTALLATION_TOKEN: "ghs_deploy",
+      DEPLOY_DISPATCH_VERIFY_DELAY_MS: "0",
       GITHUB_API_FETCH: async (url, init) => {
         calls.push({ url: String(url), init });
+        if (String(url).includes("/actions/workflows/deploy-production.yml/runs")) {
+          return new Response(
+            JSON.stringify({
+              workflow_runs: [
+                {
+                  id: 123456,
+                  html_url: "https://github.com/sample-org/vtdd-v2-p/actions/runs/123456",
+                  status: "queued",
+                  conclusion: null
+                }
+              ]
+            }),
+            { status: 200, headers: { "content-type": "application/json" } }
+          );
+        }
         return new Response(null, { status: 204 });
       }
     }
@@ -30,11 +46,53 @@ test("deploy production plane dispatches governed workflow with GO + passkey inp
 
   assert.equal(result.ok, true);
   assert.equal(result.deploy.status, "dispatched");
+  assert.equal(result.deploy.runId, 123456);
+  assert.equal(result.deploy.runUrl, "https://github.com/sample-org/vtdd-v2-p/actions/runs/123456");
   assert.equal(calls[0].url.includes("/actions/workflows/deploy-production.yml/dispatches"), true);
+  assert.equal(calls[1].url.includes("/actions/workflows/deploy-production.yml/runs"), true);
   const body = JSON.parse(calls[0].init.body);
   assert.equal(body.inputs.approval_phrase, "GO");
   assert.equal(body.inputs.approval_grant_id, "approval-deploy-123");
   assert.equal(body.inputs.runtime_url, "https://sample-user-vtdd.example.workers.dev");
+});
+
+test("deploy production plane blocks when dispatch cannot be observed as a workflow run", async () => {
+  const result = await executeDeployProductionPlane({
+    repository: "sample-org/vtdd-v2-p",
+    runtimeUrl: "https://sample-user-vtdd.example.workers.dev",
+    approvalPhrase: "GO",
+    approvalGrantId: "approval-deploy-123",
+    approvalGrant: {
+      approvalId: "approval-deploy-123",
+      verified: true,
+      expiresAt: "2099-01-01T00:00:00.000Z",
+      scope: {
+        actionType: "deploy_production",
+        highRiskKind: "deploy_production",
+        repositoryInput: "sample-org/vtdd-v2-p"
+      }
+    },
+    env: {
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_deploy",
+      DEPLOY_DISPATCH_VERIFY_ATTEMPTS: "1",
+      DEPLOY_DISPATCH_VERIFY_DELAY_MS: "0",
+      GITHUB_API_FETCH: async (url) => {
+        if (String(url).includes("/actions/workflows/deploy-production.yml/runs")) {
+          return new Response(JSON.stringify({ workflow_runs: [] }), {
+            status: 200,
+            headers: { "content-type": "application/json" }
+          });
+        }
+        return new Response(null, { status: 204 });
+      }
+    }
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.error, "deploy_dispatch_unverified");
+  assert.equal(result.deploy.status, "dispatch_unverified");
+  assert.equal(result.deploy.workflowFile, "deploy-production.yml");
+  assert.equal(result.deploy.repository, "sample-org/vtdd-v2-p");
 });
 
 test("deploy production plane blocks missing GO + passkey inputs", async () => {

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -1519,8 +1519,24 @@ test("worker dispatches governed production deploy using the request origin as t
       ...gatewayAuthEnv,
       MEMORY_PROVIDER: provider,
       GITHUB_APP_INSTALLATION_TOKEN: "ghs_deploy",
+      DEPLOY_DISPATCH_VERIFY_DELAY_MS: "0",
       GITHUB_API_FETCH: async (url, init) => {
         calls.push({ url: String(url), init });
+        if (String(url).includes("/actions/workflows/deploy-production.yml/runs")) {
+          return new Response(
+            JSON.stringify({
+              workflow_runs: [
+                {
+                  id: 9090,
+                  html_url: "https://github.com/sample-org/vtdd-v2-p/actions/runs/9090",
+                  status: "queued",
+                  conclusion: null
+                }
+              ]
+            }),
+            { status: 200, headers: { "content-type": "application/json" } }
+          );
+        }
         return new Response(null, { status: 204 });
       }
     }
@@ -1530,6 +1546,7 @@ test("worker dispatches governed production deploy using the request origin as t
   const body = await response.json();
   assert.equal(body.ok, true);
   assert.equal(body.deploy.status, "dispatched");
+  assert.equal(body.deploy.runUrl, "https://github.com/sample-org/vtdd-v2-p/actions/runs/9090");
   assert.equal(body.deploy.runtimeUrl, "https://sample-user-vtdd.example.workers.dev");
   const dispatchBody = JSON.parse(calls[0].init.body);
   assert.equal(
@@ -1584,8 +1601,24 @@ test("worker allows same-origin browser governed production deploy with a real a
       ...gatewayAuthEnv,
       MEMORY_PROVIDER: provider,
       GITHUB_APP_INSTALLATION_TOKEN: "ghs_deploy",
+      DEPLOY_DISPATCH_VERIFY_DELAY_MS: "0",
       GITHUB_API_FETCH: async (url, init) => {
         calls.push({ url: String(url), init });
+        if (String(url).includes("/actions/workflows/deploy-production.yml/runs")) {
+          return new Response(
+            JSON.stringify({
+              workflow_runs: [
+                {
+                  id: 9091,
+                  html_url: "https://github.com/sample-org/vtdd-v2-p/actions/runs/9091",
+                  status: "queued",
+                  conclusion: null
+                }
+              ]
+            }),
+            { status: 200, headers: { "content-type": "application/json" } }
+          );
+        }
         return new Response(null, { status: 204 });
       }
     }
@@ -1595,12 +1628,79 @@ test("worker allows same-origin browser governed production deploy with a real a
   const body = await response.json();
   assert.equal(body.ok, true);
   assert.equal(body.deploy.status, "dispatched");
+  assert.equal(body.deploy.runUrl, "https://github.com/sample-org/vtdd-v2-p/actions/runs/9091");
   assert.equal(body.deploy.runtimeUrl, "https://sample-user-vtdd.example.workers.dev");
   const dispatchBody = JSON.parse(calls[0].init.body);
   assert.equal(
     dispatchBody.inputs.runtime_url,
     "https://sample-user-vtdd.example.workers.dev"
   );
+});
+
+test("worker returns raw deploy context when workflow dispatch is unverified", async () => {
+  const provider = createInMemoryMemoryProvider();
+  await provider.store({
+    id: "approval-deploy-unverified-123",
+    type: MemoryRecordType.APPROVAL_LOG,
+    content: {
+      kind: "passkey_grant",
+      status: "verified",
+      approvalId: "approval-deploy-unverified-123",
+      expiresAt: "2099-01-01T00:00:00.000Z",
+      scope: {
+        actionType: "deploy_production",
+        highRiskKind: "deploy_production",
+        repositoryInput: "sample-org/vtdd-v2-p",
+        phase: "execution"
+      }
+    },
+    metadata: { source: "test" },
+    priority: 90,
+    tags: ["passkey_grant"],
+    createdAt: "2026-04-27T00:00:00.000Z"
+  });
+
+  const response = await worker.fetch(
+    new Request("https://sample-user-vtdd.example.workers.dev/v2/action/deploy", {
+      method: "POST",
+      headers: {
+        ...gatewayAuthHeaders,
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({
+        repository: "sample-org/vtdd-v2-p",
+        policyInput: {
+          approvalPhrase: "GO",
+          approvalGrantId: "approval-deploy-unverified-123"
+        }
+      })
+    }),
+    {
+      ...gatewayAuthEnv,
+      MEMORY_PROVIDER: provider,
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_deploy",
+      DEPLOY_DISPATCH_VERIFY_ATTEMPTS: "1",
+      DEPLOY_DISPATCH_VERIFY_DELAY_MS: "0",
+      GITHUB_API_FETCH: async (url) => {
+        if (String(url).includes("/actions/workflows/deploy-production.yml/runs")) {
+          return new Response(JSON.stringify({ workflow_runs: [] }), {
+            status: 200,
+            headers: { "content-type": "application/json" }
+          });
+        }
+        return new Response(null, { status: 204 });
+      }
+    }
+  );
+
+  assert.equal(response.status, 503);
+  const body = await response.json();
+  assert.equal(body.ok, false);
+  assert.equal(body.error, "deploy_dispatch_unverified");
+  assert.equal(body.deploy.status, "dispatch_unverified");
+  assert.equal(body.deploy.repository, "sample-org/vtdd-v2-p");
+  assert.equal(body.deploy.workflowFile, "deploy-production.yml");
+  assert.equal(body.deploy.runtimeUrl, "https://sample-user-vtdd.example.workers.dev");
 });
 
 test("worker returns remote Codex execution progress", async () => {


### PR DESCRIPTION
## This PR satisfies Intent

This PR fixes the Butler deploy path that could report `vtddDeployProduction` as dispatched even when no `deploy-production` GitHub Actions run was observable.

After GitHub accepts the workflow dispatch request, the deploy plane now reads workflow runs for the same workflow/ref and only returns success when a newly-created `workflow_dispatch` run is observed with a run id and URL. If no run is observed, Butler receives `deploy_dispatch_unverified` plus the raw deploy context instead of an empty result.

## Satisfied Success Criteria

- Scoped Issue: #4
- Deploy dispatch success now includes observable runtime truth: `runId`, `runUrl`, `runStatus`, and `runConclusion`.
- Dispatch verification is limited to workflow runs created at or after the dispatch attempt, avoiding false success from old deploy runs.
- If dispatch cannot be observed, the worker returns `ok:false`, `error: deploy_dispatch_unverified`, and raw `deploy` context including repository, workflowRepository, workflowFile, workflowRef, approvalGrantId, runtimeUrl, and status.
- Tests cover both observed dispatch and dispatch-unverified boundary behavior.

## Unsatisfied Success Criteria

- This does not execute a production deploy.
- This does not mutate credentials or approval grants.
- This does not complete #4.
- Live iPhone Butler E2E remains required after merge and deploy.

## Surface Update Checklist

- Cloudflare deploy: Required after merge, because this changes worker runtime behavior.
- Custom GPT Action Schema update: Not required; `/v2/action/deploy` already returns generic JSON with `additionalProperties`.
- Custom GPT Instructions update: Not required for this slice.
- iPhone Butler live E2E: Required after deploy. Re-run deploy request and confirm Butler either returns a deploy run URL or stops with `deploy_dispatch_unverified` and raw deploy context.

## Verification Evidence

- `node --test test/deploy-production-plane.test.js test/worker.test.js` -> 49/49 passed
- `npm test` -> 413/413 passed

E2E: Not yet complete. Current production runtime still lacks this dispatch verification behavior.

Evidence path/link:
- `src/core/deploy-production-plane.js`
- `src/worker.js`
- `test/deploy-production-plane.test.js`
- `test/worker.test.js`
