### PR TITLE
Add approval-bound OpenAI key secret sync

### DIFF
--- a/docs/setup/custom-gpt-actions-openapi.json
+++ b/docs/setup/custom-gpt-actions-openapi.json
@@ -1270,6 +1270,84 @@
           }
         }
       }
+    },
+    "/v2/action/github-actions-secret": {
+      "post": {
+        "operationId": "vtddSyncGitHubActionsSecret",
+        "summary": "Sync an approved GitHub Actions secret such as OPENAI_API_KEY after GO plus real passkey approval.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "repository": {
+                    "type": "string"
+                  },
+                  "secretName": {
+                    "type": "string",
+                    "enum": [
+                      "OPENAI_API_KEY"
+                    ]
+                  },
+                  "secretValue": {
+                    "type": "string"
+                  },
+                  "policyInput": {
+                    "type": "object",
+                    "properties": {
+                      "approvalGrantId": {
+                        "type": "string"
+                      }
+                    },
+                    "additionalProperties": true
+                  }
+                },
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "GitHub Actions secret synced",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VtddGenericResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing machine auth"
+          },
+          "403": {
+            "description": "Invalid machine auth"
+          },
+          "422": {
+            "description": "GitHub Actions secret sync request blocked or invalid",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VtddGenericResponse"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "GitHub Actions secret sync failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VtddGenericResponse"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/docs/setup/custom-gpt-actions-openapi.yaml
+++ b/docs/setup/custom-gpt-actions-openapi.yaml
@@ -499,6 +499,55 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/VtddGenericResponse"
+  /v2/action/github-actions-secret:
+    post:
+      operationId: vtddSyncGitHubActionsSecret
+      summary: Sync an approved GitHub Actions secret such as OPENAI_API_KEY after GO plus real passkey approval.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                repository:
+                  type: string
+                secretName:
+                  type: string
+                  enum:
+                    - OPENAI_API_KEY
+                secretValue:
+                  type: string
+                policyInput:
+                  type: object
+                  properties:
+                    approvalGrantId:
+                      type: string
+                  additionalProperties: true
+              additionalProperties: true
+      responses:
+        "200":
+          description: GitHub Actions secret synced
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VtddGenericResponse"
+        "401":
+          description: Missing machine auth
+        "403":
+          description: Invalid machine auth
+        "422":
+          description: GitHub Actions secret sync request blocked or invalid
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VtddGenericResponse"
+        "503":
+          description: GitHub Actions secret sync failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VtddGenericResponse"
   /v2/action/repository-nickname:
     post:
       operationId: vtddUpsertRepositoryNickname

--- a/docs/setup/custom-gpt-instructions-short.md
+++ b/docs/setup/custom-gpt-instructions-short.md
@@ -112,6 +112,7 @@ Deploy plane:
 - Prefer selfParity.deployRecovery.operatorUrl. If constructing from Action origin, show full https://... URL as Markdown link, not code.
 - After vtddDeployProduction, say deploy was dispatched, then re-check self-parity before claiming runtime is updated.
 - If vtddDeployProduction fails, say the exact deploy error/reason/issues and whether the blocker is missing approval grant, auth, memory, or runtime drift.
+- If fallback says openai_api_key_not_configured, do not ask for OPENAI_API_KEY in chat; send operator URL with highRiskKind=github_actions_secret_sync. vtddSyncGitHubActionsSecret syncs only OPENAI_API_KEY after GO + passkey.
 
 Progress tracking:
 - After vtddExecute, always call vtddExecutionProgress.

--- a/docs/setup/custom-gpt-instructions.md
+++ b/docs/setup/custom-gpt-instructions.md
@@ -225,6 +225,12 @@ Deploy plane:
 - After vtddDeployProduction, tell the user deploy was dispatched and then re-check self-parity before claiming runtime is updated.
 - If vtddDeployProduction fails, tell the user the exact deploy `error`, `reason`, and `issues`, including whether the blocker is missing approval grant, auth, memory, or runtime drift.
 
+GitHub Actions secret sync:
+- If reviewer fallback is blocked by `openai_api_key_not_configured`, do not ask the human to paste `OPENAI_API_KEY` into Butler chat.
+- Direct the human to the same-origin passkey operator URL with `actionType=destructive&highRiskKind=github_actions_secret_sync`.
+- The operator page may call vtddSyncGitHubActionsSecret for `OPENAI_API_KEY` only after GO + real passkey approval.
+- If vtddSyncGitHubActionsSecret fails, report the exact `error`, `reason`, and `issues`; never echo the secret value.
+
 Progress tracking:
 - After vtddExecute, always call vtddExecutionProgress.
 - Use executionId, repository, issueNumber, and branch.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
       "name": "vtdd-v2",
       "version": "0.1.0",
       "dependencies": {
-        "@simplewebauthn/server": "^13.3.0"
+        "@simplewebauthn/server": "^13.3.0",
+        "libsodium-wrappers": "^0.8.4"
       },
       "engines": {
         "node": ">=20"
@@ -216,6 +217,21 @@
       },
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/libsodium": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/libsodium/-/libsodium-0.8.4.tgz",
+      "integrity": "sha512-lMcYaRi0zcs7tarATsQUYC7rstliIXZuoq0c6zXSgNtSNtdvBgkSegjWhpMJAXzKX3SUSwIp7+zEsob+j3LuRw==",
+      "license": "ISC"
+    },
+    "node_modules/libsodium-wrappers": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/libsodium-wrappers/-/libsodium-wrappers-0.8.4.tgz",
+      "integrity": "sha512-mu8aAWucZjTB5O/BtGXtW4e1agy7uHxNYG7zPthmmD1jU43LCDmSWZLN4JhflbdPXj3yDO4lxM1O9hLDgIOXDw==",
+      "license": "ISC",
+      "dependencies": {
+        "libsodium": "^0.8.0"
       }
     },
     "node_modules/pvtsutils": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "node": ">=20"
   },
   "dependencies": {
-    "@simplewebauthn/server": "^13.3.0"
+    "@simplewebauthn/server": "^13.3.0",
+    "libsodium-wrappers": "^0.8.4"
   }
 }

--- a/src/core/github-actions-secret-sync.js
+++ b/src/core/github-actions-secret-sync.js
@@ -1,0 +1,223 @@
+import sodium from "libsodium-wrappers";
+import { resolveGitHubAppInstallationToken } from "./github-app-repository-index.js";
+
+const GITHUB_API_BASE_URL = "https://api.github.com";
+const GITHUB_API_VERSION = "2022-11-28";
+const GITHUB_API_USER_AGENT = "vtdd-v2-github-actions-secret-sync";
+const ALLOWED_ACTIONS_SECRET_NAMES = new Set(["OPENAI_API_KEY"]);
+
+export async function executeGitHubActionsSecretSync(input = {}) {
+  const repository = normalizeText(input.repository);
+  const secretName = normalizeText(input.secretName);
+  const secretValue = normalizeText(input.secretValue);
+  const approvalGrant = input.approvalGrant ?? null;
+  const env = input.env ?? {};
+  const fetchImpl = typeof env?.GITHUB_API_FETCH === "function" ? env.GITHUB_API_FETCH.bind(env) : fetch;
+  const apiBaseUrl = normalizeApiBaseUrl(env?.GITHUB_API_BASE_URL);
+  const encryptSecret =
+    typeof input.encryptSecret === "function" ? input.encryptSecret : encryptGitHubActionsSecret;
+
+  const validation = validateGitHubActionsSecretSyncRequest({
+    repository,
+    secretName,
+    secretValue,
+    approvalGrant
+  });
+  if (!validation.ok) {
+    return {
+      ok: false,
+      status: 422,
+      error: "github_actions_secret_sync_request_invalid",
+      reason: validation.issues.join(", "),
+      issues: validation.issues
+    };
+  }
+
+  const tokenResolution = await resolveGitHubAppInstallationToken({ env, fetchImpl, apiBaseUrl });
+  if (!tokenResolution.ok) {
+    return {
+      ok: false,
+      status: 503,
+      error: "github_actions_secret_sync_unavailable",
+      reason:
+        tokenResolution.warning ||
+        "GitHub App installation token is unavailable for GitHub Actions secret sync"
+    };
+  }
+
+  const encodedRepository = encodeURIComponentRepository(repository);
+  const publicKeyResponse = await fetchImpl(`${apiBaseUrl}/repos/${encodedRepository}/actions/secrets/public-key`, {
+    method: "GET",
+    headers: githubHeaders(tokenResolution.token)
+  }).catch(() => null);
+  if (!publicKeyResponse) {
+    return {
+      ok: false,
+      status: 503,
+      error: "github_actions_secret_sync_failed",
+      reason: "failed to read GitHub Actions secret public key"
+    };
+  }
+
+  const publicKeyBody = await readJsonSafe(publicKeyResponse);
+  if (!publicKeyResponse.ok) {
+    return {
+      ok: false,
+      status: publicKeyResponse.status,
+      error: "github_actions_secret_sync_failed",
+      reason: normalizeText(publicKeyBody?.message) || "GitHub Actions secret public key read failed"
+    };
+  }
+
+  const keyId = normalizeText(publicKeyBody?.key_id);
+  const key = normalizeText(publicKeyBody?.key);
+  if (!keyId || !key) {
+    return {
+      ok: false,
+      status: 503,
+      error: "github_actions_secret_sync_failed",
+      reason: "GitHub Actions secret public key response is incomplete"
+    };
+  }
+
+  const encryptedValue = await encryptSecret({ publicKey: key, secretValue });
+  const putResponse = await fetchImpl(
+    `${apiBaseUrl}/repos/${encodedRepository}/actions/secrets/${encodeURIComponent(secretName)}`,
+    {
+      method: "PUT",
+      headers: githubHeaders(tokenResolution.token),
+      body: JSON.stringify({
+        encrypted_value: encryptedValue,
+        key_id: keyId
+      })
+    }
+  ).catch(() => null);
+  if (!putResponse) {
+    return {
+      ok: false,
+      status: 503,
+      error: "github_actions_secret_sync_failed",
+      reason: "failed to write GitHub Actions secret"
+    };
+  }
+
+  if (!putResponse.ok) {
+    const putBody = await readJsonSafe(putResponse);
+    return {
+      ok: false,
+      status: putResponse.status,
+      error: "github_actions_secret_sync_failed",
+      reason: normalizeText(putBody?.message) || "GitHub Actions secret write failed"
+    };
+  }
+
+  return {
+    ok: true,
+    secretSync: {
+      repository,
+      app: "actions",
+      secretName,
+      status: putResponse.status === 201 ? "created" : "updated"
+    }
+  };
+}
+
+export function validateGitHubActionsSecretSyncRequest({
+  repository,
+  secretName,
+  secretValue,
+  approvalGrant
+}) {
+  const issues = [];
+  if (!repository) {
+    issues.push("repository is required");
+  }
+  if (!ALLOWED_ACTIONS_SECRET_NAMES.has(secretName)) {
+    issues.push("secretName must be OPENAI_API_KEY");
+  }
+  if (!secretValue) {
+    issues.push("secretValue is required");
+  }
+  const approvalValidation = validateGitHubActionsSecretSyncApprovalGrant({
+    approvalGrant,
+    repository
+  });
+  if (!approvalValidation.ok) {
+    issues.push(...approvalValidation.issues);
+  }
+  return issues.length > 0 ? { ok: false, issues } : { ok: true };
+}
+
+export function validateGitHubActionsSecretSyncApprovalGrant(input = {}) {
+  const approvalGrant = input.approvalGrant ?? null;
+  const repository = normalizeText(input.repository);
+  const now = new Date(input.now ?? Date.now());
+
+  if (!approvalGrant || approvalGrant.verified !== true) {
+    return {
+      ok: false,
+      issues: ["real approvalGrant is required for GitHub Actions secret sync"]
+    };
+  }
+
+  const expiresAt = normalizeText(approvalGrant.expiresAt);
+  if (!expiresAt || Number.isNaN(Date.parse(expiresAt)) || Date.parse(expiresAt) <= now.valueOf()) {
+    return {
+      ok: false,
+      issues: ["approvalGrant is expired or invalid"]
+    };
+  }
+
+  const scope = approvalGrant.scope ?? {};
+  if (normalizeText(scope.repositoryInput) !== repository) {
+    return {
+      ok: false,
+      issues: ["approvalGrant scope.repositoryInput must match target repo"]
+    };
+  }
+
+  if (normalizeText(scope.highRiskKind) !== "github_actions_secret_sync") {
+    return {
+      ok: false,
+      issues: ["approvalGrant scope.highRiskKind must be github_actions_secret_sync"]
+    };
+  }
+
+  return { ok: true };
+}
+
+export async function encryptGitHubActionsSecret({ publicKey, secretValue }) {
+  await sodium.ready;
+  const binaryKey = sodium.from_base64(publicKey, sodium.base64_variants.ORIGINAL);
+  const binarySecret = sodium.from_string(secretValue);
+  const encrypted = sodium.crypto_box_seal(binarySecret, binaryKey);
+  return sodium.to_base64(encrypted, sodium.base64_variants.ORIGINAL);
+}
+
+function githubHeaders(token) {
+  return {
+    authorization: `Bearer ${token}`,
+    accept: "application/vnd.github+json",
+    "content-type": "application/json; charset=utf-8",
+    "x-github-api-version": GITHUB_API_VERSION,
+    "user-agent": GITHUB_API_USER_AGENT
+  };
+}
+
+function encodeURIComponentRepository(repository) {
+  const [owner = "", name = ""] = normalizeText(repository).split("/");
+  return `${encodeURIComponent(owner)}/${encodeURIComponent(name)}`;
+}
+
+async function readJsonSafe(response) {
+  return response.json().catch(() => ({}));
+}
+
+function normalizeApiBaseUrl(value) {
+  const normalized = normalizeText(value);
+  return normalized ? normalized.replace(/\/+$/, "") : GITHUB_API_BASE_URL;
+}
+
+function normalizeText(value) {
+  return String(value ?? "").trim();
+}

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -49,6 +49,12 @@ export {
   buildCloudflareDeploySecretSyncPlan,
   executeCloudflareDeploySecretSync
 } from "./cloudflare-deploy-secret-sync.js";
+export {
+  encryptGitHubActionsSecret,
+  executeGitHubActionsSecretSync,
+  validateGitHubActionsSecretSyncApprovalGrant,
+  validateGitHubActionsSecretSyncRequest
+} from "./github-actions-secret-sync.js";
 export { requiredCredentialTier, evaluateCredentialBoundary } from "./credential-boundary.js";
 export { resolveRepositoryTarget } from "./repository-resolution.js";
 export {

--- a/src/core/passkey-operator-page.js
+++ b/src/core/passkey-operator-page.js
@@ -184,6 +184,18 @@ export function renderPasskeyOperatorPage(input = {}) {
           <p class="muted">この Worker origin を <code>runtimeUrl</code> として使います。実行後は Butler で self-parity を再確認してください。</p>
           <pre id="deploy-output"></pre>
         </section>
+
+        <section>
+          <h2>5. Codex Fallback Secret Sync</h2>
+          <p class="muted">Codex reviewer fallback 用の <code>OPENAI_API_KEY</code> を GitHub Actions secret に同期します。値は Butler 会話に貼らず、この operator page から送信します。</p>
+          <label for="openai-api-key-input">OPENAI_API_KEY</label>
+          <input id="openai-api-key-input" type="password" autocomplete="off" placeholder="sk-..." />
+          <div class="row">
+            <button id="openai-secret-sync-button">Sync OPENAI_API_KEY</button>
+          </div>
+          <p class="muted"><code>actionType=destructive</code> / <code>highRiskKind=github_actions_secret_sync</code> の approvalGrantId が必要です。</p>
+          <pre id="openai-secret-sync-output"></pre>
+        </section>
       </div>
     </main>
 
@@ -192,6 +204,7 @@ export function renderPasskeyOperatorPage(input = {}) {
       const approveOutput = document.getElementById("approve-output");
       const syncOutput = document.getElementById("sync-output");
       const deployOutput = document.getElementById("deploy-output");
+      const openaiSecretSyncOutput = document.getElementById("openai-secret-sync-output");
       let latestApprovalGrantId = "";
 
       document.getElementById("register-button").addEventListener("click", async () => {
@@ -329,6 +342,39 @@ export function renderPasskeyOperatorPage(input = {}) {
           deployOutput.textContent = JSON.stringify(deployBody, null, 2);
         } catch (error) {
           deployOutput.textContent = String(error);
+        }
+      });
+
+      document.getElementById("openai-secret-sync-button").addEventListener("click", async () => {
+        try {
+          if (!latestApprovalGrantId) {
+            throw new Error("approvalGrantId is required before OPENAI_API_KEY secret sync");
+          }
+          const secretValue = document.getElementById("openai-api-key-input").value;
+          if (!secretValue) {
+            throw new Error("OPENAI_API_KEY is required");
+          }
+          openaiSecretSyncOutput.textContent = "OPENAI_API_KEY secret sync request...";
+          const syncResponse = await fetch("${apiBase}/action/github-actions-secret", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({
+              repository: document.getElementById("repo-input").value,
+              secretName: "OPENAI_API_KEY",
+              secretValue,
+              policyInput: {
+                approvalGrantId: latestApprovalGrantId
+              }
+            })
+          });
+          const syncBody = await syncResponse.json();
+          if (!syncResponse.ok) {
+            throw new Error(syncBody.reason || syncBody.error || "OPENAI_API_KEY secret sync failed");
+          }
+          document.getElementById("openai-api-key-input").value = "";
+          openaiSecretSyncOutput.textContent = JSON.stringify(syncBody, null, 2);
+        } catch (error) {
+          openaiSecretSyncOutput.textContent = String(error);
         }
       });
 

--- a/src/worker.js
+++ b/src/worker.js
@@ -11,6 +11,7 @@ import {
   dedupePasskeys,
   dispatchRemoteCodexExecution,
   executeDeployProductionPlane,
+  executeGitHubActionsSecretSync,
   evaluateButlerSelfParity,
   executeGitHubHighRiskPlane,
   inferRelatedIssueFromGatewayInput,
@@ -196,6 +197,23 @@ export default {
       }
 
       return handleDeployProductionRequest(request, env);
+    }
+
+    if (request.method === "POST" && isApiPath(url.pathname, "/action/github-actions-secret")) {
+      const auth = authorizePasskeyBrowserOrMachineRequest({
+        request,
+        env,
+        apiSuffix: "/action/github-actions-secret"
+      });
+      if (!auth.ok) {
+        return json(auth.status, {
+          ok: false,
+          error: "unauthorized",
+          reason: auth.reason
+        });
+      }
+
+      return handleGitHubActionsSecretSyncRequest(request, env);
     }
 
     if (request.method === "POST" && isApiPath(url.pathname, "/action/repository-nickname")) {
@@ -886,6 +904,57 @@ async function handleDeployProductionRequest(request, env) {
   return json(202, {
     ok: true,
     deploy: executed.deploy
+  });
+}
+
+async function handleGitHubActionsSecretSyncRequest(request, env) {
+  const payload = await readJson(request);
+  if (!payload || typeof payload !== "object") {
+    return json(422, {
+      ok: false,
+      error: "request_body_required",
+      reason: "valid JSON request body is required"
+    });
+  }
+
+  const policyInput =
+    payload.policyInput && typeof payload.policyInput === "object" ? payload.policyInput : {};
+  const resolvedApprovalGrant = await resolveApprovalGrant({
+    payload: {
+      phase: normalizeText(payload.phase) || "execution",
+      highRiskKind: "github_actions_secret_sync",
+      repositoryInput: payload.repository
+    },
+    policyInput: {
+      ...policyInput,
+      actionType: "destructive",
+      repositoryInput: payload.repository,
+      highRiskKind: "github_actions_secret_sync"
+    },
+    env
+  });
+
+  const executed = await executeGitHubActionsSecretSync({
+    repository: payload.repository,
+    secretName: payload.secretName,
+    secretValue: payload.secretValue,
+    approvalGrant:
+      payload.approvalGrant ?? policyInput.approvalGrant ?? resolvedApprovalGrant.approvalGrant,
+    env
+  });
+
+  if (!executed.ok) {
+    return json(executed.status ?? 503, {
+      ok: false,
+      error: executed.error ?? "github_actions_secret_sync_failed",
+      reason: executed.reason,
+      issues: executed.issues ?? []
+    });
+  }
+
+  return json(200, {
+    ok: true,
+    secretSync: executed.secretSync
   });
 }
 

--- a/test/custom-gpt-setup-docs.test.js
+++ b/test/custom-gpt-setup-docs.test.js
@@ -43,6 +43,7 @@ test("custom gpt instructions preserve current butler and approval boundaries", 
   assert.equal(doc.includes("vtddWriteGitHub"), true);
   assert.equal(doc.includes("vtddGitHubAuthority"), true);
   assert.equal(doc.includes("vtddDeployProduction"), true);
+  assert.equal(doc.includes("vtddSyncGitHubActionsSecret"), true);
   assert.equal(doc.includes("vtddExecutionProgress"), true);
   assert.equal(doc.includes("vtddRetrieveGitHub"), true);
   assert.equal(doc.includes("vtddUpsertRepositoryNickname"), true);
@@ -70,6 +71,8 @@ test("custom gpt instructions preserve current butler and approval boundaries", 
   assert.equal(doc.includes("If the Action surface reports `ClientResponseError`"), true);
   assert.equal(doc.includes("report it as an unverified Action transport failure"), true);
   assert.equal(doc.includes("If vtddDeployProduction fails, tell the user the exact deploy `error`, `reason`, and `issues`"), true);
+  assert.equal(doc.includes("openai_api_key_not_configured"), true);
+  assert.equal(doc.includes("never echo the secret value"), true);
   assert.equal(doc.includes("Do not claim a PR exists when only a Codex task summary exists."), true);
   assert.equal(
     doc.includes("Do not claim that Issues/PRs/comments are absent when the read path is unsupported, unauthorized, or unverified."),
@@ -85,6 +88,7 @@ test("short custom gpt instructions stay under editor limits while preserving cr
   assert.equal(doc.includes("vtddRetrieveGitHub"), true);
   assert.equal(doc.includes("vtddRetrieveSelfParity"), true);
   assert.equal(doc.includes("vtddDeployProduction"), true);
+  assert.equal(doc.includes("vtddSyncGitHubActionsSecret"), true);
   assert.equal(doc.includes("vtddUpsertRepositoryNickname"), true);
   assert.equal(doc.includes("vtddRetrieveRepositoryNicknames"), true);
   assert.equal(doc.includes("Nickname memory is explicit user-owned alias registry data"), true);
@@ -100,6 +104,7 @@ test("short custom gpt instructions stay under editor limits while preserving cr
   assert.equal(doc.includes("never only `/v2/approval/passkey/operator...`"), true);
   assert.equal(doc.includes("Markdown link, not code"), true);
   assert.equal(doc.includes("GO + real passkey"), true);
+  assert.equal(doc.includes("openai_api_key_not_configured"), true);
   assert.equal(doc.includes("If vtddDeployProduction fails, say the exact deploy error/reason/issues"), true);
 });
 
@@ -111,6 +116,7 @@ test("custom gpt openapi doc exposes current gateway, execute, and progress rout
   assert.equal(doc.includes("/v2/action/github:"), true);
   assert.equal(doc.includes("/v2/action/github-authority:"), true);
   assert.equal(doc.includes("/v2/action/deploy:"), true);
+  assert.equal(doc.includes("/v2/action/github-actions-secret:"), true);
   assert.equal(doc.includes("/v2/action/repository-nickname:"), true);
   assert.equal(doc.includes("/v2/action/progress:"), true);
   assert.equal(doc.includes("/v2/retrieve/github:"), true);
@@ -152,6 +158,7 @@ test("custom gpt openapi json parses and exposes paths as an object", () => {
   assert.equal(typeof doc.paths["/v2/action/github"], "object");
   assert.equal(typeof doc.paths["/v2/action/github-authority"], "object");
   assert.equal(typeof doc.paths["/v2/action/deploy"], "object");
+  assert.equal(typeof doc.paths["/v2/action/github-actions-secret"], "object");
   assert.equal(typeof doc.paths["/v2/action/repository-nickname"], "object");
   assert.equal(typeof doc.paths["/v2/action/progress"], "object");
   assert.equal(typeof doc.paths["/v2/retrieve/github"], "object");

--- a/test/github-actions-secret-sync.test.js
+++ b/test/github-actions-secret-sync.test.js
@@ -1,0 +1,82 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  executeGitHubActionsSecretSync,
+  validateGitHubActionsSecretSyncApprovalGrant
+} from "../src/core/index.js";
+
+const validApprovalGrant = {
+  approvalId: "approval-secret-123",
+  verified: true,
+  expiresAt: "2099-01-01T00:00:00.000Z",
+  scope: {
+    repositoryInput: "sample-org/vtdd-v2-p",
+    highRiskKind: "github_actions_secret_sync"
+  }
+};
+
+test("github actions secret sync writes only approved OPENAI_API_KEY without echoing the secret", async () => {
+  const calls = [];
+  const result = await executeGitHubActionsSecretSync({
+    repository: "sample-org/vtdd-v2-p",
+    secretName: "OPENAI_API_KEY",
+    secretValue: "sk-test-secret",
+    approvalGrant: validApprovalGrant,
+    encryptSecret: async ({ publicKey, secretValue }) => {
+      assert.equal(publicKey, "public-key");
+      assert.equal(secretValue, "sk-test-secret");
+      return "encrypted-secret";
+    },
+    env: {
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_secret",
+      GITHUB_API_FETCH: async (url, init) => {
+        calls.push({ url: String(url), init });
+        if (String(url).endsWith("/actions/secrets/public-key")) {
+          return new Response(JSON.stringify({ key_id: "key-123", key: "public-key" }), {
+            status: 200,
+            headers: { "content-type": "application/json" }
+          });
+        }
+        return new Response(null, { status: 204 });
+      }
+    }
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.secretSync.secretName, "OPENAI_API_KEY");
+  assert.equal(result.secretSync.status, "updated");
+  assert.equal(JSON.stringify(result).includes("sk-test-secret"), false);
+  assert.equal(calls[1].url.endsWith("/actions/secrets/OPENAI_API_KEY"), true);
+  assert.equal(JSON.parse(calls[1].init.body).encrypted_value, "encrypted-secret");
+});
+
+test("github actions secret sync blocks unapproved names and wrong passkey scope", async () => {
+  const unsupported = await executeGitHubActionsSecretSync({
+    repository: "sample-org/vtdd-v2-p",
+    secretName: "GEMINI_API_KEY",
+    secretValue: "secret",
+    approvalGrant: validApprovalGrant,
+    env: {
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_secret"
+    }
+  });
+  assert.equal(unsupported.ok, false);
+  assert.equal(unsupported.error, "github_actions_secret_sync_request_invalid");
+  assert.equal(unsupported.issues.includes("secretName must be OPENAI_API_KEY"), true);
+
+  const wrongScope = validateGitHubActionsSecretSyncApprovalGrant({
+    repository: "sample-org/vtdd-v2-p",
+    approvalGrant: {
+      ...validApprovalGrant,
+      scope: {
+        repositoryInput: "sample-org/vtdd-v2-p",
+        highRiskKind: "deploy_production"
+      }
+    }
+  });
+  assert.equal(wrongScope.ok, false);
+  assert.equal(
+    wrongScope.issues.includes("approvalGrant scope.highRiskKind must be github_actions_secret_sync"),
+    true
+  );
+});

--- a/test/passkey-operator-page.test.js
+++ b/test/passkey-operator-page.test.js
@@ -16,8 +16,11 @@ test("passkey operator page can target explicit api base and sync endpoint", () 
   assert.equal(html.includes('fetch("/api/approval/passkey/challenge"'), true);
   assert.equal(html.includes('fetch("http://127.0.0.1:8789/api/github-app-secret-sync/execute"'), true);
   assert.equal(html.includes('fetch("/api/action/deploy"'), true);
+  assert.equal(html.includes('fetch("/api/action/github-actions-secret"'), true);
   assert.equal(html.includes("Sync GitHub App secrets"), true);
+  assert.equal(html.includes("Sync OPENAI_API_KEY"), true);
   assert.equal(html.includes("Dispatch production deploy"), true);
+  assert.equal(html.includes("Butler 会話に貼らず"), true);
   assert.equal(html.includes('id="action-type-input" value="deploy_production"'), true);
   assert.equal(html.includes('repositoryInput: document.getElementById("repo-input").value'), true);
   assert.equal(html.includes('issueNumber: Number(document.getElementById("issue-input").value || 0) || null'), true);

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -1603,6 +1603,74 @@ test("worker allows same-origin browser governed production deploy with a real a
   );
 });
 
+test("worker syncs OPENAI_API_KEY through approval-bound GitHub Actions secret route", async () => {
+  const provider = createInMemoryMemoryProvider();
+  const calls = [];
+  await provider.store({
+    id: "approval-actions-secret-123",
+    type: MemoryRecordType.APPROVAL_LOG,
+    content: {
+      kind: "passkey_grant",
+      status: "verified",
+      approvalId: "approval-actions-secret-123",
+      expiresAt: "2099-01-01T00:00:00.000Z",
+      scope: {
+        actionType: "destructive",
+        highRiskKind: "github_actions_secret_sync",
+        repositoryInput: "sample-org/vtdd-v2-p",
+        phase: "execution"
+      }
+    },
+    metadata: { source: "test" },
+    priority: 90,
+    tags: ["passkey_grant"],
+    createdAt: "2026-04-28T00:00:00.000Z"
+  });
+
+  const response = await worker.fetch(
+    new Request("https://sample-user-vtdd.example.workers.dev/v2/action/github-actions-secret", {
+      method: "POST",
+      headers: {
+        ...gatewayAuthHeaders,
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({
+        repository: "sample-org/vtdd-v2-p",
+        secretName: "OPENAI_API_KEY",
+        secretValue: "sk-test-secret",
+        policyInput: {
+          approvalGrantId: "approval-actions-secret-123"
+        }
+      })
+    }),
+    {
+      ...gatewayAuthEnv,
+      MEMORY_PROVIDER: provider,
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_secret",
+      GITHUB_API_FETCH: async (url, init) => {
+        calls.push({ url: String(url), init });
+        if (String(url).endsWith("/actions/secrets/public-key")) {
+          return new Response(
+            JSON.stringify({
+              key_id: "key-123",
+              key: "LW+MLFAtyNPENefjLqmydKkBGp4l5suTetSR9313Xm8="
+            }),
+            { status: 200, headers: { "content-type": "application/json" } }
+          );
+        }
+        return new Response(null, { status: 204 });
+      }
+    }
+  );
+
+  assert.equal(response.status, 200);
+  const body = await response.json();
+  assert.equal(body.ok, true);
+  assert.equal(body.secretSync.secretName, "OPENAI_API_KEY");
+  assert.equal(JSON.stringify(body).includes("sk-test-secret"), false);
+  assert.equal(calls[1].url.endsWith("/actions/secrets/OPENAI_API_KEY"), true);
+});
+
 test("worker returns remote Codex execution progress", async () => {
   const response = await worker.fetch(
     new Request("https://example.com/v2/action/progress?executionId=remote-codex-issue6-abcd12", {


### PR DESCRIPTION
## This PR satisfies Intent

This PR addresses the recurring reviewer fallback blocker where Gemini is temporarily unavailable and the non-manual Codex fallback cannot start because `OPENAI_API_KEY` is not configured.

It adds an approval-bound, iPhone-safe path for syncing only `OPENAI_API_KEY` into GitHub Actions secrets through the same-origin passkey operator page. The secret value is entered on the operator page, not pasted into Butler chat, and the worker encrypts it with the repository Actions public key before writing it to GitHub.

## Satisfied Success Criteria

- Scoped Issue: #4
- Adds `vtddSyncGitHubActionsSecret` for `OPENAI_API_KEY` only.
- Requires a real passkey approval grant with `highRiskKind=github_actions_secret_sync` and matching repository scope.
- Uses GitHub Actions public-key encryption before writing the secret.
- Does not echo `OPENAI_API_KEY` in success responses.
- Adds an operator page section to sync `OPENAI_API_KEY` after GO + passkey approval.
- Updates OpenAPI and Butler Instructions so `openai_api_key_not_configured` routes to the operator page instead of asking for the secret in chat.

## Unsatisfied Success Criteria

- This does not set the real `OPENAI_API_KEY`.
- This does not execute credential mutation from this PR.
- This does not prove live iPhone Butler E2E until merged, deployed, Action Schema updated, Instructions updated, and tested from Butler.
- This does not complete #4.

## Surface Update Checklist

- Cloudflare deploy: Required after merge, because this adds worker runtime behavior.
- Custom GPT Action Schema update: Required, because this adds `/v2/action/github-actions-secret` and `vtddSyncGitHubActionsSecret`.
- Custom GPT Instructions update: Required, because Butler must route `openai_api_key_not_configured` to the operator page and must not ask for `OPENAI_API_KEY` in chat.
- iPhone Butler live E2E: Required after deploy/schema/instructions update. Re-run reviewer fallback or a guided secret sync flow and confirm the secret is entered only on the operator page.

## Verification Evidence

- `node --test test/github-actions-secret-sync.test.js test/passkey-operator-page.test.js test/custom-gpt-setup-docs.test.js test/worker.test.js` -> 57/57 passed
- `npm test` -> 414/414 passed

E2E: Not yet complete. Real credential mutation requires human GO + passkey and operator-owned secret entry after merge/deploy/setup update.

Evidence path/link:
- `src/core/github-actions-secret-sync.js`
- `src/core/passkey-operator-page.js`
- `src/worker.js`
- `docs/setup/custom-gpt-actions-openapi.yaml`
- `docs/setup/custom-gpt-instructions-short.md`
- `test/github-actions-secret-sync.test.js`
- `test/worker.test.js`
