### PR TITLE
Surface raw operator page response failures

### DIFF
--- a/src/core/passkey-operator-page.js
+++ b/src/core/passkey-operator-page.js
@@ -217,7 +217,7 @@ export function renderPasskeyOperatorPage(input = {}) {
             return {
               error: "invalid_json_response",
               reason: String(error),
-              rawBody: text.slice(0, 500)
+              rawBody: sanitizeRawBody(text)
             };
           }
         }
@@ -225,8 +225,15 @@ export function renderPasskeyOperatorPage(input = {}) {
           error: "non_json_response",
           reason: "Expected JSON response but received " + (contentType || "unknown content-type"),
           httpStatus: response.status,
-          rawBody: text.slice(0, 500)
+          rawBody: sanitizeRawBody(text)
         };
+      }
+
+      function sanitizeRawBody(text) {
+        return String(text || "")
+          .replace(/sk-[A-Za-z0-9_-]+/g, "[REDACTED_OPENAI_KEY]")
+          .replace(/(authorization|api[_-]?key|token|secret)(["'\\s:=]+)([^"'\\s<>&]+)/gi, "$1$2[REDACTED]")
+          .slice(0, 500);
       }
 
       function responseError(body, fallback) {

--- a/src/core/passkey-operator-page.js
+++ b/src/core/passkey-operator-page.js
@@ -207,6 +207,39 @@ export function renderPasskeyOperatorPage(input = {}) {
       const openaiSecretSyncOutput = document.getElementById("openai-secret-sync-output");
       let latestApprovalGrantId = "";
 
+      async function readResponseBody(response) {
+        const contentType = response.headers.get("content-type") || "";
+        const text = await response.text();
+        if (contentType.includes("application/json")) {
+          try {
+            return text ? JSON.parse(text) : {};
+          } catch (error) {
+            return {
+              error: "invalid_json_response",
+              reason: String(error),
+              rawBody: text.slice(0, 500)
+            };
+          }
+        }
+        return {
+          error: "non_json_response",
+          reason: "Expected JSON response but received " + (contentType || "unknown content-type"),
+          httpStatus: response.status,
+          rawBody: text.slice(0, 500)
+        };
+      }
+
+      function responseError(body, fallback) {
+        const parts = [body.reason || body.error || fallback];
+        if (body.httpStatus) {
+          parts.push("HTTP status: " + body.httpStatus);
+        }
+        if (body.rawBody) {
+          parts.push("rawBody: " + body.rawBody);
+        }
+        return new Error(parts.join("\\n"));
+      }
+
       document.getElementById("register-button").addEventListener("click", async () => {
         try {
           registerOutput.textContent = "register options request...";
@@ -218,9 +251,9 @@ export function renderPasskeyOperatorPage(input = {}) {
               operatorLabel: document.getElementById("operator-label").value
             })
           });
-          const optionsBody = await optionsResponse.json();
+          const optionsBody = await readResponseBody(optionsResponse);
           if (!optionsResponse.ok) {
-            throw new Error(optionsBody.reason || optionsBody.error || "register options failed");
+            throw responseError(optionsBody, "register options failed");
           }
 
           const publicKey = decodeRegistrationOptions(optionsBody.optionsJSON);
@@ -233,9 +266,9 @@ export function renderPasskeyOperatorPage(input = {}) {
               response: encodeRegistrationCredential(credential)
             })
           });
-          const verifyBody = await verifyResponse.json();
+          const verifyBody = await readResponseBody(verifyResponse);
           if (!verifyResponse.ok) {
-            throw new Error(verifyBody.reason || verifyBody.error || "register verify failed");
+            throw responseError(verifyBody, "register verify failed");
           }
           registerOutput.textContent = JSON.stringify(verifyBody, null, 2);
         } catch (error) {
@@ -264,9 +297,9 @@ export function renderPasskeyOperatorPage(input = {}) {
               }
             })
           });
-          const challengeBody = await challengeResponse.json();
+          const challengeBody = await readResponseBody(challengeResponse);
           if (!challengeResponse.ok) {
-            throw new Error(challengeBody.reason || challengeBody.error || "approval challenge failed");
+            throw responseError(challengeBody, "approval challenge failed");
           }
 
           const publicKey = decodeAuthenticationOptions(challengeBody.optionsJSON);
@@ -279,9 +312,9 @@ export function renderPasskeyOperatorPage(input = {}) {
               response: encodeAuthenticationAssertion(assertion)
             })
           });
-          const verifyBody = await verifyResponse.json();
+          const verifyBody = await readResponseBody(verifyResponse);
           if (!verifyResponse.ok) {
-            throw new Error(verifyBody.reason || verifyBody.error || "approval verify failed");
+            throw responseError(verifyBody, "approval verify failed");
           }
           latestApprovalGrantId = verifyBody?.approvalGrant?.approvalId || "";
           approveOutput.textContent = JSON.stringify(verifyBody, null, 2);
@@ -307,9 +340,9 @@ export function renderPasskeyOperatorPage(input = {}) {
               repositoryInput: document.getElementById("repo-input").value
             })
           });
-          const syncBody = await syncResponse.json();
+          const syncBody = await readResponseBody(syncResponse);
           if (!syncResponse.ok) {
-            throw new Error(syncBody.reason || syncBody.error || "github app secret sync failed");
+            throw responseError(syncBody, "github app secret sync failed");
           }
           syncOutput.textContent = JSON.stringify(syncBody, null, 2);
         } catch (error) {
@@ -335,9 +368,9 @@ export function renderPasskeyOperatorPage(input = {}) {
               }
             })
           });
-          const deployBody = await deployResponse.json();
+          const deployBody = await readResponseBody(deployResponse);
           if (!deployResponse.ok) {
-            throw new Error(deployBody.reason || deployBody.error || "production deploy failed");
+            throw responseError(deployBody, "production deploy failed");
           }
           deployOutput.textContent = JSON.stringify(deployBody, null, 2);
         } catch (error) {
@@ -367,9 +400,9 @@ export function renderPasskeyOperatorPage(input = {}) {
               }
             })
           });
-          const syncBody = await syncResponse.json();
+          const syncBody = await readResponseBody(syncResponse);
           if (!syncResponse.ok) {
-            throw new Error(syncBody.reason || syncBody.error || "OPENAI_API_KEY secret sync failed");
+            throw responseError(syncBody, "OPENAI_API_KEY secret sync failed");
           }
           document.getElementById("openai-api-key-input").value = "";
           openaiSecretSyncOutput.textContent = JSON.stringify(syncBody, null, 2);

--- a/test/passkey-operator-page.test.js
+++ b/test/passkey-operator-page.test.js
@@ -17,6 +17,8 @@ test("passkey operator page can target explicit api base and sync endpoint", () 
   assert.equal(html.includes('fetch("http://127.0.0.1:8789/api/github-app-secret-sync/execute"'), true);
   assert.equal(html.includes('fetch("/api/action/deploy"'), true);
   assert.equal(html.includes('fetch("/api/action/github-actions-secret"'), true);
+  assert.equal(html.includes("readResponseBody"), true);
+  assert.equal(html.includes("non_json_response"), true);
   assert.equal(html.includes("Sync GitHub App secrets"), true);
   assert.equal(html.includes("Sync OPENAI_API_KEY"), true);
   assert.equal(html.includes("Dispatch production deploy"), true);

--- a/test/passkey-operator-page.test.js
+++ b/test/passkey-operator-page.test.js
@@ -1,5 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import vm from "node:vm";
 import { renderPasskeyOperatorPage } from "../src/core/index.js";
 
 test("passkey operator page can target explicit api base and sync endpoint", () => {
@@ -37,3 +38,62 @@ test("passkey operator page keeps sync disabled message when helper endpoint is 
   assert.equal(html.includes("desktop maintenance required"), true);
   assert.equal(html.includes("disabled"), true);
 });
+
+test("passkey operator page response parser reports and redacts non-json failures", async () => {
+  const helpers = loadOperatorPageHelpers();
+
+  const htmlFailure = await helpers.readResponseBody(
+    new Response("<!DOCTYPE html><p>token=secret-token sk-testsecret</p>", {
+      status: 502,
+      headers: { "content-type": "text/html" }
+    })
+  );
+  assert.equal(htmlFailure.error, "non_json_response");
+  assert.equal(htmlFailure.httpStatus, 502);
+  assert.equal(htmlFailure.rawBody.includes("<!DOCTYPE html>"), true);
+  assert.equal(htmlFailure.rawBody.includes("secret-token"), false);
+  assert.equal(htmlFailure.rawBody.includes("sk-testsecret"), false);
+
+  const malformedJson = await helpers.readResponseBody(
+    new Response("{", {
+      status: 500,
+      headers: { "content-type": "application/json" }
+    })
+  );
+  assert.equal(malformedJson.error, "invalid_json_response");
+  assert.equal(malformedJson.rawBody, "{");
+
+  const validJson = await helpers.readResponseBody(
+    new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { "content-type": "application/json; charset=utf-8" }
+    })
+  );
+  assert.equal(validJson.ok, true);
+});
+
+function loadOperatorPageHelpers() {
+  const html = renderPasskeyOperatorPage();
+  const script = html.match(/<script>([\s\S]*)<\/script>/)?.[1];
+  assert.ok(script);
+
+  const elements = new Map();
+  const context = {
+    Response,
+    document: {
+      getElementById(id) {
+        if (!elements.has(id)) {
+          elements.set(id, {
+            value: "",
+            textContent: "",
+            addEventListener() {}
+          });
+        }
+        return elements.get(id);
+      }
+    }
+  };
+  vm.runInNewContext(script, context);
+  assert.equal(typeof context.readResponseBody, "function");
+  return context;
+}

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -1671,6 +1671,75 @@ test("worker syncs OPENAI_API_KEY through approval-bound GitHub Actions secret r
   assert.equal(calls[1].url.endsWith("/actions/secrets/OPENAI_API_KEY"), true);
 });
 
+test("worker allows same-origin browser OPENAI_API_KEY secret sync with approval grant", async () => {
+  const provider = createInMemoryMemoryProvider();
+  const calls = [];
+  await provider.store({
+    id: "approval-browser-actions-secret-123",
+    type: MemoryRecordType.APPROVAL_LOG,
+    content: {
+      kind: "passkey_grant",
+      status: "verified",
+      approvalId: "approval-browser-actions-secret-123",
+      expiresAt: "2099-01-01T00:00:00.000Z",
+      scope: {
+        actionType: "destructive",
+        highRiskKind: "github_actions_secret_sync",
+        repositoryInput: "sample-org/vtdd-v2-p",
+        phase: "execution"
+      }
+    },
+    metadata: { source: "test" },
+    priority: 90,
+    tags: ["passkey_grant"],
+    createdAt: "2026-04-28T00:00:00.000Z"
+  });
+
+  const response = await worker.fetch(
+    new Request("https://sample-user-vtdd.example.workers.dev/v2/action/github-actions-secret", {
+      method: "POST",
+      headers: {
+        origin: "https://sample-user-vtdd.example.workers.dev",
+        "sec-fetch-site": "same-origin",
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({
+        repository: "sample-org/vtdd-v2-p",
+        secretName: "OPENAI_API_KEY",
+        secretValue: "sk-test-secret",
+        policyInput: {
+          approvalGrantId: "approval-browser-actions-secret-123"
+        }
+      })
+    }),
+    {
+      ...gatewayAuthEnv,
+      MEMORY_PROVIDER: provider,
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_secret",
+      GITHUB_API_FETCH: async (url, init) => {
+        calls.push({ url: String(url), init });
+        if (String(url).endsWith("/actions/secrets/public-key")) {
+          return new Response(
+            JSON.stringify({
+              key_id: "key-123",
+              key: "LW+MLFAtyNPENefjLqmydKkBGp4l5suTetSR9313Xm8="
+            }),
+            { status: 200, headers: { "content-type": "application/json" } }
+          );
+        }
+        return new Response(null, { status: 204 });
+      }
+    }
+  );
+
+  assert.equal(response.status, 200);
+  const body = await response.json();
+  assert.equal(body.ok, true);
+  assert.equal(body.secretSync.secretName, "OPENAI_API_KEY");
+  assert.equal(JSON.stringify(body).includes("sk-test-secret"), false);
+  assert.equal(calls[1].url.endsWith("/actions/secrets/OPENAI_API_KEY"), true);
+});
+
 test("worker returns remote Codex execution progress", async () => {
   const response = await worker.fetch(
     new Request("https://example.com/v2/action/progress?executionId=remote-codex-issue6-abcd12", {


### PR DESCRIPTION
## This PR satisfies Intent

Fix the live iPhone/operator-page failure mode observed after PR #102 deploy:

- `SyntaxError: Unexpected token '<', "<!DOCTYPE "... is not valid JSON`

This is scoped to the #4 Butler-origin E2E recovery path. The operator page must not hide the real HTTP status/body behind a browser JSON parse exception while the human is trying to complete approval-bound `OPENAI_API_KEY` secret sync.

## Satisfied Success Criteria

- Replaces fixed `response.json()` parsing in the passkey operator page with content-type aware response parsing.
- If a route returns HTML or another non-JSON response, the page now surfaces:
  - `non_json_response`
  - HTTP status
  - raw body prefix
- Adds worker coverage for same-origin browser `OPENAI_API_KEY` secret sync with a real approval grant shape.
- Preserves the rule that the secret value is not echoed in the response.

## Unsatisfied Success Criteria

- Does not set the real `OPENAI_API_KEY`.
- Does not perform credential mutation in this PR.
- Does not claim #4 complete.
- Live iPhone E2E remains required after merge + Cloudflare deploy.

## Surface Update Checklist

- Cloudflare deploy: Required after merge; this changes the rendered operator page JS.
- Custom GPT Action Schema: Not required.
- Custom GPT Instructions: Not required.
- iPhone Butler live E2E: Required after deploy; retry approval + `Sync OPENAI_API_KEY` and inspect raw output if it still fails.

## Verification Evidence

- `node --test test/passkey-operator-page.test.js test/worker.test.js` -> 48/48 passed
- `npm test` -> 415/415 passed
