### PR TITLE
Return JSON for Actions secret sync exceptions

### DIFF
--- a/src/core/github-actions-secret-sync.js
+++ b/src/core/github-actions-secret-sync.js
@@ -36,7 +36,8 @@ export async function executeGitHubActionsSecretSync(input = {}) {
   const tokenResolution = await resolveGitHubAppInstallationToken({ env, fetchImpl, apiBaseUrl }).catch(
     (error) => ({
       ok: false,
-      warning: `GitHub App installation token resolution threw: ${sanitizeErrorMessage(error)}`
+      reason: `GitHub App installation token resolution threw: ${sanitizeGitHubActionsSecretSyncErrorMessage(error)}`,
+      warning: `GitHub App installation token resolution threw: ${sanitizeGitHubActionsSecretSyncErrorMessage(error)}`
     })
   );
   if (!tokenResolution.ok) {
@@ -88,7 +89,7 @@ export async function executeGitHubActionsSecretSync(input = {}) {
   const encryptedValue = await encryptSecret({ publicKey: key, secretValue }).catch((error) => ({
     ok: false,
     error: "github_actions_secret_encryption_failed",
-    reason: sanitizeErrorMessage(error)
+    reason: sanitizeGitHubActionsSecretSyncErrorMessage(error)
   }));
   if (encryptedValue && typeof encryptedValue === "object" && encryptedValue.ok === false) {
     return {
@@ -239,7 +240,7 @@ function normalizeText(value) {
   return String(value ?? "").trim();
 }
 
-function sanitizeErrorMessage(error) {
+export function sanitizeGitHubActionsSecretSyncErrorMessage(error) {
   return normalizeText(error instanceof Error ? error.message : error)
     .replace(/sk-[A-Za-z0-9_-]+/g, "[REDACTED_OPENAI_KEY]")
     .replace(/(authorization|api[_-]?key|token|secret)(["'\s:=]+)([^"'\s<>&]+)/gi, "$1$2[REDACTED]")

--- a/src/core/github-actions-secret-sync.js
+++ b/src/core/github-actions-secret-sync.js
@@ -33,7 +33,12 @@ export async function executeGitHubActionsSecretSync(input = {}) {
     };
   }
 
-  const tokenResolution = await resolveGitHubAppInstallationToken({ env, fetchImpl, apiBaseUrl });
+  const tokenResolution = await resolveGitHubAppInstallationToken({ env, fetchImpl, apiBaseUrl }).catch(
+    (error) => ({
+      ok: false,
+      warning: `GitHub App installation token resolution threw: ${sanitizeErrorMessage(error)}`
+    })
+  );
   if (!tokenResolution.ok) {
     return {
       ok: false,
@@ -80,7 +85,19 @@ export async function executeGitHubActionsSecretSync(input = {}) {
     };
   }
 
-  const encryptedValue = await encryptSecret({ publicKey: key, secretValue });
+  const encryptedValue = await encryptSecret({ publicKey: key, secretValue }).catch((error) => ({
+    ok: false,
+    error: "github_actions_secret_encryption_failed",
+    reason: sanitizeErrorMessage(error)
+  }));
+  if (encryptedValue && typeof encryptedValue === "object" && encryptedValue.ok === false) {
+    return {
+      ok: false,
+      status: 503,
+      error: encryptedValue.error,
+      reason: encryptedValue.reason
+    };
+  }
   const putResponse = await fetchImpl(
     `${apiBaseUrl}/repos/${encodedRepository}/actions/secrets/${encodeURIComponent(secretName)}`,
     {
@@ -220,4 +237,11 @@ function normalizeApiBaseUrl(value) {
 
 function normalizeText(value) {
   return String(value ?? "").trim();
+}
+
+function sanitizeErrorMessage(error) {
+  return normalizeText(error instanceof Error ? error.message : error)
+    .replace(/sk-[A-Za-z0-9_-]+/g, "[REDACTED_OPENAI_KEY]")
+    .replace(/(authorization|api[_-]?key|token|secret)(["'\s:=]+)([^"'\s<>&]+)/gi, "$1$2[REDACTED]")
+    .slice(0, 500);
 }

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -52,6 +52,7 @@ export {
 export {
   encryptGitHubActionsSecret,
   executeGitHubActionsSecretSync,
+  sanitizeGitHubActionsSecretSyncErrorMessage,
   validateGitHubActionsSecretSyncApprovalGrant,
   validateGitHubActionsSecretSyncRequest
 } from "./github-actions-secret-sync.js";

--- a/src/worker.js
+++ b/src/worker.js
@@ -942,7 +942,12 @@ async function handleGitHubActionsSecretSyncRequest(request, env) {
     approvalGrant:
       payload.approvalGrant ?? policyInput.approvalGrant ?? resolvedApprovalGrant.approvalGrant,
     env
-  });
+  }).catch((error) => ({
+    ok: false,
+    status: 503,
+    error: "github_actions_secret_sync_exception",
+    reason: sanitizeOperationalErrorMessage(error)
+  }));
 
   if (!executed.ok) {
     return json(executed.status ?? 503, {
@@ -2277,6 +2282,13 @@ function normalize(value) {
 
 function normalizeText(value) {
   return String(value ?? "").trim();
+}
+
+function sanitizeOperationalErrorMessage(error) {
+  return normalizeText(error instanceof Error ? error.message : error)
+    .replace(/sk-[A-Za-z0-9_-]+/g, "[REDACTED_OPENAI_KEY]")
+    .replace(/(authorization|api[_-]?key|token|secret)(["'\s:=]+)([^"'\s<>&]+)/gi, "$1$2[REDACTED]")
+    .slice(0, 500);
 }
 
 function normalizeTag(value) {

--- a/src/worker.js
+++ b/src/worker.js
@@ -26,6 +26,7 @@ import {
   retrieveConstitution,
   retrieveCustomGptSetupArtifact,
   renderPasskeyOperatorPage,
+  sanitizeGitHubActionsSecretSyncErrorMessage,
   RepositoryNicknameMode,
   resolveGatewayAliasRegistryFromGitHubApp,
   resolveRepositoryTarget,
@@ -946,7 +947,7 @@ async function handleGitHubActionsSecretSyncRequest(request, env) {
     ok: false,
     status: 503,
     error: "github_actions_secret_sync_exception",
-    reason: sanitizeOperationalErrorMessage(error)
+    reason: sanitizeGitHubActionsSecretSyncErrorMessage(error)
   }));
 
   if (!executed.ok) {
@@ -2282,13 +2283,6 @@ function normalize(value) {
 
 function normalizeText(value) {
   return String(value ?? "").trim();
-}
-
-function sanitizeOperationalErrorMessage(error) {
-  return normalizeText(error instanceof Error ? error.message : error)
-    .replace(/sk-[A-Za-z0-9_-]+/g, "[REDACTED_OPENAI_KEY]")
-    .replace(/(authorization|api[_-]?key|token|secret)(["'\s:=]+)([^"'\s<>&]+)/gi, "$1$2[REDACTED]")
-    .slice(0, 500);
 }
 
 function normalizeTag(value) {

--- a/test/github-actions-secret-sync.test.js
+++ b/test/github-actions-secret-sync.test.js
@@ -80,3 +80,33 @@ test("github actions secret sync blocks unapproved names and wrong passkey scope
     true
   );
 });
+
+test("github actions secret sync returns redacted JSON failure when encryption throws", async () => {
+  const result = await executeGitHubActionsSecretSync({
+    repository: "sample-org/vtdd-v2-p",
+    secretName: "OPENAI_API_KEY",
+    secretValue: "sk-test-secret",
+    approvalGrant: validApprovalGrant,
+    encryptSecret: async () => {
+      throw new Error("token=secret-token sk-test-secret");
+    },
+    env: {
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_secret",
+      GITHUB_API_FETCH: async (url) => {
+        if (String(url).endsWith("/actions/secrets/public-key")) {
+          return new Response(JSON.stringify({ key_id: "key-123", key: "public-key" }), {
+            status: 200,
+            headers: { "content-type": "application/json" }
+          });
+        }
+        return new Response(null, { status: 204 });
+      }
+    }
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.status, 503);
+  assert.equal(result.error, "github_actions_secret_encryption_failed");
+  assert.equal(result.reason.includes("secret-token"), false);
+  assert.equal(result.reason.includes("sk-test-secret"), false);
+});

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -1840,7 +1840,7 @@ test("worker allows same-origin browser OPENAI_API_KEY secret sync with approval
   assert.equal(calls[1].url.endsWith("/actions/secrets/OPENAI_API_KEY"), true);
 });
 
-test("worker returns JSON when OPENAI_API_KEY secret sync throws", async () => {
+test("worker returns JSON when OPENAI_API_KEY token resolution fails", async () => {
   const provider = createInMemoryMemoryProvider();
   await provider.store({
     id: "approval-actions-secret-throw-123",
@@ -1894,6 +1894,7 @@ test("worker returns JSON when OPENAI_API_KEY secret sync throws", async () => {
   const body = await response.json();
   assert.equal(body.ok, false);
   assert.equal(body.error, "github_actions_secret_sync_unavailable");
+  assert.match(body.reason, /installation token provider failed/);
   assert.equal(JSON.stringify(body).includes("secret-token"), false);
   assert.equal(JSON.stringify(body).includes("sk-test-secret"), false);
 });

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -1840,6 +1840,64 @@ test("worker allows same-origin browser OPENAI_API_KEY secret sync with approval
   assert.equal(calls[1].url.endsWith("/actions/secrets/OPENAI_API_KEY"), true);
 });
 
+test("worker returns JSON when OPENAI_API_KEY secret sync throws", async () => {
+  const provider = createInMemoryMemoryProvider();
+  await provider.store({
+    id: "approval-actions-secret-throw-123",
+    type: MemoryRecordType.APPROVAL_LOG,
+    content: {
+      kind: "passkey_grant",
+      status: "verified",
+      approvalId: "approval-actions-secret-throw-123",
+      expiresAt: "2099-01-01T00:00:00.000Z",
+      scope: {
+        actionType: "destructive",
+        highRiskKind: "github_actions_secret_sync",
+        repositoryInput: "sample-org/vtdd-v2-p",
+        phase: "execution"
+      }
+    },
+    metadata: { source: "test" },
+    priority: 90,
+    tags: ["passkey_grant"],
+    createdAt: "2026-04-28T00:00:00.000Z"
+  });
+
+  const response = await worker.fetch(
+    new Request("https://sample-user-vtdd.example.workers.dev/v2/action/github-actions-secret", {
+      method: "POST",
+      headers: {
+        origin: "https://sample-user-vtdd.example.workers.dev",
+        "sec-fetch-site": "same-origin",
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({
+        repository: "sample-org/vtdd-v2-p",
+        secretName: "OPENAI_API_KEY",
+        secretValue: "sk-test-secret",
+        policyInput: {
+          approvalGrantId: "approval-actions-secret-throw-123"
+        }
+      })
+    }),
+    {
+      ...gatewayAuthEnv,
+      MEMORY_PROVIDER: provider,
+      GITHUB_APP_INSTALLATION_TOKEN_PROVIDER: async () => {
+        throw new Error("token=secret-token sk-test-secret");
+      }
+    }
+  );
+
+  assert.equal(response.status, 503);
+  assert.equal(response.headers.get("content-type"), "application/json; charset=utf-8");
+  const body = await response.json();
+  assert.equal(body.ok, false);
+  assert.equal(body.error, "github_actions_secret_sync_unavailable");
+  assert.equal(JSON.stringify(body).includes("secret-token"), false);
+  assert.equal(JSON.stringify(body).includes("sk-test-secret"), false);
+});
+
 test("worker returns remote Codex execution progress", async () => {
   const response = await worker.fetch(
     new Request("https://example.com/v2/action/progress?executionId=remote-codex-issue6-abcd12", {


### PR DESCRIPTION
## This PR satisfies Intent

Fix the live iPhone/operator-page failure mode observed during `OPENAI_API_KEY` secret sync after PR #103 deploy:

- Cloudflare returned HTML `Worker threw exception`
- Operator page correctly surfaced `non_json_response`, but the Worker still hid the actual exception behind Cloudflare's HTML error page

This is scoped to the #4 Butler-origin E2E recovery path. The Worker must return structured JSON error/reason fields for approval-bound Actions secret sync failures so Butler/operator can continue diagnosis without guessing.

## Satisfied Success Criteria

- Catches GitHub App installation token resolution exceptions during `vtddSyncGitHubActionsSecret`.
- Catches encryption exceptions during `OPENAI_API_KEY` GitHub Actions secret sync.
- Catches any remaining route-level exception and returns JSON instead of a Cloudflare HTML 500 page.
- Redacts OpenAI key-like strings and token/secret/api key values from failure reasons.
- Adds tests for redacted encryption failure and route-level JSON failure.

## Unsatisfied Success Criteria

- Does not set the real `OPENAI_API_KEY`.
- Does not claim the live secret sync is complete.
- Live iPhone E2E remains required after merge + Cloudflare deploy to reveal the actual underlying runtime blocker or confirm success.

## Surface Update Checklist

- Cloudflare deploy: Required after merge; this changes Worker runtime behavior.
- Custom GPT Action Schema: Not required.
- Custom GPT Instructions: Not required.
- iPhone Butler live E2E: Required after deploy; retry approval + `Sync OPENAI_API_KEY` and inspect JSON error/reason or success.

## Verification Evidence

- `node --test test/github-actions-secret-sync.test.js test/worker.test.js` -> 51/51 passed
- `npm test` -> 420/420 passed
