### PR TITLE
Defer sodium loading inside secret encryption

### DIFF
--- a/src/core/github-actions-secret-sync.js
+++ b/src/core/github-actions-secret-sync.js
@@ -1,4 +1,3 @@
-import sodium from "libsodium-wrappers";
 import { resolveGitHubAppInstallationToken } from "./github-app-repository-index.js";
 
 const GITHUB_API_BASE_URL = "https://api.github.com";
@@ -205,11 +204,17 @@ export function validateGitHubActionsSecretSyncApprovalGrant(input = {}) {
 }
 
 export async function encryptGitHubActionsSecret({ publicKey, secretValue }) {
+  const sodium = await loadSodium();
   await sodium.ready;
   const binaryKey = sodium.from_base64(publicKey, sodium.base64_variants.ORIGINAL);
   const binarySecret = sodium.from_string(secretValue);
   const encrypted = sodium.crypto_box_seal(binarySecret, binaryKey);
   return sodium.to_base64(encrypted, sodium.base64_variants.ORIGINAL);
+}
+
+export async function loadSodium() {
+  const module = await import("libsodium-wrappers");
+  return module.default ?? module;
 }
 
 function githubHeaders(token) {

--- a/test/github-actions-secret-sync.test.js
+++ b/test/github-actions-secret-sync.test.js
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import {
   executeGitHubActionsSecretSync,
+  encryptGitHubActionsSecret,
   validateGitHubActionsSecretSyncApprovalGrant
 } from "../src/core/index.js";
 
@@ -109,4 +110,15 @@ test("github actions secret sync returns redacted JSON failure when encryption t
   assert.equal(result.error, "github_actions_secret_encryption_failed");
   assert.equal(result.reason.includes("secret-token"), false);
   assert.equal(result.reason.includes("sk-test-secret"), false);
+});
+
+test("github actions secret encryption loads sodium lazily inside the handler path", async () => {
+  const encrypted = await encryptGitHubActionsSecret({
+    publicKey: "LW+MLFAtyNPENefjLqmydKkBGp4l5suTetSR9313Xm8=",
+    secretValue: "sk-test-secret"
+  });
+
+  assert.equal(typeof encrypted, "string");
+  assert.equal(encrypted.length > 0, true);
+  assert.equal(encrypted.includes("sk-test-secret"), false);
 });


### PR DESCRIPTION
## This PR satisfies Intent

Fix the live iPhone/operator-page failure observed during `OPENAI_API_KEY` secret sync after PR #104 deploy:

- `Disallowed operation called within global scope`
- Cloudflare reported that asynchronous I/O, timeout, or random generation happened before a request handler

This is scoped to the #4 Butler-origin E2E recovery path. `libsodium-wrappers` must not initialize at Worker module global scope.

## Satisfied Success Criteria

- Removes the static `libsodium-wrappers` import from the Worker dependency graph entry module.
- Loads `libsodium-wrappers` lazily inside `encryptGitHubActionsSecret`, which is called from the request handler path.
- Keeps GitHub Actions secret encryption behavior intact.
- Adds coverage that real encryption still works and does not echo the secret.

## Unsatisfied Success Criteria

- Does not set the real `OPENAI_API_KEY`.
- Does not claim live secret sync complete.
- Live iPhone E2E remains required after merge + Cloudflare deploy.

## Surface Update Checklist

- Cloudflare deploy: Required after merge; this changes Worker runtime behavior.
- Custom GPT Action Schema: Not required.
- Custom GPT Instructions: Not required.
- iPhone Butler live E2E: Required after deploy; retry approval + `Sync OPENAI_API_KEY`.

## Verification Evidence

- `node --test test/github-actions-secret-sync.test.js test/worker.test.js` -> 52/52 passed
- `npm test` -> 421/421 passed
