### PR TITLE
Use pure JS sealed box for Actions secret sync

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@simplewebauthn/server": "^13.3.0",
-        "libsodium-wrappers": "^0.8.4"
+        "tweetnacl-sealedbox-js": "^1.2.0"
       },
       "engines": {
         "node": ">=20"
@@ -219,20 +219,11 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/libsodium": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/libsodium/-/libsodium-0.8.4.tgz",
-      "integrity": "sha512-lMcYaRi0zcs7tarATsQUYC7rstliIXZuoq0c6zXSgNtSNtdvBgkSegjWhpMJAXzKX3SUSwIp7+zEsob+j3LuRw==",
-      "license": "ISC"
-    },
-    "node_modules/libsodium-wrappers": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/libsodium-wrappers/-/libsodium-wrappers-0.8.4.tgz",
-      "integrity": "sha512-mu8aAWucZjTB5O/BtGXtW4e1agy7uHxNYG7zPthmmD1jU43LCDmSWZLN4JhflbdPXj3yDO4lxM1O9hLDgIOXDw==",
-      "license": "ISC",
-      "dependencies": {
-        "libsodium": "^0.8.0"
-      }
+    "node_modules/blakejs": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.2.1.tgz",
+      "integrity": "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ==",
+      "license": "MIT"
     },
     "node_modules/pvtsutils": {
       "version": "1.3.6",
@@ -281,6 +272,22 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "license": "0BSD"
+    },
+    "node_modules/tweetnacl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
+      "license": "Unlicense"
+    },
+    "node_modules/tweetnacl-sealedbox-js": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tweetnacl-sealedbox-js/-/tweetnacl-sealedbox-js-1.2.0.tgz",
+      "integrity": "sha512-QoCr8K2hwri+ky7SUa22oSre8g88XaWi0hwwWd16pJMuDyn5gL/UyE0PyR2EOFEMJ70T2trJ9+Sv+Qa18olEmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "blakejs": "^1.1.0",
+        "tweetnacl": "^1.0.1"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,6 @@
   },
   "dependencies": {
     "@simplewebauthn/server": "^13.3.0",
-    "libsodium-wrappers": "^0.8.4"
+    "tweetnacl-sealedbox-js": "^1.2.0"
   }
 }

--- a/src/core/github-actions-secret-sync.js
+++ b/src/core/github-actions-secret-sync.js
@@ -204,17 +204,14 @@ export function validateGitHubActionsSecretSyncApprovalGrant(input = {}) {
 }
 
 export async function encryptGitHubActionsSecret({ publicKey, secretValue }) {
-  const sodium = await loadSodium();
-  await sodium.ready;
-  const binaryKey = sodium.from_base64(publicKey, sodium.base64_variants.ORIGINAL);
-  const binarySecret = sodium.from_string(secretValue);
-  const encrypted = sodium.crypto_box_seal(binarySecret, binaryKey);
-  return sodium.to_base64(encrypted, sodium.base64_variants.ORIGINAL);
-}
-
-export async function loadSodium() {
-  const module = await import("libsodium-wrappers");
-  return module.default ?? module;
+  const sealedbox = await import("tweetnacl-sealedbox-js");
+  const seal = sealedbox.seal ?? sealedbox.default?.seal;
+  if (typeof seal !== "function") {
+    throw new Error("tweetnacl sealed box seal function is unavailable");
+  }
+  const binaryKey = base64ToBytes(publicKey);
+  const binarySecret = new TextEncoder().encode(secretValue);
+  return bytesToBase64(seal(binarySecret, binaryKey));
 }
 
 function githubHeaders(token) {
@@ -243,6 +240,33 @@ function normalizeApiBaseUrl(value) {
 
 function normalizeText(value) {
   return String(value ?? "").trim();
+}
+
+function base64ToBytes(value) {
+  const normalized = normalizeText(value);
+  if (typeof atob === "function") {
+    return Uint8Array.from(atob(normalized), (char) => char.charCodeAt(0));
+  }
+  const bufferCtor = globalThis.Buffer;
+  if (bufferCtor) {
+    return Uint8Array.from(bufferCtor.from(normalized, "base64"));
+  }
+  throw new Error("base64 decoder unavailable");
+}
+
+function bytesToBase64(bytes) {
+  if (typeof btoa === "function") {
+    let binary = "";
+    for (const byte of bytes) {
+      binary += String.fromCharCode(byte);
+    }
+    return btoa(binary);
+  }
+  const bufferCtor = globalThis.Buffer;
+  if (bufferCtor) {
+    return bufferCtor.from(bytes).toString("base64");
+  }
+  throw new Error("base64 encoder unavailable");
 }
 
 export function sanitizeGitHubActionsSecretSyncErrorMessage(error) {

--- a/test/github-actions-secret-sync.test.js
+++ b/test/github-actions-secret-sync.test.js
@@ -112,7 +112,7 @@ test("github actions secret sync returns redacted JSON failure when encryption t
   assert.equal(result.reason.includes("sk-test-secret"), false);
 });
 
-test("github actions secret encryption loads sodium lazily inside the handler path", async () => {
+test("github actions secret encryption uses pure JavaScript sealed box", async () => {
   const encrypted = await encryptGitHubActionsSecret({
     publicKey: "LW+MLFAtyNPENefjLqmydKkBGp4l5suTetSR9313Xm8=",
     secretValue: "sk-test-secret"
@@ -121,4 +121,26 @@ test("github actions secret encryption loads sodium lazily inside the handler pa
   assert.equal(typeof encrypted, "string");
   assert.equal(encrypted.length > 0, true);
   assert.equal(encrypted.includes("sk-test-secret"), false);
+});
+
+test("github actions secret encryption emits standard base64 sealed box output", async () => {
+  const naclModule = await import("tweetnacl");
+  const nacl = naclModule.default ?? naclModule;
+  const sealedboxModule = await import("tweetnacl-sealedbox-js");
+  const open = sealedboxModule.open ?? sealedboxModule.default?.open;
+  const overheadLength = sealedboxModule.overheadLength ?? sealedboxModule.default?.overheadLength;
+  const keyPair = nacl.box.keyPair();
+  const secretValue = "sk-test-secret";
+
+  const encrypted = await encryptGitHubActionsSecret({
+    publicKey: Buffer.from(keyPair.publicKey).toString("base64"),
+    secretValue
+  });
+  const encryptedBytes = Uint8Array.from(Buffer.from(encrypted, "base64"));
+  const decrypted = open(encryptedBytes, keyPair.publicKey, keyPair.secretKey);
+
+  assert.match(encrypted, /^[A-Za-z0-9+/]+={0,2}$/);
+  assert.equal(encryptedBytes.length, new TextEncoder().encode(secretValue).length + overheadLength);
+  assert.notEqual(decrypted, null);
+  assert.equal(new TextDecoder().decode(decrypted), secretValue);
 });


### PR DESCRIPTION
## This PR satisfies Intent

Fix the live iPhone/operator-page failure observed after #105 deploy:

- `WebAssembly.instantiate(): Wasm code generation disallowed by embedder`

This is scoped to the #4 Butler-origin E2E recovery path. GitHub Actions `OPENAI_API_KEY` sync must not depend on WASM-based sodium in Cloudflare Workers.

## Satisfied Success Criteria

- Replaces `libsodium-wrappers` with pure JavaScript `tweetnacl-sealedbox-js`.
- Keeps GitHub Actions sealed-box encryption behavior for the repo public key.
- Removes the WASM-based sodium dependency from project dependencies.
- Adds encryption tests proving the secret is not echoed and the result is standard base64 sealed-box output that round-trips through sealed-box open.

## Unsatisfied Success Criteria

- Does not set the real `OPENAI_API_KEY`.
- Does not claim live secret sync complete.
- Live iPhone E2E remains required after merge + Cloudflare deploy.

## Surface Update Checklist

- Cloudflare deploy: Required after merge; this changes Worker runtime encryption behavior.
- Custom GPT Action Schema: Not required.
- Custom GPT Instructions: Not required.
- iPhone Butler live E2E: Required after deploy; retry approval + `Sync OPENAI_API_KEY`.

## Verification Evidence

- `node --test test/github-actions-secret-sync.test.js test/worker.test.js` -> pass, 53 tests
- `npm test` -> pass, 422 tests
