### PR TITLE
Accept OpenAPI judgment trace objects

### DIFF
--- a/src/core/judgment-order.js
+++ b/src/core/judgment-order.js
@@ -35,7 +35,7 @@ function normalizeSteps(steps) {
     return [];
   }
   return steps.map((item) =>
-    String(item ?? "")
+    String(typeof item === "object" && item !== null ? item.step : item ?? "")
       .trim()
       .toLowerCase()
   );

--- a/test/butler-orchestrator.test.js
+++ b/test/butler-orchestrator.test.js
@@ -64,6 +64,36 @@ test("butler orchestrator allows issue creation when all gates pass", () => {
   assert.equal(result.repository, "sample-org/vtdd-v2");
 });
 
+test("butler orchestrator accepts OpenAPI judgment trace objects", () => {
+  const result = evaluateButlerExecution({
+    surfaceContext: {
+      surface: "custom_gpt",
+      judgmentModelId: "vtdd-butler-core-v1"
+    },
+    judgmentTrace: judgmentTrace.map((step) => ({
+      step,
+      status: "checked",
+      rationale: `${step} checked before issue creation`
+    })),
+    policyInput: {
+      actionType: ActionType.ISSUE_CREATE,
+      mode: "execution",
+      repositoryInput: "vtdd",
+      aliasRegistry: registry,
+      constitutionConsulted: true,
+      runtimeTruth: { runtimeAvailable: true },
+      credential: { model: "github_app", tier: CredentialTier.EXECUTE },
+      consent: fullConsent,
+      ...approvalContext,
+      issueTraceable: true,
+      go: true,
+      passkey: false
+    }
+  });
+  assert.equal(result.allowed, true);
+  assert.equal(result.repository, "sample-org/vtdd-v2");
+});
+
 test("butler orchestrator blocks invalid judgment order", () => {
   const result = evaluateButlerExecution({
     surfaceContext: {


### PR DESCRIPTION
## This PR satisfies Intent

Fix a live #4 Butler-origin E2E blocker found while trying to create the #4 live verification Issue from Butler.

The Custom GPT Action schema defines `judgmentTrace` items as objects with `step`, `status`, and `rationale`, but the runtime judgment-order evaluator only accepted raw string items. As a result, Butler could send the visible correct order and still receive `butler_invalid_judgment_order` / `judgment step 1 must be constitution`.

## Satisfied Success Criteria

- Accepts OpenAPI-shaped judgment trace objects by reading `item.step`.
- Preserves existing support for raw string judgment trace arrays.
- Keeps the required order unchanged: constitution -> runtime_truth -> issue_context -> current_query.
- Adds a Butler orchestrator regression test for OpenAPI-shaped trace objects.

## Unsatisfied Success Criteria

- Does not create the live E2E verification Issue.
- Does not claim #4 live E2E completion.
- Does not merge, deploy, or mutate secrets/settings.

## Surface Update Checklist

- Cloudflare deploy: Required after merge; this changes Worker runtime judgment handling.
- Custom GPT Action Schema: Not required; schema already uses object-shaped `judgmentTrace`.
- Custom GPT Instructions: Not required for this runtime mismatch.
- Butler live E2E: Required after deploy; retry the Issue creation flow from Butler.

## Verification Evidence

- `node --test test/butler-orchestrator.test.js test/mvp-gateway.test.js test/worker.test.js` -> pass, 64 tests
- `npm test` -> pass, 423 tests
