### PR TITLE
Add Butler-safe GitHub issue creation

### DIFF
--- a/docs/setup/custom-gpt-actions-openapi.json
+++ b/docs/setup/custom-gpt-actions-openapi.json
@@ -465,6 +465,7 @@
                   "operation": {
                     "type": "string",
                     "enum": [
+                      "issue_create",
                       "issue_comment_create",
                       "issue_comment_update",
                       "branch_create",

--- a/docs/setup/custom-gpt-actions-openapi.yaml
+++ b/docs/setup/custom-gpt-actions-openapi.yaml
@@ -314,6 +314,7 @@ paths:
                 operation:
                   type: string
                   enum:
+                    - issue_create
                     - issue_comment_create
                     - issue_comment_update
                     - branch_create

--- a/docs/setup/custom-gpt-instructions-short.md
+++ b/docs/setup/custom-gpt-instructions-short.md
@@ -33,7 +33,7 @@ Self-reference:
 - When the user says `君`, `自分`, `Butler`, `VTDD`, or `このGPT` without naming another target, treat that as this Butler surface.
 
 Repository listing and nickname memory:
-- If the user asks for repository candidates/list, call vtddGateway in exploration mode.
+- For repository candidates/list, call vtddGateway in exploration mode.
 - Use:
   - phase=exploration
   - actorRole=butler
@@ -47,7 +47,7 @@ Repository listing and nickname memory:
 - If the user wants Butler to remember a repository nickname, use vtddUpsertRepositoryNickname.
 - If the user asks what repo nicknames Butler knows, use vtddRetrieveRepositoryNicknames.
 - Nickname memory is explicit user-owned alias registry data, not permission to assume a default repository.
-- If nickname resolution is ambiguous, say so plainly and ask a short confirmation before execution.
+- If nickname resolution is ambiguous, ask a short confirmation before execution.
 - If nickname save/read fails, surface the returned error/reason/issues plainly in Japanese.
 - Do not replace nickname failures with vague summaries like `認証または接続系の可能性`.
 - If an Action returns `ClientResponseError`, state action name, visible HTTP status/body fields, and missing error/reason/issues.
@@ -87,10 +87,11 @@ Remote Codex flow:
 
 GitHub normal write plane:
 - Use vtddWriteGitHub only for scoped GO-tier writes:
-  - issue comment create/update
+  - issue create/comment create/update
   - branch create
   - pull create/update
   - pull comment create
+- For issue_create, fix title+body, bind GO to that payload, call vtddWriteGitHub; do not ask for policyInput/judgmentTrace.
 - Only when repository is resolved, scope is issue-traceable, and GO exists.
 - Do not use vtddWriteGitHub for merge, issue close, deploy, secret/settings/permission mutation, or destructive cleanup.
 
@@ -111,8 +112,8 @@ Deploy plane:
 - If no deploy approval grant exists, show a full clickable absolute passkey operator URL; never only `/v2/approval/passkey/operator...`.
 - Prefer selfParity.deployRecovery.operatorUrl. If constructing from Action origin, show full https://... URL as Markdown link, not code.
 - After vtddDeployProduction, say deploy was dispatched, then re-check self-parity before claiming runtime is updated.
-- If vtddDeployProduction fails, say the exact deploy error/reason/issues and whether the blocker is missing approval grant, auth, memory, or runtime drift.
-- If fallback says openai_api_key_not_configured, do not ask for OPENAI_API_KEY in chat; send operator URL with highRiskKind=github_actions_secret_sync. vtddSyncGitHubActionsSecret syncs only OPENAI_API_KEY after GO + passkey.
+- If vtddDeployProduction fails, say the exact deploy error/reason/issues and blocker category.
+- If fallback says openai_api_key_not_configured, never ask for OPENAI_API_KEY in chat; use vtddSyncGitHubActionsSecret via operator URL.
 
 Progress tracking:
 - After vtddExecute, always call vtddExecutionProgress.

--- a/docs/setup/custom-gpt-instructions.md
+++ b/docs/setup/custom-gpt-instructions.md
@@ -178,10 +178,17 @@ Remote Codex flow:
 GitHub normal write plane:
 - Use vtddWriteGitHub for scoped GitHub normal write operations that stay inside the `GO` tier.
 - Use vtddWriteGitHub for:
+  - issue creation
   - issue comment create or update
   - branch creation for scoped work
   - pull request create or update
   - pull request comment create
+- For issue creation, first confirm or fix the exact Issue title and body, bind
+  the user's `GO` to that title/body scope, then call vtddWriteGitHub with
+  operation=`issue_create`.
+- Do not ask the user to author internal `policyInput`, `judgmentTrace`, or
+  credential payloads for normal operation. Butler must construct those
+  internal fields from the conversation and runtime truth.
 - Only use vtddWriteGitHub when:
   - repository is resolved
   - the request is traceable to the active Issue

--- a/src/core/github-write-plane.js
+++ b/src/core/github-write-plane.js
@@ -5,6 +5,7 @@ const GITHUB_API_VERSION = "2022-11-28";
 const GITHUB_API_USER_AGENT = "vtdd-v2-github-write-plane";
 
 export const GitHubWriteOperation = Object.freeze({
+  ISSUE_CREATE: "issue_create",
   ISSUE_COMMENT_CREATE: "issue_comment_create",
   ISSUE_COMMENT_UPDATE: "issue_comment_update",
   BRANCH_CREATE: "branch_create",
@@ -110,13 +111,18 @@ function validateGitHubWriteRequest(input) {
   }
 
   if (
-    (input.operation === GitHubWriteOperation.ISSUE_COMMENT_CREATE ||
+    (input.operation === GitHubWriteOperation.ISSUE_CREATE ||
+      input.operation === GitHubWriteOperation.ISSUE_COMMENT_CREATE ||
       input.operation === GitHubWriteOperation.ISSUE_COMMENT_UPDATE ||
       input.operation === GitHubWriteOperation.PULL_CREATE ||
       input.operation === GitHubWriteOperation.PULL_COMMENT_CREATE) &&
     !input.body
   ) {
     issues.push("body is required for this operation");
+  }
+
+  if (input.operation === GitHubWriteOperation.ISSUE_CREATE && !input.title) {
+    issues.push("title is required for issue creation");
   }
 
   if (input.operation === GitHubWriteOperation.BRANCH_CREATE && !input.branch) {
@@ -196,6 +202,18 @@ async function dispatchGitHubWrite(input) {
 
 async function buildGitHubWriteRequest(input) {
   const encodedRepository = encodeURIComponentRepository(input.repository);
+
+  if (input.operation === GitHubWriteOperation.ISSUE_CREATE) {
+    return {
+      ok: true,
+      method: "POST",
+      url: `${input.apiBaseUrl}/repos/${encodedRepository}/issues`,
+      body: {
+        title: input.title,
+        body: input.body
+      }
+    };
+  }
 
   if (input.operation === GitHubWriteOperation.ISSUE_COMMENT_CREATE) {
     return {
@@ -329,7 +347,7 @@ function normalizeGitHubWriteResult(input) {
   return {
     operation: input.operation,
     repository: input.repository,
-    issueNumber: input.issueNumber ?? null,
+    issueNumber: input.issueNumber ?? normalizePositiveInteger(responseBody?.number) ?? null,
     pullNumber: normalizePositiveInteger(responseBody?.number) ?? input.pullNumber ?? null,
     branch: input.branch || null,
     baseRef: input.baseRef || null,

--- a/test/custom-gpt-setup-docs.test.js
+++ b/test/custom-gpt-setup-docs.test.js
@@ -50,6 +50,8 @@ test("custom gpt instructions preserve current butler and approval boundaries", 
   assert.equal(doc.includes("vtddRetrieveRepositoryNicknames"), true);
   assert.equal(doc.includes("vtddRetrieveSetupArtifact"), true);
   assert.equal(doc.includes("vtddRetrieveSelfParity"), true);
+  assert.equal(doc.includes("operation=`issue_create`"), true);
+  assert.equal(doc.includes("Do not ask the user to author internal `policyInput`, `judgmentTrace`, or"), true);
   assert.equal(doc.includes("when the user says `君`, `自分`, `Butler`, `VTDD`, or `このGPT`"), true);
   assert.equal(doc.includes("`君自身のアップデートある？`"), true);
   assert.equal(doc.includes("`古くなってない？`"), true);
@@ -91,6 +93,7 @@ test("short custom gpt instructions stay under editor limits while preserving cr
   assert.equal(doc.includes("vtddSyncGitHubActionsSecret"), true);
   assert.equal(doc.includes("vtddUpsertRepositoryNickname"), true);
   assert.equal(doc.includes("vtddRetrieveRepositoryNicknames"), true);
+  assert.equal(doc.includes("For issue_create, fix title+body, bind GO to that payload"), true);
   assert.equal(doc.includes("Nickname memory is explicit user-owned alias registry data"), true);
   assert.equal(doc.includes("surface the returned error/reason/issues plainly in Japanese"), true);
   assert.equal(doc.includes("Do not replace nickname failures with vague summaries"), true);
@@ -129,6 +132,7 @@ test("custom gpt openapi doc exposes current gateway, execute, and progress rout
   assert.equal(doc.includes("conversation:"), true);
   assert.equal(doc.includes("repositoryInput:"), true);
   assert.equal(doc.includes("issueNumber"), true);
+  assert.equal(doc.includes("- issue_create"), true);
   assert.equal(doc.includes("pullNumber"), true);
   assert.equal(doc.includes("workflow_runs"), true);
 });
@@ -156,6 +160,12 @@ test("custom gpt openapi json parses and exposes paths as an object", () => {
   assert.equal(typeof doc.paths["/v2/gateway"], "object");
   assert.equal(typeof doc.paths["/v2/action/execute"], "object");
   assert.equal(typeof doc.paths["/v2/action/github"], "object");
+  assert.equal(
+    doc.paths["/v2/action/github"].post.requestBody.content["application/json"].schema.properties.operation.enum.includes(
+      "issue_create"
+    ),
+    true
+  );
   assert.equal(typeof doc.paths["/v2/action/github-authority"], "object");
   assert.equal(typeof doc.paths["/v2/action/deploy"], "object");
   assert.equal(typeof doc.paths["/v2/action/github-actions-secret"], "object");

--- a/test/github-write-plane.test.js
+++ b/test/github-write-plane.test.js
@@ -2,6 +2,45 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { executeGitHubWritePlane, GitHubWriteOperation } from "../src/core/index.js";
 
+test("github write plane creates scoped issues with GO approval", async () => {
+  const calls = [];
+  const result = await executeGitHubWritePlane({
+    operation: GitHubWriteOperation.ISSUE_CREATE,
+    repository: "sample-org/vtdd-v2-p",
+    title: "test: live E2E evidence",
+    body: "Issue body fixed by approval scope.",
+    approvalPhrase: "GO",
+    targetConfirmed: true,
+    approvalScopeMatched: true,
+    env: {
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_write",
+      GITHUB_API_FETCH: async (url, init) => {
+        calls.push({ url, init });
+        return new Response(
+          JSON.stringify({
+            number: 107,
+            title: "test: live E2E evidence",
+            state: "open",
+            html_url: "https://github.com/sample-org/vtdd-v2-p/issues/107"
+          }),
+          { status: 201, headers: { "content-type": "application/json" } }
+        );
+      }
+    }
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.write.operation, GitHubWriteOperation.ISSUE_CREATE);
+  assert.equal(result.write.issueNumber, 107);
+  assert.equal(result.write.url, "https://github.com/sample-org/vtdd-v2-p/issues/107");
+  assert.equal(calls[0].url.includes("/repos/sample-org/vtdd-v2-p/issues"), true);
+  assert.equal(calls[0].init.method, "POST");
+  assert.deepEqual(JSON.parse(calls[0].init.body), {
+    title: "test: live E2E evidence",
+    body: "Issue body fixed by approval scope."
+  });
+});
+
 test("github write plane creates scoped issue comments with GO approval", async () => {
   const calls = [];
   const result = await executeGitHubWritePlane({

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -1265,7 +1265,42 @@ test("worker returns deploy recovery operator url in self-parity when runtime is
   );
 });
 
-test("worker executes scoped GitHub issue comments through the normal write plane", async () => {
+test("worker executes scoped GitHub issues and issue comments through the normal write plane", async () => {
+  const issueResponse = await worker.fetch(
+    new Request("https://example.com/v2/action/github", {
+      method: "POST",
+      headers: {
+        ...gatewayAuthHeaders,
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({
+        operation: "issue_create",
+        repository: "sample-org/vtdd-v2-p",
+        title: "test: live E2E evidence",
+        body: "Issue body fixed by approval scope.",
+        policyInput: {
+          approvalPhrase: "GO",
+          targetConfirmed: true,
+          approvalScopeMatched: true
+        }
+      })
+    }),
+    {
+      ...gatewayAuthEnv,
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_write",
+      GITHUB_API_FETCH: async () =>
+        new Response(
+          JSON.stringify({
+            number: 107,
+            title: "test: live E2E evidence",
+            state: "open",
+            html_url: "https://github.com/sample-org/vtdd-v2-p/issues/107"
+          }),
+          { status: 201, headers: { "content-type": "application/json" } }
+        )
+    }
+  );
+
   const response = await worker.fetch(
     new Request("https://example.com/v2/action/github", {
       method: "POST",
@@ -1300,6 +1335,12 @@ test("worker executes scoped GitHub issue comments through the normal write plan
         )
     }
   );
+
+  assert.equal(issueResponse.status, 200);
+  const issueBody = await issueResponse.json();
+  assert.equal(issueBody.ok, true);
+  assert.equal(issueBody.write.operation, "issue_create");
+  assert.equal(issueBody.write.issueNumber, 107);
 
   assert.equal(response.status, 200);
   const body = await response.json();


### PR DESCRIPTION
## This PR satisfies Intent

Fix the #4 live E2E blocker where Butler can understand a natural-language request to create a verification Issue but cannot complete the normal GitHub write because `issue_create` is not connected to the GitHub write plane.

This is a bounded complete slice for the Butler-origin entry point: a user should not need to author `policyInput`, `judgmentTrace`, or credential payloads just to create a scoped Issue.

## Satisfied Success Criteria

- Adds `issue_create` to the normal GO-tier GitHub write plane.
- Sends `issue_create` to GitHub REST `POST /repos/{owner}/{repo}/issues` with fixed title/body.
- Keeps `GO`, target confirmation, and approval-scope binding required.
- Exposes `issue_create` in the Custom GPT Action Schema YAML and JSON.
- Updates full and short Instructions so Butler fixes title/body, binds GO to that payload, and does not ask the user for internal payload fields.
- Keeps short Instructions under 8000 characters.

## Unsatisfied Success Criteria

- Does not create the live E2E verification Issue itself.
- Does not claim #4 live E2E completion.
- Does not run Codex handoff, PR creation, merge, deploy, secret mutation, or destructive actions.

## Surface Update Checklist

- Cloudflare deploy: Required after merge; this changes Worker runtime write behavior.
- Custom GPT Action Schema: Required after merge; `issue_create` must be visible in `vtddWriteGitHub`.
- Custom GPT Instructions: Required after merge; Butler must not ask users for internal payload fields.
- iPhone Butler live E2E: Required after deploy + schema/instructions update; retry natural-language Issue creation.

## Verification Evidence

- `node --test test/github-write-plane.test.js test/worker.test.js test/custom-gpt-setup-docs.test.js` -> pass, 61 tests
- `npm test` -> pass, 424 tests
