### PR TITLE
Expose GitHub write auth error bodies

### DIFF
--- a/docs/setup/custom-gpt-actions-openapi.json
+++ b/docs/setup/custom-gpt-actions-openapi.json
@@ -543,10 +543,24 @@
             }
           },
           "401": {
-            "description": "Missing machine auth"
+            "description": "Missing machine auth",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VtddGenericResponse"
+                }
+              }
+            }
           },
           "403": {
-            "description": "Invalid machine auth"
+            "description": "Invalid machine auth",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VtddGenericResponse"
+                }
+              }
+            }
           },
           "422": {
             "description": "GitHub write request blocked or invalid",

--- a/docs/setup/custom-gpt-actions-openapi.yaml
+++ b/docs/setup/custom-gpt-actions-openapi.yaml
@@ -259,8 +259,16 @@ paths:
                 $ref: "#/components/schemas/VtddGenericResponse"
         "401":
           description: Missing machine auth
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VtddGenericResponse"
         "403":
           description: Invalid machine auth
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VtddGenericResponse"
         "422":
           description: Request blocked by policy or validation
           content:

--- a/test/custom-gpt-setup-docs.test.js
+++ b/test/custom-gpt-setup-docs.test.js
@@ -184,6 +184,7 @@ test("custom gpt openapi json parses and exposes paths as an object", () => {
 test("custom gpt openapi json exposes JSON bodies for Butler action auth failures", () => {
   const doc = JSON.parse(fs.readFileSync(OPENAPI_JSON_PATH, "utf8"));
   const routes = [
+    ["/v2/action/github", "post"],
     ["/v2/action/repository-nickname", "post"],
     ["/v2/retrieve/repository-nicknames", "get"],
     ["/v2/retrieve/self-parity", "get"]


### PR DESCRIPTION
## This PR satisfies Intent

Fix the current #4 live E2E diagnostic blocker where `vtddWriteGitHub` failures can surface in Butler only as `ClientResponseError` with no visible HTTP status/body.

The Worker already returns JSON for unauthenticated `/v2/action/github` requests, but the Custom GPT Action Schema did not declare JSON response bodies for 401/403 on this route. That can cause the Action transport to hide the useful `error` / `reason` fields.

## Satisfied Success Criteria

- Adds JSON response schemas for `401` and `403` on `/v2/action/github`.
- Updates the canonical OpenAPI YAML and JSON setup artifacts.
- Extends setup docs tests so GitHub write auth failures are covered with the same body visibility guard as nickname/self-parity routes.

## Unsatisfied Success Criteria

- Does not claim Issue creation now succeeds.
- Does not change runtime code or GitHub credentials.
- Does not deploy or mutate secrets/settings.

## Surface Update Checklist

- Cloudflare deploy: Not required; schema-only.
- Custom GPT Action Schema: Required after merge.
- Custom GPT Instructions: Not required.
- Butler live E2E: Retry Issue creation after schema update; if it still fails, the next response should expose HTTP status/body or structured error fields.

## Verification Evidence

- `node --test test/custom-gpt-setup-docs.test.js` -> pass, 8 tests
- `npm test` -> pass, 424 tests
