### PR TITLE
Return action-visible GitHub write failures

### DIFF
--- a/docs/setup/custom-gpt-actions-openapi.json
+++ b/docs/setup/custom-gpt-actions-openapi.json
@@ -501,6 +501,13 @@
                   "body": {
                     "type": "string"
                   },
+                  "responseMode": {
+                    "type": "string",
+                    "enum": [
+                      "action_visible"
+                    ],
+                    "description": "Use action_visible from Custom GPT so write failures return ok:false JSON instead of an Action transport failure."
+                  },
                   "issueContext": {
                     "type": "object",
                     "properties": {
@@ -533,7 +540,7 @@
         },
         "responses": {
           "200": {
-            "description": "GitHub normal write executed",
+            "description": "GitHub normal write executed, or an action-visible ok:false envelope when responseMode is action_visible.",
             "content": {
               "application/json": {
                 "schema": {

--- a/docs/setup/custom-gpt-actions-openapi.yaml
+++ b/docs/setup/custom-gpt-actions-openapi.yaml
@@ -347,6 +347,11 @@ paths:
                   type: string
                 body:
                   type: string
+                responseMode:
+                  type: string
+                  enum:
+                    - action_visible
+                  description: Use action_visible from Custom GPT so write failures return ok:false JSON instead of an Action transport failure.
                 issueContext:
                   type: object
                   properties:
@@ -366,7 +371,7 @@ paths:
               additionalProperties: true
       responses:
         "200":
-          description: GitHub normal write executed
+          description: GitHub normal write executed, or an action-visible ok:false envelope when responseMode is action_visible.
           content:
             application/json:
               schema:

--- a/docs/setup/custom-gpt-instructions-short.md
+++ b/docs/setup/custom-gpt-instructions-short.md
@@ -1,10 +1,8 @@
 # Custom GPT Instructions (Short)
 
-This file is the canonical paste-ready Butler Instructions template for Custom
-GPT surfaces with an 8000-character limit.
+Paste-ready Butler Instructions for Custom GPT's 8000-char limit.
 
-Use when the editor cannot accept the full template in
-`docs/setup/custom-gpt-instructions.md`.
+Use when the editor cannot accept `docs/setup/custom-gpt-instructions.md`.
 
 ```text
 You are VTDD Butler. Answer in Japanese unless the user asks otherwise.
@@ -91,7 +89,7 @@ GitHub normal write plane:
   - branch create
   - pull create/update
   - pull comment create
-- For issue_create, fix title+body, bind GO to that payload, call vtddWriteGitHub; do not ask for policyInput/judgmentTrace.
+- For issue_create, fix title+body, bind GO to that payload, call vtddWriteGitHub with responseMode=action_visible; do not ask for policyInput/judgmentTrace.
 - Only when repository is resolved, scope is issue-traceable, and GO exists.
 - Do not use vtddWriteGitHub for merge, issue close, deploy, secret/settings/permission mutation, or destructive cleanup.
 

--- a/docs/setup/custom-gpt-instructions.md
+++ b/docs/setup/custom-gpt-instructions.md
@@ -186,6 +186,9 @@ GitHub normal write plane:
 - For issue creation, first confirm or fix the exact Issue title and body, bind
   the user's `GO` to that title/body scope, then call vtddWriteGitHub with
   operation=`issue_create`.
+- When calling vtddWriteGitHub from Custom GPT, include
+  `responseMode=action_visible` so downstream write failures remain visible as
+  `ok:false` JSON with `httpStatus`.
 - Do not ask the user to author internal `policyInput`, `judgmentTrace`, or
   credential payloads for normal operation. Butler must construct those
   internal fields from the conversation and runtime truth.

--- a/src/core/github-write-plane.js
+++ b/src/core/github-write-plane.js
@@ -172,7 +172,8 @@ async function dispatchGitHubWrite(input) {
       ok: false,
       status: 503,
       error: "github_write_failed",
-      reason: `failed to execute GitHub write operation: ${input.operation}`
+      reason: `failed to execute GitHub write operation: ${input.operation}`,
+      issues: ["github_write_fetch_exception"]
     };
   }
 

--- a/src/worker.js
+++ b/src/worker.js
@@ -752,7 +752,17 @@ async function handleGitHubWritePlaneRequest(request, env) {
   });
 
   if (!executed.ok) {
-    return json(executed.status ?? 503, {
+    const httpStatus = executed.status ?? 503;
+    if (wantsActionVisibleGitHubWriteErrors(payload)) {
+      return json(200, {
+        ok: false,
+        httpStatus,
+        error: executed.error ?? "github_write_failed",
+        reason: executed.reason,
+        issues: executed.issues ?? []
+      });
+    }
+    return json(httpStatus, {
       ok: false,
       error: executed.error ?? "github_write_failed",
       reason: executed.reason,
@@ -764,6 +774,11 @@ async function handleGitHubWritePlaneRequest(request, env) {
     ok: true,
     write: executed.write
   });
+}
+
+function wantsActionVisibleGitHubWriteErrors(payload) {
+  const responseMode = normalizeText(payload?.responseMode);
+  return responseMode === "action_visible";
 }
 
 async function handleGitHubHighRiskPlaneRequest(request, env) {

--- a/test/github-write-plane.test.js
+++ b/test/github-write-plane.test.js
@@ -220,3 +220,29 @@ test("github write plane rejects missing GO approval scope or unsupported operat
   assert.equal(unsupported.ok, false);
   assert.equal(unsupported.reason.includes("operation is unsupported"), true);
 });
+
+test("github write plane preserves sanitized fetch exception details", async () => {
+  const result = await executeGitHubWritePlane({
+    operation: GitHubWriteOperation.ISSUE_CREATE,
+    repository: "sample-org/vtdd-v2-p",
+    title: "test",
+    body: "body",
+    approvalPhrase: "GO",
+    targetConfirmed: true,
+    approvalScopeMatched: true,
+    env: {
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_write",
+      GITHUB_API_FETCH: async () => {
+        throw new TypeError("fetch failed at /Users/example with Bearer ghs_secret");
+      }
+    }
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.status, 503);
+  assert.equal(result.error, "github_write_failed");
+  assert.equal(result.reason, "failed to execute GitHub write operation: issue_create");
+  assert.equal(result.issues.includes("github_write_fetch_exception"), true);
+  assert.equal(result.issues.some((issue) => issue.includes("ghs_secret")), false);
+  assert.equal(result.issues.some((issue) => issue.includes("/Users/example")), false);
+});

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -1360,6 +1360,77 @@ test("worker rejects unsupported high-risk GitHub write operations on the normal
       body: JSON.stringify({
         operation: "merge",
         repository: "sample-org/vtdd-v2-p",
+        responseMode: "action_visible",
+        policyInput: {
+          approvalPhrase: "GO",
+          targetConfirmed: true,
+          approvalScopeMatched: true
+        }
+      })
+    }),
+    {
+      ...gatewayAuthEnv,
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_write"
+    }
+  );
+
+  assert.equal(response.status, 200);
+  const body = await response.json();
+  assert.equal(body.ok, false);
+  assert.equal(body.httpStatus, 422);
+  assert.equal(body.error, "github_write_request_invalid");
+});
+
+test("worker returns action-visible GitHub write fetch failures", async () => {
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/action/github", {
+      method: "POST",
+      headers: {
+        ...gatewayAuthHeaders,
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({
+        operation: "issue_create",
+        repository: "sample-org/vtdd-v2-p",
+        title: "test",
+        body: "body",
+        responseMode: "action_visible",
+        policyInput: {
+          approvalPhrase: "GO",
+          targetConfirmed: true,
+          approvalScopeMatched: true
+        }
+      })
+    }),
+    {
+      ...gatewayAuthEnv,
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_write",
+      GITHUB_API_FETCH: async () => {
+        throw new TypeError("fetch failed");
+      }
+    }
+  );
+
+  assert.equal(response.status, 200);
+  const body = await response.json();
+  assert.equal(body.ok, false);
+  assert.equal(body.httpStatus, 503);
+  assert.equal(body.error, "github_write_failed");
+  assert.equal(body.reason, "failed to execute GitHub write operation: issue_create");
+  assert.equal(body.issues.includes("github_write_fetch_exception"), true);
+});
+
+test("worker preserves HTTP error status for GitHub write consumers that do not request action envelopes", async () => {
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/action/github", {
+      method: "POST",
+      headers: {
+        ...gatewayAuthHeaders,
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({
+        operation: "merge",
+        repository: "sample-org/vtdd-v2-p",
         policyInput: {
           approvalPhrase: "GO",
           targetConfirmed: true,
@@ -1376,6 +1447,7 @@ test("worker rejects unsupported high-risk GitHub write operations on the normal
   assert.equal(response.status, 422);
   const body = await response.json();
   assert.equal(body.ok, false);
+  assert.equal(body.httpStatus, undefined);
   assert.equal(body.error, "github_write_request_invalid");
 });
 


### PR DESCRIPTION
## This PR satisfies Intent

Fix the #4 live E2E diagnostic blocker where Butler reaches `vtddWriteGitHub.issue_create` but GitHub write failures are still not actionable from the Custom GPT surface.

The previous retry showed `error: github_write_failed` with a generic reason and empty issues. This PR adds an explicit Custom GPT action-visible response mode so downstream GitHub write validation/fetch failures can return `ok:false`, `httpStatus`, `error`, `reason`, and `issues` without changing default HTTP semantics for non-Custom-GPT consumers.

## Satisfied Success Criteria

- `/v2/action/github` can return Action-visible `ok:false` envelopes when `responseMode=action_visible` is supplied.
- Preserves the original failure status in `httpStatus` inside the Custom GPT envelope.
- Preserves normal HTTP error status behavior for clients that do not request action-visible envelopes.
- Reports fetch exceptions with the fixed non-sensitive marker `github_write_fetch_exception`; raw exception text is not exposed.
- Keeps successful GitHub writes unchanged.
- Updates Custom GPT Action Schema and Instructions so Butler knows to request the action-visible envelope for `issue_create`.
- Adds regression tests for action-visible write failure envelopes, default HTTP status behavior, and non-sensitive fetch exception reporting.

## Unsatisfied Success Criteria

- Does not claim Issue creation now succeeds.
- Does not change GitHub App credentials or permissions.
- Does not deploy, merge, mutate secrets/settings, or complete #4.

## Surface Update Checklist

- Cloudflare deploy: Required after merge; runtime behavior changes.
- Custom GPT Action Schema: Required after merge; `vtddWriteGitHub` gains `responseMode` guidance.
- Custom GPT Instructions: Required after merge; issue_create must use `responseMode=action_visible`.
- Butler live E2E: Retry issue creation after deploy + schema/instruction refresh; if it fails, the response should include `httpStatus` and `issues`.

## Verification Evidence

- `node --test test/github-write-plane.test.js test/worker.test.js test/custom-gpt-setup-docs.test.js` -> pass, 64 tests
- `npm test` -> pass, 427 tests