### PR TITLE
Install dependencies for Codex fallback review

### DIFF
--- a/.github/workflows/codex-pr-review-fallback.yml
+++ b/.github/workflows/codex-pr-review-fallback.yml
@@ -72,22 +72,43 @@ jobs:
           private-key: ${{ secrets.VTDD_GITHUB_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 
+      - name: Checkout trusted reviewer source
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.repository }}
+          ref: ${{ github.ref }}
+          path: trusted
+          fetch-depth: 1
+          persist-credentials: false
+
       - name: Checkout target repository
         uses: actions/checkout@v4
         with:
           repository: ${{ env.TARGET_REPOSITORY }}
           ref: ${{ env.TARGET_HEAD_REF }}
           token: ${{ steps.app-token.outputs.token }}
+          path: target
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Fetch base ref
         shell: bash
-        run: git fetch origin "$TARGET_BASE_REF":"refs/remotes/origin/$TARGET_BASE_REF"
+        working-directory: target
+        run: |
+          git remote set-url origin "https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/${TARGET_REPOSITORY}.git"
+          git fetch origin "$TARGET_BASE_REF":"refs/remotes/origin/$TARGET_BASE_REF"
+          git remote set-url origin "https://github.com/${TARGET_REPOSITORY}.git"
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 20
+          cache: npm
+          cache-dependency-path: trusted/package-lock.json
+
+      - name: Install trusted reviewer dependencies
+        working-directory: trusted
+        run: npm ci
 
       - name: Install Codex CLI
         shell: bash
@@ -97,4 +118,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-        run: node scripts/run-codex-pr-review-fallback.mjs
+          CODEX_REVIEW_WORKTREE: ${{ github.workspace }}/target
+        run: node trusted/scripts/run-codex-pr-review-fallback.mjs

--- a/scripts/run-codex-pr-review-fallback.mjs
+++ b/scripts/run-codex-pr-review-fallback.mjs
@@ -72,8 +72,9 @@ async function main() {
 }
 
 async function runCodexReview({ baseRef, prompt }) {
+  const cwd = process.env.CODEX_REVIEW_WORKTREE || process.cwd();
   return execFileAsync("codex", ["review", "--base", baseRef, "-"], {
-    cwd: process.cwd(),
+    cwd,
     env: process.env,
     input: prompt,
     maxBuffer: 1024 * 1024 * 8

--- a/test/gemini-pr-review-workflow.test.js
+++ b/test/gemini-pr-review-workflow.test.js
@@ -39,9 +39,24 @@ test("Codex fallback workflow runs reviewer-only Codex CLI and writes back via G
   assert.equal(fallbackWorkflow.includes("pull_request_number"), true);
   assert.equal(fallbackWorkflow.includes("head_ref"), true);
   assert.equal(fallbackWorkflow.includes("base_ref"), true);
+  assert.equal(fallbackWorkflow.includes("name: Checkout trusted reviewer source"), true);
+  assert.equal(fallbackWorkflow.includes("path: trusted"), true);
+  assert.equal(fallbackWorkflow.includes("name: Checkout target repository"), true);
+  assert.equal(fallbackWorkflow.includes("path: target"), true);
+  assert.equal(fallbackWorkflow.includes("persist-credentials: false"), true);
+  assert.equal(fallbackWorkflow.includes("cache-dependency-path: trusted/package-lock.json"), true);
+  assert.equal(fallbackWorkflow.includes("name: Install trusted reviewer dependencies"), true);
+  assert.equal(fallbackWorkflow.includes("working-directory: trusted"), true);
+  assert.equal(fallbackWorkflow.includes("run: npm ci"), true);
+  assert.equal(
+    fallbackWorkflow.indexOf("run: npm ci") <
+      fallbackWorkflow.indexOf("run: node trusted/scripts/run-codex-pr-review-fallback.mjs"),
+    true
+  );
   assert.equal(fallbackWorkflow.includes("name: Install Codex CLI"), true);
   assert.equal(fallbackWorkflow.includes("npm install -g @openai/codex"), true);
-  assert.equal(fallbackWorkflow.includes("run: node scripts/run-codex-pr-review-fallback.mjs"), true);
+  assert.equal(fallbackWorkflow.includes("CODEX_REVIEW_WORKTREE: ${{ github.workspace }}/target"), true);
+  assert.equal(fallbackWorkflow.includes("run: node trusted/scripts/run-codex-pr-review-fallback.mjs"), true);
   assert.equal(fallbackWorkflow.includes("OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}"), true);
   assert.equal(fallbackWorkflow.includes("GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}"), true);
 });


### PR DESCRIPTION
## This PR satisfies Intent

Fix the live reviewer fallback blocker observed on PR #110 where `codex-pr-review-fallback` dispatched but failed before review execution with `ERR_MODULE_NOT_FOUND: Cannot find package @simplewebauthn/server`.

The fallback script imports repository source through `src/core/index.js`, so the workflow needs trusted repository dependencies before running the reviewer script. To preserve the `pull_request_target` secret boundary, this PR runs the reviewer script and dependency install from trusted main-line source and keeps the PR head checkout as a separate review worktree.

## Satisfied Success Criteria

- Checks out trusted reviewer source into `trusted/` and installs dependencies there with `npm ci`.
- Checks out the PR head into `target/` only as the review worktree.
- Runs `node trusted/scripts/run-codex-pr-review-fallback.mjs`, not a script from the PR head.
- Passes `CODEX_REVIEW_WORKTREE=${{ github.workspace }}/target` so Codex reviews the target diff while execution code remains trusted.
- Disables persisted checkout credentials in both worktrees.
- Adds workflow regression tests proving trusted dependency install precedes fallback script execution and target worktree is separate.

## Unsatisfied Success Criteria

- Does not claim Codex fallback review is fully verified until the GitHub Actions workflow runs on this PR.
- Does not change PR #110 runtime behavior.
- Does not change Gemini reviewer behavior.
- Does not deploy, merge, mutate secrets/settings, or complete #4.

## Surface Update Checklist

- Cloudflare deploy: Not required; GitHub Actions workflow only.
- Custom GPT Action Schema: Not required.
- Custom GPT Instructions: Not required.
- Butler live E2E: After merge, rerun the fallback path and verify a completed fallback review comment replaces `requested`/failed state.

## Verification Evidence

- `node --test test/gemini-pr-review-workflow.test.js` -> pass, 4 tests
- `npm test` -> pass, 424 tests