### PR TITLE
Use codex exec review for fallback

### DIFF
--- a/.github/workflows/codex-pr-review-fallback.yml
+++ b/.github/workflows/codex-pr-review-fallback.yml
@@ -81,24 +81,6 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
 
-      - name: Checkout target repository
-        uses: actions/checkout@v4
-        with:
-          repository: ${{ env.TARGET_REPOSITORY }}
-          ref: ${{ env.TARGET_HEAD_REF }}
-          token: ${{ steps.app-token.outputs.token }}
-          path: target
-          fetch-depth: 0
-          persist-credentials: false
-
-      - name: Fetch base ref
-        shell: bash
-        working-directory: target
-        run: |
-          git remote set-url origin "https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/${TARGET_REPOSITORY}.git"
-          git fetch origin "$TARGET_BASE_REF":"refs/remotes/origin/$TARGET_BASE_REF"
-          git remote set-url origin "https://github.com/${TARGET_REPOSITORY}.git"
-
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -114,9 +96,14 @@ jobs:
         shell: bash
         run: npm install -g @openai/codex
 
+      - name: Authenticate Codex CLI
+        shell: bash
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: printenv OPENAI_API_KEY | codex login --with-api-key
+
       - name: Run non-manual Codex fallback review
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          CODEX_REVIEW_WORKTREE: ${{ github.workspace }}/target
         run: node trusted/scripts/run-codex-pr-review-fallback.mjs

--- a/scripts/run-codex-pr-review-fallback.mjs
+++ b/scripts/run-codex-pr-review-fallback.mjs
@@ -1,16 +1,14 @@
-import { execFile } from "node:child_process";
-import { promisify } from "node:util";
+import { spawn } from "node:child_process";
 import {
   ReviewerRecommendedAction,
+  buildPullRequestDiff,
+  buildPullRequestReviewContext,
   formatCodexReviewFallbackComment
 } from "../src/core/index.js";
-
-const execFileAsync = promisify(execFile);
 
 async function main() {
   const repository = mustGetEnv("TARGET_REPOSITORY");
   const prNumber = mustGetEnv("TARGET_PR_NUMBER");
-  const baseRef = mustGetEnv("TARGET_BASE_REF");
   const trigger = mustGetEnv("CODEX_FALLBACK_TRIGGER");
   const reason = mustGetEnv("CODEX_FALLBACK_REASON");
   const githubToken = mustGetEnv("GITHUB_TOKEN");
@@ -19,21 +17,33 @@ async function main() {
     throw new Error("OPENAI_API_KEY is required for non-manual Codex fallback review");
   }
 
-  const prompt = [
-    "You are the VTDD fallback reviewer.",
-    "Act only as a critique-only reviewer.",
-    "Do not propose merge or execution.",
-    "Review the current branch diff against the provided base branch.",
-    "Return strict JSON with these fields only:",
-    '{',
-    '  "criticalFindings": ["..."],',
-    '  "risks": ["..."],',
-    '  "recommendedAction": "approve|request_changes|manual_review"',
-    '}',
-    "If there are no major issues, set criticalFindings to [\"No major blocking issues found.\"], risks to [\"Human should still verify the PR before GO.\"], and recommendedAction to \"approve\"."
-  ].join("\n");
+  const apiBaseUrl = process.env.GITHUB_API_URL || "https://api.github.com";
+  const githubFetch = createGitHubFetch({ apiBaseUrl, token: githubToken });
 
-  const review = await runCodexReview({ baseRef, prompt });
+  const pullRequest = await githubFetch(`/repos/${repository}/pulls/${prNumber}`);
+  const files = await githubFetchAll(githubFetch, `/repos/${repository}/pulls/${prNumber}/files?per_page=100`);
+  const issueComments = await githubFetchAll(
+    githubFetch,
+    `/repos/${repository}/issues/${prNumber}/comments?per_page=100`
+  );
+  const reviewComments = await githubFetchAll(
+    githubFetch,
+    `/repos/${repository}/pulls/${prNumber}/comments?per_page=100`
+  );
+  const reviews = await githubFetchAll(githubFetch, `/repos/${repository}/pulls/${prNumber}/reviews?per_page=100`);
+  const prDiff = buildPullRequestDiff(files);
+  const context = buildPullRequestReviewContext({
+    repository,
+    trigger,
+    pullRequest,
+    files,
+    issueComments,
+    reviewComments,
+    reviews
+  });
+
+  const prompt = buildCodexFallbackReviewPrompt({ context, prDiff });
+  const review = await runCodexReview({ prompt });
   const parsed = parseReviewerJson(review.stdout);
   const normalizedReview = normalizeReviewerResult(parsed, review.stdout);
 
@@ -48,10 +58,11 @@ async function main() {
     rawReview: review.stdout
   });
 
-  const apiBaseUrl = process.env.GITHUB_API_URL || "https://api.github.com";
-  const githubFetch = createGitHubFetch({ apiBaseUrl, token: githubToken });
-  const existingComments = await githubFetch(`/repos/${repository}/issues/${prNumber}/comments?per_page=100`);
-  const existing = existingComments.find((comment) =>
+  const latestIssueComments = await githubFetchAll(
+    githubFetch,
+    `/repos/${repository}/issues/${prNumber}/comments?per_page=100`
+  );
+  const existing = latestIssueComments.find((comment) =>
     String(comment?.body || "").includes("<!-- vtdd:reviewer=codex-fallback -->")
   );
 
@@ -71,13 +82,94 @@ async function main() {
   console.log(`Created Codex fallback review comment on PR #${prNumber}.`);
 }
 
-async function runCodexReview({ baseRef, prompt }) {
-  const cwd = process.env.CODEX_REVIEW_WORKTREE || process.cwd();
-  return execFileAsync("codex", ["review", "--base", baseRef, "-"], {
-    cwd,
-    env: process.env,
-    input: prompt,
+function buildCodexFallbackReviewPrompt({ context, prDiff }) {
+  return [
+    "You are the VTDD fallback reviewer.",
+    "Act only as a critique-only reviewer.",
+    "Do not run shell commands or inspect the filesystem.",
+    "Review only the PR context and diff provided in this prompt.",
+    "Do not propose merge or execution.",
+    "Return strict JSON with these fields only:",
+    "{",
+    '  "criticalFindings": ["..."],',
+    '  "risks": ["..."],',
+    '  "recommendedAction": "approve|request_changes|manual_review"',
+    "}",
+    'If there are no major issues, set criticalFindings to ["No major blocking issues found."], risks to ["Human should still verify the PR before revision GO or merge GO + real passkey."], and recommendedAction to "approve".',
+    'If the provided diff or context is insufficient for critique, set recommendedAction to "manual_review" and explain exactly what is missing.',
+    "",
+    "PR context:",
+    context,
+    "",
+    "PR diff:",
+    prDiff
+  ].join("\n");
+}
+
+async function runCodexReview({ prompt }) {
+  return spawnWithInput("codex", ["exec", "--skip-git-repo-check", "--ephemeral", "-"], prompt, {
+    cwd: process.cwd(),
+    env: buildCodexExecutionEnv(process.env),
     maxBuffer: 1024 * 1024 * 8
+  });
+}
+
+function buildCodexExecutionEnv(env) {
+  const allowedNames = [
+    "CI",
+    "CODEX_HOME",
+    "HOME",
+    "LANG",
+    "LC_ALL",
+    "PATH",
+    "RUNNER_TEMP",
+    "TMPDIR",
+    "XDG_CACHE_HOME",
+    "XDG_CONFIG_HOME"
+  ];
+  return Object.fromEntries(
+    allowedNames
+      .map((name) => [name, env[name]])
+      .filter(([, value]) => typeof value === "string" && value.length > 0)
+  );
+}
+
+function spawnWithInput(command, args, input, options = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd: options.cwd,
+      env: options.env,
+      stdio: ["pipe", "pipe", "pipe"]
+    });
+    const maxBuffer = options.maxBuffer || 1024 * 1024;
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+      if (stdout.length > maxBuffer) {
+        child.kill("SIGTERM");
+        reject(new Error(`${command} stdout exceeded ${maxBuffer} bytes`));
+      }
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+      if (stderr.length > maxBuffer) {
+        child.kill("SIGTERM");
+        reject(new Error(`${command} stderr exceeded ${maxBuffer} bytes`));
+      }
+    });
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code === 0) {
+        resolve({ stdout, stderr });
+        return;
+      }
+      reject(new Error(`${command} ${args.join(" ")} failed with exit code ${code}: ${stderr || stdout}`));
+    });
+    child.stdin.end(input);
   });
 }
 
@@ -157,8 +249,45 @@ function createGitHubFetch({ apiBaseUrl, token }) {
       return null;
     }
 
-    return response.json();
+    const data = await response.json();
+    if (options.includeHeaders) {
+      return {
+        data,
+        link: response.headers.get("link") || ""
+      };
+    }
+
+    return data;
   };
+}
+
+async function githubFetchAll(githubFetch, firstPath) {
+  const records = [];
+  let path = firstPath;
+
+  while (path) {
+    const page = await githubFetch(path, { includeHeaders: true });
+    if (!Array.isArray(page.data)) {
+      throw new Error(`Expected paginated GitHub API array for ${firstPath}`);
+    }
+    records.push(...page.data);
+    path = parseNextLinkPath(page.link);
+  }
+
+  return records;
+}
+
+function parseNextLinkPath(linkHeader) {
+  const links = String(linkHeader || "").split(",");
+  for (const link of links) {
+    const match = link.match(/<([^>]+)>;\s*rel="next"/);
+    if (!match) {
+      continue;
+    }
+    const url = new URL(match[1]);
+    return `${url.pathname}${url.search}`;
+  }
+  return "";
 }
 
 function mustGetEnv(name) {

--- a/test/codex-review-fallback.test.js
+++ b/test/codex-review-fallback.test.js
@@ -1,11 +1,14 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import fs from "node:fs";
 import {
   CODEX_REVIEW_FALLBACK_MARKER,
   findExistingCodexReviewFallbackComment,
   formatCodexReviewFallbackComment,
   parseCodexReviewFallbackComment
 } from "../src/core/index.js";
+
+const fallbackScript = fs.readFileSync("scripts/run-codex-pr-review-fallback.mjs", "utf8");
 
 test("formatCodexReviewFallbackComment renders marker and requested fallback state", () => {
   const body = formatCodexReviewFallbackComment({
@@ -81,4 +84,18 @@ test("parseCodexReviewFallbackComment exposes blocked fallback reviewer state", 
     blocker: "openai_api_key_not_configured",
     body
   });
+});
+
+test("fallback script reviews GitHub API diff without checking out untrusted PR code", () => {
+  assert.equal(fallbackScript.includes("buildPullRequestDiff"), true);
+  assert.equal(fallbackScript.includes("buildPullRequestReviewContext"), true);
+  assert.equal(fallbackScript.includes("Do not run shell commands or inspect the filesystem."), true);
+  assert.equal(fallbackScript.includes('["exec", "--skip-git-repo-check", "--ephemeral", "-"]'), true);
+  assert.equal(fallbackScript.includes("buildCodexExecutionEnv(process.env)"), true);
+  assert.equal(fallbackScript.includes("env: process.env"), false);
+  assert.equal(fallbackScript.includes("githubFetchAll"), true);
+  assert.equal(fallbackScript.includes("latestIssueComments"), true);
+  assert.equal(fallbackScript.includes('rel="next"'), true);
+  assert.equal(fallbackScript.includes('["exec", "review"'), false);
+  assert.equal(fallbackScript.includes("CODEX_REVIEW_WORKTREE"), false);
 });

--- a/test/gemini-pr-review-workflow.test.js
+++ b/test/gemini-pr-review-workflow.test.js
@@ -41,8 +41,8 @@ test("Codex fallback workflow runs reviewer-only Codex CLI and writes back via G
   assert.equal(fallbackWorkflow.includes("base_ref"), true);
   assert.equal(fallbackWorkflow.includes("name: Checkout trusted reviewer source"), true);
   assert.equal(fallbackWorkflow.includes("path: trusted"), true);
-  assert.equal(fallbackWorkflow.includes("name: Checkout target repository"), true);
-  assert.equal(fallbackWorkflow.includes("path: target"), true);
+  assert.equal(fallbackWorkflow.includes("name: Checkout target repository"), false);
+  assert.equal(fallbackWorkflow.includes("path: target"), false);
   assert.equal(fallbackWorkflow.includes("persist-credentials: false"), true);
   assert.equal(fallbackWorkflow.includes("cache-dependency-path: trusted/package-lock.json"), true);
   assert.equal(fallbackWorkflow.includes("name: Install trusted reviewer dependencies"), true);
@@ -55,7 +55,14 @@ test("Codex fallback workflow runs reviewer-only Codex CLI and writes back via G
   );
   assert.equal(fallbackWorkflow.includes("name: Install Codex CLI"), true);
   assert.equal(fallbackWorkflow.includes("npm install -g @openai/codex"), true);
-  assert.equal(fallbackWorkflow.includes("CODEX_REVIEW_WORKTREE: ${{ github.workspace }}/target"), true);
+  assert.equal(fallbackWorkflow.includes("name: Authenticate Codex CLI"), true);
+  assert.equal(fallbackWorkflow.includes("printenv OPENAI_API_KEY | codex login --with-api-key"), true);
+  assert.equal(
+    fallbackWorkflow.indexOf("codex login --with-api-key") <
+      fallbackWorkflow.indexOf("run: node trusted/scripts/run-codex-pr-review-fallback.mjs"),
+    true
+  );
+  assert.equal(fallbackWorkflow.includes("CODEX_REVIEW_WORKTREE"), false);
   assert.equal(fallbackWorkflow.includes("run: node trusted/scripts/run-codex-pr-review-fallback.mjs"), true);
   assert.equal(fallbackWorkflow.includes("OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}"), true);
   assert.equal(fallbackWorkflow.includes("GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}"), true);


### PR DESCRIPTION
## This PR satisfies Intent

Fix the live Codex fallback blocker found after PR #111: the workflow can now start Codex, but `codex exec review --base main` still tried to inspect the Git worktree and produced a `bwrap` environment failure instead of reviewing the PR. This PR changes the fallback to review GitHub API-provided PR context and diff only.

## Satisfied Success Criteria

- Keeps fallback execution in trusted repository source with `npm ci` before the script runs.
- Authenticates Codex CLI with `OPENAI_API_KEY` before reviewer execution.
- Removes untrusted PR checkout and `CODEX_REVIEW_WORKTREE` from the fallback workflow.
- Fetches PR metadata, changed files, issue comments, review comments, and reviews through the GitHub App token.
- Paginates GitHub API list reads instead of silently stopping at the first 100 records.
- Builds bounded PR review context/diff with the same core helpers used by the Gemini reviewer.
- Runs `codex exec --skip-git-repo-check --ephemeral -` with an explicit critique-only prompt that tells Codex not to run shell commands or inspect the filesystem.
- Runs the Codex reviewer child process with a minimal whitelisted environment so `GITHUB_TOKEN` and `OPENAI_API_KEY` are not available to prompt-injected reviewer content.

## Unsatisfied Success Criteria

- Does not claim the fallback loop is complete until the branch workflow updates the PR fallback comment with a useful review based on the provided diff.
- Does not change Gemini reviewer behavior.
- Does not change PR #110 runtime behavior.
- Does not deploy, merge, mutate secrets/settings, or complete #4.

## Surface Update Checklist

- Cloudflare deploy: Not required; GitHub Actions script only.
- Custom GPT Action Schema: Not required.
- Custom GPT Instructions: Not required.
- Butler live E2E: Not claimed by this PR. This only repairs the non-manual Codex fallback reviewer path.

## Verification Evidence

- `node --test test/codex-review-fallback.test.js test/gemini-pr-review-workflow.test.js` -> pass, 10 tests
- `git diff --check` -> pass
- `npm test` -> pass, 428 tests
- Live branch workflow: pending rerun after this update
