### PR TITLE
Expose pull request merge truth in read plane

### DIFF
--- a/src/core/github-read-plane.js
+++ b/src/core/github-read-plane.js
@@ -333,7 +333,12 @@ function normalizePullRequest(item) {
     state: normalizeText(item?.state),
     draft: item?.draft === true,
     headRef: normalizeText(item?.head?.ref),
+    headSha: normalizeText(item?.head?.sha),
     baseRef: normalizeText(item?.base?.ref),
+    baseSha: normalizeText(item?.base?.sha),
+    merged: item?.merged === true || Boolean(normalizeText(item?.merged_at)),
+    mergedAt: normalizeText(item?.merged_at),
+    mergeCommitSha: normalizeText(item?.merge_commit_sha),
     htmlUrl: normalizeText(item?.html_url)
   };
 }

--- a/test/github-read-plane.test.js
+++ b/test/github-read-plane.test.js
@@ -102,6 +102,52 @@ test("github read plane includes issue body when reading a specific issue", asyn
   assert.equal(result.read.records[0].body, "## Intent\nButler reads the canonical Issue before execution.");
 });
 
+test("github read plane exposes pull request merge truth when reading a specific PR", async () => {
+  const calls = [];
+  const result = await retrieveGitHubReadPlane({
+    resource: GitHubReadResource.PULLS,
+    repository: "sample-org/vtdd-v2-p",
+    pullNumber: 114,
+    env: {
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_pull_read",
+      GITHUB_API_FETCH: async (url) => {
+        calls.push(url);
+        return new Response(
+          JSON.stringify({
+            number: 114,
+            title: "Treat Codex fallback comments as reviewer evidence",
+            state: "closed",
+            draft: false,
+            head: {
+              ref: "codex/fix-reviewer-evidence-instructions",
+              sha: "d8755b961c6db1a5555320abf067d459686f48b8"
+            },
+            base: {
+              ref: "main",
+              sha: "83ba6135f3a01c27948a018c721135a301d938fe"
+            },
+            merged: true,
+            merged_at: "2026-04-29T03:00:45Z",
+            merge_commit_sha: "c9ad3c36ed5032bfb4f02bb79d65a8806bcd1047",
+            html_url: "https://github.com/sample-org/vtdd-v2-p/pull/114"
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        );
+      }
+    }
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(calls[0].endsWith("/repos/sample-org/vtdd-v2-p/pulls/114"), true);
+  assert.equal(result.read.pullNumber, 114);
+  assert.equal(result.read.records[0].state, "closed");
+  assert.equal(result.read.records[0].merged, true);
+  assert.equal(result.read.records[0].mergedAt, "2026-04-29T03:00:45Z");
+  assert.equal(result.read.records[0].mergeCommitSha, "c9ad3c36ed5032bfb4f02bb79d65a8806bcd1047");
+  assert.equal(result.read.records[0].headSha, "d8755b961c6db1a5555320abf067d459686f48b8");
+  assert.equal(result.read.records[0].baseSha, "83ba6135f3a01c27948a018c721135a301d938fe");
+});
+
 test("github read plane reads pull reviews, review comments, checks, workflow runs, and branches", async () => {
   const responses = new Map([
     [


### PR DESCRIPTION
## This PR satisfies Intent

Fixes the Butler/runtime-truth gap found while checking PR #114: `vtddRetrieveGitHub(resource=pulls, pullNumber=...)` exposed `state: closed` but not whether the PR was merged. Butler therefore had to report merge status as unverified.

## Satisfied Success Criteria

- Adds normalized PR merge fields to GitHub read plane pull records:
  - `merged`
  - `mergedAt`
  - `mergeCommitSha`
  - `headSha`
  - `baseSha`
- Adds a regression test for reading a specific closed+merged PR.
- Keeps `closed` vs `merged` distinguishable from GitHub runtime truth.

## Unsatisfied Success Criteria

- Does not claim deployed Worker runtime has this change until production deploy is completed.
- Does not update Custom GPT editor state.

## Surface Update Checklist

- Cloudflare deploy: Required after merge because Worker runtime behavior changes.
- Custom GPT Action Schema: Not required; response bodies use `additionalProperties`.
- Custom GPT Instructions: Not required for this change.
- Butler live E2E: After deploy, ask Butler to re-check PR #114 merged status.

## Non-goals

- No reviewer fallback behavior change.
- No Action Schema shape change.
- No credential/secret/permission mutation.
- No merge or issue closure authority change.

## Verification Evidence

- `node --test test/github-read-plane.test.js test/worker.test.js` -> pass, 56 tests
- `git diff --check` -> pass
- `npm test` -> pass, 429 tests

Refs #4
