### PR TITLE
Fix self-parity runtime manifest

### DIFF
--- a/src/core/custom-gpt-setup-artifacts.js
+++ b/src/core/custom-gpt-setup-artifacts.js
@@ -33,8 +33,11 @@ const RUNTIME_SETUP_MANIFEST = Object.freeze({
     "/v2/action/github",
     "/v2/action/github-authority",
     "/v2/action/deploy",
+    "/v2/action/github-actions-secret",
+    "/v2/action/repository-nickname",
     "/v2/action/progress",
     "/v2/retrieve/github",
+    "/v2/retrieve/repository-nicknames",
     "/v2/retrieve/approval-grant",
     "/v2/retrieve/setup-artifact",
     "/v2/retrieve/self-parity"
@@ -46,8 +49,11 @@ const RUNTIME_SETUP_MANIFEST = Object.freeze({
     "vtddWriteGitHub",
     "vtddGitHubAuthority",
     "vtddDeployProduction",
+    "vtddSyncGitHubActionsSecret",
+    "vtddUpsertRepositoryNickname",
     "vtddExecutionProgress",
     "vtddRetrieveGitHub",
+    "vtddRetrieveRepositoryNicknames",
     "vtddRetrieveApprovalGrant",
     "vtddRetrieveSetupArtifact",
     "vtddRetrieveSelfParity"
@@ -58,8 +64,11 @@ const RUNTIME_SETUP_MANIFEST = Object.freeze({
     "vtddWriteGitHub",
     "vtddGitHubAuthority",
     "vtddDeployProduction",
+    "vtddSyncGitHubActionsSecret",
+    "vtddUpsertRepositoryNickname",
     "vtddExecutionProgress",
     "vtddRetrieveGitHub",
+    "vtddRetrieveRepositoryNicknames",
     "vtddRetrieveSetupArtifact",
     "vtddRetrieveSelfParity",
     "Action Schema update required",
@@ -207,6 +216,14 @@ export async function evaluateButlerSelfParity(input = {}) {
     runtimeMissingInstructionTokens.length > 0
       ? "cloudflare_deploy_update_required"
       : "in_sync";
+  const staleCapabilities =
+    runtimeParity === "cloudflare_deploy_update_required"
+      ? {
+          routes: runtimeMissingRoutes,
+          operationIds: runtimeMissingOperationIds,
+          instructionTokens: runtimeMissingInstructionTokens
+        }
+      : null;
 
   const deployOperatorUrl =
     runtimeParity === "cloudflare_deploy_update_required" && repository && runtimeOrigin
@@ -257,6 +274,7 @@ export async function evaluateButlerSelfParity(input = {}) {
       runtimeMissingRoutes,
       runtimeMissingOperationIds,
       runtimeMissingInstructionTokens,
+      staleCapabilities,
       deployRecovery:
         runtimeParity === "cloudflare_deploy_update_required"
           ? {

--- a/test/custom-gpt-setup-artifacts.test.js
+++ b/test/custom-gpt-setup-artifacts.test.js
@@ -108,6 +108,11 @@ test("evaluateButlerSelfParity reports deploy update required when canonical set
   assert.equal(result.ok, true);
   assert.equal(result.selfParity.runtimeParity, "cloudflare_deploy_update_required");
   assert.equal(result.selfParity.runtimeMissingOperationIds.includes("vtddBrandNewParityRoute"), true);
+  assert.deepEqual(result.selfParity.staleCapabilities, {
+    routes: [],
+    operationIds: ["vtddBrandNewParityRoute"],
+    instructionTokens: []
+  });
   assert.equal(result.selfParity.recommendedActions.includes("Cloudflare deploy update required."), true);
   assert.equal(
     result.selfParity.deployRecovery.operatorUrl,
@@ -117,4 +122,98 @@ test("evaluateButlerSelfParity reports deploy update required when canonical set
     result.selfParity.recommendedActions.some((item) => item.includes("/v2/approval/passkey/operator")),
     true
   );
+});
+
+test("evaluateButlerSelfParity treats current nickname and secret sync actions as deployed runtime capabilities", async () => {
+  const canonicalInstructions = [
+    "vtddGateway",
+    "vtddExecute",
+    "vtddWriteGitHub",
+    "vtddGitHubAuthority",
+    "vtddDeployProduction",
+    "vtddSyncGitHubActionsSecret",
+    "vtddUpsertRepositoryNickname",
+    "vtddExecutionProgress",
+    "vtddRetrieveGitHub",
+    "vtddRetrieveRepositoryNicknames",
+    "vtddRetrieveSetupArtifact",
+    "vtddRetrieveSelfParity",
+    "Action Schema update required",
+    "Instructions update required",
+    "Cloudflare deploy update required"
+  ].join("\n");
+  const canonicalOpenApi = [
+    "paths:",
+    "  /health:",
+    "    get:",
+    "      operationId: getHealth",
+    "  /v2/gateway:",
+    "    post:",
+    "      operationId: vtddGateway",
+    "  /v2/action/execute:",
+    "    post:",
+    "      operationId: vtddExecute",
+    "  /v2/action/github:",
+    "    post:",
+    "      operationId: vtddWriteGitHub",
+    "  /v2/action/github-authority:",
+    "    post:",
+    "      operationId: vtddGitHubAuthority",
+    "  /v2/action/deploy:",
+    "    post:",
+    "      operationId: vtddDeployProduction",
+    "  /v2/action/github-actions-secret:",
+    "    post:",
+    "      operationId: vtddSyncGitHubActionsSecret",
+    "  /v2/action/repository-nickname:",
+    "    post:",
+    "      operationId: vtddUpsertRepositoryNickname",
+    "  /v2/action/progress:",
+    "    get:",
+    "      operationId: vtddExecutionProgress",
+    "  /v2/retrieve/github:",
+    "    get:",
+    "      operationId: vtddRetrieveGitHub",
+    "  /v2/retrieve/repository-nicknames:",
+    "    get:",
+    "      operationId: vtddRetrieveRepositoryNicknames",
+    "  /v2/retrieve/approval-grant:",
+    "    get:",
+    "      operationId: vtddRetrieveApprovalGrant",
+    "  /v2/retrieve/setup-artifact:",
+    "    get:",
+    "      operationId: vtddRetrieveSetupArtifact",
+    "  /v2/retrieve/self-parity:",
+    "    get:",
+    "      operationId: vtddRetrieveSelfParity"
+  ].join("\n");
+
+  const result = await evaluateButlerSelfParity({
+    repository: "sample-org/vtdd-v2-p",
+    ref: "main",
+    runtimeOrigin: "https://sample-user-vtdd.example.workers.dev",
+    env: {
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_setup_read",
+      GITHUB_API_FETCH: async (url) => {
+        const parsed = new URL(url);
+        const isInstructions = parsed.pathname.endsWith("/docs/setup/custom-gpt-instructions.md");
+        return new Response(
+          JSON.stringify({
+            sha: isInstructions ? "instructions-sha" : "openapi-sha",
+            encoding: "base64",
+            content: encodeContent(isInstructions ? canonicalInstructions : canonicalOpenApi)
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        );
+      }
+    }
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.selfParity.runtimeParity, "in_sync");
+  assert.deepEqual(result.selfParity.runtimeMissingRoutes, []);
+  assert.deepEqual(result.selfParity.runtimeMissingOperationIds, []);
+  assert.deepEqual(result.selfParity.runtimeMissingInstructionTokens, []);
+  assert.equal(result.selfParity.staleCapabilities, null);
+  assert.equal(result.selfParity.deployRecovery, null);
 });


### PR DESCRIPTION
## This PR satisfies Intent

Fixes a Butler self-parity false stale reading where canonical Custom GPT setup artifacts contain already-implemented Worker capabilities, but the self-parity runtime manifest did not list them. This is scoped to Issue #4 live Butler E2E runtime truth reliability.

## Satisfied Success Criteria

- Adds the deployed nickname and GitHub Actions secret-sync routes to the self-parity runtime manifest.
- Adds the matching operation IDs to runtime capability and instruction-token parity checks.
- Adds stable `staleCapabilities` diagnostics so Butler can show the raw stale breakdown instead of relying on absent fields.
- Adds regression coverage showing current nickname and secret-sync capabilities evaluate as `in_sync`.

## Unsatisfied Success Criteria

- None for this source-level slice.
- Butler live self-parity remains unverified until this PR is merged, Cloudflare is deployed, and Butler re-runs self-parity from the Custom GPT surface.

## Surface Update Checklist

- Cloudflare deploy: required after merge because Worker runtime behavior changes.
- Custom GPT Action Schema: not required; no new action path or required schema field is introduced.
- Custom GPT Instructions: not required; no conversation policy wording changes.
- Secret/credential mutation: not included.
- Deploy/passkey operation: not included in this PR.

## Verification Evidence

- `node --test test/custom-gpt-setup-artifacts.test.js test/worker.test.js`
- `npm test`
- `git diff --check`

## Issue Traceability

- Parent issue: #4
- Scope: Butler self-parity runtime truth for live E2E reliability
- Non-goals: merge/deploy execution, credential mutation, destructive action, Action Schema/Instructions edits
