### PR TITLE
Expose GitHub write fetch diagnostics

### DIFF
--- a/src/core/github-write-plane.js
+++ b/src/core/github-write-plane.js
@@ -167,13 +167,19 @@ async function dispatchGitHubWrite(input) {
       headers: githubJsonHeaders({ token: input.token }),
       body: request.body ? JSON.stringify(request.body) : undefined
     });
-  } catch {
+  } catch (error) {
     return {
       ok: false,
       status: 503,
       error: "github_write_failed",
       reason: `failed to execute GitHub write operation: ${input.operation}`,
-      issues: ["github_write_fetch_exception"]
+      issues: ["github_write_fetch_exception"],
+      diagnostics: buildGitHubWriteFetchExceptionDiagnostics({
+        operation: input.operation,
+        method: request.method,
+        url: request.url,
+        error
+      })
     };
   }
 
@@ -403,4 +409,24 @@ function encodeURIComponentRepository(repository) {
     .split("/")
     .map((segment) => encodeURIComponent(segment))
     .join("/");
+}
+
+function buildGitHubWriteFetchExceptionDiagnostics({ operation, method, url, error }) {
+  return {
+    operation,
+    requestMethod: method,
+    requestUrl: sanitizeGitHubWriteDiagnosticText(url),
+    exceptionName: sanitizeGitHubWriteDiagnosticText(error?.name || "Error"),
+    exceptionMessage: sanitizeGitHubWriteDiagnosticText(error?.message || error)
+  };
+}
+
+function sanitizeGitHubWriteDiagnosticText(value) {
+  return normalizeText(value)
+    .replace(/sk-[A-Za-z0-9_-]+/g, "[REDACTED_OPENAI_KEY]")
+    .replace(/gh[psuro]_[A-Za-z0-9_]+/g, "[REDACTED_GITHUB_TOKEN]")
+    .replace(/Bearer\s+[A-Za-z0-9_.=-]+/gi, "Bearer [REDACTED]")
+    .replace(/(authorization|api[_-]?key|token|secret)(["'\s:=]+)([^"'\s<>&]+)/gi, "$1$2[REDACTED]")
+    .replace(/\/Users\/[^\s"'<>]+/g, "/Users/[REDACTED_PATH]")
+    .slice(0, 500);
 }

--- a/src/worker.js
+++ b/src/worker.js
@@ -759,14 +759,16 @@ async function handleGitHubWritePlaneRequest(request, env) {
         httpStatus,
         error: executed.error ?? "github_write_failed",
         reason: executed.reason,
-        issues: executed.issues ?? []
+        issues: executed.issues ?? [],
+        diagnostics: executed.diagnostics ?? null
       });
     }
     return json(httpStatus, {
       ok: false,
       error: executed.error ?? "github_write_failed",
       reason: executed.reason,
-      issues: executed.issues ?? []
+      issues: executed.issues ?? [],
+      diagnostics: executed.diagnostics ?? null
     });
   }
 

--- a/test/github-write-plane.test.js
+++ b/test/github-write-plane.test.js
@@ -243,6 +243,15 @@ test("github write plane preserves sanitized fetch exception details", async () 
   assert.equal(result.error, "github_write_failed");
   assert.equal(result.reason, "failed to execute GitHub write operation: issue_create");
   assert.equal(result.issues.includes("github_write_fetch_exception"), true);
+  assert.deepEqual(result.diagnostics, {
+    operation: "issue_create",
+    requestMethod: "POST",
+    requestUrl: "https://api.github.com/repos/sample-org/vtdd-v2-p/issues",
+    exceptionName: "TypeError",
+    exceptionMessage: "fetch failed at /Users/[REDACTED_PATH] with Bearer [REDACTED_GITHUB_TOKEN]"
+  });
   assert.equal(result.issues.some((issue) => issue.includes("ghs_secret")), false);
   assert.equal(result.issues.some((issue) => issue.includes("/Users/example")), false);
+  assert.equal(JSON.stringify(result.diagnostics).includes("ghs_secret"), false);
+  assert.equal(JSON.stringify(result.diagnostics).includes("/Users/example"), false);
 });

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -1418,6 +1418,13 @@ test("worker returns action-visible GitHub write fetch failures", async () => {
   assert.equal(body.error, "github_write_failed");
   assert.equal(body.reason, "failed to execute GitHub write operation: issue_create");
   assert.equal(body.issues.includes("github_write_fetch_exception"), true);
+  assert.deepEqual(body.diagnostics, {
+    operation: "issue_create",
+    requestMethod: "POST",
+    requestUrl: "https://api.github.com/repos/sample-org/vtdd-v2-p/issues",
+    exceptionName: "TypeError",
+    exceptionMessage: "fetch failed"
+  });
 });
 
 test("worker preserves HTTP error status for GitHub write consumers that do not request action envelopes", async () => {


### PR DESCRIPTION
## This PR satisfies Intent

Improves the Butler-first live E2E path for Issue #4 by making GitHub write-plane fetch exceptions diagnosable from the Custom GPT action surface. The current Butler failure only exposes `github_write_fetch_exception`, which is insufficient to distinguish network/runtime/API transport failures from payload or permission problems.

## Satisfied Success Criteria

- Preserves action-visible GitHub write failure envelopes.
- Adds sanitized diagnostics for fetch exceptions: operation, request method, request URL, exception name, and exception message.
- Propagates diagnostics through the Worker response for both action-visible and normal error consumers.
- Redacts GitHub/OpenAI token-shaped values and local `/Users/...` paths from diagnostic text.

## Unsatisfied Success Criteria

- This PR does not claim Issue creation now succeeds. It makes the next Butler retry return enough raw detail to identify the actual live blocker.
- Live Butler E2E remains blocked until this is merged, deployed, and the Issue creation retry is run from Butler.

## Surface Update Checklist

- Cloudflare deploy: required after merge because Worker runtime error output changes.
- Custom GPT Action Schema: not required; the response schema already permits additional properties.
- Custom GPT Instructions: not required for this runtime diagnostic slice.
- Secret/credential mutation: not included.
- Deploy/passkey operation: not included in this PR.

## Verification Evidence

- `node --test test/github-write-plane.test.js test/worker.test.js`
- `npm test`
- `git diff --check`

## Issue Traceability

- Parent issue: #4
- Scope: Butler → GitHub write diagnostics for live E2E Issue creation recovery
- Non-goals: manual Issue creation, merge/deploy execution, credential mutation, destructive action
