### PR TITLE
Prefill passkey operator action type from URL

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -992,6 +992,7 @@ function handlePasskeyOperatorPageRequest(request) {
     repositoryInput: url.searchParams.get("repositoryInput"),
     issueNumber: url.searchParams.get("issueNumber"),
     phase: url.searchParams.get("phase") || "execution",
+    actionType: url.searchParams.get("actionType") || "destructive",
     highRiskKind: url.searchParams.get("highRiskKind") || "github_app_secret_sync",
     operatorId: url.searchParams.get("operatorId") || "vtdd-operator",
     operatorLabel: url.searchParams.get("operatorLabel") || "VTDD Operator",

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -470,7 +470,7 @@ test("worker can resolve passkey memory provider from Cloudflare D1 binding fall
 test("worker serves passkey operator page", async () => {
   const response = await worker.fetch(
     new Request(
-      "https://example.com/v2/approval/passkey/operator?repositoryInput=marushu%2Fvtdd-v2-p&issueNumber=15&highRiskKind=github_app_secret_sync"
+      "https://example.com/v2/approval/passkey/operator?repositoryInput=marushu%2Fvtdd-v2-p&issueNumber=15&phase=execution&actionType=deploy_production&highRiskKind=deploy_production"
     ),
     gatewayAuthEnv
   );
@@ -480,7 +480,11 @@ test("worker serves passkey operator page", async () => {
   const html = await response.text();
   assert.equal(html.includes("VTDD Passkey Operator"), true);
   assert.equal(html.includes("/v2/approval/passkey/challenge"), true);
-  assert.equal(html.includes("github_app_secret_sync"), true);
+  assert.equal(html.includes('id="repo-input" value="marushu/vtdd-v2-p"'), true);
+  assert.equal(html.includes('id="issue-input" value="15"'), true);
+  assert.equal(html.includes('id="phase-input" value="execution"'), true);
+  assert.equal(html.includes('id="action-type-input" value="deploy_production"'), true);
+  assert.equal(html.includes('id="risk-kind-input" value="deploy_production"'), true);
 });
 
 test("worker passkey operator page enables desktop secret sync bridge when syncApiBase is provided", async () => {


### PR DESCRIPTION
## This PR satisfies Intent

Improves the iPhone-safe passkey operator path for Issue #4 by honoring the `actionType` URL parameter when rendering the operator form. Deploy helper URLs already include `actionType=deploy_production`, but the Worker did not pass it into the page, so the form fell back to `destructive`.

## Satisfied Success Criteria

- `GET /v2/approval/passkey/operator?...&actionType=deploy_production&highRiskKind=deploy_production` now renders Action Type as `deploy_production`.
- Repository, issue number, phase, action type, and high-risk kind are covered by the Worker page test.
- Reduces manual field editing on iPhone and prevents wrong deploy approval scope from the default `destructive` value.

## Unsatisfied Success Criteria

- This PR does not implement deploy run completion monitoring.
- This PR does not change approval TTL or auto-dispatch behavior after passkey approval. Those should be separate UX/runtime slices.

## Surface Update Checklist

- Cloudflare deploy: required after merge because Worker-rendered HTML changes.
- Custom GPT Action Schema: not required; no action schema change.
- Custom GPT Instructions: not required for this runtime form prefill fix.
- Secret/credential mutation: not included.
- Deploy/passkey operation: not included in this PR.

## Verification Evidence

- `node --test test/passkey-operator-page.test.js test/worker.test.js`
- `npm test`
- `git diff --check`

## Issue Traceability

- Parent issue: #4
- Scope: iPhone passkey operator deploy approval URL reliability
- Non-goals: run monitoring, manual Issue creation, credential mutation, destructive action execution
