### PR TITLE
Return deploy operator URL from self-parity

### DIFF
--- a/docs/setup/custom-gpt-instructions-short.md
+++ b/docs/setup/custom-gpt-instructions-short.md
@@ -102,14 +102,15 @@ GitHub high-risk authority plane:
 - Do not route deploy or other destructive provider actions through vtddGitHubAuthority.
 
 Deploy plane:
-- Use vtddDeployProduction for governed production deploy after Butler determines runtime deploy parity is stale and the human explicitly requests deploy.
+- Use vtddDeployProduction after deploy ask.
 - vtddDeployProduction requires:
   - resolved repository
   - explicit GO
   - real passkey approval grant scoped to deploy_production
 - If no deploy approval grant exists, show a full clickable absolute passkey operator URL; never only `/v2/approval/passkey/operator...`.
-- Prefer selfParity.deployRecovery.operatorUrl. If constructing from Action origin, show full https://... URL as Markdown link, not code.
-- After vtddDeployProduction, say deploy was dispatched, then re-check self-parity before claiming runtime is updated.
+- Prefer selfParity.deployOperatorUrl; if stale, selfParity.deployRecovery.operatorUrl also valid. Show full https://... as Markdown link, not code.
+- If user asks deploy URL while in_sync, show selfParity.deployOperatorUrl; do not block because deployRecovery is null.
+- After vtddDeployProduction, say deploy dispatched, then re-check self-parity before claiming runtime updated.
 - If vtddDeployProduction fails, say the exact deploy error/reason/issues and blocker category.
 - If fallback says openai_api_key_not_configured, never ask for OPENAI_API_KEY in chat; use vtddSyncGitHubActionsSecret via operator URL.
 

--- a/docs/setup/custom-gpt-instructions.md
+++ b/docs/setup/custom-gpt-instructions.md
@@ -221,17 +221,17 @@ GitHub high-risk authority plane:
 - Do not route deploy, secret mutation, permission mutation, or other destructive provider actions through vtddGitHubAuthority.
 
 Deploy plane:
-- Use vtddDeployProduction for governed production deploy execution after Butler determines that runtime deploy parity is stale and the human explicitly requests deploy.
+- Use vtddDeployProduction for governed production deploy execution after the human explicitly requests deploy.
 - vtddDeployProduction requires:
   - resolved repository
   - explicit `GO`
   - real passkey approval grant scoped to `deploy_production`
 - If no deploy-scoped approval grant is available yet, direct the human to the passkey operator helper as a full clickable absolute URL. Never show only the relative `/v2/approval/passkey/operator...` path in normal Butler conversation.
-- Prefer calling `vtddRetrieveSelfParity` and using `selfParity.deployRecovery.operatorUrl`; return that full absolute URL directly so the human can open it on iPhone/mobile without rebuilding the path by hand.
+- Prefer calling `vtddRetrieveSelfParity` and using `selfParity.deployOperatorUrl`; if runtime is stale, `selfParity.deployRecovery.operatorUrl` is also valid. Return that full absolute URL directly so the human can open it on iPhone/mobile without rebuilding the path by hand.
 - If you must construct the helper URL yourself from the Action server origin, present the complete `https://.../v2/approval/passkey/operator?repositoryInput=<resolved repo>&issueNumber=<active issue when relevant>&actionType=deploy_production&highRiskKind=deploy_production` URL as a clickable Markdown link, not an inline code block.
 - When you present that URL, say plainly that it is the next safe path for `GO + real passkey` deploy recovery.
 - If the human is on the same-origin passkey operator page, that operator page may also dispatch the governed deploy path after it obtains a deploy-scoped `approvalGrantId`.
-- When self-parity indicates `Cloudflare deploy update required`, you may suggest deploy as the next safe high-risk action.
+- When self-parity indicates `Cloudflare deploy update required`, you may suggest deploy as the next safe high-risk action. If the human explicitly asks for a deploy URL after a merge even while self-parity says `in_sync`, still provide `selfParity.deployOperatorUrl`; do not say no URL exists merely because `deployRecovery` is null.
 - After vtddDeployProduction, tell the user deploy was dispatched and then re-check self-parity before claiming runtime is updated.
 - If vtddDeployProduction fails, tell the user the exact deploy `error`, `reason`, and `issues`, including whether the blocker is missing approval grant, auth, memory, or runtime drift.
 

--- a/src/core/custom-gpt-setup-artifacts.js
+++ b/src/core/custom-gpt-setup-artifacts.js
@@ -226,7 +226,7 @@ export async function evaluateButlerSelfParity(input = {}) {
       : null;
 
   const deployOperatorUrl =
-    runtimeParity === "cloudflare_deploy_update_required" && repository && runtimeOrigin
+    repository && runtimeOrigin
       ? buildPasskeyOperatorUrl({
           origin: runtimeOrigin,
           repository,
@@ -275,6 +275,7 @@ export async function evaluateButlerSelfParity(input = {}) {
       runtimeMissingOperationIds,
       runtimeMissingInstructionTokens,
       staleCapabilities,
+      deployOperatorUrl,
       deployRecovery:
         runtimeParity === "cloudflare_deploy_update_required"
           ? {

--- a/test/custom-gpt-setup-artifacts.test.js
+++ b/test/custom-gpt-setup-artifacts.test.js
@@ -118,6 +118,7 @@ test("evaluateButlerSelfParity reports deploy update required when canonical set
     result.selfParity.deployRecovery.operatorUrl,
     "https://sample-user-vtdd.example.workers.dev/v2/approval/passkey/operator?repositoryInput=sample-org%2Fvtdd-v2-p&actionType=deploy_production&highRiskKind=deploy_production&issueNumber=91"
   );
+  assert.equal(result.selfParity.deployOperatorUrl, result.selfParity.deployRecovery.operatorUrl);
   assert.equal(
     result.selfParity.recommendedActions.some((item) => item.includes("/v2/approval/passkey/operator")),
     true
@@ -215,5 +216,9 @@ test("evaluateButlerSelfParity treats current nickname and secret sync actions a
   assert.deepEqual(result.selfParity.runtimeMissingOperationIds, []);
   assert.deepEqual(result.selfParity.runtimeMissingInstructionTokens, []);
   assert.equal(result.selfParity.staleCapabilities, null);
+  assert.equal(
+    result.selfParity.deployOperatorUrl,
+    "https://sample-user-vtdd.example.workers.dev/v2/approval/passkey/operator?repositoryInput=sample-org%2Fvtdd-v2-p&actionType=deploy_production&highRiskKind=deploy_production"
+  );
   assert.equal(result.selfParity.deployRecovery, null);
 });

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -1202,6 +1202,10 @@ test("worker returns Butler self-parity summary", async () => {
   assert.equal(body.selfParity.runtimeParity, "in_sync");
   assert.equal(body.selfParity.runtimeMissingRoutes.length, 0);
   assert.equal(body.selfParity.canonical.artifacts.instructions.path, "docs/setup/custom-gpt-instructions.md");
+  assert.equal(
+    body.selfParity.deployOperatorUrl,
+    "https://example.com/v2/approval/passkey/operator?repositoryInput=sample-org%2Fvtdd-v2-p&actionType=deploy_production&highRiskKind=deploy_production&issueNumber=91"
+  );
   assert.equal(body.selfParity.deployRecovery, null);
 });
 


### PR DESCRIPTION
## This PR satisfies Intent

Improves the Butler-first iPhone deploy path for Issue #4 by making `vtddRetrieveSelfParity` return a deploy passkey operator URL even when `runtimeParity` is `in_sync`. Butler previously depended on `selfParity.deployRecovery.operatorUrl`, which only exists for stale runtime parity, so it refused to provide a deploy URL after a merge when the user explicitly asked for one.

## Satisfied Success Criteria

- Adds `selfParity.deployOperatorUrl` whenever repository and runtime origin are resolved.
- Keeps `selfParity.deployRecovery.operatorUrl` for stale runtime recovery.
- Updates full and short Custom GPT instructions to prefer `selfParity.deployOperatorUrl` and not block deploy URL guidance just because `deployRecovery` is null.
- Keeps short instructions under the 8000 character limit.

## Unsatisfied Success Criteria

- This PR does not add signed/nonce-bound operator intents.
- This PR does not add deploy run completion notification/monitoring.
- Live Butler behavior remains unverified until merge, Instructions update, Cloudflare deploy, and Butler retest.

## Surface Update Checklist

- Cloudflare deploy: required after merge because Worker response shape changes.
- Custom GPT Action Schema: not required; generic response schema allows additional properties.
- Custom GPT Instructions: required after merge because deploy URL guidance changed.
- Secret/credential mutation: not included.
- Deploy/passkey operation: not included in this PR.

## Verification Evidence

- `node --test test/custom-gpt-setup-artifacts.test.js test/custom-gpt-setup-docs.test.js test/worker.test.js`
- `npm test`
- `git diff --check`

## Security Note

The operator URL parameters are prefill data, not authority. The real deploy authority remains GO + real passkey approval and approval grant validation. A future slice should consider a short-lived signed/nonce operator intent to reduce URL tampering and stale-link risk.

## Issue Traceability

- Parent issue: #4
- Scope: Butler deploy URL guidance for iPhone/mobile operator flow
- Non-goals: signed nonce intents, run monitoring, credential mutation, destructive execution
