### PR TITLE
Add approval grant copy controls

### DIFF
--- a/src/core/passkey-operator-page.js
+++ b/src/core/passkey-operator-page.js
@@ -385,11 +385,15 @@ export function renderPasskeyOperatorPage(input = {}) {
           if (!verifyResponse.ok) {
             throw responseError(verifyBody, "approval verify failed");
           }
-          latestApprovalGrantId = verifyBody?.approvalGrant?.approvalId || "";
+          latestApprovalGrantId = verifyBody?.approvalGrant?.approvalId || verifyBody?.approvalGrantId || "";
           approveOutput.textContent = JSON.stringify(verifyBody, null, 2);
           if (latestApprovalGrantId && autoCopyApprovalGrantInput.checked) {
-            await copyApprovalGrantIdToClipboard({ quiet: true });
-            approveOutput.textContent = approveOutput.textContent + "\\n\\nCopied approvalGrantId to clipboard.";
+            try {
+              await copyApprovalGrantIdToClipboard({ quiet: true });
+              approveOutput.textContent = approveOutput.textContent + "\\n\\nCopied approvalGrantId to clipboard.";
+            } catch (error) {
+              approveOutput.textContent = approveOutput.textContent + "\\n\\nAuto-copy failed: " + String(error);
+            }
           }
         } catch (error) {
           approveOutput.textContent = String(error);

--- a/src/core/passkey-operator-page.js
+++ b/src/core/passkey-operator-page.js
@@ -104,6 +104,11 @@ export function renderPasskeyOperatorPage(input = {}) {
       button.secondary {
         background: var(--accent-2);
       }
+      button.ghost {
+        background: #eef3ef;
+        color: var(--accent);
+        border: 1px solid #b8cec3;
+      }
       pre {
         white-space: pre-wrap;
         word-break: break-word;
@@ -121,6 +126,18 @@ export function renderPasskeyOperatorPage(input = {}) {
         display: flex;
         gap: 10px;
         flex-wrap: wrap;
+      }
+      .inline-check {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        margin: 8px 0 12px;
+        color: var(--muted);
+        font-size: 14px;
+      }
+      .inline-check input {
+        width: auto;
+        margin: 0;
       }
     </style>
   </head>
@@ -160,7 +177,12 @@ export function renderPasskeyOperatorPage(input = {}) {
           <input id="risk-kind-input" value="${highRiskKindDefault}" />
           <div class="row">
             <button class="secondary" id="approve-button">Approve high-risk action</button>
+            <button class="ghost" id="copy-approval-grant-button" type="button">Copy approvalGrantId</button>
           </div>
+          <label class="inline-check" for="auto-copy-approval-grant-input">
+            <input id="auto-copy-approval-grant-input" type="checkbox" />
+            Auto-copy approvalGrantId after approval
+          </label>
           <p class="muted">GitHub App secret sync なら <code>actionType=destructive</code> / <code>highRiskKind=github_app_secret_sync</code>、production deploy なら <code>actionType=deploy_production</code> / <code>highRiskKind=deploy_production</code> を使います。</p>
           <pre id="approve-output"></pre>
         </section>
@@ -205,6 +227,8 @@ export function renderPasskeyOperatorPage(input = {}) {
       const syncOutput = document.getElementById("sync-output");
       const deployOutput = document.getElementById("deploy-output");
       const openaiSecretSyncOutput = document.getElementById("openai-secret-sync-output");
+      const copyApprovalGrantButton = document.getElementById("copy-approval-grant-button");
+      const autoCopyApprovalGrantInput = document.getElementById("auto-copy-approval-grant-input");
       let latestApprovalGrantId = "";
 
       async function readResponseBody(response) {
@@ -246,6 +270,44 @@ export function renderPasskeyOperatorPage(input = {}) {
         }
         return new Error(parts.join("\\n"));
       }
+
+      async function copyText(text) {
+        const value = String(text || "");
+        if (!value) {
+          throw new Error("nothing to copy");
+        }
+        if (navigator.clipboard?.writeText) {
+          await navigator.clipboard.writeText(value);
+          return;
+        }
+        const textarea = document.createElement("textarea");
+        textarea.value = value;
+        textarea.setAttribute("readonly", "");
+        textarea.style.position = "fixed";
+        textarea.style.opacity = "0";
+        document.body.appendChild(textarea);
+        textarea.select();
+        const copied = document.execCommand("copy");
+        document.body.removeChild(textarea);
+        if (!copied) {
+          throw new Error("clipboard copy failed");
+        }
+      }
+
+      async function copyApprovalGrantIdToClipboard({ quiet = false } = {}) {
+        await copyText(latestApprovalGrantId);
+        if (!quiet) {
+          approveOutput.textContent = approveOutput.textContent + "\\n\\nCopied approvalGrantId to clipboard.";
+        }
+      }
+
+      copyApprovalGrantButton.addEventListener("click", async () => {
+        try {
+          await copyApprovalGrantIdToClipboard();
+        } catch (error) {
+          approveOutput.textContent = approveOutput.textContent + "\\n\\n" + String(error);
+        }
+      });
 
       document.getElementById("register-button").addEventListener("click", async () => {
         try {
@@ -325,6 +387,10 @@ export function renderPasskeyOperatorPage(input = {}) {
           }
           latestApprovalGrantId = verifyBody?.approvalGrant?.approvalId || "";
           approveOutput.textContent = JSON.stringify(verifyBody, null, 2);
+          if (latestApprovalGrantId && autoCopyApprovalGrantInput.checked) {
+            await copyApprovalGrantIdToClipboard({ quiet: true });
+            approveOutput.textContent = approveOutput.textContent + "\\n\\nCopied approvalGrantId to clipboard.";
+          }
         } catch (error) {
           approveOutput.textContent = String(error);
         }

--- a/test/passkey-operator-page.test.js
+++ b/test/passkey-operator-page.test.js
@@ -91,6 +91,53 @@ test("passkey operator page clipboard helper uses navigator clipboard when avail
   assert.equal(copied, "approval:test");
 });
 
+test("passkey operator page clipboard helper falls back to textarea copy", async () => {
+  let copied = false;
+  let textareaRemoved = false;
+  const textarea = {
+    value: "",
+    style: {},
+    setAttribute() {},
+    select() {
+      copied = this.value === "approval:fallback";
+    }
+  };
+  const helpers = loadOperatorPageHelpers({
+    navigator: {},
+    document: {
+      getElementById() {
+        return {
+          value: "",
+          textContent: "",
+          addEventListener() {}
+        };
+      },
+      createElement(tagName) {
+        assert.equal(tagName, "textarea");
+        return textarea;
+      },
+      execCommand(command) {
+        assert.equal(command, "copy");
+        return copied;
+      },
+      body: {
+        appendChild(element) {
+          assert.equal(element, textarea);
+        },
+        removeChild(element) {
+          assert.equal(element, textarea);
+          textareaRemoved = true;
+        }
+      }
+    }
+  });
+
+  await helpers.copyText("approval:fallback");
+
+  assert.equal(copied, true);
+  assert.equal(textareaRemoved, true);
+});
+
 function loadOperatorPageHelpers(overrides = {}) {
   const html = renderPasskeyOperatorPage();
   const script = html.match(/<script>([\s\S]*)<\/script>/)?.[1];

--- a/test/passkey-operator-page.test.js
+++ b/test/passkey-operator-page.test.js
@@ -24,6 +24,8 @@ test("passkey operator page can target explicit api base and sync endpoint", () 
   assert.equal(html.includes("Sync OPENAI_API_KEY"), true);
   assert.equal(html.includes("Dispatch production deploy"), true);
   assert.equal(html.includes("Butler 会話に貼らず"), true);
+  assert.equal(html.includes("Copy approvalGrantId"), true);
+  assert.equal(html.includes("Auto-copy approvalGrantId after approval"), true);
   assert.equal(html.includes('id="action-type-input" value="deploy_production"'), true);
   assert.equal(html.includes('repositoryInput: document.getElementById("repo-input").value'), true);
   assert.equal(html.includes('issueNumber: Number(document.getElementById("issue-input").value || 0) || null'), true);
@@ -72,7 +74,24 @@ test("passkey operator page response parser reports and redacts non-json failure
   assert.equal(validJson.ok, true);
 });
 
-function loadOperatorPageHelpers() {
+test("passkey operator page clipboard helper uses navigator clipboard when available", async () => {
+  let copied = "";
+  const helpers = loadOperatorPageHelpers({
+    navigator: {
+      clipboard: {
+        writeText: async (value) => {
+          copied = value;
+        }
+      }
+    }
+  });
+
+  await helpers.copyText("approval:test");
+
+  assert.equal(copied, "approval:test");
+});
+
+function loadOperatorPageHelpers(overrides = {}) {
   const html = renderPasskeyOperatorPage();
   const script = html.match(/<script>([\s\S]*)<\/script>/)?.[1];
   assert.ok(script);
@@ -80,6 +99,7 @@ function loadOperatorPageHelpers() {
   const elements = new Map();
   const context = {
     Response,
+    navigator: {},
     document: {
       getElementById(id) {
         if (!elements.has(id)) {
@@ -91,7 +111,8 @@ function loadOperatorPageHelpers() {
         }
         return elements.get(id);
       }
-    }
+    },
+    ...overrides
   };
   vm.runInNewContext(script, context);
   assert.equal(typeof context.readResponseBody, "function");


### PR DESCRIPTION
## This PR satisfies Intent

Improves the iPhone passkey operator handoff for Issue #4 by making the generated `approvalGrantId` easy to transfer back to Butler or this Codex thread without manual text selection.

## Satisfied Success Criteria

- Adds a `Copy approvalGrantId` button to the high-risk approval section.
- Adds an opt-in `Auto-copy approvalGrantId after approval` checkbox.
- Uses `navigator.clipboard.writeText` when available and falls back to a textarea copy path.
- Keeps auto-copy disabled by default so the page does not force clipboard mutation on users.

## Unsatisfied Success Criteria

- This PR does not implement automatic Butler callback/deep-link return.
- This PR does not add signed/nonce-bound operator intents.
- This PR does not change approval TTL or deploy run monitoring.

## Surface Update Checklist

- Cloudflare deploy: required after merge because Worker-rendered operator HTML changes.
- Custom GPT Action Schema: not required.
- Custom GPT Instructions: not required.
- Secret/credential mutation: not included.
- Deploy/passkey operation: not included in this PR.

## Verification Evidence

- `node --test test/passkey-operator-page.test.js test/worker.test.js`
- `npm test`
- `git diff --check`

## Security Note

The operator URL parameters remain prefill data, not authority. Copying the approval grant is a user-initiated clipboard operation by default; auto-copy is opt-in only. A future slice can add short-lived signed/nonce operator intents for stronger URL tamper resistance.

## Issue Traceability

- Parent issue: #4
- Scope: iPhone passkey operator approvalGrantId handoff UX
- Non-goals: automatic callback, nonce intents, deploy execution, secret mutation
