### PR TITLE
Show deploy run and Butler return links on operator page

### DIFF
--- a/src/core/passkey-operator-page.js
+++ b/src/core/passkey-operator-page.js
@@ -9,6 +9,7 @@ export function renderPasskeyOperatorPage(input = {}) {
   const phaseDefault = escapeHtml(input.phase || "execution");
   const actionTypeDefault = escapeHtml(input.actionType || "destructive");
   const highRiskKindDefault = escapeHtml(input.highRiskKind || "github_app_secret_sync");
+  const returnUrl = escapeHtml(input.returnUrl || "");
   const syncEnabled = input.syncEnabled === true;
   const syncMessage = escapeHtml(
     input.syncMessage ||
@@ -109,6 +110,19 @@ export function renderPasskeyOperatorPage(input = {}) {
         color: var(--accent);
         border: 1px solid #b8cec3;
       }
+      .button-link {
+        display: inline-flex;
+        align-items: center;
+        border-radius: 999px;
+        padding: 11px 16px;
+        background: #eef3ef;
+        color: var(--accent);
+        border: 1px solid #b8cec3;
+        text-decoration: none;
+      }
+      [hidden] {
+        display: none !important;
+      }
       pre {
         white-space: pre-wrap;
         word-break: break-word;
@@ -202,8 +216,10 @@ export function renderPasskeyOperatorPage(input = {}) {
           <p class="muted">deploy stale を検知したあと、取得済みの <code>approvalGrantId</code> を使って same-origin の governed deploy path を dispatch します。</p>
           <div class="row">
             <button id="deploy-button">Dispatch production deploy</button>
+            <a class="button-link" id="deploy-run-link" href="#" target="_blank" rel="noopener noreferrer" hidden>Open deploy run</a>
+            <a class="button-link" id="return-to-butler-link" href="${returnUrl}" rel="noopener noreferrer"${returnUrl ? "" : " hidden"}>Return to Butler</a>
           </div>
-          <p class="muted">この Worker origin を <code>runtimeUrl</code> として使います。実行後は Butler で self-parity を再確認してください。</p>
+          <p class="muted">この Worker origin を <code>runtimeUrl</code> として使います。実行後は deploy run link で完了状態を確認できます。</p>
           <pre id="deploy-output"></pre>
         </section>
 
@@ -229,6 +245,7 @@ export function renderPasskeyOperatorPage(input = {}) {
       const openaiSecretSyncOutput = document.getElementById("openai-secret-sync-output");
       const copyApprovalGrantButton = document.getElementById("copy-approval-grant-button");
       const autoCopyApprovalGrantInput = document.getElementById("auto-copy-approval-grant-input");
+      const deployRunLink = document.getElementById("deploy-run-link");
       let latestApprovalGrantId = "";
 
       async function readResponseBody(response) {
@@ -299,6 +316,46 @@ export function renderPasskeyOperatorPage(input = {}) {
         if (!quiet) {
           approveOutput.textContent = approveOutput.textContent + "\\n\\nCopied approvalGrantId to clipboard.";
         }
+      }
+
+      function extractDeployRunUrl(body) {
+        return body?.deploy?.runUrl || "";
+      }
+
+      function normalizeDeployRunUrl(value) {
+        const text = String(value || "");
+        if (!text) {
+          return "";
+        }
+        try {
+          const url = new URL(text);
+          if (url.protocol !== "https:" || url.hostname.toLowerCase() !== "github.com") {
+            return "";
+          }
+          if (!/\\/actions\\/runs\\/\\d+(?:$|[/?#])/.test(url.pathname + url.search + url.hash)) {
+            return "";
+          }
+          return url.href;
+        } catch {
+          return "";
+        }
+      }
+
+      function clearDeployRunLink() {
+        if (!deployRunLink) {
+          return;
+        }
+        deployRunLink.href = "#";
+        deployRunLink.hidden = true;
+      }
+
+      function showDeployRunLink(body) {
+        const runUrl = normalizeDeployRunUrl(extractDeployRunUrl(body));
+        if (!runUrl || !deployRunLink) {
+          return;
+        }
+        deployRunLink.href = runUrl;
+        deployRunLink.hidden = false;
       }
 
       copyApprovalGrantButton.addEventListener("click", async () => {
@@ -432,6 +489,7 @@ export function renderPasskeyOperatorPage(input = {}) {
           if (!latestApprovalGrantId) {
             throw new Error("approvalGrantId is required before production deploy");
           }
+          clearDeployRunLink();
           deployOutput.textContent = "production deploy request...";
           const deployResponse = await fetch("${apiBase}/action/deploy", {
             method: "POST",
@@ -449,6 +507,7 @@ export function renderPasskeyOperatorPage(input = {}) {
           if (!deployResponse.ok) {
             throw responseError(deployBody, "production deploy failed");
           }
+          showDeployRunLink(deployBody);
           deployOutput.textContent = JSON.stringify(deployBody, null, 2);
         } catch (error) {
           deployOutput.textContent = String(error);

--- a/src/worker.js
+++ b/src/worker.js
@@ -994,6 +994,7 @@ function handlePasskeyOperatorPageRequest(request) {
     phase: url.searchParams.get("phase") || "execution",
     actionType: url.searchParams.get("actionType") || "destructive",
     highRiskKind: url.searchParams.get("highRiskKind") || "github_app_secret_sync",
+    returnUrl: normalizeOperatorReturnUrl(url.searchParams.get("returnUrl")),
     operatorId: url.searchParams.get("operatorId") || "vtdd-operator",
     operatorLabel: url.searchParams.get("operatorLabel") || "VTDD Operator",
     syncEnabled,
@@ -1022,6 +1023,27 @@ function normalizeOptionalHttpUrl(value) {
       return "";
     }
     return url.href.replace(/\/$/, "");
+  } catch {
+    return "";
+  }
+}
+
+function normalizeOperatorReturnUrl(value) {
+  const text = normalizeText(value);
+  if (!text) {
+    return "";
+  }
+
+  try {
+    const url = new URL(text);
+    if (url.protocol !== "https:") {
+      return "";
+    }
+    const hostname = url.hostname.toLowerCase();
+    if (hostname !== "chatgpt.com" && hostname !== "chat.openai.com") {
+      return "";
+    }
+    return url.href;
   } catch {
     return "";
   }

--- a/test/passkey-operator-page.test.js
+++ b/test/passkey-operator-page.test.js
@@ -11,6 +11,7 @@ test("passkey operator page can target explicit api base and sync endpoint", () 
     repositoryInput: "marushu/vtdd-v2-p",
     issueNumber: 15,
     highRiskKind: "github_app_secret_sync",
+    returnUrl: "https://chatgpt.com/g/example-butler",
     syncEnabled: true
   });
 
@@ -23,6 +24,9 @@ test("passkey operator page can target explicit api base and sync endpoint", () 
   assert.equal(html.includes("Sync GitHub App secrets"), true);
   assert.equal(html.includes("Sync OPENAI_API_KEY"), true);
   assert.equal(html.includes("Dispatch production deploy"), true);
+  assert.equal(html.includes("Open deploy run"), true);
+  assert.equal(html.includes("Return to Butler"), true);
+  assert.equal(html.includes('href="https://chatgpt.com/g/example-butler"'), true);
   assert.equal(html.includes("Butler 会話に貼らず"), true);
   assert.equal(html.includes("Copy approvalGrantId"), true);
   assert.equal(html.includes("Auto-copy approvalGrantId after approval"), true);
@@ -138,6 +142,78 @@ test("passkey operator page clipboard helper falls back to textarea copy", async
   assert.equal(textareaRemoved, true);
 });
 
+test("passkey operator page exposes deploy run link from dispatch response", () => {
+  const deployRunLink = {
+    href: "#",
+    hidden: true
+  };
+  const helpers = loadOperatorPageHelpers({
+    document: {
+      getElementById(id) {
+        if (id === "deploy-run-link") {
+          return deployRunLink;
+        }
+        return {
+          value: "",
+          textContent: "",
+          addEventListener() {}
+        };
+      }
+    }
+  });
+
+  helpers.showDeployRunLink({
+    ok: true,
+    deploy: {
+      runUrl: "https://github.com/sample-org/vtdd-v2-p/actions/runs/123456"
+    }
+  });
+
+  assert.equal(deployRunLink.href, "https://github.com/sample-org/vtdd-v2-p/actions/runs/123456");
+  assert.equal(deployRunLink.hidden, false);
+
+  helpers.clearDeployRunLink();
+  assert.equal(deployRunLink.href, "#");
+  assert.equal(deployRunLink.hidden, true);
+});
+
+test("passkey operator page rejects unsafe or missing deploy run links", () => {
+  const deployRunLink = {
+    href: "#",
+    hidden: true
+  };
+  const helpers = loadOperatorPageHelpers({
+    document: {
+      getElementById(id) {
+        if (id === "deploy-run-link") {
+          return deployRunLink;
+        }
+        return {
+          value: "",
+          textContent: "",
+          addEventListener() {}
+        };
+      }
+    }
+  });
+
+  helpers.showDeployRunLink({
+    ok: true,
+    deploy: {
+      runUrl: "https://evil.example/actions/runs/123456"
+    }
+  });
+  assert.equal(deployRunLink.href, "#");
+  assert.equal(deployRunLink.hidden, true);
+
+  helpers.showDeployRunLink({
+    ok: true,
+    runUrl: "https://github.com/sample-org/vtdd-v2-p/actions/runs/123456"
+  });
+  assert.equal(deployRunLink.href, "#");
+  assert.equal(deployRunLink.hidden, true);
+});
+
 function loadOperatorPageHelpers(overrides = {}) {
   const html = renderPasskeyOperatorPage();
   const script = html.match(/<script>([\s\S]*)<\/script>/)?.[1];
@@ -146,6 +222,7 @@ function loadOperatorPageHelpers(overrides = {}) {
   const elements = new Map();
   const context = {
     Response,
+    URL,
     navigator: {},
     document: {
       getElementById(id) {

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -470,7 +470,7 @@ test("worker can resolve passkey memory provider from Cloudflare D1 binding fall
 test("worker serves passkey operator page", async () => {
   const response = await worker.fetch(
     new Request(
-      "https://example.com/v2/approval/passkey/operator?repositoryInput=marushu%2Fvtdd-v2-p&issueNumber=15&phase=execution&actionType=deploy_production&highRiskKind=deploy_production"
+      "https://example.com/v2/approval/passkey/operator?repositoryInput=marushu%2Fvtdd-v2-p&issueNumber=15&phase=execution&actionType=deploy_production&highRiskKind=deploy_production&returnUrl=https%3A%2F%2Fchatgpt.com%2Fg%2Fexample-butler"
     ),
     gatewayAuthEnv
   );
@@ -485,6 +485,22 @@ test("worker serves passkey operator page", async () => {
   assert.equal(html.includes('id="phase-input" value="execution"'), true);
   assert.equal(html.includes('id="action-type-input" value="deploy_production"'), true);
   assert.equal(html.includes('id="risk-kind-input" value="deploy_production"'), true);
+  assert.equal(html.includes('href="https://chatgpt.com/g/example-butler"'), true);
+  assert.equal(html.includes('href="https://evil.example/phish"'), false);
+});
+
+test("worker strips non-ChatGPT operator return urls", async () => {
+  const response = await worker.fetch(
+    new Request(
+      "https://example.com/v2/approval/passkey/operator?repositoryInput=marushu%2Fvtdd-v2-p&returnUrl=https%3A%2F%2Fevil.example%2Fphish"
+    ),
+    gatewayAuthEnv
+  );
+
+  assert.equal(response.status, 200);
+  const html = await response.text();
+  assert.equal(html.includes('href="https://evil.example/phish"'), false);
+  assert.equal(html.includes('id="return-to-butler-link" href=""'), true);
 });
 
 test("worker passkey operator page enables desktop secret sync bridge when syncApiBase is provided", async () => {


### PR DESCRIPTION
## This PR satisfies Intent

Issue #4 live E2E usability: make the iPhone-safe passkey operator deploy path less dependent on copying data back into Butler after approval.

## Satisfied Success Criteria

- [x] After passkey approval, the operator page can dispatch production deploy from the same screen.
- [x] After dispatch, the operator page exposes the GitHub Actions deploy run URL as a clickable link when the runtime response includes `deploy.runUrl`.
- [x] The operator page can render an optional `returnUrl` link for returning to Butler/ChatGPT without making that link part of the authority model.

## Unsatisfied Success Criteria

None.

## Non-goal violations

None.

## Verification Evidence

- Unit: `node --test test/passkey-operator-page.test.js`
- Integration: `npm test`
- E2E: Not executed live in Butler; this PR only updates the already-reachable operator page UI.
- Manual: Not executed.
- Evidence path/link: `test/passkey-operator-page.test.js` covers deploy run link rendering and optional return link rendering.

## Surface Update Checklist

- Cloudflare deploy: Required after merge because Worker-rendered operator HTML changes.
- Custom GPT Action Schema update: Not required; no API route/schema changed.
- Custom GPT Instructions update: Not required; existing deploy operator guidance remains valid.
- iPhone Butler live E2E: Required after deploy to confirm the operator page shows the run link on a real dispatch response.

## Related Constitution Rules

- Butler remains context-first; this does not bypass Butler for target resolution.
- High-risk deploy still requires GO + real passkey approval.
- The optional return link is navigation only, not authority.

## Out-of-scope but NOT implemented

- ChatGPT deep link injection into an existing Butler conversation.
- Nonce/signed intent URLs.
- Automatic deploy dispatch immediately after approval.
- Polling GitHub Actions run completion inside the operator page.

## Extra changes (if any)

None.