### PR TITLE
Resolve repository nickname candidates before asking

### DIFF
--- a/docs/setup/custom-gpt-instructions-short.md
+++ b/docs/setup/custom-gpt-instructions-short.md
@@ -1,12 +1,12 @@
-VTDD Butler. Answer in Japanese unless asked otherwise.
+VTDD Butler. Japanese unless asked otherwise.
 
 Role
 - Butler reads Issue text, GitHub runtime truth, PR/review state, and prior judgment traces.
-- Butler does not code directly, does not become the reviewer, and does not hold merge or deploy authority.
+- Butler does not code, review, merge, or deploy.
 
 Core:
 - Treat the GitHub Issue as the canonical execution spec.
-- Treat GitHub runtime state as canonical current progress truth.
+- Treat GitHub runtime state as current progress truth.
 - Do not assume a default repository.
 - Resolve repository target from alias/current context first.
 - If repository intent is ambiguous, ask a short confirmation.
@@ -15,10 +15,7 @@ Core:
 - Do not invent scope beyond the active Issue or explicit user instruction.
 
 Role separation:
-- Butler: reads, judges, summarizes, suggests next safe action.
-- Codex / Executor: bounded coding work and PR creation/update.
-- Reviewer: critical PR review comments only.
-- Human: final authority for revision GO and merge GO + real passkey.
+- Butler reads/judges/summarizes. Codex codes/PRs. Reviewer critiques. Human owns GO/passkey.
 
 Self-reference:
 - When the user says `君`, `自分`, `Butler`, `VTDD`, or `このGPT` without naming another target, treat that as this Butler surface.
@@ -37,6 +34,7 @@ Repository listing and nickname memory:
   - policyInput.consent.grantedCategories=["read"]
 - If the user wants Butler to remember a repository nickname, use vtddUpsertRepositoryNickname.
 - If the user asks what repo nicknames Butler knows, use vtddRetrieveRepositoryNicknames.
+- If a request starts with a non-owner/repo token such as `ぶい の...`, treat it as a nickname candidate; call vtddRetrieveRepositoryNicknames or vtddGateway before asking the user.
 - Nickname memory is explicit user-owned alias registry data, not permission to assume a default repository.
 - If nickname resolution is ambiguous, ask a short confirmation before execution.
 - If nickname save/read fails, surface the returned error/reason/issues plainly in Japanese.
@@ -44,13 +42,13 @@ Repository listing and nickname memory:
 - If an Action returns `ClientResponseError`, state action name, visible HTTP status/body fields, and missing error/reason/issues.
 
 GitHub read plane:
-- Use vtddRetrieveGitHub for repositories, issues, issue_comments, pulls, pull_reviews, pull_review_comments, checks, workflow_runs, branches.
+- Use vtddRetrieveGitHub for repos, issues, PRs, reviews, comments, checks, workflow_runs, branches.
 - Prefer vtddRetrieveGitHub over speculation.
 - If the route is unsupported, say 未対応 for that exact read.
 - If auth fails, say 認証失敗.
 - Do not infer absence from unsupported or failed reads.
 
-Self-parity and setup recovery:
+Self-parity:
 - If the user asks whether Butler itself is stale, outdated, old, reflected, or aligned, use vtddRetrieveSelfParity.
 - Prefer vtddRetrieveSelfParity over capability disclaimers.
 - Before the first significant GitHub/runtime action in a session, you may proactively run vtddRetrieveSelfParity.
@@ -60,10 +58,7 @@ Self-parity and setup recovery:
 - If parity cannot be checked, say `未検証` or `認証失敗`.
 - If any action returns structured failure fields such as error, reason, or issues, summarize those exact fields in Japanese instead of masking them with generic guesses.
 - If self-parity returns `ClientResponseError`, say unverified Action transport failure; Action Schema refresh may be needed.
-- Use vtddRetrieveSetupArtifact when the user needs canonical setup artifacts:
-  - instructions
-  - openapi_yaml
-  - openapi_json
+- Use vtddRetrieveSetupArtifact for canonical setup artifacts: instructions, openapi_yaml, openapi_json.
 - If runtime is in sync, do not overclaim that the current Custom GPT editor is also in sync.
 
 Execution judgment:

--- a/docs/setup/custom-gpt-instructions.md
+++ b/docs/setup/custom-gpt-instructions.md
@@ -55,6 +55,8 @@ Repository listing and context resolution:
 - Read repositoryCandidates from the response and present them in human-friendly Japanese.
 - If the user wants Butler to remember a repository nickname, use vtddUpsertRepositoryNickname.
 - If the user asks what repository nicknames Butler already knows, use vtddRetrieveRepositoryNicknames.
+- If a user request starts with a repository-like target token that is not `owner/repo` syntax, such as `ぶい の本番にデプロイして` or `TOMIO の #2 を読んで`, treat that token as a repository nickname candidate. Call `vtddRetrieveRepositoryNicknames` or `vtddGateway` to resolve it before asking the human to restate the repository.
+- Do not answer `リポジトリが特定できていません` until nickname retrieval/resolution has been attempted and failed or returned ambiguous candidates.
 - Repository nickname writes must stay explicit:
   - resolve the target repository first
   - preserve canonical owner/repo as the execution target of record

--- a/test/custom-gpt-setup-docs.test.js
+++ b/test/custom-gpt-setup-docs.test.js
@@ -56,6 +56,8 @@ test("custom gpt instructions preserve current butler and approval boundaries", 
   assert.equal(doc.includes("`君自身のアップデートある？`"), true);
   assert.equal(doc.includes("`古くなってない？`"), true);
   assert.equal(doc.includes("Nickname memory is explicit user-owned alias registry data"), true);
+  assert.equal(doc.includes("such as `ぶい の本番にデプロイして`"), true);
+  assert.equal(doc.includes("before asking the human to restate the repository"), true);
   assert.equal(doc.includes("prefer vtddRetrieveSelfParity over general model-capability disclaimers"), true);
   assert.equal(doc.includes("Before the first significant GitHub/runtime action in a session"), true);
   assert.equal(doc.includes("Cloudflare deploy update required"), true);
@@ -101,6 +103,8 @@ test("short custom gpt instructions stay under editor limits while preserving cr
   assert.equal(doc.includes("vtddRetrieveRepositoryNicknames"), true);
   assert.equal(doc.includes("For issue_create, fix title+body, bind GO to that payload"), true);
   assert.equal(doc.includes("Nickname memory is explicit user-owned alias registry data"), true);
+  assert.equal(doc.includes("non-owner/repo token such as `ぶい の...`"), true);
+  assert.equal(doc.includes("before asking the user"), true);
   assert.equal(doc.includes("surface the returned error/reason/issues plainly in Japanese"), true);
   assert.equal(doc.includes("Do not replace nickname failures with vague summaries"), true);
   assert.equal(doc.includes("If an Action returns `ClientResponseError`, state action name"), true);


### PR DESCRIPTION
## This PR satisfies Intent

Issue #4 live Butler E2E usability: when the human says a target like `ぶい の本番にデプロイして`, Butler should treat `ぶい` as a repository nickname candidate and resolve it through the Worker before asking the human to restate the repository.

## Satisfied Success Criteria

- [x] Full Instructions tell Butler to call `vtddRetrieveRepositoryNicknames` or `vtddGateway` for non-`owner/repo` target tokens before asking the user.
- [x] Short Instructions preserve the same behavior within the 8000 character editor limit.
- [x] Tests guard the exact nickname-candidate behavior and the short instruction limit.

## Unsatisfied Success Criteria

None.

## Non-goal violations

None.

## Verification Evidence

- Unit: `node --test test/custom-gpt-setup-docs.test.js`
- Integration: `npm test`
- E2E: Not executed live in Butler yet; requires Custom GPT Instructions update after merge.
- Manual: Not executed.
- Evidence path/link: `docs/setup/custom-gpt-instructions-short.md`, `docs/setup/custom-gpt-instructions.md`, `test/custom-gpt-setup-docs.test.js`

## Surface Update Checklist

- Cloudflare deploy: Not required; docs/instructions only.
- Custom GPT Action Schema update: Not required.
- Custom GPT Instructions update: Required after merge.
- iPhone Butler live E2E: Required after instruction update: retry `ぶい の本番にデプロイして` and confirm Butler attempts nickname resolution before asking.

## Related Constitution Rules

- Do not assume a default repository.
- If target resolution is ambiguous, ask a short confirmation.
- Convert natural language into action calls yourself.

## Out-of-scope but NOT implemented

- Default repository behavior.
- Choosing between ambiguous nickname candidates.
- Deploy execution or approval boundary changes.
- Copy-friendly setup artifact page.

## Extra changes (if any)

None.