### PR TITLE
Fix GitHub write fetch binding

### DIFF
--- a/src/core/github-write-plane.js
+++ b/src/core/github-write-plane.js
@@ -26,7 +26,7 @@ export async function executeGitHubWritePlane(input = {}) {
   const body = normalizeBody(input.body);
   const head = normalizeText(input.head) || branch;
   const env = input.env ?? {};
-  const fetchImpl = typeof env?.GITHUB_API_FETCH === "function" ? env.GITHUB_API_FETCH.bind(env) : fetch;
+  const fetchImpl = resolveGitHubWriteFetch(env);
   const apiBaseUrl = normalizeApiBaseUrl(env?.GITHUB_API_BASE_URL);
 
   const validation = validateGitHubWriteRequest({
@@ -409,6 +409,13 @@ function encodeURIComponentRepository(repository) {
     .split("/")
     .map((segment) => encodeURIComponent(segment))
     .join("/");
+}
+
+function resolveGitHubWriteFetch(env) {
+  if (typeof env?.GITHUB_API_FETCH === "function") {
+    return env.GITHUB_API_FETCH.bind(env);
+  }
+  return globalThis.fetch.bind(globalThis);
 }
 
 function buildGitHubWriteFetchExceptionDiagnostics({ operation, method, url, error }) {

--- a/test/github-write-plane.test.js
+++ b/test/github-write-plane.test.js
@@ -41,6 +41,47 @@ test("github write plane creates scoped issues with GO approval", async () => {
   });
 });
 
+test("github write plane binds global fetch for Worker-compatible writes", async () => {
+  const originalFetch = globalThis.fetch;
+  const calls = [];
+  globalThis.fetch = function fetchWithRequiredThis(url, init) {
+    assert.equal(this, globalThis);
+    calls.push({ url, init });
+    return Promise.resolve(
+      new Response(
+        JSON.stringify({
+          number: 108,
+          title: "test: bound fetch",
+          state: "open",
+          html_url: "https://github.com/sample-org/vtdd-v2-p/issues/108"
+        }),
+        { status: 201, headers: { "content-type": "application/json" } }
+      )
+    );
+  };
+
+  try {
+    const result = await executeGitHubWritePlane({
+      operation: GitHubWriteOperation.ISSUE_CREATE,
+      repository: "sample-org/vtdd-v2-p",
+      title: "test: bound fetch",
+      body: "Issue body fixed by approval scope.",
+      approvalPhrase: "GO",
+      targetConfirmed: true,
+      approvalScopeMatched: true,
+      env: {
+        GITHUB_APP_INSTALLATION_TOKEN: "ghs_write"
+      }
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.write.issueNumber, 108);
+    assert.equal(calls[0].url, "https://api.github.com/repos/sample-org/vtdd-v2-p/issues");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test("github write plane creates scoped issue comments with GO approval", async () => {
   const calls = [];
   const result = await executeGitHubWritePlane({


### PR DESCRIPTION
## This PR satisfies Intent

Fixes the live Issue #4 blocker where Butler `vtddWriteGitHub(issue_create)` reached the GitHub write plane but failed during fetch dispatch with `TypeError: Illegal invocation (incorrect this reference)`.

## Satisfied Success Criteria

- [x] GitHub normal write plane uses a Worker-compatible bound global fetch when no injected GitHub fetch is provided.
- [x] Existing injected `env.GITHUB_API_FETCH` behavior remains supported for tests/runtime overrides.
- [x] Regression coverage proves `issue_create` succeeds when global fetch requires the correct `this` binding.

## Unsatisfied Success Criteria

None.

## Non-goal violations

None.

## Verification Evidence

- Unit: `node --test test/github-write-plane.test.js test/worker.test.js` passed, 58 tests.
- Integration: `npm test` passed, 436 tests.
- E2E: Not yet run through live Butler until this PR is merged and deployed.
- Manual: None.
- Evidence path/link: `test/github-write-plane.test.js`

## Surface Update Checklist

- Cloudflare deploy: Required after merge because runtime code changed.
- Custom GPT Action Schema update: Not required.
- Custom GPT Instructions update: Not required.
- iPhone Butler live E2E: Required after deploy by retrying the same natural-language Issue creation flow.

## Related Constitution Rules

- Issue #4 remains the parent live E2E contract.
- GitHub runtime truth remains the source of current progress.
- Butler should not report write completion unless the worker write path actually succeeds.

## Out-of-scope but NOT implemented

- No deploy automation change.
- No credential mutation.
- No instruction/schema change.
- No Issue #4 completion claim.

## Extra changes (if any)

None.