### PR TITLE
Constrain Custom GPT judgment model

### DIFF
--- a/docs/setup/custom-gpt-actions-openapi.json
+++ b/docs/setup/custom-gpt-actions-openapi.json
@@ -88,7 +88,10 @@
                 "type": "string"
               },
               "judgmentModelId": {
-                "type": "string"
+                "type": "string",
+                "enum": [
+                  "vtdd-butler-core-v1"
+                ]
               }
             },
             "additionalProperties": true
@@ -222,7 +225,10 @@
                 "type": "string"
               },
               "judgmentModelId": {
-                "type": "string"
+                "type": "string",
+                "enum": [
+                  "vtdd-butler-core-v1"
+                ]
               }
             },
             "additionalProperties": true

--- a/docs/setup/custom-gpt-actions-openapi.yaml
+++ b/docs/setup/custom-gpt-actions-openapi.yaml
@@ -61,6 +61,8 @@ components:
               type: string
             judgmentModelId:
               type: string
+              enum:
+                - vtdd-butler-core-v1
           additionalProperties: true
         judgmentTrace:
           type: array
@@ -154,6 +156,8 @@ components:
               type: string
             judgmentModelId:
               type: string
+              enum:
+                - vtdd-butler-core-v1
           additionalProperties: true
         judgmentTrace:
           type: array

--- a/docs/setup/custom-gpt-instructions-short.md
+++ b/docs/setup/custom-gpt-instructions-short.md
@@ -13,6 +13,7 @@ Core:
 - Do not ask the user to type internal API paths or raw JSON unless explicitly debugging.
 - Convert natural language into action calls yourself.
 - Do not invent scope beyond the active Issue or explicit user instruction.
+- For vtddGateway/vtddExecute, use surface=custom_gpt and judgmentModelId=vtdd-butler-core-v1.
 
 Role separation:
 - Butler reads/judges/summarizes. Codex codes/PRs. Reviewer critiques. Human owns GO/passkey.

--- a/docs/setup/custom-gpt-instructions.md
+++ b/docs/setup/custom-gpt-instructions.md
@@ -28,6 +28,7 @@ Core operating rules:
 - Do not ask the user to type internal API paths such as /v2/... or raw JSON unless explicitly requested for debugging.
 - Convert natural language requests into action calls yourself.
 - Do not invent new scope beyond the active Issue or explicit user instruction.
+- When calling vtddGateway or vtddExecute, set surfaceContext.surface to `custom_gpt` and surfaceContext.judgmentModelId to `vtdd-butler-core-v1`. Do not use the ChatGPT runtime model name as the VTDD judgment model id.
 
 Role separation:
 - Butler: reads, judges, summarizes, and suggests the next safe action.

--- a/test/custom-gpt-setup-docs.test.js
+++ b/test/custom-gpt-setup-docs.test.js
@@ -109,6 +109,7 @@ test("short custom gpt instructions stay under editor limits while preserving cr
   assert.equal(doc.includes("Do not replace nickname failures with vague summaries"), true);
   assert.equal(doc.includes("If an Action returns `ClientResponseError`, state action name"), true);
   assert.equal(doc.includes("If self-parity returns `ClientResponseError`, say unverified Action transport failure"), true);
+  assert.equal(doc.includes("judgmentModelId=vtdd-butler-core-v1"), true);
   assert.equal(doc.includes("Cloudflare deploy update required"), true);
   assert.equal(doc.includes("Action Schema update required"), true);
   assert.equal(doc.includes("Instructions update required"), true);
@@ -152,6 +153,7 @@ test("custom gpt openapi doc exposes current gateway, execute, and progress rout
   assert.equal(doc.includes("- issue_create"), true);
   assert.equal(doc.includes("pullNumber"), true);
   assert.equal(doc.includes("workflow_runs"), true);
+  assert.equal(doc.includes("enum:\n                - vtdd-butler-core-v1"), true);
 });
 
 test("custom gpt openapi keeps components.schemas while avoiding nested field refs", () => {
@@ -193,6 +195,15 @@ test("custom gpt openapi json parses and exposes paths as an object", () => {
   assert.equal(typeof doc.paths["/v2/retrieve/setup-artifact"], "object");
   assert.equal(typeof doc.paths["/v2/retrieve/self-parity"], "object");
   assert.equal(typeof doc.paths["/v2/retrieve/approval-grant"], "object");
+  assert.deepEqual(
+    doc.components.schemas.VtddGatewayRequest.properties.surfaceContext.properties
+      .judgmentModelId.enum,
+    ["vtdd-butler-core-v1"]
+  );
+  assert.deepEqual(
+    doc.components.schemas.VtddExecuteRequest.properties.surfaceContext.properties.judgmentModelId.enum,
+    ["vtdd-butler-core-v1"]
+  );
   assert.deepEqual(doc.paths["/health"].get.security, []);
   assert.equal(typeof doc.components.schemas, "object");
   assert.equal(doc.components.securitySchemes.GatewayBearerAuth.scheme, "bearer");

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -208,6 +208,46 @@ test("worker gateway allows butler path when deterministic judgment order is sat
   assert.equal(body.repository, "sample-org/vtdd-v2");
 });
 
+test("worker gateway still blocks Custom GPT payloads with noncanonical judgment model ids", async () => {
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/gateway", {
+      method: "POST",
+      headers: gatewayAuthHeaders,
+      body: JSON.stringify({
+        phase: "execution",
+        actorRole: ActorRole.BUTLER,
+        surfaceContext: {
+          surface: "custom_gpt",
+          judgmentModelId: "gpt-5.5 thinking"
+        },
+        judgmentTrace: validButlerJudgmentTrace,
+        policyInput: {
+          actionType: ActionType.ISSUE_CREATE,
+          mode: TaskMode.EXECUTION,
+          repositoryInput: "vtdd",
+          aliasRegistry,
+          targetConfirmed: true,
+          constitutionConsulted: true,
+          runtimeTruth: { runtimeAvailable: true },
+          credential: { model: "github_app", tier: CredentialTier.EXECUTE },
+          consent: { grantedCategories: [ConsentCategory.PROPOSE] },
+          approvalPhrase: "GO issue create",
+          approvalScopeMatched: true,
+          issueTraceable: true,
+          go: true,
+          passkey: false
+        }
+      })
+    }),
+    gatewayAuthEnv
+  );
+
+  assert.equal(response.status, 422);
+  const body = await response.json();
+  assert.equal(body.allowed, false);
+  assert.equal(body.blockedByRule, "surface_must_not_override_judgment_model");
+});
+
 test("worker gateway returns PR revision loop guidance for Butler summaries", async () => {
   const response = await worker.fetch(
     new Request("https://example.com/v2/gateway", {


### PR DESCRIPTION
## This PR satisfies Intent

Fixes the Issue #125 / #4 live Butler handoff blocker where Custom GPT execution could send the ChatGPT runtime model name as `surfaceContext.judgmentModelId`, causing `surface_must_not_override_judgment_model` before Codex handoff.

The fix is intentionally schema/instructions-side: the Custom GPT Action Schema constrains `surfaceContext.judgmentModelId` to the VTDD Butler judgment contract (`vtdd-butler-core-v1`) for `vtddGateway` and `vtddExecute`, and the setup Instructions tell Butler not to use the ChatGPT runtime model name as the VTDD judgment model id.

This revision does not canonicalize or overwrite model ids inside the Worker gateway, so the core surface-independence guard remains intact for direct/runtime callers.

## Satisfied Success Criteria

- [x] Custom GPT setup artifacts now constrain gateway/execute `judgmentModelId` to `vtdd-butler-core-v1`.
- [x] Short Instructions remain under 8000 characters while preserving the critical boundary.
- [x] Full Instructions explicitly tell Butler to use the VTDD judgment contract id rather than the ChatGPT runtime model name.
- [x] Worker/core surface-independence enforcement remains unchanged.

## Unsatisfied Success Criteria

None.

## Non-goal violations

None.

## Verification Evidence

- Unit: `node --test test/custom-gpt-setup-docs.test.js test/worker.test.js test/surface-independence.test.js test/butler-orchestrator.test.js` passed, 67 tests.
- Integration: `npm test` passed, 436 tests.
- E2E: Not yet run through live Butler until this PR is merged and Custom GPT setup artifacts are updated.
- Manual: None.
- Evidence path/link: `docs/setup/custom-gpt-actions-openapi.yaml`, `docs/setup/custom-gpt-instructions-short.md`, `test/custom-gpt-setup-docs.test.js`

## Surface Update Checklist

- Cloudflare deploy: Not required; no runtime code changes.
- Custom GPT Action Schema update: Required after merge.
- Custom GPT Instructions update: Required after merge.
- iPhone Butler live E2E: Required after updating Custom GPT setup, by retrying the Issue #125 Codex handoff flow.

## Related Constitution Rules

- Issue #125 is the live validation slice under parent Issue #4.
- Surface independence remains enforced by the canonical Butler judgment contract.
- Butler users should not have to type internal policy/judgment payloads for normal operation.

## Out-of-scope but NOT implemented

- No Worker runtime canonicalization of user-supplied surfaceContext.
- No Codex handoff behavior change beyond Custom GPT setup artifact constraints.
- No deploy automation change.
- No credential mutation.
- No Issue #4 or #125 completion claim.

## Extra changes (if any)

None.