### PR TITLE
Fix Butler judgment trace instructions

### DIFF
--- a/docs/setup/custom-gpt-instructions-short.md
+++ b/docs/setup/custom-gpt-instructions-short.md
@@ -19,7 +19,7 @@ Role separation:
 - Butler reads/judges/summarizes. Codex codes/PRs. Reviewer critiques. Human owns GO/passkey.
 
 Self-reference:
-- When the user says `君`, `自分`, `Butler`, `VTDD`, or `このGPT` without naming another target, treat that as this Butler surface.
+- `君`/`自分`/`Butler`/`VTDD`/`このGPT` means this Butler surface unless another target is named.
 
 Repository listing and nickname memory:
 - For repository candidates/list, call vtddGateway in exploration mode.
@@ -35,7 +35,7 @@ Repository listing and nickname memory:
   - policyInput.consent.grantedCategories=["read"]
 - If the user wants Butler to remember a repository nickname, use vtddUpsertRepositoryNickname.
 - If the user asks what repo nicknames Butler knows, use vtddRetrieveRepositoryNicknames.
-- If a request starts with a non-owner/repo token such as `ぶい の...`, treat it as a nickname candidate; call vtddRetrieveRepositoryNicknames or vtddGateway before asking the user.
+- If request starts with non-owner/repo token like `ぶい の...`, treat it as nickname candidate; call nickname read/gateway before asking.
 - Nickname memory is explicit user-owned alias registry data, not permission to assume a default repository.
 - If nickname resolution is ambiguous, ask a short confirmation before execution.
 - If nickname save/read fails, surface the returned error/reason/issues plainly in Japanese.
@@ -55,7 +55,7 @@ Self-parity:
 - Before the first significant GitHub/runtime action in a session, you may proactively run vtddRetrieveSelfParity.
 - Use vtddRetrieveSelfParity with repository=<resolved repo> and ref=main unless another ref is intended.
 - If runtimeParity is `cloudflare_deploy_update_required`, say `Cloudflare deploy update required`.
-- If runtimeParity is `in_sync` but Butler still lacks expected features, say `Action Schema update required` and/or `Instructions update required`.
+- If in_sync but Butler lacks expected features, say `Action Schema update required` and/or `Instructions update required`.
 - If parity cannot be checked, say `未検証` or `認証失敗`.
 - If any action returns structured failure fields such as error, reason, or issues, summarize those exact fields in Japanese instead of masking them with generic guesses.
 - If self-parity returns `ClientResponseError`, say unverified Action transport failure; Action Schema refresh may be needed.
@@ -64,6 +64,7 @@ Self-parity:
 
 Execution judgment:
 - Before execution, read current runtime truth through vtddGateway.
+- judgmentTrace first four steps must be exactly: constitution, runtime_truth, issue_context, current_query. Put Issue reads/contract/GO details in rationale, not new step names.
 - If the target repository is unresolved, do not execute.
 - Read-only exploration may proceed without a resolved repository only when policy allows it.
 
@@ -96,8 +97,8 @@ Deploy plane:
   - resolved repository
   - explicit GO
   - real passkey approval grant scoped to deploy_production
-- If no deploy approval grant exists, show selfParity.deployOperatorMarkdownLink; fallback: `[Open deploy operator](<actual selfParity.deployOperatorUrl>)`; never only show `/v2/approval/passkey/operator...` or a bare long URL.
-- Stale fallback: selfParity.deployRecovery.operatorMarkdownLink or selfParity.deployRecovery.operatorUrl. Href needs phase=execution, actionType=deploy_production, highRiskKind=deploy_production.
+- If no deploy approval grant exists, show selfParity.deployOperatorMarkdownLink; fallback: `[Open deploy operator](<actual selfParity.deployOperatorUrl>)`; never a raw `/v2/approval/passkey/operator...` or bare URL.
+- Stale fallback: selfParity.deployRecovery.operatorMarkdownLink or operatorUrl. Href needs phase=execution, actionType=deploy_production, highRiskKind=deploy_production.
 - If deploy URL is requested while in_sync, show selfParity.deployOperatorMarkdownLink; fallback: Markdown link with selfParity.deployOperatorUrl as href. Do not block because deployRecovery is null.
 - After vtddDeployProduction, say deploy dispatched, then re-check self-parity before claiming runtime updated.
 - If vtddDeployProduction fails, say the exact deploy error/reason/issues and blocker category.

--- a/docs/setup/custom-gpt-instructions.md
+++ b/docs/setup/custom-gpt-instructions.md
@@ -162,6 +162,12 @@ Execution judgment:
 - If the target repository is unresolved, do not execute.
 - If the request is read-only exploration, you may proceed without a resolved repository when the policy response allows it.
 - If the request is execution, preserve Constitution-first and Issue-as-spec judgment order.
+- For vtddGateway and vtddExecute execution judgments, the first four judgmentTrace steps must be exactly:
+  1. constitution
+  2. runtime_truth
+  3. issue_context
+  4. current_query
+- Do not invent step names such as `issue_retrieval`, `bounded_contract`, or `go_check`; record those details in the rationale/status fields of the required steps instead.
 
 Remote Codex flow:
 - Use vtddExecute only when Butler is intentionally handing bounded work to remote Codex.

--- a/test/custom-gpt-setup-docs.test.js
+++ b/test/custom-gpt-setup-docs.test.js
@@ -52,6 +52,13 @@ test("custom gpt instructions preserve current butler and approval boundaries", 
   assert.equal(doc.includes("vtddRetrieveSelfParity"), true);
   assert.equal(doc.includes("operation=`issue_create`"), true);
   assert.equal(doc.includes("Do not ask the user to author internal `policyInput`, `judgmentTrace`, or"), true);
+  assert.equal(doc.includes("Do not invent step names such as `issue_retrieval`"), true);
+  assert.equal(
+    doc.includes(
+      "the first four judgmentTrace steps must be exactly:\n  1. constitution\n  2. runtime_truth\n  3. issue_context\n  4. current_query"
+    ),
+    true
+  );
   assert.equal(doc.includes("when the user says `君`, `自分`, `Butler`, `VTDD`, or `このGPT`"), true);
   assert.equal(doc.includes("`君自身のアップデートある？`"), true);
   assert.equal(doc.includes("`古くなってない？`"), true);
@@ -103,21 +110,25 @@ test("short custom gpt instructions stay under editor limits while preserving cr
   assert.equal(doc.includes("vtddRetrieveRepositoryNicknames"), true);
   assert.equal(doc.includes("For issue_create, fix title+body, bind GO to that payload"), true);
   assert.equal(doc.includes("Nickname memory is explicit user-owned alias registry data"), true);
-  assert.equal(doc.includes("non-owner/repo token such as `ぶい の...`"), true);
-  assert.equal(doc.includes("before asking the user"), true);
+  assert.equal(doc.includes("non-owner/repo token like `ぶい の...`"), true);
+  assert.equal(doc.includes("call nickname read/gateway before asking"), true);
   assert.equal(doc.includes("surface the returned error/reason/issues plainly in Japanese"), true);
   assert.equal(doc.includes("Do not replace nickname failures with vague summaries"), true);
   assert.equal(doc.includes("If an Action returns `ClientResponseError`, state action name"), true);
   assert.equal(doc.includes("If self-parity returns `ClientResponseError`, say unverified Action transport failure"), true);
   assert.equal(doc.includes("judgmentModelId=vtdd-butler-core-v1"), true);
+  assert.equal(
+    doc.includes("judgmentTrace first four steps must be exactly: constitution, runtime_truth, issue_context, current_query"),
+    true
+  );
   assert.equal(doc.includes("Cloudflare deploy update required"), true);
   assert.equal(doc.includes("Action Schema update required"), true);
   assert.equal(doc.includes("Instructions update required"), true);
-  assert.equal(doc.includes("selfParity.deployRecovery.operatorUrl"), true);
+  assert.equal(doc.includes("selfParity.deployRecovery.operatorMarkdownLink or operatorUrl"), true);
   assert.equal(doc.includes("selfParity.deployOperatorMarkdownLink"), true);
   assert.equal(doc.includes("<actual selfParity.deployOperatorUrl>"), true);
-  assert.equal(doc.includes("never only show `/v2/approval/passkey/operator...`"), true);
-  assert.equal(doc.includes("bare long URL"), true);
+  assert.equal(doc.includes("never a raw `/v2/approval/passkey/operator...`"), true);
+  assert.equal(doc.includes("bare URL"), true);
   assert.equal(doc.includes("phase=execution"), true);
   assert.equal(doc.includes("GO + real passkey"), true);
   assert.equal(doc.includes("openai_api_key_not_configured"), true);


### PR DESCRIPTION
## This PR satisfies Intent

Addresses Issue #125 / parent #4 live Butler handoff blocker where Butler constructed judgmentTrace with ad-hoc step names such as `issue_retrieval`, `bounded_contract`, and `go_check`, causing `butler_invalid_judgment_order` before `vtddExecute`.

The setup Instructions now explicitly state that execution judgment traces must start with the canonical four steps: `constitution`, `runtime_truth`, `issue_context`, `current_query`. Details such as Issue reads, bounded contract, and GO checks must go into rationale/status fields, not new step names.

## Satisfied Success Criteria

- [x] Short Instructions document the exact required judgmentTrace first four steps.
- [x] Full Instructions document the exact order and forbidden ad-hoc step names.
- [x] Short Instructions remain under the Custom GPT editor limit.
- [x] Tests preserve the instruction requirements.

## Unsatisfied Success Criteria

None.

## Non-goal violations

None.

## Verification Evidence

- Unit: `node --test test/custom-gpt-setup-docs.test.js` passed, 8 tests.
- Integration: `npm test` passed, 437 tests.
- E2E: Not yet run through live Butler until this PR is merged and Instructions are updated.
- Manual: None.
- Evidence path/link: `docs/setup/custom-gpt-instructions-short.md`, `docs/setup/custom-gpt-instructions.md`, `test/custom-gpt-setup-docs.test.js`

## Surface Update Checklist

- Cloudflare deploy: Not required; no runtime code changes.
- Custom GPT Action Schema update: Not required.
- Custom GPT Instructions update: Required after merge.
- iPhone Butler live E2E: Required after updating Instructions by retrying the Issue #125 Codex handoff flow.

## Related Constitution Rules

- Issue #125 is the live validation slice under parent Issue #4.
- Butler must preserve constitution-first judgment order.
- Butler users should not have to type internal judgmentTrace payloads for normal operation.

## Out-of-scope but NOT implemented

- No Worker runtime policy change.
- No Action Schema change.
- No deploy automation change.
- No credential mutation.
- No Issue #4 or #125 completion claim.

## Extra changes (if any)

None.