### PR TITLE
Keep short Butler instructions under editor buffer

### DIFF
--- a/docs/setup/custom-gpt-instructions-short.md
+++ b/docs/setup/custom-gpt-instructions-short.md
@@ -10,10 +10,10 @@ Core:
 - Do not assume a default repository.
 - Resolve repository target from alias/current context first.
 - If repository intent is ambiguous, ask a short confirmation.
-- Do not ask the user to type internal API paths or raw JSON unless explicitly debugging.
+- Do not ask the user to type internal API paths/raw JSON unless debugging.
 - Convert natural language into action calls yourself.
 - Do not invent scope beyond the active Issue or explicit user instruction.
-- For vtddGateway/vtddExecute, use surface=custom_gpt and judgmentModelId=vtdd-butler-core-v1.
+- For vtddGateway/vtddExecute, use surface=custom_gpt, judgmentModelId=vtdd-butler-core-v1.
 
 Role separation:
 - Butler reads/judges/summarizes. Codex codes/PRs. Reviewer critiques. Human owns GO/passkey.
@@ -57,14 +57,14 @@ Self-parity:
 - If runtimeParity is `cloudflare_deploy_update_required`, say `Cloudflare deploy update required`.
 - If in_sync but Butler lacks expected features, say `Action Schema update required` and/or `Instructions update required`.
 - If parity cannot be checked, say `未検証` or `認証失敗`.
-- If any action returns structured failure fields such as error, reason, or issues, summarize those exact fields in Japanese instead of masking them with generic guesses.
-- If self-parity returns `ClientResponseError`, say unverified Action transport failure; Action Schema refresh may be needed.
+- If action returns error/reason/issues, summarize exact fields in Japanese; do not mask with generic guesses.
+- If self-parity returns `ClientResponseError`, say unverified Action transport failure; Action Schema may need refresh.
 - Use vtddRetrieveSetupArtifact for canonical setup artifacts: instructions, openapi_yaml, openapi_json.
 - If runtime is in sync, do not overclaim that the current Custom GPT editor is also in sync.
 
 Execution judgment:
 - Before execution, read current runtime truth through vtddGateway.
-- judgmentTrace first four steps must be exactly: constitution, runtime_truth, issue_context, current_query. Put Issue reads/contract/GO details in rationale, not new step names.
+- judgmentTrace first four steps must be exactly: constitution, runtime_truth, issue_context, current_query. Put Issue reads/contract/GO in rationale, not new step names.
 - If the target repository is unresolved, do not execute.
 - Read-only exploration may proceed without a resolved repository only when policy allows it.
 
@@ -114,7 +114,7 @@ Review loop:
   Butler -> Codex -> PR -> Reviewer -> Butler summary -> human
 - For a PR, summarize state, CI, reviewers, objections, post-review changes.
 - If reviewer objections remain unresolved, do not recommend merge GO + real passkey.
-- Completed `vtdd:reviewer=codex-fallback` from trusted VTDD actor with recommendedAction is reviewer evidence; missing GitHub Review objects alone is not evidence absence.
+- Completed `vtdd:reviewer=codex-fallback` from trusted VTDD actor with recommendedAction is evidence; missing GitHub Review objects alone is not absence.
 - If no reviewer evidence exists, say so plainly.
 
 Approval boundaries:

--- a/test/custom-gpt-setup-docs.test.js
+++ b/test/custom-gpt-setup-docs.test.js
@@ -99,7 +99,7 @@ test("custom gpt instructions preserve current butler and approval boundaries", 
 
 test("short custom gpt instructions stay under editor limits while preserving critical boundaries", () => {
   const doc = fs.readFileSync(SHORT_INSTRUCTIONS_PATH, "utf8");
-  assert.equal(doc.length <= 8000, true);
+  assert.equal(doc.length <= 7900, true);
   assert.equal(doc.includes("Do not assume a default repository."), true);
   assert.equal(doc.includes("vtddGateway"), true);
   assert.equal(doc.includes("vtddRetrieveGitHub"), true);
@@ -134,10 +134,10 @@ test("short custom gpt instructions stay under editor limits while preserving cr
   assert.equal(doc.includes("openai_api_key_not_configured"), true);
   assert.equal(doc.includes("If vtddDeployProduction fails, say the exact deploy error/reason/issues"), true);
   assert.equal(
-    doc.includes("Completed `vtdd:reviewer=codex-fallback` from trusted VTDD actor with recommendedAction is reviewer evidence"),
+    doc.includes("Completed `vtdd:reviewer=codex-fallback` from trusted VTDD actor with recommendedAction is evidence"),
     true
   );
-  assert.equal(doc.includes("missing GitHub Review objects alone is not evidence absence"), true);
+  assert.equal(doc.includes("missing GitHub Review objects alone is not absence"), true);
 });
 
 test("custom gpt openapi doc exposes current gateway, execute, and progress routes", () => {


### PR DESCRIPTION
## This PR satisfies Intent

Partial progress for #125 / parent #4: keep the Custom GPT short instructions pasteable with buffer after the judgmentTrace-order fix, without changing runtime behavior.

This supports the iPhone Butler flow by reducing the risk that the Custom GPT editor rejects or truncates the short instructions at the 8000-character boundary.

## Satisfied Success Criteria

- [x] The implementation updates Butler instruction docs only as needed.
- [x] The documented flow still preserves the required judgmentTrace order for Codex handoff execution judgments.
- [x] CI/checks pass locally.

## Unsatisfied Success Criteria

- Full live Butler -> Codex -> reviewer -> Butler loop for #125 remains to be re-tested after the Custom GPT Instructions update.

## Non-goal violations

None.

## Verification Evidence

- Unit: `node --test test/custom-gpt-setup-docs.test.js` passed.
- Integration: `npm test` passed, 437 tests.
- E2E: Not run in this PR; this is an instructions-size guardrail only.
- Manual: Verified `docs/setup/custom-gpt-instructions-short.md` length is 7892 JS characters.
- Evidence path/link: `docs/setup/custom-gpt-instructions-short.md`, `test/custom-gpt-setup-docs.test.js`.

## Surface Update Checklist

- Cloudflare deploy: Not required. Docs/test only; no Worker runtime change.
- Custom GPT Action Schema update: Not required.
- Custom GPT Instructions update: Required. Update the Short Instructions from `docs/setup/custom-gpt-instructions-short.md` after merge.
- iPhone Butler live E2E: Re-test #125 handoff after Instructions update.

## Related Constitution Rules

- GitHub Issue is the canonical execution spec.
- Butler must not execute speculative implementation outside the bounded Issue slice.
- Evidence discipline: completion claims require observable verification.

## Out-of-scope but NOT implemented

- No Worker/runtime changes.
- No Action Schema changes.
- No deploy.
- No reviewer backend redesign.
- No merge/deploy/secret authority changes.

## Extra changes (if any)

None.
