### PR TITLE
Fix nickname fallback visibility for Butler

### DIFF
--- a/docs/setup/custom-gpt-instructions-short.md
+++ b/docs/setup/custom-gpt-instructions-short.md
@@ -1,8 +1,7 @@
 VTDD Butler. Japanese unless asked otherwise.
 
 Role
-- Butler reads Issue text, GitHub runtime truth, PR/review state, and prior judgment traces.
-- Butler does not code, review, merge, or deploy.
+- Butler reads Issues/runtime/PR/reviews/traces; Butler does not code, review, merge, or deploy.
 
 Core:
 - Treat the GitHub Issue as the canonical execution spec.
@@ -23,23 +22,13 @@ Self-reference:
 
 Repository listing and nickname memory:
 - For repository candidates/list, call vtddGateway in exploration mode.
-- Use:
-  - phase=exploration
-  - actorRole=butler
-  - policyInput.actionType=read
-  - policyInput.mode=read_only
-  - policyInput.repositoryInput=unknown
-  - policyInput.targetConfirmed=false
-  - policyInput.runtimeTruth.runtimeAvailable=false
-  - policyInput.runtimeTruth.safeFallbackChosen=true
-  - policyInput.consent.grantedCategories=["read"]
+- Use exploration/read/read_only, repositoryInput=unknown, targetConfirmed=false, runtimeAvailable=false, safeFallbackChosen=true, consent=["read"].
 - To remember a repo nickname, use vtddUpsertRepositoryNickname.
 - To list repo nicknames, use vtddRetrieveRepositoryNicknames.
 - If request starts with non-owner/repo token like `ぶい の...`, treat it as nickname candidate; call nickname read/gateway before asking.
-- Nickname memory is user-owned alias data, not permission to assume a default repo.
-- If nickname resolution is ambiguous, ask before execution.
-- If nickname save/read fails, surface the returned error/reason/issues plainly in Japanese.
-- Do not replace nickname failures with vague summaries like `認証または接続系の可能性`.
+- Nickname memory is user-owned alias data, not a default repo; if ambiguous, ask.
+- Nickname read failure is not proof of unknown repo. If conversation has a known mapping or approvalGrant.scope.repositoryInput, use that owner/repo as unverified fallback and verify by next read/action.
+- If nickname save/read fails, surface error/reason/issues; do not replace with vague guesses.
 - If Action returns `ClientResponseError`, state action, visible HTTP/body, and missing error/reason/issues.
 
 GitHub read plane:
@@ -98,6 +87,7 @@ Deploy plane:
   - resolved repository
   - explicit GO
   - real passkey approval grant scoped to deploy_production
+- If pasted approval JSON has approvalGrant.scope.repositoryInput, use that owner/repo as deploy target candidate; deploy route validates scope.
 - If no deploy approval grant exists, show selfParity.deployOperatorMarkdownLink; fallback: `[Open deploy operator](<actual selfParity.deployOperatorUrl>)`; never a raw `/v2/approval/passkey/operator...` or bare URL.
 - Stale fallback: selfParity.deployRecovery.operatorMarkdownLink or operatorUrl. Href needs phase=execution, actionType=deploy_production, highRiskKind=deploy_production.
 - If deploy URL is requested while in_sync, show selfParity.deployOperatorMarkdownLink; fallback: Markdown link with selfParity.deployOperatorUrl as href. Do not block because deployRecovery is null.

--- a/docs/setup/custom-gpt-instructions.md
+++ b/docs/setup/custom-gpt-instructions.md
@@ -58,6 +58,7 @@ Repository listing and context resolution:
 - If the user asks what repository nicknames Butler already knows, use vtddRetrieveRepositoryNicknames.
 - If a user request starts with a repository-like target token that is not `owner/repo` syntax, such as `ぶい の本番にデプロイして` or `TOMIO の #2 を読んで`, treat that token as a repository nickname candidate. Call `vtddRetrieveRepositoryNicknames` or `vtddGateway` to resolve it before asking the human to restate the repository.
 - Do not answer `リポジトリが特定できていません` until nickname retrieval/resolution has been attempted and failed or returned ambiguous candidates.
+- A nickname retrieval failure is not proof that the nickname is unknown. If the current conversation already contains a remembered mapping or a passkey approval JSON contains `approvalGrant.scope.repositoryInput`, use that `owner/repo` as an unverified fallback candidate, say the nickname registry read is unverified, and continue to the next validation/action that can verify the target.
 - Repository nickname writes must stay explicit:
   - resolve the target repository first
   - preserve canonical owner/repo as the execution target of record
@@ -100,6 +101,8 @@ Repository nickname memory:
   - `この GPT が覚えている repo の呼び名は？`
 - Nickname memory is explicit user-owned alias registry data, not permission to assume a default repository.
 - If nickname resolution is ambiguous, say so plainly and ask a short confirmation before execution.
+- If nickname read fails, do not downgrade an already-known conversation mapping like `ぶい = marushu/vtdd-v2-p` to unknown. Treat it as an unverified fallback candidate and seek runtime verification through the next relevant read/action.
+- If a pasted approval grant includes `approvalGrant.scope.repositoryInput`, that scope can identify the deploy target candidate; pass the canonical `owner/repo` to the deploy action and let the approval/deploy route validate scope match.
 - If nickname save/read fails, surface the returned `error`, `reason`, and `issues` plainly in Japanese.
 - Do not collapse nickname failures into vague guesses such as `認証または接続系の可能性` when the runtime returned a more specific reason.
 - If the Action surface reports `ClientResponseError`, do not treat that label as the complete cause. State the action name, HTTP status if visible, any visible response body fields, and explicitly say which of `error`, `reason`, or `issues` were not returned to Butler.

--- a/src/worker.js
+++ b/src/worker.js
@@ -707,12 +707,17 @@ async function handleRetrieveButlerSelfParityRequest(url, env) {
 
 async function handleRetrieveRepositoryNicknamesRequest(env) {
   const provider = resolveMemoryProvider(env);
-  const retrieved = await retrieveStoredAliasRegistry(provider);
+  const retrieved = await safeRetrieveStoredAliasRegistry(provider);
   if (!retrieved.ok) {
-    return json(retrieved.status ?? 503, {
+    return json(200, {
       ok: false,
+      httpStatus: retrieved.status ?? 503,
       error: retrieved.error,
-      reason: retrieved.reason
+      reason: retrieved.reason,
+      issues: retrieved.issues ?? [],
+      recordType: MemoryRecordType.ALIAS_REGISTRY,
+      recordCount: 0,
+      aliasRegistry: []
     });
   }
 
@@ -722,6 +727,20 @@ async function handleRetrieveRepositoryNicknamesRequest(env) {
     recordCount: retrieved.aliasRegistry.length,
     aliasRegistry: retrieved.aliasRegistry
   });
+}
+
+async function safeRetrieveStoredAliasRegistry(provider) {
+  try {
+    return await retrieveStoredAliasRegistry(provider);
+  } catch (error) {
+    return {
+      ok: false,
+      status: 503,
+      error: "repository_nickname_retrieval_failed",
+      reason: error instanceof Error ? error.message : String(error),
+      issues: ["repository_nickname_retrieval_exception"]
+    };
+  }
 }
 
 async function handleGitHubWritePlaneRequest(request, env) {
@@ -1067,10 +1086,11 @@ async function prepareGatewayPayload({ payload, env }) {
       ? AutonomyMode.GUARDED_ABSENCE
       : requestedAutonomyMode;
 
-  const combinedAliasRegistry = await resolveRuntimeAliasRegistry({
+  const runtimeAliasResolution = await resolveRuntimeAliasRegistry({
     baseAliasRegistry: basePolicyInput.aliasRegistry,
     env
   });
+  const combinedAliasRegistry = runtimeAliasResolution.aliasRegistry;
   const resolvedAliasRegistry = await resolveGatewayAliasRegistryFromGitHubApp({
     policyInput: {
       ...basePolicyInput,
@@ -1078,7 +1098,10 @@ async function prepareGatewayPayload({ payload, env }) {
     },
     env
   });
-  const warnings = [...(resolvedAliasRegistry.warnings ?? [])];
+  const warnings = [
+    ...(runtimeAliasResolution.warnings ?? []),
+    ...(resolvedAliasRegistry.warnings ?? [])
+  ];
   if (
     runtimeAutonomyMode === AutonomyMode.GUARDED_ABSENCE &&
     requestedAutonomyMode !== AutonomyMode.GUARDED_ABSENCE
@@ -1115,23 +1138,37 @@ async function prepareGatewayPayload({ payload, env }) {
 
 async function resolveRuntimeAliasRegistry({ baseAliasRegistry, env }) {
   const provider = resolveMemoryProvider(env);
-  const stored = await retrieveStoredAliasRegistry(provider);
-  return mergeAliasRegistries(
-    baseAliasRegistry,
-    stored.ok ? stored.aliasRegistry : []
-  );
+  const stored = await safeRetrieveStoredAliasRegistry(provider);
+  const aliasRegistry = mergeAliasRegistries(baseAliasRegistry, stored.ok ? stored.aliasRegistry : []);
+  if (stored.ok) {
+    return { aliasRegistry, warnings: [] };
+  }
+
+  return {
+    aliasRegistry,
+    warnings: [
+      [
+        "repository nickname registry read unverified",
+        stored.error,
+        stored.reason
+      ]
+        .map(normalizeText)
+        .filter(Boolean)
+        .join(": ")
+    ]
+  };
 }
 
 async function handleRepositoryNicknameUpsertRequest(request, env) {
   const provider = resolveMemoryProvider(env);
   const body = await readJson(request);
-  const runtimeAliasRegistry = await resolveRuntimeAliasRegistry({
+  const runtimeAliasResolution = await resolveRuntimeAliasRegistry({
     baseAliasRegistry: [],
     env
   });
   const resolvedAliasRegistry = await resolveGatewayAliasRegistryFromGitHubApp({
     policyInput: {
-      aliasRegistry: runtimeAliasRegistry
+      aliasRegistry: runtimeAliasResolution.aliasRegistry
     },
     env
   });
@@ -1160,8 +1197,10 @@ async function handleRepositoryNicknameUpsertRequest(request, env) {
   });
 
   if (!result.ok) {
-    return json(result.status ?? 422, {
+    const status = result.status ?? 422;
+    return json(status >= 500 ? 200 : status, {
       ok: false,
+      httpStatus: status,
       error: result.error,
       reason: result.reason,
       issues: result.issues ?? []

--- a/test/custom-gpt-setup-docs.test.js
+++ b/test/custom-gpt-setup-docs.test.js
@@ -68,6 +68,9 @@ test("custom gpt instructions preserve current butler and approval boundaries", 
   assert.equal(doc.includes("Nickname memory is explicit user-owned alias registry data"), true);
   assert.equal(doc.includes("such as `ぶい の本番にデプロイして`"), true);
   assert.equal(doc.includes("before asking the human to restate the repository"), true);
+  assert.equal(doc.includes("A nickname retrieval failure is not proof that the nickname is unknown"), true);
+  assert.equal(doc.includes("approvalGrant.scope.repositoryInput"), true);
+  assert.equal(doc.includes("unverified fallback candidate"), true);
   assert.equal(doc.includes("prefer vtddRetrieveSelfParity over general model-capability disclaimers"), true);
   assert.equal(doc.includes("Before the first significant GitHub/runtime action in a session"), true);
   assert.equal(doc.includes("Cloudflare deploy update required"), true);
@@ -115,8 +118,11 @@ test("short custom gpt instructions stay under editor limits while preserving cr
   assert.equal(doc.includes("Nickname memory is user-owned alias data"), true);
   assert.equal(doc.includes("non-owner/repo token like `ぶい の...`"), true);
   assert.equal(doc.includes("call nickname read/gateway before asking"), true);
-  assert.equal(doc.includes("surface the returned error/reason/issues plainly in Japanese"), true);
-  assert.equal(doc.includes("Do not replace nickname failures with vague summaries"), true);
+  assert.equal(doc.includes("Nickname read failure is not proof of unknown repo"), true);
+  assert.equal(doc.includes("approvalGrant.scope.repositoryInput"), true);
+  assert.equal(doc.includes("unverified fallback"), true);
+  assert.equal(doc.includes("surface error/reason/issues"), true);
+  assert.equal(doc.includes("do not replace with vague guesses"), true);
   assert.equal(doc.includes("If Action returns `ClientResponseError`, state action"), true);
   assert.equal(doc.includes("If self-parity returns `ClientResponseError`, say unverified Action transport failure"), true);
   assert.equal(doc.includes("judgmentModelId=vtdd-butler-core-v1"), true);

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -1062,6 +1062,45 @@ test("worker stores and retrieves repository nicknames", async () => {
   assert.deepEqual(retrieveBody.aliasRegistry[0].aliases, ["公開VTDD"]);
 });
 
+test("worker surfaces repository nickname retrieval failures as action-visible JSON", async () => {
+  const failingProvider = {
+    async store() {
+      return { ok: true };
+    },
+    async retrieve(filter) {
+      if (filter?.type === MemoryRecordType.ALIAS_REGISTRY) {
+        throw new TypeError("Illegal invocation (incorrect this reference)");
+      }
+      return [];
+    },
+    async query() {
+      return [];
+    },
+    async validateRecord() {
+      return { ok: true };
+    }
+  };
+
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/retrieve/repository-nicknames", {
+      headers: gatewayAuthHeaders
+    }),
+    {
+      ...gatewayAuthEnv,
+      MEMORY_PROVIDER: failingProvider
+    }
+  );
+
+  assert.equal(response.status, 200);
+  const body = await response.json();
+  assert.equal(body.ok, false);
+  assert.equal(body.httpStatus, 503);
+  assert.equal(body.error, "repository_nickname_retrieval_failed");
+  assert.equal(body.reason, "Illegal invocation (incorrect this reference)");
+  assert.deepEqual(body.issues, ["repository_nickname_retrieval_exception"]);
+  assert.deepEqual(body.aliasRegistry, []);
+});
+
 test("worker gateway can resolve stored repository nickname against live repository index", async () => {
   const provider = createInMemoryMemoryProvider();
   await provider.store({
@@ -1128,6 +1167,73 @@ test("worker gateway can resolve stored repository nickname against live reposit
   const body = await response.json();
   assert.equal(body.allowed, true);
   assert.equal(body.repository, "sample-org/vtdd-v2-p");
+});
+
+test("worker gateway warns when runtime nickname registry read is unverified", async () => {
+  const failingProvider = {
+    async store() {
+      return { ok: true };
+    },
+    async retrieve(filter) {
+      if (filter?.type === MemoryRecordType.ALIAS_REGISTRY) {
+        throw new TypeError("Illegal invocation (incorrect this reference)");
+      }
+      return [];
+    },
+    async query() {
+      return [];
+    },
+    async validateRecord() {
+      return { ok: true };
+    }
+  };
+
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/gateway", {
+      method: "POST",
+      headers: gatewayAuthHeaders,
+      body: JSON.stringify({
+        phase: "execution",
+        actorRole: ActorRole.BUTLER,
+        surfaceContext: {
+          surface: "custom_gpt",
+          judgmentModelId: "vtdd-butler-core-v1"
+        },
+        judgmentTrace: validButlerJudgmentTrace,
+        policyInput: {
+          actionType: ActionType.ISSUE_CREATE,
+          mode: TaskMode.EXECUTION,
+          repositoryInput: "vtdd",
+          aliasRegistry,
+          targetConfirmed: true,
+          constitutionConsulted: true,
+          runtimeTruth: { runtimeAvailable: true },
+          credential: { model: "github_app", tier: CredentialTier.EXECUTE },
+          consent: { grantedCategories: [ConsentCategory.PROPOSE] },
+          approvalPhrase: "GO issue create",
+          approvalScopeMatched: true,
+          issueTraceable: true,
+          go: true,
+          passkey: false
+        }
+      })
+    }),
+    {
+      ...gatewayAuthEnv,
+      MEMORY_PROVIDER: failingProvider
+    }
+  );
+
+  assert.equal(response.status, 200);
+  const body = await response.json();
+  assert.equal(body.allowed, true);
+  assert.equal(body.repository, "sample-org/vtdd-v2");
+  assert.equal(
+    body.warnings.some((warning) =>
+      warning.includes("repository nickname registry read unverified")
+    ),
+    true
+  );
 });
 
 test("worker blocks repository nickname write when nickname target is ambiguous", async () => {


### PR DESCRIPTION
## This PR satisfies Intent

Parent: #4
Related live slice: #125

Fixes a Butler-entry regression where a failed nickname registry read could make a known nickname such as `ぶい` look unknown, even when the conversation or passkey approval payload already contains a concrete `owner/repo` target.

## Satisfied Success Criteria

- [x] Repository nickname retrieval failures are returned as action-visible JSON instead of a transport-only `ClientResponseError`.
- [x] Nickname retrieval exceptions include `error`, `reason`, `issues`, `httpStatus`, and an empty alias registry so Butler can explain the real failure.
- [x] `vtddGateway` preserves a warning when runtime nickname registry read is unverified instead of silently losing that fact while using fallback aliases.
- [x] Butler instructions say nickname read failure is not proof that the nickname is unknown.
- [x] Butler instructions allow an unverified fallback candidate from current conversation mapping or `approvalGrant.scope.repositoryInput`, with runtime validation still required.
- [x] Short instructions remain within the Custom GPT editor limit.

## Unsatisfied Success Criteria

None for this bounded correction. Live Butler verification must still run after merge, deploy, and instruction update.

## Non-goal violations

None.

## Verification Evidence

- Unit: `node --test test/worker.test.js test/custom-gpt-setup-docs.test.js test/repository-nickname-registry.test.js` passed, 67 tests.
- Integration: `npm test` passed, 445 tests.
- E2E: Not run in live Butler yet; this PR enables the next live Butler check.
- Manual: Reviewed diff for scope: worker nickname retrieval/gateway visibility plus Custom GPT instructions only.
- Evidence path/link: `test/worker.test.js`, `test/custom-gpt-setup-docs.test.js`

## Surface Update Checklist

- Cloudflare deploy: Required after merge because `src/worker.js` changed.
- Custom GPT Action Schema update: Not required; no OpenAPI/schema change.
- Custom GPT Instructions update: Required after merge; `docs/setup/custom-gpt-instructions-short.md` changed.
- iPhone Butler live E2E: Required after deploy + instruction update. Re-test nickname list/read and deploy command using `ぶい` plus approval JSON scope fallback.

## Related Constitution Rules

- Butler is context-first.
- Alias-based repository resolution exists.
- No default repository.
- Unresolved target blocks execution.
- High-risk actions require GO + passkey.

## Out-of-scope but NOT implemented

- No deploy execution in this PR.
- No Action Schema changes.
- No GitHub credential, secret, or permission mutation.
- No merge automation.

## Extra changes (if any)

None.
