### PR TITLE
Issue #125: fix Butler Codex handoff constitution preflight

### DIFF
--- a/docs/setup/custom-gpt-instructions-short.md
+++ b/docs/setup/custom-gpt-instructions-short.md
@@ -18,14 +18,14 @@ Role separation:
 - Butler reads/judges/summarizes. Codex codes/PRs. Reviewer critiques. Human owns GO/passkey.
 
 Self-reference:
-- `君`/`自分`/`Butler`/`VTDD`/`このGPT` means this Butler surface unless another target is named.
+- `君`/`自分`/`Butler`/`VTDD`/`このGPT` means this Butler unless another target is named.
 
 Repository listing and nickname memory:
 - For repository candidates/list, call vtddGateway in exploration mode.
 - Use exploration/read/read_only, repositoryInput=unknown, targetConfirmed=false, runtimeAvailable=false, safeFallbackChosen=true, consent=["read"].
 - To remember a repo nickname, use vtddUpsertRepositoryNickname.
 - To list repo nicknames, use vtddRetrieveRepositoryNicknames.
-- If request starts with non-owner/repo token like `ぶい の...`, treat it as nickname candidate; call nickname read/gateway before asking.
+- If request starts with non-owner/repo token like `ぶい の...`, call nickname read/gateway before asking.
 - Nickname memory is user-owned alias data, not a default repo; if ambiguous, ask.
 - Nickname read failure is not proof of unknown repo. If conversation has a known mapping or approvalGrant.scope.repositoryInput, use that owner/repo as unverified fallback and verify by next read/action.
 - If nickname save/read fails, surface error/reason/issues; do not replace with vague guesses.
@@ -54,6 +54,7 @@ Self-parity:
 Execution judgment:
 - Before execution, read runtime truth through vtddGateway; do not ask vtddGateway to execute `build`.
 - judgmentTrace first four steps must be exactly: constitution, runtime_truth, issue_context, current_query. Put Issue reads/contract/GO in rationale, not new step names.
+- No constitutionConsulted input; constitution-first trace satisfies policy.
 - If the target repository is unresolved, do not execute.
 - Read-only exploration may proceed without a resolved repository only when policy allows it.
 

--- a/docs/setup/custom-gpt-instructions.md
+++ b/docs/setup/custom-gpt-instructions.md
@@ -171,6 +171,7 @@ Execution judgment:
   3. issue_context
   4. current_query
 - Do not invent step names such as `issue_retrieval`, `bounded_contract`, or `go_check`; record those details in the rationale/status fields of the required steps instead.
+- Do not ask the human to supply internal constitution flags. If the first judgmentTrace step is `constitution`, runtime policy treats constitution consultation as satisfied.
 
 Remote Codex flow:
 - Use vtddExecute only when Butler is intentionally handing bounded work to remote Codex.

--- a/src/core/butler-orchestrator.js
+++ b/src/core/butler-orchestrator.js
@@ -21,8 +21,12 @@ export function evaluateButlerExecution(input) {
     return deny(judgment.rule, judgment.reason);
   }
 
-  const policy = evaluateExecutionPolicy({
+  const policyInput = {
     ...(input?.policyInput ?? {}),
+    constitutionConsulted: true
+  };
+  const policy = evaluateExecutionPolicy({
+    ...policyInput,
     actorRole: resolveButlerPolicyActorRole(input)
   });
   if (!policy.allowed) {

--- a/test/butler-orchestrator.test.js
+++ b/test/butler-orchestrator.test.js
@@ -144,6 +144,53 @@ test("butler orchestrator allows build only as bounded remote Codex handoff", ()
   assert.equal(result.repository, "sample-org/vtdd-v2");
 });
 
+test("butler orchestrator derives constitution consultation from valid judgment trace", () => {
+  const result = evaluateButlerExecution({
+    surfaceContext: {
+      surface: "custom_gpt",
+      judgmentModelId: "vtdd-butler-core-v1"
+    },
+    judgmentTrace,
+    runtimeContext: {
+      allowButlerRemoteCodexHandoff: true
+    },
+    issueContext: {
+      issueNumber: 125
+    },
+    continuationContext: {
+      requiresHandoff: true,
+      handoff: {
+        issueTraceable: true,
+        approvalScopeMatched: true,
+        relatedIssue: 125,
+        summary: "Issue #125 bounded Codex handoff"
+      }
+    },
+    policyInput: {
+      actionType: ActionType.BUILD,
+      mode: "execution",
+      repositoryInput: "vtdd",
+      aliasRegistry: registry,
+      targetConfirmed: true,
+      runtimeTruth: { runtimeAvailable: true },
+      credential: { model: "github_app", tier: CredentialTier.EXECUTE },
+      consent: fullConsent,
+      ...approvalContext,
+      issueTraceable: true,
+      issueTraceability: {
+        relatedIssue: 125,
+        intentRefs: ["#125 Intent"],
+        successCriteriaRefs: ["#125 Success Criteria"],
+        nonGoalRefs: ["#125 Non-goals"]
+      },
+      go: true,
+      passkey: false
+    }
+  });
+  assert.equal(result.allowed, true);
+  assert.equal(result.repository, "sample-org/vtdd-v2");
+});
+
 test("butler orchestrator blocks self-asserted build handoff outside execute route", () => {
   const result = evaluateButlerExecution({
     surfaceContext: {

--- a/test/custom-gpt-setup-docs.test.js
+++ b/test/custom-gpt-setup-docs.test.js
@@ -53,6 +53,7 @@ test("custom gpt instructions preserve current butler and approval boundaries", 
   assert.equal(doc.includes("operation=`issue_create`"), true);
   assert.equal(doc.includes("Do not ask the user to author internal `policyInput`, `judgmentTrace`, or"), true);
   assert.equal(doc.includes("Do not invent step names such as `issue_retrieval`"), true);
+  assert.equal(doc.includes("Do not ask the human to supply internal constitution flags"), true);
   assert.equal(doc.includes("For vtddExecute Codex handoff, use `policyInput.actionType=build`"), true);
   assert.equal(doc.includes("policyInput.issueTraceability` includes real Intent / Success Criteria / Non-goals refs"), true);
   assert.equal(doc.includes("continuationContext.requiresHandoff=true"), true);
@@ -133,6 +134,7 @@ test("short custom gpt instructions stay under editor limits while preserving cr
     doc.includes("judgmentTrace first four steps must be exactly: constitution, runtime_truth, issue_context, current_query"),
     true
   );
+  assert.equal(doc.includes("No constitutionConsulted input"), true);
   assert.equal(doc.includes("Cloudflare deploy update required"), true);
   assert.equal(doc.includes("Action Schema update required"), true);
   assert.equal(doc.includes("Instructions update required"), true);

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -410,6 +410,100 @@ test("worker dispatches remote Codex execution", async () => {
   assert.equal(calls.length, 2);
 });
 
+test("worker dispatches remote Codex execution without user-authored constitutionConsulted", async () => {
+  const calls = [];
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/action/execute", {
+      method: "POST",
+      headers: gatewayAuthHeaders,
+      body: JSON.stringify({
+        phase: "execution",
+        actorRole: ActorRole.BUTLER,
+        surfaceContext: {
+          surface: "custom_gpt",
+          judgmentModelId: "vtdd-butler-core-v1"
+        },
+        judgmentTrace: validButlerJudgmentTrace,
+        issueContext: {
+          issueNumber: 125
+        },
+        continuationContext: {
+          requiresHandoff: true,
+          handoff: {
+            issueTraceable: true,
+            approvalScopeMatched: true,
+            relatedIssue: 125,
+            summary: "Issue #125 bounded remote Codex handoff"
+          }
+        },
+        policyInput: {
+          actionType: ActionType.BUILD,
+          mode: TaskMode.EXECUTION,
+          repositoryInput: "vtdd",
+          aliasRegistry,
+          targetConfirmed: true,
+          runtimeTruth: {
+            runtimeAvailable: true,
+            runtimeState: {
+              activeBranch: "codex/issue-125"
+            }
+          },
+          credential: { model: "github_app", tier: CredentialTier.EXECUTE },
+          consent: { grantedCategories: [ConsentCategory.PROPOSE, ConsentCategory.EXECUTE] },
+          approvalPhrase: "GO",
+          approvalScopeMatched: true,
+          issueTraceable: true,
+          issueTraceability: {
+            relatedIssue: 125,
+            intentRefs: ["#125 Intent"],
+            successCriteriaRefs: ["#125 Success Criteria"],
+            nonGoalRefs: ["#125 Non-goals"]
+          },
+          go: true,
+          passkey: false
+        }
+      })
+    }),
+    {
+      ...gatewayAuthEnv,
+      VTDD_GITHUB_ACTIONS_REPOSITORY: "sample-org/vtdd-v2-p",
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_dispatch_token",
+      GITHUB_API_FETCH: async (url, init) => {
+        calls.push({ url, init });
+        if (String(url).includes("/installation/repositories")) {
+          return new Response(
+            JSON.stringify({
+              total_count: 1,
+              repositories: [
+                {
+                  full_name: "sample-org/vtdd-v2",
+                  name: "vtdd-v2",
+                  private: true
+                }
+              ]
+            }),
+            { status: 200, headers: { "content-type": "application/json" } }
+          );
+        }
+        return new Response(
+          JSON.stringify({
+            id: 125,
+            html_url: "https://github.com/sample-org/vtdd-v2/issues/125#issuecomment-125"
+          }),
+          { status: 201, headers: { "content-type": "application/json" } }
+        );
+      }
+    }
+  );
+
+  assert.equal(response.status, 202);
+  const body = await response.json();
+  assert.equal(body.ok, true);
+  assert.equal(body.execution.issueNumber, 125);
+  assert.equal(body.execution.transport, "codex_cloud_github_comment");
+  assert.equal(calls.length, 2);
+});
+
 test("worker gateway rejects self-asserted Butler build handoff", async () => {
   const response = await worker.fetch(
     new Request("https://example.com/v2/gateway", {


### PR DESCRIPTION
## This PR satisfies Intent

Parent: #4
Related live slice: #125

Fixes the Butler -> Codex handoff preflight failure where a Custom GPT conversation could provide a valid constitution-first `judgmentTrace` but still be blocked because the internal `policyInput.constitutionConsulted` flag was omitted.

This keeps the Butler entry path aligned with the user-facing contract: humans should not have to author internal flags or raw policy JSON for normal operation.

## Satisfied Success Criteria

- [x] Butler remote Codex handoff through `vtddExecute` can pass when `judgmentTrace` starts with `constitution` even if `constitutionConsulted` is omitted.
- [x] Invalid judgment order still blocks before policy evaluation.
- [x] Self-asserted Butler build through `vtddGateway` remains blocked.
- [x] Issue-bound handoff requirements remain intact: `requiresHandoff`, related Issue, approval scope match, and Intent / Success Criteria / Non-goals refs are still required.
- [x] Custom GPT instructions now say not to ask the human for internal constitution flags.
- [x] Existing nickname, self-parity, deploy, GitHub read/write, and reviewer-related tests remain passing under the full test suite.

## Unsatisfied Success Criteria

None for this bounded correction. Live Butler verification is still required after merge, deploy, and instruction update.

## Non-goal violations

None.

## Verification Evidence

- Unit/Integration targeted: `node --test test/butler-orchestrator.test.js test/worker.test.js test/custom-gpt-setup-docs.test.js test/mvp-gateway.test.js test/repository-nickname-registry.test.js test/custom-gpt-setup-artifacts.test.js` passed, 94 tests.
- Full regression: `npm test` passed, 447 tests.
- E2E: Not run in live Butler yet; expected next live check is Issue #125 handoff from Butler conversation.
- Manual: Reviewed diff for scope; runtime change is limited to Butler execution policy preflight derivation plus instruction docs/tests.
- Evidence path/link: `src/core/butler-orchestrator.js`, `test/butler-orchestrator.test.js`, `test/worker.test.js`, `test/custom-gpt-setup-docs.test.js`

## Surface Update Checklist

- Cloudflare deploy: Required after merge because runtime behavior changed in `src/core/butler-orchestrator.js`.
- Custom GPT Action Schema update: Not required; no OpenAPI/schema change.
- Custom GPT Instructions update: Required after merge; short/full instructions changed.
- iPhone Butler live E2E: Required after deploy + instruction update. Re-test `その bounded contract で Codex に handoff して。GO。` for Issue #125 and verify it reaches execution/progress instead of `constitution must be consulted`.

## Related Constitution Rules

- Butler is context-first.
- Issue is the canonical execution spec.
- No default repository.
- Unresolved target blocks execution.
- Human owns GO/passkey boundaries.
- Butler must consult constitution before execution judgment.

## Out-of-scope but NOT implemented

- No merge automation.
- No deploy execution.
- No credential, secret, permission, or repository settings mutation.
- No reviewer backend redesign.
- No relaxation of Issue traceability or handoff scope checks.

## Extra changes (if any)

None.
