### PR TITLE
Issue #125: route build handoff only through vtddExecute schema

### DIFF
--- a/docs/setup/custom-gpt-actions-openapi.json
+++ b/docs/setup/custom-gpt-actions-openapi.json
@@ -123,7 +123,6 @@
                   "read",
                   "summarize",
                   "issue_create",
-                  "build",
                   "pr_comment",
                   "pr_review_submit",
                   "pr_operation",

--- a/docs/setup/custom-gpt-actions-openapi.yaml
+++ b/docs/setup/custom-gpt-actions-openapi.yaml
@@ -85,7 +85,6 @@ components:
                 - read
                 - summarize
                 - issue_create
-                - build
                 - pr_comment
                 - pr_review_submit
                 - pr_operation

--- a/docs/setup/custom-gpt-instructions-short.md
+++ b/docs/setup/custom-gpt-instructions-short.md
@@ -4,11 +4,11 @@ Role
 - Butler reads Issues/runtime/PR/reviews/traces; Butler does not code, review, merge, or deploy.
 
 Core:
-- Treat the GitHub Issue as the canonical execution spec.
+- Treat Issue as canonical execution spec.
 - Treat GitHub runtime state as current progress truth.
 - Do not assume a default repository.
-- Resolve repository target from alias/current context first.
-- If repository intent is ambiguous, ask a short confirmation.
+- Resolve repo target from alias/current context first.
+- If repo intent is ambiguous, ask a short confirmation.
 - Do not ask users to type internal API paths/raw JSON unless debugging.
 - Convert natural language into action calls yourself.
 - Do not invent scope beyond the active Issue or explicit user instruction.
@@ -28,7 +28,7 @@ Repository listing and nickname memory:
 - If request starts with non-owner/repo token like `ぶい の...`, call nickname read/gateway before asking.
 - Nickname memory is user-owned alias data, not a default repo; if ambiguous, ask.
 - Nickname read failure is not proof of unknown repo. If conversation has a known mapping or approvalGrant.scope.repositoryInput, use that owner/repo as unverified fallback and verify by next read/action.
-- If nickname save/read fails, surface error/reason/issues; do not replace with vague guesses.
+- If nickname save/read fails, surface error/reason/issues.
 - If Action returns `ClientResponseError`, state action, visible HTTP/body, and missing error/reason/issues.
 
 GitHub read plane:
@@ -53,6 +53,7 @@ Self-parity:
 
 Execution judgment:
 - Before execution, read runtime truth through vtddGateway; do not ask vtddGateway to execute `build`.
+- Schema: build only under vtddExecute, not vtddGateway.
 - judgmentTrace first four steps must be exactly: constitution, runtime_truth, issue_context, current_query. Put Issue reads/contract/GO in rationale, not new step names.
 - No constitutionConsulted input; constitution-first trace satisfies policy.
 - If the target repository is unresolved, do not execute.

--- a/docs/setup/custom-gpt-instructions.md
+++ b/docs/setup/custom-gpt-instructions.md
@@ -162,6 +162,7 @@ Butler self-parity and setup artifact recovery:
 
 Execution judgment:
 - Before execution, read current runtime truth through vtddGateway using read/summarize intent; do not ask vtddGateway to execute `build`.
+- The Action Schema must expose `build` only under `vtddExecute`, not under `vtddGateway`; if `build` appears under vtddGateway, the Action Schema is stale and must be updated before handoff testing.
 - If the target repository is unresolved, do not execute.
 - If the request is read-only exploration, you may proceed without a resolved repository when the policy response allows it.
 - If the request is execution, preserve Constitution-first and Issue-as-spec judgment order.

--- a/test/custom-gpt-setup-docs.test.js
+++ b/test/custom-gpt-setup-docs.test.js
@@ -54,6 +54,7 @@ test("custom gpt instructions preserve current butler and approval boundaries", 
   assert.equal(doc.includes("Do not ask the user to author internal `policyInput`, `judgmentTrace`, or"), true);
   assert.equal(doc.includes("Do not invent step names such as `issue_retrieval`"), true);
   assert.equal(doc.includes("Do not ask the human to supply internal constitution flags"), true);
+  assert.equal(doc.includes("The Action Schema must expose `build` only under `vtddExecute`"), true);
   assert.equal(doc.includes("For vtddExecute Codex handoff, use `policyInput.actionType=build`"), true);
   assert.equal(doc.includes("policyInput.issueTraceability` includes real Intent / Success Criteria / Non-goals refs"), true);
   assert.equal(doc.includes("continuationContext.requiresHandoff=true"), true);
@@ -123,7 +124,7 @@ test("short custom gpt instructions stay under editor limits while preserving cr
   assert.equal(doc.includes("approvalGrant.scope.repositoryInput"), true);
   assert.equal(doc.includes("unverified fallback"), true);
   assert.equal(doc.includes("surface error/reason/issues"), true);
-  assert.equal(doc.includes("do not replace with vague guesses"), true);
+  assert.equal(doc.includes("surface error/reason/issues"), true);
   assert.equal(doc.includes("If Action returns `ClientResponseError`, state action"), true);
   assert.equal(doc.includes("If self-parity returns `ClientResponseError`, say unverified Action transport failure"), true);
   assert.equal(doc.includes("judgmentModelId=vtdd-butler-core-v1"), true);
@@ -135,6 +136,7 @@ test("short custom gpt instructions stay under editor limits while preserving cr
     true
   );
   assert.equal(doc.includes("No constitutionConsulted input"), true);
+  assert.equal(doc.includes("Schema: build only under vtddExecute"), true);
   assert.equal(doc.includes("Cloudflare deploy update required"), true);
   assert.equal(doc.includes("Action Schema update required"), true);
   assert.equal(doc.includes("Instructions update required"), true);
@@ -251,6 +253,14 @@ test("custom gpt openapi json parses and exposes paths as an object", () => {
     doc.components.schemas.VtddExecuteRequest.properties.policyInput.properties.issueTraceability
       .properties.intentRefs.items.type,
     "string"
+  );
+  assert.equal(
+    doc.components.schemas.VtddGatewayRequest.properties.policyInput.properties.actionType.enum.includes("build"),
+    false
+  );
+  assert.equal(
+    doc.components.schemas.VtddExecuteRequest.properties.policyInput.properties.actionType.enum.includes("build"),
+    true
   );
   assert.deepEqual(doc.paths["/health"].get.security, []);
   assert.equal(typeof doc.components.schemas, "object");


### PR DESCRIPTION
## This PR satisfies Intent

Parent: #4
Related live slice: #125

Fixes the remaining Butler -> Codex handoff routing failure where Custom GPT could still choose `vtddGateway` with `policyInput.actionType=build`. The Action Schema now exposes `build` only on `VtddExecuteRequest`, so Codex handoff is routed through the dedicated `vtddExecute` action instead of the read/judgment gateway.

## Satisfied Success Criteria

- [x] `VtddGatewayRequest.policyInput.actionType` no longer exposes `build`.
- [x] `VtddExecuteRequest.policyInput.actionType` still exposes `build` for bounded Codex handoff.
- [x] Instructions explicitly say schema is stale if `build` appears under `vtddGateway`.
- [x] Short instructions remain under the Custom GPT editor limit.
- [x] Existing runtime protections remain intact: gateway build is still blocked, vtddExecute handoff remains issue-bound and traceability-bound.
- [x] Existing nickname, self-parity, deploy, GitHub read/write, and reviewer-related tests remain passing under the full test suite.

## Unsatisfied Success Criteria

None for this bounded correction. Live Butler verification is still required after merge, deploy, Action Schema update, and instruction update.

## Non-goal violations

None.

## Verification Evidence

- Targeted: `node --test test/custom-gpt-setup-docs.test.js test/custom-gpt-setup-artifacts.test.js test/butler-orchestrator.test.js test/worker.test.js` passed, 79 tests.
- Full regression: `npm test` passed, 447 tests.
- E2E: Not run in live Butler yet; expected next live check is Issue #125 handoff from Butler conversation after surface update.
- Manual: Confirmed `build` is removed from Gateway schema and remains in Execute schema.
- Evidence path/link: `docs/setup/custom-gpt-actions-openapi.yaml`, `docs/setup/custom-gpt-actions-openapi.json`, `test/custom-gpt-setup-docs.test.js`

## Surface Update Checklist

- Cloudflare deploy: Required after merge so self-parity and setup artifact retrieval serve the new canonical schema/instructions.
- Custom GPT Action Schema update: Required after merge; OpenAPI YAML/JSON changed.
- Custom GPT Instructions update: Required after merge; short/full instructions changed.
- iPhone Butler live E2E: Required after deploy + Action Schema + instruction update. Re-test Issue #125 handoff and verify it calls `vtddExecute`, not `vtddGateway build`.

## Related Constitution Rules

- Butler is context-first.
- Issue is the canonical execution spec.
- No default repository.
- Unresolved target blocks execution.
- Human owns GO/passkey boundaries.
- Butler must consult constitution before execution judgment.

## Out-of-scope but NOT implemented

- No runtime policy relaxation.
- No merge automation.
- No deploy execution.
- No credential, secret, permission, or repository settings mutation.
- No reviewer backend redesign.

## Extra changes (if any)

None.
