### PR TITLE
Issue #125: derive handoff approval scope for Codex execution

### DIFF
--- a/src/core/butler-orchestrator.js
+++ b/src/core/butler-orchestrator.js
@@ -1,5 +1,6 @@
 import { evaluateJudgmentOrder } from "./judgment-order.js";
 import { evaluateExecutionPolicy } from "./policy.js";
+import { isBoundRemoteCodexHandoff } from "./remote-codex-handoff-scope.js";
 import { evaluateSurfaceIndependence } from "./surface-independence.js";
 import { ActionType, ActorRole } from "./types.js";
 
@@ -21,13 +22,16 @@ export function evaluateButlerExecution(input) {
     return deny(judgment.rule, judgment.reason);
   }
 
+  const remoteCodexHandoff = isRemoteCodexHandoff(input);
   const policyInput = {
     ...(input?.policyInput ?? {}),
-    constitutionConsulted: true
+    constitutionConsulted: true,
+    approvalScopeMatched:
+      input?.policyInput?.approvalScopeMatched === true || remoteCodexHandoff
   };
   const policy = evaluateExecutionPolicy({
     ...policyInput,
-    actorRole: resolveButlerPolicyActorRole(input)
+    actorRole: resolveButlerPolicyActorRole({ ...input, remoteCodexHandoff })
   });
   if (!policy.allowed) {
     return { ...policy };
@@ -45,7 +49,7 @@ function resolveButlerPolicyActorRole(input) {
   const policyInput = input?.policyInput ?? {};
   if (
     policyInput.actionType === ActionType.BUILD &&
-    isRemoteCodexHandoff(input)
+    input?.remoteCodexHandoff === true
   ) {
     return ActorRole.EXECUTOR;
   }
@@ -59,49 +63,7 @@ function isRemoteCodexHandoff(input) {
     return false;
   }
 
-  const context =
-    input?.continuationContext && typeof input.continuationContext === "object"
-      ? input.continuationContext
-      : {};
-  const handoff = context.handoff && typeof context.handoff === "object" ? context.handoff : {};
-  const issueNumber = normalizePositiveInteger(input?.issueContext?.issueNumber);
-  const relatedIssue = normalizePositiveInteger(handoff.relatedIssue);
-  return (
-    context.requiresHandoff === true &&
-    handoff.issueTraceable === true &&
-    handoff.approvalScopeMatched === true &&
-    Boolean(normalizeText(handoff.summary)) &&
-    issueNumber !== null &&
-    relatedIssue === issueNumber &&
-    hasBoundIssueTraceability(input, issueNumber)
-  );
-}
-
-function normalizePositiveInteger(value) {
-  const number = Number(value);
-  return Number.isInteger(number) && number > 0 ? number : null;
-}
-
-function normalizeText(value) {
-  return typeof value === "string" ? value.trim() : "";
-}
-
-function hasBoundIssueTraceability(input, issueNumber) {
-  const traceability =
-    input?.policyInput?.issueTraceability && typeof input.policyInput.issueTraceability === "object"
-      ? input.policyInput.issueTraceability
-      : {};
-  const relatedIssue = normalizePositiveInteger(traceability.relatedIssue);
-  return (
-    relatedIssue === issueNumber &&
-    hasTextArray(traceability.intentRefs) &&
-    hasTextArray(traceability.successCriteriaRefs) &&
-    hasTextArray(traceability.nonGoalRefs)
-  );
-}
-
-function hasTextArray(value) {
-  return Array.isArray(value) && value.some((item) => Boolean(normalizeText(item)));
+  return isBoundRemoteCodexHandoff(input);
 }
 
 function deny(rule, reason) {

--- a/src/core/remote-codex-executor.js
+++ b/src/core/remote-codex-executor.js
@@ -1,5 +1,6 @@
 import { ActorRole } from "./types.js";
 import { resolveGitHubAppInstallationToken } from "./github-app-repository-index.js";
+import { isBoundRemoteCodexHandoff } from "./remote-codex-handoff-scope.js";
 
 export const REMOTE_CODEX_WORKFLOW_FILE = "remote-codex-executor.yml";
 
@@ -22,6 +23,13 @@ export function createRemoteCodexExecutionRequest(input = {}) {
   const runtimeState = normalizeObject(payload?.policyInput?.runtimeTruth?.runtimeState);
   const continuationContext = normalizeObject(payload.continuationContext);
   const handoff = normalizeObject(continuationContext.handoff);
+  const approvalScopeMatched =
+    payload?.policyInput?.approvalScopeMatched === true ||
+    isBoundRemoteCodexHandoff({
+      continuationContext,
+      issueContext,
+      policyInput: payload?.policyInput
+    });
 
   const issueNumber = normalizePositiveInteger(
     issueContext.issueNumber ?? handoff.relatedIssue ?? payload.relatedIssue
@@ -42,7 +50,7 @@ export function createRemoteCodexExecutionRequest(input = {}) {
     codexGoal: normalizeText(gatewayResult?.executionContinuity?.codexGoal),
     approvalPhrase: normalizeText(payload?.policyInput?.approvalPhrase),
     targetConfirmed: payload?.policyInput?.targetConfirmed === true,
-    approvalScopeMatched: payload?.policyInput?.approvalScopeMatched === true,
+    approvalScopeMatched,
     handoffRequired: continuationContext.requiresHandoff === true,
     handoff:
       Object.keys(handoff).length > 0
@@ -199,6 +207,7 @@ async function dispatchApiBackedWorkflow({ request, token, env }) {
       branch: request.branch,
       baseRef: request.baseRef,
       codexGoal: request.codexGoal,
+      approvalScopeMatched: request.approvalScopeMatched,
       status: RemoteCodexExecutionStatus.QUEUED
     }
   };
@@ -362,6 +371,7 @@ async function dispatchCodexCloudGitHubComment({ request, token, env }) {
       branch: request.branch,
       baseRef: request.baseRef,
       codexGoal: request.codexGoal,
+      approvalScopeMatched: request.approvalScopeMatched,
       commentId: normalizePositiveInteger(responseBody?.id),
       commentUrl: normalizeText(responseBody?.html_url) || null,
       status: RemoteCodexExecutionStatus.QUEUED

--- a/src/core/remote-codex-handoff-scope.js
+++ b/src/core/remote-codex-handoff-scope.js
@@ -1,0 +1,47 @@
+export function isBoundRemoteCodexHandoff(input = {}) {
+  const context = normalizeObject(input?.continuationContext);
+  const handoff = normalizeObject(context.handoff);
+  const issueContext = normalizeObject(input?.issueContext);
+  const issueNumber = normalizePositiveInteger(issueContext.issueNumber);
+  const relatedIssue = normalizePositiveInteger(handoff.relatedIssue);
+
+  return (
+    context.requiresHandoff === true &&
+    handoff.issueTraceable === true &&
+    handoff.approvalScopeMatched === true &&
+    Boolean(normalizeText(handoff.summary)) &&
+    issueNumber !== null &&
+    relatedIssue === issueNumber &&
+    hasBoundIssueTraceability(input?.policyInput, issueNumber)
+  );
+}
+
+function hasBoundIssueTraceability(policyInput, issueNumber) {
+  const traceability = normalizeObject(policyInput?.issueTraceability);
+  return (
+    normalizePositiveInteger(traceability.relatedIssue) === issueNumber &&
+    hasTextArray(traceability.intentRefs) &&
+    hasTextArray(traceability.successCriteriaRefs) &&
+    hasTextArray(traceability.nonGoalRefs)
+  );
+}
+
+function hasTextArray(value) {
+  return Array.isArray(value) && value.some((item) => Boolean(normalizeText(item)));
+}
+
+function normalizeObject(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return {};
+  }
+  return value;
+}
+
+function normalizeText(value) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function normalizePositiveInteger(value) {
+  const number = Number(value);
+  return Number.isInteger(number) && number > 0 ? number : null;
+}

--- a/test/butler-orchestrator.test.js
+++ b/test/butler-orchestrator.test.js
@@ -191,6 +191,147 @@ test("butler orchestrator derives constitution consultation from valid judgment 
   assert.equal(result.repository, "sample-org/vtdd-v2");
 });
 
+test("butler orchestrator derives approval scope match from bounded remote handoff", () => {
+  const result = evaluateButlerExecution({
+    surfaceContext: {
+      surface: "custom_gpt",
+      judgmentModelId: "vtdd-butler-core-v1"
+    },
+    judgmentTrace,
+    runtimeContext: {
+      allowButlerRemoteCodexHandoff: true
+    },
+    issueContext: {
+      issueNumber: 125
+    },
+    continuationContext: {
+      requiresHandoff: true,
+      handoff: {
+        issueTraceable: true,
+        approvalScopeMatched: true,
+        relatedIssue: 125,
+        summary: "Issue #125 bounded Codex handoff"
+      }
+    },
+    policyInput: {
+      actionType: ActionType.BUILD,
+      mode: "execution",
+      repositoryInput: "vtdd",
+      aliasRegistry: registry,
+      targetConfirmed: true,
+      runtimeTruth: { runtimeAvailable: true },
+      credential: { model: "github_app", tier: CredentialTier.EXECUTE },
+      consent: fullConsent,
+      approvalPhrase: "GO Issue #125 Codex handoff",
+      issueTraceable: true,
+      issueTraceability: {
+        relatedIssue: 125,
+        intentRefs: ["#125 Intent"],
+        successCriteriaRefs: ["#125 Success Criteria"],
+        nonGoalRefs: ["#125 Non-goals"]
+      },
+      go: true,
+      passkey: false
+    }
+  });
+  assert.equal(result.allowed, true);
+  assert.equal(result.repository, "sample-org/vtdd-v2");
+});
+
+test("butler orchestrator does not derive handoff approval from non-string summary", () => {
+  const result = evaluateButlerExecution({
+    surfaceContext: {
+      surface: "custom_gpt",
+      judgmentModelId: "vtdd-butler-core-v1"
+    },
+    judgmentTrace,
+    runtimeContext: {
+      allowButlerRemoteCodexHandoff: true
+    },
+    issueContext: {
+      issueNumber: 125
+    },
+    continuationContext: {
+      requiresHandoff: true,
+      handoff: {
+        issueTraceable: true,
+        approvalScopeMatched: true,
+        relatedIssue: 125,
+        summary: 125
+      }
+    },
+    policyInput: {
+      actionType: ActionType.BUILD,
+      mode: "execution",
+      repositoryInput: "vtdd",
+      aliasRegistry: registry,
+      targetConfirmed: true,
+      runtimeTruth: { runtimeAvailable: true },
+      credential: { model: "github_app", tier: CredentialTier.EXECUTE },
+      consent: fullConsent,
+      approvalPhrase: "GO Issue #125 Codex handoff",
+      issueTraceable: true,
+      issueTraceability: {
+        relatedIssue: 125,
+        intentRefs: ["#125 Intent"],
+        successCriteriaRefs: ["#125 Success Criteria"],
+        nonGoalRefs: ["#125 Non-goals"]
+      },
+      go: true,
+      passkey: false
+    }
+  });
+  assert.equal(result.allowed, false);
+  assert.equal(result.blockedByRule, "role_action_boundary");
+});
+
+test("butler orchestrator does not derive handoff approval from non-string refs", () => {
+  const result = evaluateButlerExecution({
+    surfaceContext: {
+      surface: "custom_gpt",
+      judgmentModelId: "vtdd-butler-core-v1"
+    },
+    judgmentTrace,
+    runtimeContext: {
+      allowButlerRemoteCodexHandoff: true
+    },
+    issueContext: {
+      issueNumber: 125
+    },
+    continuationContext: {
+      requiresHandoff: true,
+      handoff: {
+        issueTraceable: true,
+        approvalScopeMatched: true,
+        relatedIssue: 125,
+        summary: "Issue #125 bounded Codex handoff"
+      }
+    },
+    policyInput: {
+      actionType: ActionType.BUILD,
+      mode: "execution",
+      repositoryInput: "vtdd",
+      aliasRegistry: registry,
+      targetConfirmed: true,
+      runtimeTruth: { runtimeAvailable: true },
+      credential: { model: "github_app", tier: CredentialTier.EXECUTE },
+      consent: fullConsent,
+      approvalPhrase: "GO Issue #125 Codex handoff",
+      issueTraceable: true,
+      issueTraceability: {
+        relatedIssue: 125,
+        intentRefs: [125],
+        successCriteriaRefs: ["#125 Success Criteria"],
+        nonGoalRefs: ["#125 Non-goals"]
+      },
+      go: true,
+      passkey: false
+    }
+  });
+  assert.equal(result.allowed, false);
+  assert.equal(result.blockedByRule, "role_action_boundary");
+});
+
 test("butler orchestrator blocks self-asserted build handoff outside execute route", () => {
   const result = evaluateButlerExecution({
     surfaceContext: {

--- a/test/remote-codex-executor.test.js
+++ b/test/remote-codex-executor.test.js
@@ -41,6 +41,48 @@ test("remote Codex execution request is built from gateway result and payload", 
   assert.equal(result.request.codexGoal, "open_pr");
 });
 
+test("remote Codex execution request rejects non-string handoff approval refs", () => {
+  const result = createRemoteCodexExecutionRequest({
+    payload: {
+      actorRole: ActorRole.BUTLER,
+      issueContext: { issueNumber: 125 },
+      continuationContext: {
+        requiresHandoff: true,
+        handoff: {
+          issueTraceable: true,
+          approvalScopeMatched: true,
+          relatedIssue: 125,
+          summary: "Issue #125 bounded Codex handoff"
+        }
+      },
+      policyInput: {
+        approvalPhrase: "GO Issue #125 Codex handoff",
+        targetConfirmed: true,
+        issueTraceability: {
+          relatedIssue: 125,
+          intentRefs: [125],
+          successCriteriaRefs: ["#125 Success Criteria"],
+          nonGoalRefs: ["#125 Non-goals"]
+        },
+        runtimeTruth: {
+          runtimeState: {
+            activeBranch: "codex/issue-125"
+          }
+        }
+      }
+    },
+    gatewayResult: {
+      repository: "sample-org/vtdd-v2",
+      executionContinuity: {
+        codexGoal: "open_pr"
+      }
+    }
+  });
+
+  assert.equal(result.ok, false);
+  assert.deepEqual(result.issues, ["approvalScopeMatched must be true"]);
+});
+
 test("remote Codex execution default dispatch posts bounded @codex GitHub comment", async () => {
   const calls = [];
   const dispatched = await dispatchRemoteCodexExecution({

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -504,6 +504,99 @@ test("worker dispatches remote Codex execution without user-authored constitutio
   assert.equal(calls.length, 2);
 });
 
+test("worker dispatches remote Codex execution with approval scope matched only on handoff", async () => {
+  const calls = [];
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/action/execute", {
+      method: "POST",
+      headers: gatewayAuthHeaders,
+      body: JSON.stringify({
+        phase: "execution",
+        actorRole: ActorRole.BUTLER,
+        surfaceContext: {
+          surface: "custom_gpt",
+          judgmentModelId: "vtdd-butler-core-v1"
+        },
+        judgmentTrace: validButlerJudgmentTrace,
+        issueContext: {
+          issueNumber: 125
+        },
+        continuationContext: {
+          requiresHandoff: true,
+          handoff: {
+            issueTraceable: true,
+            approvalScopeMatched: true,
+            relatedIssue: 125,
+            summary: "Issue #125 bounded remote Codex handoff"
+          }
+        },
+        policyInput: {
+          actionType: ActionType.BUILD,
+          mode: TaskMode.EXECUTION,
+          repositoryInput: "vtdd",
+          aliasRegistry,
+          targetConfirmed: true,
+          runtimeTruth: {
+            runtimeAvailable: true,
+            runtimeState: {
+              activeBranch: "codex/issue-125"
+            }
+          },
+          credential: { model: "github_app", tier: CredentialTier.EXECUTE },
+          consent: { grantedCategories: [ConsentCategory.PROPOSE, ConsentCategory.EXECUTE] },
+          approvalPhrase: "GO Issue #125 Codex handoff",
+          issueTraceable: true,
+          issueTraceability: {
+            relatedIssue: 125,
+            intentRefs: ["#125 Intent"],
+            successCriteriaRefs: ["#125 Success Criteria"],
+            nonGoalRefs: ["#125 Non-goals"]
+          },
+          go: true,
+          passkey: false
+        }
+      })
+    }),
+    {
+      ...gatewayAuthEnv,
+      VTDD_GITHUB_ACTIONS_REPOSITORY: "sample-org/vtdd-v2-p",
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_dispatch_token",
+      GITHUB_API_FETCH: async (url, init) => {
+        calls.push({ url, init });
+        if (String(url).includes("/installation/repositories")) {
+          return new Response(
+            JSON.stringify({
+              total_count: 1,
+              repositories: [
+                {
+                  full_name: "sample-org/vtdd-v2",
+                  name: "vtdd-v2",
+                  private: true
+                }
+              ]
+            }),
+            { status: 200, headers: { "content-type": "application/json" } }
+          );
+        }
+        return new Response(
+          JSON.stringify({
+            id: 126,
+            html_url: "https://github.com/sample-org/vtdd-v2/issues/125#issuecomment-126"
+          }),
+          { status: 201, headers: { "content-type": "application/json" } }
+        );
+      }
+    }
+  );
+
+  assert.equal(response.status, 202);
+  const body = await response.json();
+  assert.equal(body.ok, true);
+  assert.equal(body.execution.issueNumber, 125);
+  assert.equal(body.execution.approvalScopeMatched, true);
+  assert.equal(calls.length, 2);
+});
+
 test("worker gateway rejects self-asserted Butler build handoff", async () => {
   const response = await worker.fetch(
     new Request("https://example.com/v2/gateway", {


### PR DESCRIPTION
## This PR satisfies Intent

Parent: #4
Related live slice: #125

Fixes the Butler -> Codex handoff approval binding failure where a bounded handoff had `continuationContext.handoff.approvalScopeMatched=true` but the execution path still blocked because `policyInput.approvalScopeMatched` was omitted. For GO-tier remote Codex handoff, runtime now derives policy and dispatch approval scope match from the validated handoff contract.

## Satisfied Success Criteria

- [x] Valid remote Codex handoff derives `approvalScopeMatched` from the bounded handoff contract.
- [x] GO-tier build does not require a passkey approval grant.
- [x] Handoff remains issue-bound and traceability-bound.
- [x] Gateway build remains blocked; only `vtddExecute` with runtime handoff context can execute.
- [x] Existing nickname, self-parity, deploy, GitHub read/write, and reviewer-related tests remain passing under the full test suite.

## Unsatisfied Success Criteria

None for this bounded correction. Live Butler verification is still required after merge and deploy.

## Non-goal violations

None.

## Verification Evidence

- Targeted: `node --test test/butler-orchestrator.test.js test/worker.test.js test/custom-gpt-setup-docs.test.js test/mvp-gateway.test.js test/repository-nickname-registry.test.js test/custom-gpt-setup-artifacts.test.js` -> 96/96 pass
- Full regression: `npm test` -> 449/449 pass
- E2E: Not run live yet; expected next live check is Issue #125 handoff from Butler conversation.
- Evidence paths: `src/core/butler-orchestrator.js`, `src/core/remote-codex-executor.js`, `test/butler-orchestrator.test.js`, `test/worker.test.js`

## Surface Update Checklist

- Cloudflare deploy: Required after merge because runtime behavior changed.
- Custom GPT Action Schema update: Not required; no OpenAPI/schema change.
- Custom GPT Instructions update: Not required; no instruction change.
- iPhone Butler live E2E: Required after deploy. Re-test Issue #125 handoff and verify it no longer blocks on `approval must be bound to the target scope`.

## Related Constitution Rules

- Butler is context-first.
- Issue is canonical execution spec.
- Human owns GO/passkey boundaries.
- GO-tier build requires GO and scope binding, not passkey grant.

## Out-of-scope but NOT implemented

- No passkey/deploy/secret mutation.
- No merge automation.
- No Action Schema change.
- No reviewer backend redesign.
