### PR TITLE
Issue #125: derive handoff credential for Codex execution

### DIFF
--- a/src/core/butler-orchestrator.js
+++ b/src/core/butler-orchestrator.js
@@ -2,7 +2,7 @@ import { evaluateJudgmentOrder } from "./judgment-order.js";
 import { evaluateExecutionPolicy } from "./policy.js";
 import { isBoundRemoteCodexHandoff } from "./remote-codex-handoff-scope.js";
 import { evaluateSurfaceIndependence } from "./surface-independence.js";
-import { ActionType, ActorRole } from "./types.js";
+import { ActionType, ActorRole, CredentialTier } from "./types.js";
 
 /**
  * Unified Butler entrypoint for execution judgments.
@@ -26,6 +26,9 @@ export function evaluateButlerExecution(input) {
   const policyInput = {
     ...(input?.policyInput ?? {}),
     constitutionConsulted: true,
+    credential:
+      input?.policyInput?.credential ??
+      (remoteCodexHandoff ? { model: "github_app", tier: CredentialTier.EXECUTE } : undefined),
     approvalScopeMatched:
       input?.policyInput?.approvalScopeMatched === true || remoteCodexHandoff
   };

--- a/test/butler-orchestrator.test.js
+++ b/test/butler-orchestrator.test.js
@@ -238,6 +238,52 @@ test("butler orchestrator derives approval scope match from bounded remote hando
   assert.equal(result.repository, "sample-org/vtdd-v2");
 });
 
+test("butler orchestrator derives GitHub App credential from bounded remote handoff", () => {
+  const result = evaluateButlerExecution({
+    surfaceContext: {
+      surface: "custom_gpt",
+      judgmentModelId: "vtdd-butler-core-v1"
+    },
+    judgmentTrace,
+    runtimeContext: {
+      allowButlerRemoteCodexHandoff: true
+    },
+    issueContext: {
+      issueNumber: 125
+    },
+    continuationContext: {
+      requiresHandoff: true,
+      handoff: {
+        issueTraceable: true,
+        approvalScopeMatched: true,
+        relatedIssue: 125,
+        summary: "Issue #125 bounded Codex handoff"
+      }
+    },
+    policyInput: {
+      actionType: ActionType.BUILD,
+      mode: "execution",
+      repositoryInput: "vtdd",
+      aliasRegistry: registry,
+      targetConfirmed: true,
+      runtimeTruth: { runtimeAvailable: true },
+      consent: fullConsent,
+      approvalPhrase: "GO Issue #125 Codex handoff",
+      issueTraceable: true,
+      issueTraceability: {
+        relatedIssue: 125,
+        intentRefs: ["#125 Intent"],
+        successCriteriaRefs: ["#125 Success Criteria"],
+        nonGoalRefs: ["#125 Non-goals"]
+      },
+      go: true,
+      passkey: false
+    }
+  });
+  assert.equal(result.allowed, true);
+  assert.equal(result.repository, "sample-org/vtdd-v2");
+});
+
 test("butler orchestrator does not derive handoff approval from non-string summary", () => {
   const result = evaluateButlerExecution({
     surfaceContext: {

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -542,7 +542,6 @@ test("worker dispatches remote Codex execution with approval scope matched only 
               activeBranch: "codex/issue-125"
             }
           },
-          credential: { model: "github_app", tier: CredentialTier.EXECUTE },
           consent: { grantedCategories: [ConsentCategory.PROPOSE, ConsentCategory.EXECUTE] },
           approvalPhrase: "GO Issue #125 Codex handoff",
           issueTraceable: true,


### PR DESCRIPTION
## This PR satisfies Intent

Parent: #4
Related live slice: #125

Fixes the next Butler -> Codex handoff blocker after #133. A bounded remote Codex handoff should not require the Butler conversation payload to include an internal `credential.model=github_app` field. The Worker runtime supplies GitHub App execution credentials, and the execution path already fails later with explicit token errors if those runtime credentials are unavailable.

## Satisfied Success Criteria

- [x] Valid bounded remote Codex handoff derives execute-tier GitHub App credential for the policy gate.
- [x] Butler/iPhone conversation no longer needs raw credential JSON to pass the credential boundary.
- [x] Derivation is limited to validated remote Codex handoff through `vtddExecute` runtime context.
- [x] Existing negative handoff tests still block malformed/non-bound handoffs.
- [x] Existing nickname, self-parity, deploy, GitHub read/write, and remote Codex tests remain passing.

## Unsatisfied Success Criteria

None for this bounded correction. Live Butler verification is still required after merge and Cloudflare deploy.

## Non-goal violations

None.

## Verification Evidence

- Targeted: `node --test test/butler-orchestrator.test.js test/worker.test.js test/remote-codex-executor.test.js test/mvp-gateway.test.js test/repository-nickname-registry.test.js` -> 94/94 pass
- Full regression: `npm test` -> 453/453 pass
- E2E: Not run live yet; expected next live check is Issue #125 handoff from Butler conversation.
- Evidence paths: `src/core/butler-orchestrator.js`, `test/butler-orchestrator.test.js`, `test/worker.test.js`

## Surface Update Checklist

- Cloudflare deploy: Required after merge because runtime behavior changed.
- Custom GPT Action Schema update: Not required; no OpenAPI/schema change.
- Custom GPT Instructions update: Not required; no instruction change.
- iPhone Butler live E2E: Required after deploy. Re-test Issue #125 handoff and verify it no longer blocks on `credential model must be github_app`.

## Related Constitution Rules

- Butler is context-first.
- Issue is canonical execution spec.
- Human owns GO/passkey boundaries.
- GitHub App remains the canonical credential model.
- Butler users should not author internal credential JSON during normal operation.

## Out-of-scope but NOT implemented

- No passkey/deploy/secret mutation.
- No merge automation.
- No Action Schema change.
- No reviewer backend redesign.
