### PR TITLE
Issue #135: enable explicit API-backed Codex runner transport

### DIFF
--- a/docs/setup/custom-gpt-actions-openapi.json
+++ b/docs/setup/custom-gpt-actions-openapi.json
@@ -446,9 +446,29 @@
                   "relatedIssue",
                   "summary"
                 ]
+              },
+              "executorTransport": {
+                "type": "string",
+                "enum": [
+                  "codex_cloud_github_comment",
+                  "api_key_runner"
+                ]
+              },
+              "apiKeyRunnerAcknowledged": {
+                "type": "boolean"
               }
             },
             "additionalProperties": true
+          },
+          "executorTransport": {
+            "type": "string",
+            "enum": [
+              "codex_cloud_github_comment",
+              "api_key_runner"
+            ]
+          },
+          "apiKeyRunnerAcknowledged": {
+            "type": "boolean"
           }
         },
         "additionalProperties": true
@@ -749,6 +769,18 @@
             "required": false,
             "schema": {
               "type": "string"
+            }
+          },
+          {
+            "name": "executorTransport",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "codex_cloud_github_comment",
+                "api_key_runner"
+              ]
             }
           }
         ],

--- a/docs/setup/custom-gpt-actions-openapi.yaml
+++ b/docs/setup/custom-gpt-actions-openapi.yaml
@@ -149,6 +149,13 @@ components:
               type: string
             requiresHandoff:
               type: boolean
+            executorTransport:
+              type: string
+              enum:
+                - codex_cloud_github_comment
+                - api_key_runner
+            apiKeyRunnerAcknowledged:
+              type: boolean
             handoff:
               type: object
               required:
@@ -309,6 +316,13 @@ components:
             issueUrl:
               type: string
           additionalProperties: true
+        executorTransport:
+          type: string
+          enum:
+            - codex_cloud_github_comment
+            - api_key_runner
+        apiKeyRunnerAcknowledged:
+          type: boolean
       additionalProperties: true
 paths:
   /health:
@@ -726,6 +740,14 @@ paths:
           required: false
           schema:
             type: string
+        - name: executorTransport
+          in: query
+          required: false
+          schema:
+            type: string
+            enum:
+              - codex_cloud_github_comment
+              - api_key_runner
       responses:
         "200":
           description: Current execution progress

--- a/docs/setup/custom-gpt-instructions-short.md
+++ b/docs/setup/custom-gpt-instructions-short.md
@@ -7,24 +7,21 @@ Core:
 - Treat Issue as canonical execution spec.
 - Treat GitHub runtime state as current progress truth.
 - Do not assume a default repository.
-- Resolve repo target from alias/current context first.
-- If repo intent is ambiguous, ask a short confirmation.
+- Resolve repo from alias/current context first.
+- If repo ambiguous, ask short confirmation.
 - Do not ask users to type internal API paths/raw JSON unless debugging.
 - Convert natural language into action calls yourself.
-- Do not invent scope beyond the active Issue or explicit user instruction.
+- Do not invent scope beyond active Issue/user instruction.
 - For vtddGateway/vtddExecute, use surface=custom_gpt, judgmentModelId=vtdd-butler-core-v1.
 
 Role separation:
 - Butler reads/judges/summarizes. Codex codes/PRs. Reviewer critiques. Human owns GO/passkey.
 
-Self-reference:
-- `君`/`自分`/`Butler`/`VTDD`/`このGPT` means this Butler unless another target is named.
-
 Repository listing and nickname memory:
 - For repository candidates/list, call vtddGateway in exploration mode.
-- Use exploration/read/read_only, repositoryInput=unknown, targetConfirmed=false, runtimeAvailable=false, safeFallbackChosen=true, consent=["read"].
-- To remember a repo nickname, use vtddUpsertRepositoryNickname.
-- To list repo nicknames, use vtddRetrieveRepositoryNicknames.
+- Repo list read: exploration/read_only, repositoryInput=unknown, targetConfirmed=false, runtimeAvailable=false, safeFallbackChosen=true, consent=["read"].
+- Remember repo nickname: vtddUpsertRepositoryNickname.
+- List repo nicknames: vtddRetrieveRepositoryNicknames.
 - If request starts with non-owner/repo token like `ぶい の...`, call nickname read/gateway before asking.
 - Nickname memory is user-owned alias data, not a default repo; if ambiguous, ask.
 - Nickname read failure is not proof of unknown repo. If conversation has a known mapping or approvalGrant.scope.repositoryInput, use that owner/repo as unverified fallback and verify by next read/action.
@@ -32,19 +29,16 @@ Repository listing and nickname memory:
 - If Action returns `ClientResponseError`, state action, visible HTTP/body, and missing error/reason/issues.
 
 GitHub read plane:
-- Use vtddRetrieveGitHub for repos, issues, PRs, reviews, comments, checks, workflow_runs, branches.
+- Use vtddRetrieveGitHub for repos, issues, PRs, reviews, comments, checks, runs, branches.
 - Prefer vtddRetrieveGitHub over speculation.
 - If the route is unsupported, say 未対応 for that exact read.
 - If auth fails, say 認証失敗.
 - Do not infer absence from unsupported or failed reads.
 
 Self-parity:
-- If user asks whether Butler is stale, outdated, old, reflected, or aligned, use vtddRetrieveSelfParity.
-- Prefer vtddRetrieveSelfParity over capability disclaimers.
-- Before first significant GitHub/runtime action, you may run vtddRetrieveSelfParity.
-- Use vtddRetrieveSelfParity with repository=<resolved repo> and ref=main unless another ref is intended.
+- For stale/outdated/reflected/aligned checks, use vtddRetrieveSelfParity, repository=<resolved repo>, ref=main.
 - If runtimeParity is `cloudflare_deploy_update_required`, say `Cloudflare deploy update required`.
-- If in_sync but Butler lacks expected features, say `Action Schema update required` and/or `Instructions update required`.
+- If in_sync but Butler lacks features, say `Action Schema update required` and/or `Instructions update required`.
 - If parity cannot be checked, say `未検証` or `認証失敗`.
 - If action returns error/reason/issues, summarize exact fields in Japanese; do not mask with generic guesses.
 - If self-parity returns `ClientResponseError`, say unverified Action transport failure; Action Schema may need refresh.
@@ -54,7 +48,7 @@ Self-parity:
 Execution judgment:
 - Before execution, read runtime truth through vtddGateway; do not ask vtddGateway to execute `build`.
 - Schema: build only under vtddExecute, not vtddGateway.
-- judgmentTrace first four steps must be exactly: constitution, runtime_truth, issue_context, current_query. Put Issue reads/contract/GO in rationale, not new step names.
+- judgmentTrace first four steps must be exactly: constitution, runtime_truth, issue_context, current_query. Put reads/contract/GO in rationale.
 - No constitutionConsulted input; constitution-first trace satisfies policy.
 - If the target repository is unresolved, do not execute.
 - Read-only exploration may proceed without a resolved repository only when policy allows it.
@@ -62,6 +56,9 @@ Execution judgment:
 Remote Codex flow:
 - Use vtddExecute only for bounded Butler -> Codex handoff.
 - vtddExecute handoff: actionType=build; requiresHandoff=true; relatedIssue=issue; include issueTraceability Intent/SC/Non-goal refs; issueTraceable/approvalScopeMatched=true.
+- Default transport is codex_cloud_github_comment; queued comment is delegation evidence, not execution evidence.
+- Paid/API approval: set executorTransport=api_key_runner and apiKeyRunnerAcknowledged=true on vtddExecute; uses OPENAI_API_KEY.
+- api_key_runner: report workflowRunId/workflowUrl/workflowConclusion; if OPENAI_API_KEY missing, surface workflow failure, no silent fallback.
 - Preserve repo, issue, branch, base, codex goal, bounded scope, and non-goals.
 - Preferred goals: open_pr, revise_pr, respond_to_review.
 
@@ -73,7 +70,7 @@ GitHub normal write plane:
   - pull comment create
 - For issue_create, fix title+body, bind GO to that payload, call vtddWriteGitHub with responseMode=action_visible; do not ask for policyInput/judgmentTrace.
 - Only when repository is resolved, scope is issue-traceable, and GO exists.
-- Do not use vtddWriteGitHub for merge, issue close, deploy, secret/settings/permission mutation, or destructive cleanup.
+- Do not use vtddWriteGitHub for merge, issue close, deploy, secret/settings/permission mutation, destructive cleanup.
 
 GitHub high-risk authority plane:
 - Use vtddGitHubAuthority for actions requiring GO + real passkey:
@@ -90,15 +87,16 @@ Deploy plane:
   - explicit GO
   - real passkey approval grant scoped to deploy_production
 - If pasted approval JSON has approvalGrant.scope.repositoryInput, use that owner/repo as deploy target candidate; deploy route validates scope.
-- If no deploy approval grant exists, show selfParity.deployOperatorMarkdownLink; fallback: `[Open deploy operator](<actual selfParity.deployOperatorUrl>)`; never a raw `/v2/approval/passkey/operator...` or bare URL.
+- If no deploy grant, show selfParity.deployOperatorMarkdownLink; fallback `[Open deploy operator](<actual selfParity.deployOperatorUrl>)`, never a raw `/v2/approval/passkey/operator...`, no bare URL.
 - Stale fallback: selfParity.deployRecovery.operatorMarkdownLink or operatorUrl. Href needs phase=execution, actionType=deploy_production, highRiskKind=deploy_production.
-- If deploy URL is requested while in_sync, show selfParity.deployOperatorMarkdownLink; fallback: Markdown link with selfParity.deployOperatorUrl as href. Do not block because deployRecovery is null.
+- If deploy URL requested while in_sync, show selfParity.deployOperatorMarkdownLink or selfParity.deployOperatorUrl as Markdown link; deployRecovery null is OK.
 - After vtddDeployProduction, say deploy dispatched, then re-check self-parity before claiming runtime updated.
 - If vtddDeployProduction fails, say the exact deploy error/reason/issues and blocker category.
 - If fallback says openai_api_key_not_configured, never ask for OPENAI_API_KEY in chat; use vtddSyncGitHubActionsSecret via operator URL.
 
 Progress tracking:
 - After vtddExecute, always call vtddExecutionProgress.
+- For api_key_runner, include executorTransport=api_key_runner in vtddExecutionProgress.
 - Use executionId, repository, issueNumber, and branch.
 - Do not claim PR creation is complete unless GitHub runtime truth actually shows the PR.
 
@@ -124,6 +122,6 @@ Forbidden behavior:
 - Do not merge, deploy, mutate secrets, or perform destructive actions on your own.
 
 Response style:
-- Be concise, factual, and Japanese-first.
+- Be concise and Japanese-first.
 - Separate what is confirmed, what is missing, and the next safe action.
 - If something is unverified, say so instead of guessing.

--- a/docs/setup/custom-gpt-instructions.md
+++ b/docs/setup/custom-gpt-instructions.md
@@ -177,6 +177,9 @@ Execution judgment:
 Remote Codex flow:
 - Use vtddExecute only when Butler is intentionally handing bounded work to remote Codex.
 - For vtddExecute Codex handoff, use `policyInput.actionType=build` only inside the vtddExecute call when `continuationContext.requiresHandoff=true`, `continuationContext.handoff.relatedIssue` matches `issueContext.issueNumber`, `policyInput.issueTraceability` includes real Intent / Success Criteria / Non-goals refs from the Issue, and `handoff.issueTraceable=true` plus `approvalScopeMatched=true`; this is a bounded transfer to Codex, not Butler doing build work.
+- Default transport is `codex_cloud_github_comment`. A queued comment proves delegation was posted, but it does not prove Codex execution, branch creation, or PR creation.
+- When the human explicitly approves the API-backed runner/cost path, set `executorTransport=api_key_runner` and `apiKeyRunnerAcknowledged=true` on `vtddExecute`. This uses `OPENAI_API_KEY` and is a no-extra-cost default deviation.
+- Do not silently fall back from `api_key_runner` to comment transport. If the workflow or `OPENAI_API_KEY` is missing, surface the workflow failure/blocker and run URL when available.
 - When handing off, preserve:
   - repository
   - issue number
@@ -260,6 +263,7 @@ GitHub Actions secret sync:
 
 Progress tracking:
 - After vtddExecute, always call vtddExecutionProgress.
+- For `api_key_runner`, include `executorTransport=api_key_runner` in vtddExecutionProgress.
 - Use executionId, repository, issueNumber, and branch.
 - If progress shows no PR yet, say clearly that GitHub PR is not yet published.
 - Do not claim PR creation is complete unless GitHub runtime truth actually shows the PR.

--- a/src/core/remote-codex-executor.js
+++ b/src/core/remote-codex-executor.js
@@ -121,8 +121,17 @@ export async function dispatchRemoteCodexExecution(input = {}) {
     };
   }
 
-  const transport = resolveExecutorTransport(input);
-  if (transport === RemoteCodexExecutorTransport.CODEX_CLOUD_GITHUB_COMMENT) {
+  const transport = resolveExecutorTransport(input, { requireRequestAcknowledgment: true });
+  if (!transport.ok) {
+    return {
+      ok: false,
+      status: 422,
+      error: transport.error,
+      reason: transport.reason,
+      issues: transport.issues
+    };
+  }
+  if (transport.value === RemoteCodexExecutorTransport.CODEX_CLOUD_GITHUB_COMMENT) {
     return dispatchCodexCloudGitHubComment({ request, token: token.value, env: input?.env });
   }
 
@@ -195,10 +204,17 @@ async function dispatchApiBackedWorkflow({ request, token, env }) {
     };
   }
 
+  const progress = await retrieveApiBackedWorkflowProgress({
+    executionId: request.executionId,
+    token,
+    env
+  });
+
   return {
     ok: true,
     execution: {
       executionId: request.executionId,
+      transport: RemoteCodexExecutorTransport.API_KEY_RUNNER,
       controlRepository,
       workflowFile,
       workflowRef,
@@ -208,6 +224,15 @@ async function dispatchApiBackedWorkflow({ request, token, env }) {
       baseRef: request.baseRef,
       codexGoal: request.codexGoal,
       approvalScopeMatched: request.approvalScopeMatched,
+      workflowRunId: progress.ok ? progress.progress.workflowRunId : null,
+      workflowUrl: progress.ok ? progress.progress.workflowUrl : null,
+      workflowConclusion: progress.ok ? progress.progress.conclusion : null,
+      progressLookup: progress.ok
+        ? null
+        : {
+            error: progress.error,
+            reason: progress.reason
+          },
       status: RemoteCodexExecutionStatus.QUEUED
     }
   };
@@ -234,8 +259,17 @@ export async function retrieveRemoteCodexExecutionProgress(input = {}) {
     };
   }
 
-  const transport = resolveExecutorTransport(input);
-  if (transport === RemoteCodexExecutorTransport.CODEX_CLOUD_GITHUB_COMMENT) {
+  const transport = resolveExecutorTransport(input, { requireRequestAcknowledgment: false });
+  if (!transport.ok) {
+    return {
+      ok: false,
+      status: 422,
+      error: transport.error,
+      reason: transport.reason,
+      issues: transport.issues
+    };
+  }
+  if (transport.value === RemoteCodexExecutorTransport.CODEX_CLOUD_GITHUB_COMMENT) {
     return retrieveCodexCloudGitHubCommentProgress({
       executionId,
       repository: normalizeText(input?.repository),
@@ -544,14 +578,31 @@ function buildCodexCloudGitHubComment({ request }) {
   return lines.join("\n");
 }
 
-function resolveExecutorTransport(input = {}) {
-  const value = normalizeText(
-    input?.executorTransport ?? input?.env?.REMOTE_CODEX_EXECUTOR_TRANSPORT
+function resolveExecutorTransport(input = {}, options = {}) {
+  const requestValue = normalizeText(
+    input?.executorTransport ??
+      input?.payload?.executorTransport ??
+      input?.payload?.continuationContext?.executorTransport
   );
+  const envValue = normalizeText(input?.env?.REMOTE_CODEX_EXECUTOR_TRANSPORT);
+  const value = requestValue || envValue;
   if (value === RemoteCodexExecutorTransport.API_KEY_RUNNER) {
-    return RemoteCodexExecutorTransport.API_KEY_RUNNER;
+    const requestSelected = requestValue === RemoteCodexExecutorTransport.API_KEY_RUNNER;
+    const acknowledged =
+      input?.apiKeyRunnerAcknowledged === true ||
+      input?.payload?.apiKeyRunnerAcknowledged === true ||
+      input?.payload?.continuationContext?.apiKeyRunnerAcknowledged === true;
+    if (requestSelected && options.requireRequestAcknowledgment !== false && !acknowledged) {
+      return {
+        ok: false,
+        error: "api_key_runner_approval_required",
+        reason: "api_key_runner requires explicit human approval because it uses OPENAI_API_KEY",
+        issues: ["api_key_runner_acknowledgment_required"]
+      };
+    }
+    return { ok: true, value: RemoteCodexExecutorTransport.API_KEY_RUNNER };
   }
-  return RemoteCodexExecutorTransport.CODEX_CLOUD_GITHUB_COMMENT;
+  return { ok: true, value: RemoteCodexExecutorTransport.CODEX_CLOUD_GITHUB_COMMENT };
 }
 
 function githubJsonHeaders({ token }) {

--- a/src/worker.js
+++ b/src/worker.js
@@ -254,6 +254,7 @@ export default {
         repository: url.searchParams.get("repository"),
         issueNumber: url.searchParams.get("issueNumber"),
         branch: url.searchParams.get("branch"),
+        executorTransport: url.searchParams.get("executorTransport"),
         env
       });
       if (!progress.ok) {

--- a/test/remote-codex-executor.test.js
+++ b/test/remote-codex-executor.test.js
@@ -195,6 +195,7 @@ test("remote Codex execution mints GitHub App installation token from worker run
 
 test("remote Codex API-backed execution dispatch posts workflow_dispatch to GitHub", async () => {
   const calls = [];
+  let executionId = "";
   const dispatched = await dispatchRemoteCodexExecution({
     payload: {
       actorRole: ActorRole.BUTLER,
@@ -222,6 +223,30 @@ test("remote Codex API-backed execution dispatch posts workflow_dispatch to GitH
       GITHUB_APP_INSTALLATION_TOKEN: "ghs_dispatch_token",
       GITHUB_API_FETCH: async (url, init) => {
         calls.push({ url, init });
+        if (String(url).includes("/dispatches")) {
+          executionId = JSON.parse(init.body).inputs.execution_id;
+          return new Response(null, { status: 204 });
+        }
+        if (String(url).includes("/runs")) {
+          return new Response(
+            JSON.stringify({
+              workflow_runs: [
+                {
+                  id: 101,
+                  name: "remote-codex-executor",
+                  display_title: executionId,
+                  html_url: "https://github.com/sample-org/vtdd-v2-p/actions/runs/101",
+                  status: "queued",
+                  conclusion: null,
+                  head_branch: "main",
+                  run_started_at: "2026-04-24T08:00:00Z",
+                  updated_at: "2026-04-24T08:01:00Z"
+                }
+              ]
+            }),
+            { status: 200, headers: { "content-type": "application/json" } }
+          );
+        }
         return new Response(null, { status: 204 });
       }
     }
@@ -229,9 +254,47 @@ test("remote Codex API-backed execution dispatch posts workflow_dispatch to GitH
 
   assert.equal(dispatched.ok, true);
   assert.equal(dispatched.execution.status, RemoteCodexExecutionStatus.QUEUED);
-  assert.equal(calls.length, 1);
+  assert.equal(dispatched.execution.transport, RemoteCodexExecutorTransport.API_KEY_RUNNER);
+  assert.equal(dispatched.execution.workflowRunId, 101);
+  assert.equal(dispatched.execution.workflowUrl, "https://github.com/sample-org/vtdd-v2-p/actions/runs/101");
+  assert.equal(calls.length, 2);
   assert.equal(calls[0].url.includes("/actions/workflows/remote-codex-executor.yml/dispatches"), true);
   assert.equal(calls[0].init.method, "POST");
+  assert.equal(calls[1].url.includes("/actions/workflows/remote-codex-executor.yml/runs"), true);
+});
+
+test("remote Codex API-backed execution requires explicit request acknowledgment", async () => {
+  const dispatched = await dispatchRemoteCodexExecution({
+    payload: {
+      actorRole: ActorRole.BUTLER,
+      executorTransport: RemoteCodexExecutorTransport.API_KEY_RUNNER,
+      issueContext: { issueNumber: 6 },
+      policyInput: {
+        approvalPhrase: "GO",
+        targetConfirmed: true,
+        approvalScopeMatched: true,
+        runtimeTruth: {
+          runtimeState: {
+            activeBranch: "codex/issue-6"
+          }
+        }
+      }
+    },
+    gatewayResult: {
+      repository: "sample-org/vtdd-v2",
+      executionContinuity: {
+        codexGoal: "open_pr"
+      }
+    },
+    env: {
+      VTDD_GITHUB_ACTIONS_REPOSITORY: "sample-org/vtdd-v2-p",
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_dispatch_token"
+    }
+  });
+
+  assert.equal(dispatched.ok, false);
+  assert.equal(dispatched.status, 422);
+  assert.equal(dispatched.error, "api_key_runner_approval_required");
 });
 
 test("remote Codex API-backed execution progress reads matching workflow run", async () => {

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -596,6 +596,121 @@ test("worker dispatches remote Codex execution with approval scope matched only 
   assert.equal(calls.length, 2);
 });
 
+test("worker dispatches API-backed remote Codex execution when explicitly selected", async () => {
+  const calls = [];
+  let executionId = "";
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/action/execute", {
+      method: "POST",
+      headers: gatewayAuthHeaders,
+      body: JSON.stringify({
+        phase: "execution",
+        actorRole: ActorRole.BUTLER,
+        executorTransport: "api_key_runner",
+        apiKeyRunnerAcknowledged: true,
+        surfaceContext: {
+          surface: "custom_gpt",
+          judgmentModelId: "vtdd-butler-core-v1"
+        },
+        judgmentTrace: validButlerJudgmentTrace,
+        issueContext: {
+          issueNumber: 135
+        },
+        continuationContext: {
+          requiresHandoff: true,
+          handoff: {
+            issueTraceable: true,
+            approvalScopeMatched: true,
+            relatedIssue: 135,
+            summary: "Issue #135 bounded remote Codex handoff"
+          }
+        },
+        policyInput: {
+          actionType: ActionType.BUILD,
+          mode: TaskMode.EXECUTION,
+          repositoryInput: "vtdd",
+          aliasRegistry,
+          targetConfirmed: true,
+          runtimeTruth: {
+            runtimeAvailable: true,
+            runtimeState: {
+              activeBranch: "codex/issue-135"
+            }
+          },
+          consent: { grantedCategories: [ConsentCategory.PROPOSE, ConsentCategory.EXECUTE] },
+          approvalPhrase: "GO",
+          issueTraceable: true,
+          issueTraceability: {
+            relatedIssue: 135,
+            intentRefs: ["#135 Intent"],
+            successCriteriaRefs: ["#135 Success Criteria"],
+            nonGoalRefs: ["#135 Non-goals"]
+          },
+          go: true,
+          passkey: false
+        }
+      })
+    }),
+    {
+      ...gatewayAuthEnv,
+      VTDD_GITHUB_ACTIONS_REPOSITORY: "sample-org/vtdd-v2-p",
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_dispatch_token",
+      GITHUB_API_FETCH: async (url, init) => {
+        calls.push({ url, init });
+        if (String(url).includes("/installation/repositories")) {
+          return new Response(
+            JSON.stringify({
+              total_count: 1,
+              repositories: [
+                {
+                  full_name: "sample-org/vtdd-v2",
+                  name: "vtdd-v2",
+                  private: true
+                }
+              ]
+            }),
+            { status: 200, headers: { "content-type": "application/json" } }
+          );
+        }
+        if (String(url).includes("/dispatches")) {
+          executionId = JSON.parse(init.body).inputs.execution_id;
+          return new Response(null, { status: 204 });
+        }
+        if (String(url).includes("/runs")) {
+          return new Response(
+            JSON.stringify({
+              workflow_runs: [
+                {
+                  id: 135101,
+                  name: "remote-codex-executor",
+                  display_title: executionId,
+                  html_url: "https://github.com/sample-org/vtdd-v2-p/actions/runs/135101",
+                  status: "queued",
+                  conclusion: null,
+                  head_branch: "main",
+                  run_started_at: "2026-04-29T10:00:00Z",
+                  updated_at: "2026-04-29T10:00:01Z"
+                }
+              ]
+            }),
+            { status: 200, headers: { "content-type": "application/json" } }
+          );
+        }
+        throw new Error(`unexpected url ${url}`);
+      }
+    }
+  );
+
+  assert.equal(response.status, 202);
+  const body = await response.json();
+  assert.equal(body.ok, true);
+  assert.equal(body.execution.issueNumber, 135);
+  assert.equal(body.execution.transport, "api_key_runner");
+  assert.equal(body.execution.workflowRunId, 135101);
+  assert.equal(body.execution.workflowUrl, "https://github.com/sample-org/vtdd-v2-p/actions/runs/135101");
+  assert.equal(calls.length, 3);
+});
+
 test("worker gateway rejects self-asserted Butler build handoff", async () => {
   const response = await worker.fetch(
     new Request("https://example.com/v2/gateway", {


### PR DESCRIPTION
## This PR satisfies Intent

Fixes #135.

This PR makes the Issue #135 transport choice real: Butler/vtddExecute can explicitly select the existing workflow_dispatch-backed Codex runner with `executorTransport=api_key_runner` and `apiKeyRunnerAcknowledged=true`. The default remains `codex_cloud_github_comment`.

## Satisfied Success Criteria

- Distinguish queued comment transport from execution evidence: satisfied by docs/instructions plus workflow evidence fields.
- workflow_dispatch/api_key_runner can be selected: satisfied by `executorTransport=api_key_runner`.
- OPENAI_API_KEY/cost boundary is explicit: satisfied by `apiKeyRunnerAcknowledged=true` requirement.
- Run URL/conclusion is readable: dispatch and progress return workflow run fields when GitHub exposes the run.
- Branch/PR or workflow failure remains the runtime truth: instructions require reporting workflow failure/blocker instead of silent fallback.
- No default paid runner switch: default remains comment transport.

## Unsatisfied Success Criteria

None for this bounded implementation.

Live E2E remains required after merge, deploy, Action Schema update, and Instruction update.

## Changed

- Runtime: request-level `api_key_runner` selection now dispatches the existing `.github/workflows/remote-codex-executor.yml` workflow instead of silently falling back to comment transport.
- Runtime: request-level `api_key_runner` is blocked unless explicitly acknowledged because it uses `OPENAI_API_KEY`.
- Runtime: API-backed dispatch returns observable workflow evidence when available: `workflowRunId`, `workflowUrl`, and `workflowConclusion`.
- Progress: `vtddExecutionProgress` accepts `executorTransport=api_key_runner` for workflow-backed progress lookup.
- Custom GPT Action Schema and Instructions document the explicit transport, acknowledgment, and evidence expectations.

## Non-goals

- No new workflow.
- No secret value in chat.
- No default switch to paid runner.
- No merge, deploy, or reviewer backend redesign.

## Verification Evidence

- Targeted: `node --test test/remote-codex-executor.test.js test/worker.test.js test/custom-gpt-setup-docs.test.js test/custom-gpt-setup-artifacts.test.js` -> 78/78 pass.
- Full regression: `npm test` -> 455/455 pass.
- Reviewer evidence: Gemini comment recommends approve; risks are operational/update reminders, not blockers.

## Surface Update Checklist

After merge:

- Cloudflare deploy: required, runtime changed.
- Custom GPT Action Schema update: required, execute/progress schema changed.
- Custom GPT Instructions update: required, Butler behavior changed.
- Live Butler E2E: required after deploy/schema/instruction update. Expected result is either workflow run evidence or explicit workflow failure, not queued-only comment evidence.
