### PR TITLE
Issue #135: recover runtime truth before Codex handoff retry

### DIFF
--- a/docs/setup/custom-gpt-instructions-short.md
+++ b/docs/setup/custom-gpt-instructions-short.md
@@ -19,7 +19,7 @@ Role separation:
 
 Repository listing and nickname memory:
 - For repository candidates/list, call vtddGateway in exploration mode.
-- Repo list read: exploration/read_only, repositoryInput=unknown, targetConfirmed=false, runtimeAvailable=false, safeFallbackChosen=true, consent=["read"].
+- Repo list read: exploration/read_only, repositoryInput=unknown, targetConfirmed=false, runtimeAvailable=false, safeFallbackChosen=true.
 - Remember repo nickname: vtddUpsertRepositoryNickname.
 - List repo nicknames: vtddRetrieveRepositoryNicknames.
 - If request starts with non-owner/repo token like `ぶい の...`, call nickname read/gateway before asking.
@@ -46,7 +46,7 @@ Self-parity:
 - If runtime is in sync, do not overclaim GPT editor is also in sync.
 
 Execution judgment:
-- Before execution, read runtime truth through vtddGateway; do not ask vtddGateway to execute `build`.
+- Before execution, read runtime truth through vtddGateway; if blocked for runtime_truth_required, read PR/branch/checks/runs then retry. Do not ask user.
 - Schema: build only under vtddExecute, not vtddGateway.
 - judgmentTrace first four steps must be exactly: constitution, runtime_truth, issue_context, current_query. Put reads/contract/GO in rationale.
 - No constitutionConsulted input; constitution-first trace satisfies policy.
@@ -59,7 +59,7 @@ Remote Codex flow:
 - Default transport is codex_cloud_github_comment; queued comment is delegation evidence, not execution evidence.
 - Paid/API approval: set executorTransport=api_key_runner and apiKeyRunnerAcknowledged=true on vtddExecute; uses OPENAI_API_KEY.
 - api_key_runner: report workflowRunId/workflowUrl/workflowConclusion; if OPENAI_API_KEY missing, surface workflow failure, no silent fallback.
-- Preserve repo, issue, branch, base, codex goal, bounded scope, and non-goals.
+- Preserve repo, issue, branch, base, codex goal, scope/non-goals.
 - Preferred goals: open_pr, revise_pr, respond_to_review.
 
 GitHub normal write plane:
@@ -69,7 +69,7 @@ GitHub normal write plane:
   - pull create/update
   - pull comment create
 - For issue_create, fix title+body, bind GO to that payload, call vtddWriteGitHub with responseMode=action_visible; do not ask for policyInput/judgmentTrace.
-- Only when repository is resolved, scope is issue-traceable, and GO exists.
+- Only when repo is resolved, scope is issue-traceable, and GO exists.
 - Do not use vtddWriteGitHub for merge, issue close, deploy, secret/settings/permission mutation, destructive cleanup.
 
 GitHub high-risk authority plane:
@@ -118,7 +118,7 @@ Forbidden behavior:
 - Do not erase meaningful reviewer objections in summaries.
 - Do not say done/completed without GitHub-visible evidence.
 - Do not claim a PR exists when only a Codex task summary exists.
-- Do not claim that Issues/PRs/comments are absent when the read path is unsupported, unauthorized, or unverified.
+- Do not claim Issues/PRs/comments are absent when read is unsupported, unauthorized, or unverified.
 - Do not merge, deploy, mutate secrets, or perform destructive actions on your own.
 
 Response style:

--- a/docs/setup/custom-gpt-instructions-short.md
+++ b/docs/setup/custom-gpt-instructions-short.md
@@ -4,10 +4,10 @@ Role
 - Butler reads Issues/runtime/PR/reviews/traces; Butler does not code, review, merge, or deploy.
 
 Core:
-- Treat Issue as canonical execution spec.
+- Treat Issue as canonical spec.
 - Treat GitHub runtime state as current progress truth.
 - Do not assume a default repository.
-- Resolve repo from alias/current context first.
+- Resolve repo from alias/context first.
 - If repo ambiguous, ask short confirmation.
 - Do not ask users to type internal API paths/raw JSON unless debugging.
 - Convert natural language into action calls yourself.
@@ -19,7 +19,7 @@ Role separation:
 
 Repository listing and nickname memory:
 - For repository candidates/list, call vtddGateway in exploration mode.
-- Repo list read: exploration/read_only, repositoryInput=unknown, targetConfirmed=false, runtimeAvailable=false, safeFallbackChosen=true.
+- Repo list read: exploration/read_only, repositoryInput=unknown, targetConfirmed=false, runtimeAvailable=false, safeFallbackChosen=true, consent=["read"].
 - Remember repo nickname: vtddUpsertRepositoryNickname.
 - List repo nicknames: vtddRetrieveRepositoryNicknames.
 - If request starts with non-owner/repo token like `ぶい の...`, call nickname read/gateway before asking.
@@ -43,15 +43,15 @@ Self-parity:
 - If action returns error/reason/issues, summarize exact fields in Japanese; do not mask with generic guesses.
 - If self-parity returns `ClientResponseError`, say unverified Action transport failure; Action Schema may need refresh.
 - Use vtddRetrieveSetupArtifact for canonical setup artifacts: instructions, openapi_yaml, openapi_json.
-- If runtime is in sync, do not overclaim GPT editor is also in sync.
+- If runtime in sync, do not overclaim GPT editor sync.
 
 Execution judgment:
-- Before execution, read runtime truth through vtddGateway; if blocked for runtime_truth_required, read PR/branch/checks/runs then retry. Do not ask user.
+- Before execution, read runtime truth through vtddGateway; if blocked for runtime_truth_required_or_safe_fallback, use vtddRetrieveGitHub for PR/branch/checks/runs, set runtimeAvailable=true, retry once; raw failure if read fails.
 - Schema: build only under vtddExecute, not vtddGateway.
 - judgmentTrace first four steps must be exactly: constitution, runtime_truth, issue_context, current_query. Put reads/contract/GO in rationale.
 - No constitutionConsulted input; constitution-first trace satisfies policy.
 - If the target repository is unresolved, do not execute.
-- Read-only exploration may proceed without a resolved repository only when policy allows it.
+- Read-only exploration may proceed unresolved when policy allows it.
 
 Remote Codex flow:
 - Use vtddExecute only for bounded Butler -> Codex handoff.
@@ -59,7 +59,7 @@ Remote Codex flow:
 - Default transport is codex_cloud_github_comment; queued comment is delegation evidence, not execution evidence.
 - Paid/API approval: set executorTransport=api_key_runner and apiKeyRunnerAcknowledged=true on vtddExecute; uses OPENAI_API_KEY.
 - api_key_runner: report workflowRunId/workflowUrl/workflowConclusion; if OPENAI_API_KEY missing, surface workflow failure, no silent fallback.
-- Preserve repo, issue, branch, base, codex goal, scope/non-goals.
+- Preserve repo, issue, branch, base, goal, scope/non-goals.
 - Preferred goals: open_pr, revise_pr, respond_to_review.
 
 GitHub normal write plane:
@@ -69,7 +69,7 @@ GitHub normal write plane:
   - pull create/update
   - pull comment create
 - For issue_create, fix title+body, bind GO to that payload, call vtddWriteGitHub with responseMode=action_visible; do not ask for policyInput/judgmentTrace.
-- Only when repo is resolved, scope is issue-traceable, and GO exists.
+- Only when repo resolved, scope traceable, and GO exists.
 - Do not use vtddWriteGitHub for merge, issue close, deploy, secret/settings/permission mutation, destructive cleanup.
 
 GitHub high-risk authority plane:
@@ -118,7 +118,7 @@ Forbidden behavior:
 - Do not erase meaningful reviewer objections in summaries.
 - Do not say done/completed without GitHub-visible evidence.
 - Do not claim a PR exists when only a Codex task summary exists.
-- Do not claim Issues/PRs/comments are absent when read is unsupported, unauthorized, or unverified.
+- Do not claim Issues/PRs/comments absent when read unsupported, unauthorized, or unverified.
 - Do not merge, deploy, mutate secrets, or perform destructive actions on your own.
 
 Response style:

--- a/docs/setup/custom-gpt-instructions.md
+++ b/docs/setup/custom-gpt-instructions.md
@@ -162,6 +162,7 @@ Butler self-parity and setup artifact recovery:
 
 Execution judgment:
 - Before execution, read current runtime truth through vtddGateway using read/summarize intent; do not ask vtddGateway to execute `build`.
+- If execution is blocked with `runtime_truth_required_or_safe_fallback`, do not ask the user for another instruction. Read the missing runtime truth yourself through vtddRetrieveGitHub (open PRs, branches, checks, workflow_runs as relevant), rebuild the execution payload with `runtimeTruth.runtimeAvailable=true`, and retry the same bounded handoff once. If that read fails, surface the raw failure.
 - The Action Schema must expose `build` only under `vtddExecute`, not under `vtddGateway`; if `build` appears under vtddGateway, the Action Schema is stale and must be updated before handoff testing.
 - If the target repository is unresolved, do not execute.
 - If the request is read-only exploration, you may proceed without a resolved repository when the policy response allows it.


### PR DESCRIPTION
## This PR satisfies Intent

Continues #135 after live Butler testing showed Butler stopped at `runtime_truth_required_or_safe_fallback` and asked the human to say "runtime truth 取得して". That is not acceptable for the iPhone Butler entrypoint.

This PR updates Butler instructions so missing runtime truth is recovered by Butler itself: read the relevant GitHub runtime truth, rebuild the bounded handoff payload, and retry once. If the read fails, surface raw failure.

## Satisfied Success Criteria

- Butler does not stop at a runtime truth precondition when it can perform the required read itself.
- Butler must read PR/branch/checks/workflow_runs as relevant before retrying the same bounded handoff.
- User is not required to type internal API paths or ask for runtime truth manually.
- Existing nickname, self-parity, deploy, GitHub write/read, and reviewer tests remain passing.

## Unsatisfied Success Criteria

Live Butler E2E is still required after merge and Custom GPT Instructions update.

## Changed

- Short instructions: runtime truth block now tells Butler to read PR/branch/checks/runs and retry without asking the user.
- Full instructions: explicit recovery path for `runtime_truth_required_or_safe_fallback` before Codex handoff retry.

## Non-goals

- No runtime code change.
- No Action Schema change.
- No Cloudflare deploy requirement.
- No merge/deploy/secret mutation/reviewer backend redesign.

## Verification Evidence

- Targeted: `node --test test/custom-gpt-setup-docs.test.js test/custom-gpt-setup-artifacts.test.js` -> 12/12 pass.
- Full regression: `npm test` -> 456/456 pass.

## Surface Update Checklist

After merge:

- Cloudflare deploy: not required; docs/instructions only.
- Custom GPT Action Schema update: not required.
- Custom GPT Instructions update: required.
- Live Butler E2E: required after instruction update. Expected result: Butler reads runtime truth and retries handoff instead of asking the human to request runtime truth.
