### PR TITLE
Issue #135: normalize natural Codex handoff GO

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -1170,12 +1170,30 @@ function normalizeRemoteCodexHandoffPayload(payload) {
     policyInput.issueTraceability && typeof policyInput.issueTraceability === "object"
       ? policyInput.issueTraceability
       : {};
+  const consent =
+    policyInput.consent && typeof policyInput.consent === "object" ? policyInput.consent : {};
+  const grantedCategories = Array.isArray(consent.grantedCategories)
+    ? consent.grantedCategories
+    : [];
+  const goGranted = policyInput.go === true;
+  const normalizedGrantedCategories = goGranted
+    ? mergeGrantedConsentCategories(grantedCategories, ["read", "propose", "execute"])
+    : grantedCategories;
+  const requestedExecutorTransport = normalizeText(
+    payload?.executorTransport ?? continuationContext.executorTransport
+  );
+  const apiKeyRunnerAcknowledged =
+    payload?.apiKeyRunnerAcknowledged === true ||
+    continuationContext.apiKeyRunnerAcknowledged === true ||
+    (goGranted && requestedExecutorTransport === "api_key_runner");
 
   return {
     ...payload,
+    apiKeyRunnerAcknowledged,
     continuationContext: {
       ...continuationContext,
       requiresHandoff: true,
+      apiKeyRunnerAcknowledged,
       handoff: {
         ...handoff,
         issueTraceable: handoff.issueTraceable === false ? false : true,
@@ -1189,6 +1207,11 @@ function normalizeRemoteCodexHandoffPayload(payload) {
     policyInput: {
       ...policyInput,
       issueTraceable: policyInput.issueTraceable === false ? false : true,
+      consent: {
+        ...consent,
+        grantedCategories: normalizedGrantedCategories
+      },
+      approvalPhrase: normalizeText(policyInput.approvalPhrase) || (goGranted ? "GO" : ""),
       issueTraceability: {
         ...issueTraceability,
         relatedIssue: normalizeIssue(issueTraceability.relatedIssue) ?? issueNumber,
@@ -1201,6 +1224,21 @@ function normalizeRemoteCodexHandoffPayload(payload) {
       }
     }
   };
+}
+
+function mergeGrantedConsentCategories(current, required) {
+  const seen = new Set();
+  const merged = [];
+  for (const category of [...current, ...required]) {
+    const text = normalizeText(category);
+    const key = normalize(text);
+    if (!text || seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    merged.push(text);
+  }
+  return merged;
 }
 
 function normalizeTraceRefs(value, fallback) {

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -810,6 +810,107 @@ test("worker normalizes minimal Butler API-backed handoff into bounded remote Co
   assert.equal(calls.length, 3);
 });
 
+test("worker accepts natural Butler build GO without internal consent or approval phrase fields", async () => {
+  const calls = [];
+  let dispatchInputs = null;
+  let executionId = "";
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/action/execute", {
+      method: "POST",
+      headers: gatewayAuthHeaders,
+      body: JSON.stringify({
+        phase: "execution",
+        actorRole: ActorRole.BUTLER,
+        executorTransport: "api_key_runner",
+        surfaceContext: {
+          surface: "custom_gpt",
+          judgmentModelId: "vtdd-butler-core-v1"
+        },
+        judgmentTrace: validButlerJudgmentTrace,
+        issueContext: {
+          issueNumber: 135
+        },
+        policyInput: {
+          actionType: ActionType.BUILD,
+          mode: TaskMode.EXECUTION,
+          repositoryInput: "vtdd",
+          aliasRegistry,
+          targetConfirmed: true,
+          runtimeTruth: {
+            runtimeAvailable: true,
+            runtimeState: {
+              activeBranch: "codex/issue-135"
+            }
+          },
+          go: true,
+          passkey: false
+        }
+      })
+    }),
+    {
+      ...gatewayAuthEnv,
+      VTDD_GITHUB_ACTIONS_REPOSITORY: "sample-org/vtdd-v2-p",
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_dispatch_token",
+      GITHUB_API_FETCH: async (url, init) => {
+        calls.push({ url, init });
+        if (String(url).includes("/installation/repositories")) {
+          return new Response(
+            JSON.stringify({
+              total_count: 1,
+              repositories: [
+                {
+                  full_name: "sample-org/vtdd-v2",
+                  name: "vtdd-v2",
+                  private: true
+                }
+              ]
+            }),
+            { status: 200, headers: { "content-type": "application/json" } }
+          );
+        }
+        if (String(url).includes("/dispatches")) {
+          dispatchInputs = JSON.parse(init.body).inputs;
+          executionId = dispatchInputs.execution_id;
+          return new Response(null, { status: 204 });
+        }
+        if (String(url).includes("/runs")) {
+          return new Response(
+            JSON.stringify({
+              workflow_runs: [
+                {
+                  id: 135303,
+                  name: "remote-codex-executor",
+                  display_title: executionId,
+                  html_url: "https://github.com/sample-org/vtdd-v2-p/actions/runs/135303",
+                  status: "queued",
+                  conclusion: null,
+                  head_branch: "main",
+                  run_started_at: "2026-04-29T10:10:00Z",
+                  updated_at: "2026-04-29T10:10:01Z"
+                }
+              ]
+            }),
+            { status: 200, headers: { "content-type": "application/json" } }
+          );
+        }
+        throw new Error(`unexpected url ${url}`);
+      }
+    }
+  );
+
+  assert.equal(response.status, 202);
+  const body = await response.json();
+  assert.equal(body.ok, true);
+  assert.equal(body.execution.issueNumber, 135);
+  assert.equal(body.execution.transport, "api_key_runner");
+  assert.equal(body.execution.workflowRunId, 135303);
+  assert.equal(dispatchInputs.target_issue_number, "135");
+  assert.equal(dispatchInputs.codex_goal, "open_pr");
+  assert.equal(dispatchInputs.approval_phrase, "GO");
+  assert.equal(JSON.parse(dispatchInputs.handoff_json).relatedIssue, 135);
+  assert.equal(calls.length, 3);
+});
+
 test("worker gateway rejects self-asserted Butler build handoff", async () => {
   const response = await worker.fetch(
     new Request("https://example.com/v2/gateway", {


### PR DESCRIPTION
## This PR satisfies Intent

Follow-up for Issue #135. Butler can turn a natural bounded request like `Issue #135 を開発して。GO` into an executable remote Codex handoff without asking the user to restate internal fields such as execute consent or approvalPhrase.

## Satisfied Success Criteria

- A handoff can dispatch a workflow-backed Codex runner when explicitly approved: the worker now normalizes GO-backed bounded build handoff payloads by deriving execute consent, approvalPhrase, and api_key_runner acknowledgement when api_key_runner was selected.
- GitHub runtime truth shows workflow evidence: the added worker test proves the normalized request reaches workflow_dispatch and returns a workflow run URL/id path.
- Existing nickname, self-parity, deploy, GitHub read/write, and reviewer evidence behavior does not regress: no nickname, deploy, schema, or reviewer code paths were changed; full test suite passes.

## Unsatisfied Success Criteria

- Live Butler conversation evidence is not claimed in this PR. After merge and Cloudflare deploy, the live Butler phrase `ぶい の Issue #135 を開発して。GO` still needs to be tested against production runtime.

## Verification Evidence

- `node --test test/worker.test.js`
- `node --test test/remote-codex-executor.test.js test/butler-orchestrator.test.js test/core-policy.test.js`
- `npm test`

## Surface Update Checklist

- Cloudflare deploy: required after merge because runtime code changed.
- Action Schema: not required.
- Custom GPT Instructions: not required for this PR; existing instructions already describe the intended behavior, and this PR makes runtime tolerate Butler drift.

## Non-goals

- No merge automation.
- No deploy.
- No secret value in chat.
- No reviewer backend redesign.
- No default switch to paid API runner without selected api_key_runner transport.
- No Issue closure.