### PR TITLE
Issue #135: configure production actions repository

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -102,10 +102,14 @@ jobs:
         env:
           CLOUDFLARE_D1_DATABASE_ID: ${{ secrets.CLOUDFLARE_D1_DATABASE_ID }}
           CLOUDFLARE_D1_DATABASE_NAME: ${{ vars.CLOUDFLARE_D1_DATABASE_NAME || 'vtdd-memory' }}
+          VTDD_GITHUB_ACTIONS_REPOSITORY: ${{ github.repository }}
         shell: bash
         run: |
           cp wrangler.toml wrangler.production.generated.toml
           cat >> wrangler.production.generated.toml <<EOF
+
+          [env.production.vars]
+          VTDD_GITHUB_ACTIONS_REPOSITORY = "$VTDD_GITHUB_ACTIONS_REPOSITORY"
 
           [[env.production.d1_databases]]
           binding = "VTDD_MEMORY_D1"

--- a/test/production-deploy-path.test.js
+++ b/test/production-deploy-path.test.js
@@ -67,6 +67,12 @@ test("deploy-production workflow enforces the MVP production deploy boundary", (
     true
   );
   assert.equal(workflow.includes("Generate production Wrangler config"), true);
+  assert.equal(workflow.includes("VTDD_GITHUB_ACTIONS_REPOSITORY: ${{ github.repository }}"), true);
+  assert.equal(workflow.includes("[env.production.vars]"), true);
+  assert.equal(
+    workflow.includes('VTDD_GITHUB_ACTIONS_REPOSITORY = "$VTDD_GITHUB_ACTIONS_REPOSITORY"'),
+    true
+  );
   assert.equal(workflow.includes("[[env.production.d1_databases]]"), true);
   assert.equal(workflow.includes('binding = "VTDD_MEMORY_D1"'), true);
   assert.equal(workflow.includes('database_id = "$CLOUDFLARE_D1_DATABASE_ID"'), true);


### PR DESCRIPTION
## This PR satisfies Intent

Issue #135 requires the api_key_runner path to reach a workflow-backed Codex runner with observable workflow evidence. The live runtime reached api_key_runner but stopped at `control_repository_unavailable` because the production Worker did not receive `VTDD_GITHUB_ACTIONS_REPOSITORY`. This PR wires that production runtime variable from `${{ github.repository }}` during governed deploy without committing an owner-specific repository value to shared config.

## Satisfied Success Criteria

- A handoff can dispatch a workflow-backed Codex runner when explicitly approved: production deploy now provides the control repository needed by the Worker to call workflow_dispatch.
- GitHub runtime truth can show workflow evidence: the Worker can resolve the control repository instead of stopping before dispatch.
- Existing nickname, self-parity, deploy, GitHub read/write, and reviewer evidence behavior does not regress: no Worker route, alias, deploy authority, Action Schema, or instruction behavior changed.

## Unsatisfied Success Criteria

- Live Butler workflow_dispatch evidence is not claimed in this PR. After merge and governed Cloudflare deploy, Butler still needs to rerun the natural phrase and report workflow run URL/conclusion.

## Verification Evidence

- `node --test test/production-deploy-path.test.js test/remote-codex-executor.test.js test/worker.test.js`
- `npm test`

## Surface Update Checklist

- Cloudflare deploy: required after merge because production generated Worker config changes.
- Action Schema: not required.
- Custom GPT Instructions: not required.

## Non-goals

- No deploy in this PR.
- No secret value in chat or committed config.
- No hardcoded owner-specific control repository in `wrangler.toml`.
- No reviewer backend redesign.
- No default switch to paid API runner.