### PR TITLE
Issue #135: normalize Butler read consent

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -1084,9 +1084,11 @@ async function prepareGatewayPayload({ payload, env, allowRemoteCodexHandoffNorm
     basePayload.policyInput && typeof basePayload.policyInput === "object"
       ? basePayload.policyInput
       : {};
-  const normalizedPayload = allowRemoteCodexHandoffNormalization
-    ? normalizeRemoteCodexHandoffPayload(basePayload)
-    : basePayload;
+  const normalizedPayload = normalizeButlerReadConsentPayload(
+    allowRemoteCodexHandoffNormalization
+      ? normalizeRemoteCodexHandoffPayload(basePayload)
+      : basePayload
+  );
   const normalizedPolicyInput =
     normalizedPayload.policyInput && typeof normalizedPayload.policyInput === "object"
       ? normalizedPayload.policyInput
@@ -1145,6 +1147,37 @@ async function prepareGatewayPayload({ payload, env, allowRemoteCodexHandoffNorm
       }
     },
     warnings
+  };
+}
+
+function normalizeButlerReadConsentPayload(payload) {
+  const policyInput =
+    payload?.policyInput && typeof payload.policyInput === "object" ? payload.policyInput : {};
+  const actionType = normalize(policyInput.actionType);
+  const actorRole = normalize(payload?.actorRole);
+  if (actorRole !== "butler" || (actionType !== "read" && actionType !== "summarize")) {
+    return payload;
+  }
+
+  const consent =
+    policyInput.consent && typeof policyInput.consent === "object" ? policyInput.consent : {};
+  const consentWasProvided = policyInput.consent && typeof policyInput.consent === "object";
+  const grantedCategories = Array.isArray(consent.grantedCategories)
+    ? consent.grantedCategories
+    : [];
+  if (consentWasProvided && grantedCategories.length > 0) {
+    return payload;
+  }
+
+  return {
+    ...payload,
+    policyInput: {
+      ...policyInput,
+      consent: {
+        ...consent,
+        grantedCategories: mergeGrantedConsentCategories(grantedCategories, ["read"])
+      }
+    }
   };
 }
 

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -315,6 +315,67 @@ test("worker gateway returns PR revision loop guidance for Butler summaries", as
   assert.equal(body.executionContinuity.nextSuggestedActions.includes("rerun_gemini_review"), true);
 });
 
+test("worker accepts natural Butler read without internal read consent field", async () => {
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/gateway", {
+      method: "POST",
+      headers: gatewayAuthHeaders,
+      body: JSON.stringify({
+        phase: "exploration",
+        actorRole: ActorRole.BUTLER,
+        surfaceContext: {
+          surface: "custom_gpt",
+          judgmentModelId: "vtdd-butler-core-v1"
+        },
+        judgmentTrace: validButlerJudgmentTrace,
+        policyInput: {
+          actionType: ActionType.READ,
+          mode: TaskMode.READ_ONLY,
+          repositoryInput: "vtdd",
+          aliasRegistry
+        }
+      })
+    }),
+    gatewayAuthEnv
+  );
+
+  assert.equal(response.status, 200);
+  const body = await response.json();
+  assert.equal(body.allowed, true);
+  assert.equal(body.repository, "sample-org/vtdd-v2");
+});
+
+test("worker does not override explicit Butler read consent categories", async () => {
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/gateway", {
+      method: "POST",
+      headers: gatewayAuthHeaders,
+      body: JSON.stringify({
+        phase: "exploration",
+        actorRole: ActorRole.BUTLER,
+        surfaceContext: {
+          surface: "custom_gpt",
+          judgmentModelId: "vtdd-butler-core-v1"
+        },
+        judgmentTrace: validButlerJudgmentTrace,
+        policyInput: {
+          actionType: ActionType.READ,
+          mode: TaskMode.READ_ONLY,
+          repositoryInput: "vtdd",
+          aliasRegistry,
+          consent: { grantedCategories: [ConsentCategory.PROPOSE] }
+        }
+      })
+    }),
+    gatewayAuthEnv
+  );
+
+  assert.equal(response.status, 422);
+  const body = await response.json();
+  assert.equal(body.allowed, false);
+  assert.equal(body.blockedByRule, "consent_boundary");
+});
+
 test("worker dispatches remote Codex execution", async () => {
   const calls = [];
   const response = await worker.fetch(


### PR DESCRIPTION
## This PR satisfies Intent

Issue #135 requires Butler-origin handoff testing to proceed from natural conversation rather than asking the user for internal consent fields. The live path is currently blocked before handoff because Butler runtime-truth reads can omit `consent=["read"]`. This PR normalizes read consent only for Butler read/summarize gateway payloads so natural read/check requests do not ask the user to restate internal read consent.

## Satisfied Success Criteria

- Butler can distinguish and inspect runtime truth before handoff without stopping on missing internal read consent.
- Existing nickname, self-parity, deploy, GitHub read/write, and reviewer evidence behavior does not regress: the change is limited to Butler read/summarize payload normalization and keeps core policy consent boundaries intact.
- The worker now has regression coverage for natural Butler read without an internal read consent field.

## Unsatisfied Success Criteria

- Live Butler workflow_dispatch evidence is not claimed in this PR. After merge and governed Cloudflare deploy, Butler still needs to rerun the natural handoff verification and report workflow run URL/conclusion.

## Verification Evidence

- `node --test test/worker.test.js test/mvp-gateway.test.js test/core-policy.test.js`
- `npm test`

## Surface Update Checklist

- Cloudflare deploy: required after merge because runtime code changed.
- Action Schema: not required.
- Custom GPT Instructions: not required.

## Non-goals

- No build, merge, deploy, secret, or destructive consent relaxation.
- No changes to core policy approval/consent requirements.
- No Action Schema or instruction change.
- No Issue closure.