### PR TITLE
Issue #135: fill runtime truth before Codex handoff

### DIFF
--- a/src/core/github-read-plane.js
+++ b/src/core/github-read-plane.js
@@ -23,6 +23,7 @@ export async function retrieveGitHubReadPlane(input = {}) {
   const issueNumber = normalizePositiveInteger(input.issueNumber);
   const pullNumber = normalizePositiveInteger(input.pullNumber);
   const branch = normalizeText(input.branch);
+  const head = normalizeText(input.head);
   const ref = normalizeText(input.ref) || branch;
   const state = normalizeText(input.state) || "open";
   const limit = normalizeLimit(input.limit, 20);
@@ -64,6 +65,7 @@ export async function retrieveGitHubReadPlane(input = {}) {
     pullNumber,
     ref,
     branch,
+    head,
     state,
     limit,
     token: tokenResolution.token,
@@ -109,6 +111,7 @@ async function fetchGitHubReadResource(input) {
     pullNumber,
     ref,
     branch,
+    head,
     state,
     limit,
     token,
@@ -123,6 +126,7 @@ async function fetchGitHubReadResource(input) {
     pullNumber,
     ref,
     branch,
+    head,
     state,
     limit,
     apiBaseUrl
@@ -180,6 +184,7 @@ function buildGitHubReadRequest({
   pullNumber,
   ref,
   branch,
+  head,
   state,
   limit,
   apiBaseUrl
@@ -216,7 +221,9 @@ function buildGitHubReadRequest({
       };
     }
     return {
-      url: `${apiBaseUrl}/repos/${encodedRepository}/pulls?state=${encodeURIComponent(state)}&per_page=${limit}`
+      url:
+        `${apiBaseUrl}/repos/${encodedRepository}/pulls?state=${encodeURIComponent(state)}&per_page=${limit}` +
+        (head ? `&head=${encodeURIComponent(head)}` : "")
     };
   }
 
@@ -334,6 +341,11 @@ function normalizePullRequest(item) {
     draft: item?.draft === true,
     headRef: normalizeText(item?.head?.ref),
     headSha: normalizeText(item?.head?.sha),
+    headOwner:
+      normalizeText(item?.head?.repo?.owner?.login) ||
+      normalizeText(item?.head?.user?.login) ||
+      normalizeText(item?.head?.repo?.full_name).split("/")[0] ||
+      null,
     baseRef: normalizeText(item?.base?.ref),
     baseSha: normalizeText(item?.base?.sha),
     merged: item?.merged === true || Boolean(normalizeText(item?.merged_at)),

--- a/src/worker.js
+++ b/src/worker.js
@@ -1123,9 +1123,20 @@ async function prepareGatewayPayload({ payload, env, allowRemoteCodexHandoffNorm
     warnings.push("runtime forces guarded absence mode; payload autonomyMode override was ignored");
   }
 
+  const runtimeTruthResolution = allowRemoteCodexHandoffNormalization
+    ? await resolveRemoteCodexHandoffRuntimeTruth({
+        payload: normalizedPayload,
+        policyInput: normalizedPolicyInput,
+        aliasRegistry: resolvedAliasRegistry.aliasRegistry,
+        env
+      })
+    : { policyInput: normalizedPolicyInput, warnings: [] };
+  warnings.push(...(runtimeTruthResolution.warnings ?? []));
+  const policyInputWithRuntimeTruth = runtimeTruthResolution.policyInput;
+
   const resolvedApprovalGrant = await resolveApprovalGrant({
     payload: normalizedPayload,
-    policyInput: normalizedPolicyInput,
+    policyInput: policyInputWithRuntimeTruth,
     env
   });
   if (resolvedApprovalGrant.warning) {
@@ -1136,17 +1147,134 @@ async function prepareGatewayPayload({ payload, env, allowRemoteCodexHandoffNorm
     payload: {
       ...normalizedPayload,
       policyInput: {
-        ...normalizedPolicyInput,
+        ...policyInputWithRuntimeTruth,
         aliasRegistry: resolvedAliasRegistry.aliasRegistry,
         autonomyMode: effectiveAutonomyMode,
         approvalGrant: resolvedApprovalGrant.approvalGrant,
         approvalScope: buildApprovalScopeSnapshot({
           payload: normalizedPayload,
-          policyInput: normalizedPolicyInput
+          policyInput: policyInputWithRuntimeTruth
         })
       }
     },
     warnings
+  };
+}
+
+async function resolveRemoteCodexHandoffRuntimeTruth({
+  payload,
+  policyInput,
+  aliasRegistry,
+  env
+}) {
+  const actionType = normalize(policyInput.actionType);
+  const actorRole = normalize(payload?.actorRole);
+  if (actorRole !== "butler" || actionType !== "build") {
+    return { policyInput, warnings: [] };
+  }
+
+  const runtimeTruth =
+    policyInput.runtimeTruth && typeof policyInput.runtimeTruth === "object"
+      ? policyInput.runtimeTruth
+      : {};
+  const runtimeState =
+    runtimeTruth.runtimeState && typeof runtimeTruth.runtimeState === "object"
+      ? runtimeTruth.runtimeState
+      : {};
+  if (runtimeTruth.runtimeAvailable === true && Object.keys(runtimeState).length > 0) {
+    return { policyInput, warnings: [] };
+  }
+
+  const repositoryResolution = resolveRepositoryTarget({
+    input: policyInput.repositoryInput,
+    mode: policyInput.mode,
+    aliasRegistry
+  });
+  if (!repositoryResolution.resolved) {
+    return { policyInput, warnings: [] };
+  }
+
+  const issueNumber = normalizeIssue(payload?.issueContext?.issueNumber);
+  const activeBranch =
+    normalizeText(runtimeState.activeBranch) ||
+    normalizeText(payload?.executionTarget?.branch) ||
+    (issueNumber ? `codex/issue-${issueNumber}` : "");
+  const [repositoryOwner] = repositoryResolution.repository.split("/");
+  const [pulls, branches, workflowRuns] = await Promise.all([
+    retrieveGitHubReadPlane({
+      resource: "pulls",
+      repository: repositoryResolution.repository,
+      state: "all",
+      head: `${repositoryOwner}:${activeBranch}`,
+      limit: 10,
+      env
+    }),
+    retrieveGitHubReadPlane({
+      resource: "branches",
+      repository: repositoryResolution.repository,
+      branch: activeBranch,
+      limit: 1,
+      env
+    }),
+    retrieveGitHubReadPlane({
+      resource: "workflow_runs",
+      repository: repositoryResolution.repository,
+      branch: activeBranch,
+      limit: 10,
+      env
+    })
+  ]);
+
+  if (!pulls.ok || !branches.ok || !workflowRuns.ok) {
+    return {
+      policyInput,
+      warnings: ["remote Codex handoff runtime truth read was unavailable"]
+    };
+  }
+
+  const pullRequest = selectPullRequestForBranch(pulls.read?.records, {
+    branch: activeBranch,
+    owner: repositoryOwner
+  });
+  const branchRecord = Array.isArray(branches.read?.records) ? branches.read.records[0] : null;
+  return {
+    policyInput: {
+      ...policyInput,
+      runtimeTruth: {
+        ...runtimeTruth,
+        runtimeAvailable: true,
+        runtimeState: {
+          ...runtimeState,
+          activeBranch,
+          branch: branchRecord ?? null,
+          pullRequest: pullRequest ?? { exists: false },
+          workflowRuns: workflowRuns.read?.records ?? []
+        }
+      }
+    },
+    warnings: []
+  };
+}
+
+function selectPullRequestForBranch(records, target) {
+  const items = Array.isArray(records) ? records : [];
+  const branch = normalizeText(target?.branch);
+  const owner = normalizeText(target?.owner);
+  const selected = items.find(
+    (item) => normalizeText(item?.headRef) === branch && normalizeText(item?.headOwner) === owner
+  );
+  if (!selected) {
+    return { exists: false };
+  }
+  return {
+    exists: true,
+    number: selected.number ?? null,
+    url: selected.htmlUrl ?? null,
+    state: selected.state ?? null,
+    title: selected.title ?? null,
+    headRef: selected.headRef ?? null,
+    headSha: selected.headSha ?? null,
+    baseRef: selected.baseRef ?? null
   };
 }
 

--- a/test/github-read-plane.test.js
+++ b/test/github-read-plane.test.js
@@ -148,6 +148,48 @@ test("github read plane exposes pull request merge truth when reading a specific
   assert.equal(result.read.records[0].baseSha, "83ba6135f3a01c27948a018c721135a301d938fe");
 });
 
+test("github read plane can filter pull requests by exact head owner and branch", async () => {
+  const calls = [];
+  const result = await retrieveGitHubReadPlane({
+    resource: GitHubReadResource.PULLS,
+    repository: "sample-org/vtdd-v2-p",
+    state: "all",
+    head: "sample-org:codex/issue-135",
+    env: {
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_pull_read",
+      GITHUB_API_FETCH: async (url) => {
+        calls.push(url);
+        return new Response(
+          JSON.stringify([
+            {
+              number: 135,
+              title: "Issue #135 runner",
+              state: "open",
+              head: {
+                ref: "codex/issue-135",
+                sha: "head-sha",
+                repo: {
+                  full_name: "sample-org/vtdd-v2-p",
+                  owner: { login: "sample-org" }
+                }
+              },
+              base: { ref: "main", sha: "base-sha" },
+              html_url: "https://github.com/sample-org/vtdd-v2-p/pull/135"
+            }
+          ]),
+          { status: 200, headers: { "content-type": "application/json" } }
+        );
+      }
+    }
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(calls[0].includes("state=all"), true);
+  assert.equal(calls[0].includes("head=sample-org%3Acodex%2Fissue-135"), true);
+  assert.equal(result.read.records[0].headRef, "codex/issue-135");
+  assert.equal(result.read.records[0].headOwner, "sample-org");
+});
+
 test("github read plane reads pull reviews, review comments, checks, workflow runs, and branches", async () => {
   const responses = new Map([
     [

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -972,6 +972,127 @@ test("worker accepts natural Butler build GO without internal consent or approva
   assert.equal(calls.length, 3);
 });
 
+test("worker fills runtime truth for natural Butler build handoff before workflow dispatch", async () => {
+  const calls = [];
+  let dispatchInputs = null;
+  let executionId = "";
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/action/execute", {
+      method: "POST",
+      headers: gatewayAuthHeaders,
+      body: JSON.stringify({
+        phase: "execution",
+        actorRole: ActorRole.BUTLER,
+        executorTransport: "api_key_runner",
+        surfaceContext: {
+          surface: "custom_gpt",
+          judgmentModelId: "vtdd-butler-core-v1"
+        },
+        judgmentTrace: validButlerJudgmentTrace,
+        issueContext: {
+          issueNumber: 135
+        },
+        policyInput: {
+          actionType: ActionType.BUILD,
+          mode: TaskMode.EXECUTION,
+          repositoryInput: "vtdd",
+          aliasRegistry,
+          targetConfirmed: true,
+          go: true,
+          passkey: false
+        }
+      })
+    }),
+    {
+      ...gatewayAuthEnv,
+      VTDD_GITHUB_ACTIONS_REPOSITORY: "sample-org/vtdd-v2-p",
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_dispatch_token",
+      GITHUB_API_FETCH: async (url, init) => {
+        calls.push({ url, init });
+        if (String(url).includes("/installation/repositories")) {
+          return new Response(
+            JSON.stringify({
+              total_count: 1,
+              repositories: [
+                {
+                  full_name: "sample-org/vtdd-v2",
+                  name: "vtdd-v2",
+                  private: true
+                }
+              ]
+            }),
+            { status: 200, headers: { "content-type": "application/json" } }
+          );
+        }
+        if (String(url).includes("/pulls?")) {
+          assert.equal(String(url).includes("state=all"), true);
+          assert.equal(String(url).includes("head=sample-org%3Acodex%2Fissue-135"), true);
+          return new Response(JSON.stringify([]), {
+            status: 200,
+            headers: { "content-type": "application/json" }
+          });
+        }
+        if (String(url).includes("/branches/codex%2Fissue-135")) {
+          return new Response(
+            JSON.stringify({
+              name: "codex/issue-135",
+              protected: false,
+              commit: { sha: "branch-sha", url: "https://api.github.test/branch-sha" }
+            }),
+            { status: 200, headers: { "content-type": "application/json" } }
+          );
+        }
+        if (
+          String(url).includes("/actions/runs") &&
+          String(url).includes("branch=codex%2Fissue-135") &&
+          !String(url).includes("/actions/workflows/")
+        ) {
+          return new Response(JSON.stringify({ workflow_runs: [] }), {
+            status: 200,
+            headers: { "content-type": "application/json" }
+          });
+        }
+        if (String(url).includes("/dispatches")) {
+          dispatchInputs = JSON.parse(init.body).inputs;
+          executionId = dispatchInputs.execution_id;
+          return new Response(null, { status: 204 });
+        }
+        if (String(url).includes("/actions/workflows/")) {
+          return new Response(
+            JSON.stringify({
+              workflow_runs: [
+                {
+                  id: 135404,
+                  name: "remote-codex-executor",
+                  display_title: executionId,
+                  html_url: "https://github.com/sample-org/vtdd-v2-p/actions/runs/135404",
+                  status: "queued",
+                  conclusion: null,
+                  head_branch: "main",
+                  run_started_at: "2026-04-29T10:15:00Z",
+                  updated_at: "2026-04-29T10:15:01Z"
+                }
+              ]
+            }),
+            { status: 200, headers: { "content-type": "application/json" } }
+          );
+        }
+        throw new Error(`unexpected url ${url}`);
+      }
+    }
+  );
+
+  assert.equal(response.status, 202);
+  const body = await response.json();
+  assert.equal(body.ok, true);
+  assert.equal(body.execution.transport, "api_key_runner");
+  assert.equal(body.execution.workflowRunId, 135404);
+  assert.equal(dispatchInputs.target_issue_number, "135");
+  assert.equal(dispatchInputs.approval_phrase, "GO");
+  assert.equal(calls.some((call) => String(call.url).includes("/pulls?")), true);
+  assert.equal(calls.some((call) => String(call.url).includes("/branches/codex%2Fissue-135")), true);
+});
+
 test("worker gateway rejects self-asserted Butler build handoff", async () => {
   const response = await worker.fetch(
     new Request("https://example.com/v2/gateway", {


### PR DESCRIPTION
## This PR satisfies Intent
Issue #135 requires Butler-origin api_key_runner handoff to reach workflow_dispatch and report workflow evidence. Live testing reached natural GO/transport/config but stopped at runtime_truth_required_or_safe_fallback. This PR makes /v2/action/execute read GitHub runtime truth for bounded Butler build handoff before policy evaluation, instead of asking the user for fallback wording.

## Satisfied Success Criteria
- Butler can distinguish queued/comment transport from execution evidence by reading PR/branch/workflow_runs before handoff.
- A handoff can dispatch the workflow-backed runner when explicitly approved: missing runtimeTruth no longer blocks if GitHub read succeeds.
- GitHub runtime truth includes PR/branch/workflow evidence: the worker preloads open PRs, target branch, and workflow runs.
- Existing nickname, self-parity, deploy, GitHub read/write, and reviewer behavior do not regress: the change is limited to /v2/action/execute bounded build handoff runtime-truth preparation.

## Unsatisfied Success Criteria
- Live Butler workflow_dispatch evidence is not claimed by this PR. It still requires merge, Cloudflare deploy, and a live Butler retest.

## Verification Evidence
- `node --test test/worker.test.js test/remote-codex-executor.test.js test/core-policy.test.js`
- `npm test`

## Surface Update Checklist
- Cloudflare deploy: required after merge because runtime code changed.
- Action Schema: not required.
- Custom GPT Instructions: not required.

## Non-goals
- No safe fallback auto-selection.
- No merge, deploy, secret, or destructive changes.
- No Action Schema or instruction change.
- No Issue closure.

Refs #135