### PR TITLE
Issue #135: authenticate remote Codex CLI runner

### DIFF
--- a/.github/workflows/remote-codex-executor.yml
+++ b/.github/workflows/remote-codex-executor.yml
@@ -132,6 +132,12 @@ jobs:
         shell: bash
         run: npm install -g @openai/codex
 
+      - name: Authenticate Codex CLI
+        shell: bash
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: printenv OPENAI_API_KEY | codex login --with-api-key
+
       - name: Prepare Codex prompt
         shell: bash
         run: |

--- a/test/remote-codex-workflow.test.js
+++ b/test/remote-codex-workflow.test.js
@@ -33,3 +33,12 @@ test("remote Codex workflow marks OPENAI_API_KEY runner as explicit opt-in", () 
   assert.equal(workflow.includes("may create separate API billing"), true);
   assert.equal(workflow.includes("OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}"), true);
 });
+
+test("remote Codex workflow authenticates Codex CLI before execution", () => {
+  assert.equal(workflow.includes("name: Authenticate Codex CLI"), true);
+  assert.equal(workflow.includes("printenv OPENAI_API_KEY | codex login --with-api-key"), true);
+  assert.equal(
+    workflow.indexOf("codex login --with-api-key") < workflow.indexOf("codex exec --skip-git-repo-check"),
+    true
+  );
+});


### PR DESCRIPTION
## This PR satisfies Intent
Issue #135 requires the API-backed remote Codex runner to produce observable workflow execution evidence rather than stopping at queued comment transport. Live workflow run 25107670098 reached workflow_dispatch but failed inside `remote-codex-executor` because Codex CLI was not logged in before `codex exec`. This PR aligns the executor with the already-working Codex fallback workflow by authenticating the Codex CLI from the approved `OPENAI_API_KEY` secret before execution.

## Satisfied Success Criteria
- The workflow-backed Codex runner can move past dispatch into authenticated Codex CLI execution.
- Workflow failure reason becomes the next concrete runner failure instead of missing OpenAI bearer authentication.
- Secret value remains in GitHub Actions secrets and is never exposed in chat or logs.
- Existing default comment transport remains unchanged.

## Unsatisfied Success Criteria
- Live PR/branch creation is not claimed until this PR is merged and the api_key_runner path is re-run.

## Verification Evidence
- `node --test test/remote-codex-workflow.test.js test/gemini-pr-review-workflow.test.js test/remote-codex-executor.test.js`
- `npm test`

## Surface Update Checklist
- Cloudflare deploy: not required; GitHub Actions workflow only.
- Action Schema: not required.
- Custom GPT Instructions: not required.

## Non-goals
- No runtime Worker changes.
- No default switch to paid/API runner.
- No secret value exposure.
- No merge, deploy, reviewer redesign, or Issue closure.

Refs #135