### PR TITLE
Issue #135: prepare runner user namespaces for Codex sandbox

### DIFF
--- a/.github/workflows/remote-codex-executor.yml
+++ b/.github/workflows/remote-codex-executor.yml
@@ -140,11 +140,13 @@ jobs:
       - name: Enable Codex sandbox user namespaces
         shell: bash
         run: |
-          if [ -w /proc/sys/kernel/unprivileged_userns_clone ]; then
+          if [ -e /proc/sys/kernel/unprivileged_userns_clone ]; then
             echo 1 | sudo tee /proc/sys/kernel/unprivileged_userns_clone
+            echo "unprivileged_userns_clone=$(cat /proc/sys/kernel/unprivileged_userns_clone)"
           fi
-          if [ -w /proc/sys/kernel/apparmor_restrict_unprivileged_userns ]; then
+          if [ -e /proc/sys/kernel/apparmor_restrict_unprivileged_userns ]; then
             echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
+            echo "apparmor_restrict_unprivileged_userns=$(cat /proc/sys/kernel/apparmor_restrict_unprivileged_userns)"
           fi
 
       - name: Authenticate Codex CLI

--- a/.github/workflows/remote-codex-executor.yml
+++ b/.github/workflows/remote-codex-executor.yml
@@ -80,6 +80,10 @@ jobs:
             echo "target_repository must be owner/repo."
             exit 1
           fi
+          if [ "$TARGET_REPOSITORY" != "$GITHUB_REPOSITORY" ]; then
+            echo "api_key_runner is restricted to this repository."
+            exit 1
+          fi
           if ! [[ "$TARGET_ISSUE_NUMBER" =~ ^[0-9]+$ ]]; then
             echo "target_issue_number must be numeric."
             exit 1
@@ -115,6 +119,7 @@ jobs:
           ref: ${{ env.BASE_REF }}
           token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
+          persist-credentials: false
           path: target-repo
 
       - name: Prepare target branch
@@ -131,6 +136,16 @@ jobs:
       - name: Install Codex CLI
         shell: bash
         run: npm install -g @openai/codex
+
+      - name: Enable Codex sandbox user namespaces
+        shell: bash
+        run: |
+          if [ -w /proc/sys/kernel/unprivileged_userns_clone ]; then
+            echo 1 | sudo tee /proc/sys/kernel/unprivileged_userns_clone
+          fi
+          if [ -w /proc/sys/kernel/apparmor_restrict_unprivileged_userns ]; then
+            echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
+          fi
 
       - name: Authenticate Codex CLI
         shell: bash
@@ -164,16 +179,15 @@ jobs:
       - name: Run Codex CLI
         working-directory: target-repo
         shell: bash
-        env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          codex exec --skip-git-repo-check "$(cat ../codex-prompt.txt)"
+          codex exec --sandbox workspace-write -c sandbox_workspace_write.network_access=true --skip-git-repo-check "$(cat ../codex-prompt.txt)"
 
       - name: Commit and push Codex changes
         id: codex-changes
         working-directory: target-repo
         shell: bash
+        env:
+          APP_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           git config user.name "vtdd-codex[bot]"
           git config user.email "vtdd-codex[bot]@users.noreply.github.com"
@@ -186,7 +200,7 @@ jobs:
 
           git add -A
           git commit -m "VTDD remote Codex execution for issue #${TARGET_ISSUE_NUMBER}"
-          git push origin "$TARGET_BRANCH"
+          git push "https://x-access-token:${APP_TOKEN}@github.com/${TARGET_REPOSITORY}.git" "$TARGET_BRANCH"
           echo "changed=true" >> "$GITHUB_OUTPUT"
 
       - name: Create or update pull request

--- a/test/remote-codex-workflow.test.js
+++ b/test/remote-codex-workflow.test.js
@@ -64,6 +64,12 @@ test("remote Codex workflow prepares GitHub runner user namespaces for bubblewra
   assert.equal(workflow.includes("name: Enable Codex sandbox user namespaces"), true);
   assert.equal(workflow.includes("/proc/sys/kernel/unprivileged_userns_clone"), true);
   assert.equal(workflow.includes("/proc/sys/kernel/apparmor_restrict_unprivileged_userns"), true);
+  assert.equal(workflow.includes("[ -w /proc/sys/kernel/unprivileged_userns_clone ]"), false);
+  assert.equal(workflow.includes("[ -w /proc/sys/kernel/apparmor_restrict_unprivileged_userns ]"), false);
+  assert.equal(workflow.includes("[ -e /proc/sys/kernel/unprivileged_userns_clone ]"), true);
+  assert.equal(workflow.includes("[ -e /proc/sys/kernel/apparmor_restrict_unprivileged_userns ]"), true);
+  assert.equal(workflow.includes("sudo tee /proc/sys/kernel/unprivileged_userns_clone"), true);
+  assert.equal(workflow.includes("sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns"), true);
 });
 
 test("remote Codex workflow keeps secrets out of the Codex exec step", () => {

--- a/test/remote-codex-workflow.test.js
+++ b/test/remote-codex-workflow.test.js
@@ -7,7 +7,10 @@ const workflow = fs.readFileSync(".github/workflows/remote-codex-executor.yml", 
 test("remote Codex workflow commits, pushes, and creates or updates a PR", () => {
   assert.equal(workflow.includes("name: Validate remote Codex inputs"), true);
   assert.equal(workflow.includes("name: Commit and push Codex changes"), true);
-  assert.equal(workflow.includes("git push origin"), true);
+  assert.equal(
+    workflow.includes('git push "https://x-access-token:${APP_TOKEN}@github.com/${TARGET_REPOSITORY}.git"'),
+    true
+  );
   assert.equal(workflow.includes("name: Create or update pull request"), true);
   assert.equal(workflow.includes("gh pr view"), true);
   assert.equal(workflow.includes("gh pr create"), true);
@@ -28,6 +31,10 @@ test("remote Codex workflow avoids embedding dispatch inputs inside shell heredo
   assert.equal(workflow.includes("git push origin \"${{ github.event.inputs.target_branch }}\""), false);
 });
 
+test("remote Codex workflow does not persist checkout credentials into the sandboxed workspace", () => {
+  assert.equal(workflow.includes("persist-credentials: false"), true);
+});
+
 test("remote Codex workflow marks OPENAI_API_KEY runner as explicit opt-in", () => {
   assert.equal(workflow.includes("Optional API-backed runner."), true);
   assert.equal(workflow.includes("may create separate API billing"), true);
@@ -38,7 +45,37 @@ test("remote Codex workflow authenticates Codex CLI before execution", () => {
   assert.equal(workflow.includes("name: Authenticate Codex CLI"), true);
   assert.equal(workflow.includes("printenv OPENAI_API_KEY | codex login --with-api-key"), true);
   assert.equal(
-    workflow.indexOf("codex login --with-api-key") < workflow.indexOf("codex exec --skip-git-repo-check"),
+    workflow.indexOf("codex login --with-api-key") < workflow.indexOf("codex exec "),
     true
   );
+});
+
+test("remote Codex workflow runs Codex with workspace-write sandbox", () => {
+  assert.equal(
+    workflow.includes(
+      "codex exec --sandbox workspace-write -c sandbox_workspace_write.network_access=true --skip-git-repo-check"
+    ),
+    true
+  );
+  assert.equal(workflow.includes("--dangerously-bypass-approvals-and-sandbox"), false);
+});
+
+test("remote Codex workflow prepares GitHub runner user namespaces for bubblewrap", () => {
+  assert.equal(workflow.includes("name: Enable Codex sandbox user namespaces"), true);
+  assert.equal(workflow.includes("/proc/sys/kernel/unprivileged_userns_clone"), true);
+  assert.equal(workflow.includes("/proc/sys/kernel/apparmor_restrict_unprivileged_userns"), true);
+});
+
+test("remote Codex workflow keeps secrets out of the Codex exec step", () => {
+  const runStepStart = workflow.indexOf("name: Run Codex CLI");
+  const commitStepStart = workflow.indexOf("name: Commit and push Codex changes");
+  const runStep = workflow.slice(runStepStart, commitStepStart);
+
+  assert.equal(runStep.includes("OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}"), false);
+  assert.equal(runStep.includes("GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}"), false);
+});
+
+test("remote Codex workflow restricts api_key_runner to the control repository", () => {
+  assert.equal(workflow.includes('if [ "$TARGET_REPOSITORY" != "$GITHUB_REPOSITORY" ]; then'), true);
+  assert.equal(workflow.includes("api_key_runner is restricted to this repository."), true);
 });


### PR DESCRIPTION
## This PR satisfies Intent
Issue #135 requires the API-backed remote Codex runner to produce observable PR/branch evidence. After PR #146, live workflow run 25108542481 reached `workspace-write` Codex execution but failed because bubblewrap could not initialize user namespaces on the GitHub runner: `bwrap: setting up uid map: Permission denied`. This PR keeps the sandboxed approach and prepares the runner for bubblewrap instead of returning to dangerous sandbox bypass.

## Satisfied Success Criteria
- The workflow-backed Codex runner has an explicit next fix for the observed GitHub Actions/bubblewrap failure.
- Codex still runs with `workspace-write` sandbox, not dangerous bypass.
- GitHub push credentials are not persisted into the checkout visible to Codex.
- Push credentials are supplied only to the later commit/push step.

## Unsatisfied Success Criteria
- Live PR/branch creation is not claimed until this PR is merged and the api_key_runner path is re-run.

## Verification Evidence
- `node --test test/remote-codex-workflow.test.js test/remote-codex-executor.test.js`
- `npm test`

## Surface Update Checklist
- Cloudflare deploy: not required; GitHub Actions workflow only.
- Action Schema: not required.
- Custom GPT Instructions: not required.

## Non-goals
- No runtime Worker changes.
- No default switch to paid/API runner.
- No secret value exposure.
- No dangerous sandbox bypass.
- No merge, deploy, reviewer redesign, or Issue closure.

Refs #135