### PR TITLE
Record blocked Codex fallback review failures

### DIFF
--- a/scripts/run-codex-pr-review-fallback.mjs
+++ b/scripts/run-codex-pr-review-fallback.mjs
@@ -13,12 +13,26 @@ async function main() {
   const reason = mustGetEnv("CODEX_FALLBACK_REASON");
   const githubToken = mustGetEnv("GITHUB_TOKEN");
 
-  if (!process.env.OPENAI_API_KEY) {
-    throw new Error("OPENAI_API_KEY is required for non-manual Codex fallback review");
-  }
-
   const apiBaseUrl = process.env.GITHUB_API_URL || "https://api.github.com";
   const githubFetch = createGitHubFetch({ apiBaseUrl, token: githubToken });
+
+  if (!process.env.OPENAI_API_KEY) {
+    await upsertCodexFallbackComment({
+      githubFetch,
+      repository,
+      prNumber,
+      body: formatCodexReviewFallbackComment({
+        status: "blocked",
+        trigger,
+        reason,
+        deliveryMode: "workflow_dispatch_codex_cli",
+        blocker: "openai_api_key_not_configured",
+        rawReview: "OPENAI_API_KEY is required for non-manual Codex fallback review."
+      })
+    });
+    console.log(`Recorded Codex fallback blocker state on PR #${prNumber}.`);
+    return;
+  }
 
   const pullRequest = await githubFetch(`/repos/${repository}/pulls/${prNumber}`);
   const files = await githubFetchAll(githubFetch, `/repos/${repository}/pulls/${prNumber}/files?per_page=100`);
@@ -43,7 +57,27 @@ async function main() {
   });
 
   const prompt = buildCodexFallbackReviewPrompt({ context, prDiff });
-  const review = await runCodexReview({ prompt });
+  let review;
+  try {
+    review = await runCodexReview({ prompt });
+  } catch (error) {
+    const failure = classifyCodexFallbackFailure(error);
+    await upsertCodexFallbackComment({
+      githubFetch,
+      repository,
+      prNumber,
+      body: formatCodexReviewFallbackComment({
+        status: "blocked",
+        trigger,
+        reason,
+        deliveryMode: "workflow_dispatch_codex_cli",
+        blocker: failure.blocker,
+        rawReview: failure.rawFailure
+      })
+    });
+    console.log(`Recorded Codex fallback blocker state on PR #${prNumber}: ${failure.blocker}.`);
+    return;
+  }
   const parsed = parseReviewerJson(review.stdout);
   const normalizedReview = normalizeReviewerResult(parsed, review.stdout);
 
@@ -58,28 +92,13 @@ async function main() {
     rawReview: review.stdout
   });
 
-  const latestIssueComments = await githubFetchAll(
+  const result = await upsertCodexFallbackComment({
     githubFetch,
-    `/repos/${repository}/issues/${prNumber}/comments?per_page=100`
-  );
-  const existing = latestIssueComments.find((comment) =>
-    String(comment?.body || "").includes("<!-- vtdd:reviewer=codex-fallback -->")
-  );
-
-  if (existing) {
-    await githubFetch(`/repos/${repository}/issues/comments/${existing.id}`, {
-      method: "PATCH",
-      body: { body }
-    });
-    console.log(`Updated Codex fallback review comment on PR #${prNumber}.`);
-    return;
-  }
-
-  await githubFetch(`/repos/${repository}/issues/${prNumber}/comments`, {
-    method: "POST",
-    body: { body }
+    repository,
+    prNumber,
+    body
   });
-  console.log(`Created Codex fallback review comment on PR #${prNumber}.`);
+  console.log(`${result === "updated" ? "Updated" : "Created"} Codex fallback review comment on PR #${prNumber}.`);
 }
 
 function buildCodexFallbackReviewPrompt({ context, prDiff }) {
@@ -224,6 +243,67 @@ function normalizeStringArray(value) {
   return value
     .map((item) => String(item ?? "").trim())
     .filter(Boolean);
+}
+
+async function upsertCodexFallbackComment({ githubFetch, repository, prNumber, body }) {
+  const latestIssueComments = await githubFetchAll(
+    githubFetch,
+    `/repos/${repository}/issues/${prNumber}/comments?per_page=100`
+  );
+  const existing = latestIssueComments.find((comment) =>
+    String(comment?.body || "").includes("<!-- vtdd:reviewer=codex-fallback -->")
+  );
+
+  if (existing) {
+    await githubFetch(`/repos/${repository}/issues/comments/${existing.id}`, {
+      method: "PATCH",
+      body: { body }
+    });
+    return "updated";
+  }
+
+  await githubFetch(`/repos/${repository}/issues/${prNumber}/comments`, {
+    method: "POST",
+    body: { body }
+  });
+  return "created";
+}
+
+function classifyCodexFallbackFailure(error) {
+  const raw = String(error?.message || error || "");
+  const lowered = raw.toLowerCase();
+  let blocker = "codex_fallback_review_failed";
+
+  if (lowered.includes("quota exceeded")) {
+    blocker = "openai_quota_exceeded";
+  } else if (
+    lowered.includes("missing bearer") ||
+    lowered.includes("401") ||
+    lowered.includes("unauthorized") ||
+    lowered.includes("api key")
+  ) {
+    blocker = "openai_api_key_invalid_or_missing";
+  } else if (lowered.includes("rate limit")) {
+    blocker = "openai_rate_limited";
+  }
+
+  return {
+    blocker,
+    rawFailure: summarizeCodexFallbackFailure(raw)
+  };
+}
+
+function summarizeCodexFallbackFailure(raw) {
+  const text = String(raw || "").replace(/\r/g, "");
+  const lines = text
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+  const salient = lines.filter((line) =>
+    /error|quota|missing bearer|unauthorized|rate limit|failed with exit code/i.test(line)
+  );
+  const summary = (salient.length > 0 ? salient : lines).slice(0, 12).join("\n");
+  return summary.slice(0, 4000) || "Codex fallback review failed without visible stderr/stdout.";
 }
 
 function createGitHubFetch({ apiBaseUrl, token }) {

--- a/src/core/codex-review-fallback.js
+++ b/src/core/codex-review-fallback.js
@@ -87,7 +87,10 @@ function buildStatusSection({
     return [
       `- Blocker: \`${blocker || "codex_fallback_unavailable"}\``,
       "",
-      "Gemini critical review is temporarily unavailable, and non-manual Codex fallback could not be started from the current repository/runtime configuration."
+      "Gemini critical review is temporarily unavailable, and non-manual Codex fallback could not be started from the current repository/runtime configuration.",
+      ...(rawReview
+        ? ["", "### Raw Failure", "", "```text", rawReview, "```"]
+        : [])
     ];
   }
 

--- a/test/codex-review-fallback.test.js
+++ b/test/codex-review-fallback.test.js
@@ -86,6 +86,22 @@ test("parseCodexReviewFallbackComment exposes blocked fallback reviewer state", 
   });
 });
 
+test("formatCodexReviewFallbackComment renders raw blocked failure details", () => {
+  const body = formatCodexReviewFallbackComment({
+    status: "blocked",
+    trigger: "pull_request_target:synchronize",
+    reason: "gemini_temporarily_unavailable",
+    deliveryMode: "workflow_dispatch_codex_cli",
+    blocker: "openai_quota_exceeded",
+    rawReview: "ERROR: Quota exceeded. Check your plan and billing details."
+  });
+
+  assert.equal(body.includes("- Status: `blocked`"), true);
+  assert.equal(body.includes("- Blocker: `openai_quota_exceeded`"), true);
+  assert.equal(body.includes("### Raw Failure"), true);
+  assert.equal(body.includes("ERROR: Quota exceeded."), true);
+});
+
 test("fallback script reviews GitHub API diff without checking out untrusted PR code", () => {
   assert.equal(fallbackScript.includes("buildPullRequestDiff"), true);
   assert.equal(fallbackScript.includes("buildPullRequestReviewContext"), true);
@@ -98,4 +114,12 @@ test("fallback script reviews GitHub API diff without checking out untrusted PR 
   assert.equal(fallbackScript.includes('rel="next"'), true);
   assert.equal(fallbackScript.includes('["exec", "review"'), false);
   assert.equal(fallbackScript.includes("CODEX_REVIEW_WORKTREE"), false);
+});
+
+test("fallback script records blocked marker comments for unavailable Codex review", () => {
+  assert.equal(fallbackScript.includes("classifyCodexFallbackFailure"), true);
+  assert.equal(fallbackScript.includes("upsertCodexFallbackComment"), true);
+  assert.equal(fallbackScript.includes("openai_quota_exceeded"), true);
+  assert.equal(fallbackScript.includes("openai_api_key_not_configured"), true);
+  assert.equal(fallbackScript.includes('status: "blocked"'), true);
 });


### PR DESCRIPTION
## This PR satisfies Intent
When Gemini is temporarily unavailable and Codex fallback review cannot complete because the OpenAI API runner is unavailable, Butler needs runtime truth instead of a stale `requested` reviewer marker. This PR updates the fallback reviewer path so quota/auth/runtime failures update the existing `vtdd:reviewer=codex-fallback` comment to `blocked` with a concrete blocker and raw failure excerpt.

## Satisfied Success Criteria
- Codex fallback review failures no longer leave the marker comment indefinitely in `requested` state.
- Missing OPENAI_API_KEY records `openai_api_key_not_configured` as a blocked marker comment.
- Codex CLI quota/auth/rate-limit failures record concrete blockers such as `openai_quota_exceeded`.
- Blocked comments can include raw failure details for Butler summary and human judgment.

## Unsatisfied Success Criteria
- This does not make quota exhaustion disappear; it makes the blocker visible and machine-readable.
- PR #148 still needs reviewer evidence to complete after this fix is merged or reviewer quota recovers.

## Non-goal violations
None.

## Verification Evidence
- Unit: `node --test test/codex-review-fallback.test.js test/execution-continuity.test.js test/butler-review-synthesis.test.js`
- Integration: `npm test` (469 pass)
- E2E: Not run; this PR fixes the blocker reporting path observed on PR #148.
- Manual: Confirmed PR #148 currently has a stale `requested` marker after Codex fallback quota failure.
- Evidence path/link: scripts/run-codex-pr-review-fallback.mjs, src/core/codex-review-fallback.js, test/codex-review-fallback.test.js

## Surface Update Checklist
- Cloudflare deploy: not required; GitHub Actions reviewer script only.
- Custom GPT Action Schema update: not required.
- Custom GPT Instructions update: not required.
- iPhone Butler live E2E: not required for this PR; this improves the reviewer blocker evidence surface.

## Related Constitution Rules
- Current Reality Guard
- Evidence Discipline
- Butler and Reviewer as Stop Roles

## Out-of-scope but NOT implemented
- Quota/billing mutation
- Secret mutation
- Deploy
- Merge
- Reviewer backend redesign

## Extra changes (if any)
None.

Refs #125