### PR TITLE
Add passkey operator PR merge path

### DIFF
--- a/docs/setup/custom-gpt-instructions-short.md
+++ b/docs/setup/custom-gpt-instructions-short.md
@@ -14,10 +14,7 @@ Core:
 - Do not invent scope beyond active Issue/user instruction.
 - For vtddGateway/vtddExecute, use surface=custom_gpt, judgmentModelId=vtdd-butler-core-v1.
 
-Role separation:
-- Butler reads/judges/summarizes. Codex codes/PRs. Reviewer critiques. Human owns GO/passkey.
-
-Repository listing and nickname memory:
+Repo/nickname:
 - For repository candidates/list, call vtddGateway in exploration mode.
 - Repo list: exploration/read_only, repositoryInput=unknown, targetConfirmed=false, runtimeAvailable=false, safeFallbackChosen=true, consent=["read"].
 - Remember repo nickname: vtddUpsertRepositoryNickname.
@@ -30,7 +27,6 @@ Repository listing and nickname memory:
 
 GitHub read plane:
 - Use vtddRetrieveGitHub for repos, issues, PRs, reviews, comments, checks, runs, branches.
-- Prefer vtddRetrieveGitHub.
 - If the route is unsupported, say 未対応 for that exact read.
 - If auth fails, say 認証失敗.
 - Do not infer absence from unsupported or failed reads.
@@ -40,7 +36,7 @@ Self-parity:
 - If runtimeParity is `cloudflare_deploy_update_required`, say `Cloudflare deploy update required`.
 - If in_sync but Butler lacks features, say `Action Schema update required` and/or `Instructions update required`.
 - If parity cannot be checked, say `未検証` or `認証失敗`.
-- If action returns error/reason/issues, summarize exact fields; no generic guesses.
+- If action returns error/reason/issues, summarize exact fields.
 - If self-parity returns `ClientResponseError`, say unverified Action transport failure; Action Schema may need refresh.
 - Use vtddRetrieveSetupArtifact for canonical setup artifacts: instructions, openapi_yaml, openapi_json.
 - If runtime in sync, do not overclaim editor sync.
@@ -62,8 +58,6 @@ Remote Codex flow:
 - Default transport is codex_cloud_github_comment; queued comment is delegation evidence, not execution evidence.
 - API runner approval: set executorTransport=api_key_runner and apiKeyRunnerAcknowledged=true; uses OPENAI_API_KEY.
 - api_key_runner: report workflowRunId/workflowUrl/workflowConclusion; surface missing OPENAI_API_KEY.
-- Preserve repo, issue, branch, base, goal, scope/non-goals.
-- Preferred goals: open_pr, revise_pr, respond_to_review.
 
 GitHub normal write plane:
 - Use vtddWriteGitHub only for scoped GO-tier writes:
@@ -81,6 +75,8 @@ GitHub high-risk authority plane:
   - pull_merge
   - issue_close
 - Confirm approval grant, repository scope, and explicit human request before using it.
+- For pull_merge no grant, show short `[Open merge operator](<full absolute operator URL>)` with repositoryInput, phase=execution, issueNumber, pullNumber, actionType=merge, highRiskKind=pull_merge, mergeMethod=squash; no bare URL/manual query.
+- Operator may approve+dispatch PR merge; then re-read runtime truth before saying merged.
 - For issue_close, include the merged PR number used to prove bounded scope.
 - Do not route deploy or other destructive provider actions through vtddGitHubAuthority.
 

--- a/docs/setup/custom-gpt-instructions.md
+++ b/docs/setup/custom-gpt-instructions.md
@@ -240,6 +240,9 @@ GitHub high-risk authority plane:
   - ensure the user has explicitly requested the action
 - For merge:
   - operation=`pull_merge`
+  - if no merge-scoped approval grant is available yet, present a short clickable Markdown link to the same-origin passkey operator helper; the href must be the full absolute URL with `repositoryInput=<resolved repo>`, `phase=execution`, `issueNumber=<parent/active issue>`, `pullNumber=<PR number>`, `actionType=merge`, `highRiskKind=pull_merge`, and `mergeMethod=squash` unless the human asked for another merge method
+  - use a short label such as `[Open merge operator](<actual URL>)`; do not paste a bare long URL or ask the human to rebuild query parameters
+  - after the passkey approval, the operator page may dispatch `vtddGitHubAuthority` for the PR merge; then re-read GitHub runtime truth before saying the PR is merged
 - For bounded issue close:
   - operation=`issue_close`
   - include the merged PR number used to prove bounded post-merge scope

--- a/src/core/passkey-operator-page.js
+++ b/src/core/passkey-operator-page.js
@@ -6,9 +6,11 @@ export function renderPasskeyOperatorPage(input = {}) {
   const registrationDefaultOperatorLabel = escapeHtml(input.operatorLabel || "VTDD Operator");
   const repoDefault = escapeHtml(input.repositoryInput || "");
   const issueDefault = escapeHtml(input.issueNumber || "");
+  const pullNumberDefault = escapeHtml(input.pullNumber || "");
   const phaseDefault = escapeHtml(input.phase || "execution");
   const actionTypeDefault = escapeHtml(input.actionType || "destructive");
   const highRiskKindDefault = escapeHtml(input.highRiskKind || "github_app_secret_sync");
+  const mergeMethodDefault = escapeHtml(input.mergeMethod || "squash");
   const returnUrl = escapeHtml(input.returnUrl || "");
   const syncEnabled = input.syncEnabled === true;
   const syncMessage = escapeHtml(
@@ -197,7 +199,7 @@ export function renderPasskeyOperatorPage(input = {}) {
             <input id="auto-copy-approval-grant-input" type="checkbox" />
             Auto-copy approvalGrantId after approval
           </label>
-          <p class="muted">GitHub App secret sync なら <code>actionType=destructive</code> / <code>highRiskKind=github_app_secret_sync</code>、production deploy なら <code>actionType=deploy_production</code> / <code>highRiskKind=deploy_production</code> を使います。</p>
+          <p class="muted">GitHub App secret sync なら <code>actionType=destructive</code> / <code>highRiskKind=github_app_secret_sync</code>、production deploy なら <code>actionType=deploy_production</code> / <code>highRiskKind=deploy_production</code>、PR merge なら <code>actionType=merge</code> / <code>highRiskKind=pull_merge</code> を使います。</p>
           <pre id="approve-output"></pre>
         </section>
 
@@ -224,7 +226,22 @@ export function renderPasskeyOperatorPage(input = {}) {
         </section>
 
         <section>
-          <h2>5. Codex Fallback Secret Sync</h2>
+          <h2>5. GitHub PR Merge</h2>
+          <p class="muted">PR merge 用の real passkey approval 後、この helper から same-origin の GitHub authority path を dispatch します。</p>
+          <label for="pull-number-input">Pull Number</label>
+          <input id="pull-number-input" value="${pullNumberDefault}" placeholder="148" />
+          <label for="merge-method-input">Merge Method</label>
+          <input id="merge-method-input" value="${mergeMethodDefault}" placeholder="squash" />
+          <div class="row">
+            <button id="merge-button">Dispatch PR merge</button>
+            <a class="button-link" id="merge-pr-link" href="#" target="_blank" rel="noopener noreferrer" hidden>Open pull request</a>
+          </div>
+          <p class="muted"><code>actionType=merge</code> / <code>highRiskKind=pull_merge</code> の approvalGrantId が必要です。merge 後は GitHub runtime truth で merged 状態を確認してください。</p>
+          <pre id="merge-output"></pre>
+        </section>
+
+        <section>
+          <h2>6. Codex Fallback Secret Sync</h2>
           <p class="muted">Codex reviewer fallback 用の <code>OPENAI_API_KEY</code> を GitHub Actions secret に同期します。値は Butler 会話に貼らず、この operator page から送信します。</p>
           <label for="openai-api-key-input">OPENAI_API_KEY</label>
           <input id="openai-api-key-input" type="password" autocomplete="off" placeholder="sk-..." />
@@ -242,10 +259,12 @@ export function renderPasskeyOperatorPage(input = {}) {
       const approveOutput = document.getElementById("approve-output");
       const syncOutput = document.getElementById("sync-output");
       const deployOutput = document.getElementById("deploy-output");
+      const mergeOutput = document.getElementById("merge-output");
       const openaiSecretSyncOutput = document.getElementById("openai-secret-sync-output");
       const copyApprovalGrantButton = document.getElementById("copy-approval-grant-button");
       const autoCopyApprovalGrantInput = document.getElementById("auto-copy-approval-grant-input");
       const deployRunLink = document.getElementById("deploy-run-link");
+      const mergePrLink = document.getElementById("merge-pr-link");
       let latestApprovalGrantId = "";
 
       async function readResponseBody(response) {
@@ -356,6 +375,46 @@ export function renderPasskeyOperatorPage(input = {}) {
         }
         deployRunLink.href = runUrl;
         deployRunLink.hidden = false;
+      }
+
+      function extractMergePullRequestUrl(body) {
+        return body?.authorityAction?.htmlUrl || body?.authorityAction?.pullRequestUrl || "";
+      }
+
+      function normalizeGitHubPullRequestUrl(value) {
+        const text = String(value || "");
+        if (!text) {
+          return "";
+        }
+        try {
+          const url = new URL(text);
+          if (url.protocol !== "https:" || url.hostname.toLowerCase() !== "github.com") {
+            return "";
+          }
+          if (!/\\/pull\\/\\d+(?:$|[/?#])/.test(url.pathname + url.search + url.hash)) {
+            return "";
+          }
+          return url.href;
+        } catch {
+          return "";
+        }
+      }
+
+      function clearMergePrLink() {
+        if (!mergePrLink) {
+          return;
+        }
+        mergePrLink.href = "#";
+        mergePrLink.hidden = true;
+      }
+
+      function showMergePrLink(body) {
+        const prUrl = normalizeGitHubPullRequestUrl(extractMergePullRequestUrl(body));
+        if (!prUrl || !mergePrLink) {
+          return;
+        }
+        mergePrLink.href = prUrl;
+        mergePrLink.hidden = false;
       }
 
       copyApprovalGrantButton.addEventListener("click", async () => {
@@ -511,6 +570,42 @@ export function renderPasskeyOperatorPage(input = {}) {
           deployOutput.textContent = JSON.stringify(deployBody, null, 2);
         } catch (error) {
           deployOutput.textContent = String(error);
+        }
+      });
+
+      document.getElementById("merge-button").addEventListener("click", async () => {
+        try {
+          if (!latestApprovalGrantId) {
+            throw new Error("approvalGrantId is required before PR merge");
+          }
+          clearMergePrLink();
+          mergeOutput.textContent = "PR merge request...";
+          const mergeResponse = await fetch("${apiBase}/action/github-authority", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({
+              operation: "pull_merge",
+              repository: document.getElementById("repo-input").value,
+              pullNumber: Number(document.getElementById("pull-number-input").value || 0) || null,
+              mergeMethod: document.getElementById("merge-method-input").value || "squash",
+              issueContext: {
+                issueNumber: Number(document.getElementById("issue-input").value || 0) || null
+              },
+              policyInput: {
+                approvalPhrase: "GO",
+                approvalGrantId: latestApprovalGrantId,
+                targetConfirmed: true
+              }
+            })
+          });
+          const mergeBody = await readResponseBody(mergeResponse);
+          if (!mergeResponse.ok) {
+            throw responseError(mergeBody, "PR merge failed");
+          }
+          showMergePrLink(mergeBody);
+          mergeOutput.textContent = JSON.stringify(mergeBody, null, 2);
+        } catch (error) {
+          mergeOutput.textContent = String(error);
         }
       });
 

--- a/src/worker.js
+++ b/src/worker.js
@@ -180,7 +180,11 @@ export default {
     }
 
     if (request.method === "POST" && isApiPath(url.pathname, "/action/github-authority")) {
-      const auth = authorizeGatewayRequest({ request, env, apiSuffix: "/action/github-authority" });
+      const auth = authorizePasskeyBrowserOrMachineRequest({
+        request,
+        env,
+        apiSuffix: "/action/github-authority"
+      });
       if (!auth.ok) {
         return json(auth.status, {
           ok: false,
@@ -880,10 +884,7 @@ async function handleGitHubHighRiskPlaneRequest(request, env) {
     commitMessage: payload.commitMessage,
     approvalPhrase: policyInput.approvalPhrase,
     targetConfirmed: policyInput.targetConfirmed,
-    approvalGrant:
-      payload.approvalGrant ??
-      policyInput.approvalGrant ??
-      resolvedApprovalGrant.approvalGrant,
+    approvalGrant: resolvedApprovalGrant.approvalGrant,
     approvalScope,
     env
   });
@@ -1020,9 +1021,11 @@ function handlePasskeyOperatorPageRequest(request) {
     syncApiBase,
     repositoryInput: url.searchParams.get("repositoryInput"),
     issueNumber: url.searchParams.get("issueNumber"),
+    pullNumber: url.searchParams.get("pullNumber"),
     phase: url.searchParams.get("phase") || "execution",
     actionType: url.searchParams.get("actionType") || "destructive",
     highRiskKind: url.searchParams.get("highRiskKind") || "github_app_secret_sync",
+    mergeMethod: url.searchParams.get("mergeMethod") || "squash",
     returnUrl: normalizeOperatorReturnUrl(url.searchParams.get("returnUrl")),
     operatorId: url.searchParams.get("operatorId") || "vtdd-operator",
     operatorLabel: url.searchParams.get("operatorLabel") || "VTDD Operator",

--- a/test/passkey-operator-page.test.js
+++ b/test/passkey-operator-page.test.js
@@ -18,13 +18,16 @@ test("passkey operator page can target explicit api base and sync endpoint", () 
   assert.equal(html.includes('fetch("/api/approval/passkey/challenge"'), true);
   assert.equal(html.includes('fetch("http://127.0.0.1:8789/api/github-app-secret-sync/execute"'), true);
   assert.equal(html.includes('fetch("/api/action/deploy"'), true);
+  assert.equal(html.includes('fetch("/api/action/github-authority"'), true);
   assert.equal(html.includes('fetch("/api/action/github-actions-secret"'), true);
   assert.equal(html.includes("readResponseBody"), true);
   assert.equal(html.includes("non_json_response"), true);
   assert.equal(html.includes("Sync GitHub App secrets"), true);
   assert.equal(html.includes("Sync OPENAI_API_KEY"), true);
   assert.equal(html.includes("Dispatch production deploy"), true);
+  assert.equal(html.includes("Dispatch PR merge"), true);
   assert.equal(html.includes("Open deploy run"), true);
+  assert.equal(html.includes("Open pull request"), true);
   assert.equal(html.includes("Return to Butler"), true);
   assert.equal(html.includes('href="https://chatgpt.com/g/example-butler"'), true);
   assert.equal(html.includes("Butler 会話に貼らず"), true);
@@ -33,6 +36,26 @@ test("passkey operator page can target explicit api base and sync endpoint", () 
   assert.equal(html.includes('id="action-type-input" value="deploy_production"'), true);
   assert.equal(html.includes('repositoryInput: document.getElementById("repo-input").value'), true);
   assert.equal(html.includes('issueNumber: Number(document.getElementById("issue-input").value || 0) || null'), true);
+});
+
+test("passkey operator page pre-fills PR merge fields from URL input", () => {
+  const html = renderPasskeyOperatorPage({
+    repositoryInput: "marushu/vtdd-v2-p",
+    issueNumber: 125,
+    pullNumber: 148,
+    phase: "execution",
+    actionType: "merge",
+    highRiskKind: "pull_merge",
+    mergeMethod: "squash"
+  });
+
+  assert.equal(html.includes('id="repo-input" value="marushu/vtdd-v2-p"'), true);
+  assert.equal(html.includes('id="issue-input" value="125"'), true);
+  assert.equal(html.includes('id="pull-number-input" value="148"'), true);
+  assert.equal(html.includes('id="action-type-input" value="merge"'), true);
+  assert.equal(html.includes('id="risk-kind-input" value="pull_merge"'), true);
+  assert.equal(html.includes('id="merge-method-input" value="squash"'), true);
+  assert.equal(html.includes('operation: "pull_merge"'), true);
 });
 
 test("passkey operator page keeps sync disabled message when helper endpoint is absent", () => {
@@ -212,6 +235,50 @@ test("passkey operator page rejects unsafe or missing deploy run links", () => {
   });
   assert.equal(deployRunLink.href, "#");
   assert.equal(deployRunLink.hidden, true);
+});
+
+test("passkey operator page exposes safe PR link from merge response", () => {
+  const mergePrLink = {
+    href: "#",
+    hidden: true
+  };
+  const helpers = loadOperatorPageHelpers({
+    document: {
+      getElementById(id) {
+        if (id === "merge-pr-link") {
+          return mergePrLink;
+        }
+        return {
+          value: "",
+          textContent: "",
+          addEventListener() {}
+        };
+      }
+    }
+  });
+
+  helpers.showMergePrLink({
+    ok: true,
+    authorityAction: {
+      htmlUrl: "https://github.com/sample-org/vtdd-v2-p/pull/148"
+    }
+  });
+
+  assert.equal(mergePrLink.href, "https://github.com/sample-org/vtdd-v2-p/pull/148");
+  assert.equal(mergePrLink.hidden, false);
+
+  helpers.clearMergePrLink();
+  assert.equal(mergePrLink.href, "#");
+  assert.equal(mergePrLink.hidden, true);
+
+  helpers.showMergePrLink({
+    ok: true,
+    authorityAction: {
+      htmlUrl: "https://evil.example/sample-org/vtdd-v2-p/pull/148"
+    }
+  });
+  assert.equal(mergePrLink.href, "#");
+  assert.equal(mergePrLink.hidden, true);
 });
 
 function loadOperatorPageHelpers(overrides = {}) {

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -1282,7 +1282,7 @@ test("worker can resolve passkey memory provider from Cloudflare D1 binding fall
 test("worker serves passkey operator page", async () => {
   const response = await worker.fetch(
     new Request(
-      "https://example.com/v2/approval/passkey/operator?repositoryInput=marushu%2Fvtdd-v2-p&issueNumber=15&phase=execution&actionType=deploy_production&highRiskKind=deploy_production&returnUrl=https%3A%2F%2Fchatgpt.com%2Fg%2Fexample-butler"
+      "https://example.com/v2/approval/passkey/operator?repositoryInput=marushu%2Fvtdd-v2-p&issueNumber=15&pullNumber=148&phase=execution&actionType=merge&highRiskKind=pull_merge&mergeMethod=squash&returnUrl=https%3A%2F%2Fchatgpt.com%2Fg%2Fexample-butler"
     ),
     gatewayAuthEnv
   );
@@ -1294,9 +1294,12 @@ test("worker serves passkey operator page", async () => {
   assert.equal(html.includes("/v2/approval/passkey/challenge"), true);
   assert.equal(html.includes('id="repo-input" value="marushu/vtdd-v2-p"'), true);
   assert.equal(html.includes('id="issue-input" value="15"'), true);
+  assert.equal(html.includes('id="pull-number-input" value="148"'), true);
   assert.equal(html.includes('id="phase-input" value="execution"'), true);
-  assert.equal(html.includes('id="action-type-input" value="deploy_production"'), true);
-  assert.equal(html.includes('id="risk-kind-input" value="deploy_production"'), true);
+  assert.equal(html.includes('id="action-type-input" value="merge"'), true);
+  assert.equal(html.includes('id="risk-kind-input" value="pull_merge"'), true);
+  assert.equal(html.includes('id="merge-method-input" value="squash"'), true);
+  assert.equal(html.includes("Dispatch PR merge"), true);
   assert.equal(html.includes('href="https://chatgpt.com/g/example-butler"'), true);
   assert.equal(html.includes('href="https://evil.example/phish"'), false);
 });
@@ -2475,6 +2478,130 @@ test("worker executes GitHub merge on the high-risk authority plane with approva
   assert.equal(body.ok, true);
   assert.equal(body.authorityAction.operation, "pull_merge");
   assert.equal(body.authorityAction.merged, true);
+});
+
+test("worker allows same-origin passkey operator to dispatch GitHub merge authority", async () => {
+  const provider = createInMemoryMemoryProvider();
+  await provider.store({
+    id: "approval-merge-browser-123",
+    type: MemoryRecordType.APPROVAL_LOG,
+    content: {
+      kind: "passkey_grant",
+      status: "verified",
+      approvalId: "approval-merge-browser-123",
+      expiresAt: "2099-01-01T00:00:00.000Z",
+      scope: {
+        actionType: "merge",
+        highRiskKind: "pull_merge",
+        repositoryInput: "sample-org/vtdd-v2-p",
+        issueNumber: "55",
+        relatedIssue: "55",
+        phase: "execution"
+      }
+    },
+    metadata: { source: "test" },
+    priority: 90,
+    tags: ["passkey_grant"],
+    createdAt: "2026-04-26T00:00:00.000Z"
+  });
+
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/action/github-authority", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        origin: "https://example.com",
+        "sec-fetch-site": "same-origin"
+      },
+      body: JSON.stringify({
+        operation: "pull_merge",
+        repository: "sample-org/vtdd-v2-p",
+        pullNumber: 21,
+        issueContext: {
+          issueNumber: 55
+        },
+        policyInput: {
+          approvalPhrase: "GO",
+          approvalGrantId: "approval-merge-browser-123",
+          targetConfirmed: true
+        }
+      })
+    }),
+    {
+      MEMORY_PROVIDER: provider,
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_high_risk",
+      GITHUB_API_FETCH: async () =>
+        new Response(
+          JSON.stringify({
+            sha: "abc123",
+            merged: true,
+            message: "Pull Request successfully merged"
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        )
+    }
+  );
+
+  assert.equal(response.status, 200);
+  const body = await response.json();
+  assert.equal(body.ok, true);
+  assert.equal(body.authorityAction.operation, "pull_merge");
+  assert.equal(body.authorityAction.htmlUrl, "https://github.com/sample-org/vtdd-v2-p/pull/21");
+});
+
+test("worker rejects fabricated browser approval grants on the GitHub authority plane", async () => {
+  let githubCalled = false;
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/action/github-authority", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        origin: "https://example.com",
+        "sec-fetch-site": "same-origin"
+      },
+      body: JSON.stringify({
+        operation: "pull_merge",
+        repository: "sample-org/vtdd-v2-p",
+        pullNumber: 21,
+        issueContext: {
+          issueNumber: 55
+        },
+        approvalGrant: {
+          approvalId: "fabricated-approval",
+          verified: true,
+          expiresAt: "2099-01-01T00:00:00.000Z",
+          scope: {
+            actionType: "merge",
+            highRiskKind: "pull_merge",
+            repositoryInput: "sample-org/vtdd-v2-p",
+            issueNumber: "55",
+            relatedIssue: "55",
+            phase: "execution"
+          }
+        },
+        policyInput: {
+          approvalPhrase: "GO",
+          targetConfirmed: true
+        }
+      })
+    }),
+    {
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_high_risk",
+      GITHUB_API_FETCH: async () => {
+        githubCalled = true;
+        return new Response(JSON.stringify({ merged: true }), {
+          status: 200,
+          headers: { "content-type": "application/json" }
+        });
+      }
+    }
+  );
+
+  assert.equal(response.status, 422);
+  const body = await response.json();
+  assert.equal(body.ok, false);
+  assert.equal(body.issues.some((issue) => String(issue).includes("real passkey approval grant is required")), true);
+  assert.equal(githubCalled, false);
 });
 
 test("worker blocks bounded issue close on the high-risk authority plane when merged pull proof is missing", async () => {


### PR DESCRIPTION
## This PR satisfies Intent

Make Butler's merge path usable from iPhone/mobile by giving the passkey operator page a PR merge dispatch path, not just deploy/secret sync helpers.

This addresses the live Butler-origin gap observed after PR #148: Butler could explain that merge needs GO + passkey, but the operator surface did not provide a merge URL/path equivalent to deploy.

## Satisfied Success Criteria

- Butler can present a short `[Open merge operator](...)` Markdown link with repository, issue, PR, action type, risk kind, and merge method prefilled.
- The passkey operator page can approve with real passkey and dispatch `pull_merge` through the existing GitHub authority plane.
- Same-origin browser dispatch to `/v2/action/github-authority` is accepted while existing bearer-token machine auth remains supported.
- After dispatch, Butler instructions require re-reading GitHub runtime truth before saying the PR is merged.

## Unsatisfied Success Criteria

- None for this bounded slice.
- Live Butler-on-iPhone merge must still be verified after merge + Cloudflare deploy + Instructions update.

## Verification Evidence

- `node --test test/passkey-operator-page.test.js test/worker.test.js test/custom-gpt-setup-docs.test.js test/github-high-risk-plane.test.js`
- `npm test` (472 passing)

## Surface Update Checklist

- Action Schema update: not required; existing `vtddGitHubAuthority` operation is reused.
- Instructions update: required after merge, because Butler must learn to emit the short merge operator link.
- Cloudflare deploy: required after merge, because worker/operator runtime changed.

## Changes

- Add PR merge fields and dispatch button to the passkey operator page:
  - `pullNumber`
  - `mergeMethod`
  - `actionType=merge`
  - `highRiskKind=pull_merge`
- Allow same-origin passkey operator browser requests to call `/v2/action/github-authority`, while preserving existing bearer-token machine auth.
- Teach Custom GPT instructions to present a short merge operator Markdown link instead of a bare long URL or manual query assembly.
- Add tests for URL prefill, safe PR link rendering, same-origin browser authority dispatch, and existing machine-authority merge behavior.

## Non-goals

- No passkeyless merge.
- No deploy behavior change.
- No reviewer backend change.
- No Action Schema operation change.
- No issue close automation.
