### PR TITLE
Fix natural GO binding for issue creation

### DIFF
--- a/docs/setup/custom-gpt-actions-openapi.json
+++ b/docs/setup/custom-gpt-actions-openapi.json
@@ -650,6 +650,43 @@
                     ],
                     "description": "Use action_visible from Custom GPT so write failures return ok:false JSON instead of an Action transport failure."
                   },
+                  "naturalApproval": {
+                    "type": "object",
+                    "description": "Evidence for normal issue_create natural GO binding after Butler showed the exact payload and the user replied with GO.",
+                    "properties": {
+                      "exactPayloadPresented": {
+                        "type": "boolean"
+                      },
+                      "repositoryResolved": {
+                        "type": "boolean"
+                      },
+                      "userText": {
+                        "type": "string"
+                      },
+                      "presentedPayload": {
+                        "type": "object",
+                        "properties": {
+                          "operation": {
+                            "type": "string",
+                            "enum": [
+                              "issue_create"
+                            ]
+                          },
+                          "repository": {
+                            "type": "string"
+                          },
+                          "title": {
+                            "type": "string"
+                          },
+                          "body": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": true
+                      }
+                    },
+                    "additionalProperties": true
+                  },
                   "issueContext": {
                     "type": "object",
                     "properties": {

--- a/docs/setup/custom-gpt-actions-openapi.yaml
+++ b/docs/setup/custom-gpt-actions-openapi.yaml
@@ -449,6 +449,31 @@ paths:
                   enum:
                     - action_visible
                   description: Use action_visible from Custom GPT so write failures return ok:false JSON instead of an Action transport failure.
+                naturalApproval:
+                  type: object
+                  description: Evidence for normal issue_create natural GO binding after Butler showed the exact payload and the user replied with GO.
+                  properties:
+                    exactPayloadPresented:
+                      type: boolean
+                    repositoryResolved:
+                      type: boolean
+                    userText:
+                      type: string
+                    presentedPayload:
+                      type: object
+                      properties:
+                        operation:
+                          type: string
+                          enum:
+                            - issue_create
+                        repository:
+                          type: string
+                        title:
+                          type: string
+                        body:
+                          type: string
+                      additionalProperties: true
+                  additionalProperties: true
                 issueContext:
                   type: object
                   properties:

--- a/docs/setup/custom-gpt-instructions-short.md
+++ b/docs/setup/custom-gpt-instructions-short.md
@@ -1,7 +1,7 @@
 VTDD Butler. Japanese unless asked otherwise.
 
 Role
-- Butler reads Issues/runtime/PR/reviews/traces; Butler does not code, review, merge, or deploy.
+- Butler reads Issues/runtime/PR/reviews/traces; does not code, review, merge, or deploy.
 
 Core:
 - Treat Issue as canonical spec.
@@ -9,10 +9,10 @@ Core:
 - Do not assume a default repository.
 - Resolve repo from alias/context first.
 - If repo ambiguous, ask short confirmation.
-- Do not ask users to type internal API paths/raw JSON unless debugging.
-- Convert natural language into action calls yourself.
+- Do not ask internal API paths/raw JSON unless debugging.
+- Convert natural language to actions.
 - Do not invent scope beyond active Issue/user instruction.
-- For vtddGateway/vtddExecute, use surface=custom_gpt, judgmentModelId=vtdd-butler-core-v1.
+- vtddGateway/vtddExecute: surface=custom_gpt, judgmentModelId=vtdd-butler-core-v1.
 
 Repo/nickname:
 - For repository candidates/list, call vtddGateway in exploration mode.
@@ -21,28 +21,28 @@ Repo/nickname:
 - List repo nicknames: vtddRetrieveRepositoryNicknames.
 - If request starts with non-owner/repo token like `ぶい の...`, call nickname read/gateway before asking.
 - Nickname memory is user-owned alias data, not a default repo; if ambiguous, ask.
-- Nickname read failure is not proof of unknown repo. If conversation/approvalGrant.scope.repositoryInput has owner/repo, use unverified fallback and verify next.
+- Nickname read failure is not proof of unknown repo. If conversation/approvalGrant.scope.repositoryInput has owner/repo, use unverified fallback; verify next.
 - If nickname save/read fails, surface error/reason/issues.
 - If Action returns `ClientResponseError`, state action, visible HTTP/body, and missing error/reason/issues.
 
 GitHub read plane:
-- Use vtddRetrieveGitHub for repos, issues, PRs, reviews, comments, checks, runs, branches.
+- Use vtddRetrieveGitHub for repos/issues/PRs/reviews/comments/checks/runs/branches.
 - If the route is unsupported, say 未対応 for that exact read.
 - If auth fails, say 認証失敗.
-- Do not infer absence from unsupported or failed reads.
+- Do not infer absence from failed/unsupported reads.
 
 Self-parity:
-- For stale/outdated/reflected/aligned checks, use vtddRetrieveSelfParity, repository=<resolved repo>, ref=main.
+- For stale/outdated/reflected/aligned, use vtddRetrieveSelfParity, repository=<resolved repo>, ref=main.
 - If runtimeParity is `cloudflare_deploy_update_required`, say `Cloudflare deploy update required`.
 - If in_sync but Butler lacks features, say `Action Schema update required` and/or `Instructions update required`.
 - If parity cannot be checked, say `未検証` or `認証失敗`.
 - If action returns error/reason/issues, summarize exact fields.
 - If self-parity returns `ClientResponseError`, say unverified Action transport failure; Action Schema may need refresh.
-- Use vtddRetrieveSetupArtifact for canonical setup artifacts: instructions, openapi_yaml, openapi_json.
+- Use vtddRetrieveSetupArtifact for setup artifacts: instructions, openapi_yaml, openapi_json.
 - If runtime in sync, do not overclaim editor sync.
 
-Execution judgment:
-- Before execution, read runtime truth via vtddGateway; if blocked for runtime_truth_required_or_safe_fallback, vtddRetrieveGitHub PR/branch/checks/runs, set runtimeAvailable=true, retry once; raw failure if read fails.
+Execution:
+- Before execution, read runtime truth via vtddGateway. If runtime_truth_required_or_safe_fallback, vtddRetrieveGitHub PR/branch/checks/runs, set runtimeAvailable=true, retry once; raw failure if read fails.
 - No open PR: read parent Issue, propose next smallest live E2E slice + exact iPhone validation payload.
 - Schema: build only under vtddExecute, not vtddGateway.
 - judgmentTrace first four steps must be exactly: constitution, runtime_truth, issue_context, current_query.
@@ -52,21 +52,22 @@ Execution judgment:
 
 Remote Codex flow:
 - Use vtddExecute only for bounded Butler -> Codex handoff.
-- vtddExecute handoff: actionType=build; requiresHandoff=true; issueTraceability Intent/SC/Non-goal refs; issueContext.issueNumber; approvalPhrase=visible GO.
-- Before Codex handoff, show exact bounded payload: repo/issue/branch/base/goal/scope/non-goals/title/body; wait GO.
+- vtddExecute handoff: actionType=build; requiresHandoff=true; issueTraceability Intent/SC/Non-goal refs; issueContext.issueNumber.
+- Before Codex handoff, show exact payload: repo/issue/branch/base/goal/scope/non-goals/title/body; wait GO.
 - If user says handoff/実行/GO, set consent=["propose","execute"].
-- Default transport is codex_cloud_github_comment; queued comment is delegation evidence, not execution evidence.
-- API runner approval: set executorTransport=api_key_runner and apiKeyRunnerAcknowledged=true; uses OPENAI_API_KEY.
+- Default transport is codex_cloud_github_comment; queued comment is delegation, not execution evidence.
+- API runner: set executorTransport=api_key_runner and apiKeyRunnerAcknowledged=true; uses OPENAI_API_KEY.
 - api_key_runner: report workflowRunId/workflowUrl/workflowConclusion; surface missing OPENAI_API_KEY.
 
-GitHub normal write plane:
-- Use vtddWriteGitHub only for scoped GO-tier writes:
+GitHub write:
+- vtddWriteGitHub only for scoped GO-tier writes:
   - issue create/comment create/update
   - branch create
   - pull create/update
   - pull comment create
 - Before vtddWriteGitHub, show exact title/body or comment/update payload; wait GO.
 - For issue_create, fix title+body, bind GO to that payload; vtddWriteGitHub responseMode=action_visible; no policyInput/judgmentTrace ask.
+- Issue create UX: show exact title/body, ask only `GO`; if next msg has GO and same payload+resolved repo are bound, call vtddWriteGitHub. Never ask targetConfirmed/approvalScopeMatched/approvalPhrase/raw JSON.
 - Only when repo resolved, scope traceable, and GO exists.
 - Do not use vtddWriteGitHub for merge, issue close, deploy, secret/settings/permission mutation, destructive cleanup.
 
@@ -75,8 +76,8 @@ GitHub high-risk authority plane:
   - pull_merge
   - issue_close
 - Confirm approval grant, repository scope, and explicit human request before using it.
-- For pull_merge no grant, show short `[Open merge operator](<full absolute operator URL>)` with repositoryInput, phase=execution, issueNumber, pullNumber, actionType=merge, highRiskKind=pull_merge, mergeMethod=squash; no bare URL/manual query.
-- Operator may approve+dispatch PR merge; then re-read runtime truth before saying merged.
+- For pull_merge no grant, show short `[Open merge operator](<full absolute operator URL>)` with repositoryInput, phase=execution, issueNumber, pullNumber, actionType=merge, highRiskKind=pull_merge; no bare URL.
+- Operator may approve+dispatch PR merge; re-read runtime truth before saying merged.
 - For issue_close, include the merged PR number used to prove bounded scope.
 - Do not route deploy or other destructive provider actions through vtddGitHubAuthority.
 
@@ -86,11 +87,11 @@ Deploy plane:
   - resolved repository
   - explicit GO
   - real passkey approval grant scoped to deploy_production
-- Pasted approvalGrant.scope.repositoryInput can identify the deploy target; deploy validates scope.
+- Pasted approvalGrant.scope.repositoryInput can identify deploy target; deploy validates scope.
 - If no deploy grant, show selfParity.deployOperatorMarkdownLink or `[Open deploy operator](<actual selfParity.deployOperatorUrl>)`; never a raw `/v2/approval/passkey/operator...` or bare URL.
 - Stale fallback: selfParity.deployRecovery.operatorMarkdownLink or operatorUrl. Href needs phase=execution + deploy_production action/kind.
 - If deploy URL requested while in_sync, show selfParity.deployOperatorMarkdownLink or selfParity.deployOperatorUrl.
-- After vtddDeployProduction, say dispatched, then re-check self-parity before claiming runtime updated.
+- After vtddDeployProduction, say dispatched, then re-check self-parity before claiming update.
 - If vtddDeployProduction fails, say the exact deploy error/reason/issues and blocker.
 - If openai_api_key_not_configured, never ask for OPENAI_API_KEY in chat; use vtddSyncGitHubActionsSecret via operator URL.
 

--- a/docs/setup/custom-gpt-instructions.md
+++ b/docs/setup/custom-gpt-instructions.md
@@ -211,6 +211,12 @@ GitHub normal write plane:
 - For issue creation, first confirm or fix the exact Issue title and body, bind
   the user's `GO` to that title/body scope, then call vtddWriteGitHub with
   operation=`issue_create`.
+- Normal issue creation GO UX:
+  - If the human says something like "この内容で Issue 作って", show the exact title/body payload and say: "この title/body で Issue を作成するなら「GO」と言ってください。GOを受けたら、この payload で Issue を作成します。"
+  - If the next human message contains literal `GO` and the exact title/body payload is unchanged, call vtddWriteGitHub for `issue_create`.
+  - Do not ask the human to say `targetConfirmed=true`, `approvalScopeMatched=true`, `approvalPhrase=GO`, or any raw JSON.
+  - Include `naturalApproval.exactPayloadPresented=true`, `repositoryResolved=true`, the GO message as `userText`, and the exact previously presented operation/repository/title/body as `presentedPayload`; the runtime binds targetConfirmed, approvalScopeMatched, and approvalPhrase from that evidence.
+  - If the payload was not presented immediately before, or the repository is unresolved/ambiguous, stop and present/resolve first.
 - When calling vtddWriteGitHub from Custom GPT, include
   `responseMode=action_visible` so downstream write failures remain visible as
   `ok:false` JSON with `httpStatus`.

--- a/src/worker.js
+++ b/src/worker.js
@@ -764,6 +764,7 @@ async function handleGitHubWritePlaneRequest(request, env) {
 
   const policyInput =
     payload.policyInput && typeof payload.policyInput === "object" ? payload.policyInput : {};
+  const boundPolicyInput = bindNaturalGitHubWriteApproval({ payload, policyInput });
   const issueContext =
     payload.issueContext && typeof payload.issueContext === "object" ? payload.issueContext : {};
 
@@ -778,9 +779,9 @@ async function handleGitHubWritePlaneRequest(request, env) {
     head: payload.head,
     title: payload.title,
     body: payload.body,
-    approvalPhrase: policyInput.approvalPhrase,
-    targetConfirmed: policyInput.targetConfirmed,
-    approvalScopeMatched: policyInput.approvalScopeMatched,
+    approvalPhrase: boundPolicyInput.approvalPhrase,
+    targetConfirmed: boundPolicyInput.targetConfirmed,
+    approvalScopeMatched: boundPolicyInput.approvalScopeMatched,
     env
   });
 
@@ -814,6 +815,67 @@ async function handleGitHubWritePlaneRequest(request, env) {
 function wantsActionVisibleGitHubWriteErrors(payload) {
   const responseMode = normalizeText(payload?.responseMode);
   return responseMode === "action_visible";
+}
+
+function bindNaturalGitHubWriteApproval({ payload, policyInput }) {
+  if (
+    policyInput?.targetConfirmed === true &&
+    policyInput?.approvalScopeMatched === true &&
+    normalizeText(policyInput?.approvalPhrase)
+  ) {
+    return policyInput;
+  }
+
+  if (!canBindNaturalIssueCreateApproval(payload)) {
+    return policyInput;
+  }
+
+  return {
+    ...policyInput,
+    targetConfirmed: true,
+    approvalScopeMatched: true,
+    approvalPhrase: "GO"
+  };
+}
+
+function canBindNaturalIssueCreateApproval(payload) {
+  const operation = normalizeText(payload?.operation);
+  if (operation !== "issue_create") {
+    return false;
+  }
+
+  const naturalApproval = normalizeObject(payload?.naturalApproval);
+  if (naturalApproval.exactPayloadPresented !== true || naturalApproval.repositoryResolved !== true) {
+    return false;
+  }
+
+  const userText = normalizeText(naturalApproval.userText);
+  if (!containsGoToken(userText)) {
+    return false;
+  }
+
+  const presentedPayload = normalizeObject(naturalApproval.presentedPayload);
+  if (normalizeText(presentedPayload.operation) !== "issue_create") {
+    return false;
+  }
+
+  if (!normalizeText(payload?.repository) || normalizeText(presentedPayload.repository) !== normalizeText(payload?.repository)) {
+    return false;
+  }
+
+  if (!normalizeText(payload?.title) || normalizeText(presentedPayload.title) !== normalizeText(payload?.title)) {
+    return false;
+  }
+
+  if (!normalizeBody(payload?.body) || normalizeBody(presentedPayload.body) !== normalizeBody(payload?.body)) {
+    return false;
+  }
+
+  return true;
+}
+
+function containsGoToken(value) {
+  return /(^|[^A-Za-z0-9_])GO([^A-Za-z0-9_]|$)/i.test(normalizeText(value));
 }
 
 async function handleGitHubHighRiskPlaneRequest(request, env) {
@@ -2643,6 +2705,10 @@ function normalize(value) {
 
 function normalizeText(value) {
   return String(value ?? "").trim();
+}
+
+function normalizeBody(value) {
+  return String(value ?? "").replace(/\r\n/g, "\n").trim();
 }
 
 function normalizeTag(value) {

--- a/test/custom-gpt-setup-docs.test.js
+++ b/test/custom-gpt-setup-docs.test.js
@@ -51,6 +51,10 @@ test("custom gpt instructions preserve current butler and approval boundaries", 
   assert.equal(doc.includes("vtddRetrieveSetupArtifact"), true);
   assert.equal(doc.includes("vtddRetrieveSelfParity"), true);
   assert.equal(doc.includes("operation=`issue_create`"), true);
+  assert.equal(doc.includes("If the human says something like \"この内容で Issue 作って\""), true);
+  assert.equal(doc.includes("この title/body で Issue を作成するなら「GO」と言ってください"), true);
+  assert.equal(doc.includes("Do not ask the human to say `targetConfirmed=true`"), true);
+  assert.equal(doc.includes("naturalApproval.exactPayloadPresented=true"), true);
   assert.equal(doc.includes("Do not ask the user to author internal `policyInput`, `judgmentTrace`, or"), true);
   assert.equal(doc.includes("Do not invent step names such as `issue_retrieval`"), true);
   assert.equal(doc.includes("Do not ask the human to supply internal constitution flags"), true);
@@ -117,6 +121,8 @@ test("short custom gpt instructions stay under editor limits while preserving cr
   assert.equal(doc.includes("vtddUpsertRepositoryNickname"), true);
   assert.equal(doc.includes("vtddRetrieveRepositoryNicknames"), true);
   assert.equal(doc.includes("For issue_create, fix title+body, bind GO to that payload"), true);
+  assert.equal(doc.includes("ask only `GO`"), true);
+  assert.equal(doc.includes("Never ask targetConfirmed/approvalScopeMatched/approvalPhrase/raw JSON"), true);
   assert.equal(doc.includes("Nickname memory is user-owned alias data"), true);
   assert.equal(doc.includes("non-owner/repo token like `ぶい の...`"), true);
   assert.equal(doc.includes("call nickname read/gateway before asking"), true);
@@ -185,6 +191,9 @@ test("custom gpt openapi doc exposes current gateway, execute, and progress rout
   assert.equal(doc.includes("- relatedIssue"), true);
   assert.equal(doc.includes("issueTraceability:"), true);
   assert.equal(doc.includes("approvalScopeMatched:"), true);
+  assert.equal(doc.includes("naturalApproval:"), true);
+  assert.equal(doc.includes("exactPayloadPresented:"), true);
+  assert.equal(doc.includes("presentedPayload:"), true);
 });
 
 test("custom gpt openapi keeps components.schemas while avoiding nested field refs", () => {
@@ -216,6 +225,9 @@ test("custom gpt openapi json parses and exposes paths as an object", () => {
     ),
     true
   );
+  const githubWriteSchema = doc.paths["/v2/action/github"].post.requestBody.content["application/json"].schema;
+  assert.equal(typeof githubWriteSchema.properties.naturalApproval, "object");
+  assert.equal(githubWriteSchema.properties.naturalApproval.properties.presentedPayload.properties.operation.enum[0], "issue_create");
   assert.equal(typeof doc.paths["/v2/action/github-authority"], "object");
   assert.equal(typeof doc.paths["/v2/action/deploy"], "object");
   assert.equal(typeof doc.paths["/v2/action/github-actions-secret"], "object");

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -2302,6 +2302,203 @@ test("worker executes scoped GitHub issues and issue comments through the normal
   assert.equal(body.write.commentId, 101);
 });
 
+test("worker binds natural GO to an immediately presented issue_create payload", async () => {
+  let requestBody = null;
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/action/github", {
+      method: "POST",
+      headers: {
+        ...gatewayAuthHeaders,
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({
+        operation: "issue_create",
+        repository: "sample-org/vtdd-v2-p",
+        title: "live E2E: natural GO issue create",
+        body: "Parent: #151\n\nExact payload shown immediately before GO.",
+        responseMode: "action_visible",
+        naturalApproval: {
+          exactPayloadPresented: true,
+          repositoryResolved: true,
+          userText: "この title/body で Issue を作成して。GO",
+          presentedPayload: {
+            operation: "issue_create",
+            repository: "sample-org/vtdd-v2-p",
+            title: "live E2E: natural GO issue create",
+            body: "Parent: #151\n\nExact payload shown immediately before GO."
+          }
+        }
+      })
+    }),
+    {
+      ...gatewayAuthEnv,
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_write",
+      GITHUB_API_FETCH: async (_url, init) => {
+        requestBody = JSON.parse(init.body);
+        return new Response(
+          JSON.stringify({
+            number: 151,
+            title: "live E2E: natural GO issue create",
+            state: "open",
+            html_url: "https://github.com/sample-org/vtdd-v2-p/issues/151"
+          }),
+          { status: 201, headers: { "content-type": "application/json" } }
+        );
+      }
+    }
+  );
+
+  assert.equal(response.status, 200);
+  const body = await response.json();
+  assert.equal(body.ok, true);
+  assert.equal(body.write.operation, "issue_create");
+  assert.equal(body.write.issueNumber, 151);
+  assert.deepEqual(requestBody, {
+    title: "live E2E: natural GO issue create",
+    body: "Parent: #151\n\nExact payload shown immediately before GO."
+  });
+});
+
+test("worker does not bind natural GO when issue_create payload was not presented", async () => {
+  let githubCalled = false;
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/action/github", {
+      method: "POST",
+      headers: {
+        ...gatewayAuthHeaders,
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({
+        operation: "issue_create",
+        repository: "sample-org/vtdd-v2-p",
+        title: "live E2E: natural GO issue create",
+        body: "Payload was not presented.",
+        responseMode: "action_visible",
+        naturalApproval: {
+          exactPayloadPresented: false,
+          repositoryResolved: true,
+          userText: "GO",
+          presentedPayload: {
+            operation: "issue_create",
+            repository: "sample-org/vtdd-v2-p",
+            title: "live E2E: natural GO issue create",
+            body: "Payload was not presented."
+          }
+        }
+      })
+    }),
+    {
+      ...gatewayAuthEnv,
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_write",
+      GITHUB_API_FETCH: async () => {
+        githubCalled = true;
+        return new Response(JSON.stringify({ number: 1 }), {
+          status: 201,
+          headers: { "content-type": "application/json" }
+        });
+      }
+    }
+  );
+
+  assert.equal(response.status, 200);
+  const body = await response.json();
+  assert.equal(body.ok, false);
+  assert.equal(body.httpStatus, 422);
+  assert.equal(body.issues.includes("targetConfirmed must be true"), true);
+  assert.equal(body.issues.includes("approvalScopeMatched must be true"), true);
+  assert.equal(body.issues.includes("approvalPhrase must be GO"), true);
+  assert.equal(githubCalled, false);
+});
+
+test("worker does not bind natural GO when presented issue_create payload differs", async () => {
+  let githubCalled = false;
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/action/github", {
+      method: "POST",
+      headers: {
+        ...gatewayAuthHeaders,
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({
+        operation: "issue_create",
+        repository: "sample-org/vtdd-v2-p",
+        title: "actual title",
+        body: "actual body",
+        responseMode: "action_visible",
+        naturalApproval: {
+          exactPayloadPresented: true,
+          repositoryResolved: true,
+          userText: "GO",
+          presentedPayload: {
+            operation: "issue_create",
+            repository: "sample-org/vtdd-v2-p",
+            title: "different title",
+            body: "actual body"
+          }
+        }
+      })
+    }),
+    {
+      ...gatewayAuthEnv,
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_write",
+      GITHUB_API_FETCH: async () => {
+        githubCalled = true;
+        return new Response(JSON.stringify({ number: 1 }), {
+          status: 201,
+          headers: { "content-type": "application/json" }
+        });
+      }
+    }
+  );
+
+  assert.equal(response.status, 200);
+  const body = await response.json();
+  assert.equal(body.ok, false);
+  assert.equal(body.httpStatus, 422);
+  assert.equal(githubCalled, false);
+});
+
+test("worker keeps natural GO binding limited to issue_create", async () => {
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/action/github", {
+      method: "POST",
+      headers: {
+        ...gatewayAuthHeaders,
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({
+        operation: "pull_create",
+        repository: "sample-org/vtdd-v2-p",
+        title: "PR title",
+        body: "PR body",
+        head: "codex/example",
+        responseMode: "action_visible",
+        naturalApproval: {
+          exactPayloadPresented: true,
+          repositoryResolved: true,
+          userText: "GO",
+          presentedPayload: {
+            operation: "pull_create",
+            repository: "sample-org/vtdd-v2-p",
+            title: "PR title",
+            body: "PR body"
+          }
+        }
+      })
+    }),
+    {
+      ...gatewayAuthEnv,
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_write"
+    }
+  );
+
+  assert.equal(response.status, 200);
+  const body = await response.json();
+  assert.equal(body.ok, false);
+  assert.equal(body.httpStatus, 422);
+  assert.equal(body.issues.includes("targetConfirmed must be true"), true);
+});
+
 test("worker rejects unsupported high-risk GitHub write operations on the normal write plane", async () => {
   const response = await worker.fetch(
     new Request("https://example.com/v2/action/github", {


### PR DESCRIPTION
## This PR satisfies Intent

Issue #151 asks VTDD Butler to stop requiring machine-style approval wording for normal Issue creation after it has already presented an exact Issue title/body payload. This PR implements the runtime binding path for that specific case: if Butler showed the exact issue_create payload, the repository is resolved, and the next user message contains literal `GO`, the worker binds the normal write approval fields internally.

This keeps the intended UX: Butler can ask "この title/body で Issue を作成するなら「GO」と言ってください" and the human only needs to reply `GO`.

## Satisfied Success Criteria

- [x] Natural phrase containing `GO` is sufficient for normal `issue_create` only when the exact title/body payload was presented immediately before.
- [x] Butler no longer needs to ask the user to type `targetConfirmed`, `approvalScopeMatched`, `approvalPhrase`, or raw JSON for this path.
- [x] Missing exact immediately previous payload remains blocked.
- [x] Mismatched presented payload remains blocked.
- [x] Non-issue-create GitHub writes remain outside this natural-GO binding path.
- [x] Custom GPT instructions document the ask-`GO` UX.
- [x] Custom GPT Action Schema exposes `naturalApproval` so Butler can pass the presented payload evidence.
- [x] CI/unit checks pass locally.

## Unsatisfied Success Criteria

- iPhone Butler live E2E remains unverified until this PR is merged, Cloudflare is deployed, Action Schema and Instructions are updated in the Custom GPT editor, and the flow is tested through Butler.

## Non-goal violations

None.

## Verification Evidence

- Unit: `node --test test/worker.test.js test/custom-gpt-setup-docs.test.js test/github-write-plane.test.js` passed 84 tests.
- Integration: `npm test` passed 477 tests.
- E2E: Not run live from Butler yet; this PR adds worker-level happy and boundary coverage for the E2E-facing path.
- Manual: Reviewed diff scope against Issue #151 and kept merge/deploy/secret/destructive paths unchanged.
- Evidence path/link: `test/worker.test.js` natural GO binding tests; `test/custom-gpt-setup-docs.test.js` schema/instruction assertions.

## Surface Update Checklist

- Cloudflare deploy: Required after merge because `src/worker.js` changes runtime behavior.
- Custom GPT Action Schema update: Required after merge because `docs/setup/custom-gpt-actions-openapi.yaml` and `.json` expose `naturalApproval`.
- Custom GPT Instructions update: Required after merge because both full and short instructions changed.
- iPhone Butler live E2E: Required after deploy/editor updates; expected test is Butler presents exact title/body, user replies `GO`, Butler creates Issue without asking internal policy fields.

## Related Constitution Rules

- Issue as canonical spec.
- Do not ask users to type raw JSON/internal API fields for normal operation.
- Convert natural conversation intent into internal action calls.
- No default repository; unresolved or ambiguous target blocks execution.
- High-risk actions still require GO + passkey.

## Out-of-scope but NOT implemented

- PR creation/update natural GO binding.
- Issue comments or other GitHub writes.
- Merge, deploy, secret mutation, destructive cleanup, or permission mutation.
- Reviewer backend changes.
- Live Butler completion claim before post-merge deployment and editor update.

## Extra changes (if any)

None.
