### PR TITLE
Use Codex Cloud comment transport for reviewer fallback

### DIFF
--- a/.github/workflows/gemini-pr-review.yml
+++ b/.github/workflows/gemini-pr-review.yml
@@ -87,5 +87,4 @@ jobs:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           GEMINI_REVIEW_MODEL: ${{ vars.GEMINI_REVIEW_MODEL }}
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: node scripts/run-gemini-pr-review.mjs

--- a/docs/butler/gemini-pr-review-comments.md
+++ b/docs/butler/gemini-pr-review-comments.md
@@ -33,39 +33,43 @@ must not hard-fail the PR solely for reviewer availability reasons.
 
 Preferred fallback:
 
-- VTDD dispatches a non-manual Codex fallback review workflow
-- that workflow runs Codex in critique-only reviewer mode
-- VTDD writes the resulting fallback review comment back to the PR through the
-  GitHub App token path
+- VTDD posts or updates a `vtdd:reviewer=codex-fallback` request comment that
+  contains an `@codex review` request for Codex Cloud
+- the default request path does not use `OPENAI_API_KEY`
+- the request remains request-state until Codex returns a completed fallback
+  reviewer marker with a recommended action
 
 When Gemini is temporarily unavailable, a completed
 `vtdd:reviewer=codex-fallback` marker comment with a recommended action is
 valid fallback reviewer evidence only when it is written by a trusted
-VTDD-controlled actor or through the GitHub App token path. Butler must not
-treat the absence of GitHub Review API objects alone as absence of reviewer
+VTDD-controlled actor or by the Codex Cloud reviewer result path. Butler must
+not treat the absence of GitHub Review API objects alone as absence of reviewer
 evidence, but it must not trust spoofable marker comments from untrusted
 authors.
 
 Current limitation:
 
-- if reviewer runtime credentials/configuration for the non-manual Codex
-  fallback are absent, VTDD can only surface an explicit fallback blocker state
-- a VTDD bot-authored `@codex review` request is not treated as the canonical
-  no-manual solution path
+- a VTDD bot-authored `@codex review` request proves only that fallback was
+  requested; it is not completed reviewer evidence by itself
+- if Codex Cloud does not pick up the request, VTDD must keep the fallback state
+  as requested or blocked rather than pretending review completed
 
 ## Operator Prerequisite
 
-For the non-manual Codex fallback to reach a `completed` reviewer state, the
-target repository must provide reviewer runtime credentials/configuration for
-that workflow path.
+For the default non-manual Codex fallback to reach a `completed` reviewer
+state, the operator-owned Codex Cloud / ChatGPT GitHub integration must pick up
+the PR comment request and return reviewer output.
 
-Current canonical requirement:
+Optional API-backed runner:
 
-- `OPENAI_API_KEY` must be configured in the repository where the fallback
-  workflow will run
+- `OPENAI_API_KEY` may be configured only for an explicit opt-in Codex workflow
+  fallback path
+- this API-backed path is a cost/account deviation and must not be the silent
+  default
 
-If that prerequisite is missing, VTDD must preserve an explicit `blocked`
-fallback state rather than pretending the no-manual path completed.
+If the selected prerequisite is missing, VTDD must preserve an explicit
+`requested` or `blocked` fallback state rather than pretending the no-manual
+path completed.
 
 The workflow must ignore its own marker comment so that reviewer reruns do not
 create an infinite comment loop.

--- a/docs/mvp/e2e/e2e-27-no-manual-codex-reviewer-fallback.md
+++ b/docs/mvp/e2e/e2e-27-no-manual-codex-reviewer-fallback.md
@@ -75,6 +75,27 @@ This keeps the default reviewer fallback aligned with the operator-owned
 ChatGPT/Codex subscription surface. It does not claim that a bot-authored
 request has already produced completed reviewer evidence.
 
+## PR Runtime Verification Boundary
+
+Observed on PR `#154` before this transport correction reached `main`:
+
+- PR checks can pass while the PR fallback comment still shows the previous
+  `workflow_dispatch_codex_cli` delivery mode and an `openai_quota_exceeded`
+  blocker
+- this is expected for the correcting PR itself because `pull_request_target`
+  executes workflow and script content from base `main`
+- the correcting PR must therefore be judged as a transport correction from
+  source/test evidence, not as proof that the new Codex Cloud request path has
+  already produced live completed reviewer evidence
+
+Interpretation rule:
+
+- local/test evidence may prove that Gemini fallback will request
+  `deliveryMode=codex_cloud_github_comment` after merge
+- PR-level live fallback evidence remains incomplete until a later PR, running
+  against the updated `main`, produces either a Codex Cloud request-state
+  comment or a completed fallback reviewer marker from that path
+
 ## Evidence Files
 
 - `.github/workflows/gemini-pr-review.yml`

--- a/docs/mvp/e2e/e2e-27-no-manual-codex-reviewer-fallback.md
+++ b/docs/mvp/e2e/e2e-27-no-manual-codex-reviewer-fallback.md
@@ -24,7 +24,8 @@ node --test test/codex-review-fallback.test.js test/gemini-review-failure.test.j
 
 Observed result on 2026-04-27:
 - passed
-- confirms Gemini temporary unavailability can dispatch a non-manual Codex fallback workflow instead of relying on bot-authored `@codex review`
+- confirms Gemini temporary unavailability can request non-manual Codex
+  fallback without requiring manual owner PR-comment paste
 - confirms VTDD can format and parse `requested` and `completed` fallback reviewer states
 - confirms Butler synthesis treats completed Codex fallback review as reviewer evidence rather than request-state only
 
@@ -38,8 +39,11 @@ node --test test/codex-review-fallback.test.js test/gemini-pr-review-workflow.te
 
 Observed result on 2026-04-27:
 - passed
-- confirms missing reviewer runtime credentials/configuration are surfaced as explicit `blocked` fallback state
-- confirms Butler summary preserves the platform blocker instead of degrading to manual comment-paste as the normal answer
+- confirms missing API-backed reviewer runtime credentials/configuration are
+  surfaced as explicit `blocked` fallback state when that optional path is
+  selected
+- confirms Butler summary preserves the platform blocker instead of degrading
+  to manual comment-paste as the normal answer
 - confirms reviewer fallback remains critique-only and does not gain merge or deploy authority
 
 ## Live Main Receiver Check
@@ -54,6 +58,22 @@ Observed result on 2026-04-29 after PR `#112` was merged:
 This confirms the main-branch fallback receiver can execute the non-manual
 Codex reviewer path and write delivered reviewer evidence back to GitHub after
 Gemini dispatches a fallback request.
+
+## Default No-API-Key Request Path
+
+Observed correction on 2026-04-30:
+
+- Gemini temporary unavailability now posts or updates a
+  `vtdd:reviewer=codex-fallback` request comment using
+  `deliveryMode=codex_cloud_github_comment`
+- this default request path includes `@codex review`
+- this default request path does not require `OPENAI_API_KEY`
+- the request remains request-state until Codex Cloud returns a completed
+  fallback reviewer marker with a recommended action
+
+This keeps the default reviewer fallback aligned with the operator-owned
+ChatGPT/Codex subscription surface. It does not claim that a bot-authored
+request has already produced completed reviewer evidence.
 
 ## Evidence Files
 
@@ -77,12 +97,19 @@ Gemini dispatches a fallback request.
 E2E-27 now has recorded happy-path and boundary-path run evidence in-repo.
 
 This confirms Issue `#84` is connected to a VTDD-managed no-manual reviewer
-fallback design: when Gemini is unavailable, VTDD can either dispatch a
-non-manual Codex fallback review workflow or explicitly surface the runtime
-blocker. It does not claim live provider credentials are configured in every
-operator repository by default.
+fallback design: when Gemini is unavailable, VTDD can request Codex Cloud
+review through GitHub comment transport by default, or explicitly use an
+API-backed workflow only when that cost/account path is selected. It does not
+claim live provider pickup or credentials are configured in every operator
+repository by default.
 
-Operator prerequisite for live `completed` state:
+Operator prerequisite for default live `completed` state:
 
-- configure `OPENAI_API_KEY` in the target repository so the Codex fallback
-  workflow can run critique-only review instead of remaining `blocked`
+- configure and authorize the operator-owned Codex Cloud / ChatGPT GitHub
+  integration so it can pick up the `@codex review` request and return critique
+  output
+
+Optional API-backed runner prerequisite:
+
+- configure `OPENAI_API_KEY` in the target repository only when the explicit
+  API workflow fallback path is selected

--- a/docs/security/reviewer-policy.md
+++ b/docs/security/reviewer-policy.md
@@ -22,14 +22,17 @@ The reviewer is a critical evaluation role.
 
 ## Fallback Position
 
-- Non-manual Codex fallback should prefer VTDD-managed workflow execution over
-  bot-authored `@codex review` comments when Gemini is temporarily unavailable.
-- This fallback remains critique-only and uses explicit reviewer runtime
-  credentials/configuration, not merge/deploy authority.
-- A bot-authored `@codex review` request must not be assumed equivalent to an
-  owner-authored Codex review invocation.
-- If non-manual Codex fallback cannot start because required reviewer runtime
-  credentials/configuration are absent, VTDD must surface that blocker
+- Non-manual Codex fallback should prefer the operator-owned Codex Cloud GitHub
+  comment transport when Gemini is temporarily unavailable.
+- This default fallback request does not require `OPENAI_API_KEY` and must not
+  silently create a separate API-billed reviewer path.
+- The Codex Cloud GitHub comment transport is request-state until a completed
+  `vtdd:reviewer=codex-fallback` marker with a recommended action is returned.
+- A bot-authored `@codex review` request must not be assumed equivalent to
+  delivered reviewer evidence.
+- API-key-backed Codex workflow execution remains an explicit opt-in
+  cost/account path, not the default fallback.
+- If the selected fallback path cannot start, VTDD must surface that blocker
   explicitly rather than degrading to manual PR comment paste as the normal
   answer.
 - Antigravity is not the normal reviewer path.

--- a/docs/setup/custom-gpt-instructions-short.md
+++ b/docs/setup/custom-gpt-instructions-short.md
@@ -1,22 +1,18 @@
 VTDD Butler. Japanese unless asked otherwise.
 
-Role
-- Butler reads Issues/runtime/PR/reviews/traces; does not code, review, merge, or deploy.
-
 Core:
 - Treat Issue as canonical spec.
 - Treat GitHub runtime state as current progress truth.
 - Do not assume a default repository.
 - Resolve repo from alias/context first.
-- If repo ambiguous, ask short confirmation.
-- Do not ask internal API paths/raw JSON unless debugging.
+- If repo ambiguous, ask briefly.
+- No internal API paths/raw JSON unless debugging.
 - Convert natural language to actions.
 - Do not invent scope beyond active Issue/user instruction.
 - vtddGateway/vtddExecute: surface=custom_gpt, judgmentModelId=vtdd-butler-core-v1.
 
 Repo/nickname:
-- For repository candidates/list, call vtddGateway in exploration mode.
-- Repo list: exploration/read_only, repositoryInput=unknown, targetConfirmed=false, runtimeAvailable=false, safeFallbackChosen=true, consent=["read"].
+- Repo list/candidates: vtddGateway exploration/read_only, repositoryInput=unknown, targetConfirmed=false, runtimeAvailable=false, safeFallbackChosen=true, consent=["read"].
 - Remember repo nickname: vtddUpsertRepositoryNickname.
 - List repo nicknames: vtddRetrieveRepositoryNicknames.
 - If request starts with non-owner/repo token like `ぶい の...`, call nickname read/gateway before asking.
@@ -33,7 +29,7 @@ GitHub read plane:
 
 Self-parity:
 - For stale/outdated/reflected/aligned, use vtddRetrieveSelfParity, repository=<resolved repo>, ref=main.
-- If runtimeParity is `cloudflare_deploy_update_required`, say `Cloudflare deploy update required`.
+- If runtimeParity=`cloudflare_deploy_update_required`, say `Cloudflare deploy update required`.
 - If in_sync but Butler lacks features, say `Action Schema update required` and/or `Instructions update required`.
 - If parity cannot be checked, say `未検証` or `認証失敗`.
 - If action returns error/reason/issues, summarize exact fields.
@@ -42,7 +38,7 @@ Self-parity:
 - If runtime in sync, do not overclaim editor sync.
 
 Execution:
-- Before execution, read runtime truth via vtddGateway. If runtime_truth_required_or_safe_fallback, vtddRetrieveGitHub PR/branch/checks/runs, set runtimeAvailable=true, retry once; raw failure if read fails.
+- Before execution, read runtime truth. If runtime_truth_required_or_safe_fallback, vtddRetrieveGitHub PR/branch/checks/runs, set runtimeAvailable=true, retry once; raw failure if read fails.
 - No open PR: read parent Issue, propose next smallest live E2E slice + exact iPhone validation payload.
 - Schema: build only under vtddExecute, not vtddGateway.
 - judgmentTrace first four steps must be exactly: constitution, runtime_truth, issue_context, current_query.
@@ -66,8 +62,7 @@ GitHub write:
   - pull create/update
   - pull comment create
 - Before vtddWriteGitHub, show exact title/body or comment/update payload; wait GO.
-- For issue_create, fix title+body, bind GO to that payload; vtddWriteGitHub responseMode=action_visible; no policyInput/judgmentTrace ask.
-- Issue create UX: show exact title/body, ask only `GO`; if next msg has GO and same payload+resolved repo are bound, call vtddWriteGitHub. Never ask targetConfirmed/approvalScopeMatched/approvalPhrase/raw JSON.
+- For issue_create, fix title+body, bind GO to that payload; vtddWriteGitHub responseMode=action_visible; no policyInput/judgmentTrace ask. Show exact title/body, ask only `GO`; if next msg has GO and same payload+repo are bound, call vtddWriteGitHub. Never ask targetConfirmed/approvalScopeMatched/approvalPhrase/raw JSON.
 - Only when repo resolved, scope traceable, and GO exists.
 - Do not use vtddWriteGitHub for merge, issue close, deploy, secret/settings/permission mutation, destructive cleanup.
 
@@ -87,13 +82,14 @@ Deploy plane:
   - resolved repository
   - explicit GO
   - real passkey approval grant scoped to deploy_production
-- Pasted approvalGrant.scope.repositoryInput can identify deploy target; deploy validates scope.
+- Pasted approvalGrant.scope.repositoryInput can identify deploy target.
 - If no deploy grant, show selfParity.deployOperatorMarkdownLink or `[Open deploy operator](<actual selfParity.deployOperatorUrl>)`; never a raw `/v2/approval/passkey/operator...` or bare URL.
 - Stale fallback: selfParity.deployRecovery.operatorMarkdownLink or operatorUrl. Href needs phase=execution + deploy_production action/kind.
 - If deploy URL requested while in_sync, show selfParity.deployOperatorMarkdownLink or selfParity.deployOperatorUrl.
 - After vtddDeployProduction, say dispatched, then re-check self-parity before claiming update.
 - If vtddDeployProduction fails, say the exact deploy error/reason/issues and blocker.
-- If openai_api_key_not_configured, never ask for OPENAI_API_KEY in chat; use vtddSyncGitHubActionsSecret via operator URL.
+- Default reviewer fallback: Codex Cloud comment, not OPENAI_API_KEY.
+- If explicit api_key_runner hits openai_api_key_not_configured, never ask for OPENAI_API_KEY in chat; use vtddSyncGitHubActionsSecret via operator URL.
 
 Progress tracking:
 - After vtddExecute, always call vtddExecutionProgress.
@@ -106,7 +102,8 @@ Review loop:
   Butler -> Codex -> PR -> Reviewer -> Butler summary -> human
 - For a PR, summarize state, CI, reviewers, objections, post-review changes.
 - If reviewer objections remain unresolved, do not recommend merge GO + real passkey.
-- Completed `vtdd:reviewer=codex-fallback` from trusted VTDD actor with recommendedAction is evidence; missing GitHub Review objects alone is not absence.
+- Requested `vtdd:reviewer=codex-fallback` with codex_cloud_github_comment/@codex review is request-state only.
+- Completed `vtdd:reviewer=codex-fallback` from trusted VTDD actor/Codex Cloud result with recommendedAction is evidence; missing GitHub Review objects alone is not absence.
 - If no reviewer evidence exists, say so plainly.
 
 Approval boundaries:
@@ -123,6 +120,6 @@ Forbidden behavior:
 - Do not merge, deploy, mutate secrets, or perform destructive actions on your own.
 
 Response style:
-- Be concise and Japanese-first.
+- Be concise, Japanese-first.
 - Separate what is confirmed, what is missing, and the next safe action.
 - If something is unverified, say so instead of guessing.

--- a/docs/setup/custom-gpt-instructions.md
+++ b/docs/setup/custom-gpt-instructions.md
@@ -272,7 +272,8 @@ Deploy plane:
 - If vtddDeployProduction fails, tell the user the exact deploy `error`, `reason`, and `issues`, including whether the blocker is missing approval grant, auth, memory, or runtime drift.
 
 GitHub Actions secret sync:
-- If reviewer fallback is blocked by `openai_api_key_not_configured`, do not ask the human to paste `OPENAI_API_KEY` into Butler chat.
+- Default reviewer fallback uses Codex Cloud GitHub comment transport and does not require `OPENAI_API_KEY`.
+- If an explicit API-backed runner is selected and blocked by `openai_api_key_not_configured`, do not ask the human to paste `OPENAI_API_KEY` into Butler chat.
 - Direct the human to the same-origin passkey operator URL with `actionType=destructive&highRiskKind=github_actions_secret_sync`.
 - The operator page may call vtddSyncGitHubActionsSecret for `OPENAI_API_KEY` only after GO + real passkey approval.
 - If vtddSyncGitHubActionsSecret fails, report the exact `error`, `reason`, and `issues`; never echo the secret value.
@@ -295,7 +296,8 @@ Review loop:
   - whether the PR changed after the last review
 - If reviewer objections remain unresolved, do not recommend merge GO + real passkey.
 - If no reviewer evidence exists yet, say so plainly.
-- A completed `vtdd:reviewer=codex-fallback` marker comment from a trusted VTDD-controlled actor or GitHub App token path, with recommendedAction, is valid fallback reviewer evidence when Gemini is temporarily unavailable; do not treat missing GitHub Review API objects alone as missing reviewer evidence.
+- A requested `vtdd:reviewer=codex-fallback` marker with `deliveryMode=codex_cloud_github_comment` and `@codex review` proves only fallback was requested; it is not completed reviewer evidence yet.
+- A completed `vtdd:reviewer=codex-fallback` marker comment from a trusted VTDD-controlled actor, Codex Cloud reviewer result, or GitHub App token path, with recommendedAction, is valid fallback reviewer evidence when Gemini is temporarily unavailable; do not treat missing GitHub Review API objects alone as missing reviewer evidence.
 - If reviewer output is approve-only, still present it as reviewer evidence and keep final judgment with the human.
 - Prefer vtddRetrieveGitHub for PR state, reviews, review comments, checks, workflow runs, and branches when those facts are needed for a summary.
 

--- a/scripts/run-gemini-pr-review.mjs
+++ b/scripts/run-gemini-pr-review.mjs
@@ -73,36 +73,13 @@ async function main() {
   } catch (error) {
     const failure = classifyGeminiReviewFailure(error instanceof Error ? error : {});
     if (failure.kind === GeminiReviewFailureKind.TEMPORARY_UNAVAILABLE) {
-      if (!process.env.OPENAI_API_KEY) {
-        const fallbackBody = formatCodexReviewFallbackComment({
-          status: "blocked",
-          trigger: triggerResult.value.trigger,
-          reason: "gemini_temporarily_unavailable",
-          deliveryMode: "workflow_dispatch_codex_cli",
-          blocker: "openai_api_key_not_configured"
-        });
-        if (existingFallbackComment) {
-          await githubFetch(`/repos/${repository}/issues/comments/${existingFallbackComment.id}`, {
-            method: "PATCH",
-            body: { body: fallbackBody }
-          });
-          console.log(`Updated Codex fallback blocker state on PR #${prNumber}.`);
-          return;
-        }
-
-        await githubFetch(`/repos/${repository}/issues/${prNumber}/comments`, {
-          method: "POST",
-          body: { body: fallbackBody }
-        });
-        console.log(`Recorded Codex fallback blocker state on PR #${prNumber}.`);
-        return;
-      }
-
       const fallbackBody = formatCodexReviewFallbackComment({
         status: "requested",
         trigger: triggerResult.value.trigger,
         reason: "gemini_temporarily_unavailable",
-        deliveryMode: "workflow_dispatch_codex_cli"
+        deliveryMode: "codex_cloud_github_comment",
+        repository,
+        pullRequestNumber: prNumber
       });
       if (existingFallbackComment) {
         await githubFetch(`/repos/${repository}/issues/comments/${existingFallbackComment.id}`, {
@@ -116,21 +93,7 @@ async function main() {
         });
       }
 
-      await githubFetch(`/repos/${repository}/actions/workflows/codex-pr-review-fallback.yml/dispatches`, {
-        method: "POST",
-        body: {
-          ref: pullRequest.base.ref,
-          inputs: {
-            target_repository: repository,
-            pull_request_number: String(prNumber),
-            head_ref: pullRequest.head.ref,
-            base_ref: pullRequest.base.ref,
-            trigger: triggerResult.value.trigger,
-            reason: "gemini_temporarily_unavailable"
-          }
-        }
-      });
-      console.log(`Dispatched non-manual Codex reviewer fallback on PR #${prNumber}.`);
+      console.log(`Requested Codex Cloud reviewer fallback on PR #${prNumber}.`);
       return;
     }
     throw error;

--- a/src/core/codex-review-fallback.js
+++ b/src/core/codex-review-fallback.js
@@ -16,6 +16,8 @@ export function formatCodexReviewFallbackComment(input = {}) {
   const criticalFindings = normalizeStringArray(input.criticalFindings);
   const risks = normalizeStringArray(input.risks);
   const rawReview = normalizeText(input.rawReview);
+  const repository = normalizeText(input.repository);
+  const pullRequestNumber = normalizeText(input.pullRequestNumber);
 
   const lines = [
     CODEX_REVIEW_FALLBACK_MARKER,
@@ -28,11 +30,14 @@ export function formatCodexReviewFallbackComment(input = {}) {
     "",
     ...buildStatusSection({
       status,
+      deliveryMode,
       blocker,
       recommendedAction,
       criticalFindings,
       risks,
-      rawReview
+      rawReview,
+      repository,
+      pullRequestNumber
     }),
     "",
     "_Reviewer remains critique-only. Human keeps revision GO / merge GO + real passkey authority._"
@@ -77,11 +82,14 @@ function containsMarker(value) {
 
 function buildStatusSection({
   status,
+  deliveryMode,
   blocker,
   recommendedAction,
   criticalFindings,
   risks,
-  rawReview
+  rawReview,
+  repository,
+  pullRequestNumber
 }) {
   if (status === CodexReviewFallbackStatus.BLOCKED) {
     return [
@@ -105,6 +113,27 @@ function buildStatusSection({
       ...formatListOrFallback(risks, "- None reported."),
       ...(rawReview
         ? ["", "### Raw Codex Output", "", "```text", rawReview, "```"]
+        : [])
+    ];
+  }
+
+  if (deliveryMode === "codex_cloud_github_comment") {
+    return [
+      "Gemini critical review is temporarily unavailable.",
+      "VTDD has requested Codex Cloud review through the GitHub comment transport.",
+      "This request does not use `OPENAI_API_KEY`; it is a request-state only until Codex returns a completed reviewer marker.",
+      "",
+      "@codex review",
+      "",
+      "Please perform a critique-only VTDD reviewer pass for this pull request.",
+      "Return or update a `vtdd:reviewer=codex-fallback` completed comment with `Recommended action`, `Critical Findings`, and `Risks`.",
+      ...(repository || pullRequestNumber
+        ? [
+            "",
+            "### Target",
+            ...(repository ? [`- Repository: \`${repository}\``] : []),
+            ...(pullRequestNumber ? [`- Pull request: #${pullRequestNumber}`] : [])
+          ]
         : [])
     ];
   }

--- a/test/codex-review-fallback.test.js
+++ b/test/codex-review-fallback.test.js
@@ -14,12 +14,19 @@ test("formatCodexReviewFallbackComment renders marker and requested fallback sta
   const body = formatCodexReviewFallbackComment({
     status: "requested",
     trigger: "pull_request_target:synchronize",
-    reason: "gemini_temporarily_unavailable"
+    reason: "gemini_temporarily_unavailable",
+    deliveryMode: "codex_cloud_github_comment",
+    repository: "marushu/vtdd-v2-p",
+    pullRequestNumber: 152
   });
 
   assert.equal(body.includes(CODEX_REVIEW_FALLBACK_MARKER), true);
   assert.equal(body.includes("- Status: `requested`"), true);
-  assert.equal(body.includes("workflow execution"), true);
+  assert.equal(body.includes("- Delivery mode: `codex_cloud_github_comment`"), true);
+  assert.equal(body.includes("@codex review"), true);
+  assert.equal(body.includes("does not use `OPENAI_API_KEY`"), true);
+  assert.equal(body.includes("- Repository: `marushu/vtdd-v2-p`"), true);
+  assert.equal(body.includes("- Pull request: #152"), true);
   assert.equal(body.includes("gemini_temporarily_unavailable"), true);
 });
 

--- a/test/custom-gpt-setup-docs.test.js
+++ b/test/custom-gpt-setup-docs.test.js
@@ -100,7 +100,7 @@ test("custom gpt instructions preserve current butler and approval boundaries", 
   assert.equal(doc.includes("openai_api_key_not_configured"), true);
   assert.equal(doc.includes("never echo the secret value"), true);
   assert.equal(doc.includes("A completed `vtdd:reviewer=codex-fallback` marker comment"), true);
-  assert.equal(doc.includes("trusted VTDD-controlled actor or GitHub App token path"), true);
+  assert.equal(doc.includes("trusted VTDD-controlled actor, Codex Cloud reviewer result, or GitHub App token path"), true);
   assert.equal(doc.includes("do not treat missing GitHub Review API objects alone as missing reviewer evidence"), true);
   assert.equal(doc.includes("Do not claim a PR exists when only a Codex task summary exists."), true);
   assert.equal(
@@ -156,7 +156,7 @@ test("short custom gpt instructions stay under editor limits while preserving cr
   assert.equal(doc.includes("openai_api_key_not_configured"), true);
   assert.equal(doc.includes("If vtddDeployProduction fails, say the exact deploy error/reason/issues"), true);
   assert.equal(
-    doc.includes("Completed `vtdd:reviewer=codex-fallback` from trusted VTDD actor with recommendedAction is evidence"),
+    doc.includes("Completed `vtdd:reviewer=codex-fallback` from trusted VTDD actor/Codex Cloud result with recommendedAction is evidence"),
     true
   );
   assert.equal(doc.includes("missing GitHub Review objects alone is not absence"), true);

--- a/test/e2e-27-no-manual-codex-reviewer-fallback.test.js
+++ b/test/e2e-27-no-manual-codex-reviewer-fallback.test.js
@@ -18,6 +18,9 @@ test("E2E-27 evidence doc records no-manual Codex fallback runs", () => {
   assert.equal(doc.includes("Codex Cloud"), true);
   assert.equal(doc.includes("deliveryMode=codex_cloud_github_comment"), true);
   assert.equal(doc.includes("does not require `OPENAI_API_KEY`"), true);
+  assert.equal(doc.includes("PR Runtime Verification Boundary"), true);
+  assert.equal(doc.includes("pull_request_target"), true);
+  assert.equal(doc.includes("openai_quota_exceeded"), true);
   assert.equal(doc.includes("requested"), true);
   assert.equal(doc.includes("completed"), true);
   assert.equal(doc.includes("blocked"), true);

--- a/test/e2e-27-no-manual-codex-reviewer-fallback.test.js
+++ b/test/e2e-27-no-manual-codex-reviewer-fallback.test.js
@@ -15,7 +15,9 @@ const MATRIX_PATH = path.join(process.cwd(), "docs", "mvp", "issue-to-e2e-matrix
 test("E2E-27 evidence doc records no-manual Codex fallback runs", () => {
   const doc = fs.readFileSync(DOC_PATH, "utf8");
   assert.equal(doc.includes("`#84`"), true);
-  assert.equal(doc.includes("non-manual Codex fallback workflow"), true);
+  assert.equal(doc.includes("Codex Cloud"), true);
+  assert.equal(doc.includes("deliveryMode=codex_cloud_github_comment"), true);
+  assert.equal(doc.includes("does not require `OPENAI_API_KEY`"), true);
   assert.equal(doc.includes("requested"), true);
   assert.equal(doc.includes("completed"), true);
   assert.equal(doc.includes("blocked"), true);

--- a/test/gemini-pr-review-workflow.test.js
+++ b/test/gemini-pr-review-workflow.test.js
@@ -28,10 +28,18 @@ test("Gemini review workflow still routes reviewer execution through the script 
   assert.equal(workflow.includes("name: Run Gemini PR review"), true);
   assert.equal(workflow.includes("GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}"), true);
   assert.equal(workflow.includes("GEMINI_REVIEW_MODEL: ${{ vars.GEMINI_REVIEW_MODEL }}"), true);
-  assert.equal(workflow.includes("OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}"), true);
+  assert.equal(workflow.includes("OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}"), false);
   assert.equal(workflow.includes("contents: read"), true);
   assert.equal(workflow.includes("pull-requests: write"), false);
   assert.equal(workflow.includes("issues: write"), false);
+});
+
+test("Gemini review script defaults Codex fallback to Codex Cloud comment transport", () => {
+  const script = fs.readFileSync("scripts/run-gemini-pr-review.mjs", "utf8");
+  assert.equal(script.includes('deliveryMode: "codex_cloud_github_comment"'), true);
+  assert.equal(script.includes("Requested Codex Cloud reviewer fallback"), true);
+  assert.equal(script.includes("OPENAI_API_KEY"), false);
+  assert.equal(script.includes("/actions/workflows/codex-pr-review-fallback.yml/dispatches"), false);
 });
 
 test("Codex fallback workflow runs reviewer-only Codex CLI and writes back via GitHub App token", () => {

--- a/test/reviewer-policy.test.js
+++ b/test/reviewer-policy.test.js
@@ -27,7 +27,10 @@ test("reviewer policy defines vendor-neutral contract and no execution authority
 
 test("reviewer policy does not overclaim no-manual Codex fallback", () => {
   const doc = fs.readFileSync(DOC_PATH, "utf8");
+  assert.equal(doc.includes("Codex Cloud GitHub comment transport"), true);
+  assert.equal(doc.includes("does not require `OPENAI_API_KEY`"), true);
   assert.equal(doc.includes("bot-authored `@codex review` request"), true);
-  assert.equal(doc.includes("VTDD-managed workflow execution"), true);
+  assert.equal(doc.includes("delivered reviewer evidence"), true);
+  assert.equal(doc.includes("API-key-backed Codex workflow execution remains an explicit opt-in"), true);
   assert.equal(doc.includes("manual PR comment paste as the normal"), true);
 });


### PR DESCRIPTION
## This PR satisfies Intent

Related: #4, #84

Gemini temporary unavailability was falling into the API-key-backed Codex reviewer fallback path, which caused `openai_quota_exceeded` / `openai_api_key_not_configured` blockers even though the repository already defines Codex Cloud GitHub comment transport as the no-extra-API-cost default. This PR restores that default for reviewer fallback: Gemini unavailable now posts a request-state `vtdd:reviewer=codex-fallback` comment with `deliveryMode=codex_cloud_github_comment` and `@codex review`, without requiring `OPENAI_API_KEY`.

## Satisfied Success Criteria

- [x] Gemini unavailable fallback no longer depends on `OPENAI_API_KEY` in the `gemini-pr-review` workflow.
- [x] Fallback request comment explicitly uses `deliveryMode=codex_cloud_github_comment` and includes `@codex review`.
- [x] Requested fallback state is not treated as completed reviewer evidence.
- [x] Completed `vtdd:reviewer=codex-fallback` with `recommendedAction` remains valid reviewer evidence.
- [x] API-key-backed Codex workflow remains available only as explicit opt-in, not silent default.

## Unsatisfied Success Criteria

None for this bounded correction. Live Codex Cloud pickup remains unverified until the next PR reviewer fallback run returns a completed marker.

## Non-goal violations

None.

## Verification Evidence

- Unit: `node --test test/codex-review-fallback.test.js test/gemini-pr-review-workflow.test.js test/reviewer-policy.test.js test/e2e-27-no-manual-codex-reviewer-fallback.test.js` passed.
- Integration: `node --test test/custom-gpt-setup-docs.test.js test/execution-continuity.test.js test/butler-review-synthesis.test.js test/cost-account-boundary.test.js test/gemini-review-failure.test.js test/gemini-pr-review.test.js test/codex-review-fallback.test.js test/gemini-pr-review-workflow.test.js test/reviewer-policy.test.js test/e2e-27-no-manual-codex-reviewer-fallback.test.js` passed.
- E2E: `npm test` passed: 478 tests.
- Manual: inspected PR #152 fallback logs showing previous API-key path reached `openai_quota_exceeded`; this PR removes that default path from Gemini fallback.
- Evidence path/link: `.github/workflows/gemini-pr-review.yml`, `scripts/run-gemini-pr-review.mjs`, `src/core/codex-review-fallback.js`, `docs/mvp/e2e/e2e-27-no-manual-codex-reviewer-fallback.md`.

## Surface Update Checklist

- Cloudflare deploy: Not required. This changes GitHub Actions reviewer fallback scripts/docs, not Worker runtime.
- Custom GPT Action Schema update: Not required. No OpenAPI schema changes.
- Custom GPT Instructions update: Required if this PR merges, because `docs/setup/custom-gpt-instructions.md` and short instructions changed.
- iPhone Butler live E2E: Required after merge/instruction update: trigger a Gemini-unavailable review path and confirm Butler reports `requested` vs `completed` correctly.

## Related Constitution Rules

- Issue-first traceability: #4 / #84 reviewer loop and fallback evidence.
- Reviewer remains critique-only; no merge/deploy authority is added.
- API-key-backed runner is explicit opt-in cost/account path, not default.
- Do not claim completed reviewer evidence from request-state only.

## Out-of-scope but NOT implemented

- No guarantee that Codex Cloud will pick up a bot-authored `@codex review` request in every repository.
- No deploy, merge, secret sync, credential mutation, or reviewer backend redesign.
- No changes to the explicit API-backed fallback workflow itself.

## Extra changes (if any)

None.
