### PR TITLE
Focus passkey operator for requested high-risk action

### DIFF
--- a/src/core/passkey-operator-page.js
+++ b/src/core/passkey-operator-page.js
@@ -1,4 +1,6 @@
 export function renderPasskeyOperatorPage(input = {}) {
+  const operatorMode = resolvePasskeyOperatorMode(input);
+  const sectionVisibility = resolveSectionVisibility(operatorMode);
   const origin = escapeHtml(input.origin || "");
   const apiBase = escapeHtml(input.apiBase || "/v2");
   const syncApiBase = escapeHtml(input.syncApiBase || "");
@@ -8,8 +10,8 @@ export function renderPasskeyOperatorPage(input = {}) {
   const issueDefault = escapeHtml(input.issueNumber || "");
   const pullNumberDefault = escapeHtml(input.pullNumber || "");
   const phaseDefault = escapeHtml(input.phase || "execution");
-  const actionTypeDefault = escapeHtml(input.actionType || "destructive");
-  const highRiskKindDefault = escapeHtml(input.highRiskKind || "github_app_secret_sync");
+  const actionTypeDefault = escapeHtml(input.actionType || defaultActionTypeForMode(operatorMode));
+  const highRiskKindDefault = escapeHtml(input.highRiskKind || defaultHighRiskKindForMode(operatorMode));
   const mergeMethodDefault = escapeHtml(input.mergeMethod || "squash");
   const returnUrl = escapeHtml(input.returnUrl || "");
   const syncEnabled = input.syncEnabled === true;
@@ -166,7 +168,7 @@ export function renderPasskeyOperatorPage(input = {}) {
       </div>
 
       <div class="grid">
-        <section>
+        <section data-operator-section="registration"${hiddenAttribute(!sectionVisibility.registration)}>
           <h2>1. Passkey 登録</h2>
           <label for="operator-id">Operator ID</label>
           <input id="operator-id" value="${registrationDefaultOperatorId}" />
@@ -179,7 +181,7 @@ export function renderPasskeyOperatorPage(input = {}) {
           <pre id="register-output"></pre>
         </section>
 
-        <section>
+        <section data-operator-section="approval"${hiddenAttribute(!sectionVisibility.approval)}>
           <h2>2. High-risk Approval</h2>
           <label for="repo-input">Repository</label>
           <input id="repo-input" value="${repoDefault}" placeholder="marushu/vtdd-v2-p" />
@@ -203,7 +205,7 @@ export function renderPasskeyOperatorPage(input = {}) {
           <pre id="approve-output"></pre>
         </section>
 
-        <section>
+        <section data-operator-section="github-app-secret-sync"${hiddenAttribute(!sectionVisibility.githubAppSecretSync)}>
           <h2>3. GitHub App Secret Sync</h2>
           <p class="muted">real passkey approval 後、この helper から <code>#15</code> の explicit operator bootstrap を実行します。</p>
           <div class="row">
@@ -213,7 +215,7 @@ export function renderPasskeyOperatorPage(input = {}) {
           <pre id="sync-output"></pre>
         </section>
 
-        <section>
+        <section data-operator-section="production-deploy"${hiddenAttribute(!sectionVisibility.productionDeploy)}>
           <h2>4. Production Deploy</h2>
           <p class="muted">deploy stale を検知したあと、取得済みの <code>approvalGrantId</code> を使って same-origin の governed deploy path を dispatch します。</p>
           <div class="row">
@@ -225,7 +227,7 @@ export function renderPasskeyOperatorPage(input = {}) {
           <pre id="deploy-output"></pre>
         </section>
 
-        <section>
+        <section data-operator-section="pr-merge"${hiddenAttribute(!sectionVisibility.prMerge)}>
           <h2>5. GitHub PR Merge</h2>
           <p class="muted">PR merge 用の real passkey approval 後、この helper から same-origin の GitHub authority path を dispatch します。</p>
           <label for="pull-number-input">Pull Number</label>
@@ -240,7 +242,7 @@ export function renderPasskeyOperatorPage(input = {}) {
           <pre id="merge-output"></pre>
         </section>
 
-        <section>
+        <section data-operator-section="github-actions-secret-sync"${hiddenAttribute(!sectionVisibility.githubActionsSecretSync)}>
           <h2>6. Codex Fallback Secret Sync</h2>
           <p class="muted">Codex reviewer fallback 用の <code>OPENAI_API_KEY</code> を GitHub Actions secret に同期します。値は Butler 会話に貼らず、この operator page から送信します。</p>
           <label for="openai-api-key-input">OPENAI_API_KEY</label>
@@ -727,6 +729,93 @@ export function renderPasskeyOperatorPage(input = {}) {
     </script>
   </body>
 </html>`;
+}
+
+export function resolvePasskeyOperatorMode(input = {}) {
+  const explicitMode = normalizeOperatorMode(input.operatorMode || input.mode);
+  if (explicitMode) {
+    return explicitMode;
+  }
+
+  const actionType = normalizeOperatorToken(input.actionType);
+  const highRiskKind = normalizeOperatorToken(input.highRiskKind);
+
+  if (!actionType && !highRiskKind) {
+    return "full";
+  }
+  if (actionType === "deploy_production" || highRiskKind === "deploy_production") {
+    return "deploy";
+  }
+  if (actionType === "merge" || highRiskKind === "pull_merge") {
+    return "merge";
+  }
+  if (highRiskKind === "github_actions_secret_sync") {
+    return "github_actions_secret_sync";
+  }
+  if (highRiskKind === "github_app_secret_sync") {
+    return "github_app_secret_sync";
+  }
+
+  return "full";
+}
+
+function resolveSectionVisibility(operatorMode) {
+  const full = operatorMode === "full";
+  return {
+    registration: true,
+    approval: true,
+    githubAppSecretSync: full || operatorMode === "github_app_secret_sync",
+    productionDeploy: full || operatorMode === "deploy",
+    prMerge: full || operatorMode === "merge",
+    githubActionsSecretSync: full || operatorMode === "github_actions_secret_sync"
+  };
+}
+
+function hiddenAttribute(hidden) {
+  return hidden ? " hidden" : "";
+}
+
+function normalizeOperatorMode(value) {
+  const token = normalizeOperatorToken(value);
+  if (["full", "deploy", "merge", "github_app_secret_sync", "github_actions_secret_sync"].includes(token)) {
+    return token;
+  }
+  if (token === "secret_sync") {
+    return "github_app_secret_sync";
+  }
+  if (token === "openai_secret_sync" || token === "codex_secret_sync") {
+    return "github_actions_secret_sync";
+  }
+  return "";
+}
+
+function defaultActionTypeForMode(operatorMode) {
+  if (operatorMode === "deploy") {
+    return "deploy_production";
+  }
+  if (operatorMode === "merge") {
+    return "merge";
+  }
+  return "destructive";
+}
+
+function defaultHighRiskKindForMode(operatorMode) {
+  if (operatorMode === "deploy") {
+    return "deploy_production";
+  }
+  if (operatorMode === "merge") {
+    return "pull_merge";
+  }
+  if (operatorMode === "github_actions_secret_sync") {
+    return "github_actions_secret_sync";
+  }
+  return "github_app_secret_sync";
+}
+
+function normalizeOperatorToken(value) {
+  return String(value || "")
+    .trim()
+    .toLowerCase();
 }
 
 function escapeHtml(value) {

--- a/src/worker.js
+++ b/src/worker.js
@@ -1078,15 +1078,18 @@ function handlePasskeyOperatorPageRequest(request) {
   const url = new URL(request.url);
   const syncApiBase = normalizeOptionalHttpUrl(url.searchParams.get("syncApiBase"));
   const syncEnabled = Boolean(syncApiBase);
+  const requestedActionType = url.searchParams.get("actionType");
+  const requestedHighRiskKind = url.searchParams.get("highRiskKind");
   const html = renderPasskeyOperatorPage({
     origin: url.origin,
     syncApiBase,
+    operatorMode: url.searchParams.get("mode") || (requestedActionType || requestedHighRiskKind ? "" : "full"),
     repositoryInput: url.searchParams.get("repositoryInput"),
     issueNumber: url.searchParams.get("issueNumber"),
     pullNumber: url.searchParams.get("pullNumber"),
     phase: url.searchParams.get("phase") || "execution",
-    actionType: url.searchParams.get("actionType") || "destructive",
-    highRiskKind: url.searchParams.get("highRiskKind") || "github_app_secret_sync",
+    actionType: requestedActionType,
+    highRiskKind: requestedHighRiskKind,
     mergeMethod: url.searchParams.get("mergeMethod") || "squash",
     returnUrl: normalizeOperatorReturnUrl(url.searchParams.get("returnUrl")),
     operatorId: url.searchParams.get("operatorId") || "vtdd-operator",

--- a/test/passkey-operator-page.test.js
+++ b/test/passkey-operator-page.test.js
@@ -58,6 +58,94 @@ test("passkey operator page pre-fills PR merge fields from URL input", () => {
   assert.equal(html.includes('operation: "pull_merge"'), true);
 });
 
+test("passkey operator page focuses deploy mode on deploy approval and dispatch sections", () => {
+  const html = renderPasskeyOperatorPage({
+    repositoryInput: "marushu/vtdd-v2-p",
+    phase: "execution",
+    actionType: "deploy_production",
+    highRiskKind: "deploy_production",
+    returnUrl: "https://chatgpt.com/g/example-butler"
+  });
+
+  assert.equal(html.includes('<section data-operator-section="registration">'), true);
+  assert.equal(html.includes('<section data-operator-section="approval">'), true);
+  assert.equal(html.includes('<section data-operator-section="production-deploy">'), true);
+  assert.equal(html.includes('<section data-operator-section="pr-merge" hidden>'), true);
+  assert.equal(html.includes('<section data-operator-section="github-app-secret-sync" hidden>'), true);
+  assert.equal(html.includes('<section data-operator-section="github-actions-secret-sync" hidden>'), true);
+  assert.equal(html.includes("Dispatch production deploy"), true);
+  assert.equal(html.includes("Return to Butler"), true);
+});
+
+test("passkey operator page fills safe approval defaults from explicit mode", () => {
+  const deployHtml = renderPasskeyOperatorPage({
+    operatorMode: "deploy",
+    repositoryInput: "marushu/vtdd-v2-p"
+  });
+
+  assert.equal(deployHtml.includes('id="action-type-input" value="deploy_production"'), true);
+  assert.equal(deployHtml.includes('id="risk-kind-input" value="deploy_production"'), true);
+  assert.equal(deployHtml.includes('<section data-operator-section="production-deploy">'), true);
+
+  const mergeHtml = renderPasskeyOperatorPage({
+    operatorMode: "merge",
+    repositoryInput: "marushu/vtdd-v2-p",
+    pullNumber: 148
+  });
+
+  assert.equal(mergeHtml.includes('id="action-type-input" value="merge"'), true);
+  assert.equal(mergeHtml.includes('id="risk-kind-input" value="pull_merge"'), true);
+  assert.equal(mergeHtml.includes('<section data-operator-section="pr-merge">'), true);
+});
+
+test("passkey operator page focuses merge mode on approval and PR merge sections", () => {
+  const html = renderPasskeyOperatorPage({
+    repositoryInput: "marushu/vtdd-v2-p",
+    pullNumber: 148,
+    actionType: "merge",
+    highRiskKind: "pull_merge"
+  });
+
+  assert.equal(html.includes('<section data-operator-section="registration">'), true);
+  assert.equal(html.includes('<section data-operator-section="approval">'), true);
+  assert.equal(html.includes('<section data-operator-section="pr-merge">'), true);
+  assert.equal(html.includes('<section data-operator-section="production-deploy" hidden>'), true);
+  assert.equal(html.includes('<section data-operator-section="github-app-secret-sync" hidden>'), true);
+  assert.equal(html.includes('<section data-operator-section="github-actions-secret-sync" hidden>'), true);
+});
+
+test("passkey operator page focuses secret sync modes without hiding the required approval section", () => {
+  const githubAppSecretHtml = renderPasskeyOperatorPage({
+    repositoryInput: "marushu/vtdd-v2-p",
+    actionType: "destructive",
+    highRiskKind: "github_app_secret_sync"
+  });
+  assert.equal(githubAppSecretHtml.includes('<section data-operator-section="approval">'), true);
+  assert.equal(githubAppSecretHtml.includes('<section data-operator-section="github-app-secret-sync">'), true);
+  assert.equal(githubAppSecretHtml.includes('<section data-operator-section="production-deploy" hidden>'), true);
+  assert.equal(githubAppSecretHtml.includes('<section data-operator-section="pr-merge" hidden>'), true);
+
+  const actionsSecretHtml = renderPasskeyOperatorPage({
+    repositoryInput: "marushu/vtdd-v2-p",
+    actionType: "destructive",
+    highRiskKind: "github_actions_secret_sync"
+  });
+  assert.equal(actionsSecretHtml.includes('<section data-operator-section="approval">'), true);
+  assert.equal(actionsSecretHtml.includes('<section data-operator-section="github-actions-secret-sync">'), true);
+  assert.equal(actionsSecretHtml.includes('<section data-operator-section="github-app-secret-sync" hidden>'), true);
+  assert.equal(actionsSecretHtml.includes('<section data-operator-section="production-deploy" hidden>'), true);
+  assert.equal(actionsSecretHtml.includes('<section data-operator-section="pr-merge" hidden>'), true);
+});
+
+test("passkey operator page keeps the full maintenance view when no mode is inferred", () => {
+  const html = renderPasskeyOperatorPage({ operatorMode: "full" });
+
+  assert.equal(html.includes('<section data-operator-section="github-app-secret-sync">'), true);
+  assert.equal(html.includes('<section data-operator-section="production-deploy">'), true);
+  assert.equal(html.includes('<section data-operator-section="pr-merge">'), true);
+  assert.equal(html.includes('<section data-operator-section="github-actions-secret-sync">'), true);
+});
+
 test("passkey operator page keeps sync disabled message when helper endpoint is absent", () => {
   const html = renderPasskeyOperatorPage({
     apiBase: "/v2",


### PR DESCRIPTION
## This PR satisfies Intent

Issue #161 の子課題「passkey operator を操作別の focused UI にする」に対する部分実装です。

Butler が iPhone 向けに発行する same-origin passkey operator URL で、ユーザーが不要な操作パネルに迷わないようにします。既存の `/v2/approval/passkey/operator` と URL prefill は維持し、`actionType` / `highRiskKind` / `mode` から必要な section だけを表示します。

## Satisfied Success Criteria

- [x] deploy URL では Passkey 登録 / High-risk Approval / Production Deploy / Return to Butler を残す
- [x] merge URL では Passkey 登録 / High-risk Approval / GitHub PR Merge を残す
- [x] secret sync URL では Passkey 登録 / High-risk Approval / 対応する Secret Sync を残す
- [x] 不要 section は `hidden` にして誤操作の余地を減らす
- [x] `mode=deploy` / `mode=merge` だけでも安全な approval default を補完する
- [x] same-origin WebAuthn / passkey 境界と既存 URL prefill を維持する

## Unsatisfied Success Criteria

#161 全体の GitHub App 操作面統一は未完了です。この PR は passkey operator focused UI の子課題のみを満たします。

未実装:

- normal GO write plane の統一 registry/model 拡張
- natural GO binding の `issue_comment_create` 等への拡張
- #153 capability matrix 全体の live evidence 化
- #157 Butler-to-Codex handoff の branch/PR 観測完了

## Non-goal violations

None.

## Verification Evidence

- Unit: `node --test test/passkey-operator-page.test.js`
- Integration: `node --test test/worker.test.js --test-name-pattern "passkey operator"`
- E2E: `npm test`
- Manual: Not run; this PR is covered by generated HTML section visibility tests.
- Evidence path/link: `test/passkey-operator-page.test.js`

## Surface Update Checklist

- Cloudflare deploy: Required after merge because Worker runtime HTML changed.
- Custom GPT Action Schema update: Not required; no endpoint, request, response, or operationId changed.
- Custom GPT Instructions update: Not required; Butler can keep emitting the same operator URLs, which now render focused UI automatically.
- iPhone Butler live E2E: Required after deploy by opening deploy/merge/secret operator links and confirming only needed sections are visible.

## Related Constitution Rules

- Butler is context-first.
- High-risk actions require GO + passkey.
- No default repository.
- User-facing operational guidance is Japanese by default.
- Do not overclaim VTDD end-to-end completion from partial adapter success.

## Out-of-scope but NOT implemented

- No new passkey origin or separate authentication system.
- No weakening of passkey approval requirements.
- No secret value handling changes beyond preserving existing input clearing behavior.
- No deploy, merge, secret mutation, or repository administration behavior change.

## Extra changes (if any)

None.
