### PR TITLE
Extend natural GO binding through GitHub operation registry

### DIFF
--- a/docs/butler/capability-matrix.md
+++ b/docs/butler/capability-matrix.md
@@ -36,9 +36,9 @@ execution.
 | closed issue list read | `broken-live` | Butler reported zero closed issues while GitHub UI had closed issues. | Read closed issues and exact known closed issues such as #135. |
 | exact Issue body read | `partial-live` | Some Issue bodies have been read; failures occurred when body was omitted. | Read #151/#153 and summarize Intent/SC/Non-goals from body. |
 | issue comments read | `unverified` | Needed for reviewer and handoff evidence. | Read comments from an Issue with known comments and compare count/content. |
-| issue comment create | `unverified` | Source write plane supports it; live Butler path not proven. | Present exact comment payload, say GO, verify GitHub URL. |
+| issue comment create | `source-only` | #161 source now binds natural GO for exact `issue_comment_create` payloads; live Butler path not proven. | Present exact comment payload, say GO, verify GitHub URL. |
 | issue comment update | `unverified` | Source write plane supports it; live Butler path not proven. | Create then update a bounded test comment. |
-| natural GO -> issue_create | `source-only` | #152 added runtime/schema/instructions and tests. #151 remains open because iPhone Butler live evidence is missing. | In Butler, after exact title/body payload, say `この title/body で Issue を作成して。GO`; verify created Issue URL. |
+| natural GO -> normal GitHub write | `source-only` | #152 added `issue_create`; #161 source expands registry-backed binding to `issue_create`, `issue_comment_create`, and `pull_comment_create`. #151 remains open because iPhone Butler live evidence is missing. | In Butler, after exact title/body or comment payload, say `GO`; verify created Issue/comment/PR comment URL. |
 | open PR read | `partial-live` | Butler has read open PRs. | Read open PR list and exact PR details. |
 | closed/merged PR read | `partial-live` | Butler has read merged PRs and merge fields. | Read a known merged PR and verify merged/mergedAt/mergeCommitSha. |
 | PR diff / changed files read | `unverified` | Required for PR summary; current matrix lacks live evidence. | Ask Butler to summarize changed files for a known PR. |
@@ -52,7 +52,7 @@ execution.
 | branch create | `unverified` | Source write plane supports it; live Butler path not proven. | Create a bounded test branch and verify branch exists. |
 | PR create | `unverified` | Source write plane supports it; live Butler path not proven from Butler. | Create PR from a bounded branch if needed by a live slice. |
 | PR update | `unverified` | Source write plane supports it; live Butler path not proven. | Update a bounded PR title/body and verify. |
-| PR comment create | `unverified` | Source write plane supports it; live Butler path not proven. | Post a bounded PR comment and verify URL. |
+| PR comment create | `source-only` | #161 source now binds natural GO for exact `pull_comment_create` payloads; live Butler path not proven. | Post a bounded PR comment and verify URL. |
 | `@codex` handoff comment | `partial-live` | PR #155 produced a `deliveryMode=codex_cloud_github_comment` request comment with `@codex review`. | Verify the same request shape from Butler-originated development handoff, not only reviewer fallback. |
 | Butler -> Codex Cloud pickup | `partial-live` | PR #155 later showed Codex Cloud can respond to a human `@codex review`, but development handoff branch/PR creation is not proven. | Under #157, confirm Butler-originated development handoff creates a branch/PR or returns a clear blocker. |
 | Codex fallback as VTDD reviewer | `partial-live` | PR #155 Codex responded, but did not return the required VTDD reviewer marker/fields. #156 tracks this contract gap. | Require `vtdd:reviewer=codex-fallback` completed marker plus recommended action before treating it as reviewer evidence. |
@@ -67,7 +67,7 @@ execution.
 
 ## Priority Order
 
-1. `natural GO -> issue_create` (#151 live proof)
+1. `natural GO -> normal GitHub write` (#151/#161 live proof)
 2. Issue read completeness: open/closed/exact body/comments/pagination
 3. PR runtime truth completeness: PR state/diff/comments/reviews/checks/runs/branches
 4. Butler -> Codex development handoff progress: requested/queued/blocked/branch/PR (#157)

--- a/docs/setup/custom-gpt-actions-openapi.json
+++ b/docs/setup/custom-gpt-actions-openapi.json
@@ -684,7 +684,7 @@
                   },
                   "naturalApproval": {
                     "type": "object",
-                    "description": "Evidence for normal issue_create natural GO binding after Butler showed the exact payload and the user replied with GO.",
+                    "description": "Evidence for normal GitHub write natural GO binding after Butler showed the exact payload and the user replied with GO. Supported natural GO operations include issue_create, issue_comment_create, and pull_comment_create.",
                     "properties": {
                       "exactPayloadPresented": {
                         "type": "boolean"
@@ -701,11 +701,19 @@
                           "operation": {
                             "type": "string",
                             "enum": [
-                              "issue_create"
+                              "issue_create",
+                              "issue_comment_create",
+                              "pull_comment_create"
                             ]
                           },
                           "repository": {
                             "type": "string"
+                          },
+                          "issueNumber": {
+                            "type": "integer"
+                          },
+                          "pullNumber": {
+                            "type": "integer"
                           },
                           "title": {
                             "type": "string"

--- a/docs/setup/custom-gpt-actions-openapi.yaml
+++ b/docs/setup/custom-gpt-actions-openapi.yaml
@@ -459,7 +459,7 @@ paths:
                   description: Use action_visible from Custom GPT so write failures return ok:false JSON instead of an Action transport failure.
                 naturalApproval:
                   type: object
-                  description: Evidence for normal issue_create natural GO binding after Butler showed the exact payload and the user replied with GO.
+                  description: Evidence for normal GitHub write natural GO binding after Butler showed the exact payload and the user replied with GO. Supported natural GO operations include issue_create, issue_comment_create, and pull_comment_create.
                   properties:
                     exactPayloadPresented:
                       type: boolean
@@ -474,8 +474,14 @@ paths:
                           type: string
                           enum:
                             - issue_create
+                            - issue_comment_create
+                            - pull_comment_create
                         repository:
                           type: string
+                        issueNumber:
+                          type: integer
+                        pullNumber:
+                          type: integer
                         title:
                           type: string
                         body:

--- a/docs/setup/custom-gpt-instructions-short.md
+++ b/docs/setup/custom-gpt-instructions-short.md
@@ -63,7 +63,7 @@ GitHub write:
   - pull create/update
   - pull comment create
 - Before vtddWriteGitHub, show exact title/body or comment/update payload; wait GO.
-- For issue_create, fix title+body, bind GO; vtddWriteGitHub responseMode=action_visible. Show exact title/body, ask only `GO`; if next msg has GO and same payload+repo are bound, call vtddWriteGitHub. Never ask targetConfirmed/approvalScopeMatched/approvalPhrase/raw JSON.
+- For normal GO writes (`issue_create`, `issue_comment_create`, `pull_comment_create`), show exact payload, ask only `GO`, then call vtddWriteGitHub with naturalApproval and responseMode=action_visible. Never ask targetConfirmed/approvalScopeMatched/approvalPhrase/raw JSON.
 - Only when repo resolved, scope traceable, and GO exists.
 - Do not use vtddWriteGitHub for merge, issue close, deploy, secret/settings/permission mutation, destructive cleanup.
 

--- a/docs/setup/custom-gpt-instructions.md
+++ b/docs/setup/custom-gpt-instructions.md
@@ -232,14 +232,16 @@ GitHub normal write plane:
   - pull request create or update
   - pull request comment create
 - Before calling vtddWriteGitHub, present the exact bounded payload to the human and wait for GO bound to that payload. For Issues and PRs, show the exact title/body. For comments or updates, show the concrete body or fields that will be written. This applies even when the next safe action is only to create the next validation Issue or PR from an iPhone Butler conversation.
-- For issue creation, first confirm or fix the exact Issue title and body, bind
-  the user's `GO` to that title/body scope, then call vtddWriteGitHub with
-  operation=`issue_create`.
-- Normal issue creation GO UX:
+- For normal GO writes, first confirm or fix the exact payload, bind the user's
+  `GO` to that payload scope, then call vtddWriteGitHub. Current natural GO
+  binding is supported for `issue_create`, `issue_comment_create`, and
+  `pull_comment_create`.
+- Normal GitHub write GO UX:
   - If the human says something like "この内容で Issue 作って", show the exact title/body payload and say: "この title/body で Issue を作成するなら「GO」と言ってください。GOを受けたら、この payload で Issue を作成します。"
-  - If the next human message contains literal `GO` and the exact title/body payload is unchanged, call vtddWriteGitHub for `issue_create`.
+  - For comments, show the exact body plus the target issue/PR number and say that `GO` will post exactly that payload.
+  - If the next human message contains literal `GO` and the exact payload is unchanged, call vtddWriteGitHub for the matching supported operation.
   - Do not ask the human to say `targetConfirmed=true`, `approvalScopeMatched=true`, `approvalPhrase=GO`, or any raw JSON.
-  - Include `naturalApproval.exactPayloadPresented=true`, `repositoryResolved=true`, the GO message as `userText`, and the exact previously presented operation/repository/title/body as `presentedPayload`; the runtime binds targetConfirmed, approvalScopeMatched, and approvalPhrase from that evidence.
+  - Include `naturalApproval.exactPayloadPresented=true`, `repositoryResolved=true`, the GO message as `userText`, and the exact previously presented operation/repository/title/body or issueNumber/pullNumber/body as `presentedPayload`; the runtime binds targetConfirmed, approvalScopeMatched, and approvalPhrase from that evidence.
   - If the payload was not presented immediately before, or the repository is unresolved/ambiguous, stop and present/resolve first.
 - When calling vtddWriteGitHub from Custom GPT, include
   `responseMode=action_visible` so downstream write failures remain visible as

--- a/src/core/github-app-operation-registry.js
+++ b/src/core/github-app-operation-registry.js
@@ -1,0 +1,199 @@
+import { GitHubWriteOperation } from "./github-write-plane.js";
+
+export const GitHubAppOperationTier = Object.freeze({
+  READ: "read",
+  NORMAL_GO: "normal_go",
+  PASSKEY_AUTHORITY: "passkey_authority"
+});
+
+export const GitHubAppOperationRegistry = Object.freeze({
+  [GitHubWriteOperation.ISSUE_CREATE]: {
+    operation: GitHubWriteOperation.ISSUE_CREATE,
+    tier: GitHubAppOperationTier.NORMAL_GO,
+    requiredPayloadFields: ["repository", "title", "body"],
+    naturalGoIdentityFields: ["repository", "title", "body"]
+  },
+  [GitHubWriteOperation.ISSUE_COMMENT_CREATE]: {
+    operation: GitHubWriteOperation.ISSUE_COMMENT_CREATE,
+    tier: GitHubAppOperationTier.NORMAL_GO,
+    requiredPayloadFields: ["repository", "issueNumber", "body"],
+    naturalGoIdentityFields: ["repository", "issueNumber", "body"]
+  },
+  [GitHubWriteOperation.ISSUE_COMMENT_UPDATE]: {
+    operation: GitHubWriteOperation.ISSUE_COMMENT_UPDATE,
+    tier: GitHubAppOperationTier.NORMAL_GO,
+    requiredPayloadFields: ["repository", "issueNumber", "commentId", "body"],
+    naturalGoIdentityFields: ["repository", "issueNumber", "commentId", "body"],
+    naturalGoEnabled: false
+  },
+  [GitHubWriteOperation.BRANCH_CREATE]: {
+    operation: GitHubWriteOperation.BRANCH_CREATE,
+    tier: GitHubAppOperationTier.NORMAL_GO,
+    requiredPayloadFields: ["repository", "branch", "baseRef"],
+    naturalGoIdentityFields: ["repository", "branch", "baseRef"],
+    naturalGoEnabled: false
+  },
+  [GitHubWriteOperation.PULL_CREATE]: {
+    operation: GitHubWriteOperation.PULL_CREATE,
+    tier: GitHubAppOperationTier.NORMAL_GO,
+    requiredPayloadFields: ["repository", "title", "body", "head", "baseRef"],
+    naturalGoIdentityFields: ["repository", "title", "body", "head", "baseRef"],
+    naturalGoEnabled: false
+  },
+  [GitHubWriteOperation.PULL_UPDATE]: {
+    operation: GitHubWriteOperation.PULL_UPDATE,
+    tier: GitHubAppOperationTier.NORMAL_GO,
+    requiredPayloadFields: ["repository", "pullNumber", "title", "body"],
+    naturalGoIdentityFields: ["repository", "pullNumber", "title", "body"],
+    naturalGoEnabled: false
+  },
+  [GitHubWriteOperation.PULL_COMMENT_CREATE]: {
+    operation: GitHubWriteOperation.PULL_COMMENT_CREATE,
+    tier: GitHubAppOperationTier.NORMAL_GO,
+    requiredPayloadFields: ["repository", "pullNumber", "body"],
+    naturalGoIdentityFields: ["repository", "pullNumber", "body"]
+  },
+  pull_merge: {
+    operation: "pull_merge",
+    tier: GitHubAppOperationTier.PASSKEY_AUTHORITY,
+    requiredPayloadFields: ["repository", "pullNumber", "mergeMethod"],
+    passkey: {
+      actionType: "merge",
+      highRiskKind: "pull_merge"
+    }
+  },
+  issue_close: {
+    operation: "issue_close",
+    tier: GitHubAppOperationTier.PASSKEY_AUTHORITY,
+    requiredPayloadFields: ["repository", "issueNumber", "mergedPullNumber"],
+    passkey: {
+      actionType: "merge",
+      highRiskKind: "issue_close"
+    }
+  },
+  deploy_production: {
+    operation: "deploy_production",
+    tier: GitHubAppOperationTier.PASSKEY_AUTHORITY,
+    requiredPayloadFields: ["repository"],
+    passkey: {
+      actionType: "deploy_production",
+      highRiskKind: "deploy_production"
+    }
+  },
+  github_actions_secret_sync: {
+    operation: "github_actions_secret_sync",
+    tier: GitHubAppOperationTier.PASSKEY_AUTHORITY,
+    requiredPayloadFields: ["repository", "secretName"],
+    passkey: {
+      actionType: "destructive",
+      highRiskKind: "github_actions_secret_sync"
+    }
+  }
+});
+
+const NATURAL_GO_ENABLED_OPERATIONS = new Set([
+  GitHubWriteOperation.ISSUE_CREATE,
+  GitHubWriteOperation.ISSUE_COMMENT_CREATE,
+  GitHubWriteOperation.PULL_COMMENT_CREATE
+]);
+
+export function getGitHubAppOperation(operation) {
+  return GitHubAppOperationRegistry[normalizeText(operation)] ?? null;
+}
+
+export function bindNaturalGitHubWriteApproval({ payload, policyInput }) {
+  if (
+    policyInput?.targetConfirmed === true &&
+    policyInput?.approvalScopeMatched === true &&
+    normalizeText(policyInput?.approvalPhrase)
+  ) {
+    return policyInput;
+  }
+
+  if (!canBindNaturalGitHubWriteApproval(payload)) {
+    return policyInput;
+  }
+
+  return {
+    ...policyInput,
+    targetConfirmed: true,
+    approvalScopeMatched: true,
+    approvalPhrase: "GO"
+  };
+}
+
+export function canBindNaturalGitHubWriteApproval(payload) {
+  const operation = normalizeText(payload?.operation);
+  const operationConfig = getGitHubAppOperation(operation);
+  if (
+    !operationConfig ||
+    operationConfig.tier !== GitHubAppOperationTier.NORMAL_GO ||
+    operationConfig.naturalGoEnabled === false ||
+    !NATURAL_GO_ENABLED_OPERATIONS.has(operation)
+  ) {
+    return false;
+  }
+
+  const naturalApproval = normalizeObject(payload?.naturalApproval);
+  if (naturalApproval.exactPayloadPresented !== true || naturalApproval.repositoryResolved !== true) {
+    return false;
+  }
+
+  if (!containsGoToken(naturalApproval.userText)) {
+    return false;
+  }
+
+  const presentedPayload = normalizeObject(naturalApproval.presentedPayload);
+  if (normalizeText(presentedPayload.operation) !== operation) {
+    return false;
+  }
+
+  return operationConfig.naturalGoIdentityFields.every((field) =>
+    fieldMatchesPresentedPayload({
+      field,
+      payload,
+      presentedPayload
+    })
+  );
+}
+
+function fieldMatchesPresentedPayload({ field, payload, presentedPayload }) {
+  const actual = readPayloadIdentityField(payload, field);
+  const presented = readPayloadIdentityField(presentedPayload, field);
+  if (field === "body") {
+    return Boolean(normalizeBody(actual)) && normalizeBody(actual) === normalizeBody(presented);
+  }
+  if (["issueNumber", "pullNumber", "commentId"].includes(field)) {
+    const actualNumber = normalizePositiveInteger(actual);
+    return Boolean(actualNumber) && actualNumber === normalizePositiveInteger(presented);
+  }
+  return Boolean(normalizeText(actual)) && normalizeText(actual) === normalizeText(presented);
+}
+
+function readPayloadIdentityField(payload, field) {
+  if (field === "issueNumber") {
+    return payload?.issueNumber ?? payload?.issueContext?.issueNumber;
+  }
+  return payload?.[field];
+}
+
+function containsGoToken(value) {
+  return /(^|[^A-Za-z0-9_])GO([^A-Za-z0-9_]|$)/i.test(normalizeText(value));
+}
+
+function normalizeObject(value) {
+  return value && typeof value === "object" && !Array.isArray(value) ? value : {};
+}
+
+function normalizeText(value) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function normalizeBody(value) {
+  return typeof value === "string" ? value : "";
+}
+
+function normalizePositiveInteger(value) {
+  const number = Number(value);
+  return Number.isInteger(number) && number > 0 ? number : null;
+}

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -196,6 +196,13 @@ export {
 } from "./custom-gpt-setup-artifacts.js";
 export { GitHubReadResource, retrieveGitHubReadPlane } from "./github-read-plane.js";
 export { GitHubWriteOperation, executeGitHubWritePlane } from "./github-write-plane.js";
+export {
+  GitHubAppOperationRegistry,
+  GitHubAppOperationTier,
+  bindNaturalGitHubWriteApproval,
+  canBindNaturalGitHubWriteApproval,
+  getGitHubAppOperation
+} from "./github-app-operation-registry.js";
 export { GitHubHighRiskOperation, executeGitHubHighRiskPlane } from "./github-high-risk-plane.js";
 export {
   WorkflowStage,

--- a/src/worker.js
+++ b/src/worker.js
@@ -35,6 +35,7 @@ import {
   retrieveStoredAliasRegistry,
   retrieveGitHubReadPlane,
   TaskMode,
+  bindNaturalGitHubWriteApproval,
   executeGitHubWritePlane,
   runMvpGateway,
   upsertRepositoryNickname,
@@ -815,67 +816,6 @@ async function handleGitHubWritePlaneRequest(request, env) {
 function wantsActionVisibleGitHubWriteErrors(payload) {
   const responseMode = normalizeText(payload?.responseMode);
   return responseMode === "action_visible";
-}
-
-function bindNaturalGitHubWriteApproval({ payload, policyInput }) {
-  if (
-    policyInput?.targetConfirmed === true &&
-    policyInput?.approvalScopeMatched === true &&
-    normalizeText(policyInput?.approvalPhrase)
-  ) {
-    return policyInput;
-  }
-
-  if (!canBindNaturalIssueCreateApproval(payload)) {
-    return policyInput;
-  }
-
-  return {
-    ...policyInput,
-    targetConfirmed: true,
-    approvalScopeMatched: true,
-    approvalPhrase: "GO"
-  };
-}
-
-function canBindNaturalIssueCreateApproval(payload) {
-  const operation = normalizeText(payload?.operation);
-  if (operation !== "issue_create") {
-    return false;
-  }
-
-  const naturalApproval = normalizeObject(payload?.naturalApproval);
-  if (naturalApproval.exactPayloadPresented !== true || naturalApproval.repositoryResolved !== true) {
-    return false;
-  }
-
-  const userText = normalizeText(naturalApproval.userText);
-  if (!containsGoToken(userText)) {
-    return false;
-  }
-
-  const presentedPayload = normalizeObject(naturalApproval.presentedPayload);
-  if (normalizeText(presentedPayload.operation) !== "issue_create") {
-    return false;
-  }
-
-  if (!normalizeText(payload?.repository) || normalizeText(presentedPayload.repository) !== normalizeText(payload?.repository)) {
-    return false;
-  }
-
-  if (!normalizeText(payload?.title) || normalizeText(presentedPayload.title) !== normalizeText(payload?.title)) {
-    return false;
-  }
-
-  if (!normalizeBody(payload?.body) || normalizeBody(presentedPayload.body) !== normalizeBody(payload?.body)) {
-    return false;
-  }
-
-  return true;
-}
-
-function containsGoToken(value) {
-  return /(^|[^A-Za-z0-9_])GO([^A-Za-z0-9_]|$)/i.test(normalizeText(value));
 }
 
 async function handleGitHubHighRiskPlaneRequest(request, env) {

--- a/test/butler-capability-matrix.test.js
+++ b/test/butler-capability-matrix.test.js
@@ -13,7 +13,8 @@ test("Butler capability matrix records live/source/unverified status without ove
   assert.equal(doc.includes("Do not report `source-only` as done."), true);
   assert.equal(doc.includes("Do not report `requested` handoff as Codex"), true);
 
-  assert.equal(doc.includes("| natural GO -> issue_create | `source-only` |"), true);
+  assert.equal(doc.includes("| natural GO -> normal GitHub write | `source-only` |"), true);
+  assert.equal(doc.includes("registry-backed binding to `issue_create`, `issue_comment_create`, and `pull_comment_create`"), true);
   assert.equal(doc.includes("#151 remains open because iPhone Butler live evidence is missing"), true);
   assert.equal(doc.includes("| closed issue list read | `broken-live` |"), true);
   assert.equal(doc.includes("| `@codex` handoff comment | `partial-live` |"), true);
@@ -30,6 +31,7 @@ test("Butler capability matrix prioritizes the Butler-to-Codex path and surface 
   assert.equal(doc.includes("requested/queued/blocked/branch/PR (#157)"), true);
   assert.equal(doc.includes("Surface update guidance"), true);
   assert.equal(doc.includes("Instructions/Action Schema/Cloudflare deploy links"), true);
+  assert.equal(doc.includes("`natural GO -> normal GitHub write` (#151/#161 live proof)"), true);
   assert.equal(doc.includes("live Butler/iPhone validation phrase"), true);
   assert.equal(doc.includes("expected GitHub/runtime evidence"), true);
 });

--- a/test/custom-gpt-setup-docs.test.js
+++ b/test/custom-gpt-setup-docs.test.js
@@ -58,7 +58,7 @@ test("custom gpt instructions preserve current butler and approval boundaries", 
   assert.equal(doc.includes("no relevant RAG/memory hit is found, say so"), true);
   assert.equal(doc.includes("do not invent past precedent"), true);
   assert.equal(doc.includes("current state is governed by GitHub runtime truth"), true);
-  assert.equal(doc.includes("operation=`issue_create`"), true);
+  assert.equal(doc.includes("Current natural GO\n  binding is supported for `issue_create`, `issue_comment_create`, and\n  `pull_comment_create`"), true);
   assert.equal(doc.includes("If the human says something like \"この内容で Issue 作って\""), true);
   assert.equal(doc.includes("この title/body で Issue を作成するなら「GO」と言ってください"), true);
   assert.equal(doc.includes("Do not ask the human to say `targetConfirmed=true`"), true);
@@ -135,7 +135,7 @@ test("short custom gpt instructions stay under editor limits while preserving cr
   assert.equal(doc.includes("no RAG hit OK"), true);
   assert.equal(doc.includes("never invent"), true);
   assert.equal(doc.includes("Runtime truth > memory"), true);
-  assert.equal(doc.includes("For issue_create, fix title+body, bind GO"), true);
+  assert.equal(doc.includes("For normal GO writes (`issue_create`, `issue_comment_create`, `pull_comment_create`)"), true);
   assert.equal(doc.includes("ask only `GO`"), true);
   assert.equal(doc.includes("Never ask targetConfirmed/approvalScopeMatched/approvalPhrase/raw JSON"), true);
   assert.equal(doc.includes("Nickname memory is user-owned alias data"), true);
@@ -250,7 +250,11 @@ test("custom gpt openapi json parses and exposes paths as an object", () => {
   );
   const githubWriteSchema = doc.paths["/v2/action/github"].post.requestBody.content["application/json"].schema;
   assert.equal(typeof githubWriteSchema.properties.naturalApproval, "object");
-  assert.equal(githubWriteSchema.properties.naturalApproval.properties.presentedPayload.properties.operation.enum[0], "issue_create");
+  assert.deepEqual(githubWriteSchema.properties.naturalApproval.properties.presentedPayload.properties.operation.enum, [
+    "issue_create",
+    "issue_comment_create",
+    "pull_comment_create"
+  ]);
   assert.equal(typeof doc.paths["/v2/action/github-authority"], "object");
   assert.equal(typeof doc.paths["/v2/action/deploy"], "object");
   assert.equal(typeof doc.paths["/v2/action/github-actions-secret"], "object");

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -2359,6 +2359,118 @@ test("worker binds natural GO to an immediately presented issue_create payload",
   });
 });
 
+test("worker binds natural GO to an immediately presented issue_comment_create payload", async () => {
+  let requestBody = null;
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/action/github", {
+      method: "POST",
+      headers: {
+        ...gatewayAuthHeaders,
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({
+        operation: "issue_comment_create",
+        repository: "sample-org/vtdd-v2-p",
+        issueContext: {
+          issueNumber: 161
+        },
+        body: "Live evidence comment for #161.",
+        responseMode: "action_visible",
+        naturalApproval: {
+          exactPayloadPresented: true,
+          repositoryResolved: true,
+          userText: "このコメントで追記して。GO",
+          presentedPayload: {
+            operation: "issue_comment_create",
+            repository: "sample-org/vtdd-v2-p",
+            issueNumber: 161,
+            body: "Live evidence comment for #161."
+          }
+        }
+      })
+    }),
+    {
+      ...gatewayAuthEnv,
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_write",
+      GITHUB_API_FETCH: async (_url, init) => {
+        requestBody = JSON.parse(init.body);
+        return new Response(
+          JSON.stringify({
+            id: 435161,
+            html_url: "https://github.com/sample-org/vtdd-v2-p/issues/161#issuecomment-435161"
+          }),
+          { status: 201, headers: { "content-type": "application/json" } }
+        );
+      }
+    }
+  );
+
+  assert.equal(response.status, 200);
+  const body = await response.json();
+  assert.equal(body.ok, true);
+  assert.equal(body.write.operation, "issue_comment_create");
+  assert.equal(body.write.issueNumber, 161);
+  assert.equal(body.write.commentId, 435161);
+  assert.deepEqual(requestBody, {
+    body: "Live evidence comment for #161."
+  });
+});
+
+test("worker binds natural GO to an immediately presented pull_comment_create payload", async () => {
+  let requestBody = null;
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/action/github", {
+      method: "POST",
+      headers: {
+        ...gatewayAuthHeaders,
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({
+        operation: "pull_comment_create",
+        repository: "sample-org/vtdd-v2-p",
+        pullNumber: 162,
+        body: "PR follow-up comment.",
+        responseMode: "action_visible",
+        naturalApproval: {
+          exactPayloadPresented: true,
+          repositoryResolved: true,
+          userText: "この PR コメントで投稿して。GO",
+          presentedPayload: {
+            operation: "pull_comment_create",
+            repository: "sample-org/vtdd-v2-p",
+            pullNumber: 162,
+            body: "PR follow-up comment."
+          }
+        }
+      })
+    }),
+    {
+      ...gatewayAuthEnv,
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_write",
+      GITHUB_API_FETCH: async (_url, init) => {
+        requestBody = JSON.parse(init.body);
+        return new Response(
+          JSON.stringify({
+            id: 435162,
+            html_url: "https://github.com/sample-org/vtdd-v2-p/pull/162#issuecomment-435162"
+          }),
+          { status: 201, headers: { "content-type": "application/json" } }
+        );
+      }
+    }
+  );
+
+  assert.equal(response.status, 200);
+  const body = await response.json();
+  assert.equal(body.ok, true);
+  assert.equal(body.write.operation, "pull_comment_create");
+  assert.equal(body.write.pullNumber, 162);
+  assert.equal(body.write.commentId, 435162);
+  assert.deepEqual(requestBody, {
+    body: "PR follow-up comment."
+  });
+});
+
 test("worker does not bind natural GO when issue_create payload was not presented", async () => {
   let githubCalled = false;
   const response = await worker.fetch(
@@ -2458,7 +2570,7 @@ test("worker does not bind natural GO when presented issue_create payload differ
   assert.equal(githubCalled, false);
 });
 
-test("worker keeps natural GO binding limited to issue_create", async () => {
+test("worker keeps natural GO binding limited to configured normal write operations", async () => {
   const response = await worker.fetch(
     new Request("https://example.com/v2/action/github", {
       method: "POST",


### PR DESCRIPTION
## This PR satisfies Intent

Issue #161 の一部として、GitHub normal write の natural GO binding を `issue_create` だけの one-off 実装から GitHub App operation registry/model へ移します。

Butler が exact payload を提示し、ユーザーが自然に `GO` と返した場合、Worker が内部で `targetConfirmed=true` / `approvalScopeMatched=true` / `approvalPhrase=GO` を束縛できる normal write 操作を広げます。

## Satisfied Success Criteria

- [x] `issue_comment_create` だけの one-off 修正ではなく、GitHub App operation registry/model を追加
- [x] natural GO binding が `issue_create` で維持される
- [x] natural GO binding が `issue_comment_create` で動く
- [x] natural GO binding が代表 normal write operation の `pull_comment_create` で動く
- [x] exact payload 未提示なら normal GO binding はブロックされる
- [x] payload が変更されていたら normal GO binding はブロックされる
- [x] `pull_create` など未許可操作は natural GO binding されない
- [x] Custom GPT Action Schema に supported natural GO operation と presentedPayload fields を露出
- [x] Butler Instructions を内部 field 名ではなく自然 GO UX として更新
- [x] #153 capability matrix を source-only evidence として更新し、live evidence とは過剰主張しない

## Unsatisfied Success Criteria

#161 全体は未完了です。この PR は normal GO write registry/binding の source-level slice です。

未実装/未検証:

- iPhone Butler live validation for `issue_comment_create` / `pull_comment_create`
- full GitHub operation registry coverage for every read/write/passkey operation
- passkey authority tier execution model consolidation beyond metadata
- #157 Butler-to-Codex handoff branch/PR live proof
- live closure of #151/#153/#157

## Non-goal violations

None.

## Verification Evidence

- Unit: `node --test test/worker.test.js --test-name-pattern "natural GO"`
- Unit: `node --test test/github-write-plane.test.js`
- Docs/schema: `node --test test/custom-gpt-setup-docs.test.js`
- Docs: `node --test test/butler-capability-matrix.test.js`
- E2E: `npm test`
- Manual: Not run. Live iPhone Butler evidence remains required before marking the capability complete.
- Evidence path/link: `test/worker.test.js`, `src/core/github-app-operation-registry.js`, `docs/butler/capability-matrix.md`

## Surface Update Checklist

- Cloudflare deploy: Required after merge because Worker runtime binding logic changed.
- Custom GPT Action Schema update: Required after merge because `docs/setup/custom-gpt-actions-openapi.yaml` changed.
- Custom GPT Instructions update: Required after merge because both Instructions docs changed.
- iPhone Butler live E2E: Required after deploy/schema/instruction update. Validate at least one natural GO `issue_comment_create` from Butler.

## Related Constitution Rules

- Butler is context-first.
- No default repository.
- High-risk actions require GO + passkey.
- User-facing operational guidance is Japanese by default.
- Do not overclaim VTDD end-to-end completion from partial adapter success.

## Out-of-scope but NOT implemented

- No merge/deploy/secret/destructive natural GO path.
- No GitHub App permission or repository settings mutation.
- No broad reviewer backend redesign.
- No Issue closure.

## Extra changes (if any)

None.
