### PR TITLE
Record live natural GO comment evidence in capability matrix

### DIFF
--- a/docs/butler/capability-matrix.md
+++ b/docs/butler/capability-matrix.md
@@ -36,9 +36,9 @@ execution.
 | closed issue list read | `broken-live` | Butler reported zero closed issues while GitHub UI had closed issues. | Read closed issues and exact known closed issues such as #135. |
 | exact Issue body read | `partial-live` | Some Issue bodies have been read; failures occurred when body was omitted. | Read #151/#153 and summarize Intent/SC/Non-goals from body. |
 | issue comments read | `unverified` | Needed for reviewer and handoff evidence. | Read comments from an Issue with known comments and compare count/content. |
-| issue comment create | `source-only` | #161 source now binds natural GO for exact `issue_comment_create` payloads; live Butler path not proven. | Present exact comment payload, say GO, verify GitHub URL. |
+| issue comment create | `verified-live` | #163 source/runtime/surface updates were deployed, then live Butler exact payload -> natural `GO` created #161 comment: https://github.com/marushu/vtdd-v2-p/issues/161#issuecomment-4351759028. | Continue boundary validation for missing/changed payload and update path. |
 | issue comment update | `unverified` | Source write plane supports it; live Butler path not proven. | Create then update a bounded test comment. |
-| natural GO -> normal GitHub write | `source-only` | #152 added `issue_create`; #161 source expands registry-backed binding to `issue_create`, `issue_comment_create`, and `pull_comment_create`. #151 remains open because iPhone Butler live evidence is missing. | In Butler, after exact title/body or comment payload, say `GO`; verify created Issue/comment/PR comment URL. |
+| natural GO -> normal GitHub write | `partial-live` | #152 added `issue_create`; #163 source expands registry-backed binding to `issue_create`, `issue_comment_create`, and `pull_comment_create`. Live Butler evidence now exists for issue comments and PR comments: https://github.com/marushu/vtdd-v2-p/issues/161#issuecomment-4351759028 and https://github.com/marushu/vtdd-v2-p/pull/163#issuecomment-4351775751. Fresh post-#163 `issue_create` and boundary failures remain unverified, so this is not fully complete. | Validate post-#163 `issue_create`, missing-payload block, changed-payload block, and unresolved-repo block. |
 | open PR read | `partial-live` | Butler has read open PRs. | Read open PR list and exact PR details. |
 | closed/merged PR read | `partial-live` | Butler has read merged PRs and merge fields. | Read a known merged PR and verify merged/mergedAt/mergeCommitSha. |
 | PR diff / changed files read | `unverified` | Required for PR summary; current matrix lacks live evidence. | Ask Butler to summarize changed files for a known PR. |
@@ -52,7 +52,7 @@ execution.
 | branch create | `unverified` | Source write plane supports it; live Butler path not proven. | Create a bounded test branch and verify branch exists. |
 | PR create | `unverified` | Source write plane supports it; live Butler path not proven from Butler. | Create PR from a bounded branch if needed by a live slice. |
 | PR update | `unverified` | Source write plane supports it; live Butler path not proven. | Update a bounded PR title/body and verify. |
-| PR comment create | `source-only` | #161 source now binds natural GO for exact `pull_comment_create` payloads; live Butler path not proven. | Post a bounded PR comment and verify URL. |
+| PR comment create | `verified-live` | #163 source/runtime/surface updates were deployed, then live Butler exact payload -> natural `GO` created PR #163 comment: https://github.com/marushu/vtdd-v2-p/pull/163#issuecomment-4351775751. | Continue boundary validation and PR state/comment readback. |
 | `@codex` handoff comment | `partial-live` | PR #155 produced a `deliveryMode=codex_cloud_github_comment` request comment with `@codex review`. | Verify the same request shape from Butler-originated development handoff, not only reviewer fallback. |
 | Butler -> Codex Cloud pickup | `partial-live` | PR #155 later showed Codex Cloud can respond to a human `@codex review`, but development handoff branch/PR creation is not proven. | Under #157, confirm Butler-originated development handoff creates a branch/PR or returns a clear blocker. |
 | Codex fallback as VTDD reviewer | `partial-live` | PR #155 Codex responded, but did not return the required VTDD reviewer marker/fields. #156 tracks this contract gap. | Require `vtdd:reviewer=codex-fallback` completed marker plus recommended action before treating it as reviewer evidence. |
@@ -67,7 +67,7 @@ execution.
 
 ## Priority Order
 
-1. `natural GO -> normal GitHub write` (#151/#161 live proof)
+1. `natural GO -> normal GitHub write` boundary/fresh `issue_create` proof (#151/#161)
 2. Issue read completeness: open/closed/exact body/comments/pagination
 3. PR runtime truth completeness: PR state/diff/comments/reviews/checks/runs/branches
 4. Butler -> Codex development handoff progress: requested/queued/blocked/branch/PR (#157)

--- a/test/butler-capability-matrix.test.js
+++ b/test/butler-capability-matrix.test.js
@@ -13,9 +13,13 @@ test("Butler capability matrix records live/source/unverified status without ove
   assert.equal(doc.includes("Do not report `source-only` as done."), true);
   assert.equal(doc.includes("Do not report `requested` handoff as Codex"), true);
 
-  assert.equal(doc.includes("| natural GO -> normal GitHub write | `source-only` |"), true);
+  assert.equal(doc.includes("| natural GO -> normal GitHub write | `partial-live` |"), true);
   assert.equal(doc.includes("registry-backed binding to `issue_create`, `issue_comment_create`, and `pull_comment_create`"), true);
-  assert.equal(doc.includes("#151 remains open because iPhone Butler live evidence is missing"), true);
+  assert.equal(doc.includes("Fresh post-#163 `issue_create` and boundary failures remain unverified"), true);
+  assert.equal(doc.includes("| issue comment create | `verified-live` |"), true);
+  assert.equal(doc.includes("https://github.com/marushu/vtdd-v2-p/issues/161#issuecomment-4351759028"), true);
+  assert.equal(doc.includes("| PR comment create | `verified-live` |"), true);
+  assert.equal(doc.includes("https://github.com/marushu/vtdd-v2-p/pull/163#issuecomment-4351775751"), true);
   assert.equal(doc.includes("| closed issue list read | `broken-live` |"), true);
   assert.equal(doc.includes("| `@codex` handoff comment | `partial-live` |"), true);
   assert.equal(doc.includes("| Butler -> Codex Cloud pickup | `partial-live` |"), true);
@@ -31,7 +35,7 @@ test("Butler capability matrix prioritizes the Butler-to-Codex path and surface 
   assert.equal(doc.includes("requested/queued/blocked/branch/PR (#157)"), true);
   assert.equal(doc.includes("Surface update guidance"), true);
   assert.equal(doc.includes("Instructions/Action Schema/Cloudflare deploy links"), true);
-  assert.equal(doc.includes("`natural GO -> normal GitHub write` (#151/#161 live proof)"), true);
+  assert.equal(doc.includes("`natural GO -> normal GitHub write` boundary/fresh `issue_create` proof (#151/#161)"), true);
   assert.equal(doc.includes("live Butler/iPhone validation phrase"), true);
   assert.equal(doc.includes("expected GitHub/runtime evidence"), true);
 });


### PR DESCRIPTION
## This PR satisfies Intent

Issue #161 / #153 の live evidence 記録です。

#163 merge 後、Cloudflare deploy / Action Schema / Instructions 更新後に、Butler から natural GO で以下が実際に通ったため、Capability Matrix を source-only から実証済み状態へ更新します。

- `issue_comment_create`: https://github.com/marushu/vtdd-v2-p/issues/161#issuecomment-4351759028
- `pull_comment_create`: https://github.com/marushu/vtdd-v2-p/pull/163#issuecomment-4351775751

## Satisfied Success Criteria

- [x] Capability Matrix が live Butler evidence を URL 付きで記録する
- [x] `issue_comment_create` を `verified-live` として記録する
- [x] `pull_comment_create` を `verified-live` として記録する
- [x] `natural GO -> normal GitHub write` は過大評価せず `partial-live` に留める

## Unsatisfied Success Criteria

- post-#163 の `issue_create` live validation は未実施
- missing-payload / changed-payload / unresolved-repo の live boundary validation は未実施
- #157 の Butler -> Codex development handoff は未実施

## Non-goal violations

None.

## Verification Evidence

- Unit: `node --test test/butler-capability-matrix.test.js` pass
- Integration: `npm test` pass（489 tests）
- E2E: 既存 live Butler evidence URL を matrix に記録
- Manual: #163 後の Butler 操作で issue comment / PR comment creation 成功確認済み
- Evidence path/link:
  - `docs/butler/capability-matrix.md`
  - `test/butler-capability-matrix.test.js`
  - https://github.com/marushu/vtdd-v2-p/issues/161#issuecomment-4351759028
  - https://github.com/marushu/vtdd-v2-p/pull/163#issuecomment-4351775751

## Surface Update Checklist

- Cloudflare deploy: 不要（docs/test only）
- Custom GPT Action Schema update: 不要
- Custom GPT Instructions update: 不要
- iPhone Butler live E2E: 実施済み evidence を記録

## Related Constitution Rules

- Evidence discipline: completion claim must include evidence
- Current reality guard: partial success must stay narrow
- Conversation UX: Butler-originated iPhone flow must be proven live, not source-only

## Out-of-scope but NOT implemented

- runtime / worker code change
- Action Schema / Instructions change
- Issue close
- deploy / merge / high-risk operation
- #157 Codex handoff progress validation

## Extra changes (if any)

None.
