### PR TITLE
Record Codex Cloud exec evidence for Issue #157

### DIFF
--- a/docs/mvp/issue-157-codex-cloud-exec-connectivity-evidence.md
+++ b/docs/mvp/issue-157-codex-cloud-exec-connectivity-evidence.md
@@ -1,0 +1,16 @@
+# Codex Cloud exec connectivity evidence for Issue #157
+
+- Issue reference: #157
+- Scope: docs/evidence only; no runtime code changes in this PR.
+
+## Evidence note
+
+This note records that a development task was executed from Codex Cloud exec as a live validation slice for Issue #157.
+
+Observed outcome for this slice: connectivity and execution path evidence were captured via this documentation update PR.
+
+## Guardrails preserved
+
+- This does **not** claim VTDD end-to-end completion.
+- Queued/requested state alone is **not** treated as success.
+- Success for this slice is limited to documented connectivity evidence tied to Issue #157.


### PR DESCRIPTION
## Intent

Record live evidence that Codex Cloud can be started through `codex cloud exec` for Issue #157, and that the produced Codex Cloud diff can be applied into a GitHub-visible branch/PR.

## Changed docs

- `docs/mvp/issue-157-codex-cloud-exec-connectivity-evidence.md`

## Evidence

- Codex Cloud task: https://chatgpt.com/codex/tasks/task_e_69f35de8e03c832f81a7531c16661981
- Task reached READY and produced a one-file diff.
- `codex cloud apply` applied the task diff locally.
- This PR is the GitHub-visible branch/PR evidence generated from that task output.

## Boundary

- This does not claim full VTDD E2E completion.
- This does not prove Butler -> Worker -> runner automation yet.
- Queued/requested alone remains insufficient evidence.
- No runtime code changes.

## Verification

- `npm test` -> 490 passing tests.

Related: #157