### PR TITLE
Codex executor transport を pluggable registry 化する

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,10 +86,28 @@ Cloudflare, and reviewer configuration. Any GitHub Actions runner that uses
 `OPENAI_API_KEY` for Codex CLI is an explicit opt-in API-backed executor, not
 the default no-extra-API-cost path.
 
-The default no-extra-API-cost executor path delegates through GitHub by posting
-a bounded `@codex` Issue/PR comment for the operator's own Codex Cloud GitHub
-integration to pick up. That path uses the operator's ChatGPT/Codex account and
-does not require an OpenAI API key in GitHub Actions.
+Executor transport is pluggable and user-owned. `marushu/vtdd-v2-p` is the
+public canonical core, not a shared hosted runner. Target repositories such as
+TOMIO or SunabaEye are separate from the executor backend that performs the
+work.
+
+Supported executor transport identities are:
+
+- `codex_cloud_github_comment`: bounded `@codex` Issue/PR comment transport.
+  This is request-only until GitHub-visible branch / PR evidence exists.
+- `codex_cloud_cli_control_runner`: user-owned private control repository or
+  trusted runner that runs `codex cloud exec` with ChatGPT-managed Codex auth.
+  This path does not use `OPENAI_API_KEY`; it consumes the user's runner
+  capacity such as private GitHub Actions minutes.
+- `vps_runner`: user-owned trusted VPS / persistent host option. This is the
+  migration target when private GitHub Actions minutes, queueing, or repository
+  constraints become the wrong trade-off. The VPS is not part of VTDD core and
+  must be maintained by the user.
+- `api_key_runner`: explicit opt-in runner that uses `OPENAI_API_KEY` and may
+  create separate API billing from ChatGPT/Codex subscription billing.
+
+The owner-specific `vtdd-v2-secret` repository is an example / evidence control
+repository for the owner. It is not a shared runner for other users.
 
 Likewise, a reviewer workflow that uses `GEMINI_API_KEY` is an optional
 provider-backed reviewer path. Reviewer choice remains pluggable.

--- a/docs/butler/remote-codex-cli-executor.md
+++ b/docs/butler/remote-codex-cli-executor.md
@@ -33,23 +33,37 @@ This slice exists specifically so the loop can continue into:
 The implementation must preserve a no-extra-API-cost default for operators who
 already use Codex through a ChatGPT/Codex subscription.
 
-The GitHub Actions Codex CLI runner is an optional `api_key_runner`, not the
-default account model. It requires `OPENAI_API_KEY` and may create separate API
-billing from a ChatGPT/Codex subscription.
+Executor transport is a pluggable registry. The VTDD public/core repository is
+not a shared hosted runner, and `marushu/vtdd-v2-p` must not be presented as an
+execution backend for other users. Each user brings their own GitHub,
+Cloudflare, ChatGPT/Codex, reviewer, and executor backend assets.
 
-The default operator path is GitHub-centered Codex Cloud delegation through the
-operator's own ChatGPT/Codex GitHub integration.
+Target repository and executor backend are separate:
 
-VTDD expresses that delegation as a bounded GitHub Issue or PR comment that
-mentions `@codex`. This lets the operator's existing Codex Cloud entitlement
-pick up the work through GitHub without requiring `OPENAI_API_KEY`.
+- target repository: the repository being changed, such as TOMIO, SunabaEye, or
+  `vtdd-v2-p`
+- executor backend: the user-owned comment integration, private control
+  repository, trusted VPS, or explicit API-key runner that performs the work
 
-This path depends on the operator having connected Codex Cloud to GitHub in
-their own ChatGPT/Codex account. VTDD must surface that as operator-owned
-configuration, not as a repository secret owned by this public repo.
+The registered executor transports are:
 
-Codex Cloud is the default account-backed executor path. `OPENAI_API_KEY`
-runners are optional opt-in machine paths only.
+| Transport | Owner / credential boundary | Billing / cost boundary | Success evidence |
+| --- | --- | --- | --- |
+| `codex_cloud_github_comment` | Operator-owned ChatGPT/Codex GitHub integration | ChatGPT/Codex subscription path; no `OPENAI_API_KEY` | Request is not success; branch and/or PR evidence must appear on GitHub |
+| `codex_cloud_cli_control_runner` | User-owned private control repository or trusted runner with ChatGPT-managed Codex auth | User-owned runner cost such as private GitHub Actions minutes; no `OPENAI_API_KEY` | workflow run plus GitHub-visible branch / PR evidence |
+| `vps_runner` | User-owned trusted VPS / persistent host | User pays and maintains VPS; VTDD core does not host it | runner log plus GitHub-visible branch / PR evidence |
+| `api_key_runner` | User-owned control repository or trusted runner with `OPENAI_API_KEY` | Explicit opt-in OpenAI API billing, separate from ChatGPT/Codex subscription | workflow run plus GitHub-visible branch / PR evidence |
+
+The `api_key_runner` transport is an optional `api_key_runner`, not a default
+account model.
+
+The owner-specific `vtdd-v2-secret` private repository is owner evidence and an
+example of the `codex_cloud_cli_control_runner` shape. It is not a shared
+runner for other VTDD users.
+
+Codex Cloud comment delegation remains request-state until GitHub-visible
+runtime truth appears. Queued/requested/comment-only evidence is not
+implementation success.
 
 ## Default Codex Cloud GitHub Comment Runner
 
@@ -68,6 +82,37 @@ grace period, Butler must not keep reporting the handoff as merely queued
 forever. It must report a first-class blocked state such as
 `codex_cloud_pickup_not_observed`, preserving the delegation comment URL and
 the absence of branch/PR evidence as runtime truth.
+
+## Codex Cloud CLI Control Runner
+
+The confirmed no-`OPENAI_API_KEY` machine path is
+`codex_cloud_cli_control_runner`:
+
+- Butler dispatches a bounded request to a user-owned private control
+  repository or trusted runner.
+- That backend restores ChatGPT-managed Codex authentication for `codex cloud
+  exec`.
+- The backend operates on the target repository and opens or updates a branch /
+  PR there.
+- Butler tracks the GitHub Actions workflow run, target branch, and PR as
+  runtime truth.
+
+The live evidence recorded for Issue #157 used this account model and produced
+GitHub-visible PR evidence. The evidence repository name `vtdd-v2-secret` is an
+owner-specific example, not shared infrastructure.
+
+Because a private control repository consumes account-wide private GitHub
+Actions minutes, Butler-facing guidance must surface cost and queueing state.
+When repeated TOMIO / SunabaEye / other target repository work makes private
+Actions minutes or repository constraints a poor fit, move the user's backend
+to `vps_runner` rather than silently changing to API billing.
+
+## User-owned VPS Runner
+
+`vps_runner` is the planned trusted-host alternative for users who want to avoid
+or reduce private GitHub Actions runner cost. It is not a prerequisite for VTDD
+core, and VTDD core does not provide or operate the VPS. The user is responsible
+for host security, patching, credentials, logging, and availability.
 
 ## Optional API-backed Runner
 

--- a/docs/setup/custom-gpt-actions-openapi.json
+++ b/docs/setup/custom-gpt-actions-openapi.json
@@ -223,6 +223,8 @@
                 "type": "string",
                 "enum": [
                   "codex_cloud_github_comment",
+                  "codex_cloud_cli_control_runner",
+                  "vps_runner",
                   "api_key_runner"
                 ]
               },
@@ -420,6 +422,18 @@
               "requiresHandoff": {
                 "type": "boolean"
               },
+              "executorTransport": {
+                "type": "string",
+                "enum": [
+                  "codex_cloud_github_comment",
+                  "codex_cloud_cli_control_runner",
+                  "vps_runner",
+                  "api_key_runner"
+                ]
+              },
+              "apiKeyRunnerAcknowledged": {
+                "type": "boolean"
+              },
               "handoff": {
                 "type": "object",
                 "required": [
@@ -466,6 +480,8 @@
             "type": "string",
             "enum": [
               "codex_cloud_github_comment",
+              "codex_cloud_cli_control_runner",
+              "vps_runner",
               "api_key_runner"
             ]
           },
@@ -1213,6 +1229,8 @@
               "type": "string",
               "enum": [
                 "codex_cloud_github_comment",
+                "codex_cloud_cli_control_runner",
+                "vps_runner",
                 "api_key_runner"
               ]
             }

--- a/docs/setup/custom-gpt-actions-openapi.yaml
+++ b/docs/setup/custom-gpt-actions-openapi.yaml
@@ -153,6 +153,8 @@ components:
               type: string
               enum:
                 - codex_cloud_github_comment
+                - codex_cloud_cli_control_runner
+                - vps_runner
                 - api_key_runner
             apiKeyRunnerAcknowledged:
               type: boolean
@@ -288,6 +290,15 @@ components:
               type: string
             requiresHandoff:
               type: boolean
+            executorTransport:
+              type: string
+              enum:
+                - codex_cloud_github_comment
+                - codex_cloud_cli_control_runner
+                - vps_runner
+                - api_key_runner
+            apiKeyRunnerAcknowledged:
+              type: boolean
             handoff:
               type: object
               required:
@@ -320,6 +331,8 @@ components:
           type: string
           enum:
             - codex_cloud_github_comment
+            - codex_cloud_cli_control_runner
+            - vps_runner
             - api_key_runner
         apiKeyRunnerAcknowledged:
           type: boolean
@@ -794,6 +807,8 @@ paths:
             type: string
             enum:
               - codex_cloud_github_comment
+              - codex_cloud_cli_control_runner
+              - vps_runner
               - api_key_runner
       responses:
         "200":

--- a/docs/setup/custom-gpt-instructions-short.md
+++ b/docs/setup/custom-gpt-instructions-short.md
@@ -1,32 +1,26 @@
 VTDD Butler. Japanese unless asked otherwise.
 
 Core:
-- Issue is canonical spec.
-- GitHub runtime state is current progress truth.
-- Before Issue proposal/write/Codex handoff/PR judgment, run preflight: vtddRetrieveCrossMemory (+ vtddRetrieveDecisionLogs/vtddRetrieveProposalLogs/vtddRetrieveConstitution if useful) + runtime truth. Report found/missing; no RAG hit OK, never invent. Runtime truth > memory.
-- Do not assume a default repository.
-- Resolve repo from alias/context.
-- If repo ambiguous, ask.
+- Issue is canonical spec; GitHub runtime state is current progress truth.
+- Before Issue proposal/write/Codex handoff/PR judgment, preflight: vtddRetrieveCrossMemory (+ vtddRetrieveDecisionLogs/vtddRetrieveProposalLogs/vtddRetrieveConstitution if useful) + runtime truth. Report found/missing; no RAG hit OK, never invent. Runtime truth > memory.
+- Do not assume a default repository. Resolve repo from alias/context; if ambiguous, ask.
 - No internal API paths/raw JSON unless debugging.
 - Convert natural language to actions.
-- Do not invent scope beyond active Issue/user instruction.
+- Do not invent scope beyond Issue/user instruction.
 - vtddGateway/vtddExecute: surface=custom_gpt, judgmentModelId=vtdd-butler-core-v1.
 
 Repo/nickname:
-- Repo list/candidates: vtddGateway exploration/read_only, repositoryInput=unknown, targetConfirmed=false, safeFallbackChosen=true, consent=["read"].
-- Remember repo nickname: vtddUpsertRepositoryNickname.
-- List repo nicknames: vtddRetrieveRepositoryNicknames.
+- Repo list: vtddGateway exploration/read_only, repositoryInput=unknown, targetConfirmed=false, consent=["read"].
+- Remember/list repo nicknames: vtddUpsertRepositoryNickname / vtddRetrieveRepositoryNicknames.
 - If request starts with non-owner/repo token like `ぶい の...`, call nickname read/gateway first.
 - Nickname memory is user-owned alias data, not default repo; if ambiguous, ask.
 - Nickname read failure is not proof of unknown repo. If conversation/approvalGrant has owner/repo, use unverified fallback; verify next.
-- If nickname save/read fails, surface error/reason/issues.
-- If Action returns `ClientResponseError`, state action, visible HTTP/body, missing error/reason/issues.
+- If nickname save/read fails, surface error/reason/issues. If Action returns `ClientResponseError`, state action and visible HTTP/body.
 
 GitHub read plane:
 - Use vtddRetrieveGitHub for repos/issues/PRs/reviews/comments/checks/runs/branches.
 - If the route is unsupported, say 未対応 for that exact read.
-- If auth fails, say 認証失敗.
-- Do not infer absence from failed/unsupported reads.
+- If auth fails, say 認証失敗. Do not infer absence from failed/unsupported reads.
 
 Self-parity:
 - For stale/outdated/reflected/aligned, use vtddRetrieveSelfParity, repo=<resolved>, ref=main.
@@ -34,27 +28,28 @@ Self-parity:
 - If in_sync but Butler lacks features, say `Action Schema update required` and/or `Instructions update required`.
 - If parity cannot be checked, say `未検証` or `認証失敗`.
 - If action returns error/reason/issues, summarize exact fields.
-- If self-parity returns `ClientResponseError`, say unverified transport failure; Schema may need refresh.
-- Use vtddRetrieveSetupArtifact for setup artifacts: instructions/openapi_yaml/openapi_json.
+- If self-parity returns `ClientResponseError`, say unverified transport failure.
+- Use vtddRetrieveSetupArtifact for setup artifacts.
 - If runtime in sync, don't overclaim editor sync.
 
 Execution:
-- Before execution, read runtime truth. If runtime_truth_required_or_safe_fallback, vtddRetrieveGitHub PR/branch/checks/runs, runtimeAvailable=true, retry once; raw failure on read fail.
-- No open PR: read parent Issue, propose next live E2E slice + exact iPhone validation payload.
+- Before execution, read runtime truth. If runtime_truth_required_or_safe_fallback, vtddRetrieveGitHub PR/branch/checks/runs, runtimeAvailable=true.
+- No open PR: read parent Issue, propose next live E2E slice.
 - Schema: build only under vtddExecute, not vtddGateway.
 - judgmentTrace first four steps exactly: constitution, runtime_truth, issue_context, current_query.
 - No constitutionConsulted input; constitution-first trace satisfies policy.
-- If the target repository is unresolved, do not execute.
-- Read-only exploration may proceed unresolved if policy allows.
+- If target repository is unresolved, do not execute. Read-only exploration may proceed unresolved if policy allows.
 
 Remote Codex flow:
 - Use vtddExecute only for bounded Butler -> Codex handoff.
-- vtddExecute handoff: actionType=build; requiresHandoff=true; issueTraceability Intent/SC/Non-goal refs; issueContext.issueNumber.
-- Before Codex handoff, show exact payload: repo/issue/branch/base/goal/scope/non-goals/title/body; wait GO.
+- vtddExecute handoff: actionType=build; requiresHandoff=true; issueTraceability Intent/SC/Non-goal refs.
+- Before Codex handoff, show payload: repo/issue/branch/base/goal/scope/non-goals/title/body; wait GO.
 - If user says handoff/実行/GO, set consent=["propose","execute"].
+- Executor transport is pluggable and user-owned; vtdd-v2-p is public core, not a shared runner.
 - Default transport is codex_cloud_github_comment; queued comment is delegation, not execution evidence.
-- API runner: set executorTransport=api_key_runner + apiKeyRunnerAcknowledged=true; uses OPENAI_API_KEY.
-- api_key_runner: report workflowRunId/workflowUrl/workflowConclusion; surface missing OPENAI_API_KEY.
+- codex_cloud_cli_control_runner: user-owned private control repo/trusted runner; ChatGPT-managed Codex auth via codex cloud exec, not OPENAI_API_KEY; report workflowRunId/workflowUrl, branch/PR evidence, private Actions minutes/cost.
+- vps_runner: user-owned VPS migration option when private Actions minutes/queueing/constraints are poor; VTDD core does not host it.
+- API runner: set executorTransport=api_key_runner + apiKeyRunnerAcknowledged=true; uses OPENAI_API_KEY; report workflowRunId/workflowUrl/workflowConclusion; surface missing OPENAI_API_KEY.
 
 GitHub write:
 - vtddWriteGitHub only for scoped GO-tier writes:
@@ -63,46 +58,41 @@ GitHub write:
   - pull create/update
   - pull comment create
 - Before vtddWriteGitHub, show exact title/body or comment/update payload; wait GO.
-- For normal GO writes (`issue_create`, `issue_comment_create`, `pull_comment_create`), show exact payload, ask only `GO`, then call vtddWriteGitHub with naturalApproval and responseMode=action_visible. Never ask targetConfirmed/approvalScopeMatched/approvalPhrase/raw JSON.
-- Only when repo resolved, scope traceable, and GO exists.
-- Do not use vtddWriteGitHub for merge, issue close, deploy, secret/settings/permission mutation, destructive cleanup.
+- For normal GO writes (`issue_create`, `issue_comment_create`, `pull_comment_create`), show exact payload, ask only `GO`, call vtddWriteGitHub. Never ask targetConfirmed/approvalScopeMatched/approvalPhrase/raw JSON.
+- Only when repo resolved, scope traceable, and GO exists. Do not use vtddWriteGitHub for merge, issue close, deploy, secret/settings/permission mutation, destructive cleanup.
 
 GitHub high-risk authority plane:
 - Use vtddGitHubAuthority for actions requiring GO + real passkey:
   - pull_merge
   - issue_close
-- Confirm approval grant, repository scope, and explicit human request before using it.
-- For pull_merge no grant, show short `[Open merge operator](<full absolute operator URL>)` with repo, phase=execution, issueNumber, pullNumber, actionType=merge, highRiskKind=pull_merge; no bare URL.
+- Confirm approval grant, repo scope, and explicit request.
+- For pull_merge no grant, show `[Open merge operator](<full absolute operator URL>)` with repo, phase=execution, issueNumber, pullNumber, actionType=merge, highRiskKind=pull_merge; no bare URL.
 - Operator may approve+dispatch PR merge; re-read runtime truth before saying merged.
 - For issue_close, include the merged PR number used to prove bounded scope.
 - Do not route deploy or other destructive provider actions through vtddGitHubAuthority.
 
 Deploy plane:
 - Use vtddDeployProduction after deploy ask.
-- vtddDeployProduction requires:
-  - resolved repository
-  - explicit GO
-  - real passkey approval grant scoped to deploy_production
+- vtddDeployProduction requires resolved repo, explicit GO, real passkey approval grant scoped to deploy_production.
 - Pasted approvalGrant.scope.repositoryInput can identify deploy target.
 - If no deploy grant, show selfParity.deployOperatorMarkdownLink or `[Open deploy operator](<actual selfParity.deployOperatorUrl>)`; never raw `/v2/approval/passkey/operator...` or bare URL.
-- Stale fallback: selfParity.deployRecovery.operatorMarkdownLink or operatorUrl. Href needs phase=execution + deploy_production action/kind.
+- Stale fallback: selfParity.deployRecovery.operatorMarkdownLink or operatorUrl. Href needs phase=execution.
 - If deploy URL requested while in_sync, show deployOperatorMarkdownLink or deployOperatorUrl.
-- After vtddDeployProduction, say dispatched, then re-check self-parity before claiming update.
+- After deploy, say dispatched, then re-check self-parity before update claim.
 - If vtddDeployProduction fails, say the exact deploy error/reason/issues and blocker.
 - Default reviewer fallback: Codex Cloud comment, not OPENAI_API_KEY.
 - If api_key_runner hits openai_api_key_not_configured, never ask for OPENAI_API_KEY in chat; use vtddSyncGitHubActionsSecret operator.
 
 Progress tracking:
 - After vtddExecute, always call vtddExecutionProgress.
-- For api_key_runner, include executorTransport=api_key_runner in progress.
+- For codex_cloud_cli_control_runner/vps_runner/api_key_runner, include selected executorTransport in progress.
 - Use executionId, repository, issueNumber, branch.
 - Do not claim PR creation is complete unless GitHub runtime truth actually shows the PR.
 
 Review loop:
-- Canonical loop:
-  Butler -> Codex -> PR -> Reviewer -> Butler summary -> human
-- For a PR, summarize state, CI, reviewers, objections, post-review changes.
-- If reviewer objections remain unresolved, do not recommend merge GO + real passkey.
+- Canonical loop: Butler -> Codex -> PR -> Reviewer -> Butler summary -> human.
+- For a PR, summarize state, CI, reviewers, objections, changes.
+- If reviewer objections remain, do not recommend merge GO+passkey.
 - Requested `vtdd:reviewer=codex-fallback` with codex_cloud_github_comment/@codex review is request-only.
 - Completed `vtdd:reviewer=codex-fallback` from trusted VTDD actor/Codex Cloud result with recommendedAction is evidence; missing GitHub Review objects alone is not absence.
 - If no reviewer evidence exists, say so plainly.
@@ -121,6 +111,6 @@ Forbidden behavior:
 - Do not merge, deploy, mutate secrets, or perform destructive actions on your own.
 
 Response style:
-- Be concise, Japanese-first.
+- Japanese first.
 - Separate what is confirmed, what is missing, and the next safe action.
 - If something is unverified, say so instead of guessing.

--- a/docs/setup/custom-gpt-instructions.md
+++ b/docs/setup/custom-gpt-instructions.md
@@ -207,7 +207,10 @@ Remote Codex flow:
 - If the user has clearly chosen the repository, Issue, bounded scope, and GO but the Butler conversation did not naturally produce the internal handoff object, still call `vtddExecute` with `issueContext.issueNumber`, `policyInput.actionType=build`, repository, GO, consent, and runtime truth; the worker derives the bounded remote Codex handoff fields only on `/v2/action/execute`, not on `/v2/gateway`.
 - For bounded build/Codex handoff, use the user's visible GO phrase as `policyInput.approvalPhrase` (for example `GO`, `GO (build)`, or the exact sentence that approved execution). Do not ask for a second approval phrase when the user already gave GO for that handoff.
 - When the user says to handoff, execute, run, proceed, or gives GO for a bounded Codex handoff, treat that as execute consent for this bounded handoff and include `policyInput.consent.grantedCategories=["propose","execute"]`; do not stop to ask the user to restate execute consent.
+- Executor transport is pluggable and user-owned. `marushu/vtdd-v2-p` is public canonical core, not a shared runner. Keep target repository separate from executor backend: TOMIO / SunabaEye / another target repo can be changed by a separate private control repo, trusted VPS, or explicit API-key runner owned by the user.
 - Default transport is `codex_cloud_github_comment`. A queued comment proves delegation was posted, but it does not prove Codex execution, branch creation, or PR creation.
+- `codex_cloud_cli_control_runner` means a user-owned private control repository or trusted runner executes `codex cloud exec` with ChatGPT-managed Codex auth. It does not use `OPENAI_API_KEY`; report workflowRunId/workflowUrl plus target branch/PR evidence, and surface private GitHub Actions minutes/cost when relevant. `vtdd-v2-secret` is owner-specific example/evidence, not a shared runner.
+- `vps_runner` means a user-owned trusted VPS/persistent host. Treat it as the migration option when private GitHub Actions minutes, queueing, or repository constraints become a poor fit. Do not imply VTDD core provides or operates that VPS.
 - When the human explicitly approves the API-backed runner/cost path, set `executorTransport=api_key_runner` and `apiKeyRunnerAcknowledged=true` on `vtddExecute`. This uses `OPENAI_API_KEY` and is a no-extra-cost default deviation.
 - Do not silently fall back from `api_key_runner` to comment transport. If the workflow or `OPENAI_API_KEY` is missing, surface the workflow failure/blocker and run URL when available.
 - When handing off, preserve:
@@ -306,7 +309,7 @@ GitHub Actions secret sync:
 
 Progress tracking:
 - After vtddExecute, always call vtddExecutionProgress.
-- For `api_key_runner`, include `executorTransport=api_key_runner` in vtddExecutionProgress.
+- For `codex_cloud_cli_control_runner`, `vps_runner`, and `api_key_runner`, include the selected `executorTransport` in vtddExecutionProgress.
 - Use executionId, repository, issueNumber, and branch.
 - If progress shows no PR yet, say clearly that GitHub PR is not yet published.
 - Do not claim PR creation is complete unless GitHub runtime truth actually shows the PR.

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -156,6 +156,7 @@ export {
   RemoteCodexExecutionStatus,
   createRemoteCodexExecutionRequest,
   dispatchRemoteCodexExecution,
+  getRemoteCodexExecutorTransportRegistry,
   retrieveRemoteCodexExecutionProgress
 } from "./remote-codex-executor.js";
 export {

--- a/src/core/remote-codex-executor.js
+++ b/src/core/remote-codex-executor.js
@@ -6,7 +6,56 @@ export const REMOTE_CODEX_WORKFLOW_FILE = "remote-codex-executor.yml";
 
 export const RemoteCodexExecutorTransport = Object.freeze({
   CODEX_CLOUD_GITHUB_COMMENT: "codex_cloud_github_comment",
+  CODEX_CLOUD_CLI_CONTROL_RUNNER: "codex_cloud_cli_control_runner",
+  VPS_RUNNER: "vps_runner",
   API_KEY_RUNNER: "api_key_runner"
+});
+
+const REMOTE_CODEX_EXECUTOR_TRANSPORT_REGISTRY = Object.freeze({
+  [RemoteCodexExecutorTransport.CODEX_CLOUD_GITHUB_COMMENT]: Object.freeze({
+    id: RemoteCodexExecutorTransport.CODEX_CLOUD_GITHUB_COMMENT,
+    label: "Codex Cloud GitHub comment transport",
+    ownerBoundary: "operator_owned_chatgpt_codex_github_integration",
+    credentialModel: "chatgpt_managed_codex_github_integration",
+    billingModel: "chatgpt_codex_subscription_no_openai_api_key",
+    default: true,
+    optIn: false,
+    requestOnlyUntilRuntimeEvidence: true,
+    successEvidence: ["github_branch", "github_pull_request"]
+  }),
+  [RemoteCodexExecutorTransport.CODEX_CLOUD_CLI_CONTROL_RUNNER]: Object.freeze({
+    id: RemoteCodexExecutorTransport.CODEX_CLOUD_CLI_CONTROL_RUNNER,
+    label: "Codex Cloud CLI control runner",
+    ownerBoundary: "user_owned_private_control_repository_or_trusted_runner",
+    credentialModel: "chatgpt_managed_codex_auth_json",
+    billingModel: "chatgpt_codex_subscription_plus_user_owned_runner_cost",
+    default: false,
+    optIn: true,
+    usesOpenAiApiKey: false,
+    successEvidence: ["github_workflow_run", "github_branch", "github_pull_request"]
+  }),
+  [RemoteCodexExecutorTransport.VPS_RUNNER]: Object.freeze({
+    id: RemoteCodexExecutorTransport.VPS_RUNNER,
+    label: "User-owned VPS runner",
+    ownerBoundary: "user_owned_trusted_persistent_host",
+    credentialModel: "user_owned_runner_credentials",
+    billingModel: "user_owned_vps_cost",
+    default: false,
+    optIn: true,
+    implemented: false,
+    successEvidence: ["runner_execution_log", "github_branch", "github_pull_request"]
+  }),
+  [RemoteCodexExecutorTransport.API_KEY_RUNNER]: Object.freeze({
+    id: RemoteCodexExecutorTransport.API_KEY_RUNNER,
+    label: "OpenAI API key runner",
+    ownerBoundary: "user_owned_control_repository_or_trusted_runner",
+    credentialModel: "openai_api_key",
+    billingModel: "openai_api_billing_separate_from_chatgpt_codex_subscription",
+    default: false,
+    optIn: true,
+    usesOpenAiApiKey: true,
+    successEvidence: ["github_workflow_run", "github_branch", "github_pull_request"]
+  })
 });
 
 export const RemoteCodexExecutionStatus = Object.freeze({
@@ -16,6 +65,10 @@ export const RemoteCodexExecutionStatus = Object.freeze({
   BLOCKED: "blocked",
   UNKNOWN: "unknown"
 });
+
+export function getRemoteCodexExecutorTransportRegistry() {
+  return REMOTE_CODEX_EXECUTOR_TRANSPORT_REGISTRY;
+}
 
 export function createRemoteCodexExecutionRequest(input = {}) {
   const gatewayResult = input?.gatewayResult ?? {};
@@ -136,10 +189,25 @@ export async function dispatchRemoteCodexExecution(input = {}) {
     return dispatchCodexCloudGitHubComment({ request, token: token.value, env: input?.env });
   }
 
-  return dispatchApiBackedWorkflow({ request, token: token.value, env: input?.env });
+  if (transport.value === RemoteCodexExecutorTransport.VPS_RUNNER) {
+    return {
+      ok: false,
+      status: 501,
+      error: "vps_runner_not_implemented",
+      reason:
+        "vps_runner is registered as a user-owned backend option, but this runtime does not implement VPS dispatch yet"
+    };
+  }
+
+  return dispatchControlRepositoryWorkflow({
+    request,
+    token: token.value,
+    env: input?.env,
+    transport: transport.value
+  });
 }
 
-async function dispatchApiBackedWorkflow({ request, token, env }) {
+async function dispatchControlRepositoryWorkflow({ request, token, env, transport }) {
   const controlRepository = resolveControlRepository(env);
   if (!controlRepository) {
     return {
@@ -205,17 +273,18 @@ async function dispatchApiBackedWorkflow({ request, token, env }) {
     };
   }
 
-  const progress = await retrieveApiBackedWorkflowProgress({
+  const progress = await retrieveControlRepositoryWorkflowProgress({
     executionId: request.executionId,
     token,
-    env
+    env,
+    transport
   });
 
   return {
     ok: true,
     execution: {
       executionId: request.executionId,
-      transport: RemoteCodexExecutorTransport.API_KEY_RUNNER,
+      transport,
       controlRepository,
       workflowFile,
       workflowRef,
@@ -281,10 +350,25 @@ export async function retrieveRemoteCodexExecutionProgress(input = {}) {
     });
   }
 
-  return retrieveApiBackedWorkflowProgress({ executionId, token: token.value, env: input?.env });
+  if (transport.value === RemoteCodexExecutorTransport.VPS_RUNNER) {
+    return {
+      ok: false,
+      status: 501,
+      error: "vps_runner_not_implemented",
+      reason:
+        "vps_runner is registered as a user-owned backend option, but this runtime does not implement VPS progress lookup yet"
+    };
+  }
+
+  return retrieveControlRepositoryWorkflowProgress({
+    executionId,
+    token: token.value,
+    env: input?.env,
+    transport: transport.value
+  });
 }
 
-async function retrieveApiBackedWorkflowProgress({ executionId, token, env }) {
+async function retrieveControlRepositoryWorkflowProgress({ executionId, token, env, transport }) {
   const controlRepository = resolveControlRepository(env);
   if (!controlRepository) {
     return {
@@ -348,6 +432,7 @@ async function retrieveApiBackedWorkflowProgress({ executionId, token, env }) {
     ok: true,
     progress: {
       executionId,
+      transport,
       controlRepository,
       workflowFile,
       workflowRunId: normalizePositiveInteger(run.id),
@@ -711,6 +796,20 @@ function resolveExecutorTransport(input = {}, options = {}) {
   );
   const envValue = normalizeText(input?.env?.REMOTE_CODEX_EXECUTOR_TRANSPORT);
   const value = requestValue || envValue;
+  if (!value) {
+    return { ok: true, value: RemoteCodexExecutorTransport.CODEX_CLOUD_GITHUB_COMMENT };
+  }
+
+  const metadata = REMOTE_CODEX_EXECUTOR_TRANSPORT_REGISTRY[value];
+  if (!metadata) {
+    return {
+      ok: false,
+      error: "remote_codex_transport_unknown",
+      reason: "executorTransport is not registered",
+      issues: [`unsupported executorTransport: ${value}`]
+    };
+  }
+
   if (value === RemoteCodexExecutorTransport.API_KEY_RUNNER) {
     const requestSelected = requestValue === RemoteCodexExecutorTransport.API_KEY_RUNNER;
     const acknowledged =
@@ -725,9 +824,8 @@ function resolveExecutorTransport(input = {}, options = {}) {
         issues: ["api_key_runner_acknowledgment_required"]
       };
     }
-    return { ok: true, value: RemoteCodexExecutorTransport.API_KEY_RUNNER };
   }
-  return { ok: true, value: RemoteCodexExecutorTransport.CODEX_CLOUD_GITHUB_COMMENT };
+  return { ok: true, value };
 }
 
 function githubJsonHeaders({ token }) {

--- a/test/cost-account-boundary.test.js
+++ b/test/cost-account-boundary.test.js
@@ -10,15 +10,26 @@ test("README states API-key Codex runner is not the no-extra-cost default", () =
   assert.equal(readme.includes("Cost And Account Boundary"), true);
   assert.equal(readme.includes("OPENAI_API_KEY"), true);
   assert.equal(readme.includes("explicit opt-in API-backed executor"), true);
-  assert.equal(readme.includes("bounded `@codex` Issue/PR comment"), true);
+  assert.equal(readme.includes("Executor transport is pluggable and user-owned."), true);
+  assert.equal(readme.includes("not a shared hosted runner"), true);
+  assert.equal(readme.includes("codex_cloud_cli_control_runner"), true);
+  assert.equal(readme.includes("private GitHub Actions minutes"), true);
+  assert.equal(readme.includes("vps_runner"), true);
+  assert.equal(readme.includes("vtdd-v2-secret"), true);
 });
 
 test("remote Codex docs keep API-backed runner optional", () => {
   const doc = read("docs/butler/remote-codex-cli-executor.md");
 
   assert.equal(doc.includes("no-extra-API-cost default"), true);
+  assert.equal(doc.includes("Executor transport is a pluggable registry."), true);
+  assert.equal(doc.includes("not a shared hosted runner"), true);
   assert.equal(doc.includes("Default Codex Cloud GitHub Comment Runner"), true);
   assert.equal(doc.includes("This runner does not use `OPENAI_API_KEY`."), true);
+  assert.equal(doc.includes("Codex Cloud CLI Control Runner"), true);
+  assert.equal(doc.includes("private GitHub Actions minutes"), true);
+  assert.equal(doc.includes("User-owned VPS Runner"), true);
+  assert.equal(doc.includes("Queued/requested/comment-only evidence is not\nimplementation success."), true);
   assert.equal(doc.includes("optional `api_key_runner`"), true);
   assert.equal(doc.includes("Do not present it as the only VTDD remote executor path."), true);
 });

--- a/test/custom-gpt-setup-docs.test.js
+++ b/test/custom-gpt-setup-docs.test.js
@@ -105,6 +105,10 @@ test("custom gpt instructions preserve current butler and approval boundaries", 
   assert.equal(doc.includes("If the Action surface reports `ClientResponseError`"), true);
   assert.equal(doc.includes("report it as an unverified Action transport failure"), true);
   assert.equal(doc.includes("If vtddDeployProduction fails, tell the user the exact deploy `error`, `reason`, and `issues`"), true);
+  assert.equal(doc.includes("Executor transport is pluggable and user-owned."), true);
+  assert.equal(doc.includes("codex_cloud_cli_control_runner"), true);
+  assert.equal(doc.includes("vtdd-v2-secret` is owner-specific example/evidence"), true);
+  assert.equal(doc.includes("vps_runner"), true);
   assert.equal(doc.includes("openai_api_key_not_configured"), true);
   assert.equal(doc.includes("never echo the secret value"), true);
   assert.equal(doc.includes("A completed `vtdd:reviewer=codex-fallback` marker comment"), true);
@@ -150,6 +154,9 @@ test("short custom gpt instructions stay under editor limits while preserving cr
   assert.equal(doc.includes("If self-parity returns `ClientResponseError`, say unverified transport failure"), true);
   assert.equal(doc.includes("judgmentModelId=vtdd-butler-core-v1"), true);
   assert.equal(doc.includes("vtddExecute handoff: actionType=build"), true);
+  assert.equal(doc.includes("Executor transport is pluggable and user-owned"), true);
+  assert.equal(doc.includes("codex_cloud_cli_control_runner"), true);
+  assert.equal(doc.includes("vps_runner"), true);
   assert.equal(doc.includes("requiresHandoff=true"), true);
   assert.equal(doc.includes("issueTraceability Intent/SC/Non-goal refs"), true);
   assert.equal(
@@ -260,6 +267,36 @@ test("custom gpt openapi json parses and exposes paths as an object", () => {
   assert.equal(typeof doc.paths["/v2/action/github-actions-secret"], "object");
   assert.equal(typeof doc.paths["/v2/action/repository-nickname"], "object");
   assert.equal(typeof doc.paths["/v2/action/progress"], "object");
+  assert.deepEqual(
+    doc.components.schemas.VtddExecuteRequest.properties.executorTransport.enum,
+    [
+      "codex_cloud_github_comment",
+      "codex_cloud_cli_control_runner",
+      "vps_runner",
+      "api_key_runner"
+    ]
+  );
+  assert.deepEqual(
+    doc.components.schemas.VtddExecuteRequest.properties.continuationContext.properties
+      .executorTransport.enum,
+    [
+      "codex_cloud_github_comment",
+      "codex_cloud_cli_control_runner",
+      "vps_runner",
+      "api_key_runner"
+    ]
+  );
+  assert.deepEqual(
+    doc.paths["/v2/action/progress"].get.parameters.find(
+      (parameter) => parameter.name === "executorTransport"
+    ).schema.enum,
+    [
+      "codex_cloud_github_comment",
+      "codex_cloud_cli_control_runner",
+      "vps_runner",
+      "api_key_runner"
+    ]
+  );
   assert.equal(typeof doc.paths["/v2/retrieve/github"], "object");
   assert.equal(typeof doc.paths["/v2/retrieve/repository-nicknames"], "object");
   assert.equal(typeof doc.paths["/v2/retrieve/setup-artifact"], "object");

--- a/test/remote-codex-executor.test.js
+++ b/test/remote-codex-executor.test.js
@@ -6,8 +6,31 @@ import {
   RemoteCodexExecutionStatus,
   createRemoteCodexExecutionRequest,
   dispatchRemoteCodexExecution,
+  getRemoteCodexExecutorTransportRegistry,
   retrieveRemoteCodexExecutionProgress
 } from "../src/core/index.js";
+
+test("remote Codex transport registry exposes pluggable user-owned backend choices", () => {
+  const registry = getRemoteCodexExecutorTransportRegistry();
+
+  assert.deepEqual(Object.keys(registry).sort(), [
+    RemoteCodexExecutorTransport.API_KEY_RUNNER,
+    RemoteCodexExecutorTransport.CODEX_CLOUD_CLI_CONTROL_RUNNER,
+    RemoteCodexExecutorTransport.CODEX_CLOUD_GITHUB_COMMENT,
+    RemoteCodexExecutorTransport.VPS_RUNNER
+  ].sort());
+  assert.equal(registry.codex_cloud_github_comment.default, true);
+  assert.equal(registry.codex_cloud_github_comment.requestOnlyUntilRuntimeEvidence, true);
+  assert.deepEqual(registry.codex_cloud_github_comment.successEvidence, [
+    "github_branch",
+    "github_pull_request"
+  ]);
+  assert.equal(registry.codex_cloud_cli_control_runner.ownerBoundary, "user_owned_private_control_repository_or_trusted_runner");
+  assert.equal(registry.codex_cloud_cli_control_runner.usesOpenAiApiKey, false);
+  assert.equal(registry.api_key_runner.optIn, true);
+  assert.equal(registry.api_key_runner.usesOpenAiApiKey, true);
+  assert.equal(registry.vps_runner.implemented, false);
+});
 
 test("remote Codex execution request is built from gateway result and payload", () => {
   const result = createRemoteCodexExecutionRequest({
@@ -263,6 +286,68 @@ test("remote Codex API-backed execution dispatch posts workflow_dispatch to GitH
   assert.equal(calls[1].url.includes("/actions/workflows/remote-codex-executor.yml/runs"), true);
 });
 
+test("remote Codex control-runner dispatch uses workflow evidence without OPENAI_API_KEY approval", async () => {
+  const calls = [];
+  let executionId = "";
+  const dispatched = await dispatchRemoteCodexExecution({
+    payload: {
+      actorRole: ActorRole.BUTLER,
+      issueContext: { issueNumber: 173 },
+      policyInput: {
+        approvalPhrase: "GO",
+        targetConfirmed: true,
+        approvalScopeMatched: true,
+        runtimeTruth: {
+          runtimeState: {
+            activeBranch: "codex/issue-173"
+          }
+        }
+      }
+    },
+    gatewayResult: {
+      repository: "sample-org/tomio",
+      executionContinuity: {
+        codexGoal: "open_pr"
+      }
+    },
+    env: {
+      REMOTE_CODEX_EXECUTOR_TRANSPORT: RemoteCodexExecutorTransport.CODEX_CLOUD_CLI_CONTROL_RUNNER,
+      VTDD_GITHUB_ACTIONS_REPOSITORY: "sample-org/private-control-runner",
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_dispatch_token",
+      GITHUB_API_FETCH: async (url, init) => {
+        calls.push({ url, init });
+        if (String(url).includes("/dispatches")) {
+          executionId = JSON.parse(init.body).inputs.execution_id;
+          return new Response(null, { status: 204 });
+        }
+        return new Response(
+          JSON.stringify({
+            workflow_runs: [
+              {
+                id: 1731,
+                name: "codex-cloud-cli-control-runner",
+                display_title: executionId,
+                html_url: "https://github.com/sample-org/private-control-runner/actions/runs/1731",
+                status: "queued",
+                conclusion: null,
+                head_branch: "main"
+              }
+            ]
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        );
+      }
+    }
+  });
+
+  assert.equal(dispatched.ok, true);
+  assert.equal(dispatched.execution.transport, RemoteCodexExecutorTransport.CODEX_CLOUD_CLI_CONTROL_RUNNER);
+  assert.equal(dispatched.execution.controlRepository, "sample-org/private-control-runner");
+  assert.equal(dispatched.execution.targetRepository, "sample-org/tomio");
+  assert.equal(dispatched.execution.workflowRunId, 1731);
+  assert.equal(JSON.stringify(calls.map((call) => call.init)).includes("OPENAI_API_KEY"), false);
+});
+
 test("remote Codex API-backed execution requires explicit request acknowledgment", async () => {
   const dispatched = await dispatchRemoteCodexExecution({
     payload: {
@@ -295,6 +380,39 @@ test("remote Codex API-backed execution requires explicit request acknowledgment
   assert.equal(dispatched.ok, false);
   assert.equal(dispatched.status, 422);
   assert.equal(dispatched.error, "api_key_runner_approval_required");
+});
+
+test("remote Codex vps_runner is registered but blocked until a user-owned VPS adapter exists", async () => {
+  const dispatched = await dispatchRemoteCodexExecution({
+    payload: {
+      actorRole: ActorRole.BUTLER,
+      executorTransport: RemoteCodexExecutorTransport.VPS_RUNNER,
+      issueContext: { issueNumber: 173 },
+      policyInput: {
+        approvalPhrase: "GO",
+        targetConfirmed: true,
+        approvalScopeMatched: true,
+        runtimeTruth: {
+          runtimeState: {
+            activeBranch: "codex/issue-173"
+          }
+        }
+      }
+    },
+    gatewayResult: {
+      repository: "sample-org/sunaba-eye",
+      executionContinuity: {
+        codexGoal: "open_pr"
+      }
+    },
+    env: {
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_dispatch_token"
+    }
+  });
+
+  assert.equal(dispatched.ok, false);
+  assert.equal(dispatched.status, 501);
+  assert.equal(dispatched.error, "vps_runner_not_implemented");
 });
 
 test("remote Codex API-backed execution progress reads matching workflow run", async () => {


### PR DESCRIPTION
Refs #173

## This PR satisfies Intent
Issue #173 の Intent に沿って、executor transport を public core に固定された単一路線ではなく user-owned backend の pluggable registry として扱えるようにします。`marushu/vtdd-v2-p` は public canonical core であり共有 hosted runner ではない、という境界を docs / runtime metadata / Butler-facing schema に反映します。

## Satisfied Success Criteria
- docs/runtime schema が executor transport を pluggable として扱います。
- `marushu/vtdd-v2-p` は共有 runner ではなく public canonical core であることを README と remote executor doc に明記しました。
- 各ユーザーが private control repository / VPS / executor backend を用意する必要があることを明記しました。
- `vtdd-v2-secret` は owner-specific example/evidence で、他ユーザー向け共有 runner ではないことを明記しました。
- GitHub Actions private minutes cost と VPS 移行判断を docs / Butler instructions に追加しました。
- `codex_cloud_github_comment` は branch/PR なしで成功扱いしない metadata と既存 progress behavior をテストで固定しました。
- `codex_cloud_cli_control_runner` を no-`OPENAI_API_KEY` の control-runner path として registry / docs / tests に追加しました。
- TOMIO / SunabaEye など任意 target repo と executor backend を分離する説明を追加しました。

## Unsatisfied Success Criteria
None for this bounded #173 implementation slice.

## Non-goals
- VPS runner の完全実装はしていません。現 runtime では `vps_runner_not_implemented` として明示 blocker を返します。
- deploy automation / merge automation / reviewer backend redesign はしていません。
- secret 値や ChatGPT auth blob は追加していません。
- `api_key_runner` を default にはしていません。

## Verification Evidence
- `node --test test/remote-codex-executor.test.js` -> 14 passed
- `node --test test/cost-account-boundary.test.js test/custom-gpt-setup-docs.test.js` -> 11 passed
- `npm test` -> 493 passed
- GitHub Actions initial run: test job passed, guarded-policy failed only because this PR body lacked required markers before body correction.

## Surface Update Checklist
- [x] Runtime code updated: `src/core/remote-codex-executor.js`, `src/core/index.js`
- [x] Butler-facing docs updated: `docs/butler/remote-codex-cli-executor.md`, README, Custom GPT instructions
- [x] Action schema updated: `docs/setup/custom-gpt-actions-openapi.yaml` and `.json` executorTransport enum
- [x] Tests updated for registry, docs, and OpenAPI surface
- [ ] Merge / Issue close not performed; requires CI/reviewer evidence and human approval after merge criteria are satisfied

## Completion note
This PR intentionally uses only `Refs #173`. Issue closure should happen only after merge, required checks, mapped evidence, and human approval are all present.