### PR TITLE
Preserve remote Codex target branch evidence

### DIFF
--- a/src/core/remote-codex-executor.js
+++ b/src/core/remote-codex-executor.js
@@ -591,7 +591,7 @@ async function retrieveCodexCloudGitHubCommentProgress({
       transport: RemoteCodexExecutorTransport.CODEX_CLOUD_GITHUB_COMMENT,
       targetRepository: repository,
       issueNumber,
-      branch: branch || null,
+      branch: branchState.branch,
       delegationCommentId: normalizePositiveInteger(delegationComment.id),
       delegationCommentUrl: normalizeText(delegationComment.html_url) || null,
       status: pullRequest.pullRequest
@@ -604,7 +604,6 @@ async function retrieveCodexCloudGitHubCommentProgress({
               ? RemoteCodexExecutionStatus.BLOCKED
               : RemoteCodexExecutionStatus.QUEUED,
       pullRequest: pullRequest.pullRequest,
-      branch: branchState.branch,
       blocker: connectorBlocker ?? pickupBlocker
     }
   };


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #157 の Butler-to-Codex handoff 進捗で、GitHub-visible branch evidence を返す `branch` field が duplicate key で上書き定義されていた問題を取り除きます。
- これは #157 の live E2E completion claim ではありません。Butler 経由で branch/PR が観測される実証は、この PR の merge/deploy 後に別途必要です。

## Satisfied Success Criteria

- [x] comment transport の progress schema を変えず、`branch` を observed branch evidence object/null として維持する。
- [x] deploy log に出た duplicate `branch` key warning の原因を除去する。

## Unsatisfied Success Criteria

- #157 の Butler-originated live handoff が observable branch/PR を作ることは、この PR だけでは未実証。

## Non-goal violations

None.

## Verification Evidence

- Unit: `node --test test/remote-codex-executor.test.js` -> 14 passed.
- Integration: `npm test` -> 493 passed.
- E2E: Not run in this PR; #157 live Butler E2E remains pending after merge/deploy.
- Manual: deploy run 25356934851 exposed the duplicate `branch` key warning that this PR addresses.
- Evidence path/link: `src/core/remote-codex-executor.js`, https://github.com/marushu/vtdd-v2-p/actions/runs/25356934851

## Surface Update Checklist

- Cloudflare deploy: Required after merge before relying on production warning cleanup.
- Custom GPT Action Schema update: Not required.
- Custom GPT Instructions update: Not required.
- iPhone Butler live E2E: Still required for #157 completion.

## Related Constitution Rules

- Issue traceability / runtime truth / no overclaiming.
- queued/requested/comment-only is not implementation success.

## Out-of-scope but NOT implemented

- No progress schema expansion.
- No new executor transport.
- No deploy/credential/secret mutation.
- No Issue close.

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: #157
- Execution ID: local-codex-issue157-progress-branch-evidence
- Goal: Remove duplicate branch key from remote Codex progress while preserving existing branch evidence shape.