### PR TITLE
Issue close authority scope を merged PR proof に紐づける

### DIFF
--- a/docs/setup/custom-gpt-instructions-short.md
+++ b/docs/setup/custom-gpt-instructions-short.md
@@ -10,10 +10,10 @@ Core:
 - vtddGateway/vtddExecute: surface=custom_gpt, judgmentModelId=vtdd-butler-core-v1.
 
 Repo/nickname:
-- Repo list: vtddGateway exploration/read_only, repositoryInput=unknown, targetConfirmed=false, consent=["read"].
+- Repo list: vtddGateway exploration/read_only, repositoryInput=unknown, targetConfirmed=false.
 - Remember/list repo nicknames: vtddUpsertRepositoryNickname / vtddRetrieveRepositoryNicknames.
 - If request starts with non-owner/repo token like `ぶい の...`, call nickname read/gateway first.
-- Nickname memory is user-owned alias data, not default repo; if ambiguous, ask.
+- Nickname memory is user-owned alias data, not default repo; ask if ambiguous.
 - Nickname read failure is not proof of unknown repo. If conversation/approvalGrant has owner/repo, use unverified fallback; verify next.
 - If nickname save/read fails, surface error/reason/issues. If Action returns `ClientResponseError`, state action and visible HTTP/body.
 
@@ -26,14 +26,14 @@ Self-parity:
 - For stale/outdated/reflected/aligned, use vtddRetrieveSelfParity, repo=<resolved>, ref=main.
 - If runtimeParity=`cloudflare_deploy_update_required`, say `Cloudflare deploy update required`.
 - If in_sync but Butler lacks features, say `Action Schema update required` and/or `Instructions update required`.
-- If parity cannot be checked, say `未検証` or `認証失敗`.
+- If parity cannot be checked, say `未検証`.
 - If action returns error/reason/issues, summarize exact fields.
 - If self-parity returns `ClientResponseError`, say unverified transport failure.
 - Use vtddRetrieveSetupArtifact for setup artifacts.
 - If runtime in sync, don't overclaim editor sync.
 
 Execution:
-- Before execution, read runtime truth. If runtime_truth_required_or_safe_fallback, vtddRetrieveGitHub PR/branch/checks/runs, runtimeAvailable=true.
+- Before execution, read runtime truth. If runtime_truth_required_or_safe_fallback, vtddRetrieveGitHub PR/branch/checks/runs.
 - No open PR: read parent Issue, propose next live E2E slice.
 - Schema: build only under vtddExecute, not vtddGateway.
 - judgmentTrace first four steps exactly: constitution, runtime_truth, issue_context, current_query.
@@ -43,13 +43,13 @@ Execution:
 Remote Codex flow:
 - Use vtddExecute only for bounded Butler -> Codex handoff.
 - vtddExecute handoff: actionType=build; requiresHandoff=true; issueTraceability Intent/SC/Non-goal refs.
-- Before Codex handoff, show payload: repo/issue/branch/base/goal/scope/non-goals/title/body; wait GO.
+- Before Codex handoff, show repo/issue/branch/base/goal/scope/non-goals/title/body; wait GO.
 - If user says handoff/実行/GO, set consent=["propose","execute"].
 - Executor transport is pluggable and user-owned; vtdd-v2-p is public core, not a shared runner.
 - Default transport is codex_cloud_github_comment; queued comment is delegation, not execution evidence.
-- codex_cloud_cli_control_runner: user-owned private control repo/trusted runner; ChatGPT-managed Codex auth via codex cloud exec, not OPENAI_API_KEY; report workflowRunId/workflowUrl, branch/PR evidence, private Actions minutes/cost.
+- codex_cloud_cli_control_runner: user-owned private control repo/trusted runner; ChatGPT-managed Codex auth via codex cloud exec, not OPENAI_API_KEY; report run URL, branch/PR evidence, private Actions minutes/cost.
 - vps_runner: user-owned VPS migration option when private Actions minutes/queueing/constraints are poor; VTDD core does not host it.
-- API runner: set executorTransport=api_key_runner + apiKeyRunnerAcknowledged=true; uses OPENAI_API_KEY; report workflowRunId/workflowUrl/workflowConclusion; surface missing OPENAI_API_KEY.
+- API runner: set executorTransport=api_key_runner + apiKeyRunnerAcknowledged=true; uses OPENAI_API_KEY; report run result; surface missing OPENAI_API_KEY.
 
 GitHub write:
 - vtddWriteGitHub only for scoped GO-tier writes:
@@ -68,7 +68,7 @@ GitHub high-risk authority plane:
 - Confirm approval grant, repo scope, and explicit request.
 - For pull_merge no grant, show `[Open merge operator](<full absolute operator URL>)` with repo, phase=execution, issueNumber, pullNumber, actionType=merge, highRiskKind=pull_merge; no bare URL.
 - Operator may approve+dispatch PR merge; re-read runtime truth before saying merged.
-- For issue_close, include the merged PR number used to prove bounded scope.
+- For issue_close, include issueNumber + merged PR pullNumber; no grant: show same-origin operator link with actionType=issue_close, highRiskKind=issue_close, issueNumber, pullNumber.
 - Do not route deploy or other destructive provider actions through vtddGitHubAuthority.
 
 Deploy plane:
@@ -77,11 +77,11 @@ Deploy plane:
 - Pasted approvalGrant.scope.repositoryInput can identify deploy target.
 - If no deploy grant, show selfParity.deployOperatorMarkdownLink or `[Open deploy operator](<actual selfParity.deployOperatorUrl>)`; never raw `/v2/approval/passkey/operator...` or bare URL.
 - Stale fallback: selfParity.deployRecovery.operatorMarkdownLink or operatorUrl. Href needs phase=execution.
-- If deploy URL requested while in_sync, show deployOperatorMarkdownLink or deployOperatorUrl.
-- After deploy, say dispatched, then re-check self-parity before update claim.
+- If deploy URL requested while in_sync, show deployOperatorUrl/link.
+- After deploy, say dispatched, then re-check self-parity.
 - If vtddDeployProduction fails, say the exact deploy error/reason/issues and blocker.
 - Default reviewer fallback: Codex Cloud comment, not OPENAI_API_KEY.
-- If api_key_runner hits openai_api_key_not_configured, never ask for OPENAI_API_KEY in chat; use vtddSyncGitHubActionsSecret operator.
+- If api_key_runner hits openai_api_key_not_configured, never ask in chat; use vtddSyncGitHubActionsSecret secret-sync operator.
 
 Progress tracking:
 - After vtddExecute, always call vtddExecutionProgress.
@@ -95,7 +95,7 @@ Review loop:
 - If reviewer objections remain, do not recommend merge GO+passkey.
 - Requested `vtdd:reviewer=codex-fallback` with codex_cloud_github_comment/@codex review is request-only.
 - Completed `vtdd:reviewer=codex-fallback` from trusted VTDD actor/Codex Cloud result with recommendedAction is evidence; missing GitHub Review objects alone is not absence.
-- If no reviewer evidence exists, say so plainly.
+- If no reviewer evidence exists, say so.
 
 Approval boundaries:
 - High-risk actions require GO + passkey.

--- a/docs/setup/custom-gpt-instructions.md
+++ b/docs/setup/custom-gpt-instructions.md
@@ -280,7 +280,8 @@ GitHub high-risk authority plane:
   - after the passkey approval, the operator page may dispatch `vtddGitHubAuthority` for the PR merge; then re-read GitHub runtime truth before saying the PR is merged
 - For bounded issue close:
   - operation=`issue_close`
-  - include the merged PR number used to prove bounded post-merge scope
+  - include `issueNumber` for the Issue being closed and `pullNumber` for the merged PR used to prove bounded post-merge scope
+  - if no issue-close-scoped approval grant is available yet, present a short clickable Markdown link to the same-origin passkey operator helper; the href must include `repositoryInput=<resolved repo>`, `phase=execution`, `issueNumber=<issue to close>`, `pullNumber=<merged PR number>`, `actionType=issue_close`, and `highRiskKind=issue_close`
 - Do not route deploy, secret mutation, permission mutation, or other destructive provider actions through vtddGitHubAuthority.
 
 Deploy plane:

--- a/src/core/github-app-operation-registry.js
+++ b/src/core/github-app-operation-registry.js
@@ -65,9 +65,9 @@ export const GitHubAppOperationRegistry = Object.freeze({
   issue_close: {
     operation: "issue_close",
     tier: GitHubAppOperationTier.PASSKEY_AUTHORITY,
-    requiredPayloadFields: ["repository", "issueNumber", "mergedPullNumber"],
+    requiredPayloadFields: ["repository", "issueNumber", "pullNumber"],
     passkey: {
-      actionType: "merge",
+      actionType: "issue_close",
       highRiskKind: "issue_close"
     }
   },

--- a/src/core/passkey-approval.js
+++ b/src/core/passkey-approval.js
@@ -419,6 +419,7 @@ export function normalizeScopeSnapshot(scope = {}) {
     highRiskKind: normalizeText(scope.highRiskKind),
     repositoryInput: normalizeText(scope.repositoryInput),
     issueNumber: normalizeText(scope.issueNumber),
+    pullNumber: normalizeText(scope.pullNumber),
     relatedIssue: normalizeText(scope.relatedIssue),
     phase: normalizeText(scope.phase)
   };

--- a/src/core/passkey-operator-page.js
+++ b/src/core/passkey-operator-page.js
@@ -474,6 +474,7 @@ export function renderPasskeyOperatorPage(input = {}) {
               highRiskKind: document.getElementById("risk-kind-input").value,
               repositoryInput: document.getElementById("repo-input").value,
               issueNumber: Number(document.getElementById("issue-input").value || 0) || null,
+              pullNumber: Number(document.getElementById("pull-number-input").value || 0) || null,
               issueContext: {
                 issueNumber: Number(document.getElementById("issue-input").value || 0) || null
               },
@@ -747,6 +748,9 @@ export function resolvePasskeyOperatorMode(input = {}) {
     return "deploy";
   }
   if (actionType === "merge" || highRiskKind === "pull_merge") {
+    return "merge";
+  }
+  if (actionType === "issue_close" || highRiskKind === "issue_close") {
     return "merge";
   }
   if (highRiskKind === "github_actions_secret_sync") {

--- a/src/worker.js
+++ b/src/worker.js
@@ -844,6 +844,7 @@ async function handleGitHubHighRiskPlaneRequest(request, env) {
       highRiskKind,
       repositoryInput: repository,
       issueNumber: scopedIssueNumber,
+      pullNumber: payload.pullNumber,
       issueContext
     },
     policyInput: {
@@ -862,6 +863,7 @@ async function handleGitHubHighRiskPlaneRequest(request, env) {
       highRiskKind,
       repositoryInput: repository,
       issueNumber: scopedIssueNumber,
+      pullNumber: payload.pullNumber,
       issueContext
     },
     policyInput: {
@@ -1735,6 +1737,7 @@ function buildApprovalScopeSnapshot({ payload, policyInput }) {
     highRiskKind: payload?.highRiskKind ?? policyInput?.highRiskKind,
     repositoryInput: policyInput?.repositoryInput ?? payload?.repositoryInput,
     issueNumber: issueContext.issueNumber ?? payload?.issueNumber,
+    pullNumber: payload?.pullNumber,
     relatedIssue: traceability.relatedIssue ?? issueContext.issueNumber ?? payload?.relatedIssue,
     phase: payload?.phase
   });
@@ -1745,7 +1748,7 @@ function mapGitHubHighRiskOperationToActionType(operation) {
     return "merge";
   }
   if (operation === GitHubHighRiskOperation.ISSUE_CLOSE) {
-    return "destructive";
+    return "issue_close";
   }
   return normalizeText(operation);
 }

--- a/test/github-high-risk-plane.test.js
+++ b/test/github-high-risk-plane.test.js
@@ -136,19 +136,21 @@ test("github high-risk plane closes bounded issue only after merged pull verific
       verified: true,
       expiresAt: "2099-01-01T00:00:00.000Z",
       scope: {
-        actionType: "destructive",
+        actionType: "issue_close",
         highRiskKind: "issue_close",
         repositoryInput: "sample-org/vtdd-v2-p",
         issueNumber: "55",
+        pullNumber: "21",
         relatedIssue: "55",
         phase: "execution"
       }
     },
     approvalScope: {
-      actionType: "destructive",
+      actionType: "issue_close",
       highRiskKind: "issue_close",
       repositoryInput: "sample-org/vtdd-v2-p",
       issueNumber: "55",
+      pullNumber: "21",
       relatedIssue: "55",
       phase: "execution"
     },
@@ -211,19 +213,21 @@ test("github high-risk plane rejects missing approval grant or unmerged bounded 
       verified: true,
       expiresAt: "2099-01-01T00:00:00.000Z",
       scope: {
-        actionType: "destructive",
+        actionType: "issue_close",
         highRiskKind: "issue_close",
         repositoryInput: "sample-org/vtdd-v2-p",
         issueNumber: "55",
+        pullNumber: "21",
         relatedIssue: "55",
         phase: "execution"
       }
     },
     approvalScope: {
-      actionType: "destructive",
+      actionType: "issue_close",
       highRiskKind: "issue_close",
       repositoryInput: "sample-org/vtdd-v2-p",
       issueNumber: "55",
+      pullNumber: "21",
       relatedIssue: "55",
       phase: "execution"
     },

--- a/test/passkey-operator-page.test.js
+++ b/test/passkey-operator-page.test.js
@@ -56,6 +56,26 @@ test("passkey operator page pre-fills PR merge fields from URL input", () => {
   assert.equal(html.includes('id="risk-kind-input" value="pull_merge"'), true);
   assert.equal(html.includes('id="merge-method-input" value="squash"'), true);
   assert.equal(html.includes('operation: "pull_merge"'), true);
+  assert.equal(html.includes('pullNumber: Number(document.getElementById("pull-number-input").value || 0) || null'), true);
+});
+
+test("passkey operator page can scope issue close approval to merged pull proof", () => {
+  const html = renderPasskeyOperatorPage({
+    repositoryInput: "marushu/vtdd-v2-p",
+    issueNumber: 157,
+    pullNumber: 176,
+    phase: "execution",
+    actionType: "issue_close",
+    highRiskKind: "issue_close"
+  });
+
+  assert.equal(html.includes('<section data-operator-section="approval">'), true);
+  assert.equal(html.includes('<section data-operator-section="pr-merge">'), true);
+  assert.equal(html.includes('id="issue-input" value="157"'), true);
+  assert.equal(html.includes('id="pull-number-input" value="176"'), true);
+  assert.equal(html.includes('id="action-type-input" value="issue_close"'), true);
+  assert.equal(html.includes('id="risk-kind-input" value="issue_close"'), true);
+  assert.equal(html.includes('pullNumber: Number(document.getElementById("pull-number-input").value || 0) || null'), true);
 });
 
 test("passkey operator page focuses deploy mode on deploy approval and dispatch sections", () => {

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -2735,6 +2735,7 @@ test("worker executes GitHub merge on the high-risk authority plane with approva
         highRiskKind: "pull_merge",
         repositoryInput: "sample-org/vtdd-v2-p",
         issueNumber: "55",
+        pullNumber: "21",
         relatedIssue: "55",
         phase: "execution"
       }
@@ -2804,6 +2805,7 @@ test("worker allows same-origin passkey operator to dispatch GitHub merge author
         highRiskKind: "pull_merge",
         repositoryInput: "sample-org/vtdd-v2-p",
         issueNumber: "55",
+        pullNumber: "21",
         relatedIssue: "55",
         phase: "execution"
       }
@@ -2924,10 +2926,11 @@ test("worker blocks bounded issue close on the high-risk authority plane when me
       approvalId: "approval-close-123",
       expiresAt: "2099-01-01T00:00:00.000Z",
       scope: {
-        actionType: "destructive",
+        actionType: "issue_close",
         highRiskKind: "issue_close",
         repositoryInput: "sample-org/vtdd-v2-p",
         issueNumber: "55",
+        pullNumber: "21",
         relatedIssue: "55",
         phase: "execution"
       }


### PR DESCRIPTION
Refs #157

## This PR satisfies Intent

Butler から `issue_close` を実行したときに `pullNumber is required` / `approval grant scope does not match current target` で止まる不整合を修正します。Issue close を Issue 番号だけで閉じるのではなく、bounded post-merge proof として merged PR の `pullNumber` を approval scope に含めます。

## Satisfied Success Criteria

- Butler が high-risk `issue_close` を `actionType=issue_close` / `highRiskKind=issue_close` として扱える
- approval grant scope に `issueNumber` と merged PR `pullNumber` が含まれ、worker 側の照合にも使われる
- passkey operator link が `issue_close` 用の `issueNumber` / `pullNumber` を保持できる
- Instructions が、ユーザーに raw JSON を書かせず operator link を出す方針を明記している
- regression tests が missing merged PR proof と scope mismatch の再発を防ぐ

## Unsatisfied Success Criteria

- #157 の Issue close 実行そのものは、この PR の merge + deploy 後に Butler から再試行して確認する必要があります
- この PR 単体では #157 を close しません

## Verification Evidence

- `node --test test/custom-gpt-setup-docs.test.js test/github-high-risk-plane.test.js test/worker.test.js test/passkey-operator-page.test.js test/passkey-approval.test.js`
  - 105 passed
- `npm test`
  - 497 passed

## Surface Update Checklist

- Runtime code: updated `src/worker.js`, `src/core/passkey-approval.js`, `src/core/github-app-operation-registry.js`, `src/core/passkey-operator-page.js`
- Custom GPT Instructions: updated issue_close guidance in `docs/setup/custom-gpt-instructions.md` and short instructions
- Action Schema: no schema enum/path change in this PR
- Deploy: not performed in this PR

## Notes

この PR は `issue_close` 失敗経路の修正です。#157 のクローズ自体は、merge + deploy 後に Butler から同じ経路を再試行して runtime truth を確認してから判断します。