### PR TITLE
Remote Codex dispatch goal を実行可能値に制限する

### DIFF
--- a/docs/setup/custom-gpt-actions-openapi.json
+++ b/docs/setup/custom-gpt-actions-openapi.json
@@ -219,6 +219,14 @@
               "requiresHandoff": {
                 "type": "boolean"
               },
+              "codexGoal": {
+                "type": "string",
+                "enum": [
+                  "open_pr",
+                  "revise_pr",
+                  "respond_to_review"
+                ]
+              },
               "executorTransport": {
                 "type": "string",
                 "enum": [
@@ -421,6 +429,14 @@
               },
               "requiresHandoff": {
                 "type": "boolean"
+              },
+              "codexGoal": {
+                "type": "string",
+                "enum": [
+                  "open_pr",
+                  "revise_pr",
+                  "respond_to_review"
+                ]
               },
               "executorTransport": {
                 "type": "string",

--- a/docs/setup/custom-gpt-actions-openapi.yaml
+++ b/docs/setup/custom-gpt-actions-openapi.yaml
@@ -149,6 +149,12 @@ components:
               type: string
             requiresHandoff:
               type: boolean
+            codexGoal:
+              type: string
+              enum:
+                - open_pr
+                - revise_pr
+                - respond_to_review
             executorTransport:
               type: string
               enum:
@@ -290,6 +296,12 @@ components:
               type: string
             requiresHandoff:
               type: boolean
+            codexGoal:
+              type: string
+              enum:
+                - open_pr
+                - revise_pr
+                - respond_to_review
             executorTransport:
               type: string
               enum:

--- a/docs/setup/custom-gpt-instructions-short.md
+++ b/docs/setup/custom-gpt-instructions-short.md
@@ -2,7 +2,7 @@ VTDD Butler. Japanese unless asked otherwise.
 
 Core:
 - Issue is canonical spec; GitHub runtime state is current progress truth.
-- Before Issue proposal/write/Codex handoff/PR judgment, preflight: vtddRetrieveCrossMemory (+ vtddRetrieveDecisionLogs/vtddRetrieveProposalLogs/vtddRetrieveConstitution if useful) + runtime truth. Report found/missing; no RAG hit OK, never invent. Runtime truth > memory.
+- Before Issue proposal/write/Codex handoff/PR judgment: vtddRetrieveCrossMemory (+ vtddRetrieveDecisionLogs/vtddRetrieveProposalLogs/vtddRetrieveConstitution if useful) + runtime truth. Report found/missing; no RAG hit OK, never invent. Runtime truth > memory.
 - Do not assume a default repository. Resolve repo from alias/context; if ambiguous, ask.
 - No internal API paths/raw JSON unless debugging.
 - Convert natural language to actions.
@@ -14,7 +14,7 @@ Repo/nickname:
 - Remember/list repo nicknames: vtddUpsertRepositoryNickname / vtddRetrieveRepositoryNicknames.
 - If request starts with non-owner/repo token like `ぶい の...`, call nickname read/gateway first.
 - Nickname memory is user-owned alias data, not default repo; ask if ambiguous.
-- Nickname read failure is not proof of unknown repo. If conversation/approvalGrant has owner/repo, use unverified fallback; verify next.
+- Nickname read failure is not proof of unknown repo. If conversation/approvalGrant has owner/repo, use unverified fallback; verify.
 - If nickname save/read fails, surface error/reason/issues. If Action returns `ClientResponseError`, state action and visible HTTP/body.
 
 GitHub read plane:
@@ -27,14 +27,14 @@ Self-parity:
 - If runtimeParity=`cloudflare_deploy_update_required`, say `Cloudflare deploy update required`.
 - If in_sync but Butler lacks features, say `Action Schema update required` and/or `Instructions update required`.
 - If parity cannot be checked, say `未検証`.
-- If action returns error/reason/issues, summarize exact fields.
+- If action returns error/reason/issues, summarize them.
 - If self-parity returns `ClientResponseError`, say unverified transport failure.
-- Use vtddRetrieveSetupArtifact for setup artifacts.
-- If runtime in sync, don't overclaim editor sync.
+- Use vtddRetrieveSetupArtifact for setup.
+- If runtime in sync, don't claim editor sync.
 
 Execution:
 - Before execution, read runtime truth. If runtime_truth_required_or_safe_fallback, vtddRetrieveGitHub PR/branch/checks/runs.
-- No open PR: read parent Issue, propose next live E2E slice.
+- No open PR: read parent Issue; propose next E2E slice.
 - Schema: build only under vtddExecute, not vtddGateway.
 - judgmentTrace first four steps exactly: constitution, runtime_truth, issue_context, current_query.
 - No constitutionConsulted input; constitution-first trace satisfies policy.
@@ -43,11 +43,12 @@ Execution:
 Remote Codex flow:
 - Use vtddExecute only for bounded Butler -> Codex handoff.
 - vtddExecute handoff: actionType=build; requiresHandoff=true; issueTraceability Intent/SC/Non-goal refs.
-- Before Codex handoff, show repo/issue/branch/base/goal/scope/non-goals/title/body; wait GO.
+- Do not dispatch `wait_for_review`; PR feedback fix => revise_pr; comment-only => respond_to_review.
+- Before Codex handoff, show repo/issue/branch/base/goal/scope/non-goals; wait GO.
 - If user says handoff/実行/GO, set consent=["propose","execute"].
 - Executor transport is pluggable and user-owned; vtdd-v2-p is public core, not a shared runner.
 - Default transport is codex_cloud_github_comment; queued comment is delegation, not execution evidence.
-- codex_cloud_cli_control_runner: user-owned private control repo/trusted runner; ChatGPT-managed Codex auth via codex cloud exec, not OPENAI_API_KEY; report run URL, branch/PR evidence, private Actions minutes/cost.
+- codex_cloud_cli_control_runner: user-owned private control repo/trusted runner; ChatGPT-managed Codex auth via codex cloud exec, not OPENAI_API_KEY; report run URL, branch/PR evidence, Actions minutes/cost.
 - vps_runner: user-owned VPS migration option when private Actions minutes/queueing/constraints are poor; VTDD core does not host it.
 - API runner: set executorTransport=api_key_runner + apiKeyRunnerAcknowledged=true; uses OPENAI_API_KEY; report run result; surface missing OPENAI_API_KEY.
 

--- a/docs/setup/custom-gpt-instructions.md
+++ b/docs/setup/custom-gpt-instructions.md
@@ -224,6 +224,7 @@ Remote Codex flow:
   - open_pr
   - revise_pr
   - respond_to_review
+- `wait_for_review` is a continuity/status signal, not a remote Codex dispatch goal. Do not dispatch `wait_for_review`. If the human explicitly asks Codex to apply PR/reviewer feedback, set `continuationContext.codexGoal=revise_pr` for code changes or `respond_to_review` for comment-only response.
 - Do not treat the handoff text itself as canonical spec.
 
 GitHub normal write plane:

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -152,6 +152,7 @@ export {
 } from "./execution-continuity.js";
 export {
   REMOTE_CODEX_WORKFLOW_FILE,
+  RemoteCodexDispatchGoal,
   RemoteCodexExecutorTransport,
   RemoteCodexExecutionStatus,
   createRemoteCodexExecutionRequest,

--- a/src/core/remote-codex-executor.js
+++ b/src/core/remote-codex-executor.js
@@ -66,6 +66,14 @@ export const RemoteCodexExecutionStatus = Object.freeze({
   UNKNOWN: "unknown"
 });
 
+export const RemoteCodexDispatchGoal = Object.freeze({
+  OPEN_PR: "open_pr",
+  REVISE_PR: "revise_pr",
+  RESPOND_TO_REVIEW: "respond_to_review"
+});
+
+const REMOTE_CODEX_DISPATCH_GOALS = new Set(Object.values(RemoteCodexDispatchGoal));
+
 export function getRemoteCodexExecutorTransportRegistry() {
   return REMOTE_CODEX_EXECUTOR_TRANSPORT_REGISTRY;
 }
@@ -101,7 +109,10 @@ export function createRemoteCodexExecutionRequest(input = {}) {
       normalizeText(payload?.executionTarget?.baseRef) ||
       normalizeText(runtimeState.baseRef) ||
       "main",
-    codexGoal: normalizeText(gatewayResult?.executionContinuity?.codexGoal),
+    codexGoal:
+      normalizeText(continuationContext.codexGoal) ||
+      normalizeText(payload?.executionTarget?.codexGoal) ||
+      normalizeText(gatewayResult?.executionContinuity?.codexGoal),
     approvalPhrase: normalizeText(payload?.policyInput?.approvalPhrase),
     targetConfirmed: payload?.policyInput?.targetConfirmed === true,
     approvalScopeMatched,
@@ -132,6 +143,8 @@ export function createRemoteCodexExecutionRequest(input = {}) {
   }
   if (!request.codexGoal) {
     issues.push("codexGoal is required");
+  } else if (!REMOTE_CODEX_DISPATCH_GOALS.has(request.codexGoal)) {
+    issues.push("codexGoal must be open_pr, revise_pr, or respond_to_review");
   }
   if (!request.baseRef) {
     issues.push("baseRef is required");

--- a/test/custom-gpt-setup-docs.test.js
+++ b/test/custom-gpt-setup-docs.test.js
@@ -154,10 +154,12 @@ test("short custom gpt instructions stay under editor limits while preserving cr
   assert.equal(doc.includes("If self-parity returns `ClientResponseError`, say unverified transport failure"), true);
   assert.equal(doc.includes("judgmentModelId=vtdd-butler-core-v1"), true);
   assert.equal(doc.includes("vtddExecute handoff: actionType=build"), true);
+  assert.equal(doc.includes("PR feedback fix => revise_pr"), true);
   assert.equal(doc.includes("Executor transport is pluggable and user-owned"), true);
   assert.equal(doc.includes("codex_cloud_cli_control_runner"), true);
   assert.equal(doc.includes("vps_runner"), true);
   assert.equal(doc.includes("requiresHandoff=true"), true);
+  assert.equal(doc.includes("Do not dispatch `wait_for_review`"), true);
   assert.equal(doc.includes("issueTraceability Intent/SC/Non-goal refs"), true);
   assert.equal(
     doc.includes("judgmentTrace first four steps exactly: constitution, runtime_truth, issue_context, current_query"),
@@ -285,6 +287,11 @@ test("custom gpt openapi json parses and exposes paths as an object", () => {
       "vps_runner",
       "api_key_runner"
     ]
+  );
+  assert.deepEqual(
+    doc.components.schemas.VtddExecuteRequest.properties.continuationContext.properties
+      .codexGoal.enum,
+    ["open_pr", "revise_pr", "respond_to_review"]
   );
   assert.deepEqual(
     doc.paths["/v2/action/progress"].get.parameters.find(

--- a/test/remote-codex-executor.test.js
+++ b/test/remote-codex-executor.test.js
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import {
   ActorRole,
+  RemoteCodexDispatchGoal,
   RemoteCodexExecutorTransport,
   RemoteCodexExecutionStatus,
   createRemoteCodexExecutionRequest,
@@ -62,6 +63,65 @@ test("remote Codex execution request is built from gateway result and payload", 
   assert.equal(result.request.branch, "codex/issue-6");
   assert.equal(result.request.baseRef, "main");
   assert.equal(result.request.codexGoal, "open_pr");
+});
+
+test("remote Codex execution request accepts explicit bounded PR revision goal override", () => {
+  const result = createRemoteCodexExecutionRequest({
+    payload: {
+      actorRole: ActorRole.BUTLER,
+      issueContext: { issueNumber: 161 },
+      continuationContext: {
+        codexGoal: RemoteCodexDispatchGoal.REVISE_PR
+      },
+      policyInput: {
+        approvalPhrase: "GO",
+        targetConfirmed: true,
+        approvalScopeMatched: true,
+        runtimeTruth: {
+          runtimeState: {
+            activeBranch: "codex/issue-161"
+          }
+        }
+      }
+    },
+    gatewayResult: {
+      repository: "sample-org/vtdd-v2",
+      executionContinuity: {
+        codexGoal: "wait_for_review"
+      }
+    }
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.request.codexGoal, RemoteCodexDispatchGoal.REVISE_PR);
+});
+
+test("remote Codex execution request rejects wait-only continuity goal before workflow dispatch", () => {
+  const result = createRemoteCodexExecutionRequest({
+    payload: {
+      actorRole: ActorRole.BUTLER,
+      issueContext: { issueNumber: 161 },
+      policyInput: {
+        approvalPhrase: "GO",
+        targetConfirmed: true,
+        approvalScopeMatched: true,
+        runtimeTruth: {
+          runtimeState: {
+            activeBranch: "codex/issue-161"
+          }
+        }
+      }
+    },
+    gatewayResult: {
+      repository: "sample-org/vtdd-v2",
+      executionContinuity: {
+        codexGoal: "wait_for_review"
+      }
+    }
+  });
+
+  assert.equal(result.ok, false);
+  assert.deepEqual(result.issues, ["codexGoal must be open_pr, revise_pr, or respond_to_review"]);
 });
 
 test("remote Codex execution request rejects non-string handoff approval refs", () => {


### PR DESCRIPTION
Refs #161
Related #157

## This PR satisfies Intent

PR コメントから Codex に追加修正を依頼したとき、continuity/status signal の `wait_for_review` が remote Codex runner に dispatch され、workflow 側の input validation で失敗していた問題を修正します。Butler が明示的な PR feedback 修正依頼では `revise_pr` / `respond_to_review` を指定でき、`wait_for_review` は workflow_dispatch 前に fail-fast します。

## Satisfied Success Criteria

- `wait_for_review` を remote Codex dispatch goal として扱わない
- `continuationContext.codexGoal` / `executionTarget.codexGoal` で bounded PR revision goal を明示できる
- remote Codex dispatch goal は `open_pr` / `revise_pr` / `respond_to_review` のみに制限される
- Custom GPT Action Schema が `continuationContext.codexGoal` を expose する
- Butler Instructions が PR feedback 修正時の `revise_pr` / `respond_to_review` mapping を説明する

## Unsatisfied Success Criteria

- この PR は PR #178 の Gemini 指摘そのものを修正しません
- merge + deploy + Action Schema refresh 後に、Butler から追加修正依頼を live retry して確認する必要があります

## Verification Evidence

- `node --test test/remote-codex-executor.test.js test/custom-gpt-setup-docs.test.js`
  - 27 passed
- `npm test`
  - 499 passed

## Surface Update Checklist

- Runtime code: updated `src/core/remote-codex-executor.js`
- Custom GPT Action Schema update: required after deploy because `continuationContext.codexGoal` is newly exposed
- Custom GPT Instructions update: required after deploy because Butler goal mapping guidance changed
- Cloudflare deploy: not performed in this PR
- iPhone Butler live E2E: pending post-deploy retry

## Notes

Observed failing run: https://github.com/marushu/vtdd-v2-p/actions/runs/25361676454/job/74362483825
Root cause: `CODEX_GOAL=wait_for_review` reached the `remote-codex-executor` workflow, whose supported goals are `open_pr`, `revise_pr`, and `respond_to_review`.
