### PR TITLE
Repository nickname Action が canonical repo 保存を通すようにする

### DIFF
--- a/docs/setup/custom-gpt-instructions-short.md
+++ b/docs/setup/custom-gpt-instructions-short.md
@@ -10,11 +10,11 @@ Core:
 - vtddGateway/vtddExecute: surface=custom_gpt, judgmentModelId=vtdd-butler-core-v1.
 
 Repo/nickname:
-- Repo list: vtddGateway exploration/read_only, repositoryInput=unknown, targetConfirmed=false.
-- Remember/list repo nicknames: vtddUpsertRepositoryNickname / vtddRetrieveRepositoryNicknames.
+- Repo list: vtddGateway exploration/read_only, repositoryInput=unknown.
+- Save/list nicknames: vtddUpsertRepositoryNickname / vtddRetrieveRepositoryNicknames.
 - If request starts with non-owner/repo token like `ぶい の...`, call nickname read/gateway first.
-- Nickname memory is user-owned alias data, not default repo; ask if ambiguous.
-- Nickname read failure is not proof of unknown repo. If conversation/approvalGrant has owner/repo, use unverified fallback; verify.
+- Save with owner/repo, not alias. Nickname memory is user-owned alias data, not default repo.
+- Nickname read failure is not proof of unknown repo. If conversation/grant has owner/repo, use unverified fallback; verify.
 - If nickname save/read fails, surface error/reason/issues. If Action returns `ClientResponseError`, state action and visible HTTP/body.
 
 GitHub read plane:

--- a/docs/setup/custom-gpt-instructions.md
+++ b/docs/setup/custom-gpt-instructions.md
@@ -69,6 +69,7 @@ Repository listing and context resolution:
 - A nickname retrieval failure is not proof that the nickname is unknown. If the current conversation already contains a remembered mapping or a passkey approval JSON contains `approvalGrant.scope.repositoryInput`, use that `owner/repo` as an unverified fallback candidate, say the nickname registry read is unverified, and continue to the next validation/action that can verify the target.
 - Repository nickname writes must stay explicit:
   - resolve the target repository first
+  - when saving a nickname, pass the resolved canonical `owner/repo` as `repository`; never pass the nickname itself as `repository`
   - preserve canonical owner/repo as the execution target of record
   - do not invent a default repository from nickname memory alone
 
@@ -124,6 +125,7 @@ Repository nickname memory:
   - `覚えている repo nickname 一覧を見せて`
   - `この GPT が覚えている repo の呼び名は？`
 - Nickname memory is explicit user-owned alias registry data, not permission to assume a default repository.
+- When saving nickname memory, resolve the target first and pass canonical `owner/repo` to `vtddUpsertRepositoryNickname`; do not pass the new nickname or an unresolved alias as `repository`.
 - If nickname resolution is ambiguous, say so plainly and ask a short confirmation before execution.
 - If nickname read fails, do not downgrade an already-known conversation mapping like `ぶい = marushu/vtdd-v2-p` to unknown. Treat it as an unverified fallback candidate and seek runtime verification through the next relevant read/action.
 - If a pasted approval grant includes `approvalGrant.scope.repositoryInput`, that scope can identify the deploy target candidate; pass the canonical `owner/repo` to the deploy action and let the approval/deploy route validate scope match.

--- a/src/core/repository-nickname-registry.js
+++ b/src/core/repository-nickname-registry.js
@@ -53,14 +53,6 @@ export async function upsertRepositoryNickname(input = {}) {
   }
 
   const registryRecord = registry.find((item) => item.canonicalRepo === repositoryInput);
-  if (!registryRecord) {
-    return {
-      ok: false,
-      status: 422,
-      error: "repository_nickname_request_invalid",
-      issues: ["repository must resolve from the current alias registry before nickname write"]
-    };
-  }
 
   const mode = normalizeNicknameMode(input.mode);
   if (!mode) {
@@ -98,8 +90,8 @@ export async function upsertRepositoryNickname(input = {}) {
     type: MemoryRecordType.ALIAS_REGISTRY,
     content: {
       canonicalRepo: repositoryInput,
-      productName: existing?.productName ?? registryRecord.productName ?? null,
-      visibility: registryRecord.visibility ?? existing?.visibility ?? "unknown",
+      productName: existing?.productName ?? registryRecord?.productName ?? null,
+      visibility: registryRecord?.visibility ?? existing?.visibility ?? "unknown",
       aliases
     },
     metadata: {

--- a/src/worker.js
+++ b/src/worker.js
@@ -1455,11 +1455,19 @@ async function handleRepositoryNicknameUpsertRequest(request, env) {
     },
     env
   });
-  const resolution = resolveRepositoryTarget({
-    input: body?.repository ?? body?.repositoryInput,
-    mode: TaskMode.EXECUTION,
-    aliasRegistry: resolvedAliasRegistry.aliasRegistry
-  });
+  const repositoryInput = body?.repository ?? body?.repositoryInput;
+  const canonicalRepositoryInput = normalizeCanonicalRepositoryInput(repositoryInput);
+  const resolution = canonicalRepositoryInput
+    ? {
+        resolved: true,
+        repository: canonicalRepositoryInput,
+        via: "canonical_owner_repo"
+      }
+    : resolveRepositoryTarget({
+        input: repositoryInput,
+        mode: TaskMode.EXECUTION,
+        aliasRegistry: resolvedAliasRegistry.aliasRegistry
+      });
 
   if (!resolution.resolved) {
     return json(422, {
@@ -1495,6 +1503,14 @@ async function handleRepositoryNicknameUpsertRequest(request, env) {
     repository: resolution.repository,
     aliasEntry: result.aliasEntry
   });
+}
+
+function normalizeCanonicalRepositoryInput(value) {
+  const text = normalizeText(value).toLowerCase();
+  if (!/^[a-z0-9_.-]+\/[a-z0-9_.-]+$/.test(text)) {
+    return "";
+  }
+  return text;
 }
 
 async function handlePasskeyRegistrationOptionsRequest(request, env) {

--- a/test/repository-nickname-registry.test.js
+++ b/test/repository-nickname-registry.test.js
@@ -63,18 +63,18 @@ test("repository nickname registry can replace prior user-defined nicknames", as
   assert.deepEqual(result.aliasEntry.aliases, ["公開V2"]);
 });
 
-test("repository nickname registry rejects unknown canonical repositories", async () => {
+test("repository nickname registry accepts canonical repositories even before live alias registry has seen them", async () => {
   const provider = createInMemoryMemoryProvider();
   const result = await upsertRepositoryNickname({
     provider,
-    repository: "sample-org/unknown-repo",
+    repository: "sample-org/new-repo",
     nickname: "unknown",
     aliasRegistry: []
   });
 
-  assert.equal(result.ok, false);
-  assert.equal(result.status, 422);
-  assert.equal(result.error, "repository_nickname_request_invalid");
+  assert.equal(result.ok, true);
+  assert.equal(result.aliasEntry.canonicalRepo, "sample-org/new-repo");
+  assert.deepEqual(result.aliasEntry.aliases, ["unknown"]);
 });
 
 test("mergeAliasRegistries combines live aliases and stored nicknames", () => {

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -1995,6 +1995,36 @@ test("worker blocks repository nickname write when nickname target is ambiguous"
   assert.equal(body.reason, "target repository nickname is ambiguous");
 });
 
+test("worker stores repository nickname for canonical owner repo without prior alias registry entry", async () => {
+  const provider = createInMemoryMemoryProvider();
+
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/action/repository-nickname", {
+      method: "POST",
+      headers: gatewayAuthHeaders,
+      body: JSON.stringify({
+        repository: "sample-org/new-repo",
+        nickname: "新規Repo"
+      })
+    }),
+    {
+      ...gatewayAuthEnv,
+      MEMORY_PROVIDER: provider,
+      GITHUB_API_FETCH: async () =>
+        new Response(JSON.stringify({ total_count: 0, repositories: [] }), {
+          status: 200,
+          headers: { "content-type": "application/json" }
+        })
+    }
+  );
+
+  assert.equal(response.status, 200);
+  const body = await response.json();
+  assert.equal(body.ok, true);
+  assert.equal(body.repository, "sample-org/new-repo");
+  assert.deepEqual(body.aliasEntry.aliases, ["新規Repo"]);
+});
+
 test("worker returns GitHub issues through read plane route", async () => {
   const response = await worker.fetch(
     new Request(


### PR DESCRIPTION
Refs #161

## This PR satisfies Intent

Butler から repository nickname を保存するとき、Action が canonical `owner/repo` を受けているのに alias registry 未登録を理由に `repository_nickname_request_invalid` で落ちる問題を修正します。ユーザーに raw JSON や内部 payload を書かせず、Action 側が安全に canonical repository nickname write を受けられるようにします。

## Satisfied Success Criteria

- `vtddUpsertRepositoryNickname` が canonical `owner/repo` を直接受けた場合、live alias registry にまだ存在しなくても nickname を保存できる
- unresolved alias / ambiguous nickname は引き続きブロックされる
- nickname 保存時の Instructions が「alias ではなく解決済み owner/repo を repository に渡す」と明示する
- short instructions は editor 制限内に維持する
- regression tests が canonical owner/repo 保存と ambiguous alias block をカバーする

## Unsatisfied Success Criteria

- 本番 Worker への deploy はこの PR では行いません
- Butler 上の実 Action retry は merge + deploy 後に確認します

## Verification Evidence

- `node --test test/repository-nickname-registry.test.js test/worker.test.js test/custom-gpt-setup-docs.test.js`
  - 84 passed
- `npm test`
  - 500 passed

## Surface Update Checklist

- Runtime code: updated `src/worker.js`, `src/core/repository-nickname-registry.js`
- Custom GPT Instructions: updated nickname write guidance in full and short instructions
- Action Schema: no schema path/field change
- Cloudflare deploy: not performed in this PR
- iPhone Butler live E2E: pending post-deploy retry

## Notes

Observed Butler failure: `repository_nickname_request_invalid` with reason `target repository could not be resolved from alias registry`. This PR keeps unresolved aliases blocked, but allows already-canonical `owner/repo` writes so Butler can save a nickname once it has resolved the repository.
