### PR TITLE
Surface Codex connector fallback blocker for issue #156

### DIFF
--- a/docs/butler/gemini-pr-review-comments.md
+++ b/docs/butler/gemini-pr-review-comments.md
@@ -51,6 +51,9 @@ Current limitation:
 
 - a VTDD bot-authored `@codex review` request proves only that fallback was
   requested; it is not completed reviewer evidence by itself
+- a `chatgpt-codex-connector` response that asks the operator to create/connect
+  a Codex account is a fallback blocker (`codex_connector_not_configured`), not
+  reviewer progress
 - if Codex Cloud does not pick up the request, VTDD must keep the fallback state
   as requested or blocked rather than pretending review completed
 

--- a/docs/security/reviewer-policy.md
+++ b/docs/security/reviewer-policy.md
@@ -30,6 +30,10 @@ The reviewer is a critical evaluation role.
   `vtdd:reviewer=codex-fallback` marker with a recommended action is returned.
 - A bot-authored `@codex review` request must not be assumed equivalent to
   delivered reviewer evidence.
+- A `chatgpt-codex-connector` setup response such as `To use Codex here...`
+  means the Codex Cloud GitHub connector is not configured for that request and
+  must be surfaced as `codex_connector_not_configured`, not as pending review
+  progress or approve-equivalent evidence.
 - API-key-backed Codex workflow execution remains an explicit opt-in
   cost/account path, not the default fallback.
 - If the selected fallback path cannot start, VTDD must surface that blocker

--- a/src/core/codex-review-fallback.js
+++ b/src/core/codex-review-fallback.js
@@ -6,6 +6,10 @@ export const CodexReviewFallbackStatus = Object.freeze({
   BLOCKED: "blocked"
 });
 
+export const CodexReviewFallbackBlocker = Object.freeze({
+  CODEX_CONNECTOR_NOT_CONFIGURED: "codex_connector_not_configured"
+});
+
 export function formatCodexReviewFallbackComment(input = {}) {
   const trigger = normalizeText(input.trigger) || "unknown";
   const reason = normalizeText(input.reason) || "gemini_temporarily_unavailable";
@@ -76,8 +80,37 @@ export function parseCodexReviewFallbackComment(comment = {}) {
   };
 }
 
+export function parseCodexConnectorSetupComment(comment = {}) {
+  const body = normalizeText(typeof comment === "string" ? comment : comment?.body);
+  const author = normalizeText(comment?.author?.login ?? comment?.user?.login);
+  if (!isCodexConnectorAuthor(author) || !isCodexConnectorSetupBody(body)) {
+    return null;
+  }
+
+  return {
+    reviewer: "codex",
+    status: CodexReviewFallbackStatus.BLOCKED,
+    blocking: true,
+    recommendedAction: null,
+    blocker: CodexReviewFallbackBlocker.CODEX_CONNECTOR_NOT_CONFIGURED,
+    body
+  };
+}
+
 function containsMarker(value) {
   return normalizeText(value).includes(CODEX_REVIEW_FALLBACK_MARKER);
+}
+
+function isCodexConnectorAuthor(value) {
+  return normalizeText(value).toLowerCase() === "chatgpt-codex-connector";
+}
+
+function isCodexConnectorSetupBody(value) {
+  const body = normalizeText(value).toLowerCase();
+  return (
+    body.includes("to use codex here") &&
+    body.includes("connect to github")
+  );
 }
 
 function buildStatusSection({

--- a/src/core/execution-continuity.js
+++ b/src/core/execution-continuity.js
@@ -1,5 +1,8 @@
 import { buildButlerReviewSynthesis } from "./butler-review-synthesis.js";
-import { parseCodexReviewFallbackComment } from "./codex-review-fallback.js";
+import {
+  parseCodexConnectorSetupComment,
+  parseCodexReviewFallbackComment
+} from "./codex-review-fallback.js";
 import { parseGeminiReviewComment } from "./gemini-pr-review.js";
 import { ActorRole, TaskMode } from "./types.js";
 
@@ -184,7 +187,9 @@ function collectGeminiReviewerSignals(pullRequest) {
 function collectCodexFallbackSignals(pullRequest) {
   const comments = [...(Array.isArray(pullRequest.issueComments) ? pullRequest.issueComments : [])];
   const parsed = comments.map(parseCodexReviewFallbackComment).filter(Boolean);
-  const latest = parsed.at(-1) ?? null;
+  const connectorBlockers = comments.map(parseCodexConnectorSetupComment).filter(Boolean);
+  const latestConnectorBlocker = connectorBlockers.at(-1) ?? null;
+  const latest = latestConnectorBlocker ?? parsed.at(-1) ?? null;
 
   return {
     requested: latest?.status === "requested",

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -176,9 +176,11 @@ export {
 } from "./gemini-pr-review.js";
 export {
   CODEX_REVIEW_FALLBACK_MARKER,
+  CodexReviewFallbackBlocker,
   CodexReviewFallbackStatus,
   findExistingCodexReviewFallbackComment,
   formatCodexReviewFallbackComment,
+  parseCodexConnectorSetupComment,
   parseCodexReviewFallbackComment
 } from "./codex-review-fallback.js";
 export {

--- a/test/codex-review-fallback.test.js
+++ b/test/codex-review-fallback.test.js
@@ -3,8 +3,10 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 import {
   CODEX_REVIEW_FALLBACK_MARKER,
+  CodexReviewFallbackBlocker,
   findExistingCodexReviewFallbackComment,
   formatCodexReviewFallbackComment,
+  parseCodexConnectorSetupComment,
   parseCodexReviewFallbackComment
 } from "../src/core/index.js";
 
@@ -91,6 +93,32 @@ test("parseCodexReviewFallbackComment exposes blocked fallback reviewer state", 
     blocker: "openai_api_key_not_configured",
     body
   });
+});
+
+test("parseCodexConnectorSetupComment exposes connector setup blocker", () => {
+  const body = "To use Codex here, [create a Codex account and connect to github](https://chatgpt.com/codex/cloud/settings/connectors).";
+  const parsed = parseCodexConnectorSetupComment({
+    author: { login: "chatgpt-codex-connector" },
+    body
+  });
+
+  assert.deepEqual(parsed, {
+    reviewer: "codex",
+    status: "blocked",
+    blocking: true,
+    recommendedAction: null,
+    blocker: CodexReviewFallbackBlocker.CODEX_CONNECTOR_NOT_CONFIGURED,
+    body
+  });
+});
+
+test("parseCodexConnectorSetupComment ignores untrusted setup-like comments", () => {
+  const parsed = parseCodexConnectorSetupComment({
+    author: { login: "random-user" },
+    body: "To use Codex here, create a Codex account and connect to github."
+  });
+
+  assert.equal(parsed, null);
 });
 
 test("formatCodexReviewFallbackComment renders raw blocked failure details", () => {

--- a/test/execution-continuity.test.js
+++ b/test/execution-continuity.test.js
@@ -202,3 +202,41 @@ test("execution continuity surfaces Codex fallback blocker when non-manual revie
   assert.equal(result.value.reviewLoop.criticalReviewPending, true);
   assert.deepEqual(result.value.nextSuggestedActions, ["surface_reviewer_platform_blocker", "summarize_for_human"]);
 });
+
+test("execution continuity surfaces Codex connector setup comments as fallback blocker", () => {
+  const result = evaluateExecutionContinuity({
+    actorRole: ActorRole.BUTLER,
+    mode: TaskMode.EXECUTION,
+    runtimeTruth: {
+      runtimeState: {
+        activeBranch: "codex/issue-156",
+        pullRequest: {
+          number: 181,
+          url: "https://github.com/example/repo/pull/181",
+          state: "open",
+          title: "Context preflight",
+          issueComments: [
+            {
+              user: { login: "vtdd-codex[bot]" },
+              body: "<!-- vtdd:reviewer=codex-fallback -->\n## VTDD Codex Reviewer Fallback Request\n\n- Status: `requested`\n\n@codex review"
+            },
+            {
+              user: { login: "chatgpt-codex-connector" },
+              body: "To use Codex here, [create a Codex account and connect to github](https://chatgpt.com/codex/cloud/settings/connectors)."
+            }
+          ]
+        }
+      }
+    }
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.value.reviewLoop.reviewer, "codex");
+  assert.equal(result.value.reviewLoop.reviewerStatus, "codex_review_blocked");
+  assert.equal(result.value.reviewLoop.criticalReviewPending, true);
+  assert.deepEqual(result.value.nextSuggestedActions, ["surface_reviewer_platform_blocker", "summarize_for_human"]);
+  assert.equal(
+    result.value.butlerReviewSynthesis.headline,
+    "PR #181 is open. Gemini is temporarily unavailable and non-manual Codex fallback is currently blocked by platform or repository configuration."
+  );
+});


### PR DESCRIPTION
## This PR satisfies Intent

Related #156.

Codex fallback reviewer path が、Codex Cloud connector 未設定コメントを reviewer evidence と誤認しないようにします。  
PR #181 で実際に観測された `chatgpt-codex-connector` の “To use Codex here...” 応答を、`codex_connector_not_configured` blocker として扱います。

## Satisfied Success Criteria

- Codex fallback reviewer evidence is accepted only when required marker/status/action fields are present.
- `chatgpt-codex-connector` setup response is parsed as blocked fallback state, not approve evidence.
- Butler execution continuity surfaces `codex_review_blocked` and `surface_reviewer_platform_blocker` when connector setup is required.
- Untrusted setup-like comments are ignored.
- Gemini reviewer behavior is unchanged.
- Reviewer receives no execution authority.
- Docs clarify the connector setup response is not reviewer progress.

## Unsatisfied Success Criteria

- This PR does not configure the external ChatGPT/Codex GitHub connector.
- This PR does not make Codex fallback reviewer complete successfully; it only prevents overclaiming and surfaces the blocker.
- Live Custom GPT/iPhone validation is not performed inside this PR.
- This PR does not close #156; human closure judgment should wait for merge + runtime/live evidence.

## Verification Evidence

Targeted:

```sh
node --test test/codex-review-fallback.test.js test/execution-continuity.test.js test/butler-review-synthesis.test.js test/reviewer-policy.test.js
```

Result: pass, 26/26.

Full suite:

```sh
npm test
```

Result: pass, 504/504.

Evidence files:

- `src/core/codex-review-fallback.js`
- `src/core/execution-continuity.js`
- `src/core/index.js`
- `test/codex-review-fallback.test.js`
- `test/execution-continuity.test.js`
- `docs/security/reviewer-policy.md`
- `docs/butler/gemini-pr-review-comments.md`

## Surface Update Checklist

- Cloudflare deploy: not required by this PR alone; no Worker route/runtime surface changed.
- Custom GPT Action Schema update: not required.
- Custom GPT Instructions update: not required by this PR.
- Reviewer/live validation: required before closing #156, using a PR that includes a connector setup comment or equivalent runtime truth.

## Non-goals

- No merge automation.
- No deploy.
- No Issue close.
- No API-key runner requirement.
- No reviewer backend redesign beyond blocker parsing/synthesis.
- No change to Gemini as primary reviewer.
