### PR TITLE
Surface Gemini reviewer evidence URL for issue #161

### DIFF
--- a/docs/butler/gemini-pr-review-comments.md
+++ b/docs/butler/gemini-pr-review-comments.md
@@ -110,6 +110,11 @@ already present.
 The goal is to keep one current critical-review surface on the PR rather than
 creating uncontrolled repeated comments.
 
+Butler summaries must present the current `Recommended action` and the Gemini
+marker comment URL. If GitHub displays the original comment timestamp, Butler
+must explain that the marker comment was updated and the current body is the
+latest reviewer evidence.
+
 When Gemini becomes available again after a fallback request, VTDD should
 return to Gemini-first behavior and clear the stale Codex fallback request
 state.

--- a/docs/setup/custom-gpt-instructions-short.md
+++ b/docs/setup/custom-gpt-instructions-short.md
@@ -2,7 +2,7 @@ VTDD Butler. Japanese unless asked otherwise.
 
 Core:
 - Issue is canonical spec; GitHub runtime state is current progress truth.
-- Before Issue proposal/write/Codex handoff/PR judgment: vtddRetrieveCrossMemory + vtddRetrieveDecisionLogs/vtddRetrieveProposalLogs/vtddRetrieveConstitution if useful + runtime truth. Report found/missing; no RAG hit OK, never invent. Runtime truth > memory.
+- Before proposal/write/Codex handoff/PR judgment: vtddRetrieveCrossMemory + vtddRetrieveDecisionLogs/vtddRetrieveProposalLogs/vtddRetrieveConstitution if useful + runtime truth. Report found/missing; no RAG hit OK, never invent. Runtime truth > memory.
 - Do not assume a default repository. Resolve repo from alias/context; if ambiguous, ask.
 - No internal API paths/raw JSON unless debugging.
 - Natural language to actions.
@@ -14,8 +14,8 @@ Repo/nickname:
 - Save/list nicknames: vtddUpsertRepositoryNickname / vtddRetrieveRepositoryNicknames.
 - If request starts with non-owner/repo token like `ぶい の...`, call nickname read/gateway first.
 - Save with owner/repo, not alias. Nickname memory is user-owned alias data, not default repo.
-- Nickname read failure is not proof of unknown repo. If conversation/grant has owner/repo, use unverified fallback; verify.
-- If nickname save/read fails, surface error/reason/issues. If Action returns `ClientResponseError`, state action + HTTP/body.
+- Nickname read failure is not proof of unknown repo. If context/grant has owner/repo, use unverified fallback; verify.
+- If nickname save/read fails, surface error/reason/issues. If Action returns `ClientResponseError`, state action.
 
 GitHub read plane:
 - Use vtddRetrieveGitHub for repos/issues/PRs/reviews/comments/checks/runs/branches.
@@ -33,7 +33,7 @@ Self-parity:
 - If runtime in sync, don't claim editor sync.
 
 Execution:
-- Before execution, read runtime truth. If runtime_truth_required_or_safe_fallback, vtddRetrieveGitHub PR/branch/checks/runs.
+- Before execution, read runtime truth. If required, vtddRetrieveGitHub PR/branch/checks/runs.
 - No open PR: read parent Issue; propose next E2E slice.
 - Schema: build only under vtddExecute, not vtddGateway.
 - judgmentTrace first four steps exactly: constitution, runtime_truth, issue_context, current_query.
@@ -49,7 +49,7 @@ Remote Codex flow:
 - If user says handoff/実行/GO, set consent=["propose","execute"].
 - Executor transport is pluggable and user-owned; vtdd-v2-p is public core, not a shared runner.
 - Default transport is codex_cloud_github_comment; queued comment is delegation, not execution evidence.
-- codex_cloud_cli_control_runner: user-owned private control repo/trusted runner; ChatGPT-managed Codex auth via codex cloud exec, not OPENAI_API_KEY; report run URL + branch/PR evidence.
+- codex_cloud_cli_control_runner: user-owned control repo/runner; ChatGPT-managed Codex auth, not OPENAI_API_KEY; report run URL + branch/PR evidence.
 - vps_runner: user-owned VPS migration option when private Actions minutes/queueing/constraints are poor; VTDD core does not host it.
 - API runner: executorTransport=api_key_runner + apiKeyRunnerAcknowledged=true; uses OPENAI_API_KEY; report run result; surface missing OPENAI_API_KEY.
 
@@ -68,9 +68,9 @@ GitHub high-risk authority plane:
   - pull_merge
   - issue_close
 - Confirm approval grant, repo scope, and explicit request.
-- For pull_merge no grant, show `[Open merge operator](<full absolute operator URL>)` with repo, phase=execution, issueNumber, pullNumber, actionType=merge, highRiskKind=pull_merge; no bare URL.
+- For pull_merge no grant, show `[Open merge operator](<absolute operator URL>)` with repo/phase/issueNumber/pullNumber/actionType/highRiskKind; no bare URL.
 - Operator may approve+dispatch PR merge; re-read runtime truth before saying merged.
-- For issue_close, include issueNumber + merged PR pullNumber; no grant: show same-origin operator link with actionType=issue_close, highRiskKind=issue_close, issueNumber, pullNumber.
+- For issue_close, include issueNumber + merged PR pullNumber; no grant: show same-origin operator link.
 - Do not route deploy or other destructive provider actions through vtddGitHubAuthority.
 
 Deploy plane:
@@ -87,7 +87,7 @@ Deploy plane:
 
 Progress tracking:
 - After vtddExecute, always call vtddExecutionProgress.
-- For codex_cloud_cli_control_runner/vps_runner/api_key_runner, include selected executorTransport in progress.
+- For control/vps/api_key runner, include executorTransport in progress.
 - Use executionId, repository, issueNumber, branch.
 - Do not claim PR creation is complete unless GitHub runtime truth actually shows the PR.
 
@@ -95,6 +95,7 @@ Review loop:
 - Canonical loop: Butler -> Codex -> PR -> Reviewer -> Butler summary -> human.
 - For a PR, summarize state, CI, reviewers, objections, changes.
 - If reviewer objections remain, do not recommend merge GO+passkey.
+- Gemini evidence: show marker URL + current action; note updated marker if timestamp looks old.
 - Requested `vtdd:reviewer=codex-fallback` with codex_cloud_github_comment/@codex review is request-only.
 - Completed `vtdd:reviewer=codex-fallback` from trusted VTDD actor/Codex Cloud result with recommendedAction is evidence; missing GitHub Review objects alone is not absence.
 - If no reviewer evidence exists, say so.

--- a/docs/setup/custom-gpt-instructions.md
+++ b/docs/setup/custom-gpt-instructions.md
@@ -330,6 +330,8 @@ Review loop:
   - whether the PR changed after the last review
 - If reviewer objections remain unresolved, do not recommend merge GO + real passkey.
 - If no reviewer evidence exists yet, say so plainly.
+- For Gemini reviewer evidence, always show the marker comment URL and current `Recommended action`.
+- Gemini reruns update the existing marker comment; if GitHub shows an old comment timestamp, explain that the current marker body is the latest reviewer judgment.
 - A requested `vtdd:reviewer=codex-fallback` marker with `deliveryMode=codex_cloud_github_comment` and `@codex review` proves only fallback was requested; it is not completed reviewer evidence yet.
 - A completed `vtdd:reviewer=codex-fallback` marker comment from a trusted VTDD-controlled actor, Codex Cloud reviewer result, or GitHub App token path, with recommendedAction, is valid fallback reviewer evidence when Gemini is temporarily unavailable; do not treat missing GitHub Review API objects alone as missing reviewer evidence.
 - If reviewer output is approve-only, still present it as reviewer evidence and keep final judgment with the human.

--- a/src/core/butler-review-synthesis.js
+++ b/src/core/butler-review-synthesis.js
@@ -27,6 +27,7 @@ export function buildButlerReviewSynthesis(input = {}) {
     reviewerSignal: {
       reviewer: reviewLoop.reviewer,
       reviewerStatus: reviewLoop.reviewerStatus,
+      reviewerEvidence: reviewLoop.reviewerEvidence,
       reviewCommentsCount: reviewLoop.reviewCommentsCount,
       unresolvedReviewCommentsCount: reviewLoop.unresolvedReviewCommentsCount,
       criticalReviewPending: reviewLoop.criticalReviewPending,
@@ -46,6 +47,15 @@ export function buildButlerReviewSynthesis(input = {}) {
 
 function buildHeadline({ pullRequest, reviewLoop }) {
   const base = `PR #${pullRequest.number} is ${pullRequest.state || "open"}.`;
+  if (
+    reviewLoop.reviewerStatus === "gemini_review_available" &&
+    reviewLoop.reviewerEvidence?.recommendedAction === "approve"
+  ) {
+    const url = reviewLoop.reviewerEvidence.url
+      ? ` Approve evidence: ${reviewLoop.reviewerEvidence.url}`
+      : "";
+    return `${base} Gemini reviewer action is approve.${url}`;
+  }
   if (reviewLoop.reviewerStatus === "codex_review_blocked") {
     return `${base} Gemini is temporarily unavailable and non-manual Codex fallback is currently blocked by platform or repository configuration.`;
   }
@@ -87,6 +97,16 @@ function buildHumanDecisionFocus({ pullRequest, reviewLoop, codexGoal }) {
   }
   if (reviewLoop.reviewCommentsCount === 0 && reviewLoop.reviewerStatus !== "codex_review_requested") {
     focus.push("Reviewer evidence is not yet present on the PR.");
+  }
+  if (reviewLoop.reviewerEvidence?.recommendedAction) {
+    const action = reviewLoop.reviewerEvidence.recommendedAction;
+    const url = reviewLoop.reviewerEvidence.url ? ` ${reviewLoop.reviewerEvidence.url}` : "";
+    focus.push(`Latest ${reviewLoop.reviewer} reviewer action is ${action}.${url}`);
+  }
+  if (reviewLoop.reviewer === "gemini" && reviewLoop.reviewerEvidence?.includesCreatedEdit) {
+    focus.push(
+      "Gemini updates its existing marker comment; GitHub may show the original comment time, so use the current marker body and evidence URL."
+    );
   }
   focus.push("Human remains the final authority for revision GO and merge GO + real passkey.");
 
@@ -151,9 +171,26 @@ function normalizeReviewLoop(value) {
   return {
     reviewer: normalizeText(input.reviewer) || "gemini",
     reviewerStatus: normalizeText(input.reviewerStatus) || "review_unavailable",
+    reviewerEvidence: normalizeReviewerEvidence(input.reviewerEvidence),
     reviewCommentsCount: normalizeCount(input.reviewCommentsCount),
     unresolvedReviewCommentsCount: normalizeCount(input.unresolvedReviewCommentsCount),
     criticalReviewPending: input.criticalReviewPending === true
+  };
+}
+
+function normalizeReviewerEvidence(value) {
+  const input = value && typeof value === "object" ? value : {};
+  const recommendedAction = normalizeText(input.recommendedAction).toLowerCase();
+  if (!recommendedAction) {
+    return null;
+  }
+  return {
+    reviewer: normalizeText(input.reviewer) || null,
+    recommendedAction,
+    url: normalizeText(input.url) || null,
+    createdAt: normalizeText(input.createdAt) || null,
+    updatedAt: normalizeText(input.updatedAt) || null,
+    includesCreatedEdit: input.includesCreatedEdit === true
   };
 }
 

--- a/src/core/execution-continuity.js
+++ b/src/core/execution-continuity.js
@@ -59,6 +59,7 @@ export function evaluateExecutionContinuity(input = {}) {
       reviewLoop: {
         reviewer: review.reviewer,
         reviewerStatus: review.reviewerStatus,
+        reviewerEvidence: review.reviewerEvidence,
         reviewCommentsCount: review.reviewCommentsCount,
         unresolvedReviewCommentsCount: review.unresolvedReviewCommentsCount,
         criticalReviewPending: review.criticalReviewPending,
@@ -75,6 +76,7 @@ export function evaluateExecutionContinuity(input = {}) {
         reviewLoop: {
           reviewer: review.reviewer,
           reviewerStatus: review.reviewerStatus,
+          reviewerEvidence: review.reviewerEvidence,
           reviewCommentsCount: review.reviewCommentsCount,
           unresolvedReviewCommentsCount: review.unresolvedReviewCommentsCount,
           criticalReviewPending: review.criticalReviewPending
@@ -164,6 +166,7 @@ function buildReviewState(pullRequest) {
   return {
     reviewer,
     reviewerStatus,
+    reviewerEvidence: parsedGeminiSignals.latestEvidence,
     reviewCommentsCount,
     unresolvedReviewCommentsCount,
     criticalReviewPending,
@@ -180,7 +183,8 @@ function collectGeminiReviewerSignals(pullRequest) {
 
   return {
     totalCount: parsed.length,
-    blockingCount: parsed.filter((signal) => signal.blocking).length
+    blockingCount: parsed.filter((signal) => signal.blocking).length,
+    latestEvidence: parsed.at(-1) ?? null
   };
 }
 

--- a/src/core/gemini-pr-review.js
+++ b/src/core/gemini-pr-review.js
@@ -283,12 +283,17 @@ export function parseGeminiReviewComment(comment = {}) {
 
   const recommendedActionMatch = body.match(/^- Recommended action:\s*`([^`]+)`/m);
   const recommendedAction = normalizeText(recommendedActionMatch?.[1]).toLowerCase() || "manual_review";
+  const source = typeof comment === "object" && comment !== null ? comment : {};
 
   return {
     reviewer: "gemini",
     recommendedAction,
     blocking:
       recommendedAction === "request_changes" || recommendedAction === "manual_review",
+    url: normalizeText(source.url) || null,
+    createdAt: normalizeText(source.createdAt) || null,
+    updatedAt: normalizeText(source.updatedAt) || null,
+    includesCreatedEdit: source.includesCreatedEdit === true,
     body
   };
 }

--- a/src/core/gemini-pr-review.js
+++ b/src/core/gemini-pr-review.js
@@ -284,16 +284,18 @@ export function parseGeminiReviewComment(comment = {}) {
   const recommendedActionMatch = body.match(/^- Recommended action:\s*`([^`]+)`/m);
   const recommendedAction = normalizeText(recommendedActionMatch?.[1]).toLowerCase() || "manual_review";
   const source = typeof comment === "object" && comment !== null ? comment : {};
+  const createdAt = normalizeText(source.createdAt ?? source.created_at);
+  const updatedAt = normalizeText(source.updatedAt ?? source.updated_at);
 
   return {
     reviewer: "gemini",
     recommendedAction,
     blocking:
       recommendedAction === "request_changes" || recommendedAction === "manual_review",
-    url: normalizeText(source.url) || null,
-    createdAt: normalizeText(source.createdAt) || null,
-    updatedAt: normalizeText(source.updatedAt) || null,
-    includesCreatedEdit: source.includesCreatedEdit === true,
+    url: normalizeText(source.url ?? source.htmlUrl ?? source.html_url) || null,
+    createdAt: createdAt || null,
+    updatedAt: updatedAt || null,
+    includesCreatedEdit: source.includesCreatedEdit === true || (Boolean(createdAt) && Boolean(updatedAt) && createdAt !== updatedAt),
     body
   };
 }

--- a/src/core/github-read-plane.js
+++ b/src/core/github-read-plane.js
@@ -324,11 +324,15 @@ function normalizeIssue(item) {
 }
 
 function normalizeIssueComment(item) {
+  const createdAt = normalizeText(item?.created_at);
+  const updatedAt = normalizeText(item?.updated_at);
   return {
     id: normalizePositiveInteger(item?.id),
     body: normalizeText(item?.body),
     author: normalizeText(item?.user?.login),
-    createdAt: normalizeText(item?.created_at),
+    createdAt,
+    updatedAt,
+    includesCreatedEdit: Boolean(createdAt) && Boolean(updatedAt) && createdAt !== updatedAt,
     htmlUrl: normalizeText(item?.html_url)
   };
 }
@@ -367,12 +371,16 @@ function normalizePullReview(item) {
 }
 
 function normalizePullReviewComment(item) {
+  const createdAt = normalizeText(item?.created_at);
+  const updatedAt = normalizeText(item?.updated_at);
   return {
     id: normalizePositiveInteger(item?.id),
     path: normalizeText(item?.path),
     body: normalizeText(item?.body),
     author: normalizeText(item?.user?.login),
-    createdAt: normalizeText(item?.created_at),
+    createdAt,
+    updatedAt,
+    includesCreatedEdit: Boolean(createdAt) && Boolean(updatedAt) && createdAt !== updatedAt,
     htmlUrl: normalizeText(item?.html_url)
   };
 }

--- a/test/butler-review-synthesis.test.js
+++ b/test/butler-review-synthesis.test.js
@@ -55,12 +55,21 @@ test("butler review synthesis does not present approve-only Gemini review as unr
       issueComments: [
         {
           user: { login: "vtdd-codex[bot]" },
-          body: "<!-- vtdd:reviewer=gemini -->\n## VTDD Gemini Critical Review\n\n- Recommended action: `approve`"
+          body: "<!-- vtdd:reviewer=gemini -->\n## VTDD Gemini Critical Review\n\n- Recommended action: `approve`",
+          url: "https://github.com/example/repo/pull/28#issuecomment-1",
+          includesCreatedEdit: true
         }
       ]
     },
     reviewLoop: {
       reviewer: "gemini",
+      reviewerStatus: "gemini_review_available",
+      reviewerEvidence: {
+        reviewer: "gemini",
+        recommendedAction: "approve",
+        url: "https://github.com/example/repo/pull/28#issuecomment-1",
+        includesCreatedEdit: true
+      },
       reviewCommentsCount: 1,
       unresolvedReviewCommentsCount: 0,
       criticalReviewPending: false
@@ -70,7 +79,24 @@ test("butler review synthesis does not present approve-only Gemini review as unr
   });
 
   assert.equal(result.available, true);
-  assert.equal(result.headline, "PR #28 is open. Reviewer feedback exists and should be checked before human GO.");
+  assert.equal(
+    result.headline,
+    "PR #28 is open. Gemini reviewer action is approve. Approve evidence: https://github.com/example/repo/pull/28#issuecomment-1"
+  );
+  assert.deepEqual(result.reviewerSignal.reviewerEvidence, {
+    reviewer: "gemini",
+    recommendedAction: "approve",
+    url: "https://github.com/example/repo/pull/28#issuecomment-1",
+    createdAt: null,
+    updatedAt: null,
+    includesCreatedEdit: true
+  });
+  assert.equal(
+    result.humanDecisionFocus.includes(
+      "Gemini updates its existing marker comment; GitHub may show the original comment time, so use the current marker body and evidence URL."
+    ),
+    true
+  );
   assert.equal(
     result.humanDecisionFocus.includes(
       "Meaningful reviewer objections remain unresolved; do not issue merge GO + real passkey yet."

--- a/test/execution-continuity.test.js
+++ b/test/execution-continuity.test.js
@@ -93,7 +93,9 @@ test("execution continuity treats approve-only Gemini reviewer comment as non-bl
           issueComments: [
             {
               user: { login: "vtdd-codex[bot]" },
-              body: "<!-- vtdd:reviewer=gemini -->\n## VTDD Gemini Critical Review\n\n- Recommended action: `approve`"
+              body: "<!-- vtdd:reviewer=gemini -->\n## VTDD Gemini Critical Review\n\n- Recommended action: `approve`",
+              url: "https://github.com/example/repo/pull/28#issuecomment-4317590536",
+              includesCreatedEdit: true
             }
           ]
         }
@@ -108,7 +110,13 @@ test("execution continuity treats approve-only Gemini reviewer comment as non-bl
   assert.equal(result.value.codexGoal, CodexGoal.WAIT_FOR_REVIEW);
   assert.equal(
     result.value.butlerReviewSynthesis.headline,
-    "PR #28 is open. Reviewer feedback exists and should be checked before human GO."
+    "PR #28 is open. Gemini reviewer action is approve. Approve evidence: https://github.com/example/repo/pull/28#issuecomment-4317590536"
+  );
+  assert.equal(
+    result.value.butlerReviewSynthesis.humanDecisionFocus.includes(
+      "Gemini updates its existing marker comment; GitHub may show the original comment time, so use the current marker body and evidence URL."
+    ),
+    true
   );
   assert.deepEqual(result.value.nextSuggestedActions, ["summarize_for_human", "wait_for_human_go"]);
 });

--- a/test/gemini-pr-review.test.js
+++ b/test/gemini-pr-review.test.js
@@ -168,15 +168,25 @@ test("findExistingGeminiReviewComment locates prior marker comment", () => {
 });
 
 test("parseGeminiReviewComment treats approve as non-blocking reviewer evidence", () => {
-  const parsed = parseGeminiReviewComment(`${GEMINI_PR_REVIEW_MARKER}
+  const parsed = parseGeminiReviewComment({
+    body: `${GEMINI_PR_REVIEW_MARKER}
 ## VTDD Gemini Critical Review
 
-- Recommended action: \`approve\``);
+- Recommended action: \`approve\``,
+    url: "https://github.com/example/repo/pull/28#issuecomment-1",
+    createdAt: "2026-05-05T06:15:35Z",
+    updatedAt: "2026-05-05T09:48:45Z",
+    includesCreatedEdit: true
+  });
 
   assert.deepEqual(parsed, {
     reviewer: "gemini",
     recommendedAction: "approve",
     blocking: false,
+    url: "https://github.com/example/repo/pull/28#issuecomment-1",
+    createdAt: "2026-05-05T06:15:35Z",
+    updatedAt: "2026-05-05T09:48:45Z",
+    includesCreatedEdit: true,
     body: `${GEMINI_PR_REVIEW_MARKER}
 ## VTDD Gemini Critical Review
 

--- a/test/gemini-pr-review.test.js
+++ b/test/gemini-pr-review.test.js
@@ -194,6 +194,21 @@ test("parseGeminiReviewComment treats approve as non-blocking reviewer evidence"
   });
 });
 
+test("parseGeminiReviewComment accepts GitHub read-plane comment fields", () => {
+  const parsed = parseGeminiReviewComment({
+    body: `${GEMINI_PR_REVIEW_MARKER}
+## VTDD Gemini Critical Review
+
+- Recommended action: \`approve\``,
+    htmlUrl: "https://github.com/example/repo/pull/28#issuecomment-2",
+    createdAt: "2026-05-05T06:15:35Z",
+    updatedAt: "2026-05-05T09:48:45Z"
+  });
+
+  assert.equal(parsed.url, "https://github.com/example/repo/pull/28#issuecomment-2");
+  assert.equal(parsed.includesCreatedEdit, true);
+});
+
 test("issue comment from human remains a rerun trigger", () => {
   const result = resolveGeminiReviewTrigger({
     eventName: "issue_comment",

--- a/test/github-read-plane.test.js
+++ b/test/github-read-plane.test.js
@@ -71,6 +71,39 @@ test("github read plane lists issues and filters pull request-shaped issue resul
   assert.equal(result.read.records[0].body, "## Intent\nUse Issue text as the execution spec.");
 });
 
+test("github read plane returns issue comment edit evidence", async () => {
+  const result = await retrieveGitHubReadPlane({
+    resource: GitHubReadResource.ISSUE_COMMENTS,
+    repository: "sample-org/vtdd-v2-p",
+    issueNumber: 183,
+    env: {
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_issue_read",
+      GITHUB_API_FETCH: async () =>
+        new Response(
+          JSON.stringify([
+            {
+              id: 4376926984,
+              body: "<!-- vtdd:reviewer=gemini -->\n- Recommended action: `approve`",
+              user: { login: "vtdd-codex" },
+              created_at: "2026-05-05T06:15:35Z",
+              updated_at: "2026-05-05T09:48:45Z",
+              html_url: "https://github.com/sample-org/vtdd-v2-p/pull/183#issuecomment-4376926984"
+            }
+          ]),
+          { status: 200, headers: { "content-type": "application/json" } }
+        )
+    }
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.read.records[0].updatedAt, "2026-05-05T09:48:45Z");
+  assert.equal(result.read.records[0].includesCreatedEdit, true);
+  assert.equal(
+    result.read.records[0].htmlUrl,
+    "https://github.com/sample-org/vtdd-v2-p/pull/183#issuecomment-4376926984"
+  );
+});
+
 test("github read plane includes issue body when reading a specific issue", async () => {
   const calls = [];
   const result = await retrieveGitHubReadPlane({


### PR DESCRIPTION
## This PR satisfies Intent

Related #161.

Butler が PR reviewer 状態を説明するとき、Gemini の reviewer marker comment が既存コメント更新型であることを明示し、現在の `Recommended action` と evidence URL を提示できるようにします。

## Satisfied Success Criteria

- Butler review synthesis now carries Gemini reviewer evidence details, including `recommendedAction`, URL, and whether the marker comment was edited after creation.
- When Gemini reviewer action is `approve`, Butler headline includes the approve evidence URL instead of only saying generic reviewer feedback exists.
- Human decision focus explains that Gemini reruns update the existing marker comment, so an old-looking GitHub timestamp does not mean the judgment is stale.
- Execution continuity passes the parsed reviewer evidence into Butler synthesis.
- Custom GPT Instructions and short instructions tell Butler to show the Gemini marker URL and current action.
- Gemini review docs now state that Butler must explain updated marker comments.

## Unsatisfied Success Criteria

- This PR does not close #161.
- This PR does not deploy the Worker runtime.
- This PR does not update a live Custom GPT configuration by itself.
- This PR does not change Gemini workflow trigger behavior; it only improves how Butler consumes and explains reviewer evidence.

## Verification Evidence

Targeted:

```sh
node --test test/gemini-pr-review.test.js test/execution-continuity.test.js test/butler-review-synthesis.test.js test/custom-gpt-setup-docs.test.js
```

Result: pass, 32/32.

Full suite:

```sh
npm test
```

Result: pass, 507/507.

Evidence files:

- `src/core/gemini-pr-review.js`
- `src/core/execution-continuity.js`
- `src/core/butler-review-synthesis.js`
- `test/gemini-pr-review.test.js`
- `test/execution-continuity.test.js`
- `test/butler-review-synthesis.test.js`
- `docs/setup/custom-gpt-instructions.md`
- `docs/setup/custom-gpt-instructions-short.md`
- `docs/butler/gemini-pr-review-comments.md`

## Surface Update Checklist

- Cloudflare deploy: required after merge because Worker-consumed core runtime code changed.
- Custom GPT Action Schema update: not required.
- Custom GPT Instructions update: required after merge because canonical Instructions changed.
- Live Butler validation: required before treating this as user-facing complete.

## Non-goals

- No merge automation.
- No deploy.
- No Issue close.
- No reviewer backend redesign.
- No change to Gemini workflow trigger policy.
