### PR TITLE
Add minimal VPS runner daemon

### DIFF
--- a/docs/butler/remote-codex-cli-executor.md
+++ b/docs/butler/remote-codex-cli-executor.md
@@ -130,10 +130,41 @@ not require a public inbound VPS API:
   branch/PR evidence appears after the grace period, progress becomes blocked
   with `vps_runner_pickup_not_observed`
 
-The initial public/core contract deliberately stops at queue/progress semantics.
-The concrete VPS daemon, Codex authentication, systemd service, and credential
-storage remain user-owned runtime setup and must not be represented as shared
-VTDD infrastructure.
+The public/core repository includes a minimal user-owned runner entrypoint at
+`scripts/run-vps-runner.mjs`. It can poll the GitHub queue contract, report
+runner events, create the target branch, run Codex CLI in a cloned workspace,
+push changes, and open a draft PR. It is intentionally an operator-owned script,
+not a hosted VTDD service.
+
+Required runner environment:
+
+- `GITHUB_TOKEN` or `GH_TOKEN`: token available to `gh`, GitHub API reads,
+  branch push, Issue comment write, and PR creation for the allowlisted target
+  repositories.
+- `VTDD_VPS_RUNNER_REPOSITORIES`: comma-separated allowlist such as
+  `owner/repo,owner/another-repo`.
+- Optional `VTDD_VPS_RUNNER_WORKDIR`: workspace root. Defaults to
+  `~/vtdd-runner/workspaces`.
+- Codex CLI must be authenticated on the VPS user account. If `codex exec`
+  returns 401 or missing authentication, the runner reports
+  `codex_auth_unavailable` back through the VPS runner event comment.
+
+Dry-run pickup check:
+
+```sh
+node scripts/run-vps-runner.mjs --dry-run
+```
+
+One-shot execution:
+
+```sh
+node scripts/run-vps-runner.mjs
+```
+
+The script is suitable for a later systemd timer/service wrapper, but systemd
+installation, Codex login, token placement, and credential storage remain
+user-owned runtime setup. They must not be represented as shared VTDD
+infrastructure or embedded in this public/core repository.
 
 ## Optional API-backed Runner
 

--- a/scripts/run-vps-runner.mjs
+++ b/scripts/run-vps-runner.mjs
@@ -1,0 +1,527 @@
+#!/usr/bin/env node
+
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { spawn } from "node:child_process";
+
+const QUEUE_MARKER_RE = /<!--\s*vtdd:vps-runner-execution:([a-zA-Z0-9._:-]+)\s*-->/;
+const EVENT_MARKER_RE = /<!--\s*vtdd:vps-runner-event:([a-zA-Z0-9._:-]+)\s*-->/;
+const DEFAULT_API_BASE_URL = "https://api.github.com";
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const token = mustGetEnv("GITHUB_TOKEN", process.env.GITHUB_TOKEN || process.env.GH_TOKEN);
+  const allowedRepositories = parseCsv(mustGetEnv("VTDD_VPS_RUNNER_REPOSITORIES"));
+  const workRoot = process.env.VTDD_VPS_RUNNER_WORKDIR || path.join(os.homedir(), "vtdd-runner", "workspaces");
+  const githubFetch = createGitHubFetch({
+    token,
+    apiBaseUrl: process.env.GITHUB_API_URL || DEFAULT_API_BASE_URL
+  });
+
+  const result = await runVpsRunnerOnce({
+    githubFetch,
+    token,
+    allowedRepositories,
+    workRoot,
+    dryRun: options.dryRun
+  });
+
+  if (!result.ok) {
+    console.error(result.reason || "VPS runner failed.");
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(result.message);
+}
+
+async function runVpsRunnerOnce({ githubFetch, token, allowedRepositories, workRoot, dryRun = false }) {
+  const candidates = [];
+  for (const repository of allowedRepositories) {
+    const comments = await readRecentIssueComments({ githubFetch, repository });
+    candidates.push(...selectPendingVpsRunnerExecutions({ comments, allowedRepositories }));
+  }
+
+  const execution = candidates.sort((a, b) => new Date(a.createdAt) - new Date(b.createdAt))[0];
+  if (!execution) {
+    return { ok: true, message: "No pending VPS runner execution found." };
+  }
+
+  if (dryRun) {
+    return {
+      ok: true,
+      message: `Dry run selected ${execution.payload.executionId} for ${execution.payload.repository}#${execution.payload.issueNumber}.`
+    };
+  }
+
+  return executeVpsRunnerExecution({ githubFetch, token, workRoot, execution });
+}
+
+async function executeVpsRunnerExecution({ githubFetch, token, workRoot, execution }) {
+  const { payload } = execution;
+  const env = buildRunnerCommandEnv({ token });
+  await postVpsRunnerEvent({
+    githubFetch,
+    payload,
+    event: {
+      status: "running",
+      lastEvent: "runner_started",
+      queueCommentId: execution.commentId
+    }
+  });
+
+  try {
+    const workspace = path.join(workRoot, safePathSegment(payload.repository), payload.executionId);
+    await fs.mkdir(path.dirname(workspace), { recursive: true });
+    await runCommand("rm", ["-rf", workspace], { env });
+    await runCommand("gh", ["repo", "clone", payload.repository, workspace], { env });
+    await runCommand("git", ["fetch", "origin", payload.baseRef || "main"], { cwd: workspace, env });
+    await runCommand("git", ["checkout", "-B", payload.branch, `origin/${payload.baseRef || "main"}`], {
+      cwd: workspace,
+      env
+    });
+    await runCommand("git", ["push", "-u", "origin", payload.branch], { cwd: workspace, env });
+
+    await postVpsRunnerEvent({
+      githubFetch,
+      payload,
+      event: {
+        status: "branch_created",
+        lastEvent: "branch_pushed",
+        branch: payload.branch
+      }
+    });
+
+    const prompt = buildCodexExecutionPrompt(payload);
+    await runCommand("codex", ["exec", "--skip-git-repo-check", "-"], {
+      cwd: workspace,
+      env: buildCodexExecutionEnv(process.env),
+      input: prompt,
+      maxBuffer: 1024 * 1024 * 12
+    });
+
+    const status = await runCommand("git", ["status", "--porcelain"], { cwd: workspace, env });
+    if (status.stdout.trim()) {
+      await runCommand("git", ["add", "-A"], { cwd: workspace, env });
+      await runCommand("git", ["commit", "-m", `Implement Issue #${payload.issueNumber} via VTDD VPS runner`], {
+        cwd: workspace,
+        env
+      });
+      await runCommand("git", ["push", "origin", payload.branch], { cwd: workspace, env });
+    }
+
+    let prUrl = await findExistingPullRequestUrl({
+      repository: payload.repository,
+      branch: payload.branch,
+      env,
+      cwd: workspace
+    });
+    if (!prUrl) {
+      const prBody = buildPullRequestBody(payload);
+      const pr = await runCommand(
+        "gh",
+        [
+          "pr",
+          "create",
+          "--draft",
+          "--base",
+          payload.baseRef || "main",
+          "--head",
+          payload.branch,
+          "--title",
+          `Issue #${payload.issueNumber}: VTDD VPS runner handoff`,
+          "--body",
+          prBody
+        ],
+        { cwd: workspace, env }
+      );
+      prUrl = pr.stdout.trim();
+    }
+
+    await postVpsRunnerEvent({
+      githubFetch,
+      payload,
+      event: {
+        status: "pr_created",
+        lastEvent: "pull_request_created",
+        branch: payload.branch,
+        pr: prUrl
+      }
+    });
+
+    return { ok: true, message: `VPS runner execution completed: ${prUrl}` };
+  } catch (error) {
+    const rawFailure = classifyVpsRunnerFailure(error);
+    await postVpsRunnerEvent({
+      githubFetch,
+      payload,
+      event: {
+        status: "failed",
+        lastEvent: "runner_failed",
+        rawFailure
+      }
+    });
+    return { ok: false, reason: rawFailure.reason };
+  }
+}
+
+function selectPendingVpsRunnerExecutions({ comments, allowedRepositories }) {
+  const allowed = new Set(allowedRepositories);
+  const queues = new Map();
+  const terminalEvents = new Set();
+  const runningEvents = new Set();
+
+  for (const comment of comments) {
+    const queue = parseVpsRunnerQueueComment(comment.body);
+    if (queue.ok && allowed.has(queue.payload.repository)) {
+      queues.set(queue.payload.executionId, {
+        ...queue,
+        commentId: comment.id,
+        commentUrl: comment.html_url,
+        createdAt: comment.created_at
+      });
+      continue;
+    }
+
+    const event = parseVpsRunnerEventComment(comment.body);
+    if (!event.ok) {
+      continue;
+    }
+    if (["pr_created", "completed", "failed", "blocked"].includes(event.event.status)) {
+      terminalEvents.add(event.executionId);
+    }
+    if (event.event.status === "running") {
+      runningEvents.add(event.executionId);
+    }
+  }
+
+  return [...queues.values()].filter(
+    (queue) => !terminalEvents.has(queue.payload.executionId) && !runningEvents.has(queue.payload.executionId)
+  );
+}
+
+function parseVpsRunnerQueueComment(body) {
+  const text = String(body || "");
+  const marker = text.match(QUEUE_MARKER_RE);
+  if (!marker) {
+    return { ok: false, reason: "vps_runner_queue_marker_missing" };
+  }
+
+  const payload = extractFirstJsonFence(text);
+  if (!payload) {
+    return { ok: false, reason: "vps_runner_payload_missing", executionId: marker[1] };
+  }
+
+  const normalized = {
+    executionId: normalizeText(payload.executionId),
+    transport: normalizeText(payload.transport),
+    repository: normalizeRepository(payload.repository),
+    issueNumber: normalizePositiveInteger(payload.issueNumber),
+    branch: normalizeText(payload.branch),
+    baseRef: normalizeText(payload.baseRef) || "main",
+    codexGoal: normalizeText(payload.codexGoal),
+    approvalScopeMatched: payload.approvalScopeMatched === true,
+    handoff: payload.handoff || null
+  };
+
+  const issues = [];
+  if (normalized.executionId !== marker[1]) {
+    issues.push("executionId does not match queue marker");
+  }
+  if (normalized.transport !== "vps_runner") {
+    issues.push("transport must be vps_runner");
+  }
+  if (!normalized.repository) {
+    issues.push("repository is required");
+  }
+  if (!normalized.issueNumber) {
+    issues.push("issueNumber is required");
+  }
+  if (!normalized.branch) {
+    issues.push("branch is required");
+  }
+  if (!normalized.approvalScopeMatched) {
+    issues.push("approvalScopeMatched must be true");
+  }
+
+  if (issues.length > 0) {
+    return { ok: false, reason: "vps_runner_payload_invalid", executionId: marker[1], issues };
+  }
+
+  return { ok: true, executionId: normalized.executionId, payload: normalized };
+}
+
+function parseVpsRunnerEventComment(body) {
+  const text = String(body || "");
+  const marker = text.match(EVENT_MARKER_RE);
+  if (!marker) {
+    return { ok: false, reason: "vps_runner_event_marker_missing" };
+  }
+  const event = extractFirstJsonFence(text);
+  if (!event) {
+    return { ok: false, reason: "vps_runner_event_payload_missing", executionId: marker[1] };
+  }
+  return { ok: true, executionId: marker[1], event };
+}
+
+function buildVpsRunnerEventComment({ executionId, event }) {
+  return [`<!-- vtdd:vps-runner-event:${executionId} -->`, "VTDD VPS runner event.", "", fencedJson(event)].join("\n");
+}
+
+function buildCodexExecutionPrompt(payload) {
+  return [
+    `Implement the bounded VTDD task for ${payload.repository} issue #${payload.issueNumber}.`,
+    "",
+    "Hard boundaries:",
+    "- Use the GitHub Issue as the canonical spec.",
+    "- Keep changes on the current branch.",
+    "- Do not merge.",
+    "- Do not deploy.",
+    "- Do not mutate secrets, permissions, repository settings, or external infrastructure.",
+    "- If the Issue is ambiguous or blocked, leave a clear note in the working tree and stop.",
+    "",
+    `Goal: ${payload.codexGoal}`,
+    `Branch: ${payload.branch}`,
+    "",
+    "When you finish, leave the working tree ready for commit."
+  ].join("\n");
+}
+
+function classifyVpsRunnerFailure(error) {
+  const reason = error instanceof Error ? error.message : String(error);
+  if (/401 Unauthorized|Missing bearer|authentication/i.test(reason)) {
+    return {
+      error: "codex_auth_unavailable",
+      reason: "Codex CLI is not authenticated on the VPS runner.",
+      rawError: reason
+    };
+  }
+  if (/codex .*failed|codex exec/i.test(reason)) {
+    return {
+      error: "codex_execution_failed",
+      reason
+    };
+  }
+  return {
+    error: "vps_runner_execution_failed",
+    reason
+  };
+}
+
+async function readRecentIssueComments({ githubFetch, repository }) {
+  const issues = await githubFetch(`/repos/${repository}/issues?state=open&sort=updated&direction=desc&per_page=100`);
+  const comments = [];
+  for (const issue of issues.filter((item) => !item.pull_request)) {
+    const issueComments = await githubFetch(`/repos/${repository}/issues/${issue.number}/comments?per_page=100`);
+    comments.push(...issueComments);
+  }
+  return comments;
+}
+
+async function postVpsRunnerEvent({ githubFetch, payload, event }) {
+  return githubFetch(`/repos/${payload.repository}/issues/${payload.issueNumber}/comments`, {
+    method: "POST",
+    body: {
+      body: buildVpsRunnerEventComment({
+        executionId: payload.executionId,
+        event: {
+          ...event,
+          executionId: payload.executionId,
+          repository: payload.repository,
+          issueNumber: payload.issueNumber
+        }
+      })
+    }
+  });
+}
+
+async function findExistingPullRequestUrl({ repository, branch, env, cwd }) {
+  try {
+    const result = await runCommand("gh", ["pr", "list", "--repo", repository, "--head", branch, "--json", "url", "--limit", "1"], {
+      cwd,
+      env
+    });
+    const parsed = JSON.parse(result.stdout || "[]");
+    return parsed[0]?.url || "";
+  } catch {
+    return "";
+  }
+}
+
+function buildPullRequestBody(payload) {
+  return [
+    `Issue: #${payload.issueNumber}`,
+    `Execution ID: ${payload.executionId}`,
+    "",
+    "Created by the VTDD VPS runner.",
+    "",
+    "Boundaries:",
+    "- No merge performed.",
+    "- No deploy performed.",
+    "- GitHub branch / PR are the runtime truth for Butler progress."
+  ].join("\n");
+}
+
+function createGitHubFetch({ apiBaseUrl, token }) {
+  return async function githubFetch(pathname, init = {}) {
+    const response = await fetch(`${apiBaseUrl}${pathname}`, {
+      method: init.method || "GET",
+      headers: {
+        accept: "application/vnd.github+json",
+        authorization: `Bearer ${token}`,
+        "content-type": "application/json",
+        "x-github-api-version": "2022-11-28"
+      },
+      body: init.body ? JSON.stringify(init.body) : undefined
+    });
+    const text = await response.text();
+    const body = text ? JSON.parse(text) : null;
+    if (!response.ok) {
+      throw new Error(`GitHub API ${response.status}: ${body?.message || text}`);
+    }
+    return body;
+  };
+}
+
+function runCommand(command, args, options = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd: options.cwd,
+      env: options.env || process.env,
+      stdio: ["pipe", "pipe", "pipe"]
+    });
+    const maxBuffer = options.maxBuffer || 1024 * 1024 * 4;
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+      if (stdout.length > maxBuffer) {
+        child.kill("SIGTERM");
+        reject(new Error(`${command} stdout exceeded ${maxBuffer} bytes`));
+      }
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+      if (stderr.length > maxBuffer) {
+        child.kill("SIGTERM");
+        reject(new Error(`${command} stderr exceeded ${maxBuffer} bytes`));
+      }
+    });
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code === 0) {
+        resolve({ stdout, stderr });
+        return;
+      }
+      reject(new Error(`${command} ${args.join(" ")} failed with exit code ${code}: ${stderr || stdout}`));
+    });
+    if (options.input) {
+      child.stdin.end(options.input);
+    } else {
+      child.stdin.end();
+    }
+  });
+}
+
+function buildRunnerCommandEnv({ token }) {
+  return {
+    ...process.env,
+    GH_TOKEN: token,
+    GITHUB_TOKEN: token
+  };
+}
+
+function buildCodexExecutionEnv(env) {
+  const allowedNames = [
+    "CI",
+    "CODEX_HOME",
+    "HOME",
+    "LANG",
+    "LC_ALL",
+    "PATH",
+    "RUNNER_TEMP",
+    "TMPDIR",
+    "XDG_CACHE_HOME",
+    "XDG_CONFIG_HOME"
+  ];
+  return Object.fromEntries(
+    allowedNames
+      .map((name) => [name, env[name]])
+      .filter(([, value]) => typeof value === "string" && value.length > 0)
+  );
+}
+
+function extractFirstJsonFence(text) {
+  const fenced = String(text || "").match(/```json\s*([\s\S]*?)```/i);
+  if (!fenced) {
+    return null;
+  }
+  try {
+    return JSON.parse(fenced[1]);
+  } catch {
+    return null;
+  }
+}
+
+function fencedJson(value) {
+  return `\`\`\`json\n${JSON.stringify(value, null, 2)}\n\`\`\``;
+}
+
+function normalizeText(value) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function normalizeRepository(value) {
+  const text = normalizeText(value);
+  return /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(text) ? text : "";
+}
+
+function normalizePositiveInteger(value) {
+  const number = Number(value);
+  return Number.isInteger(number) && number > 0 ? number : 0;
+}
+
+function safePathSegment(value) {
+  return String(value || "").replace(/[^A-Za-z0-9_.-]+/g, "_");
+}
+
+function parseCsv(value) {
+  return String(value || "")
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function mustGetEnv(name, value = process.env[name]) {
+  if (!value) {
+    throw new Error(`${name} is required`);
+  }
+  return value;
+}
+
+function parseArgs(args) {
+  return {
+    dryRun: args.includes("--dry-run")
+  };
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  });
+}
+
+export {
+  buildCodexExecutionPrompt,
+  buildVpsRunnerEventComment,
+  classifyVpsRunnerFailure,
+  parseVpsRunnerEventComment,
+  parseVpsRunnerQueueComment,
+  runVpsRunnerOnce,
+  selectPendingVpsRunnerExecutions
+};

--- a/test/vps-runner-script.test.js
+++ b/test/vps-runner-script.test.js
@@ -1,0 +1,180 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildCodexExecutionPrompt,
+  buildVpsRunnerEventComment,
+  classifyVpsRunnerFailure,
+  parseVpsRunnerEventComment,
+  parseVpsRunnerQueueComment,
+  runVpsRunnerOnce,
+  selectPendingVpsRunnerExecutions
+} from "../scripts/run-vps-runner.mjs";
+
+test("VPS runner parses bounded queue comment payload", () => {
+  const parsed = parseVpsRunnerQueueComment(`<!-- vtdd:vps-runner-execution:remote-codex-issue157-vps -->
+VTDD-managed VPS runner execution request.
+
+\`\`\`json
+{
+  "executionId": "remote-codex-issue157-vps",
+  "transport": "vps_runner",
+  "repository": "sample-org/vtdd-v2",
+  "issueNumber": 157,
+  "branch": "codex/issue-157",
+  "baseRef": "main",
+  "codexGoal": "open_pr",
+  "approvalScopeMatched": true
+}
+\`\`\``);
+
+  assert.equal(parsed.ok, true);
+  assert.equal(parsed.payload.executionId, "remote-codex-issue157-vps");
+  assert.equal(parsed.payload.repository, "sample-org/vtdd-v2");
+  assert.equal(parsed.payload.issueNumber, 157);
+  assert.equal(parsed.payload.branch, "codex/issue-157");
+});
+
+test("VPS runner rejects queue comments without scoped approval", () => {
+  const parsed = parseVpsRunnerQueueComment(`<!-- vtdd:vps-runner-execution:remote-codex-issue157-vps -->
+\`\`\`json
+{
+  "executionId": "remote-codex-issue157-vps",
+  "transport": "vps_runner",
+  "repository": "sample-org/vtdd-v2",
+  "issueNumber": 157,
+  "branch": "codex/issue-157",
+  "approvalScopeMatched": false
+}
+\`\`\``);
+
+  assert.equal(parsed.ok, false);
+  assert.equal(parsed.reason, "vps_runner_payload_invalid");
+  assert.equal(parsed.issues.includes("approvalScopeMatched must be true"), true);
+});
+
+test("VPS runner selects only allowlisted pending queues", () => {
+  const comments = [
+    {
+      id: 1,
+      html_url: "https://github.com/sample-org/vtdd-v2/issues/157#issuecomment-1",
+      created_at: "2026-05-07T10:00:00Z",
+      body: queueComment({ executionId: "exec-1", repository: "sample-org/vtdd-v2" })
+    },
+    {
+      id: 2,
+      html_url: "https://github.com/sample-org/vtdd-v2/issues/157#issuecomment-2",
+      created_at: "2026-05-07T10:01:00Z",
+      body: buildVpsRunnerEventComment({
+        executionId: "exec-2",
+        event: { status: "running", lastEvent: "runner_started" }
+      })
+    },
+    {
+      id: 3,
+      html_url: "https://github.com/sample-org/vtdd-v2/issues/157#issuecomment-3",
+      created_at: "2026-05-07T10:02:00Z",
+      body: queueComment({ executionId: "exec-2", repository: "sample-org/vtdd-v2" })
+    },
+    {
+      id: 4,
+      html_url: "https://github.com/evil/repo/issues/1#issuecomment-4",
+      created_at: "2026-05-07T10:03:00Z",
+      body: queueComment({ executionId: "exec-3", repository: "evil/repo" })
+    }
+  ];
+
+  const selected = selectPendingVpsRunnerExecutions({
+    comments,
+    allowedRepositories: ["sample-org/vtdd-v2"]
+  });
+
+  assert.equal(selected.length, 1);
+  assert.equal(selected[0].payload.executionId, "exec-1");
+});
+
+test("VPS runner event comment is parseable by execution id", () => {
+  const body = buildVpsRunnerEventComment({
+    executionId: "exec-1",
+    event: {
+      status: "failed",
+      lastEvent: "codex_login_missing",
+      rawFailure: { error: "codex_auth_unavailable" }
+    }
+  });
+  const parsed = parseVpsRunnerEventComment(body);
+
+  assert.equal(parsed.ok, true);
+  assert.equal(parsed.executionId, "exec-1");
+  assert.equal(parsed.event.status, "failed");
+  assert.equal(parsed.event.rawFailure.error, "codex_auth_unavailable");
+});
+
+test("VPS runner dry run reports selected execution without side effects", async () => {
+  const calls = [];
+  const result = await runVpsRunnerOnce({
+    token: "ghs_test",
+    allowedRepositories: ["sample-org/vtdd-v2"],
+    workRoot: "/tmp/vtdd-runner-test",
+    dryRun: true,
+    githubFetch: async (url) => {
+      calls.push(url);
+      if (url.includes("/issues?")) {
+        return [{ number: 157 }];
+      }
+      return [
+        {
+          id: 1,
+          html_url: "https://github.com/sample-org/vtdd-v2/issues/157#issuecomment-1",
+          created_at: "2026-05-07T10:00:00Z",
+          body: queueComment({ executionId: "exec-1", repository: "sample-org/vtdd-v2" })
+        }
+      ];
+    }
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.message.includes("Dry run selected exec-1"), true);
+  assert.deepEqual(calls, [
+    "/repos/sample-org/vtdd-v2/issues?state=open&sort=updated&direction=desc&per_page=100",
+    "/repos/sample-org/vtdd-v2/issues/157/comments?per_page=100"
+  ]);
+});
+
+test("VPS runner Codex prompt preserves high-risk boundaries", () => {
+  const prompt = buildCodexExecutionPrompt({
+    repository: "sample-org/vtdd-v2",
+    issueNumber: 157,
+    branch: "codex/issue-157",
+    codexGoal: "open_pr"
+  });
+
+  assert.equal(prompt.includes("Do not merge."), true);
+  assert.equal(prompt.includes("Do not deploy."), true);
+  assert.equal(prompt.includes("Do not mutate secrets"), true);
+});
+
+test("VPS runner classifies unauthenticated Codex CLI as raw auth failure", () => {
+  const failure = classifyVpsRunnerFailure(
+    new Error("codex exec failed: unexpected status 401 Unauthorized: Missing bearer authentication")
+  );
+
+  assert.equal(failure.error, "codex_auth_unavailable");
+  assert.equal(failure.reason, "Codex CLI is not authenticated on the VPS runner.");
+  assert.equal(failure.rawError.includes("401 Unauthorized"), true);
+});
+
+function queueComment({ executionId, repository }) {
+  return `<!-- vtdd:vps-runner-execution:${executionId} -->
+\`\`\`json
+{
+  "executionId": "${executionId}",
+  "transport": "vps_runner",
+  "repository": "${repository}",
+  "issueNumber": 157,
+  "branch": "codex/issue-157",
+  "baseRef": "main",
+  "codexGoal": "open_pr",
+  "approvalScopeMatched": true
+}
+\`\`\``;
+}


### PR DESCRIPTION
## This PR satisfies Intent

- Partial progress for #157: add the user-owned VPS runner entrypoint that can pick up the GitHub-backed vps_runner queue and return GitHub-visible progress events.

## Satisfied Success Criteria

- Adds scripts/run-vps-runner.mjs for queue polling, allowlisted pickup, branch push, Codex CLI execution, draft PR creation, and event comment writeback.\nAdds parser/selector/formatter tests for bounded queue payloads, scoped approval, allowlist filtering, dry-run selection, high-risk prompt boundaries, and unauthenticated Codex failure classification.\nDocuments required VPS runner environment and the codex_auth_unavailable raw failure path.

## Unsatisfied Success Criteria

- Live iPhone Butler handoff through the deployed Worker to this VPS runner is not proven in this PR.\nVPS Codex CLI authentication is currently blocked by 401 Unauthorized and still needs operator setup before live execution can create a PR.\nsystemd/timer installation and credential placement are not included.

## Non-goal violations

None.

## Verification Evidence

- Unit: npm test -> 523 passed; node --test test/vps-runner-script.test.js -> 7 passed; node --check scripts/run-vps-runner.mjs -> passed.
- Integration: SSH read-only VPS probe confirmed Node v24.15.0, npm 11.12.1, gh 2.92.0, codex-cli 0.128.0, git 2.43.0 are installed.
- E2E: Not complete. VPS codex exec probe failed with 401 Unauthorized, so live branch/PR creation from VPS is blocked until Codex CLI auth is configured.
- Manual: ssh vtdd codex exec --skip-git-repo-check returned 401 Unauthorized; this is now classified as codex_auth_unavailable.
- Evidence path/link: scripts/run-vps-runner.mjs; test/vps-runner-script.test.js; docs/butler/remote-codex-cli-executor.md

## Surface Update Checklist

- Cloudflare deploy: Not required; no Worker runtime change.
- Custom GPT Action Schema update: Not required; existing vps_runner queue/progress contract is reused.
- Custom GPT Instructions update: Not required.
- iPhone Butler live E2E: Still pending after VPS Codex auth and runner deployment.

## Related Constitution Rules

- Issue #157 runtime truth: queued is not success.\nAGENTS.md: no deploy, credential mutation, permission mutation, or destructive operation without GO + passkey.\nPublic/core boundary: no owner-specific runtime credentials or URLs embedded.

## Out-of-scope but NOT implemented

- No Cloudflare Worker expansion.\nNo RAG.\nNo SunabaEye.\nNo systemd install or VPS credential placement.\nNo merge/deploy automation.

## Extra changes (if any)

VPS Codex auth blocker was verified and surfaced in docs/tests.

<!-- VTDD metadata -->
- Issue: #157
- Execution ID: local-codex-vps-runner-daemon
- Goal: open_pr
