### PR TITLE
Handle VPS Codex sandbox fallback

### DIFF
--- a/docs/butler/remote-codex-cli-executor.md
+++ b/docs/butler/remote-codex-cli-executor.md
@@ -148,6 +148,12 @@ Required runner environment:
 - Codex CLI must be authenticated on the VPS user account. If `codex exec`
   returns 401 or missing authentication, the runner reports
   `codex_auth_unavailable` back through the VPS runner event comment.
+- Optional `VTDD_VPS_RUNNER_CODEX_SANDBOX`: Codex sandbox mode. Defaults to
+  `workspace-write`.
+- Optional `VTDD_VPS_RUNNER_CODEX_SANDBOX_BYPASS=true`: uses Codex
+  `--dangerously-bypass-approvals-and-sandbox`. This is only for a trusted,
+  user-owned runner when the host cannot run Codex's bubblewrap sandbox, and it
+  must not be enabled in shared or untrusted infrastructure.
 
 Dry-run pickup check:
 

--- a/scripts/run-vps-runner.mjs
+++ b/scripts/run-vps-runner.mjs
@@ -95,7 +95,7 @@ async function executeVpsRunnerExecution({ githubFetch, token, workRoot, executi
 
     const issue = await githubFetch(`/repos/${payload.repository}/issues/${payload.issueNumber}`);
     const prompt = buildCodexExecutionPrompt({ payload, issue });
-    await runCommand("codex", ["exec", "--skip-git-repo-check", "--sandbox", "workspace-write", "-"], {
+    await runCommand("codex", buildCodexExecArgs({ env: process.env }), {
       cwd: workspace,
       env: buildCodexExecutionEnv(process.env),
       input: prompt,
@@ -296,6 +296,14 @@ function buildCodexExecutionPrompt({ payload, issue = {} }) {
 
 function classifyVpsRunnerFailure(error) {
   const reason = error instanceof Error ? error.message : String(error);
+  if (/bwrap: loopback: Failed RTM_NEWADDR|bubblewrap/i.test(reason)) {
+    return {
+      error: "codex_sandbox_unavailable",
+      reason:
+        "Codex CLI sandbox failed on the VPS. Set VTDD_VPS_RUNNER_CODEX_SANDBOX_BYPASS=true only on a trusted runner if this host cannot run bubblewrap networking.",
+      rawError: reason
+    };
+  }
   if (/401 Unauthorized|Missing bearer|authentication/i.test(reason)) {
     return {
       error: "codex_auth_unavailable",
@@ -313,6 +321,14 @@ function classifyVpsRunnerFailure(error) {
     error: "vps_runner_execution_failed",
     reason
   };
+}
+
+function buildCodexExecArgs({ env = {} } = {}) {
+  if (env.VTDD_VPS_RUNNER_CODEX_SANDBOX_BYPASS === "true") {
+    return ["exec", "--skip-git-repo-check", "--dangerously-bypass-approvals-and-sandbox", "-"];
+  }
+  const sandbox = normalizeText(env.VTDD_VPS_RUNNER_CODEX_SANDBOX) || "workspace-write";
+  return ["exec", "--skip-git-repo-check", "--sandbox", sandbox, "-"];
 }
 
 async function readRecentIssueComments({ githubFetch, repository }) {
@@ -524,6 +540,7 @@ if (import.meta.url === `file://${process.argv[1]}`) {
 
 export {
   buildCodexExecutionPrompt,
+  buildCodexExecArgs,
   buildVpsRunnerEventComment,
   classifyVpsRunnerFailure,
   parseVpsRunnerEventComment,

--- a/test/vps-runner-script.test.js
+++ b/test/vps-runner-script.test.js
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import {
   buildCodexExecutionPrompt,
+  buildCodexExecArgs,
   buildVpsRunnerEventComment,
   classifyVpsRunnerFailure,
   parseVpsRunnerEventComment,
@@ -169,6 +170,29 @@ test("VPS runner classifies unauthenticated Codex CLI as raw auth failure", () =
   assert.equal(failure.error, "codex_auth_unavailable");
   assert.equal(failure.reason, "Codex CLI is not authenticated on the VPS runner.");
   assert.equal(failure.rawError.includes("401 Unauthorized"), true);
+});
+
+test("VPS runner classifies bubblewrap sandbox failure as sandbox unavailable", () => {
+  const failure = classifyVpsRunnerFailure(new Error("bwrap: loopback: Failed RTM_NEWADDR: Operation not permitted"));
+
+  assert.equal(failure.error, "codex_sandbox_unavailable");
+  assert.equal(failure.reason.includes("VTDD_VPS_RUNNER_CODEX_SANDBOX_BYPASS=true"), true);
+});
+
+test("VPS runner Codex args require explicit opt-in for sandbox bypass", () => {
+  assert.deepEqual(buildCodexExecArgs({ env: {} }), [
+    "exec",
+    "--skip-git-repo-check",
+    "--sandbox",
+    "workspace-write",
+    "-"
+  ]);
+  assert.deepEqual(buildCodexExecArgs({ env: { VTDD_VPS_RUNNER_CODEX_SANDBOX_BYPASS: "true" } }), [
+    "exec",
+    "--skip-git-repo-check",
+    "--dangerously-bypass-approvals-and-sandbox",
+    "-"
+  ]);
 });
 
 function queueComment({ executionId, repository }) {


### PR DESCRIPTION
## This PR satisfies Intent

Partial progress for Issue #157: the VPS runner now reports Codex sandbox startup failures explicitly and supports an explicit trusted-runner fallback when the VPS host cannot run Codex's bubblewrap sandbox.

This PR does not close #157. It only addresses the live blocker observed during the VPS smoke run.

## Satisfied Success Criteria

- VPS runner raw Codex bubblewrap failures are classified as `codex_sandbox_unavailable` instead of being hidden as a generic raw failure.
- The default Codex execution path remains sandboxed with `workspace-write`.
- Sandbox bypass requires explicit `VTDD_VPS_RUNNER_CODEX_SANDBOX_BYPASS=true` and is documented as trusted, user-owned VPS only.
- Tests cover both the failure classification and the default-versus-bypass Codex arguments.

## Unsatisfied Success Criteria

- Full Butler -> VPS runner -> Codex -> PR runtime loop is not yet complete.
- Issue #190 has proven VPS pickup and GitHub branch runtime truth, but PR creation still needs retry after this fallback is merged and configured on the VPS.
- No issue closure is requested by this PR.

## Verification Evidence

- `node --test test/vps-runner-script.test.js` -> 9 passed.
- `npm test` -> 525 passed.
- Live evidence: Issue #190 retry2 created branch `codex/issue-190-vps-smoke-retry2` from the VPS runner.
- Live failure captured from the VPS runner: `bwrap: loopback: Failed RTM_NEWADDR: Operation not permitted`.
- Retry2 PR creation did not happen because Codex could not write changes under the sandbox.

## Surface Update Checklist

- Butler / Custom GPT surface: unchanged.
- Cloudflare Worker surface: unchanged.
- VPS runner surface: documented env opt-in for trusted runner sandbox bypass.
- Public/core safety: no owner-specific runtime URL, credential, token, or account identifier added.
- Credentials / permissions / deploy: unchanged.
