### PR TITLE
Add VPS runner multi-repo policy

### DIFF
--- a/docs/butler/remote-codex-cli-executor.md
+++ b/docs/butler/remote-codex-cli-executor.md
@@ -142,7 +142,30 @@ Required runner environment:
   branch push, Issue comment write, and PR creation for the allowlisted target
   repositories.
 - `VTDD_VPS_RUNNER_REPOSITORIES`: comma-separated allowlist such as
-  `owner/repo,owner/another-repo`.
+  `owner/repo,owner/another-repo`. This is the simple default form.
+- Optional `VTDD_VPS_RUNNER_CONFIG`: path to a JSON allowlist file. When set,
+  it replaces `VTDD_VPS_RUNNER_REPOSITORIES` and allows per-repository policy:
+
+  ```json
+  {
+    "repositories": {
+      "marushu/vtdd-v2-p": {
+        "enabled": true,
+        "baseRefs": ["main"],
+        "branchPrefixes": ["codex/"]
+      },
+      "marushu/tomio": {
+        "enabled": true,
+        "baseRefs": ["private"],
+        "branchPrefixes": ["codex/"]
+      }
+    }
+  }
+  ```
+
+  The runner ignores queue comments whose repository is not allowlisted, whose
+  `baseRef` is not in that repository's `baseRefs`, or whose branch does not
+  start with one of that repository's `branchPrefixes`.
 - Optional `VTDD_VPS_RUNNER_WORKDIR`: workspace root. Defaults to
   `~/vtdd-runner/workspaces`.
 - Codex CLI must be authenticated on the VPS user account. If `codex exec`

--- a/scripts/run-vps-runner.mjs
+++ b/scripts/run-vps-runner.mjs
@@ -12,7 +12,7 @@ const DEFAULT_API_BASE_URL = "https://api.github.com";
 async function main() {
   const options = parseArgs(process.argv.slice(2));
   const token = mustGetEnv("GITHUB_TOKEN", process.env.GITHUB_TOKEN || process.env.GH_TOKEN);
-  const allowedRepositories = parseCsv(mustGetEnv("VTDD_VPS_RUNNER_REPOSITORIES"));
+  const repositoryPolicies = await loadVpsRunnerRepositoryPolicies({ env: process.env });
   const workRoot = process.env.VTDD_VPS_RUNNER_WORKDIR || path.join(os.homedir(), "vtdd-runner", "workspaces");
   const githubFetch = createGitHubFetch({
     token,
@@ -22,7 +22,7 @@ async function main() {
   const result = await runVpsRunnerOnce({
     githubFetch,
     token,
-    allowedRepositories,
+    repositoryPolicies,
     workRoot,
     dryRun: options.dryRun
   });
@@ -36,11 +36,19 @@ async function main() {
   console.log(result.message);
 }
 
-async function runVpsRunnerOnce({ githubFetch, token, allowedRepositories, workRoot, dryRun = false }) {
+async function runVpsRunnerOnce({
+  githubFetch,
+  token,
+  allowedRepositories,
+  repositoryPolicies,
+  workRoot,
+  dryRun = false
+}) {
+  const policies = normalizeRepositoryPolicies({ allowedRepositories, repositoryPolicies });
   const candidates = [];
-  for (const repository of allowedRepositories) {
+  for (const repository of policies.map((policy) => policy.repository)) {
     const comments = await readRecentIssueComments({ githubFetch, repository });
-    candidates.push(...selectPendingVpsRunnerExecutions({ comments, allowedRepositories }));
+    candidates.push(...selectPendingVpsRunnerExecutions({ comments, repositoryPolicies: policies }));
   }
 
   const execution = candidates.sort((a, b) => new Date(a.createdAt) - new Date(b.createdAt))[0];
@@ -167,15 +175,15 @@ async function executeVpsRunnerExecution({ githubFetch, token, workRoot, executi
   }
 }
 
-function selectPendingVpsRunnerExecutions({ comments, allowedRepositories }) {
-  const allowed = new Set(allowedRepositories);
+function selectPendingVpsRunnerExecutions({ comments, allowedRepositories, repositoryPolicies }) {
+  const policies = normalizeRepositoryPolicies({ allowedRepositories, repositoryPolicies });
   const queues = new Map();
   const terminalEvents = new Set();
   const runningEvents = new Set();
 
   for (const comment of comments) {
     const queue = parseVpsRunnerQueueComment(comment.body);
-    if (queue.ok && allowed.has(queue.payload.repository)) {
+    if (queue.ok && validateVpsRunnerPayloadPolicy(queue.payload, policies).ok) {
       queues.set(queue.payload.executionId, {
         ...queue,
         commentId: comment.id,
@@ -200,6 +208,63 @@ function selectPendingVpsRunnerExecutions({ comments, allowedRepositories }) {
   return [...queues.values()].filter(
     (queue) => !terminalEvents.has(queue.payload.executionId) && !runningEvents.has(queue.payload.executionId)
   );
+}
+
+async function loadVpsRunnerRepositoryPolicies({ env = process.env, readFile = fs.readFile } = {}) {
+  const configPath = normalizeText(env.VTDD_VPS_RUNNER_CONFIG);
+  if (configPath) {
+    const config = JSON.parse(await readFile(configPath, "utf8"));
+    return normalizeRepositoryPolicies({ config });
+  }
+  return normalizeRepositoryPolicies({
+    allowedRepositories: parseCsv(mustGetEnv("VTDD_VPS_RUNNER_REPOSITORIES", env.VTDD_VPS_RUNNER_REPOSITORIES))
+  });
+}
+
+function normalizeRepositoryPolicies({ allowedRepositories, repositoryPolicies, config } = {}) {
+  if (Array.isArray(repositoryPolicies) && repositoryPolicies.length > 0) {
+    return repositoryPolicies.map(normalizeRepositoryPolicy).filter((policy) => policy.repository);
+  }
+
+  if (config && typeof config === "object") {
+    const repositories = Array.isArray(config.repositories)
+      ? config.repositories
+      : Object.entries(config.repositories || {}).map(([repository, policy]) => ({
+          ...(policy && typeof policy === "object" ? policy : {}),
+          repository
+        }));
+    return repositories
+      .filter((policy) => policy?.enabled !== false)
+      .map(normalizeRepositoryPolicy)
+      .filter((policy) => policy.repository);
+  }
+
+  return (allowedRepositories || []).map((repository) => normalizeRepositoryPolicy({ repository }));
+}
+
+function normalizeRepositoryPolicy(policy = {}) {
+  return {
+    repository: normalizeRepository(policy.repository),
+    baseRefs: normalizeStringList(policy.baseRefs).length > 0 ? normalizeStringList(policy.baseRefs) : ["main"],
+    branchPrefixes:
+      normalizeStringList(policy.branchPrefixes || policy.branchPrefix).length > 0
+        ? normalizeStringList(policy.branchPrefixes || policy.branchPrefix)
+        : ["codex/"]
+  };
+}
+
+function validateVpsRunnerPayloadPolicy(payload, policies) {
+  const policy = policies.find((item) => item.repository === payload.repository);
+  if (!policy) {
+    return { ok: false, reason: "repository_not_allowlisted" };
+  }
+  if (!policy.baseRefs.includes(payload.baseRef || "main")) {
+    return { ok: false, reason: "base_ref_not_allowlisted" };
+  }
+  if (!policy.branchPrefixes.some((prefix) => payload.branch.startsWith(prefix))) {
+    return { ok: false, reason: "branch_prefix_not_allowlisted" };
+  }
+  return { ok: true, policy };
 }
 
 function parseVpsRunnerQueueComment(body) {
@@ -507,6 +572,11 @@ function normalizePositiveInteger(value) {
   return Number.isInteger(number) && number > 0 ? number : 0;
 }
 
+function normalizeStringList(value) {
+  const values = Array.isArray(value) ? value : typeof value === "string" ? [value] : [];
+  return values.map(normalizeText).filter(Boolean);
+}
+
 function safePathSegment(value) {
   return String(value || "").replace(/[^A-Za-z0-9_.-]+/g, "_");
 }
@@ -543,6 +613,8 @@ export {
   buildCodexExecArgs,
   buildVpsRunnerEventComment,
   classifyVpsRunnerFailure,
+  loadVpsRunnerRepositoryPolicies,
+  normalizeRepositoryPolicies,
   parseVpsRunnerEventComment,
   parseVpsRunnerQueueComment,
   runVpsRunnerOnce,

--- a/test/vps-runner-script.test.js
+++ b/test/vps-runner-script.test.js
@@ -5,6 +5,8 @@ import {
   buildCodexExecArgs,
   buildVpsRunnerEventComment,
   classifyVpsRunnerFailure,
+  loadVpsRunnerRepositoryPolicies,
+  normalizeRepositoryPolicies,
   parseVpsRunnerEventComment,
   parseVpsRunnerQueueComment,
   runVpsRunnerOnce,
@@ -91,6 +93,89 @@ test("VPS runner selects only allowlisted pending queues", () => {
 
   assert.equal(selected.length, 1);
   assert.equal(selected[0].payload.executionId, "exec-1");
+});
+
+test("VPS runner repository policies allow per-repo base refs and branch prefixes", () => {
+  const policies = normalizeRepositoryPolicies({
+    config: {
+      repositories: {
+        "sample-org/tomio": {
+          baseRefs: ["private"],
+          branchPrefix: "codex/"
+        }
+      }
+    }
+  });
+
+  const comments = [
+    {
+      id: 1,
+      html_url: "https://github.com/sample-org/tomio/issues/7#issuecomment-1",
+      created_at: "2026-05-07T10:00:00Z",
+      body: queueComment({
+        executionId: "tomio-1",
+        repository: "sample-org/tomio",
+        issueNumber: 7,
+        branch: "codex/issue-7",
+        baseRef: "private"
+      })
+    },
+    {
+      id: 2,
+      html_url: "https://github.com/sample-org/tomio/issues/8#issuecomment-2",
+      created_at: "2026-05-07T10:01:00Z",
+      body: queueComment({
+        executionId: "tomio-2",
+        repository: "sample-org/tomio",
+        issueNumber: 8,
+        branch: "codex/issue-8",
+        baseRef: "main"
+      })
+    },
+    {
+      id: 3,
+      html_url: "https://github.com/sample-org/tomio/issues/9#issuecomment-3",
+      created_at: "2026-05-07T10:02:00Z",
+      body: queueComment({
+        executionId: "tomio-3",
+        repository: "sample-org/tomio",
+        issueNumber: 9,
+        branch: "feature/issue-9",
+        baseRef: "private"
+      })
+    }
+  ];
+
+  const selected = selectPendingVpsRunnerExecutions({ comments, repositoryPolicies: policies });
+
+  assert.equal(selected.length, 1);
+  assert.equal(selected[0].payload.executionId, "tomio-1");
+});
+
+test("VPS runner loads repository policies from config file", async () => {
+  const policies = await loadVpsRunnerRepositoryPolicies({
+    env: { VTDD_VPS_RUNNER_CONFIG: "/tmp/vtdd-runner-repos.json" },
+    readFile: async () =>
+      JSON.stringify({
+        repositories: {
+          "sample-org/vtdd-v2": {
+            baseRefs: ["main"],
+            branchPrefixes: ["codex/"]
+          },
+          "sample-org/disabled": {
+            enabled: false
+          }
+        }
+      })
+  });
+
+  assert.deepEqual(policies, [
+    {
+      repository: "sample-org/vtdd-v2",
+      baseRefs: ["main"],
+      branchPrefixes: ["codex/"]
+    }
+  ]);
 });
 
 test("VPS runner event comment is parseable by execution id", () => {
@@ -195,16 +280,22 @@ test("VPS runner Codex args require explicit opt-in for sandbox bypass", () => {
   ]);
 });
 
-function queueComment({ executionId, repository }) {
+function queueComment({
+  executionId,
+  repository,
+  issueNumber = 157,
+  branch = "codex/issue-157",
+  baseRef = "main"
+}) {
   return `<!-- vtdd:vps-runner-execution:${executionId} -->
 \`\`\`json
 {
   "executionId": "${executionId}",
   "transport": "vps_runner",
   "repository": "${repository}",
-  "issueNumber": 157,
-  "branch": "codex/issue-157",
-  "baseRef": "main",
+  "issueNumber": ${issueNumber},
+  "branch": "${branch}",
+  "baseRef": "${baseRef}",
   "codexGoal": "open_pr",
   "approvalScopeMatched": true
 }


### PR DESCRIPTION
## This PR satisfies Intent

Partial progress for Issue #157: make the VPS runner safe to reuse across multiple repositories by replacing the single CSV allowlist-only mode with an optional per-repository policy file.

This PR does not close #157. It prepares the runner for TOMIO / other repository use without actually connecting new repository credentials or executing against TOMIO.

## Satisfied Success Criteria

- VPS runner can still use the existing `VTDD_VPS_RUNNER_REPOSITORIES` CSV allowlist.
- VPS runner can load `VTDD_VPS_RUNNER_CONFIG` JSON policy files.
- Per-repository policy supports `enabled`, `baseRefs`, and `branchPrefixes`.
- Queue comments are ignored when the repository is not allowlisted.
- Queue comments are ignored when `baseRef` is not allowed for that repository.
- Queue comments are ignored when the target branch does not match an allowed branch prefix.
- Docs include a TOMIO-style `private` base branch example without adding credentials or owner-specific runtime state.

## Unsatisfied Success Criteria

- No live TOMIO execution is performed by this PR.
- No webhook receiver is added by this PR.
- No VPS production config file is installed by this PR.
- No credential, permission, repository setting, or deploy mutation is performed.

## Verification Evidence

- `node --test test/vps-runner-script.test.js` -> 11 passed.
- `npm test` -> 528 passed.
- `git diff --check` -> passed.

## Surface Update Checklist

- Butler / Custom GPT surface: unchanged.
- Worker API contract: unchanged.
- VPS runner surface: adds optional `VTDD_VPS_RUNNER_CONFIG` policy file support while preserving `VTDD_VPS_RUNNER_REPOSITORIES`.
- Public/core safety: no owner-specific runtime URL, credential, token, or account identifier added.
- Credentials / permissions / deploy: unchanged.
