### PR TITLE
Document private repo VPS Actions boundary

### DIFF
--- a/docs/butler/remote-codex-cli-executor.md
+++ b/docs/butler/remote-codex-cli-executor.md
@@ -130,6 +130,46 @@ not require a public inbound VPS API:
   branch/PR evidence appears after the grace period, progress becomes blocked
   with `vps_runner_pickup_not_observed`
 
+### Private Repository Actions-Minimization Mode
+
+For private repositories such as TOMIO, the preferred low-Actions-consumption
+shape is:
+
+- use `vps_runner` for Codex implementation, branch push, and PR creation
+- keep GitHub Actions only for bounded PR gates that still need to run on
+  GitHub, such as required tests, guarded PR-body policy, and reviewer
+  writeback
+- do not use `remote-codex-executor.yml` for normal private-repository Codex
+  implementation work once the trusted VPS runner is configured
+- do not silently switch to `api_key_runner` as a workaround for private
+  Actions minutes
+
+This means VPS migration reduces the Actions minutes spent on Codex execution,
+fresh checkout, Node setup, Codex install/auth, and PR creation inside a
+GitHub-hosted runner. It does not eliminate Actions minutes for workflows that
+remain GitHub-hosted by design, including PR checks, Gemini review, deploy
+dispatches, or any repository-specific CI configured on the target repository.
+
+For TOMIO's private branch model, configure the repository policy with the
+private base branch explicitly:
+
+```json
+{
+  "repositories": {
+    "marushu/tomio": {
+      "enabled": true,
+      "baseRefs": ["private"],
+      "branchPrefixes": ["codex/"]
+    }
+  }
+}
+```
+
+Butler-facing guidance must describe this as "Codex implementation moved off
+GitHub-hosted Actions" rather than "Actions cost is zero." If a private
+repository still runs PR checks or reviewer workflows on GitHub-hosted runners,
+those minutes remain visible GitHub Actions usage.
+
 The public/core repository includes a minimal user-owned runner entrypoint at
 `scripts/run-vps-runner.mjs`. It can poll the GitHub queue contract, report
 runner events, create the target branch, run Codex CLI in a cloned workspace,

--- a/test/cost-account-boundary.test.js
+++ b/test/cost-account-boundary.test.js
@@ -34,6 +34,21 @@ test("remote Codex docs keep API-backed runner optional", () => {
   assert.equal(doc.includes("Do not present it as the only VTDD remote executor path."), true);
 });
 
+test("remote Codex docs define private repository VPS Actions-minimization boundary", () => {
+  const doc = read("docs/butler/remote-codex-cli-executor.md");
+
+  assert.equal(doc.includes("Private Repository Actions-Minimization Mode"), true);
+  assert.equal(doc.includes("use `vps_runner` for Codex implementation, branch push, and PR creation"), true);
+  assert.equal(
+    doc.includes("do not use `remote-codex-executor.yml` for normal private-repository Codex"),
+    true
+  );
+  assert.equal(doc.includes("does not eliminate Actions minutes"), true);
+  assert.equal(doc.includes('"baseRefs": ["private"]'), true);
+  assert.equal(doc.includes("Codex implementation moved off\nGitHub-hosted Actions"), true);
+  assert.equal(doc.includes("Actions cost is zero"), true);
+});
+
 test("reviewer policy requires explicit cost/account choice for API-key reviewers", () => {
   const doc = read("docs/security/reviewer-policy.md");
 


### PR DESCRIPTION
## This PR satisfies Intent

Partial progress for Issue #157: define how private repositories should use the VPS runner to minimize GitHub Actions consumption without overclaiming that Actions usage becomes zero.

This PR does not close #157. It records the private-repository cost/account boundary after the VPS runner and multi-repo allowlist path were proven.

## Satisfied Success Criteria

- Documents `vps_runner` as the preferred private-repository Codex implementation path once the trusted VPS is configured.
- Clarifies that `remote-codex-executor.yml` should not be the normal private-repository Codex implementation path after VPS migration.
- Clarifies that VPS migration reduces Actions minutes for Codex execution, checkout/setup/install/auth, branch push, and PR creation inside GitHub-hosted runners.
- Clarifies that PR checks, Gemini review, deploy dispatches, and repository CI may still consume GitHub Actions minutes.
- Documents TOMIO's private base-branch model as an explicit `baseRefs: ["private"]` repository policy example.
- Adds a cost-boundary test so the docs do not regress into "Actions cost is zero" overclaiming.

## Unsatisfied Success Criteria

- No live TOMIO execution is performed by this PR.
- No VPS production config is installed by this PR.
- No webhook receiver is added by this PR.
- No GitHub Actions workflow is removed or disabled by this PR.
- No credential, permission, repository setting, or deploy mutation is performed.

## Verification Evidence

- `node --test test/cost-account-boundary.test.js` -> 4 passed.
- `npm test` -> 529 passed.
- `git diff --check` -> passed.

## Surface Update Checklist

- Butler / Custom GPT surface: unchanged.
- Worker API contract: unchanged.
- VPS runner surface: unchanged; docs clarify private-repository operating mode.
- Public/core safety: no owner-specific runtime URL, credential, token, or account identifier added.
- Credentials / permissions / deploy: unchanged.
