### PR TITLE
Generalize private repo policy example

### DIFF
--- a/docs/butler/remote-codex-cli-executor.md
+++ b/docs/butler/remote-codex-cli-executor.md
@@ -150,13 +150,13 @@ GitHub-hosted runner. It does not eliminate Actions minutes for workflows that
 remain GitHub-hosted by design, including PR checks, Gemini review, deploy
 dispatches, or any repository-specific CI configured on the target repository.
 
-For TOMIO's private branch model, configure the repository policy with the
-private base branch explicitly:
+For a private-branch target repository, configure the repository policy with
+the private base branch explicitly:
 
 ```json
 {
   "repositories": {
-    "marushu/tomio": {
+    "owner/private-repo": {
       "enabled": true,
       "baseRefs": ["private"],
       "branchPrefixes": ["codex/"]
@@ -194,7 +194,7 @@ Required runner environment:
         "baseRefs": ["main"],
         "branchPrefixes": ["codex/"]
       },
-      "marushu/tomio": {
+      "owner/private-repo": {
         "enabled": true,
         "baseRefs": ["private"],
         "branchPrefixes": ["codex/"]

--- a/test/cost-account-boundary.test.js
+++ b/test/cost-account-boundary.test.js
@@ -45,6 +45,9 @@ test("remote Codex docs define private repository VPS Actions-minimization bound
   );
   assert.equal(doc.includes("does not eliminate Actions minutes"), true);
   assert.equal(doc.includes('"baseRefs": ["private"]'), true);
+  assert.equal(doc.includes("owner/private-repo"), true);
+  assert.equal(doc.includes("marushu/tomio"), false);
+  assert.equal(doc.includes("marushu/hibou-piccola-bookkeeping"), false);
   assert.equal(doc.includes("Codex implementation moved off\nGitHub-hosted Actions"), true);
   assert.equal(doc.includes("Actions cost is zero"), true);
 });


### PR DESCRIPTION
## This PR satisfies Intent

Follow-up to PR #197: keep the public/core private-repository VPS policy example generic now that TOMIO's actual repository name has been clarified separately.

## Satisfied Success Criteria

- Replaces the mistaken `marushu/tomio` example with `owner/private-repo`.
- Keeps the private `baseRefs: ["private"]` guidance intact.
- Adds regression checks that neither `marushu/tomio` nor the actual TOMIO repository name is embedded in public docs.
- Preserves the private-repository Actions-minimization boundary from PR #197.

## Unsatisfied Success Criteria

- No VPS production config is installed by this PR.
- No live TOMIO execution is performed by this PR.
- No credential, permission, repository setting, or deploy mutation is performed.

## Verification Evidence

- `node --test test/cost-account-boundary.test.js` -> 4 passed.
- `npm test` -> 529 passed.
- `git diff --check` -> passed.

## Surface Update Checklist

- Butler / Custom GPT surface: unchanged.
- Worker API contract: unchanged.
- VPS runner surface: unchanged.
- Public/core safety: removes a mistaken concrete private repository example from docs.
- Credentials / permissions / deploy: unchanged.
