### PR TITLE
Add VPS runner repository helper

### DIFF
--- a/docs/butler/remote-codex-cli-executor.md
+++ b/docs/butler/remote-codex-cli-executor.md
@@ -132,7 +132,7 @@ not require a public inbound VPS API:
 
 ### Private Repository Actions-Minimization Mode
 
-For private repositories such as TOMIO, the preferred low-Actions-consumption
+For private repositories, the preferred low-Actions-consumption
 shape is:
 
 - use `vps_runner` for Codex implementation, branch push, and PR creation
@@ -150,13 +150,13 @@ GitHub-hosted runner. It does not eliminate Actions minutes for workflows that
 remain GitHub-hosted by design, including PR checks, Gemini review, deploy
 dispatches, or any repository-specific CI configured on the target repository.
 
-For TOMIO's private branch model, configure the repository policy with the
-private base branch explicitly:
+For a private-branch target repository, configure the repository policy with
+the private base branch explicitly:
 
 ```json
 {
   "repositories": {
-    "marushu/tomio": {
+    "owner/private-repo": {
       "enabled": true,
       "baseRefs": ["private"],
       "branchPrefixes": ["codex/"]
@@ -194,7 +194,7 @@ Required runner environment:
         "baseRefs": ["main"],
         "branchPrefixes": ["codex/"]
       },
-      "marushu/tomio": {
+      "owner/private-repo": {
         "enabled": true,
         "baseRefs": ["private"],
         "branchPrefixes": ["codex/"]
@@ -206,6 +206,23 @@ Required runner environment:
   The runner ignores queue comments whose repository is not allowlisted, whose
   `baseRef` is not in that repository's `baseRefs`, or whose branch does not
   start with one of that repository's `branchPrefixes`.
+- Optional `scripts/vtdd-runner-repo.mjs`: operator helper for maintaining the
+  JSON allowlist. Butler owns nickname resolution; this helper accepts only the
+  resolved canonical `owner/repo` so the VPS does not duplicate nickname memory.
+  `add` and `check` verify GitHub runtime truth through `gh repo view`, including
+  current visibility and default branch, but visibility is not persisted as
+  policy because repositories may move between private and public:
+
+  ```bash
+  node scripts/vtdd-runner-repo.mjs add owner/private-repo --base private --branch-prefix codex/
+  node scripts/vtdd-runner-repo.mjs check owner/private-repo
+  node scripts/vtdd-runner-repo.mjs list
+  ```
+
+  The normal Butler path should remain natural-language first: Butler resolves
+  a nickname such as `TOMIO` to a canonical repository, the Worker writes a
+  bounded VPS runner queue request for that repository, and the VPS runner
+  executes only if the resolved repository is allowlisted.
 - Optional `VTDD_VPS_RUNNER_WORKDIR`: workspace root. Defaults to
   `~/vtdd-runner/workspaces`.
 - Codex CLI must be authenticated on the VPS user account. If `codex exec`

--- a/scripts/vtdd-runner-repo.mjs
+++ b/scripts/vtdd-runner-repo.mjs
@@ -1,0 +1,379 @@
+#!/usr/bin/env node
+
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const DEFAULT_CONFIG_PATH = "~/vtdd-runner/config/repos.json";
+
+async function main() {
+  const command = process.argv[2];
+  const args = process.argv.slice(3);
+
+  try {
+    if (command === "add") {
+      const options = parseRepoCommandArgs(args);
+      const repoTruth = options.verify
+        ? await readGitHubRepositoryTruth({ repository: options.repository })
+        : null;
+      const configPath = resolveConfigPath(options.configPath);
+      const config = await readRunnerRepoConfig(configPath);
+      const nextConfig = addRunnerRepositoryPolicy(config, {
+        repository: options.repository,
+        baseRefs: options.baseRefs,
+        branchPrefixes: options.branchPrefixes
+      });
+      await writeRunnerRepoConfig(configPath, nextConfig);
+      console.log(formatAddResult({ repository: options.repository, repoTruth, configPath }));
+      return;
+    }
+
+    if (command === "check") {
+      const options = parseRepoCommandArgs(args, { requirePolicyOptions: false });
+      const repoTruth = await readGitHubRepositoryTruth({ repository: options.repository });
+      const configPath = resolveConfigPath(options.configPath);
+      const config = await readRunnerRepoConfig(configPath);
+      console.log(formatCheckResult({ repository: options.repository, repoTruth, config, configPath }));
+      return;
+    }
+
+    if (command === "list") {
+      const options = parseListArgs(args);
+      const configPath = resolveConfigPath(options.configPath);
+      const config = await readRunnerRepoConfig(configPath);
+      console.log(formatRunnerRepositoryList({ config, configPath }));
+      return;
+    }
+
+    if (command === "remove") {
+      const options = parseRepoCommandArgs(args, { requirePolicyOptions: false, verifyDefault: false });
+      const configPath = resolveConfigPath(options.configPath);
+      const config = await readRunnerRepoConfig(configPath);
+      const nextConfig = removeRunnerRepositoryPolicy(config, options.repository);
+      await writeRunnerRepoConfig(configPath, nextConfig);
+      console.log(`Removed ${options.repository} from ${configPath}`);
+      return;
+    }
+
+    printUsage();
+    process.exitCode = command ? 1 : 0;
+  } catch (error) {
+    console.error(error?.message || String(error));
+    process.exitCode = 1;
+  }
+}
+
+function parseRepoCommandArgs(args, { requirePolicyOptions = true, verifyDefault = true } = {}) {
+  const positional = [];
+  const options = {
+    configPath: process.env.VTDD_VPS_RUNNER_CONFIG,
+    baseRefs: [],
+    branchPrefixes: [],
+    verify: verifyDefault
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--config") {
+      options.configPath = mustReadOptionValue(args, ++index, "--config");
+      continue;
+    }
+    if (arg === "--base") {
+      options.baseRefs.push(...normalizeStringList(mustReadOptionValue(args, ++index, "--base")));
+      continue;
+    }
+    if (arg === "--branch-prefix") {
+      options.branchPrefixes.push(...normalizeStringList(mustReadOptionValue(args, ++index, "--branch-prefix")));
+      continue;
+    }
+    if (arg === "--no-verify") {
+      options.verify = false;
+      continue;
+    }
+    if (arg.startsWith("-")) {
+      throw new Error(`Unknown option: ${arg}`);
+    }
+    positional.push(arg);
+  }
+
+  const repository = normalizeRepository(positional[0]);
+  if (!repository) {
+    throw new Error("Repository is required as owner/repo.");
+  }
+  if (positional.length > 1) {
+    throw new Error(`Unexpected arguments: ${positional.slice(1).join(" ")}`);
+  }
+
+  if (requirePolicyOptions) {
+    options.baseRefs = options.baseRefs.length > 0 ? dedupe(options.baseRefs) : ["main"];
+    options.branchPrefixes = options.branchPrefixes.length > 0 ? dedupe(options.branchPrefixes) : ["codex/"];
+  }
+
+  return {
+    ...options,
+    repository
+  };
+}
+
+function parseListArgs(args) {
+  const options = { configPath: process.env.VTDD_VPS_RUNNER_CONFIG };
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--config") {
+      options.configPath = mustReadOptionValue(args, ++index, "--config");
+      continue;
+    }
+    throw new Error(`Unknown option: ${arg}`);
+  }
+  return options;
+}
+
+function mustReadOptionValue(args, index, optionName) {
+  const value = args[index];
+  if (!value || value.startsWith("-")) {
+    throw new Error(`${optionName} requires a value.`);
+  }
+  return value;
+}
+
+async function readGitHubRepositoryTruth({ repository, runCommand = runCommandJson } = {}) {
+  const normalized = normalizeRepository(repository);
+  if (!normalized) {
+    throw new Error("Repository is required as owner/repo.");
+  }
+  const result = await runCommand("gh", [
+    "repo",
+    "view",
+    normalized,
+    "--json",
+    "nameWithOwner,visibility,isPrivate,defaultBranchRef"
+  ]);
+  return normalizeRepositoryTruth(result);
+}
+
+function normalizeRepositoryTruth(input = {}) {
+  const repository = normalizeRepository(input.nameWithOwner || input.repository);
+  const defaultBranch =
+    typeof input.defaultBranchRef === "string"
+      ? input.defaultBranchRef
+      : normalizeText(input.defaultBranchRef?.name);
+  const visibility = normalizeText(input.visibility).toLowerCase();
+  return {
+    repository,
+    visibility: visibility || (input.isPrivate ? "private" : "unknown"),
+    isPrivate: Boolean(input.isPrivate || visibility === "private"),
+    defaultBranch: defaultBranch || null
+  };
+}
+
+async function readRunnerRepoConfig(configPath) {
+  try {
+    const raw = await fs.readFile(configPath, "utf8");
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      throw new Error("config root must be an object");
+    }
+    return parsed;
+  } catch (error) {
+    if (error?.code === "ENOENT") {
+      return { repositories: {} };
+    }
+    throw new Error(`Failed to read ${configPath}: ${error.message}`);
+  }
+}
+
+async function writeRunnerRepoConfig(configPath, config) {
+  await fs.mkdir(path.dirname(configPath), { recursive: true });
+  const body = `${JSON.stringify(sortRunnerRepoConfig(config), null, 2)}\n`;
+  const tempPath = `${configPath}.${process.pid}.tmp`;
+  await fs.writeFile(tempPath, body, { mode: 0o600 });
+  await fs.rename(tempPath, configPath);
+}
+
+function addRunnerRepositoryPolicy(config, policy) {
+  const repository = normalizeRepository(policy.repository);
+  if (!repository) {
+    throw new Error("Repository is required as owner/repo.");
+  }
+  return {
+    ...config,
+    repositories: {
+      ...normalizeConfigRepositories(config.repositories),
+      [repository]: {
+        enabled: true,
+        baseRefs: normalizeStringList(policy.baseRefs).length > 0 ? normalizeStringList(policy.baseRefs) : ["main"],
+        branchPrefixes:
+          normalizeStringList(policy.branchPrefixes).length > 0 ? normalizeStringList(policy.branchPrefixes) : ["codex/"]
+      }
+    }
+  };
+}
+
+function removeRunnerRepositoryPolicy(config, repositoryInput) {
+  const repository = normalizeRepository(repositoryInput);
+  const repositories = normalizeConfigRepositories(config.repositories);
+  delete repositories[repository];
+  return {
+    ...config,
+    repositories
+  };
+}
+
+function formatAddResult({ repository, repoTruth, configPath }) {
+  const lines = [`Added ${repository} to ${configPath}`];
+  if (repoTruth) {
+    lines.push(`GitHub truth: ${repoTruth.visibility}, default branch ${repoTruth.defaultBranch || "unknown"}`);
+  }
+  lines.push("Restart the user timer after installing this config on the VPS.");
+  return lines.join("\n");
+}
+
+function formatCheckResult({ repository, repoTruth, config, configPath }) {
+  const policy = normalizeConfigRepositories(config.repositories)[repository];
+  const lines = [
+    `Repository: ${repository}`,
+    `GitHub truth: ${repoTruth.visibility}, default branch ${repoTruth.defaultBranch || "unknown"}`,
+    `Config: ${configPath}`,
+    policy
+      ? `Runner policy: enabled=${policy.enabled !== false}, baseRefs=${normalizeStringList(policy.baseRefs).join(",")}, branchPrefixes=${normalizeStringList(policy.branchPrefixes || policy.branchPrefix).join(",")}`
+      : "Runner policy: not allowlisted"
+  ];
+  return lines.join("\n");
+}
+
+function formatRunnerRepositoryList({ config, configPath }) {
+  const repositories = normalizeConfigRepositories(config.repositories);
+  const names = Object.keys(repositories).sort();
+  if (names.length === 0) {
+    return `No runner repositories configured in ${configPath}`;
+  }
+  return [
+    `Runner repositories in ${configPath}:`,
+    ...names.map((repository) => {
+      const policy = repositories[repository];
+      return `- ${repository} baseRefs=${normalizeStringList(policy.baseRefs).join(",")} branchPrefixes=${normalizeStringList(policy.branchPrefixes || policy.branchPrefix).join(",")}`;
+    })
+  ].join("\n");
+}
+
+function sortRunnerRepoConfig(config) {
+  const repositories = normalizeConfigRepositories(config.repositories);
+  return {
+    ...config,
+    repositories: Object.fromEntries(Object.entries(repositories).sort(([left], [right]) => left.localeCompare(right)))
+  };
+}
+
+function normalizeConfigRepositories(repositories) {
+  if (Array.isArray(repositories)) {
+    return Object.fromEntries(
+      repositories
+        .map((policy) => [normalizeRepository(policy?.repository), policy])
+        .filter(([repository]) => repository)
+    );
+  }
+  if (!repositories || typeof repositories !== "object") {
+    return {};
+  }
+  return Object.fromEntries(
+    Object.entries(repositories)
+      .map(([repository, policy]) => [
+        normalizeRepository(repository),
+        policy && typeof policy === "object" ? policy : { enabled: true }
+      ])
+      .filter(([repository]) => repository)
+  );
+}
+
+function resolveConfigPath(configPath = process.env.VTDD_VPS_RUNNER_CONFIG || DEFAULT_CONFIG_PATH) {
+  const normalized = normalizeText(configPath) || DEFAULT_CONFIG_PATH;
+  if (normalized === "~") {
+    return os.homedir();
+  }
+  if (normalized.startsWith("~/")) {
+    return path.join(os.homedir(), normalized.slice(2));
+  }
+  return path.resolve(normalized);
+}
+
+async function runCommandJson(command, args) {
+  const result = await runCommand(command, args);
+  try {
+    return JSON.parse(result.stdout);
+  } catch (error) {
+    throw new Error(`${command} ${args.join(" ")} returned invalid JSON: ${error.message}`);
+  }
+}
+
+function runCommand(command, args) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { stdio: ["ignore", "pipe", "pipe"] });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code === 0) {
+        resolve({ stdout, stderr });
+        return;
+      }
+      reject(new Error(`${command} ${args.join(" ")} failed with exit code ${code}: ${stderr.trim()}`));
+    });
+  });
+}
+
+function normalizeRepository(input) {
+  const value = normalizeText(input).replace(/^https:\/\/github\.com\//, "").replace(/\.git$/, "");
+  if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(value)) {
+    return "";
+  }
+  const [owner, repo] = value.split("/");
+  return `${owner}/${repo}`;
+}
+
+function normalizeStringList(input) {
+  const values = Array.isArray(input) ? input : String(input || "").split(",");
+  return dedupe(values.map(normalizeText).filter(Boolean));
+}
+
+function dedupe(values) {
+  return [...new Set(values)];
+}
+
+function normalizeText(input) {
+  return String(input || "").trim();
+}
+
+function printUsage() {
+  console.log(`Usage:
+  vtdd-runner-repo add <owner/repo> [--config path] [--base main] [--branch-prefix codex/] [--no-verify]
+  vtdd-runner-repo check <owner/repo> [--config path]
+  vtdd-runner-repo list [--config path]
+  vtdd-runner-repo remove <owner/repo> [--config path]
+
+Butler owns nickname resolution. This helper accepts the resolved canonical owner/repo only.`);
+}
+
+const isCli = process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1]);
+
+if (isCli) {
+  await main();
+}
+
+export {
+  addRunnerRepositoryPolicy,
+  formatCheckResult,
+  formatRunnerRepositoryList,
+  normalizeRepository,
+  normalizeRepositoryTruth,
+  readGitHubRepositoryTruth,
+  removeRunnerRepositoryPolicy,
+  resolveConfigPath
+};

--- a/test/vps-runner-repo-helper.test.js
+++ b/test/vps-runner-repo-helper.test.js
@@ -1,0 +1,107 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  addRunnerRepositoryPolicy,
+  formatCheckResult,
+  formatRunnerRepositoryList,
+  normalizeRepository,
+  normalizeRepositoryTruth,
+  removeRunnerRepositoryPolicy,
+  resolveConfigPath
+} from "../scripts/vtdd-runner-repo.mjs";
+
+test("runner repo helper normalizes canonical repository input without nickname memory", () => {
+  assert.equal(normalizeRepository("sample-org/private-repo"), "sample-org/private-repo");
+  assert.equal(normalizeRepository("https://github.com/sample-org/private-repo.git"), "sample-org/private-repo");
+  assert.equal(normalizeRepository("TOMIO"), "");
+});
+
+test("runner repo helper stores allowlist policy without persisting visibility", () => {
+  const config = addRunnerRepositoryPolicy(
+    { repositories: {} },
+    {
+      repository: "sample-org/private-repo",
+      baseRefs: ["private"],
+      branchPrefixes: ["codex/"]
+    }
+  );
+
+  assert.deepEqual(config, {
+    repositories: {
+      "sample-org/private-repo": {
+        enabled: true,
+        baseRefs: ["private"],
+        branchPrefixes: ["codex/"]
+      }
+    }
+  });
+  assert.equal(JSON.stringify(config).includes("visibility"), false);
+  assert.equal(JSON.stringify(config).includes("isPrivate"), false);
+});
+
+test("runner repo helper normalizes GitHub visibility as runtime truth", () => {
+  assert.deepEqual(
+    normalizeRepositoryTruth({
+      nameWithOwner: "sample-org/private-repo",
+      visibility: "PRIVATE",
+      isPrivate: true,
+      defaultBranchRef: { name: "private" }
+    }),
+    {
+      repository: "sample-org/private-repo",
+      visibility: "private",
+      isPrivate: true,
+      defaultBranch: "private"
+    }
+  );
+});
+
+test("runner repo helper formats check result with live visibility separate from policy", () => {
+  const config = addRunnerRepositoryPolicy(
+    { repositories: {} },
+    {
+      repository: "sample-org/private-repo",
+      baseRefs: ["private"],
+      branchPrefixes: ["codex/"]
+    }
+  );
+  const result = formatCheckResult({
+    repository: "sample-org/private-repo",
+    repoTruth: {
+      repository: "sample-org/private-repo",
+      visibility: "public",
+      defaultBranch: "main"
+    },
+    config,
+    configPath: "/home/vtdd-runner/vtdd-runner/config/repos.json"
+  });
+
+  assert.equal(result.includes("GitHub truth: public, default branch main"), true);
+  assert.equal(result.includes("Runner policy: enabled=true, baseRefs=private, branchPrefixes=codex/"), true);
+});
+
+test("runner repo helper lists and removes configured repositories", () => {
+  const config = addRunnerRepositoryPolicy(
+    { repositories: {} },
+    {
+      repository: "sample-org/private-repo",
+      baseRefs: ["private"],
+      branchPrefixes: ["codex/"]
+    }
+  );
+
+  assert.equal(
+    formatRunnerRepositoryList({ config, configPath: "/tmp/repos.json" }).includes(
+      "- sample-org/private-repo baseRefs=private branchPrefixes=codex/"
+    ),
+    true
+  );
+  assert.deepEqual(removeRunnerRepositoryPolicy(config, "sample-org/private-repo"), {
+    repositories: {}
+  });
+});
+
+test("runner repo helper resolves default VPS config path", () => {
+  assert.equal(resolveConfigPath("/tmp/repos.json"), "/tmp/repos.json");
+  assert.equal(resolveConfigPath("~/vtdd-runner/config/repos.json").endsWith("/vtdd-runner/config/repos.json"), true);
+});


### PR DESCRIPTION
## This PR satisfies Intent

Issue #157 VPS runner operations need a reusable way to maintain repository allowlist policy without duplicating Butler nickname memory or hardcoding public/private visibility.

## Satisfied Success Criteria

- [x] Adds a VPS-side helper for adding, checking, listing, and removing resolved canonical `owner/repo` runner policies.
- [x] Keeps Butler as the owner of nickname resolution; the helper rejects nickname-only input and accepts canonical repositories only.
- [x] Checks GitHub runtime truth for current visibility/default branch through `gh repo view` while keeping visibility out of persisted policy.
- [x] Documents that normal Butler usage remains natural-language first and that VPS execution only proceeds after the resolved repo is allowlisted.

## Unsatisfied Success Criteria

None.

## Non-goal violations

None.

## Verification Evidence

- Unit: `node --test test/vps-runner-repo-helper.test.js test/vps-runner-script.test.js`
- Integration: `npm test`
- E2E: Not run; this PR adds repo-side helper/docs/tests only and does not mutate the live VPS.
- Manual: `node scripts/vtdd-runner-repo.mjs list --config /tmp/vtdd-runner-test-repos.json`; `node scripts/vtdd-runner-repo.mjs add sample-org/private-repo --config /tmp/vtdd-runner-test-repos.json --base private --branch-prefix codex/ --no-verify && node scripts/vtdd-runner-repo.mjs list --config /tmp/vtdd-runner-test-repos.json`
- Evidence path/link: `scripts/vtdd-runner-repo.mjs`, `test/vps-runner-repo-helper.test.js`, `docs/butler/remote-codex-cli-executor.md`

## Surface Update Checklist

- Cloudflare deploy: Not touched.
- Custom GPT Action Schema update: Not touched.
- Custom GPT Instructions update: Not touched.
- iPhone Butler live E2E: Not run; live VPS configuration is a separate `GO + passkey` operation.

## Related Constitution Rules

- Runtime truth remains GitHub-backed; visibility is read from GitHub rather than stored as policy.
- Butler owns nickname resolution; unresolved or ambiguous repository targets must not execute.
- Credential/permission mutation and live VPS configuration remain out of scope without `GO + passkey`.

## Out-of-scope but NOT implemented

- Live VPS config mutation.
- Butler-to-VPS admin command queue.
- Raw SSH execution from Butler/Worker.
- TOMIO/private repository live smoke.
- Webhook/push trigger replacement for the timer.

## Extra changes (if any)

None.
