### PR TITLE
Make VPS runner PR bodies pass guardrails

### DIFF
--- a/docs/butler/gemini-pr-review-comments.md
+++ b/docs/butler/gemini-pr-review-comments.md
@@ -34,15 +34,15 @@ must not hard-fail the PR solely for reviewer availability reasons.
 Preferred fallback:
 
 - VTDD posts or updates a `vtdd:reviewer=codex-fallback` request comment that
-  contains an `@codex review` request for Codex Cloud
+  targets the user-owned VPS Codex CLI reviewer transport
 - the default request path does not use `OPENAI_API_KEY`
-- the request remains request-state until Codex returns a completed fallback
+- the request remains request-state until the VPS reviewer runner returns a completed fallback
   reviewer marker with a recommended action
 
 When Gemini is temporarily unavailable, a completed
 `vtdd:reviewer=codex-fallback` marker comment with a recommended action is
 valid fallback reviewer evidence only when it is written by a trusted
-VTDD-controlled actor or by the Codex Cloud reviewer result path. Butler must
+VTDD-controlled actor or by an explicitly configured Codex Cloud reviewer result path. Butler must
 not treat the absence of GitHub Review API objects alone as absence of reviewer
 evidence, but it must not trust spoofable marker comments from untrusted
 authors.
@@ -50,18 +50,19 @@ authors.
 Current limitation:
 
 - a VTDD bot-authored `@codex review` request proves only that fallback was
-  requested; it is not completed reviewer evidence by itself
+  requested when the legacy Codex Cloud comment path is selected; it is not completed reviewer evidence by itself
 - a `chatgpt-codex-connector` response that asks the operator to create/connect
   a Codex account is a fallback blocker (`codex_connector_not_configured`), not
   reviewer progress
-- if Codex Cloud does not pick up the request, VTDD must keep the fallback state
+- if the selected Codex reviewer transport does not pick up the request, VTDD must keep the fallback state
   as requested or blocked rather than pretending review completed
 
 ## Operator Prerequisite
 
 For the default non-manual Codex fallback to reach a `completed` reviewer
-state, the operator-owned Codex Cloud / ChatGPT GitHub integration must pick up
-the PR comment request and return reviewer output.
+state, the user-owned VPS runner must be configured with an authenticated Codex
+CLI session and allowed repository policy. This avoids depending on the
+ChatGPT/Codex GitHub connector for the default path.
 
 Optional API-backed runner:
 

--- a/docs/mvp/e2e/e2e-27-no-manual-codex-reviewer-fallback.md
+++ b/docs/mvp/e2e/e2e-27-no-manual-codex-reviewer-fallback.md
@@ -59,21 +59,24 @@ This confirms the main-branch fallback receiver can execute the non-manual
 Codex reviewer path and write delivered reviewer evidence back to GitHub after
 Gemini dispatches a fallback request.
 
-## Default No-API-Key Request Path
+## Default VPS No-API-Key Request Path
 
-Observed correction on 2026-04-30:
+Observed correction on 2026-05-08:
 
 - Gemini temporary unavailability now posts or updates a
   `vtdd:reviewer=codex-fallback` request comment using
-  `deliveryMode=codex_cloud_github_comment`
-- this default request path includes `@codex review`
+  `deliveryMode=vps_codex_cli`
+- this default request path is picked up by the user-owned VPS runner, which
+  runs the critique-only Codex CLI fallback script and writes a completed or
+  blocked marker back to GitHub
 - this default request path does not require `OPENAI_API_KEY`
-- the request remains request-state until Codex Cloud returns a completed
+- the request remains request-state until the VPS runner returns a completed
   fallback reviewer marker with a recommended action
 
 This keeps the default reviewer fallback aligned with the operator-owned
-ChatGPT/Codex subscription surface. It does not claim that a bot-authored
-request has already produced completed reviewer evidence.
+ChatGPT/Codex subscription surface through the authenticated VPS Codex CLI. It
+does not claim that a requested marker has already produced completed reviewer
+evidence.
 
 ## PR Runtime Verification Boundary
 
@@ -91,10 +94,10 @@ Observed on PR `#154` before this transport correction reached `main`:
 Interpretation rule:
 
 - local/test evidence may prove that Gemini fallback will request
-  `deliveryMode=codex_cloud_github_comment` after merge
+  `deliveryMode=vps_codex_cli` after merge
 - PR-level live fallback evidence remains incomplete until a later PR, running
-  against the updated `main`, produces either a Codex Cloud request-state
-  comment or a completed fallback reviewer marker from that path
+  against the updated `main`, produces either a VPS request-state comment or a
+  completed fallback reviewer marker from that path
 
 ## Evidence Files
 
@@ -118,7 +121,7 @@ Interpretation rule:
 E2E-27 now has recorded happy-path and boundary-path run evidence in-repo.
 
 This confirms Issue `#84` is connected to a VTDD-managed no-manual reviewer
-fallback design: when Gemini is unavailable, VTDD can request Codex Cloud
+fallback design: when Gemini is unavailable, VTDD can request VPS Codex CLI
 review through GitHub comment transport by default, or explicitly use an
 API-backed workflow only when that cost/account path is selected. It does not
 claim live provider pickup or credentials are configured in every operator
@@ -126,8 +129,9 @@ repository by default.
 
 Operator prerequisite for default live `completed` state:
 
-- configure and authorize the operator-owned Codex Cloud / ChatGPT GitHub
-  integration so it can pick up the `@codex review` request and return critique
+- configure the user-owned VPS runner with an authenticated Codex CLI session
+  and an allowlisted target repository so it can pick up the
+  `deliveryMode=vps_codex_cli` request and return critique
   output
 
 Optional API-backed runner prerequisite:

--- a/scripts/run-codex-pr-review-fallback.mjs
+++ b/scripts/run-codex-pr-review-fallback.mjs
@@ -12,27 +12,10 @@ async function main() {
   const trigger = mustGetEnv("CODEX_FALLBACK_TRIGGER");
   const reason = mustGetEnv("CODEX_FALLBACK_REASON");
   const githubToken = mustGetEnv("GITHUB_TOKEN");
+  const deliveryMode = process.env.CODEX_FALLBACK_DELIVERY_MODE || "workflow_dispatch_codex_cli";
 
   const apiBaseUrl = process.env.GITHUB_API_URL || "https://api.github.com";
   const githubFetch = createGitHubFetch({ apiBaseUrl, token: githubToken });
-
-  if (!process.env.OPENAI_API_KEY) {
-    await upsertCodexFallbackComment({
-      githubFetch,
-      repository,
-      prNumber,
-      body: formatCodexReviewFallbackComment({
-        status: "blocked",
-        trigger,
-        reason,
-        deliveryMode: "workflow_dispatch_codex_cli",
-        blocker: "openai_api_key_not_configured",
-        rawReview: "OPENAI_API_KEY is required for non-manual Codex fallback review."
-      })
-    });
-    console.log(`Recorded Codex fallback blocker state on PR #${prNumber}.`);
-    return;
-  }
 
   const pullRequest = await githubFetch(`/repos/${repository}/pulls/${prNumber}`);
   const files = await githubFetchAll(githubFetch, `/repos/${repository}/pulls/${prNumber}/files?per_page=100`);
@@ -70,7 +53,7 @@ async function main() {
         status: "blocked",
         trigger,
         reason,
-        deliveryMode: "workflow_dispatch_codex_cli",
+        deliveryMode,
         blocker: failure.blocker,
         rawReview: failure.rawFailure
       })
@@ -85,7 +68,7 @@ async function main() {
     status: "completed",
     trigger,
     reason,
-    deliveryMode: "workflow_dispatch_codex_cli",
+    deliveryMode,
     recommendedAction: normalizedReview.recommendedAction,
     criticalFindings: normalizedReview.criticalFindings,
     risks: normalizedReview.risks,
@@ -277,6 +260,8 @@ function classifyCodexFallbackFailure(error) {
   if (lowered.includes("quota exceeded")) {
     blocker = "openai_quota_exceeded";
   } else if (
+    lowered.includes("not authenticated") ||
+    lowered.includes("login") ||
     lowered.includes("missing bearer") ||
     lowered.includes("401") ||
     lowered.includes("unauthorized") ||

--- a/scripts/run-gemini-pr-review.mjs
+++ b/scripts/run-gemini-pr-review.mjs
@@ -77,7 +77,7 @@ async function main() {
         status: "requested",
         trigger: triggerResult.value.trigger,
         reason: "gemini_temporarily_unavailable",
-        deliveryMode: "codex_cloud_github_comment",
+        deliveryMode: "vps_codex_cli",
         repository,
         pullRequestNumber: prNumber
       });
@@ -93,7 +93,7 @@ async function main() {
         });
       }
 
-      console.log(`Requested Codex Cloud reviewer fallback on PR #${prNumber}.`);
+      console.log(`Requested VPS Codex reviewer fallback on PR #${prNumber}.`);
       return;
     }
     throw error;

--- a/scripts/run-vps-runner.mjs
+++ b/scripts/run-vps-runner.mjs
@@ -4,11 +4,14 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { parseCodexReviewFallbackComment } from "../src/core/index.js";
 import { renderPrBody } from "./render-pr-body.mjs";
 
 const QUEUE_MARKER_RE = /<!--\s*vtdd:vps-runner-execution:([a-zA-Z0-9._:-]+)\s*-->/;
 const EVENT_MARKER_RE = /<!--\s*vtdd:vps-runner-event:([a-zA-Z0-9._:-]+)\s*-->/;
 const DEFAULT_API_BASE_URL = "https://api.github.com";
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 
 async function main() {
   const options = parseArgs(process.argv.slice(2));
@@ -53,18 +56,36 @@ async function runVpsRunnerOnce({
   }
 
   const execution = candidates.sort((a, b) => new Date(a.createdAt) - new Date(b.createdAt))[0];
-  if (!execution) {
+  if (execution) {
+    if (dryRun) {
+      return {
+        ok: true,
+        message: `Dry run selected ${execution.payload.executionId} for ${execution.payload.repository}#${execution.payload.issueNumber}.`
+      };
+    }
+
+    return executeVpsRunnerExecution({ githubFetch, token, workRoot, execution });
+  }
+
+  const reviewerFallbacks = [];
+  for (const repository of policies.map((policy) => policy.repository)) {
+    const comments = await readRecentPullRequestComments({ githubFetch, repository });
+    reviewerFallbacks.push(...selectPendingVpsReviewerFallbacks({ comments, repositoryPolicies: policies }));
+  }
+
+  const reviewerFallback = reviewerFallbacks.sort((a, b) => new Date(a.createdAt) - new Date(b.createdAt))[0];
+  if (!reviewerFallback) {
     return { ok: true, message: "No pending VPS runner execution found." };
   }
 
   if (dryRun) {
     return {
       ok: true,
-      message: `Dry run selected ${execution.payload.executionId} for ${execution.payload.repository}#${execution.payload.issueNumber}.`
+      message: `Dry run selected Codex reviewer fallback for ${reviewerFallback.repository}#${reviewerFallback.pullRequestNumber}.`
     };
   }
 
-  return executeVpsRunnerExecution({ githubFetch, token, workRoot, execution });
+  return executeVpsReviewerFallback({ token, reviewerFallback });
 }
 
 async function executeVpsRunnerExecution({ githubFetch, token, workRoot, execution }) {
@@ -209,6 +230,38 @@ function selectPendingVpsRunnerExecutions({ comments, allowedRepositories, repos
   return [...queues.values()].filter(
     (queue) => !terminalEvents.has(queue.payload.executionId) && !runningEvents.has(queue.payload.executionId)
   );
+}
+
+function selectPendingVpsReviewerFallbacks({ comments, allowedRepositories, repositoryPolicies }) {
+  const policies = normalizeRepositoryPolicies({ allowedRepositories, repositoryPolicies });
+  return comments
+    .map((comment) => {
+      const parsed = parseCodexReviewFallbackComment(comment);
+      if (!parsed || parsed.status !== "requested") {
+        return null;
+      }
+      if (!String(comment?.body || "").includes("- Delivery mode: `vps_codex_cli`")) {
+        return null;
+      }
+      const repository = normalizeRepository(comment.repository);
+      const pullRequestNumber = normalizePositiveInteger(comment.pullRequestNumber);
+      if (!repository || !pullRequestNumber) {
+        return null;
+      }
+      if (!policies.some((policy) => policy.repository === repository)) {
+        return null;
+      }
+      return {
+        repository,
+        pullRequestNumber,
+        trigger: extractBacktickedCommentValue(comment.body, "Trigger") || "unknown",
+        reason: extractBacktickedCommentValue(comment.body, "Reason") || "gemini_temporarily_unavailable",
+        createdAt: comment.created_at,
+        commentId: comment.id,
+        commentUrl: comment.html_url
+      };
+    })
+    .filter(Boolean);
 }
 
 async function loadVpsRunnerRepositoryPolicies({ env = process.env, readFile = fs.readFile } = {}) {
@@ -407,6 +460,50 @@ async function readRecentIssueComments({ githubFetch, repository }) {
   return comments;
 }
 
+async function readRecentPullRequestComments({ githubFetch, repository }) {
+  const pulls = await githubFetch(`/repos/${repository}/pulls?state=open&sort=updated&direction=desc&per_page=100`);
+  const comments = [];
+  for (const pull of pulls) {
+    const issueComments = await githubFetch(`/repos/${repository}/issues/${pull.number}/comments?per_page=100`);
+    comments.push(
+      ...issueComments.map((comment) => ({
+        ...comment,
+        repository,
+        pullRequestNumber: pull.number
+      }))
+    );
+  }
+  return comments;
+}
+
+async function executeVpsReviewerFallback({ token, reviewerFallback }) {
+  const env = {
+    ...buildRunnerCommandEnv({ token }),
+    TARGET_REPOSITORY: reviewerFallback.repository,
+    TARGET_PR_NUMBER: String(reviewerFallback.pullRequestNumber),
+    CODEX_FALLBACK_TRIGGER: reviewerFallback.trigger,
+    CODEX_FALLBACK_REASON: reviewerFallback.reason,
+    CODEX_FALLBACK_DELIVERY_MODE: "vps_codex_cli"
+  };
+  const scriptPath = path.join(SCRIPT_DIR, "run-codex-pr-review-fallback.mjs");
+  try {
+    await runCommand("node", [scriptPath], {
+      cwd: path.dirname(SCRIPT_DIR),
+      env,
+      maxBuffer: 1024 * 1024 * 12
+    });
+    return {
+      ok: true,
+      message: `VPS Codex reviewer fallback completed for ${reviewerFallback.repository}#${reviewerFallback.pullRequestNumber}.`
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      reason: error instanceof Error ? error.message : String(error)
+    };
+  }
+}
+
 async function postVpsRunnerEvent({ githubFetch, payload, event }) {
   return githubFetch(`/repos/${payload.repository}/issues/${payload.issueNumber}/comments`, {
     method: "POST",
@@ -583,6 +680,15 @@ function normalizeText(value) {
   return typeof value === "string" ? value.trim() : "";
 }
 
+function extractBacktickedCommentValue(body, label) {
+  const match = String(body || "").match(new RegExp(`- ${escapeRegExp(label)}: \\\`([^\\\`]+)\\\``));
+  return normalizeText(match?.[1]);
+}
+
+function escapeRegExp(value) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 function normalizeRepository(value) {
   const text = normalizeText(value);
   return /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(text) ? text : "";
@@ -640,5 +746,6 @@ export {
   parseVpsRunnerEventComment,
   parseVpsRunnerQueueComment,
   runVpsRunnerOnce,
+  selectPendingVpsReviewerFallbacks,
   selectPendingVpsRunnerExecutions
 };

--- a/scripts/run-vps-runner.mjs
+++ b/scripts/run-vps-runner.mjs
@@ -4,6 +4,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { spawn } from "node:child_process";
+import { renderPrBody } from "./render-pr-body.mjs";
 
 const QUEUE_MARKER_RE = /<!--\s*vtdd:vps-runner-execution:([a-zA-Z0-9._:-]+)\s*-->/;
 const EVENT_MARKER_RE = /<!--\s*vtdd:vps-runner-event:([a-zA-Z0-9._:-]+)\s*-->/;
@@ -437,17 +438,37 @@ async function findExistingPullRequestUrl({ repository, branch, env, cwd }) {
 }
 
 function buildPullRequestBody(payload) {
-  return [
-    `Issue: #${payload.issueNumber}`,
-    `Execution ID: ${payload.executionId}`,
-    "",
-    "Created by the VTDD VPS runner.",
-    "",
-    "Boundaries:",
-    "- No merge performed.",
-    "- No deploy performed.",
-    "- GitHub branch / PR are the runtime truth for Butler progress."
-  ].join("\n");
+  return renderPrBody({
+    issue: payload.issueNumber,
+    executionId: payload.executionId,
+    codexGoal: payload.codexGoal || "open_pr",
+    intent: `VPS runner handoff for Issue #${payload.issueNumber}.`,
+    satisfied: [
+      "VPS runner created the target branch.",
+      "VPS runner opened this draft PR as GitHub-visible runtime truth."
+    ].join("\n"),
+    unsatisfied: "Human review and merge remain pending.",
+    nonGoals: "None.",
+    unit: "Not run by VPS runner.",
+    integration: "Not run by VPS runner.",
+    e2e: "GitHub branch / PR creation is the runtime evidence for this handoff.",
+    manual: "VPS runner executed the bounded Codex handoff.",
+    evidencePath: `Issue #${payload.issueNumber}, branch ${payload.branch || "not provided"}, execution ${payload.executionId}`,
+    cloudflareDeploy: "Not performed.",
+    actionSchemaUpdate: "Not required.",
+    instructionsUpdate: "Not required.",
+    iphoneButlerE2E: "Progress must be read through vtddExecutionProgress / GitHub runtime truth.",
+    rules: [
+      "Queued handoff alone is not success.",
+      "GitHub branch / PR / raw failure are runtime truth.",
+      "No merge or deploy is performed by the VPS runner."
+    ].join("\n"),
+    outOfScope: [
+      "Merge.",
+      "Deploy.",
+      "Secret, permission, or repository settings mutation."
+    ].join("\n")
+  });
 }
 
 function createGitHubFetch({ apiBaseUrl, token }) {
@@ -611,6 +632,7 @@ if (import.meta.url === `file://${process.argv[1]}`) {
 export {
   buildCodexExecutionPrompt,
   buildCodexExecArgs,
+  buildPullRequestBody,
   buildVpsRunnerEventComment,
   classifyVpsRunnerFailure,
   loadVpsRunnerRepositoryPolicies,

--- a/src/core/codex-review-fallback.js
+++ b/src/core/codex-review-fallback.js
@@ -173,7 +173,15 @@ function buildStatusSection({
 
   return [
     "Gemini critical review is temporarily unavailable.",
-    "Non-manual Codex fallback review has been dispatched through VTDD-managed workflow execution."
+    "Non-manual Codex fallback review has been dispatched through VTDD-managed workflow execution.",
+    ...(repository || pullRequestNumber
+      ? [
+          "",
+          "### Target",
+          ...(repository ? [`- Repository: \`${repository}\``] : []),
+          ...(pullRequestNumber ? [`- Pull request: #${pullRequestNumber}`] : [])
+        ]
+      : [])
   ];
 }
 

--- a/test/codex-review-fallback.test.js
+++ b/test/codex-review-fallback.test.js
@@ -17,16 +17,16 @@ test("formatCodexReviewFallbackComment renders marker and requested fallback sta
     status: "requested",
     trigger: "pull_request_target:synchronize",
     reason: "gemini_temporarily_unavailable",
-    deliveryMode: "codex_cloud_github_comment",
+    deliveryMode: "vps_codex_cli",
     repository: "marushu/vtdd-v2-p",
     pullRequestNumber: 152
   });
 
   assert.equal(body.includes(CODEX_REVIEW_FALLBACK_MARKER), true);
   assert.equal(body.includes("- Status: `requested`"), true);
-  assert.equal(body.includes("- Delivery mode: `codex_cloud_github_comment`"), true);
-  assert.equal(body.includes("@codex review"), true);
-  assert.equal(body.includes("does not use `OPENAI_API_KEY`"), true);
+  assert.equal(body.includes("- Delivery mode: `vps_codex_cli`"), true);
+  assert.equal(body.includes("@codex review"), false);
+  assert.equal(body.includes("VTDD-managed workflow execution"), true);
   assert.equal(body.includes("- Repository: `marushu/vtdd-v2-p`"), true);
   assert.equal(body.includes("- Pull request: #152"), true);
   assert.equal(body.includes("gemini_temporarily_unavailable"), true);
@@ -155,6 +155,6 @@ test("fallback script records blocked marker comments for unavailable Codex revi
   assert.equal(fallbackScript.includes("classifyCodexFallbackFailure"), true);
   assert.equal(fallbackScript.includes("upsertCodexFallbackComment"), true);
   assert.equal(fallbackScript.includes("openai_quota_exceeded"), true);
-  assert.equal(fallbackScript.includes("openai_api_key_not_configured"), true);
+  assert.equal(fallbackScript.includes("openai_api_key_invalid_or_missing"), true);
   assert.equal(fallbackScript.includes('status: "blocked"'), true);
 });

--- a/test/e2e-27-no-manual-codex-reviewer-fallback.test.js
+++ b/test/e2e-27-no-manual-codex-reviewer-fallback.test.js
@@ -15,8 +15,8 @@ const MATRIX_PATH = path.join(process.cwd(), "docs", "mvp", "issue-to-e2e-matrix
 test("E2E-27 evidence doc records no-manual Codex fallback runs", () => {
   const doc = fs.readFileSync(DOC_PATH, "utf8");
   assert.equal(doc.includes("`#84`"), true);
-  assert.equal(doc.includes("Codex Cloud"), true);
-  assert.equal(doc.includes("deliveryMode=codex_cloud_github_comment"), true);
+  assert.equal(doc.includes("VPS Codex CLI"), true);
+  assert.equal(doc.includes("deliveryMode=vps_codex_cli"), true);
   assert.equal(doc.includes("does not require `OPENAI_API_KEY`"), true);
   assert.equal(doc.includes("PR Runtime Verification Boundary"), true);
   assert.equal(doc.includes("pull_request_target"), true);

--- a/test/gemini-pr-review-workflow.test.js
+++ b/test/gemini-pr-review-workflow.test.js
@@ -35,10 +35,11 @@ test("Gemini review workflow still routes reviewer execution through the script 
   assert.equal(workflow.includes("issues: write"), false);
 });
 
-test("Gemini review script defaults Codex fallback to Codex Cloud comment transport", () => {
+test("Gemini review script defaults Codex fallback to VPS Codex CLI transport", () => {
   const script = fs.readFileSync("scripts/run-gemini-pr-review.mjs", "utf8");
-  assert.equal(script.includes('deliveryMode: "codex_cloud_github_comment"'), true);
-  assert.equal(script.includes("Requested Codex Cloud reviewer fallback"), true);
+  assert.equal(script.includes('deliveryMode: "vps_codex_cli"'), true);
+  assert.equal(script.includes("Requested VPS Codex reviewer fallback"), true);
+  assert.equal(script.includes("@codex review"), false);
   assert.equal(script.includes("OPENAI_API_KEY"), false);
   assert.equal(script.includes("/actions/workflows/codex-pr-review-fallback.yml/dispatches"), false);
 });

--- a/test/vps-runner-script.test.js
+++ b/test/vps-runner-script.test.js
@@ -11,6 +11,7 @@ import {
   parseVpsRunnerEventComment,
   parseVpsRunnerQueueComment,
   runVpsRunnerOnce,
+  selectPendingVpsReviewerFallbacks,
   selectPendingVpsRunnerExecutions
 } from "../scripts/run-vps-runner.mjs";
 
@@ -225,6 +226,49 @@ test("VPS runner dry run reports selected execution without side effects", async
     "/repos/sample-org/vtdd-v2/issues?state=open&sort=updated&direction=desc&per_page=100",
     "/repos/sample-org/vtdd-v2/issues/157/comments?per_page=100"
   ]);
+});
+
+test("VPS runner selects pending Codex reviewer fallback comments after development queues", () => {
+  const selected = selectPendingVpsReviewerFallbacks({
+    repositoryPolicies: normalizeRepositoryPolicies({
+      allowedRepositories: ["sample-org/vtdd-v2"]
+    }),
+    comments: [
+      {
+        id: 1,
+        html_url: "https://github.com/sample-org/vtdd-v2/pull/22#issuecomment-1",
+        created_at: "2026-05-08T10:00:00Z",
+        repository: "sample-org/vtdd-v2",
+        pullRequestNumber: 22,
+        body: [
+          "<!-- vtdd:reviewer=codex-fallback -->",
+          "## VTDD Codex Reviewer Fallback Request",
+          "",
+          "- Status: `requested`",
+          "- Trigger: `pull_request_target:synchronize`",
+          "- Reason: `gemini_temporarily_unavailable`",
+          "- Delivery mode: `vps_codex_cli`"
+        ].join("\n")
+      },
+      {
+        id: 2,
+        html_url: "https://github.com/sample-org/vtdd-v2/pull/23#issuecomment-2",
+        created_at: "2026-05-08T10:01:00Z",
+        repository: "sample-org/vtdd-v2",
+        pullRequestNumber: 23,
+        body: [
+          "<!-- vtdd:reviewer=codex-fallback -->",
+          "- Status: `requested`",
+          "- Delivery mode: `codex_cloud_github_comment`"
+        ].join("\n")
+      }
+    ]
+  });
+
+  assert.equal(selected.length, 1);
+  assert.equal(selected[0].repository, "sample-org/vtdd-v2");
+  assert.equal(selected[0].pullRequestNumber, 22);
+  assert.equal(selected[0].trigger, "pull_request_target:synchronize");
 });
 
 test("VPS runner Codex prompt preserves high-risk boundaries", () => {

--- a/test/vps-runner-script.test.js
+++ b/test/vps-runner-script.test.js
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import {
   buildCodexExecutionPrompt,
   buildCodexExecArgs,
+  buildPullRequestBody,
   buildVpsRunnerEventComment,
   classifyVpsRunnerFailure,
   loadVpsRunnerRepositoryPolicies,
@@ -245,6 +246,24 @@ test("VPS runner Codex prompt preserves high-risk boundaries", () => {
   assert.equal(prompt.includes("Do not merge."), true);
   assert.equal(prompt.includes("Do not deploy."), true);
   assert.equal(prompt.includes("Do not mutate secrets"), true);
+});
+
+test("VPS runner PR body satisfies guarded PR template markers", () => {
+  const body = buildPullRequestBody({
+    repository: "sample-org/vtdd-v2",
+    issueNumber: 194,
+    executionId: "remote-codex-issue194-test",
+    branch: "codex/issue-194",
+    codexGoal: "open_pr"
+  });
+
+  assert.equal(body.includes("## This PR satisfies Intent"), true);
+  assert.equal(body.includes("## Satisfied Success Criteria"), true);
+  assert.equal(body.includes("## Unsatisfied Success Criteria"), true);
+  assert.equal(body.includes("## Verification Evidence"), true);
+  assert.equal(body.includes("## Surface Update Checklist"), true);
+  assert.equal(body.includes("Execution ID: remote-codex-issue194-test"), true);
+  assert.equal(body.includes("No merge or deploy is performed by the VPS runner."), true);
 });
 
 test("VPS runner classifies unauthenticated Codex CLI as raw auth failure", () => {


### PR DESCRIPTION
## This PR satisfies Intent

VPS runner-created PRs must not start with predictable guardrail failures, and reviewer fallback must not get stuck on an unconnected Codex GitHub Connector. The runner should create guarded-template-compliant PR bodies and route Gemini-unavailable reviewer fallback through the user-owned VPS Codex CLI path.

## Satisfied Success Criteria

- [x] Replaces the ad hoc VPS runner PR body with the canonical PR body renderer.
- [x] Preserves VPS runner metadata including Issue, executionId, goal, branch, and runtime-truth boundary.
- [x] Adds a regression test that generated VPS runner PR bodies include all guarded-policy markers.
- [x] Changes Gemini temporary-unavailable fallback from `codex_cloud_github_comment` / `@codex review` to `vps_codex_cli`.
- [x] Extends the VPS runner poller to pick up pending `vps_codex_cli` reviewer fallback comments on open PRs.
- [x] Allows the Codex fallback reviewer script to use an authenticated Codex CLI session instead of requiring `OPENAI_API_KEY`.
- [x] Updated PR #202 body manually so the current failed PR is no longer missing required markers.

## Unsatisfied Success Criteria

None.

## Non-goal violations

None.

## Verification Evidence

- Unit: `node --test test/vps-runner-script.test.js test/pr-body-guardrail.test.js`
- Integration: `npm test`
- E2E: Not run against live VPS reviewer pickup after this commit; source and tests now wire the request path.
- Manual: Edited PR #202 body to the same guarded-template-compliant shape and pushed a refresh commit there; PR #202 checks are now green.
- Evidence path/link: `scripts/run-vps-runner.mjs`, `scripts/run-gemini-pr-review.mjs`, `scripts/run-codex-pr-review-fallback.mjs`, `src/core/codex-review-fallback.js`, `test/vps-runner-script.test.js`, `test/gemini-pr-review-workflow.test.js`, https://github.com/marushu/vtdd-v2-p/pull/202

## Surface Update Checklist

- Cloudflare deploy: Not performed.
- Custom GPT Action Schema update: Not required.
- Custom GPT Instructions update: Not required.
- iPhone Butler live E2E: Not run.

## Related Constitution Rules

- Queued handoff alone is not success.
- GitHub branch / PR / raw failure are runtime truth.
- Reviewer fallback request-state is not completed reviewer evidence.
- PR authoring must include verification evidence instead of intent only.

## Out-of-scope but NOT implemented

- Merging PR #202 or #203.
- Closing Issue #194.
- Deploy, credential, permission, or repository settings mutation.

## Extra changes (if any)

Reviewer fallback routing was added after live PR #203 evidence showed the legacy `@codex review` request stopped at the Codex Connector setup prompt.
