### PR TITLE
Add PR ready-for-review authority action

### DIFF
--- a/docs/setup/custom-gpt-actions-openapi.json
+++ b/docs/setup/custom-gpt-actions-openapi.json
@@ -857,6 +857,7 @@
                   "operation": {
                     "type": "string",
                     "enum": [
+                      "pull_ready_for_review",
                       "pull_merge",
                       "issue_close"
                     ]

--- a/docs/setup/custom-gpt-actions-openapi.yaml
+++ b/docs/setup/custom-gpt-actions-openapi.yaml
@@ -575,6 +575,7 @@ paths:
                 operation:
                   type: string
                   enum:
+                    - pull_ready_for_review
                     - pull_merge
                     - issue_close
                 repository:

--- a/docs/setup/custom-gpt-instructions-short.md
+++ b/docs/setup/custom-gpt-instructions-short.md
@@ -1,8 +1,8 @@
 VTDD Butler. Japanese unless asked otherwise.
 
 Core:
-- Issue is canonical spec; GitHub runtime state is progress truth.
-- Before proposal/write/Codex handoff/PR judgment: vtddRetrieveCrossMemory + vtddRetrieveDecisionLogs/vtddRetrieveProposalLogs/vtddRetrieveConstitution if useful + runtime truth. Report found/missing; no RAG hit OK, never invent. Runtime truth > memory.
+- Issue is canonical spec; Runtime truth > memory.
+- Before proposal/write/Codex handoff/PR judgment: vtddRetrieveCrossMemory + vtddRetrieveDecisionLogs/vtddRetrieveProposalLogs/vtddRetrieveConstitution if useful + runtime truth. Report found/missing; no RAG hit OK, never invent.
 - Do not assume a default repository. Resolve repo from alias/context; if ambiguous, ask.
 - No internal API paths/raw JSON unless debugging.
 - Natural language to actions.
@@ -14,7 +14,7 @@ Repo/nickname:
 - Save/list nicknames: vtddUpsertRepositoryNickname / vtddRetrieveRepositoryNicknames.
 - If request starts with non-owner/repo token like `ぶい の...`, call nickname read/gateway first.
 - Save with owner/repo, not alias. Nickname memory is user-owned alias data, not default repo.
-- Nickname read failure is not proof of unknown repo. If context/grant has owner/repo, use unverified fallback; verify.
+- Nickname read failure is not proof of unknown repo. If context/grant/approvalGrant.scope.repositoryInput has owner/repo, use unverified fallback; verify.
 - If nickname save/read fails, surface error/reason/issues. If Action returns `ClientResponseError`, state action.
 
 GitHub read plane:
@@ -22,14 +22,7 @@ GitHub read plane:
 - Unsupported route => say 未対応. Auth fail => 認証失敗. Do not infer absence from failed reads.
 
 Self-parity:
-- For stale/outdated/reflected/aligned, use vtddRetrieveSelfParity, repo=<resolved>, ref=main.
-- If runtimeParity=`cloudflare_deploy_update_required`, say `Cloudflare deploy update required`.
-- If in_sync but Butler lacks features, say `Action Schema update required` and/or `Instructions update required`.
-- If parity cannot be checked, say `未検証`.
-- If action returns error/reason/issues, surface error/reason/issues.
-- If self-parity returns `ClientResponseError`, say unverified transport failure.
-- Use vtddRetrieveSetupArtifact for setup.
-- If runtime in sync, don't claim editor sync.
+- Use vtddRetrieveSelfParity repo=<resolved>, ref=main. Surface `Cloudflare deploy update required` / `Action Schema update required` / `Instructions update required` / errors. Use vtddRetrieveSetupArtifact for setup. If runtime in sync, don't claim editor sync. If self-parity returns `ClientResponseError`, say unverified transport failure.
 
 Execution:
 - Before execution, read runtime truth; if required, vtddRetrieveGitHub PR/branch/checks/runs.
@@ -47,7 +40,7 @@ Remote Codex flow:
 - PR reviewer fixes: say `Gemini が指摘している修正を Codex に進めさせます。よければ GO と言ってください。`
 - If user says handoff/実行/GO, set consent=["propose","execute"].
 - Executor transport is pluggable and user-owned; vtdd-v2-p is public core, not a shared runner.
-- Current default for Codex task handoff is the user-owned VPS: call vtddExecute with executorTransport=vps_runner. Do not add a separate GPT Action for VPS handoff.
+- Current default for Codex task handoff is the user-owned VPS: vtddExecute executorTransport=vps_runner. Do not add a separate GPT Action for VPS handoff.
 - codex_cloud_github_comment is legacy fallback; codex_cloud_cli_control_runner is only for selected user-owned control runner. Queued comment is delegation, not execution evidence.
 - codex_cloud_cli_control_runner: user-owned control repo/runner; ChatGPT-managed Codex auth, not OPENAI_API_KEY; report run URL + branch/PR evidence.
 - vps_runner: active user-owned VPS transport for this setup; VTDD core does not host it.
@@ -65,23 +58,18 @@ GitHub write:
 
 GitHub high-risk authority plane:
 - Use vtddGitHubAuthority for actions requiring GO + real passkey:
+  - pull_ready_for_review
   - pull_merge
   - issue_close
 - Confirm approval grant, repo scope, and explicit request.
+- Draft PR before merge: pull_ready_for_review. No grant: show `[Open ready operator](<absolute operator URL>)` with repo/phase/issueNumber/pullNumber/actionType/highRiskKind.
 - For pull_merge no grant, show `[Open merge operator](<absolute operator URL>)` with repo/phase/issueNumber/pullNumber/actionType/highRiskKind; no bare URL.
 - Operator may approve+dispatch PR merge; re-read runtime truth before saying merged.
 - For issue_close, include issueNumber + merged PR pullNumber; no grant: show same-origin operator link.
 - Do not route deploy or other destructive provider actions through vtddGitHubAuthority.
 
 Deploy plane:
-- Use vtddDeployProduction after deploy ask.
-- vtddDeployProduction requires resolved repo, explicit GO, real passkey grant scoped to deploy_production.
-- Pasted approvalGrant.scope.repositoryInput can identify deploy target.
-- If no deploy grant, show selfParity.deployOperatorMarkdownLink or `[Open deploy operator](<actual selfParity.deployOperatorUrl>)`; never raw `/v2/approval/passkey/operator...` or bare URL.
-- Stale fallback: selfParity.deployRecovery.operatorMarkdownLink or operatorUrl. Href needs phase=execution.
-- If deploy URL requested while in_sync, show deployOperatorUrl/link.
-- After deploy, say dispatched, then re-check self-parity.
-- If vtddDeployProduction fails, say the exact deploy error/reason/issues and blocker.
+- vtddDeployProduction after deploy ask; requires resolved repo, explicit GO, real passkey grant scoped deploy_production. No grant: show selfParity.deployOperatorMarkdownLink or `[Open deploy operator](<actual selfParity.deployOperatorUrl>)`; never raw `/v2/approval/passkey/operator...` or bare URL. Stale: selfParity.deployRecovery.operatorMarkdownLink or operatorUrl, phase=execution. After deploy, re-check self-parity. If vtddDeployProduction fails, say the exact deploy error/reason/issues.
 - Default reviewer fallback: Codex Cloud comment, not OPENAI_API_KEY.
 - If api_key_runner hits openai_api_key_not_configured, never ask in chat; use vtddSyncGitHubActionsSecret secret-sync operator.
 

--- a/docs/setup/custom-gpt-instructions.md
+++ b/docs/setup/custom-gpt-instructions.md
@@ -272,6 +272,7 @@ GitHub normal write plane:
 GitHub high-risk authority plane:
 - Use vtddGitHubAuthority for GitHub authority actions that require `GO + real passkey`.
 - Use vtddGitHubAuthority for:
+  - marking a bounded draft PR ready for review before merge
   - merge of a bounded PR
   - bounded issue close after merged scoped work
 - Before vtddGitHubAuthority:
@@ -279,6 +280,9 @@ GitHub high-risk authority plane:
   - ensure repository and Issue scope are explicit
   - ensure the user has explicitly requested the action
 - For merge:
+  - if the PR is draft, run `pull_ready_for_review` first; draft PRs cannot be merged
+  - operation=`pull_ready_for_review`
+  - if no ready-scoped approval grant is available yet, present a short clickable Markdown link to the same-origin passkey operator helper; the href must include `repositoryInput=<resolved repo>`, `phase=execution`, `issueNumber=<parent/active issue>`, `pullNumber=<PR number>`, `actionType=pull_ready_for_review`, and `highRiskKind=pull_ready_for_review`
   - operation=`pull_merge`
   - if no merge-scoped approval grant is available yet, present a short clickable Markdown link to the same-origin passkey operator helper; the href must be the full absolute URL with `repositoryInput=<resolved repo>`, `phase=execution`, `issueNumber=<parent/active issue>`, `pullNumber=<PR number>`, `actionType=merge`, `highRiskKind=pull_merge`, and `mergeMethod=squash` unless the human asked for another merge method
   - use a short label such as `[Open merge operator](<actual URL>)`; do not paste a bare long URL or ask the human to rebuild query parameters

--- a/src/core/github-app-operation-registry.js
+++ b/src/core/github-app-operation-registry.js
@@ -56,7 +56,7 @@ export const GitHubAppOperationRegistry = Object.freeze({
   pull_ready_for_review: {
     operation: "pull_ready_for_review",
     tier: GitHubAppOperationTier.PASSKEY_AUTHORITY,
-    requiredPayloadFields: ["repository", "issueNumber"],
+    requiredPayloadFields: ["repository", "issueNumber", "pullNumber"],
     requiredRuntimeEvidenceFields: ["pullNumber"],
     authorityScopeIdentityFields: ["repository", "issueNumber", "pullNumber", "phase"],
     requiredRuntimeTruthChecks: ["pull_request_ready_for_review_result"],

--- a/src/core/github-app-operation-registry.js
+++ b/src/core/github-app-operation-registry.js
@@ -53,6 +53,21 @@ export const GitHubAppOperationRegistry = Object.freeze({
     requiredPayloadFields: ["repository", "pullNumber", "body"],
     naturalGoIdentityFields: ["repository", "pullNumber", "body"]
   },
+  pull_ready_for_review: {
+    operation: "pull_ready_for_review",
+    tier: GitHubAppOperationTier.PASSKEY_AUTHORITY,
+    requiredPayloadFields: ["repository", "issueNumber"],
+    requiredRuntimeEvidenceFields: ["pullNumber"],
+    authorityScopeIdentityFields: ["repository", "issueNumber", "pullNumber", "phase"],
+    requiredRuntimeTruthChecks: ["pull_request_ready_for_review_result"],
+    executorFunction: "executeGitHubHighRiskPlane",
+    responseSummaryShape: ["operation", "repository", "pullNumber", "readyForReview", "changed", "htmlUrl"],
+    passkey: {
+      actionType: "pull_ready_for_review",
+      highRiskKind: "pull_ready_for_review",
+      operatorUrlRequirements: ["repositoryInput", "phase", "issueNumber", "pullNumber", "actionType", "highRiskKind"]
+    }
+  },
   pull_merge: {
     operation: "pull_merge",
     tier: GitHubAppOperationTier.PASSKEY_AUTHORITY,

--- a/src/core/github-high-risk-plane.js
+++ b/src/core/github-high-risk-plane.js
@@ -272,6 +272,15 @@ async function executePullReadyForReview(input) {
   }
 
   const pull = mutationBody?.data?.markPullRequestReadyForReview?.pullRequest;
+  if (!pull || pull.isDraft !== false) {
+    return {
+      ok: false,
+      status: 422,
+      error: "github_high_risk_failed",
+      reason: "GitHub ready-for-review mutation did not return a ready pull request"
+    };
+  }
+
   return {
     ok: true,
     authorityAction: {

--- a/src/core/github-high-risk-plane.js
+++ b/src/core/github-high-risk-plane.js
@@ -10,6 +10,7 @@ const GITHUB_API_VERSION = "2022-11-28";
 const GITHUB_API_USER_AGENT = "vtdd-v2-github-high-risk-plane";
 
 export const GitHubHighRiskOperation = Object.freeze({
+  PULL_READY_FOR_REVIEW: "pull_ready_for_review",
   PULL_MERGE: "pull_merge",
   ISSUE_CLOSE: "issue_close"
 });
@@ -161,6 +162,10 @@ function hasPayloadField(input, field) {
 }
 
 async function dispatchGitHubHighRisk(input) {
+  if (input.operation === GitHubHighRiskOperation.PULL_READY_FOR_REVIEW) {
+    return executePullReadyForReview(input);
+  }
+
   if (input.operation === GitHubHighRiskOperation.PULL_MERGE) {
     return executePullMerge(input);
   }
@@ -174,6 +179,109 @@ async function dispatchGitHubHighRisk(input) {
     status: 422,
     error: "github_high_risk_request_invalid",
     reason: "operation is unsupported"
+  };
+}
+
+async function executePullReadyForReview(input) {
+  const encodedRepository = encodeURIComponentRepository(input.repository);
+  const prUrl = `${input.apiBaseUrl}/repos/${encodedRepository}/pulls/${input.pullNumber}`;
+  let prResponse;
+  try {
+    prResponse = await input.fetchImpl(prUrl, {
+      method: "GET",
+      headers: githubJsonHeaders({ token: input.token })
+    });
+  } catch (error) {
+    return {
+      ok: false,
+      status: 503,
+      error: "github_high_risk_failed",
+      reason: `failed to read pull request before ready-for-review: ${errorMessage(error)}`
+    };
+  }
+
+  const prBody = await readJsonSafe(prResponse);
+  if (!prResponse.ok) {
+    return {
+      ok: false,
+      status: prResponse.status,
+      error: "github_high_risk_failed",
+      reason: normalizeText(prBody?.message) || "failed to read pull request before ready-for-review"
+    };
+  }
+
+  if (prBody?.draft !== true) {
+    return {
+      ok: true,
+      authorityAction: {
+        operation: input.operation,
+        repository: input.repository,
+        pullNumber: input.pullNumber,
+        readyForReview: true,
+        changed: false,
+        htmlUrl: normalizeText(prBody?.html_url) || `https://github.com/${input.repository}/pull/${input.pullNumber}`
+      }
+    };
+  }
+
+  const nodeId = normalizeText(prBody?.node_id);
+  if (!nodeId) {
+    return {
+      ok: false,
+      status: 422,
+      error: "github_high_risk_request_invalid",
+      reason: "pull request node_id is required for ready-for-review mutation"
+    };
+  }
+
+  const graphqlUrl = `${input.apiBaseUrl.replace(/\/rest$/, "")}/graphql`;
+  let mutationResponse;
+  try {
+    mutationResponse = await input.fetchImpl(graphqlUrl, {
+      method: "POST",
+      headers: githubJsonHeaders({ token: input.token }),
+      body: JSON.stringify({
+        query:
+          "mutation MarkPullRequestReadyForReview($pullRequestId: ID!) { markPullRequestReadyForReview(input: { pullRequestId: $pullRequestId }) { pullRequest { isDraft url number } } }",
+        variables: {
+          pullRequestId: nodeId
+        }
+      })
+    });
+  } catch (error) {
+    return {
+      ok: false,
+      status: 503,
+      error: "github_high_risk_failed",
+      reason: `failed to mark pull request ready for review: ${errorMessage(error)}`
+    };
+  }
+
+  const mutationBody = await readJsonSafe(mutationResponse);
+  const graphqlErrors = Array.isArray(mutationBody?.errors) ? mutationBody.errors : [];
+  if (!mutationResponse.ok || graphqlErrors.length > 0) {
+    return {
+      ok: false,
+      status: mutationResponse.status,
+      error: "github_high_risk_failed",
+      reason:
+        normalizeText(graphqlErrors[0]?.message) ||
+        normalizeText(mutationBody?.message) ||
+        "GitHub ready-for-review mutation failed"
+    };
+  }
+
+  const pull = mutationBody?.data?.markPullRequestReadyForReview?.pullRequest;
+  return {
+    ok: true,
+    authorityAction: {
+      operation: input.operation,
+      repository: input.repository,
+      pullNumber: Number(pull?.number ?? input.pullNumber),
+      readyForReview: pull?.isDraft === false,
+      changed: true,
+      htmlUrl: normalizeText(pull?.url) || `https://github.com/${input.repository}/pull/${input.pullNumber}`
+    }
   };
 }
 

--- a/src/core/passkey-operator-page.js
+++ b/src/core/passkey-operator-page.js
@@ -235,10 +235,11 @@ export function renderPasskeyOperatorPage(input = {}) {
           <label for="merge-method-input">Merge Method</label>
           <input id="merge-method-input" value="${mergeMethodDefault}" placeholder="squash" />
           <div class="row">
+            <button id="ready-button">Mark ready for review</button>
             <button id="merge-button">Dispatch PR merge</button>
             <a class="button-link" id="merge-pr-link" href="#" target="_blank" rel="noopener noreferrer" hidden>Open pull request</a>
           </div>
-          <p class="muted"><code>actionType=merge</code> / <code>highRiskKind=pull_merge</code> の approvalGrantId が必要です。merge 後は GitHub runtime truth で merged 状態を確認してください。</p>
+          <p class="muted">draft を解除する場合は <code>actionType=pull_ready_for_review</code> / <code>highRiskKind=pull_ready_for_review</code>、merge は <code>actionType=merge</code> / <code>highRiskKind=pull_merge</code> の approvalGrantId が必要です。merge 後は GitHub runtime truth で merged 状態を確認してください。</p>
           <pre id="merge-output"></pre>
         </section>
 
@@ -621,6 +622,41 @@ export function renderPasskeyOperatorPage(input = {}) {
         }
       });
 
+      document.getElementById("ready-button").addEventListener("click", async () => {
+        try {
+          if (!latestApprovalGrantId) {
+            throw new Error("approvalGrantId is required before marking PR ready for review");
+          }
+          clearMergePrLink();
+          mergeOutput.textContent = "PR ready-for-review request...";
+          const readyResponse = await fetch("${apiBase}/action/github-authority", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({
+              operation: "pull_ready_for_review",
+              repository: document.getElementById("repo-input").value,
+              pullNumber: Number(document.getElementById("pull-number-input").value || 0) || null,
+              issueContext: {
+                issueNumber: Number(document.getElementById("issue-input").value || 0) || null
+              },
+              policyInput: {
+                approvalPhrase: "GO",
+                approvalGrantId: latestApprovalGrantId,
+                targetConfirmed: true
+              }
+            })
+          });
+          const readyBody = await readResponseBody(readyResponse);
+          if (!readyResponse.ok) {
+            throw responseError(readyBody, "PR ready-for-review failed");
+          }
+          showMergePrLink(readyBody);
+          mergeOutput.textContent = JSON.stringify(readyBody, null, 2);
+        } catch (error) {
+          mergeOutput.textContent = String(error);
+        }
+      });
+
       document.getElementById("openai-secret-sync-button").addEventListener("click", async () => {
         try {
           if (!latestApprovalGrantId) {
@@ -757,6 +793,9 @@ export function resolvePasskeyOperatorMode(input = {}) {
     return "deploy";
   }
   if (actionType === "merge" || highRiskKind === "pull_merge") {
+    return "merge";
+  }
+  if (actionType === "pull_ready_for_review" || highRiskKind === "pull_ready_for_review") {
     return "merge";
   }
   if (actionType === "issue_close" || highRiskKind === "issue_close") {

--- a/src/worker.js
+++ b/src/worker.js
@@ -1804,6 +1804,9 @@ function buildApprovalScopeSnapshot({ payload, policyInput }) {
 }
 
 function mapGitHubHighRiskOperationToActionType(operation) {
+  if (operation === GitHubHighRiskOperation.PULL_READY_FOR_REVIEW) {
+    return "pull_ready_for_review";
+  }
   if (operation === GitHubHighRiskOperation.PULL_MERGE) {
     return "merge";
   }

--- a/test/github-high-risk-plane.test.js
+++ b/test/github-high-risk-plane.test.js
@@ -34,9 +34,24 @@ const mergeGrant = {
   }
 };
 
+const readyGrant = {
+  approvalId: "approval-ready-123",
+  verified: true,
+  expiresAt: "2099-01-01T00:00:00.000Z",
+  scope: {
+    actionType: "pull_ready_for_review",
+    highRiskKind: "pull_ready_for_review",
+    repositoryInput: "sample-org/vtdd-v2-p",
+    issueNumber: "55",
+    pullNumber: "21",
+    phase: "execution"
+  }
+};
+
 test("github app operation registry defines issue close authority scope and runtime truth", () => {
   const issueClose = getGitHubAppOperation("issue_close");
   const pullMerge = getGitHubAppOperation("pull_merge");
+  const pullReady = getGitHubAppOperation("pull_ready_for_review");
 
   assert.equal(issueClose.tier, GitHubAppOperationTier.PASSKEY_AUTHORITY);
   assert.deepEqual(issueClose.requiredPayloadFields, ["repository", "issueNumber"]);
@@ -58,6 +73,18 @@ test("github app operation registry defines issue close authority scope and runt
     "repositoryInput",
     "phase",
     "issueNumber",
+    "actionType",
+    "highRiskKind"
+  ]);
+  assert.equal(pullReady.tier, GitHubAppOperationTier.PASSKEY_AUTHORITY);
+  assert.deepEqual(pullReady.requiredPayloadFields, ["repository", "issueNumber"]);
+  assert.deepEqual(pullReady.requiredRuntimeEvidenceFields, ["pullNumber"]);
+  assert.deepEqual(pullReady.authorityScopeIdentityFields, ["repository", "issueNumber", "pullNumber", "phase"]);
+  assert.deepEqual(pullReady.passkey.operatorUrlRequirements, [
+    "repositoryInput",
+    "phase",
+    "issueNumber",
+    "pullNumber",
     "actionType",
     "highRiskKind"
   ]);
@@ -151,6 +178,86 @@ test("github high-risk plane merges a pull request with scoped approval grant", 
   assert.equal(result.authorityAction.operation, "pull_merge");
   assert.equal(result.authorityAction.merged, true);
   assert.equal(calls[0].init.method, "PUT");
+});
+
+test("github high-risk plane marks draft pull request ready for review with scoped approval grant", async () => {
+  const calls = [];
+  const result = await executeGitHubHighRiskPlane({
+    operation: GitHubHighRiskOperation.PULL_READY_FOR_REVIEW,
+    repository: "sample-org/vtdd-v2-p",
+    issueNumber: 55,
+    pullNumber: 21,
+    approvalPhrase: "GO",
+    targetConfirmed: true,
+    approvalGrant: readyGrant,
+    approvalScope: readyGrant.scope,
+    env: {
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_high_risk",
+      GITHUB_API_FETCH: async (url, init) => {
+        calls.push({ url, init });
+        if (calls.length === 1) {
+          return new Response(
+            JSON.stringify({
+              draft: true,
+              node_id: "PR_kwDOExample",
+              html_url: "https://github.com/sample-org/vtdd-v2-p/pull/21"
+            }),
+            { status: 200, headers: { "content-type": "application/json" } }
+          );
+        }
+        return new Response(
+          JSON.stringify({
+            data: {
+              markPullRequestReadyForReview: {
+                pullRequest: {
+                  isDraft: false,
+                  number: 21,
+                  url: "https://github.com/sample-org/vtdd-v2-p/pull/21"
+                }
+              }
+            }
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        );
+      }
+    }
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.authorityAction.operation, "pull_ready_for_review");
+  assert.equal(result.authorityAction.readyForReview, true);
+  assert.equal(result.authorityAction.changed, true);
+  assert.equal(calls[0].init.method, "GET");
+  assert.equal(calls[1].url, "https://api.github.com/graphql");
+  assert.equal(calls[1].init.method, "POST");
+});
+
+test("github high-risk plane treats already-ready pull request as no-op success", async () => {
+  const result = await executeGitHubHighRiskPlane({
+    operation: GitHubHighRiskOperation.PULL_READY_FOR_REVIEW,
+    repository: "sample-org/vtdd-v2-p",
+    issueNumber: 55,
+    pullNumber: 21,
+    approvalPhrase: "GO",
+    targetConfirmed: true,
+    approvalGrant: readyGrant,
+    approvalScope: readyGrant.scope,
+    env: {
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_high_risk",
+      GITHUB_API_FETCH: async () =>
+        new Response(
+          JSON.stringify({
+            draft: false,
+            html_url: "https://github.com/sample-org/vtdd-v2-p/pull/21"
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        )
+    }
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.authorityAction.readyForReview, true);
+  assert.equal(result.authorityAction.changed, false);
 });
 
 test("github high-risk plane requires merge method from registry", async () => {

--- a/test/github-high-risk-plane.test.js
+++ b/test/github-high-risk-plane.test.js
@@ -77,7 +77,7 @@ test("github app operation registry defines issue close authority scope and runt
     "highRiskKind"
   ]);
   assert.equal(pullReady.tier, GitHubAppOperationTier.PASSKEY_AUTHORITY);
-  assert.deepEqual(pullReady.requiredPayloadFields, ["repository", "issueNumber"]);
+  assert.deepEqual(pullReady.requiredPayloadFields, ["repository", "issueNumber", "pullNumber"]);
   assert.deepEqual(pullReady.requiredRuntimeEvidenceFields, ["pullNumber"]);
   assert.deepEqual(pullReady.authorityScopeIdentityFields, ["repository", "issueNumber", "pullNumber", "phase"]);
   assert.deepEqual(pullReady.passkey.operatorUrlRequirements, [
@@ -258,6 +258,51 @@ test("github high-risk plane treats already-ready pull request as no-op success"
   assert.equal(result.ok, true);
   assert.equal(result.authorityAction.readyForReview, true);
   assert.equal(result.authorityAction.changed, false);
+});
+
+test("github high-risk plane fails when ready-for-review mutation does not prove readiness", async () => {
+  const result = await executeGitHubHighRiskPlane({
+    operation: GitHubHighRiskOperation.PULL_READY_FOR_REVIEW,
+    repository: "sample-org/vtdd-v2-p",
+    issueNumber: 55,
+    pullNumber: 21,
+    approvalPhrase: "GO",
+    targetConfirmed: true,
+    approvalGrant: readyGrant,
+    approvalScope: readyGrant.scope,
+    env: {
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_high_risk",
+      GITHUB_API_FETCH: async (url) => {
+        if (String(url).includes("/pulls/")) {
+          return new Response(
+            JSON.stringify({
+              draft: true,
+              node_id: "PR_kwDOExample"
+            }),
+            { status: 200, headers: { "content-type": "application/json" } }
+          );
+        }
+        return new Response(
+          JSON.stringify({
+            data: {
+              markPullRequestReadyForReview: {
+                pullRequest: {
+                  isDraft: true,
+                  number: 21,
+                  url: "https://github.com/sample-org/vtdd-v2-p/pull/21"
+                }
+              }
+            }
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        );
+      }
+    }
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.status, 422);
+  assert.equal(result.reason, "GitHub ready-for-review mutation did not return a ready pull request");
 });
 
 test("github high-risk plane requires merge method from registry", async () => {

--- a/test/passkey-operator-page.test.js
+++ b/test/passkey-operator-page.test.js
@@ -55,8 +55,28 @@ test("passkey operator page pre-fills PR merge fields from URL input", () => {
   assert.equal(html.includes('id="action-type-input" value="merge"'), true);
   assert.equal(html.includes('id="risk-kind-input" value="pull_merge"'), true);
   assert.equal(html.includes('id="merge-method-input" value="squash"'), true);
+  assert.equal(html.includes("Mark ready for review"), true);
+  assert.equal(html.includes('operation: "pull_ready_for_review"'), true);
   assert.equal(html.includes('operation: "pull_merge"'), true);
   assert.equal(html.includes('pullNumber: Number(document.getElementById("pull-number-input").value || 0) || null'), true);
+});
+
+test("passkey operator page can scope PR ready-for-review approval to pull proof", () => {
+  const html = renderPasskeyOperatorPage({
+    repositoryInput: "marushu/vtdd-v2-p",
+    issueNumber: 194,
+    pullNumber: 202,
+    phase: "execution",
+    actionType: "pull_ready_for_review",
+    highRiskKind: "pull_ready_for_review"
+  });
+
+  assert.equal(html.includes('<section data-operator-section="approval">'), true);
+  assert.equal(html.includes('<section data-operator-section="pr-merge">'), true);
+  assert.equal(html.includes('id="action-type-input" value="pull_ready_for_review"'), true);
+  assert.equal(html.includes('id="risk-kind-input" value="pull_ready_for_review"'), true);
+  assert.equal(html.includes('id="pull-number-input" value="202"'), true);
+  assert.equal(html.includes("PR ready-for-review request"), true);
 });
 
 test("passkey operator page can scope issue close approval to merged pull proof", () => {


### PR DESCRIPTION
## This PR satisfies Intent

Butler currently blocks #202 because the PR is draft and the GitHub authority surface has no runtime-verified way to mark a draft PR ready for review before merge. This PR adds that missing approval-bound operation.

## Satisfied Success Criteria

- [x] Adds `pull_ready_for_review` to the GitHub high-risk authority operation registry.
- [x] Implements draft PR ready-for-review execution through GitHub runtime truth.
- [x] Treats already-ready PRs as no-op success with `changed=false`.
- [x] Adds passkey operator support for marking a PR ready for review.
- [x] Exposes the operation in Custom GPT OpenAPI schema and Butler instructions.
- [x] Adds regression coverage for registry, execution, no-op, and operator page behavior.

## Unsatisfied Success Criteria

None.

## Non-goal violations

None.

## Verification Evidence

- Unit: `node --test test/github-high-risk-plane.test.js test/passkey-operator-page.test.js test/custom-gpt-setup-docs.test.js test/worker.test.js`
- Integration: `npm test`
- E2E: Not run live against #202 in this PR; runtime path is source/test verified and still requires deployed Worker + real passkey before use.
- Manual: Confirmed #202 blocker was draft state from Butler runtime truth.
- Evidence path/link: `src/core/github-high-risk-plane.js`, `src/core/github-app-operation-registry.js`, `src/core/passkey-operator-page.js`, `docs/setup/custom-gpt-actions-openapi.yaml`, `docs/setup/custom-gpt-instructions-short.md`, `test/github-high-risk-plane.test.js`, `test/passkey-operator-page.test.js`

## Surface Update Checklist

- Cloudflare deploy: Not performed. Required before Butler can use this new deployed action surface.
- Custom GPT Action Schema update: Source artifact updated in `docs/setup/custom-gpt-actions-openapi.yaml` and `.json`.
- Custom GPT Instructions update: Source artifacts updated in long and short instructions.
- iPhone Butler live E2E: Not run.

## Related Constitution Rules

- GitHub runtime truth is canonical.
- Merge requires explicit human GO + real passkey.
- Draft PRs cannot be treated as merge-ready.
- Do not pretend blocked authority operations completed.

## Out-of-scope but NOT implemented

- Merging #202.
- Closing #194.
- Deploying the Worker.
- Mutating secrets, permissions, or repository settings.

## Extra changes (if any)

None.
