### PR TITLE
Fix iPhone-only reviewer re-check after revise_pr resolution

### DIFF
--- a/docs/butler/gemini-pr-review-comments.md
+++ b/docs/butler/gemini-pr-review-comments.md
@@ -120,6 +120,24 @@ When Gemini becomes available again after a fallback request, VTDD should
 return to Gemini-first behavior and clear the stale Codex fallback request
 state.
 
+## Objection Resolution Re-Check
+
+For the iPhone-only `revise_pr` loop, a VPS/Codex revision may be followed by a
+GitHub-visible objection-resolution comment from the VTDD bot:
+
+`<!-- vtdd:reviewer-objection-resolution -->`
+
+That marker is allowed to trigger a Gemini re-check even when the comment author
+is a bot. Gemini's own `vtdd:reviewer=gemini` marker remains loop-protected and
+must not self-trigger a review.
+
+This rule is based on live Issue #206 / PR #207 evidence: the VPS runner added
+the requested `revision-applied marker`, but Gemini skipped the bot-authored
+resolution marker as `bot_or_marker_comment`. A Mac-authored follow-up comment
+was then required to move Gemini to `approve`, which failed the iPhone-only
+completion baseline. The resolution marker must therefore be treated as trusted
+review context, not as a generic marker comment.
+
 ## Setup Boundary
 
 This workflow is designed for public/per-user use:

--- a/src/core/gemini-pr-review.js
+++ b/src/core/gemini-pr-review.js
@@ -1,6 +1,7 @@
 import { validateReviewerResponse } from "./reviewer-contract.js";
 
 export const GEMINI_PR_REVIEW_MARKER = "<!-- vtdd:reviewer=gemini -->";
+export const REVIEWER_OBJECTION_RESOLUTION_MARKER = "<!-- vtdd:reviewer-objection-resolution -->";
 export const DEFAULT_GEMINI_REVIEW_MODEL = "gemini-2.5-flash";
 export const MAX_DIFF_CHARACTERS = 60000;
 export const MAX_CONTEXT_COMMENTS = 10;
@@ -31,7 +32,7 @@ export function resolveGeminiReviewTrigger(input = {}) {
     if (!issue.pull_request) {
       return skip("issue_comment_not_for_pull_request");
     }
-    if (isBotTriggered(payload) || containsMarker(comment.body)) {
+    if (!isTrustedReviewerObjectionResolution(comment.body) && (isBotTriggered(payload) || containsMarker(comment.body))) {
       return skip("bot_or_marker_comment");
     }
     return {
@@ -300,7 +301,7 @@ export function parseGeminiReviewComment(comment = {}) {
 function summarizeComments(comments) {
   const list = Array.isArray(comments) ? comments : [];
   return list
-    .filter((comment) => !containsMarker(comment?.body))
+    .filter((comment) => !containsMarker(comment?.body) || isTrustedReviewerObjectionResolution(comment?.body))
     .slice(-MAX_CONTEXT_COMMENTS)
     .map((comment) => {
       const author = normalizeText(comment?.user?.login) || "unknown";
@@ -344,6 +345,10 @@ function isBotTriggered(payload) {
 
 function containsMarker(value) {
   return normalizeText(value).includes(GEMINI_PR_REVIEW_MARKER);
+}
+
+function isTrustedReviewerObjectionResolution(value) {
+  return normalizeText(value).includes(REVIEWER_OBJECTION_RESOLUTION_MARKER);
 }
 
 function normalizeInlineText(value) {

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -165,6 +165,7 @@ export {
   GEMINI_PR_REVIEW_MARKER,
   MAX_CONTEXT_COMMENTS,
   MAX_DIFF_CHARACTERS,
+  REVIEWER_OBJECTION_RESOLUTION_MARKER,
   buildGeminiReviewRequestBody,
   buildPullRequestDiff,
   buildPullRequestReviewContext,

--- a/test/gemini-pr-review.test.js
+++ b/test/gemini-pr-review.test.js
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import {
   GEMINI_PR_REVIEW_MARKER,
+  REVIEWER_OBJECTION_RESOLUTION_MARKER,
   buildGeminiReviewRequestBody,
   buildPullRequestDiff,
   buildPullRequestReviewContext,
@@ -70,6 +71,61 @@ test("issue_comment on PR from bot marker is skipped", () => {
   assert.equal(result.value.shouldReview, false);
 });
 
+test("issue_comment on PR from bot objection resolution triggers Gemini re-check", () => {
+  const result = resolveGeminiReviewTrigger({
+    eventName: "issue_comment",
+    payload: {
+      issue: {
+        number: 207,
+        pull_request: {
+          url: "https://api.github.com/repos/marushu/vtdd-v2-p/pulls/207"
+        }
+      },
+      comment: {
+        body: `${REVIEWER_OBJECTION_RESOLUTION_MARKER}
+## VTDD Reviewer Objection Resolution
+
+The manual-test objection has been addressed because revision-applied marker is present.`
+      },
+      sender: {
+        login: "vtdd-codex[bot]"
+      }
+    }
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.value.shouldReview, true);
+  assert.equal(result.value.trigger, "issue_comment:created");
+  assert.equal(result.value.pullRequestNumber, 207);
+});
+
+test("issue_comment on PR from Gemini marker still skips self-trigger loop", () => {
+  const result = resolveGeminiReviewTrigger({
+    eventName: "issue_comment",
+    payload: {
+      issue: {
+        number: 207,
+        pull_request: {
+          url: "https://api.github.com/repos/marushu/vtdd-v2-p/pulls/207"
+        }
+      },
+      comment: {
+        body: `${GEMINI_PR_REVIEW_MARKER}
+## VTDD Gemini Critical Review
+
+- Recommended action: \`approve\``
+      },
+      sender: {
+        login: "vtdd-codex[bot]"
+      }
+    }
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.value.shouldReview, false);
+  assert.equal(result.value.reason, "bot_or_marker_comment");
+});
+
 test("buildPullRequestDiff truncates large diffs", () => {
   const diff = buildPullRequestDiff(
     [
@@ -107,6 +163,39 @@ test("buildPullRequestReviewContext includes bounded PR metadata", () => {
   assert.equal(context.includes("Repository: sample/repo"), true);
   assert.equal(context.includes("Please re-check this path."), true);
   assert.equal(context.includes("Overall risky."), true);
+});
+
+test("buildPullRequestReviewContext keeps objection resolution evidence", () => {
+  const context = buildPullRequestReviewContext({
+    repository: "sample/repo",
+    trigger: "issue_comment:created",
+    pullRequest: {
+      number: 207,
+      title: "Issue #206: VTDD VPS runner handoff",
+      body: "Smoke test.",
+      state: "open",
+      base: { ref: "main" },
+      head: { ref: "codex/issue-206" },
+      user: { login: "marushu" }
+    },
+    files: [{ filename: "docs/mvp/e2e/vps-revise-pr-objection-smoke.md", status: "added" }],
+    issueComments: [
+      {
+        user: { login: "vtdd-codex[bot]" },
+        body: `${GEMINI_PR_REVIEW_MARKER}\nold review`
+      },
+      {
+        user: { login: "vtdd-codex[bot]" },
+        body: `${REVIEWER_OBJECTION_RESOLUTION_MARKER}
+The manual-test objection has been addressed because revision-applied marker is present.`
+      }
+    ],
+    reviewComments: [],
+    reviews: []
+  });
+
+  assert.equal(context.includes("old review"), false);
+  assert.equal(context.includes("revision-applied marker is present"), true);
 });
 
 test("buildGeminiReviewRequestBody requires diff and context", () => {


### PR DESCRIPTION
## This PR satisfies Intent

Addresses #208 by removing the Mac-authored comment workaround from the reviewer re-check path. A trusted `vtdd:reviewer-objection-resolution` comment can now trigger Gemini re-review even when posted by the VTDD bot, while Gemini's own marker remains loop-protected.

## Satisfied Success Criteria

- Bot-authored `vtdd:reviewer-objection-resolution` comments can trigger Gemini re-check.
- `vtdd:reviewer=gemini` comments still skip self-trigger loops.
- Generic bot / marker comments remain skipped.
- Issue #206 / PR #207 Mac workaround failure mode is documented as evidence.
- Unit tests pass locally.

## Unsatisfied Success Criteria

- Live iPhone-only E2E re-check on the deployed runtime remains pending because this PR is not merged or deployed.

## Non-goal violations

None.

## Verification Evidence

- Unit: `node --test test/gemini-pr-review.test.js`
- Integration: `node --test test/gemini-pr-review.test.js test/execution-continuity.test.js test/butler-review-synthesis.test.js test/codex-review-fallback.test.js`
- CI: pending/current PR checks.
- Reviewer: Gemini review currently reports `approve` on PR #209.

## Surface Update Checklist

- Cloudflare deploy: Not performed.
- Custom GPT Action Schema update: Not required.
- Custom GPT Instructions update: Not required.
- iPhone Butler live E2E: This PR removes the Mac-authored comment workaround requirement, pending merge/deploy/live validation under separate GO.

## Related Constitution Rules

- Butler must not erase meaningful reviewer objections.
- Reviewer remains critique-only.
- Human keeps revision GO / merge GO + real passkey authority.
- Public/core flow must not depend on owner-specific Mac desktop state.

## Out-of-scope but NOT implemented

- Merge.
- Deploy.
- Issue close.
- Secret, permission, or repository settings mutation.
- Broad reviewer backend redesign.

## Extra changes (if any)

None.
