### PR TITLE
[codex] Fix GitHub authority merge fetch binding

### DIFF
--- a/docs/mvp/e2e/e2e-15-github-high-risk-authority-plane.md
+++ b/docs/mvp/e2e/e2e-15-github-high-risk-authority-plane.md
@@ -26,6 +26,7 @@ Observed result on 2026-04-26:
 - confirms `pull_merge` executes through `/v2/action/github-authority`
 - confirms merge requires a real approval grant resolved from passkey memory, not chat phrase substitution alone
 - confirms the authority response includes GitHub-visible merge state such as `merged: true`, merge `sha`, and `htmlUrl`
+- confirms `pull_merge` re-reads PR runtime truth after the merge API dispatch and returns `mergedAt` / `mergeCommitSha` evidence when GitHub provides it
 - confirms bounded `issue_close` only proceeds after merged pull verification and returns the closed issue `htmlUrl`
 
 ## Boundary-path Run
@@ -41,6 +42,18 @@ Observed result on 2026-04-26:
 - confirms missing real approval grant is rejected by the high-risk plane
 - confirms bounded issue close is rejected with `bounded issue close requires a merged pull request` when merged pull proof is absent
 - confirms merge and issue close remain outside the normal write plane and are not silently downgraded to `GO`-only execution
+
+## Issue #210 Runtime Failure Evidence
+
+Observed runtime failure from PR `#207` merge attempt:
+- operation: `pull_merge`
+- request method: `PUT`
+- endpoint: GitHub PR merge API for `marushu/vtdd-v2-p` PR `#207`
+- exception: `TypeError`
+- message: `Illegal invocation: function called with incorrect this reference`
+- runtime truth after the failure: PR `#207` remained unmerged
+
+Issue `#210` fixes this path by binding the default Worker `fetch` function before passing it through the high-risk plane. Tests now cover a Cloudflare-like default `fetch` that fails unless invoked with the correct `this` reference, plus the post-merge PR runtime-truth read.
 
 ## Evidence Files
 

--- a/src/core/github-high-risk-plane.js
+++ b/src/core/github-high-risk-plane.js
@@ -27,7 +27,7 @@ export async function executeGitHubHighRiskPlane(input = {}) {
   const approvalScope = input.approvalScope ?? null;
   const approvalGrant = input.approvalGrant ?? null;
   const env = input.env ?? {};
-  const fetchImpl = typeof env?.GITHUB_API_FETCH === "function" ? env.GITHUB_API_FETCH.bind(env) : fetch;
+  const fetchImpl = resolveGitHubHighRiskFetch(env);
   const apiBaseUrl = normalizeApiBaseUrl(env?.GITHUB_API_BASE_URL);
 
   const validation = validateGitHubHighRiskRequest({
@@ -231,6 +231,11 @@ async function executePullMerge(input) {
     };
   }
 
+  const runtimeTruth = await readPullRuntimeTruthAfterMerge({ ...input, encodedRepository });
+  if (!runtimeTruth.ok) {
+    return runtimeTruth;
+  }
+
   return {
     ok: true,
     authorityAction: {
@@ -240,7 +245,63 @@ async function executePullMerge(input) {
       merged: responseBody?.merged === true,
       sha: normalizeText(responseBody?.sha) || null,
       message: normalizeText(responseBody?.message) || null,
-      htmlUrl: `https://github.com/${input.repository}/pull/${input.pullNumber}`
+      htmlUrl:
+        normalizeText(runtimeTruth.pull?.htmlUrl) || `https://github.com/${input.repository}/pull/${input.pullNumber}`,
+      runtimeTruth: runtimeTruth.pull
+    }
+  };
+}
+
+async function readPullRuntimeTruthAfterMerge(input) {
+  const requestUrl = `${input.apiBaseUrl}/repos/${input.encodedRepository}/pulls/${input.pullNumber}`;
+  let response;
+  try {
+    response = await input.fetchImpl(requestUrl, {
+      method: "GET",
+      headers: githubJsonHeaders({ token: input.token })
+    });
+  } catch (error) {
+    return {
+      ok: false,
+      status: 503,
+      error: "github_high_risk_failed",
+      reason: `failed to read GitHub pull request runtime truth after merge: ${errorMessage(error)}`,
+      issues: ["github_merge_runtime_truth_fetch_exception"],
+      diagnostics: {
+        operation: input.operation,
+        requestMethod: "GET",
+        requestUrl,
+        exceptionName: errorName(error),
+        exceptionMessage: errorMessage(error)
+      }
+    };
+  }
+
+  const responseBody = await readJsonSafe(response);
+  if (!response.ok) {
+    return {
+      ok: false,
+      status: response.status,
+      error: "github_high_risk_failed",
+      reason: normalizeText(responseBody?.message) || "failed to read GitHub pull request runtime truth after merge",
+      diagnostics: {
+        operation: input.operation,
+        requestMethod: "GET",
+        requestUrl,
+        githubStatus: response.status,
+        githubMessage: normalizeText(responseBody?.message) || null,
+        githubDocumentationUrl: normalizeText(responseBody?.documentation_url) || null
+      }
+    };
+  }
+
+  return {
+    ok: true,
+    pull: {
+      merged: responseBody?.merged === true || Boolean(normalizeText(responseBody?.merged_at)),
+      mergedAt: normalizeText(responseBody?.merged_at) || null,
+      mergeCommitSha: normalizeText(responseBody?.merge_commit_sha) || null,
+      htmlUrl: normalizeText(responseBody?.html_url) || null
     }
   };
 }
@@ -368,6 +429,13 @@ function encodeURIComponentRepository(repository) {
     .split("/")
     .map((part) => encodeURIComponent(part))
     .join("/");
+}
+
+function resolveGitHubHighRiskFetch(env) {
+  if (typeof env?.GITHUB_API_FETCH === "function") {
+    return env.GITHUB_API_FETCH.bind(env);
+  }
+  return globalThis.fetch.bind(globalThis);
 }
 
 async function readJsonSafe(response) {

--- a/test/github-high-risk-plane.test.js
+++ b/test/github-high-risk-plane.test.js
@@ -139,7 +139,10 @@ test("github high-risk plane merges a pull request with scoped approval grant", 
           JSON.stringify({
             sha: "abc123",
             merged: true,
-            message: "Pull Request successfully merged"
+            message: "Pull Request successfully merged",
+            merged_at: "2026-05-09T01:02:03Z",
+            merge_commit_sha: "def456",
+            html_url: "https://github.com/sample-org/vtdd-v2-p/pull/21"
           }),
           { status: 200, headers: { "content-type": "application/json" } }
         );
@@ -150,7 +153,68 @@ test("github high-risk plane merges a pull request with scoped approval grant", 
   assert.equal(result.ok, true);
   assert.equal(result.authorityAction.operation, "pull_merge");
   assert.equal(result.authorityAction.merged, true);
+  assert.deepEqual(result.authorityAction.runtimeTruth, {
+    merged: true,
+    mergedAt: "2026-05-09T01:02:03Z",
+    mergeCommitSha: "def456",
+    htmlUrl: "https://github.com/sample-org/vtdd-v2-p/pull/21"
+  });
   assert.equal(calls[0].init.method, "PUT");
+  assert.equal(calls[1].init.method, "GET");
+});
+
+test("github high-risk plane binds default fetch for Cloudflare Worker merge dispatch", async () => {
+  const originalFetch = globalThis.fetch;
+  const calls = [];
+  globalThis.fetch = async function cloudflareLikeFetch(url, init) {
+    assert.equal(this, globalThis);
+    calls.push({ url, init });
+    if (init?.method === "PUT") {
+      return new Response(
+        JSON.stringify({
+          sha: "abc123",
+          merged: true,
+          message: "Pull Request successfully merged"
+        }),
+        { status: 200, headers: { "content-type": "application/json" } }
+      );
+    }
+    return new Response(
+      JSON.stringify({
+        merged: true,
+        merged_at: "2026-05-09T01:02:03Z",
+        merge_commit_sha: "def456",
+        html_url: "https://github.com/sample-org/vtdd-v2-p/pull/21"
+      }),
+      { status: 200, headers: { "content-type": "application/json" } }
+    );
+  };
+
+  try {
+    const result = await executeGitHubHighRiskPlane({
+      operation: GitHubHighRiskOperation.PULL_MERGE,
+      repository: "sample-org/vtdd-v2-p",
+      issueNumber: 55,
+      pullNumber: 21,
+      mergeMethod: "squash",
+      approvalPhrase: "GO",
+      targetConfirmed: true,
+      approvalGrant: mergeGrant,
+      approvalScope: mergeGrant.scope,
+      env: {
+        GITHUB_APP_INSTALLATION_TOKEN: "ghs_high_risk"
+      }
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.authorityAction.runtimeTruth.mergedAt, "2026-05-09T01:02:03Z");
+    assert.deepEqual(
+      calls.map((call) => call.init.method),
+      ["PUT", "GET"]
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
 });
 
 test("github high-risk plane requires merge method from registry", async () => {

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -3087,6 +3087,99 @@ test("worker allows same-origin passkey operator to dispatch GitHub merge author
   assert.equal(body.authorityAction.htmlUrl, "https://github.com/sample-org/vtdd-v2-p/pull/21");
 });
 
+test("worker uses bound default fetch for GitHub merge authority dispatch", async () => {
+  const provider = createInMemoryMemoryProvider();
+  await provider.store({
+    id: "approval-merge-bound-fetch",
+    type: MemoryRecordType.APPROVAL_LOG,
+    content: {
+      kind: "passkey_grant",
+      status: "verified",
+      approvalId: "approval-merge-bound-fetch",
+      expiresAt: "2099-01-01T00:00:00.000Z",
+      scope: {
+        actionType: "merge",
+        highRiskKind: "pull_merge",
+        repositoryInput: "sample-org/vtdd-v2-p",
+        issueNumber: "55",
+        phase: "execution"
+      }
+    },
+    metadata: { source: "test" },
+    priority: 90,
+    tags: ["passkey_grant"],
+    createdAt: "2026-04-26T00:00:00.000Z"
+  });
+
+  const originalFetch = globalThis.fetch;
+  const calls = [];
+  globalThis.fetch = async function workerRuntimeFetch(url, init) {
+    assert.equal(this, globalThis);
+    calls.push({ url, init });
+    if (init?.method === "PUT") {
+      return new Response(
+        JSON.stringify({
+          sha: "abc123",
+          merged: true,
+          message: "Pull Request successfully merged"
+        }),
+        { status: 200, headers: { "content-type": "application/json" } }
+      );
+    }
+    return new Response(
+      JSON.stringify({
+        merged: true,
+        merged_at: "2026-05-09T01:02:03Z",
+        merge_commit_sha: "def456",
+        html_url: "https://github.com/sample-org/vtdd-v2-p/pull/21"
+      }),
+      { status: 200, headers: { "content-type": "application/json" } }
+    );
+  };
+
+  try {
+    const response = await worker.fetch(
+      new Request("https://example.com/v2/action/github-authority", {
+        method: "POST",
+        headers: {
+          ...gatewayAuthHeaders,
+          "content-type": "application/json"
+        },
+        body: JSON.stringify({
+          operation: "pull_merge",
+          repository: "sample-org/vtdd-v2-p",
+          pullNumber: 21,
+          mergeMethod: "squash",
+          issueContext: {
+            issueNumber: 55
+          },
+          policyInput: {
+            approvalPhrase: "GO",
+            approvalGrantId: "approval-merge-bound-fetch",
+            targetConfirmed: true
+          }
+        })
+      }),
+      {
+        ...gatewayAuthEnv,
+        MEMORY_PROVIDER: provider,
+        GITHUB_APP_INSTALLATION_TOKEN: "ghs_high_risk"
+      }
+    );
+
+    assert.equal(response.status, 200);
+    const body = await response.json();
+    assert.equal(body.ok, true);
+    assert.equal(body.authorityAction.runtimeTruth.mergedAt, "2026-05-09T01:02:03Z");
+    assert.deepEqual(
+      calls.map((call) => call.init.method),
+      ["PUT", "GET"]
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test("worker returns GitHub merge diagnostics to same-origin passkey operator", async () => {
   const provider = createInMemoryMemoryProvider();
   await provider.store({


### PR DESCRIPTION
## This PR satisfies Intent

Fixes Issue #210 by repairing the GitHub authority `pull_merge` execution path so Cloudflare Worker runtime function binding does not trigger `Illegal invocation`.

## Satisfied Success Criteria

- Updates the `pull_merge` authority path to avoid incorrect `this` binding during GitHub merge API dispatch.
- Preserves explicit human GO + real passkey authority for merge.
- Preserves repository / issue / PR scope validation.
- Adds or updates focused coverage for the merge authority behavior.
- Keeps GitHub API failures distinct from Worker binding errors.
- Documents or preserves runtime evidence from the PR #207 / PR #214 merge failure mode.

## Unsatisfied Success Criteria

- Live production merge verification is not completed in this PR because deployment and merge remain separately approved high-risk actions.

## Verification Evidence

- Local / CI test workflow is expected to validate the implementation.
- Current PR #215 `test` check is passing.
- Current PR #215 `review` check is passing.
- This PR body update is intended to satisfy `guarded-autonomy-required-checks` required markers.

## Surface Update Checklist

- Custom GPT Instructions: not required unless reviewer finds Butler behavior changes.
- Action Schema: not required unless implementation changes exposed API shape.
- Cloudflare deploy: required after merge to make the Worker authority fix active.
- Secrets / permissions / repository settings: not required.