### PR TITLE
Bump OpenAPI spec to 3.0.3 and update tests

### DIFF
--- a/docs/setup/custom-gpt-actions-openapi.json
+++ b/docs/setup/custom-gpt-actions-openapi.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.1.0",
+  "openapi": "3.0.3",
   "info": {
     "title": "VTDD Butler Action API",
     "version": "0.1.0",

--- a/docs/setup/custom-gpt-actions-openapi.yaml
+++ b/docs/setup/custom-gpt-actions-openapi.yaml
@@ -1,4 +1,4 @@
-openapi: 3.1.0
+openapi: 3.0.3
 info:
   title: VTDD Butler Action API
   version: 0.1.0

--- a/test/custom-gpt-setup-docs.test.js
+++ b/test/custom-gpt-setup-docs.test.js
@@ -203,7 +203,7 @@ test("short custom gpt instructions stay under editor limits while preserving cr
 
 test("custom gpt openapi doc exposes current gateway, execute, and progress routes", () => {
   const doc = fs.readFileSync(OPENAPI_PATH, "utf8");
-  assert.equal(doc.includes("openapi: 3.1.0"), true);
+  assert.equal(doc.includes("openapi: 3.0.3"), true);
   assert.equal(doc.includes("/v2/gateway:"), true);
   assert.equal(doc.includes("/v2/action/execute:"), true);
   assert.equal(doc.includes("/v2/action/github:"), true);
@@ -260,7 +260,7 @@ test("custom gpt openapi keeps components.schemas while avoiding nested field re
 
 test("custom gpt openapi json parses and exposes paths as an object", () => {
   const doc = JSON.parse(fs.readFileSync(OPENAPI_JSON_PATH, "utf8"));
-  assert.equal(doc.openapi, "3.1.0");
+  assert.equal(doc.openapi, "3.0.3");
   assert.equal(typeof doc.paths, "object");
   assert.notEqual(doc.paths, null);
   assert.equal(typeof doc.paths["/v2/gateway"], "object");


### PR DESCRIPTION
### Motivation
- Align the packaged OpenAPI documents with the expected spec version by changing the `openapi` field from `3.1.0` to `3.0.3` so the docs and runtime expectations are consistent.

### Description
- Updated `openapi` in `docs/setup/custom-gpt-actions-openapi.yaml` and `docs/setup/custom-gpt-actions-openapi.json` from `3.1.0` to `3.0.3` and adjusted test expectations in `test/custom-gpt-setup-docs.test.js` to assert the new version.

### Testing
- Ran the related unit tests (`test/custom-gpt-setup-docs.test.js`) via `npm test` and the updated assertions passed, confirming the YAML content and parsed JSON `openapi` value match `3.0.3`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fec8412d44832fa0bcc2bb2242b607)