### PR TITLE
docs: update Custom GPT Action OpenAPI spec to 3.1.1

### DIFF
--- a/docs/setup/custom-gpt-actions-openapi.json
+++ b/docs/setup/custom-gpt-actions-openapi.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.0.3",
+  "openapi": "3.1.1",
   "info": {
     "title": "VTDD Butler Action API",
     "version": "0.1.0",

--- a/docs/setup/custom-gpt-actions-openapi.yaml
+++ b/docs/setup/custom-gpt-actions-openapi.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.3
+openapi: 3.1.1
 info:
   title: VTDD Butler Action API
   version: 0.1.0


### PR DESCRIPTION
### Motivation
- Validator for Custom GPT Action schemas requires OpenAPI `3.1.0`/`3.1.1`, so the spec was bumped to `3.1.1` to resolve the validation error.

### Description
- Set `openapi: 3.1.1` in `docs/setup/custom-gpt-actions-openapi.yaml` and `docs/setup/custom-gpt-actions-openapi.json` and left all endpoints/schemas unchanged.

### Testing
- Executed `python - <<'PY' ... json.loads(Path("docs/setup/custom-gpt-actions-openapi.json").read_text())` which parsed the JSON successfully, and verified `head -n 3 docs/setup/custom-gpt-actions-openapi.yaml` shows `openapi: 3.1.1`; an attempted YAML parse using `PyYAML` failed due to `ModuleNotFoundError: No module named 'yaml'` in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fed7582364832f93909996743f5ffe)