### PR TITLE
Return action-visible JSON envelope for repository nickname retrieval auth failures

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -446,12 +446,21 @@ export default {
     }
 
     if (request.method === "GET" && isApiPath(url.pathname, "/retrieve/repository-nicknames")) {
+      const actionVisible = wantsActionVisibleRetrieveErrors(url);
       const auth = authorizeGatewayRequest({
         request,
         env,
         apiSuffix: "/retrieve/repository-nicknames"
       });
       if (!auth.ok) {
+        if (actionVisible) {
+          return json(200, {
+            ok: false,
+            httpStatus: auth.status,
+            error: "unauthorized",
+            reason: auth.reason
+          });
+        }
         return json(auth.status, {
           ok: false,
           error: "unauthorized",
@@ -823,6 +832,11 @@ async function handleGitHubWritePlaneRequest(request, env) {
 
 function wantsActionVisibleGitHubWriteErrors(payload) {
   const responseMode = normalizeText(payload?.responseMode);
+  return responseMode === "action_visible";
+}
+
+function wantsActionVisibleRetrieveErrors(url) {
+  const responseMode = normalizeText(url?.searchParams?.get("responseMode"));
   return responseMode === "action_visible";
 }
 

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -1986,6 +1986,21 @@ test("worker surfaces repository nickname retrieval failures as action-visible J
   assert.deepEqual(body.aliasRegistry, []);
 });
 
+test("worker can return action-visible unauthorized envelope for repository nickname retrieval", async () => {
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/retrieve/repository-nicknames?responseMode=action_visible"),
+    {
+      VTDD_GATEWAY_BEARER_TOKEN: "required-token"
+    }
+  );
+
+  assert.equal(response.status, 200);
+  const body = await response.json();
+  assert.equal(body.ok, false);
+  assert.equal(body.httpStatus, 401);
+  assert.equal(body.error, "unauthorized");
+});
+
 test("worker gateway can resolve stored repository nickname against live repository index", async () => {
   const provider = createInMemoryMemoryProvider();
   await provider.store({


### PR DESCRIPTION
### Motivation
- Custom GPT Actions that call the nickname retrieval endpoint can surface `ClientResponseError` transport failures when the gateway returns non-200 HTTP statuses, making it hard for the Action to parse structured error details.
- Provide an opt-in, machine-readable envelope so Action consumers can request `responseMode=action_visible` and receive `ok:false` JSON with `httpStatus` instead of a transport-level failure.
- Keep existing behavior unchanged for clients that do not request the action-visible envelope.

### Description
- Add `wantsActionVisibleRetrieveErrors(url)` helper and use it in the `GET /v2/retrieve/repository-nicknames` handler to detect `responseMode=action_visible` requests (file: `src/worker.js`).
- When authorization fails and `responseMode=action_visible` is present, return `HTTP 200` with `{ ok:false, httpStatus, error, reason }` so callers receive structured JSON instead of triggering a transport error (file: `src/worker.js`).
- Add a unit test that verifies an action-visible unauthorized envelope is returned for nickname retrieval (file: `test/worker.test.js`).
- No changes were made to nickname persistence logic or other retrieve endpoints.

### Testing
- Ran `npm test -- test/worker.test.js` which executed the worker test suite and all tests passed (`79/79`).
- The new test `worker can return action-visible unauthorized envelope for repository nickname retrieval` passed as part of the suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fee38bfe58832f959f7d0314250daf)