### PR TITLE
Update OpenAPI version to 3.1.1 in docs

### DIFF
--- a/docs/setup/custom-gpt-actions-openapi.json
+++ b/docs/setup/custom-gpt-actions-openapi.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.0.3",
+  "openapi": "3.1.1",
   "info": {
     "title": "VTDD Butler Action API",
     "version": "0.1.0",

--- a/docs/setup/custom-gpt-actions-openapi.yaml
+++ b/docs/setup/custom-gpt-actions-openapi.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.3
+openapi: 3.1.1
 info:
   title: VTDD Butler Action API
   version: 0.1.0


### PR DESCRIPTION
### Motivation

- Align the documented OpenAPI specification with a newer OpenAPI minor version by updating from `3.0.3` to `3.1.1` in the API docs.

### Description

- Updated the `openapi` field in `docs/setup/custom-gpt-actions-openapi.json` and `docs/setup/custom-gpt-actions-openapi.yaml` from `3.0.3` to `3.1.1`.

### Testing

- No automated tests were run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69feef151990832f9d3035cf2dcbf162)