### PR TITLE
feat: mention execution actor on VPS runner milestones

### DIFF
--- a/docs/butler/remote-codex-cli-executor.md
+++ b/docs/butler/remote-codex-cli-executor.md
@@ -332,6 +332,15 @@ failure as blocked. If the latest running event is older than the stale
 threshold, Butler must surface `vps_runner_event_stale` with the last step and
 age instead of treating an existing pushed branch as healthy progress forever.
 
+Runner event comments may include a GitHub mention only as a notification
+mirror; the JSON event payload and branch / PR evidence remain the runtime
+truth. The mention target is selected in this priority order when a login is
+available and not a bot or notification-blocked actor: queue comment author,
+Issue author, PR author, approval / GO actor, then no mention. Mentions are
+limited to milestone events (`picked_up`, `branch_pushed`, `pr_created`,
+`blocked`, `failed`, `stale`, `deploy_required`, `completed`). Heartbeat and
+progress-poll comments must not mention anyone.
+
 For explicit VPS runner health checks, Butler uses `vtddVpsRunnerStatus`. The
 status check is read-only and is derived from the same GitHub queue comment,
 runner event comments, branch, and PR truth as `vtddExecutionProgress`. It

--- a/scripts/run-vps-runner.mjs
+++ b/scripts/run-vps-runner.mjs
@@ -14,6 +14,16 @@ const EVENT_MARKER_RE = /<!--\s*vtdd:vps-runner-event:([a-zA-Z0-9._:-]+)\s*-->/;
 const DEFAULT_API_BASE_URL = "https://api.github.com";
 const DEFAULT_HEARTBEAT_SECONDS = 120;
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const MILESTONE_MENTION_EVENTS = new Set([
+  "picked_up",
+  "branch_pushed",
+  "pr_created",
+  "blocked",
+  "failed",
+  "stale",
+  "deploy_required",
+  "completed"
+]);
 
 async function main() {
   const options = parseArgs(process.argv.slice(2));
@@ -93,9 +103,16 @@ async function runVpsRunnerOnce({
 async function executeVpsRunnerExecution({ githubFetch, token, workRoot, execution }) {
   const { payload } = execution;
   const env = buildRunnerCommandEnv({ token });
+  const issue = await githubFetch(`/repos/${payload.repository}/issues/${payload.issueNumber}`);
+  const notification = buildVpsRunnerNotificationContext({
+    queueCommentAuthor: execution?.actors?.queueCommentAuthor,
+    issueAuthor: issue?.user?.login,
+    approvalActor: payload?.approvalActor
+  });
   await postVpsRunnerEvent({
     githubFetch,
     payload,
+    notification,
     event: {
       status: "running",
       lastEvent: "runner_started",
@@ -111,6 +128,7 @@ async function executeVpsRunnerExecution({ githubFetch, token, workRoot, executi
       env,
       githubFetch,
       payload,
+      notification,
       currentStep: "gh_repo_clone"
     });
     await checkoutVpsRunnerBranch({ payload, cwd: workspace, env });
@@ -118,6 +136,7 @@ async function executeVpsRunnerExecution({ githubFetch, token, workRoot, executi
     await postVpsRunnerEvent({
       githubFetch,
       payload,
+      notification,
       event: {
         status: "branch_created",
         lastEvent: "branch_pushed",
@@ -126,7 +145,6 @@ async function executeVpsRunnerExecution({ githubFetch, token, workRoot, executi
       }
     });
 
-    const issue = await githubFetch(`/repos/${payload.repository}/issues/${payload.issueNumber}`);
     const pullRequestContext = isPrRevisionGoal(payload.codexGoal)
       ? await buildVpsRunnerPullRequestContext({ githubFetch, payload })
       : null;
@@ -138,6 +156,7 @@ async function executeVpsRunnerExecution({ githubFetch, token, workRoot, executi
       maxBuffer: 1024 * 1024 * 12,
       githubFetch,
       payload,
+      notification,
       currentStep: "codex_subprocess"
     });
 
@@ -160,6 +179,7 @@ async function executeVpsRunnerExecution({ githubFetch, token, workRoot, executi
       await postVpsRunnerEvent({
         githubFetch,
         payload,
+        notification,
         event: {
           status: "failed",
           lastEvent: "revision_no_changes",
@@ -185,7 +205,7 @@ async function executeVpsRunnerExecution({ githubFetch, token, workRoot, executi
         candidateBody: existingPullRequest.body
       });
       if (!normalized.ok) {
-        await postVpsRunnerPrBodyBlockedEvent({ githubFetch, payload, normalized });
+        await postVpsRunnerPrBodyBlockedEvent({ githubFetch, payload, normalized, notification });
         return { ok: false, reason: normalized.reason };
       }
       if (normalized.normalized) {
@@ -199,6 +219,7 @@ async function executeVpsRunnerExecution({ githubFetch, token, workRoot, executi
           env,
           githubFetch,
           payload,
+          notification,
           currentStep: "gh_pr_edit"
         });
       }
@@ -208,7 +229,7 @@ async function executeVpsRunnerExecution({ githubFetch, token, workRoot, executi
         candidateBody: extractCodexPrBodyDraft(payload)
       });
       if (!normalized.ok) {
-        await postVpsRunnerPrBodyBlockedEvent({ githubFetch, payload, normalized });
+        await postVpsRunnerPrBodyBlockedEvent({ githubFetch, payload, normalized, notification });
         return { ok: false, reason: normalized.reason };
       }
       const pr = await runTrackedVpsCommand(
@@ -231,6 +252,7 @@ async function executeVpsRunnerExecution({ githubFetch, token, workRoot, executi
           env,
           githubFetch,
           payload,
+          notification,
           currentStep: "gh_pr_create"
         }
       );
@@ -240,6 +262,10 @@ async function executeVpsRunnerExecution({ githubFetch, token, workRoot, executi
     await postVpsRunnerEvent({
       githubFetch,
       payload,
+      notification: buildVpsRunnerNotificationContext({
+        ...notification,
+        pullRequestAuthor: existingPullRequest?.author?.login
+      }),
       event: {
         status: "pr_created",
         lastEvent: isPrRevisionGoal(payload.codexGoal) ? "pull_request_updated" : "pull_request_created",
@@ -255,6 +281,7 @@ async function executeVpsRunnerExecution({ githubFetch, token, workRoot, executi
     await postVpsRunnerEvent({
       githubFetch,
       payload,
+      notification,
       event: {
         status: "failed",
         lastEvent: "runner_failed",
@@ -278,7 +305,10 @@ function selectPendingVpsRunnerExecutions({ comments, allowedRepositories, repos
         ...queue,
         commentId: comment.id,
         commentUrl: comment.html_url,
-        createdAt: comment.created_at
+        createdAt: comment.created_at,
+        actors: {
+          queueCommentAuthor: normalizeGitHubLogin(comment?.user?.login)
+        }
       });
       continue;
     }
@@ -410,6 +440,7 @@ function parseVpsRunnerQueueComment(body) {
     baseRef: normalizeText(payload.baseRef) || "main",
     codexGoal: normalizeText(payload.codexGoal),
     approvalScopeMatched: payload.approvalScopeMatched === true,
+    approvalActor: normalizeGitHubLogin(payload.approvalActor),
     handoff: payload.handoff || null
   };
 
@@ -453,8 +484,14 @@ function parseVpsRunnerEventComment(body) {
   return { ok: true, executionId: marker[1], event };
 }
 
-function buildVpsRunnerEventComment({ executionId, event }) {
-  return [`<!-- vtdd:vps-runner-event:${executionId} -->`, "VTDD VPS runner event.", "", fencedJson(event)].join("\n");
+function buildVpsRunnerEventComment({ executionId, event, notification } = {}) {
+  const mention = resolveVpsRunnerMention({ event, notification });
+  const lines = [`<!-- vtdd:vps-runner-event:${executionId} -->`];
+  if (mention) {
+    lines.push(`@${mention}`);
+  }
+  lines.push("VTDD VPS runner event.", "", fencedJson(event));
+  return lines.join("\n");
 }
 
 function buildCodexExecutionPrompt({ payload, issue = {}, pullRequestContext = null }) {
@@ -698,12 +735,13 @@ async function executeVpsReviewerFallback({ token, reviewerFallback }) {
   }
 }
 
-async function postVpsRunnerEvent({ githubFetch, payload, event }) {
+async function postVpsRunnerEvent({ githubFetch, payload, event, notification }) {
   return githubFetch(`/repos/${payload.repository}/issues/${payload.issueNumber}/comments`, {
     method: "POST",
     body: {
       body: buildVpsRunnerEventComment({
         executionId: payload.executionId,
+        notification,
         event: {
           ...event,
           executionId: payload.executionId,
@@ -719,7 +757,7 @@ async function findExistingPullRequest({ repository, branch, env, cwd, githubFet
   try {
     const result = await runTrackedVpsCommand(
       "gh",
-      ["pr", "list", "--repo", repository, "--head", branch, "--json", "number,url,body", "--limit", "1"],
+      ["pr", "list", "--repo", repository, "--head", branch, "--json", "number,url,body,author", "--limit", "1"],
       {
         cwd,
         env,
@@ -736,7 +774,7 @@ async function findExistingPullRequest({ repository, branch, env, cwd, githubFet
 }
 
 async function runTrackedVpsCommand(command, args, options = {}) {
-  const { githubFetch, payload, currentStep } = options;
+  const { githubFetch, payload, currentStep, notification } = options;
   if (!githubFetch || !payload || !currentStep || !["codex", "gh"].includes(command)) {
     return runCommand(command, args, options);
   }
@@ -745,6 +783,7 @@ async function runTrackedVpsCommand(command, args, options = {}) {
   await postVpsRunnerEvent({
     githubFetch,
     payload,
+    notification,
     event: {
       status: "running",
       lastEvent: `${currentStep}_started`,
@@ -768,6 +807,7 @@ async function runTrackedVpsCommand(command, args, options = {}) {
           postVpsRunnerEvent({
             githubFetch,
             payload,
+            notification,
             event: {
               status: "running",
               lastEvent: `${currentStep}_heartbeat`,
@@ -795,6 +835,7 @@ async function runTrackedVpsCommand(command, args, options = {}) {
     await postVpsRunnerEvent({
       githubFetch,
       payload,
+      notification,
       event: {
         status: "running",
         lastEvent: `${currentStep}_completed`,
@@ -818,6 +859,7 @@ async function runTrackedVpsCommand(command, args, options = {}) {
     await postVpsRunnerEvent({
       githubFetch,
       payload,
+      notification,
       event: {
         status: "failed",
         lastEvent: `${currentStep}_failed`,
@@ -934,10 +976,11 @@ async function writePullRequestBodyFile({ workspace, payload, body }) {
   return bodyFile;
 }
 
-async function postVpsRunnerPrBodyBlockedEvent({ githubFetch, payload, normalized }) {
+async function postVpsRunnerPrBodyBlockedEvent({ githubFetch, payload, normalized, notification }) {
   await postVpsRunnerEvent({
     githubFetch,
     payload,
+    notification,
     event: {
       status: "blocked",
       lastEvent: "pr_body_normalization_blocked",
@@ -1040,6 +1083,51 @@ function summarizeDiagnosticText(value, maxLength = 500) {
   return redacted.length <= maxLength ? redacted : `${redacted.slice(0, maxLength)} [truncated]`;
 }
 
+function buildVpsRunnerNotificationContext(input = {}) {
+  return {
+    queueCommentAuthor: normalizeGitHubLogin(input.queueCommentAuthor),
+    issueAuthor: normalizeGitHubLogin(input.issueAuthor),
+    pullRequestAuthor: normalizeGitHubLogin(input.pullRequestAuthor),
+    approvalActor: normalizeGitHubLogin(input.approvalActor)
+  };
+}
+
+function resolveVpsRunnerMention({ event, notification } = {}) {
+  if (!isVpsRunnerMentionMilestone(event)) {
+    return "";
+  }
+  return [
+    notification?.queueCommentAuthor,
+    notification?.issueAuthor,
+    notification?.pullRequestAuthor,
+    notification?.approvalActor
+  ].find((login) => isMentionableGitHubLogin(login)) || "";
+}
+
+function isVpsRunnerMentionMilestone(event = {}) {
+  const candidates = [
+    normalizeText(event.notificationEvent),
+    normalizeText(event.status),
+    normalizeText(event.lastEvent),
+    normalizeText(event.currentStep)
+  ];
+  if (normalizeText(event.lastEvent) === "runner_started") {
+    candidates.push("picked_up");
+  }
+  return candidates.some((candidate) => MILESTONE_MENTION_EVENTS.has(candidate));
+}
+
+function isMentionableGitHubLogin(value) {
+  const login = normalizeGitHubLogin(value);
+  if (!login) {
+    return false;
+  }
+  if (["ghost", "unknown"].includes(login.toLowerCase())) {
+    return false;
+  }
+  return true;
+}
+
 function redactDiagnosticText(value) {
   return String(value || "")
     .replace(/gh[pousr]_[A-Za-z0-9_]{20,}/g, "[REDACTED_GITHUB_TOKEN]")
@@ -1095,6 +1183,17 @@ function fencedJson(value) {
 
 function normalizeText(value) {
   return typeof value === "string" ? value.trim() : "";
+}
+
+function normalizeGitHubLogin(value) {
+  const login = normalizeText(value);
+  if (!/^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/.test(login)) {
+    return "";
+  }
+  if (/\[bot\]$/i.test(login) || /bot$/i.test(login)) {
+    return "";
+  }
+  return login;
 }
 
 function extractBacktickedCommentValue(body, label) {

--- a/scripts/run-vps-runner.mjs
+++ b/scripts/run-vps-runner.mjs
@@ -104,7 +104,7 @@ async function executeVpsRunnerExecution({ githubFetch, token, workRoot, executi
   const { payload } = execution;
   const env = buildRunnerCommandEnv({ token });
   const issue = await githubFetch(`/repos/${payload.repository}/issues/${payload.issueNumber}`);
-  const notification = buildVpsRunnerNotificationContext({
+  let notification = buildVpsRunnerNotificationContext({
     queueCommentAuthor: execution?.actors?.queueCommentAuthor,
     issueAuthor: issue?.user?.login,
     approvalActor: payload?.approvalActor
@@ -133,6 +133,15 @@ async function executeVpsRunnerExecution({ githubFetch, token, workRoot, executi
     });
     await checkoutVpsRunnerBranch({ payload, cwd: workspace, env });
 
+    const pullRequestContext = isPrRevisionGoal(payload.codexGoal)
+      ? await buildVpsRunnerPullRequestContext({ githubFetch, payload })
+      : null;
+    let pullRequestAuthor = pullRequestContext?.pullRequest?.user?.login;
+    notification = buildVpsRunnerNotificationContext({
+      ...notification,
+      pullRequestAuthor
+    });
+
     await postVpsRunnerEvent({
       githubFetch,
       payload,
@@ -145,9 +154,6 @@ async function executeVpsRunnerExecution({ githubFetch, token, workRoot, executi
       }
     });
 
-    const pullRequestContext = isPrRevisionGoal(payload.codexGoal)
-      ? await buildVpsRunnerPullRequestContext({ githubFetch, payload })
-      : null;
     const prompt = buildCodexExecutionPrompt({ payload, issue, pullRequestContext });
     await runTrackedVpsCommand("codex", buildCodexExecArgs({ env: process.env }), {
       cwd: workspace,
@@ -198,6 +204,7 @@ async function executeVpsRunnerExecution({ githubFetch, token, workRoot, executi
       githubFetch,
       payload
     });
+    pullRequestAuthor = existingPullRequest?.author?.login || pullRequestAuthor;
     let prUrl = existingPullRequest?.url || "";
     if (prUrl) {
       const normalized = buildGuardedPullRequestBody({
@@ -257,6 +264,13 @@ async function executeVpsRunnerExecution({ githubFetch, token, workRoot, executi
         }
       );
       prUrl = pr.stdout.trim();
+      pullRequestAuthor =
+        (await readVpsRunnerPullRequestAuthor({
+          repository: payload.repository,
+          pr: prUrl,
+          env,
+          cwd: workspace
+        })) || pullRequestAuthor;
     }
 
     await postVpsRunnerEvent({
@@ -264,7 +278,7 @@ async function executeVpsRunnerExecution({ githubFetch, token, workRoot, executi
       payload,
       notification: buildVpsRunnerNotificationContext({
         ...notification,
-        pullRequestAuthor: existingPullRequest?.author?.login
+        pullRequestAuthor
       }),
       event: {
         status: "pr_created",
@@ -770,6 +784,20 @@ async function findExistingPullRequest({ repository, branch, env, cwd, githubFet
     return parsed[0] || null;
   } catch {
     return null;
+  }
+}
+
+async function readVpsRunnerPullRequestAuthor({ repository, pr, env, cwd }) {
+  const target = normalizeText(pr);
+  if (!target) {
+    return "";
+  }
+  try {
+    const result = await runCommand("gh", ["pr", "view", target, "--repo", repository, "--json", "author"], { cwd, env });
+    const parsed = JSON.parse(result.stdout || "{}");
+    return normalizeGitHubLogin(parsed?.author?.login);
+  } catch {
+    return "";
   }
 }
 

--- a/src/core/remote-codex-executor.js
+++ b/src/core/remote-codex-executor.js
@@ -115,6 +115,10 @@ export function createRemoteCodexExecutionRequest(input = {}) {
       normalizeText(payload?.executionTarget?.codexGoal) ||
       normalizeText(gatewayResult?.executionContinuity?.codexGoal),
     approvalPhrase: normalizeText(payload?.policyInput?.approvalPhrase),
+    approvalActor:
+      normalizeText(payload?.policyInput?.approvalActor) ||
+      normalizeText(payload?.policyInput?.goActor) ||
+      normalizeText(payload?.sender?.login),
     targetConfirmed: payload?.policyInput?.targetConfirmed === true,
     approvalScopeMatched,
     handoffRequired: continuationContext.requiresHandoff === true,
@@ -1285,6 +1289,7 @@ function buildVpsRunnerGitHubQueueComment({ request }) {
     baseRef: request.baseRef,
     codexGoal: request.codexGoal,
     approvalScopeMatched: request.approvalScopeMatched,
+    approvalActor: request.approvalActor,
     handoff: request.handoff
   };
   const lines = [

--- a/test/remote-codex-executor.test.js
+++ b/test/remote-codex-executor.test.js
@@ -524,8 +524,10 @@ test("remote Codex vps_runner dispatch posts a GitHub-backed queue comment", asy
           runtimeState: {
             activeBranch: "codex/issue-173"
           }
-        }
-      }
+        },
+        approvalActor: "requester"
+      },
+      sender: { login: "ignored-sender" }
     },
     gatewayResult: {
       repository: "sample-org/sunaba-eye",
@@ -560,6 +562,8 @@ test("remote Codex vps_runner dispatch posts a GitHub-backed queue comment", asy
   assert.equal(body.includes("VTDD-managed VPS runner execution request."), true);
   assert.equal(body.includes('"transport": "vps_runner"'), true);
   assert.equal(body.includes('"repository": "sample-org/sunaba-eye"'), true);
+  assert.equal(body.includes('"approvalActor": "requester"'), true);
+  assert.equal(body.includes("@marushu"), false);
   assert.equal(body.includes("Do not merge."), true);
   assert.equal(body.includes("docs/pr-template-model.md"), true);
   assert.equal(body.includes("scripts/render-pr-body.mjs"), true);

--- a/test/vps-runner-script.test.js
+++ b/test/vps-runner-script.test.js
@@ -67,6 +67,7 @@ test("VPS runner selects only allowlisted pending queues", () => {
       id: 1,
       html_url: "https://github.com/sample-org/vtdd-v2/issues/157#issuecomment-1",
       created_at: "2026-05-07T10:00:00Z",
+      user: { login: "alice" },
       body: queueComment({ executionId: "exec-1", repository: "sample-org/vtdd-v2" })
     },
     {
@@ -99,6 +100,7 @@ test("VPS runner selects only allowlisted pending queues", () => {
 
   assert.equal(selected.length, 1);
   assert.equal(selected[0].payload.executionId, "exec-1");
+  assert.equal(selected[0].actors.queueCommentAuthor, "alice");
 });
 
 test("VPS runner repository policies allow per-repo base refs and branch prefixes", () => {
@@ -213,6 +215,74 @@ test("VPS runner event comment is parseable by execution id", () => {
   assert.equal(parsed.event.command.exitCode, 1);
   assert.equal(parsed.event.command.stderrSummary, "Missing bearer authentication");
   assert.equal(parsed.event.rawFailure.error, "codex_auth_unavailable");
+});
+
+test("VPS runner milestone event mentions queue comment author", () => {
+  const body = buildVpsRunnerEventComment({
+    executionId: "exec-mention",
+    notification: {
+      queueCommentAuthor: "alice",
+      issueAuthor: "bob"
+    },
+    event: {
+      status: "branch_created",
+      lastEvent: "branch_pushed"
+    }
+  });
+
+  assert.equal(body.includes("@alice"), true);
+  assert.equal(body.includes("@bob"), false);
+  assert.equal(parseVpsRunnerEventComment(body).ok, true);
+});
+
+test("VPS runner heartbeat event does not mention anyone", () => {
+  const body = buildVpsRunnerEventComment({
+    executionId: "exec-heartbeat",
+    notification: {
+      queueCommentAuthor: "alice"
+    },
+    event: {
+      status: "running",
+      lastEvent: "codex_subprocess_heartbeat",
+      currentStep: "codex_subprocess"
+    }
+  });
+
+  assert.equal(body.includes("@alice"), false);
+});
+
+test("VPS runner notification falls back from bot queue actor to issue author", () => {
+  const body = buildVpsRunnerEventComment({
+    executionId: "exec-fallback",
+    notification: {
+      queueCommentAuthor: "github-actions[bot]",
+      issueAuthor: "issue-owner"
+    },
+    event: {
+      status: "failed",
+      lastEvent: "runner_failed"
+    }
+  });
+
+  assert.equal(body.includes("@issue-owner"), true);
+  assert.equal(body.includes("@github-actions"), false);
+});
+
+test("VPS runner notification omits mention when no mentionable actor exists", () => {
+  const body = buildVpsRunnerEventComment({
+    executionId: "exec-no-mention",
+    notification: {
+      queueCommentAuthor: "app/vtdd-codex",
+      issueAuthor: "ghost"
+    },
+    event: {
+      status: "failed",
+      lastEvent: "runner_failed"
+    }
+  });
+
+  assert.equal(body.includes("@"), false);
+  assert.equal(body.includes("VTDD VPS runner event."), true);
 });
 
 test("VPS runner diagnostic summaries redact secrets and stay short", () => {

--- a/test/vps-runner-script.test.js
+++ b/test/vps-runner-script.test.js
@@ -268,6 +268,26 @@ test("VPS runner notification falls back from bot queue actor to issue author", 
   assert.equal(body.includes("@github-actions"), false);
 });
 
+test("VPS runner notification can fall back to PR author on branch milestones", () => {
+  const body = buildVpsRunnerEventComment({
+    executionId: "exec-pr-author",
+    notification: {
+      queueCommentAuthor: "github-actions[bot]",
+      issueAuthor: "vtdd-codex[bot]",
+      pullRequestAuthor: "pr-owner",
+      approvalActor: "go-owner"
+    },
+    event: {
+      status: "branch_created",
+      lastEvent: "branch_pushed"
+    }
+  });
+
+  assert.equal(body.includes("@pr-owner"), true);
+  assert.equal(body.includes("@go-owner"), false);
+  assert.equal(body.includes("@github-actions"), false);
+});
+
 test("VPS runner notification omits mention when no mentionable actor exists", () => {
   const body = buildVpsRunnerEventComment({
     executionId: "exec-no-mention",


### PR DESCRIPTION
## This PR satisfies Intent

- VPS runner milestone comments now mention the inferred execution-origin GitHub actor without fixed usernames, while preserving runner event JSON as runtime truth.

## Satisfied Success Criteria

- Fixed @marushu-style notification targets are not used.
- VPS runner captures queue comment author as the first notification candidate.
- Queue payload can carry approval / GO actor as the last-priority candidate.
- Milestone runner events add a GitHub mention when a mentionable actor is available.
- Heartbeat and running progress events do not mention anyone.
- Bot, app-style, ghost, and unknown actors fall back to the next candidate or no mention.
- Mention priority is documented as queue comment author, Issue author, PR author, approval / GO actor, then no mention.

## Unsatisfied Success Criteria

- Live GitHub Mobile / Apple Watch notification delivery is not exercised in this PR; unit coverage verifies GitHub comment mention generation.

## Non-goal violations

None.

## Verification Evidence

- Unit: npm test passed (569 tests). Targeted: node --test test/vps-runner-script.test.js; node --test test/remote-codex-executor.test.js.
- Integration: VPS runner queue/event comment behavior covered by remote Codex executor and VPS runner script tests.
- E2E: Not run live; no deploy or external runner execution per Issue #232 non-goals.
- Manual: GitHub Issue #232 inspected with gh issue view; PR body contract inspected before authoring.
- Evidence path/link: test/vps-runner-script.test.js; test/remote-codex-executor.test.js; docs/butler/remote-codex-cli-executor.md

## Surface Update Checklist

- Cloudflare deploy: Not required; no deploy performed.
- Custom GPT Action Schema update: Not required.
- Custom GPT Instructions update: Not required.
- iPhone Butler live E2E: Not run; live notification delivery remains unverified.

## Related Constitution Rules

- Issue #232 is the canonical implementation scope.
- Mention is a notification mirror, not runtime truth.
- No merge, deploy, issue close, secret, permission, or repository setting mutation.

## Out-of-scope but NOT implemented

- Slack / Discord / LINE / Web Push notifications.
- Repository settings, permissions, secrets, deploy, merge, and issue close.
- Full log streaming.
- Live phone/watch notification validation.

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: #232
- Execution ID: remote-codex-issue232-6tg8jf
- Goal: open_pr
