### PR TITLE
Add PR ready-for-review authority action

### DIFF
--- a/docs/setup/custom-gpt-actions-openapi.json
+++ b/docs/setup/custom-gpt-actions-openapi.json
@@ -853,6 +853,7 @@
                   "operation": {
                     "type": "string",
                     "enum": [
+                      "pull_ready_for_review",
                       "pull_merge",
                       "issue_close"
                     ]

--- a/docs/setup/custom-gpt-actions-openapi.yaml
+++ b/docs/setup/custom-gpt-actions-openapi.yaml
@@ -575,6 +575,7 @@ paths:
                 operation:
                   type: string
                   enum:
+                    - pull_ready_for_review
                     - pull_merge
                     - issue_close
                 repository:

--- a/docs/setup/custom-gpt-instructions-short.md
+++ b/docs/setup/custom-gpt-instructions-short.md
@@ -1,11 +1,10 @@
 VTDD Butler. Japanese unless asked otherwise.
 
 Core:
-- Issue is canonical spec; GitHub runtime state is progress truth.
+- Issue is canonical spec.
 - Before proposal/write/Codex handoff/PR judgment: vtddRetrieveCrossMemory + vtddRetrieveDecisionLogs/vtddRetrieveProposalLogs/vtddRetrieveConstitution + runtime truth. Report found/missing; no RAG hit OK, never invent. Runtime truth > memory.
 - Do not assume a default repository. Resolve repo from alias/context; if ambiguous, ask.
-- No internal API paths/raw JSON unless debugging.
-- Natural language to actions.
+- Natural language to actions; no internal paths/raw JSON unless debugging.
 - No scope beyond Issue/user instruction.
 - vtddGateway/vtddExecute: surface=custom_gpt, judgmentModelId=vtdd-butler-core-v1.
 
@@ -23,14 +22,8 @@ GitHub read plane:
 - Unsupported route => say 未対応. Auth fail => 認証失敗. Do not infer absence from failed reads.
 
 Self-parity:
-- For stale/outdated/reflected/aligned, use vtddRetrieveSelfParity, repo=<resolved>, ref=main.
-- If runtimeParity=`cloudflare_deploy_update_required`, say `Cloudflare deploy update required`.
-- If in_sync but features lack, say `Action Schema update required` and/or `Instructions update required`.
-- If parity cannot be checked, say `未検証`.
-- If action returns error/reason/issues, surface error/reason/issues.
-- If self-parity returns `ClientResponseError`, say unverified transport failure.
-- Use vtddRetrieveSetupArtifact for setup.
-- If runtime in sync, don't claim editor sync.
+- Use vtddRetrieveSelfParity repo=<resolved>, ref=main. Surface `Cloudflare deploy update required` / `Action Schema update required` / `Instructions update required` / errors.
+- If parity cannot be checked, say `未検証`. If self-parity returns `ClientResponseError`, say unverified transport failure. Use vtddRetrieveSetupArtifact for setup. If runtime in sync, don't claim editor sync.
 
 Execution:
 - Before execution, read runtime truth; if required, vtddRetrieveGitHub PR/branch/checks/runs.
@@ -66,18 +59,18 @@ GitHub write:
 
 GitHub high-risk authority plane:
 - Use vtddGitHubAuthority for actions requiring GO + real passkey:
+  - pull_ready_for_review
   - pull_merge
   - issue_close
 - Confirm approval grant, repo scope, and explicit request.
+- Draft PR before merge: pull_ready_for_review. No grant: show `[Open ready operator](<absolute operator URL>)` with repo/phase/issueNumber/pullNumber/actionType/highRiskKind.
 - For pull_merge no grant, show `[Open merge operator](<absolute operator URL>)` with repo/phase/issueNumber/pullNumber/actionType/highRiskKind; no bare URL.
 - Operator may approve+dispatch PR merge; re-read runtime truth before saying merged.
 - For issue_close, include issueNumber + merged PR pullNumber; no grant: show same-origin operator link.
 - Do not route deploy or other destructive provider actions through vtddGitHubAuthority.
 
 Deploy plane:
-- Use vtddDeployProduction after deploy ask.
-- vtddDeployProduction requires resolved repo, explicit GO, real passkey grant scoped to deploy_production.
-- Pasted approvalGrant.scope.repositoryInput can identify deploy target.
+- vtddDeployProduction after deploy ask; requires resolved repo, explicit GO, real passkey grant scoped deploy_production. Pasted approvalGrant.scope.repositoryInput can identify deploy target.
 - If no deploy grant, show selfParity.deployOperatorMarkdownLink or `[Open deploy operator](<actual selfParity.deployOperatorUrl>)`; never raw `/v2/approval/passkey/operator...` or bare URL.
 - Stale fallback: selfParity.deployRecovery.operatorMarkdownLink or operatorUrl. Href needs phase=execution.
 - If deploy URL requested while in_sync, show deployOperatorUrl/link.

--- a/docs/setup/custom-gpt-instructions.md
+++ b/docs/setup/custom-gpt-instructions.md
@@ -284,6 +284,7 @@ GitHub normal write plane:
 GitHub high-risk authority plane:
 - Use vtddGitHubAuthority for GitHub authority actions that require `GO + real passkey`.
 - Use vtddGitHubAuthority for:
+  - marking a bounded draft PR ready for review before merge
   - merge of a bounded PR
   - bounded issue close after merged scoped work
 - Before vtddGitHubAuthority:
@@ -291,6 +292,9 @@ GitHub high-risk authority plane:
   - ensure repository and Issue scope are explicit
   - ensure the user has explicitly requested the action
 - For merge:
+  - if the PR is draft, run `pull_ready_for_review` first; draft PRs cannot be merged
+  - operation=`pull_ready_for_review`
+  - if no ready-scoped approval grant is available yet, present a short clickable Markdown link to the same-origin passkey operator helper; the href must include `repositoryInput=<resolved repo>`, `phase=execution`, `issueNumber=<parent/active issue>`, `pullNumber=<PR number>`, `actionType=pull_ready_for_review`, and `highRiskKind=pull_ready_for_review`
   - operation=`pull_merge`
   - if no merge-scoped approval grant is available yet, present a short clickable Markdown link to the same-origin passkey operator helper; the href must be the full absolute URL with `repositoryInput=<resolved repo>`, `phase=execution`, `issueNumber=<parent/active issue>`, `pullNumber=<PR number>`, `actionType=merge`, `highRiskKind=pull_merge`, and `mergeMethod=squash` unless the human asked for another merge method
   - use a short label such as `[Open merge operator](<actual URL>)`; do not paste a bare long URL or ask the human to rebuild query parameters

--- a/src/core/github-app-operation-registry.js
+++ b/src/core/github-app-operation-registry.js
@@ -53,6 +53,21 @@ export const GitHubAppOperationRegistry = Object.freeze({
     requiredPayloadFields: ["repository", "pullNumber", "body"],
     naturalGoIdentityFields: ["repository", "pullNumber", "body"]
   },
+  pull_ready_for_review: {
+    operation: "pull_ready_for_review",
+    tier: GitHubAppOperationTier.PASSKEY_AUTHORITY,
+    requiredPayloadFields: ["repository", "issueNumber", "pullNumber"],
+    requiredRuntimeEvidenceFields: ["pullNumber"],
+    authorityScopeIdentityFields: ["repository", "issueNumber", "pullNumber", "phase"],
+    requiredRuntimeTruthChecks: ["pull_request_ready_for_review_result"],
+    executorFunction: "executeGitHubHighRiskPlane",
+    responseSummaryShape: ["operation", "repository", "pullNumber", "readyForReview", "changed", "htmlUrl"],
+    passkey: {
+      actionType: "pull_ready_for_review",
+      highRiskKind: "pull_ready_for_review",
+      operatorUrlRequirements: ["repositoryInput", "phase", "issueNumber", "pullNumber", "actionType", "highRiskKind"]
+    }
+  },
   pull_merge: {
     operation: "pull_merge",
     tier: GitHubAppOperationTier.PASSKEY_AUTHORITY,

--- a/src/core/github-high-risk-plane.js
+++ b/src/core/github-high-risk-plane.js
@@ -10,6 +10,7 @@ const GITHUB_API_VERSION = "2022-11-28";
 const GITHUB_API_USER_AGENT = "vtdd-v2-github-high-risk-plane";
 
 export const GitHubHighRiskOperation = Object.freeze({
+  PULL_READY_FOR_REVIEW: "pull_ready_for_review",
   PULL_MERGE: "pull_merge",
   ISSUE_CLOSE: "issue_close"
 });
@@ -161,6 +162,10 @@ function hasPayloadField(input, field) {
 }
 
 async function dispatchGitHubHighRisk(input) {
+  if (input.operation === GitHubHighRiskOperation.PULL_READY_FOR_REVIEW) {
+    return executePullReadyForReview(input);
+  }
+
   if (input.operation === GitHubHighRiskOperation.PULL_MERGE) {
     return executePullMerge(input);
   }
@@ -174,6 +179,118 @@ async function dispatchGitHubHighRisk(input) {
     status: 422,
     error: "github_high_risk_request_invalid",
     reason: "operation is unsupported"
+  };
+}
+
+async function executePullReadyForReview(input) {
+  const encodedRepository = encodeURIComponentRepository(input.repository);
+  const prUrl = `${input.apiBaseUrl}/repos/${encodedRepository}/pulls/${input.pullNumber}`;
+  let prResponse;
+  try {
+    prResponse = await input.fetchImpl(prUrl, {
+      method: "GET",
+      headers: githubJsonHeaders({ token: input.token })
+    });
+  } catch (error) {
+    return {
+      ok: false,
+      status: 503,
+      error: "github_high_risk_failed",
+      reason: `failed to read pull request before ready-for-review: ${errorMessage(error)}`
+    };
+  }
+
+  const prBody = await readJsonSafe(prResponse);
+  if (!prResponse.ok) {
+    return {
+      ok: false,
+      status: prResponse.status,
+      error: "github_high_risk_failed",
+      reason: normalizeText(prBody?.message) || "failed to read pull request before ready-for-review"
+    };
+  }
+
+  if (prBody?.draft !== true) {
+    return {
+      ok: true,
+      authorityAction: {
+        operation: input.operation,
+        repository: input.repository,
+        pullNumber: input.pullNumber,
+        readyForReview: true,
+        changed: false,
+        htmlUrl: normalizeText(prBody?.html_url) || `https://github.com/${input.repository}/pull/${input.pullNumber}`
+      }
+    };
+  }
+
+  const nodeId = normalizeText(prBody?.node_id);
+  if (!nodeId) {
+    return {
+      ok: false,
+      status: 422,
+      error: "github_high_risk_request_invalid",
+      reason: "pull request node_id is required for ready-for-review mutation"
+    };
+  }
+
+  const graphqlUrl = `${input.apiBaseUrl.replace(/\/rest$/, "")}/graphql`;
+  let mutationResponse;
+  try {
+    mutationResponse = await input.fetchImpl(graphqlUrl, {
+      method: "POST",
+      headers: githubJsonHeaders({ token: input.token }),
+      body: JSON.stringify({
+        query:
+          "mutation MarkPullRequestReadyForReview($pullRequestId: ID!) { markPullRequestReadyForReview(input: { pullRequestId: $pullRequestId }) { pullRequest { isDraft url number } } }",
+        variables: {
+          pullRequestId: nodeId
+        }
+      })
+    });
+  } catch (error) {
+    return {
+      ok: false,
+      status: 503,
+      error: "github_high_risk_failed",
+      reason: `failed to mark pull request ready for review: ${errorMessage(error)}`
+    };
+  }
+
+  const mutationBody = await readJsonSafe(mutationResponse);
+  const graphqlErrors = Array.isArray(mutationBody?.errors) ? mutationBody.errors : [];
+  if (!mutationResponse.ok || graphqlErrors.length > 0) {
+    return {
+      ok: false,
+      status: mutationResponse.status,
+      error: "github_high_risk_failed",
+      reason:
+        normalizeText(graphqlErrors[0]?.message) ||
+        normalizeText(mutationBody?.message) ||
+        "GitHub ready-for-review mutation failed"
+    };
+  }
+
+  const pull = mutationBody?.data?.markPullRequestReadyForReview?.pullRequest;
+  if (!pull || pull.isDraft !== false) {
+    return {
+      ok: false,
+      status: 422,
+      error: "github_high_risk_failed",
+      reason: "GitHub ready-for-review mutation did not return a ready pull request"
+    };
+  }
+
+  return {
+    ok: true,
+    authorityAction: {
+      operation: input.operation,
+      repository: input.repository,
+      pullNumber: Number(pull?.number ?? input.pullNumber),
+      readyForReview: true,
+      changed: true,
+      htmlUrl: normalizeText(pull?.url) || `https://github.com/${input.repository}/pull/${input.pullNumber}`
+    }
   };
 }
 

--- a/src/core/passkey-operator-page.js
+++ b/src/core/passkey-operator-page.js
@@ -235,10 +235,11 @@ export function renderPasskeyOperatorPage(input = {}) {
           <label for="merge-method-input">Merge Method</label>
           <input id="merge-method-input" value="${mergeMethodDefault}" placeholder="squash" />
           <div class="row">
+            <button id="ready-button">Mark ready for review</button>
             <button id="merge-button">Dispatch PR merge</button>
             <a class="button-link" id="merge-pr-link" href="#" target="_blank" rel="noopener noreferrer" hidden>Open pull request</a>
           </div>
-          <p class="muted"><code>actionType=merge</code> / <code>highRiskKind=pull_merge</code> の approvalGrantId が必要です。merge 後は GitHub runtime truth で merged 状態を確認してください。</p>
+          <p class="muted">draft を解除する場合は <code>actionType=pull_ready_for_review</code> / <code>highRiskKind=pull_ready_for_review</code>、merge は <code>actionType=merge</code> / <code>highRiskKind=pull_merge</code> の approvalGrantId が必要です。merge 後は GitHub runtime truth で merged 状態を確認してください。</p>
           <pre id="merge-output"></pre>
         </section>
 
@@ -621,6 +622,41 @@ export function renderPasskeyOperatorPage(input = {}) {
         }
       });
 
+      document.getElementById("ready-button").addEventListener("click", async () => {
+        try {
+          if (!latestApprovalGrantId) {
+            throw new Error("approvalGrantId is required before marking PR ready for review");
+          }
+          clearMergePrLink();
+          mergeOutput.textContent = "PR ready-for-review request...";
+          const readyResponse = await fetch("${apiBase}/action/github-authority", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({
+              operation: "pull_ready_for_review",
+              repository: document.getElementById("repo-input").value,
+              pullNumber: Number(document.getElementById("pull-number-input").value || 0) || null,
+              issueContext: {
+                issueNumber: Number(document.getElementById("issue-input").value || 0) || null
+              },
+              policyInput: {
+                approvalPhrase: "GO",
+                approvalGrantId: latestApprovalGrantId,
+                targetConfirmed: true
+              }
+            })
+          });
+          const readyBody = await readResponseBody(readyResponse);
+          if (!readyResponse.ok) {
+            throw responseError(readyBody, "PR ready-for-review failed");
+          }
+          showMergePrLink(readyBody);
+          mergeOutput.textContent = JSON.stringify(readyBody, null, 2);
+        } catch (error) {
+          mergeOutput.textContent = String(error);
+        }
+      });
+
       document.getElementById("openai-secret-sync-button").addEventListener("click", async () => {
         try {
           if (!latestApprovalGrantId) {
@@ -757,6 +793,9 @@ export function resolvePasskeyOperatorMode(input = {}) {
     return "deploy";
   }
   if (actionType === "merge" || highRiskKind === "pull_merge") {
+    return "merge";
+  }
+  if (actionType === "pull_ready_for_review" || highRiskKind === "pull_ready_for_review") {
     return "merge";
   }
   if (actionType === "issue_close" || highRiskKind === "issue_close") {

--- a/src/worker.js
+++ b/src/worker.js
@@ -1950,6 +1950,9 @@ function buildApprovalScopeSnapshot({ payload, policyInput }) {
 }
 
 function mapGitHubHighRiskOperationToActionType(operation) {
+  if (operation === GitHubHighRiskOperation.PULL_READY_FOR_REVIEW) {
+    return "pull_ready_for_review";
+  }
   if (operation === GitHubHighRiskOperation.PULL_MERGE) {
     return "merge";
   }

--- a/test/github-high-risk-plane.test.js
+++ b/test/github-high-risk-plane.test.js
@@ -34,9 +34,24 @@ const mergeGrant = {
   }
 };
 
+const readyGrant = {
+  approvalId: "approval-ready-123",
+  verified: true,
+  expiresAt: "2099-01-01T00:00:00.000Z",
+  scope: {
+    actionType: "pull_ready_for_review",
+    highRiskKind: "pull_ready_for_review",
+    repositoryInput: "sample-org/vtdd-v2-p",
+    issueNumber: "55",
+    pullNumber: "21",
+    phase: "execution"
+  }
+};
+
 test("github app operation registry defines issue close authority scope and runtime truth", () => {
   const issueClose = getGitHubAppOperation("issue_close");
   const pullMerge = getGitHubAppOperation("pull_merge");
+  const pullReady = getGitHubAppOperation("pull_ready_for_review");
 
   assert.equal(issueClose.tier, GitHubAppOperationTier.PASSKEY_AUTHORITY);
   assert.deepEqual(issueClose.requiredPayloadFields, ["repository", "issueNumber"]);
@@ -58,6 +73,18 @@ test("github app operation registry defines issue close authority scope and runt
     "repositoryInput",
     "phase",
     "issueNumber",
+    "actionType",
+    "highRiskKind"
+  ]);
+  assert.equal(pullReady.tier, GitHubAppOperationTier.PASSKEY_AUTHORITY);
+  assert.deepEqual(pullReady.requiredPayloadFields, ["repository", "issueNumber", "pullNumber"]);
+  assert.deepEqual(pullReady.requiredRuntimeEvidenceFields, ["pullNumber"]);
+  assert.deepEqual(pullReady.authorityScopeIdentityFields, ["repository", "issueNumber", "pullNumber", "phase"]);
+  assert.deepEqual(pullReady.passkey.operatorUrlRequirements, [
+    "repositoryInput",
+    "phase",
+    "issueNumber",
+    "pullNumber",
     "actionType",
     "highRiskKind"
   ]);
@@ -215,6 +242,131 @@ test("github high-risk plane binds default fetch for Cloudflare Worker merge dis
   } finally {
     globalThis.fetch = originalFetch;
   }
+});
+
+test("github high-risk plane marks draft pull request ready for review with scoped approval grant", async () => {
+  const calls = [];
+  const result = await executeGitHubHighRiskPlane({
+    operation: GitHubHighRiskOperation.PULL_READY_FOR_REVIEW,
+    repository: "sample-org/vtdd-v2-p",
+    issueNumber: 55,
+    pullNumber: 21,
+    approvalPhrase: "GO",
+    targetConfirmed: true,
+    approvalGrant: readyGrant,
+    approvalScope: readyGrant.scope,
+    env: {
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_high_risk",
+      GITHUB_API_FETCH: async (url, init) => {
+        calls.push({ url, init });
+        if (calls.length === 1) {
+          return new Response(
+            JSON.stringify({
+              draft: true,
+              node_id: "PR_kwDOExample",
+              html_url: "https://github.com/sample-org/vtdd-v2-p/pull/21"
+            }),
+            { status: 200, headers: { "content-type": "application/json" } }
+          );
+        }
+        return new Response(
+          JSON.stringify({
+            data: {
+              markPullRequestReadyForReview: {
+                pullRequest: {
+                  isDraft: false,
+                  number: 21,
+                  url: "https://github.com/sample-org/vtdd-v2-p/pull/21"
+                }
+              }
+            }
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        );
+      }
+    }
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.authorityAction.operation, "pull_ready_for_review");
+  assert.equal(result.authorityAction.readyForReview, true);
+  assert.equal(result.authorityAction.changed, true);
+  assert.equal(calls[0].init.method, "GET");
+  assert.equal(calls[1].url, "https://api.github.com/graphql");
+  assert.equal(calls[1].init.method, "POST");
+});
+
+test("github high-risk plane treats already-ready pull request as no-op success", async () => {
+  const result = await executeGitHubHighRiskPlane({
+    operation: GitHubHighRiskOperation.PULL_READY_FOR_REVIEW,
+    repository: "sample-org/vtdd-v2-p",
+    issueNumber: 55,
+    pullNumber: 21,
+    approvalPhrase: "GO",
+    targetConfirmed: true,
+    approvalGrant: readyGrant,
+    approvalScope: readyGrant.scope,
+    env: {
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_high_risk",
+      GITHUB_API_FETCH: async () =>
+        new Response(
+          JSON.stringify({
+            draft: false,
+            html_url: "https://github.com/sample-org/vtdd-v2-p/pull/21"
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        )
+    }
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.authorityAction.readyForReview, true);
+  assert.equal(result.authorityAction.changed, false);
+});
+
+test("github high-risk plane fails when ready-for-review mutation does not prove readiness", async () => {
+  const result = await executeGitHubHighRiskPlane({
+    operation: GitHubHighRiskOperation.PULL_READY_FOR_REVIEW,
+    repository: "sample-org/vtdd-v2-p",
+    issueNumber: 55,
+    pullNumber: 21,
+    approvalPhrase: "GO",
+    targetConfirmed: true,
+    approvalGrant: readyGrant,
+    approvalScope: readyGrant.scope,
+    env: {
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_high_risk",
+      GITHUB_API_FETCH: async (url) => {
+        if (String(url).includes("/pulls/")) {
+          return new Response(
+            JSON.stringify({
+              draft: true,
+              node_id: "PR_kwDOExample"
+            }),
+            { status: 200, headers: { "content-type": "application/json" } }
+          );
+        }
+        return new Response(
+          JSON.stringify({
+            data: {
+              markPullRequestReadyForReview: {
+                pullRequest: {
+                  isDraft: true,
+                  number: 21,
+                  url: "https://github.com/sample-org/vtdd-v2-p/pull/21"
+                }
+              }
+            }
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        );
+      }
+    }
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.status, 422);
+  assert.equal(result.reason, "GitHub ready-for-review mutation did not return a ready pull request");
 });
 
 test("github high-risk plane requires merge method from registry", async () => {

--- a/test/passkey-operator-page.test.js
+++ b/test/passkey-operator-page.test.js
@@ -55,8 +55,28 @@ test("passkey operator page pre-fills PR merge fields from URL input", () => {
   assert.equal(html.includes('id="action-type-input" value="merge"'), true);
   assert.equal(html.includes('id="risk-kind-input" value="pull_merge"'), true);
   assert.equal(html.includes('id="merge-method-input" value="squash"'), true);
+  assert.equal(html.includes("Mark ready for review"), true);
+  assert.equal(html.includes('operation: "pull_ready_for_review"'), true);
   assert.equal(html.includes('operation: "pull_merge"'), true);
   assert.equal(html.includes('pullNumber: Number(document.getElementById("pull-number-input").value || 0) || null'), true);
+});
+
+test("passkey operator page can scope PR ready-for-review approval to pull proof", () => {
+  const html = renderPasskeyOperatorPage({
+    repositoryInput: "marushu/vtdd-v2-p",
+    issueNumber: 194,
+    pullNumber: 202,
+    phase: "execution",
+    actionType: "pull_ready_for_review",
+    highRiskKind: "pull_ready_for_review"
+  });
+
+  assert.equal(html.includes('<section data-operator-section="approval">'), true);
+  assert.equal(html.includes('<section data-operator-section="pr-merge">'), true);
+  assert.equal(html.includes('id="action-type-input" value="pull_ready_for_review"'), true);
+  assert.equal(html.includes('id="risk-kind-input" value="pull_ready_for_review"'), true);
+  assert.equal(html.includes('id="pull-number-input" value="202"'), true);
+  assert.equal(html.includes("PR ready-for-review request"), true);
 });
 
 test("passkey operator page can scope issue close approval to merged pull proof", () => {

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -3173,6 +3173,99 @@ test("worker executes GitHub merge on the high-risk authority plane with approva
   assert.equal(body.authorityAction.merged, true);
 });
 
+test("worker executes GitHub ready-for-review on the high-risk authority plane with scoped approval grant id", async () => {
+  const provider = createInMemoryMemoryProvider();
+  await provider.store({
+    id: "approval-ready-123",
+    type: MemoryRecordType.APPROVAL_LOG,
+    content: {
+      kind: "passkey_grant",
+      status: "verified",
+      approvalId: "approval-ready-123",
+      expiresAt: "2099-01-01T00:00:00.000Z",
+      scope: {
+        actionType: "pull_ready_for_review",
+        highRiskKind: "pull_ready_for_review",
+        repositoryInput: "sample-org/vtdd-v2-p",
+        issueNumber: "55",
+        pullNumber: "21",
+        phase: "execution"
+      }
+    },
+    metadata: { source: "test" },
+    priority: 90,
+    tags: ["passkey_grant"],
+    createdAt: "2026-04-26T00:00:00.000Z"
+  });
+
+  const calls = [];
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/action/github-authority", {
+      method: "POST",
+      headers: {
+        ...gatewayAuthHeaders,
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({
+        operation: "pull_ready_for_review",
+        repository: "sample-org/vtdd-v2-p",
+        pullNumber: 21,
+        issueContext: {
+          issueNumber: 55
+        },
+        policyInput: {
+          approvalPhrase: "GO",
+          approvalGrantId: "approval-ready-123",
+          targetConfirmed: true
+        }
+      })
+    }),
+    {
+      ...gatewayAuthEnv,
+      MEMORY_PROVIDER: provider,
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_high_risk",
+      GITHUB_API_FETCH: async (url, init) => {
+        calls.push({ url, init });
+        if (calls.length === 1) {
+          return new Response(
+            JSON.stringify({
+              draft: true,
+              node_id: "PR_kwDOExample",
+              html_url: "https://github.com/sample-org/vtdd-v2-p/pull/21"
+            }),
+            { status: 200, headers: { "content-type": "application/json" } }
+          );
+        }
+        return new Response(
+          JSON.stringify({
+            data: {
+              markPullRequestReadyForReview: {
+                pullRequest: {
+                  isDraft: false,
+                  number: 21,
+                  url: "https://github.com/sample-org/vtdd-v2-p/pull/21"
+                }
+              }
+            }
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        );
+      }
+    }
+  );
+
+  assert.equal(response.status, 200);
+  const body = await response.json();
+  assert.equal(body.ok, true);
+  assert.equal(body.authorityAction.operation, "pull_ready_for_review");
+  assert.equal(body.authorityAction.readyForReview, true);
+  assert.equal(body.authorityAction.changed, true);
+  assert.deepEqual(
+    calls.map((call) => call.init.method),
+    ["GET", "POST"]
+  );
+});
+
 test("worker allows same-origin passkey operator to dispatch GitHub merge authority", async () => {
   const provider = createInMemoryMemoryProvider();
   await provider.store({


### PR DESCRIPTION
## This PR satisfies Intent

- Reapplies PR #204 intended ready-for-review authority action on the latest main-based codex/issue-238 branch.
- Adds approval-bound pull_ready_for_review so Butler/operator can mark a bounded draft PR ready for review before merge while preserving GO + real passkey boundaries.

## Satisfied Success Criteria

- Latest main is the base for codex/issue-238 at 1c7d9d0.
- Only PR #204 intended ready-for-review authority action is reapplied, plus a focused worker route regression test for the same runtime path.
- Butler can call vtddGitHubAuthority operation=pull_ready_for_review for bounded draft PR ready-for-review.
- Operator helper can approve and dispatch pull_ready_for_review with repo, issue, pull, phase, actionType, and highRiskKind scope.
- GO + real passkey approval boundary is preserved through the existing high-risk authority plane and approval grant scope matching.
- Action Schema and Custom GPT Instructions source artifacts are updated for pull_ready_for_review.
- Tests pass.
- Draft PR opened from codex/issue-238.

## Unsatisfied Success Criteria

- Live iPhone Butler E2E not run; requires deployed Worker and real passkey after merge/deploy.
- Cloudflare deploy not performed.
- Custom GPT editor update not performed.

## Non-goal violations

None.

## Verification Evidence

- Unit: node --test test/github-high-risk-plane.test.js test/passkey-operator-page.test.js test/custom-gpt-setup-docs.test.js test/custom-gpt-setup-artifacts.test.js test/worker.test.js passed.
npm test passed: 575 tests.
- Integration: Worker route regression covers /v2/action/github-authority pull_ready_for_review with scoped approval grant id.
Custom GPT setup artifact/docs tests pass.
- E2E: Not run live; out of scope for #238 before deploy/passkey availability.
- Manual: Inspected Issue #238 and PR #204 diff/body.
Confirmed branch codex/issue-238 starts from origin/main 1c7d9d0.
Verified PR body contract in docs/pr-template-model.md, scripts/render-pr-body.mjs, and scripts/validate-pr-body.mjs before drafting.
- Evidence path/link: src/core/github-high-risk-plane.js; src/core/github-app-operation-registry.js; src/core/passkey-operator-page.js; src/worker.js; docs/setup/custom-gpt-actions-openapi.yaml; docs/setup/custom-gpt-actions-openapi.json; docs/setup/custom-gpt-instructions.md; docs/setup/custom-gpt-instructions-short.md; test/github-high-risk-plane.test.js; test/passkey-operator-page.test.js; test/worker.test.js

## Surface Update Checklist

- Cloudflare deploy: Required before a deployed Butler can use this new runtime surface; not performed in this PR.
- Custom GPT Action Schema update: Required; source artifacts updated in docs/setup/custom-gpt-actions-openapi.yaml and .json.
- Custom GPT Instructions update: Required; source artifacts updated in docs/setup/custom-gpt-instructions.md and custom-gpt-instructions-short.md.
- iPhone Butler live E2E: Required after deploy/editor update for live confirmation; not run in this PR.

## Related Constitution Rules

- Issue #238 canonical scope governs this PR.
- GO + real passkey remains required for high-risk GitHub authority actions.
- No merge, deploy, Issue close, secrets, permissions, repository settings, or infrastructure mutation.
- Public/core branch must not embed owner-specific runtime URLs or account identifiers.

## Out-of-scope but NOT implemented

- Force-pushing PR #204.
- Merging this PR.
- Deploying Worker or updating live Custom GPT editor.
- Closing Issue #238.
- Changing secrets, permissions, repository settings, or external infrastructure.

## Extra changes (if any)

Added a focused worker route regression for the same ready-for-review runtime path so the Action surface is tested end-to-end inside the local Worker harness.

<!-- VTDD metadata -->
- Issue: #238
- Execution ID: local-codex-issue-238
- Goal: open_pr
