### PR TITLE
Issue #260: VTDD VPS runner handoff

### DIFF
--- a/.vtdd/pr-body-issue-260.md
+++ b/.vtdd/pr-body-issue-260.md
@@ -51,7 +51,7 @@ None.
 ## Extra changes (if any)
 
 - Gemini reviewer code-duplication risk addressed by centralizing lead-time duration calculation and formatting in src/core/execution-lead-time.js.
-- Gemini reviewer PR-body mismatch is addressed in this guarded PR body draft; live GitHub PR body update remains a separate GitHub-side action.
+- Gemini reviewer PR-body mismatch is addressed by this guarded PR body draft and the live PR body sync for PR #261.
 
 <!-- VTDD metadata -->
 - Issue: #260

--- a/.vtdd/pr-body-issue-260.md
+++ b/.vtdd/pr-body-issue-260.md
@@ -9,6 +9,7 @@
 - GitHub-visible VPS runner state/event comments include concise Lead time lines and JSON leadTime runtime truth.
 - Queue wait, Codex execution, PR creation, and total lead time durations are computed with readable labels.
 - Lead-time duration calculation and formatting are shared by Butler progress reconstruction and VPS runner comment publishing.
+- `pr_created_at` remains distinct from `completed_at`; PR creation can end total lead-time calculation without falsifying a completed timestamp.
 - Existing execution flow remains compatible; existing event parsing and tests pass.
 
 ## Unsatisfied Success Criteria
@@ -21,8 +22,8 @@ None.
 
 ## Verification Evidence
 
-- Unit: npm test (605 tests passed).
-- Integration: node --test test/execution-lead-time.test.js test/vps-runner-script.test.js test/remote-codex-executor.test.js (67 tests passed).
+- Unit: npm test (606 tests passed).
+- Integration: node --test test/execution-lead-time.test.js test/vps-runner-script.test.js test/remote-codex-executor.test.js (68 tests passed).
 - E2E: Not run live; covered by runtime progress/comment contract tests for happy-path and stale/failure boundaries.
 - Manual: Inspected docs/pr-template-model.md, scripts/render-pr-body.mjs, scripts/validate-pr-body.mjs before drafting.
 - Evidence path/link: src/core/execution-lead-time.js; test/execution-lead-time.test.js; test/remote-codex-executor.test.js; test/vps-runner-script.test.js; docs/butler/remote-codex-cli-executor.md
@@ -50,6 +51,7 @@ None.
 ## Extra changes (if any)
 
 - Gemini reviewer code-duplication risk addressed by centralizing lead-time duration calculation and formatting in src/core/execution-lead-time.js.
+- Gemini reviewer PR-body mismatch is addressed in this guarded PR body draft; live GitHub PR body update remains a separate GitHub-side action.
 
 <!-- VTDD metadata -->
 - Issue: #260

--- a/.vtdd/pr-body-issue-260.md
+++ b/.vtdd/pr-body-issue-260.md
@@ -8,11 +8,12 @@
 - execution lead time is visible from vtddVpsRunnerStatus health.leadTime.
 - GitHub-visible VPS runner state/event comments include concise Lead time lines and JSON leadTime runtime truth.
 - Queue wait, Codex execution, PR creation, and total lead time durations are computed with readable labels.
+- Lead-time duration calculation and formatting are shared by Butler progress reconstruction and VPS runner comment publishing.
 - Existing execution flow remains compatible; existing event parsing and tests pass.
 
 ## Unsatisfied Success Criteria
 
-- Live GitHub E2E on a real runner was not executed in this local workspace.
+- Live GitHub E2E on a real runner was not executed in this local workspace; this remains the reviewer-raised unverified production path.
 
 ## Non-goal violations
 
@@ -20,11 +21,11 @@ None.
 
 ## Verification Evidence
 
-- Unit: npm test (602 tests passed).
-- Integration: node --test test/remote-codex-executor.test.js; node --test test/vps-runner-script.test.js; node --test test/custom-gpt-setup-docs.test.js test/custom-gpt-setup-artifacts.test.js.
+- Unit: npm test (605 tests passed).
+- Integration: node --test test/execution-lead-time.test.js test/vps-runner-script.test.js test/remote-codex-executor.test.js (67 tests passed).
 - E2E: Not run live; covered by runtime progress/comment contract tests for happy-path and stale/failure boundaries.
 - Manual: Inspected docs/pr-template-model.md, scripts/render-pr-body.mjs, scripts/validate-pr-body.mjs before drafting.
-- Evidence path/link: test/remote-codex-executor.test.js; test/vps-runner-script.test.js; docs/butler/remote-codex-cli-executor.md
+- Evidence path/link: src/core/execution-lead-time.js; test/execution-lead-time.test.js; test/remote-codex-executor.test.js; test/vps-runner-script.test.js; docs/butler/remote-codex-cli-executor.md
 
 ## Surface Update Checklist
 
@@ -48,9 +49,9 @@ None.
 
 ## Extra changes (if any)
 
-None.
+- Gemini reviewer code-duplication risk addressed by centralizing lead-time duration calculation and formatting in src/core/execution-lead-time.js.
 
 <!-- VTDD metadata -->
 - Issue: #260
-- Execution ID: remote-codex-issue260-3rswpp
-- Goal: open_pr
+- Execution ID: remote-codex-issue260-737qrr
+- Goal: revise_pr

--- a/.vtdd/pr-body-issue-260.md
+++ b/.vtdd/pr-body-issue-260.md
@@ -1,0 +1,56 @@
+## This PR satisfies Intent
+
+- Expose VTDD/Codex execution lead-time telemetry as GitHub-visible runtime truth for Issue #260.
+
+## Satisfied Success Criteria
+
+- execution lead time is visible from Butler via vtddExecutionProgress progress.leadTime.
+- execution lead time is visible from vtddVpsRunnerStatus health.leadTime.
+- GitHub-visible VPS runner state/event comments include concise Lead time lines and JSON leadTime runtime truth.
+- Queue wait, Codex execution, PR creation, and total lead time durations are computed with readable labels.
+- Existing execution flow remains compatible; existing event parsing and tests pass.
+
+## Unsatisfied Success Criteria
+
+- Live GitHub E2E on a real runner was not executed in this local workspace.
+
+## Non-goal violations
+
+None.
+
+## Verification Evidence
+
+- Unit: npm test (602 tests passed).
+- Integration: node --test test/remote-codex-executor.test.js; node --test test/vps-runner-script.test.js; node --test test/custom-gpt-setup-docs.test.js test/custom-gpt-setup-artifacts.test.js.
+- E2E: Not run live; covered by runtime progress/comment contract tests for happy-path and stale/failure boundaries.
+- Manual: Inspected docs/pr-template-model.md, scripts/render-pr-body.mjs, scripts/validate-pr-body.mjs before drafting.
+- Evidence path/link: test/remote-codex-executor.test.js; test/vps-runner-script.test.js; docs/butler/remote-codex-cli-executor.md
+
+## Surface Update Checklist
+
+- Cloudflare deploy: Not required.
+- Custom GPT Action Schema update: Not required.
+- Custom GPT Instructions update: Done: setup Custom GPT instructions now tell Butler to report leadTime.
+- iPhone Butler live E2E: Not run.
+
+## Related Constitution Rules
+
+- Issue #260 is the only implementation scope.
+- Do not merge, deploy, close issues, mutate secrets, permissions, settings, or infrastructure.
+- Runtime truth must stay GitHub-visible and concise.
+
+## Out-of-scope but NOT implemented
+
+- Full tracing UI.
+- External telemetry vendors.
+- Log streaming.
+- Deploy, merge, or issue close automation.
+
+## Extra changes (if any)
+
+None.
+
+<!-- VTDD metadata -->
+- Issue: #260
+- Execution ID: remote-codex-issue260-3rswpp
+- Goal: open_pr

--- a/.vtdd/pr-body-issue-260.md
+++ b/.vtdd/pr-body-issue-260.md
@@ -22,10 +22,10 @@ None.
 
 ## Verification Evidence
 
-- Unit: npm test (606 tests passed).
-- Integration: node --test test/execution-lead-time.test.js test/vps-runner-script.test.js test/remote-codex-executor.test.js (68 tests passed).
-- E2E: Not run live; covered by runtime progress/comment contract tests for happy-path and stale/failure boundaries.
-- Manual: Inspected docs/pr-template-model.md, scripts/render-pr-body.mjs, scripts/validate-pr-body.mjs before drafting.
+- Unit: npm test (609 tests passed on 2026-05-10).
+- Integration: node --test test/execution-lead-time.test.js test/vps-runner-script.test.js test/remote-codex-executor.test.js test/e2e-30-execution-lead-time-telemetry.test.js test/custom-gpt-setup-docs.test.js (81 tests passed on 2026-05-10).
+- E2E: Not run live; covered by runtime progress/comment contract tests for happy-path and stale/failure boundaries. Reviewer-raised live GitHub runner E2E and iPhone Butler live E2E remain unverified.
+- Manual: Inspected docs/pr-template-model.md, scripts/render-pr-body.mjs, scripts/validate-pr-body.mjs before drafting; read GitHub Issue #260 and PR #261 runtime truth with gh on 2026-05-10.
 - Evidence path/link: src/core/execution-lead-time.js; test/execution-lead-time.test.js; test/remote-codex-executor.test.js; test/vps-runner-script.test.js; docs/butler/remote-codex-cli-executor.md
 
 ## Surface Update Checklist
@@ -55,5 +55,5 @@ None.
 
 <!-- VTDD metadata -->
 - Issue: #260
-- Execution ID: remote-codex-issue260-737qrr
+- Execution ID: remote-codex-issue260-iogni0
 - Goal: revise_pr

--- a/docs/butler/remote-codex-cli-executor.md
+++ b/docs/butler/remote-codex-cli-executor.md
@@ -334,6 +334,12 @@ runner reports failure and no target PR exists, Butler must surface the raw
 failure as blocked. If the latest running event is older than the stale
 threshold, Butler must surface `vps_runner_event_stale` with the last step and
 age instead of treating an existing pushed branch as healthy progress forever.
+Runner state/event payloads also carry concise lead-time telemetry under
+`leadTime`: `queued_at`, `picked_up_at`, `codex_started_at`,
+`branch_pushed_at`, `pr_created_at`, `completed_at`, `failed_at`, and derived
+durations for queue wait, Codex execution, PR creation, and total lead time.
+The same values are rendered as short GitHub-visible lines such as
+`Queue wait: 12s` and `Codex execution: 3m 42s`.
 
 Runner event comments may include a GitHub mention only as a notification
 mirror; the JSON event payload and branch / PR evidence remain the runtime
@@ -348,9 +354,9 @@ For explicit VPS runner health checks, Butler uses `vtddVpsRunnerStatus`. The
 status check is read-only and is derived from the same GitHub queue comment,
 runner state/event comments, branch, and PR truth as `vtddExecutionProgress`. It
 returns a short `health` summary with `runnerStatus`, `runnerAlive`,
-`lastSeenAt`, `heartbeatAt`, queue pickup state, `currentStep`, and a safe
-`reasonCode` / `reason` when the runner is stale, unavailable, or not yet
-picked up. This endpoint does not SSH into the VPS, stream logs, mutate
+`lastSeenAt`, `heartbeatAt`, queue pickup state, `leadTime`, `currentStep`, and
+a safe `reasonCode` / `reason` when the runner is stale, unavailable, or not
+yet picked up. This endpoint does not SSH into the VPS, stream logs, mutate
 credentials, deploy, merge, close Issues, or administer the runner.
 
 When Codex reaches an approval or scope boundary, the observable return path is

--- a/docs/mvp/e2e/e2e-30-execution-lead-time-telemetry.md
+++ b/docs/mvp/e2e/e2e-30-execution-lead-time-telemetry.md
@@ -1,0 +1,78 @@
+# E2E-30 Execution Lead-time Telemetry
+
+This document records concrete run evidence for Issue `#260`.
+
+## Scope
+
+Issue:
+- `#260`
+
+Goal:
+- confirm execution lifecycle timestamps are computed as GitHub-visible runtime truth
+- confirm concise durations are exposed through `vtddExecutionProgress`
+- confirm concise durations are exposed through `vtddVpsRunnerStatus`
+- confirm VPS runner state/event comments show the same concise lead-time summary before the JSON payload
+- keep live GitHub and iPhone Butler evidence explicit when it has not been run
+
+## Happy-path Run
+
+Command:
+
+```sh
+node --test test/execution-lead-time.test.js test/vps-runner-script.test.js test/remote-codex-executor.test.js test/custom-gpt-setup-docs.test.js
+```
+
+Observed result on 2026-05-10:
+- passed locally
+- confirms `queued_at`, `picked_up_at`, `codex_started_at`, `branch_pushed_at`, `pr_created_at`, `completed_at`, and `failed_at` are represented in the lead-time contract
+- confirms derived labels for queue wait, Codex execution, PR creation, and total lead time remain concise
+- confirms VPS runner state comments render `Lead time:` lines before the JSON runtime truth
+- confirms `vtddExecutionProgress` can reconstruct lead time from GitHub runner event comments
+- confirms Custom GPT instructions tell Butler to report `progress.leadTime` durations and use `vtddVpsRunnerStatus` for runner health
+
+## Boundary-path Run
+
+Command:
+
+```sh
+node --test test/execution-lead-time.test.js test/vps-runner-script.test.js test/remote-codex-executor.test.js
+```
+
+Observed result on 2026-05-10:
+- passed locally
+- confirms missing or reversed timestamps produce `null` durations instead of misleading latency
+- confirms `pr_created_at` can remain distinct from `completed_at` for non-terminal PR-created events
+- confirms successful terminal VPS runner events can populate both `pr_created_at` and `completed_at`
+- confirms stale or missing runner pickup evidence remains a blocked/unverified runtime state instead of a success claim
+
+## Live Evidence Status
+
+Live GitHub runner E2E:
+- not run in this revision
+- blocked here by the instruction not to deploy or mutate external infrastructure beyond the bounded PR revision work
+- remains required before claiming Issue `#260` fully complete from production-like runtime truth
+
+iPhone Butler live E2E:
+- not run in this revision
+- blocked here because no live iPhone Butler session or deployed runtime update was authorized
+- remains required before claiming the end-user Butler surface is fully verified
+
+## Evidence Files
+
+- `src/core/execution-lead-time.js`
+- `src/core/remote-codex-executor.js`
+- `scripts/run-vps-runner.mjs`
+- `docs/butler/remote-codex-cli-executor.md`
+- `docs/setup/custom-gpt-instructions.md`
+- `docs/setup/custom-gpt-instructions-short.md`
+- `docs/setup/custom-gpt-instructions-short-min.md`
+- `test/execution-lead-time.test.js`
+- `test/vps-runner-script.test.js`
+- `test/remote-codex-executor.test.js`
+- `test/custom-gpt-setup-docs.test.js`
+
+## Current Reading
+
+Issue `#260` has local implementation and contract evidence for lead-time
+telemetry. Live GitHub runner E2E and iPhone Butler live E2E remain explicitly
+unverified and must not be described as complete until run evidence is added.

--- a/docs/mvp/issue-to-e2e-matrix.md
+++ b/docs/mvp/issue-to-e2e-matrix.md
@@ -609,6 +609,29 @@ Status values used below:
   - `docs/mvp/e2e/e2e-29-direct-passkey-operator-link-guidance.md`
 - Status: `e2e_evidenced_pending_human_closure`
 
+## E2E-30 Execution lead-time telemetry
+
+- Issues: `#260`
+- Happy path:
+  - execution lifecycle timestamps and concise durations are visible through
+    Butler-facing progress/status contracts and GitHub runner comments
+- Boundary path:
+  - missing, reversed, stale, or not-yet-live evidence remains null, blocked,
+    or explicitly unverified instead of being reported as complete
+- Implementation evidence:
+  - `src/core/execution-lead-time.js`
+  - `src/core/remote-codex-executor.js`
+  - `scripts/run-vps-runner.mjs`
+  - `docs/setup/custom-gpt-instructions.md`
+- Test evidence:
+  - `test/execution-lead-time.test.js`
+  - `test/vps-runner-script.test.js`
+  - `test/remote-codex-executor.test.js`
+  - `test/custom-gpt-setup-docs.test.js`
+- Run evidence:
+  - `docs/mvp/e2e/e2e-30-execution-lead-time-telemetry.md`
+- Status: `implemented_pending_e2e`
+
 ## E2E-26 Governed production deploy from passkey operator
 
 - Issues: `#82`

--- a/docs/setup/custom-gpt-instructions-short-min.md
+++ b/docs/setup/custom-gpt-instructions-short-min.md
@@ -6,7 +6,7 @@ Role:
 
 Truth and scope:
 - Issue is canonical spec. GitHub/runtime state is progress truth. Runtime truth > memory.
-- Before proposal, GitHub write, Codex handoff, PR judgment, merge/deploy/close advice, or stale setup claims: retrieve runtime truth/GitHub state; use vtddRetrieveCrossMemory, vtddRetrieveDecisionLogs, vtddRetrieveProposalLogs, vtddRetrieveConstitution when useful. Report found/missing. Never invent.
+- Before proposal, writes, Codex handoff, PR judgment, merge/deploy/close advice, or stale setup claims: retrieve runtime truth/GitHub state; use memory/constitution retrieval when useful. Report found/missing. Never invent.
 - No scope beyond user instruction + active Issue; do not reinterpret "MVP".
 - Do not assume a default repository. Resolve owner/repo from explicit input, alias, grant, or verified context; if ambiguous, ask one short confirmation.
 - No internal API paths/raw JSON for users. Convert natural intent into actions.
@@ -44,8 +44,8 @@ Execution and remote Codex handoff:
 - Reviewer-fix phrase: `Gemini が指摘している修正を Codex に進めさせます。よければ GO と言ってください。`
 - Executor transport is pluggable and user-owned; vtdd-v2-p public core does not host a shared runner.
 - Default handoff here: executorTransport=vps_runner. Do not add a separate GPT Action for VPS handoff.
-- codex_cloud_github_comment is legacy fallback; codex_cloud_cli_control_runner is selected user-owned control runner. API runner uses executorTransport=api_key_runner + apiKeyRunnerAcknowledged=true and OPENAI_API_KEY; surface openai_api_key_not_configured; never request secrets in chat.
-- After vtddExecute, call vtddExecutionProgress. For control/vps/api_key runner include executorTransport. For vps_runner status, call vtddVpsRunnerStatus and report runnerStatus, lastSeenAt, heartbeatAt, queue.pickedUp, currentStep, reason.
+- codex_cloud_github_comment is legacy fallback; codex_cloud_cli_control_runner is user-owned. API runner uses api_key_runner + acknowledgment + OPENAI_API_KEY; surface openai_api_key_not_configured; never request secrets in chat.
+- After vtddExecute, call vtddExecutionProgress; report progress.leadTime durations when present. For control/vps/api_key include executorTransport. For vps_runner status, call vtddVpsRunnerStatus and report runnerStatus, queue.pickedUp, leadTime, currentStep, reason.
 - Do not claim PR creation complete unless GitHub runtime truth shows the PR.
 
 GitHub write:

--- a/docs/setup/custom-gpt-instructions-short.md
+++ b/docs/setup/custom-gpt-instructions-short.md
@@ -83,7 +83,8 @@ Progress tracking:
 - After vtddExecute, always call vtddExecutionProgress.
 - For control/vps/api_key runner, include executorTransport in progress.
 - Use executionId, repository, issueNumber, branch.
-- vps_runner health: vtddVpsRunnerStatus -> runnerStatus, lastSeenAt, heartbeatAt, queue.pickedUp, currentStep, reasonCode/reason.
+- Report progress.leadTime durations when present: queue wait, Codex execution, PR creation, total lead time.
+- vps_runner health: vtddVpsRunnerStatus -> runnerStatus, lastSeenAt, heartbeatAt, queue.pickedUp, leadTime, currentStep, reasonCode/reason.
 - Do not claim PR creation is complete unless GitHub runtime truth actually shows the PR.
 
 Review loop:

--- a/docs/setup/custom-gpt-instructions.md
+++ b/docs/setup/custom-gpt-instructions.md
@@ -333,7 +333,8 @@ Progress tracking:
 - After vtddExecute, always call vtddExecutionProgress.
 - For `codex_cloud_cli_control_runner`, `vps_runner`, and `api_key_runner`, include the selected `executorTransport` in vtddExecutionProgress.
 - Use executionId, repository, issueNumber, and branch.
-- For `vps_runner`, call vtddVpsRunnerStatus when the human asks whether the VPS runner is alive, unavailable, stale, picked up the queue, last seen, heartbeat, or current step. Use the same executionId, repository, issueNumber, and branch. Treat `health.runnerStatus`, `health.lastSeenAt`, `health.heartbeatAt`, `health.queue.pickedUp`, `health.currentStep`, `health.reasonCode`, and `health.reason` as the short Butler-facing status.
+- When vtddExecutionProgress returns `progress.leadTime`, summarize concise durations such as queue wait, Codex execution, PR creation, and total lead time.
+- For `vps_runner`, call vtddVpsRunnerStatus when the human asks whether the VPS runner is alive, unavailable, stale, picked up the queue, last seen, heartbeat, or current step. Use the same executionId, repository, issueNumber, and branch. Treat `health.runnerStatus`, `health.lastSeenAt`, `health.heartbeatAt`, `health.queue.pickedUp`, `health.leadTime`, `health.currentStep`, `health.reasonCode`, and `health.reason` as the short Butler-facing status.
 - vtddVpsRunnerStatus is read-only GitHub runtime truth. It must not be treated as SSH, log streaming, deploy, merge, issue close, or runner administration.
 - If progress shows no PR yet, say clearly that GitHub PR is not yet published.
 - Do not claim PR creation is complete unless GitHub runtime truth actually shows the PR.

--- a/scripts/run-vps-runner.mjs
+++ b/scripts/run-vps-runner.mjs
@@ -6,6 +6,7 @@ import path from "node:path";
 import { spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { parseCodexReviewFallbackComment } from "../src/core/index.js";
+import { buildExecutionLeadTime } from "../src/core/execution-lead-time.js";
 import { renderPrBody } from "./render-pr-body.mjs";
 import { validatePrBody } from "./validate-pr-body.mjs";
 
@@ -856,53 +857,9 @@ function normalizeVpsRunnerLifecycle(value = {}) {
 }
 
 function buildVpsRunnerLeadTime(lifecycle = {}) {
-  const normalized = normalizeVpsRunnerLifecycle(lifecycle);
-  const terminalAt = normalized.completedAt || normalized.failedAt || normalized.prCreatedAt || null;
-  return {
-    queued_at: normalized.queuedAt || null,
-    picked_up_at: normalized.pickedUpAt || null,
-    codex_started_at: normalized.codexStartedAt || null,
-    branch_pushed_at: normalized.branchPushedAt || null,
-    pr_created_at: normalized.prCreatedAt || null,
-    completed_at: normalized.completedAt || null,
-    failed_at: normalized.failedAt || null,
-    durations: {
-      queue_wait_duration: buildDuration(normalized.queuedAt, normalized.pickedUpAt),
-      codex_execution_duration: buildDuration(normalized.codexStartedAt, normalized.branchPushedAt || normalized.prCreatedAt || normalized.completedAt || normalized.failedAt),
-      pr_creation_duration: buildDuration(normalized.branchPushedAt, normalized.prCreatedAt),
-      total_lead_time: buildDuration(normalized.queuedAt, terminalAt)
-    }
-  };
-}
-
-function buildDuration(start, end) {
-  const startMs = Date.parse(normalizeText(start));
-  const endMs = Date.parse(normalizeText(end));
-  if (!Number.isFinite(startMs) || !Number.isFinite(endMs) || endMs < startMs) {
-    return null;
-  }
-  const seconds = Math.round((endMs - startMs) / 1000);
-  return {
-    seconds,
-    label: formatDurationSeconds(seconds)
-  };
-}
-
-function formatDurationSeconds(seconds) {
-  if (!Number.isFinite(seconds)) {
-    return null;
-  }
-  if (seconds < 60) {
-    return `${seconds}s`;
-  }
-  const minutes = Math.floor(seconds / 60);
-  const remainder = seconds % 60;
-  if (minutes < 60) {
-    return remainder ? `${minutes}m ${remainder}s` : `${minutes}m`;
-  }
-  const hours = Math.floor(minutes / 60);
-  const minuteRemainder = minutes % 60;
-  return minuteRemainder ? `${hours}h ${minuteRemainder}m` : `${hours}h`;
+  return buildExecutionLeadTime(normalizeVpsRunnerLifecycle(lifecycle), {
+    normalizeTimestamp: normalizeIsoTimestamp
+  });
 }
 
 function formatLeadTimeCommentLines(leadTime) {

--- a/scripts/run-vps-runner.mjs
+++ b/scripts/run-vps-runner.mjs
@@ -835,7 +835,7 @@ function updateVpsRunnerLifecycleForEvent({ lifecycle, event, now }) {
   if ((status === "pr_created" || lastEvent === "pull_request_created" || lastEvent === "pull_request_updated") && !next.prCreatedAt) {
     next.prCreatedAt = timestamp;
   }
-  if ((status === "completed" || status === "pr_created") && !next.completedAt) {
+  if (status === "completed" && !next.completedAt) {
     next.completedAt = timestamp;
   }
   if (status === "failed" && !next.failedAt) {
@@ -1441,7 +1441,7 @@ function normalizeText(value) {
 
 function normalizeIsoTimestamp(value) {
   const text = normalizeText(value);
-  return Number.isFinite(Date.parse(text)) ? text : "";
+  return Number.isFinite(Date.parse(text)) ? text : null;
 }
 
 function normalizeGitHubLogin(value) {

--- a/scripts/run-vps-runner.mjs
+++ b/scripts/run-vps-runner.mjs
@@ -304,7 +304,7 @@ async function executeVpsRunnerExecution({ githubFetch, token, workRoot, executi
         pullRequestAuthor
       }),
       event: {
-        status: "pr_created",
+        status: "completed",
         lastEvent: isPrRevisionGoal(payload.codexGoal) ? "pull_request_updated" : "pull_request_created",
         currentStep: isPrRevisionGoal(payload.codexGoal) ? "pull_request_updated" : "pull_request_created",
         branch: payload.branch,
@@ -1161,13 +1161,13 @@ function buildPullRequestBody(payload) {
     nonGoals: "None.",
     unit: "Not run by VPS runner.",
     integration: "Not run by VPS runner.",
-    e2e: "GitHub branch / PR creation is the runtime evidence for this handoff.",
+    e2e: "GitHub branch / PR creation proves the handoff only; issue-specific live E2E must be recorded separately.",
     manual: "VPS runner executed the bounded Codex handoff.",
     evidencePath: `Issue #${payload.issueNumber}, branch ${payload.branch || "not provided"}, execution ${payload.executionId}`,
     cloudflareDeploy: "Not performed.",
     actionSchemaUpdate: "Not required.",
     instructionsUpdate: "Not required.",
-    iphoneButlerE2E: "Progress must be read through vtddExecutionProgress / GitHub runtime truth.",
+    iphoneButlerE2E: "Not run by VPS runner; Butler must read progress through vtddExecutionProgress / GitHub runtime truth.",
     rules: [
       "Queued handoff alone is not success.",
       "GitHub branch / PR / raw failure are runtime truth.",

--- a/scripts/run-vps-runner.mjs
+++ b/scripts/run-vps-runner.mjs
@@ -102,6 +102,10 @@ async function runVpsRunnerOnce({
 
 async function executeVpsRunnerExecution({ githubFetch, token, workRoot, execution }) {
   let payload = { ...execution.payload };
+  payload.lifecycle = normalizeVpsRunnerLifecycle({
+    ...payload.lifecycle,
+    queuedAt: execution.createdAt
+  });
   const env = buildRunnerCommandEnv({ token });
   const issue = await githubFetch(`/repos/${payload.repository}/issues/${payload.issueNumber}`);
   let notification = buildVpsRunnerNotificationContext({
@@ -115,7 +119,8 @@ async function executeVpsRunnerExecution({ githubFetch, token, workRoot, executi
     notification,
     event: {
       status: "running",
-      lastEvent: "runner_started",
+      lastEvent: "picked_up",
+      currentStep: "picked_up",
       queueCommentId: execution.commentId
     }
   });
@@ -152,8 +157,8 @@ async function executeVpsRunnerExecution({ githubFetch, token, workRoot, executi
       notification,
       event: {
         status: "branch_created",
-        lastEvent: "branch_pushed",
-        currentStep: "branch_pushed",
+        lastEvent: "branch_created",
+        currentStep: "branch_created",
         branch: payload.branch,
         originalBranch: branchCheckout.originalBranch,
         branchRecovery: branchCheckout.recovered ? branchCheckout : undefined
@@ -181,6 +186,17 @@ async function executeVpsRunnerExecution({ githubFetch, token, workRoot, executi
         env
       });
       await runCommand("git", ["push", "origin", payload.branch], { cwd: workspace, env });
+      await postVpsRunnerEvent({
+        githubFetch,
+        payload,
+        notification,
+        event: {
+          status: "running",
+          lastEvent: "branch_pushed",
+          currentStep: "branch_pushed",
+          branch: payload.branch
+        }
+      });
     }
 
     if (isPrRevisionGoal(payload.codexGoal) && !hasWorkingTreeChanges) {
@@ -510,7 +526,9 @@ function buildVpsRunnerEventComment({ executionId, event, notification } = {}) {
   if (mention) {
     lines.push(`@${mention}`);
   }
-  lines.push("VTDD VPS runner event.", "", fencedJson(event));
+  lines.push("VTDD VPS runner event.", "");
+  lines.push(...formatLeadTimeCommentLines(event?.leadTime));
+  lines.push(fencedJson(event));
   return lines.join("\n");
 }
 
@@ -520,6 +538,7 @@ function buildVpsRunnerStateComment({ executionId, event }) {
     `<!-- vtdd:vps-runner-event:${executionId} -->`,
     "VTDD VPS runner state.",
     "",
+    ...formatLeadTimeCommentLines(event?.leadTime),
     fencedJson(event)
   ].join("\n");
 }
@@ -766,11 +785,18 @@ async function executeVpsReviewerFallback({ token, reviewerFallback }) {
 }
 
 async function postVpsRunnerEvent({ githubFetch, payload, event, notification }) {
+  const now = new Date().toISOString();
+  payload.lifecycle = updateVpsRunnerLifecycleForEvent({
+    lifecycle: payload.lifecycle,
+    event,
+    now
+  });
   const eventPayload = {
     ...event,
     executionId: payload.executionId,
     repository: payload.repository,
-    issueNumber: payload.issueNumber
+    issueNumber: payload.issueNumber,
+    leadTime: buildVpsRunnerLeadTime(payload.lifecycle)
   };
 
   if (shouldUpdateVpsRunnerState(eventPayload)) {
@@ -787,6 +813,110 @@ async function postVpsRunnerEvent({ githubFetch, payload, event, notification })
       })
     }
   });
+}
+
+function updateVpsRunnerLifecycleForEvent({ lifecycle, event, now }) {
+  const next = normalizeVpsRunnerLifecycle(lifecycle);
+  const lastEvent = normalizeText(event?.lastEvent);
+  const currentStep = normalizeText(event?.currentStep);
+  const status = normalizeText(event?.status);
+  const timestamp = normalizeText(event?.updatedAt) || normalizeText(event?.heartbeatAt) || now;
+
+  if ((lastEvent === "picked_up" || lastEvent === "runner_started") && !next.pickedUpAt) {
+    next.pickedUpAt = timestamp;
+  }
+  if ((currentStep === "codex_subprocess" || lastEvent === "codex_started" || lastEvent === "codex_subprocess_started") && !next.codexStartedAt) {
+    next.codexStartedAt = timestamp;
+  }
+  if (lastEvent === "branch_pushed" && !next.branchPushedAt) {
+    next.branchPushedAt = timestamp;
+  }
+  if ((status === "pr_created" || lastEvent === "pull_request_created" || lastEvent === "pull_request_updated") && !next.prCreatedAt) {
+    next.prCreatedAt = timestamp;
+  }
+  if ((status === "completed" || status === "pr_created") && !next.completedAt) {
+    next.completedAt = timestamp;
+  }
+  if (status === "failed" && !next.failedAt) {
+    next.failedAt = timestamp;
+  }
+  return next;
+}
+
+function normalizeVpsRunnerLifecycle(value = {}) {
+  return {
+    queuedAt: normalizeIsoTimestamp(value.queuedAt ?? value.queued_at),
+    pickedUpAt: normalizeIsoTimestamp(value.pickedUpAt ?? value.picked_up_at),
+    codexStartedAt: normalizeIsoTimestamp(value.codexStartedAt ?? value.codex_started_at),
+    branchPushedAt: normalizeIsoTimestamp(value.branchPushedAt ?? value.branch_pushed_at),
+    prCreatedAt: normalizeIsoTimestamp(value.prCreatedAt ?? value.pr_created_at),
+    completedAt: normalizeIsoTimestamp(value.completedAt ?? value.completed_at),
+    failedAt: normalizeIsoTimestamp(value.failedAt ?? value.failed_at)
+  };
+}
+
+function buildVpsRunnerLeadTime(lifecycle = {}) {
+  const normalized = normalizeVpsRunnerLifecycle(lifecycle);
+  const terminalAt = normalized.completedAt || normalized.failedAt || normalized.prCreatedAt || null;
+  return {
+    queued_at: normalized.queuedAt || null,
+    picked_up_at: normalized.pickedUpAt || null,
+    codex_started_at: normalized.codexStartedAt || null,
+    branch_pushed_at: normalized.branchPushedAt || null,
+    pr_created_at: normalized.prCreatedAt || null,
+    completed_at: normalized.completedAt || null,
+    failed_at: normalized.failedAt || null,
+    durations: {
+      queue_wait_duration: buildDuration(normalized.queuedAt, normalized.pickedUpAt),
+      codex_execution_duration: buildDuration(normalized.codexStartedAt, normalized.branchPushedAt || normalized.prCreatedAt || normalized.completedAt || normalized.failedAt),
+      pr_creation_duration: buildDuration(normalized.branchPushedAt, normalized.prCreatedAt),
+      total_lead_time: buildDuration(normalized.queuedAt, terminalAt)
+    }
+  };
+}
+
+function buildDuration(start, end) {
+  const startMs = Date.parse(normalizeText(start));
+  const endMs = Date.parse(normalizeText(end));
+  if (!Number.isFinite(startMs) || !Number.isFinite(endMs) || endMs < startMs) {
+    return null;
+  }
+  const seconds = Math.round((endMs - startMs) / 1000);
+  return {
+    seconds,
+    label: formatDurationSeconds(seconds)
+  };
+}
+
+function formatDurationSeconds(seconds) {
+  if (!Number.isFinite(seconds)) {
+    return null;
+  }
+  if (seconds < 60) {
+    return `${seconds}s`;
+  }
+  const minutes = Math.floor(seconds / 60);
+  const remainder = seconds % 60;
+  if (minutes < 60) {
+    return remainder ? `${minutes}m ${remainder}s` : `${minutes}m`;
+  }
+  const hours = Math.floor(minutes / 60);
+  const minuteRemainder = minutes % 60;
+  return minuteRemainder ? `${hours}h ${minuteRemainder}m` : `${hours}h`;
+}
+
+function formatLeadTimeCommentLines(leadTime) {
+  const durations = leadTime?.durations || {};
+  const entries = [
+    ["Queue wait", durations.queue_wait_duration],
+    ["Codex execution", durations.codex_execution_duration],
+    ["PR creation", durations.pr_creation_duration],
+    ["Total lead time", durations.total_lead_time]
+  ].filter(([, duration]) => duration?.label);
+  if (entries.length === 0) {
+    return [];
+  }
+  return ["Lead time:", ...entries.map(([label, duration]) => `- ${label}: ${duration.label}`), ""];
 }
 
 function shouldUpdateVpsRunnerState(event) {
@@ -1350,6 +1480,11 @@ function fencedJson(value) {
 
 function normalizeText(value) {
   return typeof value === "string" ? value.trim() : "";
+}
+
+function normalizeIsoTimestamp(value) {
+  const text = normalizeText(value);
+  return Number.isFinite(Date.parse(text)) ? text : "";
 }
 
 function normalizeGitHubLogin(value) {

--- a/src/core/execution-lead-time.js
+++ b/src/core/execution-lead-time.js
@@ -1,0 +1,69 @@
+function normalizeText(value) {
+  return String(value ?? "").trim();
+}
+
+function defaultNormalizeTimestamp(value) {
+  const text = normalizeText(value);
+  return Number.isFinite(Date.parse(text)) ? text : null;
+}
+
+export function buildExecutionLeadTime(timestamps = {}, options = {}) {
+  const normalizeTimestamp = options.normalizeTimestamp || defaultNormalizeTimestamp;
+  const queuedAt = normalizeTimestamp(timestamps.queuedAt ?? timestamps.queued_at);
+  const pickedUpAt = normalizeTimestamp(timestamps.pickedUpAt ?? timestamps.picked_up_at);
+  const codexStartedAt = normalizeTimestamp(timestamps.codexStartedAt ?? timestamps.codex_started_at);
+  const branchPushedAt = normalizeTimestamp(timestamps.branchPushedAt ?? timestamps.branch_pushed_at);
+  const prCreatedAt = normalizeTimestamp(timestamps.prCreatedAt ?? timestamps.pr_created_at);
+  const completedAt = normalizeTimestamp(timestamps.completedAt ?? timestamps.completed_at);
+  const failedAt = normalizeTimestamp(timestamps.failedAt ?? timestamps.failed_at);
+  const terminalAt = completedAt || failedAt || prCreatedAt || null;
+
+  return {
+    queued_at: queuedAt,
+    picked_up_at: pickedUpAt,
+    codex_started_at: codexStartedAt,
+    branch_pushed_at: branchPushedAt,
+    pr_created_at: prCreatedAt,
+    completed_at: completedAt,
+    failed_at: failedAt,
+    durations: {
+      queue_wait_duration: buildExecutionDuration(queuedAt, pickedUpAt),
+      codex_execution_duration: buildExecutionDuration(
+        codexStartedAt,
+        branchPushedAt || prCreatedAt || completedAt || failedAt
+      ),
+      pr_creation_duration: buildExecutionDuration(branchPushedAt, prCreatedAt),
+      total_lead_time: buildExecutionDuration(queuedAt, terminalAt)
+    }
+  };
+}
+
+export function buildExecutionDuration(start, end) {
+  const startMs = Date.parse(normalizeText(start));
+  const endMs = Date.parse(normalizeText(end));
+  if (!Number.isFinite(startMs) || !Number.isFinite(endMs) || endMs < startMs) {
+    return null;
+  }
+  const seconds = Math.round((endMs - startMs) / 1000);
+  return {
+    seconds,
+    label: formatExecutionDurationSeconds(seconds)
+  };
+}
+
+export function formatExecutionDurationSeconds(seconds) {
+  if (!Number.isFinite(seconds)) {
+    return null;
+  }
+  if (seconds < 60) {
+    return `${seconds}s`;
+  }
+  const minutes = Math.floor(seconds / 60);
+  const remainder = seconds % 60;
+  if (minutes < 60) {
+    return remainder ? `${minutes}m ${remainder}s` : `${minutes}m`;
+  }
+  const hours = Math.floor(minutes / 60);
+  const minuteRemainder = minutes % 60;
+  return minuteRemainder ? `${hours}h ${minuteRemainder}m` : `${hours}h`;
+}

--- a/src/core/remote-codex-executor.js
+++ b/src/core/remote-codex-executor.js
@@ -1,6 +1,7 @@
 import { ActorRole } from "./types.js";
 import { resolveGitHubAppInstallationToken } from "./github-app-repository-index.js";
 import { isBoundRemoteCodexHandoff } from "./remote-codex-handoff-scope.js";
+import { buildExecutionLeadTime } from "./execution-lead-time.js";
 
 export const REMOTE_CODEX_WORKFLOW_FILE = "remote-codex-executor.yml";
 
@@ -1133,60 +1134,7 @@ function buildVpsRunnerProgressLeadTime({ queueComment, runnerEvents, pullReques
 }
 
 function buildRemoteCodexLeadTime(timestamps = {}) {
-  const queuedAt = normalizeTimestamp(timestamps.queuedAt);
-  const pickedUpAt = normalizeTimestamp(timestamps.pickedUpAt);
-  const codexStartedAt = normalizeTimestamp(timestamps.codexStartedAt);
-  const branchPushedAt = normalizeTimestamp(timestamps.branchPushedAt);
-  const prCreatedAt = normalizeTimestamp(timestamps.prCreatedAt);
-  const completedAt = normalizeTimestamp(timestamps.completedAt);
-  const failedAt = normalizeTimestamp(timestamps.failedAt);
-  const terminalAt = completedAt || failedAt || prCreatedAt || null;
-
-  return {
-    queued_at: queuedAt,
-    picked_up_at: pickedUpAt,
-    codex_started_at: codexStartedAt,
-    branch_pushed_at: branchPushedAt,
-    pr_created_at: prCreatedAt,
-    completed_at: completedAt,
-    failed_at: failedAt,
-    durations: {
-      queue_wait_duration: buildLeadTimeDuration(queuedAt, pickedUpAt),
-      codex_execution_duration: buildLeadTimeDuration(codexStartedAt, branchPushedAt || prCreatedAt || completedAt || failedAt),
-      pr_creation_duration: buildLeadTimeDuration(branchPushedAt, prCreatedAt),
-      total_lead_time: buildLeadTimeDuration(queuedAt, terminalAt)
-    }
-  };
-}
-
-function buildLeadTimeDuration(start, end) {
-  const startMs = Date.parse(normalizeText(start));
-  const endMs = Date.parse(normalizeText(end));
-  if (!Number.isFinite(startMs) || !Number.isFinite(endMs) || endMs < startMs) {
-    return null;
-  }
-  const seconds = Math.round((endMs - startMs) / 1000);
-  return {
-    seconds,
-    label: formatLeadTimeDuration(seconds)
-  };
-}
-
-function formatLeadTimeDuration(seconds) {
-  if (!Number.isFinite(seconds)) {
-    return null;
-  }
-  if (seconds < 60) {
-    return `${seconds}s`;
-  }
-  const minutes = Math.floor(seconds / 60);
-  const remainder = seconds % 60;
-  if (minutes < 60) {
-    return remainder ? `${minutes}m ${remainder}s` : `${minutes}m`;
-  }
-  const hours = Math.floor(minutes / 60);
-  const minuteRemainder = minutes % 60;
-  return minuteRemainder ? `${hours}h ${minuteRemainder}m` : `${hours}h`;
+  return buildExecutionLeadTime(timestamps, { normalizeTimestamp });
 }
 
 function normalizeTimestamp(value) {

--- a/src/core/remote-codex-executor.js
+++ b/src/core/remote-codex-executor.js
@@ -1053,11 +1053,13 @@ function findVpsRunnerEvents({ comments, queueComment }) {
       if (!payload) {
         return null;
       }
-      const status = normalizeVpsRunnerEventStatus(payload.status);
+      const rawStatus = normalizeText(payload.status);
+      const status = normalizeVpsRunnerEventStatus(rawStatus);
       const leadTime = normalizeObject(payload.leadTime);
       return {
         commentId: normalizePositiveInteger(comment?.id),
         commentUrl: normalizeText(comment?.html_url) || null,
+        rawStatus,
         status,
         lastEvent: normalizeText(payload.lastEvent) || null,
         currentStep: normalizeText(payload.currentStep) || null,
@@ -1104,7 +1106,7 @@ function buildVpsRunnerProgressLeadTime({ queueComment, runnerEvents, pullReques
     codexStartedAt: normalizeText(eventLeadTime.codex_started_at),
     branchPushedAt: normalizeText(eventLeadTime.branch_pushed_at),
     prCreatedAt: normalizeText(eventLeadTime.pr_created_at) || normalizeText(pullRequest?.createdAt),
-    completedAt: normalizeText(eventLeadTime.completed_at) || normalizeText(pullRequest?.createdAt),
+    completedAt: normalizeText(eventLeadTime.completed_at),
     failedAt: normalizeText(eventLeadTime.failed_at)
   };
 
@@ -1122,7 +1124,7 @@ function buildVpsRunnerProgressLeadTime({ queueComment, runnerEvents, pullReques
     if (!timestamps.prCreatedAt && ["pull_request_created", "pull_request_updated"].includes(normalizeText(event?.lastEvent))) {
       timestamps.prCreatedAt = updatedAt;
     }
-    if (!timestamps.completedAt && [RemoteCodexExecutionStatus.COMPLETED, "pr_created"].includes(normalizeText(event?.status))) {
+    if (!timestamps.completedAt && normalizeText(event?.rawStatus) === RemoteCodexExecutionStatus.COMPLETED) {
       timestamps.completedAt = updatedAt;
     }
     if (!timestamps.failedAt && normalizeText(event?.status) === RemoteCodexExecutionStatus.BLOCKED && Object.keys(normalizeObject(event?.rawFailure)).length > 0) {

--- a/src/core/remote-codex-executor.js
+++ b/src/core/remote-codex-executor.js
@@ -725,6 +725,12 @@ async function retrieveCodexCloudGitHubCommentProgress({
       targetRepository: repository,
       issueNumber,
       branch: branchState.branch,
+      leadTime: buildRemoteCodexLeadTime({
+        queuedAt: normalizeText(delegationComment.created_at),
+        branchPushedAt: normalizeText(branchState.branch?.createdAt),
+        prCreatedAt: normalizeText(pullRequest.pullRequest?.createdAt),
+        completedAt: normalizeText(pullRequest.pullRequest?.createdAt)
+      }),
       delegationCommentId: normalizePositiveInteger(delegationComment.id),
       delegationCommentUrl: normalizeText(delegationComment.html_url) || null,
       status: pullRequest.pullRequest
@@ -806,7 +812,13 @@ async function retrieveVpsRunnerGitHubQueueProgress({
     return branchState;
   }
 
-  const runnerEvent = findLatestVpsRunnerEvent({ comments, queueComment });
+  const runnerEvents = findVpsRunnerEvents({ comments, queueComment });
+  const runnerEvent = selectLatestVpsRunnerEvent(runnerEvents);
+  const leadTime = buildVpsRunnerProgressLeadTime({
+    queueComment,
+    runnerEvents,
+    pullRequest: pullRequest.pullRequest
+  });
   const runnerEventStaleBlocker =
     runnerEvent && !pullRequest.pullRequest
       ? buildVpsRunnerEventStaleBlocker({ runnerEvent, env })
@@ -840,6 +852,7 @@ async function retrieveVpsRunnerGitHubQueueProgress({
       status,
       pullRequest: pullRequest.pullRequest,
       runnerEvent,
+      leadTime,
       blocker: failureBlocker ?? runnerEventStaleBlocker ?? staleBlocker
     }
   };
@@ -910,7 +923,9 @@ async function findPullRequestForBranch({ repository, branch, token, env }) {
           number: normalizePositiveInteger(pull.number),
           url: normalizeText(pull.html_url) || null,
           state: normalizeText(pull.state) || null,
-          title: normalizeText(pull.title) || null
+          title: normalizeText(pull.title) || null,
+          createdAt: normalizeText(pull.created_at) || null,
+          updatedAt: normalizeText(pull.updated_at) || null
         }
       : null
   };
@@ -1016,6 +1031,10 @@ function buildCodexCloudPickupBlocker({ delegationComment, env }) {
 }
 
 function findLatestVpsRunnerEvent({ comments, queueComment }) {
+  return selectLatestVpsRunnerEvent(findVpsRunnerEvents({ comments, queueComment }));
+}
+
+function findVpsRunnerEvents({ comments, queueComment }) {
   const queueCommentId = normalizePositiveInteger(queueComment?.id) ?? 0;
   const laterComments = comments.filter((comment) => {
     const commentId = normalizePositiveInteger(comment?.id) ?? 0;
@@ -1034,6 +1053,7 @@ function findLatestVpsRunnerEvent({ comments, queueComment }) {
         return null;
       }
       const status = normalizeVpsRunnerEventStatus(payload.status);
+      const leadTime = normalizeObject(payload.leadTime);
       return {
         commentId: normalizePositiveInteger(comment?.id),
         commentUrl: normalizeText(comment?.html_url) || null,
@@ -1041,6 +1061,7 @@ function findLatestVpsRunnerEvent({ comments, queueComment }) {
         lastEvent: normalizeText(payload.lastEvent) || null,
         currentStep: normalizeText(payload.currentStep) || null,
         heartbeatAt: normalizeText(payload.heartbeatAt) || null,
+        leadTime,
         rawFailure: normalizeObject(payload.rawFailure),
         command: normalizeObject(payload.command),
         branch: normalizeText(payload.branch) || null,
@@ -1055,7 +1076,11 @@ function findLatestVpsRunnerEvent({ comments, queueComment }) {
     })
     .filter(Boolean);
 
-  return events
+  return events;
+}
+
+function selectLatestVpsRunnerEvent(events) {
+  return [...(Array.isArray(events) ? events : [])]
     .sort((left, right) => {
       const leftUpdatedAt = Date.parse(normalizeText(left?.updatedAt));
       const rightUpdatedAt = Date.parse(normalizeText(right?.updatedAt));
@@ -1065,6 +1090,108 @@ function findLatestVpsRunnerEvent({ comments, queueComment }) {
       return (normalizePositiveInteger(left?.commentId) ?? 0) - (normalizePositiveInteger(right?.commentId) ?? 0);
     })
     .at(-1) || null;
+}
+
+function buildVpsRunnerProgressLeadTime({ queueComment, runnerEvents, pullRequest }) {
+  const latestWithLeadTime = [...(Array.isArray(runnerEvents) ? runnerEvents : [])]
+    .reverse()
+    .find((event) => Object.keys(normalizeObject(event?.leadTime)).length > 0);
+  const eventLeadTime = normalizeObject(latestWithLeadTime?.leadTime);
+  const timestamps = {
+    queuedAt: normalizeText(eventLeadTime.queued_at) || normalizeText(queueComment?.created_at),
+    pickedUpAt: normalizeText(eventLeadTime.picked_up_at),
+    codexStartedAt: normalizeText(eventLeadTime.codex_started_at),
+    branchPushedAt: normalizeText(eventLeadTime.branch_pushed_at),
+    prCreatedAt: normalizeText(eventLeadTime.pr_created_at) || normalizeText(pullRequest?.createdAt),
+    completedAt: normalizeText(eventLeadTime.completed_at) || normalizeText(pullRequest?.createdAt),
+    failedAt: normalizeText(eventLeadTime.failed_at)
+  };
+
+  for (const event of runnerEvents || []) {
+    const updatedAt = normalizeText(event?.updatedAt);
+    if (!timestamps.pickedUpAt && ["picked_up", "runner_started"].includes(normalizeText(event?.lastEvent))) {
+      timestamps.pickedUpAt = updatedAt;
+    }
+    if (!timestamps.codexStartedAt && (normalizeText(event?.currentStep) === "codex_subprocess" || normalizeText(event?.lastEvent) === "codex_started" || normalizeText(event?.lastEvent) === "codex_subprocess_started")) {
+      timestamps.codexStartedAt = updatedAt;
+    }
+    if (!timestamps.branchPushedAt && normalizeText(event?.lastEvent) === "branch_pushed") {
+      timestamps.branchPushedAt = updatedAt;
+    }
+    if (!timestamps.prCreatedAt && ["pull_request_created", "pull_request_updated"].includes(normalizeText(event?.lastEvent))) {
+      timestamps.prCreatedAt = updatedAt;
+    }
+    if (!timestamps.completedAt && [RemoteCodexExecutionStatus.COMPLETED, "pr_created"].includes(normalizeText(event?.status))) {
+      timestamps.completedAt = updatedAt;
+    }
+    if (!timestamps.failedAt && normalizeText(event?.status) === RemoteCodexExecutionStatus.BLOCKED && Object.keys(normalizeObject(event?.rawFailure)).length > 0) {
+      timestamps.failedAt = updatedAt;
+    }
+  }
+
+  return buildRemoteCodexLeadTime(timestamps);
+}
+
+function buildRemoteCodexLeadTime(timestamps = {}) {
+  const queuedAt = normalizeTimestamp(timestamps.queuedAt);
+  const pickedUpAt = normalizeTimestamp(timestamps.pickedUpAt);
+  const codexStartedAt = normalizeTimestamp(timestamps.codexStartedAt);
+  const branchPushedAt = normalizeTimestamp(timestamps.branchPushedAt);
+  const prCreatedAt = normalizeTimestamp(timestamps.prCreatedAt);
+  const completedAt = normalizeTimestamp(timestamps.completedAt);
+  const failedAt = normalizeTimestamp(timestamps.failedAt);
+  const terminalAt = completedAt || failedAt || prCreatedAt || null;
+
+  return {
+    queued_at: queuedAt,
+    picked_up_at: pickedUpAt,
+    codex_started_at: codexStartedAt,
+    branch_pushed_at: branchPushedAt,
+    pr_created_at: prCreatedAt,
+    completed_at: completedAt,
+    failed_at: failedAt,
+    durations: {
+      queue_wait_duration: buildLeadTimeDuration(queuedAt, pickedUpAt),
+      codex_execution_duration: buildLeadTimeDuration(codexStartedAt, branchPushedAt || prCreatedAt || completedAt || failedAt),
+      pr_creation_duration: buildLeadTimeDuration(branchPushedAt, prCreatedAt),
+      total_lead_time: buildLeadTimeDuration(queuedAt, terminalAt)
+    }
+  };
+}
+
+function buildLeadTimeDuration(start, end) {
+  const startMs = Date.parse(normalizeText(start));
+  const endMs = Date.parse(normalizeText(end));
+  if (!Number.isFinite(startMs) || !Number.isFinite(endMs) || endMs < startMs) {
+    return null;
+  }
+  const seconds = Math.round((endMs - startMs) / 1000);
+  return {
+    seconds,
+    label: formatLeadTimeDuration(seconds)
+  };
+}
+
+function formatLeadTimeDuration(seconds) {
+  if (!Number.isFinite(seconds)) {
+    return null;
+  }
+  if (seconds < 60) {
+    return `${seconds}s`;
+  }
+  const minutes = Math.floor(seconds / 60);
+  const remainder = seconds % 60;
+  if (minutes < 60) {
+    return remainder ? `${minutes}m ${remainder}s` : `${minutes}m`;
+  }
+  const hours = Math.floor(minutes / 60);
+  const minuteRemainder = minutes % 60;
+  return minuteRemainder ? `${hours}h ${minuteRemainder}m` : `${hours}h`;
+}
+
+function normalizeTimestamp(value) {
+  const text = normalizeText(value);
+  return Number.isFinite(Date.parse(text)) ? text : null;
 }
 
 function buildVpsRunnerEventStaleBlocker({ runnerEvent, env }) {
@@ -1164,6 +1291,7 @@ function buildVpsRunnerHealthStatus({ progress, env }) {
       commentId: normalizePositiveInteger(progress?.queueCommentId),
       commentUrl: normalizeText(progress?.queueCommentUrl) || null
     },
+    leadTime: normalizeObject(progress?.leadTime),
     currentStep,
     progressStatus: normalizeText(progress?.status) || RemoteCodexExecutionStatus.UNKNOWN,
     reason: unavailableReason?.reason || null,

--- a/test/e2e-30-execution-lead-time-telemetry.test.js
+++ b/test/e2e-30-execution-lead-time-telemetry.test.js
@@ -1,0 +1,39 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const DOC_PATH = path.join(
+  process.cwd(),
+  "docs",
+  "mvp",
+  "e2e",
+  "e2e-30-execution-lead-time-telemetry.md"
+);
+const MATRIX_PATH = path.join(process.cwd(), "docs", "mvp", "issue-to-e2e-matrix.md");
+
+test("E2E-30 evidence doc records Issue 260 lead-time telemetry coverage", () => {
+  const doc = fs.readFileSync(DOC_PATH, "utf8");
+
+  assert.equal(doc.includes("Issue `#260`"), true);
+  assert.equal(doc.includes("queued_at"), true);
+  assert.equal(doc.includes("picked_up_at"), true);
+  assert.equal(doc.includes("codex_started_at"), true);
+  assert.equal(doc.includes("branch_pushed_at"), true);
+  assert.equal(doc.includes("pr_created_at"), true);
+  assert.equal(doc.includes("completed_at"), true);
+  assert.equal(doc.includes("failed_at"), true);
+  assert.equal(doc.includes("vtddExecutionProgress"), true);
+  assert.equal(doc.includes("vtddVpsRunnerStatus"), true);
+  assert.equal(doc.includes("not run in this revision"), true);
+  assert.equal(doc.includes("must not be described as complete"), true);
+});
+
+test("issue-to-e2e matrix references E2E-30 without overclaiming live evidence", () => {
+  const doc = fs.readFileSync(MATRIX_PATH, "utf8");
+
+  assert.equal(doc.includes("## E2E-30 Execution lead-time telemetry"), true);
+  assert.equal(doc.includes("- Issues: `#260`"), true);
+  assert.equal(doc.includes("docs/mvp/e2e/e2e-30-execution-lead-time-telemetry.md"), true);
+  assert.equal(doc.includes("- Status: `implemented_pending_e2e`"), true);
+});

--- a/test/execution-lead-time.test.js
+++ b/test/execution-lead-time.test.js
@@ -1,0 +1,38 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildExecutionDuration,
+  buildExecutionLeadTime,
+  formatExecutionDurationSeconds
+} from "../src/core/execution-lead-time.js";
+
+test("execution lead time computes concise lifecycle durations", () => {
+  const leadTime = buildExecutionLeadTime({
+    queuedAt: "2026-05-09T10:00:00.000Z",
+    pickedUpAt: "2026-05-09T10:00:12.000Z",
+    codexStartedAt: "2026-05-09T10:00:20.000Z",
+    branchPushedAt: "2026-05-09T10:04:02.000Z",
+    prCreatedAt: "2026-05-09T10:04:10.000Z"
+  });
+
+  assert.equal(leadTime.queued_at, "2026-05-09T10:00:00.000Z");
+  assert.equal(leadTime.durations.queue_wait_duration.label, "12s");
+  assert.equal(leadTime.durations.codex_execution_duration.label, "3m 42s");
+  assert.equal(leadTime.durations.pr_creation_duration.label, "8s");
+  assert.equal(leadTime.durations.total_lead_time.label, "4m 10s");
+});
+
+test("execution duration rejects missing or reversed timestamps", () => {
+  assert.equal(buildExecutionDuration(null, "2026-05-09T10:00:00.000Z"), null);
+  assert.equal(
+    buildExecutionDuration("2026-05-09T10:00:10.000Z", "2026-05-09T10:00:00.000Z"),
+    null
+  );
+});
+
+test("execution duration formatter keeps GitHub comments compact", () => {
+  assert.equal(formatExecutionDurationSeconds(59), "59s");
+  assert.equal(formatExecutionDurationSeconds(60), "1m");
+  assert.equal(formatExecutionDurationSeconds(222), "3m 42s");
+  assert.equal(formatExecutionDurationSeconds(3660), "1h 1m");
+});

--- a/test/execution-lead-time.test.js
+++ b/test/execution-lead-time.test.js
@@ -20,6 +20,7 @@ test("execution lead time computes concise lifecycle durations", () => {
   assert.equal(leadTime.durations.codex_execution_duration.label, "3m 42s");
   assert.equal(leadTime.durations.pr_creation_duration.label, "8s");
   assert.equal(leadTime.durations.total_lead_time.label, "4m 10s");
+  assert.equal(leadTime.completed_at, null);
 });
 
 test("execution duration rejects missing or reversed timestamps", () => {

--- a/test/remote-codex-executor.test.js
+++ b/test/remote-codex-executor.test.js
@@ -790,6 +790,7 @@ test("remote Codex vps_runner progress exposes execution lead time from runner e
   assert.equal(progress.progress.leadTime.codex_started_at, "2026-05-09T10:00:20.000Z");
   assert.equal(progress.progress.leadTime.branch_pushed_at, "2026-05-09T10:04:02.000Z");
   assert.equal(progress.progress.leadTime.pr_created_at, "2026-05-09T10:04:10.000Z");
+  assert.equal(progress.progress.leadTime.completed_at, null);
   assert.equal(progress.progress.leadTime.durations.queue_wait_duration.label, "12s");
   assert.equal(progress.progress.leadTime.durations.codex_execution_duration.label, "3m 42s");
   assert.equal(progress.progress.leadTime.durations.pr_creation_duration.label, "8s");

--- a/test/remote-codex-executor.test.js
+++ b/test/remote-codex-executor.test.js
@@ -756,7 +756,7 @@ test("remote Codex vps_runner progress exposes execution lead time from runner e
                   "<!-- vtdd:vps-runner-event:remote-codex-issue260-vps -->",
                   "```json",
                   JSON.stringify({
-                    status: "pr_created",
+                    status: "completed",
                     lastEvent: "pull_request_created",
                     currentStep: "pull_request_created",
                     updatedAt: "2026-05-09T10:04:10.000Z"
@@ -790,7 +790,7 @@ test("remote Codex vps_runner progress exposes execution lead time from runner e
   assert.equal(progress.progress.leadTime.codex_started_at, "2026-05-09T10:00:20.000Z");
   assert.equal(progress.progress.leadTime.branch_pushed_at, "2026-05-09T10:04:02.000Z");
   assert.equal(progress.progress.leadTime.pr_created_at, "2026-05-09T10:04:10.000Z");
-  assert.equal(progress.progress.leadTime.completed_at, null);
+  assert.equal(progress.progress.leadTime.completed_at, "2026-05-09T10:04:10.000Z");
   assert.equal(progress.progress.leadTime.durations.queue_wait_duration.label, "12s");
   assert.equal(progress.progress.leadTime.durations.codex_execution_duration.label, "3m 42s");
   assert.equal(progress.progress.leadTime.durations.pr_creation_duration.label, "8s");

--- a/test/remote-codex-executor.test.js
+++ b/test/remote-codex-executor.test.js
@@ -677,6 +677,125 @@ test("remote Codex vps_runner progress reads queue comment and target PR truth",
   assert.equal(calls.length, 2);
 });
 
+test("remote Codex vps_runner progress exposes execution lead time from runner events", async () => {
+  const progress = await retrieveRemoteCodexExecutionProgress({
+    executionId: "remote-codex-issue260-vps",
+    repository: "sample-org/sunaba-eye",
+    issueNumber: 260,
+    branch: "codex/issue-260",
+    executorTransport: RemoteCodexExecutorTransport.VPS_RUNNER,
+    env: {
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_progress_token",
+      GITHUB_API_FETCH: async (url) => {
+        if (String(url).includes("/issues/260/comments")) {
+          return new Response(
+            JSON.stringify([
+              {
+                id: 26001,
+                html_url: "https://github.com/sample-org/sunaba-eye/issues/260#issuecomment-26001",
+                created_at: "2026-05-09T10:00:00.000Z",
+                body: "<!-- vtdd:vps-runner-execution:remote-codex-issue260-vps -->"
+              },
+              {
+                id: 26002,
+                html_url: "https://github.com/sample-org/sunaba-eye/issues/260#issuecomment-26002",
+                created_at: "2026-05-09T10:00:12.000Z",
+                updated_at: "2026-05-09T10:00:12.000Z",
+                body: [
+                  "<!-- vtdd:vps-runner-event:remote-codex-issue260-vps -->",
+                  "```json",
+                  JSON.stringify({
+                    status: "running",
+                    lastEvent: "picked_up",
+                    currentStep: "picked_up",
+                    updatedAt: "2026-05-09T10:00:12.000Z"
+                  }),
+                  "```"
+                ].join("\n")
+              },
+              {
+                id: 26003,
+                html_url: "https://github.com/sample-org/sunaba-eye/issues/260#issuecomment-26003",
+                created_at: "2026-05-09T10:00:20.000Z",
+                updated_at: "2026-05-09T10:00:20.000Z",
+                body: [
+                  "<!-- vtdd:vps-runner-event:remote-codex-issue260-vps -->",
+                  "```json",
+                  JSON.stringify({
+                    status: "running",
+                    lastEvent: "codex_subprocess_started",
+                    currentStep: "codex_subprocess",
+                    updatedAt: "2026-05-09T10:00:20.000Z"
+                  }),
+                  "```"
+                ].join("\n")
+              },
+              {
+                id: 26004,
+                html_url: "https://github.com/sample-org/sunaba-eye/issues/260#issuecomment-26004",
+                created_at: "2026-05-09T10:04:02.000Z",
+                updated_at: "2026-05-09T10:04:02.000Z",
+                body: [
+                  "<!-- vtdd:vps-runner-event:remote-codex-issue260-vps -->",
+                  "```json",
+                  JSON.stringify({
+                    status: "running",
+                    lastEvent: "branch_pushed",
+                    currentStep: "branch_pushed",
+                    updatedAt: "2026-05-09T10:04:02.000Z"
+                  }),
+                  "```"
+                ].join("\n")
+              },
+              {
+                id: 26005,
+                html_url: "https://github.com/sample-org/sunaba-eye/issues/260#issuecomment-26005",
+                created_at: "2026-05-09T10:04:10.000Z",
+                updated_at: "2026-05-09T10:04:10.000Z",
+                body: [
+                  "<!-- vtdd:vps-runner-event:remote-codex-issue260-vps -->",
+                  "```json",
+                  JSON.stringify({
+                    status: "pr_created",
+                    lastEvent: "pull_request_created",
+                    currentStep: "pull_request_created",
+                    updatedAt: "2026-05-09T10:04:10.000Z"
+                  }),
+                  "```"
+                ].join("\n")
+              }
+            ]),
+            { status: 200, headers: { "content-type": "application/json" } }
+          );
+        }
+        return new Response(
+          JSON.stringify([
+            {
+              number: 260,
+              html_url: "https://github.com/sample-org/sunaba-eye/pull/260",
+              state: "open",
+              title: "VPS runner execution for issue #260",
+              created_at: "2026-05-09T10:04:10.000Z"
+            }
+          ]),
+          { status: 200, headers: { "content-type": "application/json" } }
+        );
+      }
+    }
+  });
+
+  assert.equal(progress.ok, true);
+  assert.equal(progress.progress.leadTime.queued_at, "2026-05-09T10:00:00.000Z");
+  assert.equal(progress.progress.leadTime.picked_up_at, "2026-05-09T10:00:12.000Z");
+  assert.equal(progress.progress.leadTime.codex_started_at, "2026-05-09T10:00:20.000Z");
+  assert.equal(progress.progress.leadTime.branch_pushed_at, "2026-05-09T10:04:02.000Z");
+  assert.equal(progress.progress.leadTime.pr_created_at, "2026-05-09T10:04:10.000Z");
+  assert.equal(progress.progress.leadTime.durations.queue_wait_duration.label, "12s");
+  assert.equal(progress.progress.leadTime.durations.codex_execution_duration.label, "3m 42s");
+  assert.equal(progress.progress.leadTime.durations.pr_creation_duration.label, "8s");
+  assert.equal(progress.progress.leadTime.durations.total_lead_time.label, "4m 10s");
+});
+
 test("remote Codex vps_runner progress blocks stale queue without pickup evidence", async () => {
   const originalNow = Date.now;
   Date.now = () => Date.parse("2026-05-07T10:10:00Z");
@@ -1116,6 +1235,8 @@ test("remote Codex vps_runner health reports alive pickup and current step", asy
     assert.equal(health.health.heartbeatAt, "2026-05-09T10:01:00.000Z");
     assert.equal(health.health.queue.pickedUp, true);
     assert.equal(health.health.queue.status, "picked_up");
+    assert.equal(health.health.leadTime.queued_at, "2026-05-09T10:00:00Z");
+    assert.equal(health.health.leadTime.codex_started_at, "2026-05-09T10:01:00.000Z");
     assert.equal(health.health.currentStep, "codex_subprocess");
     assert.equal(health.health.progressStatus, RemoteCodexExecutionStatus.IN_PROGRESS);
     assert.equal(health.health.reason, null);

--- a/test/vps-runner-script.test.js
+++ b/test/vps-runner-script.test.js
@@ -519,6 +519,43 @@ test("VPS runner lead time keeps pr_created_at distinct from completed_at", asyn
   assert.equal(parsed.event.leadTime.durations.total_lead_time.label, "4m 10s");
 });
 
+test("VPS runner completed event records both PR creation and completion timestamps", async () => {
+  const calls = [];
+  const payload = {
+    executionId: "exec-completed-1",
+    repository: "sample-org/vtdd-v2",
+    issueNumber: 260,
+    lifecycle: {
+      queuedAt: "2026-05-09T10:00:00.000Z",
+      pickedUpAt: "2026-05-09T10:00:12.000Z",
+      codexStartedAt: "2026-05-09T10:00:20.000Z",
+      branchPushedAt: "2026-05-09T10:04:02.000Z"
+    }
+  };
+
+  await postVpsRunnerEvent({
+    githubFetch: async (url, init = {}) => {
+      calls.push({ url, init });
+      return { id: 26004 };
+    },
+    payload,
+    event: {
+      status: "completed",
+      lastEvent: "pull_request_created",
+      currentStep: "pull_request_created",
+      updatedAt: "2026-05-09T10:04:10.000Z"
+    }
+  });
+
+  const parsed = parseVpsRunnerEventComment(calls[0].init.body.body);
+
+  assert.equal(parsed.ok, true);
+  assert.equal(parsed.event.leadTime.pr_created_at, "2026-05-09T10:04:10.000Z");
+  assert.equal(parsed.event.leadTime.completed_at, "2026-05-09T10:04:10.000Z");
+  assert.equal(parsed.event.leadTime.durations.pr_creation_duration.label, "8s");
+  assert.equal(parsed.event.leadTime.durations.total_lead_time.label, "4m 10s");
+});
+
 test("VPS runner diagnostic summaries redact secrets and stay short", () => {
   const summary = summarizeDiagnosticText(
     [
@@ -844,6 +881,8 @@ test("VPS runner PR body satisfies guarded PR template markers", () => {
   assert.equal(body.includes("## Surface Update Checklist"), true);
   assert.equal(body.includes("Execution ID: remote-codex-issue194-test"), true);
   assert.equal(body.includes("No merge or deploy is performed by the VPS runner."), true);
+  assert.equal(body.includes("issue-specific live E2E must be recorded separately"), true);
+  assert.equal(body.includes("Not run by VPS runner; Butler must read progress"), true);
 });
 
 test("VPS runner preserves a guarded-policy-compliant PR body candidate", () => {

--- a/test/vps-runner-script.test.js
+++ b/test/vps-runner-script.test.js
@@ -483,6 +483,42 @@ test("VPS runner milestone events still create new comments", async () => {
   assert.equal(calls[0].init.body.body.includes("vtdd:vps-runner-event:exec-branch-1"), true);
 });
 
+test("VPS runner lead time keeps pr_created_at distinct from completed_at", async () => {
+  const calls = [];
+  const payload = {
+    executionId: "exec-pr-created-1",
+    repository: "sample-org/vtdd-v2",
+    issueNumber: 260,
+    lifecycle: {
+      queuedAt: "2026-05-09T10:00:00.000Z",
+      pickedUpAt: "2026-05-09T10:00:12.000Z",
+      codexStartedAt: "2026-05-09T10:00:20.000Z",
+      branchPushedAt: "2026-05-09T10:04:02.000Z"
+    }
+  };
+
+  await postVpsRunnerEvent({
+    githubFetch: async (url, init = {}) => {
+      calls.push({ url, init });
+      return { id: 26003 };
+    },
+    payload,
+    event: {
+      status: "pr_created",
+      lastEvent: "pull_request_created",
+      currentStep: "pull_request_created",
+      updatedAt: "2026-05-09T10:04:10.000Z"
+    }
+  });
+
+  const parsed = parseVpsRunnerEventComment(calls[0].init.body.body);
+
+  assert.equal(parsed.ok, true);
+  assert.equal(parsed.event.leadTime.pr_created_at, "2026-05-09T10:04:10.000Z");
+  assert.equal(parsed.event.leadTime.completed_at, null);
+  assert.equal(parsed.event.leadTime.durations.total_lead_time.label, "4m 10s");
+});
+
 test("VPS runner diagnostic summaries redact secrets and stay short", () => {
   const summary = summarizeDiagnosticText(
     [

--- a/test/vps-runner-script.test.js
+++ b/test/vps-runner-script.test.js
@@ -330,6 +330,33 @@ test("VPS runner state comment remains compatible with runner event parsing", ()
   assert.equal(parsed.event.currentStep, "codex_subprocess");
 });
 
+test("VPS runner state comment exposes concise lead time before JSON runtime truth", () => {
+  const body = buildVpsRunnerStateComment({
+    executionId: "exec-lead-time-1",
+    event: {
+      status: "running",
+      lastEvent: "branch_pushed",
+      leadTime: {
+        queued_at: "2026-05-09T10:00:00.000Z",
+        picked_up_at: "2026-05-09T10:00:12.000Z",
+        codex_started_at: "2026-05-09T10:00:20.000Z",
+        branch_pushed_at: "2026-05-09T10:04:02.000Z",
+        durations: {
+          queue_wait_duration: { seconds: 12, label: "12s" },
+          codex_execution_duration: { seconds: 222, label: "3m 42s" }
+        }
+      }
+    }
+  });
+  const parsed = parseVpsRunnerEventComment(body);
+
+  assert.equal(body.includes("Lead time:"), true);
+  assert.equal(body.includes("- Queue wait: 12s"), true);
+  assert.equal(body.includes("- Codex execution: 3m 42s"), true);
+  assert.equal(parsed.ok, true);
+  assert.equal(parsed.event.leadTime.durations.queue_wait_duration.label, "12s");
+});
+
 test("VPS runner heartbeat updates existing state comment instead of posting a new comment", async () => {
   const calls = [];
   const payload = {


### PR DESCRIPTION
## This PR satisfies Intent

- Expose VTDD/Codex execution lead-time telemetry as GitHub-visible runtime truth for Issue #260.

## Satisfied Success Criteria

- execution lead time is visible from Butler via vtddExecutionProgress progress.leadTime.
- execution lead time is visible from vtddVpsRunnerStatus health.leadTime.
- GitHub-visible VPS runner state/event comments include concise Lead time lines and JSON leadTime runtime truth.
- Queue wait, Codex execution, PR creation, and total lead time durations are computed with readable labels.
- Lead-time duration calculation and formatting are shared by Butler progress reconstruction and VPS runner comment publishing.
- `pr_created_at` remains distinct from `completed_at`; PR creation can end total lead-time calculation without falsifying a completed timestamp.
- Existing execution flow remains compatible; existing event parsing and tests pass.

## Unsatisfied Success Criteria

- Live GitHub E2E on a real runner was not executed in this local workspace; this remains the reviewer-raised unverified production path.

## Non-goal violations

None.

## Verification Evidence

- Unit: npm test (609 tests passed on 2026-05-10).
- Integration: node --test test/execution-lead-time.test.js test/vps-runner-script.test.js test/remote-codex-executor.test.js test/e2e-30-execution-lead-time-telemetry.test.js test/custom-gpt-setup-docs.test.js (81 tests passed on 2026-05-10).
- E2E: Not run live; covered by runtime progress/comment contract tests for happy-path and stale/failure boundaries. Reviewer-raised live GitHub runner E2E and iPhone Butler live E2E remain unverified.
- Manual: Inspected docs/pr-template-model.md, scripts/render-pr-body.mjs, scripts/validate-pr-body.mjs before drafting; read GitHub Issue #260 and PR #261 runtime truth with gh on 2026-05-10.
- Evidence path/link: src/core/execution-lead-time.js; test/execution-lead-time.test.js; test/remote-codex-executor.test.js; test/vps-runner-script.test.js; docs/butler/remote-codex-cli-executor.md

## Surface Update Checklist

- Cloudflare deploy: Not required.
- Custom GPT Action Schema update: Not required.
- Custom GPT Instructions update: Done: setup Custom GPT instructions now tell Butler to report leadTime.
- iPhone Butler live E2E: Not run.

## Related Constitution Rules

- Issue #260 is the only implementation scope.
- Do not merge, deploy, close issues, mutate secrets, permissions, settings, or infrastructure.
- Runtime truth must stay GitHub-visible and concise.

## Out-of-scope but NOT implemented

- Full tracing UI.
- External telemetry vendors.
- Log streaming.
- Deploy, merge, or issue close automation.

## Extra changes (if any)

- Gemini reviewer code-duplication risk addressed by centralizing lead-time duration calculation and formatting in src/core/execution-lead-time.js.
- Gemini reviewer PR-body mismatch is addressed by this guarded PR body draft and the live PR body sync for PR #261.

<!-- VTDD metadata -->
- Issue: #260
- Execution ID: remote-codex-issue260-iogni0
- Goal: revise_pr
