### PR TITLE
Fix VPS runner completed final event

### DIFF
--- a/docs/butler/remote-codex-cli-executor.md
+++ b/docs/butler/remote-codex-cli-executor.md
@@ -341,12 +341,21 @@ durations for queue wait, Codex execution, PR creation, and total lead time.
 The same values are rendered as short GitHub-visible lines such as
 `Queue wait: 12s` and `Codex execution: 3m 42s`.
 
+When the VPS runner reports `status: completed`, the same GitHub-visible event
+must also carry an explicit terminal outcome in `finalEvent` and `lastEvent`.
+Valid terminal outcomes include `pr_created`, `pr_updated`,
+`conflict_resolved`, `blocked`, `failed`, `no_changes`, and
+`merge_retry_ready`. Butler must use that terminal outcome, not the bare word
+`completed`, when explaining whether the runner created a PR, updated a PR,
+resolved a conflict, made no changes, or stopped with a visible blocker.
+
 Runner event comments may include a GitHub mention only as a notification
 mirror; the JSON event payload and branch / PR evidence remain the runtime
 truth. The mention target is selected in this priority order when a login is
 available and not a bot or notification-blocked actor: queue comment author,
 Issue author, PR author, approval / GO actor, then no mention. Mentions are
 limited to milestone events (`picked_up`, `branch_pushed`, `pr_created`,
+`pr_updated`, `conflict_resolved`, `no_changes`, `merge_retry_ready`,
 `blocked`, `failed`, `stale`, `deploy_required`, `completed`). Heartbeat and
 progress-poll comments must not mention anyone.
 

--- a/scripts/run-vps-runner.mjs
+++ b/scripts/run-vps-runner.mjs
@@ -20,6 +20,9 @@ const MILESTONE_MENTION_EVENTS = new Set([
   "branch_pushed",
   "pr_created",
   "pr_updated",
+  "conflict_resolved",
+  "no_changes",
+  "merge_retry_ready",
   "pull_request_created",
   "pull_request_updated",
   "review_result_changed",
@@ -307,6 +310,7 @@ async function executeVpsRunnerExecution({ githubFetch, token, workRoot, executi
         })) || pullRequestAuthor;
     }
 
+    const completionFinalEvent = buildVpsRunnerCompletionFinalEvent({ payload });
     await postVpsRunnerEvent({
       githubFetch,
       payload,
@@ -316,26 +320,15 @@ async function executeVpsRunnerExecution({ githubFetch, token, workRoot, executi
       }),
       event: {
         status: "completed",
-        lastEvent: isPrRevisionGoal(payload.codexGoal) ? "pull_request_updated" : "pull_request_created",
-        currentStep: isPrRevisionGoal(payload.codexGoal) ? "pull_request_updated" : "pull_request_created",
-        branch: payload.branch,
-        pr: prUrl
-      }
-    });
-
-    await postVpsRunnerEvent({
-      githubFetch,
-      payload,
-      notification: buildVpsRunnerNotificationContext({
-        ...notification,
-        pullRequestAuthor
-      }),
-      event: {
-        status: "completed",
-        lastEvent: "execution_completed",
+        lastEvent: completionFinalEvent,
+        finalEvent: completionFinalEvent,
         currentStep: "completed",
         branch: payload.branch,
-        pr: prUrl
+        pr: prUrl,
+        finalEventReason:
+          completionFinalEvent === "pr_updated"
+            ? "The VPS runner pushed revision changes and updated the existing pull request."
+            : "The VPS runner created a pull request for the bounded execution branch."
       }
     });
 
@@ -392,6 +385,10 @@ function selectPendingVpsRunnerExecutions({ comments, allowedRepositories, repos
   return [...queues.values()].filter(
     (queue) => !terminalEvents.has(queue.payload.executionId) && !runningEvents.has(queue.payload.executionId)
   );
+}
+
+function buildVpsRunnerCompletionFinalEvent({ payload } = {}) {
+  return isPrRevisionGoal(payload?.codexGoal) ? "pr_updated" : "pr_created";
 }
 
 function selectPendingVpsReviewerFallbacks({ comments, allowedRepositories, repositoryPolicies }) {
@@ -856,7 +853,14 @@ function updateVpsRunnerLifecycleForEvent({ lifecycle, event, now }) {
   if (lastEvent === "branch_pushed" && !next.branchPushedAt) {
     next.branchPushedAt = timestamp;
   }
-  if ((status === "pr_created" || lastEvent === "pull_request_created" || lastEvent === "pull_request_updated") && !next.prCreatedAt) {
+  if (
+    (status === "pr_created" ||
+      lastEvent === "pr_created" ||
+      lastEvent === "pr_updated" ||
+      lastEvent === "pull_request_created" ||
+      lastEvent === "pull_request_updated") &&
+    !next.prCreatedAt
+  ) {
     next.prCreatedAt = timestamp;
   }
   if (status === "completed" && !next.completedAt) {
@@ -1384,6 +1388,7 @@ function resolveVpsRunnerMention({ event, notification } = {}) {
 
 function isVpsRunnerMentionMilestone(event = {}) {
   const candidates = [
+    normalizeText(event.finalEvent),
     normalizeText(event.notificationEvent),
     normalizeText(event.status),
     normalizeText(event.lastEvent),
@@ -1406,6 +1411,7 @@ function formatVpsRunnerMilestoneLead({ event, mention } = {}) {
 
 function getVpsRunnerMilestoneLabel(event = {}) {
   const candidates = [
+    normalizeText(event.finalEvent),
     normalizeText(event.notificationEvent),
     normalizeText(event.status),
     normalizeText(event.lastEvent),
@@ -1420,6 +1426,9 @@ function getVpsRunnerMilestoneLabel(event = {}) {
     branch_pushed: "branch pushed",
     pr_created: "PR created",
     pr_updated: "PR updated",
+    conflict_resolved: "conflict resolved",
+    no_changes: "no changes",
+    merge_retry_ready: "merge retry ready",
     pull_request_created: "PR created",
     pull_request_updated: "PR updated",
     review_result_changed: "review result changed",
@@ -1573,6 +1582,7 @@ if (import.meta.url === `file://${process.argv[1]}`) {
 
 export {
   buildFreshExecutionBranchCandidates,
+  buildVpsRunnerCompletionFinalEvent,
   buildCodexExecutionPrompt,
   buildCodexExecArgs,
   buildGuardedPullRequestBody,

--- a/test/vps-runner-script.test.js
+++ b/test/vps-runner-script.test.js
@@ -6,6 +6,7 @@ import {
   buildCodexExecArgs,
   buildGuardedPullRequestBody,
   buildPullRequestBody,
+  buildVpsRunnerCompletionFinalEvent,
   buildVpsRunnerEventComment,
   buildVpsRunnerStateComment,
   buildVpsRunnerPullRequestContext,
@@ -555,6 +556,66 @@ test("VPS runner completed event records both PR creation and completion timesta
   assert.equal(parsed.event.leadTime.completed_at, "2026-05-09T10:04:10.000Z");
   assert.equal(parsed.event.leadTime.durations.pr_creation_duration.label, "8s");
   assert.equal(parsed.event.leadTime.durations.total_lead_time.label, "4m 10s");
+});
+
+test("VPS runner completed event exposes a GitHub-visible final event", async () => {
+  const calls = [];
+  const payload = {
+    executionId: "exec-final-event-1",
+    repository: "sample-org/vtdd-v2",
+    issueNumber: 264,
+    lifecycle: {
+      queuedAt: "2026-05-09T10:00:00.000Z",
+      pickedUpAt: "2026-05-09T10:00:12.000Z",
+      codexStartedAt: "2026-05-09T10:00:20.000Z",
+      branchPushedAt: "2026-05-09T10:04:02.000Z"
+    }
+  };
+
+  await postVpsRunnerEvent({
+    githubFetch: async (url, init = {}) => {
+      calls.push({ url, init });
+      return { id: 26401 };
+    },
+    payload,
+    event: {
+      status: "completed",
+      lastEvent: "pr_updated",
+      finalEvent: "pr_updated",
+      currentStep: "completed",
+      updatedAt: "2026-05-09T10:04:10.000Z",
+      branch: "codex/issue-264",
+      pr: "https://github.com/sample-org/vtdd-v2/pull/264",
+      finalEventReason: "The VPS runner pushed revision changes and updated the existing pull request."
+    }
+  });
+
+  const body = calls[0].init.body.body;
+  const parsed = parseVpsRunnerEventComment(body);
+
+  assert.equal(parsed.ok, true);
+  assert.equal(parsed.event.status, "completed");
+  assert.equal(parsed.event.lastEvent, "pr_updated");
+  assert.equal(parsed.event.finalEvent, "pr_updated");
+  assert.equal(parsed.event.finalEventReason.includes("updated the existing pull request"), true);
+  assert.equal(parsed.event.leadTime.pr_created_at, "2026-05-09T10:04:10.000Z");
+  assert.equal(parsed.event.leadTime.completed_at, "2026-05-09T10:04:10.000Z");
+  assert.equal(body.includes("VTDD milestone: PR updated."), true);
+});
+
+test("VPS runner maps completed execution goals to explicit final events", () => {
+  assert.equal(
+    buildVpsRunnerCompletionFinalEvent({
+      payload: { codexGoal: "open_pr" }
+    }),
+    "pr_created"
+  );
+  assert.equal(
+    buildVpsRunnerCompletionFinalEvent({
+      payload: { codexGoal: "revise_pr" }
+    }),
+    "pr_updated"
+  );
 });
 
 test("VPS runner diagnostic summaries redact secrets and stay short", () => {


### PR DESCRIPTION
## This PR satisfies Intent

- VPS runner completed comments now carry an explicit GitHub-visible terminal outcome via finalEvent/lastEvent, so completed is not interpreted without pr_created/pr_updated style runtime truth.

## Satisfied Success Criteria

- completed execution comments include finalEvent and matching lastEvent.
- PR creation and PR revision completion map to pr_created / pr_updated.
- Milestone notifications and lead-time telemetry read the explicit final event.
- Canonical VPS runner doc records the completed final-event contract.

## Unsatisfied Success Criteria

- Live VPS runner E2E against GitHub production runtime was not run in this bounded local PR work.
- Conflict-specific conflict_resolved / merge_retry_ready classification remains a future outcome producer; this PR prevents opaque completed events for current create/update completion paths.

## Non-goal violations

None.

## Verification Evidence

- Unit: npm test (625 node tests passed; includes test/vps-runner-script.test.js).
- Integration: npm test self-parity and generated worker checks passed.
- E2E: Doc-backed E2E-30 test passed locally; no live VPS/GitHub production E2E was run.
- Manual: Inspected docs/pr-template-model.md, scripts/render-pr-body.mjs, and scripts/validate-pr-body.mjs before drafting this PR body.
- Evidence path/link: scripts/run-vps-runner.mjs; test/vps-runner-script.test.js; docs/butler/remote-codex-cli-executor.md

## Surface Update Checklist

- Cloudflare deploy: Not required.
- Custom GPT Action Schema update: Not required.
- Custom GPT Instructions update: Not required.
- iPhone Butler live E2E: Not run; not authorized for this bounded code/doc PR.

## Related Constitution Rules

- Runtime truth must be GitHub-visible.
- Queued/requested/completed labels alone are not implementation success.
- No merge, deploy, secret, permission, or repository setting mutation.

## Out-of-scope but NOT implemented

- Live VPS production run.
- Merge/deploy/Issue closure.
- Credential, permission, repository setting, or external infrastructure mutation.

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: #264
- Execution ID: remote-codex-issue264-sp890p
- Goal: open_pr
