### PR TITLE
Fix VPS runner event bot notifications

### DIFF
--- a/scripts/run-vps-runner.mjs
+++ b/scripts/run-vps-runner.mjs
@@ -5,7 +5,11 @@ import os from "node:os";
 import path from "node:path";
 import { spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
-import { normalizeMentionLogin, parseCodexReviewFallbackComment } from "../src/core/index.js";
+import {
+  normalizeMentionLogin,
+  parseCodexReviewFallbackComment,
+  resolveGitHubAppInstallationToken
+} from "../src/core/index.js";
 import { buildExecutionLeadTime } from "../src/core/execution-lead-time.js";
 import { renderPrBody } from "./render-pr-body.mjs";
 import { validatePrBody } from "./validate-pr-body.mjs";
@@ -44,15 +48,27 @@ const MILESTONE_MENTION_EVENTS = new Set([
 async function main() {
   const options = parseArgs(process.argv.slice(2));
   const token = mustGetEnv("GITHUB_TOKEN", process.env.GITHUB_TOKEN || process.env.GH_TOKEN);
+  const apiBaseUrl = process.env.GITHUB_API_URL || DEFAULT_API_BASE_URL;
   const repositoryPolicies = await loadVpsRunnerRepositoryPolicies({ env: process.env });
   const workRoot = process.env.VTDD_VPS_RUNNER_WORKDIR || path.join(os.homedir(), "vtdd-runner", "workspaces");
   const githubFetch = createGitHubFetch({
     token,
-    apiBaseUrl: process.env.GITHUB_API_URL || DEFAULT_API_BASE_URL
+    apiBaseUrl
+  });
+  const eventToken = await resolveVpsRunnerEventGitHubToken({
+    env: process.env,
+    fetchImpl: fetch,
+    apiBaseUrl,
+    fallbackToken: token
+  });
+  const eventGithubFetch = createGitHubFetch({
+    token: eventToken.token,
+    apiBaseUrl
   });
 
   const result = await runVpsRunnerOnce({
     githubFetch,
+    eventGithubFetch,
     token,
     repositoryPolicies,
     workRoot,
@@ -70,6 +86,7 @@ async function main() {
 
 async function runVpsRunnerOnce({
   githubFetch,
+  eventGithubFetch,
   token,
   allowedRepositories,
   repositoryPolicies,
@@ -92,7 +109,13 @@ async function runVpsRunnerOnce({
       };
     }
 
-    return executeVpsRunnerExecution({ githubFetch, token, workRoot, execution });
+    return executeVpsRunnerExecution({
+      githubFetch,
+      eventGithubFetch: eventGithubFetch || githubFetch,
+      token,
+      workRoot,
+      execution
+    });
   }
 
   const reviewerFallbacks = [];
@@ -116,7 +139,7 @@ async function runVpsRunnerOnce({
   return executeVpsReviewerFallback({ token, reviewerFallback });
 }
 
-async function executeVpsRunnerExecution({ githubFetch, token, workRoot, execution }) {
+async function executeVpsRunnerExecution({ githubFetch, eventGithubFetch = githubFetch, token, workRoot, execution }) {
   let payload = { ...execution.payload };
   payload.lifecycle = normalizeVpsRunnerLifecycle({
     ...payload.lifecycle,
@@ -130,7 +153,7 @@ async function executeVpsRunnerExecution({ githubFetch, token, workRoot, executi
     approvalActor: payload?.approvalActor
   });
   await postVpsRunnerEvent({
-    githubFetch,
+    githubFetch: eventGithubFetch,
     payload,
     notification,
     event: {
@@ -142,19 +165,19 @@ async function executeVpsRunnerExecution({ githubFetch, token, workRoot, executi
   });
 
   try {
-    await assertVpsRunnerNotCanceled({ githubFetch, payload, checkpoint: "before_clone", notification });
+    await assertVpsRunnerNotCanceled({ githubFetch, eventGithubFetch, payload, checkpoint: "before_clone", notification });
     const workspace = path.join(workRoot, safePathSegment(payload.repository), payload.executionId);
     await fs.mkdir(path.dirname(workspace), { recursive: true });
     await runCommand("rm", ["-rf", workspace], { env });
-    await assertVpsRunnerNotCanceled({ githubFetch, payload, checkpoint: "before_clone_command", notification });
+    await assertVpsRunnerNotCanceled({ githubFetch, eventGithubFetch, payload, checkpoint: "before_clone_command", notification });
     await runTrackedVpsCommand("gh", ["repo", "clone", payload.repository, workspace], {
       env,
-      githubFetch,
+      githubFetch: eventGithubFetch,
       payload,
       notification,
       currentStep: "gh_repo_clone"
     });
-    await assertVpsRunnerNotCanceled({ githubFetch, payload, checkpoint: "after_clone", notification });
+    await assertVpsRunnerNotCanceled({ githubFetch, eventGithubFetch, payload, checkpoint: "after_clone", notification });
     const branchCheckout = await checkoutVpsRunnerBranch({ payload, cwd: workspace, env });
     payload = {
       ...payload,
@@ -171,7 +194,7 @@ async function executeVpsRunnerExecution({ githubFetch, token, workRoot, executi
     });
 
     await postVpsRunnerEvent({
-      githubFetch,
+      githubFetch: eventGithubFetch,
       payload,
       notification,
       event: {
@@ -185,18 +208,18 @@ async function executeVpsRunnerExecution({ githubFetch, token, workRoot, executi
     });
 
     const prompt = buildCodexExecutionPrompt({ payload, issue, pullRequestContext });
-    await assertVpsRunnerNotCanceled({ githubFetch, payload, checkpoint: "before_codex", notification });
+    await assertVpsRunnerNotCanceled({ githubFetch, eventGithubFetch, payload, checkpoint: "before_codex", notification });
     await runTrackedVpsCommand("codex", buildCodexExecArgs({ env: process.env }), {
       cwd: workspace,
       env: buildCodexExecutionEnv(process.env),
       input: prompt,
       maxBuffer: 1024 * 1024 * 12,
-      githubFetch,
+      githubFetch: eventGithubFetch,
       payload,
       notification,
       currentStep: "codex_subprocess"
     });
-    await assertVpsRunnerNotCanceled({ githubFetch, payload, checkpoint: "after_codex", notification });
+    await assertVpsRunnerNotCanceled({ githubFetch, eventGithubFetch, payload, checkpoint: "after_codex", notification });
 
     const status = await runCommand("git", ["status", "--porcelain"], { cwd: workspace, env });
     const hasWorkingTreeChanges = Boolean(status.stdout.trim());
@@ -208,7 +231,7 @@ async function executeVpsRunnerExecution({ githubFetch, token, workRoot, executi
       });
       await runCommand("git", ["push", "origin", payload.branch], { cwd: workspace, env });
       await postVpsRunnerEvent({
-        githubFetch,
+        githubFetch: eventGithubFetch,
         payload,
         notification,
         event: {
@@ -226,7 +249,7 @@ async function executeVpsRunnerExecution({ githubFetch, token, workRoot, executi
         reason: "Codex completed a PR revision request without producing a commit-ready diff."
       };
       await postVpsRunnerEvent({
-        githubFetch,
+        githubFetch: eventGithubFetch,
         payload,
         notification,
         event: {
@@ -244,10 +267,10 @@ async function executeVpsRunnerExecution({ githubFetch, token, workRoot, executi
       branch: payload.branch,
       env,
       cwd: workspace,
-      githubFetch,
+      githubFetch: eventGithubFetch,
       payload
     });
-    await assertVpsRunnerNotCanceled({ githubFetch, payload, checkpoint: "before_pr", notification });
+    await assertVpsRunnerNotCanceled({ githubFetch, eventGithubFetch, payload, checkpoint: "before_pr", notification });
     pullRequestAuthor = existingPullRequest?.author?.login || pullRequestAuthor;
     let prUrl = existingPullRequest?.url || "";
     if (prUrl) {
@@ -256,7 +279,7 @@ async function executeVpsRunnerExecution({ githubFetch, token, workRoot, executi
         candidateBody: existingPullRequest.body
       });
       if (!normalized.ok) {
-        await postVpsRunnerPrBodyBlockedEvent({ githubFetch, payload, normalized, notification });
+        await postVpsRunnerPrBodyBlockedEvent({ githubFetch: eventGithubFetch, payload, normalized, notification });
         return { ok: false, reason: normalized.reason };
       }
       if (normalized.normalized) {
@@ -268,7 +291,7 @@ async function executeVpsRunnerExecution({ githubFetch, token, workRoot, executi
         await runTrackedVpsCommand("gh", ["pr", "edit", String(existingPullRequest.number || prUrl), "--repo", payload.repository, "--body-file", bodyFile], {
           cwd: workspace,
           env,
-          githubFetch,
+          githubFetch: eventGithubFetch,
           payload,
           notification,
           currentStep: "gh_pr_edit"
@@ -280,7 +303,7 @@ async function executeVpsRunnerExecution({ githubFetch, token, workRoot, executi
         candidateBody: extractCodexPrBodyDraft(payload)
       });
       if (!normalized.ok) {
-        await postVpsRunnerPrBodyBlockedEvent({ githubFetch, payload, normalized, notification });
+        await postVpsRunnerPrBodyBlockedEvent({ githubFetch: eventGithubFetch, payload, normalized, notification });
         return { ok: false, reason: normalized.reason };
       }
       const pr = await runTrackedVpsCommand(
@@ -301,7 +324,7 @@ async function executeVpsRunnerExecution({ githubFetch, token, workRoot, executi
         {
           cwd: workspace,
           env,
-          githubFetch,
+          githubFetch: eventGithubFetch,
           payload,
           notification,
           currentStep: "gh_pr_create"
@@ -319,7 +342,7 @@ async function executeVpsRunnerExecution({ githubFetch, token, workRoot, executi
 
     const completionFinalEvent = buildVpsRunnerCompletionFinalEvent({ payload });
     await postVpsRunnerEvent({
-      githubFetch,
+      githubFetch: eventGithubFetch,
       payload,
       notification: buildVpsRunnerNotificationContext({
         ...notification,
@@ -346,7 +369,7 @@ async function executeVpsRunnerExecution({ githubFetch, token, workRoot, executi
     }
     const rawFailure = classifyVpsRunnerFailure(error);
     await postVpsRunnerEvent({
-      githubFetch,
+      githubFetch: eventGithubFetch,
       payload,
       notification,
       event: {
@@ -864,7 +887,7 @@ async function postVpsRunnerEvent({ githubFetch, payload, event, notification })
     return upsertVpsRunnerStateComment({ githubFetch, payload, event: eventPayload });
   }
 
-  return githubFetch(`/repos/${payload.repository}/issues/${payload.issueNumber}/comments`, {
+  const response = await githubFetch(`/repos/${payload.repository}/issues/${payload.issueNumber}/comments`, {
     method: "POST",
     body: {
       body: buildVpsRunnerEventComment({
@@ -874,15 +897,20 @@ async function postVpsRunnerEvent({ githubFetch, payload, event, notification })
       })
     }
   });
+  return normalizeVpsRunnerEventWriteResult({
+    response,
+    operation: "comment_create",
+    runtimeTruthKind: "vps_runner_event_comment"
+  });
 }
 
-async function assertVpsRunnerNotCanceled({ githubFetch, payload, checkpoint, notification }) {
+async function assertVpsRunnerNotCanceled({ githubFetch, eventGithubFetch = githubFetch, payload, checkpoint, notification }) {
   const cancellation = await readVpsRunnerCancellation({ githubFetch, payload });
   if (!cancellation) {
     return;
   }
   await postVpsRunnerEvent({
-    githubFetch,
+    githubFetch: eventGithubFetch,
     payload,
     notification,
     event: {
@@ -1001,16 +1029,42 @@ async function upsertVpsRunnerStateComment({ githubFetch, payload, event }) {
   });
   const existing = await findVpsRunnerStateComment({ githubFetch, payload });
   if (existing?.id) {
-    return githubFetch(`/repos/${payload.repository}/issues/comments/${existing.id}`, {
+    const response = await githubFetch(`/repos/${payload.repository}/issues/comments/${existing.id}`, {
       method: "PATCH",
       body: { body }
     });
+    return normalizeVpsRunnerEventWriteResult({
+      response,
+      operation: "comment_update",
+      runtimeTruthKind: "vps_runner_state_comment",
+      commentId: existing.id
+    });
   }
 
-  return githubFetch(`/repos/${payload.repository}/issues/${payload.issueNumber}/comments`, {
+  const response = await githubFetch(`/repos/${payload.repository}/issues/${payload.issueNumber}/comments`, {
     method: "POST",
     body: { body }
   });
+  return normalizeVpsRunnerEventWriteResult({
+    response,
+    operation: "comment_create",
+    runtimeTruthKind: "vps_runner_state_comment"
+  });
+}
+
+function normalizeVpsRunnerEventWriteResult({ response, operation, runtimeTruthKind, commentId }) {
+  return {
+    ok: true,
+    operation,
+    runtimeTruthKind,
+    commentId: normalizePositiveInteger(response?.id) || normalizePositiveInteger(commentId),
+    commentUrl: normalizeText(response?.html_url) || null,
+    author: {
+      login: normalizeGitHubActorLogin(response?.user?.login),
+      type: normalizeText(response?.user?.type) || null,
+      association: normalizeText(response?.author_association) || null
+    }
+  };
 }
 
 async function findVpsRunnerStateComment({ githubFetch, payload }) {
@@ -1363,6 +1417,39 @@ async function postVpsRunnerPrBodyBlockedEvent({ githubFetch, payload, normalize
   });
 }
 
+async function resolveVpsRunnerEventGitHubToken({ env = {}, fetchImpl = fetch, apiBaseUrl = DEFAULT_API_BASE_URL, fallbackToken = "" } = {}) {
+  const tokenResolution = await resolveGitHubAppInstallationToken({
+    env,
+    fetchImpl,
+    apiBaseUrl
+  });
+  if (tokenResolution.ok) {
+    return {
+      ok: true,
+      token: tokenResolution.token,
+      source: "github_app_installation"
+    };
+  }
+
+  if (toBoolean(env?.VTDD_VPS_RUNNER_EVENT_TOKEN_ALLOW_FALLBACK)) {
+    const token = normalizeText(fallbackToken);
+    if (token) {
+      return {
+        ok: true,
+        token,
+        source: "explicit_fallback"
+      };
+    }
+  }
+
+  const reason =
+    tokenResolution.warning ||
+    "GitHub App installation token is required for VPS runner operator-facing event comments";
+  throw new Error(
+    `${reason}. Configure GITHUB_APP_INSTALLATION_TOKEN or GITHUB_APP_ID / GITHUB_APP_INSTALLATION_ID / GITHUB_APP_PRIVATE_KEY for bot-authored runner notifications.`
+  );
+}
+
 function createGitHubFetch({ apiBaseUrl, token }) {
   return async function githubFetch(pathname, init = {}) {
     const response = await fetch(`${apiBaseUrl}${pathname}`, {
@@ -1382,6 +1469,11 @@ function createGitHubFetch({ apiBaseUrl, token }) {
     }
     return body;
   };
+}
+
+function toBoolean(value) {
+  const normalized = normalizeText(value).toLowerCase();
+  return normalized === "true" || normalized === "1" || normalized === "yes" || normalized === "on";
 }
 
 function runCommand(command, args, options = {}) {
@@ -1611,6 +1703,14 @@ function normalizeGitHubLogin(value) {
   return login;
 }
 
+function normalizeGitHubActorLogin(value) {
+  const login = normalizeText(value);
+  if (!/^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?(?:\[bot\])?$/.test(login)) {
+    return "";
+  }
+  return login;
+}
+
 function extractBacktickedCommentValue(body, label) {
   const match = String(body || "").match(new RegExp(`- ${escapeRegExp(label)}: \\\`([^\\\`]+)\\\``));
   return normalizeText(match?.[1]);
@@ -1686,6 +1786,7 @@ export {
   parseVpsRunnerEventComment,
   parseVpsRunnerQueueComment,
   postVpsRunnerEvent,
+  resolveVpsRunnerEventGitHubToken,
   runVpsRunnerOnce,
   summarizeDiagnosticText,
   selectPendingVpsReviewerFallbacks,

--- a/test/vps-runner-script.test.js
+++ b/test/vps-runner-script.test.js
@@ -20,6 +20,7 @@ import {
   parseVpsRunnerEventComment,
   parseVpsRunnerQueueComment,
   postVpsRunnerEvent,
+  resolveVpsRunnerEventGitHubToken,
   runVpsRunnerOnce,
   summarizeDiagnosticText,
   selectPendingVpsReviewerFallbacks,
@@ -351,6 +352,59 @@ test("VPS runner notification omits mention when no mentionable actor exists", (
   assert.equal(body.includes("VTDD milestone: failed."), true);
 });
 
+test("VPS runner event token resolves to GitHub App installation token for bot-authored notifications", async () => {
+  const calls = [];
+  const result = await resolveVpsRunnerEventGitHubToken({
+    apiBaseUrl: "https://api.github.test",
+    fallbackToken: "ghp_human_owner_token",
+    env: {
+      GITHUB_APP_ID: "12345",
+      GITHUB_APP_INSTALLATION_ID: "98765",
+      GITHUB_APP_PRIVATE_KEY: "-----BEGIN PRIVATE KEY-----\nplaceholder\n-----END PRIVATE KEY-----",
+      GITHUB_APP_JWT_PROVIDER: async () => "app_jwt_token_for_tests"
+    },
+    fetchImpl: async (url, init) => {
+      calls.push({ url, init });
+      return new Response(
+        JSON.stringify({
+          token: "ghs_vtdd_codex_bot_token",
+          expires_at: "2026-05-11T10:00:00Z"
+        }),
+        { status: 201, headers: { "content-type": "application/json" } }
+      );
+    }
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.source, "github_app_installation");
+  assert.equal(result.token, "ghs_vtdd_codex_bot_token");
+  assert.equal(calls[0].url, "https://api.github.test/app/installations/98765/access_tokens");
+  assert.equal(calls[0].init.headers.authorization, "Bearer app_jwt_token_for_tests");
+});
+
+test("VPS runner event token does not silently fall back to a human token", async () => {
+  await assert.rejects(
+    resolveVpsRunnerEventGitHubToken({
+      fallbackToken: "ghp_human_owner_token",
+      env: {}
+    }),
+    /GitHub App installation token is required/
+  );
+});
+
+test("VPS runner event token supports explicit fallback only when acknowledged", async () => {
+  const result = await resolveVpsRunnerEventGitHubToken({
+    fallbackToken: "ghs_known_bot_token",
+    env: {
+      VTDD_VPS_RUNNER_EVENT_TOKEN_ALLOW_FALLBACK: "true"
+    }
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.source, "explicit_fallback");
+  assert.equal(result.token, "ghs_known_bot_token");
+});
+
 test("VPS runner state comment remains compatible with runner event parsing", () => {
   const body = buildVpsRunnerStateComment({
     executionId: "exec-state-1",
@@ -522,6 +576,136 @@ test("VPS runner milestone events still create new comments", async () => {
   assert.equal(calls[0].url, "/repos/sample-org/vtdd-v2/issues/226/comments");
   assert.equal(calls[0].init.method, "POST");
   assert.equal(calls[0].init.body.body.includes("vtdd:vps-runner-event:exec-branch-1"), true);
+});
+
+test("VPS runner pickup records bot author runtime truth", async () => {
+  const calls = [];
+  const result = await postVpsRunnerEvent({
+    githubFetch: async (url, init = {}) => {
+      calls.push({ url, init });
+      if (String(url).endsWith("/issues/288/comments?per_page=100&page=1")) {
+        return [];
+      }
+      return {
+        id: 28801,
+        html_url: "https://github.com/sample-org/vtdd-v2/issues/288#issuecomment-28801",
+        user: { login: "vtdd-codex[bot]", type: "Bot" },
+        author_association: "NONE"
+      };
+    },
+    payload: {
+      executionId: "exec-pickup-bot-author",
+      repository: "sample-org/vtdd-v2",
+      issueNumber: 288
+    },
+    event: {
+      status: "running",
+      lastEvent: "picked_up",
+      currentStep: "picked_up"
+    }
+  });
+
+  assert.equal(calls[1].url, "/repos/sample-org/vtdd-v2/issues/288/comments");
+  assert.equal(calls[1].init.method, "POST");
+  assert.equal(result.runtimeTruthKind, "vps_runner_state_comment");
+  assert.equal(result.author.login, "vtdd-codex[bot]");
+  assert.equal(result.author.type, "Bot");
+});
+
+test("VPS runner branch recovery and codex heartbeat preserve bot state-comment author truth", async () => {
+  const calls = [];
+  const payload = {
+    executionId: "exec-branch-recovery-bot-author",
+    repository: "sample-org/vtdd-v2",
+    issueNumber: 288
+  };
+  const githubFetch = async (url, init = {}) => {
+    calls.push({ url, init });
+    if (String(url).endsWith("/issues/288/comments?per_page=100&page=1")) {
+      return [
+        {
+          id: 28802,
+          body: buildVpsRunnerStateComment({
+            executionId: payload.executionId,
+            event: {
+              status: "running",
+              lastEvent: "picked_up",
+              currentStep: "picked_up"
+            }
+          }),
+          user: { login: "vtdd-codex[bot]", type: "Bot" }
+        }
+      ];
+    }
+    return {
+      id: 28802,
+      html_url: "https://github.com/sample-org/vtdd-v2/issues/288#issuecomment-28802",
+      user: { login: "vtdd-codex[bot]", type: "Bot" }
+    };
+  };
+
+  const branchResult = await postVpsRunnerEvent({
+    githubFetch,
+    payload,
+    event: {
+      status: "branch_created",
+      lastEvent: "branch_created",
+      currentStep: "branch_created",
+      branchRecovery: {
+        recovered: true,
+        branch: "codex/issue-288-2",
+        originalBranch: "codex/issue-288"
+      }
+    }
+  });
+  const heartbeatResult = await postVpsRunnerEvent({
+    githubFetch,
+    payload,
+    event: {
+      status: "running",
+      lastEvent: "codex_subprocess_heartbeat",
+      currentStep: "codex_subprocess",
+      heartbeatAt: "2026-05-11T10:01:00.000Z",
+      updatedAt: "2026-05-11T10:01:00.000Z"
+    }
+  });
+
+  assert.equal(branchResult.author.login, "vtdd-codex[bot]");
+  assert.equal(heartbeatResult.author.login, "vtdd-codex[bot]");
+  assert.equal(calls.some((call) => call.url === "/repos/sample-org/vtdd-v2/issues/comments/28802" && call.init.method === "PATCH"), true);
+});
+
+test("VPS runner stale, failed, and revision_no_changes comments expose bot author truth", async () => {
+  const events = [
+    { status: "blocked", lastEvent: "stale", rawFailure: { error: "vps_runner_event_stale" } },
+    { status: "failed", lastEvent: "runner_failed", rawFailure: { error: "vps_runner_execution_failed" } },
+    { status: "failed", lastEvent: "revision_no_changes", rawFailure: { error: "codex_revision_no_changes" } }
+  ];
+  for (const [index, event] of events.entries()) {
+    const calls = [];
+    const result = await postVpsRunnerEvent({
+      githubFetch: async (url, init = {}) => {
+        calls.push({ url, init });
+        return {
+          id: 28810 + index,
+          html_url: `https://github.com/sample-org/vtdd-v2/issues/288#issuecomment-${28810 + index}`,
+          user: { login: "vtdd-codex[bot]", type: "Bot" }
+        };
+      },
+      payload: {
+        executionId: `exec-terminal-bot-author-${index}`,
+        repository: "sample-org/vtdd-v2",
+        issueNumber: 288
+      },
+      event
+    });
+
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].init.method, "POST");
+    assert.equal(result.runtimeTruthKind, "vps_runner_event_comment");
+    assert.equal(result.author.login, "vtdd-codex[bot]");
+    assert.equal(result.author.type, "Bot");
+  }
 });
 
 test("VPS runner lead time keeps pr_created_at distinct from completed_at", async () => {


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #288 maps VPS runner operator-facing event comments to GitHub App installation-token writes so runner notifications are bot-authored instead of owner self-comments.

## Satisfied Success Criteria

- VPS runner event writes resolve a GitHub App installation token before posting operator-facing event comments.
- runner pickup returns bot author runtime truth from the created state comment.
- branch recovery, codex heartbeat, stale, runner_failed, and revision_no_changes event writes return comment author runtime truth for bot verification.
- Implicit fallback to the human runner token is blocked unless explicitly acknowledged.

## Unsatisfied Success Criteria

- Live iPhone / Apple Watch notification delivery is not verified in this PR because deploy/VPS rollout is out of scope.
- owner self-comment notification disappearance is verified at unit/runtime-truth boundary only, not against a live GitHub notification device.

## Non-goal violations

None.

## Verification Evidence

- Unit: node --test test/vps-runner-script.test.js (45 pass); node --test test/github-app-repository-index.test.js test/github-write-plane.test.js (16 pass)
- Integration: GitHub App token resolution and write-plane regression tests passed locally.
- E2E: Not run; live device notification requires post-merge VPS runner rollout and is out of scope for this PR.
- Manual: Inspected Issue #288 and PR body contract docs/pr-template-model.md, scripts/render-pr-body.mjs, scripts/validate-pr-body.mjs before drafting.
- Evidence path/link: test/vps-runner-script.test.js

## Surface Update Checklist

- Cloudflare deploy: Not required; VPS runner script change only.
- Custom GPT Action Schema update: Not required.
- Custom GPT Instructions update: Not required.
- iPhone Butler live E2E: Required after runner rollout; not run in this PR.

## Related Constitution Rules

- Issue #288 canonical spec controls scope.
- Do not merge or deploy.
- Operator-facing events must avoid owner self-comment notification drift.
- Runtime truth evidence is required for completion claims.

## Out-of-scope but NOT implemented

- Cloudflare/App Server deployment.
- Secret, permission, repository setting, or infrastructure mutation.
- Live iPhone / Apple Watch notification verification.
- Closing Issue #288.

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: #288
- Execution ID: remote-codex-issue288-kbygt9
- Goal: open_pr
