### PR TITLE
fix: lock revise_pr routing to target PR

### DIFF
--- a/scripts/run-vps-runner.mjs
+++ b/scripts/run-vps-runner.mjs
@@ -553,12 +553,36 @@ function parseVpsRunnerQueueComment(body) {
   if (!normalized.approvalScopeMatched) {
     issues.push("approvalScopeMatched must be true");
   }
+  if (isPrRevisionGoal(normalized.codexGoal)) {
+    issues.push(...validateQueuedRevisionTarget(normalized));
+  }
 
   if (issues.length > 0) {
     return { ok: false, reason: "vps_runner_payload_invalid", executionId: marker[1], issues };
   }
 
   return { ok: true, executionId: normalized.executionId, payload: normalized };
+}
+
+function validateQueuedRevisionTarget(payload) {
+  const issues = [];
+  const target = payload.revisionTarget || {};
+  if (!target.number) {
+    issues.push("revise_pr requires target PR number");
+  }
+  if (target.state !== "open") {
+    issues.push("revise_pr target PR must be open");
+  }
+  if (!target.headRef) {
+    issues.push("revise_pr requires target PR headRef");
+  }
+  if (!target.headSha) {
+    issues.push("revise_pr requires target PR headSha");
+  }
+  if (target.headRef && payload.branch !== target.headRef) {
+    issues.push("revise_pr branch must match target PR headRef");
+  }
+  return issues;
 }
 
 function parseVpsRunnerEventComment(body) {
@@ -1237,6 +1261,10 @@ async function runTrackedVpsCommand(command, args, options = {}) {
 
 async function checkoutVpsRunnerBranch({ payload, cwd, env, run = runCommand }) {
   if (isPrRevisionGoal(payload.codexGoal)) {
+    const revisionTargetIssues = validateQueuedRevisionTarget(payload);
+    if (revisionTargetIssues.length > 0) {
+      throw new Error(`Invalid revise_pr target lock: ${revisionTargetIssues.join("; ")}`);
+    }
     await run("git", ["fetch", "origin", payload.branch], { cwd, env });
     await run("git", ["checkout", "-B", payload.branch, `origin/${payload.branch}`], { cwd, env });
     return {

--- a/src/core/remote-codex-executor.js
+++ b/src/core/remote-codex-executor.js
@@ -114,6 +114,10 @@ export function createRemoteCodexExecutionRequest(input = {}) {
     executionTarget: normalizeObject(payload?.executionTarget),
     handoff
   });
+  const revisionTargetConflicts = collectRevisionTargetConflicts({
+    executionTarget: normalizeObject(payload?.executionTarget),
+    handoff
+  });
   const request = {
     executionId: normalizeText(input?.executionId) || buildExecutionId({ issueNumber }),
     actorRole: normalizeText(payload.actorRole),
@@ -185,6 +189,7 @@ export function createRemoteCodexExecutionRequest(input = {}) {
   }
   if (request.codexGoal === RemoteCodexDispatchGoal.REVISE_PR) {
     issues.push(...validateRevisionTarget(request));
+    issues.push(...revisionTargetConflicts);
   }
 
   return issues.length > 0 ? { ok: false, issues } : { ok: true, request };
@@ -263,6 +268,66 @@ function normalizeRevisionTarget({ runtimeState, executionTarget, handoff }) {
       normalizeText(pullRequest.headSha) ||
       normalizeText(pullRequest.head?.sha) ||
       null
+  };
+}
+
+function collectRevisionTargetConflicts({ executionTarget, handoff }) {
+  const sources = [
+    normalizeRevisionTargetSource("executionTarget", {
+      number: executionTarget.prNumber ?? executionTarget.pullRequestNumber,
+      state: executionTarget.prState,
+      headRef: executionTarget.headRef,
+      headSha: executionTarget.headSha,
+      pullRequest: executionTarget.pullRequest
+    }),
+    normalizeRevisionTargetSource("handoff", {
+      number: handoff.prNumber ?? handoff.pullRequestNumber,
+      state: handoff.prState,
+      headRef: handoff.headRef,
+      headSha: handoff.headSha,
+      pullRequest: handoff.targetPullRequest ?? handoff.pullRequest ?? handoff.pr
+    })
+  ].filter((source) => source.present);
+
+  const issues = [];
+  for (let index = 0; index < sources.length; index += 1) {
+    for (let nextIndex = index + 1; nextIndex < sources.length; nextIndex += 1) {
+      const left = sources[index];
+      const right = sources[nextIndex];
+      for (const field of ["number", "state", "headRef", "headSha"]) {
+        if (left[field] && right[field] && left[field] !== right[field]) {
+          issues.push(
+            `revise_pr target ${field} mismatch between ${left.source} and ${right.source}`
+          );
+        }
+      }
+    }
+  }
+
+  return issues;
+}
+
+function normalizeRevisionTargetSource(source, value = {}) {
+  const input = value && typeof value === "object" ? value : {};
+  const pullRequest = normalizeObject(input.pullRequest);
+  const target = {
+    source,
+    number: normalizePositiveInteger(input.number ?? pullRequest.number),
+    state: normalizeText(input.state ?? pullRequest.state).toLowerCase() || null,
+    headRef:
+      normalizeText(input.headRef) ||
+      normalizeText(pullRequest.headRef) ||
+      normalizeText(pullRequest.head?.ref) ||
+      null,
+    headSha:
+      normalizeText(input.headSha) ||
+      normalizeText(pullRequest.headSha) ||
+      normalizeText(pullRequest.head?.sha) ||
+      null
+  };
+  return {
+    ...target,
+    present: Boolean(target.number || target.state || target.headRef || target.headSha)
   };
 }
 

--- a/test/remote-codex-executor.test.js
+++ b/test/remote-codex-executor.test.js
@@ -190,6 +190,61 @@ test("remote Codex execution request pins revise_pr branch to target PR headRef"
   assert.equal(result.request.revisionTarget.number, 285);
 });
 
+test("remote Codex execution request blocks conflicting revise_pr target locks", () => {
+  const result = createRemoteCodexExecutionRequest({
+    payload: {
+      actorRole: ActorRole.BUTLER,
+      issueContext: { issueNumber: 251 },
+      executionTarget: {
+        prNumber: 279,
+        prState: "closed",
+        headRef: "codex/issue-251",
+        headSha: "old-sha"
+      },
+      continuationContext: {
+        codexGoal: RemoteCodexDispatchGoal.REVISE_PR,
+        handoff: {
+          issueTraceable: true,
+          approvalScopeMatched: true,
+          relatedIssue: 251,
+          summary: "Revise fresh replacement PR only",
+          targetPullRequest: {
+            number: 285,
+            state: "open",
+            headRef: "codex/issue-251-v2",
+            headSha: "fresh-sha"
+          }
+        }
+      },
+      policyInput: {
+        approvalPhrase: "GO",
+        targetConfirmed: true,
+        approvalScopeMatched: true
+      }
+    },
+    gatewayResult: {
+      repository: "sample-org/vtdd-v2",
+      executionContinuity: {
+        codexGoal: "wait_for_review"
+      }
+    }
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(
+    result.issues.includes("revise_pr target number mismatch between executionTarget and handoff"),
+    true
+  );
+  assert.equal(
+    result.issues.includes("revise_pr target headRef mismatch between executionTarget and handoff"),
+    true
+  );
+  assert.equal(
+    result.issues.includes("revise_pr target headSha mismatch between executionTarget and handoff"),
+    true
+  );
+});
+
 test("remote Codex execution request rejects wait-only continuity goal before workflow dispatch", () => {
   const result = createRemoteCodexExecutionRequest({
     payload: {

--- a/test/vps-runner-script.test.js
+++ b/test/vps-runner-script.test.js
@@ -68,6 +68,80 @@ test("VPS runner rejects queue comments without scoped approval", () => {
   assert.equal(parsed.issues.includes("approvalScopeMatched must be true"), true);
 });
 
+test("VPS runner rejects revise_pr queue payload without open target PR lock", () => {
+  const parsed = parseVpsRunnerQueueComment(`<!-- vtdd:vps-runner-execution:remote-codex-issue251-vps -->
+\`\`\`json
+{
+  "executionId": "remote-codex-issue251-vps",
+  "transport": "vps_runner",
+  "repository": "sample-org/vtdd-v2",
+  "issueNumber": 251,
+  "branch": "codex/issue-251",
+  "baseRef": "main",
+  "codexGoal": "revise_pr",
+  "approvalScopeMatched": true,
+  "revisionTarget": {
+    "number": 279,
+    "state": "closed",
+    "headRef": "codex/issue-251",
+    "headSha": "old-sha"
+  }
+}
+\`\`\``);
+
+  assert.equal(parsed.ok, false);
+  assert.equal(parsed.reason, "vps_runner_payload_invalid");
+  assert.equal(parsed.issues.includes("revise_pr target PR must be open"), true);
+});
+
+test("VPS runner rejects revise_pr queue payload when branch differs from target PR headRef", () => {
+  const parsed = parseVpsRunnerQueueComment(`<!-- vtdd:vps-runner-execution:remote-codex-issue251-vps -->
+\`\`\`json
+{
+  "executionId": "remote-codex-issue251-vps",
+  "transport": "vps_runner",
+  "repository": "sample-org/vtdd-v2",
+  "issueNumber": 251,
+  "branch": "codex/issue-251",
+  "baseRef": "main",
+  "codexGoal": "revise_pr",
+  "approvalScopeMatched": true,
+  "revisionTarget": {
+    "number": 285,
+    "state": "open",
+    "headRef": "codex/issue-251-v2",
+    "headSha": "fresh-sha"
+  }
+}
+\`\`\``);
+
+  assert.equal(parsed.ok, false);
+  assert.equal(parsed.reason, "vps_runner_payload_invalid");
+  assert.equal(parsed.issues.includes("revise_pr branch must match target PR headRef"), true);
+});
+
+test("VPS runner checkout blocks revise_pr when target lock is incomplete", async () => {
+  await assert.rejects(
+    checkoutVpsRunnerBranch({
+      payload: {
+        codexGoal: "revise_pr",
+        branch: "codex/issue-251",
+        revisionTarget: {
+          number: 285,
+          state: "open",
+          headRef: "codex/issue-251-v2"
+        }
+      },
+      cwd: "/tmp/vtdd-test",
+      env: {},
+      run: async () => {
+        throw new Error("git must not run for invalid revision target");
+      }
+    }),
+    /Invalid revise_pr target lock: revise_pr requires target PR headSha; revise_pr branch must match target PR headRef/
+  );
+});
+
 test("VPS runner selects only allowlisted pending queues", () => {
   const comments = [
     {

--- a/worker.js
+++ b/worker.js
@@ -25265,6 +25265,10 @@ function createRemoteCodexExecutionRequest(input = {}) {
     executionTarget: normalizeObject8(payload?.executionTarget),
     handoff
   });
+  const revisionTargetConflicts = collectRevisionTargetConflicts({
+    executionTarget: normalizeObject8(payload?.executionTarget),
+    handoff
+  });
   const request = {
     executionId: normalizeText17(input?.executionId) || buildExecutionId({ issueNumber }),
     actorRole: normalizeText17(payload.actorRole),
@@ -25322,6 +25326,7 @@ function createRemoteCodexExecutionRequest(input = {}) {
   }
   if (request.codexGoal === RemoteCodexDispatchGoal.REVISE_PR) {
     issues.push(...validateRevisionTarget(request));
+    issues.push(...revisionTargetConflicts);
   }
   return issues.length > 0 ? { ok: false, issues } : { ok: true, request };
 }
@@ -25361,6 +25366,54 @@ function normalizeRevisionTarget({ runtimeState, executionTarget, handoff }) {
     ).toLowerCase() || null,
     headRef: normalizeText17(executionTarget.headRef) || normalizeText17(executionTargetPull.headRef) || normalizeText17(executionTargetPull.head?.ref) || normalizeText17(handoff.headRef) || normalizeText17(handoffTarget.headRef) || normalizeText17(handoffTarget.head?.ref) || normalizeText17(pullRequest.headRef) || normalizeText17(pullRequest.head?.ref) || null,
     headSha: normalizeText17(executionTarget.headSha) || normalizeText17(executionTargetPull.headSha) || normalizeText17(executionTargetPull.head?.sha) || normalizeText17(handoff.headSha) || normalizeText17(handoffTarget.headSha) || normalizeText17(handoffTarget.head?.sha) || normalizeText17(pullRequest.headSha) || normalizeText17(pullRequest.head?.sha) || null
+  };
+}
+function collectRevisionTargetConflicts({ executionTarget, handoff }) {
+  const sources = [
+    normalizeRevisionTargetSource("executionTarget", {
+      number: executionTarget.prNumber ?? executionTarget.pullRequestNumber,
+      state: executionTarget.prState,
+      headRef: executionTarget.headRef,
+      headSha: executionTarget.headSha,
+      pullRequest: executionTarget.pullRequest
+    }),
+    normalizeRevisionTargetSource("handoff", {
+      number: handoff.prNumber ?? handoff.pullRequestNumber,
+      state: handoff.prState,
+      headRef: handoff.headRef,
+      headSha: handoff.headSha,
+      pullRequest: handoff.targetPullRequest ?? handoff.pullRequest ?? handoff.pr
+    })
+  ].filter((source) => source.present);
+  const issues = [];
+  for (let index = 0; index < sources.length; index += 1) {
+    for (let nextIndex = index + 1; nextIndex < sources.length; nextIndex += 1) {
+      const left = sources[index];
+      const right = sources[nextIndex];
+      for (const field of ["number", "state", "headRef", "headSha"]) {
+        if (left[field] && right[field] && left[field] !== right[field]) {
+          issues.push(
+            `revise_pr target ${field} mismatch between ${left.source} and ${right.source}`
+          );
+        }
+      }
+    }
+  }
+  return issues;
+}
+function normalizeRevisionTargetSource(source, value = {}) {
+  const input = value && typeof value === "object" ? value : {};
+  const pullRequest = normalizeObject8(input.pullRequest);
+  const target = {
+    source,
+    number: normalizePositiveInteger3(input.number ?? pullRequest.number),
+    state: normalizeText17(input.state ?? pullRequest.state).toLowerCase() || null,
+    headRef: normalizeText17(input.headRef) || normalizeText17(pullRequest.headRef) || normalizeText17(pullRequest.head?.ref) || null,
+    headSha: normalizeText17(input.headSha) || normalizeText17(pullRequest.headSha) || normalizeText17(pullRequest.head?.sha) || null
+  };
+  return {
+    ...target,
+    present: Boolean(target.number || target.state || target.headRef || target.headSha)
   };
 }
 async function dispatchRemoteCodexExecution(input = {}) {


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #287: revise_pr execution is now locked to the intended open PR target and stale/conflicting target locks are blocked before dispatch or VPS runner checkout.

## Satisfied Success Criteria

- revise_pr requires an open target PR lock before VPS runner queue acceptance.
- closed PR branch revise payloads are rejected by VPS runner parsing and checkout guards.
- PR number, headRef, headSha, and state are preserved in remote Codex routing and checked for source conflicts.
- stale branch ambiguity remains exposed in runtime truth and branch attribution mismatch remains surfaced by Butler tests.
- wrong-branch revise payloads are rejected when branch differs from target PR headRef.

## Unsatisfied Success Criteria

None.

## Non-goal violations

None.

## Verification Evidence

- Unit: node --test test/remote-codex-executor.test.js; node --test test/vps-runner-script.test.js; node --test test/butler-review-synthesis.test.js; node --test
- Integration: npm run check:self-parity
- E2E: Not run live; issue is covered by unit/integration regression tests for stale/closed PR routing guards.
- Manual: GitHub Issue #287 body inspected with gh issue view; PR template contract inspected before body draft.
- Evidence path/link: local test output in this execution; changed tests in test/remote-codex-executor.test.js and test/vps-runner-script.test.js

## Surface Update Checklist

- Cloudflare deploy: Not required.
- Custom GPT Action Schema update: Not required.
- Custom GPT Instructions update: Not required.
- iPhone Butler live E2E: Not required.

## Related Constitution Rules

- Do not merge.
- Do not deploy.
- Do not mutate secrets, permissions, repository settings, or external infrastructure.
- Use the GitHub Issue as canonical spec.
- Do not close Issues automatically.

## Out-of-scope but NOT implemented

- No merge or Issue closure.
- No deploy or external infrastructure mutation.
- No Issue #251/#284 behavior work beyond routing guard regression coverage.
- No archived setup wizard changes.

## Extra changes (if any)

Generated worker.js was rebuilt from src/core/remote-codex-executor.js.

<!-- VTDD metadata -->
- Issue: #287
- Execution ID: Not provided.
- Goal: open_pr
