### PR TITLE
Separate reviewer marker truth from formal reviews

### DIFF
--- a/docs/butler/gemini-pr-review-comments.md
+++ b/docs/butler/gemini-pr-review-comments.md
@@ -116,6 +116,17 @@ marker comment URL. If GitHub displays the original comment timestamp, Butler
 must explain that the marker comment was updated and the current body is the
 latest reviewer evidence.
 
+The VTDD reviewer marker comment is the canonical VTDD reviewer signal for
+Butler synthesis. It must not be confused with GitHub formal Pull Request
+Review API objects or GitHub `reviewDecision` state. If a marker recommends
+`approve` but no GitHub formal approval exists, Butler may report the marker
+as reviewer evidence, but must not say the GitHub review decision is approved.
+
+GitHub formal review objects remain separate runtime truth. A formal
+`CHANGES_REQUESTED` / `changes_requested` state is blocking even when the VTDD
+reviewer marker recommends `approve`, and Butler must route the PR back to
+bounded revision instead of merge judgment.
+
 When Gemini becomes available again after a fallback request, VTDD should
 return to Gemini-first behavior and clear the stale Codex fallback request
 state.

--- a/docs/setup/custom-gpt-instructions-short-min.md
+++ b/docs/setup/custom-gpt-instructions-short-min.md
@@ -6,7 +6,7 @@ Role:
 
 Truth and scope:
 - Issue is canonical spec. GitHub/runtime state is progress truth. Runtime truth > memory.
-- Before proposal, writes, Codex handoff, PR judgment, merge/deploy/close advice, or stale setup claims: retrieve runtime truth/GitHub state; use memory/constitution retrieval when useful. Report found/missing. Never invent.
+- Before proposal, writes, Codex handoff, PR judgment, merge/deploy/close advice, or stale setup claims: retrieve runtime/GitHub truth; use memory/constitution when useful. Report found/missing. Never invent.
 - No scope beyond user instruction + active Issue; do not reinterpret "MVP".
 - Do not assume a default repository. Resolve owner/repo from explicit input, alias, grant, or verified context; if ambiguous, ask one short confirmation.
 - No internal API paths/raw JSON for users. Convert natural intent into actions.
@@ -17,7 +17,7 @@ Repository and nickname:
 - Use vtddRetrieveGitHub for repos, issues, PRs, reviews, comments, checks, runs, branches.
 - Save/delete/list nicknames: vtddUpsertRepositoryNickname, vtddDeleteRepositoryNickname, vtddRetrieveRepositoryNicknames.
 - If request starts with a non-owner/repo token like `ぶい の...`, resolve nickname first.
-- Nickname memory is user-owned alias data, not default repo. Save owner/repo, not alias. Delete with owner/repo + exact nickname; confirm afterward. Do not use empty replace as delete.
+- Nickname memory is user-owned alias data, not default repo. Save owner/repo, not alias. Delete owner/repo + exact nickname; never empty replace.
 - Nickname read failure is not proof of unknown repo. If context or approvalGrant.scope.repositoryInput has owner/repo, use as unverified fallback and verify.
 - Unsupported read => 未対応. Auth fail => 認証失敗. Do not infer absence from failed, unsupported, unauthorized, or unverified reads.
 
@@ -45,7 +45,7 @@ Execution and remote Codex handoff:
 - Executor transport is pluggable and user-owned; vtdd-v2-p public core does not host a shared runner.
 - Default handoff here: executorTransport=vps_runner. Do not add a separate GPT Action for VPS handoff.
 - codex_cloud_github_comment is legacy fallback; codex_cloud_cli_control_runner is user-owned. API runner uses api_key_runner + acknowledgment + OPENAI_API_KEY; surface openai_api_key_not_configured; never request secrets in chat.
-- After vtddExecute, call vtddExecutionProgress; report progress.leadTime durations when present. For control/vps/api_key include executorTransport. For vps_runner status, call vtddVpsRunnerStatus and report runnerStatus, queue.pickedUp, leadTime, currentStep, reason. For VPS cancel/drain, vtddVpsRunnerCancel mode=execution/issue_pending/drain_pending; marker only, no delete.
+- After vtddExecute, call vtddExecutionProgress; report leadTime. For control/vps/api_key include executorTransport. For vps_runner status, call vtddVpsRunnerStatus. VPS cancel/drain: vtddVpsRunnerCancel marker only, no delete.
 - Do not claim PR creation complete unless GitHub runtime truth shows the PR.
 
 GitHub write:
@@ -66,7 +66,7 @@ High-risk authority:
 
 Deploy:
 - Use vtddDeployProduction only after deploy ask + GO + real passkey grant.
-- If no deploy grant, show selfParity.deployOperatorMarkdownLink or `[Open deploy operator](<actual selfParity.deployOperatorUrl>)`; never raw `/v2/approval/passkey/operator...`/bare URL.
+- If no deploy grant, show selfParity.deployOperatorMarkdownLink or `[Open deploy operator](<actual selfParity.deployOperatorUrl>)`; no raw operator path/bare URL.
 - Stale fallback: selfParity.deployRecovery.operatorMarkdownLink or operatorUrl; href needs phase=execution.
 - After deploy dispatch, re-check self-parity. If deploy fails, say exact deploy error/reason/issues.
 - If api_key_runner hits openai_api_key_not_configured, use vtddSyncGitHubActionsSecret secret-sync operator; never ask for OPENAI_API_KEY in chat.
@@ -75,6 +75,7 @@ Review loop:
 - Canonical loop: Butler -> Codex -> PR -> Reviewer -> Butler summary -> human.
 - For a PR, summarize state, CI, reviewers, objections, and changes.
 - Preserve reviewer objections. If objections remain, do not recommend merge GO+passkey.
+- Review truth: marker approve != GitHub approval; formal CHANGES_REQUESTED blocks; show reviewerSignalTruth warnings.
 - Gemini evidence: show marker URL + current action; note if marker timestamp looks stale.
 - `vtdd:reviewer=codex-fallback` with comment/@codex review is request-only.
 - Completed fallback from trusted VTDD actor/Codex Cloud result with recommendedAction is evidence; missing GitHub Review objects alone is not absence.

--- a/docs/setup/custom-gpt-instructions-short.md
+++ b/docs/setup/custom-gpt-instructions-short.md
@@ -2,7 +2,7 @@ VTDD Butler. Japanese unless asked otherwise.
 
 Core:
 - Issue is canonical spec.
-- Before proposal/write/Codex handoff/PR judgment: vtddRetrieveCrossMemory + vtddRetrieveDecisionLogs/vtddRetrieveProposalLogs/vtddRetrieveConstitution + runtime truth. Report found/missing; no RAG hit OK, never invent. Runtime truth > memory.
+- Before proposal/write/Codex handoff/PR judgment: vtddRetrieveCrossMemory + vtddRetrieveDecisionLogs/vtddRetrieveProposalLogs/vtddRetrieveConstitution + runtime truth; no RAG hit OK, never invent. Runtime truth > memory.
 - Do not assume a default repository. Resolve repo from alias/context; if ambiguous, ask.
 - Natural language to actions; no internal paths/raw JSON.
 - No scope beyond Issue/user instruction.
@@ -63,14 +63,14 @@ GitHub high-risk authority plane:
   - pull_merge
   - issue_close
 - Confirm approval grant, repo scope, and explicit request.
-- Draft PR before merge: pull_ready_for_review. No grant: show `[Open ready operator](<absolute operator URL>)` with repo/phase/issueNumber/pullNumber/actionType/highRiskKind.
-- For pull_merge no grant, show `[Open merge operator](<absolute operator URL>)` with repo/phase/issueNumber/pullNumber/actionType/highRiskKind; no bare URL.
+- Draft PR before merge: pull_ready_for_review. No grant: show ready operator with repo/phase/issueNumber/pullNumber/actionType/highRiskKind.
+- For pull_merge no grant, show merge operator with repo/phase/issueNumber/pullNumber/actionType/highRiskKind; no bare URL.
 - Operator may approve+dispatch PR merge; re-read runtime truth before saying merged.
 - For issue_close, include issueNumber + merged PR pullNumber; no grant: show same-origin operator link.
 - Do not route deploy or other destructive provider actions through vtddGitHubAuthority.
 
 Deploy plane:
-- vtddDeployProduction after deploy ask; requires resolved repo, explicit GO, real passkey grant scoped deploy_production. Pasted approvalGrant.scope.repositoryInput can identify deploy target.
+- vtddDeployProduction after deploy ask; requires resolved repo, explicit GO, real passkey grant scoped deploy_production. approvalGrant.scope.repositoryInput can identify target.
 - If no deploy grant, show selfParity.deployOperatorMarkdownLink or `[Open deploy operator](<actual selfParity.deployOperatorUrl>)`; never raw `/v2/approval/passkey/operator...` or bare URL.
 - Stale fallback: selfParity.deployRecovery.operatorMarkdownLink or operatorUrl. Href needs phase=execution.
 - If deploy URL requested while in_sync, show deployOperatorUrl/link.
@@ -91,7 +91,8 @@ Progress tracking:
 Review loop:
 - Canonical loop: Butler -> Codex -> PR -> Reviewer -> Butler summary -> human.
 - For a PR, summarize state, CI, reviewers, objections, changes.
-- If reviewer objections remain, do not recommend merge GO+passkey.
+- If objections remain, do not recommend merge GO+passkey.
+- Review truth: marker approve != GitHub approval; formal CHANGES_REQUESTED blocks; show reviewerSignalTruth warnings.
 - Gemini evidence: show marker URL + current action; note updated marker if timestamp looks old.
 - Requested `vtdd:reviewer=codex-fallback` with codex_cloud_github_comment/@codex review is request-only.
 - Completed `vtdd:reviewer=codex-fallback` from trusted VTDD actor/Codex Cloud result with recommendedAction is evidence; missing GitHub Review objects alone is not absence.

--- a/docs/setup/custom-gpt-instructions.md
+++ b/docs/setup/custom-gpt-instructions.md
@@ -200,6 +200,12 @@ Butler self-parity and setup artifact recovery:
 
 Execution judgment:
 - Before execution, read current runtime truth through vtddGateway using read/summarize intent; do not ask vtddGateway to execute `build`.
+- Before PR merge judgment, distinguish reviewer signal truth:
+  - VTDD reviewer marker comments such as `vtdd:reviewer=gemini` / `vtdd:reviewer=codex-fallback` are the canonical VTDD reviewer recommendation when they include `Recommended action`.
+  - GitHub formal Pull Request Review API objects and `reviewDecision` are separate runtime truth.
+  - Do not report GitHub reviewDecision as approved merely because the VTDD reviewer marker recommends `approve`.
+  - A GitHub formal `CHANGES_REQUESTED` / `changes_requested` state remains blocking even if a VTDD reviewer marker recommends `approve`.
+  - Use `reviewLoop.reviewerSignalTruth` / `butlerReviewSynthesis.reviewerSignal.reviewerSignalTruth` when present, and surface its warnings in Japanese before any merge GO discussion.
 - If execution is blocked with `runtime_truth_required_or_safe_fallback`, do not ask the user for another instruction. Read the missing runtime truth yourself through vtddRetrieveGitHub (open PRs, branches, checks, workflow_runs as relevant), rebuild the execution payload with `runtimeTruth.runtimeAvailable=true`, and retry the same bounded handoff once. If that read fails, surface the raw failure.
 - If runtime truth shows no open PR for the active Issue, do not treat that as a dead end. Read the parent Issue when the active Issue names one, then propose the next smallest live E2E slice and the exact next validation payload the human can approve from the normal iPhone Butler conversation.
 - The Action Schema must expose `build` only under `vtddExecute`, not under `vtddGateway`; if `build` appears under vtddGateway, the Action Schema is stale and must be updated before handoff testing.

--- a/src/core/butler-review-synthesis.js
+++ b/src/core/butler-review-synthesis.js
@@ -36,6 +36,7 @@ export function buildButlerReviewSynthesis(input = {}) {
       reviewer: reviewLoop.reviewer,
       reviewerStatus: reviewLoop.reviewerStatus,
       reviewerEvidence: reviewLoop.reviewerEvidence,
+      reviewerSignalTruth: reviewLoop.reviewerSignalTruth,
       reviewCommentsCount: reviewLoop.reviewCommentsCount,
       unresolvedReviewCommentsCount: reviewLoop.unresolvedReviewCommentsCount,
       criticalReviewPending: reviewLoop.criticalReviewPending,
@@ -135,6 +136,15 @@ function buildHumanDecisionFocus({ pullRequest, reviewLoop, codexGoal, branchAtt
     const action = reviewLoop.reviewerEvidence.recommendedAction;
     const url = reviewLoop.reviewerEvidence.url ? ` ${reviewLoop.reviewerEvidence.url}` : "";
     focus.push(`Latest ${reviewLoop.reviewer} reviewer action is ${action}.${url}`);
+  }
+  for (const warning of reviewLoop.reviewerSignalTruth?.warnings ?? []) {
+    focus.push(warning);
+  }
+  if (reviewLoop.reviewerSignalTruth?.githubFormalReview) {
+    const formal = reviewLoop.reviewerSignalTruth.githubFormalReview;
+    focus.push(
+      `GitHub formal review truth: reviewDecision=${formal.reviewDecision || "none"}, approvals=${formal.approvalCount}, blocking=${formal.blocking === true}.`
+    );
   }
   if (reviewLoop.reviewer === "gemini" && reviewLoop.reviewerEvidence?.includesCreatedEdit) {
     focus.push(
@@ -238,9 +248,45 @@ function normalizeReviewLoop(value) {
     reviewer: normalizeText(input.reviewer) || "gemini",
     reviewerStatus: normalizeText(input.reviewerStatus) || "review_unavailable",
     reviewerEvidence: normalizeReviewerEvidence(input.reviewerEvidence),
+    reviewerSignalTruth: normalizeReviewerSignalTruth(input.reviewerSignalTruth),
     reviewCommentsCount: normalizeCount(input.reviewCommentsCount),
     unresolvedReviewCommentsCount: normalizeCount(input.unresolvedReviewCommentsCount),
     criticalReviewPending: input.criticalReviewPending === true
+  };
+}
+
+function normalizeReviewerSignalTruth(value) {
+  const input = value && typeof value === "object" ? value : {};
+  if (!normalizeText(input.canonicalSource) && !input.githubFormalReview) {
+    return null;
+  }
+  const formal = input.githubFormalReview && typeof input.githubFormalReview === "object"
+    ? input.githubFormalReview
+    : {};
+  const mergeReviewTruth = input.mergeReviewTruth && typeof input.mergeReviewTruth === "object"
+    ? input.mergeReviewTruth
+    : {};
+  return {
+    canonicalSource: normalizeText(input.canonicalSource) || "none",
+    canonicalReviewer: normalizeText(input.canonicalReviewer) || null,
+    reviewerStatus: normalizeText(input.reviewerStatus) || null,
+    recommendedAction: normalizeText(input.recommendedAction) || null,
+    vtddReviewerMarkerPresent: input.vtddReviewerMarkerPresent === true,
+    githubFormalReview: {
+      source: normalizeText(formal.source) || "github_formal_review_objects",
+      reviewDecision: normalizeText(formal.reviewDecision) || null,
+      hasFormalApproval: formal.hasFormalApproval === true,
+      approvalCount: normalizeCount(formal.approvalCount),
+      blocking: formal.blocking === true,
+      blockingReason: normalizeText(formal.blockingReason) || null,
+      latestStates: Array.isArray(formal.latestStates) ? formal.latestStates.map(normalizeText).filter(Boolean) : []
+    },
+    mergeReviewTruth: {
+      satisfied: mergeReviewTruth.satisfied === true,
+      blocked: mergeReviewTruth.blocked === true,
+      reason: normalizeText(mergeReviewTruth.reason) || null
+    },
+    warnings: normalizeStringArray(input.warnings)
   };
 }
 

--- a/src/core/execution-continuity.js
+++ b/src/core/execution-continuity.js
@@ -66,6 +66,7 @@ export function evaluateExecutionContinuity(input = {}) {
         reviewer: review.reviewer,
         reviewerStatus: review.reviewerStatus,
         reviewerEvidence: review.reviewerEvidence,
+        reviewerSignalTruth: review.reviewerSignalTruth,
         reviewCommentsCount: review.reviewCommentsCount,
         unresolvedReviewCommentsCount: review.unresolvedReviewCommentsCount,
         criticalReviewPending: review.criticalReviewPending,
@@ -83,6 +84,7 @@ export function evaluateExecutionContinuity(input = {}) {
           reviewer: review.reviewer,
           reviewerStatus: review.reviewerStatus,
           reviewerEvidence: review.reviewerEvidence,
+          reviewerSignalTruth: review.reviewerSignalTruth,
           reviewCommentsCount: review.reviewCommentsCount,
           unresolvedReviewCommentsCount: review.unresolvedReviewCommentsCount,
           criticalReviewPending: review.criticalReviewPending
@@ -135,6 +137,7 @@ function validateHandoffRequirement({ actorRole, continuation }) {
 function buildReviewState(pullRequest) {
   const parsedGeminiSignals = collectGeminiReviewerSignals(pullRequest);
   const codexFallback = collectCodexFallbackSignals(pullRequest);
+  const formalReviewTruth = collectFormalReviewTruth(pullRequest);
   const reviewCommentsCount =
     parsedGeminiSignals.totalCount > 0
       ? parsedGeminiSignals.totalCount
@@ -158,10 +161,20 @@ function buildReviewState(pullRequest) {
           : "review_unavailable";
   const reviewer =
     reviewerStatus.startsWith("codex_review") ? "codex" : pullRequest.reviewer;
+  const reviewerEvidence = reviewerStatus.startsWith("codex_review")
+    ? codexFallback.latestEvidence
+    : parsedGeminiSignals.latestEvidence;
+  const reviewerSignalTruth = buildReviewerSignalTruth({
+    reviewer,
+    reviewerStatus,
+    reviewerEvidence,
+    formalReviewTruth
+  });
   const criticalReviewPending =
     pullRequest.exists &&
     (reviewerStatus === "codex_review_requested" ||
       reviewerStatus === "codex_review_blocked" ||
+      reviewerSignalTruth.mergeReviewTruth.blocked ||
       (reviewCommentsCount > 0 && unresolvedReviewCommentsCount > 0));
   const rerunReviewer =
     pullRequest.exists &&
@@ -172,7 +185,8 @@ function buildReviewState(pullRequest) {
   return {
     reviewer,
     reviewerStatus,
-    reviewerEvidence: parsedGeminiSignals.latestEvidence,
+    reviewerEvidence,
+    reviewerSignalTruth,
     reviewCommentsCount,
     unresolvedReviewCommentsCount,
     criticalReviewPending,
@@ -205,7 +219,91 @@ function collectCodexFallbackSignals(pullRequest) {
     requested: latest?.status === "requested",
     completed: latest?.status === "completed",
     blocked: latest?.status === "blocked",
-    blocking: latest?.blocking === true
+    blocking: latest?.blocking === true,
+    latestEvidence: latest?.status === "completed"
+      ? {
+          reviewer: "codex",
+          recommendedAction: latest.recommendedAction || "manual_review",
+          url: latest.url || null,
+          createdAt: latest.createdAt || null,
+          updatedAt: latest.updatedAt || null,
+          includesCreatedEdit: latest.includesCreatedEdit === true
+        }
+      : null
+  };
+}
+
+function collectFormalReviewTruth(pullRequest) {
+  const reviews = Array.isArray(pullRequest.reviews) ? pullRequest.reviews : [];
+  const latestByReviewer = new Map();
+  for (const review of reviews) {
+    const reviewer = normalizeText(review?.user?.login) || normalizeText(review?.author) || "unknown";
+    latestByReviewer.set(reviewer, normalizeReviewState(review?.state));
+  }
+
+  const latestStates = [...latestByReviewer.values()].filter(Boolean);
+  const reviewDecision = normalizeReviewState(pullRequest.reviewDecision);
+  const blocking =
+    reviewDecision === "changes_requested" ||
+    latestStates.includes("changes_requested");
+  const approvalCount = latestStates.filter((state) => state === "approved").length;
+  const hasFormalApproval = reviewDecision === "approved" || approvalCount > 0;
+
+  return {
+    source: "github_formal_review_objects",
+    reviewDecision: reviewDecision || null,
+    hasFormalApproval,
+    approvalCount,
+    blocking,
+    blockingReason: blocking ? "github_formal_review_changes_requested" : null,
+    latestStates
+  };
+}
+
+function buildReviewerSignalTruth({ reviewer, reviewerStatus, reviewerEvidence, formalReviewTruth }) {
+  const recommendedAction = normalizeText(reviewerEvidence?.recommendedAction).toLowerCase() || null;
+  const vtddReviewerMarkerPresent = Boolean(recommendedAction);
+  const markerBlocks =
+    recommendedAction === "request_changes" || recommendedAction === "manual_review";
+  const formalBlocks = formalReviewTruth.blocking === true;
+  const satisfied =
+    vtddReviewerMarkerPresent &&
+    recommendedAction === "approve" &&
+    !formalBlocks;
+  const blocked = markerBlocks || formalBlocks;
+  const warnings = [];
+
+  if (recommendedAction === "approve" && !formalReviewTruth.hasFormalApproval) {
+    warnings.push(
+      "VTDD reviewer marker recommends approve, but GitHub formal PR review approval is absent; do not report GitHub reviewDecision as approved."
+    );
+  }
+  if (formalBlocks) {
+    warnings.push(
+      "GitHub formal review truth has requested changes; it remains blocking even if a VTDD reviewer marker recommends approve."
+    );
+  }
+  if (!vtddReviewerMarkerPresent) {
+    warnings.push("No VTDD reviewer marker recommendation is available.");
+  }
+
+  return {
+    canonicalSource: vtddReviewerMarkerPresent ? "vtdd_reviewer_marker_comment" : "none",
+    canonicalReviewer: vtddReviewerMarkerPresent ? reviewer : null,
+    reviewerStatus,
+    recommendedAction,
+    vtddReviewerMarkerPresent,
+    githubFormalReview: formalReviewTruth,
+    mergeReviewTruth: {
+      satisfied,
+      blocked,
+      reason: blocked
+        ? formalReviewTruth.blockingReason || "vtdd_reviewer_marker_blocks_merge"
+        : satisfied
+          ? "vtdd_reviewer_marker_approve_no_formal_blocker"
+          : "reviewer_signal_missing"
+    },
+    warnings
   };
 }
 
@@ -217,6 +315,9 @@ function determineCodexGoal({ pullRequest, review }) {
     return CodexGoal.REVISE_PR;
   }
   if (review.unresolvedReviewCommentsCount > 0) {
+    return CodexGoal.REVISE_PR;
+  }
+  if (review.reviewerSignalTruth?.mergeReviewTruth?.blocked) {
     return CodexGoal.REVISE_PR;
   }
   return CodexGoal.WAIT_FOR_REVIEW;
@@ -342,6 +443,10 @@ function normalizeGitHubRuntime(value) {
       ),
       updatedSinceReview: pullRequestInput.updatedSinceReview === true,
       reviewer: normalizeText(pullRequestInput.reviewer) || "gemini",
+      reviewDecision:
+        normalizeText(pullRequestInput.reviewDecision) ||
+        normalizeText(pullRequestInput.review_decision) ||
+        null,
       issueComments: Array.isArray(pullRequestInput.issueComments) ? pullRequestInput.issueComments : [],
       reviewComments: Array.isArray(pullRequestInput.reviewComments) ? pullRequestInput.reviewComments : [],
       reviews: Array.isArray(pullRequestInput.reviews) ? pullRequestInput.reviews : []
@@ -381,6 +486,23 @@ function normalizeNumber(value) {
 
 function normalizeNullableBoolean(value) {
   return typeof value === "boolean" ? value : null;
+}
+
+function normalizeReviewState(value) {
+  const normalized = normalizeText(value).toLowerCase();
+  if (!normalized) {
+    return null;
+  }
+  if (normalized === "approved") {
+    return "approved";
+  }
+  if (normalized === "changes_requested") {
+    return "changes_requested";
+  }
+  if (normalized === "review_required") {
+    return "review_required";
+  }
+  return normalized;
 }
 
 function normalizeText(value) {

--- a/test/butler-review-synthesis.test.js
+++ b/test/butler-review-synthesis.test.js
@@ -100,6 +100,12 @@ test("butler review synthesis does not present approve-only Gemini review as unr
   );
   assert.equal(
     result.humanDecisionFocus.includes(
+      "VTDD reviewer marker recommends approve, but GitHub formal PR review approval is absent; do not report GitHub reviewDecision as approved."
+    ),
+    false
+  );
+  assert.equal(
+    result.humanDecisionFocus.includes(
       "Meaningful reviewer objections remain unresolved; do not issue merge GO + real passkey yet."
     ),
     false
@@ -153,6 +159,71 @@ test("butler review synthesis blocks merge recommendation when approved PR has c
   );
   assert.equal(result.humanDecisionFocus.some((line) => line.includes("Recreate a fresh branch")), true);
   assert.deepEqual(result.nextSuggestedActions, ["create_fresh_branch", "open_fresh_pull_request"]);
+});
+
+test("butler review synthesis separates VTDD reviewer marker truth from GitHub formal review truth", () => {
+  const result = buildButlerReviewSynthesis({
+    pullRequest: {
+      number: 296,
+      url: "https://github.com/example/repo/pull/296",
+      state: "open",
+      title: "Reviewer signal truth",
+      mergeable: true,
+      mergeableState: "clean"
+    },
+    reviewLoop: {
+      reviewer: "gemini",
+      reviewerStatus: "gemini_review_available",
+      reviewerEvidence: {
+        reviewer: "gemini",
+        recommendedAction: "approve",
+        url: "https://github.com/example/repo/pull/296#issuecomment-1"
+      },
+      reviewerSignalTruth: {
+        canonicalSource: "vtdd_reviewer_marker_comment",
+        canonicalReviewer: "gemini",
+        reviewerStatus: "gemini_review_available",
+        recommendedAction: "approve",
+        vtddReviewerMarkerPresent: true,
+        githubFormalReview: {
+          source: "github_formal_review_objects",
+          reviewDecision: null,
+          hasFormalApproval: false,
+          approvalCount: 0,
+          blocking: false,
+          latestStates: []
+        },
+        mergeReviewTruth: {
+          satisfied: true,
+          blocked: false,
+          reason: "vtdd_reviewer_marker_approve_no_formal_blocker"
+        },
+        warnings: [
+          "VTDD reviewer marker recommends approve, but GitHub formal PR review approval is absent; do not report GitHub reviewDecision as approved."
+        ]
+      },
+      reviewCommentsCount: 1,
+      unresolvedReviewCommentsCount: 0,
+      criticalReviewPending: false
+    },
+    nextSuggestedActions: ["summarize_for_human", "wait_for_human_go"]
+  });
+
+  assert.equal(result.reviewerSignal.reviewerSignalTruth.canonicalSource, "vtdd_reviewer_marker_comment");
+  assert.equal(result.reviewerSignal.reviewerSignalTruth.githubFormalReview.hasFormalApproval, false);
+  assert.equal(result.reviewerSignal.reviewerSignalTruth.mergeReviewTruth.satisfied, true);
+  assert.equal(
+    result.humanDecisionFocus.includes(
+      "VTDD reviewer marker recommends approve, but GitHub formal PR review approval is absent; do not report GitHub reviewDecision as approved."
+    ),
+    true
+  );
+  assert.equal(
+    result.humanDecisionFocus.includes(
+      "GitHub formal review truth: reviewDecision=none, approvals=0, blocking=false."
+    ),
+    true
+  );
 });
 
 test("butler review synthesis marks missing conflict runtime truth as unverified", () => {

--- a/test/custom-gpt-setup-docs.test.js
+++ b/test/custom-gpt-setup-docs.test.js
@@ -138,6 +138,11 @@ test("custom gpt instructions preserve current butler and approval boundaries", 
   assert.equal(doc.includes("A completed `vtdd:reviewer=codex-fallback` marker comment"), true);
   assert.equal(doc.includes("trusted VTDD-controlled actor, Codex Cloud reviewer result, or GitHub App token path"), true);
   assert.equal(doc.includes("do not treat missing GitHub Review API objects alone as missing reviewer evidence"), true);
+  assert.equal(doc.includes("VTDD reviewer marker comments such as `vtdd:reviewer=gemini`"), true);
+  assert.equal(doc.includes("GitHub formal Pull Request Review API objects and `reviewDecision` are separate runtime truth"), true);
+  assert.equal(doc.includes("Do not report GitHub reviewDecision as approved merely because the VTDD reviewer marker recommends `approve`"), true);
+  assert.equal(doc.includes("A GitHub formal `CHANGES_REQUESTED` / `changes_requested` state remains blocking"), true);
+  assert.equal(doc.includes("reviewLoop.reviewerSignalTruth"), true);
   assert.equal(doc.includes("Do not claim a PR exists when only a Codex task summary exists."), true);
   assert.equal(
     doc.includes("Do not claim that Issues/PRs/comments are absent when the read path is unsupported, unauthorized, or unverified."),
@@ -214,6 +219,9 @@ test("short custom gpt instructions stay under editor limits while preserving cr
     true
   );
   assert.equal(doc.includes("missing GitHub Review objects alone is not absence"), true);
+  assert.equal(doc.includes("Review truth: marker approve != GitHub approval"), true);
+  assert.equal(doc.includes("formal CHANGES_REQUESTED blocks"), true);
+  assert.equal(doc.includes("reviewerSignalTruth warnings"), true);
 });
 
 test("short-min custom gpt instructions stay pasteable while preserving critical invariants", () => {
@@ -237,6 +245,9 @@ test("short-min custom gpt instructions stay pasteable while preserving critical
     "GO + real passkey",
     "show exact title/body/comment/update payload",
     "Preserve reviewer objections",
+    "Review truth: marker approve != GitHub approval",
+    "formal CHANGES_REQUESTED blocks",
+    "reviewerSignalTruth warnings",
     "vtddRetrieveSelfParity",
     "Remote Codex build invariant",
     "Executor transport is pluggable and user-owned",

--- a/test/execution-continuity.test.js
+++ b/test/execution-continuity.test.js
@@ -107,6 +107,16 @@ test("execution continuity treats approve-only Gemini reviewer comment as non-bl
   assert.equal(result.value.reviewLoop.reviewCommentsCount, 1);
   assert.equal(result.value.reviewLoop.unresolvedReviewCommentsCount, 0);
   assert.equal(result.value.reviewLoop.criticalReviewPending, false);
+  assert.equal(result.value.reviewLoop.reviewerSignalTruth.canonicalSource, "vtdd_reviewer_marker_comment");
+  assert.equal(result.value.reviewLoop.reviewerSignalTruth.recommendedAction, "approve");
+  assert.equal(result.value.reviewLoop.reviewerSignalTruth.githubFormalReview.hasFormalApproval, false);
+  assert.equal(result.value.reviewLoop.reviewerSignalTruth.mergeReviewTruth.satisfied, true);
+  assert.equal(
+    result.value.reviewLoop.reviewerSignalTruth.warnings.includes(
+      "VTDD reviewer marker recommends approve, but GitHub formal PR review approval is absent; do not report GitHub reviewDecision as approved."
+    ),
+    true
+  );
   assert.equal(result.value.codexGoal, CodexGoal.WAIT_FOR_REVIEW);
   assert.equal(
     result.value.butlerReviewSynthesis.headline,
@@ -123,6 +133,49 @@ test("execution continuity treats approve-only Gemini reviewer comment as non-bl
     "refresh_pull_request_runtime_truth",
     "summarize_for_human"
   ]);
+});
+
+test("execution continuity treats GitHub formal changes requested as blocking even with VTDD marker approve", () => {
+  const result = evaluateExecutionContinuity({
+    actorRole: ActorRole.BUTLER,
+    mode: TaskMode.EXECUTION,
+    runtimeTruth: {
+      runtimeState: {
+        activeBranch: "codex/reviewer-truth",
+        pullRequest: {
+          number: 296,
+          url: "https://github.com/example/repo/pull/296",
+          state: "open",
+          title: "Reviewer signal truth",
+          reviewer: "gemini",
+          reviewDecision: "CHANGES_REQUESTED",
+          reviews: [{ user: { login: "human-reviewer" }, state: "CHANGES_REQUESTED" }],
+          issueComments: [
+            {
+              user: { login: "vtdd-codex[bot]" },
+              body: "<!-- vtdd:reviewer=gemini -->\n## VTDD Gemini Critical Review\n\n- Recommended action: `approve`",
+              url: "https://github.com/example/repo/pull/296#issuecomment-1"
+            }
+          ]
+        }
+      }
+    }
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.value.codexGoal, CodexGoal.REVISE_PR);
+  assert.equal(result.value.reviewLoop.criticalReviewPending, true);
+  assert.equal(result.value.reviewLoop.reviewerSignalTruth.mergeReviewTruth.blocked, true);
+  assert.equal(
+    result.value.reviewLoop.reviewerSignalTruth.mergeReviewTruth.reason,
+    "github_formal_review_changes_requested"
+  );
+  assert.equal(
+    result.value.butlerReviewSynthesis.humanDecisionFocus.includes(
+      "GitHub formal review truth has requested changes; it remains blocking even if a VTDD reviewer marker recommends approve."
+    ),
+    true
+  );
 });
 
 test("execution continuity proposes a fresh PR when approved runtime truth has conflicts", () => {

--- a/worker.js
+++ b/worker.js
@@ -21126,6 +21126,7 @@ function buildButlerReviewSynthesis(input = {}) {
       reviewer: reviewLoop.reviewer,
       reviewerStatus: reviewLoop.reviewerStatus,
       reviewerEvidence: reviewLoop.reviewerEvidence,
+      reviewerSignalTruth: reviewLoop.reviewerSignalTruth,
       reviewCommentsCount: reviewLoop.reviewCommentsCount,
       unresolvedReviewCommentsCount: reviewLoop.unresolvedReviewCommentsCount,
       criticalReviewPending: reviewLoop.criticalReviewPending,
@@ -21218,6 +21219,15 @@ function buildHumanDecisionFocus({ pullRequest, reviewLoop, codexGoal, branchAtt
     const url = reviewLoop.reviewerEvidence.url ? ` ${reviewLoop.reviewerEvidence.url}` : "";
     focus.push(`Latest ${reviewLoop.reviewer} reviewer action is ${action}.${url}`);
   }
+  for (const warning of reviewLoop.reviewerSignalTruth?.warnings ?? []) {
+    focus.push(warning);
+  }
+  if (reviewLoop.reviewerSignalTruth?.githubFormalReview) {
+    const formal = reviewLoop.reviewerSignalTruth.githubFormalReview;
+    focus.push(
+      `GitHub formal review truth: reviewDecision=${formal.reviewDecision || "none"}, approvals=${formal.approvalCount}, blocking=${formal.blocking === true}.`
+    );
+  }
   if (reviewLoop.reviewer === "gemini" && reviewLoop.reviewerEvidence?.includesCreatedEdit) {
     focus.push(
       "Gemini updates its existing marker comment; GitHub may show the original comment time, so use the current marker body and evidence URL."
@@ -21294,9 +21304,40 @@ function normalizeReviewLoop(value) {
     reviewer: normalizeText4(input.reviewer) || "gemini",
     reviewerStatus: normalizeText4(input.reviewerStatus) || "review_unavailable",
     reviewerEvidence: normalizeReviewerEvidence(input.reviewerEvidence),
+    reviewerSignalTruth: normalizeReviewerSignalTruth(input.reviewerSignalTruth),
     reviewCommentsCount: normalizeCount(input.reviewCommentsCount),
     unresolvedReviewCommentsCount: normalizeCount(input.unresolvedReviewCommentsCount),
     criticalReviewPending: input.criticalReviewPending === true
+  };
+}
+function normalizeReviewerSignalTruth(value) {
+  const input = value && typeof value === "object" ? value : {};
+  if (!normalizeText4(input.canonicalSource) && !input.githubFormalReview) {
+    return null;
+  }
+  const formal = input.githubFormalReview && typeof input.githubFormalReview === "object" ? input.githubFormalReview : {};
+  const mergeReviewTruth = input.mergeReviewTruth && typeof input.mergeReviewTruth === "object" ? input.mergeReviewTruth : {};
+  return {
+    canonicalSource: normalizeText4(input.canonicalSource) || "none",
+    canonicalReviewer: normalizeText4(input.canonicalReviewer) || null,
+    reviewerStatus: normalizeText4(input.reviewerStatus) || null,
+    recommendedAction: normalizeText4(input.recommendedAction) || null,
+    vtddReviewerMarkerPresent: input.vtddReviewerMarkerPresent === true,
+    githubFormalReview: {
+      source: normalizeText4(formal.source) || "github_formal_review_objects",
+      reviewDecision: normalizeText4(formal.reviewDecision) || null,
+      hasFormalApproval: formal.hasFormalApproval === true,
+      approvalCount: normalizeCount(formal.approvalCount),
+      blocking: formal.blocking === true,
+      blockingReason: normalizeText4(formal.blockingReason) || null,
+      latestStates: Array.isArray(formal.latestStates) ? formal.latestStates.map(normalizeText4).filter(Boolean) : []
+    },
+    mergeReviewTruth: {
+      satisfied: mergeReviewTruth.satisfied === true,
+      blocked: mergeReviewTruth.blocked === true,
+      reason: normalizeText4(mergeReviewTruth.reason) || null
+    },
+    warnings: normalizeStringArray(input.warnings)
   };
 }
 function normalizeReviewerEvidence(value) {
@@ -27221,6 +27262,7 @@ function evaluateExecutionContinuity(input = {}) {
         reviewer: review.reviewer,
         reviewerStatus: review.reviewerStatus,
         reviewerEvidence: review.reviewerEvidence,
+        reviewerSignalTruth: review.reviewerSignalTruth,
         reviewCommentsCount: review.reviewCommentsCount,
         unresolvedReviewCommentsCount: review.unresolvedReviewCommentsCount,
         criticalReviewPending: review.criticalReviewPending,
@@ -27238,6 +27280,7 @@ function evaluateExecutionContinuity(input = {}) {
           reviewer: review.reviewer,
           reviewerStatus: review.reviewerStatus,
           reviewerEvidence: review.reviewerEvidence,
+          reviewerSignalTruth: review.reviewerSignalTruth,
           reviewCommentsCount: review.reviewCommentsCount,
           unresolvedReviewCommentsCount: review.unresolvedReviewCommentsCount,
           criticalReviewPending: review.criticalReviewPending
@@ -27286,16 +27329,25 @@ function validateHandoffRequirement({ actorRole, continuation }) {
 function buildReviewState(pullRequest) {
   const parsedGeminiSignals = collectGeminiReviewerSignals(pullRequest);
   const codexFallback = collectCodexFallbackSignals(pullRequest);
+  const formalReviewTruth = collectFormalReviewTruth(pullRequest);
   const reviewCommentsCount = parsedGeminiSignals.totalCount > 0 ? parsedGeminiSignals.totalCount : codexFallback.completed ? 1 : pullRequest.reviewCommentsCount;
   const unresolvedReviewCommentsCount = parsedGeminiSignals.totalCount > 0 ? parsedGeminiSignals.blockingCount : codexFallback.completed ? codexFallback.blocking ? 1 : 0 : pullRequest.unresolvedReviewCommentsCount;
   const reviewerStatus = codexFallback.completed ? "codex_review_available" : codexFallback.blocked ? "codex_review_blocked" : codexFallback.requested ? "codex_review_requested" : reviewCommentsCount > 0 ? "gemini_review_available" : "review_unavailable";
   const reviewer = reviewerStatus.startsWith("codex_review") ? "codex" : pullRequest.reviewer;
-  const criticalReviewPending = pullRequest.exists && (reviewerStatus === "codex_review_requested" || reviewerStatus === "codex_review_blocked" || reviewCommentsCount > 0 && unresolvedReviewCommentsCount > 0);
+  const reviewerEvidence = reviewerStatus.startsWith("codex_review") ? codexFallback.latestEvidence : parsedGeminiSignals.latestEvidence;
+  const reviewerSignalTruth = buildReviewerSignalTruth({
+    reviewer,
+    reviewerStatus,
+    reviewerEvidence,
+    formalReviewTruth
+  });
+  const criticalReviewPending = pullRequest.exists && (reviewerStatus === "codex_review_requested" || reviewerStatus === "codex_review_blocked" || reviewerSignalTruth.mergeReviewTruth.blocked || reviewCommentsCount > 0 && unresolvedReviewCommentsCount > 0);
   const rerunReviewer = pullRequest.exists && reviewerStatus !== "codex_review_requested" && reviewerStatus !== "codex_review_blocked" && (pullRequest.updatedSinceReview || unresolvedReviewCommentsCount > 0);
   return {
     reviewer,
     reviewerStatus,
-    reviewerEvidence: parsedGeminiSignals.latestEvidence,
+    reviewerEvidence,
+    reviewerSignalTruth,
     reviewCommentsCount,
     unresolvedReviewCommentsCount,
     criticalReviewPending,
@@ -27324,7 +27376,73 @@ function collectCodexFallbackSignals(pullRequest) {
     requested: latest?.status === "requested",
     completed: latest?.status === "completed",
     blocked: latest?.status === "blocked",
-    blocking: latest?.blocking === true
+    blocking: latest?.blocking === true,
+    latestEvidence: latest?.status === "completed" ? {
+      reviewer: "codex",
+      recommendedAction: latest.recommendedAction || "manual_review",
+      url: latest.url || null,
+      createdAt: latest.createdAt || null,
+      updatedAt: latest.updatedAt || null,
+      includesCreatedEdit: latest.includesCreatedEdit === true
+    } : null
+  };
+}
+function collectFormalReviewTruth(pullRequest) {
+  const reviews = Array.isArray(pullRequest.reviews) ? pullRequest.reviews : [];
+  const latestByReviewer = /* @__PURE__ */ new Map();
+  for (const review of reviews) {
+    const reviewer = normalizeText20(review?.user?.login) || normalizeText20(review?.author) || "unknown";
+    latestByReviewer.set(reviewer, normalizeReviewState(review?.state));
+  }
+  const latestStates = [...latestByReviewer.values()].filter(Boolean);
+  const reviewDecision = normalizeReviewState(pullRequest.reviewDecision);
+  const blocking = reviewDecision === "changes_requested" || latestStates.includes("changes_requested");
+  const approvalCount = latestStates.filter((state) => state === "approved").length;
+  const hasFormalApproval = reviewDecision === "approved" || approvalCount > 0;
+  return {
+    source: "github_formal_review_objects",
+    reviewDecision: reviewDecision || null,
+    hasFormalApproval,
+    approvalCount,
+    blocking,
+    blockingReason: blocking ? "github_formal_review_changes_requested" : null,
+    latestStates
+  };
+}
+function buildReviewerSignalTruth({ reviewer, reviewerStatus, reviewerEvidence, formalReviewTruth }) {
+  const recommendedAction = normalizeText20(reviewerEvidence?.recommendedAction).toLowerCase() || null;
+  const vtddReviewerMarkerPresent = Boolean(recommendedAction);
+  const markerBlocks = recommendedAction === "request_changes" || recommendedAction === "manual_review";
+  const formalBlocks = formalReviewTruth.blocking === true;
+  const satisfied = vtddReviewerMarkerPresent && recommendedAction === "approve" && !formalBlocks;
+  const blocked2 = markerBlocks || formalBlocks;
+  const warnings = [];
+  if (recommendedAction === "approve" && !formalReviewTruth.hasFormalApproval) {
+    warnings.push(
+      "VTDD reviewer marker recommends approve, but GitHub formal PR review approval is absent; do not report GitHub reviewDecision as approved."
+    );
+  }
+  if (formalBlocks) {
+    warnings.push(
+      "GitHub formal review truth has requested changes; it remains blocking even if a VTDD reviewer marker recommends approve."
+    );
+  }
+  if (!vtddReviewerMarkerPresent) {
+    warnings.push("No VTDD reviewer marker recommendation is available.");
+  }
+  return {
+    canonicalSource: vtddReviewerMarkerPresent ? "vtdd_reviewer_marker_comment" : "none",
+    canonicalReviewer: vtddReviewerMarkerPresent ? reviewer : null,
+    reviewerStatus,
+    recommendedAction,
+    vtddReviewerMarkerPresent,
+    githubFormalReview: formalReviewTruth,
+    mergeReviewTruth: {
+      satisfied,
+      blocked: blocked2,
+      reason: blocked2 ? formalReviewTruth.blockingReason || "vtdd_reviewer_marker_blocks_merge" : satisfied ? "vtdd_reviewer_marker_approve_no_formal_blocker" : "reviewer_signal_missing"
+    },
+    warnings
   };
 }
 function determineCodexGoal({ pullRequest, review }) {
@@ -27335,6 +27453,9 @@ function determineCodexGoal({ pullRequest, review }) {
     return CodexGoal.REVISE_PR;
   }
   if (review.unresolvedReviewCommentsCount > 0) {
+    return CodexGoal.REVISE_PR;
+  }
+  if (review.reviewerSignalTruth?.mergeReviewTruth?.blocked) {
     return CodexGoal.REVISE_PR;
   }
   return CodexGoal.WAIT_FOR_REVIEW;
@@ -27414,6 +27535,7 @@ function normalizeGitHubRuntime(value) {
       ),
       updatedSinceReview: pullRequestInput.updatedSinceReview === true,
       reviewer: normalizeText20(pullRequestInput.reviewer) || "gemini",
+      reviewDecision: normalizeText20(pullRequestInput.reviewDecision) || normalizeText20(pullRequestInput.review_decision) || null,
       issueComments: Array.isArray(pullRequestInput.issueComments) ? pullRequestInput.issueComments : [],
       reviewComments: Array.isArray(pullRequestInput.reviewComments) ? pullRequestInput.reviewComments : [],
       reviews: Array.isArray(pullRequestInput.reviews) ? pullRequestInput.reviews : []
@@ -27444,6 +27566,22 @@ function normalizeNumber2(value) {
 }
 function normalizeNullableBoolean2(value) {
   return typeof value === "boolean" ? value : null;
+}
+function normalizeReviewState(value) {
+  const normalized = normalizeText20(value).toLowerCase();
+  if (!normalized) {
+    return null;
+  }
+  if (normalized === "approved") {
+    return "approved";
+  }
+  if (normalized === "changes_requested") {
+    return "changes_requested";
+  }
+  if (normalized === "review_required") {
+    return "review_required";
+  }
+  return normalized;
 }
 function normalizeText20(value) {
   return String(value ?? "").trim();


### PR DESCRIPTION
## This PR satisfies Intent

- Explicit owner instruction: make reviewer approve-equivalent signals canonical without pretending they are GitHub formal reviews; Butler must distinguish VTDD reviewer marker comments from GitHub formal reviewDecision truth before merge judgment.

## Satisfied Success Criteria

- Runtime review loop now exposes reviewerSignalTruth with VTDD marker source, GitHub formal review truth, merge-review satisfaction/blocking, and warnings.
- Butler synthesis now surfaces marker/formal-review separation in humanDecisionFocus.
- Formal GitHub CHANGES_REQUESTED remains blocking even when a VTDD marker recommends approve.
- Custom GPT full/short/min instructions now preserve the distinction within the 8000-character short/min limits.

## Unsatisfied Success Criteria

- Post-merge Cloudflare deploy is still required before Butler runtime observes the new logic.
- Post-merge Custom GPT Instructions refresh is still required so Butler follows the new reviewer-truth language.
- A live iPhone Butler E2E run is still required after deploy and instruction refresh.

## Non-goal violations

No merge, deploy, Action Schema replacement, VPS runner update/restart, GitHub formal review submission, issue closure, or auto-approval behavior is performed by this PR.

## Verification Evidence

- Unit: node --test test/custom-gpt-setup-docs.test.js test/execution-continuity.test.js test/butler-review-synthesis.test.js test/gemini-pr-review.test.js; npm test
- Integration: npm run check:self-parity passed with 22 routes and 22 operationIds; npm run check:generated-worker passed after worker.js regeneration.
- E2E: Not yet live. Requires merge, Cloudflare deploy, Custom GPT Instructions refresh, then iPhone Butler live E2E.
- Manual: Instruction lengths verified: short=7894, short-min=7782.
- Evidence path/link: test/execution-continuity.test.js; test/butler-review-synthesis.test.js; test/custom-gpt-setup-docs.test.js

## Butler Completion Contract

- Owner goal: Butler must make merge/revision judgment from canonical reviewer signal truth without confusing VTDD reviewer marker comments with GitHub formal PR Review API/reviewDecision state.
- Butler entrypoint: Butler execution-continuity / PR review synthesis path; no new user-facing action route.
- Action Schema exposure: No OpenAPI operationId/path/request-schema change; existing responses add reviewerSignalTruth JSON that Butler can read.
- Runtime path: src/core/execution-continuity.js -> reviewLoop.reviewerSignalTruth; src/core/butler-review-synthesis.js -> humanDecisionFocus warnings; generated worker.js.
- Runner/runtime truth: Runtime separates vtdd_reviewer_marker_comment from github_formal_review_objects; GitHub formal changes_requested blocks revision/merge judgment.
- Authority boundary: No high-risk external action is executed. Deploy and Custom GPT instruction update remain post-merge human-governed operations; merge still requires explicit human GO/passkey boundary.
- E2E evidence: Incomplete until post-merge deploy + Custom GPT Instructions refresh + live iPhone Butler E2E.
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: Required after merge because Butler runtime judgment logic changes.
- Custom GPT Action Schema update: Not required: no new operationId/path/request schema.
- Custom GPT Instructions update: Required after merge: paste refreshed custom-gpt-instructions short/min/full as appropriate so Butler does not conflate marker approval with formal GitHub approval.
- iPhone Butler live E2E: Required after deploy and instruction refresh: verify Butler reports VTDD marker approve separately from GitHub formal reviewDecision and blocks formal CHANGES_REQUESTED.

## Related Constitution Rules

- AGENTS.md Canonical Source Order and Drift Stop Protocol.
- AGENTS.md Butler Completion Gate and Surface Update Checklist discipline.
- AGENTS.md Evidence Discipline and Authority Boundary.

## Out-of-scope but NOT implemented

- Creating or spoofing GitHub formal PR approvals.
- Changing OpenAPI Action Schema operationIds.
- Deploying Cloudflare runtime or updating Custom GPT Instructions.
- Updating/restarting VPS runner runtime.

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue:
- Execution ID: Not provided.
- Goal: Not provided.
