### PR TITLE
Fix known-good setup recovery fallback

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -103,6 +103,7 @@ jobs:
           CLOUDFLARE_D1_DATABASE_ID: ${{ secrets.CLOUDFLARE_D1_DATABASE_ID }}
           CLOUDFLARE_D1_DATABASE_NAME: ${{ vars.CLOUDFLARE_D1_DATABASE_NAME || 'vtdd-memory' }}
           VTDD_GITHUB_ACTIONS_REPOSITORY: ${{ github.repository }}
+          VTDD_KNOWN_GOOD_COMMIT_SHA: ${{ vars.VTDD_KNOWN_GOOD_COMMIT_SHA }}
         shell: bash
         run: |
           cp wrangler.toml wrangler.production.generated.toml
@@ -110,6 +111,17 @@ jobs:
 
           [env.production.vars]
           VTDD_GITHUB_ACTIONS_REPOSITORY = "$VTDD_GITHUB_ACTIONS_REPOSITORY"
+          EOF
+          if [ -n "$VTDD_KNOWN_GOOD_COMMIT_SHA" ]; then
+            if [[ ! "$VTDD_KNOWN_GOOD_COMMIT_SHA" =~ ^[0-9a-fA-F]{40}$ ]]; then
+              echo "VTDD_KNOWN_GOOD_COMMIT_SHA must be a 40-character commit SHA."
+              exit 1
+            fi
+            cat >> wrangler.production.generated.toml <<EOF
+          VTDD_KNOWN_GOOD_COMMIT_SHA = "$VTDD_KNOWN_GOOD_COMMIT_SHA"
+          EOF
+          fi
+          cat >> wrangler.production.generated.toml <<EOF
 
           [[env.production.d1_databases]]
           binding = "VTDD_MEMORY_D1"

--- a/docs/mvp/production-deploy-path.md
+++ b/docs/mvp/production-deploy-path.md
@@ -58,6 +58,11 @@ such as `wrangler.production.local.toml`. For GitHub Actions deploys, store the
 D1 database id in `CLOUDFLARE_D1_DATABASE_ID`; the workflow generates an
 uncommitted `wrangler.production.generated.toml` at deploy time.
 
+If `/setup/known-good` should expose a rollback bundle, set repository variable
+`VTDD_KNOWN_GOOD_COMMIT_SHA` to the last human-verified stable setup commit
+before dispatching production deploy. If this variable is absent, the Worker
+must not silently treat `main` as known-good.
+
 ## Approval Boundary (`GO + passkey`)
 
 `deploy-production` workflow is manual (`workflow_dispatch`) and requires:

--- a/src/core/custom-gpt-setup-artifacts.js
+++ b/src/core/custom-gpt-setup-artifacts.js
@@ -394,8 +394,18 @@ export async function buildCustomGptRecoveryBundle(input = {}) {
 
   const knownGoodCommit =
     channel === CustomGptSetupChannel.KNOWN_GOOD
-      ? await resolveKnownGoodCommitSha({ repository, ref: requestedRef, env })
+      ? resolveConfiguredKnownGoodCommitSha({ ref: requestedRef, env })
       : null;
+  if (channel === CustomGptSetupChannel.KNOWN_GOOD && !knownGoodCommit?.sha) {
+    return {
+      ok: false,
+      status: 503,
+      error: "known_good_setup_unavailable",
+      reason:
+        "known-good setup requires VTDD_KNOWN_GOOD_COMMIT_SHA or an explicit 40-character ref"
+    };
+  }
+
   const ref =
     channel === CustomGptSetupChannel.KNOWN_GOOD
       ? knownGoodCommit?.sha || requestedRef
@@ -540,7 +550,7 @@ export function renderCustomGptRecoveryPage(input = {}) {
     pre, textarea { width: 100%; box-sizing: border-box; white-space: pre; overflow: auto; border: 1px solid color-mix(in srgb, CanvasText 18%, transparent); border-radius: 8px; padding: 12px; background: color-mix(in srgb, CanvasText 5%, Canvas); color: CanvasText; font: 13px/1.45 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
     textarea { min-height: 320px; resize: vertical; }
     .meta { display: grid; grid-template-columns: repeat(auto-fit, minmax(210px, 1fr)); gap: 8px; }
-    .meta div { padding: 10px; border: 1px solid color-mix(in srgb, CanvasText 14%, transparent); border-radius: 8px; }
+    .meta div { min-width: 0; padding: 10px; border: 1px solid color-mix(in srgb, CanvasText 14%, transparent); border-radius: 8px; overflow-wrap: anywhere; }
     .nav { display: flex; flex-wrap: wrap; gap: 8px; align-items: center; }
     .nav strong { margin-right: auto; }
     .channel { text-transform: none; }
@@ -610,6 +620,19 @@ function validateCustomGptSetupArtifactRequest({ artifact, repository }) {
     issues.push("repository is required");
   }
   return issues.length > 0 ? { ok: false, issues } : { ok: true };
+}
+
+function resolveConfiguredKnownGoodCommitSha({ ref, env }) {
+  const configured = normalizeText(env?.[KNOWN_GOOD_COMMIT_ENV]);
+  if (/^[a-f0-9]{40}$/i.test(configured)) {
+    return { sha: configured, source: KNOWN_GOOD_COMMIT_ENV };
+  }
+
+  if (/^[a-f0-9]{40}$/i.test(ref)) {
+    return { sha: ref, source: "ref" };
+  }
+
+  return { sha: null, source: "unconfigured" };
 }
 
 async function resolveKnownGoodCommitSha({ repository, ref, env }) {

--- a/test/production-deploy-path.test.js
+++ b/test/production-deploy-path.test.js
@@ -39,6 +39,8 @@ test("production deploy doc defines the governed GitHub Actions deploy path", ()
   assert.equal(doc.includes("must not be committed"), true);
   assert.equal(doc.includes("`wrangler.production.local.toml`"), true);
   assert.equal(doc.includes("`wrangler.production.generated.toml`"), true);
+  assert.equal(doc.includes("`VTDD_KNOWN_GOOD_COMMIT_SHA`"), true);
+  assert.equal(doc.includes("must not silently treat `main` as known-good"), true);
 });
 
 test("deploy-production workflow enforces the MVP production deploy boundary", () => {
@@ -68,9 +70,23 @@ test("deploy-production workflow enforces the MVP production deploy boundary", (
   );
   assert.equal(workflow.includes("Generate production Wrangler config"), true);
   assert.equal(workflow.includes("VTDD_GITHUB_ACTIONS_REPOSITORY: ${{ github.repository }}"), true);
+  assert.equal(workflow.includes("VTDD_KNOWN_GOOD_COMMIT_SHA: ${{ vars.VTDD_KNOWN_GOOD_COMMIT_SHA }}"), true);
   assert.equal(workflow.includes("[env.production.vars]"), true);
   assert.equal(
     workflow.includes('VTDD_GITHUB_ACTIONS_REPOSITORY = "$VTDD_GITHUB_ACTIONS_REPOSITORY"'),
+    true
+  );
+  assert.equal(workflow.includes('if [ -n "$VTDD_KNOWN_GOOD_COMMIT_SHA" ]; then'), true);
+  assert.equal(
+    workflow.includes('[[ ! "$VTDD_KNOWN_GOOD_COMMIT_SHA" =~ ^[0-9a-fA-F]{40}$ ]]'),
+    true
+  );
+  assert.equal(
+    workflow.includes("VTDD_KNOWN_GOOD_COMMIT_SHA must be a 40-character commit SHA."),
+    true
+  );
+  assert.equal(
+    workflow.includes('VTDD_KNOWN_GOOD_COMMIT_SHA = "$VTDD_KNOWN_GOOD_COMMIT_SHA"'),
     true
   );
   assert.equal(workflow.includes("[[env.production.d1_databases]]"), true);

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -271,6 +271,38 @@ test("worker setup known-good page renders rollback copy-ready bundle from known
   assert.equal(html.includes("ghs_setup_read"), false);
 });
 
+test("worker setup known-good page does not silently treat main as known-good", async () => {
+  const response = await worker.fetch(new Request("https://example.com/setup/known-good"), {
+    GITHUB_APP_INSTALLATION_TOKEN: "ghs_setup_read",
+    GITHUB_API_FETCH: async () => {
+      throw new Error("known-good must not resolve main as fallback");
+    }
+  });
+
+  assert.equal(response.status, 200);
+  const html = await response.text();
+  assert.equal(html.includes("Recovery bundle unavailable."), true);
+  assert.equal(html.includes("known-good setup requires VTDD_KNOWN_GOOD_COMMIT_SHA"), true);
+  assert.equal(html.includes("Copy-ready Action Schema"), false);
+  assert.equal(html.includes("Copy-ready custom-gpt-instructions-short-min.md"), false);
+});
+
+test("worker setup known-good page rejects malformed configured known-good refs", async () => {
+  const response = await worker.fetch(new Request("https://example.com/setup/known-good"), {
+    GITHUB_APP_INSTALLATION_TOKEN: "ghs_setup_read",
+    VTDD_KNOWN_GOOD_COMMIT_SHA: "main",
+    GITHUB_API_FETCH: async () => {
+      throw new Error("malformed known-good config must not fetch artifacts");
+    }
+  });
+
+  assert.equal(response.status, 200);
+  const html = await response.text();
+  assert.equal(html.includes("Recovery bundle unavailable."), true);
+  assert.equal(html.includes("known-good setup requires VTDD_KNOWN_GOOD_COMMIT_SHA"), true);
+  assert.equal(html.includes("Copy Rollback Bundle"), false);
+});
+
 test("worker health reflects guarded absence mode when runtime env sets it", async () => {
   const response = await worker.fetch(new Request("https://example.com/health"), {
     VTDD_AUTONOMY_MODE: "guarded_absence"

--- a/worker.js
+++ b/worker.js
@@ -28771,7 +28771,15 @@ async function buildCustomGptRecoveryBundle(input = {}) {
       reason: "runtimeOrigin is required"
     };
   }
-  const knownGoodCommit = channel === CustomGptSetupChannel.KNOWN_GOOD ? await resolveKnownGoodCommitSha({ repository, ref: requestedRef, env }) : null;
+  const knownGoodCommit = channel === CustomGptSetupChannel.KNOWN_GOOD ? resolveConfiguredKnownGoodCommitSha({ ref: requestedRef, env }) : null;
+  if (channel === CustomGptSetupChannel.KNOWN_GOOD && !knownGoodCommit?.sha) {
+    return {
+      ok: false,
+      status: 503,
+      error: "known_good_setup_unavailable",
+      reason: "known-good setup requires VTDD_KNOWN_GOOD_COMMIT_SHA or an explicit 40-character ref"
+    };
+  }
   const ref = channel === CustomGptSetupChannel.KNOWN_GOOD ? knownGoodCommit?.sha || requestedRef : requestedRef;
   const [openapi, instructionsShortMin, selfParity, latestCommit] = await Promise.all([
     retrieveCustomGptSetupArtifact({
@@ -28898,7 +28906,7 @@ function renderCustomGptRecoveryPage(input = {}) {
     pre, textarea { width: 100%; box-sizing: border-box; white-space: pre; overflow: auto; border: 1px solid color-mix(in srgb, CanvasText 18%, transparent); border-radius: 8px; padding: 12px; background: color-mix(in srgb, CanvasText 5%, Canvas); color: CanvasText; font: 13px/1.45 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
     textarea { min-height: 320px; resize: vertical; }
     .meta { display: grid; grid-template-columns: repeat(auto-fit, minmax(210px, 1fr)); gap: 8px; }
-    .meta div { padding: 10px; border: 1px solid color-mix(in srgb, CanvasText 14%, transparent); border-radius: 8px; }
+    .meta div { min-width: 0; padding: 10px; border: 1px solid color-mix(in srgb, CanvasText 14%, transparent); border-radius: 8px; overflow-wrap: anywhere; }
     .nav { display: flex; flex-wrap: wrap; gap: 8px; align-items: center; }
     .nav strong { margin-right: auto; }
     .channel { text-transform: none; }
@@ -28958,6 +28966,16 @@ function validateCustomGptSetupArtifactRequest({ artifact, repository }) {
     issues.push("repository is required");
   }
   return issues.length > 0 ? { ok: false, issues } : { ok: true };
+}
+function resolveConfiguredKnownGoodCommitSha({ ref, env }) {
+  const configured = normalizeText24(env?.[KNOWN_GOOD_COMMIT_ENV]);
+  if (/^[a-f0-9]{40}$/i.test(configured)) {
+    return { sha: configured, source: KNOWN_GOOD_COMMIT_ENV };
+  }
+  if (/^[a-f0-9]{40}$/i.test(ref)) {
+    return { sha: ref, source: "ref" };
+  }
+  return { sha: null, source: "unconfigured" };
 }
 async function resolveKnownGoodCommitSha({ repository, ref, env }) {
   const configured = normalizeText24(env?.[KNOWN_GOOD_COMMIT_ENV]);


### PR DESCRIPTION
## This PR satisfies Intent

Targets #266 and #242.

This PR fixes the setup/recovery surface so `/setup/latest` remains the latest copy-ready setup bundle, while `/setup/known-good` no longer silently treats `main` as a known-good rollback bundle. Known-good rollback output now requires an explicit stable SHA through `VTDD_KNOWN_GOOD_COMMIT_SHA` or an explicit 40-character `ref`.

## Satisfied Success Criteria

- `/setup/latest` continues to render copy-ready Action Schema and `custom-gpt-instructions-short-min.md` from the requested latest ref.
- `/setup/known-good` uses only an explicit 40-character commit SHA and does not fall back to `main`, branch names, tags, or malformed values by assumption.
- If no valid known-good SHA is configured, the recovery page stays reachable and shows an explicit unavailable message instead of displaying misleading latest artifacts.
- Production deploy validates `vars.VTDD_KNOWN_GOOD_COMMIT_SHA` before writing it into Worker vars.
- Long runtime URLs and commit SHAs wrap in the page metadata cells instead of overlapping.
- No secrets, tokens, or approval grants are displayed.

## Unsatisfied Success Criteria

- Current production `/setup/known-good` will still be wrong until this PR is merged, `VTDD_KNOWN_GOOD_COMMIT_SHA` is configured to a human-verified stable setup commit, and Cloudflare deploy is run.
- Deployment-completion notification is intentionally not implemented in this PR.

## Verification Evidence

- `node --test test/worker.test.js test/production-deploy-path.test.js`
- `npm test`
- Live observation after #299 deploy: `/setup/latest` reports `in_sync` and contains `vtddWriteOperationalMemory`.

## Butler Completion Contract

- Owner goal: Make setup/latest show latest setup artifacts and setup/known-good show only an explicit stable rollback bundle without misleading main fallback.
- Butler entrypoint: Browser-openable `/setup/latest` and `/setup/known-good` pages on the Worker origin.
- Action Schema exposure: No Action Schema change; browser setup page route remains outside Custom GPT Actions.
- Runtime path: `src/core/custom-gpt-setup-artifacts.js` rendered through `src/worker/runtime.js` setup page route.
- Runner/runtime truth: Local full `npm test` passed; production `/setup/latest` after #299 deploy reports `in_sync`.
- Authority boundary: No deploy, merge, issue close, or Custom GPT editor mutation performed by this PR.
- E2E evidence: Worker setup page tests cover latest, valid known-good, absent known-good, and malformed known-good configuration.
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: Required after merge, because Worker runtime/setup page behavior changes.
- Custom GPT Action Schema: Not required for this PR; no operationId/path change.
- Custom GPT Instructions: Not required for this PR; no instruction artifact change.
- Operator/runtime config: Set repository variable `VTDD_KNOWN_GOOD_COMMIT_SHA` to the last human-verified stable setup commit before deploy if `/setup/known-good` should expose rollback copy-ready artifacts.
