### PR TITLE
Notify owner when production deploy finishes

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -18,6 +18,7 @@ on:
 
 permissions:
   contents: read
+  issues: write
 
 concurrency:
   group: deploy-production
@@ -137,3 +138,43 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           wranglerVersion: "4.83.0"
           command: deploy --config wrangler.production.generated.toml --env production
+
+      - name: Notify deploy completion
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DEPLOY_NOTIFICATION_ISSUE_NUMBER: ${{ vars.VTDD_DEPLOY_NOTIFICATION_ISSUE_NUMBER }}
+          DEPLOY_JOB_STATUS: ${{ job.status }}
+          REPOSITORY_OWNER: ${{ github.repository_owner }}
+          REPOSITORY: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          DEPLOY_SHA: ${{ github.sha }}
+          DEPLOY_ACTOR: ${{ github.actor }}
+          RUNTIME_URL: ${{ github.event.inputs.runtime_url }}
+        shell: bash
+        run: |
+          if [ -z "$DEPLOY_NOTIFICATION_ISSUE_NUMBER" ]; then
+            echo "VTDD_DEPLOY_NOTIFICATION_ISSUE_NUMBER is not set; skipping GitHub mention notification."
+            exit 0
+          fi
+          if [[ ! "$DEPLOY_NOTIFICATION_ISSUE_NUMBER" =~ ^[0-9]+$ ]]; then
+            echo "VTDD_DEPLOY_NOTIFICATION_ISSUE_NUMBER must be a GitHub issue number."
+            exit 1
+          fi
+
+          body=$(cat <<EOF
+          @${REPOSITORY_OWNER} deploy-production finished: ${DEPLOY_JOB_STATUS}.
+
+          - Repository: \`${REPOSITORY}\`
+          - Commit: \`${DEPLOY_SHA}\`
+          - Actor: \`${DEPLOY_ACTOR}\`
+          - Runtime URL: ${RUNTIME_URL}
+          - Run: ${RUN_URL}
+
+          This is a GitHub-visible deploy milestone notification. No approval grant id, token, or secret value is included.
+          EOF
+          )
+
+          gh api \
+            "repos/${REPOSITORY}/issues/${DEPLOY_NOTIFICATION_ISSUE_NUMBER}/comments" \
+            -f body="$body"

--- a/docs/mvp/production-deploy-path.md
+++ b/docs/mvp/production-deploy-path.md
@@ -63,6 +63,14 @@ If `/setup/known-good` should expose a rollback bundle, set repository variable
 before dispatching production deploy. If this variable is absent, the Worker
 must not silently treat `main` as known-good.
 
+If production deploy completion should notify the operator through GitHub
+Mobile / Apple Watch, set repository variable
+`VTDD_DEPLOY_NOTIFICATION_ISSUE_NUMBER` to a GitHub Issue number in the target
+repository. The workflow posts a short comment that mentions the repository owner,
+includes the run URL and deployed commit SHA, and intentionally omits approval
+grant ids, tokens, and other secret values. If the variable is absent,
+the deploy still runs and the mention notification is skipped.
+
 ## Approval Boundary (`GO + passkey`)
 
 `deploy-production` workflow is manual (`workflow_dispatch`) and requires:
@@ -89,4 +97,6 @@ The workflow validates the grant through `/v2/retrieve/approval-grant` using
 
 - Branch restriction: deploy job runs only when ref is `main`
 - Pre-deploy checks: approval grant validation and `npm test`
+- Deploy completion notification: optional GitHub Issue comment controlled by
+  `VTDD_DEPLOY_NOTIFICATION_ISSUE_NUMBER`
 - Future hardening (out-of-scope for MVP): external passkey attestation service, staged rollout, rollback automation

--- a/test/production-deploy-path.test.js
+++ b/test/production-deploy-path.test.js
@@ -41,12 +41,17 @@ test("production deploy doc defines the governed GitHub Actions deploy path", ()
   assert.equal(doc.includes("`wrangler.production.generated.toml`"), true);
   assert.equal(doc.includes("`VTDD_KNOWN_GOOD_COMMIT_SHA`"), true);
   assert.equal(doc.includes("must not silently treat `main` as known-good"), true);
+  assert.equal(doc.includes("`VTDD_DEPLOY_NOTIFICATION_ISSUE_NUMBER`"), true);
+  assert.equal(doc.includes("mentions the repository owner"), true);
+  assert.equal(doc.includes("intentionally omits approval"), true);
+  assert.equal(doc.includes("grant ids, tokens, and other secret values"), true);
 });
 
 test("deploy-production workflow enforces the MVP production deploy boundary", () => {
   const workflow = fs.readFileSync(WORKFLOW_PATH, "utf8");
   assert.equal(workflow.includes("name: deploy-production"), true);
   assert.equal(workflow.includes("workflow_dispatch:"), true);
+  assert.equal(workflow.includes("issues: write"), true);
   assert.equal(workflow.includes("if: github.ref == 'refs/heads/main'"), true);
   assert.equal(workflow.includes("environment: production"), true);
   assert.equal(workflow.includes('github.event.inputs.approval_phrase }}" != "GO"'), true);
@@ -96,6 +101,31 @@ test("deploy-production workflow enforces the MVP production deploy boundary", (
     workflow.includes("command: deploy --config wrangler.production.generated.toml --env production"),
     true
   );
+  assert.equal(workflow.includes("Notify deploy completion"), true);
+  assert.equal(workflow.includes("if: always()"), true);
+  assert.equal(
+    workflow.includes("DEPLOY_NOTIFICATION_ISSUE_NUMBER: ${{ vars.VTDD_DEPLOY_NOTIFICATION_ISSUE_NUMBER }}"),
+    true
+  );
+  assert.equal(
+    workflow.includes('VTDD_DEPLOY_NOTIFICATION_ISSUE_NUMBER is not set; skipping GitHub mention notification.'),
+    true
+  );
+  assert.equal(
+    workflow.includes('[[ ! "$DEPLOY_NOTIFICATION_ISSUE_NUMBER" =~ ^[0-9]+$ ]]'),
+    true
+  );
+  assert.equal(workflow.includes("@${REPOSITORY_OWNER} deploy-production finished"), true);
+  assert.equal(workflow.includes("- Run: ${RUN_URL}"), true);
+  assert.equal(
+    workflow.includes("No approval grant id, token, or secret value is included."),
+    true
+  );
+  assert.equal(
+    workflow.includes("repos/${REPOSITORY}/issues/${DEPLOY_NOTIFICATION_ISSUE_NUMBER}/comments"),
+    true
+  );
+  assert.equal(workflow.includes("approval_grant_id=${{"), false);
 });
 
 test("wrangler config fixes worker runtime entry and production environment", () => {


### PR DESCRIPTION
## This PR satisfies Intent

Targets #262.

This PR adds an optional GitHub-visible milestone notification to the governed `deploy-production` workflow. When repository variable `VTDD_DEPLOY_NOTIFICATION_ISSUE_NUMBER` is set, the workflow posts a short Issue comment that mentions the repository owner after the deploy job finishes.

## Satisfied Success Criteria

- Production deploy completion can emit a GitHub mention notification to the repository owner.
- Notification is tied to a milestone workflow completion, not heartbeat or progress polling.
- Notification includes concise runtime truth: repository, commit SHA, actor, runtime URL, and workflow run URL.
- Notification omits approval grant ids, tokens, and secret values.
- The workflow does not create issues or guess a target when the notification Issue variable is absent.
- Existing GO + passkey deploy boundary remains intact.

## Unsatisfied Success Criteria

- Live iPhone / Apple Watch notification evidence is not present until this PR is merged, `VTDD_DEPLOY_NOTIFICATION_ISSUE_NUMBER` is configured, and a production deploy run completes.

## Verification Evidence

- `node --test test/production-deploy-path.test.js`
- `npm test`

## Butler Completion Contract

- Owner goal: Notify the repository owner when deploy-production finishes, using GitHub mention instead of requiring the owner to poll the run manually.
- Butler entrypoint: GitHub Issue comment created by `.github/workflows/deploy-production.yml` when `VTDD_DEPLOY_NOTIFICATION_ISSUE_NUMBER` is configured.
- Action Schema exposure: Not required; this is GitHub Actions workflow behavior, not a Custom GPT operationId/path change.
- Runtime path: `.github/workflows/deploy-production.yml` final notification step after the Cloudflare deploy step.
- Runner/runtime truth: Local full `npm test` passed; live deploy notification remains post-merge/operator-configured evidence.
- Authority boundary: No deploy, merge, issue close, repo variable mutation, or credential mutation performed by this PR.
- E2E evidence: Workflow contract test covers permissions, optional Issue target, owner mention, run URL, and secret omission.
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: Not required for the notification workflow itself until merged workflow is used; this PR changes GitHub Actions behavior only.
- Custom GPT Action Schema: Not required.
- Custom GPT Instructions: Not required.
- Operator/runtime config: Set `VTDD_DEPLOY_NOTIFICATION_ISSUE_NUMBER` to the GitHub Issue number that should receive deploy completion comments.
