### PR TITLE
Avoid false failure after deploy dispatch

### DIFF
--- a/src/core/deploy-production-plane.js
+++ b/src/core/deploy-production-plane.js
@@ -56,7 +56,8 @@ export async function executeDeployProductionPlane(input = {}) {
     workflowFile,
     workflowRef,
     approvalGrantId,
-    runtimeUrl
+    runtimeUrl,
+    workflowRunsUrl: `https://github.com/${workflowRepository}/actions/workflows/${workflowFile}`
   };
 
   const dispatchUrl = `${apiBaseUrl}/repos/${encodeURIComponentRepository(
@@ -120,13 +121,14 @@ export async function executeDeployProductionPlane(input = {}) {
   });
   if (!observedRun.ok) {
     return {
-      ok: false,
-      status: 503,
-      error: "deploy_dispatch_unverified",
+      ok: true,
+      warning: "deploy_dispatch_unverified",
       reason: observedRun.reason,
       deploy: {
         ...deployBase,
-        status: "dispatch_unverified"
+        status: "dispatch_accepted_unverified",
+        runStatus: "unknown",
+        runConclusion: "unknown"
       }
     };
   }
@@ -154,8 +156,9 @@ async function verifyDeployWorkflowRun({
   fetchImpl,
   env
 }) {
-  const attempts = normalizePositiveInteger(env?.DEPLOY_DISPATCH_VERIFY_ATTEMPTS, 3);
-  const delayMs = normalizeNonNegativeInteger(env?.DEPLOY_DISPATCH_VERIFY_DELAY_MS, 1000);
+  const attempts = normalizePositiveInteger(env?.DEPLOY_DISPATCH_VERIFY_ATTEMPTS, 8);
+  const delayMs = normalizeNonNegativeInteger(env?.DEPLOY_DISPATCH_VERIFY_DELAY_MS, 1500);
+  const createdLowerBound = new Date(Math.max(0, Date.parse(dispatchedAt) - 120000)).toISOString();
   const runsUrl = new URL(`${apiBaseUrl}/repos/${encodeURIComponentRepository(
     workflowRepository
   )}/actions/workflows/${encodeURIComponent(
@@ -163,7 +166,7 @@ async function verifyDeployWorkflowRun({
   )}/runs`);
   runsUrl.searchParams.set("branch", workflowRef);
   runsUrl.searchParams.set("event", "workflow_dispatch");
-  runsUrl.searchParams.set("created", `>=${dispatchedAt}`);
+  runsUrl.searchParams.set("created", `>=${createdLowerBound}`);
   runsUrl.searchParams.set("per_page", "10");
 
   for (let attempt = 1; attempt <= attempts; attempt += 1) {

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -1501,6 +1501,8 @@ async function handleDeployProductionRequest(request, env) {
 
   return json(202, {
     ok: true,
+    warning: executed.warning ?? undefined,
+    reason: executed.reason ?? undefined,
     deploy: executed.deploy
   });
 }

--- a/test/deploy-production-plane.test.js
+++ b/test/deploy-production-plane.test.js
@@ -56,7 +56,7 @@ test("deploy production plane dispatches governed workflow with GO + passkey inp
   assert.equal(body.inputs.runtime_url, "https://sample-user-vtdd.example.workers.dev");
 });
 
-test("deploy production plane blocks when dispatch cannot be observed as a workflow run", async () => {
+test("deploy production plane does not fail when accepted dispatch is not immediately observable", async () => {
   const result = await executeDeployProductionPlane({
     repository: "sample-org/vtdd-v2-p",
     runtimeUrl: "https://sample-user-vtdd.example.workers.dev",
@@ -88,11 +88,17 @@ test("deploy production plane blocks when dispatch cannot be observed as a workf
     }
   });
 
-  assert.equal(result.ok, false);
-  assert.equal(result.error, "deploy_dispatch_unverified");
-  assert.equal(result.deploy.status, "dispatch_unverified");
+  assert.equal(result.ok, true);
+  assert.equal(result.warning, "deploy_dispatch_unverified");
+  assert.equal(result.deploy.status, "dispatch_accepted_unverified");
   assert.equal(result.deploy.workflowFile, "deploy-production.yml");
   assert.equal(result.deploy.repository, "sample-org/vtdd-v2-p");
+  assert.equal(
+    result.deploy.workflowRunsUrl,
+    "https://github.com/sample-org/vtdd-v2-p/actions/workflows/deploy-production.yml"
+  );
+  assert.equal(result.deploy.runStatus, "unknown");
+  assert.equal(result.deploy.runConclusion, "unknown");
 });
 
 test("deploy production plane blocks missing GO + passkey inputs", async () => {

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -4212,14 +4212,22 @@ test("worker returns raw deploy context when workflow dispatch is unverified", a
     }
   );
 
-  assert.equal(response.status, 503);
+  assert.equal(response.status, 202);
   const body = await response.json();
-  assert.equal(body.ok, false);
-  assert.equal(body.error, "deploy_dispatch_unverified");
-  assert.equal(body.deploy.status, "dispatch_unverified");
+  assert.equal(body.ok, true);
+  assert.equal(body.warning, "deploy_dispatch_unverified");
+  assert.equal(
+    body.reason,
+    "GitHub accepted deploy dispatch, but no deploy-production workflow run was observed"
+  );
+  assert.equal(body.deploy.status, "dispatch_accepted_unverified");
   assert.equal(body.deploy.repository, "sample-org/vtdd-v2-p");
   assert.equal(body.deploy.workflowFile, "deploy-production.yml");
   assert.equal(body.deploy.runtimeUrl, "https://sample-user-vtdd.example.workers.dev");
+  assert.equal(
+    body.deploy.workflowRunsUrl,
+    "https://github.com/sample-org/vtdd-v2-p/actions/workflows/deploy-production.yml"
+  );
 });
 
 test("worker syncs OPENAI_API_KEY through approval-bound GitHub Actions secret route", async () => {

--- a/worker.js
+++ b/worker.js
@@ -28222,7 +28222,8 @@ async function executeDeployProductionPlane(input = {}) {
     workflowFile,
     workflowRef,
     approvalGrantId,
-    runtimeUrl
+    runtimeUrl,
+    workflowRunsUrl: `https://github.com/${workflowRepository}/actions/workflows/${workflowFile}`
   };
   const dispatchUrl = `${apiBaseUrl}/repos/${encodeURIComponentRepository3(
     workflowRepository
@@ -28282,13 +28283,14 @@ async function executeDeployProductionPlane(input = {}) {
   });
   if (!observedRun.ok) {
     return {
-      ok: false,
-      status: 503,
-      error: "deploy_dispatch_unverified",
+      ok: true,
+      warning: "deploy_dispatch_unverified",
       reason: observedRun.reason,
       deploy: {
         ...deployBase,
-        status: "dispatch_unverified"
+        status: "dispatch_accepted_unverified",
+        runStatus: "unknown",
+        runConclusion: "unknown"
       }
     };
   }
@@ -28314,8 +28316,9 @@ async function verifyDeployWorkflowRun({
   fetchImpl,
   env
 }) {
-  const attempts = normalizePositiveInteger4(env?.DEPLOY_DISPATCH_VERIFY_ATTEMPTS, 3);
-  const delayMs = normalizeNonNegativeInteger(env?.DEPLOY_DISPATCH_VERIFY_DELAY_MS, 1e3);
+  const attempts = normalizePositiveInteger4(env?.DEPLOY_DISPATCH_VERIFY_ATTEMPTS, 8);
+  const delayMs = normalizeNonNegativeInteger(env?.DEPLOY_DISPATCH_VERIFY_DELAY_MS, 1500);
+  const createdLowerBound = new Date(Math.max(0, Date.parse(dispatchedAt) - 12e4)).toISOString();
   const runsUrl = new URL(`${apiBaseUrl}/repos/${encodeURIComponentRepository3(
     workflowRepository
   )}/actions/workflows/${encodeURIComponent(
@@ -28323,7 +28326,7 @@ async function verifyDeployWorkflowRun({
   )}/runs`);
   runsUrl.searchParams.set("branch", workflowRef);
   runsUrl.searchParams.set("event", "workflow_dispatch");
-  runsUrl.searchParams.set("created", `>=${dispatchedAt}`);
+  runsUrl.searchParams.set("created", `>=${createdLowerBound}`);
   runsUrl.searchParams.set("per_page", "10");
   for (let attempt = 1; attempt <= attempts; attempt += 1) {
     let response;
@@ -32335,6 +32338,8 @@ async function handleDeployProductionRequest(request, env) {
   }
   return json(202, {
     ok: true,
+    warning: executed.warning ?? void 0,
+    reason: executed.reason ?? void 0,
     deploy: executed.deploy
   });
 }


### PR DESCRIPTION
## This PR satisfies Intent

Targets #244 and #262.

This PR fixes the deploy-production action response so a GitHub-accepted `workflow_dispatch` is not reported to Butler as a failed deploy solely because the workflow run is not immediately visible through the runs list API. This matches the live failure observed after run `25707459762`, where GitHub created and completed the deploy successfully while Butler returned `deploy_dispatch_unverified` as an error.

## Satisfied Success Criteria

- GitHub dispatch failures still return `ok=false`.
- Accepted dispatches with an observed workflow run still return the run id, run URL, status, and conclusion.
- Accepted dispatches without an immediately observed run now return `ok=true`, HTTP 202, `deploy.status=dispatch_accepted_unverified`, a warning, the reason, and the workflow runs URL.
- Workflow run observation is less brittle by widening the created-at lower bound and increasing default verification attempts.
- Butler can stop treating accepted dispatch as a failed deploy and can direct the owner to GitHub Actions runtime truth.

## Unsatisfied Success Criteria

- Live confirmation of the new response shape requires this PR to be merged, deployed to Cloudflare, and exercised through Butler/passkey again.

## Verification Evidence

- `node --test test/worker.test.js test/deploy-production-plane.test.js`
- `npm test`

## Butler Completion Contract

- Owner goal: Prevent Butler from reporting a failed deploy when GitHub accepted the dispatch and the workflow run is merely not observed immediately.
- Butler entrypoint: `vtddDeployProduction` / `/v2/action/deploy` response after passkey-governed deploy dispatch.
- Action Schema exposure: No schema or operationId change; response fields are additive/changed runtime JSON.
- Runtime path: `src/core/deploy-production-plane.js` and `src/worker/runtime.js`.
- Runner/runtime truth: Full local `npm test` passed; live deploy run `25707459762` demonstrated the previous false negative condition.
- Authority boundary: No deploy, merge, issue close, repo variable mutation, or credential mutation performed by this PR.
- E2E evidence: Worker and deploy plane tests cover unobserved accepted dispatch returning 202 accepted/unverified instead of false failure.
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: Required after merge, because Worker runtime deploy response behavior changes.
- Custom GPT Action Schema: Not required; no operationId/path change.
- Custom GPT Instructions: Not required.
- Operator/runtime config: No new config required.
