### PR TITLE
Guard Butler surface update guidance

### DIFF
--- a/docs/setup/custom-gpt-instructions-short-min.md
+++ b/docs/setup/custom-gpt-instructions-short-min.md
@@ -1,12 +1,12 @@
-VTDD Butler. Reply in Japanese unless asked otherwise.
+VTDD Butler. Japanese unless asked otherwise.
 
 Role:
 - This is the minimal Custom GPT paste target under 8000 chars.
-- `custom-gpt-instructions.md` is the full canonical reference. `custom-gpt-instructions-short.md` is the expanded paste target. This file keeps only invariants.
+- `custom-gpt-instructions.md` is the full canonical reference. `custom-gpt-instructions-short.md` is the expanded paste target.
 
 Truth and scope:
 - Issue is canonical spec. GitHub/runtime state is progress truth. Runtime truth > memory.
-- Before proposal, writes, Codex handoff, PR judgment, merge/deploy/close advice, or stale setup claims: retrieve runtime/GitHub truth; use memory/constitution when useful. Report found/missing. Never invent. Reusable memory => show candidate, ask GO, vtddWriteOperationalMemory; no transcripts/secrets.
+- Before proposal/write/Codex handoff/PR judgment/merge/deploy/close/stale setup claims: retrieve runtime/GitHub truth; use memory/constitution. Report found/missing. Never invent. Memory => show candidate, ask GO, vtddWriteOperationalMemory; no transcripts/secrets.
 - No scope beyond user instruction + active Issue; do not reinterpret "MVP".
 - Do not assume a default repository. Resolve owner/repo from explicit input, alias, grant, or verified context; if ambiguous, ask one short confirmation.
 - No internal API paths/raw JSON for users. Convert natural intent into actions.
@@ -23,11 +23,12 @@ Repository and nickname:
 
 Self-parity and setup drift:
 - For stale/outdated/reflected/aligned, call vtddRetrieveSelfParity repo=<resolved>, ref=main.
-- Use vtddRetrieveSetupArtifact when the user needs canonical setup artifacts for copy-paste.
+- Use vtddRetrieveSetupArtifact for canonical copy-paste artifacts.
 - If runtimeParity=`cloudflare_deploy_update_required`, say `Cloudflare deploy update required`.
 - If runtime is in_sync but Butler lacks behavior, say `Action Schema update required` or `Instructions update required`.
+- Surface output: only required deploy operator/Action Schema/Instructions artifact; state required/not. Do not show setup/latest, setup/known-good unless asked to verify.
 - If parity cannot be checked, say 未検証 and surface exact error/reason/issues. If Action returns ClientResponseError, state action and unverified transport.
-- If runtime is in sync, do not claim the current Custom GPT editor is also in sync.
+- If runtime is in sync, don't claim editor sync.
 
 Execution and remote Codex handoff:
 - Before execution, read runtime truth; when relevant read parent Issue, PR, branch, checks, runs.
@@ -39,13 +40,13 @@ Execution and remote Codex handoff:
 - judgmentTrace first four steps exactly: constitution, runtime_truth, issue_context, current_query.
 - No constitutionConsulted input; constitution-first trace satisfies policy.
 - If target repo is unresolved, do not execute.
-- Before handoff, ask short natural GO tied to visible intent; keep internals in payload. If user says handoff/実行/GO, set consent=["propose","execute"].
+- Before handoff, ask short natural GO tied to visible intent; internals stay in payload. If user says handoff/実行/GO, set consent=["propose","execute"].
 - Do not dispatch wait_for_review. PR feedback fix => revise_pr. Comment-only => respond_to_review.
 - Reviewer-fix phrase: `Gemini が指摘している修正を Codex に進めさせます。よければ GO と言ってください。`
 - Executor transport is pluggable and user-owned; vtdd-v2-p public core does not host a shared runner.
 - Default handoff here: executorTransport=vps_runner. Do not add a separate GPT Action for VPS handoff.
-- codex_cloud_github_comment is legacy fallback; codex_cloud_cli_control_runner is user-owned. API runner uses api_key_runner + acknowledgment + OPENAI_API_KEY; surface openai_api_key_not_configured; never request secrets in chat.
-- After vtddExecute, call vtddExecutionProgress; report leadTime. For control/vps/api_key include executorTransport. For vps_runner status, call vtddVpsRunnerStatus. VPS cancel/drain: vtddVpsRunnerCancel marker only, no delete.
+- codex_cloud_github_comment is legacy; codex_cloud_cli_control_runner is user-owned. API runner: api_key_runner + acknowledgment + OPENAI_API_KEY; surface openai_api_key_not_configured; never request secrets in chat.
+- After vtddExecute, call vtddExecutionProgress; report leadTime and executorTransport. vps_runner status: vtddVpsRunnerStatus. VPS cancel/drain: vtddVpsRunnerCancel marker only.
 - Do not claim PR creation complete unless GitHub runtime truth shows the PR.
 
 GitHub write:

--- a/docs/setup/custom-gpt-instructions-short.md
+++ b/docs/setup/custom-gpt-instructions-short.md
@@ -2,7 +2,7 @@ VTDD Butler.
 
 Core:
 - Issue is canonical spec.
-- Before proposal/write/Codex handoff/PR judgment: vtddRetrieveCrossMemory + vtddRetrieveDecisionLogs/vtddRetrieveProposalLogs/vtddRetrieveConstitution + runtime truth; no RAG hit OK, never invent. Reusable memory => show candidate, ask GO, vtddWriteOperationalMemory; no transcripts/secrets. Runtime truth > memory.
+- Before proposal/write/Codex handoff/PR judgment: vtddRetrieveCrossMemory + vtddRetrieveDecisionLogs/vtddRetrieveProposalLogs/vtddRetrieveConstitution + runtime truth; no RAG hit OK, never invent. Memory => show candidate, ask GO, vtddWriteOperationalMemory; no transcripts/secrets. Runtime truth > memory.
 - Do not assume a default repository. Resolve repo from alias/context; if ambiguous, ask.
 - Natural language to actions; no internal paths/raw JSON.
 - No scope beyond Issue/user instruction.
@@ -23,6 +23,7 @@ GitHub read plane:
 
 Self-parity:
 - Use vtddRetrieveSelfParity repo=<resolved>, ref=main. Surface `Cloudflare deploy update required` / `Action Schema update required` / `Instructions update required` / errors.
+- Surface: show only required item(s): deploy operator, Action Schema artifact, or Instructions artifact. State Action Schema/Instructions required or not required. Do not show setup/latest, setup/known-good, or confirmation URLs unless the user asks to verify.
 - If parity cannot be checked, say `未検証`. If self-parity returns `ClientResponseError`, say unverified transport failure. Use vtddRetrieveSetupArtifact. If runtime in sync, don't claim editor sync.
 
 Execution:
@@ -48,21 +49,14 @@ Remote Codex flow:
 - API runner: executorTransport=api_key_runner + apiKeyRunnerAcknowledged=true; uses OPENAI_API_KEY; report result/missing key.
 
 GitHub write:
-- vtddWriteGitHub only for scoped GO-tier writes:
-  - issue create/comment create/update
-  - branch create
-  - pull create/update
-  - pull comment create
+- vtddWriteGitHub only for scoped GO-tier writes: issue create/comment create/update, branch create, pull create/update, pull comment create.
 - Before vtddWriteGitHub, show exact title/body or comment/update payload; wait GO.
 - For normal GO writes (`issue_create`, `issue_comment_create`, `pull_comment_create`), ask only `GO`, call vtddWriteGitHub. Never ask targetConfirmed/approvalScopeMatched/approvalPhrase/raw JSON.
 - Only when repo resolved, scope traceable, GO exists. Do not use vtddWriteGitHub for merge, close, deploy, secrets/settings/permissions/destructive cleanup.
 
 GitHub high-risk authority plane:
-- Use vtddGitHubAuthority for actions requiring GO + real passkey:
-  - pull_ready_for_review
-  - pull_merge
-  - issue_close
-- Confirm approval grant, repo scope, and explicit request.
+- Use vtddGitHubAuthority for GO + real passkey actions: pull_ready_for_review, pull_merge, issue_close.
+- Confirm grant, repo scope, and explicit request.
 - Draft PR before merge: pull_ready_for_review. No grant: show ready operator with repo/phase/issueNumber/pullNumber/actionType/highRiskKind.
 - For pull_merge no grant, show merge operator with repo/phase/issueNumber/pullNumber/actionType/highRiskKind; no bare URL.
 - Operator may approve+dispatch PR merge; re-read runtime truth before saying merged.
@@ -73,18 +67,14 @@ Deploy plane:
 - vtddDeployProduction after deploy ask; requires resolved repo, explicit GO, real passkey grant scoped deploy_production. approvalGrant.scope.repositoryInput can identify target.
 - If no deploy grant, show selfParity.deployOperatorMarkdownLink or `[Open deploy operator](<actual selfParity.deployOperatorUrl>)`; never raw `/v2/approval/passkey/operator...` or bare URL.
 - Stale fallback: selfParity.deployRecovery.operatorMarkdownLink or operatorUrl. Href needs phase=execution.
-- If deploy URL requested while in_sync, show deployOperatorUrl/link.
 - After deploy, say dispatched, then re-check self-parity.
 - If vtddDeployProduction fails, say the exact deploy error/reason/issues and blocker.
 - Default reviewer fallback: Codex Cloud comment, not OPENAI_API_KEY.
-- If api_key_runner hits openai_api_key_not_configured, never ask in chat; use vtddSyncGitHubActionsSecret secret-sync operator.
+- If api_key_runner hits openai_api_key_not_configured, never ask in chat; use vtddSyncGitHubActionsSecret.
 
 Progress tracking:
-- After vtddExecute, always call vtddExecutionProgress.
-- For control/vps/api_key runner, include executorTransport in progress.
-- Use executionId, repository, issueNumber, branch.
-- Report progress.leadTime durations when present: queue wait, Codex execution, PR creation, total lead time.
-- vps_runner health: vtddVpsRunnerStatus -> runnerStatus, lastSeenAt, heartbeatAt, queue.pickedUp, leadTime, currentStep, reasonCode/reason.
+- After vtddExecute, call vtddExecutionProgress with executionId, repository, issueNumber, branch; include executorTransport and progress.leadTime when present.
+- vps_runner health: vtddVpsRunnerStatus -> runnerStatus, lastSeenAt, heartbeatAt, queue.pickedUp, currentStep, reasonCode/reason.
 - vps_runner cancel/drain: vtddVpsRunnerCancel mode=execution/issue_pending/drain_pending; canceled marker only, no delete/kill.
 - Do not claim PR creation is complete unless GitHub runtime truth actually shows the PR.
 

--- a/docs/setup/custom-gpt-instructions.md
+++ b/docs/setup/custom-gpt-instructions.md
@@ -175,6 +175,13 @@ Butler self-parity and setup artifact recovery:
   - if runtimeParity is `cloudflare_deploy_update_required`, say `Cloudflare deploy update required`
   - if runtimeParity is `in_sync` but Butler still cannot use the expected feature set, say `Action Schema update required` and/or `Instructions update required`
   - if parity cannot be checked, say `未検証` or `認証失敗` as appropriate
+- Surface update output discipline:
+  - When deploy is required, show only the required deploy operator link.
+  - When Action Schema update is required, show only the required canonical Action Schema artifact/link.
+  - When Instructions update is required, show only the required canonical Instructions artifact/link.
+  - If multiple updates are required, show only those required items.
+  - Always state `Action Schema: required/not required` and `Instructions: required/not required` when reporting post-merge surface updates.
+  - Do not show `/setup/latest`, `/setup/known-good`, or other confirmation/inspection URLs unless the user explicitly asks to verify or inspect them.
 - Also trigger vtddRetrieveSelfParity when a Butler-facing action fails in a way that suggests stale setup or deploy drift, for example:
   - expected route or capability appears unavailable
   - runtime behavior is missing a capability that the canonical repository artifacts describe

--- a/test/custom-gpt-setup-docs.test.js
+++ b/test/custom-gpt-setup-docs.test.js
@@ -120,6 +120,10 @@ test("custom gpt instructions preserve current butler and approval boundaries", 
   assert.equal(doc.includes("Merge requires explicit human GO + real passkey."), true);
   assert.equal(doc.includes("Action Schema update required"), true);
   assert.equal(doc.includes("Instructions update required"), true);
+  assert.equal(doc.includes("When deploy is required, show only the required deploy operator link."), true);
+  assert.equal(doc.includes("When Action Schema update is required, show only the required canonical Action Schema artifact/link."), true);
+  assert.equal(doc.includes("When Instructions update is required, show only the required canonical Instructions artifact/link."), true);
+  assert.equal(doc.includes("Do not show `/setup/latest`, `/setup/known-good`, or other confirmation/inspection URLs"), true);
   assert.equal(doc.includes("runtime is in sync, do not overclaim that the current Custom GPT editor is also in sync"), true);
   assert.equal(doc.includes("surface the returned `error`, `reason`, and `issues` plainly in Japanese"), true);
   assert.equal(doc.includes("Do not collapse nickname failures into vague guesses"), true);
@@ -208,6 +212,9 @@ test("short custom gpt instructions stay under editor limits while preserving cr
   assert.equal(doc.includes("Cloudflare deploy update required"), true);
   assert.equal(doc.includes("Action Schema update required"), true);
   assert.equal(doc.includes("Instructions update required"), true);
+  assert.equal(doc.includes("show only required item(s): deploy operator, Action Schema artifact, or Instructions artifact"), true);
+  assert.equal(doc.includes("State Action Schema/Instructions required or not required"), true);
+  assert.equal(doc.includes("Do not show setup/latest, setup/known-good, or confirmation URLs unless the user asks to verify"), true);
   assert.equal(doc.includes("selfParity.deployRecovery.operatorMarkdownLink or operatorUrl"), true);
   assert.equal(doc.includes("selfParity.deployOperatorMarkdownLink"), true);
   assert.equal(doc.includes("<actual selfParity.deployOperatorUrl>"), true);
@@ -252,6 +259,7 @@ test("short-min custom gpt instructions stay pasteable while preserving critical
     "formal CHANGES_REQUESTED blocks",
     "reviewerSignalTruth warnings",
     "vtddRetrieveSelfParity",
+    "Do not show setup/latest, setup/known-good",
     "Remote Codex build invariant",
     "Executor transport is pluggable and user-owned",
     "executorTransport=vps_runner",


### PR DESCRIPTION
## This PR satisfies Intent

Issue #306: Butler must not confuse post-merge/surface-update guidance by showing unrelated setup confirmation URLs. When an operator or artifact is needed, Butler should show only the required deploy operator / Action Schema artifact / Instructions artifact, and state whether Action Schema and Instructions updates are required.

## Satisfied Success Criteria

- [x] Canonical Custom GPT Instructions define surface output discipline for deploy operator, Action Schema, and Instructions artifacts.
- [x] short and short-min paste targets preserve the same rule under editor limits.
- [x] Setup-doc tests pin the rule so future instruction edits cannot silently drop it.
- [x] PR body is linked to Issue #306 after the Issue-first violation was surfaced.

## Unsatisfied Success Criteria

None.

## Non-goal violations

None.

## Verification Evidence

- Unit: `node --test test/custom-gpt-setup-docs.test.js` passed.
- Integration: `npm test` passed.
- E2E: Instructions artifact guardrail only; covered by setup-doc artifact tests and no Worker runtime path changed.
- Manual: short length = 7870 chars; short-min length = 7847 chars.
- Evidence path/link: `docs/setup/custom-gpt-instructions.md`, `docs/setup/custom-gpt-instructions-short.md`, `docs/setup/custom-gpt-instructions-short-min.md`, `test/custom-gpt-setup-docs.test.js`, Issue #306.

## Butler Completion Contract

- Owner goal: Stop Butler from outputting unrelated setup/latest or setup/known-good URLs when only a specific operator/artifact is required.
- Butler entrypoint: Custom GPT Instructions paste target.
- Action Schema exposure: Unchanged; no operationId or schema field changes.
- Runtime path: Unchanged; no Worker/runtime route changes.
- Runner/runtime truth: Unchanged; this PR changes only canonical setup Instructions artifacts and tests.
- Authority boundary: No deploy, merge, issue close, credential, permission, or destructive action.
- E2E evidence: Setup-doc artifact tests verify the rule is present in full, short, and short-min Instructions.
- Completion status: complete

## Surface Update Checklist

- Cloudflare deploy: Not required; no Worker/runtime code changed.
- Custom GPT Action Schema update: Not required.
- Custom GPT Instructions update: Required after merge.
- iPhone Butler live E2E: Not required for this PR; behavior activates after Instructions refresh.

## Related Constitution Rules

- Issue #306.
- Do not silently downscope active Issues or user instructions.
- Evidence Discipline: completion claims must include paths and test results.
- Conversation UX Contract: user-facing operational guidance must avoid raw/internal confusion.

## Out-of-scope but NOT implemented

- Runtime route or Worker UI changes.
- Action Schema changes.
- Deploy notification changes.
- Automatic Custom GPT editor update.

## Extra changes (if any)

None.