### PR TITLE
Separate latest and known-good setup pages

### DIFF
--- a/docs/mvp/production-deploy-path.md
+++ b/docs/mvp/production-deploy-path.md
@@ -58,10 +58,18 @@ such as `wrangler.production.local.toml`. For GitHub Actions deploys, store the
 D1 database id in `CLOUDFLARE_D1_DATABASE_ID`; the workflow generates an
 uncommitted `wrangler.production.generated.toml` at deploy time.
 
-If `/setup/known-good` should expose a rollback bundle, set repository variable
-`VTDD_KNOWN_GOOD_COMMIT_SHA` to the last human-verified stable setup commit
-before dispatching production deploy. If this variable is absent, the Worker
-must not silently treat `main` as known-good.
+When Action Schema or Custom GPT Instructions are updated, `/setup/known-good`
+is the rollback bundle for the previous working setup artifacts. Set repository
+variable `VTDD_KNOWN_GOOD_COMMIT_SHA` to the last human-verified working setup
+commit before dispatching the production deploy that promotes new
+`/setup/latest` artifacts. If this variable is absent, the Worker must not
+silently treat `main` as known-good.
+
+`/setup/latest` and `/setup/known-good` are always valid recovery surfaces to
+open on request. `latest` shows the current update candidate only; it must not
+mix in known-good rollback bundle content. `known-good` shows the previous
+working rollback bundle when `VTDD_KNOWN_GOOD_COMMIT_SHA` is configured, and
+otherwise reports that known-good is unavailable.
 
 If production deploy completion should notify the operator through GitHub
 Mobile / Apple Watch, set repository variable

--- a/src/core/custom-gpt-setup-artifacts.js
+++ b/src/core/custom-gpt-setup-artifacts.js
@@ -411,7 +411,7 @@ export async function buildCustomGptRecoveryBundle(input = {}) {
       ? knownGoodCommit?.sha || requestedRef
       : requestedRef;
 
-  const [openapi, instructionsShortMin, selfParity, latestCommit] = await Promise.all([
+  const [openapi, instructionsShortMin, selfParity] = await Promise.all([
     retrieveCustomGptSetupArtifact({
       artifact: CustomGptSetupArtifact.OPENAPI_YAML,
       repository,
@@ -430,10 +430,7 @@ export async function buildCustomGptRecoveryBundle(input = {}) {
       runtimeOrigin,
       issueNumber,
       env
-    }),
-    channel === CustomGptSetupChannel.LATEST
-      ? resolveKnownGoodCommitSha({ repository, ref, env })
-      : Promise.resolve(null)
+    })
   ]);
 
   const failed = [openapi, instructionsShortMin, selfParity].find((result) => !result.ok);
@@ -479,27 +476,24 @@ export async function buildCustomGptRecoveryBundle(input = {}) {
         limitExceeded: instructionsLimitExceeded,
         content: instructions
       },
-      rollback: {
-        knownGoodCommitSha:
-          channel === CustomGptSetupChannel.KNOWN_GOOD
-            ? knownGoodCommit?.sha
-            : latestCommit?.sha,
-        knownGoodCommitSource:
-          channel === CustomGptSetupChannel.KNOWN_GOOD
-            ? knownGoodCommit?.source
-            : latestCommit?.source,
-        rollbackReady: channel === CustomGptSetupChannel.KNOWN_GOOD,
-        bundleArtifacts: [
-          openapi.artifact.path,
-          instructionsShortMin.artifact.path
-        ],
-        restoreOrder: [
-          "Copy Action Schema into the Custom GPT Action Schema editor.",
-          "Copy short-min instructions into the Custom GPT Instructions editor.",
-          "Confirm the Action Schema server URL matches this Worker origin.",
-          "Run /health directly from the browser before relying on Butler Actions."
-        ]
-      },
+      rollback:
+        channel === CustomGptSetupChannel.KNOWN_GOOD
+          ? {
+              knownGoodCommitSha: knownGoodCommit?.sha,
+              knownGoodCommitSource: knownGoodCommit?.source,
+              rollbackReady: true,
+              bundleArtifacts: [
+                openapi.artifact.path,
+                instructionsShortMin.artifact.path
+              ],
+              restoreOrder: [
+                "Copy Action Schema into the Custom GPT Action Schema editor.",
+                "Copy short-min instructions into the Custom GPT Instructions editor.",
+                "Confirm the Action Schema server URL matches this Worker origin.",
+                "Run /health directly from the browser before relying on Butler Actions."
+              ]
+            }
+          : null,
       runtime: {
         selfParity: selfParity.selfParity,
         deployState: selfParity.selfParity.runtimeParity
@@ -635,49 +629,6 @@ function resolveConfiguredKnownGoodCommitSha({ ref, env }) {
   return { sha: null, source: "unconfigured" };
 }
 
-async function resolveKnownGoodCommitSha({ repository, ref, env }) {
-  const configured = normalizeText(env?.[KNOWN_GOOD_COMMIT_ENV]);
-  if (configured) {
-    return { sha: configured, source: KNOWN_GOOD_COMMIT_ENV };
-  }
-
-  if (/^[a-f0-9]{40}$/i.test(ref)) {
-    return { sha: ref, source: "ref" };
-  }
-
-  const fetchImpl = typeof env?.GITHUB_API_FETCH === "function" ? env.GITHUB_API_FETCH.bind(env) : fetch;
-  const apiBaseUrl = normalizeApiBaseUrl(env?.GITHUB_API_BASE_URL);
-  const tokenResolution = await resolveGitHubAppInstallationToken({ env, fetchImpl, apiBaseUrl });
-  if (!tokenResolution.ok) {
-    return { sha: null, source: "unverified" };
-  }
-
-  try {
-    const response = await fetchImpl(
-      `${apiBaseUrl}/repos/${encodeRepository(repository)}/commits/${encodeURIComponent(ref)}`,
-      {
-        method: "GET",
-        headers: {
-          authorization: `Bearer ${tokenResolution.token}`,
-          accept: "application/vnd.github+json",
-          "x-github-api-version": GITHUB_API_VERSION,
-          "user-agent": GITHUB_API_USER_AGENT
-        }
-      }
-    );
-    const body = await readJsonSafe(response);
-    if (!response.ok) {
-      return { sha: null, source: "unverified" };
-    }
-    return {
-      sha: normalizeText(body?.sha) || null,
-      source: "github_commit_ref"
-    };
-  } catch {
-    return { sha: null, source: "unverified" };
-  }
-}
-
 function expandOpenApiServerUrl(content, runtimeOrigin) {
   const expanded = content.replace(
     /(^servers:\n\s*-\s*url:\s*)([^\n]+)$/m,
@@ -706,7 +657,11 @@ function renderRecoveryBundleSections(recovery) {
         <div><strong>Worker URL</strong><br>${escapeHtml(recovery.runtimeOrigin)}</div>
         <div><strong>Repository</strong><br>${escapeHtml(recovery.repository)}</div>
         <div><strong>${recovery.channel === CustomGptSetupChannel.KNOWN_GOOD ? "Known-good ref" : "Latest ref"}</strong><br>${escapeHtml(recovery.ref)}</div>
-        <div><strong>Known-good commit</strong><br>${escapeHtml(rollback.knownGoodCommitSha || "unverified")}</div>
+        ${
+          rollback
+            ? `<div><strong>Known-good commit</strong><br>${escapeHtml(rollback.knownGoodCommitSha || "unverified")}</div>`
+            : `<div><strong>Rollback</strong><br>Use setup/known-good only when reverting to the previous working artifacts.</div>`
+        }
         <div><strong>Self-parity</strong><br>${escapeHtml(selfParity.runtimeParity)}</div>
         <div><strong>Deploy state</strong><br>${escapeHtml(recovery.runtime.deployState)}</div>
         <div><strong>short-min length</strong><br>${instructions.characterCount} / ${instructions.characterLimit}</div>
@@ -725,31 +680,12 @@ function renderRecoveryBundleSections(recovery) {
       <p><button type="button" data-copy-target="instructions-short-min" data-copy-label="Copy Instructions">Copy Instructions</button></p>
       <textarea id="instructions-short-min" spellcheck="false">${escapeHtml(instructions.content)}</textarea>
     </section>
-    <section>
-      <h2>Known-good rollback bundle</h2>
-      ${
-        rollback.rollbackReady
-          ? `<p><button type="button" data-copy-target="rollback-bundle" data-copy-label="Copy Rollback Bundle">Copy Rollback Bundle</button></p>`
-          : `<p class="small">Rollback は setup/known-good で copy-ready になります。latest は現在の候補確認用です。</p>`
-      }
-      <pre>${escapeHtml(
-        [
-          `repository: ${recovery.repository}`,
-          `channel: ${recovery.channel}`,
-          `ref: ${recovery.ref}`,
-          `knownGoodCommitSha: ${rollback.knownGoodCommitSha || "unverified"}`,
-          `knownGoodCommitSource: ${rollback.knownGoodCommitSource}`,
-          `actionSchemaPath: ${actionSchema.path}`,
-          `instructionsShortMinPath: ${instructions.path}`,
-          `selfParity: ${selfParity.runtimeParity}`,
-          `deployState: ${recovery.runtime.deployState}`,
-          "restoreOrder:",
-          ...rollback.restoreOrder.map((item, index) => `  ${index + 1}. ${item}`)
-        ].join("\n")
-      )}</pre>
-      ${
-        rollback.rollbackReady
-          ? `<textarea id="rollback-bundle" spellcheck="false">${escapeHtml(
+    ${
+      rollback
+        ? `<section>
+            <h2>Known-good rollback bundle</h2>
+            <p><button type="button" data-copy-target="rollback-bundle" data-copy-label="Copy Rollback Bundle">Copy Rollback Bundle</button></p>
+            <pre>${escapeHtml(
               [
                 `repository: ${recovery.repository}`,
                 `channel: ${recovery.channel}`,
@@ -763,10 +699,28 @@ function renderRecoveryBundleSections(recovery) {
                 "restoreOrder:",
                 ...rollback.restoreOrder.map((item, index) => `  ${index + 1}. ${item}`)
               ].join("\n")
-            )}</textarea>`
-          : ""
-      }
-    </section>`;
+            )}</pre>
+            <textarea id="rollback-bundle" spellcheck="false">${escapeHtml(
+              [
+                `repository: ${recovery.repository}`,
+                `channel: ${recovery.channel}`,
+                `ref: ${recovery.ref}`,
+                `knownGoodCommitSha: ${rollback.knownGoodCommitSha || "unverified"}`,
+                `knownGoodCommitSource: ${rollback.knownGoodCommitSource}`,
+                `actionSchemaPath: ${actionSchema.path}`,
+                `instructionsShortMinPath: ${instructions.path}`,
+                `selfParity: ${selfParity.runtimeParity}`,
+                `deployState: ${recovery.runtime.deployState}`,
+                "restoreOrder:",
+                ...rollback.restoreOrder.map((item, index) => `  ${index + 1}. ${item}`)
+              ].join("\n")
+            )}</textarea>
+          </section>`
+        : `<section>
+            <h2>Latest candidate only</h2>
+            <p class="small">setup/latest は更新候補だけを表示します。期待通りに動かなかった場合は setup/known-good から直前の動作済み Action Schema / Instructions に戻してください。</p>
+          </section>`
+    }`;
 }
 
 function normalizeSetupChannel(value) {

--- a/test/custom-gpt-setup-artifacts.test.js
+++ b/test/custom-gpt-setup-artifacts.test.js
@@ -306,12 +306,7 @@ test("buildCustomGptRecoveryBundle expands Worker URL and reports short-min leng
       GITHUB_APP_INSTALLATION_TOKEN: "ghs_setup_read",
       GITHUB_API_FETCH: async (url) => {
         const parsed = new URL(url);
-        if (parsed.pathname.endsWith("/commits/main")) {
-          return new Response(JSON.stringify({ sha: "a".repeat(40) }), {
-            status: 200,
-            headers: { "content-type": "application/json" }
-          });
-        }
+        assert.equal(parsed.pathname.endsWith("/commits/main"), false);
         const isShortMin = parsed.pathname.endsWith(
           "/docs/setup/custom-gpt-instructions-short-min.md"
         );
@@ -340,7 +335,7 @@ test("buildCustomGptRecoveryBundle expands Worker URL and reports short-min leng
   assert.equal(result.recovery.actionSchema.serverUrl, "https://sample-user-vtdd.example.workers.dev");
   assert.equal(result.recovery.instructionsShortMin.characterCount, shortMin.length);
   assert.equal(result.recovery.instructionsShortMin.limitExceeded, false);
-  assert.equal(result.recovery.rollback.knownGoodCommitSha, "a".repeat(40));
+  assert.equal(result.recovery.rollback, null);
   assert.equal(result.recovery.runtime.deployState, "in_sync");
   assert.deepEqual(result.recovery.safety, {
     displaysSecrets: false,

--- a/test/production-deploy-path.test.js
+++ b/test/production-deploy-path.test.js
@@ -40,7 +40,12 @@ test("production deploy doc defines the governed GitHub Actions deploy path", ()
   assert.equal(doc.includes("`wrangler.production.local.toml`"), true);
   assert.equal(doc.includes("`wrangler.production.generated.toml`"), true);
   assert.equal(doc.includes("`VTDD_KNOWN_GOOD_COMMIT_SHA`"), true);
-  assert.equal(doc.includes("must not silently treat `main` as known-good"), true);
+  assert.equal(doc.includes("rollback bundle for the previous working setup artifacts"), true);
+  assert.equal(doc.includes("last human-verified working setup"), true);
+  assert.match(doc, /must not\s+silently treat `main` as known-good/);
+  assert.equal(doc.includes("always valid recovery surfaces to"), true);
+  assert.equal(doc.includes("latest` shows the current update candidate only"), true);
+  assert.equal(doc.includes("must not\nmix in known-good rollback bundle content"), true);
   assert.equal(doc.includes("`VTDD_DEPLOY_NOTIFICATION_ISSUE_NUMBER`"), true);
   assert.equal(doc.includes("mentions the repository owner"), true);
   assert.equal(doc.includes("intentionally omits approval"), true);

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -170,12 +170,7 @@ test("worker setup latest page renders copy-ready schema and short-min bundle fo
       GITHUB_API_FETCH: async (url) => {
         const parsed = new URL(url);
         assert.equal(parsed.pathname.startsWith("/repos/marushu/vtdd-v2-p/"), true);
-        if (parsed.pathname.endsWith("/commits/main")) {
-          return new Response(JSON.stringify({ sha: "b".repeat(40) }), {
-            status: 200,
-            headers: { "content-type": "application/json" }
-          });
-        }
+        assert.equal(parsed.pathname.endsWith("/commits/main"), false);
         const isShortMin = parsed.pathname.endsWith(
           "/docs/setup/custom-gpt-instructions-short-min.md"
         );
@@ -199,12 +194,16 @@ test("worker setup latest page renders copy-ready schema and short-min bundle fo
   const html = await response.text();
   assert.equal(html.includes("latest setup bundle"), true);
   assert.equal(html.includes("Recovery repo: marushu/vtdd-v2-p"), true);
+  assert.equal(html.includes('href="/setup/latest"'), true);
+  assert.equal(html.includes('href="/setup/known-good"'), true);
   assert.equal(html.includes("Copy-ready Action Schema"), true);
   assert.equal(html.includes("Copy-ready custom-gpt-instructions-short-min.md"), true);
   assert.equal(html.includes("  - url: https://example.com"), true);
   assert.equal(html.includes("VTDD Butler short-min instructions"), true);
-  assert.equal(html.includes("knownGoodCommitSha: " + "b".repeat(40)), true);
-  assert.equal(html.includes("Rollback は setup/known-good で copy-ready になります。latest は現在の候補確認用です。"), true);
+  assert.equal(html.includes("Known-good rollback bundle"), false);
+  assert.equal(html.includes("knownGoodCommitSha:"), false);
+  assert.equal(html.includes("Latest candidate only"), true);
+  assert.equal(html.includes("setup/latest は更新候補だけを表示します"), true);
   assert.equal(html.includes("No secret values, tokens, or approval grants are displayed."), true);
   assert.equal(html.includes("ghs_setup_read"), false);
 });
@@ -263,6 +262,8 @@ test("worker setup known-good page renders rollback copy-ready bundle from known
   assert.equal(response.status, 200);
   const html = await response.text();
   assert.equal(html.includes("known-good setup bundle"), true);
+  assert.equal(html.includes('href="/setup/latest"'), true);
+  assert.equal(html.includes('href="/setup/known-good"'), true);
   assert.equal(html.includes("Copy Rollback Bundle"), true);
   assert.equal(html.includes(`channel: known_good`), true);
   assert.equal(html.includes(`ref: ${knownGoodSha}`), true);

--- a/worker.js
+++ b/worker.js
@@ -28784,7 +28784,7 @@ async function buildCustomGptRecoveryBundle(input = {}) {
     };
   }
   const ref = channel === CustomGptSetupChannel.KNOWN_GOOD ? knownGoodCommit?.sha || requestedRef : requestedRef;
-  const [openapi, instructionsShortMin, selfParity, latestCommit] = await Promise.all([
+  const [openapi, instructionsShortMin, selfParity] = await Promise.all([
     retrieveCustomGptSetupArtifact({
       artifact: CustomGptSetupArtifact.OPENAPI_YAML,
       repository,
@@ -28803,8 +28803,7 @@ async function buildCustomGptRecoveryBundle(input = {}) {
       runtimeOrigin,
       issueNumber,
       env
-    }),
-    channel === CustomGptSetupChannel.LATEST ? resolveKnownGoodCommitSha({ repository, ref, env }) : Promise.resolve(null)
+    })
   ]);
   const failed = [openapi, instructionsShortMin, selfParity].find((result) => !result.ok);
   if (failed) {
@@ -28846,10 +28845,10 @@ async function buildCustomGptRecoveryBundle(input = {}) {
         limitExceeded: instructionsLimitExceeded,
         content: instructions
       },
-      rollback: {
-        knownGoodCommitSha: channel === CustomGptSetupChannel.KNOWN_GOOD ? knownGoodCommit?.sha : latestCommit?.sha,
-        knownGoodCommitSource: channel === CustomGptSetupChannel.KNOWN_GOOD ? knownGoodCommit?.source : latestCommit?.source,
-        rollbackReady: channel === CustomGptSetupChannel.KNOWN_GOOD,
+      rollback: channel === CustomGptSetupChannel.KNOWN_GOOD ? {
+        knownGoodCommitSha: knownGoodCommit?.sha,
+        knownGoodCommitSource: knownGoodCommit?.source,
+        rollbackReady: true,
         bundleArtifacts: [
           openapi.artifact.path,
           instructionsShortMin.artifact.path
@@ -28860,7 +28859,7 @@ async function buildCustomGptRecoveryBundle(input = {}) {
           "Confirm the Action Schema server URL matches this Worker origin.",
           "Run /health directly from the browser before relying on Butler Actions."
         ]
-      },
+      } : null,
       runtime: {
         selfParity: selfParity.selfParity,
         deployState: selfParity.selfParity.runtimeParity
@@ -28980,45 +28979,6 @@ function resolveConfiguredKnownGoodCommitSha({ ref, env }) {
   }
   return { sha: null, source: "unconfigured" };
 }
-async function resolveKnownGoodCommitSha({ repository, ref, env }) {
-  const configured = normalizeText24(env?.[KNOWN_GOOD_COMMIT_ENV]);
-  if (configured) {
-    return { sha: configured, source: KNOWN_GOOD_COMMIT_ENV };
-  }
-  if (/^[a-f0-9]{40}$/i.test(ref)) {
-    return { sha: ref, source: "ref" };
-  }
-  const fetchImpl = typeof env?.GITHUB_API_FETCH === "function" ? env.GITHUB_API_FETCH.bind(env) : fetch;
-  const apiBaseUrl = normalizeApiBaseUrl4(env?.GITHUB_API_BASE_URL);
-  const tokenResolution = await resolveGitHubAppInstallationToken({ env, fetchImpl, apiBaseUrl });
-  if (!tokenResolution.ok) {
-    return { sha: null, source: "unverified" };
-  }
-  try {
-    const response = await fetchImpl(
-      `${apiBaseUrl}/repos/${encodeRepository(repository)}/commits/${encodeURIComponent(ref)}`,
-      {
-        method: "GET",
-        headers: {
-          authorization: `Bearer ${tokenResolution.token}`,
-          accept: "application/vnd.github+json",
-          "x-github-api-version": GITHUB_API_VERSION4,
-          "user-agent": GITHUB_API_USER_AGENT4
-        }
-      }
-    );
-    const body = await readJsonSafe5(response);
-    if (!response.ok) {
-      return { sha: null, source: "unverified" };
-    }
-    return {
-      sha: normalizeText24(body?.sha) || null,
-      source: "github_commit_ref"
-    };
-  } catch {
-    return { sha: null, source: "unverified" };
-  }
-}
 function expandOpenApiServerUrl(content, runtimeOrigin) {
   const expanded = content.replace(
     /(^servers:\n\s*-\s*url:\s*)([^\n]+)$/m,
@@ -29043,7 +29003,7 @@ function renderRecoveryBundleSections(recovery) {
         <div><strong>Worker URL</strong><br>${escapeHtml2(recovery.runtimeOrigin)}</div>
         <div><strong>Repository</strong><br>${escapeHtml2(recovery.repository)}</div>
         <div><strong>${recovery.channel === CustomGptSetupChannel.KNOWN_GOOD ? "Known-good ref" : "Latest ref"}</strong><br>${escapeHtml2(recovery.ref)}</div>
-        <div><strong>Known-good commit</strong><br>${escapeHtml2(rollback.knownGoodCommitSha || "unverified")}</div>
+        ${rollback ? `<div><strong>Known-good commit</strong><br>${escapeHtml2(rollback.knownGoodCommitSha || "unverified")}</div>` : `<div><strong>Rollback</strong><br>Use setup/known-good only when reverting to the previous working artifacts.</div>`}
         <div><strong>Self-parity</strong><br>${escapeHtml2(selfParity.runtimeParity)}</div>
         <div><strong>Deploy state</strong><br>${escapeHtml2(recovery.runtime.deployState)}</div>
         <div><strong>short-min length</strong><br>${instructions.characterCount} / ${instructions.characterLimit}</div>
@@ -29062,10 +29022,10 @@ function renderRecoveryBundleSections(recovery) {
       <p><button type="button" data-copy-target="instructions-short-min" data-copy-label="Copy Instructions">Copy Instructions</button></p>
       <textarea id="instructions-short-min" spellcheck="false">${escapeHtml2(instructions.content)}</textarea>
     </section>
-    <section>
-      <h2>Known-good rollback bundle</h2>
-      ${rollback.rollbackReady ? `<p><button type="button" data-copy-target="rollback-bundle" data-copy-label="Copy Rollback Bundle">Copy Rollback Bundle</button></p>` : `<p class="small">Rollback \u306F setup/known-good \u3067 copy-ready \u306B\u306A\u308A\u307E\u3059\u3002latest \u306F\u73FE\u5728\u306E\u5019\u88DC\u78BA\u8A8D\u7528\u3067\u3059\u3002</p>`}
-      <pre>${escapeHtml2(
+    ${rollback ? `<section>
+            <h2>Known-good rollback bundle</h2>
+            <p><button type="button" data-copy-target="rollback-bundle" data-copy-label="Copy Rollback Bundle">Copy Rollback Bundle</button></p>
+            <pre>${escapeHtml2(
     [
       `repository: ${recovery.repository}`,
       `channel: ${recovery.channel}`,
@@ -29080,7 +29040,7 @@ function renderRecoveryBundleSections(recovery) {
       ...rollback.restoreOrder.map((item, index) => `  ${index + 1}. ${item}`)
     ].join("\n")
   )}</pre>
-      ${rollback.rollbackReady ? `<textarea id="rollback-bundle" spellcheck="false">${escapeHtml2(
+            <textarea id="rollback-bundle" spellcheck="false">${escapeHtml2(
     [
       `repository: ${recovery.repository}`,
       `channel: ${recovery.channel}`,
@@ -29094,8 +29054,11 @@ function renderRecoveryBundleSections(recovery) {
       "restoreOrder:",
       ...rollback.restoreOrder.map((item, index) => `  ${index + 1}. ${item}`)
     ].join("\n")
-  )}</textarea>` : ""}
-    </section>`;
+  )}</textarea>
+          </section>` : `<section>
+            <h2>Latest candidate only</h2>
+            <p class="small">setup/latest \u306F\u66F4\u65B0\u5019\u88DC\u3060\u3051\u3092\u8868\u793A\u3057\u307E\u3059\u3002\u671F\u5F85\u901A\u308A\u306B\u52D5\u304B\u306A\u304B\u3063\u305F\u5834\u5408\u306F setup/known-good \u304B\u3089\u76F4\u524D\u306E\u52D5\u4F5C\u6E08\u307F Action Schema / Instructions \u306B\u623B\u3057\u3066\u304F\u3060\u3055\u3044\u3002</p>
+          </section>`}`;
 }
 function normalizeSetupChannel(value) {
   const normalized = normalizeText24(value).replace(/-/g, "_");


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #305: keep `/setup/latest` as the current Action Schema / Instructions update candidate and `/setup/known-good` as the previous working rollback bundle, while keeping both recovery URLs available on request.

## Satisfied Success Criteria

- `/setup/latest` no longer resolves or displays known-good rollback metadata.
- `/setup/latest` shows only latest copy-ready Action Schema and Instructions plus a latest-candidate note.
- `/setup/known-good` still renders the rollback copy-ready bundle from `VTDD_KNOWN_GOOD_COMMIT_SHA`.
- Both `/setup/latest` and `/setup/known-good` links remain visible from the setup page.
- Production deploy docs describe known-good as previous working artifacts, not a fixed stable release.

## Unsatisfied Success Criteria

- Repository variable `VTDD_KNOWN_GOOD_COMMIT_SHA` still must be set separately before deployed `/setup/known-good` can return a configured rollback bundle.
- Live deployed Worker verification is pending until merge and deploy.

## Non-goal violations

None.

## Verification Evidence

- Unit: `node --test test/custom-gpt-setup-artifacts.test.js test/worker.test.js test/production-deploy-path.test.js` passed.
- Integration: `npm test` passed, including `check:self-parity` and `check:generated-worker` after committing regenerated `worker.js`.
- E2E: Worker setup page tests cover latest without known-good content, known-good rollback bundle, and unavailable known-good without main fallback.
- Manual: Issue #305 was updated with the owner clarification: `/setup/latest` and `/setup/known-good` are always requestable recovery URLs; latest is candidate, known-good is rollback.
- Evidence path/link: `src/core/custom-gpt-setup-artifacts.js`; `worker.js`; `test/worker.test.js`; `test/custom-gpt-setup-artifacts.test.js`; `test/production-deploy-path.test.js`; `docs/mvp/production-deploy-path.md`; https://github.com/marushu/vtdd-v2-p/issues/305

## Butler Completion Contract

- Owner goal: Make `/setup/latest` safe as an update candidate and `/setup/known-good` safe as the previous working rollback point for Action Schema / Instructions.
- Butler entrypoint: Worker setup recovery pages `/setup/latest` and `/setup/known-good`, surfaced by Butler/Codex when explicitly asked.
- Action Schema exposure: Not changed; no operationId or Action Schema contract changes.
- Runtime path: `src/core/custom-gpt-setup-artifacts.js` renders setup recovery bundles; `worker.js` regenerated from source.
- Runner/runtime truth: Local Worker tests verify latest and known-good page behavior; live deployed Worker remains pending until merge/deploy.
- Authority boundary: No deploy, merge, issue close, credential, permission, repository variable mutation, or destructive action.
- E2E evidence: Automated Worker setup page tests verify the Butler-facing copy-ready pages. Live iPhone Butler verification is pending after deploy.
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: Required after merge because Worker runtime/page rendering changed.
- Custom GPT Action Schema update: Not required.
- Custom GPT Instructions update: Not required.
- iPhone Butler live E2E: Required after deploy: ask Butler/Codex for `/setup/latest` and `/setup/known-good` URLs and verify latest does not include known-good rollback content.

## Related Constitution Rules

- Issue is canonical spec.
- Action Schema / Instructions are Butler life-line artifacts.
- High-risk repo variable mutation requires GO + passkey or manual owner action.
- Do not silently treat main as known-good.

## Out-of-scope but NOT implemented

- Setting `VTDD_KNOWN_GOOD_COMMIT_SHA`.
- Changing Action Schema or Custom GPT Instructions.
- Deploying the Worker.
- Automatic Custom GPT editor updates.

## Extra changes (if any)

Updated Issue #305 text to capture the owner clarification before opening this PR.

<!-- VTDD metadata -->
- Issue: #305
- Execution ID: local-mac-codex-issue-305
- Goal: Separate latest candidate and known-good rollback setup pages