### PR TITLE
Issue #315: guarded-policy が current PR body を読むようにする

### DIFF
--- a/.github/workflows/guarded-autonomy-required-checks.yml
+++ b/.github/workflows/guarded-autonomy-required-checks.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
     branches:
       - main
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - edited
 
 permissions:
   contents: read
@@ -13,12 +18,24 @@ jobs:
   guarded-policy:
     runs-on: ubuntu-latest
     steps:
+      - name: Fetch current PR body
+        id: pr-body
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          PULL_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          pr_body_file="$RUNNER_TEMP/current-pr-body.md"
+          gh api "repos/${REPOSITORY}/pulls/${PULL_NUMBER}" --jq '.body // ""' > "$pr_body_file"
+          printf 'path=%s\n' "$pr_body_file" >> "$GITHUB_OUTPUT"
+
       - name: Validate PR evidence sections
         shell: bash
         env:
-          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_BODY_FILE: ${{ steps.pr-body.outputs.path }}
         run: |
-          body="${PR_BODY:-}"
+          body="$(cat "$PR_BODY_FILE")"
           required_markers=(
             "## This PR satisfies Intent"
             "## Satisfied Success Criteria"
@@ -38,9 +55,9 @@ jobs:
       - name: Validate Butler completion contract
         shell: bash
         env:
-          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_BODY_FILE: ${{ steps.pr-body.outputs.path }}
         run: |
-          body="${PR_BODY:-}"
+          body="$(cat "$PR_BODY_FILE")"
           contract="$(printf '%s' "$body" | awk '/^## Butler Completion Contract/{flag=1; next} /^## /{flag=0} flag')"
           required_fields=(
             "Owner goal"
@@ -100,9 +117,9 @@ jobs:
       - name: Guard Closes usage with E2E evidence pointers
         shell: bash
         env:
-          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_BODY_FILE: ${{ steps.pr-body.outputs.path }}
         run: |
-          body="${PR_BODY:-}"
+          body="$(cat "$PR_BODY_FILE")"
           if printf '%s' "$body" | grep -Eiq 'Closes #[0-9]+'; then
             if ! printf '%s' "$body" | grep -Eq 'E2E:'; then
               echo "PR uses Closes but E2E slot is missing."

--- a/docs/pr-template-model.md
+++ b/docs/pr-template-model.md
@@ -86,6 +86,9 @@ hand-writing the headings. Validate the result locally with
 `node scripts/validate-pr-body.mjs <path>` before `gh pr create` or
 `gh pr edit --body-file`.
 
+Do not use `gh pr create --body ...` or `gh pr edit --body ...` with freehand
+text. Canonical flow is `render -> validate -> --body-file`.
+
 ## Non-goals
 
 This model does not define:

--- a/test/guarded-semi-automation-mode.test.js
+++ b/test/guarded-semi-automation-mode.test.js
@@ -44,6 +44,20 @@ test("required checks workflow includes guarded-policy and test jobs", () => {
   assert.equal(workflow.includes("test:"), true);
 });
 
+test("required checks workflow reruns on PR body edits and reads current PR body", () => {
+  const workflow = fs.readFileSync(WORKFLOW_PATH, "utf8");
+  assert.equal(workflow.includes("pull_request:"), true);
+  assert.equal(workflow.includes("types:"), true);
+  assert.equal(workflow.includes("- edited"), true);
+  assert.equal(workflow.includes("name: Fetch current PR body"), true);
+  assert.equal(
+    workflow.includes('gh api "repos/${REPOSITORY}/pulls/${PULL_NUMBER}" --jq \'.body // ""\''),
+    true
+  );
+  assert.equal(workflow.includes('body="$(cat "$PR_BODY_FILE")"'), true);
+  assert.equal(workflow.includes("github.event.pull_request.body"), false);
+});
+
 test("CODEOWNERS file exists for review gate wiring", () => {
   const codeowners = fs.readFileSync(CODEOWNERS_PATH, "utf8");
   assert.equal(codeowners.includes("@marushu"), true);


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #315 の Intent に沿って、guarded-policy が PR body 更新後の current body を見て再評価されるようにした。
- PR body validation と GitHub Actions の guarded-policy の実行条件差分を減らし、本文修正後も古い snapshot failure が残り続ける失敗を防ぐ。

## Satisfied Success Criteria

- `guarded-autonomy-required-checks.yml` が `pull_request.edited` でも走る。
- guarded-policy が `github.event.pull_request.body` ではなく GitHub API から current PR body を読み直す。
- PR template model に `render -> validate -> --body-file` を canonical flow として明記する。
- workflow/test が live PR body readback を検証する。

## Unsatisfied Success Criteria

- Butler-facing live PR body rerun E2E evidence はこの PR ではまだ docs/workflow-level まで。

## Non-goal violations

None.

## Verification Evidence

- Unit: `node --test test/guarded-semi-automation-mode.test.js test/pr-body-guardrail.test.js`
- Integration: None.
- E2E: None. この PR は workflow/docs/test parity slice のみ。
- Manual: 本文修正済み PR #320 で guarded-policy rerun が green になることを確認。
- Evidence path/link: .github/workflows/guarded-autonomy-required-checks.yml, docs/pr-template-model.md, test/guarded-semi-automation-mode.test.js

## Butler Completion Contract

- Owner goal: PR body を直したのに古い failure が残り続けないこと。
- Butler entrypoint: PR body guardrail / guarded-policy workflow。
- Action Schema exposure: Action Schema 変更は不要で、この PR は workflow/docs/test parity のみ。
- Runtime path: GitHub Actions guarded-policy workflow が current PR body を fetch して検証する。
- Runner/runtime truth: workflow test green。本文修正後は edited event で re-evaluate される。
- Authority boundary: No high-risk operation. Workflow read behavior only.
- E2E evidence: Butler live E2E は未追加。PR #320 rerun confirmation を process evidence として利用。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: Not required.
- Custom GPT Action Schema update: Not required.
- Custom GPT Instructions update: Not required.
- iPhone Butler live E2E: Not required.

## Related Constitution Rules

- Drift Stop Protocol (Required Before Editing Code).
- Evidence Discipline.
- Change Size and PR Discipline.

## Out-of-scope but NOT implemented

- PR template の廃止。
- Butler evidence 要件の緩和。
- remote-codex-executor の PR body 自動生成ロジック変更。

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: #315
- Execution ID: Not provided.
- Goal: issue-315 guarded-policy live PR body sync
