### PR TITLE
Issue #304: PR body を canonical helper 経路に強制する

### DIFF
--- a/.github/workflows/remote-codex-executor.yml
+++ b/.github/workflows/remote-codex-executor.yml
@@ -226,7 +226,7 @@ jobs:
             exit 1
           fi
 
-          node scripts/render-pr-body.mjs \
+          node scripts/prepare-pr-body-file.mjs \
             --output /tmp/vtdd-remote-codex-pr-body.md \
             --issue "${TARGET_ISSUE_NUMBER}" \
             --intent "Remote Codex execution result for issue #${TARGET_ISSUE_NUMBER} is being opened as a bounded PR for review." \
@@ -249,8 +249,6 @@ jobs:
             --outOfScope "Merge\nIssue closure\nDeploy\nCredential mutation" \
             --executionId "${EXECUTION_ID}" \
             --codexGoal "${CODEX_GOAL}"
-
-          node scripts/validate-pr-body.mjs /tmp/vtdd-remote-codex-pr-body.md
 
           gh pr create \
             --repo "$TARGET_REPOSITORY" \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -308,6 +308,8 @@ It must not be interpreted as a blanket prohibition for non-RAG operational logs
 - No "while we are here" edits.
 - No unrelated refactors in implementation PRs.
 - Keep docs-only PRs and runtime PRs separable when possible.
+- For PR body create/update, never use freehand `gh pr create --body` or `gh pr edit --body`.
+- Use the repository canonical path: `scripts/prepare-pr-body-file.mjs` and then `gh pr create/edit --body-file`.
 - If a new guardrail or process correction is needed, land it in its own PR
   rather than mixing it into an implementation slice.
 

--- a/docs/setup/custom-gpt-instructions-short-min.md
+++ b/docs/setup/custom-gpt-instructions-short-min.md
@@ -35,18 +35,19 @@ Execution and remote Codex handoff:
 - Before handoff, ask short natural GO tied to visible intent; keep internals in payload. If user says handoff/実行/GO, set consent=["propose","execute"].
 - Do not dispatch `wait_for_review`. PR feedback fix => revise_pr. Comment-only => respond_to_review.
 - Reviewer-fix phrase: `Gemini が指摘している修正を Codex に進めさせます。よければ GO と言ってください。`
-- Executor transport is pluggable and user-owned; public core does not host a shared runner.
+- Executor transport is pluggable and user-owned.
 - Default handoff here: executorTransport=vps_runner. Do not add a separate GPT Action for VPS handoff.
-- codex_cloud_github_comment is legacy fallback; codex_cloud_cli_control_runner is user-owned. API runner uses api_key_runner + OPENAI_API_KEY; surface openai_api_key_not_configured; never request secrets in chat.
-- After vtddExecute, call vtddExecutionProgress; report leadTime; for control/vps/api_key include executorTransport. For vps_runner status, call vtddVpsRunnerStatus. VPS cancel/drain: vtddVpsRunnerCancel marker only.
+- codex_cloud_github_comment fallback; codex_cloud_cli_control_runner is user-owned. API runner uses api_key_runner + OPENAI_API_KEY; surface openai_api_key_not_configured.
+- After vtddExecute, call vtddExecutionProgress; report leadTime and executorTransport. For vps_runner status, call vtddVpsRunnerStatus. VPS cancel/drain: vtddVpsRunnerCancel marker only.
 - Do not claim PR creation complete unless GitHub runtime truth shows the PR.
 GitHub write:
 - vtddWriteGitHub only for scoped GO-tier writes: issue create/comment create/update, branch create, pull create/update, pull comment create.
 - Before vtddWriteGitHub, show exact title/body/comment/update payload and wait for GO.
+- PR create/update: no freehand `--body`; use `scripts/prepare-pr-body-file.mjs` -> `--body-file`.
 - For implementation without an existing Issue, do issue_create first; only then do bounded Codex handoff.
 - For normal GO writes, show exact payload, ask only `GO`, then call vtddWriteGitHub. Never ask targetConfirmed, approvalScopeMatched, approvalPhrase, policyInput, judgmentTrace, raw JSON, or constitution flags.
 - Write only when repo is resolved, scope traceable, and GO exists.
-- Never use vtddWriteGitHub for merge, issue close, deploy, secrets/settings/permissions, repo admin, or destructive cleanup.
+- Never use vtddWriteGitHub for merge, issue close, deploy, secrets/settings/permissions, admin, or destructive cleanup.
 High-risk authority:
 - High-risk actions require explicit human GO + real passkey.
 - Merge requires explicit human GO + real passkey. Never merge from context.

--- a/docs/setup/custom-gpt-instructions-short.md
+++ b/docs/setup/custom-gpt-instructions-short.md
@@ -36,13 +36,14 @@ Remote Codex flow:
 - If user says handoff/実行/GO, consent=["propose","execute"].
 - Executor transport is pluggable and user-owned.
 - Current default for Codex task handoff is the user-owned VPS: executorTransport=vps_runner. Do not add a separate GPT Action for VPS handoff.
-- codex_cloud_github_comment fallback; codex_cloud_cli_control_runner opt-in. Queue comment is delegation, not execution.
+- codex_cloud_github_comment fallback; codex_cloud_cli_control_runner opt-in.
 - control runner uses ChatGPT Codex auth, not OPENAI_API_KEY.
-- vps_runner is user-owned; VTDD core does not host it.
+- vps_runner is user-owned.
 - API runner uses executorTransport=api_key_runner + apiKeyRunnerAcknowledged=true + OPENAI_API_KEY.
 GitHub write:
 - vtddWriteGitHub only for scoped GO-tier writes: issue create/comment create/update, branch create, pull create/update, pull comment create.
 - Before vtddWriteGitHub, show exact title/body or comment/update payload; wait GO.
+- PR create/update: no freehand `--body`; use `scripts/prepare-pr-body-file.mjs` -> `--body-file`.
 - If no existing Issue is fixed for an implementation request, the next safe write is Issue creation first; only after that created/existing Issue exists may Butler hand off bounded Codex work.
 - For normal GO writes (`issue_create`, `issue_comment_create`, `pull_comment_create`), ask only `GO`, call vtddWriteGitHub. Never ask targetConfirmed/approvalScopeMatched/approvalPhrase/raw JSON.
 - Only when repo resolved, scope traceable, GO exists. Do not use vtddWriteGitHub for merge/close/deploy/secrets/settings/permissions/destructive cleanup.

--- a/docs/setup/custom-gpt-instructions.md
+++ b/docs/setup/custom-gpt-instructions.md
@@ -262,6 +262,7 @@ GitHub normal write plane:
   - pull request create or update
   - pull request comment create
 - Before calling vtddWriteGitHub, present the exact bounded payload to the human and wait for GO bound to that payload. For Issues and PRs, show the exact title/body. For comments or updates, show the concrete body or fields that will be written. This applies even when the next safe action is only to create the next validation Issue or PR from an iPhone Butler conversation.
+- For PR create/update, never freehand the PR body. Use the repository canonical PR body contract (`docs/pr-template-model.md`, `scripts/prepare-pr-body-file.mjs`) and the validated `--body-file` path.
 - If an implementation request does not already name an existing Issue, the next safe write is usually `issue_create`, not Codex handoff. Present the Issue candidate first, wait for GO, create the Issue, then continue from that Issue-backed scope.
 - For normal GO writes, first confirm or fix the exact payload, bind the user's
   `GO` to that payload scope, then call vtddWriteGitHub. Current natural GO

--- a/scripts/prepare-pr-body-file.mjs
+++ b/scripts/prepare-pr-body-file.mjs
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+
+import fs from "node:fs/promises";
+
+import { renderPrBody } from "./render-pr-body.mjs";
+import { validatePrBody } from "./validate-pr-body.mjs";
+
+function normalizeText(value) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function parseArgs(argv) {
+  const result = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (!arg.startsWith("--")) {
+      continue;
+    }
+    const key = arg.slice(2);
+    const next = argv[index + 1];
+    if (!next || next.startsWith("--")) {
+      result[key] = "true";
+      continue;
+    }
+    result[key] = next;
+    index += 1;
+  }
+  return result;
+}
+
+function prepareGuardedPullRequestBody({ candidateBody, renderBody } = {}) {
+  const candidate = typeof candidateBody === "string" ? candidateBody : "";
+  const candidateValidation = normalizeText(candidate)
+    ? validatePrBody(candidate)
+    : { ok: false, errors: ["PR body candidate is missing."] };
+
+  if (candidateValidation.ok) {
+    return {
+      ok: true,
+      body: candidate,
+      normalized: false,
+      validationErrors: []
+    };
+  }
+
+  const canonicalBody = typeof renderBody === "function" ? String(renderBody()) : "";
+  const canonicalValidation = validatePrBody(canonicalBody);
+  if (!canonicalValidation.ok) {
+    return {
+      ok: false,
+      reason: "Could not render a guarded-policy-compliant PR body.",
+      validationErrors: candidateValidation.errors,
+      canonicalErrors: canonicalValidation.errors
+    };
+  }
+
+  return {
+    ok: true,
+    body: canonicalBody,
+    normalized: true,
+    validationErrors: candidateValidation.errors
+  };
+}
+
+async function prepareGuardedPullRequestBodyFile({ outputPath, candidateBody, renderBody } = {}) {
+  const prepared = prepareGuardedPullRequestBody({ candidateBody, renderBody });
+  if (!prepared.ok) {
+    return prepared;
+  }
+
+  await fs.writeFile(outputPath, prepared.body, "utf8");
+  return {
+    ...prepared,
+    outputPath
+  };
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const args = parseArgs(process.argv.slice(2));
+  const outputPath = args.output;
+  if (!outputPath) {
+    console.error("Usage: node scripts/prepare-pr-body-file.mjs --output <path> [--candidate-file <path>] [render args]");
+    process.exit(1);
+  }
+
+  const candidateBody = args["candidate-file"]
+    ? await fs.readFile(args["candidate-file"], "utf8")
+    : normalizeText(args["candidate-body"]);
+
+  const prepared = await prepareGuardedPullRequestBodyFile({
+    outputPath,
+    candidateBody,
+    renderBody: () => renderPrBody(args)
+  });
+
+  if (!prepared.ok) {
+    for (const error of prepared.validationErrors || []) {
+      console.error(error);
+    }
+    for (const error of prepared.canonicalErrors || []) {
+      console.error(error);
+    }
+    if (prepared.reason) {
+      console.error(prepared.reason);
+    }
+    process.exit(1);
+  }
+
+  process.stdout.write(prepared.normalized ? "normalized\n" : "preserved\n");
+}
+
+export { prepareGuardedPullRequestBody, prepareGuardedPullRequestBodyFile };

--- a/scripts/run-vps-runner.mjs
+++ b/scripts/run-vps-runner.mjs
@@ -8,8 +8,8 @@ import { spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { normalizeMentionLogin, parseCodexReviewFallbackComment } from "../src/core/index.js";
 import { buildExecutionLeadTime } from "../src/core/execution-lead-time.js";
+import { prepareGuardedPullRequestBody, prepareGuardedPullRequestBodyFile } from "./prepare-pr-body-file.mjs";
 import { renderPrBody } from "./render-pr-body.mjs";
-import { validatePrBody } from "./validate-pr-body.mjs";
 
 const QUEUE_MARKER_RE = /<!--\s*vtdd:vps-runner-execution:([a-zA-Z0-9._:-]+)\s*-->/;
 const EVENT_MARKER_RE = /<!--\s*vtdd:vps-runner-event:([a-zA-Z0-9._:-]+)\s*-->/;
@@ -285,10 +285,10 @@ async function executeVpsRunnerExecution({ githubFetch, token, workRoot, executi
         return { ok: false, reason: normalized.reason };
       }
       if (normalized.normalized) {
-        const bodyFile = await writePullRequestBodyFile({
+        const bodyFile = await writePreparedPullRequestBodyFile({
           workspace,
           payload,
-          body: normalized.body
+          candidateBody: existingPullRequest.body
         });
         await runTrackedVpsCommand("gh", ["pr", "edit", String(existingPullRequest.number || prUrl), "--repo", payload.repository, "--body-file", bodyFile], {
           cwd: workspace,
@@ -308,6 +308,11 @@ async function executeVpsRunnerExecution({ githubFetch, token, workRoot, executi
         await postVpsRunnerPrBodyBlockedEvent({ githubFetch, payload, normalized, notification });
         return { ok: false, reason: normalized.reason };
       }
+      const bodyFile = await writePreparedPullRequestBodyFile({
+        workspace,
+        payload,
+        candidateBody: extractCodexPrBodyDraft(payload)
+      });
       const pr = await runTrackedVpsCommand(
         "gh",
         [
@@ -320,8 +325,8 @@ async function executeVpsRunnerExecution({ githubFetch, token, workRoot, executi
           payload.branch,
           "--title",
           `Issue #${payload.issueNumber}: VTDD VPS runner handoff`,
-          "--body",
-          normalized.body
+          "--body-file",
+          bodyFile
         ],
         {
           cwd: workspace,
@@ -695,7 +700,7 @@ function buildCodexExecutionPrompt({
     "- Do not deploy.",
     "- Do not mutate secrets, permissions, repository settings, or external infrastructure.",
     "- If the Issue is ambiguous or blocked, leave a clear note in the working tree and stop.",
-    "- Before drafting or relying on a PR body, inspect the repository PR body contract: docs/pr-template-model.md, scripts/render-pr-body.mjs, and scripts/validate-pr-body.mjs.",
+    "- Before drafting or relying on a PR body, inspect the repository PR body contract: docs/pr-template-model.md, scripts/prepare-pr-body-file.mjs, scripts/render-pr-body.mjs, and scripts/validate-pr-body.mjs.",
     "- Any PR body draft must include these guarded-policy markers: ## This PR satisfies Intent; ## Satisfied Success Criteria; ## Unsatisfied Success Criteria; ## Verification Evidence; ## Butler Completion Contract; ## Surface Update Checklist.",
     "",
     `Goal: ${goal}`,
@@ -783,7 +788,7 @@ function normalizeVpsRunnerPreflightPolicy(value = {}) {
     requiredRepoFiles:
       requiredRepoFiles.length > 0
         ? requiredRepoFiles
-        : ["AGENTS.md", "docs/pr-template-model.md", "scripts/render-pr-body.mjs", "scripts/validate-pr-body.mjs"]
+        : ["AGENTS.md", "docs/pr-template-model.md", "scripts/prepare-pr-body-file.mjs", "scripts/render-pr-body.mjs", "scripts/validate-pr-body.mjs"]
   };
 }
 
@@ -1528,36 +1533,10 @@ function buildPullRequestBody(payload) {
 }
 
 function buildGuardedPullRequestBody({ payload, candidateBody } = {}) {
-  const candidate = typeof candidateBody === "string" ? candidateBody : "";
-  const candidateValidation = candidate.trim()
-    ? validatePrBody(candidate)
-    : { ok: false, errors: ["PR body candidate is missing."] };
-  if (candidateValidation.ok) {
-    return {
-      ok: true,
-      body: candidate,
-      normalized: false,
-      validationErrors: []
-    };
-  }
-
-  const canonicalBody = buildPullRequestBody(payload || {});
-  const canonicalValidation = validatePrBody(canonicalBody);
-  if (!canonicalValidation.ok) {
-    return {
-      ok: false,
-      reason: "VPS runner could not render a guarded-policy-compliant PR body.",
-      validationErrors: candidateValidation.errors,
-      canonicalErrors: canonicalValidation.errors
-    };
-  }
-
-  return {
-    ok: true,
-    body: canonicalBody,
-    normalized: true,
-    validationErrors: candidateValidation.errors
-  };
+  return prepareGuardedPullRequestBody({
+    candidateBody,
+    renderBody: () => buildPullRequestBody(payload || {})
+  });
 }
 
 function extractCodexPrBodyDraft(payload = {}) {
@@ -1570,9 +1549,16 @@ function extractCodexPrBodyDraft(payload = {}) {
   );
 }
 
-async function writePullRequestBodyFile({ workspace, payload, body }) {
+async function writePreparedPullRequestBodyFile({ workspace, payload, candidateBody }) {
   const bodyFile = path.join(os.tmpdir(), `vtdd-vps-runner-pr-body-${safePathSegment(payload.executionId)}.md`);
-  await fs.writeFile(bodyFile, body, "utf8");
+  const prepared = await prepareGuardedPullRequestBodyFile({
+    outputPath: bodyFile,
+    candidateBody,
+    renderBody: () => buildPullRequestBody(payload || {})
+  });
+  if (!prepared.ok) {
+    throw new Error(prepared.reason || "Failed to prepare guarded PR body file.");
+  }
   return bodyFile;
 }
 

--- a/test/custom-gpt-setup-docs.test.js
+++ b/test/custom-gpt-setup-docs.test.js
@@ -79,6 +79,9 @@ test("custom gpt instructions preserve current butler and approval boundaries", 
   assert.equal(doc.includes("Current natural GO\n  binding is supported for `issue_create`, `issue_comment_create`, and\n  `pull_comment_create`"), true);
   assert.equal(doc.includes("If an implementation request does not already name an existing Issue"), true);
   assert.equal(doc.includes("the next safe write is usually `issue_create`, not Codex handoff"), true);
+  assert.equal(doc.includes("never freehand the PR body"), true);
+  assert.equal(doc.includes("scripts/prepare-pr-body-file.mjs"), true);
+  assert.equal(doc.includes("validated `--body-file` path"), true);
   assert.equal(doc.includes("If the human says something like \"この内容で Issue 作って\""), true);
   assert.equal(doc.includes("この title/body で Issue を作成するなら「GO」と言ってください"), true);
   assert.equal(doc.includes("Do not ask the human to say `targetConfirmed=true`"), true);
@@ -181,6 +184,9 @@ test("short custom gpt instructions stay under editor limits while preserving cr
   assert.equal(doc.includes("#303 is the regression example"), true);
   assert.equal(doc.includes("For normal GO writes (`issue_create`, `issue_comment_create`, `pull_comment_create`)"), true);
   assert.equal(doc.includes("the next safe write is Issue creation first"), true);
+  assert.equal(doc.includes("no freehand `--body`"), true);
+  assert.equal(doc.includes("scripts/prepare-pr-body-file.mjs"), true);
+  assert.equal(doc.includes("`--body-file`"), true);
   assert.equal(doc.includes("ask only `GO`"), true);
   assert.equal(doc.includes("Never ask targetConfirmed/approvalScopeMatched/approvalPhrase/raw JSON"), true);
   assert.equal(doc.includes("Nickname memory is user-owned alias data"), true);
@@ -257,6 +263,9 @@ test("short-min custom gpt instructions stay pasteable while preserving critical
     "continuationContext.handoff.relatedIssue",
     "GO + real passkey",
     "show exact title/body/comment/update payload",
+    "no freehand `--body`",
+    "scripts/prepare-pr-body-file.mjs",
+    "`--body-file`",
     "For implementation without an existing Issue, do issue_create first",
     "Preserve reviewer objections",
     "Review truth: marker approve != GitHub approval",

--- a/test/pr-body-guardrail.test.js
+++ b/test/pr-body-guardrail.test.js
@@ -5,6 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import { execFileSync } from "node:child_process";
 
+import { prepareGuardedPullRequestBody, prepareGuardedPullRequestBodyFile } from "../scripts/prepare-pr-body-file.mjs";
 import { renderPrBody } from "../scripts/render-pr-body.mjs";
 import { validatePrBody } from "../scripts/validate-pr-body.mjs";
 
@@ -146,4 +147,59 @@ test("validate-pr-body CLI template mode accepts the canonical template structur
     },
   );
   assert.match(output, /PR body template validation passed/);
+});
+
+test("prepare-pr-body-file preserves a valid candidate body", async () => {
+  const candidate = renderPrBody({
+    issue: "57",
+    intent: "Preserve valid candidate.",
+    satisfied: "Body already matches the canonical contract.",
+    unsatisfied: "Human review remains pending.",
+    evidencePath: "docs/pr-template-model.md",
+    ownerGoal: "Keep a valid PR body unchanged.",
+    butlerEntrypoint: "PR body helper.",
+    actionSchemaExposure: "No schema change.",
+    runtimePath: "scripts/prepare-pr-body-file.mjs.",
+    runtimeTruth: "Local validator pass.",
+    authorityBoundary: "No high-risk operation.",
+    butlerE2E: "Not required for this guardrail path.",
+    completionStatus: "incomplete",
+  });
+  const prepared = prepareGuardedPullRequestBody({
+    candidateBody: candidate,
+    renderBody: () => "should not be used"
+  });
+
+  assert.equal(prepared.ok, true);
+  assert.equal(prepared.normalized, false);
+  assert.equal(prepared.body, candidate);
+});
+
+test("prepare-pr-body-file normalizes malformed candidate into canonical body file", async () => {
+  const tmpdir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "vtdd-pr-body-prepare-"));
+  const file = path.join(tmpdir, "body.md");
+  const prepared = await prepareGuardedPullRequestBodyFile({
+    outputPath: file,
+    candidateBody: "## Summary\n\nBroken.",
+    renderBody: () =>
+      renderPrBody({
+        issue: "57",
+        intent: "Normalize malformed candidate.",
+        satisfied: "Canonical helper rewrites the body.",
+        unsatisfied: "Human review remains pending.",
+        evidencePath: "docs/pr-template-model.md",
+        ownerGoal: "Avoid freehand PR body drift.",
+        butlerEntrypoint: "PR body helper.",
+        actionSchemaExposure: "No schema change.",
+        runtimePath: "scripts/prepare-pr-body-file.mjs.",
+        runtimeTruth: "Local validator pass.",
+        authorityBoundary: "No high-risk operation.",
+        butlerE2E: "Not required for this guardrail path.",
+        completionStatus: "incomplete",
+      })
+  });
+
+  assert.equal(prepared.ok, true);
+  assert.equal(prepared.normalized, true);
+  assert.equal((await fs.promises.readFile(file, "utf8")).includes("## This PR satisfies Intent"), true);
 });

--- a/test/remote-codex-workflow.test.js
+++ b/test/remote-codex-workflow.test.js
@@ -14,9 +14,9 @@ test("remote Codex workflow commits, pushes, and creates or updates a PR", () =>
   assert.equal(workflow.includes("name: Create or update pull request"), true);
   assert.equal(workflow.includes("gh pr view"), true);
   assert.equal(workflow.includes("gh pr create"), true);
-  assert.equal(workflow.includes("node scripts/render-pr-body.mjs"), true);
-  assert.equal(workflow.includes("node scripts/validate-pr-body.mjs"), true);
+  assert.equal(workflow.includes("node scripts/prepare-pr-body-file.mjs"), true);
   assert.equal(workflow.includes("--body-file /tmp/vtdd-remote-codex-pr-body.md"), true);
+  assert.equal(workflow.includes("--body "), false);
 });
 
 test("remote Codex workflow fails instead of pretending PR creation succeeded with no changes", () => {

--- a/test/vps-runner-script.test.js
+++ b/test/vps-runner-script.test.js
@@ -1285,6 +1285,13 @@ test("VPS runner normalizes malformed PR body candidates with canonical template
   assert.equal(normalized.body.includes("Completion status: incomplete"), true);
 });
 
+test("VPS runner create path uses prepared body-file helper instead of freehand --body", async () => {
+  const source = await fs.readFile(path.join(process.cwd(), "scripts", "run-vps-runner.mjs"), "utf8");
+  assert.equal(source.includes('import { prepareGuardedPullRequestBody, prepareGuardedPullRequestBodyFile } from "./prepare-pr-body-file.mjs";'), true);
+  assert.equal(source.includes('"--body-file",\n          bodyFile'), true);
+  assert.equal(source.includes('"--body",\n          normalized.body'), false);
+});
+
 test("VPS runner classifies unauthenticated Codex CLI as raw auth failure", () => {
   const failure = classifyVpsRunnerFailure(
     new Error("codex exec failed: unexpected status 401 Unauthorized: Missing bearer authentication")


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #304 の Intent に沿って、mac Codex / VPS Codex CLI / Butler のどの入口でも PR body preflight を同じ canonical helper 経路へ寄せる。
- 自由記述 `--body` ではなく、render -> validate -> --body-file を repository contract として固定する。

## Satisfied Success Criteria

- `scripts/prepare-pr-body-file.mjs` を追加し、candidate preserve / malformed normalize / validated body-file 出力を共通化した。
- VPS runner が PR create/edit で helper 生成の `--body-file` を使い、freehand `--body` create path を廃止した。
- remote Codex workflow が同じ helper を使って PR body file を作るようにした。
- AGENTS と Butler setup docs に、PR body は helper 経由以外禁止と明記した。
- workflow / runner / docs / setup docs の tests を更新した。

## Unsatisfied Success Criteria

- GitHub UI など repository 外の人手経路そのものまでは強制していない。
- Butler live PR create/update E2E は未実施。

## Non-goal violations

None.

## Verification Evidence

- Unit: `node --test test/pr-body-guardrail.test.js test/remote-codex-workflow.test.js test/vps-runner-script.test.js test/custom-gpt-setup-docs.test.js`
- Integration: None.
- E2E: None. この PR は canonical path / docs / test guardrail slice のみ。
- Manual: Helper-generated PR body file path を使ってこの PR 自身を作成する。
- Evidence path/link: scripts/prepare-pr-body-file.mjs, scripts/run-vps-runner.mjs, .github/workflows/remote-codex-executor.yml, docs/setup/custom-gpt-instructions*.md, AGENTS.md

## Butler Completion Contract

- Owner goal: PR body テンプレ壊しで毎回同じ guarded-policy エラーを出さないこと。
- Butler entrypoint: Butler setup instructions and PR body contract.
- Action Schema exposure: Action Schema changeなし。PR body preflight contract と helper path を統一。
- Runtime path: Butler docs -> VPS runner / remote workflow -> scripts/prepare-pr-body-file.mjs -> gh pr create/edit --body-file.
- Runner/runtime truth: 関連 unit tests green。runner/workflow source から freehand --body create path を除去。
- Authority boundary: No merge, deploy, issue close, credential mutation, permission mutation.
- E2E evidence: Butler live E2E は未実施。docs/runtime contract と test evidence まで。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: Not required.
- Custom GPT Action Schema update: Not required.
- Custom GPT Instructions update: done (docs/setup/custom-gpt-instructions*.md を更新).
- iPhone Butler live E2E: Not required.

## Related Constitution Rules

- Issue is canonical spec.
- Evidence Discipline.
- Change Size and PR Discipline.

## Out-of-scope but NOT implemented

- PR template 廃止。
- Butler evidence 要件の緩和。
- GitHub UI の人手作成そのものの禁止。

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: #304
- Execution ID: Not provided.
- Goal: issue-304 canonical pr body path
