### PR TITLE
Issue #317: merged PR への stale reviewer writeback を止める

### DIFF
--- a/scripts/run-gemini-pr-review.mjs
+++ b/scripts/run-gemini-pr-review.mjs
@@ -16,7 +16,51 @@ import {
   resolveGeminiReviewTrigger
 } from "../src/core/index.js";
 
-async function main() {
+export function isPullRequestReviewable(pullRequest = {}) {
+  const state = String(pullRequest?.state || "").trim().toLowerCase();
+  if (String(pullRequest?.merged_at || "").trim()) {
+    return {
+      reviewable: false,
+      reason: "pull_request_already_merged"
+    };
+  }
+  if (state && state !== "open") {
+    return {
+      reviewable: false,
+      reason: `pull_request_not_open:${state}`
+    };
+  }
+  return {
+    reviewable: true,
+    reason: null
+  };
+}
+
+async function getCurrentPullRequest({ githubFetch, repository, prNumber }) {
+  return githubFetch(`/repos/${repository}/pulls/${prNumber}`);
+}
+
+async function ensurePullRequestReviewable({ githubFetch, repository, prNumber, writePhase }) {
+  const currentPullRequest = await getCurrentPullRequest({ githubFetch, repository, prNumber });
+  const reviewable = isPullRequestReviewable(currentPullRequest);
+  if (!reviewable.reviewable) {
+    console.log(
+      `Skipping Gemini PR review writeback during ${writePhase}: ${reviewable.reason} on PR #${prNumber}.`
+    );
+    return {
+      ok: false,
+      pullRequest: currentPullRequest,
+      reason: reviewable.reason
+    };
+  }
+  return {
+    ok: true,
+    pullRequest: currentPullRequest,
+    reason: null
+  };
+}
+
+export async function main() {
   const eventName = mustGetEnv("GITHUB_EVENT_NAME");
   const repository = mustGetEnv("GITHUB_REPOSITORY");
   const eventPath = mustGetEnv("GITHUB_EVENT_PATH");
@@ -36,7 +80,7 @@ async function main() {
   const githubFetch = createGitHubFetch({ apiBaseUrl, token: githubToken });
   const prNumber = triggerResult.value.pullRequestNumber;
 
-  const pullRequest = await githubFetch(`/repos/${repository}/pulls/${prNumber}`);
+  const pullRequest = await getCurrentPullRequest({ githubFetch, repository, prNumber });
   const files = await githubFetch(`/repos/${repository}/pulls/${prNumber}/files?per_page=100`);
   const issueComments = await githubFetch(`/repos/${repository}/issues/${prNumber}/comments?per_page=100`);
   const reviewComments = await githubFetch(`/repos/${repository}/pulls/${prNumber}/comments?per_page=100`);
@@ -76,6 +120,15 @@ async function main() {
   } catch (error) {
     const failure = classifyGeminiReviewFailure(error instanceof Error ? error : {});
     if (failure.kind === GeminiReviewFailureKind.TEMPORARY_UNAVAILABLE) {
+      const reviewable = await ensurePullRequestReviewable({
+        githubFetch,
+        repository,
+        prNumber,
+        writePhase: "codex_fallback_request"
+      });
+      if (!reviewable.ok) {
+        return;
+      }
       const fallbackBody = formatCodexReviewFallbackComment({
         status: "requested",
         trigger: triggerResult.value.trigger,
@@ -118,6 +171,16 @@ async function main() {
       ? resolveOperatorMention([pullRequest?.user?.login, payload?.sender?.login])
       : ""
   });
+
+  const reviewable = await ensurePullRequestReviewable({
+    githubFetch,
+    repository,
+    prNumber,
+    writePhase: existingReviewComment ? "gemini_review_update" : "gemini_review_create"
+  });
+  if (!reviewable.ok) {
+    return;
+  }
 
   if (existingFallbackComment) {
     await githubFetch(`/repos/${repository}/issues/comments/${existingFallbackComment.id}`, {
@@ -205,7 +268,9 @@ function shouldMentionGeminiReviewResult({ existingComment, recommendedAction })
   return !existing || existing.recommendedAction !== currentAction;
 }
 
-main().catch((error) => {
-  console.error(error instanceof Error ? error.message : String(error));
-  process.exitCode = 1;
-});
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}

--- a/test/gemini-pr-review-script.test.js
+++ b/test/gemini-pr-review-script.test.js
@@ -1,0 +1,39 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { isPullRequestReviewable } from "../scripts/run-gemini-pr-review.mjs";
+
+test("isPullRequestReviewable rejects merged pull requests", () => {
+  const result = isPullRequestReviewable({
+    state: "closed",
+    merged_at: "2026-05-12T12:01:32Z"
+  });
+
+  assert.deepEqual(result, {
+    reviewable: false,
+    reason: "pull_request_already_merged"
+  });
+});
+
+test("isPullRequestReviewable rejects non-open unmerged pull requests", () => {
+  const result = isPullRequestReviewable({
+    state: "closed",
+    merged_at: null
+  });
+
+  assert.deepEqual(result, {
+    reviewable: false,
+    reason: "pull_request_not_open:closed"
+  });
+});
+
+test("isPullRequestReviewable accepts open pull requests", () => {
+  const result = isPullRequestReviewable({
+    state: "open",
+    merged_at: null
+  });
+
+  assert.deepEqual(result, {
+    reviewable: true,
+    reason: null
+  });
+});


### PR DESCRIPTION
## This PR satisfies Intent

- #317 の stale reviewer writeback を止める。\n- マージ済み/closed PR への Gemini reviewer / Codex fallback requested comment の追記を防ぐ。

## Satisfied Success Criteria

- reviewer writeback 前に current PR state を再取得する。\n- merged PR では fallback requested comment を書かずに終了する。\n- closed PR でも reviewer writeback を行わない。

## Unsatisfied Success Criteria

- #317 全体の reviewer loop hardening は未完。\n- stale requested marker を synthesis 側で無害化する追加整理は未着手。

## Non-goal violations

None.

## Verification Evidence

- Unit: node --test test/gemini-pr-review.test.js test/gemini-pr-review-workflow.test.js test/gemini-pr-review-script.test.js
- Integration: None.
- E2E: None.
- Manual: PR #323 の post-merge stale comment 再発条件をコード経路で確認。
- Evidence path/link: test/gemini-pr-review-script.test.js

## Butler Completion Contract

- Owner goal: 手動マージ後に stale reviewer comment が付かないこと。
- Butler entrypoint: Reviewer workflow internal hardening; Butler 直接経路の変更はない。
- Action Schema exposure: Unchanged; reviewer workflow internal hardening only.
- Runtime path: pull_request_target / issue_comment reviewer writeback -> scripts/run-gemini-pr-review.mjs
- Runner/runtime truth: GitHub API で writeback 直前の PR state / merged_at を再取得して判定。
- Authority boundary: No merge/deploy authority change. Reviewer writeback only.
- E2E evidence: Unchanged; Butler-facing E2E not part of this slice.
- Completion status: unconnected

## Surface Update Checklist

- Cloudflare deploy: Not required.
- Custom GPT Action Schema update: Not required.
- Custom GPT Instructions update: Not required.
- iPhone Butler live E2E: Not required.

## Related Constitution Rules

- Drift Stop Protocol\n- Evidence Discipline\n- Butler and Reviewer as Stop Roles

## Out-of-scope but NOT implemented

- Gemini コメント日本語化 (#316)\n- MCP Gateway 実装\n- reviewer state-machine 全面改修

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: #317
- Execution ID: Not provided.
- Goal: Not provided.
