### PR TITLE
Issue #329: document Codex MCP approval path for exec mode

### DIFF
--- a/docs/architecture/vtdd-mcp-ver.md
+++ b/docs/architecture/vtdd-mcp-ver.md
@@ -270,12 +270,42 @@ export VTDD_MCP_TOKEN=...
 codex mcp add vtdd --url https://your-vtdd-runtime.example.com/mcp --bearer-token-env-var VTDD_MCP_TOKEN
 ```
 
+Canonical `codex exec` config shape:
+
+```bash
+export VTDD_MCP_TOKEN=...
+codex exec \
+  --ignore-user-config \
+  -c 'mcp_servers.vtdd.url="https://your-vtdd-runtime.example.com/mcp"' \
+  -c 'mcp_servers.vtdd.bearer_token_env_var="VTDD_MCP_TOKEN"' \
+  -c 'mcp_servers.vtdd.default_tools_approval_mode="approve"' \
+  -c 'mcp_servers.vtdd.tools.vtdd_runtime_truth.approval_mode="approve"' \
+  -s read-only \
+  -C /path/to/repo \
+  'vtdd MCP を使って runtime truth を返して。JSONそのまま。'
+```
+
+`codex exec` では raw MCP tool call の approval が `request_user_input` に
+流れるため、approval mode を明示しないと
+`user cancelled MCP tool call` で止まることがある。
+
+The canonical VTDD Codex path therefore includes explicit MCP approval config
+for trusted read tools on both Mac Codex and VPS Codex CLI.
+
 Local verification shape:
 
 ```bash
 export VTDD_MCP_TOKEN=vtdd-local-test
 codex mcp add vtdd-local --url http://127.0.0.1:8788/mcp --bearer-token-env-var VTDD_MCP_TOKEN
-codex exec -s read-only -C /path/to/repo "vtdd-local MCP を使って、利用可能な tool 名だけを改行区切りで返して。説明はいらない。"
+codex exec \
+  --ignore-user-config \
+  -c 'mcp_servers.vtdd-local.url="http://127.0.0.1:8788/mcp"' \
+  -c 'mcp_servers.vtdd-local.bearer_token_env_var="VTDD_MCP_TOKEN"' \
+  -c 'mcp_servers.vtdd-local.default_tools_approval_mode="approve"' \
+  -c 'mcp_servers.vtdd-local.tools.vtdd_runtime_truth.approval_mode="approve"' \
+  -s read-only \
+  -C /path/to/repo \
+  'vtdd-local MCP を使って、marushu/vtdd-v2-p の runtime truth を JSON そのままで返して。説明不要。'
 ```
 
 The MCP runtime must expose bearer-token discovery hints that let Codex resolve

--- a/test/vtdd-mcp-ver-architecture.test.js
+++ b/test/vtdd-mcp-ver-architecture.test.js
@@ -49,5 +49,9 @@ test("vtdd-mcp-ver architecture doc defines canonical Codex MCP bridge path", ()
   assert.equal(doc.includes("Canonical Codex MCP Connection"), true);
   assert.equal(doc.includes("VTDD_MCP_TOKEN"), true);
   assert.equal(doc.includes("codex mcp add vtdd --url https://your-vtdd-runtime.example.com/mcp --bearer-token-env-var VTDD_MCP_TOKEN"), true);
+  assert.equal(doc.includes("default_tools_approval_mode=\"approve\""), true);
+  assert.equal(doc.includes("approval_mode=\"approve\""), true);
+  assert.equal(doc.includes("user cancelled MCP tool call"), true);
+  assert.equal(doc.includes("request_user_input"), true);
   assert.equal(doc.includes("bearer-token discovery hints"), true);
 });


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #329 の Success Criteria に沿って、Codex CLI exec mode で MCP tool call が cancel される原因を VTDD 固有問題から切り離し、最小既知正常系の invocation path を canonical docs に固定する。

## Satisfied Success Criteria

- official SDK example server に対して `default_tools_approval_mode="approve"` と per-tool `approval_mode="approve"` を与えると `codex exec` が成功することを確認した。
- VTDD local /mcp に対しても同じ approval 設定で `vtdd_runtime_truth` が `codex exec` から成功することを確認した。
- `docs/architecture/vtdd-mcp-ver.md` に Mac Codex / VPS Codex CLI 共通の canonical exec config を追記した。

## Unsatisfied Success Criteria

- Issue #318 全体としての Mac/VPS 運用ガイド拡張や write/high-risk surface は未実装。
- PR #328 自体の merge-ready 判定は別途 review/branch で継続する。

## Non-goal violations

None.

## Verification Evidence

- Unit: node --test test/vtdd-mcp-ver-architecture.test.js
- Integration: Official SDK example server と VTDD local /mcp に対する `codex exec --json` 実行で確認。
- E2E: Not required for this repo-core Codex CLI investigation slice.
- Manual: 1. `codex exec --json --ignore-user-config -c 'mcp_servers.mcp-example.command="node"' -c 'mcp_servers.mcp-example.args=["node_modules/@modelcontextprotocol/sdk/dist/esm/examples/server/mcpServerOutputSchema.js"]' -c 'mcp_servers.mcp-example.default_tools_approval_mode="approve"' -c 'mcp_servers.mcp-example.tools.get_weather.approval_mode="approve"' ...` で official example success を確認。\n2. `npx wrangler dev --port 8792 --var VTDD_GATEWAY_BEARER_TOKEN:vtdd-local-test` を起動。\n3. `VTDD_MCP_TOKEN=vtdd-local-test codex exec --json --ignore-user-config -c 'mcp_servers.vtdd.url="http://127.0.0.1:8792/mcp"' -c 'mcp_servers.vtdd.bearer_token_env_var="VTDD_MCP_TOKEN"' -c 'mcp_servers.vtdd.default_tools_approval_mode="approve"' -c 'mcp_servers.vtdd.tools.vtdd_runtime_truth.approval_mode="approve"' ...` で `vtdd_runtime_truth` success を確認。
- Evidence path/link: docs/architecture/vtdd-mcp-ver.md, test/vtdd-mcp-ver-architecture.test.js, local codex exec JSON evidence captured during Issue #329 investigation.

## Butler Completion Contract

- Owner goal: Butler は変えず、Mac Codex / VPS Codex CLI が Codex exec mode でも shared truth surface を読める最小既知正常系を確定する。
- Butler entrypoint: Unchanged; Butler remains on Action Schema in this slice.
- Action Schema exposure: Not required in this Codex CLI investigation slice.
- Runtime path: Mac Codex / VPS Codex CLI -> codex exec MCP config with approval overrides -> /mcp -> shared VTDD runtime truth handlers.
- Runner/runtime truth: Codex exec now reaches the same github_runtime_truth payload when the MCP server/tool approval modes are explicitly set to approve.
- Authority boundary: Read-only MCP retrieval only; no new write or high-risk authority.
- E2E evidence: Butler path is unchanged; this slice proves the Codex-side read path in exec mode.
- Completion status: complete

## Surface Update Checklist

- Cloudflare deploy: Not required.
- Custom GPT Action Schema update: Not required.
- Custom GPT Instructions update: Not required.
- iPhone Butler live E2E: Not required.

## Related Constitution Rules

- Current Reality Guard
- Evidence Discipline
- Butler Completion Gate

## Out-of-scope but NOT implemented

- Butler surface replacement
- VTDD dangerous/write MCP operations
- Declaring Issue #318 complete

## Extra changes (if any)

This PR documents that the observed `user cancelled MCP tool call` was caused by exec-mode MCP approval elicitation, not by a VTDD-specific MCP server defect.

<!-- VTDD metadata -->
- Issue: #329
- Execution ID: Not provided.
- Goal: Not provided.
