### PR TITLE
Issue #314: trust-bound review response mapping

### DIFF
--- a/src/core/gemini-pr-review.js
+++ b/src/core/gemini-pr-review.js
@@ -235,15 +235,19 @@ function reviewSignalSortTime(signal) {
 
 function isAfterReviewerMarker(comment, reviewerSignal) {
   const reviewerTime = reviewSignalSortTime(reviewerSignal);
-  const responseTime = normalizeCommentSortTime(comment);
-  if (!reviewerTime || !responseTime) {
-    return true;
+  const responseTime = normalizeCommentCreatedTime(comment);
+  if (!isValidIsoTime(reviewerTime) || !isValidIsoTime(responseTime)) {
+    return false;
   }
-  return compareIsoText(responseTime, reviewerTime) >= 0;
+  return Date.parse(responseTime) > Date.parse(reviewerTime);
 }
 
-function normalizeCommentSortTime(comment) {
-  return normalizeText(comment?.updatedAt ?? comment?.updated_at ?? comment?.createdAt ?? comment?.created_at);
+function normalizeCommentCreatedTime(comment) {
+  return normalizeText(comment?.createdAt ?? comment?.created_at);
+}
+
+function isValidIsoTime(value) {
+  return Number.isFinite(Date.parse(normalizeText(value)));
 }
 
 function compareIsoText(left, right) {

--- a/src/core/gemini-pr-review.js
+++ b/src/core/gemini-pr-review.js
@@ -173,7 +173,7 @@ export function buildReviewResponseSummary(input = {}) {
     return null;
   }
 
-  const responseComments = excludeAmbiguousResponseCommentTimes(comments
+  const responseComments = sortResponseCommentsByCreatedAt(excludeAmbiguousResponseCommentTimes(comments
     .filter((comment) =>
       isTrustedReviewerObjectionResolutionComment(comment) &&
       isAfterReviewerMarker(comment, latestReviewer)
@@ -185,7 +185,7 @@ export function buildReviewResponseSummary(input = {}) {
       updatedAt: normalizeText(comment?.updatedAt ?? comment?.updated_at) || null,
       body: normalizeMultilineText(comment?.body)
     }))
-    .filter((comment) => comment.body));
+    .filter((comment) => comment.body)));
   const responseText = responseComments.map((comment) => comment.body).join("\n\n");
   const criticalFindings = latestReviewer.criticalFindings;
   const risks = latestReviewer.risks;
@@ -258,7 +258,7 @@ function normalizeCommentCreatedTime(comment) {
 }
 
 function isValidIsoTime(value) {
-  return Number.isFinite(Date.parse(normalizeText(value)));
+  return /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/.test(normalizeText(value));
 }
 
 function excludeAmbiguousResponseCommentTimes(comments) {
@@ -268,6 +268,10 @@ function excludeAmbiguousResponseCommentTimes(comments) {
     counts.set(time, (counts.get(time) || 0) + 1);
   }
   return comments.filter((comment) => counts.get(normalizeText(comment?.createdAt)) === 1);
+}
+
+function sortResponseCommentsByCreatedAt(comments) {
+  return [...comments].sort((left, right) => Date.parse(left.createdAt) - Date.parse(right.createdAt));
 }
 
 function compareIsoText(left, right) {

--- a/src/core/gemini-pr-review.js
+++ b/src/core/gemini-pr-review.js
@@ -218,15 +218,26 @@ export function buildReviewResponseSummary(input = {}) {
 }
 
 function collectLatestGeminiReviewerComment(comments) {
-  return (Array.isArray(comments) ? comments : [])
+  const reviewerSignals = (Array.isArray(comments) ? comments : [])
     .map(parseGeminiReviewComment)
     .filter(Boolean)
-    .sort(compareReviewerSignals)
-    .at(-1) ?? null;
-}
+    .map((signal) => ({
+      signal,
+      sortTime: reviewSignalSortTime(signal)
+    }))
+    .filter(({ sortTime }) => isValidIsoTime(sortTime))
+    .sort((left, right) => Date.parse(left.sortTime) - Date.parse(right.sortTime));
 
-function compareReviewerSignals(left, right) {
-  return compareIsoText(reviewSignalSortTime(left), reviewSignalSortTime(right));
+  const latest = reviewerSignals.at(-1);
+  if (!latest) {
+    return null;
+  }
+  const latestTime = Date.parse(latest.sortTime);
+  const sameLatestTimeCount = reviewerSignals.filter(({ sortTime }) => Date.parse(sortTime) === latestTime).length;
+  if (sameLatestTimeCount > 1) {
+    return null;
+  }
+  return latest.signal;
 }
 
 function reviewSignalSortTime(signal) {

--- a/src/core/gemini-pr-review.js
+++ b/src/core/gemini-pr-review.js
@@ -173,7 +173,7 @@ export function buildReviewResponseSummary(input = {}) {
     return null;
   }
 
-  const responseComments = comments
+  const responseComments = excludeAmbiguousResponseCommentTimes(comments
     .filter((comment) =>
       isTrustedReviewerObjectionResolutionComment(comment) &&
       isAfterReviewerMarker(comment, latestReviewer)
@@ -185,7 +185,7 @@ export function buildReviewResponseSummary(input = {}) {
       updatedAt: normalizeText(comment?.updatedAt ?? comment?.updated_at) || null,
       body: normalizeMultilineText(comment?.body)
     }))
-    .filter((comment) => comment.body);
+    .filter((comment) => comment.body));
   const responseText = responseComments.map((comment) => comment.body).join("\n\n");
   const criticalFindings = latestReviewer.criticalFindings;
   const risks = latestReviewer.risks;
@@ -259,6 +259,15 @@ function normalizeCommentCreatedTime(comment) {
 
 function isValidIsoTime(value) {
   return Number.isFinite(Date.parse(normalizeText(value)));
+}
+
+function excludeAmbiguousResponseCommentTimes(comments) {
+  const counts = new Map();
+  for (const comment of comments) {
+    const time = normalizeText(comment?.createdAt);
+    counts.set(time, (counts.get(time) || 0) + 1);
+  }
+  return comments.filter((comment) => counts.get(normalizeText(comment?.createdAt)) === 1);
 }
 
 function compareIsoText(left, right) {

--- a/src/core/gemini-pr-review.js
+++ b/src/core/gemini-pr-review.js
@@ -168,15 +168,21 @@ export function buildReviewResponseSummary(input = {}) {
     ...(Array.isArray(input.issueComments) ? input.issueComments : []),
     ...(Array.isArray(input.reviewComments) ? input.reviewComments : [])
   ];
-  const latestReviewer = comments.map(parseGeminiReviewComment).filter(Boolean).at(-1);
+  const latestReviewer = collectLatestGeminiReviewerComment(comments);
   if (!latestReviewer || latestReviewer.recommendedAction !== "request_changes") {
     return null;
   }
 
   const responseComments = comments
-    .filter((comment) => isTrustedReviewerObjectionResolution(comment?.body))
+    .filter((comment) =>
+      isTrustedReviewerObjectionResolutionComment(comment) &&
+      isAfterReviewerMarker(comment, latestReviewer)
+    )
     .map((comment) => ({
       url: normalizeText(comment?.url ?? comment?.htmlUrl ?? comment?.html_url) || null,
+      author: normalizeCommentAuthor(comment) || null,
+      createdAt: normalizeText(comment?.createdAt ?? comment?.created_at) || null,
+      updatedAt: normalizeText(comment?.updatedAt ?? comment?.updated_at) || null,
       body: normalizeMultilineText(comment?.body)
     }))
     .filter((comment) => comment.body);
@@ -209,6 +215,44 @@ export function buildReviewResponseSummary(input = {}) {
     unresolvedItems,
     complete: unresolvedItems.length === 0
   };
+}
+
+function collectLatestGeminiReviewerComment(comments) {
+  return (Array.isArray(comments) ? comments : [])
+    .map(parseGeminiReviewComment)
+    .filter(Boolean)
+    .sort(compareReviewerSignals)
+    .at(-1) ?? null;
+}
+
+function compareReviewerSignals(left, right) {
+  return compareIsoText(reviewSignalSortTime(left), reviewSignalSortTime(right));
+}
+
+function reviewSignalSortTime(signal) {
+  return normalizeText(signal?.updatedAt) || normalizeText(signal?.createdAt);
+}
+
+function isAfterReviewerMarker(comment, reviewerSignal) {
+  const reviewerTime = reviewSignalSortTime(reviewerSignal);
+  const responseTime = normalizeCommentSortTime(comment);
+  if (!reviewerTime || !responseTime) {
+    return true;
+  }
+  return compareIsoText(responseTime, reviewerTime) >= 0;
+}
+
+function normalizeCommentSortTime(comment) {
+  return normalizeText(comment?.updatedAt ?? comment?.updated_at ?? comment?.createdAt ?? comment?.created_at);
+}
+
+function compareIsoText(left, right) {
+  const leftTime = Date.parse(left);
+  const rightTime = Date.parse(right);
+  if (Number.isFinite(leftTime) && Number.isFinite(rightTime)) {
+    return leftTime - rightTime;
+  }
+  return normalizeText(left).localeCompare(normalizeText(right));
 }
 
 export function formatReviewResponseSummary(summary = {}) {
@@ -585,6 +629,26 @@ function containsMarker(value) {
 
 function isTrustedReviewerObjectionResolution(value) {
   return normalizeText(value).includes(REVIEWER_OBJECTION_RESOLUTION_MARKER);
+}
+
+function isTrustedReviewerObjectionResolutionComment(comment) {
+  return isTrustedReviewerObjectionResolution(comment?.body) && isTrustedCommentAuthor(comment);
+}
+
+function isTrustedCommentAuthor(comment) {
+  const author = normalizeCommentAuthor(comment).toLowerCase();
+  const association = normalizeText(comment?.authorAssociation ?? comment?.author_association).toUpperCase();
+  return (
+    author === "vtdd-codex" ||
+    author === "vtdd-codex[bot]" ||
+    association === "OWNER" ||
+    association === "MEMBER" ||
+    association === "COLLABORATOR"
+  );
+}
+
+function normalizeCommentAuthor(comment) {
+  return normalizeText(comment?.user?.login ?? comment?.author?.login ?? comment?.author);
 }
 
 function normalizeInlineText(value) {

--- a/test/execution-continuity.test.js
+++ b/test/execution-continuity.test.js
@@ -268,11 +268,14 @@ test("execution continuity blocks readiness when request_changes finding is not 
             {
               user: { login: "vtdd-codex[bot]" },
               url: "https://github.com/example/repo/pull/314#issuecomment-review",
+              created_at: "2026-05-13T10:00:00Z",
+              updated_at: "2026-05-13T10:00:00Z",
               body: "<!-- vtdd:reviewer=gemini -->\n## VTDD Gemini レビュー\n\n- Recommended action: `request_changes`\n\n### 重要指摘\n- response summary is missing\n\n### 残リスク\n- rerun evidence must include the response packet"
             },
             {
               user: { login: "vtdd-codex[bot]" },
               url: "https://github.com/example/repo/pull/314#issuecomment-response",
+              created_at: "2026-05-13T10:01:00Z",
               body: "<!-- vtdd:reviewer-objection-resolution -->\n## VTDD Reviewer Objection Resolution\n\nEvidence: node --test test/gemini-pr-review.test.js"
             }
           ]

--- a/test/gemini-pr-review.test.js
+++ b/test/gemini-pr-review.test.js
@@ -206,6 +206,8 @@ test("buildReviewResponseSummary maps request_changes findings to response evide
   const reviewerComment = {
     user: { login: "vtdd-codex[bot]" },
     url: "https://github.com/example/repo/pull/207#issuecomment-review",
+    created_at: "2026-05-13T01:00:00Z",
+    updated_at: "2026-05-13T01:00:00Z",
     body: `${GEMINI_PR_REVIEW_MARKER}
 ## VTDD Gemini レビュー
 
@@ -220,6 +222,7 @@ test("buildReviewResponseSummary maps request_changes findings to response evide
   const responseComment = {
     user: { login: "vtdd-codex[bot]" },
     url: "https://github.com/example/repo/pull/207#issuecomment-response",
+    created_at: "2026-05-13T01:01:00Z",
     body: `${REVIEWER_OBJECTION_RESOLUTION_MARKER}
 ## VTDD Reviewer Objection Resolution
 
@@ -251,6 +254,8 @@ test("buildReviewResponseSummary supports explicit critical finding ids and unre
   const reviewerComment = {
     user: { login: "vtdd-codex[bot]" },
     url: "https://github.com/example/repo/pull/314#issuecomment-review",
+    created_at: "2026-05-13T02:00:00Z",
+    updated_at: "2026-05-13T02:00:00Z",
     body: `${GEMINI_PR_REVIEW_MARKER}
 ## VTDD Gemini レビュー
 
@@ -265,6 +270,7 @@ test("buildReviewResponseSummary supports explicit critical finding ids and unre
   };
   const responseComment = {
     user: { login: "vtdd-codex[bot]" },
+    created_at: "2026-05-13T02:01:00Z",
     body: `${REVIEWER_OBJECTION_RESOLUTION_MARKER}
 ## VTDD Reviewer Objection Resolution
 
@@ -377,6 +383,116 @@ Evidence: untrusted claim`
   ]);
   assert.deepEqual(summary.unresolvedItems, ["trusted response must be after current review"]);
   assert.equal(summary.complete, false);
+});
+
+test("buildReviewResponseSummary excludes response comments without a valid created_at boundary", () => {
+  const reviewerComment = {
+    user: { login: "vtdd-codex[bot]" },
+    created_at: "2026-05-13T04:00:00Z",
+    updated_at: "2026-05-13T04:00:00Z",
+    body: `${GEMINI_PR_REVIEW_MARKER}
+## VTDD Gemini レビュー
+
+- Recommended action: \`request_changes\`
+
+### 重要指摘
+- evidence needs a trustworthy timestamp`
+  };
+  const missingTimestampResponse = {
+    user: { login: "marushu" },
+    author_association: "OWNER",
+    body: `${REVIEWER_OBJECTION_RESOLUTION_MARKER}
+Addresses: critical-1
+Evidence: missing timestamp`
+  };
+  const invalidTimestampResponse = {
+    user: { login: "marushu" },
+    author_association: "OWNER",
+    created_at: "not-a-date",
+    body: `${REVIEWER_OBJECTION_RESOLUTION_MARKER}
+Addresses: critical-1
+Evidence: invalid timestamp`
+  };
+
+  const summary = buildReviewResponseSummary({
+    pullRequest: {},
+    issueComments: [reviewerComment, missingTimestampResponse, invalidTimestampResponse]
+  });
+
+  assert.deepEqual(summary.responseCommentUrls, []);
+  assert.deepEqual(summary.findingResponses.map((item) => [item.id, item.status]), [
+    ["critical-1", "unresolved"]
+  ]);
+  assert.deepEqual(summary.unresolvedItems, ["evidence needs a trustworthy timestamp"]);
+});
+
+test("buildReviewResponseSummary uses response created_at, not updated_at, for stale exclusion", () => {
+  const reviewerComment = {
+    user: { login: "vtdd-codex[bot]" },
+    created_at: "2026-05-13T05:00:00Z",
+    updated_at: "2026-05-13T05:00:00Z",
+    body: `${GEMINI_PR_REVIEW_MARKER}
+## VTDD Gemini レビュー
+
+- Recommended action: \`request_changes\`
+
+### 重要指摘
+- old edited response must not count`
+  };
+  const editedOldResponse = {
+    user: { login: "marushu" },
+    author_association: "OWNER",
+    created_at: "2026-05-13T04:59:00Z",
+    updated_at: "2026-05-13T05:01:00Z",
+    body: `${REVIEWER_OBJECTION_RESOLUTION_MARKER}
+Addresses: critical-1
+Evidence: edited after reviewer marker`
+  };
+
+  const summary = buildReviewResponseSummary({
+    pullRequest: {},
+    issueComments: [editedOldResponse, reviewerComment]
+  });
+
+  assert.deepEqual(summary.responseCommentUrls, []);
+  assert.deepEqual(summary.findingResponses.map((item) => [item.id, item.status]), [
+    ["critical-1", "unresolved"]
+  ]);
+  assert.deepEqual(summary.unresolvedItems, ["old edited response must not count"]);
+});
+
+test("buildReviewResponseSummary treats same-timestamp response comments as unresolved", () => {
+  const reviewerComment = {
+    user: { login: "vtdd-codex[bot]" },
+    created_at: "2026-05-13T06:00:00Z",
+    updated_at: "2026-05-13T06:00:00Z",
+    body: `${GEMINI_PR_REVIEW_MARKER}
+## VTDD Gemini レビュー
+
+- Recommended action: \`request_changes\`
+
+### 重要指摘
+- same timestamp is ambiguous`
+  };
+  const sameTimestampResponse = {
+    user: { login: "marushu" },
+    author_association: "OWNER",
+    created_at: "2026-05-13T06:00:00Z",
+    body: `${REVIEWER_OBJECTION_RESOLUTION_MARKER}
+Addresses: critical-1
+Evidence: same timestamp`
+  };
+
+  const summary = buildReviewResponseSummary({
+    pullRequest: {},
+    issueComments: [reviewerComment, sameTimestampResponse]
+  });
+
+  assert.deepEqual(summary.responseCommentUrls, []);
+  assert.deepEqual(summary.findingResponses.map((item) => [item.id, item.status]), [
+    ["critical-1", "unresolved"]
+  ]);
+  assert.deepEqual(summary.unresolvedItems, ["same timestamp is ambiguous"]);
 });
 
 test("parseGeminiReviewComment accepts legacy English reviewer sections", () => {

--- a/test/gemini-pr-review.test.js
+++ b/test/gemini-pr-review.test.js
@@ -288,6 +288,97 @@ Unresolved: critical-2 remains blocked until deploy/live Butler E2E is authorize
   assert.match(formatReviewResponseSummary(summary), /critical-2: unresolved/);
 });
 
+test("buildReviewResponseSummary chooses latest reviewer marker by timestamp across comment arrays", () => {
+  const olderReviewComment = {
+    user: { login: "vtdd-codex[bot]" },
+    url: "https://github.com/example/repo/pull/314#discussion-old",
+    created_at: "2026-05-13T01:00:00Z",
+    updated_at: "2026-05-13T01:00:00Z",
+    body: `${GEMINI_PR_REVIEW_MARKER}
+## VTDD Gemini レビュー
+
+- Recommended action: \`request_changes\`
+
+### 重要指摘
+- old finding should not be latest`
+  };
+  const newerIssueComment = {
+    user: { login: "vtdd-codex[bot]" },
+    url: "https://github.com/example/repo/pull/314#issuecomment-new",
+    created_at: "2026-05-13T02:00:00Z",
+    updated_at: "2026-05-13T02:30:00Z",
+    body: `${GEMINI_PR_REVIEW_MARKER}
+## VTDD Gemini レビュー
+
+- Recommended action: \`request_changes\`
+
+### 重要指摘
+- latest finding must be used`
+  };
+  const responseComment = {
+    user: { login: "marushu" },
+    author_association: "OWNER",
+    created_at: "2026-05-13T02:31:00Z",
+    body: `${REVIEWER_OBJECTION_RESOLUTION_MARKER}
+Addresses: critical-1
+Evidence: npm test`
+  };
+
+  const summary = buildReviewResponseSummary({
+    pullRequest: {},
+    issueComments: [newerIssueComment, responseComment],
+    reviewComments: [olderReviewComment]
+  });
+
+  assert.equal(summary.reviewerCommentUrl, "https://github.com/example/repo/pull/314#issuecomment-new");
+  assert.deepEqual(summary.criticalFindings, ["latest finding must be used"]);
+  assert.deepEqual(summary.unresolvedItems, []);
+});
+
+test("buildReviewResponseSummary ignores stale and untrusted objection resolution comments", () => {
+  const reviewerComment = {
+    user: { login: "vtdd-codex[bot]" },
+    url: "https://github.com/example/repo/pull/314#issuecomment-review",
+    created_at: "2026-05-13T03:00:00Z",
+    updated_at: "2026-05-13T03:00:00Z",
+    body: `${GEMINI_PR_REVIEW_MARKER}
+## VTDD Gemini レビュー
+
+- Recommended action: \`request_changes\`
+
+### 重要指摘
+- trusted response must be after current review`
+  };
+  const staleOwnerResponse = {
+    user: { login: "marushu" },
+    author_association: "OWNER",
+    created_at: "2026-05-13T02:00:00Z",
+    body: `${REVIEWER_OBJECTION_RESOLUTION_MARKER}
+Addresses: critical-1
+Evidence: old npm test`
+  };
+  const untrustedNewResponse = {
+    user: { login: "external-user" },
+    author_association: "NONE",
+    created_at: "2026-05-13T03:01:00Z",
+    body: `${REVIEWER_OBJECTION_RESOLUTION_MARKER}
+Addresses: critical-1
+Evidence: untrusted claim`
+  };
+
+  const summary = buildReviewResponseSummary({
+    pullRequest: {},
+    issueComments: [staleOwnerResponse, reviewerComment, untrustedNewResponse]
+  });
+
+  assert.deepEqual(summary.responseCommentUrls, []);
+  assert.deepEqual(summary.findingResponses.map((item) => [item.id, item.status]), [
+    ["critical-1", "unresolved"]
+  ]);
+  assert.deepEqual(summary.unresolvedItems, ["trusted response must be after current review"]);
+  assert.equal(summary.complete, false);
+});
+
 test("parseGeminiReviewComment accepts legacy English reviewer sections", () => {
   const parsed = parseGeminiReviewComment({
     body: `${GEMINI_PR_REVIEW_MARKER}

--- a/test/gemini-pr-review.test.js
+++ b/test/gemini-pr-review.test.js
@@ -626,6 +626,51 @@ Evidence: npm test`
   assert.deepEqual(summary.criticalFindings, ["edited reviewer marker is latest content"]);
 });
 
+test("buildReviewResponseSummary excludes trusted response comments with duplicate created_at timestamps", () => {
+  const reviewerComment = {
+    user: { login: "vtdd-codex[bot]" },
+    created_at: "2026-05-13T10:00:00Z",
+    updated_at: "2026-05-13T10:00:00Z",
+    body: `${GEMINI_PR_REVIEW_MARKER}
+## VTDD Gemini レビュー
+
+- Recommended action: \`request_changes\`
+
+### 重要指摘
+- duplicate response timestamps are ambiguous`
+  };
+  const firstResponse = {
+    user: { login: "marushu" },
+    author_association: "OWNER",
+    url: "https://github.com/example/repo/pull/314#issuecomment-response-1",
+    created_at: "2026-05-13T10:01:00Z",
+    body: `${REVIEWER_OBJECTION_RESOLUTION_MARKER}
+Addresses: critical-1
+Evidence: first same-time response`
+  };
+  const secondResponse = {
+    user: { login: "marushu" },
+    author_association: "OWNER",
+    url: "https://github.com/example/repo/pull/314#issuecomment-response-2",
+    created_at: "2026-05-13T10:01:00Z",
+    body: `${REVIEWER_OBJECTION_RESOLUTION_MARKER}
+Addresses: critical-1
+Evidence: second same-time response`
+  };
+
+  const summary = buildReviewResponseSummary({
+    pullRequest: {},
+    issueComments: [reviewerComment, firstResponse],
+    reviewComments: [secondResponse]
+  });
+
+  assert.deepEqual(summary.responseCommentUrls, []);
+  assert.deepEqual(summary.findingResponses.map((item) => [item.id, item.status]), [
+    ["critical-1", "unresolved"]
+  ]);
+  assert.deepEqual(summary.unresolvedItems, ["duplicate response timestamps are ambiguous"]);
+});
+
 test("parseGeminiReviewComment accepts legacy English reviewer sections", () => {
   const parsed = parseGeminiReviewComment({
     body: `${GEMINI_PR_REVIEW_MARKER}

--- a/test/gemini-pr-review.test.js
+++ b/test/gemini-pr-review.test.js
@@ -671,6 +671,86 @@ Evidence: second same-time response`
   assert.deepEqual(summary.unresolvedItems, ["duplicate response timestamps are ambiguous"]);
 });
 
+test("buildReviewResponseSummary sorts trusted response comments by created_at across comment arrays", () => {
+  const reviewerComment = {
+    user: { login: "vtdd-codex[bot]" },
+    created_at: "2026-05-13T11:00:00Z",
+    updated_at: "2026-05-13T11:00:00Z",
+    body: `${GEMINI_PR_REVIEW_MARKER}
+## VTDD Gemini レビュー
+
+- Recommended action: \`request_changes\`
+
+### 重要指摘
+- first response evidence
+- second response evidence`
+  };
+  const laterIssueResponse = {
+    user: { login: "marushu" },
+    author_association: "OWNER",
+    url: "https://github.com/example/repo/pull/314#issuecomment-later",
+    created_at: "2026-05-13T11:03:00Z",
+    body: `${REVIEWER_OBJECTION_RESOLUTION_MARKER}
+Addresses: critical-2
+Evidence: second response evidence`
+  };
+  const earlierReviewResponse = {
+    user: { login: "marushu" },
+    author_association: "OWNER",
+    url: "https://github.com/example/repo/pull/314#discussion-earlier",
+    created_at: "2026-05-13T11:02:00Z",
+    body: `${REVIEWER_OBJECTION_RESOLUTION_MARKER}
+Addresses: critical-1
+Evidence: first response evidence`
+  };
+
+  const summary = buildReviewResponseSummary({
+    pullRequest: {},
+    issueComments: [reviewerComment, laterIssueResponse],
+    reviewComments: [earlierReviewResponse]
+  });
+
+  assert.deepEqual(summary.responseCommentUrls, [
+    "https://github.com/example/repo/pull/314#discussion-earlier",
+    "https://github.com/example/repo/pull/314#issuecomment-later"
+  ]);
+  assert.deepEqual(summary.unresolvedItems, []);
+});
+
+test("buildReviewResponseSummary rejects non-GitHub-ISO timestamp strings", () => {
+  const reviewerComment = {
+    user: { login: "vtdd-codex[bot]" },
+    created_at: "2026-05-13T12:00:00Z",
+    updated_at: "2026-05-13T12:00:00Z",
+    body: `${GEMINI_PR_REVIEW_MARKER}
+## VTDD Gemini レビュー
+
+- Recommended action: \`request_changes\`
+
+### 重要指摘
+- ambiguous date string must not count`
+  };
+  const ambiguousResponse = {
+    user: { login: "marushu" },
+    author_association: "OWNER",
+    created_at: "May 13 2026 12:01:00",
+    body: `${REVIEWER_OBJECTION_RESOLUTION_MARKER}
+Addresses: critical-1
+Evidence: ambiguous date string`
+  };
+
+  const summary = buildReviewResponseSummary({
+    pullRequest: {},
+    issueComments: [reviewerComment, ambiguousResponse]
+  });
+
+  assert.deepEqual(summary.responseCommentUrls, []);
+  assert.deepEqual(summary.findingResponses.map((item) => [item.id, item.status]), [
+    ["critical-1", "unresolved"]
+  ]);
+  assert.deepEqual(summary.unresolvedItems, ["ambiguous date string must not count"]);
+});
+
 test("parseGeminiReviewComment accepts legacy English reviewer sections", () => {
   const parsed = parseGeminiReviewComment({
     body: `${GEMINI_PR_REVIEW_MARKER}

--- a/test/gemini-pr-review.test.js
+++ b/test/gemini-pr-review.test.js
@@ -495,6 +495,137 @@ Evidence: same timestamp`
   assert.deepEqual(summary.unresolvedItems, ["same timestamp is ambiguous"]);
 });
 
+test("buildReviewResponseSummary ignores reviewer markers without valid timestamps", () => {
+  const invalidReviewerComment = {
+    user: { login: "vtdd-codex[bot]" },
+    created_at: "not-a-date",
+    updated_at: "zzzz-invalid",
+    body: `${GEMINI_PR_REVIEW_MARKER}
+## VTDD Gemini レビュー
+
+- Recommended action: \`request_changes\`
+
+### 重要指摘
+- invalid reviewer marker must not become latest`
+  };
+  const validApproveComment = {
+    user: { login: "vtdd-codex[bot]" },
+    created_at: "2026-05-13T07:00:00Z",
+    updated_at: "2026-05-13T07:00:00Z",
+    body: `${GEMINI_PR_REVIEW_MARKER}
+## VTDD Gemini レビュー
+
+- Recommended action: \`approve\`
+
+### 重要指摘
+- 報告なし。`
+  };
+  const responseComment = {
+    user: { login: "marushu" },
+    author_association: "OWNER",
+    created_at: "2026-05-13T07:01:00Z",
+    body: `${REVIEWER_OBJECTION_RESOLUTION_MARKER}
+Addresses: critical-1
+Evidence: invalid marker should be ignored`
+  };
+
+  const summary = buildReviewResponseSummary({
+    pullRequest: {},
+    issueComments: [validApproveComment, invalidReviewerComment, responseComment]
+  });
+
+  assert.equal(summary, null);
+});
+
+test("buildReviewResponseSummary treats same-timestamp reviewer markers as ambiguous", () => {
+  const firstReviewerComment = {
+    user: { login: "vtdd-codex[bot]" },
+    created_at: "2026-05-13T08:00:00Z",
+    updated_at: "2026-05-13T08:00:00Z",
+    body: `${GEMINI_PR_REVIEW_MARKER}
+## VTDD Gemini レビュー
+
+- Recommended action: \`request_changes\`
+
+### 重要指摘
+- first same-time finding`
+  };
+  const secondReviewerComment = {
+    user: { login: "vtdd-codex[bot]" },
+    created_at: "2026-05-13T08:00:00Z",
+    updated_at: "2026-05-13T08:00:00Z",
+    body: `${GEMINI_PR_REVIEW_MARKER}
+## VTDD Gemini レビュー
+
+- Recommended action: \`request_changes\`
+
+### 重要指摘
+- second same-time finding`
+  };
+  const responseComment = {
+    user: { login: "marushu" },
+    author_association: "OWNER",
+    created_at: "2026-05-13T08:01:00Z",
+    body: `${REVIEWER_OBJECTION_RESOLUTION_MARKER}
+Addresses: critical-1
+Evidence: array order must not choose a reviewer marker`
+  };
+
+  const summary = buildReviewResponseSummary({
+    pullRequest: {},
+    issueComments: [firstReviewerComment, responseComment],
+    reviewComments: [secondReviewerComment]
+  });
+
+  assert.equal(summary, null);
+});
+
+test("buildReviewResponseSummary uses reviewer updated_at as the explicit latest marker revision time", () => {
+  const olderEditedReviewerComment = {
+    user: { login: "vtdd-codex[bot]" },
+    url: "https://github.com/example/repo/pull/314#issuecomment-edited",
+    created_at: "2026-05-13T08:30:00Z",
+    updated_at: "2026-05-13T09:30:00Z",
+    body: `${GEMINI_PR_REVIEW_MARKER}
+## VTDD Gemini レビュー
+
+- Recommended action: \`request_changes\`
+
+### 重要指摘
+- edited reviewer marker is latest content`
+  };
+  const newerCreatedReviewerComment = {
+    user: { login: "vtdd-codex[bot]" },
+    url: "https://github.com/example/repo/pull/314#issuecomment-created",
+    created_at: "2026-05-13T09:00:00Z",
+    updated_at: "2026-05-13T09:00:00Z",
+    body: `${GEMINI_PR_REVIEW_MARKER}
+## VTDD Gemini レビュー
+
+- Recommended action: \`request_changes\`
+
+### 重要指摘
+- created later but edited marker should win`
+  };
+  const responseComment = {
+    user: { login: "marushu" },
+    author_association: "OWNER",
+    created_at: "2026-05-13T09:31:00Z",
+    body: `${REVIEWER_OBJECTION_RESOLUTION_MARKER}
+Addresses: critical-1
+Evidence: npm test`
+  };
+
+  const summary = buildReviewResponseSummary({
+    pullRequest: {},
+    issueComments: [olderEditedReviewerComment, responseComment],
+    reviewComments: [newerCreatedReviewerComment]
+  });
+
+  assert.equal(summary.reviewerCommentUrl, "https://github.com/example/repo/pull/314#issuecomment-edited");
+  assert.deepEqual(summary.criticalFindings, ["edited reviewer marker is latest content"]);
+});
+
 test("parseGeminiReviewComment accepts legacy English reviewer sections", () => {
   const parsed = parseGeminiReviewComment({
     body: `${GEMINI_PR_REVIEW_MARKER}
@@ -531,6 +662,8 @@ test("buildPullRequestReviewContext passes unresolved response summary to Gemini
       {
         user: { login: "vtdd-codex[bot]" },
         url: "https://github.com/example/repo/pull/314#issuecomment-review",
+        created_at: "2026-05-13T10:30:00Z",
+        updated_at: "2026-05-13T10:30:00Z",
         body: `${GEMINI_PR_REVIEW_MARKER}
 ## VTDD Gemini レビュー
 

--- a/worker.js
+++ b/worker.js
@@ -34441,14 +34441,17 @@ function reviewSignalSortTime(signal) {
 }
 function isAfterReviewerMarker(comment, reviewerSignal) {
   const reviewerTime = reviewSignalSortTime(reviewerSignal);
-  const responseTime = normalizeCommentSortTime(comment);
-  if (!reviewerTime || !responseTime) {
-    return true;
+  const responseTime = normalizeCommentCreatedTime(comment);
+  if (!isValidIsoTime(reviewerTime) || !isValidIsoTime(responseTime)) {
+    return false;
   }
-  return compareIsoText(responseTime, reviewerTime) >= 0;
+  return Date.parse(responseTime) > Date.parse(reviewerTime);
 }
-function normalizeCommentSortTime(comment) {
-  return normalizeText20(comment?.updatedAt ?? comment?.updated_at ?? comment?.createdAt ?? comment?.created_at);
+function normalizeCommentCreatedTime(comment) {
+  return normalizeText20(comment?.createdAt ?? comment?.created_at);
+}
+function isValidIsoTime(value) {
+  return Number.isFinite(Date.parse(normalizeText20(value)));
 }
 function compareIsoText(left, right) {
   const leftTime = Date.parse(left);

--- a/worker.js
+++ b/worker.js
@@ -34394,7 +34394,7 @@ function buildReviewResponseSummary(input = {}) {
   if (!latestReviewer || latestReviewer.recommendedAction !== "request_changes") {
     return null;
   }
-  const responseComments = comments.filter(
+  const responseComments = excludeAmbiguousResponseCommentTimes(comments.filter(
     (comment) => isTrustedReviewerObjectionResolutionComment(comment) && isAfterReviewerMarker(comment, latestReviewer)
   ).map((comment) => ({
     url: normalizeText20(comment?.url ?? comment?.htmlUrl ?? comment?.html_url) || null,
@@ -34402,7 +34402,7 @@ function buildReviewResponseSummary(input = {}) {
     createdAt: normalizeText20(comment?.createdAt ?? comment?.created_at) || null,
     updatedAt: normalizeText20(comment?.updatedAt ?? comment?.updated_at) || null,
     body: normalizeMultilineText(comment?.body)
-  })).filter((comment) => comment.body);
+  })).filter((comment) => comment.body));
   const responseText = responseComments.map((comment) => comment.body).join("\n\n");
   const criticalFindings = latestReviewer.criticalFindings;
   const risks = latestReviewer.risks;
@@ -34462,6 +34462,14 @@ function normalizeCommentCreatedTime(comment) {
 }
 function isValidIsoTime(value) {
   return Number.isFinite(Date.parse(normalizeText20(value)));
+}
+function excludeAmbiguousResponseCommentTimes(comments) {
+  const counts = /* @__PURE__ */ new Map();
+  for (const comment of comments) {
+    const time3 = normalizeText20(comment?.createdAt);
+    counts.set(time3, (counts.get(time3) || 0) + 1);
+  }
+  return comments.filter((comment) => counts.get(normalizeText20(comment?.createdAt)) === 1);
 }
 function parseGeminiReviewComment(comment = {}) {
   const body = normalizeText20(typeof comment === "string" ? comment : comment?.body);

--- a/worker.js
+++ b/worker.js
@@ -34431,10 +34431,20 @@ function buildReviewResponseSummary(input = {}) {
   };
 }
 function collectLatestGeminiReviewerComment(comments) {
-  return (Array.isArray(comments) ? comments : []).map(parseGeminiReviewComment).filter(Boolean).sort(compareReviewerSignals).at(-1) ?? null;
-}
-function compareReviewerSignals(left, right) {
-  return compareIsoText(reviewSignalSortTime(left), reviewSignalSortTime(right));
+  const reviewerSignals = (Array.isArray(comments) ? comments : []).map(parseGeminiReviewComment).filter(Boolean).map((signal) => ({
+    signal,
+    sortTime: reviewSignalSortTime(signal)
+  })).filter(({ sortTime }) => isValidIsoTime(sortTime)).sort((left, right) => Date.parse(left.sortTime) - Date.parse(right.sortTime));
+  const latest = reviewerSignals.at(-1);
+  if (!latest) {
+    return null;
+  }
+  const latestTime = Date.parse(latest.sortTime);
+  const sameLatestTimeCount = reviewerSignals.filter(({ sortTime }) => Date.parse(sortTime) === latestTime).length;
+  if (sameLatestTimeCount > 1) {
+    return null;
+  }
+  return latest.signal;
 }
 function reviewSignalSortTime(signal) {
   return normalizeText20(signal?.updatedAt) || normalizeText20(signal?.createdAt);
@@ -34452,14 +34462,6 @@ function normalizeCommentCreatedTime(comment) {
 }
 function isValidIsoTime(value) {
   return Number.isFinite(Date.parse(normalizeText20(value)));
-}
-function compareIsoText(left, right) {
-  const leftTime = Date.parse(left);
-  const rightTime = Date.parse(right);
-  if (Number.isFinite(leftTime) && Number.isFinite(rightTime)) {
-    return leftTime - rightTime;
-  }
-  return normalizeText20(left).localeCompare(normalizeText20(right));
 }
 function parseGeminiReviewComment(comment = {}) {
   const body = normalizeText20(typeof comment === "string" ? comment : comment?.body);

--- a/worker.js
+++ b/worker.js
@@ -34394,7 +34394,7 @@ function buildReviewResponseSummary(input = {}) {
   if (!latestReviewer || latestReviewer.recommendedAction !== "request_changes") {
     return null;
   }
-  const responseComments = excludeAmbiguousResponseCommentTimes(comments.filter(
+  const responseComments = sortResponseCommentsByCreatedAt(excludeAmbiguousResponseCommentTimes(comments.filter(
     (comment) => isTrustedReviewerObjectionResolutionComment(comment) && isAfterReviewerMarker(comment, latestReviewer)
   ).map((comment) => ({
     url: normalizeText20(comment?.url ?? comment?.htmlUrl ?? comment?.html_url) || null,
@@ -34402,7 +34402,7 @@ function buildReviewResponseSummary(input = {}) {
     createdAt: normalizeText20(comment?.createdAt ?? comment?.created_at) || null,
     updatedAt: normalizeText20(comment?.updatedAt ?? comment?.updated_at) || null,
     body: normalizeMultilineText(comment?.body)
-  })).filter((comment) => comment.body));
+  })).filter((comment) => comment.body)));
   const responseText = responseComments.map((comment) => comment.body).join("\n\n");
   const criticalFindings = latestReviewer.criticalFindings;
   const risks = latestReviewer.risks;
@@ -34461,7 +34461,7 @@ function normalizeCommentCreatedTime(comment) {
   return normalizeText20(comment?.createdAt ?? comment?.created_at);
 }
 function isValidIsoTime(value) {
-  return Number.isFinite(Date.parse(normalizeText20(value)));
+  return /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/.test(normalizeText20(value));
 }
 function excludeAmbiguousResponseCommentTimes(comments) {
   const counts = /* @__PURE__ */ new Map();
@@ -34470,6 +34470,9 @@ function excludeAmbiguousResponseCommentTimes(comments) {
     counts.set(time3, (counts.get(time3) || 0) + 1);
   }
   return comments.filter((comment) => counts.get(normalizeText20(comment?.createdAt)) === 1);
+}
+function sortResponseCommentsByCreatedAt(comments) {
+  return [...comments].sort((left, right) => Date.parse(left.createdAt) - Date.parse(right.createdAt));
 }
 function parseGeminiReviewComment(comment = {}) {
   const body = normalizeText20(typeof comment === "string" ? comment : comment?.body);

--- a/worker.js
+++ b/worker.js
@@ -34390,12 +34390,17 @@ function buildReviewResponseSummary(input = {}) {
     ...Array.isArray(input.issueComments) ? input.issueComments : [],
     ...Array.isArray(input.reviewComments) ? input.reviewComments : []
   ];
-  const latestReviewer = comments.map(parseGeminiReviewComment).filter(Boolean).at(-1);
+  const latestReviewer = collectLatestGeminiReviewerComment(comments);
   if (!latestReviewer || latestReviewer.recommendedAction !== "request_changes") {
     return null;
   }
-  const responseComments = comments.filter((comment) => isTrustedReviewerObjectionResolution(comment?.body)).map((comment) => ({
+  const responseComments = comments.filter(
+    (comment) => isTrustedReviewerObjectionResolutionComment(comment) && isAfterReviewerMarker(comment, latestReviewer)
+  ).map((comment) => ({
     url: normalizeText20(comment?.url ?? comment?.htmlUrl ?? comment?.html_url) || null,
+    author: normalizeCommentAuthor(comment) || null,
+    createdAt: normalizeText20(comment?.createdAt ?? comment?.created_at) || null,
+    updatedAt: normalizeText20(comment?.updatedAt ?? comment?.updated_at) || null,
     body: normalizeMultilineText(comment?.body)
   })).filter((comment) => comment.body);
   const responseText = responseComments.map((comment) => comment.body).join("\n\n");
@@ -34424,6 +34429,34 @@ function buildReviewResponseSummary(input = {}) {
     unresolvedItems,
     complete: unresolvedItems.length === 0
   };
+}
+function collectLatestGeminiReviewerComment(comments) {
+  return (Array.isArray(comments) ? comments : []).map(parseGeminiReviewComment).filter(Boolean).sort(compareReviewerSignals).at(-1) ?? null;
+}
+function compareReviewerSignals(left, right) {
+  return compareIsoText(reviewSignalSortTime(left), reviewSignalSortTime(right));
+}
+function reviewSignalSortTime(signal) {
+  return normalizeText20(signal?.updatedAt) || normalizeText20(signal?.createdAt);
+}
+function isAfterReviewerMarker(comment, reviewerSignal) {
+  const reviewerTime = reviewSignalSortTime(reviewerSignal);
+  const responseTime = normalizeCommentSortTime(comment);
+  if (!reviewerTime || !responseTime) {
+    return true;
+  }
+  return compareIsoText(responseTime, reviewerTime) >= 0;
+}
+function normalizeCommentSortTime(comment) {
+  return normalizeText20(comment?.updatedAt ?? comment?.updated_at ?? comment?.createdAt ?? comment?.created_at);
+}
+function compareIsoText(left, right) {
+  const leftTime = Date.parse(left);
+  const rightTime = Date.parse(right);
+  if (Number.isFinite(leftTime) && Number.isFinite(rightTime)) {
+    return leftTime - rightTime;
+  }
+  return normalizeText20(left).localeCompare(normalizeText20(right));
 }
 function parseGeminiReviewComment(comment = {}) {
   const body = normalizeText20(typeof comment === "string" ? comment : comment?.body);
@@ -34539,6 +34572,17 @@ function containsMarker2(value) {
 }
 function isTrustedReviewerObjectionResolution(value) {
   return normalizeText20(value).includes(REVIEWER_OBJECTION_RESOLUTION_MARKER);
+}
+function isTrustedReviewerObjectionResolutionComment(comment) {
+  return isTrustedReviewerObjectionResolution(comment?.body) && isTrustedCommentAuthor(comment);
+}
+function isTrustedCommentAuthor(comment) {
+  const author = normalizeCommentAuthor(comment).toLowerCase();
+  const association = normalizeText20(comment?.authorAssociation ?? comment?.author_association).toUpperCase();
+  return author === "vtdd-codex" || author === "vtdd-codex[bot]" || association === "OWNER" || association === "MEMBER" || association === "COLLABORATOR";
+}
+function normalizeCommentAuthor(comment) {
+  return normalizeText20(comment?.user?.login ?? comment?.author?.login ?? comment?.author);
 }
 function normalizeInlineText(value) {
   return normalizeMultilineText(value).replace(/\s+/g, " ").trim();


### PR DESCRIPTION
## This PR satisfies Intent

- #314 の request_changes response summary が stale または untrusted comments を Gemini rerun input に混ぜないようにする follow-up slice。PR #335 post-merge review と PR #336 reviewer feedback で指摘された最新 marker 選択、response comment 時系列境界、trusted author 境界、reviewer/response timestamp ambiguity、response evidence ordering を実装する。

## Satisfied Success Criteria

- 最新 Gemini reviewer marker を issue comments / review comments 横断の valid timestamp ordering で選ぶ。\nreviewer marker の timestamp 欠落/invalid は latest marker 候補から除外する。\n同一 latest timestamp の複数 reviewer marker は ambiguous として response summary を作らない。\nreviewer marker の updated_at は marker comment が編集更新された最新レビュー内容の時刻として採用し、テストで固定した。\nresponse comments を latest reviewer marker 後の objection-resolution marker comments に限定する。\nresponse marker comments を vtdd-codex または OWNER/MEMBER/COLLABORATOR authorAssociation に限定する。\nresponse comment の境界を created_at 基準に固定し、updated_at 後編集では stale response を復活させない。\nresponse comment の timestamp 欠落、invalid timestamp、reviewer marker と同一 timestamp、response comment 同士の同一 timestamp は ambiguous として response summary input から除外する。\nresponse evidence は issueComments / reviewComments の配列順ではなく created_at 昇順で Gemini rerun input に渡す。\nDate.parse 可能な自然言語日付ではなく GitHub API の UTC ISO timestamp 形式だけを有効 timestamp として扱う。\ncross-array ordering、stale/untrusted response exclusion、response timestamp 欠落/invalid/後編集/同一 timestamp、reviewer marker timestamp 欠落/invalid/同一 timestamp、response evidence created_at sort の unit tests を追加した。

## Unsatisfied Success Criteria

- live Butler/iPhone E2E はこのPRスライスでは未実施。\n#314 の Issue closure は merged code、mapped E2E evidence、人間の closure judgment が揃うまで未完了。

## Non-goal violations

None.

## Verification Evidence

- Unit: node --test test/gemini-pr-review.test.js test/execution-continuity.test.js test/butler-review-synthesis.test.js: pass (56 tests). npm test: pass (715 passed, 1 skipped).
- Integration: npm test に含まれる worker MCP review_truth、check:self-parity、check:generated-worker: pass.
- E2E: live Butler E2E は未実施。local Worker/MCP contract tests は pass.
- Manual: git diff --check: pass.
- Evidence path/link: test/gemini-pr-review.test.js; test/execution-continuity.test.js; src/core/gemini-pr-review.js; worker.js generated parity; PR #335 post-merge Codex fallback findings; PR #336 reviewer findings.

## Butler Completion Contract

- Owner goal: reviewer request_changes への対応 summary を stale/untrusted/ambiguous timestamp input なしで、created_at 昇順の evidence として Gemini rerun に渡す。
- Butler entrypoint: 既存の review truth path: evaluateExecutionContinuity / vtdd_review_truth。
- Action Schema exposure: 未変更。既存の review truth surface を使用。
- Runtime path: src/core/gemini-pr-review.js buildReviewResponseSummary -> buildPullRequestReviewContext -> worker.js generated runtime.
- Runner/runtime truth: valid latest marker と trusted, uniquely-timestamped, created-after-marker response comments を created_at 昇順で summary に含める。stale/untrusted/timestamp-ambiguous response comments と ambiguous reviewer marker state は excluded/unresolved として扱う。
- Authority boundary: 未変更。deploy、credential mutation、permission mutation、merge、Issue close は含まない。
- E2E evidence: 未実施。このPRは local contract/unit evidence まで。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 不要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。

## Related Constitution Rules

- AGENTS.md Drift Stop Protocol: #314 に限定。\nEvidence Discipline: executed tests and generated worker parity を記載。\nButler Completion Gate: live Butler E2E 未実施のため incomplete。\nAuthority Boundary: high-risk external effects なし。

## Out-of-scope but NOT implemented

- Issue close。\nDeploy / credential mutation / permission mutation。\nSemantic AI matching or freeform reviewer response inference。\n#317 umbrella completion judgment。

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: #314
- Execution ID: Not provided.
- Goal: Issue #314 trust-bound review response mapping follow-up
