### PR TITLE
Issue #266: keep known-good recovery page open

### DIFF
--- a/src/core/custom-gpt-setup-artifacts.js
+++ b/src/core/custom-gpt-setup-artifacts.js
@@ -571,7 +571,12 @@ export function renderCustomGptRecoveryPage(input = {}) {
     </section>
     ${
       error
-        ? `<section class="warning"><strong>Recovery bundle unavailable.</strong><p>${escapeHtml(error.reason || error.error || "unknown error")}</p></section>`
+        ? renderRecoveryUnavailableSection({
+            error,
+            channel,
+            latestHref,
+            knownGoodHref
+          })
         : ""
     }
     ${
@@ -600,6 +605,32 @@ export function renderCustomGptRecoveryPage(input = {}) {
   </script>
 </body>
 </html>`;
+}
+
+function renderRecoveryUnavailableSection({ error, channel, latestHref, knownGoodHref }) {
+  const reason = error?.reason || error?.error || "unknown error";
+  if (channel !== CustomGptSetupChannel.KNOWN_GOOD) {
+    return `<section class="warning"><strong>Recovery bundle unavailable.</strong><p>${escapeHtml(reason)}</p></section>`;
+  }
+
+  return `<section class="warning">
+      <strong>Known-good bundle is not configured yet.</strong>
+      <p>${escapeHtml(reason)}</p>
+      <p>このページ自体は復旧導線として開けています。main/latest を known-good として silent fallback しないため、rollback bundle は表示していません。</p>
+      <p><a class="button" href="${escapeAttribute(latestHref)}">Open setup/latest instead</a></p>
+      <pre>${escapeHtml(
+        [
+          "known-good unavailable",
+          "reason: VTDD_KNOWN_GOOD_COMMIT_SHA is missing or invalid",
+          `knownGoodUrl: ${knownGoodHref}`,
+          `latestFallbackUrl: ${latestHref}`,
+          "nextSteps:",
+          "  1. Use setup/latest only as the current candidate bundle.",
+          "  2. After a human verifies a working setup commit, set VTDD_KNOWN_GOOD_COMMIT_SHA to that 40-character commit SHA.",
+          "  3. Do not treat main/latest as known-good automatically."
+        ].join("\n")
+      )}</pre>
+    </section>`;
 }
 
 function buildSetupPageHref({ path, ref, issueNumber }) {

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -768,8 +768,12 @@ test("worker setup known-good page does not silently treat main as known-good", 
 
   assert.equal(response.status, 200);
   const html = await response.text();
-  assert.equal(html.includes("Recovery bundle unavailable."), true);
+  assert.equal(html.includes("Known-good bundle is not configured yet."), true);
+  assert.equal(html.includes("このページ自体は復旧導線として開けています。"), true);
   assert.equal(html.includes("known-good setup requires VTDD_KNOWN_GOOD_COMMIT_SHA"), true);
+  assert.equal(html.includes("Open setup/latest instead"), true);
+  assert.equal(html.includes("latestFallbackUrl: /setup/latest"), true);
+  assert.equal(html.includes("Do not treat main/latest as known-good automatically."), true);
   assert.equal(html.includes("Copy-ready Action Schema"), false);
   assert.equal(html.includes("Copy-ready custom-gpt-instructions-short-min.md"), false);
 });
@@ -785,7 +789,8 @@ test("worker setup known-good page rejects malformed configured known-good refs"
 
   assert.equal(response.status, 200);
   const html = await response.text();
-  assert.equal(html.includes("Recovery bundle unavailable."), true);
+  assert.equal(html.includes("Known-good bundle is not configured yet."), true);
+  assert.equal(html.includes("Open setup/latest instead"), true);
   assert.equal(html.includes("known-good setup requires VTDD_KNOWN_GOOD_COMMIT_SHA"), true);
   assert.equal(html.includes("Copy Rollback Bundle"), false);
 });

--- a/worker.js
+++ b/worker.js
@@ -36349,7 +36349,12 @@ function renderCustomGptRecoveryPage(input = {}) {
       <a class="button" href="${escapeAttribute2(latestHref)}">setup/latest</a>
       <a class="button" href="${escapeAttribute2(knownGoodHref)}">setup/known-good</a>
     </section>
-    ${error2 ? `<section class="warning"><strong>Recovery bundle unavailable.</strong><p>${escapeHtml3(error2.reason || error2.error || "unknown error")}</p></section>` : ""}
+    ${error2 ? renderRecoveryUnavailableSection({
+    error: error2,
+    channel,
+    latestHref,
+    knownGoodHref
+  }) : ""}
     ${recovery ? renderRecoveryBundleSections(recovery) : `<p class="small">${escapeHtml3(runtimeOrigin)} \u5411\u3051\u306E ${escapeHtml3(channel)} setup bundle \u3092\u8AAD\u307F\u8FBC\u3093\u3067\u3044\u307E\u3059\u3002repo \u5165\u529B\u306F\u4E0D\u8981\u3067\u3059\u3002</p>`}
   </main>
   <script>
@@ -36372,6 +36377,30 @@ function renderCustomGptRecoveryPage(input = {}) {
   <\/script>
 </body>
 </html>`;
+}
+function renderRecoveryUnavailableSection({ error: error2, channel, latestHref, knownGoodHref }) {
+  const reason = error2?.reason || error2?.error || "unknown error";
+  if (channel !== CustomGptSetupChannel.KNOWN_GOOD) {
+    return `<section class="warning"><strong>Recovery bundle unavailable.</strong><p>${escapeHtml3(reason)}</p></section>`;
+  }
+  return `<section class="warning">
+      <strong>Known-good bundle is not configured yet.</strong>
+      <p>${escapeHtml3(reason)}</p>
+      <p>\u3053\u306E\u30DA\u30FC\u30B8\u81EA\u4F53\u306F\u5FA9\u65E7\u5C0E\u7DDA\u3068\u3057\u3066\u958B\u3051\u3066\u3044\u307E\u3059\u3002main/latest \u3092 known-good \u3068\u3057\u3066 silent fallback \u3057\u306A\u3044\u305F\u3081\u3001rollback bundle \u306F\u8868\u793A\u3057\u3066\u3044\u307E\u305B\u3093\u3002</p>
+      <p><a class="button" href="${escapeAttribute2(latestHref)}">Open setup/latest instead</a></p>
+      <pre>${escapeHtml3(
+    [
+      "known-good unavailable",
+      "reason: VTDD_KNOWN_GOOD_COMMIT_SHA is missing or invalid",
+      `knownGoodUrl: ${knownGoodHref}`,
+      `latestFallbackUrl: ${latestHref}`,
+      "nextSteps:",
+      "  1. Use setup/latest only as the current candidate bundle.",
+      "  2. After a human verifies a working setup commit, set VTDD_KNOWN_GOOD_COMMIT_SHA to that 40-character commit SHA.",
+      "  3. Do not treat main/latest as known-good automatically."
+    ].join("\n")
+  )}</pre>
+    </section>`;
 }
 function buildSetupPageHref({ path, ref, issueNumber }) {
   const params = new URLSearchParams();


### PR DESCRIPTION
## This PR satisfies Intent

- #266 の setup/recovery UX 修正。known-good SHA が未設定/不正でも /setup/known-good 自体は復旧導線として開けるようにし、理由、latest fallback、known-good SHA 設定手順を表示する。#242 の Action Schema が壊れてもブラウザから復旧できる導線、#305 の known-good は main/latest に silent fallback しない境界にも対応する。

## Satisfied Success Criteria

- /setup/known-good は known-good SHA 未設定でも 200 HTML として開く。
- 未設定/不正時は Known-good bundle is not configured yet と理由を表示する。
- /setup/latest への fallback ボタンと latestFallbackUrl を表示する。
- VTDD_KNOWN_GOOD_COMMIT_SHA の設定手順を表示する。
- main/latest を known-good として silent fallback しない既存境界は維持する。
- secret / token / approval grant は表示しない。
- worker.js を再生成して generated worker parity を維持した。

## Unsatisfied Success Criteria

- 本番 Worker への deploy は未実施。
- 実機 iPhone/Safari での live open 確認は未実施。
- known-good SHA の repository variable 設定/更新は未実施。これは GO + passkey または人間手動設定が必要。

## Non-goal violations

None.

## Verification Evidence

- Unit: node --test test/worker.test.js: pass (108 tests). npm test: pass (717 passed, 1 skipped).
- Integration: npm test に含まれる check:self-parity と check:generated-worker: pass.
- E2E: live Worker / iPhone Safari E2E は未実施。deploy なしの local Worker route evidence まで。
- Manual: git diff --check: pass.
- Evidence path/link: src/core/custom-gpt-setup-artifacts.js; test/worker.test.js; worker.js generated parity.

## Butler Completion Contract

- Owner goal: known-good が未設定でも復旧ページを開けるようにし、Butler が壊れた時の逃げ道を塞がない。
- Butler entrypoint: /setup/known-good browser route。Action Schema に依存しない human-openable recovery page。
- Action Schema exposure: 未変更。HTTP browser route の表示改善のみ。
- Runtime path: src/worker/runtime.js handleCustomGptRecoveryPageRequest -> renderCustomGptRecoveryPage -> renderRecoveryUnavailableSection。
- Runner/runtime truth: known-good SHA 未設定/不正時も page は 200 で開き、known-good unavailable / latest fallback / next steps を表示する。main/latest は known-good として扱わない。
- Authority boundary: 未変更。repository variable mutation, deploy, credential/permission mutation は含まない。known-good SHA 更新は GO + passkey または人間手動設定が必要。
- E2E evidence: 未実施。このPRは local route/unit/integration evidence まで。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 未実施。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate: deploy/live E2E 未実施のため incomplete。
- #266: setup/recovery page は VTDD repo を既定にし latest と known-good を分離する。
- #242: Action Schema が壊れても setup/recovery page は通常 HTTP route として開ける。
- #305: known-good は main/latest に silent fallback しない。

## Out-of-scope but NOT implemented

- 本番 deploy。
- VTDD_KNOWN_GOOD_COMMIT_SHA の設定/更新。
- Custom GPT editor 自動操作。
- merge / Issue close。
- Butler reviewer manual_review semantics の修正。

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: #266
- Execution ID: Not provided.
- Goal: Issue #266 known-good recovery page remains open
