### PR TITLE
ci: update GitHub Actions to Node 24

### DIFF
--- a/.github/workflows/codex-pr-review-fallback.yml
+++ b/.github/workflows/codex-pr-review-fallback.yml
@@ -73,7 +73,7 @@ jobs:
           owner: ${{ github.repository_owner }}
 
       - name: Checkout trusted reviewer source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ github.repository }}
           ref: ${{ github.ref }}
@@ -82,9 +82,9 @@ jobs:
           persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
           cache-dependency-path: trusted/package-lock.json
 

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -77,12 +77,12 @@ jobs:
           fi
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Install dependencies
         run: npm ci
@@ -131,7 +131,7 @@ jobs:
           EOF
 
       - name: Deploy to Cloudflare Workers
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@v4
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         with:

--- a/.github/workflows/gemini-pr-review.yml
+++ b/.github/workflows/gemini-pr-review.yml
@@ -59,16 +59,16 @@ jobs:
 
       - name: Checkout repository
         if: ${{ steps.app_secrets.outputs.configured == 'true' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup Node.js
         if: ${{ steps.app_secrets.outputs.configured == 'true' }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
 
       - name: Install reviewer dependencies

--- a/.github/workflows/guarded-autonomy-required-checks.yml
+++ b/.github/workflows/guarded-autonomy-required-checks.yml
@@ -143,12 +143,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Install dependencies
         run: npm install --no-audit --no-fund

--- a/.github/workflows/remote-codex-executor.yml
+++ b/.github/workflows/remote-codex-executor.yml
@@ -113,7 +113,7 @@ jobs:
           owner: ${{ github.repository_owner }}
 
       - name: Checkout target repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ env.TARGET_REPOSITORY }}
           ref: ${{ env.BASE_REF }}
@@ -129,9 +129,9 @@ jobs:
           git checkout -B "$TARGET_BRANCH"
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Install Codex CLI
         shell: bash

--- a/test/github-actions-node-runtime.test.js
+++ b/test/github-actions-node-runtime.test.js
@@ -1,0 +1,31 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const WORKFLOW_DIR = path.join(process.cwd(), ".github", "workflows");
+
+test("GitHub Actions workflows use Node 24-compatible action/runtime versions", () => {
+  const workflows = fs
+    .readdirSync(WORKFLOW_DIR)
+    .filter((file) => file.endsWith(".yml") || file.endsWith(".yaml"));
+
+  assert.ok(workflows.length > 0);
+
+  for (const workflow of workflows) {
+    const content = fs.readFileSync(path.join(WORKFLOW_DIR, workflow), "utf8");
+    assert.equal(content.includes("actions/checkout@v4"), false, workflow);
+    assert.equal(content.includes("actions/setup-node@v4"), false, workflow);
+    assert.equal(content.includes("cloudflare/wrangler-action@v3"), false, workflow);
+    assert.equal(content.includes("node-version: 20"), false, workflow);
+  }
+
+  const joined = workflows
+    .map((workflow) => fs.readFileSync(path.join(WORKFLOW_DIR, workflow), "utf8"))
+    .join("\n");
+
+  assert.equal(joined.includes("actions/checkout@v6"), true);
+  assert.equal(joined.includes("actions/setup-node@v6"), true);
+  assert.equal(joined.includes("cloudflare/wrangler-action@v4"), true);
+  assert.equal(joined.includes("node-version: 24"), true);
+});


### PR DESCRIPTION
## This PR satisfies Intent

- GitHub Actions の Node.js 20 deprecation warning を解消し、deploy/reviewer/remote Codex/guarded-policy workflow を Node 24 対応 runtime へ保守更新する。

## Satisfied Success Criteria

- checkout/setup-node/wrangler-action を Node 24 対応 major に更新した。
- 全 workflow の node-version を 24 に統一した。
- Node 20/旧 action への回帰を検知する guard test を追加した。

## Unsatisfied Success Criteria

- Custom GPT editor に実際に貼られている Action Schema / Instructions の editor-side 状態は外部から検証できないため、runtime self-parity と setup/latest 配信確認までを evidence とする。

## Non-goal violations

None.

## Verification Evidence

- Unit: npm test passed: 724 pass / 0 fail / 1 skipped.
- Integration: npm run check:self-parity passed; npm run check:generated-worker passed.
- E2E: Production deploy run 25808007351 succeeded before this PR; this PR is workflow maintenance and does not dispatch a new deploy.
- Manual: Authenticated self-parity on production returned runtimeParity=in_sync with no missing routes/operationIds/instructionTokens; /setup/latest exposes copy-ready Action Schema and short-min Instructions.
- Evidence path/link: https://github.com/marushu/vtdd-v2-p/actions/runs/25808007351

## Butler Completion Contract

- Owner goal: GitHub Actions Node 20 deprecation warning を消し、VTDD の deploy/review/runner CI 経路を Node 24 対応に保つ。
- Butler entrypoint: 未変更。Butler / Action Schema / runtime routes はこのPRでは変更しない。
- Action Schema exposure: 不要。production self-parity は in_sync。
- Runtime path: GitHub Actions workflows only: deploy-production, guarded-autonomy, Gemini review, Codex fallback, remote Codex executor.
- Runner/runtime truth: Production deploy run 25808007351 succeeded; current production self-parity is in_sync.
- Authority boundary: 未変更。deploy remains GO + real passkey; secrets/permissions/Cloudflare bindings are unchanged.
- E2E evidence: 未実施。このPRは CI/workflow maintenance であり、Butler-facing Action behavior は変更しない。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 不要。このPRは workflow definition update; merge後の次回 deploy で Node 24 action runtime が使われる。
- Custom GPT Action Schema update: 不要。self-parity in_sync.
- Custom GPT Instructions update: 不要。self-parity in_sync; editor-side paste state is not externally introspectable.
- iPhone Butler live E2E: 不要。iPhone Butler live E2E 対象の behavior change なし。

## Related Constitution Rules

- runtime_truth_over_memory
- no_out_of_scope_implementation
- require_traceability_to_issue_sections

## Out-of-scope but NOT implemented

- Cloudflare deploy execution path, passkey approval model, secrets, permissions, runner behavior, Custom GPT artifact content are not changed.

## Extra changes (if any)

Added a guard test to prevent reverting workflows to Node 20-era action/runtime versions.

<!-- VTDD metadata -->
- Issue:
- Execution ID: Not provided.
- Goal: Not provided.
