### PR TITLE
Issue #343: RAG 記憶候補にテンションノートを追加

### DIFF
--- a/docs/memory-schema.md
+++ b/docs/memory-schema.md
@@ -23,7 +23,14 @@ These families are required by Issue #2 and form the core VTDD memory model.
 ### `temperature_note`
 - Purpose: preserve user intent temperature such as urgency, preference, and
   avoidance direction
-- Typical content: desired direction, avoid list, current emphasis
+- Typical content: desired direction, avoid list, current emphasis, origin,
+  short user words, tension note, restart triggers
+
+`temperature_note` records are recall hooks, not personality labels. They may
+preserve where an idea came from, what the owner briefly said, and why the
+moment's tension matters for later restart. They must not store full casual
+conversation transcripts, secrets, or "avoid being scolded" style compliance
+notes.
 
 ### `repair_case`
 - Purpose: retain concrete failure and recovery knowledge

--- a/docs/memory/operational-memory-layer.md
+++ b/docs/memory/operational-memory-layer.md
@@ -41,6 +41,11 @@ separate from historical memory.
   `temperature_note`
 - Role: preserve operational continuity across sessions and repositories
 
+`temperature_note` preserves restart cues such as where an idea emerged, short
+owner words, and the moment's tension. It is a recall hook, not a personality
+assessment, and must stay compact enough for the owner to reread later on an
+iPhone or iPad.
+
 ### Layer 4: Semantic Operational Patterns
 
 - Scope: cross-project heuristics, preferred workflows, disliked operational

--- a/docs/setup/custom-gpt-actions-openapi.json
+++ b/docs/setup/custom-gpt-actions-openapi.json
@@ -1087,6 +1087,7 @@
                       "decision_log",
                       "proposal_log",
                       "working_memory",
+                      "temperature_note",
                       "repair_case"
                     ]
                   },
@@ -1179,6 +1180,82 @@
                       "action_visible"
                     ],
                     "description": "Use action_visible from Custom GPT so memory write failures return ok:false JSON instead of an Action transport failure."
+                  },
+                  "origin": {
+                    "type": "object",
+                    "description": "Recall-hook provenance such as surface, moment, trigger, and sourceUrl.",
+                    "additionalProperties": false,
+                    "properties": {
+                      "surface": {
+                        "type": "string"
+                      },
+                      "moment": {
+                        "type": "string"
+                      },
+                      "trigger": {
+                        "type": "string"
+                      },
+                      "sourceUrl": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "userWords": {
+                    "type": "array",
+                    "description": "Short owner words or paraphrases that help later recall. Do not send full transcripts.",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "tensionNote": {
+                    "type": "object",
+                    "description": "Structured tension note for recall, not personality judgment.",
+                    "additionalProperties": false,
+                    "properties": {
+                      "summary": {
+                        "type": "string"
+                      },
+                      "intensity": {
+                        "type": "string",
+                        "enum": [
+                          "low",
+                          "medium",
+                          "high"
+                        ]
+                      },
+                      "mode": {
+                        "type": "string"
+                      },
+                      "whyItMatters": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "restartTriggers": {
+                    "type": "array",
+                    "description": "Short phrases that help the owner resume later.",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "outcome": {
+                    "type": "object",
+                    "description": "Compact outcome such as issue, PR, status, or notes.",
+                    "additionalProperties": false,
+                    "properties": {
+                      "status": {
+                        "type": "string"
+                      },
+                      "issue": {
+                        "type": "string"
+                      },
+                      "pullRequest": {
+                        "type": "string"
+                      },
+                      "notes": {
+                        "type": "string"
+                      }
+                    }
                   }
                 },
                 "additionalProperties": false

--- a/docs/setup/custom-gpt-actions-openapi.yaml
+++ b/docs/setup/custom-gpt-actions-openapi.yaml
@@ -736,6 +736,7 @@ paths:
                     - decision_log
                     - proposal_log
                     - working_memory
+                    - temperature_note
                     - repair_case
                 confirmed:
                   type: boolean
@@ -751,6 +752,59 @@ paths:
                   type: string
                 details:
                   type: string
+                origin:
+                  type: object
+                  description: Recall-hook provenance such as surface, moment, trigger, and sourceUrl.
+                  additionalProperties: false
+                  properties:
+                    surface:
+                      type: string
+                    moment:
+                      type: string
+                    trigger:
+                      type: string
+                    sourceUrl:
+                      type: string
+                userWords:
+                  type: array
+                  description: Short owner words or paraphrases that help later recall. Do not send full transcripts.
+                  items:
+                    type: string
+                tensionNote:
+                  type: object
+                  description: Structured tension note for recall, not personality judgment.
+                  additionalProperties: false
+                  properties:
+                    summary:
+                      type: string
+                    intensity:
+                      type: string
+                      enum:
+                        - low
+                        - medium
+                        - high
+                    mode:
+                      type: string
+                    whyItMatters:
+                      type: string
+                restartTriggers:
+                  type: array
+                  description: Short phrases that help the owner resume later.
+                  items:
+                    type: string
+                outcome:
+                  type: object
+                  description: Compact outcome such as issue, PR, status, or notes.
+                  additionalProperties: false
+                  properties:
+                    status:
+                      type: string
+                    issue:
+                      type: string
+                    pullRequest:
+                      type: string
+                    notes:
+                      type: string
                 decision:
                   type: string
                 rationale:

--- a/docs/setup/custom-gpt-instructions-short-min.md
+++ b/docs/setup/custom-gpt-instructions-short-min.md
@@ -5,7 +5,7 @@ Role:
 Truth and scope:
 - Issue is canonical spec. GitHub/runtime state is progress truth. Runtime truth > memory.
 - If implementation work has no existing Issue yet, propose the Issue first, wait GO, create it, then hand off. Never PR/build first and Issue-link later; #303 is the regression example.
-- Before proposal/writes/Codex handoff/PR judgment/merge-deploy-close advice/stale setup claims: retrieve runtime/GitHub truth; use memory/constitution when useful. Report found/missing. Never invent. Reusable memory => show candidate, ask GO, vtddWriteOperationalMemory; no transcripts/secrets.
+- Before proposal/writes/Codex handoff/PR judgment/merge-deploy-close advice/stale setup claims: retrieve runtime/GitHub truth + memory/constitution. Never invent. Reusable memory/tension note => show origin/userWords/tensionNote/restartTriggers, ask GO, vtddWriteOperationalMemory; no transcripts/secrets.
 - No scope beyond user instruction + active Issue; do not reinterpret "MVP".
 - Do not assume a default repository. Resolve owner/repo from explicit input, alias, grant, or verified context; if ambiguous, ask one short confirmation.
 - No internal API paths/raw JSON for users. Convert natural intent into actions.

--- a/docs/setup/custom-gpt-instructions-short.md
+++ b/docs/setup/custom-gpt-instructions-short.md
@@ -1,8 +1,8 @@
 Butler
 Core:
 - Issue is canonical spec.
-- If implementation work does not already have an existing Issue, propose an Issue candidate first, wait for GO, create the Issue, then hand off. Do not create the PR/build first and issue-link later; #303 is the regression example.
-- Before proposal/write/Codex handoff/PR judgment: vtddRetrieveCrossMemory + vtddRetrieveDecisionLogs/vtddRetrieveProposalLogs/vtddRetrieveConstitution + runtime truth; no RAG hit OK, never invent. Reusable memory => show candidate, ask GO, vtddWriteOperationalMemory; no transcripts/secrets. Runtime truth > memory.
+- If implementation work has no existing Issue, propose an Issue candidate first, wait for GO, create the Issue, then hand off. #303 is the regression example.
+- Before proposal/write/Codex handoff/PR judgment: vtddRetrieveCrossMemory/vtddRetrieveDecisionLogs/vtddRetrieveProposalLogs/vtddRetrieveConstitution + runtime truth; no RAG hit OK, never invent. Reusable memory/tension note => show origin/userWords/tensionNote/restartTriggers, ask GO, vtddWriteOperationalMemory; no transcripts/secrets. Runtime truth > memory.
 - Do not assume a default repository. Resolve repo from alias/context; if ambiguous, ask.
 - Natural language to actions; no internal paths/raw JSON.
 - No scope beyond Issue/user instruction.

--- a/docs/setup/custom-gpt-instructions.md
+++ b/docs/setup/custom-gpt-instructions.md
@@ -122,7 +122,8 @@ VTDD context preflight / RAG:
 - Prefer both success and failure patterns when memory returns them.
 - If RAG/context retrieval is unavailable, say `RAG/context retrieval unavailable` and continue only when Issue/docs/runtime truth provide enough safe basis.
 - If runtime truth conflicts with memory, stop and reconcile instead of proceeding by memory.
-- When a reusable decision, blocker, failure pattern, repair, or handoff fact emerges, show a compact structured memory candidate, ask the human for GO, then call vtddWriteOperationalMemory. Do not store full transcripts, secrets, or raw sensitive material.
+- When a reusable decision, blocker, failure pattern, repair, handoff fact, or tension note emerges, show a compact structured memory candidate, ask the human for GO, then call vtddWriteOperationalMemory. Do not store full transcripts, secrets, or raw sensitive material.
+- Memory candidates should include recall hooks when useful: origin, short user words, tensionNote, restartTriggers, and outcome. A tension note is the moment's temperature for later recall, not a personality assessment.
 - After vtddWriteOperationalMemory succeeds, retrieve the related memory again and report the record id. If it fails, report the exact error/reason/issues.
 - Do not ask the human to name these internal retrieval routes in normal conversation.
 

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -251,6 +251,10 @@ export {
   validateIssueBody
 } from "./issue-body.js";
 export {
+  MEMORY_CANDIDATE_CONFIRMATION_PROMPT,
+  buildRagMemoryCandidate
+} from "./rag-memory-candidate.js";
+export {
   GitHubAppOperationRegistry,
   GitHubAppOperationTier,
   bindNaturalGitHubWriteApproval,

--- a/src/core/rag-memory-candidate.js
+++ b/src/core/rag-memory-candidate.js
@@ -1,0 +1,241 @@
+import { evaluateMemorySafety } from "./memory-safety.js";
+import { MemoryRecordType, validateMemoryRecord } from "./memory-schema.js";
+
+const MEMORY_CANDIDATE_CONFIRMATION_PROMPT =
+  "以下の内容で RAG に記憶します。よろしければ GO と言ってください。";
+
+const TENSION_INTENSITY_VALUES = new Set(["low", "medium", "high"]);
+const MAX_USER_WORDS = 3;
+const MAX_USER_WORD_LENGTH = 160;
+
+function buildRagMemoryCandidate(input = {}) {
+  const recordType = normalizeRecordType(input.recordType ?? input.type);
+  if (!recordType) {
+    return invalid("recordType must be decision_log, proposal_log, working_memory, temperature_note, or repair_case");
+  }
+
+  const relatedIssue = normalizeIssue(input.relatedIssue);
+  const repository = normalizeText(input.repository) || null;
+  const timestamp = normalizeText(input.timestamp) || new Date().toISOString();
+  const origin = normalizeOrigin(input.origin);
+  const userWords = normalizeUserWords(input.userWords ?? input.user_words);
+  const tensionNote = normalizeTensionNote(input.tensionNote ?? input.tension_note);
+  const restartTriggers = normalizeStringArray(input.restartTriggers ?? input.restart_triggers);
+  const outcome = normalizeOutcome(input.outcome);
+  const summary = normalizeText(input.summary);
+
+  const issues = [];
+  if (!summary) {
+    issues.push("summary is required");
+  }
+  if (!origin.surface && !origin.moment && !origin.trigger) {
+    issues.push("origin must include surface, moment, or trigger");
+  }
+  if (userWords.length === 0) {
+    issues.push("userWords must include at least one short quote or paraphrase");
+  }
+  if (!tensionNote.summary || !tensionNote.whyItMatters) {
+    issues.push("tensionNote.summary and tensionNote.whyItMatters are required");
+  }
+
+  const content = {
+    summary,
+    details: normalizeText(input.details) || null,
+    origin,
+    userWords,
+    tensionNote,
+    restartTriggers,
+    outcome,
+    relatedIssue,
+    repository,
+    timestamp
+  };
+
+  const metadata = {
+    ...normalizeObject(input.metadata),
+    relatedIssue,
+    repository,
+    source: normalizeText(input.source) || "rag_memory_candidate",
+    fullCasualChat: false,
+    recallHooks: true
+  };
+
+  const record = {
+    id: normalizeText(input.id) || buildCandidateRecordId({ recordType, relatedIssue, timestamp, summary }),
+    type: recordType,
+    content,
+    metadata,
+    priority: normalizePriority(input.priority, recordType === MemoryRecordType.TEMPERATURE_NOTE ? 75 : 65),
+    tags: buildCandidateTags({ recordType, relatedIssue, repository, extraTags: input.tags }),
+    createdAt: timestamp
+  };
+
+  const schema = validateMemoryRecord(record);
+  if (!schema.ok) {
+    issues.push(...schema.issues);
+  }
+
+  const safety = evaluateMemorySafety({
+    recordType,
+    content,
+    metadata
+  });
+  if (!safety.ok) {
+    issues.push(safety.reason || safety.rule || "memory safety check failed");
+  }
+
+  if (issues.length > 0) {
+    return {
+      ok: false,
+      issues,
+      candidate: {
+        confirmationPrompt: MEMORY_CANDIDATE_CONFIRMATION_PROMPT,
+        record
+      }
+    };
+  }
+
+  return {
+    ok: true,
+    candidate: {
+      confirmationPrompt: MEMORY_CANDIDATE_CONFIRMATION_PROMPT,
+      record,
+      writePayload: {
+        confirmed: false,
+        recordType,
+        repository,
+        relatedIssue,
+        summary,
+        details: content.details,
+        origin,
+        userWords,
+        tensionNote,
+        restartTriggers,
+        outcome,
+        metadata,
+        priority: record.priority,
+        tags: record.tags,
+        timestamp
+      }
+    }
+  };
+}
+
+function normalizeRecordType(value) {
+  const recordType = normalizeText(value);
+  if (
+    [
+      MemoryRecordType.DECISION_LOG,
+      MemoryRecordType.PROPOSAL_LOG,
+      MemoryRecordType.WORKING_MEMORY,
+      MemoryRecordType.TEMPERATURE_NOTE,
+      MemoryRecordType.REPAIR_CASE
+    ].includes(recordType)
+  ) {
+    return recordType;
+  }
+  return "";
+}
+
+function normalizeOrigin(value) {
+  const origin = normalizeObject(value);
+  return {
+    surface: normalizeText(origin.surface),
+    moment: normalizeText(origin.moment),
+    trigger: normalizeText(origin.trigger),
+    sourceUrl: normalizeText(origin.sourceUrl ?? origin.source_url) || null
+  };
+}
+
+function normalizeTensionNote(value) {
+  const note = normalizeObject(value);
+  const intensity = normalizeText(note.intensity);
+  return {
+    summary: normalizeText(note.summary),
+    intensity: TENSION_INTENSITY_VALUES.has(intensity) ? intensity : intensity || "medium",
+    mode: normalizeText(note.mode),
+    whyItMatters: normalizeText(note.whyItMatters ?? note.why_it_matters)
+  };
+}
+
+function normalizeOutcome(value) {
+  const outcome = normalizeObject(value);
+  return {
+    status: normalizeText(outcome.status),
+    issue: normalizeText(outcome.issue),
+    pullRequest: normalizeText(outcome.pullRequest ?? outcome.pull_request),
+    notes: normalizeText(outcome.notes)
+  };
+}
+
+function normalizeUserWords(value) {
+  return normalizeStringArray(value)
+    .slice(0, MAX_USER_WORDS)
+    .map((item) => item.slice(0, MAX_USER_WORD_LENGTH));
+}
+
+function buildCandidateRecordId({ recordType, relatedIssue, timestamp, summary }) {
+  const issuePart = relatedIssue ?? "none";
+  const timestampPart = normalizeText(timestamp).replace(/[^0-9]/g, "").slice(0, 14);
+  const summaryPart = normalizeTag(summary).slice(0, 40) || "candidate";
+  return `${recordType}_${issuePart}_${timestampPart}_${summaryPart}`;
+}
+
+function buildCandidateTags({ recordType, relatedIssue, repository, extraTags }) {
+  const tags = [
+    recordType,
+    "recall-hook",
+    relatedIssue ? `issue:${relatedIssue}` : null,
+    repository ? `repo:${normalizeTag(repository.replace("/", "_"))}` : null,
+    ...normalizeStringArray(extraTags)
+  ].filter(Boolean);
+  return [...new Set(tags)];
+}
+
+function normalizeIssue(value) {
+  const numeric = Number(value);
+  return Number.isInteger(numeric) && numeric > 0 ? numeric : null;
+}
+
+function normalizeObject(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return {};
+  }
+  return value;
+}
+
+function normalizeStringArray(value) {
+  const values = Array.isArray(value) ? value : value === undefined ? [] : [value];
+  return values.map(normalizeText).filter(Boolean);
+}
+
+function normalizePriority(value, fallback) {
+  const numeric = Number(value ?? fallback);
+  if (!Number.isFinite(numeric)) {
+    return fallback;
+  }
+  return Math.max(0, Math.min(100, Math.round(numeric)));
+}
+
+function normalizeTag(value) {
+  return normalizeText(value)
+    .toLowerCase()
+    .replace(/[^a-z0-9:_-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+function normalizeText(value) {
+  return String(value ?? "").trim();
+}
+
+function invalid(reason) {
+  return {
+    ok: false,
+    issues: [reason]
+  };
+}
+
+export {
+  MEMORY_CANDIDATE_CONFIRMATION_PROMPT,
+  buildRagMemoryCandidate
+};

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -1058,7 +1058,7 @@ function buildMemoryWriteRecord(payload = {}) {
   if (!recordType) {
     return {
       ok: false,
-      reason: "recordType must be decision_log, proposal_log, working_memory, or repair_case",
+      reason: "recordType must be decision_log, proposal_log, working_memory, temperature_note, or repair_case",
       issues: ["recordType is required"]
     };
   }
@@ -1124,7 +1124,7 @@ function buildMemoryWriteRecord(payload = {}) {
   if (!summary) {
     return {
       ok: false,
-      reason: "summary is required for working_memory and repair_case",
+      reason: "summary is required for working_memory, temperature_note, and repair_case",
       issues: ["summary is required"]
     };
   }
@@ -1137,6 +1137,11 @@ function buildMemoryWriteRecord(payload = {}) {
       content: {
         summary,
         details: normalizeText(payload.details) || null,
+        origin: normalizeMemoryOrigin(payload.origin),
+        userWords: normalizeStringArray(payload.userWords ?? payload.user_words).slice(0, 3),
+        tensionNote: normalizeMemoryTensionNote(payload.tensionNote ?? payload.tension_note),
+        restartTriggers: normalizeStringArray(payload.restartTriggers ?? payload.restart_triggers),
+        outcome: normalizeMemoryOutcome(payload.outcome),
         relatedIssue,
         repository,
         timestamp
@@ -1156,12 +1161,43 @@ function normalizeMemoryWriteRecordType(value) {
       MemoryRecordType.DECISION_LOG,
       MemoryRecordType.PROPOSAL_LOG,
       MemoryRecordType.WORKING_MEMORY,
+      MemoryRecordType.TEMPERATURE_NOTE,
       MemoryRecordType.REPAIR_CASE
     ].includes(type)
   ) {
     return type;
   }
   return "";
+}
+
+function normalizeMemoryOrigin(value) {
+  const origin = normalizeObject(value);
+  return {
+    surface: normalizeText(origin.surface) || null,
+    moment: normalizeText(origin.moment) || null,
+    trigger: normalizeText(origin.trigger) || null,
+    sourceUrl: normalizeText(origin.sourceUrl ?? origin.source_url) || null
+  };
+}
+
+function normalizeMemoryTensionNote(value) {
+  const note = normalizeObject(value);
+  return {
+    summary: normalizeText(note.summary) || null,
+    intensity: normalizeText(note.intensity) || null,
+    mode: normalizeText(note.mode) || null,
+    whyItMatters: normalizeText(note.whyItMatters ?? note.why_it_matters) || null
+  };
+}
+
+function normalizeMemoryOutcome(value) {
+  const outcome = normalizeObject(value);
+  return {
+    status: normalizeText(outcome.status) || null,
+    issue: normalizeText(outcome.issue) || null,
+    pullRequest: normalizeText(outcome.pullRequest ?? outcome.pull_request) || null,
+    notes: normalizeText(outcome.notes) || null
+  };
 }
 
 function normalizeMemoryPriority(value, fallback) {

--- a/test/custom-gpt-setup-docs.test.js
+++ b/test/custom-gpt-setup-docs.test.js
@@ -75,6 +75,8 @@ test("custom gpt instructions preserve current butler and approval boundaries", 
   assert.equal(doc.includes("do not invent past precedent"), true);
   assert.equal(doc.includes("current state is governed by GitHub runtime truth"), true);
   assert.equal(doc.includes("show a compact structured memory candidate, ask the human for GO"), true);
+  assert.equal(doc.includes("origin, short user words, tensionNote, restartTriggers, and outcome"), true);
+  assert.equal(doc.includes("not a personality assessment"), true);
   assert.equal(doc.includes("Do not store full transcripts, secrets, or raw sensitive material"), true);
   assert.equal(doc.includes("Current natural GO\n  binding is supported for `issue_create`, `issue_comment_create`, and\n  `pull_comment_create`"), true);
   assert.equal(doc.includes("If an implementation request does not already name an existing Issue"), true);
@@ -357,6 +359,23 @@ test("custom gpt openapi json parses and exposes paths as an object", () => {
   assert.equal(typeof doc.paths["/v2/action/github"], "object");
   assert.equal(typeof doc.paths["/v2/action/memory-write"], "object");
   assert.equal(doc.paths["/v2/action/memory-write"].post.operationId, "vtddWriteOperationalMemory");
+  const memoryWriteProps =
+    doc.paths["/v2/action/memory-write"].post.requestBody.content["application/json"].schema.properties;
+  assert.equal(memoryWriteProps.recordType.enum.includes("temperature_note"), true);
+  assert.equal(typeof memoryWriteProps.origin, "object");
+  assert.equal(typeof memoryWriteProps.userWords, "object");
+  assert.equal(typeof memoryWriteProps.tensionNote, "object");
+  assert.equal(memoryWriteProps.origin.additionalProperties, false);
+  assert.deepEqual(Object.keys(memoryWriteProps.origin.properties), ["surface", "moment", "trigger", "sourceUrl"]);
+  assert.equal(memoryWriteProps.tensionNote.additionalProperties, false);
+  assert.deepEqual(Object.keys(memoryWriteProps.tensionNote.properties), [
+    "summary",
+    "intensity",
+    "mode",
+    "whyItMatters"
+  ]);
+  assert.deepEqual(memoryWriteProps.tensionNote.properties.intensity.enum, ["low", "medium", "high"]);
+  assert.equal(memoryWriteProps.outcome.additionalProperties, false);
   assert.equal(
     doc.paths["/v2/action/github"].post.requestBody.content["application/json"].schema.properties.operation.enum.includes(
       "issue_create"

--- a/test/rag-memory-candidate.test.js
+++ b/test/rag-memory-candidate.test.js
@@ -1,0 +1,72 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  MEMORY_CANDIDATE_CONFIRMATION_PROMPT,
+  buildRagMemoryCandidate
+} from "../src/core/rag-memory-candidate.js";
+import { MemoryRecordType } from "../src/core/memory-schema.js";
+
+test("RAG memory candidate includes origin, user words, tension note, and GO prompt", () => {
+  const result = buildRagMemoryCandidate({
+    recordType: MemoryRecordType.TEMPERATURE_NOTE,
+    repository: "marushu/vtdd-v2-p",
+    relatedIssue: 343,
+    summary: "RAG memory candidate はテンションノートを recall hook として持つ。",
+    origin: {
+      surface: "mac Codex",
+      moment: "Issue #343 設計中",
+      trigger: "owner が風呂などで文脈とテンションを忘れる前提を共有した"
+    },
+    userWords: ["俺は、すぐに忘れるんだよ"],
+    tensionNote: {
+      summary: "再開性を重視する温度が高い状態",
+      intensity: "high",
+      mode: "復帰文脈の固定",
+      whyItMatters: "owner が後で戻った時に、なぜこの判断をしたか思い出すため"
+    },
+    restartTriggers: ["Issue #343", "テンションノート", "あれなんだったっけ？"],
+    outcome: {
+      status: "issue_created",
+      issue: "Issue #343"
+    },
+    tags: ["startup-preflight"]
+  });
+
+  assert.equal(result.ok, true, result.issues?.join("\n"));
+  assert.equal(result.candidate.confirmationPrompt, MEMORY_CANDIDATE_CONFIRMATION_PROMPT);
+  assert.equal(result.candidate.record.type, MemoryRecordType.TEMPERATURE_NOTE);
+  assert.equal(result.candidate.record.content.origin.surface, "mac Codex");
+  assert.equal(result.candidate.record.content.userWords[0], "俺は、すぐに忘れるんだよ");
+  assert.equal(result.candidate.record.content.tensionNote.intensity, "high");
+  assert.equal(result.candidate.writePayload.confirmed, false);
+  assert.equal(result.candidate.writePayload.recordType, MemoryRecordType.TEMPERATURE_NOTE);
+});
+
+test("RAG memory candidate rejects missing recall hooks", () => {
+  const result = buildRagMemoryCandidate({
+    recordType: MemoryRecordType.TEMPERATURE_NOTE,
+    summary: "情報だけで recall hook がない"
+  });
+
+  assert.equal(result.ok, false);
+  assert.match(result.issues.join("\n"), /origin/);
+  assert.match(result.issues.join("\n"), /userWords/);
+  assert.match(result.issues.join("\n"), /tensionNote/);
+});
+
+test("RAG memory candidate blocks secret-bearing content", () => {
+  const result = buildRagMemoryCandidate({
+    recordType: MemoryRecordType.TEMPERATURE_NOTE,
+    summary: "秘密を含む候補",
+    origin: { surface: "mac Codex" },
+    userWords: ["token: sk-secretsecretsecretsecretsecret"],
+    tensionNote: {
+      summary: "秘密混入",
+      whyItMatters: "保存してはいけない"
+    }
+  });
+
+  assert.equal(result.ok, false);
+  assert.match(result.issues.join("\n"), /sensitive token|secret|key/i);
+});

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -1047,6 +1047,56 @@ test("worker writes confirmed operational memory and retrieves it back", async (
   assert.equal(body.postWriteRetrieval.sourceCounts.decision_log, 1);
 });
 
+test("worker writes confirmed temperature note memory with recall hooks", async () => {
+  const provider = createInMemoryMemoryProvider();
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/action/memory-write", {
+      method: "POST",
+      headers: gatewayAuthHeaders,
+      body: JSON.stringify({
+        confirmed: true,
+        recordType: "temperature_note",
+        repository: "marushu/vtdd-v2-p",
+        relatedIssue: 343,
+        summary: "テンションノートを RAG の recall hook として保存する。",
+        origin: {
+          surface: "Butler",
+          moment: "Issue #343 implementation",
+          trigger: "owner が後で思い出せる記憶候補を求めた"
+        },
+        userWords: ["俺は、すぐに忘れるんだよ"],
+        tensionNote: {
+          summary: "再開性重視の温度が高い",
+          intensity: "high",
+          mode: "復帰文脈固定",
+          whyItMatters: "後で戻った時に判断理由を思い出すため"
+        },
+        restartTriggers: ["Issue #343", "テンションノート"],
+        outcome: {
+          status: "implemented"
+        }
+      })
+    }),
+    {
+      ...gatewayAuthEnv,
+      MEMORY_PROVIDER: provider
+    }
+  );
+
+  assert.equal(response.status, 200);
+  const body = await response.json();
+  assert.equal(body.memoryWritePersisted.recordType, "temperature_note");
+
+  const records = await provider.retrieve({
+    type: MemoryRecordType.TEMPERATURE_NOTE,
+    limit: 1
+  });
+  assert.equal(records.length, 1);
+  assert.equal(records[0].content.origin.surface, "Butler");
+  assert.equal(records[0].content.userWords[0], "俺は、すぐに忘れるんだよ");
+  assert.equal(records[0].content.tensionNote.intensity, "high");
+});
+
 test("worker blocks operational memory write until Butler gets GO", async () => {
   const response = await worker.fetch(
     new Request("https://example.com/v2/action/memory-write", {

--- a/worker.js
+++ b/worker.js
@@ -55012,7 +55012,7 @@ function buildMemoryWriteRecord(payload = {}) {
   if (!recordType2) {
     return {
       ok: false,
-      reason: "recordType must be decision_log, proposal_log, working_memory, or repair_case",
+      reason: "recordType must be decision_log, proposal_log, working_memory, temperature_note, or repair_case",
       issues: ["recordType is required"]
     };
   }
@@ -55074,7 +55074,7 @@ function buildMemoryWriteRecord(payload = {}) {
   if (!summary) {
     return {
       ok: false,
-      reason: "summary is required for working_memory and repair_case",
+      reason: "summary is required for working_memory, temperature_note, and repair_case",
       issues: ["summary is required"]
     };
   }
@@ -55086,6 +55086,11 @@ function buildMemoryWriteRecord(payload = {}) {
       content: {
         summary,
         details: normalizeText30(payload.details) || null,
+        origin: normalizeMemoryOrigin(payload.origin),
+        userWords: normalizeStringArray4(payload.userWords ?? payload.user_words).slice(0, 3),
+        tensionNote: normalizeMemoryTensionNote(payload.tensionNote ?? payload.tension_note),
+        restartTriggers: normalizeStringArray4(payload.restartTriggers ?? payload.restart_triggers),
+        outcome: normalizeMemoryOutcome(payload.outcome),
         relatedIssue,
         repository,
         timestamp
@@ -55103,11 +55108,39 @@ function normalizeMemoryWriteRecordType(value) {
     MemoryRecordType.DECISION_LOG,
     MemoryRecordType.PROPOSAL_LOG,
     MemoryRecordType.WORKING_MEMORY,
+    MemoryRecordType.TEMPERATURE_NOTE,
     MemoryRecordType.REPAIR_CASE
   ].includes(type)) {
     return type;
   }
   return "";
+}
+function normalizeMemoryOrigin(value) {
+  const origin = normalizeObject11(value);
+  return {
+    surface: normalizeText30(origin.surface) || null,
+    moment: normalizeText30(origin.moment) || null,
+    trigger: normalizeText30(origin.trigger) || null,
+    sourceUrl: normalizeText30(origin.sourceUrl ?? origin.source_url) || null
+  };
+}
+function normalizeMemoryTensionNote(value) {
+  const note = normalizeObject11(value);
+  return {
+    summary: normalizeText30(note.summary) || null,
+    intensity: normalizeText30(note.intensity) || null,
+    mode: normalizeText30(note.mode) || null,
+    whyItMatters: normalizeText30(note.whyItMatters ?? note.why_it_matters) || null
+  };
+}
+function normalizeMemoryOutcome(value) {
+  const outcome = normalizeObject11(value);
+  return {
+    status: normalizeText30(outcome.status) || null,
+    issue: normalizeText30(outcome.issue) || null,
+    pullRequest: normalizeText30(outcome.pullRequest ?? outcome.pull_request) || null,
+    notes: normalizeText30(outcome.notes) || null
+  };
 }
 function normalizeMemoryPriority(value, fallback) {
   const numeric = Number(value ?? fallback);


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #343 の RAG memory candidate に origin / userWords / tensionNote / restartTriggers / outcome を構造化して追加し、owner が後から『あれなんだったっけ？』と戻れる recall hook を定義・実装します。

## Satisfied Success Criteria

- RAG memory candidate builder を追加し、origin / userWords / tensionNote / restartTriggers / outcome を正規化します。
- recordType temperature_note を memory-write runtime と Custom GPT Action Schema 正本に追加します。
- tensionNote は人格評価ではなく recall hook として docs / Custom GPT Instructions に明記します。
- GO 前は writePayload.confirmed=false の候補提示に留め、runtime memory-write は confirmed=true を要求し続けます。
- secret-bearing candidate を safety filter でブロックするテストを追加します。
- Gemini 残リスクを受けて、Action Schema の origin / tensionNote / outcome を additionalProperties:false の閉じた構造にしました。

## Unsatisfied Success Criteria

- Cloudflare deploy は未実施です。runtime 反映は後続の GO + passkey 付きデプロイ待ちです。
- Custom GPT エディタ上の Instructions / Action Schema 貼り替えは未実施です。repo 正本だけ更新済みです。
- iPhone Butler live E2E は未実施です。ライブ反映後に origin / userWords / tensionNote / outcome の検索回答を検証する必要があります。
- Issue #341 の Butler repository-read capability と Issue #344 の startup preflight 全体はこのPRでは未実装です。

## Non-goal violations

None.

## Verification Evidence

- Unit: node --test test/rag-memory-candidate.test.js test/worker.test.js test/custom-gpt-setup-docs.test.js test/memory-provider.test.js test/memory-safety.test.js / npm test
- Integration: worker /v2/action/memory-write が confirmed temperature_note を保存し、origin / userWords / tensionNote を retrieve できることを test/worker.test.js で確認。Custom GPT OpenAPI JSON/YAML の memory-write schema と Instructions docs の同期を確認。
- E2E: 未実施。deploy と Custom GPT エディタ反映を後続でまとめる方針のため、live Butler E2E は未接続。
- Manual: short instructions 7831 chars、short-min instructions 7854 chars を確認。Gemini 指摘後に Action Schema の recall hook object を閉じ、npm test を再実行。
- Evidence path/link: test/rag-memory-candidate.test.js; test/worker.test.js; test/custom-gpt-setup-docs.test.js; docs/setup/custom-gpt-actions-openapi.yaml; docs/setup/custom-gpt-instructions.md

## Butler Completion Contract

- Owner goal: 後で文脈を忘れても、RAG 候補から出所・短い実発言・その時のテンション・再開トリガーを取り戻せるようにする。
- Butler entrypoint: repo 正本では vtddWriteOperationalMemory の memory-write action。ライブ Butler は deploy と Custom GPT エディタ反映まで未接続。
- Action Schema exposure: docs/setup/custom-gpt-actions-openapi.yaml と json に temperature_note / origin / userWords / tensionNote / restartTriggers / outcome を追加。origin / tensionNote / outcome は閉じた構造。エディタ反映は未実施。
- Runtime path: POST /v2/action/memory-write -> buildMemoryWriteRecord -> memory provider。confirmed=true の temperature_note を保存可能。
- Runner/runtime truth: npm test で runtime unit/integration truth は確認済み。live Cloudflare runtime truth は未確認。
- Authority boundary: RAG 保存は GO 必須のまま。deploy / Custom GPT editor update / permission or credential mutation はこのPRでは実施しない。
- E2E evidence: 未実施。ライブ反映後、Butler が候補提示、GO 後保存、再検索回答できることを別途確認する。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 未実施。後で GO + passkey によりまとめて実施する。
- Custom GPT Action Schema update: repo 正本は更新済み。Custom GPT エディタ反映は未実施。
- Custom GPT Instructions update: repo 正本は更新済み。Custom GPT エディタ反映は未実施。
- iPhone Butler live E2E: 未実施。deploy / editor update 後に実施する。

## Related Constitution Rules

- Issue が起点、GitHub が正本。
- RAG は全文会話ログではなく、未来の判断と復旧に役立つ構造化記憶を保存する。
- Runtime truth は memory より優先。
- GO がない限り RAG へ保存しない。
- secrets / raw sensitive material / private credentials は保存候補から除外する。

## Out-of-scope but NOT implemented

- Issue #341: Butler repository-read capability before shared RAG。
- Issue #344: Butler / mac Codex / VPS Codex CLI 共通 startup preflight。
- Cloudflare deploy、Custom GPT editor update、live iPhone Butler E2E。

## Extra changes (if any)

worker.js は npm run build:worker による生成物更新。Gemini の残リスクコメントを受け、Action Schema の自由オブジェクトを閉じた構造へ変更。

<!-- VTDD metadata -->
- Issue: Issue #343
- Execution ID: Not provided.
- Goal: Issue #343 tension note memory candidate
