### PR TITLE
Issue #341: Butler の repository contents read を追加

### DIFF
--- a/docs/butler/capability-matrix.md
+++ b/docs/butler/capability-matrix.md
@@ -52,7 +52,7 @@ governed action surface, and cite remediation Issue #244.
 
 | Operation family | Current status | Required Butler action surface | Boundary / runtime truth |
 |---|---:|---|---|
-| repository read | `supported` | `github_read.repository` | read-only GitHub runtime truth |
+| repository read | `supported` | `github_read.repository`, `github_read.contents` | read-only GitHub runtime truth |
 | issue read/create/comment create/comment update | `supported` | `github_read.issue`, `github_write.issue_create`, `github_write.issue_comment_create`, `github_write.issue_comment_update` | reads are ungated; writes require exact payload + human GO and readback |
 | issue body/title/state/labels/assignees/milestone update | `unsupported` | `github_write.issue_update` | remediation: #244; do not fall back to GitHub UI as steady state |
 | bounded issue close after scoped merge | `gated` | `github_high_risk.issue_close` | explicit GO + real passkey; verify merged PR then issue state |
@@ -103,6 +103,7 @@ governed action surface, and cite remediation Issue #244.
 | deploy operator | `partial-live` | Deploy operator and dispatch have worked in conversation; repeatability and post-dispatch tracking need proof. | Ask Butler for deploy URL, dispatch, and verify run/self-parity/health. |
 | self-parity check | `verified-live` | Butler has returned `runtimeParity: in_sync`. | Continue using before/after surface updates. |
 | setup artifact retrieve | `source-only` | Source/tests cover canonical setup artifacts. | Butler retrieves Instructions/OpenAPI links or content on demand. |
+| repo file/directory contents read | `source-only` | Source route `vtddRetrieveGitHub resource=contents` reads file snippets and directory entries through GitHub App-backed runtime truth. | Ask Butler on iPhone to explain a known file and list a known docs directory, then compare `path`/`htmlUrl` with GitHub UI. |
 | surface update guidance | `source-only` | #153 now requires clickable URLs for Instructions/Action Schema/operator. | After a PR changes surfaces, Butler reports required/not-required surfaces and links. |
 | auth/transport failure surfacing | `partial-live` | Some `ClientResponseError` raw surfacing improved; still inconsistent. | Force/read a known failure and verify action/status/body/error/reason/issues are not hidden. |
 

--- a/docs/setup/custom-gpt-actions-openapi.json
+++ b/docs/setup/custom-gpt-actions-openapi.json
@@ -2360,7 +2360,8 @@
                 "pull_review_comments",
                 "checks",
                 "workflow_runs",
-                "branches"
+                "branches",
+                "contents"
               ]
             }
           },
@@ -2396,16 +2397,24 @@
               "type": "string"
             }
           },
-          {
-            "name": "ref",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "state",
+            {
+              "name": "ref",
+              "in": "query",
+              "required": false,
+              "schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "path",
+              "in": "query",
+              "required": false,
+              "schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "state",
             "in": "query",
             "required": false,
             "schema": {

--- a/docs/setup/custom-gpt-actions-openapi.yaml
+++ b/docs/setup/custom-gpt-actions-openapi.yaml
@@ -1613,6 +1613,7 @@ paths:
               - checks
               - workflow_runs
               - branches
+              - contents
         - name: repository
           in: query
           required: false
@@ -1634,6 +1635,11 @@ paths:
           schema:
             type: string
         - name: ref
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: path
           in: query
           required: false
           schema:

--- a/docs/setup/custom-gpt-instructions-short-min.md
+++ b/docs/setup/custom-gpt-instructions-short-min.md
@@ -13,7 +13,7 @@ Truth and scope:
 - vtddGateway/vtddExecute use surface=custom_gpt and judgmentModelId=vtdd-butler-core-v1.
 Repository and nickname:
 - Repo list/read: vtddGateway exploration/read_only with repositoryInput=unknown.
-- Use vtddRetrieveGitHub for repos, issues, PRs, reviews, comments, checks, runs, branches. Page: vtddRetrieveCloudflarePages.
+- Use vtddRetrieveGitHub for repos, issues, PRs, reviews, comments, checks, runs, branches, contents. File explain: resource=contents+path. Page: vtddRetrieveCloudflarePages.
 - Save/delete/list nicknames: vtddUpsertRepositoryNickname, vtddDeleteRepositoryNickname, vtddRetrieveRepositoryNicknames.
 - If request starts with a non-owner/repo token like `ぶい の...`, resolve nickname first.
 - Nickname memory is user-owned alias data, not default repo. Save owner/repo, not alias. Delete owner/repo + exact nickname; never empty replace.

--- a/docs/setup/custom-gpt-instructions-short-min.md
+++ b/docs/setup/custom-gpt-instructions-short-min.md
@@ -1,6 +1,6 @@
-VTDD Butler. Japanese unless asked otherwise.
+VTDD Butler. Japanese default.
 Role:
-- minimal Custom GPT paste target under 8000 chars
+- minimal Custom GPT paste target
 - `custom-gpt-instructions.md` is the full canonical reference. `custom-gpt-instructions-short.md` is the expanded paste target. This file keeps invariants.
 Truth and scope:
 - Issue is canonical spec. GitHub/runtime state is progress truth. Runtime truth > memory.
@@ -13,7 +13,7 @@ Truth and scope:
 - vtddGateway/vtddExecute use surface=custom_gpt and judgmentModelId=vtdd-butler-core-v1.
 Repository and nickname:
 - Repo list/read: vtddGateway exploration/read_only with repositoryInput=unknown.
-- Use vtddRetrieveGitHub for repos, issues, PRs, reviews, comments, checks, runs, branches, contents. File explain: resource=contents+path. Page: vtddRetrieveCloudflarePages.
+- Use vtddRetrieveGitHub for repos, issues, PRs, reviews, comments, checks, runs, branches, contents(path). Page: vtddRetrieveCloudflarePages.
 - Save/delete/list nicknames: vtddUpsertRepositoryNickname, vtddDeleteRepositoryNickname, vtddRetrieveRepositoryNicknames.
 - If request starts with a non-owner/repo token like `ぶい の...`, resolve nickname first.
 - Nickname memory is user-owned alias data, not default repo. Save owner/repo, not alias. Delete owner/repo + exact nickname; never empty replace.

--- a/docs/setup/custom-gpt-instructions-short.md
+++ b/docs/setup/custom-gpt-instructions-short.md
@@ -1,5 +1,4 @@
-Butler
-Core:
+Butler core:
 - Issue is canonical spec.
 - If implementation work does not already have an existing Issue, propose an Issue candidate first, wait for GO, create the Issue, then hand off. Do not create the PR/build first and issue-link later; #303 is the regression example.
 - Before proposal/write/Codex handoff/PR judgment: vtddRetrieveCrossMemory + vtddRetrieveDecisionLogs/vtddRetrieveProposalLogs/vtddRetrieveConstitution + runtime truth; no RAG hit OK, never invent. Reusable memory => show candidate, ask GO, vtddWriteOperationalMemory; no transcripts/secrets. Runtime truth > memory.
@@ -15,8 +14,8 @@ Repo/nickname:
 - Nickname memory is user-owned alias data, not default repo. Save owner/repo, not alias. Delete owner/repo+nickname.
 - Nickname read failure is not proof of unknown repo. If context/grant has owner/repo, use unverified fallback; then verify.
 - Nickname action failure: surface error/reason/issues. If Action returns `ClientResponseError`, state action.
-GitHub read plane:
-- Use vtddRetrieveGitHub for repos/issues/PRs/reviews/comments/checks/runs/branches/contents; file: resource=contents+path. vtddRetrieveCloudflarePages for pages.
+GitHub read:
+- Use vtddRetrieveGitHub for repos/issues/PRs/reviews/comments/checks/runs/branches/contents(path); vtddRetrieveCloudflarePages for pages.
 - Unsupported => 未対応. Auth fail => 認証失敗. Do not infer absence from failed reads.
 Self-parity:
 - Use vtddRetrieveSelfParity repo=<resolved>, ref=main. Surface `Cloudflare deploy update required` / `Action Schema update required` / `Instructions update required` / errors.

--- a/docs/setup/custom-gpt-instructions-short.md
+++ b/docs/setup/custom-gpt-instructions-short.md
@@ -16,7 +16,7 @@ Repo/nickname:
 - Nickname read failure is not proof of unknown repo. If context/grant has owner/repo, use unverified fallback; then verify.
 - Nickname action failure: surface error/reason/issues. If Action returns `ClientResponseError`, state action.
 GitHub read plane:
-- Use vtddRetrieveGitHub for repos/issues/PRs/reviews/comments/checks/runs/branches; vtddRetrieveCloudflarePages for pages.
+- Use vtddRetrieveGitHub for repos/issues/PRs/reviews/comments/checks/runs/branches/contents; file: resource=contents+path. vtddRetrieveCloudflarePages for pages.
 - Unsupported => 未対応. Auth fail => 認証失敗. Do not infer absence from failed reads.
 Self-parity:
 - Use vtddRetrieveSelfParity repo=<resolved>, ref=main. Surface `Cloudflare deploy update required` / `Action Schema update required` / `Instructions update required` / errors.

--- a/docs/setup/custom-gpt-instructions.md
+++ b/docs/setup/custom-gpt-instructions.md
@@ -92,6 +92,7 @@ GitHub runtime truth read plane:
   - checks
   - workflow runs
   - branches
+  - repository file or directory contents
 - Map natural language into resource names yourself:
   - repositories
   - issues
@@ -102,6 +103,8 @@ GitHub runtime truth read plane:
   - checks
   - workflow_runs
   - branches
+  - contents
+- For `このファイルについて説明して`, source/doc file reads, or directory listings, use resource=`contents` with `repository`, `path`, and optional `ref`. Explain from returned `snippet` / `content` and cite `path` / `htmlUrl`.
 - For read requests, prefer vtddRetrieveGitHub over speculative explanation.
 - If the route returns unsupported, answer that the current Butler surface is未対応 for that exact read.
 - If the route returns unauthorized or invalid machine auth, answer that the read failed due to 認証失敗.

--- a/src/core/github-read-plane.js
+++ b/src/core/github-read-plane.js
@@ -15,7 +15,8 @@ export const GitHubReadResource = Object.freeze({
   PULL_REVIEW_COMMENTS: "pull_review_comments",
   CHECKS: "checks",
   WORKFLOW_RUNS: "workflow_runs",
-  BRANCHES: "branches"
+  BRANCHES: "branches",
+  CONTENTS: "contents"
 });
 
 export async function retrieveGitHubReadPlane(input = {}) {
@@ -24,6 +25,7 @@ export async function retrieveGitHubReadPlane(input = {}) {
   const issueNumber = normalizePositiveInteger(input.issueNumber);
   const pullNumber = normalizePositiveInteger(input.pullNumber);
   const branch = normalizeText(input.branch);
+  const path = normalizeRepositoryPath(input.path);
   const head = normalizeText(input.head);
   const ref = normalizeText(input.ref) || branch;
   const state = normalizeText(input.state) || "open";
@@ -65,6 +67,7 @@ export async function retrieveGitHubReadPlane(input = {}) {
     issueNumber,
     pullNumber,
     ref,
+    path,
     branch,
     head,
     state,
@@ -111,6 +114,7 @@ async function fetchGitHubReadResource(input) {
     issueNumber,
     pullNumber,
     ref,
+    path,
     branch,
     head,
     state,
@@ -126,6 +130,7 @@ async function fetchGitHubReadResource(input) {
     issueNumber,
     pullNumber,
     ref,
+    path,
     branch,
     head,
     state,
@@ -172,6 +177,7 @@ async function fetchGitHubReadResource(input) {
       pullNumber: pullNumber || null,
       branch: branch || null,
       ref: ref || null,
+      path: path || null,
       state,
       records: normalizeGitHubReadRecords(resource, body)
     }
@@ -184,6 +190,7 @@ function buildGitHubReadRequest({
   issueNumber,
   pullNumber,
   ref,
+  path,
   branch,
   head,
   state,
@@ -266,6 +273,14 @@ function buildGitHubReadRequest({
     };
   }
 
+  if (resource === GitHubReadResource.CONTENTS) {
+    const url = new URL(`${apiBaseUrl}/repos/${encodedRepository}/contents/${encodeRepositoryPath(path)}`);
+    if (ref) {
+      url.searchParams.set("ref", ref);
+    }
+    return { url: url.toString() };
+  }
+
   return { url: `${apiBaseUrl}/repos/${encodedRepository}` };
 }
 
@@ -299,6 +314,9 @@ function normalizeGitHubReadRecords(resource, body) {
   }
   if (resource === GitHubReadResource.BRANCHES) {
     return Array.isArray(body) ? body.map(normalizeBranch) : [normalizeBranch(body)];
+  }
+  if (resource === GitHubReadResource.CONTENTS) {
+    return Array.isArray(body) ? body.map(normalizeContentItem) : [normalizeContentItem(body)];
   }
   return [];
 }
@@ -427,6 +445,28 @@ function normalizeBranch(item) {
   };
 }
 
+function normalizeContentItem(item) {
+  const type = normalizeText(item?.type);
+  const content = type === "file" ? decodeGitHubContent(item?.content, item?.encoding) : "";
+  return {
+    type,
+    path: normalizeText(item?.path),
+    name: normalizeText(item?.name),
+    sha: normalizeText(item?.sha),
+    size: normalizePositiveInteger(item?.size),
+    encoding: normalizeText(item?.encoding),
+    content: content.slice(0, 12000),
+    contentTruncated: content.length > 12000,
+    truncationNotice:
+      content.length > 12000
+        ? "content is truncated; ask for a narrower path or hand off to Codex for full-file analysis"
+        : null,
+    snippet: content.slice(0, 4000),
+    downloadUrl: normalizeText(item?.download_url),
+    htmlUrl: normalizeText(item?.html_url)
+  };
+}
+
 function readJsonSafe(response) {
   return response
     .json()
@@ -439,6 +479,41 @@ function encodeURIComponentRepository(repository) {
     .split("/")
     .map((segment) => encodeURIComponent(segment))
     .join("/");
+}
+
+function encodeRepositoryPath(path) {
+  return normalizeRepositoryPath(path)
+    .split("/")
+    .filter(Boolean)
+    .map((segment) => encodeURIComponent(segment))
+    .join("/");
+}
+
+function normalizeRepositoryPath(value) {
+  return String(value ?? "")
+    .trim()
+    .replace(/^\/+/, "")
+    .replace(/\/{2,}/g, "/");
+}
+
+function decodeGitHubContent(content, encoding) {
+  if (normalizeText(encoding) !== "base64") {
+    return normalizeText(content);
+  }
+  const compact = normalizeText(content).replace(/\s+/g, "");
+  if (!compact) {
+    return "";
+  }
+  try {
+    const binary =
+      typeof atob === "function"
+        ? atob(compact)
+        : Buffer.from(compact, "base64").toString("binary");
+    const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
+    return new TextDecoder("utf-8", { fatal: false }).decode(bytes);
+  } catch {
+    return "";
+  }
 }
 
 function normalizeApiBaseUrl(value) {

--- a/src/core/github-read-plane.js
+++ b/src/core/github-read-plane.js
@@ -25,11 +25,12 @@ export async function retrieveGitHubReadPlane(input = {}) {
   const issueNumber = normalizePositiveInteger(input.issueNumber);
   const pullNumber = normalizePositiveInteger(input.pullNumber);
   const branch = normalizeText(input.branch);
-  const path = normalizeRepositoryPath(input.path);
   const head = normalizeText(input.head);
   const ref = normalizeText(input.ref) || branch;
   const state = normalizeText(input.state) || "open";
   const limit = normalizeLimit(input.limit, 20);
+  const pathValidation = validateRepositoryPath(input.path);
+  const path = pathValidation.path;
   const env = input.env ?? {};
   const fetchImpl = typeof env?.GITHUB_API_FETCH === "function" ? env.GITHUB_API_FETCH.bind(env) : fetch;
   const apiBaseUrl = normalizeApiBaseUrl(env?.GITHUB_API_BASE_URL);
@@ -49,7 +50,8 @@ export async function retrieveGitHubReadPlane(input = {}) {
     repository,
     issueNumber,
     pullNumber,
-    ref
+    ref,
+    pathValidation
   });
   if (!validation.ok) {
     return {
@@ -78,7 +80,7 @@ export async function retrieveGitHubReadPlane(input = {}) {
   });
 }
 
-function validateGitHubReadRequest({ resource, repository, issueNumber, pullNumber, ref }) {
+function validateGitHubReadRequest({ resource, repository, issueNumber, pullNumber, ref, pathValidation }) {
   const issues = [];
   if (!Object.values(GitHubReadResource).includes(resource)) {
     issues.push("resource is unsupported");
@@ -102,6 +104,10 @@ function validateGitHubReadRequest({ resource, repository, issueNumber, pullNumb
 
   if (resource === GitHubReadResource.CHECKS && !ref) {
     issues.push("ref or branch is required for checks");
+  }
+
+  if (resource === GitHubReadResource.CONTENTS && !pathValidation.ok) {
+    issues.push(pathValidation.reason);
   }
 
   return issues.length > 0 ? { ok: false, issues } : { ok: true };
@@ -274,7 +280,9 @@ function buildGitHubReadRequest({
   }
 
   if (resource === GitHubReadResource.CONTENTS) {
-    const url = new URL(`${apiBaseUrl}/repos/${encodedRepository}/contents/${encodeRepositoryPath(path)}`);
+    const encodedPath = encodeRepositoryPath(path);
+    const suffix = encodedPath ? `/${encodedPath}` : "";
+    const url = new URL(`${apiBaseUrl}/repos/${encodedRepository}/contents${suffix}`);
     if (ref) {
       url.searchParams.set("ref", ref);
     }
@@ -482,18 +490,42 @@ function encodeURIComponentRepository(repository) {
 }
 
 function encodeRepositoryPath(path) {
-  return normalizeRepositoryPath(path)
+  return String(path ?? "")
     .split("/")
     .filter(Boolean)
     .map((segment) => encodeURIComponent(segment))
     .join("/");
 }
 
-function normalizeRepositoryPath(value) {
-  return String(value ?? "")
-    .trim()
-    .replace(/^\/+/, "")
-    .replace(/\/{2,}/g, "/");
+function validateRepositoryPath(value) {
+  const text = String(value ?? "").trim();
+  if (!text) {
+    return { ok: true, path: "" };
+  }
+
+  if (text.includes("\\") || text.includes("\0")) {
+    return {
+      ok: false,
+      path: "",
+      reason: "path contains unsupported characters"
+    };
+  }
+
+  const path = text.replace(/^\/+|\/+$/g, "");
+  if (!path) {
+    return { ok: true, path: "" };
+  }
+
+  const segments = path.split("/");
+  if (segments.some((segment) => segment === "" || segment === "." || segment === "..")) {
+    return {
+      ok: false,
+      path: "",
+      reason: "path must not contain empty, dot, or dot-dot segments"
+    };
+  }
+
+  return { ok: true, path };
 }
 
 function decodeGitHubContent(content, encoding) {

--- a/src/core/github-read-plane.js
+++ b/src/core/github-read-plane.js
@@ -455,23 +455,95 @@ function normalizeBranch(item) {
 
 function normalizeContentItem(item) {
   const type = normalizeText(item?.type);
-  const content = type === "file" ? decodeGitHubContent(item?.content, item?.encoding) : "";
+  const size = normalizePositiveInteger(item?.size);
+  const decoded = decodeGitHubContentItem({ item, type, size });
+  const content = decoded.content;
   return {
     type,
     path: normalizeText(item?.path),
     name: normalizeText(item?.name),
     sha: normalizeText(item?.sha),
-    size: normalizePositiveInteger(item?.size),
+    size,
     encoding: normalizeText(item?.encoding),
+    contentAvailable: decoded.available,
+    contentStatus: decoded.status,
+    contentUnavailableReason: decoded.unavailableReason,
     content: content.slice(0, 12000),
-    contentTruncated: content.length > 12000,
-    truncationNotice:
-      content.length > 12000
-        ? "content is truncated; ask for a narrower path or hand off to Codex for full-file analysis"
-        : null,
+    contentTruncated: decoded.truncated,
+    truncationNotice: decoded.truncationNotice,
     snippet: content.slice(0, 4000),
     downloadUrl: normalizeText(item?.download_url),
     htmlUrl: normalizeText(item?.html_url)
+  };
+}
+
+function decodeGitHubContentItem({ item, type, size }) {
+  if (type !== "file") {
+    return {
+      available: false,
+      content: "",
+      status: "directory_or_non_file_entry",
+      truncated: false,
+      truncationNotice: null,
+      unavailableReason: "contents API entry is not a file body"
+    };
+  }
+
+  const encoding = normalizeText(item?.encoding);
+  const hasContentField = Object.prototype.hasOwnProperty.call(item ?? {}, "content");
+  const rawContent = normalizeText(item?.content);
+  const sizeExceedsInlineLimit = Number.isFinite(size) && size > 12000;
+
+  if (!rawContent && !hasContentField) {
+    return {
+      available: false,
+      content: "",
+      status: sizeExceedsInlineLimit ? "content_not_returned_large_file" : "content_not_returned",
+      truncated: sizeExceedsInlineLimit,
+      truncationNotice: sizeExceedsInlineLimit
+        ? "content is not returned and file size exceeds inline limit; ask for a narrower path or hand off to Codex for full-file analysis"
+        : null,
+      unavailableReason: "GitHub response did not include file content"
+    };
+  }
+
+  if (encoding && encoding !== "base64") {
+    return {
+      available: false,
+      content: "",
+      status: "unsupported_content_encoding",
+      truncated: sizeExceedsInlineLimit,
+      truncationNotice: sizeExceedsInlineLimit
+        ? "content is not decoded and file size exceeds inline limit; ask for a narrower path or hand off to Codex for full-file analysis"
+        : null,
+      unavailableReason: `unsupported GitHub content encoding: ${encoding}`
+    };
+  }
+
+  const decoded = decodeGitHubContent(rawContent, encoding);
+  if (!decoded && rawContent) {
+    return {
+      available: false,
+      content: "",
+      status: "content_decode_failed",
+      truncated: sizeExceedsInlineLimit,
+      truncationNotice: sizeExceedsInlineLimit
+        ? "content could not be decoded and file size exceeds inline limit; ask for a narrower path or hand off to Codex for full-file analysis"
+        : null,
+      unavailableReason: "GitHub file content could not be decoded"
+    };
+  }
+
+  const decodedExceedsInlineLimit = decoded.length > 12000;
+  return {
+    available: true,
+    content: decoded,
+    status: decodedExceedsInlineLimit ? "content_truncated" : "content_available",
+    truncated: decodedExceedsInlineLimit,
+    truncationNotice: decodedExceedsInlineLimit
+      ? "content is truncated; ask for a narrower path or hand off to Codex for full-file analysis"
+      : null,
+    unavailableReason: null
   };
 }
 

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -1231,6 +1231,7 @@ async function handleRetrieveGitHubReadPlaneRequest(url, env) {
     pullNumber: url.searchParams.get("pullNumber"),
     branch: url.searchParams.get("branch"),
     ref: url.searchParams.get("ref"),
+    path: url.searchParams.get("path"),
     state: url.searchParams.get("state"),
     limit: url.searchParams.get("limit"),
     env

--- a/test/custom-gpt-setup-docs.test.js
+++ b/test/custom-gpt-setup-docs.test.js
@@ -328,6 +328,8 @@ test("custom gpt openapi doc exposes current gateway, execute, and progress rout
   assert.equal(doc.includes("- issue_create"), true);
   assert.equal(doc.includes("pullNumber"), true);
   assert.equal(doc.includes("workflow_runs"), true);
+  assert.equal(doc.includes("- contents"), true);
+  assert.equal(doc.includes("name: path"), true);
   assert.equal(doc.includes("enum:\n                - vtdd-butler-core-v1"), true);
   assert.equal(doc.includes("requiresHandoff:"), true);
   assert.equal(doc.includes("- relatedIssue"), true);

--- a/test/github-read-plane.test.js
+++ b/test/github-read-plane.test.js
@@ -480,6 +480,9 @@ test("github read plane reads repository file contents with snippet and html sou
   assert.equal(result.read.path, "docs/butler/capability-matrix.md");
   assert.equal(result.read.records[0].type, "file");
   assert.equal(result.read.records[0].snippet.includes("Butler Capability Matrix"), true);
+  assert.equal(result.read.records[0].contentAvailable, true);
+  assert.equal(result.read.records[0].contentStatus, "content_available");
+  assert.equal(result.read.records[0].contentUnavailableReason, null);
   assert.equal(result.read.records[0].contentTruncated, false);
   assert.equal(result.read.records[0].truncationNotice, null);
   assert.equal(
@@ -513,9 +516,74 @@ test("github read plane marks truncated repository file contents", async () => {
   });
 
   assert.equal(result.ok, true);
+  assert.equal(result.read.records[0].contentAvailable, true);
+  assert.equal(result.read.records[0].contentStatus, "content_truncated");
   assert.equal(result.read.records[0].content.length, 12000);
   assert.equal(result.read.records[0].contentTruncated, true);
   assert.match(result.read.records[0].truncationNotice, /truncated/);
+});
+
+test("github read plane does not report missing large file content as complete", async () => {
+  const result = await retrieveGitHubReadPlane({
+    resource: GitHubReadResource.CONTENTS,
+    repository: "sample-org/vtdd-v2-p",
+    path: "src/large.js",
+    env: {
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_contents_read",
+      GITHUB_API_FETCH: async () =>
+        new Response(
+          JSON.stringify({
+            type: "file",
+            name: "large.js",
+            path: "src/large.js",
+            sha: "large-sha",
+            size: 13000,
+            html_url: "https://github.com/sample-org/vtdd-v2-p/blob/main/src/large.js"
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        )
+    }
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.read.records[0].contentAvailable, false);
+  assert.equal(result.read.records[0].contentStatus, "content_not_returned_large_file");
+  assert.match(result.read.records[0].contentUnavailableReason, /did not include/);
+  assert.equal(result.read.records[0].content, "");
+  assert.equal(result.read.records[0].snippet, "");
+  assert.equal(result.read.records[0].contentTruncated, true);
+  assert.match(result.read.records[0].truncationNotice, /not returned/);
+});
+
+test("github read plane does not report unsupported content encoding as complete", async () => {
+  const result = await retrieveGitHubReadPlane({
+    resource: GitHubReadResource.CONTENTS,
+    repository: "sample-org/vtdd-v2-p",
+    path: "src/binary.bin",
+    env: {
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_contents_read",
+      GITHUB_API_FETCH: async () =>
+        new Response(
+          JSON.stringify({
+            type: "file",
+            name: "binary.bin",
+            path: "src/binary.bin",
+            sha: "binary-sha",
+            size: 10,
+            encoding: "none",
+            content: "not-inline",
+            html_url: "https://github.com/sample-org/vtdd-v2-p/blob/main/src/binary.bin"
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        )
+    }
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.read.records[0].contentAvailable, false);
+  assert.equal(result.read.records[0].contentStatus, "unsupported_content_encoding");
+  assert.match(result.read.records[0].contentUnavailableReason, /unsupported/);
+  assert.equal(result.read.records[0].contentTruncated, false);
 });
 
 test("github read plane reads repository directory contents as entries", async () => {
@@ -554,7 +622,13 @@ test("github read plane reads repository directory contents as entries", async (
   assert.equal(result.read.records.length, 2);
   assert.equal(result.read.records[0].type, "dir");
   assert.equal(result.read.records[0].path, "docs/butler");
+  assert.equal(result.read.records[0].contentAvailable, false);
+  assert.equal(result.read.records[0].contentStatus, "directory_or_non_file_entry");
   assert.equal(result.read.records[0].htmlUrl, "https://github.com/sample-org/vtdd-v2-p/tree/main/docs/butler");
+  assert.equal(result.read.records[1].type, "file");
+  assert.equal(result.read.records[1].contentAvailable, false);
+  assert.equal(result.read.records[1].contentStatus, "content_not_returned");
+  assert.match(result.read.records[1].contentUnavailableReason, /did not include/);
 });
 
 test("github read plane rejects unsafe repository content paths before fetch", async () => {

--- a/test/github-read-plane.test.js
+++ b/test/github-read-plane.test.js
@@ -444,6 +444,117 @@ test("github read plane reads pull reviews, review comments, checks, workflow ru
   assert.equal(branches.read.records[0].sha, "abc123");
 });
 
+test("github read plane reads repository file contents with snippet and html source", async () => {
+  const calls = [];
+  const result = await retrieveGitHubReadPlane({
+    resource: GitHubReadResource.CONTENTS,
+    repository: "sample-org/vtdd-v2-p",
+    path: "docs/butler/capability-matrix.md",
+    ref: "main",
+    env: {
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_contents_read",
+      GITHUB_API_FETCH: async (url) => {
+        calls.push(url);
+        return new Response(
+          JSON.stringify({
+            type: "file",
+            name: "capability-matrix.md",
+            path: "docs/butler/capability-matrix.md",
+            sha: "file-sha",
+            size: 38,
+            encoding: "base64",
+            content: Buffer.from("# Butler Capability Matrix\n\nrepo read", "utf8").toString("base64"),
+            html_url: "https://github.com/sample-org/vtdd-v2-p/blob/main/docs/butler/capability-matrix.md",
+            download_url:
+              "https://raw.githubusercontent.com/sample-org/vtdd-v2-p/main/docs/butler/capability-matrix.md"
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        );
+      }
+    }
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(calls[0].includes("/repos/sample-org/vtdd-v2-p/contents/docs/butler/capability-matrix.md"), true);
+  assert.equal(calls[0].includes("ref=main"), true);
+  assert.equal(result.read.path, "docs/butler/capability-matrix.md");
+  assert.equal(result.read.records[0].type, "file");
+  assert.equal(result.read.records[0].snippet.includes("Butler Capability Matrix"), true);
+  assert.equal(result.read.records[0].contentTruncated, false);
+  assert.equal(result.read.records[0].truncationNotice, null);
+  assert.equal(
+    result.read.records[0].htmlUrl,
+    "https://github.com/sample-org/vtdd-v2-p/blob/main/docs/butler/capability-matrix.md"
+  );
+});
+
+test("github read plane marks truncated repository file contents", async () => {
+  const result = await retrieveGitHubReadPlane({
+    resource: GitHubReadResource.CONTENTS,
+    repository: "sample-org/vtdd-v2-p",
+    path: "src/large.js",
+    env: {
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_contents_read",
+      GITHUB_API_FETCH: async () =>
+        new Response(
+          JSON.stringify({
+            type: "file",
+            name: "large.js",
+            path: "src/large.js",
+            sha: "large-sha",
+            size: 13000,
+            encoding: "base64",
+            content: Buffer.from("x".repeat(13001), "utf8").toString("base64"),
+            html_url: "https://github.com/sample-org/vtdd-v2-p/blob/main/src/large.js"
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        )
+    }
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.read.records[0].content.length, 12000);
+  assert.equal(result.read.records[0].contentTruncated, true);
+  assert.match(result.read.records[0].truncationNotice, /truncated/);
+});
+
+test("github read plane reads repository directory contents as entries", async () => {
+  const result = await retrieveGitHubReadPlane({
+    resource: GitHubReadResource.CONTENTS,
+    repository: "sample-org/vtdd-v2-p",
+    path: "docs",
+    env: {
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_contents_read",
+      GITHUB_API_FETCH: async () =>
+        new Response(
+          JSON.stringify([
+            {
+              type: "dir",
+              name: "butler",
+              path: "docs/butler",
+              sha: "dir-sha",
+              html_url: "https://github.com/sample-org/vtdd-v2-p/tree/main/docs/butler"
+            },
+            {
+              type: "file",
+              name: "README.md",
+              path: "docs/README.md",
+              sha: "readme-sha",
+              size: 100,
+              html_url: "https://github.com/sample-org/vtdd-v2-p/blob/main/docs/README.md"
+            }
+          ]),
+          { status: 200, headers: { "content-type": "application/json" } }
+        )
+    }
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.read.records.length, 2);
+  assert.equal(result.read.records[0].type, "dir");
+  assert.equal(result.read.records[0].path, "docs/butler");
+});
+
 test("github read plane rejects unsupported resources and missing required identifiers", async () => {
   const unsupported = await retrieveGitHubReadPlane({
     resource: "milestones",

--- a/test/github-read-plane.test.js
+++ b/test/github-read-plane.test.js
@@ -550,9 +550,36 @@ test("github read plane reads repository directory contents as entries", async (
   });
 
   assert.equal(result.ok, true);
+  assert.equal(result.read.path, "docs");
   assert.equal(result.read.records.length, 2);
   assert.equal(result.read.records[0].type, "dir");
   assert.equal(result.read.records[0].path, "docs/butler");
+  assert.equal(result.read.records[0].htmlUrl, "https://github.com/sample-org/vtdd-v2-p/tree/main/docs/butler");
+});
+
+test("github read plane rejects unsafe repository content paths before fetch", async () => {
+  const rejectedPaths = ["../issues", "docs/../src", "docs/./setup", "docs//setup", "docs\\setup"];
+
+  for (const path of rejectedPaths) {
+    let fetchCalled = false;
+    const result = await retrieveGitHubReadPlane({
+      resource: GitHubReadResource.CONTENTS,
+      repository: "sample-org/vtdd-v2-p",
+      path,
+      env: {
+        GITHUB_APP_INSTALLATION_TOKEN: "ghs_contents_read",
+        GITHUB_API_FETCH: async () => {
+          fetchCalled = true;
+          return new Response("{}", { status: 200, headers: { "content-type": "application/json" } });
+        }
+      }
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.status, 422);
+    assert.equal(fetchCalled, false);
+    assert.match(result.reason, /path/);
+  }
 });
 
 test("github read plane rejects unsupported resources and missing required identifiers", async () => {

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -3369,6 +3369,43 @@ test("worker returns GitHub issues through read plane route", async () => {
   assert.equal(body.read.records[0].body, "## Intent\nExpose Issue text to Butler.");
 });
 
+test("worker returns GitHub repository file contents through read plane route", async () => {
+  const response = await worker.fetch(
+    new Request(
+      "https://example.com/v2/retrieve/github?resource=contents&repository=sample-org/vtdd-v2-p&path=src%2Fcore%2Findex.js&ref=main",
+      {
+        headers: gatewayAuthHeaders
+      }
+    ),
+    {
+      ...gatewayAuthEnv,
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_contents_read",
+      GITHUB_API_FETCH: async () =>
+        new Response(
+          JSON.stringify({
+            type: "file",
+            name: "index.js",
+            path: "src/core/index.js",
+            sha: "index-sha",
+            size: 32,
+            encoding: "base64",
+            content: Buffer.from("export { retrieveGitHubReadPlane };", "utf8").toString("base64"),
+            html_url: "https://github.com/sample-org/vtdd-v2-p/blob/main/src/core/index.js"
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        )
+    }
+  );
+
+  assert.equal(response.status, 200);
+  const body = await response.json();
+  assert.equal(body.ok, true);
+  assert.equal(body.read.resource, "contents");
+  assert.equal(body.read.path, "src/core/index.js");
+  assert.equal(body.read.records[0].snippet, "export { retrieveGitHubReadPlane };");
+  assert.equal(body.read.records[0].htmlUrl, "https://github.com/sample-org/vtdd-v2-p/blob/main/src/core/index.js");
+});
+
 test("worker returns unsupported for unknown GitHub read resources", async () => {
   const response = await worker.fetch(
     new Request("https://example.com/v2/retrieve/github?resource=milestones", {

--- a/worker.js
+++ b/worker.js
@@ -36890,7 +36890,8 @@ var GitHubReadResource = Object.freeze({
   PULL_REVIEW_COMMENTS: "pull_review_comments",
   CHECKS: "checks",
   WORKFLOW_RUNS: "workflow_runs",
-  BRANCHES: "branches"
+  BRANCHES: "branches",
+  CONTENTS: "contents"
 });
 async function retrieveGitHubReadPlane(input = {}) {
   const resource = normalizeText26(input.resource);
@@ -36898,6 +36899,7 @@ async function retrieveGitHubReadPlane(input = {}) {
   const issueNumber = normalizePositiveInteger5(input.issueNumber);
   const pullNumber = normalizePositiveInteger5(input.pullNumber);
   const branch = normalizeText26(input.branch);
+  const path = normalizeRepositoryPath(input.path);
   const head = normalizeText26(input.head);
   const ref = normalizeText26(input.ref) || branch;
   const state = normalizeText26(input.state) || "open";
@@ -36936,6 +36938,7 @@ async function retrieveGitHubReadPlane(input = {}) {
     issueNumber,
     pullNumber,
     ref,
+    path,
     branch,
     head,
     state,
@@ -36971,6 +36974,7 @@ async function fetchGitHubReadResource(input) {
     issueNumber,
     pullNumber,
     ref,
+    path,
     branch,
     head,
     state,
@@ -36985,6 +36989,7 @@ async function fetchGitHubReadResource(input) {
     issueNumber,
     pullNumber,
     ref,
+    path,
     branch,
     head,
     state,
@@ -37028,6 +37033,7 @@ async function fetchGitHubReadResource(input) {
       pullNumber: pullNumber || null,
       branch: branch || null,
       ref: ref || null,
+      path: path || null,
       state,
       records: normalizeGitHubReadRecords(resource, body)
     }
@@ -37039,6 +37045,7 @@ function buildGitHubReadRequest({
   issueNumber,
   pullNumber,
   ref,
+  path,
   branch,
   head,
   state,
@@ -37109,6 +37116,13 @@ function buildGitHubReadRequest({
       url: `${apiBaseUrl}/repos/${encodedRepository}/branches?per_page=${limit}`
     };
   }
+  if (resource === GitHubReadResource.CONTENTS) {
+    const url = new URL(`${apiBaseUrl}/repos/${encodedRepository}/contents/${encodeRepositoryPath(path)}`);
+    if (ref) {
+      url.searchParams.set("ref", ref);
+    }
+    return { url: url.toString() };
+  }
   return { url: `${apiBaseUrl}/repos/${encodedRepository}` };
 }
 function normalizeGitHubReadRecords(resource, body) {
@@ -37141,6 +37155,9 @@ function normalizeGitHubReadRecords(resource, body) {
   }
   if (resource === GitHubReadResource.BRANCHES) {
     return Array.isArray(body) ? body.map(normalizeBranch) : [normalizeBranch(body)];
+  }
+  if (resource === GitHubReadResource.CONTENTS) {
+    return Array.isArray(body) ? body.map(normalizeContentItem) : [normalizeContentItem(body)];
   }
   return [];
 }
@@ -37255,11 +37272,51 @@ function normalizeBranch(item) {
     htmlUrl: normalizeText26(item?.commit?.url)
   };
 }
+function normalizeContentItem(item) {
+  const type = normalizeText26(item?.type);
+  const content = type === "file" ? decodeGitHubContent(item?.content, item?.encoding) : "";
+  return {
+    type,
+    path: normalizeText26(item?.path),
+    name: normalizeText26(item?.name),
+    sha: normalizeText26(item?.sha),
+    size: normalizePositiveInteger5(item?.size),
+    encoding: normalizeText26(item?.encoding),
+    content: content.slice(0, 12e3),
+    contentTruncated: content.length > 12e3,
+    truncationNotice: content.length > 12e3 ? "content is truncated; ask for a narrower path or hand off to Codex for full-file analysis" : null,
+    snippet: content.slice(0, 4e3),
+    downloadUrl: normalizeText26(item?.download_url),
+    htmlUrl: normalizeText26(item?.html_url)
+  };
+}
 function readJsonSafe6(response) {
   return response.json().catch(async () => ({ message: normalizeText26(await response.text().catch(() => "")) }));
 }
 function encodeURIComponentRepository4(repository) {
   return String(repository ?? "").trim().split("/").map((segment) => encodeURIComponent(segment)).join("/");
+}
+function encodeRepositoryPath(path) {
+  return normalizeRepositoryPath(path).split("/").filter(Boolean).map((segment) => encodeURIComponent(segment)).join("/");
+}
+function normalizeRepositoryPath(value) {
+  return String(value ?? "").trim().replace(/^\/+/, "").replace(/\/{2,}/g, "/");
+}
+function decodeGitHubContent(content, encoding) {
+  if (normalizeText26(encoding) !== "base64") {
+    return normalizeText26(content);
+  }
+  const compact = normalizeText26(content).replace(/\s+/g, "");
+  if (!compact) {
+    return "";
+  }
+  try {
+    const binary = typeof atob === "function" ? atob(compact) : Buffer.from(compact, "base64").toString("binary");
+    const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
+    return new TextDecoder("utf-8", { fatal: false }).decode(bytes);
+  } catch {
+    return "";
+  }
 }
 function normalizeApiBaseUrl5(value) {
   const text = normalizeText26(value);
@@ -55186,6 +55243,7 @@ async function handleRetrieveGitHubReadPlaneRequest(url, env) {
     pullNumber: url.searchParams.get("pullNumber"),
     branch: url.searchParams.get("branch"),
     ref: url.searchParams.get("ref"),
+    path: url.searchParams.get("path"),
     state: url.searchParams.get("state"),
     limit: url.searchParams.get("limit"),
     env

--- a/worker.js
+++ b/worker.js
@@ -37281,20 +37281,81 @@ function normalizeBranch(item) {
 }
 function normalizeContentItem(item) {
   const type = normalizeText26(item?.type);
-  const content = type === "file" ? decodeGitHubContent(item?.content, item?.encoding) : "";
+  const size = normalizePositiveInteger5(item?.size);
+  const decoded = decodeGitHubContentItem({ item, type, size });
+  const content = decoded.content;
   return {
     type,
     path: normalizeText26(item?.path),
     name: normalizeText26(item?.name),
     sha: normalizeText26(item?.sha),
-    size: normalizePositiveInteger5(item?.size),
+    size,
     encoding: normalizeText26(item?.encoding),
+    contentAvailable: decoded.available,
+    contentStatus: decoded.status,
+    contentUnavailableReason: decoded.unavailableReason,
     content: content.slice(0, 12e3),
-    contentTruncated: content.length > 12e3,
-    truncationNotice: content.length > 12e3 ? "content is truncated; ask for a narrower path or hand off to Codex for full-file analysis" : null,
+    contentTruncated: decoded.truncated,
+    truncationNotice: decoded.truncationNotice,
     snippet: content.slice(0, 4e3),
     downloadUrl: normalizeText26(item?.download_url),
     htmlUrl: normalizeText26(item?.html_url)
+  };
+}
+function decodeGitHubContentItem({ item, type, size }) {
+  if (type !== "file") {
+    return {
+      available: false,
+      content: "",
+      status: "directory_or_non_file_entry",
+      truncated: false,
+      truncationNotice: null,
+      unavailableReason: "contents API entry is not a file body"
+    };
+  }
+  const encoding = normalizeText26(item?.encoding);
+  const hasContentField = Object.prototype.hasOwnProperty.call(item ?? {}, "content");
+  const rawContent = normalizeText26(item?.content);
+  const sizeExceedsInlineLimit = Number.isFinite(size) && size > 12e3;
+  if (!rawContent && !hasContentField) {
+    return {
+      available: false,
+      content: "",
+      status: sizeExceedsInlineLimit ? "content_not_returned_large_file" : "content_not_returned",
+      truncated: sizeExceedsInlineLimit,
+      truncationNotice: sizeExceedsInlineLimit ? "content is not returned and file size exceeds inline limit; ask for a narrower path or hand off to Codex for full-file analysis" : null,
+      unavailableReason: "GitHub response did not include file content"
+    };
+  }
+  if (encoding && encoding !== "base64") {
+    return {
+      available: false,
+      content: "",
+      status: "unsupported_content_encoding",
+      truncated: sizeExceedsInlineLimit,
+      truncationNotice: sizeExceedsInlineLimit ? "content is not decoded and file size exceeds inline limit; ask for a narrower path or hand off to Codex for full-file analysis" : null,
+      unavailableReason: `unsupported GitHub content encoding: ${encoding}`
+    };
+  }
+  const decoded = decodeGitHubContent(rawContent, encoding);
+  if (!decoded && rawContent) {
+    return {
+      available: false,
+      content: "",
+      status: "content_decode_failed",
+      truncated: sizeExceedsInlineLimit,
+      truncationNotice: sizeExceedsInlineLimit ? "content could not be decoded and file size exceeds inline limit; ask for a narrower path or hand off to Codex for full-file analysis" : null,
+      unavailableReason: "GitHub file content could not be decoded"
+    };
+  }
+  const decodedExceedsInlineLimit = decoded.length > 12e3;
+  return {
+    available: true,
+    content: decoded,
+    status: decodedExceedsInlineLimit ? "content_truncated" : "content_available",
+    truncated: decodedExceedsInlineLimit,
+    truncationNotice: decodedExceedsInlineLimit ? "content is truncated; ask for a narrower path or hand off to Codex for full-file analysis" : null,
+    unavailableReason: null
   };
 }
 function readJsonSafe6(response) {

--- a/worker.js
+++ b/worker.js
@@ -36899,11 +36899,12 @@ async function retrieveGitHubReadPlane(input = {}) {
   const issueNumber = normalizePositiveInteger5(input.issueNumber);
   const pullNumber = normalizePositiveInteger5(input.pullNumber);
   const branch = normalizeText26(input.branch);
-  const path = normalizeRepositoryPath(input.path);
   const head = normalizeText26(input.head);
   const ref = normalizeText26(input.ref) || branch;
   const state = normalizeText26(input.state) || "open";
   const limit = normalizeLimit6(input.limit, 20);
+  const pathValidation = validateRepositoryPath(input.path);
+  const path = pathValidation.path;
   const env = input.env ?? {};
   const fetchImpl = typeof env?.GITHUB_API_FETCH === "function" ? env.GITHUB_API_FETCH.bind(env) : fetch;
   const apiBaseUrl = normalizeApiBaseUrl5(env?.GITHUB_API_BASE_URL);
@@ -36921,7 +36922,8 @@ async function retrieveGitHubReadPlane(input = {}) {
     repository,
     issueNumber,
     pullNumber,
-    ref
+    ref,
+    pathValidation
   });
   if (!validation.ok) {
     return {
@@ -36948,7 +36950,7 @@ async function retrieveGitHubReadPlane(input = {}) {
     apiBaseUrl
   });
 }
-function validateGitHubReadRequest({ resource, repository, issueNumber, pullNumber, ref }) {
+function validateGitHubReadRequest({ resource, repository, issueNumber, pullNumber, ref, pathValidation }) {
   const issues = [];
   if (!Object.values(GitHubReadResource).includes(resource)) {
     issues.push("resource is unsupported");
@@ -36964,6 +36966,9 @@ function validateGitHubReadRequest({ resource, repository, issueNumber, pullNumb
   }
   if (resource === GitHubReadResource.CHECKS && !ref) {
     issues.push("ref or branch is required for checks");
+  }
+  if (resource === GitHubReadResource.CONTENTS && !pathValidation.ok) {
+    issues.push(pathValidation.reason);
   }
   return issues.length > 0 ? { ok: false, issues } : { ok: true };
 }
@@ -37117,7 +37122,9 @@ function buildGitHubReadRequest({
     };
   }
   if (resource === GitHubReadResource.CONTENTS) {
-    const url = new URL(`${apiBaseUrl}/repos/${encodedRepository}/contents/${encodeRepositoryPath(path)}`);
+    const encodedPath = encodeRepositoryPath(path);
+    const suffix = encodedPath ? `/${encodedPath}` : "";
+    const url = new URL(`${apiBaseUrl}/repos/${encodedRepository}/contents${suffix}`);
     if (ref) {
       url.searchParams.set("ref", ref);
     }
@@ -37297,10 +37304,33 @@ function encodeURIComponentRepository4(repository) {
   return String(repository ?? "").trim().split("/").map((segment) => encodeURIComponent(segment)).join("/");
 }
 function encodeRepositoryPath(path) {
-  return normalizeRepositoryPath(path).split("/").filter(Boolean).map((segment) => encodeURIComponent(segment)).join("/");
+  return String(path ?? "").split("/").filter(Boolean).map((segment) => encodeURIComponent(segment)).join("/");
 }
-function normalizeRepositoryPath(value) {
-  return String(value ?? "").trim().replace(/^\/+/, "").replace(/\/{2,}/g, "/");
+function validateRepositoryPath(value) {
+  const text = String(value ?? "").trim();
+  if (!text) {
+    return { ok: true, path: "" };
+  }
+  if (text.includes("\\") || text.includes("\0")) {
+    return {
+      ok: false,
+      path: "",
+      reason: "path contains unsupported characters"
+    };
+  }
+  const path = text.replace(/^\/+|\/+$/g, "");
+  if (!path) {
+    return { ok: true, path: "" };
+  }
+  const segments = path.split("/");
+  if (segments.some((segment) => segment === "" || segment === "." || segment === "..")) {
+    return {
+      ok: false,
+      path: "",
+      reason: "path must not contain empty, dot, or dot-dot segments"
+    };
+  }
+  return { ok: true, path };
 }
 function decodeGitHubContent(content, encoding) {
   if (normalizeText26(encoding) !== "base64") {


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #341 の Butler repository-read capability に向けて、GitHub App-backed read plane で repository file / directory contents を安全に読めるようにする。

## Satisfied Success Criteria

- vtddRetrieveGitHub の resource enum に contents を追加し、repository path/ref から GitHub contents API を読めるようにしました。
- file response は content/snippet/htmlUrl/path を返し、Butler が『このファイルについて説明して』に出所つきで答えるための材料を持てます。
- directory response は read.records として directory entries を返し、各 entry の path/htmlUrl を出所として使えます。
- contents path は fetch 前に検証し、空 root path は許可しつつ、途中の空セグメント、dot、dot-dot、backslash、NUL を 422 で拒否します。
- 巨大または内容未返却の file は contentAvailable/contentStatus/contentUnavailableReason/contentTruncated/truncationNotice を返し、完全に読めた扱いにしません。
- Custom GPT Action Schema と Instructions 正本に contents(path) を追加しました。
- Butler capability matrix に repo file/directory contents read を source-only として追加しました。

## Unsatisfied Success Criteria

- Cloudflare deploy は未実施です。runtime 反映は後続の GO + passkey 付きデプロイ待ちです。
- Custom GPT エディタ上の Instructions / Action Schema 貼り替えは未実施です。repo 正本だけ更新済みです。
- iPhone Butler live E2E は未実施です。ライブ反映後に『このファイルについて説明して』と directory listing を検証する必要があります。
- mac Codex / VPS Codex CLI と比較した capability gap report は docs の source-only 更新に留まり、Butler-facing live report は未実施です。
- VPS Codex CLI / runner への不足時委任分類と shared RAG read/write/search はこのPRでは未実装です。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #341
- Implementing Success Criteria: Butler が GitHub App-backed read plane で repository file / directory contents を読み、未取得/巨大/非対応 encoding を runtime truth として区別できること。
- Explicit Non-goals: deploy、Custom GPT editor 反映、Issue close、shared RAG、startup preflight、VPS 委任分類はこの PR では扱わない。
- Expected touched files/routes/workflows: src/core/github-read-plane.js; src/worker/runtime.js; worker.js; docs/setup/custom-gpt-actions-openapi.{json,yaml}; docs/setup/custom-gpt-instructions*.md; docs/butler/capability-matrix.md; test/github-read-plane.test.js; test/worker.test.js; test/custom-gpt-setup-docs.test.js
- Affected Issues: Issue #341 が主対象。Issue #344 startup preflight と Issue #361 RAG checkpoint は読取入口を後で利用し得るが、この PR では変更しない。
- Affected PRs: PR #347 の既存 draft を更新。PR #346/#348 は未マージのため直接変更しない。
- Affected workflows: gemini-pr-review、codex-pr-review-fallback、guarded-autonomy-required-checks、test。Gemini 復活後のコメント増殖を監視する。
- Affected runtime/operator surfaces: Butler Custom GPT Action Schema 正本、Worker /v2/retrieve/github、setup latest artifact、iPhone Butler live flow。ただし deploy/editor 反映前は未接続。
- What may break if we patch narrowly: contents だけを増やすと directory entry を完全な file body と誤認したり、GitHub が大きい file body を返さない時に Butler が読めたと誤答するリスクがある。
- Unknowns to investigate before coding: live GitHub contents API の巨大 file 挙動、Custom GPT editor 反映後の自然言語 routing、Gemini reviewer 再有効化後のコメント量。
- Validation needed: node --test test/github-read-plane.test.js test/worker.test.js test/custom-gpt-setup-docs.test.js; npm test; PR #347 checks; reviewer comment count monitoring; deploy/editor 後の iPhone Butler live E2E。
- Stop condition: read-only を超える権限変更、deploy/editor 反映、secret/permission mutation、または Butler live E2E を完了扱いにする必要が出たら停止して別承認に分ける。

## File / Line Hypotheses

- file: `src/core/github-read-plane.js:455`
  - hypothesis: normalizeContentItem が content length だけで complete/truncated を判定しており、内容未返却を完全扱いし得る。
  - risk if changed narrowly: directory listing の file entry と file body response を混同し、Butler が読めていない本文を説明してしまう。
  - validation: missing large content、unsupported encoding、directory entry、normal file、truncated file の unit test。
  - related Issue: Issue #341
- file: `docs/setup/custom-gpt-instructions-short*.md`
  - hypothesis: contents guidance 追加で Custom GPT paste limit を超えやすい。
  - risk if changed narrowly: setup artifact が貼り付け不能になり、復旧導線が壊れる。
  - validation: test/custom-gpt-setup-docs.test.js の length/invariant checks。
  - related Issue: Issue #341

## Hypothesis Retrospective

- expected: content が無い巨大 file と directory entry を完全な file content と区別する必要がある。
- actual: contentAvailable/contentStatus/contentUnavailableReason を追加し、truncationNotice を content 未返却にも出すようにした。
- mismatch: PR #347 旧版は short/short-min が main の最新上限から外れ、docs test が落ちた。表現圧縮で正本の意味を保った。
- lesson: repo read capability は正常系 file read だけでなく、GitHub が返さない/返せない状態を owner-facing truth として扱う必要がある。
- should become RAG candidate: yes; Butler repo read では未取得を成功扱いしないこと。

## Verification Evidence

- Unit: node --test test/github-read-plane.test.js; node --test test/custom-gpt-setup-docs.test.js
- Integration: node --test test/worker.test.js test/custom-gpt-setup-docs.test.js; npm test => 762 tests, 761 pass, 1 skip; self-parity passed; generated worker check passed.
- E2E: 未実施。deploy と Custom GPT editor 反映後に iPhone Butler から file explanation / directory listing を確認する。
- Manual: PR #347 既存 reviewer 指摘を確認し、内容未返却/巨大 file/非対応 encoding/directory entry の誤認を修正対象に限定。
- Evidence path/link: src/core/github-read-plane.js; test/github-read-plane.test.js; test/worker.test.js; docs/setup/custom-gpt-actions-openapi.yaml; docs/setup/custom-gpt-instructions.md; worker.js

## Butler Completion Contract

- Owner goal: iPhone/iPad の Butler から、リポジトリの docs/source file/directory entries を読んで説明できる入口を作る。
- Butler entrypoint: repo 正本では vtddRetrieveGitHub resource=contents(path)。ライブ Butler は deploy と Custom GPT エディタ反映まで未接続。
- Action Schema exposure: docs/setup/custom-gpt-actions-openapi.yaml/json に resource=contents と path parameter を追加。エディタ反映は未実施。
- Runtime path: GET /v2/retrieve/github -> retrieveGitHubReadPlane -> GitHub Contents API -> normalized file records / directory entry records。unsafe path は GitHub fetch 前に 422 で拒否。
- Runner/runtime truth: unit/integration では contentAvailable/contentStatus/contentUnavailableReason/contentTruncated/truncationNotice を確認。live Cloudflare runtime truth は未確認。
- Authority boundary: read-only GitHub runtime truth。GO/passkey は不要。deploy / Custom GPT editor update / permission or credential mutation はこの PR では実施しない。
- E2E evidence: 未実施。ライブ反映後、Butler が自然言語から resource=contents を使い、file explanation と directory listing を返せることを確認する。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 未実施。後で GO + passkey によりまとめて実施する。
- Custom GPT Action Schema update: repo 正本は更新済み。Custom GPT エディタ反映は未実施。
- Custom GPT Instructions update: repo 正本は更新済み。Custom GPT エディタ反映は未実施。
- iPhone Butler live E2E: 未実施。deploy / editor update 後に実施する。

## Related Constitution Rules

- Issue が起点、GitHub が正本。
- Butler completion は owner-facing workflow evidence が必要。
- Runtime truth は memory より優先。
- Butler の通常運用で local terminal / local server / raw API payload を要求しない。
- GitHub read plane は read-only GitHub App-backed runtime truth として扱う。
- contents path は resource boundary を壊さないよう fetch 前に検証する。

## Out-of-scope but NOT implemented

- Issue #343: RAG memory candidate tension note の live 反映。
- Issue #344: startup preflight 全体。
- VPS Codex CLI / runner 委任分類の完成。
- Shared RAG read/write/search 全体。
- Cloudflare deploy、Custom GPT editor update、live iPhone Butler E2E。

## Extra changes (if any)

worker.js は npm run build:worker による生成物更新。PR #346 は未マージのため、この PR は main から独立した Issue #341 スライスです。Gemini / Codex fallback の blocker を受け、contents response truth と unsafe path rejection の回帰テストを追加。

<!-- VTDD metadata -->
- Issue: Issue #341
- Execution ID: Not provided.
- Goal: Issue #341 repository contents read plane
