### PR TITLE
Issue #349: reviewer marker comment loop を止める

### DIFF
--- a/src/core/gemini-pr-review.js
+++ b/src/core/gemini-pr-review.js
@@ -34,7 +34,10 @@ export function resolveGeminiReviewTrigger(input = {}) {
     if (!issue.pull_request) {
       return skip("issue_comment_not_for_pull_request");
     }
-    if (!isTrustedReviewerObjectionResolution(comment.body) && (isBotTriggered(payload) || containsMarker(comment.body))) {
+    if (
+      !isTrustedReviewerObjectionResolution(comment.body) &&
+      (isBotTriggered(payload) || containsReviewerMarker(comment.body))
+    ) {
       return skip("bot_or_marker_comment");
     }
     return {
@@ -53,7 +56,7 @@ export function resolveGeminiReviewTrigger(input = {}) {
     if (!["submitted", "edited"].includes(normalizeText(payload.action))) {
       return skip("unsupported_pull_request_review_action");
     }
-    if (isBotTriggered(payload) || containsMarker(review.body)) {
+    if (isBotTriggered(payload) || containsReviewerMarker(review.body)) {
       return skip("bot_or_marker_review");
     }
     return {
@@ -72,7 +75,7 @@ export function resolveGeminiReviewTrigger(input = {}) {
     if (!["created", "edited"].includes(normalizeText(payload.action))) {
       return skip("unsupported_pull_request_review_comment_action");
     }
-    if (isBotTriggered(payload) || containsMarker(comment.body)) {
+    if (isBotTriggered(payload) || containsReviewerMarker(comment.body)) {
       return skip("bot_or_marker_review_comment");
     }
     return {
@@ -447,14 +450,14 @@ export function formatGeminiReviewComment(input = {}) {
 
 export function findExistingGeminiReviewComment(comments = []) {
   return (
-    comments.find((comment) => containsMarker(comment?.body)) ??
+    comments.find((comment) => containsGeminiReviewMarker(comment?.body)) ??
     null
   );
 }
 
 export function parseGeminiReviewComment(comment = {}) {
   const body = normalizeText(typeof comment === "string" ? comment : comment?.body);
-  if (!body || !containsMarker(body)) {
+  if (!body || !containsGeminiReviewMarker(body)) {
     return null;
   }
 
@@ -609,7 +612,7 @@ function uniqueTextList(values) {
 function summarizeComments(comments) {
   const list = Array.isArray(comments) ? comments : [];
   return list
-    .filter((comment) => !containsMarker(comment?.body) || isTrustedReviewerObjectionResolution(comment?.body))
+    .filter((comment) => !containsReviewerMarker(comment?.body) || isTrustedReviewerObjectionResolution(comment?.body))
     .slice(-MAX_CONTEXT_COMMENTS)
     .map((comment) => {
       const author = normalizeText(comment?.user?.login) || "unknown";
@@ -651,7 +654,11 @@ function isBotTriggered(payload) {
   return senderLogin.endsWith("[bot]");
 }
 
-function containsMarker(value) {
+function containsReviewerMarker(value) {
+  return /<!--\s*vtdd:reviewer=[^>\s]+\s*-->/.test(normalizeText(value));
+}
+
+function containsGeminiReviewMarker(value) {
   return normalizeText(value).includes(GEMINI_PR_REVIEW_MARKER);
 }
 

--- a/test/gemini-pr-review.test.js
+++ b/test/gemini-pr-review.test.js
@@ -130,6 +130,57 @@ test("issue_comment on PR from Gemini marker still skips self-trigger loop", () 
   assert.equal(result.value.reason, "bot_or_marker_comment");
 });
 
+test("issue_comment on PR from Codex fallback marker skips self-trigger loop", () => {
+  const result = resolveGeminiReviewTrigger({
+    eventName: "issue_comment",
+    payload: {
+      issue: {
+        number: 347,
+        pull_request: {
+          url: "https://api.github.com/repos/marushu/vtdd-v2-p/pulls/347"
+        }
+      },
+      comment: {
+        body: `<!-- vtdd:reviewer=codex-fallback -->
+## VTDD Codex fallback レビュー
+
+- Recommended action: \`request_changes\``
+      },
+      sender: {
+        login: "vtdd-codex"
+      }
+    }
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.value.shouldReview, false);
+  assert.equal(result.value.reason, "bot_or_marker_comment");
+});
+
+test("issue_comment on PR from future reviewer marker skips self-trigger loop", () => {
+  const result = resolveGeminiReviewTrigger({
+    eventName: "issue_comment",
+    payload: {
+      issue: {
+        number: 347,
+        pull_request: {
+          url: "https://api.github.com/repos/marushu/vtdd-v2-p/pulls/347"
+        }
+      },
+      comment: {
+        body: "<!-- vtdd:reviewer=future-reviewer -->\n## Future reviewer"
+      },
+      sender: {
+        login: "marushu"
+      }
+    }
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.value.shouldReview, false);
+  assert.equal(result.value.reason, "bot_or_marker_comment");
+});
+
 test("buildPullRequestDiff truncates large diffs", () => {
   const diff = buildPullRequestDiff(
     [

--- a/worker.js
+++ b/worker.js
@@ -34507,7 +34507,7 @@ function sortResponseCommentsByCreatedAt(comments) {
 }
 function parseGeminiReviewComment(comment = {}) {
   const body = normalizeText20(typeof comment === "string" ? comment : comment?.body);
-  if (!body || !containsMarker2(body)) {
+  if (!body || !containsGeminiReviewMarker(body)) {
     return null;
   }
   const recommendedActionMatch = body.match(/^- Recommended action:\s*`([^`]+)`/m);
@@ -34614,7 +34614,7 @@ function extractFirstMarkdownListSection(body, headings) {
 function uniqueTextList(values) {
   return [...new Set(values.map(normalizeText20).filter(Boolean))];
 }
-function containsMarker2(value) {
+function containsGeminiReviewMarker(value) {
   return normalizeText20(value).includes(GEMINI_PR_REVIEW_MARKER);
 }
 function isTrustedReviewerObjectionResolution(value) {


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #349 の reviewer marker comment loop を止めるため、issue_comment trigger では vtdd:reviewer=<id> marker comment を再レビュー対象から除外する。

## Satisfied Success Criteria

- issue_comment trigger が vtdd:reviewer=gemini marker comment を skip する既存挙動を維持しました。
- issue_comment trigger が vtdd:reviewer=codex-fallback marker comment を skip する回帰テストを追加しました。
- 将来の vtdd:reviewer=<id> marker comment も reviewer marker として skip する回帰テストを追加しました。
- vtdd:reviewer-objection-resolution は従来どおり信頼できる応答コメントとして review 再実行できます。
- Gemini review parser / execution continuity timeline は Gemini marker と汎用 reviewer marker を混同しないよう、marker 判定を分離しました。

## Unsatisfied Success Criteria

- gemini-pr-review workflow は止血のため GitHub 上で disabled_manually のままです。PR merge 後、人間判断で再有効化が必要です。
- Issue #341 / PR #347 にすでに投稿された大量コメントの cleanup は未実施です。

## Non-goal violations

None.

## Verification Evidence

- Unit: node --test test/gemini-pr-review.test.js test/execution-continuity.test.js test/gemini-pr-review-workflow.test.js / npm test
- Integration: resolveGeminiReviewTrigger が Gemini / Codex fallback / future reviewer marker comment を issue_comment trigger から skip し、objection resolution は再実行対象に残ることを確認。execution continuity の reviewer timeline 解析が壊れないことを確認。
- E2E: GitHub 上で gemini-pr-review workflow を disabled_manually にし、10秒監視して新規 run が増えないことを確認。再有効化後の live E2E は未実施。
- Manual: gh workflow list で gemini-pr-review が disabled_manually であることを確認。gh run list で 2026-05-13T22:26:55Z 以降に新規 gemini-pr-review run が増えていないことを確認。
- Evidence path/link: src/core/gemini-pr-review.js; test/gemini-pr-review.test.js; test/execution-continuity.test.js; worker.js; GitHub workflow state gemini-pr-review disabled_manually

## Butler Completion Contract

- Owner goal: PR comment loop による owner-facing GitHub comments の大量増殖を止め、再有効化しても reviewer marker comment が自己増殖しないようにする。
- Butler entrypoint: なし。これは Butler 機能ではなく reviewer workflow guardrail 修正。
- Action Schema exposure: 不要。Custom GPT Action Schema は変更しない。
- Runtime path: GitHub Actions issue_comment event -> scripts/run-gemini-pr-review.mjs -> resolveGeminiReviewTrigger。reviewer marker comment は shouldReview=false。
- Runner/runtime truth: npm test 成功。GitHub workflow は止血のため disabled_manually。live 再有効化後の workflow run truth は未確認。
- Authority boundary: 一時止血として gemini-pr-review workflow を GitHub 上で disabled_manually にしました。deploy / credentials / permissions は変更していません。再有効化は PR merge 後に人間判断で行う。
- E2E evidence: 対象外。GitHub Actions loop の再発防止が対象。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 不要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 不要。

## Related Constitution Rules

- Issue が起点、GitHub が正本。
- Reviewer role は批評専用で、reviewer marker comment が自己増殖してはならない。
- Owner-facing operational guidance は日本語優先。
- No while-we-are-here edits。Issue #341 の実装修正とは分離する。

## Out-of-scope but NOT implemented

- Issue #341 repository contents read の追加修正。
- PR #347 の大量コメント cleanup。
- gemini-pr-review workflow の恒久的な無効化。
- Gemini / Codex fallback reviewer 方針の変更。

## Extra changes (if any)

止血のため、PR 作成前に gemini-pr-review workflow を GitHub 上で disabled_manually にしました。この PR 自体では workflow file を無効化していません。

<!-- VTDD metadata -->
- Issue: Issue #349
- Execution ID: Not provided.
- Goal: Issue #349 reviewer marker comment loop guard
