### PR TITLE
Issue #351: GitHub App actor identity を役割別に分離する

### DIFF
--- a/.github/workflows/codex-pr-review-fallback.yml
+++ b/.github/workflows/codex-pr-review-fallback.yml
@@ -64,12 +64,33 @@ jobs:
             exit 1
           fi
 
-      - name: Mint GitHub App token
+      - name: Detect Codex fallback reviewer GitHub App secrets
+        id: app_secrets
+        env:
+          VTDD_CODEX_FALLBACK_REVIEWER_APP_ID: ${{ secrets.VTDD_CODEX_FALLBACK_REVIEWER_APP_ID }}
+          VTDD_CODEX_FALLBACK_REVIEWER_APP_PRIVATE_KEY: ${{ secrets.VTDD_CODEX_FALLBACK_REVIEWER_APP_PRIVATE_KEY }}
+        shell: bash
+        run: |
+          if [ -n "$VTDD_CODEX_FALLBACK_REVIEWER_APP_ID" ] && [ -n "$VTDD_CODEX_FALLBACK_REVIEWER_APP_PRIVATE_KEY" ]; then
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Stop when Codex fallback reviewer GitHub App secrets are missing
+        if: ${{ steps.app_secrets.outputs.configured != 'true' }}
+        shell: bash
+        run: |
+          echo "Codex fallback reviewer requires VTDD_CODEX_FALLBACK_REVIEWER_APP_ID / VTDD_CODEX_FALLBACK_REVIEWER_APP_PRIVATE_KEY."
+          exit 1
+
+      - name: Mint Codex fallback reviewer GitHub App token
+        if: ${{ steps.app_secrets.outputs.configured == 'true' }}
         id: app-token
         uses: actions/create-github-app-token@v1
         with:
-          app-id: ${{ secrets.VTDD_GITHUB_APP_ID }}
-          private-key: ${{ secrets.VTDD_GITHUB_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.VTDD_CODEX_FALLBACK_REVIEWER_APP_ID }}
+          private-key: ${{ secrets.VTDD_CODEX_FALLBACK_REVIEWER_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 
       - name: Checkout trusted reviewer source

--- a/.github/workflows/gemini-pr-review.yml
+++ b/.github/workflows/gemini-pr-review.yml
@@ -33,10 +33,10 @@ jobs:
       - name: Detect GitHub App secret availability
         id: app_secrets
         env:
-          VTDD_GITHUB_APP_ID: ${{ secrets.VTDD_GITHUB_APP_ID }}
-          VTDD_GITHUB_APP_PRIVATE_KEY: ${{ secrets.VTDD_GITHUB_APP_PRIVATE_KEY }}
+          VTDD_GEMINI_REVIEWER_APP_ID: ${{ secrets.VTDD_GEMINI_REVIEWER_APP_ID }}
+          VTDD_GEMINI_REVIEWER_APP_PRIVATE_KEY: ${{ secrets.VTDD_GEMINI_REVIEWER_APP_PRIVATE_KEY }}
         run: |
-          if [ -n "$VTDD_GITHUB_APP_ID" ] && [ -n "$VTDD_GITHUB_APP_PRIVATE_KEY" ]; then
+          if [ -n "$VTDD_GEMINI_REVIEWER_APP_ID" ] && [ -n "$VTDD_GEMINI_REVIEWER_APP_PRIVATE_KEY" ]; then
             echo "configured=true" >> "$GITHUB_OUTPUT"
           else
             echo "configured=false" >> "$GITHUB_OUTPUT"
@@ -45,7 +45,7 @@ jobs:
       - name: Skip when GitHub App secrets are not configured
         if: ${{ steps.app_secrets.outputs.configured != 'true' }}
         run: |
-          echo "Skipping Gemini review because VTDD_GITHUB_APP_ID / VTDD_GITHUB_APP_PRIVATE_KEY are not configured."
+          echo "Skipping Gemini review because VTDD_GEMINI_REVIEWER_APP_ID / VTDD_GEMINI_REVIEWER_APP_PRIVATE_KEY are not configured."
           exit 0
 
       - name: Mint GitHub App token
@@ -53,8 +53,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v1
         with:
-          app-id: ${{ secrets.VTDD_GITHUB_APP_ID }}
-          private-key: ${{ secrets.VTDD_GITHUB_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.VTDD_GEMINI_REVIEWER_APP_ID }}
+          private-key: ${{ secrets.VTDD_GEMINI_REVIEWER_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 
       - name: Checkout repository

--- a/.github/workflows/remote-codex-executor.yml
+++ b/.github/workflows/remote-codex-executor.yml
@@ -40,6 +40,15 @@ on:
         description: "Optional handoff payload JSON"
         required: false
         type: string
+      codex_actor:
+        description: "GitHub App actor: vtdd-codex / mac-codex / vps-codex-cli"
+        required: false
+        default: "vtdd-codex"
+        type: choice
+        options:
+          - vtdd-codex
+          - mac-codex
+          - vps-codex-cli
 
 run-name: remote-codex-${{ inputs.execution_id }}
 
@@ -64,6 +73,7 @@ jobs:
       CODEX_GOAL: ${{ github.event.inputs.codex_goal }}
       APPROVAL_PHRASE: ${{ github.event.inputs.approval_phrase }}
       HANDOFF_JSON: ${{ github.event.inputs.handoff_json }}
+      CODEX_ACTOR: ${{ github.event.inputs.codex_actor || 'vtdd-codex' }}
     steps:
       - name: Enforce bounded GO
         shell: bash
@@ -103,13 +113,61 @@ jobs:
               exit 1
               ;;
           esac
+          case "$CODEX_ACTOR" in
+            vtdd-codex|mac-codex|vps-codex-cli) ;;
+            *)
+              echo "codex_actor must be vtdd-codex, mac-codex, or vps-codex-cli."
+              exit 1
+              ;;
+          esac
 
-      - name: Mint GitHub App token
-        id: app-token
+      - name: Resolve GitHub App actor
+        id: app-actor
+        shell: bash
+        run: |
+          case "$CODEX_ACTOR" in
+            mac-codex)
+              echo "token_output=mac" >> "$GITHUB_OUTPUT"
+              echo "git_user_name=vtdd-mac-codex[bot]" >> "$GITHUB_OUTPUT"
+              echo "git_user_email=vtdd-mac-codex[bot]@users.noreply.github.com" >> "$GITHUB_OUTPUT"
+              ;;
+            vps-codex-cli)
+              echo "token_output=vps" >> "$GITHUB_OUTPUT"
+              echo "git_user_name=vtdd-vps-codex-cli[bot]" >> "$GITHUB_OUTPUT"
+              echo "git_user_email=vtdd-vps-codex-cli[bot]@users.noreply.github.com" >> "$GITHUB_OUTPUT"
+              ;;
+            vtdd-codex)
+              echo "token_output=legacy" >> "$GITHUB_OUTPUT"
+              echo "git_user_name=vtdd-codex[bot]" >> "$GITHUB_OUTPUT"
+              echo "git_user_email=vtdd-codex[bot]@users.noreply.github.com" >> "$GITHUB_OUTPUT"
+              ;;
+          esac
+
+      - name: Mint legacy vtdd-codex GitHub App token
+        if: ${{ steps.app-actor.outputs.token_output == 'legacy' }}
+        id: app-token-legacy
         uses: actions/create-github-app-token@v1
         with:
           app-id: ${{ secrets.VTDD_GITHUB_APP_ID }}
           private-key: ${{ secrets.VTDD_GITHUB_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Mint mac Codex GitHub App token
+        if: ${{ steps.app-actor.outputs.token_output == 'mac' }}
+        id: app-token-mac
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.VTDD_MAC_CODEX_APP_ID }}
+          private-key: ${{ secrets.VTDD_MAC_CODEX_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Mint VPS Codex CLI GitHub App token
+        if: ${{ steps.app-actor.outputs.token_output == 'vps' }}
+        id: app-token-vps
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.VTDD_VPS_CODEX_CLI_APP_ID }}
+          private-key: ${{ secrets.VTDD_VPS_CODEX_CLI_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 
       - name: Checkout target repository
@@ -117,7 +175,7 @@ jobs:
         with:
           repository: ${{ env.TARGET_REPOSITORY }}
           ref: ${{ env.BASE_REF }}
-          token: ${{ steps.app-token.outputs.token }}
+          token: ${{ steps.app-token-legacy.outputs.token || steps.app-token-mac.outputs.token || steps.app-token-vps.outputs.token }}
           fetch-depth: 0
           persist-credentials: false
           path: target-repo
@@ -167,6 +225,7 @@ jobs:
             `Issue: #${process.env.TARGET_ISSUE_NUMBER}`,
             `Branch: ${process.env.TARGET_BRANCH}`,
             `Goal: ${process.env.CODEX_GOAL}`,
+            `Actor: ${process.env.CODEX_ACTOR}`,
             `Handoff JSON: ${process.env.HANDOFF_JSON || ""}`,
             "",
             "Before making changes:",
@@ -189,10 +248,12 @@ jobs:
         working-directory: target-repo
         shell: bash
         env:
-          APP_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_TOKEN: ${{ steps.app-token-legacy.outputs.token || steps.app-token-mac.outputs.token || steps.app-token-vps.outputs.token }}
+          GIT_USER_NAME: ${{ steps.app-actor.outputs.git_user_name }}
+          GIT_USER_EMAIL: ${{ steps.app-actor.outputs.git_user_email }}
         run: |
-          git config user.name "vtdd-codex[bot]"
-          git config user.email "vtdd-codex[bot]@users.noreply.github.com"
+          git config user.name "$GIT_USER_NAME"
+          git config user.email "$GIT_USER_EMAIL"
 
           if git diff --quiet && git diff --cached --quiet; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
@@ -209,7 +270,7 @@ jobs:
         working-directory: target-repo
         shell: bash
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ steps.app-token-legacy.outputs.token || steps.app-token-mac.outputs.token || steps.app-token-vps.outputs.token }}
         run: |
           existing_url="$(gh pr view "$TARGET_BRANCH" \
             --repo "$TARGET_REPOSITORY" \

--- a/docs/butler/gemini-pr-review-comments.md
+++ b/docs/butler/gemini-pr-review-comments.md
@@ -92,6 +92,18 @@ Gemini does not receive:
 - merge authority
 - deployment authority
 
+## GitHub Actor Boundary
+
+Gemini reviewer writeback must use the role-specific `VTDD Gemini Reviewer`
+GitHub App token. The Actions secrets are:
+
+- `VTDD_GEMINI_REVIEWER_APP_ID`
+- `VTDD_GEMINI_REVIEWER_APP_PRIVATE_KEY`
+
+The legacy shared `VTDD_GITHUB_APP_ID` / `VTDD_GITHUB_APP_PRIVATE_KEY` token
+must not be used for Gemini reviewer comments because it makes the GitHub
+timeline ambiguous about which VTDD role wrote the comment.
+
 ## Reviewer Output Boundary
 
 Gemini output must remain compatible with the existing reviewer contract:

--- a/docs/butler/remote-codex-cli-executor.md
+++ b/docs/butler/remote-codex-cli-executor.md
@@ -287,9 +287,16 @@ The optional machine-runner implementation path is GitHub Actions centered.
 - the workflow runs Codex CLI remotely
 - the workflow operates on the target repository and branch
 - progress is observed through GitHub Actions run state plus VTDD execution logs
+- the workflow accepts `codex_actor` so GitHub-visible writes can be attributed
+  to `vtdd-codex`, `mac-codex`, or `vps-codex-cli`
 
 This path must remain explicit opt-in because it depends on `OPENAI_API_KEY`.
 Do not present it as the only VTDD remote executor path.
+
+The `codex_actor` secret mapping is defined in
+`docs/security/github-app-actor-identity.md`. The default remains
+`vtdd-codex` for compatibility. Selecting `mac-codex` or `vps-codex-cli`
+requires the corresponding role-specific GitHub App secrets to be configured.
 
 ## Required Inputs
 

--- a/docs/mvp/e2e/e2e-18-gemini-pr-review-comment-writeback.md
+++ b/docs/mvp/e2e/e2e-18-gemini-pr-review-comment-writeback.md
@@ -40,7 +40,7 @@ node --test test/gemini-pr-review-workflow.test.js test/gemini-pr-review.test.js
 
 Observed result on 2026-04-26:
 - passed
-- confirms the workflow skips when `VTDD_GITHUB_APP_ID` / `VTDD_GITHUB_APP_PRIVATE_KEY` are not configured
+- confirms the workflow skips when `VTDD_GEMINI_REVIEWER_APP_ID` / `VTDD_GEMINI_REVIEWER_APP_PRIVATE_KEY` are not configured
 - confirms the workflow mints a GitHub App token and passes it as `GITHUB_TOKEN` to `scripts/run-gemini-pr-review.mjs`
 - confirms rerun triggers ignore the reviewer marker to avoid uncontrolled comment loops
 - confirms reviewer output remains PR-comment writeback only and does not grant execution credentials or merge authority

--- a/docs/security/github-app-actor-identity.md
+++ b/docs/security/github-app-actor-identity.md
@@ -1,0 +1,59 @@
+# GitHub App Actor Identity
+
+This document is the canonical actor identity contract for Issue #351.
+
+## Purpose
+
+VTDD must make GitHub-visible comments and write operations visually traceable
+to the role that performed them.
+
+The owner account `marushu` should appear only for owner actions such as manual
+merge, close, or repository administration. Normal VTDD machine activity must
+use a role-specific GitHub App token so GitHub displays the bot name and icon
+for that role.
+
+## Actors
+
+| Role | GitHub-visible actor | Workflow / runtime path | Secret names |
+| --- | --- | --- | --- |
+| Butler | `VTDD Butler V2` | Custom GPT Action runtime | Runtime-owned Butler credentials |
+| Legacy Codex executor | `vtdd-codex` | `.github/workflows/remote-codex-executor.yml` with `codex_actor=vtdd-codex` | `VTDD_GITHUB_APP_ID`, `VTDD_GITHUB_APP_PRIVATE_KEY` |
+| mac Codex executor | `VTDD mac Codex` | `.github/workflows/remote-codex-executor.yml` with `codex_actor=mac-codex` | `VTDD_MAC_CODEX_APP_ID`, `VTDD_MAC_CODEX_APP_PRIVATE_KEY` |
+| VPS Codex CLI executor | `VTDD VPS Codex CLI` | `.github/workflows/remote-codex-executor.yml` with `codex_actor=vps-codex-cli` | `VTDD_VPS_CODEX_CLI_APP_ID`, `VTDD_VPS_CODEX_CLI_APP_PRIVATE_KEY` |
+| Gemini reviewer | `VTDD Gemini Reviewer` | `.github/workflows/gemini-pr-review.yml` | `VTDD_GEMINI_REVIEWER_APP_ID`, `VTDD_GEMINI_REVIEWER_APP_PRIVATE_KEY` |
+| Codex fallback reviewer | `VTDD Codex Fallback Reviewer` | `.github/workflows/codex-pr-review-fallback.yml` | `VTDD_CODEX_FALLBACK_REVIEWER_APP_ID`, `VTDD_CODEX_FALLBACK_REVIEWER_APP_PRIVATE_KEY` |
+| Owner | `marushu` | Manual GitHub UI / owner-authorized administration | Owner login only |
+
+## Authority Boundary
+
+Role-specific GitHub Apps make the actor visible. They do not grant standing
+permission to act.
+
+- Reviewer Apps are critique-only. They may read the PR context and write
+  reviewer comments, but must not receive execution, merge, deploy, credential
+  mutation, or repository administration authority.
+- Executor Apps may push bounded branch changes and create/update PRs only when
+  the scoped execution contract authorizes that work.
+- Merge, post-merge Issue closure, deploy, credential mutation, permission
+  mutation, and destructive operations still follow the repository authority
+  boundary in `AGENTS.md` and `docs/security/consent-approval-model.md`.
+- GitHub App installation, permission, and Actions secret mutation require
+  `GO + passkey`.
+
+## Secret Registration Boundary
+
+This repository can define the required secret names and route workflows through
+them. Registering or updating those secrets is a high-risk external effect and
+is not completed by code changes alone.
+
+Before production use, the owner must approve syncing the App IDs and private
+keys into GitHub Actions secrets with `GO + passkey`.
+
+Until the new secrets are configured:
+
+- Gemini review skips explicitly rather than posting as the wrong actor.
+- Codex fallback reviewer fails explicitly rather than posting as the wrong
+  actor.
+- Remote Codex executor keeps `vtdd-codex` compatibility by default and uses
+  `mac-codex` or `vps-codex-cli` only when that actor is selected and its
+  secrets are configured.

--- a/test/e2e-18-gemini-pr-review-comment-writeback.test.js
+++ b/test/e2e-18-gemini-pr-review-comment-writeback.test.js
@@ -21,8 +21,8 @@ test("E2E-18 evidence doc records live Gemini reviewer writeback and boundary te
     doc.includes("node --test test/gemini-pr-review-workflow.test.js test/gemini-pr-review.test.js"),
     true
   );
-  assert.equal(doc.includes("VTDD_GITHUB_APP_ID"), true);
-  assert.equal(doc.includes("VTDD_GITHUB_APP_PRIVATE_KEY"), true);
+  assert.equal(doc.includes("VTDD_GEMINI_REVIEWER_APP_ID"), true);
+  assert.equal(doc.includes("VTDD_GEMINI_REVIEWER_APP_PRIVATE_KEY"), true);
   assert.equal(doc.includes("uncontrolled comment loops"), true);
 });
 

--- a/test/gemini-pr-review-workflow.test.js
+++ b/test/gemini-pr-review-workflow.test.js
@@ -11,9 +11,11 @@ const fallbackWorkflow = fs.readFileSync(
 test("Gemini review workflow skips when GitHub App secrets are not configured", () => {
   assert.equal(workflow.includes("name: Detect GitHub App secret availability"), true);
   assert.equal(
-    workflow.includes("Skipping Gemini review because VTDD_GITHUB_APP_ID / VTDD_GITHUB_APP_PRIVATE_KEY are not configured."),
+    workflow.includes("Skipping Gemini review because VTDD_GEMINI_REVIEWER_APP_ID / VTDD_GEMINI_REVIEWER_APP_PRIVATE_KEY are not configured."),
     true
   );
+  assert.equal(workflow.includes("VTDD_GEMINI_REVIEWER_APP_ID"), true);
+  assert.equal(workflow.includes("VTDD_GEMINI_REVIEWER_APP_PRIVATE_KEY"), true);
 });
 
 test("Gemini review workflow mints a GitHub App token and passes it to reviewer writeback", () => {
@@ -87,4 +89,21 @@ test("Codex fallback workflow runs reviewer-only Codex CLI and writes back via G
   assert.equal(fallbackWorkflow.includes("run: node trusted/scripts/run-codex-pr-review-fallback.mjs"), true);
   assert.equal(fallbackWorkflow.includes("OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}"), true);
   assert.equal(fallbackWorkflow.includes("GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}"), true);
+});
+
+test("Codex fallback workflow uses the dedicated fallback reviewer GitHub App", () => {
+  assert.equal(
+    fallbackWorkflow.includes("name: Detect Codex fallback reviewer GitHub App secrets"),
+    true
+  );
+  assert.equal(fallbackWorkflow.includes("VTDD_CODEX_FALLBACK_REVIEWER_APP_ID"), true);
+  assert.equal(fallbackWorkflow.includes("VTDD_CODEX_FALLBACK_REVIEWER_APP_PRIVATE_KEY"), true);
+  assert.equal(
+    fallbackWorkflow.includes("Codex fallback reviewer requires VTDD_CODEX_FALLBACK_REVIEWER_APP_ID / VTDD_CODEX_FALLBACK_REVIEWER_APP_PRIVATE_KEY."),
+    true
+  );
+  assert.equal(
+    fallbackWorkflow.includes("name: Mint Codex fallback reviewer GitHub App token"),
+    true
+  );
 });

--- a/test/github-app-actor-identity.test.js
+++ b/test/github-app-actor-identity.test.js
@@ -1,0 +1,27 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const doc = fs.readFileSync("docs/security/github-app-actor-identity.md", "utf8");
+
+test("GitHub App actor identity doc maps VTDD roles to visible actors and secrets", () => {
+  assert.equal(doc.includes("Issue #351"), true);
+  assert.equal(doc.includes("`VTDD Butler V2`"), true);
+  assert.equal(doc.includes("`vtdd-codex`"), true);
+  assert.equal(doc.includes("`VTDD mac Codex`"), true);
+  assert.equal(doc.includes("`VTDD VPS Codex CLI`"), true);
+  assert.equal(doc.includes("`VTDD Gemini Reviewer`"), true);
+  assert.equal(doc.includes("`VTDD Codex Fallback Reviewer`"), true);
+  assert.equal(doc.includes("`marushu`"), true);
+  assert.equal(doc.includes("VTDD_MAC_CODEX_APP_ID"), true);
+  assert.equal(doc.includes("VTDD_VPS_CODEX_CLI_APP_ID"), true);
+  assert.equal(doc.includes("VTDD_GEMINI_REVIEWER_APP_ID"), true);
+  assert.equal(doc.includes("VTDD_CODEX_FALLBACK_REVIEWER_APP_ID"), true);
+});
+
+test("GitHub App actor identity doc preserves authority and passkey boundaries", () => {
+  assert.equal(doc.includes("Reviewer Apps are critique-only."), true);
+  assert.equal(doc.includes("Executor Apps may push bounded branch changes"), true);
+  assert.equal(doc.includes("`GO + passkey`"), true);
+  assert.equal(doc.includes("Registering or updating those secrets is a high-risk external effect"), true);
+});

--- a/test/remote-codex-workflow.test.js
+++ b/test/remote-codex-workflow.test.js
@@ -85,3 +85,18 @@ test("remote Codex workflow restricts api_key_runner to the control repository",
   assert.equal(workflow.includes('if [ "$TARGET_REPOSITORY" != "$GITHUB_REPOSITORY" ]; then'), true);
   assert.equal(workflow.includes("api_key_runner is restricted to this repository."), true);
 });
+
+test("remote Codex workflow can choose the GitHub App actor while preserving vtdd-codex compatibility", () => {
+  assert.equal(workflow.includes("codex_actor:"), true);
+  assert.equal(workflow.includes("default: \"vtdd-codex\""), true);
+  assert.equal(workflow.includes("vtdd-codex|mac-codex|vps-codex-cli"), true);
+  assert.equal(workflow.includes("name: Resolve GitHub App actor"), true);
+  assert.equal(workflow.includes("name: Mint legacy vtdd-codex GitHub App token"), true);
+  assert.equal(workflow.includes("VTDD_GITHUB_APP_ID"), true);
+  assert.equal(workflow.includes("VTDD_MAC_CODEX_APP_ID"), true);
+  assert.equal(workflow.includes("VTDD_MAC_CODEX_APP_PRIVATE_KEY"), true);
+  assert.equal(workflow.includes("VTDD_VPS_CODEX_CLI_APP_ID"), true);
+  assert.equal(workflow.includes("VTDD_VPS_CODEX_CLI_APP_PRIVATE_KEY"), true);
+  assert.equal(workflow.includes('git config user.name "$GIT_USER_NAME"'), true);
+  assert.equal(workflow.includes('`Actor: ${process.env.CODEX_ACTOR}`'), true);
+});


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #351 に対して、GitHub 上で marushu に見えていた VTDD 機械投稿を役割別 GitHub App actor に分離する。

## Satisfied Success Criteria

- Gemini reviewer は VTDD_GEMINI_REVIEWER_APP_* を使う。Codex fallback reviewer は VTDD_CODEX_FALLBACK_REVIEWER_APP_* を使う。remote Codex executor は codex_actor で vtdd-codex / mac-codex / vps-codex-cli を選べる。必要 secret 名と権限境界を docs/security/github-app-actor-identity.md に明記した。

## Unsatisfied Success Criteria

- GitHub Actions secrets への App ID / private key 登録は GO + passkey が必要な高リスク操作なので、この PR では実行していない。本番の GitHub タイムライン上で各 Bot 名として投稿される live E2E は secret 登録後に別途確認が必要。

## Non-goal violations

None.

## Verification Evidence

- Unit: node --test test/gemini-pr-review-workflow.test.js test/remote-codex-workflow.test.js test/e2e-18-gemini-pr-review-comment-writeback.test.js test/github-app-actor-identity.test.js
- Integration: npm test
- E2E: 未実施。secret 登録は GO + passkey 後に実施するため、この PR は live Bot 投稿までは主張しない。
- Manual: git diff --check
- Evidence path/link: .github/workflows/gemini-pr-review.yml; .github/workflows/codex-pr-review-fallback.yml; .github/workflows/remote-codex-executor.yml; docs/security/github-app-actor-identity.md; test/github-app-actor-identity.test.js

## Butler Completion Contract

- Owner goal: GitHub のコメントや PR 更新が、marushu 手動操作なのか mac Codex / VPS Codex CLI / Gemini reviewer / Codex fallback reviewer なのか視覚的に区別できるようにする。
- Butler entrypoint: Butler 自体の Action Schema は変更しない。Butler が読む GitHub runtime truth 上の actor 分離を支える workflow / docs 変更。
- Action Schema exposure: 変更なし。
- Runtime path: GitHub Actions workflows: gemini-pr-review, codex-pr-review-fallback, remote-codex-executor.
- Runner/runtime truth: workflow_dispatch の codex_actor input、GitHub App token mint step、PR コメント/PR 更新の GitHub actor 表示。
- Authority boundary: GitHub App secret 登録、permission mutation、deploy、merge、Issue close はこの PR の範囲外。Reviewer Apps は批評専用。Executor Apps は bounded execution contract 内の branch/PR 操作のみ。
- E2E evidence: 未完了。secret 登録後、Butler が PR timeline を読み、各 marker/comment の author が役割別 Bot になっていることを確認する必要がある。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 不要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 不要。

## Related Constitution Rules

- Issue #351 scope only; AGENTS.md Authority Boundary; Evidence Discipline; Change Size and PR Discipline

## Out-of-scope but NOT implemented

- GitHub App secret 登録; GitHub App permission mutation; 既存 PR #347 コメント削除; Issue #349 loop guard の再実装; deploy

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #351
- Execution ID: Not provided.
- Goal: Not provided.
