### PR TITLE
Issue #351: operator URL で role-specific GitHub App secret sync を可能にする

### DIFF
--- a/docs/setup/github-app-secret-sync.md
+++ b/docs/setup/github-app-secret-sync.md
@@ -25,6 +25,17 @@ The sync target is GitHub Actions secrets:
 - `VTDD_GITHUB_APP_ID`
 - `VTDD_GITHUB_APP_PRIVATE_KEY`
 
+Role-specific GitHub App sync is also supported for actor-separated VTDD
+roles:
+
+| Role | App ID secret | Private key secret |
+| --- | --- | --- |
+| `legacy` | `VTDD_GITHUB_APP_ID` | `VTDD_GITHUB_APP_PRIVATE_KEY` |
+| `gemini-reviewer` | `VTDD_GEMINI_REVIEWER_APP_ID` | `VTDD_GEMINI_REVIEWER_APP_PRIVATE_KEY` |
+| `codex-fallback-reviewer` | `VTDD_CODEX_FALLBACK_REVIEWER_APP_ID` | `VTDD_CODEX_FALLBACK_REVIEWER_APP_PRIVATE_KEY` |
+| `mac-codex` | `VTDD_MAC_CODEX_APP_ID` | `VTDD_MAC_CODEX_APP_PRIVATE_KEY` |
+| `vps-codex-cli` | `VTDD_VPS_CODEX_CLI_APP_ID` | `VTDD_VPS_CODEX_CLI_APP_PRIVATE_KEY` |
+
 ## Boundary
 
 This is a high-risk operation because it mutates repository secrets.
@@ -40,6 +51,17 @@ Review the planned sync without mutation:
 
 ```bash
 node scripts/sync-github-app-actions-secrets.mjs --repo marushu/vtdd-v2-p
+```
+
+For a role-specific App private key that is not part of the legacy bootstrap
+vault:
+
+```bash
+node scripts/sync-github-app-actions-secrets.mjs \
+  --repo marushu/vtdd-v2-p \
+  --app-role gemini-reviewer \
+  --app-id 3706701 \
+  --private-key-path /path/to/vtdd-gemini-reviewer.private-key.pem
 ```
 
 ## Execute
@@ -59,6 +81,19 @@ Then execute the local bootstrap/update path with the returned
 node scripts/sync-github-app-actions-secrets.mjs \
   --repo marushu/vtdd-v2-p \
   --execute \
+  --runtime-url https://<your-runtime-host> \
+  --approval-grant-id <approvalGrantId>
+```
+
+Role-specific execution uses the same approval boundary:
+
+```bash
+node scripts/sync-github-app-actions-secrets.mjs \
+  --repo marushu/vtdd-v2-p \
+  --execute \
+  --app-role gemini-reviewer \
+  --app-id 3706701 \
+  --private-key-path /path/to/vtdd-gemini-reviewer.private-key.pem \
   --runtime-url https://<your-runtime-host> \
   --approval-grant-id <approvalGrantId>
 ```
@@ -88,6 +123,20 @@ node scripts/run-passkey-operator-helper.mjs \
   --runtime-url https://<your-runtime-host> \
   --repo marushu/vtdd-v2-p \
   --issue-number 15
+```
+
+For role-specific repair, start the helper with the role and key path it is
+allowed to serve. The Worker operator page will include the role in the sync
+request, and the helper refuses requests for a different role:
+
+```bash
+node scripts/run-passkey-operator-helper.mjs \
+  --runtime-url https://<your-runtime-host> \
+  --repo marushu/vtdd-v2-p \
+  --issue-number 351 \
+  --app-role gemini-reviewer \
+  --app-id 3706701 \
+  --private-key-path /path/to/vtdd-gemini-reviewer.private-key.pem
 ```
 
 This helper:

--- a/scripts/run-passkey-operator-helper.mjs
+++ b/scripts/run-passkey-operator-helper.mjs
@@ -17,7 +17,11 @@ async function main() {
   }
 
   const sourceResult = await loadGitHubAppSecretSource({
-    manifestPath: args.manifestPath
+    manifestPath: args.manifestPath,
+    role: args.appRole,
+    appId: args.appId,
+    privateKeyPath: args.privateKeyPath,
+    installationId: args.installationId
   });
   if (!sourceResult.ok) {
     throw new Error(sourceResult.issues.join(", "));
@@ -45,7 +49,11 @@ async function main() {
     repo: normalizeText(args.repo || "marushu/vtdd-v2-p"),
     issueNumber: normalizeText(args.issueNumber || "15"),
     highRiskKind: normalizeText(args.highRiskKind || "github_app_secret_sync"),
-    manifestPath: normalizeText(args.manifestPath || sourceResult.source.manifestPath)
+    manifestPath: normalizeText(args.manifestPath || sourceResult.source.manifestPath),
+    appRole: normalizeText(args.appRole || sourceResult.source.role || "legacy"),
+    appId: normalizeText(args.appId || sourceResult.source.appId),
+    privateKeyPath: normalizeText(args.privateKeyPath || sourceResult.source.privateKeyPath),
+    installationId: normalizeText(args.installationId || sourceResult.source.installationId)
   };
 
   const server = http.createServer((request, response) =>
@@ -84,6 +92,7 @@ async function handleRequest({ request, response, state }) {
       repositoryInput: state.repo,
       issueNumber: state.issueNumber,
       highRiskKind: state.highRiskKind,
+      githubAppRole: state.appRole,
       syncEnabled: true
     });
     response.writeHead(200, { "content-type": "text/html; charset=utf-8" });
@@ -100,11 +109,20 @@ async function handleRequest({ request, response, state }) {
     const body = await readJson(request);
     const approvalGrantId = normalizeText(body.approvalGrantId);
     const repo = normalizeText(body.repositoryInput || state.repo);
+    const appRole = normalizeText(body.githubAppRole || state.appRole);
     if (!approvalGrantId) {
       writeJson(response, 422, {
         ok: false,
         error: "approval_grant_id_required",
         reason: "approvalGrantId is required"
+      }, corsHeaders);
+      return;
+    }
+    if (appRole !== state.appRole) {
+      writeJson(response, 422, {
+        ok: false,
+        error: "github_app_role_not_served",
+        reason: `desktop helper is serving ${state.appRole}, not ${appRole}`
       }, corsHeaders);
       return;
     }
@@ -114,6 +132,12 @@ async function handleRequest({ request, response, state }) {
       "--repo",
       repo,
       "--execute",
+      "--app-role",
+      state.appRole,
+      "--app-id",
+      state.appId,
+      "--private-key-path",
+      state.privateKeyPath,
       "--runtime-url",
       state.runtimeUrl,
       "--approval-grant-id",
@@ -121,6 +145,9 @@ async function handleRequest({ request, response, state }) {
     ];
     if (state.manifestPath) {
       args.push("--manifest-path", state.manifestPath);
+    }
+    if (state.installationId) {
+      args.push("--installation-id", state.installationId);
     }
 
     const result = await execFileAsync(process.execPath, args, {
@@ -236,6 +263,26 @@ function parseArgs(args) {
     }
     if (current === "--manifest-path") {
       parsed.manifestPath = args[index + 1];
+      index += 1;
+      continue;
+    }
+    if (current === "--app-role") {
+      parsed.appRole = args[index + 1];
+      index += 1;
+      continue;
+    }
+    if (current === "--app-id") {
+      parsed.appId = args[index + 1];
+      index += 1;
+      continue;
+    }
+    if (current === "--private-key-path") {
+      parsed.privateKeyPath = args[index + 1];
+      index += 1;
+      continue;
+    }
+    if (current === "--installation-id") {
+      parsed.installationId = args[index + 1];
       index += 1;
     }
   }

--- a/scripts/sync-github-app-actions-secrets.mjs
+++ b/scripts/sync-github-app-actions-secrets.mjs
@@ -14,7 +14,11 @@ async function main() {
   const execute = args.execute === true;
 
   const sourceResult = await loadGitHubAppSecretSource({
-    manifestPath: args.manifestPath
+    manifestPath: args.manifestPath,
+    role: args.appRole,
+    appId: args.appId,
+    privateKeyPath: args.privateKeyPath,
+    installationId: args.installationId
   });
   if (!sourceResult.ok) {
     throw new Error(sourceResult.issues.join(", "));
@@ -23,6 +27,7 @@ async function main() {
   const planResult = buildGitHubAppSecretSyncPlan({
     repo,
     source: sourceResult.source,
+    role: args.appRole,
     execute
   });
   if (!planResult.ok) {
@@ -67,9 +72,10 @@ async function main() {
 function printDryRun(plan, source) {
   console.log("GitHub App secret sync dry-run");
   console.log(`repo: ${plan.repo}`);
-  console.log(`vault manifest: ${source.manifestPath}`);
+  console.log(`role: ${plan.role} (${plan.roleLabel})`);
+  console.log(`vault manifest: ${source.manifestPath || "[not used for role-specific key]"}`);
   console.log(`app id: ${source.appId}`);
-  console.log(`installation id: ${source.installationId}`);
+  console.log(`installation id: ${source.installationId || "[not provided]"}`);
   console.log(`private key path: ${source.privateKeyPath}`);
   console.log(
     `gateway bearer token path: ${source.gatewayBearerTokenPath || "[not configured in vault manifest]"}`
@@ -77,7 +83,7 @@ function printDryRun(plan, source) {
   console.log("secrets to sync:");
   for (const secret of plan.secrets) {
     const detail =
-      secret.name === "VTDD_GITHUB_APP_PRIVATE_KEY"
+      secret.name.endsWith("_PRIVATE_KEY")
         ? "[redacted private key content]"
         : secret.value;
     console.log(`- ${secret.name}: ${detail}`);
@@ -102,6 +108,26 @@ function parseArgs(args) {
     }
     if (current === "--manifest-path") {
       parsed.manifestPath = args[index + 1];
+      index += 1;
+      continue;
+    }
+    if (current === "--app-role") {
+      parsed.appRole = args[index + 1];
+      index += 1;
+      continue;
+    }
+    if (current === "--app-id") {
+      parsed.appId = args[index + 1];
+      index += 1;
+      continue;
+    }
+    if (current === "--private-key-path") {
+      parsed.privateKeyPath = args[index + 1];
+      index += 1;
+      continue;
+    }
+    if (current === "--installation-id") {
+      parsed.installationId = args[index + 1];
       index += 1;
       continue;
     }

--- a/src/core/github-app-secret-sync.js
+++ b/src/core/github-app-secret-sync.js
@@ -2,8 +2,42 @@ import {
   DEFAULT_VTDD_VAULT_MANIFEST_PATH,
   loadDesktopBootstrapVault
 } from "./desktop-bootstrap-vault.js";
+import fs from "node:fs/promises";
+
+export const GITHUB_APP_SECRET_SYNC_ROLES = {
+  legacy: {
+    label: "Legacy vtdd-codex",
+    appIdSecretName: "VTDD_GITHUB_APP_ID",
+    privateKeySecretName: "VTDD_GITHUB_APP_PRIVATE_KEY"
+  },
+  "gemini-reviewer": {
+    label: "VTDD Gemini Reviewer",
+    appIdSecretName: "VTDD_GEMINI_REVIEWER_APP_ID",
+    privateKeySecretName: "VTDD_GEMINI_REVIEWER_APP_PRIVATE_KEY"
+  },
+  "codex-fallback-reviewer": {
+    label: "VTDD Codex Fallback Reviewer",
+    appIdSecretName: "VTDD_CODEX_FALLBACK_REVIEWER_APP_ID",
+    privateKeySecretName: "VTDD_CODEX_FALLBACK_REVIEWER_APP_PRIVATE_KEY"
+  },
+  "mac-codex": {
+    label: "VTDD mac Codex",
+    appIdSecretName: "VTDD_MAC_CODEX_APP_ID",
+    privateKeySecretName: "VTDD_MAC_CODEX_APP_PRIVATE_KEY"
+  },
+  "vps-codex-cli": {
+    label: "VTDD VPS Codex CLI",
+    appIdSecretName: "VTDD_VPS_CODEX_CLI_APP_ID",
+    privateKeySecretName: "VTDD_VPS_CODEX_CLI_APP_PRIVATE_KEY"
+  }
+};
 
 export async function loadGitHubAppSecretSource(input = {}) {
+  const role = normalizeGitHubAppSecretSyncRole(input.role);
+  if (role !== "legacy" || normalizeText(input.appId) || normalizeText(input.privateKeyPath)) {
+    return loadExplicitGitHubAppSecretSource({ ...input, role });
+  }
+
   const manifestPath = input.manifestPath || DEFAULT_VTDD_VAULT_MANIFEST_PATH;
   const vaultResult = await loadDesktopBootstrapVault({ manifestPath });
   if (!vaultResult.ok) {
@@ -15,6 +49,7 @@ export async function loadGitHubAppSecretSource(input = {}) {
     ok: true,
     source: {
       sourceType: "desktop_bootstrap_vault",
+      role,
       manifestPath: vault.manifestPath,
       appId: vault.githubApp.appId,
       installationId: vault.githubApp.installationId,
@@ -30,8 +65,13 @@ export function buildGitHubAppSecretSyncPlan(input = {}) {
   const source = input.source ?? {};
   const repo = normalizeText(input.repo);
   const execute = input.execute === true;
+  const role = normalizeGitHubAppSecretSyncRole(input.role || source.role);
+  const roleConfig = GITHUB_APP_SECRET_SYNC_ROLES[role];
   const issues = [];
 
+  if (!roleConfig) {
+    issues.push("unsupported GitHub App secret sync role");
+  }
   if (!repo) {
     issues.push("repo is required");
   }
@@ -51,13 +91,15 @@ export function buildGitHubAppSecretSyncPlan(input = {}) {
     plan: {
       repo,
       execute,
+      role,
+      roleLabel: roleConfig.label,
       secrets: [
         {
-          name: "VTDD_GITHUB_APP_ID",
+          name: roleConfig.appIdSecretName,
           value: source.appId
         },
         {
-          name: "VTDD_GITHUB_APP_PRIVATE_KEY",
+          name: roleConfig.privateKeySecretName,
           value: source.privateKey
         }
       ]
@@ -88,6 +130,63 @@ export async function executeGitHubAppSecretSync(input = {}) {
     result: {
       repo: plan.repo,
       synced: results
+    }
+  };
+}
+
+export function normalizeGitHubAppSecretSyncRole(value) {
+  const normalized = normalizeText(value) || "legacy";
+  return Object.hasOwn(GITHUB_APP_SECRET_SYNC_ROLES, normalized) ? normalized : "";
+}
+
+async function loadExplicitGitHubAppSecretSource(input = {}) {
+  const role = normalizeGitHubAppSecretSyncRole(input.role);
+  const appId = normalizeText(input.appId);
+  const privateKeyPath = normalizeText(input.privateKeyPath);
+  const issues = [];
+
+  if (!role) {
+    issues.push("unsupported GitHub App secret sync role");
+  }
+  if (!appId) {
+    issues.push("appId is required for role-specific GitHub App secret sync");
+  }
+  if (!privateKeyPath) {
+    issues.push("privateKeyPath is required for role-specific GitHub App secret sync");
+  }
+
+  let privateKey = "";
+  if (privateKeyPath) {
+    try {
+      privateKey = normalizeText(await fs.readFile(privateKeyPath, "utf8"));
+    } catch {
+      issues.push(`GitHub App private key file is unreadable: ${privateKeyPath}`);
+    }
+  }
+  if (privateKeyPath && !privateKey) {
+    issues.push("GitHub App private key file is empty or unreadable");
+  }
+
+  if (issues.length > 0) {
+    return { ok: false, issues };
+  }
+
+  const manifestPath = input.manifestPath || DEFAULT_VTDD_VAULT_MANIFEST_PATH;
+  const vaultResult = await loadDesktopBootstrapVault({ manifestPath }).catch(() => null);
+  const vault = vaultResult?.ok ? vaultResult.vault : null;
+
+  return {
+    ok: true,
+    source: {
+      sourceType: "explicit_role_private_key",
+      role,
+      manifestPath: vault?.manifestPath || normalizeText(input.manifestPath),
+      appId,
+      installationId: normalizeText(input.installationId),
+      privateKeyPath,
+      privateKey,
+      gatewayBearerTokenPath: vault?.gateway?.bearerTokenPath || "",
+      gatewayBearerToken: vault?.gateway?.bearerToken || ""
     }
   };
 }

--- a/src/core/passkey-operator-page.js
+++ b/src/core/passkey-operator-page.js
@@ -14,6 +14,7 @@ export function renderPasskeyOperatorPage(input = {}) {
   const highRiskKindDefault = escapeHtml(input.highRiskKind || defaultHighRiskKindForMode(operatorMode));
   const mergeMethodDefault = escapeHtml(input.mergeMethod || "squash");
   const returnUrl = escapeHtml(input.returnUrl || "");
+  const githubAppRoleDefault = escapeHtml(input.githubAppRole || "legacy");
   const syncEnabled = input.syncEnabled === true;
   const syncMessage = escapeHtml(
     input.syncMessage ||
@@ -86,7 +87,8 @@ export function renderPasskeyOperatorPage(input = {}) {
         color: var(--muted);
         margin-bottom: 6px;
       }
-      input {
+      input,
+      select {
         width: 100%;
         box-sizing: border-box;
         padding: 10px 12px;
@@ -208,6 +210,14 @@ export function renderPasskeyOperatorPage(input = {}) {
         <section data-operator-section="github-app-secret-sync"${hiddenAttribute(!sectionVisibility.githubAppSecretSync)}>
           <h2>3. GitHub App Secret Sync</h2>
           <p class="muted">real passkey approval 後、この helper から <code>#15</code> の explicit operator bootstrap を実行します。</p>
+          <label for="github-app-role-input">GitHub App Role</label>
+          <select id="github-app-role-input">
+            ${renderGithubAppRoleOption("legacy", "Legacy vtdd-codex", githubAppRoleDefault)}
+            ${renderGithubAppRoleOption("gemini-reviewer", "VTDD Gemini Reviewer", githubAppRoleDefault)}
+            ${renderGithubAppRoleOption("codex-fallback-reviewer", "VTDD Codex Fallback Reviewer", githubAppRoleDefault)}
+            ${renderGithubAppRoleOption("mac-codex", "VTDD mac Codex", githubAppRoleDefault)}
+            ${renderGithubAppRoleOption("vps-codex-cli", "VTDD VPS Codex CLI", githubAppRoleDefault)}
+          </select>
           <div class="row">
             <button id="sync-button"${syncEnabled ? "" : " disabled"}>Sync GitHub App secrets</button>
           </div>
@@ -543,7 +553,8 @@ export function renderPasskeyOperatorPage(input = {}) {
             headers: { "content-type": "application/json" },
             body: JSON.stringify({
               approvalGrantId: latestApprovalGrantId,
-              repositoryInput: document.getElementById("repo-input").value
+              repositoryInput: document.getElementById("repo-input").value,
+              githubAppRole: document.getElementById("github-app-role-input").value
             })
           });
           const syncBody = await readResponseBody(syncResponse);
@@ -829,6 +840,11 @@ function resolveSectionVisibility(operatorMode) {
 
 function hiddenAttribute(hidden) {
   return hidden ? " hidden" : "";
+}
+
+function renderGithubAppRoleOption(value, label, selectedValue) {
+  const selected = value === selectedValue ? " selected" : "";
+  return `<option value="${escapeHtml(value)}"${selected}>${escapeHtml(label)}</option>`;
 }
 
 function normalizeOperatorMode(value) {

--- a/test/github-app-secret-sync.test.js
+++ b/test/github-app-secret-sync.test.js
@@ -66,6 +66,43 @@ test("buildGitHubAppSecretSyncPlan targets actions secrets from source of truth"
   );
 });
 
+test("buildGitHubAppSecretSyncPlan targets role-specific Gemini reviewer secrets", () => {
+  const result = buildGitHubAppSecretSyncPlan({
+    repo: "marushu/vtdd-v2-p",
+    role: "gemini-reviewer",
+    source: {
+      appId: "3706701",
+      privateKey: "-----BEGIN PRIVATE KEY-----\nexample\n-----END PRIVATE KEY-----"
+    }
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.plan.role, "gemini-reviewer");
+  assert.deepEqual(
+    result.plan.secrets.map((secret) => secret.name),
+    ["VTDD_GEMINI_REVIEWER_APP_ID", "VTDD_GEMINI_REVIEWER_APP_PRIVATE_KEY"]
+  );
+});
+
+test("loadGitHubAppSecretSource can read explicit role private key material", async () => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "vtdd-role-app-sync-"));
+  const keyPath = path.join(tempDir, "gemini-private-key.pem");
+  await fs.writeFile(keyPath, "-----BEGIN PRIVATE KEY-----\nrole-example\n-----END PRIVATE KEY-----\n", "utf8");
+
+  const result = await loadGitHubAppSecretSource({
+    role: "gemini-reviewer",
+    appId: "3706701",
+    privateKeyPath: keyPath
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.source.sourceType, "explicit_role_private_key");
+  assert.equal(result.source.role, "gemini-reviewer");
+  assert.equal(result.source.appId, "3706701");
+  assert.equal(result.source.privateKeyPath, keyPath);
+  assert.equal(result.source.privateKey.includes("role-example"), true);
+});
+
 test("executeGitHubAppSecretSync calls runner for each target secret", async () => {
   const calls = [];
   const result = await executeGitHubAppSecretSync({
@@ -82,6 +119,28 @@ test("executeGitHubAppSecretSync calls runner for each target secret", async () 
 
   assert.equal(result.ok, true);
   assert.deepEqual(calls, ["VTDD_GITHUB_APP_ID", "VTDD_GITHUB_APP_PRIVATE_KEY"]);
+});
+
+test("executeGitHubAppSecretSync calls runner for role-specific target secrets", async () => {
+  const calls = [];
+  const result = await executeGitHubAppSecretSync({
+    repo: "marushu/vtdd-v2-p",
+    role: "codex-fallback-reviewer",
+    source: {
+      appId: "3706921",
+      privateKey: "-----BEGIN PRIVATE KEY-----\nexample\n-----END PRIVATE KEY-----"
+    },
+    runner: async (secret) => {
+      calls.push(secret.name);
+      return { ok: true, name: secret.name };
+    }
+  });
+
+  assert.equal(result.ok, true);
+  assert.deepEqual(calls, [
+    "VTDD_CODEX_FALLBACK_REVIEWER_APP_ID",
+    "VTDD_CODEX_FALLBACK_REVIEWER_APP_PRIVATE_KEY"
+  ]);
 });
 
 test("GitHub App secret sync approval grant must match repo and high-risk kind", () => {

--- a/test/passkey-operator-helper.test.js
+++ b/test/passkey-operator-helper.test.js
@@ -1,10 +1,21 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import fs from "node:fs";
 import { buildCorsHeaders } from "../scripts/run-passkey-operator-helper.mjs";
+
+const helperSource = fs.readFileSync("scripts/run-passkey-operator-helper.mjs", "utf8");
 
 test("desktop helper bridge returns CORS headers for worker-hosted sync requests", () => {
   const headers = buildCorsHeaders("https://sample-user-vtdd.example.workers.dev");
   assert.equal(headers["access-control-allow-origin"], "https://sample-user-vtdd.example.workers.dev");
   assert.equal(headers["access-control-allow-methods"], "POST, GET, OPTIONS");
   assert.equal(headers["access-control-allow-headers"], "content-type");
+});
+
+test("desktop helper bridge passes role-specific GitHub App sync arguments", () => {
+  assert.equal(helperSource.includes("--app-role"), true);
+  assert.equal(helperSource.includes("--app-id"), true);
+  assert.equal(helperSource.includes("--private-key-path"), true);
+  assert.equal(helperSource.includes("githubAppRole"), true);
+  assert.equal(helperSource.includes("github_app_role_not_served"), true);
 });

--- a/test/passkey-operator-page.test.js
+++ b/test/passkey-operator-page.test.js
@@ -162,6 +162,10 @@ test("passkey operator page focuses secret sync modes without hiding the require
   });
   assert.equal(githubAppSecretHtml.includes('<section data-operator-section="approval">'), true);
   assert.equal(githubAppSecretHtml.includes('<section data-operator-section="github-app-secret-sync">'), true);
+  assert.equal(githubAppSecretHtml.includes('<select id="github-app-role-input">'), true);
+  assert.equal(githubAppSecretHtml.includes('value="gemini-reviewer"'), true);
+  assert.equal(githubAppSecretHtml.includes("VTDD Gemini Reviewer"), true);
+  assert.equal(githubAppSecretHtml.includes("githubAppRole: document.getElementById"), true);
   assert.equal(githubAppSecretHtml.includes('<section data-operator-section="production-deploy" hidden>'), true);
   assert.equal(githubAppSecretHtml.includes('<section data-operator-section="pr-merge" hidden>'), true);
 

--- a/worker.js
+++ b/worker.js
@@ -27095,6 +27095,7 @@ function renderPasskeyOperatorPage(input = {}) {
   const highRiskKindDefault = escapeHtml(input.highRiskKind || defaultHighRiskKindForMode(operatorMode));
   const mergeMethodDefault = escapeHtml(input.mergeMethod || "squash");
   const returnUrl = escapeHtml(input.returnUrl || "");
+  const githubAppRoleDefault = escapeHtml(input.githubAppRole || "legacy");
   const syncEnabled = input.syncEnabled === true;
   const syncMessage = escapeHtml(
     input.syncMessage || (syncEnabled ? "approvalGrantId \u304C\u53D6\u5F97\u6E08\u307F\u306A\u3089\u5B9F\u884C\u3067\u304D\u307E\u3059\u3002desktop helper bridge \u306B\u63A5\u7D9A\u3057\u307E\u3059\u3002" : "desktop maintenance required: local secret sync bridge \u304C\u672A\u63A5\u7D9A\u3067\u3059\u3002")
@@ -27163,7 +27164,8 @@ function renderPasskeyOperatorPage(input = {}) {
         color: var(--muted);
         margin-bottom: 6px;
       }
-      input {
+      input,
+      select {
         width: 100%;
         box-sizing: border-box;
         padding: 10px 12px;
@@ -27285,6 +27287,14 @@ function renderPasskeyOperatorPage(input = {}) {
         <section data-operator-section="github-app-secret-sync"${hiddenAttribute(!sectionVisibility.githubAppSecretSync)}>
           <h2>3. GitHub App Secret Sync</h2>
           <p class="muted">real passkey approval \u5F8C\u3001\u3053\u306E helper \u304B\u3089 <code>#15</code> \u306E explicit operator bootstrap \u3092\u5B9F\u884C\u3057\u307E\u3059\u3002</p>
+          <label for="github-app-role-input">GitHub App Role</label>
+          <select id="github-app-role-input">
+            ${renderGithubAppRoleOption("legacy", "Legacy vtdd-codex", githubAppRoleDefault)}
+            ${renderGithubAppRoleOption("gemini-reviewer", "VTDD Gemini Reviewer", githubAppRoleDefault)}
+            ${renderGithubAppRoleOption("codex-fallback-reviewer", "VTDD Codex Fallback Reviewer", githubAppRoleDefault)}
+            ${renderGithubAppRoleOption("mac-codex", "VTDD mac Codex", githubAppRoleDefault)}
+            ${renderGithubAppRoleOption("vps-codex-cli", "VTDD VPS Codex CLI", githubAppRoleDefault)}
+          </select>
           <div class="row">
             <button id="sync-button"${syncEnabled ? "" : " disabled"}>Sync GitHub App secrets</button>
           </div>
@@ -27620,7 +27630,8 @@ function renderPasskeyOperatorPage(input = {}) {
             headers: { "content-type": "application/json" },
             body: JSON.stringify({
               approvalGrantId: latestApprovalGrantId,
-              repositoryInput: document.getElementById("repo-input").value
+              repositoryInput: document.getElementById("repo-input").value,
+              githubAppRole: document.getElementById("github-app-role-input").value
             })
           });
           const syncBody = await readResponseBody(syncResponse);
@@ -27900,6 +27911,10 @@ function resolveSectionVisibility(operatorMode) {
 }
 function hiddenAttribute(hidden) {
   return hidden ? " hidden" : "";
+}
+function renderGithubAppRoleOption(value, label, selectedValue) {
+  const selected = value === selectedValue ? " selected" : "";
+  return `<option value="${escapeHtml(value)}"${selected}>${escapeHtml(label)}</option>`;
 }
 function normalizeOperatorMode(value) {
   const token = normalizeOperatorToken(value);


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #351 の残作業として、operator URL / desktop helper 経由で role-specific GitHub App secrets を同期できるようにする。

## Satisfied Success Criteria

- GitHub App secret sync plan が legacy / gemini-reviewer / codex-fallback-reviewer / mac-codex / vps-codex-cli を選べるようになった。operator page は GitHub App Role select を持ち、sync request に githubAppRole を含める。desktop helper は serving role と異なる role の sync request を拒否し、sync script に --app-role / --app-id / --private-key-path を渡す。Gemini reviewer key の dry-run で VTDD_GEMINI_REVIEWER_APP_ID / VTDD_GEMINI_REVIEWER_APP_PRIVATE_KEY だけが対象になることを確認した。

## Unsatisfied Success Criteria

- GitHub Actions secrets への実登録は GO + passkey が必要な高リスク操作なので、この PR では実行していない。PR マージ後に operator URL 経由で Gemini reviewer secret を同期し、実際に VTDD Gemini Reviewer Bot として PR コメントされる live E2E が必要。

## Non-goal violations

None.

## Verification Evidence

- Unit: node --test test/github-app-secret-sync.test.js test/passkey-operator-helper.test.js test/passkey-operator-page.test.js test/e2e-16-worker-passkey-secret-sync-bridge.test.js test/e2e-17-github-app-secret-sync-bootstrap.test.js
- Integration: npm test
- E2E: Dry-run only: node scripts/sync-github-app-actions-secrets.mjs --repo marushu/vtdd-v2-p --app-role gemini-reviewer --app-id 3706701 --private-key-path /Users/shuhei/Downloads/vtdd-gemini-reviewer.2026-05-13.private-key.pem
- Manual: git diff --check; chmod 600 /Users/shuhei/Downloads/vtdd-gemini-reviewer.2026-05-13.private-key.pem
- Evidence path/link: src/core/github-app-secret-sync.js; src/core/passkey-operator-page.js; scripts/run-passkey-operator-helper.mjs; scripts/sync-github-app-actions-secrets.mjs; docs/setup/github-app-secret-sync.md; test/github-app-secret-sync.test.js; test/passkey-operator-helper.test.js; test/passkey-operator-page.test.js

## Butler Completion Contract

- Owner goal: Gemini PR 批判的レビュアーを、チャットや手作業の gh secret set ではなく、operator URL と GO + passkey 境界で復活できるようにする。
- Butler entrypoint: Butler は高リスク secret sync の operator URL を提示し、人間が passkey approval 後に desktop helper bridge 経由で同期する。
- Action Schema exposure: 変更なし。既存 passkey operator / secret sync 導線を role-specific に拡張する。
- Runtime path: Worker passkey operator page -> desktop helper /api/github-app-secret-sync/execute -> scripts/sync-github-app-actions-secrets.mjs -> GitHub Actions secrets.
- Runner/runtime truth: Dry-run output shows role gemini-reviewer and target secrets VTDD_GEMINI_REVIEWER_APP_ID / VTDD_GEMINI_REVIEWER_APP_PRIVATE_KEY. Live runtime truth remains pending until GO + passkey sync and reviewer workflow run.
- Authority boundary: No GitHub secret mutation, permission mutation, deploy, merge, or issue close in this PR. Secret mutation remains blocked until real GO + passkey approval grant.
- E2E evidence: 未完了。マージ後に operator URL から Gemini reviewer secrets を同期し、open PR の timeline で VTDD Gemini Reviewer Bot コメントを確認する必要がある。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 不要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 不要。

## Related Constitution Rules

- Issue #351 scope only; AGENTS.md Authority Boundary; Evidence Discipline; Change Size and PR Discipline

## Out-of-scope but NOT implemented

- GitHub Actions secrets 実登録; GitHub App permission mutation; deploy; 既存 PR #347 コメント削除; Issue close

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #351
- Execution ID: Not provided.
- Goal: Not provided.
