### PR TITLE
Issue #361 RAG checkpoint を記憶セーブポイントとして追加

### DIFF
--- a/docs/memory-schema.md
+++ b/docs/memory-schema.md
@@ -19,6 +19,9 @@ These families are required by Issue #2 and form the core VTDD memory model.
 ### `working_memory`
 - Purpose: keep short-lived but operationally useful context
 - Typical content: current risk, pending ambiguity, active constraints
+- RAG checkpoint use: a compact memory savepoint captured before context
+  compression, sleep, travel, implementation, or large investigation changes the
+  active thread state
 
 ### `temperature_note`
 - Purpose: preserve user intent temperature such as urgency, preference, and
@@ -73,6 +76,34 @@ All memory records use the following shape:
 - Required
 - Structured payload for the record's primary meaning
 - Content shape may vary by `type`
+
+For a RAG checkpoint stored as `working_memory`, content should stay compact and
+may include:
+
+- `summary`
+- `details`
+- `checkpointReason`
+- `thoughtLocation`
+- `userTension`
+- `contextSourceQuality`
+- `hypothesis`
+- `expectedFiles`
+- `evidenceLinks`
+- `previousRecordIds`
+- `captureBoundary`
+- `relatedIssue`
+- `repository`
+- `timestamp`
+
+`captureBoundary` must describe the stored material as a judgment log or
+operational summary, not raw hidden chain-of-thought or full transcript capture.
+
+Suggested `contextSourceQuality` values:
+
+- `full_thread_context`: captured before compression from the active thread
+- `compressed_context`: reconstructed after compression and requiring caution
+- `external_evidence`: backed by Issue, PR, commit, log, or runtime truth
+- `missing_context_risk`: known context loss risk remains
 
 ### `metadata`
 - Required object

--- a/docs/memory/rag-memory-philosophy.md
+++ b/docs/memory/rag-memory-philosophy.md
@@ -103,3 +103,38 @@ Store only what improves future judgment and recovery.
   - deletion plan.
 - Proposal/decision/execution records should remain compact and referenceable
   rather than transcript-heavy.
+
+## RAG Checkpoint Principle
+
+A RAG checkpoint is VTDD's memory savepoint. It is closer to pressing `Cmd+S`
+during a fragile creative session than to writing a polished final report.
+
+Capture small checkpoints when:
+
+- the owner says or implies "this is important",
+- strong tension, concern, anger, relief, or excitement changes the decision
+  context,
+- an implementation hypothesis or expected file set appears,
+- a dry-run finds a likely breakage point,
+- an error deserves observation before repair,
+- a large docs / PR / log investigation begins or ends,
+- context compression appears likely or has just happened,
+- the owner is about to sleep, bathe, travel, or otherwise lose the active
+  mental thread.
+
+The checkpoint should store a compact judgment log:
+
+- what was noticed,
+- why it matters,
+- where it came from,
+- the owner's tension at that moment,
+- related Issue / PR,
+- expected files or hypotheses,
+- evidence links when available,
+- whether the source context was full, compressed, externally verified, or
+  risky.
+
+Do not store raw full transcripts or hidden chain-of-thought as checkpoints.
+If a checkpoint is created after compression, mark it as lower-trust
+`compressed_context` or `missing_context_risk` until Issue / PR / runtime
+evidence verifies it.

--- a/docs/memory/vtdd-memory-bridge.md
+++ b/docs/memory/vtdd-memory-bridge.md
@@ -56,6 +56,27 @@ node scripts/vtdd-memory.mjs retrieve-cross \
   --pretty true
 ```
 
+Write a RAG checkpoint through the Worker runtime:
+
+```sh
+node scripts/vtdd-memory.mjs write-runtime-checkpoint \
+  --runtime-url "$VTDD_RUNTIME_URL" \
+  --confirmed true \
+  --owner-consent "GO" \
+  --repository "owner/repo" \
+  --related-issue 361 \
+  --summary "Compact checkpoint summary." \
+  --checkpoint-reason "Context compression risk before implementation." \
+  --thought-location "Owner and Codex discussion before touching code." \
+  --user-tension "Concerned that compressed context may create partial RAG." \
+  --context-source-quality "full_thread_context" \
+  --hypothesis "Checkpoint schema should ride existing working_memory." \
+  --expected-file "docs/memory-schema.md" \
+  --expected-file "scripts/vtdd-memory.mjs" \
+  --tag "issue:361" \
+  --pretty true
+```
+
 Retrieve canonical cross memory directly from D1:
 
 ```sh
@@ -113,11 +134,15 @@ node scripts/vtdd-memory.mjs write-record \
 ## Safety Rules
 
 - Do not store full conversation transcripts by default.
+- Do not store raw hidden chain-of-thought. Store compact judgment logs:
+  observations, reasons, hypotheses, tensions, evidence, and next return points.
 - Do not store secrets, raw tokens, private keys, or owner-only credentials.
 - Do not treat memory as permission to deploy, merge, close issues, mutate
   credentials, or run destructive operations.
 - Use decision/proposal helpers when the record must be retrievable through
   cross-memory by `relatedIssue`.
+- Use runtime checkpoint writes from Mac Codex and VPS Codex CLI when the goal is
+  shared Butler-visible memory rather than direct Cloudflare administration.
 - Treat empty retrieval as an operational finding, not as proof that no
   relevant history exists.
 

--- a/docs/setup/custom-gpt-actions-openapi.json
+++ b/docs/setup/custom-gpt-actions-openapi.json
@@ -1110,6 +1110,32 @@
                   "details": {
                     "type": "string"
                   },
+                  "checkpointReason": {
+                    "type": "string",
+                    "description": "Why this RAG checkpoint is being saved, such as context compression risk, owner leaving, dry-run hypothesis, or error observation."
+                  },
+                  "thoughtLocation": {
+                    "type": "string",
+                    "description": "Human-readable place where the thought emerged, without requiring raw transcript capture."
+                  },
+                  "userTension": {
+                    "type": "string",
+                    "description": "The owner's tension or mood relevant to future recall, expressed compactly."
+                  },
+                  "contextSourceQuality": {
+                    "type": "string",
+                    "enum": [
+                      "full_thread_context",
+                      "compressed_context",
+                      "external_evidence",
+                      "missing_context_risk"
+                    ],
+                    "description": "Whether the checkpoint came from full active context, compressed context, external evidence, or known context-loss risk."
+                  },
+                  "captureBoundary": {
+                    "type": "string",
+                    "description": "Must describe a judgment log or operational summary, not hidden chain-of-thought or full transcript capture."
+                  },
                   "decision": {
                     "type": "string"
                   },
@@ -1162,6 +1188,24 @@
                     }
                   },
                   "tags": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "expectedFiles": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "evidenceLinks": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "previousRecordIds": {
                     "type": "array",
                     "items": {
                       "type": "string"

--- a/docs/setup/custom-gpt-actions-openapi.yaml
+++ b/docs/setup/custom-gpt-actions-openapi.yaml
@@ -751,6 +751,26 @@ paths:
                   type: string
                 details:
                   type: string
+                checkpointReason:
+                  type: string
+                  description: Why this RAG checkpoint is being saved, such as context compression risk, owner leaving, dry-run hypothesis, or error observation.
+                thoughtLocation:
+                  type: string
+                  description: Human-readable place where the thought emerged, without requiring raw transcript capture.
+                userTension:
+                  type: string
+                  description: The owner's tension or mood relevant to future recall, expressed compactly.
+                contextSourceQuality:
+                  type: string
+                  enum:
+                    - full_thread_context
+                    - compressed_context
+                    - external_evidence
+                    - missing_context_risk
+                  description: Whether the checkpoint came from full active context, compressed context, external evidence, or known context-loss risk.
+                captureBoundary:
+                  type: string
+                  description: Must describe a judgment log or operational summary, not hidden chain-of-thought or full transcript capture.
                 decision:
                   type: string
                 rationale:
@@ -786,6 +806,18 @@ paths:
                         type: string
                     additionalProperties: false
                 tags:
+                  type: array
+                  items:
+                    type: string
+                expectedFiles:
+                  type: array
+                  items:
+                    type: string
+                evidenceLinks:
+                  type: array
+                  items:
+                    type: string
+                previousRecordIds:
                   type: array
                   items:
                     type: string

--- a/docs/setup/custom-gpt-instructions-short-min.md
+++ b/docs/setup/custom-gpt-instructions-short-min.md
@@ -6,6 +6,7 @@ Truth and scope:
 - Issue is canonical spec. GitHub/runtime state is progress truth. Runtime truth > memory.
 - If implementation work has no existing Issue yet, propose the Issue first, wait GO, create it, then hand off. Never PR/build first and Issue-link later; #303 is the regression example.
 - Before proposal/writes/Codex handoff/PR judgment/merge-deploy-close advice/stale setup claims: retrieve runtime/GitHub truth; use memory/constitution when useful. Report found/missing. Never invent. Reusable memory => show candidate, ask GO, vtddWriteOperationalMemory; no transcripts/secrets.
+- RAG checkpoint: GO -> vtddWriteOperationalMemory.
 - No scope beyond user instruction + active Issue; do not reinterpret "MVP".
 - Do not assume a default repository. Resolve owner/repo from explicit input, alias, grant, or verified context; if ambiguous, ask one short confirmation.
 - No internal API paths/raw JSON for users. Convert natural intent into actions.

--- a/docs/setup/custom-gpt-instructions-short.md
+++ b/docs/setup/custom-gpt-instructions-short.md
@@ -3,6 +3,7 @@ Core:
 - Issue is canonical spec.
 - If implementation work does not already have an existing Issue, propose an Issue candidate first, wait for GO, create the Issue, then hand off. Do not create the PR/build first and issue-link later; #303 is the regression example.
 - Before proposal/write/Codex handoff/PR judgment: vtddRetrieveCrossMemory + vtddRetrieveDecisionLogs/vtddRetrieveProposalLogs/vtddRetrieveConstitution + runtime truth; no RAG hit OK, never invent. Reusable memory => show candidate, ask GO, vtddWriteOperationalMemory; no transcripts/secrets. Runtime truth > memory.
+- RAG ckpt -> vtddWriteOperationalMemory.
 - Do not assume a default repository. Resolve repo from alias/context; if ambiguous, ask.
 - Natural language to actions; no internal paths/raw JSON.
 - No scope beyond Issue/user instruction.

--- a/docs/setup/custom-gpt-instructions.md
+++ b/docs/setup/custom-gpt-instructions.md
@@ -123,6 +123,9 @@ VTDD context preflight / RAG:
 - If RAG/context retrieval is unavailable, say `RAG/context retrieval unavailable` and continue only when Issue/docs/runtime truth provide enough safe basis.
 - If runtime truth conflicts with memory, stop and reconcile instead of proceeding by memory.
 - When a reusable decision, blocker, failure pattern, repair, or handoff fact emerges, show a compact structured memory candidate, ask the human for GO, then call vtddWriteOperationalMemory. Do not store full transcripts, secrets, or raw sensitive material.
+- Treat a RAG checkpoint as a memory savepoint. Offer one when context compression risk appears, the owner is about to leave/sleep/bathe/travel, a strong owner tension appears, a dry-run hypothesis/expected file set appears, an error deserves observation before repair, or a large docs/PR/log investigation begins or ends.
+- For a RAG checkpoint, write `recordType=working_memory`, include tag `rag-checkpoint`, and fill compact fields such as `checkpointReason`, `thoughtLocation`, `userTension`, `contextSourceQuality`, `hypothesis`, `expectedFiles`, `evidenceLinks`, and `previousRecordIds` when available. Store judgment logs and return points, not hidden chain-of-thought or full transcripts.
+- Mark checkpoint `contextSourceQuality=compressed_context` or `missing_context_risk` when the source thread has already been compressed or evidence is incomplete.
 - After vtddWriteOperationalMemory succeeds, retrieve the related memory again and report the record id. If it fails, report the exact error/reason/issues.
 - Do not ask the human to name these internal retrieval routes in normal conversation.
 

--- a/scripts/vtdd-memory.mjs
+++ b/scripts/vtdd-memory.mjs
@@ -130,6 +130,65 @@ export function buildRuntimeCrossMemoryRequest(options) {
   };
 }
 
+export function buildRuntimeMemoryWriteRequest(options) {
+  const env = options.env ?? process.env;
+  const runtimeUrl = normalizeRequiredText(
+    options.runtimeUrl ?? env.VTDD_RUNTIME_URL,
+    "runtime-url"
+  );
+  const token = normalizeRequiredText(
+    env.VTDD_GATEWAY_BEARER_TOKEN,
+    "VTDD_GATEWAY_BEARER_TOKEN"
+  );
+  const payload = normalizeObject(options.payload);
+  if (payload.confirmed !== true) {
+    throw new Error("confirmed=true is required before writing memory through runtime");
+  }
+  const url = new URL("/v2/action/memory-write", runtimeUrl);
+
+  return {
+    url: url.toString(),
+    headers: {
+      authorization: `Bearer ${token}`,
+      "content-type": "application/json"
+    },
+    body: JSON.stringify({
+      ...payload,
+      responseMode: payload.responseMode ?? "action_visible"
+    })
+  };
+}
+
+export function buildCheckpointPayload(options) {
+  const relatedIssue = normalizePositiveInteger(options.relatedIssue, "relatedIssue");
+  const tags = mergeTags(options.tag ?? options.tags, [
+    `issue:${relatedIssue}`,
+    "rag-checkpoint",
+    "memory-savepoint"
+  ]);
+  return {
+    recordType: "working_memory",
+    confirmed: normalizeBoolean(options.confirmed),
+    ownerConsent: normalizeOptionalText(options.ownerConsent),
+    repository: normalizeOptionalText(options.repository),
+    relatedIssue,
+    summary: normalizeRequiredText(options.summary, "summary"),
+    details: normalizeOptionalText(options.details),
+    checkpointReason: normalizeOptionalText(options.checkpointReason),
+    thoughtLocation: normalizeOptionalText(options.thoughtLocation),
+    userTension: normalizeOptionalText(options.userTension),
+    contextSourceQuality: normalizeOptionalText(options.contextSourceQuality) || "full_thread_context",
+    hypothesis: normalizeOptionalText(options.hypothesis),
+    expectedFiles: normalizeList(options.expectedFile ?? options.expectedFiles),
+    evidenceLinks: normalizeList(options.evidenceLink ?? options.evidenceLinks),
+    previousRecordIds: normalizeList(options.previousRecordId ?? options.previousRecordIds),
+    captureBoundary: "judgment_log_not_chain_of_thought",
+    priority: options.priority ?? 75,
+    timestamp: options.timestamp ?? new Date().toISOString(),
+    tags
+  };
+}
+
 export function buildDecisionRecord(options) {
   const relatedIssue = normalizePositiveInteger(options.relatedIssue, "relatedIssue");
   const timestamp = options.timestamp ?? new Date().toISOString();
@@ -249,6 +308,27 @@ export async function runCli(argv = process.argv.slice(2), io = defaultIo) {
     return result;
   }
 
+  if (command === "write-runtime-checkpoint") {
+    const payload = buildCheckpointPayload({
+      ...options,
+      confirmed: normalizeBoolean(options.confirmed)
+    });
+    const request = buildRuntimeMemoryWriteRequest({ ...options, payload });
+    const response = await fetch(request.url, {
+      method: "POST",
+      headers: request.headers,
+      body: request.body
+    });
+    const text = await response.text();
+    const body = parseMaybeJson(text);
+    const result = { ok: response.ok, status: response.status, body };
+    io.writeJson(result, options);
+    if (!response.ok) {
+      throw new Error(`runtime memory write failed with status ${response.status}`);
+    }
+    return result;
+  }
+
   if (command === "write-decision") {
     const record = buildDecisionRecord(options);
     const result = writeRecordToD1(record, options);
@@ -351,6 +431,13 @@ function normalizeOptionalText(value) {
   return text || null;
 }
 
+function normalizeObject(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return {};
+  }
+  return value;
+}
+
 function normalizeList(value) {
   const items = Array.isArray(value) ? value : value === undefined ? [] : [value];
   return items
@@ -380,6 +467,16 @@ function parseJsonArray(value, label) {
     throw new Error(`${label} must be a JSON array`);
   }
   return parsed;
+}
+
+function normalizeBoolean(value) {
+  if (value === true || value === "true") {
+    return true;
+  }
+  if (value === false || value === "false" || value === undefined) {
+    return false;
+  }
+  throw new Error("boolean option must be true or false");
 }
 
 function parseMaybeJson(text) {

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -1137,6 +1137,19 @@ function buildMemoryWriteRecord(payload = {}) {
       content: {
         summary,
         details: normalizeText(payload.details) || null,
+        checkpointReason: normalizeText(payload.checkpointReason) || null,
+        thoughtLocation: normalizeText(payload.thoughtLocation) || null,
+        userTension: normalizeText(payload.userTension) || null,
+        contextSourceQuality: normalizeText(payload.contextSourceQuality) || null,
+        hypothesis: normalizeText(payload.hypothesis) || null,
+        expectedFiles: normalizeStringArray(payload.expectedFiles),
+        evidenceLinks: normalizeStringArray(payload.evidenceLinks),
+        previousRecordIds: normalizeStringArray(payload.previousRecordIds),
+        captureBoundary:
+          normalizeText(payload.captureBoundary) ||
+          (normalizeText(payload.checkpointReason)
+            ? "judgment_log_not_chain_of_thought"
+            : null),
         relatedIssue,
         repository,
         timestamp

--- a/test/vtdd-memory-cli.test.js
+++ b/test/vtdd-memory-cli.test.js
@@ -2,12 +2,14 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  buildCheckpointPayload,
   buildCrossMemorySql,
   buildDecisionRecord,
   buildInsertRecordSql,
   buildInventorySql,
   buildProposalRecord,
   buildRuntimeCrossMemoryRequest,
+  buildRuntimeMemoryWriteRequest,
   parseArgs
 } from "../scripts/vtdd-memory.mjs";
 
@@ -112,4 +114,54 @@ test("runtime cross-memory request keeps auth in headers", () => {
   assert.equal(url.searchParams.get("text"), "shared rag harness");
   assert.equal(request.headers.authorization, "Bearer test-token");
   assert.equal(request.url.includes("test-token"), false);
+});
+
+test("buildCheckpointPayload creates a compact RAG checkpoint payload", () => {
+  const payload = buildCheckpointPayload({
+    confirmed: "true",
+    ownerConsent: "GO",
+    repository: "marushu/vtdd-v2-p",
+    relatedIssue: "361",
+    summary: "Save current RAG checkpoint before compression.",
+    checkpointReason: "Context compression risk.",
+    thoughtLocation: "Owner and Codex discussion.",
+    userTension: "Concerned but constructive.",
+    hypothesis: "Use working_memory as checkpoint.",
+    expectedFile: ["docs/memory-schema.md", "scripts/vtdd-memory.mjs"],
+    evidenceLink: "https://github.com/marushu/vtdd-v2-p/issues/361",
+    previousRecordId: "decision_360_example",
+    timestamp: "2026-05-14T09:30:00.000Z"
+  });
+
+  assert.equal(payload.recordType, "working_memory");
+  assert.equal(payload.confirmed, true);
+  assert.equal(payload.relatedIssue, 361);
+  assert.equal(payload.contextSourceQuality, "full_thread_context");
+  assert.equal(payload.captureBoundary, "judgment_log_not_chain_of_thought");
+  assert.deepEqual(payload.expectedFiles, ["docs/memory-schema.md", "scripts/vtdd-memory.mjs"]);
+  assert.equal(payload.tags.includes("rag-checkpoint"), true);
+  assert.equal(payload.tags.includes("memory-savepoint"), true);
+});
+
+test("runtime memory write request posts checkpoint without leaking auth into URL", () => {
+  const payload = buildCheckpointPayload({
+    confirmed: true,
+    relatedIssue: 361,
+    summary: "Checkpoint.",
+    timestamp: "2026-05-14T09:31:00.000Z"
+  });
+  const request = buildRuntimeMemoryWriteRequest({
+    runtimeUrl: "https://example.invalid",
+    env: {
+      VTDD_GATEWAY_BEARER_TOKEN: "test-token"
+    },
+    payload
+  });
+
+  const body = JSON.parse(request.body);
+  assert.equal(new URL(request.url).pathname, "/v2/action/memory-write");
+  assert.equal(request.headers.authorization, "Bearer test-token");
+  assert.equal(request.url.includes("test-token"), false);
+  assert.equal(body.recordType, "working_memory");
+  assert.equal(body.responseMode, "action_visible");
 });

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -1148,6 +1148,51 @@ test("worker includes post-write retrieval for working memory writes", async () 
   assert.equal(body.postWriteRetrieval.relatedIssue, 251);
 });
 
+test("worker persists RAG checkpoint fields as working memory", async () => {
+  const provider = createInMemoryMemoryProvider();
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/action/memory-write", {
+      method: "POST",
+      headers: gatewayAuthHeaders,
+      body: JSON.stringify({
+        recordType: "working_memory",
+        confirmed: true,
+        repository: "sample-org/vtdd-v2",
+        relatedIssue: 361,
+        summary: "Save the current RAG checkpoint before context compression.",
+        checkpointReason: "Context compression risk before implementation.",
+        thoughtLocation: "Owner and Codex discussion before touching code.",
+        userTension: "Concerned that compressed context may create partial RAG.",
+        contextSourceQuality: "full_thread_context",
+        hypothesis: "Checkpoint schema should ride existing working_memory.",
+        expectedFiles: ["docs/memory-schema.md", "scripts/vtdd-memory.mjs"],
+        evidenceLinks: ["https://github.com/marushu/vtdd-v2-p/issues/361"],
+        previousRecordIds: ["decision_360_example"],
+        tags: ["rag-checkpoint"],
+        responseMode: "action_visible"
+      })
+    }),
+    {
+      ...gatewayAuthEnv,
+      MEMORY_PROVIDER: provider
+    }
+  );
+
+  assert.equal(response.status, 200);
+  const body = await response.json();
+  assert.equal(body.ok, true);
+  assert.equal(body.memoryWritePersisted.recordType, "working_memory");
+
+  const records = await provider.retrieve({ type: "working_memory", limit: 1 });
+  assert.equal(records[0].content.contextSourceQuality, "full_thread_context");
+  assert.deepEqual(records[0].content.expectedFiles, [
+    "docs/memory-schema.md",
+    "scripts/vtdd-memory.mjs"
+  ]);
+  assert.equal(records[0].content.captureBoundary, "judgment_log_not_chain_of_thought");
+  assert.equal(records[0].tags.includes("rag-checkpoint"), true);
+});
+
 test("worker does not override explicit Butler read consent categories", async () => {
   const response = await worker.fetch(
     new Request("https://example.com/v2/gateway", {

--- a/worker.js
+++ b/worker.js
@@ -55101,6 +55101,15 @@ function buildMemoryWriteRecord(payload = {}) {
       content: {
         summary,
         details: normalizeText30(payload.details) || null,
+        checkpointReason: normalizeText30(payload.checkpointReason) || null,
+        thoughtLocation: normalizeText30(payload.thoughtLocation) || null,
+        userTension: normalizeText30(payload.userTension) || null,
+        contextSourceQuality: normalizeText30(payload.contextSourceQuality) || null,
+        hypothesis: normalizeText30(payload.hypothesis) || null,
+        expectedFiles: normalizeStringArray4(payload.expectedFiles),
+        evidenceLinks: normalizeStringArray4(payload.evidenceLinks),
+        previousRecordIds: normalizeStringArray4(payload.previousRecordIds),
+        captureBoundary: normalizeText30(payload.captureBoundary) || (normalizeText30(payload.checkpointReason) ? "judgment_log_not_chain_of_thought" : null),
         relatedIssue,
         repository,
         timestamp


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #361 の RAG checkpoint を、Butler / mac Codex / VPS Codex CLI が共有できる記憶セーブポイントとして実装するための最初の runtime / schema / docs slice。

## Satisfied Success Criteria

- RAG checkpoint の保存タイミングと contextSourceQuality を docs に定義した。
- vtddWriteOperationalMemory の Action Schema に checkpointReason / thoughtLocation / userTension / contextSourceQuality / expectedFiles などを追加した。
- Worker runtime が working_memory checkpoint fields を永続化できるようにした。
- mac Codex / VPS Codex CLI 向けに runtime 経由の write-runtime-checkpoint CLI を追加した。
- checkpoint payload と Worker persistence のテストを追加した。

## Unsatisfied Success Criteria

- Butler live Custom GPT 上での iPhone E2E は未実施。
- VPS Codex CLI 実機からの write-runtime-checkpoint は未実施。
- Issue #344 の会話開始時 preflight への完全組み込みは別 Issue として残る。

## Non-goal violations

None.

## Verification Evidence

- Unit: node --test test/vtdd-memory-cli.test.js / node --test test/worker.test.js / node --test test/custom-gpt-setup-docs.test.js test/custom-gpt-setup-artifacts.test.js
- Integration: node --test test/operational-memory.test.js test/cross-retrieval-runtime.test.js test/retrieval-contract.test.js test/memory-safety.test.js test/memory-provider.test.js test/decision-log-runtime.test.js test/proposal-log-runtime.test.js
- E2E: npm test（747 pass, 1 skipped: live read-only conflicting PR fixture requires env）
- Manual: Cloudflare deploy / credential mutation は未実施。
- Evidence path/link: PR verification output / modified tests: test/worker.test.js, test/vtdd-memory-cli.test.js

## Butler Completion Contract

- Owner goal: コンテキスト圧縮や離席前に、後で Butler / mac Codex / VPS Codex CLI が思い出せる小さな RAG checkpoint を残せるようにする。
- Butler entrypoint: Butler: vtddWriteOperationalMemory recordType=working_memory + tag=rag-checkpoint。mac/VPS: scripts/vtdd-memory.mjs write-runtime-checkpoint。
- Action Schema exposure: 更新あり。docs/setup/custom-gpt-actions-openapi.yaml/json に checkpoint fields を追加。
- Runtime path: POST /v2/action/memory-write が working_memory checkpoint fields を保存。CLI は同 route を runtime URL + bearer token で呼ぶ。
- Runner/runtime truth: Worker unit test で checkpoint fields persistence と post-write path を確認。runtime deploy は未実施。
- Authority boundary: 通常 RAG write と同じ。Butler は候補提示後 GO が必要。deploy/credential/permission mutation は含まない。
- E2E evidence: 未実施。Action Schema / runtime route / CLI path の実装と unit/integration evidence まで。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 未実施。deploy が必要な場合は後続で GO + passkey。
- Custom GPT Action Schema update: 必要。PR merge/deploy 後、Custom GPT Action Schema の更新対象。
- Custom GPT Instructions update: 必要。PR merge/deploy 後、Custom GPT Instructions の更新対象。
- iPhone Butler live E2E: 未実施。Issue #361 の後続確認として残す。

## Related Constitution Rules

- Issue traceability / RAG Memory Capture and Cost Boundary / Conversation UX Contract / Butler Completion Gate

## Out-of-scope but NOT implemented

- Gemini reviewer 復活。
- Issue #344 startup preflight 完全実装。
- 本番 Cloudflare deploy。
- 既存 RAG record の直接 mutation。

## Extra changes (if any)

Generated worker.js を npm run build:worker で更新。

<!-- VTDD metadata -->
- Issue: Issue #361
- Execution ID: Not provided.
- Goal: Not provided.
