### PR TITLE
Issue #355: passkey approval と local secret helper を分離

### DIFF
--- a/scripts/run-passkey-operator-helper.mjs
+++ b/scripts/run-passkey-operator-helper.mjs
@@ -93,15 +93,13 @@ async function handleRequest({ request, response, state }) {
       issueNumber: state.issueNumber,
       highRiskKind: state.highRiskKind,
       githubAppRole: state.appRole,
-      syncEnabled: true
+      syncEnabled: true,
+      passkeyEnabled: false,
+      syncMessage:
+        "Worker origin で取得した approvalGrantId を貼り付けて実行します。この local helper は passkey/WebAuthn を実行しません。"
     });
     response.writeHead(200, { "content-type": "text/html; charset=utf-8" });
     response.end(html);
-    return;
-  }
-
-  if (url.pathname.startsWith("/api/approval/passkey/")) {
-    await proxyPasskeyApi({ request, response, state, pathname: url.pathname.replace("/api", "/v2") });
     return;
   }
 
@@ -201,25 +199,6 @@ async function handleRequest({ request, response, state }) {
     ok: false,
     error: "not_found"
   }, corsHeaders);
-}
-
-async function proxyPasskeyApi({ request, response, state, pathname }) {
-  const endpoint = new URL(pathname, state.runtimeUrl);
-  const body =
-    request.method === "GET" || request.method === "HEAD" ? undefined : await readBody(request);
-  const proxied = await fetch(endpoint, {
-    method: request.method,
-    headers: {
-      authorization: `Bearer ${state.bearerToken}`,
-      "content-type": request.headers["content-type"] || "application/json"
-    },
-    body
-  });
-  const text = await proxied.text();
-  response.writeHead(proxied.status, {
-    "content-type": proxied.headers.get("content-type") || "application/json; charset=utf-8"
-  });
-  response.end(text);
 }
 
 function parseArgs(args) {

--- a/src/core/passkey-operator-page.js
+++ b/src/core/passkey-operator-page.js
@@ -1,6 +1,7 @@
 export function renderPasskeyOperatorPage(input = {}) {
   const operatorMode = resolvePasskeyOperatorMode(input);
-  const sectionVisibility = resolveSectionVisibility(operatorMode);
+  const passkeyEnabled = input.passkeyEnabled !== false;
+  const sectionVisibility = resolveSectionVisibility(operatorMode, { passkeyEnabled });
   const origin = escapeHtml(input.origin || "");
   const apiBase = escapeHtml(input.apiBase || "/v2");
   const syncApiBase = escapeHtml(input.syncApiBase || "");
@@ -218,6 +219,8 @@ export function renderPasskeyOperatorPage(input = {}) {
             ${renderGithubAppRoleOption("mac-codex", "VTDD mac Codex", githubAppRoleDefault)}
             ${renderGithubAppRoleOption("vps-codex-cli", "VTDD VPS Codex CLI", githubAppRoleDefault)}
           </select>
+          <label for="approval-grant-id-input">approvalGrantId</label>
+          <input id="approval-grant-id-input" value="" placeholder="approval:..." autocomplete="off" />
           <div class="row">
             <button id="sync-button"${syncEnabled ? "" : " disabled"}>Sync GitHub App secrets</button>
           </div>
@@ -541,7 +544,9 @@ export function renderPasskeyOperatorPage(input = {}) {
 
       document.getElementById("sync-button").addEventListener("click", async () => {
         try {
-          if (!latestApprovalGrantId) {
+          const pastedApprovalGrantId = document.getElementById("approval-grant-id-input").value.trim();
+          const approvalGrantId = latestApprovalGrantId || pastedApprovalGrantId;
+          if (!approvalGrantId) {
             throw new Error("approvalGrantId is required before secret sync");
           }
           if (!"${syncApiBase}") {
@@ -552,7 +557,7 @@ export function renderPasskeyOperatorPage(input = {}) {
             method: "POST",
             headers: { "content-type": "application/json" },
             body: JSON.stringify({
-              approvalGrantId: latestApprovalGrantId,
+              approvalGrantId,
               repositoryInput: document.getElementById("repo-input").value,
               githubAppRole: document.getElementById("github-app-role-input").value
             })
@@ -825,11 +830,12 @@ export function resolvePasskeyOperatorMode(input = {}) {
   return "full";
 }
 
-function resolveSectionVisibility(operatorMode) {
+function resolveSectionVisibility(operatorMode, options = {}) {
   const full = operatorMode === "full";
+  const passkeyEnabled = options.passkeyEnabled !== false;
   return {
-    registration: true,
-    approval: true,
+    registration: passkeyEnabled,
+    approval: passkeyEnabled,
     githubAppSecretSync: full || operatorMode === "github_app_secret_sync",
     productionDeploy: full || operatorMode === "deploy",
     prMerge: full || operatorMode === "merge",

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -855,7 +855,6 @@ async function handleRetrieveOperationalMemoryRequest(url, env) {
 
 async function handleRetrieveApprovalGrantRequest(url, env) {
   const provider = resolveMemoryProvider(env);
-  await purgeExpiredPasskeyArtifacts(provider);
   const validation = validateMemoryProvider(provider);
   if (!validation.ok) {
     return retrieveErrorJson(url, 503, {
@@ -880,6 +879,13 @@ async function handleRetrieveApprovalGrantRequest(url, env) {
       ok: false,
       error: "approval_grant_not_found",
       reason: "matching passkey approval grant was not found"
+    });
+  }
+  if (isExpiredPasskeyEphemeralRecord(record)) {
+    return retrieveErrorJson(url, 410, {
+      ok: false,
+      error: "approval_grant_expired",
+      reason: "approval grant is expired. Worker origin で再承認して、新しい approvalGrantId を取得してください。"
     });
   }
 
@@ -2502,6 +2508,7 @@ function handlePasskeyOperatorPageRequest(request) {
     returnUrl: normalizeOperatorReturnUrl(url.searchParams.get("returnUrl")),
     operatorId: url.searchParams.get("operatorId") || "vtdd-operator",
     operatorLabel: url.searchParams.get("operatorLabel") || "VTDD Operator",
+    githubAppRole: url.searchParams.get("githubAppRole") || "legacy",
     syncEnabled,
     syncMessage: syncEnabled
       ? "approvalGrantId が取得済みなら実行できます。desktop helper bridge に接続します。"
@@ -3397,10 +3404,25 @@ async function findApprovalRecordById(provider, recordId) {
     text: recordId,
     limit: 50
   });
-  return (
+  const matched =
     records.find((record) => normalizeText(record?.id) === recordId) ??
     records.find((record) => normalizeText(record?.content?.approvalId) === recordId) ??
     records.find((record) => normalizeText(record?.content?.sessionId) === recordId) ??
+    null;
+  if (matched) {
+    return matched;
+  }
+  if (typeof provider.retrieve !== "function") {
+    return null;
+  }
+  const fallbackRecords = await provider.retrieve({
+    type: MemoryRecordType.APPROVAL_LOG,
+    limit: MAX_MEMORY_LIMIT
+  });
+  return (
+    fallbackRecords.find((record) => normalizeText(record?.id) === recordId) ??
+    fallbackRecords.find((record) => normalizeText(record?.content?.approvalId) === recordId) ??
+    fallbackRecords.find((record) => normalizeText(record?.content?.sessionId) === recordId) ??
     null
   );
 }

--- a/test/passkey-operator-helper.test.js
+++ b/test/passkey-operator-helper.test.js
@@ -19,3 +19,10 @@ test("desktop helper bridge passes role-specific GitHub App sync arguments", () 
   assert.equal(helperSource.includes("githubAppRole"), true);
   assert.equal(helperSource.includes("github_app_role_not_served"), true);
 });
+
+test("desktop helper bridge does not proxy local passkey WebAuthn APIs", () => {
+  assert.equal(helperSource.includes('url.pathname.startsWith("/api/approval/passkey/")'), false);
+  assert.equal(helperSource.includes("function proxyPasskeyApi"), false);
+  assert.equal(helperSource.includes("passkeyEnabled: false"), true);
+  assert.equal(helperSource.includes("この local helper は passkey/WebAuthn を実行しません。"), true);
+});

--- a/test/passkey-operator-page.test.js
+++ b/test/passkey-operator-page.test.js
@@ -33,6 +33,8 @@ test("passkey operator page can target explicit api base and sync endpoint", () 
   assert.equal(html.includes("Butler 会話に貼らず"), true);
   assert.equal(html.includes("Copy approvalGrantId"), true);
   assert.equal(html.includes("Auto-copy approvalGrantId after approval"), true);
+  assert.equal(html.includes('id="approval-grant-id-input"'), true);
+  assert.equal(html.includes("const approvalGrantId = latestApprovalGrantId || pastedApprovalGrantId"), true);
   assert.equal(html.includes('id="action-type-input" value="deploy_production"'), true);
   assert.equal(html.includes('repositoryInput: document.getElementById("repo-input").value'), true);
   assert.equal(html.includes('issueNumber: Number(document.getElementById("issue-input").value || 0) || null'), true);
@@ -179,6 +181,24 @@ test("passkey operator page focuses secret sync modes without hiding the require
   assert.equal(actionsSecretHtml.includes('<section data-operator-section="github-app-secret-sync" hidden>'), true);
   assert.equal(actionsSecretHtml.includes('<section data-operator-section="production-deploy" hidden>'), true);
   assert.equal(actionsSecretHtml.includes('<section data-operator-section="pr-merge" hidden>'), true);
+});
+
+test("passkey operator page supports local helper mode without passkey controls", () => {
+  const html = renderPasskeyOperatorPage({
+    apiBase: "/api",
+    repositoryInput: "marushu/vtdd-v2-p",
+    actionType: "destructive",
+    highRiskKind: "github_app_secret_sync",
+    githubAppRole: "gemini-reviewer",
+    syncEnabled: true,
+    passkeyEnabled: false
+  });
+
+  assert.equal(html.includes('<section data-operator-section="registration" hidden>'), true);
+  assert.equal(html.includes('<section data-operator-section="approval" hidden>'), true);
+  assert.equal(html.includes('<option value="gemini-reviewer" selected>VTDD Gemini Reviewer</option>'), true);
+  assert.equal(html.includes('id="approval-grant-id-input"'), true);
+  assert.equal(html.includes('fetch("/api/approval/passkey/challenge"'), true);
 });
 
 test("passkey operator page focuses VPS runner admin mode on real approval only", () => {

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -2707,6 +2707,113 @@ test("worker returns approval grant through retrieve route", async () => {
   assert.equal(body.approvalGrant.scope.repositoryInput, "sample-org/vtdd-v2-p");
 });
 
+test("worker retrieves approval grant by id even when provider query misses", async () => {
+  const provider = createInMemoryMemoryProvider();
+  await provider.store({
+    id: "approval-query-miss",
+    type: MemoryRecordType.APPROVAL_LOG,
+    content: {
+      kind: "passkey_grant",
+      status: "verified",
+      approvalId: "approval-query-miss",
+      verifiedAt: "2026-04-25T00:00:00.000Z",
+      expiresAt: "2099-01-01T00:00:00.000Z",
+      scope: {
+        actionType: "destructive",
+        repositoryInput: "sample-org/vtdd-v2-p",
+        issueNumber: "15",
+        relatedIssue: "15",
+        phase: "execution",
+        highRiskKind: "github_app_secret_sync"
+      }
+    },
+    metadata: { source: "test" },
+    priority: 90,
+    tags: ["passkey_grant"],
+    createdAt: "2026-04-25T00:00:00.000Z"
+  });
+  const queryMissProvider = {
+    ...provider,
+    async query() {
+      return [];
+    }
+  };
+
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/retrieve/approval-grant?approvalId=approval-query-miss", {
+      headers: gatewayAuthHeaders
+    }),
+    {
+      ...gatewayAuthEnv,
+      MEMORY_PROVIDER: queryMissProvider
+    }
+  );
+
+  assert.equal(response.status, 200);
+  const body = await response.json();
+  assert.equal(body.ok, true);
+  assert.equal(body.approvalGrant.approvalId, "approval-query-miss");
+});
+
+test("worker returns explicit expired approval grant error", async () => {
+  const provider = createInMemoryMemoryProvider();
+  await provider.store({
+    id: "approval-expired",
+    type: MemoryRecordType.APPROVAL_LOG,
+    content: {
+      kind: "passkey_grant",
+      status: "verified",
+      approvalId: "approval-expired",
+      verifiedAt: "2026-04-25T00:00:00.000Z",
+      expiresAt: "2000-01-01T00:00:00.000Z",
+      scope: {
+        actionType: "destructive",
+        repositoryInput: "sample-org/vtdd-v2-p",
+        issueNumber: "15",
+        relatedIssue: "15",
+        phase: "execution",
+        highRiskKind: "github_app_secret_sync"
+      }
+    },
+    metadata: { source: "test" },
+    priority: 90,
+    tags: ["passkey_grant"],
+    createdAt: "2026-04-25T00:00:00.000Z"
+  });
+
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/retrieve/approval-grant?approvalId=approval-expired", {
+      headers: gatewayAuthHeaders
+    }),
+    {
+      ...gatewayAuthEnv,
+      MEMORY_PROVIDER: provider
+    }
+  );
+
+  assert.equal(response.status, 410);
+  const body = await response.json();
+  assert.equal(body.ok, false);
+  assert.equal(body.error, "approval_grant_expired");
+  assert.equal(body.reason.includes("再承認"), true);
+});
+
+test("worker passkey operator page preselects GitHub App role from query", async () => {
+  const response = await worker.fetch(
+    new Request(
+      "https://example.com/v2/approval/passkey/operator?actionType=destructive&highRiskKind=github_app_secret_sync&githubAppRole=gemini-reviewer",
+      {
+        headers: gatewayAuthHeaders
+      }
+    ),
+    gatewayAuthEnv
+  );
+
+  assert.equal(response.status, 200);
+  const html = await response.text();
+  assert.equal(html.includes('<option value="gemini-reviewer" selected>VTDD Gemini Reviewer</option>'), true);
+});
+
 test("worker returns GitHub repositories through read plane route", async () => {
   const response = await worker.fetch(
     new Request("https://example.com/v2/retrieve/github?resource=repositories&limit=5", {

--- a/worker.js
+++ b/worker.js
@@ -27081,7 +27081,8 @@ function normalize(value) {
 // src/core/passkey-operator-page.js
 function renderPasskeyOperatorPage(input = {}) {
   const operatorMode = resolvePasskeyOperatorMode(input);
-  const sectionVisibility = resolveSectionVisibility(operatorMode);
+  const passkeyEnabled = input.passkeyEnabled !== false;
+  const sectionVisibility = resolveSectionVisibility(operatorMode, { passkeyEnabled });
   const origin = escapeHtml(input.origin || "");
   const apiBase = escapeHtml(input.apiBase || "/v2");
   const syncApiBase = escapeHtml(input.syncApiBase || "");
@@ -27295,6 +27296,8 @@ function renderPasskeyOperatorPage(input = {}) {
             ${renderGithubAppRoleOption("mac-codex", "VTDD mac Codex", githubAppRoleDefault)}
             ${renderGithubAppRoleOption("vps-codex-cli", "VTDD VPS Codex CLI", githubAppRoleDefault)}
           </select>
+          <label for="approval-grant-id-input">approvalGrantId</label>
+          <input id="approval-grant-id-input" value="" placeholder="approval:..." autocomplete="off" />
           <div class="row">
             <button id="sync-button"${syncEnabled ? "" : " disabled"}>Sync GitHub App secrets</button>
           </div>
@@ -27618,7 +27621,9 @@ function renderPasskeyOperatorPage(input = {}) {
 
       document.getElementById("sync-button").addEventListener("click", async () => {
         try {
-          if (!latestApprovalGrantId) {
+          const pastedApprovalGrantId = document.getElementById("approval-grant-id-input").value.trim();
+          const approvalGrantId = latestApprovalGrantId || pastedApprovalGrantId;
+          if (!approvalGrantId) {
             throw new Error("approvalGrantId is required before secret sync");
           }
           if (!"${syncApiBase}") {
@@ -27629,7 +27634,7 @@ function renderPasskeyOperatorPage(input = {}) {
             method: "POST",
             headers: { "content-type": "application/json" },
             body: JSON.stringify({
-              approvalGrantId: latestApprovalGrantId,
+              approvalGrantId,
               repositoryInput: document.getElementById("repo-input").value,
               githubAppRole: document.getElementById("github-app-role-input").value
             })
@@ -27897,11 +27902,12 @@ function resolvePasskeyOperatorMode(input = {}) {
   }
   return "full";
 }
-function resolveSectionVisibility(operatorMode) {
+function resolveSectionVisibility(operatorMode, options = {}) {
   const full = operatorMode === "full";
+  const passkeyEnabled = options.passkeyEnabled !== false;
   return {
-    registration: true,
-    approval: true,
+    registration: passkeyEnabled,
+    approval: passkeyEnabled,
     githubAppSecretSync: full || operatorMode === "github_app_secret_sync",
     productionDeploy: full || operatorMode === "deploy",
     prMerge: full || operatorMode === "merge",
@@ -54846,7 +54852,6 @@ async function handleRetrieveOperationalMemoryRequest(url, env) {
 }
 async function handleRetrieveApprovalGrantRequest(url, env) {
   const provider = resolveMemoryProvider(env);
-  await purgeExpiredPasskeyArtifacts(provider);
   const validation = validateMemoryProvider(provider);
   if (!validation.ok) {
     return retrieveErrorJson(url, 503, {
@@ -54869,6 +54874,13 @@ async function handleRetrieveApprovalGrantRequest(url, env) {
       ok: false,
       error: "approval_grant_not_found",
       reason: "matching passkey approval grant was not found"
+    });
+  }
+  if (isExpiredPasskeyEphemeralRecord(record2)) {
+    return retrieveErrorJson(url, 410, {
+      ok: false,
+      error: "approval_grant_expired",
+      reason: "approval grant is expired. Worker origin \u3067\u518D\u627F\u8A8D\u3057\u3066\u3001\u65B0\u3057\u3044 approvalGrantId \u3092\u53D6\u5F97\u3057\u3066\u304F\u3060\u3055\u3044\u3002"
     });
   }
   return json(200, {
@@ -56243,6 +56255,7 @@ function handlePasskeyOperatorPageRequest(request) {
     returnUrl: normalizeOperatorReturnUrl(url.searchParams.get("returnUrl")),
     operatorId: url.searchParams.get("operatorId") || "vtdd-operator",
     operatorLabel: url.searchParams.get("operatorLabel") || "VTDD Operator",
+    githubAppRole: url.searchParams.get("githubAppRole") || "legacy",
     syncEnabled,
     syncMessage: syncEnabled ? "approvalGrantId \u304C\u53D6\u5F97\u6E08\u307F\u306A\u3089\u5B9F\u884C\u3067\u304D\u307E\u3059\u3002desktop helper bridge \u306B\u63A5\u7D9A\u3057\u307E\u3059\u3002" : "desktop maintenance required: local secret sync bridge \u304C\u672A\u63A5\u7D9A\u3067\u3059\u3002"
   });
@@ -56977,7 +56990,18 @@ async function findApprovalRecordById(provider, recordId) {
     text: recordId,
     limit: 50
   });
-  return records.find((record2) => normalizeText30(record2?.id) === recordId) ?? records.find((record2) => normalizeText30(record2?.content?.approvalId) === recordId) ?? records.find((record2) => normalizeText30(record2?.content?.sessionId) === recordId) ?? null;
+  const matched = records.find((record2) => normalizeText30(record2?.id) === recordId) ?? records.find((record2) => normalizeText30(record2?.content?.approvalId) === recordId) ?? records.find((record2) => normalizeText30(record2?.content?.sessionId) === recordId) ?? null;
+  if (matched) {
+    return matched;
+  }
+  if (typeof provider.retrieve !== "function") {
+    return null;
+  }
+  const fallbackRecords = await provider.retrieve({
+    type: MemoryRecordType.APPROVAL_LOG,
+    limit: MAX_MEMORY_LIMIT
+  });
+  return fallbackRecords.find((record2) => normalizeText30(record2?.id) === recordId) ?? fallbackRecords.find((record2) => normalizeText30(record2?.content?.approvalId) === recordId) ?? fallbackRecords.find((record2) => normalizeText30(record2?.content?.sessionId) === recordId) ?? null;
 }
 async function appendGuardedAbsenceExecutionLog({ payload, gatewayOutcome, env }) {
   const policyInput = normalizeObject11(payload?.policyInput);


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #355 のうち、Worker origin の passkey approval と local helper の GitHub App secret sync 実行を分離し、approvalGrantId handoff と role 初期選択と grant retrieval の破綻を修正する。

## Satisfied Success Criteria

- local helper が passkey/WebAuthn API を proxy しなくなった。 local helper は Worker origin で取得した approvalGrantId を貼り付けて secret sync する。 Worker operator が githubAppRole query を GitHub App Role 初期選択へ反映する。 /v2/retrieve/approval-grant が provider.query miss でも retrieve fallback で grant を見つける。 期限切れ grant は approval_grant_not_found ではなく approval_grant_expired と再承認案内を返す。

## Unsatisfied Success Criteria

- Worker approval -> helper sync -> GitHub Actions secret existence check の live E2E は未実施。 iPhone/iPad からの完全復旧導線は Issue #359 / Issue #357 と合わせて後続確認が必要。 Gemini reviewer workflow の再有効化は Issue #351 / reviewer側の別判断。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #355
- Implementing Success Criteria: Issue #355 の success criteria から、origin separation、approvalGrantId handoff、githubAppRole 初期選択、sync no-op/error、approval grant retrieval/expired handling を実装する。
- Explicit Non-goals: Gemini workflow 再有効化、Custom GPT recovery page 全面改修、runtime URL 正本化、secret mutation の実行はしない。
- Expected touched files/routes/workflows: src/core/passkey-operator-page.js; src/worker/runtime.js; scripts/run-passkey-operator-helper.mjs; test/passkey-operator-helper.test.js; test/passkey-operator-page.test.js; test/worker.test.js; worker.js
- Affected Issues: Issue #355 本体。Issue #351、Issue #357、Issue #359、Issue #358、Issue #344 は隣接だがこのPRでは未実装。
- Affected PRs: PR #346 / PR #347 / PR #348 は直接触らない。PR #364 の dry-run gate に従う。
- Affected workflows: deploy-production は approval grant retrieval に影響し得る。gemini-pr-review は secret sync 後続だがこのPRでは再有効化しない。
- Affected runtime/operator surfaces: Worker passkey operator、approval-grant retrieve route、desktop helper bridge、generated worker。Custom GPT Action Schema は未変更。
- What may break if we patch narrowly: local helper だけ直すと grant retrieval miss が残る。retrieval だけ直すと WebAuthn origin SecurityError が残る。role query だけ直すと owner-facing sync がまだ失敗する。
- Unknowns to investigate before coding: live Worker + browser + helper で PNA/CORS/localhost fetch がどこまで許可されるか。VPS helper を iPhone-first recovery の主経路にするかは後続。
- Validation needed: node --check、targeted tests、npm test。merge/deploy 後に live Worker approval -> helper sync -> secret existence check。
- Stop condition: runtime URL 正本化、Custom GPT recovery UI、workflow enable/disable、credential mutation が必要になったらこのPRでは止める。

## File / Line Hypotheses

- file: `scripts/run-passkey-operator-helper.mjs:88`\n  - hypothesis: local helper が passkey page と passkey API proxy を持つため WebAuthn origin が壊れる。\n  - risk if changed narrowly: approvalGrantId handoff が未設計になる。\n  - validation: helper source/test で passkey proxy 不在と pasted grant sync を確認。\n  - related Issue: Issue #355\n- file: `src/worker/runtime.js:2485`\n  - hypothesis: githubAppRole query が render に渡っていない。\n  - risk if changed narrowly: role だけ直って sync/retrieval failure は残る。\n  - validation: worker operator page role preselect test。\n  - related Issue: Issue #355\n- file: `src/worker/runtime.js:3391`\n  - hypothesis: provider.query 依存で approvalGrantId を取り逃がす。\n  - risk if changed narrowly: scripts 側 bypass で approval boundary が弱くなる。\n  - validation: query miss fallback と expired grant tests。\n  - related Issue: Issue #355

## Hypothesis Retrospective

- expected: Issue #355 の既存 file/line hypotheses は主に当たっている。\n- actual: helper passkey proxy、role query未反映、query依存 retrieval は実在した。構文 brace 仮説は外れ、node --check は成功。\n- mismatch: live browser/helper E2E と GitHub secret existence check はまだ未実施。\n- lesson: WebAuthn は local helper に寄せず、Worker origin approval と helper execution を明示的に分ける。\n- should become RAG candidate: yes

## Verification Evidence

- Unit: node --check scripts/run-passkey-operator-helper.mjs; node --test test/passkey-operator-helper.test.js test/passkey-operator-page.test.js test/worker.test.js; npm test
- Integration: Worker retrieve approval-grant route、operator page render、desktop helper bridge の境界を test/worker.test.js と helper/page tests で検証。
- E2E: source/integration evidence まで。live Worker approval -> helper sync -> GitHub secret existence check は未実施のため、このPRは Issue #355 を close しない。
- Manual: Issue #355 の既存 dry-run comment と File / Line Hypotheses を読み、当たっていた仮説を source で検証してから実装した。
- Evidence path/link: scripts/run-passkey-operator-helper.mjs; src/core/passkey-operator-page.js; src/worker/runtime.js; test/passkey-operator-helper.test.js; test/passkey-operator-page.test.js; test/worker.test.js

## Butler Completion Contract

- Owner goal: Worker origin で passkey 承認し、local helper は approvalGrantId を受け取って secret sync だけを行う。
- Butler entrypoint: Butler からは operator URL を案内し、owner は Worker origin で approvalGrantId を取得して local/VPS helper へ渡す。live Butler E2E は未実施。
- Action Schema exposure: 変更なし。既存 operator / retrieve / secret sync 経路の runtime behavior 修正。
- Runtime path: GET /v2/approval/passkey/operator -> renderPasskeyOperatorPage; GET /v2/retrieve/approval-grant -> findApprovalRecordById; scripts/run-passkey-operator-helper.mjs -> /api/github-app-secret-sync/execute.
- Runner/runtime truth: unit/integration tests で local helper no-passkey proxy、role preselect、query miss retrieval、expired grant error を確認。
- Authority boundary: GO + passkey 境界は維持。secret 値は UI/log/RAG に出さない。deploy / credential mutation / permission mutation はこのPRでは実行しない。
- E2E evidence: 未実施。このPRは incomplete。live Worker approval -> helper sync -> secret existence check が残る。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 必要。runtime.js / worker.js 変更のため、merge 後に Cloudflare deploy が必要。
- Custom GPT Action Schema update: 不要。Action Schema operationId は変更なし。
- Custom GPT Instructions update: 不要。Instructions 文面変更なし。
- iPhone Butler live E2E: 必要。deploy 後に iPhone/Butler から operator URL -> approvalGrantId -> helper handoff を確認する。

## Related Constitution Rules

- Issue が起点、GitHub が正本。high-risk actions require GO + passkey。local helper は passkey/WebAuthn を実行しない。secret value は UI/log/RAG に出さない。

## Out-of-scope but NOT implemented

- Issue #351 Gemini workflow 再有効化。Issue #357 runtime URL 正本化。Issue #359 Custom GPT recovery copy UI。Issue #358 runaway stop。

## Extra changes (if any)

worker.js は npm run build:worker による生成物更新。

<!-- VTDD metadata -->
- Issue: Issue #355
- Execution ID: Not provided.
- Goal: Issue #355 passkey operator と local helper の origin 境界を分離する
