### PR TITLE
Issue #366: reviewer approve を terminal state として扱う

### DIFF
--- a/.github/workflows/gemini-pr-review.yml
+++ b/.github/workflows/gemini-pr-review.yml
@@ -28,6 +28,12 @@ concurrency:
 
 jobs:
   review:
+    if: >-
+      ${{
+        github.event_name != 'issue_comment' ||
+        !contains(github.event.comment.body, '<!-- vtdd:reviewer=') ||
+        contains(github.event.comment.body, '<!-- vtdd:reviewer-objection-resolution -->')
+      }}
     runs-on: ubuntu-latest
     steps:
       - name: Detect GitHub App secret availability

--- a/scripts/run-codex-pr-review-fallback.mjs
+++ b/scripts/run-codex-pr-review-fallback.mjs
@@ -5,6 +5,7 @@ import {
   buildPullRequestReviewContext,
   findExistingCodexReviewFallbackComment,
   formatCodexReviewFallbackComment,
+  isReviewerTerminalApproved,
   parseCodexReviewFallbackComment,
   resolveOperatorMention
 } from "../src/core/index.js";
@@ -32,6 +33,15 @@ async function main() {
   );
   const reviews = await githubFetchAll(githubFetch, `/repos/${repository}/pulls/${prNumber}/reviews?per_page=100`);
   const existingFallbackComment = findExistingCodexReviewFallbackComment(issueComments);
+  if (
+    isReviewerTerminalApproved({
+      comments: issueComments,
+      headSha: pullRequest?.head?.sha
+    })
+  ) {
+    console.log(`Skipping Codex fallback review: reviewer already approved current PR head on PR #${prNumber}.`);
+    return;
+  }
   const prDiff = buildPullRequestDiff(files);
   const context = buildPullRequestReviewContext({
     repository,
@@ -60,6 +70,7 @@ async function main() {
         deliveryMode,
         blocker: failure.blocker,
         rawReview: failure.rawFailure,
+        headSha: pullRequest?.head?.sha,
         notificationMention: shouldMentionCodexFallback({
           existingComment: existingFallbackComment,
           status: "blocked"
@@ -83,6 +94,7 @@ async function main() {
     criticalFindings: normalizedReview.criticalFindings,
     risks: normalizedReview.risks,
     rawReview: review.stdout,
+    headSha: pullRequest?.head?.sha,
     notificationMention: shouldMentionCodexFallback({
       existingComment: existingFallbackComment,
       status: "completed",

--- a/scripts/run-gemini-pr-review.mjs
+++ b/scripts/run-gemini-pr-review.mjs
@@ -11,6 +11,7 @@ import {
   findExistingGeminiReviewComment,
   formatCodexReviewFallbackComment,
   formatGeminiReviewComment,
+  isReviewerTerminalApproved,
   parseGeminiReviewComment,
   resolveOperatorMention,
   resolveGeminiReviewTrigger
@@ -43,6 +44,16 @@ async function main() {
   const reviews = await githubFetch(`/repos/${repository}/pulls/${prNumber}/reviews?per_page=100`);
   const existingReviewComment = findExistingGeminiReviewComment(issueComments);
   const existingFallbackComment = findExistingCodexReviewFallbackComment(issueComments);
+  if (
+    triggerResult.value.trigger === "issue_comment:created" &&
+    isReviewerTerminalApproved({
+      comments: issueComments,
+      headSha: pullRequest?.head?.sha
+    })
+  ) {
+    console.log(`Skipping Gemini PR review: reviewer already approved current PR head on PR #${prNumber}.`);
+    return;
+  }
 
   if (!process.env.GEMINI_API_KEY) {
     console.log("Skipping Gemini PR review: GEMINI_API_KEY is not configured.");
@@ -83,6 +94,7 @@ async function main() {
         deliveryMode: "vps_codex_cli",
         repository,
         pullRequestNumber: prNumber,
+        headSha: pullRequest?.head?.sha,
         notificationMention: resolveOperatorMention([pullRequest?.user?.login, payload?.sender?.login])
       });
       await githubFetch(`/repos/${repository}/issues/${prNumber}/comments`, {
@@ -104,6 +116,7 @@ async function main() {
     review: reviewResult.review,
     trigger: triggerResult.value.trigger,
     model,
+    headSha: pullRequest?.head?.sha,
     notificationMention: shouldMentionGeminiReviewResult({
       existingComment: existingReviewComment,
       recommendedAction: reviewResult.review.recommendedAction

--- a/scripts/run-vps-runner.mjs
+++ b/scripts/run-vps-runner.mjs
@@ -6,7 +6,11 @@ import path from "node:path";
 import crypto from "node:crypto";
 import { spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
-import { normalizeMentionLogin, parseCodexReviewFallbackComment } from "../src/core/index.js";
+import {
+  isReviewerTerminalApproved,
+  normalizeMentionLogin,
+  parseCodexReviewFallbackComment
+} from "../src/core/index.js";
 import { buildExecutionLeadTime } from "../src/core/execution-lead-time.js";
 import { prepareGuardedPullRequestBody, prepareGuardedPullRequestBodyFile } from "./prepare-pr-body-file.mjs";
 import { renderPrBody } from "./render-pr-body.mjs";
@@ -468,6 +472,20 @@ function selectPendingVpsReviewerFallbacks({ comments, allowedRepositories, repo
       if (!policies.some((policy) => policy.repository === repository)) {
         return null;
       }
+      const samePullRequestComments = comments.filter(
+        (candidate) =>
+          normalizeRepository(candidate.repository) === repository &&
+          normalizePositiveInteger(candidate.pullRequestNumber) === pullRequestNumber
+      );
+      if (
+        isReviewerTerminalApproved({
+          comments: samePullRequestComments,
+          after: comment.created_at,
+          headSha: normalizeText(comment.headSha)
+        })
+      ) {
+        return null;
+      }
       return {
         repository,
         pullRequestNumber,
@@ -897,16 +915,35 @@ async function readRecentPullRequestComments({ githubFetch, repository }) {
   const pulls = await githubFetch(`/repos/${repository}/pulls?state=open&sort=updated&direction=desc&per_page=100`);
   const comments = [];
   for (const pull of pulls) {
-    const issueComments = await githubFetch(`/repos/${repository}/issues/${pull.number}/comments?per_page=100`);
+    const issueComments = await readAllIssueCommentsForNumber({
+      githubFetch,
+      repository,
+      issueNumber: pull.number
+    });
     comments.push(
       ...issueComments.map((comment) => ({
         ...comment,
         repository,
-        pullRequestNumber: pull.number
+        pullRequestNumber: pull.number,
+        headSha: normalizeText(pull?.head?.sha)
       }))
     );
   }
   return comments;
+}
+
+async function readAllIssueCommentsForNumber({ githubFetch, repository, issueNumber }) {
+  const comments = [];
+  for (let page = 1; ; page += 1) {
+    const pageComments = await githubFetch(
+      `/repos/${repository}/issues/${issueNumber}/comments?per_page=100&page=${page}`
+    );
+    const normalized = Array.isArray(pageComments) ? pageComments : [];
+    comments.push(...normalized);
+    if (normalized.length < 100) {
+      return comments;
+    }
+  }
 }
 
 async function buildVpsRunnerPullRequestContext({ githubFetch, payload }) {

--- a/src/core/codex-review-fallback.js
+++ b/src/core/codex-review-fallback.js
@@ -20,6 +20,7 @@ export function formatCodexReviewFallbackComment(input = {}) {
   const deliveryMode = normalizeText(input.deliveryMode) || "workflow_dispatch";
   const blocker = normalizeText(input.blocker);
   const recommendedAction = normalizeText(input.recommendedAction) || "manual_review";
+  const headSha = normalizeText(input.headSha);
   const criticalFindings = normalizeStringArray(input.criticalFindings);
   const risks = normalizeStringArray(input.risks);
   const rawReview = normalizeText(input.rawReview);
@@ -45,6 +46,7 @@ export function formatCodexReviewFallbackComment(input = {}) {
     `- Trigger: \`${trigger}\``,
     `- Reason: \`${reason}\``,
     `- Delivery mode: \`${deliveryMode}\``,
+    ...(headSha ? [`- Head SHA: \`${headSha}\``] : []),
     "",
     ...buildStatusSection({
       status,

--- a/src/core/gemini-pr-review.js
+++ b/src/core/gemini-pr-review.js
@@ -419,6 +419,7 @@ export function formatGeminiReviewComment(input = {}) {
   const risks = normalizeStringArray(review.risks);
   const recommendedAction = normalizeText(review.recommendedAction) || "manual_review";
   const notificationMention = normalizeMentionLogin(input.notificationMention);
+  const headSha = normalizeText(input.headSha);
 
   const lines = [
     GEMINI_PR_REVIEW_MARKER,
@@ -434,6 +435,7 @@ export function formatGeminiReviewComment(input = {}) {
     "",
     `- Trigger: \`${trigger}\``,
     `- Model: \`${model}\``,
+    ...(headSha ? [`- Head SHA: \`${headSha}\``] : []),
     `- Recommended action: \`${recommendedAction}\``,
     "",
     "### 重要指摘",

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -215,6 +215,7 @@ export {
   parseCodexConnectorSetupComment,
   parseCodexReviewFallbackComment
 } from "./codex-review-fallback.js";
+export { isReviewerTerminalApproved } from "./reviewer-terminal-state.js";
 export {
   GeminiReviewFailureKind,
   classifyGeminiReviewFailure

--- a/src/core/reviewer-terminal-state.js
+++ b/src/core/reviewer-terminal-state.js
@@ -1,0 +1,87 @@
+import { parseCodexReviewFallbackComment } from "./codex-review-fallback.js";
+import { parseGeminiReviewComment } from "./gemini-pr-review.js";
+
+function isReviewerTerminalApproved(input = {}) {
+  const comments = Array.isArray(input.comments) ? input.comments : [];
+  const after = parseTime(input.after);
+  const headSha = normalizeText(input.headSha);
+  const markers = comments
+    .map((comment) => normalizeReviewerMarker(comment))
+    .filter(Boolean)
+    .filter((marker) => !after || marker.time >= after)
+    .filter((marker) => !headSha || !marker.headSha || marker.headSha === headSha)
+    .sort((left, right) => left.time - right.time);
+
+  if (markers.length === 0) {
+    return false;
+  }
+
+  const latest = markers.at(-1);
+  return latest.terminal === true;
+}
+
+function normalizeReviewerMarker(comment) {
+  if (!isTrustedReviewerComment(comment)) {
+    return null;
+  }
+
+  const gemini = parseGeminiReviewComment(comment);
+  if (gemini) {
+    return {
+      reviewer: "gemini",
+      terminal: gemini.recommendedAction === "approve",
+      blocking: gemini.blocking === true,
+      headSha: extractHeadSha(comment?.body),
+      time: parseTime(comment?.created_at ?? comment?.createdAt)
+    };
+  }
+
+  const codex = parseCodexReviewFallbackComment(comment);
+  if (codex) {
+    return {
+      reviewer: "codex-fallback",
+      terminal: codex.status === "completed" && codex.recommendedAction === "approve",
+      blocking: codex.blocking === true,
+      headSha: extractHeadSha(comment?.body),
+      time: parseTime(comment?.created_at ?? comment?.createdAt)
+    };
+  }
+
+  return null;
+}
+
+function isTrustedReviewerComment(comment) {
+  const login = normalizeText(comment?.user?.login ?? comment?.author?.login).toLowerCase();
+  const association = normalizeText(comment?.author_association ?? comment?.authorAssociation).toUpperCase();
+  const trustedLogins = new Set([
+    "marushu",
+    "vtdd-codex",
+    "vtdd-codex[bot]",
+    "vtdd-gemini-reviewer",
+    "vtdd-gemini-reviewer[bot]",
+    "vtdd-codex-fallback-reviewer",
+    "vtdd-codex-fallback-reviewer[bot]"
+  ]);
+
+  if (trustedLogins.has(login)) {
+    return true;
+  }
+
+  return association === "OWNER" || association === "MEMBER" || association === "COLLABORATOR";
+}
+
+function extractHeadSha(value) {
+  const match = normalizeText(value).match(/^- Head SHA:\s*`([^`]+)`/m);
+  return normalizeText(match?.[1]);
+}
+
+function parseTime(value) {
+  const timestamp = Date.parse(normalizeText(value));
+  return Number.isFinite(timestamp) ? timestamp : 0;
+}
+
+function normalizeText(value) {
+  return String(value ?? "").trim();
+}
+
+export { isReviewerTerminalApproved, isTrustedReviewerComment };

--- a/test/gemini-pr-review-workflow.test.js
+++ b/test/gemini-pr-review-workflow.test.js
@@ -37,6 +37,27 @@ test("Gemini review workflow still routes reviewer execution through the script 
   assert.equal(workflow.includes("issues: write"), false);
 });
 
+test("Gemini review workflow skips reviewer marker issue comments before dependency install", () => {
+  assert.equal(workflow.includes("github.event_name != 'issue_comment'"), true);
+  assert.equal(workflow.includes("!contains(github.event.comment.body, '<!-- vtdd:reviewer=')"), true);
+  assert.equal(
+    workflow.includes("contains(github.event.comment.body, '<!-- vtdd:reviewer-objection-resolution -->')"),
+    true
+  );
+  assert.equal(
+    workflow.indexOf("github.event_name != 'issue_comment'") <
+      workflow.indexOf("name: Detect GitHub App secret availability"),
+    true
+  );
+});
+
+test("Gemini review script stops issue-comment reruns when reviewer already approved", () => {
+  const script = fs.readFileSync("scripts/run-gemini-pr-review.mjs", "utf8");
+  assert.equal(script.includes("isReviewerTerminalApproved"), true);
+  assert.equal(script.includes("Skipping Gemini PR review: reviewer already approved current PR head"), true);
+  assert.equal(script.includes("headSha: pullRequest?.head?.sha"), true);
+});
+
 test("Gemini review script defaults Codex fallback to VPS Codex CLI transport", () => {
   const script = fs.readFileSync("scripts/run-gemini-pr-review.mjs", "utf8");
   assert.equal(script.includes('deliveryMode: "vps_codex_cli"'), true);

--- a/test/vps-runner-script.test.js
+++ b/test/vps-runner-script.test.js
@@ -924,6 +924,147 @@ test("VPS runner selects pending Codex reviewer fallback comments after developm
   assert.equal(selected[0].trigger, "pull_request_target:synchronize");
 });
 
+test("VPS runner does not reprocess Codex fallback requested comments after reviewer approve", () => {
+  const selected = selectPendingVpsReviewerFallbacks({
+    repositoryPolicies: normalizeRepositoryPolicies({
+      allowedRepositories: ["sample-org/vtdd-v2"]
+    }),
+    comments: [
+      {
+        id: 1,
+        html_url: "https://github.com/sample-org/vtdd-v2/pull/22#issuecomment-1",
+        created_at: "2026-05-14T11:50:00Z",
+        repository: "sample-org/vtdd-v2",
+        pullRequestNumber: 22,
+        headSha: "abc123",
+        body: [
+          "<!-- vtdd:reviewer=codex-fallback -->",
+          "## VTDD Codex fallback レビュー",
+          "",
+          "- Status: `requested`",
+          "- Trigger: `issue_comment:created`",
+          "- Reason: `gemini_temporarily_unavailable`",
+          "- Delivery mode: `vps_codex_cli`",
+          "- Head SHA: `abc123`"
+        ].join("\n")
+      },
+      {
+        id: 2,
+        html_url: "https://github.com/sample-org/vtdd-v2/pull/22#issuecomment-2",
+        created_at: "2026-05-14T11:51:00Z",
+        user: { login: "vtdd-codex[bot]" },
+        repository: "sample-org/vtdd-v2",
+        pullRequestNumber: 22,
+        headSha: "abc123",
+        body: [
+          "<!-- vtdd:reviewer=codex-fallback -->",
+          "## VTDD Codex fallback レビュー",
+          "",
+          "- Status: `completed`",
+          "- Trigger: `issue_comment:created`",
+          "- Reason: `gemini_temporarily_unavailable`",
+          "- Delivery mode: `vps_codex_cli`",
+          "- Head SHA: `abc123`",
+          "- Recommended action: `approve`"
+        ].join("\n")
+      }
+    ]
+  });
+
+  assert.equal(selected.length, 0);
+});
+
+test("VPS runner can reprocess Codex fallback requested comments for a new head SHA", () => {
+  const selected = selectPendingVpsReviewerFallbacks({
+    repositoryPolicies: normalizeRepositoryPolicies({
+      allowedRepositories: ["sample-org/vtdd-v2"]
+    }),
+    comments: [
+      {
+        id: 1,
+        created_at: "2026-05-14T11:50:00Z",
+        repository: "sample-org/vtdd-v2",
+        pullRequestNumber: 22,
+        headSha: "new456",
+        body: [
+          "<!-- vtdd:reviewer=codex-fallback -->",
+          "- Status: `requested`",
+          "- Trigger: `pull_request_target:synchronize`",
+          "- Reason: `gemini_temporarily_unavailable`",
+          "- Delivery mode: `vps_codex_cli`",
+          "- Head SHA: `new456`"
+        ].join("\n")
+      },
+      {
+        id: 2,
+        created_at: "2026-05-14T11:40:00Z",
+        user: { login: "vtdd-codex[bot]" },
+        repository: "sample-org/vtdd-v2",
+        pullRequestNumber: 22,
+        headSha: "new456",
+        body: [
+          "<!-- vtdd:reviewer=codex-fallback -->",
+          "- Status: `completed`",
+          "- Trigger: `issue_comment:created`",
+          "- Reason: `gemini_temporarily_unavailable`",
+          "- Delivery mode: `vps_codex_cli`",
+          "- Head SHA: `old123`",
+          "- Recommended action: `approve`"
+        ].join("\n")
+      }
+    ]
+  });
+
+  assert.equal(selected.length, 1);
+  assert.equal(selected[0].pullRequestNumber, 22);
+});
+
+test("VPS runner ignores untrusted approve markers when selecting Codex fallback requests", () => {
+  const selected = selectPendingVpsReviewerFallbacks({
+    repositoryPolicies: normalizeRepositoryPolicies({
+      allowedRepositories: ["sample-org/vtdd-v2"]
+    }),
+    comments: [
+      {
+        id: 1,
+        created_at: "2026-05-14T11:50:00Z",
+        repository: "sample-org/vtdd-v2",
+        pullRequestNumber: 22,
+        headSha: "abc123",
+        body: [
+          "<!-- vtdd:reviewer=codex-fallback -->",
+          "- Status: `requested`",
+          "- Trigger: `pull_request_target:synchronize`",
+          "- Reason: `gemini_temporarily_unavailable`",
+          "- Delivery mode: `vps_codex_cli`",
+          "- Head SHA: `abc123`"
+        ].join("\n")
+      },
+      {
+        id: 2,
+        created_at: "2026-05-14T11:51:00Z",
+        user: { login: "external-contributor" },
+        author_association: "NONE",
+        repository: "sample-org/vtdd-v2",
+        pullRequestNumber: 22,
+        headSha: "abc123",
+        body: [
+          "<!-- vtdd:reviewer=codex-fallback -->",
+          "- Status: `completed`",
+          "- Trigger: `issue_comment:created`",
+          "- Reason: `gemini_temporarily_unavailable`",
+          "- Delivery mode: `vps_codex_cli`",
+          "- Head SHA: `abc123`",
+          "- Recommended action: `approve`"
+        ].join("\n")
+      }
+    ]
+  });
+
+  assert.equal(selected.length, 1);
+  assert.equal(selected[0].pullRequestNumber, 22);
+});
+
 test("VPS runner Codex prompt preserves high-risk boundaries", () => {
   const prompt = buildCodexExecutionPrompt({
     payload: {


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #366 の Intent に対し、同一 PR / 同一 head SHA で trusted reviewer marker が approve を出した後は、Gemini reviewer と Codex fallback reviewer の再実行ループを止めます。
- PR #347 のコメント嵐で見えた、古い fallback requested comment を VPS runner が再処理し続ける経路を、コメント全ページ取得と terminal state 判定で止めます。
- レビュアー marker には head SHA を出すようにして、approve の停止範囲を現在の PR head に限定します。

## Satisfied Success Criteria

- trusted reviewer marker の latest approve / merge 可能状態を、同一 head SHA の terminal state として判定する共通 helper を追加しました。
- VPS runner は open PR の issue comments を 100 件固定ではなく全ページ取得し、後続の approve marker がある fallback requested を選択しません。
- Gemini workflow は reviewer marker の issue_comment では job 自体を開始しません。ただし objection resolution marker は再確認できるよう例外を残しました。
- Gemini reviewer と Codex fallback reviewer の script は、同一 head SHA がすでに approve 済みなら新規コメント投稿前に停止します。
- PR #347 型の fixture として、approve 後に fallback requested を再処理しないテスト、新しい head SHA なら再処理できるテスト、外部投稿者の偽 approve は無視するテストを追加しました。

## Unsatisfied Success Criteria

- merge 後に Gemini workflow と VPS runner を再有効化し、PR #347 のコメント数が増えないことを live evidence として確認する作業は未実施です。
- 既存の PR #347 大量コメントは削除・編集していません。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #366
- Implementing Success Criteria: approve を同一 head SHA の terminal state として扱い、Gemini / Codex fallback の reviewer loop を停止する。
- Explicit Non-goals: 既存コメント削除、レビュアー廃止、PR #347 実装変更、deploy、credential mutation、permission mutation はしない。
- Expected touched files/routes/workflows: `.github/workflows/gemini-pr-review.yml`, `scripts/run-gemini-pr-review.mjs`, `scripts/run-codex-pr-review-fallback.mjs`, `scripts/run-vps-runner.mjs`, `src/core/reviewer-terminal-state.js`, `src/core/gemini-pr-review.js`, `src/core/codex-review-fallback.js`, `src/core/index.js`, `test/gemini-pr-review-workflow.test.js`, `test/vps-runner-script.test.js`
- Affected Issues: Issue #366。Reviewer loop / PR comment 増殖に関係する既存 reviewer 系 Issue に影響し得るが、この PR では Issue #366 に限定する。
- Affected PRs: PR #347 は再発確認対象。既存 PR 内容は変更しない。
- Affected workflows: `gemini-pr-review.yml`, VPS runner の reviewer fallback polling, Codex fallback reviewer script。
- Affected runtime/operator surfaces: GitHub PR comment surface, VPS Codex CLI runner, Gemini reviewer, Codex fallback reviewer。Butler Action Schema / Custom GPT Instructions / Cloudflare Worker route は未変更。
- What may break if we patch narrowly: コメント先頭 100 件だけを見る修正だと PR #347 のような大量コメント PR で古い requested を拾い続ける。marker だけを見る修正だと外部投稿者の偽 approve で reviewer が止まる。head SHA を見ない修正だと新 commit 後の再レビューが止まる。
- Unknowns to investigate before coding: GitHub issue_comment が reviewer marker 自体で再起動するか、VPS runner が全ページ取得できているか、approve marker が trusted reviewer 由来か。
- Validation needed: targeted node --test、npm test、PR 作成後の Actions、merge 後の live observation、VPS runner restart 後の PR #347 コメント数監視。
- Stop condition: reviewer marker の信頼元、head SHA、または Issue #366 scope が判定できない場合は実装を止める。

## File / Line Hypotheses

- file: `scripts/run-vps-runner.mjs`
  - hypothesis: `readRecentPullRequestComments` が comments first page だけを読み、PR #347 の latest approve に到達できない。
  - risk if changed narrowly: page 取得だけでは approve terminal 判定がないため、古い requested を再処理する可能性が残る。
  - validation: 全ページ取得 helper と approve 後 skip fixture を追加する。
  - related Issue: Issue #366
- file: `.github/workflows/gemini-pr-review.yml`
  - hypothesis: reviewer marker の issue_comment が Gemini workflow を再起動している。
  - risk if changed narrowly: objection resolution まで止めると人間が再確認を依頼できなくなる。
  - validation: reviewer marker は skip、objection resolution marker は許可する workflow test を追加する。
  - related Issue: Issue #366
- file: `src/core/reviewer-terminal-state.js`
  - hypothesis: reviewer approve 判定を共通化し、head SHA と trusted actor を同時に見る必要がある。
  - risk if changed narrowly: 外部投稿者の偽 marker または古い head の approve で reviewer が止まる。
  - validation: trusted approve / new head / untrusted approve の fixture を追加する。
  - related Issue: Issue #366

## Hypothesis Retrospective

- expected: PR #347 では comments first page only と reviewer marker self-trigger が重なり、fallback requested が再処理された。
- actual: 実装では VPS runner の全ページ取得、terminal approve 判定、Gemini issue_comment skip の三点が必要だった。
- mismatch: 単に Gemini workflow を止めるだけでは不十分で、VPS Codex CLI fallback runner 側にも停止条件が必要だった。
- lesson: approve は「人間が安心して止めたい状態」なので、same head SHA / trusted marker / latest state の三条件で扱う。
- should become RAG candidate: はい。PR comment storm 再発防止と reviewer terminal state の設計判断として RAG 候補。

## Verification Evidence

- Unit: `node --test test/gemini-pr-review.test.js test/gemini-pr-review-workflow.test.js test/vps-runner-script.test.js test/codex-review-fallback.test.js` -> 109 tests pass。
- Integration: `npm test` -> 760 tests, 759 pass, 1 skip。`check:self-parity` passed。`check:generated-worker` passed。
- PR checks: PR #367 `guarded-policy` pass、`test` pass。
- E2E: PR #347 comment count observed stable at 1283 after VPS runner stop。merge 後の reviewer 再有効化 live E2E は未実施。
- Manual: VPS runner timer/service は停止済み状態でコメント増殖停止を確認済み。Gemini workflow は disabled_manually のまま。
- Evidence path/link: Issue #366 / this PR checks / PR #347 comment-count observation。

## Butler Completion Contract

- Owner goal: PR コメント嵐の再発を止め、approve 後に reviewer が同じ PR head へ新規 reviewer comment を増やし続けないようにする。
- Butler entrypoint: この PR は reviewer/runtime 修正であり、Butler natural-language entrypoint は未変更。
- Action Schema exposure: 未変更。Action Schema 更新は不要。
- Runtime path: GitHub Actions Gemini reviewer、VPS runner fallback polling、Codex fallback reviewer script。
- Runner/runtime truth: targeted test と npm test は成功。live runtime truth は merge 後に reviewer / VPS runner を戻して確認する必要がある。
- Authority boundary: 新しい high-risk authority は追加しない。deploy、secret、permission mutation はしていない。
- E2E evidence: merge 後の live reviewer 再有効化と PR #347 監視が未実施のため incomplete。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 不要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 不要。ただし merge 後の reviewer 再有効化は owner-visible runtime evidence として別途必要。

## Related Constitution Rules

- Issue traceability: Issue #366 に限定する。
- Drift Stop Protocol: bounded change contract の範囲外を触らない。
- Evidence Discipline: tests と PR #347 observation を明記し、merge 後 live evidence は未完了として扱う。
- Butler and Reviewer as Stop Roles: reviewer approve を停止信号として扱う。
- Authority Boundary: deploy / credential / permission mutation は GO + passkey なしに実行しない。

## Out-of-scope but NOT implemented

- Gemini workflow の再有効化。
- VPS runner service/timer の再起動。
- PR #347 既存コメントの削除または編集。
- reviewer comment を update 方式へ全面変更すること。

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #366
- Execution ID: local-mac-codex-issue-366-reviewer-approve-terminal
- Goal: stop_reviewer_loop_after_approve
