### PR TITLE
Issue #349: reviewer docs を append timeline 方針へ揃える

### DIFF
--- a/docs/butler/gemini-pr-review-comments.md
+++ b/docs/butler/gemini-pr-review-comments.md
@@ -33,7 +33,7 @@ must not hard-fail the PR solely for reviewer availability reasons.
 
 Preferred fallback:
 
-- VTDD posts or updates a `vtdd:reviewer=codex-fallback` request comment that
+- VTDD appends a timestamped `vtdd:reviewer=codex-fallback` request comment that
   targets the user-owned VPS Codex CLI reviewer transport
 - the default request path does not use `OPENAI_API_KEY`
 - the request remains request-state until the VPS reviewer runner returns a completed fallback
@@ -115,18 +115,23 @@ Gemini output must remain compatible with the existing reviewer contract:
 For this slice, the canonical return surface is a PR comment carrying that
 structured critique in a human-readable format.
 
-## Upsert Rule
+## Append Timeline Rule
 
-Gemini reruns must update the existing VTDD Gemini review comment when one is
-already present.
+Gemini reruns must append a new timestamped VTDD Gemini reviewer marker comment.
+Existing reviewer evidence must not be overwritten.
 
-The goal is to keep one current critical-review surface on the PR rather than
-creating uncontrolled repeated comments.
+The goal is to preserve a GitHub-visible reviewer timeline. Butler, mac Codex,
+and VPS Codex CLI must read the latest trusted marker for the relevant PR head
+SHA instead of assuming there is only one current reviewer comment.
 
 Butler summaries must present the current `Recommended action` and the Gemini
-marker comment URL. If GitHub displays the original comment timestamp, Butler
-must explain that the marker comment was updated and the current body is the
-latest reviewer evidence.
+marker comment URL from the latest trusted reviewer marker. Older marker
+comments remain historical evidence, not the current reviewer judgment.
+
+Append does not mean uncontrolled repetition. Reviewer marker comments must not
+self-trigger review loops, and an `approve` marker for the same PR head SHA is a
+terminal state unless a new commit, explicit trusted re-review request, or later
+blocking reviewer signal reopens review.
 
 The VTDD reviewer marker comment is the canonical VTDD reviewer signal for
 Butler synthesis. It must not be confused with GitHub formal Pull Request
@@ -139,9 +144,10 @@ GitHub formal review objects remain separate runtime truth. A formal
 reviewer marker recommends `approve`, and Butler must route the PR back to
 bounded revision instead of merge judgment.
 
-When Gemini becomes available again after a fallback request, VTDD should
-return to Gemini-first behavior and clear the stale Codex fallback request
-state.
+When Gemini becomes available again after a fallback request, VTDD should return
+to Gemini-first behavior by appending fresh Gemini reviewer evidence. Stale
+Codex fallback request comments remain historical evidence; Butler should treat
+the latest trusted marker for the relevant head SHA as current.
 
 ## Objection Resolution Re-Check
 

--- a/docs/setup/custom-gpt-instructions.md
+++ b/docs/setup/custom-gpt-instructions.md
@@ -359,6 +359,11 @@ Progress tracking:
 - If progress shows no PR yet, say clearly that GitHub PR is not yet published.
 - Do not claim PR creation is complete unless GitHub runtime truth actually shows the PR.
 
+Generated Worker build:
+- If a PR changes `src/**`, `src/worker.js`, `src/worker/runtime.js`, or worker-facing core code, remind the human that `worker.js` is generated and must be rebuilt with `npm run build:worker` before merge.
+- Treat `npm test` / `check-generated-worker` failure saying `Generated worker.js is out of date` as a build artifact mismatch, not as a feature failure.
+- When summarizing such a PR, say whether `worker.js` was regenerated and committed. If not verified, mark runtime/deploy readiness as unverified.
+
 Review loop:
 - Canonical loop is:
   Butler -> Codex -> PR -> Reviewer comments -> Butler summary -> human decision
@@ -371,7 +376,7 @@ Review loop:
 - If reviewer objections remain unresolved, do not recommend merge GO + real passkey.
 - If no reviewer evidence exists yet, say so plainly.
 - For Gemini reviewer evidence, always show the marker comment URL and current `Recommended action`.
-- Gemini reruns update the existing marker comment; if GitHub shows an old comment timestamp, explain that the current marker body is the latest reviewer judgment.
+- Gemini reruns append a new timestamped marker comment; use the latest trusted marker for the relevant PR head SHA as the current reviewer judgment, and keep older markers as historical evidence.
 - A requested `vtdd:reviewer=codex-fallback` marker with `deliveryMode=codex_cloud_github_comment` and `@codex review` proves only fallback was requested; it is not completed reviewer evidence yet.
 - A completed `vtdd:reviewer=codex-fallback` marker comment from a trusted VTDD-controlled actor, Codex Cloud reviewer result, or GitHub App token path, with recommendedAction, is valid fallback reviewer evidence when Gemini is temporarily unavailable; do not treat missing GitHub Review API objects alone as missing reviewer evidence.
 - If reviewer output is approve-only, still present it as reviewer evidence and keep final judgment with the human.

--- a/src/core/butler-review-synthesis.js
+++ b/src/core/butler-review-synthesis.js
@@ -171,7 +171,7 @@ function buildHumanDecisionFocus({ pullRequest, reviewLoop, codexGoal, branchAtt
   }
   if (reviewLoop.reviewer === "gemini" && reviewLoop.reviewerEvidence?.includesCreatedEdit) {
     focus.push(
-      "Gemini updates its existing marker comment; GitHub may show the original comment time, so use the current marker body and evidence URL."
+      "Gemini appends timestamped marker comments; use the latest trusted marker for the relevant PR head SHA as current reviewer evidence."
     );
   }
   focus.push("Human remains the final authority for revision GO and merge GO + real passkey.");

--- a/test/butler-review-synthesis.test.js
+++ b/test/butler-review-synthesis.test.js
@@ -94,7 +94,7 @@ test("butler review synthesis does not present approve-only Gemini review as unr
   });
   assert.equal(
     result.humanDecisionFocus.includes(
-      "Gemini updates its existing marker comment; GitHub may show the original comment time, so use the current marker body and evidence URL."
+      "Gemini appends timestamped marker comments; use the latest trusted marker for the relevant PR head SHA as current reviewer evidence."
     ),
     true
   );

--- a/test/execution-continuity.test.js
+++ b/test/execution-continuity.test.js
@@ -125,7 +125,7 @@ test("execution continuity treats approve-only Gemini reviewer comment as non-bl
   assert.equal(result.value.butlerReviewSynthesis.prState.mergeability.status, "unverified");
   assert.equal(
     result.value.butlerReviewSynthesis.humanDecisionFocus.includes(
-      "Gemini updates its existing marker comment; GitHub may show the original comment time, so use the current marker body and evidence URL."
+      "Gemini appends timestamped marker comments; use the latest trusted marker for the relevant PR head SHA as current reviewer evidence."
     ),
     true
   );

--- a/worker.js
+++ b/worker.js
@@ -28396,7 +28396,7 @@ function buildHumanDecisionFocus({ pullRequest, reviewLoop, codexGoal, branchAtt
   }
   if (reviewLoop.reviewer === "gemini" && reviewLoop.reviewerEvidence?.includesCreatedEdit) {
     focus.push(
-      "Gemini updates its existing marker comment; GitHub may show the original comment time, so use the current marker body and evidence URL."
+      "Gemini appends timestamped marker comments; use the latest trusted marker for the relevant PR head SHA as current reviewer evidence."
     );
   }
   focus.push("Human remains the final authority for revision GO and merge GO + real passkey.");


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #349 / Issue #366 の reviewer comment loop 再発防止に対し、canonical docs と Butler 表示文言を「既存コメント更新」ではなく「時系列 append」へ揃えます。
- Issue #360 の dry-run/build impact として、`src/**` 変更時に `worker.js` 生成物 rebuild が必要なことを Butler Instructions に追加します。
- 現行実装とテストが守っている append 方針を、docs / Custom GPT Instructions / Butler synthesis の文言と一致させます。

## Satisfied Success Criteria

- `docs/butler/gemini-pr-review-comments.md` の Upsert Rule を Append Timeline Rule に置き換えました。
- Gemini rerun と Codex fallback request は既存 evidence を上書きせず、timestamped marker comment として append する方針を明記しました。
- Butler synthesis の人間向け文言を、latest trusted marker for relevant PR head SHA を読む説明に更新しました。
- Custom GPT Instructions に、`src/**` や worker-facing core 変更時は `npm run build:worker` と `worker.js` commit が必要だと案内するルールを追加しました。
- `worker.js` を `npm run build:worker` で再生成しました。

## Unsatisfied Success Criteria

- この PR は docs / synthesis 文言 / generated worker の整合修正であり、Issue #349 / Issue #366 の全 Completion Gate を閉じるものではありません。
- merge 後、Custom GPT Instructions の貼り替えと Cloudflare deploy が必要です。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #349, Issue #366, Issue #360
- Implementing Success Criteria: reviewer evidence は append timeline を正とし、Butler が latest trusted marker / relevant PR head SHA を読む。`src/**` 変更時の worker build requirement を Butler が案内できるようにする。
- Explicit Non-goals: reviewer runtime code の再設計、workflow 変更、Gemini/VPS runner 再起動、既存 PR コメント編集・削除、Issue close はしない。
- Expected touched files/routes/workflows: `docs/butler/gemini-pr-review-comments.md`, `docs/setup/custom-gpt-instructions.md`, `src/core/butler-review-synthesis.js`, `test/butler-review-synthesis.test.js`, `test/execution-continuity.test.js`, generated `worker.js`
- Affected Issues: Issue #349, Issue #366, Issue #360。Custom GPT Instructions 更新があるため setup/surface update guidance に影響する。
- Affected PRs: PR #347 は背景 evidence。既存 PR 内容やコメントは変更しない。
- Affected workflows: なし。GitHub Actions 定義は変更しない。
- Affected runtime/operator surfaces: Butler synthesis 文言、Custom GPT Instructions、Cloudflare Worker bundle。Action Schema は未変更。
- What may break if we patch narrowly: docs だけ直すと Butler synthesis が古い upsert 文言を出し続ける。src だけ直すと worker.js 生成物が古くなり deploy/runtime がズレる。Custom GPT Instructions を直さないと Butler が build:worker requirement を会話で案内できない。
- Unknowns to investigate before coding: 既存 docs / Butler Instructions / tests に upsert 文言が残っているか。`worker.js` が生成物として更新必要か。
- Validation needed: targeted tests、`npm test`、`check-generated-worker`、PR checks。merge 後は deploy と Instructions 貼り替えが必要。
- Stop condition: append 方針と runtime 実装が矛盾する、または Action Schema 変更が必要になる場合は停止する。

## File / Line Hypotheses

- file: `docs/butler/gemini-pr-review-comments.md`
  - hypothesis: 古い upsert 方針が canonical docs に残り、将来の AI がコメント更新へ戻す drift を起こす。
  - risk if changed narrowly: docs だけ直すと Butler 表示文言が古いまま残る。
  - validation: upsert/update existing marker 文言検索と reviewer 関連テスト。
  - related Issue: Issue #349 / Issue #366
- file: `src/core/butler-review-synthesis.js`
  - hypothesis: Butler が人間へ古い upsert 説明を出す。
  - risk if changed narrowly: `worker.js` を再生成しないと runtime bundle が古い。
  - validation: synthesis tests、`npm run build:worker`、`check-generated-worker`。
  - related Issue: Issue #349 / Issue #366
- file: `docs/setup/custom-gpt-instructions.md`
  - hypothesis: Butler は `src/**` 変更時の worker build requirement を知らない。
  - risk if changed narrowly: CI は気づくが、Butler が通常会話で事前案内できない。
  - validation: custom GPT setup docs tests。
  - related Issue: Issue #360

## Hypothesis Retrospective

- expected: docs の upsert 文言だけが drift している。
- actual: docs に加えて Butler synthesis と Custom GPT Instructions にも、運用判断へ影響する文言が残っていた。
- mismatch: `src/core` を触ったため generated `worker.js` rebuild が必要だった。これは Butler Instructions にも明示すべき運用知識だった。
- lesson: reviewer evidence は append timeline が正本。更新ではなく latest trusted marker / head SHA / terminal state で読む。`src/**` 変更時は generated worker の整合を必ず見る。
- should become RAG candidate: はい。reviewer append timeline と generated worker build requirement は今後の drift 防止知識。

## Verification Evidence

- Unit: `node --test test/gemini-pr-review-workflow.test.js test/butler-review-synthesis.test.js test/execution-continuity.test.js test/custom-gpt-setup-docs.test.js test/custom-gpt-setup-artifacts.test.js` -> pass。
- Integration: `npm test` -> 760 tests, 759 pass, 1 skip。`check:self-parity` passed。`check:generated-worker` passed。
- E2E: なし。この PR は docs / synthesis 文言 / generated worker consistency の修正であり、live reviewer E2E は既存 Issue #349 / Issue #366 の継続 evidence に委ねる。
- Manual: 古い `update existing marker` / `Gemini reruns update` 系文言が残っていないことを `rg` で確認。
- Evidence path/link: this PR checks。

## Butler Completion Contract

- Owner goal: Butler / mac Codex / VPS Codex CLI が reviewer evidence をコメント更新ではなく時系列 append として読み、生成 worker build requirement も見落とさないようにする。
- Butler entrypoint: Custom GPT Instructions に反映されれば、Butler は PR summary / surface guidance で build requirement と latest reviewer marker 方針を案内できる。
- Action Schema exposure: 未変更。
- Runtime path: Butler synthesis 文言は `src/core/butler-review-synthesis.js` から generated `worker.js` に反映済み。
- Runner/runtime truth: `npm test` と `check-generated-worker` で source/generated worker 整合を確認済み。
- Authority boundary: 新しい high-risk authority は追加しない。deploy はこの PR では未実行。
- E2E evidence: Butler live surface は merge 後の deploy / Instructions 更新後に確認する必要がある。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 必要。`worker.js` が変わったため merge 後に deploy が必要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 必要。`docs/setup/custom-gpt-instructions.md` が変わったため、merge 後に `/setup` から貼り替え対象。
- iPhone Butler live E2E: 推奨。merge/deploy/Instructions 更新後に、Butler が reviewer append timeline と worker build requirement を説明できるか確認する。

## Related Constitution Rules

- Issue traceability: Issue #349 / Issue #366 / Issue #360 に限定する。
- Drift Stop Protocol: runtime code の再設計や workflow mutation へ広げない。
- Evidence Discipline: generated worker が更新済みかを `check-generated-worker` で確認する。
- Conversation UX Contract: Butler の owner-facing guidance を日本語運用に合わせる。

## Out-of-scope but NOT implemented

- reviewer workflow の変更。
- reviewer comment cleanup。
- Issue #349 / Issue #366 の close。
- Cloudflare deploy と Custom GPT Instructions 貼り替え。

## Extra changes (if any)

- `worker.js` は generated artifact として `npm run build:worker` で更新しました。

<!-- VTDD metadata -->
- Issue: Issue #349 / Issue #366 / Issue #360
- Execution ID: local-mac-codex-reviewer-append-docs
- Goal: align_reviewer_append_timeline_docs
