### PR TITLE
Issue #351: VPS fallback reviewer の actor identity を fail-closed にする

### DIFF
--- a/docs/security/github-app-actor-identity.md
+++ b/docs/security/github-app-actor-identity.md
@@ -21,7 +21,7 @@ for that role.
 | mac Codex executor | `VTDD mac Codex` | `.github/workflows/remote-codex-executor.yml` with `codex_actor=mac-codex` | `VTDD_MAC_CODEX_APP_ID`, `VTDD_MAC_CODEX_APP_PRIVATE_KEY` |
 | VPS Codex CLI executor | `VTDD VPS Codex CLI` | `.github/workflows/remote-codex-executor.yml` with `codex_actor=vps-codex-cli` | `VTDD_VPS_CODEX_CLI_APP_ID`, `VTDD_VPS_CODEX_CLI_APP_PRIVATE_KEY` |
 | Gemini reviewer | `VTDD Gemini Reviewer` | `.github/workflows/gemini-pr-review.yml` | `VTDD_GEMINI_REVIEWER_APP_ID`, `VTDD_GEMINI_REVIEWER_APP_PRIVATE_KEY` |
-| Codex fallback reviewer | `VTDD Codex Fallback Reviewer` | `.github/workflows/codex-pr-review-fallback.yml` | `VTDD_CODEX_FALLBACK_REVIEWER_APP_ID`, `VTDD_CODEX_FALLBACK_REVIEWER_APP_PRIVATE_KEY` |
+| Codex fallback reviewer | `VTDD Codex Fallback Reviewer` | `.github/workflows/codex-pr-review-fallback.yml`; VPS fallback writeback path | `VTDD_CODEX_FALLBACK_REVIEWER_APP_ID`, `VTDD_CODEX_FALLBACK_REVIEWER_APP_PRIVATE_KEY`, `VTDD_CODEX_FALLBACK_REVIEWER_APP_INSTALLATION_ID` on VPS |
 | Owner | `marushu` | Manual GitHub UI / owner-authorized administration | Owner login only |
 
 ## Authority Boundary
@@ -57,3 +57,22 @@ Until the new secrets are configured:
 - Remote Codex executor keeps `vtdd-codex` compatibility by default and uses
   `mac-codex` or `vps-codex-cli` only when that actor is selected and its
   secrets are configured.
+
+## Incident Visibility
+
+Actor identity failures are recovery incidents, not silent script failures.
+
+If the VPS fallback path cannot mint a `VTDD Codex Fallback Reviewer`
+installation access token, it must not post the completed reviewer marker as
+`marushu`. When `VTDD VPS Codex CLI` credentials are available, the VPS runner
+posts a Japanese-first `@marushu` incident comment instead:
+
+- first line is readable from iPhone / Apple Watch notifications,
+- body includes `<!-- vtdd:incident=actor_identity_failure -->`,
+- body names the expected actor, detected-by actor, affected PR, and next
+  credential setup action.
+
+If the VPS notifier App token is also unavailable, the runner must fail closed
+and log the incident reason. That state is incomplete for normal VTDD recovery
+until startup preflight can surface the incident through Butler / mac Codex /
+VPS Codex CLI.

--- a/scripts/run-vps-runner.mjs
+++ b/scripts/run-vps-runner.mjs
@@ -9,7 +9,8 @@ import { fileURLToPath } from "node:url";
 import {
   isReviewerTerminalApproved,
   normalizeMentionLogin,
-  parseCodexReviewFallbackComment
+  parseCodexReviewFallbackComment,
+  resolveGitHubAppInstallationToken
 } from "../src/core/index.js";
 import { buildExecutionLeadTime } from "../src/core/execution-lead-time.js";
 import { prepareGuardedPullRequestBody, prepareGuardedPullRequestBodyFile } from "./prepare-pr-body-file.mjs";
@@ -21,6 +22,23 @@ const CANCELED_MARKER_RE = /<!--\s*vtdd:vps-runner-canceled:([a-zA-Z0-9._:-]+)\s
 const DEFAULT_API_BASE_URL = "https://api.github.com";
 const DEFAULT_HEARTBEAT_SECONDS = 120;
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const VTDD_INCIDENT_ACTOR_IDENTITY_FAILURE_MARKER = "<!-- vtdd:incident=actor_identity_failure -->";
+const ROLE_GITHUB_APP_ENV = {
+  codex_fallback_reviewer: {
+    label: "VTDD Codex Fallback Reviewer",
+    appId: "VTDD_CODEX_FALLBACK_REVIEWER_APP_ID",
+    privateKey: "VTDD_CODEX_FALLBACK_REVIEWER_APP_PRIVATE_KEY",
+    privateKeyBase64: "VTDD_CODEX_FALLBACK_REVIEWER_APP_PRIVATE_KEY_BASE64",
+    installationId: "VTDD_CODEX_FALLBACK_REVIEWER_APP_INSTALLATION_ID"
+  },
+  vps_codex_cli: {
+    label: "VTDD VPS Codex CLI",
+    appId: "VTDD_VPS_CODEX_CLI_APP_ID",
+    privateKey: "VTDD_VPS_CODEX_CLI_APP_PRIVATE_KEY",
+    privateKeyBase64: "VTDD_VPS_CODEX_CLI_APP_PRIVATE_KEY_BASE64",
+    installationId: "VTDD_VPS_CODEX_CLI_APP_INSTALLATION_ID"
+  }
+};
 const MILESTONE_MENTION_EVENTS = new Set([
   "picked_up",
   "branch_pushed",
@@ -486,6 +504,15 @@ function selectPendingVpsReviewerFallbacks({ comments, allowedRepositories, repo
       ) {
         return null;
       }
+      if (
+        hasVpsReviewerFallbackActorIdentityIncident({
+          comments: samePullRequestComments,
+          after: comment.created_at,
+          headSha: normalizeText(comment.headSha)
+        })
+      ) {
+        return null;
+      }
       return {
         repository,
         pullRequestNumber,
@@ -493,7 +520,8 @@ function selectPendingVpsReviewerFallbacks({ comments, allowedRepositories, repo
         reason: extractBacktickedCommentValue(comment.body, "Reason") || "gemini_temporarily_unavailable",
         createdAt: comment.created_at,
         commentId: comment.id,
-        commentUrl: comment.html_url
+        commentUrl: comment.html_url,
+        headSha: normalizeText(comment.headSha)
       };
     })
     .filter(Boolean);
@@ -1080,8 +1108,22 @@ function truncateForPrompt(value, maxLength) {
 }
 
 async function executeVpsReviewerFallback({ token, reviewerFallback }) {
+  const apiBaseUrl = process.env.GITHUB_API_URL || DEFAULT_API_BASE_URL;
+  const fallbackToken = await resolveRoleGitHubAppInstallationToken({
+    role: "codex_fallback_reviewer",
+    env: process.env,
+    apiBaseUrl
+  });
+  if (!fallbackToken.ok) {
+    return handleVpsReviewerFallbackActorIdentityFailure({
+      reviewerFallback,
+      reason: fallbackToken.reason,
+      apiBaseUrl
+    });
+  }
+
   const env = {
-    ...buildRunnerCommandEnv({ token }),
+    ...buildRunnerCommandEnv({ token: fallbackToken.token }),
     TARGET_REPOSITORY: reviewerFallback.repository,
     TARGET_PR_NUMBER: String(reviewerFallback.pullRequestNumber),
     CODEX_FALLBACK_TRIGGER: reviewerFallback.trigger,
@@ -1105,6 +1147,174 @@ async function executeVpsReviewerFallback({ token, reviewerFallback }) {
       reason: error instanceof Error ? error.message : String(error)
     };
   }
+}
+
+async function handleVpsReviewerFallbackActorIdentityFailure({
+  reviewerFallback,
+  reason,
+  apiBaseUrl
+}) {
+  const notificationToken = await resolveRoleGitHubAppInstallationToken({
+    role: "vps_codex_cli",
+    env: process.env,
+    apiBaseUrl
+  });
+  const incident = buildVpsReviewerFallbackActorIdentityIncident({
+    reviewerFallback,
+    reason,
+    notifierAvailable: notificationToken.ok,
+    notifierReason: notificationToken.reason
+  });
+
+  if (!notificationToken.ok) {
+    return {
+      ok: false,
+      reason: incident.logSummary
+    };
+  }
+
+  const incidentFetch = createGitHubFetch({
+    token: notificationToken.token,
+    apiBaseUrl
+  });
+  await incidentFetch(`/repos/${reviewerFallback.repository}/issues/${reviewerFallback.pullRequestNumber}/comments`, {
+    method: "POST",
+    body: {
+      body: incident.body
+    }
+  });
+
+  return {
+    ok: false,
+    reason: incident.logSummary
+  };
+}
+
+function buildVpsReviewerFallbackActorIdentityIncident({
+  reviewerFallback,
+  reason,
+  notifierAvailable,
+  notifierReason
+}) {
+  const mention = resolveIncidentOperatorMention({ repository: reviewerFallback?.repository });
+  const headSha = normalizeText(reviewerFallback?.headSha) || "unknown";
+  const body = [
+    `${mention ? `@${mention} ` : ""}【要対応】VPS Codex CLI: PRレビュー結果を正しいBot名で投稿できません`,
+    "",
+    VTDD_INCIDENT_ACTOR_IDENTITY_FAILURE_MARKER,
+    "",
+    "## 何が起きたか",
+    "",
+    "`VTDD Codex Fallback Reviewer` として fallback review completed を投稿するための App token を用意できませんでした。",
+    "`marushu` として代替投稿することは禁止されているため、reviewer completed comment は投稿していません。",
+    "",
+    "## 影響",
+    "",
+    `- Repository: \`${normalizeRepository(reviewerFallback?.repository) || "unknown"}\``,
+    `- Pull request: #${normalizePositiveInteger(reviewerFallback?.pullRequestNumber) || "unknown"}`,
+    `- Head SHA: \`${headSha}\``,
+    "- Expected actor: `VTDD Codex Fallback Reviewer`",
+    "- Detected by: `VTDD VPS Codex CLI`",
+    "",
+    "## 次に必要なこと",
+    "",
+    "`VTDD_CODEX_FALLBACK_REVIEWER_APP_ID` / `VTDD_CODEX_FALLBACK_REVIEWER_APP_PRIVATE_KEY` / `VTDD_CODEX_FALLBACK_REVIEWER_APP_INSTALLATION_ID` を VPS runner から使える状態にしてください。",
+    "",
+    "## Runtime truth",
+    "",
+    `- failure: \`${sanitizeIncidentField(reason) || "fallback_reviewer_app_token_unavailable"}\``,
+    `- notifierAvailable: \`${notifierAvailable ? "true" : "false"}\``,
+    `- notifierReason: \`${sanitizeIncidentField(notifierReason) || "none"}\``
+  ].join("\n");
+
+  return {
+    body,
+    logSummary: [
+      "Codex fallback reviewer actor identity failure:",
+      sanitizeIncidentField(reason) || "fallback reviewer App token unavailable",
+      "Posting as marushu is forbidden.",
+      notifierAvailable
+        ? "Incident notification was posted by VTDD VPS Codex CLI."
+        : `Incident notification was not posted: ${sanitizeIncidentField(notifierReason) || "VPS Codex CLI App token unavailable"}.`
+    ].join(" ")
+  };
+}
+
+async function resolveRoleGitHubAppInstallationToken({ role, env = process.env, apiBaseUrl }) {
+  const names = ROLE_GITHUB_APP_ENV[role];
+  if (!names) {
+    return {
+      ok: false,
+      reason: `unknown GitHub App role: ${role}`
+    };
+  }
+  const roleEnv = buildRoleGitHubAppInstallationTokenEnv({ env, names });
+  const missing = [
+    ["app id", roleEnv.GITHUB_APP_ID],
+    ["private key", roleEnv.GITHUB_APP_PRIVATE_KEY || roleEnv.GITHUB_APP_PRIVATE_KEY_BASE64],
+    ["installation id", roleEnv.GITHUB_APP_INSTALLATION_ID]
+  ]
+    .filter(([, value]) => !normalizeText(value))
+    .map(([label]) => label);
+  if (missing.length > 0) {
+    return {
+      ok: false,
+      reason: `${names.label} GitHub App token unavailable: missing ${missing.join(", ")}`
+    };
+  }
+
+  const tokenResolution = await resolveGitHubAppInstallationToken({
+    env: roleEnv,
+    apiBaseUrl
+  });
+  if (!tokenResolution.ok) {
+    return {
+      ok: false,
+      reason: tokenResolution.warning || `${names.label} GitHub App token unavailable`
+    };
+  }
+  return {
+    ok: true,
+    token: tokenResolution.token
+  };
+}
+
+function buildRoleGitHubAppInstallationTokenEnv({ env = process.env, names }) {
+  return {
+    ...env,
+    GITHUB_APP_ID: env[names.appId],
+    GITHUB_APP_PRIVATE_KEY: env[names.privateKey],
+    GITHUB_APP_PRIVATE_KEY_BASE64: env[names.privateKeyBase64],
+    GITHUB_APP_INSTALLATION_ID: env[names.installationId]
+  };
+}
+
+function hasVpsReviewerFallbackActorIdentityIncident({ comments, after, headSha }) {
+  const afterTime = Date.parse(normalizeText(after));
+  const expectedHeadSha = normalizeText(headSha);
+  return comments.some((comment) => {
+    const body = String(comment?.body || "");
+    if (!body.includes(VTDD_INCIDENT_ACTOR_IDENTITY_FAILURE_MARKER)) {
+      return false;
+    }
+    const createdAt = Date.parse(normalizeText(comment?.created_at));
+    if (Number.isFinite(afterTime) && Number.isFinite(createdAt) && createdAt < afterTime) {
+      return false;
+    }
+    const incidentHeadSha = extractBacktickedCommentValue(body, "Head SHA");
+    return !expectedHeadSha || incidentHeadSha === expectedHeadSha || incidentHeadSha === "unknown";
+  });
+}
+
+function resolveIncidentOperatorMention({ repository }) {
+  const [owner] = normalizeRepository(repository).split("/", 1);
+  return normalizeMentionLogin(owner);
+}
+
+function sanitizeIncidentField(value) {
+  return redactDiagnosticText(value)
+    .replace(/`/g, "'")
+    .slice(0, 240);
 }
 
 async function postVpsRunnerEvent({ githubFetch, payload, event, notification }) {
@@ -1930,6 +2140,7 @@ export {
   buildGuardedPullRequestBody,
   buildPullRequestBody,
   buildVpsRunnerEventComment,
+  buildVpsReviewerFallbackActorIdentityIncident,
   buildVpsRunnerStateComment,
   buildVpsRunnerPullRequestContext,
   checkoutVpsRunnerBranch,
@@ -1943,6 +2154,7 @@ export {
   parseVpsRunnerQueueComment,
   postVpsRunnerEvent,
   runVpsRunnerOnce,
+  resolveRoleGitHubAppInstallationToken,
   summarizeDiagnosticText,
   selectPendingVpsReviewerFallbacks,
   selectPendingVpsRunnerExecutions

--- a/test/vps-runner-script.test.js
+++ b/test/vps-runner-script.test.js
@@ -12,6 +12,7 @@ import {
   buildVpsRunnerPreflightReceipt,
   buildVpsRunnerCompletionFinalEvent,
   buildVpsRunnerEventComment,
+  buildVpsReviewerFallbackActorIdentityIncident,
   buildVpsRunnerStateComment,
   buildVpsRunnerPullRequestContext,
   checkoutVpsRunnerBranch,
@@ -25,6 +26,7 @@ import {
   parseVpsRunnerQueueComment,
   postVpsRunnerEvent,
   runVpsRunnerOnce,
+  resolveRoleGitHubAppInstallationToken,
   summarizeDiagnosticText,
   selectPendingVpsReviewerFallbacks,
   selectPendingVpsRunnerExecutions
@@ -1017,6 +1019,80 @@ test("VPS runner can reprocess Codex fallback requested comments for a new head 
 
   assert.equal(selected.length, 1);
   assert.equal(selected[0].pullRequestNumber, 22);
+});
+
+test("VPS runner does not reprocess Codex fallback requests after actor identity incident", () => {
+  const selected = selectPendingVpsReviewerFallbacks({
+    repositoryPolicies: normalizeRepositoryPolicies({
+      allowedRepositories: ["sample-org/vtdd-v2"]
+    }),
+    comments: [
+      {
+        id: 1,
+        created_at: "2026-05-14T11:50:00Z",
+        repository: "sample-org/vtdd-v2",
+        pullRequestNumber: 22,
+        headSha: "abc123",
+        body: [
+          "<!-- vtdd:reviewer=codex-fallback -->",
+          "- Status: `requested`",
+          "- Trigger: `pull_request_target:synchronize`",
+          "- Reason: `gemini_temporarily_unavailable`",
+          "- Delivery mode: `vps_codex_cli`",
+          "- Head SHA: `abc123`"
+        ].join("\n")
+      },
+      {
+        id: 2,
+        created_at: "2026-05-14T11:51:00Z",
+        repository: "sample-org/vtdd-v2",
+        pullRequestNumber: 22,
+        headSha: "abc123",
+        body: [
+          "@marushu 【要対応】VPS Codex CLI: PRレビュー結果を正しいBot名で投稿できません",
+          "",
+          "<!-- vtdd:incident=actor_identity_failure -->",
+          "",
+          "- Head SHA: `abc123`"
+        ].join("\n")
+      }
+    ]
+  });
+
+  assert.equal(selected.length, 0);
+});
+
+test("VPS runner actor identity incident starts with Japanese owner notification", () => {
+  const incident = buildVpsReviewerFallbackActorIdentityIncident({
+    reviewerFallback: {
+      repository: "marushu/vtdd-v2-p",
+      pullRequestNumber: 368,
+      headSha: "abc123"
+    },
+    reason: "VTDD Codex Fallback Reviewer GitHub App token unavailable: missing private key",
+    notifierAvailable: true
+  });
+
+  assert.equal(
+    incident.body.split("\n")[0],
+    "@marushu 【要対応】VPS Codex CLI: PRレビュー結果を正しいBot名で投稿できません"
+  );
+  assert.equal(incident.body.includes("<!-- vtdd:incident=actor_identity_failure -->"), true);
+  assert.equal(incident.body.includes("- Expected actor: `VTDD Codex Fallback Reviewer`"), true);
+  assert.equal(incident.body.includes("- Detected by: `VTDD VPS Codex CLI`"), true);
+  assert.equal(incident.body.includes("`marushu` として代替投稿することは禁止"), true);
+});
+
+test("VPS runner role App token resolution fails closed when role credentials are missing", async () => {
+  const result = await resolveRoleGitHubAppInstallationToken({
+    role: "codex_fallback_reviewer",
+    env: {},
+    apiBaseUrl: "https://api.github.com"
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.reason.includes("VTDD Codex Fallback Reviewer"), true);
+  assert.equal(result.reason.includes("missing app id, private key, installation id"), true);
 });
 
 test("VPS runner ignores untrusted approve markers when selecting Codex fallback requests", () => {


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #351 の部分進捗です。VTDD が壊れた時に iPhone / Apple Watch / Butler / VPS から原因を追えるよう、VPS fallback reviewer の投稿 actor を role App token 境界に固定し、marushu 代替投稿を禁止します。

## Satisfied Success Criteria

- VPS fallback reviewer completed 投稿は VTDD Codex Fallback Reviewer App token が無い場合に実行しない。
- App token 不足時は VTDD VPS Codex CLI App token で @marushu 【要対応】から始まる日本語 incident コメントを投稿する経路を追加。
- actor identity incident marker がある同一 PR/head は再処理しない。
- Issue #351 docs に VPS fallback writeback と incident visibility の契約を追加。

## Unsatisfied Success Criteria

- GitHub Actions / VPS への role App secrets 登録は未実施。GO + passkey が必要。
- Butler / mac Codex / VPS Codex CLI startup preflight が incident marker を読む実装は別 Issue #344 系で未実装。
- live PR で Bot 表示が正しく出る E2E は secrets 接続後に必要。

## Non-goal violations

Secrets 登録、GitHub App permission mutation、deploy、Issue close、既存 PR コメント削除は行いません。

## Dry-run Impact Report

- Target Issue: Issue #351
- Implementing Success Criteria: Codex fallback reviewer workflow / VPS fallback writeback が専用 App token を使い、marushu 表示に落ちないこと。必要 secret 名と権限境界を docs/tests に固定すること。
- Explicit Non-goals: Issue #344 の startup preflight 全実装、secret sync、GitHub App install/permission mutation、deploy は含めません。
- Expected touched files/routes/workflows: scripts/run-vps-runner.mjs, test/vps-runner-script.test.js, docs/security/github-app-actor-identity.md
- Affected Issues: Issue #351 が主対象。Issue #344 は incident marker を後続 preflight で読む必要があるため関連。
- Affected PRs: PR #368 の marushu 表示コメントが発見の根拠。既存 PR コメントは変更しません。
- Affected workflows: VPS runner fallback path。GitHub Actions fallback workflow は既に App token 経路を持つため直接変更なし。
- Affected runtime/operator surfaces: VPS Codex CLI runner, GitHub PR comments, iPhone / Apple Watch notification first line, future Butler startup preflight.
- What may break if we patch narrowly: 単に token を差し替えるだけだと、token 不足時に黙って止まるか、再び marushu 投稿に落ちる危険があります。そのため incident marker と再処理抑止を同時に入れています。
- Unknowns to investigate before coding: VPS に role App installation id / private key をどう安全に配布するかは GO + passkey 領域で未実施。
- Validation needed: targeted node --test と npm test。secret 接続後に live PR Bot 表示確認が必要。
- Stop condition: marushu token を投稿用 fallback として使う変更、または incident を Butler/preflight で拾えないまま完了扱いする変更は drift。

## File / Line Hypotheses

- file: scripts/run-vps-runner.mjs
  - hypothesis: executeVpsReviewerFallback が runner token をそのまま fallback script に渡しているため marushu 投稿になる。
  - risk if changed narrowly: token 不足時にコメント嵐または黙った停止になる。
  - validation: actor identity incident 後に同一 requested comment を再処理しないテスト。
  - related Issue: Issue #351
- file: docs/security/github-app-actor-identity.md
  - hypothesis: VPS fallback writeback と incident visibility の契約が未記載。
  - risk if changed narrowly: 後続 AI が GitHub Actions workflow だけを見て VPS 経路を見落とす。
  - validation: actor identity doc tests と PR body mapping。
  - related Issue: Issue #351

## Hypothesis Retrospective

- expected: VPS fallback completed comment の actor が marushu になった原因は gh auth token の投稿転用。
- actual: scripts/run-vps-runner.mjs が buildRunnerCommandEnv に同じ token を渡していたため、仮説通り。
- mismatch: repo から installation id を自動解決する実装は今回入れていない。まず fail-closed と incident 可視化を優先。
- lesson: VTDD 復旧可能性では、正常系 actor だけでなく異常通知 actor と通知1行目も契約化する必要がある。
- should become RAG candidate: yes

## Verification Evidence

- Unit: node --test test/vps-runner-script.test.js test/github-app-actor-identity.test.js test/gemini-pr-review-workflow.test.js: pass (64 tests).
- Integration: npm test: pass (763 tests, 762 pass, 1 skip); check:self-parity pass; check:generated-worker pass.
- E2E: Live Bot表示 E2E は未実施。role App secrets / VPS credentials 接続後に必要。
- Manual: PR #368 の marushu 表示コメントを根拠に、VPS runner token 境界を確認。
- Evidence path/link: Local test output in this run.

## Butler Completion Contract

- Owner goal: VTDD が壊れた時でも、iPhone / Apple Watch / Butler / VPS から原因を見つけて復旧に進めること。
- Butler entrypoint: このPRでは Butler entrypoint は未変更。後続 Issue #344 で incident marker を startup preflight に接続する必要があります。
- Action Schema exposure: 不要。このPRは Action Schema を変更しません。
- Runtime path: VPS runner が Codex fallback requested marker を拾う runtime path。completed 投稿は Codex Fallback Reviewer App token、異常通知は VPS Codex CLI App token に分離。
- Runner/runtime truth: App token 不足時の incident body に expected actor / detected by / affected PR / head SHA / next action を残します。
- Authority boundary: marushu token による reviewer completed 代替投稿は禁止。secret 登録や credential mutation は GO + passkey のまま。
- E2E evidence: このPRスライスでは未接続。Butler startup preflight 接続は後続 Issue #344 側。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 不要。src/worker と worker.js は変更していません。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。通知1行目は日本語 @marushu 【要対応】形式でテスト済み。

## Related Constitution Rules

- Issue traceability: Issue #351。
- Authority boundary: credential mutation は GO + passkey。
- Recovery-first: actor identity failure を silent failure ではなく incident として残す。

## Out-of-scope but NOT implemented

- VPS credential 配布。
- Butler startup preflight 接続。
- GitHub App installation / permission mutation。

## Extra changes (if any)

src/** は変更していないため worker.js 再生成は不要です。

<!-- VTDD metadata -->
- Issue: Issue #351
- Execution ID: Not provided.
- Goal: Not provided.
