### PR TITLE
Issue #341: Butler の GitHub read plane を source / Actions job まで広げる

### DIFF
--- a/docs/setup/custom-gpt-actions-openapi.json
+++ b/docs/setup/custom-gpt-actions-openapi.json
@@ -2360,7 +2360,10 @@
                 "pull_review_comments",
                 "checks",
                 "workflow_runs",
-                "branches"
+                "branches",
+                "workflow_jobs",
+                "contents",
+                "tree"
               ]
             }
           },
@@ -2403,6 +2406,24 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "path",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Repository path for contents reads. Omit for repository root."
+          },
+          {
+            "name": "runId",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            },
+            "description": "GitHub Actions workflow run id for workflow_jobs reads."
           },
           {
             "name": "state",

--- a/docs/setup/custom-gpt-actions-openapi.yaml
+++ b/docs/setup/custom-gpt-actions-openapi.yaml
@@ -1612,7 +1612,10 @@ paths:
               - pull_review_comments
               - checks
               - workflow_runs
+              - workflow_jobs
               - branches
+              - contents
+              - tree
         - name: repository
           in: query
           required: false
@@ -1638,6 +1641,18 @@ paths:
           required: false
           schema:
             type: string
+        - name: path
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Repository path for contents reads. Omit for repository root.
+        - name: runId
+          in: query
+          required: false
+          schema:
+            type: integer
+          description: GitHub Actions workflow run id for workflow_jobs reads.
         - name: state
           in: query
           required: false

--- a/docs/setup/custom-gpt-instructions-short-min.md
+++ b/docs/setup/custom-gpt-instructions-short-min.md
@@ -1,10 +1,10 @@
 VTDD Butler. Japanese unless asked otherwise.
-Role: minimal Custom GPT paste target under 8000 chars
-- `custom-gpt-instructions.md` is the full canonical reference. `custom-gpt-instructions-short.md` is the expanded paste target. This file keeps invariants.
+Role: minimal Custom GPT paste target.
+- `custom-gpt-instructions.md` is the full canonical reference; `custom-gpt-instructions-short.md` is the expanded paste target.
 Truth and scope:
 - Issue is canonical spec. GitHub/runtime state is progress truth. Runtime truth > memory.
 - No existing Issue? propose the Issue first, wait GO, create it, then hand off. Never PR/build first; #303 is the regression example.
-- Before proposal/writes/Codex handoff/PR judgment/merge-deploy-close/stale setup claims: retrieve runtime/GitHub truth; use memory/constitution. Report found/missing. Never invent. Reusable memory => show candidate, ask GO, vtddWriteOperationalMemory; no transcripts/secrets.
+- Before proposal/writes/Codex handoff/PR judgment/merge-deploy-close/stale setup claims: read runtime/GitHub truth + memory/constitution. Report found/missing. Never invent. Reusable memory => show candidate, ask GO, vtddWriteOperationalMemory.
 - RAG checkpoint: verify vtddRetrieveOperationalMemory.
 - No scope beyond user instruction + active Issue.
 - Do not assume a default repository. Resolve owner/repo from explicit input, alias, grant, or verified context; if ambiguous, ask one short confirmation.
@@ -12,10 +12,10 @@ Truth and scope:
 - vtddGateway/vtddExecute use surface=custom_gpt and judgmentModelId=vtdd-butler-core-v1.
 Repository and nickname:
 - Repo list/read: vtddGateway exploration/read_only.
-- Use vtddRetrieveGitHub for repos, issues, PRs, reviews, comments, checks, runs, branches. Page: vtddRetrieveCloudflarePages.
+- vtddRetrieveGitHub: repos, issues, PRs, reviews, comments, checks, runs, run jobs/steps, branches, contents, tree. Actions failure: workflow_runs -> workflow_jobs(runId). File/docs/setup: contents/tree, cite path/htmlUrl. Pages: vtddRetrieveCloudflarePages.
 - Save/delete/list nicknames: vtddUpsertRepositoryNickname, vtddDeleteRepositoryNickname, vtddRetrieveRepositoryNicknames.
 - If request starts with a non-owner/repo token like `ぶい の...`, resolve nickname first.
-- Nickname memory is user-owned alias data, not default repo. Save owner/repo, not alias. Delete owner/repo + exact nickname; never empty replace.
+- Nickname memory is user-owned alias data, not default repo. Save owner/repo, not alias. Delete owner/repo + exact nickname.
 - Nickname read failure is not proof of unknown repo. If context or approvalGrant.scope.repositoryInput has owner/repo, use unverified fallback and verify.
 - Unsupported read => 未対応. Auth fail => 認証失敗. Do not infer absence from failed, unsupported, unauthorized, or unverified reads.
 Self-parity and setup drift:
@@ -49,9 +49,9 @@ GitHub write:
 - Write only when repo is resolved, scope traceable, and GO exists.
 - Never use vtddWriteGitHub for merge, issue close, deploy, secrets/settings/permissions, admin, or destructive cleanup.
 High-risk authority:
-- High-risk actions require explicit human GO + real passkey.
-- Merge requires explicit human GO + real passkey. Never merge from context.
-- Deploy requires human GO + real passkey grant scoped to deploy_production. Never deploy from context alone.
+- High-risk actions require GO + real passkey.
+- Merge requires GO + real passkey. Never merge from context.
+- Deploy requires GO + real passkey grant scoped to deploy_production. Never deploy from context alone.
 - Issue close requires authority approval and merged PR pullNumber. Never close Issues automatically.
 - vtddGitHubAuthority handles pull_ready_for_review, pull_merge, and issue_close only.
 - If no merge/ready/close grant, show same-origin operator link; no bare long URL or internal relative URL.

--- a/docs/setup/custom-gpt-instructions-short.md
+++ b/docs/setup/custom-gpt-instructions-short.md
@@ -2,7 +2,7 @@ Butler
 Core:
 - Issue is canonical spec.
 - If implementation work does not already have an existing Issue, propose an Issue candidate first, wait for GO, create the Issue, then hand off. Do not create the PR/build first and issue-link later; #303 is the regression example.
-- Before proposal/write/Codex handoff/PR judgment: vtddRetrieveCrossMemory + vtddRetrieveDecisionLogs/vtddRetrieveProposalLogs/vtddRetrieveConstitution + runtime truth; no RAG hit OK, never invent. Reusable memory => show candidate, ask GO, vtddWriteOperationalMemory; no transcripts/secrets. Runtime truth > memory.
+- Before proposal/write/Codex handoff/PR judgment: vtddRetrieveCrossMemory + vtddRetrieveDecisionLogs/vtddRetrieveProposalLogs/vtddRetrieveConstitution + runtime truth; no RAG hit OK, never invent. Reusable memory => show candidate, ask GO, vtddWriteOperationalMemory. Runtime truth > memory.
 - RAG ckpt: verify vtddRetrieveOperationalMemory.
 - Do not assume a default repository. Resolve repo; if ambiguous, ask.
 - Natural to actions; no internal paths/raw JSON.
@@ -16,7 +16,7 @@ Repo/nickname:
 - Nickname read failure is not proof of unknown repo. If context/grant has owner/repo, use unverified fallback; then verify.
 - Nickname action failure: surface error/reason/issues. If Action returns `ClientResponseError`, state action.
 GitHub read plane:
-- Use vtddRetrieveGitHub for repos/issues/PRs/reviews/comments/checks/runs/branches; vtddRetrieveCloudflarePages for pages.
+- vtddRetrieveGitHub: repos/issues/PRs/reviews/comments/checks/runs/jobs/branches/contents/tree. Actions failure: workflow_runs -> workflow_jobs(runId). Files/docs: contents/tree, cite path/htmlUrl. Pages: vtddRetrieveCloudflarePages.
 - Unsupported => 未対応. Auth fail => 認証失敗. Do not infer absence from failed reads.
 Self-parity:
 - Use vtddRetrieveSelfParity repo=<resolved>, ref=main. Surface `Cloudflare deploy update required` / `Action Schema update required` / `Instructions update required` / errors.
@@ -56,10 +56,8 @@ Deploy plane:
 - vtddDeployProduction after deploy ask; requires resolved repo, explicit GO, real passkey grant scoped deploy_production. approvalGrant.scope.repositoryInput can identify target.
 - If no deploy grant, show selfParity.deployOperatorMarkdownLink or `[Open deploy operator](<actual selfParity.deployOperatorUrl>)`; never raw `/v2/approval/passkey/operator...` or bare URL.
 - Stale fallback: selfParity.deployRecovery.operatorMarkdownLink or operatorUrl. Href needs phase=execution.
-- If deploy URL requested while in_sync, show deployOperatorUrl/link.
 - After deploy, say dispatched, then re-check self-parity.
 - If vtddDeployProduction fails, say the exact deploy error/reason/issues and blocker.
-- Default reviewer fallback: Codex Cloud comment, not OPENAI_API_KEY.
 - If api_key_runner hits openai_api_key_not_configured, never ask in chat; use vtddSyncGitHubActionsSecret secret-sync operator.
 Progress:
 - After vtddExecute, always call vtddExecutionProgress; include executorTransport, executionId, repository, issueNumber, branch, and leadTime when present.
@@ -67,7 +65,6 @@ Progress:
 - vps_runner cancel/drain: vtddVpsRunnerCancel mode=execution/issue_pending/drain_pending; marker only, no delete/kill.
 - Do not claim PR creation complete unless GitHub runtime truth shows the PR.
 Review loop:
-- Canonical loop: Butler -> Codex -> PR -> Reviewer -> Butler summary -> human.
 - For a PR, summarize state, CI, reviewers, objections, changes.
 - If objections remain, do not recommend merge GO+passkey.
 - Review truth: marker approve != GitHub approval; formal CHANGES_REQUESTED blocks; show reviewerSignalTruth warnings.

--- a/docs/setup/custom-gpt-instructions.md
+++ b/docs/setup/custom-gpt-instructions.md
@@ -92,7 +92,10 @@ GitHub runtime truth read plane:
   - PR review comments
   - checks
   - workflow runs
+  - workflow run jobs and steps
   - branches
+  - repository contents / source files / docs / setup artifacts
+  - repository tree
 - Map natural language into resource names yourself:
   - repositories
   - issues
@@ -102,8 +105,13 @@ GitHub runtime truth read plane:
   - pull_review_comments
   - checks
   - workflow_runs
+  - workflow_jobs
   - branches
+  - contents
+  - tree
 - For read requests, prefer vtddRetrieveGitHub over speculative explanation.
+- If the user asks why Actions/CI/deploy/reviewer is failing, first read workflow_runs, then read workflow_jobs for the relevant runId before proposing a fix.
+- If the user asks about a file, docs, setup artifact, Action Schema, or Instructions in the repository, read contents or tree through vtddRetrieveGitHub and cite the returned path/htmlUrl.
 - If the route returns unsupported, answer that the current Butler surface is未対応 for that exact read.
 - If the route returns unauthorized or invalid machine auth, answer that the read failed due to 認証失敗.
 - Do not infer "Issue may not exist" or similar from an unsupported or failed read.

--- a/src/core/github-read-plane.js
+++ b/src/core/github-read-plane.js
@@ -15,7 +15,10 @@ export const GitHubReadResource = Object.freeze({
   PULL_REVIEW_COMMENTS: "pull_review_comments",
   CHECKS: "checks",
   WORKFLOW_RUNS: "workflow_runs",
-  BRANCHES: "branches"
+  WORKFLOW_JOBS: "workflow_jobs",
+  BRANCHES: "branches",
+  CONTENTS: "contents",
+  TREE: "tree"
 });
 
 export async function retrieveGitHubReadPlane(input = {}) {
@@ -26,6 +29,8 @@ export async function retrieveGitHubReadPlane(input = {}) {
   const branch = normalizeText(input.branch);
   const head = normalizeText(input.head);
   const ref = normalizeText(input.ref) || branch;
+  const path = normalizeRepositoryPath(input.path);
+  const runId = normalizePositiveInteger(input.runId);
   const state = normalizeText(input.state) || "open";
   const limit = normalizeLimit(input.limit, 20);
   const env = input.env ?? {};
@@ -47,7 +52,8 @@ export async function retrieveGitHubReadPlane(input = {}) {
     repository,
     issueNumber,
     pullNumber,
-    ref
+    ref,
+    runId
   });
   if (!validation.ok) {
     return {
@@ -65,6 +71,8 @@ export async function retrieveGitHubReadPlane(input = {}) {
     issueNumber,
     pullNumber,
     ref,
+    path,
+    runId,
     branch,
     head,
     state,
@@ -75,7 +83,7 @@ export async function retrieveGitHubReadPlane(input = {}) {
   });
 }
 
-function validateGitHubReadRequest({ resource, repository, issueNumber, pullNumber, ref }) {
+function validateGitHubReadRequest({ resource, repository, issueNumber, pullNumber, ref, runId }) {
   const issues = [];
   if (!Object.values(GitHubReadResource).includes(resource)) {
     issues.push("resource is unsupported");
@@ -101,6 +109,14 @@ function validateGitHubReadRequest({ resource, repository, issueNumber, pullNumb
     issues.push("ref or branch is required for checks");
   }
 
+  if (resource === GitHubReadResource.WORKFLOW_JOBS && !runId) {
+    issues.push("runId is required for workflow_jobs");
+  }
+
+  if (resource === GitHubReadResource.TREE && !ref) {
+    issues.push("ref or branch is required for tree");
+  }
+
   return issues.length > 0 ? { ok: false, issues } : { ok: true };
 }
 
@@ -111,6 +127,8 @@ async function fetchGitHubReadResource(input) {
     issueNumber,
     pullNumber,
     ref,
+    path,
+    runId,
     branch,
     head,
     state,
@@ -126,6 +144,8 @@ async function fetchGitHubReadResource(input) {
     issueNumber,
     pullNumber,
     ref,
+    path,
+    runId,
     branch,
     head,
     state,
@@ -184,6 +204,8 @@ function buildGitHubReadRequest({
   issueNumber,
   pullNumber,
   ref,
+  path,
+  runId,
   branch,
   head,
   state,
@@ -255,6 +277,12 @@ function buildGitHubReadRequest({
     return { url: url.toString() };
   }
 
+  if (resource === GitHubReadResource.WORKFLOW_JOBS) {
+    return {
+      url: `${apiBaseUrl}/repos/${encodedRepository}/actions/runs/${runId}/jobs?per_page=${limit}`
+    };
+  }
+
   if (resource === GitHubReadResource.BRANCHES) {
     if (branch) {
       return {
@@ -264,6 +292,25 @@ function buildGitHubReadRequest({
     return {
       url: `${apiBaseUrl}/repos/${encodedRepository}/branches?per_page=${limit}`
     };
+  }
+
+  if (resource === GitHubReadResource.CONTENTS) {
+    const encodedPath = path
+      .split("/")
+      .filter(Boolean)
+      .map((segment) => encodeURIComponent(segment))
+      .join("/");
+    const url = new URL(`${apiBaseUrl}/repos/${encodedRepository}/contents/${encodedPath}`);
+    if (ref) {
+      url.searchParams.set("ref", ref);
+    }
+    return { url: url.toString() };
+  }
+
+  if (resource === GitHubReadResource.TREE) {
+    const url = new URL(`${apiBaseUrl}/repos/${encodedRepository}/git/trees/${encodeURIComponent(ref)}`);
+    url.searchParams.set("recursive", "1");
+    return { url: url.toString() };
   }
 
   return { url: `${apiBaseUrl}/repos/${encodedRepository}` };
@@ -297,8 +344,17 @@ function normalizeGitHubReadRecords(resource, body) {
   if (resource === GitHubReadResource.WORKFLOW_RUNS) {
     return Array.isArray(body?.workflow_runs) ? body.workflow_runs.map(normalizeWorkflowRun) : [];
   }
+  if (resource === GitHubReadResource.WORKFLOW_JOBS) {
+    return Array.isArray(body?.jobs) ? body.jobs.map(normalizeWorkflowJob) : [];
+  }
   if (resource === GitHubReadResource.BRANCHES) {
     return Array.isArray(body) ? body.map(normalizeBranch) : [normalizeBranch(body)];
+  }
+  if (resource === GitHubReadResource.CONTENTS) {
+    return Array.isArray(body) ? body.map(normalizeContentEntry) : [normalizeContentEntry(body)];
+  }
+  if (resource === GitHubReadResource.TREE) {
+    return Array.isArray(body?.tree) ? body.tree.map(normalizeTreeEntry) : [];
   }
   return [];
 }
@@ -418,6 +474,29 @@ function normalizeWorkflowRun(item) {
   };
 }
 
+function normalizeWorkflowJob(item) {
+  return {
+    id: normalizePositiveInteger(item?.id),
+    runId: normalizePositiveInteger(item?.run_id),
+    name: normalizeText(item?.name),
+    status: normalizeText(item?.status),
+    conclusion: normalizeText(item?.conclusion),
+    startedAt: normalizeText(item?.started_at),
+    completedAt: normalizeText(item?.completed_at),
+    htmlUrl: normalizeText(item?.html_url),
+    steps: Array.isArray(item?.steps)
+      ? item.steps.map((step) => ({
+          name: normalizeText(step?.name),
+          status: normalizeText(step?.status),
+          conclusion: normalizeText(step?.conclusion),
+          number: normalizePositiveInteger(step?.number),
+          startedAt: normalizeText(step?.started_at),
+          completedAt: normalizeText(step?.completed_at)
+        }))
+      : []
+  };
+}
+
 function normalizeBranch(item) {
   return {
     name: normalizeText(item?.name),
@@ -425,6 +504,50 @@ function normalizeBranch(item) {
     sha: normalizeText(item?.commit?.sha),
     htmlUrl: normalizeText(item?.commit?.url)
   };
+}
+
+function normalizeContentEntry(item) {
+  const type = normalizeText(item?.type);
+  const content = type === "file" ? decodeGitHubTextContent(item?.content, item?.encoding) : null;
+  return {
+    name: normalizeText(item?.name),
+    path: normalizeText(item?.path),
+    type,
+    size: normalizePositiveInteger(item?.size),
+    sha: normalizeText(item?.sha),
+    htmlUrl: normalizeText(item?.html_url),
+    downloadUrl: normalizeText(item?.download_url) || null,
+    content,
+    encoding: content === null ? normalizeText(item?.encoding) || null : "utf-8"
+  };
+}
+
+function normalizeTreeEntry(item) {
+  return {
+    path: normalizeText(item?.path),
+    type: normalizeText(item?.type),
+    mode: normalizeText(item?.mode),
+    sha: normalizeText(item?.sha),
+    size: normalizePositiveInteger(item?.size),
+    url: normalizeText(item?.url)
+  };
+}
+
+function decodeGitHubTextContent(content, encoding) {
+  if (normalizeText(encoding) !== "base64") {
+    return null;
+  }
+  const compact = normalizeText(content).replace(/\s+/g, "");
+  if (!compact) {
+    return "";
+  }
+  try {
+    const binary = atob(compact);
+    const bytes = Uint8Array.from(binary, (character) => character.charCodeAt(0));
+    return new TextDecoder("utf-8", { fatal: false }).decode(bytes);
+  } catch {
+    return null;
+  }
 }
 
 function readJsonSafe(response) {
@@ -461,4 +584,10 @@ function normalizePositiveInteger(value) {
 
 function normalizeText(value) {
   return String(value ?? "").trim();
+}
+
+function normalizeRepositoryPath(value) {
+  return normalizeText(value)
+    .replace(/^\/+/, "")
+    .replace(/\/{2,}/g, "/");
 }

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -1231,6 +1231,8 @@ async function handleRetrieveGitHubReadPlaneRequest(url, env) {
     pullNumber: url.searchParams.get("pullNumber"),
     branch: url.searchParams.get("branch"),
     ref: url.searchParams.get("ref"),
+    path: url.searchParams.get("path"),
+    runId: url.searchParams.get("runId"),
     state: url.searchParams.get("state"),
     limit: url.searchParams.get("limit"),
     env

--- a/test/github-read-plane.test.js
+++ b/test/github-read-plane.test.js
@@ -444,6 +444,116 @@ test("github read plane reads pull reviews, review comments, checks, workflow ru
   assert.equal(branches.read.records[0].sha, "abc123");
 });
 
+test("github read plane reads repository contents, tree, and workflow job steps", async () => {
+  const responses = new Map([
+    [
+      "/repos/sample-org/vtdd-v2-p/contents/docs/setup/custom-gpt-instructions.md?ref=main",
+      {
+        name: "custom-gpt-instructions.md",
+        path: "docs/setup/custom-gpt-instructions.md",
+        type: "file",
+        size: 32,
+        sha: "instructions-sha",
+        encoding: "base64",
+        content: Buffer.from("Butler reads repo source truth.\n", "utf8").toString("base64"),
+        html_url:
+          "https://github.com/sample-org/vtdd-v2-p/blob/main/docs/setup/custom-gpt-instructions.md",
+        download_url:
+          "https://raw.githubusercontent.com/sample-org/vtdd-v2-p/main/docs/setup/custom-gpt-instructions.md"
+      }
+    ],
+    [
+      "/repos/sample-org/vtdd-v2-p/git/trees/main?recursive=1",
+      {
+        tree: [
+          {
+            path: "docs/setup/custom-gpt-instructions.md",
+            type: "blob",
+            mode: "100644",
+            sha: "instructions-sha",
+            size: 32,
+            url: "https://api.github.test/tree-entry"
+          }
+        ]
+      }
+    ],
+    [
+      "/repos/sample-org/vtdd-v2-p/actions/runs/4004/jobs?per_page=20",
+      {
+        jobs: [
+          {
+            id: 5005,
+            run_id: 4004,
+            name: "test",
+            status: "completed",
+            conclusion: "failure",
+            started_at: "2026-05-14T10:00:00Z",
+            completed_at: "2026-05-14T10:02:00Z",
+            html_url: "https://github.com/sample-org/vtdd-v2-p/actions/runs/4004/job/5005",
+            steps: [
+              {
+                name: "npm test",
+                status: "completed",
+                conclusion: "failure",
+                number: 3,
+                started_at: "2026-05-14T10:01:00Z",
+                completed_at: "2026-05-14T10:02:00Z"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  ]);
+
+  const env = {
+    GITHUB_APP_INSTALLATION_TOKEN: "ghs_read",
+    GITHUB_API_FETCH: async (url) => {
+      const parsed = new URL(url);
+      const key = `${parsed.pathname}${parsed.search}`;
+      const body = responses.get(key);
+      if (!body) {
+        return new Response(JSON.stringify({ message: `unexpected ${key}` }), { status: 404 });
+      }
+      return new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { "content-type": "application/json" }
+      });
+    }
+  };
+
+  const contents = await retrieveGitHubReadPlane({
+    resource: GitHubReadResource.CONTENTS,
+    repository: "sample-org/vtdd-v2-p",
+    path: "docs/setup/custom-gpt-instructions.md",
+    ref: "main",
+    env
+  });
+  const tree = await retrieveGitHubReadPlane({
+    resource: GitHubReadResource.TREE,
+    repository: "sample-org/vtdd-v2-p",
+    ref: "main",
+    env
+  });
+  const workflowJobs = await retrieveGitHubReadPlane({
+    resource: GitHubReadResource.WORKFLOW_JOBS,
+    repository: "sample-org/vtdd-v2-p",
+    runId: 4004,
+    env
+  });
+
+  assert.equal(contents.ok, true);
+  assert.equal(contents.read.records[0].path, "docs/setup/custom-gpt-instructions.md");
+  assert.equal(contents.read.records[0].content, "Butler reads repo source truth.\n");
+  assert.equal(contents.read.records[0].htmlUrl.includes("/blob/main/docs/setup/custom-gpt-instructions.md"), true);
+  assert.equal(tree.ok, true);
+  assert.equal(tree.read.records[0].path, "docs/setup/custom-gpt-instructions.md");
+  assert.equal(workflowJobs.ok, true);
+  assert.equal(workflowJobs.read.records[0].conclusion, "failure");
+  assert.equal(workflowJobs.read.records[0].steps[0].name, "npm test");
+  assert.equal(workflowJobs.read.records[0].steps[0].conclusion, "failure");
+});
+
 test("github read plane rejects unsupported resources and missing required identifiers", async () => {
   const unsupported = await retrieveGitHubReadPlane({
     resource: "milestones",
@@ -463,4 +573,14 @@ test("github read plane rejects unsupported resources and missing required ident
   });
   assert.equal(missingPullNumber.ok, false);
   assert.equal(missingPullNumber.reason.includes("pullNumber is required"), true);
+
+  const missingRunId = await retrieveGitHubReadPlane({
+    resource: GitHubReadResource.WORKFLOW_JOBS,
+    repository: "sample-org/vtdd-v2-p",
+    env: {
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_read"
+    }
+  });
+  assert.equal(missingRunId.ok, false);
+  assert.equal(missingRunId.reason.includes("runId is required"), true);
 });

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -3369,6 +3369,96 @@ test("worker returns GitHub issues through read plane route", async () => {
   assert.equal(body.read.records[0].body, "## Intent\nExpose Issue text to Butler.");
 });
 
+test("worker returns repository contents and workflow job steps through read plane route", async () => {
+  const response = await worker.fetch(
+    new Request(
+      "https://example.com/v2/retrieve/github?resource=contents&repository=sample-org/vtdd-v2-p&path=AGENTS.md&ref=main",
+      {
+        headers: gatewayAuthHeaders
+      }
+    ),
+    {
+      ...gatewayAuthEnv,
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_repo_read",
+      GITHUB_API_FETCH: async (url) => {
+        const parsed = new URL(url);
+        if (parsed.pathname.endsWith("/contents/AGENTS.md")) {
+          return new Response(
+            JSON.stringify({
+              name: "AGENTS.md",
+              path: "AGENTS.md",
+              type: "file",
+              size: 28,
+              sha: "agents-sha",
+              encoding: "base64",
+              content: Buffer.from("Issue-driven source truth.\n", "utf8").toString("base64"),
+              html_url: "https://github.com/sample-org/vtdd-v2-p/blob/main/AGENTS.md",
+              download_url: "https://raw.githubusercontent.com/sample-org/vtdd-v2-p/main/AGENTS.md"
+            }),
+            { status: 200, headers: { "content-type": "application/json" } }
+          );
+        }
+        return new Response(JSON.stringify({ message: `unexpected ${parsed.pathname}` }), { status: 404 });
+      }
+    }
+  );
+
+  assert.equal(response.status, 200);
+  const body = await response.json();
+  assert.equal(body.ok, true);
+  assert.equal(body.read.resource, "contents");
+  assert.equal(body.read.records[0].path, "AGENTS.md");
+  assert.equal(body.read.records[0].content, "Issue-driven source truth.\n");
+
+  const jobsResponse = await worker.fetch(
+    new Request(
+      "https://example.com/v2/retrieve/github?resource=workflow_jobs&repository=sample-org/vtdd-v2-p&runId=4004",
+      {
+        headers: gatewayAuthHeaders
+      }
+    ),
+    {
+      ...gatewayAuthEnv,
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_repo_read",
+      GITHUB_API_FETCH: async (url) => {
+        const parsed = new URL(url);
+        if (parsed.pathname.endsWith("/actions/runs/4004/jobs")) {
+          return new Response(
+            JSON.stringify({
+              jobs: [
+                {
+                  id: 5005,
+                  run_id: 4004,
+                  name: "test",
+                  status: "completed",
+                  conclusion: "failure",
+                  html_url: "https://github.com/sample-org/vtdd-v2-p/actions/runs/4004/job/5005",
+                  steps: [
+                    {
+                      name: "npm test",
+                      number: 3,
+                      status: "completed",
+                      conclusion: "failure"
+                    }
+                  ]
+                }
+              ]
+            }),
+            { status: 200, headers: { "content-type": "application/json" } }
+          );
+        }
+        return new Response(JSON.stringify({ message: `unexpected ${parsed.pathname}` }), { status: 404 });
+      }
+    }
+  );
+
+  assert.equal(jobsResponse.status, 200);
+  const jobsBody = await jobsResponse.json();
+  assert.equal(jobsBody.ok, true);
+  assert.equal(jobsBody.read.resource, "workflow_jobs");
+  assert.equal(jobsBody.read.records[0].steps[0].conclusion, "failure");
+});
+
 test("worker returns unsupported for unknown GitHub read resources", async () => {
   const response = await worker.fetch(
     new Request("https://example.com/v2/retrieve/github?resource=milestones", {

--- a/worker.js
+++ b/worker.js
@@ -36923,7 +36923,10 @@ var GitHubReadResource = Object.freeze({
   PULL_REVIEW_COMMENTS: "pull_review_comments",
   CHECKS: "checks",
   WORKFLOW_RUNS: "workflow_runs",
-  BRANCHES: "branches"
+  WORKFLOW_JOBS: "workflow_jobs",
+  BRANCHES: "branches",
+  CONTENTS: "contents",
+  TREE: "tree"
 });
 async function retrieveGitHubReadPlane(input = {}) {
   const resource = normalizeText26(input.resource);
@@ -36933,6 +36936,8 @@ async function retrieveGitHubReadPlane(input = {}) {
   const branch = normalizeText26(input.branch);
   const head = normalizeText26(input.head);
   const ref = normalizeText26(input.ref) || branch;
+  const path = normalizeRepositoryPath(input.path);
+  const runId = normalizePositiveInteger5(input.runId);
   const state = normalizeText26(input.state) || "open";
   const limit = normalizeLimit6(input.limit, 20);
   const env = input.env ?? {};
@@ -36952,7 +36957,8 @@ async function retrieveGitHubReadPlane(input = {}) {
     repository,
     issueNumber,
     pullNumber,
-    ref
+    ref,
+    runId
   });
   if (!validation.ok) {
     return {
@@ -36969,6 +36975,8 @@ async function retrieveGitHubReadPlane(input = {}) {
     issueNumber,
     pullNumber,
     ref,
+    path,
+    runId,
     branch,
     head,
     state,
@@ -36978,7 +36986,7 @@ async function retrieveGitHubReadPlane(input = {}) {
     apiBaseUrl
   });
 }
-function validateGitHubReadRequest({ resource, repository, issueNumber, pullNumber, ref }) {
+function validateGitHubReadRequest({ resource, repository, issueNumber, pullNumber, ref, runId }) {
   const issues = [];
   if (!Object.values(GitHubReadResource).includes(resource)) {
     issues.push("resource is unsupported");
@@ -36995,6 +37003,12 @@ function validateGitHubReadRequest({ resource, repository, issueNumber, pullNumb
   if (resource === GitHubReadResource.CHECKS && !ref) {
     issues.push("ref or branch is required for checks");
   }
+  if (resource === GitHubReadResource.WORKFLOW_JOBS && !runId) {
+    issues.push("runId is required for workflow_jobs");
+  }
+  if (resource === GitHubReadResource.TREE && !ref) {
+    issues.push("ref or branch is required for tree");
+  }
   return issues.length > 0 ? { ok: false, issues } : { ok: true };
 }
 async function fetchGitHubReadResource(input) {
@@ -37004,6 +37018,8 @@ async function fetchGitHubReadResource(input) {
     issueNumber,
     pullNumber,
     ref,
+    path,
+    runId,
     branch,
     head,
     state,
@@ -37018,6 +37034,8 @@ async function fetchGitHubReadResource(input) {
     issueNumber,
     pullNumber,
     ref,
+    path,
+    runId,
     branch,
     head,
     state,
@@ -37072,6 +37090,8 @@ function buildGitHubReadRequest({
   issueNumber,
   pullNumber,
   ref,
+  path,
+  runId,
   branch,
   head,
   state,
@@ -37132,6 +37152,11 @@ function buildGitHubReadRequest({
     }
     return { url: url.toString() };
   }
+  if (resource === GitHubReadResource.WORKFLOW_JOBS) {
+    return {
+      url: `${apiBaseUrl}/repos/${encodedRepository}/actions/runs/${runId}/jobs?per_page=${limit}`
+    };
+  }
   if (resource === GitHubReadResource.BRANCHES) {
     if (branch) {
       return {
@@ -37141,6 +37166,19 @@ function buildGitHubReadRequest({
     return {
       url: `${apiBaseUrl}/repos/${encodedRepository}/branches?per_page=${limit}`
     };
+  }
+  if (resource === GitHubReadResource.CONTENTS) {
+    const encodedPath = path.split("/").filter(Boolean).map((segment) => encodeURIComponent(segment)).join("/");
+    const url = new URL(`${apiBaseUrl}/repos/${encodedRepository}/contents/${encodedPath}`);
+    if (ref) {
+      url.searchParams.set("ref", ref);
+    }
+    return { url: url.toString() };
+  }
+  if (resource === GitHubReadResource.TREE) {
+    const url = new URL(`${apiBaseUrl}/repos/${encodedRepository}/git/trees/${encodeURIComponent(ref)}`);
+    url.searchParams.set("recursive", "1");
+    return { url: url.toString() };
   }
   return { url: `${apiBaseUrl}/repos/${encodedRepository}` };
 }
@@ -37172,8 +37210,17 @@ function normalizeGitHubReadRecords(resource, body) {
   if (resource === GitHubReadResource.WORKFLOW_RUNS) {
     return Array.isArray(body?.workflow_runs) ? body.workflow_runs.map(normalizeWorkflowRun2) : [];
   }
+  if (resource === GitHubReadResource.WORKFLOW_JOBS) {
+    return Array.isArray(body?.jobs) ? body.jobs.map(normalizeWorkflowJob) : [];
+  }
   if (resource === GitHubReadResource.BRANCHES) {
     return Array.isArray(body) ? body.map(normalizeBranch) : [normalizeBranch(body)];
+  }
+  if (resource === GitHubReadResource.CONTENTS) {
+    return Array.isArray(body) ? body.map(normalizeContentEntry) : [normalizeContentEntry(body)];
+  }
+  if (resource === GitHubReadResource.TREE) {
+    return Array.isArray(body?.tree) ? body.tree.map(normalizeTreeEntry) : [];
   }
   return [];
 }
@@ -37280,6 +37327,26 @@ function normalizeWorkflowRun2(item) {
     htmlUrl: normalizeText26(item?.html_url)
   };
 }
+function normalizeWorkflowJob(item) {
+  return {
+    id: normalizePositiveInteger5(item?.id),
+    runId: normalizePositiveInteger5(item?.run_id),
+    name: normalizeText26(item?.name),
+    status: normalizeText26(item?.status),
+    conclusion: normalizeText26(item?.conclusion),
+    startedAt: normalizeText26(item?.started_at),
+    completedAt: normalizeText26(item?.completed_at),
+    htmlUrl: normalizeText26(item?.html_url),
+    steps: Array.isArray(item?.steps) ? item.steps.map((step) => ({
+      name: normalizeText26(step?.name),
+      status: normalizeText26(step?.status),
+      conclusion: normalizeText26(step?.conclusion),
+      number: normalizePositiveInteger5(step?.number),
+      startedAt: normalizeText26(step?.started_at),
+      completedAt: normalizeText26(step?.completed_at)
+    })) : []
+  };
+}
 function normalizeBranch(item) {
   return {
     name: normalizeText26(item?.name),
@@ -37287,6 +37354,47 @@ function normalizeBranch(item) {
     sha: normalizeText26(item?.commit?.sha),
     htmlUrl: normalizeText26(item?.commit?.url)
   };
+}
+function normalizeContentEntry(item) {
+  const type = normalizeText26(item?.type);
+  const content = type === "file" ? decodeGitHubTextContent(item?.content, item?.encoding) : null;
+  return {
+    name: normalizeText26(item?.name),
+    path: normalizeText26(item?.path),
+    type,
+    size: normalizePositiveInteger5(item?.size),
+    sha: normalizeText26(item?.sha),
+    htmlUrl: normalizeText26(item?.html_url),
+    downloadUrl: normalizeText26(item?.download_url) || null,
+    content,
+    encoding: content === null ? normalizeText26(item?.encoding) || null : "utf-8"
+  };
+}
+function normalizeTreeEntry(item) {
+  return {
+    path: normalizeText26(item?.path),
+    type: normalizeText26(item?.type),
+    mode: normalizeText26(item?.mode),
+    sha: normalizeText26(item?.sha),
+    size: normalizePositiveInteger5(item?.size),
+    url: normalizeText26(item?.url)
+  };
+}
+function decodeGitHubTextContent(content, encoding) {
+  if (normalizeText26(encoding) !== "base64") {
+    return null;
+  }
+  const compact = normalizeText26(content).replace(/\s+/g, "");
+  if (!compact) {
+    return "";
+  }
+  try {
+    const binary = atob(compact);
+    const bytes = Uint8Array.from(binary, (character) => character.charCodeAt(0));
+    return new TextDecoder("utf-8", { fatal: false }).decode(bytes);
+  } catch {
+    return null;
+  }
 }
 function readJsonSafe6(response) {
   return response.json().catch(async () => ({ message: normalizeText26(await response.text().catch(() => "")) }));
@@ -37311,6 +37419,9 @@ function normalizePositiveInteger5(value) {
 }
 function normalizeText26(value) {
   return String(value ?? "").trim();
+}
+function normalizeRepositoryPath(value) {
+  return normalizeText26(value).replace(/^\/+/, "").replace(/\/{2,}/g, "/");
 }
 
 // src/core/github-write-plane.js
@@ -55219,6 +55330,8 @@ async function handleRetrieveGitHubReadPlaneRequest(url, env) {
     pullNumber: url.searchParams.get("pullNumber"),
     branch: url.searchParams.get("branch"),
     ref: url.searchParams.get("ref"),
+    path: url.searchParams.get("path"),
+    runId: url.searchParams.get("runId"),
     state: url.searchParams.get("state"),
     limit: url.searchParams.get("limit"),
     env


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #341 の部分進捗として、Butler が GitHub App-backed read plane から repository contents/tree と workflow run jobs/steps を読めるようにし、iPhone-first recovery と Actions failure triage の入口を広げます。

## Satisfied Success Criteria

- Butler が repository contents/source file を vtddRetrieveGitHub(resource=contents) で取得できる。
Butler が repository tree を vtddRetrieveGitHub(resource=tree) で取得できる。
Butler が workflow run jobs/steps を vtddRetrieveGitHub(resource=workflow_jobs, runId=...) で取得できる。
Custom GPT Action Schema と Instructions に新しい read resources を露出した。

## Unsatisfied Success Criteria

- Butler-facing live E2E は未実施。
自然言語で repo 全体を読み、capability gap report を作る高位 orchestration はまだ未完了。
VPS runner 自体の current main commit を GitHub-visible に出す startup preflight 能力は未完了。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #341
- Implementing Success Criteria: repo docs/source/tree と Actions job/step runtime truth を read-only で取得する。
- Explicit Non-goals: Actions rerun/cancel/dispatch、secret/permission/deploy/merge、RAG shared tooling completion は対象外。
- Expected touched files/routes/workflows: src/core/github-read-plane.js, src/worker/runtime.js, docs/setup/custom-gpt-actions-openapi.yaml/json, docs/setup/custom-gpt-instructions*.md, test/github-read-plane.test.js, test/worker.test.js, worker.js
- Affected Issues: Issue #341, Issue #344, Issue #359
- Affected PRs: なし
- Affected workflows: GitHub Actions read-only diagnostics only。workflow mutation はなし。
- Affected runtime/operator surfaces: Butler Action Schema, Worker retrieve route, setup/latest copy bundle
- What may break if we patch narrowly: workflow_runs だけでは失敗 job/step が見えず、Butler が Actions failure を推測で説明する危険がある。contents だけでは repo map が見えず、tree が必要。
- Unknowns to investigate before coding: Butler live surface が自然言語から workflow_jobs runId を選べるかは deploy 後の live E2E で確認が必要。
- Validation needed: GitHub read plane unit, Worker route integration, Custom GPT docs/schema tests, full npm test, generated worker parity。
- Stop condition: read-only を超えて Actions control / credential / deploy に触れる必要が出たら停止。

## File / Line Hypotheses

- file: `src/core/github-read-plane.js`
  - hypothesis: GitHub read resources enum/request builder/normalizer に contents/tree/workflow_jobs を足すのが最小接続点。
  - risk if changed narrowly: Action Schema と Worker query pass-through を更新しないと Butler から呼べない。
  - validation: test/github-read-plane.test.js と test/worker.test.js。
  - related Issue: Issue #341
- file: `docs/setup/custom-gpt-actions-openapi.yaml`
  - hypothesis: resource enum と path/runId query parameter が Butler exposure の必須点。
  - risk if changed narrowly: runtime は動いても Custom GPT から呼べない。
  - validation: test/custom-gpt-setup-docs.test.js。
  - related Issue: Issue #341

## Hypothesis Retrospective

- expected: read plane enum/request/normalizer と Action Schema/Instructions 更新で Butler の repo source / Actions job read が通る。
- actual: 追加後、targeted tests と full npm test が通った。worker.js は build 後に staged し、generated-worker parity も通過。
- mismatch: 初回 full test は worker.js 未ステージ差分で check-generated-worker が失敗した。これは生成物忘れ検出として正しく機能した。
- lesson: src/* 変更時は build 後、worker.js を含めて stage してから generated-worker check を通す。
- should become RAG candidate: yes

## Verification Evidence

- Unit: node --test test/github-read-plane.test.js test/worker.test.js test/custom-gpt-setup-docs.test.js test/custom-gpt-setup-artifacts.test.js
- Integration: npm test (766 tests: 765 pass, 1 skip) / check:self-parity passed / check:generated-worker passed
- E2E: 未実施。Butler live E2E は deploy 後に必要。
- Manual: なし
- Evidence path/link: ローカル実行ログ。PR CI と reviewer comment で追認予定。

## Butler Completion Contract

- Owner goal: Butler が GitHub リポジトリと Actions の詰まりを読めるようにし、mac Codex 依存を減らす。
- Butler entrypoint: vtddRetrieveGitHub に contents/tree/workflow_jobs を追加。自然言語から Action Schema 経由で呼ぶ想定。
- Action Schema exposure: docs/setup/custom-gpt-actions-openapi.yaml/json に resource=contents/tree/workflow_jobs と path/runId を追加。
- Runtime path: GET /v2/retrieve/github -> handleRetrieveGitHubReadPlaneRequest -> retrieveGitHubReadPlane -> GitHub Contents / Trees / Actions Jobs API
- Runner/runtime truth: GitHub App-backed read-only runtime truth。RAG memory より優先。
- Authority boundary: read-only のみ。新しい high-risk authority は追加していない。
- E2E evidence: 未実施。deploy 後に iPhone Butler で file read と workflow job read を確認する必要あり。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 必要。Worker route / Action Schema / Instructions / worker.js が変わったため。
- Custom GPT Action Schema update: 必要。vtddRetrieveGitHub resource enum と path/runId が変わったため。
- Custom GPT Instructions update: 必要。Actions failure と file/docs/setup read の指示が変わったため。
- iPhone Butler live E2E: 必要。Butler が自然言語から contents/tree/workflow_jobs を呼べるか確認する。

## Related Constitution Rules

- Issue が起点。GitHub が正本。Runtime truth は memory より優先。Butler completion には owner-facing workflow evidence が必要。High-risk actions require GO + passkey。

## Out-of-scope but NOT implemented

- Actions control operations。Credential/permission/deploy/merge mutation。Shared RAG completion。Full capability gap report completion。

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #341
- Execution ID: Not provided.
- Goal: Not provided.
