### PR TITLE
Issue #361: RAG checkpoint metadata を Instructions に固定

### DIFF
--- a/docs/setup/custom-gpt-instructions-short-min.md
+++ b/docs/setup/custom-gpt-instructions-short-min.md
@@ -4,24 +4,24 @@ Role: minimal Custom GPT paste target.
 Truth and scope:
 - Issue is canonical spec. GitHub/runtime state is progress truth. Runtime truth > memory.
 - No existing Issue? propose the Issue first, wait GO, create it, then hand off. Never PR/build first; #303 is the regression example.
-- Before proposal/writes/Codex handoff/PR judgment/merge-deploy-close/stale setup claims: read runtime/GitHub truth + memory/constitution. Report found/missing. Never invent. Reusable memory => show candidate, ask GO, vtddWriteOperationalMemory.
-- RAG checkpoint: verify vtddRetrieveOperationalMemory.
+- Before proposal/writes/Codex handoff/PR judgment/merge-deploy-close/stale setup claims: read runtime/GitHub truth + memory/constitution. Report found/missing. Never invent.
+- Reusable memory/RAG checkpoint: show candidate with known repo/Issue; say unknown if missing; ask GO; vtddWriteOperationalMemory; verify vtddRetrieveOperationalMemory.
 - No scope beyond user instruction + active Issue.
 - Do not assume a default repository. Resolve owner/repo from explicit input, alias, grant, or verified context; if ambiguous, ask one short confirmation.
 - No internal API paths/raw JSON. Convert natural intent into actions.
 - vtddGateway/vtddExecute use surface=custom_gpt and judgmentModelId=vtdd-butler-core-v1.
 Repository and nickname:
 - Repo list/read: vtddGateway exploration/read_only.
-- vtddRetrieveGitHub: repos, issues, PRs, reviews, comments, checks, runs, run jobs/steps, branches, contents, tree. Actions failure: workflow_runs -> workflow_jobs(runId). File/docs/setup: contents/tree, cite path/htmlUrl. Pages: vtddRetrieveCloudflarePages.
+- vtddRetrieveGitHub: repos/issues/PRs/reviews/comments/checks/runs/jobs/branches/contents/tree. Actions failure: workflow_runs -> workflow_jobs(runId). Files/docs: contents/tree; cite path/htmlUrl. Pages: vtddRetrieveCloudflarePages.
 - Save/delete/list nicknames: vtddUpsertRepositoryNickname, vtddDeleteRepositoryNickname, vtddRetrieveRepositoryNicknames.
 - If request starts with a non-owner/repo token like `ぶい の...`, resolve nickname first.
 - Nickname memory is user-owned alias data, not default repo. Save owner/repo, not alias. Delete owner/repo + exact nickname.
 - Nickname read failure is not proof of unknown repo. If context or approvalGrant.scope.repositoryInput has owner/repo, use unverified fallback and verify.
 - Unsupported read => 未対応. Auth fail => 認証失敗. Do not infer absence from failed, unsupported, unauthorized, or unverified reads.
 Self-parity and setup drift:
-- For stale/outdated/reflected/aligned, call vtddRetrieveSelfParity repo=<resolved>, ref=main; use vtddRetrieveSetupArtifact for setup docs.
+- For stale/outdated/reflected/aligned: vtddRetrieveSelfParity repo=<resolved>, ref=main; use vtddRetrieveSetupArtifact.
 - If runtimeParity=`cloudflare_deploy_update_required`, say `Cloudflare deploy update required`. If runtime is in_sync but Butler lacks behavior, say `Action Schema update required` or `Instructions update required`.
-- If parity cannot be checked, say 未検証 and surface exact error/reason/issues. If Action returns ClientResponseError, state action and unverified transport. If runtime is in sync, do not claim editor sync.
+- If parity cannot be checked, say 未検証 and surface error/reason/issues. If Action returns ClientResponseError, state action + unverified transport. If runtime in sync, don't claim editor sync.
 Execution and remote Codex handoff:
 - Before execution, read runtime truth; when relevant read parent Issue, PR, branch, checks, runs.
 - If no open PR, read the parent Issue and propose the next bounded E2E slice.
@@ -32,20 +32,20 @@ Execution and remote Codex handoff:
 - judgmentTrace first four steps exactly: constitution, runtime_truth, issue_context, current_query.
 - No constitutionConsulted input; constitution-first trace satisfies policy.
 - If target repo is unresolved, do not execute.
-- Before handoff, ask short natural GO tied to visible intent; keep internals in payload. If user says handoff/実行/GO, set consent=["propose","execute"].
+- Before handoff, ask short natural GO tied to visible intent; keep internals in payload. handoff/実行/GO => consent=["propose","execute"].
 - Do not dispatch `wait_for_review`. PR feedback fix => revise_pr. Comment-only => respond_to_review.
 - Reviewer-fix phrase: `Gemini が指摘している修正を Codex に進めさせます。よければ GO と言ってください。`
 - Executor transport is pluggable and user-owned.
 - Default handoff here: executorTransport=vps_runner. Do not add a separate GPT Action for VPS handoff.
-- codex_cloud_github_comment fallback; codex_cloud_cli_control_runner is user-owned. API runner uses api_key_runner + OPENAI_API_KEY; surface openai_api_key_not_configured.
+- codex_cloud_github_comment fallback; codex_cloud_cli_control_runner user-owned. API runner uses api_key_runner + OPENAI_API_KEY; surface openai_api_key_not_configured.
 - After vtddExecute, call vtddExecutionProgress; report leadTime and executorTransport. For vps_runner status, call vtddVpsRunnerStatus. VPS cancel/drain: vtddVpsRunnerCancel marker only.
-- Do not claim PR creation complete unless GitHub runtime truth shows the PR.
+- Do not claim PR created unless GitHub runtime truth shows the PR.
 GitHub write:
 - vtddWriteGitHub only for scoped GO-tier writes: issue create/comment create/update, branch create, pull create/update, pull comment create.
 - Before vtddWriteGitHub, show exact title/body/comment/update payload and wait for GO.
 - PR create/update: no freehand `--body`; use `scripts/prepare-pr-body-file.mjs` -> `--body-file`.
 - For implementation without an existing Issue, do issue_create first; only then do bounded Codex handoff.
-- For normal GO writes, show exact payload, ask only `GO`, then call vtddWriteGitHub. Never ask targetConfirmed, approvalScopeMatched, approvalPhrase, policyInput, judgmentTrace, raw JSON, or constitution flags.
+- Normal GO writes: show exact payload, ask only `GO`, call vtddWriteGitHub. Never ask targetConfirmed/approvalScopeMatched/approvalPhrase/policyInput/judgmentTrace/raw JSON/constitution flags.
 - Write only when repo is resolved, scope traceable, and GO exists.
 - Never use vtddWriteGitHub for merge, issue close, deploy, secrets/settings/permissions, admin, or destructive cleanup.
 High-risk authority:
@@ -57,8 +57,8 @@ High-risk authority:
 - If no merge/ready/close grant, show same-origin operator link; no bare long URL or internal relative URL.
 - Before saying merged/closed/deployed, re-read runtime truth.
 Deploy:
-- Use vtddDeployProduction only after deploy ask + GO + real passkey grant.
-- If no deploy grant, show selfParity.deployOperatorMarkdownLink or `[Open deploy operator](<actual selfParity.deployOperatorUrl>)`; no raw operator path/bare URL.
+- Use vtddDeployProduction after deploy ask + GO + real passkey grant.
+- If no deploy grant, show selfParity.deployOperatorMarkdownLink or `[Open deploy operator](<actual selfParity.deployOperatorUrl>)`; no raw/bare URL.
 - Stale fallback: selfParity.deployRecovery.operatorMarkdownLink or operatorUrl; href needs phase=execution.
 - After deploy dispatch, re-check self-parity. If deploy fails, say exact deploy error/reason/issues.
 - If api_key_runner hits openai_api_key_not_configured, use vtddSyncGitHubActionsSecret secret-sync operator; never ask for OPENAI_API_KEY in chat.
@@ -70,7 +70,7 @@ Review loop:
 - `vtdd:reviewer=codex-fallback` with comment/@codex review is request-only.
 - Completed fallback from trusted VTDD actor/Codex Cloud result with recommendedAction is evidence; missing GitHub Review objects alone is not absence.
 - `vtdd:incident=actor_identity_failure`: recovery blocker; explain role/PR in Japanese; never count `marushu` substitute as review done.
-- If no reviewer evidence exists, say so.
+- If no reviewer evidence, say so.
 Forbidden:
 - No default repo assumption.
 - No issue/PR/comment absence claim from unsupported, unauthorized, failed, or unverified reads.
@@ -80,5 +80,5 @@ Forbidden:
 - No merge, deploy, secret/settings/permission mutation, issue close, or destructive action on your own.
 - No owner-specific runtime URL/account/bootstrap value in public guidance.
 Response style:
-- Japanese first; separate confirmed, missing, and next safe action.
+- Japanese; separate confirmed, missing, next safe action.
 - If unverified, say 未検証 instead of guessing.

--- a/docs/setup/custom-gpt-instructions-short.md
+++ b/docs/setup/custom-gpt-instructions-short.md
@@ -2,8 +2,8 @@ Butler
 Core:
 - Issue is canonical spec.
 - If implementation work does not already have an existing Issue, propose an Issue candidate first, wait for GO, create the Issue, then hand off. Do not create the PR/build first and issue-link later; #303 is the regression example.
-- Before proposal/write/Codex handoff/PR judgment: vtddRetrieveCrossMemory + vtddRetrieveDecisionLogs/vtddRetrieveProposalLogs/vtddRetrieveConstitution + runtime truth; no RAG hit OK, never invent. Reusable memory => show candidate, ask GO, vtddWriteOperationalMemory. Runtime truth > memory.
-- RAG ckpt: verify vtddRetrieveOperationalMemory.
+- Before proposal/write/Codex handoff/PR judgment: vtddRetrieveCrossMemory + vtddRetrieveDecisionLogs/vtddRetrieveProposalLogs/vtddRetrieveConstitution + runtime truth; no RAG hit OK, never invent. Runtime truth > memory.
+- Reusable memory/RAG ckpt: show candidate with known repo/Issue; say unknown if missing; ask GO; vtddWriteOperationalMemory; verify vtddRetrieveOperationalMemory.
 - Do not assume a default repository. Resolve repo; if ambiguous, ask.
 - Natural to actions; no internal paths/raw JSON.
 - No scope beyond Issue/user instruction.

--- a/test/custom-gpt-setup-docs.test.js
+++ b/test/custom-gpt-setup-docs.test.js
@@ -184,6 +184,8 @@ test("short custom gpt instructions stay under editor limits while preserving cr
   assert.equal(doc.includes("no RAG hit OK"), true);
   assert.equal(doc.includes("never invent"), true);
   assert.equal(doc.includes("Runtime truth > memory"), true);
+  assert.equal(doc.includes("Reusable memory/RAG ckpt: show candidate with known repo/Issue"), true);
+  assert.equal(doc.includes("say unknown if missing"), true);
   assert.equal(doc.includes("propose an Issue candidate first, wait for GO, create the Issue, then hand off"), true);
   assert.equal(doc.includes("#303 is the regression example"), true);
   assert.equal(doc.includes("For normal GO writes (`issue_create`, `issue_comment_create`, `pull_comment_create`)"), true);
@@ -258,6 +260,9 @@ test("short-min custom gpt instructions stay pasteable while preserving critical
     "propose the Issue first, wait GO, create it, then hand off",
     "#303 is the regression example",
     "GitHub/runtime state is progress truth",
+    "Reusable memory/RAG checkpoint",
+    "show candidate with known repo/Issue",
+    "say unknown if missing",
     "Do not assume a default repository.",
     "vtddExecute handoff must use actionType=build",
     "requiresHandoff=true",


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #361 の RAG checkpoint 運用で、Butler が保存候補を作る時に既知の repository / Issue metadata を落とさないよう short / short-min Instructions に明示します。

## Satisfied Success Criteria

- RAG checkpoint candidate は known repo/Issue を含める、と short / short-min Instructions に明記しました。
- repo/Issue が不明な場合は unknown と明示し、捏造しない、と明記しました。
- 保存後確認は vtddRetrieveOperationalMemory を使う、という既存方針を同じ行へ統合しました。

## Unsatisfied Success Criteria

- Issue #361 の startup preflight 完全統合と Issue #344 の 3 surface parity はこの PR では未完了です。
- Butler live editor に Instructions を反映した後の iPhone E2E は未実施です。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #361
- Implementing Success Criteria: Butler / mac Codex / VPS Codex CLI が RAG checkpoint を同じ概念として扱い、checkpoint に repository / related Issue を含められる。
- Explicit Non-goals: startup preflight 全体、runtime memory provider、Action Schema、Cloudflare deploy は対象外。
- Expected touched files/routes/workflows: docs/setup/custom-gpt-instructions-short.md; docs/setup/custom-gpt-instructions-short-min.md; test/custom-gpt-setup-docs.test.js
- Affected Issues: Issue #343, Issue #344, Issue #360
- Affected PRs: なし
- Affected workflows: CI の test / self-parity / generated-worker check。Reviewer workflow には影響なし。
- Affected runtime/operator surfaces: Butler Custom GPT Instructions のみ。Worker runtime / Action Schema / VPS runner は未変更。
- What may break if we patch narrowly: short-min は上限近く、単純追記すると paste 上限を超えて setup recovery が弱くなる。
- Unknowns to investigate before coding: Butler live editor がこの更新を反映するまでは実運用反映は未検証。
- Validation needed: setup docs tests; npm test; 反映後に Butler live で checkpoint candidate の repo/Issue preservation を確認。
- Stop condition: Action Schema や runtime route 変更が必要になる場合は、この docs-only PR から分離する。

## File / Line Hypotheses

- file: docs/setup/custom-gpt-instructions-short-min.md
  - hypothesis: short-min の RAG checkpoint 行が repo/Issue preservation を明示していない。
  - risk if changed narrowly: 文字数上限を超えると iPhone からの setup recovery が壊れる。
  - validation: wc と setup docs tests。
  - related Issue: Issue #361
- file: docs/setup/custom-gpt-instructions-short.md
  - hypothesis: expanded paste target も同じ指示を持つ必要がある。
  - risk if changed narrowly: short と short-min の判断がずれる。
  - validation: custom-gpt setup docs tests。
  - related Issue: Issue #361

## Hypothesis Retrospective

- expected: docs-only で repo/Issue preservation を明示できる。
- actual: short / short-min の RAG checkpoint 行を置換し、short-min は 7899 bytes に維持。
- mismatch: なし。
- lesson: 上限近い Instructions は追記ではなく既存行の置換で扱う。
- should become RAG candidate: 低。Issue #361 の実装ログとして PR に残す。

## Verification Evidence

- Unit: node --test test/custom-gpt-setup-docs.test.js test/custom-gpt-setup-artifacts.test.js: pass
- Integration: npm test: pass（765 pass, 1 skipped）; check:self-parity pass; check:generated-worker pass
- E2E: 未実施。この PR は Instructions docs-only slice。
- Manual: wc -c: short-min 7899 bytes, short 7897 bytes。
- Evidence path/link: test/custom-gpt-setup-docs.test.js

## Butler Completion Contract

- Owner goal: Butler が RAG checkpoint 保存時に repo/Issue metadata を落とさず、後で思い出せる記憶にする。
- Butler entrypoint: Custom GPT Instructions の自然会話 checkpoint 候補提示。
- Action Schema exposure: 未変更。既存 vtddWriteOperationalMemory / vtddRetrieveOperationalMemory を使う。
- Runtime path: 未変更。既存 /v2/action/memory-write と /v2/retrieve/operational-memory を使う。
- Runner/runtime truth: 未変更。テストと setup self-parity で docs/runtime manifest parity を確認。
- Authority boundary: RAG write は候補提示後の GO が必要。high-risk authority は追加しない。
- E2E evidence: 未実施。Custom GPT Instructions 反映後に live Butler で確認が必要。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 不要。src/worker/runtime.js と worker.js は未変更。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 必要。merge 後 /setup/latest から Custom GPT Instructions を再反映する。
- iPhone Butler live E2E: merge + Instructions 反映後に実施。

## Related Constitution Rules

- Issue #361 RAG checkpoint は Butler / mac Codex / VPS Codex CLI の共有記憶にする。
- RAG は full transcript ではなく構造化 checkpoint を保存する。
- Evidence がない完了主張はしない。

## Out-of-scope but NOT implemented

- Issue #344 startup preflight 完全統合。
- Issue #343 tension_note schema の追加実装。
- Runtime memory provider / semantic index の変更。

## Extra changes (if any)

short-min の 8KB 制約を守るため、意味を変えない範囲で周辺文言を圧縮しました。

<!-- VTDD metadata -->
- Issue: Issue #361
- Execution ID: Not provided.
- Goal: Not provided.
