### PR TITLE
Issue #344: startup preflight に surface dependency を固定

### DIFF
--- a/docs/butler/capability-matrix.md
+++ b/docs/butler/capability-matrix.md
@@ -48,6 +48,24 @@ GitHub UI fallback is not a steady-state answer. If an owner operation is
 unsupported, Butler must report that the operation is in scope, name the missing
 governed action surface, and cite remediation Issue #244.
 
+### Startup Surface Dependency Reading
+
+Issue #344 startup preflight must separate "can work from iPhone" from "can
+work only because the owner's Mac is currently awake." This distinction is
+owner-facing runtime truth, not trivia.
+
+| Surface | Mac required? | Current reading | Butler startup wording |
+|---|---:|---|---|
+| Butler Custom GPT on iPhone/iPad | no | Primary owner-facing surface. Can use configured Actions, GitHub runtime truth, RAG memory, passkey operator pages, and governed handoff routes. | Treat as the normal VTDD entrypoint. Do not ask for terminal/local server use during normal operation. |
+| ChatGPT iPhone Codex cloud | no for cloud tasks | Cloud task execution can run in an OpenAI-managed environment when the GitHub connector/environment is available. It is not the same as controlling the local Mac Codex. | Say `Codex cloud can run without the Mac when connector/env are available`; verify branch/PR/runtime evidence before claiming success. |
+| mac Codex | yes | Most capable local repair surface because it can use the local checkout, browser, and local credentials, but it disappears when the Mac sleeps or is offline. | Say `Mac dependency detected` if the proposed path needs local files, desktop/browser state, or unexported local credentials. |
+| VPS Codex CLI / runner | no for Mac | Owner-controlled always-on execution/reviewer fallback candidate. It should read repo truth and shared RAG, and it can provide terminal-like execution without an iPhone terminal app. | Prefer as the iPhone-safe fallback when Butler needs bounded implementation/review execution. |
+| Human GitHub UI from iPhone | no | Emergency manual fallback for merge/close/settings visibility, but not the intended steady-state VTDD operator path. | Use only as a clearly labeled fallback, not as proof that Butler completed the workflow. |
+
+Startup preflight should report any Mac dependency before handoff. If a task can
+be done through GitHub truth, runtime route, VPS runner, Codex cloud, or
+passkey operator, prefer that route over a Mac-only instruction.
+
 ### Owner-Operation Inventory Reading
 
 | Operation family | Current status | Required Butler action surface | Boundary / runtime truth |

--- a/docs/setup/custom-gpt-instructions.md
+++ b/docs/setup/custom-gpt-instructions.md
@@ -132,6 +132,12 @@ VTDD context preflight / RAG:
 - Prefer both success and failure patterns when memory returns them.
 - If RAG/context retrieval is unavailable, say `RAG/context retrieval unavailable` and continue only when Issue/docs/runtime truth provide enough safe basis.
 - If runtime truth conflicts with memory, stop and reconcile instead of proceeding by memory.
+- At startup, distinguish the execution surfaces before proposing development work:
+  - Butler on iPhone/iPad must not assume the owner's Mac is awake, reachable, or available.
+  - ChatGPT iPhone Codex cloud tasks can run in OpenAI-managed cloud environments when the repository connector/environment is available; do not describe that as operating the local Mac Codex.
+  - mac Codex can read the local checkout and local credentials, but it is Mac-dependent and should not be the steady-state iPhone recovery path.
+  - VPS Codex CLI / runner is the owner-controlled always-on fallback candidate for terminal-like execution, review fallback, and repo-backed automation.
+  - If a task requires local Mac-only files, local desktop state, local browser state, or unexported local credentials, say `Mac dependency detected` and propose the next repo/runtime/VPS-safe alternative instead of silently requiring the Mac.
 - When a reusable decision, blocker, failure pattern, repair, or handoff fact emerges, show a compact structured memory candidate, ask the human for GO, then call vtddWriteOperationalMemory. Do not store full transcripts, secrets, or raw sensitive material.
 - Treat a RAG checkpoint as a memory savepoint. Offer one when context compression risk appears, the owner is about to leave/sleep/bathe/travel, a strong owner tension appears, a dry-run hypothesis/expected file set appears, an error deserves observation before repair, or a large docs/PR/log investigation begins or ends.
 - For a RAG checkpoint, write `recordType=working_memory`, include tag `rag-checkpoint`, and fill compact fields such as `checkpointReason`, `thoughtLocation`, `userTension`, `contextSourceQuality`, `hypothesis`, `expectedFiles`, `evidenceLinks`, and `previousRecordIds` when available. Store judgment logs and return points, not hidden chain-of-thought or full transcripts.

--- a/test/butler-capability-matrix.test.js
+++ b/test/butler-capability-matrix.test.js
@@ -22,6 +22,13 @@ test("Butler capability matrix records live/source/unverified status without ove
   assert.equal(doc.includes("| archive/delete/transfer/visibility/destructive cleanup | `intentionally_blocked` |"), true);
   assert.equal(doc.includes("GitHub UI fallback is not a steady-state answer."), true);
   assert.equal(doc.includes("iPhone/mobile"), true);
+  assert.equal(doc.includes("Startup Surface Dependency Reading"), true);
+  assert.equal(doc.includes("| ChatGPT iPhone Codex cloud | no for cloud tasks |"), true);
+  assert.equal(doc.includes("It is not the same as controlling the local Mac Codex."), true);
+  assert.equal(doc.includes("| mac Codex | yes |"), true);
+  assert.equal(doc.includes("Mac dependency detected"), true);
+  assert.equal(doc.includes("| VPS Codex CLI / runner | no for Mac |"), true);
+  assert.equal(doc.includes("Startup preflight should report any Mac dependency before handoff."), true);
   assert.equal(doc.includes("Do not report `source-only` as done."), true);
   assert.equal(doc.includes("Do not report `requested` handoff as Codex"), true);
 

--- a/test/custom-gpt-setup-docs.test.js
+++ b/test/custom-gpt-setup-docs.test.js
@@ -79,6 +79,11 @@ test("custom gpt instructions preserve current butler and approval boundaries", 
   assert.equal(doc.includes("After writing a RAG checkpoint, confirm it with `vtddRetrieveOperationalMemory`"), true);
   assert.equal(doc.includes("Do not use `vtddRetrieveCrossMemory` as the only confirmation path for `working_memory` checkpoints"), true);
   assert.equal(doc.includes("Cross memory is decision/proposal/Issue oriented; operational memory is the checkpoint recall surface"), true);
+  assert.equal(doc.includes("At startup, distinguish the execution surfaces before proposing development work"), true);
+  assert.equal(doc.includes("Butler on iPhone/iPad must not assume the owner's Mac is awake"), true);
+  assert.equal(doc.includes("ChatGPT iPhone Codex cloud tasks can run in OpenAI-managed cloud environments"), true);
+  assert.equal(doc.includes("do not describe that as operating the local Mac Codex"), true);
+  assert.equal(doc.includes("Mac dependency detected"), true);
   assert.equal(doc.includes("Current natural GO\n  binding is supported for `issue_create`, `issue_comment_create`, and\n  `pull_comment_create`"), true);
   assert.equal(doc.includes("If an implementation request does not already name an existing Issue"), true);
   assert.equal(doc.includes("the next safe write is usually `issue_create`, not Codex handoff"), true);


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #344 の startup preflight に、iPhone から開発する時の surface dependency を明示します。
- Butler が Mac Codex / ChatGPT iPhone Codex cloud / VPS Codex CLI を混同せず、Mac 依存を owner-facing に報告できるようにします。

## Satisfied Success Criteria

- startup preflight に Butler / mac Codex / VPS Codex CLI の surface capability と不足機能を含めるための docs anchor を追加しました。
- Butler Instructions に、iPhone/iPad 通常運用では Mac が awake/reachable である前提を置かないルールを追加しました。
- ChatGPT iPhone Codex cloud は cloud task として Mac 非依存で動けるが、local Mac Codex 操作ではない、と明記しました。
- Mac-only files / desktop state / local browser state / unexported credentials が必要な場合は `Mac dependency detected` と言うようにしました。

## Unsatisfied Success Criteria

- Issue #344 の full startup preflight response / runtime route / 3 surface parity evidence は未完了です。
- Butler live Custom GPT がこの Instructions 更新を読んだ状態での iPhone E2E は未実施です。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #344
- Implementing Success Criteria: startup preflight に surface capability と不足機能を含め、iPhone から再開しても Mac dependency を誤認しない。
- Explicit Non-goals: runtime route / Action Schema / worker.js / Codex cloud integration 実装は対象外。
- Expected touched files/routes/workflows: docs/setup/custom-gpt-instructions.md; docs/butler/capability-matrix.md; test/custom-gpt-setup-docs.test.js; test/butler-capability-matrix.test.js
- Affected Issues: Issue #341, Issue #359, Issue #360, Issue #361
- Affected PRs: なし
- Affected workflows: CI の test / self-parity / generated-worker check。Reviewer workflow には影響なし。
- Affected runtime/operator surfaces: Butler Custom GPT Instructions と capability docs のみ。runtime / Action Schema / VPS runner は未変更。
- What may break if we patch narrowly: Mac Codex と Codex cloud を混同すると、iPhone-first 復旧の設計が再び Mac 依存になる。
- Unknowns to investigate before coding: Codex cloud の connector/environment availability はユーザー account/runtime truth で別途確認が必要。
- Validation needed: docs tests; npm test; merge 後に Custom GPT Instructions 反映と Butler live preflight 確認。
- Stop condition: Codex cloud 実行 route や GitHub connector 設定変更が必要になる場合は、この docs-only PR から分離する。

## File / Line Hypotheses

- file: docs/setup/custom-gpt-instructions.md
  - hypothesis: Butler の full Instructions が surface dependency を明示すべき正本である。
  - risk if changed narrowly: short-min だけに入れると full source と setup bundle が drift する。
  - validation: custom-gpt setup docs test。
  - related Issue: Issue #344
- file: docs/butler/capability-matrix.md
  - hypothesis: owner-facing surface capability は matrix に固定するのが preflight の参照元として安全。
  - risk if changed narrowly: runtime routes がない状態で completed と誤報告する。
  - validation: butler capability matrix test。
  - related Issue: Issue #344

## Hypothesis Retrospective

- expected: docs/test だけで Mac dependency と Codex cloud の境界を startup preflight に固定できる。
- actual: Instructions と capability matrix に surface dependency reading を追加し、runtime code は触らずに済んだ。
- mismatch: なし。
- lesson: iPhone-first の障壁は実装機能だけではなく、どの surface が何に依存するかの誤認にもある。
- should become RAG candidate: 低から中。Issue #344 の preflight 設計ログとして PR に残す。

## Verification Evidence

- Unit: node --test test/custom-gpt-setup-docs.test.js test/butler-capability-matrix.test.js: pass
- Integration: npm test: pass（765 pass, 1 skipped）; check:self-parity pass; check:generated-worker pass
- E2E: 未実施。この PR は startup preflight docs/test slice。
- Manual: OpenAI official Codex docs/help を確認し、Codex cloud が iOS から cloud task として使えること、Mac local operation とは別であることを反映。
- Evidence path/link: test/custom-gpt-setup-docs.test.js; test/butler-capability-matrix.test.js

## Butler Completion Contract

- Owner goal: iPhone から Butler で開発を始める時、Mac が寝ていても何が使える/使えないかを誤認しない。
- Butler entrypoint: 会話開始時または開発依頼前の startup preflight。
- Action Schema exposure: 未変更。
- Runtime path: 未変更。
- Runner/runtime truth: 未変更。surface capability は docs/test anchor として追加。
- Authority boundary: 未変更。high-risk authority は追加しない。
- E2E evidence: 未実施。Custom GPT Instructions 反映後に live Butler で確認が必要。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 不要。src/worker/runtime.js と worker.js は未変更。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 必要。merge 後 /setup/latest から Custom GPT Instructions を再反映する。
- iPhone Butler live E2E: merge + Instructions 反映後に実施。

## Related Constitution Rules

- Butler 通常運用は iPhone/iPad-first で、local terminal / local server / Mac awake を前提にしない。
- Runtime truth と GitHub truth は memory より優先する。
- Evidence がない完了主張はしない。

## Out-of-scope but NOT implemented

- Issue #344 full startup preflight route。
- Codex cloud connector/environment 自動確認。
- VPS runner の新規実行機能。
- Issue #359 setup recovery UI 修正。

## Extra changes (if any)

OpenAI 公式 docs/help の current Codex cloud 説明を参照し、VTDD docs には owner-facing の境界だけを残しました。

<!-- VTDD metadata -->
- Issue: Issue #344
- Execution ID: Not provided.
- Goal: Not provided.
