### PR TITLE
Issue #344: VPS preflight に handoff note を追加

### DIFF
--- a/docs/butler/remote-codex-cli-executor.md
+++ b/docs/butler/remote-codex-cli-executor.md
@@ -334,6 +334,15 @@ Progress must be reconstructable from:
 - branch / PR state in GitHub runtime truth
 - VPS runner GitHub queue and event comments when using `vps_runner`
 
+For `vps_runner`, the preflight receipt must also include a `handoffNote`
+readable by Butler, mac Codex, and VPS Codex CLI. This note is restart context,
+not a substitute for GitHub runtime truth. It records the current surface, target
+repository, Issue, branch/base ref, Codex goal, the next safe action, the
+blocked-return route, and the expectation that important decisions or failed
+hypotheses should be offered as RAG checkpoint candidates before handoff ends.
+If the note and GitHub runtime truth conflict, Butler must follow runtime truth
+and surface the mismatch rather than guessing.
+
 For `codex_cloud_cli_control_runner`, the top-level progress `status` and
 `branch` describe the control workflow run for compatibility with existing
 consumers. Implementation success is reported separately under

--- a/scripts/run-vps-runner.mjs
+++ b/scripts/run-vps-runner.mjs
@@ -810,6 +810,7 @@ async function buildVpsRunnerPreflightReceipt({ workspace, payload, issue }) {
     mode: policy.mode,
     onMissingContract: policy.onMissingContract,
     issue: issueReceipt,
+    handoffNote: buildVpsRunnerHandoffNote({ payload, issueReceipt }),
     artifacts,
     missing,
     createdAt: new Date().toISOString()
@@ -822,6 +823,35 @@ async function buildVpsRunnerPreflightReceipt({ workspace, payload, issue }) {
   }
   payload.preflightReceipt = receipt;
   return receipt;
+}
+
+function buildVpsRunnerHandoffNote({ payload, issueReceipt }) {
+  const repository = normalizeRepository(payload?.repository);
+  const issueNumber = normalizePositiveInteger(issueReceipt?.number ?? payload?.issueNumber);
+  const codexGoal = normalizeText(payload?.codexGoal) || "unknown";
+  const branch = normalizeText(payload?.branch) || "";
+  const baseRef = normalizeText(payload?.baseRef) || "";
+  const currentSurface = "VPS Codex CLI";
+  const nextReadableBy = ["Butler", "mac Codex", "VPS Codex CLI"];
+  const nextSafeAction =
+    codexGoal === "revise_pr"
+      ? "resume from GitHub PR runtime truth, reviewer comments, and this preflight receipt"
+      : "resume from the canonical Issue, GitHub runtime truth, RAG checkpoints, and this preflight receipt";
+  return {
+    version: 1,
+    currentSurface,
+    nextReadableBy,
+    repository: repository || null,
+    issueNumber: issueNumber || null,
+    branch: branch || null,
+    baseRef: baseRef || null,
+    codexGoal,
+    nextSafeAction,
+    blockedReturnRoute:
+      "If the issue/runtime truth is insufficient, stop and return a Japanese blocker comment for Butler/owner instead of guessing.",
+    memoryExpectation:
+      "Important decisions, failed hypotheses, and restart context should be offered as RAG checkpoint candidates before handoff ends."
+  };
 }
 
 function normalizeVpsRunnerPreflightPolicy(value = {}) {
@@ -878,6 +908,16 @@ function formatVpsRunnerPreflightReceipt(preflight) {
   }
   lines.push("- Issue excerpt:");
   lines.push(indentForPrompt(normalizeText(preflight?.issue?.bodyExcerpt) || "(missing issue body)"));
+  if (preflight.handoffNote && typeof preflight.handoffNote === "object") {
+    const note = preflight.handoffNote;
+    lines.push("- Handoff note:");
+    lines.push(`  - Current surface: ${normalizeText(note.currentSurface) || "unknown"}`);
+    lines.push(`  - Repository: ${normalizeText(note.repository) || "unknown"}`);
+    lines.push(`  - Issue: #${normalizePositiveInteger(note.issueNumber) || "unknown"}`);
+    lines.push(`  - Goal: ${normalizeText(note.codexGoal) || "unknown"}`);
+    lines.push(`  - Next safe action: ${normalizeText(note.nextSafeAction) || "unknown"}`);
+    lines.push(`  - Blocked return route: ${normalizeText(note.blockedReturnRoute) || "unknown"}`);
+  }
   return lines.join("\n");
 }
 

--- a/test/cost-account-boundary.test.js
+++ b/test/cost-account-boundary.test.js
@@ -52,6 +52,16 @@ test("remote Codex docs define private repository VPS Actions-minimization bound
   assert.equal(doc.includes("Actions cost is zero"), true);
 });
 
+test("remote Codex docs require VPS handoff note as restart context", () => {
+  const doc = read("docs/butler/remote-codex-cli-executor.md");
+
+  assert.equal(doc.includes("preflight receipt must also include a `handoffNote`"), true);
+  assert.equal(doc.includes("readable by Butler, mac Codex, and VPS Codex CLI"), true);
+  assert.equal(doc.includes("restart context,\nnot a substitute for GitHub runtime truth"), true);
+  assert.equal(doc.includes("RAG checkpoint candidates before handoff ends"), true);
+  assert.equal(doc.includes("surface the mismatch rather than guessing"), true);
+});
+
 test("reviewer policy requires explicit cost/account choice for API-key reviewers", () => {
   const doc = read("docs/security/reviewer-policy.md");
 

--- a/test/vps-runner-script.test.js
+++ b/test/vps-runner-script.test.js
@@ -1161,6 +1161,14 @@ test("VPS runner Codex prompt preserves high-risk boundaries", () => {
         title: "Smoke test",
         bodyExcerpt: "Create a small smoke evidence file."
       },
+      handoffNote: {
+        currentSurface: "VPS Codex CLI",
+        repository: "sample-org/vtdd-v2",
+        issueNumber: 157,
+        codexGoal: "open_pr",
+        nextSafeAction: "resume from the canonical Issue, GitHub runtime truth, RAG checkpoints, and this preflight receipt",
+        blockedReturnRoute: "If the issue/runtime truth is insufficient, stop and return a Japanese blocker comment for Butler/owner instead of guessing."
+      },
       artifacts: [{ path: "AGENTS.md", sha1: "abc123" }],
       missing: []
     }
@@ -1176,6 +1184,10 @@ test("VPS runner Codex prompt preserves high-risk boundaries", () => {
   assert.equal(prompt.includes("scripts/validate-pr-body.mjs"), true);
   assert.equal(prompt.includes("Context preflight receipt:"), true);
   assert.equal(prompt.includes("AGENTS.md sha1=abc123"), true);
+  assert.equal(prompt.includes("Handoff note:"), true);
+  assert.equal(prompt.includes("Current surface: VPS Codex CLI"), true);
+  assert.equal(prompt.includes("Next safe action: resume from the canonical Issue"), true);
+  assert.equal(prompt.includes("Japanese blocker comment for Butler/owner"), true);
   assert.equal(prompt.includes("owner_decision_required"), true);
   assert.equal(prompt.includes("## This PR satisfies Intent"), true);
   assert.equal(prompt.includes("## Surface Update Checklist"), true);
@@ -1191,7 +1203,11 @@ test("VPS runner builds preflight receipt from canonical repo files", async () =
   await fs.writeFile(path.join(tempRoot, "scripts/validate-pr-body.mjs"), "export function validatePrBody() {}\n");
 
   const payload = {
+    repository: "sample-org/vtdd-v2",
     issueNumber: 307,
+    branch: "codex/issue-307",
+    baseRef: "main",
+    codexGoal: "open_pr",
     preflightPolicy: {
       mode: "auto_receipt",
       onMissingContract: "owner_decision_required",
@@ -1217,7 +1233,17 @@ test("VPS runner builds preflight receipt from canonical repo files", async () =
   assert.equal(receipt.ok, true);
   assert.equal(receipt.artifacts.length, 4);
   assert.equal(receipt.issue.number, 307);
+  assert.equal(receipt.handoffNote.currentSurface, "VPS Codex CLI");
+  assert.deepEqual(receipt.handoffNote.nextReadableBy, ["Butler", "mac Codex", "VPS Codex CLI"]);
+  assert.equal(receipt.handoffNote.repository, "sample-org/vtdd-v2");
+  assert.equal(receipt.handoffNote.issueNumber, 307);
+  assert.equal(receipt.handoffNote.branch, "codex/issue-307");
+  assert.equal(receipt.handoffNote.baseRef, "main");
+  assert.equal(receipt.handoffNote.codexGoal, "open_pr");
+  assert.match(receipt.handoffNote.nextSafeAction, /RAG checkpoints/);
+  assert.match(receipt.handoffNote.blockedReturnRoute, /Butler\/owner/);
   assert.equal(payload.preflightReceipt.ok, true);
+  assert.equal(payload.preflightReceipt.handoffNote.issueNumber, 307);
 });
 
 test("VPS runner preflight receipt requires owner decision when required files are missing", async () => {


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #344 の部分進捗です。VPS Codex CLI が開始時に作る preflight receipt に、Butler / mac Codex / VPS Codex CLI が同じ再開文脈を読める handoff note を追加します。
- mac 依存を減らし、Butler 起点で VPS runner に渡した開発を GitHub-visible な文脈から再開しやすくします。

## Satisfied Success Criteria

- VPS runner preflight receipt に current surface / repository / Issue / branch / base ref / Codex goal / next safe action / blocked return route / RAG checkpoint expectation を含む `handoffNote` を追加しました。
- Codex prompt に handoff note を表示し、VPS 側の実行者が次に何を読んで止まるべきかを見失いにくくしました。
- `handoffNote` は runtime truth の代替ではなく restart context として doc 化し、矛盾時は Butler が mismatch を表面化する方針にしました。

## Unsatisfied Success Criteria

- Issue #344 全体の complete ではありません。Butler 起点の startup preflight が全 surface で自動実行される live E2E は未実施です。
- Butler と VPS Codex CLI が自然言語で直接対話して開発完了まで進む経路は、この PR では未実装です。
- Custom GPT Action Schema / runtime route の新規追加はこの PR では行っていません。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #344
- Implementing Success Criteria: VPS runner が開始時に、次の AI surface が読める再開文脈を preflight receipt と prompt に残す。
- Explicit Non-goals: 新規 Action Schema 追加、Cloudflare runtime route 追加、Butler↔VPS 自然言語対話の完成、Issue #344 の完了宣言。
- Expected touched files/routes/workflows: `scripts/run-vps-runner.mjs`, `test/vps-runner-script.test.js`, `docs/butler/remote-codex-cli-executor.md`, `test/cost-account-boundary.test.js`。`src/**` と `worker.js` は触らない。
- Affected Issues: Issue #344。将来の Issue #360 dry-run gate / Issue #361 RAG checkpoint と接続し得るが、この PR では実装しない。
- Affected PRs: なし。
- Affected workflows: GitHub Actions の通常 test のみ。deploy / reviewer workflow は変更しない。
- Affected runtime/operator surfaces: VPS runner prompt と preflight receipt。Butler は将来この receipt を runtime truth と合わせて読む想定。mac Codex / VPS Codex CLI は同じ handoff note を読める。
- What may break if we patch narrowly: handoff note を runtime truth と誤認すると drift する。doc に restart context と明記し、矛盾時は runtime truth 優先にした。
- Unknowns to investigate before coding: 既存 preflight receipt の作成位置、prompt formatting、VPS runner test の既存境界。
- Validation needed: VPS runner script targeted test、doc guard test、全体 test/self-parity/generated-worker check。
- Stop condition: 新規 route/schema/deploy が必要になる、または Issue #344 外の Butler executor 設計変更が必要になる場合は止める。

## File / Line Hypotheses

- file: `scripts/run-vps-runner.mjs`
  - hypothesis: `buildVpsRunnerPreflightReceipt` と `formatVpsRunnerPreflightReceipt` が VPS runner 開始文脈の最小接続点。
  - risk if changed narrowly: receipt だけに入れて prompt に出さないと VPS Codex CLI が読めない。prompt だけに出すと Butler が runtime truth として復元しづらい。
  - validation: receipt object と prompt 出力の両方を `test/vps-runner-script.test.js` で確認する。
  - related Issue: Issue #344
- file: `docs/butler/remote-codex-cli-executor.md`
  - hypothesis: handoff note の正本性を誤ると drift するため、progress contract に restart context として明記する必要がある。
  - risk if changed narrowly: doc なしだと後続の Butler/mac/VPS 実装で memory や receipt が GitHub runtime truth を上書きしかねない。
  - validation: doc guard test で必須文言を確認する。
  - related Issue: Issue #344

## Hypothesis Retrospective

- expected: preflight receipt と prompt formatter だけで、VPS 側の再開文脈を追加できる。
- actual: その通り。`src/**` や Action Schema を触らずに VPS runner の receipt/prompt/doc/test に限定できた。
- mismatch: なし。
- lesson: handoff context は GitHub runtime truth の補助として扱う必要がある。AI surface 間の共通文脈を増やす時ほど、正本と補助情報の境界を PR に残すべき。
- should become RAG candidate: はい。Butler / mac Codex / VPS Codex CLI の再開文脈は runtime truth 優先で、handoff note は restart context として扱う。

## Verification Evidence

- Unit: `node --test test/vps-runner-script.test.js` pass: 53 tests。`node --test test/cost-account-boundary.test.js` pass: 5 tests。
- Integration: `npm test` pass: 766 passed, 1 skipped, 0 failed。`check:self-parity` pass。`check:generated-worker` pass。
- E2E: 未実施。この PR は VPS runner preflight の部分接続であり、Butler-facing live E2E は Issue #344 の後続で必要です。
- Manual: `git diff` で `src/**` と generated `worker.js` を触っていないことを確認。
- Evidence path/link: `scripts/run-vps-runner.mjs`, `test/vps-runner-script.test.js`, `docs/butler/remote-codex-cli-executor.md`, `test/cost-account-boundary.test.js`

## Butler Completion Contract

- Owner goal: Butler 起点の開発を mac に依存せず、VPS Codex CLI と mac Codex が同じ文脈で再開できる方向へ進める。
- Butler entrypoint: この PR では未変更。既存の `vtddExecute` / `executorTransport=vps_runner` 経路が前提。
- Action Schema exposure: 変更なし。新規 operationId は追加していません。
- Runtime path: Butler `vtddExecute` -> VPS runner queue comment -> `scripts/run-vps-runner.mjs` -> preflight receipt -> Codex prompt。
- Runner/runtime truth: VPS runner preflight receipt に `handoffNote` を含める。GitHub runtime truth と矛盾した場合は runtime truth を優先し、mismatch を表面化する。
- Authority boundary: 変更なし。merge / deploy / secret / permission / repository settings は実行しません。
- E2E evidence: この PR では未接続。Butler-facing live E2E は未実施です。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 不要。`src/**` / runtime Worker は変更していません。
- Custom GPT Action Schema update: 不要。Action Schema は変更していません。
- Custom GPT Instructions update: 不要。setup instructions は変更していません。
- iPhone Butler live E2E: 未実施。この PR は VPS runner 内部の preflight/prompt スライスです。

## Related Constitution Rules

- Issue 起点で進める。
- Butler owner-facing workflow が未接続なら complete と言わない。
- GitHub runtime truth を正本とし、memory / handoff note は補助として扱う。
- mac ローカル依存を Butler 通常運用の前提にしない。

## Out-of-scope but NOT implemented

- Butler と VPS Codex CLI の自然言語対話。
- startup preflight の全 surface 自動実行。
- RAG checkpoint の自動保存。
- Cloudflare runtime / Action Schema / Custom GPT Instructions の更新。

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #344
- Execution ID: Not provided.
- Goal: vps_runner_handoff_note
