### PR TITLE
Issue #358: Gemini reviewer comment storm guard を追加

### DIFF
--- a/docs/butler/gemini-pr-review-comments.md
+++ b/docs/butler/gemini-pr-review-comments.md
@@ -133,6 +133,19 @@ self-trigger review loops, and an `approve` marker for the same PR head SHA is a
 terminal state unless a new commit, explicit trusted re-review request, or later
 blocking reviewer signal reopens review.
 
+## Runaway Guard
+
+If the Gemini reviewer sees too many trusted reviewer markers in a short time
+window, it must stop before making another Gemini call or appending another
+review. The workflow writes at most one GitHub-visible guard marker:
+
+`<!-- vtdd:reviewer=runaway-guard -->`
+
+That marker is owner-facing Japanese status. It states the stopped scope, the
+detected marker count, the threshold, and the resume condition. The marker uses
+the normal reviewer marker shape so the `issue_comment` trigger skips it before
+dependency install instead of creating a new review loop.
+
 The VTDD reviewer marker comment is the canonical VTDD reviewer signal for
 Butler synthesis. It must not be confused with GitHub formal Pull Request
 Review API objects or GitHub `reviewDecision` state. If a marker recommends

--- a/scripts/run-gemini-pr-review.mjs
+++ b/scripts/run-gemini-pr-review.mjs
@@ -2,15 +2,19 @@ import fs from "node:fs/promises";
 import {
   classifyGeminiReviewFailure,
   DEFAULT_GEMINI_REVIEW_MODEL,
+  DEFAULT_REVIEWER_RUNAWAY_MAX_COMMENTS,
+  DEFAULT_REVIEWER_RUNAWAY_WINDOW_MINUTES,
   GeminiReviewFailureKind,
   buildGeminiReviewRequestBody,
   buildPullRequestDiff,
   buildPullRequestReviewContext,
+  detectGeminiReviewerRunaway,
   extractReviewerResponseFromGemini,
   findExistingCodexReviewFallbackComment,
   findExistingGeminiReviewComment,
   formatCodexReviewFallbackComment,
   formatGeminiReviewComment,
+  formatGeminiReviewRunawayGuardComment,
   isReviewerTerminalApproved,
   parseGeminiReviewComment,
   resolveOperatorMention,
@@ -52,6 +56,33 @@ async function main() {
     })
   ) {
     console.log(`Skipping Gemini PR review: reviewer already approved current PR head on PR #${prNumber}.`);
+    return;
+  }
+
+  const runawayGuard = detectGeminiReviewerRunaway({
+    issueComments,
+    windowMinutes: parsePositiveInteger(process.env.VTDD_REVIEWER_RUNAWAY_WINDOW_MINUTES) || DEFAULT_REVIEWER_RUNAWAY_WINDOW_MINUTES,
+    maxReviewerComments: parsePositiveInteger(process.env.VTDD_REVIEWER_RUNAWAY_MAX_COMMENTS) || DEFAULT_REVIEWER_RUNAWAY_MAX_COMMENTS
+  });
+  if (runawayGuard.triggered) {
+    if (runawayGuard.shouldNotifyOwner) {
+      const guardBody = formatGeminiReviewRunawayGuardComment({
+        repository,
+        pullRequestNumber: prNumber,
+        headSha: pullRequest?.head?.sha,
+        windowMinutes: runawayGuard.windowMinutes,
+        maxReviewerComments: runawayGuard.maxReviewerComments,
+        recentReviewerCommentCount: runawayGuard.recentReviewerCommentCount,
+        notificationMention: resolveOperatorMention([pullRequest?.user?.login, payload?.sender?.login])
+      });
+      await githubFetch(`/repos/${repository}/issues/${prNumber}/comments`, {
+        method: "POST",
+        body: { body: guardBody }
+      });
+    }
+    console.log(
+      `Skipping Gemini PR review: runaway guard triggered on PR #${prNumber} (${runawayGuard.recentReviewerCommentCount}/${runawayGuard.maxReviewerComments} reviewer comments in ${runawayGuard.windowMinutes}m).`
+    );
     return;
   }
 
@@ -187,6 +218,11 @@ function mustGetEnv(name) {
     throw new Error(`${name} is required`);
   }
   return value;
+}
+
+function parsePositiveInteger(value) {
+  const numeric = Number(value);
+  return Number.isInteger(numeric) && numeric > 0 ? numeric : null;
 }
 
 function shouldMentionGeminiReviewResult({ existingComment, recommendedAction }) {

--- a/src/core/gemini-pr-review.js
+++ b/src/core/gemini-pr-review.js
@@ -4,9 +4,12 @@ import { formatReviewerOperatorSummary } from "./reviewer-operator-summary.js";
 
 export const GEMINI_PR_REVIEW_MARKER = "<!-- vtdd:reviewer=gemini -->";
 export const REVIEWER_OBJECTION_RESOLUTION_MARKER = "<!-- vtdd:reviewer-objection-resolution -->";
+export const GEMINI_REVIEW_RUNAWAY_GUARD_MARKER = "<!-- vtdd:reviewer=runaway-guard -->";
 export const DEFAULT_GEMINI_REVIEW_MODEL = "gemini-2.5-flash";
 export const MAX_DIFF_CHARACTERS = 60000;
 export const MAX_CONTEXT_COMMENTS = 10;
+export const DEFAULT_REVIEWER_RUNAWAY_WINDOW_MINUTES = 30;
+export const DEFAULT_REVIEWER_RUNAWAY_MAX_COMMENTS = 20;
 
 export function resolveGeminiReviewTrigger(input = {}) {
   const eventName = normalizeText(input.eventName);
@@ -112,6 +115,65 @@ export function buildPullRequestDiff(files = [], options = {}) {
     return joined;
   }
   return `${joined.slice(0, maxCharacters)}\n\n[diff truncated]`;
+}
+
+export function detectGeminiReviewerRunaway(input = {}) {
+  const comments = Array.isArray(input.issueComments) ? input.issueComments : [];
+  const windowMinutes =
+    normalizePositiveInteger(input.windowMinutes) || DEFAULT_REVIEWER_RUNAWAY_WINDOW_MINUTES;
+  const maxReviewerComments =
+    normalizePositiveInteger(input.maxReviewerComments) || DEFAULT_REVIEWER_RUNAWAY_MAX_COMMENTS;
+  const nowMs = normalizeTimestampMs(input.now) ?? Date.now();
+  const windowStartMs = nowMs - windowMinutes * 60 * 1000;
+  const recentReviewerComments = comments.filter((comment) => {
+    const createdAtMs = normalizeTimestampMs(comment?.created_at);
+    if (!createdAtMs || createdAtMs < windowStartMs || createdAtMs > nowMs) {
+      return false;
+    }
+    const body = normalizeText(comment?.body);
+    return containsReviewerMarker(body) || body.includes("<!-- vtdd:reviewer=codex-fallback");
+  });
+  const existingGuardComment =
+    comments.find((comment) => normalizeText(comment?.body).includes(GEMINI_REVIEW_RUNAWAY_GUARD_MARKER)) ?? null;
+
+  return {
+    triggered: recentReviewerComments.length >= maxReviewerComments,
+    reason: recentReviewerComments.length >= maxReviewerComments ? "reviewer_comment_storm" : "within_threshold",
+    windowMinutes,
+    maxReviewerComments,
+    recentReviewerCommentCount: recentReviewerComments.length,
+    existingGuardComment,
+    shouldNotifyOwner: recentReviewerComments.length >= maxReviewerComments && !existingGuardComment
+  };
+}
+
+export function formatGeminiReviewRunawayGuardComment(input = {}) {
+  const notificationMention = normalizeMentionLogin(input.notificationMention);
+  const mentionPrefix = notificationMention ? `@${notificationMention} ` : "";
+  const repository = normalizeText(input.repository) || "unknown";
+  const pullRequestNumber = normalizePositiveInteger(input.pullRequestNumber) || "unknown";
+  const headSha = normalizeText(input.headSha) || "unknown";
+  const recentCount = normalizePositiveInteger(input.recentReviewerCommentCount) || 0;
+  const windowMinutes =
+    normalizePositiveInteger(input.windowMinutes) || DEFAULT_REVIEWER_RUNAWAY_WINDOW_MINUTES;
+  const maxReviewerComments =
+    normalizePositiveInteger(input.maxReviewerComments) || DEFAULT_REVIEWER_RUNAWAY_MAX_COMMENTS;
+  return [
+    GEMINI_REVIEW_RUNAWAY_GUARD_MARKER,
+    `${mentionPrefix}VTDD runaway guard: Gemini reviewer loop を停止しました。`.trim(),
+    "",
+    "## Operator Summary",
+    "",
+    "- status: stopped",
+    "- stopped scope: gemini-pr-review",
+    `- repository: ${repository}`,
+    `- pull request: #${pullRequestNumber}`,
+    `- headSha: ${headSha}`,
+    `- detected: ${recentCount} reviewer marker comments within ${windowMinutes} minutes`,
+    `- threshold: ${maxReviewerComments}`,
+    "- next: Issue / PR / reviewer marker timeline を確認し、原因を切り分けてから resume 条件を決めてください。",
+    "- resume condition: time window が落ち着く、または owner が原因確認後に明示的に再開判断するまで追加 Gemini review は行いません。"
+  ].join("\n");
 }
 
 export function buildPullRequestReviewContext(input = {}) {
@@ -706,6 +768,11 @@ function normalizePositiveInteger(value) {
     return null;
   }
   return numeric;
+}
+
+function normalizeTimestampMs(value) {
+  const timestamp = Date.parse(normalizeText(value));
+  return Number.isFinite(timestamp) ? timestamp : null;
 }
 
 function normalizeObject(value) {

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -187,6 +187,9 @@ export {
 } from "./remote-codex-executor.js";
 export {
   DEFAULT_GEMINI_REVIEW_MODEL,
+  DEFAULT_REVIEWER_RUNAWAY_MAX_COMMENTS,
+  DEFAULT_REVIEWER_RUNAWAY_WINDOW_MINUTES,
+  GEMINI_REVIEW_RUNAWAY_GUARD_MARKER,
   GEMINI_PR_REVIEW_MARKER,
   MAX_CONTEXT_COMMENTS,
   MAX_DIFF_CHARACTERS,
@@ -195,8 +198,10 @@ export {
   buildPullRequestDiff,
   buildPullRequestReviewContext,
   buildReviewResponseSummary,
+  detectGeminiReviewerRunaway,
   extractReviewerResponseFromGemini,
   findExistingGeminiReviewComment,
+  formatGeminiReviewRunawayGuardComment,
   formatReviewResponseSummary,
   formatGeminiReviewComment,
   parseGeminiReviewComment,

--- a/test/gemini-pr-review-workflow.test.js
+++ b/test/gemini-pr-review-workflow.test.js
@@ -58,6 +58,15 @@ test("Gemini review script stops issue-comment reruns when reviewer already appr
   assert.equal(script.includes("headSha: pullRequest?.head?.sha"), true);
 });
 
+test("Gemini review script stops reviewer comment storms before another review", () => {
+  const script = fs.readFileSync("scripts/run-gemini-pr-review.mjs", "utf8");
+  assert.equal(script.includes("detectGeminiReviewerRunaway"), true);
+  assert.equal(script.includes("formatGeminiReviewRunawayGuardComment"), true);
+  assert.equal(script.includes("VTDD_REVIEWER_RUNAWAY_WINDOW_MINUTES"), true);
+  assert.equal(script.includes("VTDD_REVIEWER_RUNAWAY_MAX_COMMENTS"), true);
+  assert.equal(script.includes("Skipping Gemini PR review: runaway guard triggered"), true);
+});
+
 test("Gemini review script defaults Codex fallback to VPS Codex CLI transport", () => {
   const script = fs.readFileSync("scripts/run-gemini-pr-review.mjs", "utf8");
   assert.equal(script.includes('deliveryMode: "vps_codex_cli"'), true);

--- a/test/gemini-pr-review.test.js
+++ b/test/gemini-pr-review.test.js
@@ -2,15 +2,18 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import {
   GEMINI_PR_REVIEW_MARKER,
+  GEMINI_REVIEW_RUNAWAY_GUARD_MARKER,
   REVIEWER_OBJECTION_RESOLUTION_MARKER,
   buildGeminiReviewRequestBody,
   buildPullRequestDiff,
   buildPullRequestReviewContext,
   buildReviewResponseSummary,
+  detectGeminiReviewerRunaway,
   extractReviewerResponseFromGemini,
   findExistingGeminiReviewComment,
   formatReviewResponseSummary,
   formatGeminiReviewComment,
+  formatGeminiReviewRunawayGuardComment,
   normalizeMentionLogin,
   parseGeminiReviewComment,
   resolveOperatorMention,
@@ -179,6 +182,92 @@ test("issue_comment on PR from future reviewer marker skips self-trigger loop", 
   assert.equal(result.ok, true);
   assert.equal(result.value.shouldReview, false);
   assert.equal(result.value.reason, "bot_or_marker_comment");
+});
+
+test("issue_comment on PR from runaway guard marker skips self-trigger loop", () => {
+  const result = resolveGeminiReviewTrigger({
+    eventName: "issue_comment",
+    payload: {
+      issue: {
+        number: 347,
+        pull_request: {
+          url: "https://api.github.com/repos/marushu/vtdd-v2-p/pulls/347"
+        }
+      },
+      comment: {
+        body: `${GEMINI_REVIEW_RUNAWAY_GUARD_MARKER}\nVTDD runaway guard`
+      },
+      sender: {
+        login: "vtdd-gemini-reviewer[bot]"
+      }
+    }
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.value.shouldReview, false);
+  assert.equal(result.value.reason, "bot_or_marker_comment");
+});
+
+test("Gemini reviewer runaway detector triggers on recent reviewer marker storm", () => {
+  const now = "2026-05-15T10:00:00.000Z";
+  const issueComments = Array.from({ length: 4 }, (_, index) => ({
+    created_at: `2026-05-15T09:5${index}:00.000Z`,
+    body: index % 2 === 0 ? GEMINI_PR_REVIEW_MARKER : "<!-- vtdd:reviewer=codex-fallback -->"
+  }));
+
+  const result = detectGeminiReviewerRunaway({
+    issueComments,
+    now,
+    windowMinutes: 15,
+    maxReviewerComments: 4
+  });
+
+  assert.equal(result.triggered, true);
+  assert.equal(result.reason, "reviewer_comment_storm");
+  assert.equal(result.recentReviewerCommentCount, 4);
+  assert.equal(result.shouldNotifyOwner, true);
+});
+
+test("Gemini reviewer runaway detector does not re-notify when guard already exists", () => {
+  const issueComments = [
+    ...Array.from({ length: 3 }, () => ({
+      created_at: "2026-05-15T10:00:00.000Z",
+      body: GEMINI_PR_REVIEW_MARKER
+    })),
+    {
+      created_at: "2026-05-15T10:01:00.000Z",
+      body: GEMINI_REVIEW_RUNAWAY_GUARD_MARKER
+    }
+  ];
+
+  const result = detectGeminiReviewerRunaway({
+    issueComments,
+    now: "2026-05-15T10:02:00.000Z",
+    windowMinutes: 10,
+    maxReviewerComments: 3
+  });
+
+  assert.equal(result.triggered, true);
+  assert.equal(result.shouldNotifyOwner, false);
+  assert.equal(result.existingGuardComment.body, GEMINI_REVIEW_RUNAWAY_GUARD_MARKER);
+});
+
+test("formatGeminiReviewRunawayGuardComment renders Japanese owner notification", () => {
+  const body = formatGeminiReviewRunawayGuardComment({
+    notificationMention: "marushu",
+    repository: "marushu/vtdd-v2-p",
+    pullRequestNumber: 347,
+    headSha: "abc123",
+    recentReviewerCommentCount: 622,
+    windowMinutes: 60,
+    maxReviewerComments: 20
+  });
+
+  assert.equal(body.includes(GEMINI_REVIEW_RUNAWAY_GUARD_MARKER), true);
+  assert.equal(body.includes("@marushu VTDD runaway guard"), true);
+  assert.equal(body.includes("Gemini reviewer loop を停止しました"), true);
+  assert.equal(body.includes("detected: 622 reviewer marker comments within 60 minutes"), true);
+  assert.equal(body.includes("resume condition"), true);
 });
 
 test("buildPullRequestDiff truncates large diffs", () => {


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #358 の部分進捗として、Gemini reviewer のコメント嵐を検知した時に追加レビュー前で停止し、owner に日本語で要対応通知を残す。
- PR #347 で起きた大量コメント再発を、reviewer 自身の self-stop guard として最小範囲で止める。

## Satisfied Success Criteria

- 一定時間内の reviewer marker コメント数を検知する detectGeminiReviewerRunaway を追加。
- 閾値超過時は Gemini API 呼び出し前に停止する。
- 既存 guard がない場合だけ、日本語 owner-facing の runaway guard marker コメントを 1 件だけ投稿する。
- runaway guard marker 自体は issue_comment trigger の reviewer marker skip に乗るため、追加 loop を起こさない。
- 閾値と時間窓を VTDD_REVIEWER_RUNAWAY_WINDOW_MINUTES / VTDD_REVIEWER_RUNAWAY_MAX_COMMENTS で調整できる。

## Unsatisfied Success Criteria

- Issue #358 全体の owner emergency stop、Butler 自然言語 stop intent、全 workflow/run 数監視、resume UI、PR #347 実データ fixture E2E は未実装。
- この PR は Gemini reviewer の comment storm guard のみで、executor / deploy / secret mutation / repository settings には触れていない。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #358
- Implementing Success Criteria: Gemini reviewer が異常な reviewer comment storm を検知し、追加実行を止め、owner に日本語で止めた範囲と次の確認点を知らせる。
- Explicit Non-goals: workflow disable、repository settings mutation、全 actor kill switch、Butler stop intent、PR #347 fixture 化はこの PR では扱わない。
- Expected touched files/routes/workflows: scripts/run-gemini-pr-review.mjs、src/core/gemini-pr-review.js、src/core/index.js、test/gemini-pr-review*.test.js、docs/butler/gemini-pr-review-comments.md
- Affected Issues: Issue #358。関連: Issue #349 / Issue #351 / Issue #356 は設計上影響し得るが、この PR では直接実装しない。
- Affected PRs: PR #347 の再発防止観点。既存 open PR への直接変更なし。
- Affected workflows: gemini-pr-review workflow の script 実行経路。codex-fallback reviewer は marker count の対象になるが、fallback 実装自体は変更しない。
- Affected runtime/operator surfaces: GitHub Actions reviewer surface。Butler / Worker / operator / Custom GPT Action Schema は未変更。
- What may break if we patch narrowly: コメント更新方式だけを変えると時系列 evidence を失う。workflow disable だけに寄せると原因通知と resume 条件が残らない。今回は append 方針を維持し、異常時だけ self-stop marker を 1 件に制限する。
- Unknowns to investigate before coding: 本番 PR #347 の実コメント timeline fixture 化は未実施。GitHub App token 投稿者 identity は既存 workflow 設定に依存する。
- Validation needed: unit / workflow script integration / full npm test。live PR での runaway E2E は別スライス。
- Stop condition: owner emergency stop や repo settings mutation が必要になった場合は GO + passkey が必要なので停止する。

## File / Line Hypotheses

- file: scripts/run-gemini-pr-review.mjs
  - hypothesis: Gemini API 呼び出し前に comment storm guard を入れると、追加レビューと追加コメントを止められる。
  - risk if changed narrowly: terminal approve 判定より前に置くと approve 済み PR で不要通知が出るため、approve 判定後・Gemini call 前に置く。
  - validation: workflow script test と unit test。
  - related Issue: Issue #358
- file: src/core/gemini-pr-review.js
  - hypothesis: reviewer marker の短時間 count と既存 guard 検出を pure function にすると、workflow 以外からも再利用できる。
  - risk if changed narrowly: guard marker が self-trigger すると再び loop するため、既存 reviewer marker skip と同じ marker 形にする。
  - validation: issue_comment trigger skip test。
  - related Issue: Issue #358

## Hypothesis Retrospective

- expected: Gemini review call 前の guard で comment storm を止められる。
- actual: synthetic comment storm unit test と workflow script integration では停止条件・1 回通知・self-skip を確認。
- mismatch: PR #347 実コメント fixture と live workflow E2E は未実施。
- lesson: append evidence 方針は維持しつつ、異常時は時系列追加より self-stop を優先する必要がある。
- should become RAG candidate: はい。PR #347 のコメント嵐再発防止の判断ログとして有用。

## Verification Evidence

- Unit: node --test test/gemini-pr-review.test.js test/gemini-pr-review-workflow.test.js passed: 51 tests.
- Integration: npm test passed: 772 tests, 771 pass, 1 skipped. check:generated-worker passed.
- E2E: 未実施。この PR は synthetic reviewer comment storm による partial guard 実装。PR #347 fixture/live E2E は別スライス。
- Manual: git diff --check passed.
- Evidence path/link: local test output in this Codex run.

## Butler Completion Contract

- Owner goal: VTDD がコメント嵐や reviewer loop で credit / Actions / owner 注意力を浪費しないよう、異常時に止まり、知らせる。
- Butler entrypoint: 未接続。この PR では Butler の自然言語 stop intent は実装しない。
- Action Schema exposure: 未変更。
- Runtime path: GitHub Actions gemini-pr-review -> scripts/run-gemini-pr-review.mjs -> detectGeminiReviewerRunaway -> guard comment or skip.
- Runner/runtime truth: GitHub PR comment timeline に runaway guard marker を残す。workflow log は Skipping Gemini PR review: runaway guard triggered を出す。
- Authority boundary: 新しい high-risk authority なし。repo settings / workflow disable / credential mutation は行わない。既存 reviewer GitHub App token による issue comment 投稿のみ。
- E2E evidence: 未実施。Butler-facing emergency stop は Issue #358 の残作業。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 不要。この PR は Worker runtime route / worker.js を変更していない。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。Butler stop intent は別スライス。

## Related Constitution Rules

- Issue-driven partial PR。
- AGENTS.md Drift Stop Protocol。
- Owner-facing 日本語通知。
- Evidence Discipline: completion は incomplete と明記。

## Out-of-scope but NOT implemented

- Butler から「止めて」で止める owner emergency stop。
- workflow run 数 / Actions minutes / quota の横断監視。
- 全 actor 共通 kill switch。
- PR #347 実データ fixture 化。

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #358
- Execution ID: mac-codex-issue-358-runaway-guard
- Goal: PR #347 型の Gemini reviewer コメント嵐を reviewer 自身が検知して止まる最小 guard を入れる。
