### PR TITLE
Issue #359: setup surface update truth を表示する

### DIFF
--- a/src/core/custom-gpt-setup-artifacts.js
+++ b/src/core/custom-gpt-setup-artifacts.js
@@ -249,6 +249,14 @@ export async function evaluateButlerSelfParity(input = {}) {
     instructions.artifact.content,
     RUNTIME_SETUP_MANIFEST.operationIds
   );
+  const knownGoodComparison = await compareKnownGoodSetupArtifacts({
+    repository,
+    ref,
+    runtimeOrigin,
+    env,
+    latestInstructions: instructions.artifact,
+    latestOpenapi: openapi.artifact
+  });
   const runtimeMissingRoutes = manifestParity.runtimeMissing.routes;
   const runtimeMissingOperationIds = manifestParity.runtimeMissing.operationIds;
   const runtimeMissingInstructionTokens = manifestParity.runtimeMissing.instructionTokens;
@@ -295,6 +303,14 @@ export async function evaluateButlerSelfParity(input = {}) {
             ? `Open the same-origin passkey operator helper: ${deployOperatorMarkdownLink}`
             : "Resolve the repository on the current Butler surface before generating a passkey operator helper URL."
         ];
+  const surfaceUpdateChecklist = buildSurfaceUpdateChecklist({
+    runtimeParity,
+    deployOperatorUrl,
+    deployOperatorMarkdownLink,
+    instructionsArtifact: instructions.artifact,
+    openapiArtifact: openapi.artifact,
+    knownGoodComparison
+  });
 
   return {
     ok: true,
@@ -336,6 +352,8 @@ export async function evaluateButlerSelfParity(input = {}) {
               operatorMarkdownLink: deployOperatorMarkdownLink
             }
           : null,
+      knownGoodComparison,
+      surfaceUpdateChecklist,
       recommendedActions
     }
   };
@@ -516,7 +534,9 @@ export async function buildCustomGptRecoveryBundle(input = {}) {
       },
       runtime: {
         selfParity: selfParity.selfParity,
-        deployState: selfParity.selfParity.runtimeParity
+        deployState: selfParity.selfParity.runtimeParity,
+        knownGoodComparison: selfParity.selfParity.knownGoodComparison,
+        surfaceUpdateChecklist: selfParity.selfParity.surfaceUpdateChecklist
       },
       safety: {
         displaysSecrets: false,
@@ -739,6 +759,8 @@ function renderRecoveryBundleSections(recovery) {
   const actionSchema = recovery.actionSchema;
   const rollback = recovery.rollback;
   const selfParity = recovery.runtime.selfParity;
+  const surfaceUpdateChecklist = recovery.runtime.surfaceUpdateChecklist;
+  const knownGoodComparison = recovery.runtime.knownGoodComparison;
   const warning = instructions.limitExceeded
     ? `<section class="warning"><strong>Instructions exceed ${instructions.characterLimit} characters.</strong><p>${instructions.characterCount} characters. Shorten before pasting into the Custom GPT editor.</p></section>`
     : "";
@@ -760,6 +782,8 @@ function renderRecoveryBundleSections(recovery) {
         <div><strong>Safety</strong><br>No secret values, tokens, or approval grants are displayed.</div>
       </div>
     </section>
+    ${renderSurfaceUpdateChecklist(surfaceUpdateChecklist)}
+    ${renderKnownGoodComparison(knownGoodComparison)}
     <section>
       <h2>URL separation</h2>
       <div class="meta">
@@ -834,6 +858,176 @@ function renderRecoveryBundleSections(recovery) {
             )}</textarea>`
           : ""
       }
+    </section>`;
+}
+
+function buildSurfaceUpdateChecklist({
+  runtimeParity,
+  deployOperatorUrl,
+  deployOperatorMarkdownLink,
+  instructionsArtifact,
+  openapiArtifact,
+  knownGoodComparison
+}) {
+  const deployRequired = runtimeParity === "cloudflare_deploy_update_required";
+  const actionSchemaDiffers = knownGoodComparison?.actionSchema?.status === "different";
+  const instructionsDiffers = knownGoodComparison?.instructions?.status === "different";
+  return {
+    cloudflareDeploy: {
+      status: deployRequired ? "required" : "not_required",
+      reason: deployRequired
+        ? "Canonical setup expects runtime capability that the deployed manifest does not advertise."
+        : "Runtime manifest matches canonical setup routes, operationIds, and instruction tokens.",
+      operatorUrl: deployRequired ? deployOperatorUrl : null,
+      operatorMarkdownLink: deployRequired ? deployOperatorMarkdownLink : null
+    },
+    customGptActionSchema: {
+      status: actionSchemaDiffers ? "update_required_if_editor_is_known_good" : "unverified_editor_state",
+      reason: actionSchemaDiffers
+        ? "Latest Action Schema differs from known-good. If the Custom GPT editor is still on known-good, Action Schema update required."
+        : "VTDD runtime cannot read the current Custom GPT editor Action Schema. If this source SHA was not pasted after the last setup update, Action Schema update required.",
+      sourcePath: openapiArtifact?.path ?? "docs/setup/custom-gpt-actions-openapi.yaml",
+      sourceSha: openapiArtifact?.sha ?? null,
+      knownGoodSourceSha: knownGoodComparison?.actionSchema?.knownGoodSourceSha ?? null,
+      copyFrom: "/setup/latest",
+      copyPayload: "raw_yaml_not_url_encoded"
+    },
+    customGptInstructions: {
+      status: instructionsDiffers ? "update_required_if_editor_is_known_good" : "unverified_editor_state",
+      reason: instructionsDiffers
+        ? "Latest Instructions differ from known-good. If the Custom GPT editor is still on known-good, Instructions update required."
+        : "VTDD runtime cannot read the current Custom GPT editor Instructions. If this source SHA was not pasted after the last setup update, Instructions update required.",
+      sourcePath: instructionsArtifact?.path ?? "docs/setup/custom-gpt-instructions.md",
+      sourceSha: instructionsArtifact?.sha ?? null,
+      knownGoodSourceSha: knownGoodComparison?.instructions?.knownGoodSourceSha ?? null,
+      copyFrom: "/setup/latest",
+      copyPayload: "raw_markdown_not_url_encoded"
+    }
+  };
+}
+
+async function compareKnownGoodSetupArtifacts({
+  repository,
+  ref,
+  runtimeOrigin,
+  env,
+  latestInstructions,
+  latestOpenapi
+}) {
+  const knownGood = resolveConfiguredKnownGoodCommitSha({ ref: "", env });
+  if (!knownGood?.sha) {
+    return {
+      status: "known_good_unavailable",
+      knownGoodCommitSha: null,
+      knownGoodCommitSource: knownGood?.source ?? "unconfigured",
+      updateJudgment: "unverified",
+      summary:
+        "known-good commit が未設定のため、latest と known-good の差分から Custom GPT 更新要否を判断できません。"
+    };
+  }
+
+  if (knownGood.sha === ref) {
+    return {
+      status: "same_ref",
+      knownGoodCommitSha: knownGood.sha,
+      knownGoodCommitSource: knownGood.source,
+      updateJudgment: "no_known_good_difference",
+      summary: "latest ref と known-good ref が同一です。"
+    };
+  }
+
+  const [knownGoodInstructions, knownGoodOpenapi] = await Promise.all([
+    retrieveCustomGptSetupArtifact({
+      artifact: CustomGptSetupArtifact.INSTRUCTIONS,
+      repository,
+      ref: knownGood.sha,
+      env
+    }),
+    retrieveCustomGptSetupArtifact({
+      artifact: CustomGptSetupArtifact.OPENAPI_YAML,
+      repository,
+      ref: knownGood.sha,
+      env
+    })
+  ]);
+
+  if (!knownGoodInstructions.ok || !knownGoodOpenapi.ok) {
+    const failed = [knownGoodInstructions, knownGoodOpenapi].find((result) => !result.ok);
+    return {
+      status: "comparison_unavailable",
+      knownGoodCommitSha: knownGood.sha,
+      knownGoodCommitSource: knownGood.source,
+      updateJudgment: "unverified",
+      reason: failed?.reason ?? "known-good setup artifact could not be read",
+      summary:
+        "known-good artifact を読めないため、latest と known-good の差分から Custom GPT 更新要否を判断できません。"
+    };
+  }
+
+  const latestActionSchema = expandOpenApiServerUrl(latestOpenapi.content, runtimeOrigin);
+  const knownGoodActionSchema = expandOpenApiServerUrl(
+    knownGoodOpenapi.artifact.content,
+    runtimeOrigin
+  );
+  const actionSchemaStatus = latestActionSchema === knownGoodActionSchema ? "same" : "different";
+  const instructionsStatus =
+    latestInstructions.content === knownGoodInstructions.artifact.content ? "same" : "different";
+  const hasDifference = actionSchemaStatus === "different" || instructionsStatus === "different";
+
+  return {
+    status: hasDifference ? "different" : "same",
+    knownGoodCommitSha: knownGood.sha,
+    knownGoodCommitSource: knownGood.source,
+    updateJudgment: hasDifference
+      ? "update_required_if_editor_is_known_good"
+      : "no_known_good_difference",
+    summary: hasDifference
+      ? "latest と known-good に差があります。Custom GPT editor が known-good のままなら更新が必要です。"
+      : "latest と known-good の copy payload は一致しています。",
+    actionSchema: {
+      status: actionSchemaStatus,
+      latestSourceSha: latestOpenapi.sha,
+      knownGoodSourceSha: knownGoodOpenapi.artifact.sha
+    },
+    instructions: {
+      status: instructionsStatus,
+      latestSourceSha: latestInstructions.sha,
+      knownGoodSourceSha: knownGoodInstructions.artifact.sha
+    }
+  };
+}
+
+function renderSurfaceUpdateChecklist(checklist) {
+  if (!checklist) {
+    return "";
+  }
+  const deploy = checklist.cloudflareDeploy ?? {};
+  const actionSchema = checklist.customGptActionSchema ?? {};
+  const instructions = checklist.customGptInstructions ?? {};
+  return `<section>
+      <h2>Surface update checklist</h2>
+      <div class="meta">
+        <div><strong>Cloudflare deploy</strong><br>${escapeHtml(deploy.status || "未確認")}<br><span class="small">${escapeHtml(deploy.reason || "")}</span></div>
+        <div><strong>Custom GPT Action Schema</strong><br>${escapeHtml(actionSchema.status || "未確認")}<br><span class="small">${escapeHtml(actionSchema.sourcePath || "")}<br>sourceSha: ${escapeHtml(actionSchema.sourceSha || "未確認")}</span></div>
+        <div><strong>Custom GPT Instructions</strong><br>${escapeHtml(instructions.status || "未確認")}<br><span class="small">${escapeHtml(instructions.sourcePath || "")}<br>sourceSha: ${escapeHtml(instructions.sourceSha || "未確認")}</span></div>
+      </div>
+      <p class="small">Custom GPT editor の現在値は runtime から読めないため、editor 側は未検証として表示します。最後に貼った sourceSha が一致しない場合は更新が必要です。</p>
+    </section>`;
+}
+
+function renderKnownGoodComparison(comparison) {
+  if (!comparison) {
+    return "";
+  }
+  return `<section>
+      <h2>Latest / known-good comparison</h2>
+      <div class="meta">
+        <div><strong>Comparison</strong><br>${escapeHtml(comparison.status || "未確認")}<br><span class="small">${escapeHtml(comparison.summary || "")}</span></div>
+        <div><strong>Update judgment</strong><br>${escapeHtml(comparison.updateJudgment || "unverified")}</div>
+        <div><strong>Known-good commit</strong><br>${escapeHtml(comparison.knownGoodCommitSha || "未確認")}<br><span class="small">${escapeHtml(comparison.knownGoodCommitSource || "")}</span></div>
+        <div><strong>Action Schema diff</strong><br>${escapeHtml(comparison.actionSchema?.status || "未確認")}</div>
+        <div><strong>Instructions diff</strong><br>${escapeHtml(comparison.instructions?.status || "未確認")}</div>
+      </div>
     </section>`;
 }
 

--- a/test/custom-gpt-setup-artifacts.test.js
+++ b/test/custom-gpt-setup-artifacts.test.js
@@ -358,9 +358,120 @@ test("buildCustomGptRecoveryBundle expands Worker URL and reports short-min leng
   assert.equal(result.recovery.rollback.knownGoodCommitSha, null);
   assert.equal(result.recovery.rollback.knownGoodCommitSource, "not_checked_on_latest");
   assert.equal(result.recovery.runtime.deployState, "in_sync");
+  assert.deepEqual(result.recovery.runtime.surfaceUpdateChecklist.cloudflareDeploy, {
+    status: "not_required",
+    reason: "Runtime manifest matches canonical setup routes, operationIds, and instruction tokens.",
+    operatorUrl: null,
+    operatorMarkdownLink: null
+  });
+  assert.equal(
+    result.recovery.runtime.surfaceUpdateChecklist.customGptActionSchema.status,
+    "unverified_editor_state"
+  );
+  assert.equal(
+    result.recovery.runtime.surfaceUpdateChecklist.customGptActionSchema.sourceSha,
+    "openapi-sha"
+  );
+  assert.equal(
+    result.recovery.runtime.surfaceUpdateChecklist.customGptInstructions.status,
+    "unverified_editor_state"
+  );
+  assert.equal(
+    result.recovery.runtime.surfaceUpdateChecklist.customGptInstructions.sourceSha,
+    "instructions-sha"
+  );
+  assert.equal(result.recovery.runtime.knownGoodComparison.status, "known_good_unavailable");
+  assert.equal(result.recovery.runtime.knownGoodComparison.updateJudgment, "unverified");
   assert.deepEqual(result.recovery.safety, {
     displaysSecrets: false,
     displaysTokens: false,
     displaysApprovalGrant: false
   });
+});
+
+test("buildCustomGptRecoveryBundle reports latest differs from configured known-good", async () => {
+  const latestOpenApi = [
+    "openapi: 3.1.1",
+    "servers:",
+    "  - url: https://your-runtime-host.example.workers.dev",
+    "paths:",
+    "  /health:",
+    "    get:",
+    "      operationId: getHealth",
+    "  /v2/retrieve/self-parity:",
+    "    get:",
+    "      operationId: vtddRetrieveSelfParity"
+  ].join("\n");
+  const latestInstructions = [
+    "vtddRetrieveSelfParity",
+    "Action Schema update required",
+    "Instructions update required",
+    "Cloudflare deploy update required"
+  ].join("\n");
+  const knownGoodOpenApi = latestOpenApi.replace("/v2/retrieve/self-parity", "/v2/retrieve/setup-artifact");
+  const knownGoodInstructions = latestInstructions.replace("vtddRetrieveSelfParity", "vtddRetrieveSetupArtifact");
+  const knownGoodSha = "c".repeat(40);
+
+  const result = await buildCustomGptRecoveryBundle({
+    repository: "sample-org/vtdd-v2-p",
+    ref: "main",
+    runtimeOrigin: "https://sample-user-vtdd.example.workers.dev",
+    env: {
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_setup_read",
+      VTDD_KNOWN_GOOD_COMMIT_SHA: knownGoodSha,
+      GITHUB_API_FETCH: async (url) => {
+        const parsed = new URL(url);
+        if (parsed.pathname.endsWith("/commits/main")) {
+          return new Response(JSON.stringify({ sha: "d".repeat(40) }), {
+            status: 200,
+            headers: { "content-type": "application/json" }
+          });
+        }
+        const ref = parsed.searchParams.get("ref");
+        const isKnownGood = ref === knownGoodSha;
+        const isShortMin = parsed.pathname.endsWith(
+          "/docs/setup/custom-gpt-instructions-short-min.md"
+        );
+        const isInstructions = parsed.pathname.endsWith("/docs/setup/custom-gpt-instructions.md");
+        const content = isKnownGood
+          ? isInstructions || isShortMin
+            ? knownGoodInstructions
+            : knownGoodOpenApi
+          : isInstructions || isShortMin
+            ? latestInstructions
+            : latestOpenApi;
+        return new Response(
+          JSON.stringify({
+            sha: isKnownGood
+              ? isInstructions || isShortMin
+                ? "known-good-instructions-sha"
+                : "known-good-openapi-sha"
+              : isInstructions || isShortMin
+                ? "latest-instructions-sha"
+                : "latest-openapi-sha",
+            encoding: "base64",
+            content: encodeContent(content)
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        );
+      }
+    }
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.recovery.runtime.knownGoodComparison.status, "different");
+  assert.equal(
+    result.recovery.runtime.knownGoodComparison.updateJudgment,
+    "update_required_if_editor_is_known_good"
+  );
+  assert.equal(result.recovery.runtime.knownGoodComparison.actionSchema.status, "different");
+  assert.equal(result.recovery.runtime.knownGoodComparison.instructions.status, "different");
+  assert.equal(
+    result.recovery.runtime.surfaceUpdateChecklist.customGptActionSchema.status,
+    "update_required_if_editor_is_known_good"
+  );
+  assert.equal(
+    result.recovery.runtime.surfaceUpdateChecklist.customGptInstructions.status,
+    "update_required_if_editor_is_known_good"
+  );
 });

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -696,6 +696,13 @@ test("worker setup latest page renders copy-ready schema and short-min bundle fo
   assert.equal(html.includes("Rollback は setup/known-good で copy-ready になります。latest は現在の候補確認用で、known-good としては未確認です。"), true);
   assert.equal(html.includes("Action Schema length"), true);
   assert.equal(html.includes("instructionsShortMinLength:"), true);
+  assert.equal(html.includes("Surface update checklist"), true);
+  assert.equal(html.includes("Latest / known-good comparison"), true);
+  assert.equal(html.includes("known_good_unavailable"), true);
+  assert.equal(html.includes("Cloudflare deploy"), true);
+  assert.equal(html.includes("not_required"), true);
+  assert.equal(html.includes("Custom GPT editor の現在値は runtime から読めない"), true);
+  assert.equal(html.includes("unverified_editor_state"), true);
   assert.equal(html.includes("No secret values, tokens, or approval grants are displayed."), true);
   assert.equal(html.includes("ghs_setup_read"), false);
 });
@@ -3591,6 +3598,16 @@ test("worker returns Butler self-parity summary", async () => {
     `[Open deploy operator](${body.selfParity.deployOperatorUrl})`
   );
   assert.equal(body.selfParity.deployRecovery, null);
+  assert.equal(body.selfParity.surfaceUpdateChecklist.cloudflareDeploy.status, "not_required");
+  assert.equal(body.selfParity.knownGoodComparison.status, "known_good_unavailable");
+  assert.equal(
+    body.selfParity.surfaceUpdateChecklist.customGptActionSchema.status,
+    "unverified_editor_state"
+  );
+  assert.equal(
+    body.selfParity.surfaceUpdateChecklist.customGptInstructions.sourceSha,
+    "instructions-sha"
+  );
 });
 
 test("worker returns deploy recovery operator url in self-parity when runtime is stale", async () => {
@@ -3661,6 +3678,11 @@ test("worker returns deploy recovery operator url in self-parity when runtime is
   assert.equal(
     body.selfParity.deployRecovery.operatorMarkdownLink,
     `[Open deploy operator](${body.selfParity.deployRecovery.operatorUrl})`
+  );
+  assert.equal(body.selfParity.surfaceUpdateChecklist.cloudflareDeploy.status, "required");
+  assert.equal(
+    body.selfParity.surfaceUpdateChecklist.cloudflareDeploy.operatorUrl,
+    body.selfParity.deployRecovery.operatorUrl
   );
 });
 

--- a/worker.js
+++ b/worker.js
@@ -36285,6 +36285,14 @@ async function evaluateButlerSelfParity(input = {}) {
     instructions.artifact.content,
     RUNTIME_SETUP_MANIFEST.operationIds
   );
+  const knownGoodComparison = await compareKnownGoodSetupArtifacts({
+    repository,
+    ref,
+    runtimeOrigin,
+    env,
+    latestInstructions: instructions.artifact,
+    latestOpenapi: openapi.artifact
+  });
   const runtimeMissingRoutes = manifestParity.runtimeMissing.routes;
   const runtimeMissingOperationIds = manifestParity.runtimeMissing.operationIds;
   const runtimeMissingInstructionTokens = manifestParity.runtimeMissing.instructionTokens;
@@ -36310,6 +36318,14 @@ async function evaluateButlerSelfParity(input = {}) {
     "Cloudflare deploy update required.",
     deployOperatorMarkdownLink ? `Open the same-origin passkey operator helper: ${deployOperatorMarkdownLink}` : "Resolve the repository on the current Butler surface before generating a passkey operator helper URL."
   ];
+  const surfaceUpdateChecklist = buildSurfaceUpdateChecklist({
+    runtimeParity,
+    deployOperatorUrl,
+    deployOperatorMarkdownLink,
+    instructionsArtifact: instructions.artifact,
+    openapiArtifact: openapi.artifact,
+    knownGoodComparison
+  });
   return {
     ok: true,
     selfParity: {
@@ -36347,6 +36363,8 @@ async function evaluateButlerSelfParity(input = {}) {
         operatorUrl: deployOperatorUrl,
         operatorMarkdownLink: deployOperatorMarkdownLink
       } : null,
+      knownGoodComparison,
+      surfaceUpdateChecklist,
       recommendedActions
     }
   };
@@ -36489,7 +36507,9 @@ async function buildCustomGptRecoveryBundle(input = {}) {
       },
       runtime: {
         selfParity: selfParity.selfParity,
-        deployState: selfParity.selfParity.runtimeParity
+        deployState: selfParity.selfParity.runtimeParity,
+        knownGoodComparison: selfParity.selfParity.knownGoodComparison,
+        surfaceUpdateChecklist: selfParity.selfParity.surfaceUpdateChecklist
       },
       safety: {
         displaysSecrets: false,
@@ -36689,6 +36709,8 @@ function renderRecoveryBundleSections(recovery) {
   const actionSchema = recovery.actionSchema;
   const rollback = recovery.rollback;
   const selfParity = recovery.runtime.selfParity;
+  const surfaceUpdateChecklist = recovery.runtime.surfaceUpdateChecklist;
+  const knownGoodComparison = recovery.runtime.knownGoodComparison;
   const warning = instructions.limitExceeded ? `<section class="warning"><strong>Instructions exceed ${instructions.characterLimit} characters.</strong><p>${instructions.characterCount} characters. Shorten before pasting into the Custom GPT editor.</p></section>` : "";
   return `
     ${warning}
@@ -36707,6 +36729,8 @@ function renderRecoveryBundleSections(recovery) {
         <div><strong>Safety</strong><br>No secret values, tokens, or approval grants are displayed.</div>
       </div>
     </section>
+    ${renderSurfaceUpdateChecklist(surfaceUpdateChecklist)}
+    ${renderKnownGoodComparison(knownGoodComparison)}
     <section>
       <h2>URL separation</h2>
       <div class="meta">
@@ -36773,6 +36797,154 @@ function renderRecoveryBundleSections(recovery) {
       ...rollback.restoreOrder.map((item, index) => `  ${index + 1}. ${item}`)
     ].join("\n")
   )}</textarea>` : ""}
+    </section>`;
+}
+function buildSurfaceUpdateChecklist({
+  runtimeParity,
+  deployOperatorUrl,
+  deployOperatorMarkdownLink,
+  instructionsArtifact,
+  openapiArtifact,
+  knownGoodComparison
+}) {
+  const deployRequired = runtimeParity === "cloudflare_deploy_update_required";
+  const actionSchemaDiffers = knownGoodComparison?.actionSchema?.status === "different";
+  const instructionsDiffers = knownGoodComparison?.instructions?.status === "different";
+  return {
+    cloudflareDeploy: {
+      status: deployRequired ? "required" : "not_required",
+      reason: deployRequired ? "Canonical setup expects runtime capability that the deployed manifest does not advertise." : "Runtime manifest matches canonical setup routes, operationIds, and instruction tokens.",
+      operatorUrl: deployRequired ? deployOperatorUrl : null,
+      operatorMarkdownLink: deployRequired ? deployOperatorMarkdownLink : null
+    },
+    customGptActionSchema: {
+      status: actionSchemaDiffers ? "update_required_if_editor_is_known_good" : "unverified_editor_state",
+      reason: actionSchemaDiffers ? "Latest Action Schema differs from known-good. If the Custom GPT editor is still on known-good, Action Schema update required." : "VTDD runtime cannot read the current Custom GPT editor Action Schema. If this source SHA was not pasted after the last setup update, Action Schema update required.",
+      sourcePath: openapiArtifact?.path ?? "docs/setup/custom-gpt-actions-openapi.yaml",
+      sourceSha: openapiArtifact?.sha ?? null,
+      knownGoodSourceSha: knownGoodComparison?.actionSchema?.knownGoodSourceSha ?? null,
+      copyFrom: "/setup/latest",
+      copyPayload: "raw_yaml_not_url_encoded"
+    },
+    customGptInstructions: {
+      status: instructionsDiffers ? "update_required_if_editor_is_known_good" : "unverified_editor_state",
+      reason: instructionsDiffers ? "Latest Instructions differ from known-good. If the Custom GPT editor is still on known-good, Instructions update required." : "VTDD runtime cannot read the current Custom GPT editor Instructions. If this source SHA was not pasted after the last setup update, Instructions update required.",
+      sourcePath: instructionsArtifact?.path ?? "docs/setup/custom-gpt-instructions.md",
+      sourceSha: instructionsArtifact?.sha ?? null,
+      knownGoodSourceSha: knownGoodComparison?.instructions?.knownGoodSourceSha ?? null,
+      copyFrom: "/setup/latest",
+      copyPayload: "raw_markdown_not_url_encoded"
+    }
+  };
+}
+async function compareKnownGoodSetupArtifacts({
+  repository,
+  ref,
+  runtimeOrigin,
+  env,
+  latestInstructions,
+  latestOpenapi
+}) {
+  const knownGood = resolveConfiguredKnownGoodCommitSha({ ref: "", env });
+  if (!knownGood?.sha) {
+    return {
+      status: "known_good_unavailable",
+      knownGoodCommitSha: null,
+      knownGoodCommitSource: knownGood?.source ?? "unconfigured",
+      updateJudgment: "unverified",
+      summary: "known-good commit \u304C\u672A\u8A2D\u5B9A\u306E\u305F\u3081\u3001latest \u3068 known-good \u306E\u5DEE\u5206\u304B\u3089 Custom GPT \u66F4\u65B0\u8981\u5426\u3092\u5224\u65AD\u3067\u304D\u307E\u305B\u3093\u3002"
+    };
+  }
+  if (knownGood.sha === ref) {
+    return {
+      status: "same_ref",
+      knownGoodCommitSha: knownGood.sha,
+      knownGoodCommitSource: knownGood.source,
+      updateJudgment: "no_known_good_difference",
+      summary: "latest ref \u3068 known-good ref \u304C\u540C\u4E00\u3067\u3059\u3002"
+    };
+  }
+  const [knownGoodInstructions, knownGoodOpenapi] = await Promise.all([
+    retrieveCustomGptSetupArtifact({
+      artifact: CustomGptSetupArtifact.INSTRUCTIONS,
+      repository,
+      ref: knownGood.sha,
+      env
+    }),
+    retrieveCustomGptSetupArtifact({
+      artifact: CustomGptSetupArtifact.OPENAPI_YAML,
+      repository,
+      ref: knownGood.sha,
+      env
+    })
+  ]);
+  if (!knownGoodInstructions.ok || !knownGoodOpenapi.ok) {
+    const failed = [knownGoodInstructions, knownGoodOpenapi].find((result) => !result.ok);
+    return {
+      status: "comparison_unavailable",
+      knownGoodCommitSha: knownGood.sha,
+      knownGoodCommitSource: knownGood.source,
+      updateJudgment: "unverified",
+      reason: failed?.reason ?? "known-good setup artifact could not be read",
+      summary: "known-good artifact \u3092\u8AAD\u3081\u306A\u3044\u305F\u3081\u3001latest \u3068 known-good \u306E\u5DEE\u5206\u304B\u3089 Custom GPT \u66F4\u65B0\u8981\u5426\u3092\u5224\u65AD\u3067\u304D\u307E\u305B\u3093\u3002"
+    };
+  }
+  const latestActionSchema = expandOpenApiServerUrl(latestOpenapi.content, runtimeOrigin);
+  const knownGoodActionSchema = expandOpenApiServerUrl(
+    knownGoodOpenapi.artifact.content,
+    runtimeOrigin
+  );
+  const actionSchemaStatus = latestActionSchema === knownGoodActionSchema ? "same" : "different";
+  const instructionsStatus = latestInstructions.content === knownGoodInstructions.artifact.content ? "same" : "different";
+  const hasDifference = actionSchemaStatus === "different" || instructionsStatus === "different";
+  return {
+    status: hasDifference ? "different" : "same",
+    knownGoodCommitSha: knownGood.sha,
+    knownGoodCommitSource: knownGood.source,
+    updateJudgment: hasDifference ? "update_required_if_editor_is_known_good" : "no_known_good_difference",
+    summary: hasDifference ? "latest \u3068 known-good \u306B\u5DEE\u304C\u3042\u308A\u307E\u3059\u3002Custom GPT editor \u304C known-good \u306E\u307E\u307E\u306A\u3089\u66F4\u65B0\u304C\u5FC5\u8981\u3067\u3059\u3002" : "latest \u3068 known-good \u306E copy payload \u306F\u4E00\u81F4\u3057\u3066\u3044\u307E\u3059\u3002",
+    actionSchema: {
+      status: actionSchemaStatus,
+      latestSourceSha: latestOpenapi.sha,
+      knownGoodSourceSha: knownGoodOpenapi.artifact.sha
+    },
+    instructions: {
+      status: instructionsStatus,
+      latestSourceSha: latestInstructions.sha,
+      knownGoodSourceSha: knownGoodInstructions.artifact.sha
+    }
+  };
+}
+function renderSurfaceUpdateChecklist(checklist) {
+  if (!checklist) {
+    return "";
+  }
+  const deploy = checklist.cloudflareDeploy ?? {};
+  const actionSchema = checklist.customGptActionSchema ?? {};
+  const instructions = checklist.customGptInstructions ?? {};
+  return `<section>
+      <h2>Surface update checklist</h2>
+      <div class="meta">
+        <div><strong>Cloudflare deploy</strong><br>${escapeHtml3(deploy.status || "\u672A\u78BA\u8A8D")}<br><span class="small">${escapeHtml3(deploy.reason || "")}</span></div>
+        <div><strong>Custom GPT Action Schema</strong><br>${escapeHtml3(actionSchema.status || "\u672A\u78BA\u8A8D")}<br><span class="small">${escapeHtml3(actionSchema.sourcePath || "")}<br>sourceSha: ${escapeHtml3(actionSchema.sourceSha || "\u672A\u78BA\u8A8D")}</span></div>
+        <div><strong>Custom GPT Instructions</strong><br>${escapeHtml3(instructions.status || "\u672A\u78BA\u8A8D")}<br><span class="small">${escapeHtml3(instructions.sourcePath || "")}<br>sourceSha: ${escapeHtml3(instructions.sourceSha || "\u672A\u78BA\u8A8D")}</span></div>
+      </div>
+      <p class="small">Custom GPT editor \u306E\u73FE\u5728\u5024\u306F runtime \u304B\u3089\u8AAD\u3081\u306A\u3044\u305F\u3081\u3001editor \u5074\u306F\u672A\u691C\u8A3C\u3068\u3057\u3066\u8868\u793A\u3057\u307E\u3059\u3002\u6700\u5F8C\u306B\u8CBC\u3063\u305F sourceSha \u304C\u4E00\u81F4\u3057\u306A\u3044\u5834\u5408\u306F\u66F4\u65B0\u304C\u5FC5\u8981\u3067\u3059\u3002</p>
+    </section>`;
+}
+function renderKnownGoodComparison(comparison) {
+  if (!comparison) {
+    return "";
+  }
+  return `<section>
+      <h2>Latest / known-good comparison</h2>
+      <div class="meta">
+        <div><strong>Comparison</strong><br>${escapeHtml3(comparison.status || "\u672A\u78BA\u8A8D")}<br><span class="small">${escapeHtml3(comparison.summary || "")}</span></div>
+        <div><strong>Update judgment</strong><br>${escapeHtml3(comparison.updateJudgment || "unverified")}</div>
+        <div><strong>Known-good commit</strong><br>${escapeHtml3(comparison.knownGoodCommitSha || "\u672A\u78BA\u8A8D")}<br><span class="small">${escapeHtml3(comparison.knownGoodCommitSource || "")}</span></div>
+        <div><strong>Action Schema diff</strong><br>${escapeHtml3(comparison.actionSchema?.status || "\u672A\u78BA\u8A8D")}</div>
+        <div><strong>Instructions diff</strong><br>${escapeHtml3(comparison.instructions?.status || "\u672A\u78BA\u8A8D")}</div>
+      </div>
     </section>`;
 }
 function normalizeSetupChannel(value) {


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #359 の部分進捗として、Butler / recovery page が surface 更新要否を嘘なく読めるようにする。
- /latest と /known-good の copy payload 差分を比較し、Custom GPT editor を読めない状態でも「known-good のままなら要更新」を判断できる材料を返す。

## Satisfied Success Criteria

- self-parity に surfaceUpdateChecklist を追加し、Cloudflare deploy は required / not_required を返す。
- self-parity と setup recovery bundle に knownGoodComparison を追加し、latest と configured known-good の Action Schema / Instructions payload 差分を返す。
- known-good 未設定時は known_good_unavailable / unverified として、更新要否を断定しない。
- latest と known-good に差がある場合は update_required_if_editor_is_known_good を返す。
- /setup/latest に Surface update checklist と Latest / known-good comparison を表示する。

## Unsatisfied Success Criteria

- Custom GPT editor の現在値そのものは読めないため、editor が本当に最新かどうかの断定は未実装。
- owner が「反映済み」と言った記録を永続化し、sourceSha と照合する機能は未実装。
- Issue #359 の mobile clipboard E2E はこの PR では未実施。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #359
- Implementing Success Criteria: Butler / recovery page が deploy / Instructions / Action Schema の更新要否を、runtime から確認できる範囲と未検証範囲に分けて案内できる。
- Explicit Non-goals: Custom GPT editor の自動読み取り、自動貼り付け、反映済み記録の永続化、deploy 実行、credential mutation は扱わない。
- Expected touched files/routes/workflows: src/core/custom-gpt-setup-artifacts.js、test/custom-gpt-setup-artifacts.test.js、test/worker.test.js、worker.js
- Affected Issues: Issue #359。関連: Issue #344 は startup preflight の surface update guidance として影響し得るが、この PR では直接変更しない。
- Affected PRs: なし。
- Affected workflows: なし。GitHub Actions workflow は変更しない。
- Affected runtime/operator surfaces: Cloudflare Worker /setup/latest、/v2/retrieve/self-parity、Custom GPT setup recovery surface。
- What may break if we patch narrowly: Custom GPT editor が読めないのに「不要」と断定すると drift になる。latest と known-good の差分だけを確実な truth として返す。
- Unknowns to investigate before coding: 現 runtime の VTDD_KNOWN_GOOD_COMMIT_SHA が未設定の場合、known-good 比較は unverified になる。Custom GPT editor 側の実 pasted sourceSha は外部から読めない。
- Validation needed: targeted unit/worker tests、npm test、generated worker check。
- Stop condition: Custom GPT editor 読み取りや credential/deploy 操作が必要になった場合はこの PR の範囲外なので停止する。

## File / Line Hypotheses

- file: src/core/custom-gpt-setup-artifacts.js
  - hypothesis: self-parity の返却値に surfaceUpdateChecklist と knownGoodComparison を追加すれば、Butler が「何を更新すべきか」を runtime truth として読める。
  - risk if changed narrowly: editor の現在値を読めるかのように断定すると誤案内になる。
  - validation: custom-gpt setup artifact tests / worker self-parity tests。
  - related Issue: Issue #359
- file: worker.js
  - hypothesis: src/core 変更後に generated worker を更新すれば deployed Worker と source のずれを防げる。
  - risk if changed narrowly: worker.js 未更新だと CI が止まり、deploy 後の /setup が古いままになる。
  - validation: npm run check:generated-worker。
  - related Issue: Issue #359

## Hypothesis Retrospective

- expected: latest/known-good 差分を使えば、Custom GPT editor を読まずに更新候補を判断できる。
- actual: configured known-good がある場合に Action Schema / Instructions 差分を検出し、update_required_if_editor_is_known_good を返すテストを追加した。
- mismatch: editor 現在値の断定はできないため、更新「必要」を無条件には言わない。
- lesson: VTDD の復旧案内は、読める truth と読めない editor state を分けて表示する必要がある。
- should become RAG candidate: はい。setup 更新要否判断の基準として有用。

## Verification Evidence

- Unit: node --test test/custom-gpt-setup-artifacts.test.js test/worker.test.js passed: 119 tests.
- Integration: npm test passed: 773 tests, 772 pass, 1 skipped. check:self-parity and check:generated-worker passed.
- E2E: 未実施。mobile clipboard E2E は Issue #359 の残作業。
- Manual: git diff --cached --check passed.
- Evidence path/link: local test output in this Codex run.

## Butler Completion Contract

- Owner goal: iPhone から Butler / setup recovery を見た時、Instructions / Action Schema / deploy の更新要否が混ざらず、嘘なく分かる。
- Butler entrypoint: vtddRetrieveSelfParity / setup recovery page から読める。自然会話での案内品質は既存 Instructions に依存する。
- Action Schema exposure: 既存 vtddRetrieveSelfParity の response に fields を追加。operationId 変更なし。Action Schema update はこの PR では不要。
- Runtime path: /v2/retrieve/self-parity -> evaluateButlerSelfParity -> surfaceUpdateChecklist / knownGoodComparison。/setup/latest -> buildCustomGptRecoveryBundle -> recovery page sections。
- Runner/runtime truth: selfParity.surfaceUpdateChecklist と selfParity.knownGoodComparison に runtime-readable truth を返す。
- Authority boundary: 新しい high-risk authority なし。deploy/operator URL を表示する場合も実行は GO + passkey 境界のまま。
- E2E evidence: 未実施。Butler live E2E は deploy 後の確認が必要。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 必要。src/core と worker.js を変更したため、merge 後に Worker deploy が必要。
- Custom GPT Action Schema update: 不要。operationId / route は変更していない。
- Custom GPT Instructions update: 不要。この PR では docs/setup/custom-gpt-instructions*.md を変更していない。
- iPhone Butler live E2E: 未実施。deploy 後に /setup/latest の mobile 表示と Butler self-parity 応答で確認する。

## Related Constitution Rules

- Issue-driven partial PR。
- AGENTS.md Drift Stop Protocol。
- Custom GPT editor を読めない状態を断定しない。
- Generated worker discipline。

## Out-of-scope but NOT implemented

- Custom GPT editor の現在値読み取り。
- 反映済み sourceSha の永続記録。
- mobile clipboard live E2E。
- deploy 実行。

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #359
- Execution ID: mac-codex-issue-359-surface-update-checklist
- Goal: Butler / setup recovery が surface 更新要否を latest/known-good 差分と runtime parity から判断できるようにする。
