### PR TITLE
Issue #359: repo known-good manifest を追加

### DIFF
--- a/docs/mvp/production-deploy-path.md
+++ b/docs/mvp/production-deploy-path.md
@@ -58,10 +58,11 @@ such as `wrangler.production.local.toml`. For GitHub Actions deploys, store the
 D1 database id in `CLOUDFLARE_D1_DATABASE_ID`; the workflow generates an
 uncommitted `wrangler.production.generated.toml` at deploy time.
 
-If `/setup/known-good` should expose a rollback bundle, set repository variable
-`VTDD_KNOWN_GOOD_COMMIT_SHA` to the last human-verified stable setup commit
-before dispatching production deploy. If this variable is absent, the Worker
-must not silently treat `main` as known-good.
+If `/setup/known-good` should expose a rollback bundle, the preferred source of
+truth is `docs/setup/known-good.json` with the last human-verified stable setup
+commit. Repository variable `VTDD_KNOWN_GOOD_COMMIT_SHA` remains an explicit
+operator override for emergency recovery. If neither a valid manifest nor a
+valid override is present, the Worker must not silently treat `main` as known-good.
 
 If production deploy completion should notify the operator through GitHub
 Mobile / Apple Watch, set repository variable

--- a/docs/setup/known-good.json
+++ b/docs/setup/known-good.json
@@ -1,0 +1,6 @@
+{
+  "commitSha": "9a9d23e51fded7bd8dab427a73bbf97f3d7bbe0f",
+  "verifiedAt": "2026-05-15T02:10:23Z",
+  "source": "deploy-production",
+  "notes": "PR #378 merge commit. Deploy-production run 25896437582 completed successfully and /setup/latest exposed surface update checklist plus known-good comparison."
+}

--- a/src/core/custom-gpt-setup-artifacts.js
+++ b/src/core/custom-gpt-setup-artifacts.js
@@ -116,6 +116,7 @@ export const RUNTIME_SETUP_MANIFEST = Object.freeze({
 
 const INSTRUCTIONS_CHARACTER_LIMIT = 8000;
 const KNOWN_GOOD_COMMIT_ENV = "VTDD_KNOWN_GOOD_COMMIT_SHA";
+const KNOWN_GOOD_MANIFEST_PATH = "docs/setup/known-good.json";
 export const VTDD_SETUP_REPOSITORY = "marushu/vtdd-v2-p";
 
 export const CustomGptSetupChannel = Object.freeze({
@@ -415,7 +416,7 @@ export async function buildCustomGptRecoveryBundle(input = {}) {
 
   const knownGoodCommit =
     channel === CustomGptSetupChannel.KNOWN_GOOD
-      ? resolveConfiguredKnownGoodCommitSha({ ref: requestedRef, env })
+      ? await resolveKnownGoodCommitPointer({ repository, ref: requestedRef, env })
       : null;
   if (channel === CustomGptSetupChannel.KNOWN_GOOD && !knownGoodCommit?.sha) {
     return {
@@ -423,7 +424,8 @@ export async function buildCustomGptRecoveryBundle(input = {}) {
       status: 503,
       error: "known_good_setup_unavailable",
       reason:
-        "known-good setup requires VTDD_KNOWN_GOOD_COMMIT_SHA or an explicit 40-character ref"
+        knownGoodCommit?.reason ||
+        "known-good setup requires docs/setup/known-good.json, VTDD_KNOWN_GOOD_COMMIT_SHA, or an explicit 40-character ref"
     };
   }
 
@@ -432,7 +434,7 @@ export async function buildCustomGptRecoveryBundle(input = {}) {
       ? knownGoodCommit?.sha || requestedRef
       : requestedRef;
 
-  const [openapi, instructionsShortMin, selfParity, latestCommit] = await Promise.all([
+  const [openapi, instructionsShortMin, selfParity, latestCommit, knownGoodPointer] = await Promise.all([
     retrieveCustomGptSetupArtifact({
       artifact: CustomGptSetupArtifact.OPENAPI_YAML,
       repository,
@@ -454,7 +456,10 @@ export async function buildCustomGptRecoveryBundle(input = {}) {
     }),
     channel === CustomGptSetupChannel.LATEST
       ? resolveKnownGoodCommitSha({ repository, ref, env })
-      : Promise.resolve(null)
+      : Promise.resolve(null),
+    channel === CustomGptSetupChannel.LATEST
+      ? resolveKnownGoodCommitPointer({ repository, ref, env })
+      : Promise.resolve(knownGoodCommit)
   ]);
 
   const failed = [openapi, instructionsShortMin, selfParity].find((result) => !result.ok);
@@ -515,12 +520,15 @@ export async function buildCustomGptRecoveryBundle(input = {}) {
         knownGoodCommitSha:
           channel === CustomGptSetupChannel.KNOWN_GOOD
             ? knownGoodCommit?.sha
-            : null,
+            : knownGoodPointer?.sha ?? null,
         knownGoodCommitSource:
           channel === CustomGptSetupChannel.KNOWN_GOOD
             ? knownGoodCommit?.source
-            : "not_checked_on_latest",
+            : knownGoodPointer?.source ?? "unconfigured",
         rollbackReady: channel === CustomGptSetupChannel.KNOWN_GOOD,
+        knownGoodManifestPath: KNOWN_GOOD_MANIFEST_PATH,
+        knownGoodManifestSha: knownGoodPointer?.manifestSha ?? null,
+        knownGoodVerifiedAt: knownGoodPointer?.verifiedAt ?? null,
         bundleArtifacts: [
           openapi.artifact.path,
           instructionsShortMin.artifact.path
@@ -693,11 +701,127 @@ function resolveConfiguredKnownGoodCommitSha({ ref, env }) {
     return { sha: configured, source: KNOWN_GOOD_COMMIT_ENV };
   }
 
+  if (configured) {
+    return {
+      sha: null,
+      source: KNOWN_GOOD_COMMIT_ENV,
+      reason: `${KNOWN_GOOD_COMMIT_ENV} must be a 40-character commit SHA`
+    };
+  }
+
   if (/^[a-f0-9]{40}$/i.test(ref)) {
     return { sha: ref, source: "ref" };
   }
 
   return { sha: null, source: "unconfigured" };
+}
+
+async function resolveKnownGoodCommitPointer({ repository, ref, env }) {
+  const configured = resolveConfiguredKnownGoodCommitSha({ ref, env });
+  if (configured.sha || configured.reason || configured.source === "ref") {
+    return configured;
+  }
+
+  const manifest = await retrieveKnownGoodManifest({ repository, ref, env });
+  if (manifest.ok) {
+    return {
+      sha: manifest.commitSha,
+      source: KNOWN_GOOD_MANIFEST_PATH,
+      manifestSha: manifest.manifestSha,
+      verifiedAt: manifest.verifiedAt
+    };
+  }
+
+  return {
+    sha: null,
+    source: manifest.source || "unconfigured",
+    reason:
+      manifest.source === "unconfigured"
+        ? `known-good setup requires ${KNOWN_GOOD_MANIFEST_PATH}, ${KNOWN_GOOD_COMMIT_ENV}, or an explicit 40-character ref`
+        : manifest.reason
+  };
+}
+
+async function retrieveKnownGoodManifest({ repository, ref, env }) {
+  const fetchImpl = typeof env?.GITHUB_API_FETCH === "function" ? env.GITHUB_API_FETCH.bind(env) : fetch;
+  const apiBaseUrl = normalizeApiBaseUrl(env?.GITHUB_API_BASE_URL);
+  const tokenResolution = await resolveGitHubAppInstallationToken({ env, fetchImpl, apiBaseUrl });
+  if (!tokenResolution.ok) {
+    return {
+      ok: false,
+      source: "unverified",
+      reason: tokenResolution.warning || "GitHub App installation token is unavailable"
+    };
+  }
+
+  let response;
+  try {
+    response = await fetchImpl(
+      `${apiBaseUrl}/repos/${encodeRepository(repository)}/contents/${KNOWN_GOOD_MANIFEST_PATH}?ref=${encodeURIComponent(ref || "main")}`,
+      {
+        method: "GET",
+        headers: {
+          authorization: `Bearer ${tokenResolution.token}`,
+          accept: "application/vnd.github+json",
+          "x-github-api-version": GITHUB_API_VERSION,
+          "user-agent": GITHUB_API_USER_AGENT
+        }
+      }
+    );
+  } catch {
+    return {
+      ok: false,
+      source: "unverified",
+      reason: `failed to retrieve ${KNOWN_GOOD_MANIFEST_PATH}`
+    };
+  }
+
+  const body = await readJsonSafe(response);
+  if (!response.ok) {
+    return {
+      ok: false,
+      source: response.status === 404 ? "unconfigured" : "unverified",
+      reason:
+        normalizeText(body?.message) ||
+        `${KNOWN_GOOD_MANIFEST_PATH} is unavailable at ${ref || "main"}`
+    };
+  }
+
+  const content = decodeGitHubFileContent(body?.content, body?.encoding);
+  if (!content) {
+    return {
+      ok: false,
+      source: "unverified",
+      reason: `${KNOWN_GOOD_MANIFEST_PATH} is unreadable`
+    };
+  }
+
+  let manifest;
+  try {
+    manifest = JSON.parse(content);
+  } catch {
+    return {
+      ok: false,
+      source: "unverified",
+      reason: `${KNOWN_GOOD_MANIFEST_PATH} is not valid JSON`
+    };
+  }
+
+  const commitSha = normalizeText(manifest?.commitSha);
+  if (!/^[a-f0-9]{40}$/i.test(commitSha)) {
+    return {
+      ok: false,
+      source: "unverified",
+      reason: `${KNOWN_GOOD_MANIFEST_PATH} commitSha must be a 40-character commit SHA`
+    };
+  }
+
+  return {
+    ok: true,
+    commitSha,
+    manifestSha: normalizeText(body?.sha) || null,
+    verifiedAt: normalizeText(manifest?.verifiedAt) || null
+  };
 }
 
 async function resolveKnownGoodCommitSha({ repository, ref, env }) {
@@ -914,7 +1038,7 @@ async function compareKnownGoodSetupArtifacts({
   latestInstructions,
   latestOpenapi
 }) {
-  const knownGood = resolveConfiguredKnownGoodCommitSha({ ref: "", env });
+  const knownGood = await resolveKnownGoodCommitPointer({ repository, ref, env });
   if (!knownGood?.sha) {
     return {
       status: "known_good_unavailable",

--- a/test/custom-gpt-setup-artifacts.test.js
+++ b/test/custom-gpt-setup-artifacts.test.js
@@ -317,6 +317,12 @@ test("buildCustomGptRecoveryBundle expands Worker URL and reports short-min leng
       GITHUB_APP_INSTALLATION_TOKEN: "ghs_setup_read",
       GITHUB_API_FETCH: async (url) => {
         const parsed = new URL(url);
+        if (parsed.pathname.endsWith("/docs/setup/known-good.json")) {
+          return new Response(JSON.stringify({ message: "Not Found" }), {
+            status: 404,
+            headers: { "content-type": "application/json" }
+          });
+        }
         if (parsed.pathname.endsWith("/commits/main")) {
           return new Response(JSON.stringify({ sha: "a".repeat(40) }), {
             status: 200,
@@ -356,7 +362,7 @@ test("buildCustomGptRecoveryBundle expands Worker URL and reports short-min leng
   assert.equal(result.recovery.instructionsShortMin.limitExceeded, false);
   assert.equal(result.recovery.sourceCommitSha, "a".repeat(40));
   assert.equal(result.recovery.rollback.knownGoodCommitSha, null);
-  assert.equal(result.recovery.rollback.knownGoodCommitSource, "not_checked_on_latest");
+  assert.equal(result.recovery.rollback.knownGoodCommitSource, "unconfigured");
   assert.equal(result.recovery.runtime.deployState, "in_sync");
   assert.deepEqual(result.recovery.runtime.surfaceUpdateChecklist.cloudflareDeploy, {
     status: "not_required",
@@ -387,6 +393,101 @@ test("buildCustomGptRecoveryBundle expands Worker URL and reports short-min leng
     displaysTokens: false,
     displaysApprovalGrant: false
   });
+});
+
+test("buildCustomGptRecoveryBundle reads repo-tracked known-good manifest", async () => {
+  const latestOpenApi = [
+    "openapi: 3.1.1",
+    "servers:",
+    "  - url: https://your-runtime-host.example.workers.dev",
+    "paths:",
+    "  /health:",
+    "    get:",
+    "      operationId: getHealth",
+    "  /v2/retrieve/self-parity:",
+    "    get:",
+    "      operationId: vtddRetrieveSelfParity"
+  ].join("\n");
+  const latestInstructions = [
+    "vtddRetrieveSelfParity",
+    "Action Schema update required",
+    "Instructions update required",
+    "Cloudflare deploy update required"
+  ].join("\n");
+  const knownGoodOpenApi = latestOpenApi.replace("/v2/retrieve/self-parity", "/v2/retrieve/setup-artifact");
+  const knownGoodInstructions = latestInstructions.replace("vtddRetrieveSelfParity", "vtddRetrieveSetupArtifact");
+  const knownGoodSha = "e".repeat(40);
+
+  const result = await buildCustomGptRecoveryBundle({
+    repository: "sample-org/vtdd-v2-p",
+    ref: "main",
+    runtimeOrigin: "https://sample-user-vtdd.example.workers.dev",
+    env: {
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_setup_read",
+      GITHUB_API_FETCH: async (url) => {
+        const parsed = new URL(url);
+        if (parsed.pathname.endsWith("/commits/main")) {
+          return new Response(JSON.stringify({ sha: "f".repeat(40) }), {
+            status: 200,
+            headers: { "content-type": "application/json" }
+          });
+        }
+        if (parsed.pathname.endsWith("/docs/setup/known-good.json")) {
+          return new Response(
+            JSON.stringify({
+              sha: "known-good-manifest-sha",
+              encoding: "base64",
+              content: encodeContent(
+                JSON.stringify({
+                  commitSha: knownGoodSha,
+                  verifiedAt: "2026-05-15T02:10:23Z"
+                })
+              )
+            }),
+            { status: 200, headers: { "content-type": "application/json" } }
+          );
+        }
+        const ref = parsed.searchParams.get("ref");
+        const isKnownGood = ref === knownGoodSha;
+        const isShortMin = parsed.pathname.endsWith(
+          "/docs/setup/custom-gpt-instructions-short-min.md"
+        );
+        const isInstructions = parsed.pathname.endsWith("/docs/setup/custom-gpt-instructions.md");
+        const content = isKnownGood
+          ? isInstructions || isShortMin
+            ? knownGoodInstructions
+            : knownGoodOpenApi
+          : isInstructions || isShortMin
+            ? latestInstructions
+            : latestOpenApi;
+        return new Response(
+          JSON.stringify({
+            sha: isKnownGood
+              ? isInstructions || isShortMin
+                ? "known-good-instructions-sha"
+                : "known-good-openapi-sha"
+              : isInstructions || isShortMin
+                ? "latest-instructions-sha"
+                : "latest-openapi-sha",
+            encoding: "base64",
+            content: encodeContent(content)
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        );
+      }
+    }
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.recovery.rollback.knownGoodCommitSha, knownGoodSha);
+  assert.equal(result.recovery.rollback.knownGoodCommitSource, "docs/setup/known-good.json");
+  assert.equal(result.recovery.rollback.knownGoodManifestSha, "known-good-manifest-sha");
+  assert.equal(result.recovery.rollback.knownGoodVerifiedAt, "2026-05-15T02:10:23Z");
+  assert.equal(result.recovery.runtime.knownGoodComparison.status, "different");
+  assert.equal(
+    result.recovery.runtime.knownGoodComparison.updateJudgment,
+    "update_required_if_editor_is_known_good"
+  );
 });
 
 test("buildCustomGptRecoveryBundle reports latest differs from configured known-good", async () => {

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -653,6 +653,12 @@ test("worker setup latest page renders copy-ready schema and short-min bundle fo
       GITHUB_API_FETCH: async (url) => {
         const parsed = new URL(url);
         assert.equal(parsed.pathname.startsWith("/repos/marushu/vtdd-v2-p/"), true);
+        if (parsed.pathname.endsWith("/docs/setup/known-good.json")) {
+          return new Response(JSON.stringify({ message: "Not Found" }), {
+            status: 404,
+            headers: { "content-type": "application/json" }
+          });
+        }
         if (parsed.pathname.endsWith("/commits/main")) {
           return new Response(JSON.stringify({ sha: "b".repeat(40) }), {
             status: 200,
@@ -779,8 +785,13 @@ test("worker setup known-good page renders rollback copy-ready bundle from known
 test("worker setup known-good page does not silently treat main as known-good", async () => {
   const response = await worker.fetch(new Request("https://example.com/setup/known-good"), {
     GITHUB_APP_INSTALLATION_TOKEN: "ghs_setup_read",
-    GITHUB_API_FETCH: async () => {
-      throw new Error("known-good must not resolve main as fallback");
+    GITHUB_API_FETCH: async (url) => {
+      const parsed = new URL(url);
+      assert.equal(parsed.pathname.endsWith("/docs/setup/known-good.json"), true);
+      return new Response(JSON.stringify({ message: "Not Found" }), {
+        status: 404,
+        headers: { "content-type": "application/json" }
+      });
     }
   });
 
@@ -788,7 +799,7 @@ test("worker setup known-good page does not silently treat main as known-good", 
   const html = await response.text();
   assert.equal(html.includes("Known-good bundle is not configured yet."), true);
   assert.equal(html.includes("このページ自体は復旧導線として開けています。"), true);
-  assert.equal(html.includes("known-good setup requires VTDD_KNOWN_GOOD_COMMIT_SHA"), true);
+  assert.equal(html.includes("known-good setup requires docs/setup/known-good.json"), true);
   assert.equal(html.includes("Open setup/latest instead"), true);
   assert.equal(html.includes("latestFallbackUrl: /setup/latest"), true);
   assert.equal(html.includes("Do not treat main/latest as known-good automatically."), true);
@@ -809,7 +820,7 @@ test("worker setup known-good page rejects malformed configured known-good refs"
   const html = await response.text();
   assert.equal(html.includes("Known-good bundle is not configured yet."), true);
   assert.equal(html.includes("Open setup/latest instead"), true);
-  assert.equal(html.includes("known-good setup requires VTDD_KNOWN_GOOD_COMMIT_SHA"), true);
+  assert.equal(html.includes("VTDD_KNOWN_GOOD_COMMIT_SHA must be a 40-character commit SHA"), true);
   assert.equal(html.includes("Copy Rollback Bundle"), false);
 });
 
@@ -3540,6 +3551,12 @@ test("worker returns Butler self-parity summary", async () => {
       GITHUB_APP_INSTALLATION_TOKEN: "ghs_setup_read",
       GITHUB_API_FETCH: async (url) => {
         const parsed = new URL(url);
+        if (parsed.pathname.endsWith("/docs/setup/known-good.json")) {
+          return new Response(JSON.stringify({ message: "Not Found" }), {
+            status: 404,
+            headers: { "content-type": "application/json" }
+          });
+        }
         const isInstructions = parsed.pathname.endsWith("/docs/setup/custom-gpt-instructions.md");
         return new Response(
           JSON.stringify({
@@ -3623,6 +3640,12 @@ test("worker returns deploy recovery operator url in self-parity when runtime is
       GITHUB_APP_INSTALLATION_TOKEN: "ghs_setup_read",
       GITHUB_API_FETCH: async (url) => {
         const parsed = new URL(url);
+        if (parsed.pathname.endsWith("/docs/setup/known-good.json")) {
+          return new Response(JSON.stringify({ message: "Not Found" }), {
+            status: 404,
+            headers: { "content-type": "application/json" }
+          });
+        }
         const isInstructions = parsed.pathname.endsWith("/docs/setup/custom-gpt-instructions.md");
         return new Response(
           JSON.stringify({

--- a/worker.js
+++ b/worker.js
@@ -36165,6 +36165,7 @@ var RUNTIME_SETUP_MANIFEST = Object.freeze({
 });
 var INSTRUCTIONS_CHARACTER_LIMIT = 8e3;
 var KNOWN_GOOD_COMMIT_ENV = "VTDD_KNOWN_GOOD_COMMIT_SHA";
+var KNOWN_GOOD_MANIFEST_PATH = "docs/setup/known-good.json";
 var VTDD_SETUP_REPOSITORY = "marushu/vtdd-v2-p";
 var CustomGptSetupChannel = Object.freeze({
   LATEST: "latest",
@@ -36413,17 +36414,17 @@ async function buildCustomGptRecoveryBundle(input = {}) {
       reason: "runtimeOrigin is required"
     };
   }
-  const knownGoodCommit = channel === CustomGptSetupChannel.KNOWN_GOOD ? resolveConfiguredKnownGoodCommitSha({ ref: requestedRef, env }) : null;
+  const knownGoodCommit = channel === CustomGptSetupChannel.KNOWN_GOOD ? await resolveKnownGoodCommitPointer({ repository, ref: requestedRef, env }) : null;
   if (channel === CustomGptSetupChannel.KNOWN_GOOD && !knownGoodCommit?.sha) {
     return {
       ok: false,
       status: 503,
       error: "known_good_setup_unavailable",
-      reason: "known-good setup requires VTDD_KNOWN_GOOD_COMMIT_SHA or an explicit 40-character ref"
+      reason: knownGoodCommit?.reason || "known-good setup requires docs/setup/known-good.json, VTDD_KNOWN_GOOD_COMMIT_SHA, or an explicit 40-character ref"
     };
   }
   const ref = channel === CustomGptSetupChannel.KNOWN_GOOD ? knownGoodCommit?.sha || requestedRef : requestedRef;
-  const [openapi, instructionsShortMin, selfParity, latestCommit] = await Promise.all([
+  const [openapi, instructionsShortMin, selfParity, latestCommit, knownGoodPointer] = await Promise.all([
     retrieveCustomGptSetupArtifact({
       artifact: CustomGptSetupArtifact.OPENAPI_YAML,
       repository,
@@ -36443,7 +36444,8 @@ async function buildCustomGptRecoveryBundle(input = {}) {
       issueNumber,
       env
     }),
-    channel === CustomGptSetupChannel.LATEST ? resolveKnownGoodCommitSha({ repository, ref, env }) : Promise.resolve(null)
+    channel === CustomGptSetupChannel.LATEST ? resolveKnownGoodCommitSha({ repository, ref, env }) : Promise.resolve(null),
+    channel === CustomGptSetupChannel.LATEST ? resolveKnownGoodCommitPointer({ repository, ref, env }) : Promise.resolve(knownGoodCommit)
   ]);
   const failed = [openapi, instructionsShortMin, selfParity].find((result) => !result.ok);
   if (failed) {
@@ -36491,9 +36493,12 @@ async function buildCustomGptRecoveryBundle(input = {}) {
         content: instructions
       },
       rollback: {
-        knownGoodCommitSha: channel === CustomGptSetupChannel.KNOWN_GOOD ? knownGoodCommit?.sha : null,
-        knownGoodCommitSource: channel === CustomGptSetupChannel.KNOWN_GOOD ? knownGoodCommit?.source : "not_checked_on_latest",
+        knownGoodCommitSha: channel === CustomGptSetupChannel.KNOWN_GOOD ? knownGoodCommit?.sha : knownGoodPointer?.sha ?? null,
+        knownGoodCommitSource: channel === CustomGptSetupChannel.KNOWN_GOOD ? knownGoodCommit?.source : knownGoodPointer?.source ?? "unconfigured",
         rollbackReady: channel === CustomGptSetupChannel.KNOWN_GOOD,
+        knownGoodManifestPath: KNOWN_GOOD_MANIFEST_PATH,
+        knownGoodManifestSha: knownGoodPointer?.manifestSha ?? null,
+        knownGoodVerifiedAt: knownGoodPointer?.verifiedAt ?? null,
         bundleArtifacts: [
           openapi.artifact.path,
           instructionsShortMin.artifact.path
@@ -36650,10 +36655,110 @@ function resolveConfiguredKnownGoodCommitSha({ ref, env }) {
   if (/^[a-f0-9]{40}$/i.test(configured)) {
     return { sha: configured, source: KNOWN_GOOD_COMMIT_ENV };
   }
+  if (configured) {
+    return {
+      sha: null,
+      source: KNOWN_GOOD_COMMIT_ENV,
+      reason: `${KNOWN_GOOD_COMMIT_ENV} must be a 40-character commit SHA`
+    };
+  }
   if (/^[a-f0-9]{40}$/i.test(ref)) {
     return { sha: ref, source: "ref" };
   }
   return { sha: null, source: "unconfigured" };
+}
+async function resolveKnownGoodCommitPointer({ repository, ref, env }) {
+  const configured = resolveConfiguredKnownGoodCommitSha({ ref, env });
+  if (configured.sha || configured.reason || configured.source === "ref") {
+    return configured;
+  }
+  const manifest = await retrieveKnownGoodManifest({ repository, ref, env });
+  if (manifest.ok) {
+    return {
+      sha: manifest.commitSha,
+      source: KNOWN_GOOD_MANIFEST_PATH,
+      manifestSha: manifest.manifestSha,
+      verifiedAt: manifest.verifiedAt
+    };
+  }
+  return {
+    sha: null,
+    source: manifest.source || "unconfigured",
+    reason: manifest.source === "unconfigured" ? `known-good setup requires ${KNOWN_GOOD_MANIFEST_PATH}, ${KNOWN_GOOD_COMMIT_ENV}, or an explicit 40-character ref` : manifest.reason
+  };
+}
+async function retrieveKnownGoodManifest({ repository, ref, env }) {
+  const fetchImpl = typeof env?.GITHUB_API_FETCH === "function" ? env.GITHUB_API_FETCH.bind(env) : fetch;
+  const apiBaseUrl = normalizeApiBaseUrl4(env?.GITHUB_API_BASE_URL);
+  const tokenResolution = await resolveGitHubAppInstallationToken({ env, fetchImpl, apiBaseUrl });
+  if (!tokenResolution.ok) {
+    return {
+      ok: false,
+      source: "unverified",
+      reason: tokenResolution.warning || "GitHub App installation token is unavailable"
+    };
+  }
+  let response;
+  try {
+    response = await fetchImpl(
+      `${apiBaseUrl}/repos/${encodeRepository(repository)}/contents/${KNOWN_GOOD_MANIFEST_PATH}?ref=${encodeURIComponent(ref || "main")}`,
+      {
+        method: "GET",
+        headers: {
+          authorization: `Bearer ${tokenResolution.token}`,
+          accept: "application/vnd.github+json",
+          "x-github-api-version": GITHUB_API_VERSION4,
+          "user-agent": GITHUB_API_USER_AGENT4
+        }
+      }
+    );
+  } catch {
+    return {
+      ok: false,
+      source: "unverified",
+      reason: `failed to retrieve ${KNOWN_GOOD_MANIFEST_PATH}`
+    };
+  }
+  const body = await readJsonSafe5(response);
+  if (!response.ok) {
+    return {
+      ok: false,
+      source: response.status === 404 ? "unconfigured" : "unverified",
+      reason: normalizeText24(body?.message) || `${KNOWN_GOOD_MANIFEST_PATH} is unavailable at ${ref || "main"}`
+    };
+  }
+  const content = decodeGitHubFileContent(body?.content, body?.encoding);
+  if (!content) {
+    return {
+      ok: false,
+      source: "unverified",
+      reason: `${KNOWN_GOOD_MANIFEST_PATH} is unreadable`
+    };
+  }
+  let manifest;
+  try {
+    manifest = JSON.parse(content);
+  } catch {
+    return {
+      ok: false,
+      source: "unverified",
+      reason: `${KNOWN_GOOD_MANIFEST_PATH} is not valid JSON`
+    };
+  }
+  const commitSha = normalizeText24(manifest?.commitSha);
+  if (!/^[a-f0-9]{40}$/i.test(commitSha)) {
+    return {
+      ok: false,
+      source: "unverified",
+      reason: `${KNOWN_GOOD_MANIFEST_PATH} commitSha must be a 40-character commit SHA`
+    };
+  }
+  return {
+    ok: true,
+    commitSha,
+    manifestSha: normalizeText24(body?.sha) || null,
+    verifiedAt: normalizeText24(manifest?.verifiedAt) || null
+  };
 }
 async function resolveKnownGoodCommitSha({ repository, ref, env }) {
   const configured = normalizeText24(env?.[KNOWN_GOOD_COMMIT_ENV]);
@@ -36845,7 +36950,7 @@ async function compareKnownGoodSetupArtifacts({
   latestInstructions,
   latestOpenapi
 }) {
-  const knownGood = resolveConfiguredKnownGoodCommitSha({ ref: "", env });
+  const knownGood = await resolveKnownGoodCommitPointer({ repository, ref, env });
   if (!knownGood?.sha) {
     return {
       status: "known_good_unavailable",


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #359 の部分進捗です。iPhone から復旧判断するための known-good rollback source を、Cloudflare/GitHub variable だけでなく GitHub repo 上の `docs/setup/known-good.json` から読めるようにします。
- `/setup/latest` と `/setup/known-good` が、repo-tracked known-good commit を使って current candidate と rollback candidate の差分判断へ進める状態にします。

## Satisfied Success Criteria

- `docs/setup/known-good.json` を追加し、直近で production deploy と `/setup/latest` 表示を確認済みの commit `9a9d23e51fded7bd8dab427a73bbf97f3d7bbe0f` を known-good として記録しました。
- `VTDD_KNOWN_GOOD_COMMIT_SHA` が未設定でも、Worker が GitHub App read で `docs/setup/known-good.json` を取得して `/setup/known-good` rollback bundle を構築できるようにしました。
- `/setup/latest` の rollback metadata に known-good commit / source / manifest sha / verifiedAt を表示できるようにしました。
- `VTDD_KNOWN_GOOD_COMMIT_SHA` が malformed の場合は repo manifest に黙って fallback せず、operator override の異常として fail-closed します。
- production deploy doc に、repo manifest が preferred source、env var は emergency override であることを追記しました。

## Unsatisfied Success Criteria

- この PR では production deploy は実施していません。merge 後に Cloudflare deploy が必要です。
- iPhone の Butler / setup page からの live E2E は、deploy 後に別途確認が必要です。
- Custom GPT editor の現在値は外部から読めないため、この PR では editor 内が known-good かどうかは断定しません。
- known-good manifest の自動昇格、更新 UI、operator approval flow はこの PR では未実装です。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #359
- Implementing Success Criteria: `/setup/known-good` と `/setup/latest` comparison が repo-tracked known-good manifest を source of truth として読めること。known-good 未設定時に `main` を黙って rollback と扱わないこと。
- Explicit Non-goals: deploy 実行、credential / permission mutation、Custom GPT editor の読み取り、known-good 自動昇格、setup wizard 復活は行いません。
- Expected touched files/routes/workflows: `src/core/custom-gpt-setup-artifacts.js`, `worker.js`, `docs/setup/known-good.json`, `docs/mvp/production-deploy-path.md`, setup recovery tests。route shape と Action Schema operationId は変更しません。
- Affected Issues: Issue #359。Issue #361 の RAG checkpoint とは直接競合しませんが、復旧判断ログの候補になり得ます。
- Affected PRs: 直前の PR #378 の surface update truth を前提に、known-good comparison の unavailable 状態を解消する方向です。
- Affected workflows: GitHub Actions workflow は変更しません。`src/*` 変更のため `worker.js` build が必要です。
- Affected runtime/operator surfaces: `/setup/latest`, `/setup/known-good`, Butler-facing setup recovery page。Butler Action Schema と Instructions の paste target は変更しません。
- What may break if we patch narrowly: env var fallback だけに寄せると iPhone 復旧時に Cloudflare/GitHub settings を見られない状態で詰まる。逆に `main` を known-good 扱いすると壊れた latest を rollback と誤認します。
- Unknowns to investigate before coding: GitHub contents API の manifest 取得失敗時に unavailable と unverified を分ける必要、malformed env var を override 異常として扱うべきか。
- Validation needed: setup artifact unit tests、Worker setup page tests、production deploy path doc test、full `npm test`、generated `worker.js` parity check。
- Stop condition: known-good の source が repo manifest / env override / explicit ref のどれか判別できない、または latest/main を rollback と扱いそうな実装になった場合は停止。

## File / Line Hypotheses

- file: `src/core/custom-gpt-setup-artifacts.js`
  - hypothesis: known-good 解決は `buildCustomGptRecoveryBundle` と `compareKnownGoodSetupArtifacts` の pointer resolution に集約するのが安全。
  - risk if changed narrowly: `/setup/known-good` だけ直すと `/setup/latest` の comparison が `known_good_unavailable` のまま残り、Butler が更新要否を読めません。
  - validation: repo manifest を読む unit test と Worker page test で latest / known-good の両方を確認。
  - related Issue: Issue #359
- file: `docs/setup/known-good.json`
  - hypothesis: GitHub repo に known-good commit を置けば iPhone-first recovery でも GitHub runtime truth から読める。
  - risk if changed narrowly: verifiedAt/source がなければ、後からなぜその commit が known-good なのか追跡しづらくなります。
  - validation: contents API mock で manifest sha / verifiedAt が rollback metadata に露出することを確認。
  - related Issue: Issue #359
- file: `worker.js`
  - hypothesis: `src/*` 変更後は build output を必ず更新しないと deploy artifact が古くなる。
  - risk if changed narrowly: tests は通っても production Worker が古い logic のままになります。
  - validation: `npm run build:worker` 後に `npm run check:generated-worker` と `npm test` を実行。
  - related Issue: Issue #359

## Hypothesis Retrospective

- expected: repo manifest fallback を入れると `/setup/latest` の known-good comparison が unavailable から meaningful comparison に進める。
- actual: unit test で repo-tracked manifest から known-good commit/source/manifest sha/verifiedAt を読み、latest と known-good の差分 status `different` を返すことを確認しました。
- mismatch: なし。ただし live deploy 前なので production runtime での表示は未確認です。
- lesson: recovery truth は Cloudflare/GitHub variable だけに置くと iPhone 復旧時に弱い。GitHub repo に小さな manifest を置く方が VTDD の GitHub 正本に合う。
- should become RAG candidate: はい。Issue #359 の復旧設計判断として候補になります。

## Verification Evidence

- Unit: `node --test test/custom-gpt-setup-artifacts.test.js test/worker.test.js test/production-deploy-path.test.js` passed。`npm test` passed: 774 tests, 773 pass, 1 skipped。
- Integration: `npm run check:self-parity` passed。`npm run check:generated-worker` passed。
- E2E: 未実施。deploy 後に `/setup/latest` と `/setup/known-good` の live page を iPhone/Butler surface から確認する必要があります。
- Manual: `git diff --cached --check` passed。
- Evidence path/link: local test output in this PR run; live deploy evidence は merge/deploy 後に追記対象です。

## Butler Completion Contract

- Owner goal: iPhone から Custom GPT recovery の latest / known-good 差分を読み、更新要否と rollback 候補を嘘なく判断できるようにする。
- Butler entrypoint: `/setup/latest` と `/setup/known-good` の recovery page。Butler natural language からの完全な復旧案内は deploy 後の live E2E が必要です。
- Action Schema exposure: 不要。route / operationId / schema は変更していません。
- Runtime path: Worker setup recovery bundle generation path in `src/core/custom-gpt-setup-artifacts.js`。
- Runner/runtime truth: repo manifest, GitHub contents API, self-parity, deploy state, known-good comparison metadata を runtime truth として返します。
- Authority boundary: 新しい high-risk authority は追加していません。deploy はこの PR 外で GO + passkey が必要です。
- E2E evidence: 未実施。merge 後 deploy して `/setup/latest` と `/setup/known-good` の live evidence を確認する必要があります。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 必要。`src/core/custom-gpt-setup-artifacts.js` と `worker.js` を変更したため、merge 後に production deploy が必要です。
- Custom GPT Action Schema update: 不要。Action Schema の path / operationId / request shape は変更していません。
- Custom GPT Instructions update: 不要。`docs/setup/custom-gpt-instructions*.md` は変更していません。
- iPhone Butler live E2E: 必要。deploy 後に `/setup/latest` と `/setup/known-good` の表示確認が必要です。

## Related Constitution Rules

- Issue 起点で変更し、Issue #359 の recovery/setup surface に限定しました。
- Butler Completion Gate に従い、live E2E 未実施のため completion status は incomplete としました。
- Safety Invariants: known-good 未設定時に `main` を rollback として扱わないことを維持しました。
- Change Size and PR Discipline: runtime slice として bounded にし、Action Schema / Instructions 更新を混ぜていません。

## Out-of-scope but NOT implemented

- deploy 実行
- Custom GPT editor の実値読み取り
- known-good manifest 自動昇格
- GitHub variable / secret / permission mutation
- setup wizard 復活

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #359
- Execution ID: mac-codex-issue-359-known-good-manifest-20260515
- Goal: known-good rollback source を GitHub repo manifest 化し、setup recovery の更新要否判断を強くする
