### PR TITLE
Issue #380: mac/VPS から正規 route で RAG を書く machine auth 経路

### DIFF
--- a/docs/memory/vtdd-memory-bridge.md
+++ b/docs/memory/vtdd-memory-bridge.md
@@ -27,13 +27,21 @@ Use environment variables or equivalent command flags:
 - `VTDD_MEMORY_D1_DATABASE_NAME`: Cloudflare D1 database name for direct
   Wrangler operations.
 - `VTDD_RUNTIME_URL`: Worker runtime base URL for retrieve operations.
-- `VTDD_GATEWAY_BEARER_TOKEN`: machine-auth token for runtime retrieve
+- `VTDD_GATEWAY_BEARER_TOKEN`: machine-auth token for runtime retrieve/write
   operations.
+- `~/.vtdd/credentials/manifest.json`: optional desktop/VPS bootstrap vault
+  fallback. When `VTDD_GATEWAY_BEARER_TOKEN` is absent, the CLI may read
+  `gateway.bearerTokenPath` from this manifest and use that file's contents as
+  the runtime bearer token.
 
 Do not commit runtime URLs, database IDs, bearer tokens, account IDs, or owner
 specific bootstrap values into this repository.
 Do not pass bearer tokens as command-line flags; use the environment variable
 so the token is less likely to land in shell history or process logs.
+If neither the environment variable nor the bootstrap vault token path is
+available, the runtime memory commands must fail with `desktop maintenance
+required` instead of falling back to D1 direct writes or asking the operator to
+paste a secret into chat.
 
 ## Commands
 
@@ -76,6 +84,22 @@ node scripts/vtdd-memory.mjs write-runtime-checkpoint \
   --tag "issue:361" \
   --pretty true
 ```
+
+Confirm a RAG checkpoint through the same Worker runtime operational-memory
+surface:
+
+```sh
+node scripts/vtdd-memory.mjs retrieve-operational \
+  --runtime-url "$VTDD_RUNTIME_URL" \
+  --repository "owner/repo" \
+  --text "Compact checkpoint summary or tags." \
+  --limit 5 \
+  --pretty true
+```
+
+Mac Codex and VPS Codex CLI should use the same runtime write/retrieve contract
+for normal RAG checkpoint handling. Direct Wrangler/D1 writes remain an
+operator repair tool, not the default path for shared memory continuity.
 
 Retrieve canonical cross memory directly from D1:
 

--- a/scripts/vtdd-memory.mjs
+++ b/scripts/vtdd-memory.mjs
@@ -2,6 +2,7 @@
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
+import { loadDesktopBootstrapVault } from "../src/core/desktop-bootstrap-vault.js";
 import { createDecisionLogEntry, createProposalLogEntry } from "../src/core/log-contracts.js";
 import { createMemoryRecord } from "../src/core/memory-schema.js";
 import { evaluateMemorySafety } from "../src/core/memory-safety.js";
@@ -159,6 +160,43 @@ export function buildRuntimeMemoryWriteRequest(options) {
   };
 }
 
+export function buildRuntimeOperationalMemoryRequest(options) {
+  const env = options.env ?? process.env;
+  const runtimeUrl = normalizeRequiredText(
+    options.runtimeUrl ?? env.VTDD_RUNTIME_URL,
+    "runtime-url"
+  );
+  const token = normalizeRequiredText(
+    env.VTDD_GATEWAY_BEARER_TOKEN,
+    "VTDD_GATEWAY_BEARER_TOKEN"
+  );
+  const url = new URL("/v2/retrieve/operational-memory", runtimeUrl);
+  url.searchParams.set("limit", String(normalizeLimit(options.limit ?? DEFAULT_LIMIT)));
+  url.searchParams.set("responseMode", "action_visible");
+  if (options.repository) {
+    url.searchParams.set("repository", String(options.repository));
+  }
+  if (options.text) {
+    url.searchParams.set("text", String(options.text));
+  }
+  if (options.currentState) {
+    url.searchParams.set("currentState", String(options.currentState));
+  }
+  if (options.runtimeTruthSource) {
+    url.searchParams.set("runtimeTruthSource", String(options.runtimeTruthSource));
+  }
+  if (options.checkedAt) {
+    url.searchParams.set("checkedAt", String(options.checkedAt));
+  }
+
+  return {
+    url: url.toString(),
+    headers: {
+      authorization: `Bearer ${token}`
+    }
+  };
+}
+
 export function buildCheckpointPayload(options) {
   const relatedIssue = normalizePositiveInteger(options.relatedIssue, "relatedIssue");
   const tags = mergeTags(options.tag ?? options.tags, [
@@ -288,7 +326,8 @@ export async function runCli(argv = process.argv.slice(2), io = defaultIo) {
   if (command === "retrieve-cross") {
     const transport = options.transport ?? inferTransport(options);
     if (transport === "runtime") {
-      const request = buildRuntimeCrossMemoryRequest(options);
+      const runtimeOptions = await withRuntimeMachineAuth(options);
+      const request = buildRuntimeCrossMemoryRequest(runtimeOptions);
       const response = await fetch(request.url, { headers: request.headers });
       const text = await response.text();
       const body = parseMaybeJson(text);
@@ -308,12 +347,27 @@ export async function runCli(argv = process.argv.slice(2), io = defaultIo) {
     return result;
   }
 
+  if (command === "retrieve-operational") {
+    const runtimeOptions = await withRuntimeMachineAuth(options);
+    const request = buildRuntimeOperationalMemoryRequest(runtimeOptions);
+    const response = await fetch(request.url, { headers: request.headers });
+    const text = await response.text();
+    const body = parseMaybeJson(text);
+    const result = { ok: response.ok, status: response.status, body };
+    io.writeJson(result, options);
+    if (!response.ok) {
+      throw new Error(`runtime retrieve-operational failed with status ${response.status}`);
+    }
+    return result;
+  }
+
   if (command === "write-runtime-checkpoint") {
+    const runtimeOptions = await withRuntimeMachineAuth(options);
     const payload = buildCheckpointPayload({
-      ...options,
+      ...runtimeOptions,
       confirmed: normalizeBoolean(options.confirmed)
     });
-    const request = buildRuntimeMemoryWriteRequest({ ...options, payload });
+    const request = buildRuntimeMemoryWriteRequest({ ...runtimeOptions, payload });
     const response = await fetch(request.url, {
       method: "POST",
       headers: request.headers,
@@ -351,6 +405,35 @@ export async function runCli(argv = process.argv.slice(2), io = defaultIo) {
   }
 
   throw new Error(`unknown command: ${command || "(missing)"}`);
+}
+
+export async function withRuntimeMachineAuth(options = {}) {
+  const env = options.env ?? process.env;
+  if (normalizeText(env.VTDD_GATEWAY_BEARER_TOKEN)) {
+    return options;
+  }
+
+  const vault = await loadDesktopBootstrapVault({
+    manifestPath: options.manifestPath
+  });
+  if (!vault.ok) {
+    throw new Error(
+      `desktop maintenance required: gateway_bearer_token_missing; ${vault.issues.join("; ")}`
+    );
+  }
+
+  const bearerToken = normalizeText(vault.vault?.gateway?.bearerToken);
+  if (!bearerToken) {
+    throw new Error("desktop maintenance required: gateway_bearer_token_missing");
+  }
+
+  return {
+    ...options,
+    env: {
+      ...env,
+      VTDD_GATEWAY_BEARER_TOKEN: bearerToken
+    }
+  };
 }
 
 function buildSafeMemoryRecord(input) {
@@ -429,6 +512,10 @@ function normalizeRequiredText(value, label) {
 function normalizeOptionalText(value) {
   const text = String(value ?? "").trim();
   return text || null;
+}
+
+function normalizeText(value) {
+  return String(value ?? "").trim();
 }
 
 function normalizeObject(value) {

--- a/test/vtdd-memory-cli.test.js
+++ b/test/vtdd-memory-cli.test.js
@@ -1,4 +1,7 @@
 import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import test from "node:test";
 
 import {
@@ -10,7 +13,9 @@ import {
   buildProposalRecord,
   buildRuntimeCrossMemoryRequest,
   buildRuntimeMemoryWriteRequest,
-  parseArgs
+  buildRuntimeOperationalMemoryRequest,
+  parseArgs,
+  withRuntimeMachineAuth
 } from "../scripts/vtdd-memory.mjs";
 
 test("parseArgs supports repeated option values", () => {
@@ -164,4 +169,87 @@ test("runtime memory write request posts checkpoint without leaking auth into UR
   assert.equal(request.url.includes("test-token"), false);
   assert.equal(body.recordType, "working_memory");
   assert.equal(body.responseMode, "action_visible");
+});
+
+test("runtime operational memory request keeps auth in headers", () => {
+  const request = buildRuntimeOperationalMemoryRequest({
+    runtimeUrl: "https://example.invalid",
+    env: {
+      VTDD_GATEWAY_BEARER_TOKEN: "test-token"
+    },
+    repository: "marushu/vtdd-v2-p",
+    text: "setup recovery latency",
+    currentState: "deploy confirmed",
+    runtimeTruthSource: "github_issue",
+    checkedAt: "2026-05-15T02:36:00Z",
+    limit: 3
+  });
+
+  const url = new URL(request.url);
+  assert.equal(url.pathname, "/v2/retrieve/operational-memory");
+  assert.equal(url.searchParams.get("repository"), "marushu/vtdd-v2-p");
+  assert.equal(url.searchParams.get("text"), "setup recovery latency");
+  assert.equal(url.searchParams.get("responseMode"), "action_visible");
+  assert.equal(request.headers.authorization, "Bearer test-token");
+  assert.equal(request.url.includes("test-token"), false);
+});
+
+test("runtime machine auth resolves gateway bearer token from desktop vault", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "vtdd-memory-vault-"));
+  await fs.mkdir(path.join(root, "github-app"), { recursive: true });
+  await fs.mkdir(path.join(root, "gateway"), { recursive: true });
+  await fs.writeFile(path.join(root, "github-app", "private-key.pem"), "private-key", "utf8");
+  await fs.writeFile(path.join(root, "gateway", "bearer-token.txt"), "vault-token", "utf8");
+  const manifestPath = path.join(root, "manifest.json");
+  await fs.writeFile(
+    manifestPath,
+    JSON.stringify({
+      version: 1,
+      githubApp: {
+        appId: "123",
+        installationId: "456",
+        privateKeyPath: "github-app/private-key.pem"
+      },
+      gateway: {
+        bearerTokenPath: "gateway/bearer-token.txt"
+      }
+    }),
+    "utf8"
+  );
+
+  const resolved = await withRuntimeMachineAuth({
+    manifestPath,
+    env: {},
+    runtimeUrl: "https://example.invalid"
+  });
+
+  assert.equal(resolved.env.VTDD_GATEWAY_BEARER_TOKEN, "vault-token");
+});
+
+test("runtime machine auth prefers environment token over desktop vault", async () => {
+  const resolved = await withRuntimeMachineAuth({
+    manifestPath: "/does/not/exist.json",
+    env: {
+      VTDD_GATEWAY_BEARER_TOKEN: "env-token"
+    },
+    runtimeUrl: "https://example.invalid"
+  });
+
+  assert.equal(resolved.env.VTDD_GATEWAY_BEARER_TOKEN, "env-token");
+});
+
+test("runtime machine auth reports desktop maintenance required without leaking token", async () => {
+  await assert.rejects(
+    () =>
+      withRuntimeMachineAuth({
+        manifestPath: "/does/not/exist.json",
+        env: {},
+        runtimeUrl: "https://example.invalid"
+      }),
+    (error) => {
+      assert.match(error.message, /desktop maintenance required: gateway_bearer_token_missing/);
+      assert.equal(error.message.includes("Bearer"), false);
+      return true;
+    }
+  );
 });


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #380 の部分進捗です。mac Codex / VPS Codex CLI が RAG checkpoint を D1 直書きではなく VTDD 正規 runtime route へ送るための machine auth 解決経路を追加します。
- 既存契約 `~/.vtdd/credentials/manifest.json` の `gateway.bearerTokenPath` を CLI fallback として使い、保存後確認用の operational-memory retrieve コマンドも追加します。

## Satisfied Success Criteria

- `scripts/vtdd-memory.mjs write-runtime-checkpoint` / `retrieve-cross` が `VTDD_GATEWAY_BEARER_TOKEN` を優先し、無い場合は desktop bootstrap vault の `gateway.bearerTokenPath` から token を解決できるようにしました。
- `retrieve-operational` コマンドを追加し、保存後に `/v2/retrieve/operational-memory` で確認できるようにしました。
- token は URL に含めず、Authorization header のみに入ることを test で確認しました。
- vault が無い場合は `desktop maintenance required: gateway_bearer_token_missing` として失敗し、D1 直書き fallback を案内しないようにしました。
- docs に mac Codex / VPS Codex CLI が同じ runtime write/retrieve contract を使うこと、D1 直書きは通常経路ではないことを追記しました。

## Unsatisfied Success Criteria

- この PR では実際の `~/.vtdd/credentials/manifest.json` や gateway token file は作成していません。
- production runtime への実 RAG write / retrieve E2E は、認証済み vault または env token がこの実行環境に入ってから実施が必要です。
- Butler から同じ checkpoint を呼び出して確認する owner-facing E2E は未実施です。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #380
- Implementing Success Criteria: mac Codex / VPS Codex CLI が `VTDD_GATEWAY_BEARER_TOKEN` または desktop bootstrap vault から machine auth を得て、正規 runtime RAG write/retrieve route を使えること。
- Explicit Non-goals: secret 値の作成/表示/変更、Cloudflare/GitHub secret mutation、D1 直書きの通常化、Custom GPT Action Schema / Instructions 更新、setup wizard 復活は行いません。
- Expected touched files/routes/workflows: `scripts/vtdd-memory.mjs`, `test/vtdd-memory-cli.test.js`, `docs/memory/vtdd-memory-bridge.md`。Worker route と GitHub Actions workflow は変更しません。
- Affected Issues: Issue #380, Issue #361, Issue #356, Issue #344, Issue #359。
- Affected PRs: PR #379 の deploy 後に出た RAG checkpoint candidate を正規 route で保存するための前提になります。
- Affected workflows: GitHub Actions は変更しません。CLI-only change のため `worker.js` build は不要です。
- Affected runtime/operator surfaces: `/v2/action/memory-write`, `/v2/retrieve/operational-memory` の既存 runtime surface を CLI から使いやすくします。runtime implementation 自体は変更しません。
- What may break if we patch narrowly: env token だけに寄せると mac/VPS で再現性が低く、D1 直書きに戻りやすい。vault を steady-state 前提にすると iPhone-first の設計から drift します。
- Unknowns to investigate before coding: 既存 vault 契約があるか、token を出さずに CLI が request を組めるか、operational-memory retrieve の CLI helper があるか。
- Validation needed: `test/vtdd-memory-cli.test.js`, full `npm test`, token 非表示確認。
- Stop condition: token 値を表示する必要が出る、または D1 直書きを通常 RAG write 経路として扱いそうになった場合は停止。

## File / Line Hypotheses

- file: `scripts/vtdd-memory.mjs`
  - hypothesis: runtime auth 解決は request builder ではなく CLI 実行前の `withRuntimeMachineAuth` に閉じるのが安全。
  - risk if changed narrowly: builder が local vault を直接読むと unit test と pure request building が secret filesystem に依存します。
  - validation: env token 優先、vault fallback、missing vault failure、URL 非混入を unit test で確認。
  - related Issue: Issue #380
- file: `docs/memory/vtdd-memory-bridge.md`
  - hypothesis: docs に正規 route と D1 repair boundary を明記しないと、次の agent がまた D1 直書きへ逃げる。
  - risk if changed narrowly: mac Codex と VPS Codex CLI の運用が分岐し、RAG が shared memory ではなくなる。
  - validation: docs diff と PR body で Non-goal を確認。
  - related Issue: Issue #380
- file: `test/vtdd-memory-cli.test.js`
  - hypothesis: secret 非表示と missing vault failure を test に固定すれば再発しにくい。
  - risk if changed narrowly: happy path だけ通って、失敗時に token を漏らす regression を見逃す。
  - validation: targeted test と full test。
  - related Issue: Issue #380

## Hypothesis Retrospective

- expected: 既存 desktop bootstrap vault 契約を CLI に接続すれば、mac Codex / VPS Codex CLI が正規 runtime RAG route を使える入口になる。
- actual: `withRuntimeMachineAuth` で env token 優先、vault fallback、missing 時の `desktop maintenance required` を実装し、`retrieve-operational` も追加できました。
- mismatch: 実環境にはまだ `~/.vtdd/credentials/manifest.json` が無いため、実 RAG 書き込みはこの PR 単体では完了しません。
- lesson: runtime route があるだけでは VTDD 的には未接続。AI surface が安全に認証を得る bootstrap path まで含めて実行面です。
- should become RAG candidate: はい。Issue #380 の判断として保存候補です。

## Verification Evidence

- Unit: `node --test test/vtdd-memory-cli.test.js` passed: 12 tests。
- Integration: `npm test` passed: 778 tests, 777 pass, 1 skipped。`check:self-parity` passed。`check:generated-worker` passed。
- E2E: 未実施。実 gateway token がこの環境に無いため production runtime write/retrieve は未確認です。
- Manual: `git diff --check` passed。
- Evidence path/link: `scripts/vtdd-memory.mjs`, `test/vtdd-memory-cli.test.js`, `docs/memory/vtdd-memory-bridge.md`

## Butler Completion Contract

- Owner goal: mac Codex / VPS Codex CLI からも Butler と同じ正規 runtime RAG route で checkpoint を保存・確認できるようにする。
- Butler entrypoint: Butler 側は既存 `vtddWriteOperationalMemory` / `vtddRetrieveOperationalMemory`。この PR は mac/VPS CLI 側の接続を補強します。
- Action Schema exposure: 不要。既存 operationId は変更しません。
- Runtime path: 既存 `/v2/action/memory-write` と `/v2/retrieve/operational-memory`。
- Runner/runtime truth: CLI が runtime response を JSON として返します。失敗時は HTTP status と body を返します。
- Authority boundary: 新しい high-risk authority は追加しません。secret 値の作成/同期/表示はこの PR 外です。
- E2E evidence: 未実施。実 token のある mac/VPS 環境で checkpoint write と retrieve が必要です。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 不要。Worker runtime / `worker.js` は変更していません。
- Custom GPT Action Schema update: 不要。Action Schema は変更していません。
- Custom GPT Instructions update: 不要。Instructions は変更していません。
- iPhone Butler live E2E: 後続で必要。Butler から保存済み checkpoint を retrieve して確認します。

## Related Constitution Rules

- Issue 起点で変更し、Issue #380 の machine auth 経路に限定しました。
- RAG 書き込みは正規 runtime route を通し、D1 直書きへ逃げない境界を docs/test に固定しました。
- secret 値を出力しないことを test で固定しました。
- Butler Completion Gate に従い、実 E2E 未実施のため complete とは扱いません。

## Out-of-scope but NOT implemented

- 実 gateway token / vault manifest の作成
- Cloudflare Worker secret / GitHub Actions secret の変更
- production runtime への実 checkpoint 書き込み
- Butler からの live retrieve 確認
- Custom GPT Action Schema / Instructions 更新

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #380
- Execution ID: mac-codex-issue-380-rag-machine-auth-20260515
- Goal: mac Codex / VPS Codex CLI が正規 runtime route で RAG checkpoint を保存確認できる machine auth 経路を作る
