### PR TITLE
Issue #380: gateway bearer token vault bootstrap を追加

### DIFF
--- a/docs/memory/vtdd-memory-bridge.md
+++ b/docs/memory/vtdd-memory-bridge.md
@@ -43,6 +43,19 @@ available, the runtime memory commands must fail with `desktop maintenance
 required` instead of falling back to D1 direct writes or asking the operator to
 paste a secret into chat.
 
+Bootstrap the local gateway bearer token reference with:
+
+```sh
+printf '%s' "$VTDD_GATEWAY_BEARER_TOKEN" | node scripts/bootstrap-gateway-bearer-vault.mjs \
+  --token-stdin \
+  --pretty
+```
+
+This creates/updates `~/.vtdd/credentials/manifest.json` and
+`~/.vtdd/credentials/gateway/bearer-token.txt` without printing the token value.
+It only configures the local Mac/VPS caller. It does not rotate or sync Worker
+secrets, GitHub Actions secrets, or Custom GPT Action auth.
+
 ## Commands
 
 Inventory D1 memory records:

--- a/docs/setup/desktop-bootstrap-vault.md
+++ b/docs/setup/desktop-bootstrap-vault.md
@@ -20,6 +20,22 @@ The canonical local path is:
 
 - `~/.vtdd/credentials/manifest.json`
 
+For the gateway bearer token specifically, use the repository bootstrap helper
+instead of pasting the token into chat or a command argument:
+
+```bash
+printf '%s' "$VTDD_GATEWAY_BEARER_TOKEN" | node scripts/bootstrap-gateway-bearer-vault.mjs \
+  --token-stdin \
+  --pretty
+```
+
+The helper writes `gateway/bearer-token.txt`, updates
+`~/.vtdd/credentials/manifest.json`, keeps the token value out of stdout, and
+uses operator-only file modes where the filesystem supports them. `--generate`
+can create a new local token, but that token will not work against the deployed
+Worker until the Worker secret and Custom GPT Action auth are intentionally
+rotated through their own approval boundaries.
+
 ## Boundary
 
 This vault is:

--- a/scripts/bootstrap-gateway-bearer-vault.mjs
+++ b/scripts/bootstrap-gateway-bearer-vault.mjs
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+import crypto from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { DEFAULT_VTDD_VAULT_MANIFEST_PATH } from "../src/core/desktop-bootstrap-vault.js";
+
+const DEFAULT_TOKEN_RELATIVE_PATH = "gateway/bearer-token.txt";
+
+export function parseArgs(argv) {
+  const parsed = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const current = argv[index];
+    if (current === "--manifest-path") {
+      parsed.manifestPath = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (current === "--token-path") {
+      parsed.tokenPath = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (current === "--token-stdin") {
+      parsed.tokenStdin = true;
+      continue;
+    }
+    if (current === "--generate") {
+      parsed.generate = true;
+      continue;
+    }
+    if (current === "--dry-run") {
+      parsed.dryRun = true;
+      continue;
+    }
+    if (current === "--pretty") {
+      parsed.pretty = true;
+      continue;
+    }
+  }
+  return parsed;
+}
+
+export async function bootstrapGatewayBearerVault(options = {}) {
+  const manifestPath = path.resolve(
+    normalizeText(options.manifestPath) || DEFAULT_VTDD_VAULT_MANIFEST_PATH
+  );
+  const manifestDir = path.dirname(manifestPath);
+  const tokenRelativePath = normalizeText(options.tokenPath) || DEFAULT_TOKEN_RELATIVE_PATH;
+  if (path.isAbsolute(tokenRelativePath)) {
+    throw new Error("token path must be relative to the credentials manifest directory");
+  }
+
+  const token = await resolveToken(options);
+  if (!token) {
+    throw new Error("gateway bearer token source is required via VTDD_GATEWAY_BEARER_TOKEN, --token-stdin, or --generate");
+  }
+
+  const tokenPath = path.join(manifestDir, tokenRelativePath);
+  const manifest = await readExistingManifest(manifestPath);
+  const nextManifest = {
+    ...manifest,
+    version: 1,
+    gateway: {
+      ...(manifest.gateway && typeof manifest.gateway === "object" ? manifest.gateway : {}),
+      bearerTokenPath: tokenRelativePath
+    }
+  };
+
+  if (!options.dryRun) {
+    await fs.mkdir(path.dirname(tokenPath), { recursive: true, mode: 0o700 });
+    await fs.mkdir(manifestDir, { recursive: true, mode: 0o700 });
+    await fs.writeFile(tokenPath, `${token}\n`, { mode: 0o600 });
+    await fs.writeFile(manifestPath, `${JSON.stringify(nextManifest, null, 2)}\n`, { mode: 0o600 });
+    await chmodBestEffort(path.dirname(tokenPath), 0o700);
+    await chmodBestEffort(manifestDir, 0o700);
+    await chmodBestEffort(tokenPath, 0o600);
+    await chmodBestEffort(manifestPath, 0o600);
+  }
+
+  return {
+    ok: true,
+    dryRun: options.dryRun === true,
+    manifestPath,
+    tokenPath,
+    manifestUpdated: true,
+    tokenWritten: options.dryRun !== true,
+    tokenSource: token.source,
+    tokenPreview: "[redacted]"
+  };
+}
+
+async function resolveToken(options) {
+  const envToken = normalizeText(options.env?.VTDD_GATEWAY_BEARER_TOKEN ?? process.env.VTDD_GATEWAY_BEARER_TOKEN);
+  if (envToken) {
+    return Object.assign(new String(envToken), { source: "env" });
+  }
+  if (options.tokenStdin) {
+    const stdinToken = normalizeText(options.stdinText ?? (await readStdin()));
+    if (stdinToken) {
+      return Object.assign(new String(stdinToken), { source: "stdin" });
+    }
+  }
+  if (options.generate) {
+    const generated = crypto.randomBytes(32).toString("base64url");
+    return Object.assign(new String(generated), { source: "generated" });
+  }
+  return "";
+}
+
+async function readExistingManifest(manifestPath) {
+  try {
+    const content = await fs.readFile(manifestPath, "utf8");
+    const parsed = JSON.parse(content);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : {};
+  } catch (error) {
+    if (error?.code === "ENOENT") {
+      return {};
+    }
+    throw new Error(`existing manifest is unreadable: ${manifestPath}`);
+  }
+}
+
+async function chmodBestEffort(targetPath, mode) {
+  try {
+    await fs.chmod(targetPath, mode);
+  } catch {
+    // Some filesystems do not support POSIX modes. Creation still succeeds.
+  }
+}
+
+function readStdin() {
+  return new Promise((resolve, reject) => {
+    let data = "";
+    process.stdin.setEncoding("utf8");
+    process.stdin.on("data", (chunk) => {
+      data += chunk;
+    });
+    process.stdin.on("end", () => resolve(data));
+    process.stdin.on("error", reject);
+  });
+}
+
+function normalizeText(value) {
+  return String(value ?? "").trim();
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const args = parseArgs(process.argv.slice(2));
+  bootstrapGatewayBearerVault(args)
+    .then((result) => {
+      const spacing = args.pretty ? 2 : 0;
+      process.stdout.write(`${JSON.stringify(result, null, spacing)}\n`);
+    })
+    .catch((error) => {
+      process.stderr.write(`${error.message}\n`);
+      process.exitCode = 1;
+    });
+}

--- a/test/gateway-bearer-vault-bootstrap.test.js
+++ b/test/gateway-bearer-vault-bootstrap.test.js
@@ -1,0 +1,95 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { bootstrapGatewayBearerVault } from "../scripts/bootstrap-gateway-bearer-vault.mjs";
+
+test("gateway bearer vault bootstrap writes token file and manifest without printing token", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "vtdd-gateway-vault-"));
+  const manifestPath = path.join(root, "manifest.json");
+
+  const result = await bootstrapGatewayBearerVault({
+    manifestPath,
+    env: {
+      VTDD_GATEWAY_BEARER_TOKEN: "local-test-token"
+    }
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.tokenPreview, "[redacted]");
+  assert.equal(JSON.stringify(result).includes("local-test-token"), false);
+
+  const manifest = JSON.parse(await fs.readFile(manifestPath, "utf8"));
+  assert.equal(manifest.version, 1);
+  assert.equal(manifest.gateway.bearerTokenPath, "gateway/bearer-token.txt");
+  assert.equal(await fs.readFile(path.join(root, "gateway", "bearer-token.txt"), "utf8"), "local-test-token\n");
+});
+
+test("gateway bearer vault bootstrap preserves existing manifest sections", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "vtdd-gateway-vault-"));
+  const manifestPath = path.join(root, "manifest.json");
+  await fs.writeFile(
+    manifestPath,
+    JSON.stringify({
+      version: 1,
+      githubApp: {
+        appId: "123",
+        installationId: "456",
+        privateKeyPath: "github-app/private-key.pem"
+      }
+    }),
+    "utf8"
+  );
+
+  await bootstrapGatewayBearerVault({
+    manifestPath,
+    stdinText: "stdin-token",
+    tokenStdin: true,
+    tokenPath: "gateway/custom-token.txt"
+  });
+
+  const manifest = JSON.parse(await fs.readFile(manifestPath, "utf8"));
+  assert.equal(manifest.githubApp.appId, "123");
+  assert.equal(manifest.gateway.bearerTokenPath, "gateway/custom-token.txt");
+  assert.equal(await fs.readFile(path.join(root, "gateway", "custom-token.txt"), "utf8"), "stdin-token\n");
+});
+
+test("gateway bearer vault bootstrap dry-run does not write files", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "vtdd-gateway-vault-"));
+  const manifestPath = path.join(root, "manifest.json");
+
+  const result = await bootstrapGatewayBearerVault({
+    manifestPath,
+    dryRun: true,
+    generate: true
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.dryRun, true);
+  await assert.rejects(() => fs.readFile(manifestPath, "utf8"), /ENOENT/);
+});
+
+test("gateway bearer vault bootstrap rejects absolute token paths", async () => {
+  await assert.rejects(
+    () =>
+      bootstrapGatewayBearerVault({
+        manifestPath: path.join(os.tmpdir(), "manifest.json"),
+        tokenPath: path.join(os.tmpdir(), "token.txt"),
+        generate: true
+      }),
+    /token path must be relative/
+  );
+});
+
+test("gateway bearer vault bootstrap requires an explicit token source", async () => {
+  await assert.rejects(
+    () =>
+      bootstrapGatewayBearerVault({
+        manifestPath: path.join(os.tmpdir(), "manifest.json"),
+        env: {}
+      }),
+    /gateway bearer token source is required/
+  );
+});


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #380 の部分進捗です。mac Codex / VPS Codex CLI が正規 runtime RAG route を使うために必要な `~/.vtdd/credentials/manifest.json` と `gateway/bearer-token.txt` を、安全に作る bootstrap helper を追加します。
- token 値を chat、stdout、PR body に出さず、stdin/env/generate から local vault へ置く入口を用意します。

## Satisfied Success Criteria

- `scripts/bootstrap-gateway-bearer-vault.mjs` を追加し、`VTDD_GATEWAY_BEARER_TOKEN` または `--token-stdin` から gateway bearer token file を作成できるようにしました。
- 既存 manifest の `githubApp` などの section を保持しつつ、`gateway.bearerTokenPath` を追加/更新できます。
- token path は manifest dir からの relative path のみに制限し、absolute path は拒否します。
- stdout の result は token 値を含まず、`tokenPreview: "[redacted]"` のみを返します。
- `--dry-run` と `--generate` を用意しました。ただし生成 token は runtime secret / Custom GPT Action auth と同期しなければ使えないことを docs に明記しました。
- memory bridge / desktop bootstrap vault docs に、D1 直書きではなく正規 runtime route 用の local vault bootstrap であることを追記しました。

## Unsatisfied Success Criteria

- この PR では実際の operator Mac / VPS に token file を作成していません。
- この PR では Worker secret、GitHub Actions secret、Custom GPT Action auth を変更していません。
- production runtime に対する実 RAG write / retrieve E2E は未実施です。
- 既存 Worker secret と Custom GPT Action auth の token 値は読み戻せないため、既存 token の local vault 化は owner が安全な経路で token source を持っている場合に限られます。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #380
- Implementing Success Criteria: `~/.vtdd/credentials/manifest.json` と gateway bearer token file を安全に作成し、PR #381 の runtime machine auth fallback が読める状態に近づける。
- Explicit Non-goals: Worker secret 変更、GitHub secret 変更、Custom GPT Action auth 更新、deploy、実 token のこの場での配置、D1 直書き、setup wizard 復活は行いません。
- Expected touched files/routes/workflows: `scripts/bootstrap-gateway-bearer-vault.mjs`, `test/gateway-bearer-vault-bootstrap.test.js`, `docs/setup/desktop-bootstrap-vault.md`, `docs/memory/vtdd-memory-bridge.md`。runtime route と workflow は変更しません。
- Affected Issues: Issue #380, Issue #361, Issue #356, Issue #344。
- Affected PRs: PR #381 の後続。PR #381 が追加した vault fallback を実際に満たすための helper です。
- Affected workflows: なし。CLI/docs/test のみです。
- Affected runtime/operator surfaces: local Mac/VPS bootstrap surface。Butler Action Schema と Worker runtime は変更しません。
- What may break if we patch narrowly: token file を手作業前提にすると chat への token 貼り付けや shell history 混入が起きやすい。逆に自動 rotation まで混ぜると Worker secret / Custom GPT auth の高リスク境界を壊します。
- Unknowns to investigate before coding: 既存 Worker secret の値は読み戻せないため、local vault に既存 token を入れるには owner が安全な token source を持っている必要がある。
- Validation needed: bootstrap helper unit tests、desktop vault docs test、full `npm test`。
- Stop condition: token 値を表示する必要が出る、または Worker/Custom GPT credential rotation をこの PR に混ぜそうになった場合は停止。

## File / Line Hypotheses

- file: `scripts/bootstrap-gateway-bearer-vault.mjs`
  - hypothesis: local vault bootstrap は独立 CLI に切り出すと、RAG write CLI と secret placement が混ざらず安全。
  - risk if changed narrowly: `vtdd-memory.mjs` に token file 作成まで混ぜると、通常 RAG write と credential bootstrap の境界が曖昧になります。
  - validation: token 非表示、manifest preserve、absolute path reject、dry-run no-write を unit test で確認。
  - related Issue: Issue #380
- file: `docs/setup/desktop-bootstrap-vault.md`
  - hypothesis: `--generate` の限界を明記しないと、生成 token がそのまま runtime で使えると誤解されます。
  - risk if changed narrowly: Worker secret / Custom GPT auth と不一致の token を作って 401/403 で詰まります。
  - validation: docs diff と PR body の Unsatisfied Success Criteria に明記。
  - related Issue: Issue #380
- file: `docs/memory/vtdd-memory-bridge.md`
  - hypothesis: RAG memory bridge docs に bootstrap command を置くと、mac Codex / VPS Codex CLI の再開導線になる。
  - risk if changed narrowly: 次の agent がまた D1 直書きや chat token 貼り付けへ drift します。
  - validation: docs に D1 repair boundary と local-only bootstrap を併記。
  - related Issue: Issue #380

## Hypothesis Retrospective

- expected: local vault bootstrap helper を追加すれば、PR #381 の machine auth fallback が実運用に近づく。
- actual: helper は token 非表示で manifest/token file を作り、既存 manifest を保持し、absolute path を拒否できました。
- mismatch: 既存 deployed Worker / Custom GPT Action auth の token は読み戻せないため、この PR 単体では今すぐ RAG 書き込み E2E には到達しません。
- lesson: VTDD の credential bootstrap は「読む」「置く」「runtime と一致させる」を分けて扱わないと危険。ここでは local vault placement だけを切りました。
- should become RAG candidate: はい。credential bootstrap 境界の判断として候補になります。

## Verification Evidence

- Unit: `node --test test/gateway-bearer-vault-bootstrap.test.js test/vtdd-memory-cli.test.js test/desktop-bootstrap-vault.test.js` passed: 21 tests。
- Integration: `npm test` passed: 783 tests, 782 pass, 1 skipped。`check:self-parity` passed。`check:generated-worker` passed。
- E2E: 未実施。実 token placement と runtime write/retrieve は高リスク credential 境界のため、この PR では行っていません。
- Manual: `git diff --check` passed。
- Evidence path/link: `scripts/bootstrap-gateway-bearer-vault.mjs`, `test/gateway-bearer-vault-bootstrap.test.js`, `docs/setup/desktop-bootstrap-vault.md`, `docs/memory/vtdd-memory-bridge.md`

## Butler Completion Contract

- Owner goal: mac Codex / VPS Codex CLI が正規 runtime RAG route を叩くための gateway bearer token を local vault から安全に読めるようにする。
- Butler entrypoint: Butler の既存 `vtddWriteOperationalMemory` / `vtddRetrieveOperationalMemory` は変更なし。この PR は mac/VPS local bootstrap 側の補助です。
- Action Schema exposure: 不要。Action Schema は変更していません。
- Runtime path: 既存 `/v2/action/memory-write` と `/v2/retrieve/operational-memory`。runtime code は変更していません。
- Runner/runtime truth: helper は local file placement result を JSON で返します。token 値は返しません。
- Authority boundary: 実 token 配置、secret sync、rotation は credential mutation として別途 `GO + passkey` が必要です。この PR は実行していません。
- E2E evidence: 未実施。実 token source を得て local vault に配置し、runtime write/retrieve する確認が残っています。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 不要。Worker runtime / `worker.js` は変更していません。
- Custom GPT Action Schema update: 不要。Action Schema は変更していません。
- Custom GPT Instructions update: 不要。Instructions は変更していません。
- iPhone Butler live E2E: 後続で必要。Butler と mac/VPS が同じ checkpoint を読めることを確認します。

## Related Constitution Rules

- Issue 起点で変更し、Issue #380 の local vault bootstrap に限定しました。
- secret 値を出力しないことを test で固定しました。
- credential mutation / deploy / permission mutation はこの PR で実行していません。
- Butler Completion Gate に従い、実 RAG write/retrieve E2E 未実施のため complete とは扱いません。

## Out-of-scope but NOT implemented

- 実 token の配置実行
- Worker secret / GitHub Actions secret / Custom GPT Action auth の変更
- production runtime への実 RAG checkpoint 書き込み
- Butler からの live retrieve 確認
- deploy

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #380
- Execution ID: mac-codex-issue-380-gateway-vault-bootstrap-20260515
- Goal: gateway bearer token file を安全に local vault へ置く bootstrap helper を追加する
