### PR TITLE
Issue #380: VTDD_GATEWAY_BEARER_TOKEN を Actions secret sync 対象に追加

### DIFF
--- a/docs/memory/vtdd-memory-bridge.md
+++ b/docs/memory/vtdd-memory-bridge.md
@@ -56,6 +56,17 @@ This creates/updates `~/.vtdd/credentials/manifest.json` and
 It only configures the local Mac/VPS caller. It does not rotate or sync Worker
 secrets, GitHub Actions secrets, or Custom GPT Action auth.
 
+If the gateway bearer token is rotated, the same value must be aligned across:
+
+- the local Mac/VPS vault token file,
+- GitHub Actions secret `VTDD_GATEWAY_BEARER_TOKEN`,
+- the deployed Worker secret `VTDD_GATEWAY_BEARER_TOKEN`,
+- Custom GPT Action bearer auth.
+
+The operator page can sync the GitHub Actions secret under
+`highRiskKind=github_actions_secret_sync`, but Worker secret rotation and Custom
+GPT Action auth update remain separate explicit credential-update steps.
+
 ## Commands
 
 Inventory D1 memory records:

--- a/src/core/github-actions-secret-sync.js
+++ b/src/core/github-actions-secret-sync.js
@@ -3,7 +3,7 @@ import { resolveGitHubAppInstallationToken } from "./github-app-repository-index
 const GITHUB_API_BASE_URL = "https://api.github.com";
 const GITHUB_API_VERSION = "2022-11-28";
 const GITHUB_API_USER_AGENT = "vtdd-v2-github-actions-secret-sync";
-const ALLOWED_ACTIONS_SECRET_NAMES = new Set(["OPENAI_API_KEY"]);
+const ALLOWED_ACTIONS_SECRET_NAMES = new Set(["OPENAI_API_KEY", "VTDD_GATEWAY_BEARER_TOKEN"]);
 
 export async function executeGitHubActionsSecretSync(input = {}) {
   const repository = normalizeText(input.repository);
@@ -150,7 +150,7 @@ export function validateGitHubActionsSecretSyncRequest({
     issues.push("repository is required");
   }
   if (!ALLOWED_ACTIONS_SECRET_NAMES.has(secretName)) {
-    issues.push("secretName must be OPENAI_API_KEY");
+    issues.push("secretName must be OPENAI_API_KEY or VTDD_GATEWAY_BEARER_TOKEN");
   }
   if (!secretValue) {
     issues.push("secretValue is required");

--- a/src/core/passkey-operator-page.js
+++ b/src/core/passkey-operator-page.js
@@ -257,12 +257,17 @@ export function renderPasskeyOperatorPage(input = {}) {
         </section>
 
         <section data-operator-section="github-actions-secret-sync"${hiddenAttribute(!sectionVisibility.githubActionsSecretSync)}>
-          <h2>6. Codex Fallback Secret Sync</h2>
-          <p class="muted">Codex reviewer fallback 用の <code>OPENAI_API_KEY</code> を GitHub Actions secret に同期します。値は Butler 会話に貼らず、この operator page から送信します。</p>
+          <h2>6. GitHub Actions Secret Sync</h2>
+          <p class="muted">GitHub Actions secret を同期します。値は Butler 会話に貼らず、この operator page から送信します。<code>VTDD_GATEWAY_BEARER_TOKEN</code> は Actions secret だけではなく Worker secret / Custom GPT Action auth と一致している必要があります。</p>
+          <label for="github-actions-secret-name-input">Secret name</label>
+          <select id="github-actions-secret-name-input">
+            <option value="OPENAI_API_KEY">OPENAI_API_KEY</option>
+            <option value="VTDD_GATEWAY_BEARER_TOKEN">VTDD_GATEWAY_BEARER_TOKEN</option>
+          </select>
           <label for="openai-api-key-input">OPENAI_API_KEY</label>
           <input id="openai-api-key-input" type="password" autocomplete="off" placeholder="sk-..." />
           <div class="row">
-            <button id="openai-secret-sync-button">Sync OPENAI_API_KEY</button>
+            <button id="openai-secret-sync-button">Sync GitHub Actions secret</button>
           </div>
           <p class="muted"><code>actionType=destructive</code> / <code>highRiskKind=github_actions_secret_sync</code> の approvalGrantId が必要です。</p>
           <pre id="openai-secret-sync-output"></pre>
@@ -676,19 +681,20 @@ export function renderPasskeyOperatorPage(input = {}) {
       document.getElementById("openai-secret-sync-button").addEventListener("click", async () => {
         try {
           if (!latestApprovalGrantId) {
-            throw new Error("approvalGrantId is required before OPENAI_API_KEY secret sync");
+            throw new Error("approvalGrantId is required before GitHub Actions secret sync");
           }
+          const secretName = document.getElementById("github-actions-secret-name-input").value;
           const secretValue = document.getElementById("openai-api-key-input").value;
           if (!secretValue) {
-            throw new Error("OPENAI_API_KEY is required");
+            throw new Error(secretName + " is required");
           }
-          openaiSecretSyncOutput.textContent = "OPENAI_API_KEY secret sync request...";
+          openaiSecretSyncOutput.textContent = secretName + " secret sync request...";
           const syncResponse = await fetch("${apiBase}/action/github-actions-secret", {
             method: "POST",
             headers: { "content-type": "application/json" },
             body: JSON.stringify({
               repository: document.getElementById("repo-input").value,
-              secretName: "OPENAI_API_KEY",
+              secretName,
               secretValue,
               policyInput: {
                 approvalGrantId: latestApprovalGrantId
@@ -697,7 +703,7 @@ export function renderPasskeyOperatorPage(input = {}) {
           });
           const syncBody = await readResponseBody(syncResponse);
           if (!syncResponse.ok) {
-            throw responseError(syncBody, "OPENAI_API_KEY secret sync failed");
+            throw responseError(syncBody, secretName + " secret sync failed");
           }
           document.getElementById("openai-api-key-input").value = "";
           openaiSecretSyncOutput.textContent = JSON.stringify(syncBody, null, 2);

--- a/test/github-actions-secret-sync.test.js
+++ b/test/github-actions-secret-sync.test.js
@@ -16,7 +16,7 @@ const validApprovalGrant = {
   }
 };
 
-test("github actions secret sync writes only approved OPENAI_API_KEY without echoing the secret", async () => {
+test("github actions secret sync writes approved OPENAI_API_KEY without echoing the secret", async () => {
   const calls = [];
   const result = await executeGitHubActionsSecretSync({
     repository: "sample-org/vtdd-v2-p",
@@ -51,6 +51,40 @@ test("github actions secret sync writes only approved OPENAI_API_KEY without ech
   assert.equal(JSON.parse(calls[1].init.body).encrypted_value, "encrypted-secret");
 });
 
+test("github actions secret sync writes approved VTDD_GATEWAY_BEARER_TOKEN without echoing the secret", async () => {
+  const calls = [];
+  const result = await executeGitHubActionsSecretSync({
+    repository: "sample-org/vtdd-v2-p",
+    secretName: "VTDD_GATEWAY_BEARER_TOKEN",
+    secretValue: "gateway-test-secret",
+    approvalGrant: validApprovalGrant,
+    encryptSecret: async ({ publicKey, secretValue }) => {
+      assert.equal(publicKey, "public-key");
+      assert.equal(secretValue, "gateway-test-secret");
+      return "encrypted-gateway-secret";
+    },
+    env: {
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_secret",
+      GITHUB_API_FETCH: async (url, init) => {
+        calls.push({ url: String(url), init });
+        if (String(url).endsWith("/actions/secrets/public-key")) {
+          return new Response(JSON.stringify({ key_id: "key-123", key: "public-key" }), {
+            status: 200,
+            headers: { "content-type": "application/json" }
+          });
+        }
+        return new Response(null, { status: 204 });
+      }
+    }
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.secretSync.secretName, "VTDD_GATEWAY_BEARER_TOKEN");
+  assert.equal(JSON.stringify(result).includes("gateway-test-secret"), false);
+  assert.equal(calls[1].url.endsWith("/actions/secrets/VTDD_GATEWAY_BEARER_TOKEN"), true);
+  assert.equal(JSON.parse(calls[1].init.body).encrypted_value, "encrypted-gateway-secret");
+});
+
 test("github actions secret sync blocks unapproved names and wrong passkey scope", async () => {
   const unsupported = await executeGitHubActionsSecretSync({
     repository: "sample-org/vtdd-v2-p",
@@ -63,7 +97,10 @@ test("github actions secret sync blocks unapproved names and wrong passkey scope
   });
   assert.equal(unsupported.ok, false);
   assert.equal(unsupported.error, "github_actions_secret_sync_request_invalid");
-  assert.equal(unsupported.issues.includes("secretName must be OPENAI_API_KEY"), true);
+  assert.equal(
+    unsupported.issues.includes("secretName must be OPENAI_API_KEY or VTDD_GATEWAY_BEARER_TOKEN"),
+    true
+  );
 
   const wrongScope = validateGitHubActionsSecretSyncApprovalGrant({
     repository: "sample-org/vtdd-v2-p",

--- a/test/passkey-operator-page.test.js
+++ b/test/passkey-operator-page.test.js
@@ -23,7 +23,8 @@ test("passkey operator page can target explicit api base and sync endpoint", () 
   assert.equal(html.includes("readResponseBody"), true);
   assert.equal(html.includes("non_json_response"), true);
   assert.equal(html.includes("Sync GitHub App secrets"), true);
-  assert.equal(html.includes("Sync OPENAI_API_KEY"), true);
+  assert.equal(html.includes("Sync GitHub Actions secret"), true);
+  assert.equal(html.includes("VTDD_GATEWAY_BEARER_TOKEN"), true);
   assert.equal(html.includes("Dispatch production deploy"), true);
   assert.equal(html.includes("Dispatch PR merge"), true);
   assert.equal(html.includes("Open deploy run"), true);
@@ -178,6 +179,8 @@ test("passkey operator page focuses secret sync modes without hiding the require
   });
   assert.equal(actionsSecretHtml.includes('<section data-operator-section="approval">'), true);
   assert.equal(actionsSecretHtml.includes('<section data-operator-section="github-actions-secret-sync">'), true);
+  assert.equal(actionsSecretHtml.includes('<option value="VTDD_GATEWAY_BEARER_TOKEN">'), true);
+  assert.equal(actionsSecretHtml.includes("Worker secret / Custom GPT Action auth"), true);
   assert.equal(actionsSecretHtml.includes('<section data-operator-section="github-app-secret-sync" hidden>'), true);
   assert.equal(actionsSecretHtml.includes('<section data-operator-section="production-deploy" hidden>'), true);
   assert.equal(actionsSecretHtml.includes('<section data-operator-section="pr-merge" hidden>'), true);

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -5094,6 +5094,74 @@ test("worker syncs OPENAI_API_KEY through approval-bound GitHub Actions secret r
   assert.equal(calls[1].url.endsWith("/actions/secrets/OPENAI_API_KEY"), true);
 });
 
+test("worker syncs VTDD_GATEWAY_BEARER_TOKEN through approval-bound GitHub Actions secret route", async () => {
+  const provider = createInMemoryMemoryProvider();
+  const calls = [];
+  await provider.store({
+    id: "approval-actions-gateway-secret-123",
+    type: MemoryRecordType.APPROVAL_LOG,
+    content: {
+      kind: "passkey_grant",
+      status: "verified",
+      approvalId: "approval-actions-gateway-secret-123",
+      expiresAt: "2099-01-01T00:00:00.000Z",
+      scope: {
+        actionType: "destructive",
+        highRiskKind: "github_actions_secret_sync",
+        repositoryInput: "sample-org/vtdd-v2-p",
+        phase: "execution"
+      }
+    },
+    metadata: { source: "test" },
+    priority: 90,
+    tags: ["passkey_grant"],
+    createdAt: "2026-04-28T00:00:00.000Z"
+  });
+
+  const response = await worker.fetch(
+    new Request("https://sample-user-vtdd.example.workers.dev/v2/action/github-actions-secret", {
+      method: "POST",
+      headers: {
+        ...gatewayAuthHeaders,
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({
+        repository: "sample-org/vtdd-v2-p",
+        secretName: "VTDD_GATEWAY_BEARER_TOKEN",
+        secretValue: "gateway-test-secret",
+        policyInput: {
+          approvalGrantId: "approval-actions-gateway-secret-123"
+        }
+      })
+    }),
+    {
+      ...gatewayAuthEnv,
+      MEMORY_PROVIDER: provider,
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_secret",
+      GITHUB_API_FETCH: async (url, init) => {
+        calls.push({ url: String(url), init });
+        if (String(url).endsWith("/actions/secrets/public-key")) {
+          return new Response(
+            JSON.stringify({
+              key_id: "key-123",
+              key: "LW+MLFAtyNPENefjLqmydKkBGp4l5suTetSR9313Xm8="
+            }),
+            { status: 200, headers: { "content-type": "application/json" } }
+          );
+        }
+        return new Response(null, { status: 204 });
+      }
+    }
+  );
+
+  assert.equal(response.status, 200);
+  const body = await response.json();
+  assert.equal(body.ok, true);
+  assert.equal(body.secretSync.secretName, "VTDD_GATEWAY_BEARER_TOKEN");
+  assert.equal(JSON.stringify(body).includes("gateway-test-secret"), false);
+  assert.equal(calls[1].url.endsWith("/actions/secrets/VTDD_GATEWAY_BEARER_TOKEN"), true);
+});
+
 test("worker allows same-origin browser OPENAI_API_KEY secret sync with approval grant", async () => {
   const provider = createInMemoryMemoryProvider();
   const calls = [];

--- a/worker.js
+++ b/worker.js
@@ -27334,12 +27334,17 @@ function renderPasskeyOperatorPage(input = {}) {
         </section>
 
         <section data-operator-section="github-actions-secret-sync"${hiddenAttribute(!sectionVisibility.githubActionsSecretSync)}>
-          <h2>6. Codex Fallback Secret Sync</h2>
-          <p class="muted">Codex reviewer fallback \u7528\u306E <code>OPENAI_API_KEY</code> \u3092 GitHub Actions secret \u306B\u540C\u671F\u3057\u307E\u3059\u3002\u5024\u306F Butler \u4F1A\u8A71\u306B\u8CBC\u3089\u305A\u3001\u3053\u306E operator page \u304B\u3089\u9001\u4FE1\u3057\u307E\u3059\u3002</p>
+          <h2>6. GitHub Actions Secret Sync</h2>
+          <p class="muted">GitHub Actions secret \u3092\u540C\u671F\u3057\u307E\u3059\u3002\u5024\u306F Butler \u4F1A\u8A71\u306B\u8CBC\u3089\u305A\u3001\u3053\u306E operator page \u304B\u3089\u9001\u4FE1\u3057\u307E\u3059\u3002<code>VTDD_GATEWAY_BEARER_TOKEN</code> \u306F Actions secret \u3060\u3051\u3067\u306F\u306A\u304F Worker secret / Custom GPT Action auth \u3068\u4E00\u81F4\u3057\u3066\u3044\u308B\u5FC5\u8981\u304C\u3042\u308A\u307E\u3059\u3002</p>
+          <label for="github-actions-secret-name-input">Secret name</label>
+          <select id="github-actions-secret-name-input">
+            <option value="OPENAI_API_KEY">OPENAI_API_KEY</option>
+            <option value="VTDD_GATEWAY_BEARER_TOKEN">VTDD_GATEWAY_BEARER_TOKEN</option>
+          </select>
           <label for="openai-api-key-input">OPENAI_API_KEY</label>
           <input id="openai-api-key-input" type="password" autocomplete="off" placeholder="sk-..." />
           <div class="row">
-            <button id="openai-secret-sync-button">Sync OPENAI_API_KEY</button>
+            <button id="openai-secret-sync-button">Sync GitHub Actions secret</button>
           </div>
           <p class="muted"><code>actionType=destructive</code> / <code>highRiskKind=github_actions_secret_sync</code> \u306E approvalGrantId \u304C\u5FC5\u8981\u3067\u3059\u3002</p>
           <pre id="openai-secret-sync-output"></pre>
@@ -27753,19 +27758,20 @@ function renderPasskeyOperatorPage(input = {}) {
       document.getElementById("openai-secret-sync-button").addEventListener("click", async () => {
         try {
           if (!latestApprovalGrantId) {
-            throw new Error("approvalGrantId is required before OPENAI_API_KEY secret sync");
+            throw new Error("approvalGrantId is required before GitHub Actions secret sync");
           }
+          const secretName = document.getElementById("github-actions-secret-name-input").value;
           const secretValue = document.getElementById("openai-api-key-input").value;
           if (!secretValue) {
-            throw new Error("OPENAI_API_KEY is required");
+            throw new Error(secretName + " is required");
           }
-          openaiSecretSyncOutput.textContent = "OPENAI_API_KEY secret sync request...";
+          openaiSecretSyncOutput.textContent = secretName + " secret sync request...";
           const syncResponse = await fetch("${apiBase}/action/github-actions-secret", {
             method: "POST",
             headers: { "content-type": "application/json" },
             body: JSON.stringify({
               repository: document.getElementById("repo-input").value,
-              secretName: "OPENAI_API_KEY",
+              secretName,
               secretValue,
               policyInput: {
                 approvalGrantId: latestApprovalGrantId
@@ -27774,7 +27780,7 @@ function renderPasskeyOperatorPage(input = {}) {
           });
           const syncBody = await readResponseBody(syncResponse);
           if (!syncResponse.ok) {
-            throw responseError(syncBody, "OPENAI_API_KEY secret sync failed");
+            throw responseError(syncBody, secretName + " secret sync failed");
           }
           document.getElementById("openai-api-key-input").value = "";
           openaiSecretSyncOutput.textContent = JSON.stringify(syncBody, null, 2);
@@ -29267,7 +29273,7 @@ function normalizeText7(value) {
 var GITHUB_API_BASE_URL2 = "https://api.github.com";
 var GITHUB_API_VERSION2 = "2022-11-28";
 var GITHUB_API_USER_AGENT2 = "vtdd-v2-github-actions-secret-sync";
-var ALLOWED_ACTIONS_SECRET_NAMES = /* @__PURE__ */ new Set(["OPENAI_API_KEY"]);
+var ALLOWED_ACTIONS_SECRET_NAMES = /* @__PURE__ */ new Set(["OPENAI_API_KEY", "VTDD_GATEWAY_BEARER_TOKEN"]);
 async function executeGitHubActionsSecretSync(input = {}) {
   const repository = normalizeText8(input.repository);
   const secretName = normalizeText8(input.secretName);
@@ -29401,7 +29407,7 @@ function validateGitHubActionsSecretSyncRequest({
     issues.push("repository is required");
   }
   if (!ALLOWED_ACTIONS_SECRET_NAMES.has(secretName)) {
-    issues.push("secretName must be OPENAI_API_KEY");
+    issues.push("secretName must be OPENAI_API_KEY or VTDD_GATEWAY_BEARER_TOKEN");
   }
   if (!secretValue) {
     issues.push("secretValue is required");


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #380 の部分進捗です。mac Codex / VPS Codex CLI が正規 runtime RAG route を使うために必要な `VTDD_GATEWAY_BEARER_TOKEN` を、既存の GitHub Actions secret sync plane でも扱えるようにします。
- operator page から `OPENAI_API_KEY` だけでなく `VTDD_GATEWAY_BEARER_TOKEN` も選べるようにし、Actions secret だけでは Worker secret / Custom GPT Action auth と一致しないと使えないことを明示します。

## Satisfied Success Criteria

- `executeGitHubActionsSecretSync` の許可対象に `VTDD_GATEWAY_BEARER_TOKEN` を追加しました。
- `/v2/action/github-actions-secret` 経由で `VTDD_GATEWAY_BEARER_TOKEN` を GitHub Actions secret に同期できることを test で確認しました。
- operator page の GitHub Actions Secret Sync section で secret name を選択できるようにしました。
- secret 値は response / test assertion / URL に露出しないことを確認しました。
- docs に、gateway bearer token は local vault / GitHub Actions secret / Worker secret / Custom GPT Action auth の値が一致している必要があることを追記しました。

## Unsatisfied Success Criteria

- この PR では Worker secret `VTDD_GATEWAY_BEARER_TOKEN` は更新していません。
- この PR では Custom GPT Action bearer auth は更新していません。
- この PR では local vault token file への実 token 配置は実行していません。
- production runtime への実 RAG write / retrieve E2E は未実施です。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #380
- Implementing Success Criteria: GitHub Actions secret sync plane が `VTDD_GATEWAY_BEARER_TOKEN` を扱えるようにし、RAG runtime auth bootstrap の同期面を一つ増やす。
- Explicit Non-goals: Worker secret 更新、Custom GPT Action auth 更新、実 token 配置、deploy、RAG write 実行、secret 値表示は行いません。
- Expected touched files/routes/workflows: `src/core/github-actions-secret-sync.js`, `src/core/passkey-operator-page.js`, `worker.js`, tests, `docs/memory/vtdd-memory-bridge.md`。既存 route `/v2/action/github-actions-secret` を使い、operationId は変更しません。
- Affected Issues: Issue #380, Issue #361, Issue #356, Issue #344。
- Affected PRs: PR #381 と PR #382 の後続。local vault と runtime RAG CLI が使う token を Actions secret plane へ同期できるようにする補助です。
- Affected workflows: deploy-production workflow は変更しません。ただし deploy workflow が読む Actions secret `VTDD_GATEWAY_BEARER_TOKEN` の同期対象になります。
- Affected runtime/operator surfaces: passkey operator page の GitHub Actions Secret Sync section、Worker route `/v2/action/github-actions-secret`。
- What may break if we patch narrowly: Actions secret だけ更新して Worker secret / Custom GPT auth を忘れると、deploy validation や Butler Action auth がズレて 401/403 になります。
- Unknowns to investigate before coding: 既存 secret sync allowlist が `OPENAI_API_KEY` 固定か、operator page が secret name を選べる設計か。
- Validation needed: GitHub Actions secret sync unit tests、passkey operator page tests、worker route tests、full `npm test`、generated `worker.js` check。
- Stop condition: token 値を表示する必要が出る、または Worker/Custom GPT auth 更新までこの PR に混ぜそうになった場合は停止。

## File / Line Hypotheses

- file: `src/core/github-actions-secret-sync.js`
  - hypothesis: allowlist に `VTDD_GATEWAY_BEARER_TOKEN` を追加するだけで既存の approval/encryption/write plane を再利用できる。
  - risk if changed narrowly: allowlist だけ増やして test を足さないと secret 値漏れや wrong scope regression を見逃します。
  - validation: approved gateway token sync test と unsupported name test を更新。
  - related Issue: Issue #380
- file: `src/core/passkey-operator-page.js`
  - hypothesis: operator page は secret name select を持てば、OPENAI と gateway token を同じ high-risk planeで扱える。
  - risk if changed narrowly: UI が OPENAI 固定文言のままだと、owner が何を同期しているか誤認します。
  - validation: page rendering tests で option と注意文を確認。
  - related Issue: Issue #380
- file: `docs/memory/vtdd-memory-bridge.md`
  - hypothesis: token の一致対象を docs に列挙しないと、Actions secret だけ同期して RAG が動かない事故が起きる。
  - risk if changed narrowly: local vault / Worker / Custom GPT auth の不一致が見えず、認証エラーの原因が分からなくなります。
  - validation: PR body と docs diff で未完了面を明記。
  - related Issue: Issue #380

## Hypothesis Retrospective

- expected: 既存 GitHub Actions secret sync plane を拡張すれば、gateway bearer token の同期面を安全に一つ増やせる。
- actual: allowlist と operator page select の追加で、`VTDD_GATEWAY_BEARER_TOKEN` を同じ approval-bound route から同期できるようになりました。
- mismatch: RAG 実行に必要な Worker secret と Custom GPT Action auth はこの PR の外に残りました。
- lesson: gateway bearer token は単一 secret に見えるが、local / Actions / Worker / GPT auth の一致問題として扱う必要があります。
- should become RAG candidate: はい。credential alignment の判断として候補です。

## Verification Evidence

- Unit: `node --test test/github-actions-secret-sync.test.js test/passkey-operator-page.test.js test/worker.test.js` passed: 139 tests。
- Integration: `npm test` passed: 785 tests, 784 pass, 1 skipped。`check:self-parity` passed。`check:generated-worker` passed。
- E2E: 未実施。実 secret sync / Worker secret update / Custom GPT Action auth update / RAG write は未実施です。
- Manual: `git diff --check` passed。
- Evidence path/link: `src/core/github-actions-secret-sync.js`, `src/core/passkey-operator-page.js`, `test/github-actions-secret-sync.test.js`, `test/worker.test.js`, `worker.js`

## Butler Completion Contract

- Owner goal: mac Codex / VPS Codex CLI が正規 runtime RAG route を叩けるよう、gateway bearer token の同期面を GitHub Actions secret plane に追加する。
- Butler entrypoint: operator page の GitHub Actions Secret Sync section。Butler は deploy/secret sync 要否を説明する側であり、secret 値は会話に貼りません。
- Action Schema exposure: 不要。既存 `/v2/action/github-actions-secret` を使い、operationId は変更していません。
- Runtime path: `/v2/action/github-actions-secret`。
- Runner/runtime truth: sync result は secret name と created/updated status のみ返し、secret 値は返しません。
- Authority boundary: GitHub Actions secret sync は `GO + passkey` の high-risk action。Worker secret / Custom GPT Action auth 更新は別境界です。
- E2E evidence: 未実施。実 secret alignment 後に RAG write/retrieve を確認する必要があります。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 必要。`src/core/passkey-operator-page.js`, `src/core/github-actions-secret-sync.js`, `worker.js` を変更しました。
- Custom GPT Action Schema update: 不要。Action Schema は変更していません。
- Custom GPT Instructions update: 不要。Instructions は変更していません。
- iPhone Butler live E2E: 後続で必要。operator page から secret sync できること、RAG write/retrieve が通ることを確認します。

## Related Constitution Rules

- Issue 起点で変更し、Issue #380 の gateway bearer alignment に限定しました。
- secret 値を response / URL / docs に出さないことを test で固定しました。
- high-risk credential mutation は `GO + passkey` 境界に残しました。
- Butler Completion Gate に従い、実 RAG write/retrieve E2E 未実施のため complete とは扱いません。

## Out-of-scope but NOT implemented

- Worker secret `VTDD_GATEWAY_BEARER_TOKEN` の更新
- Custom GPT Action bearer auth の更新
- local vault への実 token 配置
- production runtime への実 RAG checkpoint 書き込み
- deploy 実行

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #380
- Execution ID: mac-codex-issue-380-actions-gateway-secret-name-20260515
- Goal: `VTDD_GATEWAY_BEARER_TOKEN` を GitHub Actions secret sync plane の許可対象に追加する
