### PR TITLE
Issue #380: operator page から gateway bearer vault bootstrap を追加

### DIFF
--- a/docs/setup/github-app-secret-sync.md
+++ b/docs/setup/github-app-secret-sync.md
@@ -145,6 +145,9 @@ This helper:
 - proxies the real `/v2/approval/passkey/*` runtime with machine auth
 - executes `scripts/sync-github-app-actions-secrets.mjs` only after a real
   `approvalGrantId` has been issued
+- executes `scripts/bootstrap-gateway-bearer-vault.mjs` through stdin when an
+  operator explicitly pastes `VTDD_GATEWAY_BEARER_TOKEN` into the gateway vault
+  section
 
 It is an explicit operator helper for bootstrap/update/repair, not a setup
 wizard, not a background sync path, and not a steady-state runtime dependency.
@@ -175,6 +178,13 @@ Current contract:
 - the Worker runtime does not read `~/.vtdd` directly
 - the desktop helper remains the only component that reads the local bootstrap
   vault and executes the GitHub Actions secret mutation path
+
+The same `syncApiBase` bridge can bootstrap the local gateway bearer vault from
+the Worker-hosted page. Use `actionType=destructive` and
+`highRiskKind=gateway_bearer_vault_bootstrap`, paste the memo-app copy of
+`VTDD_GATEWAY_BEARER_TOKEN` into `Gateway Bearer Vault`, and submit it through
+the helper. The token must not be pasted into Butler chat, GitHub comments, RAG
+memory, stdout, or stderr.
 
 ## Non-goals
 

--- a/scripts/run-passkey-operator-helper.mjs
+++ b/scripts/run-passkey-operator-helper.mjs
@@ -8,6 +8,7 @@ import { renderPasskeyOperatorPage } from "../src/core/index.js";
 const execFileAsync = promisify(execFile);
 const SCRIPT_DIR = path.dirname(new URL(import.meta.url).pathname);
 const SYNC_SCRIPT_PATH = path.join(SCRIPT_DIR, "sync-github-app-actions-secrets.mjs");
+const GATEWAY_BEARER_VAULT_SCRIPT_PATH = path.join(SCRIPT_DIR, "bootstrap-gateway-bearer-vault.mjs");
 
 async function main() {
   const args = parseArgs(process.argv.slice(2));
@@ -23,19 +24,12 @@ async function main() {
     privateKeyPath: args.privateKeyPath,
     installationId: args.installationId
   });
-  if (!sourceResult.ok) {
-    throw new Error(sourceResult.issues.join(", "));
-  }
+  const source = sourceResult.ok ? sourceResult.source : {};
   const bearerToken = normalizeText(
     args.gatewayBearerToken ||
       process.env.VTDD_GATEWAY_BEARER_TOKEN ||
-      sourceResult.source.gatewayBearerToken
+      source.gatewayBearerToken
   );
-  if (!bearerToken) {
-    throw new Error(
-      "gateway bearer token is required via --gateway-bearer-token, VTDD_GATEWAY_BEARER_TOKEN, or ~/.vtdd/credentials/manifest.json"
-    );
-  }
 
   const bind = normalizeText(args.bind || "127.0.0.1");
   const port = Number(args.port || 8789);
@@ -49,11 +43,13 @@ async function main() {
     repo: normalizeText(args.repo || "marushu/vtdd-v2-p"),
     issueNumber: normalizeText(args.issueNumber || "15"),
     highRiskKind: normalizeText(args.highRiskKind || "github_app_secret_sync"),
-    manifestPath: normalizeText(args.manifestPath || sourceResult.source.manifestPath),
-    appRole: normalizeText(args.appRole || sourceResult.source.role || "legacy"),
-    appId: normalizeText(args.appId || sourceResult.source.appId),
-    privateKeyPath: normalizeText(args.privateKeyPath || sourceResult.source.privateKeyPath),
-    installationId: normalizeText(args.installationId || sourceResult.source.installationId)
+    sourceOk: sourceResult.ok === true,
+    sourceIssues: sourceResult.issues ?? [],
+    manifestPath: normalizeText(args.manifestPath || source.manifestPath),
+    appRole: normalizeText(args.appRole || source.role || "legacy"),
+    appId: normalizeText(args.appId || source.appId),
+    privateKeyPath: normalizeText(args.privateKeyPath || source.privateKeyPath),
+    installationId: normalizeText(args.installationId || source.installationId)
   };
 
   const server = http.createServer((request, response) =>
@@ -79,7 +75,11 @@ async function handleRequest({ request, response, state }) {
   const url = new URL(request.url, `http://${request.headers.host || "localhost"}`);
   const corsHeaders = buildCorsHeaders(request.headers.origin);
 
-  if (request.method === "OPTIONS" && url.pathname === "/api/github-app-secret-sync/execute") {
+  if (
+    request.method === "OPTIONS" &&
+    (url.pathname === "/api/github-app-secret-sync/execute" ||
+      url.pathname === "/api/gateway-bearer-vault/bootstrap")
+  ) {
     response.writeHead(204, corsHeaders);
     response.end();
     return;
@@ -121,6 +121,15 @@ async function handleRequest({ request, response, state }) {
         ok: false,
         error: "github_app_role_not_served",
         reason: `desktop helper is serving ${state.appRole}, not ${appRole}`
+      }, corsHeaders);
+      return;
+    }
+    if (!state.sourceOk) {
+      writeJson(response, 503, {
+        ok: false,
+        error: "github_app_secret_source_unavailable",
+        reason: "GitHub App secret source is not configured for this helper",
+        issues: state.sourceIssues
       }, corsHeaders);
       return;
     }
@@ -177,7 +186,89 @@ async function handleRequest({ request, response, state }) {
     return;
   }
 
+  if (request.method === "POST" && url.pathname === "/api/gateway-bearer-vault/bootstrap") {
+    const body = await readJson(request);
+    const approvalGrantId = normalizeText(body.approvalGrantId);
+    const gatewayBearerToken = normalizeText(body.gatewayBearerToken);
+    if (!approvalGrantId) {
+      writeJson(response, 422, {
+        ok: false,
+        error: "approval_grant_id_required",
+        reason: "approvalGrantId is required"
+      }, corsHeaders);
+      return;
+    }
+    if (!gatewayBearerToken) {
+      writeJson(response, 422, {
+        ok: false,
+        error: "gateway_bearer_token_required",
+        reason: "gatewayBearerToken is required"
+      }, corsHeaders);
+      return;
+    }
+    const approvalVerification = await verifyGatewayBearerVaultApproval({
+      state,
+      approvalGrantId,
+      repositoryInput: normalizeText(body.repositoryInput || state.repo)
+    });
+    if (!approvalVerification.ok) {
+      writeJson(response, 403, {
+        ok: false,
+        error: "gateway_bearer_vault_approval_invalid",
+        reason: approvalVerification.reason,
+        diagnostics: approvalVerification.diagnostics
+      }, corsHeaders);
+      return;
+    }
+
+    const args = [
+      GATEWAY_BEARER_VAULT_SCRIPT_PATH,
+      "--token-stdin",
+      "--pretty"
+    ];
+    if (state.manifestPath) {
+      args.push("--manifest-path", state.manifestPath);
+    }
+
+    const result = await execFileWithInput(process.execPath, args, `${gatewayBearerToken}\n`, {
+      cwd: process.cwd(),
+      maxBuffer: 10 * 1024 * 1024
+    }).catch((error) => ({
+      ok: false,
+      stdout: error.stdout || "",
+      stderr: error.stderr || "",
+      reason: error instanceof Error ? error.message : String(error)
+    }));
+
+    if (result.ok === false) {
+      writeJson(response, 500, {
+        ok: false,
+        error: "gateway_bearer_vault_bootstrap_failed",
+        reason: redactSecretText(result.reason),
+        stdout: redactSecretText(normalizeText(result.stdout)),
+        stderr: redactSecretText(normalizeText(result.stderr))
+      }, corsHeaders);
+      return;
+    }
+
+    writeJson(response, 200, {
+      ok: true,
+      approvalGrantVerification: approvalVerification.status,
+      stdout: redactSecretText(normalizeText(result.stdout)),
+      stderr: redactSecretText(normalizeText(result.stderr))
+    }, corsHeaders);
+    return;
+  }
+
   if (request.method === "GET" && url.pathname === "/api/retrieve/approval-grant") {
+    if (!state.bearerToken) {
+      writeJson(response, 503, {
+        ok: false,
+        error: "gateway_bearer_token_missing",
+        reason: "gateway bearer token is not configured in this helper"
+      }, corsHeaders);
+      return;
+    }
     const endpoint = new URL("/v2/retrieve/approval-grant", state.runtimeUrl);
     if (url.searchParams.has("approvalId")) {
       endpoint.searchParams.set("approvalId", url.searchParams.get("approvalId"));
@@ -277,12 +368,82 @@ function readBody(request) {
   });
 }
 
+function execFileWithInput(file, args, input, options = {}) {
+  return new Promise((resolve, reject) => {
+    const child = execFile(file, args, options, (error, stdout, stderr) => {
+      if (error) {
+        error.stdout = stdout;
+        error.stderr = stderr;
+        reject(error);
+        return;
+      }
+      resolve({ stdout, stderr });
+    });
+    child.stdin.end(input);
+  });
+}
+
 async function readJson(request) {
   const body = await readBody(request);
   if (body.length === 0) {
     return {};
   }
   return JSON.parse(body.toString("utf8"));
+}
+
+async function verifyGatewayBearerVaultApproval({ state, approvalGrantId, repositoryInput }) {
+  if (!state.bearerToken) {
+    return {
+      ok: true,
+      status: "not_checked_initial_bootstrap_gateway_bearer_missing"
+    };
+  }
+  const endpoint = new URL("/v2/retrieve/approval-grant", state.runtimeUrl);
+  endpoint.searchParams.set("approvalId", approvalGrantId);
+  const response = await fetch(endpoint, {
+    headers: {
+      authorization: `Bearer ${state.bearerToken}`
+    }
+  });
+  const body = await response.json().catch(() => ({}));
+  if (!response.ok || body?.ok === false) {
+    return {
+      ok: false,
+      reason: "approvalGrant could not be retrieved from runtime",
+      diagnostics: {
+        status: response.status,
+        error: body?.error || null
+      }
+    };
+  }
+  const approvalGrant = body?.approvalGrant;
+  const scope = approvalGrant?.scope ?? {};
+  const expectedRepo = normalizeText(repositoryInput);
+  if (approvalGrant?.verified !== true) {
+    return { ok: false, reason: "approvalGrant is not verified" };
+  }
+  if (normalizeText(scope.repositoryInput) !== expectedRepo) {
+    return {
+      ok: false,
+      reason: "approvalGrant scope.repositoryInput does not match target repository"
+    };
+  }
+  if (normalizeText(scope.actionType) !== "destructive") {
+    return {
+      ok: false,
+      reason: "approvalGrant scope.actionType must be destructive"
+    };
+  }
+  if (normalizeText(scope.highRiskKind) !== "gateway_bearer_vault_bootstrap") {
+    return {
+      ok: false,
+      reason: "approvalGrant scope.highRiskKind must be gateway_bearer_vault_bootstrap"
+    };
+  }
+  return {
+    ok: true,
+    status: "verified_runtime_approval_grant"
+  };
 }
 
 function writeJson(response, status, body, extraHeaders = {}) {
@@ -305,6 +466,12 @@ function buildCorsHeaders(origin) {
 
 function normalizeText(value) {
   return String(value ?? "").trim();
+}
+
+function redactSecretText(value) {
+  return String(value ?? "")
+    .replace(/sk-[A-Za-z0-9_-]+/g, "[REDACTED_OPENAI_KEY]")
+    .replace(/(authorization|api[_-]?key|token|secret)(["'\s:=]+)([^"'\s<>&]+)/gi, "$1$2[REDACTED]");
 }
 
 if (isDirectRun()) {

--- a/src/core/passkey-operator-page.js
+++ b/src/core/passkey-operator-page.js
@@ -273,8 +273,21 @@ export function renderPasskeyOperatorPage(input = {}) {
           <pre id="openai-secret-sync-output"></pre>
         </section>
 
+        <section data-operator-section="gateway-bearer-vault"${hiddenAttribute(!sectionVisibility.gatewayBearerVault)}>
+          <h2>7. Gateway Bearer Vault</h2>
+          <p class="muted">メモアプリ等に保管している <code>VTDD_GATEWAY_BEARER_TOKEN</code> を、この端末の local helper 経由で Mac/VPS vault に保存します。値は Butler 会話、GitHub コメント、RAG、レスポンス本文に表示しません。</p>
+          <label for="gateway-bearer-token-input">VTDD_GATEWAY_BEARER_TOKEN</label>
+          <input id="gateway-bearer-token-input" type="password" autocomplete="off" placeholder="token..." />
+          <div class="row">
+            <button id="gateway-bearer-vault-button"${syncEnabled ? "" : " disabled"}>Save gateway bearer to vault</button>
+          </div>
+          <p class="muted"><code>actionType=destructive</code> / <code>highRiskKind=gateway_bearer_vault_bootstrap</code> の approvalGrantId が必要です。<code>syncApiBase</code> が未指定の場合、このページから local vault へは書き込めません。</p>
+          <p class="muted">初回 bootstrap では既存 bearer token がなく、helper が approvalGrant を runtime 検証できない場合があります。その場合はレスポンスに <code>not_checked_initial_bootstrap_gateway_bearer_missing</code> と表示します。Repository / Issue / High-risk Kind を確認してから実行してください。</p>
+          <pre id="gateway-bearer-vault-output"></pre>
+        </section>
+
         <section data-operator-section="vps-runner-admin"${hiddenAttribute(!sectionVisibility.vpsRunnerAdmin)}>
-          <h2>7. VPS Runner Admin</h2>
+          <h2>8. VPS Runner Admin</h2>
           <p class="muted">VPS runner の repo allowlist 追加、runner restart、smoke などの管理操作用 approval です。ここでは real passkey で短命の <code>approvalGrantId</code> だけを発行します。VPS 操作そのものは GitHub queue と runner event に残る bounded command として別途実行されます。</p>
           <p class="muted"><code>actionType=destructive</code> / <code>highRiskKind=vps_runner_admin</code> の approvalGrantId が必要です。文字列としての passkey は承認ではありません。</p>
         </section>
@@ -288,6 +301,7 @@ export function renderPasskeyOperatorPage(input = {}) {
       const deployOutput = document.getElementById("deploy-output");
       const mergeOutput = document.getElementById("merge-output");
       const openaiSecretSyncOutput = document.getElementById("openai-secret-sync-output");
+      const gatewayBearerVaultOutput = document.getElementById("gateway-bearer-vault-output");
       const copyApprovalGrantButton = document.getElementById("copy-approval-grant-button");
       const autoCopyApprovalGrantInput = document.getElementById("auto-copy-approval-grant-input");
       const deployRunLink = document.getElementById("deploy-run-link");
@@ -712,6 +726,42 @@ export function renderPasskeyOperatorPage(input = {}) {
         }
       });
 
+      document.getElementById("gateway-bearer-vault-button").addEventListener("click", async () => {
+        try {
+          const pastedApprovalGrantId = document.getElementById("approval-grant-id-input").value.trim();
+          const approvalGrantId = latestApprovalGrantId || pastedApprovalGrantId;
+          if (!approvalGrantId) {
+            throw new Error("approvalGrantId is required before gateway bearer vault bootstrap");
+          }
+          if (!"${syncApiBase}") {
+            throw new Error("desktop maintenance required: local gateway bearer vault bridge is not configured");
+          }
+          const gatewayBearerTokenInput = document.getElementById("gateway-bearer-token-input");
+          const gatewayBearerToken = gatewayBearerTokenInput.value;
+          if (!gatewayBearerToken) {
+            throw new Error("VTDD_GATEWAY_BEARER_TOKEN is required");
+          }
+          gatewayBearerVaultOutput.textContent = "gateway bearer vault bootstrap request...";
+          const vaultResponse = await fetch("${syncApiBase}/gateway-bearer-vault/bootstrap", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({
+              approvalGrantId,
+              repositoryInput: document.getElementById("repo-input").value,
+              gatewayBearerToken
+            })
+          });
+          const vaultBody = await readResponseBody(vaultResponse);
+          if (!vaultResponse.ok) {
+            throw responseError(vaultBody, "gateway bearer vault bootstrap failed");
+          }
+          gatewayBearerTokenInput.value = "";
+          gatewayBearerVaultOutput.textContent = JSON.stringify(vaultBody, null, 2);
+        } catch (error) {
+          gatewayBearerVaultOutput.textContent = String(error);
+        }
+      });
+
       function decodeRegistrationOptions(options) {
         return {
           ...options,
@@ -826,6 +876,9 @@ export function resolvePasskeyOperatorMode(input = {}) {
   if (highRiskKind === "github_actions_secret_sync") {
     return "github_actions_secret_sync";
   }
+  if (highRiskKind === "gateway_bearer_vault_bootstrap") {
+    return "gateway_bearer_vault";
+  }
   if (highRiskKind === "github_app_secret_sync") {
     return "github_app_secret_sync";
   }
@@ -846,6 +899,7 @@ function resolveSectionVisibility(operatorMode, options = {}) {
     productionDeploy: full || operatorMode === "deploy",
     prMerge: full || operatorMode === "merge",
     githubActionsSecretSync: full || operatorMode === "github_actions_secret_sync",
+    gatewayBearerVault: full || operatorMode === "gateway_bearer_vault",
     vpsRunnerAdmin: full || operatorMode === "vps"
   };
 }
@@ -861,7 +915,7 @@ function renderGithubAppRoleOption(value, label, selectedValue) {
 
 function normalizeOperatorMode(value) {
   const token = normalizeOperatorToken(value);
-  if (["full", "deploy", "merge", "github_app_secret_sync", "github_actions_secret_sync", "vps"].includes(token)) {
+  if (["full", "deploy", "merge", "github_app_secret_sync", "github_actions_secret_sync", "gateway_bearer_vault", "vps"].includes(token)) {
     return token;
   }
   if (token === "secret_sync") {
@@ -869,6 +923,9 @@ function normalizeOperatorMode(value) {
   }
   if (token === "openai_secret_sync" || token === "codex_secret_sync") {
     return "github_actions_secret_sync";
+  }
+  if (token === "gateway_vault" || token === "gateway_bearer") {
+    return "gateway_bearer_vault";
   }
   return "";
 }
@@ -892,6 +949,9 @@ function defaultHighRiskKindForMode(operatorMode) {
   }
   if (operatorMode === "github_actions_secret_sync") {
     return "github_actions_secret_sync";
+  }
+  if (operatorMode === "gateway_bearer_vault") {
+    return "gateway_bearer_vault_bootstrap";
   }
   if (operatorMode === "vps") {
     return "vps_runner_admin";

--- a/test/passkey-operator-helper.test.js
+++ b/test/passkey-operator-helper.test.js
@@ -20,6 +20,17 @@ test("desktop helper bridge passes role-specific GitHub App sync arguments", () 
   assert.equal(helperSource.includes("github_app_role_not_served"), true);
 });
 
+test("desktop helper bridge exposes gateway bearer vault bootstrap without printing token", () => {
+  assert.equal(helperSource.includes("/api/gateway-bearer-vault/bootstrap"), true);
+  assert.equal(helperSource.includes("bootstrap-gateway-bearer-vault.mjs"), true);
+  assert.equal(helperSource.includes("--token-stdin"), true);
+  assert.equal(helperSource.includes("gateway_bearer_vault_bootstrap_failed"), true);
+  assert.equal(helperSource.includes("gateway_bearer_vault_approval_invalid"), true);
+  assert.equal(helperSource.includes("not_checked_initial_bootstrap_gateway_bearer_missing"), true);
+  assert.equal(helperSource.includes("verified_runtime_approval_grant"), true);
+  assert.equal(helperSource.includes("redactSecretText"), true);
+});
+
 test("desktop helper bridge does not proxy local passkey WebAuthn APIs", () => {
   assert.equal(helperSource.includes('url.pathname.startsWith("/api/approval/passkey/")'), false);
   assert.equal(helperSource.includes("function proxyPasskeyApi"), false);

--- a/test/passkey-operator-page.test.js
+++ b/test/passkey-operator-page.test.js
@@ -17,6 +17,7 @@ test("passkey operator page can target explicit api base and sync endpoint", () 
 
   assert.equal(html.includes('fetch("/api/approval/passkey/challenge"'), true);
   assert.equal(html.includes('fetch("http://127.0.0.1:8789/api/github-app-secret-sync/execute"'), true);
+  assert.equal(html.includes('fetch("http://127.0.0.1:8789/api/gateway-bearer-vault/bootstrap"'), true);
   assert.equal(html.includes('fetch("/api/action/deploy"'), true);
   assert.equal(html.includes('fetch("/api/action/github-authority"'), true);
   assert.equal(html.includes('fetch("/api/action/github-actions-secret"'), true);
@@ -25,6 +26,7 @@ test("passkey operator page can target explicit api base and sync endpoint", () 
   assert.equal(html.includes("Sync GitHub App secrets"), true);
   assert.equal(html.includes("Sync GitHub Actions secret"), true);
   assert.equal(html.includes("VTDD_GATEWAY_BEARER_TOKEN"), true);
+  assert.equal(html.includes("Save gateway bearer to vault"), true);
   assert.equal(html.includes("Dispatch production deploy"), true);
   assert.equal(html.includes("Dispatch PR merge"), true);
   assert.equal(html.includes("Open deploy run"), true);
@@ -181,6 +183,7 @@ test("passkey operator page focuses secret sync modes without hiding the require
   assert.equal(actionsSecretHtml.includes('<section data-operator-section="github-actions-secret-sync">'), true);
   assert.equal(actionsSecretHtml.includes('<option value="VTDD_GATEWAY_BEARER_TOKEN">'), true);
   assert.equal(actionsSecretHtml.includes("Worker secret / Custom GPT Action auth"), true);
+  assert.equal(actionsSecretHtml.includes('<section data-operator-section="gateway-bearer-vault" hidden>'), true);
   assert.equal(actionsSecretHtml.includes('<section data-operator-section="github-app-secret-sync" hidden>'), true);
   assert.equal(actionsSecretHtml.includes('<section data-operator-section="production-deploy" hidden>'), true);
   assert.equal(actionsSecretHtml.includes('<section data-operator-section="pr-merge" hidden>'), true);
@@ -218,9 +221,30 @@ test("passkey operator page focuses VPS runner admin mode on real approval only"
   assert.equal(html.includes('<section data-operator-section="pr-merge" hidden>'), true);
   assert.equal(html.includes('<section data-operator-section="github-app-secret-sync" hidden>'), true);
   assert.equal(html.includes('<section data-operator-section="github-actions-secret-sync" hidden>'), true);
+  assert.equal(html.includes('<section data-operator-section="gateway-bearer-vault" hidden>'), true);
   assert.equal(html.includes('id="action-type-input" value="destructive"'), true);
   assert.equal(html.includes('id="risk-kind-input" value="vps_runner_admin"'), true);
   assert.equal(html.includes("文字列としての passkey は承認ではありません"), true);
+});
+
+test("passkey operator page supports gateway bearer vault bootstrap mode", () => {
+  const html = renderPasskeyOperatorPage({
+    repositoryInput: "marushu/vtdd-v2-p",
+    actionType: "destructive",
+    highRiskKind: "gateway_bearer_vault_bootstrap",
+    syncApiBase: "http://127.0.0.1:8789/api",
+    syncEnabled: true
+  });
+
+  assert.equal(html.includes('<section data-operator-section="approval">'), true);
+  assert.equal(html.includes('<section data-operator-section="gateway-bearer-vault">'), true);
+  assert.equal(html.includes('id="risk-kind-input" value="gateway_bearer_vault_bootstrap"'), true);
+  assert.equal(html.includes('id="gateway-bearer-token-input" type="password"'), true);
+  assert.equal(html.includes('fetch("http://127.0.0.1:8789/api/gateway-bearer-vault/bootstrap"'), true);
+  assert.equal(html.includes("Butler 会話、GitHub コメント、RAG、レスポンス本文に表示しません"), true);
+  assert.equal(html.includes("not_checked_initial_bootstrap_gateway_bearer_missing"), true);
+  assert.equal(html.includes('<section data-operator-section="github-app-secret-sync" hidden>'), true);
+  assert.equal(html.includes('<section data-operator-section="production-deploy" hidden>'), true);
 });
 
 test("passkey operator page fills VPS runner admin defaults from explicit mode", () => {
@@ -241,6 +265,7 @@ test("passkey operator page keeps the full maintenance view when no mode is infe
   assert.equal(html.includes('<section data-operator-section="production-deploy">'), true);
   assert.equal(html.includes('<section data-operator-section="pr-merge">'), true);
   assert.equal(html.includes('<section data-operator-section="github-actions-secret-sync">'), true);
+  assert.equal(html.includes('<section data-operator-section="gateway-bearer-vault">'), true);
   assert.equal(html.includes('<section data-operator-section="vps-runner-admin">'), true);
 });
 

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -2387,7 +2387,25 @@ test("worker passkey operator page enables desktop secret sync bridge when syncA
   assert.equal(response.status, 200);
   const html = await response.text();
   assert.equal(html.includes('fetch("http://127.0.0.1:8789/api/github-app-secret-sync/execute"'), true);
+  assert.equal(html.includes('fetch("http://127.0.0.1:8789/api/gateway-bearer-vault/bootstrap"'), true);
   assert.equal(html.includes("desktop helper bridge に接続します"), true);
+});
+
+test("worker serves gateway bearer vault operator mode", async () => {
+  const response = await worker.fetch(
+    new Request(
+      "https://example.com/v2/approval/passkey/operator?repositoryInput=marushu%2Fvtdd-v2-p&issueNumber=380&highRiskKind=gateway_bearer_vault_bootstrap&syncApiBase=http%3A%2F%2F127.0.0.1%3A8789%2Fapi"
+    ),
+    gatewayAuthEnv
+  );
+
+  assert.equal(response.status, 200);
+  const html = await response.text();
+  assert.equal(html.includes("Gateway Bearer Vault"), true);
+  assert.equal(html.includes('id="issue-input" value="380"'), true);
+  assert.equal(html.includes('id="risk-kind-input" value="gateway_bearer_vault_bootstrap"'), true);
+  assert.equal(html.includes('id="gateway-bearer-token-input" type="password"'), true);
+  assert.equal(html.includes('fetch("http://127.0.0.1:8789/api/gateway-bearer-vault/bootstrap"'), true);
 });
 
 test("worker serves VPS runner admin passkey operator mode", async () => {

--- a/worker.js
+++ b/worker.js
@@ -27350,8 +27350,21 @@ function renderPasskeyOperatorPage(input = {}) {
           <pre id="openai-secret-sync-output"></pre>
         </section>
 
+        <section data-operator-section="gateway-bearer-vault"${hiddenAttribute(!sectionVisibility.gatewayBearerVault)}>
+          <h2>7. Gateway Bearer Vault</h2>
+          <p class="muted">\u30E1\u30E2\u30A2\u30D7\u30EA\u7B49\u306B\u4FDD\u7BA1\u3057\u3066\u3044\u308B <code>VTDD_GATEWAY_BEARER_TOKEN</code> \u3092\u3001\u3053\u306E\u7AEF\u672B\u306E local helper \u7D4C\u7531\u3067 Mac/VPS vault \u306B\u4FDD\u5B58\u3057\u307E\u3059\u3002\u5024\u306F Butler \u4F1A\u8A71\u3001GitHub \u30B3\u30E1\u30F3\u30C8\u3001RAG\u3001\u30EC\u30B9\u30DD\u30F3\u30B9\u672C\u6587\u306B\u8868\u793A\u3057\u307E\u305B\u3093\u3002</p>
+          <label for="gateway-bearer-token-input">VTDD_GATEWAY_BEARER_TOKEN</label>
+          <input id="gateway-bearer-token-input" type="password" autocomplete="off" placeholder="token..." />
+          <div class="row">
+            <button id="gateway-bearer-vault-button"${syncEnabled ? "" : " disabled"}>Save gateway bearer to vault</button>
+          </div>
+          <p class="muted"><code>actionType=destructive</code> / <code>highRiskKind=gateway_bearer_vault_bootstrap</code> \u306E approvalGrantId \u304C\u5FC5\u8981\u3067\u3059\u3002<code>syncApiBase</code> \u304C\u672A\u6307\u5B9A\u306E\u5834\u5408\u3001\u3053\u306E\u30DA\u30FC\u30B8\u304B\u3089 local vault \u3078\u306F\u66F8\u304D\u8FBC\u3081\u307E\u305B\u3093\u3002</p>
+          <p class="muted">\u521D\u56DE bootstrap \u3067\u306F\u65E2\u5B58 bearer token \u304C\u306A\u304F\u3001helper \u304C approvalGrant \u3092 runtime \u691C\u8A3C\u3067\u304D\u306A\u3044\u5834\u5408\u304C\u3042\u308A\u307E\u3059\u3002\u305D\u306E\u5834\u5408\u306F\u30EC\u30B9\u30DD\u30F3\u30B9\u306B <code>not_checked_initial_bootstrap_gateway_bearer_missing</code> \u3068\u8868\u793A\u3057\u307E\u3059\u3002Repository / Issue / High-risk Kind \u3092\u78BA\u8A8D\u3057\u3066\u304B\u3089\u5B9F\u884C\u3057\u3066\u304F\u3060\u3055\u3044\u3002</p>
+          <pre id="gateway-bearer-vault-output"></pre>
+        </section>
+
         <section data-operator-section="vps-runner-admin"${hiddenAttribute(!sectionVisibility.vpsRunnerAdmin)}>
-          <h2>7. VPS Runner Admin</h2>
+          <h2>8. VPS Runner Admin</h2>
           <p class="muted">VPS runner \u306E repo allowlist \u8FFD\u52A0\u3001runner restart\u3001smoke \u306A\u3069\u306E\u7BA1\u7406\u64CD\u4F5C\u7528 approval \u3067\u3059\u3002\u3053\u3053\u3067\u306F real passkey \u3067\u77ED\u547D\u306E <code>approvalGrantId</code> \u3060\u3051\u3092\u767A\u884C\u3057\u307E\u3059\u3002VPS \u64CD\u4F5C\u305D\u306E\u3082\u306E\u306F GitHub queue \u3068 runner event \u306B\u6B8B\u308B bounded command \u3068\u3057\u3066\u5225\u9014\u5B9F\u884C\u3055\u308C\u307E\u3059\u3002</p>
           <p class="muted"><code>actionType=destructive</code> / <code>highRiskKind=vps_runner_admin</code> \u306E approvalGrantId \u304C\u5FC5\u8981\u3067\u3059\u3002\u6587\u5B57\u5217\u3068\u3057\u3066\u306E passkey \u306F\u627F\u8A8D\u3067\u306F\u3042\u308A\u307E\u305B\u3093\u3002</p>
         </section>
@@ -27365,6 +27378,7 @@ function renderPasskeyOperatorPage(input = {}) {
       const deployOutput = document.getElementById("deploy-output");
       const mergeOutput = document.getElementById("merge-output");
       const openaiSecretSyncOutput = document.getElementById("openai-secret-sync-output");
+      const gatewayBearerVaultOutput = document.getElementById("gateway-bearer-vault-output");
       const copyApprovalGrantButton = document.getElementById("copy-approval-grant-button");
       const autoCopyApprovalGrantInput = document.getElementById("auto-copy-approval-grant-input");
       const deployRunLink = document.getElementById("deploy-run-link");
@@ -27789,6 +27803,42 @@ function renderPasskeyOperatorPage(input = {}) {
         }
       });
 
+      document.getElementById("gateway-bearer-vault-button").addEventListener("click", async () => {
+        try {
+          const pastedApprovalGrantId = document.getElementById("approval-grant-id-input").value.trim();
+          const approvalGrantId = latestApprovalGrantId || pastedApprovalGrantId;
+          if (!approvalGrantId) {
+            throw new Error("approvalGrantId is required before gateway bearer vault bootstrap");
+          }
+          if (!"${syncApiBase}") {
+            throw new Error("desktop maintenance required: local gateway bearer vault bridge is not configured");
+          }
+          const gatewayBearerTokenInput = document.getElementById("gateway-bearer-token-input");
+          const gatewayBearerToken = gatewayBearerTokenInput.value;
+          if (!gatewayBearerToken) {
+            throw new Error("VTDD_GATEWAY_BEARER_TOKEN is required");
+          }
+          gatewayBearerVaultOutput.textContent = "gateway bearer vault bootstrap request...";
+          const vaultResponse = await fetch("${syncApiBase}/gateway-bearer-vault/bootstrap", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({
+              approvalGrantId,
+              repositoryInput: document.getElementById("repo-input").value,
+              gatewayBearerToken
+            })
+          });
+          const vaultBody = await readResponseBody(vaultResponse);
+          if (!vaultResponse.ok) {
+            throw responseError(vaultBody, "gateway bearer vault bootstrap failed");
+          }
+          gatewayBearerTokenInput.value = "";
+          gatewayBearerVaultOutput.textContent = JSON.stringify(vaultBody, null, 2);
+        } catch (error) {
+          gatewayBearerVaultOutput.textContent = String(error);
+        }
+      });
+
       function decodeRegistrationOptions(options) {
         return {
           ...options,
@@ -27900,6 +27950,9 @@ function resolvePasskeyOperatorMode(input = {}) {
   if (highRiskKind === "github_actions_secret_sync") {
     return "github_actions_secret_sync";
   }
+  if (highRiskKind === "gateway_bearer_vault_bootstrap") {
+    return "gateway_bearer_vault";
+  }
   if (highRiskKind === "github_app_secret_sync") {
     return "github_app_secret_sync";
   }
@@ -27918,6 +27971,7 @@ function resolveSectionVisibility(operatorMode, options = {}) {
     productionDeploy: full || operatorMode === "deploy",
     prMerge: full || operatorMode === "merge",
     githubActionsSecretSync: full || operatorMode === "github_actions_secret_sync",
+    gatewayBearerVault: full || operatorMode === "gateway_bearer_vault",
     vpsRunnerAdmin: full || operatorMode === "vps"
   };
 }
@@ -27930,7 +27984,7 @@ function renderGithubAppRoleOption(value, label, selectedValue) {
 }
 function normalizeOperatorMode(value) {
   const token = normalizeOperatorToken(value);
-  if (["full", "deploy", "merge", "github_app_secret_sync", "github_actions_secret_sync", "vps"].includes(token)) {
+  if (["full", "deploy", "merge", "github_app_secret_sync", "github_actions_secret_sync", "gateway_bearer_vault", "vps"].includes(token)) {
     return token;
   }
   if (token === "secret_sync") {
@@ -27938,6 +27992,9 @@ function normalizeOperatorMode(value) {
   }
   if (token === "openai_secret_sync" || token === "codex_secret_sync") {
     return "github_actions_secret_sync";
+  }
+  if (token === "gateway_vault" || token === "gateway_bearer") {
+    return "gateway_bearer_vault";
   }
   return "";
 }
@@ -27959,6 +28016,9 @@ function defaultHighRiskKindForMode(operatorMode) {
   }
   if (operatorMode === "github_actions_secret_sync") {
     return "github_actions_secret_sync";
+  }
+  if (operatorMode === "gateway_bearer_vault") {
+    return "gateway_bearer_vault_bootstrap";
   }
   if (operatorMode === "vps") {
     return "vps_runner_admin";


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #380 の部分進捗です。iPhone の operator page でメモアプリから `VTDD_GATEWAY_BEARER_TOKEN` を貼り付け、local helper 経由で Mac/VPS vault に保存できる bootstrap 入口を追加します。
- GitHub Actions secret だけ更新できても mac Codex / VPS Codex CLI が正規 route で RAG を書けない問題に対し、local vault 側の欠落を埋めます。

## Satisfied Success Criteria

- [x] Operator page に `Gateway Bearer Vault` セクションを追加し、`syncApiBase` がある場合だけ local helper に保存要求を送れる。
- [x] local helper に `/api/gateway-bearer-vault/bootstrap` を追加し、token を stdin 経由で `scripts/bootstrap-gateway-bearer-vault.mjs` に渡す。
- [x] token は Butler 会話、GitHub コメント、RAG、レスポンス本文、stdout/stderr に表示しない。
- [x] helper は既存 bearer がある場合 approvalGrant を runtime で検証し、初回 bootstrap で bearer がない場合は未検証状態をレスポンスに明示する。
- [x] `src/core/passkey-operator-page.js` 更新に合わせて `worker.js` を再生成した。

## Unsatisfied Success Criteria

- Worker secret `VTDD_GATEWAY_BEARER_TOKEN` と Custom GPT Action bearer auth の整合更新はこのPRスライス外です。
- iPhone 実機からの live E2E は deploy 後に実施が必要です。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #380
- Implementing Success Criteria: operator page/local helper から gateway bearer token を local vault に保存し、mac Codex / VPS Codex CLI の正規 runtime route 利用に近づける。
- Explicit Non-goals: Worker secret 自動更新、Custom GPT editor 自動更新、RAG への secret 保存、GitHub コメントへの token 表示、setup wizard 復活はしない。
- Expected touched files/routes/workflows: `src/core/passkey-operator-page.js`, `scripts/run-passkey-operator-helper.mjs`, `worker.js`, operator page route `/v2/approval/passkey/operator`, local helper route `/api/gateway-bearer-vault/bootstrap`, docs/tests。
- Affected Issues: Issue #380。Issue #359 とは setup/recovery 文脈で隣接するが、このPRでは変更しない。
- Affected PRs: なし。
- Affected workflows: GitHub Actions workflow 自体は未変更。生成物検査 `check:generated-worker` に影響。
- Affected runtime/operator surfaces: Cloudflare operator page、local helper、Mac/VPS vault bootstrap。
- What may break if we patch narrowly: operator page の mode 判定、既存 GitHub App secret sync、VPS runner admin セクション番号、worker.js 生成物同期。
- Unknowns to investigate before coding: 既存 helper が GitHub App secret sync 専用か、初回 bearer なしで helper 起動できるか、token を stdout に出さず保存できるか。
- Validation needed: page render tests、helper source guard tests、worker operator route tests、全体 `npm test`。
- Stop condition: token をログ・レスポンス・RAG・GitHub に出す必要が出た場合、または Worker secret / Custom GPT auth まで同一PRで触る必要が出た場合は停止。

## File / Line Hypotheses

- file: `src/core/passkey-operator-page.js`
  - hypothesis: operator page に新セクションと mode 判定を足せば iPhone から token paste UI を提供できる。
  - risk if changed narrowly: 既存 secret sync / deploy / merge mode が隠れる、または event listener が壊れる。
  - validation: `test/passkey-operator-page.test.js`, `test/worker.test.js`
  - related Issue: Issue #380
- file: `scripts/run-passkey-operator-helper.mjs`
  - hypothesis: local helper に vault bootstrap endpoint を足せば、token を CLI 引数ではなく stdin で保存できる。
  - risk if changed narrowly: GitHub App source がない初回状態で helper が起動不能、または token が stdout/stderr に出る。
  - validation: `node --check`, `test/passkey-operator-helper.test.js`, `npm test`
  - related Issue: Issue #380
- file: `worker.js`
  - hypothesis: `src/core/passkey-operator-page.js` 変更後に build 生成物を更新する必要がある。
  - risk if changed narrowly: deploy 後の Worker が古い UI を返す。
  - validation: `npm run build:worker`, `npm run check:generated-worker`, `npm test`
  - related Issue: Issue #380

## Hypothesis Retrospective

- expected: operator page と local helper だけで local vault bootstrap 入口を追加できる。
- actual: 入口は追加できた。加えて、初回 bearer なしで helper が起動不能になる既存結合を分離する必要があった。
- mismatch: approvalGrant 検証は既存 bearer がない初回 bootstrap では runtime retrieve できないため、未検証 bootstrap 状態を明示する設計にした。
- lesson: 初回復旧経路では、既存 credential がある前提を置くと fail-safe が fail する。初回と通常時を分けて表示する必要がある。
- should become RAG candidate: はい。初回復旧経路は既存 bearer/token に依存してはいけない。

## Verification Evidence

- Unit: `node --test test/passkey-operator-page.test.js test/passkey-operator-helper.test.js test/worker.test.js` passed。`node --check scripts/run-passkey-operator-helper.mjs` passed。
- Integration: `npm test` passed（788 tests, 787 pass, 1 skipped。`check:self-parity` と `check:generated-worker` passed）。
- E2E: Worker route test `worker serves gateway bearer vault operator mode` passed。live iPhone E2E は deploy 後に実施予定。
- Manual: 未実施。
- Evidence path/link: local test output in this PR run。該当テスト: `test/passkey-operator-page.test.js`, `test/passkey-operator-helper.test.js`, `test/worker.test.js`。

## Butler Completion Contract

- Owner goal: iPhone の operator page からメモアプリの token を貼り付け、mac Codex / VPS Codex CLI が正規 route を使うための local vault bootstrap に近づける。
- Butler entrypoint: Butler は operator URL を案内できる前提。実際の vault 保存は operator page + local helper 経由。
- Action Schema exposure: 変更なし。Custom GPT Action Schema の operationId 追加は不要。
- Runtime path: Worker operator page `/v2/approval/passkey/operator?...highRiskKind=gateway_bearer_vault_bootstrap&syncApiBase=...` と local helper `/api/gateway-bearer-vault/bootstrap`。
- Runner/runtime truth: existing bearer がある場合は helper が runtime `/v2/retrieve/approval-grant` で approvalGrant を検証する。初回 bearer なしでは `not_checked_initial_bootstrap_gateway_bearer_missing` を返す。
- Authority boundary: GO + real passkey approval。初回 bearer なしでは runtime 検証不能であることをレスポンスに明示する。
- E2E evidence: local automated route evidence あり。iPhone 実機 live E2E は deploy 後。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 必要。operator page が Worker 生成物に含まれるため、merge 後に deploy が必要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 必要。deploy 後、operator URL に `highRiskKind=gateway_bearer_vault_bootstrap` と `syncApiBase` を付けて確認する。

## Related Constitution Rules

- Issue 起点で実装する。
- High-risk credential mutation は GO + passkey 境界を明示する。
- Memory/RAG に secret や raw sensitive material を保存しない。
- iPhone/Butler 通常運用でターミナル操作を前提にしない。
- 生成物 `worker.js` を更新する。

## Out-of-scope but NOT implemented

- Worker secret `VTDD_GATEWAY_BEARER_TOKEN` の自動更新。
- Custom GPT Action bearer auth の自動更新。
- RAG への token 保存。
- GitHub Actions secret sync の仕様変更。
- setup wizard の復活。

## Extra changes (if any)

- local helper は GitHub App source が未設定でも起動できるように分離した。GitHub App secret sync を実行する場合は source 不足を明示的に 503 で返す。

<!-- VTDD metadata -->
- Issue: Issue #380
- Execution ID: mac-codex-issue-380-operator-gateway-vault
- Goal: operator page から gateway bearer local vault bootstrap を実行できるようにする
