### PR TITLE
Issue #380: gateway-only vault で RAG machine auth を解決

### DIFF
--- a/scripts/vtdd-memory.mjs
+++ b/scripts/vtdd-memory.mjs
@@ -2,7 +2,7 @@
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
-import { loadDesktopBootstrapVault } from "../src/core/desktop-bootstrap-vault.js";
+import { loadGatewayBearerTokenFromVault } from "../src/core/desktop-bootstrap-vault.js";
 import { createDecisionLogEntry, createProposalLogEntry } from "../src/core/log-contracts.js";
 import { createMemoryRecord } from "../src/core/memory-schema.js";
 import { evaluateMemorySafety } from "../src/core/memory-safety.js";
@@ -413,7 +413,7 @@ export async function withRuntimeMachineAuth(options = {}) {
     return options;
   }
 
-  const vault = await loadDesktopBootstrapVault({
+  const vault = await loadGatewayBearerTokenFromVault({
     manifestPath: options.manifestPath
   });
   if (!vault.ok) {
@@ -422,7 +422,7 @@ export async function withRuntimeMachineAuth(options = {}) {
     );
   }
 
-  const bearerToken = normalizeText(vault.vault?.gateway?.bearerToken);
+  const bearerToken = normalizeText(vault.gateway?.bearerToken);
   if (!bearerToken) {
     throw new Error("desktop maintenance required: gateway_bearer_token_missing");
   }

--- a/src/core/desktop-bootstrap-vault.js
+++ b/src/core/desktop-bootstrap-vault.js
@@ -102,6 +102,58 @@ export async function loadDesktopBootstrapVault(input = {}) {
   };
 }
 
+export async function loadGatewayBearerTokenFromVault(input = {}) {
+  const manifestPath = normalizeText(input.manifestPath) || DEFAULT_VTDD_VAULT_MANIFEST_PATH;
+  const manifestDir = path.dirname(manifestPath);
+
+  let manifest;
+  try {
+    const content = await fs.readFile(manifestPath, "utf8");
+    manifest = JSON.parse(content);
+  } catch (error) {
+    return {
+      ok: false,
+      issues: [
+        error?.code === "ENOENT"
+          ? `desktop bootstrap vault manifest not found: ${manifestPath}`
+          : `desktop bootstrap vault manifest is unreadable: ${manifestPath}`
+      ]
+    };
+  }
+
+  if (Number(manifest?.version) !== 1) {
+    return {
+      ok: false,
+      issues: ["desktop bootstrap vault manifest version must be 1"]
+    };
+  }
+
+  const bearerTokenPath = resolveReferencedPath(manifestDir, manifest?.gateway?.bearerTokenPath);
+  if (!bearerTokenPath) {
+    return {
+      ok: false,
+      issues: ["gateway.bearerTokenPath is required in desktop bootstrap vault manifest"]
+    };
+  }
+
+  const issues = [];
+  const bearerToken = await readOptionalTextFile(bearerTokenPath, issues);
+  if (!normalizeText(bearerToken)) {
+    issues.push("desktop bootstrap vault gateway bearer token file is empty or unreadable");
+  }
+  if (issues.length > 0) {
+    return { ok: false, issues };
+  }
+
+  return {
+    ok: true,
+    gateway: {
+      bearerTokenPath,
+      bearerToken
+    }
+  };
+}
+
 function resolveReferencedPath(manifestDir, referencedPath) {
   const normalized = normalizeText(referencedPath);
   if (!normalized) {

--- a/test/vtdd-memory-cli.test.js
+++ b/test/vtdd-memory-cli.test.js
@@ -196,20 +196,13 @@ test("runtime operational memory request keeps auth in headers", () => {
 
 test("runtime machine auth resolves gateway bearer token from desktop vault", async () => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "vtdd-memory-vault-"));
-  await fs.mkdir(path.join(root, "github-app"), { recursive: true });
   await fs.mkdir(path.join(root, "gateway"), { recursive: true });
-  await fs.writeFile(path.join(root, "github-app", "private-key.pem"), "private-key", "utf8");
   await fs.writeFile(path.join(root, "gateway", "bearer-token.txt"), "vault-token", "utf8");
   const manifestPath = path.join(root, "manifest.json");
   await fs.writeFile(
     manifestPath,
     JSON.stringify({
       version: 1,
-      githubApp: {
-        appId: "123",
-        installationId: "456",
-        privateKeyPath: "github-app/private-key.pem"
-      },
       gateway: {
         bearerTokenPath: "gateway/bearer-token.txt"
       }


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #380 の部分進捗です。PR #384 後に、Mac vault へ `VTDD_GATEWAY_BEARER_TOKEN` は保存できたものの、`scripts/vtdd-memory.mjs` が GitHub App vault 欠落を理由に正規 retrieve route へ進めない不具合を修正します。
- RAG machine auth では gateway bearer token だけが必要なので、GitHub App credential 一式を要求しない gateway 専用 loader を追加します。

## Satisfied Success Criteria

- [x] gateway bearer token だけが入った vault manifest から `vtdd-memory.mjs` が runtime machine auth を解決できる。
- [x] GitHub App credential 欠落を `gateway_bearer_token_missing` と誤判定しない。
- [x] token は出力・URL・エラーに漏らさない。
- [x] 保存済み Mac vault を使って `retrieve-operational` が正規 route に到達できることを確認した。

## Unsatisfied Success Criteria

- VPS vault への iPhone-first 保存経路は未実装です。
- Worker secret / Custom GPT Action auth との整合確認はこのPRスライス外です。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #380
- Implementing Success Criteria: mac Codex / VPS Codex CLI が正規 route で RAG を読む・書くための gateway bearer vault 解決を、GitHub App vault に依存させない。
- Explicit Non-goals: GitHub App secret sync、Cloudflare secret mutation、Custom GPT auth 更新、VPS helper 実装はしない。
- Expected touched files/routes/workflows: `src/core/desktop-bootstrap-vault.js`, `scripts/vtdd-memory.mjs`, `test/vtdd-memory-cli.test.js`。
- Affected Issues: Issue #380。
- Affected PRs: PR #384 の後続修正。
- Affected workflows: なし。
- Affected runtime/operator surfaces: mac Codex / VPS Codex CLI の `scripts/vtdd-memory.mjs` 実行面。
- What may break if we patch narrowly: 既存 full desktop vault loader を変更すると GitHub App secret sync が壊れる可能性があるため、新しい gateway 専用 loader を追加する。
- Unknowns to investigate before coding: `vtdd-memory.mjs` が full vault loader を使っているか、gateway token だけの manifest で retrieve が失敗するか。
- Validation needed: targeted tests、保存済み Mac vault で live retrieve、全体 `npm test`。
- Stop condition: GitHub App vault の検証条件を弱める必要が出た場合、または token を出力する必要が出た場合。

## File / Line Hypotheses

- file: `scripts/vtdd-memory.mjs`
  - hypothesis: `withRuntimeMachineAuth()` が full vault loader を呼ぶため、gateway token があるのに GitHub App 欠落で失敗している。
  - risk if changed narrowly: GitHub App secret sync 側の credential validation を弱めてしまう。
  - validation: `test/vtdd-memory-cli.test.js`, live `retrieve-operational`
  - related Issue: Issue #380
- file: `src/core/desktop-bootstrap-vault.js`
  - hypothesis: full vault loader とは別に gateway token 専用 loader を追加すれば、用途ごとの authority boundary を崩さず直せる。
  - risk if changed narrowly: manifest version や token path validation が不足すると壊れた vault を正しく検出できない。
  - validation: `test/vtdd-memory-cli.test.js`, `test/desktop-bootstrap-vault.test.js`
  - related Issue: Issue #380

## Hypothesis Retrospective

- expected: Mac vault 保存後、`vtdd-memory.mjs retrieve-operational` が正規 route に到達する。
- actual: GitHub App fields 欠落を理由に `gateway_bearer_token_missing` として失敗した。
- mismatch: gateway-only machine auth が full desktop bootstrap vault に結合していた。
- lesson: bootstrap/recovery 経路では credential の用途を混ぜない。RAG runtime auth は gateway token だけ、GitHub App mutation は GitHub App vault を別に検証する。
- should become RAG candidate: はい。初回 bootstrap 直後の復旧経路は full vault を前提にしない。

## Verification Evidence

- Unit: `node --test test/vtdd-memory-cli.test.js test/desktop-bootstrap-vault.test.js` passed。
- Integration: `npm test` passed（788 tests, 787 pass, 1 skipped / check:self-parity pass / check:generated-worker pass）。
- E2E: 保存済み Mac vault で `node scripts/vtdd-memory.mjs retrieve-operational --runtime-url current owner-operated Cloudflare Worker origin --query "gateway bearer vault bootstrap" --limit 1` が `ok:true` で正規 route に到達。
- Manual: ユーザーが operator page から Mac vault 保存を完了。レスポンスで `manifestUpdated:true`, `tokenWritten:true`, `tokenPreview:"[redacted]"` を確認。
- Evidence path/link: local command output in this PR run。

## Butler Completion Contract

- Owner goal: Mac vault に保存した gateway bearer token を mac Codex の RAG 正規 route 利用に実際につなげる。
- Butler entrypoint: 変更なし。Butler からの保存経路は PR #384 の operator page 側。
- Action Schema exposure: 変更なし。
- Runtime path: `scripts/vtdd-memory.mjs retrieve-operational` -> `/v2/retrieve/operational-memory`。
- Runner/runtime truth: 保存済み Mac vault から token を読み、runtime が `ok:true` を返した。
- Authority boundary: token は local vault に保存済み。今回のPRは読み取り解決の修正であり、新しい secret mutation は行わない。
- E2E evidence: mac Codex local CLI から正規 runtime retrieve を実行済み。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 不要。runtime code / worker.js は変更なし。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 不要。このPRは mac/VPS CLI 側の local auth 解決修正。

## Related Constitution Rules

- Issue 起点で実装する。
- Secret をログ・RAG・GitHub に出さない。
- 用途別の credential boundary を混ぜない。
- 証拠なしに完了を主張しない。

## Out-of-scope but NOT implemented

- VPS vault への保存経路。
- Worker secret / Custom GPT Action auth の整合更新。
- GitHub App credential vault の補完。

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #380
- Execution ID: mac-codex-issue-380-gateway-only-memory-auth
- Goal: gateway-only vault で vtdd-memory 正規 runtime auth を解決する

