### PR TITLE
Issue #380: gateway bearer vault approvalGrant 検証器を追加

### DIFF
--- a/scripts/validate-gateway-bearer-vault-approval-grant.mjs
+++ b/scripts/validate-gateway-bearer-vault-approval-grant.mjs
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+import { loadGatewayBearerTokenFromVault } from "../src/core/desktop-bootstrap-vault.js";
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const result = await validateGatewayBearerVaultApprovalGrant({
+    approvalGrantId: args.approvalGrantId,
+    runtimeUrl: args.runtimeUrl || process.env.VTDD_RUNTIME_URL,
+    repositoryInput: args.repository || process.env.GITHUB_REPOSITORY,
+    gatewayBearerToken: args.gatewayBearerToken || process.env.VTDD_GATEWAY_BEARER_TOKEN,
+    manifestPath: args.manifestPath
+  });
+
+  if (!result.ok) {
+    throw new Error(result.issues.join(", "));
+  }
+  process.stdout.write("gateway bearer vault approval grant validated\n");
+}
+
+export async function validateGatewayBearerVaultApprovalGrant(input = {}) {
+  const approvalGrantId = normalizeText(input.approvalGrantId);
+  const runtimeUrl = normalizeText(input.runtimeUrl);
+  const repositoryInput = normalizeText(input.repositoryInput);
+  const bearerToken = await resolveGatewayBearerToken(input);
+  const issues = [];
+
+  if (!approvalGrantId) {
+    issues.push("--approval-grant-id is required");
+  }
+  if (!runtimeUrl) {
+    issues.push("--runtime-url or VTDD_RUNTIME_URL is required");
+  }
+  if (!repositoryInput) {
+    issues.push("--repository or GITHUB_REPOSITORY is required");
+  }
+  if (!bearerToken) {
+    issues.push("--gateway-bearer-token, VTDD_GATEWAY_BEARER_TOKEN, or gateway vault token is required");
+  }
+  if (issues.length > 0) {
+    return { ok: false, issues };
+  }
+
+  const endpoint = new URL("/v2/retrieve/approval-grant", runtimeUrl);
+  endpoint.searchParams.set("approvalId", approvalGrantId);
+  const response = await (input.fetch || fetch)(endpoint, {
+    headers: {
+      authorization: `Bearer ${bearerToken}`
+    }
+  });
+  const body = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    return {
+      ok: false,
+      issues: [normalizeText(body.reason || body.error) || `approval grant retrieval failed with status ${response.status}`]
+    };
+  }
+
+  const approvalGrant = body?.approvalGrant;
+  const validation = validateGatewayBearerVaultApprovalGrantObject({
+    approvalGrant,
+    repositoryInput
+  });
+  if (!validation.ok) {
+    return validation;
+  }
+
+  return {
+    ok: true,
+    approvalGrant: {
+      approvalId: normalizeText(approvalGrant.approvalId),
+      expiresAt: normalizeText(approvalGrant.expiresAt),
+      scope: approvalGrant.scope
+    }
+  };
+}
+
+export function validateGatewayBearerVaultApprovalGrantObject({ approvalGrant, repositoryInput } = {}) {
+  const issues = [];
+  if (!approvalGrant || approvalGrant.verified !== true) {
+    issues.push("real approvalGrant is required for gateway bearer vault bootstrap");
+  }
+  const expiresAt = normalizeText(approvalGrant?.expiresAt);
+  if (!expiresAt || Number.isNaN(Date.parse(expiresAt)) || Date.parse(expiresAt) <= Date.now()) {
+    issues.push("approvalGrant is expired or invalid");
+  }
+  const scope = approvalGrant?.scope ?? {};
+  if (normalizeText(scope.repositoryInput) !== normalizeText(repositoryInput)) {
+    issues.push("approvalGrant scope.repositoryInput must match target repo");
+  }
+  if (normalizeText(scope.actionType) !== "destructive") {
+    issues.push("approvalGrant scope.actionType must be destructive");
+  }
+  if (normalizeText(scope.highRiskKind) !== "gateway_bearer_vault_bootstrap") {
+    issues.push("approvalGrant scope.highRiskKind must be gateway_bearer_vault_bootstrap");
+  }
+  return {
+    ok: issues.length === 0,
+    issues
+  };
+}
+
+async function resolveGatewayBearerToken(input = {}) {
+  const direct = normalizeText(input.gatewayBearerToken);
+  if (direct) {
+    return direct;
+  }
+  const vault = await loadGatewayBearerTokenFromVault({ manifestPath: input.manifestPath });
+  if (!vault.ok) {
+    return "";
+  }
+  return normalizeText(vault.gateway?.bearerToken);
+}
+
+function parseArgs(args) {
+  const parsed = {};
+  for (let index = 0; index < args.length; index += 1) {
+    const current = args[index];
+    if (current === "--approval-grant-id") {
+      parsed.approvalGrantId = args[index + 1];
+      index += 1;
+      continue;
+    }
+    if (current === "--runtime-url") {
+      parsed.runtimeUrl = args[index + 1];
+      index += 1;
+      continue;
+    }
+    if (current === "--repository") {
+      parsed.repository = args[index + 1];
+      index += 1;
+      continue;
+    }
+    if (current === "--gateway-bearer-token") {
+      parsed.gatewayBearerToken = args[index + 1];
+      index += 1;
+      continue;
+    }
+    if (current === "--manifest-path") {
+      parsed.manifestPath = args[index + 1];
+      index += 1;
+    }
+  }
+  return parsed;
+}
+
+function normalizeText(value) {
+  return String(value ?? "").trim();
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}

--- a/test/gateway-bearer-vault-approval-grant.test.js
+++ b/test/gateway-bearer-vault-approval-grant.test.js
@@ -1,0 +1,78 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  validateGatewayBearerVaultApprovalGrant,
+  validateGatewayBearerVaultApprovalGrantObject
+} from "../scripts/validate-gateway-bearer-vault-approval-grant.mjs";
+
+test("gateway bearer vault approval grant validator accepts scoped destructive grant", () => {
+  const result = validateGatewayBearerVaultApprovalGrantObject({
+    repositoryInput: "marushu/vtdd-v2-p",
+    approvalGrant: {
+      verified: true,
+      expiresAt: "2999-01-01T00:00:00.000Z",
+      scope: {
+        repositoryInput: "marushu/vtdd-v2-p",
+        actionType: "destructive",
+        highRiskKind: "gateway_bearer_vault_bootstrap"
+      }
+    }
+  });
+
+  assert.equal(result.ok, true);
+});
+
+test("gateway bearer vault approval grant validator rejects wrong high-risk kind", () => {
+  const result = validateGatewayBearerVaultApprovalGrantObject({
+    repositoryInput: "marushu/vtdd-v2-p",
+    approvalGrant: {
+      verified: true,
+      expiresAt: "2999-01-01T00:00:00.000Z",
+      scope: {
+        repositoryInput: "marushu/vtdd-v2-p",
+        actionType: "destructive",
+        highRiskKind: "github_actions_secret_sync"
+      }
+    }
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(
+    result.issues.includes("approvalGrant scope.highRiskKind must be gateway_bearer_vault_bootstrap"),
+    true
+  );
+});
+
+test("gateway bearer vault approval grant retrieval keeps bearer token in header", async () => {
+  let request;
+  const result = await validateGatewayBearerVaultApprovalGrant({
+    approvalGrantId: "approval:test",
+    runtimeUrl: "https://runtime.example",
+    repositoryInput: "marushu/vtdd-v2-p",
+    gatewayBearerToken: "secret-token",
+    fetch: async (url, init) => {
+      request = { url: String(url), init };
+      return new Response(
+        JSON.stringify({
+          ok: true,
+          approvalGrant: {
+            approvalId: "approval:test",
+            verified: true,
+            expiresAt: "2999-01-01T00:00:00.000Z",
+            scope: {
+              repositoryInput: "marushu/vtdd-v2-p",
+              actionType: "destructive",
+              highRiskKind: "gateway_bearer_vault_bootstrap"
+            }
+          }
+        }),
+        { status: 200, headers: { "content-type": "application/json" } }
+      );
+    }
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(request.init.headers.authorization, "Bearer secret-token");
+  assert.equal(request.url.includes("secret-token"), false);
+});


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #380 の部分進捗です。VPS vault へ `VTDD_GATEWAY_BEARER_TOKEN` を保存する前に、`gateway_bearer_vault_bootstrap` 用の real passkey approvalGrant を CLI で検証できるようにします。
- これにより、Mac から SSH で VPS vault を更新するような高リスク操作でも、実行前に runtime truth の approvalGrant scope を確認できます。

## Satisfied Success Criteria

- [x] `gateway_bearer_vault_bootstrap` 専用の approvalGrant 検証 script を追加した。
- [x] repository / actionType / highRiskKind / expiresAt / verified を検証する。
- [x] bearer token は URL ではなく Authorization header にだけ入る。
- [x] 既存 Mac vault の gateway token を使って検証できる。

## Unsatisfied Success Criteria

- VPS vault への実際の token 保存はこのPRでは行いません。
- iPhone だけで VPS vault へ直接保存する公開 HTTPS helper は未実装です。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #380
- Implementing Success Criteria: VPS vault credential mutation の前段として、approvalGrant scope を検証できる CLI を追加する。
- Explicit Non-goals: VPS への credential mutation、Worker route 追加、Action Schema 更新、公開 helper の実装はしない。
- Expected touched files/routes/workflows: `scripts/validate-gateway-bearer-vault-approval-grant.mjs`, `test/gateway-bearer-vault-approval-grant.test.js`。
- Affected Issues: Issue #380。
- Affected PRs: PR #384 / PR #385 の後続。
- Affected workflows: なし。
- Affected runtime/operator surfaces: mac Codex / VPS bootstrap operator work。
- What may break if we patch narrowly: deploy approval validator と混同すると deploy_production scope を誤用する可能性があるため、専用 validator に分ける。
- Unknowns to investigate before coding: approvalGrant retrieve route の戻り値と highRiskKind scope 名。
- Validation needed: targeted tests、全体 `npm test`。
- Stop condition: token を CLI 引数や URL に載せる必要が出た場合、または validation が deploy scope と混ざる場合。

## File / Line Hypotheses

- file: `scripts/validate-deploy-approval-grant.mjs`
  - hypothesis: deploy validator と同じ retrieve pattern を gateway bearer vault 用に分ければよい。
  - risk if changed narrowly: deploy scope を流用して wrong highRiskKind を許可する。
  - validation: new validator tests。
  - related Issue: Issue #380
- file: `src/core/desktop-bootstrap-vault.js`
  - hypothesis: PR #385 の gateway-only loader を使えば env なしでも Mac vault token で retrieve できる。
  - risk if changed narrowly: token が URL やエラーに漏れる。
  - validation: authorization header test。
  - related Issue: Issue #380

## Hypothesis Retrospective

- expected: 専用 validator を追加すれば、VPS 書き込み前に GO + passkey scope を検証できる。
- actual: 追加できた。bearer token は header のみに保持される。
- mismatch: なし。
- lesson: credential mutation 実行器より先に、approvalGrant 検証器を独立させると境界が見えやすい。
- should become RAG candidate: はい。高リスク操作は実行器より先に検証器を作る。

## Verification Evidence

- Unit: `node --test test/gateway-bearer-vault-approval-grant.test.js test/gateway-bearer-vault-bootstrap.test.js test/vtdd-memory-cli.test.js` passed。
- Integration: `npm test` passed（791 tests, 790 pass, 1 skipped / check:self-parity pass / check:generated-worker pass）。
- E2E: 未実施。このPRは検証器のみ。
- Manual: 未実施。
- Evidence path/link: local test output in this PR run。

## Butler Completion Contract

- Owner goal: VPS vault へ token を保存する前に、scope が合う approvalGrant を検証できるようにする。
- Butler entrypoint: 変更なし。Butler は operator URL で approvalGrant を発行する想定。
- Action Schema exposure: 変更なし。
- Runtime path: `/v2/retrieve/approval-grant` を machine auth 付きで読む。
- Runner/runtime truth: approvalGrant の verified/expiresAt/scope を runtime truth として検証する。
- Authority boundary: GO + passkey approvalGrant の検証のみ。credential mutation は未実行。
- E2E evidence: 未実施。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 不要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 不要。このPRは CLI validator 追加のみ。

## Related Constitution Rules

- Credential mutation は GO + passkey 境界を必要とする。
- Secret を URL / GitHub / RAG / logs に出さない。
- Issue 起点で実装する。

## Out-of-scope but NOT implemented

- VPS vault への実際の token 保存。
- public HTTPS VPS helper。
- Worker/Action Schema 更新。

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #380
- Execution ID: mac-codex-issue-380-gateway-vault-approval-validator
- Goal: VPS vault 保存前の gateway bearer vault approvalGrant を検証する
