### PR TITLE
Issue #389: GitHub App secret sync の hang 防止

### DIFF
--- a/docs/setup/github-app-secret-sync.md
+++ b/docs/setup/github-app-secret-sync.md
@@ -107,6 +107,24 @@ auth, verifies that:
 
 and only then performs GitHub Actions secret mutation.
 
+During mutation, the script feeds each secret value to `gh secret set` through
+explicit subprocess stdin and closes stdin immediately. If `gh secret set`
+stops responding, the script terminates that subprocess after the configured
+timeout instead of waiting forever. It first sends `SIGTERM`; if the process
+does not exit after a short grace period, it escalates to `SIGKILL`.
+
+Expected failure behavior:
+
+- the failing GitHub Actions secret name is shown
+- stdout/stderr byte counts may be shown for diagnostics
+- secret values, private key contents, bearer tokens, and approval grant values
+  are not printed
+- a timeout means the local bootstrap/helper path needs maintenance before the
+  operator retries
+
+The default timeout is 30 seconds per secret. For diagnostics only, it can be
+overridden with `--secret-set-timeout-ms <milliseconds>`.
+
 By default, the script reads:
 
 - `~/.vtdd/credentials/manifest.json`

--- a/scripts/sync-github-app-actions-secrets.mjs
+++ b/scripts/sync-github-app-actions-secrets.mjs
@@ -1,12 +1,13 @@
-import { execFile } from "node:child_process";
-import { promisify } from "node:util";
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
 import {
   buildGitHubAppSecretSyncPlan,
   loadGitHubAppSecretSource,
   validateGitHubAppSecretSyncApprovalGrant
 } from "../src/core/github-app-secret-sync.js";
 
-const execFileAsync = promisify(execFile);
+const DEFAULT_GH_SECRET_SET_TIMEOUT_MS = 30_000;
+const DEFAULT_GH_SECRET_SET_KILL_GRACE_MS = 2_000;
 
 async function main() {
   const args = parseArgs(process.argv.slice(2));
@@ -57,16 +58,119 @@ async function main() {
   }
 
   for (const secret of plan.secrets) {
-    await execFileAsync(
-      "gh",
-      ["secret", "set", secret.name, "--repo", repo, "--app", "actions"],
-      {
-        input: secret.value,
-        maxBuffer: 10 * 1024 * 1024
-      }
-    );
+    await setGitHubActionsSecret({
+      repo,
+      secret,
+      timeoutMs: args.secretSetTimeoutMs
+    });
     console.log(`synced ${secret.name}`);
   }
+}
+
+export function setGitHubActionsSecret({
+  repo,
+  secret,
+  timeoutMs = DEFAULT_GH_SECRET_SET_TIMEOUT_MS,
+  killGraceMs = DEFAULT_GH_SECRET_SET_KILL_GRACE_MS,
+  spawnImpl = spawn
+}) {
+  const secretName = String(secret?.name ?? "").trim();
+  const secretValue = String(secret?.value ?? "");
+  const normalizedRepo = String(repo ?? "").trim();
+  const normalizedTimeoutMs = normalizeTimeoutMs(timeoutMs);
+  const normalizedKillGraceMs = normalizeTimeoutMs(killGraceMs);
+
+  if (!normalizedRepo) {
+    throw new Error("repo is required for GitHub App secret sync");
+  }
+  if (!secretName) {
+    throw new Error("secret name is required for GitHub App secret sync");
+  }
+
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    let closed = false;
+    let killTimer = null;
+    let stdoutBytes = 0;
+    let stderrBytes = 0;
+    const child = spawnImpl(
+      "gh",
+      ["secret", "set", secretName, "--repo", normalizedRepo, "--app", "actions"],
+      {
+        stdio: ["pipe", "pipe", "pipe"]
+      }
+    );
+
+    const finish = (callback, value) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      if (closed && killTimer) {
+        clearTimeout(killTimer);
+      }
+      callback(value);
+    };
+
+    const fail = (reason) => {
+      finish(reject, new Error(`gh secret set failed for ${secretName}: ${reason}`));
+    };
+
+    const timer = setTimeout(() => {
+      if (typeof child.kill === "function") {
+        child.kill("SIGTERM");
+        killTimer = setTimeout(() => {
+          if (!closed && typeof child.kill === "function") {
+            child.kill("SIGKILL");
+          }
+        }, normalizedKillGraceMs);
+        killTimer.unref?.();
+      }
+      fail(`timeout after ${normalizedTimeoutMs}ms`);
+    }, normalizedTimeoutMs);
+
+    child.stdout?.on?.("data", (chunk) => {
+      stdoutBytes += Buffer.byteLength(chunk);
+    });
+    child.stderr?.on?.("data", (chunk) => {
+      stderrBytes += Buffer.byteLength(chunk);
+    });
+    child.on?.("error", (error) => {
+      fail(error instanceof Error ? error.message : String(error));
+    });
+    child.on?.("close", (code, signal) => {
+      closed = true;
+      if (killTimer) {
+        clearTimeout(killTimer);
+      }
+      if (settled) {
+        return;
+      }
+      if (code === 0) {
+        finish(resolve, { ok: true, name: secretName });
+        return;
+      }
+      const suffix = signal
+        ? `signal ${signal}`
+        : `exit code ${code}`;
+      fail(`${suffix}; stdout=${stdoutBytes} bytes; stderr=${stderrBytes} bytes`);
+    });
+
+    child.stdin?.on?.("error", (error) => {
+      fail(`stdin error: ${error instanceof Error ? error.message : String(error)}`);
+    });
+    child.stdin?.write?.(secretValue);
+    child.stdin?.end?.();
+  });
+}
+
+function normalizeTimeoutMs(value) {
+  const timeoutMs = Number(value ?? DEFAULT_GH_SECRET_SET_TIMEOUT_MS);
+  if (!Number.isInteger(timeoutMs) || timeoutMs <= 0) {
+    throw new Error("secret set timeout must be a positive integer");
+  }
+  return timeoutMs;
 }
 
 function printDryRun(plan, source) {
@@ -144,6 +248,11 @@ function parseArgs(args) {
     if (current === "--gateway-bearer-token") {
       parsed.gatewayBearerToken = args[index + 1];
       index += 1;
+      continue;
+    }
+    if (current === "--secret-set-timeout-ms") {
+      parsed.secretSetTimeoutMs = args[index + 1];
+      index += 1;
     }
   }
   return parsed;
@@ -184,7 +293,9 @@ async function resolveApprovalGrant(input = {}) {
   return body.approvalGrant;
 }
 
-main().catch((error) => {
-  console.error(error instanceof Error ? error.message : String(error));
-  process.exitCode = 1;
-});
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}

--- a/test/github-app-secret-sync-script.test.js
+++ b/test/github-app-secret-sync-script.test.js
@@ -1,0 +1,116 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+
+import { setGitHubActionsSecret } from "../scripts/sync-github-app-actions-secrets.mjs";
+
+test("setGitHubActionsSecret writes secret value to gh stdin and closes stdin", async () => {
+  const writes = [];
+  const argsSeen = [];
+  const child = createFakeChild({
+    stdin: {
+      write(value) {
+        writes.push(value);
+      },
+      end() {
+        writes.push("[end]");
+      }
+    }
+  });
+  const resultPromise = setGitHubActionsSecret({
+    repo: "marushu/vtdd-v2-p",
+    secret: {
+      name: "VTDD_CODEX_FALLBACK_REVIEWER_APP_ID",
+      value: "3706921"
+    },
+    spawnImpl(command, args) {
+      argsSeen.push(command, ...args);
+      queueMicrotask(() => child.emit("close", 0, null));
+      return child;
+    }
+  });
+
+  await assert.doesNotReject(resultPromise);
+  assert.deepEqual(argsSeen, [
+    "gh",
+    "secret",
+    "set",
+    "VTDD_CODEX_FALLBACK_REVIEWER_APP_ID",
+    "--repo",
+    "marushu/vtdd-v2-p",
+    "--app",
+    "actions"
+  ]);
+  assert.deepEqual(writes, ["3706921", "[end]"]);
+});
+
+test("setGitHubActionsSecret times out a stuck gh secret set without leaking secret value", async () => {
+  const child = createFakeChild();
+  const killedSignals = [];
+  child.kill = (signal) => {
+    killedSignals.push(signal);
+  };
+
+  await assert.rejects(
+    setGitHubActionsSecret({
+      repo: "marushu/vtdd-v2-p",
+      secret: {
+        name: "VTDD_CODEX_FALLBACK_REVIEWER_APP_PRIVATE_KEY",
+        value: "super-secret-private-key"
+      },
+      timeoutMs: 1,
+      killGraceMs: 1,
+      spawnImpl() {
+        return child;
+      }
+    }),
+    (error) => {
+      assert.match(error.message, /VTDD_CODEX_FALLBACK_REVIEWER_APP_PRIVATE_KEY/);
+      assert.match(error.message, /timeout after 1ms/);
+      assert.equal(error.message.includes("super-secret-private-key"), false);
+      return true;
+    }
+  );
+  await new Promise((resolve) => setTimeout(resolve, 5));
+  assert.deepEqual(killedSignals, ["SIGTERM", "SIGKILL"]);
+});
+
+test("setGitHubActionsSecret reports failing secret name without echoing process output", async () => {
+  const child = createFakeChild();
+  const promise = setGitHubActionsSecret({
+    repo: "marushu/vtdd-v2-p",
+    secret: {
+      name: "VTDD_GEMINI_REVIEWER_APP_PRIVATE_KEY",
+      value: "secret-value-that-must-not-appear"
+    },
+    spawnImpl() {
+      queueMicrotask(() => {
+        child.stderr.emit("data", "stderr contains secret-value-that-must-not-appear");
+        child.stdout.emit("data", "stdout contains secret-value-that-must-not-appear");
+        child.emit("close", 1, null);
+      });
+      return child;
+    }
+  });
+
+  await assert.rejects(promise, (error) => {
+    assert.match(error.message, /VTDD_GEMINI_REVIEWER_APP_PRIVATE_KEY/);
+    assert.match(error.message, /exit code 1/);
+    assert.equal(error.message.includes("secret-value-that-must-not-appear"), false);
+    assert.match(error.message, /stdout=\d+ bytes/);
+    assert.match(error.message, /stderr=\d+ bytes/);
+    return true;
+  });
+});
+
+function createFakeChild(overrides = {}) {
+  const child = new EventEmitter();
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.stdin = new EventEmitter();
+  child.stdin.write = () => {};
+  child.stdin.end = () => {};
+  child.kill = () => {};
+
+  return Object.assign(child, overrides);
+}


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #389 の GitHub App secret sync hang を防ぐため、gh secret set への secret 値受け渡しを明示的 stdin 書き込みに変更し、timeout、SIGTERM->SIGKILL escalation、redacted failure を追加します。

## Satisfied Success Criteria

- scripts/sync-github-app-actions-secrets.mjs が gh secret set に secret 値を stdin write/end で渡す。
subprocess timeout により stdin 待ちや応答停止で無限に待たない。
失敗時は secret 名と stdout/stderr byte count だけを表示し、secret 値は表示しない。
test/github-app-secret-sync-script.test.js で stdin 受け渡し、timeout、secret 非表示を検証する。
docs/setup/github-app-secret-sync.md に expected failure と timeout を追記する。

## Unsatisfied Success Criteria

None for this PR slice. Live secret mutation は GO + passkey が必要なため、この PR では out-of-scope として mocked execution まで。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #389
- Implementing Success Criteria: gh secret set の stdin hang 防止、timeout/stuck detection、secret 非表示 failure、テスト、docs 追記。
- Explicit Non-goals: 実 secret mutation、approval boundary 変更、GitHub App 権限設計変更、orphan process cleanup はしない。
- Expected touched files/routes/workflows: scripts/sync-github-app-actions-secrets.mjs; test/github-app-secret-sync-script.test.js; docs/setup/github-app-secret-sync.md
- Affected Issues: Issue #380 は secret/vault repair 文脈で影響あり。Issue #389 が直接対象。
- Affected PRs: なし。
- Affected workflows: GitHub App secret sync bootstrap を使う operator/helper repair flow。GitHub Actions workflow 定義は未変更。
- Affected runtime/operator surfaces: mac Codex / local helper の bootstrap path。Butler normal runtime、Worker Action Schema、Custom GPT Instructions は未変更。
- What may break if we patch narrowly: secret sync path だけを直すため、実 credential mutation の live E2E はこの PR では実行しない。timeout を入れすぎると遅い gh 実行を止める可能性があるため default は 30 秒にした。
- Unknowns to investigate before coding: execFile input が詰まった環境差の根本原因は未特定。ただし stdin write/end と timeout で同じ症状は停止可能。
- Validation needed: script unit test、既存 GitHub App secret sync test、npm test。live mutation は GO + passkey 時のみ。
- Stop condition: secret 値をログに出す必要が出た場合、または approval boundary を弱める必要が出た場合は停止。

## File / Line Hypotheses

- file: `scripts/sync-github-app-actions-secrets.mjs`
  - hypothesis: `promisify(execFile)` の `input` 受け渡しと timeout 不在が hang の直接原因。
  - risk if changed narrowly: secret 値が error/stdout/stderr に漏れると復旧機能そのものが危険になる。
  - validation: spawn stub で stdin write/end、timeout kill、redacted error を検証。
  - related Issue: Issue #389
- file: `docs/setup/github-app-secret-sync.md`
  - hypothesis: 復旧時の expected failure が docs にないため、次回 Butler/mac/VPS が止まり方を説明しにくい。
  - validation: docs に timeout と secret 非表示 failure を追記。
  - related Issue: Issue #389

## Hypothesis Retrospective

- expected: gh secret set の実行を明示的 stdin 書き込みにすれば、stdin 待ち hang を timeout で止められる。
- actual: `setGitHubActionsSecret` を追加し、stub test で stdin write/end、timeout SIGTERM->SIGKILL、secret 非表示 failure を確認した。
- mismatch: 実 live secret mutation は GO + passkey 境界のため未実施。
- lesson: high-risk repair script は失敗時に secret 値ではなく secret 名と byte count だけを返す方が iPhone 復旧時に安全。
- should become RAG candidate: 実 live repair で再発が確認された場合は RAG 候補。

## Verification Evidence

- Unit: node --test test/github-app-secret-sync-script.test.js test/github-app-secret-sync.test.js: pass
- Integration: npm test: pass（794 tests, 793 pass, 1 skipped; check:self-parity pass; check:generated-worker pass）
- E2E: Live secret mutation は GO + passkey が必要なため未実施。mocked execution で stdin / timeout / redaction を検証。
- Manual: なし。
- Evidence path/link: scripts/sync-github-app-actions-secrets.mjs; test/github-app-secret-sync-script.test.js; docs/setup/github-app-secret-sync.md

## Butler Completion Contract

- Owner goal: iPhone / Butler 起点の credential repair で、secret sync が無限待ちせず、どの secret で止まったかを安全に把握できる。
- Butler entrypoint: この PR では Butler 通常会話入口は未変更。operator/helper repair path の安全性改善。
- Action Schema exposure: 不要。Action Schema 変更なし。
- Runtime path: local helper / mac Codex が `scripts/sync-github-app-actions-secrets.mjs --execute` を使う GitHub App secret sync bootstrap path。
- Runner/runtime truth: テストで subprocess 挙動を検証。実 GitHub secret mutation は high-risk のため GO + passkey 時のみ。
- Authority boundary: 未変更。GitHub App secret sync は引き続き GO + passkey が必要。
- E2E evidence: Butler-facing通常E2Eではなく、operator/helper repair path の mocked E2E。Live mutation は GO + passkey が必要。
- Completion status: complete

## Surface Update Checklist

- Cloudflare deploy: 不要。Worker runtime / generated worker は未変更。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 不要。iPhone repair 時は operator/helper flow で確認する。

## Related Constitution Rules

- Issue-driven。Secret / token / private key をログ、Issue、PR、RAGに出さない。GitHub secret mutation は GO + passkey。PR body は prepare-pr-body-file 経由。

## Out-of-scope but NOT implemented

- orphan gh process cleanup。GitHub App permission redesign。live secret mutation。

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #389
- Execution ID: mac-codex-issue-389
- Goal: Issue #389 secret sync hang prevention
