### PR TITLE
Issue #344: thread-independent startup contract を追加

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,21 @@ Do not talk about executor / handoff / reviewer / claim behavior as if it were
 missing from scratch until you have explicitly checked for an existing contract,
 draft, test, or implementation anchor in-repo.
 
+## Thread-Independent Startup Contract
+
+Thread-local behavior is not a stable VTDD rule. If a behavior must survive a
+new chat thread, context compression, Butler handoff, mac Codex handoff, or VPS
+Codex CLI handoff, promote it into repository docs, Issue comments, or RAG.
+
+Before starting or resuming Issue-backed work, read
+`docs/butler/thread-independent-startup-contract.md` when startup behavior,
+handoff behavior, RAG recall, or cross-surface consistency is relevant.
+
+Startup/preflight must report whether thread-local assumptions have been
+promoted into durable repo/RAG state. If not, say
+`threadLocalAssumptionsPromoted=false` or `未確認`; do not proceed as if the
+current thread's implicit habits are canonical.
+
 ## Active-Issue Coverage Policy
 
 Default assumption: implementation scope covers all active Issues unless the user explicitly narrows scope.

--- a/docs/butler/thread-independent-startup-contract.md
+++ b/docs/butler/thread-independent-startup-contract.md
@@ -1,0 +1,79 @@
+# Thread-independent startup contract
+
+Issue: #344
+
+This contract exists so VTDD work can resume from Butler, mac Codex, or VPS
+Codex CLI without depending on the memory of one chat thread.
+
+## Purpose
+
+When a surface starts or resumes VTDD work, it must reconstruct the current
+working frame from durable sources before proposing code, PR, merge, close,
+deploy, or recovery action.
+
+The goal is not to make startup verbose. The goal is to stop hidden
+thread-local assumptions from becoming drift.
+
+## Required startup sources
+
+Read or explicitly mark missing:
+
+1. The user's current explicit instruction.
+2. The active GitHub Issue text and latest relevant comments.
+3. This contract, `AGENTS.md`, and the Butler setup instructions when surface
+   behavior or doctrine matters.
+4. GitHub runtime truth: branch, PR, review, check, workflow, deploy, and setup
+   state relevant to the requested action.
+5. Shared RAG / operational memory for prior decisions, failures, repair
+   patterns, checkpoints, and tension notes.
+6. Current surface capability: Butler, mac Codex, VPS Codex CLI, reviewer, or
+   fallback reviewer.
+
+If a source cannot be read, say `未確認` or the exact error. Do not replace it
+with a guess.
+
+## Required startup report
+
+Before handoff or implementation, summarize in Japanese:
+
+- target repository, Issue, PR, and branch, or `未確認`
+- current surface and its limits
+- runtime truth found
+- relevant RAG/checkpoint hits found or missing
+- thread-local assumptions that have been promoted into repo/RAG, or
+  `threadLocalAssumptionsPromoted=false`
+- expected files/routes/workflows and file/line hypotheses when known
+- cross-Issue or cross-surface risk
+- next safe action and stop condition
+
+This report is a guardrail. It is not completion evidence.
+
+## Shared behavior to preserve
+
+- Do not rely on one chat thread's habits as authority. If a behavior matters
+  after a thread switch, promote it into repo docs, Issue comments, or RAG.
+- When a reusable fact is discovered, offer a compact RAG candidate and wait for
+  `GO`. Store checkpoint/savepoint/current verification records as
+  `working_memory`. Use `decision_log` only for rationale-backed decisions.
+- RAG is shared memory for Butler, mac Codex, and VPS Codex CLI. It is not a
+  Butler-only notebook.
+- Unknowns and errors are first-class signals. Investigate them and preserve the
+  reason when useful; do not quickly map them to familiar patterns.
+- VTDD is iPhone/iPad-first. A Mac-dependent path is a fallback or maintenance
+  path, not the normal Butler completion path.
+- Butler -> VPS Codex CLI is the preferred always-on execution direction when a
+  task requires repo-backed natural-language development without the owner's Mac.
+- Actor identity matters. If a role app cannot post as itself, do not silently
+  substitute `marushu`; surface an owner-visible incident.
+- Close comments are optional when the merged PR, tests, E2E evidence, and RAG
+  record already preserve the reusable judgment. Do not add noisy closure
+  comments just to perform ritual bookkeeping.
+- Draft PRs or uncommitted work from another thread are runtime truth, not
+  instructions to overwrite. Detect them, report them, and reconcile before
+  continuing.
+
+## Completion boundary
+
+Adding or updating this contract does not complete Issue #344 by itself.
+Issue #344 remains incomplete until Butler, mac Codex, and VPS Codex CLI can
+show matching startup/preflight results with evidence.

--- a/docs/setup/custom-gpt-instructions-short-min.md
+++ b/docs/setup/custom-gpt-instructions-short-min.md
@@ -4,15 +4,16 @@ Role: minimal Custom GPT paste target.
 Truth and scope:
 - Issue is canonical spec. GitHub/runtime state is progress truth. Runtime truth > memory.
 - No existing Issue? propose the Issue first, wait GO, create it, then hand off. Never PR/build first; #303 is the regression example.
-- Before proposal/writes/handoff/PR judgment/stale setup claims: read runtime/GitHub truth + memory/constitution. Report found/missing. Never invent.
+- Before proposal/writes/handoff/PR judgment/stale setup claims: read runtime/GitHub truth + memory/constitution; report found/missing; never invent.
 - Reusable memory/RAG checkpoint: show candidate with known repo/Issue; recordType=working_memory; say unknown if missing; ask GO; vtddWriteOperationalMemory; verify vtddRetrieveOperationalMemory. decision_log only for rationale-backed decided judgments.
+- Thread startup: no chat-only habits; read startup contract/runtime/RAG; report promoted or 未確認.
 - No scope beyond user instruction + active Issue.
 - Do not assume a default repository. Resolve owner/repo from explicit input, alias, grant, verified context; ambiguous=>ask one short confirmation.
 - No internal API paths/raw JSON. Convert natural intent into actions.
 - vtddGateway/vtddExecute use surface=custom_gpt and judgmentModelId=vtdd-butler-core-v1.
 Repository and nickname:
 - Repo list/read: vtddGateway exploration/read_only.
-- vtddRetrieveGitHub: repos/issues/PRs/reviews/comments/checks/runs/jobs/branches/contents/tree. Actions failure: workflow_runs -> workflow_jobs(runId). Files/docs: contents/tree; cite path/htmlUrl. Pages: vtddRetrieveCloudflarePages.
+- vtddRetrieveGitHub: repos/issues/PRs/reviews/comments/checks/runs/jobs/branches/contents/tree. Actions failure: runs -> jobs(runId). Files/docs: contents/tree; cite path/htmlUrl. Pages: vtddRetrieveCloudflarePages.
 - Save/delete/list nicknames: vtddUpsertRepositoryNickname, vtddDeleteRepositoryNickname, vtddRetrieveRepositoryNicknames.
 - If request starts with a non-owner/repo token like `ぶい の...`, resolve nickname first.
 - Nickname memory is user-owned alias data, not default repo. Save owner/repo, not alias. Delete owner/repo + exact nickname.
@@ -46,7 +47,7 @@ GitHub write:
 - Before vtddWriteGitHub, show exact title/body/comment/update payload and wait for GO.
 - PR create/update: no freehand `--body`; use `scripts/prepare-pr-body-file.mjs` -> `--body-file`.
 - For implementation without an existing Issue, do issue_create first; only then do bounded Codex handoff.
-- Normal GO writes: show exact payload, ask only `GO`, call vtddWriteGitHub. Never ask targetConfirmed/approvalScopeMatched/approvalPhrase/policyInput/judgmentTrace/raw JSON.
+- Normal GO writes: show exact payload, ask only `GO`, call vtddWriteGitHub. Never ask targetConfirmed/approvalScopeMatched/approvalPhrase/raw JSON.
 - Write only when repo is resolved, scope traceable, and GO exists.
 - Never use vtddWriteGitHub for merge, issue close, deploy, secrets/settings/permissions, admin, or destructive cleanup.
 High-risk authority:

--- a/docs/setup/custom-gpt-instructions-short.md
+++ b/docs/setup/custom-gpt-instructions-short.md
@@ -2,8 +2,9 @@ Butler
 Core:
 - Issue is canonical spec.
 - No existing Issue: propose an Issue candidate first, wait for GO, create the Issue, then hand off. No PR/build first; #303 is the regression example.
-- Before proposal/write/handoff/PR judgment: vtddRetrieveCrossMemory + vtddRetrieveDecisionLogs/vtddRetrieveProposalLogs/vtddRetrieveConstitution + runtime truth; no RAG hit OK, never invent. Runtime truth > memory.
+- Before proposal/write/handoff/PR: vtddRetrieveCrossMemory + vtddRetrieveDecisionLogs/vtddRetrieveProposalLogs/vtddRetrieveConstitution + runtime; no RAG hit OK, never invent. Runtime truth > memory.
 - Reusable memory/RAG ckpt: show candidate with known repo/Issue; recordType=working_memory; say unknown if missing; ask GO; vtddWriteOperationalMemory; verify vtddRetrieveOperationalMemory. decision_log only for rationale-backed decided judgments.
+- Startup: no chat-only habits; read startup contract/runtime/RAG; report 未確認.
 - Do not assume a default repository. Resolve repo; ambiguous=>ask.
 - Natural to actions; no internal paths/raw JSON.
 - No scope beyond Issue/user instruction.

--- a/docs/setup/custom-gpt-instructions.md
+++ b/docs/setup/custom-gpt-instructions.md
@@ -28,7 +28,7 @@ Core operating rules:
   - retrieve decision/proposal logs when related Issue context exists
   - read GitHub runtime truth for current state
   - inspect PR/Issue comments for VTDD incident markers such as `vtdd:incident=actor_identity_failure`; treat them as recovery blockers until explained
-  - read canonical docs/setup artifacts when surface drift or VTDD doctrine matters
+  - read canonical docs/setup artifacts and `docs/butler/thread-independent-startup-contract.md` when surface drift, thread switch, handoff, or VTDD doctrine matters
   - report what was found and what was not found before proposing the next payload
 - RAG/memory can recover prior success patterns, failure patterns, and judgment rationale, but current state is governed by GitHub runtime truth.
 - If no relevant RAG/memory hit is found, say so plainly; do not invent past precedent.
@@ -136,12 +136,14 @@ VTDD context preflight / RAG:
 - Include file/line hypotheses when known. If the likely files are unknown, say unknown and investigate repo/docs/runtime truth instead of mapping the work to a familiar pattern by assumption.
 - If the dry-run finds a separable prerequisite, missing capability, ambiguous authority boundary, or likely cross-surface breakage, stop before handoff and propose the prerequisite Issue/comment rather than asking Codex to code through it.
 - Treat the dry-run report as shared startup context for Butler, mac Codex, and VPS Codex CLI. The report is not completion evidence; it is a guardrail that must be reflected in PR body `Dry-run Impact Report`, `File / Line Hypotheses`, and `Hypothesis Retrospective`.
+- Do not rely on this chat thread's implicit habits as authority. If a behavior must survive a new thread or context compression, make it durable through repo docs, Issue comments, or RAG; otherwise report `threadLocalAssumptionsPromoted=false` or `未確認`.
 - At startup, distinguish the execution surfaces before proposing development work:
   - Butler on iPhone/iPad must not assume the owner's Mac is awake, reachable, or available.
   - ChatGPT iPhone Codex cloud tasks can run in OpenAI-managed cloud environments when the repository connector/environment is available; do not describe that as operating the local Mac Codex.
   - mac Codex can read the local checkout and local credentials, but it is Mac-dependent and should not be the steady-state iPhone recovery path.
   - VPS Codex CLI / runner is the owner-controlled always-on fallback candidate for terminal-like execution, review fallback, and repo-backed automation.
   - If a task requires local Mac-only files, local desktop state, local browser state, or unexported local credentials, say `Mac dependency detected` and propose the next repo/runtime/VPS-safe alternative instead of silently requiring the Mac.
+- Treat Butler -> VPS Codex CLI as the preferred always-on direction for repo-backed natural-language development when the owner is on iPhone/iPad and the Mac is unavailable.
 - When a reusable decision, blocker, failure pattern, repair, or handoff fact emerges, show a compact structured memory candidate, ask the human for GO, then call vtddWriteOperationalMemory. Do not store full transcripts, secrets, or raw sensitive material.
 - Use `recordType=decision_log` only for a decided judgment that includes an explicit rationale. If the user asks for a RAG checkpoint, savepoint, current verification result, handoff return point, or context-compression guard, use `recordType=working_memory` instead.
 - Treat a RAG checkpoint as a memory savepoint. Offer one when context compression risk appears, the owner is about to leave/sleep/bathe/travel, a strong owner tension appears, a dry-run hypothesis/expected file set appears, an error deserves observation before repair, or a large docs/PR/log investigation begins or ends.
@@ -152,6 +154,7 @@ VTDD context preflight / RAG:
 - Mark checkpoint `contextSourceQuality=compressed_context` or `missing_context_risk` when the source thread has already been compressed or evidence is incomplete.
 - After vtddWriteOperationalMemory succeeds, retrieve the related memory again and report the record id. If it fails, report the exact error/reason/issues.
 - Do not ask the human to name these internal retrieval routes in normal conversation.
+- When a merged PR, tests, E2E evidence, and RAG record already preserve the reusable judgment, do not add noisy closure comments by default; preserve only comments that add owner-facing recovery value.
 
 Repository nickname memory:
 - Use vtddUpsertRepositoryNickname when the user says things like:

--- a/scripts/run-vps-runner.mjs
+++ b/scripts/run-vps-runner.mjs
@@ -866,7 +866,14 @@ function normalizeVpsRunnerPreflightPolicy(value = {}) {
     requiredRepoFiles:
       requiredRepoFiles.length > 0
         ? requiredRepoFiles
-        : ["AGENTS.md", "docs/pr-template-model.md", "scripts/prepare-pr-body-file.mjs", "scripts/render-pr-body.mjs", "scripts/validate-pr-body.mjs"]
+        : [
+            "AGENTS.md",
+            "docs/butler/thread-independent-startup-contract.md",
+            "docs/pr-template-model.md",
+            "scripts/prepare-pr-body-file.mjs",
+            "scripts/render-pr-body.mjs",
+            "scripts/validate-pr-body.mjs"
+          ]
   };
 }
 

--- a/test/thread-independent-startup-contract.test.js
+++ b/test/thread-independent-startup-contract.test.js
@@ -1,0 +1,38 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const CONTRACT_PATH = "docs/butler/thread-independent-startup-contract.md";
+
+test("thread-independent startup contract captures cross-surface drift guardrails", () => {
+  const doc = fs.readFileSync(CONTRACT_PATH, "utf8");
+
+  assert.equal(doc.includes("Issue: #344"), true);
+  assert.equal(doc.includes("without depending on the memory of one chat thread"), true);
+  assert.equal(doc.includes("threadLocalAssumptionsPromoted=false"), true);
+  assert.equal(doc.includes("Butler, mac Codex, and VPS Codex CLI"), true);
+  assert.equal(doc.includes("Store checkpoint/savepoint/current verification records as"), true);
+  assert.equal(doc.includes("`working_memory`"), true);
+  assert.equal(doc.includes("Use `decision_log` only for rationale-backed decisions"), true);
+  assert.equal(doc.includes("VTDD is iPhone/iPad-first"), true);
+  assert.equal(doc.includes("Butler -> VPS Codex CLI"), true);
+  assert.equal(doc.includes("do not silently"), true);
+  assert.equal(doc.includes("Close comments are optional"), true);
+  assert.equal(doc.includes("does not complete Issue #344 by itself"), true);
+});
+
+test("AGENTS and Butler setup docs reference the thread-independent startup contract", () => {
+  const agents = fs.readFileSync("AGENTS.md", "utf8");
+  const instructions = fs.readFileSync("docs/setup/custom-gpt-instructions.md", "utf8");
+  const short = fs.readFileSync("docs/setup/custom-gpt-instructions-short.md", "utf8");
+  const shortMin = fs.readFileSync("docs/setup/custom-gpt-instructions-short-min.md", "utf8");
+
+  assert.equal(agents.includes(CONTRACT_PATH), true);
+  assert.equal(agents.includes("threadLocalAssumptionsPromoted=false"), true);
+  assert.equal(instructions.includes(CONTRACT_PATH), true);
+  assert.equal(instructions.includes("threadLocalAssumptionsPromoted=false"), true);
+  assert.equal(instructions.includes("Butler -> VPS Codex CLI"), true);
+  assert.equal(instructions.includes("do not add noisy closure comments by default"), true);
+  assert.equal(short.includes("Startup: no chat-only habits"), true);
+  assert.equal(shortMin.includes("Thread startup: no chat-only habits"), true);
+});

--- a/test/vps-runner-script.test.js
+++ b/test/vps-runner-script.test.js
@@ -1251,6 +1251,51 @@ test("VPS runner builds preflight receipt from canonical repo files", async () =
   assert.equal(payload.preflightReceipt.handoffNote.issueNumber, 307);
 });
 
+test("VPS runner default preflight reads the thread-independent startup contract", async () => {
+  const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "vtdd-preflight-default-"));
+  await fs.writeFile(path.join(tempRoot, "AGENTS.md"), "Thread-Independent Startup Contract\n");
+  await fs.mkdir(path.join(tempRoot, "docs", "butler"), { recursive: true });
+  await fs.mkdir(path.join(tempRoot, "scripts"), { recursive: true });
+  await fs.writeFile(
+    path.join(tempRoot, "docs", "butler", "thread-independent-startup-contract.md"),
+    "threadLocalAssumptionsPromoted=false\n"
+  );
+  await fs.writeFile(path.join(tempRoot, "docs", "pr-template-model.md"), "PR template contract\n");
+  await fs.writeFile(path.join(tempRoot, "scripts", "prepare-pr-body-file.mjs"), "prepare\n");
+  await fs.writeFile(path.join(tempRoot, "scripts", "render-pr-body.mjs"), "render\n");
+  await fs.writeFile(path.join(tempRoot, "scripts", "validate-pr-body.mjs"), "validate\n");
+
+  const payload = {
+    repository: "sample-org/vtdd-v2",
+    issueNumber: 344,
+    codexGoal: "open_pr"
+  };
+
+  const receipt = await buildVpsRunnerPreflightReceipt({
+    workspace: tempRoot,
+    payload,
+    issue: {
+      number: 344,
+      title: "共通起動前確認",
+      body: "Butler / mac Codex / VPS Codex CLI で同じ startup preflight を返す"
+    }
+  });
+
+  assert.equal(receipt.ok, true);
+  assert.equal(
+    receipt.artifacts.some(
+      (artifact) => artifact.path === "docs/butler/thread-independent-startup-contract.md"
+    ),
+    true
+  );
+  assert.equal(
+    payload.preflightReceipt.artifacts.some((artifact) =>
+      artifact.excerpt.includes("threadLocalAssumptionsPromoted=false")
+    ),
+    true
+  );
+});
+
 test("VPS runner preflight receipt requires owner decision when required files are missing", async () => {
   const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "vtdd-preflight-missing-"));
   await fs.writeFile(path.join(tempRoot, "AGENTS.md"), "Do not silently downscope active Issues.\n");


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #344 の共通起動前確認について、このスレッド固有だった運用を repo 上の startup contract に昇格し、Butler / mac Codex / VPS Codex CLI が同じ前提を読めるようにする部分進捗です。

## Satisfied Success Criteria

- 共通 startup contract を docs/butler/thread-independent-startup-contract.md として追加しました。
AGENTS.md と Butler setup instructions から contract を参照するようにしました。
VPS runner の既定 preflight required files に startup contract を追加しました。

## Unsatisfied Success Criteria

- Butler / mac Codex / VPS Codex CLI の 3 surface が同一 preflight 結果を返す live E2E は未実施です。
新しい Action Schema operationId や runtime route はこのPRでは追加していません。
Issue #344 全体はまだ close-ready ではありません。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #344
- Implementing Success Criteria: 共通 startup preflight contract、source order、thread-local assumption の durable 化、VPS runner preflight からの contract 読み込み。
- Explicit Non-goals: runtime route 追加、Action Schema 追加、Cloudflare deploy、Custom GPT editor 更新、旧 draft PR #348 の流用、Issue #344 close。
- Expected touched files/routes/workflows: AGENTS.md; docs/butler/thread-independent-startup-contract.md; docs/setup/custom-gpt-instructions*.md; scripts/run-vps-runner.mjs; test/thread-independent-startup-contract.test.js; test/vps-runner-script.test.js
- Affected Issues: Issue #344。関連する Issue #341/Issue #343/Issue #356/Issue #360 は参照対象だが、このPRでは実装しない。
- Affected PRs: 旧 draft PR #348 は触らない。
- Affected workflows: GitHub Actions の通常 test。VPS runner preflight prompt の required artifact が1つ増える。
- Affected runtime/operator surfaces: Butler Instructions、mac Codex AGENTS.md、VPS Codex CLI runner preflight。Custom GPT Action Schema と Worker runtime route は未変更。
- What may break if we patch narrowly: Instructions だけに書くと mac/VPS が読まず、AGENTS.md だけに書くと Butler が読まない。runner preflight に含めないと VPS 側で別スレッドの drift を再発する。
- Unknowns to investigate before coding: 3 surface live preflight の完全一致は未検証。Butler が実際に contract doc を GitHub read plane から読む E2E は後続。
- Validation needed: node --test test/thread-independent-startup-contract.test.js; node --test test/custom-gpt-setup-docs.test.js; node --test test/vps-runner-script.test.js; npm test
- Stop condition: runtime route や Action Schema が必要になった場合は、このPRで押し込まず後続 Issue/PR に分ける。

## File / Line Hypotheses

- file: AGENTS.md
  - hypothesis: mac Codex の起動時ルールに thread-independent startup contract 参照を足す必要がある。
  - risk if changed narrowly: Butler/VPS だけが知る規則になり surface drift が残る。
  - validation: test/thread-independent-startup-contract.test.js。
  - related Issue: Issue #344
- file: docs/setup/custom-gpt-instructions.md
  - hypothesis: Butler が thread switch / handoff 時に contract と RAG を読む明示ルールが必要。
  - risk if changed narrowly: Custom GPT がこのスレッドの暗黙前提を復元できない。
  - validation: test/custom-gpt-setup-docs.test.js。
  - related Issue: Issue #344
- file: scripts/run-vps-runner.mjs
  - hypothesis: VPS runner preflight の既定 requiredRepoFiles に contract doc を追加する必要がある。
  - risk if changed narrowly: VPS Codex CLI が古い AGENTS.md だけで開始し、Butler と判断がズレる。
  - validation: test/vps-runner-script.test.js。
  - related Issue: Issue #344

## Hypothesis Retrospective

- expected: 既存規則を壊さず、共通 contract doc を追加して 3 surface から参照させる。
- actual: 新規 contract doc、AGENTS.md、Butler setup docs、VPS runner default preflight、tests を追加/更新した。
- mismatch: runtime route / Action Schema までは触らない判断にしたため、Issue #344 全体は未完了。
- lesson: スレッド固有の運用は、RAG だけでなく repo contract と runner preflight に固定しないと再発する。
- should become RAG candidate: はい。Issue #344 の startup contract 部分進捗として候補。

## Verification Evidence

- Unit: node --test test/thread-independent-startup-contract.test.js; node --test test/custom-gpt-setup-docs.test.js; node --test test/vps-runner-script.test.js
- Integration: npm test
- E2E: 未実施。3 surface live startup preflight 一致は Issue #344 の残作業。
- Manual: 未実施。
- Evidence path/link: docs/butler/thread-independent-startup-contract.md; test/thread-independent-startup-contract.test.js; test/vps-runner-script.test.js

## Butler Completion Contract

- Owner goal: スレッドが変わっても Butler / mac Codex / VPS Codex CLI の VTDD 挙動がズレないよう、起動時に読む共通前提を repo に固定する。
- Butler entrypoint: 既存 Butler Instructions の VTDD context preflight。新規 Action は未追加。
- Action Schema exposure: 不要。このPRは既存 retrieve/read/handoff ルールの docs/preflight contract 更新のみ。
- Runtime path: VPS runner は scripts/run-vps-runner.mjs の default requiredRepoFiles で contract doc を読む。Butler は setup instructions から GitHub read plane で contract doc を読む前提。
- Runner/runtime truth: npm test により docs/tests/runner preflight の静的接続を確認。live Butler/VPS runtime truth は未確認。
- Authority boundary: 未変更。deploy/secrets/merge/close は行わない。
- E2E evidence: 未実施。このPRは contract 接続までで、Issue #344 全体の Butler-facing E2E は後続。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 不要。src/worker.js/Action Schema は未変更。
- Custom GPT Action Schema update: 不要。OpenAPI は未変更。
- Custom GPT Instructions update: 必要。Custom GPT editor へ反映する場合は /setup/latest の Instructions 更新が必要。
- iPhone Butler live E2E: 未実施。

## Related Constitution Rules

- Issue-first / drift stop / evidence discipline / Butler completion gate / RAG memory capture boundary

## Out-of-scope but NOT implemented

- runtime route 追加; Action Schema operationId 追加; 旧 draft PR #348 の採用; Issue #344 close; deploy

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #344
- Execution ID: Not provided.
- Goal: Not provided.
