### PR TITLE
fix: RSA形式のGitHub App keyでfallback reviewer tokenをmintする

### DIFF
--- a/src/core/github-app-repository-index.js
+++ b/src/core/github-app-repository-index.js
@@ -612,11 +612,90 @@ function normalizeGitHubAppPrivateKeyValue(value) {
 
 function decodePemPrivateKey(value) {
   const pem = normalizeText(value);
+  const isPkcs1RsaPrivateKey = pem.includes("-----BEGIN RSA PRIVATE KEY-----");
   const body = pem
     .replaceAll("-----BEGIN PRIVATE KEY-----", "")
     .replaceAll("-----END PRIVATE KEY-----", "")
+    .replaceAll("-----BEGIN RSA PRIVATE KEY-----", "")
+    .replaceAll("-----END RSA PRIVATE KEY-----", "")
     .replace(/\s+/g, "");
-  return decodeBase64ToBytes(body);
+  const keyBytes = decodeBase64ToBytes(body);
+  if (isPkcs1RsaPrivateKey) {
+    return wrapPkcs1RsaPrivateKeyAsPkcs8(keyBytes);
+  }
+  return keyBytes;
+}
+
+function wrapPkcs1RsaPrivateKeyAsPkcs8(pkcs1Bytes) {
+  return asn1Sequence([
+    asn1IntegerZero(),
+    asn1Sequence([
+      asn1ObjectIdentifier([1, 2, 840, 113549, 1, 1, 1]),
+      new Uint8Array([0x05, 0x00])
+    ]),
+    asn1OctetString(pkcs1Bytes)
+  ]);
+}
+
+function asn1IntegerZero() {
+  return new Uint8Array([0x02, 0x01, 0x00]);
+}
+
+function asn1Sequence(parts) {
+  return asn1Tlv(0x30, concatBytes(parts));
+}
+
+function asn1OctetString(bytes) {
+  return asn1Tlv(0x04, bytes);
+}
+
+function asn1ObjectIdentifier(parts) {
+  if (!Array.isArray(parts) || parts.length < 2) {
+    return asn1Tlv(0x06, new Uint8Array());
+  }
+  const encoded = [parts[0] * 40 + parts[1]];
+  for (const part of parts.slice(2)) {
+    encoded.push(...encodeBase128Integer(part));
+  }
+  return asn1Tlv(0x06, new Uint8Array(encoded));
+}
+
+function asn1Tlv(tag, value) {
+  return concatBytes([new Uint8Array([tag]), encodeAsn1Length(value.length), value]);
+}
+
+function encodeAsn1Length(length) {
+  if (length < 0x80) {
+    return new Uint8Array([length]);
+  }
+  const bytes = [];
+  let remaining = length;
+  while (remaining > 0) {
+    bytes.unshift(remaining & 0xff);
+    remaining >>= 8;
+  }
+  return new Uint8Array([0x80 | bytes.length, ...bytes]);
+}
+
+function encodeBase128Integer(value) {
+  const bytes = [value & 0x7f];
+  let remaining = value >> 7;
+  while (remaining > 0) {
+    bytes.unshift(0x80 | (remaining & 0x7f));
+    remaining >>= 7;
+  }
+  return bytes;
+}
+
+function concatBytes(parts) {
+  const totalLength = parts.reduce((sum, part) => sum + part.length, 0);
+  const result = new Uint8Array(totalLength);
+  let offset = 0;
+  for (const part of parts) {
+    result.set(part, offset);
+    offset += part.length;
+  }
+  return result;
 }
 
 function encodeJwtPart(payload) {

--- a/test/github-app-repository-index.test.js
+++ b/test/github-app-repository-index.test.js
@@ -353,6 +353,60 @@ test("github app index normalizes escaped private key newlines before jwt provid
   assert.equal(seenKey, "normalized");
 });
 
+test("github app index can mint installation token from PKCS#1 RSA private key", async () => {
+  const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+  const pkcs1Pem = privateKey.export({ type: "pkcs1", format: "pem" });
+  const calls = [];
+
+  const result = await resolveGatewayAliasRegistryFromGitHubApp({
+    policyInput: { aliasRegistry: [] },
+    env: {
+      GITHUB_APP_ID: "24680",
+      GITHUB_APP_INSTALLATION_ID: "13579",
+      GITHUB_APP_PRIVATE_KEY: pkcs1Pem,
+      GITHUB_API_FETCH: async (url, init = {}) => {
+        calls.push({ url, init });
+        if (String(url).includes("/app/installations/13579/access_tokens")) {
+          const authHeader = String(init?.headers?.authorization ?? "");
+          assert.equal(authHeader.startsWith("Bearer "), true);
+          return new Response(
+            JSON.stringify({
+              token: "ghs_minted_installation_token",
+              expires_at: "2030-01-01T00:00:00Z"
+            }),
+            {
+              status: 201,
+              headers: { "content-type": "application/json" }
+            }
+          );
+        }
+        return new Response(
+          JSON.stringify({
+            total_count: 1,
+            repositories: [
+              {
+                full_name: "sample-org/vtdd-v2",
+                name: "vtdd-v2",
+                private: true
+              }
+            ]
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" }
+          }
+        );
+      }
+    }
+  });
+
+  assert.equal(result.source, "github_app_live");
+  assert.equal(result.warnings.length, 0);
+  assert.equal(calls.length, 2);
+  assert.equal(calls[0].url.includes("/app/installations/13579/access_tokens"), true);
+  assert.equal(calls[1].url.includes("/installation/repositories"), true);
+});
+
 test("github app index can enforce minted-token mode and block static token fallback", async () => {
   const result = await resolveGatewayAliasRegistryFromGitHubApp({
     policyInput: {

--- a/worker.js
+++ b/worker.js
@@ -29277,8 +29277,76 @@ function normalizeGitHubAppPrivateKeyValue(value) {
 }
 function decodePemPrivateKey(value) {
   const pem = normalizeText7(value);
-  const body = pem.replaceAll("-----BEGIN PRIVATE KEY-----", "").replaceAll("-----END PRIVATE KEY-----", "").replace(/\s+/g, "");
-  return decodeBase64ToBytes(body);
+  const isPkcs1RsaPrivateKey = pem.includes("-----BEGIN RSA PRIVATE KEY-----");
+  const body = pem.replaceAll("-----BEGIN PRIVATE KEY-----", "").replaceAll("-----END PRIVATE KEY-----", "").replaceAll("-----BEGIN RSA PRIVATE KEY-----", "").replaceAll("-----END RSA PRIVATE KEY-----", "").replace(/\s+/g, "");
+  const keyBytes = decodeBase64ToBytes(body);
+  if (isPkcs1RsaPrivateKey) {
+    return wrapPkcs1RsaPrivateKeyAsPkcs8(keyBytes);
+  }
+  return keyBytes;
+}
+function wrapPkcs1RsaPrivateKeyAsPkcs8(pkcs1Bytes) {
+  return asn1Sequence([
+    asn1IntegerZero(),
+    asn1Sequence([
+      asn1ObjectIdentifier([1, 2, 840, 113549, 1, 1, 1]),
+      new Uint8Array([5, 0])
+    ]),
+    asn1OctetString(pkcs1Bytes)
+  ]);
+}
+function asn1IntegerZero() {
+  return new Uint8Array([2, 1, 0]);
+}
+function asn1Sequence(parts) {
+  return asn1Tlv(48, concatBytes(parts));
+}
+function asn1OctetString(bytes) {
+  return asn1Tlv(4, bytes);
+}
+function asn1ObjectIdentifier(parts) {
+  if (!Array.isArray(parts) || parts.length < 2) {
+    return asn1Tlv(6, new Uint8Array());
+  }
+  const encoded = [parts[0] * 40 + parts[1]];
+  for (const part of parts.slice(2)) {
+    encoded.push(...encodeBase128Integer(part));
+  }
+  return asn1Tlv(6, new Uint8Array(encoded));
+}
+function asn1Tlv(tag, value) {
+  return concatBytes([new Uint8Array([tag]), encodeAsn1Length(value.length), value]);
+}
+function encodeAsn1Length(length) {
+  if (length < 128) {
+    return new Uint8Array([length]);
+  }
+  const bytes = [];
+  let remaining = length;
+  while (remaining > 0) {
+    bytes.unshift(remaining & 255);
+    remaining >>= 8;
+  }
+  return new Uint8Array([128 | bytes.length, ...bytes]);
+}
+function encodeBase128Integer(value) {
+  const bytes = [value & 127];
+  let remaining = value >> 7;
+  while (remaining > 0) {
+    bytes.unshift(128 | remaining & 127);
+    remaining >>= 7;
+  }
+  return bytes;
+}
+function concatBytes(parts) {
+  const totalLength = parts.reduce((sum, part) => sum + part.length, 0);
+  const result = new Uint8Array(totalLength);
+  let offset = 0;
+  for (const part of parts) {
+    result.set(part, offset);
+    offset += part.length;
+  }
+  return result;
 }
 function encodeJwtPart(payload) {
   const json2 = JSON.stringify(payload);


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #393 のうち、GitHub App private key が PKCS#1 RSA PRIVATE KEY 形式だった場合に JWT 署名できず Codex fallback reviewer が止まる問題を解消する。\n- PR #392 後続の実測で、PKCS#8 変換すれば token mint が通ることを確認したため、runtime 側で同等の変換を行う。

## Satisfied Success Criteria

- RSA PRIVATE KEY 形式の GitHub App private key でも installation token を mint できる。\n- src/core を変更したため worker.js を再生成済み。\n- marushu 代替投稿禁止や actor identity incident の既存挙動は変更していない。

## Unsatisfied Success Criteria

- VPS runner 常駐環境へ credential を永続配置する bootstrap は未実装。\n- VPS runner が実際に常駐状態で requested から completed へ進む live E2E は未実施。\n- GitHub App credential 未設定時の通知経路は既存 incident に依存しており、VPS Codex CLI App token も無い場合の外部通知は未解決。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #393
- Implementing Success Criteria: RSA PRIVATE KEY と PRIVATE KEY のどちらかを受け取っても署名できる、のうち RSA PRIVATE KEY 形式を runtime 側で許容する部分。
- Explicit Non-goals: GitHub App 新規作成、権限変更、VPS への secret 永続配置、Gemini reviewer 全体復旧、PR #392 の実装変更。
- Expected touched files/routes/workflows: src/core/github-app-repository-index.js, test/github-app-repository-index.test.js, worker.js
- Affected Issues: Issue #393, Issue #351, Issue #366
- Affected PRs: PR #392 の後続。
- Affected workflows: VPS runner fallback reviewer、GitHub App installation token mint、Worker bundle の GitHub App token resolution。
- Affected runtime/operator surfaces: mac Codex, VPS Codex CLI, Worker runtime。Butler Action Schema / Instructions は変更なし。
- What may break if we patch narrowly: 鍵形式だけ直しても、VPS runner の credential 未設定は残る。PR は #393 完了ではなく部分進捗として扱う。
- Unknowns to investigate before coding: VPS への role App credential 永続配置をどの bootstrap/approval 経路で扱うかは未決。
- Validation needed: 該当 unit、VPS runner script test、実 GitHub App RSA key で tokenAvailable=true、npm test。
- Stop condition: credential 永続配置や権限変更が必要になった場合は GO + passkey が必要なため、この PR では進めない。

## File / Line Hypotheses

- file: src/core/github-app-repository-index.js\n  - hypothesis: decodePemPrivateKey が BEGIN PRIVATE KEY だけを取り除き、BEGIN RSA PRIVATE KEY の PKCS#1 DER を WebCrypto pkcs8 import に渡して失敗している。\n  - risk if changed narrowly: JWT signing 以外の GitHub App token mint 全体に影響するため、既存 PKCS#8 と escaped newline のテストを壊さない必要がある。\n  - validation: PKCS#1 RSA key で installation token mint mock が通る unit を追加する。\n  - related Issue: Issue #393

## Hypothesis Retrospective

- expected: PKCS#1 RSA key を PKCS#8 wrapper に包めば WebCrypto の pkcs8 import が通る。\n- actual: 追加 unit と実 fallback reviewer App key の token mint 確認で通った。\n- mismatch: VPS credential 未設定は別問題として残った。\n- lesson: reviewer が止まった時は credential 有無と key 形式を分けて見る必要がある。\n- should become RAG candidate: はい。PR #392 後続の fallback reviewer 復旧知見として候補。

## Verification Evidence

- Unit: node --test test/github-app-repository-index.test.js; node --test test/vps-runner-script.test.js
- Integration: 実 fallback reviewer App の RSA PRIVATE KEY をそのまま渡し、resolveGitHubAppInstallationToken が tokenAvailable=true を返すことを確認。token 値は出力していない。
- E2E: npm test。live VPS 常駐 runner E2E は credential 永続配置が未解決のため未実施。
- Manual: PR #392 で起きた失敗原因を再確認し、PKCS#8 手動変換なしで実 key が通ることを確認。
- Evidence path/link: Issue #393 / この PR の Verification Evidence

## Butler Completion Contract

- Owner goal: Butler / VPS Codex CLI 開発で Codex fallback reviewer が鍵形式差分で止まらないようにする。
- Butler entrypoint: 未変更。Butler からは reviewer requested/completed/incident を GitHub runtime truth として読む。
- Action Schema exposure: 不要。Action Schema の operationId は変更していない。
- Runtime path: resolveGitHubAppInstallationToken -> signGitHubAppJwt -> GitHub installation access token mint。
- Runner/runtime truth: RSA key 形式の実 key で tokenAvailable=true。npm test passed。
- Authority boundary: 未変更。credential mutation / deploy / permission mutation は実施していない。
- E2E evidence: 未完了。#393 全体では VPS 常駐 runner の live E2E が残る。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 必要。src/core と worker.js を変更したため、マージ後に runtime 反映が必要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。#393 全体の後続で確認する。

## Related Constitution Rules

- Issue traceability: Issue #393\n- GitHub App actor identity を marushu 代替投稿に落とさない\n- src/* 変更時は worker.js を再生成する\n- 秘密情報をログ/Issue/PR/RAG に保存しない

## Out-of-scope but NOT implemented

- VPS runner credential 永続配置\n- GitHub App 権限変更\n- Gemini reviewer 復旧全体\n- Issue #393 の close 判断

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #393
- Execution ID: Not provided.
- Goal: Not provided.
