### PR TITLE
feat: VPS runner が role App credential を vault から読む

### DIFF
--- a/docs/setup/desktop-bootstrap-vault.md
+++ b/docs/setup/desktop-bootstrap-vault.md
@@ -66,6 +66,9 @@ Recommended layout:
     manifest.json
     github-app/
       private-key.pem
+    github-apps/
+      codex-fallback-reviewer.pem
+      vps-codex-cli.pem
     cloudflare/
       api-token.txt
     gateway/
@@ -87,6 +90,18 @@ Example:
     "appId": "3467409",
     "installationId": "126180737",
     "privateKeyPath": "github-app/private-key.pem"
+  },
+  "githubAppRoles": {
+    "codex-fallback-reviewer": {
+      "appId": "3706921",
+      "installationId": "132169447",
+      "privateKeyPath": "github-apps/codex-fallback-reviewer.pem"
+    },
+    "vps-codex-cli": {
+      "appId": "your-vps-codex-cli-app-id",
+      "installationId": "your-vps-codex-cli-installation-id",
+      "privateKeyPath": "github-apps/vps-codex-cli.pem"
+    }
   },
   "cloudflare": {
     "accountId": "your-cloudflare-account-id",
@@ -111,6 +126,10 @@ At minimum, the vault contract covers:
   - `appId`
   - `installationId`
   - private key path
+- role-specific GitHub App material for local/VPS repair paths
+  - `githubAppRoles.codex-fallback-reviewer`
+  - `githubAppRoles.vps-codex-cli`
+  - each role stores `appId`, `installationId`, and a private key path
 - Cloudflare root material
   - `accountId`
   - API token path

--- a/scripts/run-vps-runner.mjs
+++ b/scripts/run-vps-runner.mjs
@@ -12,6 +12,7 @@ import {
   parseCodexReviewFallbackComment,
   resolveGitHubAppInstallationToken
 } from "../src/core/index.js";
+import { loadGitHubAppRoleCredentialsFromVault } from "../src/core/desktop-bootstrap-vault.js";
 import { buildExecutionLeadTime } from "../src/core/execution-lead-time.js";
 import { prepareGuardedPullRequestBody, prepareGuardedPullRequestBodyFile } from "./prepare-pr-body-file.mjs";
 import { renderPrBody } from "./render-pr-body.mjs";
@@ -26,6 +27,7 @@ const VTDD_INCIDENT_ACTOR_IDENTITY_FAILURE_MARKER = "<!-- vtdd:incident=actor_id
 const ROLE_GITHUB_APP_ENV = {
   codex_fallback_reviewer: {
     label: "VTDD Codex Fallback Reviewer",
+    vaultRole: "codex-fallback-reviewer",
     appId: "VTDD_CODEX_FALLBACK_REVIEWER_APP_ID",
     privateKey: "VTDD_CODEX_FALLBACK_REVIEWER_APP_PRIVATE_KEY",
     privateKeyBase64: "VTDD_CODEX_FALLBACK_REVIEWER_APP_PRIVATE_KEY_BASE64",
@@ -33,6 +35,7 @@ const ROLE_GITHUB_APP_ENV = {
   },
   vps_codex_cli: {
     label: "VTDD VPS Codex CLI",
+    vaultRole: "vps-codex-cli",
     appId: "VTDD_VPS_CODEX_CLI_APP_ID",
     privateKey: "VTDD_VPS_CODEX_CLI_APP_PRIVATE_KEY",
     privateKeyBase64: "VTDD_VPS_CODEX_CLI_APP_PRIVATE_KEY_BASE64",
@@ -1297,7 +1300,8 @@ async function resolveRoleGitHubAppInstallationToken({ role, env = process.env, 
       reason: `unknown GitHub App role: ${role}`
     };
   }
-  const roleEnv = buildRoleGitHubAppInstallationTokenEnv({ env, names });
+  const roleEnvResult = await buildRoleGitHubAppInstallationTokenEnv({ env, names });
+  const roleEnv = roleEnvResult.env;
   const missing = [
     ["app id", roleEnv.GITHUB_APP_ID],
     ["private key", roleEnv.GITHUB_APP_PRIVATE_KEY || roleEnv.GITHUB_APP_PRIVATE_KEY_BASE64],
@@ -1306,9 +1310,12 @@ async function resolveRoleGitHubAppInstallationToken({ role, env = process.env, 
     .filter(([, value]) => !normalizeText(value))
     .map(([label]) => label);
   if (missing.length > 0) {
+    const vaultReason = normalizeText(roleEnvResult.vaultIssues?.join("; "));
     return {
       ok: false,
-      reason: `${names.label} GitHub App token unavailable: missing ${missing.join(", ")}`
+      reason: `${names.label} GitHub App token unavailable: missing ${missing.join(", ")}${
+        vaultReason ? `; vault: ${vaultReason}` : ""
+      }`
     };
   }
 
@@ -1328,13 +1335,39 @@ async function resolveRoleGitHubAppInstallationToken({ role, env = process.env, 
   };
 }
 
-function buildRoleGitHubAppInstallationTokenEnv({ env = process.env, names }) {
-  return {
+async function buildRoleGitHubAppInstallationTokenEnv({ env = process.env, names }) {
+  const roleEnv = {
     ...env,
     GITHUB_APP_ID: env[names.appId],
     GITHUB_APP_PRIVATE_KEY: env[names.privateKey],
     GITHUB_APP_PRIVATE_KEY_BASE64: env[names.privateKeyBase64],
     GITHUB_APP_INSTALLATION_ID: env[names.installationId]
+  };
+  if (
+    normalizeText(roleEnv.GITHUB_APP_ID) &&
+    (normalizeText(roleEnv.GITHUB_APP_PRIVATE_KEY) || normalizeText(roleEnv.GITHUB_APP_PRIVATE_KEY_BASE64)) &&
+    normalizeText(roleEnv.GITHUB_APP_INSTALLATION_ID)
+  ) {
+    return { env: roleEnv, vaultIssues: [] };
+  }
+
+  const vaultResult = await loadGitHubAppRoleCredentialsFromVault({
+    role: names.vaultRole,
+    manifestPath: env.VTDD_VPS_RUNNER_CREDENTIALS_MANIFEST || env.VTDD_CREDENTIALS_MANIFEST
+  });
+  if (!vaultResult.ok) {
+    return { env: roleEnv, vaultIssues: vaultResult.issues || [] };
+  }
+
+  return {
+    env: {
+      ...roleEnv,
+      GITHUB_APP_ID: roleEnv.GITHUB_APP_ID || vaultResult.credentials.appId,
+      GITHUB_APP_PRIVATE_KEY: roleEnv.GITHUB_APP_PRIVATE_KEY || vaultResult.credentials.privateKey,
+      GITHUB_APP_INSTALLATION_ID:
+        roleEnv.GITHUB_APP_INSTALLATION_ID || vaultResult.credentials.installationId
+    },
+    vaultIssues: []
   };
 }
 

--- a/src/core/desktop-bootstrap-vault.js
+++ b/src/core/desktop-bootstrap-vault.js
@@ -154,6 +154,82 @@ export async function loadGatewayBearerTokenFromVault(input = {}) {
   };
 }
 
+export async function loadGitHubAppRoleCredentialsFromVault(input = {}) {
+  const manifestPath = normalizeText(input.manifestPath) || DEFAULT_VTDD_VAULT_MANIFEST_PATH;
+  const manifestDir = path.dirname(manifestPath);
+  const role = normalizeText(input.role);
+
+  if (!role) {
+    return {
+      ok: false,
+      issues: ["github app role is required in desktop bootstrap vault lookup"]
+    };
+  }
+
+  let manifest;
+  try {
+    const content = await fs.readFile(manifestPath, "utf8");
+    manifest = JSON.parse(content);
+  } catch (error) {
+    return {
+      ok: false,
+      issues: [
+        error?.code === "ENOENT"
+          ? `desktop bootstrap vault manifest not found: ${manifestPath}`
+          : `desktop bootstrap vault manifest is unreadable: ${manifestPath}`
+      ]
+    };
+  }
+
+  if (Number(manifest?.version) !== 1) {
+    return {
+      ok: false,
+      issues: ["desktop bootstrap vault manifest version must be 1"]
+    };
+  }
+
+  const roleRecord = manifest?.githubAppRoles?.[role] ?? manifest?.githubApps?.[role] ?? null;
+  if (!roleRecord || typeof roleRecord !== "object") {
+    return {
+      ok: false,
+      issues: [`githubAppRoles.${role} is required in desktop bootstrap vault manifest`]
+    };
+  }
+
+  const issues = [];
+  const privateKeyPath = resolveReferencedPath(manifestDir, roleRecord.privateKeyPath);
+  const privateKey = await readOptionalTextFile(privateKeyPath, issues);
+
+  if (!normalizeText(roleRecord.appId)) {
+    issues.push(`githubAppRoles.${role}.appId is required in desktop bootstrap vault manifest`);
+  }
+  if (!normalizeText(roleRecord.installationId)) {
+    issues.push(`githubAppRoles.${role}.installationId is required in desktop bootstrap vault manifest`);
+  }
+  if (!normalizeText(roleRecord.privateKeyPath)) {
+    issues.push(`githubAppRoles.${role}.privateKeyPath is required in desktop bootstrap vault manifest`);
+  }
+  if (normalizeText(roleRecord.privateKeyPath) && !normalizeText(privateKey)) {
+    issues.push(`desktop bootstrap vault GitHub App private key file is empty or unreadable for role ${role}`);
+  }
+
+  if (issues.length > 0) {
+    return { ok: false, issues };
+  }
+
+  return {
+    ok: true,
+    role,
+    manifestPath,
+    credentials: {
+      appId: normalizeText(roleRecord.appId),
+      installationId: normalizeText(roleRecord.installationId),
+      privateKeyPath,
+      privateKey
+    }
+  };
+}
+
 function resolveReferencedPath(manifestDir, referencedPath) {
   const normalized = normalizeText(referencedPath);
   if (!normalized) {

--- a/test/desktop-bootstrap-vault.test.js
+++ b/test/desktop-bootstrap-vault.test.js
@@ -6,7 +6,8 @@ import os from "node:os";
 import path from "node:path";
 import {
   DEFAULT_VTDD_VAULT_MANIFEST_PATH,
-  loadDesktopBootstrapVault
+  loadDesktopBootstrapVault,
+  loadGitHubAppRoleCredentialsFromVault
 } from "../src/core/desktop-bootstrap-vault.js";
 
 test("desktop bootstrap vault loads referenced root credential files", async () => {
@@ -73,6 +74,45 @@ test("desktop bootstrap vault reports missing canonical manifest", async () => {
   assert.equal(result.issues[0].includes("desktop bootstrap vault manifest not found"), true);
 });
 
+test("desktop bootstrap vault loads role-specific GitHub App credentials", async () => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "vtdd-role-vault-"));
+  const credentialsDir = path.join(tempDir, "credentials");
+  await fs.mkdir(path.join(credentialsDir, "github-apps"), { recursive: true });
+  const keyPath = path.join(credentialsDir, "github-apps", "codex-fallback.pem");
+  const manifestPath = path.join(credentialsDir, "manifest.json");
+
+  await fs.writeFile(keyPath, "-----BEGIN RSA PRIVATE KEY-----\nrole-example\n-----END RSA PRIVATE KEY-----\n");
+  await fs.writeFile(
+    manifestPath,
+    JSON.stringify(
+      {
+        version: 1,
+        githubAppRoles: {
+          "codex-fallback-reviewer": {
+            appId: "3706921",
+            installationId: "132169447",
+            privateKeyPath: "github-apps/codex-fallback.pem"
+          }
+        }
+      },
+      null,
+      2
+    )
+  );
+
+  const result = await loadGitHubAppRoleCredentialsFromVault({
+    manifestPath,
+    role: "codex-fallback-reviewer"
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.role, "codex-fallback-reviewer");
+  assert.equal(result.credentials.appId, "3706921");
+  assert.equal(result.credentials.installationId, "132169447");
+  assert.equal(result.credentials.privateKeyPath, keyPath);
+  assert.equal(result.credentials.privateKey.includes("role-example"), true);
+});
+
 test("desktop bootstrap vault constants point to ~/.vtdd by default", () => {
   assert.equal(DEFAULT_VTDD_VAULT_MANIFEST_PATH.endsWith(".vtdd/credentials/manifest.json"), true);
 });
@@ -86,4 +126,6 @@ test("desktop bootstrap vault doc defines canonical path and desktop maintenance
   assert.equal(doc.includes("Short-lived execution credentials must not be stored here."), true);
   assert.equal(doc.includes("not the steady-state operational source"), true);
   assert.equal(doc.includes("steady-state VTDD operation should not require the local desktop vault"), true);
+  assert.equal(doc.includes("githubAppRoles.codex-fallback-reviewer"), true);
+  assert.equal(doc.includes("githubAppRoles.vps-codex-cli"), true);
 });

--- a/test/vps-runner-script.test.js
+++ b/test/vps-runner-script.test.js
@@ -1095,6 +1095,60 @@ test("VPS runner role App token resolution fails closed when role credentials ar
   assert.equal(result.reason.includes("missing app id, private key, installation id"), true);
 });
 
+test("VPS runner role App token resolution can read role credentials from vault manifest", async () => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "vtdd-vps-role-vault-"));
+  const credentialsDir = path.join(tempDir, "credentials");
+  await fs.mkdir(path.join(credentialsDir, "github-apps"), { recursive: true });
+  const keyPath = path.join(credentialsDir, "github-apps", "codex-fallback.pem");
+  const manifestPath = path.join(credentialsDir, "manifest.json");
+  await fs.writeFile(keyPath, "-----BEGIN PRIVATE KEY-----\nrole-example\n-----END PRIVATE KEY-----\n");
+  await fs.writeFile(
+    manifestPath,
+    JSON.stringify(
+      {
+        version: 1,
+        githubAppRoles: {
+          "codex-fallback-reviewer": {
+            appId: "3706921",
+            installationId: "132169447",
+            privateKeyPath: "github-apps/codex-fallback.pem"
+          }
+        }
+      },
+      null,
+      2
+    )
+  );
+
+  const calls = [];
+  const result = await resolveRoleGitHubAppInstallationToken({
+    role: "codex_fallback_reviewer",
+    apiBaseUrl: "https://api.github.invalid",
+    env: {
+      VTDD_VPS_RUNNER_CREDENTIALS_MANIFEST: manifestPath,
+      GITHUB_APP_JWT_PROVIDER: async () => "app_jwt_for_test",
+      GITHUB_API_FETCH: async (url, init = {}) => {
+        calls.push({ url, init });
+        return new Response(
+          JSON.stringify({
+            token: "ghs_role_installation_token",
+            expires_at: "2030-01-01T00:00:00Z"
+          }),
+          {
+            status: 201,
+            headers: { "content-type": "application/json" }
+          }
+        );
+      }
+    }
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.token, "ghs_role_installation_token");
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].url.includes("/app/installations/132169447/access_tokens"), true);
+});
+
 test("VPS runner ignores untrusted approve markers when selecting Codex fallback requests", () => {
   const selected = selectPendingVpsReviewerFallbacks({
     repositoryPolicies: normalizeRepositoryPolicies({


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #393 のうち、VPS runner が role App credential を環境変数だけでなく operator-owned vault manifest から読めるようにする。\n- PR #394 で key 形式問題は解消済み。次に、常駐 runner が必要な role App credential へ到達する repo 側経路を作る。

## Satisfied Success Criteria

- desktop bootstrap vault に githubAppRoles.codex-fallback-reviewer / githubAppRoles.vps-codex-cli の manifest schema を追加した。\n- VPS runner の role App token resolution が env 不足時に vault manifest を読むようにした。\n- credential 未設定時は引き続き marushu 代替投稿せず、既存の actor identity incident 経路に進む。\n- Worker bundle に node:fs を持ち込まないよう、runner は Node専用 vault helper を直接 import する。

## Unsatisfied Success Criteria

- 実 VPS への credential 永続配置は未実施。\n- 常駐 systemd runner の live E2E は未実施。\n- Issue #393 close には、VPS 常駐 runner が requested から completed/blocked へ進む evidence がまだ必要。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #393
- Implementing Success Criteria: VPS runner の常駐実行で PR review requested から completed/blocked の終端状態まで進むための前提として、role App credential を vault manifest から読めるようにする。
- Explicit Non-goals: 実 secret の配置、GitHub App 権限変更、Gemini reviewer 復旧全体、Issue #393 close。
- Expected touched files/routes/workflows: src/core/desktop-bootstrap-vault.js, scripts/run-vps-runner.mjs, docs/setup/desktop-bootstrap-vault.md, test/desktop-bootstrap-vault.test.js, test/vps-runner-script.test.js
- Affected Issues: Issue #393, Issue #351, Issue #366
- Affected PRs: PR #394 の後続。
- Affected workflows: VPS runner fallback reviewer。GitHub Actions workflow は変更なし。
- Affected runtime/operator surfaces: VPS Codex CLI runner。Cloudflare Worker runtime / Custom GPT Action Schema / Instructions は変更なし。
- What may break if we patch narrowly: src/core/index.js から Node専用 vault helper を export すると Worker bundle が壊れる。実際に build で検出し、runner から直接 import に修正した。
- Unknowns to investigate before coding: VPS へ実 credential を置く操作は high-risk credential mutation なので、別途 GO + passkey 境界が必要。
- Validation needed: vault unit、runner integration、build:worker、npm test。
- Stop condition: 実 secret 配置や権限変更が必要になったら、この PR では進めない。

## File / Line Hypotheses

- file: scripts/run-vps-runner.mjs\n  - hypothesis: resolveRoleGitHubAppInstallationToken が env だけを見ているため、VPS の manifest に credential があっても利用できない。\n  - risk if changed narrowly: Worker bundle に Node専用 module を混ぜると Cloudflare build が壊れる。\n  - validation: runner test と build:worker で確認する。\n  - related Issue: Issue #393\n- file: src/core/desktop-bootstrap-vault.js\n  - hypothesis: gateway bearer と root GitHub App は読めるが、role-specific GitHub App material を読む関数がない。\n  - risk if changed narrowly: root githubApp と role githubAppRoles の境界が曖昧になる。\n  - validation: role-specific vault test を追加する。\n  - related Issue: Issue #393

## Hypothesis Retrospective

- expected: runner が vault manifest の githubAppRoles から appId / installationId / privateKey を読み、token mint に進める。\n- actual: unit/integration で確認済み。途中で src/core/index.js export が Worker bundle を壊すことを build が検出したため、Node専用 direct import に変更した。\n- mismatch: 実 VPS secret 配置と live常駐 runner E2E は未実施。\n- lesson: Node専用 helper を core barrel export すると Worker に混入する危険がある。\n- should become RAG candidate: はい。Worker/Node 境界と role App credential 復旧の判断材料。

## Verification Evidence

- Unit: node --test test/desktop-bootstrap-vault.test.js test/vps-runner-script.test.js
- Integration: VPS runner role App token resolution can read role credentials from vault manifest test。
- E2E: npm test。live VPS 常駐 runner E2E は未実施。
- Manual: npm run build:worker で Worker bundle に node:fs が混入しないことを確認。
- Evidence path/link: Issue #393 / この PR の Verification Evidence

## Butler Completion Contract

- Owner goal: VPS runner が role App credential へ到達できず fallback reviewer が止まる状態を解消する。
- Butler entrypoint: 未変更。Butler は GitHub runtime truth と #393 の進捗を読む。
- Action Schema exposure: 不要。Action Schema の operationId は変更していない。
- Runtime path: scripts/run-vps-runner.mjs -> loadGitHubAppRoleCredentialsFromVault -> resolveGitHubAppInstallationToken。
- Runner/runtime truth: npm test passed。role-specific vault fixture から installation token mint まで到達。
- Authority boundary: 実 credential mutation は未実施。今後の VPS への secret 配置は GO + passkey。
- E2E evidence: 未完了。#393 全体では VPS 常駐 runner の live E2E が残る。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 不要。Worker bundle は変更なし。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。#393 全体の後続で確認する。

## Related Constitution Rules

- Issue traceability: Issue #393\n- Role App identity を marushu 代替投稿に落とさない\n- Node専用 credential helper を Worker runtime に混入させない\n- 秘密情報をログ/Issue/PR/RAG に保存しない

## Out-of-scope but NOT implemented

- VPS への実 credential 配置\n- GitHub App 権限変更\n- Gemini reviewer 復旧全体\n- Issue #393 close 判断

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #393
- Execution ID: Not provided.
- Goal: Not provided.
