### PR TITLE
Issue #397: Butler post-merge verification を VPS runner に接続

### DIFF
--- a/docs/butler/remote-codex-cli-executor.md
+++ b/docs/butler/remote-codex-cli-executor.md
@@ -124,6 +124,10 @@ not require a public inbound VPS API:
   issue-traceable queue comments
 - the VPS runner reports milestone events back as Issue comments with
   `<!-- vtdd:vps-runner-event:<executionId> -->`
+- for post-merge verification, Butler uses the same queue with
+  `codexGoal=post_merge_verify`; the VPS runner does not start Codex or create
+  a branch/PR, and instead verifies merged PR truth, VPS `main` sync, runner
+  timer/service state, and pending work snapshot
 - while long-running Codex CLI or `gh` commands are active, the VPS runner
   updates one runner state comment with
   `<!-- vtdd:vps-runner-state:<executionId> -->`; the state comment also keeps
@@ -382,10 +386,12 @@ The same values are rendered as short GitHub-visible lines such as
 When the VPS runner reports `status: completed`, the same GitHub-visible event
 must also carry an explicit terminal outcome in `finalEvent` and `lastEvent`.
 Valid terminal outcomes include `pr_created`, `pr_updated`,
+`post_merge_verification_completed`,
 `conflict_resolved`, `blocked`, `failed`, `no_changes`, and
 `merge_retry_ready`. Butler must use that terminal outcome, not the bare word
 `completed`, when explaining whether the runner created a PR, updated a PR,
-resolved a conflict, made no changes, or stopped with a visible blocker.
+verified post-merge runtime truth, resolved a conflict, made no changes, or
+stopped with a visible blocker.
 
 Runner event comments may include a GitHub mention only as a notification
 mirror; the JSON event payload and branch / PR evidence remain the runtime

--- a/docs/mvp/e2e/e2e-33-post-merge-verification.md
+++ b/docs/mvp/e2e/e2e-33-post-merge-verification.md
@@ -1,0 +1,59 @@
+# E2E-33: Butler-triggered post-merge verification
+
+Issue: #397
+
+Purpose:
+
+- Let Butler request the post-merge checks that mac Codex previously performed manually.
+- Keep the verification bounded to an already merged PR and its base branch.
+- Record enough GitHub-visible evidence for the owner to judge whether post-merge Issue closure can continue.
+
+Happy path:
+
+1. Butler reads the target PR runtime truth and confirms the PR is merged.
+2. Butler dispatches `vtddExecute` with `executorTransport=vps_runner` and `continuationContext.codexGoal=post_merge_verify`.
+3. The queued request names the merged PR, base branch, merge commit, and repository.
+4. The VPS runner consumes the request as a verification task, not as a Codex editing task.
+5. The runner checks GitHub PR truth, VPS main sync, runner service/timer state, and pending runner queues.
+6. The runner posts GitHub-visible `completed` evidence when all checks pass.
+
+Boundary path:
+
+- Missing PR number is rejected before execution.
+- An unmerged, open, or branch-mismatched PR is rejected before queueing.
+- If VPS main cannot fast-forward, the merge commit is not reachable, runner service/timer is inactive, or pending runner items remain, the runner posts a blocked result instead of claiming completion.
+
+Implementation evidence:
+
+- `src/core/remote-codex-executor.js`
+- `scripts/run-vps-runner.mjs`
+- `docs/butler/remote-codex-cli-executor.md`
+- `docs/setup/custom-gpt-actions-openapi.yaml`
+- `docs/setup/custom-gpt-instructions.md`
+
+Test evidence:
+
+- `test/remote-codex-executor.test.js`
+- `test/vps-runner-script.test.js`
+- `test/custom-gpt-setup-docs.test.js`
+
+Run evidence:
+
+- `node --test` passed locally with 805 passing tests and 1 skipped test.
+- `npm run check:self-parity` passed after Action Schema and setup instruction updates.
+- `npm run build:worker` regenerated `worker.js`.
+
+Local verification caveat:
+
+- `npm test -- test/custom-gpt-setup-docs.test.js test/thread-independent-startup-contract.test.js test/remote-codex-executor.test.js test/vps-runner-script.test.js` reaches `npm run check:generated-worker`, which intentionally fails in the dirty worktree because `worker.js` has generated changes not yet committed. The generated file is included in this PR.
+
+Remaining live evidence:
+
+- This PR does not yet prove a live VPS timer consumed a real post-merge verification request after merge.
+- After this PR is merged and deployed, a follow-up Butler request should run `post_merge_verify` against the merged PR and record the resulting GitHub comment URL.
+
+Non-goals:
+
+- Do not deploy from this PR.
+- Do not mutate credentials or GitHub App permissions.
+- Do not close Issue #397 from code/tests alone without post-merge live evidence and human GO.

--- a/docs/mvp/issue-to-e2e-matrix.md
+++ b/docs/mvp/issue-to-e2e-matrix.md
@@ -688,6 +688,29 @@ Status values used below:
   - `docs/mvp/e2e/e2e-26-governed-production-deploy-from-passkey-operator.md`
 - Status: `e2e_evidenced_pending_human_closure`
 
+## E2E-33 Butler-triggered post-merge verification
+
+- Issues: `#397`
+- Happy path:
+  - Butler can dispatch a bounded VPS runner request with `codexGoal=post_merge_verify` for an already merged PR, and the runner records GitHub-visible runtime truth evidence instead of opening mac Codex
+- Boundary path:
+  - missing PR number, unmerged target PR, base-branch mismatch, VPS main sync failure, inactive runner unit, or remaining pending runner work blocks completion instead of claiming Issue closure readiness
+- Implementation evidence:
+  - `src/core/remote-codex-executor.js`
+  - `scripts/run-vps-runner.mjs`
+  - `docs/butler/remote-codex-cli-executor.md`
+  - `docs/setup/custom-gpt-actions-openapi.yaml`
+  - `docs/setup/custom-gpt-instructions.md`
+- Test evidence:
+  - `test/remote-codex-executor.test.js`
+  - `test/vps-runner-script.test.js`
+  - `test/custom-gpt-setup-docs.test.js`
+- Run evidence:
+  - `docs/mvp/e2e/e2e-33-post-merge-verification.md`
+- Remaining blocker:
+  - live VPS post-merge verification against the merged PR is still required before closing Issue #397
+- Status: `partial`
+
 ## Current Completion Reading
 
 - Repository completion status: `partial`

--- a/docs/setup/custom-gpt-actions-openapi.json
+++ b/docs/setup/custom-gpt-actions-openapi.json
@@ -449,7 +449,8 @@
                 "enum": [
                   "open_pr",
                   "revise_pr",
-                  "respond_to_review"
+                  "respond_to_review",
+                  "post_merge_verify"
                 ]
               },
               "executorTransport": {
@@ -660,7 +661,8 @@
                 "enum": [
                   "open_pr",
                   "revise_pr",
-                  "respond_to_review"
+                  "respond_to_review",
+                  "post_merge_verify"
                 ]
               },
               "executorTransport": {

--- a/docs/setup/custom-gpt-actions-openapi.yaml
+++ b/docs/setup/custom-gpt-actions-openapi.yaml
@@ -310,6 +310,7 @@ components:
                 - open_pr
                 - revise_pr
                 - respond_to_review
+                - post_merge_verify
             executorTransport:
               type: string
               enum:
@@ -457,6 +458,7 @@ components:
                 - open_pr
                 - revise_pr
                 - respond_to_review
+                - post_merge_verify
             executorTransport:
               type: string
               enum:

--- a/docs/setup/custom-gpt-instructions-short-min.md
+++ b/docs/setup/custom-gpt-instructions-short-min.md
@@ -7,21 +7,22 @@ Truth and scope:
 - Before proposal/writes/handoff/PR judgment/stale setup claims: read runtime/GitHub truth + memory/constitution; report found/missing; never invent.
 - Reusable memory/RAG checkpoint: show candidate with known repo/Issue; recordType=working_memory; say unknown if missing; ask GO; vtddWriteOperationalMemory; verify vtddRetrieveOperationalMemory. decision_log only for rationale-backed decided judgments.
 - Thread startup: no chat-only habits; read startup contract/runtime/RAG; report promoted or 未確認.
-- No scope beyond user instruction + active Issue.
-- Do not assume a default repository. Resolve owner/repo from explicit input, alias, grant, verified context; ambiguous=>ask one short confirmation.
+- No scope beyond user instruction+active Issue.
+- Do not assume a default repository. Resolve owner/repo from input, alias, grant, verified context; ambiguous=>ask.
 - No internal API paths/raw JSON. Convert natural intent into actions.
-- vtddGateway/vtddExecute use surface=custom_gpt and judgmentModelId=vtdd-butler-core-v1.
+- vtddGateway/vtddExecute: surface=custom_gpt, judgmentModelId=vtdd-butler-core-v1.
+- PR merge後確認: read PR truth; vtddExecute vps_runner + post_merge_verify; verify only.
 Repository and nickname:
 - Repo list/read: vtddGateway exploration/read_only.
-- vtddRetrieveGitHub: repos/issues/PRs/reviews/comments/checks/runs/jobs/branches/contents/tree. Actions failure: runs -> jobs(runId). Files/docs: contents/tree; cite path/htmlUrl. Pages: vtddRetrieveCloudflarePages.
-- Save/delete/list nicknames: vtddUpsertRepositoryNickname, vtddDeleteRepositoryNickname, vtddRetrieveRepositoryNicknames.
-- If request starts with a non-owner/repo token like `ぶい の...`, resolve nickname first.
+- vtddRetrieveGitHub: repos/issues/PRs/reviews/comments/checks/runs/jobs/branches/contents/tree. Actions failure: runs -> jobs(runId). Files/docs: contents/tree; cite path/htmlUrl.
+- Nicknames: vtddUpsertRepositoryNickname, vtddDeleteRepositoryNickname, vtddRetrieveRepositoryNicknames.
+- If request starts with non-owner/repo token, resolve nickname first.
 - Nickname memory is user-owned alias data, not default repo. Save owner/repo, not alias. Delete owner/repo + exact nickname.
-- Nickname read failure is not proof of unknown repo. If context or approvalGrant.scope.repositoryInput has owner/repo, use unverified fallback and verify.
-- Unsupported read => 未対応. Auth fail => 認証失敗. Do not infer absence from failed, unsupported, unauthorized, or unverified reads.
+- Nickname read failure is not proof of unknown repo. If context/grant has owner/repo, use unverified fallback and verify.
+- Unsupported read=>未対応. Auth fail=>認証失敗. Do not infer absence from failed, unsupported, unauthorized, or unverified reads.
 Self-parity and setup drift:
-- For stale/outdated/reflected/aligned: vtddRetrieveSelfParity repo=<resolved>, ref=main; vtddRetrieveSetupArtifact.
-- runtimeParity=`cloudflare_deploy_update_required`=>`Cloudflare deploy update required`. in_sync missing behavior=>`Action Schema update required` or `Instructions update required`.
+- For stale/outdated: vtddRetrieveSelfParity repo=<resolved>, ref=main; vtddRetrieveSetupArtifact.
+- runtimeParity=cloudflare_deploy_update_required=>Cloudflare deploy update required. in_sync missing behavior=>Action Schema/Instructions update required.
 - Parity unchecked=>未検証 + error/reason/issues. ClientResponseError=>state action + unverified transport. runtime in_sync=>don't claim editor sync.
 Execution and remote Codex handoff:
 - Before execution, read runtime truth; when relevant read parent Issue, PR, branch, checks, runs.
@@ -32,7 +33,7 @@ Execution and remote Codex handoff:
 - Remote Codex build invariant: issueContext.issueNumber, policyInput.issueTraceability.relatedIssue, continuationContext.handoff.relatedIssue must exist and match.
 - judgmentTrace first four steps exactly: constitution, runtime_truth, issue_context, current_query.
 - No constitutionConsulted input; constitution-first trace satisfies policy.
-- If target repo is unresolved, do not execute.
+- If target repo unresolved, do not execute.
 - Before handoff, ask short natural GO tied to visible intent; keep internals in payload. handoff/実行/GO => consent=["propose","execute"].
 - Handoff前dry-run: Issue/SC/non-goals/files/affected/risk/unknowns/validation/stop; PR bodyに反映。
 - Do not dispatch `wait_for_review`. PR feedback fix => revise_pr. Comment-only => respond_to_review.
@@ -72,7 +73,7 @@ Review loop:
 - `vtdd:reviewer=codex-fallback` with comment/@codex review is request-only.
 - Completed fallback from trusted VTDD actor/Codex Cloud result with recommendedAction is evidence; missing GitHub Review objects alone is not absence.
 - `vtdd:incident=actor_identity_failure`: recovery blocker; explain role/PR in Japanese; never count `marushu` substitute as review done.
-- If no reviewer evidence, say so.
+- If no reviewer evidence, say.
 Forbidden:
 - No default repo assumption.
 - No issue/PR/comment absence claim from unsupported, unauthorized, failed, or unverified reads.

--- a/docs/setup/custom-gpt-instructions-short.md
+++ b/docs/setup/custom-gpt-instructions-short.md
@@ -16,11 +16,11 @@ Repo/nickname:
 - Nickname memory is user-owned alias data, not default repo. Save owner/repo, not alias. Delete owner/repo+nickname.
 - Nickname read failure is not proof of unknown repo. If context/grant has owner/repo, use unverified fallback; then verify.
 - Nickname action failure: surface error/reason/issues. If Action returns `ClientResponseError`, state action.
-GitHub read plane:
-- vtddRetrieveGitHub: repos/issues/PRs/reviews/comments/checks/runs/jobs/branches/contents/tree. Actions failure: workflow_runs -> workflow_jobs(runId). Files/docs: contents/tree, cite path/htmlUrl. Pages: vtddRetrieveCloudflarePages.
+GitHub read:
+- vtddRetrieveGitHub: repos/issues/PRs/reviews/comments/checks/runs/jobs/branches/contents/tree. Actions failure: runs -> jobs(runId). Files/docs: contents/tree; cite path/htmlUrl. Pages: vtddRetrieveCloudflarePages.
 - Unsupported => 未対応. Auth fail => 認証失敗. Do not infer absence from failed reads.
 Self-parity:
-- Use vtddRetrieveSelfParity repo=<resolved>, ref=main. Surface `Cloudflare deploy update required` / `Action Schema update required` / `Instructions update required` / errors.
+- Use vtddRetrieveSelfParity repo=<resolved>, ref=main. Surface Cloudflare deploy update required / Action Schema update required / Instructions update required / errors.
 - Parity unchecked=>`未検証`. If self-parity returns `ClientResponseError`, say unverified transport failure. vtddRetrieveSetupArtifact. in_sync runtime != editor sync.
 Execution:
 - Before execution, read runtime truth; when needed, vtddRetrieveGitHub PR/branch/checks/runs.
@@ -39,28 +39,29 @@ Remote Codex flow:
 - Executor transport is pluggable and user-owned.
 - Current default for Codex task handoff is the user-owned VPS: executorTransport=vps_runner. Do not add a separate GPT Action for VPS handoff.
 - codex_cloud_github_comment fallback; codex_cloud_cli_control_runner opt-in; vps_runner is user-owned.
-- API runner uses executorTransport=api_key_runner + apiKeyRunnerAcknowledged=true + OPENAI_API_KEY.
+- PR merge後: read PR truth; vtddExecute vps_runner+post_merge_verify.
+- API runner: executorTransport=api_key_runner + apiKeyRunnerAcknowledged=true + OPENAI_API_KEY.
 GitHub write:
 - vtddWriteGitHub only for scoped GO-tier writes: issue create/comment create/update, branch create, pull create/update, pull comment create.
 - Before vtddWriteGitHub, show exact title/body or comment/update payload; wait GO.
 - PR create/update: no freehand `--body`; use `scripts/prepare-pr-body-file.mjs` -> `--body-file`.
-- If no existing Issue is fixed for an implementation request, the next safe write is Issue creation first; after that Issue exists, Butler may hand off bounded Codex work.
+- If no existing Issue is fixed, the next safe write is Issue creation first; after that Issue exists, Butler may hand off bounded Codex work.
 - For normal GO writes (`issue_create`, `issue_comment_create`, `pull_comment_create`), ask only `GO`, call vtddWriteGitHub. Never ask targetConfirmed/approvalScopeMatched/approvalPhrase/raw JSON.
 - Only when repo resolved, scope traceable, GO exists. Do not use vtddWriteGitHub for merge/close/deploy/secrets/settings/permissions/destructive cleanup.
-GitHub high-risk authority plane:
+High-risk authority:
 - Use vtddGitHubAuthority for actions requiring GO + real passkey: pull_ready_for_review, pull_merge, issue_close.
 - Draft PR before merge: pull_ready_for_review. No grant: show ready operator with repo/phase/issueNumber/pullNumber/actionType/highRiskKind.
 - For pull_merge no grant, show merge operator with repo/phase/issueNumber/pullNumber/actionType/highRiskKind; no bare URL.
 - Re-read runtime truth before saying merged.
 - For issue_close, include issueNumber + merged PR pullNumber; else show operator link.
-- Do not route deploy or other destructive provider actions through vtddGitHubAuthority.
-Deploy plane:
-- vtddDeployProduction after deploy ask; requires resolved repo, explicit GO, real passkey grant scoped deploy_production. approvalGrant.scope.repositoryInput can identify target.
+- Do not route deploy/destructive provider actions through vtddGitHubAuthority.
+Deploy:
+- vtddDeployProduction requires repo, GO, deploy_production passkey grant. approvalGrant.scope.repositoryInput can identify target.
 - If no deploy grant, show selfParity.deployOperatorMarkdownLink or `[Open deploy operator](<actual selfParity.deployOperatorUrl>)`; never raw `/v2/approval/passkey/operator...` or bare URL.
-- Stale fallback: selfParity.deployRecovery.operatorMarkdownLink or operatorUrl. Href needs phase=execution.
-- After deploy, say dispatched, then re-check self-parity.
+- Stale: selfParity.deployRecovery.operatorMarkdownLink or operatorUrl; phase=execution.
+- After deploy, re-check self-parity.
 - If vtddDeployProduction fails, say the exact deploy error/reason/issues and blocker.
-- If api_key_runner hits openai_api_key_not_configured, never ask in chat; use vtddSyncGitHubActionsSecret secret-sync operator.
+- If api_key_runner hits openai_api_key_not_configured, use vtddSyncGitHubActionsSecret secret-sync operator; never ask in chat.
 Progress:
 - After vtddExecute, call vtddExecutionProgress; include executorTransport, executionId, repository, issueNumber, branch, leadTime when present.
 - vps_runner health: vtddVpsRunnerStatus -> runnerStatus/lastSeenAt/heartbeatAt/queue.pickedUp/leadTime/currentStep/reasonCode/reason.

--- a/docs/setup/custom-gpt-instructions.md
+++ b/docs/setup/custom-gpt-instructions.md
@@ -267,6 +267,7 @@ Remote Codex flow:
 - Default transport is `vps_runner` for this runtime. `codex_cloud_github_comment` is only a legacy/comment-only fallback, and `codex_cloud_cli_control_runner` is only for an explicitly selected user-owned control runner repository. A queued comment proves delegation was posted, but it does not prove Codex execution, branch creation, or PR creation.
 - `codex_cloud_cli_control_runner` means a user-owned private control repository or trusted runner executes `codex cloud exec` with ChatGPT-managed Codex auth. It does not use `OPENAI_API_KEY`; report workflowRunId/workflowUrl plus target branch/PR evidence, and surface private GitHub Actions minutes/cost when relevant. `vtdd-v2-secret` is owner-specific example/evidence, not a shared runner.
 - `vps_runner` means a user-owned trusted VPS/persistent host. Treat it as the active Codex task transport for this VTDD setup. Do not imply VTDD core provides or operates that VPS.
+- PR merge後の確認を頼まれたら、GitHub runtime truthで対象PRのmerged state/mergedAt/mergeCommitShaを読んだうえで、`vtddExecute` に `executorTransport=vps_runner` と `continuationContext.codexGoal=post_merge_verify` を指定する。これは検証専用であり、コード編集・PR作成・merge・deploy・credential mutation ではない。
 - When the human explicitly approves the API-backed runner/cost path, set `executorTransport=api_key_runner` and `apiKeyRunnerAcknowledged=true` on `vtddExecute`. This uses `OPENAI_API_KEY` and is a no-extra-cost default deviation.
 - Do not silently fall back from `api_key_runner` to comment transport. If the workflow or `OPENAI_API_KEY` is missing, surface the workflow failure/blocker and run URL when available.
 - When handing off, preserve:
@@ -280,6 +281,7 @@ Remote Codex flow:
   - open_pr
   - revise_pr
   - respond_to_review
+  - post_merge_verify
 - `wait_for_review` is a continuity/status signal, not a remote Codex dispatch goal. Do not dispatch `wait_for_review`. If the human explicitly asks Codex to apply PR/reviewer feedback, set `continuationContext.codexGoal=revise_pr` for code changes or `respond_to_review` for comment-only response.
 - Do not treat the handoff text itself as canonical spec.
 

--- a/scripts/run-vps-runner.mjs
+++ b/scripts/run-vps-runner.mjs
@@ -24,6 +24,7 @@ const CANCELED_MARKER_RE = /<!--\s*vtdd:vps-runner-canceled:([a-zA-Z0-9._:-]+)\s
 const DEFAULT_API_BASE_URL = "https://api.github.com";
 const DEFAULT_HEARTBEAT_SECONDS = 120;
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const REPOSITORY_ROOT = path.dirname(SCRIPT_DIR);
 const VTDD_INCIDENT_ACTOR_IDENTITY_FAILURE_MARKER = "<!-- vtdd:incident=actor_identity_failure -->";
 const ROLE_GITHUB_APP_ENV = {
   codex_fallback_reviewer: {
@@ -119,7 +120,13 @@ async function runVpsRunnerOnce({
       };
     }
 
-    return executeVpsRunnerExecution({ githubFetch, token, workRoot, execution });
+    return executeVpsRunnerExecution({
+      githubFetch,
+      token,
+      workRoot,
+      execution,
+      repositoryPolicies: policies
+    });
   }
 
   const reviewerFallbacks = [];
@@ -143,7 +150,13 @@ async function runVpsRunnerOnce({
   return executeVpsReviewerFallback({ token, reviewerFallback });
 }
 
-async function executeVpsRunnerExecution({ githubFetch, token, workRoot, execution }) {
+async function executeVpsRunnerExecution({
+  githubFetch,
+  token,
+  workRoot,
+  execution,
+  repositoryPolicies
+}) {
   let payload = { ...execution.payload };
   payload.lifecycle = normalizeVpsRunnerLifecycle({
     ...payload.lifecycle,
@@ -169,6 +182,16 @@ async function executeVpsRunnerExecution({ githubFetch, token, workRoot, executi
   });
 
   try {
+    if (isPostMergeVerificationGoal(payload.codexGoal)) {
+      return executeVpsPostMergeVerification({
+        githubFetch,
+        payload,
+        notification,
+        repositoryPolicies,
+        env
+      });
+    }
+
     await assertVpsRunnerNotCanceled({ githubFetch, payload, checkpoint: "before_clone", notification });
     const workspace = path.join(workRoot, safePathSegment(payload.repository), payload.executionId);
     await fs.mkdir(path.dirname(workspace), { recursive: true });
@@ -415,6 +438,230 @@ async function executeVpsRunnerExecution({ githubFetch, token, workRoot, executi
   }
 }
 
+async function executeVpsPostMergeVerification({
+  githubFetch,
+  payload,
+  notification,
+  repositoryPolicies,
+  env
+}) {
+  const result = await collectVpsPostMergeVerification({
+    githubFetch,
+    payload,
+    repositoryPolicies,
+    env
+  });
+  const ok = result.ok === true;
+  await postVpsRunnerEvent({
+    githubFetch,
+    payload,
+    notification,
+    event: {
+      status: ok ? "completed" : "blocked",
+      lastEvent: ok ? "post_merge_verification_completed" : "post_merge_verification_blocked",
+      finalEvent: ok ? "post_merge_verification_completed" : undefined,
+      currentStep: "post_merge_verification",
+      postMergeVerification: result,
+      blocker: ok
+        ? undefined
+        : {
+            error: "post_merge_verification_failed",
+            reason: result.reason,
+            actionRequired: result.actionRequired
+          }
+    }
+  });
+  return {
+    ok,
+    message: ok
+      ? `Post-merge verification completed for ${payload.repository}#${result.pullRequest.number}.`
+      : result.reason
+  };
+}
+
+async function collectVpsPostMergeVerification({ githubFetch, payload, repositoryPolicies, env }) {
+  const target = normalizeRevisionTarget(payload.revisionTarget);
+  const pullNumber = normalizePositiveInteger(target.number);
+  const pull = pullNumber
+    ? await githubFetch(`/repos/${payload.repository}/pulls/${pullNumber}`)
+    : null;
+  const prTruth = buildPostMergePullTruth({ pull, target });
+  const repoRoot = normalizeText(process.env.VTDD_VPS_RUNNER_REPO_ROOT) || REPOSITORY_ROOT;
+  const baseRef = normalizeText(payload.baseRef) || normalizeText(prTruth.baseRef) || "main";
+  const [mainSync, runnerStatus, pendingSnapshot] = await Promise.all([
+    collectVpsMainSyncStatus({
+      repoRoot,
+      baseRef,
+      mergeCommitSha: prTruth.mergeCommitSha,
+      env
+    }),
+    collectVpsRunnerSystemdStatus({ env: process.env }),
+    collectVpsRunnerPendingSnapshot({ githubFetch, repositoryPolicies })
+  ]);
+  const failedChecks = [];
+  if (!prTruth.merged) {
+    failedChecks.push("target PR is not merged");
+  }
+  if (!mainSync.ok) {
+    failedChecks.push("VPS main sync failed");
+  } else if (!mainSync.inSyncWithOrigin) {
+    failedChecks.push("VPS main is not in sync with origin");
+  } else if (prTruth.mergeCommitSha && !mainSync.mergeCommitReachable) {
+    failedChecks.push("merge commit is not reachable from VPS main");
+  }
+  if (!runnerStatus.timerActive) {
+    failedChecks.push("VPS runner timer is not active");
+  }
+  if (pendingSnapshot.pendingExecutionCount > 0 || pendingSnapshot.pendingReviewerFallbackCount > 0) {
+    failedChecks.push("VPS runner has pending work");
+  }
+
+  return {
+    ok: failedChecks.length === 0,
+    reason:
+      failedChecks.length > 0
+        ? `Post-merge verification needs attention: ${failedChecks.join("; ")}`
+        : "Post-merge verification passed.",
+    actionRequired:
+      failedChecks.length > 0
+        ? "Butler/owner should inspect the failed checks before starting the next bounded task."
+        : null,
+    repository: payload.repository,
+    issueNumber: payload.issueNumber,
+    branch: payload.branch,
+    baseRef,
+    pullRequest: prTruth,
+    vpsMain: mainSync,
+    runner: runnerStatus,
+    pending: pendingSnapshot,
+    checkedAt: new Date().toISOString()
+  };
+}
+
+function buildPostMergePullTruth({ pull, target }) {
+  const normalizedPull = pull && typeof pull === "object" ? pull : {};
+  return {
+    number: normalizePositiveInteger(normalizedPull.number ?? target.number),
+    url: normalizeText(normalizedPull.html_url ?? normalizedPull.url ?? target.url) || null,
+    state: normalizeText(normalizedPull.state || target.state) || null,
+    merged: normalizedPull.merged === true || target.merged === true,
+    mergedAt:
+      normalizeIsoTimestamp(normalizedPull.merged_at) ||
+      normalizeIsoTimestamp(target.mergedAt) ||
+      null,
+    mergeCommitSha:
+      normalizeText(normalizedPull.merge_commit_sha) || normalizeText(target.mergeCommitSha) || null,
+    headRef: normalizeText(normalizedPull.head?.ref || target.headRef) || null,
+    headSha: normalizeText(normalizedPull.head?.sha || target.headSha) || null,
+    baseRef: normalizeText(normalizedPull.base?.ref || target.baseRef) || null
+  };
+}
+
+async function collectVpsMainSyncStatus({ repoRoot, baseRef, mergeCommitSha, env }) {
+  const result = {
+    ok: false,
+    repoRoot,
+    baseRef,
+    headSha: null,
+    originHeadSha: null,
+    mergeCommitSha: normalizeText(mergeCommitSha) || null,
+    mergeCommitReachable: false,
+    inSyncWithOrigin: false,
+    error: null
+  };
+  try {
+    await runCommand("git", ["fetch", "origin", baseRef], { cwd: repoRoot, env });
+    await runCommand("git", ["checkout", baseRef], { cwd: repoRoot, env });
+    await runCommand("git", ["pull", "--ff-only", "origin", baseRef], { cwd: repoRoot, env });
+    const head = await runCommand("git", ["rev-parse", "HEAD"], { cwd: repoRoot, env });
+    const originHead = await runCommand("git", ["rev-parse", `origin/${baseRef}`], { cwd: repoRoot, env });
+    result.headSha = normalizeText(head.stdout) || null;
+    result.originHeadSha = normalizeText(originHead.stdout) || null;
+    result.inSyncWithOrigin = Boolean(result.headSha && result.headSha === result.originHeadSha);
+    if (result.mergeCommitSha) {
+      const reachable = await runCommand(
+        "git",
+        ["merge-base", "--is-ancestor", result.mergeCommitSha, "HEAD"],
+        { cwd: repoRoot, env }
+      ).then(
+        () => true,
+        () => false
+      );
+      result.mergeCommitReachable = reachable;
+    } else {
+      result.mergeCommitReachable = null;
+    }
+    result.ok = true;
+  } catch (error) {
+    result.error = summarizeDiagnosticText(error?.stderr || error?.message);
+  }
+  return result;
+}
+
+async function collectVpsRunnerSystemdStatus({ env }) {
+  const timerUnit = normalizeText(env.VTDD_VPS_RUNNER_TIMER_UNIT) || "vtdd-vps-runner.timer";
+  const serviceUnit = normalizeText(env.VTDD_VPS_RUNNER_SERVICE_UNIT) || "vtdd-vps-runner.service";
+  const [timer, service] = await Promise.all([
+    runCommandSafe("systemctl", ["--user", "is-active", timerUnit], { env }),
+    runCommandSafe("systemctl", ["--user", "is-active", serviceUnit], { env })
+  ]);
+  return {
+    timerUnit,
+    timerActive: normalizeText(timer.stdout) === "active",
+    timerStatus: normalizeText(timer.stdout) || (timer.exitCode === 0 ? "active" : "unknown"),
+    timerExitCode: timer.exitCode,
+    serviceUnit,
+    serviceActive: normalizeText(service.stdout) === "active",
+    serviceStatus: normalizeText(service.stdout) || (service.exitCode === 0 ? "active" : "unknown"),
+    serviceExitCode: service.exitCode,
+    checkedAt: new Date().toISOString()
+  };
+}
+
+async function collectVpsRunnerPendingSnapshot({ githubFetch, repositoryPolicies }) {
+  const policies = normalizeRepositoryPolicies({ repositoryPolicies });
+  const executions = [];
+  const reviewerFallbacks = [];
+  for (const repository of policies.map((policy) => policy.repository)) {
+    const issueComments = await readRecentIssueComments({ githubFetch, repository });
+    executions.push(...selectPendingVpsRunnerExecutions({ comments: issueComments, repositoryPolicies: policies }));
+    const pullComments = await readRecentPullRequestComments({ githubFetch, repository });
+    reviewerFallbacks.push(...selectPendingVpsReviewerFallbacks({ comments: pullComments, repositoryPolicies: policies }));
+  }
+  return {
+    pendingExecutionCount: executions.length,
+    pendingReviewerFallbackCount: reviewerFallbacks.length,
+    pendingExecutions: executions.map((item) => ({
+      executionId: item.payload.executionId,
+      repository: item.payload.repository,
+      issueNumber: item.payload.issueNumber,
+      codexGoal: item.payload.codexGoal
+    })),
+    pendingReviewerFallbacks: reviewerFallbacks.map((item) => ({
+      repository: item.repository,
+      pullRequestNumber: item.pullRequestNumber,
+      fallbackCommentId: item.commentId
+    }))
+  };
+}
+
+async function runCommandSafe(command, args, options = {}) {
+  try {
+    const result = await runCommand(command, args, options);
+    return {
+      exitCode: 0,
+      stdout: result.stdout,
+      stderr: result.stderr
+    };
+  } catch (error) {
+    return {
+      exitCode: Number.isInteger(error?.exitCode) ? error.exitCode : 1,
+      stdout: error?.stdout || "",
+      stderr: error?.stderr || error?.message || ""
+    };
+  }
+}
+
 function selectPendingVpsRunnerExecutions({ comments, allowedRepositories, repositoryPolicies }) {
   const policies = normalizeRepositoryPolicies({ allowedRepositories, repositoryPolicies });
   const queues = new Map();
@@ -461,6 +708,9 @@ function selectPendingVpsRunnerExecutions({ comments, allowedRepositories, repos
 }
 
 function buildVpsRunnerCompletionFinalEvent({ payload } = {}) {
+  if (isPostMergeVerificationGoal(payload?.codexGoal)) {
+    return "post_merge_verification_completed";
+  }
   return isPrRevisionGoal(payload?.codexGoal) ? "pr_updated" : "pr_created";
 }
 
@@ -471,7 +721,11 @@ function normalizeRevisionTarget(value = {}) {
     url: normalizeText(input.url ?? input.prUrl),
     state: normalizeText(input.state ?? input.prState).toLowerCase(),
     headRef: normalizeText(input.headRef ?? input.head?.ref),
-    headSha: normalizeText(input.headSha ?? input.head?.sha)
+    headSha: normalizeText(input.headSha ?? input.head?.sha),
+    baseRef: normalizeText(input.baseRef ?? input.base?.ref),
+    merged: typeof input.merged === "boolean" ? input.merged : null,
+    mergedAt: normalizeIsoTimestamp(input.mergedAt ?? input.merged_at),
+    mergeCommitSha: normalizeText(input.mergeCommitSha ?? input.merge_commit_sha)
   };
 }
 
@@ -582,6 +836,9 @@ function validateVpsRunnerPayloadPolicy(payload, policies) {
   if (!policy.baseRefs.includes(payload.baseRef || "main")) {
     return { ok: false, reason: "base_ref_not_allowlisted" };
   }
+  if (isPostMergeVerificationGoal(payload.codexGoal)) {
+    return { ok: true, policy };
+  }
   if (!policy.branchPrefixes.some((prefix) => payload.branch.startsWith(prefix))) {
     return { ok: false, reason: "branch_prefix_not_allowlisted" };
   }
@@ -641,12 +898,33 @@ function parseVpsRunnerQueueComment(body) {
   if (isPrRevisionGoal(normalized.codexGoal)) {
     issues.push(...validateQueuedRevisionTarget(normalized));
   }
+  if (isPostMergeVerificationGoal(normalized.codexGoal)) {
+    issues.push(...validateQueuedPostMergeVerificationTarget(normalized));
+  }
 
   if (issues.length > 0) {
     return { ok: false, reason: "vps_runner_payload_invalid", executionId: marker[1], issues };
   }
 
   return { ok: true, executionId: normalized.executionId, payload: normalized };
+}
+
+function validateQueuedPostMergeVerificationTarget(payload) {
+  const issues = [];
+  const target = payload.revisionTarget || {};
+  if (!target.number) {
+    issues.push("post_merge_verify requires target PR number");
+  }
+  if (target.state && !["closed", "merged"].includes(target.state)) {
+    issues.push("post_merge_verify target PR must be closed or merged");
+  }
+  if (target.merged === false) {
+    issues.push("post_merge_verify target PR must be merged");
+  }
+  if (payload.branch !== (payload.baseRef || "main")) {
+    issues.push("post_merge_verify branch must match baseRef");
+  }
+  return issues;
 }
 
 function validateQueuedRevisionTarget(payload) {
@@ -936,6 +1214,10 @@ function formatVpsRunnerPreflightReceipt(preflight) {
 
 function isPrRevisionGoal(goal) {
   return ["revise_pr", "respond_to_review"].includes(normalizeText(goal));
+}
+
+function isPostMergeVerificationGoal(goal) {
+  return normalizeText(goal) === "post_merge_verify";
 }
 
 function buildVpsRunnerCommitMessage(payload) {
@@ -2221,6 +2503,7 @@ export {
   buildCodexExecArgs,
   buildVpsRunnerPreflightReceipt,
   buildGuardedPullRequestBody,
+  buildPostMergePullTruth,
   buildPullRequestBody,
   buildVpsRunnerEventComment,
   buildVpsReviewerFallbackActorIdentityIncident,

--- a/src/core/remote-codex-executor.js
+++ b/src/core/remote-codex-executor.js
@@ -78,7 +78,8 @@ export const VpsRunnerCancelMode = Object.freeze({
 export const RemoteCodexDispatchGoal = Object.freeze({
   OPEN_PR: "open_pr",
   REVISE_PR: "revise_pr",
-  RESPOND_TO_REVIEW: "respond_to_review"
+  RESPOND_TO_REVIEW: "respond_to_review",
+  POST_MERGE_VERIFY: "post_merge_verify"
 });
 
 const REMOTE_CODEX_DISPATCH_GOALS = new Set(Object.values(RemoteCodexDispatchGoal));
@@ -118,20 +119,23 @@ export function createRemoteCodexExecutionRequest(input = {}) {
     executionTarget: normalizeObject(payload?.executionTarget),
     handoff
   });
+  const baseRef =
+    normalizeText(payload?.executionTarget?.baseRef) ||
+    normalizeText(runtimeState.baseRef) ||
+    normalizeText(revisionTarget.baseRef) ||
+    "main";
   const request = {
     executionId: normalizeText(input?.executionId) || buildExecutionId({ issueNumber }),
     actorRole: normalizeText(payload.actorRole),
     repository: normalizeText(gatewayResult.repository),
     issueNumber,
     branch:
+      (codexGoal === RemoteCodexDispatchGoal.POST_MERGE_VERIFY ? baseRef : "") ||
       (codexGoal === RemoteCodexDispatchGoal.REVISE_PR ? revisionTarget.headRef : "") ||
       normalizeText(runtimeState.activeBranch) ||
       normalizeText(payload?.executionTarget?.branch) ||
       (issueNumber ? `codex/issue-${issueNumber}` : ""),
-    baseRef:
-      normalizeText(payload?.executionTarget?.baseRef) ||
-      normalizeText(runtimeState.baseRef) ||
-      "main",
+    baseRef,
     codexGoal,
     approvalPhrase: normalizeText(payload?.policyInput?.approvalPhrase),
     approvalActor:
@@ -177,7 +181,7 @@ export function createRemoteCodexExecutionRequest(input = {}) {
   if (!request.codexGoal) {
     issues.push("codexGoal is required");
   } else if (!REMOTE_CODEX_DISPATCH_GOALS.has(request.codexGoal)) {
-    issues.push("codexGoal must be open_pr, revise_pr, or respond_to_review");
+    issues.push("codexGoal must be open_pr, revise_pr, respond_to_review, or post_merge_verify");
   }
   if (!request.baseRef) {
     issues.push("baseRef is required");
@@ -197,6 +201,9 @@ export function createRemoteCodexExecutionRequest(input = {}) {
   if (request.codexGoal === RemoteCodexDispatchGoal.REVISE_PR) {
     issues.push(...validateRevisionTarget(request));
     issues.push(...revisionTargetConflicts);
+  }
+  if (request.codexGoal === RemoteCodexDispatchGoal.POST_MERGE_VERIFY) {
+    issues.push(...validatePostMergeVerificationTarget(request));
   }
 
   return issues.length > 0 ? { ok: false, issues } : { ok: true, request };
@@ -223,13 +230,31 @@ function validateRevisionTarget(request) {
   return issues;
 }
 
+function validatePostMergeVerificationTarget(request) {
+  const issues = [];
+  const target = request.revisionTarget;
+  if (!target.number) {
+    issues.push("post_merge_verify requires target PR number from runtime truth or handoff");
+  }
+  if (target.state && !["closed", "merged"].includes(target.state)) {
+    issues.push("post_merge_verify target PR must be closed or merged");
+  }
+  if (target.merged === false) {
+    issues.push("post_merge_verify target PR must be merged");
+  }
+  if (request.branch !== request.baseRef) {
+    issues.push("post_merge_verify branch must match baseRef");
+  }
+  return issues;
+}
+
 function normalizeRevisionTarget({ runtimeState, executionTarget, handoff }) {
   const pullRequest = normalizeObject(runtimeState.pullRequest);
   const handoffTarget = normalizeObject(
     handoff.targetPullRequest ?? handoff.pullRequest ?? handoff.pr
   );
   const executionTargetPull = normalizeObject(executionTarget.pullRequest);
-  return {
+  const target = {
     number: normalizePositiveInteger(
       executionTarget.prNumber ??
         executionTarget.pullRequestNumber ??
@@ -276,6 +301,58 @@ function normalizeRevisionTarget({ runtimeState, executionTarget, handoff }) {
       normalizeText(pullRequest.head?.sha) ||
       null
   };
+  const baseRef =
+    normalizeText(executionTarget.baseRef) ||
+    normalizeText(executionTargetPull.baseRef) ||
+    normalizeText(executionTargetPull.base?.ref) ||
+    normalizeText(handoff.baseRef) ||
+    normalizeText(handoffTarget.baseRef) ||
+    normalizeText(handoffTarget.base?.ref) ||
+    normalizeText(pullRequest.baseRef) ||
+    normalizeText(pullRequest.base?.ref);
+  const merged =
+    typeof executionTarget.merged === "boolean"
+      ? executionTarget.merged
+      : typeof executionTargetPull.merged === "boolean"
+        ? executionTargetPull.merged
+        : typeof handoff.merged === "boolean"
+          ? handoff.merged
+          : typeof handoffTarget.merged === "boolean"
+            ? handoffTarget.merged
+            : typeof pullRequest.merged === "boolean"
+              ? pullRequest.merged
+              : null;
+  const mergedAt =
+    normalizeText(executionTarget.mergedAt) ||
+    normalizeText(executionTargetPull.mergedAt) ||
+    normalizeText(executionTargetPull.merged_at) ||
+    normalizeText(handoff.mergedAt) ||
+    normalizeText(handoffTarget.mergedAt) ||
+    normalizeText(handoffTarget.merged_at) ||
+    normalizeText(pullRequest.mergedAt) ||
+    normalizeText(pullRequest.merged_at);
+  const mergeCommitSha =
+    normalizeText(executionTarget.mergeCommitSha) ||
+    normalizeText(executionTargetPull.mergeCommitSha) ||
+    normalizeText(executionTargetPull.merge_commit_sha) ||
+    normalizeText(handoff.mergeCommitSha) ||
+    normalizeText(handoffTarget.mergeCommitSha) ||
+    normalizeText(handoffTarget.merge_commit_sha) ||
+    normalizeText(pullRequest.mergeCommitSha) ||
+    normalizeText(pullRequest.merge_commit_sha);
+  if (baseRef) {
+    target.baseRef = baseRef;
+  }
+  if (merged !== null) {
+    target.merged = merged;
+  }
+  if (mergedAt) {
+    target.mergedAt = mergedAt;
+  }
+  if (mergeCommitSha) {
+    target.mergeCommitSha = mergeCommitSha;
+  }
+  return target;
 }
 
 function collectRevisionTargetConflicts({ executionTarget, handoff }) {
@@ -924,6 +1001,7 @@ async function dispatchVpsRunnerGitHubQueue({ request, token, env }) {
       branch: request.branch,
       baseRef: request.baseRef,
       codexGoal: request.codexGoal,
+      revisionTarget: request.revisionTarget,
       approvalScopeMatched: request.approvalScopeMatched,
       queueCommentId: normalizePositiveInteger(responseBody?.id),
       queueCommentUrl: normalizeText(responseBody?.html_url) || null,
@@ -1856,6 +1934,15 @@ function buildCodexCloudGitHubComment({ request }) {
           `- Target PR headSha: ${request.revisionTarget.headSha}`
         ]
       : []),
+    ...(request.codexGoal === RemoteCodexDispatchGoal.POST_MERGE_VERIFY
+      ? [
+          `- Target PR: #${request.revisionTarget.number}`,
+          `- Target PR state: ${request.revisionTarget.state || "unknown"}`,
+          `- Target PR merged: ${request.revisionTarget.merged === false ? "false" : "true_or_unverified"}`,
+          `- Target PR mergedAt: ${request.revisionTarget.mergedAt || "unverified"}`,
+          `- Target PR mergeCommitSha: ${request.revisionTarget.mergeCommitSha || "unverified"}`
+        ]
+      : []),
     "- Canonical spec: this GitHub Issue",
     "- Runtime truth: current GitHub branch / diff / PR / review comments",
     "- Completion target: create or update a pull request",
@@ -1911,9 +1998,20 @@ function buildVpsRunnerGitHubQueueComment({ request }) {
           `- Target PR headSha: ${request.revisionTarget.headSha}`
         ]
       : []),
+    ...(request.codexGoal === RemoteCodexDispatchGoal.POST_MERGE_VERIFY
+      ? [
+          `- Target PR: #${request.revisionTarget.number}`,
+          `- Target PR state: ${request.revisionTarget.state || "unknown"}`,
+          `- Target PR merged: ${request.revisionTarget.merged === false ? "false" : "true_or_unverified"}`,
+          `- Target PR mergedAt: ${request.revisionTarget.mergedAt || "unverified"}`,
+          `- Target PR mergeCommitSha: ${request.revisionTarget.mergeCommitSha || "unverified"}`
+        ]
+      : []),
     "- Canonical spec: this GitHub Issue",
     "- Runtime truth: current GitHub branch / diff / PR / review comments",
-    "- Completion target: create or update a pull request",
+    request.codexGoal === RemoteCodexDispatchGoal.POST_MERGE_VERIFY
+      ? "- Completion target: verify post-merge runtime truth and post GitHub-visible evidence"
+      : "- Completion target: create or update a pull request",
     "- PR body requirement: Codex must inspect `docs/pr-template-model.md`, `scripts/render-pr-body.mjs`, and `scripts/validate-pr-body.mjs`; the VPS runner will validate and normalize the PR body again before create/update.",
     "- Context preflight requirement: the VPS runner will automatically read `AGENTS.md`, `docs/butler/thread-independent-startup-contract.md`, the canonical Issue, and the PR body contract files, then generate a machine-readable preflight receipt before Codex starts editing.",
     "- Missing preflight inputs do not authorize speculative implementation; the runner must ask Butler/owner to confirm the next action, then wait for a reissued bounded request.",

--- a/test/custom-gpt-setup-docs.test.js
+++ b/test/custom-gpt-setup-docs.test.js
@@ -428,7 +428,7 @@ test("custom gpt openapi json parses and exposes paths as an object", () => {
   assert.deepEqual(
     doc.components.schemas.VtddExecuteRequest.properties.continuationContext.properties
       .codexGoal.enum,
-    ["open_pr", "revise_pr", "respond_to_review"]
+    ["open_pr", "revise_pr", "respond_to_review", "post_merge_verify"]
   );
   assert.deepEqual(
     doc.paths["/v2/action/progress"].get.parameters.find(

--- a/test/remote-codex-executor.test.js
+++ b/test/remote-codex-executor.test.js
@@ -270,7 +270,9 @@ test("remote Codex execution request rejects wait-only continuity goal before wo
   });
 
   assert.equal(result.ok, false);
-  assert.deepEqual(result.issues, ["codexGoal must be open_pr, revise_pr, or respond_to_review"]);
+  assert.deepEqual(result.issues, [
+    "codexGoal must be open_pr, revise_pr, respond_to_review, or post_merge_verify"
+  ]);
 });
 
 test("remote Codex execution request rejects non-string handoff approval refs", () => {
@@ -776,6 +778,66 @@ test("remote Codex vps_runner dispatch preserves bounded PR revision goal", asyn
   assert.equal(body.includes('"branch": "codex/add-pr-ready-authority"'), true);
   assert.equal(body.includes('"number": 204'), true);
   assert.equal(body.includes('"headSha": "sha-204"'), true);
+});
+
+test("remote Codex vps_runner dispatch preserves bounded post-merge verification goal", async () => {
+  const calls = [];
+  const dispatched = await dispatchRemoteCodexExecution({
+    payload: {
+      actorRole: ActorRole.BUTLER,
+      executorTransport: RemoteCodexExecutorTransport.VPS_RUNNER,
+      issueContext: { issueNumber: 397 },
+      continuationContext: {
+        codexGoal: RemoteCodexDispatchGoal.POST_MERGE_VERIFY
+      },
+      policyInput: {
+        approvalPhrase: "GO",
+        targetConfirmed: true,
+        approvalScopeMatched: true,
+        runtimeTruth: {
+          runtimeState: {
+            pullRequest: {
+              number: 396,
+              state: "closed",
+              merged: true,
+              mergedAt: "2026-05-15T13:43:25Z",
+              mergeCommitSha: "merge-sha-396",
+              baseRef: "main",
+              headRef: "codex/issue-393",
+              headSha: "head-sha-393"
+            }
+          }
+        }
+      }
+    },
+    gatewayResult: {
+      repository: "sample-org/vtdd-v2"
+    },
+    env: {
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_dispatch_token",
+      GITHUB_API_FETCH: async (url, init) => {
+        calls.push({ url, init });
+        return new Response(
+          JSON.stringify({
+            id: 39701,
+            html_url: "https://github.com/sample-org/vtdd-v2/issues/397#issuecomment-39701"
+          }),
+          { status: 201, headers: { "content-type": "application/json" } }
+        );
+      }
+    }
+  });
+
+  assert.equal(dispatched.ok, true);
+  assert.equal(dispatched.execution.transport, RemoteCodexExecutorTransport.VPS_RUNNER);
+  assert.equal(dispatched.execution.branch, "main");
+  assert.equal(dispatched.execution.revisionTarget.number, 396);
+  const body = JSON.parse(calls[0].init.body).body;
+  assert.equal(body.includes('"codexGoal": "post_merge_verify"'), true);
+  assert.equal(body.includes('"branch": "main"'), true);
+  assert.equal(body.includes('"number": 396'), true);
+  assert.equal(body.includes('"mergeCommitSha": "merge-sha-396"'), true);
+  assert.equal(body.includes("verify post-merge runtime truth"), true);
 });
 
 test("remote Codex vps_runner progress reads queue comment and target PR truth", async () => {

--- a/test/vps-runner-script.test.js
+++ b/test/vps-runner-script.test.js
@@ -8,6 +8,7 @@ import {
   buildCodexExecutionPrompt,
   buildCodexExecArgs,
   buildGuardedPullRequestBody,
+  buildPostMergePullTruth,
   buildPullRequestBody,
   buildVpsRunnerPreflightReceipt,
   buildVpsRunnerCompletionFinalEvent,
@@ -139,6 +140,97 @@ test("VPS runner rejects revise_pr queue payload when branch differs from target
   assert.equal(parsed.ok, false);
   assert.equal(parsed.reason, "vps_runner_payload_invalid");
   assert.equal(parsed.issues.includes("revise_pr branch must match target PR headRef"), true);
+});
+
+test("VPS runner parses post_merge_verify queue payload with merged target PR lock", () => {
+  const parsed = parseVpsRunnerQueueComment(`<!-- vtdd:vps-runner-execution:remote-codex-issue397-postmerge -->
+\`\`\`json
+{
+  "executionId": "remote-codex-issue397-postmerge",
+  "transport": "vps_runner",
+  "repository": "sample-org/vtdd-v2",
+  "issueNumber": 397,
+  "branch": "main",
+  "baseRef": "main",
+  "codexGoal": "post_merge_verify",
+  "approvalScopeMatched": true,
+  "issueTraceability": {
+    "issueTraceable": true
+  },
+  "revisionTarget": {
+    "number": 396,
+    "state": "closed",
+    "merged": true,
+    "mergedAt": "2026-05-15T13:43:25Z",
+    "mergeCommitSha": "merge-sha-396",
+    "headRef": "codex/issue-393",
+    "headSha": "head-sha-393",
+    "baseRef": "main"
+  }
+}
+\`\`\``);
+
+  assert.equal(parsed.ok, true);
+  assert.equal(parsed.payload.codexGoal, "post_merge_verify");
+  assert.equal(parsed.payload.branch, "main");
+  assert.equal(parsed.payload.revisionTarget.number, 396);
+  assert.equal(parsed.payload.revisionTarget.merged, true);
+  assert.equal(parsed.payload.revisionTarget.mergeCommitSha, "merge-sha-396");
+});
+
+test("VPS runner rejects post_merge_verify queue payload without target PR number", () => {
+  const parsed = parseVpsRunnerQueueComment(`<!-- vtdd:vps-runner-execution:remote-codex-issue397-postmerge -->
+\`\`\`json
+{
+  "executionId": "remote-codex-issue397-postmerge",
+  "transport": "vps_runner",
+  "repository": "sample-org/vtdd-v2",
+  "issueNumber": 397,
+  "branch": "main",
+  "baseRef": "main",
+  "codexGoal": "post_merge_verify",
+  "approvalScopeMatched": true,
+  "issueTraceability": {
+    "issueTraceable": true
+  },
+  "revisionTarget": {
+    "state": "closed",
+    "merged": true
+  }
+}
+\`\`\``);
+
+  assert.equal(parsed.ok, false);
+  assert.equal(parsed.reason, "vps_runner_payload_invalid");
+  assert.equal(parsed.issues.includes("post_merge_verify requires target PR number"), true);
+});
+
+test("VPS runner builds post-merge PR truth from GitHub pull response", () => {
+  const truth = buildPostMergePullTruth({
+    pull: {
+      number: 396,
+      html_url: "https://github.com/sample-org/vtdd-v2/pull/396",
+      state: "closed",
+      merged: true,
+      merged_at: "2026-05-15T13:43:25Z",
+      merge_commit_sha: "merge-sha-396",
+      base: { ref: "main" },
+      head: { ref: "codex/issue-393", sha: "head-sha-393" }
+    },
+    target: {}
+  });
+
+  assert.deepEqual(truth, {
+    number: 396,
+    url: "https://github.com/sample-org/vtdd-v2/pull/396",
+    state: "closed",
+    merged: true,
+    mergedAt: "2026-05-15T13:43:25Z",
+    mergeCommitSha: "merge-sha-396",
+    headRef: "codex/issue-393",
+    headSha: "head-sha-393",
+    baseRef: "main"
+  });
 });
 
 test("VPS runner checkout blocks revise_pr when target lock is incomplete", async () => {

--- a/worker.js
+++ b/worker.js
@@ -32647,7 +32647,8 @@ var VpsRunnerCancelMode = Object.freeze({
 var RemoteCodexDispatchGoal = Object.freeze({
   OPEN_PR: "open_pr",
   REVISE_PR: "revise_pr",
-  RESPOND_TO_REVIEW: "respond_to_review"
+  RESPOND_TO_REVIEW: "respond_to_review",
+  POST_MERGE_VERIFY: "post_merge_verify"
 });
 var REMOTE_CODEX_DISPATCH_GOALS = new Set(Object.values(RemoteCodexDispatchGoal));
 function createRemoteCodexExecutionRequest(input = {}) {
@@ -32675,13 +32676,14 @@ function createRemoteCodexExecutionRequest(input = {}) {
     executionTarget: normalizeObject8(payload?.executionTarget),
     handoff
   });
+  const baseRef = normalizeText18(payload?.executionTarget?.baseRef) || normalizeText18(runtimeState.baseRef) || normalizeText18(revisionTarget.baseRef) || "main";
   const request = {
     executionId: normalizeText18(input?.executionId) || buildExecutionId({ issueNumber }),
     actorRole: normalizeText18(payload.actorRole),
     repository: normalizeText18(gatewayResult.repository),
     issueNumber,
-    branch: (codexGoal === RemoteCodexDispatchGoal.REVISE_PR ? revisionTarget.headRef : "") || normalizeText18(runtimeState.activeBranch) || normalizeText18(payload?.executionTarget?.branch) || (issueNumber ? `codex/issue-${issueNumber}` : ""),
-    baseRef: normalizeText18(payload?.executionTarget?.baseRef) || normalizeText18(runtimeState.baseRef) || "main",
+    branch: (codexGoal === RemoteCodexDispatchGoal.POST_MERGE_VERIFY ? baseRef : "") || (codexGoal === RemoteCodexDispatchGoal.REVISE_PR ? revisionTarget.headRef : "") || normalizeText18(runtimeState.activeBranch) || normalizeText18(payload?.executionTarget?.branch) || (issueNumber ? `codex/issue-${issueNumber}` : ""),
+    baseRef,
     codexGoal,
     approvalPhrase: normalizeText18(payload?.policyInput?.approvalPhrase),
     approvalActor: normalizeText18(payload?.policyInput?.approvalActor) || normalizeText18(payload?.policyInput?.goActor) || normalizeText18(payload?.sender?.login),
@@ -32720,7 +32722,7 @@ function createRemoteCodexExecutionRequest(input = {}) {
   if (!request.codexGoal) {
     issues.push("codexGoal is required");
   } else if (!REMOTE_CODEX_DISPATCH_GOALS.has(request.codexGoal)) {
-    issues.push("codexGoal must be open_pr, revise_pr, or respond_to_review");
+    issues.push("codexGoal must be open_pr, revise_pr, respond_to_review, or post_merge_verify");
   }
   if (!request.baseRef) {
     issues.push("baseRef is required");
@@ -32740,6 +32742,9 @@ function createRemoteCodexExecutionRequest(input = {}) {
   if (request.codexGoal === RemoteCodexDispatchGoal.REVISE_PR) {
     issues.push(...validateRevisionTarget(request));
     issues.push(...revisionTargetConflicts);
+  }
+  if (request.codexGoal === RemoteCodexDispatchGoal.POST_MERGE_VERIFY) {
+    issues.push(...validatePostMergeVerificationTarget(request));
   }
   return issues.length > 0 ? { ok: false, issues } : { ok: true, request };
 }
@@ -32763,13 +32768,30 @@ function validateRevisionTarget(request) {
   }
   return issues;
 }
+function validatePostMergeVerificationTarget(request) {
+  const issues = [];
+  const target = request.revisionTarget;
+  if (!target.number) {
+    issues.push("post_merge_verify requires target PR number from runtime truth or handoff");
+  }
+  if (target.state && !["closed", "merged"].includes(target.state)) {
+    issues.push("post_merge_verify target PR must be closed or merged");
+  }
+  if (target.merged === false) {
+    issues.push("post_merge_verify target PR must be merged");
+  }
+  if (request.branch !== request.baseRef) {
+    issues.push("post_merge_verify branch must match baseRef");
+  }
+  return issues;
+}
 function normalizeRevisionTarget({ runtimeState, executionTarget, handoff }) {
   const pullRequest = normalizeObject8(runtimeState.pullRequest);
   const handoffTarget = normalizeObject8(
     handoff.targetPullRequest ?? handoff.pullRequest ?? handoff.pr
   );
   const executionTargetPull = normalizeObject8(executionTarget.pullRequest);
-  return {
+  const target = {
     number: normalizePositiveInteger3(
       executionTarget.prNumber ?? executionTarget.pullRequestNumber ?? executionTargetPull.number ?? handoff.prNumber ?? handoff.pullRequestNumber ?? handoffTarget.number ?? pullRequest.number
     ),
@@ -32780,6 +32802,23 @@ function normalizeRevisionTarget({ runtimeState, executionTarget, handoff }) {
     headRef: normalizeText18(executionTarget.headRef) || normalizeText18(executionTargetPull.headRef) || normalizeText18(executionTargetPull.head?.ref) || normalizeText18(handoff.headRef) || normalizeText18(handoffTarget.headRef) || normalizeText18(handoffTarget.head?.ref) || normalizeText18(pullRequest.headRef) || normalizeText18(pullRequest.head?.ref) || null,
     headSha: normalizeText18(executionTarget.headSha) || normalizeText18(executionTargetPull.headSha) || normalizeText18(executionTargetPull.head?.sha) || normalizeText18(handoff.headSha) || normalizeText18(handoffTarget.headSha) || normalizeText18(handoffTarget.head?.sha) || normalizeText18(pullRequest.headSha) || normalizeText18(pullRequest.head?.sha) || null
   };
+  const baseRef = normalizeText18(executionTarget.baseRef) || normalizeText18(executionTargetPull.baseRef) || normalizeText18(executionTargetPull.base?.ref) || normalizeText18(handoff.baseRef) || normalizeText18(handoffTarget.baseRef) || normalizeText18(handoffTarget.base?.ref) || normalizeText18(pullRequest.baseRef) || normalizeText18(pullRequest.base?.ref);
+  const merged = typeof executionTarget.merged === "boolean" ? executionTarget.merged : typeof executionTargetPull.merged === "boolean" ? executionTargetPull.merged : typeof handoff.merged === "boolean" ? handoff.merged : typeof handoffTarget.merged === "boolean" ? handoffTarget.merged : typeof pullRequest.merged === "boolean" ? pullRequest.merged : null;
+  const mergedAt = normalizeText18(executionTarget.mergedAt) || normalizeText18(executionTargetPull.mergedAt) || normalizeText18(executionTargetPull.merged_at) || normalizeText18(handoff.mergedAt) || normalizeText18(handoffTarget.mergedAt) || normalizeText18(handoffTarget.merged_at) || normalizeText18(pullRequest.mergedAt) || normalizeText18(pullRequest.merged_at);
+  const mergeCommitSha = normalizeText18(executionTarget.mergeCommitSha) || normalizeText18(executionTargetPull.mergeCommitSha) || normalizeText18(executionTargetPull.merge_commit_sha) || normalizeText18(handoff.mergeCommitSha) || normalizeText18(handoffTarget.mergeCommitSha) || normalizeText18(handoffTarget.merge_commit_sha) || normalizeText18(pullRequest.mergeCommitSha) || normalizeText18(pullRequest.merge_commit_sha);
+  if (baseRef) {
+    target.baseRef = baseRef;
+  }
+  if (merged !== null) {
+    target.merged = merged;
+  }
+  if (mergedAt) {
+    target.mergedAt = mergedAt;
+  }
+  if (mergeCommitSha) {
+    target.mergeCommitSha = mergeCommitSha;
+  }
+  return target;
 }
 function collectRevisionTargetConflicts({ executionTarget, handoff }) {
   const sources = [
@@ -33359,6 +33398,7 @@ async function dispatchVpsRunnerGitHubQueue({ request, token, env }) {
       branch: request.branch,
       baseRef: request.baseRef,
       codexGoal: request.codexGoal,
+      revisionTarget: request.revisionTarget,
       approvalScopeMatched: request.approvalScopeMatched,
       queueCommentId: normalizePositiveInteger3(responseBody?.id),
       queueCommentUrl: normalizeText18(responseBody?.html_url) || null,
@@ -34120,6 +34160,13 @@ function buildCodexCloudGitHubComment({ request }) {
       `- Target PR headRef: ${request.revisionTarget.headRef}`,
       `- Target PR headSha: ${request.revisionTarget.headSha}`
     ] : [],
+    ...request.codexGoal === RemoteCodexDispatchGoal.POST_MERGE_VERIFY ? [
+      `- Target PR: #${request.revisionTarget.number}`,
+      `- Target PR state: ${request.revisionTarget.state || "unknown"}`,
+      `- Target PR merged: ${request.revisionTarget.merged === false ? "false" : "true_or_unverified"}`,
+      `- Target PR mergedAt: ${request.revisionTarget.mergedAt || "unverified"}`,
+      `- Target PR mergeCommitSha: ${request.revisionTarget.mergeCommitSha || "unverified"}`
+    ] : [],
     "- Canonical spec: this GitHub Issue",
     "- Runtime truth: current GitHub branch / diff / PR / review comments",
     "- Completion target: create or update a pull request",
@@ -34170,9 +34217,16 @@ function buildVpsRunnerGitHubQueueComment({ request }) {
       `- Target PR headRef: ${request.revisionTarget.headRef}`,
       `- Target PR headSha: ${request.revisionTarget.headSha}`
     ] : [],
+    ...request.codexGoal === RemoteCodexDispatchGoal.POST_MERGE_VERIFY ? [
+      `- Target PR: #${request.revisionTarget.number}`,
+      `- Target PR state: ${request.revisionTarget.state || "unknown"}`,
+      `- Target PR merged: ${request.revisionTarget.merged === false ? "false" : "true_or_unverified"}`,
+      `- Target PR mergedAt: ${request.revisionTarget.mergedAt || "unverified"}`,
+      `- Target PR mergeCommitSha: ${request.revisionTarget.mergeCommitSha || "unverified"}`
+    ] : [],
     "- Canonical spec: this GitHub Issue",
     "- Runtime truth: current GitHub branch / diff / PR / review comments",
-    "- Completion target: create or update a pull request",
+    request.codexGoal === RemoteCodexDispatchGoal.POST_MERGE_VERIFY ? "- Completion target: verify post-merge runtime truth and post GitHub-visible evidence" : "- Completion target: create or update a pull request",
     "- PR body requirement: Codex must inspect `docs/pr-template-model.md`, `scripts/render-pr-body.mjs`, and `scripts/validate-pr-body.mjs`; the VPS runner will validate and normalize the PR body again before create/update.",
     "- Context preflight requirement: the VPS runner will automatically read `AGENTS.md`, `docs/butler/thread-independent-startup-contract.md`, the canonical Issue, and the PR body contract files, then generate a machine-readable preflight receipt before Codex starts editing.",
     "- Missing preflight inputs do not authorize speculative implementation; the runner must ask Butler/owner to confirm the next action, then wait for a reissued bounded request.",


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #397 の部分進捗。Butler が merge 済み PR の post-merge verification を VPS runner に委任できる入口を追加する。

## Satisfied Success Criteria

- Action Schema に `post_merge_verify` を追加。
- Butler instructions に PR merge 後確認の `vtddExecute` 経路を追加。
- VPS runner が `post_merge_verify` を編集タスクではなく検証タスクとして処理し、PR truth / VPS main sync / runner systemd / pending queue を GitHub-visible event に記録する。
- 境界条件を unit test と E2E-33 証跡に追加。

## Unsatisfied Success Criteria

- merge 後の live VPS post-merge verification 実行と、その GitHub comment URL の記録はこの PR merge 後に必要。
- Issue #397 の closure はこの live evidence と人間の GO まで未完了。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #397
- Implementing Success Criteria: Butler から `vtddExecute` + `vps_runner` + `post_merge_verify` を出せる。VPS runner が merge 済み PR を検証し、成功/失敗を runtime truth としてコメントできる。
- Explicit Non-goals: deploy、credential mutation、権限変更、Issue close は対象外。
- Expected touched files/routes/workflows: `src/core/remote-codex-executor.js`, `scripts/run-vps-runner.mjs`, `docs/setup/*`, `docs/butler/remote-codex-cli-executor.md`, tests, `worker.js`, E2E matrix
- Affected Issues: #397。関連背景として post-merge Issue closure flow に影響するが、この PR では closure 実行はしない。
- Affected PRs: なし。
- Affected workflows: VPS runner queue consumption。GitHub Actions deploy/reviewer workflow は直接変更しない。
- Affected runtime/operator surfaces: Butler, Custom GPT Action Schema, Worker `vtddExecute`, VPS runner, setup recovery artifacts
- What may break if we patch narrowly: Action Schema だけ追加すると runner が拾えない。runner だけ追加すると Butler が出せない。検証成功を過大に言うと Issue closure が drift する。
- Unknowns to investigate before coding: live VPS timer が merge 後 PR を実際に拾うことは merge 前には未検証。
- Validation needed: `node --test`, `check:self-parity`, `check:generated-worker`, merge 後 live VPS post-merge verification
- Stop condition: live evidence なしに Issue #397 close-ready と主張しそうになった時。

## File / Line Hypotheses

- file: `src/core/remote-codex-executor.js`
  - hypothesis: Butler 入口で `post_merge_verify` を正式 goal として扱えば、PR 作成/修正とは別の検証リクエストとして安全に queue できる。
  - risk if changed narrowly: Action Schema または runner 側とズレると、Butler が出せても実行面が拾えない。
  - validation: `test/remote-codex-executor.test.js`
  - related Issue: #397
- file: `scripts/run-vps-runner.mjs`
  - hypothesis: VPS runner が `post_merge_verify` を Codex 編集タスクにせず、GitHub/VPS runtime truth 検証タスクとして処理すれば mac Codex 手動確認を置き換えられる。
  - risk if changed narrowly: pending queue や systemd 状態を見ずに成功扱いすると、Issue close 判断が drift する。
  - validation: `test/vps-runner-script.test.js`
  - related Issue: #397
- file: `docs/setup/custom-gpt-actions-openapi.yaml` / `docs/setup/custom-gpt-instructions*.md`
  - hypothesis: Butler が自然言語から到達するには Action Schema と Instructions の両方が必要。
  - risk if changed narrowly: repo 内にコードがあっても Butler Completion Gate を満たさない。
  - validation: `test/custom-gpt-setup-docs.test.js`
  - related Issue: #397

## Hypothesis Retrospective

- expected: `post_merge_verify` は PR 作成/修正ではなく検証タスクとして扱う。
- actual: request builder と VPS runner の両方に専用 goal を追加し、main sync / systemd / pending queue の blocked/completed event を持たせた。
- mismatch: live VPS 実行は merge 前に未実施。
- lesson: Butler-facing 完了には surface/schema/runner/evidence を同時に見る必要がある。
- should become RAG candidate: はい。live 検証後に保存候補。

## Verification Evidence

- Unit: `node --test`: 805 pass, 1 skipped。個別: `issue-to-e2e`, `custom-gpt-setup-docs`, `remote-codex-executor`, `vps-runner-script` は 111 pass。
- Integration: `npm run check:self-parity`: pass。`npm run check:generated-worker`: pass after commit。`npm run build:worker`: pass。
- E2E: `docs/mvp/e2e/e2e-33-post-merge-verification.md` を追加。live VPS 実行は merge 後に必要。
- Manual: なし。
- Evidence path/link: `docs/mvp/e2e/e2e-33-post-merge-verification.md`

## Butler Completion Contract

- Owner goal: Butler が mac Codex を開かずに、merge 後の確認作業を VPS runner に頼める状態に近づける。
- Butler entrypoint: Butler: `vtddExecute` with `executorTransport=vps_runner` and `continuationContext.codexGoal=post_merge_verify`
- Action Schema exposure: `custom-gpt-actions-openapi.yaml/json` に `post_merge_verify` enum を追加。
- Runtime path: Worker remote Codex executor -> GitHub queue comment -> VPS runner `post_merge_verify` verification task
- Runner/runtime truth: GitHub PR truth, VPS main sync status, systemd timer/service status, pending runner queue snapshot を event comment に記録。
- Authority boundary: 検証専用。コード編集・PR作成・merge・deploy・credential mutation ではない。Issue close は別途 GO + 条件充足が必要。
- E2E evidence: `surface_connected`。merge 後 live VPS 実行が残るため complete ではない。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 必要。Action Schema/Instructions/`worker.js` が変わるため、merge 後に deploy と setup 更新確認が必要。
- Custom GPT Action Schema update: 必要。`/setup/latest` の Action Schema を Custom GPT に反映する。
- Custom GPT Instructions update: 必要。`/setup/latest` の Instructions を Custom GPT に反映する。
- iPhone Butler live E2E: 必要。merge/deploy 後に Butler から `post_merge_verify` を依頼して GitHub comment URL を得る。

## Related Constitution Rules

- Issue-first
- Butler Completion Gate
- Evidence Discipline
- No deploy/credential mutation without GO + passkey

## Out-of-scope but NOT implemented

- live VPS post-merge run
- deploy
- credential mutation
- Issue #397 close

## Extra changes (if any)

`worker.js` は `npm run build:worker` で生成済み。

<!-- VTDD metadata -->
- Issue: Issue #397
- Execution ID: manual-mac-codex-issue-397
- Goal: post_merge_verify
