### PR TITLE
AGENTS: Butler-first operating principle を追加

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,49 @@ exist. Completion requires all of:
 If any item is missing, report the work as incomplete/unconnected. Do not claim
 implementation complete.
 
+## Butler-First Operating Principle
+
+VTDD is an iPhone/iPad-first, handoff-first development system.
+
+The target experience is not "the owner sits at a Mac and uses mac Codex."
+The target experience is:
+
+- the owner starts from Butler on iPhone or iPad,
+- Butler acts as the owner's delegate,
+- VPS Codex CLI is the always-on execution surface,
+- GitHub Issue / PR / Actions / runtime truth / RAG provide shared memory and
+  evidence,
+- mac Codex is an emergency or auxiliary surface, not the default operating
+  center.
+
+Before doing work, especially when mac Codex can easily inspect files, run
+commands, open browsers, or SSH into servers, ask:
+
+1. Can Butler understand this user intent in natural language?
+2. Can Butler read the needed repository / Issue / PR / Actions / setup / RAG
+   truth without the owner opening mac Codex?
+3. Can Butler hand off the executable part to VPS Codex CLI or another declared
+   runner?
+4. Can Butler observe progress, result, blocker, and before/after runtime truth?
+5. Can the owner continue or recover from iPhone/iPad only?
+
+If the answer is no, do not present the mac Codex action as VTDD completion.
+Report it as one of:
+
+- `mac_codex_only_probe`: useful investigation, not Butler-complete
+- `butler_gap_found`: a missing Butler capability that should become Issue work
+- `vps_handoff_gap_found`: a missing VPS Codex CLI / runner capability
+- `recovery_gap_found`: a missing iPhone/iPad recovery path
+
+Direct mac Codex shell, browser, SSH, or local filesystem work may be used to
+bootstrap or debug VTDD, but it must not redefine the product around mac Codex.
+When mac Codex performs a step that Butler cannot perform, record the gap in
+the PR body, Issue comment, or RAG candidate before claiming progress.
+
+This principle is not stylistic. It is the core product constraint:
+the owner should not have to keep a MacBook awake, powered, or physically
+available for normal VTDD development.
+
 ## Non-Negotiable Rules
 
 1. Do not reinterpret scope words (including "MVP") on your own.


### PR DESCRIPTION
## This PR satisfies Intent

- ユーザー明示指示により、VTDD の通常運用中心を mac Codex ではなく Butler/iPhone/iPad + VPS Codex CLI に置く guardrail を `AGENTS.md` に追加する。

## Satisfied Success Criteria

- `AGENTS.md` に `Butler-First Operating Principle` を追加した。
- 作業前に「Butler ならできるか」「iPhone/iPad だけで継続・復旧できるか」「VPS Codex CLI に渡せるか」を確認する質問を明文化した。
- mac Codex の shell/browser/SSH/local FS 作業を VTDD completion と誤認しない分類を追加した。

## Unsatisfied Success Criteria

- なし。この PR は process guardrail の追加のみ。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: ユーザー明示指示による process correction。既存 Issue への実装ではない。
- Implementing Success Criteria: スレッドが変わっても「Butler ができるか」を第一判定にする。
- Explicit Non-goals: runtime、Worker、Action Schema、VPS runner、RAG schema は変更しない。
- Expected touched files/routes/workflows: `AGENTS.md`
- Affected Issues: #341, #344, #360, #397 以降の運用判断に影響するが、各 Issue の実装はしない。
- Affected PRs: なし。
- Affected workflows: なし。
- Affected runtime/operator surfaces: なし。agent behavior guard のみ。
- What may break if we patch narrowly: guardrail を durable repo state に残さないと、次スレッドで mac Codex 中心に戻る。
- Unknowns to investigate before coding: なし。
- Validation needed: `git diff --check` と文面確認。
- Stop condition: runtime/code 変更を混ぜそうになった時。

## File / Line Hypotheses

- file: `AGENTS.md`
  - hypothesis: Butler-first principle を `Butler Completion Gate` 直後に置くと、作業開始時の第一判定として読みやすい。
  - risk if changed narrowly: 既存の completion gate だけでは mac Codex で調査した結果を VTDD progress と過大評価しやすい。
  - validation: `git diff --check`
  - related Issue: user-direct process correction

## Hypothesis Retrospective

- expected: mac Codex ができることではなく、Butler が iPhone/iPad からできることを第一判定にする文言が必要。
- actual: `Butler-First Operating Principle` と gap classification を追加した。
- mismatch: なし。
- lesson: VTDD の完成条件は mac Codex の万能性ではなく、Butler + VPS Codex CLI へのハンドオフ可能性。
- should become RAG candidate: はい。VTDD の中核判断として保存候補。

## Verification Evidence

- Unit: なし。docs/process only。
- Integration: `git diff --check`: pass。
- E2E: なし。guardrail 文書更新。
- Manual: `AGENTS.md` diff を確認。
- Evidence path/link: `AGENTS.md`

## Butler Completion Contract

- Owner goal: VTDD が mac Codex 中心へ戻らず、Butler/iPhone/iPad + VPS Codex CLI 中心で設計されるようにする。
- Butler entrypoint: 変更なし。
- Action Schema exposure: 変更なし。
- Runtime path: 変更なし。
- Runner/runtime truth: 変更なし。
- Authority boundary: 変更なし。
- E2E evidence: process guardrail のため該当なし。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 不要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 不要。

## Related Constitution Rules

- Butler Completion Gate
- Thread-Independent Startup Contract
- Drift Stop Protocol
- Evidence Discipline

## Out-of-scope but NOT implemented

- Butler repository read 実装
- VPS Codex CLI 会話 loop 実装
- RAG schema/route 変更
- runtime/deploy 変更

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue:
- Execution ID: manual-mac-codex-butler-first-guard
- Goal: process_guardrail
