### PR TITLE
Issue #344: Butler Action 認証復旧導線を明示

### DIFF
--- a/docs/setup/custom-gpt-actions-openapi.json
+++ b/docs/setup/custom-gpt-actions-openapi.json
@@ -1479,7 +1479,7 @@
     "/v2/action/github-actions-secret": {
       "post": {
         "operationId": "vtddSyncGitHubActionsSecret",
-        "summary": "Sync an approved GitHub Actions secret such as OPENAI_API_KEY after GO plus real passkey approval.",
+        "summary": "Sync an approved GitHub Actions secret such as OPENAI_API_KEY or VTDD_GATEWAY_BEARER_TOKEN after GO plus real passkey approval.",
         "requestBody": {
           "required": true,
           "content": {
@@ -1493,7 +1493,8 @@
                   "secretName": {
                     "type": "string",
                     "enum": [
-                      "OPENAI_API_KEY"
+                      "OPENAI_API_KEY",
+                      "VTDD_GATEWAY_BEARER_TOKEN"
                     ]
                   },
                   "secretValue": {

--- a/docs/setup/custom-gpt-actions-openapi.yaml
+++ b/docs/setup/custom-gpt-actions-openapi.yaml
@@ -989,7 +989,7 @@ paths:
   /v2/action/github-actions-secret:
     post:
       operationId: vtddSyncGitHubActionsSecret
-      summary: Sync an approved GitHub Actions secret such as OPENAI_API_KEY after GO plus real passkey approval.
+      summary: Sync an approved GitHub Actions secret such as OPENAI_API_KEY or VTDD_GATEWAY_BEARER_TOKEN after GO plus real passkey approval.
       requestBody:
         required: true
         content:
@@ -1003,6 +1003,7 @@ paths:
                   type: string
                   enum:
                     - OPENAI_API_KEY
+                    - VTDD_GATEWAY_BEARER_TOKEN
                 secretValue:
                   type: string
                 policyInput:

--- a/docs/setup/custom-gpt-instructions-short-min.md
+++ b/docs/setup/custom-gpt-instructions-short-min.md
@@ -22,6 +22,7 @@ Repository and nickname:
 - Unsupported read=>未対応. Auth fail=>認証失敗. Do not infer absence from failed, unsupported, unauthorized, or unverified reads.
 Self-parity and setup drift:
 - For stale/outdated: vtddRetrieveSelfParity repo=<resolved>, ref=main; vtddRetrieveSetupArtifact.
+- Protected retrieve auth/ClientResponseError=>check Action Bearer; not nickname absent.
 - runtimeParity=cloudflare_deploy_update_required=>Cloudflare deploy update required. in_sync missing behavior=>Action Schema/Instructions update required.
 - Parity unchecked=>未検証 + error/reason/issues. ClientResponseError=>state action + unverified transport. runtime in_sync=>don't claim editor sync.
 Execution and remote Codex handoff:

--- a/docs/setup/custom-gpt-instructions-short.md
+++ b/docs/setup/custom-gpt-instructions-short.md
@@ -21,6 +21,7 @@ GitHub read:
 - Unsupported => 未対応. Auth fail => 認証失敗. Do not infer absence from failed reads.
 Self-parity:
 - Use vtddRetrieveSelfParity repo=<resolved>, ref=main. Surface Cloudflare deploy update required / Action Schema update required / Instructions update required / errors.
+- Protected retrieve auth/ClientResponseError=>check Action Bearer; not nickname/Issue absent.
 - Parity unchecked=>`未検証`. If self-parity returns `ClientResponseError`, say unverified transport failure. vtddRetrieveSetupArtifact. in_sync runtime != editor sync.
 Execution:
 - Before execution, read runtime truth; when needed, vtddRetrieveGitHub PR/branch/checks/runs.

--- a/docs/setup/custom-gpt-instructions.md
+++ b/docs/setup/custom-gpt-instructions.md
@@ -229,6 +229,7 @@ Butler self-parity and setup artifact recovery:
   - openapi_json
 - When returning canonical setup artifacts, make it clear they are the repository canonical source, not proof that the current Custom GPT editor is already updated.
 - If a self-parity check says runtime is in sync, do not overclaim that the current Custom GPT editor is also in sync; editor-side drift can still require Action Schema or Instructions refresh.
+- If protected retrieve Actions such as `vtddRetrieveRepositoryNicknames` or `vtddStartupPreflight` return `ClientResponseError` / 認証失敗, do not conclude the nickname or Issue is missing. First report that Custom GPT Action Authentication may not be sending the configured Bearer token. `/health` is unauthenticated; protected `/v2/retrieve/*` routes require `GatewayBearerAuth`.
 - If any Butler action returns structured failure fields such as `error`, `reason`, or `issues`, summarize those exact fields in Japanese before proposing the next step.
 - Do not hide specific runtime failures behind generic summaries if the worker already returned a concrete cause.
 - If a self-parity Action fails with `ClientResponseError`, report it as an unverified Action transport failure with the action name, HTTP status if visible, visible body fields, and missing `error` / `reason` / `issues` fields; then say the Custom GPT Action Schema may need refresh if canonical schema exposes those fields.

--- a/src/core/custom-gpt-setup-artifacts.js
+++ b/src/core/custom-gpt-setup-artifacts.js
@@ -921,6 +921,17 @@ function renderRecoveryBundleSections(recovery) {
       </div>
     </section>
     <section>
+      <h2>Custom GPT Action Authentication</h2>
+      <p class="small">Action Schema を貼り直しても、Custom GPT editor の Authentication 設定は runtime から読めません。protected retrieve が ClientResponseError / 認証失敗になる場合は、Action の Authentication を確認してください。</p>
+      <div class="meta">
+        <div><strong>Authentication type</strong><br>API Key</div>
+        <div><strong>Auth type</strong><br>Bearer</div>
+        <div><strong>Header</strong><br>Authorization: Bearer &lt;VTDD_GATEWAY_BEARER_TOKEN&gt;</div>
+        <div><strong>Unauthenticated route</strong><br>/health only</div>
+      </div>
+      <p class="small">token value はここには表示しません。iPhone の保管場所から Custom GPT Action Authentication に貼り直してください。</p>
+    </section>
+    <section>
       <h2>Copy-ready Action Schema</h2>
       <p class="small">source: ${escapeHtml(actionSchema.path)}; sourceSha: ${escapeHtml(actionSchema.sourceSha)}; copy payload: raw YAML, not URL encoded</p>
       <p><button type="button" data-copy-target="action-schema" data-copy-label="Copy Action Schema">Copy Action Schema</button></p>

--- a/test/custom-gpt-setup-docs.test.js
+++ b/test/custom-gpt-setup-docs.test.js
@@ -141,6 +141,8 @@ test("custom gpt instructions preserve current butler and approval boundaries", 
   assert.equal(doc.includes("Action Schema update required"), true);
   assert.equal(doc.includes("Instructions update required"), true);
   assert.equal(doc.includes("runtime is in sync, do not overclaim that the current Custom GPT editor is also in sync"), true);
+  assert.equal(doc.includes("Custom GPT Action Authentication may not be sending the configured Bearer token"), true);
+  assert.equal(doc.includes("protected `/v2/retrieve/*` routes require `GatewayBearerAuth`"), true);
   assert.equal(doc.includes("surface the returned `error`, `reason`, and `issues` plainly in Japanese"), true);
   assert.equal(doc.includes("Do not collapse nickname failures into vague guesses"), true);
   assert.equal(doc.includes("If the Action surface reports `ClientResponseError`"), true);
@@ -243,6 +245,7 @@ test("short custom gpt instructions stay under editor limits while preserving cr
   assert.equal(doc.includes("Cloudflare deploy update required"), true);
   assert.equal(doc.includes("Action Schema update required"), true);
   assert.equal(doc.includes("Instructions update required"), true);
+  assert.equal(doc.includes("Protected retrieve auth/ClientResponseError=>check Action Bearer"), true);
   assert.equal(doc.includes("selfParity.deployRecovery.operatorMarkdownLink or operatorUrl"), true);
   assert.equal(doc.includes("selfParity.deployOperatorMarkdownLink"), true);
   assert.equal(doc.includes("<actual selfParity.deployOperatorUrl>"), true);
@@ -323,6 +326,7 @@ test("custom gpt openapi doc exposes current gateway, execute, and progress rout
   assert.equal(doc.includes("/v2/action/github-authority:"), true);
   assert.equal(doc.includes("/v2/action/deploy:"), true);
   assert.equal(doc.includes("/v2/action/github-actions-secret:"), true);
+  assert.equal(doc.includes("- VTDD_GATEWAY_BEARER_TOKEN"), true);
   assert.equal(doc.includes("/v2/action/repository-nickname:"), true);
   assert.equal(doc.includes("/v2/action/repository-nickname/delete:"), true);
   assert.equal(doc.includes("/v2/action/progress:"), true);
@@ -405,6 +409,12 @@ test("custom gpt openapi json parses and exposes paths as an object", () => {
   assert.equal(typeof doc.paths["/v2/action/github-authority"], "object");
   assert.equal(typeof doc.paths["/v2/action/deploy"], "object");
   assert.equal(typeof doc.paths["/v2/action/github-actions-secret"], "object");
+  assert.equal(
+    doc.paths["/v2/action/github-actions-secret"].post.requestBody.content[
+      "application/json"
+    ].schema.properties.secretName.enum.includes("VTDD_GATEWAY_BEARER_TOKEN"),
+    true
+  );
   assert.equal(typeof doc.paths["/v2/action/repository-nickname"], "object");
   assert.equal(typeof doc.paths["/v2/action/repository-nickname/delete"], "object");
   assert.equal(

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -694,6 +694,11 @@ test("worker setup latest page renders copy-ready schema and short-min bundle fo
   assert.equal(html.includes("VTDD Butler short-min instructions"), true);
   assert.equal(html.includes("URL separation"), true);
   assert.equal(html.includes("Action Schema server URL"), true);
+  assert.equal(html.includes("Custom GPT Action Authentication"), true);
+  assert.equal(html.includes("Authentication type"), true);
+  assert.equal(html.includes("Auth type"), true);
+  assert.equal(html.includes("Authorization: Bearer &lt;VTDD_GATEWAY_BEARER_TOKEN&gt;"), true);
+  assert.equal(html.includes("Unauthenticated route"), true);
   assert.equal(html.includes("copy payload: raw YAML, not URL encoded"), true);
   assert.equal(html.includes("copy payload: raw Markdown, not URL encoded"), true);
   assert.equal(html.includes("Bundle commit"), true);

--- a/worker.js
+++ b/worker.js
@@ -37038,6 +37038,17 @@ function renderRecoveryBundleSections(recovery) {
       </div>
     </section>
     <section>
+      <h2>Custom GPT Action Authentication</h2>
+      <p class="small">Action Schema \u3092\u8CBC\u308A\u76F4\u3057\u3066\u3082\u3001Custom GPT editor \u306E Authentication \u8A2D\u5B9A\u306F runtime \u304B\u3089\u8AAD\u3081\u307E\u305B\u3093\u3002protected retrieve \u304C ClientResponseError / \u8A8D\u8A3C\u5931\u6557\u306B\u306A\u308B\u5834\u5408\u306F\u3001Action \u306E Authentication \u3092\u78BA\u8A8D\u3057\u3066\u304F\u3060\u3055\u3044\u3002</p>
+      <div class="meta">
+        <div><strong>Authentication type</strong><br>API Key</div>
+        <div><strong>Auth type</strong><br>Bearer</div>
+        <div><strong>Header</strong><br>Authorization: Bearer &lt;VTDD_GATEWAY_BEARER_TOKEN&gt;</div>
+        <div><strong>Unauthenticated route</strong><br>/health only</div>
+      </div>
+      <p class="small">token value \u306F\u3053\u3053\u306B\u306F\u8868\u793A\u3057\u307E\u305B\u3093\u3002iPhone \u306E\u4FDD\u7BA1\u5834\u6240\u304B\u3089 Custom GPT Action Authentication \u306B\u8CBC\u308A\u76F4\u3057\u3066\u304F\u3060\u3055\u3044\u3002</p>
+    </section>
+    <section>
       <h2>Copy-ready Action Schema</h2>
       <p class="small">source: ${escapeHtml3(actionSchema.path)}; sourceSha: ${escapeHtml3(actionSchema.sourceSha)}; copy payload: raw YAML, not URL encoded</p>
       <p><button type="button" data-copy-target="action-schema" data-copy-label="Copy Action Schema">Copy Action Schema</button></p>


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #344 の startup preflight で、Butler が protected retrieve の ClientResponseError を nickname/repo 不在と誤読しないようにする部分進捗。Action Schema と setup/latest に Custom GPT Action Bearer 認証の復旧導線を追加する。

## Satisfied Success Criteria

- Protected retrieve の ClientResponseError / 認証失敗時は、nickname や Issue 不在ではなく Custom GPT Action Authentication の Bearer token 不送信を先に疑うよう Instructions に明記した。
- vtddSyncGitHubActionsSecret の Action Schema enum に、runtime が既に扱う VTDD_GATEWAY_BEARER_TOKEN を追加した。
- /setup/latest に Custom GPT Action Authentication の確認項目を追加し、iPhone から token 保管場所を見て貼り直す復旧導線を表示する。
- RAG checkpoint working_memory_344_20260515175950_butler_nickname_preflight_repo_custom_gp を保存し、retrieval で先頭 hit することを確認した。

## Unsatisfied Success Criteria

- Custom GPT editor の現在の Authentication 設定は外部から読めないため、この PR だけでは editor 内 Bearer token の実状態は未検証。
- merge/deploy 後に /setup/latest から Action Schema と Instructions を更新し、Butler で nickname read と vtddStartupPreflight の live 再実行が必要。
- Issue #344 全体の 3 surface startup preflight parity は未完了。

## Non-goal violations

VPS Codex CLI 会話ループ、runner 常駐、GitHub App 権限、Cloudflare secret rotation、Custom GPT editor 自動更新はこの PR では触らない。

## Dry-run Impact Report

- Target Issue: Issue #344
- Implementing Success Criteria: preflight 失敗時は 未確認 と明示し推測で作業を始めない / owner が iPhone だけで復旧できる説明を得られる / 3 surface が同じ失敗パターンを RAG から読めるための部分進捗。
- Explicit Non-goals: Issue #344 全体完了、Butler repository-read 完了、shared RAG 全体完了、credential rotation は対象外。
- Expected touched files/routes/workflows: docs/setup/custom-gpt-actions-openapi.yaml,json; docs/setup/custom-gpt-instructions*.md; src/core/custom-gpt-setup-artifacts.js; test/custom-gpt-setup-docs.test.js; test/worker.test.js; worker.js
- Affected Issues: Issue #344。関連して Issue #341 / Issue #342 / Issue #343 の開始時 preflight 判断に効くが、この PR では実装しない。
- Affected PRs: なし。
- Affected workflows: Custom GPT setup artifact validation / generated worker check / self-parity check。GitHub Actions reviewer workflow は変更しない。
- Affected runtime/operator surfaces: Butler Action Schema, Custom GPT Instructions, /setup/latest, Worker generated bundle。VPS runner と GitHub authority route は変更しない。
- What may break if we patch narrowly: short-min だけ直すと Action Schema enum と setup page がズレたままになり、Butler が再び ClientResponseError を repo 未解決と誤読する。schema だけ直すと iPhone からの復旧導線が残らない。
- Unknowns to investigate before coding: Custom GPT editor の Bearer token 設定は runtime から読めない。merge/deploy 後に owner が editor 更新し、Butler live action で再確認する必要がある。
- Validation needed: npm test; self-parity; generated worker check; post-merge deploy; setup/latest 更新確認; Butler live nickname/preflight retry。
- Stop condition: Custom GPT editor の実 token 状態を runtime が読めるかのように主張しそうになったら停止する。Issue #344 全体完了と誤認しそうになったら停止する。

## File / Line Hypotheses

- file: docs/setup/custom-gpt-actions-openapi.yaml / json
  - hypothesis: runtime は VTDD_GATEWAY_BEARER_TOKEN secret sync に対応済みだが Action Schema enum が古く、Butler から選べない。
  - risk if changed narrowly: schema と runtime の drift が残る。
  - validation: docs test と self-parity。
  - related Issue: Issue #344
- file: docs/setup/custom-gpt-instructions*.md
  - hypothesis: Butler が ClientResponseError を nickname 不在と誤読するため、protected retrieve auth failure の扱いを明文化する必要がある。
  - risk if changed narrowly: short/short-min だけズレる。
  - validation: instruction doc tests と length tests。
  - related Issue: Issue #344
- file: src/core/custom-gpt-setup-artifacts.js
  - hypothesis: /setup/latest に Action Authentication の復旧手順が見えないと iPhone 復旧が詰まる。
  - risk if changed narrowly: setup page と docs の復旧導線が食い違う。
  - validation: worker setup page test。
  - related Issue: Issue #344

## Hypothesis Retrospective

- expected: protected retrieve の ClientResponseError は Bearer 認証不備として扱う導線が必要。
- actual: /health は未認証で到達し、protected retrieve は action_visible 401 を返せるため、runtime 到達性ではなく Action Authentication 伝播が疑わしい。
- mismatch: Action Schema の github-actions-secret enum が runtime 対応済みの VTDD_GATEWAY_BEARER_TOKEN を含んでいなかった。
- lesson: ClientResponseError を repo/nickname 不在と読まず、auth/schema/runtime drift を先に確認する。
- should become RAG candidate: yes。working_memory_344_20260515175950_butler_nickname_preflight_repo_custom_gp として保存済み。

## Verification Evidence

- Unit: npm test: pass 806, skipped 1。custom-gpt setup docs / worker setup page / runtime parity を含む。
- Integration: npm run check:self-parity: passed。npm run check:generated-worker: passed as part of npm test。
- E2E: 未実施。merge/deploy/Custom GPT 更新後に Butler live action で nickname read と vtddStartupPreflight を再確認する。
- Manual: runtime curl で /health は 200、protected retrieve は no-auth + responseMode=action_visible で ok:false/httpStatus 401 を確認。RAG write/retrieve 確認済み。
- Evidence path/link: RAG: working_memory_344_20260515175950_butler_nickname_preflight_repo_custom_gp / local test output: npm test

## Butler Completion Contract

- Owner goal: iPhone Butler が startup preflight 失敗時に repo 未解決と誤判定せず、Action Bearer 認証確認へ誘導できること。
- Butler entrypoint: Butler の protected retrieve 失敗時の応答と /setup/latest の復旧ページ。
- Action Schema exposure: vtddSyncGitHubActionsSecret secretName enum に VTDD_GATEWAY_BEARER_TOKEN を追加。
- Runtime path: /setup/latest rendering; existing /v2/retrieve/* protected routes; existing /v2/action/github-actions-secret route。
- Runner/runtime truth: runtime route は既存。Custom GPT editor auth state は外部から読めないため unverified。
- Authority boundary: 新しい high-risk authority は追加しない。secret sync や deploy は引き続き GO + passkey。
- E2E evidence: 未完了。post-merge deploy と Custom GPT 更新後に Butler で live retry が必要。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 必要。/setup/latest と worker.js が変わるため。
- Custom GPT Action Schema update: 必要。VTDD_GATEWAY_BEARER_TOKEN enum 追加。
- Custom GPT Instructions update: 必要。protected retrieve auth failure の誤読防止を追加。
- iPhone Butler live E2E: 必要。Action Authentication を確認後、ぶい nickname read と Issue #344 startup preflight を再実行する。

## Related Constitution Rules

- Issue が正本。runtime truth > memory。Butler completion には owner-facing workflow evidence が必要。ClientResponseError や認証失敗から absence を推測しない。

## Out-of-scope but NOT implemented

- Issue #344 全体完了。VPS Codex CLI 会話。runner 常駐。Cloudflare/GitHub/Custom GPT credential mutation。

## Extra changes (if any)

worker.js は src/core/custom-gpt-setup-artifacts.js 変更に合わせて npm run build:worker で再生成。

<!-- VTDD metadata -->
- Issue: Issue #344
- Execution ID: Not provided.
- Goal: Not provided.
