### PR TITLE
Issue #344 startup preflight の Butler-first 判定を修正

### DIFF
--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -982,16 +982,16 @@ async function buildStartupPreflight({
   const activeIssue = issueRecords[0] ?? null;
   const openIssues = openIssuesResult.ok ? openIssuesResult.read.records : [];
   const threadLocalAssumptionsPromoted =
-    sources.some(
-      (source) =>
-        source.path === "AGENTS.md" &&
-        String(source.excerpt || "").includes("Butler-First Operating Principle")
-    ) &&
-    sources.some(
-      (source) =>
-        source.path === "docs/butler/thread-independent-startup-contract.md" &&
-        String(source.excerpt || "").includes("threadLocalAssumptionsPromoted")
-    );
+    startupSourceContentIncludes({
+      sourceResults,
+      path: "AGENTS.md",
+      text: "Butler-First Operating Principle"
+    }) &&
+    startupSourceContentIncludes({
+      sourceResults,
+      path: "docs/butler/thread-independent-startup-contract.md",
+      text: "threadLocalAssumptionsPromoted"
+    });
 
   return {
     schemaVersion: "startup_preflight_v1",
@@ -1207,6 +1207,15 @@ function buildStartupNextSafeAction({ issueNumber, currentSurface, missingSource
   return issueNumber
     ? `Issue #${issueNumber} の Intent / Success Criteria / Non-goals に沿って dry-run impact gate へ進む。`
     : "対象 Issue を確認してから dry-run impact gate へ進む。";
+}
+
+function startupSourceContentIncludes({ sourceResults, path, text }) {
+  return sourceResults.some(
+    (result) =>
+      result.ok &&
+      result.path === path &&
+      String(result.record?.content || "").includes(text)
+  );
 }
 
 function compactExcerpt(value, maxLength = 400) {

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -992,6 +992,7 @@ async function buildStartupPreflight({
       path: "docs/butler/thread-independent-startup-contract.md",
       text: "threadLocalAssumptionsPromoted"
     });
+  const butlerFirstPrincipleStatus = threadLocalAssumptionsPromoted ? "promoted" : "未確認";
 
   return {
     schemaVersion: "startup_preflight_v1",
@@ -1011,7 +1012,7 @@ async function buildStartupPreflight({
       "surface_capability"
     ],
     butlerFirstPrinciple: {
-      status: threadLocalAssumptionsPromoted ? "promoted" : "未確認",
+      status: butlerFirstPrincipleStatus,
       summary:
         "VTDD is iPhone/iPad-first and handoff-first. Butler is the owner delegate; VPS Codex CLI is the always-on execution surface; mac Codex is auxiliary, not the normal operating center.",
       macCodexCompletionRule:

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -3669,11 +3669,13 @@ test("worker returns Butler startup preflight from shared repo truth and memory"
   const sourceContent = {
     "AGENTS.md": [
       "# AGENTS.md",
+      "Purpose: ".padEnd(520, "x"),
       "## Butler-First Operating Principle",
       "VTDD is iPhone/iPad-first and handoff-first."
     ].join("\n"),
     "docs/butler/thread-independent-startup-contract.md": [
       "# Thread-independent startup contract",
+      "Startup source order: ".padEnd(520, "y"),
       "threadLocalAssumptionsPromoted=false",
       "Butler -> VPS Codex CLI"
     ].join("\n"),
@@ -3797,6 +3799,7 @@ test("worker returns Butler startup preflight from shared repo truth and memory"
   assert.equal(body.startupPreflight.repository, "sample-org/vtdd-v2-p");
   assert.equal(body.startupPreflight.issueNumber, 344);
   assert.equal(body.startupPreflight.threadLocalAssumptionsPromoted, true);
+  assert.equal(body.startupPreflight.butlerFirstPrinciple.status, "promoted");
   assert.equal(body.startupPreflight.activeIssue.number, 344);
   assert.equal(body.startupPreflight.memory.status, "read");
   assert.equal(body.startupPreflight.memory.compactContext[0].id, "startup-preflight-memory-344");

--- a/worker.js
+++ b/worker.js
@@ -55617,11 +55617,15 @@ async function buildStartupPreflight({
   const issueRecords = issueResult.ok ? issueResult.read.records : [];
   const activeIssue = issueRecords[0] ?? null;
   const openIssues = openIssuesResult.ok ? openIssuesResult.read.records : [];
-  const threadLocalAssumptionsPromoted = sources.some(
-    (source) => source.path === "AGENTS.md" && String(source.excerpt || "").includes("Butler-First Operating Principle")
-  ) && sources.some(
-    (source) => source.path === "docs/butler/thread-independent-startup-contract.md" && String(source.excerpt || "").includes("threadLocalAssumptionsPromoted")
-  );
+  const threadLocalAssumptionsPromoted = startupSourceContentIncludes({
+    sourceResults,
+    path: "AGENTS.md",
+    text: "Butler-First Operating Principle"
+  }) && startupSourceContentIncludes({
+    sourceResults,
+    path: "docs/butler/thread-independent-startup-contract.md",
+    text: "threadLocalAssumptionsPromoted"
+  });
   return {
     schemaVersion: "startup_preflight_v1",
     issueNumber: issueNumber || null,
@@ -55820,6 +55824,11 @@ function buildStartupNextSafeAction({ issueNumber, currentSurface, missingSource
     return "mac Codex \u3067\u9032\u3081\u308B\u524D\u306B\u3001\u540C\u3058\u4F5C\u696D\u3092 Butler/VPS Codex CLI \u306B\u6E21\u305B\u308B\u304B\u3092\u660E\u793A\u3059\u308B\u3002";
   }
   return issueNumber ? `Issue #${issueNumber} \u306E Intent / Success Criteria / Non-goals \u306B\u6CBF\u3063\u3066 dry-run impact gate \u3078\u9032\u3080\u3002` : "\u5BFE\u8C61 Issue \u3092\u78BA\u8A8D\u3057\u3066\u304B\u3089 dry-run impact gate \u3078\u9032\u3080\u3002";
+}
+function startupSourceContentIncludes({ sourceResults, path, text }) {
+  return sourceResults.some(
+    (result) => result.ok && result.path === path && String(result.record?.content || "").includes(text)
+  );
 }
 function compactExcerpt(value, maxLength = 400) {
   const text = normalizeText30(value).replace(/\s+/g, " ");

--- a/worker.js
+++ b/worker.js
@@ -55626,6 +55626,7 @@ async function buildStartupPreflight({
     path: "docs/butler/thread-independent-startup-contract.md",
     text: "threadLocalAssumptionsPromoted"
   });
+  const butlerFirstPrincipleStatus = threadLocalAssumptionsPromoted ? "promoted" : "\u672A\u78BA\u8A8D";
   return {
     schemaVersion: "startup_preflight_v1",
     issueNumber: issueNumber || null,
@@ -55644,7 +55645,7 @@ async function buildStartupPreflight({
       "surface_capability"
     ],
     butlerFirstPrinciple: {
-      status: threadLocalAssumptionsPromoted ? "promoted" : "\u672A\u78BA\u8A8D",
+      status: butlerFirstPrincipleStatus,
       summary: "VTDD is iPhone/iPad-first and handoff-first. Butler is the owner delegate; VPS Codex CLI is the always-on execution surface; mac Codex is auxiliary, not the normal operating center.",
       macCodexCompletionRule: "If mac Codex performs a step Butler cannot perform, classify it as mac_codex_only_probe or a Butler/VPS/recovery gap, not VTDD completion."
     },


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #344 の startup preflight が、GitHub 上の AGENTS.md と thread-independent startup contract に昇格済みの Butler-first / thread-local 前提を読んだ時、excerpt の長さに左右されず promoted と判定できるようにする部分進捗です。

## Satisfied Success Criteria

- startup preflight に VTDD identity / Butler-first principle の runtime 判定が含まれる。
preflight が読む repo source が長い場合でも、GitHub read plane の full content に基づいて threadLocalAssumptionsPromoted を判定する。
誤って 未確認 になる fixture を追加し、既存 response field `butlerFirstPrinciple.status` が promoted を返すことを runtime test で確認する。

## Unsatisfied Success Criteria

- Issue #344 の 3 surface parity evidence は未実施です。
Butler / mac Codex / VPS Codex CLI が同じ preflight result を返す live E2E は未実施です。
Butler からの live iPhone/iPad-facing E2E は未実施です。
この PR だけでは Issue #344 は close しません。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #344
- Implementing Success Criteria: startup preflight に VTDD identity / GitHub が正本 / Issue が起点 / runtime truth > memory が含まれること、および preflight 失敗時は 未確認 と明示すること。今回の実装対象は Butler-first / thread-local 昇格判定の誤判定修正に限定。
- Explicit Non-goals: Issue #344 全体完了、3 surface parity E2E、deploy、credential/permission 変更、Issue close、archived wizard 復活。
- Expected touched files/routes/workflows: src/worker/runtime.js, test/worker.test.js, worker.js。route は /v2/retrieve/startup-preflight の既存 runtime path のみ。workflow 変更なし。
- Affected Issues: Issue #344。子 Issue #341/#342/#343 は完了扱いしない。
- Affected PRs: なし。PR #402 後の main から分岐。
- Affected workflows: GitHub Actions の test/check-generated-worker に影響。workflow 定義変更なし。
- Affected runtime/operator surfaces: Butler Custom GPT Action の vtddStartupPreflight response、Worker runtime、mac Codex/VPS Codex CLI が読む startup preflight result。Custom GPT Action Schema と Instructions は未変更。
- What may break if we patch narrowly: excerpt 表示用フィールドを判定に使い続けると、長い AGENTS.md や contract で promoted が false になり、Butler が repo に昇格済みの前提を 未確認 と誤表示する。full content 判定へ限定変更するため response shape は変えない。既存の `butlerFirstPrinciple.status` を新設したのではなく、値の算出根拠だけを full content に変更する。
- Unknowns to investigate before coding: live runtime の RAG/provider 状態と Butler iPhone surface での実測はこの PR では未確認。deploy 後に Butler-facing E2E が必要。
- Validation needed: node --test、npm run check:self-parity、npm run build:worker、PR/CI 上の check-generated-worker。live Butler E2E は別 evidence として必要。
- Stop condition: GitHub source read が失敗する、full content が取得できない、または Action Schema/Instructions/route 接続の変更が必要になる場合はこの PR で推測実装せず停止。

## File / Line Hypotheses

- file: `src/worker/runtime.js:984`
  - hypothesis: threadLocalAssumptionsPromoted が sources[].excerpt を見ているため、repo source の先頭 420 文字に marker がないと false になる。
  - risk if changed narrowly: response excerpt の表示用途と判定用途を混同したままだと live preflight が 未確認 を返す。full content に限定して判定すれば API shape は変えずに修正できる。
  - validation: marker を 520 文字後ろに置いた fixture で vtddStartupPreflight が promoted を返すこと。
  - related Issue: #344

## Hypothesis Retrospective

- expected: excerpt 判定が原因で、長い canonical docs では Butler-first 昇格済みでも 未確認 になる。
- actual: runtime は excerpt ではなく GitHub read plane の full content を見るようになり、長い fixture でも promoted を返した。
- mismatch: なし。
- lesson: startup preflight の truth 判定には owner-facing excerpt を使わず、取得済み source content を使う。
- should become RAG candidate: いいえ。既存 Issue #344 と PR evidence で足りる小修正。

## Verification Evidence

- Unit: node --test test/worker.test.js --test-name-pattern 'worker returns Butler startup preflight' は test/worker.test.js 全体 116 件 pass。node --test は 806 pass / 1 live-only skip。
- Integration: npm run check:self-parity pass。node --test test/thread-independent-startup-contract.test.js test/custom-gpt-setup-docs.test.js test/butler-capability-matrix.test.js は 14 pass。
- E2E: 未実施。この PR は Butler-facing live E2E 完了を主張しない。
- Manual: git diff --check pass。npm run build:worker 実行済み。npm run check:generated-worker pass。PR CI の guarded-policy, test, gemini-pr-review も initial run では SUCCESS。
- Evidence path/link: test/worker.test.js の startup preflight fixture とこの PR の Verification Evidence。

## Butler Completion Contract

- Owner goal: Butler が startup preflight で、repo に昇格済みの Butler-first 前提を誤って 未確認 と言わないようにする。
- Butler entrypoint: 既存 vtddStartupPreflight。新規 entrypoint は追加しない。
- Action Schema exposure: 未変更。/v2/retrieve/startup-preflight と operationId vtddStartupPreflight は既存のまま。
- Runtime path: GET /v2/retrieve/startup-preflight。buildStartupPreflight の threadLocalAssumptionsPromoted 判定を full content ベースに修正。
- Runner/runtime truth: unit/integration evidence では promoted を確認。deploy 後 live runtime truth と Butler iPhone E2E は未実施。
- Authority boundary: 未変更。read-only retrieve path の修正で、新しい GO/passkey/high-risk authority は追加しない。
- E2E evidence: 未実施。この PR は Butler completion gate 全体を満たさない。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: この PR merge 後に runtime deploy が必要になる可能性あり。deploy 自体は GO + passkey 対象なのでこの PR では未実施。
- Custom GPT Action Schema update: 不要。schema path/operationId/parameters は未変更。
- Custom GPT Instructions update: 不要。Instructions は未変更。
- iPhone Butler live E2E: 未実施。deploy 後に vtddStartupPreflight を Butler から実行して promoted を確認する必要あり。

## Related Constitution Rules

- Issue が正本。
Butler completion gate を過大主張しない。
runtime truth > memory。
mac Codex only probe を VTDD completion と扱わない。
deploy / credential / permission / destructive は GO + passkey。

## Out-of-scope but NOT implemented

- 3 surface parity live E2E。
Issue #344 closure。
Custom GPT Action Schema / Instructions の変更。
Cloudflare deploy。
RAG memory write。

## Extra changes (if any)

Generated worker.js を npm run build:worker で更新。

<!-- VTDD metadata -->
- Issue: Issue #344
- Execution ID: Not provided.
- Goal: Not provided.

