### PR TITLE
Issue #359: clarify setup recovery latest metadata

### DIFF
--- a/src/core/custom-gpt-setup-artifacts.js
+++ b/src/core/custom-gpt-setup-artifacts.js
@@ -888,6 +888,7 @@ function renderRecoveryBundleSections(recovery) {
   const selfParity = recovery.runtime.selfParity;
   const surfaceUpdateChecklist = recovery.runtime.surfaceUpdateChecklist;
   const knownGoodComparison = recovery.runtime.knownGoodComparison;
+  const isKnownGoodChannel = recovery.channel === CustomGptSetupChannel.KNOWN_GOOD;
   const warning = instructions.limitExceeded
     ? `<section class="warning"><strong>Instructions exceed ${instructions.characterLimit} characters.</strong><p>${instructions.characterCount} characters. Shorten before pasting into the Custom GPT editor.</p></section>`
     : "";
@@ -944,11 +945,13 @@ function renderRecoveryBundleSections(recovery) {
       <textarea id="instructions-short-min" spellcheck="false">${escapeHtml(instructions.content)}</textarea>
     </section>
     <section>
-      <h2>${rollback.rollbackReady ? "Known-good rollback bundle" : "Known-good status / rollback preview"}</h2>
+      <h2>${isKnownGoodChannel ? "Known-good rollback bundle" : "Latest setup bundle metadata"}</h2>
       ${
         rollback.rollbackReady
           ? `<p><button type="button" data-copy-target="rollback-bundle" data-copy-label="Copy Rollback Bundle">Copy Rollback Bundle</button></p>`
-          : `<p class="small">Rollback は setup/known-good で copy-ready になります。latest は現在の候補確認用で、known-good としては未確認です。</p>`
+          : isKnownGoodChannel
+            ? `<p class="small">Known-good rollback bundle はまだ copy-ready ではありません。known-good source と runtime parity を確認してください。</p>`
+            : `<p class="small">この metadata は /setup/latest の現在候補です。Rollback copy-ready bundle は /setup/known-good でのみ表示します。latest は known-good としては未確認です。</p>`
       }
       <pre>${escapeHtml(
         [

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -697,6 +697,19 @@ test("worker setup latest page renders copy-ready schema and short-min bundle fo
   assert.equal(html.includes("Copy-ready custom-gpt-instructions-short-min.md"), true);
   assert.equal(html.includes("  - url: https://example.com"), true);
   assert.equal(html.includes("VTDD Butler short-min instructions"), true);
+  const actionSchemaTextarea = html.match(
+    /<textarea id="action-schema" spellcheck="false">([\s\S]*?)<\/textarea>/
+  )?.[1];
+  const instructionsTextarea = html.match(
+    /<textarea id="instructions-short-min" spellcheck="false">([\s\S]*?)<\/textarea>/
+  )?.[1];
+  assert.equal(actionSchemaTextarea?.includes("openapi: 3.1.1"), true);
+  assert.equal(actionSchemaTextarea?.includes("  - url: https://example.com"), true);
+  assert.equal(actionSchemaTextarea?.includes("openapi%3A"), false);
+  assert.equal(actionSchemaTextarea?.includes("%20-%20url"), false);
+  assert.equal(actionSchemaTextarea?.includes("[Open deploy operator]"), false);
+  assert.equal(instructionsTextarea?.includes(shortMin), true);
+  assert.equal(instructionsTextarea?.includes("VTDD%20Butler"), false);
   assert.equal(html.includes("URL separation"), true);
   assert.equal(html.includes("Action Schema server URL"), true);
   assert.equal(html.includes("Custom GPT Action Authentication"), true);
@@ -709,7 +722,9 @@ test("worker setup latest page renders copy-ready schema and short-min bundle fo
   assert.equal(html.includes("Bundle commit"), true);
   assert.equal(html.includes("bundleCommitSha: " + "b".repeat(40)), true);
   assert.equal(html.includes("knownGoodCommitSha: 未確認"), true);
-  assert.equal(html.includes("Rollback は setup/known-good で copy-ready になります。latest は現在の候補確認用で、known-good としては未確認です。"), true);
+  assert.equal(html.includes("Latest setup bundle metadata"), true);
+  assert.equal(html.includes("Rollback copy-ready bundle は /setup/known-good でのみ表示します。"), true);
+  assert.equal(html.includes("Known-good rollback bundle"), false);
   assert.equal(html.includes("Action Schema length"), true);
   assert.equal(html.includes("instructionsShortMinLength:"), true);
   assert.equal(html.includes("Surface update checklist"), true);
@@ -781,6 +796,7 @@ test("worker setup known-good page renders rollback copy-ready bundle from known
   assert.equal(response.status, 200);
   const html = await response.text();
   assert.equal(html.includes("known-good setup bundle"), true);
+  assert.equal(html.includes("Known-good rollback bundle"), true);
   assert.equal(html.includes("Copy Rollback Bundle"), true);
   assert.equal(html.includes(`channel: known_good`), true);
   assert.equal(html.includes(`ref: ${knownGoodSha}`), true);
@@ -815,6 +831,8 @@ test("worker setup known-good page does not silently treat main as known-good", 
   assert.equal(html.includes("Do not treat main/latest as known-good automatically."), true);
   assert.equal(html.includes("Copy-ready Action Schema"), false);
   assert.equal(html.includes("Copy-ready custom-gpt-instructions-short-min.md"), false);
+  assert.equal(html.includes("Known-good rollback bundle"), false);
+  assert.equal(html.includes("Latest setup bundle metadata"), false);
 });
 
 test("worker setup known-good page rejects malformed configured known-good refs", async () => {

--- a/worker.js
+++ b/worker.js
@@ -37046,6 +37046,7 @@ function renderRecoveryBundleSections(recovery) {
   const selfParity = recovery.runtime.selfParity;
   const surfaceUpdateChecklist = recovery.runtime.surfaceUpdateChecklist;
   const knownGoodComparison = recovery.runtime.knownGoodComparison;
+  const isKnownGoodChannel = recovery.channel === CustomGptSetupChannel.KNOWN_GOOD;
   const warning = instructions.limitExceeded ? `<section class="warning"><strong>Instructions exceed ${instructions.characterLimit} characters.</strong><p>${instructions.characterCount} characters. Shorten before pasting into the Custom GPT editor.</p></section>` : "";
   return `
     ${warning}
@@ -37099,8 +37100,8 @@ function renderRecoveryBundleSections(recovery) {
       <textarea id="instructions-short-min" spellcheck="false">${escapeHtml3(instructions.content)}</textarea>
     </section>
     <section>
-      <h2>${rollback.rollbackReady ? "Known-good rollback bundle" : "Known-good status / rollback preview"}</h2>
-      ${rollback.rollbackReady ? `<p><button type="button" data-copy-target="rollback-bundle" data-copy-label="Copy Rollback Bundle">Copy Rollback Bundle</button></p>` : `<p class="small">Rollback \u306F setup/known-good \u3067 copy-ready \u306B\u306A\u308A\u307E\u3059\u3002latest \u306F\u73FE\u5728\u306E\u5019\u88DC\u78BA\u8A8D\u7528\u3067\u3001known-good \u3068\u3057\u3066\u306F\u672A\u78BA\u8A8D\u3067\u3059\u3002</p>`}
+      <h2>${isKnownGoodChannel ? "Known-good rollback bundle" : "Latest setup bundle metadata"}</h2>
+      ${rollback.rollbackReady ? `<p><button type="button" data-copy-target="rollback-bundle" data-copy-label="Copy Rollback Bundle">Copy Rollback Bundle</button></p>` : isKnownGoodChannel ? `<p class="small">Known-good rollback bundle \u306F\u307E\u3060 copy-ready \u3067\u306F\u3042\u308A\u307E\u305B\u3093\u3002known-good source \u3068 runtime parity \u3092\u78BA\u8A8D\u3057\u3066\u304F\u3060\u3055\u3044\u3002</p>` : `<p class="small">\u3053\u306E metadata \u306F /setup/latest \u306E\u73FE\u5728\u5019\u88DC\u3067\u3059\u3002Rollback copy-ready bundle \u306F /setup/known-good \u3067\u306E\u307F\u8868\u793A\u3057\u307E\u3059\u3002latest \u306F known-good \u3068\u3057\u3066\u306F\u672A\u78BA\u8A8D\u3067\u3059\u3002</p>`}
       <pre>${escapeHtml3(
     [
       `repository: ${recovery.repository}`,


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #359 の recovery page で latest と known-good rollback の役割を混同しないようにし、copy-ready payload が raw YAML/Markdown のまま URL encoded や Markdown link と混ざらないことをテストで固定する。

## Satisfied Success Criteria

- latest setup page の metadata 見出しを Latest setup bundle metadata に変更し、/setup/known-good の rollback bundle と分離した。\nAction Schema textarea が raw YAML を含み、URL encoded 文字列や deploy operator Markdown link を含まないことを worker test で固定した。\nInstructions textarea が raw Markdown を含み、URL encoded 文字列ではないことを worker test で固定した。\nknown-good page は Known-good rollback bundle と Copy Rollback Bundle を維持することをテストで固定した。

## Unsatisfied Success Criteria

- mobile viewport での実ブラウザ clipboard payload 検証は post-merge/deploy 後の live E2E に残る。\nButler が「Custom GPT が壊れた」と言われた時に /setup/latest を短い Markdown link として案内できる live evidence は未実施。\nIssue #357 の runtime URL resolver 拡張はこの PR では扱わない。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #359
- Implementing Success Criteria: /setup/latest と /setup/known-good の役割分離、raw copy payload のテスト固定、latest metadata の誤解低減。
- Explicit Non-goals: Custom GPT editor 自動貼り付け、ChatGPT UI 自動化、deploy/credential/permission mutation、Issue #357 runtime URL resolver 拡張、setup wizard 再導入はしない。
- Expected touched files/routes/workflows: src/core/custom-gpt-setup-artifacts.js, test/worker.test.js, worker.js; routes /setup/latest and /setup/known-good; workflow changes none.
- Affected Issues: Issue #357, Issue #355, closed Issue #344.
- Affected PRs: PR #379 の setup recovery UI follow-up。
- Affected workflows: guarded checks only; deploy-production is not changed.
- Affected runtime/operator surfaces: /setup/latest, /setup/known-good, Custom GPT copy payloads, self-parity/surface update display.
- What may break if we patch narrowly: 見出しだけ直すと copy payload regression を見落とす。URL separation を文言だけにすると Action Schema server URL と copy payload の混入を検出できない。
- Unknowns to investigate before coding: mobile viewport clipboard の実ブラウザ検証は post-merge/deploy 後に残る。current slice では textarea payload を integration test で固定する。
- Validation needed: node --test test/worker.test.js test/custom-gpt-setup-artifacts.test.js test/custom-gpt-setup-docs.test.js; npm test; post-merge/deploy 後に /setup/latest live check.
- Stop condition: runtime URL source-of-truth 変更が必要なら Issue #357 に切り出す。deploy が必要になったら GO + passkey まで停止する。Custom GPT editor state は runtime から推測しない。

## File / Line Hypotheses

- file: `src/core/custom-gpt-setup-artifacts.js:947`\n  - hypothesis: latest page の metadata section が known-good/rollback を連想させる見出しを出しており、iPhone 復旧時に latest と rollback を混同させる。\n  - risk if changed narrowly: 見出しだけ直して copy payload の raw 性を固定しないと recovery の本質が弱いままになる。\n  - validation: latest は `Latest setup bundle metadata`、known-good は `Known-good rollback bundle` を表示する worker tests。\n  - related Issue: Issue #359\n- file: `test/worker.test.js:697`\n  - hypothesis: 既存テストは raw payload 文言を見ているが textarea payload が URL encoded でないことまでは固定していない。\n  - risk if changed narrowly: copy button が raw ではない値をコピーする regression を見逃す。\n  - validation: textarea content に raw YAML/Markdown があり、URL encoded fragments と operator Markdown link がないことを assert する。\n  - related Issue: Issue #359

## Hypothesis Retrospective

- expected: setup recovery HTML の見出し変更と worker tests の追加だけで、latest/known-good の混同と raw copy payload regression を抑えられる。\n- actual: `src/core/custom-gpt-setup-artifacts.js` の metadata heading/text と `test/worker.test.js` の textarea assertions、generated `worker.js` のみを変更した。\n- mismatch: 実ブラウザ clipboard/mobile viewport 検証はこの local slice では未実施。post-merge/deploy 後の live E2E に残す。\n- lesson: recovery UI の文言修正は copy payload regression test と一緒に固定するのが安全。\n- should become RAG candidate: no

## Verification Evidence

- Unit: node --test test/worker.test.js test/custom-gpt-setup-artifacts.test.js test/custom-gpt-setup-docs.test.js: pass. npm test: pass.
- Integration: worker setup latest/known-good route tests pass; check:self-parity and check:generated-worker pass inside npm test.
- E2E: Local integration coverage only. iPhone Butler/live clipboard evidence remains post-merge/deploy work.
- Manual: Dry-run Impact Report posted to Issue #359: https://github.com/marushu/vtdd-v2-p/issues/359#issuecomment-4465229839
- Evidence path/link: tests listed above; commit 25cf546

## Butler Completion Contract

- Owner goal: Custom GPT が壊れた時に、owner が iPhone/iPad で latest と known-good を混同せず raw setup payload をコピーできる状態に近づける。
- Butler entrypoint: /setup/latest and /setup/known-good browser recovery pages; Butler Action Schema unchanged.
- Action Schema exposure: 変更なし。既存の setup recovery browser page を改善するだけで、新 operationId は追加しない。
- Runtime path: /setup/latest, /setup/known-good via Worker setup recovery renderer.
- Runner/runtime truth: Generated worker.js updated; npm test includes check:self-parity and check:generated-worker pass.
- Authority boundary: Read-only recovery UI。deploy, credentials, permissions, approval grants, secret values は変更しない。
- E2E evidence: 未完了。post-merge/deploy 後に iPhone Butler/live recovery guidance と clipboard/copy payload evidence が必要。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 必要。Worker runtime page output が変わるため merge 後に GO + passkey deploy が必要。
- Custom GPT Action Schema update: 不要。Action Schema operation/path は変更なし。
- Custom GPT Instructions update: 不要。Instructions は変更なし。
- iPhone Butler live E2E: 必要。merge+deploy 後に /setup/latest live guidance/copy evidence を確認する。

## Related Constitution Rules

- Issue が正本。Drift Stop Protocol。Butler Completion Gate。Public/core branch に owner-specific runtime URL を固定しない。Deploy/credential/permission mutation は GO + passkey。

## Out-of-scope but NOT implemented

- Issue #357 runtime URL resolver 拡張。Custom GPT editor 自動貼り付け。ChatGPT UI 自動化。setup wizard 再導入。

## Extra changes (if any)

Generated worker.js updated with npm run build:worker.

<!-- VTDD metadata -->
- Issue: Issue #359
- Execution ID: Not provided.
- Goal: Not provided.
