### PR TITLE
Issue #408: add issue close operator UI

### DIFF
--- a/src/core/passkey-operator-page.js
+++ b/src/core/passkey-operator-page.js
@@ -256,8 +256,21 @@ export function renderPasskeyOperatorPage(input = {}) {
           <pre id="merge-output"></pre>
         </section>
 
+        <section data-operator-section="issue-close"${hiddenAttribute(!sectionVisibility.issueClose)}>
+          <h2>6. GitHub Issue Close</h2>
+          <p class="muted">Issue close 用の real passkey approval 後、この helper から same-origin の GitHub authority path を dispatch します。</p>
+          <label for="issue-close-pull-number-input">Merged Pull Number</label>
+          <input id="issue-close-pull-number-input" value="${pullNumberDefault}" placeholder="407" />
+          <div class="row">
+            <button id="issue-close-button">Dispatch Issue close</button>
+            <a class="button-link" id="issue-close-link" href="#" target="_blank" rel="noopener noreferrer" hidden>Open closed issue</a>
+          </div>
+          <p class="muted"><code>actionType=issue_close</code> / <code>highRiskKind=issue_close</code> の approvalGrantId が必要です。bounded issue close は merged pull proof を確認してから実行します。</p>
+          <pre id="issue-close-output"></pre>
+        </section>
+
         <section data-operator-section="github-actions-secret-sync"${hiddenAttribute(!sectionVisibility.githubActionsSecretSync)}>
-          <h2>6. GitHub Actions Secret Sync</h2>
+          <h2>7. GitHub Actions Secret Sync</h2>
           <p class="muted">GitHub Actions secret を同期します。値は Butler 会話に貼らず、この operator page から送信します。<code>VTDD_GATEWAY_BEARER_TOKEN</code> は Actions secret だけではなく Worker secret / Custom GPT Action auth と一致している必要があります。</p>
           <label for="github-actions-secret-name-input">Secret name</label>
           <select id="github-actions-secret-name-input">
@@ -274,7 +287,7 @@ export function renderPasskeyOperatorPage(input = {}) {
         </section>
 
         <section data-operator-section="gateway-bearer-vault"${hiddenAttribute(!sectionVisibility.gatewayBearerVault)}>
-          <h2>7. Gateway Bearer Vault</h2>
+          <h2>8. Gateway Bearer Vault</h2>
           <p class="muted">メモアプリ等に保管している <code>VTDD_GATEWAY_BEARER_TOKEN</code> を、この端末の local helper 経由で Mac/VPS vault に保存します。値は Butler 会話、GitHub コメント、RAG、レスポンス本文に表示しません。</p>
           <label for="gateway-bearer-token-input">VTDD_GATEWAY_BEARER_TOKEN</label>
           <input id="gateway-bearer-token-input" type="password" autocomplete="off" placeholder="token..." />
@@ -287,7 +300,7 @@ export function renderPasskeyOperatorPage(input = {}) {
         </section>
 
         <section data-operator-section="vps-runner-admin"${hiddenAttribute(!sectionVisibility.vpsRunnerAdmin)}>
-          <h2>8. VPS Runner Admin</h2>
+          <h2>9. VPS Runner Admin</h2>
           <p class="muted">VPS runner の repo allowlist 追加、runner restart、smoke などの管理操作用 approval です。ここでは real passkey で短命の <code>approvalGrantId</code> だけを発行します。VPS 操作そのものは GitHub queue と runner event に残る bounded command として別途実行されます。</p>
           <p class="muted"><code>actionType=destructive</code> / <code>highRiskKind=vps_runner_admin</code> の approvalGrantId が必要です。文字列としての passkey は承認ではありません。</p>
         </section>
@@ -300,12 +313,14 @@ export function renderPasskeyOperatorPage(input = {}) {
       const syncOutput = document.getElementById("sync-output");
       const deployOutput = document.getElementById("deploy-output");
       const mergeOutput = document.getElementById("merge-output");
+      const issueCloseOutput = document.getElementById("issue-close-output");
       const openaiSecretSyncOutput = document.getElementById("openai-secret-sync-output");
       const gatewayBearerVaultOutput = document.getElementById("gateway-bearer-vault-output");
       const copyApprovalGrantButton = document.getElementById("copy-approval-grant-button");
       const autoCopyApprovalGrantInput = document.getElementById("auto-copy-approval-grant-input");
       const deployRunLink = document.getElementById("deploy-run-link");
       const mergePrLink = document.getElementById("merge-pr-link");
+      const issueCloseLink = document.getElementById("issue-close-link");
       let latestApprovalGrantId = "";
 
       async function readResponseBody(response) {
@@ -461,6 +476,59 @@ export function renderPasskeyOperatorPage(input = {}) {
         mergePrLink.hidden = false;
       }
 
+      function extractIssueCloseUrl(body) {
+        return body?.authorityAction?.htmlUrl || "";
+      }
+
+      function normalizeGitHubIssueUrl(value) {
+        const text = String(value || "");
+        if (!text) {
+          return "";
+        }
+        try {
+          const url = new URL(text);
+          if (url.protocol !== "https:" || url.hostname.toLowerCase() !== "github.com") {
+            return "";
+          }
+          if (!/\\/issues\\/\\d+(?:$|[/?#])/.test(url.pathname + url.search + url.hash)) {
+            return "";
+          }
+          return url.href;
+        } catch {
+          return "";
+        }
+      }
+
+      function clearIssueCloseLink() {
+        if (!issueCloseLink) {
+          return;
+        }
+        issueCloseLink.href = "#";
+        issueCloseLink.hidden = true;
+      }
+
+      function showIssueCloseLink(body) {
+        const issueUrl = normalizeGitHubIssueUrl(extractIssueCloseUrl(body));
+        if (!issueUrl || !issueCloseLink) {
+          return;
+        }
+        issueCloseLink.href = issueUrl;
+        issueCloseLink.hidden = false;
+      }
+
+      function readNumberInput(id) {
+        const input = document.getElementById(id);
+        return Number(input?.value || 0) || null;
+      }
+
+      function readApprovalPullNumber() {
+        const highRiskKind = document.getElementById("risk-kind-input").value;
+        if (highRiskKind === "issue_close") {
+          return readNumberInput("issue-close-pull-number-input") || readNumberInput("pull-number-input");
+        }
+        return readNumberInput("pull-number-input");
+      }
+
       copyApprovalGrantButton.addEventListener("click", async () => {
         try {
           await copyApprovalGrantIdToClipboard();
@@ -516,7 +584,7 @@ export function renderPasskeyOperatorPage(input = {}) {
               highRiskKind: document.getElementById("risk-kind-input").value,
               repositoryInput: document.getElementById("repo-input").value,
               issueNumber: Number(document.getElementById("issue-input").value || 0) || null,
-              pullNumber: Number(document.getElementById("pull-number-input").value || 0) || null,
+              pullNumber: readApprovalPullNumber(),
               issueContext: {
                 issueNumber: Number(document.getElementById("issue-input").value || 0) || null
               },
@@ -689,6 +757,42 @@ export function renderPasskeyOperatorPage(input = {}) {
           mergeOutput.textContent = JSON.stringify(readyBody, null, 2);
         } catch (error) {
           mergeOutput.textContent = String(error);
+        }
+      });
+
+      document.getElementById("issue-close-button").addEventListener("click", async () => {
+        try {
+          if (!latestApprovalGrantId) {
+            throw new Error("approvalGrantId is required before Issue close");
+          }
+          clearIssueCloseLink();
+          issueCloseOutput.textContent = "Issue close request...";
+          const issueCloseResponse = await fetch("${apiBase}/action/github-authority", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({
+              operation: "issue_close",
+              repository: document.getElementById("repo-input").value,
+              issueNumber: Number(document.getElementById("issue-input").value || 0) || null,
+              pullNumber: Number(document.getElementById("issue-close-pull-number-input").value || 0) || null,
+              issueContext: {
+                issueNumber: Number(document.getElementById("issue-input").value || 0) || null
+              },
+              policyInput: {
+                approvalPhrase: "GO",
+                approvalGrantId: latestApprovalGrantId,
+                targetConfirmed: true
+              }
+            })
+          });
+          const issueCloseBody = await readResponseBody(issueCloseResponse);
+          if (!issueCloseResponse.ok) {
+            throw responseError(issueCloseBody, "Issue close failed");
+          }
+          showIssueCloseLink(issueCloseBody);
+          issueCloseOutput.textContent = JSON.stringify(issueCloseBody, null, 2);
+        } catch (error) {
+          issueCloseOutput.textContent = String(error);
         }
       });
 
@@ -871,7 +975,7 @@ export function resolvePasskeyOperatorMode(input = {}) {
     return "merge";
   }
   if (actionType === "issue_close" || highRiskKind === "issue_close") {
-    return "merge";
+    return "issue_close";
   }
   if (highRiskKind === "github_actions_secret_sync") {
     return "github_actions_secret_sync";
@@ -898,6 +1002,7 @@ function resolveSectionVisibility(operatorMode, options = {}) {
     githubAppSecretSync: full || operatorMode === "github_app_secret_sync",
     productionDeploy: full || operatorMode === "deploy",
     prMerge: full || operatorMode === "merge",
+    issueClose: full || operatorMode === "issue_close",
     githubActionsSecretSync: full || operatorMode === "github_actions_secret_sync",
     gatewayBearerVault: full || operatorMode === "gateway_bearer_vault",
     vpsRunnerAdmin: full || operatorMode === "vps"
@@ -915,7 +1020,7 @@ function renderGithubAppRoleOption(value, label, selectedValue) {
 
 function normalizeOperatorMode(value) {
   const token = normalizeOperatorToken(value);
-  if (["full", "deploy", "merge", "github_app_secret_sync", "github_actions_secret_sync", "gateway_bearer_vault", "vps"].includes(token)) {
+  if (["full", "deploy", "merge", "issue_close", "github_app_secret_sync", "github_actions_secret_sync", "gateway_bearer_vault", "vps"].includes(token)) {
     return token;
   }
   if (token === "secret_sync") {
@@ -937,6 +1042,9 @@ function defaultActionTypeForMode(operatorMode) {
   if (operatorMode === "merge") {
     return "merge";
   }
+  if (operatorMode === "issue_close") {
+    return "issue_close";
+  }
   return "destructive";
 }
 
@@ -946,6 +1054,9 @@ function defaultHighRiskKindForMode(operatorMode) {
   }
   if (operatorMode === "merge") {
     return "pull_merge";
+  }
+  if (operatorMode === "issue_close") {
+    return "issue_close";
   }
   if (operatorMode === "github_actions_secret_sync") {
     return "github_actions_secret_sync";

--- a/test/passkey-operator-page.test.js
+++ b/test/passkey-operator-page.test.js
@@ -29,8 +29,10 @@ test("passkey operator page can target explicit api base and sync endpoint", () 
   assert.equal(html.includes("Save gateway bearer to vault"), true);
   assert.equal(html.includes("Dispatch production deploy"), true);
   assert.equal(html.includes("Dispatch PR merge"), true);
+  assert.equal(html.includes("Dispatch Issue close"), true);
   assert.equal(html.includes("Open deploy run"), true);
   assert.equal(html.includes("Open pull request"), true);
+  assert.equal(html.includes("Open closed issue"), true);
   assert.equal(html.includes("Return to Butler"), true);
   assert.equal(html.includes('href="https://chatgpt.com/g/example-butler"'), true);
   assert.equal(html.includes("Butler 会話に貼らず"), true);
@@ -95,12 +97,17 @@ test("passkey operator page can scope issue close approval to merged pull proof"
   });
 
   assert.equal(html.includes('<section data-operator-section="approval">'), true);
-  assert.equal(html.includes('<section data-operator-section="pr-merge">'), true);
+  assert.equal(html.includes('<section data-operator-section="pr-merge" hidden>'), true);
+  assert.equal(html.includes('<section data-operator-section="issue-close">'), true);
   assert.equal(html.includes('id="issue-input" value="157"'), true);
-  assert.equal(html.includes('id="pull-number-input" value="176"'), true);
+  assert.equal(html.includes('id="issue-close-pull-number-input" value="176"'), true);
   assert.equal(html.includes('id="action-type-input" value="issue_close"'), true);
   assert.equal(html.includes('id="risk-kind-input" value="issue_close"'), true);
-  assert.equal(html.includes('pullNumber: Number(document.getElementById("pull-number-input").value || 0) || null'), true);
+  assert.equal(html.includes("Dispatch Issue close"), true);
+  assert.equal(html.includes('operation: "issue_close"'), true);
+  assert.equal(html.includes('pullNumber: Number(document.getElementById("issue-close-pull-number-input").value || 0) || null'), true);
+  assert.equal(html.includes("Issue close request"), true);
+  assert.equal(html.includes("Open closed issue"), true);
 });
 
 test("passkey operator page focuses deploy mode on deploy approval and dispatch sections", () => {
@@ -116,6 +123,7 @@ test("passkey operator page focuses deploy mode on deploy approval and dispatch 
   assert.equal(html.includes('<section data-operator-section="approval">'), true);
   assert.equal(html.includes('<section data-operator-section="production-deploy">'), true);
   assert.equal(html.includes('<section data-operator-section="pr-merge" hidden>'), true);
+  assert.equal(html.includes('<section data-operator-section="issue-close" hidden>'), true);
   assert.equal(html.includes('<section data-operator-section="github-app-secret-sync" hidden>'), true);
   assert.equal(html.includes('<section data-operator-section="github-actions-secret-sync" hidden>'), true);
   assert.equal(html.includes("Dispatch production deploy"), true);
@@ -141,6 +149,16 @@ test("passkey operator page fills safe approval defaults from explicit mode", ()
   assert.equal(mergeHtml.includes('id="action-type-input" value="merge"'), true);
   assert.equal(mergeHtml.includes('id="risk-kind-input" value="pull_merge"'), true);
   assert.equal(mergeHtml.includes('<section data-operator-section="pr-merge">'), true);
+  assert.equal(mergeHtml.includes('<section data-operator-section="issue-close" hidden>'), true);
+
+  const issueCloseHtml = renderPasskeyOperatorPage({
+    operatorMode: "issue_close",
+    repositoryInput: "marushu/vtdd-v2-p"
+  });
+  assert.equal(issueCloseHtml.includes('id="action-type-input" value="issue_close"'), true);
+  assert.equal(issueCloseHtml.includes('id="risk-kind-input" value="issue_close"'), true);
+  assert.equal(issueCloseHtml.includes('<section data-operator-section="issue-close">'), true);
+  assert.equal(issueCloseHtml.includes('<section data-operator-section="pr-merge" hidden>'), true);
 });
 
 test("passkey operator page focuses merge mode on approval and PR merge sections", () => {
@@ -154,6 +172,7 @@ test("passkey operator page focuses merge mode on approval and PR merge sections
   assert.equal(html.includes('<section data-operator-section="registration">'), true);
   assert.equal(html.includes('<section data-operator-section="approval">'), true);
   assert.equal(html.includes('<section data-operator-section="pr-merge">'), true);
+  assert.equal(html.includes('<section data-operator-section="issue-close" hidden>'), true);
   assert.equal(html.includes('<section data-operator-section="production-deploy" hidden>'), true);
   assert.equal(html.includes('<section data-operator-section="github-app-secret-sync" hidden>'), true);
   assert.equal(html.includes('<section data-operator-section="github-actions-secret-sync" hidden>'), true);
@@ -173,6 +192,7 @@ test("passkey operator page focuses secret sync modes without hiding the require
   assert.equal(githubAppSecretHtml.includes("githubAppRole: document.getElementById"), true);
   assert.equal(githubAppSecretHtml.includes('<section data-operator-section="production-deploy" hidden>'), true);
   assert.equal(githubAppSecretHtml.includes('<section data-operator-section="pr-merge" hidden>'), true);
+  assert.equal(githubAppSecretHtml.includes('<section data-operator-section="issue-close" hidden>'), true);
 
   const actionsSecretHtml = renderPasskeyOperatorPage({
     repositoryInput: "marushu/vtdd-v2-p",
@@ -187,6 +207,7 @@ test("passkey operator page focuses secret sync modes without hiding the require
   assert.equal(actionsSecretHtml.includes('<section data-operator-section="github-app-secret-sync" hidden>'), true);
   assert.equal(actionsSecretHtml.includes('<section data-operator-section="production-deploy" hidden>'), true);
   assert.equal(actionsSecretHtml.includes('<section data-operator-section="pr-merge" hidden>'), true);
+  assert.equal(actionsSecretHtml.includes('<section data-operator-section="issue-close" hidden>'), true);
 });
 
 test("passkey operator page supports local helper mode without passkey controls", () => {
@@ -219,6 +240,7 @@ test("passkey operator page focuses VPS runner admin mode on real approval only"
   assert.equal(html.includes('<section data-operator-section="vps-runner-admin">'), true);
   assert.equal(html.includes('<section data-operator-section="production-deploy" hidden>'), true);
   assert.equal(html.includes('<section data-operator-section="pr-merge" hidden>'), true);
+  assert.equal(html.includes('<section data-operator-section="issue-close" hidden>'), true);
   assert.equal(html.includes('<section data-operator-section="github-app-secret-sync" hidden>'), true);
   assert.equal(html.includes('<section data-operator-section="github-actions-secret-sync" hidden>'), true);
   assert.equal(html.includes('<section data-operator-section="gateway-bearer-vault" hidden>'), true);
@@ -264,6 +286,7 @@ test("passkey operator page keeps the full maintenance view when no mode is infe
   assert.equal(html.includes('<section data-operator-section="github-app-secret-sync">'), true);
   assert.equal(html.includes('<section data-operator-section="production-deploy">'), true);
   assert.equal(html.includes('<section data-operator-section="pr-merge">'), true);
+  assert.equal(html.includes('<section data-operator-section="issue-close">'), true);
   assert.equal(html.includes('<section data-operator-section="github-actions-secret-sync">'), true);
   assert.equal(html.includes('<section data-operator-section="gateway-bearer-vault">'), true);
   assert.equal(html.includes('<section data-operator-section="vps-runner-admin">'), true);
@@ -490,6 +513,50 @@ test("passkey operator page exposes safe PR link from merge response", () => {
   });
   assert.equal(mergePrLink.href, "#");
   assert.equal(mergePrLink.hidden, true);
+});
+
+test("passkey operator page exposes safe issue link from issue close response", () => {
+  const issueCloseLink = {
+    href: "#",
+    hidden: true
+  };
+  const helpers = loadOperatorPageHelpers({
+    document: {
+      getElementById(id) {
+        if (id === "issue-close-link") {
+          return issueCloseLink;
+        }
+        return {
+          value: "",
+          textContent: "",
+          addEventListener() {}
+        };
+      }
+    }
+  });
+
+  helpers.showIssueCloseLink({
+    ok: true,
+    authorityAction: {
+      htmlUrl: "https://github.com/sample-org/vtdd-v2-p/issues/349"
+    }
+  });
+
+  assert.equal(issueCloseLink.href, "https://github.com/sample-org/vtdd-v2-p/issues/349");
+  assert.equal(issueCloseLink.hidden, false);
+
+  helpers.clearIssueCloseLink();
+  assert.equal(issueCloseLink.href, "#");
+  assert.equal(issueCloseLink.hidden, true);
+
+  helpers.showIssueCloseLink({
+    ok: true,
+    authorityAction: {
+      htmlUrl: "https://evil.example/sample-org/vtdd-v2-p/issues/349"
+    }
+  });
+  assert.equal(issueCloseLink.href, "#");
+  assert.equal(issueCloseLink.hidden, true);
 });
 
 function loadOperatorPageHelpers(overrides = {}) {

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -2583,6 +2583,27 @@ test("worker serves passkey operator page", async () => {
   assert.equal(html.includes('href="https://evil.example/phish"'), false);
 });
 
+test("worker serves issue close operator mode without falling back to PR merge UI", async () => {
+  const response = await worker.fetch(
+    new Request(
+      "https://example.com/v2/approval/passkey/operator?repositoryInput=marushu%2Fvtdd-v2-p&issueNumber=349&pullNumber=407&phase=execution&actionType=issue_close&highRiskKind=issue_close"
+    ),
+    gatewayAuthEnv
+  );
+
+  assert.equal(response.status, 200);
+  const html = await response.text();
+  assert.equal(html.includes("GitHub Issue Close"), true);
+  assert.equal(html.includes("Dispatch Issue close"), true);
+  assert.equal(html.includes('<section data-operator-section="issue-close">'), true);
+  assert.equal(html.includes('<section data-operator-section="pr-merge" hidden>'), true);
+  assert.equal(html.includes('id="issue-input" value="349"'), true);
+  assert.equal(html.includes('id="issue-close-pull-number-input" value="407"'), true);
+  assert.equal(html.includes('id="action-type-input" value="issue_close"'), true);
+  assert.equal(html.includes('id="risk-kind-input" value="issue_close"'), true);
+  assert.equal(html.includes('operation: "issue_close"'), true);
+});
+
 test("worker strips non-ChatGPT operator return urls", async () => {
   const response = await worker.fetch(
     new Request(

--- a/worker.js
+++ b/worker.js
@@ -27333,8 +27333,21 @@ function renderPasskeyOperatorPage(input = {}) {
           <pre id="merge-output"></pre>
         </section>
 
+        <section data-operator-section="issue-close"${hiddenAttribute(!sectionVisibility.issueClose)}>
+          <h2>6. GitHub Issue Close</h2>
+          <p class="muted">Issue close \u7528\u306E real passkey approval \u5F8C\u3001\u3053\u306E helper \u304B\u3089 same-origin \u306E GitHub authority path \u3092 dispatch \u3057\u307E\u3059\u3002</p>
+          <label for="issue-close-pull-number-input">Merged Pull Number</label>
+          <input id="issue-close-pull-number-input" value="${pullNumberDefault}" placeholder="407" />
+          <div class="row">
+            <button id="issue-close-button">Dispatch Issue close</button>
+            <a class="button-link" id="issue-close-link" href="#" target="_blank" rel="noopener noreferrer" hidden>Open closed issue</a>
+          </div>
+          <p class="muted"><code>actionType=issue_close</code> / <code>highRiskKind=issue_close</code> \u306E approvalGrantId \u304C\u5FC5\u8981\u3067\u3059\u3002bounded issue close \u306F merged pull proof \u3092\u78BA\u8A8D\u3057\u3066\u304B\u3089\u5B9F\u884C\u3057\u307E\u3059\u3002</p>
+          <pre id="issue-close-output"></pre>
+        </section>
+
         <section data-operator-section="github-actions-secret-sync"${hiddenAttribute(!sectionVisibility.githubActionsSecretSync)}>
-          <h2>6. GitHub Actions Secret Sync</h2>
+          <h2>7. GitHub Actions Secret Sync</h2>
           <p class="muted">GitHub Actions secret \u3092\u540C\u671F\u3057\u307E\u3059\u3002\u5024\u306F Butler \u4F1A\u8A71\u306B\u8CBC\u3089\u305A\u3001\u3053\u306E operator page \u304B\u3089\u9001\u4FE1\u3057\u307E\u3059\u3002<code>VTDD_GATEWAY_BEARER_TOKEN</code> \u306F Actions secret \u3060\u3051\u3067\u306F\u306A\u304F Worker secret / Custom GPT Action auth \u3068\u4E00\u81F4\u3057\u3066\u3044\u308B\u5FC5\u8981\u304C\u3042\u308A\u307E\u3059\u3002</p>
           <label for="github-actions-secret-name-input">Secret name</label>
           <select id="github-actions-secret-name-input">
@@ -27351,7 +27364,7 @@ function renderPasskeyOperatorPage(input = {}) {
         </section>
 
         <section data-operator-section="gateway-bearer-vault"${hiddenAttribute(!sectionVisibility.gatewayBearerVault)}>
-          <h2>7. Gateway Bearer Vault</h2>
+          <h2>8. Gateway Bearer Vault</h2>
           <p class="muted">\u30E1\u30E2\u30A2\u30D7\u30EA\u7B49\u306B\u4FDD\u7BA1\u3057\u3066\u3044\u308B <code>VTDD_GATEWAY_BEARER_TOKEN</code> \u3092\u3001\u3053\u306E\u7AEF\u672B\u306E local helper \u7D4C\u7531\u3067 Mac/VPS vault \u306B\u4FDD\u5B58\u3057\u307E\u3059\u3002\u5024\u306F Butler \u4F1A\u8A71\u3001GitHub \u30B3\u30E1\u30F3\u30C8\u3001RAG\u3001\u30EC\u30B9\u30DD\u30F3\u30B9\u672C\u6587\u306B\u8868\u793A\u3057\u307E\u305B\u3093\u3002</p>
           <label for="gateway-bearer-token-input">VTDD_GATEWAY_BEARER_TOKEN</label>
           <input id="gateway-bearer-token-input" type="password" autocomplete="off" placeholder="token..." />
@@ -27364,7 +27377,7 @@ function renderPasskeyOperatorPage(input = {}) {
         </section>
 
         <section data-operator-section="vps-runner-admin"${hiddenAttribute(!sectionVisibility.vpsRunnerAdmin)}>
-          <h2>8. VPS Runner Admin</h2>
+          <h2>9. VPS Runner Admin</h2>
           <p class="muted">VPS runner \u306E repo allowlist \u8FFD\u52A0\u3001runner restart\u3001smoke \u306A\u3069\u306E\u7BA1\u7406\u64CD\u4F5C\u7528 approval \u3067\u3059\u3002\u3053\u3053\u3067\u306F real passkey \u3067\u77ED\u547D\u306E <code>approvalGrantId</code> \u3060\u3051\u3092\u767A\u884C\u3057\u307E\u3059\u3002VPS \u64CD\u4F5C\u305D\u306E\u3082\u306E\u306F GitHub queue \u3068 runner event \u306B\u6B8B\u308B bounded command \u3068\u3057\u3066\u5225\u9014\u5B9F\u884C\u3055\u308C\u307E\u3059\u3002</p>
           <p class="muted"><code>actionType=destructive</code> / <code>highRiskKind=vps_runner_admin</code> \u306E approvalGrantId \u304C\u5FC5\u8981\u3067\u3059\u3002\u6587\u5B57\u5217\u3068\u3057\u3066\u306E passkey \u306F\u627F\u8A8D\u3067\u306F\u3042\u308A\u307E\u305B\u3093\u3002</p>
         </section>
@@ -27377,12 +27390,14 @@ function renderPasskeyOperatorPage(input = {}) {
       const syncOutput = document.getElementById("sync-output");
       const deployOutput = document.getElementById("deploy-output");
       const mergeOutput = document.getElementById("merge-output");
+      const issueCloseOutput = document.getElementById("issue-close-output");
       const openaiSecretSyncOutput = document.getElementById("openai-secret-sync-output");
       const gatewayBearerVaultOutput = document.getElementById("gateway-bearer-vault-output");
       const copyApprovalGrantButton = document.getElementById("copy-approval-grant-button");
       const autoCopyApprovalGrantInput = document.getElementById("auto-copy-approval-grant-input");
       const deployRunLink = document.getElementById("deploy-run-link");
       const mergePrLink = document.getElementById("merge-pr-link");
+      const issueCloseLink = document.getElementById("issue-close-link");
       let latestApprovalGrantId = "";
 
       async function readResponseBody(response) {
@@ -27538,6 +27553,59 @@ function renderPasskeyOperatorPage(input = {}) {
         mergePrLink.hidden = false;
       }
 
+      function extractIssueCloseUrl(body) {
+        return body?.authorityAction?.htmlUrl || "";
+      }
+
+      function normalizeGitHubIssueUrl(value) {
+        const text = String(value || "");
+        if (!text) {
+          return "";
+        }
+        try {
+          const url = new URL(text);
+          if (url.protocol !== "https:" || url.hostname.toLowerCase() !== "github.com") {
+            return "";
+          }
+          if (!/\\/issues\\/\\d+(?:$|[/?#])/.test(url.pathname + url.search + url.hash)) {
+            return "";
+          }
+          return url.href;
+        } catch {
+          return "";
+        }
+      }
+
+      function clearIssueCloseLink() {
+        if (!issueCloseLink) {
+          return;
+        }
+        issueCloseLink.href = "#";
+        issueCloseLink.hidden = true;
+      }
+
+      function showIssueCloseLink(body) {
+        const issueUrl = normalizeGitHubIssueUrl(extractIssueCloseUrl(body));
+        if (!issueUrl || !issueCloseLink) {
+          return;
+        }
+        issueCloseLink.href = issueUrl;
+        issueCloseLink.hidden = false;
+      }
+
+      function readNumberInput(id) {
+        const input = document.getElementById(id);
+        return Number(input?.value || 0) || null;
+      }
+
+      function readApprovalPullNumber() {
+        const highRiskKind = document.getElementById("risk-kind-input").value;
+        if (highRiskKind === "issue_close") {
+          return readNumberInput("issue-close-pull-number-input") || readNumberInput("pull-number-input");
+        }
+        return readNumberInput("pull-number-input");
+      }
+
       copyApprovalGrantButton.addEventListener("click", async () => {
         try {
           await copyApprovalGrantIdToClipboard();
@@ -27593,7 +27661,7 @@ function renderPasskeyOperatorPage(input = {}) {
               highRiskKind: document.getElementById("risk-kind-input").value,
               repositoryInput: document.getElementById("repo-input").value,
               issueNumber: Number(document.getElementById("issue-input").value || 0) || null,
-              pullNumber: Number(document.getElementById("pull-number-input").value || 0) || null,
+              pullNumber: readApprovalPullNumber(),
               issueContext: {
                 issueNumber: Number(document.getElementById("issue-input").value || 0) || null
               },
@@ -27766,6 +27834,42 @@ function renderPasskeyOperatorPage(input = {}) {
           mergeOutput.textContent = JSON.stringify(readyBody, null, 2);
         } catch (error) {
           mergeOutput.textContent = String(error);
+        }
+      });
+
+      document.getElementById("issue-close-button").addEventListener("click", async () => {
+        try {
+          if (!latestApprovalGrantId) {
+            throw new Error("approvalGrantId is required before Issue close");
+          }
+          clearIssueCloseLink();
+          issueCloseOutput.textContent = "Issue close request...";
+          const issueCloseResponse = await fetch("${apiBase}/action/github-authority", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({
+              operation: "issue_close",
+              repository: document.getElementById("repo-input").value,
+              issueNumber: Number(document.getElementById("issue-input").value || 0) || null,
+              pullNumber: Number(document.getElementById("issue-close-pull-number-input").value || 0) || null,
+              issueContext: {
+                issueNumber: Number(document.getElementById("issue-input").value || 0) || null
+              },
+              policyInput: {
+                approvalPhrase: "GO",
+                approvalGrantId: latestApprovalGrantId,
+                targetConfirmed: true
+              }
+            })
+          });
+          const issueCloseBody = await readResponseBody(issueCloseResponse);
+          if (!issueCloseResponse.ok) {
+            throw responseError(issueCloseBody, "Issue close failed");
+          }
+          showIssueCloseLink(issueCloseBody);
+          issueCloseOutput.textContent = JSON.stringify(issueCloseBody, null, 2);
+        } catch (error) {
+          issueCloseOutput.textContent = String(error);
         }
       });
 
@@ -27945,7 +28049,7 @@ function resolvePasskeyOperatorMode(input = {}) {
     return "merge";
   }
   if (actionType === "issue_close" || highRiskKind === "issue_close") {
-    return "merge";
+    return "issue_close";
   }
   if (highRiskKind === "github_actions_secret_sync") {
     return "github_actions_secret_sync";
@@ -27970,6 +28074,7 @@ function resolveSectionVisibility(operatorMode, options = {}) {
     githubAppSecretSync: full || operatorMode === "github_app_secret_sync",
     productionDeploy: full || operatorMode === "deploy",
     prMerge: full || operatorMode === "merge",
+    issueClose: full || operatorMode === "issue_close",
     githubActionsSecretSync: full || operatorMode === "github_actions_secret_sync",
     gatewayBearerVault: full || operatorMode === "gateway_bearer_vault",
     vpsRunnerAdmin: full || operatorMode === "vps"
@@ -27984,7 +28089,7 @@ function renderGithubAppRoleOption(value, label, selectedValue) {
 }
 function normalizeOperatorMode(value) {
   const token = normalizeOperatorToken(value);
-  if (["full", "deploy", "merge", "github_app_secret_sync", "github_actions_secret_sync", "gateway_bearer_vault", "vps"].includes(token)) {
+  if (["full", "deploy", "merge", "issue_close", "github_app_secret_sync", "github_actions_secret_sync", "gateway_bearer_vault", "vps"].includes(token)) {
     return token;
   }
   if (token === "secret_sync") {
@@ -28005,6 +28110,9 @@ function defaultActionTypeForMode(operatorMode) {
   if (operatorMode === "merge") {
     return "merge";
   }
+  if (operatorMode === "issue_close") {
+    return "issue_close";
+  }
   return "destructive";
 }
 function defaultHighRiskKindForMode(operatorMode) {
@@ -28013,6 +28121,9 @@ function defaultHighRiskKindForMode(operatorMode) {
   }
   if (operatorMode === "merge") {
     return "pull_merge";
+  }
+  if (operatorMode === "issue_close") {
+    return "issue_close";
   }
   if (operatorMode === "github_actions_secret_sync") {
     return "github_actions_secret_sync";


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #408 の scoped implementation。Butler/iPhone の passkey operator page で issue_close approvalGrantId は発行できるのに、実行 UI が PR merge section へ倒れて Issue close を dispatch できない gap を修正する。
- issue_close を merge mode から独立させ、owner-facing operator page に Issue close 専用 section と dispatch button を追加する。

## Satisfied Success Criteria

- passkey operator page が actionType=issue_close / highRiskKind=issue_close のとき Issue close section を表示する。
- Issue close section は approvalGrantId 取得後に /v2/action/github-authority operation=issue_close を dispatch する。
- issue_close mode では PR merge section を hidden にし、PR merge UI への誤誘導を避ける。
- merged pull proof 用の pullNumber input と closed issue link を owner-facing UI に追加した。
- Worker route test で issue_close operator URL が Issue close UI を返すことを固定した。

## Unsatisfied Success Criteria

- post-merge/deploy 後の iPhone Butler live E2E は未実施。
- Issue #349 の実 close はこの PR では実行しない。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #408
- Implementing Success Criteria: issue_close operator mode, Issue close dispatch UI, no PR merge UI confusion, runtime truth response link handling.
- Explicit Non-goals: Issue #349 close, deploy execution, merge/deploy/secret sync redesign, passkey/WebAuthn model changes, setup wizard.
- Expected touched files/routes/workflows: src/core/passkey-operator-page.js; test/passkey-operator-page.test.js; test/worker.test.js; generated worker.js. Routes/workflows unchanged.
- Affected Issues: Issue #408 primary. Issue #349 remains open until this path is deployed and live E2E proves Butler/iPhone close works. Issue #355 adjacent operator boundary unchanged.
- Affected PRs: None directly; this PR creates the implementation slice for Issue #408.
- Affected workflows: guarded-autonomy-required-checks/test only. No deploy workflow mutation.
- Affected runtime/operator surfaces: Worker passkey operator page /v2/approval/passkey/operator and same-origin GitHub authority dispatch /v2/action/github-authority.
- What may break if we patch narrowly: If issue_close stayed mapped to merge mode, Butler/iPhone would still receive PR merge UI and #349 close would remain mac_codex_only. If pullNumber proof were omitted, bounded issue close would fail without an owner-visible input.
- Unknowns to investigate before coding: Whether post-deploy live passkey + issue_close dispatch succeeds from iPhone; this requires GO + passkey after merge/deploy and should use Issue #349 as the live target only after human approval.
- Validation needed: Unit operator page tests; Worker route test for issue_close operator URL; high-risk plane regression tests; npm test; post-merge deploy and Butler/iPhone live E2E.
- Stop condition: If runtime authority plane semantics needed widening beyond existing issue_close operation, stop. If Issue #349 close would be performed before deploy/live E2E, stop. If passkey boundary weakens, stop.

## File / Line Hypotheses

- file: `src/core/passkey-operator-page.js`
  - hypothesis: `resolvePasskeyOperatorMode()` maps issue_close to merge, so the UI shows PR merge controls instead of Issue close controls.
  - risk if changed narrowly: approvalGrantId issuance works but dispatch remains unreachable from Butler/iPhone.
  - validation: issue_close mode renders `data-operator-section="issue-close"` and hides `pr-merge`.
  - related Issue: Issue #408
- file: `test/passkey-operator-page.test.js` / `test/worker.test.js`
  - hypothesis: existing tests accidentally fixed the wrong behavior by expecting issue_close to show pr-merge.
  - risk if changed narrowly: regression returns silently later.
  - validation: tests now assert Issue close section and operation=issue_close dispatch.

## Hypothesis Retrospective

- expected: issue_close was routed to merge mode.
- actual: confirmed; `resolvePasskeyOperatorMode()` returned `merge` for issue_close.
- mismatch: none.
- lesson: approvalGrantId issuance alone is not Butler completion; operator execution UI must also exist.
- should become RAG candidate: yes, after live E2E if this gap recurs as recovery lesson.

## Verification Evidence

- Unit: node --test test/passkey-operator-page.test.js test/worker.test.js test/github-high-risk-plane.test.js: pass (154 pass). npm test: pass (815 pass / 1 skipped, self-parity pass, generated-worker pass).
- Integration: Worker route test `worker serves issue close operator mode without falling back to PR merge UI`: pass.
- E2E: Not yet run. Requires merge + deploy + iPhone Butler real passkey flow.
- Manual: Screenshot evidence from user showed issue_close approval page with PR Merge section only; this PR addresses that observed UI gap.
- Evidence path/link: Issue #408 and PR checks; post-merge live E2E to be added as Issue comment.

## Butler Completion Contract

- Owner goal: Butler/iPhone から scoped Issue close を完了できる operator execution path を復旧する。
- Butler entrypoint: Butler returns same-origin passkey operator URL with actionType=issue_close/highRiskKind=issue_close; owner opens on iPhone.
- Action Schema exposure: No Action Schema change. Existing operator URL and github authority operation remain used.
- Runtime path: /v2/approval/passkey/operator renders issue_close section; browser dispatches POST /v2/action/github-authority operation=issue_close.
- Runner/runtime truth: Unit/integration tests verify rendered UI and existing high-risk plane returns closed issue URL after merged pull proof.
- Authority boundary: Unchanged: issue close still requires GO + real passkey approvalGrantId and bounded merged pull proof.
- E2E evidence: Incomplete until merged/deployed and verified from iPhone Butler. This PR makes the missing UI reachable.
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: Required after merge because worker.js/runtime UI changes.
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: Required after deploy. Use Issue #349 close path only with explicit human GO.

## Related Constitution Rules

- AGENTS.md Butler Completion Gate.
- High-risk issue close requires GO + real passkey.
- Do not close Issues automatically.
- Runtime truth > memory.

## Out-of-scope but NOT implemented

- Issue #349 remains open.
- Live close dispatch is deferred to post-merge/deploy evidence.
- No deploy in this PR.

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #408
- Execution ID: mac-codex-issue-408-operator-ui
- Goal: Repair issue_close passkey operator execution UI gap.
