### PR TITLE
Issue #408 expose issue close operator URL

### DIFF
--- a/docs/setup/custom-gpt-actions-openapi.json
+++ b/docs/setup/custom-gpt-actions-openapi.json
@@ -2664,6 +2664,24 @@
             }
           },
           {
+            "name": "issueNumber",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            },
+            "description": "Active Issue number when a passkey operator URL should be scoped to an Issue."
+          },
+          {
+            "name": "pullNumber",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            },
+            "description": "Merged PR number used as bounded post-merge proof for issue_close operator links."
+          },
+          {
             "name": "responseMode",
             "in": "query",
             "required": false,

--- a/docs/setup/custom-gpt-actions-openapi.yaml
+++ b/docs/setup/custom-gpt-actions-openapi.yaml
@@ -1923,6 +1923,18 @@ paths:
           required: false
           schema:
             type: string
+        - name: issueNumber
+          in: query
+          required: false
+          schema:
+            type: integer
+          description: Active Issue number when a passkey operator URL should be scoped to an Issue.
+        - name: pullNumber
+          in: query
+          required: false
+          schema:
+            type: integer
+          description: Merged PR number used as bounded post-merge proof for issue_close operator links.
         - name: responseMode
           in: query
           required: false

--- a/docs/setup/custom-gpt-instructions-short-min.md
+++ b/docs/setup/custom-gpt-instructions-short-min.md
@@ -14,17 +14,17 @@ Truth and scope:
 - PR merge後確認: read PR truth; vtddExecute vps_runner + post_merge_verify; verify only.
 Repository and nickname:
 - Repo list/read: vtddGateway exploration/read_only.
-- vtddRetrieveGitHub: repos/issues/PRs/reviews/comments/checks/runs/jobs/branches/contents/tree. Actions failure: runs -> jobs(runId). Files/docs: contents/tree; cite path/htmlUrl.
+- vtddRetrieveGitHub: repos/issues/PRs/reviews/comments/checks/runs/jobs/branches/contents/tree. Actions failure: runs -> jobs(runId). Cite path/htmlUrl.
 - Nicknames: vtddUpsertRepositoryNickname, vtddDeleteRepositoryNickname, vtddRetrieveRepositoryNicknames.
 - If request starts with non-owner/repo token, resolve nickname first.
 - Nickname memory is user-owned alias data, not default repo. Save owner/repo, not alias. Delete owner/repo + exact nickname.
 - Nickname read failure is not proof of unknown repo. If context/grant has owner/repo, use unverified fallback and verify.
-- Unsupported read=>未対応. Auth fail=>認証失敗. Do not infer absence from failed, unsupported, unauthorized, or unverified reads.
+- Unsupported read=>未対応. Auth fail=>認証失敗. Do not infer absence from failed/unsupported/unauthorized/unverified reads.
 Self-parity and setup drift:
 - For stale/outdated: vtddRetrieveSelfParity repo=<resolved>, ref=main; vtddRetrieveSetupArtifact.
 - Protected retrieve auth/ClientResponseError=>check Action Bearer; not nickname absent.
 - runtimeParity=cloudflare_deploy_update_required=>Cloudflare deploy update required. in_sync missing behavior=>Action Schema/Instructions update required.
-- Parity unchecked=>未検証 + error/reason/issues. ClientResponseError=>state action + unverified transport. runtime in_sync=>don't claim editor sync.
+- Parity unchecked=>未検証 + error/reason/issues. ClientResponseError=>state action + transport unverified. runtime in_sync=>don't claim editor sync.
 Execution and remote Codex handoff:
 - Before execution, read runtime truth; when relevant read parent Issue, PR, branch, checks, runs.
 - If no open PR, read the parent Issue and propose the next bounded E2E slice.
@@ -41,15 +41,15 @@ Execution and remote Codex handoff:
 - Reviewer-fix phrase: `Gemini が指摘している修正を Codex に進めさせます。よければ GO と言ってください。`
 - Executor transport is pluggable and user-owned.
 - Default handoff here: executorTransport=vps_runner. Do not add a separate GPT Action for VPS handoff.
-- codex_cloud_github_comment fallback; codex_cloud_cli_control_runner user-owned. API runner: api_key_runner + OPENAI_API_KEY; surface openai_api_key_not_configured.
-- After vtddExecute, call vtddExecutionProgress; report leadTime and executorTransport. vps_runner status: vtddVpsRunnerStatus. VPS cancel/drain: vtddVpsRunnerCancel marker only.
+- codex_cloud_github_comment fallback; codex_cloud_cli_control_runner user-owned. API runner: api_key_runner + OPENAI_API_KEY; surface key_missing.
+- After vtddExecute, call vtddExecutionProgress; report leadTime + executorTransport. vps_runner: vtddVpsRunnerStatus. VPS cancel/drain: vtddVpsRunnerCancel marker only.
 - Do not claim PR created unless GitHub runtime truth shows the PR.
 GitHub write:
-- vtddWriteGitHub only for scoped GO-tier writes: issue create/comment create/update, branch create, pull create/update, pull comment create.
+- vtddWriteGitHub only for scoped GO-tier writes: issue/comment create/update, branch create, pull create/update/comment.
 - Before vtddWriteGitHub, show exact title/body/comment/update payload and wait for GO.
 - PR create/update: no freehand `--body`; use `scripts/prepare-pr-body-file.mjs` -> `--body-file`.
 - For implementation without an existing Issue, do issue_create first; only then do bounded Codex handoff.
-- Normal GO writes: show exact payload, ask only `GO`, call vtddWriteGitHub. Never ask targetConfirmed/approvalScopeMatched/approvalPhrase/raw JSON.
+- Normal GO writes: show exact payload, ask only `GO`, call vtddWriteGitHub. Never ask targetConfirmed/approvalScopeMatched/raw JSON.
 - Write only when repo is resolved, scope traceable, and GO exists.
 - Never use vtddWriteGitHub for merge, issue close, deploy, secrets/settings/permissions, admin, or destructive cleanup.
 High-risk authority:
@@ -58,21 +58,21 @@ High-risk authority:
 - Deploy requires GO + real passkey grant scoped to deploy_production. Never deploy from context alone.
 - Issue close requires authority approval and merged PR pullNumber. Never close Issues automatically.
 - vtddGitHubAuthority handles pull_ready_for_review, pull_merge, and issue_close only.
-- If no merge/ready/close grant, show same-origin operator link; no bare long URL or internal relative URL.
+- If no merge/ready/close grant, show same-origin operator link; close: selfParity.issueCloseOperatorMarkdownLink after issueNumber+pullNumber else stop on status. No bare/relative URL.
 - Before saying merged/closed/deployed, re-read runtime truth.
 Deploy:
 - Use vtddDeployProduction after deploy ask + GO + real passkey grant.
 - If no deploy grant, show selfParity.deployOperatorMarkdownLink or `[Open deploy operator](<actual selfParity.deployOperatorUrl>)`; no raw/bare URL.
 - Stale fallback: selfParity.deployRecovery.operatorMarkdownLink or operatorUrl; href needs phase=execution.
 - After deploy dispatch, re-check self-parity. If deploy fails, say exact deploy error/reason/issues.
-- If api_key_runner hits openai_api_key_not_configured, use vtddSyncGitHubActionsSecret secret-sync operator; never ask for OPENAI_API_KEY in chat.
+- If api_key_runner hits openai_api_key_not_configured, use vtddSyncGitHubActionsSecret; never ask for OPENAI_API_KEY in chat.
 Review loop:
 - For a PR, summarize state, CI, reviewers, objections, and changes.
 - Preserve reviewer objections. If objections remain, do not recommend merge GO+passkey.
 - Review truth: marker approve != GitHub approval; formal CHANGES_REQUESTED blocks; show reviewerSignalTruth warnings.
 - Gemini evidence: show marker URL + current action; note if marker timestamp looks stale.
 - `vtdd:reviewer=codex-fallback` with comment/@codex review is request-only.
-- Completed fallback from trusted VTDD actor/Codex Cloud result with recommendedAction is evidence; missing GitHub Review objects alone is not absence.
+- Completed fallback from trusted VTDD actor/Codex Cloud result with recommendedAction is evidence; missing Review objects alone is not absence.
 - `vtdd:incident=actor_identity_failure`: recovery blocker; explain role/PR in Japanese; never count `marushu` substitute as review done.
 - If no reviewer evidence, say.
 Forbidden:

--- a/docs/setup/custom-gpt-instructions.md
+++ b/docs/setup/custom-gpt-instructions.md
@@ -349,6 +349,7 @@ GitHub high-risk authority plane:
   - operation=`issue_close`
   - include `issueNumber` for the Issue being closed and `pullNumber` for the merged PR used to prove bounded post-merge scope
   - if no issue-close-scoped approval grant is available yet, present a short clickable Markdown link to the same-origin passkey operator helper; the href must include `repositoryInput=<resolved repo>`, `phase=execution`, `issueNumber=<issue to close>`, `pullNumber=<merged PR number>`, `actionType=issue_close`, and `highRiskKind=issue_close`
+  - prefer calling `vtddRetrieveSelfParity` with `issueNumber` and `pullNumber`, then using `selfParity.issueCloseOperatorMarkdownLink`; if unavailable, report `selfParity.issueCloseOperator.status` / missing fields and do not invent or manually construct the URL
 - Do not route deploy, secret mutation, permission mutation, or other destructive provider actions through vtddGitHubAuthority.
 
 Deploy plane:

--- a/src/core/custom-gpt-setup-artifacts.js
+++ b/src/core/custom-gpt-setup-artifacts.js
@@ -218,6 +218,7 @@ export async function evaluateButlerSelfParity(input = {}) {
   const ref = normalizeText(input.ref) || "main";
   const runtimeOrigin = normalizeOrigin(input.runtimeOrigin);
   const issueNumber = normalizeIssueNumber(input.issueNumber);
+  const pullNumber = normalizeIssueNumber(input.pullNumber);
   const env = input.env ?? {};
 
   const instructions = await retrieveCustomGptSetupArtifact({
@@ -294,6 +295,28 @@ export async function evaluateButlerSelfParity(input = {}) {
   const deployOperatorMarkdownLink = deployOperatorUrl
     ? `[Open deploy operator](${deployOperatorUrl})`
     : null;
+  const issueCloseOperatorUrl =
+    repository && runtimeOrigin && issueNumber && pullNumber
+      ? buildPasskeyOperatorUrl({
+          origin: runtimeOrigin,
+          repository,
+          phase: "execution",
+          actionType: "issue_close",
+          highRiskKind: "issue_close",
+          issueNumber,
+          pullNumber
+        })
+      : null;
+  const issueCloseOperatorMarkdownLink = issueCloseOperatorUrl
+    ? `[Open issue close operator](${issueCloseOperatorUrl})`
+    : null;
+  const issueCloseOperatorStatus = classifyIssueCloseOperatorStatus({
+    repository,
+    runtimeOrigin,
+    issueNumber,
+    pullNumber,
+    issueCloseOperatorUrl
+  });
 
   const recommendedActions =
     runtimeParity === "in_sync"
@@ -344,6 +367,23 @@ export async function evaluateButlerSelfParity(input = {}) {
       staleCapabilities,
       deployOperatorUrl,
       deployOperatorMarkdownLink,
+      issueCloseOperatorUrl,
+      issueCloseOperatorMarkdownLink,
+      issueCloseOperator:
+        issueCloseOperatorStatus.status !== "not_requested"
+          ? {
+              actionType: "issue_close",
+              highRiskKind: "issue_close",
+              requires: ["GO", "real passkey", "merged pull proof"],
+              repository,
+              issueNumber,
+              pullNumber,
+              operatorUrl: issueCloseOperatorUrl,
+              operatorMarkdownLink: issueCloseOperatorMarkdownLink,
+              status: issueCloseOperatorStatus.status,
+              blockers: issueCloseOperatorStatus.blockers
+            }
+          : null,
       deployRecovery:
         runtimeParity === "cloudflare_deploy_update_required"
           ? {
@@ -1245,7 +1285,7 @@ function normalizeApiBaseUrl(value) {
   return normalized ? normalized.replace(/\/+$/, "") : GITHUB_API_BASE_URL;
 }
 
-function buildPasskeyOperatorUrl({ origin, repository, phase, actionType, highRiskKind, issueNumber }) {
+function buildPasskeyOperatorUrl({ origin, repository, phase, actionType, highRiskKind, issueNumber, pullNumber }) {
   const url = new URL("/v2/approval/passkey/operator", `${origin}/`);
   url.searchParams.set("repositoryInput", repository);
   url.searchParams.set("phase", phase || "execution");
@@ -1254,7 +1294,44 @@ function buildPasskeyOperatorUrl({ origin, repository, phase, actionType, highRi
   if (Number.isInteger(issueNumber) && issueNumber > 0) {
     url.searchParams.set("issueNumber", String(issueNumber));
   }
+  if (Number.isInteger(pullNumber) && pullNumber > 0) {
+    url.searchParams.set("pullNumber", String(pullNumber));
+  }
   return url.toString();
+}
+
+function classifyIssueCloseOperatorStatus({
+  repository,
+  runtimeOrigin,
+  issueNumber,
+  pullNumber,
+  issueCloseOperatorUrl
+}) {
+  if (issueCloseOperatorUrl) {
+    return { status: "ready", blockers: [] };
+  }
+  if (!issueNumber && !pullNumber) {
+    return { status: "not_requested", blockers: [] };
+  }
+
+  const blockers = [];
+  if (!repository) {
+    blockers.push("missing_repository");
+  }
+  if (!runtimeOrigin) {
+    blockers.push("missing_runtime_origin");
+  }
+  if (!issueNumber) {
+    blockers.push("missing_issue_number");
+  }
+  if (!pullNumber) {
+    blockers.push("missing_merged_pull_number");
+  }
+
+  return {
+    status: blockers[0] || "unavailable",
+    blockers
+  };
 }
 
 function normalizeOrigin(value) {

--- a/src/core/github-app-operation-registry.js
+++ b/src/core/github-app-operation-registry.js
@@ -95,7 +95,7 @@ export const GitHubAppOperationRegistry = Object.freeze({
     passkey: {
       actionType: "issue_close",
       highRiskKind: "issue_close",
-      operatorUrlRequirements: ["repositoryInput", "phase", "issueNumber", "actionType", "highRiskKind"]
+      operatorUrlRequirements: ["repositoryInput", "phase", "issueNumber", "pullNumber", "actionType", "highRiskKind"]
     }
   },
   deploy_production: {

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -1154,7 +1154,8 @@ async function evaluateStartupPreflightSelfParity({
       result.selfParity.surfaceUpdateChecklist?.customGptActionSchema?.status || "未確認",
     instructionsState:
       result.selfParity.surfaceUpdateChecklist?.customGptInstructions?.status || "未確認",
-    deployOperatorUrl: result.selfParity.deployOperatorUrl || null
+    deployOperatorUrl: result.selfParity.deployOperatorUrl || null,
+    issueCloseOperatorUrl: result.selfParity.issueCloseOperatorUrl || null
   };
 }
 
@@ -1702,6 +1703,7 @@ async function handleRetrieveButlerSelfParityRequest(url, env) {
     repository: normalizeText(url.searchParams.get("repository")),
     ref: normalizeText(url.searchParams.get("ref")),
     issueNumber: normalizeIssue(url.searchParams.get("issueNumber")),
+    pullNumber: normalizeIssue(url.searchParams.get("pullNumber")),
     runtimeOrigin: url.origin,
     env
   });

--- a/test/custom-gpt-setup-artifacts.test.js
+++ b/test/custom-gpt-setup-artifacts.test.js
@@ -104,6 +104,7 @@ test("evaluateButlerSelfParity reports deploy update required when canonical set
     ref: "main",
     runtimeOrigin: "https://sample-user-vtdd.example.workers.dev",
     issueNumber: 91,
+    pullNumber: 148,
     env: {
       GITHUB_APP_INSTALLATION_TOKEN: "ghs_setup_read",
       GITHUB_API_FETCH: async (url) => {
@@ -143,6 +144,26 @@ test("evaluateButlerSelfParity reports deploy update required when canonical set
     result.selfParity.deployRecovery.operatorMarkdownLink,
     result.selfParity.deployOperatorMarkdownLink
   );
+  assert.equal(
+    result.selfParity.issueCloseOperatorUrl,
+    "https://sample-user-vtdd.example.workers.dev/v2/approval/passkey/operator?repositoryInput=sample-org%2Fvtdd-v2-p&phase=execution&actionType=issue_close&highRiskKind=issue_close&issueNumber=91&pullNumber=148"
+  );
+  assert.equal(
+    result.selfParity.issueCloseOperatorMarkdownLink,
+    `[Open issue close operator](${result.selfParity.issueCloseOperatorUrl})`
+  );
+  assert.deepEqual(result.selfParity.issueCloseOperator, {
+    actionType: "issue_close",
+    highRiskKind: "issue_close",
+    requires: ["GO", "real passkey", "merged pull proof"],
+    repository: "sample-org/vtdd-v2-p",
+    issueNumber: 91,
+    pullNumber: 148,
+    operatorUrl: result.selfParity.issueCloseOperatorUrl,
+    operatorMarkdownLink: result.selfParity.issueCloseOperatorMarkdownLink,
+    status: "ready",
+    blockers: []
+  });
   assert.equal(
     result.selfParity.recommendedActions.some((item) => item.includes("/v2/approval/passkey/operator")),
     true
@@ -276,7 +297,61 @@ test("evaluateButlerSelfParity treats current nickname and secret sync actions a
     result.selfParity.deployOperatorMarkdownLink,
     `[Open deploy operator](${result.selfParity.deployOperatorUrl})`
   );
+  assert.equal(result.selfParity.issueCloseOperatorUrl, null);
+  assert.equal(result.selfParity.issueCloseOperator, null);
   assert.equal(result.selfParity.deployRecovery, null);
+});
+
+test("evaluateButlerSelfParity reports issue close operator blockers without constructing a URL", async () => {
+  const canonicalOpenApi = [
+    "openapi: 3.1.1",
+    "paths:",
+    "  /v2/action/gateway:",
+    "    post:",
+    "      operationId: vtddGateway",
+    "  /v2/action/deploy-production:",
+    "    post:",
+    "      operationId: vtddDeployProduction",
+    "  /v2/retrieve/github:",
+    "    get:",
+    "      operationId: vtddRetrieveGitHub",
+    "  /v2/retrieve/self-parity:",
+    "    get:",
+    "      operationId: vtddRetrieveSelfParity"
+  ].join("\n");
+  const canonicalInstructions = [
+    "vtddGateway",
+    "vtddDeployProduction",
+    "vtddRetrieveGitHub",
+    "vtddRetrieveSelfParity"
+  ].join("\n");
+
+  const result = await evaluateButlerSelfParity({
+    repository: "sample-org/vtdd-v2-p",
+    ref: "main",
+    runtimeOrigin: "https://sample-user-vtdd.example.workers.dev",
+    issueNumber: 91,
+    env: {
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_setup_read",
+      GITHUB_API_FETCH: async (url) => {
+        const parsed = new URL(url);
+        const isInstructions = parsed.pathname.endsWith("/docs/setup/custom-gpt-instructions.md");
+        return new Response(
+          JSON.stringify({
+            sha: isInstructions ? "instructions-sha" : "openapi-sha",
+            encoding: "base64",
+            content: encodeContent(isInstructions ? canonicalInstructions : canonicalOpenApi)
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        );
+      }
+    }
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.selfParity.issueCloseOperatorUrl, null);
+  assert.equal(result.selfParity.issueCloseOperator.status, "missing_merged_pull_number");
+  assert.deepEqual(result.selfParity.issueCloseOperator.blockers, ["missing_merged_pull_number"]);
 });
 
 test("buildCustomGptRecoveryBundle expands Worker URL and reports short-min length", async () => {

--- a/test/github-high-risk-plane.test.js
+++ b/test/github-high-risk-plane.test.js
@@ -62,6 +62,7 @@ test("github app operation registry defines issue close authority scope and runt
     "repositoryInput",
     "phase",
     "issueNumber",
+    "pullNumber",
     "actionType",
     "highRiskKind"
   ]);

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -3801,7 +3801,7 @@ test("worker returns canonical Custom GPT setup artifacts", async () => {
 test("worker returns Butler self-parity summary", async () => {
   const response = await worker.fetch(
     new Request(
-      "https://example.com/v2/retrieve/self-parity?repository=sample-org/vtdd-v2-p&ref=main&issueNumber=91",
+      "https://example.com/v2/retrieve/self-parity?repository=sample-org/vtdd-v2-p&ref=main&issueNumber=91&pullNumber=148",
       {
         headers: gatewayAuthHeaders
       }
@@ -3874,6 +3874,16 @@ test("worker returns Butler self-parity summary", async () => {
     body.selfParity.deployOperatorMarkdownLink,
     `[Open deploy operator](${body.selfParity.deployOperatorUrl})`
   );
+  assert.equal(
+    body.selfParity.issueCloseOperatorUrl,
+    "https://example.com/v2/approval/passkey/operator?repositoryInput=sample-org%2Fvtdd-v2-p&phase=execution&actionType=issue_close&highRiskKind=issue_close&issueNumber=91&pullNumber=148"
+  );
+  assert.equal(
+    body.selfParity.issueCloseOperatorMarkdownLink,
+    `[Open issue close operator](${body.selfParity.issueCloseOperatorUrl})`
+  );
+  assert.equal(body.selfParity.issueCloseOperator.status, "ready");
+  assert.deepEqual(body.selfParity.issueCloseOperator.blockers, []);
   assert.equal(body.selfParity.deployRecovery, null);
   assert.equal(body.selfParity.surfaceUpdateChecklist.cloudflareDeploy.status, "not_required");
   assert.equal(body.selfParity.knownGoodComparison.status, "known_good_unavailable");

--- a/worker.js
+++ b/worker.js
@@ -36595,6 +36595,7 @@ async function evaluateButlerSelfParity(input = {}) {
   const ref = normalizeText24(input.ref) || "main";
   const runtimeOrigin = normalizeOrigin2(input.runtimeOrigin);
   const issueNumber = normalizeIssueNumber(input.issueNumber);
+  const pullNumber = normalizeIssueNumber(input.pullNumber);
   const env = input.env ?? {};
   const instructions = await retrieveCustomGptSetupArtifact({
     artifact: CustomGptSetupArtifact.INSTRUCTIONS,
@@ -36653,6 +36654,23 @@ async function evaluateButlerSelfParity(input = {}) {
     issueNumber
   }) : null;
   const deployOperatorMarkdownLink = deployOperatorUrl ? `[Open deploy operator](${deployOperatorUrl})` : null;
+  const issueCloseOperatorUrl = repository && runtimeOrigin && issueNumber && pullNumber ? buildPasskeyOperatorUrl({
+    origin: runtimeOrigin,
+    repository,
+    phase: "execution",
+    actionType: "issue_close",
+    highRiskKind: "issue_close",
+    issueNumber,
+    pullNumber
+  }) : null;
+  const issueCloseOperatorMarkdownLink = issueCloseOperatorUrl ? `[Open issue close operator](${issueCloseOperatorUrl})` : null;
+  const issueCloseOperatorStatus = classifyIssueCloseOperatorStatus({
+    repository,
+    runtimeOrigin,
+    issueNumber,
+    pullNumber,
+    issueCloseOperatorUrl
+  });
   const recommendedActions = runtimeParity === "in_sync" ? [
     "If Butler cannot use the expected feature set from the current surface, Action Schema update required.",
     "If Butler cannot follow the expected behavior from the current surface, Instructions update required."
@@ -36696,6 +36714,20 @@ async function evaluateButlerSelfParity(input = {}) {
       staleCapabilities,
       deployOperatorUrl,
       deployOperatorMarkdownLink,
+      issueCloseOperatorUrl,
+      issueCloseOperatorMarkdownLink,
+      issueCloseOperator: issueCloseOperatorStatus.status !== "not_requested" ? {
+        actionType: "issue_close",
+        highRiskKind: "issue_close",
+        requires: ["GO", "real passkey", "merged pull proof"],
+        repository,
+        issueNumber,
+        pullNumber,
+        operatorUrl: issueCloseOperatorUrl,
+        operatorMarkdownLink: issueCloseOperatorMarkdownLink,
+        status: issueCloseOperatorStatus.status,
+        blockers: issueCloseOperatorStatus.blockers
+      } : null,
       deployRecovery: runtimeParity === "cloudflare_deploy_update_required" ? {
         actionType: "deploy_production",
         highRiskKind: "deploy_production",
@@ -37459,7 +37491,7 @@ function normalizeApiBaseUrl4(value) {
   const normalized = normalizeText24(value);
   return normalized ? normalized.replace(/\/+$/, "") : GITHUB_API_BASE_URL3;
 }
-function buildPasskeyOperatorUrl({ origin, repository, phase, actionType, highRiskKind, issueNumber }) {
+function buildPasskeyOperatorUrl({ origin, repository, phase, actionType, highRiskKind, issueNumber, pullNumber }) {
   const url = new URL("/v2/approval/passkey/operator", `${origin}/`);
   url.searchParams.set("repositoryInput", repository);
   url.searchParams.set("phase", phase || "execution");
@@ -37468,7 +37500,41 @@ function buildPasskeyOperatorUrl({ origin, repository, phase, actionType, highRi
   if (Number.isInteger(issueNumber) && issueNumber > 0) {
     url.searchParams.set("issueNumber", String(issueNumber));
   }
+  if (Number.isInteger(pullNumber) && pullNumber > 0) {
+    url.searchParams.set("pullNumber", String(pullNumber));
+  }
   return url.toString();
+}
+function classifyIssueCloseOperatorStatus({
+  repository,
+  runtimeOrigin,
+  issueNumber,
+  pullNumber,
+  issueCloseOperatorUrl
+}) {
+  if (issueCloseOperatorUrl) {
+    return { status: "ready", blockers: [] };
+  }
+  if (!issueNumber && !pullNumber) {
+    return { status: "not_requested", blockers: [] };
+  }
+  const blockers = [];
+  if (!repository) {
+    blockers.push("missing_repository");
+  }
+  if (!runtimeOrigin) {
+    blockers.push("missing_runtime_origin");
+  }
+  if (!issueNumber) {
+    blockers.push("missing_issue_number");
+  }
+  if (!pullNumber) {
+    blockers.push("missing_merged_pull_number");
+  }
+  return {
+    status: blockers[0] || "unavailable",
+    blockers
+  };
 }
 function normalizeOrigin2(value) {
   const normalized = normalizeText24(value);
@@ -38555,7 +38621,7 @@ var GitHubAppOperationRegistry = Object.freeze({
     passkey: {
       actionType: "issue_close",
       highRiskKind: "issue_close",
-      operatorUrlRequirements: ["repositoryInput", "phase", "issueNumber", "actionType", "highRiskKind"]
+      operatorUrlRequirements: ["repositoryInput", "phase", "issueNumber", "pullNumber", "actionType", "highRiskKind"]
     }
   },
   deploy_production: {
@@ -55926,7 +55992,8 @@ async function evaluateStartupPreflightSelfParity({
     deployState: result.selfParity.surfaceUpdateChecklist?.cloudflareDeploy?.status || "\u672A\u78BA\u8A8D",
     actionSchemaState: result.selfParity.surfaceUpdateChecklist?.customGptActionSchema?.status || "\u672A\u78BA\u8A8D",
     instructionsState: result.selfParity.surfaceUpdateChecklist?.customGptInstructions?.status || "\u672A\u78BA\u8A8D",
-    deployOperatorUrl: result.selfParity.deployOperatorUrl || null
+    deployOperatorUrl: result.selfParity.deployOperatorUrl || null,
+    issueCloseOperatorUrl: result.selfParity.issueCloseOperatorUrl || null
   };
 }
 function buildStartupSurfaceCapability(currentSurface) {
@@ -56407,6 +56474,7 @@ async function handleRetrieveButlerSelfParityRequest(url, env) {
     repository: normalizeText30(url.searchParams.get("repository")),
     ref: normalizeText30(url.searchParams.get("ref")),
     issueNumber: normalizeIssue6(url.searchParams.get("issueNumber")),
+    pullNumber: normalizeIssue6(url.searchParams.get("pullNumber")),
     runtimeOrigin: url.origin,
     env
   });


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #408 の残り gap として、Butler が issue_close 用 passkey operator URL を推測ではなく runtime truth から取得できるようにする。
- `vtddRetrieveSelfParity` に `issueNumber` / `pullNumber` を渡せるようにし、`selfParity.issueCloseOperatorUrl` / `selfParity.issueCloseOperatorMarkdownLink` を返す。
- issue_close の operator URL requirements を merged pull proof 付きに揃える。

## Satisfied Success Criteria

- passkey operator page の issue close mode へ Butler が issue-bound URL で到達できる。
- issueNumber は operator URL / input から明示され、raw JSON authoring を owner に要求しない。
- bounded issue close に必要な merged pull proof を operator URL 生成契約に含める。
- Butler/iPhone から approval -> dispatch -> runtime truth confirmation へ進むための operator URL が runtime truth として返る。

## Unsatisfied Success Criteria

- live iPhone Butler E2E は merge + deploy + Custom GPT Action Schema/Instructions 更新後に実施する。
- 実際の Issue close 実行と GitHub state=closed 確認は post-merge live E2E として残す。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #408
- Implementing Success Criteria: Butler が issue_close 用 operator URL を runtime truth から取得できること。Issue close operator URL が issueNumber と merged PR pullNumber を含むこと。
- Explicit Non-goals: Issue #349/#408 自体をこのPRで閉じない。deploy/secret/permission/admin mutation は行わない。passkey/WebAuthn authority model は弱めない。setup wizard は戻さない。
- Expected touched files/routes/workflows: `src/core/custom-gpt-setup-artifacts.js`, `src/worker/runtime.js`, `src/core/github-app-operation-registry.js`, `docs/setup/custom-gpt-actions-openapi.yaml`, `docs/setup/custom-gpt-actions-openapi.json`, `docs/setup/custom-gpt-instructions*.md`, tests, generated `worker.js`。
- Affected Issues: #408, #349, #357
- Affected PRs: #409 の後続補完。
- Affected workflows: GitHub Actions test / guarded-policy のみ。
- Affected runtime/operator surfaces: Butler Custom GPT Action Schema, self-parity retrieve route, passkey operator URL guidance, issue_close high-risk operator surface。
- What may break if we patch narrowly: deploy URL と issue_close URL の契約が混ざると Butler が wrong-scope approval を案内する可能性がある。
- Unknowns to investigate before coding: selfParity に issue_close URL helper が存在するか、short-min instructions が Butler に十分な URL guidance を渡しているか。
- Validation needed: unit/integration tests, OpenAPI JSON parse, self-parity route test, generated worker check, full `npm test`。
- Stop condition: issue_close URL を deploy URL と同じ field に押し込む必要が出た場合、または passkey authority boundary を弱める必要が出た場合。

## File / Line Hypotheses

- file: `src/core/custom-gpt-setup-artifacts.js`
  - hypothesis: `deployOperatorUrl` しか返していないため Butler が issue_close URL を runtime truth として取得できない。
  - risk if changed narrowly: deploy recovery と issue_close recovery の authority scope が混線する。
  - validation: selfParity tests で deploy URL と issueClose URL を別 field として確認。
  - related Issue: #408
- file: `docs/setup/custom-gpt-actions-openapi.yaml`
  - hypothesis: `vtddRetrieveSelfParity` が issueNumber / pullNumber を query parameter として露出していない。
  - risk if changed narrowly: Butler が Action UI から merged pull proof を渡せない。
  - validation: OpenAPI docs tests と runtime route test。
  - related Issue: #408

## Hypothesis Retrospective

- expected: selfParity に deploy 専用 URL しかなく、issue_close URL helper は存在しない。
- actual: `deployOperatorUrl` のみ存在していたため、`issueCloseOperatorUrl` / `issueCloseOperatorMarkdownLink` を追加した。
- mismatch: issue_close registry では runtime evidence に pullNumber が必要なのに operatorUrlRequirements に pullNumber がなかった。
- lesson: high-risk operator URL は action type ごとに structured field と requirements を揃える必要がある。
- should become RAG candidate: yes, post-merge live E2E 後に判断。

## Verification Evidence

- Unit: `node --test test/custom-gpt-setup-artifacts.test.js`; `node --test test/github-high-risk-plane.test.js`; `node --test test/custom-gpt-setup-docs.test.js`
- Integration: `node --test test/worker.test.js`
- E2E: `npm test` pass。live iPhone Butler E2E は post-merge/deploy 後。
- Manual: selfParity response contract と generated worker を確認。
- Evidence path/link: local test output in this PR run.

## Butler Completion Contract

- Owner goal: Butler が Issue close 用 operator URL を捏造せず runtime truth から取得できる。
- Butler entrypoint: `vtddRetrieveSelfParity(repository, issueNumber, pullNumber)`。
- Action Schema exposure: `vtddRetrieveSelfParity` に optional `issueNumber` / `pullNumber` query parameter を追加。
- Runtime path: `/v2/retrieve/self-parity` -> `selfParity.issueCloseOperatorUrl` / `selfParity.issueCloseOperatorMarkdownLink`。
- Runner/runtime truth: selfParity route test で issue_close URL に repo / issue / pull / actionType / highRiskKind が入ることを確認。
- Authority boundary: GO + real passkey + merged pull proof。Issue close 実行自体は `vtddGitHubAuthority operation=issue_close` のまま。
- E2E evidence: このPRでは runtime/helper contract まで。live iPhone Butler close 実行は merge + deploy + Custom GPT update 後。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: merge 後に必要。
- Custom GPT Action Schema update: 必要。`vtddRetrieveSelfParity` の query parameter が増える。
- Custom GPT Instructions update: 必要。short-min/full instructions が issueCloseOperatorMarkdownLink を案内する。
- iPhone Butler live E2E: merge + deploy + setup/latest 更新後に必要。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate
- AGENTS.md Issue Lifecycle Gate
- AGENTS.md Authority Boundary
- AGENTS.md Conversation UX Contract

## Out-of-scope but NOT implemented

- Issue #349 の close 実行。
- Issue #408 の close 判定。
- deploy / credential / permission / admin mutation。

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #408
- Execution ID: Not provided.
- Goal: issue_close_operator_url_runtime_truth
