### PR TITLE
Issue #408 expose self-parity proof params

### DIFF
--- a/docs/setup/custom-gpt-actions-openapi.json
+++ b/docs/setup/custom-gpt-actions-openapi.json
@@ -2664,24 +2664,6 @@
             }
           },
           {
-            "name": "issueNumber",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer"
-            },
-            "description": "Active Issue number when a passkey operator URL should be scoped to an Issue."
-          },
-          {
-            "name": "pullNumber",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer"
-            },
-            "description": "Merged PR number used as bounded post-merge proof for issue_close operator links."
-          },
-          {
             "name": "responseMode",
             "in": "query",
             "required": false,
@@ -2825,6 +2807,24 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "issueNumber",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            },
+            "description": "Active Issue number when a passkey operator URL should be scoped to an Issue."
+          },
+          {
+            "name": "pullNumber",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            },
+            "description": "Merged PR number used as bounded post-merge proof for issue_close operator links."
           },
           {
             "name": "responseMode",

--- a/docs/setup/custom-gpt-actions-openapi.yaml
+++ b/docs/setup/custom-gpt-actions-openapi.yaml
@@ -1923,18 +1923,6 @@ paths:
           required: false
           schema:
             type: string
-        - name: issueNumber
-          in: query
-          required: false
-          schema:
-            type: integer
-          description: Active Issue number when a passkey operator URL should be scoped to an Issue.
-        - name: pullNumber
-          in: query
-          required: false
-          schema:
-            type: integer
-          description: Merged PR number used as bounded post-merge proof for issue_close operator links.
         - name: responseMode
           in: query
           required: false
@@ -1989,6 +1977,18 @@ paths:
           required: false
           schema:
             type: string
+        - name: issueNumber
+          in: query
+          required: false
+          schema:
+            type: integer
+          description: Active Issue number when a passkey operator URL should be scoped to an Issue.
+        - name: pullNumber
+          in: query
+          required: false
+          schema:
+            type: integer
+          description: Merged PR number used as bounded post-merge proof for issue_close operator links.
         - name: responseMode
           in: query
           required: false

--- a/test/custom-gpt-setup-docs.test.js
+++ b/test/custom-gpt-setup-docs.test.js
@@ -385,10 +385,16 @@ test("custom gpt self-parity action exposes issue close proof parameters", () =>
   assert.equal(selfParityParams.includes("pullNumber"), true);
 
   const yaml = fs.readFileSync(OPENAPI_PATH, "utf8");
+  const setupArtifactSection = yaml.slice(
+    yaml.indexOf("  /v2/retrieve/setup-artifact:"),
+    yaml.indexOf("  /v2/retrieve/self-parity:")
+  );
   const selfParitySection = yaml.slice(
     yaml.indexOf("  /v2/retrieve/self-parity:"),
     yaml.indexOf("  /v2/retrieve/approval-grant:")
   );
+  assert.equal(setupArtifactSection.includes("- name: issueNumber"), false);
+  assert.equal(setupArtifactSection.includes("- name: pullNumber"), false);
   assert.equal(selfParitySection.includes("- name: issueNumber"), true);
   assert.equal(selfParitySection.includes("- name: pullNumber"), true);
 });

--- a/test/custom-gpt-setup-docs.test.js
+++ b/test/custom-gpt-setup-docs.test.js
@@ -372,6 +372,27 @@ test("custom gpt openapi doc exposes current gateway, execute, and progress rout
   assert.equal(doc.includes("presentedPayload:"), true);
 });
 
+test("custom gpt self-parity action exposes issue close proof parameters", () => {
+  const openapiJson = JSON.parse(fs.readFileSync(OPENAPI_JSON_PATH, "utf8"));
+  const setupArtifactParams =
+    openapiJson.paths["/v2/retrieve/setup-artifact"].get.parameters.map((parameter) => parameter.name);
+  const selfParityParams =
+    openapiJson.paths["/v2/retrieve/self-parity"].get.parameters.map((parameter) => parameter.name);
+
+  assert.equal(setupArtifactParams.includes("issueNumber"), false);
+  assert.equal(setupArtifactParams.includes("pullNumber"), false);
+  assert.equal(selfParityParams.includes("issueNumber"), true);
+  assert.equal(selfParityParams.includes("pullNumber"), true);
+
+  const yaml = fs.readFileSync(OPENAPI_PATH, "utf8");
+  const selfParitySection = yaml.slice(
+    yaml.indexOf("  /v2/retrieve/self-parity:"),
+    yaml.indexOf("  /v2/retrieve/approval-grant:")
+  );
+  assert.equal(selfParitySection.includes("- name: issueNumber"), true);
+  assert.equal(selfParitySection.includes("- name: pullNumber"), true);
+});
+
 test("custom gpt openapi keeps components.schemas while avoiding nested field refs", () => {
   const doc = fs.readFileSync(OPENAPI_PATH, "utf8");
   assert.equal(doc.includes("components:"), true);


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #408 の follow-up として、Butler が issue close operator URL を取得するための self-parity proof parameters を Custom GPT Action Schema の正しい operation に公開する。
- PR #410 で runtime 側の issueCloseOperatorUrl 生成は追加済みだったが、Action Schema では issueNumber / pullNumber が vtddRetrieveSetupArtifact 側に誤配置され、vtddRetrieveSelfParity から渡せなかった。

## Satisfied Success Criteria

- vtddRetrieveSelfParity の Action Schema に issueNumber / pullNumber を追加した。
- vtddRetrieveSetupArtifact から issue close proof 用ではない issueNumber / pullNumber を削除した。
- JSON と YAML の配置を回帰テストで固定した。
- Reviewer 指摘を受け、YAML 側でも setup-artifact に issueNumber / pullNumber が再混入しないことを negative assertion で固定した。

## Unsatisfied Success Criteria

- merge 後に setup latest から Custom GPT Action Schema を更新する必要がある。
- 更新後、Butler から repository=marushu/vtdd-v2-p / issueNumber=349 / pullNumber=350 で selfParity を再取得し、issueCloseOperatorUrl / issueCloseOperatorMarkdownLink が返ることを live E2E で確認する必要がある。
- このPRでは Issue close は実行しない。

## Non-goal violations

Issue #349 の close 実行はしない。Cloudflare deploy、credential、permission、authority model は変更しない。runtime handler は PR #410 で接続済みのため、このPRでは変更しない。

## Dry-run Impact Report

- Target Issue: Issue #408
- Implementing Success Criteria: Butler が issue close 用の bounded proof input を vtddRetrieveSelfParity に渡せるよう、Action Schema 上の operationId/tool exposure を修正する。
- Explicit Non-goals: Issue close 実行、deploy、credential mutation、permission mutation、operator authority model 変更、runtime route 変更は対象外。
- Expected touched files/routes/workflows: docs/setup/custom-gpt-actions-openapi.yaml, docs/setup/custom-gpt-actions-openapi.json, test/custom-gpt-setup-docs.test.js, PR body only follow-up for public/core safety.
- Affected Issues: Issue #408。Issue #349 close live E2E の unblock に影響するが、このPRは Issue #349 を閉じない。
- Affected PRs: PR #410 の follow-up。PR #350 は Issue #349 close proof として後続 E2E で使う。
- Affected workflows: CI の npm test。GitHub Actions や deploy workflow 自体は変更しない。
- Affected runtime/operator surfaces: Custom GPT Action Schema, Butler selfParity action, setup latest copy-ready schema。Worker runtime source は変更しない。
- What may break if we patch narrowly: Schema だけ直して runtime handler が未接続なら URL は返らないが、PR #410 merge 後 runtime handler と core selfParity は issueNumber / pullNumber を受け取る実装済みであることを確認済み。
- Unknowns to investigate before coding: merge 後の Custom GPT editor が更新済みかは runtime だけでは判定できないため、setup latest から Action Schema 更新後の Butler live E2E が必要。
- Validation needed: node --test test/custom-gpt-setup-docs.test.js, npm test, merge 後の setup latest 反映確認, Butler selfParity live E2E。
- Stop condition: runtime source 変更や authority boundary 変更が必要と判明した場合は、この docs/schema follow-up PR の範囲を超えるため停止する。

## File / Line Hypotheses

- file: docs/setup/custom-gpt-actions-openapi.yaml
  - hypothesis: issueNumber / pullNumber が /v2/retrieve/setup-artifact に誤配置され、/v2/retrieve/self-parity に存在しないため Butler が vtddRetrieveSelfParity で渡せない。
  - risk if changed narrowly: JSON 側やテストが追従しないと setup latest の copy-ready schema と regression coverage がずれる。
  - validation: YAML/JSON の両方で self-parity に params があり setup-artifact に params がないことをテストする。
  - related Issue: Issue #408

## Hypothesis Retrospective

- expected: self-parity operation に issueNumber / pullNumber を移動すれば Butler が bounded issue close proof を渡せる。
- actual: YAML/JSON の self-parity に params を追加し、setup-artifact から削除した。追加で YAML 側の negative assertion も固定した。
- mismatch: runtime handler は既に受け取り可能だったため、修正対象は Action Schema exposure に限定できた。
- lesson: operationId/tool exposure の配置は runtime in_sync だけでは検出できないので、schema placement regression test が必要。
- should become RAG candidate: merge 後の live E2E 結果次第で判断。

## Verification Evidence

- Unit: node --test test/custom-gpt-setup-docs.test.js: pass (11/11)
- Integration: npm test: pass before follow-up test tightening (818 tests, 817 pass, 1 skipped)。After tightening, targeted setup docs test pass (11/11) and CI guarded-policy/test pass on head 48915c6.
- E2E: 未実施。merge 後に setup latest から Action Schema 更新し、Butler から selfParity を再取得して確認する。
- Manual: PR #410 後の live failure で issueCloseOperatorUrl / issueCloseOperatorMarkdownLink が null だった原因を schema parameter placement として確認。
- Evidence path/link: test/custom-gpt-setup-docs.test.js; GitHub Actions guarded-policy/test success on PR #411 head 48915c6.

## Butler Completion Contract

- Owner goal: iPhone Butler が Issue #349 の scoped close に必要な issue-bound operator URL を自力で取得できるようにする。
- Butler entrypoint: Custom GPT Action vtddRetrieveSelfParity に repository/ref/issueNumber/pullNumber を指定する。
- Action Schema exposure: vtddRetrieveSelfParity exposes issueNumber and pullNumber. vtddRetrieveSetupArtifact no longer exposes those unrelated proof params.
- Runtime path: GET /v2/retrieve/self-parity with repository, issueNumber, and pullNumber query parameters. runtime handler/core path は PR #410 で接続済み。
- Runner/runtime truth: merge 前は test evidence のみ。merge 後は setup latest と Butler live selfParity response で issueCloseOperatorUrl / issueCloseOperatorMarkdownLink を確認する。
- Authority boundary: 未変更。Issue close 実行には issue_close approval grant と GO が必要。このPRでは close しない。
- E2E evidence: 未実施。merge 後に Action Schema 更新して iPhone Butler live E2E を行う。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 通常は不要。docs/setup の copy-ready Action Schema 変更なので、merge 後に runtime truth で deployState を確認する。public/core PR body には owner-specific operator URL を記載しない。
- Custom GPT Action Schema update: 必要。merge 後に runtime setup latest から Action Schema を更新する。public/core PR body には owner-specific setup URL を記載しない。
- Custom GPT Instructions update: 不要想定。このPRは Instructions を変更していない。merge 後の runtime truth で再確認する。
- iPhone Butler live E2E: 必要。Action Schema 更新後、Butler で Issue #349 / PR #350 の issueCloseOperatorUrl が返ることを確認する。

## Related Constitution Rules

- Butler Completion Gate: operationId/tool exposure と Butler-facing E2E が必要。
- Drift Stop Protocol: Issue #408 の bounded follow-up として schema placement のみ修正。
- Issue Lifecycle Gate: このPRでは Issue close を実行せず、post-merge evidence 後に判断する。
- Safety Invariants: public/core PR body には owner-specific runtime URL / deploy operator URL を埋め込まない。

## Out-of-scope but NOT implemented

- Issue #349 の close 実行。Cloudflare deploy 実行。Instructions 更新。runtime authority model 変更。owner-specific runtime URL / deploy operator URL の PR body 掲載。

## Extra changes (if any)

PR #410 merge 後の live failure に対する narrow follow-up。原因は selfParity runtime ではなく Custom GPT Action Schema parameter placement。Reviewer request_changes を受け、PR body から owner-specific runtime URL / deploy operator URL を中立化した。

<!-- VTDD metadata -->
- Issue: Issue #408
- Execution ID: Not provided.
- Goal: Not provided.
