### PR TITLE
Issue #418 fix setup diagnostics schema false positive

### DIFF
--- a/src/core/custom-gpt-setup-artifacts.js
+++ b/src/core/custom-gpt-setup-artifacts.js
@@ -1302,10 +1302,10 @@ function evaluateActionSchemaDiagnostics({ openApiContent, runtimeOrigin }) {
   const hasSelfParity = operationIds.includes("vtddRetrieveSelfParity");
   const hasSetupArtifact = operationIds.includes("vtddRetrieveSetupArtifact");
   const hasSetupDiagnostics = operationIds.includes("vtddRetrieveSetupDiagnostics");
-  const executeBlock = extractYamlPathBlock(content, "/v2/action/execute");
-  const gatewayBlock = extractYamlPathBlock(content, "/v2/gateway");
-  const buildUnderExecute = executeBlock.includes("- build");
-  const buildUnderGateway = gatewayBlock.includes("- build");
+  const executeSchemaBlock = extractYamlSchemaBlock(content, "VtddExecuteRequest");
+  const gatewaySchemaBlock = extractYamlSchemaBlock(content, "VtddGatewayRequest");
+  const buildUnderExecute = executeSchemaBlock.includes("- build");
+  const buildUnderGateway = gatewaySchemaBlock.includes("- build");
   const serverUrl = extractOpenApiServerUrl(content);
   const expectedServerUrl = normalizeOrigin(runtimeOrigin);
   const serverUrlMatchesRuntime =
@@ -1490,14 +1490,14 @@ function normalizeObservedSetupFailure(input = {}) {
   };
 }
 
-function extractYamlPathBlock(content, path) {
+function extractYamlSchemaBlock(content, schemaName) {
   const value = String(content ?? "");
-  const marker = `  ${path}:`;
+  const marker = `    ${schemaName}:`;
   const start = value.indexOf(marker);
   if (start === -1) {
     return "";
   }
-  const next = value.slice(start + marker.length).search(/\n  \/[^\n]+:/);
+  const next = value.slice(start + marker.length).search(/\n    [A-Za-z0-9_.-]+:/);
   return next === -1 ? value.slice(start) : value.slice(start, start + marker.length + next);
 }
 

--- a/test/custom-gpt-setup-artifacts.test.js
+++ b/test/custom-gpt-setup-artifacts.test.js
@@ -1,5 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import fs from "node:fs";
 
 import {
   buildCustomGptRecoveryBundle,
@@ -64,6 +65,29 @@ test("evaluateCustomGptSetupDiagnostics classifies Action Schema, auth, and depl
     "    GatewayBearerAuth:",
     "      type: http",
     "      scheme: bearer",
+    "  schemas:",
+    "    VtddGatewayRequest:",
+    "      type: object",
+    "      properties:",
+    "        policyInput:",
+    "          type: object",
+    "          properties:",
+    "            actionType:",
+    "              type: string",
+    "              enum:",
+    "                - read",
+    "                - issue_create",
+    "    VtddExecuteRequest:",
+    "      type: object",
+    "      properties:",
+    "        policyInput:",
+    "          type: object",
+    "          properties:",
+    "            actionType:",
+    "              type: string",
+    "              enum:",
+    "                - read",
+    "                - build",
     "paths:",
     "  /v2/retrieve/self-parity:",
     "    get:",
@@ -79,8 +103,6 @@ test("evaluateCustomGptSetupDiagnostics classifies Action Schema, auth, and depl
     "  /v2/action/execute:",
     "    post:",
     "      operationId: vtddExecute",
-    "      enum:",
-    "        - build",
     "  /v2/action/not-deployed-yet:",
     "    post:",
     "      operationId: vtddBrandNewDiagnosticsAction"
@@ -142,6 +164,47 @@ test("evaluateCustomGptSetupDiagnostics classifies Action Schema, auth, and depl
     true
   );
   assert.equal(JSON.stringify(result.diagnostics).includes("ghs_setup_read"), false);
+});
+
+test("evaluateCustomGptSetupDiagnostics treats canonical OpenAPI execute build enum as valid", async () => {
+  const canonicalOpenApi = fs.readFileSync("docs/setup/custom-gpt-actions-openapi.yaml", "utf8");
+  const canonicalInstructions = fs.readFileSync("docs/setup/custom-gpt-instructions.md", "utf8");
+
+  const result = await evaluateCustomGptSetupDiagnostics({
+    repository: "sample-org/vtdd-v2-p",
+    ref: "main",
+    runtimeOrigin: "https://sample-user-vtdd.example.workers.dev",
+    env: {
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_setup_read",
+      GITHUB_API_FETCH: async (url) => {
+        const parsed = new URL(url);
+        if (parsed.pathname.endsWith("/docs/setup/known-good.json")) {
+          return new Response(
+            JSON.stringify({
+              sha: "known-good-manifest-sha",
+              encoding: "base64",
+              content: encodeContent(JSON.stringify({ commitSha: "a".repeat(40) }))
+            }),
+            { status: 200, headers: { "content-type": "application/json" } }
+          );
+        }
+        const isInstructions = parsed.pathname.endsWith("/docs/setup/custom-gpt-instructions.md");
+        return new Response(
+          JSON.stringify({
+            sha: isInstructions ? "latest-instructions-sha" : "latest-openapi-sha",
+            encoding: "base64",
+            content: encodeContent(isInstructions ? canonicalInstructions : canonicalOpenApi)
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        );
+      }
+    }
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.diagnostics.actionSchema.checks.buildUnderExecute, true);
+  assert.equal(result.diagnostics.actionSchema.checks.buildUnderGateway, false);
+  assert.equal(result.diagnostics.actionSchema.missing.includes("build enum under vtddExecute"), false);
 });
 
 test("retrieveCustomGptSetupArtifact rejects unsupported artifacts", async () => {

--- a/worker.js
+++ b/worker.js
@@ -37810,10 +37810,10 @@ function evaluateActionSchemaDiagnostics({ openApiContent, runtimeOrigin }) {
   const hasSelfParity = operationIds.includes("vtddRetrieveSelfParity");
   const hasSetupArtifact = operationIds.includes("vtddRetrieveSetupArtifact");
   const hasSetupDiagnostics = operationIds.includes("vtddRetrieveSetupDiagnostics");
-  const executeBlock = extractYamlPathBlock(content, "/v2/action/execute");
-  const gatewayBlock = extractYamlPathBlock(content, "/v2/gateway");
-  const buildUnderExecute = executeBlock.includes("- build");
-  const buildUnderGateway = gatewayBlock.includes("- build");
+  const executeSchemaBlock = extractYamlSchemaBlock(content, "VtddExecuteRequest");
+  const gatewaySchemaBlock = extractYamlSchemaBlock(content, "VtddGatewayRequest");
+  const buildUnderExecute = executeSchemaBlock.includes("- build");
+  const buildUnderGateway = gatewaySchemaBlock.includes("- build");
   const serverUrl = extractOpenApiServerUrl(content);
   const expectedServerUrl = normalizeOrigin2(runtimeOrigin);
   const serverUrlMatchesRuntime = !expectedServerUrl || serverUrl === expectedServerUrl || serverUrl === "https://your-runtime-host.example.workers.dev";
@@ -37970,14 +37970,14 @@ function normalizeObservedSetupFailure(input = {}) {
     missingBodyFields: normalizeText24(input.missingBodyFields)
   };
 }
-function extractYamlPathBlock(content, path) {
+function extractYamlSchemaBlock(content, schemaName) {
   const value = String(content ?? "");
-  const marker = `  ${path}:`;
+  const marker = `    ${schemaName}:`;
   const start = value.indexOf(marker);
   if (start === -1) {
     return "";
   }
-  const next = value.slice(start + marker.length).search(/\n  \/[^\n]+:/);
+  const next = value.slice(start + marker.length).search(/\n    [A-Za-z0-9_.-]+:/);
   return next === -1 ? value.slice(start) : value.slice(start, start + marker.length + next);
 }
 function extractOpenApiServerUrl(content) {


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #418 の追加修正です。`/setup/diagnostics` が canonical Action Schema を誤って `custom_gpt_action_schema_update_required` と判定し続ける回帰を修正します。
- 実際の `docs/setup/custom-gpt-actions-openapi.yaml` では `build` enum は `/v2/action/execute` path block ではなく `components.schemas.VtddExecuteRequest` に定義されているため、診断ロジックを schema block 参照に合わせます。

## Satisfied Success Criteria

- Action Schema 診断が `VtddExecuteRequest` の `build` enum と `VtddGatewayRequest` の非 `build` 状態を正しく読む。
- 実ファイルの canonical OpenAPI を使った回帰テストで `build enum under vtddExecute` の誤 missing を防ぐ。
- 生成済み `worker.js` を更新する。

## Unsatisfied Success Criteria

- Cloudflare deploy と live Butler E2E はこのPRでは未実行。merge後に GO + passkey の deploy と本番 `/setup/diagnostics` 再確認が必要。

## Non-goal violations

なし。

## Dry-run Impact Report

- Target Issue: #418
- Implementing Success Criteria: Action Schema / Instructions / Cloudflare deploy diagnostics のうち、Action Schema 診断の誤分類修正。
- Explicit Non-goals: deploy、credential/permission/secret 変更、Custom GPT editor 操作、Issue close、setup wizard 再導入。
- Expected touched files/routes/workflows: `src/core/custom-gpt-setup-artifacts.js`, `test/custom-gpt-setup-artifacts.test.js`, `worker.js`。route/workflow 追加なし。
- Affected Issues: #418。
- Affected PRs: #419 の post-merge follow-up。
- Affected workflows: なし。
- Affected runtime/operator surfaces: `/setup/diagnostics` の表示判定のみ。
- What may break if we patch narrowly: OpenAPI の schema 配置が変わると enum 判定が再びずれる可能性があるため、実ファイル回帰テストで固定。
- Unknowns to investigate before coding: なし。実ファイルで誤判定を確認済み。
- Validation needed: focused tests、full node test、self-parity、generated-worker。
- Stop condition: schema 判定以外の runtime behavior や deploy 操作が必要になったら停止。

## File / Line Hypotheses

- `src/core/custom-gpt-setup-artifacts.js`: `evaluateActionSchemaDiagnostics` が path block を読んでいたため、component schema 内の `build` enum を見落としていた。
- `test/custom-gpt-setup-artifacts.test.js`: synthetic OpenAPI が実際の schema 配置を再現しておらず、誤判定を捕まえられていなかった。

## Hypothesis Retrospective

- 仮説どおり、`/setup/latest` には `build` と `vtddRetrieveSetupDiagnostics` が含まれていたが、診断ロジックだけが古い見方をしていた。

## Verification Evidence

- Unit: `node --test test/custom-gpt-setup-artifacts.test.js` pass。
- Integration: `node --test test/custom-gpt-setup-artifacts.test.js test/worker.test.js test/custom-gpt-setup-docs.test.js test/e2e-418-setup-action-schema-deploy-diagnostics.test.js` pass。
- E2E: `node --test` pass（825 pass / 1 skipped / 0 fail）。
- Manual: 本番 `/setup/diagnostics` が merge前時点で `build enum under vtddExecute` missing を返すことを確認済み。このPRはその source-side fix。
- Evidence path/link: Issue #418 comment と this PR checks。

## Butler Completion Contract

- Owner goal: Butler が setup / Action Schema / Cloudflare deploy drift の原因を誤分類せずに読めること。
- Butler entrypoint: `/setup/diagnostics` と `vtddRetrieveSetupDiagnostics`。
- Action Schema exposure: 既存 operationId を変更しない。
- Runtime path: `evaluateCustomGptSetupDiagnostics` -> setup diagnostics render/retrieve。
- Runner/runtime truth: repo内 test と generated worker。live runtime は merge/deploy 後に再確認。
- Authority boundary: このPRは code/test のみ。deploy は GO + passkey。Issue close は未実行。
- E2E evidence: repo内 E2E test pass。live Butler E2E は未実行。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 未実行。merge後に GO + passkey が必要。
- Custom GPT Action Schema update: 不要。schema内容は変えない。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実行。deploy後に確認が必要。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate。
- AGENTS.md Evidence Discipline。
- AGENTS.md Drift Stop Protocol。
- AGENTS.md Issue Lifecycle Gate。

## Out-of-scope but NOT implemented

- Cloudflare deploy。
- Custom GPT editor の自動更新。
- Issue #418 close。

## Extra changes (if any)

なし。

<!-- VTDD metadata -->
- Issue: Issue #418
- Execution ID: mac_codex_post_merge_diagnostics_fix_20260518
- Goal: Fix setup diagnostics false positive after PR #419 deploy/update.
