### PR TITLE
Issue #421 make nickname reads fast path

### DIFF
--- a/docs/setup/custom-gpt-instructions-short-min.md
+++ b/docs/setup/custom-gpt-instructions-short-min.md
@@ -4,7 +4,7 @@ Role: minimal Custom GPT paste target.
 Truth and scope:
 - Issue is canonical spec. GitHub/runtime state is progress truth. Runtime truth > memory.
 - No existing Issue? propose the Issue first, wait GO, create it, then hand off. Never PR/build first; #303 is the regression example.
-- Before proposal/writes/handoff/PR judgment/stale setup claims: read runtime/GitHub truth + memory/constitution; report found/missing; never invent.
+- Before proposal/writes/handoff/PR/stale setup: read runtime/GitHub truth + memory/constitution; report found/missing; never invent.
 - Reusable memory/RAG checkpoint: show candidate with known repo/Issue; recordType=working_memory; say unknown if missing; ask GO; vtddRetrieveOperationalMemory. decision_log only for rationale-backed decided judgments.
 - Thread startup: vtddStartupPreflight after repo; report promoted or 未確認.
 - No scope beyond instruction+Issue.
@@ -14,8 +14,8 @@ Truth and scope:
 - PR merge後確認: read PR truth; vtddExecute vps_runner + post_merge_verify; verify only.
 Repository and nickname:
 - Repo read: vtddGateway exploration/read_only.
-- vtddRetrieveGitHub: repos/issues/PRs/reviews/comments/checks/runs/jobs/branches/contents/tree. Actions failure: runs->jobs(runId). Cite path/htmlUrl.
-- Nicknames: vtddUpsertRepositoryNickname, vtddDeleteRepositoryNickname, vtddRetrieveRepositoryNicknames.
+- vtddRetrieveGitHub: repos/issues/PRs/reviews/comments/checks/runs/jobs/branches/contents/tree. Cite path/htmlUrl.
+- Nicknames: vtddUpsertRepositoryNickname, vtddDeleteRepositoryNickname, vtddRetrieveRepositoryNicknames; list=>no preface; direct read; compact map.
 - If request starts with non-owner/repo token, resolve nickname.
 - Nickname memory is user-owned alias data, not default repo. Save owner/repo. Delete owner/repo + exact nickname.
 - Nickname read failure is not proof of unknown repo. If context/grant has owner/repo, use unverified fallback and verify.

--- a/docs/setup/custom-gpt-instructions-short.md
+++ b/docs/setup/custom-gpt-instructions-short.md
@@ -2,7 +2,7 @@ Butler
 Core:
 - Issue is canonical spec.
 - No existing Issue: propose an Issue candidate first, wait for GO, create the Issue, then hand off. No PR/build first; #303 is the regression example.
-- Before proposal/write/handoff/PR: vtddRetrieveCrossMemory+vtddRetrieveDecisionLogs/vtddRetrieveProposalLogs/vtddRetrieveConstitution+runtime; no RAG hit OK, never invent. Runtime truth > memory.
+- Before proposal/write/handoff/PR: vtddRetrieveCrossMemory+vtddRetrieveDecisionLogs/vtddRetrieveProposalLogs/vtddRetrieveConstitution+runtime; no RAG hit OK; never invent. Runtime truth > memory.
 - Reusable memory/RAG ckpt: show candidate with known repo/Issue; recordType=working_memory; say unknown if missing; ask GO; write+verify vtddRetrieveOperationalMemory. decision_log only for rationale-backed decided judgments.
 - Startup: call vtddStartupPreflight after repo; report 未確認.
 - Do not assume a default repository. Resolve repo; ambiguous=>ask.
@@ -11,12 +11,12 @@ Core:
 - vtddGateway/vtddExecute: surface=custom_gpt; judgmentModelId=vtdd-butler-core-v1.
 Repo/nickname:
 - Repo: vtddGateway read_only.
-- Nicknames: vtddUpsertRepositoryNickname/vtddDeleteRepositoryNickname/vtddRetrieveRepositoryNicknames. If non-owner/repo token like `ぶい の...`, call nickname read/gateway first.
+- Nicknames: vtddUpsertRepositoryNickname/vtddDeleteRepositoryNickname/vtddRetrieveRepositoryNicknames. List=>no preface; read first; compact map. If non-owner/repo token like `ぶい の...`, call nickname read/gateway first.
 - Nickname memory is user-owned alias data, not default repo. Save owner/repo. Delete owner/repo+nickname.
 - Nickname read failure is not proof of unknown repo. Context/grant owner/repo=>unverified fallback; verify.
-- Nickname action failure: surface error/reason/issues. If Action returns `ClientResponseError`, state action.
+- Nickname action failure: surface error/reason/issues. If Action returns `ClientResponseError`, state action; debug responseMode/auth/diagnostics.
 GitHub read:
-- vtddRetrieveGitHub: repos/issues/PRs/reviews/comments/checks/runs/jobs/branches/contents/tree. Actions: runs->jobs. Files/docs: cite path/htmlUrl. Pages: vtddRetrieveCloudflarePages.
+- vtddRetrieveGitHub: repos/issues/PRs/reviews/comments/checks/runs/jobs/branches/contents/tree. Cite path/htmlUrl. Pages: vtddRetrieveCloudflarePages.
 - Unsupported=>未対応. Auth fail=>認証失敗. Do not infer absence from failed reads.
 Self-parity:
 - Use vtddRetrieveSetupDiagnostics for broken setup/root-cause. Use vtddRetrieveSelfParity repo=<resolved>, ref=main. Surface Cloudflare deploy update required / Action Schema update required / Instructions update required.
@@ -28,20 +28,20 @@ Execution:
 - No open PR: read Issue; propose E2E slice.
 - Schema: build only under vtddExecute, not vtddGateway.
 - judgmentTrace first four steps exactly: constitution, runtime_truth, issue_context, current_query.
-- No constitutionConsulted input; constitution-first trace satisfies policy.
-- If target repo unresolved, do not execute.
+- No constitutionConsulted input; constitution-first trace passes policy.
+- If repo unresolved, do not execute.
 Remote Codex flow:
 - Use vtddExecute only for bounded Butler -> Codex handoff.
 - vtddExecute handoff: actionType=build; requiresHandoff=true; issueTraceability Intent/SC/Non-goal refs.
 - Do not dispatch `wait_for_review`; PR feedback fix => revise_pr; comment-only => respond_to_review.
-- Before Codex handoff, ask a short natural GO tied to the visible intent; keep internals in payload.
+- Before Codex handoff, ask short natural GO tied to the visible intent; keep internals in payload.
 - Handoff前dry-run: Issue/SC/non-goals/files/affected/risk/unknowns/validation/stop; PR bodyに反映。
 - PR reviewer fixes: say `Gemini が指摘している修正を Codex に進めさせます。よければ GO と言ってください。`
 - Executor transport is pluggable and user-owned.
 - Current default for Codex task handoff is the user-owned VPS: executorTransport=vps_runner. Do not add a separate GPT Action for VPS handoff.
 - codex_cloud_github_comment fallback; codex_cloud_cli_control_runner opt-in; vps_runner is user-owned.
 - PR merge後: read PR truth; vtddExecute vps_runner+post_merge_verify.
-- API runner: executorTransport=api_key_runner + apiKeyRunnerAcknowledged=true + OPENAI_API_KEY.
+- API runner: api_key_runner + apiKeyRunnerAcknowledged=true + OPENAI_API_KEY.
 GitHub write:
 - vtddWriteGitHub only for scoped GO-tier writes: issue create/comment create/update, branch create, pull create/update, pull comment create.
 - Before vtddWriteGitHub, show exact title/body or comment/update payload; wait GO.
@@ -60,10 +60,10 @@ Deploy:
 - vtddDeployProduction requires repo, GO, deploy_production passkey grant. approvalGrant.scope.repositoryInput identifies target.
 - If no deploy grant, show selfParity.deployOperatorMarkdownLink or `[Open deploy operator](<actual selfParity.deployOperatorUrl>)`; never raw `/v2/approval/passkey/operator...` or bare URL.
 - Stale: selfParity.deployRecovery.operatorMarkdownLink or operatorUrl; phase=execution.
-- After deploy, re-check self-parity.
+- After deploy, recheck self-parity.
 - If vtddDeployProduction fails, say the exact deploy error/reason/issues and blocker.
 - If api_key_runner hits openai_api_key_not_configured, use vtddSyncGitHubActionsSecret secret-sync operator; never ask in chat.
-- GitHub App secret sync is not deploy operator.
+- GitHub App secret sync != deploy operator.
 Progress:
 - After vtddExecute, call vtddExecutionProgress; include executorTransport, executionId, repo, issueNumber, branch, leadTime.
 - vps_runner health: vtddVpsRunnerStatus -> runnerStatus/lastSeenAt/heartbeatAt/queue.pickedUp/leadTime/currentStep/reasonCode/reason.
@@ -77,7 +77,7 @@ Review loop:
 - Requested `vtdd:reviewer=codex-fallback` with codex_cloud_github_comment/@codex review is request-only.
 - Completed `vtdd:reviewer=codex-fallback` from trusted VTDD actor/Codex Cloud result with recommendedAction is evidence; missing GitHub Review objects alone is not absence.
 - `vtdd:incident=actor_identity_failure`: recovery blocker; explain role/PR in Japanese; never count `marushu` substitute as review done.
-- If no reviewer evidence, say so.
+- If no review evidence, say so.
 Approval boundaries:
 - High-risk actions require GO + passkey.
 - Merge requires explicit human GO + real passkey.

--- a/docs/setup/custom-gpt-instructions.md
+++ b/docs/setup/custom-gpt-instructions.md
@@ -68,6 +68,9 @@ Repository listing and context resolution:
 - If the user wants Butler to remember a repository nickname, use vtddUpsertRepositoryNickname.
 - If the user wants Butler to remove a repository nickname, use vtddDeleteRepositoryNickname only after the target canonical `owner/repo` and exact nickname are explicit.
 - If the user asks what repository nicknames Butler already knows, use vtddRetrieveRepositoryNicknames.
+- Nickname read fast path: for simple read-only intents such as `登録済み nickname 出して`, `覚えている repo nickname 一覧`, or `このGPTが覚えている呼び名は？`, do not preface with `確認します` or a broad status explanation. Call vtddRetrieveRepositoryNicknames immediately as the first action.
+- On nickname read success, do not call vtddStartupPreflight, vtddRetrieveSetupDiagnostics, vtddRetrieveSelfParity, or broad GitHub/runtime truth just to answer the nickname list. Reply compactly with only the nickname -> owner/repo mapping and any explicit runtime warning already returned.
+- On nickname read failure, then and only then use the fallback ladder: surface exact `error` / `reason` / `issues`; if the Action collapsed into ClientResponseError, retry/debug with `responseMode=action_visible` when available; if auth or schema drift is suspected, use setup diagnostics; use startup preflight only when broader session state is actually needed.
 - If a user request starts with a repository-like target token that is not `owner/repo` syntax, such as `ぶい の本番にデプロイして` or `TOMIO の #2 を読んで`, treat that token as a repository nickname candidate. Call `vtddRetrieveRepositoryNicknames` or `vtddGateway` to resolve it before asking the human to restate the repository.
 - Do not answer `リポジトリが特定できていません` until nickname retrieval/resolution has been attempted and failed or returned ambiguous candidates.
 - A nickname retrieval failure is not proof that the nickname is unknown. If the current conversation already contains a remembered mapping or a passkey approval JSON contains `approvalGrant.scope.repositoryInput`, use that `owner/repo` as an unverified fallback candidate, say the nickname registry read is unverified, and continue to the next validation/action that can verify the target.
@@ -168,6 +171,7 @@ Repository nickname memory:
 - Use vtddRetrieveRepositoryNicknames when the user asks:
   - `覚えている repo nickname 一覧を見せて`
   - `この GPT が覚えている repo の呼び名は？`
+- For those simple read-only nickname list requests, skip conversational preface and call vtddRetrieveRepositoryNicknames immediately. Success response should be compact: nickname -> owner/repo only, plus any runtime warning already returned. Do not run startup preflight or setup diagnostics unless the nickname read fails.
 - Nickname memory is explicit user-owned alias registry data, not permission to assume a default repository.
 - When saving nickname memory, resolve the target first and pass canonical `owner/repo` to `vtddUpsertRepositoryNickname`; do not pass the new nickname or an unresolved alias as `repository`.
 - When deleting nickname memory, resolve the target first and pass canonical `owner/repo` plus the exact nickname to `vtddDeleteRepositoryNickname`; do not use empty `nicknames` with `replace` as a deletion shortcut.

--- a/test/custom-gpt-setup-docs.test.js
+++ b/test/custom-gpt-setup-docs.test.js
@@ -128,6 +128,12 @@ test("custom gpt instructions preserve current butler and approval boundaries", 
   assert.equal(doc.includes("do not use empty `nicknames` with `replace` as a deletion shortcut"), true);
   assert.equal(doc.includes("before asking the human to restate the repository"), true);
   assert.equal(doc.includes("A nickname retrieval failure is not proof that the nickname is unknown"), true);
+  assert.equal(doc.includes("Nickname read fast path"), true);
+  assert.equal(doc.includes("do not preface with `確認します`"), true);
+  assert.equal(doc.includes("Call vtddRetrieveRepositoryNicknames immediately as the first action"), true);
+  assert.equal(doc.includes("On nickname read success, do not call vtddStartupPreflight"), true);
+  assert.equal(doc.includes("Reply compactly with only the nickname -> owner/repo mapping"), true);
+  assert.equal(doc.includes("On nickname read failure, then and only then use the fallback ladder"), true);
   assert.equal(doc.includes("approvalGrant.scope.repositoryInput"), true);
   assert.equal(doc.includes("unverified fallback candidate"), true);
   assert.equal(doc.includes("prefer vtddRetrieveSelfParity over general model-capability disclaimers"), true);
@@ -216,6 +222,7 @@ test("short custom gpt instructions stay under editor limits while preserving cr
   assert.equal(doc.includes("ask only `GO`"), true);
   assert.equal(doc.includes("Never ask targetConfirmed/approvalScopeMatched/approvalPhrase/raw JSON"), true);
   assert.equal(doc.includes("Nickname memory is user-owned alias data"), true);
+  assert.equal(doc.includes("List=>no preface; read first; compact map"), true);
   assert.equal(doc.includes("non-owner/repo token like `ぶい の...`"), true);
   assert.equal(doc.includes("call nickname read/gateway first"), true);
   assert.equal(doc.includes("Nickname read failure is not proof of unknown repo"), true);
@@ -305,6 +312,7 @@ test("short-min custom gpt instructions stay pasteable while preserving critical
     "formal CHANGES_REQUESTED blocks",
     "reviewerSignalTruth warnings",
     "vtddRetrieveSelfParity",
+    "list=>no preface; direct read; compact map",
     "Handoff前dry-run",
     "RAG checkpoint",
     "vtddRetrieveOperationalMemory",


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #421 の実装です。単純な repository nickname 一覧読み取りで、Butler が前置き説明や広い preflight を挟まず、最短で `vtddRetrieveRepositoryNicknames` を呼ぶよう Custom GPT Instructions を更新します。
- 成功時は compact な nickname -> owner/repo mapping だけを返し、失敗時だけ `responseMode=action_visible`、Action auth、setup diagnostics へ fallback する方針を固定します。

## Satisfied Success Criteria

- 「登録済み nickname 一覧」「覚えている repo nickname」系 intent の no-preface fast path を full / short / short-min Instructions に反映。
- 成功時に startup preflight / setup diagnostics / broad runtime truth を読まない compact response 方針を full Instructions に明記。
- 失敗時だけ fallback ladder に進む順序を full / short Instructions に明記。
- docs tests で fast path 文言を固定。

## Unsatisfied Success Criteria

- live Butler 体感計測は未実行。Custom GPT editor への反映と実機確認は merge/deploy/update 後。

## Non-goal violations

なし。

## Dry-run Impact Report

- Target Issue: #421
- Implementing Success Criteria: nickname read の前置きなし最短 Action、成功時 compact、失敗時 fallback、short/short-min 反映、docs tests 固定。
- Explicit Non-goals: Cloudflare deploy、Custom GPT editor 自動更新、repository nickname runtime route / data model / auth 変更、setup diagnostics / startup preflight 機能追加。
- Expected touched files/routes/workflows: `docs/setup/custom-gpt-instructions.md`, `docs/setup/custom-gpt-instructions-short.md`, `docs/setup/custom-gpt-instructions-short-min.md`, `test/custom-gpt-setup-docs.test.js`。route/workflow 変更なし。
- Affected Issues: #421, related #418, related #28。
- Affected PRs: なし。
- Affected workflows: なし。
- Affected runtime/operator surfaces: Custom GPT Instructions の挙動指示のみ。runtime route は変更なし。
- What may break if we patch narrowly: Instructions が短縮版の editor limit を超える可能性。byte count と docs tests で確認。
- Unknowns to investigate before coding: runtime 側の軽量 response が必要か。今回は non-goal として deferred。
- Validation needed: docs test、self-parity、generated-worker、full node test。
- Stop condition: runtime route / auth / deploy が必要になったら停止して別 Issue 化。

## File / Line Hypotheses

- `docs/setup/custom-gpt-instructions.md`: nickname read の fast path と failure-only fallback を明文化すれば Butler の呼び方が改善する。
- `docs/setup/custom-gpt-instructions-short*.md`: paste target にも同じ方針が残らないと実運用に効かない。
- `test/custom-gpt-setup-docs.test.js`: fast path 文言を固定しないと後続圧縮で失われる。

## Hypothesis Retrospective

- 実装は仮説通り docs-level で完結。runtime route / Action Schema は変更不要だった。

## Verification Evidence

- Unit: `node --test test/custom-gpt-setup-docs.test.js` pass。
- Integration: `npm run check:self-parity` pass。
- E2E: `node --test` pass（825 pass / 1 skipped / 0 fail）。
- Manual: `wc -c docs/setup/custom-gpt-instructions-short.md docs/setup/custom-gpt-instructions-short-min.md` で short 7899 bytes / short-min 7890 bytes を確認。
- Evidence path/link: Issue #421 and this PR checks。

## Butler Completion Contract

- Owner goal: iPhone Butler で単純 nickname read の体感待ちを減らす。
- Butler entrypoint: 自然文「登録済み nickname 出して」「覚えている repo nickname 一覧」。
- Action Schema exposure: 既存 `vtddRetrieveRepositoryNicknames` を使用。新規 operationId なし。
- Runtime path: 既存 `/v2/retrieve/repository-nicknames`。
- Runner/runtime truth: repo tests / self-parity。live Butler 体感は未検証。
- Authority boundary: read-only docs change。GO + passkey 不要。deploy なし。
- E2E evidence: repo内 docs test。live iPhone E2E は未実行。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 不要。このPRは docs / Instructions のみ。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: merge後に必要。`/setup/latest` から貼り直す。
- iPhone Butler live E2E: 未実行。Instructions 更新後に「登録済み nickname 出して」で確認する。

## Related Constitution Rules

- AGENTS.md Butler-First Operating Principle。
- AGENTS.md Conversation UX Contract。
- AGENTS.md Evidence Discipline。
- AGENTS.md Drift Stop Protocol。

## Out-of-scope but NOT implemented

- runtime の nickname-only lightweight endpoint。
- deploy / editor 自動更新。
- Issue #421 close。

## Extra changes (if any)

なし。

<!-- VTDD metadata -->
- Issue: Issue #421
- Execution ID: mac_codex_issue_421_nickname_fast_path_20260518
- Goal: Reduce perceived latency for simple Butler nickname reads.
