### PR TITLE
Issue #421 skip confirmation for nickname read

### DIFF
--- a/docs/setup/custom-gpt-instructions-short-min.md
+++ b/docs/setup/custom-gpt-instructions-short-min.md
@@ -4,18 +4,18 @@ Role: minimal Custom GPT paste target.
 Truth and scope:
 - Issue is canonical spec. GitHub/runtime state is progress truth. Runtime truth > memory.
 - No existing Issue? propose the Issue first, wait GO, create it, then hand off. Never PR/build first; #303 is the regression example.
-- Before proposal/writes/handoff/PR/stale setup: read runtime/GitHub truth + memory/constitution; report found/missing; never invent.
+- Before proposal/writes/handoff/PR/stale setup: read runtime/GitHub truth+memory/constitution; report found/missing; no invent.
 - Reusable memory/RAG checkpoint: show candidate with known repo/Issue; recordType=working_memory; say unknown if missing; ask GO; vtddRetrieveOperationalMemory. decision_log only for rationale-backed decided judgments.
 - Thread startup: vtddStartupPreflight after repo; report promoted or 未確認.
 - No scope beyond instruction+Issue.
 - Do not assume a default repository. Resolve owner/repo from input, alias, grant, verified context; ambiguous=>ask.
-- No internal paths/raw JSON. Convert natural intent into actions.
+- No internal paths/raw JSON. Natural intent=>actions.
 - vtddGateway/vtddExecute: surface=custom_gpt; judgmentModelId=vtdd-butler-core-v1.
 - PR merge後確認: read PR truth; vtddExecute vps_runner + post_merge_verify; verify only.
 Repository and nickname:
 - Repo read: vtddGateway exploration/read_only.
 - vtddRetrieveGitHub: repos/issues/PRs/reviews/comments/checks/runs/jobs/branches/contents/tree. Cite path/htmlUrl.
-- Nicknames: vtddUpsertRepositoryNickname, vtddDeleteRepositoryNickname, vtddRetrieveRepositoryNicknames; list=>no preface; direct read; compact map.
+- Nicknames: vtddUpsertRepositoryNickname, vtddDeleteRepositoryNickname, vtddRetrieveRepositoryNicknames; list=>no preface/no GO/no 実行しますか; direct read; compact map; not every request.
 - If request starts with non-owner/repo token, resolve nickname.
 - Nickname memory is user-owned alias data, not default repo. Save owner/repo. Delete owner/repo + exact nickname.
 - Nickname read failure is not proof of unknown repo. If context/grant has owner/repo, use unverified fallback and verify.

--- a/docs/setup/custom-gpt-instructions-short.md
+++ b/docs/setup/custom-gpt-instructions-short.md
@@ -11,7 +11,7 @@ Core:
 - vtddGateway/vtddExecute: surface=custom_gpt; judgmentModelId=vtdd-butler-core-v1.
 Repo/nickname:
 - Repo: vtddGateway read_only.
-- Nicknames: vtddUpsertRepositoryNickname/vtddDeleteRepositoryNickname/vtddRetrieveRepositoryNicknames. List=>no preface; read first; compact map. If non-owner/repo token like `ぶい の...`, call nickname read/gateway first.
+- Nicknames: vtddUpsertRepositoryNickname/vtddDeleteRepositoryNickname/vtddRetrieveRepositoryNicknames. List=>no preface/no GO/no 実行しますか; read first; compact map. Do not run for every request. If non-owner/repo token like `ぶい の...`, call nickname read/gateway first.
 - Nickname memory is user-owned alias data, not default repo. Save owner/repo. Delete owner/repo+nickname.
 - Nickname read failure is not proof of unknown repo. Context/grant owner/repo=>unverified fallback; verify.
 - Nickname action failure: surface error/reason/issues. If Action returns `ClientResponseError`, state action; debug responseMode/auth/diagnostics.

--- a/docs/setup/custom-gpt-instructions.md
+++ b/docs/setup/custom-gpt-instructions.md
@@ -69,6 +69,8 @@ Repository listing and context resolution:
 - If the user wants Butler to remove a repository nickname, use vtddDeleteRepositoryNickname only after the target canonical `owner/repo` and exact nickname are explicit.
 - If the user asks what repository nicknames Butler already knows, use vtddRetrieveRepositoryNicknames.
 - Nickname read fast path: for simple read-only intents such as `登録済み nickname 出して`, `覚えている repo nickname 一覧`, or `このGPTが覚えている呼び名は？`, do not preface with `確認します` or a broad status explanation. Call vtddRetrieveRepositoryNicknames immediately as the first action.
+- This read-only retrieve does not require GO, passkey, or a confirmation question. Do not ask `実行しますか？`; call the Action immediately.
+- Do not run nickname retrieval for every VTDD request. Use it only for explicit nickname list/read intents or when the requested repository target is not valid `owner/repo` syntax.
 - On nickname read success, do not call vtddStartupPreflight, vtddRetrieveSetupDiagnostics, vtddRetrieveSelfParity, or broad GitHub/runtime truth just to answer the nickname list. Reply compactly with only the nickname -> owner/repo mapping and any explicit runtime warning already returned.
 - On nickname read failure, then and only then use the fallback ladder: surface exact `error` / `reason` / `issues`; if the Action collapsed into ClientResponseError, retry/debug with `responseMode=action_visible` when available; if auth or schema drift is suspected, use setup diagnostics; use startup preflight only when broader session state is actually needed.
 - If a user request starts with a repository-like target token that is not `owner/repo` syntax, such as `ぶい の本番にデプロイして` or `TOMIO の #2 を読んで`, treat that token as a repository nickname candidate. Call `vtddRetrieveRepositoryNicknames` or `vtddGateway` to resolve it before asking the human to restate the repository.
@@ -171,7 +173,7 @@ Repository nickname memory:
 - Use vtddRetrieveRepositoryNicknames when the user asks:
   - `覚えている repo nickname 一覧を見せて`
   - `この GPT が覚えている repo の呼び名は？`
-- For those simple read-only nickname list requests, skip conversational preface and call vtddRetrieveRepositoryNicknames immediately. Success response should be compact: nickname -> owner/repo only, plus any runtime warning already returned. Do not run startup preflight or setup diagnostics unless the nickname read fails.
+- For those simple read-only nickname list requests, skip conversational preface and call vtddRetrieveRepositoryNicknames immediately. Do not ask for GO or `実行しますか？` for this read-only retrieve. Do not run nickname retrieval for unrelated VTDD requests. Success response should be compact: nickname -> owner/repo only, plus any runtime warning already returned. Do not run startup preflight or setup diagnostics unless the nickname read fails.
 - Nickname memory is explicit user-owned alias registry data, not permission to assume a default repository.
 - When saving nickname memory, resolve the target first and pass canonical `owner/repo` to `vtddUpsertRepositoryNickname`; do not pass the new nickname or an unresolved alias as `repository`.
 - When deleting nickname memory, resolve the target first and pass canonical `owner/repo` plus the exact nickname to `vtddDeleteRepositoryNickname`; do not use empty `nicknames` with `replace` as a deletion shortcut.

--- a/test/custom-gpt-setup-docs.test.js
+++ b/test/custom-gpt-setup-docs.test.js
@@ -131,6 +131,10 @@ test("custom gpt instructions preserve current butler and approval boundaries", 
   assert.equal(doc.includes("Nickname read fast path"), true);
   assert.equal(doc.includes("do not preface with `確認します`"), true);
   assert.equal(doc.includes("Call vtddRetrieveRepositoryNicknames immediately as the first action"), true);
+  assert.equal(doc.includes("does not require GO, passkey, or a confirmation question"), true);
+  assert.equal(doc.includes("Do not ask `実行しますか？`; call the Action immediately"), true);
+  assert.equal(doc.includes("Do not run nickname retrieval for every VTDD request"), true);
+  assert.equal(doc.includes("explicit nickname list/read intents"), true);
   assert.equal(doc.includes("On nickname read success, do not call vtddStartupPreflight"), true);
   assert.equal(doc.includes("Reply compactly with only the nickname -> owner/repo mapping"), true);
   assert.equal(doc.includes("On nickname read failure, then and only then use the fallback ladder"), true);
@@ -222,7 +226,8 @@ test("short custom gpt instructions stay under editor limits while preserving cr
   assert.equal(doc.includes("ask only `GO`"), true);
   assert.equal(doc.includes("Never ask targetConfirmed/approvalScopeMatched/approvalPhrase/raw JSON"), true);
   assert.equal(doc.includes("Nickname memory is user-owned alias data"), true);
-  assert.equal(doc.includes("List=>no preface; read first; compact map"), true);
+  assert.equal(doc.includes("List=>no preface/no GO/no 実行しますか; read first; compact map"), true);
+  assert.equal(doc.includes("Do not run for every request"), true);
   assert.equal(doc.includes("non-owner/repo token like `ぶい の...`"), true);
   assert.equal(doc.includes("call nickname read/gateway first"), true);
   assert.equal(doc.includes("Nickname read failure is not proof of unknown repo"), true);
@@ -312,7 +317,7 @@ test("short-min custom gpt instructions stay pasteable while preserving critical
     "formal CHANGES_REQUESTED blocks",
     "reviewerSignalTruth warnings",
     "vtddRetrieveSelfParity",
-    "list=>no preface; direct read; compact map",
+    "list=>no preface/no GO/no 実行しますか; direct read; compact map; not every request",
     "Handoff前dry-run",
     "RAG checkpoint",
     "vtddRetrieveOperationalMemory",


### PR DESCRIPTION
## This PR satisfies Intent

- #421 の nickname 一覧 read-only UX の続きとして、Butler が取得確認を挟まず vtddRetrieveRepositoryNicknames を即実行しつつ、nickname retrieval を全 VTDD request の前提にしない Instructions を明文化する。

## Satisfied Success Criteria

- Custom GPT Instructions の nickname read fast path に、read-only retrieve は GO/passkey/確認質問不要で `実行しますか？` を聞かないことを追加した。 nickname retrieval は explicit nickname list/read intent または non-owner/repo target 解決だけに限定し、全リクエストでは走らせない guard を追加した。 short / short-min paste target にも no GO / no 実行しますか / not every request を反映した。 setup docs test で full/short/short-min の保持を固定した。

## Unsatisfied Success Criteria

- Custom GPT editor への実貼付と iPhone Butler live E2E は、この PR だけでは未検証。

## Non-goal violations

runtime route/auth/model/deploy/editor 自動更新/Issue close は対象外。

## Dry-run Impact Report

- Target Issue: Issue #421
- Implementing Success Criteria: nickname list read-only intent が前置きや確認質問なしで retrieve Action に入り、かつ nickname retrieval が unrelated VTDD requests に広がらない Instructions を明文化する。
- Explicit Non-goals: runtime route、Action Schema、auth、deploy、editor 実貼付、Issue close は変更しない。
- Expected touched files/routes/workflows: docs/setup/custom-gpt-instructions.md; docs/setup/custom-gpt-instructions-short.md; docs/setup/custom-gpt-instructions-short-min.md; test/custom-gpt-setup-docs.test.js
- Affected Issues: Issue #421
- Affected PRs: PR #422 の follow-up
- Affected workflows: guarded-policy / test / gemini-pr-review の通常 PR checks のみ。workflow 定義変更なし。
- Affected runtime/operator surfaces: Custom GPT Instructions paste target。Worker runtime path は未変更。
- What may break if we patch narrowly: 確認不要を nickname read に限定しないと write/merge/deploy の approval boundary を弱めるリスクがある。nickname retrieval を全 request に広げると他機能の repository resolution が nickname 前提に寄るため、explicit list/read と non-owner/repo target 解決に限定した。
- Unknowns to investigate before coding: Custom GPT editor の現在貼付内容と live Butler 挙動は runtime から読めないため未検証。
- Validation needed: node --test test/custom-gpt-setup-docs.test.js; npm run check:self-parity; npm run check:generated-worker; node --test
- Stop condition: GO/passkey が必要な high-risk/normal-write 境界に影響する変更、または nickname を default repository 的に扱う変更が必要になった場合は停止。

## File / Line Hypotheses

- file: `docs/setup/custom-gpt-instructions.md`; hypothesis: full canonical instructions の nickname read fast path に確認不要と非グローバル適用の明示が不足している; risk: read-only retrieve 以外に確認不要や nickname 前提が広がると approval/repo resolution boundary が壊れる; validation: docs test と全文確認; related Issue: Issue #421. - file: short/short-min instructions; hypothesis: paste target に no GO/no 実行しますか/not every request がないため Butler が確認質問または nickname 前提処理を選び得る; risk: paste target のサイズや critical tokens が壊れる; validation: docs test と length guard; related Issue: Issue #421.

## Hypothesis Retrospective

expected: nickname list read-only path に no confirmation rule と not every request guard が残る。 actual: full/short/short-min に no GO/no 実行しますか/not every request を追加し、tests で固定。 mismatch: なし。 lesson: no-preface/no-confirm だけでは nickname 前提化の懸念を抑えきれないため、適用条件を明示した。 should become RAG candidate: 必要なら #421 完了後に候補化。

## Verification Evidence

- Unit: node --test test/custom-gpt-setup-docs.test.js: pass
- Integration: npm run check:self-parity: pass; npm run check:generated-worker: pass; node --test: pass (825 pass / 1 skipped / 0 fail)
- E2E: 未実施。この PR は Instructions-only follow-up で、live Butler E2E は editor 貼り直し後に確認が必要。
- Manual: wc -c 確認: short 7957 bytes; short-min 7920 bytes。既存 docs test の pasteability guard は pass。
- Evidence path/link: docs/setup/custom-gpt-instructions.md; docs/setup/custom-gpt-instructions-short.md; docs/setup/custom-gpt-instructions-short-min.md; test/custom-gpt-setup-docs.test.js

## Butler Completion Contract

- Owner goal: 登録済み nickname 一覧では Butler が「実行しますか？」を挟まず即取得するが、他の VTDD 機能を nickname 前提にしない。
- Butler entrypoint: 自然文: 登録済み nickname 出して / 覚えている repo nickname 一覧。nickname 解決は non-owner/repo target の時だけ使う。
- Action Schema exposure: 未変更。既存 vtddRetrieveRepositoryNicknames を使う。
- Runtime path: 未変更。既存 nickname retrieve route/action を使う Instructions-only change。
- Runner/runtime truth: 未変更。runtime truth は既存 retrieve response に従う。
- Authority boundary: read-only retrieve に限定して GO/passkey/確認質問不要。write/merge/deploy/secrets/settings/permissions の境界は未変更。
- E2E evidence: 未実施。Custom GPT editor に latest Instructions を貼り直した後、iPhone Butler で確認が必要。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 不要。runtime 変更なし。
- Custom GPT Action Schema update: 不要。既存 operationId を使う。
- Custom GPT Instructions update: 必要。この PR merge 後に /setup/latest の Instructions を Custom GPT editor へ貼り直す必要がある。
- iPhone Butler live E2E: 未実施。merge/editor update 後に nickname list intent と unrelated VTDD intent で確認。

## Related Constitution Rules

- Issue-backed work only (Issue #421)。Read-only nickname retrieve は fast path、ただし全リクエスト前提にはしない。High-risk approval boundary は維持。Butler Completion Gate: live Butler E2E 未実施のため completion status は incomplete。

## Out-of-scope but NOT implemented

- runtime latency改善。Action Schema 変更。Cloudflare deploy。Custom GPT editor 実貼付。Issue close。

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #421
- Execution ID: Not provided.
- Goal: Issue #421 nickname read confirmation prompt follow-up
