### PR TITLE
Issue #426 Butler status reads respond first

### DIFF
--- a/.vtdd/pr-body-issue-426.md
+++ b/.vtdd/pr-body-issue-426.md
@@ -1,0 +1,120 @@
+## This PR satisfies Intent
+
+- Issue #426 の Intent に対し、Butler が Issue / PR / close readiness / status / 残タスク確認 intent を受けた時の初回応答を短くし、重い startupPreflight / Gemini / deploy / milestone judgment を初回応答前に抱え込まない方針を Custom GPT Instructions に固定します。
+- runtime endpoint は追加せず、docs と docs tests で staged lightweight read ladder を固定する PR です。
+
+## Satisfied Success Criteria
+
+- Custom GPT Instructions に、status 系 intent ではまず短い受付返答を返し、初回応答前に全確認を抱え込まない方針を明記しました。
+- repo 解決済みの status 系 intent では初手 `vtddStartupPreflight` を避け、`vtddRetrieveGitHub` の Issue / PR / comments / reviews / checks / workflow runs / jobs / branches / deploy truth の軽量 read ladder を優先する方針を明記しました。
+- `vtddStartupPreflight` は target unresolved、startup / handoff / RAG / surface consistency が本当に必要な時に使う方針へ限定しました。
+- Gemini review、残タスク候補、milestone judgment は明示要求または後段に回し、初回応答前に抱え込まない方針を明記しました。
+- short / short-min Instructions にも同じ first-response latency 方針を editor limit 内で保持しました。
+- docs tests に staged response / startupPreflight avoidance / lightweight read ladder の invariant を追加しました。
+
+## Unsatisfied Success Criteria
+
+- code/docs merged は未完了です。この PR が merge されるまで Completion Gate は満たしません。
+- live Butler 実機 E2E は未実施です。Custom GPT editor 貼り直し後に iPhone/iPad Butler で確認が必要です。
+- human approval は未完了です。
+
+## Non-goal violations
+
+None.
+
+## Dry-run Impact Report
+
+- Target Issue: Issue #426
+- Implementing Success Criteria: status intent の短い初回応答、startupPreflight avoidance、lightweight read ladder、Gemini / 残タスク候補 / milestone judgment の後段化、short / short-min invariant、docs tests 固定。
+- Explicit Non-goals: runtime API endpoint 追加なし。Issue close / merge / deploy authority model 変更なし。approvalGrantId TTL 変更なし。Gemini reviewer logic 変更なし。実測 latency 完全保証の主張なし。
+- Expected touched files/routes/workflows: `docs/setup/custom-gpt-instructions.md`, `docs/setup/custom-gpt-instructions-short.md`, `docs/setup/custom-gpt-instructions-short-min.md`, `test/custom-gpt-setup-docs.test.js`。runtime route / OpenAPI schema / workflow は未変更。
+- Affected Issues: Issue #426。関連文脈として Issue #421 nickname read fast path、Issue #424 close readiness 実例、Issue #417 post-action orchestration を参照。
+- Affected PRs: 新規 PR のみ。既存 PR は変更しません。
+- Affected workflows: docs unit、self-parity check、generated-worker check。GitHub Actions workflow 定義は未変更。
+- Affected runtime/operator surfaces: Custom GPT Instructions surface と `/setup/latest` の short-min copy target。Worker runtime、deploy operator、GitHub authority plane は未変更。
+- What may break if we patch narrowly: startup 文言を弱めすぎると、本当に startup / handoff / RAG consistency が必要な実装 handoff 前 preflight まで省略されるリスクがあります。このため status intent 例外として限定しました。
+- Unknowns to investigate before coding: short / short-min の文字数制限内に first-response latency 方針を保持できるか。既存 docs test の startup preflight 固定 assertion を Issue #426 に合わせて更新できるか。
+- Validation needed: `node --test test/custom-gpt-setup-docs.test.js`、`npm run check:self-parity`、`npm run check:generated-worker`、short-min Instructions の manual static check、live Butler E2E は Custom GPT editor 貼り直し後。
+- Stop condition: runtime route 追加、Action Schema 変更、authority model 変更、または Issue #426 Non-goal を越える修正が必要になった場合は停止。
+
+## File / Line Hypotheses
+
+- file: `docs/setup/custom-gpt-instructions.md`
+  - hypothesis: 旧 startup 文言が status intent でも `vtddStartupPreflight` 優先へ倒すため、true startup と status intent を分離する必要がある。
+  - risk if changed narrowly: Codex handoff / proposal / write 前の必要 preflight まで省略される。
+  - validation: docs test で status intent 例外と startupPreflight 限定を assert する。
+  - related Issue: Issue #426
+- file: `docs/setup/custom-gpt-instructions-short.md`
+  - hypothesis: short paste target にも startup 優先文言があり、editor limit 内で status 例外を保持する必要がある。
+  - risk if changed narrowly: full instructions だけ直って実際の paste target に遅延方針が残る。
+  - validation: short docs test と character limit assertion。
+  - related Issue: Issue #426
+- file: `docs/setup/custom-gpt-instructions-short-min.md`
+  - hypothesis: `/setup/latest` の実貼り付け候補である short-min に同方針が残らないと実機 Butler UX が改善しない。
+  - risk if changed narrowly: canonical full docs は正しくても owner が貼る short-min に反映されない。
+  - validation: short-min docs test と manual static check。
+  - related Issue: Issue #426
+- file: `test/custom-gpt-setup-docs.test.js`
+  - hypothesis: nickname fast path と同じ粒度で status staged response / preflight avoidance / read ladder を固定する assertion が必要。
+  - risk if changed narrowly: 将来の docs edit で first-response latency 方針が消える。
+  - validation: `node --test test/custom-gpt-setup-docs.test.js`
+  - related Issue: Issue #426
+
+## Hypothesis Retrospective
+
+- expected: Issue の File / Line Hypotheses どおり、full / short / short-min Instructions と docs tests が主な変更点になる。
+- actual: 予想どおり runtime は変更せず、3つの Instructions と docs test だけを変更しました。short / short-min は既存上限に近かったため、既存文言を圧縮しつつ status 方針を追加しました。
+- mismatch: `src/worker/runtime.js` は確認対象でしたが、この Issue の Non-goal どおり変更不要でした。
+- lesson: paste target が editor limit 近くにあるため、今後の guardrail 追加は short / short-min の文字数余地を先に確認する必要があります。
+- should become RAG candidate: はい。`Issue #426 では status intent の first-response latency 方針を docs/tests 固定で解決し、runtime route は触らなかった` という working_memory 候補にできます。
+
+## Verification Evidence
+
+- Unit: `node --test test/custom-gpt-setup-docs.test.js` passed. 11 tests passed.
+- Integration: `npm run check:self-parity` passed. Runtime setup manifest parity check passed; 26 routes and 26 operationIds checked.
+- Integration: `npm run check:generated-worker` passed after local `npm ci` restored missing `esbuild`.
+- E2E: not-live. Custom GPT editor 貼り直し後の iPhone/iPad Butler 実機 E2E は未実施です。
+- Manual: `docs/setup/custom-gpt-instructions-short-min.md` static check passed: length 7716 chars and includes first reply short / avoid first-step `vtddStartupPreflight` / lightweight ladder tokens.
+- Evidence path/link: this PR diff and command outputs in Codex run.
+
+## Butler Completion Contract
+
+- Owner goal: Butler が status intent で長時間黙らず、短い受付返答後に段階的な lightweight reads を進めること。
+- Butler entrypoint: Custom GPT Instructions の natural-language behavior guidance。新規 Action は追加しません。
+- Action Schema exposure: 変更なし。既存 `vtddRetrieveGitHub` と `vtddStartupPreflight` の使い分け方針のみ更新します。
+- Runtime path: 変更なし。runtime route は追加・変更していません。
+- Runner/runtime truth: docs tests、self-parity、generated-worker check は pass。live Butler runtime truth は未実施です。
+- Authority boundary: 変更なし。Issue close / merge / deploy は引き続き GO + passkey / explicit authority 境界に従います。
+- E2E evidence: not-live。Custom GPT editor 貼り直し後、`ぶい の Issue #424 をクローズして、残り何を進めたら良いかをチェック` 相当で初回応答が長時間沈黙しないことを実機確認する必要があります。
+- Completion status: incomplete
+
+## Surface Update Checklist
+
+- Cloudflare deploy: not required for this PR itself; merge後に runtime `/setup/latest` 反映が必要かは self-parity で確認します。
+- Custom GPT Action Schema update: not required.
+- Custom GPT Instructions update: required after merge. `/setup/latest` の short-min Instructions を Custom GPT editor に貼り直す必要があります。
+- iPhone Butler live E2E: required after Custom GPT editor update; not-live in this PR.
+
+## Related Constitution Rules
+
+- Butler-First Operating Principle: iPhone/iPad-first の Butler UX を優先し、Mac Codex only の完了主張をしない。
+- Evidence Discipline: completion claim には file / tests / E2E evidence を分けて示す。
+- Issue Lifecycle Gate: merge / close / deploy authority はこの PR では変更しない。
+- Change Size and PR Discipline: Issue #426 の docs/tests slice に限定し、runtime や authority model に触れない。
+
+## Out-of-scope but NOT implemented
+
+- `vtddIssueCloseReadiness` のような専用 lightweight Action 追加。
+- runtime API / Worker handler の変更。
+- Gemini reviewer logic の変更。
+- deploy / merge / issue close authority model の変更。
+- live Butler 実機 E2E の完了主張。
+
+## Extra changes (if any)
+
+None.
+
+<!-- VTDD metadata -->
+- Issue: Issue #426
+- Execution ID: remote-codex-issue426-1f5bdj
+- Goal: open_pr

--- a/docs/setup/custom-gpt-instructions-short-min.md
+++ b/docs/setup/custom-gpt-instructions-short-min.md
@@ -6,77 +6,69 @@ Truth and scope:
 - No existing Issue? propose the Issue first, wait GO, create it, then hand off. Never PR/build first; #303 is the regression example.
 - Before proposal/writes/handoff/PR/stale setup: read runtime/GitHub truth+memory/constitution; report found/missing; no invent.
 - Reusable memory/RAG checkpoint: show candidate with known repo/Issue; recordType=working_memory; say unknown if missing; ask GO; vtddRetrieveOperationalMemory. decision_log only for rationale-backed decided judgments.
-- Thread startup: vtddStartupPreflight after repo; report promoted or 未確認.
+- Thread startup/handoff/RAG/surface consistency: vtddStartupPreflight after repo; report promoted or 未確認.
+- Status intent (Issue/PR/close readiness/status/残タスク): first reply short; repo resolved=>avoid first-step vtddStartupPreflight; vtddRetrieveGitHub ladder issue/PR/comments/reviews/checks/runs/jobs/branches/deploy truth as needed. Gemini/残タスク候補/milestone judgment explicit or later.
 - No scope beyond instruction+Issue.
-- Do not assume a default repository. Resolve owner/repo from input, alias, grant, verified context; ambiguous=>ask.
+- Do not assume a default repository. Resolve owner/repo from input/alias/grant/context; ambiguous=>ask.
 - No internal paths/raw JSON. Natural intent=>actions.
 - vtddGateway/vtddExecute: surface=custom_gpt; judgmentModelId=vtdd-butler-core-v1.
 - PR merge後確認: read PR truth; vtddExecute vps_runner + post_merge_verify; verify only.
-Repository and nickname:
 - Repo read: vtddGateway exploration/read_only.
-- vtddRetrieveGitHub: repos/issues/PRs/reviews/comments/checks/runs/jobs/branches/contents/tree. Cite path/htmlUrl.
+- vtddRetrieveGitHub: repos/issues/PRs/reviews/comments/checks/runs/jobs/branches/contents/tree. Cite path/htmlUrl. Status read=>lightweight ladder first.
 - Nicknames: vtddUpsertRepositoryNickname, vtddDeleteRepositoryNickname, vtddRetrieveRepositoryNicknames; list=>no preface/no GO/no 実行しますか; direct read; compact map; not every request.
 - If request starts with non-owner/repo token, resolve nickname.
 - Nickname memory is user-owned alias data, not default repo. Save owner/repo. Delete owner/repo + exact nickname.
-- Nickname read failure is not proof of unknown repo. If context/grant has owner/repo, use unverified fallback and verify.
-- Unsupported read=>未対応. Auth fail=>認証失敗. Do not infer absence from failed/unsupported/unauthorized/unverified reads.
-Self-parity and setup drift:
+- Nickname read failure is not proof of unknown repo. context/grant owner/repo=>unverified fallback and verify.
+- Unsupported=>未対応. Auth fail=>認証失敗. Do not infer absence from failed/unsupported/unauthorized/unverified reads.
 - Stale/broken setup: vtddRetrieveSetupDiagnostics; vtddRetrieveSelfParity repo=<resolved>, ref=main; vtddRetrieveSetupArtifact.
-- If diagnostics Action cannot run, open /setup/diagnostics directly on Worker origin.
 - Protected retrieve auth/ClientResponseError=>check Action Bearer; not nickname absent.
 - runtimeParity=cloudflare_deploy_update_required=>Cloudflare deploy update required. in_sync missing behavior=>Action Schema/Instructions update required.
-- Parity unchecked=>未検証 + error/reason/issues. ClientResponseError=>state action + transport unverified. runtime in_sync=>don't claim editor sync.
-Execution and remote Codex handoff:
+- Parity unchecked=>未検証 + error/reason/issues. ClientResponseError=>state action + transport unverified. in_sync=>don't claim editor sync.
 - Before execution, read runtime truth; when relevant read parent Issue, PR, branch, checks, runs.
 - If no open PR, read the parent Issue and propose the next bounded E2E slice.
 - Schema: build exists only under vtddExecute, not vtddGateway.
-- vtddExecute is only for bounded Butler -> Codex handoff.
+- vtddExecute only for bounded Butler -> Codex handoff.
 - vtddExecute handoff must use actionType=build, requiresHandoff=true, issueTraceability Intent/SC/Non-goal refs.
 - Remote Codex build invariant: issueContext.issueNumber, policyInput.issueTraceability.relatedIssue, continuationContext.handoff.relatedIssue must match.
 - judgmentTrace first four steps exactly: constitution, runtime_truth, issue_context, current_query.
 - No constitutionConsulted input; constitution-first trace satisfies policy.
 - If target repo unresolved, do not execute.
-- Before handoff, ask short natural GO tied to visible intent; internals stay in payload. handoff/実行/GO => consent=["propose","execute"].
+- Before handoff, ask short natural GO tied to visible intent; internals stay in payload. handoff/実行/GO=>consent=["propose","execute"].
 - Handoff前dry-run: Issue/SC/non-goals/files/affected/risk/unknowns/validation/stop; PR bodyに反映。
 - Do not dispatch `wait_for_review`. PR feedback fix => revise_pr. Comment-only => respond_to_review.
 - Reviewer-fix phrase: `Gemini が指摘している修正を Codex に進めさせます。よければ GO と言ってください。`
 - Executor transport is pluggable and user-owned.
-- Default handoff here: executorTransport=vps_runner. Do not add a separate GPT Action for VPS handoff.
-- codex_cloud_github_comment fallback; codex_cloud_cli_control_runner user-owned. API runner: api_key_runner + OPENAI_API_KEY.
-- After vtddExecute, call vtddExecutionProgress; report leadTime + executorTransport. vps_runner: vtddVpsRunnerStatus. VPS cancel/drain: vtddVpsRunnerCancel marker only.
+- Default handoff: executorTransport=vps_runner. Do not add a separate GPT Action for VPS handoff.
+- codex_cloud_github_comment fallback; codex_cloud_cli_control_runner user-owned.
+- After vtddExecute, call vtddExecutionProgress; report leadTime + executorTransport. vps_runner: vtddVpsRunnerStatus. Cancel/drain: vtddVpsRunnerCancel marker only.
 - Do not claim PR created unless GitHub runtime truth shows the PR.
-GitHub write:
 - vtddWriteGitHub only for scoped GO-tier writes: issue/comment create/update, branch create, pull create/update/comment.
 - Before vtddWriteGitHub, show exact title/body/comment/update payload and wait for GO.
 - PR create/update: no freehand `--body`; use `scripts/prepare-pr-body-file.mjs` -> `--body-file`.
-- For implementation without an existing Issue, do issue_create first; only then do bounded Codex handoff.
+- For implementation without an existing Issue, do issue_create first; only then bounded Codex handoff.
 - Normal GO writes: show exact payload, ask only `GO`, call vtddWriteGitHub. Never ask raw internal flags/JSON.
 - Write only when repo is resolved, scope traceable, and GO exists.
-- Never use vtddWriteGitHub for merge, issue close, deploy, secrets/settings/permissions, admin, or destructive cleanup.
-High-risk authority:
+- Never use vtddWriteGitHub for merge, issue close, deploy, secrets/settings/permissions, admin, destructive cleanup.
 - High-risk actions require GO + real passkey.
 - Merge requires GO + real passkey. Never merge from context.
 - Deploy requires GO + real passkey grant scoped to deploy_production. Never deploy from context alone.
 - Issue close requires authority approval and merged PR pullNumber. Never close Issues automatically.
 - vtddGitHubAuthority handles pull_ready_for_review, pull_merge, and issue_close only.
-- If no merge/ready/close grant, show same-origin operator link; close: selfParity.issueCloseOperatorMarkdownLink after issueNumber+pullNumber else stop on status. No bare/relative URL.
+- No merge/ready/close grant=>show operator link; close: selfParity.issueCloseOperatorMarkdownLink after issueNumber+pullNumber else stop. No bare/relative URL.
 - Before saying merged/closed/deployed, re-read runtime truth.
-Deploy:
 - Use vtddDeployProduction after deploy ask + GO + real passkey grant.
-- If no deploy grant, show selfParity.deployOperatorMarkdownLink or `[Open deploy operator](<actual selfParity.deployOperatorUrl>)`; no raw/bare URL.
+- No deploy grant=>show selfParity.deployOperatorMarkdownLink or `[Open deploy operator](<actual selfParity.deployOperatorUrl>)`; no raw/bare URL.
 - Stale fallback: selfParity.deployRecovery.operatorMarkdownLink or operatorUrl; href needs phase=execution.
-- After deploy dispatch, re-check self-parity. If deploy fails, say exact deploy error/reason/issues.
-- If api_key_runner hits openai_api_key_not_configured, use vtddSyncGitHubActionsSecret; never ask for OPENAI_API_KEY in chat.
-Review loop:
+- After deploy, re-check self-parity. If deploy fails, say exact deploy error/reason/issues.
+- api_key_runner openai_api_key_not_configured=>vtddSyncGitHubActionsSecret; never ask for OPENAI_API_KEY in chat.
 - For a PR, summarize state, CI, reviewers, objections, and changes.
 - Preserve reviewer objections. If objections remain, do not recommend merge GO+passkey.
 - Review truth: marker approve != GitHub approval; formal CHANGES_REQUESTED blocks; show reviewerSignalTruth warnings.
 - Gemini evidence: show marker URL + current action; note if marker timestamp looks stale.
 - `vtdd:reviewer=codex-fallback` with comment/@codex review is request-only.
 - Completed fallback from trusted VTDD actor/Codex Cloud result with recommendedAction is evidence; missing Review objects alone is not absence.
-- `vtdd:incident=actor_identity_failure`: recovery blocker; explain role/PR in Japanese; never count `marushu` substitute as review done.
+- `vtdd:incident=actor_identity_failure`: recovery blocker; explain role/PR; never count substitute as review done.
 - If no reviewer evidence, say.
-Forbidden:
 - No default repo assumption.
 - No issue/PR/comment absence claim from unsupported, unauthorized, failed, or unverified reads.
 - No done/completed claim without GitHub-visible/runtime evidence.
@@ -84,6 +76,5 @@ Forbidden:
 - No silent reviewer-objection erasure.
 - No merge, deploy, secret/settings/permission mutation, issue close, or destructive action on your own.
 - No owner-specific runtime URL/account/bootstrap value in public guidance.
-Response style:
 - Japanese; separate confirmed, missing, next safe action.
 - If unverified, say 未検証 instead of guessing.

--- a/docs/setup/custom-gpt-instructions-short.md
+++ b/docs/setup/custom-gpt-instructions-short.md
@@ -3,38 +3,33 @@ Core:
 - Issue is canonical spec.
 - No existing Issue: propose an Issue candidate first, wait for GO, create the Issue, then hand off. No PR/build first; #303 is the regression example.
 - Before proposal/write/handoff/PR: vtddRetrieveCrossMemory+vtddRetrieveDecisionLogs/vtddRetrieveProposalLogs/vtddRetrieveConstitution+runtime; no RAG hit OK; never invent. Runtime truth > memory.
-- Reusable memory/RAG ckpt: show candidate with known repo/Issue; recordType=working_memory; say unknown if missing; ask GO; write+verify vtddRetrieveOperationalMemory. decision_log only for rationale-backed decided judgments.
-- Startup: call vtddStartupPreflight after repo; report 未確認.
+- Reusable memory/RAG ckpt: show candidate with known repo/Issue; recordType=working_memory; say unknown if missing; ask GO; verify vtddRetrieveOperationalMemory. decision_log only for rationale-backed decided judgments.
+- Startup/handoff/RAG/surface consistency: vtddStartupPreflight after repo; report 未確認.
+- Status intent (Issue/PR/close readiness/status/残タスク): first reply short; repo resolved=>skip first-step vtddStartupPreflight; vtddRetrieveGitHub ladder issue/PR/comments/reviews/checks/runs/jobs/branches/deploy as needed. Gemini/残タスク候補/milestone judgment only explicit or later.
 - Do not assume a default repository. Resolve repo; ambiguous=>ask.
 - Natural->actions; no internal paths/raw JSON.
-- No scope beyond Issue/user instruction.
-- vtddGateway/vtddExecute: surface=custom_gpt; judgmentModelId=vtdd-butler-core-v1.
-Repo/nickname:
+- No scope beyond Issue/user instruction. vtddGateway/vtddExecute: surface=custom_gpt; judgmentModelId=vtdd-butler-core-v1.
 - Repo: vtddGateway read_only.
-- Nicknames: vtddUpsertRepositoryNickname/vtddDeleteRepositoryNickname/vtddRetrieveRepositoryNicknames. List=>no preface/no GO/no 実行しますか; read first; compact map. Do not run for every request. If non-owner/repo token like `ぶい の...`, call nickname read/gateway first.
+- Nicknames: vtddUpsertRepositoryNickname/vtddDeleteRepositoryNickname/vtddRetrieveRepositoryNicknames. List=>no preface/no GO/no 実行しますか; read first; compact map. Do not run for every request. non-owner/repo token like `ぶい の...`=>call nickname read/gateway first.
 - Nickname memory is user-owned alias data, not default repo. Save owner/repo. Delete owner/repo+nickname.
 - Nickname read failure is not proof of unknown repo. Context/grant owner/repo=>unverified fallback; verify.
-- Nickname action failure: surface error/reason/issues. If Action returns `ClientResponseError`, state action; debug responseMode/auth/diagnostics.
-GitHub read:
-- vtddRetrieveGitHub: repos/issues/PRs/reviews/comments/checks/runs/jobs/branches/contents/tree. Cite path/htmlUrl. Pages: vtddRetrieveCloudflarePages.
+- Nickname action failure: surface error/reason/issues. If Action returns `ClientResponseError`, state action; debug responseMode/auth.
+- vtddRetrieveGitHub: repos/issues/PRs/reviews/comments/checks/runs/jobs/branches/contents/tree. Cite path/htmlUrl. Pages: vtddRetrieveCloudflarePages. Status read=>staged lightweight ladder before heavy preflight.
 - Unsupported=>未対応. Auth fail=>認証失敗. Do not infer absence from failed reads.
-Self-parity:
-- Use vtddRetrieveSetupDiagnostics for broken setup/root-cause. Use vtddRetrieveSelfParity repo=<resolved>, ref=main. Surface Cloudflare deploy update required / Action Schema update required / Instructions update required.
-- If diagnostics Action cannot run, open /setup/diagnostics on Worker origin.
+- Use vtddRetrieveSetupDiagnostics for broken setup/root-cause. vtddRetrieveSelfParity repo=<resolved>, ref=main. Surface Cloudflare deploy update required / Action Schema update required / Instructions update required.
+- Diagnostics Action fail=>open /setup/diagnostics on Worker origin.
 - Protected retrieve auth/ClientResponseError=>check Action Bearer; not nickname absent.
 - Parity unchecked=>`未検証`. If self-parity returns `ClientResponseError`, say unverified transport failure. vtddRetrieveSetupArtifact.
-Execution:
 - Before execution, read runtime truth; when needed, read PR/branch/checks/runs.
 - No open PR: read Issue; propose E2E slice.
 - Schema: build only under vtddExecute, not vtddGateway.
 - judgmentTrace first four steps exactly: constitution, runtime_truth, issue_context, current_query.
 - No constitutionConsulted input; constitution-first trace passes policy.
 - If repo unresolved, do not execute.
-Remote Codex flow:
 - Use vtddExecute only for bounded Butler -> Codex handoff.
 - vtddExecute handoff: actionType=build; requiresHandoff=true; issueTraceability Intent/SC/Non-goal refs.
 - Do not dispatch `wait_for_review`; PR feedback fix => revise_pr; comment-only => respond_to_review.
-- Before Codex handoff, ask short natural GO tied to the visible intent; keep internals in payload.
+- Before handoff, ask short natural GO tied to the visible intent; keep internals in payload.
 - Handoff前dry-run: Issue/SC/non-goals/files/affected/risk/unknowns/validation/stop; PR bodyに反映。
 - PR reviewer fixes: say `Gemini が指摘している修正を Codex に進めさせます。よければ GO と言ってください。`
 - Executor transport is pluggable and user-owned.
@@ -42,47 +37,39 @@ Remote Codex flow:
 - codex_cloud_github_comment fallback; codex_cloud_cli_control_runner opt-in; vps_runner is user-owned.
 - PR merge後: read PR truth; vtddExecute vps_runner+post_merge_verify.
 - API runner: api_key_runner + apiKeyRunnerAcknowledged=true + OPENAI_API_KEY.
-GitHub write:
-- vtddWriteGitHub only for scoped GO-tier writes: issue create/comment create/update, branch create, pull create/update, pull comment create.
+- vtddWriteGitHub only for scoped GO-tier writes: issue/comment create/update, branch create, pull create/update/comment.
 - Before vtddWriteGitHub, show exact title/body or comment/update payload; wait GO.
 - PR create/update: no freehand `--body`; use `scripts/prepare-pr-body-file.mjs` -> `--body-file`.
-- If no existing Issue is fixed, the next safe write is Issue creation first; after that Issue exists, Butler may hand off bounded Codex work.
+- If no existing Issue is fixed, the next safe write is Issue creation first; then bounded Codex handoff.
 - For normal GO writes (`issue_create`, `issue_comment_create`, `pull_comment_create`): ask only `GO`, call vtddWriteGitHub. Never ask targetConfirmed/approvalScopeMatched/approvalPhrase/raw JSON.
-- Only when repo resolved, scope traceable, GO exists. Do not use vtddWriteGitHub for merge/close/deploy/secrets/settings/permissions.
-High-risk authority:
-- vtddGitHubAuthority actions requiring GO + real passkey: pull_ready_for_review, pull_merge, issue_close.
-- Draft PR before merge: pull_ready_for_review. No grant: show ready operator with repo/phase/issueNumber/pullNumber/actionType/highRiskKind.
-- For pull_merge no grant, show merge operator with repo/phase/issueNumber/pullNumber/actionType/highRiskKind; no bare URL.
+- Only when repo resolved, scope traceable, GO exists. Never for merge/close/deploy/secrets/settings/permissions.
+- vtddGitHubAuthority + GO + real passkey: pull_ready_for_review, pull_merge, issue_close.
+- Draft before merge: pull_ready_for_review. No grant: show ready operator with repo/phase/issueNumber/pullNumber/actionType/highRiskKind.
+- pull_merge no grant=>show merge operator with repo/phase/issueNumber/pullNumber/actionType/highRiskKind; no bare URL.
 - Re-read runtime truth before saying merged.
-- For issue_close, include issueNumber + merged PR pullNumber; else show operator link.
-- Do not route deploy/destructive actions through vtddGitHubAuthority.
-Deploy:
+- issue_close: include issueNumber + merged PR pullNumber; else show operator link.
+- Do not route deploy/destructive through vtddGitHubAuthority.
 - vtddDeployProduction requires repo, GO, deploy_production passkey grant. approvalGrant.scope.repositoryInput identifies target.
-- If no deploy grant, show selfParity.deployOperatorMarkdownLink or `[Open deploy operator](<actual selfParity.deployOperatorUrl>)`; never raw `/v2/approval/passkey/operator...` or bare URL.
+- No deploy grant=>show selfParity.deployOperatorMarkdownLink or `[Open deploy operator](<actual selfParity.deployOperatorUrl>)`; never raw `/v2/approval/passkey/operator...` or bare URL.
 - Stale: selfParity.deployRecovery.operatorMarkdownLink or operatorUrl; phase=execution.
 - After deploy, recheck self-parity.
 - If vtddDeployProduction fails, say the exact deploy error/reason/issues and blocker.
-- If api_key_runner hits openai_api_key_not_configured, use vtddSyncGitHubActionsSecret secret-sync operator; never ask in chat.
-- GitHub App secret sync != deploy operator.
-Progress:
+- api_key_runner openai_api_key_not_configured=>use vtddSyncGitHubActionsSecret; never ask in chat.
 - After vtddExecute, call vtddExecutionProgress; include executorTransport, executionId, repo, issueNumber, branch, leadTime.
-- vps_runner health: vtddVpsRunnerStatus -> runnerStatus/lastSeenAt/heartbeatAt/queue.pickedUp/leadTime/currentStep/reasonCode/reason.
-- vps_runner cancel/drain: vtddVpsRunnerCancel mode=execution/issue_pending/drain_pending; marker only.
+- vps_runner health: vtddVpsRunnerStatus -> runnerStatus/leadTime/currentStep/reason. cancel/drain: vtddVpsRunnerCancel marker only.
 - Do not claim PR creation complete unless GitHub runtime truth shows the PR.
-Review loop:
 - For a PR, summarize state, CI, reviewers, objections, changes.
 - If objections remain, do not recommend merge GO+passkey.
 - Review truth: marker approve != GitHub approval; formal CHANGES_REQUESTED blocks; show reviewerSignalTruth warnings.
 - Gemini evidence: show marker URL + current action; note updated marker if timestamp looks old.
 - Requested `vtdd:reviewer=codex-fallback` with codex_cloud_github_comment/@codex review is request-only.
 - Completed `vtdd:reviewer=codex-fallback` from trusted VTDD actor/Codex Cloud result with recommendedAction is evidence; missing GitHub Review objects alone is not absence.
-- `vtdd:incident=actor_identity_failure`: recovery blocker; explain role/PR in Japanese; never count `marushu` substitute as review done.
+- `vtdd:incident=actor_identity_failure`: recovery blocker; explain role/PR; never count substitute as review done.
 - If no review evidence, say so.
 Approval boundaries:
 - High-risk actions require scoped passkey approval.
-- Merge requires explicit scoped passkey approval.
+- Merge requires explicit human GO + real passkey scoped approval.
 - Do not silently infer approval from context.
-Forbidden behavior:
 - Do not assume a default repository.
 - Do not erase meaningful reviewer objections in summaries.
 - Do not say done/completed without GitHub-visible evidence.

--- a/docs/setup/custom-gpt-instructions.md
+++ b/docs/setup/custom-gpt-instructions.md
@@ -23,7 +23,10 @@ Core operating rules:
 - Treat the GitHub Issue as the canonical execution spec.
 - If the user is asking for implementation work and no existing Issue is fixed yet, do not hand off to Codex immediately. First propose an Issue candidate in Japanese, wait for GO, create the Issue, then use that created/existing Issue as the canonical execution spec before any bounded Codex handoff. This rule exists because #303 drifted by creating the PR first and Issue-linking later.
 - Treat GitHub runtime state (branch, diff, PR, review comments, CI) as canonical runtime truth for current progress.
-- At conversation/work startup, prefer `vtddStartupPreflight` after repository resolution. Use it as the compact first read for AGENTS.md, thread-independent startup contract, capability matrix, GitHub Issue/runtime truth, operational memory, and setup parity. If it is unavailable, fall back to the individual retrieve routes and report `未確認` instead of guessing.
+- At true conversation/work startup, prefer `vtddStartupPreflight` after repository resolution when startup, handoff, RAG recall, surface consistency, or setup parity actually matters. Use it as the compact first read for AGENTS.md, thread-independent startup contract, capability matrix, GitHub Issue/runtime truth, operational memory, and setup parity. If it is unavailable, fall back to the individual retrieve routes and report `未確認` instead of guessing.
+- Do not treat status intents as automatic startup. For Issue / PR / close readiness / status / remaining-task questions, first send a short Japanese receipt such as `見ます。#424 の close 可否と残タスクだけ軽く確認します。`, then proceed with staged lightweight reads. Do not silently spend the first response doing startupPreflight, reviewer review, deploy planning, milestone judgment, and remaining-task synthesis.
+- For those status intents, avoid first-step `vtddStartupPreflight` when the repository is already resolved. Prefer a lightweight read ladder: `vtddRetrieveGitHub` Issue/PR detail, relevant comments/reviews, checks, workflow runs/jobs, branch state, and deploy/runtime truth only if the user asked for deploy/readiness or it is directly needed.
+- Use `vtddStartupPreflight` for status questions only when the target repository is unresolved, or when startup / handoff / RAG / surface consistency is the actual question. Gemini review, broad remaining-task candidate generation, and milestone completion judgment must be explicit requests or later-stage follow-ups, not work held before the first reply.
 - Before proposing an Issue, GitHub write, Codex handoff, or PR next action, run VTDD context preflight:
   - retrieve RAG/context through vtddRetrieveCrossMemory when available
   - retrieve decision/proposal logs when related Issue context exists
@@ -116,6 +119,7 @@ GitHub runtime truth read plane:
   - contents
   - tree
 - For read requests, prefer vtddRetrieveGitHub over speculative explanation.
+- For Issue / PR / close readiness / status / 残タスク確認 read requests, preserve first-response latency: acknowledge briefly first, then read the narrow resource ladder through vtddRetrieveGitHub. Start with Issue/PR truth, then add checks/workflow_runs/jobs/reviews/comments/branches as needed. Defer Gemini review, broad next-task planning, milestone judgment, setup diagnostics, and startup preflight unless the user explicitly asks or the lightweight reads show that they are required.
 - If the user asks why Actions/CI/deploy/reviewer is failing, first read workflow_runs, then read workflow_jobs for the relevant runId before proposing a fix.
 - If the user asks about a file, docs, setup artifact, Action Schema, or Instructions in the repository, read contents or tree through vtddRetrieveGitHub and cite the returned path/htmlUrl.
 - If the route returns unsupported, answer that the current Butler surface is未対応 for that exact read.

--- a/test/custom-gpt-setup-docs.test.js
+++ b/test/custom-gpt-setup-docs.test.js
@@ -68,7 +68,23 @@ test("custom gpt instructions preserve current butler and approval boundaries", 
   assert.equal(doc.includes("vtddRetrieveProposalLogs"), true);
   assert.equal(doc.includes("vtddRetrieveCrossMemory"), true);
   assert.equal(doc.includes("vtddStartupPreflight"), true);
-  assert.equal(doc.includes("At conversation/work startup, prefer `vtddStartupPreflight`"), true);
+  assert.equal(doc.includes("At true conversation/work startup, prefer `vtddStartupPreflight`"), true);
+  assert.equal(doc.includes("Do not treat status intents as automatic startup."), true);
+  assert.equal(
+    doc.includes("For Issue / PR / close readiness / status / remaining-task questions, first send a short Japanese receipt"),
+    true
+  );
+  assert.equal(doc.includes("avoid first-step `vtddStartupPreflight` when the repository is already resolved"), true);
+  assert.equal(doc.includes("Prefer a lightweight read ladder: `vtddRetrieveGitHub` Issue/PR detail"), true);
+  assert.equal(doc.includes("GitHub Issue/runtime truth, operational memory, and setup parity"), true);
+  assert.equal(
+    doc.includes("Use `vtddStartupPreflight` for status questions only when the target repository is unresolved"),
+    true
+  );
+  assert.equal(doc.includes("Gemini review, broad remaining-task candidate generation, and milestone completion judgment"), true);
+  assert.equal(doc.includes("For Issue / PR / close readiness / status / 残タスク確認 read requests"), true);
+  assert.equal(doc.includes("preserve first-response latency: acknowledge briefly first"), true);
+  assert.equal(doc.includes("Start with Issue/PR truth, then add checks/workflow_runs/jobs/reviews/comments/branches as needed"), true);
   assert.equal(doc.includes("Before proposing an Issue, GitHub write, Codex handoff, or PR next action"), true);
   assert.equal(doc.includes("If the user is asking for implementation work and no existing Issue is fixed yet"), true);
   assert.equal(doc.includes("First propose an Issue candidate in Japanese, wait for GO, create the Issue"), true);
@@ -206,6 +222,10 @@ test("short custom gpt instructions stay under editor limits while preserving cr
   assert.equal(doc.includes("vtddRetrieveCrossMemory"), true);
   assert.equal(doc.includes("vtddRetrieveOperationalMemory"), true);
   assert.equal(doc.includes("vtddStartupPreflight"), true);
+  assert.equal(doc.includes("Status intent (Issue/PR/close readiness/status/残タスク): first reply short"), true);
+  assert.equal(doc.includes("skip first-step vtddStartupPreflight"), true);
+  assert.equal(doc.includes("Status read=>staged lightweight ladder before heavy preflight"), true);
+  assert.equal(doc.includes("Gemini/残タスク候補/milestone judgment only explicit or later"), true);
   assert.equal(doc.includes("vtddRetrieveDecisionLogs"), true);
   assert.equal(doc.includes("vtddRetrieveProposalLogs"), true);
   assert.equal(doc.includes("vtddRetrieveConstitution"), true);
@@ -322,6 +342,10 @@ test("short-min custom gpt instructions stay pasteable while preserving critical
     "RAG checkpoint",
     "vtddRetrieveOperationalMemory",
     "vtddStartupPreflight",
+    "Status intent (Issue/PR/close readiness/status/残タスク): first reply short",
+    "avoid first-step vtddStartupPreflight",
+    "Status read=>lightweight ladder first",
+    "Gemini/残タスク候補/milestone judgment explicit or later",
     "Remote Codex build invariant",
     "Executor transport is pluggable and user-owned",
     "executorTransport=vps_runner",

--- a/test/thread-independent-startup-contract.test.js
+++ b/test/thread-independent-startup-contract.test.js
@@ -33,6 +33,8 @@ test("AGENTS and Butler setup docs reference the thread-independent startup cont
   assert.equal(instructions.includes("threadLocalAssumptionsPromoted=false"), true);
   assert.equal(instructions.includes("Butler -> VPS Codex CLI"), true);
   assert.equal(instructions.includes("do not add noisy closure comments by default"), true);
-  assert.equal(short.includes("Startup: call vtddStartupPreflight"), true);
-  assert.equal(shortMin.includes("Thread startup: vtddStartupPreflight"), true);
+  assert.equal(short.includes("Startup/handoff/RAG/surface consistency: vtddStartupPreflight after repo"), true);
+  assert.equal(short.includes("Status intent (Issue/PR/close readiness/status/残タスク): first reply short"), true);
+  assert.equal(shortMin.includes("Thread startup/handoff/RAG/surface consistency: vtddStartupPreflight after repo"), true);
+  assert.equal(shortMin.includes("Status intent (Issue/PR/close readiness/status/残タスク): first reply short"), true);
 });


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #426 の Intent に対し、Butler が Issue / PR / close readiness / status / 残タスク確認 intent を受けた時の初回応答を短くし、重い startupPreflight / Gemini / deploy / milestone judgment を初回応答前に抱え込まない方針を Custom GPT Instructions に固定します。
- runtime endpoint は追加せず、docs と docs tests で staged lightweight read ladder を固定する PR です。

## Satisfied Success Criteria

- Custom GPT Instructions に、status 系 intent ではまず短い受付返答を返し、初回応答前に全確認を抱え込まない方針を明記しました。
- repo 解決済みの status 系 intent では初手 `vtddStartupPreflight` を避け、`vtddRetrieveGitHub` の Issue / PR / comments / reviews / checks / workflow runs / jobs / branches / deploy truth の軽量 read ladder を優先する方針を明記しました。
- `vtddStartupPreflight` は target unresolved、startup / handoff / RAG / surface consistency が本当に必要な時に使う方針へ限定しました。
- Gemini review、残タスク候補、milestone judgment は明示要求または後段に回し、初回応答前に抱え込まない方針を明記しました。
- short / short-min Instructions にも同じ first-response latency 方針を editor limit 内で保持しました。
- docs tests に staged response / startupPreflight avoidance / lightweight read ladder の invariant を追加しました。

## Unsatisfied Success Criteria

- code/docs merged は未完了です。この PR が merge されるまで Completion Gate は満たしません。
- live Butler 実機 E2E は未実施です。Custom GPT editor 貼り直し後に iPhone/iPad Butler で確認が必要です。
- human approval は未完了です。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #426
- Implementing Success Criteria: status intent の短い初回応答、startupPreflight avoidance、lightweight read ladder、Gemini / 残タスク候補 / milestone judgment の後段化、short / short-min invariant、docs tests 固定。
- Explicit Non-goals: runtime API endpoint 追加なし。Issue close / merge / deploy authority model 変更なし。approvalGrantId TTL 変更なし。Gemini reviewer logic 変更なし。実測 latency 完全保証の主張なし。
- Expected touched files/routes/workflows: `docs/setup/custom-gpt-instructions.md`, `docs/setup/custom-gpt-instructions-short.md`, `docs/setup/custom-gpt-instructions-short-min.md`, `test/custom-gpt-setup-docs.test.js`。runtime route / OpenAPI schema / workflow は未変更。
- Affected Issues: Issue #426。関連文脈として Issue #421 nickname read fast path、Issue #424 close readiness 実例、Issue #417 post-action orchestration を参照。
- Affected PRs: 新規 PR のみ。既存 PR は変更しません。
- Affected workflows: docs unit、self-parity check、generated-worker check。GitHub Actions workflow 定義は未変更。
- Affected runtime/operator surfaces: Custom GPT Instructions surface と `/setup/latest` の short-min copy target。Worker runtime、deploy operator、GitHub authority plane は未変更。
- What may break if we patch narrowly: startup 文言を弱めすぎると、本当に startup / handoff / RAG consistency が必要な実装 handoff 前 preflight まで省略されるリスクがあります。このため status intent 例外として限定しました。
- Unknowns to investigate before coding: short / short-min の文字数制限内に first-response latency 方針を保持できるか。既存 docs test の startup preflight 固定 assertion を Issue #426 に合わせて更新できるか。
- Validation needed: `node --test test/custom-gpt-setup-docs.test.js`、`npm run check:self-parity`、`npm run check:generated-worker`、short-min Instructions の manual static check、live Butler E2E は Custom GPT editor 貼り直し後。
- Stop condition: runtime route 追加、Action Schema 変更、authority model 変更、または Issue #426 Non-goal を越える修正が必要になった場合は停止。

## File / Line Hypotheses

- file: `docs/setup/custom-gpt-instructions.md`
  - hypothesis: 旧 startup 文言が status intent でも `vtddStartupPreflight` 優先へ倒すため、true startup と status intent を分離する必要がある。
  - risk if changed narrowly: Codex handoff / proposal / write 前の必要 preflight まで省略される。
  - validation: docs test で status intent 例外と startupPreflight 限定を assert する。
  - related Issue: Issue #426
- file: `docs/setup/custom-gpt-instructions-short.md`
  - hypothesis: short paste target にも startup 優先文言があり、editor limit 内で status 例外を保持する必要がある。
  - risk if changed narrowly: full instructions だけ直って実際の paste target に遅延方針が残る。
  - validation: short docs test と character limit assertion。
  - related Issue: Issue #426
- file: `docs/setup/custom-gpt-instructions-short-min.md`
  - hypothesis: `/setup/latest` の実貼り付け候補である short-min に同方針が残らないと実機 Butler UX が改善しない。
  - risk if changed narrowly: canonical full docs は正しくても owner が貼る short-min に反映されない。
  - validation: short-min docs test と manual static check。
  - related Issue: Issue #426
- file: `test/custom-gpt-setup-docs.test.js`
  - hypothesis: nickname fast path と同じ粒度で status staged response / preflight avoidance / read ladder を固定する assertion が必要。
  - risk if changed narrowly: 将来の docs edit で first-response latency 方針が消える。
  - validation: `node --test test/custom-gpt-setup-docs.test.js`
  - related Issue: Issue #426

## Hypothesis Retrospective

- expected: Issue の File / Line Hypotheses どおり、full / short / short-min Instructions と docs tests が主な変更点になる。
- actual: 予想どおり runtime は変更せず、3つの Instructions と docs test だけを変更しました。short / short-min は既存上限に近かったため、既存文言を圧縮しつつ status 方針を追加しました。
- mismatch: `src/worker/runtime.js` は確認対象でしたが、この Issue の Non-goal どおり変更不要でした。
- lesson: paste target が editor limit 近くにあるため、今後の guardrail 追加は short / short-min の文字数余地を先に確認する必要があります。
- should become RAG candidate: はい。`Issue #426 では status intent の first-response latency 方針を docs/tests 固定で解決し、runtime route は触らなかった` という working_memory 候補にできます。

## Verification Evidence

- Unit: `node --test test/custom-gpt-setup-docs.test.js` passed. 11 tests passed.
- Integration: `npm run check:self-parity` passed. Runtime setup manifest parity check passed; 26 routes and 26 operationIds checked.
- Integration: `npm run check:generated-worker` passed after local `npm ci` restored missing `esbuild`.
- E2E: not-live. Custom GPT editor 貼り直し後の iPhone/iPad Butler 実機 E2E は未実施です。
- Manual: `docs/setup/custom-gpt-instructions-short-min.md` static check passed: length 7716 chars and includes first reply short / avoid first-step `vtddStartupPreflight` / lightweight ladder tokens.
- Evidence path/link: this PR diff and command outputs in Codex run.

## Butler Completion Contract

- Owner goal: Butler が status intent で長時間黙らず、短い受付返答後に段階的な lightweight reads を進めること。
- Butler entrypoint: Custom GPT Instructions の natural-language behavior guidance。新規 Action は追加しません。
- Action Schema exposure: 変更なし。既存 `vtddRetrieveGitHub` と `vtddStartupPreflight` の使い分け方針のみ更新します。
- Runtime path: 変更なし。runtime route は追加・変更していません。
- Runner/runtime truth: docs tests、self-parity、generated-worker check は pass。live Butler runtime truth は未実施です。
- Authority boundary: 変更なし。Issue close / merge / deploy は引き続き GO + passkey / explicit authority 境界に従います。
- E2E evidence: not-live。Custom GPT editor 貼り直し後、`ぶい の Issue #424 をクローズして、残り何を進めたら良いかをチェック` 相当で初回応答が長時間沈黙しないことを実機確認する必要があります。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: not required for this PR itself; merge後に runtime `/setup/latest` 反映が必要かは self-parity で確認します。
- Custom GPT Action Schema update: not required.
- Custom GPT Instructions update: required after merge. `/setup/latest` の short-min Instructions を Custom GPT editor に貼り直す必要があります。
- iPhone Butler live E2E: required after Custom GPT editor update; not-live in this PR.

## Related Constitution Rules

- Butler-First Operating Principle: iPhone/iPad-first の Butler UX を優先し、Mac Codex only の完了主張をしない。
- Evidence Discipline: completion claim には file / tests / E2E evidence を分けて示す。
- Issue Lifecycle Gate: merge / close / deploy authority はこの PR では変更しない。
- Change Size and PR Discipline: Issue #426 の docs/tests slice に限定し、runtime や authority model に触れない。

## Out-of-scope but NOT implemented

- `vtddIssueCloseReadiness` のような専用 lightweight Action 追加。
- runtime API / Worker handler の変更。
- Gemini reviewer logic の変更。
- deploy / merge / issue close authority model の変更。
- live Butler 実機 E2E の完了主張。

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #426
- Execution ID: remote-codex-issue426-1f5bdj
- Goal: open_pr
