### PR TITLE
v2 Worker にダッシュボード surface を追加

### DIFF
--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -125,6 +125,10 @@ export default {
       );
     }
 
+    if (request.method === "GET" && (url.pathname === "/dashboard" || url.pathname === "/orchestrator")) {
+      return html(200, renderV2DashboardPage({ runtimeOrigin: url.origin }));
+    }
+
     if (
       request.method === "GET" &&
       (url.pathname === MCP_PROTECTED_RESOURCE_METADATA_PATH ||
@@ -4889,6 +4893,148 @@ function normalizeTextList(value) {
 
 function uniqueTextList(value) {
   return [...new Set(normalizeTextList(value))];
+}
+
+function renderV2DashboardPage({ runtimeOrigin }) {
+  const origin = normalize(runtimeOrigin);
+  const repository = "marushu/vtdd-v2-p";
+  const encodedRepository = encodeURIComponent(repository);
+  const surfaces = [
+    {
+      title: "Startup preflight",
+      body: "AGENTS.md、thread-independent startup、runtime truth、RAG、self parity を最初に読む入口。",
+      href: `${origin}/v2/retrieve/startup-preflight?repository=${encodedRepository}&currentSurface=dashboard&responseMode=action_visible`
+    },
+    {
+      title: "Execution progress",
+      body: "VPS Codex CLI / remote Codex execution の進捗確認。",
+      href: `${origin}/v2/action/progress?repository=${encodedRepository}&responseMode=action_visible`
+    },
+    {
+      title: "VPS runner status",
+      body: "runner health、queue、対象 execution の状態確認。",
+      href: `${origin}/v2/action/vps-runner-status?repository=${encodedRepository}&responseMode=action_visible`
+    },
+    {
+      title: "GitHub runtime truth",
+      body: "Issues、PRs、checks、workflow runs、reviewer comments を読む入口。",
+      href: `${origin}/v2/retrieve/github?repository=${encodedRepository}&include=open_prs,open_issues,workflow_runs,issue_comments&responseMode=action_visible`
+    },
+    {
+      title: "Operational RAG",
+      body: "decision / proposal / working memory の compact retrieval。runtime truth の代替ではない。",
+      href: `${origin}/v2/retrieve/operational-memory?repository=${encodedRepository}&limit=5&responseMode=action_visible`
+    },
+    {
+      title: "Self parity",
+      body: "Action Schema、Instructions、Cloudflare deploy freshness、operator URL を確認。",
+      href: `${origin}/v2/retrieve/self-parity?repository=${encodedRepository}&responseMode=action_visible`
+    },
+    {
+      title: "Setup diagnostics",
+      body: "Butler / Custom GPT / deploy drift の診断ページ。",
+      href: `${origin}/setup/diagnostics?repository=${encodedRepository}`
+    },
+    {
+      title: "Deploy passkey operator",
+      body: "production deploy は GO + passkey の後ろ。approval grant や secret は dashboard に保存しない。",
+      href: `${origin}/v2/approval/passkey/operator?repositoryInput=${encodedRepository}&phase=execution&actionType=deploy_production&highRiskKind=deploy_production`
+    }
+  ];
+  const workflows = [
+    ["remote-codex-executor", "https://github.com/marushu/vtdd-v2-p/actions/workflows/remote-codex-executor.yml"],
+    ["gemini-pr-review", "https://github.com/marushu/vtdd-v2-p/actions/workflows/gemini-pr-review.yml"],
+    ["codex-pr-review-fallback", "https://github.com/marushu/vtdd-v2-p/actions/workflows/codex-pr-review-fallback.yml"],
+    ["deploy-production", "https://github.com/marushu/vtdd-v2-p/actions/workflows/deploy-production.yml"]
+  ];
+
+  return `<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>VTDD v2 Dashboard</title>
+  <style>
+    :root { color-scheme: light; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; color: #182125; background: #f7faf7; }
+    body { margin: 0; }
+    main { width: min(1120px, calc(100% - 32px)); margin: 0 auto; padding: 28px 0 48px; }
+    header { display: flex; justify-content: space-between; gap: 16px; align-items: flex-start; margin-bottom: 20px; }
+    h1 { font-size: clamp(32px, 6vw, 56px); line-height: 1; margin: 8px 0; }
+    h2 { font-size: 24px; margin: 0 0 14px; }
+    p { line-height: 1.7; color: #4d5c56; }
+    .eyebrow { color: #2c7658; font-size: 13px; font-weight: 800; letter-spacing: .08em; text-transform: uppercase; }
+    .panel { background: #fff; border: 1px solid #dce5dd; border-radius: 8px; padding: 22px; box-shadow: 0 10px 30px rgba(28, 44, 35, .06); margin: 16px 0; }
+    .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 14px; }
+    .card { border: 1px solid #dce5dd; border-radius: 8px; padding: 16px; background: #fbfdfb; }
+    .card h3 { margin: 0 0 8px; font-size: 19px; }
+    a.button, .card a { display: inline-flex; align-items: center; justify-content: center; border: 1px solid #b9cabe; border-radius: 7px; padding: 9px 12px; color: #0f513b; font-weight: 750; text-decoration: none; }
+    .card a { margin-top: 8px; }
+    .notice { border-color: #e6c6a0; background: #fff8ef; }
+    .danger { border-color: #e3b4a7; background: #fff5f3; }
+    code { color: #596860; }
+    ul { margin: 0; padding-left: 20px; color: #4d5c56; line-height: 1.8; }
+    @media (max-width: 640px) { header { display: block; } main { width: min(100% - 20px, 1120px); padding-top: 16px; } }
+  </style>
+</head>
+<body>
+  <main>
+    <header>
+      <div>
+        <p class="eyebrow">VTDD v2 operational dashboard</p>
+        <h1>VTDD Butler</h1>
+        <p>v2 の GitHub App / VPS runner / Gemini reviewer / RAG / passkey / runtime truth をそのまま使う dashboard 入口です。</p>
+      </div>
+      <a class="button" href="${escapeDashboardHtml(origin)}/health">Health</a>
+    </header>
+
+    <section class="panel notice">
+      <h2>現在の判断</h2>
+      <p>v3 dashboard は prototype として扱い、実運用の本線は v2-p に戻します。この dashboard は新しい実行権限を持たず、既存の v2 runtime route へ owner を案内します。</p>
+    </section>
+
+    <section class="panel">
+      <h2>Runtime surfaces</h2>
+      <div class="grid">
+        ${surfaces.map((surface) => `<article class="card">
+          <h3>${escapeDashboardHtml(surface.title)}</h3>
+          <p>${escapeDashboardHtml(surface.body)}</p>
+          <a href="${escapeDashboardHtml(surface.href)}">開く</a>
+        </article>`).join("")}
+      </div>
+    </section>
+
+    <section class="panel">
+      <h2>GitHub workflows</h2>
+      <div class="grid">
+        ${workflows.map(([title, href]) => `<article class="card">
+          <h3>${escapeDashboardHtml(title)}</h3>
+          <p>GitHub Actions runtime truth / execution surface。</p>
+          <a href="${escapeDashboardHtml(href)}">GitHub Actions</a>
+        </article>`).join("")}
+      </div>
+    </section>
+
+    <section class="panel danger">
+      <h2>v3 Worker の扱い</h2>
+      <p><code>vtdd-v3-orchestrator.polished-tree-da7c.workers.dev</code> は prototype として残します。削除は Cloudflare Worker deletion なので destructive operation です。実行する場合は GO + passkey と削除対象名の明示が必要です。</p>
+      <ul>
+        <li>削除前に v2 dashboard / deploy path が本番反映済みであることを確認する。</li>
+        <li>必要なら v3 Worker は disable / rename / delete の順に検討する。</li>
+        <li>secret や approval grant は dashboard に表示しない。</li>
+      </ul>
+    </section>
+  </main>
+</body>
+</html>`;
+}
+
+function escapeDashboardHtml(value) {
+  return String(value ?? "")
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
 }
 
 function json(status, body, extraHeaders = {}) {

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -129,6 +129,25 @@ test("worker returns health", async () => {
   assert.equal(body.autonomyMode, AutonomyMode.NORMAL);
 });
 
+test("worker serves v2 dashboard without exposing secrets", async () => {
+  const response = await worker.fetch(new Request("https://example.com/dashboard"));
+  assert.equal(response.status, 200);
+  assert.match(response.headers.get("content-type"), /text\/html/);
+  const body = await response.text();
+  assert.equal(body.includes("VTDD v2 operational dashboard"), true);
+  assert.equal(body.includes("/v2/retrieve/startup-preflight"), true);
+  assert.equal(body.includes("/v2/action/vps-runner-status"), true);
+  assert.equal(body.includes("/v2/retrieve/operational-memory"), true);
+  assert.equal(body.includes("gemini-pr-review"), true);
+  assert.equal(body.includes("GO + passkey"), true);
+  assert.equal(body.includes("approvalGrantId"), false);
+  assert.equal(body.includes("CLOUDFLARE_API_TOKEN"), false);
+
+  const alias = await worker.fetch(new Request("https://example.com/orchestrator"));
+  assert.equal(alias.status, 200);
+  assert.equal((await alias.text()).includes("VTDD Butler"), true);
+});
+
 test("worker setup recovery page opens without Action auth and defaults to VTDD repo", async () => {
   const response = await worker.fetch(new Request("https://example.com/setup/recovery"));
 

--- a/worker.js
+++ b/worker.js
@@ -55783,6 +55783,9 @@ var runtime_default = {
         })
       );
     }
+    if (request.method === "GET" && (url.pathname === "/dashboard" || url.pathname === "/orchestrator")) {
+      return html(200, renderV2DashboardPage({ runtimeOrigin: url.origin }));
+    }
     if (request.method === "GET" && (url.pathname === MCP_PROTECTED_RESOURCE_METADATA_PATH || url.pathname === MCP_PROTECTED_RESOURCE_METADATA_MIRROR_PATH)) {
       return json(200, buildMcpProtectedResourceMetadata(url));
     }
@@ -59852,6 +59855,140 @@ function normalizeTextList2(value) {
 }
 function uniqueTextList2(value) {
   return [...new Set(normalizeTextList2(value))];
+}
+function renderV2DashboardPage({ runtimeOrigin }) {
+  const origin = normalize7(runtimeOrigin);
+  const repository = "marushu/vtdd-v2-p";
+  const encodedRepository = encodeURIComponent(repository);
+  const surfaces = [
+    {
+      title: "Startup preflight",
+      body: "AGENTS.md\u3001thread-independent startup\u3001runtime truth\u3001RAG\u3001self parity \u3092\u6700\u521D\u306B\u8AAD\u3080\u5165\u53E3\u3002",
+      href: `${origin}/v2/retrieve/startup-preflight?repository=${encodedRepository}&currentSurface=dashboard&responseMode=action_visible`
+    },
+    {
+      title: "Execution progress",
+      body: "VPS Codex CLI / remote Codex execution \u306E\u9032\u6357\u78BA\u8A8D\u3002",
+      href: `${origin}/v2/action/progress?repository=${encodedRepository}&responseMode=action_visible`
+    },
+    {
+      title: "VPS runner status",
+      body: "runner health\u3001queue\u3001\u5BFE\u8C61 execution \u306E\u72B6\u614B\u78BA\u8A8D\u3002",
+      href: `${origin}/v2/action/vps-runner-status?repository=${encodedRepository}&responseMode=action_visible`
+    },
+    {
+      title: "GitHub runtime truth",
+      body: "Issues\u3001PRs\u3001checks\u3001workflow runs\u3001reviewer comments \u3092\u8AAD\u3080\u5165\u53E3\u3002",
+      href: `${origin}/v2/retrieve/github?repository=${encodedRepository}&include=open_prs,open_issues,workflow_runs,issue_comments&responseMode=action_visible`
+    },
+    {
+      title: "Operational RAG",
+      body: "decision / proposal / working memory \u306E compact retrieval\u3002runtime truth \u306E\u4EE3\u66FF\u3067\u306F\u306A\u3044\u3002",
+      href: `${origin}/v2/retrieve/operational-memory?repository=${encodedRepository}&limit=5&responseMode=action_visible`
+    },
+    {
+      title: "Self parity",
+      body: "Action Schema\u3001Instructions\u3001Cloudflare deploy freshness\u3001operator URL \u3092\u78BA\u8A8D\u3002",
+      href: `${origin}/v2/retrieve/self-parity?repository=${encodedRepository}&responseMode=action_visible`
+    },
+    {
+      title: "Setup diagnostics",
+      body: "Butler / Custom GPT / deploy drift \u306E\u8A3A\u65AD\u30DA\u30FC\u30B8\u3002",
+      href: `${origin}/setup/diagnostics?repository=${encodedRepository}`
+    },
+    {
+      title: "Deploy passkey operator",
+      body: "production deploy \u306F GO + passkey \u306E\u5F8C\u308D\u3002approval grant \u3084 secret \u306F dashboard \u306B\u4FDD\u5B58\u3057\u306A\u3044\u3002",
+      href: `${origin}/v2/approval/passkey/operator?repositoryInput=${encodedRepository}&phase=execution&actionType=deploy_production&highRiskKind=deploy_production`
+    }
+  ];
+  const workflows = [
+    ["remote-codex-executor", "https://github.com/marushu/vtdd-v2-p/actions/workflows/remote-codex-executor.yml"],
+    ["gemini-pr-review", "https://github.com/marushu/vtdd-v2-p/actions/workflows/gemini-pr-review.yml"],
+    ["codex-pr-review-fallback", "https://github.com/marushu/vtdd-v2-p/actions/workflows/codex-pr-review-fallback.yml"],
+    ["deploy-production", "https://github.com/marushu/vtdd-v2-p/actions/workflows/deploy-production.yml"]
+  ];
+  return `<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>VTDD v2 Dashboard</title>
+  <style>
+    :root { color-scheme: light; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; color: #182125; background: #f7faf7; }
+    body { margin: 0; }
+    main { width: min(1120px, calc(100% - 32px)); margin: 0 auto; padding: 28px 0 48px; }
+    header { display: flex; justify-content: space-between; gap: 16px; align-items: flex-start; margin-bottom: 20px; }
+    h1 { font-size: clamp(32px, 6vw, 56px); line-height: 1; margin: 8px 0; }
+    h2 { font-size: 24px; margin: 0 0 14px; }
+    p { line-height: 1.7; color: #4d5c56; }
+    .eyebrow { color: #2c7658; font-size: 13px; font-weight: 800; letter-spacing: .08em; text-transform: uppercase; }
+    .panel { background: #fff; border: 1px solid #dce5dd; border-radius: 8px; padding: 22px; box-shadow: 0 10px 30px rgba(28, 44, 35, .06); margin: 16px 0; }
+    .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 14px; }
+    .card { border: 1px solid #dce5dd; border-radius: 8px; padding: 16px; background: #fbfdfb; }
+    .card h3 { margin: 0 0 8px; font-size: 19px; }
+    a.button, .card a { display: inline-flex; align-items: center; justify-content: center; border: 1px solid #b9cabe; border-radius: 7px; padding: 9px 12px; color: #0f513b; font-weight: 750; text-decoration: none; }
+    .card a { margin-top: 8px; }
+    .notice { border-color: #e6c6a0; background: #fff8ef; }
+    .danger { border-color: #e3b4a7; background: #fff5f3; }
+    code { color: #596860; }
+    ul { margin: 0; padding-left: 20px; color: #4d5c56; line-height: 1.8; }
+    @media (max-width: 640px) { header { display: block; } main { width: min(100% - 20px, 1120px); padding-top: 16px; } }
+  </style>
+</head>
+<body>
+  <main>
+    <header>
+      <div>
+        <p class="eyebrow">VTDD v2 operational dashboard</p>
+        <h1>VTDD Butler</h1>
+        <p>v2 \u306E GitHub App / VPS runner / Gemini reviewer / RAG / passkey / runtime truth \u3092\u305D\u306E\u307E\u307E\u4F7F\u3046 dashboard \u5165\u53E3\u3067\u3059\u3002</p>
+      </div>
+      <a class="button" href="${escapeDashboardHtml(origin)}/health">Health</a>
+    </header>
+
+    <section class="panel notice">
+      <h2>\u73FE\u5728\u306E\u5224\u65AD</h2>
+      <p>v3 dashboard \u306F prototype \u3068\u3057\u3066\u6271\u3044\u3001\u5B9F\u904B\u7528\u306E\u672C\u7DDA\u306F v2-p \u306B\u623B\u3057\u307E\u3059\u3002\u3053\u306E dashboard \u306F\u65B0\u3057\u3044\u5B9F\u884C\u6A29\u9650\u3092\u6301\u305F\u305A\u3001\u65E2\u5B58\u306E v2 runtime route \u3078 owner \u3092\u6848\u5185\u3057\u307E\u3059\u3002</p>
+    </section>
+
+    <section class="panel">
+      <h2>Runtime surfaces</h2>
+      <div class="grid">
+        ${surfaces.map((surface) => `<article class="card">
+          <h3>${escapeDashboardHtml(surface.title)}</h3>
+          <p>${escapeDashboardHtml(surface.body)}</p>
+          <a href="${escapeDashboardHtml(surface.href)}">\u958B\u304F</a>
+        </article>`).join("")}
+      </div>
+    </section>
+
+    <section class="panel">
+      <h2>GitHub workflows</h2>
+      <div class="grid">
+        ${workflows.map(([title, href]) => `<article class="card">
+          <h3>${escapeDashboardHtml(title)}</h3>
+          <p>GitHub Actions runtime truth / execution surface\u3002</p>
+          <a href="${escapeDashboardHtml(href)}">GitHub Actions</a>
+        </article>`).join("")}
+      </div>
+    </section>
+
+    <section class="panel danger">
+      <h2>v3 Worker \u306E\u6271\u3044</h2>
+      <p><code>vtdd-v3-orchestrator.polished-tree-da7c.workers.dev</code> \u306F prototype \u3068\u3057\u3066\u6B8B\u3057\u307E\u3059\u3002\u524A\u9664\u306F Cloudflare Worker deletion \u306A\u306E\u3067 destructive operation \u3067\u3059\u3002\u5B9F\u884C\u3059\u308B\u5834\u5408\u306F GO + passkey \u3068\u524A\u9664\u5BFE\u8C61\u540D\u306E\u660E\u793A\u304C\u5FC5\u8981\u3067\u3059\u3002</p>
+      <ul>
+        <li>\u524A\u9664\u524D\u306B v2 dashboard / deploy path \u304C\u672C\u756A\u53CD\u6620\u6E08\u307F\u3067\u3042\u308B\u3053\u3068\u3092\u78BA\u8A8D\u3059\u308B\u3002</li>
+        <li>\u5FC5\u8981\u306A\u3089 v3 Worker \u306F disable / rename / delete \u306E\u9806\u306B\u691C\u8A0E\u3059\u308B\u3002</li>
+        <li>secret \u3084 approval grant \u306F dashboard \u306B\u8868\u793A\u3057\u306A\u3044\u3002</li>
+      </ul>
+    </section>
+  </main>
+</body>
+</html>`;
+}
+function escapeDashboardHtml(value) {
+  return String(value ?? "").replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;").replaceAll('"', "&quot;").replaceAll("'", "&#39;");
 }
 function json(status, body, extraHeaders = {}) {
   return new Response(JSON.stringify(body), {


### PR DESCRIPTION
## This PR satisfies Intent

- #428 の Intent に沿って、v2-p Worker を VTDD dashboard の本線 surface として使えるようにする。v3 Worker は prototype と明示し、削除はこのPRでは実行しない。

## Satisfied Success Criteria

- GET /dashboard と GET /orchestrator を追加し、v2 の既存 runtime truth / progress / VPS runner / GitHub / RAG / setup diagnostics / deploy approval surface へ移動できる owner-facing dashboard を表示する。\nダッシュボード本文で v2 が本線、v3 が prototype であることを明示する。\nv3 Worker 削除は Cloudflare Worker deletion で destructive/high-risk のため GO + passkey と明示する。\napprovalGrantId や Cloudflare token などの secret / grant を dashboard HTML に出さない。

## Unsatisfied Success Criteria

- Cloudflare production deploy は未実施。\niPhone Butler live E2E は未実施。\nv3 Worker 削除は未実施。削除する場合は別途 GO + passkey と明示 target が必要。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #428
- Implementing Success Criteria: v2 Worker dashboard surface を追加し、既存 v2 runtime/protocol へ誘導する。v3 Worker 削除はこのPRでは実行しない。
- Explicit Non-goals: React/PWA 化、v3 Worker 削除、Cloudflare deploy、GitHub App/secret/permission mutation、Custom GPT Action Schema 変更は対象外。
- Expected touched files/routes/workflows: src/worker/runtime.js; worker.js; test/worker.test.js; route GET /dashboard; route GET /orchestrator
- Affected Issues: #428
- Affected PRs: なし
- Affected workflows: generated-worker check に影響。GitHub Actions workflow 定義は変更なし。
- Affected runtime/operator surfaces: Worker owner-facing dashboard surface。既存 Butler Action Schema / VPS runner / GitHub App / RAG route は参照のみで未変更。
- What may break if we patch narrowly: dashboard が既存 runtime path と乖離すると、見た目だけの v3 と同じ失敗になる。既存 v2 route への静的リンクに限定して drift を避ける。
- Unknowns to investigate before coding: production deploy 後の iPhone 実機表示は未確認。v3 Worker deletion は target と authority 境界確認が必要。
- Validation needed: node --test test/worker.test.js; npm test; generated worker parity; production deploy 後の /dashboard smoke
- Stop condition: Cloudflare deploy、v3 Worker deletion、secret/permission mutation が必要になった場合は GO + passkey なしに進めない。

## File / Line Hypotheses

- file: src/worker/runtime.js\n  - hypothesis: Worker route table と HTML renderer に dashboard route を追加すれば、v2 の既存 runtime truth surface へ owner を誘導できる。\n  - risk if changed narrowly: runtime route だけ追加して generated worker を更新しないと parity check が落ちる。\n  - validation: node --test test/worker.test.js と npm test で route と generated worker parity を確認する。\n  - related Issue: #428\n- file: test/worker.test.js\n  - hypothesis: dashboard が secret/grant を出さず、主要リンクを含むことを worker test で固定する。\n  - risk if changed narrowly: 表示だけ成功して authority boundary が曖昧になる。\n  - validation: dashboard HTML の包含/非包含 assertion。\n  - related Issue: #428

## Hypothesis Retrospective

- expected: runtime route と renderer 追加で dashboard surface が出せる。\n- actual: /dashboard と /orchestrator を追加し、既存 v2 surface へのリンク集と v3 prototype/deletion guard を表示できた。\n- mismatch: なし。\n- lesson: v3 の dashboard 実験は v2 の execution/reviewer/RAG/approval protocol を再利用できていなかったため、v2-p を本線に戻す判断が妥当。\n- should become RAG candidate: はい。v3 dashboard 先行で protocol parity を失った失敗は今後の判断材料にする。

## Verification Evidence

- Unit: node --test test/worker.test.js PASS: 123 tests
- Integration: npm test PASS: 828 tests, 827 pass, 1 skipped。check:self-parity と check:generated-worker も PASS。
- E2E: 未実施。production deploy 後に v2 Worker /dashboard を iPhone Butler から確認する必要がある。
- Manual: ローカル route レベルの HTML assertion で主要導線と secret 非露出を確認。
- Evidence path/link: ローカル実行ログ: node --test test/worker.test.js; npm test

## Butler Completion Contract

- Owner goal: v2-p の working protocol を維持したまま、VTDD dashboard を v2 Worker 上の本線 surface として使えるようにする。
- Butler entrypoint: GET /dashboard または GET /orchestrator。Butler natural-language からこのURLを案内する運用が必要。
- Action Schema exposure: 未変更。既存 v2 runtime routes への dashboard link surface 追加のみ。
- Runtime path: GET /dashboard; GET /orchestrator
- Runner/runtime truth: dashboard HTML が v2 runtime truth / progress / VPS runner / GitHub / RAG / setup diagnostics / deploy approval surface へリンクする。
- Authority boundary: dashboard 表示は低リスク。Cloudflare deploy と v3 Worker deletion は GO + passkey 必須。approvalGrantId は表示しない。
- E2E evidence: 未実施。production deploy 後に iPhone Butler から /dashboard を開き、主要導線を確認する。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: required after merge: GO + passkey が必要。
- Custom GPT Action Schema update: 不要。このPRでは operationId を追加しない。
- Custom GPT Instructions update: 不要。このPRでは Custom GPT instructions を変更しない。
- iPhone Butler live E2E: required after deploy: /dashboard live smoke が必要。

## Related Constitution Rules

- Butler Completion Gate\nButler-First Operating Principle\nAuthority Boundary\nEvidence Discipline\nChange Size and PR Discipline

## Out-of-scope but NOT implemented

- v3 Worker deletion。\nReact/PWA chat UI。\nGitHub App installation automation。\nGemini reviewer loop migration。\nCustom GPT Action Schema 更新。

## Extra changes (if any)

worker.js は npm run build:worker により src/worker/runtime.js から再生成。

<!-- VTDD metadata -->
- Issue: Issue #428
- Execution ID: mac-codex-issue-428-v2-dashboard
- Goal: v2-p Worker に dashboard surface を追加する
