### PR TITLE
passkey approval を高リスク操作の署名付き GO にする

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -3,10 +3,6 @@ name: deploy-production
 on:
   workflow_dispatch:
     inputs:
-      approval_phrase:
-        description: "Type GO to approve production deploy"
-        required: true
-        type: string
       runtime_url:
         description: "Worker runtime URL used to validate the real passkey approval grant"
         required: true
@@ -30,13 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     steps:
-      - name: Enforce GO + passkey boundary
+      - name: Enforce passkey approval boundary
         shell: bash
         run: |
-          if [ "${{ github.event.inputs.approval_phrase }}" != "GO" ]; then
-            echo "Approval phrase must be GO for production deploy."
-            exit 1
-          fi
           if [ -z "${{ github.event.inputs.runtime_url }}" ]; then
             echo "runtime_url is required for production deploy."
             exit 1
@@ -72,7 +64,7 @@ jobs:
             missing=1
           fi
           if [ "$missing" -ne 0 ]; then
-            echo "Configure the missing secrets before requesting GO + passkey for production deploy."
+            echo "Configure the missing secrets before requesting passkey approval for production deploy."
             exit 1
           fi
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,7 +92,7 @@ That delegation does not allow:
 - changing the scoped Issue set by assumption
 - declaring milestone-complete by implication
 - deploy, credential mutation, permission mutation, or destructive operation
-  without `GO + passkey`
+  without scoped passkey approval
 
 ## Canonical Source Order
 
@@ -252,7 +252,9 @@ MVP completion claim is allowed only when the matrix shows complete coverage for
 - Alias-based repository resolution exists.
 - No default repository.
 - Unresolved target blocks execution.
-- High-risk actions require GO + passkey.
+- High-risk actions require scoped passkey approval. A real same-origin
+  approval grant whose page displayed the action scope is treated as signed GO
+  for that one high-risk execution.
 - Merge, post-merge Issue closure, and merged-branch deletion require explicit
   `GO`, not silent inference.
 - Credential model is GitHub App.
@@ -304,8 +306,9 @@ inside an explicitly stated contract. Stop when:
   merge, post-merge Issue closure, and merged-branch deletion.
 - `GO` does not authorize deploy, credential mutation, permission mutation, or
   destructive/high-blast-radius operations.
-- `GO + passkey` is required for deploy, credential mutation, permission
-  mutation, destructive operations, and other high-risk external effects.
+- scoped passkey approval is required for deploy, credential mutation,
+  permission mutation, destructive operations, and other high-risk external
+  effects.
 - Issue closure is allowed only after merge and only when scoped criteria,
   tests, and mapped E2E evidence are all present.
 - Merged-branch deletion is allowed only for the branch merged by that scoped
@@ -313,7 +316,7 @@ inside an explicitly stated contract. Stop when:
 - GitHub-side approval boundaries are canonicalized in
   `docs/security/consent-approval-model.md`.
 - Treat GitHub App capability as execution ability, not as standing permission.
-- Require `GO + passkey` for GitHub-side secret/variable mutation, GitHub App
+- Require scoped passkey approval for GitHub-side secret/variable mutation, GitHub App
   install or permission mutation, repository settings mutation, ruleset/branch
   protection mutation, collaborator mutation, repository archive/delete/transfer,
   and destructive cleanup outside the bounded post-merge path.

--- a/docs/architecture/vtdd-mcp-ver.md
+++ b/docs/architecture/vtdd-mcp-ver.md
@@ -227,7 +227,7 @@ The same operation classes apply regardless of surface:
 - permission mutation
 - destructive external changes
 
-High-risk operations remain `GO + passkey`.
+High-risk operations remain governed by scoped passkey approval.
 
 Butler, Mac Codex, and VPS Codex CLI must converge on the same capability
 registry. MCP is not permanently read-only. It simply must not skip governance.

--- a/docs/butler/capability-matrix.md
+++ b/docs/butler/capability-matrix.md
@@ -132,7 +132,7 @@ passkey operator, prefer that route over a Mac-only instruction.
 4. Codex fallback reviewer contract: Gemini/Codex, requested/completed/blocked (#156)
 5. Reviewer evidence aggregation: requested/completed/blocked without overclaiming
 6. Surface update guidance: Instructions/Action Schema/Cloudflare deploy links
-7. High-risk operator flows: merge/deploy/issue close under GO + passkey
+7. High-risk operator flows: merge/deploy/issue close under scoped passkey approval
 
 ## Completion Rule
 

--- a/docs/mvp/deploy-authority-branching.md
+++ b/docs/mvp/deploy-authority-branching.md
@@ -24,7 +24,7 @@ Production deploy must remain a VTDD-governed high-risk action.
 
 Required invariants:
 
-- deploy requires `GO + passkey`
+- deploy requires scoped passkey approval
 - deploy authority must be short-lived or one-shot
 - GitHub Actions must not require permanent production deploy authority
 - a mistaken push to `main` must not immediately imply production deploy
@@ -60,7 +60,7 @@ Important:
 
 Flow:
 
-1. Operator gives `GO + passkey`
+1. Operator completes scoped passkey approval
 2. VTDD mints or injects one-shot deploy credential
 3. VTDD triggers a deploy-only workflow
 4. credential expires immediately after the run
@@ -80,7 +80,7 @@ Cons:
 
 Flow:
 
-1. Operator gives `GO + passkey`
+1. Operator completes scoped passkey approval
 2. VTDD obtains short-lived provider credential
 3. VTDD deploys directly to Cloudflare Workers
 

--- a/docs/mvp/machine-auth-path.md
+++ b/docs/mvp/machine-auth-path.md
@@ -56,4 +56,4 @@ Cloudflare Access service token mode is a valid fallback when bearer auth cannot
 - Least privilege
   - only grant scopes required for API invocation path
   - keep `/setup/*` and browser-auth path separate from machine-auth API path
-  - keep high-risk execution controls (`GO + passkey`) unchanged
+  - keep high-risk execution controls (scoped passkey approval) unchanged

--- a/docs/mvp/production-deploy-path.md
+++ b/docs/mvp/production-deploy-path.md
@@ -45,8 +45,8 @@ Production must bind the VTDD memory D1 database as `VTDD_MEMORY_D1`.
 
 This binding is required for real passkey registration, approval challenge
 persistence, and approval grant retrieval. A production deploy that drops this
-binding breaks `GO + passkey` issuance and therefore blocks high-risk runtime
-operations.
+binding breaks scoped passkey approval issuance and therefore blocks high-risk
+runtime operations.
 
 Because this repository is public and reusable, owner-specific Cloudflare
 resource identifiers must not be committed to the shared `wrangler.toml`.
@@ -72,20 +72,18 @@ includes the run URL and deployed commit SHA, and intentionally omits approval
 grant ids, tokens, and other secret values. If the variable is absent,
 the deploy still runs and the mention notification is skipped.
 
-## Approval Boundary (`GO + passkey`)
+## Approval Boundary (scoped passkey approval)
 
 `deploy-production` workflow is manual (`workflow_dispatch`) and requires:
 
-- `approval_phrase=GO`
 - `runtime_url=<user-owned worker runtime>`
 - `approval_grant_id=<real passkey approval grant id>`
 - environment approval on `production`
 
 This encodes the MVP high-risk policy as:
 
-1. explicit GO phrase
-2. real WebAuthn/passkey approval grant validated against the worker runtime
-3. protected environment confirmation
+1. real WebAuthn/passkey approval grant validated against the worker runtime
+2. protected environment confirmation
 
 The workflow validates the grant through `/v2/retrieve/approval-grant` using
 `VTDD_GATEWAY_BEARER_TOKEN`, and the grant scope must match:

--- a/docs/security/consent-approval-model.md
+++ b/docs/security/consent-approval-model.md
@@ -31,10 +31,13 @@ action on this specific scope proceed now?"
 
 - Consent and approval are separate checks.
 - `destructive` is the highest-risk consent category.
-- `approvalPhrase` is required whenever approval level is not `none`.
+- `approvalPhrase` is required for `go` approval.
 - Approval must be bound to the target scope.
-- High-risk operations require `GO + passkey`.
-- Merge and bounded post-merge completion tasks require explicit `GO + passkey`.
+- High-risk operations require a real, scoped passkey approval grant.
+- A real passkey approval grant includes scope confirmation and user
+  authentication, so it acts as signed `GO` for that one high-risk execution.
+- Merge and bounded post-merge completion tasks require explicit scoped passkey
+  approval.
 
 ## Canonical Action Mapping
 
@@ -76,7 +79,7 @@ level as `merge`:
 - deletion of the merged topic branch tied to that PR
 
 These tasks are not authorized by category consent alone and must not be
-inferred without explicit scoped `GO + passkey`.
+inferred without explicit scoped passkey approval.
 
 ## GitHub Operation Matrix
 
@@ -95,10 +98,11 @@ Bounded repository workflow operations may proceed with explicit scoped `GO`:
 - PR comment and scoped review iteration
 - deletion of the merged topic branch tied to that scoped PR
 
-### `GO + passkey`
+### `passkey approval`
 
 High-risk or administration-bearing GitHub operations require explicit scoped
-`GO + passkey`:
+passkey approval. The passkey page must show the action, repository, relevant
+Issue / PR, impact scope, and expiry before the user approves:
 
 - merge, when scoped criteria, tests, and mapped E2E evidence are present
 - post-merge issue close for the scoped work
@@ -122,14 +126,15 @@ alone, even when the GitHub App technically has the capability:
 - milestone completion judgment
 - issue closure without bounded scope linkage to the merged work
 - repository administration or permission mutation without explicit high-risk approval
-- destructive operation without explicit scoped `GO + passkey`
+- destructive operation without explicit scoped passkey approval
 - broad cleanup outside the currently scoped branch / PR / issue window
 - policy reinterpretation from "the app can do it" to "the app may do it now"
 
 ## Destructive Handling
 
 - Destructive operations must pass the `destructive` consent category.
-- Destructive operations require `go_passkey`.
+- Destructive operations require `go_passkey`, satisfied by a real scoped
+  passkey approval grant.
 - Scope binding is mandatory.
 - Destructive execution must not proceed from category consent alone.
 

--- a/docs/security/github-app-actor-identity.md
+++ b/docs/security/github-app-actor-identity.md
@@ -38,7 +38,7 @@ permission to act.
   mutation, and destructive operations still follow the repository authority
   boundary in `AGENTS.md` and `docs/security/consent-approval-model.md`.
 - GitHub App installation, permission, and Actions secret mutation require
-  `GO + passkey`.
+  scoped passkey approval.
 
 ## Secret Registration Boundary
 
@@ -47,7 +47,7 @@ them. Registering or updating those secrets is a high-risk external effect and
 is not completed by code changes alone.
 
 Before production use, the owner must approve syncing the App IDs and private
-keys into GitHub Actions secrets with `GO + passkey`.
+keys into GitHub Actions secrets with scoped passkey approval.
 
 Until the new secrets are configured:
 

--- a/docs/security/go-passkey-approval-model.md
+++ b/docs/security/go-passkey-approval-model.md
@@ -1,4 +1,4 @@
-# GO + Passkey Approval Model
+# Passkey Approval Model
 
 This document focuses on the highest-risk approval path.
 For the full canonical consent / approval model, see
@@ -6,14 +6,15 @@ For the full canonical consent / approval model, see
 
 ## Intent
 
-High-risk actions should require both explicit intent and strong user authentication.
+High-risk actions should require explicit scoped intent and strong user authentication.
 Merge and bounded post-merge completion tasks are part of the high-risk set and
-must follow the same `GO + passkey` path as other authority-bearing actions.
+must follow the same scoped passkey approval path as other authority-bearing
+actions.
 
 ## Drift Note
 
-Historically, the repo used phrase-based `passkey` confirmation inside policy
-payloads. That phrase gate is not itself a real passkey ceremony.
+Historically, the repo used phrase-based `GO + passkey` confirmation inside
+policy payloads. That phrase gate is not itself a real passkey ceremony.
 
 The executable runtime path for real WebAuthn/passkey verification is tracked in
 [webauthn-passkey-runtime.md](./webauthn-passkey-runtime.md).
@@ -47,11 +48,11 @@ Requires `GO`.
 - destructive actions
 - external publish
 
-Requires `GO + passkey`.
+Requires scoped passkey approval.
 
 ## GitHub-side High-risk Examples
 
-When the execution surface is GitHub, `GO + passkey` includes at least:
+When the execution surface is GitHub, scoped passkey approval covers at least:
 
 - pull request merge
 - bounded issue close for the scoped merged work
@@ -65,11 +66,11 @@ When the execution surface is GitHub, `GO + passkey` includes at least:
   the bounded post-merge cleanup path
 
 These operations may be technically possible for the GitHub App, but VTDD must
-still block them until explicit scoped `GO + passkey` succeeds.
+still block them until explicit scoped passkey approval succeeds.
 
 ## Never-auto Boundary
 
-`GO + passkey` is a required unlock for high-risk execution, but it does not
+Scoped passkey approval is a required unlock for high-risk execution, but it does not
 convert GitHub state changes into auto-permitted behavior. VTDD must still
 forbid automatic:
 
@@ -80,17 +81,18 @@ forbid automatic:
 
 ## Approval Components
 
-- `GO` confirms human intent.
-- `passkey` confirms user identity.
+- the passkey approval screen confirms human intent by showing the exact scope
+  before approval
+- `passkey` confirms user identity
 - a short-lived credential enables the action.
 
 ## Required High-risk Flow
 
 1. Resolve target repository and action.
 2. Summarize impact.
-3. Receive `GO`.
+3. Show the exact approval scope on the same-origin passkey page.
 4. Complete passkey approval.
-5. Mint short-lived credential.
+5. Mint short-lived approval grant / credential.
 6. Execute once.
 7. Write audit log.
 
@@ -102,5 +104,5 @@ It should work with iPhone, iPad, Android, web, and future native clients throug
 ## Non-goals
 
 - requiring passkey for every action,
-- allowing passkey without `GO`,
+- allowing passkey approval without visible scope,
 - tying approval to a single platform vendor.

--- a/docs/security/guarded-semi-automation-mode.md
+++ b/docs/security/guarded-semi-automation-mode.md
@@ -8,7 +8,7 @@ ambiguous or high-risk execution.
 
 - `normal`
   - standard execution policy flow
-  - high-risk actions still require `GO + passkey`
+  - high-risk actions still require scoped passkey approval
 - `guarded_absence`
   - constrained autopilot mode for operator absence
   - execution is allowed only for explicitly low-risk operations
@@ -54,8 +54,8 @@ If runtime forces `guarded_absence`, request payload override is ignored.
 - `destructive`
 - `external_publish`
 
-High-risk actions remain forbidden in guarded absence mode even if `GO + passkey`
-is present.
+High-risk actions remain forbidden in guarded absence mode even if scoped
+passkey approval is present.
 
 ## Mandatory Stop Boundaries in `guarded_absence`
 

--- a/docs/security/webauthn-passkey-runtime.md
+++ b/docs/security/webauthn-passkey-runtime.md
@@ -15,6 +15,11 @@ High-risk operations must be unlocked through a real WebAuthn/passkey
 challenge, verified by the worker runtime, and converted into a short-lived
 approval grant that Butler can use on the next high-risk request.
 
+When the same-origin approval page clearly displays the target scope before
+the user approves, that real passkey approval grant is treated as signed `GO`
+for that one scoped high-risk execution. Butler should not ask for a separate
+chat `GO` after the scoped passkey ceremony succeeds.
+
 ## Current Endpoints
 
 - `POST /v2/approval/passkey/register/options`

--- a/docs/setup/custom-gpt-actions-openapi.json
+++ b/docs/setup/custom-gpt-actions-openapi.json
@@ -1461,7 +1461,7 @@
     "/v2/action/github-authority": {
       "post": {
         "operationId": "vtddGitHubAuthority",
-        "summary": "Execute approval-bound GitHub authority actions that require GO plus real passkey.",
+        "summary": "Execute approval-bound GitHub authority actions that require scoped passkey approval.",
         "requestBody": {
           "required": true,
           "content": {
@@ -1573,7 +1573,7 @@
     "/v2/action/deploy": {
       "post": {
         "operationId": "vtddDeployProduction",
-        "summary": "Dispatch governed production deploy after GO plus real passkey approval.",
+        "summary": "Dispatch governed production deploy after scoped passkey approval approval.",
         "requestBody": {
           "required": true,
           "content": {
@@ -1651,7 +1651,7 @@
     "/v2/action/github-actions-secret": {
       "post": {
         "operationId": "vtddSyncGitHubActionsSecret",
-        "summary": "Sync an approved GitHub Actions secret such as OPENAI_API_KEY or VTDD_GATEWAY_BEARER_TOKEN after GO plus real passkey approval.",
+        "summary": "Sync an approved GitHub Actions secret such as OPENAI_API_KEY or VTDD_GATEWAY_BEARER_TOKEN after scoped passkey approval approval.",
         "requestBody": {
           "required": true,
           "content": {

--- a/docs/setup/custom-gpt-actions-openapi.yaml
+++ b/docs/setup/custom-gpt-actions-openapi.yaml
@@ -992,7 +992,7 @@ paths:
   /v2/action/github-authority:
     post:
       operationId: vtddGitHubAuthority
-      summary: Execute approval-bound GitHub authority actions that require GO plus real passkey.
+      summary: Execute approval-bound GitHub authority actions that require scoped passkey approval.
       requestBody:
         required: true
         content:
@@ -1065,7 +1065,7 @@ paths:
   /v2/action/deploy:
     post:
       operationId: vtddDeployProduction
-      summary: Dispatch governed production deploy after GO plus real passkey approval.
+      summary: Dispatch governed production deploy after scoped passkey approval approval.
       requestBody:
         required: true
         content:
@@ -1114,7 +1114,7 @@ paths:
   /v2/action/github-actions-secret:
     post:
       operationId: vtddSyncGitHubActionsSecret
-      summary: Sync an approved GitHub Actions secret such as OPENAI_API_KEY or VTDD_GATEWAY_BEARER_TOKEN after GO plus real passkey approval.
+      summary: Sync an approved GitHub Actions secret such as OPENAI_API_KEY or VTDD_GATEWAY_BEARER_TOKEN after scoped passkey approval approval.
       requestBody:
         required: true
         content:

--- a/docs/setup/custom-gpt-instructions-short.md
+++ b/docs/setup/custom-gpt-instructions-short.md
@@ -79,8 +79,8 @@ Review loop:
 - `vtdd:incident=actor_identity_failure`: recovery blocker; explain role/PR in Japanese; never count `marushu` substitute as review done.
 - If no review evidence, say so.
 Approval boundaries:
-- High-risk actions require GO + passkey.
-- Merge requires explicit human GO + real passkey.
+- High-risk actions require scoped passkey approval.
+- Merge requires explicit scoped passkey approval.
 - Do not silently infer approval from context.
 Forbidden behavior:
 - Do not assume a default repository.

--- a/docs/setup/custom-gpt-instructions.md
+++ b/docs/setup/custom-gpt-instructions.md
@@ -422,7 +422,7 @@ Review loop:
   - reviewer comments
   - unresolved reviewer objections
   - whether the PR changed after the last review
-- If reviewer objections remain unresolved, do not recommend merge GO + real passkey.
+- If reviewer objections remain unresolved, do not recommend merge passkey approval.
 - If no reviewer evidence exists yet, say so plainly.
 - For Gemini reviewer evidence, always show the marker comment URL and current `Recommended action`.
 - Gemini reruns append a new timestamped marker comment; use the latest trusted marker for the relevant PR head SHA as the current reviewer judgment, and keep older markers as historical evidence.
@@ -432,9 +432,9 @@ Review loop:
 - Prefer vtddRetrieveGitHub for PR state, reviews, review comments, checks, workflow runs, and branches when those facts are needed for a summary.
 
 Approval boundaries:
-- High-risk actions require GO + passkey.
-- Merge requires explicit human GO + real passkey.
-- Deploy, secret mutation, permission mutation, destructive actions, and similar high-risk operations require GO + passkey.
+- High-risk actions require scoped passkey approval.
+- Merge requires explicit scoped passkey approval.
+- Deploy, secret mutation, permission mutation, destructive actions, and similar high-risk operations require scoped passkey approval.
 - Do not silently infer approval from context.
 
 Forbidden behavior:

--- a/docs/setup/github-app-secret-sync.md
+++ b/docs/setup/github-app-secret-sync.md
@@ -43,7 +43,7 @@ This is a high-risk operation because it mutates repository secrets.
 - it is not background automation
 - it is not normal Butler runtime
 - it must remain an explicit operator bootstrap step
-- it follows the current `GO + passkey` high-risk boundary
+- it follows the current scoped passkey approval high-risk boundary
 
 ## Dry-run First
 

--- a/docs/vision/vtdd-v2-overview.md
+++ b/docs/vision/vtdd-v2-overview.md
@@ -84,7 +84,7 @@ But none of these define the essence of VTDD V2.
 - alias/context-first repository resolution
 - no default repository
 - unresolved target blocks execution
-- high-risk actions require `GO + passkey`
+- high-risk actions require scoped passkey approval
 - reviewer is a blocking risk signal, not an executor
 - mobile-first operation should not require pasting secrets into chat answers
 

--- a/src/core/approval.js
+++ b/src/core/approval.js
@@ -96,6 +96,36 @@ export function evaluateApproval({
     };
   }
 
+  if (required === ApprovalLevel.GO_PASSKEY) {
+    const grantResult = evaluateApprovalGrant({
+      approvalGrant,
+      scope: approvalScope
+    });
+    if (grantResult.ok) {
+      return { ok: true, required };
+    }
+
+    const phrase = normalize(approvalPhrase);
+    if (!phrase) {
+      return {
+        ok: false,
+        required,
+        reason: grantResult.reason || "real scoped passkey approval grant is required"
+      };
+    }
+
+    if (go && passkey) {
+      return { ok: true, required };
+    }
+    return {
+      ok: false,
+      required,
+      reason: passkey
+        ? "high-risk action requires real scoped passkey approval or legacy explicit GO phrase plus passkey flag"
+        : grantResult.reason || "real scoped passkey approval grant is required"
+    };
+  }
+
   const phrase = normalize(approvalPhrase);
   if (!phrase) {
     return {
@@ -114,20 +144,6 @@ export function evaluateApproval({
           reason: "explicit GO is required before execution"
         };
   }
-  const grantResult = evaluateApprovalGrant({
-    approvalGrant,
-    scope: approvalScope
-  });
-  if (go && (passkey || grantResult.ok)) {
-    return { ok: true, required };
-  }
-  return {
-    ok: false,
-    required,
-    reason: passkey
-      ? "high-risk action requires GO + passkey"
-      : grantResult.reason || "high-risk action requires GO + passkey"
-  };
 }
 
 function normalize(value) {

--- a/src/core/deploy-production-plane.js
+++ b/src/core/deploy-production-plane.js
@@ -9,7 +9,6 @@ const DEFAULT_DEPLOY_WORKFLOW_REF = "main";
 export async function executeDeployProductionPlane(input = {}) {
   const repository = normalizeText(input.repository);
   const runtimeUrl = normalizeText(input.runtimeUrl);
-  const approvalPhrase = normalizeText(input.approvalPhrase);
   const approvalGrant = input.approvalGrant ?? null;
   const approvalGrantId =
     normalizeText(input.approvalGrantId) || normalizeText(approvalGrant?.approvalId);
@@ -20,7 +19,6 @@ export async function executeDeployProductionPlane(input = {}) {
   const validation = validateDeployProductionRequest({
     repository,
     runtimeUrl,
-    approvalPhrase,
     approvalGrant,
     approvalGrantId
   });
@@ -66,7 +64,6 @@ export async function executeDeployProductionPlane(input = {}) {
   const dispatchBody = {
     ref: workflowRef,
     inputs: {
-      approval_phrase: "GO",
       runtime_url: runtimeUrl,
       approval_grant_id: approvalGrantId
     }
@@ -217,7 +214,6 @@ async function verifyDeployWorkflowRun({
 function validateDeployProductionRequest({
   repository,
   runtimeUrl,
-  approvalPhrase,
   approvalGrant,
   approvalGrantId
 }) {
@@ -227,9 +223,6 @@ function validateDeployProductionRequest({
   }
   if (!runtimeUrl) {
     issues.push("runtimeUrl is required");
-  }
-  if (approvalPhrase !== "GO") {
-    issues.push("approvalPhrase must be GO");
   }
   if (!approvalGrantId) {
     issues.push("approvalGrantId is required");

--- a/src/core/github-high-risk-plane.js
+++ b/src/core/github-high-risk-plane.js
@@ -24,7 +24,6 @@ export async function executeGitHubHighRiskPlane(input = {}) {
   const mergeMethod = normalizeMergeMethod(input.mergeMethod);
   const commitTitle = normalizeText(input.commitTitle);
   const commitMessage = normalizeBody(input.commitMessage);
-  const approvalPhrase = normalizeText(input.approvalPhrase);
   const targetConfirmed = input.targetConfirmed === true;
   const approvalScope = input.approvalScope ?? null;
   const approvalGrant = input.approvalGrant ?? null;
@@ -38,7 +37,6 @@ export async function executeGitHubHighRiskPlane(input = {}) {
     issueNumber,
     pullNumber,
     mergeMethod,
-    approvalPhrase,
     targetConfirmed,
     approvalGrant,
     approvalScope
@@ -106,9 +104,6 @@ function validateGitHubHighRiskRequest(input) {
 
   if (!input.targetConfirmed) {
     issues.push("targetConfirmed must be true");
-  }
-  if (normalizeText(input.approvalPhrase).toUpperCase() !== "GO") {
-    issues.push("approvalPhrase must be GO");
   }
   if (
     input.operation === GitHubHighRiskOperation.PULL_MERGE &&

--- a/src/core/github-owner-operation-inventory.js
+++ b/src/core/github-owner-operation-inventory.js
@@ -44,7 +44,7 @@ export const GitHubOwnerOperationInventory = Object.freeze([
     status: GitHubOwnerOperationStatus.UNSUPPORTED,
     requiredGitHubAppPermission: "issues:write",
     requiredButlerActionSurface: "github_write.issue_update",
-    requiredPasskeyOperatorBoundary: "exact payload + human GO for bounded edits; GO + passkey when closing after merge",
+    requiredPasskeyOperatorBoundary: "exact payload + human GO for bounded edits; scoped passkey approval when closing after merge",
     runtimeTruthVerificationMethod: "PATCH /repos/{owner}/{repo}/issues/{issue_number} then read back changed fields",
     remediationIssue: ISSUE_244
   },
@@ -54,7 +54,7 @@ export const GitHubOwnerOperationInventory = Object.freeze([
     status: GitHubOwnerOperationStatus.GATED,
     requiredGitHubAppPermission: "issues:write and pull_requests:read",
     requiredButlerActionSurface: "github_high_risk.issue_close",
-    requiredPasskeyOperatorBoundary: "explicit GO + real passkey/operator approval",
+    requiredPasskeyOperatorBoundary: "scoped passkey approval",
     runtimeTruthVerificationMethod: "verify PR merged_at, PATCH issue state=closed, then read issue state",
     remediationIssue: null
   },
@@ -74,7 +74,7 @@ export const GitHubOwnerOperationInventory = Object.freeze([
     status: GitHubOwnerOperationStatus.UNSUPPORTED,
     requiredGitHubAppPermission: "issues:write",
     requiredButlerActionSurface: "github_write.issue_comment_delete",
-    requiredPasskeyOperatorBoundary: "GO + passkey/operator approval when deletion is destructive or evidence-bearing",
+    requiredPasskeyOperatorBoundary: "scoped passkey approval when deletion is destructive or evidence-bearing",
     runtimeTruthVerificationMethod: "DELETE /repos/{owner}/{repo}/issues/comments/{comment_id} then verify comment is absent/tombstoned",
     remediationIssue: ISSUE_244
   },
@@ -104,7 +104,7 @@ export const GitHubOwnerOperationInventory = Object.freeze([
     status: GitHubOwnerOperationStatus.UNSUPPORTED,
     requiredGitHubAppPermission: "pull_requests:write and issues:write",
     requiredButlerActionSurface: "github_write.pull_state_update",
-    requiredPasskeyOperatorBoundary: "exact payload + human GO; GO + passkey for destructive state transitions if policy marks high-risk",
+    requiredPasskeyOperatorBoundary: "exact payload + human GO; scoped passkey approval for destructive state transitions if policy marks high-risk",
     runtimeTruthVerificationMethod: "PATCH /pulls/{pull_number} or related PR endpoints, then read PR state",
     remediationIssue: ISSUE_244
   },
@@ -114,7 +114,7 @@ export const GitHubOwnerOperationInventory = Object.freeze([
     status: GitHubOwnerOperationStatus.GATED,
     requiredGitHubAppPermission: "pull_requests:write",
     requiredButlerActionSurface: "github_high_risk.pull_ready_for_review",
-    requiredPasskeyOperatorBoundary: "explicit GO + real passkey/operator approval",
+    requiredPasskeyOperatorBoundary: "scoped passkey approval",
     runtimeTruthVerificationMethod: "read draft=true, GraphQL markPullRequestReadyForReview, then verify isDraft=false",
     remediationIssue: null
   },
@@ -124,7 +124,7 @@ export const GitHubOwnerOperationInventory = Object.freeze([
     status: GitHubOwnerOperationStatus.GATED,
     requiredGitHubAppPermission: "pull_requests:write and contents:write",
     requiredButlerActionSurface: "github_high_risk.pull_merge",
-    requiredPasskeyOperatorBoundary: "explicit GO + real passkey/operator approval",
+    requiredPasskeyOperatorBoundary: "scoped passkey approval",
     runtimeTruthVerificationMethod: "PUT /pulls/{pull_number}/merge then read merged_at and merge_commit_sha",
     remediationIssue: null
   },
@@ -144,7 +144,7 @@ export const GitHubOwnerOperationInventory = Object.freeze([
     status: GitHubOwnerOperationStatus.UNSUPPORTED,
     requiredGitHubAppPermission: "contents:write",
     requiredButlerActionSurface: "github_write.branch_ref_update_delete",
-    requiredPasskeyOperatorBoundary: "exact payload + human GO for scoped ref update; deletion only for merged scoped branch or GO + passkey if destructive",
+    requiredPasskeyOperatorBoundary: "exact payload + human GO for scoped ref update; deletion only for merged scoped branch or scoped passkey approval if destructive",
     runtimeTruthVerificationMethod: "PATCH/DELETE git refs, then read branch/ref absence or updated sha",
     remediationIssue: ISSUE_244
   },
@@ -154,7 +154,7 @@ export const GitHubOwnerOperationInventory = Object.freeze([
     status: GitHubOwnerOperationStatus.UNSUPPORTED,
     requiredGitHubAppPermission: "actions:write and actions:read",
     requiredButlerActionSurface: "github_actions.workflow_governed_control",
-    requiredPasskeyOperatorBoundary: "exact payload + human GO for bounded dispatch/rerun; GO + passkey for cancel/destructive cleanup",
+    requiredPasskeyOperatorBoundary: "exact payload + human GO for bounded dispatch/rerun; scoped passkey approval for cancel/destructive cleanup",
     runtimeTruthVerificationMethod: "workflow dispatch/cancel/rerun API then read run status, conclusion, URL, and artifact state",
     remediationIssue: ISSUE_244
   },
@@ -184,7 +184,7 @@ export const GitHubOwnerOperationInventory = Object.freeze([
     status: GitHubOwnerOperationStatus.GATED,
     requiredGitHubAppPermission: "secrets:write, variables:write, actions:write, environments:write as applicable",
     requiredButlerActionSurface: "github_actions_secret_sync and github_admin.variable_governed_change",
-    requiredPasskeyOperatorBoundary: "explicit GO + real passkey/operator approval; never expose raw secret material",
+    requiredPasskeyOperatorBoundary: "scoped passkey approval; never expose raw secret material",
     runtimeTruthVerificationMethod: "encrypted secret/variable write result plus metadata readback without raw value",
     remediationIssue: null
   },
@@ -194,7 +194,7 @@ export const GitHubOwnerOperationInventory = Object.freeze([
     status: GitHubOwnerOperationStatus.UNSUPPORTED,
     requiredGitHubAppPermission: "contents:write and packages:write where applicable",
     requiredButlerActionSurface: "github_release.governed_release_control",
-    requiredPasskeyOperatorBoundary: "exact payload + human GO for draft metadata; GO + passkey for publish/delete",
+    requiredPasskeyOperatorBoundary: "exact payload + human GO for draft metadata; scoped passkey approval for publish/delete",
     runtimeTruthVerificationMethod: "release/tag/package API mutation then read release/tag/package state and URL",
     remediationIssue: ISSUE_244
   },

--- a/src/core/help-guide-page.js
+++ b/src/core/help-guide-page.js
@@ -66,7 +66,7 @@ export function renderVtddHelpGuidePage(input = {}) {
         <div class="panel"><strong>Repository resolution</strong>alias / nickname / GitHub App repository index で対象を解決します。default repository はありません。</div>
         <div class="panel"><strong>GitHub read plane</strong>repository、Issue、PR、review、checks、workflow runs、branch state を Butler が読める runtime truth として返します。</div>
         <div class="panel"><strong>GitHub write plane</strong>コメント、PR更新、runner queue など通常 write を approval boundary に沿って実行します。</div>
-        <div class="panel"><strong>High-risk authority plane</strong>merge、Issue close、secret sync、deploy など高リスク操作は GO + passkey または明示的な禁止境界を通ります。</div>
+        <div class="panel"><strong>High-risk authority plane</strong>merge、Issue close、secret sync、deploy など高リスク操作は scoped passkey approval または明示的な禁止境界を通ります。</div>
         <div class="panel"><strong>Runner / reviewer loop</strong>Butler -> Codex runner -> PR -> reviewer -> Butler summary の GitHub-visible loop を扱います。</div>
         <div class="panel"><strong>Memory / retrieval</strong>constitution、decision log、proposal log、operational memory を読んで判断の前提を復元します。</div>
         <div class="panel"><strong>MCP read surface</strong>Mac Codex / VPS Codex CLI は <code>${escapeHtml(mcpPath)}</code> を通じて Butler と同じ runtime truth / review truth / memory recall を読みます。</div>
@@ -94,7 +94,7 @@ export function renderVtddHelpGuidePage(input = {}) {
         <div class="panel"><strong>PRを直したい</strong>Butler が reviewer comment と PR state を読み、revise_pr として runner に渡せるか確認します。</div>
         <div class="panel"><strong>mergeしたい</strong>Butler が checks、reviewer signal、mergeability、Issue evidence を確認し、必要な approval boundary を提示します。</div>
         <div class="panel"><strong>Action Schema が壊れた</strong>この runtime の setup/recovery page を直接開き、known-good または latest bundle をコピーします。</div>
-        <div class="panel"><strong>deployやsecret更新をしたい</strong>GO + passkey と対象 scope が必要です。Worker は secret 値をこのページに表示しません。</div>
+        <div class="panel"><strong>deployやsecret更新をしたい</strong>対象 scope が表示された passkey approval が必要です。Worker は secret 値をこのページに表示しません。</div>
       </div>
     </section>
 
@@ -102,7 +102,7 @@ export function renderVtddHelpGuidePage(input = {}) {
       <h2>権限境界</h2>
       <div class="route"><strong>Allowed without GO</strong>読み取り、状態確認、説明、proposal、低リスクな案内。実行能力とは区別します。</div>
       <div class="route"><strong>GO required</strong>bounded implementation dispatch、通常 write、PR review/comment など、Issue scope と runtime truth に接続された操作。</div>
-      <div class="route"><strong>GO + passkey required</strong>deploy、credential mutation、permission mutation、high-risk GitHub operation、destructive/high-blast-radius operation。</div>
+      <div class="route"><strong>passkey approval required</strong>deploy、credential mutation、permission mutation、high-risk GitHub operation、destructive/high-blast-radius operation。</div>
       <div class="route"><strong>Forbidden / stop</strong>対象 repo 未解決、Issue traceability 不足、owner-specific runtime 依存、secret 表示、scope conflict、reviewer objection の楽観的な無視。</div>
     </section>
 
@@ -206,7 +206,7 @@ export function buildVtddCloudflarePageDirectory(input = {}) {
       label: "Passkey operator",
       path: "/v2/approval/passkey/operator",
       url: buildRuntimeUrl(runtimeOrigin, "/v2/approval/passkey/operator"),
-      description: "GO + passkey が必要な deploy、merge、secret sync などの operator helper です。",
+      description: "scope 明示済み passkey approval が必要な deploy、merge、secret sync などの operator helper です。",
       audience: ["owner", "operator"],
       authority: "go_plus_passkey_required_for_execution"
     },

--- a/src/core/passkey-operator-page.js
+++ b/src/core/passkey-operator-page.js
@@ -683,7 +683,6 @@ export function renderPasskeyOperatorPage(input = {}) {
               repository: repositoryInput,
               issueNumber: Number(document.getElementById("issue-input").value || 0) || null,
               policyInput: {
-                approvalPhrase: "GO",
                 approvalGrantId: latestApprovalGrantId
               }
             })
@@ -718,7 +717,6 @@ export function renderPasskeyOperatorPage(input = {}) {
                 issueNumber: Number(document.getElementById("issue-input").value || 0) || null
               },
               policyInput: {
-                approvalPhrase: "GO",
                 approvalGrantId: latestApprovalGrantId,
                 targetConfirmed: true
               }
@@ -753,7 +751,6 @@ export function renderPasskeyOperatorPage(input = {}) {
                 issueNumber: Number(document.getElementById("issue-input").value || 0) || null
               },
               policyInput: {
-                approvalPhrase: "GO",
                 approvalGrantId: latestApprovalGrantId,
                 targetConfirmed: true
               }
@@ -789,7 +786,6 @@ export function renderPasskeyOperatorPage(input = {}) {
                 issueNumber: Number(document.getElementById("issue-input").value || 0) || null
               },
               policyInput: {
-                approvalPhrase: "GO",
                 approvalGrantId: latestApprovalGrantId,
                 targetConfirmed: true
               }

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -4937,7 +4937,7 @@ function renderV2DashboardPage({ runtimeOrigin }) {
     },
     {
       title: "Deploy passkey operator",
-      body: "production deploy は GO + passkey の後ろ。approval grant や secret は dashboard に保存しない。",
+      body: "production deploy は scope 明示済み passkey approval の後ろ。approval grant や secret は dashboard に保存しない。",
       href: `${origin}/v2/approval/passkey/operator?repositoryInput=${encodedRepository}&phase=execution&actionType=deploy_production&highRiskKind=deploy_production`
     }
   ];
@@ -5016,7 +5016,7 @@ function renderV2DashboardPage({ runtimeOrigin }) {
 
     <section class="panel danger">
       <h2>v3 Worker の扱い</h2>
-      <p><code>vtdd-v3-orchestrator.polished-tree-da7c.workers.dev</code> は prototype として残します。削除は Cloudflare Worker deletion なので destructive operation です。実行する場合は GO + passkey と削除対象名の明示が必要です。</p>
+      <p><code>vtdd-v3-orchestrator.polished-tree-da7c.workers.dev</code> は prototype として残します。削除は Cloudflare Worker deletion なので destructive operation です。実行する場合は scope 明示済み passkey approval と削除対象名の明示が必要です。</p>
       <ul>
         <li>削除前に v2 dashboard / deploy path が本番反映済みであることを確認する。</li>
         <li>必要なら v3 Worker は disable / rename / delete の順に検討する。</li>

--- a/test/approval-model.test.js
+++ b/test/approval-model.test.js
@@ -44,5 +44,6 @@ test("consent and approval docs contain canonical categories and levels", () => 
 
   assert.equal(doc.includes("`destructive` is the highest-risk consent category."), true);
   assert.equal(doc.includes("Approval must be bound to the target scope."), true);
-  assert.equal(doc.includes("`approvalPhrase` is required"), true);
+  assert.equal(doc.includes("`approvalPhrase` is required for `go` approval."), true);
+  assert.equal(doc.includes("signed `GO`"), true);
 });

--- a/test/core-policy.test.js
+++ b/test/core-policy.test.js
@@ -176,7 +176,44 @@ test("execution mode blocks ambiguous repository nickname", () => {
   assert.equal(result.blockedByRule, "unresolved_target_blocks_execution");
 });
 
-test("high-risk action requires GO + passkey", () => {
+const deployApprovalScope = {
+  actionType: ActionType.DEPLOY_PRODUCTION,
+  repositoryInput: "ledger",
+  issueNumber: "430",
+  relatedIssue: "430",
+  phase: "execution"
+};
+
+const validDeployApprovalGrant = {
+  verified: true,
+  expiresAt: "2099-01-01T00:00:00.000Z",
+  scope: deployApprovalScope
+};
+
+test("high-risk action accepts real scoped passkey approval grant without separate GO", () => {
+  const result = evaluateExecutionPolicy({
+    actionType: ActionType.DEPLOY_PRODUCTION,
+    mode: TaskMode.EXECUTION,
+    repositoryInput: "ledger",
+    aliasRegistry: registry,
+    targetConfirmed: true,
+    constitutionConsulted: true,
+    runtimeTruth: { runtimeAvailable: true },
+    credential: highRiskCredential,
+    consent: fullConsent,
+    approvalPhrase: "",
+    approvalScopeMatched: true,
+    approvalGrant: validDeployApprovalGrant,
+    approvalScope: deployApprovalScope,
+    issueTraceable: true,
+    go: false,
+    passkey: false
+  });
+  assert.equal(result.allowed, true);
+  assert.equal(result.requiredApproval, "go_passkey");
+});
+
+test("high-risk action still rejects missing real approval grant", () => {
   const result = evaluateExecutionPolicy({
     actionType: ActionType.DEPLOY_PRODUCTION,
     mode: TaskMode.EXECUTION,
@@ -196,7 +233,29 @@ test("high-risk action requires GO + passkey", () => {
   assert.equal(result.requiredApproval, "go_passkey");
 });
 
-test("merge requires explicit GO + passkey approval", () => {
+test("high-risk action rejects phrase-only passkey without separate GO", () => {
+  const result = evaluateExecutionPolicy({
+    actionType: ActionType.DEPLOY_PRODUCTION,
+    mode: TaskMode.EXECUTION,
+    repositoryInput: "ledger",
+    aliasRegistry: registry,
+    targetConfirmed: true,
+    constitutionConsulted: true,
+    runtimeTruth: { runtimeAvailable: true },
+    credential: highRiskCredential,
+    consent: fullConsent,
+    ...approvalContext,
+    approvalScope: deployApprovalScope,
+    issueTraceable: true,
+    go: false,
+    passkey: true
+  });
+  assert.equal(result.allowed, false);
+  assert.equal(result.blockedByRule, "approval_boundary");
+  assert.equal(result.reason.includes("real scoped passkey approval"), true);
+});
+
+test("merge requires scoped passkey approval or legacy explicit GO phrase plus passkey flag", () => {
   const result = evaluateExecutionPolicy({
     actionType: ActionType.MERGE,
     mode: TaskMode.EXECUTION,
@@ -216,7 +275,7 @@ test("merge requires explicit GO + passkey approval", () => {
   assert.equal(result.requiredApproval, "go_passkey");
 });
 
-test("guarded absence mode blocks merge even with GO + passkey", () => {
+test("guarded absence mode blocks merge even with scoped approval", () => {
   const result = evaluateExecutionPolicy({
     actionType: ActionType.MERGE,
     mode: TaskMode.EXECUTION,

--- a/test/custom-gpt-setup-docs.test.js
+++ b/test/custom-gpt-setup-docs.test.js
@@ -150,8 +150,8 @@ test("custom gpt instructions preserve current butler and approval boundaries", 
   assert.equal(doc.includes("still provide `selfParity.deployOperatorMarkdownLink`"), true);
   assert.equal(doc.includes("render `selfParity.deployOperatorUrl` as a short Markdown link"), true);
   assert.equal(doc.includes("phase=execution"), true);
-  assert.equal(doc.includes("High-risk actions require GO + passkey."), true);
-  assert.equal(doc.includes("Merge requires explicit human GO + real passkey."), true);
+  assert.equal(doc.includes("High-risk actions require scoped passkey approval."), true);
+  assert.equal(doc.includes("Merge requires explicit scoped passkey approval."), true);
   assert.equal(doc.includes("Action Schema update required"), true);
   assert.equal(doc.includes("Instructions update required"), true);
   assert.equal(doc.includes("runtime is in sync, do not overclaim that the current Custom GPT editor is also in sync"), true);

--- a/test/deploy-authority-branching-doc.test.js
+++ b/test/deploy-authority-branching-doc.test.js
@@ -17,7 +17,7 @@ test("deploy authority branching doc compares candidate paths and fixes first ca
 
 test("deploy authority branching doc fixes invariants against permanent github deploy authority", () => {
   const doc = fs.readFileSync(DOC_PATH, "utf8");
-  assert.equal(doc.includes("deploy requires `GO + passkey`"), true);
+  assert.equal(doc.includes("deploy requires scoped passkey approval"), true);
   assert.equal(doc.includes("deploy authority must be short-lived or one-shot"), true);
   assert.equal(doc.includes("GitHub Actions must not require permanent production deploy authority"), true);
   assert.equal(doc.includes("a mistaken push to `main` must not immediately imply production deploy"), true);

--- a/test/deploy-production-plane.test.js
+++ b/test/deploy-production-plane.test.js
@@ -2,12 +2,11 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { executeDeployProductionPlane } from "../src/core/index.js";
 
-test("deploy production plane dispatches governed workflow with GO + passkey inputs", async () => {
+test("deploy production plane dispatches governed workflow with scoped passkey approval inputs", async () => {
   const calls = [];
   const result = await executeDeployProductionPlane({
     repository: "sample-org/vtdd-v2-p",
     runtimeUrl: "https://sample-user-vtdd.example.workers.dev",
-    approvalPhrase: "GO",
     approvalGrantId: "approval-deploy-123",
     approvalGrant: {
       approvalId: "approval-deploy-123",
@@ -51,7 +50,7 @@ test("deploy production plane dispatches governed workflow with GO + passkey inp
   assert.equal(calls[0].url.includes("/actions/workflows/deploy-production.yml/dispatches"), true);
   assert.equal(calls[1].url.includes("/actions/workflows/deploy-production.yml/runs"), true);
   const body = JSON.parse(calls[0].init.body);
-  assert.equal(body.inputs.approval_phrase, "GO");
+  assert.equal("approval_phrase" in body.inputs, false);
   assert.equal(body.inputs.approval_grant_id, "approval-deploy-123");
   assert.equal(body.inputs.runtime_url, "https://sample-user-vtdd.example.workers.dev");
 });
@@ -60,7 +59,6 @@ test("deploy production plane does not fail when accepted dispatch is not immedi
   const result = await executeDeployProductionPlane({
     repository: "sample-org/vtdd-v2-p",
     runtimeUrl: "https://sample-user-vtdd.example.workers.dev",
-    approvalPhrase: "GO",
     approvalGrantId: "approval-deploy-123",
     approvalGrant: {
       approvalId: "approval-deploy-123",
@@ -101,11 +99,10 @@ test("deploy production plane does not fail when accepted dispatch is not immedi
   assert.equal(result.deploy.runConclusion, "unknown");
 });
 
-test("deploy production plane blocks missing GO + passkey inputs", async () => {
+test("deploy production plane blocks missing passkey approval inputs", async () => {
   const result = await executeDeployProductionPlane({
     repository: "sample-org/vtdd-v2-p",
     runtimeUrl: "",
-    approvalPhrase: "NO",
     approvalGrantId: "",
     approvalGrant: null,
     env: {}
@@ -114,7 +111,6 @@ test("deploy production plane blocks missing GO + passkey inputs", async () => {
   assert.equal(result.ok, false);
   assert.equal(result.error, "deploy_request_invalid");
   assert.equal(result.issues.includes("runtimeUrl is required"), true);
-  assert.equal(result.issues.includes("approvalPhrase must be GO"), true);
   assert.equal(result.issues.includes("real approvalGrant is required for deploy_production"), true);
 });
 
@@ -122,7 +118,6 @@ test("deploy production plane returns explicit unavailable category when deploy 
   const result = await executeDeployProductionPlane({
     repository: "sample-org/vtdd-v2-p",
     runtimeUrl: "https://sample-user-vtdd.example.workers.dev",
-    approvalPhrase: "GO",
     approvalGrantId: "approval-deploy-123",
     approvalGrant: {
       approvalId: "approval-deploy-123",

--- a/test/github-app-actor-identity.test.js
+++ b/test/github-app-actor-identity.test.js
@@ -22,6 +22,6 @@ test("GitHub App actor identity doc maps VTDD roles to visible actors and secret
 test("GitHub App actor identity doc preserves authority and passkey boundaries", () => {
   assert.equal(doc.includes("Reviewer Apps are critique-only."), true);
   assert.equal(doc.includes("Executor Apps may push bounded branch changes"), true);
-  assert.equal(doc.includes("`GO + passkey`"), true);
+  assert.equal(doc.includes("scoped passkey approval"), true);
   assert.equal(doc.includes("Registering or updating those secrets is a high-risk external effect"), true);
 });

--- a/test/github-high-risk-plane.test.js
+++ b/test/github-high-risk-plane.test.js
@@ -91,7 +91,7 @@ test("github app operation registry defines issue close authority scope and runt
   ]);
 });
 
-test("merge now requires GO + passkey approval level in core policy", () => {
+test("merge requires scoped passkey approval level in core policy", () => {
   const denied = evaluateExecutionPolicy({
     actionType: ActionType.MERGE,
     mode: TaskMode.EXECUTION,
@@ -132,12 +132,11 @@ test("merge now requires GO + passkey approval level in core policy", () => {
     consent: {
       grantedCategories: [ConsentCategory.EXECUTE]
     },
-    approvalPhrase: "GO merge request",
     approvalGrant: mergeGrant,
     approvalScope: mergeGrant.scope,
     approvalScopeMatched: true,
     issueTraceable: true,
-    go: true,
+    go: false,
     passkey: false
   });
 

--- a/test/pr-body-guardrail.test.js
+++ b/test/pr-body-guardrail.test.js
@@ -219,7 +219,7 @@ test("validatePrBody rejects closing PRs without complete Butler evidence", () =
     actionSchemaExposure: "operationId exposed.",
     runtimePath: "Connected runtime path.",
     runtimeTruth: "Runtime truth reports success.",
-    authorityBoundary: "GO + passkey where required.",
+    authorityBoundary: "scoped passkey approval where required.",
     butlerE2E: "None.",
     completionStatus: "incomplete",
   });

--- a/test/production-deploy-path.test.js
+++ b/test/production-deploy-path.test.js
@@ -20,7 +20,6 @@ test("production deploy doc defines the governed GitHub Actions deploy path", ()
   assert.equal(doc.includes("Cloudflare Workers"), true);
   assert.equal(doc.includes("`wrangler deploy --env production`"), true);
   assert.equal(doc.includes("GitHub Environment `production`"), true);
-  assert.equal(doc.includes("`approval_phrase=GO`"), true);
   assert.equal(doc.includes("`approval_grant_id=<real passkey approval grant id>`"), true);
   assert.equal(doc.includes("`runtime_url=<user-owned worker runtime>`"), true);
   assert.equal(doc.includes("`VTDD_GATEWAY_BEARER_TOKEN`"), true);
@@ -54,7 +53,7 @@ test("deploy-production workflow enforces the MVP production deploy boundary", (
   assert.equal(workflow.includes("issues: write"), true);
   assert.equal(workflow.includes("if: github.ref == 'refs/heads/main'"), true);
   assert.equal(workflow.includes("environment: production"), true);
-  assert.equal(workflow.includes('github.event.inputs.approval_phrase }}" != "GO"'), true);
+  assert.equal(workflow.includes("approval_phrase"), false);
   assert.equal(workflow.includes('github.event.inputs.runtime_url'), true);
   assert.equal(workflow.includes('github.event.inputs.approval_grant_id'), true);
   assert.equal(workflow.includes("Preflight deploy credentials"), true);

--- a/test/vtdd-mcp-ver-architecture.test.js
+++ b/test/vtdd-mcp-ver-architecture.test.js
@@ -21,7 +21,7 @@ test("vtdd-mcp-ver architecture doc preserves governance over MCP", () => {
   assert.equal(doc.includes("MCP is an interface layer inside that system."), true);
   assert.equal(doc.includes("MCP is not the source of truth"), true);
   assert.equal(doc.includes("MCP must not create a separate weaker or stronger governance model."), true);
-  assert.equal(doc.includes("High-risk operations remain `GO + passkey`."), true);
+  assert.equal(doc.includes("High-risk operations remain governed by scoped passkey approval."), true);
   assert.equal(doc.includes("MCP is not permanently read-only."), true);
 });
 

--- a/test/vtdd-v2-overview-current-state.test.js
+++ b/test/vtdd-v2-overview-current-state.test.js
@@ -18,6 +18,6 @@ test("overview includes current operational direction boundaries", () => {
   assert.equal(doc.includes("alias/context-first repository resolution"), true);
   assert.equal(doc.includes("no default repository"), true);
   assert.equal(doc.includes("unresolved target blocks execution"), true);
-  assert.equal(doc.includes("high-risk actions require `GO + passkey`"), true);
+  assert.equal(doc.includes("high-risk actions require scoped passkey approval"), true);
   assert.equal(doc.includes("mobile-first operation should not require pasting secrets into chat answers"), true);
 });

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -139,7 +139,7 @@ test("worker serves v2 dashboard without exposing secrets", async () => {
   assert.equal(body.includes("/v2/action/vps-runner-status"), true);
   assert.equal(body.includes("/v2/retrieve/operational-memory"), true);
   assert.equal(body.includes("gemini-pr-review"), true);
-  assert.equal(body.includes("GO + passkey"), true);
+  assert.equal(body.includes("passkey approval"), true);
   assert.equal(body.includes("approvalGrantId"), false);
   assert.equal(body.includes("CLOUDFLARE_API_TOKEN"), false);
 
@@ -170,7 +170,7 @@ test("worker help guide opens without Action auth and documents safe operation b
   const html = await response.text();
   assert.equal(html.includes("VTDD help guide"), true);
   assert.equal(html.includes("Butler -> Worker"), true);
-  assert.equal(html.includes("GO + passkey required"), true);
+  assert.equal(html.includes("passkey approval required"), true);
   assert.equal(html.includes("setup/latest"), true);
   assert.equal(html.includes("setup/known-good"), true);
   assert.equal(html.includes("Cloudflare 上のページ一覧"), true);
@@ -5474,6 +5474,7 @@ test("worker dispatches governed production deploy using the request origin as t
     dispatchBody.inputs.runtime_url,
     "https://sample-user-vtdd.example.workers.dev"
   );
+  assert.equal("approval_phrase" in dispatchBody.inputs, false);
 });
 
 test("worker allows same-origin browser governed production deploy with a real approval grant", async () => {
@@ -5513,7 +5514,6 @@ test("worker allows same-origin browser governed production deploy with a real a
       body: JSON.stringify({
         repository: "sample-org/vtdd-v2-p",
         policyInput: {
-          approvalPhrase: "GO",
           approvalGrantId: "approval-deploy-browser-123"
         }
       })
@@ -5556,6 +5556,7 @@ test("worker allows same-origin browser governed production deploy with a real a
     dispatchBody.inputs.runtime_url,
     "https://sample-user-vtdd.example.workers.dev"
   );
+  assert.equal("approval_phrase" in dispatchBody.inputs, false);
 });
 
 test("worker returns raw deploy context when workflow dispatch is unverified", async () => {

--- a/worker.js
+++ b/worker.js
@@ -27197,6 +27197,31 @@ function evaluateApproval({
       reason: "approval must be bound to the target scope"
     };
   }
+  if (required2 === ApprovalLevel.GO_PASSKEY) {
+    const grantResult = evaluateApprovalGrant({
+      approvalGrant,
+      scope: approvalScope
+    });
+    if (grantResult.ok) {
+      return { ok: true, required: required2 };
+    }
+    const phrase2 = normalize(approvalPhrase);
+    if (!phrase2) {
+      return {
+        ok: false,
+        required: required2,
+        reason: grantResult.reason || "real scoped passkey approval grant is required"
+      };
+    }
+    if (go && passkey) {
+      return { ok: true, required: required2 };
+    }
+    return {
+      ok: false,
+      required: required2,
+      reason: passkey ? "high-risk action requires real scoped passkey approval or legacy explicit GO phrase plus passkey flag" : grantResult.reason || "real scoped passkey approval grant is required"
+    };
+  }
   const phrase = normalize(approvalPhrase);
   if (!phrase) {
     return {
@@ -27212,18 +27237,6 @@ function evaluateApproval({
       reason: "explicit GO is required before execution"
     };
   }
-  const grantResult = evaluateApprovalGrant({
-    approvalGrant,
-    scope: approvalScope
-  });
-  if (go && (passkey || grantResult.ok)) {
-    return { ok: true, required: required2 };
-  }
-  return {
-    ok: false,
-    required: required2,
-    reason: passkey ? "high-risk action requires GO + passkey" : grantResult.reason || "high-risk action requires GO + passkey"
-  };
 }
 function normalize(value) {
   return String(value ?? "").trim().toLowerCase();
@@ -27911,7 +27924,6 @@ function renderPasskeyOperatorPage(input = {}) {
               repository: repositoryInput,
               issueNumber: Number(document.getElementById("issue-input").value || 0) || null,
               policyInput: {
-                approvalPhrase: "GO",
                 approvalGrantId: latestApprovalGrantId
               }
             })
@@ -27946,7 +27958,6 @@ function renderPasskeyOperatorPage(input = {}) {
                 issueNumber: Number(document.getElementById("issue-input").value || 0) || null
               },
               policyInput: {
-                approvalPhrase: "GO",
                 approvalGrantId: latestApprovalGrantId,
                 targetConfirmed: true
               }
@@ -27981,7 +27992,6 @@ function renderPasskeyOperatorPage(input = {}) {
                 issueNumber: Number(document.getElementById("issue-input").value || 0) || null
               },
               policyInput: {
-                approvalPhrase: "GO",
                 approvalGrantId: latestApprovalGrantId,
                 targetConfirmed: true
               }
@@ -28017,7 +28027,6 @@ function renderPasskeyOperatorPage(input = {}) {
                 issueNumber: Number(document.getElementById("issue-input").value || 0) || null
               },
               policyInput: {
-                approvalPhrase: "GO",
                 approvalGrantId: latestApprovalGrantId,
                 targetConfirmed: true
               }
@@ -28372,7 +28381,7 @@ function renderVtddHelpGuidePage(input = {}) {
         <div class="panel"><strong>Repository resolution</strong>alias / nickname / GitHub App repository index \u3067\u5BFE\u8C61\u3092\u89E3\u6C7A\u3057\u307E\u3059\u3002default repository \u306F\u3042\u308A\u307E\u305B\u3093\u3002</div>
         <div class="panel"><strong>GitHub read plane</strong>repository\u3001Issue\u3001PR\u3001review\u3001checks\u3001workflow runs\u3001branch state \u3092 Butler \u304C\u8AAD\u3081\u308B runtime truth \u3068\u3057\u3066\u8FD4\u3057\u307E\u3059\u3002</div>
         <div class="panel"><strong>GitHub write plane</strong>\u30B3\u30E1\u30F3\u30C8\u3001PR\u66F4\u65B0\u3001runner queue \u306A\u3069\u901A\u5E38 write \u3092 approval boundary \u306B\u6CBF\u3063\u3066\u5B9F\u884C\u3057\u307E\u3059\u3002</div>
-        <div class="panel"><strong>High-risk authority plane</strong>merge\u3001Issue close\u3001secret sync\u3001deploy \u306A\u3069\u9AD8\u30EA\u30B9\u30AF\u64CD\u4F5C\u306F GO + passkey \u307E\u305F\u306F\u660E\u793A\u7684\u306A\u7981\u6B62\u5883\u754C\u3092\u901A\u308A\u307E\u3059\u3002</div>
+        <div class="panel"><strong>High-risk authority plane</strong>merge\u3001Issue close\u3001secret sync\u3001deploy \u306A\u3069\u9AD8\u30EA\u30B9\u30AF\u64CD\u4F5C\u306F scoped passkey approval \u307E\u305F\u306F\u660E\u793A\u7684\u306A\u7981\u6B62\u5883\u754C\u3092\u901A\u308A\u307E\u3059\u3002</div>
         <div class="panel"><strong>Runner / reviewer loop</strong>Butler -> Codex runner -> PR -> reviewer -> Butler summary \u306E GitHub-visible loop \u3092\u6271\u3044\u307E\u3059\u3002</div>
         <div class="panel"><strong>Memory / retrieval</strong>constitution\u3001decision log\u3001proposal log\u3001operational memory \u3092\u8AAD\u3093\u3067\u5224\u65AD\u306E\u524D\u63D0\u3092\u5FA9\u5143\u3057\u307E\u3059\u3002</div>
         <div class="panel"><strong>MCP read surface</strong>Mac Codex / VPS Codex CLI \u306F <code>${escapeHtml2(mcpPath)}</code> \u3092\u901A\u3058\u3066 Butler \u3068\u540C\u3058 runtime truth / review truth / memory recall \u3092\u8AAD\u307F\u307E\u3059\u3002</div>
@@ -28400,7 +28409,7 @@ function renderVtddHelpGuidePage(input = {}) {
         <div class="panel"><strong>PR\u3092\u76F4\u3057\u305F\u3044</strong>Butler \u304C reviewer comment \u3068 PR state \u3092\u8AAD\u307F\u3001revise_pr \u3068\u3057\u3066 runner \u306B\u6E21\u305B\u308B\u304B\u78BA\u8A8D\u3057\u307E\u3059\u3002</div>
         <div class="panel"><strong>merge\u3057\u305F\u3044</strong>Butler \u304C checks\u3001reviewer signal\u3001mergeability\u3001Issue evidence \u3092\u78BA\u8A8D\u3057\u3001\u5FC5\u8981\u306A approval boundary \u3092\u63D0\u793A\u3057\u307E\u3059\u3002</div>
         <div class="panel"><strong>Action Schema \u304C\u58CA\u308C\u305F</strong>\u3053\u306E runtime \u306E setup/recovery page \u3092\u76F4\u63A5\u958B\u304D\u3001known-good \u307E\u305F\u306F latest bundle \u3092\u30B3\u30D4\u30FC\u3057\u307E\u3059\u3002</div>
-        <div class="panel"><strong>deploy\u3084secret\u66F4\u65B0\u3092\u3057\u305F\u3044</strong>GO + passkey \u3068\u5BFE\u8C61 scope \u304C\u5FC5\u8981\u3067\u3059\u3002Worker \u306F secret \u5024\u3092\u3053\u306E\u30DA\u30FC\u30B8\u306B\u8868\u793A\u3057\u307E\u305B\u3093\u3002</div>
+        <div class="panel"><strong>deploy\u3084secret\u66F4\u65B0\u3092\u3057\u305F\u3044</strong>\u5BFE\u8C61 scope \u304C\u8868\u793A\u3055\u308C\u305F passkey approval \u304C\u5FC5\u8981\u3067\u3059\u3002Worker \u306F secret \u5024\u3092\u3053\u306E\u30DA\u30FC\u30B8\u306B\u8868\u793A\u3057\u307E\u305B\u3093\u3002</div>
       </div>
     </section>
 
@@ -28408,7 +28417,7 @@ function renderVtddHelpGuidePage(input = {}) {
       <h2>\u6A29\u9650\u5883\u754C</h2>
       <div class="route"><strong>Allowed without GO</strong>\u8AAD\u307F\u53D6\u308A\u3001\u72B6\u614B\u78BA\u8A8D\u3001\u8AAC\u660E\u3001proposal\u3001\u4F4E\u30EA\u30B9\u30AF\u306A\u6848\u5185\u3002\u5B9F\u884C\u80FD\u529B\u3068\u306F\u533A\u5225\u3057\u307E\u3059\u3002</div>
       <div class="route"><strong>GO required</strong>bounded implementation dispatch\u3001\u901A\u5E38 write\u3001PR review/comment \u306A\u3069\u3001Issue scope \u3068 runtime truth \u306B\u63A5\u7D9A\u3055\u308C\u305F\u64CD\u4F5C\u3002</div>
-      <div class="route"><strong>GO + passkey required</strong>deploy\u3001credential mutation\u3001permission mutation\u3001high-risk GitHub operation\u3001destructive/high-blast-radius operation\u3002</div>
+      <div class="route"><strong>passkey approval required</strong>deploy\u3001credential mutation\u3001permission mutation\u3001high-risk GitHub operation\u3001destructive/high-blast-radius operation\u3002</div>
       <div class="route"><strong>Forbidden / stop</strong>\u5BFE\u8C61 repo \u672A\u89E3\u6C7A\u3001Issue traceability \u4E0D\u8DB3\u3001owner-specific runtime \u4F9D\u5B58\u3001secret \u8868\u793A\u3001scope conflict\u3001reviewer objection \u306E\u697D\u89B3\u7684\u306A\u7121\u8996\u3002</div>
     </section>
 
@@ -28509,7 +28518,7 @@ function buildVtddCloudflarePageDirectory(input = {}) {
       label: "Passkey operator",
       path: "/v2/approval/passkey/operator",
       url: buildRuntimeUrl(runtimeOrigin, "/v2/approval/passkey/operator"),
-      description: "GO + passkey \u304C\u5FC5\u8981\u306A deploy\u3001merge\u3001secret sync \u306A\u3069\u306E operator helper \u3067\u3059\u3002",
+      description: "scope \u660E\u793A\u6E08\u307F passkey approval \u304C\u5FC5\u8981\u306A deploy\u3001merge\u3001secret sync \u306A\u3069\u306E operator helper \u3067\u3059\u3002",
       audience: ["owner", "operator"],
       authority: "go_plus_passkey_required_for_execution"
     },
@@ -36443,7 +36452,6 @@ var DEFAULT_DEPLOY_WORKFLOW_REF = "main";
 async function executeDeployProductionPlane(input = {}) {
   const repository = normalizeText23(input.repository);
   const runtimeUrl = normalizeText23(input.runtimeUrl);
-  const approvalPhrase = normalizeText23(input.approvalPhrase);
   const approvalGrant = input.approvalGrant ?? null;
   const approvalGrantId = normalizeText23(input.approvalGrantId) || normalizeText23(approvalGrant?.approvalId);
   const env = input.env ?? {};
@@ -36452,7 +36460,6 @@ async function executeDeployProductionPlane(input = {}) {
   const validation = validateDeployProductionRequest({
     repository,
     runtimeUrl,
-    approvalPhrase,
     approvalGrant,
     approvalGrantId
   });
@@ -36492,7 +36499,6 @@ async function executeDeployProductionPlane(input = {}) {
   const dispatchBody = {
     ref: workflowRef,
     inputs: {
-      approval_phrase: "GO",
       runtime_url: runtimeUrl,
       approval_grant_id: approvalGrantId
     }
@@ -36630,7 +36636,6 @@ async function verifyDeployWorkflowRun({
 function validateDeployProductionRequest({
   repository,
   runtimeUrl,
-  approvalPhrase,
   approvalGrant,
   approvalGrantId
 }) {
@@ -36640,9 +36645,6 @@ function validateDeployProductionRequest({
   }
   if (!runtimeUrl) {
     issues.push("runtimeUrl is required");
-  }
-  if (approvalPhrase !== "GO") {
-    issues.push("approvalPhrase must be GO");
   }
   if (!approvalGrantId) {
     issues.push("approvalGrantId is required");
@@ -39492,7 +39494,7 @@ var GitHubOwnerOperationInventory = Object.freeze([
     status: GitHubOwnerOperationStatus.UNSUPPORTED,
     requiredGitHubAppPermission: "issues:write",
     requiredButlerActionSurface: "github_write.issue_update",
-    requiredPasskeyOperatorBoundary: "exact payload + human GO for bounded edits; GO + passkey when closing after merge",
+    requiredPasskeyOperatorBoundary: "exact payload + human GO for bounded edits; scoped passkey approval when closing after merge",
     runtimeTruthVerificationMethod: "PATCH /repos/{owner}/{repo}/issues/{issue_number} then read back changed fields",
     remediationIssue: ISSUE_244
   },
@@ -39502,7 +39504,7 @@ var GitHubOwnerOperationInventory = Object.freeze([
     status: GitHubOwnerOperationStatus.GATED,
     requiredGitHubAppPermission: "issues:write and pull_requests:read",
     requiredButlerActionSurface: "github_high_risk.issue_close",
-    requiredPasskeyOperatorBoundary: "explicit GO + real passkey/operator approval",
+    requiredPasskeyOperatorBoundary: "scoped passkey approval",
     runtimeTruthVerificationMethod: "verify PR merged_at, PATCH issue state=closed, then read issue state",
     remediationIssue: null
   },
@@ -39522,7 +39524,7 @@ var GitHubOwnerOperationInventory = Object.freeze([
     status: GitHubOwnerOperationStatus.UNSUPPORTED,
     requiredGitHubAppPermission: "issues:write",
     requiredButlerActionSurface: "github_write.issue_comment_delete",
-    requiredPasskeyOperatorBoundary: "GO + passkey/operator approval when deletion is destructive or evidence-bearing",
+    requiredPasskeyOperatorBoundary: "scoped passkey approval when deletion is destructive or evidence-bearing",
     runtimeTruthVerificationMethod: "DELETE /repos/{owner}/{repo}/issues/comments/{comment_id} then verify comment is absent/tombstoned",
     remediationIssue: ISSUE_244
   },
@@ -39552,7 +39554,7 @@ var GitHubOwnerOperationInventory = Object.freeze([
     status: GitHubOwnerOperationStatus.UNSUPPORTED,
     requiredGitHubAppPermission: "pull_requests:write and issues:write",
     requiredButlerActionSurface: "github_write.pull_state_update",
-    requiredPasskeyOperatorBoundary: "exact payload + human GO; GO + passkey for destructive state transitions if policy marks high-risk",
+    requiredPasskeyOperatorBoundary: "exact payload + human GO; scoped passkey approval for destructive state transitions if policy marks high-risk",
     runtimeTruthVerificationMethod: "PATCH /pulls/{pull_number} or related PR endpoints, then read PR state",
     remediationIssue: ISSUE_244
   },
@@ -39562,7 +39564,7 @@ var GitHubOwnerOperationInventory = Object.freeze([
     status: GitHubOwnerOperationStatus.GATED,
     requiredGitHubAppPermission: "pull_requests:write",
     requiredButlerActionSurface: "github_high_risk.pull_ready_for_review",
-    requiredPasskeyOperatorBoundary: "explicit GO + real passkey/operator approval",
+    requiredPasskeyOperatorBoundary: "scoped passkey approval",
     runtimeTruthVerificationMethod: "read draft=true, GraphQL markPullRequestReadyForReview, then verify isDraft=false",
     remediationIssue: null
   },
@@ -39572,7 +39574,7 @@ var GitHubOwnerOperationInventory = Object.freeze([
     status: GitHubOwnerOperationStatus.GATED,
     requiredGitHubAppPermission: "pull_requests:write and contents:write",
     requiredButlerActionSurface: "github_high_risk.pull_merge",
-    requiredPasskeyOperatorBoundary: "explicit GO + real passkey/operator approval",
+    requiredPasskeyOperatorBoundary: "scoped passkey approval",
     runtimeTruthVerificationMethod: "PUT /pulls/{pull_number}/merge then read merged_at and merge_commit_sha",
     remediationIssue: null
   },
@@ -39592,7 +39594,7 @@ var GitHubOwnerOperationInventory = Object.freeze([
     status: GitHubOwnerOperationStatus.UNSUPPORTED,
     requiredGitHubAppPermission: "contents:write",
     requiredButlerActionSurface: "github_write.branch_ref_update_delete",
-    requiredPasskeyOperatorBoundary: "exact payload + human GO for scoped ref update; deletion only for merged scoped branch or GO + passkey if destructive",
+    requiredPasskeyOperatorBoundary: "exact payload + human GO for scoped ref update; deletion only for merged scoped branch or scoped passkey approval if destructive",
     runtimeTruthVerificationMethod: "PATCH/DELETE git refs, then read branch/ref absence or updated sha",
     remediationIssue: ISSUE_244
   },
@@ -39602,7 +39604,7 @@ var GitHubOwnerOperationInventory = Object.freeze([
     status: GitHubOwnerOperationStatus.UNSUPPORTED,
     requiredGitHubAppPermission: "actions:write and actions:read",
     requiredButlerActionSurface: "github_actions.workflow_governed_control",
-    requiredPasskeyOperatorBoundary: "exact payload + human GO for bounded dispatch/rerun; GO + passkey for cancel/destructive cleanup",
+    requiredPasskeyOperatorBoundary: "exact payload + human GO for bounded dispatch/rerun; scoped passkey approval for cancel/destructive cleanup",
     runtimeTruthVerificationMethod: "workflow dispatch/cancel/rerun API then read run status, conclusion, URL, and artifact state",
     remediationIssue: ISSUE_244
   },
@@ -39632,7 +39634,7 @@ var GitHubOwnerOperationInventory = Object.freeze([
     status: GitHubOwnerOperationStatus.GATED,
     requiredGitHubAppPermission: "secrets:write, variables:write, actions:write, environments:write as applicable",
     requiredButlerActionSurface: "github_actions_secret_sync and github_admin.variable_governed_change",
-    requiredPasskeyOperatorBoundary: "explicit GO + real passkey/operator approval; never expose raw secret material",
+    requiredPasskeyOperatorBoundary: "scoped passkey approval; never expose raw secret material",
     runtimeTruthVerificationMethod: "encrypted secret/variable write result plus metadata readback without raw value",
     remediationIssue: null
   },
@@ -39642,7 +39644,7 @@ var GitHubOwnerOperationInventory = Object.freeze([
     status: GitHubOwnerOperationStatus.UNSUPPORTED,
     requiredGitHubAppPermission: "contents:write and packages:write where applicable",
     requiredButlerActionSurface: "github_release.governed_release_control",
-    requiredPasskeyOperatorBoundary: "exact payload + human GO for draft metadata; GO + passkey for publish/delete",
+    requiredPasskeyOperatorBoundary: "exact payload + human GO for draft metadata; scoped passkey approval for publish/delete",
     runtimeTruthVerificationMethod: "release/tag/package API mutation then read release/tag/package state and URL",
     remediationIssue: ISSUE_244
   },
@@ -39685,7 +39687,6 @@ async function executeGitHubHighRiskPlane(input = {}) {
   const mergeMethod = normalizeMergeMethod(input.mergeMethod);
   const commitTitle = normalizeText29(input.commitTitle);
   const commitMessage = normalizeBody3(input.commitMessage);
-  const approvalPhrase = normalizeText29(input.approvalPhrase);
   const targetConfirmed = input.targetConfirmed === true;
   const approvalScope = input.approvalScope ?? null;
   const approvalGrant = input.approvalGrant ?? null;
@@ -39698,7 +39699,6 @@ async function executeGitHubHighRiskPlane(input = {}) {
     issueNumber,
     pullNumber,
     mergeMethod,
-    approvalPhrase,
     targetConfirmed,
     approvalGrant,
     approvalScope
@@ -39756,9 +39756,6 @@ function validateGitHubHighRiskRequest(input) {
   }
   if (!input.targetConfirmed) {
     issues.push("targetConfirmed must be true");
-  }
-  if (normalizeText29(input.approvalPhrase).toUpperCase() !== "GO") {
-    issues.push("approvalPhrase must be GO");
   }
   if (input.operation === GitHubHighRiskOperation.PULL_MERGE && input.mergeMethod && !["merge", "squash", "rebase"].includes(input.mergeMethod)) {
     issues.push("mergeMethod must be merge, squash, or rebase");
@@ -59898,7 +59895,7 @@ function renderV2DashboardPage({ runtimeOrigin }) {
     },
     {
       title: "Deploy passkey operator",
-      body: "production deploy \u306F GO + passkey \u306E\u5F8C\u308D\u3002approval grant \u3084 secret \u306F dashboard \u306B\u4FDD\u5B58\u3057\u306A\u3044\u3002",
+      body: "production deploy \u306F scope \u660E\u793A\u6E08\u307F passkey approval \u306E\u5F8C\u308D\u3002approval grant \u3084 secret \u306F dashboard \u306B\u4FDD\u5B58\u3057\u306A\u3044\u3002",
       href: `${origin}/v2/approval/passkey/operator?repositoryInput=${encodedRepository}&phase=execution&actionType=deploy_production&highRiskKind=deploy_production`
     }
   ];
@@ -59976,7 +59973,7 @@ function renderV2DashboardPage({ runtimeOrigin }) {
 
     <section class="panel danger">
       <h2>v3 Worker \u306E\u6271\u3044</h2>
-      <p><code>vtdd-v3-orchestrator.polished-tree-da7c.workers.dev</code> \u306F prototype \u3068\u3057\u3066\u6B8B\u3057\u307E\u3059\u3002\u524A\u9664\u306F Cloudflare Worker deletion \u306A\u306E\u3067 destructive operation \u3067\u3059\u3002\u5B9F\u884C\u3059\u308B\u5834\u5408\u306F GO + passkey \u3068\u524A\u9664\u5BFE\u8C61\u540D\u306E\u660E\u793A\u304C\u5FC5\u8981\u3067\u3059\u3002</p>
+      <p><code>vtdd-v3-orchestrator.polished-tree-da7c.workers.dev</code> \u306F prototype \u3068\u3057\u3066\u6B8B\u3057\u307E\u3059\u3002\u524A\u9664\u306F Cloudflare Worker deletion \u306A\u306E\u3067 destructive operation \u3067\u3059\u3002\u5B9F\u884C\u3059\u308B\u5834\u5408\u306F scope \u660E\u793A\u6E08\u307F passkey approval \u3068\u524A\u9664\u5BFE\u8C61\u540D\u306E\u660E\u793A\u304C\u5FC5\u8981\u3067\u3059\u3002</p>
       <ul>
         <li>\u524A\u9664\u524D\u306B v2 dashboard / deploy path \u304C\u672C\u756A\u53CD\u6620\u6E08\u307F\u3067\u3042\u308B\u3053\u3068\u3092\u78BA\u8A8D\u3059\u308B\u3002</li>
         <li>\u5FC5\u8981\u306A\u3089 v3 Worker \u306F disable / rename / delete \u306E\u9806\u306B\u691C\u8A0E\u3059\u308B\u3002</li>


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #430 の Intent に沿って、scope 明示済み real passkey approval grant を高リスク操作の署名付き GO として扱う。dashboard Butler / passkey operator では、ユーザーが対象 scope を確認して passkey 承認した後に、追加のチャット GO を要求しない。

## Satisfied Success Criteria

- Canonical docs / AGENTS.md / owner-facing help 文言を scoped passkey approval モデルへ更新した。\nCore approval policy が、scope 一致済み real approvalGrant を GO なしで high-risk action に許可する。\nphrase-only passkey / missing grant / expired grant / scope mismatch は引き続き拒否する。\nproduction deploy workflow と deploy dispatch から approval_phrase=GO を外し、runtime_url + approval_grant_id を承認実体にした。\nGitHub high-risk authority plane から approvalPhrase=GO 要求を外し、approvalGrant + scope validation を承認実体にした。\npasskey operator から high-risk dispatch 時の approvalPhrase=GO 送信を外した。\n関連テストで passkey approval implies GO と phrase-only passkey 拒否を固定した。

## Unsatisfied Success Criteria

- Cloudflare production deploy は未実施。\nCustom GPT editor への手動反映は未実施。\niPhone 実機での passkey operator live E2E は未実施。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #430
- Implementing Success Criteria: 高リスク操作で real scoped passkey approval grant がある場合は GO を追加要求しない。passkey なし・scope 不一致・期限切れは拒否する。通常 write / build の GO 境界は維持する。
- Explicit Non-goals: Cloudflare deploy、v3 Worker deletion、credential/permission mutation、Action Schema editor 手動更新は対象外。
- Expected touched files/routes/workflows: src/core/approval.js; src/core/deploy-production-plane.js; src/core/github-high-risk-plane.js; src/core/passkey-operator-page.js; .github/workflows/deploy-production.yml; docs/security/*; dashboard/help docs; tests; worker.js
- Affected Issues: #430
- Affected PRs: なし
- Affected workflows: deploy-production workflow dispatch input から approval_phrase を削除。remote-codex-executor の通常 GO approval_phrase は維持。
- Affected runtime/operator surfaces: passkey operator; production deploy path; GitHub high-risk authority plane; dashboard/help owner-facing copy; Custom GPT setup artifacts docs
- What may break if we patch narrowly: policy だけ変えると deploy workflow や GitHub high-risk plane が古い GO 要求で失敗する。文言だけ変えると実行時の承認境界が矛盾する。
- Unknowns to investigate before coding: production deploy 後の live passkey operator E2E は未確認。Custom GPT editor 側には旧 schema/instructions が残る可能性がある。
- Validation needed: node --test 対象テスト; npm test; generated worker parity
- Stop condition: passkey なしで high-risk action が通る、scope 不一致が通る、通常 write/build の GO 境界が消える場合は停止。

## File / Line Hypotheses

- file: src/core/approval.js\n  - hypothesis: GO_PASSKEY branch を先に評価し、valid approvalGrant を署名付き GO とみなせば中核 policy が変わる。\n  - risk if changed narrowly: deploy/high-risk GitHub plane 側に approvalPhrase=GO 要求が残ると operator 体験が変わらない。\n  - validation: core-policy / deploy-production-plane / github-high-risk-plane / worker tests。\n  - related Issue: #430\n- file: .github/workflows/deploy-production.yml\n  - hypothesis: approval_phrase input を削除し、approval_grant_id validation に集約できる。\n  - risk if changed narrowly: workflow_dispatch payload と runtime dispatch body が不一致になる。\n  - validation: production-deploy-path / deploy-production-plane / worker tests。\n  - related Issue: #430

## Hypothesis Retrospective

- expected: scoped real approvalGrant を中心にすれば GO の二重要求を外せる。\n- actual: core policy、deploy workflow、deploy plane、GitHub high-risk plane、passkey operator、docs/tests を合わせて更新した。\n- mismatch: 生成 worker は commit 前の npm test で dirty 差分扱いになったため、commit 後に npm test を再実行した。\n- lesson: authority policy は docs だけでなく workflow input / dispatch payload / operator UI / generated worker まで同時に揃える必要がある。\n- should become RAG candidate: はい。高リスク approval は endpoint ごとに古い GO 要求が残りやすい。

## Verification Evidence

- Unit: node --test focused approval/deploy/high-risk/worker/doc tests PASS。
- Integration: npm test PASS: 830 tests, 829 pass, 1 skipped。check:self-parity PASS。check:generated-worker PASS。
- E2E: 未実施。production deploy 後に passkey operator の live E2E が必要。
- Manual: PR 作成前に rg で現行 surface の GO + passkey 文言が historical/draft 以外から外れていることを確認。
- Evidence path/link: ローカル実行ログ: node --test ...; npm test

## Butler Completion Contract

- Owner goal: 高リスク操作では passkey approval 画面の scope 確認を GO として扱い、dashboard Butler で余計な二重確認を減らす。
- Butler entrypoint: GET /v2/approval/passkey/operator。今後 dashboard Butler は passkey approval URL を出せば、追加 GO なしに scoped high-risk dispatch へ進める。
- Action Schema exposure: 既存 operationId の payload 互換。approvalPhrase は high-risk path で不要になるが、通常 write/build の GO 境界は維持。
- Runtime path: evaluateApproval; executeDeployProductionPlane; executeGitHubHighRiskPlane; deploy-production workflow; passkey operator page
- Runner/runtime truth: approvalGrant scope validation が runtime truth。deploy workflow は approval_grant_id を Worker runtime へ検証しに行く。
- Authority boundary: 低リスク表示は不要。通常 write/build は GO required のまま。高リスクは scoped passkey approval required。passkey なし・scope mismatch・expired grant は拒否。
- E2E evidence: 未実施。production deploy 後に iPhone/same-origin passkey operator で確認する。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: required after merge: GO ではなく scoped passkey approval が必要。
- Custom GPT Action Schema update: 必要になる可能性あり。ただしこのPRは runtime/docs を更新し、Custom GPT editor への手動反映は未実施。
- Custom GPT Instructions update: 必要になる可能性あり。ただし dashboard Butler へ寄せる前提で、editor 手動更新は別判断。
- iPhone Butler live E2E: required after deploy。

## Related Constitution Rules

- Butler Completion Gate\nAuthority Boundary\nEvidence Discipline\nIssue #430\ndocs/security/consent-approval-model.md

## Out-of-scope but NOT implemented

- Cloudflare deploy。\nv3 Worker deletion。\nCustom GPT editor への手動貼り替え。\npasskey なし high-risk 実行。

## Extra changes (if any)

worker.js は npm run build:worker で再生成。historical draft docs の GO + passkey 記述は過去文脈として残した。

<!-- VTDD metadata -->
- Issue: Issue #430
- Execution ID: mac-codex-issue-430-passkey-implies-go
- Goal: scoped passkey approval を high-risk signed GO として扱う
