### PR TITLE
deploy workflow に旧 operator 用の互換 input を戻す

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -3,6 +3,10 @@ name: deploy-production
 on:
   workflow_dispatch:
     inputs:
+      approval_phrase:
+        description: "Deprecated compatibility input from pre-#430 operators. Ignored; scoped approval_grant_id is authoritative."
+        required: false
+        type: string
       runtime_url:
         description: "Worker runtime URL used to validate the real passkey approval grant"
         required: true

--- a/test/production-deploy-path.test.js
+++ b/test/production-deploy-path.test.js
@@ -53,7 +53,9 @@ test("deploy-production workflow enforces the MVP production deploy boundary", (
   assert.equal(workflow.includes("issues: write"), true);
   assert.equal(workflow.includes("if: github.ref == 'refs/heads/main'"), true);
   assert.equal(workflow.includes("environment: production"), true);
-  assert.equal(workflow.includes("approval_phrase"), false);
+  assert.equal(workflow.includes("approval_phrase:"), true);
+  assert.equal(workflow.includes("Deprecated compatibility input from pre-#430 operators"), true);
+  assert.equal(workflow.includes('github.event.inputs.approval_phrase }}" != "GO"'), false);
   assert.equal(workflow.includes('github.event.inputs.runtime_url'), true);
   assert.equal(workflow.includes('github.event.inputs.approval_grant_id'), true);
   assert.equal(workflow.includes("Preflight deploy credentials"), true);


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #430 の deploy bootstrap 回復。#431 merge 後、古い production Worker operator が deprecated approval_phrase を送るため、まだ本番反映前の Worker から deploy できない状態を解消する。workflow は approval_phrase を任意互換 input として受けるが、承認判定には使わず scoped approval_grant_id を authoritative とする。

## Satisfied Success Criteria

- deploy-production workflow が deprecated approval_phrase input を任意で受ける。\napproval_phrase=GO の検証は復活させない。\n新 runtime dispatch は引き続き approval_phrase を送らない。\nテストで互換 input と非検証を固定した。

## Unsatisfied Success Criteria

- Cloudflare production deploy は未実施。\n本番 Worker の old operator 互換 deploy live 確認は未実施。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #430
- Implementing Success Criteria: old production operator が送る approval_phrase による workflow_dispatch failure を止める。新承認モデルは scoped approval_grant_id のまま維持する。
- Explicit Non-goals: policy rollback、approvalPhrase 再必須化、deploy 実行、v3 Worker 削除、Action Schema 更新は対象外。
- Expected touched files/routes/workflows: .github/workflows/deploy-production.yml; test/production-deploy-path.test.js
- Affected Issues: #430
- Affected PRs: #431 の production bootstrap 回復
- Affected workflows: deploy-production workflow の workflow_dispatch inputs
- Affected runtime/operator surfaces: pre-#430 production passkey operator からの deploy dispatch
- What may break if we patch narrowly: approval_phrase を再必須化すると #430 の設計を戻してしまう。互換 input の受け口だけに限定する。
- Unknowns to investigate before coding: production deploy run は未実施。新しい grant で old operator から成功するかは merge 後に確認する。
- Validation needed: node --test test/production-deploy-path.test.js test/deploy-production-plane.test.js
- Stop condition: approval_phrase が承認判定として復活する、または approval_grant_id なし deploy が通る場合は停止。

## File / Line Hypotheses

- file: .github/workflows/deploy-production.yml\n  - hypothesis: workflow_dispatch input に optional approval_phrase を戻せば GitHub Actions の Unexpected inputs を回避できる。\n  - risk if changed narrowly: validation step で GO を再要求すると #430 の目的を壊す。\n  - validation: production deploy path test。\n  - related Issue: #430

## Hypothesis Retrospective

- expected: optional input 追加のみで old operator bootstrap trap を解消できる。\n- actual: workflow に任意 approval_phrase input を追加し、検証では使わないことをテストで固定した。\n- mismatch: #431 で input 自体を削除したのが早すぎた。production Worker が古い間は workflow 側に互換口が必要。\n- lesson: self-deploy path の schema 変更は、old production operator から新 workflow を呼ぶ bootstrap compatibility が必要。\n- should become RAG candidate: はい。

## Verification Evidence

- Unit: node --test test/production-deploy-path.test.js test/deploy-production-plane.test.js PASS: 8 tests
- Integration: 未実施。変更は workflow input 互換のみ。
- E2E: 未実施。merge 後に old production operator または gh workflow run で deploy を確認する。
- Manual: GitHub Actions failure 'Unexpected inputs provided: [approval_phrase]' に対する互換修正。
- Evidence path/link: ローカル実行ログ: node --test test/production-deploy-path.test.js test/deploy-production-plane.test.js

## Butler Completion Contract

- Owner goal: 本番反映前の古い operator からでも #430 後 workflow を呼べるようにして、v2 Worker deploy を詰まらせない。
- Butler entrypoint: GET /v2/approval/passkey/operator の pre-#430 production page。
- Action Schema exposure: 変更なし。workflow_dispatch input の互換口のみ。
- Runtime path: deploy-production workflow_dispatch
- Runner/runtime truth: approval_grant_id の validation step が承認実体。approval_phrase は ignored compatibility input。
- Authority boundary: scoped passkey approval required。approval_phrase は承認境界ではない。
- E2E evidence: 未実施。merge 後に production deploy run で確認。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: required after merge with scoped passkey approval.
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: merge/deploy 後に必要。

## Related Constitution Rules

- Issue #430\nAuthority Boundary\nEvidence Discipline\nSelf-deploy bootstrap compatibility

## Out-of-scope but NOT implemented

- Cloudflare deploy 実行。\npolicy rollback。\nCustom GPT editor 更新。

## Extra changes (if any)

この PR は #431 の hotfix/compat slice。

<!-- VTDD metadata -->
- Issue: Issue #430
- Execution ID: mac-codex-issue-430-deploy-compat
- Goal: old production operator の deploy workflow_dispatch 互換を戻す
