### PR TITLE
Issue #435 /status 人間向け health viewer

### DIFF
--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -101,6 +101,16 @@ export default {
       });
     }
 
+    if (request.method === "GET" && url.pathname === "/status") {
+      return html(
+        200,
+        renderV2StatusPage({
+          runtimeOrigin: url.origin,
+          autonomyMode: resolveRuntimeAutonomyMode(env)
+        })
+      );
+    }
+
     if (
       request.method === "GET" &&
       (url.pathname === "/setup" ||
@@ -5020,7 +5030,7 @@ function renderV2DashboardPage({ runtimeOrigin }) {
         <h1>VTDD Butler</h1>
         <p>v2 の GitHub App / VPS runner / Gemini reviewer / RAG / passkey / runtime truth をそのまま使う dashboard 入口です。</p>
       </div>
-      <a class="button" href="${escapeDashboardHtml(origin)}/health">Health</a>
+      <a class="button" href="${escapeDashboardHtml(origin)}/status">Health</a>
     </header>
 
     <section class="panel cockpit" aria-label="Butler conversation cockpit">
@@ -5122,6 +5132,84 @@ function renderV2DashboardPage({ runtimeOrigin }) {
         <li>必要なら v3 Worker は disable / rename / delete の順に検討する。</li>
         <li>secret や approval grant は dashboard に表示しない。</li>
       </ul>
+    </section>
+  </main>
+</body>
+</html>`;
+}
+
+function renderV2StatusPage({ runtimeOrigin, autonomyMode }) {
+  const origin = normalize(runtimeOrigin);
+  const mode = "v2";
+  const resolvedAutonomyMode = normalizeText(autonomyMode) || "normal";
+  const cards = [
+    ["Worker", "正常", "Cloudflare Worker は応答しています。"],
+    ["Mode", mode, "現在の runtime mode です。"],
+    ["Autonomy", resolvedAutonomyMode, "guarded absence などの実行抑制状態を示します。"],
+    ["Dashboard", "利用可能", "/dashboard と /orchestrator は人間向け入口です。"],
+    ["Passkey", "same-origin", "高リスク操作は scope 明示済み passkey approval の後ろです。"],
+    ["Raw health", "JSON", "/health は API 互換の machine-readable endpoint として残します。"]
+  ];
+
+  return `<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>VTDD v2 Status</title>
+  <style>
+    :root { color-scheme: light; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; color: #182125; background: #f7faf7; }
+    body { margin: 0; }
+    main { width: min(1040px, calc(100% - 32px)); margin: 0 auto; padding: 28px 0 48px; }
+    header { display: flex; justify-content: space-between; gap: 16px; align-items: flex-start; margin-bottom: 20px; }
+    h1 { font-size: clamp(32px, 6vw, 52px); line-height: 1; margin: 8px 0; }
+    h2 { font-size: 24px; margin: 0 0 14px; }
+    h3 { margin: 0 0 8px; font-size: 19px; }
+    p { line-height: 1.7; color: #4d5c56; }
+    .eyebrow { color: #2c7658; font-size: 13px; font-weight: 800; letter-spacing: .08em; text-transform: uppercase; }
+    .panel { background: #fff; border: 1px solid #dce5dd; border-radius: 8px; padding: 22px; box-shadow: 0 10px 30px rgba(28, 44, 35, .06); margin: 16px 0; }
+    .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(230px, 1fr)); gap: 14px; }
+    .card { border: 1px solid #dce5dd; border-radius: 8px; padding: 16px; background: #fbfdfb; }
+    .badge { display: inline-flex; align-items: center; border: 1px solid #c8d8cc; border-radius: 999px; padding: 4px 9px; color: #315245; background: #f7faf7; font-size: 13px; font-weight: 750; }
+    a.button, .card a { display: inline-flex; align-items: center; justify-content: center; border: 1px solid #b9cabe; border-radius: 7px; padding: 9px 12px; color: #0f513b; font-weight: 750; text-decoration: none; background: #f8fbf8; }
+    a.primary { background: #247a5b; color: #fff; border-color: #247a5b; }
+    .actions { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 14px; }
+    .notice { border-color: #d8e6d5; background: #f7fcf8; }
+    code { color: #596860; }
+    @media (max-width: 640px) { header { display: block; } main { width: min(100% - 20px, 1040px); padding-top: 16px; } .actions a { width: 100%; } }
+  </style>
+</head>
+<body>
+  <main>
+    <header>
+      <div>
+        <p class="eyebrow">VTDD v2 status</p>
+        <h1>Runtime Status</h1>
+        <p>ブラウザで見るための health summary です。機械向け JSON は <code>/health</code> に残しています。</p>
+      </div>
+      <a class="button" href="${escapeDashboardHtml(origin)}/dashboard">Dashboard</a>
+    </header>
+
+    <section class="panel notice">
+      <h2>現在の状態</h2>
+      <p><span class="badge">正常</span></p>
+      <p>Worker は応答しています。ここでは secret、token、approval grant は表示しません。</p>
+      <div class="actions">
+        <a class="primary" href="${escapeDashboardHtml(origin)}/dashboard">Butler dashboard</a>
+        <a href="${escapeDashboardHtml(origin)}/health">raw /health JSON</a>
+        <a href="${escapeDashboardHtml(origin)}/v2/approval/passkey/operator?repositoryInput=marushu%2Fvtdd-v2-p">Passkey operator</a>
+      </div>
+    </section>
+
+    <section class="panel">
+      <h2>Summary</h2>
+      <div class="grid">
+        ${cards.map(([title, status, body]) => `<article class="card">
+          <h3>${escapeDashboardHtml(title)}</h3>
+          <p><span class="badge">${escapeDashboardHtml(status)}</span></p>
+          <p>${escapeDashboardHtml(body)}</p>
+        </article>`).join("")}
+      </div>
     </section>
   </main>
 </body>

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -129,6 +129,20 @@ test("worker returns health", async () => {
   assert.equal(body.autonomyMode, AutonomyMode.NORMAL);
 });
 
+test("worker serves human-facing status page while keeping raw health JSON", async () => {
+  const response = await worker.fetch(new Request("https://example.com/status"));
+  assert.equal(response.status, 200);
+  assert.match(response.headers.get("content-type"), /text\/html/);
+  const body = await response.text();
+  assert.equal(body.includes("VTDD v2 status"), true);
+  assert.equal(body.includes("Runtime Status"), true);
+  assert.equal(body.includes("raw /health JSON"), true);
+  assert.equal(body.includes("/dashboard"), true);
+  assert.equal(body.includes("/v2/approval/passkey/operator?repositoryInput=marushu%2Fvtdd-v2-p"), true);
+  assert.equal(body.includes("approvalGrantId"), false);
+  assert.equal(body.includes("CLOUDFLARE_API_TOKEN"), false);
+});
+
 test("worker serves v2 dashboard without exposing secrets", async () => {
   const response = await worker.fetch(new Request("https://example.com/dashboard"));
   assert.equal(response.status, 200);
@@ -152,6 +166,7 @@ test("worker serves v2 dashboard without exposing secrets", async () => {
     body.includes("/v2/approval/passkey/operator?repositoryInput=marushu%2Fvtdd-v2-p"),
     true
   );
+  assert.equal(body.includes('href="https://example.com/status">Health</a>'), true);
   assert.equal(body.includes("/v2/retrieve/startup-preflight"), true);
   assert.equal(body.includes("/v2/action/vps-runner-status"), true);
   assert.equal(body.includes("/v2/retrieve/operational-memory"), true);

--- a/worker.js
+++ b/worker.js
@@ -55765,6 +55765,15 @@ var runtime_default = {
         autonomyMode: resolveRuntimeAutonomyMode(env)
       });
     }
+    if (request.method === "GET" && url.pathname === "/status") {
+      return html(
+        200,
+        renderV2StatusPage({
+          runtimeOrigin: url.origin,
+          autonomyMode: resolveRuntimeAutonomyMode(env)
+        })
+      );
+    }
     if (request.method === "GET" && (url.pathname === "/setup" || url.pathname === "/setup/recovery" || url.pathname === "/setup/latest" || url.pathname === "/setup/known-good")) {
       return handleCustomGptRecoveryPageRequest(url, env);
     }
@@ -59977,7 +59986,7 @@ function renderV2DashboardPage({ runtimeOrigin }) {
         <h1>VTDD Butler</h1>
         <p>v2 \u306E GitHub App / VPS runner / Gemini reviewer / RAG / passkey / runtime truth \u3092\u305D\u306E\u307E\u307E\u4F7F\u3046 dashboard \u5165\u53E3\u3067\u3059\u3002</p>
       </div>
-      <a class="button" href="${escapeDashboardHtml(origin)}/health">Health</a>
+      <a class="button" href="${escapeDashboardHtml(origin)}/status">Health</a>
     </header>
 
     <section class="panel cockpit" aria-label="Butler conversation cockpit">
@@ -60079,6 +60088,82 @@ function renderV2DashboardPage({ runtimeOrigin }) {
         <li>\u5FC5\u8981\u306A\u3089 v3 Worker \u306F disable / rename / delete \u306E\u9806\u306B\u691C\u8A0E\u3059\u308B\u3002</li>
         <li>secret \u3084 approval grant \u306F dashboard \u306B\u8868\u793A\u3057\u306A\u3044\u3002</li>
       </ul>
+    </section>
+  </main>
+</body>
+</html>`;
+}
+function renderV2StatusPage({ runtimeOrigin, autonomyMode }) {
+  const origin = normalize7(runtimeOrigin);
+  const mode = "v2";
+  const resolvedAutonomyMode = normalizeText30(autonomyMode) || "normal";
+  const cards = [
+    ["Worker", "\u6B63\u5E38", "Cloudflare Worker \u306F\u5FDC\u7B54\u3057\u3066\u3044\u307E\u3059\u3002"],
+    ["Mode", mode, "\u73FE\u5728\u306E runtime mode \u3067\u3059\u3002"],
+    ["Autonomy", resolvedAutonomyMode, "guarded absence \u306A\u3069\u306E\u5B9F\u884C\u6291\u5236\u72B6\u614B\u3092\u793A\u3057\u307E\u3059\u3002"],
+    ["Dashboard", "\u5229\u7528\u53EF\u80FD", "/dashboard \u3068 /orchestrator \u306F\u4EBA\u9593\u5411\u3051\u5165\u53E3\u3067\u3059\u3002"],
+    ["Passkey", "same-origin", "\u9AD8\u30EA\u30B9\u30AF\u64CD\u4F5C\u306F scope \u660E\u793A\u6E08\u307F passkey approval \u306E\u5F8C\u308D\u3067\u3059\u3002"],
+    ["Raw health", "JSON", "/health \u306F API \u4E92\u63DB\u306E machine-readable endpoint \u3068\u3057\u3066\u6B8B\u3057\u307E\u3059\u3002"]
+  ];
+  return `<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>VTDD v2 Status</title>
+  <style>
+    :root { color-scheme: light; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; color: #182125; background: #f7faf7; }
+    body { margin: 0; }
+    main { width: min(1040px, calc(100% - 32px)); margin: 0 auto; padding: 28px 0 48px; }
+    header { display: flex; justify-content: space-between; gap: 16px; align-items: flex-start; margin-bottom: 20px; }
+    h1 { font-size: clamp(32px, 6vw, 52px); line-height: 1; margin: 8px 0; }
+    h2 { font-size: 24px; margin: 0 0 14px; }
+    h3 { margin: 0 0 8px; font-size: 19px; }
+    p { line-height: 1.7; color: #4d5c56; }
+    .eyebrow { color: #2c7658; font-size: 13px; font-weight: 800; letter-spacing: .08em; text-transform: uppercase; }
+    .panel { background: #fff; border: 1px solid #dce5dd; border-radius: 8px; padding: 22px; box-shadow: 0 10px 30px rgba(28, 44, 35, .06); margin: 16px 0; }
+    .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(230px, 1fr)); gap: 14px; }
+    .card { border: 1px solid #dce5dd; border-radius: 8px; padding: 16px; background: #fbfdfb; }
+    .badge { display: inline-flex; align-items: center; border: 1px solid #c8d8cc; border-radius: 999px; padding: 4px 9px; color: #315245; background: #f7faf7; font-size: 13px; font-weight: 750; }
+    a.button, .card a { display: inline-flex; align-items: center; justify-content: center; border: 1px solid #b9cabe; border-radius: 7px; padding: 9px 12px; color: #0f513b; font-weight: 750; text-decoration: none; background: #f8fbf8; }
+    a.primary { background: #247a5b; color: #fff; border-color: #247a5b; }
+    .actions { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 14px; }
+    .notice { border-color: #d8e6d5; background: #f7fcf8; }
+    code { color: #596860; }
+    @media (max-width: 640px) { header { display: block; } main { width: min(100% - 20px, 1040px); padding-top: 16px; } .actions a { width: 100%; } }
+  </style>
+</head>
+<body>
+  <main>
+    <header>
+      <div>
+        <p class="eyebrow">VTDD v2 status</p>
+        <h1>Runtime Status</h1>
+        <p>\u30D6\u30E9\u30A6\u30B6\u3067\u898B\u308B\u305F\u3081\u306E health summary \u3067\u3059\u3002\u6A5F\u68B0\u5411\u3051 JSON \u306F <code>/health</code> \u306B\u6B8B\u3057\u3066\u3044\u307E\u3059\u3002</p>
+      </div>
+      <a class="button" href="${escapeDashboardHtml(origin)}/dashboard">Dashboard</a>
+    </header>
+
+    <section class="panel notice">
+      <h2>\u73FE\u5728\u306E\u72B6\u614B</h2>
+      <p><span class="badge">\u6B63\u5E38</span></p>
+      <p>Worker \u306F\u5FDC\u7B54\u3057\u3066\u3044\u307E\u3059\u3002\u3053\u3053\u3067\u306F secret\u3001token\u3001approval grant \u306F\u8868\u793A\u3057\u307E\u305B\u3093\u3002</p>
+      <div class="actions">
+        <a class="primary" href="${escapeDashboardHtml(origin)}/dashboard">Butler dashboard</a>
+        <a href="${escapeDashboardHtml(origin)}/health">raw /health JSON</a>
+        <a href="${escapeDashboardHtml(origin)}/v2/approval/passkey/operator?repositoryInput=marushu%2Fvtdd-v2-p">Passkey operator</a>
+      </div>
+    </section>
+
+    <section class="panel">
+      <h2>Summary</h2>
+      <div class="grid">
+        ${cards.map(([title, status, body]) => `<article class="card">
+          <h3>${escapeDashboardHtml(title)}</h3>
+          <p><span class="badge">${escapeDashboardHtml(status)}</span></p>
+          <p>${escapeDashboardHtml(body)}</p>
+        </article>`).join("")}
+      </div>
     </section>
   </main>
 </body>


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #435 の Intent に従い、/health を直接開いた時の JSON だけの体験を dashboard から避けるため、人間向け /status ページを追加しました。\n- /health は API 互換の JSON endpoint として残し、dashboard の Health 導線だけ /status に変更しました。

## Satisfied Success Criteria

- /health は既存 JSON のまま維持しました。\n- /status は人間向け HTML として Worker、mode、autonomy、dashboard、passkey、raw health 導線を表示します。\n- /dashboard の Health ボタンを /status に向けました。\n- /status から raw /health JSON を開けます。\n- /status に secret、token、approvalGrantId を表示しないことをテストしました。

## Unsatisfied Success Criteria

- live deploy SHA 比較、GitHub Actions / VPS runner / reviewer の実測 status はこの PR の Non-goal として未実装です。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #435
- Implementing Success Criteria: /health JSON 互換維持、/status HTML 追加、dashboard Health link 更新、secret 非表示。
- Explicit Non-goals: GitHub API live check、VPS runner 実測、通知、会話エンジンは対象外。
- Expected touched files/routes/workflows: src/worker/runtime.js, worker.js, test/worker.test.js
- Affected Issues: Issue #428, Issue #433, Issue #435
- Affected PRs: なし
- Affected workflows: deploy-production は merge 後の本番反映時のみ影響。
- Affected runtime/operator surfaces: /health, /status, /dashboard
- What may break if we patch narrowly: /health を HTML に変えると API 互換を壊すため、/status を追加して dashboard 導線だけ変える。
- Unknowns to investigate before coding: 将来 /status に live truth を足す場合の GitHub / VPS fetch 境界は未決定。
- Validation needed: node --test test/worker.test.js, npm test.
- Stop condition: /status が secret や approvalGrantId を表示する必要が出たら停止。live external fetch が必要になったら別 Issue 化。

## File / Line Hypotheses

- file: src/worker/runtime.js\n  - hypothesis: /health は API として残し、/status を追加するのが互換性を壊さない。\n  - risk if changed narrowly: dashboard の Health link を変え忘れると owner は引き続き JSON に落ちる。\n  - validation: test/worker.test.js で /health JSON、/status HTML、dashboard link を確認。\n  - related Issue: Issue #435

## Hypothesis Retrospective

- expected: /status が人間向け HTML を返し、/health JSON は維持される。\n- actual: /status 追加、dashboard Health link 更新、/health JSON 維持を確認。\n- mismatch: なし。\n- lesson: machine endpoint と owner-facing viewer を分けると API 互換と UX を両立できる。\n- should become RAG candidate: はい。runtime truth viewer 方針の候補。

## Verification Evidence

- Unit: node --test test/worker.test.js PASS: 124 tests
- Integration: npm test PASS: 831 tests, 830 pass, 1 skipped; self-parity pass; generated-worker check pass
- E2E: Worker fetch test で /status HTML と /dashboard -> /status 導線を確認。
- Manual: 未実施。merge/deploy 後に本番 Worker URL で確認予定。
- Evidence path/link: test/worker.test.js と PR checks

## Butler Completion Contract

- Owner goal: Health を押した owner がいきなり JSON を見せられず、状態を人間向けに読めるようにする。
- Butler entrypoint: /dashboard の Health ボタン、/status
- Action Schema exposure: 不要。/health JSON 互換を維持し、人間向け HTML route を追加。
- Runtime path: GET /health, GET /status, GET /dashboard
- Runner/runtime truth: /status が Worker 自身の mode/autonomy と既存導線を表示する。
- Authority boundary: 新しい authority なし。passkey operator へのリンクのみ。
- E2E evidence: ローカル Worker fetch test で確認。本番 iPhone 確認は deploy 後。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: merge 後に必要。production deploy は scoped passkey approval 対象。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: merge/deploy 後に本番 /status を確認。

## Related Constitution Rules

- AGENTS.md Conversation UX Contract\n- AGENTS.md Evidence Discipline\n- AGENTS.md Butler Completion Gate

## Out-of-scope but NOT implemented

- GitHub Actions live status card\n- VPS runner live status card\n- reviewer live status card\n- Butler 会話エンジン

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #435
- Execution ID: mac-codex-issue-435-status-page
- Goal: 人間向け /status を追加して dashboard Health 導線を改善する
