### PR TITLE
dashboard: GitHub Actions 完了イベントを表示する

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -135,6 +135,51 @@ jobs:
           wranglerVersion: "4.83.0"
           command: deploy --config wrangler.production.generated.toml --env production
 
+      - name: Notify dashboard deploy event
+        if: always()
+        env:
+          VTDD_GATEWAY_BEARER_TOKEN: ${{ secrets.VTDD_GATEWAY_BEARER_TOKEN }}
+          DEPLOY_JOB_STATUS: ${{ job.status }}
+          REPOSITORY: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          DEPLOY_SHA: ${{ github.sha }}
+          DEPLOY_BRANCH: ${{ github.ref_name }}
+          RUNTIME_URL: ${{ github.event.inputs.runtime_url }}
+        shell: bash
+        run: |
+          if [ -z "$RUNTIME_URL" ]; then
+            echo "runtime_url is not set; skipping dashboard deploy event."
+            exit 0
+          fi
+          if [ -z "$VTDD_GATEWAY_BEARER_TOKEN" ]; then
+            echo "VTDD_GATEWAY_BEARER_TOKEN is not set; skipping dashboard deploy event."
+            exit 0
+          fi
+
+          event_body=$(node - <<'NODE'
+          const payload = {
+            repository: process.env.REPOSITORY,
+            workflowName: "deploy-production",
+            runId: process.env.RUN_ID,
+            runUrl: process.env.RUN_URL,
+            status: "completed",
+            conclusion: process.env.DEPLOY_JOB_STATUS,
+            headSha: process.env.DEPLOY_SHA,
+            headBranch: process.env.DEPLOY_BRANCH,
+            displayTitle: "deploy-production",
+            updatedAt: new Date().toISOString()
+          };
+          process.stdout.write(JSON.stringify(payload));
+          NODE
+          )
+
+          curl --fail-with-body --show-error --silent \
+            -X POST "${RUNTIME_URL%/}/v2/events/github-actions" \
+            -H "authorization: Bearer ${VTDD_GATEWAY_BEARER_TOKEN}" \
+            -H "content-type: application/json" \
+            --data "$event_body"
+
       - name: Notify deploy completion
         if: always()
         env:

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -87,6 +87,7 @@ const DEFAULT_MEMORY_LIMIT = 20;
 const MAX_MEMORY_LIMIT = 200;
 const memoryProviderCache = new WeakMap();
 const d1AdapterCache = new WeakMap();
+const dashboardEventStoreCache = new WeakMap();
 
 export default {
   async fetch(request, env) {
@@ -136,7 +137,13 @@ export default {
     }
 
     if (request.method === "GET" && (url.pathname === "/dashboard" || url.pathname === "/orchestrator")) {
-      return html(200, renderV2DashboardPage({ runtimeOrigin: url.origin }));
+      return html(
+        200,
+        await renderV2DashboardPage({
+          runtimeOrigin: url.origin,
+          dashboardEventStore: resolveDashboardEventStore(env)
+        })
+      );
     }
 
     if (
@@ -317,6 +324,23 @@ export default {
       }
 
       return handleDeployProductionRequest(request, env);
+    }
+
+    if (request.method === "POST" && isApiPath(url.pathname, "/events/github-actions")) {
+      const auth = authorizeGatewayRequest({
+        request,
+        env,
+        apiSuffix: "/events/github-actions"
+      });
+      if (!auth.ok) {
+        return json(auth.status, {
+          ok: false,
+          error: "unauthorized",
+          reason: auth.reason
+        });
+      }
+
+      return handleGitHubActionsEventRequest(request, env);
     }
 
     if (request.method === "POST" && isApiPath(url.pathname, "/action/github-actions-secret")) {
@@ -2982,6 +3006,33 @@ async function handleDeployProductionRequest(request, env) {
   });
 }
 
+async function handleGitHubActionsEventRequest(request, env) {
+  const payload = await readJson(request);
+  const event = normalizeGitHubActionsEvent(payload);
+  if (!event.ok) {
+    return json(422, {
+      ok: false,
+      error: event.error,
+      reason: event.reason
+    });
+  }
+
+  const store = resolveDashboardEventStore(env);
+  if (!store) {
+    return json(503, {
+      ok: false,
+      error: "dashboard_event_store_unavailable",
+      reason: "dashboard event store is not configured"
+    });
+  }
+
+  await store.put(event.event);
+  return json(202, {
+    ok: true,
+    event: event.event
+  });
+}
+
 async function handleGitHubActionsSecretSyncRequest(request, env) {
   const payload = await readJson(request);
   if (!payload || typeof payload !== "object") {
@@ -4458,6 +4509,138 @@ function resolveMemoryProvider(env) {
   return provider;
 }
 
+function resolveDashboardEventStore(env) {
+  if (!env || typeof env !== "object") {
+    return null;
+  }
+  const injectedStore = env.DASHBOARD_EVENT_STORE ?? null;
+  if (
+    injectedStore &&
+    typeof injectedStore.put === "function" &&
+    typeof injectedStore.latest === "function"
+  ) {
+    return injectedStore;
+  }
+
+  const d1Binding = env[MEMORY_D1_BINDING] ?? null;
+  if (!d1Binding || typeof d1Binding.prepare !== "function") {
+    return null;
+  }
+  if (dashboardEventStoreCache.has(d1Binding)) {
+    return dashboardEventStoreCache.get(d1Binding);
+  }
+  const store = createD1DashboardEventStore(d1Binding);
+  dashboardEventStoreCache.set(d1Binding, store);
+  return store;
+}
+
+function createD1DashboardEventStore(d1) {
+  let schemaPromise = null;
+  return {
+    async put(event) {
+      const normalized = normalizeDashboardEventRecord(event);
+      await ensureSchema();
+      await d1
+        .prepare(
+          `INSERT OR REPLACE INTO vtdd_dashboard_events (
+             id, kind, repository, workflow_name, run_id, status, conclusion,
+             head_sha, head_branch, run_url, title, created_at, updated_at, payload_json
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+        )
+        .bind(
+          normalized.id,
+          normalized.kind,
+          normalized.repository,
+          normalized.workflowName,
+          normalized.runId,
+          normalized.status,
+          normalized.conclusion,
+          normalized.headSha,
+          normalized.headBranch,
+          normalized.runUrl,
+          normalized.title,
+          normalized.createdAt,
+          normalized.updatedAt,
+          JSON.stringify(normalized)
+        )
+        .run();
+      return normalized;
+    },
+
+    async latest(filter = {}) {
+      await ensureSchema();
+      const kind = normalizeText(filter.kind);
+      const repository = normalizeCanonicalRepositoryInput(filter.repository);
+      const workflowName = normalizeText(filter.workflowName);
+      const clauses = [];
+      const params = [];
+      if (kind) {
+        clauses.push("kind = ?");
+        params.push(kind);
+      }
+      if (repository) {
+        clauses.push("repository = ?");
+        params.push(repository);
+      }
+      if (workflowName) {
+        clauses.push("workflow_name = ?");
+        params.push(workflowName);
+      }
+      const where = clauses.length > 0 ? `WHERE ${clauses.join(" AND ")}` : "";
+      const result = await d1
+        .prepare(
+          `SELECT payload_json FROM vtdd_dashboard_events ${where} ORDER BY updated_at DESC, created_at DESC LIMIT 1`
+        )
+        .bind(...params)
+        .all();
+      const row = Array.isArray(result?.results) ? result.results[0] : null;
+      if (!row?.payload_json) {
+        return null;
+      }
+      try {
+        return normalizeDashboardEventRecord(JSON.parse(row.payload_json));
+      } catch {
+        return null;
+      }
+    }
+  };
+
+  function ensureSchema() {
+    if (!schemaPromise) {
+      schemaPromise = (async () => {
+        await d1.exec(
+          "CREATE TABLE IF NOT EXISTS vtdd_dashboard_events (id TEXT PRIMARY KEY, kind TEXT NOT NULL, repository TEXT NOT NULL, workflow_name TEXT NOT NULL, run_id TEXT NOT NULL, status TEXT NOT NULL, conclusion TEXT, head_sha TEXT, head_branch TEXT, run_url TEXT, title TEXT, created_at TEXT NOT NULL, updated_at TEXT NOT NULL, payload_json TEXT NOT NULL);"
+        );
+        await d1.exec(
+          "CREATE INDEX IF NOT EXISTS idx_vtdd_dashboard_events_lookup ON vtdd_dashboard_events (kind, repository, workflow_name, updated_at DESC);"
+        );
+      })();
+    }
+    return schemaPromise;
+  }
+}
+
+function normalizeDashboardEventRecord(event) {
+  const input = normalizeObject(event);
+  const updatedAt = normalizeIsoTimestamp(input.updatedAt) || new Date().toISOString();
+  const createdAt = normalizeIsoTimestamp(input.createdAt) || updatedAt;
+  return {
+    id: normalizeText(input.id),
+    kind: normalizeText(input.kind),
+    repository: normalizeCanonicalRepositoryInput(input.repository),
+    workflowName: normalizeText(input.workflowName),
+    runId: normalizeText(input.runId),
+    status: normalizeText(input.status),
+    conclusion: normalizeText(input.conclusion) || null,
+    headSha: normalizeText(input.headSha) || null,
+    headBranch: normalizeText(input.headBranch) || null,
+    runUrl: normalizeText(input.runUrl) || null,
+    title: normalizeText(input.title) || normalizeText(input.workflowName),
+    createdAt,
+    updatedAt
+  };
+}
+
 function createD1MemoryIndexAdapter(d1) {
   if (!d1 || typeof d1.prepare !== "function") {
     return null;
@@ -4893,6 +5076,119 @@ function normalizeObject(value) {
   return value;
 }
 
+function normalizeGitHubActionsEvent(payload) {
+  const input = normalizeObject(payload);
+  const repository = normalizeCanonicalRepositoryInput(input.repository || input.githubRepository);
+  const workflowName = normalizeText(input.workflowName || input.workflow || input.workflow_name);
+  const runId = normalizeText(input.runId || input.run_id || input.databaseId || input.database_id);
+  const runUrl = normalizeText(input.runUrl || input.run_url || input.url);
+  const status = normalizeText(input.status || "completed").toLowerCase();
+  const conclusion = normalizeText(input.conclusion || input.result).toLowerCase();
+  const updatedAt = normalizeIsoTimestamp(input.updatedAt || input.updated_at) || new Date().toISOString();
+  const createdAt = normalizeIsoTimestamp(input.createdAt || input.created_at) || updatedAt;
+  const headSha = normalizeText(input.headSha || input.head_sha || input.sha);
+  const headBranch = normalizeText(input.headBranch || input.head_branch || input.branch);
+  const title = normalizeText(input.displayTitle || input.display_title || input.title);
+
+  if (!repository) {
+    return {
+      ok: false,
+      error: "repository_required",
+      reason: "GitHub Actions event repository is required"
+    };
+  }
+  if (!workflowName) {
+    return {
+      ok: false,
+      error: "workflow_required",
+      reason: "GitHub Actions event workflowName is required"
+    };
+  }
+  if (!runId) {
+    return {
+      ok: false,
+      error: "run_id_required",
+      reason: "GitHub Actions event runId is required"
+    };
+  }
+  if (!["queued", "in_progress", "completed", "requested", "waiting"].includes(status)) {
+    return {
+      ok: false,
+      error: "status_unsupported",
+      reason: "GitHub Actions event status must be queued, in_progress, completed, requested, or waiting"
+    };
+  }
+  if (conclusion && !["success", "failure", "cancelled", "skipped", "timed_out", "action_required"].includes(conclusion)) {
+    return {
+      ok: false,
+      error: "conclusion_unsupported",
+      reason: "GitHub Actions event conclusion is not supported"
+    };
+  }
+
+  const event = {
+    id: `github-actions:${repository}:${workflowName}:${runId}`,
+    kind: "github_actions_workflow_run",
+    repository,
+    workflowName,
+    runId,
+    status,
+    conclusion: conclusion || null,
+    headSha: headSha || null,
+    headBranch: headBranch || null,
+    runUrl: runUrl || null,
+    title: title || workflowName,
+    createdAt,
+    updatedAt
+  };
+
+  return {
+    ok: true,
+    event
+  };
+}
+
+function normalizeIsoTimestamp(value) {
+  const text = normalizeText(value);
+  if (!text) {
+    return "";
+  }
+  const timestamp = new Date(text);
+  if (Number.isNaN(timestamp.getTime())) {
+    return "";
+  }
+  return timestamp.toISOString();
+}
+
+async function retrieveLatestDashboardEvent({ store, kind, repository, workflowName } = {}) {
+  if (!store || typeof store.latest !== "function") {
+    return null;
+  }
+  try {
+    return await store.latest({ kind, repository, workflowName });
+  } catch {
+    return null;
+  }
+}
+
+function renderDashboardDeployEvent(event) {
+  if (!event) {
+    return `<div class="deploy-event muted">直近 deploy event: 未受信</div>`;
+  }
+  const conclusion = normalizeText(event.conclusion) || normalizeText(event.status) || "unknown";
+  const badgeClass = conclusion === "success" ? "success" : conclusion === "failure" || conclusion === "cancelled" ? "danger" : "";
+  const updatedAt = normalizeText(event.updatedAt);
+  const sha = normalizeText(event.headSha);
+  const shortSha = sha ? sha.slice(0, 7) : "unknown";
+  const runUrl = normalizeText(event.runUrl);
+  const runLabel = runUrl ? `<a class="chat-link" href="${escapeDashboardHtml(runUrl)}">Actions run</a>` : "Actions run 未設定";
+  return `<div class="deploy-event">
+            <div class="lane-title"><strong>最新 deploy</strong><span class="pill ${badgeClass}">${escapeDashboardHtml(conclusion)}</span></div>
+            <p>${escapeDashboardHtml(event.workflowName || "deploy-production")} / <code>${escapeDashboardHtml(shortSha)}</code></p>
+            <p class="muted">${escapeDashboardHtml(updatedAt || "updatedAt 未受信")} ・ ${runLabel}</p>
+          </div>`;
+}
+
 function normalizeTextList(value) {
   if (Array.isArray(value)) {
     return value.map(normalizeText).filter(Boolean);
@@ -4905,10 +5201,16 @@ function uniqueTextList(value) {
   return [...new Set(normalizeTextList(value))];
 }
 
-function renderV2DashboardPage({ runtimeOrigin }) {
+async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}) {
   const origin = normalize(runtimeOrigin);
   const repository = "marushu/vtdd-v2-p";
   const encodedRepository = encodeURIComponent(repository);
+  const latestDeployEvent = await retrieveLatestDashboardEvent({
+    store: dashboardEventStore,
+    kind: "github_actions_workflow_run",
+    repository,
+    workflowName: "deploy-production"
+  });
   const surfaces = [
     {
       title: "Status page",
@@ -5062,6 +5364,10 @@ function renderV2DashboardPage({ runtimeOrigin }) {
     .lane, details { border: 1px solid var(--border); border-radius: 14px; padding: 12px; background: var(--panel-strong); }
     .lane-title { display: flex; justify-content: space-between; gap: 8px; align-items: baseline; }
     .pill { display: inline-flex; align-items: center; border: 1px solid var(--border); border-radius: 999px; padding: 3px 8px; color: var(--text); background: var(--soft); font-size: 12px; white-space: nowrap; }
+    .pill.success { border-color: #7fb797; background: #e7f5ec; color: #145c34; }
+    .pill.danger { border-color: #d69b9b; background: #fff0f0; color: #8a1f1f; }
+    .deploy-event { border: 1px solid var(--border); border-radius: 12px; padding: 10px; margin: 10px 0; background: var(--soft); }
+    .deploy-event p { margin-bottom: 6px; font-size: 13px; line-height: 1.45; }
     .quick-actions, .surface-list { display: grid; gap: 8px; }
     .quick-actions { grid-template-columns: repeat(2, minmax(0, 1fr)); }
     .quick-actions a, .surface-list a { display: inline-flex; align-items: center; justify-content: center; min-height: 36px; border: 1px solid var(--border); border-radius: 10px; padding: 7px 9px; color: var(--text); text-decoration: none; background: var(--soft); font-weight: 750; font-size: 13px; text-align: center; }
@@ -5182,6 +5488,7 @@ function renderV2DashboardPage({ runtimeOrigin }) {
         <div class="lane">
           <div class="lane-title"><h3>進行中 execution</h3><span class="pill">runtime truth</span></div>
           <p>進捗は GitHub Actions / VPS runner status / execution progress route から読みます。</p>
+          ${renderDashboardDeployEvent(latestDeployEvent)}
           <div class="quick-actions">
             ${cockpitActions.map((action) => `<a href="${escapeDashboardHtml(action.href)}">${escapeDashboardHtml(action.label)}</a>`).join("")}
           </div>

--- a/test/production-deploy-path.test.js
+++ b/test/production-deploy-path.test.js
@@ -103,6 +103,11 @@ test("deploy-production workflow enforces the MVP production deploy boundary", (
     true
   );
   assert.equal(workflow.includes("Notify deploy completion"), true);
+  assert.equal(workflow.includes("Notify dashboard deploy event"), true);
+  assert.equal(workflow.includes("/v2/events/github-actions"), true);
+  assert.equal(workflow.includes("curl --fail-with-body"), true);
+  assert.equal(workflow.includes("authorization: Bearer ${VTDD_GATEWAY_BEARER_TOKEN}"), true);
+  assert.equal(workflow.includes('approvalGrantId'), false);
   assert.equal(workflow.includes("if: always()"), true);
   assert.equal(
     workflow.includes("DEPLOY_NOTIFICATION_ISSUE_NUMBER: ${{ vars.VTDD_DEPLOY_NOTIFICATION_ISSUE_NUMBER }}"),

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -36,6 +36,32 @@ const gatewayAuthEnv = {
   VTDD_GATEWAY_BEARER_TOKEN: "test-token"
 };
 
+function createInMemoryDashboardEventStore() {
+  const events = new Map();
+  return {
+    async put(event) {
+      events.set(event.id, event);
+      return event;
+    },
+    async latest(filter = {}) {
+      const matches = [...events.values()].filter((event) => {
+        if (filter.kind && event.kind !== filter.kind) {
+          return false;
+        }
+        if (filter.repository && event.repository !== filter.repository) {
+          return false;
+        }
+        if (filter.workflowName && event.workflowName !== filter.workflowName) {
+          return false;
+        }
+        return true;
+      });
+      matches.sort((left, right) => String(right.updatedAt).localeCompare(String(left.updatedAt)));
+      return matches[0] ?? null;
+    }
+  };
+}
+
 const passkeyAdapter = {
   async generateRegistrationOptions(input) {
     return { challenge: input.challenge };
@@ -190,6 +216,80 @@ test("worker serves v2 dashboard without exposing secrets", async () => {
   assert.equal(aliasBody.includes("dashboard main chat"), true);
   assert.equal(aliasBody.includes("管理メニュー"), true);
   assert.equal(aliasBody.includes("自動更新なし"), true);
+});
+
+test("worker ingests GitHub Actions deploy completion event and shows it on dashboard", async () => {
+  const store = createInMemoryDashboardEventStore();
+  const eventResponse = await worker.fetch(
+    new Request("https://example.com/v2/events/github-actions", {
+      method: "POST",
+      headers: gatewayAuthHeaders,
+      body: JSON.stringify({
+        repository: "marushu/vtdd-v2-p",
+        workflowName: "deploy-production",
+        runId: "26133044458",
+        runUrl: "https://github.com/marushu/vtdd-v2-p/actions/runs/26133044458",
+        status: "completed",
+        conclusion: "success",
+        headSha: "ef55709c4f52b54f436417acc239ec03a0c999fd",
+        headBranch: "main",
+        displayTitle: "deploy-production",
+        updatedAt: "2026-05-20T00:10:01Z",
+        approvalGrantId: "approval:must-not-persist",
+        token: "secret-must-not-persist"
+      })
+    }),
+    {
+      ...gatewayAuthEnv,
+      DASHBOARD_EVENT_STORE: store
+    }
+  );
+
+  assert.equal(eventResponse.status, 202);
+  const eventBody = await eventResponse.json();
+  assert.equal(eventBody.ok, true);
+  assert.equal(eventBody.event.runId, "26133044458");
+  assert.equal("approvalGrantId" in eventBody.event, false);
+  assert.equal("token" in eventBody.event, false);
+
+  const dashboardResponse = await worker.fetch(new Request("https://example.com/dashboard"), {
+    DASHBOARD_EVENT_STORE: store
+  });
+  assert.equal(dashboardResponse.status, 200);
+  const dashboardBody = await dashboardResponse.text();
+  assert.equal(dashboardBody.includes("最新 deploy"), true);
+  assert.equal(dashboardBody.includes("success"), true);
+  assert.equal(dashboardBody.includes("ef55709"), true);
+  assert.equal(
+    dashboardBody.includes("https://github.com/marushu/vtdd-v2-p/actions/runs/26133044458"),
+    true
+  );
+  assert.equal(dashboardBody.includes("approval:must-not-persist"), false);
+  assert.equal(dashboardBody.includes("secret-must-not-persist"), false);
+  assert.equal(dashboardBody.includes("setInterval("), false);
+  assert.equal(dashboardBody.includes("fetch("), false);
+});
+
+test("worker rejects GitHub Actions deploy completion event without machine auth", async () => {
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/events/github-actions", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        repository: "marushu/vtdd-v2-p",
+        workflowName: "deploy-production",
+        runId: "26133044458",
+        status: "completed",
+        conclusion: "success"
+      })
+    }),
+    {
+      ...gatewayAuthEnv,
+      DASHBOARD_EVENT_STORE: createInMemoryDashboardEventStore()
+    }
+  );
+
+  assert.equal(response.status, 401);
 });
 
 test("worker setup recovery page opens without Action auth and defaults to VTDD repo", async () => {

--- a/worker.js
+++ b/worker.js
@@ -55754,6 +55754,7 @@ var DEFAULT_MEMORY_LIMIT = 20;
 var MAX_MEMORY_LIMIT = 200;
 var memoryProviderCache = /* @__PURE__ */ new WeakMap();
 var d1AdapterCache = /* @__PURE__ */ new WeakMap();
+var dashboardEventStoreCache = /* @__PURE__ */ new WeakMap();
 var runtime_default = {
   async fetch(request, env) {
     const url = new URL(request.url);
@@ -55790,7 +55791,13 @@ var runtime_default = {
       );
     }
     if (request.method === "GET" && (url.pathname === "/dashboard" || url.pathname === "/orchestrator")) {
-      return html(200, renderV2DashboardPage({ runtimeOrigin: url.origin }));
+      return html(
+        200,
+        await renderV2DashboardPage({
+          runtimeOrigin: url.origin,
+          dashboardEventStore: resolveDashboardEventStore(env)
+        })
+      );
     }
     if (request.method === "GET" && (url.pathname === MCP_PROTECTED_RESOURCE_METADATA_PATH || url.pathname === MCP_PROTECTED_RESOURCE_METADATA_MIRROR_PATH)) {
       return json(200, buildMcpProtectedResourceMetadata(url));
@@ -55945,6 +55952,21 @@ var runtime_default = {
         });
       }
       return handleDeployProductionRequest(request, env);
+    }
+    if (request.method === "POST" && isApiPath(url.pathname, "/events/github-actions")) {
+      const auth = authorizeGatewayRequest({
+        request,
+        env,
+        apiSuffix: "/events/github-actions"
+      });
+      if (!auth.ok) {
+        return json(auth.status, {
+          ok: false,
+          error: "unauthorized",
+          reason: auth.reason
+        });
+      }
+      return handleGitHubActionsEventRequest(request, env);
     }
     if (request.method === "POST" && isApiPath(url.pathname, "/action/github-actions-secret")) {
       const auth = authorizePasskeyBrowserOrMachineRequest({
@@ -58252,6 +58274,30 @@ async function handleDeployProductionRequest(request, env) {
     deploy: executed.deploy
   });
 }
+async function handleGitHubActionsEventRequest(request, env) {
+  const payload = await readJson(request);
+  const event = normalizeGitHubActionsEvent(payload);
+  if (!event.ok) {
+    return json(422, {
+      ok: false,
+      error: event.error,
+      reason: event.reason
+    });
+  }
+  const store = resolveDashboardEventStore(env);
+  if (!store) {
+    return json(503, {
+      ok: false,
+      error: "dashboard_event_store_unavailable",
+      reason: "dashboard event store is not configured"
+    });
+  }
+  await store.put(event.event);
+  return json(202, {
+    ok: true,
+    event: event.event
+  });
+}
 async function handleGitHubActionsSecretSyncRequest(request, env) {
   const payload = await readJson(request);
   if (!payload || typeof payload !== "object") {
@@ -59479,6 +59525,122 @@ function resolveMemoryProvider(env) {
   memoryProviderCache.set(env, provider);
   return provider;
 }
+function resolveDashboardEventStore(env) {
+  if (!env || typeof env !== "object") {
+    return null;
+  }
+  const injectedStore = env.DASHBOARD_EVENT_STORE ?? null;
+  if (injectedStore && typeof injectedStore.put === "function" && typeof injectedStore.latest === "function") {
+    return injectedStore;
+  }
+  const d1Binding = env[MEMORY_D1_BINDING] ?? null;
+  if (!d1Binding || typeof d1Binding.prepare !== "function") {
+    return null;
+  }
+  if (dashboardEventStoreCache.has(d1Binding)) {
+    return dashboardEventStoreCache.get(d1Binding);
+  }
+  const store = createD1DashboardEventStore(d1Binding);
+  dashboardEventStoreCache.set(d1Binding, store);
+  return store;
+}
+function createD1DashboardEventStore(d1) {
+  let schemaPromise = null;
+  return {
+    async put(event) {
+      const normalized = normalizeDashboardEventRecord(event);
+      await ensureSchema();
+      await d1.prepare(
+        `INSERT OR REPLACE INTO vtdd_dashboard_events (
+             id, kind, repository, workflow_name, run_id, status, conclusion,
+             head_sha, head_branch, run_url, title, created_at, updated_at, payload_json
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      ).bind(
+        normalized.id,
+        normalized.kind,
+        normalized.repository,
+        normalized.workflowName,
+        normalized.runId,
+        normalized.status,
+        normalized.conclusion,
+        normalized.headSha,
+        normalized.headBranch,
+        normalized.runUrl,
+        normalized.title,
+        normalized.createdAt,
+        normalized.updatedAt,
+        JSON.stringify(normalized)
+      ).run();
+      return normalized;
+    },
+    async latest(filter = {}) {
+      await ensureSchema();
+      const kind = normalizeText30(filter.kind);
+      const repository = normalizeCanonicalRepositoryInput(filter.repository);
+      const workflowName = normalizeText30(filter.workflowName);
+      const clauses = [];
+      const params = [];
+      if (kind) {
+        clauses.push("kind = ?");
+        params.push(kind);
+      }
+      if (repository) {
+        clauses.push("repository = ?");
+        params.push(repository);
+      }
+      if (workflowName) {
+        clauses.push("workflow_name = ?");
+        params.push(workflowName);
+      }
+      const where = clauses.length > 0 ? `WHERE ${clauses.join(" AND ")}` : "";
+      const result = await d1.prepare(
+        `SELECT payload_json FROM vtdd_dashboard_events ${where} ORDER BY updated_at DESC, created_at DESC LIMIT 1`
+      ).bind(...params).all();
+      const row = Array.isArray(result?.results) ? result.results[0] : null;
+      if (!row?.payload_json) {
+        return null;
+      }
+      try {
+        return normalizeDashboardEventRecord(JSON.parse(row.payload_json));
+      } catch {
+        return null;
+      }
+    }
+  };
+  function ensureSchema() {
+    if (!schemaPromise) {
+      schemaPromise = (async () => {
+        await d1.exec(
+          "CREATE TABLE IF NOT EXISTS vtdd_dashboard_events (id TEXT PRIMARY KEY, kind TEXT NOT NULL, repository TEXT NOT NULL, workflow_name TEXT NOT NULL, run_id TEXT NOT NULL, status TEXT NOT NULL, conclusion TEXT, head_sha TEXT, head_branch TEXT, run_url TEXT, title TEXT, created_at TEXT NOT NULL, updated_at TEXT NOT NULL, payload_json TEXT NOT NULL);"
+        );
+        await d1.exec(
+          "CREATE INDEX IF NOT EXISTS idx_vtdd_dashboard_events_lookup ON vtdd_dashboard_events (kind, repository, workflow_name, updated_at DESC);"
+        );
+      })();
+    }
+    return schemaPromise;
+  }
+}
+function normalizeDashboardEventRecord(event) {
+  const input = normalizeObject11(event);
+  const updatedAt = normalizeIsoTimestamp(input.updatedAt) || (/* @__PURE__ */ new Date()).toISOString();
+  const createdAt = normalizeIsoTimestamp(input.createdAt) || updatedAt;
+  return {
+    id: normalizeText30(input.id),
+    kind: normalizeText30(input.kind),
+    repository: normalizeCanonicalRepositoryInput(input.repository),
+    workflowName: normalizeText30(input.workflowName),
+    runId: normalizeText30(input.runId),
+    status: normalizeText30(input.status),
+    conclusion: normalizeText30(input.conclusion) || null,
+    headSha: normalizeText30(input.headSha) || null,
+    headBranch: normalizeText30(input.headBranch) || null,
+    runUrl: normalizeText30(input.runUrl) || null,
+    title: normalizeText30(input.title) || normalizeText30(input.workflowName),
+    createdAt,
+    updatedAt
+  };
+}
 function createD1MemoryIndexAdapter(d1) {
   if (!d1 || typeof d1.prepare !== "function") {
     return null;
@@ -59852,6 +60014,112 @@ function normalizeObject11(value) {
   }
   return value;
 }
+function normalizeGitHubActionsEvent(payload) {
+  const input = normalizeObject11(payload);
+  const repository = normalizeCanonicalRepositoryInput(input.repository || input.githubRepository);
+  const workflowName = normalizeText30(input.workflowName || input.workflow || input.workflow_name);
+  const runId = normalizeText30(input.runId || input.run_id || input.databaseId || input.database_id);
+  const runUrl = normalizeText30(input.runUrl || input.run_url || input.url);
+  const status = normalizeText30(input.status || "completed").toLowerCase();
+  const conclusion = normalizeText30(input.conclusion || input.result).toLowerCase();
+  const updatedAt = normalizeIsoTimestamp(input.updatedAt || input.updated_at) || (/* @__PURE__ */ new Date()).toISOString();
+  const createdAt = normalizeIsoTimestamp(input.createdAt || input.created_at) || updatedAt;
+  const headSha = normalizeText30(input.headSha || input.head_sha || input.sha);
+  const headBranch = normalizeText30(input.headBranch || input.head_branch || input.branch);
+  const title = normalizeText30(input.displayTitle || input.display_title || input.title);
+  if (!repository) {
+    return {
+      ok: false,
+      error: "repository_required",
+      reason: "GitHub Actions event repository is required"
+    };
+  }
+  if (!workflowName) {
+    return {
+      ok: false,
+      error: "workflow_required",
+      reason: "GitHub Actions event workflowName is required"
+    };
+  }
+  if (!runId) {
+    return {
+      ok: false,
+      error: "run_id_required",
+      reason: "GitHub Actions event runId is required"
+    };
+  }
+  if (!["queued", "in_progress", "completed", "requested", "waiting"].includes(status)) {
+    return {
+      ok: false,
+      error: "status_unsupported",
+      reason: "GitHub Actions event status must be queued, in_progress, completed, requested, or waiting"
+    };
+  }
+  if (conclusion && !["success", "failure", "cancelled", "skipped", "timed_out", "action_required"].includes(conclusion)) {
+    return {
+      ok: false,
+      error: "conclusion_unsupported",
+      reason: "GitHub Actions event conclusion is not supported"
+    };
+  }
+  const event = {
+    id: `github-actions:${repository}:${workflowName}:${runId}`,
+    kind: "github_actions_workflow_run",
+    repository,
+    workflowName,
+    runId,
+    status,
+    conclusion: conclusion || null,
+    headSha: headSha || null,
+    headBranch: headBranch || null,
+    runUrl: runUrl || null,
+    title: title || workflowName,
+    createdAt,
+    updatedAt
+  };
+  return {
+    ok: true,
+    event
+  };
+}
+function normalizeIsoTimestamp(value) {
+  const text = normalizeText30(value);
+  if (!text) {
+    return "";
+  }
+  const timestamp = new Date(text);
+  if (Number.isNaN(timestamp.getTime())) {
+    return "";
+  }
+  return timestamp.toISOString();
+}
+async function retrieveLatestDashboardEvent({ store, kind, repository, workflowName } = {}) {
+  if (!store || typeof store.latest !== "function") {
+    return null;
+  }
+  try {
+    return await store.latest({ kind, repository, workflowName });
+  } catch {
+    return null;
+  }
+}
+function renderDashboardDeployEvent(event) {
+  if (!event) {
+    return `<div class="deploy-event muted">\u76F4\u8FD1 deploy event: \u672A\u53D7\u4FE1</div>`;
+  }
+  const conclusion = normalizeText30(event.conclusion) || normalizeText30(event.status) || "unknown";
+  const badgeClass = conclusion === "success" ? "success" : conclusion === "failure" || conclusion === "cancelled" ? "danger" : "";
+  const updatedAt = normalizeText30(event.updatedAt);
+  const sha = normalizeText30(event.headSha);
+  const shortSha = sha ? sha.slice(0, 7) : "unknown";
+  const runUrl = normalizeText30(event.runUrl);
+  const runLabel = runUrl ? `<a class="chat-link" href="${escapeDashboardHtml(runUrl)}">Actions run</a>` : "Actions run \u672A\u8A2D\u5B9A";
+  return `<div class="deploy-event">
+            <div class="lane-title"><strong>\u6700\u65B0 deploy</strong><span class="pill ${badgeClass}">${escapeDashboardHtml(conclusion)}</span></div>
+            <p>${escapeDashboardHtml(event.workflowName || "deploy-production")} / <code>${escapeDashboardHtml(shortSha)}</code></p>
+            <p class="muted">${escapeDashboardHtml(updatedAt || "updatedAt \u672A\u53D7\u4FE1")} \u30FB ${runLabel}</p>
+          </div>`;
+}
 function normalizeTextList2(value) {
   if (Array.isArray(value)) {
     return value.map(normalizeText30).filter(Boolean);
@@ -59862,10 +60130,16 @@ function normalizeTextList2(value) {
 function uniqueTextList2(value) {
   return [...new Set(normalizeTextList2(value))];
 }
-function renderV2DashboardPage({ runtimeOrigin }) {
+async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}) {
   const origin = normalize7(runtimeOrigin);
   const repository = "marushu/vtdd-v2-p";
   const encodedRepository = encodeURIComponent(repository);
+  const latestDeployEvent = await retrieveLatestDashboardEvent({
+    store: dashboardEventStore,
+    kind: "github_actions_workflow_run",
+    repository,
+    workflowName: "deploy-production"
+  });
   const surfaces = [
     {
       title: "Status page",
@@ -60018,6 +60292,10 @@ function renderV2DashboardPage({ runtimeOrigin }) {
     .lane, details { border: 1px solid var(--border); border-radius: 14px; padding: 12px; background: var(--panel-strong); }
     .lane-title { display: flex; justify-content: space-between; gap: 8px; align-items: baseline; }
     .pill { display: inline-flex; align-items: center; border: 1px solid var(--border); border-radius: 999px; padding: 3px 8px; color: var(--text); background: var(--soft); font-size: 12px; white-space: nowrap; }
+    .pill.success { border-color: #7fb797; background: #e7f5ec; color: #145c34; }
+    .pill.danger { border-color: #d69b9b; background: #fff0f0; color: #8a1f1f; }
+    .deploy-event { border: 1px solid var(--border); border-radius: 12px; padding: 10px; margin: 10px 0; background: var(--soft); }
+    .deploy-event p { margin-bottom: 6px; font-size: 13px; line-height: 1.45; }
     .quick-actions, .surface-list { display: grid; gap: 8px; }
     .quick-actions { grid-template-columns: repeat(2, minmax(0, 1fr)); }
     .quick-actions a, .surface-list a { display: inline-flex; align-items: center; justify-content: center; min-height: 36px; border: 1px solid var(--border); border-radius: 10px; padding: 7px 9px; color: var(--text); text-decoration: none; background: var(--soft); font-weight: 750; font-size: 13px; text-align: center; }
@@ -60138,6 +60416,7 @@ function renderV2DashboardPage({ runtimeOrigin }) {
         <div class="lane">
           <div class="lane-title"><h3>\u9032\u884C\u4E2D execution</h3><span class="pill">runtime truth</span></div>
           <p>\u9032\u6357\u306F GitHub Actions / VPS runner status / execution progress route \u304B\u3089\u8AAD\u307F\u307E\u3059\u3002</p>
+          ${renderDashboardDeployEvent(latestDeployEvent)}
           <div class="quick-actions">
             ${cockpitActions.map((action) => `<a href="${escapeDashboardHtml(action.href)}">${escapeDashboardHtml(action.label)}</a>`).join("")}
           </div>


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #438 の目的である「GitHub Actions の deploy-production 完了を Worker に取り込み、dashboard に表示する」ための runtime path を追加します。
- dashboard 側が GitHub を polling するのではなく、deploy workflow 側から Worker へ完了イベントを POST する設計にしました。

## Satisfied Success Criteria

- `deploy-production` workflow の完了時に Worker へ GitHub Actions event を POST する step を追加しました。
- Worker は `/v2/events/github-actions` で run id / workflow / conclusion / status / sha / branch / run url / updatedAt を受け取り保存できます。
- `approvalGrantId`、token、secret、raw sensitive material は保存対象に入れず、テストで非表示を確認しました。
- dashboard は保存済みの最新 deploy event を表示し、`success` / `failure` / `cancelled` 系の見分けが付く badge を出します。
- dashboard は自動リロード、`setInterval`、`fetch` polling を追加していません。

## Unsatisfied Success Criteria

- 本番 Worker への反映と実 deploy workflow からの live event 受信は、この PR merge 後の Cloudflare deploy で確認します。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #438
- Implementing Success Criteria: Actions 完了 event POST、Worker event ingest、dashboard 表示、secret 非保存、自動 polling なし。
- Explicit Non-goals: iPhone push 通知、SSE / WebSocket live update、本物の Butler 双方向チャット、GitHub Actions polling、deploy 実行そのもの。
- Expected touched files/routes/workflows: `.github/workflows/deploy-production.yml`, `src/worker/runtime.js`, `worker.js`, `test/worker.test.js`, `test/production-deploy-path.test.js`, route `/v2/events/github-actions`, dashboard `/dashboard`。
- Affected Issues: Issue #428, Issue #433, Issue #438。
- Affected PRs: なし。
- Affected workflows: `deploy-production`。
- Affected runtime/operator surfaces: Worker dashboard, deploy workflow, machine-auth event ingest endpoint。
- What may break if we patch narrowly: dashboard event store を RAG memory に混ぜると memory cost / quality が崩れるため、専用 D1 table と注入可能 store に分けました。
- Unknowns to investigate before coding: 既存 D1 binding の使い方、deploy workflow の完了通知位置、dashboard の自動更新禁止条件。
- Validation needed: worker unit test、workflow static test、generated worker parity、self parity。
- Stop condition: approval grant や secret を保存する必要が出た場合、または dashboard polling を入れないと成立しない場合は drift として停止。

## File / Line Hypotheses

- file: `src/worker/runtime.js`
  - hypothesis: dashboard render と Worker route に event ingest / event store を足すのが最小変更。
  - risk if changed narrowly: RAG memory provider に deploy log を混ぜると AGENTS.md の RAG cost boundary と衝突する。
  - validation: `test/worker.test.js` で POST、secret 非保存、dashboard 表示、自動 polling なしを確認。
  - related Issue: #438
- file: `.github/workflows/deploy-production.yml`
  - hypothesis: deploy step 後の `if: always()` step で Worker へ完了 event を送るのが Actions 完了 truth に一番近い。
  - risk if changed narrowly: approval grant id を payload に含めると secret/approval boundary を壊す。
  - validation: `test/production-deploy-path.test.js` で endpoint、bearer auth、approvalGrantId 非露出を確認。
  - related Issue: #438

## Hypothesis Retrospective

- expected: deploy workflow から Worker へ event POST し、dashboard に最新 deploy 状態を表示できる。
- actual: 専用 event store と `/v2/events/github-actions` を追加し、dashboard の「進行中 execution」枠に最新 deploy 表示を追加した。
- mismatch: ローカル wrangler smoke は runtime env の machine auth 設定が入らず endpoint が 401/503 系で拒否したが、unit test では auth と store 注入で通過した。
- lesson: 本番で live event を確認するには merge 後 deploy と次回 deploy workflow 実行が必要。
- should become RAG candidate: はい。dashboard は polling ではなく Actions / runner から event POST で更新する判断を RAG 候補にできる。

## Verification Evidence

- Unit: `node --test test/worker.test.js test/production-deploy-path.test.js` PASS
- Integration: `npm test` PASS。`deploy-production` workflow static test で `/v2/events/github-actions` と bearer auth と approvalGrantId 非露出を確認。
- E2E: Worker unit test でサンプル Actions event POST から dashboard HTML 反映まで確認。live deploy event は merge/deploy 後に確認予定。
- Manual: `gh run view 26133044458` で実 deploy run が `success` だったことを確認。ローカル wrangler smoke は machine auth runtime 未設定で拒否され、拒否境界は確認済み。
- Evidence path/link: `test/worker.test.js`, `test/production-deploy-path.test.js`, `.github/workflows/deploy-production.yml`, `src/worker/runtime.js`

## Butler Completion Contract

- Owner goal: iPhone ホーム画面の dashboard から、直近 deploy の完了状態を Actions run link 付きで見たい。
- Butler entrypoint: `/dashboard`。deploy 完了 event は workflow から `/v2/events/github-actions` へ送る。
- Action Schema exposure: Custom GPT Action Schema は未変更。これは dashboard/workflow runtime path の追加で、Butler の会話 tool ではない。
- Runtime path: `deploy-production` workflow -> `POST /v2/events/github-actions` -> D1-backed dashboard event store -> `/dashboard` 表示。
- Runner/runtime truth: GitHub Actions run id、workflow、status、conclusion、sha、run url を保存し、dashboard が読む。
- Authority boundary: machine auth bearer が必要。deploy 実行自体は従来通り GO + passkey。approval grant や secret は保存しない。
- E2E evidence: サンプル GitHub Actions event POST から dashboard HTML 反映まで `test/worker.test.js` で確認済み。live deploy event は merge/deploy 後に確認。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: merge 後に必要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: merge/deploy 後に dashboard で最新 deploy event 表示を確認。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate
- AGENTS.md Authority Boundary
- AGENTS.md RAG Memory Capture and Cost Boundary
- Issue #438

## Out-of-scope but NOT implemented

- iPhone push 通知
- SSE / WebSocket live update
- 本物の Butler 双方向チャット
- GitHub Actions polling
- deploy 実行そのもの

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #438
- Execution ID: mac-codex-issue438-dashboard-actions-event
- Goal: GitHub Actions deploy completion event を Worker に取り込み dashboard に表示する
