### PR TITLE
fix: deploy event 通知の propagation race を吸収する

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -174,11 +174,33 @@ jobs:
           NODE
           )
 
-          curl --fail-with-body --show-error --silent \
-            -X POST "${RUNTIME_URL%/}/v2/events/github-actions" \
-            -H "authorization: Bearer ${VTDD_GATEWAY_BEARER_TOKEN}" \
-            -H "content-type: application/json" \
-            --data "$event_body"
+          event_endpoint="${RUNTIME_URL%/}/v2/events/github-actions"
+          event_sent=0
+          for attempt in 1 2 3 4 5 6; do
+            response_file="$(mktemp)"
+            http_code="$(
+              curl --show-error --silent \
+                -o "$response_file" \
+                -w "%{http_code}" \
+                -X POST "$event_endpoint" \
+                -H "authorization: Bearer ${VTDD_GATEWAY_BEARER_TOKEN}" \
+                -H "content-type: application/json" \
+                --data "$event_body" || true
+            )"
+            if [ "$http_code" -ge 200 ] && [ "$http_code" -lt 300 ]; then
+              event_sent=1
+              rm -f "$response_file"
+              break
+            fi
+            echo "dashboard deploy event notification attempt ${attempt} failed with HTTP ${http_code}; retrying after Worker propagation delay."
+            sed -E 's/(approval:[a-zA-Z0-9-]+|gh[psuor]_[A-Za-z0-9_]+)/[redacted]/g' "$response_file" || true
+            rm -f "$response_file"
+            sleep 5
+          done
+
+          if [ "$event_sent" -ne 1 ]; then
+            echo "dashboard deploy event notification did not reach Worker after retries; deploy remains successful, but dashboard may be stale until the next event."
+          fi
 
       - name: Notify deploy completion
         if: always()

--- a/test/production-deploy-path.test.js
+++ b/test/production-deploy-path.test.js
@@ -105,7 +105,9 @@ test("deploy-production workflow enforces the MVP production deploy boundary", (
   assert.equal(workflow.includes("Notify deploy completion"), true);
   assert.equal(workflow.includes("Notify dashboard deploy event"), true);
   assert.equal(workflow.includes("/v2/events/github-actions"), true);
-  assert.equal(workflow.includes("curl --fail-with-body"), true);
+  assert.equal(workflow.includes("for attempt in 1 2 3 4 5 6"), true);
+  assert.equal(workflow.includes("retrying after Worker propagation delay"), true);
+  assert.equal(workflow.includes("deploy remains successful, but dashboard may be stale until the next event"), true);
   assert.equal(workflow.includes("authorization: Bearer ${VTDD_GATEWAY_BEARER_TOKEN}"), true);
   assert.equal(workflow.includes('approvalGrantId'), false);
   assert.equal(workflow.includes("if: always()"), true);


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #440 の deploy-production workflow で、Cloudflare Worker deploy 直後の propagation race による /v2/events/github-actions 404 が deploy 成功を workflow failure に変える問題を修正します。

## Satisfied Success Criteria

- Notify dashboard deploy event が 404 / 5xx / 一時的な curl 失敗を 6 回 retry するようにしました。
- retry 後も通知できない場合は deploy 本体成功を workflow failure として上書きしないようにしました。
- 通知失敗時は dashboard event が未反映であることをログに明示します。
- bearer token と approvalGrantId を payload / ログに出さない境界を test で維持しました。
- workflow static test で retry と non-fatal boundary を確認しました。

## Unsatisfied Success Criteria

- merge 後の本番 deploy run で、実際に Notify dashboard deploy event が成功または non-fatal warning になる live E2E は未実施です。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #440
- Implementing Success Criteria: deploy event notification の retry / non-fatal 化、secret 非露出、workflow static test 更新。
- Explicit Non-goals: deploy 実行、passkey approval 仕様変更、dashboard UI 変更、iPhone push 通知。
- Expected touched files/routes/workflows: .github/workflows/deploy-production.yml, test/production-deploy-path.test.js
- Affected Issues: #440, #438
- Affected PRs: #439 の post-merge deploy failure を受けた修正。
- Affected workflows: deploy-production.yml の Notify dashboard deploy event step。
- Affected runtime/operator surfaces: Cloudflare Worker /v2/events/github-actions への dashboard event 通知。Butler UI と Action Schema は未変更。
- What may break if we patch narrowly: 通知失敗を完全に握りつぶすと dashboard stale に気づけないため、最終 warning を明示します。
- Unknowns to investigate before coding: 次回 deploy 時の Worker propagation duration は環境依存のため live run で確認が必要です。
- Validation needed: node --test test/production-deploy-path.test.js, npm test, 次回 production deploy run の live E2E。
- Stop condition: deploy 本体の approval / validation 失敗まで非致命化しそうになった場合は drift なので停止します。

## File / Line Hypotheses

- file: .github/workflows/deploy-production.yml
  - hypothesis: Notify dashboard deploy event step の単発 curl が Worker route 反映前の 404 を fatal 扱いしている。
  - risk if changed narrowly: deploy 本体の失敗まで隠すと危険なため、この step の dashboard event 通知だけを non-fatal にする。
  - validation: workflow static test と次回 deploy run の step 結果で確認する。
  - related Issue: #440
- file: test/production-deploy-path.test.js
  - hypothesis: production deploy boundary test が単発 curl 前提なので retry / non-fatal contract に更新する必要がある。
  - risk if changed narrowly: approvalGrantId 非露出や bearer auth の guard が落ちるため既存 assertion を残す。
  - validation: node --test test/production-deploy-path.test.js
  - related Issue: #440

## Hypothesis Retrospective

- expected: deploy step は成功し、dashboard event 通知だけが propagation race で一時失敗する。
- actual: run 26133608086 では Deploy to Cloudflare Workers は成功し、Notify dashboard deploy event が 404 で workflow failure になった。
- mismatch: 通知の補助 step が deploy 成功の runtime truth を赤に上書きしていた。
- lesson: Worker deploy 直後に新規 route を叩く event 通知は retry し、最終失敗は stale warning として扱う。
- should become RAG candidate: はい。deploy 後 event 通知は propagation race を前提に設計する。

## Verification Evidence

- Unit: node --test test/production-deploy-path.test.js: PASS
- Integration: npm test: PASS (833 tests, 832 pass, 1 skipped)
- E2E: 未実施。次回 production deploy run で Notify dashboard deploy event が成功または non-fatal warning になることを確認します。
- Manual: runtime truth: https://github.com/marushu/vtdd-v2-p/actions/runs/26133608086/job/76863819159#step:11:1 は 404 failure。live Worker endpoint は現在 401 unauthorized を返し、route 自体は存在します。
- Evidence path/link: .github/workflows/deploy-production.yml; test/production-deploy-path.test.js; https://github.com/marushu/vtdd-v2-p/actions/runs/26133608086/job/76863819159#step:11:1

## Butler Completion Contract

- Owner goal: deploy 完了 event 通知の一時的な 404 で、成功した deploy workflow が赤くならないようにする。
- Butler entrypoint: この PR では Butler natural-language entrypoint は未変更です。
- Action Schema exposure: 不要。この PR は既存 workflow step の耐障害性修正で、Custom GPT Action Schema は未変更です。
- Runtime path: GitHub Actions deploy-production.yml -> Cloudflare Worker /v2/events/github-actions
- Runner/runtime truth: run 26133608086 の step 11 failure と live Worker endpoint の 401 unauthorized 応答を確認済み。
- Authority boundary: 未変更。deploy 実行は引き続き GO + passkey。dashboard event 通知は machine bearer token 必須。
- E2E evidence: 未実施。この PR は workflow fix で、merge 後 deploy run が mapped E2E になります。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: この PR 自体では未実施。merge 後の production deploy で確認します。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 不要。

## Related Constitution Rules

- AGENTS.md Evidence Discipline
- AGENTS.md Authority Boundary
- AGENTS.md Current Reality Guard
- Issue #440 Success Criteria

## Out-of-scope but NOT implemented

- dashboard UI の追加変更。
- passkey approval flow の変更。
- GitHub Actions 以外の event source 追加。

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #440
- Execution ID: mac-codex-issue-440-dashboard-event-retry
- Goal: deploy event notification propagation race を retry + non-fatal にする
