### PR TITLE
fix: dashboard mobile 管理メニューを実際に開ける drawer にする

### DIFF
--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -5323,8 +5323,9 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
       }
     }
     * { box-sizing: border-box; }
+    html, body { max-width: 100%; overflow-x: hidden; }
     body { margin: 0; background: var(--page-bg); }
-    main { min-height: 100dvh; display: grid; grid-template-columns: minmax(0, 1fr) minmax(220px, 320px); gap: 18px; padding: 16px; }
+    main { width: 100%; min-height: 100dvh; display: grid; grid-template-columns: minmax(0, 1fr) minmax(220px, 320px); gap: 18px; padding: 16px; overflow-x: hidden; }
     h1, h2, h3, p { margin-top: 0; }
     h1 { font-size: 22px; line-height: 1.1; margin-bottom: 4px; }
     h2 { font-size: 19px; margin-bottom: 12px; }
@@ -5335,12 +5336,15 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
     .topbar { display: flex; justify-content: space-between; align-items: center; gap: 12px; padding: 4px 2px 20px; }
     .top-left, .top-right { display: flex; align-items: center; gap: 10px; min-width: 0; }
     .round-button, .tool-button, .send-button, .icon-button { display: inline-flex; align-items: center; justify-content: center; border: 1px solid var(--border); background: var(--button); color: var(--text); text-decoration: none; font: inherit; font-weight: 750; }
+    .menu-open { cursor: pointer; }
     .round-button { width: 44px; height: 44px; border-radius: 999px; font-size: 24px; flex: 0 0 auto; }
     .tool-button { min-height: 40px; border-radius: 999px; padding: 0 14px; }
     .thread-title { min-width: 0; }
+    .thread-title h1 { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
     .thread-title span { display: block; color: var(--muted); font-size: 13px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
     .chat-scroll { min-height: 0; overflow: auto; padding: 8px 4px 118px; display: flex; flex-direction: column; gap: 22px; scrollbar-width: thin; }
     .bubble { max-width: min(760px, 88%); color: var(--text); font-size: 17px; line-height: 1.72; }
+    .bubble, .bubble p, .bubble li { overflow-wrap: anywhere; }
     .bubble strong { display: block; color: var(--muted); font-size: 12px; letter-spacing: .08em; text-transform: uppercase; margin-bottom: 8px; }
     .bubble p { color: var(--text); margin-bottom: 12px; }
     .bubble ul { margin: 0; padding-left: 22px; color: var(--text); line-height: 1.85; }
@@ -5374,7 +5378,8 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
     summary { cursor: pointer; color: var(--text); font-weight: 800; }
     .muted { color: var(--muted); }
     code { color: var(--text); overflow-wrap: anywhere; }
-    .mobile-tools { display: none; }
+    .menu-toggle { position: fixed; width: 1px; height: 1px; opacity: 0; pointer-events: none; }
+    .mobile-backdrop, .mobile-drawer { display: none; }
     .menu-callout { color: var(--muted); font-size: 12px; line-height: 1.55; }
     @media (min-width: 1180px) {
       .chat-scroll { align-items: center; }
@@ -5383,9 +5388,14 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
     @media (max-width: 900px) {
       main { display: block; padding: 14px 14px 0; }
       .app-shell { min-height: 100dvh; }
+      .topbar { display: grid; grid-template-columns: minmax(0, 1fr) auto; align-items: center; }
       .sidebar { display: none; }
       .composer { left: 14px; right: 14px; }
-      .mobile-tools { display: block; margin: 0 0 140px; }
+      .mobile-backdrop { position: fixed; inset: 0; z-index: 10; background: rgba(0, 0, 0, .38); backdrop-filter: blur(2px); }
+      .mobile-drawer { position: fixed; top: 0; bottom: 0; left: 0; z-index: 11; width: min(86vw, 360px); overflow: auto; padding: max(16px, env(safe-area-inset-top)) 14px max(18px, env(safe-area-inset-bottom)); border-right: 1px solid var(--border); background: var(--panel); box-shadow: 18px 0 60px var(--shadow); }
+      .menu-toggle:checked ~ .mobile-backdrop, .menu-toggle:checked ~ .mobile-drawer { display: block; }
+      .mobile-drawer-header { display: flex; justify-content: space-between; align-items: center; gap: 12px; margin-bottom: 14px; }
+      .mobile-drawer-content { display: grid; gap: 12px; }
       .chat-scroll { padding-bottom: 104px; }
       .bubble { max-width: 100%; font-size: 16px; }
       .bubble.owner { max-width: 82%; }
@@ -5405,19 +5415,54 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
 <body>
   <main>
     <section class="app-shell" aria-label="Butler chat shell">
+      <input class="menu-toggle" type="checkbox" id="mobile-menu-toggle" aria-hidden="true">
       <header class="topbar">
         <div class="top-left">
-          <a class="round-button" href="${escapeDashboardHtml(origin)}/dashboard" aria-label="メニュー">≡</a>
+          <label class="round-button menu-open" for="mobile-menu-toggle" aria-label="管理メニューを開く">≡</label>
           <div class="thread-title">
             <h1>VTDD Butler</h1>
             <span>${escapeDashboardHtml(repository)} ・ dashboard main chat</span>
           </div>
         </div>
         <div class="top-right">
-          <a class="tool-button" href="#mobile-management">管理</a>
+          <label class="tool-button menu-open" for="mobile-menu-toggle">管理</label>
           <a class="round-button" href="${escapeDashboardHtml(origin)}/v2/approval/passkey/operator?repositoryInput=${encodedRepository}" aria-label="Passkey">◇</a>
         </div>
       </header>
+
+      <label class="mobile-backdrop" for="mobile-menu-toggle" aria-label="管理メニューを閉じる"></label>
+      <aside class="mobile-drawer" aria-label="モバイル管理メニュー">
+        <div class="mobile-drawer-header">
+          <span>
+            <span class="eyebrow">管理メニュー</span>
+            <strong>必要な時だけ開く</strong>
+          </span>
+          <label class="round-button menu-open" for="mobile-menu-toggle" aria-label="管理メニューを閉じる">×</label>
+        </div>
+        <div class="mobile-drawer-content">
+          <p class="menu-callout">状態確認、進捗、RAG、workflow はここから開きます。通知ではなく、現在は dashboard 内の状態表示です。</p>
+          <div class="lane">
+            <div class="lane-title"><h3>進行中 execution</h3><span class="pill">runtime truth</span></div>
+            <p>GitHub Actions / VPS runner status / execution progress route から読みます。</p>
+            ${renderDashboardDeployEvent(latestDeployEvent)}
+          </div>
+          <div class="quick-actions">
+            ${cockpitActions.map((action) => `<a href="${escapeDashboardHtml(action.href)}">${escapeDashboardHtml(action.label)}</a>`).join("")}
+          </div>
+          <details open>
+            <summary>Runtime surfaces</summary>
+            <div class="surface-list">
+              ${surfaces.map((surface) => `<a href="${escapeDashboardHtml(surface.href)}">${escapeDashboardHtml(surface.title)}</a>`).join("")}
+            </div>
+          </details>
+          <details>
+            <summary>GitHub workflows</summary>
+            <div class="surface-list">
+              ${workflows.map(([title, href]) => `<a href="${escapeDashboardHtml(href)}">${escapeDashboardHtml(title)}</a>`).join("")}
+            </div>
+          </details>
+        </div>
+      </aside>
 
       <div class="chat-scroll">
         <article class="bubble owner">
@@ -5443,13 +5488,6 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
           <span class="connection-note">未接続: この入力欄はまだ保存・送信・LLM 返信しません</span>
         </article>
 
-        <details id="mobile-management" class="mobile-tools">
-          <summary>管理メニューを開く</summary>
-          <div class="surface-list">
-            ${surfaces.map((surface) => `<a href="${escapeDashboardHtml(surface.href)}">${escapeDashboardHtml(surface.title)}</a>`).join("")}
-            ${workflows.map(([title, href]) => `<a href="${escapeDashboardHtml(href)}">${escapeDashboardHtml(title)}</a>`).join("")}
-          </div>
-        </details>
       </div>
 
       <div class="composer" aria-label="Butler composer">

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -180,6 +180,8 @@ test("worker serves v2 dashboard without exposing secrets", async () => {
   assert.equal(body.includes("必要な時だけ開く"), true);
   assert.equal(body.includes("color-scheme: light dark"), true);
   assert.equal(body.includes("prefers-color-scheme: dark"), true);
+  assert.equal(body.includes("overflow-x: hidden"), true);
+  assert.equal(body.includes("grid-template-columns: minmax(0, 1fr) auto"), true);
   assert.equal(body.includes("自動更新なし"), true);
   assert.equal(body.includes("自動更新・polling はありません"), true);
   assert.equal(body.includes("Issue #433"), true);
@@ -188,7 +190,10 @@ test("worker serves v2 dashboard without exposing secrets", async () => {
   assert.equal(body.includes("実行 URL は会話例として常時表示しません"), true);
   assert.equal(body.includes("deploy 用 passkey URL"), false);
   assert.equal(body.includes("vtdd-v3-orchestrator.polished-tree-da7c.workers.dev"), false);
-  assert.equal(body.includes('href="#mobile-management"'), true);
+  assert.equal(body.includes('id="mobile-menu-toggle"'), true);
+  assert.equal(body.includes('for="mobile-menu-toggle"'), true);
+  assert.equal(body.includes("モバイル管理メニュー"), true);
+  assert.equal(body.includes("直近 deploy event"), true);
   assert.equal(body.includes("Butler V2 にメッセージ"), true);
   assert.equal(body.includes("状態確認"), true);
   assert.equal(body.includes('name="text"'), false);

--- a/worker.js
+++ b/worker.js
@@ -60251,8 +60251,9 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
       }
     }
     * { box-sizing: border-box; }
+    html, body { max-width: 100%; overflow-x: hidden; }
     body { margin: 0; background: var(--page-bg); }
-    main { min-height: 100dvh; display: grid; grid-template-columns: minmax(0, 1fr) minmax(220px, 320px); gap: 18px; padding: 16px; }
+    main { width: 100%; min-height: 100dvh; display: grid; grid-template-columns: minmax(0, 1fr) minmax(220px, 320px); gap: 18px; padding: 16px; overflow-x: hidden; }
     h1, h2, h3, p { margin-top: 0; }
     h1 { font-size: 22px; line-height: 1.1; margin-bottom: 4px; }
     h2 { font-size: 19px; margin-bottom: 12px; }
@@ -60263,12 +60264,15 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
     .topbar { display: flex; justify-content: space-between; align-items: center; gap: 12px; padding: 4px 2px 20px; }
     .top-left, .top-right { display: flex; align-items: center; gap: 10px; min-width: 0; }
     .round-button, .tool-button, .send-button, .icon-button { display: inline-flex; align-items: center; justify-content: center; border: 1px solid var(--border); background: var(--button); color: var(--text); text-decoration: none; font: inherit; font-weight: 750; }
+    .menu-open { cursor: pointer; }
     .round-button { width: 44px; height: 44px; border-radius: 999px; font-size: 24px; flex: 0 0 auto; }
     .tool-button { min-height: 40px; border-radius: 999px; padding: 0 14px; }
     .thread-title { min-width: 0; }
+    .thread-title h1 { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
     .thread-title span { display: block; color: var(--muted); font-size: 13px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
     .chat-scroll { min-height: 0; overflow: auto; padding: 8px 4px 118px; display: flex; flex-direction: column; gap: 22px; scrollbar-width: thin; }
     .bubble { max-width: min(760px, 88%); color: var(--text); font-size: 17px; line-height: 1.72; }
+    .bubble, .bubble p, .bubble li { overflow-wrap: anywhere; }
     .bubble strong { display: block; color: var(--muted); font-size: 12px; letter-spacing: .08em; text-transform: uppercase; margin-bottom: 8px; }
     .bubble p { color: var(--text); margin-bottom: 12px; }
     .bubble ul { margin: 0; padding-left: 22px; color: var(--text); line-height: 1.85; }
@@ -60302,7 +60306,8 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
     summary { cursor: pointer; color: var(--text); font-weight: 800; }
     .muted { color: var(--muted); }
     code { color: var(--text); overflow-wrap: anywhere; }
-    .mobile-tools { display: none; }
+    .menu-toggle { position: fixed; width: 1px; height: 1px; opacity: 0; pointer-events: none; }
+    .mobile-backdrop, .mobile-drawer { display: none; }
     .menu-callout { color: var(--muted); font-size: 12px; line-height: 1.55; }
     @media (min-width: 1180px) {
       .chat-scroll { align-items: center; }
@@ -60311,9 +60316,14 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
     @media (max-width: 900px) {
       main { display: block; padding: 14px 14px 0; }
       .app-shell { min-height: 100dvh; }
+      .topbar { display: grid; grid-template-columns: minmax(0, 1fr) auto; align-items: center; }
       .sidebar { display: none; }
       .composer { left: 14px; right: 14px; }
-      .mobile-tools { display: block; margin: 0 0 140px; }
+      .mobile-backdrop { position: fixed; inset: 0; z-index: 10; background: rgba(0, 0, 0, .38); backdrop-filter: blur(2px); }
+      .mobile-drawer { position: fixed; top: 0; bottom: 0; left: 0; z-index: 11; width: min(86vw, 360px); overflow: auto; padding: max(16px, env(safe-area-inset-top)) 14px max(18px, env(safe-area-inset-bottom)); border-right: 1px solid var(--border); background: var(--panel); box-shadow: 18px 0 60px var(--shadow); }
+      .menu-toggle:checked ~ .mobile-backdrop, .menu-toggle:checked ~ .mobile-drawer { display: block; }
+      .mobile-drawer-header { display: flex; justify-content: space-between; align-items: center; gap: 12px; margin-bottom: 14px; }
+      .mobile-drawer-content { display: grid; gap: 12px; }
       .chat-scroll { padding-bottom: 104px; }
       .bubble { max-width: 100%; font-size: 16px; }
       .bubble.owner { max-width: 82%; }
@@ -60333,19 +60343,54 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
 <body>
   <main>
     <section class="app-shell" aria-label="Butler chat shell">
+      <input class="menu-toggle" type="checkbox" id="mobile-menu-toggle" aria-hidden="true">
       <header class="topbar">
         <div class="top-left">
-          <a class="round-button" href="${escapeDashboardHtml(origin)}/dashboard" aria-label="\u30E1\u30CB\u30E5\u30FC">\u2261</a>
+          <label class="round-button menu-open" for="mobile-menu-toggle" aria-label="\u7BA1\u7406\u30E1\u30CB\u30E5\u30FC\u3092\u958B\u304F">\u2261</label>
           <div class="thread-title">
             <h1>VTDD Butler</h1>
             <span>${escapeDashboardHtml(repository)} \u30FB dashboard main chat</span>
           </div>
         </div>
         <div class="top-right">
-          <a class="tool-button" href="#mobile-management">\u7BA1\u7406</a>
+          <label class="tool-button menu-open" for="mobile-menu-toggle">\u7BA1\u7406</label>
           <a class="round-button" href="${escapeDashboardHtml(origin)}/v2/approval/passkey/operator?repositoryInput=${encodedRepository}" aria-label="Passkey">\u25C7</a>
         </div>
       </header>
+
+      <label class="mobile-backdrop" for="mobile-menu-toggle" aria-label="\u7BA1\u7406\u30E1\u30CB\u30E5\u30FC\u3092\u9589\u3058\u308B"></label>
+      <aside class="mobile-drawer" aria-label="\u30E2\u30D0\u30A4\u30EB\u7BA1\u7406\u30E1\u30CB\u30E5\u30FC">
+        <div class="mobile-drawer-header">
+          <span>
+            <span class="eyebrow">\u7BA1\u7406\u30E1\u30CB\u30E5\u30FC</span>
+            <strong>\u5FC5\u8981\u306A\u6642\u3060\u3051\u958B\u304F</strong>
+          </span>
+          <label class="round-button menu-open" for="mobile-menu-toggle" aria-label="\u7BA1\u7406\u30E1\u30CB\u30E5\u30FC\u3092\u9589\u3058\u308B">\xD7</label>
+        </div>
+        <div class="mobile-drawer-content">
+          <p class="menu-callout">\u72B6\u614B\u78BA\u8A8D\u3001\u9032\u6357\u3001RAG\u3001workflow \u306F\u3053\u3053\u304B\u3089\u958B\u304D\u307E\u3059\u3002\u901A\u77E5\u3067\u306F\u306A\u304F\u3001\u73FE\u5728\u306F dashboard \u5185\u306E\u72B6\u614B\u8868\u793A\u3067\u3059\u3002</p>
+          <div class="lane">
+            <div class="lane-title"><h3>\u9032\u884C\u4E2D execution</h3><span class="pill">runtime truth</span></div>
+            <p>GitHub Actions / VPS runner status / execution progress route \u304B\u3089\u8AAD\u307F\u307E\u3059\u3002</p>
+            ${renderDashboardDeployEvent(latestDeployEvent)}
+          </div>
+          <div class="quick-actions">
+            ${cockpitActions.map((action) => `<a href="${escapeDashboardHtml(action.href)}">${escapeDashboardHtml(action.label)}</a>`).join("")}
+          </div>
+          <details open>
+            <summary>Runtime surfaces</summary>
+            <div class="surface-list">
+              ${surfaces.map((surface) => `<a href="${escapeDashboardHtml(surface.href)}">${escapeDashboardHtml(surface.title)}</a>`).join("")}
+            </div>
+          </details>
+          <details>
+            <summary>GitHub workflows</summary>
+            <div class="surface-list">
+              ${workflows.map(([title, href]) => `<a href="${escapeDashboardHtml(href)}">${escapeDashboardHtml(title)}</a>`).join("")}
+            </div>
+          </details>
+        </div>
+      </aside>
 
       <div class="chat-scroll">
         <article class="bubble owner">
@@ -60371,13 +60416,6 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
           <span class="connection-note">\u672A\u63A5\u7D9A: \u3053\u306E\u5165\u529B\u6B04\u306F\u307E\u3060\u4FDD\u5B58\u30FB\u9001\u4FE1\u30FBLLM \u8FD4\u4FE1\u3057\u307E\u305B\u3093</span>
         </article>
 
-        <details id="mobile-management" class="mobile-tools">
-          <summary>\u7BA1\u7406\u30E1\u30CB\u30E5\u30FC\u3092\u958B\u304F</summary>
-          <div class="surface-list">
-            ${surfaces.map((surface) => `<a href="${escapeDashboardHtml(surface.href)}">${escapeDashboardHtml(surface.title)}</a>`).join("")}
-            ${workflows.map(([title, href]) => `<a href="${escapeDashboardHtml(href)}">${escapeDashboardHtml(title)}</a>`).join("")}
-          </div>
-        </details>
       </div>
 
       <div class="composer" aria-label="Butler composer">


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #433 の dashboard chat-first shell で、iPhone 幅の管理メニューが実際には開かず、最新 deploy event の場所も分かりにくい問題を修正します。

## Satisfied Success Criteria

- iPhone 幅で左ハンバーガーと右の管理ボタンが、同じ mobile drawer を開閉するようにしました。
- mobile drawer 内に進行中 execution と直近 deploy event 表示を配置しました。
- 押しても画面遷移するだけだったハンバーガーリンクを、開閉操作に変更しました。
- ヘッダーと吹き出しの横はみ出しを抑え、mobile viewport で横スクロールが出にくい CSS にしました。
- 自動更新、polling、fetch、secret 埋め込みは追加していません。

## Unsatisfied Success Criteria

- 本物の LLM 会話、VPS runner dispatch、iOS Push 通知、音、バッジは未実装です。live iPhone 実機確認は merge/deploy 後に必要です。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #433
- Implementing Success Criteria: iPhone 幅の chat-first dashboard で管理メニューを実際に開けること、最新 deploy event の表示場所が mobile でも到達可能なこと、横スクロールを抑えること。
- Explicit Non-goals: Push 通知、音、バッジ、LLM 会話接続、VPS runner dispatch、deploy 実行。
- Expected touched files/routes/workflows: src/worker/runtime.js, worker.js, test/worker.test.js
- Affected Issues: #433, #438
- Affected PRs: #437, #439, #441 の dashboard 表示に関係します。
- Affected workflows: なし。
- Affected runtime/operator surfaces: /dashboard, /orchestrator の HTML surface。Action Schema は未変更。
- What may break if we patch narrowly: mobile drawer を JS で実装すると自動更新や入力中 UX を壊す可能性があるため、CSS checkbox drawer に限定しました。
- Unknowns to investigate before coding: iPhone 実機での Safari / in-app browser 表示は deploy 後の live確認が必要です。
- Validation needed: node --test test/worker.test.js, npm test, deploy 後の iPhone live smoke。
- Stop condition: LLM 会話や通知機能まで混ぜそうになった場合は scope drift なので停止します。

## File / Line Hypotheses

- file: src/worker/runtime.js
  - hypothesis: topbar のハンバーガーが /dashboard link のままで、mobile 管理メニューを開かない。
  - risk if changed narrowly: 管理導線が desktop sidebar のみになり、iPhone で最新 deploy event に到達できない。
  - validation: dashboard HTML test と iPhone live smoke。
  - related Issue: #433
- file: src/worker/runtime.js
  - hypothesis: mobile header / bubble が viewport を超えて横スクロールを発生させる。
  - risk if changed narrowly: composer や bubble の入力 UX が崩れる。
  - validation: CSS guard と live smoke。
  - related Issue: #433
- file: test/worker.test.js
  - hypothesis: 既存 test は href anchor だけを確認しており、開閉可能な drawer contract を検出していない。
  - risk if changed narrowly: また押せないメニューを通してしまう。
  - validation: mobile-menu-toggle / drawer / no polling を assertion。

## Hypothesis Retrospective

- expected: mobile ではクリック可能な drawer が必要。
- actual: 既存 HTML はハンバーガーが /dashboard link、管理ボタンが下部 anchor で、ユーザーには開けないように見えた。
- mismatch: chat-first shell の mobile 管理導線が owner-facing になっていなかった。
- lesson: mobile の管理導線は drawer として第一画面から開閉できる必要がある。
- should become RAG candidate: はい。dashboard mobile shell は見た目のボタンではなく実操作を持つこと。

## Verification Evidence

- Unit: node --test test/worker.test.js: PASS
- Integration: npm test: PASS (833 tests, 832 pass, 1 skipped; self-parity / generated-worker pass)
- E2E: 未実施。merge/deploy 後に iPhone でハンバーガー/管理 drawer と横スクロール有無を確認します。
- Manual: ユーザー添付スクリーンショットで、ハンバーガーが開けず、mobile 横スクロールが出ている runtime truth を確認。
- Evidence path/link: src/worker/runtime.js; worker.js; test/worker.test.js

## Butler Completion Contract

- Owner goal: iPhone で dashboard の管理メニューを自然に開き、直近 deploy event の場所に辿り着けるようにする。
- Butler entrypoint: /dashboard と /orchestrator。Butler 会話入口の mobile 管理 drawer。
- Action Schema exposure: 不要。この PR は dashboard HTML surface の修正で、Custom GPT Action Schema は未変更です。
- Runtime path: GET /dashboard, GET /orchestrator
- Runner/runtime truth: 添付スクリーンショットで mobile menu 不達と横スクロールを確認。修正後の live runtime truth は deploy 後に確認します。
- Authority boundary: 未変更。高リスク操作は追加していません。deploy は引き続き GO + passkey。
- E2E evidence: 未実施。deploy 後に iPhone で drawer と横スクロールを確認します。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 未実施。merge 後に必要です。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。merge/deploy 後に実機確認します。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate
- AGENTS.md Conversation UX Contract
- AGENTS.md Evidence Discipline
- Issue #433 Success Criteria

## Out-of-scope but NOT implemented

- Push 通知、音、バッジ。
- 本物の LLM 会話接続。
- VPS runner dispatch。
- Issue #440 の closure。

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #433
- Execution ID: mac-codex-issue-433-mobile-menu-drawer
- Goal: dashboard mobile management drawer と横スクロール抑制
