### PR TITLE
fix: dashboard メニューを人間向けページへ統一

### DIFF
--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -146,6 +146,40 @@ export default {
       );
     }
 
+    if (request.method === "GET" && url.pathname === "/dashboard/github") {
+      return html(200, await renderDashboardGitHubTruthPage({ url, env }));
+    }
+
+    if (request.method === "GET" && url.pathname === "/dashboard/preflight") {
+      return html(200, await renderDashboardPreflightPage({ url, env }));
+    }
+
+    if (request.method === "GET" && url.pathname === "/dashboard/progress") {
+      return html(200, await renderDashboardProgressPage({ url, env }));
+    }
+
+    if (request.method === "GET" && url.pathname === "/dashboard/vps-runner") {
+      return html(200, await renderDashboardVpsRunnerPage({ url, env }));
+    }
+
+    if (request.method === "GET" && url.pathname === "/dashboard/memory") {
+      return html(200, await renderDashboardMemoryPage({ url, env }));
+    }
+
+    if (request.method === "GET" && url.pathname === "/dashboard/self-parity") {
+      return html(200, await renderDashboardSelfParityPage({ url, env }));
+    }
+
+    if (request.method === "GET" && url.pathname === "/dashboard/notifications") {
+      return html(
+        200,
+        await renderDashboardNotificationsPage({
+          runtimeOrigin: url.origin,
+          dashboardEventStore: resolveDashboardEventStore(env)
+        })
+      );
+    }
+
     if (
       request.method === "GET" &&
       (url.pathname === MCP_PROTECTED_RESOURCE_METADATA_PATH ||
@@ -5189,6 +5223,408 @@ function renderDashboardDeployEvent(event) {
           </div>`;
 }
 
+async function renderDashboardGitHubTruthPage({ url, env } = {}) {
+  const origin = normalize(url?.origin);
+  const repository = normalizeCanonicalRepositoryInput(url?.searchParams?.get("repository")) || "marushu/vtdd-v2-p";
+  const [issues, pulls, workflowRuns] = await Promise.all([
+    retrieveGitHubReadPlane({
+      resource: "issues",
+      repository,
+      state: "open",
+      limit: 12,
+      env
+    }),
+    retrieveGitHubReadPlane({
+      resource: "pulls",
+      repository,
+      state: "open",
+      limit: 12,
+      env
+    }),
+    retrieveGitHubReadPlane({
+      resource: "workflow_runs",
+      repository,
+      limit: 8,
+      env
+    })
+  ]);
+  const failures = [issues, pulls, workflowRuns].filter((item) => !item.ok);
+  return renderDashboardUtilityPage({
+    title: "GitHub runtime truth",
+    subtitle: repository,
+    backHref: `${origin}/dashboard`,
+    body: `
+      <section class="hero">
+        <p>Butler / Action 向け JSON ではなく、人間が読むための GitHub 現在地です。</p>
+      </section>
+      ${failures.length > 0 ? renderDashboardNotice("一部の GitHub runtime truth を読めませんでした。GitHub App / token 設定を確認してください。") : ""}
+      <div class="grid">
+        ${renderGitHubTruthLane("Open Issues", issues, renderIssueTruthCard)}
+        ${renderGitHubTruthLane("Open PRs", pulls, renderPullTruthCard)}
+        ${renderGitHubTruthLane("Workflow Runs", workflowRuns, renderWorkflowRunTruthCard)}
+      </div>
+    `
+  });
+}
+
+async function renderDashboardPreflightPage({ url, env } = {}) {
+  const origin = normalize(url?.origin);
+  const repository = normalizeCanonicalRepositoryInput(url?.searchParams?.get("repository")) || "marushu/vtdd-v2-p";
+  const issueNumber = normalizeIssue(url?.searchParams?.get("issueNumber"));
+  const phase = normalizeText(url?.searchParams?.get("phase")) || "execution";
+  const currentSurface = normalizeText(url?.searchParams?.get("currentSurface")) || "dashboard";
+  const startupPreflight = await buildStartupPreflight({
+    repository,
+    ref: normalizeText(url?.searchParams?.get("ref")) || "main",
+    issueNumber,
+    phase,
+    currentSurface,
+    queryText: "VTDD dashboard startup preflight",
+    runtimeOrigin: origin,
+    env
+  });
+  return renderDashboardUtilityPage({
+    title: "Startup preflight",
+    subtitle: repository,
+    backHref: `${origin}/dashboard`,
+    body: `
+      <section class="hero">
+        <p>Butler が最初に読むべき AGENTS / Issue / runtime truth / RAG / self parity の現在地です。</p>
+      </section>
+      <div class="grid">
+        <section class="lane">
+          <div class="lane-title"><h2>Source truth</h2><span class="pill">${startupPreflight.sources.length}件</span></div>
+          ${startupPreflight.sources.map((source) => renderTruthRow(source.path, source.status, source.reason || source.sha || "")).join("")}
+        </section>
+        <section class="lane">
+          <div class="lane-title"><h2>Open Issues</h2><span class="pill">${startupPreflight.openIssues.length}件</span></div>
+          ${startupPreflight.openIssues.length > 0 ? startupPreflight.openIssues.map((issue) => renderLinkedTruthRow(`#${issue.number} ${issue.title}`, issue.htmlUrl, issue.state)).join("") : `<p class="muted">該当なし</p>`}
+        </section>
+        <section class="lane">
+          <div class="lane-title"><h2>Next safe action</h2><span class="pill">${escapeDashboardHtml(startupPreflight.butlerFirstPrinciple.status)}</span></div>
+          ${renderObjectSummary(startupPreflight.nextSafeAction)}
+        </section>
+      </div>
+    `
+  });
+}
+
+async function renderDashboardProgressPage({ url, env } = {}) {
+  const origin = normalize(url?.origin);
+  const repository = normalizeCanonicalRepositoryInput(url?.searchParams?.get("repository")) || "marushu/vtdd-v2-p";
+  const progress = await retrieveRemoteCodexExecutionProgress({
+    executionId: url.searchParams.get("executionId"),
+    repository,
+    issueNumber: url.searchParams.get("issueNumber"),
+    branch: url.searchParams.get("branch"),
+    executorTransport: url.searchParams.get("executorTransport"),
+    env
+  });
+  return renderDashboardUtilityPage({
+    title: "Execution progress",
+    subtitle: repository,
+    backHref: `${origin}/dashboard`,
+    body: `
+      <section class="hero">
+        <p>VPS Codex CLI / remote Codex execution の進捗を人間向けに表示します。入力中に勝手な自動更新はしません。</p>
+      </section>
+      ${progress.ok ? renderProgressSummary(progress.progress) : renderDashboardNotice(progress.reason || progress.error || "progress unavailable")}
+    `
+  });
+}
+
+async function renderDashboardVpsRunnerPage({ url, env } = {}) {
+  const origin = normalize(url?.origin);
+  const repository = normalizeCanonicalRepositoryInput(url?.searchParams?.get("repository")) || "marushu/vtdd-v2-p";
+  const status = await retrieveVpsRunnerHealthStatus({
+    executionId: url.searchParams.get("executionId"),
+    repository,
+    issueNumber: url.searchParams.get("issueNumber"),
+    branch: url.searchParams.get("branch"),
+    env
+  });
+  return renderDashboardUtilityPage({
+    title: "VPS runner status",
+    subtitle: repository,
+    backHref: `${origin}/dashboard`,
+    body: `
+      <section class="hero">
+        <p>VPS runner の health / queue / progress を人間向けに表示します。</p>
+      </section>
+      ${status.ok ? `<div class="grid">${renderStatusLane("Health", status.health)}${renderStatusLane("Progress", status.progress)}</div>` : renderDashboardNotice(status.reason || status.error || "runner status unavailable")}
+    `
+  });
+}
+
+async function renderDashboardMemoryPage({ url, env } = {}) {
+  const origin = normalize(url?.origin);
+  const repository = normalizeCanonicalRepositoryInput(url?.searchParams?.get("repository")) || "marushu/vtdd-v2-p";
+  const retrieved = await retrieveOperationalMemory(resolveMemoryProvider(env), {
+    text: normalizeText(url.searchParams.get("text")) || normalizeText(url.searchParams.get("q")),
+    recordId: normalizeText(url.searchParams.get("recordId")),
+    repository,
+    limit: normalizeLimit(url.searchParams.get("limit"), 8),
+    runtimeTruth: buildRetrieveRuntimeTruth(url)
+  });
+  return renderDashboardUtilityPage({
+    title: "Operational RAG",
+    subtitle: repository,
+    backHref: `${origin}/dashboard`,
+    body: `
+      <section class="hero">
+        <p>decision / proposal / working memory の compact retrieval です。runtime truth の代替ではありません。</p>
+      </section>
+      ${retrieved.ok ? renderMemorySummary(retrieved) : renderDashboardNotice(retrieved.reason || retrieved.error || "memory unavailable")}
+    `
+  });
+}
+
+async function renderDashboardSelfParityPage({ url, env } = {}) {
+  const origin = normalize(url?.origin);
+  const repository = normalizeCanonicalRepositoryInput(url?.searchParams?.get("repository")) || "marushu/vtdd-v2-p";
+  const parity = await evaluateButlerSelfParity({
+    repository,
+    ref: normalizeText(url.searchParams.get("ref")),
+    issueNumber: normalizeIssue(url.searchParams.get("issueNumber")),
+    pullNumber: normalizeIssue(url.searchParams.get("pullNumber")),
+    runtimeOrigin: origin,
+    env
+  });
+  return renderDashboardUtilityPage({
+    title: "Self parity",
+    subtitle: repository,
+    backHref: `${origin}/dashboard`,
+    body: `
+      <section class="hero">
+        <p>Action Schema / Instructions / Cloudflare deploy freshness / operator URL の自己診断です。</p>
+      </section>
+      ${parity.ok ? renderObjectSummary(parity.selfParity) : renderDashboardNotice(parity.reason || parity.error || "self parity unavailable")}
+    `
+  });
+}
+
+async function renderDashboardNotificationsPage({ runtimeOrigin, dashboardEventStore } = {}) {
+  const origin = normalize(runtimeOrigin);
+  const latestDeployEvent = await retrieveLatestDashboardEvent({
+    store: dashboardEventStore,
+    kind: "github_actions_workflow_run",
+    repository: "marushu/vtdd-v2-p",
+    workflowName: "deploy-production"
+  });
+  return renderDashboardUtilityPage({
+    title: "通知センター",
+    subtitle: "dashboard events",
+    backHref: `${origin}/dashboard`,
+    body: `
+      <section class="hero">
+        <p>今は iOS Push / 音 / PWA badge ではなく、Worker に届いた dashboard event の人間向け表示です。</p>
+        <p class="muted">次の段階で Web Push 購読、通知 permission、通知タップ遷移を追加します。</p>
+      </section>
+      <div class="grid single">
+        <section class="lane">
+          <div class="lane-title"><h2>deploy-production</h2><span class="pill">latest</span></div>
+          ${renderDashboardDeployEvent(latestDeployEvent)}
+        </section>
+      </div>
+    `
+  });
+}
+
+function renderGitHubTruthLane(title, result, renderCard) {
+  if (!result.ok) {
+    return `<section class="lane">
+      <div class="lane-title"><h2>${escapeDashboardHtml(title)}</h2><span class="pill danger">unavailable</span></div>
+      <p>${escapeDashboardHtml(result.reason || result.error || "GitHub read unavailable")}</p>
+    </section>`;
+  }
+  const records = Array.isArray(result.read?.records) ? result.read.records : [];
+  return `<section class="lane">
+    <div class="lane-title"><h2>${escapeDashboardHtml(title)}</h2><span class="pill">${records.length}件</span></div>
+    ${records.length > 0 ? records.map(renderCard).join("") : `<p class="muted">該当なし</p>`}
+  </section>`;
+}
+
+function renderIssueTruthCard(issue) {
+  return `<article class="truth-card">
+    <div class="truth-card-title"><a href="${escapeDashboardHtml(issue.htmlUrl)}">#${escapeDashboardHtml(issue.number)} ${escapeDashboardHtml(issue.title)}</a></div>
+    <p>${escapeDashboardHtml(issue.author || "unknown")} / ${escapeDashboardHtml(issue.state || "open")}</p>
+  </article>`;
+}
+
+function renderPullTruthCard(pull) {
+  const state = pull.draft ? "draft" : pull.state || "open";
+  return `<article class="truth-card">
+    <div class="truth-card-title"><a href="${escapeDashboardHtml(pull.htmlUrl)}">#${escapeDashboardHtml(pull.number)} ${escapeDashboardHtml(pull.title)}</a></div>
+    <p>${escapeDashboardHtml(state)} / ${escapeDashboardHtml(pull.headRef || "head unknown")} -> ${escapeDashboardHtml(pull.baseRef || "base unknown")}</p>
+  </article>`;
+}
+
+function renderWorkflowRunTruthCard(run) {
+  const conclusion = run.conclusion || run.status || "unknown";
+  const badgeClass = conclusion === "success" ? "success" : conclusion === "failure" ? "danger" : "";
+  return `<article class="truth-card">
+    <div class="truth-card-title"><a href="${escapeDashboardHtml(run.htmlUrl)}">${escapeDashboardHtml(run.name || `run ${run.id}`)}</a></div>
+    <p><span class="pill ${badgeClass}">${escapeDashboardHtml(conclusion)}</span> ${escapeDashboardHtml(run.headBranch || "")}</p>
+  </article>`;
+}
+
+function renderDashboardNotice(message) {
+  return `<section class="notice">${escapeDashboardHtml(message)}</section>`;
+}
+
+function renderTruthRow(label, value, detail = "") {
+  return `<article class="truth-card">
+    <div class="truth-card-title"><strong>${escapeDashboardHtml(label)}</strong><span class="pill">${escapeDashboardHtml(value || "未確認")}</span></div>
+    ${detail ? `<p>${escapeDashboardHtml(detail)}</p>` : ""}
+  </article>`;
+}
+
+function renderLinkedTruthRow(label, href, detail = "") {
+  return `<article class="truth-card">
+    <div class="truth-card-title"><a href="${escapeDashboardHtml(href || "#")}">${escapeDashboardHtml(label)}</a></div>
+    ${detail ? `<p>${escapeDashboardHtml(detail)}</p>` : ""}
+  </article>`;
+}
+
+function renderProgressSummary(progress) {
+  return `<div class="grid single">
+    <section class="lane">
+      <div class="lane-title"><h2>Progress</h2><span class="pill">${escapeDashboardHtml(progress?.status || "未確認")}</span></div>
+      ${renderObjectSummary(progress)}
+    </section>
+  </div>`;
+}
+
+function renderStatusLane(title, value) {
+  return `<section class="lane">
+    <div class="lane-title"><h2>${escapeDashboardHtml(title)}</h2><span class="pill">summary</span></div>
+    ${renderObjectSummary(value)}
+  </section>`;
+}
+
+function renderMemorySummary(retrieved) {
+  const references = retrieved.referencesByLayer && typeof retrieved.referencesByLayer === "object"
+    ? Object.entries(retrieved.referencesByLayer)
+    : [];
+  return `<div class="grid">
+    <section class="lane">
+      <div class="lane-title"><h2>Compact context</h2><span class="pill">${escapeDashboardHtml(retrieved.architecture || "memory")}</span></div>
+      <p>${escapeDashboardHtml(retrieved.compactContext || "該当なし")}</p>
+    </section>
+    <section class="lane">
+      <div class="lane-title"><h2>References</h2><span class="pill">${references.length} layers</span></div>
+      ${references.length > 0 ? references.map(([layer, records]) => renderTruthRow(layer, Array.isArray(records) ? `${records.length}件` : "未確認")).join("") : `<p class="muted">該当なし</p>`}
+    </section>
+    <section class="lane">
+      <div class="lane-title"><h2>Signals</h2><span class="pill">retrieval</span></div>
+      ${renderObjectSummary(retrieved.retrievalSignals)}
+    </section>
+  </div>`;
+}
+
+function renderObjectSummary(value, depth = 0) {
+  if (value === null || value === undefined || value === "") {
+    return `<p class="muted">未確認</p>`;
+  }
+  if (typeof value !== "object") {
+    return `<p>${escapeDashboardHtml(String(value))}</p>`;
+  }
+  if (Array.isArray(value)) {
+    if (value.length === 0) {
+      return `<p class="muted">該当なし</p>`;
+    }
+    return value.slice(0, 8).map((item, index) => renderTruthRow(`#${index + 1}`, summarizeObjectValue(item))).join("");
+  }
+  const entries = Object.entries(value).filter(([, item]) => item !== undefined && typeof item !== "function");
+  if (entries.length === 0) {
+    return `<p class="muted">該当なし</p>`;
+  }
+  return `<dl class="summary-list">
+    ${entries.slice(0, 16).map(([key, item]) => `
+      <div>
+        <dt>${escapeDashboardHtml(key)}</dt>
+        <dd>${depth < 1 && item && typeof item === "object" ? renderObjectSummary(item, depth + 1) : escapeDashboardHtml(summarizeObjectValue(item))}</dd>
+      </div>
+    `).join("")}
+  </dl>`;
+}
+
+function summarizeObjectValue(value) {
+  if (value === null || value === undefined || value === "") {
+    return "未確認";
+  }
+  if (Array.isArray(value)) {
+    return `${value.length}件`;
+  }
+  if (typeof value === "object") {
+    const title = value.title || value.name || value.status || value.state || value.id || value.number;
+    return title ? String(title) : `${Object.keys(value).length} fields`;
+  }
+  return String(value);
+}
+
+function renderDashboardUtilityPage({ title, subtitle, backHref, body }) {
+  return `<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>${escapeDashboardHtml(title)} - VTDD Butler</title>
+  <style>
+    :root { color-scheme: light dark; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; --bg: #f7f7f4; --panel: #fff; --text: #151515; --muted: #62625d; --border: #deded6; --soft: #f0f0eb; }
+    @media (prefers-color-scheme: dark) { :root { --bg: #050505; --panel: #101010; --text: #f7f7f4; --muted: #a0a09a; --border: #2b2b2b; --soft: #1b1b1b; } }
+    * { box-sizing: border-box; }
+    html, body { max-width: 100%; overflow-x: hidden; }
+    body { margin: 0; background: var(--bg); color: var(--text); }
+    main { width: min(1120px, 100%); margin: 0 auto; padding: 16px; }
+    header { display: flex; justify-content: space-between; align-items: center; gap: 12px; margin-bottom: 18px; }
+    h1 { font-size: 24px; margin: 0 0 4px; }
+    h2 { font-size: 18px; margin: 0; }
+    p { line-height: 1.6; margin: 0 0 10px; }
+    a { color: inherit; text-underline-offset: 4px; }
+    .back, .actions a { display: inline-flex; min-height: 38px; align-items: center; justify-content: center; border: 1px solid var(--border); border-radius: 999px; padding: 6px 12px; background: var(--soft); text-decoration: none; font-weight: 750; }
+    .hero, .lane, .notice { border: 1px solid var(--border); border-radius: 16px; background: var(--panel); padding: 14px; margin-bottom: 14px; }
+    .actions { display: flex; flex-wrap: wrap; gap: 8px; }
+    .grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 14px; }
+    .grid.single { grid-template-columns: minmax(0, 1fr); }
+    .lane-title, .truth-card-title { display: flex; justify-content: space-between; align-items: baseline; gap: 8px; }
+    .truth-card { border-top: 1px solid var(--border); padding: 11px 0; }
+    .truth-card:first-of-type { border-top: 0; }
+    .truth-card p, .muted { color: var(--muted); }
+    .summary-list { margin: 0; display: grid; gap: 8px; }
+    .summary-list div { display: grid; grid-template-columns: minmax(96px, 0.4fr) minmax(0, 1fr); gap: 10px; padding: 8px 0; border-top: 1px solid var(--border); }
+    .summary-list div:first-child { border-top: 0; }
+    .summary-list dt { color: var(--muted); font-size: 13px; }
+    .summary-list dd { margin: 0; overflow-wrap: anywhere; }
+    .pill { display: inline-flex; border: 1px solid var(--border); border-radius: 999px; padding: 3px 8px; background: var(--soft); font-size: 12px; white-space: nowrap; }
+    .pill.success { border-color: #7fb797; background: #e7f5ec; color: #145c34; }
+    .pill.danger { border-color: #d69b9b; background: #fff0f0; color: #8a1f1f; }
+    .deploy-event { border: 1px solid var(--border); border-radius: 12px; padding: 10px; margin: 10px 0; background: var(--soft); }
+    .deploy-event p { margin-bottom: 6px; font-size: 13px; }
+    code { overflow-wrap: anywhere; }
+    @media (max-width: 760px) {
+      main { padding: 12px; }
+      header { align-items: flex-start; }
+      .grid { grid-template-columns: minmax(0, 1fr); }
+      .summary-list div { grid-template-columns: minmax(0, 1fr); }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <header>
+      <div>
+        <h1>${escapeDashboardHtml(title)}</h1>
+        <p class="muted">${escapeDashboardHtml(subtitle || "")}</p>
+      </div>
+      <a class="back" href="${escapeDashboardHtml(backHref || "/dashboard")}">Dashboard</a>
+    </header>
+    ${body}
+  </main>
+</body>
+</html>`;
+}
+
 function normalizeTextList(value) {
   if (Array.isArray(value)) {
     return value.map(normalizeText).filter(Boolean);
@@ -5214,38 +5650,43 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
   const surfaces = [
     {
       title: "Status page",
-      body: "人間向けの runtime status。raw /health JSON ではなく、まずここを見る。",
+      body: "人間向けの runtime status。まずここを見る。",
       href: `${origin}/status`
     },
     {
       title: "Startup preflight",
       body: "AGENTS.md、thread-independent startup、runtime truth、RAG、self parity を最初に読む入口。",
-      href: `${origin}/v2/retrieve/startup-preflight?repository=${encodedRepository}&currentSurface=dashboard&responseMode=action_visible`
+      href: `${origin}/dashboard/preflight?repository=${encodedRepository}`
     },
     {
       title: "Execution progress",
       body: "VPS Codex CLI / remote Codex execution の進捗確認。",
-      href: `${origin}/v2/action/progress?repository=${encodedRepository}&responseMode=action_visible`
+      href: `${origin}/dashboard/progress?repository=${encodedRepository}`
     },
     {
       title: "VPS runner status",
       body: "runner health、queue、対象 execution の状態確認。",
-      href: `${origin}/v2/action/vps-runner-status?repository=${encodedRepository}&responseMode=action_visible`
+      href: `${origin}/dashboard/vps-runner?repository=${encodedRepository}`
     },
     {
       title: "GitHub runtime truth",
       body: "Issues、PRs、checks、workflow runs、reviewer comments を読む入口。",
-      href: `${origin}/v2/retrieve/github?repository=${encodedRepository}&include=open_prs,open_issues,workflow_runs,issue_comments&responseMode=action_visible`
+      href: `${origin}/dashboard/github?repository=${encodedRepository}`
+    },
+    {
+      title: "通知センター",
+      body: "GitHub Actions / deploy から Worker に届いた dashboard event を人間向けに見る入口。",
+      href: `${origin}/dashboard/notifications`
     },
     {
       title: "Operational RAG",
       body: "decision / proposal / working memory の compact retrieval。runtime truth の代替ではない。",
-      href: `${origin}/v2/retrieve/operational-memory?repository=${encodedRepository}&limit=5&responseMode=action_visible`
+      href: `${origin}/dashboard/memory?repository=${encodedRepository}`
     },
     {
       title: "Self parity",
       body: "Action Schema、Instructions、Cloudflare deploy freshness、operator URL を確認。",
-      href: `${origin}/v2/retrieve/self-parity?repository=${encodedRepository}&responseMode=action_visible`
+      href: `${origin}/dashboard/self-parity?repository=${encodedRepository}`
     },
     {
       title: "Setup diagnostics",
@@ -5267,15 +5708,19 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
   const cockpitActions = [
     {
       label: "状態確認",
-      href: `${origin}/v2/retrieve/github?repository=${encodedRepository}&include=open_prs,open_issues,workflow_runs,issue_comments&responseMode=action_visible`
+      href: `${origin}/dashboard/github?repository=${encodedRepository}`
     },
     {
       label: "進捗を見る",
-      href: `${origin}/v2/action/progress?repository=${encodedRepository}&responseMode=action_visible`
+      href: `${origin}/dashboard/progress?repository=${encodedRepository}`
     },
     {
       label: "RAG を読む",
-      href: `${origin}/v2/retrieve/operational-memory?repository=${encodedRepository}&limit=5&responseMode=action_visible`
+      href: `${origin}/dashboard/memory?repository=${encodedRepository}`
+    },
+    {
+      label: "通知",
+      href: `${origin}/dashboard/notifications`
     },
     {
       label: "Passkey",
@@ -5566,8 +6011,7 @@ function renderV2StatusPage({ runtimeOrigin, autonomyMode }) {
     ["Mode", mode, "現在の runtime mode です。"],
     ["Autonomy", resolvedAutonomyMode, "guarded absence などの実行抑制状態を示します。"],
     ["Dashboard", "利用可能", "/dashboard と /orchestrator は人間向け入口です。"],
-    ["Passkey", "same-origin", "高リスク操作は scope 明示済み passkey approval の後ろです。"],
-    ["Raw health", "JSON", "/health は API 互換の machine-readable endpoint として残します。"]
+    ["Passkey", "same-origin", "高リスク操作は scope 明示済み passkey approval の後ろです。"]
   ];
 
   return `<!doctype html>
@@ -5604,7 +6048,7 @@ function renderV2StatusPage({ runtimeOrigin, autonomyMode }) {
       <div>
         <p class="eyebrow">VTDD v2 status</p>
         <h1>Runtime Status</h1>
-        <p>ブラウザで見るための health summary です。機械向け JSON は <code>/health</code> に残しています。</p>
+        <p>ブラウザで見るための health summary です。</p>
       </div>
       <a class="button" href="${escapeDashboardHtml(origin)}/dashboard">Dashboard</a>
     </header>
@@ -5615,7 +6059,6 @@ function renderV2StatusPage({ runtimeOrigin, autonomyMode }) {
       <p>Worker は応答しています。ここでは secret、token、approval grant は表示しません。</p>
       <div class="actions">
         <a class="primary" href="${escapeDashboardHtml(origin)}/dashboard">Butler dashboard</a>
-        <a href="${escapeDashboardHtml(origin)}/health">raw /health JSON</a>
         <a href="${escapeDashboardHtml(origin)}/v2/approval/passkey/operator?repositoryInput=marushu%2Fvtdd-v2-p">Passkey operator</a>
       </div>
     </section>

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -155,14 +155,14 @@ test("worker returns health", async () => {
   assert.equal(body.autonomyMode, AutonomyMode.NORMAL);
 });
 
-test("worker serves human-facing status page while keeping raw health JSON", async () => {
+test("worker serves human-facing status page without raw JSON links", async () => {
   const response = await worker.fetch(new Request("https://example.com/status"));
   assert.equal(response.status, 200);
   assert.match(response.headers.get("content-type"), /text\/html/);
   const body = await response.text();
   assert.equal(body.includes("VTDD v2 status"), true);
   assert.equal(body.includes("Runtime Status"), true);
-  assert.equal(body.includes("raw /health JSON"), true);
+  assert.equal(body.includes("raw /health JSON"), false);
   assert.equal(body.includes("/dashboard"), true);
   assert.equal(body.includes("/v2/approval/passkey/operator?repositoryInput=marushu%2Fvtdd-v2-p"), true);
   assert.equal(body.includes("approvalGrantId"), false);
@@ -196,6 +196,9 @@ test("worker serves v2 dashboard without exposing secrets", async () => {
   assert.equal(body.includes("直近 deploy event"), true);
   assert.equal(body.includes("Butler V2 にメッセージ"), true);
   assert.equal(body.includes("状態確認"), true);
+  assert.equal(body.includes("/dashboard/github?repository=marushu%2Fvtdd-v2-p"), true);
+  assert.equal(body.includes("/dashboard/notifications"), true);
+  assert.equal(body.includes("include=open_prs"), false);
   assert.equal(body.includes('name="text"'), false);
   assert.equal(/<meta[^>]+http-equiv=["']?refresh/i.test(body), false);
   assert.equal(body.includes("setInterval("), false);
@@ -206,9 +209,16 @@ test("worker serves v2 dashboard without exposing secrets", async () => {
     true
   );
   assert.equal(body.includes("/status"), true);
-  assert.equal(body.includes("/v2/retrieve/startup-preflight"), true);
-  assert.equal(body.includes("/v2/action/vps-runner-status"), true);
-  assert.equal(body.includes("/v2/retrieve/operational-memory"), true);
+  assert.equal(body.includes("/dashboard/preflight?repository=marushu%2Fvtdd-v2-p"), true);
+  assert.equal(body.includes("/dashboard/progress?repository=marushu%2Fvtdd-v2-p"), true);
+  assert.equal(body.includes("/dashboard/vps-runner?repository=marushu%2Fvtdd-v2-p"), true);
+  assert.equal(body.includes("/dashboard/memory?repository=marushu%2Fvtdd-v2-p"), true);
+  assert.equal(body.includes("/dashboard/self-parity?repository=marushu%2Fvtdd-v2-p"), true);
+  assert.equal(body.includes("/v2/retrieve/startup-preflight?repository=marushu%2Fvtdd-v2-p"), false);
+  assert.equal(body.includes("/v2/action/progress?repository=marushu%2Fvtdd-v2-p"), false);
+  assert.equal(body.includes("/v2/action/vps-runner-status?repository=marushu%2Fvtdd-v2-p"), false);
+  assert.equal(body.includes("/v2/retrieve/operational-memory?repository=marushu%2Fvtdd-v2-p"), false);
+  assert.equal(body.includes("/v2/retrieve/self-parity?repository=marushu%2Fvtdd-v2-p"), false);
   assert.equal(body.includes("gemini-pr-review"), true);
   assert.equal(body.includes("passkey approval"), true);
   assert.equal(body.includes("approvalGrantId"), false);
@@ -221,6 +231,132 @@ test("worker serves v2 dashboard without exposing secrets", async () => {
   assert.equal(aliasBody.includes("dashboard main chat"), true);
   assert.equal(aliasBody.includes("管理メニュー"), true);
   assert.equal(aliasBody.includes("自動更新なし"), true);
+});
+
+test("worker serves human-facing GitHub truth dashboard instead of raw action JSON", async () => {
+  const response = await worker.fetch(
+    new Request("https://example.com/dashboard/github?repository=sample-org/vtdd-v2-p"),
+    {
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_read",
+      GITHUB_API_FETCH: async (url) => {
+        const parsed = new URL(url);
+        if (parsed.pathname.endsWith("/issues")) {
+          return new Response(
+            JSON.stringify([
+              {
+                number: 46,
+                title: "GitHub read plane",
+                state: "open",
+                html_url: "https://github.com/sample-org/vtdd-v2-p/issues/46",
+                user: { login: "marushu" }
+              }
+            ]),
+            { status: 200, headers: { "content-type": "application/json" } }
+          );
+        }
+        if (parsed.pathname.endsWith("/pulls")) {
+          return new Response(
+            JSON.stringify([
+              {
+                number: 47,
+                title: "Dashboard HTML",
+                state: "open",
+                draft: false,
+                html_url: "https://github.com/sample-org/vtdd-v2-p/pull/47",
+                head: { ref: "codex/dashboard", sha: "abc", repo: { owner: { login: "sample-org" } } },
+                base: { ref: "main", sha: "def" }
+              }
+            ]),
+            { status: 200, headers: { "content-type": "application/json" } }
+          );
+        }
+        if (parsed.pathname.endsWith("/actions/runs")) {
+          return new Response(
+            JSON.stringify({
+              workflow_runs: [
+                {
+                  id: 4800,
+                  name: "deploy-production",
+                  status: "completed",
+                  conclusion: "success",
+                  head_branch: "main",
+                  html_url: "https://github.com/sample-org/vtdd-v2-p/actions/runs/4800"
+                }
+              ]
+            }),
+            { status: 200, headers: { "content-type": "application/json" } }
+          );
+        }
+        return new Response(JSON.stringify({ message: `unexpected ${parsed.pathname}` }), {
+          status: 404,
+          headers: { "content-type": "application/json" }
+        });
+      }
+    }
+  );
+
+  assert.equal(response.status, 200);
+  assert.match(response.headers.get("content-type"), /text\/html/);
+  const body = await response.text();
+  assert.equal(body.includes("GitHub runtime truth"), true);
+  assert.equal(body.includes("Open Issues"), true);
+  assert.equal(body.includes("#46 GitHub read plane"), true);
+  assert.equal(body.includes("Open PRs"), true);
+  assert.equal(body.includes("#47 Dashboard HTML"), true);
+  assert.equal(body.includes("Workflow Runs"), true);
+  assert.equal(body.includes("deploy-production"), true);
+  assert.equal(body.includes("raw issues JSON"), false);
+  assert.equal(body.includes("{\"ok\""), false);
+});
+
+test("worker serves human-facing dashboard pages for every management menu", async () => {
+  const routes = [
+    ["/dashboard/preflight?repository=sample-org/vtdd-v2-p", "Startup preflight", "raw preflight JSON"],
+    ["/dashboard/progress?repository=sample-org/vtdd-v2-p", "Execution progress", "raw progress JSON"],
+    ["/dashboard/vps-runner?repository=sample-org/vtdd-v2-p", "VPS runner status", "raw runner JSON"],
+    ["/dashboard/memory?repository=sample-org/vtdd-v2-p", "Operational RAG", "raw memory JSON"],
+    ["/dashboard/self-parity?repository=sample-org/vtdd-v2-p", "Self parity", "raw self parity JSON"]
+  ];
+
+  for (const [route, title, rawLabel] of routes) {
+    const response = await worker.fetch(new Request(`https://example.com${route}`));
+    assert.equal(response.status, 200);
+    assert.match(response.headers.get("content-type"), /text\/html/);
+    const body = await response.text();
+    assert.equal(body.includes(title), true);
+    assert.equal(body.includes(rawLabel), false);
+    assert.equal(body.includes("{\"ok\""), false);
+  }
+});
+
+test("worker serves dashboard notification center for latest deploy event", async () => {
+  const store = createInMemoryDashboardEventStore();
+  await store.put({
+    id: "github_actions_workflow_run:marushu/vtdd-v2-p:deploy-production:26134526815",
+    kind: "github_actions_workflow_run",
+    repository: "marushu/vtdd-v2-p",
+    workflowName: "deploy-production",
+    runId: "26134526815",
+    runUrl: "https://github.com/marushu/vtdd-v2-p/actions/runs/26134526815",
+    status: "completed",
+    conclusion: "success",
+    headSha: "daad4fb023cf699b3ad531e0394e064fde2b5515",
+    headBranch: "main",
+    title: "deploy-production",
+    updatedAt: "2026-05-20T00:54:27Z"
+  });
+
+  const response = await worker.fetch(new Request("https://example.com/dashboard/notifications"), {
+    DASHBOARD_EVENT_STORE: store
+  });
+  assert.equal(response.status, 200);
+  assert.match(response.headers.get("content-type"), /text\/html/);
+  const body = await response.text();
+  assert.equal(body.includes("通知センター"), true);
+  assert.equal(body.includes("iOS Push / 音 / PWA badge ではなく"), true);
+  assert.equal(body.includes("最新 deploy"), true);
+  assert.equal(body.includes("success"), true);
+  assert.equal(body.includes("26134526815"), true);
 });
 
 test("worker ingests GitHub Actions deploy completion event and shows it on dashboard", async () => {

--- a/worker.js
+++ b/worker.js
@@ -55799,6 +55799,33 @@ var runtime_default = {
         })
       );
     }
+    if (request.method === "GET" && url.pathname === "/dashboard/github") {
+      return html(200, await renderDashboardGitHubTruthPage({ url, env }));
+    }
+    if (request.method === "GET" && url.pathname === "/dashboard/preflight") {
+      return html(200, await renderDashboardPreflightPage({ url, env }));
+    }
+    if (request.method === "GET" && url.pathname === "/dashboard/progress") {
+      return html(200, await renderDashboardProgressPage({ url, env }));
+    }
+    if (request.method === "GET" && url.pathname === "/dashboard/vps-runner") {
+      return html(200, await renderDashboardVpsRunnerPage({ url, env }));
+    }
+    if (request.method === "GET" && url.pathname === "/dashboard/memory") {
+      return html(200, await renderDashboardMemoryPage({ url, env }));
+    }
+    if (request.method === "GET" && url.pathname === "/dashboard/self-parity") {
+      return html(200, await renderDashboardSelfParityPage({ url, env }));
+    }
+    if (request.method === "GET" && url.pathname === "/dashboard/notifications") {
+      return html(
+        200,
+        await renderDashboardNotificationsPage({
+          runtimeOrigin: url.origin,
+          dashboardEventStore: resolveDashboardEventStore(env)
+        })
+      );
+    }
     if (request.method === "GET" && (url.pathname === MCP_PROTECTED_RESOURCE_METADATA_PATH || url.pathname === MCP_PROTECTED_RESOURCE_METADATA_MIRROR_PATH)) {
       return json(200, buildMcpProtectedResourceMetadata(url));
     }
@@ -60120,6 +60147,386 @@ function renderDashboardDeployEvent(event) {
             <p class="muted">${escapeDashboardHtml(updatedAt || "updatedAt \u672A\u53D7\u4FE1")} \u30FB ${runLabel}</p>
           </div>`;
 }
+async function renderDashboardGitHubTruthPage({ url, env } = {}) {
+  const origin = normalize7(url?.origin);
+  const repository = normalizeCanonicalRepositoryInput(url?.searchParams?.get("repository")) || "marushu/vtdd-v2-p";
+  const [issues, pulls, workflowRuns] = await Promise.all([
+    retrieveGitHubReadPlane({
+      resource: "issues",
+      repository,
+      state: "open",
+      limit: 12,
+      env
+    }),
+    retrieveGitHubReadPlane({
+      resource: "pulls",
+      repository,
+      state: "open",
+      limit: 12,
+      env
+    }),
+    retrieveGitHubReadPlane({
+      resource: "workflow_runs",
+      repository,
+      limit: 8,
+      env
+    })
+  ]);
+  const failures = [issues, pulls, workflowRuns].filter((item) => !item.ok);
+  return renderDashboardUtilityPage({
+    title: "GitHub runtime truth",
+    subtitle: repository,
+    backHref: `${origin}/dashboard`,
+    body: `
+      <section class="hero">
+        <p>Butler / Action \u5411\u3051 JSON \u3067\u306F\u306A\u304F\u3001\u4EBA\u9593\u304C\u8AAD\u3080\u305F\u3081\u306E GitHub \u73FE\u5728\u5730\u3067\u3059\u3002</p>
+      </section>
+      ${failures.length > 0 ? renderDashboardNotice("\u4E00\u90E8\u306E GitHub runtime truth \u3092\u8AAD\u3081\u307E\u305B\u3093\u3067\u3057\u305F\u3002GitHub App / token \u8A2D\u5B9A\u3092\u78BA\u8A8D\u3057\u3066\u304F\u3060\u3055\u3044\u3002") : ""}
+      <div class="grid">
+        ${renderGitHubTruthLane("Open Issues", issues, renderIssueTruthCard)}
+        ${renderGitHubTruthLane("Open PRs", pulls, renderPullTruthCard)}
+        ${renderGitHubTruthLane("Workflow Runs", workflowRuns, renderWorkflowRunTruthCard)}
+      </div>
+    `
+  });
+}
+async function renderDashboardPreflightPage({ url, env } = {}) {
+  const origin = normalize7(url?.origin);
+  const repository = normalizeCanonicalRepositoryInput(url?.searchParams?.get("repository")) || "marushu/vtdd-v2-p";
+  const issueNumber = normalizeIssue6(url?.searchParams?.get("issueNumber"));
+  const phase = normalizeText30(url?.searchParams?.get("phase")) || "execution";
+  const currentSurface = normalizeText30(url?.searchParams?.get("currentSurface")) || "dashboard";
+  const startupPreflight = await buildStartupPreflight({
+    repository,
+    ref: normalizeText30(url?.searchParams?.get("ref")) || "main",
+    issueNumber,
+    phase,
+    currentSurface,
+    queryText: "VTDD dashboard startup preflight",
+    runtimeOrigin: origin,
+    env
+  });
+  return renderDashboardUtilityPage({
+    title: "Startup preflight",
+    subtitle: repository,
+    backHref: `${origin}/dashboard`,
+    body: `
+      <section class="hero">
+        <p>Butler \u304C\u6700\u521D\u306B\u8AAD\u3080\u3079\u304D AGENTS / Issue / runtime truth / RAG / self parity \u306E\u73FE\u5728\u5730\u3067\u3059\u3002</p>
+      </section>
+      <div class="grid">
+        <section class="lane">
+          <div class="lane-title"><h2>Source truth</h2><span class="pill">${startupPreflight.sources.length}\u4EF6</span></div>
+          ${startupPreflight.sources.map((source) => renderTruthRow(source.path, source.status, source.reason || source.sha || "")).join("")}
+        </section>
+        <section class="lane">
+          <div class="lane-title"><h2>Open Issues</h2><span class="pill">${startupPreflight.openIssues.length}\u4EF6</span></div>
+          ${startupPreflight.openIssues.length > 0 ? startupPreflight.openIssues.map((issue2) => renderLinkedTruthRow(`#${issue2.number} ${issue2.title}`, issue2.htmlUrl, issue2.state)).join("") : `<p class="muted">\u8A72\u5F53\u306A\u3057</p>`}
+        </section>
+        <section class="lane">
+          <div class="lane-title"><h2>Next safe action</h2><span class="pill">${escapeDashboardHtml(startupPreflight.butlerFirstPrinciple.status)}</span></div>
+          ${renderObjectSummary(startupPreflight.nextSafeAction)}
+        </section>
+      </div>
+    `
+  });
+}
+async function renderDashboardProgressPage({ url, env } = {}) {
+  const origin = normalize7(url?.origin);
+  const repository = normalizeCanonicalRepositoryInput(url?.searchParams?.get("repository")) || "marushu/vtdd-v2-p";
+  const progress = await retrieveRemoteCodexExecutionProgress({
+    executionId: url.searchParams.get("executionId"),
+    repository,
+    issueNumber: url.searchParams.get("issueNumber"),
+    branch: url.searchParams.get("branch"),
+    executorTransport: url.searchParams.get("executorTransport"),
+    env
+  });
+  return renderDashboardUtilityPage({
+    title: "Execution progress",
+    subtitle: repository,
+    backHref: `${origin}/dashboard`,
+    body: `
+      <section class="hero">
+        <p>VPS Codex CLI / remote Codex execution \u306E\u9032\u6357\u3092\u4EBA\u9593\u5411\u3051\u306B\u8868\u793A\u3057\u307E\u3059\u3002\u5165\u529B\u4E2D\u306B\u52DD\u624B\u306A\u81EA\u52D5\u66F4\u65B0\u306F\u3057\u307E\u305B\u3093\u3002</p>
+      </section>
+      ${progress.ok ? renderProgressSummary(progress.progress) : renderDashboardNotice(progress.reason || progress.error || "progress unavailable")}
+    `
+  });
+}
+async function renderDashboardVpsRunnerPage({ url, env } = {}) {
+  const origin = normalize7(url?.origin);
+  const repository = normalizeCanonicalRepositoryInput(url?.searchParams?.get("repository")) || "marushu/vtdd-v2-p";
+  const status = await retrieveVpsRunnerHealthStatus({
+    executionId: url.searchParams.get("executionId"),
+    repository,
+    issueNumber: url.searchParams.get("issueNumber"),
+    branch: url.searchParams.get("branch"),
+    env
+  });
+  return renderDashboardUtilityPage({
+    title: "VPS runner status",
+    subtitle: repository,
+    backHref: `${origin}/dashboard`,
+    body: `
+      <section class="hero">
+        <p>VPS runner \u306E health / queue / progress \u3092\u4EBA\u9593\u5411\u3051\u306B\u8868\u793A\u3057\u307E\u3059\u3002</p>
+      </section>
+      ${status.ok ? `<div class="grid">${renderStatusLane("Health", status.health)}${renderStatusLane("Progress", status.progress)}</div>` : renderDashboardNotice(status.reason || status.error || "runner status unavailable")}
+    `
+  });
+}
+async function renderDashboardMemoryPage({ url, env } = {}) {
+  const origin = normalize7(url?.origin);
+  const repository = normalizeCanonicalRepositoryInput(url?.searchParams?.get("repository")) || "marushu/vtdd-v2-p";
+  const retrieved = await retrieveOperationalMemory(resolveMemoryProvider(env), {
+    text: normalizeText30(url.searchParams.get("text")) || normalizeText30(url.searchParams.get("q")),
+    recordId: normalizeText30(url.searchParams.get("recordId")),
+    repository,
+    limit: normalizeLimit7(url.searchParams.get("limit"), 8),
+    runtimeTruth: buildRetrieveRuntimeTruth(url)
+  });
+  return renderDashboardUtilityPage({
+    title: "Operational RAG",
+    subtitle: repository,
+    backHref: `${origin}/dashboard`,
+    body: `
+      <section class="hero">
+        <p>decision / proposal / working memory \u306E compact retrieval \u3067\u3059\u3002runtime truth \u306E\u4EE3\u66FF\u3067\u306F\u3042\u308A\u307E\u305B\u3093\u3002</p>
+      </section>
+      ${retrieved.ok ? renderMemorySummary(retrieved) : renderDashboardNotice(retrieved.reason || retrieved.error || "memory unavailable")}
+    `
+  });
+}
+async function renderDashboardSelfParityPage({ url, env } = {}) {
+  const origin = normalize7(url?.origin);
+  const repository = normalizeCanonicalRepositoryInput(url?.searchParams?.get("repository")) || "marushu/vtdd-v2-p";
+  const parity = await evaluateButlerSelfParity({
+    repository,
+    ref: normalizeText30(url.searchParams.get("ref")),
+    issueNumber: normalizeIssue6(url.searchParams.get("issueNumber")),
+    pullNumber: normalizeIssue6(url.searchParams.get("pullNumber")),
+    runtimeOrigin: origin,
+    env
+  });
+  return renderDashboardUtilityPage({
+    title: "Self parity",
+    subtitle: repository,
+    backHref: `${origin}/dashboard`,
+    body: `
+      <section class="hero">
+        <p>Action Schema / Instructions / Cloudflare deploy freshness / operator URL \u306E\u81EA\u5DF1\u8A3A\u65AD\u3067\u3059\u3002</p>
+      </section>
+      ${parity.ok ? renderObjectSummary(parity.selfParity) : renderDashboardNotice(parity.reason || parity.error || "self parity unavailable")}
+    `
+  });
+}
+async function renderDashboardNotificationsPage({ runtimeOrigin, dashboardEventStore } = {}) {
+  const origin = normalize7(runtimeOrigin);
+  const latestDeployEvent = await retrieveLatestDashboardEvent({
+    store: dashboardEventStore,
+    kind: "github_actions_workflow_run",
+    repository: "marushu/vtdd-v2-p",
+    workflowName: "deploy-production"
+  });
+  return renderDashboardUtilityPage({
+    title: "\u901A\u77E5\u30BB\u30F3\u30BF\u30FC",
+    subtitle: "dashboard events",
+    backHref: `${origin}/dashboard`,
+    body: `
+      <section class="hero">
+        <p>\u4ECA\u306F iOS Push / \u97F3 / PWA badge \u3067\u306F\u306A\u304F\u3001Worker \u306B\u5C4A\u3044\u305F dashboard event \u306E\u4EBA\u9593\u5411\u3051\u8868\u793A\u3067\u3059\u3002</p>
+        <p class="muted">\u6B21\u306E\u6BB5\u968E\u3067 Web Push \u8CFC\u8AAD\u3001\u901A\u77E5 permission\u3001\u901A\u77E5\u30BF\u30C3\u30D7\u9077\u79FB\u3092\u8FFD\u52A0\u3057\u307E\u3059\u3002</p>
+      </section>
+      <div class="grid single">
+        <section class="lane">
+          <div class="lane-title"><h2>deploy-production</h2><span class="pill">latest</span></div>
+          ${renderDashboardDeployEvent(latestDeployEvent)}
+        </section>
+      </div>
+    `
+  });
+}
+function renderGitHubTruthLane(title, result, renderCard) {
+  if (!result.ok) {
+    return `<section class="lane">
+      <div class="lane-title"><h2>${escapeDashboardHtml(title)}</h2><span class="pill danger">unavailable</span></div>
+      <p>${escapeDashboardHtml(result.reason || result.error || "GitHub read unavailable")}</p>
+    </section>`;
+  }
+  const records = Array.isArray(result.read?.records) ? result.read.records : [];
+  return `<section class="lane">
+    <div class="lane-title"><h2>${escapeDashboardHtml(title)}</h2><span class="pill">${records.length}\u4EF6</span></div>
+    ${records.length > 0 ? records.map(renderCard).join("") : `<p class="muted">\u8A72\u5F53\u306A\u3057</p>`}
+  </section>`;
+}
+function renderIssueTruthCard(issue2) {
+  return `<article class="truth-card">
+    <div class="truth-card-title"><a href="${escapeDashboardHtml(issue2.htmlUrl)}">#${escapeDashboardHtml(issue2.number)} ${escapeDashboardHtml(issue2.title)}</a></div>
+    <p>${escapeDashboardHtml(issue2.author || "unknown")} / ${escapeDashboardHtml(issue2.state || "open")}</p>
+  </article>`;
+}
+function renderPullTruthCard(pull) {
+  const state = pull.draft ? "draft" : pull.state || "open";
+  return `<article class="truth-card">
+    <div class="truth-card-title"><a href="${escapeDashboardHtml(pull.htmlUrl)}">#${escapeDashboardHtml(pull.number)} ${escapeDashboardHtml(pull.title)}</a></div>
+    <p>${escapeDashboardHtml(state)} / ${escapeDashboardHtml(pull.headRef || "head unknown")} -> ${escapeDashboardHtml(pull.baseRef || "base unknown")}</p>
+  </article>`;
+}
+function renderWorkflowRunTruthCard(run) {
+  const conclusion = run.conclusion || run.status || "unknown";
+  const badgeClass = conclusion === "success" ? "success" : conclusion === "failure" ? "danger" : "";
+  return `<article class="truth-card">
+    <div class="truth-card-title"><a href="${escapeDashboardHtml(run.htmlUrl)}">${escapeDashboardHtml(run.name || `run ${run.id}`)}</a></div>
+    <p><span class="pill ${badgeClass}">${escapeDashboardHtml(conclusion)}</span> ${escapeDashboardHtml(run.headBranch || "")}</p>
+  </article>`;
+}
+function renderDashboardNotice(message) {
+  return `<section class="notice">${escapeDashboardHtml(message)}</section>`;
+}
+function renderTruthRow(label, value, detail = "") {
+  return `<article class="truth-card">
+    <div class="truth-card-title"><strong>${escapeDashboardHtml(label)}</strong><span class="pill">${escapeDashboardHtml(value || "\u672A\u78BA\u8A8D")}</span></div>
+    ${detail ? `<p>${escapeDashboardHtml(detail)}</p>` : ""}
+  </article>`;
+}
+function renderLinkedTruthRow(label, href, detail = "") {
+  return `<article class="truth-card">
+    <div class="truth-card-title"><a href="${escapeDashboardHtml(href || "#")}">${escapeDashboardHtml(label)}</a></div>
+    ${detail ? `<p>${escapeDashboardHtml(detail)}</p>` : ""}
+  </article>`;
+}
+function renderProgressSummary(progress) {
+  return `<div class="grid single">
+    <section class="lane">
+      <div class="lane-title"><h2>Progress</h2><span class="pill">${escapeDashboardHtml(progress?.status || "\u672A\u78BA\u8A8D")}</span></div>
+      ${renderObjectSummary(progress)}
+    </section>
+  </div>`;
+}
+function renderStatusLane(title, value) {
+  return `<section class="lane">
+    <div class="lane-title"><h2>${escapeDashboardHtml(title)}</h2><span class="pill">summary</span></div>
+    ${renderObjectSummary(value)}
+  </section>`;
+}
+function renderMemorySummary(retrieved) {
+  const references = retrieved.referencesByLayer && typeof retrieved.referencesByLayer === "object" ? Object.entries(retrieved.referencesByLayer) : [];
+  return `<div class="grid">
+    <section class="lane">
+      <div class="lane-title"><h2>Compact context</h2><span class="pill">${escapeDashboardHtml(retrieved.architecture || "memory")}</span></div>
+      <p>${escapeDashboardHtml(retrieved.compactContext || "\u8A72\u5F53\u306A\u3057")}</p>
+    </section>
+    <section class="lane">
+      <div class="lane-title"><h2>References</h2><span class="pill">${references.length} layers</span></div>
+      ${references.length > 0 ? references.map(([layer, records]) => renderTruthRow(layer, Array.isArray(records) ? `${records.length}\u4EF6` : "\u672A\u78BA\u8A8D")).join("") : `<p class="muted">\u8A72\u5F53\u306A\u3057</p>`}
+    </section>
+    <section class="lane">
+      <div class="lane-title"><h2>Signals</h2><span class="pill">retrieval</span></div>
+      ${renderObjectSummary(retrieved.retrievalSignals)}
+    </section>
+  </div>`;
+}
+function renderObjectSummary(value, depth = 0) {
+  if (value === null || value === void 0 || value === "") {
+    return `<p class="muted">\u672A\u78BA\u8A8D</p>`;
+  }
+  if (typeof value !== "object") {
+    return `<p>${escapeDashboardHtml(String(value))}</p>`;
+  }
+  if (Array.isArray(value)) {
+    if (value.length === 0) {
+      return `<p class="muted">\u8A72\u5F53\u306A\u3057</p>`;
+    }
+    return value.slice(0, 8).map((item, index) => renderTruthRow(`#${index + 1}`, summarizeObjectValue(item))).join("");
+  }
+  const entries = Object.entries(value).filter(([, item]) => item !== void 0 && typeof item !== "function");
+  if (entries.length === 0) {
+    return `<p class="muted">\u8A72\u5F53\u306A\u3057</p>`;
+  }
+  return `<dl class="summary-list">
+    ${entries.slice(0, 16).map(([key, item]) => `
+      <div>
+        <dt>${escapeDashboardHtml(key)}</dt>
+        <dd>${depth < 1 && item && typeof item === "object" ? renderObjectSummary(item, depth + 1) : escapeDashboardHtml(summarizeObjectValue(item))}</dd>
+      </div>
+    `).join("")}
+  </dl>`;
+}
+function summarizeObjectValue(value) {
+  if (value === null || value === void 0 || value === "") {
+    return "\u672A\u78BA\u8A8D";
+  }
+  if (Array.isArray(value)) {
+    return `${value.length}\u4EF6`;
+  }
+  if (typeof value === "object") {
+    const title = value.title || value.name || value.status || value.state || value.id || value.number;
+    return title ? String(title) : `${Object.keys(value).length} fields`;
+  }
+  return String(value);
+}
+function renderDashboardUtilityPage({ title, subtitle, backHref, body }) {
+  return `<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>${escapeDashboardHtml(title)} - VTDD Butler</title>
+  <style>
+    :root { color-scheme: light dark; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; --bg: #f7f7f4; --panel: #fff; --text: #151515; --muted: #62625d; --border: #deded6; --soft: #f0f0eb; }
+    @media (prefers-color-scheme: dark) { :root { --bg: #050505; --panel: #101010; --text: #f7f7f4; --muted: #a0a09a; --border: #2b2b2b; --soft: #1b1b1b; } }
+    * { box-sizing: border-box; }
+    html, body { max-width: 100%; overflow-x: hidden; }
+    body { margin: 0; background: var(--bg); color: var(--text); }
+    main { width: min(1120px, 100%); margin: 0 auto; padding: 16px; }
+    header { display: flex; justify-content: space-between; align-items: center; gap: 12px; margin-bottom: 18px; }
+    h1 { font-size: 24px; margin: 0 0 4px; }
+    h2 { font-size: 18px; margin: 0; }
+    p { line-height: 1.6; margin: 0 0 10px; }
+    a { color: inherit; text-underline-offset: 4px; }
+    .back, .actions a { display: inline-flex; min-height: 38px; align-items: center; justify-content: center; border: 1px solid var(--border); border-radius: 999px; padding: 6px 12px; background: var(--soft); text-decoration: none; font-weight: 750; }
+    .hero, .lane, .notice { border: 1px solid var(--border); border-radius: 16px; background: var(--panel); padding: 14px; margin-bottom: 14px; }
+    .actions { display: flex; flex-wrap: wrap; gap: 8px; }
+    .grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 14px; }
+    .grid.single { grid-template-columns: minmax(0, 1fr); }
+    .lane-title, .truth-card-title { display: flex; justify-content: space-between; align-items: baseline; gap: 8px; }
+    .truth-card { border-top: 1px solid var(--border); padding: 11px 0; }
+    .truth-card:first-of-type { border-top: 0; }
+    .truth-card p, .muted { color: var(--muted); }
+    .summary-list { margin: 0; display: grid; gap: 8px; }
+    .summary-list div { display: grid; grid-template-columns: minmax(96px, 0.4fr) minmax(0, 1fr); gap: 10px; padding: 8px 0; border-top: 1px solid var(--border); }
+    .summary-list div:first-child { border-top: 0; }
+    .summary-list dt { color: var(--muted); font-size: 13px; }
+    .summary-list dd { margin: 0; overflow-wrap: anywhere; }
+    .pill { display: inline-flex; border: 1px solid var(--border); border-radius: 999px; padding: 3px 8px; background: var(--soft); font-size: 12px; white-space: nowrap; }
+    .pill.success { border-color: #7fb797; background: #e7f5ec; color: #145c34; }
+    .pill.danger { border-color: #d69b9b; background: #fff0f0; color: #8a1f1f; }
+    .deploy-event { border: 1px solid var(--border); border-radius: 12px; padding: 10px; margin: 10px 0; background: var(--soft); }
+    .deploy-event p { margin-bottom: 6px; font-size: 13px; }
+    code { overflow-wrap: anywhere; }
+    @media (max-width: 760px) {
+      main { padding: 12px; }
+      header { align-items: flex-start; }
+      .grid { grid-template-columns: minmax(0, 1fr); }
+      .summary-list div { grid-template-columns: minmax(0, 1fr); }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <header>
+      <div>
+        <h1>${escapeDashboardHtml(title)}</h1>
+        <p class="muted">${escapeDashboardHtml(subtitle || "")}</p>
+      </div>
+      <a class="back" href="${escapeDashboardHtml(backHref || "/dashboard")}">Dashboard</a>
+    </header>
+    ${body}
+  </main>
+</body>
+</html>`;
+}
 function normalizeTextList2(value) {
   if (Array.isArray(value)) {
     return value.map(normalizeText30).filter(Boolean);
@@ -60143,38 +60550,43 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
   const surfaces = [
     {
       title: "Status page",
-      body: "\u4EBA\u9593\u5411\u3051\u306E runtime status\u3002raw /health JSON \u3067\u306F\u306A\u304F\u3001\u307E\u305A\u3053\u3053\u3092\u898B\u308B\u3002",
+      body: "\u4EBA\u9593\u5411\u3051\u306E runtime status\u3002\u307E\u305A\u3053\u3053\u3092\u898B\u308B\u3002",
       href: `${origin}/status`
     },
     {
       title: "Startup preflight",
       body: "AGENTS.md\u3001thread-independent startup\u3001runtime truth\u3001RAG\u3001self parity \u3092\u6700\u521D\u306B\u8AAD\u3080\u5165\u53E3\u3002",
-      href: `${origin}/v2/retrieve/startup-preflight?repository=${encodedRepository}&currentSurface=dashboard&responseMode=action_visible`
+      href: `${origin}/dashboard/preflight?repository=${encodedRepository}`
     },
     {
       title: "Execution progress",
       body: "VPS Codex CLI / remote Codex execution \u306E\u9032\u6357\u78BA\u8A8D\u3002",
-      href: `${origin}/v2/action/progress?repository=${encodedRepository}&responseMode=action_visible`
+      href: `${origin}/dashboard/progress?repository=${encodedRepository}`
     },
     {
       title: "VPS runner status",
       body: "runner health\u3001queue\u3001\u5BFE\u8C61 execution \u306E\u72B6\u614B\u78BA\u8A8D\u3002",
-      href: `${origin}/v2/action/vps-runner-status?repository=${encodedRepository}&responseMode=action_visible`
+      href: `${origin}/dashboard/vps-runner?repository=${encodedRepository}`
     },
     {
       title: "GitHub runtime truth",
       body: "Issues\u3001PRs\u3001checks\u3001workflow runs\u3001reviewer comments \u3092\u8AAD\u3080\u5165\u53E3\u3002",
-      href: `${origin}/v2/retrieve/github?repository=${encodedRepository}&include=open_prs,open_issues,workflow_runs,issue_comments&responseMode=action_visible`
+      href: `${origin}/dashboard/github?repository=${encodedRepository}`
+    },
+    {
+      title: "\u901A\u77E5\u30BB\u30F3\u30BF\u30FC",
+      body: "GitHub Actions / deploy \u304B\u3089 Worker \u306B\u5C4A\u3044\u305F dashboard event \u3092\u4EBA\u9593\u5411\u3051\u306B\u898B\u308B\u5165\u53E3\u3002",
+      href: `${origin}/dashboard/notifications`
     },
     {
       title: "Operational RAG",
       body: "decision / proposal / working memory \u306E compact retrieval\u3002runtime truth \u306E\u4EE3\u66FF\u3067\u306F\u306A\u3044\u3002",
-      href: `${origin}/v2/retrieve/operational-memory?repository=${encodedRepository}&limit=5&responseMode=action_visible`
+      href: `${origin}/dashboard/memory?repository=${encodedRepository}`
     },
     {
       title: "Self parity",
       body: "Action Schema\u3001Instructions\u3001Cloudflare deploy freshness\u3001operator URL \u3092\u78BA\u8A8D\u3002",
-      href: `${origin}/v2/retrieve/self-parity?repository=${encodedRepository}&responseMode=action_visible`
+      href: `${origin}/dashboard/self-parity?repository=${encodedRepository}`
     },
     {
       title: "Setup diagnostics",
@@ -60196,15 +60608,19 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
   const cockpitActions = [
     {
       label: "\u72B6\u614B\u78BA\u8A8D",
-      href: `${origin}/v2/retrieve/github?repository=${encodedRepository}&include=open_prs,open_issues,workflow_runs,issue_comments&responseMode=action_visible`
+      href: `${origin}/dashboard/github?repository=${encodedRepository}`
     },
     {
       label: "\u9032\u6357\u3092\u898B\u308B",
-      href: `${origin}/v2/action/progress?repository=${encodedRepository}&responseMode=action_visible`
+      href: `${origin}/dashboard/progress?repository=${encodedRepository}`
     },
     {
       label: "RAG \u3092\u8AAD\u3080",
-      href: `${origin}/v2/retrieve/operational-memory?repository=${encodedRepository}&limit=5&responseMode=action_visible`
+      href: `${origin}/dashboard/memory?repository=${encodedRepository}`
+    },
+    {
+      label: "\u901A\u77E5",
+      href: `${origin}/dashboard/notifications`
     },
     {
       label: "Passkey",
@@ -60493,8 +60909,7 @@ function renderV2StatusPage({ runtimeOrigin, autonomyMode }) {
     ["Mode", mode, "\u73FE\u5728\u306E runtime mode \u3067\u3059\u3002"],
     ["Autonomy", resolvedAutonomyMode, "guarded absence \u306A\u3069\u306E\u5B9F\u884C\u6291\u5236\u72B6\u614B\u3092\u793A\u3057\u307E\u3059\u3002"],
     ["Dashboard", "\u5229\u7528\u53EF\u80FD", "/dashboard \u3068 /orchestrator \u306F\u4EBA\u9593\u5411\u3051\u5165\u53E3\u3067\u3059\u3002"],
-    ["Passkey", "same-origin", "\u9AD8\u30EA\u30B9\u30AF\u64CD\u4F5C\u306F scope \u660E\u793A\u6E08\u307F passkey approval \u306E\u5F8C\u308D\u3067\u3059\u3002"],
-    ["Raw health", "JSON", "/health \u306F API \u4E92\u63DB\u306E machine-readable endpoint \u3068\u3057\u3066\u6B8B\u3057\u307E\u3059\u3002"]
+    ["Passkey", "same-origin", "\u9AD8\u30EA\u30B9\u30AF\u64CD\u4F5C\u306F scope \u660E\u793A\u6E08\u307F passkey approval \u306E\u5F8C\u308D\u3067\u3059\u3002"]
   ];
   return `<!doctype html>
 <html lang="ja">
@@ -60530,7 +60945,7 @@ function renderV2StatusPage({ runtimeOrigin, autonomyMode }) {
       <div>
         <p class="eyebrow">VTDD v2 status</p>
         <h1>Runtime Status</h1>
-        <p>\u30D6\u30E9\u30A6\u30B6\u3067\u898B\u308B\u305F\u3081\u306E health summary \u3067\u3059\u3002\u6A5F\u68B0\u5411\u3051 JSON \u306F <code>/health</code> \u306B\u6B8B\u3057\u3066\u3044\u307E\u3059\u3002</p>
+        <p>\u30D6\u30E9\u30A6\u30B6\u3067\u898B\u308B\u305F\u3081\u306E health summary \u3067\u3059\u3002</p>
       </div>
       <a class="button" href="${escapeDashboardHtml(origin)}/dashboard">Dashboard</a>
     </header>
@@ -60541,7 +60956,6 @@ function renderV2StatusPage({ runtimeOrigin, autonomyMode }) {
       <p>Worker \u306F\u5FDC\u7B54\u3057\u3066\u3044\u307E\u3059\u3002\u3053\u3053\u3067\u306F secret\u3001token\u3001approval grant \u306F\u8868\u793A\u3057\u307E\u305B\u3093\u3002</p>
       <div class="actions">
         <a class="primary" href="${escapeDashboardHtml(origin)}/dashboard">Butler dashboard</a>
-        <a href="${escapeDashboardHtml(origin)}/health">raw /health JSON</a>
         <a href="${escapeDashboardHtml(origin)}/v2/approval/passkey/operator?repositoryInput=marushu%2Fvtdd-v2-p">Passkey operator</a>
       </div>
     </section>


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #433 の継続スライスです。ダッシュボードの人間向けメニューが raw JSON / Action JSON に直行せず、HTML の runtime truth / progress / runner / RAG / self parity / notification 画面へ遷移するようにします。

## Satisfied Success Criteria

- ダッシュボードの主要メニューを /dashboard/github, /dashboard/preflight, /dashboard/progress, /dashboard/vps-runner, /dashboard/memory, /dashboard/self-parity, /dashboard/notifications の HTML ページへ統一。
- /status から raw /health JSON リンクを削除。
- 人間向けダッシュボード内に raw JSON 文言と responseMode=action_visible 直行リンクが残らないことをテストで固定。
- 通知は iOS Push ではなく、Worker が受け取った dashboard event を見る通知センターとして実装。

## Unsatisfied Success Criteria

- 本番 Cloudflare への deploy と iPhone 実機 E2E はこのPR時点では未実施。
- iOS Push / 音 / PWA badge / 通知タップ遷移は未実装で、別 Issue スライスが必要。
- Dashboard Butler の本格チャット応答、LLM連携、ファイルアップロードは未実装。

## Non-goal violations

iOS Push / Web Push / PWA badge / 音通知は実装しない。Action Schema と Custom GPT Instructions は変更しない。GitHub App 権限、secret、deploy authority は変更しない。

## Dry-run Impact Report

- Target Issue: Issue #433
- Implementing Success Criteria: ダッシュボードの人間向けメニューが JSON 画面へ直行しない。通知の入口が人間向けに存在する。入力中に自動更新しない。
- Explicit Non-goals: Push通知、音通知、PWA badge、LLMチャット、ファイルアップロード、deploy、credential mutation は対象外。
- Expected touched files/routes/workflows: src/worker/runtime.js, test/worker.test.js, worker.js
- Affected Issues: #433。通知の本格化は後続 Issue 候補。
- Affected PRs: なし。
- Affected workflows: deploy-production は表示対象のみ。workflow 定義は変更しない。
- Affected runtime/operator surfaces: Cloudflare Worker dashboard / status / dashboard utility pages。Custom GPT Action surface は変更しない。
- What may break if we patch narrowly: ユーザーが指摘した URL だけ直すと、他メニューから JSON 直行が残るため、全メニューを棚卸しして HTML route に統一した。
- Unknowns to investigate before coding: 本番 D1/KV の dashboard event store 内容と iPhone 実機表示は deploy 後に runtime truth で確認が必要。
- Validation needed: node --test test/worker.test.js, npm test, deploy 後の /dashboard と各 /dashboard/* の iPhone E2E。
- Stop condition: 人間向けメニューから JSON に直行するリンクが残る、または高リスク操作 URL を常時露出する場合は停止。

## File / Line Hypotheses

- file: src/worker/runtime.js
  - hypothesis: renderV2DashboardPage の surfaces / cockpitActions が JSON 直行の主因。
  - risk if changed narrowly: 指摘 URL だけ直して他メニューに JSON 直行が残る。
  - validation: rg と worker.test で dashboard メニューの /dashboard/* 統一を確認。
  - related Issue: #433
- file: test/worker.test.js
  - hypothesis: dashboard HTML のリンク契約をテスト化しないと再発する。
  - risk if changed narrowly: UI変更時に raw JSON リンクが戻る。
  - validation: human-facing dashboard pages for every management menu テストを追加。
  - related Issue: #433

## Hypothesis Retrospective

- expected: 指摘 URL 以外にも JSON 直行リンクが残っている。
- actual: Startup preflight / progress / VPS runner / Operational RAG / Self parity に残っていた。
- mismatch: 初回実装は GitHub truth と notifications に寄りすぎていた。
- lesson: dashboard メニューは個別 URL ではなく一覧棚卸しで直す。
- should become RAG candidate: はい。

## Verification Evidence

- Unit: node --test test/worker.test.js PASS: 129 tests
- Integration: npm test PASS: 835 pass / 1 skipped, check:self-parity PASS, check:generated-worker PASS
- E2E: 未実施。本番 deploy 後に /dashboard, /status, /dashboard/github, /dashboard/preflight, /dashboard/progress, /dashboard/vps-runner, /dashboard/memory, /dashboard/self-parity, /dashboard/notifications を iPhone で確認する。
- Manual: rg で src/worker/runtime.js の dashboard から raw JSON / responseMode=action_visible 直行リンクが消えたことを確認。
- Evidence path/link: local test output in this PR run; deploy E2E pending

## Butler Completion Contract

- Owner goal: iPhone でダッシュボードを触った時に JSON 画面へ飛ばされず、状態・進捗・通知を人間向け画面で読める。
- Butler entrypoint: /dashboard, /orchestrator, /status, /dashboard/*
- Action Schema exposure: 変更なし。raw API は Butler / Action / Codex 向けに残し、人間向け UI からは露出しない。
- Runtime path: GET /dashboard/github, /dashboard/preflight, /dashboard/progress, /dashboard/vps-runner, /dashboard/memory, /dashboard/self-parity, /dashboard/notifications, /status
- Runner/runtime truth: ローカル Worker tests で HTML content-type と raw JSON 非露出を確認。本番 runtime truth は deploy 後。
- Authority boundary: 変更なし。閲覧系は read-only。deploy / credential mutation / permission mutation は引き続き GO + passkey。
- E2E evidence: 未完了。本番 deploy 後に iPhone Butler dashboard E2E が必要。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 未実施。merge 後に GO + passkey で必要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。deploy 後に必要。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate。Conversation UX Contract。Evidence Discipline。Authority Boundary。

## Out-of-scope but NOT implemented

- 本格 Push 通知、音、PWA badge、Dashboard Butler の LLM 応答、ファイルアップロード、Gmail 接続。

## Extra changes (if any)

なし。

<!-- VTDD metadata -->
- Issue: Issue #433
- Execution ID: Not provided.
- Goal: Not provided.
