### PR TITLE
fix: 通知センターに相対時刻を表示する

### DIFF
--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -5212,6 +5212,7 @@ function renderDashboardDeployEvent(event) {
   const conclusion = normalizeText(event.conclusion) || normalizeText(event.status) || "unknown";
   const badgeClass = conclusion === "success" ? "success" : conclusion === "failure" || conclusion === "cancelled" ? "danger" : "";
   const updatedAt = normalizeText(event.updatedAt);
+  const relativeUpdatedAt = formatDashboardRelativeTime(updatedAt);
   const sha = normalizeText(event.headSha);
   const shortSha = sha ? sha.slice(0, 7) : "unknown";
   const runUrl = normalizeText(event.runUrl);
@@ -5219,8 +5220,38 @@ function renderDashboardDeployEvent(event) {
   return `<div class="deploy-event">
             <div class="lane-title"><strong>最新 deploy</strong><span class="pill ${badgeClass}">${escapeDashboardHtml(conclusion)}</span></div>
             <p>${escapeDashboardHtml(event.workflowName || "deploy-production")} / <code>${escapeDashboardHtml(shortSha)}</code></p>
-            <p class="muted">${escapeDashboardHtml(updatedAt || "updatedAt 未受信")} ・ ${runLabel}</p>
+            <p class="muted">${escapeDashboardHtml(relativeUpdatedAt || "時刻未受信")} ・ ${escapeDashboardHtml(updatedAt || "updatedAt 未受信")} ・ ${runLabel}</p>
           </div>`;
+}
+
+function formatDashboardRelativeTime(value, now = new Date()) {
+  const timestamp = new Date(normalizeText(value));
+  const nowTime = now instanceof Date ? now.getTime() : new Date(now).getTime();
+  if (Number.isNaN(timestamp.getTime()) || Number.isNaN(nowTime)) {
+    return "";
+  }
+  const diffMs = Math.max(0, nowTime - timestamp.getTime());
+  const seconds = Math.floor(diffMs / 1000);
+  if (seconds < 60) {
+    return "たった今";
+  }
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) {
+    return `${minutes}分前`;
+  }
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) {
+    return `${hours}時間前`;
+  }
+  const days = Math.floor(hours / 24);
+  if (days < 30) {
+    return `${days}日前`;
+  }
+  const months = Math.floor(days / 30);
+  if (months < 12) {
+    return `${months}か月前`;
+  }
+  return `${Math.floor(months / 12)}年前`;
 }
 
 async function renderDashboardGitHubTruthPage({ url, env } = {}) {

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -331,6 +331,7 @@ test("worker serves human-facing dashboard pages for every management menu", asy
 
 test("worker serves dashboard notification center for latest deploy event", async () => {
   const store = createInMemoryDashboardEventStore();
+  const fiveMinutesAgo = new Date(Date.now() - 5 * 60 * 1000).toISOString();
   await store.put({
     id: "github_actions_workflow_run:marushu/vtdd-v2-p:deploy-production:26134526815",
     kind: "github_actions_workflow_run",
@@ -343,7 +344,7 @@ test("worker serves dashboard notification center for latest deploy event", asyn
     headSha: "daad4fb023cf699b3ad531e0394e064fde2b5515",
     headBranch: "main",
     title: "deploy-production",
-    updatedAt: "2026-05-20T00:54:27Z"
+    updatedAt: fiveMinutesAgo
   });
 
   const response = await worker.fetch(new Request("https://example.com/dashboard/notifications"), {
@@ -357,6 +358,8 @@ test("worker serves dashboard notification center for latest deploy event", asyn
   assert.equal(body.includes("最新 deploy"), true);
   assert.equal(body.includes("success"), true);
   assert.equal(body.includes("26134526815"), true);
+  assert.equal(body.includes("5分前"), true);
+  assert.equal(body.includes(fiveMinutesAgo), true);
 });
 
 test("worker ingests GitHub Actions deploy completion event and shows it on dashboard", async () => {

--- a/worker.js
+++ b/worker.js
@@ -60137,6 +60137,7 @@ function renderDashboardDeployEvent(event) {
   const conclusion = normalizeText30(event.conclusion) || normalizeText30(event.status) || "unknown";
   const badgeClass = conclusion === "success" ? "success" : conclusion === "failure" || conclusion === "cancelled" ? "danger" : "";
   const updatedAt = normalizeText30(event.updatedAt);
+  const relativeUpdatedAt = formatDashboardRelativeTime(updatedAt);
   const sha = normalizeText30(event.headSha);
   const shortSha = sha ? sha.slice(0, 7) : "unknown";
   const runUrl = normalizeText30(event.runUrl);
@@ -60144,8 +60145,37 @@ function renderDashboardDeployEvent(event) {
   return `<div class="deploy-event">
             <div class="lane-title"><strong>\u6700\u65B0 deploy</strong><span class="pill ${badgeClass}">${escapeDashboardHtml(conclusion)}</span></div>
             <p>${escapeDashboardHtml(event.workflowName || "deploy-production")} / <code>${escapeDashboardHtml(shortSha)}</code></p>
-            <p class="muted">${escapeDashboardHtml(updatedAt || "updatedAt \u672A\u53D7\u4FE1")} \u30FB ${runLabel}</p>
+            <p class="muted">${escapeDashboardHtml(relativeUpdatedAt || "\u6642\u523B\u672A\u53D7\u4FE1")} \u30FB ${escapeDashboardHtml(updatedAt || "updatedAt \u672A\u53D7\u4FE1")} \u30FB ${runLabel}</p>
           </div>`;
+}
+function formatDashboardRelativeTime(value, now = /* @__PURE__ */ new Date()) {
+  const timestamp = new Date(normalizeText30(value));
+  const nowTime = now instanceof Date ? now.getTime() : new Date(now).getTime();
+  if (Number.isNaN(timestamp.getTime()) || Number.isNaN(nowTime)) {
+    return "";
+  }
+  const diffMs = Math.max(0, nowTime - timestamp.getTime());
+  const seconds = Math.floor(diffMs / 1e3);
+  if (seconds < 60) {
+    return "\u305F\u3063\u305F\u4ECA";
+  }
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) {
+    return `${minutes}\u5206\u524D`;
+  }
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) {
+    return `${hours}\u6642\u9593\u524D`;
+  }
+  const days = Math.floor(hours / 24);
+  if (days < 30) {
+    return `${days}\u65E5\u524D`;
+  }
+  const months = Math.floor(days / 30);
+  if (months < 12) {
+    return `${months}\u304B\u6708\u524D`;
+  }
+  return `${Math.floor(months / 12)}\u5E74\u524D`;
 }
 async function renderDashboardGitHubTruthPage({ url, env } = {}) {
   const origin = normalize7(url?.origin);


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #444 の初回スライスです。通知センターの最新 deploy event に absolute timestamp だけでなく「◯分前 / ◯時間前」の相対時刻を表示し、iPhone で見た時にいつの通知かをすぐ判断できるようにします。

## Satisfied Success Criteria

- 通知センターの deploy event 表示に「たった今 / ◯分前 / ◯時間前 / ◯日前 / ◯か月前 / ◯年前」の相対時刻を追加。
- absolute timestamp は証跡として引き続き表示。
- worker test で「5分前」と absolute timestamp が同時に表示されることを固定。

## Unsatisfied Success Criteria

- iOS PWA Web Push、音通知、通知バナー、notificationclick、Badging API は未実装。
- 通知 permission UI、Service Worker 登録状態表示、push subscription 保存、VAPID / push 送信 path は未実装。
- iPhone 実機 E2E は deploy 後に未実施。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #444
- Implementing Success Criteria: 通知センターの各イベントに absolute timestamp だけでなく「◯分前 / ◯時間前」相対時刻が表示される。
- Explicit Non-goals: Web Push 本体、音、PWA badge、Service Worker 購読、VAPID、push subscription 保存、通知タップ遷移は対象外。
- Expected touched files/routes/workflows: src/worker/runtime.js, test/worker.test.js, worker.js
- Affected Issues: Issue #444, Issue #433
- Affected PRs: なし。
- Affected workflows: なし。deploy-production から受けた dashboard event の表示だけを変更する。
- Affected runtime/operator surfaces: GET /dashboard/notifications, /dashboard 内の最新 deploy event 表示。
- What may break if we patch narrowly: Date 表示だけを消すと証跡性が落ちるため、相対時刻と absolute timestamp を併記する。
- Unknowns to investigate before coding: iOS PWA Push 本体は後続で Apple / MDN 標準と保存先を確認して実装する。
- Validation needed: node --test test/worker.test.js, npm test, deploy 後の通知センター表示確認。
- Stop condition: timestamp が欠損した event で表示が壊れる、または通知に secret / approvalGrantId が露出する場合は停止。

## File / Line Hypotheses

- file: src/worker/runtime.js
  - hypothesis: renderDashboardDeployEvent が通知センターと dashboard の deploy event 表示を組み立てている。
  - risk if changed narrowly: absolute timestamp を消すと runtime truth 証跡が弱くなる。
  - validation: test/worker.test.js で相対時刻と absolute timestamp の併記を確認。
  - related Issue: #444
- file: test/worker.test.js
  - hypothesis: 通知センター test に相対時刻の期待値を追加すれば再発を防げる。
  - risk if changed narrowly: 今後 UI 修正で「◯分前」が消える。
  - validation: dashboard notification center test が 5分前 を検証。
  - related Issue: #444

## Hypothesis Retrospective

- expected: 通知センターは absolute timestamp だけでは iPhone 上で直感的に分かりにくい。
- actual: renderDashboardDeployEvent に相対時刻 formatter を足すだけで低リスクに改善できた。
- mismatch: iOS Push / 音 / badge は同じPRに混ぜるには authority と保存先の未確定が大きい。
- lesson: 通知 UX は表示改善と Push 基盤を分ける。
- should become RAG candidate: はい。

## Verification Evidence

- Unit: node --test test/worker.test.js PASS: 129 tests
- Integration: npm test PASS: 835 pass / 1 skipped, check:self-parity PASS, check:generated-worker PASS
- E2E: 未実施。merge + deploy 後に /dashboard/notifications で「◯分前」表示を確認する。
- Manual: 変更 diff を確認。通知 event は相対時刻と absolute timestamp を併記する。
- Evidence path/link: local test output in this PR run; deploy E2E pending

## Butler Completion Contract

- Owner goal: iPhone の通知センターで、通知がいつ来たものかを「◯分前」で即判断できる。
- Butler entrypoint: /dashboard/notifications, /dashboard
- Action Schema exposure: 変更なし。
- Runtime path: GET /dashboard/notifications の deploy event 表示。
- Runner/runtime truth: dashboard event の updatedAt を元に相対時刻を算出し、absolute timestamp も保持。
- Authority boundary: read-only 表示変更のみ。Push / badge / permission / deploy はこのPRでは実行しない。
- E2E evidence: 未完了。本番 deploy 後に iPhone 表示確認が必要。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 未実施。merge 後に GO + passkey で必要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。deploy 後に必要。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate。
- Conversation UX Contract。
- Evidence Discipline。
- Authority Boundary。

## Out-of-scope but NOT implemented

- iOS Web Push、音、通知バナー、PWA badge、Service Worker push handling、VAPID、push subscription 保存。

## Extra changes (if any)

- Issue #444 を作成し、PWA通知・音・バッジの本体スコープを分離した。

<!-- VTDD metadata -->
- Issue: Issue #444
- Execution ID: Not provided.
- Goal: notification relative time first slice
