### PR TITLE
fix: 通知センターを直近イベント横断表示にする

### DIFF
--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -4603,9 +4603,9 @@ function createD1DashboardEventStore(d1) {
 
     async latest(filter = {}) {
       await ensureSchema();
-      const kind = normalizeText(filter.kind);
+      const kind = normalizeDashboardEventText(filter.kind);
       const repository = normalizeCanonicalRepositoryInput(filter.repository);
-      const workflowName = normalizeText(filter.workflowName);
+      const workflowName = normalizeDashboardEventText(filter.workflowName);
       const clauses = [];
       const params = [];
       if (kind) {
@@ -4636,6 +4636,49 @@ function createD1DashboardEventStore(d1) {
       } catch {
         return null;
       }
+    },
+
+    async listRecent(filter = {}) {
+      await ensureSchema();
+      const kind = normalizeDashboardEventText(filter.kind);
+      const repository = normalizeCanonicalRepositoryInput(filter.repository);
+      const workflowName = normalizeDashboardEventText(filter.workflowName);
+      const since = normalizeIsoTimestamp(filter.since);
+      const limit = normalizeLimit(filter.limit, 20);
+      const clauses = [];
+      const params = [];
+      if (kind) {
+        clauses.push("kind = ?");
+        params.push(kind);
+      }
+      if (repository) {
+        clauses.push("repository = ?");
+        params.push(repository);
+      }
+      if (workflowName) {
+        clauses.push("workflow_name = ?");
+        params.push(workflowName);
+      }
+      if (since) {
+        clauses.push("updated_at >= ?");
+        params.push(since);
+      }
+      const where = clauses.length > 0 ? `WHERE ${clauses.join(" AND ")}` : "";
+      const result = await d1
+        .prepare(
+          `SELECT payload_json FROM vtdd_dashboard_events ${where} ORDER BY updated_at DESC, created_at DESC LIMIT ?`
+        )
+        .bind(...params, limit)
+        .all();
+      return (Array.isArray(result?.results) ? result.results : [])
+        .map((row) => {
+          try {
+            return row?.payload_json ? normalizeDashboardEventRecord(JSON.parse(row.payload_json)) : null;
+          } catch {
+            return null;
+          }
+        })
+        .filter(Boolean);
     }
   };
 
@@ -4648,6 +4691,9 @@ function createD1DashboardEventStore(d1) {
         await d1.exec(
           "CREATE INDEX IF NOT EXISTS idx_vtdd_dashboard_events_lookup ON vtdd_dashboard_events (kind, repository, workflow_name, updated_at DESC);"
         );
+        await d1.exec(
+          "CREATE INDEX IF NOT EXISTS idx_vtdd_dashboard_events_recent ON vtdd_dashboard_events (updated_at DESC, created_at DESC);"
+        );
       })();
     }
     return schemaPromise;
@@ -4659,20 +4705,24 @@ function normalizeDashboardEventRecord(event) {
   const updatedAt = normalizeIsoTimestamp(input.updatedAt) || new Date().toISOString();
   const createdAt = normalizeIsoTimestamp(input.createdAt) || updatedAt;
   return {
-    id: normalizeText(input.id),
-    kind: normalizeText(input.kind),
+    id: normalizeDashboardEventText(input.id),
+    kind: normalizeDashboardEventText(input.kind),
     repository: normalizeCanonicalRepositoryInput(input.repository),
-    workflowName: normalizeText(input.workflowName),
-    runId: normalizeText(input.runId),
-    status: normalizeText(input.status),
-    conclusion: normalizeText(input.conclusion) || null,
-    headSha: normalizeText(input.headSha) || null,
-    headBranch: normalizeText(input.headBranch) || null,
-    runUrl: normalizeText(input.runUrl) || null,
-    title: normalizeText(input.title) || normalizeText(input.workflowName),
+    workflowName: normalizeDashboardEventText(input.workflowName),
+    runId: normalizeDashboardEventText(input.runId),
+    status: normalizeDashboardEventText(input.status),
+    conclusion: normalizeDashboardEventText(input.conclusion) || null,
+    headSha: normalizeDashboardEventText(input.headSha) || null,
+    headBranch: normalizeDashboardEventText(input.headBranch) || null,
+    runUrl: normalizeDashboardEventText(input.runUrl) || null,
+    title: normalizeDashboardEventText(input.title) || normalizeDashboardEventText(input.workflowName),
     createdAt,
     updatedAt
   };
+}
+
+function normalizeDashboardEventText(value) {
+  return String(value ?? "").trim();
 }
 
 function createD1MemoryIndexAdapter(d1) {
@@ -5113,16 +5163,16 @@ function normalizeObject(value) {
 function normalizeGitHubActionsEvent(payload) {
   const input = normalizeObject(payload);
   const repository = normalizeCanonicalRepositoryInput(input.repository || input.githubRepository);
-  const workflowName = normalizeText(input.workflowName || input.workflow || input.workflow_name);
-  const runId = normalizeText(input.runId || input.run_id || input.databaseId || input.database_id);
-  const runUrl = normalizeText(input.runUrl || input.run_url || input.url);
-  const status = normalizeText(input.status || "completed").toLowerCase();
-  const conclusion = normalizeText(input.conclusion || input.result).toLowerCase();
+  const workflowName = normalizeDashboardEventText(input.workflowName || input.workflow || input.workflow_name);
+  const runId = normalizeDashboardEventText(input.runId || input.run_id || input.databaseId || input.database_id);
+  const runUrl = normalizeDashboardEventText(input.runUrl || input.run_url || input.url);
+  const status = normalizeDashboardEventText(input.status || "completed").toLowerCase();
+  const conclusion = normalizeDashboardEventText(input.conclusion || input.result).toLowerCase();
   const updatedAt = normalizeIsoTimestamp(input.updatedAt || input.updated_at) || new Date().toISOString();
   const createdAt = normalizeIsoTimestamp(input.createdAt || input.created_at) || updatedAt;
-  const headSha = normalizeText(input.headSha || input.head_sha || input.sha);
-  const headBranch = normalizeText(input.headBranch || input.head_branch || input.branch);
-  const title = normalizeText(input.displayTitle || input.display_title || input.title);
+  const headSha = normalizeDashboardEventText(input.headSha || input.head_sha || input.sha);
+  const headBranch = normalizeDashboardEventText(input.headBranch || input.head_branch || input.branch);
+  const title = normalizeDashboardEventText(input.displayTitle || input.display_title || input.title);
 
   if (!repository) {
     return {
@@ -5205,21 +5255,80 @@ async function retrieveLatestDashboardEvent({ store, kind, repository, workflowN
   }
 }
 
+async function retrieveRecentDashboardEvents({ store, kind, repository, workflowName, since, limit } = {}) {
+  if (!store) {
+    return [];
+  }
+  if (typeof store.listRecent === "function") {
+    try {
+      return await store.listRecent({ kind, repository, workflowName, since, limit });
+    } catch {
+      return [];
+    }
+  }
+  if (typeof store.latest === "function") {
+    const latest = await retrieveLatestDashboardEvent({ store, kind, repository, workflowName });
+    if (!latest) {
+      return [];
+    }
+    const sinceTimestamp = normalizeIsoTimestamp(since);
+    if (!sinceTimestamp) {
+      return [latest];
+    }
+    const latestTime = new Date(normalizeText(latest.updatedAt)).getTime();
+    const sinceTime = new Date(sinceTimestamp).getTime();
+    if (Number.isNaN(latestTime) || Number.isNaN(sinceTime) || latestTime < sinceTime) {
+      return [];
+    }
+    return [latest];
+  }
+  return [];
+}
+
 function renderDashboardDeployEvent(event) {
   if (!event) {
     return `<div class="deploy-event muted">直近 deploy event: 未受信</div>`;
   }
-  const conclusion = normalizeText(event.conclusion) || normalizeText(event.status) || "unknown";
+  const conclusion = normalizeDashboardEventText(event.conclusion) || normalizeDashboardEventText(event.status) || "unknown";
   const badgeClass = conclusion === "success" ? "success" : conclusion === "failure" || conclusion === "cancelled" ? "danger" : "";
-  const updatedAt = normalizeText(event.updatedAt);
+  const updatedAt = normalizeDashboardEventText(event.updatedAt);
   const relativeUpdatedAt = formatDashboardRelativeTime(updatedAt);
-  const sha = normalizeText(event.headSha);
+  const sha = normalizeDashboardEventText(event.headSha);
   const shortSha = sha ? sha.slice(0, 7) : "unknown";
-  const runUrl = normalizeText(event.runUrl);
+  const runUrl = normalizeDashboardEventText(event.runUrl);
   const runLabel = runUrl ? `<a class="chat-link" href="${escapeDashboardHtml(runUrl)}">Actions run</a>` : "Actions run 未設定";
   return `<div class="deploy-event">
             <div class="lane-title"><strong>最新 deploy</strong><span class="pill ${badgeClass}">${escapeDashboardHtml(conclusion)}</span></div>
             <p>${escapeDashboardHtml(event.workflowName || "deploy-production")} / <code>${escapeDashboardHtml(shortSha)}</code></p>
+            <p class="muted">${escapeDashboardHtml(relativeUpdatedAt || "時刻未受信")} ・ ${escapeDashboardHtml(updatedAt || "updatedAt 未受信")} ・ ${runLabel}</p>
+          </div>`;
+}
+
+function renderDashboardNotificationEvent(event) {
+  if (!event) {
+    return "";
+  }
+  const conclusion = normalizeDashboardEventText(event.conclusion) || normalizeDashboardEventText(event.status) || "unknown";
+  const badgeClass = conclusion === "success" ? "success" : conclusion === "failure" || conclusion === "cancelled" ? "danger" : "";
+  const updatedAt = normalizeDashboardEventText(event.updatedAt);
+  const relativeUpdatedAt = formatDashboardRelativeTime(updatedAt);
+  const repository = normalizeCanonicalRepositoryInput(event.repository) || "repository 未受信";
+  const workflowName = normalizeDashboardEventText(event.workflowName) || normalizeDashboardEventText(event.kind) || "event";
+  const title = normalizeDashboardEventText(event.title) || workflowName;
+  const runId = normalizeDashboardEventText(event.runId);
+  const sha = normalizeDashboardEventText(event.headSha);
+  const shortSha = sha ? sha.slice(0, 7) : "";
+  const runUrl = normalizeDashboardEventText(event.runUrl);
+  const runLabel = runUrl ? `<a class="chat-link" href="${escapeDashboardHtml(runUrl)}">詳細を開く</a>` : "詳細リンク未受信";
+  const meta = [
+    repository,
+    workflowName,
+    runId ? `run ${runId}` : "",
+    shortSha ? `sha ${shortSha}` : ""
+  ].filter(Boolean).join(" / ");
+  return `<div class="deploy-event">
+            <div class="lane-title"><strong>${escapeDashboardHtml(title)}</strong><span class="pill ${badgeClass}">${escapeDashboardHtml(conclusion)}</span></div>
+            <p>${escapeDashboardHtml(meta)}</p>
             <p class="muted">${escapeDashboardHtml(relativeUpdatedAt || "時刻未受信")} ・ ${escapeDashboardHtml(updatedAt || "updatedAt 未受信")} ・ ${runLabel}</p>
           </div>`;
 }
@@ -5436,11 +5545,11 @@ async function renderDashboardSelfParityPage({ url, env } = {}) {
 
 async function renderDashboardNotificationsPage({ runtimeOrigin, dashboardEventStore } = {}) {
   const origin = normalize(runtimeOrigin);
-  const latestDeployEvent = await retrieveLatestDashboardEvent({
+  const recentSince = new Date(Date.now() - 5 * 60 * 1000).toISOString();
+  const recentEvents = await retrieveRecentDashboardEvents({
     store: dashboardEventStore,
-    kind: "github_actions_workflow_run",
-    repository: "marushu/vtdd-v2-p",
-    workflowName: "deploy-production"
+    since: recentSince,
+    limit: 20
   });
   return renderDashboardUtilityPage({
     title: "通知センター",
@@ -5449,12 +5558,13 @@ async function renderDashboardNotificationsPage({ runtimeOrigin, dashboardEventS
     body: `
       <section class="hero">
         <p>今は iOS Push / 音 / PWA badge ではなく、Worker に届いた dashboard event の人間向け表示です。</p>
+        <p class="muted">VTDD だけでなく、他 repo / 並行開発 / queue / workflow から届いたイベントを直近5分だけ表示します。</p>
         <p class="muted">次の段階で Web Push 購読、通知 permission、通知タップ遷移を追加します。</p>
       </section>
       <div class="grid single">
         <section class="lane">
-          <div class="lane-title"><h2>deploy-production</h2><span class="pill">latest</span></div>
-          ${renderDashboardDeployEvent(latestDeployEvent)}
+          <div class="lane-title"><h2>最新通知</h2><span class="pill">直近5分</span></div>
+          ${recentEvents.length > 0 ? recentEvents.map((event) => renderDashboardNotificationEvent(event)).join("") : `<p class="muted">直近5分の通知はありません。</p>`}
         </section>
       </div>
     `

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -58,6 +58,26 @@ function createInMemoryDashboardEventStore() {
       });
       matches.sort((left, right) => String(right.updatedAt).localeCompare(String(left.updatedAt)));
       return matches[0] ?? null;
+    },
+    async listRecent(filter = {}) {
+      const sinceTime = filter.since ? new Date(filter.since).getTime() : null;
+      const matches = [...events.values()].filter((event) => {
+        if (filter.kind && event.kind !== filter.kind) {
+          return false;
+        }
+        if (filter.repository && event.repository !== filter.repository) {
+          return false;
+        }
+        if (filter.workflowName && event.workflowName !== filter.workflowName) {
+          return false;
+        }
+        if (sinceTime && new Date(event.updatedAt).getTime() < sinceTime) {
+          return false;
+        }
+        return true;
+      });
+      matches.sort((left, right) => String(right.updatedAt).localeCompare(String(left.updatedAt)));
+      return matches.slice(0, Number(filter.limit) || 20);
     }
   };
 }
@@ -329,9 +349,11 @@ test("worker serves human-facing dashboard pages for every management menu", asy
   }
 });
 
-test("worker serves dashboard notification center for latest deploy event", async () => {
+test("worker serves dashboard notification center for recent events across repositories", async () => {
   const store = createInMemoryDashboardEventStore();
-  const fiveMinutesAgo = new Date(Date.now() - 5 * 60 * 1000).toISOString();
+  const fourMinutesAgo = new Date(Date.now() - 4 * 60 * 1000).toISOString();
+  const twoMinutesAgo = new Date(Date.now() - 2 * 60 * 1000).toISOString();
+  const sixMinutesAgo = new Date(Date.now() - 6 * 60 * 1000).toISOString();
   await store.put({
     id: "github_actions_workflow_run:marushu/vtdd-v2-p:deploy-production:26134526815",
     kind: "github_actions_workflow_run",
@@ -344,7 +366,35 @@ test("worker serves dashboard notification center for latest deploy event", asyn
     headSha: "daad4fb023cf699b3ad531e0394e064fde2b5515",
     headBranch: "main",
     title: "deploy-production",
-    updatedAt: fiveMinutesAgo
+    updatedAt: fourMinutesAgo
+  });
+  await store.put({
+    id: "vps_runner_execution:marushu/sunabaeye:remote-codex-issue9",
+    kind: "vps_runner_execution",
+    repository: "marushu/sunabaeye",
+    workflowName: "remote-codex",
+    runId: "remote-codex-issue9",
+    runUrl: "https://example.com/progress/remote-codex-issue9?repository=marushu%2Fsunabaeye&source=dashboard-notification-center",
+    status: "running",
+    conclusion: "",
+    headSha: "abc1234567890",
+    headBranch: "codex/issue-9",
+    title: "SunabaEye queue pickup with long notification title",
+    updatedAt: twoMinutesAgo
+  });
+  await store.put({
+    id: "github_actions_workflow_run:marushu/old:deploy-production:old",
+    kind: "github_actions_workflow_run",
+    repository: "marushu/old",
+    workflowName: "deploy-production",
+    runId: "old",
+    runUrl: "https://example.com/old",
+    status: "completed",
+    conclusion: "failure",
+    headSha: "old1234567890",
+    headBranch: "main",
+    title: "old notification",
+    updatedAt: sixMinutesAgo
   });
 
   const response = await worker.fetch(new Request("https://example.com/dashboard/notifications"), {
@@ -355,11 +405,17 @@ test("worker serves dashboard notification center for latest deploy event", asyn
   const body = await response.text();
   assert.equal(body.includes("通知センター"), true);
   assert.equal(body.includes("iOS Push / 音 / PWA badge ではなく"), true);
-  assert.equal(body.includes("最新 deploy"), true);
+  assert.equal(body.includes("他 repo / 並行開発 / queue / workflow"), true);
+  assert.equal(body.includes("最新通知"), true);
   assert.equal(body.includes("success"), true);
   assert.equal(body.includes("26134526815"), true);
-  assert.equal(body.includes("5分前"), true);
-  assert.equal(body.includes(fiveMinutesAgo), true);
+  assert.equal(body.includes("4分前"), true);
+  assert.equal(body.includes(fourMinutesAgo), true);
+  assert.equal(body.includes("SunabaEye queue pickup with long notification title"), true);
+  assert.equal(body.includes("marushu/sunabaeye"), true);
+  assert.equal(body.includes("dashboard-notification-center"), true);
+  assert.equal(body.includes("2分前"), true);
+  assert.equal(body.includes("old notification"), false);
 });
 
 test("worker ingests GitHub Actions deploy completion event and shows it on dashboard", async () => {

--- a/worker.js
+++ b/worker.js
@@ -59602,9 +59602,9 @@ function createD1DashboardEventStore(d1) {
     },
     async latest(filter = {}) {
       await ensureSchema();
-      const kind = normalizeText30(filter.kind);
+      const kind = normalizeDashboardEventText(filter.kind);
       const repository = normalizeCanonicalRepositoryInput(filter.repository);
-      const workflowName = normalizeText30(filter.workflowName);
+      const workflowName = normalizeDashboardEventText(filter.workflowName);
       const clauses = [];
       const params = [];
       if (kind) {
@@ -59632,6 +59632,43 @@ function createD1DashboardEventStore(d1) {
       } catch {
         return null;
       }
+    },
+    async listRecent(filter = {}) {
+      await ensureSchema();
+      const kind = normalizeDashboardEventText(filter.kind);
+      const repository = normalizeCanonicalRepositoryInput(filter.repository);
+      const workflowName = normalizeDashboardEventText(filter.workflowName);
+      const since = normalizeIsoTimestamp(filter.since);
+      const limit = normalizeLimit7(filter.limit, 20);
+      const clauses = [];
+      const params = [];
+      if (kind) {
+        clauses.push("kind = ?");
+        params.push(kind);
+      }
+      if (repository) {
+        clauses.push("repository = ?");
+        params.push(repository);
+      }
+      if (workflowName) {
+        clauses.push("workflow_name = ?");
+        params.push(workflowName);
+      }
+      if (since) {
+        clauses.push("updated_at >= ?");
+        params.push(since);
+      }
+      const where = clauses.length > 0 ? `WHERE ${clauses.join(" AND ")}` : "";
+      const result = await d1.prepare(
+        `SELECT payload_json FROM vtdd_dashboard_events ${where} ORDER BY updated_at DESC, created_at DESC LIMIT ?`
+      ).bind(...params, limit).all();
+      return (Array.isArray(result?.results) ? result.results : []).map((row) => {
+        try {
+          return row?.payload_json ? normalizeDashboardEventRecord(JSON.parse(row.payload_json)) : null;
+        } catch {
+          return null;
+        }
+      }).filter(Boolean);
     }
   };
   function ensureSchema() {
@@ -59643,6 +59680,9 @@ function createD1DashboardEventStore(d1) {
         await d1.exec(
           "CREATE INDEX IF NOT EXISTS idx_vtdd_dashboard_events_lookup ON vtdd_dashboard_events (kind, repository, workflow_name, updated_at DESC);"
         );
+        await d1.exec(
+          "CREATE INDEX IF NOT EXISTS idx_vtdd_dashboard_events_recent ON vtdd_dashboard_events (updated_at DESC, created_at DESC);"
+        );
       })();
     }
     return schemaPromise;
@@ -59653,20 +59693,23 @@ function normalizeDashboardEventRecord(event) {
   const updatedAt = normalizeIsoTimestamp(input.updatedAt) || (/* @__PURE__ */ new Date()).toISOString();
   const createdAt = normalizeIsoTimestamp(input.createdAt) || updatedAt;
   return {
-    id: normalizeText30(input.id),
-    kind: normalizeText30(input.kind),
+    id: normalizeDashboardEventText(input.id),
+    kind: normalizeDashboardEventText(input.kind),
     repository: normalizeCanonicalRepositoryInput(input.repository),
-    workflowName: normalizeText30(input.workflowName),
-    runId: normalizeText30(input.runId),
-    status: normalizeText30(input.status),
-    conclusion: normalizeText30(input.conclusion) || null,
-    headSha: normalizeText30(input.headSha) || null,
-    headBranch: normalizeText30(input.headBranch) || null,
-    runUrl: normalizeText30(input.runUrl) || null,
-    title: normalizeText30(input.title) || normalizeText30(input.workflowName),
+    workflowName: normalizeDashboardEventText(input.workflowName),
+    runId: normalizeDashboardEventText(input.runId),
+    status: normalizeDashboardEventText(input.status),
+    conclusion: normalizeDashboardEventText(input.conclusion) || null,
+    headSha: normalizeDashboardEventText(input.headSha) || null,
+    headBranch: normalizeDashboardEventText(input.headBranch) || null,
+    runUrl: normalizeDashboardEventText(input.runUrl) || null,
+    title: normalizeDashboardEventText(input.title) || normalizeDashboardEventText(input.workflowName),
     createdAt,
     updatedAt
   };
+}
+function normalizeDashboardEventText(value) {
+  return String(value ?? "").trim();
 }
 function createD1MemoryIndexAdapter(d1) {
   if (!d1 || typeof d1.prepare !== "function") {
@@ -60044,16 +60087,16 @@ function normalizeObject11(value) {
 function normalizeGitHubActionsEvent(payload) {
   const input = normalizeObject11(payload);
   const repository = normalizeCanonicalRepositoryInput(input.repository || input.githubRepository);
-  const workflowName = normalizeText30(input.workflowName || input.workflow || input.workflow_name);
-  const runId = normalizeText30(input.runId || input.run_id || input.databaseId || input.database_id);
-  const runUrl = normalizeText30(input.runUrl || input.run_url || input.url);
-  const status = normalizeText30(input.status || "completed").toLowerCase();
-  const conclusion = normalizeText30(input.conclusion || input.result).toLowerCase();
+  const workflowName = normalizeDashboardEventText(input.workflowName || input.workflow || input.workflow_name);
+  const runId = normalizeDashboardEventText(input.runId || input.run_id || input.databaseId || input.database_id);
+  const runUrl = normalizeDashboardEventText(input.runUrl || input.run_url || input.url);
+  const status = normalizeDashboardEventText(input.status || "completed").toLowerCase();
+  const conclusion = normalizeDashboardEventText(input.conclusion || input.result).toLowerCase();
   const updatedAt = normalizeIsoTimestamp(input.updatedAt || input.updated_at) || (/* @__PURE__ */ new Date()).toISOString();
   const createdAt = normalizeIsoTimestamp(input.createdAt || input.created_at) || updatedAt;
-  const headSha = normalizeText30(input.headSha || input.head_sha || input.sha);
-  const headBranch = normalizeText30(input.headBranch || input.head_branch || input.branch);
-  const title = normalizeText30(input.displayTitle || input.display_title || input.title);
+  const headSha = normalizeDashboardEventText(input.headSha || input.head_sha || input.sha);
+  const headBranch = normalizeDashboardEventText(input.headBranch || input.head_branch || input.branch);
+  const title = normalizeDashboardEventText(input.displayTitle || input.display_title || input.title);
   if (!repository) {
     return {
       ok: false,
@@ -60130,21 +60173,78 @@ async function retrieveLatestDashboardEvent({ store, kind, repository, workflowN
     return null;
   }
 }
+async function retrieveRecentDashboardEvents({ store, kind, repository, workflowName, since, limit } = {}) {
+  if (!store) {
+    return [];
+  }
+  if (typeof store.listRecent === "function") {
+    try {
+      return await store.listRecent({ kind, repository, workflowName, since, limit });
+    } catch {
+      return [];
+    }
+  }
+  if (typeof store.latest === "function") {
+    const latest = await retrieveLatestDashboardEvent({ store, kind, repository, workflowName });
+    if (!latest) {
+      return [];
+    }
+    const sinceTimestamp = normalizeIsoTimestamp(since);
+    if (!sinceTimestamp) {
+      return [latest];
+    }
+    const latestTime = new Date(normalizeText30(latest.updatedAt)).getTime();
+    const sinceTime = new Date(sinceTimestamp).getTime();
+    if (Number.isNaN(latestTime) || Number.isNaN(sinceTime) || latestTime < sinceTime) {
+      return [];
+    }
+    return [latest];
+  }
+  return [];
+}
 function renderDashboardDeployEvent(event) {
   if (!event) {
     return `<div class="deploy-event muted">\u76F4\u8FD1 deploy event: \u672A\u53D7\u4FE1</div>`;
   }
-  const conclusion = normalizeText30(event.conclusion) || normalizeText30(event.status) || "unknown";
+  const conclusion = normalizeDashboardEventText(event.conclusion) || normalizeDashboardEventText(event.status) || "unknown";
   const badgeClass = conclusion === "success" ? "success" : conclusion === "failure" || conclusion === "cancelled" ? "danger" : "";
-  const updatedAt = normalizeText30(event.updatedAt);
+  const updatedAt = normalizeDashboardEventText(event.updatedAt);
   const relativeUpdatedAt = formatDashboardRelativeTime(updatedAt);
-  const sha = normalizeText30(event.headSha);
+  const sha = normalizeDashboardEventText(event.headSha);
   const shortSha = sha ? sha.slice(0, 7) : "unknown";
-  const runUrl = normalizeText30(event.runUrl);
+  const runUrl = normalizeDashboardEventText(event.runUrl);
   const runLabel = runUrl ? `<a class="chat-link" href="${escapeDashboardHtml(runUrl)}">Actions run</a>` : "Actions run \u672A\u8A2D\u5B9A";
   return `<div class="deploy-event">
             <div class="lane-title"><strong>\u6700\u65B0 deploy</strong><span class="pill ${badgeClass}">${escapeDashboardHtml(conclusion)}</span></div>
             <p>${escapeDashboardHtml(event.workflowName || "deploy-production")} / <code>${escapeDashboardHtml(shortSha)}</code></p>
+            <p class="muted">${escapeDashboardHtml(relativeUpdatedAt || "\u6642\u523B\u672A\u53D7\u4FE1")} \u30FB ${escapeDashboardHtml(updatedAt || "updatedAt \u672A\u53D7\u4FE1")} \u30FB ${runLabel}</p>
+          </div>`;
+}
+function renderDashboardNotificationEvent(event) {
+  if (!event) {
+    return "";
+  }
+  const conclusion = normalizeDashboardEventText(event.conclusion) || normalizeDashboardEventText(event.status) || "unknown";
+  const badgeClass = conclusion === "success" ? "success" : conclusion === "failure" || conclusion === "cancelled" ? "danger" : "";
+  const updatedAt = normalizeDashboardEventText(event.updatedAt);
+  const relativeUpdatedAt = formatDashboardRelativeTime(updatedAt);
+  const repository = normalizeCanonicalRepositoryInput(event.repository) || "repository \u672A\u53D7\u4FE1";
+  const workflowName = normalizeDashboardEventText(event.workflowName) || normalizeDashboardEventText(event.kind) || "event";
+  const title = normalizeDashboardEventText(event.title) || workflowName;
+  const runId = normalizeDashboardEventText(event.runId);
+  const sha = normalizeDashboardEventText(event.headSha);
+  const shortSha = sha ? sha.slice(0, 7) : "";
+  const runUrl = normalizeDashboardEventText(event.runUrl);
+  const runLabel = runUrl ? `<a class="chat-link" href="${escapeDashboardHtml(runUrl)}">\u8A73\u7D30\u3092\u958B\u304F</a>` : "\u8A73\u7D30\u30EA\u30F3\u30AF\u672A\u53D7\u4FE1";
+  const meta2 = [
+    repository,
+    workflowName,
+    runId ? `run ${runId}` : "",
+    shortSha ? `sha ${shortSha}` : ""
+  ].filter(Boolean).join(" / ");
+  return `<div class="deploy-event">
+            <div class="lane-title"><strong>${escapeDashboardHtml(title)}</strong><span class="pill ${badgeClass}">${escapeDashboardHtml(conclusion)}</span></div>
+            <p>${escapeDashboardHtml(meta2)}</p>
             <p class="muted">${escapeDashboardHtml(relativeUpdatedAt || "\u6642\u523B\u672A\u53D7\u4FE1")} \u30FB ${escapeDashboardHtml(updatedAt || "updatedAt \u672A\u53D7\u4FE1")} \u30FB ${runLabel}</p>
           </div>`;
 }
@@ -60353,11 +60453,11 @@ async function renderDashboardSelfParityPage({ url, env } = {}) {
 }
 async function renderDashboardNotificationsPage({ runtimeOrigin, dashboardEventStore } = {}) {
   const origin = normalize7(runtimeOrigin);
-  const latestDeployEvent = await retrieveLatestDashboardEvent({
+  const recentSince = new Date(Date.now() - 5 * 60 * 1e3).toISOString();
+  const recentEvents = await retrieveRecentDashboardEvents({
     store: dashboardEventStore,
-    kind: "github_actions_workflow_run",
-    repository: "marushu/vtdd-v2-p",
-    workflowName: "deploy-production"
+    since: recentSince,
+    limit: 20
   });
   return renderDashboardUtilityPage({
     title: "\u901A\u77E5\u30BB\u30F3\u30BF\u30FC",
@@ -60366,12 +60466,13 @@ async function renderDashboardNotificationsPage({ runtimeOrigin, dashboardEventS
     body: `
       <section class="hero">
         <p>\u4ECA\u306F iOS Push / \u97F3 / PWA badge \u3067\u306F\u306A\u304F\u3001Worker \u306B\u5C4A\u3044\u305F dashboard event \u306E\u4EBA\u9593\u5411\u3051\u8868\u793A\u3067\u3059\u3002</p>
+        <p class="muted">VTDD \u3060\u3051\u3067\u306A\u304F\u3001\u4ED6 repo / \u4E26\u884C\u958B\u767A / queue / workflow \u304B\u3089\u5C4A\u3044\u305F\u30A4\u30D9\u30F3\u30C8\u3092\u76F4\u8FD15\u5206\u3060\u3051\u8868\u793A\u3057\u307E\u3059\u3002</p>
         <p class="muted">\u6B21\u306E\u6BB5\u968E\u3067 Web Push \u8CFC\u8AAD\u3001\u901A\u77E5 permission\u3001\u901A\u77E5\u30BF\u30C3\u30D7\u9077\u79FB\u3092\u8FFD\u52A0\u3057\u307E\u3059\u3002</p>
       </section>
       <div class="grid single">
         <section class="lane">
-          <div class="lane-title"><h2>deploy-production</h2><span class="pill">latest</span></div>
-          ${renderDashboardDeployEvent(latestDeployEvent)}
+          <div class="lane-title"><h2>\u6700\u65B0\u901A\u77E5</h2><span class="pill">\u76F4\u8FD15\u5206</span></div>
+          ${recentEvents.length > 0 ? recentEvents.map((event) => renderDashboardNotificationEvent(event)).join("") : `<p class="muted">\u76F4\u8FD15\u5206\u306E\u901A\u77E5\u306F\u3042\u308A\u307E\u305B\u3093\u3002</p>`}
         </section>
       </div>
     `


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #444 の通知センター first visible slice として、VTDD 固定 deploy ではなく、dashboard event store に届いた複数 repo / workflow / queue / execution event を直近5分だけ人間向けに表示する。

## Satisfied Success Criteria

- /dashboard/notifications が marushu/vtdd-v2-p の deploy-production 固定表示をやめ、event store の recent feed を表示する。
- D1 dashboard event store に listRecent(filter) を追加し、kind / repository / workflowName / since / limit で横断取得できる。
- 通知カードに repository、workflow、run id、短縮 SHA、相対時刻、詳細リンクを表示する。
- 5分より古い通知は通知センターに表示しない。
- test/worker.test.js で vtdd-v2-p と sunabaeye の recent event が同時表示され、古い event が出ないことを検証する。

## Unsatisfied Success Criteria

- iOS Web Push / 音 / PWA badge / notificationclick は未実装。
- VPS Codex CLI との会話 UI は未実装。
- VPS runner / queue 側が dashboard event store に publish する producer 接続は、受け口設計の次スライス。今回の表示面は event store に届いたものを repo 横断で扱える状態まで。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #444
- Implementing Success Criteria: 通知センターを特定 repo deploy 固定から、複数 repo / 並行開発 / queue / workflow の recent event feed へ変更する。
- Explicit Non-goals: iOS Push/音/バッジ本体、VPS Codex CLI 会話 UI、VPS runner producer 接続の完成はこのPRでは扱わない。
- Expected touched files/routes/workflows: src/worker/runtime.js, test/worker.test.js, worker.js
- Affected Issues: Issue #444
- Affected PRs: PR #445 の後続スライス。
- Affected workflows: GitHub Actions workflow 自体は未変更。dashboard event store の読み取りのみ拡張。
- Affected runtime/operator surfaces: /dashboard/notifications, dashboard event store, generated worker.js
- What may break if we patch narrowly: 通知センターだけを直すと producer 未接続イベントは出ない。PR body で未接続スライスとして明記する。
- Unknowns to investigate before coding: 本番 D1 に現在どの producer が dashboard event を書いているかは runtime deploy 後に確認する。
- Validation needed: node --test test/worker.test.js; npm test
- Stop condition: VPS runner への producer 接続や iOS Push credential を同時に実装し始める場合は scope 超過として止める。

## File / Line Hypotheses

- file: `src/worker/runtime.js`
  - hypothesis: `createD1DashboardEventStore.latest` と `renderDashboardNotificationsPage` が通知センターを単一 deploy に固定している。
  - risk if changed narrowly: D1 store と injected test store の API がずれると runtime/test parity が壊れる。
  - validation: `node --test test/worker.test.js` と `npm test`。
  - related Issue: #444

## Hypothesis Retrospective

- expected: notification center が fixed deploy ではなく recent event list を表示する。
- actual: `listRecent` と generic notification card を追加し、複数 repo recent event と old event exclusion をテストで確認した。
- mismatch: producer 側の全イベント publish は今回未接続。
- lesson: 表示面と producer 接続を分ける場合、未接続をPRに明記する必要がある。
- should become RAG candidate: はい。通知は「全 repo recent feed」と「producer publish 接続」を分けて扱う。

## Verification Evidence

- Unit: node --test test/worker.test.js PASS: 129 tests.
- Integration: npm test PASS: 835 pass / 1 skipped; self-parity PASS; generated-worker PASS.
- E2E: Worker unit E2E: /dashboard/notifications renders recent vtdd-v2-p + sunabaeye events and excludes a 6-minute-old event.
- Manual: 未実施。本番 deploy 後に /dashboard/notifications で直近5分の runtime event 表示を確認する。
- Evidence path/link: test/worker.test.js dashboard notification center for recent events across repositories

## Butler Completion Contract

- Owner goal: 通知センターで VTDD だけでなく他 repo / 並行開発 / queue 開発の最新通知を見られるようにする。
- Butler entrypoint: /dashboard/notifications
- Action Schema exposure: 不要。Dashboard HTML surface のみ。
- Runtime path: /dashboard/notifications -> dashboard event store listRecent
- Runner/runtime truth: D1 dashboard event store に届いた event の updatedAt が直近5分なら表示、古いものは非表示。
- Authority boundary: 読み取り表示のみ。GO/passkey 不要。
- E2E evidence: Worker test で人間向け dashboard surface を検証。iPhone live E2E は deploy 後。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: PR merge 後に必要。deploy は GO + passkey。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: deploy 後に /dashboard/notifications を iPhone で確認。

## Related Constitution Rules

- Butler Completion Gate
- Evidence Discipline
- Drift Stop Protocol
- Conversation UX Contract

## Out-of-scope but NOT implemented

- iOS Push / 音 / badge 実装
- VPS Codex CLI 会話 UI
- VPS runner/queue から dashboard event store への producer 書き込み接続
- 通知保持/既読/アーカイブ UI

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #444
- Execution ID: Not provided.
- Goal: Not provided.
