### PR TITLE
Issue #444 dashboard PWA cache を補強

### DIFF
--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -6242,7 +6242,9 @@ function html(status, body) {
   return new Response(body, {
     status,
     headers: {
-      "content-type": "text/html; charset=utf-8"
+      "content-type": "text/html; charset=utf-8",
+      "cache-control": "no-store, no-cache, must-revalidate, max-age=0",
+      pragma: "no-cache"
     }
   });
 }

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -193,6 +193,7 @@ test("worker serves v2 dashboard without exposing secrets", async () => {
   const response = await worker.fetch(new Request("https://example.com/dashboard"));
   assert.equal(response.status, 200);
   assert.match(response.headers.get("content-type"), /text\/html/);
+  assert.match(response.headers.get("cache-control"), /no-store/);
   const body = await response.text();
   assert.equal(body.includes("Butler chat shell"), true);
   assert.equal(body.includes("dashboard main chat"), true);
@@ -216,8 +217,10 @@ test("worker serves v2 dashboard without exposing secrets", async () => {
   assert.equal(body.includes("直近 deploy event"), true);
   assert.equal(body.includes("Butler V2 にメッセージ"), true);
   assert.equal(body.includes("状態確認"), true);
+  assert.equal(body.includes(">通知</a>"), true);
   assert.equal(body.includes("/dashboard/github?repository=marushu%2Fvtdd-v2-p"), true);
   assert.equal(body.includes("/dashboard/notifications"), true);
+  assert.equal(body.includes(">通知センター</a>"), true);
   assert.equal(body.includes("include=open_prs"), false);
   assert.equal(body.includes('name="text"'), false);
   assert.equal(/<meta[^>]+http-equiv=["']?refresh/i.test(body), false);
@@ -246,6 +249,7 @@ test("worker serves v2 dashboard without exposing secrets", async () => {
 
   const alias = await worker.fetch(new Request("https://example.com/orchestrator"));
   assert.equal(alias.status, 200);
+  assert.match(alias.headers.get("cache-control"), /no-store/);
   const aliasBody = await alias.text();
   assert.equal(aliasBody.includes("VTDD Butler"), true);
   assert.equal(aliasBody.includes("dashboard main chat"), true);

--- a/worker.js
+++ b/worker.js
@@ -61121,7 +61121,9 @@ function html(status, body) {
   return new Response(body, {
     status,
     headers: {
-      "content-type": "text/html; charset=utf-8"
+      "content-type": "text/html; charset=utf-8",
+      "cache-control": "no-store, no-cache, must-revalidate, max-age=0",
+      pragma: "no-cache"
     }
   });
 }


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #444 の部分進捗として、iPhone ホーム画面/ブックマークから開く dashboard 入口が古い管理メニューを保持し、通知センターへ辿れなくなる状態を防ぎます。

## Satisfied Success Criteria

- dashboard HTML response に no-store/no-cache header を付け、PWA/ブックマーク入口が古い HTML を保持しにくいようにしました。
/dashboard と /orchestrator の入口 HTML に通知/通知センター導線が存在することをテストで固定しました。

## Unsatisfied Success Criteria

- iOS Push 通知、音、PWA badge の実装はこの PR では未実装です。
VPS Codex CLI との会話 UI はこの PR では未実装です。

## Non-goal violations

passkey 不要 deploy は行いません。GitHub/Cloudflare の高リスク authority 境界は変更しません。通知ページのイベント取り込み仕様は変更しません。

## Dry-run Impact Report

- Target Issue: Issue #444
- Implementing Success Criteria: ブックマーク/PWA 入口の /dashboard から通知センターへ確実に辿れること。dashboard 系 HTML が stale menu を保持しにくいこと。
- Explicit Non-goals: iOS Push/音/バッジ本体、passkey 不要 deploy、VPS Codex CLI 会話 UI は対象外。
- Expected touched files/routes/workflows: src/worker/runtime.js, test/worker.test.js, worker.js
- Affected Issues: Issue #444
- Affected PRs: 直前の通知センター PR #446 の入口導線を補強します。
- Affected workflows: deploy-production は実行しません。GitHub Actions workflow 定義は変更しません。
- Affected runtime/operator surfaces: Cloudflare Worker の HTML dashboard surfaces: /dashboard, /orchestrator, /dashboard/notifications。
- What may break if we patch narrowly: 通知ページだけを直すと、ホーム画面/ブックマーク入口の古い管理メニュー問題が残ります。
- Unknowns to investigate before coding: iOS ホーム画面 WebView の保持挙動は端末依存が残ります。Worker 側では no-store と導線テストで再発を抑えます。
- Validation needed: node --test test/worker.test.js と npm test。
- Stop condition: 高リスク deploy 自動化や passkey boundary 変更が必要になった場合はこの PR では止めます。

## File / Line Hypotheses

- file: src/worker/runtime.js
  - hypothesis: 共通 html() helper が cache-control を付けていないため、dashboard HTML がブックマーク/PWA 入口で古く残る可能性がある。
  - risk if changed narrowly: /dashboard/notifications だけを直すと入口メニューには反映されない。
  - validation: /dashboard と /orchestrator の header と通知導線を test/worker.test.js で固定する。
  - related Issue: #444

## Hypothesis Retrospective

- expected: HTML 共通 helper に no-store を付ければ dashboard 系 human-facing ページへ一括適用できる。
- actual: src/worker/runtime.js の html() に cache-control/pragma を追加し、/dashboard と /orchestrator のテストで確認した。
- mismatch: iOS の既に開いている WebView document は即時には差し替わらない可能性が残る。
- lesson: PWA 入口は直接ページの存在だけでなく、入口導線と cache header を同時に検証する必要がある。
- should become RAG candidate: はい。iPhone ホーム画面 dashboard の stale menu 再発防止として残す価値があります。

## Verification Evidence

- Unit: node --test test/worker.test.js: PASS (129 tests)
- Integration: npm test: PASS (835 pass / 1 skipped, self-parity pass, generated-worker pass)
- E2E: 未実施。iPhone 実機ホーム画面での再表示確認は deploy 後に必要です。
- Manual: production runtime では /dashboard/notifications は直接表示済み。今回の PR は /dashboard 入口の stale/cache 問題を補強します。
- Evidence path/link: test/worker.test.js dashboard assertions and npm test output in this PR run

## Butler Completion Contract

- Owner goal: iPhone ホーム画面/ブックマークから開いた dashboard でも通知センターへ迷わず辿れるようにする。
- Butler entrypoint: Cloudflare dashboard の /dashboard または /orchestrator。Butler 会話 UI 本体はこの PR では未接続。
- Action Schema exposure: 不要。Custom GPT Action Schema は変更しません。
- Runtime path: GET /dashboard, GET /orchestrator, GET /dashboard/notifications
- Runner/runtime truth: HTML response header と dashboard body assertions で確認。runtime deploy 後に iPhone 実機確認が必要。
- Authority boundary: 未変更。deploy や credential mutation は GO + passkey 境界のままです。
- E2E evidence: 未実施。deploy 後に iPhone ホーム画面の dashboard から通知センター導線を確認する必要があります。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 必要。merge 後に Cloudflare production deploy が必要です。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: merge + deploy 後に、ホーム画面 dashboard から管理メニューを開き、通知/通知センター導線が見えることを確認してください。

## Related Constitution Rules

- High-risk actions require GO + passkey.
Dashboard は iPhone/iPad-first の owner-facing runtime surface。
raw JSON ではなく human-facing HTML 導線を優先する。

## Out-of-scope but NOT implemented

- iOS Push/音/バッジ本体。
deploy stale notice automation。
VPS Codex CLI との本格チャット接続。

## Extra changes (if any)

worker.js は npm run build:worker による生成更新です。

<!-- VTDD metadata -->
- Issue: Issue #444
- Execution ID: mac-codex-issue444-dashboard-cache
- Goal: ブックマーク/PWA 入口の stale dashboard menu を防ぎ、通知センター導線を固定する
