### PR TITLE
Issue #448 approve 自動マージ policy を追加

### DIFF
--- a/.github/workflows/approve-auto-merge.yml
+++ b/.github/workflows/approve-auto-merge.yml
@@ -1,0 +1,99 @@
+name: approve-auto-merge
+
+on:
+  workflow_run:
+    workflows:
+      - guarded-autonomy-required-checks
+      - gemini-pr-review
+      - codex-pr-review-fallback
+    types:
+      - completed
+  pull_request_review:
+    types:
+      - submitted
+      - edited
+  issue_comment:
+    types:
+      - created
+      - edited
+  workflow_dispatch:
+    inputs:
+      target_pr_number:
+        description: "Target pull request number"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: read
+
+concurrency:
+  group: approve-auto-merge-${{ github.repository }}-${{ github.event.workflow_run.head_sha || github.event.pull_request.number || github.event.issue.number || github.event.inputs.target_pr_number || github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    env:
+      TARGET_PR_NUMBER: ${{ github.event.inputs.target_pr_number }}
+      VTDD_AUTO_MERGE_POLICY: ${{ vars.VTDD_AUTO_MERGE_POLICY || 'approve_auto_merge' }}
+      VTDD_AUTO_MERGE_REQUIRED_CHECKS: ${{ vars.VTDD_AUTO_MERGE_REQUIRED_CHECKS || 'guarded-policy,test,review' }}
+      VTDD_AUTO_MERGE_METHOD: ${{ vars.VTDD_AUTO_MERGE_METHOD || 'squash' }}
+      VTDD_RUNTIME_URL: ${{ vars.VTDD_RUNTIME_URL }}
+      VTDD_GATEWAY_BEARER_TOKEN: ${{ secrets.VTDD_GATEWAY_BEARER_TOKEN }}
+    steps:
+      - name: Detect auto merge GitHub App secrets
+        id: app_secrets
+        env:
+          VTDD_GITHUB_APP_ID: ${{ secrets.VTDD_GITHUB_APP_ID }}
+          VTDD_GITHUB_APP_PRIVATE_KEY: ${{ secrets.VTDD_GITHUB_APP_PRIVATE_KEY }}
+        shell: bash
+        run: |
+          if [ -n "$VTDD_GITHUB_APP_ID" ] && [ -n "$VTDD_GITHUB_APP_PRIVATE_KEY" ]; then
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Stop when auto merge GitHub App secrets are missing
+        if: ${{ steps.app_secrets.outputs.configured != 'true' }}
+        shell: bash
+        run: |
+          echo "approve-auto-merge requires VTDD_GITHUB_APP_ID / VTDD_GITHUB_APP_PRIVATE_KEY."
+          exit 0
+
+      - name: Mint auto merge GitHub App token
+        if: ${{ steps.app_secrets.outputs.configured == 'true' }}
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.VTDD_GITHUB_APP_ID }}
+          private-key: ${{ secrets.VTDD_GITHUB_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Checkout trusted source
+        if: ${{ steps.app_secrets.outputs.configured == 'true' }}
+        uses: actions/checkout@v6
+        with:
+          ref: main
+          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Setup Node.js
+        if: ${{ steps.app_secrets.outputs.configured == 'true' }}
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        if: ${{ steps.app_secrets.outputs.configured == 'true' }}
+        run: npm ci
+
+      - name: Evaluate and execute approve auto merge
+        if: ${{ steps.app_secrets.outputs.configured == 'true' }}
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: node scripts/run-approve-auto-merge.mjs

--- a/scripts/run-approve-auto-merge.mjs
+++ b/scripts/run-approve-auto-merge.mjs
@@ -1,0 +1,389 @@
+#!/usr/bin/env node
+
+import fs from "node:fs/promises";
+import {
+  APPROVE_AUTO_MERGE_BLOCKED_MARKER,
+  APPROVE_AUTO_MERGE_CANDIDATE_MARKER,
+  APPROVE_AUTO_MERGE_EXECUTED_MARKER,
+  ActorRole,
+  TaskMode,
+  evaluateApproveAutoMerge,
+  evaluateExecutionContinuity,
+  formatApproveAutoMergeBlockedComment,
+  formatApproveAutoMergeCandidateComment,
+  formatApproveAutoMergeExecutedComment,
+  resolveApproveAutoMergePolicy
+} from "../src/core/index.js";
+
+async function main() {
+  const repository = mustGetEnv("GITHUB_REPOSITORY");
+  const token = mustGetEnv("GITHUB_TOKEN");
+  const apiBaseUrl = process.env.GITHUB_API_URL || "https://api.github.com";
+  const githubFetch = createGitHubFetch({ apiBaseUrl, token });
+  const eventName = process.env.GITHUB_EVENT_NAME || "";
+  const eventPath = process.env.GITHUB_EVENT_PATH || "";
+  const payload = eventPath ? JSON.parse(await fs.readFile(eventPath, "utf8")) : {};
+  const pullNumbers = resolvePullNumbers({ payload, env: process.env });
+
+  if (pullNumbers.length === 0) {
+    console.log("No pull request candidate for approve auto merge.");
+    return;
+  }
+
+  for (const pullNumber of pullNumbers) {
+    await processPullRequest({
+      githubFetch,
+      repository,
+      pullNumber,
+      eventName,
+      env: process.env
+    });
+  }
+}
+
+async function processPullRequest({ githubFetch, repository, pullNumber, eventName, env }) {
+  const pullRequest = await githubFetch(`/repos/${repository}/pulls/${pullNumber}`);
+  if (pullRequest.state !== "open") {
+    console.log(`Skipping PR #${pullNumber}: state=${pullRequest.state}.`);
+    return;
+  }
+
+  const [issue, files, issueComments, reviewComments, reviews, checkRunsResponse] = await Promise.all([
+    githubFetch(`/repos/${repository}/issues/${pullNumber}`),
+    githubFetchAll(githubFetch, `/repos/${repository}/pulls/${pullNumber}/files?per_page=100`),
+    githubFetchAll(githubFetch, `/repos/${repository}/issues/${pullNumber}/comments?per_page=100`),
+    githubFetchAll(githubFetch, `/repos/${repository}/pulls/${pullNumber}/comments?per_page=100`),
+    githubFetchAll(githubFetch, `/repos/${repository}/pulls/${pullNumber}/reviews?per_page=100`),
+    githubFetch(`/repos/${repository}/commits/${pullRequest.head.sha}/check-runs?per_page=100`)
+  ]);
+
+  const labels = normalizeLabels(issue.labels);
+  const policyMode = resolveApproveAutoMergePolicy({
+    policyMode: env.VTDD_AUTO_MERGE_POLICY,
+    labels
+  });
+  const runtimePullRequest = {
+    repository,
+    number: pullRequest.number,
+    url: pullRequest.html_url,
+    state: pullRequest.state,
+    title: pullRequest.title,
+    body: pullRequest.body,
+    draft: pullRequest.draft === true,
+    baseRef: pullRequest.base?.ref,
+    headRef: pullRequest.head?.ref,
+    headSha: pullRequest.head?.sha,
+    mergeable: pullRequest.mergeable,
+    mergeableState: pullRequest.mergeable_state,
+    reviewDecision: pullRequest.review_decision,
+    issueComments,
+    reviewComments,
+    reviews,
+    files,
+    labels
+  };
+  const continuity = evaluateExecutionContinuity({
+    mode: TaskMode.EXECUTION,
+    actorRole: ActorRole.EXECUTOR,
+    runtimeTruth: {
+      runtimeState: {
+        pullRequest: runtimePullRequest
+      }
+    }
+  });
+  if (!continuity.ok) {
+    console.log(`Skipping PR #${pullNumber}: continuity failed: ${continuity.reason || continuity.error}`);
+    return;
+  }
+
+  const evaluation = evaluateApproveAutoMerge({
+    policyMode,
+    labels,
+    pullRequest: {
+      ...runtimePullRequest,
+      issueNumber: extractIssueNumber(pullRequest.body)
+    },
+    reviewLoop: continuity.value.reviewLoop,
+    checkRuns: checkRunsResponse.check_runs || [],
+    requiredChecks: env.VTDD_AUTO_MERGE_REQUIRED_CHECKS
+  });
+
+  const contextPull = {
+    repository,
+    number: pullRequest.number,
+    issueNumber: extractIssueNumber(pullRequest.body),
+    body: pullRequest.body,
+    state: pullRequest.state,
+    draft: pullRequest.draft,
+    headSha: pullRequest.head?.sha,
+    mergeable: pullRequest.mergeable,
+    mergeableState: pullRequest.mergeable_state
+  };
+
+  if (!evaluation.allowed) {
+    if (policyMode === "approve_auto_merge" && shouldPostBlockedComment({ evaluation, issueComments, headSha: pullRequest.head?.sha })) {
+      await githubFetch(`/repos/${repository}/issues/${pullNumber}/comments`, {
+        method: "POST",
+        body: {
+          body: formatApproveAutoMergeBlockedComment({
+            pullRequest: contextPull,
+            evaluation
+          })
+        }
+      });
+      await notifyDashboardEvent({
+        env,
+        repository,
+        pullRequest,
+        title: `自動マージ停止: PR #${pullNumber}`,
+        status: "completed",
+        conclusion: "action_required"
+      });
+      console.log(`Posted approve auto merge blocked evidence on PR #${pullNumber}.`);
+    } else {
+      console.log(`Skipping PR #${pullNumber}: ${evaluation.reasons.join("; ")}`);
+    }
+    return;
+  }
+
+  if (hasExecutedAutoMergeComment({ issueComments, headSha: pullRequest.head?.sha })) {
+    console.log(`Skipping PR #${pullNumber}: auto merge already executed for this head.`);
+    return;
+  }
+
+  if (!hasCandidateAutoMergeComment({ issueComments, headSha: pullRequest.head?.sha })) {
+    await githubFetch(`/repos/${repository}/issues/${pullNumber}/comments`, {
+      method: "POST",
+      body: {
+        body: formatApproveAutoMergeCandidateComment({
+          pullRequest: contextPull,
+          evaluation
+        })
+      }
+    });
+    await notifyDashboardEvent({
+      env,
+      repository,
+      pullRequest,
+      title: `自動マージ候補: PR #${pullNumber}`,
+      status: "in_progress",
+      conclusion: ""
+    });
+  }
+
+  const mergeMethod = normalizeMergeMethod(env.VTDD_AUTO_MERGE_METHOD) || "squash";
+  const mergeResult = await githubFetch(`/repos/${repository}/pulls/${pullNumber}/merge`, {
+    method: "PUT",
+    body: {
+      merge_method: mergeMethod,
+      commit_title: `自動マージ: PR #${pullNumber} ${pullRequest.title || ""}`.trim(),
+      commit_message: [
+        "VTDD approve_auto_merge により自動マージしました。",
+        "",
+        `検索語: 自動マージ`,
+        `Repository: ${repository}`,
+        `PR: #${pullNumber}`,
+        `Head SHA: ${pullRequest.head?.sha || "unknown"}`,
+        `Triggered by: ${eventName || "unknown"}`
+      ].join("\n")
+    }
+  });
+
+  await githubFetch(`/repos/${repository}/issues/${pullNumber}/comments`, {
+    method: "POST",
+    body: {
+      body: formatApproveAutoMergeExecutedComment({
+        pullRequest: contextPull,
+        evaluation,
+        mergeResult
+      })
+    }
+  });
+
+  await notifyDashboardEvent({
+    env,
+    repository,
+    pullRequest,
+    title: `自動マージ完了: PR #${pullNumber}`,
+    status: "completed",
+    conclusion: "success"
+  });
+
+  console.log(`Auto-merged PR #${pullNumber}: ${mergeResult.sha || "sha unknown"}.`);
+}
+
+async function notifyDashboardEvent({ env, repository, pullRequest, title, status, conclusion }) {
+  const runtimeUrl = String(env.VTDD_RUNTIME_URL || "").trim();
+  const token = String(env.VTDD_GATEWAY_BEARER_TOKEN || "").trim();
+  if (!runtimeUrl || !token) {
+    console.log("Skipping dashboard event notification: VTDD_RUNTIME_URL or VTDD_GATEWAY_BEARER_TOKEN is missing.");
+    return;
+  }
+  const endpoint = new URL("/v2/events/github-actions", runtimeUrl);
+  const runUrl = [
+    env.GITHUB_SERVER_URL || "https://github.com",
+    repository,
+    "actions/runs",
+    env.GITHUB_RUN_ID || ""
+  ].filter(Boolean).join("/");
+  const response = await fetch(endpoint, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${token}`,
+      "content-type": "application/json"
+    },
+    body: JSON.stringify({
+      repository,
+      workflowName: "approve-auto-merge",
+      runId: env.GITHUB_RUN_ID || `approve-auto-merge-pr-${pullRequest.number}`,
+      runUrl,
+      status,
+      conclusion: conclusion || undefined,
+      headSha: pullRequest.head?.sha,
+      headBranch: pullRequest.head?.ref,
+      displayTitle: title,
+      updatedAt: new Date().toISOString()
+    })
+  });
+  if (!response.ok) {
+    const text = await response.text();
+    console.log(`Dashboard event notification failed with HTTP ${response.status}: ${text.slice(0, 240)}`);
+  }
+}
+
+function resolvePullNumbers({ payload, env }) {
+  const explicit = normalizePositiveInteger(env.TARGET_PR_NUMBER);
+  if (explicit) {
+    return [explicit];
+  }
+  const pullNumbers = new Set();
+  if (normalizePositiveInteger(payload?.pull_request?.number)) {
+    pullNumbers.add(Number(payload.pull_request.number));
+  }
+  if (payload?.issue?.pull_request && normalizePositiveInteger(payload?.issue?.number)) {
+    pullNumbers.add(Number(payload.issue.number));
+  }
+  for (const pull of payload?.workflow_run?.pull_requests || []) {
+    if (normalizePositiveInteger(pull?.number)) {
+      pullNumbers.add(Number(pull.number));
+    }
+  }
+  return [...pullNumbers];
+}
+
+function shouldPostBlockedComment({ evaluation, issueComments, headSha }) {
+  if (evaluation.reasons.includes("latest trusted reviewer action is not approve.")) {
+    return false;
+  }
+  if (evaluation.reasons.includes("reviewer evidence head SHA is missing.")) {
+    return false;
+  }
+  return !issueComments.some(
+    (comment) =>
+      String(comment?.body || "").includes(APPROVE_AUTO_MERGE_BLOCKED_MARKER) &&
+      String(comment?.body || "").includes(String(headSha || ""))
+  );
+}
+
+function hasCandidateAutoMergeComment({ issueComments, headSha }) {
+  return issueComments.some(
+    (comment) =>
+      String(comment?.body || "").includes(APPROVE_AUTO_MERGE_CANDIDATE_MARKER) &&
+      String(comment?.body || "").includes(String(headSha || ""))
+  );
+}
+
+function hasExecutedAutoMergeComment({ issueComments, headSha }) {
+  return issueComments.some(
+    (comment) =>
+      String(comment?.body || "").includes(APPROVE_AUTO_MERGE_EXECUTED_MARKER) &&
+      String(comment?.body || "").includes(String(headSha || ""))
+  );
+}
+
+function extractIssueNumber(body) {
+  const match = String(body || "").match(/(?:Issue|Related Issue|Closes)\s+#([0-9]+)/i);
+  return normalizePositiveInteger(match?.[1]);
+}
+
+function normalizeMergeMethod(value) {
+  const normalized = String(value || "").trim().toLowerCase();
+  return ["merge", "squash", "rebase"].includes(normalized) ? normalized : null;
+}
+
+function normalizePositiveInteger(value) {
+  const numeric = Number(value);
+  return Number.isInteger(numeric) && numeric > 0 ? numeric : null;
+}
+
+function normalizeLabels(value) {
+  return (Array.isArray(value) ? value : [])
+    .map((label) => String(typeof label === "string" ? label : label?.name || "").trim().toLowerCase())
+    .filter(Boolean);
+}
+
+async function githubFetchAll(githubFetch, firstPath) {
+  const records = [];
+  let path = firstPath;
+  for (let page = 0; page < 10 && path; page += 1) {
+    const result = await githubFetch(path, { includeHeaders: true });
+    const body = Array.isArray(result.body) ? result.body : [];
+    records.push(...body);
+    path = parseNextPath(result.headers.get("link"));
+  }
+  return records;
+}
+
+function parseNextPath(linkHeader) {
+  const link = String(linkHeader || "");
+  const match = link
+    .split(",")
+    .map((part) => part.trim())
+    .find((part) => part.includes('rel="next"'))
+    ?.match(/<([^>]+)>/);
+  if (!match) {
+    return null;
+  }
+  const url = new URL(match[1]);
+  return `${url.pathname}${url.search}`;
+}
+
+function createGitHubFetch({ apiBaseUrl, token }) {
+  return async function githubFetch(pathname, init = {}) {
+    const response = await fetch(`${apiBaseUrl}${pathname}`, {
+      method: init.method || "GET",
+      headers: {
+        accept: "application/vnd.github+json",
+        authorization: `Bearer ${token}`,
+        "content-type": "application/json",
+        "x-github-api-version": "2022-11-28",
+        "user-agent": "vtdd-v2-approve-auto-merge"
+      },
+      body: init.body ? JSON.stringify(init.body) : undefined
+    });
+    const text = await response.text();
+    const body = text ? JSON.parse(text) : null;
+    if (!response.ok) {
+      throw new Error(`GitHub API ${response.status}: ${body?.message || text}`);
+    }
+    if (init.includeHeaders) {
+      return { body, headers: response.headers };
+    }
+    return body;
+  };
+}
+
+function mustGetEnv(name) {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`${name} is required`);
+  }
+  return value;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}

--- a/src/core/approve-auto-merge.js
+++ b/src/core/approve-auto-merge.js
@@ -1,0 +1,407 @@
+import { normalizeText } from "./text-normalization.js";
+
+export const ApproveAutoMergePolicyMode = Object.freeze({
+  MANUAL: "manual",
+  APPROVE_AUTO_MERGE: "approve_auto_merge"
+});
+
+export const APPROVE_AUTO_MERGE_CANDIDATE_MARKER = "<!-- vtdd:auto-merge=candidate -->";
+export const APPROVE_AUTO_MERGE_BLOCKED_MARKER = "<!-- vtdd:auto-merge=blocked -->";
+export const APPROVE_AUTO_MERGE_EXECUTED_MARKER = "<!-- vtdd:auto-merge=executed -->";
+
+const DEFAULT_REQUIRED_CHECKS = ["guarded-policy", "test", "review"];
+const AUTO_MERGE_LABELS = new Set(["approve_auto_merge", "vtdd:auto-merge", "auto-merge"]);
+
+export function resolveApproveAutoMergePolicy(input = {}) {
+  const explicit = normalizePolicyMode(input.policyMode || input.mode || input.envPolicy);
+  if (explicit) {
+    return explicit;
+  }
+  const labels = normalizeLabels(input.labels);
+  if (labels.some((label) => AUTO_MERGE_LABELS.has(label))) {
+    return ApproveAutoMergePolicyMode.APPROVE_AUTO_MERGE;
+  }
+  return ApproveAutoMergePolicyMode.MANUAL;
+}
+
+export function evaluateApproveAutoMerge(input = {}) {
+  const policyMode = resolveApproveAutoMergePolicy({
+    policyMode: input.policyMode,
+    labels: input.labels
+  });
+  const pullRequest = normalizePullRequest(input.pullRequest);
+  const reviewLoop = normalizeReviewLoop(input.reviewLoop);
+  const requiredChecks = normalizeRequiredChecks(input.requiredChecks);
+  const checkRuns = normalizeCheckRuns(input.checkRuns);
+  const checkTruth = evaluateRequiredChecks({ checkRuns, requiredChecks });
+  const reasons = [];
+  const evidence = [];
+
+  if (policyMode !== ApproveAutoMergePolicyMode.APPROVE_AUTO_MERGE) {
+    reasons.push("approve_auto_merge policy is not enabled for this repository, Issue, or PR.");
+  }
+  if (!pullRequest.exists) {
+    reasons.push("pull request runtime truth is missing.");
+  }
+  if (pullRequest.state && pullRequest.state !== "open") {
+    reasons.push(`pull request state is ${pullRequest.state}, not open.`);
+  }
+  if (pullRequest.draft) {
+    reasons.push("pull request is still draft.");
+  }
+  if (!pullRequest.number) {
+    reasons.push("pull request number is missing.");
+  }
+  if (!pullRequest.headSha) {
+    reasons.push("pull request head SHA is missing.");
+  }
+  if (!pullRequest.issueNumber) {
+    reasons.push("related Issue number is missing.");
+  }
+  if (pullRequest.mergeConflict || pullRequest.mergeability.status === "conflict") {
+    reasons.push("runtime truth shows merge conflicts.");
+  }
+  if (!pullRequest.mergeability.verified) {
+    reasons.push("pull request mergeability is unverified.");
+  }
+  if (pullRequest.mergeability.verified && pullRequest.mergeability.mergeable !== true) {
+    reasons.push("pull request is not mergeable.");
+  }
+  if (
+    pullRequest.mergeability.mergeableState &&
+    !["clean", "has_hooks", "unstable"].includes(pullRequest.mergeability.mergeableState)
+  ) {
+    reasons.push(`pull request mergeable_state is ${pullRequest.mergeability.mergeableState}.`);
+  }
+  if (pullRequest.updatedSinceReview) {
+    reasons.push("pull request changed after the latest reviewer evidence.");
+  }
+
+  if (reviewLoop.reviewerSignalTruth?.mergeReviewTruth?.satisfied !== true) {
+    reasons.push("reviewer merge truth is not satisfied.");
+  }
+  if (reviewLoop.reviewerSignalTruth?.mergeReviewTruth?.blocked === true) {
+    reasons.push("reviewer merge truth is blocked.");
+  }
+  if (reviewLoop.unresolvedReviewCommentsCount > 0) {
+    reasons.push("unresolved reviewer objections remain.");
+  }
+  if (reviewLoop.criticalReviewPending) {
+    reasons.push("critical review is still pending.");
+  }
+  if (reviewLoop.reviewerEvidence?.recommendedAction !== "approve") {
+    reasons.push("latest trusted reviewer action is not approve.");
+  }
+  if (!reviewLoop.reviewerEvidence?.headSha) {
+    reasons.push("reviewer evidence head SHA is missing.");
+  }
+  if (
+    reviewLoop.reviewerEvidence?.headSha &&
+    pullRequest.headSha &&
+    reviewLoop.reviewerEvidence.headSha !== pullRequest.headSha
+  ) {
+    reasons.push("reviewer evidence head SHA does not match current PR head SHA.");
+  }
+  if (reviewLoop.hasRunawayIncident) {
+    reasons.push("reviewer runaway incident is present.");
+  }
+  if (reviewLoop.hasActorIdentityIncident) {
+    reasons.push("actor identity incident is present.");
+  }
+  if (!checkTruth.satisfied) {
+    reasons.push(...checkTruth.reasons);
+  }
+
+  evidence.push(`policy=${policyMode}`);
+  evidence.push(`repo=${pullRequest.repository || "unknown"}`);
+  evidence.push(`pr=${pullRequest.number || "unknown"}`);
+  evidence.push(`issue=${pullRequest.issueNumber || "unknown"}`);
+  evidence.push(`headSha=${pullRequest.headSha || "unknown"}`);
+  evidence.push(`reviewer=${reviewLoop.reviewer || "unknown"}`);
+  evidence.push(`reviewerAction=${reviewLoop.reviewerEvidence?.recommendedAction || "none"}`);
+  evidence.push(`reviewerHeadSha=${reviewLoop.reviewerEvidence?.headSha || "unknown"}`);
+  evidence.push(`mergeable=${String(pullRequest.mergeability.mergeable)}`);
+  evidence.push(`mergeableState=${pullRequest.mergeability.mergeableState || "unknown"}`);
+  evidence.push(`checks=${checkTruth.summary}`);
+
+  return {
+    allowed: reasons.length === 0,
+    policyMode,
+    reasons,
+    evidence,
+    requiredChecks,
+    checkTruth,
+    searchKeyword: "自動マージ"
+  };
+}
+
+export function formatApproveAutoMergeCandidateComment(input = {}) {
+  const evaluation = input.evaluation || {};
+  const pullRequest = normalizePullRequest(input.pullRequest);
+  const lines = [
+    APPROVE_AUTO_MERGE_CANDIDATE_MARKER,
+    "## VTDD 自動マージ候補",
+    "",
+    "この PR は `approve_auto_merge` policy の gate を通過しました。merge 実行前の証跡として残します。",
+    "",
+    "- 検索語: `自動マージ`",
+    `- Repository: \`${pullRequest.repository || "unknown"}\``,
+    `- PR: \`#${pullRequest.number || "unknown"}\``,
+    `- Issue: \`#${pullRequest.issueNumber || "unknown"}\``,
+    `- Head SHA: \`${pullRequest.headSha || "unknown"}\``,
+    "",
+    "### 判定根拠",
+    ...formatList(evaluation.evidence),
+    "",
+    "_Reviewer approve 単体ではなく、checks / mergeability / SHA / reviewer objection / incident gate を通過した場合のみ自動マージします。_"
+  ];
+  return lines.join("\n");
+}
+
+export function formatApproveAutoMergeBlockedComment(input = {}) {
+  const evaluation = input.evaluation || {};
+  const pullRequest = normalizePullRequest(input.pullRequest);
+  const lines = [
+    APPROVE_AUTO_MERGE_BLOCKED_MARKER,
+    "## VTDD 自動マージ停止",
+    "",
+    "この PR は `approve_auto_merge` policy 対象ですが、自動マージ gate を通過しませんでした。",
+    "",
+    "- 検索語: `自動マージ`",
+    `- Repository: \`${pullRequest.repository || "unknown"}\``,
+    `- PR: \`#${pullRequest.number || "unknown"}\``,
+    `- Issue: \`#${pullRequest.issueNumber || "unknown"}\``,
+    `- Head SHA: \`${pullRequest.headSha || "unknown"}\``,
+    "",
+    "### 停止理由",
+    ...formatList(evaluation.reasons),
+    "",
+    "### 判定根拠",
+    ...formatList(evaluation.evidence),
+    "",
+    "_必要なら owner が手動 GO / passkey merge path で判断してください。_"
+  ];
+  return lines.join("\n");
+}
+
+export function formatApproveAutoMergeExecutedComment(input = {}) {
+  const evaluation = input.evaluation || {};
+  const pullRequest = normalizePullRequest(input.pullRequest);
+  const mergeResult = input.mergeResult && typeof input.mergeResult === "object" ? input.mergeResult : {};
+  const lines = [
+    APPROVE_AUTO_MERGE_EXECUTED_MARKER,
+    "## VTDD 自動マージ実行済み",
+    "",
+    "この PR は `approve_auto_merge` policy により自動マージされました。",
+    "",
+    "- 検索語: `自動マージ`",
+    `- Repository: \`${pullRequest.repository || "unknown"}\``,
+    `- PR: \`#${pullRequest.number || "unknown"}\``,
+    `- Issue: \`#${pullRequest.issueNumber || "unknown"}\``,
+    `- Head SHA: \`${pullRequest.headSha || "unknown"}\``,
+    `- Merge SHA: \`${normalizeText(mergeResult.sha) || "unknown"}\``,
+    `- Merge message: ${normalizeText(mergeResult.message) || "unknown"}`,
+    "",
+    "### 判定根拠",
+    ...formatList(evaluation.evidence),
+    "",
+    "### RAG 保存候補",
+    "",
+    "```json",
+    JSON.stringify(buildApproveAutoMergeMemoryCandidate({ evaluation, pullRequest, mergeResult }), null, 2),
+    "```",
+    "",
+    "_問題が起きた場合は `自動マージ` で検索し、このコメントから判断根拠を辿ってください。_"
+  ];
+  return lines.join("\n");
+}
+
+function buildApproveAutoMergeMemoryCandidate({ evaluation, pullRequest, mergeResult }) {
+  return {
+    recordType: "working_memory",
+    summary: `自動マージ実行: ${pullRequest.repository || "unknown"} PR #${pullRequest.number || "unknown"}`,
+    relatedIssue: pullRequest.issueNumber || null,
+    repository: pullRequest.repository || null,
+    details: [
+      "approve_auto_merge policy により、reviewer approve / checks / mergeability / head SHA / objection / incident gate を通過したため自動マージした。",
+      `PR: #${pullRequest.number || "unknown"}`,
+      `Head SHA: ${pullRequest.headSha || "unknown"}`,
+      `Merge SHA: ${normalizeText(mergeResult.sha) || "unknown"}`,
+      `Evidence: ${(Array.isArray(evaluation.evidence) ? evaluation.evidence : []).join("; ")}`
+    ].join("\n"),
+    tags: [
+      "auto_merge",
+      "自動マージ",
+      "approve_auto_merge",
+      pullRequest.repository ? `repo:${pullRequest.repository}` : null,
+      pullRequest.issueNumber ? `issue:${pullRequest.issueNumber}` : null,
+      pullRequest.number ? `pr:${pullRequest.number}` : null
+    ].filter(Boolean),
+    priority: 75
+  };
+}
+
+function evaluateRequiredChecks({ checkRuns, requiredChecks }) {
+  const reasons = [];
+  const byName = new Map();
+  for (const check of checkRuns) {
+    const existing = byName.get(check.name);
+    if (!existing || check.startedAt > existing.startedAt) {
+      byName.set(check.name, check);
+    }
+  }
+
+  for (const name of requiredChecks) {
+    const check = byName.get(name);
+    if (!check) {
+      reasons.push(`required check ${name} is missing.`);
+      continue;
+    }
+    if (check.status !== "completed") {
+      reasons.push(`required check ${name} is ${check.status || "unknown"}, not completed.`);
+      continue;
+    }
+    if (check.conclusion !== "success") {
+      reasons.push(`required check ${name} conclusion is ${check.conclusion || "unknown"}, not success.`);
+    }
+  }
+
+  return {
+    satisfied: reasons.length === 0,
+    reasons,
+    summary: requiredChecks
+      .map((name) => {
+        const check = byName.get(name);
+        return `${name}:${check?.status || "missing"}/${check?.conclusion || "none"}`;
+      })
+      .join(", ")
+  };
+}
+
+function normalizePullRequest(value) {
+  const input = value && typeof value === "object" ? value : {};
+  const labels = normalizeLabels(input.labels);
+  const issueNumber = normalizePositiveInteger(input.issueNumber) || extractIssueNumber(input.body);
+  const mergeable = typeof input.mergeable === "boolean" ? input.mergeable : normalizeNullableBoolean(input.mergeability?.mergeable);
+  const mergeableState =
+    normalizeText(input.mergeableState) ||
+    normalizeText(input.mergeable_state) ||
+    normalizeText(input.mergeability?.state) ||
+    normalizeText(input.mergeability?.mergeableState);
+  const mergeConflict =
+    input.mergeConflict === true ||
+    input.mergeability?.hasConflict === true ||
+    mergeable === false ||
+    mergeableState === "dirty";
+  const verified = typeof mergeable === "boolean" || Boolean(mergeableState);
+  return {
+    exists:
+      Boolean(normalizePositiveInteger(input.number)) ||
+      Boolean(normalizeText(input.url)) ||
+      Boolean(normalizeText(input.state)),
+    repository: normalizeText(input.repository) || null,
+    number: normalizePositiveInteger(input.number),
+    issueNumber,
+    url: normalizeText(input.url) || null,
+    body: normalizeText(input.body) || null,
+    state: normalizeText(input.state).toLowerCase() || "open",
+    draft: input.draft === true,
+    headSha: normalizeText(input.headSha) || normalizeText(input.head?.sha) || null,
+    labels,
+    updatedSinceReview: input.updatedSinceReview === true,
+    mergeConflict,
+    mergeability: {
+      verified,
+      status: mergeConflict ? "conflict" : verified ? "verified" : "unverified",
+      mergeable,
+      mergeableState: mergeableState || null
+    }
+  };
+}
+
+function normalizeReviewLoop(value) {
+  const input = value && typeof value === "object" ? value : {};
+  const reviewerEvidence = input.reviewerEvidence && typeof input.reviewerEvidence === "object"
+    ? input.reviewerEvidence
+    : {};
+  const timeline = Array.isArray(input.reviewTimeline) ? input.reviewTimeline : [];
+  return {
+    reviewer: normalizeText(input.reviewer) || "gemini",
+    reviewerEvidence: {
+      recommendedAction: normalizeText(reviewerEvidence.recommendedAction).toLowerCase() || null,
+      headSha: normalizeText(reviewerEvidence.headSha) || null,
+      url: normalizeText(reviewerEvidence.url) || null
+    },
+    reviewerSignalTruth: input.reviewerSignalTruth && typeof input.reviewerSignalTruth === "object"
+      ? input.reviewerSignalTruth
+      : null,
+    unresolvedReviewCommentsCount: normalizeCount(input.unresolvedReviewCommentsCount),
+    criticalReviewPending: input.criticalReviewPending === true,
+    hasRunawayIncident: timeline.some((item) => normalizeText(item?.type) === "reviewer_runaway"),
+    hasActorIdentityIncident: timeline.some((item) => normalizeText(item?.type) === "vtdd_incident")
+  };
+}
+
+function normalizeRequiredChecks(value) {
+  const list = Array.isArray(value) ? value : String(value ?? "").split(",");
+  const normalized = list.map(normalizeText).filter(Boolean);
+  return normalized.length > 0 ? normalized : DEFAULT_REQUIRED_CHECKS;
+}
+
+function normalizeCheckRuns(value) {
+  return (Array.isArray(value) ? value : [])
+    .map((item) => {
+      const name = normalizeText(item?.name);
+      if (!name) {
+        return null;
+      }
+      return {
+        name,
+        status: normalizeText(item?.status).toLowerCase() || null,
+        conclusion: normalizeText(item?.conclusion).toLowerCase() || null,
+        startedAt: Date.parse(normalizeText(item?.startedAt ?? item?.started_at)) || 0
+      };
+    })
+    .filter(Boolean);
+}
+
+function normalizePolicyMode(value) {
+  const normalized = normalizeText(value).toLowerCase();
+  if (normalized === ApproveAutoMergePolicyMode.APPROVE_AUTO_MERGE) {
+    return ApproveAutoMergePolicyMode.APPROVE_AUTO_MERGE;
+  }
+  if (normalized === ApproveAutoMergePolicyMode.MANUAL) {
+    return ApproveAutoMergePolicyMode.MANUAL;
+  }
+  return null;
+}
+
+function normalizeLabels(value) {
+  return (Array.isArray(value) ? value : [])
+    .map((label) => normalizeText(typeof label === "string" ? label : label?.name).toLowerCase())
+    .filter(Boolean);
+}
+
+function normalizeNullableBoolean(value) {
+  return typeof value === "boolean" ? value : null;
+}
+
+function normalizePositiveInteger(value) {
+  const numeric = Number(value);
+  return Number.isInteger(numeric) && numeric > 0 ? numeric : null;
+}
+
+function normalizeCount(value) {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) && numeric > 0 ? Math.floor(numeric) : 0;
+}
+
+function extractIssueNumber(body) {
+  const match = normalizeText(body).match(/(?:Issue|Related Issue|Closes)\s+#([0-9]+)/i);
+  return normalizePositiveInteger(match?.[1]);
+}
+
+function formatList(items, fallback = "- なし。") {
+  const list = (Array.isArray(items) ? items : []).map(normalizeText).filter(Boolean);
+  return list.length > 0 ? list.map((item) => `- ${item}`) : [fallback];
+}

--- a/src/core/butler-review-synthesis.js
+++ b/src/core/butler-review-synthesis.js
@@ -358,6 +358,9 @@ function normalizeReviewerSignalTruth(value) {
     canonicalReviewer: normalizeText(input.canonicalReviewer) || null,
     reviewerStatus: normalizeText(input.reviewerStatus) || null,
     recommendedAction: normalizeText(input.recommendedAction) || null,
+    ...(normalizeText(input.reviewerHeadSha)
+      ? { reviewerHeadSha: normalizeText(input.reviewerHeadSha) }
+      : {}),
     vtddReviewerMarkerPresent: input.vtddReviewerMarkerPresent === true,
     githubFormalReview: {
       source: normalizeText(formal.source) || "github_formal_review_objects",
@@ -386,6 +389,7 @@ function normalizeReviewerEvidence(value) {
   return {
     reviewer: normalizeText(input.reviewer) || null,
     recommendedAction,
+    ...(normalizeText(input.headSha) ? { headSha: normalizeText(input.headSha) } : {}),
     url: normalizeText(input.url) || null,
     createdAt: normalizeText(input.createdAt) || null,
     updatedAt: normalizeText(input.updatedAt) || null,

--- a/src/core/codex-review-fallback.js
+++ b/src/core/codex-review-fallback.js
@@ -80,6 +80,7 @@ export function parseCodexReviewFallbackComment(comment = {}) {
     extractBacktickedValue(body, "Status") ||
     (body.includes("@codex review") ? CodexReviewFallbackStatus.REQUESTED : "");
   const recommendedAction = extractBacktickedValue(body, "Recommended action");
+  const headSha = extractBacktickedValue(body, "Head SHA");
   const blocker = extractBacktickedValue(body, "Blocker");
 
   return {
@@ -91,6 +92,7 @@ export function parseCodexReviewFallbackComment(comment = {}) {
       blocker
     }),
     recommendedAction: recommendedAction || null,
+    ...(headSha ? { headSha } : {}),
     blocker: blocker || null,
     body
   };

--- a/src/core/execution-continuity.js
+++ b/src/core/execution-continuity.js
@@ -244,9 +244,10 @@ function collectCodexFallbackSignals(pullRequest) {
     blocked: latest?.status === "blocked",
     blocking: latest?.blocking === true,
     latestEvidence: latest?.status === "completed"
-      ? {
+        ? {
           reviewer: "codex",
           recommendedAction: latest.recommendedAction || "manual_review",
+          ...(latest.headSha ? { headSha: latest.headSha } : {}),
           url: latest.url || null,
           createdAt: latest.createdAt || null,
           updatedAt: latest.updatedAt || null,
@@ -275,6 +276,7 @@ function buildReviewTimelineItem(comment) {
       reviewer: "gemini",
       status: gemini.recommendedAction,
       recommendedAction: gemini.recommendedAction,
+      ...(gemini.headSha ? { headSha: gemini.headSha } : {}),
       blocking: gemini.blocking === true,
       url: gemini.url || normalizeCommentUrl(comment),
       createdAt: gemini.createdAt || normalizeCommentCreatedAt(comment),
@@ -292,6 +294,7 @@ function buildReviewTimelineItem(comment) {
       reviewer: "codex",
       status: codex.status,
       recommendedAction: codex.recommendedAction || null,
+      ...(codex.headSha ? { headSha: codex.headSha } : {}),
       blocking: codex.blocking === true,
       url: normalizeCommentUrl(comment),
       createdAt: normalizeCommentCreatedAt(comment),
@@ -481,6 +484,9 @@ function buildReviewerSignalTruth({ reviewer, reviewerStatus, reviewerEvidence, 
     canonicalReviewer: vtddReviewerMarkerPresent ? reviewer : null,
     reviewerStatus,
     recommendedAction,
+    ...(normalizeText(reviewerEvidence?.headSha)
+      ? { reviewerHeadSha: normalizeText(reviewerEvidence?.headSha) }
+      : {}),
     vtddReviewerMarkerPresent,
     githubFormalReview: formalReviewTruth,
     mergeReviewTruth: {

--- a/src/core/gemini-pr-review.js
+++ b/src/core/gemini-pr-review.js
@@ -527,6 +527,8 @@ export function parseGeminiReviewComment(comment = {}) {
 
   const recommendedActionMatch = body.match(/^- Recommended action:\s*`([^`]+)`/m);
   const recommendedAction = normalizeText(recommendedActionMatch?.[1]).toLowerCase() || "manual_review";
+  const headShaMatch = body.match(/^- Head SHA:\s*`([^`]+)`/m);
+  const headSha = normalizeText(headShaMatch?.[1]) || null;
   const source = typeof comment === "object" && comment !== null ? comment : {};
   const createdAt = normalizeText(source.createdAt ?? source.created_at);
   const updatedAt = normalizeText(source.updatedAt ?? source.updated_at);
@@ -534,6 +536,7 @@ export function parseGeminiReviewComment(comment = {}) {
   return {
     reviewer: "gemini",
     recommendedAction,
+    ...(headSha ? { headSha } : {}),
     criticalFindings: extractFirstMarkdownListSection(body, ["### 重要指摘", "### Critical Findings"]),
     risks: extractFirstMarkdownListSection(body, ["### 残リスク", "### Risks"]),
     blocking:

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -175,6 +175,17 @@ export {
   evaluateExecutionContinuity
 } from "./execution-continuity.js";
 export {
+  APPROVE_AUTO_MERGE_BLOCKED_MARKER,
+  APPROVE_AUTO_MERGE_CANDIDATE_MARKER,
+  APPROVE_AUTO_MERGE_EXECUTED_MARKER,
+  ApproveAutoMergePolicyMode,
+  evaluateApproveAutoMerge,
+  formatApproveAutoMergeBlockedComment,
+  formatApproveAutoMergeCandidateComment,
+  formatApproveAutoMergeExecutedComment,
+  resolveApproveAutoMergePolicy
+} from "./approve-auto-merge.js";
+export {
   REMOTE_CODEX_WORKFLOW_FILE,
   RemoteCodexDispatchGoal,
   RemoteCodexExecutorTransport,

--- a/test/approve-auto-merge-workflow.test.js
+++ b/test/approve-auto-merge-workflow.test.js
@@ -1,0 +1,29 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const workflow = fs.readFileSync(".github/workflows/approve-auto-merge.yml", "utf8");
+const script = fs.readFileSync("scripts/run-approve-auto-merge.mjs", "utf8");
+
+test("approve auto merge workflow runs from trusted main and uses App token", () => {
+  assert.equal(workflow.includes("name: approve-auto-merge"), true);
+  assert.equal(workflow.includes("workflow_run:"), true);
+  assert.equal(workflow.includes("guarded-autonomy-required-checks"), true);
+  assert.equal(workflow.includes("gemini-pr-review"), true);
+  assert.equal(workflow.includes("codex-pr-review-fallback"), true);
+  assert.equal(workflow.includes("uses: actions/create-github-app-token@v1"), true);
+  assert.equal(workflow.includes("ref: main"), true);
+  assert.equal(workflow.includes("VTDD_RUNTIME_URL"), true);
+  assert.equal(workflow.includes("VTDD_GATEWAY_BEARER_TOKEN"), true);
+  assert.equal(workflow.includes("node scripts/run-approve-auto-merge.mjs"), true);
+});
+
+test("approve auto merge script records searchable evidence before and after merge", () => {
+  assert.equal(script.includes("formatApproveAutoMergeCandidateComment"), true);
+  assert.equal(script.includes("formatApproveAutoMergeExecutedComment"), true);
+  assert.equal(script.includes("自動マージ"), true);
+  assert.equal(script.includes("/merge"), true);
+  assert.equal(script.includes("/v2/events/github-actions"), true);
+  assert.equal(script.includes("notifyDashboardEvent"), true);
+  assert.equal(script.includes("evaluateApproveAutoMerge"), true);
+});

--- a/test/approve-auto-merge.test.js
+++ b/test/approve-auto-merge.test.js
@@ -1,0 +1,150 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  APPROVE_AUTO_MERGE_CANDIDATE_MARKER,
+  APPROVE_AUTO_MERGE_EXECUTED_MARKER,
+  ApproveAutoMergePolicyMode,
+  evaluateApproveAutoMerge,
+  formatApproveAutoMergeCandidateComment,
+  formatApproveAutoMergeExecutedComment,
+  parseGeminiReviewComment,
+  resolveApproveAutoMergePolicy
+} from "../src/core/index.js";
+
+const approvedReviewLoop = {
+  reviewer: "gemini",
+  reviewerEvidence: {
+    recommendedAction: "approve",
+    headSha: "abc123",
+    url: "https://github.com/sample-org/vtdd-v2-p/pull/10#issuecomment-1"
+  },
+  reviewerSignalTruth: {
+    mergeReviewTruth: {
+      satisfied: true,
+      blocked: false,
+      reason: "vtdd_reviewer_marker_approve_no_formal_blocker"
+    }
+  },
+  unresolvedReviewCommentsCount: 0,
+  criticalReviewPending: false,
+  reviewTimeline: [
+    {
+      type: "gemini_review",
+      recommendedAction: "approve",
+      headSha: "abc123"
+    }
+  ]
+};
+
+const mergeablePullRequest = {
+  repository: "sample-org/vtdd-v2-p",
+  number: 10,
+  issueNumber: 448,
+  state: "open",
+  draft: false,
+  headSha: "abc123",
+  mergeable: true,
+  mergeableState: "clean"
+};
+
+const successChecks = [
+  { name: "guarded-policy", status: "completed", conclusion: "success", startedAt: "2026-05-20T00:00:00Z" },
+  { name: "test", status: "completed", conclusion: "success", startedAt: "2026-05-20T00:00:01Z" },
+  { name: "review", status: "completed", conclusion: "success", startedAt: "2026-05-20T00:00:02Z" }
+];
+
+test("approve auto merge allows only fully gated approve PRs", () => {
+  const result = evaluateApproveAutoMerge({
+    policyMode: ApproveAutoMergePolicyMode.APPROVE_AUTO_MERGE,
+    pullRequest: mergeablePullRequest,
+    reviewLoop: approvedReviewLoop,
+    checkRuns: successChecks
+  });
+
+  assert.equal(result.allowed, true);
+  assert.equal(result.reasons.length, 0);
+  assert.equal(result.evidence.some((item) => item.includes("reviewerAction=approve")), true);
+  assert.equal(result.searchKeyword, "自動マージ");
+});
+
+test("approve auto merge blocks approve when required checks fail", () => {
+  const result = evaluateApproveAutoMerge({
+    policyMode: ApproveAutoMergePolicyMode.APPROVE_AUTO_MERGE,
+    pullRequest: mergeablePullRequest,
+    reviewLoop: approvedReviewLoop,
+    checkRuns: successChecks.map((check) =>
+      check.name === "test" ? { ...check, conclusion: "failure" } : check
+    )
+  });
+
+  assert.equal(result.allowed, false);
+  assert.equal(result.reasons.includes("required check test conclusion is failure, not success."), true);
+});
+
+test("approve auto merge blocks stale reviewer head SHA", () => {
+  const result = evaluateApproveAutoMerge({
+    policyMode: ApproveAutoMergePolicyMode.APPROVE_AUTO_MERGE,
+    pullRequest: { ...mergeablePullRequest, headSha: "new456" },
+    reviewLoop: approvedReviewLoop,
+    checkRuns: successChecks
+  });
+
+  assert.equal(result.allowed, false);
+  assert.equal(result.reasons.includes("reviewer evidence head SHA does not match current PR head SHA."), true);
+});
+
+test("approve auto merge remains opt-in by policy or labels", () => {
+  assert.equal(resolveApproveAutoMergePolicy({}), ApproveAutoMergePolicyMode.MANUAL);
+  assert.equal(
+    resolveApproveAutoMergePolicy({ labels: [{ name: "vtdd:auto-merge" }] }),
+    ApproveAutoMergePolicyMode.APPROVE_AUTO_MERGE
+  );
+});
+
+test("approve auto merge evidence comments are searchable by 自動マージ", () => {
+  const evaluation = evaluateApproveAutoMerge({
+    policyMode: ApproveAutoMergePolicyMode.APPROVE_AUTO_MERGE,
+    pullRequest: mergeablePullRequest,
+    reviewLoop: approvedReviewLoop,
+    checkRuns: successChecks
+  });
+  const candidate = formatApproveAutoMergeCandidateComment({
+    pullRequest: mergeablePullRequest,
+    evaluation
+  });
+  const executed = formatApproveAutoMergeExecutedComment({
+    pullRequest: mergeablePullRequest,
+    evaluation,
+    mergeResult: {
+      sha: "merge789",
+      message: "Pull Request successfully merged"
+    }
+  });
+
+  assert.equal(candidate.includes(APPROVE_AUTO_MERGE_CANDIDATE_MARKER), true);
+  assert.equal(candidate.includes("自動マージ"), true);
+  assert.equal(executed.includes(APPROVE_AUTO_MERGE_EXECUTED_MARKER), true);
+  assert.equal(executed.includes("merge789"), true);
+  assert.equal(executed.includes("自動マージ"), true);
+  assert.equal(executed.includes("RAG 保存候補"), true);
+  assert.equal(executed.includes('"recordType": "working_memory"'), true);
+  assert.equal(executed.includes('"auto_merge"'), true);
+});
+
+test("Gemini reviewer parser preserves reviewed head SHA for auto merge gate", () => {
+  const parsed = parseGeminiReviewComment({
+    body: [
+      "<!-- vtdd:reviewer=gemini -->",
+      "## VTDD Gemini レビュー",
+      "- Head SHA: `abc123`",
+      "- Recommended action: `approve`",
+      "### 重要指摘",
+      "- 重大 blocker は見つかりませんでした。",
+      "### 残リスク",
+      "- なし。"
+    ].join("\n")
+  });
+
+  assert.equal(parsed.recommendedAction, "approve");
+  assert.equal(parsed.headSha, "abc123");
+});

--- a/worker.js
+++ b/worker.js
@@ -28901,6 +28901,7 @@ function normalizeReviewerSignalTruth(value) {
     canonicalReviewer: normalizeText5(input.canonicalReviewer) || null,
     reviewerStatus: normalizeText5(input.reviewerStatus) || null,
     recommendedAction: normalizeText5(input.recommendedAction) || null,
+    ...normalizeText5(input.reviewerHeadSha) ? { reviewerHeadSha: normalizeText5(input.reviewerHeadSha) } : {},
     vtddReviewerMarkerPresent: input.vtddReviewerMarkerPresent === true,
     githubFormalReview: {
       source: normalizeText5(formal.source) || "github_formal_review_objects",
@@ -28928,6 +28929,7 @@ function normalizeReviewerEvidence(value) {
   return {
     reviewer: normalizeText5(input.reviewer) || null,
     recommendedAction,
+    ...normalizeText5(input.headSha) ? { headSha: normalizeText5(input.headSha) } : {},
     url: normalizeText5(input.url) || null,
     createdAt: normalizeText5(input.createdAt) || null,
     updatedAt: normalizeText5(input.updatedAt) || null,
@@ -35017,6 +35019,7 @@ function parseCodexReviewFallbackComment(comment = {}) {
   }
   const status = extractBacktickedValue(body, "Status") || (body.includes("@codex review") ? CodexReviewFallbackStatus.REQUESTED : "");
   const recommendedAction = extractBacktickedValue(body, "Recommended action");
+  const headSha = extractBacktickedValue(body, "Head SHA");
   const blocker = extractBacktickedValue(body, "Blocker");
   return {
     reviewer: "codex",
@@ -35027,6 +35030,7 @@ function parseCodexReviewFallbackComment(comment = {}) {
       blocker
     }),
     recommendedAction: recommendedAction || null,
+    ...headSha ? { headSha } : {},
     blocker: blocker || null,
     body
   };
@@ -35185,12 +35189,15 @@ function parseGeminiReviewComment(comment = {}) {
   }
   const recommendedActionMatch = body.match(/^- Recommended action:\s*`([^`]+)`/m);
   const recommendedAction = normalizeText20(recommendedActionMatch?.[1]).toLowerCase() || "manual_review";
+  const headShaMatch = body.match(/^- Head SHA:\s*`([^`]+)`/m);
+  const headSha = normalizeText20(headShaMatch?.[1]) || null;
   const source = typeof comment === "object" && comment !== null ? comment : {};
   const createdAt = normalizeText20(source.createdAt ?? source.created_at);
   const updatedAt = normalizeText20(source.updatedAt ?? source.updated_at);
   return {
     reviewer: "gemini",
     recommendedAction,
+    ...headSha ? { headSha } : {},
     criticalFindings: extractFirstMarkdownListSection(body, ["### \u91CD\u8981\u6307\u6458", "### Critical Findings"]),
     risks: extractFirstMarkdownListSection(body, ["### \u6B8B\u30EA\u30B9\u30AF", "### Risks"]),
     blocking: recommendedAction === "request_changes" || recommendedAction === "manual_review",
@@ -35505,6 +35512,7 @@ function collectCodexFallbackSignals(pullRequest) {
     latestEvidence: latest?.status === "completed" ? {
       reviewer: "codex",
       recommendedAction: latest.recommendedAction || "manual_review",
+      ...latest.headSha ? { headSha: latest.headSha } : {},
       url: latest.url || null,
       createdAt: latest.createdAt || null,
       updatedAt: latest.updatedAt || null,
@@ -35527,6 +35535,7 @@ function buildReviewTimelineItem(comment) {
       reviewer: "gemini",
       status: gemini.recommendedAction,
       recommendedAction: gemini.recommendedAction,
+      ...gemini.headSha ? { headSha: gemini.headSha } : {},
       blocking: gemini.blocking === true,
       url: gemini.url || normalizeCommentUrl(comment),
       createdAt: gemini.createdAt || normalizeCommentCreatedAt(comment),
@@ -35543,6 +35552,7 @@ function buildReviewTimelineItem(comment) {
       reviewer: "codex",
       status: codex.status,
       recommendedAction: codex.recommendedAction || null,
+      ...codex.headSha ? { headSha: codex.headSha } : {},
       blocking: codex.blocking === true,
       url: normalizeCommentUrl(comment),
       createdAt: normalizeCommentCreatedAt(comment),
@@ -35707,6 +35717,7 @@ function buildReviewerSignalTruth({ reviewer, reviewerStatus, reviewerEvidence, 
     canonicalReviewer: vtddReviewerMarkerPresent ? reviewer : null,
     reviewerStatus,
     recommendedAction,
+    ...normalizeText5(reviewerEvidence?.headSha) ? { reviewerHeadSha: normalizeText5(reviewerEvidence?.headSha) } : {},
     vtddReviewerMarkerPresent,
     githubFormalReview: formalReviewTruth,
     mergeReviewTruth: {
@@ -35863,6 +35874,12 @@ function deny7(rule, reason) {
     reason
   };
 }
+
+// src/core/approve-auto-merge.js
+var ApproveAutoMergePolicyMode = Object.freeze({
+  MANUAL: "manual",
+  APPROVE_AUTO_MERGE: "approve_auto_merge"
+});
 
 // src/core/gemini-review-failure.js
 var GeminiReviewFailureKind = Object.freeze({


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #448 の approve_auto_merge policy を実装し、reviewer approve だけでなく checks / mergeability / head SHA / reviewer objection / incident gate を通過した PR だけを証跡付きで自動マージする。

## Satisfied Success Criteria

- approve_auto_merge policy evaluator を追加し、manual / approve_auto_merge を解決する。
required checks success、mergeability verified、current head SHA と reviewer head SHA 一致、reviewer merge truth satisfied、unresolved objections なし、runaway / actor incident なしを gate にした。
GitHub Actions workflow approve-auto-merge を追加し、trusted main checkout + GitHub App token で評価・merge を実行する。
自動マージ候補 / 停止 / 実行済みの PR comment に検索語 自動マージ と判定根拠を残す。
実行済み comment に RAG 保存候補 JSON を残す。
VTDD_RUNTIME_URL と VTDD_GATEWAY_BEARER_TOKEN がある場合は /v2/events/github-actions へ dashboard event を送る。
Gemini / Codex fallback reviewer marker から Head SHA を読み、stale approve を block する。

## Unsatisfied Success Criteria

None.

## Non-goal violations

deploy 自動化、credential / permission / secret mutation、reviewer approve 単体での merge、Issue closure 自動化は行っていません。

## Dry-run Impact Report

- Target Issue: Issue #448
- Implementing Success Criteria: approve_auto_merge policy / gated merge / PR comment evidence / dashboard event / RAG candidate / block reason / manual path preservation
- Explicit Non-goals: deploy 自動化、credential mutation、permission mutation、secret mutation、Issue closure 自動化
- Expected touched files/routes/workflows: src/core/approve-auto-merge.js, scripts/run-approve-auto-merge.mjs, .github/workflows/approve-auto-merge.yml, reviewer parser/synthesis files, worker.js, tests
- Affected Issues: #448
- Affected PRs: なし
- Affected workflows: approve-auto-merge を新規追加。guarded-autonomy-required-checks / gemini-pr-review / codex-pr-review-fallback の completion を入力 signal として読む。
- Affected runtime/operator surfaces: GitHub Actions, PR comment timeline, dashboard notification center /v2/events/github-actions, operational RAG candidate in PR comment
- What may break if we patch narrowly: approve だけで merge すると stale SHA / failed checks / unresolved reviewer objection / actor incident を抜けるため、gate evaluator と workflow を分けて実装した。
- Unknowns to investigate before coding: 本番の GitHub App permission は merge 実行時に runtime truth で検証される。App token が不足する場合は workflow が失敗/停止証跡を残す。
- Validation needed: node --test と npm test。workflow/script static tests。
- Stop condition: reviewer head SHA が取れない、required checks が揃わない、mergeability が unverified、または dashboard auth が未設定の場合は自動マージを進めない。

## File / Line Hypotheses

- file: `src/core/approve-auto-merge.js`
  - hypothesis: 自動マージ可否は core evaluator に閉じるとテストしやすく drift しにくい。
  - risk if changed narrowly: workflow だけで条件分岐すると stale reviewer / failed checks を見落とす。
  - validation: `test/approve-auto-merge.test.js`
  - related Issue: #448
- file: `.github/workflows/approve-auto-merge.yml`
  - hypothesis: trusted main checkout + GitHub App token で PR branch code 実行を避ける必要がある。
  - risk if changed narrowly: untrusted PR code 実行や GITHUB_TOKEN 権限不足で merge path が不安定になる。
  - validation: `test/approve-auto-merge-workflow.test.js`
  - related Issue: #448
- file: `scripts/run-approve-auto-merge.mjs`
  - hypothesis: PR comment evidence と dashboard event を workflow 側から残すと Butler/dashboard が追える。
  - risk if changed narrowly: merge だけ成功してなぜ merge されたか検索できなくなる。
  - validation: `test/approve-auto-merge-workflow.test.js`
  - related Issue: #448

## Hypothesis Retrospective

- expected: approve_auto_merge は approve 単体ではなく複数 gate を通る。
- actual: evaluator が checks / mergeability / SHA / objection / incident をすべて判定し、script は通過時のみ merge する。
- mismatch: なし。
- lesson: 自動化するほど、PR comment / dashboard event / RAG candidate の証跡を先に決める必要がある。
- should become RAG candidate: yes, 自動マージ policy の成功パターン。

## Verification Evidence

- Unit: node --test test/approve-auto-merge.test.js test/approve-auto-merge-workflow.test.js test/execution-continuity.test.js test/butler-review-synthesis.test.js test/gemini-pr-review.test.js test/codex-review-fallback.test.js PASS: 90 tests
- Integration: npm test PASS: 843 pass / 1 skipped, self-parity passed, generated worker check passed
- E2E: Workflow-level E2E は PR merge 後に GitHub Actions 上で初回動作を確認予定。このPRでは evaluator/script/workflow の local integration evidence まで。
- Manual: 未実施。production deploy はこのPRの非対象。
- Evidence path/link: test/approve-auto-merge.test.js; test/approve-auto-merge-workflow.test.js; npm test output

## Butler Completion Contract

- Owner goal: reviewer approve 後の冗長な手動 merge を、VTDD の安全 gate と証跡付きで自動化する。
- Butler entrypoint: PR review/checks/workflow completion を GitHub Actions が受け、PR comment と dashboard event に結果を返す。
- Action Schema exposure: 不要。このスライスは Custom GPT Action Schema ではなく GitHub Actions workflow と dashboard event に接続する。
- Runtime path: .github/workflows/approve-auto-merge.yml -> scripts/run-approve-auto-merge.mjs -> GitHub PR merge API / PR comments / /v2/events/github-actions
- Runner/runtime truth: PR comment の vtdd:auto-merge markers、GitHub Actions run、dashboard notification event、merge result SHA。
- Authority boundary: deploy / credential / permission mutation は対象外。approve_auto_merge は reviewer approve + checks + mergeability + SHA + no-objection + no-incident gate 通過時のみ merge する repository-level automation。
- E2E evidence: PR comment と dashboard event により Butler/dashboard が自動マージ候補・停止・実行済みを読める。production 実PRでの初回 live evidence は merge 後。
- Completion status: complete

## Surface Update Checklist

- Cloudflare deploy: 不要。このPRは dashboard event endpoint を既存利用するのみ。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。merge 後の実PR自動マージ event を iPhone dashboard で確認する。

## Related Constitution Rules

- Butler Completion Gate
Authority Boundary
Evidence Discipline
Change Size and PR Discipline
RAG Memory Capture and Cost Boundary

## Out-of-scope but NOT implemented

- deploy 自動化
Issue closure 自動化
GitHub App permission mutation
Custom GPT Action Schema 更新

## Extra changes (if any)

worker.js は生成物として更新。

<!-- VTDD metadata -->
- Issue: Issue #448
- Execution ID: mac-codex-issue448-approve-auto-merge
- Goal: approve_auto_merge policy を安全 gate と証跡付きで実装する
