### PR TITLE
dashboard: VPS runner event を Butler chat に返す

### DIFF
--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -3123,7 +3123,21 @@ async function handleVpsRunnerEventRequest(request, env) {
   }
 
   await eventStore.put(event.event);
-  const messages = await chatStore.appendMany(event.threadId, [event.chatMessage]);
+  let messages;
+  try {
+    messages = await chatStore.appendMany(event.threadId, [event.chatMessage]);
+  } catch (error) {
+    await eventStore.delete(event.event.id);
+    return json(502, {
+      ok: false,
+      error: "dashboard_event_chat_append_failed",
+      reason: "VPS runner event was not saved because Butler chat append failed",
+      rollback: {
+        eventId: event.event.id,
+        notificationDeleted: true
+      }
+    });
+  }
   return json(202, {
     ok: true,
     event: event.event,
@@ -4671,6 +4685,7 @@ function resolveDashboardEventStore(env) {
   if (
     injectedStore &&
     typeof injectedStore.put === "function" &&
+    typeof injectedStore.delete === "function" &&
     typeof injectedStore.latest === "function"
   ) {
     return injectedStore;
@@ -4744,6 +4759,16 @@ function createD1DashboardEventStore(d1) {
         )
         .run();
       return normalized;
+    },
+
+    async delete(eventId) {
+      const id = normalizeDashboardEventText(eventId);
+      if (!id) {
+        return false;
+      }
+      await ensureSchema();
+      await d1.prepare("DELETE FROM vtdd_dashboard_events WHERE id = ?").bind(id).run();
+      return true;
     },
 
     async latest(filter = {}) {

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -386,6 +386,23 @@ export default {
       return handleGitHubActionsEventRequest(request, env);
     }
 
+    if (request.method === "POST" && isApiPath(url.pathname, "/events/vps-runner")) {
+      const auth = authorizeGatewayRequest({
+        request,
+        env,
+        apiSuffix: "/events/vps-runner"
+      });
+      if (!auth.ok) {
+        return json(auth.status, {
+          ok: false,
+          error: "unauthorized",
+          reason: auth.reason
+        });
+      }
+
+      return handleVpsRunnerEventRequest(request, env);
+    }
+
     if (request.method === "POST" && isApiPath(url.pathname, "/action/github-actions-secret")) {
       const auth = authorizePasskeyBrowserOrMachineRequest({
         request,
@@ -3076,6 +3093,45 @@ async function handleGitHubActionsEventRequest(request, env) {
   });
 }
 
+async function handleVpsRunnerEventRequest(request, env) {
+  const payload = await readJson(request);
+  const event = normalizeVpsRunnerDashboardEvent(payload);
+  if (!event.ok) {
+    return json(422, {
+      ok: false,
+      error: event.error,
+      reason: event.reason
+    });
+  }
+
+  const eventStore = resolveDashboardEventStore(env);
+  if (!eventStore) {
+    return json(503, {
+      ok: false,
+      error: "dashboard_event_store_unavailable",
+      reason: "dashboard event store is not configured"
+    });
+  }
+
+  const chatStore = resolveDashboardChatStore(env);
+  if (!chatStore) {
+    return json(503, {
+      ok: false,
+      error: "dashboard_chat_store_unavailable",
+      reason: "dashboard Butler chat store is not configured"
+    });
+  }
+
+  await eventStore.put(event.event);
+  const messages = await chatStore.appendMany(event.threadId, [event.chatMessage]);
+  return json(202, {
+    ok: true,
+    event: event.event,
+    threadId: event.threadId,
+    messages
+  });
+}
+
 async function handleDashboardChatMessageRequest(request, env) {
   const payload = await readJson(request);
   const prepared = buildDashboardChatTurn(payload);
@@ -4989,7 +5045,8 @@ function sanitizeDashboardChatText(value) {
     .replace(/\bgh[psuor]_[A-Za-z0-9_]{20,}\b/g, "[redacted-token]")
     .replace(/\bsk-proj-[A-Za-z0-9_-]{20,}\b/g, "[redacted-openai-key]")
     .replace(/\bBearer\s+[A-Za-z0-9._~+/=-]{12,}/gi, "Bearer [redacted]")
-    .replace(/\b(CLOUDFLARE_API_TOKEN|OPENAI_API_KEY|GITHUB_TOKEN)=\S+/gi, "$1=[redacted]");
+    .replace(/\b(CLOUDFLARE_API_TOKEN|OPENAI_API_KEY|GITHUB_TOKEN)=\S+/gi, "$1=[redacted]")
+    .replace(/([?&](?:token|approvalGrantId|approval_grant_id|key|secret)=)[^&\s]+/gi, "$1[redacted]");
   return text.slice(0, 4000);
 }
 
@@ -5546,6 +5603,198 @@ function normalizeGitHubActionsEvent(payload) {
     ok: true,
     event
   };
+}
+
+function normalizeVpsRunnerDashboardEvent(payload) {
+  const input = normalizeObject(payload);
+  const repository = normalizeCanonicalRepositoryInput(input.repository || input.githubRepository);
+  const executionId = normalizeDashboardEventText(
+    input.executionId || input.execution_id || input.runId || input.run_id
+  );
+  const rawStatus = normalizeDashboardEventText(input.status || input.runnerStatus || "running").toLowerCase();
+  const status = normalizeVpsRunnerDashboardStatus(rawStatus);
+  const conclusion = normalizeVpsRunnerDashboardConclusion(input.conclusion || input.result || rawStatus);
+  const currentStep = sanitizeDashboardChatText(input.currentStep || input.current_step);
+  const lastEvent = sanitizeDashboardChatText(input.lastEvent || input.last_event || input.event);
+  const message = sanitizeDashboardChatText(input.message || input.summary || input.text || input.reason);
+  const updatedAt = normalizeIsoTimestamp(input.updatedAt || input.updated_at || input.heartbeatAt) || new Date().toISOString();
+  const createdAt = normalizeIsoTimestamp(input.createdAt || input.created_at) || updatedAt;
+  const issueNumber = normalizePositiveInteger(input.issueNumber || input.issue_number || input.relatedIssue);
+  const branch = sanitizeDashboardChatText(input.branch || input.headBranch || input.head_branch);
+  const progressUrl = normalizeDashboardUrl(input.progressUrl || input.progress_url || input.runUrl || input.run_url || input.url);
+  const threadId =
+    normalizeDashboardThreadId(input.threadId || input.thread_id) ||
+    normalizeDashboardThreadId(`execution-${executionId}`);
+  const title = buildVpsRunnerDashboardTitle({ status, currentStep, lastEvent, message });
+
+  if (!repository) {
+    return {
+      ok: false,
+      error: "repository_required",
+      reason: "VPS runner event repository is required"
+    };
+  }
+  if (!executionId) {
+    return {
+      ok: false,
+      error: "execution_id_required",
+      reason: "VPS runner event executionId is required"
+    };
+  }
+  if (!status) {
+    return {
+      ok: false,
+      error: "status_unsupported",
+      reason: "VPS runner event status is not supported"
+    };
+  }
+
+  const event = {
+    id: `vps-runner:${repository}:${executionId}:${lastEvent || status}:${updatedAt}`,
+    kind: "vps_runner_execution",
+    repository,
+    workflowName: "vps-runner",
+    runId: executionId,
+    status,
+    conclusion,
+    headSha: null,
+    headBranch: branch || null,
+    runUrl: progressUrl || null,
+    title,
+    createdAt,
+    updatedAt
+  };
+  const chatMessage = normalizeDashboardChatMessage(
+    {
+      threadId,
+      role: "runner",
+      repository,
+      relatedIssue: issueNumber,
+      status: mapVpsRunnerStatusToChatStatus(status),
+      text: buildVpsRunnerChatMessageText({
+        repository,
+        executionId,
+        status,
+        currentStep,
+        lastEvent,
+        message,
+        branch,
+        progressUrl
+      }),
+      createdAt: updatedAt
+    },
+    { threadId }
+  );
+
+  return {
+    ok: true,
+    event,
+    threadId,
+    chatMessage
+  };
+}
+
+function normalizeVpsRunnerDashboardStatus(value) {
+  const status = normalizeDashboardEventText(value).toLowerCase();
+  if (["queued", "requested", "waiting"].includes(status)) {
+    return "queued";
+  }
+  if (["running", "in_progress", "picked_up", "started", "codex_subprocess"].includes(status)) {
+    return "running";
+  }
+  if (["completed", "success", "done", "merged", "pr_created"].includes(status)) {
+    return "completed";
+  }
+  if (["blocked", "failed", "failure", "error"].includes(status)) {
+    return "blocked";
+  }
+  if (["canceled", "cancelled"].includes(status)) {
+    return "canceled";
+  }
+  return "";
+}
+
+function normalizeVpsRunnerDashboardConclusion(value) {
+  const conclusion = normalizeDashboardEventText(value).toLowerCase();
+  if (["success", "completed", "done", "merged", "pr_created"].includes(conclusion)) {
+    return "success";
+  }
+  if (["failure", "failed", "blocked", "error"].includes(conclusion)) {
+    return "failure";
+  }
+  if (["cancelled", "canceled"].includes(conclusion)) {
+    return "cancelled";
+  }
+  return null;
+}
+
+function mapVpsRunnerStatusToChatStatus(status) {
+  if (status === "queued" || status === "running") {
+    return "thinking";
+  }
+  if (status === "completed") {
+    return "replied";
+  }
+  if (status === "canceled") {
+    return "blocked";
+  }
+  return "failed";
+}
+
+function buildVpsRunnerDashboardTitle({ status, currentStep, lastEvent, message }) {
+  const prefix = currentStep || lastEvent || `VPS runner ${status}`;
+  const title = message ? `${prefix}: ${message}` : prefix;
+  return title.slice(0, 160);
+}
+
+function buildVpsRunnerChatMessageText({
+  repository,
+  executionId,
+  status,
+  currentStep,
+  lastEvent,
+  message,
+  branch,
+  progressUrl
+}) {
+  const parts = [
+    `VPS Codex CLI から更新です。`,
+    `repo: ${repository}`,
+    `execution: ${executionId}`,
+    `status: ${status}`
+  ];
+  if (currentStep) {
+    parts.push(`step: ${currentStep}`);
+  }
+  if (lastEvent) {
+    parts.push(`event: ${lastEvent}`);
+  }
+  if (branch) {
+    parts.push(`branch: ${branch}`);
+  }
+  if (message) {
+    parts.push(message);
+  }
+  if (progressUrl) {
+    parts.push(`進捗: ${progressUrl}`);
+  }
+  return parts.join("\n");
+}
+
+function normalizeDashboardUrl(value) {
+  const text = sanitizeDashboardChatText(value);
+  if (!text) {
+    return "";
+  }
+  try {
+    const url = new URL(text);
+    if (url.protocol !== "https:" && url.protocol !== "http:") {
+      return "";
+    }
+    return url.toString();
+  } catch {
+    return "";
+  }
 }
 
 function normalizeIsoTimestamp(value) {

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -43,6 +43,9 @@ function createInMemoryDashboardEventStore() {
       events.set(event.id, event);
       return event;
     },
+    async delete(eventId) {
+      return events.delete(eventId);
+    },
     async latest(filter = {}) {
       const matches = [...events.values()].filter((event) => {
         if (filter.kind && event.kind !== filter.kind) {
@@ -675,6 +678,51 @@ test("worker rejects VPS runner event without machine auth", async () => {
   );
 
   assert.equal(response.status, 401);
+});
+
+test("worker rolls back VPS runner notification when Butler chat append fails", async () => {
+  const eventStore = createInMemoryDashboardEventStore();
+  const chatStore = {
+    async appendMany() {
+      throw new Error("chat append failed");
+    },
+    async listThread() {
+      return [];
+    }
+  };
+
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/events/vps-runner", {
+      method: "POST",
+      headers: gatewayAuthHeaders,
+      body: JSON.stringify({
+        repository: "marushu/vtdd-v2-p",
+        executionId: "remote-codex-issue452-partial-write",
+        threadId: "dashboard-main-marushu-vtdd-v2-p",
+        issueNumber: 452,
+        status: "running",
+        currentStep: "codex_subprocess"
+      })
+    }),
+    {
+      ...gatewayAuthEnv,
+      DASHBOARD_EVENT_STORE: eventStore,
+      DASHBOARD_CHAT_STORE: chatStore
+    }
+  );
+
+  assert.equal(response.status, 502);
+  const body = await response.json();
+  assert.equal(body.ok, false);
+  assert.equal(body.error, "dashboard_event_chat_append_failed");
+  assert.equal(body.rollback.notificationDeleted, true);
+
+  const latest = await eventStore.latest({
+    kind: "vps_runner_execution",
+    repository: "marushu/vtdd-v2-p",
+    workflowName: "vps-runner"
+  });
+  assert.equal(latest, null);
 });
 
 test("worker setup recovery page opens without Action auth and defaults to VTDD repo", async () => {

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -585,6 +585,98 @@ test("worker rejects GitHub Actions deploy completion event without machine auth
   assert.equal(response.status, 401);
 });
 
+test("worker ingests VPS runner event into notifications and Butler chat thread", async () => {
+  const eventStore = createInMemoryDashboardEventStore();
+  const chatStore = createInMemoryDashboardChatStore();
+  const eventResponse = await worker.fetch(
+    new Request("https://example.com/v2/events/vps-runner", {
+      method: "POST",
+      headers: gatewayAuthHeaders,
+      body: JSON.stringify({
+        repository: "marushu/vtdd-v2-p",
+        executionId: "remote-codex-issue452-chat",
+        threadId: "dashboard-main-marushu-vtdd-v2-p",
+        issueNumber: 452,
+        status: "running",
+        currentStep: "codex_subprocess",
+        lastEvent: "codex_started",
+        branch: "codex/issue-452-vps-runner-chat-events",
+        progressUrl:
+          "https://vtdd-v2-mvp.example/progress/remote-codex-issue452-chat?token=secret-must-not-persist",
+        message:
+          "VPS Codex CLI が作業を開始しました。approval:15b6f20d-11b6-4f8b-8008-99e7d7397452",
+        updatedAt: new Date(Date.now() - 60 * 1000).toISOString()
+      })
+    }),
+    {
+      ...gatewayAuthEnv,
+      DASHBOARD_EVENT_STORE: eventStore,
+      DASHBOARD_CHAT_STORE: chatStore
+    }
+  );
+
+  assert.equal(eventResponse.status, 202);
+  const eventBody = await eventResponse.json();
+  assert.equal(eventBody.ok, true);
+  assert.equal(eventBody.event.kind, "vps_runner_execution");
+  assert.equal(eventBody.event.repository, "marushu/vtdd-v2-p");
+  assert.equal(eventBody.event.runId, "remote-codex-issue452-chat");
+  assert.equal(eventBody.event.status, "running");
+  assert.equal(eventBody.event.runUrl.includes("secret-must-not-persist"), false);
+  assert.equal(JSON.stringify(eventBody).includes("approval:15b6f20d"), false);
+  assert.equal(JSON.stringify(eventBody).includes("secret-must-not-persist"), false);
+  assert.equal(eventBody.threadId, "dashboard-main-marushu-vtdd-v2-p");
+  assert.equal(eventBody.messages[0].role, "runner");
+  assert.equal(eventBody.messages[0].status, "thinking");
+  assert.equal(eventBody.messages[0].relatedIssue, 452);
+  assert.equal(eventBody.messages[0].text.includes("VPS Codex CLI"), true);
+  assert.equal(eventBody.messages[0].text.includes("codex_subprocess"), true);
+
+  const chatResponse = await worker.fetch(
+    new Request("https://example.com/v2/dashboard/chat/dashboard-main-marushu-vtdd-v2-p"),
+    { DASHBOARD_CHAT_STORE: chatStore }
+  );
+  assert.equal(chatResponse.status, 200);
+  const chatBody = await chatResponse.json();
+  assert.equal(chatBody.messages.length, 1);
+  assert.equal(chatBody.messages[0].role, "runner");
+  assert.equal(JSON.stringify(chatBody).includes("approval:15b6f20d"), false);
+  assert.equal(JSON.stringify(chatBody).includes("secret-must-not-persist"), false);
+
+  const notificationsResponse = await worker.fetch(
+    new Request("https://example.com/dashboard/notifications"),
+    { DASHBOARD_EVENT_STORE: eventStore }
+  );
+  assert.equal(notificationsResponse.status, 200);
+  const notificationsBody = await notificationsResponse.text();
+  assert.equal(notificationsBody.includes("通知センター"), true);
+  assert.equal(notificationsBody.includes("remote-codex-issue452-chat"), true);
+  assert.equal(notificationsBody.includes("marushu/vtdd-v2-p"), true);
+  assert.equal(notificationsBody.includes("codex_subprocess"), true);
+  assert.equal(notificationsBody.includes("secret-must-not-persist"), false);
+});
+
+test("worker rejects VPS runner event without machine auth", async () => {
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/events/vps-runner", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        repository: "marushu/vtdd-v2-p",
+        executionId: "remote-codex-issue452-chat",
+        status: "running"
+      })
+    }),
+    {
+      ...gatewayAuthEnv,
+      DASHBOARD_EVENT_STORE: createInMemoryDashboardEventStore(),
+      DASHBOARD_CHAT_STORE: createInMemoryDashboardChatStore()
+    }
+  );
+
+  assert.equal(response.status, 401);
+});
+
 test("worker setup recovery page opens without Action auth and defaults to VTDD repo", async () => {
   const response = await worker.fetch(new Request("https://example.com/setup/recovery"));
 

--- a/worker.js
+++ b/worker.js
@@ -56019,6 +56019,21 @@ var runtime_default = {
       }
       return handleGitHubActionsEventRequest(request, env);
     }
+    if (request.method === "POST" && isApiPath(url.pathname, "/events/vps-runner")) {
+      const auth = authorizeGatewayRequest({
+        request,
+        env,
+        apiSuffix: "/events/vps-runner"
+      });
+      if (!auth.ok) {
+        return json(auth.status, {
+          ok: false,
+          error: "unauthorized",
+          reason: auth.reason
+        });
+      }
+      return handleVpsRunnerEventRequest(request, env);
+    }
     if (request.method === "POST" && isApiPath(url.pathname, "/action/github-actions-secret")) {
       const auth = authorizePasskeyBrowserOrMachineRequest({
         request,
@@ -58349,6 +58364,41 @@ async function handleGitHubActionsEventRequest(request, env) {
     event: event.event
   });
 }
+async function handleVpsRunnerEventRequest(request, env) {
+  const payload = await readJson(request);
+  const event = normalizeVpsRunnerDashboardEvent(payload);
+  if (!event.ok) {
+    return json(422, {
+      ok: false,
+      error: event.error,
+      reason: event.reason
+    });
+  }
+  const eventStore = resolveDashboardEventStore(env);
+  if (!eventStore) {
+    return json(503, {
+      ok: false,
+      error: "dashboard_event_store_unavailable",
+      reason: "dashboard event store is not configured"
+    });
+  }
+  const chatStore = resolveDashboardChatStore(env);
+  if (!chatStore) {
+    return json(503, {
+      ok: false,
+      error: "dashboard_chat_store_unavailable",
+      reason: "dashboard Butler chat store is not configured"
+    });
+  }
+  await eventStore.put(event.event);
+  const messages = await chatStore.appendMany(event.threadId, [event.chatMessage]);
+  return json(202, {
+    ok: true,
+    event: event.event,
+    threadId: event.threadId,
+    messages
+  });
+}
 async function handleDashboardChatMessageRequest(request, env) {
   const payload = await readJson(request);
   const prepared = buildDashboardChatTurn(payload);
@@ -59945,7 +59995,7 @@ function normalizeDashboardThreadId(value) {
   return text.slice(0, 160);
 }
 function sanitizeDashboardChatText(value) {
-  const text = normalizeText30(value).replace(/approval:[0-9a-f-]{20,}/gi, "[redacted-approval]").replace(/\bgh[psuor]_[A-Za-z0-9_]{20,}\b/g, "[redacted-token]").replace(/\bsk-proj-[A-Za-z0-9_-]{20,}\b/g, "[redacted-openai-key]").replace(/\bBearer\s+[A-Za-z0-9._~+/=-]{12,}/gi, "Bearer [redacted]").replace(/\b(CLOUDFLARE_API_TOKEN|OPENAI_API_KEY|GITHUB_TOKEN)=\S+/gi, "$1=[redacted]");
+  const text = normalizeText30(value).replace(/approval:[0-9a-f-]{20,}/gi, "[redacted-approval]").replace(/\bgh[psuor]_[A-Za-z0-9_]{20,}\b/g, "[redacted-token]").replace(/\bsk-proj-[A-Za-z0-9_-]{20,}\b/g, "[redacted-openai-key]").replace(/\bBearer\s+[A-Za-z0-9._~+/=-]{12,}/gi, "Bearer [redacted]").replace(/\b(CLOUDFLARE_API_TOKEN|OPENAI_API_KEY|GITHUB_TOKEN)=\S+/gi, "$1=[redacted]").replace(/([?&](?:token|approvalGrantId|approval_grant_id|key|secret)=)[^&\s]+/gi, "$1[redacted]");
   return text.slice(0, 4e3);
 }
 function isDashboardChatThreadApiPath(pathname) {
@@ -60425,6 +60475,186 @@ function normalizeGitHubActionsEvent(payload) {
     ok: true,
     event
   };
+}
+function normalizeVpsRunnerDashboardEvent(payload) {
+  const input = normalizeObject11(payload);
+  const repository = normalizeCanonicalRepositoryInput(input.repository || input.githubRepository);
+  const executionId = normalizeDashboardEventText(
+    input.executionId || input.execution_id || input.runId || input.run_id
+  );
+  const rawStatus = normalizeDashboardEventText(input.status || input.runnerStatus || "running").toLowerCase();
+  const status = normalizeVpsRunnerDashboardStatus(rawStatus);
+  const conclusion = normalizeVpsRunnerDashboardConclusion(input.conclusion || input.result || rawStatus);
+  const currentStep = sanitizeDashboardChatText(input.currentStep || input.current_step);
+  const lastEvent = sanitizeDashboardChatText(input.lastEvent || input.last_event || input.event);
+  const message = sanitizeDashboardChatText(input.message || input.summary || input.text || input.reason);
+  const updatedAt = normalizeIsoTimestamp(input.updatedAt || input.updated_at || input.heartbeatAt) || (/* @__PURE__ */ new Date()).toISOString();
+  const createdAt = normalizeIsoTimestamp(input.createdAt || input.created_at) || updatedAt;
+  const issueNumber = normalizePositiveInteger9(input.issueNumber || input.issue_number || input.relatedIssue);
+  const branch = sanitizeDashboardChatText(input.branch || input.headBranch || input.head_branch);
+  const progressUrl = normalizeDashboardUrl(input.progressUrl || input.progress_url || input.runUrl || input.run_url || input.url);
+  const threadId = normalizeDashboardThreadId(input.threadId || input.thread_id) || normalizeDashboardThreadId(`execution-${executionId}`);
+  const title = buildVpsRunnerDashboardTitle({ status, currentStep, lastEvent, message });
+  if (!repository) {
+    return {
+      ok: false,
+      error: "repository_required",
+      reason: "VPS runner event repository is required"
+    };
+  }
+  if (!executionId) {
+    return {
+      ok: false,
+      error: "execution_id_required",
+      reason: "VPS runner event executionId is required"
+    };
+  }
+  if (!status) {
+    return {
+      ok: false,
+      error: "status_unsupported",
+      reason: "VPS runner event status is not supported"
+    };
+  }
+  const event = {
+    id: `vps-runner:${repository}:${executionId}:${lastEvent || status}:${updatedAt}`,
+    kind: "vps_runner_execution",
+    repository,
+    workflowName: "vps-runner",
+    runId: executionId,
+    status,
+    conclusion,
+    headSha: null,
+    headBranch: branch || null,
+    runUrl: progressUrl || null,
+    title,
+    createdAt,
+    updatedAt
+  };
+  const chatMessage = normalizeDashboardChatMessage(
+    {
+      threadId,
+      role: "runner",
+      repository,
+      relatedIssue: issueNumber,
+      status: mapVpsRunnerStatusToChatStatus(status),
+      text: buildVpsRunnerChatMessageText({
+        repository,
+        executionId,
+        status,
+        currentStep,
+        lastEvent,
+        message,
+        branch,
+        progressUrl
+      }),
+      createdAt: updatedAt
+    },
+    { threadId }
+  );
+  return {
+    ok: true,
+    event,
+    threadId,
+    chatMessage
+  };
+}
+function normalizeVpsRunnerDashboardStatus(value) {
+  const status = normalizeDashboardEventText(value).toLowerCase();
+  if (["queued", "requested", "waiting"].includes(status)) {
+    return "queued";
+  }
+  if (["running", "in_progress", "picked_up", "started", "codex_subprocess"].includes(status)) {
+    return "running";
+  }
+  if (["completed", "success", "done", "merged", "pr_created"].includes(status)) {
+    return "completed";
+  }
+  if (["blocked", "failed", "failure", "error"].includes(status)) {
+    return "blocked";
+  }
+  if (["canceled", "cancelled"].includes(status)) {
+    return "canceled";
+  }
+  return "";
+}
+function normalizeVpsRunnerDashboardConclusion(value) {
+  const conclusion = normalizeDashboardEventText(value).toLowerCase();
+  if (["success", "completed", "done", "merged", "pr_created"].includes(conclusion)) {
+    return "success";
+  }
+  if (["failure", "failed", "blocked", "error"].includes(conclusion)) {
+    return "failure";
+  }
+  if (["cancelled", "canceled"].includes(conclusion)) {
+    return "cancelled";
+  }
+  return null;
+}
+function mapVpsRunnerStatusToChatStatus(status) {
+  if (status === "queued" || status === "running") {
+    return "thinking";
+  }
+  if (status === "completed") {
+    return "replied";
+  }
+  if (status === "canceled") {
+    return "blocked";
+  }
+  return "failed";
+}
+function buildVpsRunnerDashboardTitle({ status, currentStep, lastEvent, message }) {
+  const prefix = currentStep || lastEvent || `VPS runner ${status}`;
+  const title = message ? `${prefix}: ${message}` : prefix;
+  return title.slice(0, 160);
+}
+function buildVpsRunnerChatMessageText({
+  repository,
+  executionId,
+  status,
+  currentStep,
+  lastEvent,
+  message,
+  branch,
+  progressUrl
+}) {
+  const parts = [
+    `VPS Codex CLI \u304B\u3089\u66F4\u65B0\u3067\u3059\u3002`,
+    `repo: ${repository}`,
+    `execution: ${executionId}`,
+    `status: ${status}`
+  ];
+  if (currentStep) {
+    parts.push(`step: ${currentStep}`);
+  }
+  if (lastEvent) {
+    parts.push(`event: ${lastEvent}`);
+  }
+  if (branch) {
+    parts.push(`branch: ${branch}`);
+  }
+  if (message) {
+    parts.push(message);
+  }
+  if (progressUrl) {
+    parts.push(`\u9032\u6357: ${progressUrl}`);
+  }
+  return parts.join("\n");
+}
+function normalizeDashboardUrl(value) {
+  const text = sanitizeDashboardChatText(value);
+  if (!text) {
+    return "";
+  }
+  try {
+    const url = new URL(text);
+    if (url.protocol !== "https:" && url.protocol !== "http:") {
+      return "";
+    }
+    return url.toString();
+  } catch {
+    return "";
+  }
 }
 function normalizeIsoTimestamp(value) {
   const text = normalizeText30(value);

--- a/worker.js
+++ b/worker.js
@@ -58391,7 +58391,21 @@ async function handleVpsRunnerEventRequest(request, env) {
     });
   }
   await eventStore.put(event.event);
-  const messages = await chatStore.appendMany(event.threadId, [event.chatMessage]);
+  let messages;
+  try {
+    messages = await chatStore.appendMany(event.threadId, [event.chatMessage]);
+  } catch (error2) {
+    await eventStore.delete(event.event.id);
+    return json(502, {
+      ok: false,
+      error: "dashboard_event_chat_append_failed",
+      reason: "VPS runner event was not saved because Butler chat append failed",
+      rollback: {
+        eventId: event.event.id,
+        notificationDeleted: true
+      }
+    });
+  }
   return json(202, {
     ok: true,
     event: event.event,
@@ -59682,7 +59696,7 @@ function resolveDashboardEventStore(env) {
     return null;
   }
   const injectedStore = env.DASHBOARD_EVENT_STORE ?? null;
-  if (injectedStore && typeof injectedStore.put === "function" && typeof injectedStore.latest === "function") {
+  if (injectedStore && typeof injectedStore.put === "function" && typeof injectedStore.delete === "function" && typeof injectedStore.latest === "function") {
     return injectedStore;
   }
   const d1Binding = env[MEMORY_D1_BINDING] ?? null;
@@ -59743,6 +59757,15 @@ function createD1DashboardEventStore(d1) {
         JSON.stringify(normalized)
       ).run();
       return normalized;
+    },
+    async delete(eventId) {
+      const id = normalizeDashboardEventText(eventId);
+      if (!id) {
+        return false;
+      }
+      await ensureSchema();
+      await d1.prepare("DELETE FROM vtdd_dashboard_events WHERE id = ?").bind(id).run();
+      return true;
     },
     async latest(filter = {}) {
       await ensureSchema();


### PR DESCRIPTION
## This PR satisfies Intent

Issue #452 の Intent を満たします。VPS Codex CLI / VPS runner からの進捗・返信イベントを Worker が受け取り、dashboard 通知センターと Butler chat thread の両方へ保存できる runtime endpoint を追加します。

このPRにより、dashboard Butler は「人間が送った会話」だけでなく「runner から返ってきた進捗」も同じ message model に載せられるようになります。

## Satisfied Success Criteria

- `POST /v2/events/vps-runner` を追加し、machine auth なしの request を拒否します。
- payload から repository / executionId / status / currentStep / lastEvent / message / issueNumber / branch / progressUrl / updatedAt を正規化します。
- valid event を dashboard event store に `kind: vps_runner_execution` として保存します。
- valid event を指定 `threadId`、または executionId 由来の thread に `role: runner` message として append します。
- chat append と API response から approval grant / token / secret URL query を redaction します。
- 通知センターに VPS runner event が表示できることを test で確認しました。
- polling / 自動 reload は追加していません。

## Unsatisfied Success Criteria

- WebSocket / EventSource / iOS push による dashboard の自動受信表示はこのPRスライス外です。Worker runtime truth と保存面までを接続しました。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: #452
- Implementing Success Criteria: VPS runner event endpoint、machine auth、dashboard event store 保存、Butler chat append、redaction、tests
- Explicit Non-goals: WebSocket 常時接続、push notification、Issue/PR/merge/deploy 自動実行、Custom GPT Action Schema 更新
- Expected touched files/routes/workflows: `src/worker/runtime.js`, `worker.js`, `test/worker.test.js`, `/v2/events/vps-runner`
- Affected Issues: #452, #450
- Affected PRs: このPRのみ
- Affected workflows: なし
- Affected runtime/operator surfaces: Cloudflare Worker dashboard runtime、通知センター、Butler chat thread、VPS runner event ingress
- What may break if we patch narrowly: runner 側がまだこの endpoint を呼ばない限り、UI には自動では流れません。次スライスで VPS runner から POST する必要があります。
- Unknowns to investigate before coding: runner 側の event POST retry / GitHub comment fallback の正確な順序
- Validation needed: worker tests、full npm test、generated worker parity
- Stop condition: runner からの event POST だけを扱い、execution dispatch / merge / deploy などの外部効果は実装しない

## File / Line Hypotheses

- file: `src/worker/runtime.js`
  - hypothesis: 既存の `/v2/events/github-actions` と dashboard event store の型を流用すれば、VPS runner event も通知センターへ自然に流せる。
  - risk if changed narrowly: chat append と notification append の片方だけ成功する partial write リスクがあるため、両方の store を先に解決してから保存する。
  - validation: `worker ingests VPS runner event into notifications and Butler chat thread`
  - related Issue: #452

## Hypothesis Retrospective

- expected: runner event を dashboard event と chat message の両方に保存できる。
- actual: `POST /v2/events/vps-runner` が `vps_runner_execution` event と `runner` chat message を返し、通知センターにも表示できた。
- mismatch: 自動受信 stream はまだなく、dashboard 側の表示更新は次スライスで必要。
- lesson: まず保存面を固定したことで、次は runner 側 POST と UI fan-out に分けて進められる。
- should become RAG candidate: true

## Verification Evidence

- Unit: `node --test test/worker.test.js` PASS 133 tests
- Integration: `npm test` PASS 847, skipped 1
- E2E: Worker test で `/v2/events/vps-runner` が通知センターと chat thread の両方へ保存することを確認
- Manual: 未実施。production deploy 後に runner event smoke が必要
- Evidence path/link: `test/worker.test.js`

## Butler Completion Contract

- Owner goal: VPS runner の返事・進捗を dashboard Butler の会話と通知に返す。
- Butler entrypoint: `/dashboard` の chat thread と `/dashboard/notifications` が保存結果を読める。
- Action Schema exposure: このPRスライスでは未変更。machine runtime endpoint なので Custom GPT Action Schema には依存しない。
- Runtime path: `POST /v2/events/vps-runner`, `GET /v2/dashboard/chat/:threadId`, `/dashboard/notifications`
- Runner/runtime truth: Worker は runner event を保存・返却できる。runner 側から実際に POST する実装は次スライス。
- Authority boundary: machine auth required。high-risk action / merge / deploy / credential mutation は追加していない。
- E2E evidence: worker integration test。live runner POST は deploy 後に必要。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 未実施。このPR merge 後に通常 deploy が必要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。deploy 後に dashboard で通知/チャット反映確認が必要。

## Related Constitution Rules

- Butler Completion Gate
- Butler-First Operating Principle
- Conversation UX Contract
- Safety Invariants
- Evidence Discipline

## Out-of-scope but NOT implemented

- VPS runner 側からこの endpoint へ POST する実装
- WebSocket / EventSource / push notification
- 音声 overlay / file upload / image upload
- Issue draft auto split / execution dispatch
- merge / deploy / close の自動実行

## Extra changes (if any)

None.
