### PR TITLE
approve_auto_merge: current head reviewer truth を優先する

### DIFF
--- a/src/core/execution-continuity.js
+++ b/src/core/execution-continuity.js
@@ -148,25 +148,38 @@ function validateHandoffRequirement({ actorRole, continuation }) {
 function buildReviewState(pullRequest) {
   const parsedGeminiSignals = collectGeminiReviewerSignals(pullRequest);
   const codexFallback = collectCodexFallbackSignals(pullRequest);
+  const currentHeadSha = normalizeText(pullRequest.headSha);
+  const geminiEvidenceMatchesCurrentHead = evidenceMatchesHead(
+    parsedGeminiSignals.latestEvidence,
+    currentHeadSha
+  );
+  const codexFallbackStaleForCurrentHead = evidenceTargetsDifferentHead(
+    codexFallback.latestSignal ?? codexFallback.latestEvidence,
+    currentHeadSha
+  );
+  const effectiveCodexFallback =
+    geminiEvidenceMatchesCurrentHead && codexFallbackStaleForCurrentHead
+      ? emptyCodexFallbackSignals()
+      : codexFallback;
   const formalReviewTruth = collectFormalReviewTruth(pullRequest);
   const reviewTimeline = buildReviewTimeline(pullRequest);
   const reviewCommentsCount =
     parsedGeminiSignals.totalCount > 0
       ? parsedGeminiSignals.totalCount
-      : codexFallback.completed
+      : effectiveCodexFallback.completed
         ? 1
         : pullRequest.reviewCommentsCount;
   const unresolvedReviewCommentsCount =
     parsedGeminiSignals.totalCount > 0
       ? parsedGeminiSignals.blockingCount
-      : codexFallback.completed
-        ? (codexFallback.blocking ? 1 : 0)
+      : effectiveCodexFallback.completed
+        ? (effectiveCodexFallback.blocking ? 1 : 0)
         : pullRequest.unresolvedReviewCommentsCount;
-  const reviewerStatus = codexFallback.completed
+  const reviewerStatus = effectiveCodexFallback.completed
     ? "codex_review_available"
-    : codexFallback.blocked
+    : effectiveCodexFallback.blocked
       ? "codex_review_blocked"
-      : codexFallback.requested
+      : effectiveCodexFallback.requested
         ? "codex_review_requested"
         : reviewCommentsCount > 0
           ? "gemini_review_available"
@@ -174,7 +187,7 @@ function buildReviewState(pullRequest) {
   const reviewer =
     reviewerStatus.startsWith("codex_review") ? "codex" : pullRequest.reviewer;
   const reviewerEvidence = reviewerStatus.startsWith("codex_review")
-    ? codexFallback.latestEvidence
+    ? effectiveCodexFallback.latestEvidence
     : parsedGeminiSignals.latestEvidence;
   const reviewResponseSummary = buildReviewResponseSummary({
     pullRequest,
@@ -220,18 +233,39 @@ function collectGeminiReviewerSignals(pullRequest) {
     ...(Array.isArray(pullRequest.issueComments) ? pullRequest.issueComments : []),
     ...(Array.isArray(pullRequest.reviewComments) ? pullRequest.reviewComments : [])
   ];
-  const parsed = comments.map(parseGeminiReviewComment).filter(Boolean);
+  const parsed = comments
+    .map(parseGeminiReviewComment)
+    .filter(Boolean)
+    .sort(compareTimelineItems);
+  const currentHeadSha = normalizeText(pullRequest.headSha);
+  const currentHeadSignals = currentHeadSha
+    ? parsed.filter((signal) => evidenceMatchesHead(signal, currentHeadSha))
+    : [];
+  const activeSignals = currentHeadSignals.length > 0 ? currentHeadSignals : parsed;
 
   return {
-    totalCount: parsed.length,
-    blockingCount: parsed.filter((signal) => signal.blocking).length,
-    latestEvidence: parsed.at(-1) ?? null
+    totalCount: activeSignals.length,
+    blockingCount: activeSignals.filter((signal) => signal.blocking).length,
+    latestEvidence: activeSignals.at(-1) ?? null
   };
 }
 
 function collectCodexFallbackSignals(pullRequest) {
   const comments = [...(Array.isArray(pullRequest.issueComments) ? pullRequest.issueComments : [])];
-  const parsed = comments.map(parseCodexReviewFallbackComment).filter(Boolean);
+  const parsed = comments
+    .map((comment) => {
+      const signal = parseCodexReviewFallbackComment(comment);
+      return signal
+        ? {
+          ...signal,
+          url: normalizeCommentUrl(comment),
+          createdAt: normalizeCommentCreatedAt(comment),
+          updatedAt: normalizeCommentUpdatedAt(comment)
+        }
+        : null;
+    })
+    .filter(Boolean)
+    .sort(compareTimelineItems);
   const connectorBlockers = comments.map(parseCodexConnectorSetupComment).filter(Boolean);
   const actorIdentityIncidents = comments.map(parseActorIdentityIncidentComment).filter(Boolean);
   const latestActorIdentityIncident = actorIdentityIncidents.at(-1) ?? null;
@@ -243,6 +277,7 @@ function collectCodexFallbackSignals(pullRequest) {
     completed: latest?.status === "completed",
     blocked: latest?.status === "blocked",
     blocking: latest?.blocking === true,
+    latestSignal: latest,
     latestEvidence: latest?.status === "completed"
         ? {
           reviewer: "codex",
@@ -255,6 +290,28 @@ function collectCodexFallbackSignals(pullRequest) {
         }
       : null
   };
+}
+
+function emptyCodexFallbackSignals() {
+  return {
+    requested: false,
+    completed: false,
+    blocked: false,
+    blocking: false,
+    latestSignal: null,
+    latestEvidence: null
+  };
+}
+
+function evidenceMatchesHead(evidence, headSha) {
+  const normalizedHead = normalizeText(headSha);
+  return Boolean(normalizedHead && normalizeText(evidence?.headSha) === normalizedHead);
+}
+
+function evidenceTargetsDifferentHead(evidence, headSha) {
+  const normalizedHead = normalizeText(headSha);
+  const evidenceHead = normalizeText(evidence?.headSha);
+  return Boolean(normalizedHead && evidenceHead && evidenceHead !== normalizedHead);
 }
 
 function buildReviewTimeline(pullRequest) {
@@ -591,6 +648,11 @@ function normalizeGitHubRuntime(value) {
       title: normalizeText(pullRequestInput.title) || null,
       baseRef: normalizeText(pullRequestInput.baseRef) || normalizeText(pullRequestInput.base?.ref) || null,
       headRef: normalizeText(pullRequestInput.headRef) || normalizeText(pullRequestInput.head?.ref) || null,
+      headSha:
+        normalizeText(pullRequestInput.headSha) ||
+        normalizeText(pullRequestInput.head_sha) ||
+        normalizeText(pullRequestInput.head?.sha) ||
+        null,
       mergeable: normalizeNullableBoolean(pullRequestInput.mergeable),
       mergeableState:
         normalizeText(pullRequestInput.mergeableState) ||

--- a/src/core/execution-continuity.js
+++ b/src/core/execution-continuity.js
@@ -241,11 +241,8 @@ function collectGeminiReviewerSignals(pullRequest) {
   const currentHeadSignals = currentHeadSha
     ? parsed.filter((signal) => evidenceMatchesHead(signal, currentHeadSha))
     : [];
-  const headlessSignals = currentHeadSha
-    ? parsed.filter((signal) => !evidenceHasHead(signal))
-    : [];
   const activeSignals = currentHeadSha
-    ? (currentHeadSignals.length > 0 ? currentHeadSignals : headlessSignals)
+    ? currentHeadSignals
     : parsed;
 
   return {
@@ -313,10 +310,6 @@ function emptyCodexFallbackSignals() {
 function evidenceMatchesHead(evidence, headSha) {
   const normalizedHead = normalizeText(headSha);
   return Boolean(normalizedHead && normalizeText(evidence?.headSha) === normalizedHead);
-}
-
-function evidenceHasHead(evidence) {
-  return Boolean(normalizeText(evidence?.headSha));
 }
 
 function evidenceTargetsDifferentHead(evidence, headSha) {

--- a/src/core/execution-continuity.js
+++ b/src/core/execution-continuity.js
@@ -158,7 +158,7 @@ function buildReviewState(pullRequest) {
     currentHeadSha
   );
   const effectiveCodexFallback =
-    geminiEvidenceMatchesCurrentHead && codexFallbackStaleForCurrentHead
+    geminiEvidenceMatchesCurrentHead && codexFallbackStaleForCurrentHead && !codexFallback.globalBlocker
       ? emptyCodexFallbackSignals()
       : codexFallback;
   const formalReviewTruth = collectFormalReviewTruth(pullRequest);
@@ -241,7 +241,12 @@ function collectGeminiReviewerSignals(pullRequest) {
   const currentHeadSignals = currentHeadSha
     ? parsed.filter((signal) => evidenceMatchesHead(signal, currentHeadSha))
     : [];
-  const activeSignals = currentHeadSignals.length > 0 ? currentHeadSignals : parsed;
+  const headlessSignals = currentHeadSha
+    ? parsed.filter((signal) => !evidenceHasHead(signal))
+    : [];
+  const activeSignals = currentHeadSha
+    ? (currentHeadSignals.length > 0 ? currentHeadSignals : headlessSignals)
+    : parsed;
 
   return {
     totalCount: activeSignals.length,
@@ -277,6 +282,7 @@ function collectCodexFallbackSignals(pullRequest) {
     completed: latest?.status === "completed",
     blocked: latest?.status === "blocked",
     blocking: latest?.blocking === true,
+    globalBlocker: Boolean(latestActorIdentityIncident || latestConnectorBlocker),
     latestSignal: latest,
     latestEvidence: latest?.status === "completed"
         ? {
@@ -298,6 +304,7 @@ function emptyCodexFallbackSignals() {
     completed: false,
     blocked: false,
     blocking: false,
+    globalBlocker: false,
     latestSignal: null,
     latestEvidence: null
   };
@@ -306,6 +313,10 @@ function emptyCodexFallbackSignals() {
 function evidenceMatchesHead(evidence, headSha) {
   const normalizedHead = normalizeText(headSha);
   return Boolean(normalizedHead && normalizeText(evidence?.headSha) === normalizedHead);
+}
+
+function evidenceHasHead(evidence) {
+  return Boolean(normalizeText(evidence?.headSha));
 }
 
 function evidenceTargetsDifferentHead(evidence, headSha) {

--- a/test/execution-continuity.test.js
+++ b/test/execution-continuity.test.js
@@ -179,6 +179,82 @@ test("execution continuity prefers current-head Gemini approve over stale Codex 
   assert.equal(result.value.nextSuggestedActions.includes("apply_pr_feedback"), false);
 });
 
+test("execution continuity does not satisfy review truth from stale Gemini approve when current head is unreviewed", () => {
+  const result = evaluateExecutionContinuity({
+    actorRole: ActorRole.BUTLER,
+    mode: TaskMode.EXECUTION,
+    runtimeTruth: {
+      runtimeState: {
+        activeBranch: "codex/issue-448",
+        pullRequest: {
+          number: 454,
+          url: "https://github.com/example/repo/pull/454",
+          state: "open",
+          title: "Auto merge reviewer truth",
+          reviewer: "gemini",
+          headSha: "new456",
+          issueComments: [
+            {
+              user: { login: "vtdd-codex[bot]" },
+              createdAt: "2026-05-20T01:00:00.000Z",
+              body: "<!-- vtdd:reviewer=gemini -->\n## VTDD Gemini レビュー\n\n- Head SHA: `old123`\n- Recommended action: `approve`"
+            }
+          ]
+        }
+      }
+    }
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.value.reviewLoop.reviewerStatus, "review_unavailable");
+  assert.equal(result.value.reviewLoop.reviewerEvidence, null);
+  assert.equal(result.value.reviewLoop.reviewerSignalTruth.mergeReviewTruth.satisfied, false);
+  assert.deepEqual(result.value.nextSuggestedActions, ["rerun_gemini_review", "summarize_for_human"]);
+});
+
+test("execution continuity keeps global Codex blocker even with current-head Gemini approve", () => {
+  const result = evaluateExecutionContinuity({
+    actorRole: ActorRole.BUTLER,
+    mode: TaskMode.EXECUTION,
+    runtimeTruth: {
+      runtimeState: {
+        activeBranch: "codex/issue-448",
+        pullRequest: {
+          number: 454,
+          url: "https://github.com/example/repo/pull/454",
+          state: "open",
+          title: "Auto merge reviewer truth",
+          reviewer: "gemini",
+          headSha: "new456",
+          issueComments: [
+            {
+              user: { login: "vtdd-codex[bot]" },
+              createdAt: "2026-05-20T01:00:00.000Z",
+              body: "<!-- vtdd:reviewer=codex-fallback -->\n## VTDD Codex fallback レビュー\n\n- Status: `completed`\n- Head SHA: `old123`\n- Recommended action: `request_changes`"
+            },
+            {
+              user: { login: "vtdd-codex[bot]" },
+              createdAt: "2026-05-20T01:05:00.000Z",
+              body: "<!-- vtdd:reviewer=gemini -->\n## VTDD Gemini レビュー\n\n- Head SHA: `new456`\n- Recommended action: `approve`"
+            },
+            {
+              user: { login: "chatgpt-codex-connector" },
+              createdAt: "2026-05-20T01:10:00.000Z",
+              body: "To use Codex here, [create a Codex account and connect to github](https://chatgpt.com/codex/cloud/settings/connectors)."
+            }
+          ]
+        }
+      }
+    }
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.value.reviewLoop.reviewer, "codex");
+  assert.equal(result.value.reviewLoop.reviewerStatus, "codex_review_blocked");
+  assert.equal(result.value.reviewLoop.criticalReviewPending, true);
+  assert.deepEqual(result.value.nextSuggestedActions, ["surface_reviewer_platform_blocker", "summarize_for_human"]);
+});
+
 test("execution continuity treats GitHub formal changes requested as blocking even with VTDD marker approve", () => {
   const result = evaluateExecutionContinuity({
     actorRole: ActorRole.BUTLER,

--- a/test/execution-continuity.test.js
+++ b/test/execution-continuity.test.js
@@ -212,6 +212,39 @@ test("execution continuity does not satisfy review truth from stale Gemini appro
   assert.deepEqual(result.value.nextSuggestedActions, ["rerun_gemini_review", "summarize_for_human"]);
 });
 
+test("execution continuity does not satisfy review truth from headless Gemini approve when PR head is known", () => {
+  const result = evaluateExecutionContinuity({
+    actorRole: ActorRole.BUTLER,
+    mode: TaskMode.EXECUTION,
+    runtimeTruth: {
+      runtimeState: {
+        activeBranch: "codex/issue-448",
+        pullRequest: {
+          number: 454,
+          url: "https://github.com/example/repo/pull/454",
+          state: "open",
+          title: "Auto merge reviewer truth",
+          reviewer: "gemini",
+          headSha: "new456",
+          issueComments: [
+            {
+              user: { login: "vtdd-codex[bot]" },
+              createdAt: "2026-05-20T01:00:00.000Z",
+              body: "<!-- vtdd:reviewer=gemini -->\n## VTDD Gemini レビュー\n\n- Recommended action: `approve`"
+            }
+          ]
+        }
+      }
+    }
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.value.reviewLoop.reviewerStatus, "review_unavailable");
+  assert.equal(result.value.reviewLoop.reviewerEvidence, null);
+  assert.equal(result.value.reviewLoop.reviewerSignalTruth.mergeReviewTruth.satisfied, false);
+  assert.deepEqual(result.value.nextSuggestedActions, ["rerun_gemini_review", "summarize_for_human"]);
+});
+
 test("execution continuity keeps global Codex blocker even with current-head Gemini approve", () => {
   const result = evaluateExecutionContinuity({
     actorRole: ActorRole.BUTLER,

--- a/test/execution-continuity.test.js
+++ b/test/execution-continuity.test.js
@@ -135,6 +135,50 @@ test("execution continuity treats approve-only Gemini reviewer comment as non-bl
   ]);
 });
 
+test("execution continuity prefers current-head Gemini approve over stale Codex fallback request changes", () => {
+  const result = evaluateExecutionContinuity({
+    actorRole: ActorRole.BUTLER,
+    mode: TaskMode.EXECUTION,
+    runtimeTruth: {
+      runtimeState: {
+        activeBranch: "codex/issue-452",
+        pullRequest: {
+          number: 453,
+          url: "https://github.com/example/repo/pull/453",
+          state: "open",
+          title: "Dashboard runner chat events",
+          reviewer: "gemini",
+          headSha: "new456",
+          mergeable: true,
+          mergeableState: "clean",
+          issueComments: [
+            {
+              user: { login: "vtdd-codex[bot]" },
+              createdAt: "2026-05-20T01:00:00.000Z",
+              body: "<!-- vtdd:reviewer=codex-fallback -->\n## VTDD Codex fallback レビュー\n\n- Status: `completed`\n- Head SHA: `old123`\n- Recommended action: `request_changes`\n\n### 重要指摘\n- old head still needed changes"
+            },
+            {
+              user: { login: "vtdd-codex[bot]" },
+              createdAt: "2026-05-20T01:05:00.000Z",
+              body: "<!-- vtdd:reviewer=gemini -->\n## VTDD Gemini レビュー\n\n- Head SHA: `new456`\n- Recommended action: `approve`\n\n### 残リスク\n- none"
+            }
+          ]
+        }
+      }
+    }
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.value.reviewLoop.reviewer, "gemini");
+  assert.equal(result.value.reviewLoop.reviewerStatus, "gemini_review_available");
+  assert.equal(result.value.reviewLoop.reviewerEvidence.recommendedAction, "approve");
+  assert.equal(result.value.reviewLoop.reviewerEvidence.headSha, "new456");
+  assert.equal(result.value.reviewLoop.unresolvedReviewCommentsCount, 0);
+  assert.equal(result.value.reviewLoop.criticalReviewPending, false);
+  assert.equal(result.value.reviewLoop.reviewerSignalTruth.mergeReviewTruth.satisfied, true);
+  assert.equal(result.value.nextSuggestedActions.includes("apply_pr_feedback"), false);
+});
+
 test("execution continuity treats GitHub formal changes requested as blocking even with VTDD marker approve", () => {
   const result = evaluateExecutionContinuity({
     actorRole: ActorRole.BUTLER,

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -1033,7 +1033,7 @@ test("worker MCP review_truth tool returns review synthesis from GitHub runtime 
             JSON.stringify([
               {
                 id: 10,
-                body: "<!-- vtdd:reviewer=gemini -->\n## VTDD Gemini Critical Review\n\n- Recommended action: `approve`",
+                body: "<!-- vtdd:reviewer=gemini -->\n## VTDD Gemini Critical Review\n\n- Head SHA: `abc123`\n- Recommended action: `approve`",
                 user: { login: "vtdd-codex[bot]" },
                 created_at: "2026-05-12T01:10:00Z",
                 updated_at: "2026-05-12T01:10:00Z",

--- a/worker.js
+++ b/worker.js
@@ -35449,13 +35449,23 @@ function validateHandoffRequirement({ actorRole, continuation }) {
 function buildReviewState(pullRequest) {
   const parsedGeminiSignals = collectGeminiReviewerSignals(pullRequest);
   const codexFallback = collectCodexFallbackSignals(pullRequest);
+  const currentHeadSha = normalizeText5(pullRequest.headSha);
+  const geminiEvidenceMatchesCurrentHead = evidenceMatchesHead(
+    parsedGeminiSignals.latestEvidence,
+    currentHeadSha
+  );
+  const codexFallbackStaleForCurrentHead = evidenceTargetsDifferentHead(
+    codexFallback.latestSignal ?? codexFallback.latestEvidence,
+    currentHeadSha
+  );
+  const effectiveCodexFallback = geminiEvidenceMatchesCurrentHead && codexFallbackStaleForCurrentHead ? emptyCodexFallbackSignals() : codexFallback;
   const formalReviewTruth = collectFormalReviewTruth(pullRequest);
   const reviewTimeline = buildReviewTimeline(pullRequest);
-  const reviewCommentsCount = parsedGeminiSignals.totalCount > 0 ? parsedGeminiSignals.totalCount : codexFallback.completed ? 1 : pullRequest.reviewCommentsCount;
-  const unresolvedReviewCommentsCount = parsedGeminiSignals.totalCount > 0 ? parsedGeminiSignals.blockingCount : codexFallback.completed ? codexFallback.blocking ? 1 : 0 : pullRequest.unresolvedReviewCommentsCount;
-  const reviewerStatus = codexFallback.completed ? "codex_review_available" : codexFallback.blocked ? "codex_review_blocked" : codexFallback.requested ? "codex_review_requested" : reviewCommentsCount > 0 ? "gemini_review_available" : "review_unavailable";
+  const reviewCommentsCount = parsedGeminiSignals.totalCount > 0 ? parsedGeminiSignals.totalCount : effectiveCodexFallback.completed ? 1 : pullRequest.reviewCommentsCount;
+  const unresolvedReviewCommentsCount = parsedGeminiSignals.totalCount > 0 ? parsedGeminiSignals.blockingCount : effectiveCodexFallback.completed ? effectiveCodexFallback.blocking ? 1 : 0 : pullRequest.unresolvedReviewCommentsCount;
+  const reviewerStatus = effectiveCodexFallback.completed ? "codex_review_available" : effectiveCodexFallback.blocked ? "codex_review_blocked" : effectiveCodexFallback.requested ? "codex_review_requested" : reviewCommentsCount > 0 ? "gemini_review_available" : "review_unavailable";
   const reviewer = reviewerStatus.startsWith("codex_review") ? "codex" : pullRequest.reviewer;
-  const reviewerEvidence = reviewerStatus.startsWith("codex_review") ? codexFallback.latestEvidence : parsedGeminiSignals.latestEvidence;
+  const reviewerEvidence = reviewerStatus.startsWith("codex_review") ? effectiveCodexFallback.latestEvidence : parsedGeminiSignals.latestEvidence;
   const reviewResponseSummary = buildReviewResponseSummary({
     pullRequest,
     files: pullRequest.files,
@@ -35489,16 +35499,27 @@ function collectGeminiReviewerSignals(pullRequest) {
     ...Array.isArray(pullRequest.issueComments) ? pullRequest.issueComments : [],
     ...Array.isArray(pullRequest.reviewComments) ? pullRequest.reviewComments : []
   ];
-  const parsed = comments.map(parseGeminiReviewComment).filter(Boolean);
+  const parsed = comments.map(parseGeminiReviewComment).filter(Boolean).sort(compareTimelineItems);
+  const currentHeadSha = normalizeText5(pullRequest.headSha);
+  const currentHeadSignals = currentHeadSha ? parsed.filter((signal) => evidenceMatchesHead(signal, currentHeadSha)) : [];
+  const activeSignals = currentHeadSignals.length > 0 ? currentHeadSignals : parsed;
   return {
-    totalCount: parsed.length,
-    blockingCount: parsed.filter((signal) => signal.blocking).length,
-    latestEvidence: parsed.at(-1) ?? null
+    totalCount: activeSignals.length,
+    blockingCount: activeSignals.filter((signal) => signal.blocking).length,
+    latestEvidence: activeSignals.at(-1) ?? null
   };
 }
 function collectCodexFallbackSignals(pullRequest) {
   const comments = [...Array.isArray(pullRequest.issueComments) ? pullRequest.issueComments : []];
-  const parsed = comments.map(parseCodexReviewFallbackComment).filter(Boolean);
+  const parsed = comments.map((comment) => {
+    const signal = parseCodexReviewFallbackComment(comment);
+    return signal ? {
+      ...signal,
+      url: normalizeCommentUrl(comment),
+      createdAt: normalizeCommentCreatedAt(comment),
+      updatedAt: normalizeCommentUpdatedAt(comment)
+    } : null;
+  }).filter(Boolean).sort(compareTimelineItems);
   const connectorBlockers = comments.map(parseCodexConnectorSetupComment).filter(Boolean);
   const actorIdentityIncidents = comments.map(parseActorIdentityIncidentComment).filter(Boolean);
   const latestActorIdentityIncident = actorIdentityIncidents.at(-1) ?? null;
@@ -35509,6 +35530,7 @@ function collectCodexFallbackSignals(pullRequest) {
     completed: latest?.status === "completed",
     blocked: latest?.status === "blocked",
     blocking: latest?.blocking === true,
+    latestSignal: latest,
     latestEvidence: latest?.status === "completed" ? {
       reviewer: "codex",
       recommendedAction: latest.recommendedAction || "manual_review",
@@ -35519,6 +35541,25 @@ function collectCodexFallbackSignals(pullRequest) {
       includesCreatedEdit: latest.includesCreatedEdit === true
     } : null
   };
+}
+function emptyCodexFallbackSignals() {
+  return {
+    requested: false,
+    completed: false,
+    blocked: false,
+    blocking: false,
+    latestSignal: null,
+    latestEvidence: null
+  };
+}
+function evidenceMatchesHead(evidence, headSha) {
+  const normalizedHead = normalizeText5(headSha);
+  return Boolean(normalizedHead && normalizeText5(evidence?.headSha) === normalizedHead);
+}
+function evidenceTargetsDifferentHead(evidence, headSha) {
+  const normalizedHead = normalizeText5(headSha);
+  const evidenceHead = normalizeText5(evidence?.headSha);
+  return Boolean(normalizedHead && evidenceHead && evidenceHead !== normalizedHead);
 }
 function buildReviewTimeline(pullRequest) {
   const comments = [
@@ -35800,6 +35841,7 @@ function normalizeGitHubRuntime(value) {
       title: normalizeText5(pullRequestInput.title) || null,
       baseRef: normalizeText5(pullRequestInput.baseRef) || normalizeText5(pullRequestInput.base?.ref) || null,
       headRef: normalizeText5(pullRequestInput.headRef) || normalizeText5(pullRequestInput.head?.ref) || null,
+      headSha: normalizeText5(pullRequestInput.headSha) || normalizeText5(pullRequestInput.head_sha) || normalizeText5(pullRequestInput.head?.sha) || null,
       mergeable: normalizeNullableBoolean2(pullRequestInput.mergeable),
       mergeableState: normalizeText5(pullRequestInput.mergeableState) || normalizeText5(pullRequestInput.mergeable_state) || normalizeText5(pullRequestInput.mergeability?.state) || null,
       mergeConflict: pullRequestInput.mergeConflict === true || pullRequestInput.mergeability?.hasConflict === true || normalizeNullableBoolean2(pullRequestInput.mergeable) === false || normalizeText5(pullRequestInput.mergeableState) === "dirty" || normalizeText5(pullRequestInput.mergeable_state) === "dirty" || normalizeText5(pullRequestInput.mergeability?.state) === "dirty",

--- a/worker.js
+++ b/worker.js
@@ -35502,8 +35502,7 @@ function collectGeminiReviewerSignals(pullRequest) {
   const parsed = comments.map(parseGeminiReviewComment).filter(Boolean).sort(compareTimelineItems);
   const currentHeadSha = normalizeText5(pullRequest.headSha);
   const currentHeadSignals = currentHeadSha ? parsed.filter((signal) => evidenceMatchesHead(signal, currentHeadSha)) : [];
-  const headlessSignals = currentHeadSha ? parsed.filter((signal) => !evidenceHasHead(signal)) : [];
-  const activeSignals = currentHeadSha ? currentHeadSignals.length > 0 ? currentHeadSignals : headlessSignals : parsed;
+  const activeSignals = currentHeadSha ? currentHeadSignals : parsed;
   return {
     totalCount: activeSignals.length,
     blockingCount: activeSignals.filter((signal) => signal.blocking).length,
@@ -35558,9 +35557,6 @@ function emptyCodexFallbackSignals() {
 function evidenceMatchesHead(evidence, headSha) {
   const normalizedHead = normalizeText5(headSha);
   return Boolean(normalizedHead && normalizeText5(evidence?.headSha) === normalizedHead);
-}
-function evidenceHasHead(evidence) {
-  return Boolean(normalizeText5(evidence?.headSha));
 }
 function evidenceTargetsDifferentHead(evidence, headSha) {
   const normalizedHead = normalizeText5(headSha);

--- a/worker.js
+++ b/worker.js
@@ -35458,7 +35458,7 @@ function buildReviewState(pullRequest) {
     codexFallback.latestSignal ?? codexFallback.latestEvidence,
     currentHeadSha
   );
-  const effectiveCodexFallback = geminiEvidenceMatchesCurrentHead && codexFallbackStaleForCurrentHead ? emptyCodexFallbackSignals() : codexFallback;
+  const effectiveCodexFallback = geminiEvidenceMatchesCurrentHead && codexFallbackStaleForCurrentHead && !codexFallback.globalBlocker ? emptyCodexFallbackSignals() : codexFallback;
   const formalReviewTruth = collectFormalReviewTruth(pullRequest);
   const reviewTimeline = buildReviewTimeline(pullRequest);
   const reviewCommentsCount = parsedGeminiSignals.totalCount > 0 ? parsedGeminiSignals.totalCount : effectiveCodexFallback.completed ? 1 : pullRequest.reviewCommentsCount;
@@ -35502,7 +35502,8 @@ function collectGeminiReviewerSignals(pullRequest) {
   const parsed = comments.map(parseGeminiReviewComment).filter(Boolean).sort(compareTimelineItems);
   const currentHeadSha = normalizeText5(pullRequest.headSha);
   const currentHeadSignals = currentHeadSha ? parsed.filter((signal) => evidenceMatchesHead(signal, currentHeadSha)) : [];
-  const activeSignals = currentHeadSignals.length > 0 ? currentHeadSignals : parsed;
+  const headlessSignals = currentHeadSha ? parsed.filter((signal) => !evidenceHasHead(signal)) : [];
+  const activeSignals = currentHeadSha ? currentHeadSignals.length > 0 ? currentHeadSignals : headlessSignals : parsed;
   return {
     totalCount: activeSignals.length,
     blockingCount: activeSignals.filter((signal) => signal.blocking).length,
@@ -35530,6 +35531,7 @@ function collectCodexFallbackSignals(pullRequest) {
     completed: latest?.status === "completed",
     blocked: latest?.status === "blocked",
     blocking: latest?.blocking === true,
+    globalBlocker: Boolean(latestActorIdentityIncident || latestConnectorBlocker),
     latestSignal: latest,
     latestEvidence: latest?.status === "completed" ? {
       reviewer: "codex",
@@ -35548,6 +35550,7 @@ function emptyCodexFallbackSignals() {
     completed: false,
     blocked: false,
     blocking: false,
+    globalBlocker: false,
     latestSignal: null,
     latestEvidence: null
   };
@@ -35555,6 +35558,9 @@ function emptyCodexFallbackSignals() {
 function evidenceMatchesHead(evidence, headSha) {
   const normalizedHead = normalizeText5(headSha);
   return Boolean(normalizedHead && normalizeText5(evidence?.headSha) === normalizedHead);
+}
+function evidenceHasHead(evidence) {
+  return Boolean(normalizeText5(evidence?.headSha));
 }
 function evidenceTargetsDifferentHead(evidence, headSha) {
   const normalizedHead = normalizeText5(headSha);


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #448 の reviewer truth 判定で current head を優先し、PR #453 で発生した旧 head の request_changes が最新 approve を止め続ける不具合を解消する。

## Satisfied Success Criteria

- PR headSha を runtime truth に保持し、Gemini / Codex fallback の reviewer marker を current head 基準で評価する。\ncurrent head Gemini approve がある場合、旧 head の Codex fallback request_changes は自動マージ判定から外す。\n旧 head の Gemini approve は current head 未レビュー時の review truth として採用しない。\nPR head が既知の場合、Head SHA 欄のない Gemini approve も auto-merge reviewer truth には採用しない。\nCodex connector / actor identity incident のような global blocker は current head approve があっても消さない。\nPR #453 の実例を Issue #448 に記録済み。

## Unsatisfied Success Criteria

None.

## Non-goal violations

deploy 自動化、credential / permission mutation、PR #453 の機能変更、Issue #448 close、Custom GPT Action Schema 更新はこのPRでは扱わない。

## Dry-run Impact Report

- Target Issue: Issue #448
- Implementing Success Criteria: approve → 証跡コメント → 自動マージが stale review truth によって止まり続けないこと。current head 未レビュー、headless approve、platform blocker は引き続き止めること。
- Explicit Non-goals: deploy / credential / permission / dashboard UI は変更しない。
- Expected touched files/routes/workflows: src/core/execution-continuity.js, test/execution-continuity.test.js, test/worker.test.js, worker.js
- Affected Issues: #448
- Affected PRs: #453 は再現実例。#454 が修正PR。
- Affected workflows: approve-auto-merge の review truth 前提、gemini-pr-review / codex-pr-review-fallback の marker 解釈。workflow 定義自体は変更なし。
- Affected runtime/operator surfaces: Worker review_truth / execution continuity / Butler merge-readiness synthesis。
- What may break if we patch narrowly: 旧 head marker だけを雑に無視すると headless marker や connector/actor blocker を誤って承認扱い・非表示扱いにするリスクがある。
- Unknowns to investigate before coding: Codex fallback request_changes、Gemini approve、headless marker、global blocker が head を跨いだ場合の選択順。レビュー指摘で境界を追加確認済み。
- Validation needed: node --test test/execution-continuity.test.js / npm test / self-parity / generated-worker check
- Stop condition: current head 未レビュー・headless approve・connector/actor blocker が merge-ready になる場合は停止。

## File / Line Hypotheses

- file: src/core/execution-continuity.js\n  - hypothesis: buildReviewState / collectGeminiReviewerSignals / collectCodexFallbackSignals が headSha をまたいだ marker を同じ最新 truth として扱っている。\n  - risk if changed narrowly: 旧 head request_changes だけでなく、旧 head approve、headless approve、platform blocker まで誤って隠す。\n  - validation: current head approve, stale Gemini approve, headless Gemini approve, global blocker の境界テストを追加する。\n  - related Issue: #448\n- file: test/execution-continuity.test.js\n  - hypothesis: PR #453 型の stale review truth 再現テストが不足している。\n  - risk if changed narrowly: approve auto merge が再び古い reviewer marker で止まる、または古い approve を通す。\n  - validation: stale/current/headless 混在ケースを unit test 化する。\n  - related Issue: #448

## Hypothesis Retrospective

- expected: current head Gemini approve は stale Codex fallback request_changes より優先される。\n- actual: その通り。さらにレビュー指摘で stale Gemini approve、headless approve、global blocker の境界も追加した。\n- mismatch: headless legacy Gemini marker は表示履歴としては残せるが、PR head が既知なら reviewer truth としては採用しない方針へ修正した。\n- lesson: reviewer truth は reviewer 種別だけでなく head attribution と platform blocker を分けて扱う。\n- should become RAG candidate: はい。PR #453 / Issue #448 の stale reviewer truth 事故として記録候補。

## Verification Evidence

- Unit: node --test test/execution-continuity.test.js PASS: 21 tests
- Integration: npm test PASS: 852 pass / 1 skip, check:self-parity PASS, check:generated-worker PASS
- E2E: PR #453 の実例を Issue #448 に記録。current-head approve vs stale request_changes / stale approve / headless approve / global blocker を unit boundary として再現。
- Manual: gh pr view #453 で旧 head Codex fallback request_changes と current head Gemini approve の混在を確認し、PR #453 は手動 merge 済み。
- Evidence path/link: Issue #448 comment: https://github.com/marushu/vtdd-v2-p/issues/448#issuecomment-4494382347 / PR #454

## Butler Completion Contract

- Owner goal: approve 済み PR が古い reviewer truth で止まり続けず、必要な blocker だけ残るようにする。
- Butler entrypoint: 既存の Butler review readiness / review_truth surface。Action Schema はこのPRでは変更なし。
- Action Schema exposure: 既存 operationId の範囲内。新規 Action Schema なし。
- Runtime path: Worker review_truth / execution continuity path。
- Runner/runtime truth: PR headSha と reviewer marker head SHA を使って before/after review truth を判定する。
- Authority boundary: merge authority は変更なし。自動マージは既存 approve-auto-merge gate の範囲。deploy / credential / permission なし。
- E2E evidence: このPRでは runtime unit/integration evidence。iPhone Butler live E2E は不要。
- Completion status: complete

## Surface Update Checklist

- Cloudflare deploy: 不要。worker.js 生成物は更新済みだが Cloudflare deploy はこのPRでは実行しない。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 不要。

## Related Constitution Rules

- Safety Invariants: reviewer truth は stale runtime truth を採用しない。\nAuthority Boundary: merge gate / deploy gate は変更しない。\nEvidence Discipline: PR #453 の実例と追加テストで証跡化。

## Out-of-scope but NOT implemented

- dashboard Butler chat のリアルタイム化。\ndeploy 自動化。\nGitHub App installation 自動化。

## Extra changes (if any)

Codex fallback reviewer の request_changes 指摘を反映し、stale Gemini approve / headless approve / global blocker の境界を追加。

<!-- VTDD metadata -->
- Issue: Issue #448
- Execution ID: mac-codex-issue448-current-head-review-truth
- Goal: Fix current-head reviewer truth for approve auto merge
