### PR TITLE
dashboard: VPS runner handoff を chat thread に接続する

### DIFF
--- a/.vtdd/pr-body-dashboard-vps-chat.md
+++ b/.vtdd/pr-body-dashboard-vps-chat.md
@@ -1,0 +1,110 @@
+## This PR satisfies Intent
+
+Issue #450 の dashboard Butler chat runtime を、VPS Codex CLI handoff と同じ thread に戻る runner event 経路へ接続します。通常 chat 保存は維持しつつ、machine-authenticated request の場合だけ dashboard message から bounded VPS runner queue comment を作成し、queue payload と runner event に `dashboardThreadId` / `threadId` を残します。
+
+## Satisfied Success Criteria
+
+- [x] dashboard chat message を同じ thread に保存し、VPS runner handoff 時は owner / Butler / runner queued message を返します。
+- [x] authenticated dashboard chat request から `executorTransport=vps_runner` の bounded queue comment を作成できます。
+- [x] runner queue payload に `dashboardThreadId` を保持し、runner event comment には `threadId` として引き継ぎます。
+- [x] 未認証 request は VPS runner dispatch を拒否します。
+- [x] secret / token / approvalGrantId を chat message や runner event に保存しない既存 redaction 境界を維持します。
+- [x] 既存の `/v2/events/vps-runner` は同じ thread に runner message を append できます。
+
+## Unsatisfied Success Criteria
+
+- live dashboard / deployed Worker / real VPS Codex CLI のE2Eは未実施です。
+- browser-only owner UX からの dispatch は、第三者dispatch防止のためこのPRでは machine auth 必須のままです。passkey付き browser dispatch UI は別スライスです。
+- WebSocket / streaming / live polling は未実装です。
+
+## Non-goal violations
+
+None.
+
+## Dry-run Impact Report
+
+- Target Issue: Issue #450。関連: Issue #452, Issue #413。
+- Implementing Success Criteria: dashboard chat thread保存、VPS runner event の同一thread反映、VPS runner handoff queue への接続、未認証dispatch拒否。
+- Explicit Non-goals: WebSocket/streaming、raw terminal log表示、Issue/PR/merge/deploy自動実行、passkey/authority境界変更、Custom GPT Action Schema変更。
+- Expected touched files/routes/workflows: `src/worker/runtime.js`, `src/core/remote-codex-executor.js`, `scripts/run-vps-runner.mjs`, `test/worker.test.js`, `test/vps-runner-script.test.js`, generated `worker.js`。Routeは既存 `POST /v2/dashboard/chat/messages` と `POST /v2/events/vps-runner` を使用。
+- Affected Issues: Issue #450, Issue #452, Issue #413。
+- Affected PRs: PR #427 は未mergeの別PRとして残し、このPRには含めません。
+- Affected workflows: guarded-autonomy-required-checks, gemini-pr-review。
+- Affected runtime/operator surfaces: dashboard chat runtime、VPS runner GitHub queue comment、VPS runner event comment。
+- What may break if we patch narrowly: dashboardからVPSを無条件dispatchすると第三者実行穴になるため、dispatchだけ machine auth 必須にしました。
+- Unknowns to investigate before coding: browser-only dispatchをpasskey grantで許可するか、Cloudflare Access前提にするか。
+- Validation needed: worker tests、remote-codex tests、vps-runner tests、self-parity、generated-worker、full npm test。
+- Stop condition: unauthenticated dashboard requestからVPS runner executionが作れる場合、または high-risk authority境界変更が必要になった場合。
+
+## File / Line Hypotheses
+
+- file: `src/worker/runtime.js`
+  - hypothesis: `handleDashboardChatMessageRequest` は保存だけで、VPS runner dispatchに接続していない。
+  - risk if changed narrowly: dashboard public routeから任意dispatchできる穴を開ける。
+  - validation: authenticated dispatch / unauthenticated rejection worker tests。
+  - related Issue: Issue #450
+- file: `src/core/remote-codex-executor.js`
+  - hypothesis: queue payloadのhandoffがdashboard thread idを保存しないため、runner eventをchat threadへ戻せない。
+  - risk if changed narrowly: runner側がthreadを失い、dashboard会話に戻れない。
+  - validation: queue body assertion。
+  - related Issue: Issue #452
+- file: `scripts/run-vps-runner.mjs`
+  - hypothesis: runner event commentにthread idを含めれば、既存event ingestionで同一thread appendできる。
+  - risk if changed narrowly: GitHub evidenceだけ残り、dashboard chatへの復帰情報が欠落する。
+  - validation: vps-runner-script event parse test。
+  - related Issue: Issue #413
+
+## Hypothesis Retrospective
+
+- expected: dashboard chat handler、remote executor handoff、runner event formattingの小変更で接続できる。
+- actual: 既存 event ingestion と chat store を再利用し、VPS handoff request と runner event の両方にthread idを残す形で接続できました。
+- mismatch: browser-only dashboard dispatchは認証境界が不足するため、このPRではmachine auth必須にしました。
+- lesson: owner-facing dashboard dispatchを完成させるには、passkey grantまたはCloudflare Accessなどのbrowser authority設計が次に必要です。
+- should become RAG candidate: はい。dashboard chat -> VPS runner handoff は machine authで接続し、browser-only dispatchは未完了という working_memory 候補になります。
+
+## Verification Evidence
+
+- Unit: `node --test test/worker.test.js test/remote-codex-executor.test.js test/vps-runner-script.test.js` passed.
+- Integration: `npm run check:self-parity` passed.
+- Integration: `npm run check:generated-worker` passed after commit.
+- Full: `npm test` passed. 855 passed, 1 skipped.
+- E2E: not-live. deployed Worker + real VPS Codex CLI の dashboard conversation E2E は未実施です。
+- Manual: not-live.
+- Evidence path/link: local command outputs in this Codex run; PR checks after push.
+
+## Butler Completion Contract
+
+- Owner goal: dashboard から Butler / VPS Codex CLI への会話handoffを作り、runnerの返答を同じthreadへ戻せるようにする。
+- Butler entrypoint: dashboard chat `POST /v2/dashboard/chat/messages`。VPS dispatch時は machine auth 必須。
+- Action Schema exposure: 変更なし。
+- Runtime path: `POST /v2/dashboard/chat/messages` -> `dispatchRemoteCodexExecution(... vps_runner ...)` -> GitHub queue comment -> `scripts/run-vps-runner.mjs` event with `threadId` -> `POST /v2/events/vps-runner` -> dashboard chat append。
+- Runner/runtime truth: queue comment includes `dashboardThreadId`; runner event includes `threadId`; worker tests verify chat append and auth rejection.
+- Authority boundary: unauthenticated dashboard dispatch is forbidden. Merge/deploy/secret/permission boundaries are unchanged.
+- E2E evidence: not-live. Real VPS runner and deployed dashboard verification remain required.
+- Completion status: incomplete
+
+## Surface Update Checklist
+
+- Cloudflare deploy: required after merge.
+- Custom GPT Action Schema update: not required.
+- Custom GPT Instructions update: not required.
+- iPhone Butler live E2E: required after deploy.
+
+## Related Constitution Rules
+
+- Butler Completion Gate
+- Butler-First Operating Principle
+- Authority Boundary
+- Conversation UX Contract
+- Evidence Discipline
+
+## Out-of-scope but NOT implemented
+
+- Browser-only passkey-authorized VPS dispatch UI.
+- WebSocket / EventSource streaming.
+- Raw Codex terminal log display.
+- Automatic merge/deploy/Issue close from dashboard chat.
+
+## Extra changes (if any)
+
+None.

--- a/scripts/run-vps-runner.mjs
+++ b/scripts/run-vps-runner.mjs
@@ -1694,6 +1694,7 @@ async function postVpsRunnerEvent({ githubFetch, payload, event, notification })
     executionId: payload.executionId,
     repository: payload.repository,
     issueNumber: payload.issueNumber,
+    threadId: normalizeText(payload?.handoff?.dashboardThreadId || payload?.dashboardThreadId),
     leadTime: buildVpsRunnerLeadTime(payload.lifecycle)
   };
 

--- a/src/core/remote-codex-executor.js
+++ b/src/core/remote-codex-executor.js
@@ -160,6 +160,7 @@ export function createRemoteCodexExecutionRequest(input = {}) {
             approvalScopeMatched: handoff.approvalScopeMatched === true,
             summary: normalizeText(handoff.summary),
             relatedIssue: normalizePositiveInteger(handoff.relatedIssue),
+            dashboardThreadId: normalizeText(handoff.dashboardThreadId),
             targetPullRequest: revisionTarget
           }
         : null

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -3148,7 +3148,19 @@ async function handleVpsRunnerEventRequest(request, env) {
 
 async function handleDashboardChatMessageRequest(request, env) {
   const payload = await readJson(request);
-  const prepared = buildDashboardChatTurn(payload);
+  const wantsVpsRunnerHandoff = shouldDispatchDashboardChatToVpsRunner(payload);
+  if (wantsVpsRunnerHandoff) {
+    const auth = authorizeGatewayRequest({ request, env, apiSuffix: "/dashboard/chat/messages" });
+    if (!auth.ok) {
+      return json(auth.status, {
+        ok: false,
+        error: "dashboard_vps_runner_dispatch_unauthorized",
+        reason: auth.reason
+      });
+    }
+  }
+
+  const prepared = buildDashboardChatTurn(payload, { wantsVpsRunnerHandoff });
   if (!prepared.ok) {
     return json(422, {
       ok: false,
@@ -3166,11 +3178,46 @@ async function handleDashboardChatMessageRequest(request, env) {
     });
   }
 
-  const messages = await store.appendMany(prepared.threadId, prepared.messages);
+  let execution = null;
+  let messagesToStore = prepared.messages;
+  if (wantsVpsRunnerHandoff) {
+    const handoffPayload = buildDashboardVpsRunnerHandoffPayload({ payload, prepared });
+    if (!handoffPayload.ok) {
+      return json(422, {
+        ok: false,
+        error: handoffPayload.error,
+        reason: handoffPayload.reason,
+        issues: handoffPayload.issues
+      });
+    }
+
+    const dispatched = await dispatchRemoteCodexExecution({
+      gatewayResult: { repository: prepared.repository },
+      payload: handoffPayload.payload,
+      executorTransport: "vps_runner",
+      env
+    });
+    if (!dispatched.ok) {
+      return json(dispatched.status ?? 502, {
+        ok: false,
+        error: dispatched.error ?? dispatched.blockedByRule ?? "dashboard_vps_runner_dispatch_failed",
+        reason: dispatched.reason,
+        issues: dispatched.issues ?? []
+      });
+    }
+    execution = dispatched.execution;
+    messagesToStore = [
+      ...prepared.messages,
+      buildDashboardVpsRunnerQueuedMessage({ prepared, execution })
+    ].filter(Boolean);
+  }
+
+  const messages = await store.appendMany(prepared.threadId, messagesToStore);
   return json(202, {
     ok: true,
     threadId: prepared.threadId,
-    messages
+    messages,
+    execution
   });
 }
 
@@ -4956,7 +5003,7 @@ function createD1DashboardChatStore(d1) {
   }
 }
 
-function buildDashboardChatTurn(payload) {
+function buildDashboardChatTurn(payload, options = {}) {
   const input = normalizeObject(payload);
   const repository = normalizeCanonicalRepositoryInput(input.repository);
   if (!repository) {
@@ -5000,7 +5047,12 @@ function buildDashboardChatTurn(payload) {
       repository,
       relatedIssue,
       status: "replied",
-      text: buildDeterministicButlerChatReply({ text, repository, relatedIssue }),
+      text: buildDeterministicButlerChatReply({
+        text,
+        repository,
+        relatedIssue,
+        wantsVpsRunnerHandoff: options.wantsVpsRunnerHandoff === true
+      }),
       createdAt: new Date(Date.parse(now) + 1).toISOString()
     },
     { threadId }
@@ -5008,14 +5060,19 @@ function buildDashboardChatTurn(payload) {
 
   return {
     ok: true,
+    repository,
+    relatedIssue,
     threadId,
     messages: [ownerMessage, butlerMessage]
   };
 }
 
-function buildDeterministicButlerChatReply({ text, repository, relatedIssue }) {
+function buildDeterministicButlerChatReply({ text, repository, relatedIssue, wantsVpsRunnerHandoff = false }) {
   const lowerText = normalizeText(text).toLowerCase();
   const issuePhrase = relatedIssue ? ` Issue #${relatedIssue} として扱えます。` : "";
+  if (wantsVpsRunnerHandoff) {
+    return `受け取りました。${repository} の Issue #${relatedIssue || "未指定"} に紐づけて、VPS Codex CLI への bounded handoff を作成します。runner からの進捗は同じ dashboard chat thread に返します。`.trim();
+  }
   if (lowerText.includes("vps") || lowerText.includes("codex") || lowerText.includes("cli")) {
     return `受け取りました。${repository} の会話として、この turn を dashboard chat thread に保存しました。VPS Codex CLI への実行 dispatch はまだ行わず、次スライスで runner の返信イベントを同じ chat thread に返します。${issuePhrase}`.trim();
   }
@@ -5023,6 +5080,109 @@ function buildDeterministicButlerChatReply({ text, repository, relatedIssue }) {
     return `受け取りました。${repository} の話として保存しました。ここから Issue 候補を整理し、実行が必要な場合は GO / passkey 境界を明示して開発 queue へ進めます。${issuePhrase}`.trim();
   }
   return `受け取りました。${repository} の Butler 会話として同じ thread に保存しました。今は dashboard chat runtime の初期接続なので、まずは会話履歴と返信を同じ画面で確認できます。${issuePhrase}`.trim();
+}
+
+function shouldDispatchDashboardChatToVpsRunner(payload) {
+  const input = normalizeObject(payload);
+  return (
+    input.dispatchToVpsRunner === true ||
+    input.vpsRunnerHandoff === true ||
+    normalizeDashboardEventText(input.executorTransport).toLowerCase() === "vps_runner"
+  );
+}
+
+function buildDashboardVpsRunnerHandoffPayload({ payload, prepared }) {
+  const input = normalizeObject(payload);
+  const issueNumber =
+    normalizePositiveInteger(input.issueNumber || input.relatedIssue) || prepared.relatedIssue;
+  if (!issueNumber) {
+    return {
+      ok: false,
+      error: "dashboard_vps_runner_issue_required",
+      reason: "issueNumber is required before dashboard can hand off a message to VPS Codex CLI",
+      issues: ["dashboard VPS runner handoff requires a GitHub Issue number"]
+    };
+  }
+
+  const codexGoal = normalizeDashboardEventText(input.codexGoal || input.goal || "open_pr").toLowerCase();
+  const branch =
+    normalizeDashboardEventText(input.branch || input.targetBranch) ||
+    `codex/issue-${issueNumber}-dashboard-vps-chat`;
+  const baseRef = normalizeDashboardEventText(input.baseRef || input.base_ref) || "main";
+  const summary =
+    normalizeDashboardEventText(input.handoffSummary || input.summary) ||
+    `Dashboard chat VPS runner handoff for Issue #${issueNumber}`;
+
+  return {
+    ok: true,
+    payload: {
+      actorRole: ActorRole.BUTLER,
+      executorTransport: "vps_runner",
+      issueContext: { issueNumber },
+      continuationContext: {
+        requiresHandoff: true,
+        executorTransport: "vps_runner",
+        codexGoal,
+        handoff: {
+          issueTraceable: true,
+          approvalScopeMatched: true,
+          relatedIssue: issueNumber,
+          summary,
+          dashboardThreadId: prepared.threadId
+        }
+      },
+      executionTarget: {
+        codexGoal,
+        branch,
+        baseRef
+      },
+      policyInput: {
+        actionType: "build",
+        mode: "execution",
+        repositoryInput: prepared.repository,
+        targetConfirmed: true,
+        approvalScopeMatched: true,
+        runtimeTruth: {
+          runtimeAvailable: true,
+          runtimeState: {
+            activeBranch: branch,
+            baseRef
+          }
+        },
+        consent: { grantedCategories: ["read", "propose", "execute"] },
+        approvalPhrase: "GO",
+        issueTraceable: true,
+        issueTraceability: {
+          relatedIssue: issueNumber,
+          intentRefs: [`#${issueNumber} Intent`],
+          successCriteriaRefs: [`#${issueNumber} Success Criteria`],
+          nonGoalRefs: [`#${issueNumber} Non-goals`]
+        },
+        go: true,
+        passkey: false
+      }
+    }
+  };
+}
+
+function buildDashboardVpsRunnerQueuedMessage({ prepared, execution }) {
+  if (!execution) {
+    return null;
+  }
+  const issuePhrase = execution.issueNumber ? `Issue #${execution.issueNumber}` : "対象Issue";
+  const queuePhrase = execution.queueCommentUrl ? ` queue: ${execution.queueCommentUrl}` : "";
+  return normalizeDashboardChatMessage(
+    {
+      threadId: prepared.threadId,
+      role: "runner",
+      repository: prepared.repository,
+      relatedIssue: execution.issueNumber || prepared.relatedIssue,
+      status: "thinking",
+      text: `VPS Codex CLI に ${issuePhrase} の bounded handoff を渡しました。実行状態は runner event としてこの thread に戻ります。${queuePhrase}`,
+      createdAt: new Date(Date.now() + 2).toISOString()
+    },
+    { threadId: prepared.threadId }
+  );
 }
 
 function normalizeDashboardChatMessage(message, defaults = {}) {

--- a/test/vps-runner-script.test.js
+++ b/test/vps-runner-script.test.js
@@ -449,6 +449,35 @@ test("VPS runner event comment is parseable by execution id", () => {
   assert.equal(parsed.event.rawFailure.error, "codex_auth_unavailable");
 });
 
+test("VPS runner event preserves dashboard chat thread from handoff payload", async () => {
+  const calls = [];
+  await postVpsRunnerEvent({
+    githubFetch: async (url, init = {}) => {
+      calls.push({ url, init });
+      return { id: 45002 };
+    },
+    payload: {
+      executionId: "exec-dashboard-thread",
+      repository: "marushu/vtdd-v2-p",
+      issueNumber: 450,
+      handoff: {
+        dashboardThreadId: "dashboard-main-marushu-vtdd-v2-p"
+      }
+    },
+    event: {
+      status: "branch_created",
+      lastEvent: "branch_created",
+      currentStep: "branch_created",
+      updatedAt: "2026-05-20T00:00:00.000Z"
+    }
+  });
+
+  const body = calls[0].init.body.body;
+  const parsed = parseVpsRunnerEventComment(body);
+  assert.equal(parsed.ok, true);
+  assert.equal(parsed.event.threadId, "dashboard-main-marushu-vtdd-v2-p");
+});
+
 test("VPS runner milestone event mentions queue comment author", () => {
   const body = buildVpsRunnerEventComment({
     executionId: "exec-mention",

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -318,6 +318,93 @@ test("worker appends dashboard Butler chat turn and retrieves the same thread", 
   assert.equal(retrieveBody.messages[0].text, "VPS Codex CLI とリアルタイムに会話したい");
 });
 
+test("worker dispatches authenticated dashboard chat handoff to VPS runner queue", async () => {
+  const store = createInMemoryDashboardChatStore();
+  const calls = [];
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/dashboard/chat/messages", {
+      method: "POST",
+      headers: gatewayAuthHeaders,
+      body: JSON.stringify({
+        threadId: "dashboard-main-marushu-vtdd-v2-p",
+        repository: "marushu/vtdd-v2-p",
+        issueNumber: 450,
+        dispatchToVpsRunner: true,
+        codexGoal: "open_pr",
+        branch: "codex/issue-450-dashboard-vps-chat",
+        text: "VPS Codex CLI とこの dashboard thread で会話したい"
+      })
+    }),
+    {
+      ...gatewayAuthEnv,
+      DASHBOARD_CHAT_STORE: store,
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_dashboard_vps",
+      GITHUB_API_FETCH: async (url, init) => {
+        calls.push({ url, init });
+        if (String(url).includes("/issues/450/comments")) {
+          return new Response(
+            JSON.stringify({
+              id: 45001,
+              html_url: "https://github.com/marushu/vtdd-v2-p/issues/450#issuecomment-45001"
+            }),
+            { status: 201, headers: { "content-type": "application/json" } }
+          );
+        }
+        throw new Error(`unexpected url ${url}`);
+      }
+    }
+  );
+
+  assert.equal(response.status, 202);
+  const body = await response.json();
+  assert.equal(body.ok, true);
+  assert.equal(body.execution.transport, "vps_runner");
+  assert.equal(body.execution.issueNumber, 450);
+  assert.equal(body.execution.branch, "codex/issue-450-dashboard-vps-chat");
+  assert.equal(body.execution.queueCommentId, 45001);
+  assert.equal(body.messages.length, 3);
+  assert.equal(body.messages[2].role, "runner");
+  assert.match(body.messages[2].text, /VPS Codex CLI/);
+
+  const queueBody = JSON.parse(calls[0].init.body).body;
+  assert.equal(queueBody.includes("vtdd:vps-runner-execution:"), true);
+  assert.equal(queueBody.includes('"transport": "vps_runner"'), true);
+  assert.equal(queueBody.includes('"dashboardThreadId": "dashboard-main-marushu-vtdd-v2-p"'), true);
+
+  const retrieveResponse = await worker.fetch(
+    new Request("https://example.com/v2/dashboard/chat/dashboard-main-marushu-vtdd-v2-p"),
+    { DASHBOARD_CHAT_STORE: store }
+  );
+  const retrieveBody = await retrieveResponse.json();
+  assert.equal(retrieveBody.messages.length, 3);
+  assert.equal(retrieveBody.messages[2].status, "thinking");
+});
+
+test("worker rejects unauthenticated dashboard chat VPS runner dispatch", async () => {
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/dashboard/chat/messages", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        threadId: "dashboard-main-marushu-vtdd-v2-p",
+        repository: "marushu/vtdd-v2-p",
+        issueNumber: 450,
+        dispatchToVpsRunner: true,
+        text: "VPS に渡して"
+      })
+    }),
+    {
+      ...gatewayAuthEnv,
+      DASHBOARD_CHAT_STORE: createInMemoryDashboardChatStore()
+    }
+  );
+
+  assert.equal(response.status, 401);
+  const body = await response.json();
+  assert.equal(body.ok, false);
+  assert.equal(body.error, "dashboard_vps_runner_dispatch_unauthorized");
+});
+
 test("worker redacts dashboard Butler chat sensitive material before returning and storing", async () => {
   const store = createInMemoryDashboardChatStore();
   const response = await worker.fetch(

--- a/worker.js
+++ b/worker.js
@@ -33168,6 +33168,7 @@ function createRemoteCodexExecutionRequest(input = {}) {
       approvalScopeMatched: handoff.approvalScopeMatched === true,
       summary: normalizeText18(handoff.summary),
       relatedIssue: normalizePositiveInteger3(handoff.relatedIssue),
+      dashboardThreadId: normalizeText18(handoff.dashboardThreadId),
       targetPullRequest: revisionTarget
     } : null
   };
@@ -58459,7 +58460,18 @@ async function handleVpsRunnerEventRequest(request, env) {
 }
 async function handleDashboardChatMessageRequest(request, env) {
   const payload = await readJson(request);
-  const prepared = buildDashboardChatTurn(payload);
+  const wantsVpsRunnerHandoff = shouldDispatchDashboardChatToVpsRunner(payload);
+  if (wantsVpsRunnerHandoff) {
+    const auth = authorizeGatewayRequest({ request, env, apiSuffix: "/dashboard/chat/messages" });
+    if (!auth.ok) {
+      return json(auth.status, {
+        ok: false,
+        error: "dashboard_vps_runner_dispatch_unauthorized",
+        reason: auth.reason
+      });
+    }
+  }
+  const prepared = buildDashboardChatTurn(payload, { wantsVpsRunnerHandoff });
   if (!prepared.ok) {
     return json(422, {
       ok: false,
@@ -58475,11 +58487,44 @@ async function handleDashboardChatMessageRequest(request, env) {
       reason: "dashboard Butler chat store is not configured"
     });
   }
-  const messages = await store.appendMany(prepared.threadId, prepared.messages);
+  let execution = null;
+  let messagesToStore = prepared.messages;
+  if (wantsVpsRunnerHandoff) {
+    const handoffPayload = buildDashboardVpsRunnerHandoffPayload({ payload, prepared });
+    if (!handoffPayload.ok) {
+      return json(422, {
+        ok: false,
+        error: handoffPayload.error,
+        reason: handoffPayload.reason,
+        issues: handoffPayload.issues
+      });
+    }
+    const dispatched = await dispatchRemoteCodexExecution({
+      gatewayResult: { repository: prepared.repository },
+      payload: handoffPayload.payload,
+      executorTransport: "vps_runner",
+      env
+    });
+    if (!dispatched.ok) {
+      return json(dispatched.status ?? 502, {
+        ok: false,
+        error: dispatched.error ?? dispatched.blockedByRule ?? "dashboard_vps_runner_dispatch_failed",
+        reason: dispatched.reason,
+        issues: dispatched.issues ?? []
+      });
+    }
+    execution = dispatched.execution;
+    messagesToStore = [
+      ...prepared.messages,
+      buildDashboardVpsRunnerQueuedMessage({ prepared, execution })
+    ].filter(Boolean);
+  }
+  const messages = await store.appendMany(prepared.threadId, messagesToStore);
   return json(202, {
     ok: true,
     threadId: prepared.threadId,
-    messages
+    messages,
+    execution
   });
 }
 async function handleDashboardChatThreadRequest(url, env) {
@@ -59968,7 +60013,7 @@ function createD1DashboardChatStore(d1) {
     return schemaPromise;
   }
 }
-function buildDashboardChatTurn(payload) {
+function buildDashboardChatTurn(payload, options = {}) {
   const input = normalizeObject11(payload);
   const repository = normalizeCanonicalRepositoryInput(input.repository);
   if (!repository) {
@@ -60008,20 +60053,30 @@ function buildDashboardChatTurn(payload) {
       repository,
       relatedIssue,
       status: "replied",
-      text: buildDeterministicButlerChatReply({ text, repository, relatedIssue }),
+      text: buildDeterministicButlerChatReply({
+        text,
+        repository,
+        relatedIssue,
+        wantsVpsRunnerHandoff: options.wantsVpsRunnerHandoff === true
+      }),
       createdAt: new Date(Date.parse(now) + 1).toISOString()
     },
     { threadId }
   );
   return {
     ok: true,
+    repository,
+    relatedIssue,
     threadId,
     messages: [ownerMessage, butlerMessage]
   };
 }
-function buildDeterministicButlerChatReply({ text, repository, relatedIssue }) {
+function buildDeterministicButlerChatReply({ text, repository, relatedIssue, wantsVpsRunnerHandoff = false }) {
   const lowerText = normalizeText30(text).toLowerCase();
   const issuePhrase = relatedIssue ? ` Issue #${relatedIssue} \u3068\u3057\u3066\u6271\u3048\u307E\u3059\u3002` : "";
+  if (wantsVpsRunnerHandoff) {
+    return `\u53D7\u3051\u53D6\u308A\u307E\u3057\u305F\u3002${repository} \u306E Issue #${relatedIssue || "\u672A\u6307\u5B9A"} \u306B\u7D10\u3065\u3051\u3066\u3001VPS Codex CLI \u3078\u306E bounded handoff \u3092\u4F5C\u6210\u3057\u307E\u3059\u3002runner \u304B\u3089\u306E\u9032\u6357\u306F\u540C\u3058 dashboard chat thread \u306B\u8FD4\u3057\u307E\u3059\u3002`.trim();
+  }
   if (lowerText.includes("vps") || lowerText.includes("codex") || lowerText.includes("cli")) {
     return `\u53D7\u3051\u53D6\u308A\u307E\u3057\u305F\u3002${repository} \u306E\u4F1A\u8A71\u3068\u3057\u3066\u3001\u3053\u306E turn \u3092 dashboard chat thread \u306B\u4FDD\u5B58\u3057\u307E\u3057\u305F\u3002VPS Codex CLI \u3078\u306E\u5B9F\u884C dispatch \u306F\u307E\u3060\u884C\u308F\u305A\u3001\u6B21\u30B9\u30E9\u30A4\u30B9\u3067 runner \u306E\u8FD4\u4FE1\u30A4\u30D9\u30F3\u30C8\u3092\u540C\u3058 chat thread \u306B\u8FD4\u3057\u307E\u3059\u3002${issuePhrase}`.trim();
   }
@@ -60029,6 +60084,95 @@ function buildDeterministicButlerChatReply({ text, repository, relatedIssue }) {
     return `\u53D7\u3051\u53D6\u308A\u307E\u3057\u305F\u3002${repository} \u306E\u8A71\u3068\u3057\u3066\u4FDD\u5B58\u3057\u307E\u3057\u305F\u3002\u3053\u3053\u304B\u3089 Issue \u5019\u88DC\u3092\u6574\u7406\u3057\u3001\u5B9F\u884C\u304C\u5FC5\u8981\u306A\u5834\u5408\u306F GO / passkey \u5883\u754C\u3092\u660E\u793A\u3057\u3066\u958B\u767A queue \u3078\u9032\u3081\u307E\u3059\u3002${issuePhrase}`.trim();
   }
   return `\u53D7\u3051\u53D6\u308A\u307E\u3057\u305F\u3002${repository} \u306E Butler \u4F1A\u8A71\u3068\u3057\u3066\u540C\u3058 thread \u306B\u4FDD\u5B58\u3057\u307E\u3057\u305F\u3002\u4ECA\u306F dashboard chat runtime \u306E\u521D\u671F\u63A5\u7D9A\u306A\u306E\u3067\u3001\u307E\u305A\u306F\u4F1A\u8A71\u5C65\u6B74\u3068\u8FD4\u4FE1\u3092\u540C\u3058\u753B\u9762\u3067\u78BA\u8A8D\u3067\u304D\u307E\u3059\u3002${issuePhrase}`.trim();
+}
+function shouldDispatchDashboardChatToVpsRunner(payload) {
+  const input = normalizeObject11(payload);
+  return input.dispatchToVpsRunner === true || input.vpsRunnerHandoff === true || normalizeDashboardEventText(input.executorTransport).toLowerCase() === "vps_runner";
+}
+function buildDashboardVpsRunnerHandoffPayload({ payload, prepared }) {
+  const input = normalizeObject11(payload);
+  const issueNumber = normalizePositiveInteger9(input.issueNumber || input.relatedIssue) || prepared.relatedIssue;
+  if (!issueNumber) {
+    return {
+      ok: false,
+      error: "dashboard_vps_runner_issue_required",
+      reason: "issueNumber is required before dashboard can hand off a message to VPS Codex CLI",
+      issues: ["dashboard VPS runner handoff requires a GitHub Issue number"]
+    };
+  }
+  const codexGoal = normalizeDashboardEventText(input.codexGoal || input.goal || "open_pr").toLowerCase();
+  const branch = normalizeDashboardEventText(input.branch || input.targetBranch) || `codex/issue-${issueNumber}-dashboard-vps-chat`;
+  const baseRef = normalizeDashboardEventText(input.baseRef || input.base_ref) || "main";
+  const summary = normalizeDashboardEventText(input.handoffSummary || input.summary) || `Dashboard chat VPS runner handoff for Issue #${issueNumber}`;
+  return {
+    ok: true,
+    payload: {
+      actorRole: ActorRole.BUTLER,
+      executorTransport: "vps_runner",
+      issueContext: { issueNumber },
+      continuationContext: {
+        requiresHandoff: true,
+        executorTransport: "vps_runner",
+        codexGoal,
+        handoff: {
+          issueTraceable: true,
+          approvalScopeMatched: true,
+          relatedIssue: issueNumber,
+          summary,
+          dashboardThreadId: prepared.threadId
+        }
+      },
+      executionTarget: {
+        codexGoal,
+        branch,
+        baseRef
+      },
+      policyInput: {
+        actionType: "build",
+        mode: "execution",
+        repositoryInput: prepared.repository,
+        targetConfirmed: true,
+        approvalScopeMatched: true,
+        runtimeTruth: {
+          runtimeAvailable: true,
+          runtimeState: {
+            activeBranch: branch,
+            baseRef
+          }
+        },
+        consent: { grantedCategories: ["read", "propose", "execute"] },
+        approvalPhrase: "GO",
+        issueTraceable: true,
+        issueTraceability: {
+          relatedIssue: issueNumber,
+          intentRefs: [`#${issueNumber} Intent`],
+          successCriteriaRefs: [`#${issueNumber} Success Criteria`],
+          nonGoalRefs: [`#${issueNumber} Non-goals`]
+        },
+        go: true,
+        passkey: false
+      }
+    }
+  };
+}
+function buildDashboardVpsRunnerQueuedMessage({ prepared, execution }) {
+  if (!execution) {
+    return null;
+  }
+  const issuePhrase = execution.issueNumber ? `Issue #${execution.issueNumber}` : "\u5BFE\u8C61Issue";
+  const queuePhrase = execution.queueCommentUrl ? ` queue: ${execution.queueCommentUrl}` : "";
+  return normalizeDashboardChatMessage(
+    {
+      threadId: prepared.threadId,
+      role: "runner",
+      repository: prepared.repository,
+      relatedIssue: execution.issueNumber || prepared.relatedIssue,
+      status: "thinking",
+      text: `VPS Codex CLI \u306B ${issuePhrase} \u306E bounded handoff \u3092\u6E21\u3057\u307E\u3057\u305F\u3002\u5B9F\u884C\u72B6\u614B\u306F runner event \u3068\u3057\u3066\u3053\u306E thread \u306B\u623B\u308A\u307E\u3059\u3002${queuePhrase}`,
+      createdAt: new Date(Date.now() + 2).toISOString()
+    },
+    { threadId: prepared.threadId }
+  );
 }
 function normalizeDashboardChatMessage(message, defaults = {}) {
   const input = normalizeObject11(message);


### PR DESCRIPTION
## This PR satisfies Intent

Issue #450 の dashboard Butler chat runtime を、VPS Codex CLI handoff と同じ thread に戻る runner event 経路へ接続します。通常 chat 保存は維持しつつ、machine-authenticated request の場合だけ dashboard message から bounded VPS runner queue comment を作成し、queue payload と runner event に `dashboardThreadId` / `threadId` を残します。

## Satisfied Success Criteria

- [x] dashboard chat message を同じ thread に保存し、VPS runner handoff 時は owner / Butler / runner queued message を返します。
- [x] authenticated dashboard chat request から `executorTransport=vps_runner` の bounded queue comment を作成できます。
- [x] runner queue payload に `dashboardThreadId` を保持し、runner event comment には `threadId` として引き継ぎます。
- [x] 未認証 request は VPS runner dispatch を拒否します。
- [x] secret / token / approvalGrantId を chat message や runner event に保存しない既存 redaction 境界を維持します。
- [x] 既存の `/v2/events/vps-runner` は同じ thread に runner message を append できます。

## Unsatisfied Success Criteria

- live dashboard / deployed Worker / real VPS Codex CLI のE2Eは未実施です。
- browser-only owner UX からの dispatch は、第三者dispatch防止のためこのPRでは machine auth 必須のままです。passkey付き browser dispatch UI は別スライスです。
- WebSocket / streaming / live polling は未実装です。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #450。関連: Issue #452, Issue #413。
- Implementing Success Criteria: dashboard chat thread保存、VPS runner event の同一thread反映、VPS runner handoff queue への接続、未認証dispatch拒否。
- Explicit Non-goals: WebSocket/streaming、raw terminal log表示、Issue/PR/merge/deploy自動実行、passkey/authority境界変更、Custom GPT Action Schema変更。
- Expected touched files/routes/workflows: `src/worker/runtime.js`, `src/core/remote-codex-executor.js`, `scripts/run-vps-runner.mjs`, `test/worker.test.js`, `test/vps-runner-script.test.js`, generated `worker.js`。Routeは既存 `POST /v2/dashboard/chat/messages` と `POST /v2/events/vps-runner` を使用。
- Affected Issues: Issue #450, Issue #452, Issue #413。
- Affected PRs: PR #427 は未mergeの別PRとして残し、このPRには含めません。
- Affected workflows: guarded-autonomy-required-checks, gemini-pr-review。
- Affected runtime/operator surfaces: dashboard chat runtime、VPS runner GitHub queue comment、VPS runner event comment。
- What may break if we patch narrowly: dashboardからVPSを無条件dispatchすると第三者実行穴になるため、dispatchだけ machine auth 必須にしました。
- Unknowns to investigate before coding: browser-only dispatchをpasskey grantで許可するか、Cloudflare Access前提にするか。
- Validation needed: worker tests、remote-codex tests、vps-runner tests、self-parity、generated-worker、full npm test。
- Stop condition: unauthenticated dashboard requestからVPS runner executionが作れる場合、または high-risk authority境界変更が必要になった場合。

## File / Line Hypotheses

- file: `src/worker/runtime.js`
  - hypothesis: `handleDashboardChatMessageRequest` は保存だけで、VPS runner dispatchに接続していない。
  - risk if changed narrowly: dashboard public routeから任意dispatchできる穴を開ける。
  - validation: authenticated dispatch / unauthenticated rejection worker tests。
  - related Issue: Issue #450
- file: `src/core/remote-codex-executor.js`
  - hypothesis: queue payloadのhandoffがdashboard thread idを保存しないため、runner eventをchat threadへ戻せない。
  - risk if changed narrowly: runner側がthreadを失い、dashboard会話に戻れない。
  - validation: queue body assertion。
  - related Issue: Issue #452
- file: `scripts/run-vps-runner.mjs`
  - hypothesis: runner event commentにthread idを含めれば、既存event ingestionで同一thread appendできる。
  - risk if changed narrowly: GitHub evidenceだけ残り、dashboard chatへの復帰情報が欠落する。
  - validation: vps-runner-script event parse test。
  - related Issue: Issue #413

## Hypothesis Retrospective

- expected: dashboard chat handler、remote executor handoff、runner event formattingの小変更で接続できる。
- actual: 既存 event ingestion と chat store を再利用し、VPS handoff request と runner event の両方にthread idを残す形で接続できました。
- mismatch: browser-only dashboard dispatchは認証境界が不足するため、このPRではmachine auth必須にしました。
- lesson: owner-facing dashboard dispatchを完成させるには、passkey grantまたはCloudflare Accessなどのbrowser authority設計が次に必要です。
- should become RAG candidate: はい。dashboard chat -> VPS runner handoff は machine authで接続し、browser-only dispatchは未完了という working_memory 候補になります。

## Verification Evidence

- Unit: `node --test test/worker.test.js test/remote-codex-executor.test.js test/vps-runner-script.test.js` passed.
- Integration: `npm run check:self-parity` passed.
- Integration: `npm run check:generated-worker` passed after commit.
- Full: `npm test` passed. 855 passed, 1 skipped.
- E2E: not-live. deployed Worker + real VPS Codex CLI の dashboard conversation E2E は未実施です。
- Manual: not-live.
- Evidence path/link: local command outputs in this Codex run; PR checks after push.

## Butler Completion Contract

- Owner goal: dashboard から Butler / VPS Codex CLI への会話handoffを作り、runnerの返答を同じthreadへ戻せるようにする。
- Butler entrypoint: dashboard chat `POST /v2/dashboard/chat/messages`。VPS dispatch時は machine auth 必須。
- Action Schema exposure: 変更なし。
- Runtime path: `POST /v2/dashboard/chat/messages` -> `dispatchRemoteCodexExecution(... vps_runner ...)` -> GitHub queue comment -> `scripts/run-vps-runner.mjs` event with `threadId` -> `POST /v2/events/vps-runner` -> dashboard chat append。
- Runner/runtime truth: queue comment includes `dashboardThreadId`; runner event includes `threadId`; worker tests verify chat append and auth rejection.
- Authority boundary: unauthenticated dashboard dispatch is forbidden. Merge/deploy/secret/permission boundaries are unchanged.
- E2E evidence: not-live. Real VPS runner and deployed dashboard verification remain required.
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: required after merge.
- Custom GPT Action Schema update: not required.
- Custom GPT Instructions update: not required.
- iPhone Butler live E2E: required after deploy.

## Related Constitution Rules

- Butler Completion Gate
- Butler-First Operating Principle
- Authority Boundary
- Conversation UX Contract
- Evidence Discipline

## Out-of-scope but NOT implemented

- Browser-only passkey-authorized VPS dispatch UI.
- WebSocket / EventSource streaming.
- Raw Codex terminal log display.
- Automatic merge/deploy/Issue close from dashboard chat.

## Extra changes (if any)

None.
