### PR TITLE
Gate dashboard access behind owner auth

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -101,6 +101,10 @@ jobs:
           CLOUDFLARE_D1_DATABASE_NAME: ${{ vars.CLOUDFLARE_D1_DATABASE_NAME || 'vtdd-memory' }}
           VTDD_GITHUB_ACTIONS_REPOSITORY: ${{ github.repository }}
           VTDD_KNOWN_GOOD_COMMIT_SHA: ${{ vars.VTDD_KNOWN_GOOD_COMMIT_SHA }}
+          VTDD_DASHBOARD_ALLOWED_EMAILS: ${{ vars.VTDD_DASHBOARD_ALLOWED_EMAILS }}
+          VTDD_DASHBOARD_ALLOWED_GITHUB_LOGINS: ${{ vars.VTDD_DASHBOARD_ALLOWED_GITHUB_LOGINS }}
+          CF_ACCESS_TEAM_DOMAIN: ${{ vars.CF_ACCESS_TEAM_DOMAIN }}
+          CF_ACCESS_AUD: ${{ vars.CF_ACCESS_AUD }}
         shell: bash
         run: |
           cp wrangler.toml wrangler.production.generated.toml
@@ -109,6 +113,25 @@ jobs:
           [env.production.vars]
           VTDD_GITHUB_ACTIONS_REPOSITORY = "$VTDD_GITHUB_ACTIONS_REPOSITORY"
           EOF
+          append_toml_var() {
+            local key="$1"
+            local value="$2"
+            if [ -n "$value" ]; then
+              node -e 'const [key, value] = process.argv.slice(1); console.log(`${key} = ${JSON.stringify(value)}`);' "$key" "$value" >> wrangler.production.generated.toml
+            fi
+          }
+          if [ -n "$VTDD_DASHBOARD_ALLOWED_EMAILS" ]; then
+            append_toml_var "VTDD_DASHBOARD_ALLOWED_EMAILS" "$VTDD_DASHBOARD_ALLOWED_EMAILS"
+          fi
+          if [ -n "$VTDD_DASHBOARD_ALLOWED_GITHUB_LOGINS" ]; then
+            append_toml_var "VTDD_DASHBOARD_ALLOWED_GITHUB_LOGINS" "$VTDD_DASHBOARD_ALLOWED_GITHUB_LOGINS"
+          fi
+          if [ -n "$CF_ACCESS_TEAM_DOMAIN" ]; then
+            append_toml_var "CF_ACCESS_TEAM_DOMAIN" "$CF_ACCESS_TEAM_DOMAIN"
+          fi
+          if [ -n "$CF_ACCESS_AUD" ]; then
+            append_toml_var "CF_ACCESS_AUD" "$CF_ACCESS_AUD"
+          fi
           if [ -n "$VTDD_KNOWN_GOOD_COMMIT_SHA" ]; then
             if [[ ! "$VTDD_KNOWN_GOOD_COMMIT_SHA" =~ ^[0-9a-fA-F]{40}$ ]]; then
               echo "VTDD_KNOWN_GOOD_COMMIT_SHA must be a 40-character commit SHA."

--- a/docs/mvp/production-deploy-path.md
+++ b/docs/mvp/production-deploy-path.md
@@ -72,6 +72,22 @@ includes the run URL and deployed commit SHA, and intentionally omits approval
 grant ids, tokens, and other secret values. If the variable is absent,
 the deploy still runs and the mention notification is skipped.
 
+Dashboard pages are owner-facing surfaces, not public documentation pages.
+Set at least one repository variable before deploy:
+
+- `VTDD_DASHBOARD_ALLOWED_EMAILS`
+- `VTDD_DASHBOARD_ALLOWED_GITHUB_LOGINS`
+
+Also set both Cloudflare Access JWT validation variables:
+
+- `CF_ACCESS_TEAM_DOMAIN`
+- `CF_ACCESS_AUD`
+
+The Worker fails closed when neither allowlist is configured, or when Access JWT
+validation is not configured. Browser access is accepted only when Cloudflare
+Access supplies a matching identity and a valid `Cf-Access-Jwt-Assertion`.
+Service-to-service dashboard event ingestion still uses machine auth.
+
 ## Approval Boundary (scoped passkey approval)
 
 `deploy-production` workflow is manual (`workflow_dispatch`) and requires:

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -78,6 +78,8 @@ const MCP_SERVER_INFO = Object.freeze({
 });
 const MCP_INSTRUCTIONS =
   "VTDD MCP は Butler と同じ runtime truth / review truth / operational memory を読むための read-first surface です。現在の truth は runtime truth を優先し、memory は補助として扱ってください。";
+const CLOUDFLARE_ACCESS_JWKS_CACHE_TTL_MS = 5 * 60 * 1000;
+const cloudflareAccessJwksCache = new Map();
 const AUTONOMY_MODE_ENV = "VTDD_AUTONOMY_MODE";
 const LEGACY_AUTONOMY_MODE_ENV = "MVP_AUTONOMY_MODE";
 const MEMORY_D1_BINDING = "VTDD_MEMORY_D1";
@@ -137,6 +139,13 @@ export default {
       );
     }
 
+    if (request.method === "GET" && isDashboardPagePath(url.pathname)) {
+      const auth = await authorizeDashboardRequest({ request, env, apiSuffix: url.pathname });
+      if (!auth.ok) {
+        return html(auth.status, renderDashboardAuthRequiredPage({ runtimeOrigin: url.origin, reason: auth.reason }));
+      }
+    }
+
     if (request.method === "GET" && (url.pathname === "/dashboard" || url.pathname === "/orchestrator")) {
       return html(
         200,
@@ -186,7 +195,7 @@ export default {
     }
 
     if (request.method === "GET" && isDashboardChatThreadApiPath(url.pathname)) {
-      return handleDashboardChatThreadRequest(url, env);
+      return handleDashboardChatThreadRequest(request, url, env);
     }
 
     if (
@@ -3144,6 +3153,19 @@ async function handleVpsRunnerEventRequest(request, env) {
 }
 
 async function handleDashboardChatMessageRequest(request, env) {
+  const dashboardAuth = await authorizeDashboardRequest({
+    request,
+    env,
+    apiSuffix: "/dashboard/chat/messages"
+  });
+  if (!dashboardAuth.ok) {
+    return json(dashboardAuth.status, {
+      ok: false,
+      error: "dashboard_auth_required",
+      reason: dashboardAuth.reason
+    });
+  }
+
   const payload = await readJson(request);
   const wantsVpsRunnerHandoff = shouldDispatchDashboardChatToVpsRunner(payload);
   if (wantsVpsRunnerHandoff) {
@@ -3218,7 +3240,20 @@ async function handleDashboardChatMessageRequest(request, env) {
   });
 }
 
-async function handleDashboardChatThreadRequest(url, env) {
+async function handleDashboardChatThreadRequest(request, url, env) {
+  const auth = await authorizeDashboardRequest({
+    request,
+    env,
+    apiSuffix: "/dashboard/chat/:threadId"
+  });
+  if (!auth.ok) {
+    return json(auth.status, {
+      ok: false,
+      error: "dashboard_auth_required",
+      reason: auth.reason
+    });
+  }
+
   const threadId = extractDashboardChatThreadId(url.pathname);
   if (!threadId) {
     return json(422, {
@@ -5239,6 +5274,15 @@ function isDashboardChatThreadApiPath(pathname) {
   );
 }
 
+function isDashboardPagePath(pathname) {
+  return (
+    pathname === "/dashboard" ||
+    pathname.startsWith("/dashboard/") ||
+    pathname === "/orchestrator" ||
+    pathname.startsWith("/orchestrator/")
+  );
+}
+
 function extractDashboardChatThreadId(pathname) {
   const prefix = pathname.startsWith(`${CANONICAL_API_PREFIX}/dashboard/chat/`)
     ? `${CANONICAL_API_PREFIX}/dashboard/chat/`
@@ -5609,6 +5653,324 @@ function authorizeGatewayRequest({ request, env, apiSuffix = "/gateway" }) {
     status: 503,
     reason: `machine auth runtime is not configured for ${routeLabel}`
   };
+}
+
+async function authorizeDashboardRequest({ request, env, apiSuffix = "/dashboard" }) {
+  const machineAuth = authorizeGatewayRequest({ request, env, apiSuffix });
+  if (machineAuth.ok) {
+    return { ok: true, authType: "machine" };
+  }
+
+  const runtimeEnv = env ?? {};
+  const routeLabel = `dashboard surface ${apiSuffix}`;
+  const allowedEmails = parseAuthList(
+    runtimeEnv.VTDD_DASHBOARD_ALLOWED_EMAILS ?? runtimeEnv.CF_ACCESS_ALLOWED_EMAILS
+  );
+  const allowedLogins = parseAuthList(
+    runtimeEnv.VTDD_DASHBOARD_ALLOWED_GITHUB_LOGINS ?? runtimeEnv.CF_ACCESS_ALLOWED_GITHUB_LOGINS
+  );
+  const accessEmail = normalize(request.headers.get("cf-access-authenticated-user-email"));
+  const accessLogin = normalize(
+    request.headers.get("cf-access-authenticated-user-login") ||
+      request.headers.get("x-github-login") ||
+      request.headers.get("x-github-username")
+  );
+  const accessJwt = normalizeText(request.headers.get("cf-access-jwt-assertion"));
+
+  if (!accessEmail && !accessLogin) {
+    return {
+      ok: false,
+      status: 401,
+      reason: `Cloudflare Access authenticated owner identity is required for ${routeLabel}`
+    };
+  }
+  if (allowedEmails.length === 0 && allowedLogins.length === 0) {
+    return {
+      ok: false,
+      status: 503,
+      reason:
+        "dashboard owner allowlist is not configured (set VTDD_DASHBOARD_ALLOWED_EMAILS or VTDD_DASHBOARD_ALLOWED_GITHUB_LOGINS)"
+    };
+  }
+  if (!accessJwt) {
+    return {
+      ok: false,
+      status: 401,
+      reason: `Cloudflare Access JWT assertion is required for ${routeLabel}`
+    };
+  }
+  const jwtVerification = await verifyCloudflareAccessJwt({ token: accessJwt, env: runtimeEnv });
+  if (!jwtVerification.ok) {
+    return {
+      ok: false,
+      status: jwtVerification.status ?? 403,
+      reason: jwtVerification.reason
+    };
+  }
+  const jwtIdentity = extractCloudflareAccessJwtIdentity(jwtVerification.payload);
+  if (accessEmail && !jwtIdentity.email) {
+    return {
+      ok: false,
+      status: 403,
+      reason: "Cloudflare Access email header is present but the verified JWT has no email claim"
+    };
+  }
+  if (accessEmail && accessEmail !== jwtIdentity.email) {
+    return {
+      ok: false,
+      status: 403,
+      reason: "Cloudflare Access email header does not match the verified JWT identity"
+    };
+  }
+  if (accessLogin && !jwtIdentity.login) {
+    return {
+      ok: false,
+      status: 403,
+      reason: "Cloudflare Access login header is present but the verified JWT has no login claim"
+    };
+  }
+  if (accessLogin && accessLogin !== jwtIdentity.login) {
+    return {
+      ok: false,
+      status: 403,
+      reason: "Cloudflare Access login header does not match the verified JWT identity"
+    };
+  }
+  if (
+    (jwtIdentity.email && allowedEmails.includes(jwtIdentity.email)) ||
+    (jwtIdentity.login && allowedLogins.includes(jwtIdentity.login))
+  ) {
+    return {
+      ok: true,
+      authType: "cloudflare_access",
+      subject: jwtIdentity.login || jwtIdentity.email
+    };
+  }
+  return {
+    ok: false,
+    status: 403,
+    reason: `Cloudflare Access identity is not allowed for ${routeLabel}`
+  };
+}
+
+function extractCloudflareAccessJwtIdentity(payload) {
+  const custom = payload?.custom && typeof payload.custom === "object" ? payload.custom : {};
+  return {
+    email: normalize(payload?.email || payload?.identity?.email || custom.email),
+    login: normalize(
+      payload?.github_login ||
+        payload?.login ||
+        payload?.username ||
+        payload?.identity?.github_login ||
+        payload?.identity?.login ||
+        payload?.identity?.username ||
+        custom.github_login ||
+        custom.login ||
+        custom.username
+    )
+  };
+}
+
+function parseAuthList(value) {
+  return normalizeText(value)
+    .split(/[\s,]+/)
+    .map((item) => normalize(item))
+    .filter(Boolean);
+}
+
+async function verifyCloudflareAccessJwt({ token, env }) {
+  if (typeof env?.CF_ACCESS_JWT_VERIFIER === "function") {
+    return env.CF_ACCESS_JWT_VERIFIER(token);
+  }
+
+  const teamDomain = normalizeCloudflareAccessTeamDomain(env?.CF_ACCESS_TEAM_DOMAIN);
+  const expectedAudience = normalizeText(env?.CF_ACCESS_AUD);
+  if (!teamDomain || !expectedAudience) {
+    return {
+      ok: false,
+      status: 503,
+      reason: "Cloudflare Access JWT validation is not configured (set CF_ACCESS_TEAM_DOMAIN and CF_ACCESS_AUD)"
+    };
+  }
+
+  const parsed = parseJwt(token);
+  if (!parsed.ok) {
+    return parsed;
+  }
+  if (normalizeText(parsed.header.alg) !== "RS256") {
+    return {
+      ok: false,
+      status: 403,
+      reason: "Cloudflare Access JWT must use RS256"
+    };
+  }
+  if (normalizeText(parsed.payload.iss).replace(/\/$/, "") !== `https://${teamDomain}`) {
+    return {
+      ok: false,
+      status: 403,
+      reason: "Cloudflare Access JWT issuer does not match configured team domain"
+    };
+  }
+  const aud = Array.isArray(parsed.payload.aud) ? parsed.payload.aud : [parsed.payload.aud];
+  if (!aud.map((item) => normalizeText(item)).includes(expectedAudience)) {
+    return {
+      ok: false,
+      status: 403,
+      reason: "Cloudflare Access JWT audience does not match configured application audience"
+    };
+  }
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  if (!Number.isFinite(parsed.payload.exp)) {
+    return {
+      ok: false,
+      status: 403,
+      reason: "Cloudflare Access JWT expiration claim is required"
+    };
+  }
+  if (parsed.payload.exp <= nowSeconds) {
+    return {
+      ok: false,
+      status: 403,
+      reason: "Cloudflare Access JWT is expired"
+    };
+  }
+  if (parsed.payload.nbf !== undefined && !Number.isFinite(parsed.payload.nbf)) {
+    return {
+      ok: false,
+      status: 403,
+      reason: "Cloudflare Access JWT not-before claim must be numeric"
+    };
+  }
+  if (Number.isFinite(parsed.payload.nbf) && parsed.payload.nbf > nowSeconds) {
+    return {
+      ok: false,
+      status: 403,
+      reason: "Cloudflare Access JWT is not valid yet"
+    };
+  }
+
+  const jwks = await fetchCloudflareAccessJwks({ teamDomain, env });
+  if (!jwks.ok) {
+    return jwks;
+  }
+  const jwk = (jwks.keys || []).find((candidate) => normalizeText(candidate.kid) === normalizeText(parsed.header.kid));
+  if (!jwk) {
+    return {
+      ok: false,
+      status: 403,
+      reason: "Cloudflare Access JWT key id is not trusted"
+    };
+  }
+
+  const key = await crypto.subtle.importKey(
+    "jwk",
+    jwk,
+    { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
+    false,
+    ["verify"]
+  );
+  const verified = await crypto.subtle.verify(
+    "RSASSA-PKCS1-v1_5",
+    key,
+    parsed.signature,
+    new TextEncoder().encode(parsed.signingInput)
+  );
+  if (!verified) {
+    return {
+      ok: false,
+      status: 403,
+      reason: "Cloudflare Access JWT signature is invalid"
+    };
+  }
+
+  return { ok: true, payload: parsed.payload };
+}
+
+function normalizeCloudflareAccessTeamDomain(value) {
+  const text = normalizeText(value).replace(/^https?:\/\//, "").replace(/\/.*$/, "");
+  return text || "";
+}
+
+async function fetchCloudflareAccessJwks({ teamDomain, env }) {
+  const fetcher = env?.CF_ACCESS_JWKS_FETCH ?? fetch;
+  const jwksUrl = normalizeText(env?.CF_ACCESS_JWKS_URL) || `https://${teamDomain}/cdn-cgi/access/certs`;
+  const now = Date.now();
+  const cached = cloudflareAccessJwksCache.get(jwksUrl);
+  if (cached && cached.expiresAt > now) {
+    return {
+      ok: true,
+      keys: cached.keys
+    };
+  }
+  try {
+    const response = await fetcher(jwksUrl);
+    if (!response.ok) {
+      return {
+        ok: false,
+        status: 503,
+        reason: `Cloudflare Access JWKS fetch failed with HTTP ${response.status}`
+      };
+    }
+    const body = await response.json();
+    const keys = Array.isArray(body.keys) ? body.keys : [];
+    cloudflareAccessJwksCache.set(jwksUrl, {
+      keys,
+      expiresAt: now + CLOUDFLARE_ACCESS_JWKS_CACHE_TTL_MS
+    });
+    return {
+      ok: true,
+      keys
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      status: 503,
+      reason: `Cloudflare Access JWKS fetch failed: ${sanitizeErrorMessage(error)}`
+    };
+  }
+}
+
+function parseJwt(token) {
+  const parts = normalizeText(token).split(".");
+  if (parts.length !== 3) {
+    return {
+      ok: false,
+      status: 403,
+      reason: "Cloudflare Access JWT is malformed"
+    };
+  }
+  try {
+    return {
+      ok: true,
+      header: JSON.parse(base64UrlDecodeText(parts[0])),
+      payload: JSON.parse(base64UrlDecodeText(parts[1])),
+      signature: base64UrlDecodeBytes(parts[2]),
+      signingInput: `${parts[0]}.${parts[1]}`
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      status: 403,
+      reason: `Cloudflare Access JWT could not be decoded: ${sanitizeErrorMessage(error)}`
+    };
+  }
+}
+
+function base64UrlDecodeText(value) {
+  return new TextDecoder().decode(base64UrlDecodeBytes(value));
+}
+
+function base64UrlDecodeBytes(value) {
+  const normalized = normalizeText(value).replace(/-/g, "+").replace(/_/g, "/");
+  const padded = normalized.padEnd(Math.ceil(normalized.length / 4) * 4, "=");
+  if (typeof atob === "function") {
+    return Uint8Array.from(atob(padded), (char) => char.charCodeAt(0));
+  }
+  return Uint8Array.from(Buffer.from(padded, "base64"));
+}
+
+function sanitizeErrorMessage(error) {
+  return normalizeText(error?.message || error).replace(/Bearer\s+[A-Za-z0-9._~+/=-]+/g, "Bearer [redacted]");
 }
 
 async function authorizePasskeyRegistrationRequest({ request, env, apiSuffix }) {
@@ -6959,6 +7321,38 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
       });
     })();
   </script>
+</body>
+</html>`;
+}
+
+function renderDashboardAuthRequiredPage({ runtimeOrigin, reason } = {}) {
+  const origin = normalizeText(runtimeOrigin);
+  return `<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Dashboard auth required</title>
+  <style>
+    :root { color-scheme: light; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; color: #17211d; background: #f8faf8; }
+    body { margin: 0; }
+    main { width: min(720px, calc(100% - 32px)); margin: 0 auto; padding: 56px 0; }
+    .panel { background: #fff; border: 1px solid #d8e2dc; border-radius: 8px; padding: 24px; box-shadow: 0 12px 32px rgba(24, 37, 31, .08); }
+    h1 { margin: 0 0 12px; font-size: 30px; }
+    p { line-height: 1.7; color: #4d5c56; }
+    a { color: #176b4d; font-weight: 750; }
+    code { color: #5f6c66; }
+  </style>
+</head>
+<body>
+  <main>
+    <section class="panel">
+      <h1>Dashboard auth required</h1>
+      <p>この dashboard は owner-facing surface です。対象の GitHub / Cloudflare Access identity で認証されたユーザー、または machine-authenticated service だけが利用できます。</p>
+      <p><code>${escapeDashboardHtml(reason || "dashboard authentication required")}</code></p>
+      <p><a href="${escapeDashboardHtml(origin || "/status")}/status">Status</a></p>
+    </section>
+  </main>
 </body>
 </html>`;
 }

--- a/test/production-deploy-path.test.js
+++ b/test/production-deploy-path.test.js
@@ -44,6 +44,14 @@ test("production deploy doc defines the governed GitHub Actions deploy path", ()
   assert.equal(doc.includes("mentions the repository owner"), true);
   assert.equal(doc.includes("intentionally omits approval"), true);
   assert.equal(doc.includes("grant ids, tokens, and other secret values"), true);
+  assert.equal(doc.includes("Dashboard pages are owner-facing surfaces"), true);
+  assert.equal(doc.includes("`VTDD_DASHBOARD_ALLOWED_EMAILS`"), true);
+  assert.equal(doc.includes("`VTDD_DASHBOARD_ALLOWED_GITHUB_LOGINS`"), true);
+  assert.equal(doc.includes("`CF_ACCESS_TEAM_DOMAIN`"), true);
+  assert.equal(doc.includes("`CF_ACCESS_AUD`"), true);
+  assert.equal(doc.includes("`Cf-Access-Jwt-Assertion`"), true);
+  assert.equal(doc.includes("fails closed"), true);
+  assert.equal(doc.includes("Cloudflare Access"), true);
 });
 
 test("deploy-production workflow enforces the MVP production deploy boundary", () => {
@@ -77,11 +85,32 @@ test("deploy-production workflow enforces the MVP production deploy boundary", (
   assert.equal(workflow.includes("Generate production Wrangler config"), true);
   assert.equal(workflow.includes("VTDD_GITHUB_ACTIONS_REPOSITORY: ${{ github.repository }}"), true);
   assert.equal(workflow.includes("VTDD_KNOWN_GOOD_COMMIT_SHA: ${{ vars.VTDD_KNOWN_GOOD_COMMIT_SHA }}"), true);
+  assert.equal(workflow.includes("VTDD_DASHBOARD_ALLOWED_EMAILS: ${{ vars.VTDD_DASHBOARD_ALLOWED_EMAILS }}"), true);
+  assert.equal(
+    workflow.includes("VTDD_DASHBOARD_ALLOWED_GITHUB_LOGINS: ${{ vars.VTDD_DASHBOARD_ALLOWED_GITHUB_LOGINS }}"),
+    true
+  );
+  assert.equal(workflow.includes("CF_ACCESS_TEAM_DOMAIN: ${{ vars.CF_ACCESS_TEAM_DOMAIN }}"), true);
+  assert.equal(workflow.includes("CF_ACCESS_AUD: ${{ vars.CF_ACCESS_AUD }}"), true);
   assert.equal(workflow.includes("[env.production.vars]"), true);
   assert.equal(
     workflow.includes('VTDD_GITHUB_ACTIONS_REPOSITORY = "$VTDD_GITHUB_ACTIONS_REPOSITORY"'),
     true
   );
+  assert.equal(workflow.includes("append_toml_var()"), true);
+  assert.equal(workflow.includes("JSON.stringify(value)"), true);
+  assert.equal(
+    workflow.includes('append_toml_var "VTDD_DASHBOARD_ALLOWED_EMAILS" "$VTDD_DASHBOARD_ALLOWED_EMAILS"'),
+    true
+  );
+  assert.equal(
+    workflow.includes(
+      'append_toml_var "VTDD_DASHBOARD_ALLOWED_GITHUB_LOGINS" "$VTDD_DASHBOARD_ALLOWED_GITHUB_LOGINS"'
+    ),
+    true
+  );
+  assert.equal(workflow.includes('append_toml_var "CF_ACCESS_TEAM_DOMAIN" "$CF_ACCESS_TEAM_DOMAIN"'), true);
+  assert.equal(workflow.includes('append_toml_var "CF_ACCESS_AUD" "$CF_ACCESS_AUD"'), true);
   assert.equal(workflow.includes('if [ -n "$VTDD_KNOWN_GOOD_COMMIT_SHA" ]; then'), true);
   assert.equal(
     workflow.includes('[[ ! "$VTDD_KNOWN_GOOD_COMMIT_SHA" =~ ^[0-9a-fA-F]{40}$ ]]'),

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -36,6 +36,21 @@ const gatewayAuthEnv = {
   VTDD_GATEWAY_BEARER_TOKEN: "test-token"
 };
 
+const dashboardAccessHeaders = {
+  "cf-access-authenticated-user-email": "owner@example.com",
+  "cf-access-jwt-assertion": "test-access-jwt"
+};
+
+const dashboardAccessEnv = {
+  VTDD_DASHBOARD_ALLOWED_EMAILS: "owner@example.com",
+  CF_ACCESS_JWT_VERIFIER: async (token) => ({
+    ok: token === "test-access-jwt",
+    status: token === "test-access-jwt" ? 200 : 403,
+    reason: token === "test-access-jwt" ? undefined : "test access jwt invalid",
+    payload: token === "test-access-jwt" ? { email: "owner@example.com", exp: 4102444800 } : null
+  })
+};
+
 function createInMemoryDashboardEventStore() {
   const events = new Map();
   return {
@@ -212,8 +227,85 @@ test("worker serves human-facing status page without raw JSON links", async () =
   assert.equal(body.includes("CLOUDFLARE_API_TOKEN"), false);
 });
 
-test("worker serves v2 dashboard without exposing secrets", async () => {
+test("worker rejects dashboard access without owner identity", async () => {
   const response = await worker.fetch(new Request("https://example.com/dashboard"));
+  assert.equal(response.status, 401);
+  assert.match(response.headers.get("content-type"), /text\/html/);
+  const body = await response.text();
+  assert.equal(body.includes("Dashboard auth required"), true);
+  assert.equal(body.includes("owner-facing surface"), true);
+});
+
+test("worker rejects unlisted dashboard subpaths before they can become public pages", async () => {
+  const response = await worker.fetch(new Request("https://example.com/dashboard/future-page"));
+  assert.equal(response.status, 401);
+  const body = await response.text();
+  assert.equal(body.includes("Dashboard auth required"), true);
+});
+
+test("worker rejects dashboard access when owner identity lacks a verified Access JWT", async () => {
+  const response = await worker.fetch(
+    new Request("https://example.com/dashboard", {
+      headers: {
+        "cf-access-authenticated-user-email": "owner@example.com"
+      }
+    }),
+    dashboardAccessEnv
+  );
+  assert.equal(response.status, 401);
+  const body = await response.text();
+  assert.equal(body.includes("Cloudflare Access JWT assertion is required"), true);
+});
+
+test("worker rejects dashboard access when Access email header has no matching JWT email claim", async () => {
+  const response = await worker.fetch(
+    new Request("https://example.com/dashboard", {
+      headers: {
+        "cf-access-authenticated-user-email": "owner@example.com",
+        "cf-access-jwt-assertion": "login-only-access-jwt"
+      }
+    }),
+    {
+      VTDD_DASHBOARD_ALLOWED_EMAILS: "owner@example.com",
+      CF_ACCESS_JWT_VERIFIER: async () => ({
+        ok: true,
+        payload: { login: "owner-login", exp: 4102444800 }
+      })
+    }
+  );
+  assert.equal(response.status, 403);
+  const body = await response.text();
+  assert.equal(body.includes("verified JWT has no email claim"), true);
+});
+
+test("worker rejects dashboard access when identity header does not match verified Access JWT", async () => {
+  const response = await worker.fetch(
+    new Request("https://example.com/dashboard", {
+      headers: {
+        "cf-access-authenticated-user-email": "owner@example.com",
+        "cf-access-jwt-assertion": "non-owner-access-jwt"
+      }
+    }),
+    {
+      VTDD_DASHBOARD_ALLOWED_EMAILS: "owner@example.com",
+      CF_ACCESS_JWT_VERIFIER: async () => ({
+        ok: true,
+        payload: { email: "other@example.com", exp: 4102444800 }
+      })
+    }
+  );
+  assert.equal(response.status, 403);
+  const body = await response.text();
+  assert.equal(body.includes("does not match the verified JWT identity"), true);
+});
+
+test("worker serves v2 dashboard for allowed owner identity without exposing secrets", async () => {
+  const response = await worker.fetch(
+    new Request("https://example.com/dashboard", {
+      headers: dashboardAccessHeaders
+    }),
+    dashboardAccessEnv
+  );
   assert.equal(response.status, 200);
   assert.match(response.headers.get("content-type"), /text\/html/);
   assert.match(response.headers.get("cache-control"), /no-store/);
@@ -273,7 +365,12 @@ test("worker serves v2 dashboard without exposing secrets", async () => {
   assert.equal(body.includes("approvalGrantId"), false);
   assert.equal(body.includes("CLOUDFLARE_API_TOKEN"), false);
 
-  const alias = await worker.fetch(new Request("https://example.com/orchestrator"));
+  const alias = await worker.fetch(
+    new Request("https://example.com/orchestrator", {
+      headers: dashboardAccessHeaders
+    }),
+    dashboardAccessEnv
+  );
   assert.equal(alias.status, 200);
   assert.match(alias.headers.get("cache-control"), /no-store/);
   const aliasBody = await alias.text();
@@ -288,14 +385,14 @@ test("worker appends dashboard Butler chat turn and retrieves the same thread", 
   const response = await worker.fetch(
     new Request("https://example.com/v2/dashboard/chat/messages", {
       method: "POST",
-      headers: { "content-type": "application/json" },
+      headers: { ...dashboardAccessHeaders, "content-type": "application/json" },
       body: JSON.stringify({
         threadId: "dashboard-main-marushu-vtdd-v2-p",
         repository: "marushu/vtdd-v2-p",
         text: "VPS Codex CLI とリアルタイムに会話したい"
       })
     }),
-    { DASHBOARD_CHAT_STORE: store }
+    { ...dashboardAccessEnv, DASHBOARD_CHAT_STORE: store }
   );
 
   assert.equal(response.status, 202);
@@ -308,8 +405,10 @@ test("worker appends dashboard Butler chat turn and retrieves the same thread", 
   assert.match(body.messages[1].text, /VPS Codex CLI/);
 
   const retrieveResponse = await worker.fetch(
-    new Request("https://example.com/v2/dashboard/chat/dashboard-main-marushu-vtdd-v2-p"),
-    { DASHBOARD_CHAT_STORE: store }
+    new Request("https://example.com/v2/dashboard/chat/dashboard-main-marushu-vtdd-v2-p", {
+      headers: dashboardAccessHeaders
+    }),
+    { ...dashboardAccessEnv, DASHBOARD_CHAT_STORE: store }
   );
   assert.equal(retrieveResponse.status, 200);
   const retrieveBody = await retrieveResponse.json();
@@ -372,8 +471,10 @@ test("worker dispatches authenticated dashboard chat handoff to VPS runner queue
   assert.equal(queueBody.includes('"dashboardThreadId": "dashboard-main-marushu-vtdd-v2-p"'), true);
 
   const retrieveResponse = await worker.fetch(
-    new Request("https://example.com/v2/dashboard/chat/dashboard-main-marushu-vtdd-v2-p"),
-    { DASHBOARD_CHAT_STORE: store }
+    new Request("https://example.com/v2/dashboard/chat/dashboard-main-marushu-vtdd-v2-p", {
+      headers: dashboardAccessHeaders
+    }),
+    { ...dashboardAccessEnv, DASHBOARD_CHAT_STORE: store }
   );
   const retrieveBody = await retrieveResponse.json();
   assert.equal(retrieveBody.messages.length, 3);
@@ -402,11 +503,10 @@ test("worker rejects unauthenticated dashboard chat VPS runner dispatch", async 
   assert.equal(response.status, 401);
   const body = await response.json();
   assert.equal(body.ok, false);
-  assert.equal(body.error, "dashboard_vps_runner_dispatch_unauthorized");
+  assert.equal(body.error, "dashboard_auth_required");
 });
 
-test("worker redacts dashboard Butler chat sensitive material before returning and storing", async () => {
-  const store = createInMemoryDashboardChatStore();
+test("worker rejects unauthenticated dashboard chat writes even without VPS dispatch", async () => {
   const response = await worker.fetch(
     new Request("https://example.com/v2/dashboard/chat/messages", {
       method: "POST",
@@ -414,10 +514,34 @@ test("worker redacts dashboard Butler chat sensitive material before returning a
       body: JSON.stringify({
         threadId: "dashboard-main-marushu-vtdd-v2-p",
         repository: "marushu/vtdd-v2-p",
+        text: "public post should not land in dashboard"
+      })
+    }),
+    {
+      ...dashboardAccessEnv,
+      DASHBOARD_CHAT_STORE: createInMemoryDashboardChatStore()
+    }
+  );
+
+  assert.equal(response.status, 401);
+  const body = await response.json();
+  assert.equal(body.ok, false);
+  assert.equal(body.error, "dashboard_auth_required");
+});
+
+test("worker redacts dashboard Butler chat sensitive material before returning and storing", async () => {
+  const store = createInMemoryDashboardChatStore();
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/dashboard/chat/messages", {
+      method: "POST",
+      headers: { ...dashboardAccessHeaders, "content-type": "application/json" },
+      body: JSON.stringify({
+        threadId: "dashboard-main-marushu-vtdd-v2-p",
+        repository: "marushu/vtdd-v2-p",
         text: "approval:15b6f20d-11b6-4f8b-8008-99e7d7397452 と Bearer supersecrettoken123 を貼った"
       })
     }),
-    { DASHBOARD_CHAT_STORE: store }
+    { ...dashboardAccessEnv, DASHBOARD_CHAT_STORE: store }
   );
 
   assert.equal(response.status, 202);
@@ -428,8 +552,10 @@ test("worker redacts dashboard Butler chat sensitive material before returning a
   assert.equal(body.messages[0].text.includes("Bearer [redacted]"), true);
 
   const retrieveResponse = await worker.fetch(
-    new Request("https://example.com/v2/dashboard/chat/dashboard-main-marushu-vtdd-v2-p"),
-    { DASHBOARD_CHAT_STORE: store }
+    new Request("https://example.com/v2/dashboard/chat/dashboard-main-marushu-vtdd-v2-p", {
+      headers: dashboardAccessHeaders
+    }),
+    { ...dashboardAccessEnv, DASHBOARD_CHAT_STORE: store }
   );
   const retrieveBody = await retrieveResponse.json();
   assert.equal(JSON.stringify(retrieveBody).includes("approval:15b6f20d"), false);
@@ -438,8 +564,11 @@ test("worker redacts dashboard Butler chat sensitive material before returning a
 
 test("worker serves human-facing GitHub truth dashboard instead of raw action JSON", async () => {
   const response = await worker.fetch(
-    new Request("https://example.com/dashboard/github?repository=sample-org/vtdd-v2-p"),
+    new Request("https://example.com/dashboard/github?repository=sample-org/vtdd-v2-p", {
+      headers: dashboardAccessHeaders
+    }),
     {
+      ...dashboardAccessEnv,
       GITHUB_APP_INSTALLATION_TOKEN: "ghs_read",
       GITHUB_API_FETCH: async (url) => {
         const parsed = new URL(url);
@@ -522,7 +651,12 @@ test("worker serves human-facing dashboard pages for every management menu", asy
   ];
 
   for (const [route, title, rawLabel] of routes) {
-    const response = await worker.fetch(new Request(`https://example.com${route}`));
+    const response = await worker.fetch(
+      new Request(`https://example.com${route}`, {
+        headers: dashboardAccessHeaders
+      }),
+      dashboardAccessEnv
+    );
     assert.equal(response.status, 200);
     assert.match(response.headers.get("content-type"), /text\/html/);
     const body = await response.text();
@@ -580,9 +714,15 @@ test("worker serves dashboard notification center for recent events across repos
     updatedAt: sixMinutesAgo
   });
 
-  const response = await worker.fetch(new Request("https://example.com/dashboard/notifications"), {
-    DASHBOARD_EVENT_STORE: store
-  });
+  const response = await worker.fetch(
+    new Request("https://example.com/dashboard/notifications", {
+      headers: dashboardAccessHeaders
+    }),
+    {
+      ...dashboardAccessEnv,
+      DASHBOARD_EVENT_STORE: store
+    }
+  );
   assert.equal(response.status, 200);
   assert.match(response.headers.get("content-type"), /text\/html/);
   const body = await response.text();
@@ -635,9 +775,15 @@ test("worker ingests GitHub Actions deploy completion event and shows it on dash
   assert.equal("approvalGrantId" in eventBody.event, false);
   assert.equal("token" in eventBody.event, false);
 
-  const dashboardResponse = await worker.fetch(new Request("https://example.com/dashboard"), {
-    DASHBOARD_EVENT_STORE: store
-  });
+  const dashboardResponse = await worker.fetch(
+    new Request("https://example.com/dashboard", {
+      headers: dashboardAccessHeaders
+    }),
+    {
+      ...dashboardAccessEnv,
+      DASHBOARD_EVENT_STORE: store
+    }
+  );
   assert.equal(dashboardResponse.status, 200);
   const dashboardBody = await dashboardResponse.text();
   assert.equal(dashboardBody.includes("最新 deploy"), true);
@@ -723,8 +869,10 @@ test("worker ingests VPS runner event into notifications and Butler chat thread"
   assert.equal(eventBody.messages[0].text.includes("codex_subprocess"), true);
 
   const chatResponse = await worker.fetch(
-    new Request("https://example.com/v2/dashboard/chat/dashboard-main-marushu-vtdd-v2-p"),
-    { DASHBOARD_CHAT_STORE: chatStore }
+    new Request("https://example.com/v2/dashboard/chat/dashboard-main-marushu-vtdd-v2-p", {
+      headers: dashboardAccessHeaders
+    }),
+    { ...dashboardAccessEnv, DASHBOARD_CHAT_STORE: chatStore }
   );
   assert.equal(chatResponse.status, 200);
   const chatBody = await chatResponse.json();
@@ -734,8 +882,10 @@ test("worker ingests VPS runner event into notifications and Butler chat thread"
   assert.equal(JSON.stringify(chatBody).includes("secret-must-not-persist"), false);
 
   const notificationsResponse = await worker.fetch(
-    new Request("https://example.com/dashboard/notifications"),
-    { DASHBOARD_EVENT_STORE: eventStore }
+    new Request("https://example.com/dashboard/notifications", {
+      headers: dashboardAccessHeaders
+    }),
+    { ...dashboardAccessEnv, DASHBOARD_EVENT_STORE: eventStore }
   );
   assert.equal(notificationsResponse.status, 200);
   const notificationsBody = await notificationsResponse.text();

--- a/worker.js
+++ b/worker.js
@@ -55807,6 +55807,8 @@ var MCP_SERVER_INFO = Object.freeze({
   version: "0.1.0"
 });
 var MCP_INSTRUCTIONS = "VTDD MCP \u306F Butler \u3068\u540C\u3058 runtime truth / review truth / operational memory \u3092\u8AAD\u3080\u305F\u3081\u306E read-first surface \u3067\u3059\u3002\u73FE\u5728\u306E truth \u306F runtime truth \u3092\u512A\u5148\u3057\u3001memory \u306F\u88DC\u52A9\u3068\u3057\u3066\u6271\u3063\u3066\u304F\u3060\u3055\u3044\u3002";
+var CLOUDFLARE_ACCESS_JWKS_CACHE_TTL_MS = 5 * 60 * 1e3;
+var cloudflareAccessJwksCache = /* @__PURE__ */ new Map();
 var AUTONOMY_MODE_ENV = "VTDD_AUTONOMY_MODE";
 var LEGACY_AUTONOMY_MODE_ENV = "MVP_AUTONOMY_MODE";
 var MEMORY_D1_BINDING = "VTDD_MEMORY_D1";
@@ -55853,6 +55855,12 @@ var runtime_default = {
         })
       );
     }
+    if (request.method === "GET" && isDashboardPagePath(url.pathname)) {
+      const auth = await authorizeDashboardRequest({ request, env, apiSuffix: url.pathname });
+      if (!auth.ok) {
+        return html(auth.status, renderDashboardAuthRequiredPage({ runtimeOrigin: url.origin, reason: auth.reason }));
+      }
+    }
     if (request.method === "GET" && (url.pathname === "/dashboard" || url.pathname === "/orchestrator")) {
       return html(
         200,
@@ -55893,7 +55901,7 @@ var runtime_default = {
       return handleDashboardChatMessageRequest(request, env);
     }
     if (request.method === "GET" && isDashboardChatThreadApiPath(url.pathname)) {
-      return handleDashboardChatThreadRequest(url, env);
+      return handleDashboardChatThreadRequest(request, url, env);
     }
     if (request.method === "GET" && (url.pathname === MCP_PROTECTED_RESOURCE_METADATA_PATH || url.pathname === MCP_PROTECTED_RESOURCE_METADATA_MIRROR_PATH)) {
       return json(200, buildMcpProtectedResourceMetadata(url));
@@ -58456,6 +58464,18 @@ async function handleVpsRunnerEventRequest(request, env) {
   });
 }
 async function handleDashboardChatMessageRequest(request, env) {
+  const dashboardAuth = await authorizeDashboardRequest({
+    request,
+    env,
+    apiSuffix: "/dashboard/chat/messages"
+  });
+  if (!dashboardAuth.ok) {
+    return json(dashboardAuth.status, {
+      ok: false,
+      error: "dashboard_auth_required",
+      reason: dashboardAuth.reason
+    });
+  }
   const payload = await readJson(request);
   const wantsVpsRunnerHandoff = shouldDispatchDashboardChatToVpsRunner(payload);
   if (wantsVpsRunnerHandoff) {
@@ -58524,7 +58544,19 @@ async function handleDashboardChatMessageRequest(request, env) {
     execution
   });
 }
-async function handleDashboardChatThreadRequest(url, env) {
+async function handleDashboardChatThreadRequest(request, url, env) {
+  const auth = await authorizeDashboardRequest({
+    request,
+    env,
+    apiSuffix: "/dashboard/chat/:threadId"
+  });
+  if (!auth.ok) {
+    return json(auth.status, {
+      ok: false,
+      error: "dashboard_auth_required",
+      reason: auth.reason
+    });
+  }
   const threadId = extractDashboardChatThreadId(url.pathname);
   if (!threadId) {
     return json(422, {
@@ -60209,6 +60241,9 @@ function sanitizeDashboardChatText(value) {
 function isDashboardChatThreadApiPath(pathname) {
   return pathname.startsWith(`${CANONICAL_API_PREFIX}/dashboard/chat/`) || pathname.startsWith(`${LEGACY_API_PREFIX}/dashboard/chat/`);
 }
+function isDashboardPagePath(pathname) {
+  return pathname === "/dashboard" || pathname.startsWith("/dashboard/") || pathname === "/orchestrator" || pathname.startsWith("/orchestrator/");
+}
 function extractDashboardChatThreadId(pathname) {
   const prefix = pathname.startsWith(`${CANONICAL_API_PREFIX}/dashboard/chat/`) ? `${CANONICAL_API_PREFIX}/dashboard/chat/` : pathname.startsWith(`${LEGACY_API_PREFIX}/dashboard/chat/`) ? `${LEGACY_API_PREFIX}/dashboard/chat/` : "";
   if (!prefix) {
@@ -60524,6 +60559,290 @@ function authorizeGatewayRequest({ request, env, apiSuffix = "/gateway" }) {
     status: 503,
     reason: `machine auth runtime is not configured for ${routeLabel}`
   };
+}
+async function authorizeDashboardRequest({ request, env, apiSuffix = "/dashboard" }) {
+  const machineAuth = authorizeGatewayRequest({ request, env, apiSuffix });
+  if (machineAuth.ok) {
+    return { ok: true, authType: "machine" };
+  }
+  const runtimeEnv = env ?? {};
+  const routeLabel = `dashboard surface ${apiSuffix}`;
+  const allowedEmails = parseAuthList(
+    runtimeEnv.VTDD_DASHBOARD_ALLOWED_EMAILS ?? runtimeEnv.CF_ACCESS_ALLOWED_EMAILS
+  );
+  const allowedLogins = parseAuthList(
+    runtimeEnv.VTDD_DASHBOARD_ALLOWED_GITHUB_LOGINS ?? runtimeEnv.CF_ACCESS_ALLOWED_GITHUB_LOGINS
+  );
+  const accessEmail = normalize7(request.headers.get("cf-access-authenticated-user-email"));
+  const accessLogin = normalize7(
+    request.headers.get("cf-access-authenticated-user-login") || request.headers.get("x-github-login") || request.headers.get("x-github-username")
+  );
+  const accessJwt = normalizeText30(request.headers.get("cf-access-jwt-assertion"));
+  if (!accessEmail && !accessLogin) {
+    return {
+      ok: false,
+      status: 401,
+      reason: `Cloudflare Access authenticated owner identity is required for ${routeLabel}`
+    };
+  }
+  if (allowedEmails.length === 0 && allowedLogins.length === 0) {
+    return {
+      ok: false,
+      status: 503,
+      reason: "dashboard owner allowlist is not configured (set VTDD_DASHBOARD_ALLOWED_EMAILS or VTDD_DASHBOARD_ALLOWED_GITHUB_LOGINS)"
+    };
+  }
+  if (!accessJwt) {
+    return {
+      ok: false,
+      status: 401,
+      reason: `Cloudflare Access JWT assertion is required for ${routeLabel}`
+    };
+  }
+  const jwtVerification = await verifyCloudflareAccessJwt({ token: accessJwt, env: runtimeEnv });
+  if (!jwtVerification.ok) {
+    return {
+      ok: false,
+      status: jwtVerification.status ?? 403,
+      reason: jwtVerification.reason
+    };
+  }
+  const jwtIdentity = extractCloudflareAccessJwtIdentity(jwtVerification.payload);
+  if (accessEmail && !jwtIdentity.email) {
+    return {
+      ok: false,
+      status: 403,
+      reason: "Cloudflare Access email header is present but the verified JWT has no email claim"
+    };
+  }
+  if (accessEmail && accessEmail !== jwtIdentity.email) {
+    return {
+      ok: false,
+      status: 403,
+      reason: "Cloudflare Access email header does not match the verified JWT identity"
+    };
+  }
+  if (accessLogin && !jwtIdentity.login) {
+    return {
+      ok: false,
+      status: 403,
+      reason: "Cloudflare Access login header is present but the verified JWT has no login claim"
+    };
+  }
+  if (accessLogin && accessLogin !== jwtIdentity.login) {
+    return {
+      ok: false,
+      status: 403,
+      reason: "Cloudflare Access login header does not match the verified JWT identity"
+    };
+  }
+  if (jwtIdentity.email && allowedEmails.includes(jwtIdentity.email) || jwtIdentity.login && allowedLogins.includes(jwtIdentity.login)) {
+    return {
+      ok: true,
+      authType: "cloudflare_access",
+      subject: jwtIdentity.login || jwtIdentity.email
+    };
+  }
+  return {
+    ok: false,
+    status: 403,
+    reason: `Cloudflare Access identity is not allowed for ${routeLabel}`
+  };
+}
+function extractCloudflareAccessJwtIdentity(payload) {
+  const custom2 = payload?.custom && typeof payload.custom === "object" ? payload.custom : {};
+  return {
+    email: normalize7(payload?.email || payload?.identity?.email || custom2.email),
+    login: normalize7(
+      payload?.github_login || payload?.login || payload?.username || payload?.identity?.github_login || payload?.identity?.login || payload?.identity?.username || custom2.github_login || custom2.login || custom2.username
+    )
+  };
+}
+function parseAuthList(value) {
+  return normalizeText30(value).split(/[\s,]+/).map((item) => normalize7(item)).filter(Boolean);
+}
+async function verifyCloudflareAccessJwt({ token, env }) {
+  if (typeof env?.CF_ACCESS_JWT_VERIFIER === "function") {
+    return env.CF_ACCESS_JWT_VERIFIER(token);
+  }
+  const teamDomain = normalizeCloudflareAccessTeamDomain(env?.CF_ACCESS_TEAM_DOMAIN);
+  const expectedAudience = normalizeText30(env?.CF_ACCESS_AUD);
+  if (!teamDomain || !expectedAudience) {
+    return {
+      ok: false,
+      status: 503,
+      reason: "Cloudflare Access JWT validation is not configured (set CF_ACCESS_TEAM_DOMAIN and CF_ACCESS_AUD)"
+    };
+  }
+  const parsed = parseJwt(token);
+  if (!parsed.ok) {
+    return parsed;
+  }
+  if (normalizeText30(parsed.header.alg) !== "RS256") {
+    return {
+      ok: false,
+      status: 403,
+      reason: "Cloudflare Access JWT must use RS256"
+    };
+  }
+  if (normalizeText30(parsed.payload.iss).replace(/\/$/, "") !== `https://${teamDomain}`) {
+    return {
+      ok: false,
+      status: 403,
+      reason: "Cloudflare Access JWT issuer does not match configured team domain"
+    };
+  }
+  const aud = Array.isArray(parsed.payload.aud) ? parsed.payload.aud : [parsed.payload.aud];
+  if (!aud.map((item) => normalizeText30(item)).includes(expectedAudience)) {
+    return {
+      ok: false,
+      status: 403,
+      reason: "Cloudflare Access JWT audience does not match configured application audience"
+    };
+  }
+  const nowSeconds = Math.floor(Date.now() / 1e3);
+  if (!Number.isFinite(parsed.payload.exp)) {
+    return {
+      ok: false,
+      status: 403,
+      reason: "Cloudflare Access JWT expiration claim is required"
+    };
+  }
+  if (parsed.payload.exp <= nowSeconds) {
+    return {
+      ok: false,
+      status: 403,
+      reason: "Cloudflare Access JWT is expired"
+    };
+  }
+  if (parsed.payload.nbf !== void 0 && !Number.isFinite(parsed.payload.nbf)) {
+    return {
+      ok: false,
+      status: 403,
+      reason: "Cloudflare Access JWT not-before claim must be numeric"
+    };
+  }
+  if (Number.isFinite(parsed.payload.nbf) && parsed.payload.nbf > nowSeconds) {
+    return {
+      ok: false,
+      status: 403,
+      reason: "Cloudflare Access JWT is not valid yet"
+    };
+  }
+  const jwks = await fetchCloudflareAccessJwks({ teamDomain, env });
+  if (!jwks.ok) {
+    return jwks;
+  }
+  const jwk = (jwks.keys || []).find((candidate) => normalizeText30(candidate.kid) === normalizeText30(parsed.header.kid));
+  if (!jwk) {
+    return {
+      ok: false,
+      status: 403,
+      reason: "Cloudflare Access JWT key id is not trusted"
+    };
+  }
+  const key = await crypto.subtle.importKey(
+    "jwk",
+    jwk,
+    { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
+    false,
+    ["verify"]
+  );
+  const verified = await crypto.subtle.verify(
+    "RSASSA-PKCS1-v1_5",
+    key,
+    parsed.signature,
+    new TextEncoder().encode(parsed.signingInput)
+  );
+  if (!verified) {
+    return {
+      ok: false,
+      status: 403,
+      reason: "Cloudflare Access JWT signature is invalid"
+    };
+  }
+  return { ok: true, payload: parsed.payload };
+}
+function normalizeCloudflareAccessTeamDomain(value) {
+  const text = normalizeText30(value).replace(/^https?:\/\//, "").replace(/\/.*$/, "");
+  return text || "";
+}
+async function fetchCloudflareAccessJwks({ teamDomain, env }) {
+  const fetcher = env?.CF_ACCESS_JWKS_FETCH ?? fetch;
+  const jwksUrl = normalizeText30(env?.CF_ACCESS_JWKS_URL) || `https://${teamDomain}/cdn-cgi/access/certs`;
+  const now = Date.now();
+  const cached2 = cloudflareAccessJwksCache.get(jwksUrl);
+  if (cached2 && cached2.expiresAt > now) {
+    return {
+      ok: true,
+      keys: cached2.keys
+    };
+  }
+  try {
+    const response = await fetcher(jwksUrl);
+    if (!response.ok) {
+      return {
+        ok: false,
+        status: 503,
+        reason: `Cloudflare Access JWKS fetch failed with HTTP ${response.status}`
+      };
+    }
+    const body = await response.json();
+    const keys = Array.isArray(body.keys) ? body.keys : [];
+    cloudflareAccessJwksCache.set(jwksUrl, {
+      keys,
+      expiresAt: now + CLOUDFLARE_ACCESS_JWKS_CACHE_TTL_MS
+    });
+    return {
+      ok: true,
+      keys
+    };
+  } catch (error2) {
+    return {
+      ok: false,
+      status: 503,
+      reason: `Cloudflare Access JWKS fetch failed: ${sanitizeErrorMessage(error2)}`
+    };
+  }
+}
+function parseJwt(token) {
+  const parts = normalizeText30(token).split(".");
+  if (parts.length !== 3) {
+    return {
+      ok: false,
+      status: 403,
+      reason: "Cloudflare Access JWT is malformed"
+    };
+  }
+  try {
+    return {
+      ok: true,
+      header: JSON.parse(base64UrlDecodeText(parts[0])),
+      payload: JSON.parse(base64UrlDecodeText(parts[1])),
+      signature: base64UrlDecodeBytes(parts[2]),
+      signingInput: `${parts[0]}.${parts[1]}`
+    };
+  } catch (error2) {
+    return {
+      ok: false,
+      status: 403,
+      reason: `Cloudflare Access JWT could not be decoded: ${sanitizeErrorMessage(error2)}`
+    };
+  }
+}
+function base64UrlDecodeText(value) {
+  return new TextDecoder().decode(base64UrlDecodeBytes(value));
+}
+function base64UrlDecodeBytes(value) {
+  const normalized = normalizeText30(value).replace(/-/g, "+").replace(/_/g, "/");
+  const padded = normalized.padEnd(Math.ceil(normalized.length / 4) * 4, "=");
+  if (typeof atob === "function") {
+    return Uint8Array.from(atob(padded), (char) => char.charCodeAt(0));
+  }
+  return Uint8Array.from(Buffer.from(padded, "base64"));
+}
+function sanitizeErrorMessage(error2) {
+  return normalizeText30(error2?.message || error2).replace(/Bearer\s+[A-Za-z0-9._~+/=-]+/g, "Bearer [redacted]");
 }
 async function authorizePasskeyRegistrationRequest({ request, env, apiSuffix }) {
   const machineAuth = authorizeGatewayRequest({ request, env, apiSuffix });
@@ -61813,6 +62132,37 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
       });
     })();
   <\/script>
+</body>
+</html>`;
+}
+function renderDashboardAuthRequiredPage({ runtimeOrigin, reason } = {}) {
+  const origin = normalizeText30(runtimeOrigin);
+  return `<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Dashboard auth required</title>
+  <style>
+    :root { color-scheme: light; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; color: #17211d; background: #f8faf8; }
+    body { margin: 0; }
+    main { width: min(720px, calc(100% - 32px)); margin: 0 auto; padding: 56px 0; }
+    .panel { background: #fff; border: 1px solid #d8e2dc; border-radius: 8px; padding: 24px; box-shadow: 0 12px 32px rgba(24, 37, 31, .08); }
+    h1 { margin: 0 0 12px; font-size: 30px; }
+    p { line-height: 1.7; color: #4d5c56; }
+    a { color: #176b4d; font-weight: 750; }
+    code { color: #5f6c66; }
+  </style>
+</head>
+<body>
+  <main>
+    <section class="panel">
+      <h1>Dashboard auth required</h1>
+      <p>\u3053\u306E dashboard \u306F owner-facing surface \u3067\u3059\u3002\u5BFE\u8C61\u306E GitHub / Cloudflare Access identity \u3067\u8A8D\u8A3C\u3055\u308C\u305F\u30E6\u30FC\u30B6\u30FC\u3001\u307E\u305F\u306F machine-authenticated service \u3060\u3051\u304C\u5229\u7528\u3067\u304D\u307E\u3059\u3002</p>
+      <p><code>${escapeDashboardHtml(reason || "dashboard authentication required")}</code></p>
+      <p><a href="${escapeDashboardHtml(origin || "/status")}/status">Status</a></p>
+    </section>
+  </main>
 </body>
 </html>`;
 }


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #428 / #433 / #450 / #452 の dashboard / Butler chat / VPS handoff surface に対して、owner-facing dashboard を public surface ではなく認証済み owner / machine service 境界に置く部分進捗です。

## Satisfied Success Criteria

- GET /dashboard と関連 dashboard page は Cloudflare Access verified JWT payload identity、または machine auth がない場合 401/403/503 で fail closed する。
- /v2/dashboard/chat/messages と /v2/dashboard/chat/:threadId は body parse 前に dashboard 認可を要求し、未認証の通常POSTを保存しない。
- JWT payload の email/login と Access identity header が矛盾する場合は拒否する。
- GitHub Actions deploy event と VPS runner event の service-to-service POST は machine auth 境界に残す。
- production deploy workflow が dashboard allowlist と Cloudflare Access JWT validation repo variables を escaped TOML として Worker env に渡せる。

## Unsatisfied Success Criteria

- 本番 Cloudflare Access policy と repo variable の実設定はこのPRでは行っていない。deploy / variable mutation には scoped passkey approval が必要。
- 対象 GitHub アカウント identity を Cloudflare Access がどの JWT claim として渡すかの live E2E は未実施。

## Non-goal violations

外部 Cloudflare Access policy の変更、GitHub OAuth 実装、repo variable / secret mutation、production deploy 実行はこのPRの非対象。

## Dry-run Impact Report

- Target Issue: #428 / #433 / #450 / #452
- Implementing Success Criteria: dashboard view と dashboard chat read/write を owner / machine 認可境界に入れる。service event ingestion は machine auth を維持する。Cloudflare Access JWT を検証し、JWT payload identity を allowlist 判定に使う。
- Explicit Non-goals: deploy、credential mutation、permission mutation、Cloudflare Access policy creation、Issue close は行わない。
- Expected touched files/routes/workflows: src/worker/runtime.js, test/worker.test.js, .github/workflows/deploy-production.yml, docs/mvp/production-deploy-path.md, test/production-deploy-path.test.js, worker.js
- Affected Issues: #428 / #433 / #450 / #452。dashboard と Butler/VPS handoff の公開面に関係するため。
- Affected PRs: 直近の dashboard / RAG / deploy PR の後続 security fix。PR #456, #457, #458 の runtime surface を狭く補強する。
- Affected workflows: deploy-production が dashboard allowlist variables と CF_ACCESS_TEAM_DOMAIN / CF_ACCESS_AUD を production Worker config に反映する。
- Affected runtime/operator surfaces: Cloudflare Worker dashboard pages, dashboard chat API, dashboard event ingestion, VPS runner event API.
- What may break if we patch narrowly: dashboard HTML だけ閉じると chat POST が公開のまま残る。chat POST だけ閉じると dashboard HTML が読める。JWT payload identity と allowlist を結び付けないと spoofing 余地が残る。service POST に人間認証を要求すると Actions / VPS runner 連携が壊れる。
- Unknowns to investigate before coding: production Cloudflare Access が対象 GitHub account を email と login のどちらの JWT claim で渡すか。CF_ACCESS_TEAM_DOMAIN / CF_ACCESS_AUD の実値。
- Validation needed: npm test。merge 後に allowlist repo variable、CF_ACCESS_TEAM_DOMAIN、CF_ACCESS_AUD、Cloudflare Access policy を設定して production smoke / live E2E が必要。
- Stop condition: Cloudflare Access JWT 検証、JWT payload identity allowlist、production Access policy が未確認なまま、owner だけが通れると完了主張すること。

## File / Line Hypotheses

file: src/worker/runtime.js
  - hypothesis: dashboard page route（/dashboard/* catch-all）と dashboard chat route の入口で共通認可を要求し、Cloudflare Access JWT payload identity を検証すれば public read/write と identity spoofing を止められる。
  - risk if changed narrowly: event ingestion まで browser auth 化すると GitHub Actions / VPS runner が投稿不能になる。
  - validation: worker tests で unauth dashboard GET/POST reject、JWTなし reject、JWT/header mismatch reject、unlisted /dashboard/* reject、authenticated dashboard access、machine event ingestion を確認。
  - related Issue: #428 / #433 / #450 / #452
file: .github/workflows/deploy-production.yml
  - hypothesis: allowlist repo variables と Access JWT validation variables を production Worker vars に safely escaped で渡さないと本番で owner identity 判定ができない。
  - risk if changed narrowly: code は fail closed するが owner も入れない状態になる。quote/newline を含む variable で TOML が壊れる。
  - validation: production deploy path test と post-merge production smoke。

## Hypothesis Retrospective

expected: dashboard GET/POST は未認証、未検証JWT、JWT/header mismatch で拒否され、service event POST は machine auth で維持される。
actual: npm test で該当 unit/integration path は pass。live production は未deploy。
mismatch: production Access identity JWT claim、AUD、team domain、allowlist variable は未設定のため未検証。
lesson: dashboardを公開面として扱った前提が誤り。owner-facing surface は初回実装時から認可境界と JWT payload identity 検証を持つ必要がある。
should become RAG candidate: はい。dashboard public surface は owner auth と machine auth を分離し、Access JWT payload identity 検証を必須にする判断として保存候補。

## Verification Evidence

- Unit: npm test: 863 pass / 1 skipped。dashboard unauth reject、JWTなし reject、JWT/header mismatch reject、owner identity allow、chat unauth reject、event machine auth 維持を含む。
- Integration: npm test 内の worker route integration と production deploy path validation が pass。
- E2E: 未実施。本番 deploy と Cloudflare Access identity / allowlist / JWT validation 設定後に実施が必要。
- Manual: ローカル差分確認済み。本番 dashboard はこのPRが merge/deploy されるまで既存状態のまま。
- Evidence path/link: ローカル npm test output。merge後は GitHub Actions run URL と production smoke を追記対象。

## Butler Completion Contract

- Owner goal: 対象 GitHub アカウントでログインしていないユーザーが dashboard を見られず、公開POSTも dashboard conversation に入らないようにする。
- Butler entrypoint: dashboard UI と /v2/dashboard/chat/*。このPRは入口を認可境界に接続するが、Butler自然言語からの live E2E は未実施。
- Action Schema exposure: 未変更。既存の service/machine endpoints を維持し、dashboard browser surface の認可を追加する。
- Runtime path: Cloudflare Worker fetch route: dashboard page guard, dashboard chat guard, Cloudflare Access JWT verification, JWT payload identity allowlist, service event machine-auth routes。
- Runner/runtime truth: unit/integration runtime truth は pass。本番 runtime truth は merge/deploy/allowlist/Access JWT設定後に確認予定。
- Authority boundary: dashboard browser access は Cloudflare Access verified JWT payload identity allowlist、または machine auth。service POST は bearer / Access service token。deploy と repo variable mutation は scoped passkey approval 必須。
- E2E evidence: 未完了。production allowlist と Access identity/JWT 設定後に owner can access / non-owner cannot access / service POST succeeds を確認する。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 必要。ただしこのPR内では未実行。scoped passkey approval と allowlist / Access JWT repo variable 設定後に deploy-production を実行する。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。dashboard auth gate の production live E2E 後に再評価。

## Related Constitution Rules

- Dashboard は owner-facing surface であり公開ドキュメントではない。
- Cloudflare Access identity header だけではなく JWT 署名検証と JWT payload identity allowlist を要求する。
- High-risk deploy / variable mutation は scoped passkey approval が必要。
- Service-to-service POST は machine auth 境界を維持する。
- 完了主張には production E2E evidence が必要。

## Out-of-scope but NOT implemented

- Cloudflare Access policy creation。
- repo variable VTDD_DASHBOARD_ALLOWED_EMAILS / VTDD_DASHBOARD_ALLOWED_GITHUB_LOGINS / CF_ACCESS_TEAM_DOMAIN / CF_ACCESS_AUD の実設定。
- production deploy 実行。
- Issue close。

## Extra changes (if any)

worker.js は npm run build:worker による生成物更新。

<!-- VTDD metadata -->
- Issue: Issue #452
- Execution ID: mac_codex_only_probe-dashboard-owner-auth-gate-2026-05-20
- Goal: dashboard 公開面を owner / machine auth 境界へ閉じる
