### PR TITLE
Add passkey dashboard owner session

### DIFF
--- a/src/core/passkey-operator-page.js
+++ b/src/core/passkey-operator-page.js
@@ -321,6 +321,7 @@ export function renderPasskeyOperatorPage(input = {}) {
       const deployRunLink = document.getElementById("deploy-run-link");
       const mergePrLink = document.getElementById("merge-pr-link");
       const issueCloseLink = document.getElementById("issue-close-link");
+      const operatorMode = "${escapeHtml(operatorMode)}";
       let latestApprovalGrantId = "";
 
       async function readResponseBody(response) {
@@ -625,6 +626,10 @@ export function renderPasskeyOperatorPage(input = {}) {
           }
           latestApprovalGrantId = verifyBody?.approvalGrant?.approvalId || verifyBody?.approvalGrantId || "";
           approveOutput.textContent = JSON.stringify(verifyBody, null, 2);
+          if (operatorMode === "dashboard") {
+            window.location.assign("/dashboard");
+            return;
+          }
           if (latestApprovalGrantId && autoCopyApprovalGrantInput.checked) {
             try {
               await copyApprovalGrantIdToClipboard({ quiet: true });
@@ -1026,8 +1031,11 @@ function renderGithubAppRoleOption(value, label, selectedValue) {
 
 function normalizeOperatorMode(value) {
   const token = normalizeOperatorToken(value);
-  if (["full", "deploy", "merge", "issue_close", "github_app_secret_sync", "github_actions_secret_sync", "gateway_bearer_vault", "vps"].includes(token)) {
+  if (["full", "deploy", "merge", "issue_close", "github_app_secret_sync", "github_actions_secret_sync", "gateway_bearer_vault", "vps", "dashboard"].includes(token)) {
     return token;
+  }
+  if (token === "dashboard_access") {
+    return "dashboard";
   }
   if (token === "secret_sync") {
     return "github_app_secret_sync";
@@ -1051,6 +1059,9 @@ function defaultActionTypeForMode(operatorMode) {
   if (operatorMode === "issue_close") {
     return "issue_close";
   }
+  if (operatorMode === "dashboard") {
+    return "read";
+  }
   return "destructive";
 }
 
@@ -1063,6 +1074,9 @@ function defaultHighRiskKindForMode(operatorMode) {
   }
   if (operatorMode === "issue_close") {
     return "issue_close";
+  }
+  if (operatorMode === "dashboard") {
+    return "dashboard_access";
   }
   if (operatorMode === "github_actions_secret_sync") {
     return "github_actions_secret_sync";

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -79,6 +79,8 @@ const MCP_SERVER_INFO = Object.freeze({
 const MCP_INSTRUCTIONS =
   "VTDD MCP は Butler と同じ runtime truth / review truth / operational memory を読むための read-first surface です。現在の truth は runtime truth を優先し、memory は補助として扱ってください。";
 const CLOUDFLARE_ACCESS_JWKS_CACHE_TTL_MS = 5 * 60 * 1000;
+const DASHBOARD_PASSKEY_SESSION_COOKIE = "vtdd_dashboard_session";
+const DASHBOARD_PASSKEY_SESSION_MAX_AGE_SECONDS = 60 * 60 * 8;
 const cloudflareAccessJwksCache = new Map();
 const AUTONOMY_MODE_ENV = "VTDD_AUTONOMY_MODE";
 const LEGACY_AUTONOMY_MODE_ENV = "MVP_AUTONOMY_MODE";
@@ -4158,10 +4160,15 @@ async function handlePasskeyApprovalVerifyRequest(request, env) {
   await provider.store(verified.updatedPasskeyRecord);
   await provider.store(verified.grantRecord);
 
+  const extraHeaders = {};
+  if (isDashboardPasskeyScope(verified.approvalGrant?.scope)) {
+    extraHeaders["set-cookie"] = buildDashboardPasskeySessionCookie(verified.approvalGrant);
+  }
+
   return json(200, {
     ok: true,
     approvalGrant: verified.approvalGrant
-  });
+  }, extraHeaders);
 }
 
 function appendWarnings(result, warnings) {
@@ -5662,6 +5669,14 @@ async function authorizeDashboardRequest({ request, env, apiSuffix = "/dashboard
   }
 
   const runtimeEnv = env ?? {};
+  const passkeyAuth = await authorizeDashboardPasskeySession({ request, env: runtimeEnv });
+  if (passkeyAuth.ok) {
+    return passkeyAuth;
+  }
+  if (passkeyAuth.blocking) {
+    return passkeyAuth;
+  }
+
   const routeLabel = `dashboard surface ${apiSuffix}`;
   const allowedEmails = parseAuthList(
     runtimeEnv.VTDD_DASHBOARD_ALLOWED_EMAILS ?? runtimeEnv.CF_ACCESS_ALLOWED_EMAILS
@@ -5751,6 +5766,84 @@ async function authorizeDashboardRequest({ request, env, apiSuffix = "/dashboard
     status: 403,
     reason: `Cloudflare Access identity is not allowed for ${routeLabel}`
   };
+}
+
+async function authorizeDashboardPasskeySession({ request, env }) {
+  const approvalId = parseCookieHeader(request.headers.get("cookie"))[DASHBOARD_PASSKEY_SESSION_COOKIE];
+  if (!approvalId) {
+    return { ok: false, blocking: false };
+  }
+
+  const provider = resolveMemoryProvider(env);
+  const validation = validateMemoryProvider(provider);
+  if (!validation.ok) {
+    return {
+      ok: false,
+      blocking: true,
+      status: 503,
+      reason: "dashboard passkey session cannot be verified because memory provider is unavailable"
+    };
+  }
+
+  const record = await findApprovalRecordById(provider, approvalId);
+  if (!record || normalizeText(record?.content?.kind) !== "passkey_grant") {
+    return {
+      ok: false,
+      blocking: true,
+      status: 401,
+      reason: "dashboard passkey session was not found; open the dashboard passkey sign-in link again"
+    };
+  }
+  if (isExpiredPasskeyEphemeralRecord(record)) {
+    return {
+      ok: false,
+      blocking: true,
+      status: 401,
+      reason: "dashboard passkey session expired; open the dashboard passkey sign-in link again"
+    };
+  }
+  if (!isDashboardPasskeyScope(record?.content?.scope)) {
+    return {
+      ok: false,
+      blocking: true,
+      status: 403,
+      reason: "passkey grant scope is not valid for dashboard access"
+    };
+  }
+  return {
+    ok: true,
+    authType: "passkey_dashboard_session",
+    subject: normalizeText(record?.content?.credentialId) || "passkey"
+  };
+}
+
+function isDashboardPasskeyScope(scope = {}) {
+  return normalizeText(scope?.actionType) === "read" && normalizeText(scope?.highRiskKind) === "dashboard_access";
+}
+
+function buildDashboardPasskeySessionCookie(approvalGrant = {}) {
+  const approvalId = normalizeText(approvalGrant.approvalId);
+  return [
+    `${DASHBOARD_PASSKEY_SESSION_COOKIE}=${encodeURIComponent(approvalId)}`,
+    "Path=/",
+    `Max-Age=${DASHBOARD_PASSKEY_SESSION_MAX_AGE_SECONDS}`,
+    "HttpOnly",
+    "Secure",
+    "SameSite=Lax"
+  ].join("; ");
+}
+
+function parseCookieHeader(value) {
+  const cookies = {};
+  for (const part of normalizeText(value).split(";")) {
+    const [rawName, ...rawValueParts] = part.split("=");
+    const name = normalizeText(rawName);
+    if (!name) {
+      continue;
+    }
+    cookies[name] = decodeURIComponent(rawValueParts.join("=") || "");
+  }
+  return cookies;
 }
 
 function extractCloudflareAccessJwtIdentity(payload) {
@@ -7327,6 +7420,7 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
 
 function renderDashboardAuthRequiredPage({ runtimeOrigin, reason } = {}) {
   const origin = normalizeText(runtimeOrigin);
+  const dashboardSignInUrl = `${origin || ""}/v2/approval/passkey/operator?mode=dashboard&repositoryInput=marushu%2Fvtdd-v2-p&phase=execution&actionType=read&highRiskKind=dashboard_access`;
   return `<!doctype html>
 <html lang="ja">
 <head>
@@ -7350,6 +7444,7 @@ function renderDashboardAuthRequiredPage({ runtimeOrigin, reason } = {}) {
       <h1>Dashboard auth required</h1>
       <p>この dashboard は owner-facing surface です。対象の GitHub / Cloudflare Access identity で認証されたユーザー、または machine-authenticated service だけが利用できます。</p>
       <p><code>${escapeDashboardHtml(reason || "dashboard authentication required")}</code></p>
+      <p><a href="${escapeDashboardHtml(dashboardSignInUrl)}">Passkey で dashboard に入る</a></p>
       <p><a href="${escapeDashboardHtml(origin || "/status")}/status">Status</a></p>
     </section>
   </main>

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -257,6 +257,64 @@ test("worker rejects dashboard access when owner identity lacks a verified Acces
   assert.equal(body.includes("Cloudflare Access JWT assertion is required"), true);
 });
 
+test("worker serves v2 dashboard for valid dashboard passkey session", async () => {
+  const provider = createInMemoryMemoryProvider();
+  await provider.store({
+    id: "approval:dashboard-session",
+    type: MemoryRecordType.APPROVAL_LOG,
+    content: {
+      kind: "passkey_grant",
+      status: "verified",
+      approvalId: "approval:dashboard-session",
+      credentialId: "AQIDBA",
+      verifiedAt: "2026-05-20T00:00:00.000Z",
+      expiresAt: "2999-01-01T00:00:00.000Z",
+      scope: {
+        actionType: "read",
+        highRiskKind: "dashboard_access",
+        repositoryInput: "marushu/vtdd-v2-p",
+        phase: "execution"
+      }
+    },
+    metadata: { source: "test" },
+    priority: 96,
+    tags: ["passkey_grant", "passkey_approval", "verified"],
+    createdAt: "2026-05-20T00:00:00.000Z"
+  });
+
+  const response = await worker.fetch(
+    new Request("https://example.com/dashboard", {
+      headers: {
+        cookie: "vtdd_dashboard_session=approval%3Adashboard-session"
+      }
+    }),
+    {
+      MEMORY_PROVIDER: provider
+    }
+  );
+
+  assert.equal(response.status, 200);
+  const body = await response.text();
+  assert.equal(body.includes("VTDD v2 Dashboard"), true);
+});
+
+test("worker rejects stale dashboard passkey session cookies", async () => {
+  const response = await worker.fetch(
+    new Request("https://example.com/dashboard", {
+      headers: {
+        cookie: "vtdd_dashboard_session=approval%3Amissing"
+      }
+    }),
+    {
+      MEMORY_PROVIDER: createInMemoryMemoryProvider()
+    }
+  );
+
+  assert.equal(response.status, 401);
+  const body = await response.text();
+  assert.equal(body.includes("dashboard passkey session was not found"), true);
+});
+
 test("worker rejects dashboard access when Access email header has no matching JWT email claim", async () => {
   const response = await worker.fetch(
     new Request("https://example.com/dashboard", {
@@ -3565,6 +3623,19 @@ test("worker serves passkey operator page", async () => {
   assert.equal(html.includes('href="https://evil.example/phish"'), false);
 });
 
+test("worker serves dashboard passkey operator mode", async () => {
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/approval/passkey/operator?mode=dashboard&repositoryInput=marushu%2Fvtdd-v2-p"),
+    gatewayAuthEnv
+  );
+
+  assert.equal(response.status, 200);
+  const html = await response.text();
+  assert.equal(html.includes('id="action-type-input" value="read"'), true);
+  assert.equal(html.includes('id="risk-kind-input" value="dashboard_access"'), true);
+  assert.equal(html.includes('const operatorMode = "dashboard"'), true);
+});
+
 test("worker serves issue close operator mode without falling back to PR merge UI", async () => {
   const response = await worker.fetch(
     new Request(
@@ -3865,6 +3936,81 @@ test("worker allows same-origin browser approval flow after passkey exists", asy
   assert.equal(verifyBody.approvalGrant.scope.repositoryInput, "marushu/vtdd-v2-p");
   assert.equal(verifyBody.approvalGrant.scope.issueNumber, "15");
   assert.equal(verifyBody.approvalGrant.scope.relatedIssue, "15");
+});
+
+test("worker sets dashboard session cookie after dashboard passkey approval", async () => {
+  const provider = createInMemoryMemoryProvider();
+  await provider.store({
+    id: "passkey:AQIDBA",
+    type: MemoryRecordType.WORKING_MEMORY,
+    content: {
+      kind: "passkey_registry",
+      credentialId: "AQIDBA",
+      publicKey: "BQYHCA",
+      counter: 1,
+      transports: ["internal"]
+    },
+    metadata: { source: "test" },
+    priority: 80,
+    tags: ["passkey_registry"],
+    createdAt: "2026-04-25T00:00:00.000Z"
+  });
+
+  const challenge = await worker.fetch(
+    new Request("https://example.com/v2/approval/passkey/challenge", {
+      method: "POST",
+      headers: {
+        origin: "https://example.com",
+        "sec-fetch-site": "same-origin",
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({
+        phase: "execution",
+        highRiskKind: "dashboard_access",
+        repositoryInput: "marushu/vtdd-v2-p",
+        policyInput: {
+          actionType: ActionType.READ,
+          repositoryInput: "marushu/vtdd-v2-p",
+          highRiskKind: "dashboard_access"
+        }
+      })
+    }),
+    {
+      MEMORY_PROVIDER: provider,
+      PASSKEY_ADAPTER: passkeyAdapter
+    }
+  );
+  assert.equal(challenge.status, 200);
+  const challengeBody = await challenge.json();
+
+  const verify = await worker.fetch(
+    new Request("https://example.com/v2/approval/passkey/verify", {
+      method: "POST",
+      headers: {
+        origin: "https://example.com",
+        "sec-fetch-site": "same-origin",
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({
+        sessionId: challengeBody.sessionId,
+        response: {
+          id: "AQIDBA",
+          response: {}
+        }
+      })
+    }),
+    {
+      MEMORY_PROVIDER: provider,
+      PASSKEY_ADAPTER: passkeyAdapter
+    }
+  );
+
+  assert.equal(verify.status, 200);
+  assert.match(verify.headers.get("set-cookie"), /vtdd_dashboard_session=approval%3A/);
+  assert.match(verify.headers.get("set-cookie"), /HttpOnly/);
+  assert.match(verify.headers.get("set-cookie"), /SameSite=Lax/);
+  const verifyBody = await verify.json();
+  assert.equal(verifyBody.approvalGrant.scope.highRiskKind, "dashboard_access");
 });
 
 test("worker gateway accepts high-risk approval grant resolved from memory", async () => {

--- a/worker.js
+++ b/worker.js
@@ -27562,6 +27562,7 @@ function renderPasskeyOperatorPage(input = {}) {
       const deployRunLink = document.getElementById("deploy-run-link");
       const mergePrLink = document.getElementById("merge-pr-link");
       const issueCloseLink = document.getElementById("issue-close-link");
+      const operatorMode = "${escapeHtml(operatorMode)}";
       let latestApprovalGrantId = "";
 
       async function readResponseBody(response) {
@@ -27866,6 +27867,10 @@ function renderPasskeyOperatorPage(input = {}) {
           }
           latestApprovalGrantId = verifyBody?.approvalGrant?.approvalId || verifyBody?.approvalGrantId || "";
           approveOutput.textContent = JSON.stringify(verifyBody, null, 2);
+          if (operatorMode === "dashboard") {
+            window.location.assign("/dashboard");
+            return;
+          }
           if (latestApprovalGrantId && autoCopyApprovalGrantInput.checked) {
             try {
               await copyApprovalGrantIdToClipboard({ quiet: true });
@@ -28259,8 +28264,11 @@ function renderGithubAppRoleOption(value, label, selectedValue) {
 }
 function normalizeOperatorMode(value) {
   const token = normalizeOperatorToken(value);
-  if (["full", "deploy", "merge", "issue_close", "github_app_secret_sync", "github_actions_secret_sync", "gateway_bearer_vault", "vps"].includes(token)) {
+  if (["full", "deploy", "merge", "issue_close", "github_app_secret_sync", "github_actions_secret_sync", "gateway_bearer_vault", "vps", "dashboard"].includes(token)) {
     return token;
+  }
+  if (token === "dashboard_access") {
+    return "dashboard";
   }
   if (token === "secret_sync") {
     return "github_app_secret_sync";
@@ -28283,6 +28291,9 @@ function defaultActionTypeForMode(operatorMode) {
   if (operatorMode === "issue_close") {
     return "issue_close";
   }
+  if (operatorMode === "dashboard") {
+    return "read";
+  }
   return "destructive";
 }
 function defaultHighRiskKindForMode(operatorMode) {
@@ -28294,6 +28305,9 @@ function defaultHighRiskKindForMode(operatorMode) {
   }
   if (operatorMode === "issue_close") {
     return "issue_close";
+  }
+  if (operatorMode === "dashboard") {
+    return "dashboard_access";
   }
   if (operatorMode === "github_actions_secret_sync") {
     return "github_actions_secret_sync";
@@ -55808,6 +55822,8 @@ var MCP_SERVER_INFO = Object.freeze({
 });
 var MCP_INSTRUCTIONS = "VTDD MCP \u306F Butler \u3068\u540C\u3058 runtime truth / review truth / operational memory \u3092\u8AAD\u3080\u305F\u3081\u306E read-first surface \u3067\u3059\u3002\u73FE\u5728\u306E truth \u306F runtime truth \u3092\u512A\u5148\u3057\u3001memory \u306F\u88DC\u52A9\u3068\u3057\u3066\u6271\u3063\u3066\u304F\u3060\u3055\u3044\u3002";
 var CLOUDFLARE_ACCESS_JWKS_CACHE_TTL_MS = 5 * 60 * 1e3;
+var DASHBOARD_PASSKEY_SESSION_COOKIE = "vtdd_dashboard_session";
+var DASHBOARD_PASSKEY_SESSION_MAX_AGE_SECONDS = 60 * 60 * 8;
 var cloudflareAccessJwksCache = /* @__PURE__ */ new Map();
 var AUTONOMY_MODE_ENV = "VTDD_AUTONOMY_MODE";
 var LEGACY_AUTONOMY_MODE_ENV = "MVP_AUTONOMY_MODE";
@@ -59308,10 +59324,14 @@ async function handlePasskeyApprovalVerifyRequest(request, env) {
   }
   await provider.store(verified.updatedPasskeyRecord);
   await provider.store(verified.grantRecord);
+  const extraHeaders = {};
+  if (isDashboardPasskeyScope(verified.approvalGrant?.scope)) {
+    extraHeaders["set-cookie"] = buildDashboardPasskeySessionCookie(verified.approvalGrant);
+  }
   return json(200, {
     ok: true,
     approvalGrant: verified.approvalGrant
-  });
+  }, extraHeaders);
 }
 function appendWarnings(result, warnings) {
   if (!Array.isArray(warnings) || warnings.length === 0) {
@@ -60566,6 +60586,13 @@ async function authorizeDashboardRequest({ request, env, apiSuffix = "/dashboard
     return { ok: true, authType: "machine" };
   }
   const runtimeEnv = env ?? {};
+  const passkeyAuth = await authorizeDashboardPasskeySession({ request, env: runtimeEnv });
+  if (passkeyAuth.ok) {
+    return passkeyAuth;
+  }
+  if (passkeyAuth.blocking) {
+    return passkeyAuth;
+  }
   const routeLabel = `dashboard surface ${apiSuffix}`;
   const allowedEmails = parseAuthList(
     runtimeEnv.VTDD_DASHBOARD_ALLOWED_EMAILS ?? runtimeEnv.CF_ACCESS_ALLOWED_EMAILS
@@ -60648,6 +60675,78 @@ async function authorizeDashboardRequest({ request, env, apiSuffix = "/dashboard
     status: 403,
     reason: `Cloudflare Access identity is not allowed for ${routeLabel}`
   };
+}
+async function authorizeDashboardPasskeySession({ request, env }) {
+  const approvalId = parseCookieHeader(request.headers.get("cookie"))[DASHBOARD_PASSKEY_SESSION_COOKIE];
+  if (!approvalId) {
+    return { ok: false, blocking: false };
+  }
+  const provider = resolveMemoryProvider(env);
+  const validation = validateMemoryProvider(provider);
+  if (!validation.ok) {
+    return {
+      ok: false,
+      blocking: true,
+      status: 503,
+      reason: "dashboard passkey session cannot be verified because memory provider is unavailable"
+    };
+  }
+  const record2 = await findApprovalRecordById(provider, approvalId);
+  if (!record2 || normalizeText30(record2?.content?.kind) !== "passkey_grant") {
+    return {
+      ok: false,
+      blocking: true,
+      status: 401,
+      reason: "dashboard passkey session was not found; open the dashboard passkey sign-in link again"
+    };
+  }
+  if (isExpiredPasskeyEphemeralRecord(record2)) {
+    return {
+      ok: false,
+      blocking: true,
+      status: 401,
+      reason: "dashboard passkey session expired; open the dashboard passkey sign-in link again"
+    };
+  }
+  if (!isDashboardPasskeyScope(record2?.content?.scope)) {
+    return {
+      ok: false,
+      blocking: true,
+      status: 403,
+      reason: "passkey grant scope is not valid for dashboard access"
+    };
+  }
+  return {
+    ok: true,
+    authType: "passkey_dashboard_session",
+    subject: normalizeText30(record2?.content?.credentialId) || "passkey"
+  };
+}
+function isDashboardPasskeyScope(scope = {}) {
+  return normalizeText30(scope?.actionType) === "read" && normalizeText30(scope?.highRiskKind) === "dashboard_access";
+}
+function buildDashboardPasskeySessionCookie(approvalGrant = {}) {
+  const approvalId = normalizeText30(approvalGrant.approvalId);
+  return [
+    `${DASHBOARD_PASSKEY_SESSION_COOKIE}=${encodeURIComponent(approvalId)}`,
+    "Path=/",
+    `Max-Age=${DASHBOARD_PASSKEY_SESSION_MAX_AGE_SECONDS}`,
+    "HttpOnly",
+    "Secure",
+    "SameSite=Lax"
+  ].join("; ");
+}
+function parseCookieHeader(value) {
+  const cookies = {};
+  for (const part of normalizeText30(value).split(";")) {
+    const [rawName, ...rawValueParts] = part.split("=");
+    const name = normalizeText30(rawName);
+    if (!name) {
+      continue;
+    }
+    cookies[name] = decodeURIComponent(rawValueParts.join("=") || "");
+  }
+  return cookies;
 }
 function extractCloudflareAccessJwtIdentity(payload) {
   const custom2 = payload?.custom && typeof payload.custom === "object" ? payload.custom : {};
@@ -62137,6 +62236,7 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
 }
 function renderDashboardAuthRequiredPage({ runtimeOrigin, reason } = {}) {
   const origin = normalizeText30(runtimeOrigin);
+  const dashboardSignInUrl = `${origin || ""}/v2/approval/passkey/operator?mode=dashboard&repositoryInput=marushu%2Fvtdd-v2-p&phase=execution&actionType=read&highRiskKind=dashboard_access`;
   return `<!doctype html>
 <html lang="ja">
 <head>
@@ -62160,6 +62260,7 @@ function renderDashboardAuthRequiredPage({ runtimeOrigin, reason } = {}) {
       <h1>Dashboard auth required</h1>
       <p>\u3053\u306E dashboard \u306F owner-facing surface \u3067\u3059\u3002\u5BFE\u8C61\u306E GitHub / Cloudflare Access identity \u3067\u8A8D\u8A3C\u3055\u308C\u305F\u30E6\u30FC\u30B6\u30FC\u3001\u307E\u305F\u306F machine-authenticated service \u3060\u3051\u304C\u5229\u7528\u3067\u304D\u307E\u3059\u3002</p>
       <p><code>${escapeDashboardHtml(reason || "dashboard authentication required")}</code></p>
+      <p><a href="${escapeDashboardHtml(dashboardSignInUrl)}">Passkey \u3067 dashboard \u306B\u5165\u308B</a></p>
       <p><a href="${escapeDashboardHtml(origin || "/status")}/status">Status</a></p>
     </section>
   </main>


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #428 / #433 / #450 / #452 の dashboard / Butler chat / VPS handoff surface に対して、公開 dashboard を閉じた後も owner が same-origin passkey で dashboard を開けるようにする部分進捗です。

## Satisfied Success Criteria

- Dashboard auth required 画面から dashboard 用 passkey operator link を開ける。
- Passkey approval scope actionType=read / highRiskKind=dashboard_access の検証後、HttpOnly/Secure/SameSite=Lax の dashboard session cookie を発行する。
- 有効な dashboard passkey session cookie で /dashboard/* と dashboard chat API を利用できる。
- 期限切れ・不明な dashboard passkey session cookie は 401/403 で拒否する。
- machine auth と Cloudflare Access JWT allowlist path は維持する。

## Unsatisfied Success Criteria

- 本番 live E2E はこのPR merge/deploy 後に実施する必要がある。
- Butler 自然言語から dashboard sign-in link を提示する UX はこのPRでは未変更。

## Non-goal violations

Cloudflare Access policy creation、repo variable/secret mutation、GitHub App permission mutation、Issue close は行わない。

## Dry-run Impact Report

- Target Issue: #428 / #433 / #450 / #452
- Implementing Success Criteria: owner が dashboard auth required 画面から passkey でログインし、dashboard と chat をブラウザで使える。未認証と stale session は拒否する。
- Explicit Non-goals: Cloudflare Access 設定、deploy 実行、credential mutation、permission mutation、Issue close は行わない。
- Expected touched files/routes/workflows: src/worker/runtime.js, src/core/passkey-operator-page.js, test/worker.test.js, worker.js
- Affected Issues: #428 / #433 / #450 / #452。dashboard owner access と Butler/VPS handoff surface に関係するため。
- Affected PRs: PR #459 の follow-up。公開面を閉じた後、owner が dashboard に入れない欠落を補う。
- Affected workflows: なし。deploy workflow は変更しない。
- Affected runtime/operator surfaces: Cloudflare Worker dashboard pages, dashboard chat API, passkey operator page, passkey approval verify route.
- What may break if we patch narrowly: Cloudflare Access だけに寄せると owner の実利用が外部 policy/variable 設定に依存する。passkey grant を dashboard session に接続しないと owner が dashboard を開けない。machine auth を変えると Actions/VPS runner が壊れる。
- Unknowns to investigate before coding: 本番で既存 passkey registration が利用可能か。未登録の場合は同じ operator page から登録が必要。
- Validation needed: npm test。merge/deploy 後に /dashboard -> Passkey sign-in -> /dashboard 200 の live browser E2E が必要。
- Stop condition: passkey session が dashboard 以外の high-risk grant を dashboard access として扱う場合、または未認証 dashboard access を再び許す場合。

## File / Line Hypotheses

file: src/worker/runtime.js
  - hypothesis: passkey approval verify で dashboard_access scope のときだけ session cookie を発行し、dashboard auth gate がその grant を検証すれば owner は Cloudflare Access なしで入れる。
  - risk if changed narrowly: 任意の passkey grant を dashboard session として受けると authority boundary が広がる。
  - validation: dashboard session cookie accept / stale cookie reject / set-cookie tests。
  - related Issue: #428 / #433 / #450 / #452
file: src/core/passkey-operator-page.js
  - hypothesis: mode=dashboard を追加し、verify 後に /dashboard へ戻せば owner はコピー操作なしで dashboard に入れる。
  - risk if changed narrowly: approvalGrantId をコピーさせる UX のままだと Butler/iPhone-first にならない。
  - validation: operator page mode test。

## Hypothesis Retrospective

expected: owner は passkey operator から dashboard session を作り、/dashboard を開ける。
actual: local npm test で session cookie accept、stale reject、operator dashboard mode、set-cookie を確認。
mismatch: production browser live E2E は未実施。
lesson: dashboard security fix は owner access recovery と一体で扱う必要がある。
should become RAG candidate: はい。dashboard を閉じる変更は owner passkey recovery path まで同一スライスで扱う判断として保存候補。

## Verification Evidence

- Unit: npm test: 867 pass / 1 skipped。dashboard passkey session accept/stale reject、dashboard operator mode、set-cookie を含む。
- Integration: worker route integration と generated worker parity が pass。
- E2E: 未実施。merge/deploy 後に production browser で passkey sign-in -> dashboard 200 を確認する。
- Manual: ローカル差分確認済み。
- Evidence path/link: ローカル npm test output。merge後は GitHub Actions run URL と production smoke を追記対象。

## Butler Completion Contract

- Owner goal: owner が Mac の標準出力に依存せず、dashboard をブラウザ/Butler 起点で開いて開発状態を見られるようにする。
- Butler entrypoint: Dashboard auth required page の Passkey sign-in link。Butler が同じ link を提示する自然言語 UX は次スライス。
- Action Schema exposure: 未変更。dashboard browser surface と passkey operator route の接続。
- Runtime path: Cloudflare Worker fetch route: dashboard auth gate -> passkey session cookie lookup -> passkey grant scope validation -> dashboard/chat access。
- Runner/runtime truth: unit/integration runtime truth は pass。本番 runtime truth は merge/deploy 後に確認予定。
- Authority boundary: dashboard browser access は machine auth、Cloudflare Access verified identity、または same-origin passkey dashboard_access session。GitHub App/Actions/VPS service auth は変更なし。
- E2E evidence: 未完了。production deploy 後に owner passkey sign-in と dashboard access を確認する。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 必要。このPR merge 後に scoped passkey approval 付き deploy-production が必要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。production browser/passkey smoke 後に iPhone Butler からの link guidance を確認する。

## Related Constitution Rules

- Dashboard は owner-facing surface であり閉じるだけでは不十分。
- Owner recovery path は same-origin passkey/operator 境界で提供する。
- Service-to-service POST は machine auth 境界を維持する。
- 完了主張には production E2E evidence が必要。

## Out-of-scope but NOT implemented

- Cloudflare Access policy creation。
- repo variable/secret mutation。
- production deploy 実行。
- Butler natural-language link generation UX。
- Issue close。

## Extra changes (if any)

worker.js は npm run build:worker による生成物更新。

<!-- VTDD metadata -->
- Issue: Issue #452
- Execution ID: mac_codex_only_probe-dashboard-passkey-owner-session-2026-05-20
- Goal: owner が passkey で dashboard に入れる状態を復旧する
