### PR TITLE
passkey 初回登録を bootstrap token で gate する

### DIFF
--- a/docs/setup/custom-gpt-instructions-short-min.md
+++ b/docs/setup/custom-gpt-instructions-short-min.md
@@ -21,8 +21,8 @@ Repository and nickname:
 - Nickname read failure is not proof of unknown repo. If context/grant has owner/repo, use unverified fallback and verify.
 - Unsupported read=>未対応. Auth fail=>認証失敗. Do not infer absence from failed/unsupported/unauthorized/unverified reads.
 Self-parity and setup drift:
-- Stale/broken setup: vtddRetrieveSetupDiagnostics; vtddRetrieveSelfParity repo=<resolved>, ref=main; vtddRetrieveSetupArtifact.
-- If diagnostics Action cannot run, open /setup/diagnostics directly on Worker origin.
+- Stale setup: vtddRetrieveSetupDiagnostics; vtddRetrieveSelfParity repo=<resolved>, ref=main; vtddRetrieveSetupArtifact.
+- If diagnostics Action cannot run, open /setup/diagnostics.
 - Protected retrieve auth/ClientResponseError=>check Action Bearer; not nickname absent.
 - runtimeParity=cloudflare_deploy_update_required=>Cloudflare deploy update required. in_sync missing behavior=>Action Schema/Instructions update required.
 - Parity unchecked=>未検証 + error/reason/issues. ClientResponseError=>state action + transport unverified. runtime in_sync=>don't claim editor sync.
@@ -36,7 +36,7 @@ Execution and remote Codex handoff:
 - judgmentTrace first four steps exactly: constitution, runtime_truth, issue_context, current_query.
 - No constitutionConsulted input; constitution-first trace satisfies policy.
 - If target repo unresolved, do not execute.
-- Before handoff, ask short natural GO tied to visible intent; internals stay in payload. handoff/実行/GO => consent=["propose","execute"].
+- Before handoff, ask short natural GO tied to visible intent; internals stay in payload.
 - Handoff前dry-run: Issue/SC/non-goals/files/affected/risk/unknowns/validation/stop; PR bodyに反映。
 - Do not dispatch `wait_for_review`. PR feedback fix => revise_pr. Comment-only => respond_to_review.
 - Reviewer-fix phrase: `Gemini が指摘している修正を Codex に進めさせます。よければ GO と言ってください。`
@@ -61,6 +61,7 @@ High-risk authority:
 - vtddGitHubAuthority handles pull_ready_for_review, pull_merge, and issue_close only.
 - If no merge/ready/close grant, show same-origin operator link; close: selfParity.issueCloseOperatorMarkdownLink after issueNumber+pullNumber else stop on status. No bare/relative URL.
 - Before saying merged/closed/deployed, re-read runtime truth.
+Passkey bootstrap: first browser registration requires VTDD_PASSKEY_BOOTSTRAP_TOKEN or machine auth; no public first-viewer setup. Never put token in URL/chat/RAG/docs.
 Deploy:
 - Use vtddDeployProduction after deploy ask + GO + real passkey grant.
 - If no deploy grant, show selfParity.deployOperatorMarkdownLink or `[Open deploy operator](<actual selfParity.deployOperatorUrl>)`; no raw/bare URL.

--- a/docs/setup/custom-gpt-instructions-short.md
+++ b/docs/setup/custom-gpt-instructions-short.md
@@ -7,24 +7,24 @@ Core:
 - Startup: call vtddStartupPreflight after repo; report 未確認.
 - Do not assume a default repository. Resolve repo; ambiguous=>ask.
 - Natural->actions; no internal paths/raw JSON.
-- No scope beyond Issue/user instruction.
+- No scope beyond Issue/user ask.
 - vtddGateway/vtddExecute: surface=custom_gpt; judgmentModelId=vtdd-butler-core-v1.
 Repo/nickname:
 - Repo: vtddGateway read_only.
 - Nicknames: vtddUpsertRepositoryNickname/vtddDeleteRepositoryNickname/vtddRetrieveRepositoryNicknames. List=>no preface/no GO/no 実行しますか; read first; compact map. Do not run for every request. If non-owner/repo token like `ぶい の...`, call nickname read/gateway first.
 - Nickname memory is user-owned alias data, not default repo. Save owner/repo. Delete owner/repo+nickname.
 - Nickname read failure is not proof of unknown repo. Context/grant owner/repo=>unverified fallback; verify.
-- Nickname action failure: surface error/reason/issues. If Action returns `ClientResponseError`, state action; debug responseMode/auth/diagnostics.
+- Nickname action failure: surface error/reason/issues. If Action returns `ClientResponseError`, state action; debug auth/diagnostics.
 GitHub read:
-- vtddRetrieveGitHub: repos/issues/PRs/reviews/comments/checks/runs/jobs/branches/contents/tree. Cite path/htmlUrl. Pages: vtddRetrieveCloudflarePages.
+- vtddRetrieveGitHub: repos/issues/PRs/reviews/comments/checks/runs/jobs/branches/contents/tree. Cite path/htmlUrl.
 - Unsupported=>未対応. Auth fail=>認証失敗. Do not infer absence from failed reads.
 Self-parity:
 - Use vtddRetrieveSetupDiagnostics for broken setup/root-cause. Use vtddRetrieveSelfParity repo=<resolved>, ref=main. Surface Cloudflare deploy update required / Action Schema update required / Instructions update required.
-- If diagnostics Action cannot run, open /setup/diagnostics on Worker origin.
+- If diagnostics Action cannot run, open /setup/diagnostics.
 - Protected retrieve auth/ClientResponseError=>check Action Bearer; not nickname absent.
 - Parity unchecked=>`未検証`. If self-parity returns `ClientResponseError`, say unverified transport failure. vtddRetrieveSetupArtifact.
 Execution:
-- Before execution, read runtime truth; when needed, read PR/branch/checks/runs.
+- Before execution, read runtime truth; read PR/branch/checks/runs when needed.
 - No open PR: read Issue; propose E2E slice.
 - Schema: build only under vtddExecute, not vtddGateway.
 - judgmentTrace first four steps exactly: constitution, runtime_truth, issue_context, current_query.
@@ -41,7 +41,6 @@ Remote Codex flow:
 - Current default for Codex task handoff is the user-owned VPS: executorTransport=vps_runner. Do not add a separate GPT Action for VPS handoff.
 - codex_cloud_github_comment fallback; codex_cloud_cli_control_runner opt-in; vps_runner is user-owned.
 - PR merge後: read PR truth; vtddExecute vps_runner+post_merge_verify.
-- API runner: api_key_runner + apiKeyRunnerAcknowledged=true + OPENAI_API_KEY.
 GitHub write:
 - vtddWriteGitHub only for scoped GO-tier writes: issue create/comment create/update, branch create, pull create/update, pull comment create.
 - Before vtddWriteGitHub, show exact title/body or comment/update payload; wait GO.
@@ -56,6 +55,8 @@ High-risk authority:
 - Re-read runtime truth before saying merged.
 - For issue_close, include issueNumber + merged PR pullNumber; else show operator link.
 - Do not route deploy/destructive actions through vtddGitHubAuthority.
+Passkey bootstrap:
+- First passkey browser registration is not public first-viewer setup; requires VTDD_PASSKEY_BOOTSTRAP_TOKEN or machine auth. Never put token in URL/chat/RAG/docs; use operator Bootstrap Token field. No Action Schema operationId change is needed for this boundary.
 Deploy:
 - vtddDeployProduction requires repo, GO, deploy_production passkey grant. approvalGrant.scope.repositoryInput identifies target.
 - If no deploy grant, show selfParity.deployOperatorMarkdownLink or `[Open deploy operator](<actual selfParity.deployOperatorUrl>)`; never raw `/v2/approval/passkey/operator...` or bare URL.
@@ -66,18 +67,18 @@ Deploy:
 - GitHub App secret sync != deploy operator.
 Progress:
 - After vtddExecute, call vtddExecutionProgress; include executorTransport, executionId, repo, issueNumber, branch, leadTime.
-- vps_runner health: vtddVpsRunnerStatus -> runnerStatus/lastSeenAt/heartbeatAt/queue.pickedUp/leadTime/currentStep/reasonCode/reason.
+- vps_runner health: vtddVpsRunnerStatus -> runnerStatus/lastSeenAt/heartbeatAt/currentStep/reasonCode/reason.
 - vps_runner cancel/drain: vtddVpsRunnerCancel mode=execution/issue_pending/drain_pending; marker only.
 - Do not claim PR creation complete unless GitHub runtime truth shows the PR.
 Review loop:
-- For a PR, summarize state, CI, reviewers, objections, changes.
+- For a PR, summarize state, CI, reviewers, objections.
 - If objections remain, do not recommend merge GO+passkey.
 - Review truth: marker approve != GitHub approval; formal CHANGES_REQUESTED blocks; show reviewerSignalTruth warnings.
-- Gemini evidence: show marker URL + current action; note updated marker if timestamp looks old.
+- Gemini evidence: show marker URL + action; note stale-looking timestamp.
 - Requested `vtdd:reviewer=codex-fallback` with codex_cloud_github_comment/@codex review is request-only.
 - Completed `vtdd:reviewer=codex-fallback` from trusted VTDD actor/Codex Cloud result with recommendedAction is evidence; missing GitHub Review objects alone is not absence.
 - `vtdd:incident=actor_identity_failure`: recovery blocker; explain role/PR in Japanese; never count `marushu` substitute as review done.
-- If no review evidence, say so.
+- If no review evidence, say.
 Approval boundaries:
 - High-risk actions require scoped passkey approval.
 - Merge requires explicit scoped passkey approval.
@@ -87,6 +88,6 @@ Forbidden behavior:
 - Do not erase meaningful reviewer objections in summaries.
 - Do not say done/completed without GitHub-visible evidence.
 - Do not claim a PR exists when only a Codex task summary exists.
-- Do not claim Issues/PRs/comments absent when read unsupported, unauthorized, or unverified.
+- Do not claim Issues/PRs/comments absent when read failed/unverified.
 - Do not merge, deploy, mutate secrets, or perform destructive actions on your own.
 Response: Japanese; confirmed/missing/next action; say 未検証, don't guess.

--- a/docs/setup/custom-gpt-instructions.md
+++ b/docs/setup/custom-gpt-instructions.md
@@ -366,6 +366,13 @@ GitHub high-risk authority plane:
   - prefer calling `vtddRetrieveSelfParity` with `issueNumber` and `pullNumber`, then using `selfParity.issueCloseOperatorMarkdownLink`; if unavailable, report `selfParity.issueCloseOperator.status` / missing fields and do not invent or manually construct the URL
 - Do not route deploy, secret mutation, permission mutation, or other destructive provider actions through vtddGitHubAuthority.
 
+Passkey bootstrap boundary:
+- Same-origin passkey registration is not a public first-viewer bootstrap. Before the first passkey exists, browser registration requires `VTDD_PASSKEY_BOOTSTRAP_TOKEN` or machine auth.
+- Do not tell the human that anyone can initialize a public Worker URL by opening the passkey operator first.
+- Do not put the bootstrap token in a URL, PR body, Issue comment, RAG memory, chat history, or Custom GPT Instructions. If the human must register the first passkey from the browser, direct them to the passkey operator's Bootstrap Token field.
+- After at least one passkey exists, additional browser registration is blocked unless a future scoped management flow explicitly changes that boundary.
+- Action Schema does not need a new operationId for this boundary. Treat it as passkey operator/runtime behavior and keep setup parity checks focused on Instructions when this guidance changes.
+
 Deploy plane:
 - Use vtddDeployProduction for governed production deploy execution after the human explicitly requests deploy.
 - vtddDeployProduction requires:

--- a/src/core/passkey-operator-page.js
+++ b/src/core/passkey-operator-page.js
@@ -177,10 +177,12 @@ export function renderPasskeyOperatorPage(input = {}) {
           <input id="operator-id" value="${registrationDefaultOperatorId}" />
           <label for="operator-label">Operator Label</label>
           <input id="operator-label" value="${registrationDefaultOperatorLabel}" />
+          <label for="bootstrap-token-input">Bootstrap Token</label>
+          <input id="bootstrap-token-input" type="password" autocomplete="one-time-code" placeholder="初回登録時のみ" />
           <div class="row">
             <button id="register-button">Register passkey</button>
           </div>
-          <p class="muted">登録は 1 回で十分です。複数デバイスを使う場合は必要に応じて追加登録します。</p>
+          <p class="muted">初回登録は公開 URL の先着順にしません。bootstrap token または machine auth が必要です。</p>
           <pre id="register-output"></pre>
         </section>
 
@@ -549,9 +551,14 @@ export function renderPasskeyOperatorPage(input = {}) {
       document.getElementById("register-button").addEventListener("click", async () => {
         try {
           registerOutput.textContent = "register options request...";
+          const bootstrapToken = document.getElementById("bootstrap-token-input").value.trim();
+          const registrationHeaders = { "content-type": "application/json" };
+          if (bootstrapToken) {
+            registrationHeaders["x-vtdd-passkey-bootstrap-token"] = bootstrapToken;
+          }
           const optionsResponse = await fetch("${apiBase}/approval/passkey/register/options", {
             method: "POST",
-            headers: { "content-type": "application/json" },
+            headers: registrationHeaders,
             body: JSON.stringify({
               operatorId: document.getElementById("operator-id").value,
               operatorLabel: document.getElementById("operator-label").value
@@ -566,7 +573,7 @@ export function renderPasskeyOperatorPage(input = {}) {
           const credential = await navigator.credentials.create({ publicKey });
           const verifyResponse = await fetch("${apiBase}/approval/passkey/register/verify", {
             method: "POST",
-            headers: { "content-type": "application/json" },
+            headers: registrationHeaders,
             body: JSON.stringify({
               sessionId: optionsBody.sessionId,
               response: encodeRegistrationCredential(credential)

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -6080,18 +6080,31 @@ async function authorizePasskeyRegistrationRequest({ request, env, apiSuffix }) 
   const provider = resolveMemoryProvider(env);
   const validation = validateMemoryProvider(provider);
   if (!validation.ok) {
-    return browserAuth;
+    return {
+      ok: false,
+      status: 503,
+      reason: "valid memory provider is required before browser passkey registration can be authorized"
+    };
   }
 
   const passkeys = await retrieveRegisteredPasskeys(provider);
-  if (passkeys.length === 0) {
+  if (passkeys.length > 0) {
+    return {
+      ok: false,
+      status: 403,
+      reason: "browser passkey registration is blocked after the first passkey is registered"
+    };
+  }
+
+  const bootstrapTokenAuth = authorizePasskeyBootstrapTokenRequest({ request, env });
+  if (bootstrapTokenAuth.ok) {
     return browserAuth;
   }
 
   return {
     ok: false,
-    status: 403,
-    reason: "browser bootstrap registration is allowed only before the first passkey is registered"
+    status: bootstrapTokenAuth.status,
+    reason: bootstrapTokenAuth.reason
   };
 }
 
@@ -6104,6 +6117,36 @@ function authorizePasskeyBrowserOrMachineRequest({ request, env, apiSuffix }) {
     return { ok: true };
   }
   return machineAuth;
+}
+
+function authorizePasskeyBootstrapTokenRequest({ request, env }) {
+  const expectedToken = normalizeText(env?.VTDD_PASSKEY_BOOTSTRAP_TOKEN);
+  if (!expectedToken) {
+    return {
+      ok: false,
+      status: 403,
+      reason: "browser passkey bootstrap token is not configured; use machine auth or configure VTDD_PASSKEY_BOOTSTRAP_TOKEN before first registration"
+    };
+  }
+
+  const providedToken =
+    normalizeText(request.headers.get("x-vtdd-passkey-bootstrap-token")) ||
+    normalizeText(request.headers.get("x-passkey-bootstrap-token"));
+  if (!providedToken) {
+    return {
+      ok: false,
+      status: 401,
+      reason: "browser passkey bootstrap token is required before first passkey registration"
+    };
+  }
+  if (providedToken !== expectedToken) {
+    return {
+      ok: false,
+      status: 403,
+      reason: "browser passkey bootstrap token is invalid"
+    };
+  }
+  return { ok: true };
 }
 
 function isSameOriginBrowserRequest(request) {

--- a/test/custom-gpt-setup-docs.test.js
+++ b/test/custom-gpt-setup-docs.test.js
@@ -152,6 +152,10 @@ test("custom gpt instructions preserve current butler and approval boundaries", 
   assert.equal(doc.includes("phase=execution"), true);
   assert.equal(doc.includes("High-risk actions require scoped passkey approval."), true);
   assert.equal(doc.includes("Merge requires explicit scoped passkey approval."), true);
+  assert.equal(doc.includes("Same-origin passkey registration is not a public first-viewer bootstrap"), true);
+  assert.equal(doc.includes("browser registration requires `VTDD_PASSKEY_BOOTSTRAP_TOKEN` or machine auth"), true);
+  assert.equal(doc.includes("Do not put the bootstrap token in a URL, PR body, Issue comment, RAG memory, chat history, or Custom GPT Instructions"), true);
+  assert.equal(doc.includes("Action Schema does not need a new operationId for this boundary"), true);
   assert.equal(doc.includes("Action Schema update required"), true);
   assert.equal(doc.includes("Instructions update required"), true);
   assert.equal(doc.includes("runtime is in sync, do not overclaim that the current Custom GPT editor is also in sync"), true);
@@ -269,6 +273,9 @@ test("short custom gpt instructions stay under editor limits while preserving cr
   assert.equal(doc.includes("bare URL"), true);
   assert.equal(doc.includes("phase=execution"), true);
   assert.equal(doc.includes("GO + real passkey"), true);
+  assert.equal(doc.includes("First passkey browser registration is not public first-viewer setup"), true);
+  assert.equal(doc.includes("requires VTDD_PASSKEY_BOOTSTRAP_TOKEN or machine auth"), true);
+  assert.equal(doc.includes("No Action Schema operationId change is needed for this boundary"), true);
   assert.equal(doc.includes("openai_api_key_not_configured"), true);
   assert.equal(doc.includes("If vtddDeployProduction fails, say the exact deploy error/reason/issues"), true);
   assert.equal(
@@ -307,6 +314,7 @@ test("short-min custom gpt instructions stay pasteable while preserving critical
     "policyInput.issueTraceability.relatedIssue",
     "continuationContext.handoff.relatedIssue",
     "GO + real passkey",
+    "first browser registration requires VTDD_PASSKEY_BOOTSTRAP_TOKEN or machine auth",
     "show exact title/body/comment/update payload",
     "no freehand `--body`",
     "scripts/prepare-pr-body-file.mjs",

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -3611,6 +3611,8 @@ test("worker serves passkey operator page", async () => {
   const html = await response.text();
   assert.equal(html.includes("VTDD Passkey Operator"), true);
   assert.equal(html.includes("/v2/approval/passkey/challenge"), true);
+  assert.equal(html.includes('id="bootstrap-token-input" type="password"'), true);
+  assert.equal(html.includes("初回登録は公開 URL の先着順にしません"), true);
   assert.equal(html.includes('id="repo-input" value="marushu/vtdd-v2-p"'), true);
   assert.equal(html.includes('id="issue-input" value="15"'), true);
   assert.equal(html.includes('id="pull-number-input" value="148"'), true);
@@ -3725,7 +3727,7 @@ test("worker serves VPS runner admin passkey operator mode", async () => {
   assert.equal(html.includes("文字列としての passkey は承認ではありません"), true);
 });
 
-test("worker allows same-origin browser bootstrap registration before first passkey exists", async () => {
+test("worker blocks same-origin browser bootstrap registration without bootstrap token", async () => {
   const provider = createInMemoryMemoryProvider();
 
   const response = await worker.fetch(
@@ -3743,6 +3745,39 @@ test("worker allows same-origin browser bootstrap registration before first pass
     }),
     {
       ...gatewayAuthEnv,
+      MEMORY_PROVIDER: provider,
+      PASSKEY_ADAPTER: passkeyAdapter
+    }
+  );
+
+  assert.equal(response.status, 403);
+  const body = await response.json();
+  assert.equal(
+    body.reason.includes("VTDD_PASSKEY_BOOTSTRAP_TOKEN before first registration"),
+    true
+  );
+});
+
+test("worker allows same-origin browser bootstrap registration before first passkey exists with bootstrap token", async () => {
+  const provider = createInMemoryMemoryProvider();
+
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/approval/passkey/register/options", {
+      method: "POST",
+      headers: {
+        origin: "https://example.com",
+        "sec-fetch-site": "same-origin",
+        "content-type": "application/json",
+        "x-vtdd-passkey-bootstrap-token": "setup-token"
+      },
+      body: JSON.stringify({
+        operatorId: "owner",
+        operatorLabel: "Owner"
+      })
+    }),
+    {
+      ...gatewayAuthEnv,
+      VTDD_PASSKEY_BOOTSTRAP_TOKEN: "setup-token",
       MEMORY_PROVIDER: provider,
       PASSKEY_ADAPTER: passkeyAdapter
     }

--- a/worker.js
+++ b/worker.js
@@ -27418,10 +27418,12 @@ function renderPasskeyOperatorPage(input = {}) {
           <input id="operator-id" value="${registrationDefaultOperatorId}" />
           <label for="operator-label">Operator Label</label>
           <input id="operator-label" value="${registrationDefaultOperatorLabel}" />
+          <label for="bootstrap-token-input">Bootstrap Token</label>
+          <input id="bootstrap-token-input" type="password" autocomplete="one-time-code" placeholder="\u521D\u56DE\u767B\u9332\u6642\u306E\u307F" />
           <div class="row">
             <button id="register-button">Register passkey</button>
           </div>
-          <p class="muted">\u767B\u9332\u306F 1 \u56DE\u3067\u5341\u5206\u3067\u3059\u3002\u8907\u6570\u30C7\u30D0\u30A4\u30B9\u3092\u4F7F\u3046\u5834\u5408\u306F\u5FC5\u8981\u306B\u5FDC\u3058\u3066\u8FFD\u52A0\u767B\u9332\u3057\u307E\u3059\u3002</p>
+          <p class="muted">\u521D\u56DE\u767B\u9332\u306F\u516C\u958B URL \u306E\u5148\u7740\u9806\u306B\u3057\u307E\u305B\u3093\u3002bootstrap token \u307E\u305F\u306F machine auth \u304C\u5FC5\u8981\u3067\u3059\u3002</p>
           <pre id="register-output"></pre>
         </section>
 
@@ -27790,9 +27792,14 @@ function renderPasskeyOperatorPage(input = {}) {
       document.getElementById("register-button").addEventListener("click", async () => {
         try {
           registerOutput.textContent = "register options request...";
+          const bootstrapToken = document.getElementById("bootstrap-token-input").value.trim();
+          const registrationHeaders = { "content-type": "application/json" };
+          if (bootstrapToken) {
+            registrationHeaders["x-vtdd-passkey-bootstrap-token"] = bootstrapToken;
+          }
           const optionsResponse = await fetch("${apiBase}/approval/passkey/register/options", {
             method: "POST",
-            headers: { "content-type": "application/json" },
+            headers: registrationHeaders,
             body: JSON.stringify({
               operatorId: document.getElementById("operator-id").value,
               operatorLabel: document.getElementById("operator-label").value
@@ -27807,7 +27814,7 @@ function renderPasskeyOperatorPage(input = {}) {
           const credential = await navigator.credentials.create({ publicKey });
           const verifyResponse = await fetch("${apiBase}/approval/passkey/register/verify", {
             method: "POST",
-            headers: { "content-type": "application/json" },
+            headers: registrationHeaders,
             body: JSON.stringify({
               sessionId: optionsBody.sessionId,
               response: encodeRegistrationCredential(credential)
@@ -60955,16 +60962,28 @@ async function authorizePasskeyRegistrationRequest({ request, env, apiSuffix }) 
   const provider = resolveMemoryProvider(env);
   const validation = validateMemoryProvider(provider);
   if (!validation.ok) {
-    return browserAuth;
+    return {
+      ok: false,
+      status: 503,
+      reason: "valid memory provider is required before browser passkey registration can be authorized"
+    };
   }
   const passkeys = await retrieveRegisteredPasskeys(provider);
-  if (passkeys.length === 0) {
+  if (passkeys.length > 0) {
+    return {
+      ok: false,
+      status: 403,
+      reason: "browser passkey registration is blocked after the first passkey is registered"
+    };
+  }
+  const bootstrapTokenAuth = authorizePasskeyBootstrapTokenRequest({ request, env });
+  if (bootstrapTokenAuth.ok) {
     return browserAuth;
   }
   return {
     ok: false,
-    status: 403,
-    reason: "browser bootstrap registration is allowed only before the first passkey is registered"
+    status: bootstrapTokenAuth.status,
+    reason: bootstrapTokenAuth.reason
   };
 }
 function authorizePasskeyBrowserOrMachineRequest({ request, env, apiSuffix }) {
@@ -60976,6 +60995,32 @@ function authorizePasskeyBrowserOrMachineRequest({ request, env, apiSuffix }) {
     return { ok: true };
   }
   return machineAuth;
+}
+function authorizePasskeyBootstrapTokenRequest({ request, env }) {
+  const expectedToken = normalizeText30(env?.VTDD_PASSKEY_BOOTSTRAP_TOKEN);
+  if (!expectedToken) {
+    return {
+      ok: false,
+      status: 403,
+      reason: "browser passkey bootstrap token is not configured; use machine auth or configure VTDD_PASSKEY_BOOTSTRAP_TOKEN before first registration"
+    };
+  }
+  const providedToken = normalizeText30(request.headers.get("x-vtdd-passkey-bootstrap-token")) || normalizeText30(request.headers.get("x-passkey-bootstrap-token"));
+  if (!providedToken) {
+    return {
+      ok: false,
+      status: 401,
+      reason: "browser passkey bootstrap token is required before first passkey registration"
+    };
+  }
+  if (providedToken !== expectedToken) {
+    return {
+      ok: false,
+      status: 403,
+      reason: "browser passkey bootstrap token is invalid"
+    };
+  }
+  return { ok: true };
 }
 function isSameOriginBrowserRequest(request) {
   const originHeader = normalizeText30(request.headers.get("origin"));


### PR DESCRIPTION
## This PR satisfies Intent

- #355 の passkey/origin authority 境界の部分進捗として、公開 URL の初回 passkey 登録を先着順にしない。
- #433 の dashboard passkey 導線で、登録前 bootstrap も owner-controlled token または machine auth の後ろに置く。
- VPS Codex CLI が本線でも Custom GPT Butler を継続利用できるよう、canonical Instructions / short / short-min に同じ passkey bootstrap 境界を反映する。

## Satisfied Success Criteria

- 未登録状態でも same-origin browser だけでは passkey 登録できず、`VTDD_PASSKEY_BOOTSTRAP_TOKEN` または machine auth が必要になった。
- Passkey operator page に初回登録用 bootstrap token 入力を追加し、登録 options/verify の両方へ header で渡す。
- 既存 passkey approval / dashboard session flow は維持した。
- Custom GPT Instructions に「初回登録は public first-viewer setup ではない」「bootstrap token を URL/chat/RAG/docs に出さない」「Action Schema operationId 変更は不要」を明記した。

## Unsatisfied Success Criteria

- #355 全体の helper secret sync E2E はこのPRでは未完了。
- #433 全体の Butler chat / VPS runner 接続はこのPRでは未完了。
- 既存 passkey の一覧・失効・追加登録UIはこのPRでは未実装。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: #355 / #433
- Implementing Success Criteria: 初回 passkey 登録を公開 URL の先着順にしない。dashboard/passkey operator の owner-facing 登録導線に bootstrap token 境界を追加し、Custom GPT Instructions にも同じ運用境界を残す。
- Explicit Non-goals: Cloudflare Access 設定変更、secret/variable mutation、既存 passkey の失効UI、Issue close、deploy、Action Schema operationId 追加。
- Expected touched files/routes/workflows: `src/worker/runtime.js`, `src/core/passkey-operator-page.js`, `test/worker.test.js`, `docs/setup/custom-gpt-instructions*.md`, `test/custom-gpt-setup-docs.test.js`, `worker.js`
- Affected Issues: #355, #433
- Affected PRs: なし
- Affected workflows: deploy workflow は未変更。PR checks のみ影響。
- Affected runtime/operator surfaces: Worker passkey registration routes, passkey operator page, Custom GPT setup Instructions, dashboard passkey sign-in の前提境界。
- What may break if we patch narrowly: registration verify 側を gate しないと options sessionId 流出時に穴が残るため、options と verify の両方を同じ registration auth に通した。Instructions を更新しないと Custom GPT Butler が古い bootstrap 説明を続ける。
- Unknowns to investigate before coding: 本番の `VTDD_PASSKEY_BOOTSTRAP_TOKEN` 設定有無は未確認。既存登録済み passkey がある本番では通常 dashboard sign-in には不要。
- Validation needed: `node --test test/worker.test.js`, `node --test test/custom-gpt-setup-docs.test.js`, `npm test`, post-deploy smoke if deployed.
- Stop condition: bootstrap token を URL query / Instructions / Issue / PR / RAG に埋め込む必要が出た場合は secret exposure risk のため停止。

## File / Line Hypotheses

- file: `src/worker/runtime.js`
  - hypothesis: `authorizePasskeyRegistrationRequest` が初回登録の公開 bootstrap 窓を作っている。
  - risk if changed narrowly: approval flow まで壊す可能性。
  - validation: worker tests で registration options/verify と approval flow を確認。
  - related Issue: #355 / #433
- file: `src/core/passkey-operator-page.js`
  - hypothesis: 登録 UI が token を送れないと owner-facing 初回登録ができない。
  - risk if changed narrowly: secret をHTMLやURLへ埋め込むリスク。
  - validation: password input と header forwarding を test で確認。
  - related Issue: #355 / #433
- file: `docs/setup/custom-gpt-instructions*.md`
  - hypothesis: Custom GPT Butler が古い境界を持つと、VPS Codex CLI 以外の運用面で誤案内する。
  - risk if changed narrowly: Action Schema 変更が不要なのに必要と誤判定する、または token を貼る案内に drift する。
  - validation: setup docs tests と short length tests を確認。
  - related Issue: #355 / #433

## Hypothesis Retrospective

- expected: same-origin browser bootstrap は token なしで拒否され、token ありだけ通る。Custom GPT Instructions は token を URL/chat/RAG/docs に出さない境界を持つ。
- actual: worker tests で token なし 403、token あり 200、既存 passkey 後 403 を確認。setup docs tests で full/short/short-min Instructions の境界を確認。
- mismatch: なし。
- lesson: production owner surface の初回登録は URL 先着順にしない。VPS runner 本線でも Custom GPT surface の Instructions は継続更新する。
- should become RAG candidate: はい。bootstrap 境界と Custom GPT 継続更新判断として候補。

## Verification Evidence

- Unit: `node --test test/worker.test.js`: 147 tests passed. `node --test test/custom-gpt-setup-docs.test.js`: 11 tests passed.
- Integration: `npm test`: 868 passed / 1 skipped; self-parity passed; generated-worker check passed.
- E2E: Live E2E は未実施。deploy 後に未登録環境で token なし登録 403、token あり登録 200、既存 dashboard session 継続を確認する。
- Manual: 本番 deploy は未実施。
- Evidence path/link: `test/worker.test.js`; `test/custom-gpt-setup-docs.test.js`; `src/worker/runtime.js`; `src/core/passkey-operator-page.js`; `docs/setup/custom-gpt-instructions.md`

## Butler Completion Contract

- Owner goal: 公開 worker URL の初回 passkey 登録を、見た人勝ちではなく owner-controlled bootstrap 境界にする。Custom GPT Butler も同じ境界を説明できるようにする。
- Butler entrypoint: Dashboard/passkey operator page。Custom GPT Instructions は更新。Action Schema は未変更。
- Action Schema exposure: route/operationId 追加なし。registration route の authority 境界と operator UI / Instructions を変更。
- Runtime path: `POST /v2/approval/passkey/register/options` と `/verify` が machine auth または `x-vtdd-passkey-bootstrap-token` を要求する。
- Runner/runtime truth: Unit/integration test で token なし拒否、token あり許可、既存 passkey 後拒否、Instructions 境界を確認。
- Authority boundary: 初回 browser registration: `VTDD_PASSKEY_BOOTSTRAP_TOKEN` または machine auth。Approval/dashboard session: 既存 passkey 境界を維持。
- E2E evidence: このPRでは未実施。deploy 後の owner browser smoke が必要。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 必要なら merge 後に別途 scoped passkey approval で実施。
- Custom GPT Action Schema update: 不要。operationId / schema shape 変更なし。
- Custom GPT Instructions update: 必要。`docs/setup/custom-gpt-instructions.md`, short, short-min を更新済み。
- iPhone Butler live E2E: 未実施。

## Related Constitution Rules

- AGENTS.md Drift Stop Protocol
- AGENTS.md Authority Boundary
- AGENTS.md Public Repo Collaboration Boundary
- AGENTS.md Butler-First Operating Principle
- AGENTS.md Evidence Discipline

## Out-of-scope but NOT implemented

- Cloudflare Access allowlist 設定
- Passkey 失効・一覧管理 UI
- VPS Codex CLI との会話接続
- Issue close
- Custom GPT Action Schema operationId 追加

## Extra changes (if any)

RAG 候補: production owner surface の初回 passkey 登録は公開 URL 先着順にせず、bootstrap token または machine auth の後ろに置く。VPS Codex CLI が本線でも Custom GPT Butler の Instructions / Action Schema parity は継続管理する。今回 Action Schema 変更は不要だが Instructions は更新対象。

<!-- VTDD metadata -->
- Issue: Issue #355
- Execution ID: mac-codex-passkey-bootstrap-token-2026-05-20
- Goal: secure_passkey_bootstrap
