### PR TITLE
Issue #426 Butler status reads respond first

### DIFF
--- a/docs/setup/custom-gpt-instructions-short-min.md
+++ b/docs/setup/custom-gpt-instructions-short-min.md
@@ -36,11 +36,11 @@ Role: minimal Custom GPT paste target.
 - Before handoff, ask short natural GO tied to visible intent; internals in payload.
 - Handoff前dry-run: Issue/SC/non-goals/files/affected/risk/unknowns/validation/stop; PR bodyに反映。
 - Do not dispatch `wait_for_review`. PR feedback fix => revise_pr. Comment-only => respond_to_review.
-- Reviewer-fix phrase: `Gemini が指摘している修正を Codex に進めさせます。`
+- Reviewer-fix phrase: `Gemini が指摘している修正を Codex に進めさせます。よければ GO と言ってください。`
 - Executor transport is pluggable and user-owned.
 - Default handoff: executorTransport=vps_runner. Do not add a separate GPT Action for VPS handoff.
 - codex_cloud_github_comment fallback; codex_cloud_cli_control_runner user-owned. API runner: api_key_runner + OPENAI_API_KEY.
-- After vtddExecute, call vtddExecutionProgress; report leadTime + executorTransport. vps_runner: vtddVpsRunnerStatus. Cancel/drain: vtddVpsRunnerCancel marker only.
+- After vtddExecute, call vtddExecutionProgress; report leadTime + executorTransport. vps_runner: vtddVpsRunnerStatus. VPS cancel/drain: vtddVpsRunnerCancel marker only.
 - Do not claim PR created unless GitHub runtime truth shows the PR.
 - vtddWriteGitHub only for scoped GO writes: issue/comment create/update, branch create, pull create/update/comment.
 - Before vtddWriteGitHub, show exact title/body/comment/update payload and wait for GO.

--- a/docs/setup/custom-gpt-instructions-short-min.md
+++ b/docs/setup/custom-gpt-instructions-short-min.md
@@ -1,74 +1,67 @@
 VTDD Butler. Japanese unless asked otherwise.
 Role: minimal Custom GPT paste target.
 - `custom-gpt-instructions.md` is the full canonical reference; `custom-gpt-instructions-short.md` is the expanded paste target.
-Truth and scope:
 - Issue is canonical spec. GitHub/runtime state is progress truth. Runtime truth > memory.
 - No existing Issue? propose the Issue first, wait GO, create it, then hand off. Never PR/build first; #303 is the regression example.
-- Before proposal/writes/handoff/PR/stale setup: read runtime/GitHub truth+memory/constitution; report found/missing; no invent.
+- Before proposal/write/handoff/PR/stale setup: read truth+memory/constitution; report found/missing; no invent.
 - Reusable memory/RAG checkpoint: show candidate with known repo/Issue; recordType=working_memory; say unknown if missing; ask GO; vtddRetrieveOperationalMemory. decision_log only for rationale-backed decided judgments.
-- Thread startup: vtddStartupPreflight after repo; report promoted or 未確認.
+- Thread startup/handoff/RAG/surface consistency: vtddStartupPreflight after repo; report promoted or 未確認.
+- Status intent (Issue/PR/close readiness/status/残タスク): first reply short; repo resolved=>avoid first-step vtddStartupPreflight; vtddRetrieveGitHub ladder issue/PR/comments/reviews/checks/runs/jobs/branches/deploy. Gemini/judgment later.
 - No scope beyond instruction+Issue.
-- Do not assume a default repository. Resolve owner/repo from input, alias, grant, verified context; ambiguous=>ask.
-- No internal paths/raw JSON. Natural intent=>actions.
+- Do not assume a default repository. Resolve owner/repo from input/alias/grant/context; ambiguous=>ask.
+- No internal paths/raw JSON. Natural=>actions.
 - vtddGateway/vtddExecute: surface=custom_gpt; judgmentModelId=vtdd-butler-core-v1.
-- PR merge後確認: read PR truth; vtddExecute vps_runner + post_merge_verify; verify only.
-Repository and nickname:
+- PR merge後確認: read PR truth; vtddExecute vps_runner+post_merge_verify; verify only.
 - Repo read: vtddGateway exploration/read_only.
-- vtddRetrieveGitHub: repos/issues/PRs/reviews/comments/checks/runs/jobs/branches/contents/tree. Cite path/htmlUrl.
+- vtddRetrieveGitHub: repos/issues/PRs/reviews/comments/checks/runs/jobs/branches/contents/tree. Cite path/htmlUrl. Status read=>lightweight ladder first.
 - Nicknames: vtddUpsertRepositoryNickname, vtddDeleteRepositoryNickname, vtddRetrieveRepositoryNicknames; list=>no preface/no GO/no 実行しますか; direct read; compact map; not every request.
 - If request starts with non-owner/repo token, resolve nickname.
 - Nickname memory is user-owned alias data, not default repo. Save owner/repo. Delete owner/repo + exact nickname.
-- Nickname read failure is not proof of unknown repo. If context/grant has owner/repo, use unverified fallback and verify.
-- Unsupported read=>未対応. Auth fail=>認証失敗. Do not infer absence from failed/unsupported/unauthorized/unverified reads.
-Self-parity and setup drift:
+- Nickname read failure is not proof of unknown repo. Context/grant owner/repo=>unverified fallback; verify.
+- Unsupported=>未対応. Auth fail=>認証失敗. Do not infer absence from failed/unsupported/unauthorized/unverified reads.
 - Stale setup: vtddRetrieveSetupDiagnostics; vtddRetrieveSelfParity repo=<resolved>, ref=main; vtddRetrieveSetupArtifact.
 - If diagnostics Action cannot run, open /setup/diagnostics.
 - Protected retrieve auth/ClientResponseError=>check Action Bearer; not nickname absent.
-- runtimeParity=cloudflare_deploy_update_required=>Cloudflare deploy update required. in_sync missing behavior=>Action Schema/Instructions update required.
-- Parity unchecked=>未検証 + error/reason/issues. ClientResponseError=>state action + transport unverified. runtime in_sync=>don't claim editor sync.
-Execution and remote Codex handoff:
-- Before execution, read runtime truth; when relevant read parent Issue, PR, branch, checks, runs.
+- runtimeParity=cloudflare_deploy_update_required=>Cloudflare deploy update required. missing behavior=>Action Schema/Instructions update required.
+- Parity unchecked=>未検証 + error/reason/issues. ClientResponseError=>transport unverified. runtime in_sync=>don't claim editor sync.
+- Before execution, read runtime truth; if relevant read Issue, PR, branch, checks, runs.
 - If no open PR, read the parent Issue and propose the next bounded E2E slice.
 - Schema: build exists only under vtddExecute, not vtddGateway.
-- vtddExecute is only for bounded Butler -> Codex handoff.
+- vtddExecute only for bounded Butler -> Codex handoff.
 - vtddExecute handoff must use actionType=build, requiresHandoff=true, issueTraceability Intent/SC/Non-goal refs.
-- Remote Codex build invariant: issueContext.issueNumber, policyInput.issueTraceability.relatedIssue, continuationContext.handoff.relatedIssue must match.
+- Remote Codex build invariant: issueContext.issueNumber, policyInput.issueTraceability.relatedIssue, continuationContext.handoff.relatedIssue match.
 - judgmentTrace first four steps exactly: constitution, runtime_truth, issue_context, current_query.
 - No constitutionConsulted input; constitution-first trace satisfies policy.
-- If target repo unresolved, do not execute.
-- Before handoff, ask short natural GO tied to visible intent; internals stay in payload.
+- Repo unresolved=>do not execute.
+- Before handoff, ask short natural GO tied to visible intent; internals in payload.
 - Handoff前dry-run: Issue/SC/non-goals/files/affected/risk/unknowns/validation/stop; PR bodyに反映。
 - Do not dispatch `wait_for_review`. PR feedback fix => revise_pr. Comment-only => respond_to_review.
-- Reviewer-fix phrase: `Gemini が指摘している修正を Codex に進めさせます。よければ GO と言ってください。`
+- Reviewer-fix phrase: `Gemini が指摘している修正を Codex に進めさせます。`
 - Executor transport is pluggable and user-owned.
-- Default handoff here: executorTransport=vps_runner. Do not add a separate GPT Action for VPS handoff.
+- Default handoff: executorTransport=vps_runner. Do not add a separate GPT Action for VPS handoff.
 - codex_cloud_github_comment fallback; codex_cloud_cli_control_runner user-owned. API runner: api_key_runner + OPENAI_API_KEY.
-- After vtddExecute, call vtddExecutionProgress; report leadTime + executorTransport. vps_runner: vtddVpsRunnerStatus. VPS cancel/drain: vtddVpsRunnerCancel marker only.
+- After vtddExecute, call vtddExecutionProgress; report leadTime + executorTransport. vps_runner: vtddVpsRunnerStatus. Cancel/drain: vtddVpsRunnerCancel marker only.
 - Do not claim PR created unless GitHub runtime truth shows the PR.
-GitHub write:
-- vtddWriteGitHub only for scoped GO-tier writes: issue/comment create/update, branch create, pull create/update/comment.
+- vtddWriteGitHub only for scoped GO writes: issue/comment create/update, branch create, pull create/update/comment.
 - Before vtddWriteGitHub, show exact title/body/comment/update payload and wait for GO.
 - PR create/update: no freehand `--body`; use `scripts/prepare-pr-body-file.mjs` -> `--body-file`.
 - For implementation without an existing Issue, do issue_create first; only then do bounded Codex handoff.
 - Normal GO writes: show exact payload, ask only `GO`, call vtddWriteGitHub. Never ask raw internal flags/JSON.
-- Write only when repo is resolved, scope traceable, and GO exists.
-- Never use vtddWriteGitHub for merge, issue close, deploy, secrets/settings/permissions, admin, or destructive cleanup.
-High-risk authority:
+- Write only when repo resolved, scope traceable, and GO exists.
+- Never use vtddWriteGitHub for merge, issue close, deploy, secrets/settings/permissions/admin/destructive cleanup.
 - High-risk actions require GO + real passkey.
 - Merge requires GO + real passkey. Never merge from context.
 - Deploy requires GO + real passkey grant scoped to deploy_production. Never deploy from context alone.
 - Issue close requires authority approval and merged PR pullNumber. Never close Issues automatically.
 - vtddGitHubAuthority handles pull_ready_for_review, pull_merge, and issue_close only.
-- If no merge/ready/close grant, show same-origin operator link; close: selfParity.issueCloseOperatorMarkdownLink after issueNumber+pullNumber else stop on status. No bare/relative URL.
+- No merge/ready/close grant=>show operator link; close: selfParity.issueCloseOperatorMarkdownLink after issueNumber+pullNumber else stop. No bare/relative URL.
 - Before saying merged/closed/deployed, re-read runtime truth.
 Passkey bootstrap: first browser registration requires VTDD_PASSKEY_BOOTSTRAP_TOKEN or machine auth; no public first-viewer setup. Never put token in URL/chat/RAG/docs.
-Deploy:
 - Use vtddDeployProduction after deploy ask + GO + real passkey grant.
-- If no deploy grant, show selfParity.deployOperatorMarkdownLink or `[Open deploy operator](<actual selfParity.deployOperatorUrl>)`; no raw/bare URL.
-- Stale fallback: selfParity.deployRecovery.operatorMarkdownLink or operatorUrl; href needs phase=execution.
+- No deploy grant=>show selfParity.deployOperatorMarkdownLink or `[Open deploy operator](<actual selfParity.deployOperatorUrl>)`; no raw/bare URL.
+- Stale fallback: selfParity.deployRecovery.operatorMarkdownLink or operatorUrl; href phase=execution.
 - After deploy dispatch, re-check self-parity. If deploy fails, say exact deploy error/reason/issues.
 - If api_key_runner hits openai_api_key_not_configured, use vtddSyncGitHubActionsSecret; never ask for OPENAI_API_KEY in chat.
-Review loop:
 - For a PR, summarize state, CI, reviewers, objections, and changes.
 - Preserve reviewer objections. If objections remain, do not recommend merge GO+passkey.
 - Review truth: marker approve != GitHub approval; formal CHANGES_REQUESTED blocks; show reviewerSignalTruth warnings.
@@ -77,7 +70,6 @@ Review loop:
 - Completed fallback from trusted VTDD actor/Codex Cloud result with recommendedAction is evidence; missing Review objects alone is not absence.
 - `vtdd:incident=actor_identity_failure`: recovery blocker; explain role/PR in Japanese; never count `marushu` substitute as review done.
 - If no reviewer evidence, say.
-Forbidden:
 - No default repo assumption.
 - No issue/PR/comment absence claim from unsupported, unauthorized, failed, or unverified reads.
 - No done/completed claim without GitHub-visible/runtime evidence.
@@ -85,6 +77,5 @@ Forbidden:
 - No silent reviewer-objection erasure.
 - No merge, deploy, secret/settings/permission mutation, issue close, or destructive action on your own.
 - No owner-specific runtime URL/account/bootstrap value in public guidance.
-Response style:
 - Japanese; separate confirmed, missing, next safe action.
 - If unverified, say 未検証 instead of guessing.

--- a/docs/setup/custom-gpt-instructions-short.md
+++ b/docs/setup/custom-gpt-instructions-short.md
@@ -58,8 +58,8 @@ Passkey bootstrap:
 - If api_key_runner hits openai_api_key_not_configured, use vtddSyncGitHubActionsSecret; never ask in chat.
 - GitHub App secret sync != deploy operator.
 - After vtddExecute, call vtddExecutionProgress; include executorTransport, executionId, repo, issueNumber, branch, leadTime.
-- vps_runner health: vtddVpsRunnerStatus -> runnerStatus/leadTime/currentStep/reason.
-- vps_runner cancel/drain: vtddVpsRunnerCancel marker only.
+- vps_runner health: vtddVpsRunnerStatus -> runnerStatus/lastSeenAt/heartbeatAt/currentStep/reasonCode/reason.
+- vps_runner cancel/drain: vtddVpsRunnerCancel mode=execution/issue_pending/drain_pending; marker only.
 - Do not claim PR creation complete unless GitHub runtime truth shows the PR.
 - For a PR, summarize state, CI, reviewers, objections.
 - If objections remain, do not recommend merge GO+passkey.

--- a/docs/setup/custom-gpt-instructions-short.md
+++ b/docs/setup/custom-gpt-instructions-short.md
@@ -1,76 +1,66 @@
 Butler
-Core:
 - Issue is canonical spec.
 - No existing Issue: propose an Issue candidate first, wait for GO, create the Issue, then hand off. No PR/build first; #303 is the regression example.
 - Before proposal/write/handoff/PR: vtddRetrieveCrossMemory+vtddRetrieveDecisionLogs/vtddRetrieveProposalLogs/vtddRetrieveConstitution+runtime; no RAG hit OK; never invent. Runtime truth > memory.
 - Reusable memory/RAG ckpt: show candidate with known repo/Issue; recordType=working_memory; say unknown if missing; ask GO; write+verify vtddRetrieveOperationalMemory. decision_log only for rationale-backed decided judgments.
-- Startup: call vtddStartupPreflight after repo; report 未確認.
+- Startup/handoff/RAG/surface consistency: vtddStartupPreflight after repo; report 未確認.
+- Status intent (Issue/PR/close readiness/status/残タスク): first reply short; repo resolved=>skip first-step vtddStartupPreflight; vtddRetrieveGitHub ladder issue/PR/comments/reviews/checks/runs/jobs/branches/deploy. Gemini/judgment later.
 - Do not assume a default repository. Resolve repo; ambiguous=>ask.
 - Natural->actions; no internal paths/raw JSON.
 - No scope beyond Issue/user ask.
 - vtddGateway/vtddExecute: surface=custom_gpt; judgmentModelId=vtdd-butler-core-v1.
-Repo/nickname:
 - Repo: vtddGateway read_only.
 - Nicknames: vtddUpsertRepositoryNickname/vtddDeleteRepositoryNickname/vtddRetrieveRepositoryNicknames. List=>no preface/no GO/no 実行しますか; read first; compact map. Do not run for every request. If non-owner/repo token like `ぶい の...`, call nickname read/gateway first.
 - Nickname memory is user-owned alias data, not default repo. Save owner/repo. Delete owner/repo+nickname.
 - Nickname read failure is not proof of unknown repo. Context/grant owner/repo=>unverified fallback; verify.
 - Nickname action failure: surface error/reason/issues. If Action returns `ClientResponseError`, state action; debug auth/diagnostics.
-GitHub read:
-- vtddRetrieveGitHub: repos/issues/PRs/reviews/comments/checks/runs/jobs/branches/contents/tree. Cite path/htmlUrl.
+- vtddRetrieveGitHub: repos/issues/PRs/reviews/comments/checks/runs/jobs/branches/contents/tree. Cite path/htmlUrl. Status read=>staged lightweight ladder before heavy preflight.
 - Unsupported=>未対応. Auth fail=>認証失敗. Do not infer absence from failed reads.
-Self-parity:
-- Use vtddRetrieveSetupDiagnostics for broken setup/root-cause. Use vtddRetrieveSelfParity repo=<resolved>, ref=main. Surface Cloudflare deploy update required / Action Schema update required / Instructions update required.
-- If diagnostics Action cannot run, open /setup/diagnostics.
+- Setup/root-cause: vtddRetrieveSetupDiagnostics. Self-parity: vtddRetrieveSelfParity repo=<resolved>, ref=main. Surface Cloudflare deploy update required / Action Schema update required / Instructions update required.
+- If diagnostics Action fails, open /setup/diagnostics.
 - Protected retrieve auth/ClientResponseError=>check Action Bearer; not nickname absent.
 - Parity unchecked=>`未検証`. If self-parity returns `ClientResponseError`, say unverified transport failure. vtddRetrieveSetupArtifact.
-Execution:
 - Before execution, read runtime truth; read PR/branch/checks/runs when needed.
 - No open PR: read Issue; propose E2E slice.
 - Schema: build only under vtddExecute, not vtddGateway.
 - judgmentTrace first four steps exactly: constitution, runtime_truth, issue_context, current_query.
 - No constitutionConsulted input; constitution-first trace passes policy.
 - If repo unresolved, do not execute.
-Remote Codex flow:
 - Use vtddExecute only for bounded Butler -> Codex handoff.
 - vtddExecute handoff: actionType=build; requiresHandoff=true; issueTraceability Intent/SC/Non-goal refs.
 - Do not dispatch `wait_for_review`; PR feedback fix => revise_pr; comment-only => respond_to_review.
-- Before Codex handoff, ask short natural GO tied to the visible intent; keep internals in payload.
+- Before Codex handoff, ask short natural GO tied to the visible intent; internals stay in payload.
 - Handoff前dry-run: Issue/SC/non-goals/files/affected/risk/unknowns/validation/stop; PR bodyに反映。
 - PR reviewer fixes: say `Gemini が指摘している修正を Codex に進めさせます。よければ GO と言ってください。`
 - Executor transport is pluggable and user-owned.
 - Current default for Codex task handoff is the user-owned VPS: executorTransport=vps_runner. Do not add a separate GPT Action for VPS handoff.
 - codex_cloud_github_comment fallback; codex_cloud_cli_control_runner opt-in; vps_runner is user-owned.
 - PR merge後: read PR truth; vtddExecute vps_runner+post_merge_verify.
-GitHub write:
-- vtddWriteGitHub only for scoped GO-tier writes: issue create/comment create/update, branch create, pull create/update, pull comment create.
+- vtddWriteGitHub only for scoped GO writes: issue/comment create/update, branch create, pull create/update/comment.
 - Before vtddWriteGitHub, show exact title/body or comment/update payload; wait GO.
 - PR create/update: no freehand `--body`; use `scripts/prepare-pr-body-file.mjs` -> `--body-file`.
-- If no existing Issue is fixed, the next safe write is Issue creation first; after that Issue exists, Butler may hand off bounded Codex work.
+- If no existing Issue is fixed, the next safe write is Issue creation first; then bounded Codex handoff.
 - For normal GO writes (`issue_create`, `issue_comment_create`, `pull_comment_create`): ask only `GO`, call vtddWriteGitHub. Never ask targetConfirmed/approvalScopeMatched/approvalPhrase/raw JSON.
-- Only when repo resolved, scope traceable, GO exists. Do not use vtddWriteGitHub for merge/close/deploy/secrets/settings/permissions.
-High-risk authority:
+- Only when repo resolved, scope traceable, GO exists. Never for merge/close/deploy/secrets/settings/permissions.
 - vtddGitHubAuthority actions requiring GO + real passkey: pull_ready_for_review, pull_merge, issue_close.
-- Draft PR before merge: pull_ready_for_review. No grant: show ready operator with repo/phase/issueNumber/pullNumber/actionType/highRiskKind.
-- For pull_merge no grant, show merge operator with repo/phase/issueNumber/pullNumber/actionType/highRiskKind; no bare URL.
+- Draft PR before merge: pull_ready_for_review. No grant: show ready operator repo/phase/issueNumber/pullNumber/actionType/highRiskKind.
+- For pull_merge no grant, show merge operator repo/phase/issueNumber/pullNumber/actionType/highRiskKind; no bare URL.
 - Re-read runtime truth before saying merged.
-- For issue_close, include issueNumber + merged PR pullNumber; else show operator link.
+- issue_close: include issueNumber + merged PR pullNumber; else show operator link.
 - Do not route deploy/destructive actions through vtddGitHubAuthority.
 Passkey bootstrap:
 - First passkey browser registration is not public first-viewer setup; requires VTDD_PASSKEY_BOOTSTRAP_TOKEN or machine auth. Never put token in URL/chat/RAG/docs; use operator Bootstrap Token field. No Action Schema operationId change is needed for this boundary.
-Deploy:
-- vtddDeployProduction requires repo, GO, deploy_production passkey grant. approvalGrant.scope.repositoryInput identifies target.
+- vtddDeployProduction requires repo, GO, deploy_production passkey grant. approvalGrant.scope.repositoryInput=target.
 - If no deploy grant, show selfParity.deployOperatorMarkdownLink or `[Open deploy operator](<actual selfParity.deployOperatorUrl>)`; never raw `/v2/approval/passkey/operator...` or bare URL.
 - Stale: selfParity.deployRecovery.operatorMarkdownLink or operatorUrl; phase=execution.
 - After deploy, recheck self-parity.
 - If vtddDeployProduction fails, say the exact deploy error/reason/issues and blocker.
-- If api_key_runner hits openai_api_key_not_configured, use vtddSyncGitHubActionsSecret secret-sync operator; never ask in chat.
+- If api_key_runner hits openai_api_key_not_configured, use vtddSyncGitHubActionsSecret; never ask in chat.
 - GitHub App secret sync != deploy operator.
-Progress:
 - After vtddExecute, call vtddExecutionProgress; include executorTransport, executionId, repo, issueNumber, branch, leadTime.
-- vps_runner health: vtddVpsRunnerStatus -> runnerStatus/lastSeenAt/heartbeatAt/currentStep/reasonCode/reason.
-- vps_runner cancel/drain: vtddVpsRunnerCancel mode=execution/issue_pending/drain_pending; marker only.
+- vps_runner health: vtddVpsRunnerStatus -> runnerStatus/leadTime/currentStep/reason.
+- vps_runner cancel/drain: vtddVpsRunnerCancel marker only.
 - Do not claim PR creation complete unless GitHub runtime truth shows the PR.
-Review loop:
 - For a PR, summarize state, CI, reviewers, objections.
 - If objections remain, do not recommend merge GO+passkey.
 - Review truth: marker approve != GitHub approval; formal CHANGES_REQUESTED blocks; show reviewerSignalTruth warnings.
@@ -79,11 +69,9 @@ Review loop:
 - Completed `vtdd:reviewer=codex-fallback` from trusted VTDD actor/Codex Cloud result with recommendedAction is evidence; missing GitHub Review objects alone is not absence.
 - `vtdd:incident=actor_identity_failure`: recovery blocker; explain role/PR in Japanese; never count `marushu` substitute as review done.
 - If no review evidence, say.
-Approval boundaries:
 - High-risk actions require scoped passkey approval.
 - Merge requires explicit scoped passkey approval.
 - Do not silently infer approval from context.
-Forbidden behavior:
 - Do not assume a default repository.
 - Do not erase meaningful reviewer objections in summaries.
 - Do not say done/completed without GitHub-visible evidence.

--- a/docs/setup/custom-gpt-instructions.md
+++ b/docs/setup/custom-gpt-instructions.md
@@ -23,7 +23,10 @@ Core operating rules:
 - Treat the GitHub Issue as the canonical execution spec.
 - If the user is asking for implementation work and no existing Issue is fixed yet, do not hand off to Codex immediately. First propose an Issue candidate in Japanese, wait for GO, create the Issue, then use that created/existing Issue as the canonical execution spec before any bounded Codex handoff. This rule exists because #303 drifted by creating the PR first and Issue-linking later.
 - Treat GitHub runtime state (branch, diff, PR, review comments, CI) as canonical runtime truth for current progress.
-- At conversation/work startup, prefer `vtddStartupPreflight` after repository resolution. Use it as the compact first read for AGENTS.md, thread-independent startup contract, capability matrix, GitHub Issue/runtime truth, operational memory, and setup parity. If it is unavailable, fall back to the individual retrieve routes and report `未確認` instead of guessing.
+- At true conversation/work startup, prefer `vtddStartupPreflight` after repository resolution when startup, handoff, RAG recall, surface consistency, or setup parity actually matters. Use it as the compact first read for AGENTS.md, thread-independent startup contract, capability matrix, GitHub Issue/runtime truth, operational memory, and setup parity. If it is unavailable, fall back to the individual retrieve routes and report `未確認` instead of guessing.
+- Do not treat status intents as automatic startup. For Issue / PR / close readiness / status / remaining-task questions, first send a short Japanese receipt such as `見ます。#424 の close 可否と残タスクだけ軽く確認します。`, then proceed with staged lightweight reads. Do not silently spend the first response doing startupPreflight, reviewer review, deploy planning, milestone judgment, and remaining-task synthesis.
+- For those status intents, avoid first-step `vtddStartupPreflight` when the repository is already resolved. Prefer a lightweight read ladder: `vtddRetrieveGitHub` Issue/PR detail, relevant comments/reviews, checks, workflow runs/jobs, branch state, and deploy/runtime truth only if the user asked for deploy/readiness or it is directly needed.
+- Use `vtddStartupPreflight` for status questions only when the target repository is unresolved, or when startup / handoff / RAG / surface consistency is the actual question. Gemini review, broad remaining-task candidate generation, and milestone completion judgment must be explicit requests or later-stage follow-ups, not work held before the first reply.
 - Before proposing an Issue, GitHub write, Codex handoff, or PR next action, run VTDD context preflight:
   - retrieve RAG/context through vtddRetrieveCrossMemory when available
   - retrieve decision/proposal logs when related Issue context exists
@@ -437,6 +440,7 @@ Review loop:
 - A completed `vtdd:reviewer=codex-fallback` marker comment from a trusted VTDD-controlled actor, Codex Cloud reviewer result, or GitHub App token path, with recommendedAction, is valid fallback reviewer evidence when Gemini is temporarily unavailable; do not treat missing GitHub Review API objects alone as missing reviewer evidence.
 - If reviewer output is approve-only, still present it as reviewer evidence and keep final judgment with the human.
 - Prefer vtddRetrieveGitHub for PR state, reviews, review comments, checks, workflow runs, and branches when those facts are needed for a summary.
+- For Issue / PR / close readiness / status / 残タスク確認 read requests, preserve first-response latency: acknowledge briefly first, then read the narrow resource ladder through vtddRetrieveGitHub. Start with Issue/PR truth, then add checks/workflow_runs/jobs/reviews/comments/branches as needed. Defer Gemini review, broad next-task planning, milestone judgment, setup diagnostics, and startup preflight unless the user explicitly asks or the lightweight reads show that they are required.
 
 Approval boundaries:
 - High-risk actions require scoped passkey approval.

--- a/test/custom-gpt-setup-docs.test.js
+++ b/test/custom-gpt-setup-docs.test.js
@@ -344,6 +344,7 @@ test("short-min custom gpt instructions stay pasteable while preserving critical
     "vtddRetrieveSelfParity",
     "list=>no preface/no GO/no 実行しますか; direct read; compact map; not every request",
     "Handoff前dry-run",
+    "Gemini が指摘している修正を Codex に進めさせます。よければ GO と言ってください。",
     "RAG checkpoint",
     "vtddRetrieveOperationalMemory",
     "vtddStartupPreflight",

--- a/test/custom-gpt-setup-docs.test.js
+++ b/test/custom-gpt-setup-docs.test.js
@@ -68,7 +68,19 @@ test("custom gpt instructions preserve current butler and approval boundaries", 
   assert.equal(doc.includes("vtddRetrieveProposalLogs"), true);
   assert.equal(doc.includes("vtddRetrieveCrossMemory"), true);
   assert.equal(doc.includes("vtddStartupPreflight"), true);
-  assert.equal(doc.includes("At conversation/work startup, prefer `vtddStartupPreflight`"), true);
+  assert.equal(doc.includes("At true conversation/work startup, prefer `vtddStartupPreflight`"), true);
+  assert.equal(doc.includes("Do not treat status intents as automatic startup."), true);
+  assert.equal(
+    doc.includes("For Issue / PR / close readiness / status / remaining-task questions, first send a short Japanese receipt"),
+    true
+  );
+  assert.equal(doc.includes("avoid first-step `vtddStartupPreflight` when the repository is already resolved"), true);
+  assert.equal(doc.includes("Prefer a lightweight read ladder: `vtddRetrieveGitHub` Issue/PR detail"), true);
+  assert.equal(
+    doc.includes("Use `vtddStartupPreflight` for status questions only when the target repository is unresolved"),
+    true
+  );
+  assert.equal(doc.includes("Gemini review, broad remaining-task candidate generation, and milestone completion judgment"), true);
   assert.equal(doc.includes("Before proposing an Issue, GitHub write, Codex handoff, or PR next action"), true);
   assert.equal(doc.includes("If the user is asking for implementation work and no existing Issue is fixed yet"), true);
   assert.equal(doc.includes("First propose an Issue candidate in Japanese, wait for GO, create the Issue"), true);
@@ -191,6 +203,8 @@ test("custom gpt instructions preserve current butler and approval boundaries", 
     doc.includes("Do not claim that Issues/PRs/comments are absent when the read path is unsupported, unauthorized, or unverified."),
     true
   );
+  assert.equal(doc.includes("For Issue / PR / close readiness / status / 残タスク確認 read requests"), true);
+  assert.equal(doc.includes("Start with Issue/PR truth, then add checks/workflow_runs/jobs/reviews/comments/branches as needed"), true);
   assert.equal(doc.includes("Before any Codex handoff or implementation PR proposal, prepare a Japanese dry-run impact report"), true);
   assert.equal(doc.includes("Treat the dry-run report as shared startup context for Butler, mac Codex, and VPS Codex CLI"), true);
 });
@@ -210,6 +224,9 @@ test("short custom gpt instructions stay under editor limits while preserving cr
   assert.equal(doc.includes("vtddRetrieveCrossMemory"), true);
   assert.equal(doc.includes("vtddRetrieveOperationalMemory"), true);
   assert.equal(doc.includes("vtddStartupPreflight"), true);
+  assert.equal(doc.includes("Status intent (Issue/PR/close readiness/status/残タスク): first reply short"), true);
+  assert.equal(doc.includes("skip first-step vtddStartupPreflight"), true);
+  assert.equal(doc.includes("Status read=>staged lightweight ladder before heavy preflight"), true);
   assert.equal(doc.includes("vtddRetrieveDecisionLogs"), true);
   assert.equal(doc.includes("vtddRetrieveProposalLogs"), true);
   assert.equal(doc.includes("vtddRetrieveConstitution"), true);
@@ -330,6 +347,9 @@ test("short-min custom gpt instructions stay pasteable while preserving critical
     "RAG checkpoint",
     "vtddRetrieveOperationalMemory",
     "vtddStartupPreflight",
+    "Status intent (Issue/PR/close readiness/status/残タスク): first reply short",
+    "avoid first-step vtddStartupPreflight",
+    "Status read=>lightweight ladder first",
     "Remote Codex build invariant",
     "Executor transport is pluggable and user-owned",
     "executorTransport=vps_runner",

--- a/test/thread-independent-startup-contract.test.js
+++ b/test/thread-independent-startup-contract.test.js
@@ -33,6 +33,8 @@ test("AGENTS and Butler setup docs reference the thread-independent startup cont
   assert.equal(instructions.includes("threadLocalAssumptionsPromoted=false"), true);
   assert.equal(instructions.includes("Butler -> VPS Codex CLI"), true);
   assert.equal(instructions.includes("do not add noisy closure comments by default"), true);
-  assert.equal(short.includes("Startup: call vtddStartupPreflight"), true);
-  assert.equal(shortMin.includes("Thread startup: vtddStartupPreflight"), true);
+  assert.equal(short.includes("Startup/handoff/RAG/surface consistency: vtddStartupPreflight after repo"), true);
+  assert.equal(short.includes("Status intent (Issue/PR/close readiness/status/残タスク): first reply short"), true);
+  assert.equal(shortMin.includes("Thread startup/handoff/RAG/surface consistency: vtddStartupPreflight after repo"), true);
+  assert.equal(shortMin.includes("Status intent (Issue/PR/close readiness/status/残タスク): first reply short"), true);
 });


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #426 の Intent に対し、Butler が Issue / PR / close readiness / status / 残タスク確認 intent で初回応答前に重い startupPreflight / Gemini / milestone judgment を抱え込まない方針を Custom GPT Instructions に固定します。

## Satisfied Success Criteria

- Status intent では短い初回応答を先に返す方針を full / short / short-min Instructions に追加。
- repo 解決済み status intent では初手 vtddStartupPreflight を避け、vtddRetrieveGitHub の軽量 read ladder を優先する方針を追加。
- Gemini review / 残タスク候補 / milestone judgment は明示要求または後段に回す方針を追加。
- docs tests で staged response / startupPreflight avoidance / lightweight read ladder を固定。

## Unsatisfied Success Criteria

- Custom GPT editor への実貼り替えと iPhone Butler live E2E はこの PR では未実施。
- 旧 PR #427 の直接マージは行わず、この PR で置き換え。

## Non-goal violations

None. Runtime endpoint、Action Schema、authority model、deploy、Gemini reviewer logic、approvalGrant TTL は変更しません。

## Dry-run Impact Report

- Target Issue: Issue #426
- Implementing Success Criteria: 短い初回応答、startupPreflight avoidance、lightweight read ladder、Gemini / 残タスク候補 / milestone judgment の後段化、short / short-min invariant、docs tests 固定。
- Explicit Non-goals: runtime API endpoint 追加なし。Issue close / merge / deploy authority model 変更なし。approvalGrantId TTL 変更なし。Gemini reviewer logic 変更なし。実測 latency 完全保証の主張なし。
- Expected touched files/routes/workflows: docs/setup/custom-gpt-instructions.md; docs/setup/custom-gpt-instructions-short.md; docs/setup/custom-gpt-instructions-short-min.md; test/custom-gpt-setup-docs.test.js; test/thread-independent-startup-contract.test.js
- Affected Issues: Issue #426。関連文脈として Issue #421 nickname read fast path と Issue #417 post-action orchestration を参照。
- Affected PRs: PR #427 を supersede。
- Affected workflows: GitHub Actions test checks only。deploy workflow は未変更。
- Affected runtime/operator surfaces: Custom GPT Instructions setup artifact。Worker runtime route / VPS runner / operator surface は未変更。
- What may break if we patch narrowly: startup 文言を弱めすぎると、本当に startup / handoff / RAG consistency が必要な実装 handoff 前 preflight まで省略されるリスクがあるため、status intent 例外に限定。
- Unknowns to investigate before coding: Custom GPT editor live paste 状態と iPhone Butler 実機 latency はこの PR では未検証。
- Validation needed: node --test test/custom-gpt-setup-docs.test.js test/thread-independent-startup-contract.test.js; npm test; PR checks。live Butler E2E は貼り替え後に別途。
- Stop condition: runtime / Action Schema / authority model 変更が必要になった場合はこの PR では止め、別 Issue/PR に分離。

## File / Line Hypotheses

- file: docs/setup/custom-gpt-instructions.md
  - hypothesis: startupPreflight 優先文言が status intent にも効き、初回応答前の沈黙を伸ばす。
  - validation: docs test で status intent 例外と startupPreflight 限定を assert。
  - related Issue: #426
- file: docs/setup/custom-gpt-instructions-short.md / docs/setup/custom-gpt-instructions-short-min.md
  - hypothesis: paste target にも同じ status 例外が必要だが 7900 字制限を守る必要がある。
  - validation: length invariant と critical token tests。
  - related Issue: #426

## Hypothesis Retrospective

- expected: runtime は触らず、Instructions と docs tests のみで status intent 方針を固定する。
- actual: 5 ファイルのみ変更。fallback review 指摘に従い、short-min の reviewer-fix GO 定型文と vps_runner health 表示項目を復元。short は 7897 chars、short-min は 7838 chars。
- mismatch: 初回差分で short-min の `よければ GO と言ってください。` を削りすぎていたため、修正して test invariant に追加。
- lesson: startup preflight は true startup と status read で明確に分ける必要がある。
- should become RAG candidate: はい。Issue #426 は status intent の first-response latency 方針を docs/tests 固定で切り直した。

## Verification Evidence

- Unit: node --test test/custom-gpt-setup-docs.test.js test/thread-independent-startup-contract.test.js: pass (13 tests).
- Integration: npm test: pass (868 pass / 1 skipped), check:self-parity pass, check:generated-worker pass.
- E2E: not-live。Custom GPT editor 貼り替え後に iPhone Butler で status intent 初回応答を確認する必要があります。
- Manual: short length 7897 chars; short-min length 7838 chars.
- Evidence path/link: Local test output in this PR run; PR checks after push.

## Butler Completion Contract

- Owner goal: Butler が status intent で長時間黙らず、短い受付返答後に段階的な lightweight reads を進めること。
- Butler entrypoint: Custom GPT natural status intent: Issue / PR / close readiness / status / 残タスク確認。
- Action Schema exposure: 変更なし。既存 vtddRetrieveGitHub と vtddStartupPreflight の使い分け方針のみ更新。
- Runtime path: 変更なし。runtime route は追加しない。
- Runner/runtime truth: この PR は docs/tests 固定。runtime truth は PR checks と setup artifact による検証。
- Authority boundary: 変更なし。merge / issue close / deploy は既存の GO + passkey / authority 境界に従う。
- E2E evidence: not-live。貼り替え後に実機確認が必要。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 不要。この PR は docs/tests only。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 必要。merge 後に Custom GPT Instructions の貼り替え対象。
- iPhone Butler live E2E: 未実施。貼り替え後に実施。

## Related Constitution Rules

- Butler Completion Gate
- Drift Stop Protocol
- Conversation UX Contract
- Evidence Discipline

## Out-of-scope but NOT implemented

- runtime endpoint 追加。
- Action Schema operationId 追加。
- Gemini reviewer logic 変更。
- 旧 PR #427 の conflict 解消マージ。

## Extra changes (if any)

最新 main から codex/issue-426-status-read-latest-main を切り直し、PR #427 を置き換えます。
Codex fallback review の request_changes 指摘を受け、short-min の reviewer-fix GO 文言を復元してテスト固定しました。

<!-- VTDD metadata -->
- Issue: Issue #426
- Execution ID: mac_codex_recut_issue_426_2026-05-20
- Goal: Issue #426 status reads recut from latest main
