### PR TITLE
Issue #450 fix live dashboard Butler chat controls

### DIFF
--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -7167,7 +7167,7 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
     .app-shell { min-height: calc(100dvh - 32px); display: grid; grid-template-rows: auto 1fr auto; }
     .topbar { display: flex; justify-content: space-between; align-items: center; gap: 12px; padding: 4px 2px 20px; }
     .top-left, .top-right { display: flex; align-items: center; gap: 10px; min-width: 0; }
-    .round-button, .tool-button, .send-button, .icon-button { display: inline-flex; align-items: center; justify-content: center; border: 1px solid var(--border); background: var(--button); color: var(--text); text-decoration: none; font: inherit; font-weight: 750; }
+    .round-button, .tool-button, .send-button { display: inline-flex; align-items: center; justify-content: center; border: 1px solid var(--border); background: var(--button); color: var(--text); text-decoration: none; font: inherit; font-weight: 750; }
     .menu-open { cursor: pointer; }
     .round-button { width: 44px; height: 44px; border-radius: 999px; font-size: 24px; flex: 0 0 auto; }
     .tool-button { min-height: 40px; border-radius: 999px; padding: 0 14px; }
@@ -7185,10 +7185,9 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
     .connection-note { display: inline-flex; align-items: center; width: fit-content; border: 1px solid var(--border); border-radius: 999px; padding: 5px 10px; color: var(--muted); font-size: 13px; }
     .chat-link { color: var(--text); text-decoration-thickness: 1px; text-underline-offset: 4px; font-weight: 750; }
     .composer { position: fixed; left: 16px; right: 354px; bottom: max(16px, env(safe-area-inset-bottom)); display: grid; gap: 8px; z-index: 4; }
-    .composer-box { display: grid; grid-template-columns: 44px minmax(0, 1fr) 38px 44px; align-items: end; gap: 8px; min-height: 62px; padding: 8px; border: 1px solid var(--border); border-radius: 28px; background: var(--panel-strong); box-shadow: 0 16px 60px var(--shadow); }
+    .composer-box { display: grid; grid-template-columns: minmax(0, 1fr) 44px; align-items: end; gap: 8px; min-height: 62px; padding: 8px; border: 1px solid var(--border); border-radius: 28px; background: var(--panel-strong); box-shadow: 0 16px 60px var(--shadow); }
     textarea { width: 100%; min-height: 44px; max-height: 160px; border: 0; outline: 0; resize: vertical; padding: 10px 2px; color: var(--text); background: transparent; font: inherit; line-height: 1.45; }
     textarea::placeholder { color: var(--muted); }
-    .icon-button { width: 38px; height: 38px; border-radius: 999px; font-size: 24px; }
     .send-button { width: 44px; height: 44px; border-radius: 999px; background: var(--text); color: var(--page-bg); font-size: 22px; }
     .composer-status { padding-left: 16px; color: var(--muted); font-size: 12px; }
     .sidebar { position: sticky; top: 16px; align-self: start; max-height: calc(100dvh - 32px); overflow: auto; border: 1px solid var(--border); border-radius: 18px; background: var(--panel); }
@@ -7236,11 +7235,10 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
     @media (max-width: 460px) {
       main { padding: 12px 10px 0; }
       .composer { left: 10px; right: 10px; }
-      .composer-box { grid-template-columns: 40px minmax(0, 1fr) 34px 40px; border-radius: 24px; }
+      .composer-box { grid-template-columns: minmax(0, 1fr) 40px; border-radius: 24px; }
       .round-button { width: 40px; height: 40px; }
       .tool-button { min-height: 38px; padding: 0 12px; }
       .send-button { width: 40px; height: 40px; }
-      .icon-button { width: 34px; height: 34px; }
     }
   </style>
 </head>
@@ -7322,11 +7320,9 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
 
       </div>
 
-      <form class="composer" id="butler-chat-form" aria-label="Butler composer" data-endpoint="${escapeDashboardHtml(origin)}/v2/dashboard/chat/messages" data-thread-id="${escapeDashboardHtml(chatThreadId)}" data-repository="${escapeDashboardHtml(repository)}">
+      <form class="composer" id="butler-chat-form" aria-label="Butler composer" data-endpoint="${escapeDashboardHtml(origin)}/v2/dashboard/chat/messages" data-thread-endpoint="${escapeDashboardHtml(origin)}/v2/dashboard/chat/${escapeDashboardHtml(chatThreadId)}" data-thread-id="${escapeDashboardHtml(chatThreadId)}" data-repository="${escapeDashboardHtml(repository)}">
         <div class="composer-box">
-          <span class="icon-button" aria-hidden="true">＋</span>
           <textarea id="butler-message" name="text" placeholder="Butler V2 にメッセージ..." aria-label="Butler V2 にメッセージ"></textarea>
-          <span class="icon-button" aria-hidden="true">♪</span>
           <button class="send-button" type="submit" aria-label="Butler に送信">↑</button>
         </div>
         <div class="composer-status" id="butler-chat-status">接続済み。送信するとこの thread に保存されます。自動更新・polling はありません。</div>
@@ -7394,8 +7390,10 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
       if (!form || !log || !textarea || !status) return;
 
       const endpoint = form.dataset.endpoint;
+      const threadEndpoint = form.dataset.threadEndpoint;
       const threadId = form.dataset.threadId;
       const repository = form.dataset.repository;
+      const initialMarkup = log.innerHTML;
 
       function setStatus(text) {
         status.textContent = text;
@@ -7420,6 +7418,38 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
         appendMessage({ role: "butler", text });
       }
 
+      function renderThread(messages) {
+        if (!Array.isArray(messages) || messages.length === 0) {
+          log.innerHTML = initialMarkup;
+          return;
+        }
+        log.replaceChildren();
+        for (const message of messages) {
+          appendMessage(message);
+        }
+      }
+
+      async function refreshThread() {
+        if (!threadEndpoint) return;
+        setStatus("会話履歴を読み込み中です。");
+        try {
+          const response = await fetch(threadEndpoint, {
+            method: "GET",
+            headers: { "accept": "application/json" },
+            credentials: "same-origin"
+          });
+          const body = await response.json().catch(() => ({}));
+          if (!response.ok || !body.ok) {
+            setStatus(body.reason || "会話履歴を読めませんでした。送信時に再試行します。");
+            return;
+          }
+          renderThread(body.messages || []);
+          setStatus("接続済み。送信するとこの thread に保存されます。自動更新・polling はありません。");
+        } catch {
+          setStatus("会話履歴を読めませんでした。送信時に再試行します。");
+        }
+      }
+
       form.addEventListener("submit", async (event) => {
         event.preventDefault();
         const text = textarea.value.trim();
@@ -7433,7 +7463,8 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
         try {
           const response = await fetch(endpoint, {
             method: "POST",
-            headers: { "content-type": "application/json" },
+            headers: { "content-type": "application/json", "accept": "application/json" },
+            credentials: "same-origin",
             body: JSON.stringify({ threadId, repository, text })
           });
           const body = await response.json().catch(() => ({}));
@@ -7455,6 +7486,8 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
           textarea.focus();
         }
       });
+
+      refreshThread();
     })();
   </script>
 </body>

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -388,7 +388,14 @@ test("worker serves v2 dashboard for allowed owner identity without exposing sec
   assert.equal(body.includes('for="mobile-menu-toggle"'), true);
   assert.equal(body.includes('id="butler-chat-form"'), true);
   assert.equal(body.includes('id="butler-chat-log"'), true);
+  assert.equal(body.includes('class="icon-button"'), false);
+  assert.equal(body.includes('aria-hidden="true">＋</span>'), false);
+  assert.equal(body.includes('aria-hidden="true">♪</span>'), false);
   assert.equal(body.includes("/v2/dashboard/chat/messages"), true);
+  assert.equal(body.includes('data-thread-endpoint="https://example.com/v2/dashboard/chat/dashboard-main-marushu-vtdd-v2-p"'), true);
+  assert.equal(body.includes("function refreshThread()"), true);
+  assert.equal(body.includes('credentials: "same-origin"'), true);
+  assert.equal(body.includes("会話履歴を読み込み中です"), true);
   assert.equal(body.includes("モバイル管理メニュー"), true);
   assert.equal(body.includes("直近 deploy event"), true);
   assert.equal(body.includes("Butler V2 にメッセージ"), true);
@@ -473,6 +480,59 @@ test("worker appends dashboard Butler chat turn and retrieves the same thread", 
   assert.equal(retrieveBody.ok, true);
   assert.equal(retrieveBody.messages.length, 2);
   assert.equal(retrieveBody.messages[0].text, "VPS Codex CLI とリアルタイムに会話したい");
+});
+
+test("worker appends dashboard Butler chat turn with dashboard passkey session cookie", async () => {
+  const provider = createInMemoryMemoryProvider();
+  await provider.store({
+    id: "approval:dashboard-chat-session",
+    type: MemoryRecordType.APPROVAL_LOG,
+    content: {
+      kind: "passkey_grant",
+      status: "verified",
+      approvalId: "approval:dashboard-chat-session",
+      credentialId: "AQIDBA",
+      verifiedAt: "2026-05-20T00:00:00.000Z",
+      expiresAt: "2999-01-01T00:00:00.000Z",
+      scope: {
+        actionType: "read",
+        highRiskKind: "dashboard_access",
+        repositoryInput: "marushu/vtdd-v2-p",
+        phase: "execution"
+      }
+    },
+    metadata: { source: "test" },
+    priority: 96,
+    tags: ["passkey_grant", "passkey_approval", "verified"],
+    createdAt: "2026-05-20T00:00:00.000Z"
+  });
+
+  const store = createInMemoryDashboardChatStore();
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/dashboard/chat/messages", {
+      method: "POST",
+      headers: {
+        cookie: "vtdd_dashboard_session=approval%3Adashboard-chat-session",
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({
+        threadId: "dashboard-main-marushu-vtdd-v2-p",
+        repository: "marushu/vtdd-v2-p",
+        text: "dashboard passkey session から Butler に送る"
+      })
+    }),
+    {
+      MEMORY_PROVIDER: provider,
+      DASHBOARD_CHAT_STORE: store
+    }
+  );
+
+  assert.equal(response.status, 202);
+  const body = await response.json();
+  assert.equal(body.ok, true);
+  assert.equal(body.messages.length, 2);
+  assert.equal(body.messages[0].role, "owner");
+  assert.equal(body.messages[1].role, "butler");
 });
 
 test("worker dispatches authenticated dashboard chat handoff to VPS runner queue", async () => {

--- a/worker.js
+++ b/worker.js
@@ -61986,7 +61986,7 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
     .app-shell { min-height: calc(100dvh - 32px); display: grid; grid-template-rows: auto 1fr auto; }
     .topbar { display: flex; justify-content: space-between; align-items: center; gap: 12px; padding: 4px 2px 20px; }
     .top-left, .top-right { display: flex; align-items: center; gap: 10px; min-width: 0; }
-    .round-button, .tool-button, .send-button, .icon-button { display: inline-flex; align-items: center; justify-content: center; border: 1px solid var(--border); background: var(--button); color: var(--text); text-decoration: none; font: inherit; font-weight: 750; }
+    .round-button, .tool-button, .send-button { display: inline-flex; align-items: center; justify-content: center; border: 1px solid var(--border); background: var(--button); color: var(--text); text-decoration: none; font: inherit; font-weight: 750; }
     .menu-open { cursor: pointer; }
     .round-button { width: 44px; height: 44px; border-radius: 999px; font-size: 24px; flex: 0 0 auto; }
     .tool-button { min-height: 40px; border-radius: 999px; padding: 0 14px; }
@@ -62004,10 +62004,9 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
     .connection-note { display: inline-flex; align-items: center; width: fit-content; border: 1px solid var(--border); border-radius: 999px; padding: 5px 10px; color: var(--muted); font-size: 13px; }
     .chat-link { color: var(--text); text-decoration-thickness: 1px; text-underline-offset: 4px; font-weight: 750; }
     .composer { position: fixed; left: 16px; right: 354px; bottom: max(16px, env(safe-area-inset-bottom)); display: grid; gap: 8px; z-index: 4; }
-    .composer-box { display: grid; grid-template-columns: 44px minmax(0, 1fr) 38px 44px; align-items: end; gap: 8px; min-height: 62px; padding: 8px; border: 1px solid var(--border); border-radius: 28px; background: var(--panel-strong); box-shadow: 0 16px 60px var(--shadow); }
+    .composer-box { display: grid; grid-template-columns: minmax(0, 1fr) 44px; align-items: end; gap: 8px; min-height: 62px; padding: 8px; border: 1px solid var(--border); border-radius: 28px; background: var(--panel-strong); box-shadow: 0 16px 60px var(--shadow); }
     textarea { width: 100%; min-height: 44px; max-height: 160px; border: 0; outline: 0; resize: vertical; padding: 10px 2px; color: var(--text); background: transparent; font: inherit; line-height: 1.45; }
     textarea::placeholder { color: var(--muted); }
-    .icon-button { width: 38px; height: 38px; border-radius: 999px; font-size: 24px; }
     .send-button { width: 44px; height: 44px; border-radius: 999px; background: var(--text); color: var(--page-bg); font-size: 22px; }
     .composer-status { padding-left: 16px; color: var(--muted); font-size: 12px; }
     .sidebar { position: sticky; top: 16px; align-self: start; max-height: calc(100dvh - 32px); overflow: auto; border: 1px solid var(--border); border-radius: 18px; background: var(--panel); }
@@ -62055,11 +62054,10 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
     @media (max-width: 460px) {
       main { padding: 12px 10px 0; }
       .composer { left: 10px; right: 10px; }
-      .composer-box { grid-template-columns: 40px minmax(0, 1fr) 34px 40px; border-radius: 24px; }
+      .composer-box { grid-template-columns: minmax(0, 1fr) 40px; border-radius: 24px; }
       .round-button { width: 40px; height: 40px; }
       .tool-button { min-height: 38px; padding: 0 12px; }
       .send-button { width: 40px; height: 40px; }
-      .icon-button { width: 34px; height: 34px; }
     }
   </style>
 </head>
@@ -62141,11 +62139,9 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
 
       </div>
 
-      <form class="composer" id="butler-chat-form" aria-label="Butler composer" data-endpoint="${escapeDashboardHtml(origin)}/v2/dashboard/chat/messages" data-thread-id="${escapeDashboardHtml(chatThreadId)}" data-repository="${escapeDashboardHtml(repository)}">
+      <form class="composer" id="butler-chat-form" aria-label="Butler composer" data-endpoint="${escapeDashboardHtml(origin)}/v2/dashboard/chat/messages" data-thread-endpoint="${escapeDashboardHtml(origin)}/v2/dashboard/chat/${escapeDashboardHtml(chatThreadId)}" data-thread-id="${escapeDashboardHtml(chatThreadId)}" data-repository="${escapeDashboardHtml(repository)}">
         <div class="composer-box">
-          <span class="icon-button" aria-hidden="true">\uFF0B</span>
           <textarea id="butler-message" name="text" placeholder="Butler V2 \u306B\u30E1\u30C3\u30BB\u30FC\u30B8..." aria-label="Butler V2 \u306B\u30E1\u30C3\u30BB\u30FC\u30B8"></textarea>
-          <span class="icon-button" aria-hidden="true">\u266A</span>
           <button class="send-button" type="submit" aria-label="Butler \u306B\u9001\u4FE1">\u2191</button>
         </div>
         <div class="composer-status" id="butler-chat-status">\u63A5\u7D9A\u6E08\u307F\u3002\u9001\u4FE1\u3059\u308B\u3068\u3053\u306E thread \u306B\u4FDD\u5B58\u3055\u308C\u307E\u3059\u3002\u81EA\u52D5\u66F4\u65B0\u30FBpolling \u306F\u3042\u308A\u307E\u305B\u3093\u3002</div>
@@ -62213,8 +62209,10 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
       if (!form || !log || !textarea || !status) return;
 
       const endpoint = form.dataset.endpoint;
+      const threadEndpoint = form.dataset.threadEndpoint;
       const threadId = form.dataset.threadId;
       const repository = form.dataset.repository;
+      const initialMarkup = log.innerHTML;
 
       function setStatus(text) {
         status.textContent = text;
@@ -62239,6 +62237,38 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
         appendMessage({ role: "butler", text });
       }
 
+      function renderThread(messages) {
+        if (!Array.isArray(messages) || messages.length === 0) {
+          log.innerHTML = initialMarkup;
+          return;
+        }
+        log.replaceChildren();
+        for (const message of messages) {
+          appendMessage(message);
+        }
+      }
+
+      async function refreshThread() {
+        if (!threadEndpoint) return;
+        setStatus("\u4F1A\u8A71\u5C65\u6B74\u3092\u8AAD\u307F\u8FBC\u307F\u4E2D\u3067\u3059\u3002");
+        try {
+          const response = await fetch(threadEndpoint, {
+            method: "GET",
+            headers: { "accept": "application/json" },
+            credentials: "same-origin"
+          });
+          const body = await response.json().catch(() => ({}));
+          if (!response.ok || !body.ok) {
+            setStatus(body.reason || "\u4F1A\u8A71\u5C65\u6B74\u3092\u8AAD\u3081\u307E\u305B\u3093\u3067\u3057\u305F\u3002\u9001\u4FE1\u6642\u306B\u518D\u8A66\u884C\u3057\u307E\u3059\u3002");
+            return;
+          }
+          renderThread(body.messages || []);
+          setStatus("\u63A5\u7D9A\u6E08\u307F\u3002\u9001\u4FE1\u3059\u308B\u3068\u3053\u306E thread \u306B\u4FDD\u5B58\u3055\u308C\u307E\u3059\u3002\u81EA\u52D5\u66F4\u65B0\u30FBpolling \u306F\u3042\u308A\u307E\u305B\u3093\u3002");
+        } catch {
+          setStatus("\u4F1A\u8A71\u5C65\u6B74\u3092\u8AAD\u3081\u307E\u305B\u3093\u3067\u3057\u305F\u3002\u9001\u4FE1\u6642\u306B\u518D\u8A66\u884C\u3057\u307E\u3059\u3002");
+        }
+      }
+
       form.addEventListener("submit", async (event) => {
         event.preventDefault();
         const text = textarea.value.trim();
@@ -62252,7 +62282,8 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
         try {
           const response = await fetch(endpoint, {
             method: "POST",
-            headers: { "content-type": "application/json" },
+            headers: { "content-type": "application/json", "accept": "application/json" },
+            credentials: "same-origin",
             body: JSON.stringify({ threadId, repository, text })
           });
           const body = await response.json().catch(() => ({}));
@@ -62274,6 +62305,8 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
           textarea.focus();
         }
       });
+
+      refreshThread();
     })();
   <\/script>
 </body>


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #450 の dashboard Butler chat を、見た目だけの composer から実際の同一 origin chat API に接続する修正です。
- 送信ボタンは `/v2/dashboard/chat/messages` に `credentials: "same-origin"` 付きで POST し、同じ chat surface に owner message と Butler reply を追記します。
- dashboard 表示時に `/v2/dashboard/chat/:threadId` を GET して、既存 thread を同一画面に復元します。
- 動かない画像追加と音声風の `＋` / `♪` 表示は、Issue #450 の Non-goal が file upload / 音声 overlay を除外しているため削除します。

## Satisfied Success Criteria

- `/dashboard` のチャット欄から message を送信できる runtime path を同一 origin fetch として接続しました。
- 返信は page reload ではなく、送信応答の `messages` を同じ chat surface へ描画します。
- thread id / message id / role / createdAt / repository / status を返す既存 chat response を画面側が扱えるようにしました。
- dashboard の自動 page reload / setInterval polling は追加していません。初回 thread 復元は明示的な GET だけです。
- 未認証 third party は既存 dashboard auth boundary のままブロックされます。
- raw JSON を owner に見せず、失敗時は status 行と Butler reply に日本語 reason を表示します。
- test で message append、reply append、thread retrieval、passkey session cookie 経由の送信、偽アイコン削除、same-origin fetch を確認しました。

## Unsatisfied Success Criteria

- 本番 dashboard へは未デプロイです。merge 後に deploy_production 承認と live dashboard E2E が必要です。
- owner の実ブラウザで、送信、返信表示、thread 復元、失敗理由表示をまだ確認していません。
- VPS Codex CLI からの runner reply は別 PR #456 由来の thread append path に依存します。この PR は dashboard composer の接続修正です。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #450
- Implementing Success Criteria: dashboard chat surface の送信、同一画面 reply append、thread 復元、認証 session cookie 維持、偽の画像追加/音声風 icon 削除。
- Explicit Non-goals: OpenAI API 導入、有料 LLM backend、完全双方向 VPS streaming、GitHub Issue/PR/merge/deploy の chat 送信実行、iOS Push、音声 overlay、file upload、画像加工。
- Expected touched files/routes/workflows: `src/worker/runtime.js`, `worker.js`, `test/worker.test.js`, route `/v2/dashboard/chat/messages`, route `/v2/dashboard/chat/:threadId`; GitHub Actions workflow は変更なし。
- Affected Issues: #450。画像 upload / 音声入力を実装する場合は #450 ではなく別 Issue が必要です。
- Affected PRs: なし。過去 PR #451/#456 の実装に dashboard UI が届いていなかった穴を補います。
- Affected workflows: CI test / generated worker check のみ。deploy workflow 自体は変更しません。
- Affected runtime/operator surfaces: Cloudflare Worker dashboard, dashboard passkey session cookie, Butler chat composer, Butler chat thread view。
- What may break if we patch narrowly: thread GET が失敗した場合に初期説明が消える、または auth cookie が送信されず 401 になるリスクがありました。`initialMarkup` 復元と `credentials: "same-origin"` で抑えています。
- Unknowns to investigate before coding: 本番環境の owner browser session cookie が実際に Cloudflare Worker へ渡るかは deploy 後 live E2E で確認が必要です。
- Validation needed: `npm test`、本番 deploy 後の dashboard live E2E、未認証 POST が 401 のまま維持されること。
- Stop condition: file upload / mic mode 実装要求が入る場合は Issue #450 Non-goal と衝突するため、別 Issue または明示的な scope 変更なしに実装しません。

## File / Line Hypotheses

- file: `src/worker/runtime.js`
  - hypothesis: dashboard composer が UI 上は存在するが、thread retrieval endpoint と same-origin credential 指定が不足しているため live dashboard で送信/復元が失敗しやすい。
  - risk if changed narrowly: API response は存在しても owner session cookie が送られず、実画面では 401 になる。
  - validation: `test/worker.test.js` で passkey session cookie 経由の POST と generated HTML の `credentials: "same-origin"` を確認する。
  - related Issue: #450
- file: `test/worker.test.js`
  - hypothesis: 既存 test は dashboard HTML が chat form を含むことを見ているだけで、owner passkey session から送信できることを見ていない。
  - risk if changed narrowly: UI だけあるが実機では一切動かない状態を再発させる。
  - validation: dashboard passkey session cookie 付き POST が 202 を返し、owner / butler messages が返ることを確認する。
  - related Issue: #450

## Hypothesis Retrospective

- expected: UI shell だけでなく、same-origin credential 付きの送信と thread 復元を接続すれば dashboard Butler chat は最低限操作可能になる。
- actual: worker test で passkey session cookie 経由 POST、thread endpoint の HTML 露出、履歴復元関数、偽アイコン削除を確認しました。
- mismatch: 本番 dashboard は未デプロイなので、owner browser での live E2E は残っています。
- lesson: dashboard に見えるが押せない control は Issue completion を満たさない。Non-goal の画像/音声は偽 UI として置かず、別 Issue 化する。
- should become RAG candidate: はい。#450 の再発防止として「見える control は runtime path と E2E がなければ置かない」を保存候補にします。

## Verification Evidence

- Unit: `npm test` passed. Node test result: 870 tests, 869 pass, 1 skipped, 0 fail.
- Integration: `test/worker.test.js` に dashboard passkey session cookie 付き chat POST、thread endpoint HTML、same-origin fetch、偽 icon 不在の確認を追加。
- E2E: 未実施。本番 deploy 後に owner dashboard で送信、返信表示、thread 復元、失敗理由表示を確認する必要があります。
- Manual: `https://vtdd-v2-mvp.polished-tree-da7c.workers.dev/health` は 200 OK。未認証 `/v2/dashboard/chat/messages` POST は 401 のまま維持されることを事前確認済み。
- Evidence path/link: `src/worker/runtime.js`, `worker.js`, `test/worker.test.js`, Issue #450

## Butler Completion Contract

- Owner goal: dashboard 上の Butler chat で、送信ボタンを押したら同じ画面に会話が返るようにする。
- Butler entrypoint: `/dashboard` の `#butler-chat-form`。Custom GPT ではなく owner-facing dashboard surface。
- Action Schema exposure: 不要。この PR は Custom GPT Action Schema を増やさず、既存 Worker dashboard route を接続します。
- Runtime path: `/dashboard` HTML -> `GET /v2/dashboard/chat/:threadId` -> `POST /v2/dashboard/chat/messages` -> dashboard chat store -> in-page message append。
- Runner/runtime truth: worker test で passkey session cookie 経由の POST と response messages を確認。本番 runtime truth は deploy 後に確認が必要です。
- Authority boundary: 既存 dashboard auth / passkey session cookie 境界を維持。未認証 third party は 401。merge/deploy/VPS execution はこの chat 送信だけでは実行しません。
- E2E evidence: 未完了。本番 deploy 後の owner dashboard E2E が必要です。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 必要。merge 後、`deploy_production` の scoped passkey approval が必要です。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 必要。本番 dashboard で送信、返信、thread 復元、失敗理由表示を確認します。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate
- AGENTS.md Butler-First Operating Principle
- AGENTS.md Drift Stop Protocol
- AGENTS.md Issue Lifecycle Gate
- AGENTS.md Conversation UX Contract
- AGENTS.md Authority Boundary

## Out-of-scope but NOT implemented

- 画像追加 / file upload
- マイク入力 / 音声 overlay
- 有料 LLM backend
- 完全双方向 VPS Codex CLI streaming
- chat 送信だけによる merge / deploy / Issue close

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #450
- Execution ID: mac_codex_issue_450_live_dashboard_butler
- Goal: dashboard Butler chat の送信・復元・偽 control 削除
