### PR TITLE
Issue #450 fix mobile Butler composer overlap

### DIFF
--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -7174,7 +7174,7 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
     .thread-title { min-width: 0; }
     .thread-title h1 { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
     .thread-title span { display: block; color: var(--muted); font-size: 13px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-    .chat-scroll { min-height: 0; overflow: auto; padding: 8px 4px 118px; display: flex; flex-direction: column; gap: 22px; scrollbar-width: thin; }
+    .chat-scroll { min-height: 0; overflow: auto; padding: 8px 4px var(--composer-reserve, 156px); scroll-padding-bottom: var(--composer-reserve, 156px); display: flex; flex-direction: column; gap: 22px; scrollbar-width: thin; }
     .bubble { max-width: min(760px, 88%); color: var(--text); font-size: 17px; line-height: 1.72; }
     .bubble, .bubble p, .bubble li { overflow-wrap: anywhere; }
     .bubble strong { display: block; color: var(--muted); font-size: 12px; letter-spacing: .08em; text-transform: uppercase; margin-bottom: 8px; }
@@ -7184,7 +7184,7 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
     .bubble.owner p { color: var(--owner-text); margin: 0; }
     .connection-note { display: inline-flex; align-items: center; width: fit-content; border: 1px solid var(--border); border-radius: 999px; padding: 5px 10px; color: var(--muted); font-size: 13px; }
     .chat-link { color: var(--text); text-decoration-thickness: 1px; text-underline-offset: 4px; font-weight: 750; }
-    .composer { position: fixed; left: 16px; right: 354px; bottom: max(16px, env(safe-area-inset-bottom)); display: grid; gap: 8px; z-index: 4; }
+    .composer { position: fixed; left: 16px; right: 354px; bottom: 0; display: grid; gap: 8px; z-index: 4; padding: 14px 0 max(16px, env(safe-area-inset-bottom)); background: var(--page-bg); }
     .composer-box { display: grid; grid-template-columns: minmax(0, 1fr) 44px; align-items: end; gap: 8px; min-height: 62px; padding: 8px; border: 1px solid var(--border); border-radius: 28px; background: var(--panel-strong); box-shadow: 0 16px 60px var(--shadow); }
     textarea { width: 100%; min-height: 44px; max-height: 160px; border: 0; outline: 0; resize: vertical; padding: 10px 2px; color: var(--text); background: transparent; font: inherit; line-height: 1.45; }
     textarea::placeholder { color: var(--muted); }
@@ -7227,7 +7227,7 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
       .menu-toggle:checked ~ .mobile-backdrop, .menu-toggle:checked ~ .mobile-drawer { display: block; }
       .mobile-drawer-header { display: flex; justify-content: space-between; align-items: center; gap: 12px; margin-bottom: 14px; }
       .mobile-drawer-content { display: grid; gap: 12px; }
-      .chat-scroll { padding-bottom: 104px; }
+      .chat-scroll { padding-bottom: var(--composer-reserve, 170px); }
       .bubble { max-width: 100%; font-size: 16px; }
       .bubble.owner { max-width: 82%; }
       .topbar { padding-bottom: 18px; }
@@ -7395,6 +7395,16 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
       const repository = form.dataset.repository;
       const initialMarkup = log.innerHTML;
 
+      function updateComposerReserve() {
+        const reserve = Math.ceil(form.getBoundingClientRect().height + 36);
+        log.style.setProperty("--composer-reserve", reserve + "px");
+      }
+
+      function scrollToLatest() {
+        updateComposerReserve();
+        log.scrollTop = log.scrollHeight;
+      }
+
       function setStatus(text) {
         status.textContent = text;
       }
@@ -7411,7 +7421,7 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
         paragraph.textContent = message.text || "（空のメッセージ）";
         article.appendChild(paragraph);
         log.appendChild(article);
-        article.scrollIntoView({ block: "end" });
+        scrollToLatest();
       }
 
       function appendError(text) {
@@ -7421,12 +7431,14 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
       function renderThread(messages) {
         if (!Array.isArray(messages) || messages.length === 0) {
           log.innerHTML = initialMarkup;
+          scrollToLatest();
           return;
         }
         log.replaceChildren();
         for (const message of messages) {
           appendMessage(message);
         }
+        scrollToLatest();
       }
 
       async function refreshThread() {
@@ -7484,9 +7496,12 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
         } finally {
           if (submitButton) submitButton.disabled = false;
           textarea.focus();
+          updateComposerReserve();
         }
       });
 
+      updateComposerReserve();
+      window.addEventListener("resize", updateComposerReserve);
       refreshThread();
     })();
   </script>

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -394,6 +394,10 @@ test("worker serves v2 dashboard for allowed owner identity without exposing sec
   assert.equal(body.includes("/v2/dashboard/chat/messages"), true);
   assert.equal(body.includes('data-thread-endpoint="https://example.com/v2/dashboard/chat/dashboard-main-marushu-vtdd-v2-p"'), true);
   assert.equal(body.includes("function refreshThread()"), true);
+  assert.equal(body.includes("function updateComposerReserve()"), true);
+  assert.equal(body.includes("function scrollToLatest()"), true);
+  assert.equal(body.includes("--composer-reserve"), true);
+  assert.equal(body.includes("background: var(--page-bg)"), true);
   assert.equal(body.includes('credentials: "same-origin"'), true);
   assert.equal(body.includes("会話履歴を読み込み中です"), true);
   assert.equal(body.includes("モバイル管理メニュー"), true);

--- a/worker.js
+++ b/worker.js
@@ -61993,7 +61993,7 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
     .thread-title { min-width: 0; }
     .thread-title h1 { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
     .thread-title span { display: block; color: var(--muted); font-size: 13px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-    .chat-scroll { min-height: 0; overflow: auto; padding: 8px 4px 118px; display: flex; flex-direction: column; gap: 22px; scrollbar-width: thin; }
+    .chat-scroll { min-height: 0; overflow: auto; padding: 8px 4px var(--composer-reserve, 156px); scroll-padding-bottom: var(--composer-reserve, 156px); display: flex; flex-direction: column; gap: 22px; scrollbar-width: thin; }
     .bubble { max-width: min(760px, 88%); color: var(--text); font-size: 17px; line-height: 1.72; }
     .bubble, .bubble p, .bubble li { overflow-wrap: anywhere; }
     .bubble strong { display: block; color: var(--muted); font-size: 12px; letter-spacing: .08em; text-transform: uppercase; margin-bottom: 8px; }
@@ -62003,7 +62003,7 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
     .bubble.owner p { color: var(--owner-text); margin: 0; }
     .connection-note { display: inline-flex; align-items: center; width: fit-content; border: 1px solid var(--border); border-radius: 999px; padding: 5px 10px; color: var(--muted); font-size: 13px; }
     .chat-link { color: var(--text); text-decoration-thickness: 1px; text-underline-offset: 4px; font-weight: 750; }
-    .composer { position: fixed; left: 16px; right: 354px; bottom: max(16px, env(safe-area-inset-bottom)); display: grid; gap: 8px; z-index: 4; }
+    .composer { position: fixed; left: 16px; right: 354px; bottom: 0; display: grid; gap: 8px; z-index: 4; padding: 14px 0 max(16px, env(safe-area-inset-bottom)); background: var(--page-bg); }
     .composer-box { display: grid; grid-template-columns: minmax(0, 1fr) 44px; align-items: end; gap: 8px; min-height: 62px; padding: 8px; border: 1px solid var(--border); border-radius: 28px; background: var(--panel-strong); box-shadow: 0 16px 60px var(--shadow); }
     textarea { width: 100%; min-height: 44px; max-height: 160px; border: 0; outline: 0; resize: vertical; padding: 10px 2px; color: var(--text); background: transparent; font: inherit; line-height: 1.45; }
     textarea::placeholder { color: var(--muted); }
@@ -62046,7 +62046,7 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
       .menu-toggle:checked ~ .mobile-backdrop, .menu-toggle:checked ~ .mobile-drawer { display: block; }
       .mobile-drawer-header { display: flex; justify-content: space-between; align-items: center; gap: 12px; margin-bottom: 14px; }
       .mobile-drawer-content { display: grid; gap: 12px; }
-      .chat-scroll { padding-bottom: 104px; }
+      .chat-scroll { padding-bottom: var(--composer-reserve, 170px); }
       .bubble { max-width: 100%; font-size: 16px; }
       .bubble.owner { max-width: 82%; }
       .topbar { padding-bottom: 18px; }
@@ -62214,6 +62214,16 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
       const repository = form.dataset.repository;
       const initialMarkup = log.innerHTML;
 
+      function updateComposerReserve() {
+        const reserve = Math.ceil(form.getBoundingClientRect().height + 36);
+        log.style.setProperty("--composer-reserve", reserve + "px");
+      }
+
+      function scrollToLatest() {
+        updateComposerReserve();
+        log.scrollTop = log.scrollHeight;
+      }
+
       function setStatus(text) {
         status.textContent = text;
       }
@@ -62230,7 +62240,7 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
         paragraph.textContent = message.text || "\uFF08\u7A7A\u306E\u30E1\u30C3\u30BB\u30FC\u30B8\uFF09";
         article.appendChild(paragraph);
         log.appendChild(article);
-        article.scrollIntoView({ block: "end" });
+        scrollToLatest();
       }
 
       function appendError(text) {
@@ -62240,12 +62250,14 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
       function renderThread(messages) {
         if (!Array.isArray(messages) || messages.length === 0) {
           log.innerHTML = initialMarkup;
+          scrollToLatest();
           return;
         }
         log.replaceChildren();
         for (const message of messages) {
           appendMessage(message);
         }
+        scrollToLatest();
       }
 
       async function refreshThread() {
@@ -62303,9 +62315,12 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
         } finally {
           if (submitButton) submitButton.disabled = false;
           textarea.focus();
+          updateComposerReserve();
         }
       });
 
+      updateComposerReserve();
+      window.addEventListener("resize", updateComposerReserve);
       refreshThread();
     })();
   <\/script>


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #450 の live dashboard E2E で、iPhone 幅の fixed composer が最新 Butler reply / status text に被る問題を修正します。
- 送信と deterministic Butler reply は thread に append されていましたが、最新返信が入力欄の下へ潜り、owner が読めない状態でした。
- chat surface が会話として読めるよう、composer 高さを runtime で測り、chat log の bottom reserve / scroll padding に反映します。

## Satisfied Success Criteria

- `/dashboard` の同一 chat surface で、送信後の owner message と Butler reply が composer に隠れないようにしました。
- fixed composer の背面を page background で覆い、下の thread text が透けて見えないようにしました。
- `scrollIntoView` 依存をやめ、composer reserve を更新してから chat log を末尾まで scroll します。
- iPhone 幅向けに `--composer-reserve` を使った bottom padding / scroll padding を固定しました。
- test で composer reserve、latest scroll helper、背景被り防止の HTML/CSS/JS marker を確認しました。

## Unsatisfied Success Criteria

- 本番 dashboard へは未デプロイです。merge 後に deploy_production 承認と live dashboard E2E が必要です。
- owner の実ブラウザで、最新返信が composer に被らないことをまだ再確認していません。
- deterministic Butler reply はまだ本物の VPS Codex CLI 返信ではありません。VPS runner reply path は別スライスで継続確認が必要です。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #450
- Implementing Success Criteria: dashboard chat surface の返信が同一画面で読めること、mobile composer が thread text を隠さないこと。
- Explicit Non-goals: 実 LLM reply、完全双方向 VPS streaming、画像追加、音声入力、file upload、merge/deploy 実行機能。
- Expected touched files/routes/workflows: `src/worker/runtime.js`, `worker.js`, `test/worker.test.js`; route と workflow は変更なし。
- Affected Issues: #450。
- Affected PRs: #463 の live E2E follow-up。
- Affected workflows: CI test / generated worker check のみ。
- Affected runtime/operator surfaces: Cloudflare Worker dashboard, mobile Butler chat surface。
- What may break if we patch narrowly: composer height が textarea resize や Safari toolbar で変わると reserve が不足し、また最新 reply が隠れる可能性があります。runtime height measurement で抑えます。
- Unknowns to investigate before coding: owner iPhone の Safari / in-app browser で実際の viewport と toolbar の高さがどこまで効くかは deploy 後 live E2E が必要です。
- Validation needed: `node --test test/worker.test.js`, `npm test`, deploy 後の iPhone dashboard live E2E。
- Stop condition: 本物の Butler/VPS 返信実装に踏み込む要求が出た場合、この UI 修正 PR では止めて別 Issue/scope に分けます。

## File / Line Hypotheses

- file: `src/worker/runtime.js`
  - hypothesis: `.chat-scroll` の固定 bottom padding と `article.scrollIntoView({ block: "end" })` が fixed composer の実高さを考慮せず、最新 reply が入力欄に隠れる。
  - risk if changed narrowly: desktop は問題なく見えても iPhone 幅では Safari toolbar / composer status / textarea height により再発する。
  - validation: composer height を測る `updateComposerReserve()` と `scrollToLatest()` を追加し、HTML marker test で固定する。
  - related Issue: #450
- file: `test/worker.test.js`
  - hypothesis: 既存 test は form / endpoint 接続を見ているが、mobile composer overlap の回帰を固定していない。
  - risk if changed narrowly: 送信 API は通るが owner が返信を読めない状態を再発させる。
  - validation: `--composer-reserve`, `updateComposerReserve`, `scrollToLatest`, composer background marker を確認する。
  - related Issue: #450

## Hypothesis Retrospective

- expected: composer 高さを reserve として chat log に渡し、末尾 scroll を log 自身に対して行えば、最新 reply が入力欄に隠れなくなる。
- actual: runtime code と generated worker を更新し、worker test と full test が通りました。
- mismatch: owner iPhone の live E2E は deploy 後に必要です。
- lesson: API append が通っていても、mobile fixed UI で読めなければ #450 の owner-facing completion ではない。
- should become RAG candidate: はい。dashboard chat の completion は API 成功だけでなく mobile visual E2E を必須にする。

## Verification Evidence

- Unit: `node --test test/worker.test.js` passed. 148 tests, 148 pass.
- Integration: `npm test` passed. 870 tests, 869 pass, 1 skipped, 0 fail.
- E2E: 未実施。本番 deploy 後に owner iPhone dashboard で最新 reply が composer に被らないことを確認する必要があります。
- Manual: owner 提供スクリーンショットで、#463 deploy 後の live dashboard が text append 済みだが mobile composer overlap を起こしていることを確認。
- Evidence path/link: `src/worker/runtime.js`, `worker.js`, `test/worker.test.js`, Issue #450

## Butler Completion Contract

- Owner goal: dashboard Butler chat で送信後の返信が入力欄に隠れず、iPhone で読める状態にする。
- Butler entrypoint: `/dashboard` の `#butler-chat-form`。
- Action Schema exposure: 不要。この PR は Custom GPT Action Schema を変更しません。
- Runtime path: `/dashboard` HTML -> same-origin chat API -> in-page append -> composer-aware scroll reserve。
- Runner/runtime truth: tests は通過。本番 runtime truth と owner mobile E2E は deploy 後に確認が必要です。
- Authority boundary: 変更なし。dashboard auth / passkey session 境界を維持します。
- E2E evidence: 未完了。本番 deploy 後の owner dashboard E2E が必要です。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 必要。merge 後、`deploy_production` の scoped passkey approval が必要です。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 必要。最新 reply が composer に被らないことを確認します。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate
- AGENTS.md Butler-First Operating Principle
- AGENTS.md Drift Stop Protocol
- AGENTS.md Evidence Discipline
- AGENTS.md Conversation UX Contract

## Out-of-scope but NOT implemented

- 画像追加 / file upload
- マイク入力 / 音声 overlay
- 実 LLM reply
- 完全双方向 VPS Codex CLI streaming

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #450
- Execution ID: mac_codex_issue_450_mobile_composer_overlap
- Goal: iPhone dashboard Butler chat の composer overlap 修正
