### PR TITLE
Issue #450 fix dashboard chat bottom alignment

### DIFF
--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -7155,16 +7155,16 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
       }
     }
     * { box-sizing: border-box; }
-    html, body { max-width: 100%; overflow-x: hidden; }
+    html, body { max-width: 100%; height: 100%; overflow: hidden; }
     body { margin: 0; background: var(--page-bg); }
-    main { width: 100%; min-height: 100dvh; display: grid; grid-template-columns: minmax(0, 1fr) minmax(220px, 320px); gap: 18px; padding: 16px; overflow-x: hidden; }
+    main { width: 100%; height: 100dvh; min-height: 0; display: grid; grid-template-columns: minmax(0, 1fr) minmax(220px, 320px); gap: 18px; padding: 16px; overflow: hidden; }
     h1, h2, h3, p { margin-top: 0; }
     h1 { font-size: 22px; line-height: 1.1; margin-bottom: 4px; }
     h2 { font-size: 19px; margin-bottom: 12px; }
     h3 { font-size: 15px; margin-bottom: 8px; }
     p { line-height: 1.65; color: var(--text); }
     a { color: inherit; }
-    .app-shell { min-height: calc(100dvh - 32px); display: grid; grid-template-rows: auto 1fr auto; }
+    .app-shell { height: calc(100dvh - 32px); min-height: 0; display: grid; grid-template-rows: auto minmax(0, 1fr) auto; overflow: hidden; }
     .topbar { display: flex; justify-content: space-between; align-items: center; gap: 12px; padding: 4px 2px 20px; }
     .top-left, .top-right { display: flex; align-items: center; gap: 10px; min-width: 0; }
     .round-button, .tool-button, .send-button { display: inline-flex; align-items: center; justify-content: center; border: 1px solid var(--border); background: var(--button); color: var(--text); text-decoration: none; font: inherit; font-weight: 750; }
@@ -7174,7 +7174,7 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
     .thread-title { min-width: 0; }
     .thread-title h1 { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
     .thread-title span { display: block; color: var(--muted); font-size: 13px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-    .chat-scroll { min-height: 0; overflow: auto; padding: 8px 4px var(--composer-reserve, 156px); scroll-padding-bottom: var(--composer-reserve, 156px); display: flex; flex-direction: column; gap: 22px; scrollbar-width: thin; }
+    .chat-scroll { min-height: 0; overflow: auto; padding: 8px 4px 28px; scroll-padding-bottom: 28px; display: flex; flex-direction: column; gap: 22px; scrollbar-width: thin; }
     .bubble { max-width: min(760px, 88%); color: var(--text); font-size: 17px; line-height: 1.72; }
     .bubble, .bubble p, .bubble li { overflow-wrap: anywhere; }
     .bubble strong { display: block; color: var(--muted); font-size: 12px; letter-spacing: .08em; text-transform: uppercase; margin-bottom: 8px; }
@@ -7182,9 +7182,12 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
     .bubble ul { margin: 0; padding-left: 22px; color: var(--text); line-height: 1.85; }
     .bubble.owner { align-self: flex-end; background: var(--owner-bubble); color: var(--owner-text); border-radius: 24px; padding: 12px 16px; }
     .bubble.owner p { color: var(--owner-text); margin: 0; }
+    .bubble.thinking { color: var(--muted); }
+    .thinking-dots::after { content: ""; display: inline-block; width: 1.4em; text-align: left; animation: thinkingDots 1.2s steps(4, end) infinite; }
+    @keyframes thinkingDots { 0% { content: ""; } 25% { content: "."; } 50% { content: ".."; } 75%, 100% { content: "..."; } }
     .connection-note { display: inline-flex; align-items: center; width: fit-content; border: 1px solid var(--border); border-radius: 999px; padding: 5px 10px; color: var(--muted); font-size: 13px; }
     .chat-link { color: var(--text); text-decoration-thickness: 1px; text-underline-offset: 4px; font-weight: 750; }
-    .composer { position: fixed; left: 16px; right: 354px; bottom: 0; display: grid; gap: 8px; z-index: 4; padding: 14px 0 max(16px, env(safe-area-inset-bottom)); background: var(--page-bg); }
+    .composer { min-width: 0; display: grid; gap: 8px; z-index: 4; padding: 14px 0 max(16px, env(safe-area-inset-bottom)); background: var(--page-bg); }
     .composer-box { display: grid; grid-template-columns: minmax(0, 1fr) 44px; align-items: end; gap: 8px; min-height: 62px; padding: 8px; border: 1px solid var(--border); border-radius: 28px; background: var(--panel-strong); box-shadow: 0 16px 60px var(--shadow); }
     textarea { width: 100%; min-height: 44px; max-height: 160px; border: 0; outline: 0; resize: vertical; padding: 10px 2px; color: var(--text); background: transparent; font: inherit; line-height: 1.45; }
     textarea::placeholder { color: var(--muted); }
@@ -7218,23 +7221,22 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
     }
     @media (max-width: 900px) {
       main { display: block; padding: 14px 14px 0; }
-      .app-shell { min-height: 100dvh; }
+      .app-shell { height: calc(100dvh - 14px); }
       .topbar { display: grid; grid-template-columns: minmax(0, 1fr) auto; align-items: center; }
       .sidebar { display: none; }
-      .composer { left: 14px; right: 14px; }
       .mobile-backdrop { position: fixed; inset: 0; z-index: 10; background: rgba(0, 0, 0, .38); backdrop-filter: blur(2px); }
       .mobile-drawer { position: fixed; top: 0; bottom: 0; left: 0; z-index: 11; width: min(86vw, 360px); overflow: auto; padding: max(16px, env(safe-area-inset-top)) 14px max(18px, env(safe-area-inset-bottom)); border-right: 1px solid var(--border); background: var(--panel); box-shadow: 18px 0 60px var(--shadow); }
       .menu-toggle:checked ~ .mobile-backdrop, .menu-toggle:checked ~ .mobile-drawer { display: block; }
       .mobile-drawer-header { display: flex; justify-content: space-between; align-items: center; gap: 12px; margin-bottom: 14px; }
       .mobile-drawer-content { display: grid; gap: 12px; }
-      .chat-scroll { padding-bottom: var(--composer-reserve, 170px); }
+      .chat-scroll { padding-bottom: 28px; }
       .bubble { max-width: 100%; font-size: 16px; }
       .bubble.owner { max-width: 82%; }
       .topbar { padding-bottom: 18px; }
     }
     @media (max-width: 460px) {
       main { padding: 12px 10px 0; }
-      .composer { left: 10px; right: 10px; }
+      .app-shell { height: calc(100dvh - 12px); }
       .composer-box { grid-template-columns: minmax(0, 1fr) 40px; border-radius: 24px; }
       .round-button { width: 40px; height: 40px; }
       .tool-button { min-height: 38px; padding: 0 12px; }
@@ -7396,13 +7398,15 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
       const initialMarkup = log.innerHTML;
 
       function updateComposerReserve() {
-        const reserve = Math.ceil(form.getBoundingClientRect().height + 36);
-        log.style.setProperty("--composer-reserve", reserve + "px");
+        log.style.setProperty("--composer-reserve", Math.ceil(form.getBoundingClientRect().height) + "px");
       }
 
       function scrollToLatest() {
         updateComposerReserve();
         log.scrollTop = log.scrollHeight;
+        requestAnimationFrame(() => {
+          log.scrollTop = log.scrollHeight;
+        });
       }
 
       function setStatus(text) {
@@ -7426,6 +7430,27 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
 
       function appendError(text) {
         appendMessage({ role: "butler", text });
+      }
+
+      function showThinking() {
+        const article = document.createElement("article");
+        article.className = "bubble thinking";
+        article.dataset.pending = "butler";
+        const paragraph = document.createElement("p");
+        const span = document.createElement("span");
+        span.className = "thinking-dots";
+        span.textContent = "考えています";
+        paragraph.appendChild(span);
+        article.appendChild(paragraph);
+        log.appendChild(article);
+        scrollToLatest();
+        return article;
+      }
+
+      function removeThinking(article) {
+        if (article && article.parentNode) {
+          article.parentNode.removeChild(article);
+        }
       }
 
       function renderThread(messages) {
@@ -7472,6 +7497,7 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
         const submitButton = form.querySelector("button[type='submit']");
         if (submitButton) submitButton.disabled = true;
         setStatus("送信中です。Butler が同じ thread に返信します。");
+        const thinking = showThinking();
         try {
           const response = await fetch(endpoint, {
             method: "POST",
@@ -7480,6 +7506,7 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
             body: JSON.stringify({ threadId, repository, text })
           });
           const body = await response.json().catch(() => ({}));
+          removeThinking(thinking);
           if (!response.ok || !body.ok) {
             appendError(body.reason || "送信に失敗しました。runtime truth を確認してください。");
             setStatus("送信に失敗しました。");
@@ -7491,11 +7518,12 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
           }
           setStatus("保存済み。Butler 返信を同じ thread に追加しました。");
         } catch {
+          removeThinking(thinking);
           appendError("Worker chat runtime に接続できませんでした。ネットワークまたは deploy 状態を確認してください。");
           setStatus("接続に失敗しました。");
         } finally {
           if (submitButton) submitButton.disabled = false;
-          textarea.focus();
+          textarea.focus({ preventScroll: true });
           updateComposerReserve();
         }
       });

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -374,7 +374,7 @@ test("worker serves v2 dashboard for allowed owner identity without exposing sec
   assert.equal(body.includes("必要な時だけ開く"), true);
   assert.equal(body.includes("color-scheme: light dark"), true);
   assert.equal(body.includes("prefers-color-scheme: dark"), true);
-  assert.equal(body.includes("overflow-x: hidden"), true);
+  assert.equal(body.includes("overflow: hidden"), true);
   assert.equal(body.includes("grid-template-columns: minmax(0, 1fr) auto"), true);
   assert.equal(body.includes("自動更新なし"), true);
   assert.equal(body.includes("自動更新・polling はありません"), true);
@@ -396,6 +396,15 @@ test("worker serves v2 dashboard for allowed owner identity without exposing sec
   assert.equal(body.includes("function refreshThread()"), true);
   assert.equal(body.includes("function updateComposerReserve()"), true);
   assert.equal(body.includes("function scrollToLatest()"), true);
+  assert.equal(body.includes("function showThinking()"), true);
+  assert.equal(body.includes("function removeThinking("), true);
+  assert.equal(body.includes("考えています"), true);
+  assert.equal(body.includes("thinking-dots"), true);
+  assert.equal(body.includes("grid-template-rows: auto minmax(0, 1fr) auto"), true);
+  assert.equal(body.includes("height: 100dvh"), true);
+  assert.equal(body.includes("overflow: hidden"), true);
+  assert.equal(body.includes("requestAnimationFrame"), true);
+  assert.equal(body.includes("preventScroll: true"), true);
   assert.equal(body.includes("--composer-reserve"), true);
   assert.equal(body.includes("background: var(--page-bg)"), true);
   assert.equal(body.includes('credentials: "same-origin"'), true);

--- a/worker.js
+++ b/worker.js
@@ -61974,16 +61974,16 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
       }
     }
     * { box-sizing: border-box; }
-    html, body { max-width: 100%; overflow-x: hidden; }
+    html, body { max-width: 100%; height: 100%; overflow: hidden; }
     body { margin: 0; background: var(--page-bg); }
-    main { width: 100%; min-height: 100dvh; display: grid; grid-template-columns: minmax(0, 1fr) minmax(220px, 320px); gap: 18px; padding: 16px; overflow-x: hidden; }
+    main { width: 100%; height: 100dvh; min-height: 0; display: grid; grid-template-columns: minmax(0, 1fr) minmax(220px, 320px); gap: 18px; padding: 16px; overflow: hidden; }
     h1, h2, h3, p { margin-top: 0; }
     h1 { font-size: 22px; line-height: 1.1; margin-bottom: 4px; }
     h2 { font-size: 19px; margin-bottom: 12px; }
     h3 { font-size: 15px; margin-bottom: 8px; }
     p { line-height: 1.65; color: var(--text); }
     a { color: inherit; }
-    .app-shell { min-height: calc(100dvh - 32px); display: grid; grid-template-rows: auto 1fr auto; }
+    .app-shell { height: calc(100dvh - 32px); min-height: 0; display: grid; grid-template-rows: auto minmax(0, 1fr) auto; overflow: hidden; }
     .topbar { display: flex; justify-content: space-between; align-items: center; gap: 12px; padding: 4px 2px 20px; }
     .top-left, .top-right { display: flex; align-items: center; gap: 10px; min-width: 0; }
     .round-button, .tool-button, .send-button { display: inline-flex; align-items: center; justify-content: center; border: 1px solid var(--border); background: var(--button); color: var(--text); text-decoration: none; font: inherit; font-weight: 750; }
@@ -61993,7 +61993,7 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
     .thread-title { min-width: 0; }
     .thread-title h1 { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
     .thread-title span { display: block; color: var(--muted); font-size: 13px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-    .chat-scroll { min-height: 0; overflow: auto; padding: 8px 4px var(--composer-reserve, 156px); scroll-padding-bottom: var(--composer-reserve, 156px); display: flex; flex-direction: column; gap: 22px; scrollbar-width: thin; }
+    .chat-scroll { min-height: 0; overflow: auto; padding: 8px 4px 28px; scroll-padding-bottom: 28px; display: flex; flex-direction: column; gap: 22px; scrollbar-width: thin; }
     .bubble { max-width: min(760px, 88%); color: var(--text); font-size: 17px; line-height: 1.72; }
     .bubble, .bubble p, .bubble li { overflow-wrap: anywhere; }
     .bubble strong { display: block; color: var(--muted); font-size: 12px; letter-spacing: .08em; text-transform: uppercase; margin-bottom: 8px; }
@@ -62001,9 +62001,12 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
     .bubble ul { margin: 0; padding-left: 22px; color: var(--text); line-height: 1.85; }
     .bubble.owner { align-self: flex-end; background: var(--owner-bubble); color: var(--owner-text); border-radius: 24px; padding: 12px 16px; }
     .bubble.owner p { color: var(--owner-text); margin: 0; }
+    .bubble.thinking { color: var(--muted); }
+    .thinking-dots::after { content: ""; display: inline-block; width: 1.4em; text-align: left; animation: thinkingDots 1.2s steps(4, end) infinite; }
+    @keyframes thinkingDots { 0% { content: ""; } 25% { content: "."; } 50% { content: ".."; } 75%, 100% { content: "..."; } }
     .connection-note { display: inline-flex; align-items: center; width: fit-content; border: 1px solid var(--border); border-radius: 999px; padding: 5px 10px; color: var(--muted); font-size: 13px; }
     .chat-link { color: var(--text); text-decoration-thickness: 1px; text-underline-offset: 4px; font-weight: 750; }
-    .composer { position: fixed; left: 16px; right: 354px; bottom: 0; display: grid; gap: 8px; z-index: 4; padding: 14px 0 max(16px, env(safe-area-inset-bottom)); background: var(--page-bg); }
+    .composer { min-width: 0; display: grid; gap: 8px; z-index: 4; padding: 14px 0 max(16px, env(safe-area-inset-bottom)); background: var(--page-bg); }
     .composer-box { display: grid; grid-template-columns: minmax(0, 1fr) 44px; align-items: end; gap: 8px; min-height: 62px; padding: 8px; border: 1px solid var(--border); border-radius: 28px; background: var(--panel-strong); box-shadow: 0 16px 60px var(--shadow); }
     textarea { width: 100%; min-height: 44px; max-height: 160px; border: 0; outline: 0; resize: vertical; padding: 10px 2px; color: var(--text); background: transparent; font: inherit; line-height: 1.45; }
     textarea::placeholder { color: var(--muted); }
@@ -62037,23 +62040,22 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
     }
     @media (max-width: 900px) {
       main { display: block; padding: 14px 14px 0; }
-      .app-shell { min-height: 100dvh; }
+      .app-shell { height: calc(100dvh - 14px); }
       .topbar { display: grid; grid-template-columns: minmax(0, 1fr) auto; align-items: center; }
       .sidebar { display: none; }
-      .composer { left: 14px; right: 14px; }
       .mobile-backdrop { position: fixed; inset: 0; z-index: 10; background: rgba(0, 0, 0, .38); backdrop-filter: blur(2px); }
       .mobile-drawer { position: fixed; top: 0; bottom: 0; left: 0; z-index: 11; width: min(86vw, 360px); overflow: auto; padding: max(16px, env(safe-area-inset-top)) 14px max(18px, env(safe-area-inset-bottom)); border-right: 1px solid var(--border); background: var(--panel); box-shadow: 18px 0 60px var(--shadow); }
       .menu-toggle:checked ~ .mobile-backdrop, .menu-toggle:checked ~ .mobile-drawer { display: block; }
       .mobile-drawer-header { display: flex; justify-content: space-between; align-items: center; gap: 12px; margin-bottom: 14px; }
       .mobile-drawer-content { display: grid; gap: 12px; }
-      .chat-scroll { padding-bottom: var(--composer-reserve, 170px); }
+      .chat-scroll { padding-bottom: 28px; }
       .bubble { max-width: 100%; font-size: 16px; }
       .bubble.owner { max-width: 82%; }
       .topbar { padding-bottom: 18px; }
     }
     @media (max-width: 460px) {
       main { padding: 12px 10px 0; }
-      .composer { left: 10px; right: 10px; }
+      .app-shell { height: calc(100dvh - 12px); }
       .composer-box { grid-template-columns: minmax(0, 1fr) 40px; border-radius: 24px; }
       .round-button { width: 40px; height: 40px; }
       .tool-button { min-height: 38px; padding: 0 12px; }
@@ -62215,13 +62217,15 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
       const initialMarkup = log.innerHTML;
 
       function updateComposerReserve() {
-        const reserve = Math.ceil(form.getBoundingClientRect().height + 36);
-        log.style.setProperty("--composer-reserve", reserve + "px");
+        log.style.setProperty("--composer-reserve", Math.ceil(form.getBoundingClientRect().height) + "px");
       }
 
       function scrollToLatest() {
         updateComposerReserve();
         log.scrollTop = log.scrollHeight;
+        requestAnimationFrame(() => {
+          log.scrollTop = log.scrollHeight;
+        });
       }
 
       function setStatus(text) {
@@ -62245,6 +62249,27 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
 
       function appendError(text) {
         appendMessage({ role: "butler", text });
+      }
+
+      function showThinking() {
+        const article = document.createElement("article");
+        article.className = "bubble thinking";
+        article.dataset.pending = "butler";
+        const paragraph = document.createElement("p");
+        const span = document.createElement("span");
+        span.className = "thinking-dots";
+        span.textContent = "\u8003\u3048\u3066\u3044\u307E\u3059";
+        paragraph.appendChild(span);
+        article.appendChild(paragraph);
+        log.appendChild(article);
+        scrollToLatest();
+        return article;
+      }
+
+      function removeThinking(article) {
+        if (article && article.parentNode) {
+          article.parentNode.removeChild(article);
+        }
       }
 
       function renderThread(messages) {
@@ -62291,6 +62316,7 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
         const submitButton = form.querySelector("button[type='submit']");
         if (submitButton) submitButton.disabled = true;
         setStatus("\u9001\u4FE1\u4E2D\u3067\u3059\u3002Butler \u304C\u540C\u3058 thread \u306B\u8FD4\u4FE1\u3057\u307E\u3059\u3002");
+        const thinking = showThinking();
         try {
           const response = await fetch(endpoint, {
             method: "POST",
@@ -62299,6 +62325,7 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
             body: JSON.stringify({ threadId, repository, text })
           });
           const body = await response.json().catch(() => ({}));
+          removeThinking(thinking);
           if (!response.ok || !body.ok) {
             appendError(body.reason || "\u9001\u4FE1\u306B\u5931\u6557\u3057\u307E\u3057\u305F\u3002runtime truth \u3092\u78BA\u8A8D\u3057\u3066\u304F\u3060\u3055\u3044\u3002");
             setStatus("\u9001\u4FE1\u306B\u5931\u6557\u3057\u307E\u3057\u305F\u3002");
@@ -62310,11 +62337,12 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
           }
           setStatus("\u4FDD\u5B58\u6E08\u307F\u3002Butler \u8FD4\u4FE1\u3092\u540C\u3058 thread \u306B\u8FFD\u52A0\u3057\u307E\u3057\u305F\u3002");
         } catch {
+          removeThinking(thinking);
           appendError("Worker chat runtime \u306B\u63A5\u7D9A\u3067\u304D\u307E\u305B\u3093\u3067\u3057\u305F\u3002\u30CD\u30C3\u30C8\u30EF\u30FC\u30AF\u307E\u305F\u306F deploy \u72B6\u614B\u3092\u78BA\u8A8D\u3057\u3066\u304F\u3060\u3055\u3044\u3002");
           setStatus("\u63A5\u7D9A\u306B\u5931\u6557\u3057\u307E\u3057\u305F\u3002");
         } finally {
           if (submitButton) submitButton.disabled = false;
-          textarea.focus();
+          textarea.focus({ preventScroll: true });
           updateComposerReserve();
         }
       });


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #450 の live dashboard E2E で、iPhone 送信後の最新 turn が入力欄に半分隠れ、ChatGPT / Custom GPT のように「常にチャット下」へ来ない問題を修正します。
- fixed composer と body scroll の組み合わせをやめ、dashboard を `header / scrollable chat / composer` の 3 段 layout にして、composer を layout 内の下段として扱います。
- 送信直後に `考えています...` の pending Butler bubble を出し、応答または失敗時に置き換えます。

## Satisfied Success Criteria

- iPhone 幅で、最新 owner message / Butler reply が composer の上に読める位置へ来るようにしました。
- page 全体ではなく chat log を scroll container にし、`requestAnimationFrame` で layout 後にも末尾へ寄せます。
- 送信後の focus scroll が画面を崩さないよう `preventScroll: true` を使います。
- 待機中は `考えています` の pending bubble を表示し、固まって見える状態を避けます。
- test で 3 段 layout、overflow 固定、pending bubble、latest scroll helper を確認しました。

## Unsatisfied Success Criteria

- 本番 dashboard へは未デプロイです。merge 後に deploy_production 承認と live iPhone E2E が必要です。
- owner の実ブラウザで、送信直後に最新 turn が composer 上へ来ること、`考えています` が出ることをまだ再確認していません。
- 通常テキスト送信は deterministic Butler reply です。VPS Codex CLI handoff は issueNumber と明示 handoff がある別 gate であり、通常送信が常に VPS へ行くわけではありません。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #450
- Implementing Success Criteria: dashboard chat surface の最新 turn が入力欄に隠れず、ChatGPT 型に下端へ揃うこと。待機中 state が見えること。
- Explicit Non-goals: 実 LLM reply、通常送信の常時 VPS dispatch、完全双方向 VPS streaming、画像追加、音声入力、file upload。
- Expected touched files/routes/workflows: `src/worker/runtime.js`, `worker.js`, `test/worker.test.js`; route と workflow は変更なし。
- Affected Issues: #450。
- Affected PRs: #463/#464 の live E2E follow-up。
- Affected workflows: CI test / generated worker check のみ。
- Affected runtime/operator surfaces: Cloudflare Worker dashboard, mobile Butler chat surface。
- What may break if we patch narrowly: body scroll と inner scroll が混在すると Safari の address bar / focus scroll で再発します。body/main/app-shell を fixed-height layout にして chat log だけを scroll させます。
- Unknowns to investigate before coding: owner iPhone の Safari / in-app browser で `100dvh` と keyboard focus が期待通り動くかは deploy 後 live E2E が必要です。
- Validation needed: `npm test`, deploy 後の iPhone dashboard live E2E。
- Stop condition: 通常会話を常時 VPS Codex CLI dispatch に変える場合は authority boundary と Issue scope が変わるため、この UI 修正 PR では実装しません。

## File / Line Hypotheses

- file: `src/worker/runtime.js`
  - hypothesis: fixed composer が viewport に重なり、Safari が body を scroll しているため、chat log の `scrollTop` だけでは最新 turn が入力欄の上へ来ない。
  - risk if changed narrowly: padding reserve を増やしても keyboard / toolbar / focus scroll で再発する。
  - validation: app-shell を `auto minmax(0,1fr) auto` にして、composer を layout 下段へ置き、test marker で固定する。
  - related Issue: #450
- file: `test/worker.test.js`
  - hypothesis: 既存 test は endpoint 接続と reserve marker は見ているが、3 段 chat layout と pending state を固定していない。
  - risk if changed narrowly: API は動くが iPhone 実画面で読めない状態を再発させる。
  - validation: `grid-template-rows: auto minmax(0, 1fr) auto`, `overflow: hidden`, `showThinking`, `考えています`, `preventScroll` を確認する。
  - related Issue: #450

## Hypothesis Retrospective

- expected: composer を fixed overlay から layout 下段に戻し、chat log だけを scroll container にすると、最新 turn が ChatGPT 型に composer 上へ来る。
- actual: runtime code と generated worker を更新し、pending bubble も追加しました。full test は通過しました。
- mismatch: owner iPhone の live E2E は deploy 後に必要です。
- lesson: dashboard chat completion は API append だけでは足りない。mobile Safari の visual position と waiting state まで確認する。
- should become RAG candidate: はい。#450 dashboard chat は mobile bottom alignment と pending state を E2E 条件に含める。

## Verification Evidence

- Unit: `node --test test/worker.test.js` passed. 148 tests, 148 pass.
- Integration: `npm test` passed. 870 tests, 869 pass, 1 skipped, 0 fail.
- E2E: 未実施。本番 deploy 後に owner iPhone dashboard で最新 turn と pending state を確認する必要があります。
- Manual: owner 提供スクリーンショットで、#464 deploy 後も latest owner bubble が composer に隠れることを確認。
- Evidence path/link: `src/worker/runtime.js`, `worker.js`, `test/worker.test.js`, Issue #450

## Butler Completion Contract

- Owner goal: dashboard Butler chat が ChatGPT / Custom GPT と同じように、送信後に最新 turn を入力欄の上で読める状態にする。
- Butler entrypoint: `/dashboard` の `#butler-chat-form`。
- Action Schema exposure: 不要。この PR は Custom GPT Action Schema を変更しません。
- Runtime path: `/dashboard` HTML -> same-origin chat API -> pending bubble -> in-page append -> chat-log bottom scroll。
- Runner/runtime truth: tests は通過。本番 runtime truth と owner mobile E2E は deploy 後に確認が必要です。
- Authority boundary: 変更なし。通常 text send は Worker chat runtime。VPS Codex CLI handoff は既存の別 gate / issueNumber / authority boundary を維持します。
- E2E evidence: 未完了。本番 deploy 後の owner dashboard E2E が必要です。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 必要。merge 後、`deploy_production` の scoped passkey approval が必要です。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 必要。最新 turn が composer 上へ来ること、`考えています` が表示されることを確認します。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate
- AGENTS.md Butler-First Operating Principle
- AGENTS.md Drift Stop Protocol
- AGENTS.md Evidence Discipline
- AGENTS.md Conversation UX Contract

## Out-of-scope but NOT implemented

- 画像追加 / file upload
- マイク入力 / 音声 overlay
- 実 LLM reply
- 通常送信の常時 VPS Codex CLI dispatch
- 完全双方向 VPS Codex CLI streaming

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #450
- Execution ID: mac_codex_issue_450_chat_bottom_layout
- Goal: iPhone dashboard Butler chat の bottom alignment と pending state 修正
