### PR TITLE
Fix dashboard chat VPS WebSocket truth

### DIFF
--- a/scripts/run-vps-runner.mjs
+++ b/scripts/run-vps-runner.mjs
@@ -182,6 +182,17 @@ async function executeVpsRunnerExecution({
   });
 
   try {
+    if (isDashboardChatTriageGoal(payload.codexGoal)) {
+      return executeVpsDashboardChatTriage({
+        githubFetch,
+        payload,
+        notification,
+        workRoot,
+        env,
+        issue
+      });
+    }
+
     if (isPostMergeVerificationGoal(payload.codexGoal)) {
       return executeVpsPostMergeVerification({
         githubFetch,
@@ -477,6 +488,121 @@ async function executeVpsPostMergeVerification({
       ? `Post-merge verification completed for ${payload.repository}#${result.pullRequest.number}.`
       : result.reason
   };
+}
+
+async function executeVpsDashboardChatTriage({ githubFetch, payload, notification, workRoot, env, issue }) {
+  await assertVpsRunnerNotCanceled({ githubFetch, payload, checkpoint: "before_triage_clone", notification });
+  const workspace = path.join(workRoot, safePathSegment(payload.repository), payload.executionId);
+  await fs.mkdir(path.dirname(workspace), { recursive: true });
+  await runCommand("rm", ["-rf", workspace], { env });
+  await runTrackedVpsCommand("gh", ["repo", "clone", payload.repository, workspace], {
+    env,
+    githubFetch,
+    payload,
+    notification,
+    currentStep: "dashboard_chat_repo_clone"
+  });
+  const preflight = await buildVpsRunnerPreflightReceipt({
+    workspace,
+    payload,
+    issue
+  });
+  await postVpsRunnerEvent({
+    githubFetch,
+    payload,
+    notification,
+    event: {
+      status: preflight.ok ? "running" : "blocked",
+      lastEvent: preflight.ok ? "context_preflight_completed" : "context_preflight_blocked",
+      currentStep: "context_preflight",
+      preflight
+    }
+  });
+  if (!preflight.ok) {
+    return {
+      ok: false,
+      reason:
+        preflight.reason ||
+        "VPS runner preflight receipt could not be created. Butler/owner decision is required before dashboard chat triage."
+    };
+  }
+  await assertVpsRunnerNotCanceled({ githubFetch, payload, checkpoint: "before_triage_codex", notification });
+  const prompt = buildDashboardChatTriagePrompt({ payload, issue, preflight });
+  const result = await runTrackedVpsCommand("codex", buildCodexExecArgs({ env: process.env }), {
+    cwd: workspace,
+    env: buildCodexExecutionEnv(process.env),
+    input: prompt,
+    maxBuffer: 1024 * 1024 * 12,
+    githubFetch,
+    payload,
+    notification,
+    currentStep: "dashboard_chat_triage"
+  });
+  await assertVpsRunnerNotCanceled({ githubFetch, payload, checkpoint: "after_triage_codex", notification });
+  const reply = summarizeDiagnosticText(result.stdout || result.stderr || "VPS Codex CLI completed dashboard chat triage.", 4000);
+  await postVpsRunnerEvent({
+    githubFetch,
+    payload,
+    notification,
+    event: {
+      status: "completed",
+      lastEvent: "dashboard_chat_triage_completed",
+      finalEvent: "dashboard_chat_triage_completed",
+      currentStep: "dashboard_chat_triage",
+      message: reply
+    }
+  });
+  return { ok: true, message: reply };
+}
+
+function buildDashboardChatTriagePrompt({ payload, issue = {}, preflight = null }) {
+  const handoff = payload?.handoff && typeof payload.handoff === "object" ? payload.handoff : {};
+  const ownerMessage = normalizeText(handoff.ownerMessage);
+  const repositoryInput = normalizeText(handoff.repositoryInput) || normalizeText(payload.repository);
+  return [
+    `You are VTDD Butler traffic control running on the user's VPS Codex CLI for ${payload.repository}.`,
+    "",
+    "Owner dashboard message:",
+    ownerMessage || "(missing dashboard owner message)",
+    "",
+    "Resolved target:",
+    `- repositoryInput: ${repositoryInput || "missing"}`,
+    `- repository: ${payload.repository}`,
+    `- queue issue: #${payload.issueNumber}`,
+    `- dashboardThreadId: ${normalizeText(handoff.dashboardThreadId) || "missing"}`,
+    "",
+    "Custom GPT parity requirement:",
+    "- Preserve every owner-facing capability that the Custom GPT Butler had.",
+    "- Treat the top dashboard chat as the natural-language Butler entrypoint, not as an open_pr form.",
+    "- Resolve repository/nickname intent before acting. If the target is ambiguous, ask one short Japanese confirmation question.",
+    "- Read GitHub runtime truth when the owner asks about Issues, PRs, checks, Actions, deploys, reviews, or remaining work.",
+    "- Use repository nickname semantics: no default repository, unresolved target blocks execution, ambiguous nickname blocks execution.",
+    "- Triage broad owner input into: answer from runtime truth, Issue split proposal, existing Issue linkage, bounded VPS execution handoff, approval URL needed, RAG candidate, or blocker.",
+    "- If Issue creation/splitting is needed, propose concrete Japanese Issue titles/bodies and say what approval/GO is needed; do not silently create or close Issues.",
+    "- If implementation is needed, name the target Issue/scope and required GO/passkey boundary before any execution.",
+    "- If deploy, merge, credential, permission, repository settings, destructive cleanup, or Issue close is requested, return the needed governed approval boundary instead of doing it.",
+    "- Never invent VPS replies. Return only what you can justify from repo/runtime truth and this dashboard message.",
+    "",
+    "Available local context:",
+    "- You are inside a fresh clone of the target repository.",
+    "- You may inspect files and use GitHub CLI/API if available to read runtime truth.",
+    "- Do not edit files, commit, push, create PRs, merge, deploy, mutate secrets, mutate permissions, or close Issues in dashboard_chat_triage.",
+    "",
+    "Context preflight receipt:",
+    formatVpsRunnerPreflightReceipt(preflight),
+    "",
+    "Queue Issue context:",
+    `Title: ${normalizeText(issue.title) || "(missing issue title)"}`,
+    "",
+    normalizeText(issue.body) || "(missing issue body)",
+    "",
+    "Reply format:",
+    "- Japanese first.",
+    "- Be concise but operational.",
+    "- Include the classification: answer / issue_split_proposal / existing_issue_link / execution_handoff_needed / approval_needed / rag_candidate / blocker.",
+    "- Include next action and any missing information.",
+    "- If you mention a GitHub item, include a clickable URL if known."
+  ].join("\n");
 }
 
 async function collectVpsPostMergeVerification({ githubFetch, payload, repositoryPolicies, env }) {
@@ -1214,6 +1340,10 @@ function formatVpsRunnerPreflightReceipt(preflight) {
 
 function isPrRevisionGoal(goal) {
   return ["revise_pr", "respond_to_review"].includes(normalizeText(goal));
+}
+
+function isDashboardChatTriageGoal(goal) {
+  return normalizeText(goal) === "dashboard_chat_triage";
 }
 
 function isPostMergeVerificationGoal(goal) {
@@ -2501,6 +2631,7 @@ export {
   buildFreshExecutionBranchCandidates,
   buildVpsRunnerCompletionFinalEvent,
   buildCodexExecutionPrompt,
+  buildDashboardChatTriagePrompt,
   buildCodexExecArgs,
   buildVpsRunnerPreflightReceipt,
   buildGuardedPullRequestBody,

--- a/src/core/remote-codex-executor.js
+++ b/src/core/remote-codex-executor.js
@@ -76,6 +76,7 @@ export const VpsRunnerCancelMode = Object.freeze({
 });
 
 export const RemoteCodexDispatchGoal = Object.freeze({
+  DASHBOARD_CHAT_TRIAGE: "dashboard_chat_triage",
   OPEN_PR: "open_pr",
   REVISE_PR: "revise_pr",
   RESPOND_TO_REVIEW: "respond_to_review",
@@ -150,7 +151,7 @@ export function createRemoteCodexExecutionRequest(input = {}) {
       relatedIssue: issueNumber,
       issueTraceable: issueNumber > 0
     },
-    preflightPolicy: buildExecutionPreflightPolicy(),
+    preflightPolicy: buildExecutionPreflightPolicy({ codexGoal }),
     handoffRequired: continuationContext.requiresHandoff === true,
     revisionTarget,
     handoff:
@@ -160,6 +161,8 @@ export function createRemoteCodexExecutionRequest(input = {}) {
             approvalScopeMatched: handoff.approvalScopeMatched === true,
             summary: normalizeText(handoff.summary),
             relatedIssue: normalizePositiveInteger(handoff.relatedIssue),
+            ownerMessage: normalizeText(handoff.ownerMessage),
+            repositoryInput: normalizeText(handoff.repositoryInput),
             dashboardThreadId: normalizeText(handoff.dashboardThreadId),
             targetPullRequest: revisionTarget
           }
@@ -182,7 +185,7 @@ export function createRemoteCodexExecutionRequest(input = {}) {
   if (!request.codexGoal) {
     issues.push("codexGoal is required");
   } else if (!REMOTE_CODEX_DISPATCH_GOALS.has(request.codexGoal)) {
-    issues.push("codexGoal must be open_pr, revise_pr, respond_to_review, or post_merge_verify");
+    issues.push("codexGoal must be dashboard_chat_triage, open_pr, revise_pr, respond_to_review, or post_merge_verify");
   }
   if (!request.baseRef) {
     issues.push("baseRef is required");
@@ -1966,6 +1969,7 @@ function buildCodexCloudGitHubComment({ request }) {
 }
 
 function buildVpsRunnerGitHubQueueComment({ request }) {
+  const isDashboardChatTriage = request.codexGoal === RemoteCodexDispatchGoal.DASHBOARD_CHAT_TRIAGE;
   const payload = {
     executionId: request.executionId,
     transport: RemoteCodexExecutorTransport.VPS_RUNNER,
@@ -2010,16 +2014,26 @@ function buildVpsRunnerGitHubQueueComment({ request }) {
       : []),
     "- Canonical spec: this GitHub Issue",
     "- Runtime truth: current GitHub branch / diff / PR / review comments",
-    request.codexGoal === RemoteCodexDispatchGoal.POST_MERGE_VERIFY
-      ? "- Completion target: verify post-merge runtime truth and post GitHub-visible evidence"
-      : "- Completion target: create or update a pull request",
-    "- PR body requirement: Codex must inspect `docs/pr-template-model.md`, `scripts/render-pr-body.mjs`, and `scripts/validate-pr-body.mjs`; the VPS runner will validate and normalize the PR body again before create/update.",
-    "- Context preflight requirement: the VPS runner will automatically read `AGENTS.md`, `docs/butler/thread-independent-startup-contract.md`, the canonical Issue, and the PR body contract files, then generate a machine-readable preflight receipt before Codex starts editing.",
+    isDashboardChatTriage
+      ? "- Completion target: post a dashboard chat triage response to the same thread"
+      : request.codexGoal === RemoteCodexDispatchGoal.POST_MERGE_VERIFY
+        ? "- Completion target: verify post-merge runtime truth and post GitHub-visible evidence"
+        : "- Completion target: create or update a pull request",
+    ...(isDashboardChatTriage
+      ? [
+          "- PR body requirement: not applicable; dashboard chat triage must not create or update a PR.",
+          "- Context preflight requirement: the VPS runner will automatically read `AGENTS.md`, `docs/butler/thread-independent-startup-contract.md`, and the canonical Issue, then generate a machine-readable preflight receipt before Codex starts triage."
+        ]
+      : [
+          "- PR body requirement: Codex must inspect `docs/pr-template-model.md`, `scripts/render-pr-body.mjs`, and `scripts/validate-pr-body.mjs`; the VPS runner will validate and normalize the PR body again before create/update.",
+          "- Context preflight requirement: the VPS runner will automatically read `AGENTS.md`, `docs/butler/thread-independent-startup-contract.md`, the canonical Issue, and the PR body contract files, then generate a machine-readable preflight receipt before Codex starts editing.",
+          "- Required PR body markers: `## This PR satisfies Intent`, `## Satisfied Success Criteria`, `## Unsatisfied Success Criteria`, `## Verification Evidence`, `## Surface Update Checklist`."
+        ]),
     "- Missing preflight inputs do not authorize speculative implementation; the runner must ask Butler/owner to confirm the next action, then wait for a reissued bounded request.",
-    "- Required PR body markers: `## This PR satisfies Intent`, `## Satisfied Success Criteria`, `## Unsatisfied Success Criteria`, `## Verification Evidence`, `## Surface Update Checklist`.",
     "",
     "Rules:",
     "- Do not expand scope beyond the Issue.",
+    ...(isDashboardChatTriage ? ["- Do not edit files.", "- Do not commit.", "- Do not push.", "- Do not create or update PRs."] : []),
     "- Do not merge.",
     "- Do not deploy.",
     "- Preserve reviewer objections for Butler/human judgment.",
@@ -2032,17 +2046,22 @@ function buildVpsRunnerGitHubQueueComment({ request }) {
   return lines.join("\n");
 }
 
-function buildExecutionPreflightPolicy() {
-  return {
-    mode: "auto_receipt",
-    onMissingContract: "owner_decision_required",
-    requiredRepoFiles: [
-      "AGENTS.md",
-      "docs/butler/thread-independent-startup-contract.md",
+function buildExecutionPreflightPolicy({ codexGoal } = {}) {
+  const requiredRepoFiles = [
+    "AGENTS.md",
+    "docs/butler/thread-independent-startup-contract.md"
+  ];
+  if (codexGoal !== RemoteCodexDispatchGoal.DASHBOARD_CHAT_TRIAGE) {
+    requiredRepoFiles.push(
       "docs/pr-template-model.md",
       "scripts/render-pr-body.mjs",
       "scripts/validate-pr-body.mjs"
-    ]
+    );
+  }
+  return {
+    mode: "auto_receipt",
+    onMissingContract: "owner_decision_required",
+    requiredRepoFiles
   };
 }
 

--- a/src/worker.js
+++ b/src/worker.js
@@ -1,3 +1,5 @@
 import worker from "./worker/runtime.js";
 
+export { DashboardChatRoom } from "./worker/runtime.js";
+
 export default worker;

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -299,6 +299,7 @@ export default {
         200,
         await renderV2DashboardPage({
           runtimeOrigin: url.origin,
+          url,
           dashboardEventStore: resolveDashboardEventStore(env)
         })
       );
@@ -3322,8 +3323,27 @@ async function handleDashboardChatMessageRequest(request, env) {
 
   const payload = await readJson(request);
   const wantsVpsRunnerHandoff = shouldDispatchDashboardChatToVpsRunner(payload);
+  const repositoryResolution = await resolveDashboardChatRepository({ payload, env });
+  if (!repositoryResolution.ok) {
+    return json(repositoryResolution.status ?? 422, {
+      ok: false,
+      error: repositoryResolution.error,
+      reason: repositoryResolution.reason,
+      issues: repositoryResolution.issues ?? [],
+      candidates: repositoryResolution.candidates ?? []
+    });
+  }
 
-  const prepared = buildDashboardChatTurn(payload, { wantsVpsRunnerHandoff });
+  const prepared = buildDashboardChatTurn(
+    {
+      ...payload,
+      repository: repositoryResolution.repository,
+      relatedIssue:
+        normalizePositiveInteger(payload?.relatedIssue || payload?.issueNumber) ||
+        extractIssueNumberFromDashboardChatText(payload?.text || payload?.message || payload?.body)
+    },
+    { wantsVpsRunnerHandoff }
+  );
   if (!prepared.ok) {
     return json(422, {
       ok: false,
@@ -3344,7 +3364,7 @@ async function handleDashboardChatMessageRequest(request, env) {
   let execution = null;
   let messagesToStore = prepared.messages;
   if (wantsVpsRunnerHandoff) {
-    const handoffPayload = buildDashboardVpsRunnerHandoffPayload({ payload, prepared });
+    const handoffPayload = buildDashboardVpsRunnerHandoffPayload({ payload, prepared, env });
     if (!handoffPayload.ok) {
       return json(422, {
         ok: false,
@@ -5012,6 +5032,58 @@ function resolveDashboardChatRoomStub(env, threadId) {
   return null;
 }
 
+async function resolveDashboardChatRepository({ payload, env }) {
+  const input = normalizeObject(payload);
+  const rawRepositoryInput =
+    normalizeDashboardEventText(input.repository || input.repositoryInput || input.repository_input) ||
+    extractRepositoryTokenFromDashboardChatText(input.text || input.message || input.body);
+  const canonicalRepository = normalizeCanonicalRepositoryInput(rawRepositoryInput);
+  if (canonicalRepository) {
+    return {
+      ok: true,
+      repository: canonicalRepository,
+      input: rawRepositoryInput,
+      via: "canonical"
+    };
+  }
+  if (!rawRepositoryInput) {
+    return {
+      ok: false,
+      status: 422,
+      error: "repository_required",
+      reason: "repository or repository nickname is required before dashboard can hand off to VPS Codex CLI",
+      issues: ["top chat must include a repository target or open the dashboard with repositoryInput"]
+    };
+  }
+
+  const provider = resolveMemoryProvider(env);
+  const registryResult = await safeRetrieveStoredAliasRegistry(provider);
+  const aliasRegistry = registryResult.ok ? registryResult.aliasRegistry : [];
+  const resolved = resolveRepositoryTarget({
+    input: rawRepositoryInput,
+    mode: TaskMode.EXECUTION,
+    aliasRegistry
+  });
+  if (resolved.resolved) {
+    return {
+      ok: true,
+      repository: resolved.repository,
+      input: rawRepositoryInput,
+      via: resolved.via || "alias"
+    };
+  }
+  return {
+    ok: false,
+    status: resolved.ambiguous ? 409 : 422,
+    error: resolved.ambiguous ? "repository_nickname_ambiguous" : "repository_unresolved",
+    reason: resolved.reason || "repository could not be resolved",
+    issues: registryResult.ok
+      ? ["repository nickname could not be resolved"]
+      : [registryResult.reason || "repository nickname registry could not be read"],
+    candidates: resolved.candidates || []
+  };
+}
+
 async function notifyDashboardChatRoom({ env, threadId, messages }) {
   const room = resolveDashboardChatRoomStub(env, threadId);
   if (!room || typeof room.fetch !== "function") {
@@ -5030,6 +5102,29 @@ async function notifyDashboardChatRoom({ env, threadId, messages }) {
   } catch {
     return false;
   }
+}
+
+function extractRepositoryTokenFromDashboardChatText(value) {
+  const text = sanitizeDashboardChatText(value);
+  if (!text) {
+    return "";
+  }
+  const canonicalMatch = text.match(/^[\s　]*([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)/);
+  if (canonicalMatch) {
+    return canonicalMatch[1];
+  }
+  const nicknameMatch = text.match(/^[\s　]*([^\s　#「『【\\/:]+)(?:\s+|[　]*の|[　]*を|[　]*で|[　]*に)/u);
+  return normalizeDashboardEventText(nicknameMatch?.[1]);
+}
+
+function extractIssueNumberFromDashboardChatText(value) {
+  const text = sanitizeDashboardChatText(value);
+  const match = text.match(/#([1-9][0-9]*)/);
+  return normalizePositiveInteger(match?.[1]);
+}
+
+function normalizeDashboardRepositoryInput(value) {
+  return normalizeDashboardEventText(value).toLowerCase();
 }
 
 function createD1DashboardEventStore(d1) {
@@ -5350,20 +5445,22 @@ function shouldDispatchDashboardChatToVpsRunner(payload) {
   );
 }
 
-function buildDashboardVpsRunnerHandoffPayload({ payload, prepared }) {
+function buildDashboardVpsRunnerHandoffPayload({ payload, prepared, env }) {
   const input = normalizeObject(payload);
   const issueNumber =
-    normalizePositiveInteger(input.issueNumber || input.relatedIssue) || prepared.relatedIssue;
+    normalizePositiveInteger(input.issueNumber || input.relatedIssue) ||
+    prepared.relatedIssue ||
+    normalizePositiveInteger(env?.VTDD_DASHBOARD_CHAT_TRIAGE_ISSUE_NUMBER);
   if (!issueNumber) {
     return {
       ok: false,
       error: "dashboard_vps_runner_issue_required",
-      reason: "issueNumber is required before dashboard can hand off a message to VPS Codex CLI",
-      issues: ["dashboard VPS runner handoff requires a GitHub Issue number"]
+      reason: "issueNumber or VTDD_DASHBOARD_CHAT_TRIAGE_ISSUE_NUMBER is required before dashboard can hand off a message to VPS Codex CLI",
+      issues: ["dashboard VPS runner handoff requires a GitHub Issue queue target"]
     };
   }
 
-  const codexGoal = normalizeDashboardEventText(input.codexGoal || input.goal || "open_pr").toLowerCase();
+  const codexGoal = normalizeDashboardEventText(input.codexGoal || input.goal || "dashboard_chat_triage").toLowerCase();
   const branch =
     normalizeDashboardEventText(input.branch || input.targetBranch) ||
     `codex/issue-${issueNumber}-dashboard-vps-chat`;
@@ -5387,6 +5484,10 @@ function buildDashboardVpsRunnerHandoffPayload({ payload, prepared }) {
           approvalScopeMatched: true,
           relatedIssue: issueNumber,
           summary,
+          ownerMessage: sanitizeDashboardChatText(input.text || input.message || input.body),
+          repositoryInput: normalizeDashboardRepositoryInput(
+            input.repositoryInput || input.repository_input || input.repository || prepared.repository
+          ),
           dashboardThreadId: prepared.threadId
         }
       },
@@ -7254,17 +7355,20 @@ function uniqueTextList(value) {
   return [...new Set(normalizeTextList(value))];
 }
 
-async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}) {
+async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore } = {}) {
   const origin = normalize(runtimeOrigin);
-  const repository = "marushu/vtdd-v2-p";
-  const encodedRepository = encodeURIComponent(repository);
-  const dashboardChatIssueNumber = 450;
-  const chatThreadId = `dashboard-main-${repository.replace("/", "-")}`;
+  const repositoryInput = normalizeDashboardRepositoryInput(
+    url?.searchParams?.get("repositoryInput") || url?.searchParams?.get("repository")
+  );
+  const dashboardIssueNumber = normalizePositiveInteger(url?.searchParams?.get("issueNumber"));
+  const dashboardTargetLabel = repositoryInput || "repo/nickname 未指定";
+  const encodedRepository = encodeURIComponent(repositoryInput);
+  const chatThreadId = `dashboard-main-${(repositoryInput || "unresolved").replace(/[^a-z0-9_.-]+/gi, "-")}`;
   const socketOrigin = origin.replace(/^http/i, "ws");
   const latestDeployEvent = await retrieveLatestDashboardEvent({
     store: dashboardEventStore,
     kind: "github_actions_workflow_run",
-    repository,
+    repository: normalizeCanonicalRepositoryInput(repositoryInput),
     workflowName: "deploy-production"
   });
   const surfaces = [
@@ -7486,7 +7590,7 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
           <label class="round-button menu-open" for="mobile-menu-toggle" aria-label="管理メニューを開く">≡</label>
           <div class="thread-title">
             <h1>VTDD Butler</h1>
-            <span>${escapeDashboardHtml(repository)} ・ dashboard main chat</span>
+            <span>${escapeDashboardHtml(dashboardTargetLabel)} ・ dashboard main chat</span>
           </div>
         </div>
         <div class="top-right">
@@ -7538,9 +7642,8 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
           <p>はい。私は v2 の Butler として、Issue 駆動・GitHub runtime truth・VPS runner・Gemini reviewer・RAG・passkey 境界を扱います。</p>
           <p>この画面は会話を主役にするための chat-first runtime です。管理画面は右のサイドバーへ退避しました。</p>
           <ul>
-            <li>関連 repo: <code>${escapeDashboardHtml(repository)}</code></li>
-            <li>Issue 候補: #433 の継続スライス</li>
-            <li>会話: この画面から送信すると、同じ thread に Butler 返信が残ります</li>
+            <li>関連 repo/nickname: <code>${escapeDashboardHtml(dashboardTargetLabel)}</code></li>
+            <li>会話: この画面から送信すると、VPS Codex CLI が repo 解決・Issue/PR/RAG/進捗/承認境界を交通整理します</li>
           </ul>
         </article>
         <article class="bubble owner">
@@ -7549,13 +7652,13 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
         <article class="bubble">
           <strong>Butler</strong>
           <p>その方針で進めます。中央はチャットだけ、状態確認・進捗・RAG・workflow・prototype cleanup の扱いはサイドバーのメニューから必要な時だけ開きます。</p>
-          <p>この dashboard からの送信は Issue #${dashboardChatIssueNumber} の VPS Codex CLI queue に渡します。返信として表示するのは runner から戻った event post だけです。</p>
+          <p>この dashboard からの送信は VPS Codex CLI の dashboard chat triage queue に渡します。返信として表示するのは runner から戻った event post だけです。</p>
           <span class="connection-note">接続済み: WebSocket で runner event post を待ちます</span>
         </article>
 
       </div>
 
-      <form class="composer" id="butler-chat-form" aria-label="Butler composer" data-endpoint="${escapeDashboardHtml(origin)}/v2/dashboard/chat/messages" data-thread-endpoint="${escapeDashboardHtml(origin)}/v2/dashboard/chat/${escapeDashboardHtml(chatThreadId)}" data-socket-endpoint="${escapeDashboardHtml(socketOrigin)}/v2/dashboard/chat/${escapeDashboardHtml(chatThreadId)}/ws" data-thread-id="${escapeDashboardHtml(chatThreadId)}" data-repository="${escapeDashboardHtml(repository)}" data-issue-number="${dashboardChatIssueNumber}" data-dispatch-to-vps-runner="true" data-codex-goal="open_pr">
+      <form class="composer" id="butler-chat-form" aria-label="Butler composer" data-endpoint="${escapeDashboardHtml(origin)}/v2/dashboard/chat/messages" data-thread-endpoint="${escapeDashboardHtml(origin)}/v2/dashboard/chat/${escapeDashboardHtml(chatThreadId)}" data-socket-endpoint="${escapeDashboardHtml(socketOrigin)}/v2/dashboard/chat/${escapeDashboardHtml(chatThreadId)}/ws" data-thread-id="${escapeDashboardHtml(chatThreadId)}" data-repository-input="${escapeDashboardHtml(repositoryInput)}" data-issue-number="${dashboardIssueNumber || ""}" data-dispatch-to-vps-runner="true" data-codex-goal="dashboard_chat_triage">
         <div class="composer-box">
           <textarea id="butler-message" name="text" placeholder="Butler V2 にメッセージ..." aria-label="Butler V2 にメッセージ"></textarea>
           <button class="send-button" type="submit" aria-label="Butler に送信">↑</button>
@@ -7577,13 +7680,13 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
 
         <div class="lane">
           <div class="lane-title"><h3>関連 repo</h3><span class="pill">resolved</span></div>
-          <p><strong>${escapeDashboardHtml(repository)}</strong></p>
+          <p><strong>${escapeDashboardHtml(dashboardTargetLabel)}</strong></p>
           <p class="muted">nickname / startup preflight / GitHub runtime truth は既存 v2 route で確認します。</p>
         </div>
 
         <div class="lane">
           <div class="lane-title"><h3>Issue 候補</h3><span class="pill">draft</span></div>
-          <p>会話入口の UI は Issue #433 として固定済み。本物の双方向チャット、音声 overlay、ファイル upload は別 Issue です。</p>
+          <p>トップチャットは Custom GPT 相当の自然文入口です。repo/nickname 解決、Issue/PR/RAG/進捗/承認境界を VPS Codex CLI に交通整理させます。</p>
         </div>
 
         <div class="lane">
@@ -7628,10 +7731,10 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
       const threadEndpoint = form.dataset.threadEndpoint;
       const socketEndpoint = form.dataset.socketEndpoint;
       const threadId = form.dataset.threadId;
-      const repository = form.dataset.repository;
+      const repositoryInput = form.dataset.repositoryInput;
       const issueNumber = Number.parseInt(form.dataset.issueNumber || "", 10);
       const dispatchToVpsRunner = form.dataset.dispatchToVpsRunner === "true";
-      const codexGoal = form.dataset.codexGoal || "open_pr";
+      const codexGoal = form.dataset.codexGoal || "dashboard_chat_triage";
       const initialMarkup = log.innerHTML;
 
       function updateComposerReserve() {
@@ -7765,7 +7868,7 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
             credentials: "same-origin",
             body: JSON.stringify({
               threadId,
-              repository,
+              repositoryInput,
               text,
               issueNumber,
               relatedIssue: issueNumber,

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -78,6 +78,152 @@ const MCP_SERVER_INFO = Object.freeze({
 });
 const MCP_INSTRUCTIONS =
   "VTDD MCP は Butler と同じ runtime truth / review truth / operational memory を読むための read-first surface です。現在の truth は runtime truth を優先し、memory は補助として扱ってください。";
+
+export class DashboardChatRoom {
+  constructor(state, env) {
+    this.ctx = state;
+    this.env = env;
+    this.sessions = new Set();
+  }
+
+  async fetch(request) {
+    const url = new URL(request.url);
+    if (request.method === "POST" && url.pathname === "/broadcast") {
+      const payload = await readJson(request);
+      const threadId = normalizeDashboardThreadId(payload.threadId || payload.thread_id);
+      if (!threadId) {
+        return json(422, {
+          ok: false,
+          error: "thread_id_required",
+          reason: "threadId is required"
+        });
+      }
+      await this.broadcastThread({
+        threadId,
+        messages: Array.isArray(payload.messages) ? payload.messages : null
+      });
+      return json(202, { ok: true, threadId });
+    }
+
+    if (request.headers.get("upgrade")?.toLowerCase() !== "websocket") {
+      return json(426, {
+        ok: false,
+        error: "websocket_upgrade_required",
+        reason: "dashboard chat room requires a WebSocket upgrade"
+      });
+    }
+    if (typeof WebSocketPair !== "function") {
+      return json(501, {
+        ok: false,
+        error: "websocket_runtime_unavailable",
+        reason: "WebSocketPair is not available in this runtime"
+      });
+    }
+
+    const threadId = extractDashboardChatSocketThreadId(url.pathname);
+    if (!threadId) {
+      return json(422, {
+        ok: false,
+        error: "thread_id_required",
+        reason: "threadId is required"
+      });
+    }
+
+    const pair = new WebSocketPair();
+    const [client, server] = Object.values(pair);
+    if (typeof this.ctx?.acceptWebSocket === "function") {
+      server.serializeAttachment({ threadId });
+      this.ctx.acceptWebSocket(server);
+    } else {
+      server.accept();
+      this.sessions.add(server);
+      server.addEventListener("close", () => this.sessions.delete(server));
+      server.addEventListener("error", () => this.sessions.delete(server));
+      server.addEventListener("message", (event) => this.handleSocketMessage(server, event?.data, threadId));
+    }
+    await this.sendThread(server, threadId);
+
+    return new Response(null, {
+      status: 101,
+      webSocket: client
+    });
+  }
+
+  async webSocketMessage(socket, message) {
+    const attachment = typeof socket.deserializeAttachment === "function" ? socket.deserializeAttachment() : null;
+    const threadId = normalizeDashboardThreadId(attachment?.threadId);
+    this.handleSocketMessage(socket, message, threadId);
+  }
+
+  webSocketClose(socket) {
+    this.sessions.delete(socket);
+  }
+
+  webSocketError(socket) {
+    this.sessions.delete(socket);
+  }
+
+  handleSocketMessage(socket, message, threadId) {
+    const text = normalizeDashboardEventText(message).toLowerCase();
+    if (text === "ping" && isSocketOpen(socket)) {
+      socket.send(JSON.stringify({ type: "pong", ok: true, threadId }));
+    }
+  }
+
+  async broadcastThread({ threadId, messages = null }) {
+    const resolvedMessages = Array.isArray(messages) ? messages : await this.listThreadMessages(threadId);
+    const payload = JSON.stringify({
+      type: "thread",
+      ok: true,
+      threadId,
+      messages: resolvedMessages
+    });
+    for (const socket of this.connectedSockets()) {
+      if (isSocketOpen(socket)) {
+        socket.send(payload);
+      }
+    }
+  }
+
+  async sendThread(socket, threadId) {
+    if (!isSocketOpen(socket)) return;
+    try {
+      socket.send(
+        JSON.stringify({
+          type: "thread",
+          ok: true,
+          threadId,
+          messages: await this.listThreadMessages(threadId)
+        })
+      );
+    } catch (error) {
+      if (isSocketOpen(socket)) {
+        socket.send(
+          JSON.stringify({
+            type: "error",
+            ok: false,
+            reason: sanitizeDashboardChatText(error?.message || "dashboard chat room failed")
+          })
+        );
+      }
+    }
+  }
+
+  async listThreadMessages(threadId) {
+    const store = resolveDashboardChatStore(this.env);
+    if (!store) {
+      return [];
+    }
+    return store.listThread(threadId, { limit: 80 });
+  }
+
+  connectedSockets() {
+    if (typeof this.ctx?.getWebSockets === "function") {
+      return this.ctx.getWebSockets();
+    }
+    return Array.from(this.sessions);
+  }
+}
 const CLOUDFLARE_ACCESS_JWKS_CACHE_TTL_MS = 5 * 60 * 1000;
 const DASHBOARD_PASSKEY_SESSION_COOKIE = "vtdd_dashboard_session";
 const DASHBOARD_PASSKEY_SESSION_MAX_AGE_SECONDS = 60 * 60 * 8;
@@ -194,6 +340,10 @@ export default {
 
     if (request.method === "POST" && isApiPath(url.pathname, "/dashboard/chat/messages")) {
       return handleDashboardChatMessageRequest(request, env);
+    }
+
+    if (request.method === "GET" && isDashboardChatSocketApiPath(url.pathname)) {
+      return handleDashboardChatSocketRequest(request, url, env);
     }
 
     if (request.method === "GET" && isDashboardChatThreadApiPath(url.pathname)) {
@@ -3146,11 +3296,13 @@ async function handleVpsRunnerEventRequest(request, env) {
       }
     });
   }
+  const webSocketBroadcast = await notifyDashboardChatRoom({ env, threadId: event.threadId, messages });
   return json(202, {
     ok: true,
     event: event.event,
     threadId: event.threadId,
-    messages
+    messages,
+    webSocketBroadcast
   });
 }
 
@@ -3170,16 +3322,6 @@ async function handleDashboardChatMessageRequest(request, env) {
 
   const payload = await readJson(request);
   const wantsVpsRunnerHandoff = shouldDispatchDashboardChatToVpsRunner(payload);
-  if (wantsVpsRunnerHandoff) {
-    const auth = authorizeGatewayRequest({ request, env, apiSuffix: "/dashboard/chat/messages" });
-    if (!auth.ok) {
-      return json(auth.status, {
-        ok: false,
-        error: "dashboard_vps_runner_dispatch_unauthorized",
-        reason: auth.reason
-      });
-    }
-  }
 
   const prepared = buildDashboardChatTurn(payload, { wantsVpsRunnerHandoff });
   if (!prepared.ok) {
@@ -3240,6 +3382,47 @@ async function handleDashboardChatMessageRequest(request, env) {
     messages,
     execution
   });
+}
+
+async function handleDashboardChatSocketRequest(request, url, env) {
+  const auth = await authorizeDashboardRequest({
+    request,
+    env,
+    apiSuffix: "/dashboard/chat/:threadId/ws"
+  });
+  if (!auth.ok) {
+    return json(auth.status, {
+      ok: false,
+      error: "dashboard_auth_required",
+      reason: auth.reason
+    });
+  }
+
+  const threadId = extractDashboardChatSocketThreadId(url.pathname);
+  if (!threadId) {
+    return json(422, {
+      ok: false,
+      error: "thread_id_required",
+      reason: "threadId is required"
+    });
+  }
+  const room = resolveDashboardChatRoomStub(env, threadId);
+  if (!room) {
+    return json(503, {
+      ok: false,
+      error: "dashboard_chat_room_unavailable",
+      reason: "DASHBOARD_CHAT_ROOMS Durable Object binding is not configured"
+    });
+  }
+
+  if (request.headers.get("upgrade")?.toLowerCase() !== "websocket") {
+    return json(426, {
+      ok: false,
+      error: "websocket_upgrade_required",
+      reason: "dashboard chat updates require a WebSocket upgrade"
+    });
+  }
+  return room.fetch(request);
 }
 
 async function handleDashboardChatThreadRequest(request, url, env) {
@@ -4814,6 +4997,41 @@ function resolveDashboardChatStore(env) {
   return store;
 }
 
+function resolveDashboardChatRoomStub(env, threadId) {
+  const namespace = env?.DASHBOARD_CHAT_ROOMS ?? null;
+  const roomName = normalizeDashboardThreadId(threadId);
+  if (!namespace || !roomName) {
+    return null;
+  }
+  if (typeof namespace.getByName === "function") {
+    return namespace.getByName(roomName);
+  }
+  if (typeof namespace.idFromName === "function" && typeof namespace.get === "function") {
+    return namespace.get(namespace.idFromName(roomName));
+  }
+  return null;
+}
+
+async function notifyDashboardChatRoom({ env, threadId, messages }) {
+  const room = resolveDashboardChatRoomStub(env, threadId);
+  if (!room || typeof room.fetch !== "function") {
+    return false;
+  }
+  try {
+    const response = await room.fetch("https://dashboard-chat-room.internal/broadcast", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        threadId,
+        messages: Array.isArray(messages) ? messages : []
+      })
+    });
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
 function createD1DashboardEventStore(d1) {
   let schemaPromise = null;
   return {
@@ -5079,30 +5297,32 @@ function buildDashboardChatTurn(payload, options = {}) {
     },
     { threadId }
   );
-  const butlerMessage = normalizeDashboardChatMessage(
-    {
-      threadId,
-      role: "butler",
-      repository,
-      relatedIssue,
-      status: "replied",
-      text: buildDeterministicButlerChatReply({
-        text,
-        repository,
-        relatedIssue,
-        wantsVpsRunnerHandoff: options.wantsVpsRunnerHandoff === true
-      }),
-      createdAt: new Date(Date.parse(now) + 1).toISOString()
-    },
-    { threadId }
-  );
+  const butlerMessage =
+    options.wantsVpsRunnerHandoff === true
+      ? null
+      : normalizeDashboardChatMessage(
+          {
+            threadId,
+            role: "butler",
+            repository,
+            relatedIssue,
+            status: "replied",
+            text: buildDeterministicButlerChatReply({
+              text,
+              repository,
+              relatedIssue
+            }),
+            createdAt: new Date(Date.parse(now) + 1).toISOString()
+          },
+          { threadId }
+        );
 
   return {
     ok: true,
     repository,
     relatedIssue,
     threadId,
-    messages: [ownerMessage, butlerMessage]
+    messages: [ownerMessage, butlerMessage].filter(Boolean)
   };
 }
 
@@ -5213,11 +5433,11 @@ function buildDashboardVpsRunnerQueuedMessage({ prepared, execution }) {
   return normalizeDashboardChatMessage(
     {
       threadId: prepared.threadId,
-      role: "runner",
+      role: "system",
       repository: prepared.repository,
       relatedIssue: execution.issueNumber || prepared.relatedIssue,
       status: "thinking",
-      text: `VPS Codex CLI に ${issuePhrase} の bounded handoff を渡しました。実行状態は runner event としてこの thread に戻ります。${queuePhrase}`,
+      text: `VPS Codex CLI queue に ${issuePhrase} の bounded handoff を渡しました。これは返信ではありません。runner からの event post だけを返信としてこの thread に表示します。${queuePhrase}`,
       createdAt: new Date(Date.now() + 2).toISOString()
     },
     { threadId: prepared.threadId }
@@ -5281,6 +5501,13 @@ function isDashboardChatThreadApiPath(pathname) {
   );
 }
 
+function isDashboardChatSocketApiPath(pathname) {
+  return (
+    pathname.startsWith(`${CANONICAL_API_PREFIX}/dashboard/chat/`) ||
+    pathname.startsWith(`${LEGACY_API_PREFIX}/dashboard/chat/`)
+  ) && pathname.endsWith("/ws");
+}
+
 function isDashboardPagePath(pathname) {
   return (
     pathname === "/dashboard" ||
@@ -5304,6 +5531,10 @@ function extractDashboardChatThreadId(pathname) {
   } catch {
     return normalizeDashboardThreadId(pathname.slice(prefix.length));
   }
+}
+
+function extractDashboardChatSocketThreadId(pathname) {
+  return extractDashboardChatThreadId(pathname.replace(/\/ws$/, ""));
 }
 
 function normalizeDashboardEventRecord(event) {
@@ -7027,7 +7258,9 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
   const origin = normalize(runtimeOrigin);
   const repository = "marushu/vtdd-v2-p";
   const encodedRepository = encodeURIComponent(repository);
+  const dashboardChatIssueNumber = 450;
   const chatThreadId = `dashboard-main-${repository.replace("/", "-")}`;
+  const socketOrigin = origin.replace(/^http/i, "ws");
   const latestDeployEvent = await retrieveLatestDashboardEvent({
     store: dashboardEventStore,
     kind: "github_actions_workflow_run",
@@ -7316,18 +7549,18 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
         <article class="bubble">
           <strong>Butler</strong>
           <p>その方針で進めます。中央はチャットだけ、状態確認・進捗・RAG・workflow・prototype cleanup の扱いはサイドバーのメニューから必要な時だけ開きます。</p>
-          <p>deploy が必要になった時は、普通のチャットと同じようにこの会話内へ scope 明示済みの passkey URL を出します。VPS Codex CLI への実行 dispatch は別 gate で扱います。</p>
-          <span class="connection-note">接続済み: Worker chat runtime に保存・返信します</span>
+          <p>この dashboard からの送信は Issue #${dashboardChatIssueNumber} の VPS Codex CLI queue に渡します。返信として表示するのは runner から戻った event post だけです。</p>
+          <span class="connection-note">接続済み: WebSocket で runner event post を待ちます</span>
         </article>
 
       </div>
 
-      <form class="composer" id="butler-chat-form" aria-label="Butler composer" data-endpoint="${escapeDashboardHtml(origin)}/v2/dashboard/chat/messages" data-thread-endpoint="${escapeDashboardHtml(origin)}/v2/dashboard/chat/${escapeDashboardHtml(chatThreadId)}" data-thread-id="${escapeDashboardHtml(chatThreadId)}" data-repository="${escapeDashboardHtml(repository)}">
+      <form class="composer" id="butler-chat-form" aria-label="Butler composer" data-endpoint="${escapeDashboardHtml(origin)}/v2/dashboard/chat/messages" data-thread-endpoint="${escapeDashboardHtml(origin)}/v2/dashboard/chat/${escapeDashboardHtml(chatThreadId)}" data-socket-endpoint="${escapeDashboardHtml(socketOrigin)}/v2/dashboard/chat/${escapeDashboardHtml(chatThreadId)}/ws" data-thread-id="${escapeDashboardHtml(chatThreadId)}" data-repository="${escapeDashboardHtml(repository)}" data-issue-number="${dashboardChatIssueNumber}" data-dispatch-to-vps-runner="true" data-codex-goal="open_pr">
         <div class="composer-box">
           <textarea id="butler-message" name="text" placeholder="Butler V2 にメッセージ..." aria-label="Butler V2 にメッセージ"></textarea>
           <button class="send-button" type="submit" aria-label="Butler に送信">↑</button>
         </div>
-        <div class="composer-status" id="butler-chat-status">接続済み。送信するとこの thread に保存されます。自動更新・polling はありません。</div>
+        <div class="composer-status" id="butler-chat-status">接続済み。送信すると VPS Codex CLI queue に渡します。返信は runner event post だけを表示します。</div>
       </form>
     </section>
 
@@ -7337,7 +7570,7 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
           <span class="eyebrow">管理メニュー</span>
           <strong>必要な時だけ開く</strong>
         </span>
-        <span class="pill">自動更新なし</span>
+        <span class="pill">WebSocket</span>
       </summary>
       <div class="sidebar-content">
         <p class="menu-callout">状態確認、進捗、RAG、workflow はここから遷移します。普段の画面はチャットを主役にします。</p>
@@ -7393,8 +7626,12 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
 
       const endpoint = form.dataset.endpoint;
       const threadEndpoint = form.dataset.threadEndpoint;
+      const socketEndpoint = form.dataset.socketEndpoint;
       const threadId = form.dataset.threadId;
       const repository = form.dataset.repository;
+      const issueNumber = Number.parseInt(form.dataset.issueNumber || "", 10);
+      const dispatchToVpsRunner = form.dataset.dispatchToVpsRunner === "true";
+      const codexGoal = form.dataset.codexGoal || "open_pr";
       const initialMarkup = log.innerHTML;
 
       function updateComposerReserve() {
@@ -7418,7 +7655,7 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
         article.className = message.role === "owner" ? "bubble owner" : "bubble";
         if (message.role !== "owner") {
           const strong = document.createElement("strong");
-          strong.textContent = message.role === "runner" ? "VPS Codex CLI" : "Butler";
+          strong.textContent = message.role === "runner" ? "VPS Codex CLI" : message.role === "system" ? "SYSTEM" : "Butler";
           article.appendChild(strong);
         }
         const paragraph = document.createElement("p");
@@ -7466,6 +7703,29 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
         scrollToLatest();
       }
 
+      function connectThreadSocket() {
+        if (!socketEndpoint || typeof WebSocket !== "function") {
+          setStatus("WebSocket を開始できません。runner 返信は再読み込みで確認してください。");
+          return;
+        }
+        const socket = new WebSocket(socketEndpoint);
+        socket.addEventListener("open", () => {
+          setStatus("WebSocket 接続済み。VPS Codex CLI の runner event post を待っています。");
+        });
+        socket.addEventListener("message", (event) => {
+          const body = JSON.parse(event.data || "{}");
+          if (body.type === "thread" && body.ok) {
+            renderThread(body.messages || []);
+          }
+        });
+        socket.addEventListener("close", () => {
+          setStatus("WebSocket が切れました。再読み込みすると最新 thread を確認できます。");
+        });
+        socket.addEventListener("error", () => {
+          setStatus("WebSocket 接続に失敗しました。再読み込みすると最新 thread を確認できます。");
+        });
+      }
+
       async function refreshThread() {
         if (!threadEndpoint) return;
         setStatus("会話履歴を読み込み中です。");
@@ -7481,7 +7741,7 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
             return;
           }
           renderThread(body.messages || []);
-          setStatus("接続済み。送信するとこの thread に保存されます。自動更新・polling はありません。");
+          setStatus("接続済み。送信すると VPS Codex CLI queue に渡します。返信は runner event post だけを表示します。");
         } catch {
           setStatus("会話履歴を読めませんでした。送信時に再試行します。");
         }
@@ -7496,14 +7756,24 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
         }
         const submitButton = form.querySelector("button[type='submit']");
         if (submitButton) submitButton.disabled = true;
-        setStatus("送信中です。Butler が同じ thread に返信します。");
+        setStatus("送信中です。VPS Codex CLI queue に渡します。");
         const thinking = showThinking();
         try {
           const response = await fetch(endpoint, {
             method: "POST",
             headers: { "content-type": "application/json", "accept": "application/json" },
             credentials: "same-origin",
-            body: JSON.stringify({ threadId, repository, text })
+            body: JSON.stringify({
+              threadId,
+              repository,
+              text,
+              issueNumber,
+              relatedIssue: issueNumber,
+              dispatchToVpsRunner,
+              executorTransport: dispatchToVpsRunner ? "vps_runner" : undefined,
+              codexGoal,
+              handoffSummary: "Dashboard Butler chat message from owner"
+            })
           });
           const body = await response.json().catch(() => ({}));
           removeThinking(thinking);
@@ -7516,7 +7786,7 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
           for (const message of body.messages || []) {
             appendMessage(message);
           }
-          setStatus("保存済み。Butler 返信を同じ thread に追加しました。");
+          setStatus(body.execution ? "保存済み。VPS Codex CLI queue に渡しました。runner event post を待っています。" : "保存済み。Worker runtime に保存しました。");
         } catch {
           removeThinking(thinking);
           appendError("Worker chat runtime に接続できませんでした。ネットワークまたは deploy 状態を確認してください。");
@@ -7531,6 +7801,7 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
       updateComposerReserve();
       window.addEventListener("resize", updateComposerReserve);
       refreshThread();
+      connectThreadSocket();
     })();
   </script>
 </body>
@@ -7690,6 +7961,10 @@ function normalizeText(value) {
 function normalizePositiveInteger(value) {
   const number = Number(value);
   return Number.isInteger(number) && number > 0 ? number : null;
+}
+
+function isSocketOpen(socket) {
+  return socket?.readyState === 1 || (typeof WebSocket !== "undefined" && socket?.readyState === WebSocket.OPEN);
 }
 
 function normalizeBody(value) {

--- a/test/production-deploy-path.test.js
+++ b/test/production-deploy-path.test.js
@@ -170,6 +170,9 @@ test("wrangler config fixes worker runtime entry and production environment", ()
   assert.equal(wrangler.includes('main = "worker.js"'), true);
   assert.equal(wrangler.includes("[env.production]"), true);
   assert.equal(wrangler.includes('name = "vtdd-v2-mvp"'), true);
+  assert.equal(wrangler.includes('name = "DASHBOARD_CHAT_ROOMS"'), true);
+  assert.equal(wrangler.includes('class_name = "DashboardChatRoom"'), true);
+  assert.equal(wrangler.includes('new_sqlite_classes = ["DashboardChatRoom"]'), true);
   assert.equal(wrangler.includes(OWNER_D1_DATABASE_ID), false);
   assert.equal(wrangler.includes("database_id"), false);
 });

--- a/test/remote-codex-executor.test.js
+++ b/test/remote-codex-executor.test.js
@@ -271,8 +271,48 @@ test("remote Codex execution request rejects wait-only continuity goal before wo
 
   assert.equal(result.ok, false);
   assert.deepEqual(result.issues, [
-    "codexGoal must be open_pr, revise_pr, respond_to_review, or post_merge_verify"
+    "codexGoal must be dashboard_chat_triage, open_pr, revise_pr, respond_to_review, or post_merge_verify"
   ]);
+});
+
+test("remote Codex execution request accepts dashboard chat triage goal", () => {
+  const result = createRemoteCodexExecutionRequest({
+    payload: {
+      actorRole: ActorRole.BUTLER,
+      issueContext: { issueNumber: 450 },
+      continuationContext: {
+        requiresHandoff: true,
+        codexGoal: RemoteCodexDispatchGoal.DASHBOARD_CHAT_TRIAGE,
+        handoff: {
+          issueTraceable: true,
+          approvalScopeMatched: true,
+          relatedIssue: 450,
+          summary: "Dashboard chat triage",
+          ownerMessage: "ぶい の残り Issue と PR を確認して",
+          repositoryInput: "ぶい",
+          dashboardThreadId: "dashboard-main-vtdd"
+        }
+      },
+      executionTarget: {
+        codexGoal: RemoteCodexDispatchGoal.DASHBOARD_CHAT_TRIAGE,
+        branch: "codex/issue-450-dashboard-chat-triage"
+      },
+      policyInput: {
+        approvalPhrase: "GO",
+        targetConfirmed: true,
+        approvalScopeMatched: true
+      }
+    },
+    gatewayResult: {
+      repository: "sample-org/vtdd-v2"
+    }
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.request.codexGoal, RemoteCodexDispatchGoal.DASHBOARD_CHAT_TRIAGE);
+  assert.equal(result.request.handoff.dashboardThreadId, "dashboard-main-vtdd");
+  assert.equal(result.request.handoff.ownerMessage, "ぶい の残り Issue と PR を確認して");
+  assert.equal(result.request.handoff.repositoryInput, "ぶい");
 });
 
 test("remote Codex execution request rejects non-string handoff approval refs", () => {
@@ -721,6 +761,73 @@ test("remote Codex vps_runner dispatch posts a GitHub-backed queue comment", asy
   assert.equal(body.includes('"docs/butler/thread-independent-startup-contract.md"'), true);
   assert.equal(body.includes("## This PR satisfies Intent"), true);
   assert.equal(body.includes("## Surface Update Checklist"), true);
+});
+
+test("remote Codex vps_runner dashboard chat triage queue does not masquerade as PR work", async () => {
+  const calls = [];
+  const dispatched = await dispatchRemoteCodexExecution({
+    payload: {
+      actorRole: ActorRole.BUTLER,
+      executorTransport: RemoteCodexExecutorTransport.VPS_RUNNER,
+      issueContext: { issueNumber: 450 },
+      policyInput: {
+        approvalPhrase: "GO",
+        targetConfirmed: true,
+        approvalScopeMatched: true,
+        runtimeTruth: {
+          runtimeState: {
+            activeBranch: "codex/issue-450-dashboard-vps-chat"
+          }
+        },
+        approvalActor: "owner"
+      },
+      continuationContext: {
+        requiresHandoff: true,
+        handoff: {
+          issueTraceable: true,
+          approvalScopeMatched: true,
+          relatedIssue: 450,
+          summary: "Dashboard chat handoff",
+          ownerMessage: "ぶい の残り Issue と PR を確認して交通整理して",
+          repositoryInput: "ぶい",
+          dashboardThreadId: "dashboard-main-vtdd"
+        }
+      }
+    },
+    gatewayResult: {
+      repository: "marushu/vtdd-v2-p",
+      executionContinuity: {
+        codexGoal: RemoteCodexDispatchGoal.DASHBOARD_CHAT_TRIAGE
+      }
+    },
+    env: {
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_dispatch_token",
+      GITHUB_API_FETCH: async (url, init) => {
+        calls.push({ url, init });
+        return new Response(
+          JSON.stringify({
+            id: 45001,
+            html_url: "https://github.com/marushu/vtdd-v2-p/issues/450#issuecomment-45001"
+          }),
+          { status: 201, headers: { "content-type": "application/json" } }
+        );
+      }
+    }
+  });
+
+  assert.equal(dispatched.ok, true);
+  const body = JSON.parse(calls[0].init.body).body;
+  assert.equal(body.includes('"codexGoal": "dashboard_chat_triage"'), true);
+  assert.equal(body.includes('"ownerMessage": "ぶい の残り Issue と PR を確認して交通整理して"'), true);
+  assert.equal(body.includes('"repositoryInput": "ぶい"'), true);
+  assert.equal(body.includes("Completion target: post a dashboard chat triage response to the same thread"), true);
+  assert.equal(body.includes("dashboard chat triage must not create or update a PR"), true);
+  assert.equal(body.includes("Do not create or update PRs."), true);
+  assert.equal(body.includes("Completion target: create or update a pull request"), false);
+  assert.equal(body.includes("Required PR body markers"), false);
+  assert.equal(body.includes("docs/pr-template-model.md"), false);
+  assert.equal(body.includes("scripts/render-pr-body.mjs"), false);
+  assert.equal(body.includes('"requiredRepoFiles": [\n      "AGENTS.md",\n      "docs/butler/thread-independent-startup-contract.md"\n    ]'), true);
 });
 
 test("remote Codex vps_runner dispatch preserves bounded PR revision goal", async () => {

--- a/test/vps-runner-script.test.js
+++ b/test/vps-runner-script.test.js
@@ -6,6 +6,7 @@ import path from "node:path";
 import {
   buildFreshExecutionBranchCandidates,
   buildCodexExecutionPrompt,
+  buildDashboardChatTriagePrompt,
   buildCodexExecArgs,
   buildGuardedPullRequestBody,
   buildPostMergePullTruth,
@@ -1471,6 +1472,58 @@ test("VPS runner Codex prompt preserves high-risk boundaries", () => {
   assert.equal(prompt.includes("## File / Line Hypotheses"), true);
   assert.equal(prompt.includes("## Hypothesis Retrospective"), true);
   assert.equal(prompt.includes("## Surface Update Checklist"), true);
+});
+
+test("VPS runner dashboard chat triage prompt preserves Custom GPT parity and blocks mutation", () => {
+  const prompt = buildDashboardChatTriagePrompt({
+    payload: {
+      repository: "marushu/vtdd-v2-p",
+      issueNumber: 450,
+      codexGoal: "dashboard_chat_triage",
+      handoff: {
+        ownerMessage: "ぶい の残り Issue と PR 確認して交通整理して",
+        repositoryInput: "ぶい",
+        dashboardThreadId: "dashboard-main-vtdd"
+      }
+    },
+    issue: {
+      title: "Dashboard Butler chat",
+      body: "Top chat must preserve Custom GPT Butler capabilities."
+    },
+    preflight: {
+      ok: true,
+      mode: "auto_receipt",
+      onMissingContract: "owner_decision_required",
+      issue: {
+        number: 450,
+        title: "Dashboard Butler chat",
+        bodyExcerpt: "Top chat must preserve Custom GPT Butler capabilities."
+      },
+      handoffNote: {
+        currentSurface: "VPS Codex CLI",
+        repository: "marushu/vtdd-v2-p",
+        issueNumber: 450,
+        codexGoal: "dashboard_chat_triage",
+        nextSafeAction: "resume from the canonical Issue, GitHub runtime truth, RAG checkpoints, and this preflight receipt",
+        blockedReturnRoute: "If the issue/runtime truth is insufficient, stop and return a Japanese blocker comment for Butler/owner instead of guessing."
+      },
+      artifacts: [{ path: "AGENTS.md", sha1: "abc123" }],
+      missing: []
+    }
+  });
+
+  assert.equal(prompt.includes("Custom GPT parity requirement:"), true);
+  assert.equal(prompt.includes("natural-language Butler entrypoint"), true);
+  assert.equal(prompt.includes("repository/nickname"), true);
+  assert.equal(prompt.includes("Issue split proposal"), true);
+  assert.equal(prompt.includes("existing Issue linkage"), true);
+  assert.equal(prompt.includes("GitHub runtime truth"), true);
+  assert.equal(prompt.includes("RAG"), true);
+  assert.equal(prompt.includes("approval URL needed"), true);
+  assert.equal(prompt.includes("Do not edit files, commit, push, create PRs, merge, deploy"), true);
+  assert.equal(prompt.includes("ぶい の残り Issue と PR 確認して交通整理して"), true);
+  assert.equal(prompt.includes("Context preflight receipt:"), true);
+  assert.equal(prompt.includes("AGENTS.md sha1=abc123"), true);
 });
 
 test("VPS runner builds preflight receipt from canonical repo files", async () => {

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -120,6 +120,26 @@ function createInMemoryDashboardChatStore() {
   };
 }
 
+function createMockDashboardChatRoomNamespace() {
+  const calls = [];
+  return {
+    calls,
+    namespace: {
+      getByName(name) {
+        return {
+          async fetch(input, init) {
+            calls.push({ name, input, init });
+            return new Response(JSON.stringify({ ok: true, name }), {
+              status: 202,
+              headers: { "content-type": "application/json" }
+            });
+          }
+        };
+      }
+    }
+  };
+}
+
 const passkeyAdapter = {
   async generateRegistrationOptions(input) {
     return { challenge: input.challenge };
@@ -376,12 +396,11 @@ test("worker serves v2 dashboard for allowed owner identity without exposing sec
   assert.equal(body.includes("prefers-color-scheme: dark"), true);
   assert.equal(body.includes("overflow: hidden"), true);
   assert.equal(body.includes("grid-template-columns: minmax(0, 1fr) auto"), true);
-  assert.equal(body.includes("自動更新なし"), true);
-  assert.equal(body.includes("自動更新・polling はありません"), true);
+  assert.equal(body.includes("WebSocket"), true);
   assert.equal(body.includes("Issue #433"), true);
-  assert.equal(body.includes("接続済み: Worker chat runtime に保存・返信します"), true);
-  assert.equal(body.includes("deploy が必要になった時は、普通のチャットと同じようにこの会話内へ scope 明示済みの passkey URL を出します"), true);
-  assert.equal(body.includes("VPS Codex CLI への実行 dispatch は別 gate で扱います"), true);
+  assert.equal(body.includes("接続済み: WebSocket で runner event post を待ちます"), true);
+  assert.equal(body.includes("Issue #450 の VPS Codex CLI queue に渡します"), true);
+  assert.equal(body.includes("返信として表示するのは runner から戻った event post だけです"), true);
   assert.equal(body.includes("deploy 用 passkey URL"), false);
   assert.equal(body.includes("vtdd-v3-orchestrator.polished-tree-da7c.workers.dev"), false);
   assert.equal(body.includes('id="mobile-menu-toggle"'), true);
@@ -393,6 +412,12 @@ test("worker serves v2 dashboard for allowed owner identity without exposing sec
   assert.equal(body.includes('aria-hidden="true">♪</span>'), false);
   assert.equal(body.includes("/v2/dashboard/chat/messages"), true);
   assert.equal(body.includes('data-thread-endpoint="https://example.com/v2/dashboard/chat/dashboard-main-marushu-vtdd-v2-p"'), true);
+  assert.equal(body.includes('data-socket-endpoint="wss://example.com/v2/dashboard/chat/dashboard-main-marushu-vtdd-v2-p/ws"'), true);
+  assert.equal(body.includes('data-dispatch-to-vps-runner="true"'), true);
+  assert.equal(body.includes('data-issue-number="450"'), true);
+  assert.equal(body.includes('executorTransport: dispatchToVpsRunner ? "vps_runner" : undefined'), true);
+  assert.equal(body.includes("new WebSocket(socketEndpoint)"), true);
+  assert.equal(body.includes("VPS Codex CLI の runner event post を待っています"), true);
   assert.equal(body.includes("function refreshThread()"), true);
   assert.equal(body.includes("function updateComposerReserve()"), true);
   assert.equal(body.includes("function scrollToLatest()"), true);
@@ -455,7 +480,7 @@ test("worker serves v2 dashboard for allowed owner identity without exposing sec
   assert.equal(aliasBody.includes("VTDD Butler"), true);
   assert.equal(aliasBody.includes("dashboard main chat"), true);
   assert.equal(aliasBody.includes("管理メニュー"), true);
-  assert.equal(aliasBody.includes("自動更新なし"), true);
+  assert.equal(aliasBody.includes("WebSocket"), true);
 });
 
 test("worker appends dashboard Butler chat turn and retrieves the same thread", async () => {
@@ -592,9 +617,9 @@ test("worker dispatches authenticated dashboard chat handoff to VPS runner queue
   assert.equal(body.execution.issueNumber, 450);
   assert.equal(body.execution.branch, "codex/issue-450-dashboard-vps-chat");
   assert.equal(body.execution.queueCommentId, 45001);
-  assert.equal(body.messages.length, 3);
-  assert.equal(body.messages[2].role, "runner");
-  assert.match(body.messages[2].text, /VPS Codex CLI/);
+  assert.equal(body.messages.length, 2);
+  assert.equal(body.messages[1].role, "system");
+  assert.match(body.messages[1].text, /これは返信ではありません/);
 
   const queueBody = JSON.parse(calls[0].init.body).body;
   assert.equal(queueBody.includes("vtdd:vps-runner-execution:"), true);
@@ -608,8 +633,80 @@ test("worker dispatches authenticated dashboard chat handoff to VPS runner queue
     { ...dashboardAccessEnv, DASHBOARD_CHAT_STORE: store }
   );
   const retrieveBody = await retrieveResponse.json();
-  assert.equal(retrieveBody.messages.length, 3);
-  assert.equal(retrieveBody.messages[2].status, "thinking");
+  assert.equal(retrieveBody.messages.length, 2);
+  assert.equal(retrieveBody.messages[1].status, "thinking");
+});
+
+test("worker allows dashboard passkey session to hand off chat to VPS runner queue", async () => {
+  const provider = createInMemoryMemoryProvider();
+  await provider.store({
+    id: "approval:dashboard-vps-session",
+    type: MemoryRecordType.APPROVAL_LOG,
+    content: {
+      kind: "passkey_grant",
+      status: "verified",
+      approvalId: "approval:dashboard-vps-session",
+      credentialId: "AQIDBA",
+      verifiedAt: "2026-05-20T00:00:00.000Z",
+      expiresAt: "2999-01-01T00:00:00.000Z",
+      scope: {
+        actionType: "read",
+        highRiskKind: "dashboard_access",
+        repositoryInput: "marushu/vtdd-v2-p",
+        phase: "execution"
+      }
+    },
+    metadata: { source: "test" },
+    priority: 96,
+    tags: ["passkey_grant", "passkey_approval", "verified"],
+    createdAt: "2026-05-20T00:00:00.000Z"
+  });
+
+  const store = createInMemoryDashboardChatStore();
+  const calls = [];
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/dashboard/chat/messages", {
+      method: "POST",
+      headers: {
+        cookie: "vtdd_dashboard_session=approval%3Adashboard-vps-session",
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({
+        threadId: "dashboard-main-marushu-vtdd-v2-p",
+        repository: "marushu/vtdd-v2-p",
+        issueNumber: 450,
+        relatedIssue: 450,
+        dispatchToVpsRunner: true,
+        executorTransport: "vps_runner",
+        codexGoal: "open_pr",
+        text: "dashboard から VPS Codex CLI に投げる"
+      })
+    }),
+    {
+      MEMORY_PROVIDER: provider,
+      DASHBOARD_CHAT_STORE: store,
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_dashboard_passkey_vps",
+      GITHUB_API_FETCH: async (url, init) => {
+        calls.push({ url, init });
+        return new Response(
+          JSON.stringify({
+            id: 45002,
+            html_url: "https://github.com/marushu/vtdd-v2-p/issues/450#issuecomment-45002"
+          }),
+          { status: 201, headers: { "content-type": "application/json" } }
+        );
+      }
+    }
+  );
+
+  assert.equal(response.status, 202);
+  const body = await response.json();
+  assert.equal(body.ok, true);
+  assert.equal(body.execution.transport, "vps_runner");
+  assert.equal(body.messages[1].role, "system");
+  assert.equal(calls.length, 1);
+  const queueBody = JSON.parse(calls[0].init.body).body;
+  assert.equal(queueBody.includes('"dashboardThreadId": "dashboard-main-marushu-vtdd-v2-p"'), true);
 });
 
 test("worker rejects unauthenticated dashboard chat VPS runner dispatch", async () => {
@@ -658,6 +755,34 @@ test("worker rejects unauthenticated dashboard chat writes even without VPS disp
   const body = await response.json();
   assert.equal(body.ok, false);
   assert.equal(body.error, "dashboard_auth_required");
+});
+
+test("worker requires WebSocket upgrade for dashboard chat live updates", async () => {
+  const store = createInMemoryDashboardChatStore();
+  const rooms = createMockDashboardChatRoomNamespace();
+  await store.appendMany("dashboard-main-marushu-vtdd-v2-p", [
+    {
+      threadId: "dashboard-main-marushu-vtdd-v2-p",
+      role: "runner",
+      repository: "marushu/vtdd-v2-p",
+      relatedIssue: 450,
+      status: "replied",
+      text: "VPS Codex CLI から dashboard に戻した返信",
+      createdAt: "2026-05-20T00:00:00.000Z"
+    }
+  ]);
+
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/dashboard/chat/dashboard-main-marushu-vtdd-v2-p/ws", {
+      headers: dashboardAccessHeaders
+    }),
+    { ...dashboardAccessEnv, DASHBOARD_CHAT_STORE: store, DASHBOARD_CHAT_ROOMS: rooms.namespace }
+  );
+
+  assert.equal(response.status, 426);
+  const body = await response.json();
+  assert.equal(body.error, "websocket_upgrade_required");
+  assert.equal(rooms.calls.length, 0);
 });
 
 test("worker redacts dashboard Butler chat sensitive material before returning and storing", async () => {
@@ -955,6 +1080,7 @@ test("worker rejects GitHub Actions deploy completion event without machine auth
 test("worker ingests VPS runner event into notifications and Butler chat thread", async () => {
   const eventStore = createInMemoryDashboardEventStore();
   const chatStore = createInMemoryDashboardChatStore();
+  const rooms = createMockDashboardChatRoomNamespace();
   const eventResponse = await worker.fetch(
     new Request("https://example.com/v2/events/vps-runner", {
       method: "POST",
@@ -978,7 +1104,8 @@ test("worker ingests VPS runner event into notifications and Butler chat thread"
     {
       ...gatewayAuthEnv,
       DASHBOARD_EVENT_STORE: eventStore,
-      DASHBOARD_CHAT_STORE: chatStore
+      DASHBOARD_CHAT_STORE: chatStore,
+      DASHBOARD_CHAT_ROOMS: rooms.namespace
     }
   );
 
@@ -993,11 +1120,18 @@ test("worker ingests VPS runner event into notifications and Butler chat thread"
   assert.equal(JSON.stringify(eventBody).includes("approval:15b6f20d"), false);
   assert.equal(JSON.stringify(eventBody).includes("secret-must-not-persist"), false);
   assert.equal(eventBody.threadId, "dashboard-main-marushu-vtdd-v2-p");
+  assert.equal(eventBody.webSocketBroadcast, true);
   assert.equal(eventBody.messages[0].role, "runner");
   assert.equal(eventBody.messages[0].status, "thinking");
   assert.equal(eventBody.messages[0].relatedIssue, 452);
   assert.equal(eventBody.messages[0].text.includes("VPS Codex CLI"), true);
   assert.equal(eventBody.messages[0].text.includes("codex_subprocess"), true);
+  assert.equal(rooms.calls.length, 1);
+  assert.equal(rooms.calls[0].name, "dashboard-main-marushu-vtdd-v2-p");
+  assert.equal(String(rooms.calls[0].input), "https://dashboard-chat-room.internal/broadcast");
+  const broadcastBody = JSON.parse(rooms.calls[0].init.body);
+  assert.equal(broadcastBody.threadId, "dashboard-main-marushu-vtdd-v2-p");
+  assert.equal(broadcastBody.messages[0].role, "runner");
 
   const chatResponse = await worker.fetch(
     new Request("https://example.com/v2/dashboard/chat/dashboard-main-marushu-vtdd-v2-p", {

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -397,9 +397,9 @@ test("worker serves v2 dashboard for allowed owner identity without exposing sec
   assert.equal(body.includes("overflow: hidden"), true);
   assert.equal(body.includes("grid-template-columns: minmax(0, 1fr) auto"), true);
   assert.equal(body.includes("WebSocket"), true);
-  assert.equal(body.includes("Issue #433"), true);
   assert.equal(body.includes("接続済み: WebSocket で runner event post を待ちます"), true);
-  assert.equal(body.includes("Issue #450 の VPS Codex CLI queue に渡します"), true);
+  assert.equal(body.includes("repo/nickname 未指定"), true);
+  assert.equal(body.includes("dashboard chat triage queue に渡します"), true);
   assert.equal(body.includes("返信として表示するのは runner から戻った event post だけです"), true);
   assert.equal(body.includes("deploy 用 passkey URL"), false);
   assert.equal(body.includes("vtdd-v3-orchestrator.polished-tree-da7c.workers.dev"), false);
@@ -411,10 +411,11 @@ test("worker serves v2 dashboard for allowed owner identity without exposing sec
   assert.equal(body.includes('aria-hidden="true">＋</span>'), false);
   assert.equal(body.includes('aria-hidden="true">♪</span>'), false);
   assert.equal(body.includes("/v2/dashboard/chat/messages"), true);
-  assert.equal(body.includes('data-thread-endpoint="https://example.com/v2/dashboard/chat/dashboard-main-marushu-vtdd-v2-p"'), true);
-  assert.equal(body.includes('data-socket-endpoint="wss://example.com/v2/dashboard/chat/dashboard-main-marushu-vtdd-v2-p/ws"'), true);
+  assert.equal(body.includes('data-thread-endpoint="https://example.com/v2/dashboard/chat/dashboard-main-unresolved"'), true);
+  assert.equal(body.includes('data-socket-endpoint="wss://example.com/v2/dashboard/chat/dashboard-main-unresolved/ws"'), true);
   assert.equal(body.includes('data-dispatch-to-vps-runner="true"'), true);
-  assert.equal(body.includes('data-issue-number="450"'), true);
+  assert.equal(body.includes('data-issue-number=""'), true);
+  assert.equal(body.includes('data-codex-goal="dashboard_chat_triage"'), true);
   assert.equal(body.includes('executorTransport: dispatchToVpsRunner ? "vps_runner" : undefined'), true);
   assert.equal(body.includes("new WebSocket(socketEndpoint)"), true);
   assert.equal(body.includes("VPS Codex CLI の runner event post を待っています"), true);
@@ -439,7 +440,7 @@ test("worker serves v2 dashboard for allowed owner identity without exposing sec
   assert.equal(body.includes("Butler V2 にメッセージ"), true);
   assert.equal(body.includes("状態確認"), true);
   assert.equal(body.includes(">通知</a>"), true);
-  assert.equal(body.includes("/dashboard/github?repository=marushu%2Fvtdd-v2-p"), true);
+  assert.equal(body.includes("/dashboard/github?repository=marushu%2Fvtdd-v2-p"), false);
   assert.equal(body.includes("/dashboard/notifications"), true);
   assert.equal(body.includes(">通知センター</a>"), true);
   assert.equal(body.includes("include=open_prs"), false);
@@ -448,16 +449,13 @@ test("worker serves v2 dashboard for allowed owner identity without exposing sec
   assert.equal(body.includes("setInterval("), false);
   assert.equal(body.includes("setTimeout("), false);
   assert.equal(body.includes("fetch("), true);
-  assert.equal(
-    body.includes("/v2/approval/passkey/operator?repositoryInput=marushu%2Fvtdd-v2-p"),
-    true
-  );
+  assert.equal(body.includes("repositoryInput=marushu%2Fvtdd-v2-p"), false);
   assert.equal(body.includes("/status"), true);
-  assert.equal(body.includes("/dashboard/preflight?repository=marushu%2Fvtdd-v2-p"), true);
-  assert.equal(body.includes("/dashboard/progress?repository=marushu%2Fvtdd-v2-p"), true);
-  assert.equal(body.includes("/dashboard/vps-runner?repository=marushu%2Fvtdd-v2-p"), true);
-  assert.equal(body.includes("/dashboard/memory?repository=marushu%2Fvtdd-v2-p"), true);
-  assert.equal(body.includes("/dashboard/self-parity?repository=marushu%2Fvtdd-v2-p"), true);
+  assert.equal(body.includes("/dashboard/preflight?repository=marushu%2Fvtdd-v2-p"), false);
+  assert.equal(body.includes("/dashboard/progress?repository=marushu%2Fvtdd-v2-p"), false);
+  assert.equal(body.includes("/dashboard/vps-runner?repository=marushu%2Fvtdd-v2-p"), false);
+  assert.equal(body.includes("/dashboard/memory?repository=marushu%2Fvtdd-v2-p"), false);
+  assert.equal(body.includes("/dashboard/self-parity?repository=marushu%2Fvtdd-v2-p"), false);
   assert.equal(body.includes("/v2/retrieve/startup-preflight?repository=marushu%2Fvtdd-v2-p"), false);
   assert.equal(body.includes("/v2/action/progress?repository=marushu%2Fvtdd-v2-p"), false);
   assert.equal(body.includes("/v2/action/vps-runner-status?repository=marushu%2Fvtdd-v2-p"), false);
@@ -585,7 +583,7 @@ test("worker dispatches authenticated dashboard chat handoff to VPS runner queue
         repository: "marushu/vtdd-v2-p",
         issueNumber: 450,
         dispatchToVpsRunner: true,
-        codexGoal: "open_pr",
+        codexGoal: "dashboard_chat_triage",
         branch: "codex/issue-450-dashboard-vps-chat",
         text: "VPS Codex CLI とこの dashboard thread で会話したい"
       })
@@ -615,6 +613,7 @@ test("worker dispatches authenticated dashboard chat handoff to VPS runner queue
   assert.equal(body.ok, true);
   assert.equal(body.execution.transport, "vps_runner");
   assert.equal(body.execution.issueNumber, 450);
+  assert.equal(body.execution.codexGoal, "dashboard_chat_triage");
   assert.equal(body.execution.branch, "codex/issue-450-dashboard-vps-chat");
   assert.equal(body.execution.queueCommentId, 45001);
   assert.equal(body.messages.length, 2);
@@ -624,6 +623,8 @@ test("worker dispatches authenticated dashboard chat handoff to VPS runner queue
   const queueBody = JSON.parse(calls[0].init.body).body;
   assert.equal(queueBody.includes("vtdd:vps-runner-execution:"), true);
   assert.equal(queueBody.includes('"transport": "vps_runner"'), true);
+  assert.equal(queueBody.includes('"codexGoal": "dashboard_chat_triage"'), true);
+  assert.equal(queueBody.includes('"ownerMessage": "VPS Codex CLI とこの dashboard thread で会話したい"'), true);
   assert.equal(queueBody.includes('"dashboardThreadId": "dashboard-main-marushu-vtdd-v2-p"'), true);
 
   const retrieveResponse = await worker.fetch(
@@ -661,6 +662,18 @@ test("worker allows dashboard passkey session to hand off chat to VPS runner que
     tags: ["passkey_grant", "passkey_approval", "verified"],
     createdAt: "2026-05-20T00:00:00.000Z"
   });
+  await provider.store({
+    id: "alias_registry:marushu/vtdd-v2-p",
+    type: MemoryRecordType.ALIAS_REGISTRY,
+    content: {
+      canonicalRepo: "marushu/vtdd-v2-p",
+      aliases: ["ぶい", "vtdd"]
+    },
+    metadata: { source: "test" },
+    priority: 60,
+    tags: ["alias_registry", "marushu/vtdd-v2-p"],
+    createdAt: "2026-05-20T00:00:00.000Z"
+  });
 
   const store = createInMemoryDashboardChatStore();
   const calls = [];
@@ -673,19 +686,17 @@ test("worker allows dashboard passkey session to hand off chat to VPS runner que
       },
       body: JSON.stringify({
         threadId: "dashboard-main-marushu-vtdd-v2-p",
-        repository: "marushu/vtdd-v2-p",
-        issueNumber: 450,
-        relatedIssue: 450,
+        repositoryInput: "ぶい",
         dispatchToVpsRunner: true,
         executorTransport: "vps_runner",
-        codexGoal: "open_pr",
-        text: "dashboard から VPS Codex CLI に投げる"
+        text: "ぶい #450 の残り Issue と PR を確認して交通整理して"
       })
     }),
     {
       MEMORY_PROVIDER: provider,
       DASHBOARD_CHAT_STORE: store,
       GITHUB_APP_INSTALLATION_TOKEN: "ghs_dashboard_passkey_vps",
+      VTDD_DASHBOARD_CHAT_TRIAGE_ISSUE_NUMBER: "450",
       GITHUB_API_FETCH: async (url, init) => {
         calls.push({ url, init });
         return new Response(
@@ -703,10 +714,15 @@ test("worker allows dashboard passkey session to hand off chat to VPS runner que
   const body = await response.json();
   assert.equal(body.ok, true);
   assert.equal(body.execution.transport, "vps_runner");
+  assert.equal(body.execution.targetRepository, "marushu/vtdd-v2-p");
+  assert.equal(body.execution.issueNumber, 450);
+  assert.equal(body.execution.codexGoal, "dashboard_chat_triage");
   assert.equal(body.messages[1].role, "system");
   assert.equal(calls.length, 1);
   const queueBody = JSON.parse(calls[0].init.body).body;
   assert.equal(queueBody.includes('"dashboardThreadId": "dashboard-main-marushu-vtdd-v2-p"'), true);
+  assert.equal(queueBody.includes('"repositoryInput": "ぶい"'), true);
+  assert.equal(queueBody.includes('"ownerMessage": "ぶい #450 の残り Issue と PR を確認して交通整理して"'), true);
 });
 
 test("worker rejects unauthenticated dashboard chat VPS runner dispatch", async () => {

--- a/worker.js
+++ b/worker.js
@@ -55828,6 +55828,138 @@ var MCP_SERVER_INFO = Object.freeze({
   version: "0.1.0"
 });
 var MCP_INSTRUCTIONS = "VTDD MCP \u306F Butler \u3068\u540C\u3058 runtime truth / review truth / operational memory \u3092\u8AAD\u3080\u305F\u3081\u306E read-first surface \u3067\u3059\u3002\u73FE\u5728\u306E truth \u306F runtime truth \u3092\u512A\u5148\u3057\u3001memory \u306F\u88DC\u52A9\u3068\u3057\u3066\u6271\u3063\u3066\u304F\u3060\u3055\u3044\u3002";
+var DashboardChatRoom = class {
+  constructor(state, env) {
+    this.ctx = state;
+    this.env = env;
+    this.sessions = /* @__PURE__ */ new Set();
+  }
+  async fetch(request) {
+    const url = new URL(request.url);
+    if (request.method === "POST" && url.pathname === "/broadcast") {
+      const payload = await readJson(request);
+      const threadId2 = normalizeDashboardThreadId(payload.threadId || payload.thread_id);
+      if (!threadId2) {
+        return json(422, {
+          ok: false,
+          error: "thread_id_required",
+          reason: "threadId is required"
+        });
+      }
+      await this.broadcastThread({
+        threadId: threadId2,
+        messages: Array.isArray(payload.messages) ? payload.messages : null
+      });
+      return json(202, { ok: true, threadId: threadId2 });
+    }
+    if (request.headers.get("upgrade")?.toLowerCase() !== "websocket") {
+      return json(426, {
+        ok: false,
+        error: "websocket_upgrade_required",
+        reason: "dashboard chat room requires a WebSocket upgrade"
+      });
+    }
+    if (typeof WebSocketPair !== "function") {
+      return json(501, {
+        ok: false,
+        error: "websocket_runtime_unavailable",
+        reason: "WebSocketPair is not available in this runtime"
+      });
+    }
+    const threadId = extractDashboardChatSocketThreadId(url.pathname);
+    if (!threadId) {
+      return json(422, {
+        ok: false,
+        error: "thread_id_required",
+        reason: "threadId is required"
+      });
+    }
+    const pair = new WebSocketPair();
+    const [client, server] = Object.values(pair);
+    if (typeof this.ctx?.acceptWebSocket === "function") {
+      server.serializeAttachment({ threadId });
+      this.ctx.acceptWebSocket(server);
+    } else {
+      server.accept();
+      this.sessions.add(server);
+      server.addEventListener("close", () => this.sessions.delete(server));
+      server.addEventListener("error", () => this.sessions.delete(server));
+      server.addEventListener("message", (event) => this.handleSocketMessage(server, event?.data, threadId));
+    }
+    await this.sendThread(server, threadId);
+    return new Response(null, {
+      status: 101,
+      webSocket: client
+    });
+  }
+  async webSocketMessage(socket, message) {
+    const attachment = typeof socket.deserializeAttachment === "function" ? socket.deserializeAttachment() : null;
+    const threadId = normalizeDashboardThreadId(attachment?.threadId);
+    this.handleSocketMessage(socket, message, threadId);
+  }
+  webSocketClose(socket) {
+    this.sessions.delete(socket);
+  }
+  webSocketError(socket) {
+    this.sessions.delete(socket);
+  }
+  handleSocketMessage(socket, message, threadId) {
+    const text = normalizeDashboardEventText(message).toLowerCase();
+    if (text === "ping" && isSocketOpen(socket)) {
+      socket.send(JSON.stringify({ type: "pong", ok: true, threadId }));
+    }
+  }
+  async broadcastThread({ threadId, messages = null }) {
+    const resolvedMessages = Array.isArray(messages) ? messages : await this.listThreadMessages(threadId);
+    const payload = JSON.stringify({
+      type: "thread",
+      ok: true,
+      threadId,
+      messages: resolvedMessages
+    });
+    for (const socket of this.connectedSockets()) {
+      if (isSocketOpen(socket)) {
+        socket.send(payload);
+      }
+    }
+  }
+  async sendThread(socket, threadId) {
+    if (!isSocketOpen(socket)) return;
+    try {
+      socket.send(
+        JSON.stringify({
+          type: "thread",
+          ok: true,
+          threadId,
+          messages: await this.listThreadMessages(threadId)
+        })
+      );
+    } catch (error2) {
+      if (isSocketOpen(socket)) {
+        socket.send(
+          JSON.stringify({
+            type: "error",
+            ok: false,
+            reason: sanitizeDashboardChatText(error2?.message || "dashboard chat room failed")
+          })
+        );
+      }
+    }
+  }
+  async listThreadMessages(threadId) {
+    const store = resolveDashboardChatStore(this.env);
+    if (!store) {
+      return [];
+    }
+    return store.listThread(threadId, { limit: 80 });
+  }
+  connectedSockets() {
+    if (typeof this.ctx?.getWebSockets === "function") {
+      return this.ctx.getWebSockets();
+    }
+    return Array.from(this.sessions);
+  }
+};
 var CLOUDFLARE_ACCESS_JWKS_CACHE_TTL_MS = 5 * 60 * 1e3;
 var DASHBOARD_PASSKEY_SESSION_COOKIE = "vtdd_dashboard_session";
 var DASHBOARD_PASSKEY_SESSION_MAX_AGE_SECONDS = 60 * 60 * 8;
@@ -55922,6 +56054,9 @@ var runtime_default = {
     }
     if (request.method === "POST" && isApiPath(url.pathname, "/dashboard/chat/messages")) {
       return handleDashboardChatMessageRequest(request, env);
+    }
+    if (request.method === "GET" && isDashboardChatSocketApiPath(url.pathname)) {
+      return handleDashboardChatSocketRequest(request, url, env);
     }
     if (request.method === "GET" && isDashboardChatThreadApiPath(url.pathname)) {
       return handleDashboardChatThreadRequest(request, url, env);
@@ -58479,11 +58614,13 @@ async function handleVpsRunnerEventRequest(request, env) {
       }
     });
   }
+  const webSocketBroadcast = await notifyDashboardChatRoom({ env, threadId: event.threadId, messages });
   return json(202, {
     ok: true,
     event: event.event,
     threadId: event.threadId,
-    messages
+    messages,
+    webSocketBroadcast
   });
 }
 async function handleDashboardChatMessageRequest(request, env) {
@@ -58501,16 +58638,6 @@ async function handleDashboardChatMessageRequest(request, env) {
   }
   const payload = await readJson(request);
   const wantsVpsRunnerHandoff = shouldDispatchDashboardChatToVpsRunner(payload);
-  if (wantsVpsRunnerHandoff) {
-    const auth = authorizeGatewayRequest({ request, env, apiSuffix: "/dashboard/chat/messages" });
-    if (!auth.ok) {
-      return json(auth.status, {
-        ok: false,
-        error: "dashboard_vps_runner_dispatch_unauthorized",
-        reason: auth.reason
-      });
-    }
-  }
   const prepared = buildDashboardChatTurn(payload, { wantsVpsRunnerHandoff });
   if (!prepared.ok) {
     return json(422, {
@@ -58566,6 +58693,44 @@ async function handleDashboardChatMessageRequest(request, env) {
     messages,
     execution
   });
+}
+async function handleDashboardChatSocketRequest(request, url, env) {
+  const auth = await authorizeDashboardRequest({
+    request,
+    env,
+    apiSuffix: "/dashboard/chat/:threadId/ws"
+  });
+  if (!auth.ok) {
+    return json(auth.status, {
+      ok: false,
+      error: "dashboard_auth_required",
+      reason: auth.reason
+    });
+  }
+  const threadId = extractDashboardChatSocketThreadId(url.pathname);
+  if (!threadId) {
+    return json(422, {
+      ok: false,
+      error: "thread_id_required",
+      reason: "threadId is required"
+    });
+  }
+  const room = resolveDashboardChatRoomStub(env, threadId);
+  if (!room) {
+    return json(503, {
+      ok: false,
+      error: "dashboard_chat_room_unavailable",
+      reason: "DASHBOARD_CHAT_ROOMS Durable Object binding is not configured"
+    });
+  }
+  if (request.headers.get("upgrade")?.toLowerCase() !== "websocket") {
+    return json(426, {
+      ok: false,
+      error: "websocket_upgrade_required",
+      reason: "dashboard chat updates require a WebSocket upgrade"
+    });
+  }
+  return room.fetch(request);
 }
 async function handleDashboardChatThreadRequest(request, url, env) {
   const auth = await authorizeDashboardRequest({
@@ -59874,6 +60039,39 @@ function resolveDashboardChatStore(env) {
   dashboardChatStoreCache.set(d1Binding, store);
   return store;
 }
+function resolveDashboardChatRoomStub(env, threadId) {
+  const namespace = env?.DASHBOARD_CHAT_ROOMS ?? null;
+  const roomName = normalizeDashboardThreadId(threadId);
+  if (!namespace || !roomName) {
+    return null;
+  }
+  if (typeof namespace.getByName === "function") {
+    return namespace.getByName(roomName);
+  }
+  if (typeof namespace.idFromName === "function" && typeof namespace.get === "function") {
+    return namespace.get(namespace.idFromName(roomName));
+  }
+  return null;
+}
+async function notifyDashboardChatRoom({ env, threadId, messages }) {
+  const room = resolveDashboardChatRoomStub(env, threadId);
+  if (!room || typeof room.fetch !== "function") {
+    return false;
+  }
+  try {
+    const response = await room.fetch("https://dashboard-chat-room.internal/broadcast", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        threadId,
+        messages: Array.isArray(messages) ? messages : []
+      })
+    });
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
 function createD1DashboardEventStore(d1) {
   let schemaPromise = null;
   return {
@@ -60102,7 +60300,7 @@ function buildDashboardChatTurn(payload, options = {}) {
     },
     { threadId }
   );
-  const butlerMessage = normalizeDashboardChatMessage(
+  const butlerMessage = options.wantsVpsRunnerHandoff === true ? null : normalizeDashboardChatMessage(
     {
       threadId,
       role: "butler",
@@ -60112,8 +60310,7 @@ function buildDashboardChatTurn(payload, options = {}) {
       text: buildDeterministicButlerChatReply({
         text,
         repository,
-        relatedIssue,
-        wantsVpsRunnerHandoff: options.wantsVpsRunnerHandoff === true
+        relatedIssue
       }),
       createdAt: new Date(Date.parse(now) + 1).toISOString()
     },
@@ -60124,7 +60321,7 @@ function buildDashboardChatTurn(payload, options = {}) {
     repository,
     relatedIssue,
     threadId,
-    messages: [ownerMessage, butlerMessage]
+    messages: [ownerMessage, butlerMessage].filter(Boolean)
   };
 }
 function buildDeterministicButlerChatReply({ text, repository, relatedIssue, wantsVpsRunnerHandoff = false }) {
@@ -60220,11 +60417,11 @@ function buildDashboardVpsRunnerQueuedMessage({ prepared, execution }) {
   return normalizeDashboardChatMessage(
     {
       threadId: prepared.threadId,
-      role: "runner",
+      role: "system",
       repository: prepared.repository,
       relatedIssue: execution.issueNumber || prepared.relatedIssue,
       status: "thinking",
-      text: `VPS Codex CLI \u306B ${issuePhrase} \u306E bounded handoff \u3092\u6E21\u3057\u307E\u3057\u305F\u3002\u5B9F\u884C\u72B6\u614B\u306F runner event \u3068\u3057\u3066\u3053\u306E thread \u306B\u623B\u308A\u307E\u3059\u3002${queuePhrase}`,
+      text: `VPS Codex CLI queue \u306B ${issuePhrase} \u306E bounded handoff \u3092\u6E21\u3057\u307E\u3057\u305F\u3002\u3053\u308C\u306F\u8FD4\u4FE1\u3067\u306F\u3042\u308A\u307E\u305B\u3093\u3002runner \u304B\u3089\u306E event post \u3060\u3051\u3092\u8FD4\u4FE1\u3068\u3057\u3066\u3053\u306E thread \u306B\u8868\u793A\u3057\u307E\u3059\u3002${queuePhrase}`,
       createdAt: new Date(Date.now() + 2).toISOString()
     },
     { threadId: prepared.threadId }
@@ -60268,6 +60465,9 @@ function sanitizeDashboardChatText(value) {
 function isDashboardChatThreadApiPath(pathname) {
   return pathname.startsWith(`${CANONICAL_API_PREFIX}/dashboard/chat/`) || pathname.startsWith(`${LEGACY_API_PREFIX}/dashboard/chat/`);
 }
+function isDashboardChatSocketApiPath(pathname) {
+  return (pathname.startsWith(`${CANONICAL_API_PREFIX}/dashboard/chat/`) || pathname.startsWith(`${LEGACY_API_PREFIX}/dashboard/chat/`)) && pathname.endsWith("/ws");
+}
 function isDashboardPagePath(pathname) {
   return pathname === "/dashboard" || pathname.startsWith("/dashboard/") || pathname === "/orchestrator" || pathname.startsWith("/orchestrator/");
 }
@@ -60281,6 +60481,9 @@ function extractDashboardChatThreadId(pathname) {
   } catch {
     return normalizeDashboardThreadId(pathname.slice(prefix.length));
   }
+}
+function extractDashboardChatSocketThreadId(pathname) {
+  return extractDashboardChatThreadId(pathname.replace(/\/ws$/, ""));
 }
 function normalizeDashboardEventRecord(event) {
   const input = normalizeObject11(event);
@@ -61847,7 +62050,9 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
   const origin = normalize7(runtimeOrigin);
   const repository = "marushu/vtdd-v2-p";
   const encodedRepository = encodeURIComponent(repository);
+  const dashboardChatIssueNumber = 450;
   const chatThreadId = `dashboard-main-${repository.replace("/", "-")}`;
+  const socketOrigin = origin.replace(/^http/i, "ws");
   const latestDeployEvent = await retrieveLatestDashboardEvent({
     store: dashboardEventStore,
     kind: "github_actions_workflow_run",
@@ -62135,18 +62340,18 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
         <article class="bubble">
           <strong>Butler</strong>
           <p>\u305D\u306E\u65B9\u91DD\u3067\u9032\u3081\u307E\u3059\u3002\u4E2D\u592E\u306F\u30C1\u30E3\u30C3\u30C8\u3060\u3051\u3001\u72B6\u614B\u78BA\u8A8D\u30FB\u9032\u6357\u30FBRAG\u30FBworkflow\u30FBprototype cleanup \u306E\u6271\u3044\u306F\u30B5\u30A4\u30C9\u30D0\u30FC\u306E\u30E1\u30CB\u30E5\u30FC\u304B\u3089\u5FC5\u8981\u306A\u6642\u3060\u3051\u958B\u304D\u307E\u3059\u3002</p>
-          <p>deploy \u304C\u5FC5\u8981\u306B\u306A\u3063\u305F\u6642\u306F\u3001\u666E\u901A\u306E\u30C1\u30E3\u30C3\u30C8\u3068\u540C\u3058\u3088\u3046\u306B\u3053\u306E\u4F1A\u8A71\u5185\u3078 scope \u660E\u793A\u6E08\u307F\u306E passkey URL \u3092\u51FA\u3057\u307E\u3059\u3002VPS Codex CLI \u3078\u306E\u5B9F\u884C dispatch \u306F\u5225 gate \u3067\u6271\u3044\u307E\u3059\u3002</p>
-          <span class="connection-note">\u63A5\u7D9A\u6E08\u307F: Worker chat runtime \u306B\u4FDD\u5B58\u30FB\u8FD4\u4FE1\u3057\u307E\u3059</span>
+          <p>\u3053\u306E dashboard \u304B\u3089\u306E\u9001\u4FE1\u306F Issue #${dashboardChatIssueNumber} \u306E VPS Codex CLI queue \u306B\u6E21\u3057\u307E\u3059\u3002\u8FD4\u4FE1\u3068\u3057\u3066\u8868\u793A\u3059\u308B\u306E\u306F runner \u304B\u3089\u623B\u3063\u305F event post \u3060\u3051\u3067\u3059\u3002</p>
+          <span class="connection-note">\u63A5\u7D9A\u6E08\u307F: WebSocket \u3067 runner event post \u3092\u5F85\u3061\u307E\u3059</span>
         </article>
 
       </div>
 
-      <form class="composer" id="butler-chat-form" aria-label="Butler composer" data-endpoint="${escapeDashboardHtml(origin)}/v2/dashboard/chat/messages" data-thread-endpoint="${escapeDashboardHtml(origin)}/v2/dashboard/chat/${escapeDashboardHtml(chatThreadId)}" data-thread-id="${escapeDashboardHtml(chatThreadId)}" data-repository="${escapeDashboardHtml(repository)}">
+      <form class="composer" id="butler-chat-form" aria-label="Butler composer" data-endpoint="${escapeDashboardHtml(origin)}/v2/dashboard/chat/messages" data-thread-endpoint="${escapeDashboardHtml(origin)}/v2/dashboard/chat/${escapeDashboardHtml(chatThreadId)}" data-socket-endpoint="${escapeDashboardHtml(socketOrigin)}/v2/dashboard/chat/${escapeDashboardHtml(chatThreadId)}/ws" data-thread-id="${escapeDashboardHtml(chatThreadId)}" data-repository="${escapeDashboardHtml(repository)}" data-issue-number="${dashboardChatIssueNumber}" data-dispatch-to-vps-runner="true" data-codex-goal="open_pr">
         <div class="composer-box">
           <textarea id="butler-message" name="text" placeholder="Butler V2 \u306B\u30E1\u30C3\u30BB\u30FC\u30B8..." aria-label="Butler V2 \u306B\u30E1\u30C3\u30BB\u30FC\u30B8"></textarea>
           <button class="send-button" type="submit" aria-label="Butler \u306B\u9001\u4FE1">\u2191</button>
         </div>
-        <div class="composer-status" id="butler-chat-status">\u63A5\u7D9A\u6E08\u307F\u3002\u9001\u4FE1\u3059\u308B\u3068\u3053\u306E thread \u306B\u4FDD\u5B58\u3055\u308C\u307E\u3059\u3002\u81EA\u52D5\u66F4\u65B0\u30FBpolling \u306F\u3042\u308A\u307E\u305B\u3093\u3002</div>
+        <div class="composer-status" id="butler-chat-status">\u63A5\u7D9A\u6E08\u307F\u3002\u9001\u4FE1\u3059\u308B\u3068 VPS Codex CLI queue \u306B\u6E21\u3057\u307E\u3059\u3002\u8FD4\u4FE1\u306F runner event post \u3060\u3051\u3092\u8868\u793A\u3057\u307E\u3059\u3002</div>
       </form>
     </section>
 
@@ -62156,7 +62361,7 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
           <span class="eyebrow">\u7BA1\u7406\u30E1\u30CB\u30E5\u30FC</span>
           <strong>\u5FC5\u8981\u306A\u6642\u3060\u3051\u958B\u304F</strong>
         </span>
-        <span class="pill">\u81EA\u52D5\u66F4\u65B0\u306A\u3057</span>
+        <span class="pill">WebSocket</span>
       </summary>
       <div class="sidebar-content">
         <p class="menu-callout">\u72B6\u614B\u78BA\u8A8D\u3001\u9032\u6357\u3001RAG\u3001workflow \u306F\u3053\u3053\u304B\u3089\u9077\u79FB\u3057\u307E\u3059\u3002\u666E\u6BB5\u306E\u753B\u9762\u306F\u30C1\u30E3\u30C3\u30C8\u3092\u4E3B\u5F79\u306B\u3057\u307E\u3059\u3002</p>
@@ -62212,8 +62417,12 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
 
       const endpoint = form.dataset.endpoint;
       const threadEndpoint = form.dataset.threadEndpoint;
+      const socketEndpoint = form.dataset.socketEndpoint;
       const threadId = form.dataset.threadId;
       const repository = form.dataset.repository;
+      const issueNumber = Number.parseInt(form.dataset.issueNumber || "", 10);
+      const dispatchToVpsRunner = form.dataset.dispatchToVpsRunner === "true";
+      const codexGoal = form.dataset.codexGoal || "open_pr";
       const initialMarkup = log.innerHTML;
 
       function updateComposerReserve() {
@@ -62237,7 +62446,7 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
         article.className = message.role === "owner" ? "bubble owner" : "bubble";
         if (message.role !== "owner") {
           const strong = document.createElement("strong");
-          strong.textContent = message.role === "runner" ? "VPS Codex CLI" : "Butler";
+          strong.textContent = message.role === "runner" ? "VPS Codex CLI" : message.role === "system" ? "SYSTEM" : "Butler";
           article.appendChild(strong);
         }
         const paragraph = document.createElement("p");
@@ -62285,6 +62494,29 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
         scrollToLatest();
       }
 
+      function connectThreadSocket() {
+        if (!socketEndpoint || typeof WebSocket !== "function") {
+          setStatus("WebSocket \u3092\u958B\u59CB\u3067\u304D\u307E\u305B\u3093\u3002runner \u8FD4\u4FE1\u306F\u518D\u8AAD\u307F\u8FBC\u307F\u3067\u78BA\u8A8D\u3057\u3066\u304F\u3060\u3055\u3044\u3002");
+          return;
+        }
+        const socket = new WebSocket(socketEndpoint);
+        socket.addEventListener("open", () => {
+          setStatus("WebSocket \u63A5\u7D9A\u6E08\u307F\u3002VPS Codex CLI \u306E runner event post \u3092\u5F85\u3063\u3066\u3044\u307E\u3059\u3002");
+        });
+        socket.addEventListener("message", (event) => {
+          const body = JSON.parse(event.data || "{}");
+          if (body.type === "thread" && body.ok) {
+            renderThread(body.messages || []);
+          }
+        });
+        socket.addEventListener("close", () => {
+          setStatus("WebSocket \u304C\u5207\u308C\u307E\u3057\u305F\u3002\u518D\u8AAD\u307F\u8FBC\u307F\u3059\u308B\u3068\u6700\u65B0 thread \u3092\u78BA\u8A8D\u3067\u304D\u307E\u3059\u3002");
+        });
+        socket.addEventListener("error", () => {
+          setStatus("WebSocket \u63A5\u7D9A\u306B\u5931\u6557\u3057\u307E\u3057\u305F\u3002\u518D\u8AAD\u307F\u8FBC\u307F\u3059\u308B\u3068\u6700\u65B0 thread \u3092\u78BA\u8A8D\u3067\u304D\u307E\u3059\u3002");
+        });
+      }
+
       async function refreshThread() {
         if (!threadEndpoint) return;
         setStatus("\u4F1A\u8A71\u5C65\u6B74\u3092\u8AAD\u307F\u8FBC\u307F\u4E2D\u3067\u3059\u3002");
@@ -62300,7 +62532,7 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
             return;
           }
           renderThread(body.messages || []);
-          setStatus("\u63A5\u7D9A\u6E08\u307F\u3002\u9001\u4FE1\u3059\u308B\u3068\u3053\u306E thread \u306B\u4FDD\u5B58\u3055\u308C\u307E\u3059\u3002\u81EA\u52D5\u66F4\u65B0\u30FBpolling \u306F\u3042\u308A\u307E\u305B\u3093\u3002");
+          setStatus("\u63A5\u7D9A\u6E08\u307F\u3002\u9001\u4FE1\u3059\u308B\u3068 VPS Codex CLI queue \u306B\u6E21\u3057\u307E\u3059\u3002\u8FD4\u4FE1\u306F runner event post \u3060\u3051\u3092\u8868\u793A\u3057\u307E\u3059\u3002");
         } catch {
           setStatus("\u4F1A\u8A71\u5C65\u6B74\u3092\u8AAD\u3081\u307E\u305B\u3093\u3067\u3057\u305F\u3002\u9001\u4FE1\u6642\u306B\u518D\u8A66\u884C\u3057\u307E\u3059\u3002");
         }
@@ -62315,14 +62547,24 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
         }
         const submitButton = form.querySelector("button[type='submit']");
         if (submitButton) submitButton.disabled = true;
-        setStatus("\u9001\u4FE1\u4E2D\u3067\u3059\u3002Butler \u304C\u540C\u3058 thread \u306B\u8FD4\u4FE1\u3057\u307E\u3059\u3002");
+        setStatus("\u9001\u4FE1\u4E2D\u3067\u3059\u3002VPS Codex CLI queue \u306B\u6E21\u3057\u307E\u3059\u3002");
         const thinking = showThinking();
         try {
           const response = await fetch(endpoint, {
             method: "POST",
             headers: { "content-type": "application/json", "accept": "application/json" },
             credentials: "same-origin",
-            body: JSON.stringify({ threadId, repository, text })
+            body: JSON.stringify({
+              threadId,
+              repository,
+              text,
+              issueNumber,
+              relatedIssue: issueNumber,
+              dispatchToVpsRunner,
+              executorTransport: dispatchToVpsRunner ? "vps_runner" : undefined,
+              codexGoal,
+              handoffSummary: "Dashboard Butler chat message from owner"
+            })
           });
           const body = await response.json().catch(() => ({}));
           removeThinking(thinking);
@@ -62335,7 +62577,7 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
           for (const message of body.messages || []) {
             appendMessage(message);
           }
-          setStatus("\u4FDD\u5B58\u6E08\u307F\u3002Butler \u8FD4\u4FE1\u3092\u540C\u3058 thread \u306B\u8FFD\u52A0\u3057\u307E\u3057\u305F\u3002");
+          setStatus(body.execution ? "\u4FDD\u5B58\u6E08\u307F\u3002VPS Codex CLI queue \u306B\u6E21\u3057\u307E\u3057\u305F\u3002runner event post \u3092\u5F85\u3063\u3066\u3044\u307E\u3059\u3002" : "\u4FDD\u5B58\u6E08\u307F\u3002Worker runtime \u306B\u4FDD\u5B58\u3057\u307E\u3057\u305F\u3002");
         } catch {
           removeThinking(thinking);
           appendError("Worker chat runtime \u306B\u63A5\u7D9A\u3067\u304D\u307E\u305B\u3093\u3067\u3057\u305F\u3002\u30CD\u30C3\u30C8\u30EF\u30FC\u30AF\u307E\u305F\u306F deploy \u72B6\u614B\u3092\u78BA\u8A8D\u3057\u3066\u304F\u3060\u3055\u3044\u3002");
@@ -62350,6 +62592,7 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
       updateComposerReserve();
       window.addEventListener("resize", updateComposerReserve);
       refreshThread();
+      connectThreadSocket();
     })();
   <\/script>
 </body>
@@ -62494,6 +62737,9 @@ function normalizePositiveInteger9(value) {
   const number3 = Number(value);
   return Number.isInteger(number3) && number3 > 0 ? number3 : null;
 }
+function isSocketOpen(socket) {
+  return socket?.readyState === 1 || typeof WebSocket !== "undefined" && socket?.readyState === WebSocket.OPEN;
+}
 function normalizeTag3(value) {
   return normalizeText30(value).toLowerCase().replace(/[^a-z0-9:_-]+/g, "_");
 }
@@ -62515,5 +62761,6 @@ function isApiPath(pathname, suffix) {
 // src/worker.js
 var worker_default = runtime_default;
 export {
+  DashboardChatRoom,
   worker_default as default
 };

--- a/worker.js
+++ b/worker.js
@@ -33131,6 +33131,7 @@ var VpsRunnerCancelMode = Object.freeze({
   DRAIN_PENDING: "drain_pending"
 });
 var RemoteCodexDispatchGoal = Object.freeze({
+  DASHBOARD_CHAT_TRIAGE: "dashboard_chat_triage",
   OPEN_PR: "open_pr",
   REVISE_PR: "revise_pr",
   RESPOND_TO_REVIEW: "respond_to_review",
@@ -33181,7 +33182,7 @@ function createRemoteCodexExecutionRequest(input = {}) {
       relatedIssue: issueNumber,
       issueTraceable: issueNumber > 0
     },
-    preflightPolicy: buildExecutionPreflightPolicy(),
+    preflightPolicy: buildExecutionPreflightPolicy({ codexGoal }),
     handoffRequired: continuationContext.requiresHandoff === true,
     revisionTarget,
     handoff: Object.keys(handoff).length > 0 ? {
@@ -33189,6 +33190,8 @@ function createRemoteCodexExecutionRequest(input = {}) {
       approvalScopeMatched: handoff.approvalScopeMatched === true,
       summary: normalizeText18(handoff.summary),
       relatedIssue: normalizePositiveInteger3(handoff.relatedIssue),
+      ownerMessage: normalizeText18(handoff.ownerMessage),
+      repositoryInput: normalizeText18(handoff.repositoryInput),
       dashboardThreadId: normalizeText18(handoff.dashboardThreadId),
       targetPullRequest: revisionTarget
     } : null
@@ -33209,7 +33212,7 @@ function createRemoteCodexExecutionRequest(input = {}) {
   if (!request.codexGoal) {
     issues.push("codexGoal is required");
   } else if (!REMOTE_CODEX_DISPATCH_GOALS.has(request.codexGoal)) {
-    issues.push("codexGoal must be open_pr, revise_pr, respond_to_review, or post_merge_verify");
+    issues.push("codexGoal must be dashboard_chat_triage, open_pr, revise_pr, respond_to_review, or post_merge_verify");
   }
   if (!request.baseRef) {
     issues.push("baseRef is required");
@@ -34673,6 +34676,7 @@ function buildCodexCloudGitHubComment({ request }) {
   return lines.join("\n");
 }
 function buildVpsRunnerGitHubQueueComment({ request }) {
+  const isDashboardChatTriage = request.codexGoal === RemoteCodexDispatchGoal.DASHBOARD_CHAT_TRIAGE;
   const payload = {
     executionId: request.executionId,
     transport: RemoteCodexExecutorTransport.VPS_RUNNER,
@@ -34713,14 +34717,20 @@ function buildVpsRunnerGitHubQueueComment({ request }) {
     ] : [],
     "- Canonical spec: this GitHub Issue",
     "- Runtime truth: current GitHub branch / diff / PR / review comments",
-    request.codexGoal === RemoteCodexDispatchGoal.POST_MERGE_VERIFY ? "- Completion target: verify post-merge runtime truth and post GitHub-visible evidence" : "- Completion target: create or update a pull request",
-    "- PR body requirement: Codex must inspect `docs/pr-template-model.md`, `scripts/render-pr-body.mjs`, and `scripts/validate-pr-body.mjs`; the VPS runner will validate and normalize the PR body again before create/update.",
-    "- Context preflight requirement: the VPS runner will automatically read `AGENTS.md`, `docs/butler/thread-independent-startup-contract.md`, the canonical Issue, and the PR body contract files, then generate a machine-readable preflight receipt before Codex starts editing.",
+    isDashboardChatTriage ? "- Completion target: post a dashboard chat triage response to the same thread" : request.codexGoal === RemoteCodexDispatchGoal.POST_MERGE_VERIFY ? "- Completion target: verify post-merge runtime truth and post GitHub-visible evidence" : "- Completion target: create or update a pull request",
+    ...isDashboardChatTriage ? [
+      "- PR body requirement: not applicable; dashboard chat triage must not create or update a PR.",
+      "- Context preflight requirement: the VPS runner will automatically read `AGENTS.md`, `docs/butler/thread-independent-startup-contract.md`, and the canonical Issue, then generate a machine-readable preflight receipt before Codex starts triage."
+    ] : [
+      "- PR body requirement: Codex must inspect `docs/pr-template-model.md`, `scripts/render-pr-body.mjs`, and `scripts/validate-pr-body.mjs`; the VPS runner will validate and normalize the PR body again before create/update.",
+      "- Context preflight requirement: the VPS runner will automatically read `AGENTS.md`, `docs/butler/thread-independent-startup-contract.md`, the canonical Issue, and the PR body contract files, then generate a machine-readable preflight receipt before Codex starts editing.",
+      "- Required PR body markers: `## This PR satisfies Intent`, `## Satisfied Success Criteria`, `## Unsatisfied Success Criteria`, `## Verification Evidence`, `## Surface Update Checklist`."
+    ],
     "- Missing preflight inputs do not authorize speculative implementation; the runner must ask Butler/owner to confirm the next action, then wait for a reissued bounded request.",
-    "- Required PR body markers: `## This PR satisfies Intent`, `## Satisfied Success Criteria`, `## Unsatisfied Success Criteria`, `## Verification Evidence`, `## Surface Update Checklist`.",
     "",
     "Rules:",
     "- Do not expand scope beyond the Issue.",
+    ...isDashboardChatTriage ? ["- Do not edit files.", "- Do not commit.", "- Do not push.", "- Do not create or update PRs."] : [],
     "- Do not merge.",
     "- Do not deploy.",
     "- Preserve reviewer objections for Butler/human judgment.",
@@ -34731,17 +34741,22 @@ function buildVpsRunnerGitHubQueueComment({ request }) {
   ];
   return lines.join("\n");
 }
-function buildExecutionPreflightPolicy() {
-  return {
-    mode: "auto_receipt",
-    onMissingContract: "owner_decision_required",
-    requiredRepoFiles: [
-      "AGENTS.md",
-      "docs/butler/thread-independent-startup-contract.md",
+function buildExecutionPreflightPolicy({ codexGoal } = {}) {
+  const requiredRepoFiles = [
+    "AGENTS.md",
+    "docs/butler/thread-independent-startup-contract.md"
+  ];
+  if (codexGoal !== RemoteCodexDispatchGoal.DASHBOARD_CHAT_TRIAGE) {
+    requiredRepoFiles.push(
       "docs/pr-template-model.md",
       "scripts/render-pr-body.mjs",
       "scripts/validate-pr-body.mjs"
-    ]
+    );
+  }
+  return {
+    mode: "auto_receipt",
+    onMissingContract: "owner_decision_required",
+    requiredRepoFiles
   };
 }
 function resolveExecutorTransport(input = {}, options = {}) {
@@ -56021,6 +56036,7 @@ var runtime_default = {
         200,
         await renderV2DashboardPage({
           runtimeOrigin: url.origin,
+          url,
           dashboardEventStore: resolveDashboardEventStore(env)
         })
       );
@@ -58638,7 +58654,24 @@ async function handleDashboardChatMessageRequest(request, env) {
   }
   const payload = await readJson(request);
   const wantsVpsRunnerHandoff = shouldDispatchDashboardChatToVpsRunner(payload);
-  const prepared = buildDashboardChatTurn(payload, { wantsVpsRunnerHandoff });
+  const repositoryResolution = await resolveDashboardChatRepository({ payload, env });
+  if (!repositoryResolution.ok) {
+    return json(repositoryResolution.status ?? 422, {
+      ok: false,
+      error: repositoryResolution.error,
+      reason: repositoryResolution.reason,
+      issues: repositoryResolution.issues ?? [],
+      candidates: repositoryResolution.candidates ?? []
+    });
+  }
+  const prepared = buildDashboardChatTurn(
+    {
+      ...payload,
+      repository: repositoryResolution.repository,
+      relatedIssue: normalizePositiveInteger9(payload?.relatedIssue || payload?.issueNumber) || extractIssueNumberFromDashboardChatText(payload?.text || payload?.message || payload?.body)
+    },
+    { wantsVpsRunnerHandoff }
+  );
   if (!prepared.ok) {
     return json(422, {
       ok: false,
@@ -58657,7 +58690,7 @@ async function handleDashboardChatMessageRequest(request, env) {
   let execution = null;
   let messagesToStore = prepared.messages;
   if (wantsVpsRunnerHandoff) {
-    const handoffPayload = buildDashboardVpsRunnerHandoffPayload({ payload, prepared });
+    const handoffPayload = buildDashboardVpsRunnerHandoffPayload({ payload, prepared, env });
     if (!handoffPayload.ok) {
       return json(422, {
         ok: false,
@@ -60053,6 +60086,52 @@ function resolveDashboardChatRoomStub(env, threadId) {
   }
   return null;
 }
+async function resolveDashboardChatRepository({ payload, env }) {
+  const input = normalizeObject11(payload);
+  const rawRepositoryInput = normalizeDashboardEventText(input.repository || input.repositoryInput || input.repository_input) || extractRepositoryTokenFromDashboardChatText(input.text || input.message || input.body);
+  const canonicalRepository = normalizeCanonicalRepositoryInput(rawRepositoryInput);
+  if (canonicalRepository) {
+    return {
+      ok: true,
+      repository: canonicalRepository,
+      input: rawRepositoryInput,
+      via: "canonical"
+    };
+  }
+  if (!rawRepositoryInput) {
+    return {
+      ok: false,
+      status: 422,
+      error: "repository_required",
+      reason: "repository or repository nickname is required before dashboard can hand off to VPS Codex CLI",
+      issues: ["top chat must include a repository target or open the dashboard with repositoryInput"]
+    };
+  }
+  const provider = resolveMemoryProvider(env);
+  const registryResult = await safeRetrieveStoredAliasRegistry(provider);
+  const aliasRegistry = registryResult.ok ? registryResult.aliasRegistry : [];
+  const resolved = resolveRepositoryTarget({
+    input: rawRepositoryInput,
+    mode: TaskMode.EXECUTION,
+    aliasRegistry
+  });
+  if (resolved.resolved) {
+    return {
+      ok: true,
+      repository: resolved.repository,
+      input: rawRepositoryInput,
+      via: resolved.via || "alias"
+    };
+  }
+  return {
+    ok: false,
+    status: resolved.ambiguous ? 409 : 422,
+    error: resolved.ambiguous ? "repository_nickname_ambiguous" : "repository_unresolved",
+    reason: resolved.reason || "repository could not be resolved",
+    issues: registryResult.ok ? ["repository nickname could not be resolved"] : [registryResult.reason || "repository nickname registry could not be read"],
+    candidates: resolved.candidates || []
+  };
+}
 async function notifyDashboardChatRoom({ env, threadId, messages }) {
   const room = resolveDashboardChatRoomStub(env, threadId);
   if (!room || typeof room.fetch !== "function") {
@@ -60071,6 +60150,26 @@ async function notifyDashboardChatRoom({ env, threadId, messages }) {
   } catch {
     return false;
   }
+}
+function extractRepositoryTokenFromDashboardChatText(value) {
+  const text = sanitizeDashboardChatText(value);
+  if (!text) {
+    return "";
+  }
+  const canonicalMatch = text.match(/^[\s　]*([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)/);
+  if (canonicalMatch) {
+    return canonicalMatch[1];
+  }
+  const nicknameMatch = text.match(/^[\s　]*([^\s　#「『【\\/:]+)(?:\s+|[　]*の|[　]*を|[　]*で|[　]*に)/u);
+  return normalizeDashboardEventText(nicknameMatch?.[1]);
+}
+function extractIssueNumberFromDashboardChatText(value) {
+  const text = sanitizeDashboardChatText(value);
+  const match = text.match(/#([1-9][0-9]*)/);
+  return normalizePositiveInteger9(match?.[1]);
+}
+function normalizeDashboardRepositoryInput(value) {
+  return normalizeDashboardEventText(value).toLowerCase();
 }
 function createD1DashboardEventStore(d1) {
   let schemaPromise = null;
@@ -60342,18 +60441,18 @@ function shouldDispatchDashboardChatToVpsRunner(payload) {
   const input = normalizeObject11(payload);
   return input.dispatchToVpsRunner === true || input.vpsRunnerHandoff === true || normalizeDashboardEventText(input.executorTransport).toLowerCase() === "vps_runner";
 }
-function buildDashboardVpsRunnerHandoffPayload({ payload, prepared }) {
+function buildDashboardVpsRunnerHandoffPayload({ payload, prepared, env }) {
   const input = normalizeObject11(payload);
-  const issueNumber = normalizePositiveInteger9(input.issueNumber || input.relatedIssue) || prepared.relatedIssue;
+  const issueNumber = normalizePositiveInteger9(input.issueNumber || input.relatedIssue) || prepared.relatedIssue || normalizePositiveInteger9(env?.VTDD_DASHBOARD_CHAT_TRIAGE_ISSUE_NUMBER);
   if (!issueNumber) {
     return {
       ok: false,
       error: "dashboard_vps_runner_issue_required",
-      reason: "issueNumber is required before dashboard can hand off a message to VPS Codex CLI",
-      issues: ["dashboard VPS runner handoff requires a GitHub Issue number"]
+      reason: "issueNumber or VTDD_DASHBOARD_CHAT_TRIAGE_ISSUE_NUMBER is required before dashboard can hand off a message to VPS Codex CLI",
+      issues: ["dashboard VPS runner handoff requires a GitHub Issue queue target"]
     };
   }
-  const codexGoal = normalizeDashboardEventText(input.codexGoal || input.goal || "open_pr").toLowerCase();
+  const codexGoal = normalizeDashboardEventText(input.codexGoal || input.goal || "dashboard_chat_triage").toLowerCase();
   const branch = normalizeDashboardEventText(input.branch || input.targetBranch) || `codex/issue-${issueNumber}-dashboard-vps-chat`;
   const baseRef = normalizeDashboardEventText(input.baseRef || input.base_ref) || "main";
   const summary = normalizeDashboardEventText(input.handoffSummary || input.summary) || `Dashboard chat VPS runner handoff for Issue #${issueNumber}`;
@@ -60372,6 +60471,10 @@ function buildDashboardVpsRunnerHandoffPayload({ payload, prepared }) {
           approvalScopeMatched: true,
           relatedIssue: issueNumber,
           summary,
+          ownerMessage: sanitizeDashboardChatText(input.text || input.message || input.body),
+          repositoryInput: normalizeDashboardRepositoryInput(
+            input.repositoryInput || input.repository_input || input.repository || prepared.repository
+          ),
           dashboardThreadId: prepared.threadId
         }
       },
@@ -62046,17 +62149,20 @@ function normalizeTextList2(value) {
 function uniqueTextList2(value) {
   return [...new Set(normalizeTextList2(value))];
 }
-async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}) {
+async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore } = {}) {
   const origin = normalize7(runtimeOrigin);
-  const repository = "marushu/vtdd-v2-p";
-  const encodedRepository = encodeURIComponent(repository);
-  const dashboardChatIssueNumber = 450;
-  const chatThreadId = `dashboard-main-${repository.replace("/", "-")}`;
+  const repositoryInput = normalizeDashboardRepositoryInput(
+    url?.searchParams?.get("repositoryInput") || url?.searchParams?.get("repository")
+  );
+  const dashboardIssueNumber = normalizePositiveInteger9(url?.searchParams?.get("issueNumber"));
+  const dashboardTargetLabel = repositoryInput || "repo/nickname \u672A\u6307\u5B9A";
+  const encodedRepository = encodeURIComponent(repositoryInput);
+  const chatThreadId = `dashboard-main-${(repositoryInput || "unresolved").replace(/[^a-z0-9_.-]+/gi, "-")}`;
   const socketOrigin = origin.replace(/^http/i, "ws");
   const latestDeployEvent = await retrieveLatestDashboardEvent({
     store: dashboardEventStore,
     kind: "github_actions_workflow_run",
-    repository,
+    repository: normalizeCanonicalRepositoryInput(repositoryInput),
     workflowName: "deploy-production"
   });
   const surfaces = [
@@ -62277,7 +62383,7 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
           <label class="round-button menu-open" for="mobile-menu-toggle" aria-label="\u7BA1\u7406\u30E1\u30CB\u30E5\u30FC\u3092\u958B\u304F">\u2261</label>
           <div class="thread-title">
             <h1>VTDD Butler</h1>
-            <span>${escapeDashboardHtml(repository)} \u30FB dashboard main chat</span>
+            <span>${escapeDashboardHtml(dashboardTargetLabel)} \u30FB dashboard main chat</span>
           </div>
         </div>
         <div class="top-right">
@@ -62329,9 +62435,8 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
           <p>\u306F\u3044\u3002\u79C1\u306F v2 \u306E Butler \u3068\u3057\u3066\u3001Issue \u99C6\u52D5\u30FBGitHub runtime truth\u30FBVPS runner\u30FBGemini reviewer\u30FBRAG\u30FBpasskey \u5883\u754C\u3092\u6271\u3044\u307E\u3059\u3002</p>
           <p>\u3053\u306E\u753B\u9762\u306F\u4F1A\u8A71\u3092\u4E3B\u5F79\u306B\u3059\u308B\u305F\u3081\u306E chat-first runtime \u3067\u3059\u3002\u7BA1\u7406\u753B\u9762\u306F\u53F3\u306E\u30B5\u30A4\u30C9\u30D0\u30FC\u3078\u9000\u907F\u3057\u307E\u3057\u305F\u3002</p>
           <ul>
-            <li>\u95A2\u9023 repo: <code>${escapeDashboardHtml(repository)}</code></li>
-            <li>Issue \u5019\u88DC: #433 \u306E\u7D99\u7D9A\u30B9\u30E9\u30A4\u30B9</li>
-            <li>\u4F1A\u8A71: \u3053\u306E\u753B\u9762\u304B\u3089\u9001\u4FE1\u3059\u308B\u3068\u3001\u540C\u3058 thread \u306B Butler \u8FD4\u4FE1\u304C\u6B8B\u308A\u307E\u3059</li>
+            <li>\u95A2\u9023 repo/nickname: <code>${escapeDashboardHtml(dashboardTargetLabel)}</code></li>
+            <li>\u4F1A\u8A71: \u3053\u306E\u753B\u9762\u304B\u3089\u9001\u4FE1\u3059\u308B\u3068\u3001VPS Codex CLI \u304C repo \u89E3\u6C7A\u30FBIssue/PR/RAG/\u9032\u6357/\u627F\u8A8D\u5883\u754C\u3092\u4EA4\u901A\u6574\u7406\u3057\u307E\u3059</li>
           </ul>
         </article>
         <article class="bubble owner">
@@ -62340,13 +62445,13 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
         <article class="bubble">
           <strong>Butler</strong>
           <p>\u305D\u306E\u65B9\u91DD\u3067\u9032\u3081\u307E\u3059\u3002\u4E2D\u592E\u306F\u30C1\u30E3\u30C3\u30C8\u3060\u3051\u3001\u72B6\u614B\u78BA\u8A8D\u30FB\u9032\u6357\u30FBRAG\u30FBworkflow\u30FBprototype cleanup \u306E\u6271\u3044\u306F\u30B5\u30A4\u30C9\u30D0\u30FC\u306E\u30E1\u30CB\u30E5\u30FC\u304B\u3089\u5FC5\u8981\u306A\u6642\u3060\u3051\u958B\u304D\u307E\u3059\u3002</p>
-          <p>\u3053\u306E dashboard \u304B\u3089\u306E\u9001\u4FE1\u306F Issue #${dashboardChatIssueNumber} \u306E VPS Codex CLI queue \u306B\u6E21\u3057\u307E\u3059\u3002\u8FD4\u4FE1\u3068\u3057\u3066\u8868\u793A\u3059\u308B\u306E\u306F runner \u304B\u3089\u623B\u3063\u305F event post \u3060\u3051\u3067\u3059\u3002</p>
+          <p>\u3053\u306E dashboard \u304B\u3089\u306E\u9001\u4FE1\u306F VPS Codex CLI \u306E dashboard chat triage queue \u306B\u6E21\u3057\u307E\u3059\u3002\u8FD4\u4FE1\u3068\u3057\u3066\u8868\u793A\u3059\u308B\u306E\u306F runner \u304B\u3089\u623B\u3063\u305F event post \u3060\u3051\u3067\u3059\u3002</p>
           <span class="connection-note">\u63A5\u7D9A\u6E08\u307F: WebSocket \u3067 runner event post \u3092\u5F85\u3061\u307E\u3059</span>
         </article>
 
       </div>
 
-      <form class="composer" id="butler-chat-form" aria-label="Butler composer" data-endpoint="${escapeDashboardHtml(origin)}/v2/dashboard/chat/messages" data-thread-endpoint="${escapeDashboardHtml(origin)}/v2/dashboard/chat/${escapeDashboardHtml(chatThreadId)}" data-socket-endpoint="${escapeDashboardHtml(socketOrigin)}/v2/dashboard/chat/${escapeDashboardHtml(chatThreadId)}/ws" data-thread-id="${escapeDashboardHtml(chatThreadId)}" data-repository="${escapeDashboardHtml(repository)}" data-issue-number="${dashboardChatIssueNumber}" data-dispatch-to-vps-runner="true" data-codex-goal="open_pr">
+      <form class="composer" id="butler-chat-form" aria-label="Butler composer" data-endpoint="${escapeDashboardHtml(origin)}/v2/dashboard/chat/messages" data-thread-endpoint="${escapeDashboardHtml(origin)}/v2/dashboard/chat/${escapeDashboardHtml(chatThreadId)}" data-socket-endpoint="${escapeDashboardHtml(socketOrigin)}/v2/dashboard/chat/${escapeDashboardHtml(chatThreadId)}/ws" data-thread-id="${escapeDashboardHtml(chatThreadId)}" data-repository-input="${escapeDashboardHtml(repositoryInput)}" data-issue-number="${dashboardIssueNumber || ""}" data-dispatch-to-vps-runner="true" data-codex-goal="dashboard_chat_triage">
         <div class="composer-box">
           <textarea id="butler-message" name="text" placeholder="Butler V2 \u306B\u30E1\u30C3\u30BB\u30FC\u30B8..." aria-label="Butler V2 \u306B\u30E1\u30C3\u30BB\u30FC\u30B8"></textarea>
           <button class="send-button" type="submit" aria-label="Butler \u306B\u9001\u4FE1">\u2191</button>
@@ -62368,13 +62473,13 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
 
         <div class="lane">
           <div class="lane-title"><h3>\u95A2\u9023 repo</h3><span class="pill">resolved</span></div>
-          <p><strong>${escapeDashboardHtml(repository)}</strong></p>
+          <p><strong>${escapeDashboardHtml(dashboardTargetLabel)}</strong></p>
           <p class="muted">nickname / startup preflight / GitHub runtime truth \u306F\u65E2\u5B58 v2 route \u3067\u78BA\u8A8D\u3057\u307E\u3059\u3002</p>
         </div>
 
         <div class="lane">
           <div class="lane-title"><h3>Issue \u5019\u88DC</h3><span class="pill">draft</span></div>
-          <p>\u4F1A\u8A71\u5165\u53E3\u306E UI \u306F Issue #433 \u3068\u3057\u3066\u56FA\u5B9A\u6E08\u307F\u3002\u672C\u7269\u306E\u53CC\u65B9\u5411\u30C1\u30E3\u30C3\u30C8\u3001\u97F3\u58F0 overlay\u3001\u30D5\u30A1\u30A4\u30EB upload \u306F\u5225 Issue \u3067\u3059\u3002</p>
+          <p>\u30C8\u30C3\u30D7\u30C1\u30E3\u30C3\u30C8\u306F Custom GPT \u76F8\u5F53\u306E\u81EA\u7136\u6587\u5165\u53E3\u3067\u3059\u3002repo/nickname \u89E3\u6C7A\u3001Issue/PR/RAG/\u9032\u6357/\u627F\u8A8D\u5883\u754C\u3092 VPS Codex CLI \u306B\u4EA4\u901A\u6574\u7406\u3055\u305B\u307E\u3059\u3002</p>
         </div>
 
         <div class="lane">
@@ -62419,10 +62524,10 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
       const threadEndpoint = form.dataset.threadEndpoint;
       const socketEndpoint = form.dataset.socketEndpoint;
       const threadId = form.dataset.threadId;
-      const repository = form.dataset.repository;
+      const repositoryInput = form.dataset.repositoryInput;
       const issueNumber = Number.parseInt(form.dataset.issueNumber || "", 10);
       const dispatchToVpsRunner = form.dataset.dispatchToVpsRunner === "true";
-      const codexGoal = form.dataset.codexGoal || "open_pr";
+      const codexGoal = form.dataset.codexGoal || "dashboard_chat_triage";
       const initialMarkup = log.innerHTML;
 
       function updateComposerReserve() {
@@ -62556,7 +62661,7 @@ async function renderV2DashboardPage({ runtimeOrigin, dashboardEventStore } = {}
             credentials: "same-origin",
             body: JSON.stringify({
               threadId,
-              repository,
+              repositoryInput,
               text,
               issueNumber,
               relatedIssue: issueNumber,

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -2,5 +2,17 @@ name = "vtdd-v2-mvp"
 main = "worker.js"
 compatibility_date = "2026-04-15"
 
+[[durable_objects.bindings]]
+name = "DASHBOARD_CHAT_ROOMS"
+class_name = "DashboardChatRoom"
+
+[[migrations]]
+tag = "v1-dashboard-chat-rooms"
+new_sqlite_classes = ["DashboardChatRoom"]
+
 [env.production]
 name = "vtdd-v2-mvp"
+
+[[env.production.durable_objects.bindings]]
+name = "DASHBOARD_CHAT_ROOMS"
+class_name = "DashboardChatRoom"


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #450 の dashboard Butler chat を、定型返信ではなく VPS Codex CLI runner event post 由来の返信だけを表示する runtime に寄せる。
- トップチャットを `open_pr` フォームではなく `dashboard_chat_triage` の自然文入口として扱い、repo/nickname、元メッセージ、dashboard thread を VPS runner queue へ渡す。
- VPS Codex CLI 側の triage prompt に Custom GPT Butler 相当の交通整理要件を明示し、Issue/PR/GitHub runtime truth/RAG/承認境界/Issue 分割候補/実行 handoff/blocker を分類して返す契約にした。

## Satisfied Success Criteria

- dashboard 送信は dashboard auth/passkey session から VPS runner queue へ渡る。
- VPS handoff ありの送信では `buildDeterministicButlerChatReply` を返信として保存しない。
- Dashboard chat live updates は Durable Object `DashboardChatRoom` の WebSocket room に接続する。
- `/v2/events/vps-runner` が保存した runner chat message を同じ Durable Object room へ broadcast する。
- `wrangler.toml` に `DASHBOARD_CHAT_ROOMS` Durable Object binding と migration を追加した。
- dashboard chat handoff の既定 goal を `dashboard_chat_triage` にし、queue comment へ `ownerMessage` / `repositoryInput` / `dashboardThreadId` を保存する。
- dashboard chat は固定 repo 既定値を持たず、canonical repo または nickname alias で解決できない場合は fail closed する。
- VPS runner の `dashboard_chat_triage` は clone + preflight + Codex prompt + `/v2/events/vps-runner` post の経路に入り、PR 作成・commit・push・merge・deploy・Issue close を禁止する。

## Unsatisfied Success Criteria

- Cloudflare deploy 後の iPhone 実機 E2E は未実施。
- 実際の VPS Codex CLI が queue を拾い、`/v2/events/vps-runner` へ返信 event post し、dashboard WebSocket 上で表示される live evidence は未取得。
- Custom GPT でできていた全操作の live parity は未検証。特に nickname、GitHub Issue/PR truth、Issue 分割候補、実行 handoff、RAG candidate、approval URL、blocker の実機確認が必要。
- この PR だけでは Issue #450 を close しない。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #450
- Implementing Success Criteria: dashboard から VPS Codex CLI queue へ送る、runner event post だけを返信として表示する、WebSocket で同一 thread 更新を受ける、dashboard chat を `dashboard_chat_triage` として repo/nickname 解決込みで VPS runner に渡す
- Explicit Non-goals: 音声入力、画像添付、Custom GPT Action Schema 変更、Issue close、deploy 実行、実機 live parity の完了宣言
- Expected touched files/routes/workflows: `src/worker/runtime.js`, `worker.js`, `src/core/remote-codex-executor.js`, `scripts/run-vps-runner.mjs`, `wrangler.toml`, `test/worker.test.js`, `test/remote-codex-executor.test.js`, `test/vps-runner-script.test.js`, `test/production-deploy-path.test.js`
- Affected Issues: Issue #450
- Affected PRs: PR #466
- Affected workflows: Cloudflare deploy は Durable Object migration を含むため deploy 後確認が必要
- Affected runtime/operator surfaces: dashboard `/v2/dashboard/chat/messages`, `/v2/dashboard/chat/:threadId/ws`, `/v2/events/vps-runner`, VPS runner queue comment parser/executor, Cloudflare Durable Object `DashboardChatRoom`
- What may break if we patch narrowly: Durable Object binding が production deploy に反映されないと WebSocket は 503 で停止する。runner triage が fake 返信に戻ると dashboard が張りぼてになる。repo 既定値を戻すと別 repo 開発と nickname 運用が壊れる。
- Unknowns to investigate before coding: live Cloudflare runtime で DO migration が通ること、VPS runner が dashboardThreadId を保持して event post すること、Custom GPT parity の各操作が iPhone dashboard から実際に継続できること
- Validation needed: `npm test`、deploy 後 iPhone dashboard live E2E、VPS runner からの実返信 event post 確認、nickname/Issue/PR/RAG/approval 境界の live parity 確認
- Stop condition: runner event post が届かない、Worker 生成の定型文が返信として表示される、repo/nickname が解決不能なのに実行へ進む、または live parity 未検証なのに Issue #450 完了扱いにする場合は停止する

## File / Line Hypotheses

- file: `src/worker/runtime.js`
  - hypothesis: dashboard POST が定型返信を作っており、VPS runner queue と runner event post 表示が分離できていない。
  - risk if changed narrowly: queue 受付を runner 返信に見せるとまた張りぼてになる。
  - validation: VPS handoff 時の messages は owner + system だけ、runner role は `/v2/events/vps-runner` 由来だけにする。
  - related Issue: Issue #450
- file: `src/core/remote-codex-executor.js`
  - hypothesis: `dashboard_chat_triage` を正式 goal にしないと queue comment が PR 作成 request に見え、元メッセージや nickname が落ちる。
  - risk if changed narrowly: VPS runner が dashboard chat を通常 PR 実装として処理する。
  - validation: queue payload に `ownerMessage` / `repositoryInput` / `dashboardThreadId` が残り、PR body markers は triage queue から消える。
  - related Issue: Issue #450
- file: `scripts/run-vps-runner.mjs`
  - hypothesis: runner 側に triage goal の専用経路が必要。通常 open_pr 経路では会話交通整理にならない。
  - risk if changed narrowly: dashboard chat が PR 作成・commit・push へ流れる。
  - validation: `dashboard_chat_triage` prompt が Custom GPT parity と mutation 禁止を含み、preflight 後に runner event post を返す。
  - related Issue: Issue #450

## Hypothesis Retrospective

- expected: dashboard は VPS handoff 直後に定型返信を表示しない。
- actual: VPS handoff 時は SYSTEM の queue 受付だけを保存し、runner event post だけが runner message になる。
- mismatch: 既存実装は定型文を Butler/runner 返信のように見せていた。また dashboard chat queue が `open_pr` 前提に寄っていた。
- lesson: WebSocket UI でも runner truth が無ければ返信扱いしない。トップチャットは `dashboard_chat_triage` として repo/nickname と owner message を失わず VPS Codex CLI に渡す必要がある。
- should become RAG candidate: true

## Verification Evidence

- Unit: `node --test test/worker.test.js test/remote-codex-executor.test.js test/vps-runner-script.test.js` passed: 253 pass / 0 fail.
- Integration: `npm test` passed: `node --test` 874 pass / 1 skip / 0 fail, `check:self-parity` passed, `check:generated-worker` passed.
- E2E: 未実施。deploy 後に iPhone dashboard から送信し、VPS runner event post が WebSocket 表示されることを確認する。
- Manual: 未実施。
- Evidence path/link: local test output for this PR update, GitHub Actions to be checked after push.

## Butler Completion Contract

- Owner goal: iPhone dashboard のトップチャットに自然文を投げるだけで Butler/VPS Codex CLI が交通整理し、必要なら Issue 分割・既存 Issue 紐付け・実行キュー・確認待ちへ振り分け、VPS Codex CLI の返信だけを chat に表示する。
- Butler entrypoint: dashboard composer: `/dashboard` -> `/v2/dashboard/chat/messages`
- Action Schema exposure: 未変更。Custom GPT Action Schema ではなく dashboard runtime の修正。
- Runtime path: `POST /v2/dashboard/chat/messages` -> `vps_runner` queue; `GET /v2/dashboard/chat/:threadId/ws` -> `DashboardChatRoom` Durable Object WebSocket; `POST /v2/events/vps-runner` -> chat store + room broadcast
- Runner/runtime truth: queue comment creation, dashboard chat store messages, `webSocketBroadcast` boolean, VPS runner event records, `dashboard_chat_triage_completed` final event
- Authority boundary: dashboard auth/passkey session が必要。VPS event post は machine auth が必要。deploy は未実行。Issue 作成/分割や実行は既存 GO/passkey 境界に従う必要がある。
- E2E evidence: 未完了。Cloudflare deploy 後に owner の iPhone dashboard で live E2E が必要。Custom GPT parity の各操作も live 確認が必要。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 必要。Durable Object binding/migration を含むため passkey approval 後に deploy run URL を提示する。
- Custom GPT Action Schema update: 不要
- Custom GPT Instructions update: 不要
- iPhone Butler live E2E: 必要。Issue #450 close 前に実施する。

## Related Constitution Rules

- Butler Completion Gate
- Butler-First Operating Principle
- Evidence Discipline
- Change Size and PR Discipline
- Authority Boundary

## Out-of-scope but NOT implemented

- Issue #450 close
- deploy 実行
- 画像添付・音声入力
- Custom GPT Action Schema 更新
- Custom GPT 全機能同等の live 完了宣言

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #450
- Execution ID: dashboard-chat-triage-pr466
- Goal: dashboard_chat_triage
