### PR TITLE
Post VPS runner replies to dashboard chat

### DIFF
--- a/scripts/run-vps-runner.mjs
+++ b/scripts/run-vps-runner.mjs
@@ -1122,7 +1122,7 @@ function buildVpsRunnerStateComment({ executionId, event }) {
   return [
     `<!-- vtdd:vps-runner-state:${executionId} -->`,
     `<!-- vtdd:vps-runner-event:${executionId} -->`,
-    "VTDD VPS runner state.",
+    "VTDD VPS runner 状態です。",
     "",
     ...formatLeadTimeCommentLines(event?.leadTime),
     fencedJson(event)
@@ -1812,7 +1812,7 @@ function sanitizeIncidentField(value) {
     .slice(0, 240);
 }
 
-async function postVpsRunnerEvent({ githubFetch, payload, event, notification }) {
+async function postVpsRunnerEvent({ githubFetch, payload, event, notification, env = process.env, fetchImpl = globalThis.fetch }) {
   const now = new Date().toISOString();
   payload.lifecycle = updateVpsRunnerLifecycleForEvent({
     lifecycle: payload.lifecycle,
@@ -1832,6 +1832,12 @@ async function postVpsRunnerEvent({ githubFetch, payload, event, notification })
     return upsertVpsRunnerStateComment({ githubFetch, payload, event: eventPayload });
   }
 
+  eventPayload.dashboardDelivery = await postVpsRunnerDashboardEvent({
+    eventPayload,
+    env,
+    fetchImpl
+  });
+
   return githubFetch(`/repos/${payload.repository}/issues/${payload.issueNumber}/comments`, {
     method: "POST",
     body: {
@@ -1842,6 +1848,65 @@ async function postVpsRunnerEvent({ githubFetch, payload, event, notification })
       })
     }
   });
+}
+
+async function postVpsRunnerDashboardEvent({ eventPayload, env = process.env, fetchImpl = globalThis.fetch }) {
+  if (!normalizeText(eventPayload?.threadId)) {
+    return {
+      status: "skipped",
+      reason: "dashboard threadId is missing"
+    };
+  }
+  const runtimeUrl = normalizeText(env?.VTDD_RUNTIME_URL);
+  const bearerToken = normalizeText(env?.VTDD_GATEWAY_BEARER_TOKEN);
+  if (!runtimeUrl || !bearerToken) {
+    return {
+      status: "skipped",
+      reason: "VTDD_RUNTIME_URL or VTDD_GATEWAY_BEARER_TOKEN is missing"
+    };
+  }
+  if (typeof fetchImpl !== "function") {
+    return {
+      status: "failed",
+      reason: "fetch is not available"
+    };
+  }
+
+  let endpoint;
+  try {
+    endpoint = new URL("/v2/events/vps-runner", runtimeUrl);
+  } catch (error) {
+    return {
+      status: "failed",
+      reason: "VTDD_RUNTIME_URL is not a valid URL"
+    };
+  }
+
+  try {
+    const response = await fetchImpl(endpoint, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${bearerToken}`,
+        "content-type": "application/json"
+      },
+      body: JSON.stringify(eventPayload)
+    });
+    if (!response || response.ok !== true) {
+      return {
+        status: "failed",
+        reason: `runtime event post failed with HTTP ${response?.status || "unknown"}`
+      };
+    }
+    return {
+      status: "delivered",
+      endpoint: endpoint.origin + endpoint.pathname
+    };
+  } catch (error) {
+    return {
+      status: "failed",
+      reason: summarizeDiagnosticText(error?.message || String(error), 240)
+    };
+  }
 }
 
 async function assertVpsRunnerNotCanceled({ githubFetch, payload, checkpoint, notification }) {
@@ -1947,15 +2012,15 @@ function buildVpsRunnerLeadTime(lifecycle = {}) {
 function formatLeadTimeCommentLines(leadTime) {
   const durations = leadTime?.durations || {};
   const entries = [
-    ["Queue wait", durations.queue_wait_duration],
-    ["Codex execution", durations.codex_execution_duration],
-    ["PR creation", durations.pr_creation_duration],
-    ["Total lead time", durations.total_lead_time]
+    ["queue 待ち", durations.queue_wait_duration],
+    ["Codex 実行", durations.codex_execution_duration],
+    ["PR 作成", durations.pr_creation_duration],
+    ["合計", durations.total_lead_time]
   ].filter(([, duration]) => duration?.label);
   if (entries.length === 0) {
     return [];
   }
-  return ["Lead time:", ...entries.map(([label, duration]) => `- ${label}: ${duration.label}`), ""];
+  return ["所要時間:", ...entries.map(([label, duration]) => `- ${label}: ${duration.label}`), ""];
 }
 
 function shouldUpdateVpsRunnerState(event) {
@@ -2449,11 +2514,11 @@ function isVpsRunnerMentionMilestone(event = {}) {
 
 function formatVpsRunnerMilestoneLead({ event, mention } = {}) {
   if (!isVpsRunnerMentionMilestone(event)) {
-    return "VTDD VPS runner event.";
+    return "VTDD VPS runner event です。";
   }
   const label = getVpsRunnerMilestoneLabel(event);
   const prefix = mention ? `@${mention} ` : "";
-  return `${prefix}VTDD milestone: ${label}.`;
+  return `${prefix}VTDD milestone: ${label}。`;
 }
 
 function getVpsRunnerMilestoneLabel(event = {}) {
@@ -2469,30 +2534,30 @@ function getVpsRunnerMilestoneLabel(event = {}) {
   }
   const matched = candidates.find((candidate) => MILESTONE_MENTION_EVENTS.has(candidate));
   const labels = {
-    picked_up: "execution picked up",
-    branch_pushed: "branch pushed",
-    pr_created: "PR created",
-    pr_updated: "PR updated",
-    conflict_resolved: "conflict resolved",
-    no_changes: "no changes",
-    merge_retry_ready: "merge retry ready",
-    pull_request_created: "PR created",
-    pull_request_updated: "PR updated",
-    review_result_changed: "review result changed",
-    manual_review_required: "manual review required",
-    ready_for_review_completed: "ready for review completed",
-    merge_ready_reached: "merge-ready reached",
-    blocked: "blocked",
-    failed: "failed",
-    stale: "stale",
-    deploy_required: "deploy required",
-    completed: "completed",
-    runner_failed: "failed",
-    request_changes: "review requested changes",
-    manual_review: "manual review required",
-    approve: "review approved"
+    picked_up: "実行を拾いました",
+    branch_pushed: "branch を push しました",
+    pr_created: "PR を作成しました",
+    pr_updated: "PR を更新しました",
+    conflict_resolved: "conflict を解消しました",
+    no_changes: "差分なしです",
+    merge_retry_ready: "merge retry 可能です",
+    pull_request_created: "PR を作成しました",
+    pull_request_updated: "PR を更新しました",
+    review_result_changed: "review 結果が変わりました",
+    manual_review_required: "manual review が必要です",
+    ready_for_review_completed: "ready-for-review が完了しました",
+    merge_ready_reached: "merge-ready に到達しました",
+    blocked: "blocker で停止しました",
+    failed: "失敗しました",
+    stale: "stale です",
+    deploy_required: "deploy が必要です",
+    completed: "完了しました",
+    runner_failed: "runner が失敗しました",
+    request_changes: "review で修正要求があります",
+    manual_review: "manual review が必要です",
+    approve: "review approve です"
   };
-  return labels[matched] || "runtime event";
+  return labels[matched] || "runtime event です";
 }
 
 function isMentionableGitHubLogin(value) {

--- a/src/core/remote-codex-executor.js
+++ b/src/core/remote-codex-executor.js
@@ -1987,57 +1987,59 @@ function buildVpsRunnerGitHubQueueComment({ request }) {
   };
   const lines = [
     `<!-- vtdd:vps-runner-execution:${request.executionId} -->`,
-    "VTDD-managed VPS runner execution request.",
+    "VTDD 管理の VPS runner 実行キューです。",
     "",
-    "Bounded execution contract:",
-    `- Repository: ${request.repository}`,
+    "このコメントは dashboard への返信ではありません。VPS Codex CLI が拾い、完了 event を runtime に返したものだけを dashboard の返信として扱います。",
+    "",
+    "実行境界:",
+    `- リポジトリ: ${request.repository}`,
     `- Issue: #${request.issueNumber}`,
-    `- Branch: ${request.branch}`,
-    `- Base ref: ${request.baseRef}`,
-    `- Goal: ${request.codexGoal}`,
+    `- ブランチ: ${request.branch}`,
+    `- base ref: ${request.baseRef}`,
+    `- goal: ${request.codexGoal}`,
     ...(request.codexGoal === RemoteCodexDispatchGoal.REVISE_PR
       ? [
-          `- Target PR: #${request.revisionTarget.number}`,
-          `- Target PR state: ${request.revisionTarget.state}`,
-          `- Target PR headRef: ${request.revisionTarget.headRef}`,
-          `- Target PR headSha: ${request.revisionTarget.headSha}`
+          `- 対象 PR: #${request.revisionTarget.number}`,
+          `- 対象 PR state: ${request.revisionTarget.state}`,
+          `- 対象 PR headRef: ${request.revisionTarget.headRef}`,
+          `- 対象 PR headSha: ${request.revisionTarget.headSha}`
         ]
       : []),
     ...(request.codexGoal === RemoteCodexDispatchGoal.POST_MERGE_VERIFY
       ? [
-          `- Target PR: #${request.revisionTarget.number}`,
-          `- Target PR state: ${request.revisionTarget.state || "unknown"}`,
-          `- Target PR merged: ${request.revisionTarget.merged === false ? "false" : "true_or_unverified"}`,
-          `- Target PR mergedAt: ${request.revisionTarget.mergedAt || "unverified"}`,
-          `- Target PR mergeCommitSha: ${request.revisionTarget.mergeCommitSha || "unverified"}`
+          `- 対象 PR: #${request.revisionTarget.number}`,
+          `- 対象 PR state: ${request.revisionTarget.state || "unknown"}`,
+          `- 対象 PR merged: ${request.revisionTarget.merged === false ? "false" : "true_or_unverified"}`,
+          `- 対象 PR mergedAt: ${request.revisionTarget.mergedAt || "unverified"}`,
+          `- 対象 PR mergeCommitSha: ${request.revisionTarget.mergeCommitSha || "unverified"}`
         ]
       : []),
-    "- Canonical spec: this GitHub Issue",
-    "- Runtime truth: current GitHub branch / diff / PR / review comments",
+    "- 正本: この GitHub Issue",
+    "- runtime truth: 現在の GitHub branch / diff / PR / review comments",
     isDashboardChatTriage
-      ? "- Completion target: post a dashboard chat triage response to the same thread"
+      ? "- 完了条件: dashboard chat triage の返信 event を同じ thread に返す"
       : request.codexGoal === RemoteCodexDispatchGoal.POST_MERGE_VERIFY
-        ? "- Completion target: verify post-merge runtime truth and post GitHub-visible evidence"
-        : "- Completion target: create or update a pull request",
+        ? "- 完了条件: merge 後 runtime truth を検証し、GitHub-visible evidence を残す"
+        : "- 完了条件: pull request を作成または更新する",
     ...(isDashboardChatTriage
       ? [
-          "- PR body requirement: not applicable; dashboard chat triage must not create or update a PR.",
-          "- Context preflight requirement: the VPS runner will automatically read `AGENTS.md`, `docs/butler/thread-independent-startup-contract.md`, and the canonical Issue, then generate a machine-readable preflight receipt before Codex starts triage."
+          "- PR body requirement: 不要。dashboard chat triage は PR を作成・更新しません。",
+          "- context preflight: VPS runner は `AGENTS.md`、`docs/butler/thread-independent-startup-contract.md`、正本 Issue を読んでから triage を開始します。"
         ]
       : [
-          "- PR body requirement: Codex must inspect `docs/pr-template-model.md`, `scripts/render-pr-body.mjs`, and `scripts/validate-pr-body.mjs`; the VPS runner will validate and normalize the PR body again before create/update.",
-          "- Context preflight requirement: the VPS runner will automatically read `AGENTS.md`, `docs/butler/thread-independent-startup-contract.md`, the canonical Issue, and the PR body contract files, then generate a machine-readable preflight receipt before Codex starts editing.",
-          "- Required PR body markers: `## This PR satisfies Intent`, `## Satisfied Success Criteria`, `## Unsatisfied Success Criteria`, `## Verification Evidence`, `## Surface Update Checklist`."
+          "- PR body requirement: Codex は `docs/pr-template-model.md`、`scripts/render-pr-body.mjs`、`scripts/validate-pr-body.mjs` を確認します。VPS runner も PR create/update 前に検証・正規化します。",
+          "- context preflight: VPS runner は `AGENTS.md`、`docs/butler/thread-independent-startup-contract.md`、正本 Issue、PR body contract files を読んでから編集を開始します。",
+          "- 必須 PR body markers: `## This PR satisfies Intent`, `## Satisfied Success Criteria`, `## Unsatisfied Success Criteria`, `## Verification Evidence`, `## Surface Update Checklist`."
         ]),
-    "- Missing preflight inputs do not authorize speculative implementation; the runner must ask Butler/owner to confirm the next action, then wait for a reissued bounded request.",
+    "- preflight 入力が不足している場合、推測実装は禁止です。runner は Butler/owner に次の判断を求め、bounded request の再発行を待ちます。",
     "",
-    "Rules:",
-    "- Do not expand scope beyond the Issue.",
-    ...(isDashboardChatTriage ? ["- Do not edit files.", "- Do not commit.", "- Do not push.", "- Do not create or update PRs."] : []),
-    "- Do not merge.",
-    "- Do not deploy.",
-    "- Preserve reviewer objections for Butler/human judgment.",
-    "- If the Issue or runtime truth is insufficient, stop and comment with the blocked reason.",
+    "ルール:",
+    "- Issue の範囲を勝手に広げない。",
+    ...(isDashboardChatTriage ? ["- ファイル編集しない。", "- commit しない。", "- push しない。", "- PR を作成・更新しない。"] : []),
+    "- merge しない。",
+    "- deploy しない。",
+    "- reviewer objection は Butler/human judgment 用に残す。",
+    "- Issue または runtime truth が不足している場合は停止し、日本語で blocker reason をコメントする。",
     "",
     "Runner payload:",
     fencedJson(payload)

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -6686,6 +6686,7 @@ function normalizeVpsRunnerDashboardEvent(payload) {
       text: buildVpsRunnerChatMessageText({
         repository,
         executionId,
+        issueNumber,
         status,
         currentStep,
         lastEvent,
@@ -6762,6 +6763,7 @@ function buildVpsRunnerDashboardTitle({ status, currentStep, lastEvent, message 
 function buildVpsRunnerChatMessageText({
   repository,
   executionId,
+  issueNumber,
   status,
   currentStep,
   lastEvent,
@@ -6770,27 +6772,52 @@ function buildVpsRunnerChatMessageText({
   progressUrl
 }) {
   const parts = [
-    `VPS Codex CLI から更新です。`,
-    `repo: ${repository}`,
-    `execution: ${executionId}`,
-    `status: ${status}`
+    "VPS Codex CLI から返信です。",
+    "",
+    "状態:",
+    `- repo: ${repository}`,
+    `- execution: ${executionId}`,
+    `- status: ${formatVpsRunnerDashboardStatusForOwner(status)}`
   ];
+  if (issueNumber) {
+    parts.push(`- Issue: #${issueNumber}`);
+  }
   if (currentStep) {
-    parts.push(`step: ${currentStep}`);
+    parts.push(`- step: ${currentStep}`);
   }
   if (lastEvent) {
-    parts.push(`event: ${lastEvent}`);
+    parts.push(`- event: ${lastEvent}`);
   }
   if (branch) {
-    parts.push(`branch: ${branch}`);
+    parts.push(`- branch: ${branch}`);
   }
   if (message) {
+    parts.push("", "本文:");
     parts.push(message);
   }
   if (progressUrl) {
-    parts.push(`進捗: ${progressUrl}`);
+    parts.push("", `進捗: ${progressUrl}`);
   }
   return parts.join("\n");
+}
+
+function formatVpsRunnerDashboardStatusForOwner(status) {
+  if (status === "completed") {
+    return "完了";
+  }
+  if (status === "running") {
+    return "実行中";
+  }
+  if (status === "queued") {
+    return "待機中";
+  }
+  if (status === "blocked") {
+    return "停止";
+  }
+  if (status === "canceled") {
+    return "キャンセル";
+  }
+  return status || "不明";
 }
 
 function normalizeDashboardUrl(value) {
@@ -7515,7 +7542,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
     .bubble { max-width: min(760px, 88%); color: var(--text); font-size: 17px; line-height: 1.72; }
     .bubble, .bubble p, .bubble li { overflow-wrap: anywhere; }
     .bubble strong { display: block; color: var(--muted); font-size: 12px; letter-spacing: .08em; text-transform: uppercase; margin-bottom: 8px; }
-    .bubble p { color: var(--text); margin-bottom: 12px; }
+    .bubble p { color: var(--text); margin-bottom: 12px; white-space: pre-wrap; }
     .bubble ul { margin: 0; padding-left: 22px; color: var(--text); line-height: 1.85; }
     .bubble.owner { align-self: flex-end; background: var(--owner-bubble); color: var(--owner-text); border-radius: 24px; padding: 12px 16px; }
     .bubble.owner p { color: var(--owner-text); margin: 0; }
@@ -7762,10 +7789,33 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           article.appendChild(strong);
         }
         const paragraph = document.createElement("p");
-        paragraph.textContent = message.text || "（空のメッセージ）";
+        renderMessageText(paragraph, message.text || "（空のメッセージ）");
         article.appendChild(paragraph);
         log.appendChild(article);
         scrollToLatest();
+      }
+
+      function renderMessageText(container, text) {
+        const source = String(text || "");
+        const urlPattern = /https?:\\/\\/[^\\s<>"']+/g;
+        let cursor = 0;
+        for (const match of source.matchAll(urlPattern)) {
+          if (match.index > cursor) {
+            container.appendChild(document.createTextNode(source.slice(cursor, match.index)));
+          }
+          const href = match[0];
+          const link = document.createElement("a");
+          link.className = "chat-link";
+          link.href = href;
+          link.textContent = href;
+          link.target = "_blank";
+          link.rel = "noreferrer";
+          container.appendChild(link);
+          cursor = match.index + href.length;
+        }
+        if (cursor < source.length) {
+          container.appendChild(document.createTextNode(source.slice(cursor)));
+        }
       }
 
       function appendError(text) {

--- a/test/remote-codex-executor.test.js
+++ b/test/remote-codex-executor.test.js
@@ -748,12 +748,12 @@ test("remote Codex vps_runner dispatch posts a GitHub-backed queue comment", asy
   assert.equal(calls[0].init.method, "POST");
   const body = JSON.parse(calls[0].init.body).body;
   assert.equal(body.includes("vtdd:vps-runner-execution:"), true);
-  assert.equal(body.includes("VTDD-managed VPS runner execution request."), true);
+  assert.equal(body.includes("VTDD 管理の VPS runner 実行キューです。"), true);
   assert.equal(body.includes('"transport": "vps_runner"'), true);
   assert.equal(body.includes('"repository": "sample-org/sunaba-eye"'), true);
   assert.equal(body.includes('"approvalActor": "requester"'), true);
   assert.equal(body.includes("@marushu"), false);
-  assert.equal(body.includes("Do not merge."), true);
+  assert.equal(body.includes("merge しない。"), true);
   assert.equal(body.includes("docs/butler/thread-independent-startup-contract.md"), true);
   assert.equal(body.includes("docs/pr-template-model.md"), true);
   assert.equal(body.includes("scripts/render-pr-body.mjs"), true);
@@ -820,10 +820,10 @@ test("remote Codex vps_runner dashboard chat triage queue does not masquerade as
   assert.equal(body.includes('"codexGoal": "dashboard_chat_triage"'), true);
   assert.equal(body.includes('"ownerMessage": "ぶい の残り Issue と PR を確認して交通整理して"'), true);
   assert.equal(body.includes('"repositoryInput": "ぶい"'), true);
-  assert.equal(body.includes("Completion target: post a dashboard chat triage response to the same thread"), true);
-  assert.equal(body.includes("dashboard chat triage must not create or update a PR"), true);
-  assert.equal(body.includes("Do not create or update PRs."), true);
-  assert.equal(body.includes("Completion target: create or update a pull request"), false);
+  assert.equal(body.includes("完了条件: dashboard chat triage の返信 event を同じ thread に返す"), true);
+  assert.equal(body.includes("dashboard chat triage は PR を作成・更新しません"), true);
+  assert.equal(body.includes("PR を作成・更新しない。"), true);
+  assert.equal(body.includes("完了条件: pull request を作成または更新する"), false);
   assert.equal(body.includes("Required PR body markers"), false);
   assert.equal(body.includes("docs/pr-template-model.md"), false);
   assert.equal(body.includes("scripts/render-pr-body.mjs"), false);
@@ -944,7 +944,7 @@ test("remote Codex vps_runner dispatch preserves bounded post-merge verification
   assert.equal(body.includes('"branch": "main"'), true);
   assert.equal(body.includes('"number": 396'), true);
   assert.equal(body.includes('"mergeCommitSha": "merge-sha-396"'), true);
-  assert.equal(body.includes("verify post-merge runtime truth"), true);
+  assert.equal(body.includes("merge 後 runtime truth を検証"), true);
 });
 
 test("remote Codex vps_runner progress reads queue comment and target PR truth", async () => {

--- a/test/vps-runner-script.test.js
+++ b/test/vps-runner-script.test.js
@@ -36,7 +36,7 @@ import {
 
 test("VPS runner parses bounded queue comment payload", () => {
   const parsed = parseVpsRunnerQueueComment(`<!-- vtdd:vps-runner-execution:remote-codex-issue157-vps -->
-VTDD-managed VPS runner execution request.
+VTDD 管理の VPS runner 実行キューです。
 
 \`\`\`json
 {
@@ -479,6 +479,94 @@ test("VPS runner event preserves dashboard chat thread from handoff payload", as
   assert.equal(parsed.event.threadId, "dashboard-main-marushu-vtdd-v2-p");
 });
 
+test("VPS runner event posts dashboard thread events to runtime", async () => {
+  const githubCalls = [];
+  const runtimeCalls = [];
+  await postVpsRunnerEvent({
+    githubFetch: async (url, init = {}) => {
+      githubCalls.push({ url, init });
+      return { id: 45003 };
+    },
+    fetchImpl: async (url, init = {}) => {
+      runtimeCalls.push({ url: String(url), init });
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 202,
+        headers: { "content-type": "application/json" }
+      });
+    },
+    env: {
+      VTDD_RUNTIME_URL: "https://vtdd-v2-mvp.example.workers.dev",
+      VTDD_GATEWAY_BEARER_TOKEN: "gateway-token-for-test"
+    },
+    payload: {
+      executionId: "exec-dashboard-runtime",
+      repository: "marushu/vtdd-v2-p",
+      issueNumber: 450,
+      handoff: {
+        dashboardThreadId: "dashboard-main-marushu-vtdd-v2-p"
+      }
+    },
+    event: {
+      status: "completed",
+      lastEvent: "dashboard_chat_triage_completed",
+      finalEvent: "dashboard_chat_triage_completed",
+      currentStep: "dashboard_chat_triage",
+      message: "分類: answer\n次は Issue #450 の live E2E を確認します。"
+    }
+  });
+
+  assert.equal(runtimeCalls.length, 1);
+  assert.equal(runtimeCalls[0].url, "https://vtdd-v2-mvp.example.workers.dev/v2/events/vps-runner");
+  assert.equal(runtimeCalls[0].init.method, "POST");
+  assert.equal(runtimeCalls[0].init.headers.authorization, "Bearer gateway-token-for-test");
+  const runtimeBody = JSON.parse(runtimeCalls[0].init.body);
+  assert.equal(runtimeBody.threadId, "dashboard-main-marushu-vtdd-v2-p");
+  assert.equal(runtimeBody.status, "completed");
+  assert.equal(runtimeBody.lastEvent, "dashboard_chat_triage_completed");
+  assert.equal(runtimeBody.message.includes("分類: answer"), true);
+
+  const parsed = parseVpsRunnerEventComment(githubCalls[0].init.body.body);
+  assert.equal(parsed.ok, true);
+  assert.equal(parsed.event.dashboardDelivery.status, "delivered");
+  assert.equal(
+    parsed.event.dashboardDelivery.endpoint,
+    "https://vtdd-v2-mvp.example.workers.dev/v2/events/vps-runner"
+  );
+});
+
+test("VPS runner event records missing runtime dashboard delivery configuration", async () => {
+  const calls = [];
+  await postVpsRunnerEvent({
+    githubFetch: async (url, init = {}) => {
+      calls.push({ url, init });
+      return { id: 45004 };
+    },
+    payload: {
+      executionId: "exec-dashboard-missing-runtime",
+      repository: "marushu/vtdd-v2-p",
+      issueNumber: 450,
+      handoff: {
+        dashboardThreadId: "dashboard-main-marushu-vtdd-v2-p"
+      }
+    },
+    event: {
+      status: "completed",
+      lastEvent: "dashboard_chat_triage_completed",
+      currentStep: "dashboard_chat_triage",
+      message: "完了"
+    },
+    env: {}
+  });
+
+  const parsed = parseVpsRunnerEventComment(calls[0].init.body.body);
+  assert.equal(parsed.ok, true);
+  assert.equal(parsed.event.dashboardDelivery.status, "skipped");
+  assert.equal(
+    parsed.event.dashboardDelivery.reason,
+    "VTDD_RUNTIME_URL or VTDD_GATEWAY_BEARER_TOKEN is missing"
+  );
+});
+
 test("VPS runner milestone event mentions queue comment author", () => {
   const body = buildVpsRunnerEventComment({
     executionId: "exec-mention",
@@ -492,7 +580,7 @@ test("VPS runner milestone event mentions queue comment author", () => {
     }
   });
 
-  assert.equal(body.split("\n")[1], "@alice VTDD milestone: branch pushed.");
+  assert.equal(body.split("\n")[1], "@alice VTDD milestone: branch を push しました。");
   assert.equal(body.includes("@alice"), true);
   assert.equal(body.includes("@bob"), false);
   assert.equal(parseVpsRunnerEventComment(body).ok, true);
@@ -565,7 +653,7 @@ test("VPS runner notification omits mention when no mentionable actor exists", (
   });
 
   assert.equal(body.includes("@"), false);
-  assert.equal(body.includes("VTDD milestone: failed."), true);
+  assert.equal(body.includes("VTDD milestone: 失敗しました。"), true);
 });
 
 test("VPS runner state comment remains compatible with runner event parsing", () => {
@@ -608,9 +696,9 @@ test("VPS runner state comment exposes concise lead time before JSON runtime tru
   });
   const parsed = parseVpsRunnerEventComment(body);
 
-  assert.equal(body.includes("Lead time:"), true);
-  assert.equal(body.includes("- Queue wait: 12s"), true);
-  assert.equal(body.includes("- Codex execution: 3m 42s"), true);
+  assert.equal(body.includes("所要時間:"), true);
+  assert.equal(body.includes("- queue 待ち: 12s"), true);
+  assert.equal(body.includes("- Codex 実行: 3m 42s"), true);
   assert.equal(parsed.ok, true);
   assert.equal(parsed.event.leadTime.durations.queue_wait_duration.label, "12s");
 });
@@ -856,7 +944,7 @@ test("VPS runner completed event exposes a GitHub-visible final event", async ()
   assert.equal(parsed.event.finalEventReason.includes("updated the existing pull request"), true);
   assert.equal(parsed.event.leadTime.pr_created_at, "2026-05-09T10:04:10.000Z");
   assert.equal(parsed.event.leadTime.completed_at, "2026-05-09T10:04:10.000Z");
-  assert.equal(body.includes("VTDD milestone: PR updated."), true);
+  assert.equal(body.includes("VTDD milestone: PR を更新しました。"), true);
 });
 
 test("VPS runner maps completed execution goals to explicit final events", () => {

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -424,6 +424,10 @@ test("worker serves v2 dashboard for allowed owner identity without exposing sec
   assert.equal(body.includes("function scrollToLatest()"), true);
   assert.equal(body.includes("function showThinking()"), true);
   assert.equal(body.includes("function removeThinking("), true);
+  assert.equal(body.includes("function renderMessageText("), true);
+  assert.equal(body.includes("white-space: pre-wrap"), true);
+  assert.equal(body.includes("urlPattern"), true);
+  assert.equal(body.includes('link.className = "chat-link"'), true);
   assert.equal(body.includes("考えています"), true);
   assert.equal(body.includes("thinking-dots"), true);
   assert.equal(body.includes("grid-template-rows: auto minmax(0, 1fr) auto"), true);
@@ -1141,6 +1145,9 @@ test("worker ingests VPS runner event into notifications and Butler chat thread"
   assert.equal(eventBody.messages[0].status, "thinking");
   assert.equal(eventBody.messages[0].relatedIssue, 452);
   assert.equal(eventBody.messages[0].text.includes("VPS Codex CLI"), true);
+  assert.equal(eventBody.messages[0].text.includes("\n状態:\n- repo: marushu/vtdd-v2-p"), true);
+  assert.equal(eventBody.messages[0].text.includes("- status: 実行中"), true);
+  assert.equal(eventBody.messages[0].text.includes("\n本文:\nVPS Codex CLI が作業を開始しました。"), true);
   assert.equal(eventBody.messages[0].text.includes("codex_subprocess"), true);
   assert.equal(rooms.calls.length, 1);
   assert.equal(rooms.calls[0].name, "dashboard-main-marushu-vtdd-v2-p");
@@ -3311,7 +3318,7 @@ test("worker dispatches VPS runner execution by posting a bounded queue comment"
   assert.equal(queueBody.includes('"transport": "vps_runner"'), true);
   assert.equal(queueBody.includes('"repository": "sample-org/vtdd-v2"'), true);
   assert.equal(queueBody.includes('"branch": "codex/issue-157-vps-worker-dispatch"'), true);
-  assert.equal(queueBody.includes("- Do not merge."), true);
+  assert.equal(queueBody.includes("- merge しない。"), true);
 });
 
 test("worker normalizes minimal Butler API-backed handoff into bounded remote Codex execution", async () => {

--- a/worker.js
+++ b/worker.js
@@ -34694,47 +34694,49 @@ function buildVpsRunnerGitHubQueueComment({ request }) {
   };
   const lines = [
     `<!-- vtdd:vps-runner-execution:${request.executionId} -->`,
-    "VTDD-managed VPS runner execution request.",
+    "VTDD \u7BA1\u7406\u306E VPS runner \u5B9F\u884C\u30AD\u30E5\u30FC\u3067\u3059\u3002",
     "",
-    "Bounded execution contract:",
-    `- Repository: ${request.repository}`,
+    "\u3053\u306E\u30B3\u30E1\u30F3\u30C8\u306F dashboard \u3078\u306E\u8FD4\u4FE1\u3067\u306F\u3042\u308A\u307E\u305B\u3093\u3002VPS Codex CLI \u304C\u62FE\u3044\u3001\u5B8C\u4E86 event \u3092 runtime \u306B\u8FD4\u3057\u305F\u3082\u306E\u3060\u3051\u3092 dashboard \u306E\u8FD4\u4FE1\u3068\u3057\u3066\u6271\u3044\u307E\u3059\u3002",
+    "",
+    "\u5B9F\u884C\u5883\u754C:",
+    `- \u30EA\u30DD\u30B8\u30C8\u30EA: ${request.repository}`,
     `- Issue: #${request.issueNumber}`,
-    `- Branch: ${request.branch}`,
-    `- Base ref: ${request.baseRef}`,
-    `- Goal: ${request.codexGoal}`,
+    `- \u30D6\u30E9\u30F3\u30C1: ${request.branch}`,
+    `- base ref: ${request.baseRef}`,
+    `- goal: ${request.codexGoal}`,
     ...request.codexGoal === RemoteCodexDispatchGoal.REVISE_PR ? [
-      `- Target PR: #${request.revisionTarget.number}`,
-      `- Target PR state: ${request.revisionTarget.state}`,
-      `- Target PR headRef: ${request.revisionTarget.headRef}`,
-      `- Target PR headSha: ${request.revisionTarget.headSha}`
+      `- \u5BFE\u8C61 PR: #${request.revisionTarget.number}`,
+      `- \u5BFE\u8C61 PR state: ${request.revisionTarget.state}`,
+      `- \u5BFE\u8C61 PR headRef: ${request.revisionTarget.headRef}`,
+      `- \u5BFE\u8C61 PR headSha: ${request.revisionTarget.headSha}`
     ] : [],
     ...request.codexGoal === RemoteCodexDispatchGoal.POST_MERGE_VERIFY ? [
-      `- Target PR: #${request.revisionTarget.number}`,
-      `- Target PR state: ${request.revisionTarget.state || "unknown"}`,
-      `- Target PR merged: ${request.revisionTarget.merged === false ? "false" : "true_or_unverified"}`,
-      `- Target PR mergedAt: ${request.revisionTarget.mergedAt || "unverified"}`,
-      `- Target PR mergeCommitSha: ${request.revisionTarget.mergeCommitSha || "unverified"}`
+      `- \u5BFE\u8C61 PR: #${request.revisionTarget.number}`,
+      `- \u5BFE\u8C61 PR state: ${request.revisionTarget.state || "unknown"}`,
+      `- \u5BFE\u8C61 PR merged: ${request.revisionTarget.merged === false ? "false" : "true_or_unverified"}`,
+      `- \u5BFE\u8C61 PR mergedAt: ${request.revisionTarget.mergedAt || "unverified"}`,
+      `- \u5BFE\u8C61 PR mergeCommitSha: ${request.revisionTarget.mergeCommitSha || "unverified"}`
     ] : [],
-    "- Canonical spec: this GitHub Issue",
-    "- Runtime truth: current GitHub branch / diff / PR / review comments",
-    isDashboardChatTriage ? "- Completion target: post a dashboard chat triage response to the same thread" : request.codexGoal === RemoteCodexDispatchGoal.POST_MERGE_VERIFY ? "- Completion target: verify post-merge runtime truth and post GitHub-visible evidence" : "- Completion target: create or update a pull request",
+    "- \u6B63\u672C: \u3053\u306E GitHub Issue",
+    "- runtime truth: \u73FE\u5728\u306E GitHub branch / diff / PR / review comments",
+    isDashboardChatTriage ? "- \u5B8C\u4E86\u6761\u4EF6: dashboard chat triage \u306E\u8FD4\u4FE1 event \u3092\u540C\u3058 thread \u306B\u8FD4\u3059" : request.codexGoal === RemoteCodexDispatchGoal.POST_MERGE_VERIFY ? "- \u5B8C\u4E86\u6761\u4EF6: merge \u5F8C runtime truth \u3092\u691C\u8A3C\u3057\u3001GitHub-visible evidence \u3092\u6B8B\u3059" : "- \u5B8C\u4E86\u6761\u4EF6: pull request \u3092\u4F5C\u6210\u307E\u305F\u306F\u66F4\u65B0\u3059\u308B",
     ...isDashboardChatTriage ? [
-      "- PR body requirement: not applicable; dashboard chat triage must not create or update a PR.",
-      "- Context preflight requirement: the VPS runner will automatically read `AGENTS.md`, `docs/butler/thread-independent-startup-contract.md`, and the canonical Issue, then generate a machine-readable preflight receipt before Codex starts triage."
+      "- PR body requirement: \u4E0D\u8981\u3002dashboard chat triage \u306F PR \u3092\u4F5C\u6210\u30FB\u66F4\u65B0\u3057\u307E\u305B\u3093\u3002",
+      "- context preflight: VPS runner \u306F `AGENTS.md`\u3001`docs/butler/thread-independent-startup-contract.md`\u3001\u6B63\u672C Issue \u3092\u8AAD\u3093\u3067\u304B\u3089 triage \u3092\u958B\u59CB\u3057\u307E\u3059\u3002"
     ] : [
-      "- PR body requirement: Codex must inspect `docs/pr-template-model.md`, `scripts/render-pr-body.mjs`, and `scripts/validate-pr-body.mjs`; the VPS runner will validate and normalize the PR body again before create/update.",
-      "- Context preflight requirement: the VPS runner will automatically read `AGENTS.md`, `docs/butler/thread-independent-startup-contract.md`, the canonical Issue, and the PR body contract files, then generate a machine-readable preflight receipt before Codex starts editing.",
-      "- Required PR body markers: `## This PR satisfies Intent`, `## Satisfied Success Criteria`, `## Unsatisfied Success Criteria`, `## Verification Evidence`, `## Surface Update Checklist`."
+      "- PR body requirement: Codex \u306F `docs/pr-template-model.md`\u3001`scripts/render-pr-body.mjs`\u3001`scripts/validate-pr-body.mjs` \u3092\u78BA\u8A8D\u3057\u307E\u3059\u3002VPS runner \u3082 PR create/update \u524D\u306B\u691C\u8A3C\u30FB\u6B63\u898F\u5316\u3057\u307E\u3059\u3002",
+      "- context preflight: VPS runner \u306F `AGENTS.md`\u3001`docs/butler/thread-independent-startup-contract.md`\u3001\u6B63\u672C Issue\u3001PR body contract files \u3092\u8AAD\u3093\u3067\u304B\u3089\u7DE8\u96C6\u3092\u958B\u59CB\u3057\u307E\u3059\u3002",
+      "- \u5FC5\u9808 PR body markers: `## This PR satisfies Intent`, `## Satisfied Success Criteria`, `## Unsatisfied Success Criteria`, `## Verification Evidence`, `## Surface Update Checklist`."
     ],
-    "- Missing preflight inputs do not authorize speculative implementation; the runner must ask Butler/owner to confirm the next action, then wait for a reissued bounded request.",
+    "- preflight \u5165\u529B\u304C\u4E0D\u8DB3\u3057\u3066\u3044\u308B\u5834\u5408\u3001\u63A8\u6E2C\u5B9F\u88C5\u306F\u7981\u6B62\u3067\u3059\u3002runner \u306F Butler/owner \u306B\u6B21\u306E\u5224\u65AD\u3092\u6C42\u3081\u3001bounded request \u306E\u518D\u767A\u884C\u3092\u5F85\u3061\u307E\u3059\u3002",
     "",
-    "Rules:",
-    "- Do not expand scope beyond the Issue.",
-    ...isDashboardChatTriage ? ["- Do not edit files.", "- Do not commit.", "- Do not push.", "- Do not create or update PRs."] : [],
-    "- Do not merge.",
-    "- Do not deploy.",
-    "- Preserve reviewer objections for Butler/human judgment.",
-    "- If the Issue or runtime truth is insufficient, stop and comment with the blocked reason.",
+    "\u30EB\u30FC\u30EB:",
+    "- Issue \u306E\u7BC4\u56F2\u3092\u52DD\u624B\u306B\u5E83\u3052\u306A\u3044\u3002",
+    ...isDashboardChatTriage ? ["- \u30D5\u30A1\u30A4\u30EB\u7DE8\u96C6\u3057\u306A\u3044\u3002", "- commit \u3057\u306A\u3044\u3002", "- push \u3057\u306A\u3044\u3002", "- PR \u3092\u4F5C\u6210\u30FB\u66F4\u65B0\u3057\u306A\u3044\u3002"] : [],
+    "- merge \u3057\u306A\u3044\u3002",
+    "- deploy \u3057\u306A\u3044\u3002",
+    "- reviewer objection \u306F Butler/human judgment \u7528\u306B\u6B8B\u3059\u3002",
+    "- Issue \u307E\u305F\u306F runtime truth \u304C\u4E0D\u8DB3\u3057\u3066\u3044\u308B\u5834\u5408\u306F\u505C\u6B62\u3057\u3001\u65E5\u672C\u8A9E\u3067 blocker reason \u3092\u30B3\u30E1\u30F3\u30C8\u3059\u308B\u3002",
     "",
     "Runner payload:",
     fencedJson(payload)
@@ -61518,6 +61520,7 @@ function normalizeVpsRunnerDashboardEvent(payload) {
       text: buildVpsRunnerChatMessageText({
         repository,
         executionId,
+        issueNumber,
         status,
         currentStep,
         lastEvent,
@@ -61588,6 +61591,7 @@ function buildVpsRunnerDashboardTitle({ status, currentStep, lastEvent, message 
 function buildVpsRunnerChatMessageText({
   repository,
   executionId,
+  issueNumber,
   status,
   currentStep,
   lastEvent,
@@ -61596,27 +61600,51 @@ function buildVpsRunnerChatMessageText({
   progressUrl
 }) {
   const parts = [
-    `VPS Codex CLI \u304B\u3089\u66F4\u65B0\u3067\u3059\u3002`,
-    `repo: ${repository}`,
-    `execution: ${executionId}`,
-    `status: ${status}`
+    "VPS Codex CLI \u304B\u3089\u8FD4\u4FE1\u3067\u3059\u3002",
+    "",
+    "\u72B6\u614B:",
+    `- repo: ${repository}`,
+    `- execution: ${executionId}`,
+    `- status: ${formatVpsRunnerDashboardStatusForOwner(status)}`
   ];
+  if (issueNumber) {
+    parts.push(`- Issue: #${issueNumber}`);
+  }
   if (currentStep) {
-    parts.push(`step: ${currentStep}`);
+    parts.push(`- step: ${currentStep}`);
   }
   if (lastEvent) {
-    parts.push(`event: ${lastEvent}`);
+    parts.push(`- event: ${lastEvent}`);
   }
   if (branch) {
-    parts.push(`branch: ${branch}`);
+    parts.push(`- branch: ${branch}`);
   }
   if (message) {
+    parts.push("", "\u672C\u6587:");
     parts.push(message);
   }
   if (progressUrl) {
-    parts.push(`\u9032\u6357: ${progressUrl}`);
+    parts.push("", `\u9032\u6357: ${progressUrl}`);
   }
   return parts.join("\n");
+}
+function formatVpsRunnerDashboardStatusForOwner(status) {
+  if (status === "completed") {
+    return "\u5B8C\u4E86";
+  }
+  if (status === "running") {
+    return "\u5B9F\u884C\u4E2D";
+  }
+  if (status === "queued") {
+    return "\u5F85\u6A5F\u4E2D";
+  }
+  if (status === "blocked") {
+    return "\u505C\u6B62";
+  }
+  if (status === "canceled") {
+    return "\u30AD\u30E3\u30F3\u30BB\u30EB";
+  }
+  return status || "\u4E0D\u660E";
 }
 function normalizeDashboardUrl(value) {
   const text = sanitizeDashboardChatText(value);
@@ -62308,7 +62336,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
     .bubble { max-width: min(760px, 88%); color: var(--text); font-size: 17px; line-height: 1.72; }
     .bubble, .bubble p, .bubble li { overflow-wrap: anywhere; }
     .bubble strong { display: block; color: var(--muted); font-size: 12px; letter-spacing: .08em; text-transform: uppercase; margin-bottom: 8px; }
-    .bubble p { color: var(--text); margin-bottom: 12px; }
+    .bubble p { color: var(--text); margin-bottom: 12px; white-space: pre-wrap; }
     .bubble ul { margin: 0; padding-left: 22px; color: var(--text); line-height: 1.85; }
     .bubble.owner { align-self: flex-end; background: var(--owner-bubble); color: var(--owner-text); border-radius: 24px; padding: 12px 16px; }
     .bubble.owner p { color: var(--owner-text); margin: 0; }
@@ -62555,10 +62583,33 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           article.appendChild(strong);
         }
         const paragraph = document.createElement("p");
-        paragraph.textContent = message.text || "\uFF08\u7A7A\u306E\u30E1\u30C3\u30BB\u30FC\u30B8\uFF09";
+        renderMessageText(paragraph, message.text || "\uFF08\u7A7A\u306E\u30E1\u30C3\u30BB\u30FC\u30B8\uFF09");
         article.appendChild(paragraph);
         log.appendChild(article);
         scrollToLatest();
+      }
+
+      function renderMessageText(container, text) {
+        const source = String(text || "");
+        const urlPattern = /https?:\\/\\/[^\\s<>"']+/g;
+        let cursor = 0;
+        for (const match of source.matchAll(urlPattern)) {
+          if (match.index > cursor) {
+            container.appendChild(document.createTextNode(source.slice(cursor, match.index)));
+          }
+          const href = match[0];
+          const link = document.createElement("a");
+          link.className = "chat-link";
+          link.href = href;
+          link.textContent = href;
+          link.target = "_blank";
+          link.rel = "noreferrer";
+          container.appendChild(link);
+          cursor = match.index + href.length;
+        }
+        if (cursor < source.length) {
+          container.appendChild(document.createTextNode(source.slice(cursor)));
+        }
       }
 
       function appendError(text) {


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #450 の追加修正です。VPS runner の実返信が GitHub Issue comment だけに残り dashboard chat に戻らない問題を直します。dashboard の返信表示も改行・箇条書き・URL が読める形にします。

## Satisfied Success Criteria

- VPS runner の完了 event を dashboard runtime の /v2/events/vps-runner に POST します。
- GitHub 側 runner event comment に dashboardDelivery の結果を残します。
- 設定不足時は skipped と reason を残して失敗を隠しません。
- dashboard chat の runner 返信は改行を保持し、URL をクリック可能にします。
- VPS runner queue / milestone / lead time の owner-facing 文言を日本語優先にします。

## Unsatisfied Success Criteria

- production deploy 後の owner authenticated dashboard live E2E は未実行です。
- 実 VPS Codex CLI から新規 dashboard message を処理し、runner event が同じ thread に戻る live E2E は未実行です。
- Issue #450 close 判定は未実施です。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #450
- Implementing Success Criteria: VPS runner 完了 event が dashboard runtime に届くこと。届いた返信が改行・箇条書き・URL link のまま読めること。
- Explicit Non-goals: merge、deploy、Issue close、credential / permission / repository settings mutation、Custom GPT Action Schema 変更、dashboard_chat_triage 以外の executor behavior 拡張。
- Expected touched files/routes/workflows: scripts/run-vps-runner.mjs、src/worker/runtime.js、src/core/remote-codex-executor.js、worker.js、関連テスト。
- Affected Issues: Issue #450。
- Affected PRs: PR #466 の追加修正。新規 PR として扱います。
- Affected workflows: VPS runner script と generated Worker check。GitHub Actions deploy workflow 自体は未変更。
- Affected runtime/operator surfaces: Dashboard chat、/v2/events/vps-runner、VPS runner GitHub queue/comment。
- What may break if we patch narrowly: runtime POST だけ直すと、返信が届いても iPhone 画面では読みにくいままになる。表示だけ直すと、runner 実返信は dashboard に戻らない。
- Unknowns to investigate before coding: merge 後 production runtime の live WebSocket 表示は deploy 後に owner authenticated dashboard で確認が必要。
- Validation needed: targeted node --test、npm test、merge/deploy 後 live E2E。
- Stop condition: Issue #450 を越えて merge/deploy/Issue close/credential mutation に踏み込む場合は停止。

## File / Line Hypotheses

- file: scripts/run-vps-runner.mjs
  - hypothesis: postVpsRunnerEvent が GitHub comment だけを書き、dashboard runtime への POST が欠落している。
  - risk if changed narrowly: runtime auth 設定不足を隠すと再発が見えない。
  - validation: runtime POST 成功と missing config skipped をテストする。
  - related Issue: #450
- file: src/worker/runtime.js
  - hypothesis: appendMessage が 1 つの paragraph に textContent を入れ、white-space 指定がないため改行が潰れる。
  - risk if changed narrowly: URL がクリックできず owner が確認しづらい。
  - validation: dashboard HTML と runner event chat text のテストで確認する。

## Hypothesis Retrospective

- expected: runner 実返信は Issue comment にはあり、dashboard runtime POST が欠けている。
- actual: その通り。manual replay では /v2/events/vps-runner に POST すると同じ thread に返信が出た。
- mismatch: 返信本文は届いても表示側で改行が潰れる追加問題があった。
- lesson: runner 配線と owner-readable rendering は同時に検証する必要がある。
- should become RAG candidate: yes。

## Verification Evidence

- Unit: node --test test/remote-codex-executor.test.js test/vps-runner-script.test.js test/worker.test.js: 255 pass / 0 fail。
- Integration: npm test: node --test 876 pass / 1 skip / 0 fail、check:self-parity passed、check:generated-worker passed。
- E2E: 未実行。merge/deploy 後に owner authenticated dashboard live E2E が必要。
- Manual: manual replay は runtime へ 202 OK / webSocketBroadcast=true / messages=1 を確認済み。ただしこの PR の commit 後 live E2E ではない。
- Evidence path/link: local test output in this PR run。

## Butler Completion Contract

- Owner goal: Dashboard から送った会話に対して、VPS Codex CLI の実返信を同じ chat thread に返し、owner が iPhone で読める形にする。
- Butler entrypoint: Dashboard top chat。自然文を VPS runner dashboard_chat_triage queue に渡す既存入口を使う。
- Action Schema exposure: 未変更。Custom GPT Action Schema はこの PR では触らない。
- Runtime path: POST /v2/events/vps-runner と GET /v2/dashboard/chat/:threadId、WebSocket /v2/dashboard/chat/:threadId/ws。
- Runner/runtime truth: runner event comment に dashboardDelivery を記録し、runtime 側は event store と chat thread store に保存する。
- Authority boundary: 通常 runner event POST は machine bearer auth。merge/deploy/Issue close/credential mutation はこの PR では実行しない。
- E2E evidence: 未実行。merge/deploy 後に owner authenticated dashboard で新規 message -> VPS runner -> same thread reply を確認する。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 必要。merge 後に production deploy しないと runtime には反映されない。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実行。deploy 後に必須。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate。
- AGENTS.md Conversation UX Contract。
- AGENTS.md Evidence Discipline。
- AGENTS.md Change Size and PR Discipline。

## Out-of-scope but NOT implemented

- Production deploy。
- Issue #450 close。
- Custom GPT Action Schema 更新。
- credential / permission mutation。

## Extra changes (if any)

generated worker.js を src/worker/runtime.js に合わせて更新。

<!-- VTDD metadata -->
- Issue: Issue #450
- Execution ID: manual-dashboard-replay-1779277704044 follow-up
- Goal: dashboard_chat_triage
