### PR TITLE
Fix dashboard repository resolution UX

### DIFF
--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -3323,6 +3323,24 @@ async function handleDashboardChatMessageRequest(request, env) {
 
   const payload = await readJson(request);
   const wantsVpsRunnerHandoff = shouldDispatchDashboardChatToVpsRunner(payload);
+  const nicknameListTurn = await buildDashboardRepositoryNicknameListTurn({ payload, env });
+  if (nicknameListTurn) {
+    const store = resolveDashboardChatStore(env);
+    if (!store) {
+      return json(503, {
+        ok: false,
+        error: "dashboard_chat_store_unavailable",
+        reason: "dashboard Butler chat store is not configured"
+      });
+    }
+    const messages = await store.appendMany(nicknameListTurn.threadId, nicknameListTurn.messages);
+    return json(202, {
+      ok: true,
+      threadId: nicknameListTurn.threadId,
+      messages,
+      execution: null
+    });
+  }
   const repositoryResolution = await resolveDashboardChatRepository({ payload, env });
   if (!repositoryResolution.ok) {
     return json(repositoryResolution.status ?? 422, {
@@ -5051,8 +5069,9 @@ async function resolveDashboardChatRepository({ payload, env }) {
       ok: false,
       status: 422,
       error: "repository_required",
-      reason: "repository or repository nickname is required before dashboard can hand off to VPS Codex CLI",
-      issues: ["top chat must include a repository target or open the dashboard with repositoryInput"]
+      reason:
+        "対象 repository が未指定です。VPS Codex CLI に渡す前に、repo/nickname を指定してください。例: `ぶい #450 の残り Issue と PR を確認して`。登録済み nickname を確認する場合は `登録済みのニックネーム出して` と送ってください。",
+      issues: ["dashboard top chat requires a repository target before VPS Codex CLI handoff"]
     };
   }
 
@@ -5076,7 +5095,9 @@ async function resolveDashboardChatRepository({ payload, env }) {
     ok: false,
     status: resolved.ambiguous ? 409 : 422,
     error: resolved.ambiguous ? "repository_nickname_ambiguous" : "repository_unresolved",
-    reason: resolved.reason || "repository could not be resolved",
+    reason: resolved.ambiguous
+      ? "対象 repository nickname が曖昧です。候補から 1 つを owner/repo 形式で指定してください。"
+      : "対象 repository nickname を登録済み alias から解決できませんでした。`登録済みのニックネーム出して` で候補を確認するか、owner/repo 形式で指定してください。",
     issues: registryResult.ok
       ? ["repository nickname could not be resolved"]
       : [registryResult.reason || "repository nickname registry could not be read"],
@@ -5434,6 +5455,90 @@ function buildDeterministicButlerChatReply({ text, repository, relatedIssue, wan
     return `受け取りました。${repository} の話として保存しました。ここから Issue 候補を整理し、実行が必要な場合は GO / passkey 境界を明示して開発 queue へ進めます。${issuePhrase}`.trim();
   }
   return `受け取りました。${repository} の Butler 会話として同じ thread に保存しました。今は dashboard chat runtime の初期接続なので、まずは会話履歴と返信を同じ画面で確認できます。${issuePhrase}`.trim();
+}
+
+async function buildDashboardRepositoryNicknameListTurn({ payload, env }) {
+  const input = normalizeObject(payload);
+  const text = sanitizeDashboardChatText(input.text || input.message || input.body);
+  if (!isDashboardRepositoryNicknameListRequest(text)) {
+    return null;
+  }
+  const threadId =
+    normalizeDashboardThreadId(input.threadId || input.thread_id) ||
+    normalizeDashboardThreadId("dashboard-main-unresolved");
+  const now = new Date().toISOString();
+  const ownerMessage = normalizeDashboardChatMessage(
+    {
+      threadId,
+      role: "owner",
+      status: "sent",
+      text,
+      createdAt: now
+    },
+    { threadId }
+  );
+  const registryResult = await safeRetrieveStoredAliasRegistry(resolveMemoryProvider(env));
+  const butlerMessage = normalizeDashboardChatMessage(
+    {
+      threadId,
+      role: "butler",
+      status: registryResult.ok ? "replied" : "blocked",
+      text: formatDashboardRepositoryNicknameListReply(registryResult),
+      createdAt: new Date(Date.parse(now) + 1).toISOString()
+    },
+    { threadId }
+  );
+  return {
+    threadId,
+    messages: [ownerMessage, butlerMessage].filter(Boolean)
+  };
+}
+
+function isDashboardRepositoryNicknameListRequest(text) {
+  const normalized = normalizeDashboardEventText(text).toLowerCase();
+  if (!normalized) {
+    return false;
+  }
+  return (
+    normalized.includes("ニックネーム") &&
+    (normalized.includes("一覧") ||
+      normalized.includes("登録済") ||
+      normalized.includes("登録ずみ") ||
+      normalized.includes("出して") ||
+      normalized.includes("見せて") ||
+      normalized.includes("教えて"))
+  );
+}
+
+function formatDashboardRepositoryNicknameListReply(registryResult) {
+  if (!registryResult?.ok) {
+    return [
+      "登録済みニックネームを読めませんでした。",
+      "",
+      `理由: ${registryResult?.reason || "memory provider が利用できません。"}`,
+      "",
+      "この状態では repo/nickname 未指定のまま VPS Codex CLI に渡せないため、owner/repo 形式で対象 repository を指定してください。"
+    ].join("\n");
+  }
+  const entries = Array.isArray(registryResult.aliasRegistry) ? registryResult.aliasRegistry : [];
+  if (entries.length === 0) {
+    return [
+      "登録済みニックネームはありません。",
+      "",
+      "この状態では repo/nickname 未指定のまま VPS Codex CLI に渡せません。",
+      "まず `marushu/vtdd-v2-p` のように owner/repo 形式で対象 repository を指定してください。"
+    ].join("\n");
+  }
+  return [
+    "登録済みニックネームです。",
+    "",
+    ...entries.map((entry) => {
+      const aliases = Array.isArray(entry.aliases) && entry.aliases.length > 0 ? entry.aliases.join(", ") : "なし";
+      return `- ${entry.canonicalRepo}: ${aliases}`;
+    }),
+    "",
+    "送信例: `ぶい #450 の残り Issue と PR を確認して`"
+  ].join("\n");
 }
 
 function shouldDispatchDashboardChatToVpsRunner(payload) {

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -729,6 +729,74 @@ test("worker allows dashboard passkey session to hand off chat to VPS runner que
   assert.equal(queueBody.includes('"ownerMessage": "ぶい #450 の残り Issue と PR を確認して交通整理して"'), true);
 });
 
+test("worker returns registered dashboard repository nicknames in Japanese without VPS handoff", async () => {
+  const provider = createInMemoryMemoryProvider();
+  await provider.store({
+    id: "alias_registry:marushu/vtdd-v2-p",
+    type: MemoryRecordType.ALIAS_REGISTRY,
+    content: {
+      canonicalRepo: "marushu/vtdd-v2-p",
+      aliases: ["ぶい", "vtdd"]
+    },
+    metadata: { source: "test" },
+    priority: 60,
+    tags: ["alias_registry", "marushu/vtdd-v2-p"],
+    createdAt: "2026-05-20T00:00:00.000Z"
+  });
+  const store = createInMemoryDashboardChatStore();
+
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/dashboard/chat/messages", {
+      method: "POST",
+      headers: gatewayAuthHeaders,
+      body: JSON.stringify({
+        threadId: "dashboard-main-unresolved",
+        dispatchToVpsRunner: true,
+        text: "登録済みのニックネーム出して"
+      })
+    }),
+    {
+      ...gatewayAuthEnv,
+      MEMORY_PROVIDER: provider,
+      DASHBOARD_CHAT_STORE: store
+    }
+  );
+
+  assert.equal(response.status, 202);
+  const body = await response.json();
+  assert.equal(body.ok, true);
+  assert.equal(body.execution, null);
+  assert.equal(body.messages.length, 2);
+  assert.equal(body.messages[1].role, "butler");
+  assert.equal(body.messages[1].text.includes("登録済みニックネームです。"), true);
+  assert.equal(body.messages[1].text.includes("- marushu/vtdd-v2-p: ぶい, vtdd"), true);
+});
+
+test("worker rejects dashboard chat handoff without repository using Japanese owner-facing reason", async () => {
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/dashboard/chat/messages", {
+      method: "POST",
+      headers: gatewayAuthHeaders,
+      body: JSON.stringify({
+        threadId: "dashboard-main-unresolved",
+        dispatchToVpsRunner: true,
+        text: "VPS Codex CLI の返事を確認するテスト。"
+      })
+    }),
+    {
+      ...gatewayAuthEnv,
+      DASHBOARD_CHAT_STORE: createInMemoryDashboardChatStore()
+    }
+  );
+
+  assert.equal(response.status, 422);
+  const body = await response.json();
+  assert.equal(body.ok, false);
+  assert.equal(body.error, "repository_unresolved");
+  assert.equal(body.reason.includes("対象 repository nickname を登録済み alias から解決できませんでした"), true);
+  assert.equal(body.reason.includes("target repository could not be resolved"), false);
+});
+
 test("worker rejects unauthenticated dashboard chat VPS runner dispatch", async () => {
   const response = await worker.fetch(
     new Request("https://example.com/v2/dashboard/chat/messages", {

--- a/worker.js
+++ b/worker.js
@@ -58656,6 +58656,24 @@ async function handleDashboardChatMessageRequest(request, env) {
   }
   const payload = await readJson(request);
   const wantsVpsRunnerHandoff = shouldDispatchDashboardChatToVpsRunner(payload);
+  const nicknameListTurn = await buildDashboardRepositoryNicknameListTurn({ payload, env });
+  if (nicknameListTurn) {
+    const store2 = resolveDashboardChatStore(env);
+    if (!store2) {
+      return json(503, {
+        ok: false,
+        error: "dashboard_chat_store_unavailable",
+        reason: "dashboard Butler chat store is not configured"
+      });
+    }
+    const messages2 = await store2.appendMany(nicknameListTurn.threadId, nicknameListTurn.messages);
+    return json(202, {
+      ok: true,
+      threadId: nicknameListTurn.threadId,
+      messages: messages2,
+      execution: null
+    });
+  }
   const repositoryResolution = await resolveDashboardChatRepository({ payload, env });
   if (!repositoryResolution.ok) {
     return json(repositoryResolution.status ?? 422, {
@@ -60105,8 +60123,8 @@ async function resolveDashboardChatRepository({ payload, env }) {
       ok: false,
       status: 422,
       error: "repository_required",
-      reason: "repository or repository nickname is required before dashboard can hand off to VPS Codex CLI",
-      issues: ["top chat must include a repository target or open the dashboard with repositoryInput"]
+      reason: "\u5BFE\u8C61 repository \u304C\u672A\u6307\u5B9A\u3067\u3059\u3002VPS Codex CLI \u306B\u6E21\u3059\u524D\u306B\u3001repo/nickname \u3092\u6307\u5B9A\u3057\u3066\u304F\u3060\u3055\u3044\u3002\u4F8B: `\u3076\u3044 #450 \u306E\u6B8B\u308A Issue \u3068 PR \u3092\u78BA\u8A8D\u3057\u3066`\u3002\u767B\u9332\u6E08\u307F nickname \u3092\u78BA\u8A8D\u3059\u308B\u5834\u5408\u306F `\u767B\u9332\u6E08\u307F\u306E\u30CB\u30C3\u30AF\u30CD\u30FC\u30E0\u51FA\u3057\u3066` \u3068\u9001\u3063\u3066\u304F\u3060\u3055\u3044\u3002",
+      issues: ["dashboard top chat requires a repository target before VPS Codex CLI handoff"]
     };
   }
   const provider = resolveMemoryProvider(env);
@@ -60129,7 +60147,7 @@ async function resolveDashboardChatRepository({ payload, env }) {
     ok: false,
     status: resolved.ambiguous ? 409 : 422,
     error: resolved.ambiguous ? "repository_nickname_ambiguous" : "repository_unresolved",
-    reason: resolved.reason || "repository could not be resolved",
+    reason: resolved.ambiguous ? "\u5BFE\u8C61 repository nickname \u304C\u66D6\u6627\u3067\u3059\u3002\u5019\u88DC\u304B\u3089 1 \u3064\u3092 owner/repo \u5F62\u5F0F\u3067\u6307\u5B9A\u3057\u3066\u304F\u3060\u3055\u3044\u3002" : "\u5BFE\u8C61 repository nickname \u3092\u767B\u9332\u6E08\u307F alias \u304B\u3089\u89E3\u6C7A\u3067\u304D\u307E\u305B\u3093\u3067\u3057\u305F\u3002`\u767B\u9332\u6E08\u307F\u306E\u30CB\u30C3\u30AF\u30CD\u30FC\u30E0\u51FA\u3057\u3066` \u3067\u5019\u88DC\u3092\u78BA\u8A8D\u3059\u308B\u304B\u3001owner/repo \u5F62\u5F0F\u3067\u6307\u5B9A\u3057\u3066\u304F\u3060\u3055\u3044\u3002",
     issues: registryResult.ok ? ["repository nickname could not be resolved"] : [registryResult.reason || "repository nickname registry could not be read"],
     candidates: resolved.candidates || []
   };
@@ -60438,6 +60456,77 @@ function buildDeterministicButlerChatReply({ text, repository, relatedIssue, wan
     return `\u53D7\u3051\u53D6\u308A\u307E\u3057\u305F\u3002${repository} \u306E\u8A71\u3068\u3057\u3066\u4FDD\u5B58\u3057\u307E\u3057\u305F\u3002\u3053\u3053\u304B\u3089 Issue \u5019\u88DC\u3092\u6574\u7406\u3057\u3001\u5B9F\u884C\u304C\u5FC5\u8981\u306A\u5834\u5408\u306F GO / passkey \u5883\u754C\u3092\u660E\u793A\u3057\u3066\u958B\u767A queue \u3078\u9032\u3081\u307E\u3059\u3002${issuePhrase}`.trim();
   }
   return `\u53D7\u3051\u53D6\u308A\u307E\u3057\u305F\u3002${repository} \u306E Butler \u4F1A\u8A71\u3068\u3057\u3066\u540C\u3058 thread \u306B\u4FDD\u5B58\u3057\u307E\u3057\u305F\u3002\u4ECA\u306F dashboard chat runtime \u306E\u521D\u671F\u63A5\u7D9A\u306A\u306E\u3067\u3001\u307E\u305A\u306F\u4F1A\u8A71\u5C65\u6B74\u3068\u8FD4\u4FE1\u3092\u540C\u3058\u753B\u9762\u3067\u78BA\u8A8D\u3067\u304D\u307E\u3059\u3002${issuePhrase}`.trim();
+}
+async function buildDashboardRepositoryNicknameListTurn({ payload, env }) {
+  const input = normalizeObject11(payload);
+  const text = sanitizeDashboardChatText(input.text || input.message || input.body);
+  if (!isDashboardRepositoryNicknameListRequest(text)) {
+    return null;
+  }
+  const threadId = normalizeDashboardThreadId(input.threadId || input.thread_id) || normalizeDashboardThreadId("dashboard-main-unresolved");
+  const now = (/* @__PURE__ */ new Date()).toISOString();
+  const ownerMessage = normalizeDashboardChatMessage(
+    {
+      threadId,
+      role: "owner",
+      status: "sent",
+      text,
+      createdAt: now
+    },
+    { threadId }
+  );
+  const registryResult = await safeRetrieveStoredAliasRegistry(resolveMemoryProvider(env));
+  const butlerMessage = normalizeDashboardChatMessage(
+    {
+      threadId,
+      role: "butler",
+      status: registryResult.ok ? "replied" : "blocked",
+      text: formatDashboardRepositoryNicknameListReply(registryResult),
+      createdAt: new Date(Date.parse(now) + 1).toISOString()
+    },
+    { threadId }
+  );
+  return {
+    threadId,
+    messages: [ownerMessage, butlerMessage].filter(Boolean)
+  };
+}
+function isDashboardRepositoryNicknameListRequest(text) {
+  const normalized = normalizeDashboardEventText(text).toLowerCase();
+  if (!normalized) {
+    return false;
+  }
+  return normalized.includes("\u30CB\u30C3\u30AF\u30CD\u30FC\u30E0") && (normalized.includes("\u4E00\u89A7") || normalized.includes("\u767B\u9332\u6E08") || normalized.includes("\u767B\u9332\u305A\u307F") || normalized.includes("\u51FA\u3057\u3066") || normalized.includes("\u898B\u305B\u3066") || normalized.includes("\u6559\u3048\u3066"));
+}
+function formatDashboardRepositoryNicknameListReply(registryResult) {
+  if (!registryResult?.ok) {
+    return [
+      "\u767B\u9332\u6E08\u307F\u30CB\u30C3\u30AF\u30CD\u30FC\u30E0\u3092\u8AAD\u3081\u307E\u305B\u3093\u3067\u3057\u305F\u3002",
+      "",
+      `\u7406\u7531: ${registryResult?.reason || "memory provider \u304C\u5229\u7528\u3067\u304D\u307E\u305B\u3093\u3002"}`,
+      "",
+      "\u3053\u306E\u72B6\u614B\u3067\u306F repo/nickname \u672A\u6307\u5B9A\u306E\u307E\u307E VPS Codex CLI \u306B\u6E21\u305B\u306A\u3044\u305F\u3081\u3001owner/repo \u5F62\u5F0F\u3067\u5BFE\u8C61 repository \u3092\u6307\u5B9A\u3057\u3066\u304F\u3060\u3055\u3044\u3002"
+    ].join("\n");
+  }
+  const entries = Array.isArray(registryResult.aliasRegistry) ? registryResult.aliasRegistry : [];
+  if (entries.length === 0) {
+    return [
+      "\u767B\u9332\u6E08\u307F\u30CB\u30C3\u30AF\u30CD\u30FC\u30E0\u306F\u3042\u308A\u307E\u305B\u3093\u3002",
+      "",
+      "\u3053\u306E\u72B6\u614B\u3067\u306F repo/nickname \u672A\u6307\u5B9A\u306E\u307E\u307E VPS Codex CLI \u306B\u6E21\u305B\u307E\u305B\u3093\u3002",
+      "\u307E\u305A `marushu/vtdd-v2-p` \u306E\u3088\u3046\u306B owner/repo \u5F62\u5F0F\u3067\u5BFE\u8C61 repository \u3092\u6307\u5B9A\u3057\u3066\u304F\u3060\u3055\u3044\u3002"
+    ].join("\n");
+  }
+  return [
+    "\u767B\u9332\u6E08\u307F\u30CB\u30C3\u30AF\u30CD\u30FC\u30E0\u3067\u3059\u3002",
+    "",
+    ...entries.map((entry) => {
+      const aliases = Array.isArray(entry.aliases) && entry.aliases.length > 0 ? entry.aliases.join(", ") : "\u306A\u3057";
+      return `- ${entry.canonicalRepo}: ${aliases}`;
+    }),
+    "",
+    "\u9001\u4FE1\u4F8B: `\u3076\u3044 #450 \u306E\u6B8B\u308A Issue \u3068 PR \u3092\u78BA\u8A8D\u3057\u3066`"
+  ].join("\n");
 }
 function shouldDispatchDashboardChatToVpsRunner(payload) {
   const input = normalizeObject11(payload);


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #450 の live E2E 不合格対応です。dashboard が repo/nickname 未指定の状態で英語エラーをチャットに積む問題を直し、登録済み nickname を owner が日本語で確認できるようにします。

## Satisfied Success Criteria

- repo 未指定または未解決 nickname の dashboard handoff 失敗理由を日本語 owner-facing 文にします。
- `登録済みのニックネーム出して` に対して dashboard chat thread 内で登録済み nickname 一覧を返します。
- 登録済み nickname 一覧要求は VPS runner に投げず、dashboard 内の通常返信として保存します。
- 生成済み `worker.js` を更新します。

## Unsatisfied Success Criteria

- production deploy 後の iPhone owner authenticated live E2E は未実行です。
- repo/nickname 指定後に VPS runner の実返信が同じ thread に戻る live E2E は未実行です。
- Issue #450 close 判定は未実施です。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #450
- Implementing Success Criteria: 壊れた dashboard chat UX を修正し、英語 API reason を owner-facing chat に出さず、登録済み nickname を確認できること。
- Explicit Non-goals: deploy、Issue close、credential / permission mutation、自動マージ policy 変更、repo default の導入。
- Expected touched files/routes/workflows: `src/worker/runtime.js`、`test/worker.test.js`、`worker.js`。
- Affected Issues: Issue #450。
- Affected PRs: PR #467 の follow-up。
- Affected workflows: generated worker check。workflow 自体は未変更。
- Affected runtime/operator surfaces: Dashboard top chat、`/v2/dashboard/chat/messages`。
- What may break if we patch narrowly: 英語 reason だけ直すと nickname 確認要求が依然として失敗扱いになる。nickname 一覧だけ実装すると通常失敗時の英語表示が残る。
- Unknowns to investigate before coding: production runtime の D1 alias registry に実データが入っているかは deploy 後の live で確認が必要。
- Validation needed: `node --test test/worker.test.js`、`npm test`、deploy 後 iPhone live E2E。
- Stop condition: repo default を導入しそうになった場合、または Issue #450 を越えて credential/deploy/close に踏み込む場合。

## File / Line Hypotheses

- file: `src/worker/runtime.js`
  - hypothesis: `handleDashboardChatMessageRequest` が repo 解決失敗時に API reason をそのまま返し、client がそれを chat に積んでいる。
  - risk if changed narrowly: repo default を入れると no default repository invariant を壊す。
  - validation: repo 未解決時の Japanese reason と nickname 一覧返信を worker test で確認する。
  - related Issue: Issue #450

## Hypothesis Retrospective

- expected: repo/nickname 未指定状態で英語 reason が返っている。
- actual: `VPS...` のような入力は `VPS` を nickname として抽出し、unresolved の英語 reason を返していた。
- mismatch: 単なる required ではなく unresolved path も直す必要があった。
- lesson: owner-facing chat の失敗 path は API error code ではなく日本語 recovery guidance にする。
- should become RAG candidate: yes。

## Verification Evidence

- Unit: `node --test test/worker.test.js`: 152 pass / 0 fail。
- Integration: `npm test`: `node --test` 878 pass / 1 skip / 0 fail、`check:self-parity` passed、`check:generated-worker` passed。
- E2E: 未実行。deploy 後に iPhone dashboard で確認が必要。
- Manual: スクリーンショット上の壊れ方を再現する path をテストで固定。
- Evidence path/link: local test output in this PR run。

## Butler Completion Contract

- Owner goal: Dashboard top chat で失敗しても owner が次に何をすればよいか日本語で分かり、登録済み nickname を確認できるようにする。
- Butler entrypoint: Dashboard top chat。
- Action Schema exposure: 未変更。
- Runtime path: `POST /v2/dashboard/chat/messages`。
- Runner/runtime truth: dashboard chat store に nickname 一覧返信を保存する。repo handoff 失敗時は日本語 reason を返す。
- Authority boundary: repo default は導入しない。VPS runner handoff は repo/nickname 解決後のみ。deploy/close/credential mutation は実行しない。
- E2E evidence: 未実行。deploy 後に owner authenticated dashboard で `登録済みのニックネーム出して` と repo 指定送信を確認する。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 必要。merge 後に production deploy しないと runtime には反映されない。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実行。deploy 後に必須。

## Related Constitution Rules

- AGENTS.md Conversation UX Contract。
- AGENTS.md Safety Invariants: No default repository。
- AGENTS.md Evidence Discipline。

## Out-of-scope but NOT implemented

- Production deploy。
- Issue #450 close。
- 自動マージ policy 変更。
- repo default 導入。

## Extra changes (if any)

generated `worker.js` を更新。

<!-- VTDD metadata -->
- Issue: Issue #450
- Execution ID: dashboard-live-e2e-fix
- Goal: dashboard_chat_triage
