### PR TITLE
dashboard: Butler chat を WebSocket push 経路へ寄せる

### DIFF
--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -83,7 +83,7 @@ export class DashboardChatRoom {
   constructor(state, env) {
     this.ctx = state;
     this.env = env;
-    this.sessions = new Set();
+    this.sessions = new Map();
   }
 
   async fetch(request) {
@@ -105,6 +105,12 @@ export class DashboardChatRoom {
       return json(202, { ok: true, threadId });
     }
 
+    if (request.method === "POST" && url.pathname === "/dispatch") {
+      const payload = await readJson(request);
+      const result = await this.pushVpsRunnerJob(payload);
+      return json(result.ok ? 202 : 503, result);
+    }
+
     if (request.headers.get("upgrade")?.toLowerCase() !== "websocket") {
       return json(426, {
         ok: false,
@@ -120,7 +126,10 @@ export class DashboardChatRoom {
       });
     }
 
-    const threadId = extractDashboardChatSocketThreadId(url.pathname);
+    const isVpsRunnerSocket = url.pathname.endsWith("/dashboard/vps-runner/ws") || url.pathname === "/vps-runner/ws";
+    const threadId = isVpsRunnerSocket
+      ? normalizeDashboardThreadId(url.searchParams.get("threadId") || url.searchParams.get("thread_id"))
+      : extractDashboardChatSocketThreadId(url.pathname);
     if (!threadId) {
       return json(422, {
         ok: false,
@@ -131,17 +140,22 @@ export class DashboardChatRoom {
 
     const pair = new WebSocketPair();
     const [client, server] = Object.values(pair);
+    const attachment = isVpsRunnerSocket ? { role: "vps_runner", threadId } : { role: "dashboard", threadId };
     if (typeof this.ctx?.acceptWebSocket === "function") {
-      server.serializeAttachment({ threadId });
+      server.serializeAttachment(attachment);
       this.ctx.acceptWebSocket(server);
     } else {
       server.accept();
-      this.sessions.add(server);
+      this.sessions.set(server, attachment);
       server.addEventListener("close", () => this.sessions.delete(server));
       server.addEventListener("error", () => this.sessions.delete(server));
-      server.addEventListener("message", (event) => this.handleSocketMessage(server, event?.data, threadId));
+      server.addEventListener("message", (event) => this.handleSocketMessage(server, event?.data, attachment));
     }
-    await this.sendThread(server, threadId);
+    if (isVpsRunnerSocket && isSocketOpen(server)) {
+      server.send(JSON.stringify({ type: "vps_runner_connected", ok: true }));
+    } else {
+      await this.sendThread(server, threadId);
+    }
 
     return new Response(null, {
       status: 101,
@@ -151,8 +165,7 @@ export class DashboardChatRoom {
 
   async webSocketMessage(socket, message) {
     const attachment = typeof socket.deserializeAttachment === "function" ? socket.deserializeAttachment() : null;
-    const threadId = normalizeDashboardThreadId(attachment?.threadId);
-    this.handleSocketMessage(socket, message, threadId);
+    await this.handleSocketMessage(socket, message, attachment);
   }
 
   webSocketClose(socket) {
@@ -163,11 +176,153 @@ export class DashboardChatRoom {
     this.sessions.delete(socket);
   }
 
-  handleSocketMessage(socket, message, threadId) {
-    const text = normalizeDashboardEventText(message).toLowerCase();
-    if (text === "ping" && isSocketOpen(socket)) {
+  async handleSocketMessage(socket, message, attachment = {}) {
+    const socketAttachment = attachment || this.sessions.get(socket) || {};
+    const threadId = normalizeDashboardThreadId(socketAttachment.threadId);
+    const text = normalizeDashboardEventText(message);
+    const lowerText = text.toLowerCase();
+    if (lowerText === "ping" && isSocketOpen(socket)) {
       socket.send(JSON.stringify({ type: "pong", ok: true, threadId }));
+      return;
     }
+    let payload = null;
+    try {
+      payload = text ? JSON.parse(text) : null;
+    } catch {
+      payload = null;
+    }
+    if (socketAttachment.role === "vps_runner") {
+      await this.acceptVpsRunnerReply(payload, socketAttachment);
+      return;
+    }
+    if (payload?.type === "owner_message") {
+      await this.acceptOwnerMessage({ socket, threadId, payload });
+    }
+  }
+
+  async acceptOwnerMessage({ socket, threadId, payload }) {
+    const text = sanitizeDashboardChatText(payload?.text || payload?.message || payload?.body);
+    if (!threadId || !text) {
+      if (isSocketOpen(socket)) {
+        socket.send(JSON.stringify({ type: "error", ok: false, reason: "message text is required" }));
+      }
+      return;
+    }
+    const repository = normalizeCanonicalRepositoryInput(payload?.repository || payload?.repositoryInput);
+    const relatedIssue = normalizePositiveInteger(payload?.relatedIssue || payload?.issueNumber);
+    const now = new Date().toISOString();
+    const ownerMessage = normalizeDashboardChatMessage(
+      {
+        threadId,
+        role: "owner",
+        repository,
+        relatedIssue,
+        status: "sent",
+        text,
+        createdAt: now
+      },
+      { threadId }
+    );
+    const thinkingMessage = normalizeDashboardChatMessage(
+      {
+        threadId,
+        role: "system",
+        repository,
+        relatedIssue,
+        status: "thinking",
+        text: "VPS Codex CLI に送信しました。返信を待っています。",
+        createdAt: new Date(Date.parse(now) + 1).toISOString()
+      },
+      { threadId }
+    );
+    const store = resolveDashboardChatStore(this.env);
+    const messages = store ? await store.appendMany(threadId, [ownerMessage, thinkingMessage]) : [ownerMessage, thinkingMessage].filter(Boolean);
+    await this.broadcastThread({ threadId, messages });
+    const pushed = await this.pushVpsRunnerJob({
+      type: "dashboard_chat_job",
+      threadId,
+      repository,
+      relatedIssue,
+      text,
+      codexGoal: normalizeDashboardEventText(payload?.codexGoal || "dashboard_chat_triage"),
+      createdAt: now
+    });
+    if (!pushed.ok) {
+      const failedMessage = normalizeDashboardChatMessage(
+        {
+          threadId,
+          role: "system",
+          repository,
+          relatedIssue,
+          status: "failed",
+          text: "VPS Codex CLI が WebSocket 接続されていないため送信できませんでした。runner 接続を確認してください。",
+          createdAt: new Date(Date.parse(now) + 2).toISOString()
+        },
+        { threadId }
+      );
+      const failedMessages = store ? await store.appendMany(threadId, [failedMessage]) : [failedMessage].filter(Boolean);
+      await this.broadcastThread({ threadId, messages: failedMessages });
+    }
+  }
+
+  async acceptVpsRunnerReply(payload, socketAttachment = {}) {
+    const socketThreadId = normalizeDashboardThreadId(socketAttachment.threadId);
+    const threadId = normalizeDashboardThreadId(payload?.threadId || payload?.thread_id || socketThreadId);
+    if (!threadId) {
+      return;
+    }
+    if (socketThreadId && threadId !== socketThreadId) {
+      return;
+    }
+    const message = normalizeDashboardChatMessage(
+      {
+        threadId,
+        role: "runner",
+        repository: payload?.repository,
+        relatedIssue: payload?.relatedIssue || payload?.issueNumber,
+        status: payload?.status === "failed" ? "failed" : "replied",
+        text: payload?.text || payload?.message || payload?.body,
+        createdAt: payload?.createdAt || payload?.updatedAt
+      },
+      { threadId }
+    );
+    const store = resolveDashboardChatStore(this.env);
+    const messages = store ? await store.appendMany(threadId, [message]) : [message].filter(Boolean);
+    await this.broadcastThread({ threadId, messages });
+  }
+
+  async pushVpsRunnerJob(payload) {
+    const job = {
+      type: "dashboard_chat_job",
+      jobId: normalizeDashboardEventText(payload?.jobId) || crypto.randomUUID(),
+      threadId: normalizeDashboardThreadId(payload?.threadId || payload?.thread_id),
+      repository: normalizeCanonicalRepositoryInput(payload?.repository),
+      relatedIssue: normalizePositiveInteger(payload?.relatedIssue || payload?.issueNumber),
+      text: sanitizeDashboardChatText(payload?.text || payload?.message || payload?.body),
+      codexGoal: normalizeDashboardEventText(payload?.codexGoal || "dashboard_chat_triage"),
+      createdAt: normalizeIsoTimestamp(payload?.createdAt) || new Date().toISOString()
+    };
+    const runners = this.connectedSockets().filter((socket) => this.getSocketAttachment(socket).role === "vps_runner");
+    if (runners.length === 0) {
+      return {
+        ok: false,
+        error: "vps_runner_not_connected",
+        reason: "VPS Codex CLI WebSocket is not connected"
+      };
+    }
+    const frame = JSON.stringify(job);
+    let pushed = 0;
+    for (const runner of runners) {
+      if (isSocketOpen(runner)) {
+        runner.send(frame);
+        pushed += 1;
+      }
+    }
+    return {
+      ok: pushed > 0,
+      pushed,
+      jobId: job.jobId
+    };
   }
 
   async broadcastThread({ threadId, messages = null }) {
@@ -179,7 +334,8 @@ export class DashboardChatRoom {
       messages: resolvedMessages
     });
     for (const socket of this.connectedSockets()) {
-      if (isSocketOpen(socket)) {
+      const attachment = this.getSocketAttachment(socket);
+      if (attachment.role !== "vps_runner" && (!attachment.threadId || attachment.threadId === threadId) && isSocketOpen(socket)) {
         socket.send(payload);
       }
     }
@@ -221,7 +377,14 @@ export class DashboardChatRoom {
     if (typeof this.ctx?.getWebSockets === "function") {
       return this.ctx.getWebSockets();
     }
-    return Array.from(this.sessions);
+    return Array.from(this.sessions.keys());
+  }
+
+  getSocketAttachment(socket) {
+    if (typeof socket?.deserializeAttachment === "function") {
+      return socket.deserializeAttachment() || {};
+    }
+    return this.sessions.get(socket) || {};
   }
 }
 const CLOUDFLARE_ACCESS_JWKS_CACHE_TTL_MS = 5 * 60 * 1000;
@@ -345,6 +508,21 @@ export default {
 
     if (request.method === "GET" && isDashboardChatSocketApiPath(url.pathname)) {
       return handleDashboardChatSocketRequest(request, url, env);
+    }
+
+    if (request.method === "GET" && isApiPath(url.pathname, "/dashboard/vps-runner/ws")) {
+      return handleDashboardVpsRunnerSocketRequest(request, env);
+    }
+
+    if (request.method === "GET" && isApiPath(url.pathname, "/dashboard/chat/search")) {
+      return handleDashboardChatSearchRequest(request, url, env);
+    }
+
+    if (
+      (request.method === "GET" || request.method === "POST") &&
+      isDashboardChatSummaryApiPath(url.pathname)
+    ) {
+      return handleDashboardChatSummaryRequest(request, url, env);
     }
 
     if (request.method === "GET" && isDashboardChatThreadApiPath(url.pathname)) {
@@ -3382,7 +3560,12 @@ async function handleDashboardChatMessageRequest(request, env) {
   let execution = null;
   let messagesToStore = prepared.messages;
   if (wantsVpsRunnerHandoff) {
-    const handoffPayload = buildDashboardVpsRunnerHandoffPayload({ payload, prepared, env });
+    const handoffPayload = buildDashboardVpsRunnerHandoffPayload({
+      payload,
+      prepared,
+      env,
+      runtimeUrl: new URL(request.url).origin
+    });
     if (!handoffPayload.ok) {
       return json(422, {
         ok: false,
@@ -3463,6 +3646,46 @@ async function handleDashboardChatSocketRequest(request, url, env) {
   return room.fetch(request);
 }
 
+async function handleDashboardVpsRunnerSocketRequest(request, env) {
+  const auth = authorizeGatewayRequest({
+    request,
+    env,
+    apiSuffix: "/dashboard/vps-runner/ws"
+  });
+  if (!auth.ok) {
+    return json(auth.status, {
+      ok: false,
+      error: "unauthorized",
+      reason: auth.reason
+    });
+  }
+  const url = new URL(request.url);
+  const threadId = normalizeDashboardThreadId(url.searchParams.get("threadId") || url.searchParams.get("thread_id"));
+  if (!threadId) {
+    return json(422, {
+      ok: false,
+      error: "thread_id_required",
+      reason: "threadId is required for VPS Codex CLI dashboard WebSocket"
+    });
+  }
+  const room = resolveDashboardChatRoomStub(env, threadId);
+  if (!room) {
+    return json(503, {
+      ok: false,
+      error: "dashboard_vps_runner_room_unavailable",
+      reason: "DASHBOARD_CHAT_ROOMS Durable Object binding is not configured"
+    });
+  }
+  if (request.headers.get("upgrade")?.toLowerCase() !== "websocket") {
+    return json(426, {
+      ok: false,
+      error: "websocket_upgrade_required",
+      reason: "VPS Codex CLI push channel requires a WebSocket upgrade"
+    });
+  }
+  return room.fetch(request);
+}
+
 async function handleDashboardChatThreadRequest(request, url, env) {
   const auth = await authorizeDashboardRequest({
     request,
@@ -3496,10 +3719,109 @@ async function handleDashboardChatThreadRequest(request, url, env) {
   const messages = await store.listThread(threadId, {
     limit: normalizeLimit(url.searchParams.get("limit"), 80)
   });
+  const summary =
+    typeof store.getSummary === "function" ? await store.getSummary(threadId) : null;
   return json(200, {
     ok: true,
     threadId,
-    messages
+    messages,
+    summary
+  });
+}
+
+async function handleDashboardChatSearchRequest(request, url, env) {
+  const auth = await authorizeDashboardRequest({
+    request,
+    env,
+    apiSuffix: "/dashboard/chat/search"
+  });
+  if (!auth.ok) {
+    return json(auth.status, {
+      ok: false,
+      error: "dashboard_auth_required",
+      reason: auth.reason
+    });
+  }
+
+  const store = resolveDashboardChatStore(env);
+  if (!store || typeof store.search !== "function") {
+    return json(503, {
+      ok: false,
+      error: "dashboard_chat_search_unavailable",
+      reason: "dashboard Butler chat search store is not configured"
+    });
+  }
+  const results = await store.search({
+    text: url.searchParams.get("text") || url.searchParams.get("q"),
+    repository: url.searchParams.get("repository"),
+    relatedIssue: url.searchParams.get("relatedIssue") || url.searchParams.get("issueNumber"),
+    limit: normalizeLimit(url.searchParams.get("limit"), 20)
+  });
+  return json(200, {
+    ok: true,
+    results
+  });
+}
+
+async function handleDashboardChatSummaryRequest(request, url, env) {
+  const auth = await authorizeDashboardRequest({
+    request,
+    env,
+    apiSuffix: "/dashboard/chat/:threadId/summary"
+  });
+  if (!auth.ok) {
+    return json(auth.status, {
+      ok: false,
+      error: "dashboard_auth_required",
+      reason: auth.reason
+    });
+  }
+
+  const threadId = extractDashboardChatSummaryThreadId(url.pathname);
+  if (!threadId) {
+    return json(422, {
+      ok: false,
+      error: "thread_id_required",
+      reason: "threadId is required"
+    });
+  }
+  const store = resolveDashboardChatStore(env);
+  if (!store) {
+    return json(503, {
+      ok: false,
+      error: "dashboard_chat_store_unavailable",
+      reason: "dashboard Butler chat store is not configured"
+    });
+  }
+  if (request.method === "GET") {
+    const summary =
+      typeof store.getSummary === "function" ? await store.getSummary(threadId) : null;
+    return json(200, {
+      ok: true,
+      threadId,
+      summary
+    });
+  }
+  if (typeof store.putSummary !== "function") {
+    return json(503, {
+      ok: false,
+      error: "dashboard_chat_summary_unavailable",
+      reason: "dashboard Butler chat summary store is not configured"
+    });
+  }
+  const payload = await readJson(request);
+  const summary = await store.putSummary(threadId, payload);
+  if (!summary) {
+    return json(422, {
+      ok: false,
+      error: "summary_required",
+      reason: "summary text is required"
+    });
+  }
+  return json(200, {
+    ok: true,
+    threadId,
+    summary
   });
 }
 
@@ -5358,6 +5680,135 @@ function createD1DashboardChatStore(d1) {
         })
         .filter(Boolean)
         .reverse();
+    },
+
+    async putSummary(threadId, summary) {
+      const normalized = normalizeDashboardThreadSummary(summary, { threadId });
+      if (!normalized) {
+        return null;
+      }
+      await ensureSchema();
+      await d1
+        .prepare(
+          `INSERT OR REPLACE INTO vtdd_dashboard_thread_summaries (
+             thread_id, repository, related_issue, summary, decisions_json,
+             open_items_json, archived_until_message_id, updated_at, payload_json
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+        )
+        .bind(
+          normalized.threadId,
+          normalized.repository,
+          normalized.relatedIssue,
+          normalized.summary,
+          JSON.stringify(normalized.decisions),
+          JSON.stringify(normalized.openItems),
+          normalized.archivedUntilMessageId,
+          normalized.updatedAt,
+          JSON.stringify(normalized)
+        )
+        .run();
+      return normalized;
+    },
+
+    async getSummary(threadId) {
+      const resolvedThreadId = normalizeDashboardThreadId(threadId);
+      if (!resolvedThreadId) {
+        return null;
+      }
+      await ensureSchema();
+      const result = await d1
+        .prepare("SELECT payload_json FROM vtdd_dashboard_thread_summaries WHERE thread_id = ? LIMIT 1")
+        .bind(resolvedThreadId)
+        .all();
+      const row = Array.isArray(result?.results) ? result.results[0] : null;
+      try {
+        return row?.payload_json
+          ? normalizeDashboardThreadSummary(JSON.parse(row.payload_json), { threadId: resolvedThreadId })
+          : null;
+      } catch {
+        return null;
+      }
+    },
+
+    async search(filter = {}) {
+      await ensureSchema();
+      const text = sanitizeDashboardChatText(filter.text || filter.q);
+      const repository = normalizeCanonicalRepositoryInput(filter.repository);
+      const relatedIssue = normalizePositiveInteger(filter.relatedIssue || filter.issueNumber);
+      const limit = normalizeLimit(filter.limit, 20);
+      const results = [];
+
+      const messageClauses = [];
+      const messageParams = [];
+      if (text) {
+        messageClauses.push("text LIKE ?");
+        messageParams.push(`%${text}%`);
+      }
+      if (repository) {
+        messageClauses.push("repository = ?");
+        messageParams.push(repository);
+      }
+      if (relatedIssue) {
+        messageClauses.push("related_issue = ?");
+        messageParams.push(relatedIssue);
+      }
+      const messageWhere = messageClauses.length > 0 ? `WHERE ${messageClauses.join(" AND ")}` : "";
+      const messageRows = await d1
+        .prepare(
+          `SELECT payload_json FROM vtdd_dashboard_chat_messages
+           ${messageWhere}
+           ORDER BY created_at DESC, message_id DESC
+           LIMIT ?`
+        )
+        .bind(...messageParams, limit)
+        .all();
+      for (const row of Array.isArray(messageRows?.results) ? messageRows.results : []) {
+        try {
+          const message = row?.payload_json ? normalizeDashboardChatMessage(JSON.parse(row.payload_json)) : null;
+          if (message) {
+            results.push({ kind: "message", threadId: message.threadId, message });
+          }
+        } catch {
+          // ignore malformed rows
+        }
+      }
+
+      const summaryClauses = [];
+      const summaryParams = [];
+      if (text) {
+        summaryClauses.push("(summary LIKE ? OR decisions_json LIKE ? OR open_items_json LIKE ?)");
+        summaryParams.push(`%${text}%`, `%${text}%`, `%${text}%`);
+      }
+      if (repository) {
+        summaryClauses.push("repository = ?");
+        summaryParams.push(repository);
+      }
+      if (relatedIssue) {
+        summaryClauses.push("related_issue = ?");
+        summaryParams.push(relatedIssue);
+      }
+      const summaryWhere = summaryClauses.length > 0 ? `WHERE ${summaryClauses.join(" AND ")}` : "";
+      const summaryRows = await d1
+        .prepare(
+          `SELECT payload_json FROM vtdd_dashboard_thread_summaries
+           ${summaryWhere}
+           ORDER BY updated_at DESC
+           LIMIT ?`
+        )
+        .bind(...summaryParams, limit)
+        .all();
+      for (const row of Array.isArray(summaryRows?.results) ? summaryRows.results : []) {
+        try {
+          const summary = row?.payload_json ? normalizeDashboardThreadSummary(JSON.parse(row.payload_json)) : null;
+          if (summary) {
+            results.push({ kind: "summary", threadId: summary.threadId, summary });
+          }
+        } catch {
+          // ignore malformed rows
+        }
+      }
+
+      return results.slice(0, limit);
     }
   };
 
@@ -5369,6 +5820,15 @@ function createD1DashboardChatStore(d1) {
         );
         await d1.exec(
           "CREATE INDEX IF NOT EXISTS idx_vtdd_dashboard_chat_messages_thread ON vtdd_dashboard_chat_messages (thread_id, created_at DESC);"
+        );
+        await d1.exec(
+          "CREATE INDEX IF NOT EXISTS idx_vtdd_dashboard_chat_messages_lookup ON vtdd_dashboard_chat_messages (repository, related_issue, created_at DESC);"
+        );
+        await d1.exec(
+          "CREATE TABLE IF NOT EXISTS vtdd_dashboard_thread_summaries (thread_id TEXT PRIMARY KEY, repository TEXT, related_issue INTEGER, summary TEXT NOT NULL, decisions_json TEXT NOT NULL, open_items_json TEXT NOT NULL, archived_until_message_id TEXT, updated_at TEXT NOT NULL, payload_json TEXT NOT NULL);"
+        );
+        await d1.exec(
+          "CREATE INDEX IF NOT EXISTS idx_vtdd_dashboard_thread_summaries_lookup ON vtdd_dashboard_thread_summaries (repository, related_issue, updated_at DESC);"
         );
       })();
     }
@@ -5550,7 +6010,7 @@ function shouldDispatchDashboardChatToVpsRunner(payload) {
   );
 }
 
-function buildDashboardVpsRunnerHandoffPayload({ payload, prepared, env }) {
+function buildDashboardVpsRunnerHandoffPayload({ payload, prepared, env, runtimeUrl }) {
   const input = normalizeObject(payload);
   const issueNumber =
     normalizePositiveInteger(input.issueNumber || input.relatedIssue) ||
@@ -5593,7 +6053,8 @@ function buildDashboardVpsRunnerHandoffPayload({ payload, prepared, env }) {
           repositoryInput: normalizeDashboardRepositoryInput(
             input.repositoryInput || input.repository_input || input.repository || prepared.repository
           ),
-          dashboardThreadId: prepared.threadId
+          dashboardThreadId: prepared.threadId,
+          dashboardRuntimeUrl: normalizeDashboardEventText(input.dashboardRuntimeUrl || runtimeUrl)
         }
       },
       executionTarget: {
@@ -5670,6 +6131,44 @@ function normalizeDashboardChatMessage(message, defaults = {}) {
   };
 }
 
+function normalizeDashboardThreadSummary(summary, defaults = {}) {
+  const input = normalizeObject(summary);
+  const threadId = normalizeDashboardThreadId(input.threadId || input.thread_id || defaults.threadId);
+  if (!threadId) {
+    return null;
+  }
+  const summaryText = sanitizeDashboardChatText(input.summary || input.text || input.body);
+  if (!summaryText) {
+    return null;
+  }
+  const decisions = normalizeStringList(input.decisions || input.decisionLog || input.decision_log);
+  const openItems = normalizeStringList(input.openItems || input.open_items || input.todo || input.todos);
+  return {
+    threadId,
+    repository: normalizeCanonicalRepositoryInput(input.repository || defaults.repository) || null,
+    relatedIssue: normalizePositiveInteger(
+      input.relatedIssue || input.issueNumber || input.related_issue || defaults.relatedIssue
+    ),
+    summary: summaryText,
+    decisions,
+    openItems,
+    archivedUntilMessageId:
+      normalizeDashboardEventText(
+        input.archivedUntilMessageId || input.archived_until_message_id || defaults.archivedUntilMessageId
+      ) || null,
+    updatedAt:
+      normalizeIsoTimestamp(input.updatedAt || input.updated_at || defaults.updatedAt) || new Date().toISOString()
+  };
+}
+
+function normalizeStringList(value) {
+  const list = Array.isArray(value) ? value : value ? [value] : [];
+  return list
+    .map((item) => sanitizeDashboardChatText(item))
+    .filter(Boolean)
+    .slice(0, 40);
+}
+
 function normalizeDashboardChatRole(value) {
   const role = normalizeDashboardEventText(value).toLowerCase();
   return ["owner", "butler", "runner", "system"].includes(role) ? role : "system";
@@ -5704,7 +6203,7 @@ function isDashboardChatThreadApiPath(pathname) {
   return (
     pathname.startsWith(`${CANONICAL_API_PREFIX}/dashboard/chat/`) ||
     pathname.startsWith(`${LEGACY_API_PREFIX}/dashboard/chat/`)
-  );
+  ) && !pathname.endsWith("/summary");
 }
 
 function isDashboardChatSocketApiPath(pathname) {
@@ -5741,6 +6240,17 @@ function extractDashboardChatThreadId(pathname) {
 
 function extractDashboardChatSocketThreadId(pathname) {
   return extractDashboardChatThreadId(pathname.replace(/\/ws$/, ""));
+}
+
+function isDashboardChatSummaryApiPath(pathname) {
+  return (
+    pathname.startsWith(`${CANONICAL_API_PREFIX}/dashboard/chat/`) ||
+    pathname.startsWith(`${LEGACY_API_PREFIX}/dashboard/chat/`)
+  ) && pathname.endsWith("/summary");
+}
+
+function extractDashboardChatSummaryThreadId(pathname) {
+  return extractDashboardChatThreadId(pathname.replace(/\/summary$/, ""));
 }
 
 function normalizeDashboardEventRecord(event) {
@@ -7784,18 +8294,18 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         <article class="bubble">
           <strong>Butler</strong>
           <p>その方針で進めます。中央はチャットだけ、状態確認・進捗・RAG・workflow・prototype cleanup の扱いはサイドバーのメニューから必要な時だけ開きます。</p>
-          <p>この dashboard からの送信は VPS Codex CLI の dashboard chat triage queue に渡します。返信として表示するのは runner から戻った event post だけです。</p>
-          <span class="connection-note">接続済み: WebSocket で runner event post を待ちます</span>
+          <p>この dashboard からの送信は WebSocket で VPS Codex CLI に直接 push します。GitHub Issue コメント queue は通常会話では使いません。</p>
+          <span class="connection-note">接続準備中: WebSocket で Butler と VPS Codex CLI に接続します</span>
         </article>
 
       </div>
 
-      <form class="composer" id="butler-chat-form" aria-label="Butler composer" data-endpoint="${escapeDashboardHtml(origin)}/v2/dashboard/chat/messages" data-thread-endpoint="${escapeDashboardHtml(origin)}/v2/dashboard/chat/${escapeDashboardHtml(chatThreadId)}" data-socket-endpoint="${escapeDashboardHtml(socketOrigin)}/v2/dashboard/chat/${escapeDashboardHtml(chatThreadId)}/ws" data-thread-id="${escapeDashboardHtml(chatThreadId)}" data-repository-input="${escapeDashboardHtml(repositoryInput)}" data-issue-number="${dashboardIssueNumber || ""}" data-dispatch-to-vps-runner="true" data-codex-goal="dashboard_chat_triage">
+      <form class="composer" id="butler-chat-form" aria-label="Butler composer" data-socket-endpoint="${escapeDashboardHtml(socketOrigin)}/v2/dashboard/chat/${escapeDashboardHtml(chatThreadId)}/ws" data-thread-endpoint="${escapeDashboardHtml(origin)}/v2/dashboard/chat/${escapeDashboardHtml(chatThreadId)}" data-thread-id="${escapeDashboardHtml(chatThreadId)}" data-repository-input="${escapeDashboardHtml(repositoryInput)}" data-issue-number="${dashboardIssueNumber || ""}" data-dispatch-to-vps-runner="true" data-codex-goal="dashboard_chat_triage">
         <div class="composer-box">
           <textarea id="butler-message" name="text" placeholder="Butler V2 にメッセージ..." aria-label="Butler V2 にメッセージ"></textarea>
           <button class="send-button" type="submit" aria-label="Butler に送信">↑</button>
         </div>
-        <div class="composer-status" id="butler-chat-status">接続済み。送信すると VPS Codex CLI queue に渡します。返信は runner event post だけを表示します。</div>
+        <div class="composer-status" id="butler-chat-status">接続準備中です。WebSocket 接続後に送信できます。</div>
       </form>
     </section>
 
@@ -7859,15 +8369,18 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
       const status = document.getElementById("butler-chat-status");
       if (!form || !log || !textarea || !status) return;
 
-      const endpoint = form.dataset.endpoint;
-      const threadEndpoint = form.dataset.threadEndpoint;
       const socketEndpoint = form.dataset.socketEndpoint;
+      const threadEndpoint = form.dataset.threadEndpoint;
       const threadId = form.dataset.threadId;
       const repositoryInput = form.dataset.repositoryInput;
       const issueNumber = Number.parseInt(form.dataset.issueNumber || "", 10);
       const dispatchToVpsRunner = form.dataset.dispatchToVpsRunner === "true";
       const codexGoal = form.dataset.codexGoal || "dashboard_chat_triage";
       const initialMarkup = log.innerHTML;
+      let chatSocket = null;
+      let reconnectTimer = null;
+      let reconnectAttempt = 0;
+      let refreshingThread = false;
 
       function updateComposerReserve() {
         log.style.setProperty("--composer-reserve", Math.ceil(form.getBoundingClientRect().height) + "px");
@@ -7927,27 +8440,6 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         appendMessage({ role: "butler", text });
       }
 
-      function showThinking() {
-        const article = document.createElement("article");
-        article.className = "bubble thinking";
-        article.dataset.pending = "butler";
-        const paragraph = document.createElement("p");
-        const span = document.createElement("span");
-        span.className = "thinking-dots";
-        span.textContent = "考えています";
-        paragraph.appendChild(span);
-        article.appendChild(paragraph);
-        log.appendChild(article);
-        scrollToLatest();
-        return article;
-      }
-
-      function removeThinking(article) {
-        if (article && article.parentNode) {
-          article.parentNode.removeChild(article);
-        }
-      }
-
       function renderThread(messages) {
         if (!Array.isArray(messages) || messages.length === 0) {
           log.innerHTML = initialMarkup;
@@ -7961,48 +8453,79 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         scrollToLatest();
       }
 
-      function connectThreadSocket() {
-        if (!socketEndpoint || typeof WebSocket !== "function") {
-          setStatus("WebSocket を開始できません。runner 返信は再読み込みで確認してください。");
-          return;
-        }
-        const socket = new WebSocket(socketEndpoint);
-        socket.addEventListener("open", () => {
-          setStatus("WebSocket 接続済み。VPS Codex CLI の runner event post を待っています。");
-        });
-        socket.addEventListener("message", (event) => {
-          const body = JSON.parse(event.data || "{}");
-          if (body.type === "thread" && body.ok) {
-            renderThread(body.messages || []);
-          }
-        });
-        socket.addEventListener("close", () => {
-          setStatus("WebSocket が切れました。再読み込みすると最新 thread を確認できます。");
-        });
-        socket.addEventListener("error", () => {
-          setStatus("WebSocket 接続に失敗しました。再読み込みすると最新 thread を確認できます。");
-        });
-      }
-
       async function refreshThread() {
-        if (!threadEndpoint) return;
-        setStatus("会話履歴を読み込み中です。");
+        if (!threadEndpoint || refreshingThread) return;
+        refreshingThread = true;
         try {
           const response = await fetch(threadEndpoint, {
-            method: "GET",
             headers: { "accept": "application/json" },
             credentials: "same-origin"
           });
-          const body = await response.json().catch(() => ({}));
-          if (!response.ok || !body.ok) {
-            setStatus(body.reason || "会話履歴を読めませんでした。送信時に再試行します。");
+          if (!response.ok) {
+            setStatus("履歴の再取得に失敗しました。WebSocket を再接続しています。");
             return;
           }
-          renderThread(body.messages || []);
-          setStatus("接続済み。送信すると VPS Codex CLI queue に渡します。返信は runner event post だけを表示します。");
+          const body = await response.json();
+          if (body && body.ok) {
+            renderThread(body.messages || []);
+          }
         } catch {
-          setStatus("会話履歴を読めませんでした。送信時に再試行します。");
+          setStatus("履歴の再取得に失敗しました。WebSocket を再接続しています。");
+        } finally {
+          refreshingThread = false;
         }
+      }
+
+      function scheduleReconnect() {
+        if (reconnectTimer || !socketEndpoint || typeof WebSocket !== "function") return;
+        const delay = Math.min(10000, 1000 * Math.pow(2, reconnectAttempt));
+        reconnectAttempt += 1;
+        reconnectTimer = window.setTimeout(() => {
+          reconnectTimer = null;
+          connectThreadSocket();
+        }, delay);
+      }
+
+      function connectThreadSocket() {
+        if (!socketEndpoint || typeof WebSocket !== "function") {
+          setStatus("WebSocket を開始できません。dashboard Butler は送信できません。");
+          return;
+        }
+        if (chatSocket && (chatSocket.readyState === WebSocket.OPEN || chatSocket.readyState === WebSocket.CONNECTING)) {
+          return;
+        }
+        chatSocket = new WebSocket(socketEndpoint);
+        chatSocket.addEventListener("open", () => {
+          reconnectAttempt = 0;
+          if (reconnectTimer) {
+            window.clearTimeout(reconnectTimer);
+            reconnectTimer = null;
+          }
+          setStatus("WebSocket 接続済み。送信すると VPS Codex CLI に push します。");
+          refreshThread();
+        });
+        chatSocket.addEventListener("message", (event) => {
+          try {
+            const body = JSON.parse(event.data || "{}");
+            if (body.type === "thread" && body.ok) {
+              renderThread(body.messages || []);
+            } else if (body.type === "error") {
+              appendError(body.reason || "WebSocket message error");
+            }
+          } catch {
+            appendError("WebSocket message を読み取れませんでした。");
+          }
+        });
+        chatSocket.addEventListener("close", () => {
+          setStatus("WebSocket が切れました。履歴を再取得して再接続します。");
+          refreshThread();
+          scheduleReconnect();
+        });
+        chatSocket.addEventListener("error", () => {
+          setStatus("WebSocket 接続に失敗しました。履歴を再取得して再接続します。");
+          refreshThread();
+          scheduleReconnect();
+        });
       }
 
       form.addEventListener("submit", async (event) => {
@@ -8013,52 +8536,47 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           return;
         }
         const submitButton = form.querySelector("button[type='submit']");
-        if (submitButton) submitButton.disabled = true;
-        setStatus("送信中です。VPS Codex CLI queue に渡します。");
-        const thinking = showThinking();
-        try {
-          const response = await fetch(endpoint, {
-            method: "POST",
-            headers: { "content-type": "application/json", "accept": "application/json" },
-            credentials: "same-origin",
-            body: JSON.stringify({
-              threadId,
-              repositoryInput,
-              text,
-              issueNumber,
-              relatedIssue: issueNumber,
-              dispatchToVpsRunner,
-              executorTransport: dispatchToVpsRunner ? "vps_runner" : undefined,
-              codexGoal,
-              handoffSummary: "Dashboard Butler chat message from owner"
-            })
-          });
-          const body = await response.json().catch(() => ({}));
-          removeThinking(thinking);
-          if (!response.ok || !body.ok) {
-            appendError(body.reason || "送信に失敗しました。runtime truth を確認してください。");
-            setStatus("送信に失敗しました。");
-            return;
-          }
-          textarea.value = "";
-          for (const message of body.messages || []) {
-            appendMessage(message);
-          }
-          setStatus(body.execution ? "保存済み。VPS Codex CLI queue に渡しました。runner event post を待っています。" : "保存済み。Worker runtime に保存しました。");
-        } catch {
-          removeThinking(thinking);
-          appendError("Worker chat runtime に接続できませんでした。ネットワークまたは deploy 状態を確認してください。");
-          setStatus("接続に失敗しました。");
-        } finally {
-          if (submitButton) submitButton.disabled = false;
+        if (!chatSocket || chatSocket.readyState !== WebSocket.OPEN) {
+          setStatus("WebSocket 再接続中です。履歴を再取得しています。接続後にもう一度送信してください。");
+          await refreshThread();
+          scheduleReconnect();
           textarea.focus({ preventScroll: true });
-          updateComposerReserve();
+          return;
         }
+        if (submitButton) submitButton.disabled = true;
+        setStatus("送信中です。VPS Codex CLI に push します。");
+        chatSocket.send(JSON.stringify({
+          type: "owner_message",
+          threadId,
+          repositoryInput,
+          text,
+          issueNumber,
+          relatedIssue: issueNumber,
+          dispatchToVpsRunner,
+          executorTransport: dispatchToVpsRunner ? "vps_runner" : undefined,
+          codexGoal
+        }));
+        textarea.value = "";
+        setStatus("送信済み。VPS Codex CLI の返信を待っています。");
+        if (submitButton) submitButton.disabled = false;
+        textarea.focus({ preventScroll: true });
+        updateComposerReserve();
       });
 
       updateComposerReserve();
       window.addEventListener("resize", updateComposerReserve);
-      refreshThread();
+      window.addEventListener("online", () => {
+        setStatus("ネットワーク復帰を検知しました。履歴を再取得して再接続します。");
+        refreshThread();
+        scheduleReconnect();
+      });
+      document.addEventListener("visibilitychange", () => {
+        if (document.visibilityState === "visible" && (!chatSocket || chatSocket.readyState !== WebSocket.OPEN)) {
+          setStatus("画面復帰を検知しました。履歴を再取得して再接続します。");
+          refreshThread();
+          scheduleReconnect();
+        }
+      });
       connectThreadSocket();
     })();
   </script>

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -1,6 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import worker from "../src/worker.js";
+import { DashboardChatRoom } from "../src/worker.js";
 import {
   ActionType,
   ActorRole,
@@ -102,10 +103,18 @@ function createInMemoryDashboardEventStore() {
 
 function createInMemoryDashboardChatStore() {
   const messagesByThread = new Map();
+  const summariesByThread = new Map();
   return {
     async appendMany(threadId, messages) {
       const list = messagesByThread.get(threadId) ?? [];
       const normalizedMessages = (Array.isArray(messages) ? messages : []).map((message) => ({
+        messageId: message.messageId || `${threadId}-${list.length + 1}`,
+        role: message.role || "system",
+        repository: message.repository || null,
+        relatedIssue: message.relatedIssue || message.issueNumber || null,
+        status: message.status || "sent",
+        text: message.text || "",
+        createdAt: message.createdAt || new Date().toISOString(),
         ...message,
         threadId
       }));
@@ -116,6 +125,46 @@ function createInMemoryDashboardChatStore() {
     async listThread(threadId, filter = {}) {
       const limit = Number(filter.limit) || 80;
       return (messagesByThread.get(threadId) ?? []).slice(-limit);
+    },
+    async putSummary(threadId, summary) {
+      const record = {
+        threadId,
+        repository: summary.repository || null,
+        relatedIssue: summary.relatedIssue || summary.issueNumber || null,
+        summary: summary.summary || summary.text || "",
+        decisions: Array.isArray(summary.decisions) ? summary.decisions : [],
+        openItems: Array.isArray(summary.openItems) ? summary.openItems : [],
+        archivedUntilMessageId: summary.archivedUntilMessageId || null,
+        updatedAt: summary.updatedAt || new Date().toISOString()
+      };
+      summariesByThread.set(threadId, record);
+      return record.summary ? record : null;
+    },
+    async getSummary(threadId) {
+      return summariesByThread.get(threadId) || null;
+    },
+    async search(filter = {}) {
+      const text = String(filter.text || filter.q || "");
+      const repository = filter.repository || "";
+      const relatedIssue = Number(filter.relatedIssue || filter.issueNumber) || null;
+      const limit = Number(filter.limit) || 20;
+      const results = [];
+      for (const [threadId, messages] of messagesByThread.entries()) {
+        for (const message of messages) {
+          if (text && !String(message.text || "").includes(text)) continue;
+          if (repository && message.repository !== repository) continue;
+          if (relatedIssue && message.relatedIssue !== relatedIssue) continue;
+          results.push({ kind: "message", threadId, message });
+        }
+      }
+      for (const [threadId, summary] of summariesByThread.entries()) {
+        const haystack = [summary.summary, ...summary.decisions, ...summary.openItems].join("\n");
+        if (text && !haystack.includes(text)) continue;
+        if (repository && summary.repository !== repository) continue;
+        if (relatedIssue && summary.relatedIssue !== relatedIssue) continue;
+        results.push({ kind: "summary", threadId, summary });
+      }
+      return results.slice(0, limit);
     }
   };
 }
@@ -136,6 +185,20 @@ function createMockDashboardChatRoomNamespace() {
           }
         };
       }
+    }
+  };
+}
+
+function createMockSocket(role, threadId) {
+  const sent = [];
+  return {
+    readyState: 1,
+    sent,
+    send(message) {
+      sent.push(String(message));
+    },
+    deserializeAttachment() {
+      return { role, threadId };
     }
   };
 }
@@ -397,10 +460,10 @@ test("worker serves v2 dashboard for allowed owner identity without exposing sec
   assert.equal(body.includes("overflow: hidden"), true);
   assert.equal(body.includes("grid-template-columns: minmax(0, 1fr) auto"), true);
   assert.equal(body.includes("WebSocket"), true);
-  assert.equal(body.includes("接続済み: WebSocket で runner event post を待ちます"), true);
+  assert.equal(body.includes("接続準備中: WebSocket で Butler と VPS Codex CLI に接続します"), true);
   assert.equal(body.includes("repo/nickname 未指定"), true);
-  assert.equal(body.includes("dashboard chat triage queue に渡します"), true);
-  assert.equal(body.includes("返信として表示するのは runner から戻った event post だけです"), true);
+  assert.equal(body.includes("WebSocket で VPS Codex CLI に直接 push します"), true);
+  assert.equal(body.includes("GitHub Issue コメント queue は通常会話では使いません"), true);
   assert.equal(body.includes("deploy 用 passkey URL"), false);
   assert.equal(body.includes("vtdd-v3-orchestrator.polished-tree-da7c.workers.dev"), false);
   assert.equal(body.includes('id="mobile-menu-toggle"'), true);
@@ -410,7 +473,7 @@ test("worker serves v2 dashboard for allowed owner identity without exposing sec
   assert.equal(body.includes('class="icon-button"'), false);
   assert.equal(body.includes('aria-hidden="true">＋</span>'), false);
   assert.equal(body.includes('aria-hidden="true">♪</span>'), false);
-  assert.equal(body.includes("/v2/dashboard/chat/messages"), true);
+  assert.equal(body.includes("/v2/dashboard/chat/messages"), false);
   assert.equal(body.includes('data-thread-endpoint="https://example.com/v2/dashboard/chat/dashboard-main-unresolved"'), true);
   assert.equal(body.includes('data-socket-endpoint="wss://example.com/v2/dashboard/chat/dashboard-main-unresolved/ws"'), true);
   assert.equal(body.includes('data-dispatch-to-vps-runner="true"'), true);
@@ -418,17 +481,21 @@ test("worker serves v2 dashboard for allowed owner identity without exposing sec
   assert.equal(body.includes('data-codex-goal="dashboard_chat_triage"'), true);
   assert.equal(body.includes('executorTransport: dispatchToVpsRunner ? "vps_runner" : undefined'), true);
   assert.equal(body.includes("new WebSocket(socketEndpoint)"), true);
-  assert.equal(body.includes("VPS Codex CLI の runner event post を待っています"), true);
   assert.equal(body.includes("function refreshThread()"), true);
+  assert.equal(body.includes("function scheduleReconnect()"), true);
+  assert.equal(body.includes("履歴を再取得して再接続します"), true);
+  assert.equal(body.includes("document.addEventListener(\"visibilitychange\""), true);
+  assert.equal(body.includes("window.addEventListener(\"online\""), true);
+  assert.equal(body.includes("VPS Codex CLI に push します"), true);
   assert.equal(body.includes("function updateComposerReserve()"), true);
   assert.equal(body.includes("function scrollToLatest()"), true);
-  assert.equal(body.includes("function showThinking()"), true);
-  assert.equal(body.includes("function removeThinking("), true);
+  assert.equal(body.includes("function showThinking()"), false);
+  assert.equal(body.includes("function removeThinking("), false);
   assert.equal(body.includes("function renderMessageText("), true);
   assert.equal(body.includes("white-space: pre-wrap"), true);
   assert.equal(body.includes("urlPattern"), true);
   assert.equal(body.includes('link.className = "chat-link"'), true);
-  assert.equal(body.includes("考えています"), true);
+  assert.equal(body.includes("考えています"), false);
   assert.equal(body.includes("thinking-dots"), true);
   assert.equal(body.includes("grid-template-rows: auto minmax(0, 1fr) auto"), true);
   assert.equal(body.includes("height: 100dvh"), true);
@@ -438,7 +505,7 @@ test("worker serves v2 dashboard for allowed owner identity without exposing sec
   assert.equal(body.includes("--composer-reserve"), true);
   assert.equal(body.includes("background: var(--page-bg)"), true);
   assert.equal(body.includes('credentials: "same-origin"'), true);
-  assert.equal(body.includes("会話履歴を読み込み中です"), true);
+  assert.equal(body.includes("会話履歴を読み込み中です"), false);
   assert.equal(body.includes("モバイル管理メニュー"), true);
   assert.equal(body.includes("直近 deploy event"), true);
   assert.equal(body.includes("Butler V2 にメッセージ"), true);
@@ -451,8 +518,8 @@ test("worker serves v2 dashboard for allowed owner identity without exposing sec
   assert.equal(body.includes('name="text"'), true);
   assert.equal(/<meta[^>]+http-equiv=["']?refresh/i.test(body), false);
   assert.equal(body.includes("setInterval("), false);
-  assert.equal(body.includes("setTimeout("), false);
-  assert.equal(body.includes("fetch("), true);
+  assert.equal(body.includes("setTimeout("), true);
+  assert.equal(body.includes("fetch(threadEndpoint"), true);
   assert.equal(body.includes("repositoryInput=marushu%2Fvtdd-v2-p"), false);
   assert.equal(body.includes("/status"), true);
   assert.equal(body.includes("/dashboard/preflight?repository=marushu%2Fvtdd-v2-p"), false);
@@ -520,6 +587,73 @@ test("worker appends dashboard Butler chat turn and retrieves the same thread", 
   assert.equal(retrieveBody.ok, true);
   assert.equal(retrieveBody.messages.length, 2);
   assert.equal(retrieveBody.messages[0].text, "VPS Codex CLI とリアルタイムに会話したい");
+  assert.equal(retrieveBody.summary, null);
+});
+
+test("worker stores dashboard Butler thread summaries and searches archived context", async () => {
+  const store = createInMemoryDashboardChatStore();
+  await store.appendMany("dashboard-main-marushu-vtdd-v2-p", [
+    {
+      role: "owner",
+      repository: "marushu/vtdd-v2-p",
+      relatedIssue: 450,
+      status: "sent",
+      text: "長いスレッドを分割して検索できるようにして",
+      createdAt: "2026-05-20T00:00:00.000Z"
+    }
+  ]);
+  await store.appendMany("dashboard-main-other", [
+    {
+      role: "owner",
+      repository: "marushu/other",
+      relatedIssue: 1,
+      status: "sent",
+      text: "別リポジトリの話",
+      createdAt: "2026-05-20T00:00:01.000Z"
+    }
+  ]);
+
+  const summaryResponse = await worker.fetch(
+    new Request("https://example.com/v2/dashboard/chat/dashboard-main-marushu-vtdd-v2-p/summary", {
+      method: "POST",
+      headers: { ...dashboardAccessHeaders, "content-type": "application/json" },
+      body: JSON.stringify({
+        repository: "marushu/vtdd-v2-p",
+        relatedIssue: 450,
+        summary: "Butler chat は長期スレッドを要約し、古い文脈をアーカイブ検索へ寄せる。",
+        decisions: ["直近表示は短く保ち、過去文脈は検索する"],
+        openItems: ["LLM 自動仕分けは次スライス"]
+      })
+    }),
+    { ...dashboardAccessEnv, DASHBOARD_CHAT_STORE: store }
+  );
+  assert.equal(summaryResponse.status, 200);
+  const summaryBody = await summaryResponse.json();
+  assert.equal(summaryBody.ok, true);
+  assert.equal(summaryBody.summary.relatedIssue, 450);
+
+  const threadResponse = await worker.fetch(
+    new Request("https://example.com/v2/dashboard/chat/dashboard-main-marushu-vtdd-v2-p", {
+      headers: dashboardAccessHeaders
+    }),
+    { ...dashboardAccessEnv, DASHBOARD_CHAT_STORE: store }
+  );
+  assert.equal(threadResponse.status, 200);
+  const threadBody = await threadResponse.json();
+  assert.equal(threadBody.summary.summary.includes("アーカイブ検索"), true);
+
+  const searchResponse = await worker.fetch(
+    new Request(
+      "https://example.com/v2/dashboard/chat/search?text=%E3%82%A2%E3%83%BC%E3%82%AB%E3%82%A4%E3%83%96&repository=marushu%2Fvtdd-v2-p&relatedIssue=450",
+      { headers: dashboardAccessHeaders }
+    ),
+    { ...dashboardAccessEnv, DASHBOARD_CHAT_STORE: store }
+  );
+  assert.equal(searchResponse.status, 200);
+  const searchBody = await searchResponse.json();
+  assert.equal(searchBody.ok, true);
+  assert.equal(searchBody.results.some((result) => result.kind === "summary"), true);
+  assert.equal(searchBody.results.every((result) => result.threadId === "dashboard-main-marushu-vtdd-v2-p"), true);
 });
 
 test("worker appends dashboard Butler chat turn with dashboard passkey session cookie", async () => {
@@ -873,6 +1007,175 @@ test("worker requires WebSocket upgrade for dashboard chat live updates", async 
   assert.equal(rooms.calls.length, 0);
 });
 
+test("worker exposes machine-authenticated VPS runner WebSocket push channel", async () => {
+  const rooms = createMockDashboardChatRoomNamespace();
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/dashboard/vps-runner/ws?threadId=dashboard-main-marushu-vtdd-v2-p", {
+      headers: gatewayAuthHeaders
+    }),
+    { ...gatewayAuthEnv, DASHBOARD_CHAT_ROOMS: rooms.namespace }
+  );
+
+  assert.equal(response.status, 426);
+  const body = await response.json();
+  assert.equal(body.error, "websocket_upgrade_required");
+  assert.equal(rooms.calls.length, 0);
+
+  const unauthorized = await worker.fetch(
+    new Request("https://example.com/v2/dashboard/vps-runner/ws?threadId=dashboard-main-marushu-vtdd-v2-p"),
+    { ...gatewayAuthEnv, DASHBOARD_CHAT_ROOMS: rooms.namespace }
+  );
+  assert.equal(unauthorized.status, 401);
+
+  const missingThread = await worker.fetch(
+    new Request("https://example.com/v2/dashboard/vps-runner/ws", {
+      headers: gatewayAuthHeaders
+    }),
+    { ...gatewayAuthEnv, DASHBOARD_CHAT_ROOMS: rooms.namespace }
+  );
+  assert.equal(missingThread.status, 422);
+  const missingBody = await missingThread.json();
+  assert.equal(missingBody.error, "thread_id_required");
+});
+
+test("DashboardChatRoom pushes owner messages to a runner socket in the same thread room", async () => {
+  const store = createInMemoryDashboardChatStore();
+  const room = new DashboardChatRoom(
+    {
+      getWebSockets() {
+        return [dashboardSocket, runnerSocket];
+      }
+    },
+    { DASHBOARD_CHAT_STORE: store }
+  );
+  const dashboardSocket = createMockSocket("dashboard", "dashboard-main-marushu-vtdd-v2-p");
+  const runnerSocket = createMockSocket("vps_runner", "dashboard-main-marushu-vtdd-v2-p");
+
+  await room.webSocketMessage(
+    dashboardSocket,
+    JSON.stringify({
+      type: "owner_message",
+      threadId: "dashboard-main-marushu-vtdd-v2-p",
+      repositoryInput: "marushu/vtdd-v2-p",
+      issueNumber: 450,
+      text: "進捗は？"
+    })
+  );
+
+  assert.equal(runnerSocket.sent.length, 1);
+  const job = JSON.parse(runnerSocket.sent[0]);
+  assert.equal(job.type, "dashboard_chat_job");
+  assert.equal(job.threadId, "dashboard-main-marushu-vtdd-v2-p");
+  assert.equal(job.repository, "marushu/vtdd-v2-p");
+  assert.equal(job.relatedIssue, 450);
+  assert.equal(job.text, "進捗は？");
+
+  assert.equal(dashboardSocket.sent.length, 1);
+  const broadcast = JSON.parse(dashboardSocket.sent[0]);
+  assert.equal(broadcast.type, "thread");
+  assert.equal(broadcast.messages.length, 2);
+  assert.equal(broadcast.messages[0].role, "owner");
+  assert.equal(broadcast.messages[1].status, "thinking");
+});
+
+test("DashboardChatRoom broadcasts VPS runner replies to dashboard sockets in the same thread room", async () => {
+  const store = createInMemoryDashboardChatStore();
+  const dashboardSocket = createMockSocket("dashboard", "dashboard-main-marushu-vtdd-v2-p");
+  const runnerSocket = createMockSocket("vps_runner", "dashboard-main-marushu-vtdd-v2-p");
+  const room = new DashboardChatRoom(
+    {
+      getWebSockets() {
+        return [dashboardSocket, runnerSocket];
+      }
+    },
+    { DASHBOARD_CHAT_STORE: store }
+  );
+
+  await room.webSocketMessage(
+    runnerSocket,
+    JSON.stringify({
+      threadId: "dashboard-main-marushu-vtdd-v2-p",
+      repository: "marushu/vtdd-v2-p",
+      issueNumber: 450,
+      status: "completed",
+      message: "VPS Codex CLI からの返信です。"
+    })
+  );
+
+  assert.equal(dashboardSocket.sent.length, 1);
+  const broadcast = JSON.parse(dashboardSocket.sent[0]);
+  assert.equal(broadcast.threadId, "dashboard-main-marushu-vtdd-v2-p");
+  assert.equal(broadcast.messages.length, 1);
+  assert.equal(broadcast.messages[0].role, "runner");
+  assert.equal(broadcast.messages[0].status, "replied");
+  assert.equal(broadcast.messages[0].text, "VPS Codex CLI からの返信です。");
+  assert.equal(runnerSocket.sent.length, 0);
+});
+
+test("DashboardChatRoom rejects VPS runner replies for a different thread room", async () => {
+  const store = createInMemoryDashboardChatStore();
+  const dashboardSocket = createMockSocket("dashboard", "dashboard-main-marushu-vtdd-v2-p");
+  const runnerSocket = createMockSocket("vps_runner", "dashboard-main-marushu-vtdd-v2-p");
+  const room = new DashboardChatRoom(
+    {
+      getWebSockets() {
+        return [dashboardSocket, runnerSocket];
+      }
+    },
+    { DASHBOARD_CHAT_STORE: store }
+  );
+
+  await room.webSocketMessage(
+    runnerSocket,
+    JSON.stringify({
+      threadId: "dashboard-main-other",
+      repository: "marushu/vtdd-v2-p",
+      issueNumber: 450,
+      status: "completed",
+      message: "別 thread に混ざってはいけない返信"
+    })
+  );
+
+  assert.equal(dashboardSocket.sent.length, 0);
+  assert.equal(runnerSocket.sent.length, 0);
+  assert.equal((await store.listThread("dashboard-main-marushu-vtdd-v2-p")).length, 0);
+  assert.equal((await store.listThread("dashboard-main-other")).length, 0);
+});
+
+test("DashboardChatRoom stores a visible failure when no runner socket is connected", async () => {
+  const store = createInMemoryDashboardChatStore();
+  const dashboardSocket = createMockSocket("dashboard", "dashboard-main-marushu-vtdd-v2-p");
+  const room = new DashboardChatRoom(
+    {
+      getWebSockets() {
+        return [dashboardSocket];
+      }
+    },
+    { DASHBOARD_CHAT_STORE: store }
+  );
+
+  await room.webSocketMessage(
+    dashboardSocket,
+    JSON.stringify({
+      type: "owner_message",
+      threadId: "dashboard-main-marushu-vtdd-v2-p",
+      repositoryInput: "marushu/vtdd-v2-p",
+      issueNumber: 450,
+      text: "返事ある？"
+    })
+  );
+
+  assert.equal(dashboardSocket.sent.length, 2);
+  const failureBroadcast = JSON.parse(dashboardSocket.sent[1]);
+  assert.equal(failureBroadcast.messages.length, 1);
+  assert.equal(failureBroadcast.messages[0].status, "failed");
+  assert.equal(failureBroadcast.messages[0].text.includes("WebSocket 接続されていない"), true);
+
+  const stored = await store.listThread("dashboard-main-marushu-vtdd-v2-p");
+  assert.equal(stored.length, 3);
+  assert.equal(stored[2].status, "failed");
+});
+
 test("worker redacts dashboard Butler chat sensitive material before returning and storing", async () => {
   const store = createInMemoryDashboardChatStore();
   const response = await worker.fetch(
@@ -1140,7 +1443,7 @@ test("worker ingests GitHub Actions deploy completion event and shows it on dash
   assert.equal(dashboardBody.includes("approval:must-not-persist"), false);
   assert.equal(dashboardBody.includes("secret-must-not-persist"), false);
   assert.equal(dashboardBody.includes("setInterval("), false);
-  assert.equal(dashboardBody.includes("fetch("), true);
+  assert.equal(dashboardBody.includes("fetch(threadEndpoint"), true);
 });
 
 test("worker rejects GitHub Actions deploy completion event without machine auth", async () => {

--- a/worker.js
+++ b/worker.js
@@ -55849,7 +55849,7 @@ var DashboardChatRoom = class {
   constructor(state, env) {
     this.ctx = state;
     this.env = env;
-    this.sessions = /* @__PURE__ */ new Set();
+    this.sessions = /* @__PURE__ */ new Map();
   }
   async fetch(request) {
     const url = new URL(request.url);
@@ -55869,6 +55869,11 @@ var DashboardChatRoom = class {
       });
       return json(202, { ok: true, threadId: threadId2 });
     }
+    if (request.method === "POST" && url.pathname === "/dispatch") {
+      const payload = await readJson(request);
+      const result = await this.pushVpsRunnerJob(payload);
+      return json(result.ok ? 202 : 503, result);
+    }
     if (request.headers.get("upgrade")?.toLowerCase() !== "websocket") {
       return json(426, {
         ok: false,
@@ -55883,7 +55888,8 @@ var DashboardChatRoom = class {
         reason: "WebSocketPair is not available in this runtime"
       });
     }
-    const threadId = extractDashboardChatSocketThreadId(url.pathname);
+    const isVpsRunnerSocket = url.pathname.endsWith("/dashboard/vps-runner/ws") || url.pathname === "/vps-runner/ws";
+    const threadId = isVpsRunnerSocket ? normalizeDashboardThreadId(url.searchParams.get("threadId") || url.searchParams.get("thread_id")) : extractDashboardChatSocketThreadId(url.pathname);
     if (!threadId) {
       return json(422, {
         ok: false,
@@ -55893,17 +55899,22 @@ var DashboardChatRoom = class {
     }
     const pair = new WebSocketPair();
     const [client, server] = Object.values(pair);
+    const attachment = isVpsRunnerSocket ? { role: "vps_runner", threadId } : { role: "dashboard", threadId };
     if (typeof this.ctx?.acceptWebSocket === "function") {
-      server.serializeAttachment({ threadId });
+      server.serializeAttachment(attachment);
       this.ctx.acceptWebSocket(server);
     } else {
       server.accept();
-      this.sessions.add(server);
+      this.sessions.set(server, attachment);
       server.addEventListener("close", () => this.sessions.delete(server));
       server.addEventListener("error", () => this.sessions.delete(server));
-      server.addEventListener("message", (event) => this.handleSocketMessage(server, event?.data, threadId));
+      server.addEventListener("message", (event) => this.handleSocketMessage(server, event?.data, attachment));
     }
-    await this.sendThread(server, threadId);
+    if (isVpsRunnerSocket && isSocketOpen(server)) {
+      server.send(JSON.stringify({ type: "vps_runner_connected", ok: true }));
+    } else {
+      await this.sendThread(server, threadId);
+    }
     return new Response(null, {
       status: 101,
       webSocket: client
@@ -55911,8 +55922,7 @@ var DashboardChatRoom = class {
   }
   async webSocketMessage(socket, message) {
     const attachment = typeof socket.deserializeAttachment === "function" ? socket.deserializeAttachment() : null;
-    const threadId = normalizeDashboardThreadId(attachment?.threadId);
-    this.handleSocketMessage(socket, message, threadId);
+    await this.handleSocketMessage(socket, message, attachment);
   }
   webSocketClose(socket) {
     this.sessions.delete(socket);
@@ -55920,11 +55930,150 @@ var DashboardChatRoom = class {
   webSocketError(socket) {
     this.sessions.delete(socket);
   }
-  handleSocketMessage(socket, message, threadId) {
-    const text = normalizeDashboardEventText(message).toLowerCase();
-    if (text === "ping" && isSocketOpen(socket)) {
+  async handleSocketMessage(socket, message, attachment = {}) {
+    const socketAttachment = attachment || this.sessions.get(socket) || {};
+    const threadId = normalizeDashboardThreadId(socketAttachment.threadId);
+    const text = normalizeDashboardEventText(message);
+    const lowerText = text.toLowerCase();
+    if (lowerText === "ping" && isSocketOpen(socket)) {
       socket.send(JSON.stringify({ type: "pong", ok: true, threadId }));
+      return;
     }
+    let payload = null;
+    try {
+      payload = text ? JSON.parse(text) : null;
+    } catch {
+      payload = null;
+    }
+    if (socketAttachment.role === "vps_runner") {
+      await this.acceptVpsRunnerReply(payload, socketAttachment);
+      return;
+    }
+    if (payload?.type === "owner_message") {
+      await this.acceptOwnerMessage({ socket, threadId, payload });
+    }
+  }
+  async acceptOwnerMessage({ socket, threadId, payload }) {
+    const text = sanitizeDashboardChatText(payload?.text || payload?.message || payload?.body);
+    if (!threadId || !text) {
+      if (isSocketOpen(socket)) {
+        socket.send(JSON.stringify({ type: "error", ok: false, reason: "message text is required" }));
+      }
+      return;
+    }
+    const repository = normalizeCanonicalRepositoryInput(payload?.repository || payload?.repositoryInput);
+    const relatedIssue = normalizePositiveInteger9(payload?.relatedIssue || payload?.issueNumber);
+    const now = (/* @__PURE__ */ new Date()).toISOString();
+    const ownerMessage = normalizeDashboardChatMessage(
+      {
+        threadId,
+        role: "owner",
+        repository,
+        relatedIssue,
+        status: "sent",
+        text,
+        createdAt: now
+      },
+      { threadId }
+    );
+    const thinkingMessage = normalizeDashboardChatMessage(
+      {
+        threadId,
+        role: "system",
+        repository,
+        relatedIssue,
+        status: "thinking",
+        text: "VPS Codex CLI \u306B\u9001\u4FE1\u3057\u307E\u3057\u305F\u3002\u8FD4\u4FE1\u3092\u5F85\u3063\u3066\u3044\u307E\u3059\u3002",
+        createdAt: new Date(Date.parse(now) + 1).toISOString()
+      },
+      { threadId }
+    );
+    const store = resolveDashboardChatStore(this.env);
+    const messages = store ? await store.appendMany(threadId, [ownerMessage, thinkingMessage]) : [ownerMessage, thinkingMessage].filter(Boolean);
+    await this.broadcastThread({ threadId, messages });
+    const pushed = await this.pushVpsRunnerJob({
+      type: "dashboard_chat_job",
+      threadId,
+      repository,
+      relatedIssue,
+      text,
+      codexGoal: normalizeDashboardEventText(payload?.codexGoal || "dashboard_chat_triage"),
+      createdAt: now
+    });
+    if (!pushed.ok) {
+      const failedMessage = normalizeDashboardChatMessage(
+        {
+          threadId,
+          role: "system",
+          repository,
+          relatedIssue,
+          status: "failed",
+          text: "VPS Codex CLI \u304C WebSocket \u63A5\u7D9A\u3055\u308C\u3066\u3044\u306A\u3044\u305F\u3081\u9001\u4FE1\u3067\u304D\u307E\u305B\u3093\u3067\u3057\u305F\u3002runner \u63A5\u7D9A\u3092\u78BA\u8A8D\u3057\u3066\u304F\u3060\u3055\u3044\u3002",
+          createdAt: new Date(Date.parse(now) + 2).toISOString()
+        },
+        { threadId }
+      );
+      const failedMessages = store ? await store.appendMany(threadId, [failedMessage]) : [failedMessage].filter(Boolean);
+      await this.broadcastThread({ threadId, messages: failedMessages });
+    }
+  }
+  async acceptVpsRunnerReply(payload, socketAttachment = {}) {
+    const socketThreadId = normalizeDashboardThreadId(socketAttachment.threadId);
+    const threadId = normalizeDashboardThreadId(payload?.threadId || payload?.thread_id || socketThreadId);
+    if (!threadId) {
+      return;
+    }
+    if (socketThreadId && threadId !== socketThreadId) {
+      return;
+    }
+    const message = normalizeDashboardChatMessage(
+      {
+        threadId,
+        role: "runner",
+        repository: payload?.repository,
+        relatedIssue: payload?.relatedIssue || payload?.issueNumber,
+        status: payload?.status === "failed" ? "failed" : "replied",
+        text: payload?.text || payload?.message || payload?.body,
+        createdAt: payload?.createdAt || payload?.updatedAt
+      },
+      { threadId }
+    );
+    const store = resolveDashboardChatStore(this.env);
+    const messages = store ? await store.appendMany(threadId, [message]) : [message].filter(Boolean);
+    await this.broadcastThread({ threadId, messages });
+  }
+  async pushVpsRunnerJob(payload) {
+    const job = {
+      type: "dashboard_chat_job",
+      jobId: normalizeDashboardEventText(payload?.jobId) || crypto.randomUUID(),
+      threadId: normalizeDashboardThreadId(payload?.threadId || payload?.thread_id),
+      repository: normalizeCanonicalRepositoryInput(payload?.repository),
+      relatedIssue: normalizePositiveInteger9(payload?.relatedIssue || payload?.issueNumber),
+      text: sanitizeDashboardChatText(payload?.text || payload?.message || payload?.body),
+      codexGoal: normalizeDashboardEventText(payload?.codexGoal || "dashboard_chat_triage"),
+      createdAt: normalizeIsoTimestamp(payload?.createdAt) || (/* @__PURE__ */ new Date()).toISOString()
+    };
+    const runners = this.connectedSockets().filter((socket) => this.getSocketAttachment(socket).role === "vps_runner");
+    if (runners.length === 0) {
+      return {
+        ok: false,
+        error: "vps_runner_not_connected",
+        reason: "VPS Codex CLI WebSocket is not connected"
+      };
+    }
+    const frame = JSON.stringify(job);
+    let pushed = 0;
+    for (const runner of runners) {
+      if (isSocketOpen(runner)) {
+        runner.send(frame);
+        pushed += 1;
+      }
+    }
+    return {
+      ok: pushed > 0,
+      pushed,
+      jobId: job.jobId
+    };
   }
   async broadcastThread({ threadId, messages = null }) {
     const resolvedMessages = Array.isArray(messages) ? messages : await this.listThreadMessages(threadId);
@@ -55935,7 +56084,8 @@ var DashboardChatRoom = class {
       messages: resolvedMessages
     });
     for (const socket of this.connectedSockets()) {
-      if (isSocketOpen(socket)) {
+      const attachment = this.getSocketAttachment(socket);
+      if (attachment.role !== "vps_runner" && (!attachment.threadId || attachment.threadId === threadId) && isSocketOpen(socket)) {
         socket.send(payload);
       }
     }
@@ -55974,7 +56124,13 @@ var DashboardChatRoom = class {
     if (typeof this.ctx?.getWebSockets === "function") {
       return this.ctx.getWebSockets();
     }
-    return Array.from(this.sessions);
+    return Array.from(this.sessions.keys());
+  }
+  getSocketAttachment(socket) {
+    if (typeof socket?.deserializeAttachment === "function") {
+      return socket.deserializeAttachment() || {};
+    }
+    return this.sessions.get(socket) || {};
   }
 };
 var CLOUDFLARE_ACCESS_JWKS_CACHE_TTL_MS = 5 * 60 * 1e3;
@@ -56075,6 +56231,15 @@ var runtime_default = {
     }
     if (request.method === "GET" && isDashboardChatSocketApiPath(url.pathname)) {
       return handleDashboardChatSocketRequest(request, url, env);
+    }
+    if (request.method === "GET" && isApiPath(url.pathname, "/dashboard/vps-runner/ws")) {
+      return handleDashboardVpsRunnerSocketRequest(request, env);
+    }
+    if (request.method === "GET" && isApiPath(url.pathname, "/dashboard/chat/search")) {
+      return handleDashboardChatSearchRequest(request, url, env);
+    }
+    if ((request.method === "GET" || request.method === "POST") && isDashboardChatSummaryApiPath(url.pathname)) {
+      return handleDashboardChatSummaryRequest(request, url, env);
     }
     if (request.method === "GET" && isDashboardChatThreadApiPath(url.pathname)) {
       return handleDashboardChatThreadRequest(request, url, env);
@@ -58710,7 +58875,12 @@ async function handleDashboardChatMessageRequest(request, env) {
   let execution = null;
   let messagesToStore = prepared.messages;
   if (wantsVpsRunnerHandoff) {
-    const handoffPayload = buildDashboardVpsRunnerHandoffPayload({ payload, prepared, env });
+    const handoffPayload = buildDashboardVpsRunnerHandoffPayload({
+      payload,
+      prepared,
+      env,
+      runtimeUrl: new URL(request.url).origin
+    });
     if (!handoffPayload.ok) {
       return json(422, {
         ok: false,
@@ -58785,6 +58955,45 @@ async function handleDashboardChatSocketRequest(request, url, env) {
   }
   return room.fetch(request);
 }
+async function handleDashboardVpsRunnerSocketRequest(request, env) {
+  const auth = authorizeGatewayRequest({
+    request,
+    env,
+    apiSuffix: "/dashboard/vps-runner/ws"
+  });
+  if (!auth.ok) {
+    return json(auth.status, {
+      ok: false,
+      error: "unauthorized",
+      reason: auth.reason
+    });
+  }
+  const url = new URL(request.url);
+  const threadId = normalizeDashboardThreadId(url.searchParams.get("threadId") || url.searchParams.get("thread_id"));
+  if (!threadId) {
+    return json(422, {
+      ok: false,
+      error: "thread_id_required",
+      reason: "threadId is required for VPS Codex CLI dashboard WebSocket"
+    });
+  }
+  const room = resolveDashboardChatRoomStub(env, threadId);
+  if (!room) {
+    return json(503, {
+      ok: false,
+      error: "dashboard_vps_runner_room_unavailable",
+      reason: "DASHBOARD_CHAT_ROOMS Durable Object binding is not configured"
+    });
+  }
+  if (request.headers.get("upgrade")?.toLowerCase() !== "websocket") {
+    return json(426, {
+      ok: false,
+      error: "websocket_upgrade_required",
+      reason: "VPS Codex CLI push channel requires a WebSocket upgrade"
+    });
+  }
+  return room.fetch(request);
+}
 async function handleDashboardChatThreadRequest(request, url, env) {
   const auth = await authorizeDashboardRequest({
     request,
@@ -58817,10 +59026,103 @@ async function handleDashboardChatThreadRequest(request, url, env) {
   const messages = await store.listThread(threadId, {
     limit: normalizeLimit7(url.searchParams.get("limit"), 80)
   });
+  const summary = typeof store.getSummary === "function" ? await store.getSummary(threadId) : null;
   return json(200, {
     ok: true,
     threadId,
-    messages
+    messages,
+    summary
+  });
+}
+async function handleDashboardChatSearchRequest(request, url, env) {
+  const auth = await authorizeDashboardRequest({
+    request,
+    env,
+    apiSuffix: "/dashboard/chat/search"
+  });
+  if (!auth.ok) {
+    return json(auth.status, {
+      ok: false,
+      error: "dashboard_auth_required",
+      reason: auth.reason
+    });
+  }
+  const store = resolveDashboardChatStore(env);
+  if (!store || typeof store.search !== "function") {
+    return json(503, {
+      ok: false,
+      error: "dashboard_chat_search_unavailable",
+      reason: "dashboard Butler chat search store is not configured"
+    });
+  }
+  const results = await store.search({
+    text: url.searchParams.get("text") || url.searchParams.get("q"),
+    repository: url.searchParams.get("repository"),
+    relatedIssue: url.searchParams.get("relatedIssue") || url.searchParams.get("issueNumber"),
+    limit: normalizeLimit7(url.searchParams.get("limit"), 20)
+  });
+  return json(200, {
+    ok: true,
+    results
+  });
+}
+async function handleDashboardChatSummaryRequest(request, url, env) {
+  const auth = await authorizeDashboardRequest({
+    request,
+    env,
+    apiSuffix: "/dashboard/chat/:threadId/summary"
+  });
+  if (!auth.ok) {
+    return json(auth.status, {
+      ok: false,
+      error: "dashboard_auth_required",
+      reason: auth.reason
+    });
+  }
+  const threadId = extractDashboardChatSummaryThreadId(url.pathname);
+  if (!threadId) {
+    return json(422, {
+      ok: false,
+      error: "thread_id_required",
+      reason: "threadId is required"
+    });
+  }
+  const store = resolveDashboardChatStore(env);
+  if (!store) {
+    return json(503, {
+      ok: false,
+      error: "dashboard_chat_store_unavailable",
+      reason: "dashboard Butler chat store is not configured"
+    });
+  }
+  if (request.method === "GET") {
+    const summary2 = typeof store.getSummary === "function" ? await store.getSummary(threadId) : null;
+    return json(200, {
+      ok: true,
+      threadId,
+      summary: summary2
+    });
+  }
+  if (typeof store.putSummary !== "function") {
+    return json(503, {
+      ok: false,
+      error: "dashboard_chat_summary_unavailable",
+      reason: "dashboard Butler chat summary store is not configured"
+    });
+  }
+  const payload = await readJson(request);
+  const summary = await store.putSummary(threadId, payload);
+  if (!summary) {
+    return json(422, {
+      ok: false,
+      error: "summary_required",
+      reason: "summary text is required"
+    });
+  }
+  return json(200, {
+    ok: true,
+    threadId,
+    summary
   });
 }
 async function handleGitHubActionsSecretSyncRequest(request, env) {
@@ -60370,6 +60672,113 @@ function createD1DashboardChatStore(d1) {
           return null;
         }
       }).filter(Boolean).reverse();
+    },
+    async putSummary(threadId, summary) {
+      const normalized = normalizeDashboardThreadSummary(summary, { threadId });
+      if (!normalized) {
+        return null;
+      }
+      await ensureSchema();
+      await d1.prepare(
+        `INSERT OR REPLACE INTO vtdd_dashboard_thread_summaries (
+             thread_id, repository, related_issue, summary, decisions_json,
+             open_items_json, archived_until_message_id, updated_at, payload_json
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      ).bind(
+        normalized.threadId,
+        normalized.repository,
+        normalized.relatedIssue,
+        normalized.summary,
+        JSON.stringify(normalized.decisions),
+        JSON.stringify(normalized.openItems),
+        normalized.archivedUntilMessageId,
+        normalized.updatedAt,
+        JSON.stringify(normalized)
+      ).run();
+      return normalized;
+    },
+    async getSummary(threadId) {
+      const resolvedThreadId = normalizeDashboardThreadId(threadId);
+      if (!resolvedThreadId) {
+        return null;
+      }
+      await ensureSchema();
+      const result = await d1.prepare("SELECT payload_json FROM vtdd_dashboard_thread_summaries WHERE thread_id = ? LIMIT 1").bind(resolvedThreadId).all();
+      const row = Array.isArray(result?.results) ? result.results[0] : null;
+      try {
+        return row?.payload_json ? normalizeDashboardThreadSummary(JSON.parse(row.payload_json), { threadId: resolvedThreadId }) : null;
+      } catch {
+        return null;
+      }
+    },
+    async search(filter = {}) {
+      await ensureSchema();
+      const text = sanitizeDashboardChatText(filter.text || filter.q);
+      const repository = normalizeCanonicalRepositoryInput(filter.repository);
+      const relatedIssue = normalizePositiveInteger9(filter.relatedIssue || filter.issueNumber);
+      const limit = normalizeLimit7(filter.limit, 20);
+      const results = [];
+      const messageClauses = [];
+      const messageParams = [];
+      if (text) {
+        messageClauses.push("text LIKE ?");
+        messageParams.push(`%${text}%`);
+      }
+      if (repository) {
+        messageClauses.push("repository = ?");
+        messageParams.push(repository);
+      }
+      if (relatedIssue) {
+        messageClauses.push("related_issue = ?");
+        messageParams.push(relatedIssue);
+      }
+      const messageWhere = messageClauses.length > 0 ? `WHERE ${messageClauses.join(" AND ")}` : "";
+      const messageRows = await d1.prepare(
+        `SELECT payload_json FROM vtdd_dashboard_chat_messages
+           ${messageWhere}
+           ORDER BY created_at DESC, message_id DESC
+           LIMIT ?`
+      ).bind(...messageParams, limit).all();
+      for (const row of Array.isArray(messageRows?.results) ? messageRows.results : []) {
+        try {
+          const message = row?.payload_json ? normalizeDashboardChatMessage(JSON.parse(row.payload_json)) : null;
+          if (message) {
+            results.push({ kind: "message", threadId: message.threadId, message });
+          }
+        } catch {
+        }
+      }
+      const summaryClauses = [];
+      const summaryParams = [];
+      if (text) {
+        summaryClauses.push("(summary LIKE ? OR decisions_json LIKE ? OR open_items_json LIKE ?)");
+        summaryParams.push(`%${text}%`, `%${text}%`, `%${text}%`);
+      }
+      if (repository) {
+        summaryClauses.push("repository = ?");
+        summaryParams.push(repository);
+      }
+      if (relatedIssue) {
+        summaryClauses.push("related_issue = ?");
+        summaryParams.push(relatedIssue);
+      }
+      const summaryWhere = summaryClauses.length > 0 ? `WHERE ${summaryClauses.join(" AND ")}` : "";
+      const summaryRows = await d1.prepare(
+        `SELECT payload_json FROM vtdd_dashboard_thread_summaries
+           ${summaryWhere}
+           ORDER BY updated_at DESC
+           LIMIT ?`
+      ).bind(...summaryParams, limit).all();
+      for (const row of Array.isArray(summaryRows?.results) ? summaryRows.results : []) {
+        try {
+          const summary = row?.payload_json ? normalizeDashboardThreadSummary(JSON.parse(row.payload_json)) : null;
+          if (summary) {
+            results.push({ kind: "summary", threadId: summary.threadId, summary });
+          }
+        } catch {
+        }
+      }
+      return results.slice(0, limit);
     }
   };
   function ensureSchema() {
@@ -60380,6 +60789,15 @@ function createD1DashboardChatStore(d1) {
         );
         await d1.exec(
           "CREATE INDEX IF NOT EXISTS idx_vtdd_dashboard_chat_messages_thread ON vtdd_dashboard_chat_messages (thread_id, created_at DESC);"
+        );
+        await d1.exec(
+          "CREATE INDEX IF NOT EXISTS idx_vtdd_dashboard_chat_messages_lookup ON vtdd_dashboard_chat_messages (repository, related_issue, created_at DESC);"
+        );
+        await d1.exec(
+          "CREATE TABLE IF NOT EXISTS vtdd_dashboard_thread_summaries (thread_id TEXT PRIMARY KEY, repository TEXT, related_issue INTEGER, summary TEXT NOT NULL, decisions_json TEXT NOT NULL, open_items_json TEXT NOT NULL, archived_until_message_id TEXT, updated_at TEXT NOT NULL, payload_json TEXT NOT NULL);"
+        );
+        await d1.exec(
+          "CREATE INDEX IF NOT EXISTS idx_vtdd_dashboard_thread_summaries_lookup ON vtdd_dashboard_thread_summaries (repository, related_issue, updated_at DESC);"
         );
       })();
     }
@@ -60532,7 +60950,7 @@ function shouldDispatchDashboardChatToVpsRunner(payload) {
   const input = normalizeObject11(payload);
   return input.dispatchToVpsRunner === true || input.vpsRunnerHandoff === true || normalizeDashboardEventText(input.executorTransport).toLowerCase() === "vps_runner";
 }
-function buildDashboardVpsRunnerHandoffPayload({ payload, prepared, env }) {
+function buildDashboardVpsRunnerHandoffPayload({ payload, prepared, env, runtimeUrl }) {
   const input = normalizeObject11(payload);
   const issueNumber = normalizePositiveInteger9(input.issueNumber || input.relatedIssue) || prepared.relatedIssue || normalizePositiveInteger9(env?.VTDD_DASHBOARD_CHAT_TRIAGE_ISSUE_NUMBER);
   if (!issueNumber) {
@@ -60566,7 +60984,8 @@ function buildDashboardVpsRunnerHandoffPayload({ payload, prepared, env }) {
           repositoryInput: normalizeDashboardRepositoryInput(
             input.repositoryInput || input.repository_input || input.repository || prepared.repository
           ),
-          dashboardThreadId: prepared.threadId
+          dashboardThreadId: prepared.threadId,
+          dashboardRuntimeUrl: normalizeDashboardEventText(input.dashboardRuntimeUrl || runtimeUrl)
         }
       },
       executionTarget: {
@@ -60640,6 +61059,37 @@ function normalizeDashboardChatMessage(message, defaults = {}) {
     createdAt
   };
 }
+function normalizeDashboardThreadSummary(summary, defaults = {}) {
+  const input = normalizeObject11(summary);
+  const threadId = normalizeDashboardThreadId(input.threadId || input.thread_id || defaults.threadId);
+  if (!threadId) {
+    return null;
+  }
+  const summaryText = sanitizeDashboardChatText(input.summary || input.text || input.body);
+  if (!summaryText) {
+    return null;
+  }
+  const decisions = normalizeStringList(input.decisions || input.decisionLog || input.decision_log);
+  const openItems = normalizeStringList(input.openItems || input.open_items || input.todo || input.todos);
+  return {
+    threadId,
+    repository: normalizeCanonicalRepositoryInput(input.repository || defaults.repository) || null,
+    relatedIssue: normalizePositiveInteger9(
+      input.relatedIssue || input.issueNumber || input.related_issue || defaults.relatedIssue
+    ),
+    summary: summaryText,
+    decisions,
+    openItems,
+    archivedUntilMessageId: normalizeDashboardEventText(
+      input.archivedUntilMessageId || input.archived_until_message_id || defaults.archivedUntilMessageId
+    ) || null,
+    updatedAt: normalizeIsoTimestamp(input.updatedAt || input.updated_at || defaults.updatedAt) || (/* @__PURE__ */ new Date()).toISOString()
+  };
+}
+function normalizeStringList(value) {
+  const list = Array.isArray(value) ? value : value ? [value] : [];
+  return list.map((item) => sanitizeDashboardChatText(item)).filter(Boolean).slice(0, 40);
+}
 function normalizeDashboardChatRole(value) {
   const role = normalizeDashboardEventText(value).toLowerCase();
   return ["owner", "butler", "runner", "system"].includes(role) ? role : "system";
@@ -60657,7 +61107,7 @@ function sanitizeDashboardChatText(value) {
   return text.slice(0, 4e3);
 }
 function isDashboardChatThreadApiPath(pathname) {
-  return pathname.startsWith(`${CANONICAL_API_PREFIX}/dashboard/chat/`) || pathname.startsWith(`${LEGACY_API_PREFIX}/dashboard/chat/`);
+  return (pathname.startsWith(`${CANONICAL_API_PREFIX}/dashboard/chat/`) || pathname.startsWith(`${LEGACY_API_PREFIX}/dashboard/chat/`)) && !pathname.endsWith("/summary");
 }
 function isDashboardChatSocketApiPath(pathname) {
   return (pathname.startsWith(`${CANONICAL_API_PREFIX}/dashboard/chat/`) || pathname.startsWith(`${LEGACY_API_PREFIX}/dashboard/chat/`)) && pathname.endsWith("/ws");
@@ -60678,6 +61128,12 @@ function extractDashboardChatThreadId(pathname) {
 }
 function extractDashboardChatSocketThreadId(pathname) {
   return extractDashboardChatThreadId(pathname.replace(/\/ws$/, ""));
+}
+function isDashboardChatSummaryApiPath(pathname) {
+  return (pathname.startsWith(`${CANONICAL_API_PREFIX}/dashboard/chat/`) || pathname.startsWith(`${LEGACY_API_PREFIX}/dashboard/chat/`)) && pathname.endsWith("/summary");
+}
+function extractDashboardChatSummaryThreadId(pathname) {
+  return extractDashboardChatThreadId(pathname.replace(/\/summary$/, ""));
 }
 function normalizeDashboardEventRecord(event) {
   const input = normalizeObject11(event);
@@ -62562,18 +63018,18 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         <article class="bubble">
           <strong>Butler</strong>
           <p>\u305D\u306E\u65B9\u91DD\u3067\u9032\u3081\u307E\u3059\u3002\u4E2D\u592E\u306F\u30C1\u30E3\u30C3\u30C8\u3060\u3051\u3001\u72B6\u614B\u78BA\u8A8D\u30FB\u9032\u6357\u30FBRAG\u30FBworkflow\u30FBprototype cleanup \u306E\u6271\u3044\u306F\u30B5\u30A4\u30C9\u30D0\u30FC\u306E\u30E1\u30CB\u30E5\u30FC\u304B\u3089\u5FC5\u8981\u306A\u6642\u3060\u3051\u958B\u304D\u307E\u3059\u3002</p>
-          <p>\u3053\u306E dashboard \u304B\u3089\u306E\u9001\u4FE1\u306F VPS Codex CLI \u306E dashboard chat triage queue \u306B\u6E21\u3057\u307E\u3059\u3002\u8FD4\u4FE1\u3068\u3057\u3066\u8868\u793A\u3059\u308B\u306E\u306F runner \u304B\u3089\u623B\u3063\u305F event post \u3060\u3051\u3067\u3059\u3002</p>
-          <span class="connection-note">\u63A5\u7D9A\u6E08\u307F: WebSocket \u3067 runner event post \u3092\u5F85\u3061\u307E\u3059</span>
+          <p>\u3053\u306E dashboard \u304B\u3089\u306E\u9001\u4FE1\u306F WebSocket \u3067 VPS Codex CLI \u306B\u76F4\u63A5 push \u3057\u307E\u3059\u3002GitHub Issue \u30B3\u30E1\u30F3\u30C8 queue \u306F\u901A\u5E38\u4F1A\u8A71\u3067\u306F\u4F7F\u3044\u307E\u305B\u3093\u3002</p>
+          <span class="connection-note">\u63A5\u7D9A\u6E96\u5099\u4E2D: WebSocket \u3067 Butler \u3068 VPS Codex CLI \u306B\u63A5\u7D9A\u3057\u307E\u3059</span>
         </article>
 
       </div>
 
-      <form class="composer" id="butler-chat-form" aria-label="Butler composer" data-endpoint="${escapeDashboardHtml(origin)}/v2/dashboard/chat/messages" data-thread-endpoint="${escapeDashboardHtml(origin)}/v2/dashboard/chat/${escapeDashboardHtml(chatThreadId)}" data-socket-endpoint="${escapeDashboardHtml(socketOrigin)}/v2/dashboard/chat/${escapeDashboardHtml(chatThreadId)}/ws" data-thread-id="${escapeDashboardHtml(chatThreadId)}" data-repository-input="${escapeDashboardHtml(repositoryInput)}" data-issue-number="${dashboardIssueNumber || ""}" data-dispatch-to-vps-runner="true" data-codex-goal="dashboard_chat_triage">
+      <form class="composer" id="butler-chat-form" aria-label="Butler composer" data-socket-endpoint="${escapeDashboardHtml(socketOrigin)}/v2/dashboard/chat/${escapeDashboardHtml(chatThreadId)}/ws" data-thread-endpoint="${escapeDashboardHtml(origin)}/v2/dashboard/chat/${escapeDashboardHtml(chatThreadId)}" data-thread-id="${escapeDashboardHtml(chatThreadId)}" data-repository-input="${escapeDashboardHtml(repositoryInput)}" data-issue-number="${dashboardIssueNumber || ""}" data-dispatch-to-vps-runner="true" data-codex-goal="dashboard_chat_triage">
         <div class="composer-box">
           <textarea id="butler-message" name="text" placeholder="Butler V2 \u306B\u30E1\u30C3\u30BB\u30FC\u30B8..." aria-label="Butler V2 \u306B\u30E1\u30C3\u30BB\u30FC\u30B8"></textarea>
           <button class="send-button" type="submit" aria-label="Butler \u306B\u9001\u4FE1">\u2191</button>
         </div>
-        <div class="composer-status" id="butler-chat-status">\u63A5\u7D9A\u6E08\u307F\u3002\u9001\u4FE1\u3059\u308B\u3068 VPS Codex CLI queue \u306B\u6E21\u3057\u307E\u3059\u3002\u8FD4\u4FE1\u306F runner event post \u3060\u3051\u3092\u8868\u793A\u3057\u307E\u3059\u3002</div>
+        <div class="composer-status" id="butler-chat-status">\u63A5\u7D9A\u6E96\u5099\u4E2D\u3067\u3059\u3002WebSocket \u63A5\u7D9A\u5F8C\u306B\u9001\u4FE1\u3067\u304D\u307E\u3059\u3002</div>
       </form>
     </section>
 
@@ -62637,15 +63093,18 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
       const status = document.getElementById("butler-chat-status");
       if (!form || !log || !textarea || !status) return;
 
-      const endpoint = form.dataset.endpoint;
-      const threadEndpoint = form.dataset.threadEndpoint;
       const socketEndpoint = form.dataset.socketEndpoint;
+      const threadEndpoint = form.dataset.threadEndpoint;
       const threadId = form.dataset.threadId;
       const repositoryInput = form.dataset.repositoryInput;
       const issueNumber = Number.parseInt(form.dataset.issueNumber || "", 10);
       const dispatchToVpsRunner = form.dataset.dispatchToVpsRunner === "true";
       const codexGoal = form.dataset.codexGoal || "dashboard_chat_triage";
       const initialMarkup = log.innerHTML;
+      let chatSocket = null;
+      let reconnectTimer = null;
+      let reconnectAttempt = 0;
+      let refreshingThread = false;
 
       function updateComposerReserve() {
         log.style.setProperty("--composer-reserve", Math.ceil(form.getBoundingClientRect().height) + "px");
@@ -62705,27 +63164,6 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         appendMessage({ role: "butler", text });
       }
 
-      function showThinking() {
-        const article = document.createElement("article");
-        article.className = "bubble thinking";
-        article.dataset.pending = "butler";
-        const paragraph = document.createElement("p");
-        const span = document.createElement("span");
-        span.className = "thinking-dots";
-        span.textContent = "\u8003\u3048\u3066\u3044\u307E\u3059";
-        paragraph.appendChild(span);
-        article.appendChild(paragraph);
-        log.appendChild(article);
-        scrollToLatest();
-        return article;
-      }
-
-      function removeThinking(article) {
-        if (article && article.parentNode) {
-          article.parentNode.removeChild(article);
-        }
-      }
-
       function renderThread(messages) {
         if (!Array.isArray(messages) || messages.length === 0) {
           log.innerHTML = initialMarkup;
@@ -62739,48 +63177,79 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         scrollToLatest();
       }
 
-      function connectThreadSocket() {
-        if (!socketEndpoint || typeof WebSocket !== "function") {
-          setStatus("WebSocket \u3092\u958B\u59CB\u3067\u304D\u307E\u305B\u3093\u3002runner \u8FD4\u4FE1\u306F\u518D\u8AAD\u307F\u8FBC\u307F\u3067\u78BA\u8A8D\u3057\u3066\u304F\u3060\u3055\u3044\u3002");
-          return;
-        }
-        const socket = new WebSocket(socketEndpoint);
-        socket.addEventListener("open", () => {
-          setStatus("WebSocket \u63A5\u7D9A\u6E08\u307F\u3002VPS Codex CLI \u306E runner event post \u3092\u5F85\u3063\u3066\u3044\u307E\u3059\u3002");
-        });
-        socket.addEventListener("message", (event) => {
-          const body = JSON.parse(event.data || "{}");
-          if (body.type === "thread" && body.ok) {
-            renderThread(body.messages || []);
-          }
-        });
-        socket.addEventListener("close", () => {
-          setStatus("WebSocket \u304C\u5207\u308C\u307E\u3057\u305F\u3002\u518D\u8AAD\u307F\u8FBC\u307F\u3059\u308B\u3068\u6700\u65B0 thread \u3092\u78BA\u8A8D\u3067\u304D\u307E\u3059\u3002");
-        });
-        socket.addEventListener("error", () => {
-          setStatus("WebSocket \u63A5\u7D9A\u306B\u5931\u6557\u3057\u307E\u3057\u305F\u3002\u518D\u8AAD\u307F\u8FBC\u307F\u3059\u308B\u3068\u6700\u65B0 thread \u3092\u78BA\u8A8D\u3067\u304D\u307E\u3059\u3002");
-        });
-      }
-
       async function refreshThread() {
-        if (!threadEndpoint) return;
-        setStatus("\u4F1A\u8A71\u5C65\u6B74\u3092\u8AAD\u307F\u8FBC\u307F\u4E2D\u3067\u3059\u3002");
+        if (!threadEndpoint || refreshingThread) return;
+        refreshingThread = true;
         try {
           const response = await fetch(threadEndpoint, {
-            method: "GET",
             headers: { "accept": "application/json" },
             credentials: "same-origin"
           });
-          const body = await response.json().catch(() => ({}));
-          if (!response.ok || !body.ok) {
-            setStatus(body.reason || "\u4F1A\u8A71\u5C65\u6B74\u3092\u8AAD\u3081\u307E\u305B\u3093\u3067\u3057\u305F\u3002\u9001\u4FE1\u6642\u306B\u518D\u8A66\u884C\u3057\u307E\u3059\u3002");
+          if (!response.ok) {
+            setStatus("\u5C65\u6B74\u306E\u518D\u53D6\u5F97\u306B\u5931\u6557\u3057\u307E\u3057\u305F\u3002WebSocket \u3092\u518D\u63A5\u7D9A\u3057\u3066\u3044\u307E\u3059\u3002");
             return;
           }
-          renderThread(body.messages || []);
-          setStatus("\u63A5\u7D9A\u6E08\u307F\u3002\u9001\u4FE1\u3059\u308B\u3068 VPS Codex CLI queue \u306B\u6E21\u3057\u307E\u3059\u3002\u8FD4\u4FE1\u306F runner event post \u3060\u3051\u3092\u8868\u793A\u3057\u307E\u3059\u3002");
+          const body = await response.json();
+          if (body && body.ok) {
+            renderThread(body.messages || []);
+          }
         } catch {
-          setStatus("\u4F1A\u8A71\u5C65\u6B74\u3092\u8AAD\u3081\u307E\u305B\u3093\u3067\u3057\u305F\u3002\u9001\u4FE1\u6642\u306B\u518D\u8A66\u884C\u3057\u307E\u3059\u3002");
+          setStatus("\u5C65\u6B74\u306E\u518D\u53D6\u5F97\u306B\u5931\u6557\u3057\u307E\u3057\u305F\u3002WebSocket \u3092\u518D\u63A5\u7D9A\u3057\u3066\u3044\u307E\u3059\u3002");
+        } finally {
+          refreshingThread = false;
         }
+      }
+
+      function scheduleReconnect() {
+        if (reconnectTimer || !socketEndpoint || typeof WebSocket !== "function") return;
+        const delay = Math.min(10000, 1000 * Math.pow(2, reconnectAttempt));
+        reconnectAttempt += 1;
+        reconnectTimer = window.setTimeout(() => {
+          reconnectTimer = null;
+          connectThreadSocket();
+        }, delay);
+      }
+
+      function connectThreadSocket() {
+        if (!socketEndpoint || typeof WebSocket !== "function") {
+          setStatus("WebSocket \u3092\u958B\u59CB\u3067\u304D\u307E\u305B\u3093\u3002dashboard Butler \u306F\u9001\u4FE1\u3067\u304D\u307E\u305B\u3093\u3002");
+          return;
+        }
+        if (chatSocket && (chatSocket.readyState === WebSocket.OPEN || chatSocket.readyState === WebSocket.CONNECTING)) {
+          return;
+        }
+        chatSocket = new WebSocket(socketEndpoint);
+        chatSocket.addEventListener("open", () => {
+          reconnectAttempt = 0;
+          if (reconnectTimer) {
+            window.clearTimeout(reconnectTimer);
+            reconnectTimer = null;
+          }
+          setStatus("WebSocket \u63A5\u7D9A\u6E08\u307F\u3002\u9001\u4FE1\u3059\u308B\u3068 VPS Codex CLI \u306B push \u3057\u307E\u3059\u3002");
+          refreshThread();
+        });
+        chatSocket.addEventListener("message", (event) => {
+          try {
+            const body = JSON.parse(event.data || "{}");
+            if (body.type === "thread" && body.ok) {
+              renderThread(body.messages || []);
+            } else if (body.type === "error") {
+              appendError(body.reason || "WebSocket message error");
+            }
+          } catch {
+            appendError("WebSocket message \u3092\u8AAD\u307F\u53D6\u308C\u307E\u305B\u3093\u3067\u3057\u305F\u3002");
+          }
+        });
+        chatSocket.addEventListener("close", () => {
+          setStatus("WebSocket \u304C\u5207\u308C\u307E\u3057\u305F\u3002\u5C65\u6B74\u3092\u518D\u53D6\u5F97\u3057\u3066\u518D\u63A5\u7D9A\u3057\u307E\u3059\u3002");
+          refreshThread();
+          scheduleReconnect();
+        });
+        chatSocket.addEventListener("error", () => {
+          setStatus("WebSocket \u63A5\u7D9A\u306B\u5931\u6557\u3057\u307E\u3057\u305F\u3002\u5C65\u6B74\u3092\u518D\u53D6\u5F97\u3057\u3066\u518D\u63A5\u7D9A\u3057\u307E\u3059\u3002");
+          refreshThread();
+          scheduleReconnect();
+        });
       }
 
       form.addEventListener("submit", async (event) => {
@@ -62791,52 +63260,47 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           return;
         }
         const submitButton = form.querySelector("button[type='submit']");
-        if (submitButton) submitButton.disabled = true;
-        setStatus("\u9001\u4FE1\u4E2D\u3067\u3059\u3002VPS Codex CLI queue \u306B\u6E21\u3057\u307E\u3059\u3002");
-        const thinking = showThinking();
-        try {
-          const response = await fetch(endpoint, {
-            method: "POST",
-            headers: { "content-type": "application/json", "accept": "application/json" },
-            credentials: "same-origin",
-            body: JSON.stringify({
-              threadId,
-              repositoryInput,
-              text,
-              issueNumber,
-              relatedIssue: issueNumber,
-              dispatchToVpsRunner,
-              executorTransport: dispatchToVpsRunner ? "vps_runner" : undefined,
-              codexGoal,
-              handoffSummary: "Dashboard Butler chat message from owner"
-            })
-          });
-          const body = await response.json().catch(() => ({}));
-          removeThinking(thinking);
-          if (!response.ok || !body.ok) {
-            appendError(body.reason || "\u9001\u4FE1\u306B\u5931\u6557\u3057\u307E\u3057\u305F\u3002runtime truth \u3092\u78BA\u8A8D\u3057\u3066\u304F\u3060\u3055\u3044\u3002");
-            setStatus("\u9001\u4FE1\u306B\u5931\u6557\u3057\u307E\u3057\u305F\u3002");
-            return;
-          }
-          textarea.value = "";
-          for (const message of body.messages || []) {
-            appendMessage(message);
-          }
-          setStatus(body.execution ? "\u4FDD\u5B58\u6E08\u307F\u3002VPS Codex CLI queue \u306B\u6E21\u3057\u307E\u3057\u305F\u3002runner event post \u3092\u5F85\u3063\u3066\u3044\u307E\u3059\u3002" : "\u4FDD\u5B58\u6E08\u307F\u3002Worker runtime \u306B\u4FDD\u5B58\u3057\u307E\u3057\u305F\u3002");
-        } catch {
-          removeThinking(thinking);
-          appendError("Worker chat runtime \u306B\u63A5\u7D9A\u3067\u304D\u307E\u305B\u3093\u3067\u3057\u305F\u3002\u30CD\u30C3\u30C8\u30EF\u30FC\u30AF\u307E\u305F\u306F deploy \u72B6\u614B\u3092\u78BA\u8A8D\u3057\u3066\u304F\u3060\u3055\u3044\u3002");
-          setStatus("\u63A5\u7D9A\u306B\u5931\u6557\u3057\u307E\u3057\u305F\u3002");
-        } finally {
-          if (submitButton) submitButton.disabled = false;
+        if (!chatSocket || chatSocket.readyState !== WebSocket.OPEN) {
+          setStatus("WebSocket \u518D\u63A5\u7D9A\u4E2D\u3067\u3059\u3002\u5C65\u6B74\u3092\u518D\u53D6\u5F97\u3057\u3066\u3044\u307E\u3059\u3002\u63A5\u7D9A\u5F8C\u306B\u3082\u3046\u4E00\u5EA6\u9001\u4FE1\u3057\u3066\u304F\u3060\u3055\u3044\u3002");
+          await refreshThread();
+          scheduleReconnect();
           textarea.focus({ preventScroll: true });
-          updateComposerReserve();
+          return;
         }
+        if (submitButton) submitButton.disabled = true;
+        setStatus("\u9001\u4FE1\u4E2D\u3067\u3059\u3002VPS Codex CLI \u306B push \u3057\u307E\u3059\u3002");
+        chatSocket.send(JSON.stringify({
+          type: "owner_message",
+          threadId,
+          repositoryInput,
+          text,
+          issueNumber,
+          relatedIssue: issueNumber,
+          dispatchToVpsRunner,
+          executorTransport: dispatchToVpsRunner ? "vps_runner" : undefined,
+          codexGoal
+        }));
+        textarea.value = "";
+        setStatus("\u9001\u4FE1\u6E08\u307F\u3002VPS Codex CLI \u306E\u8FD4\u4FE1\u3092\u5F85\u3063\u3066\u3044\u307E\u3059\u3002");
+        if (submitButton) submitButton.disabled = false;
+        textarea.focus({ preventScroll: true });
+        updateComposerReserve();
       });
 
       updateComposerReserve();
       window.addEventListener("resize", updateComposerReserve);
-      refreshThread();
+      window.addEventListener("online", () => {
+        setStatus("\u30CD\u30C3\u30C8\u30EF\u30FC\u30AF\u5FA9\u5E30\u3092\u691C\u77E5\u3057\u307E\u3057\u305F\u3002\u5C65\u6B74\u3092\u518D\u53D6\u5F97\u3057\u3066\u518D\u63A5\u7D9A\u3057\u307E\u3059\u3002");
+        refreshThread();
+        scheduleReconnect();
+      });
+      document.addEventListener("visibilitychange", () => {
+        if (document.visibilityState === "visible" && (!chatSocket || chatSocket.readyState !== WebSocket.OPEN)) {
+          setStatus("\u753B\u9762\u5FA9\u5E30\u3092\u691C\u77E5\u3057\u307E\u3057\u305F\u3002\u5C65\u6B74\u3092\u518D\u53D6\u5F97\u3057\u3066\u518D\u63A5\u7D9A\u3057\u307E\u3059\u3002");
+          refreshThread();
+          scheduleReconnect();
+        }
+      });
       connectThreadSocket();
     })();
   <\/script>


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #450 の dashboard Butler chat を通常会話では GitHub Issue コメント queue に流さず、既存 Durable Object WebSocket 上で owner message を送受信し、VPS Codex CLI へ push する経路に寄せる。
- WebSocket close/error、モバイル回線断、iPhone/iPad のスリープ復帰時に、ページ再読み込みだけに頼らず、同じ thread の履歴を再取得して WebSocket を再接続する。
- 長い dashboard chat thread は、直近 message 表示と dashboard chat summary/search を分け、過去文脈を owner-authenticated な同一 runtime 内で検索できる土台にする。

## Satisfied Success Criteria

- dashboard UI の通常送信処理を WebSocket send に変更した。DashboardChatRoom が owner_message を保存し、thinking message を同じ thread に流し、接続済み VPS runner WebSocket へ dashboard_chat_job を push する。
- VPS runner 用の machine-authenticated WebSocket endpoint `/v2/dashboard/vps-runner/ws?threadId=...` を追加し、dashboard と runner を同じ Durable Object thread room に接続する。
- VPS runner script に `--dashboard-ws` mode を追加し、`VTDD_RUNTIME_URL` / `VTDD_GATEWAY_BEARER_TOKEN` / `VTDD_DASHBOARD_THREAD_ID` で Worker WebSocket に接続し、`dashboard_chat_job` を受けて VPS Codex CLI の triage 結果を同じ socket に返信する。
- runner reply は接続 room の `threadId` と payload の `threadId` が一致する場合だけ保存・broadcast する。不一致 payload は別 thread へ書き込まない。
- WebSocket close/error、`online`、`visibilitychange` で thread 履歴を `GET /v2/dashboard/chat/:threadId` から再取得し、指数 backoff で WebSocket を再接続する。通常会話の送信は GitHub queue / POST fallback へ戻さない。
- dashboard chat summary/search API を追加した。`GET /v2/dashboard/chat/search` は message と summary を repository / relatedIssue / text で検索する。`POST/GET /v2/dashboard/chat/:threadId/summary` は summary/decisions/openItems を保存・取得する。
- 既存の VPS polling / GitHub queue dispatch route は残した。

## Unsatisfied Success Criteria

- VPS Codex CLI 側の WebSocket client 実装は追加済み。常駐プロセスとしての運用設定と live 接続 E2E は未実施。
- production deploy と iPhone 実機 E2E は未実施。
- LLM による自動仕分け・自動要約・RAG 昇格の実行本体は未実施。

## Non-goal violations

既存 VPS polling queue は廃止しない。Custom GPT / Action 経路は変更しない。deploy、secret mutation、Issue close は行わない。通常会話の失敗時に GitHub Issue コメント queue へ送信を戻さない。

## Dry-run Impact Report

- Target Issue: Issue #450
- Implementing Success Criteria: dashboard は自動 page reload、setInterval polling、入力中の画面破壊をしない。必要な場合は WebSocket を使う。通常会話で GitHub queue を使わない。WebSocket 切断時は owner が iPhone/iPad から履歴を復元し再接続できる。
- Explicit Non-goals: VPS polling 廃止、Custom GPT 経路変更、deploy、secret mutation、Issue close、LLM 自動要約本体、RAG への全会話保存。
- Expected touched files/routes/workflows: src/worker/runtime.js、test/worker.test.js、worker.js
- Affected Issues: #450
- Affected PRs: なし
- Affected workflows: deploy workflow は未変更。
- Affected runtime/operator surfaces: Dashboard Butler、Cloudflare Worker/Durable Object、VPS Codex CLI push channel。既存 Custom GPT/VPS polling route は維持。
- What may break if we patch narrowly: dashboard UI だけを POST から外すと runner 接続がない時に無反応になるため、未接続時は chat thread に system failed message を返す。WebSocket close/error 後は thread reload と reconnect を行う。
- Unknowns to investigate before coding: VPS Codex CLI 常時 WebSocket client の常駐方法と再接続運用は次スライスで要実装。
- Validation needed: node --test test/worker.test.js、npm test、生成済み worker.js check。
- Stop condition: 既存 VPS polling route を壊す、dashboard access/machine auth 境界が曖昧になる、または summary/search が RAG 永続記憶の代替として扱われる場合。

## File / Line Hypotheses

- file: src/worker/runtime.js
  - hypothesis: DashboardChatRoom と dashboard inline script が GitHub queue/POST に寄りすぎている。
  - risk if changed narrowly: 既存 machine event POST / Custom GPT route を壊す。
  - validation: worker tests と full npm test。
  - related Issue: #450
- file: src/worker/runtime.js
  - hypothesis: WebSocket close/error 後の復旧がないと iPhone/iPad のスリープ復帰で送信不能になる。
  - risk if changed narrowly: POST fallback を戻すと通常会話が GitHub queue に戻り、Issue #450 の意図から外れる。
  - validation: dashboard HTML test で `refreshThread` / `scheduleReconnect` / `online` / `visibilitychange` を固定する。
  - related Issue: #450

## Hypothesis Retrospective

- expected: dashboard UI の通常送信だけ WebSocket-only にし、既存 polling queue は残す。
- actual: DashboardChatRoom に owner_message / vps_runner socket role / job push を追加し、dashboard inline script から通常送信 fetch を除去。WebSocket close/error/online/visibilitychange で thread reload と reconnect を行う。
- mismatch: VPS CLI client 常駐実装は未実施。LLM 自動 summary/search 昇格は未実施。
- lesson: dashboard chat と GitHub Issue queue は分離する。長い thread は live UI、message DB、summary/search、RAG を分ける。
- should become RAG candidate: はい。

## Verification Evidence

- Unit: node --test test/worker.test.js: pass
- Integration: npm test: pass（node --test、check:self-parity、check:generated-worker）
- E2E: 未実施。production deploy 後に owner dashboard と VPS runner WebSocket client の live E2E が必要。
- VPS runner script: node --test test/vps-runner-script.test.js: pass
- Manual: 未実施。
- Evidence path/link: test/worker.test.js、src/worker/runtime.js、worker.js

## Butler Completion Contract

- Owner goal: owner が dashboard Butler に入力した通常会話を GitHub Issue コメント queue へ流さず、WebSocket で VPS Codex CLI に push する。長い thread でも必要な過去文脈を検索できる土台を持つ。
- Butler entrypoint: /dashboard の Butler chat composer。
- Action Schema exposure: 不要。dashboard UI 経路であり Custom GPT Action Schema は未変更。
- Runtime path: Browser dashboard WebSocket -> DashboardChatRoom Durable Object -> connected VPS runner WebSocket -> `scripts/run-vps-runner.mjs --dashboard-ws` -> VPS Codex CLI triage -> runner reply -> same DashboardChatRoom thread broadcast。WebSocket close/error 時は same-origin `GET /v2/dashboard/chat/:threadId` で履歴再取得し再接続する。
- Runner/runtime truth: npm test pass。VPS runner WebSocket client unit test は pass。production live 接続は未実施。
- Authority boundary: dashboard access は既存 owner auth。thread history / summary / search は dashboard owner auth の中だけで返す。VPS runner WebSocket は machine bearer auth。GitHub high-risk authority は未変更。
- Search/memory boundary: summary/search は D1 dashboard chat store の補助記憶であり、RAG 永続記憶の代替ではない。message は sanitized text を保存する。summary/decisions/openItems は owner-authenticated route で repository / relatedIssue filter を受ける。全会話を RAG に丸ごと保存しない。
- E2E evidence: 未実施。live VPS runner WebSocket client 実装後に iPhone dashboard E2E が必要。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 必要。merge 後に通常 deploy が必要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。deploy 後に必要。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate
- AGENTS.md Butler-First Operating Principle
- AGENTS.md Conversation UX Contract
- AGENTS.md RAG Memory Capture and Cost Boundary
- Issue #450 Success Criteria

## Out-of-scope but NOT implemented

- VPS Codex CLI 常時 WebSocket client の VPS サービス常駐設定。
- 既存 VPS polling queue の廃止。
- LLM による自動仕分け・自動要約・RAG 昇格。
- Issue #450 close 判定。

## Extra changes (if any)

worker.js は npm run build:worker で生成。

<!-- VTDD metadata -->
- Issue: Issue #450
- Execution ID: mac-codex-issue450-dashboard-ws-push
- Goal: dashboard_chat_websocket_push

