### PR TITLE
dashboard: VPS runner WebSocket client を追加

### DIFF
--- a/scripts/run-vps-runner.mjs
+++ b/scripts/run-vps-runner.mjs
@@ -79,6 +79,17 @@ async function main() {
     apiBaseUrl: process.env.GITHUB_API_URL || DEFAULT_API_BASE_URL
   });
 
+  if (options.dashboardWs) {
+    await startVpsDashboardWebSocketRunner({
+      githubFetch,
+      token,
+      repositoryPolicies,
+      workRoot,
+      env: process.env
+    });
+    return;
+  }
+
   const result = await runVpsRunnerOnce({
     githubFetch,
     token,
@@ -94,6 +105,41 @@ async function main() {
   }
 
   console.log(result.message);
+}
+
+async function startVpsDashboardWebSocketRunner({
+  githubFetch,
+  token,
+  repositoryPolicies,
+  workRoot,
+  env = process.env,
+  WebSocketImpl = globalThis.WebSocket,
+  logger = console
+}) {
+  const threadId = normalizeText(env.VTDD_DASHBOARD_THREAD_ID);
+  if (!threadId) {
+    throw new Error("VTDD_DASHBOARD_THREAD_ID is required for dashboard WebSocket mode");
+  }
+  const runtimeUrl = mustGetEnv("VTDD_RUNTIME_URL", env.VTDD_RUNTIME_URL);
+  const bearerToken = mustGetEnv("VTDD_GATEWAY_BEARER_TOKEN", env.VTDD_GATEWAY_BEARER_TOKEN);
+  return connectVpsDashboardWebSocketClient({
+    runtimeUrl,
+    bearerToken,
+    threadId,
+    WebSocketImpl,
+    logger,
+    onJob: async (job, socket) => {
+      await executeVpsDashboardSocketJob({
+        githubFetch,
+        token,
+        workRoot,
+        job,
+        socket,
+        repositoryPolicies,
+        env
+      });
+    }
+  });
 }
 
 async function runVpsRunnerOnce({
@@ -553,6 +599,209 @@ async function executeVpsDashboardChatTriage({ githubFetch, payload, notificatio
     }
   });
   return { ok: true, message: reply };
+}
+
+function buildDashboardRunnerWebSocketUrl({ runtimeUrl, threadId }) {
+  const resolvedThreadId = normalizeText(threadId);
+  if (!resolvedThreadId) {
+    throw new Error("dashboard threadId is required");
+  }
+  const endpoint = new URL("/v2/dashboard/vps-runner/ws", runtimeUrl);
+  endpoint.protocol = endpoint.protocol === "http:" ? "ws:" : "wss:";
+  endpoint.searchParams.set("threadId", resolvedThreadId);
+  return endpoint.toString();
+}
+
+async function connectVpsDashboardWebSocketClient({
+  runtimeUrl,
+  bearerToken,
+  threadId,
+  WebSocketImpl = globalThis.WebSocket,
+  onJob,
+  logger = console,
+  reconnect = true,
+  reconnectDelays = [1000, 5000, 15000, 30000],
+  reconnectAttempt = 0,
+  setTimeoutFn = globalThis.setTimeout
+}) {
+  if (typeof WebSocketImpl !== "function") {
+    throw new Error("WebSocket is not available in this Node runtime");
+  }
+  const protocols = ["vtdd-vps-runner", buildDashboardRunnerBearerProtocol(bearerToken)];
+  const socket = new WebSocketImpl(buildDashboardRunnerWebSocketUrl({ runtimeUrl, threadId }), protocols, {
+    headers: {
+      authorization: `Bearer ${bearerToken}`
+    }
+  });
+  addSocketListener(socket, "open", () => {
+    reconnectAttempt = 0;
+    logger?.log?.(`Connected dashboard WebSocket runner for ${threadId}.`);
+  });
+  addSocketListener(socket, "message", async (event) => {
+    const raw = typeof event?.data === "string" ? event.data : event;
+    let payload;
+    try {
+      payload = JSON.parse(String(raw || "{}"));
+    } catch (error) {
+      sendDashboardSocketReply(socket, {
+        threadId,
+        status: "failed",
+        message: "VPS Codex CLI が dashboard job JSON を読み取れませんでした。"
+      });
+      return;
+    }
+    if (payload?.type !== "dashboard_chat_job") {
+      return;
+    }
+    try {
+      await onJob?.(payload, socket);
+    } catch (error) {
+      sendDashboardSocketReply(socket, {
+        threadId: normalizeText(payload.threadId) || threadId,
+        repository: normalizeRepository(payload.repository),
+        issueNumber: normalizePositiveInteger(payload.relatedIssue || payload.issueNumber),
+        status: "failed",
+        message: `VPS Codex CLI dashboard job failed: ${summarizeDiagnosticText(error?.message || String(error), 1000)}`
+      });
+    }
+  });
+  addSocketListener(socket, "close", () => {
+    logger?.error?.(`Dashboard WebSocket runner disconnected for ${threadId}.`);
+    if (!reconnect) {
+      return;
+    }
+    const delays = Array.isArray(reconnectDelays) && reconnectDelays.length > 0 ? reconnectDelays : [1000];
+    const delay = Number(delays[Math.min(reconnectAttempt, delays.length - 1)]) || 1000;
+    logger?.log?.(`Reconnecting dashboard WebSocket runner for ${threadId} in ${delay}ms.`);
+    setTimeoutFn(() => {
+      connectVpsDashboardWebSocketClient({
+        runtimeUrl,
+        bearerToken,
+        threadId,
+        WebSocketImpl,
+        onJob,
+        logger,
+        reconnect,
+        reconnectDelays,
+        reconnectAttempt: reconnectAttempt + 1,
+        setTimeoutFn
+      }).catch((error) => {
+        logger?.error?.(`Dashboard WebSocket runner reconnect failed: ${error?.message || String(error)}`);
+      });
+    }, delay);
+  });
+  addSocketListener(socket, "error", (error) => {
+    logger?.error?.(`Dashboard WebSocket runner error: ${error?.message || String(error)}`);
+  });
+  return socket;
+}
+
+function addSocketListener(socket, eventName, handler) {
+  if (typeof socket?.addEventListener === "function") {
+    socket.addEventListener(eventName, handler);
+    return;
+  }
+  if (typeof socket?.on === "function") {
+    socket.on(eventName, handler);
+  }
+}
+
+async function executeVpsDashboardSocketJob({
+  githubFetch,
+  token,
+  workRoot,
+  job,
+  socket,
+  repositoryPolicies,
+  env = process.env
+}) {
+  const payload = buildVpsDashboardSocketExecutionPayload(job);
+  const policies = normalizeRepositoryPolicies({ repositoryPolicies });
+  const policy = validateVpsRunnerPayloadPolicy(payload, policies);
+  if (!policy.ok) {
+    sendDashboardSocketReply(socket, {
+      threadId: payload.handoff.dashboardThreadId,
+      repository: payload.repository,
+      issueNumber: payload.issueNumber,
+      status: "blocked",
+      message: `VPS Codex CLI blocked dashboard job: ${policy.reason}`
+    });
+    return;
+  }
+  const commandEnv = buildRunnerCommandEnv({ token });
+  const issue = payload.issueNumber
+    ? await githubFetch(`/repos/${payload.repository}/issues/${payload.issueNumber}`)
+    : {};
+  const workspace = path.join(workRoot, safePathSegment(payload.repository), payload.executionId);
+  await fs.mkdir(path.dirname(workspace), { recursive: true });
+  await runCommand("rm", ["-rf", workspace], { env: commandEnv });
+  await runCommand("gh", ["repo", "clone", payload.repository, workspace], { env: commandEnv });
+  const preflight = await buildVpsRunnerPreflightReceipt({ workspace, payload, issue });
+  if (!preflight.ok) {
+    sendDashboardSocketReply(socket, {
+      threadId: payload.handoff.dashboardThreadId,
+      repository: payload.repository,
+      issueNumber: payload.issueNumber,
+      status: "blocked",
+      message:
+        preflight.reason ||
+        "VPS runner preflight receipt could not be created. Butler/owner decision is required before dashboard chat triage."
+    });
+    return;
+  }
+  const result = await runCommand("codex", buildCodexExecArgs({ env }), {
+    cwd: workspace,
+    env: buildCodexExecutionEnv(env),
+    input: buildDashboardChatTriagePrompt({ payload, issue, preflight }),
+    maxBuffer: 1024 * 1024 * 12
+  });
+  const reply = summarizeDiagnosticText(result.stdout || result.stderr || "VPS Codex CLI completed dashboard chat triage.", 4000);
+  sendDashboardSocketReply(socket, {
+    threadId: payload.handoff.dashboardThreadId,
+    repository: payload.repository,
+    issueNumber: payload.issueNumber,
+    status: "completed",
+    message: reply
+  });
+}
+
+function buildVpsDashboardSocketExecutionPayload(job) {
+  const repository = normalizeRepository(job?.repository);
+  const issueNumber = normalizePositiveInteger(job?.relatedIssue || job?.issueNumber);
+  const threadId = normalizeText(job?.threadId);
+  return {
+    executionId: `dashboard-ws-${Date.now()}-${crypto.randomUUID()}`,
+    repository,
+    issueNumber,
+    branch: `codex/dashboard-chat-${Date.now()}`,
+    baseRef: "main",
+    codexGoal: "dashboard_chat_triage",
+    handoff: {
+      ownerMessage: normalizeText(job?.text),
+      repositoryInput: normalizeText(job?.repositoryInput) || repository,
+      dashboardThreadId: threadId
+    }
+  };
+}
+
+function sendDashboardSocketReply(socket, reply) {
+  if (typeof socket?.send !== "function") {
+    return;
+  }
+  socket.send(
+    JSON.stringify({
+      type: "vps_runner_reply",
+      threadId: normalizeText(reply.threadId),
+      repository: normalizeRepository(reply.repository),
+      issueNumber: normalizePositiveInteger(reply.issueNumber),
+      status: normalizeText(reply.status) || "completed",
+      message: normalizeText(reply.message) || "VPS Codex CLI completed dashboard job."
+    })
+  );
+}
+
+function buildDashboardRunnerBearerProtocol(bearerToken) {
+  return `vtdd-gateway-bearer-${Buffer.from(String(bearerToken), "utf8").toString("base64url")}`;
 }
 
 function buildDashboardChatTriagePrompt({ payload, issue = {}, preflight = null }) {
@@ -2681,7 +2930,8 @@ function mustGetEnv(name, value = process.env[name]) {
 
 function parseArgs(args) {
   return {
-    dryRun: args.includes("--dry-run")
+    dryRun: args.includes("--dry-run"),
+    dashboardWs: args.includes("--dashboard-ws")
   };
 }
 
@@ -2697,6 +2947,7 @@ export {
   buildVpsRunnerCompletionFinalEvent,
   buildCodexExecutionPrompt,
   buildDashboardChatTriagePrompt,
+  buildDashboardRunnerWebSocketUrl,
   buildCodexExecArgs,
   buildVpsRunnerPreflightReceipt,
   buildGuardedPullRequestBody,
@@ -2708,6 +2959,7 @@ export {
   buildVpsRunnerPullRequestContext,
   checkoutVpsRunnerBranch,
   classifyVpsRunnerFailure,
+  connectVpsDashboardWebSocketClient,
   formatPullRequestContext,
   isNonFastForwardPushFailure,
   loadVpsRunnerRepositoryPolicies,
@@ -2717,6 +2969,7 @@ export {
   parseVpsRunnerQueueComment,
   postVpsRunnerEvent,
   runVpsRunnerOnce,
+  startVpsDashboardWebSocketRunner,
   resolveRoleGitHubAppInstallationToken,
   summarizeDiagnosticText,
   selectPendingVpsReviewerFallbacks,

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -3648,7 +3648,7 @@ async function handleDashboardChatSocketRequest(request, url, env) {
 
 async function handleDashboardVpsRunnerSocketRequest(request, env) {
   const auth = authorizeGatewayRequest({
-    request,
+    request: withDashboardRunnerProtocolAuthorization(request),
     env,
     apiSuffix: "/dashboard/vps-runner/ws"
   });
@@ -3684,6 +3684,44 @@ async function handleDashboardVpsRunnerSocketRequest(request, env) {
     });
   }
   return room.fetch(request);
+}
+
+function withDashboardRunnerProtocolAuthorization(request) {
+  if (request.headers.get("authorization")) {
+    return request;
+  }
+  const protocol = normalizeText(request.headers.get("sec-websocket-protocol"));
+  const token = protocol
+    .split(",")
+    .map((item) => item.trim())
+    .find((item) => item.startsWith("vtdd-gateway-bearer-"));
+  if (!token) {
+    return request;
+  }
+  const encoded = token.slice("vtdd-gateway-bearer-".length);
+  const bearerToken = decodeBase64UrlText(encoded);
+  if (!bearerToken) {
+    return request;
+  }
+  const headers = new Headers(request.headers);
+  headers.set("authorization", `Bearer ${bearerToken}`);
+  return new Request(request, { headers });
+}
+
+function decodeBase64UrlText(value) {
+  const normalized = normalizeText(value);
+  if (!/^[A-Za-z0-9_-]+$/.test(normalized)) {
+    return "";
+  }
+  try {
+    const base64 = normalized.replace(/-/g, "+").replace(/_/g, "/");
+    const padded = base64.padEnd(Math.ceil(base64.length / 4) * 4, "=");
+    const binary = atob(padded);
+    const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
+    return new TextDecoder().decode(bytes);
+  } catch {
+    return "";
+  }
 }
 
 async function handleDashboardChatThreadRequest(request, url, env) {

--- a/test/vps-runner-script.test.js
+++ b/test/vps-runner-script.test.js
@@ -7,6 +7,7 @@ import {
   buildFreshExecutionBranchCandidates,
   buildCodexExecutionPrompt,
   buildDashboardChatTriagePrompt,
+  buildDashboardRunnerWebSocketUrl,
   buildCodexExecArgs,
   buildGuardedPullRequestBody,
   buildPostMergePullTruth,
@@ -19,6 +20,7 @@ import {
   buildVpsRunnerPullRequestContext,
   checkoutVpsRunnerBranch,
   classifyVpsRunnerFailure,
+  connectVpsDashboardWebSocketClient,
   formatPullRequestContext,
   isNonFastForwardPushFailure,
   loadVpsRunnerRepositoryPolicies,
@@ -565,6 +567,127 @@ test("VPS runner event records missing runtime dashboard delivery configuration"
     parsed.event.dashboardDelivery.reason,
     "VTDD_RUNTIME_URL or VTDD_GATEWAY_BEARER_TOKEN is missing"
   );
+});
+
+test("VPS runner builds dashboard WebSocket endpoint with machine thread id", () => {
+  assert.equal(
+    buildDashboardRunnerWebSocketUrl({
+      runtimeUrl: "https://vtdd-v2-mvp.example.workers.dev",
+      threadId: "dashboard-main-marushu-vtdd-v2-p"
+    }),
+    "wss://vtdd-v2-mvp.example.workers.dev/v2/dashboard/vps-runner/ws?threadId=dashboard-main-marushu-vtdd-v2-p"
+  );
+});
+
+test("VPS runner dashboard WebSocket client authenticates and handles dashboard jobs", async () => {
+  const sockets = [];
+  class FakeWebSocket {
+    constructor(url, protocols, options) {
+      this.url = url;
+      this.protocols = protocols;
+      this.options = options;
+      this.listeners = new Map();
+      this.sent = [];
+      sockets.push(this);
+    }
+    addEventListener(eventName, handler) {
+      this.listeners.set(eventName, handler);
+    }
+    send(body) {
+      this.sent.push(body);
+    }
+    emit(eventName, event) {
+      return this.listeners.get(eventName)?.(event);
+    }
+  }
+
+  const jobs = [];
+  const socket = await connectVpsDashboardWebSocketClient({
+    runtimeUrl: "https://vtdd-v2-mvp.example.workers.dev",
+    bearerToken: "gateway-token-for-test",
+    threadId: "dashboard-main-marushu-vtdd-v2-p",
+    WebSocketImpl: FakeWebSocket,
+    logger: { log() {}, error() {} },
+    onJob: async (job, runnerSocket) => {
+      jobs.push(job);
+      runnerSocket.send(
+        JSON.stringify({
+          type: "vps_runner_reply",
+          threadId: job.threadId,
+          repository: job.repository,
+          issueNumber: job.relatedIssue,
+          status: "completed",
+          message: "VPS Codex CLI からの返信です。"
+        })
+      );
+    }
+  });
+
+  assert.equal(sockets.length, 1);
+  assert.equal(
+    sockets[0].url,
+    "wss://vtdd-v2-mvp.example.workers.dev/v2/dashboard/vps-runner/ws?threadId=dashboard-main-marushu-vtdd-v2-p"
+  );
+  assert.equal(sockets[0].options.headers.authorization, "Bearer gateway-token-for-test");
+  assert.equal(sockets[0].protocols[0], "vtdd-vps-runner");
+  assert.equal(sockets[0].protocols[1].startsWith("vtdd-gateway-bearer-"), true);
+
+  await socket.emit("message", {
+    data: JSON.stringify({
+      type: "dashboard_chat_job",
+      threadId: "dashboard-main-marushu-vtdd-v2-p",
+      repository: "marushu/vtdd-v2-p",
+      relatedIssue: 450,
+      text: "進捗は？"
+    })
+  });
+
+  assert.equal(jobs.length, 1);
+  assert.equal(jobs[0].text, "進捗は？");
+  assert.equal(JSON.parse(socket.sent[0]).type, "vps_runner_reply");
+  assert.equal(JSON.parse(socket.sent[0]).message, "VPS Codex CLI からの返信です。");
+});
+
+test("VPS runner dashboard WebSocket client reconnects after disconnect", async () => {
+  const sockets = [];
+  const timers = [];
+  class FakeWebSocket {
+    constructor(url, protocols, options) {
+      this.url = url;
+      this.protocols = protocols;
+      this.options = options;
+      this.listeners = new Map();
+      sockets.push(this);
+    }
+    addEventListener(eventName, handler) {
+      this.listeners.set(eventName, handler);
+    }
+    emit(eventName, event) {
+      return this.listeners.get(eventName)?.(event);
+    }
+  }
+
+  const socket = await connectVpsDashboardWebSocketClient({
+    runtimeUrl: "https://vtdd-v2-mvp.example.workers.dev",
+    bearerToken: "gateway-token-for-test",
+    threadId: "dashboard-main-marushu-vtdd-v2-p",
+    WebSocketImpl: FakeWebSocket,
+    logger: { log() {}, error() {} },
+    onJob: async () => {},
+    reconnectDelays: [250],
+    setTimeoutFn: (callback, delay) => {
+      timers.push({ callback, delay });
+    }
+  });
+
+  socket.emit("close");
+  assert.equal(timers.length, 1);
+  assert.equal(timers[0].delay, 250);
+
+  await timers[0].callback();
+  assert.equal(sockets.length, 2);
+  assert.equal(sockets[1].url, sockets[0].url);
+  assert.equal(sockets[1].protocols[0], "vtdd-vps-runner");
 });
 
 test("VPS runner milestone event mentions queue comment author", () => {

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -1021,6 +1021,19 @@ test("worker exposes machine-authenticated VPS runner WebSocket push channel", a
   assert.equal(body.error, "websocket_upgrade_required");
   assert.equal(rooms.calls.length, 0);
 
+  const protocolToken = Buffer.from(gatewayAuthEnv.VTDD_GATEWAY_BEARER_TOKEN, "utf8").toString("base64url");
+  const protocolAuthorized = await worker.fetch(
+    new Request("https://example.com/v2/dashboard/vps-runner/ws?threadId=dashboard-main-marushu-vtdd-v2-p", {
+      headers: {
+        "sec-websocket-protocol": `vtdd-vps-runner, vtdd-gateway-bearer-${protocolToken}`
+      }
+    }),
+    { ...gatewayAuthEnv, DASHBOARD_CHAT_ROOMS: rooms.namespace }
+  );
+  assert.equal(protocolAuthorized.status, 426);
+  const protocolBody = await protocolAuthorized.json();
+  assert.equal(protocolBody.error, "websocket_upgrade_required");
+
   const unauthorized = await worker.fetch(
     new Request("https://example.com/v2/dashboard/vps-runner/ws?threadId=dashboard-main-marushu-vtdd-v2-p"),
     { ...gatewayAuthEnv, DASHBOARD_CHAT_ROOMS: rooms.namespace }

--- a/worker.js
+++ b/worker.js
@@ -58957,7 +58957,7 @@ async function handleDashboardChatSocketRequest(request, url, env) {
 }
 async function handleDashboardVpsRunnerSocketRequest(request, env) {
   const auth = authorizeGatewayRequest({
-    request,
+    request: withDashboardRunnerProtocolAuthorization(request),
     env,
     apiSuffix: "/dashboard/vps-runner/ws"
   });
@@ -58993,6 +58993,39 @@ async function handleDashboardVpsRunnerSocketRequest(request, env) {
     });
   }
   return room.fetch(request);
+}
+function withDashboardRunnerProtocolAuthorization(request) {
+  if (request.headers.get("authorization")) {
+    return request;
+  }
+  const protocol = normalizeText30(request.headers.get("sec-websocket-protocol"));
+  const token = protocol.split(",").map((item) => item.trim()).find((item) => item.startsWith("vtdd-gateway-bearer-"));
+  if (!token) {
+    return request;
+  }
+  const encoded = token.slice("vtdd-gateway-bearer-".length);
+  const bearerToken = decodeBase64UrlText(encoded);
+  if (!bearerToken) {
+    return request;
+  }
+  const headers = new Headers(request.headers);
+  headers.set("authorization", `Bearer ${bearerToken}`);
+  return new Request(request, { headers });
+}
+function decodeBase64UrlText(value) {
+  const normalized = normalizeText30(value);
+  if (!/^[A-Za-z0-9_-]+$/.test(normalized)) {
+    return "";
+  }
+  try {
+    const base643 = normalized.replace(/-/g, "+").replace(/_/g, "/");
+    const padded = base643.padEnd(Math.ceil(base643.length / 4) * 4, "=");
+    const binary = atob(padded);
+    const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
+    return new TextDecoder().decode(bytes);
+  } catch {
+    return "";
+  }
 }
 async function handleDashboardChatThreadRequest(request, url, env) {
   const auth = await authorizeDashboardRequest({


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #450 / PR #469 の reviewer blocker だった VPS Codex CLI 側 WebSocket client 未実装を解消する。\nDashboard Butler chat から Worker Durable Object WebSocket に流れた dashboard_chat_job を VPS runner が受け取り、VPS Codex CLI の triage 結果を同じ WebSocket thread に返せるようにする。\n通常チャットを GitHub queue comment だけに逃がさず、dashboard 専用の push 経路を追加する。

## Satisfied Success Criteria

- scripts/run-vps-runner.mjs --dashboard-ws mode を追加した。\nVTDD_RUNTIME_URL / VTDD_GATEWAY_BEARER_TOKEN / VTDD_DASHBOARD_THREAD_ID を使い、Worker の wss://.../v2/dashboard/vps-runner/ws?threadId=... へ machine auth 付きで接続する。\nNode WebSocket で任意 Authorization header が使えない場合に備え、Sec-WebSocket-Protocol の vtdd-gateway-bearer-* fallback を Worker 側で bearer auth として解決する。\ndashboard_chat_job を受け取ったら VPS runner が dashboard chat triage payload を組み、runner reply を type: vps_runner_reply 付きで同じ WebSocket thread に返す。\n通常チャットから approval.phrase: GO を合成しない。\nWebSocket close 時に段階的 backoff で再接続する。\n既存の GitHub queue / polling path は残した。\nWorker 側は接続 room の threadId と違う runner reply を拒否する既存 contract を維持し、machine auth fallback を test で固定した。

## Unsatisfied Success Criteria

- VPS 上で --dashboard-ws を systemd/tmux 等に常駐させる運用設定は未実施。\nproduction deploy と iPhone 実機 live E2E は未実施。\nLLM による自動仕分け・自動要約・RAG 昇格の実行本体は未実施。

## Non-goal violations

既存 VPS polling queue は廃止しない。Custom GPT / Action 経路は変更しない。deploy、secret mutation、Issue close は行わない。

## Dry-run Impact Report

- Target Issue: Issue #450
- Implementing Success Criteria: dashboard 通常会話を GitHub queue へ戻さず、WebSocket 経由で VPS Codex CLI に届く runner 側 client、machine auth fallback、切断時の再接続を追加する。
- Explicit Non-goals: VPS polling 廃止、Custom GPT 経路変更、deploy、secret mutation、Issue close、VPS service 常駐設定、live E2E の完了宣言。
- Expected touched files/routes/workflows: scripts/run-vps-runner.mjs、src/worker/runtime.js、test/vps-runner-script.test.js、test/worker.test.js、worker.js
- Affected Issues: Issue #450
- Affected PRs: PR #469 follow-up / PR #470
- Affected workflows: なし
- Affected runtime/operator surfaces: VPS Codex CLI runner、Dashboard Butler WebSocket push channel、Worker machine-authenticated VPS runner WebSocket endpoint。
- What may break if we patch narrowly: runner が WebSocket job を受けられないと dashboard は runner 未接続で止まる。既存 queue path を触ると polling fallback が壊れる。認証を header のみへ寄せると Node WebSocket 実ランタイムで接続できない可能性が残る。再接続がないと一度の close で push path が停止する。
- Unknowns to investigate before coding: VPS 上の常駐方式と live network E2E は次スライスで運用確認が必要。
- Validation needed: node --check scripts/run-vps-runner.mjs、node --test test/vps-runner-script.test.js、node --test test/worker.test.js test/vps-runner-script.test.js、npm run build:worker、npm test。
- Stop condition: machine auth 境界が query token 化される、既存 queue path を壊す、通常チャットを GO として扱う、または live E2E を未実施なのに完了扱いする場合。

## File / Line Hypotheses

file: scripts/run-vps-runner.mjs\n  - hypothesis: dashboard WebSocket job を受ける VPS client mode がないため、#469 deploy 後も runner 未接続で止まる。\n  - risk if changed narrowly: GitHub queue runner と dashboard WebSocket runner の責務が混線する。\n  - validation: WebSocket URL/auth/job/reconnect handling unit test と full npm test。\n  - related Issue: #450\nfile: src/worker/runtime.js\n  - hypothesis: Node WebSocket が任意 Authorization header を送れない場合、Worker 側が subprotocol bearer を machine auth として解決できないと live 接続が失敗する。\n  - risk if changed narrowly: token を query に置くと URL/log に残りやすくなる。\n  - validation: sec-websocket-protocol bearer fallback test と full npm test。\n  - related Issue: #450

## Hypothesis Retrospective

expected: Worker 側 WebSocket endpoint だけでは不十分で、VPS runner 側の client、machine auth fallback、切断時 reconnect が必要。\nactual: --dashboard-ws mode、standard WebSocket subprotocol bearer fallback、typed runner reply、GO 合成削除、close 後 backoff reconnect を追加した。\nmismatch: VPS service 常駐設定と production live E2E は未実施。\nlesson: dashboard push path は Worker endpoint と VPS client の両方が揃って初めて有効。通常チャットは承認 GO ではない。runner は切断復帰できないと運用上使えない。\nshould become RAG candidate: はい。

## Verification Evidence

- Unit: node --test test/vps-runner-script.test.js: pass, 67 tests. node --test test/worker.test.js test/vps-runner-script.test.js: pass, 225 tests.
- Integration: npm test: pass, 887 pass / 1 skip. npm run build:worker: pass. check:generated-worker: pass.
- E2E: 未実施。production deploy 後に owner dashboard と VPS runner WebSocket client の live E2E が必要。
- Manual: 未実施。
- Evidence path/link: scripts/run-vps-runner.mjs、src/worker/runtime.js、test/vps-runner-script.test.js、test/worker.test.js、worker.js

## Butler Completion Contract

- Owner goal: dashboard Butler の通常会話を VPS Codex CLI に直接届け、同じ chat thread に返信を戻す。
- Butler entrypoint: /dashboard の Butler chat composer。
- Action Schema exposure: 不要。dashboard UI 経路であり Custom GPT Action Schema は未変更。
- Runtime path: Browser dashboard WebSocket -> DashboardChatRoom Durable Object -> connected VPS runner WebSocket -> scripts/run-vps-runner.mjs --dashboard-ws -> VPS Codex CLI triage -> type: vps_runner_reply -> same DashboardChatRoom thread broadcast。close 時は runner client が同じ endpoint へ backoff reconnect する。
- Runner/runtime truth: npm test pass。VPS runner WebSocket client unit test pass。Worker subprotocol auth fallback test pass。reconnect test pass。production live 接続は未実施。
- Authority boundary: dashboard access は既存 owner auth。VPS runner WebSocket は machine bearer auth header または Sec-WebSocket-Protocol bearer fallback。通常チャットから GO は合成しない。GitHub high-risk authority は未変更。
- E2E evidence: 未実施。live VPS runner WebSocket client 常駐後に iPhone dashboard E2E が必要。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 必要。merge 後に通常 deploy が必要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。deploy 後に必要。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate\nAGENTS.md Butler-First Operating Principle\nAGENTS.md Conversation UX Contract\nIssue #450 Success Criteria

## Out-of-scope but NOT implemented

- VPS service 常駐設定。\n既存 VPS polling queue の廃止。\nLLM による自動仕分け・自動要約・RAG 昇格。\nIssue #450 close 判定。

## Extra changes (if any)

reviewer blocker 対応として Authorization header 依存を subprotocol fallback で補強し、通常チャットの GO 合成を削除し、close 後 reconnect を追加した。

<!-- VTDD metadata -->
- Issue: Issue #450
- Execution ID: mac-codex-issue450-dashboard-ws-vps-client-followup
- Goal: dashboard_chat_websocket_vps_client
