### PR TITLE
dashboard: VPS WebSocket subprotocol echo を修正

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -1,5 +1,5 @@
 import worker from "./worker/runtime.js";
 
-export { DashboardChatRoom } from "./worker/runtime.js";
+export { DashboardChatRoom, selectDashboardWebSocketResponseProtocol } from "./worker/runtime.js";
 
 export default worker;

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -157,8 +157,15 @@ export class DashboardChatRoom {
       await this.sendThread(server, threadId);
     }
 
+    const responseHeaders = new Headers();
+    const responseProtocol = selectDashboardWebSocketResponseProtocol(request.headers.get("sec-websocket-protocol"));
+    if (responseProtocol) {
+      responseHeaders.set("sec-websocket-protocol", responseProtocol);
+    }
+
     return new Response(null, {
       status: 101,
+      headers: responseHeaders,
       webSocket: client
     });
   }
@@ -3644,6 +3651,14 @@ async function handleDashboardChatSocketRequest(request, url, env) {
     });
   }
   return room.fetch(request);
+}
+
+export function selectDashboardWebSocketResponseProtocol(value) {
+  const protocols = normalizeText(value)
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+  return protocols.includes("vtdd-vps-runner") ? "vtdd-vps-runner" : "";
 }
 
 async function handleDashboardVpsRunnerSocketRequest(request, env) {

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import worker from "../src/worker.js";
-import { DashboardChatRoom } from "../src/worker.js";
+import { DashboardChatRoom, selectDashboardWebSocketResponseProtocol } from "../src/worker.js";
 import {
   ActionType,
   ActorRole,
@@ -1049,6 +1049,15 @@ test("worker exposes machine-authenticated VPS runner WebSocket push channel", a
   assert.equal(missingThread.status, 422);
   const missingBody = await missingThread.json();
   assert.equal(missingBody.error, "thread_id_required");
+});
+
+test("DashboardChatRoom selects VPS runner WebSocket subprotocol without echoing bearer token", () => {
+  const selected = selectDashboardWebSocketResponseProtocol(
+    "vtdd-vps-runner, vtdd-gateway-bearer-redacted-test-token"
+  );
+
+  assert.equal(selected, "vtdd-vps-runner");
+  assert.equal(selected.includes("bearer"), false);
 });
 
 test("DashboardChatRoom pushes owner messages to a runner socket in the same thread room", async () => {

--- a/worker.js
+++ b/worker.js
@@ -55915,8 +55915,14 @@ var DashboardChatRoom = class {
     } else {
       await this.sendThread(server, threadId);
     }
+    const responseHeaders = new Headers();
+    const responseProtocol = selectDashboardWebSocketResponseProtocol(request.headers.get("sec-websocket-protocol"));
+    if (responseProtocol) {
+      responseHeaders.set("sec-websocket-protocol", responseProtocol);
+    }
     return new Response(null, {
       status: 101,
+      headers: responseHeaders,
       webSocket: client
     });
   }
@@ -58954,6 +58960,10 @@ async function handleDashboardChatSocketRequest(request, url, env) {
     });
   }
   return room.fetch(request);
+}
+function selectDashboardWebSocketResponseProtocol(value) {
+  const protocols = normalizeText30(value).split(",").map((item) => item.trim()).filter(Boolean);
+  return protocols.includes("vtdd-vps-runner") ? "vtdd-vps-runner" : "";
 }
 async function handleDashboardVpsRunnerSocketRequest(request, env) {
   const auth = authorizeGatewayRequest({
@@ -63504,5 +63514,6 @@ function isApiPath(pathname, suffix) {
 var worker_default = runtime_default;
 export {
   DashboardChatRoom,
-  worker_default as default
+  worker_default as default,
+  selectDashboardWebSocketResponseProtocol
 };


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #450 の dashboard Butler WebSocket runtime で、VPS Codex CLI runner が Node native WebSocket から接続できない handshake 問題を修正する。\nVPS runner が Sec-WebSocket-Protocol で vtdd-vps-runner と bearer fallback を送る場合、Worker は公開 subprotocol の vtdd-vps-runner だけを 101 response へ echo する。

## Satisfied Success Criteria

- DashboardChatRoom の WebSocket upgrade response が vtdd-vps-runner subprotocol を選択して返す。\nbearer 派生 protocol は response に echo しない。\nVPS runner endpoint の machine auth fallback は維持する。\n既存 dashboard chat / runner reply contract は変更しない。

## Unsatisfied Success Criteria

- production deploy は未実施。\nVPS dashboard WebSocket runner の live reconnect は deploy 後に再確認が必要。\niPhone dashboard からの live E2E は未実施。

## Non-goal violations

secret mutation、VPS env 変更、Issue close、Custom GPT Action Schema 変更、GitHub queue/poller 廃止は行わない。

## Dry-run Impact Report

- Target Issue: Issue #450
- Implementing Success Criteria: VPS runner WebSocket handshake で subprotocol 不一致により接続が落ちないよう、Worker 101 response が vtdd-vps-runner を echo する。
- Explicit Non-goals: deploy、secret mutation、VPS service 操作、Issue close、GitHub queue/poller 廃止。
- Expected touched files/routes/workflows: src/worker/runtime.js、src/worker.js、test/worker.test.js、worker.js
- Affected Issues: Issue #450
- Affected PRs: なし
- Affected workflows: guarded-autonomy-required-checks、gemini-pr-review、deploy-production は merge 後に別途必要。
- Affected runtime/operator surfaces: DashboardChatRoom Durable Object WebSocket upgrade response、VPS Codex CLI dashboard WebSocket runner。
- What may break if we patch narrowly: bearer protocol を response に echo すると token 相当値が client/intermediate に残る。subprotocol を返さないと native WebSocket client が handshake 失敗する。
- Unknowns to investigate before coding: production deploy 後の Cloudflare WebSocket handshake 実挙動は live確認が必要。
- Validation needed: node --check src/worker/runtime.js、node --test test/worker.test.js --test-name-pattern、npm run build:worker、npm test。
- Stop condition: bearer token を URL/query/response body/log に出す変更になる場合、または通常 dashboard auth boundary を緩める場合。

## File / Line Hypotheses

file: src/worker/runtime.js\n  - hypothesis: VPS runner client が subprotocol を送る一方、Worker 101 response が subprotocol を返さないため native WebSocket handshake が失敗している。\n  - risk if changed narrowly: bearer fallback protocol を echo すると secret 相当値が漏れる。\n  - validation: subprotocol selector test と full npm test。\n  - related Issue: #450

## Hypothesis Retrospective

expected: Worker が vtdd-vps-runner だけを echo すれば native WebSocket の subprotocol 不一致が解消する。\nactual: selector を追加し、bearer 派生 protocol を echo しない test を追加した。\nmismatch: production deploy と live handshake は未実施。\nlesson: machine auth fallback を subprotocol で渡す場合、server は公開 subprotocol だけを選択して返す必要がある。\nshould become RAG candidate: はい。

## Verification Evidence

- Unit: node --test test/worker.test.js --test-name-pattern "VPS runner WebSocket|subprotocol": pass, 159 tests. npm test 内 worker tests: pass.
- Integration: npm run build:worker: pass. npm test: pass, 888 pass / 1 skip. check:generated-worker: pass.
- E2E: 未実施。deploy 後に VPS service reconnect と iPhone dashboard live E2E が必要。
- Manual: VPS service は現行 production で handshake/reconnect 中。Worker 修正 deploy 後に再確認する。
- Evidence path/link: src/worker/runtime.js、src/worker.js、test/worker.test.js、worker.js

## Butler Completion Contract

- Owner goal: dashboard Butler の通常会話を VPS Codex CLI に直接届け、同じ chat thread に返信を戻す。
- Butler entrypoint: /dashboard の Butler chat composer。
- Action Schema exposure: 不要。dashboard UI / WebSocket runtime 経路であり Custom GPT Action Schema は未変更。
- Runtime path: Browser dashboard WebSocket -> DashboardChatRoom Durable Object -> connected VPS runner WebSocket。VPS runner machine auth fallback は request subprotocol、Worker response は vtdd-vps-runner のみ echo。
- Runner/runtime truth: local tests pass。production runtime は未deployのため未確認。
- Authority boundary: VPS runner WebSocket は machine bearer auth header または Sec-WebSocket-Protocol bearer fallback。response には bearer 派生 protocol を返さない。
- E2E evidence: 未実施。deploy 後に iPhone dashboard から VPS Codex CLI reply を確認する。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 必要。merge 後に production deploy が必要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。deploy 後に必要。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate\nAGENTS.md Butler-First Operating Principle\nAGENTS.md Authority Boundary\nIssue #450 Success Criteria

## Out-of-scope but NOT implemented

- VPS env file 更新。\nVPS service 起動/停止。\nIssue #450 close 判定。\nCustom GPT Action Schema 更新。

## Extra changes (if any)

Node の test Response は status 101 を扱えないため、subprotocol selector を export して unit test で固定した。

<!-- VTDD metadata -->
- Issue: Issue #450
- Execution ID: mac-codex-issue450-dashboard-ws-subprotocol
- Goal: dashboard_vps_websocket_subprotocol_echo
