### PR TITLE
Fix dashboard WebSocket repository resolution

### DIFF
--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -215,9 +215,32 @@ export class DashboardChatRoom {
       }
       return;
     }
-    const repository = normalizeCanonicalRepositoryInput(payload?.repository || payload?.repositoryInput);
-    const relatedIssue = normalizePositiveInteger(payload?.relatedIssue || payload?.issueNumber);
+    const repositoryResolution = await resolveDashboardChatRepository({
+      payload: { ...normalizeObject(payload), text },
+      env: this.env
+    });
+    const repository = repositoryResolution.ok ? repositoryResolution.repository : "";
+    const relatedIssue =
+      normalizePositiveInteger(payload?.relatedIssue || payload?.issueNumber) || extractIssueNumberFromDashboardChatText(text);
     const now = new Date().toISOString();
+    if (!repositoryResolution.ok) {
+      const failedMessage = normalizeDashboardChatMessage(
+        {
+          threadId,
+          role: "system",
+          repository,
+          relatedIssue,
+          status: "failed",
+          text: repositoryResolution.reason,
+          createdAt: now
+        },
+        { threadId }
+      );
+      const store = resolveDashboardChatStore(this.env);
+      const messages = store ? await store.appendMany(threadId, [failedMessage]) : [failedMessage].filter(Boolean);
+      await this.broadcastThread({ threadId, messages });
+      return;
+    }
     const ownerMessage = normalizeDashboardChatMessage(
       {
         threadId,
@@ -249,6 +272,7 @@ export class DashboardChatRoom {
       type: "dashboard_chat_job",
       threadId,
       repository,
+      repositoryInput: repositoryResolution.input || payload?.repositoryInput || payload?.repository,
       relatedIssue,
       text,
       codexGoal: normalizeDashboardEventText(payload?.codexGoal || "dashboard_chat_triage"),
@@ -304,6 +328,7 @@ export class DashboardChatRoom {
       jobId: normalizeDashboardEventText(payload?.jobId) || crypto.randomUUID(),
       threadId: normalizeDashboardThreadId(payload?.threadId || payload?.thread_id),
       repository: normalizeCanonicalRepositoryInput(payload?.repository),
+      repositoryInput: normalizeDashboardEventText(payload?.repositoryInput || payload?.repository_input),
       relatedIssue: normalizePositiveInteger(payload?.relatedIssue || payload?.issueNumber),
       text: sanitizeDashboardChatText(payload?.text || payload?.message || payload?.body),
       codexGoal: normalizeDashboardEventText(payload?.codexGoal || "dashboard_chat_triage"),

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -1100,6 +1100,80 @@ test("DashboardChatRoom pushes owner messages to a runner socket in the same thr
   assert.equal(broadcast.messages[1].status, "thinking");
 });
 
+test("DashboardChatRoom resolves repository nicknames before pushing unresolved-thread owner messages", async () => {
+  const provider = createInMemoryMemoryProvider();
+  await provider.store({
+    id: "alias_registry:marushu/vtdd-v2-p",
+    type: MemoryRecordType.ALIAS_REGISTRY,
+    content: {
+      canonicalRepo: "marushu/vtdd-v2-p",
+      aliases: ["ぶい", "vtdd"]
+    },
+    metadata: { source: "test" },
+    priority: 60,
+    tags: ["alias_registry", "marushu/vtdd-v2-p"],
+    createdAt: "2026-05-20T00:00:00.000Z"
+  });
+  const store = createInMemoryDashboardChatStore();
+  const dashboardSocket = createMockSocket("dashboard", "dashboard-main-unresolved");
+  const runnerSocket = createMockSocket("vps_runner", "dashboard-main-unresolved");
+  const room = new DashboardChatRoom(
+    {
+      getWebSockets() {
+        return [dashboardSocket, runnerSocket];
+      }
+    },
+    { DASHBOARD_CHAT_STORE: store, MEMORY_PROVIDER: provider }
+  );
+
+  await room.webSocketMessage(
+    dashboardSocket,
+    JSON.stringify({
+      type: "owner_message",
+      threadId: "dashboard-main-unresolved",
+      text: "ぶい #450 の残りを短く返して"
+    })
+  );
+
+  assert.equal(runnerSocket.sent.length, 1);
+  const job = JSON.parse(runnerSocket.sent[0]);
+  assert.equal(job.threadId, "dashboard-main-unresolved");
+  assert.equal(job.repository, "marushu/vtdd-v2-p");
+  assert.equal(job.repositoryInput, "ぶい");
+  assert.equal(job.relatedIssue, 450);
+});
+
+test("DashboardChatRoom blocks unresolved repository owner messages before VPS handoff", async () => {
+  const store = createInMemoryDashboardChatStore();
+  const dashboardSocket = createMockSocket("dashboard", "dashboard-main-unresolved");
+  const runnerSocket = createMockSocket("vps_runner", "dashboard-main-unresolved");
+  const room = new DashboardChatRoom(
+    {
+      getWebSockets() {
+        return [dashboardSocket, runnerSocket];
+      }
+    },
+    { DASHBOARD_CHAT_STORE: store, MEMORY_PROVIDER: createInMemoryMemoryProvider() }
+  );
+
+  await room.webSocketMessage(
+    dashboardSocket,
+    JSON.stringify({
+      type: "owner_message",
+      threadId: "dashboard-main-unresolved",
+      text: "VPS Codex CLI 疎通テスト。今の #450 の残りを短く返して。"
+    })
+  );
+
+  assert.equal(runnerSocket.sent.length, 0);
+  assert.equal(dashboardSocket.sent.length, 1);
+  const broadcast = JSON.parse(dashboardSocket.sent[0]);
+  assert.equal(broadcast.messages.length, 1);
+  assert.equal(broadcast.messages[0].status, "failed");
+  assert.equal(broadcast.messages[0].text.includes("対象 repository"), true);
+  assert.equal(broadcast.messages[0].relatedIssue, 450);
+});
+
 test("DashboardChatRoom broadcasts VPS runner replies to dashboard sockets in the same thread room", async () => {
   const store = createInMemoryDashboardChatStore();
   const dashboardSocket = createMockSocket("dashboard", "dashboard-main-marushu-vtdd-v2-p");

--- a/worker.js
+++ b/worker.js
@@ -55967,9 +55967,31 @@ var DashboardChatRoom = class {
       }
       return;
     }
-    const repository = normalizeCanonicalRepositoryInput(payload?.repository || payload?.repositoryInput);
-    const relatedIssue = normalizePositiveInteger9(payload?.relatedIssue || payload?.issueNumber);
+    const repositoryResolution = await resolveDashboardChatRepository({
+      payload: { ...normalizeObject11(payload), text },
+      env: this.env
+    });
+    const repository = repositoryResolution.ok ? repositoryResolution.repository : "";
+    const relatedIssue = normalizePositiveInteger9(payload?.relatedIssue || payload?.issueNumber) || extractIssueNumberFromDashboardChatText(text);
     const now = (/* @__PURE__ */ new Date()).toISOString();
+    if (!repositoryResolution.ok) {
+      const failedMessage = normalizeDashboardChatMessage(
+        {
+          threadId,
+          role: "system",
+          repository,
+          relatedIssue,
+          status: "failed",
+          text: repositoryResolution.reason,
+          createdAt: now
+        },
+        { threadId }
+      );
+      const store2 = resolveDashboardChatStore(this.env);
+      const messages2 = store2 ? await store2.appendMany(threadId, [failedMessage]) : [failedMessage].filter(Boolean);
+      await this.broadcastThread({ threadId, messages: messages2 });
+      return;
+    }
     const ownerMessage = normalizeDashboardChatMessage(
       {
         threadId,
@@ -56001,6 +56023,7 @@ var DashboardChatRoom = class {
       type: "dashboard_chat_job",
       threadId,
       repository,
+      repositoryInput: repositoryResolution.input || payload?.repositoryInput || payload?.repository,
       relatedIssue,
       text,
       codexGoal: normalizeDashboardEventText(payload?.codexGoal || "dashboard_chat_triage"),
@@ -56054,6 +56077,7 @@ var DashboardChatRoom = class {
       jobId: normalizeDashboardEventText(payload?.jobId) || crypto.randomUUID(),
       threadId: normalizeDashboardThreadId(payload?.threadId || payload?.thread_id),
       repository: normalizeCanonicalRepositoryInput(payload?.repository),
+      repositoryInput: normalizeDashboardEventText(payload?.repositoryInput || payload?.repository_input),
       relatedIssue: normalizePositiveInteger9(payload?.relatedIssue || payload?.issueNumber),
       text: sanitizeDashboardChatText(payload?.text || payload?.message || payload?.body),
       codexGoal: normalizeDashboardEventText(payload?.codexGoal || "dashboard_chat_triage"),


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #450 の dashboard Butler WebSocket 送信で、POST 経路と同じ repository / nickname 解決を行い、空 repository を VPS Codex CLI に渡さないようにする。

## Satisfied Success Criteria

- dashboard WebSocket owner_message が repositoryInput / nickname / 文頭 alias を canonical repository に解決してから dashboard_chat_job を runner に push する。
- repository 未解決時は VPS Codex CLI に投げず、同じ thread に日本語の失敗 message を保存・broadcast する。
- #450 など本文内 issue number を WebSocket 経路でも relatedIssue に反映する。

## Unsatisfied Success Criteria

- 本番 deploy と iPhone live E2E はこの PR merge 後に別途必要。Issue #450 全体の完了判断はまだしない。

## Non-goal violations

production deploy、VPS service 設定変更、secret / permission 変更、Issue close はこの PR では行わない。

## Dry-run Impact Report

- Target Issue: Issue #450
- Implementing Success Criteria: dashboard Butler WebSocket の owner_message が repo/nickname 解決済み payload だけを VPS runner に渡す。未解決 target は Worker 側で止めて日本語で表示する。
- Explicit Non-goals: production deploy、VPS systemd 更新、credential mutation、Issue close。
- Expected touched files/routes/workflows: src/worker/runtime.js、test/worker.test.js、worker.js。
- Affected Issues: #450。
- Affected PRs: なし。
- Affected workflows: GitHub Actions の通常 test / generated-worker check。workflow 定義は変更しない。
- Affected runtime/operator surfaces: Cloudflare Worker dashboard WebSocket runtime、VPS runner push payload、iPhone dashboard chat 表示。
- What may break if we patch narrowly: POST 経路と WebSocket 経路の repository 解決が再び乖離すると、VPS 側で repository_not_allowlisted だけが見える。
- Unknowns to investigate before coding: なし。現象は runtime.js の acceptOwnerMessage が resolveDashboardChatRepository を通っていないことで説明できる。
- Validation needed: DashboardChatRoom WebSocket unit と npm test。merge 後に deploy と iPhone live E2E が必要。
- Stop condition: default repository を暗黙導入する必要が出た場合は No default repository invariant に反するため停止する。

## File / Line Hypotheses

- file: `src/worker/runtime.js`
  - hypothesis: `DashboardChatRoom.acceptOwnerMessage` が `resolveDashboardChatRepository` を呼ばず、payload の repositoryInput だけを canonical 正規化しているため、未指定 thread から空 repository が VPS に渡る。
  - risk if changed narrowly: POST 経路との差分が残ると同じ failure が再発する。
  - validation: DashboardChatRoom WebSocket tests で alias 解決 happy path と未解決 boundary path を追加する。
  - related Issue: #450

## Hypothesis Retrospective

- expected: WebSocket owner_message でも alias `ぶい` が `marushu/vtdd-v2-p` に解決され、未解決なら VPS 送信前に画面へ failed message が出る。
- actual: `node --test test/worker.test.js --test-name-pattern DashboardChatRoom` と `npm test` で確認済み。
- mismatch: なし。
- lesson: dashboard chat は POST と WebSocket の repository resolution を同じ contract に寄せる必要がある。
- should become RAG candidate: はい。Issue #450 の WebSocket 経路再発防止候補。

## Verification Evidence

- Unit: node --test test/worker.test.js --test-name-pattern DashboardChatRoom: pass。npm test: pass。
- Integration: npm test 内の check:self-parity と check:generated-worker: pass。
- E2E: 未実施。merge / deploy 後に iPhone dashboard から `ぶい #450 ...` で live E2E が必要。
- Manual: 未実施。
- Evidence path/link: この PR の checks と追加テスト。

## Butler Completion Contract

- Owner goal: iPhone dashboard Butler から repo/nickname 付き自然文を送れば VPS Codex CLI に正しい repository で push され、未指定なら意味のある日本語 failure が返る。
- Butler entrypoint: Dashboard Butler chat WebSocket owner_message。
- Action Schema exposure: 不要。Custom GPT Action Schema は未変更。
- Runtime path: Cloudflare Worker DashboardChatRoom.acceptOwnerMessage -> resolveDashboardChatRepository -> pushVpsRunnerJob。
- Runner/runtime truth: runner job payload に canonical repository / repositoryInput / relatedIssue を含める。未解決時は failed message を thread に保存・broadcast し、VPS には送らない。
- Authority boundary: 未変更。新しい high-risk authority は追加していない。default repository も追加していない。
- E2E evidence: 未実施。deploy 後に iPhone dashboard live E2E が必要。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: merge 後に必要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: merge / deploy 後に必要。

## Related Constitution Rules

- No default repository。
- Unresolved target blocks execution。
- Owner-facing operational guidance is Japanese by default。
- Butler Completion Gate。

## Out-of-scope but NOT implemented

- default repository の導入。
- VPS service / credential 設定変更。
- Issue #450 close。

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #450
- Execution ID: mac-codex-issue-450-dashboard-ws-repo-resolution
- Goal: dashboard_ws_repository_resolution
