### PR TITLE
Add dashboard reply copy and preserve chat history

### DIFF
--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -8464,7 +8464,6 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
       let reconnectAttempt = 0;
       let refreshingThread = false;
       const messagesById = new Map();
-      let syntheticMessageIndex = 0;
 
       function updateComposerReserve() {
         log.style.setProperty("--composer-reserve", Math.ceil(form.getBoundingClientRect().height) + "px");
@@ -8563,13 +8562,23 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
 
       function messageKey(message) {
         if (message && message.messageId) return String(message.messageId);
-        syntheticMessageIndex += 1;
-        return "local-" + syntheticMessageIndex;
+        return [
+          message?.role || "system",
+          message?.status || "sent",
+          message?.createdAt || "",
+          message?.repository || "",
+          message?.relatedIssue || "",
+          message?.text || ""
+        ].join("\\u001f");
       }
 
-      function renderThread(messages) {
+      function renderThread(messages, options = {}) {
+        const replace = options.replace === true;
+        if (replace) {
+          messagesById.clear();
+        }
         if (!Array.isArray(messages) || messages.length === 0) {
-          if (messagesById.size === 0) {
+          if (replace || messagesById.size === 0) {
             log.innerHTML = initialMarkup;
           }
           scrollToLatest();
@@ -8599,7 +8608,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           }
           const body = await response.json();
           if (body && body.ok) {
-            renderThread(body.messages || []);
+            renderThread(body.messages || [], { replace: true });
           }
         } catch {
           setStatus("履歴の再取得に失敗しました。WebSocket を再接続しています。");
@@ -8640,7 +8649,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           try {
             const body = JSON.parse(event.data || "{}");
             if (body.type === "thread" && body.ok) {
-              renderThread(body.messages || []);
+              renderThread(body.messages || [], { replace: false });
             } else if (body.type === "error") {
               appendError(body.reason || "WebSocket message error");
             }

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -8234,8 +8234,12 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
     .chat-scroll { min-height: 0; overflow: auto; padding: 8px 4px 28px; scroll-padding-bottom: 28px; display: flex; flex-direction: column; gap: 22px; scrollbar-width: thin; }
     .bubble { max-width: min(760px, 88%); color: var(--text); font-size: 17px; line-height: 1.72; }
     .bubble, .bubble p, .bubble li { overflow-wrap: anywhere; }
+    .bubble-header { display: flex; align-items: center; gap: 10px; margin-bottom: 8px; }
     .bubble strong { display: block; color: var(--muted); font-size: 12px; letter-spacing: .08em; text-transform: uppercase; margin-bottom: 8px; }
+    .bubble-header strong { margin-bottom: 0; }
     .bubble p { color: var(--text); margin-bottom: 12px; white-space: pre-wrap; }
+    .copy-message { display: inline-flex; align-items: center; justify-content: center; width: 30px; height: 30px; border: 1px solid var(--border); border-radius: 999px; background: var(--button); color: var(--text); font-size: 15px; line-height: 1; cursor: pointer; }
+    .copy-message:focus-visible { outline: 2px solid var(--text); outline-offset: 2px; }
     .bubble ul { margin: 0; padding-left: 22px; color: var(--text); line-height: 1.85; }
     .bubble.owner { align-self: flex-end; background: var(--owner-bubble); color: var(--owner-text); border-radius: 24px; padding: 12px 16px; }
     .bubble.owner p { color: var(--owner-text); margin: 0; }
@@ -8459,6 +8463,8 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
       let reconnectTimer = null;
       let reconnectAttempt = 0;
       let refreshingThread = false;
+      const messagesById = new Map();
+      let syntheticMessageIndex = 0;
 
       function updateComposerReserve() {
         log.style.setProperty("--composer-reserve", Math.ceil(form.getBoundingClientRect().height) + "px");
@@ -8480,9 +8486,20 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         const article = document.createElement("article");
         article.className = message.role === "owner" ? "bubble owner" : "bubble";
         if (message.role !== "owner") {
+          const header = document.createElement("div");
+          header.className = "bubble-header";
           const strong = document.createElement("strong");
           strong.textContent = message.role === "runner" ? "VPS Codex CLI" : message.role === "system" ? "SYSTEM" : "Butler";
-          article.appendChild(strong);
+          header.appendChild(strong);
+          const copyButton = document.createElement("button");
+          copyButton.className = "copy-message";
+          copyButton.type = "button";
+          copyButton.textContent = "⧉";
+          copyButton.setAttribute("aria-label", "返信をコピー");
+          copyButton.title = "返信をコピー";
+          copyButton.addEventListener("click", () => copyMessageText(copyButton, message.text || ""));
+          header.appendChild(copyButton);
+          article.appendChild(header);
         }
         const paragraph = document.createElement("p");
         renderMessageText(paragraph, message.text || "（空のメッセージ）");
@@ -8514,18 +8531,55 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         }
       }
 
+      async function copyMessageText(button, text) {
+        const source = String(text || "");
+        try {
+          if (navigator.clipboard && window.isSecureContext) {
+            await navigator.clipboard.writeText(source);
+          } else {
+            const copySource = document.createElement("textarea");
+            copySource.value = source;
+            copySource.setAttribute("readonly", "");
+            copySource.style.position = "fixed";
+            copySource.style.left = "-9999px";
+            document.body.appendChild(copySource);
+            copySource.select();
+            document.execCommand("copy");
+            copySource.remove();
+          }
+          const previous = button.textContent;
+          button.textContent = "✓";
+          window.setTimeout(() => {
+            button.textContent = previous;
+          }, 1200);
+        } catch {
+          setStatus("コピーに失敗しました。長押しで本文を選択してください。");
+        }
+      }
+
       function appendError(text) {
         appendMessage({ role: "butler", text });
       }
 
+      function messageKey(message) {
+        if (message && message.messageId) return String(message.messageId);
+        syntheticMessageIndex += 1;
+        return "local-" + syntheticMessageIndex;
+      }
+
       function renderThread(messages) {
         if (!Array.isArray(messages) || messages.length === 0) {
-          log.innerHTML = initialMarkup;
+          if (messagesById.size === 0) {
+            log.innerHTML = initialMarkup;
+          }
           scrollToLatest();
           return;
         }
-        log.replaceChildren();
         for (const message of messages) {
+          messagesById.set(messageKey(message), message);
+        }
+        log.replaceChildren();
+        for (const message of messagesById.values()) {
           appendMessage(message);
         }
         scrollToLatest();

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -498,6 +498,10 @@ test("worker serves v2 dashboard for allowed owner identity without exposing sec
   assert.equal(body.includes('className = "copy-message"'), true);
   assert.equal(body.includes("const messagesById = new Map()"), true);
   assert.equal(body.includes("messagesById.set(messageKey(message), message)"), true);
+  assert.equal(body.includes("messagesById.clear()"), true);
+  assert.equal(body.includes("message?.createdAt"), true);
+  assert.equal(body.includes('renderThread(body.messages || [], { replace: true })'), true);
+  assert.equal(body.includes('renderThread(body.messages || [], { replace: false })'), true);
   assert.equal(body.includes("white-space: pre-wrap"), true);
   assert.equal(body.includes("urlPattern"), true);
   assert.equal(body.includes('link.className = "chat-link"'), true);

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -492,6 +492,12 @@ test("worker serves v2 dashboard for allowed owner identity without exposing sec
   assert.equal(body.includes("function showThinking()"), false);
   assert.equal(body.includes("function removeThinking("), false);
   assert.equal(body.includes("function renderMessageText("), true);
+  assert.equal(body.includes("function copyMessageText("), true);
+  assert.equal(body.includes("navigator.clipboard.writeText"), true);
+  assert.equal(body.includes("返信をコピー"), true);
+  assert.equal(body.includes('className = "copy-message"'), true);
+  assert.equal(body.includes("const messagesById = new Map()"), true);
+  assert.equal(body.includes("messagesById.set(messageKey(message), message)"), true);
   assert.equal(body.includes("white-space: pre-wrap"), true);
   assert.equal(body.includes("urlPattern"), true);
   assert.equal(body.includes('link.className = "chat-link"'), true);

--- a/worker.js
+++ b/worker.js
@@ -63177,7 +63177,6 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
       let reconnectAttempt = 0;
       let refreshingThread = false;
       const messagesById = new Map();
-      let syntheticMessageIndex = 0;
 
       function updateComposerReserve() {
         log.style.setProperty("--composer-reserve", Math.ceil(form.getBoundingClientRect().height) + "px");
@@ -63276,13 +63275,23 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
 
       function messageKey(message) {
         if (message && message.messageId) return String(message.messageId);
-        syntheticMessageIndex += 1;
-        return "local-" + syntheticMessageIndex;
+        return [
+          message?.role || "system",
+          message?.status || "sent",
+          message?.createdAt || "",
+          message?.repository || "",
+          message?.relatedIssue || "",
+          message?.text || ""
+        ].join("\\u001f");
       }
 
-      function renderThread(messages) {
+      function renderThread(messages, options = {}) {
+        const replace = options.replace === true;
+        if (replace) {
+          messagesById.clear();
+        }
         if (!Array.isArray(messages) || messages.length === 0) {
-          if (messagesById.size === 0) {
+          if (replace || messagesById.size === 0) {
             log.innerHTML = initialMarkup;
           }
           scrollToLatest();
@@ -63312,7 +63321,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           }
           const body = await response.json();
           if (body && body.ok) {
-            renderThread(body.messages || []);
+            renderThread(body.messages || [], { replace: true });
           }
         } catch {
           setStatus("\u5C65\u6B74\u306E\u518D\u53D6\u5F97\u306B\u5931\u6557\u3057\u307E\u3057\u305F\u3002WebSocket \u3092\u518D\u63A5\u7D9A\u3057\u3066\u3044\u307E\u3059\u3002");
@@ -63353,7 +63362,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           try {
             const body = JSON.parse(event.data || "{}");
             if (body.type === "thread" && body.ok) {
-              renderThread(body.messages || []);
+              renderThread(body.messages || [], { replace: false });
             } else if (body.type === "error") {
               appendError(body.reason || "WebSocket message error");
             }

--- a/worker.js
+++ b/worker.js
@@ -62947,8 +62947,12 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
     .chat-scroll { min-height: 0; overflow: auto; padding: 8px 4px 28px; scroll-padding-bottom: 28px; display: flex; flex-direction: column; gap: 22px; scrollbar-width: thin; }
     .bubble { max-width: min(760px, 88%); color: var(--text); font-size: 17px; line-height: 1.72; }
     .bubble, .bubble p, .bubble li { overflow-wrap: anywhere; }
+    .bubble-header { display: flex; align-items: center; gap: 10px; margin-bottom: 8px; }
     .bubble strong { display: block; color: var(--muted); font-size: 12px; letter-spacing: .08em; text-transform: uppercase; margin-bottom: 8px; }
+    .bubble-header strong { margin-bottom: 0; }
     .bubble p { color: var(--text); margin-bottom: 12px; white-space: pre-wrap; }
+    .copy-message { display: inline-flex; align-items: center; justify-content: center; width: 30px; height: 30px; border: 1px solid var(--border); border-radius: 999px; background: var(--button); color: var(--text); font-size: 15px; line-height: 1; cursor: pointer; }
+    .copy-message:focus-visible { outline: 2px solid var(--text); outline-offset: 2px; }
     .bubble ul { margin: 0; padding-left: 22px; color: var(--text); line-height: 1.85; }
     .bubble.owner { align-self: flex-end; background: var(--owner-bubble); color: var(--owner-text); border-radius: 24px; padding: 12px 16px; }
     .bubble.owner p { color: var(--owner-text); margin: 0; }
@@ -63172,6 +63176,8 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
       let reconnectTimer = null;
       let reconnectAttempt = 0;
       let refreshingThread = false;
+      const messagesById = new Map();
+      let syntheticMessageIndex = 0;
 
       function updateComposerReserve() {
         log.style.setProperty("--composer-reserve", Math.ceil(form.getBoundingClientRect().height) + "px");
@@ -63193,9 +63199,20 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         const article = document.createElement("article");
         article.className = message.role === "owner" ? "bubble owner" : "bubble";
         if (message.role !== "owner") {
+          const header = document.createElement("div");
+          header.className = "bubble-header";
           const strong = document.createElement("strong");
           strong.textContent = message.role === "runner" ? "VPS Codex CLI" : message.role === "system" ? "SYSTEM" : "Butler";
-          article.appendChild(strong);
+          header.appendChild(strong);
+          const copyButton = document.createElement("button");
+          copyButton.className = "copy-message";
+          copyButton.type = "button";
+          copyButton.textContent = "\u29C9";
+          copyButton.setAttribute("aria-label", "\u8FD4\u4FE1\u3092\u30B3\u30D4\u30FC");
+          copyButton.title = "\u8FD4\u4FE1\u3092\u30B3\u30D4\u30FC";
+          copyButton.addEventListener("click", () => copyMessageText(copyButton, message.text || ""));
+          header.appendChild(copyButton);
+          article.appendChild(header);
         }
         const paragraph = document.createElement("p");
         renderMessageText(paragraph, message.text || "\uFF08\u7A7A\u306E\u30E1\u30C3\u30BB\u30FC\u30B8\uFF09");
@@ -63227,18 +63244,55 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         }
       }
 
+      async function copyMessageText(button, text) {
+        const source = String(text || "");
+        try {
+          if (navigator.clipboard && window.isSecureContext) {
+            await navigator.clipboard.writeText(source);
+          } else {
+            const copySource = document.createElement("textarea");
+            copySource.value = source;
+            copySource.setAttribute("readonly", "");
+            copySource.style.position = "fixed";
+            copySource.style.left = "-9999px";
+            document.body.appendChild(copySource);
+            copySource.select();
+            document.execCommand("copy");
+            copySource.remove();
+          }
+          const previous = button.textContent;
+          button.textContent = "\u2713";
+          window.setTimeout(() => {
+            button.textContent = previous;
+          }, 1200);
+        } catch {
+          setStatus("\u30B3\u30D4\u30FC\u306B\u5931\u6557\u3057\u307E\u3057\u305F\u3002\u9577\u62BC\u3057\u3067\u672C\u6587\u3092\u9078\u629E\u3057\u3066\u304F\u3060\u3055\u3044\u3002");
+        }
+      }
+
       function appendError(text) {
         appendMessage({ role: "butler", text });
       }
 
+      function messageKey(message) {
+        if (message && message.messageId) return String(message.messageId);
+        syntheticMessageIndex += 1;
+        return "local-" + syntheticMessageIndex;
+      }
+
       function renderThread(messages) {
         if (!Array.isArray(messages) || messages.length === 0) {
-          log.innerHTML = initialMarkup;
+          if (messagesById.size === 0) {
+            log.innerHTML = initialMarkup;
+          }
           scrollToLatest();
           return;
         }
-        log.replaceChildren();
         for (const message of messages) {
+          messagesById.set(messageKey(message), message);
+        }
+        log.replaceChildren();
+        for (const message of messagesById.values()) {
           appendMessage(message);
         }
         scrollToLatest();


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #450 の dashboard chat UX 追加修正として、VPS Codex CLI / Butler / SYSTEM 返信をコピーできるようにし、WebSocket 差分更新で過去コメントが消えないようにする。

## Satisfied Success Criteria

- 返信 bubble にコピー按钮を追加し、Clipboard API と fallback copy を用意した。
- WebSocket で届く追加 message を messageId で既存履歴に merge し、送信後や返信後に過去コメントが消えないようにした。
- 既存のリンク化と改行保持は維持した。

## Unsatisfied Success Criteria

- 本番 deploy と iPhone live E2E は merge 後に必要。Issue #450 全体の close 判断はまだ行わない。

## Non-goal violations

VPS runner 通信、repository 解決、secret / permission、production deploy、Issue close はこの PR では行わない。

## Dry-run Impact Report

- Target Issue: Issue #450
- Implementing Success Criteria: dashboard chat 返信をワンタップでコピーできる。WebSocket 差分受信後も thread の過去コメントが残る。
- Explicit Non-goals: runner 経路変更、repo 解決変更、deploy、credential mutation、Issue close。
- Expected touched files/routes/workflows: src/worker/runtime.js、test/worker.test.js、worker.js。
- Affected Issues: #450。
- Affected PRs: なし。
- Affected workflows: 通常 CI の test / generated-worker check。workflow 定義は変更しない。
- Affected runtime/operator surfaces: Cloudflare Worker dashboard HTML / CSS / browser JS。
- What may break if we patch narrowly: 差分 WebSocket message を全履歴として扱うと過去コメントが消える。messageId merge が崩れると重複や欠落が出る。
- Unknowns to investigate before coding: なし。実装前確認で renderThread が `log.replaceChildren()` していることを確認済み。
- Validation needed: dashboard 表示テスト、node --check、npm test。merge 後に iPhone live E2E。
- Stop condition: UI 修正を超えて runner protocol や default repo の挙動変更が必要になった場合は停止する。

## File / Line Hypotheses

- file: `src/worker/runtime.js`
  - hypothesis: browser JS の `renderThread` が WebSocket 追加分でも `log.replaceChildren()` するため、送信後に過去コメントが消える。
  - risk if changed narrowly: messageId で merge しないと過去履歴保持と重複防止を両立できない。
  - validation: dashboard HTML テストで copy handler と message map を確認し、npm test を通す。
  - related Issue: #450

## Hypothesis Retrospective

- expected: copy button が返信に表示され、WebSocket 差分更新後も過去コメントが残る。
- actual: `node --test test/worker.test.js --test-name-pattern dashboard|DashboardChatRoom` と `npm test` で確認済み。
- mismatch: live iPhone E2E は deploy 後。
- lesson: WebSocket payload が差分か全量かを UI 側で破壊的に扱わない。
- should become RAG candidate: はい。dashboard chat 差分描画の再発防止候補。

## Verification Evidence

- Unit: node --test test/worker.test.js --test-name-pattern dashboard|DashboardChatRoom: pass。npm test: pass。
- Integration: npm test 内の check:self-parity と check:generated-worker: pass。
- E2E: 未実施。merge / deploy 後に iPhone dashboard でコピー按钮と履歴保持を確認する。
- Manual: 未実施。
- Evidence path/link: この PR の checks と追加表示テスト。

## Butler Completion Contract

- Owner goal: iPhone dashboard Butler で VPS Codex CLI 返信をコピーでき、送信や返信のたびに過去コメントが消えない。
- Butler entrypoint: Dashboard Butler chat page。
- Action Schema exposure: 不要。Custom GPT Action Schema は未変更。
- Runtime path: Cloudflare Worker renderV2DashboardPage の browser JS / CSS。
- Runner/runtime truth: UI 表示変更のみ。runner/runtime event payload は変更しない。
- Authority boundary: 未変更。新しい high-risk authority は追加していない。
- E2E evidence: 未実施。deploy 後に iPhone dashboard live E2E が必要。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: merge 後に必要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: merge / deploy 後に必要。

## Related Constitution Rules

- Butler Completion Gate。
- Conversation UX Contract。
- No unrelated refactors。
- Evidence Discipline。

## Out-of-scope but NOT implemented

- VPS runner protocol 変更。
- repository resolution 変更。
- Issue #450 close。

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #450
- Execution ID: mac-codex-issue-450-dashboard-copy-replies
- Goal: dashboard_chat_copy_and_history_retention
