### PR TITLE
Add dashboard Butler input classification

### DIFF
--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -215,15 +215,79 @@ export class DashboardChatRoom {
       }
       return;
     }
-    const repositoryResolution = await resolveDashboardChatRepository({
-      payload: { ...normalizeObject(payload), text },
-      env: this.env
-    });
-    const repository = repositoryResolution.ok ? repositoryResolution.repository : "";
     const relatedIssue =
       normalizePositiveInteger(payload?.relatedIssue || payload?.issueNumber) || extractIssueNumberFromDashboardChatText(text);
     const now = new Date().toISOString();
+    const store = resolveDashboardChatStore(this.env);
+    const nicknameListTurn = await buildDashboardRepositoryNicknameListTurn({
+      payload: { ...normalizeObject(payload), text, threadId },
+      env: this.env
+    });
+    if (nicknameListTurn) {
+      const ownerMessage = normalizeDashboardChatMessage(
+        {
+          threadId: nicknameListTurn.threadId,
+          role: "owner",
+          relatedIssue,
+          status: "sent",
+          text,
+          createdAt: now
+        },
+        { threadId: nicknameListTurn.threadId }
+      );
+      const replyMessages = nicknameListTurn.messages.filter((message) => message.role !== "owner");
+      const messages = store
+        ? await store.appendMany(nicknameListTurn.threadId, [ownerMessage, ...replyMessages])
+        : [ownerMessage, ...replyMessages].filter(Boolean);
+      await this.broadcastThread({ threadId: nicknameListTurn.threadId, messages });
+      return;
+    }
+    const localReply = buildDashboardLocalButlerReply(text);
+    if (localReply) {
+      const ownerMessage = normalizeDashboardChatMessage(
+        {
+          threadId,
+          role: "owner",
+          relatedIssue,
+          status: "sent",
+          text,
+          createdAt: now
+        },
+        { threadId }
+      );
+      const butlerMessage = normalizeDashboardChatMessage(
+        {
+          threadId,
+          role: "butler",
+          relatedIssue,
+          status: "replied",
+          text: localReply,
+          createdAt: new Date(Date.parse(now) + 1).toISOString()
+        },
+        { threadId }
+      );
+      const messages = store ? await store.appendMany(threadId, [ownerMessage, butlerMessage]) : [ownerMessage, butlerMessage].filter(Boolean);
+      await this.broadcastThread({ threadId, messages });
+      return;
+    }
+    const repositoryResolution = await resolveDashboardChatRepository({
+      payload: { ...normalizeObject(payload), text, threadId },
+      env: this.env
+    });
+    const repository = repositoryResolution.ok ? repositoryResolution.repository : "";
     if (!repositoryResolution.ok) {
+      const ownerMessage = normalizeDashboardChatMessage(
+        {
+          threadId,
+          role: "owner",
+          repository,
+          relatedIssue,
+          status: "sent",
+          text,
+          createdAt: now
+        },
+        { threadId }
+      );
       const failedMessage = normalizeDashboardChatMessage(
         {
           threadId,
@@ -236,8 +300,7 @@ export class DashboardChatRoom {
         },
         { threadId }
       );
-      const store = resolveDashboardChatStore(this.env);
-      const messages = store ? await store.appendMany(threadId, [failedMessage]) : [failedMessage].filter(Boolean);
+      const messages = store ? await store.appendMany(threadId, [ownerMessage, failedMessage]) : [ownerMessage, failedMessage].filter(Boolean);
       await this.broadcastThread({ threadId, messages });
       return;
     }
@@ -265,7 +328,6 @@ export class DashboardChatRoom {
       },
       { threadId }
     );
-    const store = resolveDashboardChatStore(this.env);
     const messages = store ? await store.appendMany(threadId, [ownerMessage, thinkingMessage]) : [ownerMessage, thinkingMessage].filter(Boolean);
     await this.broadcastThread({ threadId, messages });
     const pushed = await this.pushVpsRunnerJob({
@@ -5465,6 +5527,18 @@ async function resolveDashboardChatRepository({ payload, env }) {
     };
   }
   if (!rawRepositoryInput) {
+    const threadContextRepository = await resolveDashboardThreadContextRepository({
+      threadId: input.threadId || input.thread_id,
+      env
+    });
+    if (threadContextRepository) {
+      return {
+        ok: true,
+        repository: threadContextRepository,
+        input: threadContextRepository,
+        via: "thread_context"
+      };
+    }
     return {
       ok: false,
       status: 422,
@@ -5505,6 +5579,51 @@ async function resolveDashboardChatRepository({ payload, env }) {
   };
 }
 
+async function resolveDashboardThreadContextRepository({ threadId, env } = {}) {
+  const normalizedThreadId = normalizeDashboardThreadId(threadId);
+  if (!normalizedThreadId) {
+    return "";
+  }
+  const store = resolveDashboardChatStore(env);
+  if (!store || typeof store.listThread !== "function") {
+    return "";
+  }
+  try {
+    const messages = await store.listThread(normalizedThreadId, { limit: 20 });
+    const latestWithRepository = [...(Array.isArray(messages) ? messages : [])]
+      .reverse()
+      .find((message) => normalizeCanonicalRepositoryInput(message?.repository));
+    return normalizeCanonicalRepositoryInput(latestWithRepository?.repository);
+  } catch {
+    return "";
+  }
+}
+
+function buildDashboardLocalButlerReply(value) {
+  const text = sanitizeDashboardChatText(value);
+  if (!text) {
+    return "";
+  }
+  if (/(君|あなた|お前|butler|Butler|VTDD).{0,8}(誰|だれ|何者)|^(誰|だれ)ですか|who are you/i.test(text)) {
+    return [
+      "私は VTDD Butler です。",
+      "iPhone / iPad からの自然文を受け取り、repo/nickname、Issue、PR、RAG、VPS Codex CLI、承認境界を交通整理します。",
+      "実装や調査が必要な依頼は、対象 repo を解決してから VPS Codex CLI に渡します。例: `ぶいの残りタスクを確認して`。"
+    ].join("\n");
+  }
+  if (/(何ができる|なにができる|使い方|ヘルプ|help|カスタムGPT.*できること|できること)/i.test(text)) {
+    return [
+      "この dashboard Butler では、自然文を次の入口に仕分けます。",
+      "- repo/nickname 付きの作業依頼: VPS Codex CLI に push します。",
+      "- `登録済みのニックネーム出して`: 登録済み alias を表示します。",
+      "- `君は誰？` / `何ができる？`: この画面で直接答えます。",
+      "- 同じ thread に repo 文脈が残っている場合: `進捗は？` のような続きの依頼もその repo 文脈で扱います。",
+      "高リスク操作、deploy、credential、merge、Issue close は passkey / GO 境界を越えない限り実行しません。"
+    ].join("\n");
+  }
+  return "";
+}
+
 async function notifyDashboardChatRoom({ env, threadId, messages }) {
   const room = resolveDashboardChatRoomStub(env, threadId);
   if (!room || typeof room.fetch !== "function") {
@@ -5534,7 +5653,7 @@ function extractRepositoryTokenFromDashboardChatText(value) {
   if (canonicalMatch) {
     return canonicalMatch[1];
   }
-  const nicknameMatch = text.match(/^[\s　]*([^\s　#「『【\\/:]+)(?:\s+|[　]*の|[　]*を|[　]*で|[　]*に)/u);
+  const nicknameMatch = text.match(/^[\s　]*([^\s　#「『【\\/:]+?)(?:\s+|[　]*の|[　]*を|[　]*で|[　]*に)/u);
   return normalizeDashboardEventText(nicknameMatch?.[1]);
 }
 

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -1153,6 +1153,47 @@ test("DashboardChatRoom resolves repository nicknames before pushing unresolved-
   assert.equal(job.relatedIssue, 450);
 });
 
+test("DashboardChatRoom resolves Japanese no-particle nickname requests before VPS handoff", async () => {
+  const provider = createInMemoryMemoryProvider();
+  await provider.store({
+    id: "alias_registry:marushu/vtdd-v2-p",
+    type: MemoryRecordType.ALIAS_REGISTRY,
+    content: {
+      canonicalRepo: "marushu/vtdd-v2-p",
+      aliases: ["ぶい", "vtdd"]
+    },
+    metadata: { source: "test" },
+    priority: 60,
+    tags: ["alias_registry", "marushu/vtdd-v2-p"],
+    createdAt: "2026-05-20T00:00:00.000Z"
+  });
+  const store = createInMemoryDashboardChatStore();
+  const dashboardSocket = createMockSocket("dashboard", "dashboard-main-unresolved");
+  const runnerSocket = createMockSocket("vps_runner", "dashboard-main-unresolved");
+  const room = new DashboardChatRoom(
+    {
+      getWebSockets() {
+        return [dashboardSocket, runnerSocket];
+      }
+    },
+    { DASHBOARD_CHAT_STORE: store, MEMORY_PROVIDER: provider }
+  );
+
+  await room.webSocketMessage(
+    dashboardSocket,
+    JSON.stringify({
+      type: "owner_message",
+      threadId: "dashboard-main-unresolved",
+      text: "ぶいの残りタスクを確認して"
+    })
+  );
+
+  assert.equal(runnerSocket.sent.length, 1);
+  const job = JSON.parse(runnerSocket.sent[0]);
+  assert.equal(job.repository, "marushu/vtdd-v2-p");
+  assert.equal(job.repositoryInput, "ぶい");
+});
+
 test("DashboardChatRoom blocks unresolved repository owner messages before VPS handoff", async () => {
   const store = createInMemoryDashboardChatStore();
   const dashboardSocket = createMockSocket("dashboard", "dashboard-main-unresolved");
@@ -1178,10 +1219,155 @@ test("DashboardChatRoom blocks unresolved repository owner messages before VPS h
   assert.equal(runnerSocket.sent.length, 0);
   assert.equal(dashboardSocket.sent.length, 1);
   const broadcast = JSON.parse(dashboardSocket.sent[0]);
-  assert.equal(broadcast.messages.length, 1);
-  assert.equal(broadcast.messages[0].status, "failed");
-  assert.equal(broadcast.messages[0].text.includes("対象 repository"), true);
-  assert.equal(broadcast.messages[0].relatedIssue, 450);
+  assert.equal(broadcast.messages.length, 2);
+  assert.equal(broadcast.messages[0].role, "owner");
+  assert.equal(broadcast.messages[0].text, "VPS Codex CLI 疎通テスト。今の #450 の残りを短く返して。");
+  assert.equal(broadcast.messages[1].status, "failed");
+  assert.equal(broadcast.messages[1].text.includes("対象 repository"), true);
+  assert.equal(broadcast.messages[1].relatedIssue, 450);
+});
+
+test("DashboardChatRoom answers local Butler identity questions without repository handoff", async () => {
+  const store = createInMemoryDashboardChatStore();
+  const dashboardSocket = createMockSocket("dashboard", "dashboard-main-unresolved");
+  const runnerSocket = createMockSocket("vps_runner", "dashboard-main-unresolved");
+  const room = new DashboardChatRoom(
+    {
+      getWebSockets() {
+        return [dashboardSocket, runnerSocket];
+      }
+    },
+    { DASHBOARD_CHAT_STORE: store, MEMORY_PROVIDER: createInMemoryMemoryProvider() }
+  );
+
+  await room.webSocketMessage(
+    dashboardSocket,
+    JSON.stringify({
+      type: "owner_message",
+      threadId: "dashboard-main-unresolved",
+      text: "君は誰？"
+    })
+  );
+
+  assert.equal(runnerSocket.sent.length, 0);
+  assert.equal(dashboardSocket.sent.length, 1);
+  const broadcast = JSON.parse(dashboardSocket.sent[0]);
+  assert.equal(broadcast.messages.length, 2);
+  assert.equal(broadcast.messages[0].role, "owner");
+  assert.equal(broadcast.messages[1].role, "butler");
+  assert.equal(broadcast.messages[1].text.includes("私は VTDD Butler です"), true);
+});
+
+test("DashboardChatRoom answers local capability questions without repository handoff", async () => {
+  const store = createInMemoryDashboardChatStore();
+  const dashboardSocket = createMockSocket("dashboard", "dashboard-main-unresolved");
+  const runnerSocket = createMockSocket("vps_runner", "dashboard-main-unresolved");
+  const room = new DashboardChatRoom(
+    {
+      getWebSockets() {
+        return [dashboardSocket, runnerSocket];
+      }
+    },
+    { DASHBOARD_CHAT_STORE: store, MEMORY_PROVIDER: createInMemoryMemoryProvider() }
+  );
+
+  await room.webSocketMessage(
+    dashboardSocket,
+    JSON.stringify({
+      type: "owner_message",
+      threadId: "dashboard-main-unresolved",
+      text: "何ができる？"
+    })
+  );
+
+  assert.equal(runnerSocket.sent.length, 0);
+  const broadcast = JSON.parse(dashboardSocket.sent[0]);
+  assert.equal(broadcast.messages.length, 2);
+  assert.equal(broadcast.messages[0].role, "owner");
+  assert.equal(broadcast.messages[1].role, "butler");
+  assert.equal(broadcast.messages[1].text.includes("自然文を次の入口に仕分けます"), true);
+});
+
+test("DashboardChatRoom uses same-thread repository context for follow-up owner messages", async () => {
+  const store = createInMemoryDashboardChatStore();
+  await store.appendMany("dashboard-main-unresolved", [
+    {
+      role: "runner",
+      repository: "marushu/vtdd-v2-p",
+      relatedIssue: 450,
+      status: "replied",
+      text: "Issue #450 の返答です。",
+      createdAt: "2026-05-21T00:00:00.000Z"
+    }
+  ]);
+  const dashboardSocket = createMockSocket("dashboard", "dashboard-main-unresolved");
+  const runnerSocket = createMockSocket("vps_runner", "dashboard-main-unresolved");
+  const room = new DashboardChatRoom(
+    {
+      getWebSockets() {
+        return [dashboardSocket, runnerSocket];
+      }
+    },
+    { DASHBOARD_CHAT_STORE: store, MEMORY_PROVIDER: createInMemoryMemoryProvider() }
+  );
+
+  await room.webSocketMessage(
+    dashboardSocket,
+    JSON.stringify({
+      type: "owner_message",
+      threadId: "dashboard-main-unresolved",
+      text: "進捗は？"
+    })
+  );
+
+  assert.equal(runnerSocket.sent.length, 1);
+  const job = JSON.parse(runnerSocket.sent[0]);
+  assert.equal(job.repository, "marushu/vtdd-v2-p");
+  assert.equal(job.repositoryInput, "marushu/vtdd-v2-p");
+  assert.equal(job.text, "進捗は？");
+});
+
+test("DashboardChatRoom returns nickname list without repository handoff", async () => {
+  const provider = createInMemoryMemoryProvider();
+  await provider.store({
+    id: "alias_registry:marushu/vtdd-v2-p",
+    type: MemoryRecordType.ALIAS_REGISTRY,
+    content: {
+      canonicalRepo: "marushu/vtdd-v2-p",
+      aliases: ["ぶい", "vtdd"]
+    },
+    metadata: { source: "test" },
+    priority: 60,
+    tags: ["alias_registry", "marushu/vtdd-v2-p"],
+    createdAt: "2026-05-20T00:00:00.000Z"
+  });
+  const store = createInMemoryDashboardChatStore();
+  const dashboardSocket = createMockSocket("dashboard", "dashboard-main-unresolved");
+  const runnerSocket = createMockSocket("vps_runner", "dashboard-main-unresolved");
+  const room = new DashboardChatRoom(
+    {
+      getWebSockets() {
+        return [dashboardSocket, runnerSocket];
+      }
+    },
+    { DASHBOARD_CHAT_STORE: store, MEMORY_PROVIDER: provider }
+  );
+
+  await room.webSocketMessage(
+    dashboardSocket,
+    JSON.stringify({
+      type: "owner_message",
+      threadId: "dashboard-main-unresolved",
+      text: "登録済みのニックネーム出して"
+    })
+  );
+
+  assert.equal(runnerSocket.sent.length, 0);
+  const broadcast = JSON.parse(dashboardSocket.sent[0]);
+  assert.equal(broadcast.messages.length, 2);
+  assert.equal(broadcast.messages[0].role, "owner");
+  assert.equal(broadcast.messages[1].text.includes("登録済みニックネームです。"), true);
+  assert.equal(broadcast.messages[1].text.includes("- marushu/vtdd-v2-p: ぶい, vtdd"), true);
 });
 
 test("DashboardChatRoom broadcasts VPS runner replies to dashboard sockets in the same thread room", async () => {

--- a/worker.js
+++ b/worker.js
@@ -55967,14 +55967,76 @@ var DashboardChatRoom = class {
       }
       return;
     }
+    const relatedIssue = normalizePositiveInteger9(payload?.relatedIssue || payload?.issueNumber) || extractIssueNumberFromDashboardChatText(text);
+    const now = (/* @__PURE__ */ new Date()).toISOString();
+    const store = resolveDashboardChatStore(this.env);
+    const nicknameListTurn = await buildDashboardRepositoryNicknameListTurn({
+      payload: { ...normalizeObject11(payload), text, threadId },
+      env: this.env
+    });
+    if (nicknameListTurn) {
+      const ownerMessage2 = normalizeDashboardChatMessage(
+        {
+          threadId: nicknameListTurn.threadId,
+          role: "owner",
+          relatedIssue,
+          status: "sent",
+          text,
+          createdAt: now
+        },
+        { threadId: nicknameListTurn.threadId }
+      );
+      const replyMessages = nicknameListTurn.messages.filter((message) => message.role !== "owner");
+      const messages2 = store ? await store.appendMany(nicknameListTurn.threadId, [ownerMessage2, ...replyMessages]) : [ownerMessage2, ...replyMessages].filter(Boolean);
+      await this.broadcastThread({ threadId: nicknameListTurn.threadId, messages: messages2 });
+      return;
+    }
+    const localReply = buildDashboardLocalButlerReply(text);
+    if (localReply) {
+      const ownerMessage2 = normalizeDashboardChatMessage(
+        {
+          threadId,
+          role: "owner",
+          relatedIssue,
+          status: "sent",
+          text,
+          createdAt: now
+        },
+        { threadId }
+      );
+      const butlerMessage = normalizeDashboardChatMessage(
+        {
+          threadId,
+          role: "butler",
+          relatedIssue,
+          status: "replied",
+          text: localReply,
+          createdAt: new Date(Date.parse(now) + 1).toISOString()
+        },
+        { threadId }
+      );
+      const messages2 = store ? await store.appendMany(threadId, [ownerMessage2, butlerMessage]) : [ownerMessage2, butlerMessage].filter(Boolean);
+      await this.broadcastThread({ threadId, messages: messages2 });
+      return;
+    }
     const repositoryResolution = await resolveDashboardChatRepository({
-      payload: { ...normalizeObject11(payload), text },
+      payload: { ...normalizeObject11(payload), text, threadId },
       env: this.env
     });
     const repository = repositoryResolution.ok ? repositoryResolution.repository : "";
-    const relatedIssue = normalizePositiveInteger9(payload?.relatedIssue || payload?.issueNumber) || extractIssueNumberFromDashboardChatText(text);
-    const now = (/* @__PURE__ */ new Date()).toISOString();
     if (!repositoryResolution.ok) {
+      const ownerMessage2 = normalizeDashboardChatMessage(
+        {
+          threadId,
+          role: "owner",
+          repository,
+          relatedIssue,
+          status: "sent",
+          text,
+          createdAt: now
+        },
+        { threadId }
+      );
       const failedMessage = normalizeDashboardChatMessage(
         {
           threadId,
@@ -55987,8 +56049,7 @@ var DashboardChatRoom = class {
         },
         { threadId }
       );
-      const store2 = resolveDashboardChatStore(this.env);
-      const messages2 = store2 ? await store2.appendMany(threadId, [failedMessage]) : [failedMessage].filter(Boolean);
+      const messages2 = store ? await store.appendMany(threadId, [ownerMessage2, failedMessage]) : [ownerMessage2, failedMessage].filter(Boolean);
       await this.broadcastThread({ threadId, messages: messages2 });
       return;
     }
@@ -56016,7 +56077,6 @@ var DashboardChatRoom = class {
       },
       { threadId }
     );
-    const store = resolveDashboardChatStore(this.env);
     const messages = store ? await store.appendMany(threadId, [ownerMessage, thinkingMessage]) : [ownerMessage, thinkingMessage].filter(Boolean);
     await this.broadcastThread({ threadId, messages });
     const pushed = await this.pushVpsRunnerJob({
@@ -60488,6 +60548,18 @@ async function resolveDashboardChatRepository({ payload, env }) {
     };
   }
   if (!rawRepositoryInput) {
+    const threadContextRepository = await resolveDashboardThreadContextRepository({
+      threadId: input.threadId || input.thread_id,
+      env
+    });
+    if (threadContextRepository) {
+      return {
+        ok: true,
+        repository: threadContextRepository,
+        input: threadContextRepository,
+        via: "thread_context"
+      };
+    }
     return {
       ok: false,
       status: 422,
@@ -60521,6 +60593,47 @@ async function resolveDashboardChatRepository({ payload, env }) {
     candidates: resolved.candidates || []
   };
 }
+async function resolveDashboardThreadContextRepository({ threadId, env } = {}) {
+  const normalizedThreadId = normalizeDashboardThreadId(threadId);
+  if (!normalizedThreadId) {
+    return "";
+  }
+  const store = resolveDashboardChatStore(env);
+  if (!store || typeof store.listThread !== "function") {
+    return "";
+  }
+  try {
+    const messages = await store.listThread(normalizedThreadId, { limit: 20 });
+    const latestWithRepository = [...Array.isArray(messages) ? messages : []].reverse().find((message) => normalizeCanonicalRepositoryInput(message?.repository));
+    return normalizeCanonicalRepositoryInput(latestWithRepository?.repository);
+  } catch {
+    return "";
+  }
+}
+function buildDashboardLocalButlerReply(value) {
+  const text = sanitizeDashboardChatText(value);
+  if (!text) {
+    return "";
+  }
+  if (/(君|あなた|お前|butler|Butler|VTDD).{0,8}(誰|だれ|何者)|^(誰|だれ)ですか|who are you/i.test(text)) {
+    return [
+      "\u79C1\u306F VTDD Butler \u3067\u3059\u3002",
+      "iPhone / iPad \u304B\u3089\u306E\u81EA\u7136\u6587\u3092\u53D7\u3051\u53D6\u308A\u3001repo/nickname\u3001Issue\u3001PR\u3001RAG\u3001VPS Codex CLI\u3001\u627F\u8A8D\u5883\u754C\u3092\u4EA4\u901A\u6574\u7406\u3057\u307E\u3059\u3002",
+      "\u5B9F\u88C5\u3084\u8ABF\u67FB\u304C\u5FC5\u8981\u306A\u4F9D\u983C\u306F\u3001\u5BFE\u8C61 repo \u3092\u89E3\u6C7A\u3057\u3066\u304B\u3089 VPS Codex CLI \u306B\u6E21\u3057\u307E\u3059\u3002\u4F8B: `\u3076\u3044\u306E\u6B8B\u308A\u30BF\u30B9\u30AF\u3092\u78BA\u8A8D\u3057\u3066`\u3002"
+    ].join("\n");
+  }
+  if (/(何ができる|なにができる|使い方|ヘルプ|help|カスタムGPT.*できること|できること)/i.test(text)) {
+    return [
+      "\u3053\u306E dashboard Butler \u3067\u306F\u3001\u81EA\u7136\u6587\u3092\u6B21\u306E\u5165\u53E3\u306B\u4ED5\u5206\u3051\u307E\u3059\u3002",
+      "- repo/nickname \u4ED8\u304D\u306E\u4F5C\u696D\u4F9D\u983C: VPS Codex CLI \u306B push \u3057\u307E\u3059\u3002",
+      "- `\u767B\u9332\u6E08\u307F\u306E\u30CB\u30C3\u30AF\u30CD\u30FC\u30E0\u51FA\u3057\u3066`: \u767B\u9332\u6E08\u307F alias \u3092\u8868\u793A\u3057\u307E\u3059\u3002",
+      "- `\u541B\u306F\u8AB0\uFF1F` / `\u4F55\u304C\u3067\u304D\u308B\uFF1F`: \u3053\u306E\u753B\u9762\u3067\u76F4\u63A5\u7B54\u3048\u307E\u3059\u3002",
+      "- \u540C\u3058 thread \u306B repo \u6587\u8108\u304C\u6B8B\u3063\u3066\u3044\u308B\u5834\u5408: `\u9032\u6357\u306F\uFF1F` \u306E\u3088\u3046\u306A\u7D9A\u304D\u306E\u4F9D\u983C\u3082\u305D\u306E repo \u6587\u8108\u3067\u6271\u3044\u307E\u3059\u3002",
+      "\u9AD8\u30EA\u30B9\u30AF\u64CD\u4F5C\u3001deploy\u3001credential\u3001merge\u3001Issue close \u306F passkey / GO \u5883\u754C\u3092\u8D8A\u3048\u306A\u3044\u9650\u308A\u5B9F\u884C\u3057\u307E\u305B\u3093\u3002"
+    ].join("\n");
+  }
+  return "";
+}
 async function notifyDashboardChatRoom({ env, threadId, messages }) {
   const room = resolveDashboardChatRoomStub(env, threadId);
   if (!room || typeof room.fetch !== "function") {
@@ -60549,7 +60662,7 @@ function extractRepositoryTokenFromDashboardChatText(value) {
   if (canonicalMatch) {
     return canonicalMatch[1];
   }
-  const nicknameMatch = text.match(/^[\s　]*([^\s　#「『【\\/:]+)(?:\s+|[　]*の|[　]*を|[　]*で|[　]*に)/u);
+  const nicknameMatch = text.match(/^[\s　]*([^\s　#「『【\\/:]+?)(?:\s+|[　]*の|[　]*を|[　]*で|[　]*に)/u);
   return normalizeDashboardEventText(nicknameMatch?.[1]);
 }
 function extractIssueNumberFromDashboardChatText(value) {


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #450 の dashboard Butler 入口を、個別文言ではなく自然文分類として修正する。repo/nickname 明示、同一 thread の repo 文脈、ローカル応答、nickname 一覧、repo 必須 stop を分ける。

## Satisfied Success Criteria

- WebSocket owner message で `ぶいの残りタスクを確認して` を `ぶい` alias として解決し VPS runner に渡す。
- 同じ thread に repository 文脈がある場合、`進捗は？` のような follow-up をその repository 文脈で VPS runner に渡す。
- `君は誰？` / `何ができる？` / `登録済みのニックネーム出して` は VPS に投げず dashboard Butler が owner 発言込みで返す。
- repository 解決失敗時も owner 発言を thread に残してから日本語 failure を返す。

## Unsatisfied Success Criteria

- 本番 deploy と iPhone live E2E は merge 後に必要。Custom GPT parity 全体の完了判断や Issue #450 close はこの PR では行わない。

## Non-goal violations

default repository の導入、VPS runner protocol 変更、secret / permission 変更、production deploy、Issue close はこの PR では行わない。

## Dry-run Impact Report

- Target Issue: Issue #450
- Implementing Success Criteria: dashboard Butler が自然文を local answer / nickname list / thread-context follow-up / repo-bound VPS handoff / repo-required stop に分類する。
- Explicit Non-goals: default repository、runner protocol、deploy、credential mutation、Issue close。
- Expected touched files/routes/workflows: src/worker/runtime.js、test/worker.test.js、worker.js。
- Affected Issues: #450。
- Affected PRs: なし。
- Affected workflows: 通常 CI の test / generated-worker check。workflow 定義は変更しない。
- Affected runtime/operator surfaces: Cloudflare Worker DashboardChatRoom WebSocket owner_message runtime、dashboard chat display store。
- What may break if we patch narrowly: 個別文言だけを直すと Custom GPT parity の入口分類がまた崩れる。thread context を default repo と混同すると No default repository invariant を壊す。
- Unknowns to investigate before coding: なし。現象は nickname extraction、repository failure path、local-answer classification、thread context fallback の不足として説明できる。
- Validation needed: DashboardChatRoom 分類テスト、node --check、npm test。merge 後に iPhone live E2E。
- Stop condition: 暗黙 default repository や high-risk action 実行を要求する変更が必要になった場合は停止する。

## File / Line Hypotheses

- file: `src/worker/runtime.js`
  - hypothesis: WebSocket owner_message が repo 解決前に local intent を分類せず、repository 未解決時に owner message も保存しないため、自己紹介や nickname 一覧も同じ error になり、発言も消える。
  - risk if changed narrowly: `ぶいの...` だけを直しても `進捗は？` や `君は誰？` がまた破綻する。
  - validation: DashboardChatRoom tests で alias、同一 thread context、local identity/capability、nickname list、repo-required stop をまとめて確認する。
  - related Issue: #450

## Hypothesis Retrospective

- expected: dashboard chat が自然文を5分類し、repo が必要な作業だけ VPS に渡す。
- actual: `node --test test/worker.test.js --test-name-pattern DashboardChatRoom` と `npm test` で確認済み。
- mismatch: live iPhone E2E は deploy 後。
- lesson: dashboard Butler は API route ではなく会話入口なので、repo 解決だけでなく local intent と thread context を先に扱う必要がある。
- should become RAG candidate: はい。dashboard Butler input classifier の再発防止候補。

## Verification Evidence

- Unit: node --test test/worker.test.js --test-name-pattern DashboardChatRoom: pass。npm test: pass。
- Integration: npm test 内の check:self-parity と check:generated-worker: pass。
- E2E: 未実施。merge / deploy 後に iPhone dashboard で `君は誰？`、`何ができる？`、`登録済みのニックネーム出して`、`ぶいの残りタスクを確認して`、follow-up `進捗は？` を確認する。
- Manual: 未実施。
- Evidence path/link: この PR の checks と DashboardChatRoom 分類テスト。

## Butler Completion Contract

- Owner goal: iPhone dashboard Butler が Custom GPT と同じく自然文を仕分け、repo 作業は VPS に渡し、repo 不要の会話はその場で返す。
- Butler entrypoint: Dashboard Butler chat WebSocket owner_message。
- Action Schema exposure: 不要。Custom GPT Action Schema は未変更。
- Runtime path: Cloudflare Worker DashboardChatRoom.acceptOwnerMessage -> local intent / nickname list / repository resolution / thread context / VPS push。
- Runner/runtime truth: owner message は失敗時も保存される。repo-bound job は canonical repository を含む。local replies は VPS runner に送らない。
- Authority boundary: 未変更。default repository は導入しない。同一 thread context は既存 chat message repository からのみ使う。high-risk authority は追加しない。
- E2E evidence: 未実施。deploy 後に iPhone dashboard live E2E が必要。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: merge 後に必要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: merge / deploy 後に必要。

## Related Constitution Rules

- Butler Completion Gate。
- Conversation UX Contract。
- No default repository。
- Unresolved target blocks execution。
- Evidence Discipline。

## Out-of-scope but NOT implemented

- Custom GPT parity 全体の完了宣言。
- Issue #450 close。
- VPS runner protocol 変更。
- default repository 導入。

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #450
- Execution ID: mac-codex-issue-450-dashboard-input-classifier
- Goal: dashboard_butler_input_classifier
