### PR TITLE
dashboard Butler を VPS Codex CLI 入口に戻す

### DIFF
--- a/scripts/run-vps-runner.mjs
+++ b/scripts/run-vps-runner.mjs
@@ -716,6 +716,20 @@ async function executeVpsDashboardSocketJob({
   env = process.env
 }) {
   const payload = buildVpsDashboardSocketExecutionPayload(job);
+  if (payload.conversationOnly) {
+    const result = await runCommand("codex", buildCodexExecArgs({ env }), {
+      env: buildCodexExecutionEnv(env),
+      input: buildDashboardGeneralChatPrompt({ payload }),
+      maxBuffer: 1024 * 1024 * 12
+    });
+    const reply = summarizeDiagnosticText(result.stdout || result.stderr || "VPS Codex CLI completed dashboard chat.", 4000);
+    sendDashboardSocketReply(socket, {
+      threadId: payload.handoff.dashboardThreadId,
+      status: "completed",
+      message: reply
+    });
+    return;
+  }
   const policies = normalizeRepositoryPolicies({ repositoryPolicies });
   const policy = validateVpsRunnerPayloadPolicy(payload, policies);
   if (!policy.ok) {
@@ -769,6 +783,8 @@ function buildVpsDashboardSocketExecutionPayload(job) {
   const repository = normalizeRepository(job?.repository);
   const issueNumber = normalizePositiveInteger(job?.relatedIssue || job?.issueNumber);
   const threadId = normalizeText(job?.threadId);
+  const repositoryResolution = job?.repositoryResolution && typeof job.repositoryResolution === "object" ? job.repositoryResolution : {};
+  const conversationOnly = !repository && !issueNumber;
   return {
     executionId: `dashboard-ws-${Date.now()}-${crypto.randomUUID()}`,
     repository,
@@ -776,12 +792,42 @@ function buildVpsDashboardSocketExecutionPayload(job) {
     branch: `codex/dashboard-chat-${Date.now()}`,
     baseRef: "main",
     codexGoal: "dashboard_chat_triage",
+    conversationOnly,
+    repositoryResolution: {
+      ok: repositoryResolution.ok === true,
+      error: normalizeText(repositoryResolution.error),
+      reason: normalizeText(repositoryResolution.reason),
+      via: normalizeText(repositoryResolution.via)
+    },
     handoff: {
       ownerMessage: normalizeText(job?.text),
       repositoryInput: normalizeText(job?.repositoryInput) || repository,
       dashboardThreadId: threadId
     }
   };
+}
+
+function buildDashboardGeneralChatPrompt({ payload }) {
+  const handoff = payload?.handoff && typeof payload.handoff === "object" ? payload.handoff : {};
+  const ownerMessage = normalizeText(handoff.ownerMessage);
+  return [
+    "You are VTDD Butler running on the user's VPS Codex CLI.",
+    "",
+    "Owner dashboard message:",
+    ownerMessage || "(missing dashboard owner message)",
+    "",
+    "Dashboard routing:",
+    "- This message did not resolve to a repository/Issue execution target.",
+    "- Answer as a normal Butler conversation. Do not require GitHub Issue preflight for general chat.",
+    "- If the owner is asking for repository work, explain in Japanese that repo/nickname or owner/repo is needed, and give one short example.",
+    "- If the owner is asking a general question, answer directly in Japanese.",
+    "- Do not edit files, commit, push, create PRs, merge, deploy, mutate secrets, mutate permissions, or close Issues.",
+    "",
+    "Reply format:",
+    "- Japanese first.",
+    "- Be concise.",
+    "- Do not mention internal JSON, WebSocket, preflight, or queue unless it is the actual answer."
+  ].join("\n");
 }
 
 function sendDashboardSocketReply(socket, reply) {
@@ -2947,6 +2993,7 @@ export {
   buildVpsRunnerCompletionFinalEvent,
   buildCodexExecutionPrompt,
   buildDashboardChatTriagePrompt,
+  buildDashboardGeneralChatPrompt,
   buildDashboardRunnerWebSocketUrl,
   buildCodexExecArgs,
   buildVpsRunnerPreflightReceipt,

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -242,68 +242,11 @@ export class DashboardChatRoom {
       await this.broadcastThread({ threadId: nicknameListTurn.threadId, messages });
       return;
     }
-    const localReply = buildDashboardLocalButlerReply(text);
-    if (localReply) {
-      const ownerMessage = normalizeDashboardChatMessage(
-        {
-          threadId,
-          role: "owner",
-          relatedIssue,
-          status: "sent",
-          text,
-          createdAt: now
-        },
-        { threadId }
-      );
-      const butlerMessage = normalizeDashboardChatMessage(
-        {
-          threadId,
-          role: "butler",
-          relatedIssue,
-          status: "replied",
-          text: localReply,
-          createdAt: new Date(Date.parse(now) + 1).toISOString()
-        },
-        { threadId }
-      );
-      const messages = store ? await store.appendMany(threadId, [ownerMessage, butlerMessage]) : [ownerMessage, butlerMessage].filter(Boolean);
-      await this.broadcastThread({ threadId, messages });
-      return;
-    }
     const repositoryResolution = await resolveDashboardChatRepository({
       payload: { ...normalizeObject(payload), text, threadId },
       env: this.env
     });
     const repository = repositoryResolution.ok ? repositoryResolution.repository : "";
-    if (!repositoryResolution.ok) {
-      const ownerMessage = normalizeDashboardChatMessage(
-        {
-          threadId,
-          role: "owner",
-          repository,
-          relatedIssue,
-          status: "sent",
-          text,
-          createdAt: now
-        },
-        { threadId }
-      );
-      const failedMessage = normalizeDashboardChatMessage(
-        {
-          threadId,
-          role: "system",
-          repository,
-          relatedIssue,
-          status: "failed",
-          text: repositoryResolution.reason,
-          createdAt: now
-        },
-        { threadId }
-      );
-      const messages = store ? await store.appendMany(threadId, [ownerMessage, failedMessage]) : [ownerMessage, failedMessage].filter(Boolean);
-      await this.broadcastThread({ threadId, messages });
-      return;
-    }
     const ownerMessage = normalizeDashboardChatMessage(
       {
         threadId,
@@ -335,6 +278,7 @@ export class DashboardChatRoom {
       threadId,
       repository,
       repositoryInput: repositoryResolution.input || payload?.repositoryInput || payload?.repository,
+      repositoryResolution,
       relatedIssue,
       text,
       codexGoal: normalizeDashboardEventText(payload?.codexGoal || "dashboard_chat_triage"),
@@ -391,6 +335,7 @@ export class DashboardChatRoom {
       threadId: normalizeDashboardThreadId(payload?.threadId || payload?.thread_id),
       repository: normalizeCanonicalRepositoryInput(payload?.repository),
       repositoryInput: normalizeDashboardEventText(payload?.repositoryInput || payload?.repository_input),
+      repositoryResolution: normalizeObject(payload?.repositoryResolution || payload?.repository_resolution),
       relatedIssue: normalizePositiveInteger(payload?.relatedIssue || payload?.issueNumber),
       text: sanitizeDashboardChatText(payload?.text || payload?.message || payload?.body),
       codexGoal: normalizeDashboardEventText(payload?.codexGoal || "dashboard_chat_triage"),
@@ -5514,9 +5459,10 @@ function resolveDashboardChatRoomStub(env, threadId) {
 
 async function resolveDashboardChatRepository({ payload, env }) {
   const input = normalizeObject(payload);
+  const text = input.text || input.message || input.body;
   const rawRepositoryInput =
     normalizeDashboardEventText(input.repository || input.repositoryInput || input.repository_input) ||
-    extractRepositoryTokenFromDashboardChatText(input.text || input.message || input.body);
+    extractRepositoryTokenFromDashboardChatText(text);
   const canonicalRepository = normalizeCanonicalRepositoryInput(rawRepositoryInput);
   if (canonicalRepository) {
     return {
@@ -5527,17 +5473,19 @@ async function resolveDashboardChatRepository({ payload, env }) {
     };
   }
   if (!rawRepositoryInput) {
-    const threadContextRepository = await resolveDashboardThreadContextRepository({
-      threadId: input.threadId || input.thread_id,
-      env
-    });
-    if (threadContextRepository) {
-      return {
-        ok: true,
-        repository: threadContextRepository,
-        input: threadContextRepository,
-        via: "thread_context"
-      };
+    if (shouldUseDashboardThreadRepositoryContext(text)) {
+      const threadContextRepository = await resolveDashboardThreadContextRepository({
+        threadId: input.threadId || input.thread_id,
+        env
+      });
+      if (threadContextRepository) {
+        return {
+          ok: true,
+          repository: threadContextRepository,
+          input: threadContextRepository,
+          via: "thread_context"
+        };
+      }
     }
     return {
       ok: false,
@@ -5599,29 +5547,17 @@ async function resolveDashboardThreadContextRepository({ threadId, env } = {}) {
   }
 }
 
-function buildDashboardLocalButlerReply(value) {
+function shouldUseDashboardThreadRepositoryContext(value) {
   const text = sanitizeDashboardChatText(value);
   if (!text) {
-    return "";
+    return false;
   }
-  if (/(君|あなた|お前|butler|Butler|VTDD).{0,8}(誰|だれ|何者)|^(誰|だれ)ですか|who are you/i.test(text)) {
-    return [
-      "私は VTDD Butler です。",
-      "iPhone / iPad からの自然文を受け取り、repo/nickname、Issue、PR、RAG、VPS Codex CLI、承認境界を交通整理します。",
-      "実装や調査が必要な依頼は、対象 repo を解決してから VPS Codex CLI に渡します。例: `ぶいの残りタスクを確認して`。"
-    ].join("\n");
+  if (/#\d+\b/.test(text)) {
+    return true;
   }
-  if (/(何ができる|なにができる|使い方|ヘルプ|help|カスタムGPT.*できること|できること)/i.test(text)) {
-    return [
-      "この dashboard Butler では、自然文を次の入口に仕分けます。",
-      "- repo/nickname 付きの作業依頼: VPS Codex CLI に push します。",
-      "- `登録済みのニックネーム出して`: 登録済み alias を表示します。",
-      "- `君は誰？` / `何ができる？`: この画面で直接答えます。",
-      "- 同じ thread に repo 文脈が残っている場合: `進捗は？` のような続きの依頼もその repo 文脈で扱います。",
-      "高リスク操作、deploy、credential、merge、Issue close は passkey / GO 境界を越えない限り実行しません。"
-    ].join("\n");
-  }
-  return "";
+  return /(\bissue\b|\bissues\b|\bpr\b|\bpull request\b|\bactions?\b|\bci\b|\brag\b|\bvps\b|\bcodex\b|\brunner\b|Issue|PR|残り|タスク|進捗|状況|確認|見て|調べて|レビュー|指摘|マージ|merge|デプロイ|deploy|実装|修正|直して|壊れ|バグ|エラー|失敗|ブロッカー|close|クローズ|返信|保存|検索|thread|スレッド)/i.test(
+    text
+  );
 }
 
 async function notifyDashboardChatRoom({ env, threadId, messages }) {

--- a/test/vps-runner-script.test.js
+++ b/test/vps-runner-script.test.js
@@ -7,6 +7,7 @@ import {
   buildFreshExecutionBranchCandidates,
   buildCodexExecutionPrompt,
   buildDashboardChatTriagePrompt,
+  buildDashboardGeneralChatPrompt,
   buildDashboardRunnerWebSocketUrl,
   buildCodexExecArgs,
   buildGuardedPullRequestBody,
@@ -1735,6 +1736,24 @@ test("VPS runner dashboard chat triage prompt preserves Custom GPT parity and bl
   assert.equal(prompt.includes("ぶい の残り Issue と PR 確認して交通整理して"), true);
   assert.equal(prompt.includes("Context preflight receipt:"), true);
   assert.equal(prompt.includes("AGENTS.md sha1=abc123"), true);
+});
+
+test("VPS runner general dashboard chat prompt allows normal conversation without Issue preflight", () => {
+  const prompt = buildDashboardGeneralChatPrompt({
+    payload: {
+      conversationOnly: true,
+      handoff: {
+        ownerMessage: "今日は何月何日？日本時間を答えて",
+        dashboardThreadId: "dashboard-main"
+      }
+    }
+  });
+
+  assert.equal(prompt.includes("Owner dashboard message:"), true);
+  assert.equal(prompt.includes("今日は何月何日？日本時間を答えて"), true);
+  assert.equal(prompt.includes("Answer as a normal Butler conversation"), true);
+  assert.equal(prompt.includes("Do not require GitHub Issue preflight for general chat"), true);
+  assert.equal(prompt.includes("Do not edit files, commit, push, create PRs, merge, deploy"), true);
 });
 
 test("VPS runner builds preflight receipt from canonical repo files", async () => {

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -1194,7 +1194,7 @@ test("DashboardChatRoom resolves Japanese no-particle nickname requests before V
   assert.equal(job.repositoryInput, "ぶい");
 });
 
-test("DashboardChatRoom blocks unresolved repository owner messages before VPS handoff", async () => {
+test("DashboardChatRoom forwards unresolved repository work to VPS runner for conversational handling", async () => {
   const store = createInMemoryDashboardChatStore();
   const dashboardSocket = createMockSocket("dashboard", "dashboard-main-unresolved");
   const runnerSocket = createMockSocket("vps_runner", "dashboard-main-unresolved");
@@ -1216,18 +1216,23 @@ test("DashboardChatRoom blocks unresolved repository owner messages before VPS h
     })
   );
 
-  assert.equal(runnerSocket.sent.length, 0);
+  assert.equal(runnerSocket.sent.length, 1);
+  const job = JSON.parse(runnerSocket.sent[0]);
+  assert.equal(job.text, "VPS Codex CLI 疎通テスト。今の #450 の残りを短く返して。");
+  assert.equal(job.repository, "");
+  assert.equal(job.relatedIssue, 450);
+  assert.equal(job.repositoryResolution.ok, false);
   assert.equal(dashboardSocket.sent.length, 1);
   const broadcast = JSON.parse(dashboardSocket.sent[0]);
   assert.equal(broadcast.messages.length, 2);
   assert.equal(broadcast.messages[0].role, "owner");
   assert.equal(broadcast.messages[0].text, "VPS Codex CLI 疎通テスト。今の #450 の残りを短く返して。");
-  assert.equal(broadcast.messages[1].status, "failed");
-  assert.equal(broadcast.messages[1].text.includes("対象 repository"), true);
+  assert.equal(broadcast.messages[1].status, "thinking");
+  assert.equal(broadcast.messages[1].text.includes("VPS Codex CLI に送信しました"), true);
   assert.equal(broadcast.messages[1].relatedIssue, 450);
 });
 
-test("DashboardChatRoom answers local Butler identity questions without repository handoff", async () => {
+test("DashboardChatRoom forwards identity questions to VPS runner instead of answering in the Worker", async () => {
   const store = createInMemoryDashboardChatStore();
   const dashboardSocket = createMockSocket("dashboard", "dashboard-main-unresolved");
   const runnerSocket = createMockSocket("vps_runner", "dashboard-main-unresolved");
@@ -1249,16 +1254,20 @@ test("DashboardChatRoom answers local Butler identity questions without reposito
     })
   );
 
-  assert.equal(runnerSocket.sent.length, 0);
+  assert.equal(runnerSocket.sent.length, 1);
+  const job = JSON.parse(runnerSocket.sent[0]);
+  assert.equal(job.text, "君は誰？");
+  assert.equal(job.repository, "");
+  assert.equal(job.repositoryResolution.ok, false);
   assert.equal(dashboardSocket.sent.length, 1);
   const broadcast = JSON.parse(dashboardSocket.sent[0]);
   assert.equal(broadcast.messages.length, 2);
   assert.equal(broadcast.messages[0].role, "owner");
-  assert.equal(broadcast.messages[1].role, "butler");
-  assert.equal(broadcast.messages[1].text.includes("私は VTDD Butler です"), true);
+  assert.equal(broadcast.messages[1].role, "system");
+  assert.equal(broadcast.messages[1].status, "thinking");
 });
 
-test("DashboardChatRoom answers local capability questions without repository handoff", async () => {
+test("DashboardChatRoom forwards capability questions to VPS runner instead of answering in the Worker", async () => {
   const store = createInMemoryDashboardChatStore();
   const dashboardSocket = createMockSocket("dashboard", "dashboard-main-unresolved");
   const runnerSocket = createMockSocket("vps_runner", "dashboard-main-unresolved");
@@ -1280,12 +1289,62 @@ test("DashboardChatRoom answers local capability questions without repository ha
     })
   );
 
-  assert.equal(runnerSocket.sent.length, 0);
+  assert.equal(runnerSocket.sent.length, 1);
+  const job = JSON.parse(runnerSocket.sent[0]);
+  assert.equal(job.text, "何ができる？");
+  assert.equal(job.repository, "");
+  assert.equal(job.repositoryResolution.ok, false);
   const broadcast = JSON.parse(dashboardSocket.sent[0]);
   assert.equal(broadcast.messages.length, 2);
   assert.equal(broadcast.messages[0].role, "owner");
-  assert.equal(broadcast.messages[1].role, "butler");
-  assert.equal(broadcast.messages[1].text.includes("自然文を次の入口に仕分けます"), true);
+  assert.equal(broadcast.messages[1].role, "system");
+  assert.equal(broadcast.messages[1].status, "thinking");
+});
+
+test("DashboardChatRoom forwards general date questions to VPS runner even when thread has repository context", async () => {
+  const store = createInMemoryDashboardChatStore();
+  await store.appendMany("dashboard-main-unresolved", [
+    {
+      role: "runner",
+      repository: "marushu/vtdd-v2-p",
+      relatedIssue: 450,
+      status: "replied",
+      text: "Issue #450 の返答です。",
+      createdAt: "2026-05-21T00:00:00.000Z"
+    }
+  ]);
+  const dashboardSocket = createMockSocket("dashboard", "dashboard-main-unresolved");
+  const runnerSocket = createMockSocket("vps_runner", "dashboard-main-unresolved");
+  const room = new DashboardChatRoom(
+    {
+      getWebSockets() {
+        return [dashboardSocket, runnerSocket];
+      }
+    },
+    { DASHBOARD_CHAT_STORE: store, MEMORY_PROVIDER: createInMemoryMemoryProvider() }
+  );
+
+  await room.webSocketMessage(
+    dashboardSocket,
+    JSON.stringify({
+      type: "owner_message",
+      threadId: "dashboard-main-unresolved",
+      text: "今日は何月何日？日本時間を答えて"
+    })
+  );
+
+  assert.equal(runnerSocket.sent.length, 1);
+  const job = JSON.parse(runnerSocket.sent[0]);
+  assert.equal(job.text, "今日は何月何日？日本時間を答えて");
+  assert.equal(job.repository, "");
+  assert.equal(job.repositoryResolution.ok, false);
+  assert.equal(dashboardSocket.sent.length, 1);
+  const broadcast = JSON.parse(dashboardSocket.sent[0]);
+  assert.equal(broadcast.messages.length, 2);
+  assert.equal(broadcast.messages[0].role, "owner");
+  assert.equal(broadcast.messages[0].text, "今日は何月何日？日本時間を答えて");
+  assert.equal(broadcast.messages[1].role, "system");
+  assert.equal(broadcast.messages[1].status, "thinking");
 });
 
 test("DashboardChatRoom uses same-thread repository context for follow-up owner messages", async () => {

--- a/worker.js
+++ b/worker.js
@@ -55991,68 +55991,11 @@ var DashboardChatRoom = class {
       await this.broadcastThread({ threadId: nicknameListTurn.threadId, messages: messages2 });
       return;
     }
-    const localReply = buildDashboardLocalButlerReply(text);
-    if (localReply) {
-      const ownerMessage2 = normalizeDashboardChatMessage(
-        {
-          threadId,
-          role: "owner",
-          relatedIssue,
-          status: "sent",
-          text,
-          createdAt: now
-        },
-        { threadId }
-      );
-      const butlerMessage = normalizeDashboardChatMessage(
-        {
-          threadId,
-          role: "butler",
-          relatedIssue,
-          status: "replied",
-          text: localReply,
-          createdAt: new Date(Date.parse(now) + 1).toISOString()
-        },
-        { threadId }
-      );
-      const messages2 = store ? await store.appendMany(threadId, [ownerMessage2, butlerMessage]) : [ownerMessage2, butlerMessage].filter(Boolean);
-      await this.broadcastThread({ threadId, messages: messages2 });
-      return;
-    }
     const repositoryResolution = await resolveDashboardChatRepository({
       payload: { ...normalizeObject11(payload), text, threadId },
       env: this.env
     });
     const repository = repositoryResolution.ok ? repositoryResolution.repository : "";
-    if (!repositoryResolution.ok) {
-      const ownerMessage2 = normalizeDashboardChatMessage(
-        {
-          threadId,
-          role: "owner",
-          repository,
-          relatedIssue,
-          status: "sent",
-          text,
-          createdAt: now
-        },
-        { threadId }
-      );
-      const failedMessage = normalizeDashboardChatMessage(
-        {
-          threadId,
-          role: "system",
-          repository,
-          relatedIssue,
-          status: "failed",
-          text: repositoryResolution.reason,
-          createdAt: now
-        },
-        { threadId }
-      );
-      const messages2 = store ? await store.appendMany(threadId, [ownerMessage2, failedMessage]) : [ownerMessage2, failedMessage].filter(Boolean);
-      await this.broadcastThread({ threadId, messages: messages2 });
-      return;
-    }
     const ownerMessage = normalizeDashboardChatMessage(
       {
         threadId,
@@ -56084,6 +56027,7 @@ var DashboardChatRoom = class {
       threadId,
       repository,
       repositoryInput: repositoryResolution.input || payload?.repositoryInput || payload?.repository,
+      repositoryResolution,
       relatedIssue,
       text,
       codexGoal: normalizeDashboardEventText(payload?.codexGoal || "dashboard_chat_triage"),
@@ -56138,6 +56082,7 @@ var DashboardChatRoom = class {
       threadId: normalizeDashboardThreadId(payload?.threadId || payload?.thread_id),
       repository: normalizeCanonicalRepositoryInput(payload?.repository),
       repositoryInput: normalizeDashboardEventText(payload?.repositoryInput || payload?.repository_input),
+      repositoryResolution: normalizeObject11(payload?.repositoryResolution || payload?.repository_resolution),
       relatedIssue: normalizePositiveInteger9(payload?.relatedIssue || payload?.issueNumber),
       text: sanitizeDashboardChatText(payload?.text || payload?.message || payload?.body),
       codexGoal: normalizeDashboardEventText(payload?.codexGoal || "dashboard_chat_triage"),
@@ -60537,7 +60482,8 @@ function resolveDashboardChatRoomStub(env, threadId) {
 }
 async function resolveDashboardChatRepository({ payload, env }) {
   const input = normalizeObject11(payload);
-  const rawRepositoryInput = normalizeDashboardEventText(input.repository || input.repositoryInput || input.repository_input) || extractRepositoryTokenFromDashboardChatText(input.text || input.message || input.body);
+  const text = input.text || input.message || input.body;
+  const rawRepositoryInput = normalizeDashboardEventText(input.repository || input.repositoryInput || input.repository_input) || extractRepositoryTokenFromDashboardChatText(text);
   const canonicalRepository = normalizeCanonicalRepositoryInput(rawRepositoryInput);
   if (canonicalRepository) {
     return {
@@ -60548,17 +60494,19 @@ async function resolveDashboardChatRepository({ payload, env }) {
     };
   }
   if (!rawRepositoryInput) {
-    const threadContextRepository = await resolveDashboardThreadContextRepository({
-      threadId: input.threadId || input.thread_id,
-      env
-    });
-    if (threadContextRepository) {
-      return {
-        ok: true,
-        repository: threadContextRepository,
-        input: threadContextRepository,
-        via: "thread_context"
-      };
+    if (shouldUseDashboardThreadRepositoryContext(text)) {
+      const threadContextRepository = await resolveDashboardThreadContextRepository({
+        threadId: input.threadId || input.thread_id,
+        env
+      });
+      if (threadContextRepository) {
+        return {
+          ok: true,
+          repository: threadContextRepository,
+          input: threadContextRepository,
+          via: "thread_context"
+        };
+      }
     }
     return {
       ok: false,
@@ -60610,29 +60558,17 @@ async function resolveDashboardThreadContextRepository({ threadId, env } = {}) {
     return "";
   }
 }
-function buildDashboardLocalButlerReply(value) {
+function shouldUseDashboardThreadRepositoryContext(value) {
   const text = sanitizeDashboardChatText(value);
   if (!text) {
-    return "";
+    return false;
   }
-  if (/(君|あなた|お前|butler|Butler|VTDD).{0,8}(誰|だれ|何者)|^(誰|だれ)ですか|who are you/i.test(text)) {
-    return [
-      "\u79C1\u306F VTDD Butler \u3067\u3059\u3002",
-      "iPhone / iPad \u304B\u3089\u306E\u81EA\u7136\u6587\u3092\u53D7\u3051\u53D6\u308A\u3001repo/nickname\u3001Issue\u3001PR\u3001RAG\u3001VPS Codex CLI\u3001\u627F\u8A8D\u5883\u754C\u3092\u4EA4\u901A\u6574\u7406\u3057\u307E\u3059\u3002",
-      "\u5B9F\u88C5\u3084\u8ABF\u67FB\u304C\u5FC5\u8981\u306A\u4F9D\u983C\u306F\u3001\u5BFE\u8C61 repo \u3092\u89E3\u6C7A\u3057\u3066\u304B\u3089 VPS Codex CLI \u306B\u6E21\u3057\u307E\u3059\u3002\u4F8B: `\u3076\u3044\u306E\u6B8B\u308A\u30BF\u30B9\u30AF\u3092\u78BA\u8A8D\u3057\u3066`\u3002"
-    ].join("\n");
+  if (/#\d+\b/.test(text)) {
+    return true;
   }
-  if (/(何ができる|なにができる|使い方|ヘルプ|help|カスタムGPT.*できること|できること)/i.test(text)) {
-    return [
-      "\u3053\u306E dashboard Butler \u3067\u306F\u3001\u81EA\u7136\u6587\u3092\u6B21\u306E\u5165\u53E3\u306B\u4ED5\u5206\u3051\u307E\u3059\u3002",
-      "- repo/nickname \u4ED8\u304D\u306E\u4F5C\u696D\u4F9D\u983C: VPS Codex CLI \u306B push \u3057\u307E\u3059\u3002",
-      "- `\u767B\u9332\u6E08\u307F\u306E\u30CB\u30C3\u30AF\u30CD\u30FC\u30E0\u51FA\u3057\u3066`: \u767B\u9332\u6E08\u307F alias \u3092\u8868\u793A\u3057\u307E\u3059\u3002",
-      "- `\u541B\u306F\u8AB0\uFF1F` / `\u4F55\u304C\u3067\u304D\u308B\uFF1F`: \u3053\u306E\u753B\u9762\u3067\u76F4\u63A5\u7B54\u3048\u307E\u3059\u3002",
-      "- \u540C\u3058 thread \u306B repo \u6587\u8108\u304C\u6B8B\u3063\u3066\u3044\u308B\u5834\u5408: `\u9032\u6357\u306F\uFF1F` \u306E\u3088\u3046\u306A\u7D9A\u304D\u306E\u4F9D\u983C\u3082\u305D\u306E repo \u6587\u8108\u3067\u6271\u3044\u307E\u3059\u3002",
-      "\u9AD8\u30EA\u30B9\u30AF\u64CD\u4F5C\u3001deploy\u3001credential\u3001merge\u3001Issue close \u306F passkey / GO \u5883\u754C\u3092\u8D8A\u3048\u306A\u3044\u9650\u308A\u5B9F\u884C\u3057\u307E\u305B\u3093\u3002"
-    ].join("\n");
-  }
-  return "";
+  return /(\bissue\b|\bissues\b|\bpr\b|\bpull request\b|\bactions?\b|\bci\b|\brag\b|\bvps\b|\bcodex\b|\brunner\b|Issue|PR|残り|タスク|進捗|状況|確認|見て|調べて|レビュー|指摘|マージ|merge|デプロイ|deploy|実装|修正|直して|壊れ|バグ|エラー|失敗|ブロッカー|close|クローズ|返信|保存|検索|thread|スレッド)/i.test(
+    text
+  );
 }
 async function notifyDashboardChatRoom({ env, threadId, messages }) {
   const room = resolveDashboardChatRoomStub(env, threadId);


### PR DESCRIPTION
## This PR satisfies Intent

- #450 dashboard Butler chat を VPS Codex CLI の入口として扱い、Worker が定型返答や repo 未解決 failure を作らず全入力を runner へ渡す。

## Satisfied Success Criteria

- Worker のローカル定型応答を削除し、owner message を保存して VPS runner WebSocket job として送る。
- repo 未解決・一般会話・自己紹介・日付質問も VPS runner に渡す。
- VPS runner 側に general dashboard chat prompt を追加し、repo/Issue preflight なしの通常会話を Codex CLI が返せるようにする。
- repo 作業の follow-up は同じ thread の repo 文脈を引き続き使う。

## Unsatisfied Success Criteria

- live production dashboard で owner が実際に「君は誰？」「今日は何月何日？日本時間を答えて」「ぶい #450 の残りを短く返して」を送り、VPS Codex CLI の返信が返る E2E は deploy 後確認が必要。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: #450
- Implementing Success Criteria: dashboard Butler chat が通常ターミナルの Codex CLI 入口として動き、Worker が回答生成しない。
- Explicit Non-goals: deploy、credential/permission 変更、merge、Issue close はこの PR では行いません。Worker を AI 化しません。
- Expected touched files/routes/workflows: src/worker/runtime.js, scripts/run-vps-runner.mjs, test/worker.test.js, test/vps-runner-script.test.js, worker.js
- Affected Issues: #450
- Affected PRs: なし
- Affected workflows: guarded-autonomy-required-checks, gemini-pr-review
- Affected runtime/operator surfaces: dashboard Worker chat room, VPS dashboard WebSocket runner
- What may break if we patch narrowly: 個別文言だけを Worker で返すと、一般会話がまた preflight/blocker になり dashboard Butler が AI 入口にならない。
- Unknowns to investigate before coding: deploy 後の live runner 接続と Codex CLI 応答レイテンシ。
- Validation needed: DashboardChatRoom targeted tests, VPS runner prompt tests, npm test, deploy 後 iPhone live E2E
- Stop condition: Worker が回答本文を生成する方向に戻る、または repo/Issue preflight を一般会話に要求する場合。

## File / Line Hypotheses

- file: src/worker/runtime.js
  - hypothesis: acceptOwnerMessage の local reply / unresolved repo failure が dashboard Worker を疑似 AI 化している。
  - risk if changed narrowly: repo follow-up 文脈や nickname 解決を壊す。
  - validation: DashboardChatRoom tests。
  - related Issue: #450
- file: scripts/run-vps-runner.mjs
  - hypothesis: executeVpsDashboardSocketJob が repo/Issue preflight 前提だけなので一般会話を拒否する。
  - risk if changed narrowly: repo 作業の安全 preflight を緩める。
  - validation: VPS runner prompt tests。
  - related Issue: #450

## Hypothesis Retrospective

- expected: Worker から回答生成を外し、全入力を runner に渡す。
- actual: Worker local reply と unresolved failure を削除し、conversationOnly payload を VPS Codex CLI prompt に渡した。
- mismatch: repo 作業 follow-up の thread context は残したが、一般会話は repository empty のまま runner に渡す形にした。
- lesson: dashboard Butler は AI ではなく Codex CLI 入口。Worker の個別応答追加は drift。
- should become RAG candidate: true

## Verification Evidence

- Unit: node --check src/worker/runtime.js; node --check scripts/run-vps-runner.mjs
- Integration: node --test test/worker.test.js --test-name-pattern 'DashboardChatRoom'; node --test test/vps-runner-script.test.js --test-name-pattern 'dashboard chat|general dashboard'; npm test
- E2E: 未実施。deploy 後の iPhone live dashboard E2E が必要。
- Manual: なし
- Evidence path/link: local test output in PR run; deploy 後に #450 へ live E2E 証跡追記予定

## Butler Completion Contract

- Owner goal: iPhone dashboard Butler を、通常ターミナルで VPS Codex CLI に話しかける入口として使う。
- Butler entrypoint: dashboard top chat composer -> Worker 保存 / WebSocket 中継 -> VPS Codex CLI
- Action Schema exposure: 不要。dashboard WebSocket route の修正であり Custom GPT Action Schema は変更なし。
- Runtime path: DashboardChatRoom.acceptOwnerMessage -> pushVpsRunnerJob -> scripts/run-vps-runner.mjs executeVpsDashboardSocketJob
- Runner/runtime truth: Worker は thinking/system と owner message を保存し、VPS runner reply だけを回答として thread に表示する。
- Authority boundary: 未変更。Worker は高リスク操作を実行せず、VPS general chat prompt も commit/push/PR/merge/deploy/secret/permission/Issue close を禁止。
- E2E evidence: deploy 後に live dashboard で確認が必要。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 必要。merge 後 deploy-production が必要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 必要。「君は誰？」と「今日は何月何日？日本時間を答えて」が VPS Codex CLI から返ること。

## Related Constitution Rules

- Butler Completion Gate
- Butler-First Operating Principle
- Conversation UX Contract
- Safety Invariants
- Evidence Discipline

## Out-of-scope but NOT implemented

- VPS Codex CLI のモデル性能改善。
- RAG 長期記憶の追加実装。
- Issue close 判断。

## Extra changes (if any)

生成済み worker.js を npm run build:worker で更新。

<!-- VTDD metadata -->
- Issue: Issue #450
- Execution ID: local-codex-issue450-dashboard-vps-chat
- Goal: dashboard_chat_triage
