### PR TITLE
Dashboard Butler の一般会話 routing と返信整形を直す

### DIFF
--- a/scripts/run-vps-runner.mjs
+++ b/scripts/run-vps-runner.mjs
@@ -785,6 +785,7 @@ function buildVpsDashboardSocketExecutionPayload(job) {
   const threadId = normalizeText(job?.threadId);
   const repositoryResolution = job?.repositoryResolution && typeof job.repositoryResolution === "object" ? job.repositoryResolution : {};
   const conversationOnly = !repository;
+  const issueContextReadable = Boolean(repository && issueNumber);
   return {
     executionId: `dashboard-ws-${Date.now()}-${crypto.randomUUID()}`,
     repository,
@@ -793,6 +794,7 @@ function buildVpsDashboardSocketExecutionPayload(job) {
     baseRef: "main",
     codexGoal: "dashboard_chat_triage",
     conversationOnly,
+    issueContextReadable,
     repositoryResolution: {
       ok: repositoryResolution.ok === true,
       error: normalizeText(repositoryResolution.error),
@@ -810,6 +812,11 @@ function buildVpsDashboardSocketExecutionPayload(job) {
 function buildDashboardGeneralChatPrompt({ payload }) {
   const handoff = payload?.handoff && typeof payload.handoff === "object" ? payload.handoff : {};
   const ownerMessage = normalizeText(handoff.ownerMessage);
+  const repositoryInput = normalizeText(handoff.repositoryInput);
+  const issueNumber = normalizePositiveInteger(payload?.issueNumber);
+  const repositoryResolution = payload?.repositoryResolution && typeof payload.repositoryResolution === "object"
+    ? payload.repositoryResolution
+    : {};
   return [
     "You are VTDD Butler running on the user's VPS Codex CLI.",
     "",
@@ -819,7 +826,12 @@ function buildDashboardGeneralChatPrompt({ payload }) {
     "Dashboard routing:",
     "- This message did not resolve to a repository/Issue execution target.",
     "- Answer as a normal Butler conversation. Do not require GitHub Issue preflight for general chat.",
-    "- If the owner is asking for repository work, explain in Japanese that repo/nickname or owner/repo is needed, and give one short example.",
+    `- repositoryInput: ${repositoryInput || "missing"}`,
+    `- detectedIssueNumber: ${issueNumber ? `#${issueNumber}` : "missing"}`,
+    `- repositoryResolution: ${repositoryResolution.ok === true ? "resolved" : normalizeText(repositoryResolution.error) || "unresolved"}`,
+    "- If an Issue number is present but repository is unresolved, do not answer as if you read that Issue, PRs, checks, or runtime truth.",
+    "- For unresolved repository work, explain in Japanese that repo/nickname or owner/repo is needed before VTDD can read GitHub truth or continue development, and give one short example.",
+    "- If ordinary conversation reveals a new actionable development need, classify it as issue_split_proposal or execution_handoff_needed, then ask for the target repo/nickname and GO boundary before any issue creation or implementation.",
     "- If the owner is asking a general question, answer directly in Japanese.",
     "- Do not edit files, commit, push, create PRs, merge, deploy, mutate secrets, mutate permissions, or close Issues.",
     "Reply format:",

--- a/scripts/run-vps-runner.mjs
+++ b/scripts/run-vps-runner.mjs
@@ -585,7 +585,7 @@ async function executeVpsDashboardChatTriage({ githubFetch, payload, notificatio
     currentStep: "dashboard_chat_triage"
   });
   await assertVpsRunnerNotCanceled({ githubFetch, payload, checkpoint: "after_triage_codex", notification });
-  const reply = summarizeDiagnosticText(result.stdout || result.stderr || "VPS Codex CLI completed dashboard chat triage.", 4000);
+  const reply = summarizeDashboardReplyText(result.stdout || result.stderr || "VPS Codex CLI completed dashboard chat triage.", 4000);
   await postVpsRunnerEvent({
     githubFetch,
     payload,
@@ -722,7 +722,7 @@ async function executeVpsDashboardSocketJob({
       input: buildDashboardGeneralChatPrompt({ payload }),
       maxBuffer: 1024 * 1024 * 12
     });
-    const reply = summarizeDiagnosticText(result.stdout || result.stderr || "VPS Codex CLI completed dashboard chat.", 4000);
+    const reply = summarizeDashboardReplyText(result.stdout || result.stderr || "VPS Codex CLI completed dashboard chat.", 4000);
     sendDashboardSocketReply(socket, {
       threadId: payload.handoff.dashboardThreadId,
       status: "completed",
@@ -769,7 +769,7 @@ async function executeVpsDashboardSocketJob({
     input: buildDashboardChatTriagePrompt({ payload, issue, preflight }),
     maxBuffer: 1024 * 1024 * 12
   });
-  const reply = summarizeDiagnosticText(result.stdout || result.stderr || "VPS Codex CLI completed dashboard chat triage.", 4000);
+  const reply = summarizeDashboardReplyText(result.stdout || result.stderr || "VPS Codex CLI completed dashboard chat triage.", 4000);
   sendDashboardSocketReply(socket, {
     threadId: payload.handoff.dashboardThreadId,
     repository: payload.repository,
@@ -784,7 +784,7 @@ function buildVpsDashboardSocketExecutionPayload(job) {
   const issueNumber = normalizePositiveInteger(job?.relatedIssue || job?.issueNumber);
   const threadId = normalizeText(job?.threadId);
   const repositoryResolution = job?.repositoryResolution && typeof job.repositoryResolution === "object" ? job.repositoryResolution : {};
-  const conversationOnly = !repository && !issueNumber;
+  const conversationOnly = !repository;
   return {
     executionId: `dashboard-ws-${Date.now()}-${crypto.randomUUID()}`,
     repository,
@@ -825,6 +825,7 @@ function buildDashboardGeneralChatPrompt({ payload }) {
     "Reply format:",
     "- Japanese first.",
     "- Be concise.",
+    "- Use readable Markdown with short paragraphs or bullets when the answer has multiple facts.",
     "- Do not mention internal JSON, WebSocket, preflight, or queue unless it is the actual answer."
   ].join("\n");
 }
@@ -895,6 +896,7 @@ function buildDashboardChatTriagePrompt({ payload, issue = {}, preflight = null 
     "Reply format:",
     "- Japanese first.",
     "- Be concise but operational.",
+    "- Use readable Markdown with line breaks. Do not compress bullets into one paragraph.",
     "- Include the classification: answer / issue_split_proposal / existing_issue_link / execution_handoff_needed / approval_needed / rag_candidate / blocker.",
     "- Include next action and any missing information.",
     "- If you mention a GitHub item, include a clickable URL if known."
@@ -2829,6 +2831,19 @@ function summarizeDiagnosticText(value, maxLength = 500) {
   return redacted.length <= maxLength ? redacted : `${redacted.slice(0, maxLength)} [truncated]`;
 }
 
+function summarizeDashboardReplyText(value, maxLength = 4000) {
+  const redacted = redactDiagnosticText(value)
+    .split("\n")
+    .map((line) => line.trimEnd())
+    .join("\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+  if (!redacted) {
+    return null;
+  }
+  return redacted.length <= maxLength ? redacted : `${redacted.slice(0, maxLength)}\n[truncated]`;
+}
+
 function buildVpsRunnerNotificationContext(input = {}) {
   return {
     queueCommentAuthor: normalizeGitHubLogin(input.queueCommentAuthor),
@@ -3054,6 +3069,7 @@ export {
   buildCodexExecutionPrompt,
   buildDashboardChatTriagePrompt,
   buildDashboardGeneralChatPrompt,
+  buildVpsDashboardSocketExecutionPayload,
   buildVpsDashboardActionBridgeGuide,
   buildVpsDashboardActionReadBridgeGuide,
   buildDashboardRunnerWebSocketUrl,
@@ -3081,6 +3097,7 @@ export {
   runVpsRunnerOnce,
   startVpsDashboardWebSocketRunner,
   resolveRoleGitHubAppInstallationToken,
+  summarizeDashboardReplyText,
   summarizeDiagnosticText,
   selectPendingVpsReviewerFallbacks,
   selectPendingVpsRunnerExecutions

--- a/test/vps-runner-script.test.js
+++ b/test/vps-runner-script.test.js
@@ -8,6 +8,7 @@ import {
   buildCodexExecutionPrompt,
   buildDashboardChatTriagePrompt,
   buildDashboardGeneralChatPrompt,
+  buildVpsDashboardSocketExecutionPayload,
   buildVpsDashboardActionBridgeGuide,
   buildVpsDashboardActionReadBridgeGuide,
   buildDashboardRunnerWebSocketUrl,
@@ -35,6 +36,7 @@ import {
   postVpsRunnerEvent,
   runVpsRunnerOnce,
   resolveRoleGitHubAppInstallationToken,
+  summarizeDashboardReplyText,
   summarizeDiagnosticText,
   selectPendingVpsReviewerFallbacks,
   selectPendingVpsRunnerExecutions
@@ -694,6 +696,21 @@ test("VPS runner dashboard WebSocket client reconnects after disconnect", async 
   assert.equal(sockets[1].protocols[0], "vtdd-vps-runner");
 });
 
+test("VPS runner treats unresolved dashboard issue-only jobs as conversation", () => {
+  const payload = buildVpsDashboardSocketExecutionPayload({
+    type: "dashboard_chat_job",
+    threadId: "dashboard-main-unresolved",
+    repository: "",
+    repositoryResolution: { ok: false, error: "repository_required" },
+    relatedIssue: 450,
+    text: "今の #450 の残りを短く返して"
+  });
+
+  assert.equal(payload.repository, "");
+  assert.equal(payload.issueNumber, 450);
+  assert.equal(payload.conversationOnly, true);
+});
+
 test("VPS runner milestone event mentions queue comment author", () => {
   const body = buildVpsRunnerEventComment({
     executionId: "exec-mention",
@@ -1105,6 +1122,28 @@ test("VPS runner diagnostic summaries redact secrets and stay short", () => {
   assert.equal(summary.includes("[REDACTED_API_KEY]"), true);
   assert.equal(summary.endsWith("[truncated]"), true);
   assert.equal(summary.length <= 192, true);
+});
+
+test("VPS runner dashboard replies preserve readable line breaks", () => {
+  const summary = summarizeDashboardReplyText(
+    [
+      "分類: `answer / existing_issue_link`",
+      "",
+      "#450 の残りはこれだけです。",
+      "",
+      "- #450 はまだ OPEN",
+      "- open PR は 0 件",
+      "",
+      "残り作業:",
+      "1. dashboard live E2E",
+      "2. 証跡を残す"
+    ].join("\n"),
+    4000
+  );
+
+  assert.equal(summary.includes("\n\n- #450 はまだ OPEN\n- open PR は 0 件"), true);
+  assert.equal(summary.includes("OPEN - open PR"), false);
+  assert.equal(summary.includes("\n1. dashboard live E2E\n2. 証跡を残す"), true);
 });
 
 test("VPS runner dry run reports selected execution without side effects", async () => {

--- a/test/vps-runner-script.test.js
+++ b/test/vps-runner-script.test.js
@@ -696,7 +696,7 @@ test("VPS runner dashboard WebSocket client reconnects after disconnect", async 
   assert.equal(sockets[1].protocols[0], "vtdd-vps-runner");
 });
 
-test("VPS runner treats unresolved dashboard issue-only jobs as conversation", () => {
+test("VPS runner treats unresolved dashboard issue-only jobs as conversation without readable Issue context", () => {
   const payload = buildVpsDashboardSocketExecutionPayload({
     type: "dashboard_chat_job",
     threadId: "dashboard-main-unresolved",
@@ -709,6 +709,24 @@ test("VPS runner treats unresolved dashboard issue-only jobs as conversation", (
   assert.equal(payload.repository, "");
   assert.equal(payload.issueNumber, 450);
   assert.equal(payload.conversationOnly, true);
+  assert.equal(payload.issueContextReadable, false);
+});
+
+test("VPS runner preserves readable Issue context only after repository resolution", () => {
+  const payload = buildVpsDashboardSocketExecutionPayload({
+    type: "dashboard_chat_job",
+    threadId: "dashboard-main-marushu-vtdd-v2-p",
+    repository: "marushu/vtdd-v2-p",
+    repositoryInput: "ぶい",
+    repositoryResolution: { ok: true, via: "alias" },
+    relatedIssue: 450,
+    text: "#450 の残り Issue と PR を確認して"
+  });
+
+  assert.equal(payload.repository, "marushu/vtdd-v2-p");
+  assert.equal(payload.issueNumber, 450);
+  assert.equal(payload.conversationOnly, false);
+  assert.equal(payload.issueContextReadable, true);
 });
 
 test("VPS runner milestone event mentions queue comment author", () => {
@@ -1789,8 +1807,11 @@ test("VPS runner general dashboard chat prompt allows normal conversation withou
   const prompt = buildDashboardGeneralChatPrompt({
     payload: {
       conversationOnly: true,
+      issueNumber: 450,
+      repositoryResolution: { ok: false, error: "repository_required" },
       handoff: {
         ownerMessage: "今日は何月何日？日本時間を答えて",
+        repositoryInput: "missing",
         dashboardThreadId: "dashboard-main"
       }
     }
@@ -1800,6 +1821,12 @@ test("VPS runner general dashboard chat prompt allows normal conversation withou
   assert.equal(prompt.includes("今日は何月何日？日本時間を答えて"), true);
   assert.equal(prompt.includes("Answer as a normal Butler conversation"), true);
   assert.equal(prompt.includes("Do not require GitHub Issue preflight for general chat"), true);
+  assert.equal(prompt.includes("detectedIssueNumber: #450"), true);
+  assert.equal(prompt.includes("repositoryResolution: repository_required"), true);
+  assert.equal(prompt.includes("do not answer as if you read that Issue"), true);
+  assert.equal(prompt.includes("before VTDD can read GitHub truth or continue development"), true);
+  assert.equal(prompt.includes("ordinary conversation reveals a new actionable development need"), true);
+  assert.equal(prompt.includes("issue_split_proposal or execution_handoff_needed"), true);
   assert.equal(prompt.includes("Runtime read-only bridge:"), false);
   assert.equal(prompt.includes("vtddRetrieveRepositoryNicknames: GET /v2/retrieve/repository-nicknames"), false);
   assert.equal(prompt.includes("vtddWriteOperationalMemory: POST /v2/action/memory-write"), false);


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #450 の live dashboard E2E で出た追加不具合として、一般会話が `repository_not_allowlisted` で止まる経路と、VPS Codex CLI 返信の改行が潰れて読みにくくなる経路を修正します。

## Satisfied Success Criteria

- repository 未解決でも dashboard job に issueNumber が付いているだけで allowlist gate に落ちないよう、`conversationOnly` を repository 有無で判定します。
- repository 未解決の issue-only job は `issueContextReadable=false` として扱い、Issue/PR/check/runtime truth を読んだ回答としては扱わない境界を prompt とテストで固定します。
- repository 解決済み + issueNumber ありの job だけを `issueContextReadable=true` とし、clone / preflight / runtime read bridge 付きの dashboard triage path に進めることをテストで固定します。
- dashboard chat 返信だけは `summarizeDashboardReplyText` で改行を保持し、箇条書き・番号付きリストを 1 行に潰さないようにします。
- Codex prompt に、複数事実の回答は readable Markdown / line breaks を使う指示を追加します。

## Unsatisfied Success Criteria

- persistent long-lived Codex CLI session 化は未実装です。現状は送信ごとに `codex exec -` subprocess を起動します。
- live dashboard での再確認と deploy は未実施です。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #450
- Implementing Success Criteria: general dashboard chat must reach VPS Codex CLI without repository allowlist block; VPS replies must preserve readable formatting.
- Explicit Non-goals: deploy, merge, Issue close, credential/permission mutation, persistent Codex session architecture.
- Expected touched files/routes/workflows: scripts/run-vps-runner.mjs, test/vps-runner-script.test.js
- Affected Issues: Issue #450
- Affected PRs: #476 follow-up
- Affected workflows: guarded-autonomy-required-checks, gemini-pr-review
- Affected runtime/operator surfaces: dashboard Butler chat, VPS dashboard WebSocket runner
- What may break if we patch narrowly: unresolved repo + issue-only dashboard messages may continue to be blocked by repository allowlist, and runner replies may remain unreadable.
- Unknowns to investigate before coding: none for this narrow fix.
- Validation needed: targeted VPS runner tests, npm test, deploy after merge, live dashboard E2E.
- Stop condition: changing high-risk approval/deploy/merge/credential boundaries.

## File / Line Hypotheses

- file: scripts/run-vps-runner.mjs
  - hypothesis: `conversationOnly = !repository && !issueNumber` incorrectly sends issue-only unresolved dashboard messages through repository allowlist policy.
  - risk if changed narrowly: repo-backed execution could accidentally bypass allowlist. Mitigation: only repository absence is conversation-only; any resolved repository still goes through policy.
  - validation: VPS runner issue-only conversation test.
  - related Issue: Issue #450

- file: scripts/run-vps-runner.mjs
  - hypothesis: `summarizeDiagnosticText` flattens dashboard replies by joining lines with spaces.
  - risk if changed narrowly: diagnostic logs elsewhere might need flattening. Mitigation: add dashboard-specific summarizer and leave diagnostic summarizer unchanged.
  - validation: dashboard reply line-break preservation test.
  - related Issue: Issue #450

## Hypothesis Retrospective

- expected: general questions and unresolved issue-only dashboard messages should reach Codex as conversation, not fail with `repository_not_allowlisted`; VPS replies should keep bullet formatting.
- actual: added dashboard-specific conversation routing and reply summarization.
- mismatch: persistent Codex session is still not implemented.
- lesson: dashboard chat is a conversation surface; diagnostic flattening and executor allowlist errors should not leak into normal chat UX.
- should become RAG candidate: true

## Verification Evidence

- Unit: `node --check scripts/run-vps-runner.mjs`
- Integration: `node --test test/vps-runner-script.test.js --test-name-pattern 'dashboard WebSocket|dashboard replies|issue-only|dashboard chat|Codex execution env'`
- Integration: `node --test test/vps-runner-script.test.js --test-name-pattern 'dashboard'`
- Integration: `node --test test/vps-runner-script.test.js`
- Full local: `npm test` passed after reviewer-response changes: 903 pass / 1 skipped, self-parity passed, generated-worker check passed.
- Full local: `npm test` passed before branch recreation with the same changes: 902 pass / 1 skipped, self-parity passed, generated-worker check passed.
- E2E: 未実施。merge/deploy 後に owner dashboard で確認が必要。
- Manual: user-provided live screenshots showed `repository_not_allowlisted` and flattened reply formatting.
- Evidence path/link: PR checks after creation; local test output in Codex session.

## Reviewer Response

- 指摘: repository 未解決 + issueNumber ありの dashboard job が Issue 文脈回答として扱われるリスク。
  - 対応: `issueContextReadable` を payload に追加し、未解決 repo では `false`、repo 解決済み + issueNumber ありでのみ `true` にしました。一般会話 prompt には「Issue 番号があっても repo 未解決なら Issue/PR/check/runtime truth を読んだ回答をしない」と明記しました。
- 指摘: `No default repository` / `Unresolved target blocks execution` との関係が未整理。
  - 対応: 未解決 repo は実行や Issue truth 読み取りではなく normal Butler conversation に限定し、開発要求に変わった場合は `issue_split_proposal` / `execution_handoff_needed` として repo/nickname と GO 境界を求める prompt にしました。repo 解決済みの場合だけ clone / preflight / runtime read bridge 付き triage path に進みます。

## Butler Completion Contract

- Owner goal: dashboard Butler で普通の会話と Issue 文脈の質問が読める形で返る。
- Butler entrypoint: dashboard top chat -> WebSocket -> VPS Codex CLI
- Action Schema exposure: 変更なし。
- Runtime path: scripts/run-vps-runner.mjs dashboard WebSocket job routing and reply formatting.
- Runner/runtime truth: unresolved repo + issue-only jobs become conversationOnly and avoid repository policy block; formatted stdout is preserved.
- Authority boundary: high-risk/deploy/merge/credential boundaries are unchanged.
- E2E evidence: 未実施。deploy 後に live dashboard E2E が必要。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 必要。ただしこの PR では実行しない。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 必要。

## Related Constitution Rules

- Butler Completion Gate
- Butler-First Operating Principle
- Conversation UX Contract
- Evidence Discipline

## Out-of-scope but NOT implemented

- Persistent, long-lived Codex CLI session per dashboard thread.
- Deploy execution.
- Issue close judgment.

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #450
- Execution ID: local-codex-issue450-dashboard-live-reply-fix
- Goal: dashboard_chat_live_fix
