### PR TITLE
Dashboard Butler app-server live path を固定する

### DIFF
--- a/docs/butler/dashboard-butler-app-server-live-path.md
+++ b/docs/butler/dashboard-butler-app-server-live-path.md
@@ -1,0 +1,125 @@
+# Dashboard Butler app-server live path
+
+Issue: #450
+
+## Decision
+
+Dashboard Butler is a separate live chat path. It is not a thin UI over the
+Custom GPT Action path, and it is not a WebSocket wrapper around one-shot
+`codex exec` jobs.
+
+The Dashboard Butler implementation target is:
+
+```text
+Dashboard Butler PWA
+  -> Worker / Durable Object dashboard chat room
+  -> VPS Dashboard Bridge
+  -> codex app-server
+  -> live Codex thread / turn / event stream
+  -> Dashboard chat thread
+```
+
+The fallback surface is the existing Custom GPT Butler.
+
+`codex exec` is not the Dashboard Butler fallback. It may remain useful for
+bounded non-interactive automation elsewhere, but it must not be used to claim
+Dashboard Butler live chat completion.
+
+## Why this is required
+
+The current Dashboard path was built from the older VPS runner pattern:
+
+```text
+Dashboard WebSocket job
+  -> VPS runner
+  -> codex exec
+  -> final stdout/stderr reply
+```
+
+That path is insufficient for Issue #450 because it starts a separate Codex
+process per turn. A WebSocket transport alone does not make a chat session. The
+owner-facing failures observed after PR #477 and deploy confirm this:
+
+- follow-up questions do not behave like the same live Codex conversation
+- ordinary conversation is too tied to repository/job dispatch semantics
+- response latency feels like a fresh job instead of an active chat
+- live Codex events are not surfaced as dashboard state
+- final replies are hard to read in the dashboard thread
+
+This is a `butler_gap_found` and `vps_handoff_gap_found`, not a cosmetic UI bug.
+
+## Required boundaries
+
+Dashboard Butler live path:
+
+- MUST use `codex app-server` as the primary Codex execution interface.
+- MUST keep one Dashboard thread mapped to a live Codex thread/session.
+- MUST send follow-up owner messages as turns on the same Codex thread.
+- MUST surface live events from Codex as dashboard chat state.
+- MUST support ordinary conversation without requiring repository resolution.
+- MUST escalate to repository, Issue, GO, or passkey boundaries only when the
+  conversation actually needs those boundaries.
+- MUST persist enough Dashboard thread state for iPhone/iPad PWA recovery.
+- MUST avoid periodic polling as the primary chat mechanism.
+
+Custom GPT Butler fallback:
+
+- remains the fallback owner surface when the Dashboard live path is unavailable
+- continues to use existing Actions, GitHub App reads/writes, runtime truth,
+  RAG, and passkey operator links
+- is not replaced by the Dashboard path
+- is not a reason to keep the Dashboard path on `codex exec`
+
+Shared durable truth:
+
+- GitHub Issues / PRs / Actions
+- Worker runtime truth
+- operational RAG
+- approval grants
+- deploy evidence
+- dashboard thread records
+
+## Non-goals for this decision
+
+- Do not implement the app-server bridge in this document.
+- Do not deploy.
+- Do not mutate credentials, permissions, repository settings, or secrets.
+- Do not close Issue #450.
+- Do not present PR #477 as completing Issue #450.
+- Do not keep adding small UI patches to hide the missing live Codex session.
+
+## Implementation planning requirements
+
+Before implementation, the next PR must define:
+
+- the Worker <-> VPS Dashboard Bridge message schema
+- the VPS Dashboard Bridge <-> `codex app-server` protocol usage
+- Dashboard thread id to Codex thread/session id mapping
+- event mapping from Codex app-server events to dashboard messages
+- reconnect and restart recovery behavior
+- authority boundary handling for repository resolution, Issue creation,
+  implementation handoff, merge, deploy, credential mutation, and Issue close
+- live E2E evidence required before #450 can close
+
+## Completion reading
+
+Issue #450 remains incomplete until the owner can use Dashboard Butler on
+iPhone/iPad as a real continuing chat backed by a live Codex app-server session.
+
+Completion cannot be claimed from:
+
+- WebSocket delivery alone
+- one-shot `codex exec` subprocess calls
+- stored final replies alone
+- PR checks alone
+- deploy success alone
+
+Completion requires live Dashboard E2E evidence for:
+
+- ordinary conversation
+- follow-up questions in the same thread
+- repository / Issue context escalation
+- live status while Codex is working
+- readable replies
+- PWA recovery after app switch / return
+- governed high-risk approval boundaries


### PR DESCRIPTION
## This PR satisfies Intent

- Dashboard Butler の残スコープを、Custom GPT fallback とは別経路の codex app-server backed live chat path として固定します。\nPR #477 / deploy 後の live E2E failure を、UI 小修正ではなく codex exec per-turn runner 設計の未達として明示します。

## Satisfied Success Criteria

- docs/butler/dashboard-butler-app-server-live-path.md を追加し、Dashboard Butler live path は codex app-server を主経路、Custom GPT Butler を fallback surface、codex exec を Dashboard fallback ではないと固定しました。\nIssue #450 に同じ方針をコメントとして残しました。

## Unsatisfied Success Criteria

- app-server bridge 実装は未実施です。\nDashboard thread と Codex thread/session の mapping 実装は未実施です。\nlive stream / turn event / PWA recovery の E2E は未実施です。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #450
- Implementing Success Criteria: Dashboard Butler を期待通りの live chat にするための app-server 前提設計固定。
- Explicit Non-goals: runtime code 実装、deploy、merge、Issue close、credential/permission mutation、VPS systemd 操作。
- Expected touched files/routes/workflows: docs/butler/dashboard-butler-app-server-live-path.md
- Affected Issues: Issue #450
- Affected PRs: PR #477 は partial fix として扱い、#450 completion とは扱わない。
- Affected workflows: なし。docs-only。
- Affected runtime/operator surfaces: Dashboard Butler, VPS Dashboard Bridge, codex app-server, Custom GPT Butler fallback.
- What may break if we patch narrowly: UI 小修正や codex exec 延命に戻ると、Dashboard Butler が chat ではなく job submitter のままになる。
- Unknowns to investigate before coding: app-server protocol の具体 schema / daemon 化 / thread mapping は次の実装前調査で確認する。
- Validation needed: doc grep / PR body validation。コード未変更のため unit test は不要。
- Stop condition: codex exec を Dashboard Butler fallback として再導入しようとする変更。

## File / Line Hypotheses

- file: docs/butler/dashboard-butler-app-server-live-path.md\n  - hypothesis: durable repo anchor がないと、次の thread / VPS handoff で codex exec runner 延命に戻る。\n  - risk if changed narrowly: Issue #450 の本丸が UI polish と誤読される。\n  - validation: doc と Issue #450 comment に方針を固定する。\n  - related Issue: Issue #450

## Hypothesis Retrospective

- expected: Dashboard Butler live path の正本方針が repo と Issue に残る。\n- actual: docs anchor と Issue #450 comment を追加した。\n- mismatch: なし。\n- lesson: app-server path / Custom GPT fallback / codex exec non-fallback は durable state に固定する必要がある。\n- should become RAG candidate: true

## Verification Evidence

- Unit: Not run; docs-only.
- Integration: Not run; docs-only.
- E2E: Not run; design correction only.
- Manual: docs/butler/dashboard-butler-app-server-live-path.md を確認。Issue #450 comment: https://github.com/marushu/vtdd-v2-p/issues/450#issuecomment-4517435221
- Evidence path/link: docs/butler/dashboard-butler-app-server-live-path.md

## Butler Completion Contract

- Owner goal: Dashboard Butler を Custom GPT fallback とは別経路の app-server backed live chat として完成させる。
- Butler entrypoint: Dashboard Butler PWA。Custom GPT Butler は fallback surface。
- Action Schema exposure: 変更なし。Custom GPT Action Schema は fallback path として維持。
- Runtime path: 未実装。このPRは Dashboard PWA -> Worker/Durable Object -> VPS Dashboard Bridge -> codex app-server -> live Codex thread/event stream の設計固定のみ。
- Runner/runtime truth: 未変更。GitHub/Worker/RAG/deploy evidence は shared durable truth として維持する方針。
- Authority boundary: 未変更。普通の会話は可能、実行/merge/deploy/secret/permission/Issue close は既存 GO/passkey 境界に従う。
- E2E evidence: 未実施。#450 は incomplete。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 不要。docs-only。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 必要。app-server bridge 実装後。

## Related Constitution Rules

- Butler Completion Gate\nButler-First Operating Principle\nThread-Independent Startup Contract\nEvidence Discipline

## Out-of-scope but NOT implemented

- codex app-server bridge 実装\nPWA chat UI 実装修正\nVPS daemon / systemd 設定\nCloudflare deploy

## Extra changes (if any)

Issue #450 に方針固定コメントを投稿済み。

<!-- VTDD metadata -->
- Issue: Issue #450
- Execution ID: local-codex-issue450-app-server-path-doc
- Goal: dashboard_butler_app_server_path_doc
