### PR TITLE
#450 Dashboard Butler の旧 codex exec 経路を削除

### DIFF
--- a/docs/butler/dashboard-butler-app-server-live-path.md
+++ b/docs/butler/dashboard-butler-app-server-live-path.md
@@ -27,7 +27,8 @@ Dashboard Butler live chat completion.
 
 ## Why this is required
 
-The current Dashboard path was built from the older VPS runner pattern:
+The Dashboard path removed by PR #478 had been built from the older VPS runner
+pattern:
 
 ```text
 Dashboard WebSocket job
@@ -36,7 +37,7 @@ Dashboard WebSocket job
   -> final stdout/stderr reply
 ```
 
-That path is insufficient for Issue #450 because it starts a separate Codex
+That removed path is insufficient for Issue #450 because it starts a separate Codex
 process per turn. A WebSocket transport alone does not make a chat session. The
 owner-facing failures observed after PR #477 and deploy confirm this:
 

--- a/scripts/run-vps-runner.mjs
+++ b/scripts/run-vps-runner.mjs
@@ -79,17 +79,6 @@ async function main() {
     apiBaseUrl: process.env.GITHUB_API_URL || DEFAULT_API_BASE_URL
   });
 
-  if (options.dashboardWs) {
-    await startVpsDashboardWebSocketRunner({
-      githubFetch,
-      token,
-      repositoryPolicies,
-      workRoot,
-      env: process.env
-    });
-    return;
-  }
-
   const result = await runVpsRunnerOnce({
     githubFetch,
     token,
@@ -105,41 +94,6 @@ async function main() {
   }
 
   console.log(result.message);
-}
-
-async function startVpsDashboardWebSocketRunner({
-  githubFetch,
-  token,
-  repositoryPolicies,
-  workRoot,
-  env = process.env,
-  WebSocketImpl = globalThis.WebSocket,
-  logger = console
-}) {
-  const threadId = normalizeText(env.VTDD_DASHBOARD_THREAD_ID);
-  if (!threadId) {
-    throw new Error("VTDD_DASHBOARD_THREAD_ID is required for dashboard WebSocket mode");
-  }
-  const runtimeUrl = mustGetEnv("VTDD_RUNTIME_URL", env.VTDD_RUNTIME_URL);
-  const bearerToken = mustGetEnv("VTDD_GATEWAY_BEARER_TOKEN", env.VTDD_GATEWAY_BEARER_TOKEN);
-  return connectVpsDashboardWebSocketClient({
-    runtimeUrl,
-    bearerToken,
-    threadId,
-    WebSocketImpl,
-    logger,
-    onJob: async (job, socket) => {
-      await executeVpsDashboardSocketJob({
-        githubFetch,
-        token,
-        workRoot,
-        job,
-        socket,
-        repositoryPolicies,
-        env
-      });
-    }
-  });
 }
 
 async function runVpsRunnerOnce({
@@ -228,17 +182,6 @@ async function executeVpsRunnerExecution({
   });
 
   try {
-    if (isDashboardChatTriageGoal(payload.codexGoal)) {
-      return executeVpsDashboardChatTriage({
-        githubFetch,
-        payload,
-        notification,
-        workRoot,
-        env,
-        issue
-      });
-    }
-
     if (isPostMergeVerificationGoal(payload.codexGoal)) {
       return executeVpsPostMergeVerification({
         githubFetch,
@@ -534,441 +477,6 @@ async function executeVpsPostMergeVerification({
       ? `Post-merge verification completed for ${payload.repository}#${result.pullRequest.number}.`
       : result.reason
   };
-}
-
-async function executeVpsDashboardChatTriage({ githubFetch, payload, notification, workRoot, env, issue }) {
-  await assertVpsRunnerNotCanceled({ githubFetch, payload, checkpoint: "before_triage_clone", notification });
-  const workspace = path.join(workRoot, safePathSegment(payload.repository), payload.executionId);
-  await fs.mkdir(path.dirname(workspace), { recursive: true });
-  await runCommand("rm", ["-rf", workspace], { env });
-  await runTrackedVpsCommand("gh", ["repo", "clone", payload.repository, workspace], {
-    env,
-    githubFetch,
-    payload,
-    notification,
-    currentStep: "dashboard_chat_repo_clone"
-  });
-  const preflight = await buildVpsRunnerPreflightReceipt({
-    workspace,
-    payload,
-    issue
-  });
-  await postVpsRunnerEvent({
-    githubFetch,
-    payload,
-    notification,
-    event: {
-      status: preflight.ok ? "running" : "blocked",
-      lastEvent: preflight.ok ? "context_preflight_completed" : "context_preflight_blocked",
-      currentStep: "context_preflight",
-      preflight
-    }
-  });
-  if (!preflight.ok) {
-    return {
-      ok: false,
-      reason:
-        preflight.reason ||
-        "VPS runner preflight receipt could not be created. Butler/owner decision is required before dashboard chat triage."
-    };
-  }
-  await assertVpsRunnerNotCanceled({ githubFetch, payload, checkpoint: "before_triage_codex", notification });
-  const prompt = buildDashboardChatTriagePrompt({ payload, issue, preflight });
-  const result = await runTrackedVpsCommand("codex", buildCodexExecArgs({ env: process.env }), {
-    cwd: workspace,
-    env: buildCodexExecutionEnv(process.env, { includeRuntimeBridge: true }),
-    input: prompt,
-    maxBuffer: 1024 * 1024 * 12,
-    githubFetch,
-    payload,
-    notification,
-    currentStep: "dashboard_chat_triage"
-  });
-  await assertVpsRunnerNotCanceled({ githubFetch, payload, checkpoint: "after_triage_codex", notification });
-  const reply = summarizeDashboardReplyText(result.stdout || result.stderr || "VPS Codex CLI completed dashboard chat triage.", 4000);
-  await postVpsRunnerEvent({
-    githubFetch,
-    payload,
-    notification,
-    event: {
-      status: "completed",
-      lastEvent: "dashboard_chat_triage_completed",
-      finalEvent: "dashboard_chat_triage_completed",
-      currentStep: "dashboard_chat_triage",
-      message: reply
-    }
-  });
-  return { ok: true, message: reply };
-}
-
-function buildDashboardRunnerWebSocketUrl({ runtimeUrl, threadId }) {
-  const resolvedThreadId = normalizeText(threadId);
-  if (!resolvedThreadId) {
-    throw new Error("dashboard threadId is required");
-  }
-  const endpoint = new URL("/v2/dashboard/vps-runner/ws", runtimeUrl);
-  endpoint.protocol = endpoint.protocol === "http:" ? "ws:" : "wss:";
-  endpoint.searchParams.set("threadId", resolvedThreadId);
-  return endpoint.toString();
-}
-
-async function connectVpsDashboardWebSocketClient({
-  runtimeUrl,
-  bearerToken,
-  threadId,
-  WebSocketImpl = globalThis.WebSocket,
-  onJob,
-  logger = console,
-  reconnect = true,
-  reconnectDelays = [1000, 5000, 15000, 30000],
-  reconnectAttempt = 0,
-  setTimeoutFn = globalThis.setTimeout
-}) {
-  if (typeof WebSocketImpl !== "function") {
-    throw new Error("WebSocket is not available in this Node runtime");
-  }
-  const protocols = ["vtdd-vps-runner", buildDashboardRunnerBearerProtocol(bearerToken)];
-  const socket = new WebSocketImpl(buildDashboardRunnerWebSocketUrl({ runtimeUrl, threadId }), protocols, {
-    headers: {
-      authorization: `Bearer ${bearerToken}`
-    }
-  });
-  addSocketListener(socket, "open", () => {
-    reconnectAttempt = 0;
-    logger?.log?.(`Connected dashboard WebSocket runner for ${threadId}.`);
-  });
-  addSocketListener(socket, "message", async (event) => {
-    const raw = typeof event?.data === "string" ? event.data : event;
-    let payload;
-    try {
-      payload = JSON.parse(String(raw || "{}"));
-    } catch (error) {
-      sendDashboardSocketReply(socket, {
-        threadId,
-        status: "failed",
-        message: "VPS Codex CLI が dashboard job JSON を読み取れませんでした。"
-      });
-      return;
-    }
-    if (payload?.type !== "dashboard_chat_job") {
-      return;
-    }
-    try {
-      await onJob?.(payload, socket);
-    } catch (error) {
-      sendDashboardSocketReply(socket, {
-        threadId: normalizeText(payload.threadId) || threadId,
-        repository: normalizeRepository(payload.repository),
-        issueNumber: normalizePositiveInteger(payload.relatedIssue || payload.issueNumber),
-        status: "failed",
-        message: `VPS Codex CLI dashboard job failed: ${summarizeDiagnosticText(error?.message || String(error), 1000)}`
-      });
-    }
-  });
-  addSocketListener(socket, "close", () => {
-    logger?.error?.(`Dashboard WebSocket runner disconnected for ${threadId}.`);
-    if (!reconnect) {
-      return;
-    }
-    const delays = Array.isArray(reconnectDelays) && reconnectDelays.length > 0 ? reconnectDelays : [1000];
-    const delay = Number(delays[Math.min(reconnectAttempt, delays.length - 1)]) || 1000;
-    logger?.log?.(`Reconnecting dashboard WebSocket runner for ${threadId} in ${delay}ms.`);
-    setTimeoutFn(() => {
-      connectVpsDashboardWebSocketClient({
-        runtimeUrl,
-        bearerToken,
-        threadId,
-        WebSocketImpl,
-        onJob,
-        logger,
-        reconnect,
-        reconnectDelays,
-        reconnectAttempt: reconnectAttempt + 1,
-        setTimeoutFn
-      }).catch((error) => {
-        logger?.error?.(`Dashboard WebSocket runner reconnect failed: ${error?.message || String(error)}`);
-      });
-    }, delay);
-  });
-  addSocketListener(socket, "error", (error) => {
-    logger?.error?.(`Dashboard WebSocket runner error: ${error?.message || String(error)}`);
-  });
-  return socket;
-}
-
-function addSocketListener(socket, eventName, handler) {
-  if (typeof socket?.addEventListener === "function") {
-    socket.addEventListener(eventName, handler);
-    return;
-  }
-  if (typeof socket?.on === "function") {
-    socket.on(eventName, handler);
-  }
-}
-
-async function executeVpsDashboardSocketJob({
-  githubFetch,
-  token,
-  workRoot,
-  job,
-  socket,
-  repositoryPolicies,
-  env = process.env
-}) {
-  const payload = buildVpsDashboardSocketExecutionPayload(job);
-  if (payload.conversationOnly) {
-    const result = await runCommand("codex", buildCodexExecArgs({ env }), {
-      env: buildCodexExecutionEnv(env),
-      input: buildDashboardGeneralChatPrompt({ payload }),
-      maxBuffer: 1024 * 1024 * 12
-    });
-    const reply = summarizeDashboardReplyText(result.stdout || result.stderr || "VPS Codex CLI completed dashboard chat.", 4000);
-    sendDashboardSocketReply(socket, {
-      threadId: payload.handoff.dashboardThreadId,
-      status: "completed",
-      message: reply
-    });
-    return;
-  }
-  const policies = normalizeRepositoryPolicies({ repositoryPolicies });
-  const policy = validateVpsRunnerPayloadPolicy(payload, policies);
-  if (!policy.ok) {
-    sendDashboardSocketReply(socket, {
-      threadId: payload.handoff.dashboardThreadId,
-      repository: payload.repository,
-      issueNumber: payload.issueNumber,
-      status: "blocked",
-      message: `VPS Codex CLI blocked dashboard job: ${policy.reason}`
-    });
-    return;
-  }
-  const commandEnv = buildRunnerCommandEnv({ token });
-  const issue = payload.issueNumber
-    ? await githubFetch(`/repos/${payload.repository}/issues/${payload.issueNumber}`)
-    : {};
-  const workspace = path.join(workRoot, safePathSegment(payload.repository), payload.executionId);
-  await fs.mkdir(path.dirname(workspace), { recursive: true });
-  await runCommand("rm", ["-rf", workspace], { env: commandEnv });
-  await runCommand("gh", ["repo", "clone", payload.repository, workspace], { env: commandEnv });
-  const preflight = await buildVpsRunnerPreflightReceipt({ workspace, payload, issue });
-  if (!preflight.ok) {
-    sendDashboardSocketReply(socket, {
-      threadId: payload.handoff.dashboardThreadId,
-      repository: payload.repository,
-      issueNumber: payload.issueNumber,
-      status: "blocked",
-      message:
-        preflight.reason ||
-        "VPS runner preflight receipt could not be created. Butler/owner decision is required before dashboard chat triage."
-    });
-    return;
-  }
-  const result = await runCommand("codex", buildCodexExecArgs({ env }), {
-    cwd: workspace,
-    env: buildCodexExecutionEnv(env, { includeRuntimeBridge: true }),
-    input: buildDashboardChatTriagePrompt({ payload, issue, preflight }),
-    maxBuffer: 1024 * 1024 * 12
-  });
-  const reply = summarizeDashboardReplyText(result.stdout || result.stderr || "VPS Codex CLI completed dashboard chat triage.", 4000);
-  sendDashboardSocketReply(socket, {
-    threadId: payload.handoff.dashboardThreadId,
-    repository: payload.repository,
-    issueNumber: payload.issueNumber,
-    status: "completed",
-    message: reply
-  });
-}
-
-function buildVpsDashboardSocketExecutionPayload(job) {
-  const repository = normalizeRepository(job?.repository);
-  const issueNumber = normalizePositiveInteger(job?.relatedIssue || job?.issueNumber);
-  const threadId = normalizeText(job?.threadId);
-  const repositoryResolution = job?.repositoryResolution && typeof job.repositoryResolution === "object" ? job.repositoryResolution : {};
-  const conversationOnly = !repository;
-  const issueContextReadable = Boolean(repository && issueNumber);
-  return {
-    executionId: `dashboard-ws-${Date.now()}-${crypto.randomUUID()}`,
-    repository,
-    issueNumber,
-    branch: `codex/dashboard-chat-${Date.now()}`,
-    baseRef: "main",
-    codexGoal: "dashboard_chat_triage",
-    conversationOnly,
-    issueContextReadable,
-    repositoryResolution: {
-      ok: repositoryResolution.ok === true,
-      error: normalizeText(repositoryResolution.error),
-      reason: normalizeText(repositoryResolution.reason),
-      via: normalizeText(repositoryResolution.via)
-    },
-    handoff: {
-      ownerMessage: normalizeText(job?.text),
-      repositoryInput: normalizeText(job?.repositoryInput) || repository,
-      dashboardThreadId: threadId
-    }
-  };
-}
-
-function buildDashboardGeneralChatPrompt({ payload }) {
-  const handoff = payload?.handoff && typeof payload.handoff === "object" ? payload.handoff : {};
-  const ownerMessage = normalizeText(handoff.ownerMessage);
-  const repositoryInput = normalizeText(handoff.repositoryInput);
-  const issueNumber = normalizePositiveInteger(payload?.issueNumber);
-  const repositoryResolution = payload?.repositoryResolution && typeof payload.repositoryResolution === "object"
-    ? payload.repositoryResolution
-    : {};
-  return [
-    "You are VTDD Butler running on the user's VPS Codex CLI.",
-    "",
-    "Owner dashboard message:",
-    ownerMessage || "(missing dashboard owner message)",
-    "",
-    "Dashboard routing:",
-    "- This message did not resolve to a repository/Issue execution target.",
-    "- Answer as a normal Butler conversation. Do not require GitHub Issue preflight for general chat.",
-    `- repositoryInput: ${repositoryInput || "missing"}`,
-    `- detectedIssueNumber: ${issueNumber ? `#${issueNumber}` : "missing"}`,
-    `- repositoryResolution: ${repositoryResolution.ok === true ? "resolved" : normalizeText(repositoryResolution.error) || "unresolved"}`,
-    "- If an Issue number is present but repository is unresolved, do not answer as if you read that Issue, PRs, checks, or runtime truth.",
-    "- For unresolved repository work, explain in Japanese that repo/nickname or owner/repo is needed before VTDD can read GitHub truth or continue development, and give one short example.",
-    "- If ordinary conversation reveals a new actionable development need, classify it as issue_split_proposal or execution_handoff_needed, then ask for the target repo/nickname and GO boundary before any issue creation or implementation.",
-    "- If the owner is asking a general question, answer directly in Japanese.",
-    "- Do not edit files, commit, push, create PRs, merge, deploy, mutate secrets, mutate permissions, or close Issues.",
-    "Reply format:",
-    "- Japanese first.",
-    "- Be concise.",
-    "- Use readable Markdown with short paragraphs or bullets when the answer has multiple facts.",
-    "- Do not mention internal JSON, WebSocket, preflight, or queue unless it is the actual answer."
-  ].join("\n");
-}
-
-function sendDashboardSocketReply(socket, reply) {
-  if (typeof socket?.send !== "function") {
-    return;
-  }
-  socket.send(
-    JSON.stringify({
-      type: "vps_runner_reply",
-      threadId: normalizeText(reply.threadId),
-      repository: normalizeRepository(reply.repository),
-      issueNumber: normalizePositiveInteger(reply.issueNumber),
-      status: normalizeText(reply.status) || "completed",
-      message: normalizeText(reply.message) || "VPS Codex CLI completed dashboard job."
-    })
-  );
-}
-
-function buildDashboardRunnerBearerProtocol(bearerToken) {
-  return `vtdd-gateway-bearer-${Buffer.from(String(bearerToken), "utf8").toString("base64url")}`;
-}
-
-function buildDashboardChatTriagePrompt({ payload, issue = {}, preflight = null }) {
-  const handoff = payload?.handoff && typeof payload.handoff === "object" ? payload.handoff : {};
-  const ownerMessage = normalizeText(handoff.ownerMessage);
-  const repositoryInput = normalizeText(handoff.repositoryInput) || normalizeText(payload.repository);
-  return [
-    `You are VTDD Butler traffic control running on the user's VPS Codex CLI for ${payload.repository}.`,
-    "",
-    "Owner dashboard message:",
-    ownerMessage || "(missing dashboard owner message)",
-    "",
-    "Resolved target:",
-    `- repositoryInput: ${repositoryInput || "missing"}`,
-    `- repository: ${payload.repository}`,
-    `- queue issue: #${payload.issueNumber}`,
-    `- dashboardThreadId: ${normalizeText(handoff.dashboardThreadId) || "missing"}`,
-    "",
-    "Custom GPT parity requirement:",
-    "- Preserve every owner-facing capability that the Custom GPT Butler had.",
-    "- Treat the top dashboard chat as the natural-language Butler entrypoint, not as an open_pr form.",
-    "- Resolve repository/nickname intent before acting. If the target is ambiguous, ask one short Japanese confirmation question.",
-    "- Read GitHub runtime truth when the owner asks about Issues, PRs, checks, Actions, deploys, reviews, or remaining work.",
-    "- Use repository nickname semantics: no default repository, unresolved target blocks execution, ambiguous nickname blocks execution.",
-    "- Triage broad owner input into: answer from runtime truth, Issue split proposal, existing Issue linkage, bounded VPS execution handoff, approval URL needed, RAG candidate, or blocker.",
-    "- If Issue creation/splitting is needed, propose concrete Japanese Issue titles/bodies and say what approval/GO is needed; do not silently create or close Issues.",
-    "- If implementation is needed, name the target Issue/scope and required GO/passkey boundary before any execution.",
-    "- If deploy, merge, credential, permission, repository settings, destructive cleanup, or Issue close is requested, return the needed governed approval boundary instead of doing it.",
-    "- Never invent VPS replies. Return only what you can justify from repo/runtime truth and this dashboard message.",
-    "",
-    buildVpsDashboardActionBridgeGuide(),
-    "",
-    "Available local context:",
-    "- You are inside a fresh clone of the target repository.",
-    "- You may inspect files and use GitHub CLI/API if available to read runtime truth.",
-    "- Do not edit files, commit, push, create PRs, merge, deploy, mutate secrets, mutate permissions, or close Issues in dashboard_chat_triage.",
-    "",
-    "Context preflight receipt:",
-    formatVpsRunnerPreflightReceipt(preflight),
-    "",
-    "Queue Issue context:",
-    `Title: ${normalizeText(issue.title) || "(missing issue title)"}`,
-    "",
-    normalizeText(issue.body) || "(missing issue body)",
-    "",
-    "Reply format:",
-    "- Japanese first.",
-    "- Be concise but operational.",
-    "- Use readable Markdown with line breaks. Do not compress bullets into one paragraph.",
-    "- Include the classification: answer / issue_split_proposal / existing_issue_link / execution_handoff_needed / approval_needed / rag_candidate / blocker.",
-    "- Include next action and any missing information.",
-    "- If you mention a GitHub item, include a clickable URL if known."
-  ].join("\n");
-}
-
-function buildVpsDashboardActionReadBridgeGuide() {
-  return [
-    "Runtime read-only bridge:",
-    "- You may call read-only VTDD runtime routes from this VPS Codex CLI when the owner asks for VTDD status, memory, repository, or setup facts.",
-    "- Use environment variables only; do not print or expose VTDD_GATEWAY_BEARER_TOKEN.",
-    "- Base URL: ${VTDD_RUNTIME_URL}",
-    "- Auth header: Authorization: Bearer ${VTDD_GATEWAY_BEARER_TOKEN}",
-    "- curl pattern for GET: curl -sS -H \"Authorization: Bearer ${VTDD_GATEWAY_BEARER_TOKEN}\" \"${VTDD_RUNTIME_URL}<path>?<query>\"",
-    "",
-    "Read/retrieve operations available to mirror Custom GPT Actions:",
-    "- vtddRetrieveGitHub: GET /v2/retrieve/github",
-    "- vtddRetrieveRepositoryNicknames: GET /v2/retrieve/repository-nicknames",
-    "- vtddRetrieveOperationalMemory: GET /v2/retrieve/operational-memory",
-    "- vtddRetrieveCrossMemory: GET /v2/retrieve/cross",
-    "- vtddStartupPreflight: GET /v2/retrieve/startup-preflight",
-    "- vtddRetrieveSelfParity: GET /v2/retrieve/self-parity",
-    "- vtddRetrieveConstitution: GET /v2/retrieve/constitution",
-    "- vtddRetrieveDecisionLogs: GET /v2/retrieve/decisions",
-    "- vtddRetrieveProposalLogs: GET /v2/retrieve/proposals",
-    "- vtddRetrieveCloudflarePages: GET /v2/retrieve/cloudflare-pages",
-    "",
-    "Do not call write/action/high-risk routes from general chat unless the owner has moved into an Issue-backed bounded action and the runtime approval boundary is satisfied."
-  ].join("\n");
-}
-
-function buildVpsDashboardActionBridgeGuide() {
-  return [
-    buildVpsDashboardActionReadBridgeGuide(),
-    "",
-    "Runtime write/action bridge for Issue-backed bounded VTDD work:",
-    "- Use these only after the owner request is tied to a repository/Issue or an explicit bounded runtime action.",
-    "- curl pattern for POST: curl -sS -X POST -H \"Authorization: Bearer ${VTDD_GATEWAY_BEARER_TOKEN}\" -H \"content-type: application/json\" --data '<json>' \"${VTDD_RUNTIME_URL}<path>\"",
-    "",
-    "Write/action operations available only under the same approval boundaries as Custom GPT Actions:",
-    "- vtddGateway: POST /v2/gateway",
-    "- vtddExecute: POST /v2/action/execute",
-    "- vtddWriteGitHub: POST /v2/action/github",
-    "- vtddWriteOperationalMemory: POST /v2/action/memory-write",
-    "- vtddUpsertRepositoryNickname: POST /v2/action/repository-nickname",
-    "- vtddDeleteRepositoryNickname: POST /v2/action/repository-nickname/delete",
-    "- vtddExecutionProgress: GET /v2/action/progress",
-    "- vtddVpsRunnerStatus: GET /v2/action/vps-runner-status",
-    "- vtddVpsRunnerCancel: POST /v2/action/vps-runner-cancel",
-    "",
-    "High-risk operation guidance:",
-    "- Do not call high-risk routes from dashboard chat just because they are listed here.",
-    "- When the owner asks for deploy, credential mutation, permission mutation, repository administration, merge, destructive cleanup, or Issue close, return approval_needed with the required scoped passkey boundary.",
-    "- If a scoped approval grant is missing or mismatched, runtime routes must reject the request. GO alone does not authorize deploy, credential mutation, permission mutation, repository administration, merge, destructive cleanup, or Issue close.",
-    "- vtddGitHubAuthority: POST /v2/action/github-authority",
-    "- vtddDeployProduction: POST /v2/action/deploy",
-    "- vtddSyncGitHubActionsSecret: POST /v2/action/github-actions-secret",
-    "",
-    "Use the Action bridge when it gives better runtime truth than local files. If a call fails, report the exact Japanese blocker without hiding it."
-  ].join("\n");
 }
 
 async function collectVpsPostMergeVerification({ githubFetch, payload, repositoryPolicies, env }) {
@@ -1706,10 +1214,6 @@ function formatVpsRunnerPreflightReceipt(preflight) {
 
 function isPrRevisionGoal(goal) {
   return ["revise_pr", "respond_to_review"].includes(normalizeText(goal));
-}
-
-function isDashboardChatTriageGoal(goal) {
-  return normalizeText(goal) === "dashboard_chat_triage";
 }
 
 function isPostMergeVerificationGoal(goal) {
@@ -2843,19 +2347,6 @@ function summarizeDiagnosticText(value, maxLength = 500) {
   return redacted.length <= maxLength ? redacted : `${redacted.slice(0, maxLength)} [truncated]`;
 }
 
-function summarizeDashboardReplyText(value, maxLength = 4000) {
-  const redacted = redactDiagnosticText(value)
-    .split("\n")
-    .map((line) => line.trimEnd())
-    .join("\n")
-    .replace(/\n{3,}/g, "\n\n")
-    .trim();
-  if (!redacted) {
-    return null;
-  }
-  return redacted.length <= maxLength ? redacted : `${redacted.slice(0, maxLength)}\n[truncated]`;
-}
-
 function buildVpsRunnerNotificationContext(input = {}) {
   return {
     queueCommentAuthor: normalizeGitHubLogin(input.queueCommentAuthor),
@@ -3063,8 +2554,7 @@ function mustGetEnv(name, value = process.env[name]) {
 
 function parseArgs(args) {
   return {
-    dryRun: args.includes("--dry-run"),
-    dashboardWs: args.includes("--dashboard-ws")
+    dryRun: args.includes("--dry-run")
   };
 }
 
@@ -3079,12 +2569,6 @@ export {
   buildFreshExecutionBranchCandidates,
   buildVpsRunnerCompletionFinalEvent,
   buildCodexExecutionPrompt,
-  buildDashboardChatTriagePrompt,
-  buildDashboardGeneralChatPrompt,
-  buildVpsDashboardSocketExecutionPayload,
-  buildVpsDashboardActionBridgeGuide,
-  buildVpsDashboardActionReadBridgeGuide,
-  buildDashboardRunnerWebSocketUrl,
   buildCodexExecArgs,
   buildCodexExecutionEnv,
   buildVpsRunnerPreflightReceipt,
@@ -3097,7 +2581,6 @@ export {
   buildVpsRunnerPullRequestContext,
   checkoutVpsRunnerBranch,
   classifyVpsRunnerFailure,
-  connectVpsDashboardWebSocketClient,
   formatPullRequestContext,
   isNonFastForwardPushFailure,
   loadVpsRunnerRepositoryPolicies,
@@ -3107,9 +2590,7 @@ export {
   parseVpsRunnerQueueComment,
   postVpsRunnerEvent,
   runVpsRunnerOnce,
-  startVpsDashboardWebSocketRunner,
   resolveRoleGitHubAppInstallationToken,
-  summarizeDashboardReplyText,
   summarizeDiagnosticText,
   selectPendingVpsReviewerFallbacks,
   selectPendingVpsRunnerExecutions

--- a/src/core/remote-codex-executor.js
+++ b/src/core/remote-codex-executor.js
@@ -76,7 +76,6 @@ export const VpsRunnerCancelMode = Object.freeze({
 });
 
 export const RemoteCodexDispatchGoal = Object.freeze({
-  DASHBOARD_CHAT_TRIAGE: "dashboard_chat_triage",
   OPEN_PR: "open_pr",
   REVISE_PR: "revise_pr",
   RESPOND_TO_REVIEW: "respond_to_review",
@@ -185,7 +184,7 @@ export function createRemoteCodexExecutionRequest(input = {}) {
   if (!request.codexGoal) {
     issues.push("codexGoal is required");
   } else if (!REMOTE_CODEX_DISPATCH_GOALS.has(request.codexGoal)) {
-    issues.push("codexGoal must be dashboard_chat_triage, open_pr, revise_pr, respond_to_review, or post_merge_verify");
+    issues.push("codexGoal must be open_pr, revise_pr, respond_to_review, or post_merge_verify");
   }
   if (!request.baseRef) {
     issues.push("baseRef is required");
@@ -1969,7 +1968,6 @@ function buildCodexCloudGitHubComment({ request }) {
 }
 
 function buildVpsRunnerGitHubQueueComment({ request }) {
-  const isDashboardChatTriage = request.codexGoal === RemoteCodexDispatchGoal.DASHBOARD_CHAT_TRIAGE;
   const payload = {
     executionId: request.executionId,
     transport: RemoteCodexExecutorTransport.VPS_RUNNER,
@@ -1988,8 +1986,6 @@ function buildVpsRunnerGitHubQueueComment({ request }) {
   const lines = [
     `<!-- vtdd:vps-runner-execution:${request.executionId} -->`,
     "VTDD 管理の VPS runner 実行キューです。",
-    "",
-    "このコメントは dashboard への返信ではありません。VPS Codex CLI が拾い、完了 event を runtime に返したものだけを dashboard の返信として扱います。",
     "",
     "実行境界:",
     `- リポジトリ: ${request.repository}`,
@@ -2016,26 +2012,16 @@ function buildVpsRunnerGitHubQueueComment({ request }) {
       : []),
     "- 正本: この GitHub Issue",
     "- runtime truth: 現在の GitHub branch / diff / PR / review comments",
-    isDashboardChatTriage
-      ? "- 完了条件: dashboard chat triage の返信 event を同じ thread に返す"
-      : request.codexGoal === RemoteCodexDispatchGoal.POST_MERGE_VERIFY
-        ? "- 完了条件: merge 後 runtime truth を検証し、GitHub-visible evidence を残す"
-        : "- 完了条件: pull request を作成または更新する",
-    ...(isDashboardChatTriage
-      ? [
-          "- PR body requirement: 不要。dashboard chat triage は PR を作成・更新しません。",
-          "- context preflight: VPS runner は `AGENTS.md`、`docs/butler/thread-independent-startup-contract.md`、正本 Issue を読んでから triage を開始します。"
-        ]
-      : [
-          "- PR body requirement: Codex は `docs/pr-template-model.md`、`scripts/render-pr-body.mjs`、`scripts/validate-pr-body.mjs` を確認します。VPS runner も PR create/update 前に検証・正規化します。",
-          "- context preflight: VPS runner は `AGENTS.md`、`docs/butler/thread-independent-startup-contract.md`、正本 Issue、PR body contract files を読んでから編集を開始します。",
-          "- 必須 PR body markers: `## This PR satisfies Intent`, `## Satisfied Success Criteria`, `## Unsatisfied Success Criteria`, `## Verification Evidence`, `## Surface Update Checklist`."
-        ]),
+    request.codexGoal === RemoteCodexDispatchGoal.POST_MERGE_VERIFY
+      ? "- 完了条件: merge 後 runtime truth を検証し、GitHub-visible evidence を残す"
+      : "- 完了条件: pull request を作成または更新する",
+    "- PR body requirement: Codex は `docs/pr-template-model.md`、`scripts/render-pr-body.mjs`、`scripts/validate-pr-body.mjs` を確認します。VPS runner も PR create/update 前に検証・正規化します。",
+    "- context preflight: VPS runner は `AGENTS.md`、`docs/butler/thread-independent-startup-contract.md`、正本 Issue、PR body contract files を読んでから編集を開始します。",
+    "- 必須 PR body markers: `## This PR satisfies Intent`, `## Satisfied Success Criteria`, `## Unsatisfied Success Criteria`, `## Verification Evidence`, `## Surface Update Checklist`.",
     "- preflight 入力が不足している場合、推測実装は禁止です。runner は Butler/owner に次の判断を求め、bounded request の再発行を待ちます。",
     "",
     "ルール:",
     "- Issue の範囲を勝手に広げない。",
-    ...(isDashboardChatTriage ? ["- ファイル編集しない。", "- commit しない。", "- push しない。", "- PR を作成・更新しない。"] : []),
     "- merge しない。",
     "- deploy しない。",
     "- reviewer objection は Butler/human judgment 用に残す。",
@@ -2051,15 +2037,11 @@ function buildVpsRunnerGitHubQueueComment({ request }) {
 function buildExecutionPreflightPolicy({ codexGoal } = {}) {
   const requiredRepoFiles = [
     "AGENTS.md",
-    "docs/butler/thread-independent-startup-contract.md"
+    "docs/butler/thread-independent-startup-contract.md",
+    "docs/pr-template-model.md",
+    "scripts/render-pr-body.mjs",
+    "scripts/validate-pr-body.mjs"
   ];
-  if (codexGoal !== RemoteCodexDispatchGoal.DASHBOARD_CHAT_TRIAGE) {
-    requiredRepoFiles.push(
-      "docs/pr-template-model.md",
-      "scripts/render-pr-body.mjs",
-      "scripts/validate-pr-body.mjs"
-    );
-  }
   return {
     mode: "auto_receipt",
     onMissingContract: "owner_decision_required",

--- a/src/worker.js
+++ b/src/worker.js
@@ -1,5 +1,5 @@
 import worker from "./worker/runtime.js";
 
-export { DashboardChatRoom, selectDashboardWebSocketResponseProtocol } from "./worker/runtime.js";
+export { DashboardChatRoom } from "./worker/runtime.js";
 
 export default worker;

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -105,12 +105,6 @@ export class DashboardChatRoom {
       return json(202, { ok: true, threadId });
     }
 
-    if (request.method === "POST" && url.pathname === "/dispatch") {
-      const payload = await readJson(request);
-      const result = await this.pushVpsRunnerJob(payload);
-      return json(result.ok ? 202 : 503, result);
-    }
-
     if (request.headers.get("upgrade")?.toLowerCase() !== "websocket") {
       return json(426, {
         ok: false,
@@ -126,10 +120,7 @@ export class DashboardChatRoom {
       });
     }
 
-    const isVpsRunnerSocket = url.pathname.endsWith("/dashboard/vps-runner/ws") || url.pathname === "/vps-runner/ws";
-    const threadId = isVpsRunnerSocket
-      ? normalizeDashboardThreadId(url.searchParams.get("threadId") || url.searchParams.get("thread_id"))
-      : extractDashboardChatSocketThreadId(url.pathname);
+    const threadId = extractDashboardChatSocketThreadId(url.pathname);
     if (!threadId) {
       return json(422, {
         ok: false,
@@ -140,7 +131,7 @@ export class DashboardChatRoom {
 
     const pair = new WebSocketPair();
     const [client, server] = Object.values(pair);
-    const attachment = isVpsRunnerSocket ? { role: "vps_runner", threadId } : { role: "dashboard", threadId };
+    const attachment = { role: "dashboard", threadId };
     if (typeof this.ctx?.acceptWebSocket === "function") {
       server.serializeAttachment(attachment);
       this.ctx.acceptWebSocket(server);
@@ -151,21 +142,10 @@ export class DashboardChatRoom {
       server.addEventListener("error", () => this.sessions.delete(server));
       server.addEventListener("message", (event) => this.handleSocketMessage(server, event?.data, attachment));
     }
-    if (isVpsRunnerSocket && isSocketOpen(server)) {
-      server.send(JSON.stringify({ type: "vps_runner_connected", ok: true }));
-    } else {
-      await this.sendThread(server, threadId);
-    }
-
-    const responseHeaders = new Headers();
-    const responseProtocol = selectDashboardWebSocketResponseProtocol(request.headers.get("sec-websocket-protocol"));
-    if (responseProtocol) {
-      responseHeaders.set("sec-websocket-protocol", responseProtocol);
-    }
+    await this.sendThread(server, threadId);
 
     return new Response(null, {
       status: 101,
-      headers: responseHeaders,
       webSocket: client
     });
   }
@@ -197,10 +177,6 @@ export class DashboardChatRoom {
       payload = text ? JSON.parse(text) : null;
     } catch {
       payload = null;
-    }
-    if (socketAttachment.role === "vps_runner") {
-      await this.acceptVpsRunnerReply(payload, socketAttachment);
-      return;
     }
     if (payload?.type === "owner_message") {
       await this.acceptOwnerMessage({ socket, threadId, payload });
@@ -259,109 +235,20 @@ export class DashboardChatRoom {
       },
       { threadId }
     );
-    const thinkingMessage = normalizeDashboardChatMessage(
+    const butlerMessage = normalizeDashboardChatMessage(
       {
         threadId,
-        role: "system",
+        role: "butler",
         repository,
         relatedIssue,
-        status: "thinking",
-        text: "VPS Codex CLI に送信しました。返信を待っています。",
+        status: "blocked",
+        text: buildDashboardAppServerNotConnectedReply({ repository, relatedIssue }),
         createdAt: new Date(Date.parse(now) + 1).toISOString()
       },
       { threadId }
     );
-    const messages = store ? await store.appendMany(threadId, [ownerMessage, thinkingMessage]) : [ownerMessage, thinkingMessage].filter(Boolean);
+    const messages = store ? await store.appendMany(threadId, [ownerMessage, butlerMessage]) : [ownerMessage, butlerMessage].filter(Boolean);
     await this.broadcastThread({ threadId, messages });
-    const pushed = await this.pushVpsRunnerJob({
-      type: "dashboard_chat_job",
-      threadId,
-      repository,
-      repositoryInput: repositoryResolution.input || payload?.repositoryInput || payload?.repository,
-      repositoryResolution,
-      relatedIssue,
-      text,
-      codexGoal: normalizeDashboardEventText(payload?.codexGoal || "dashboard_chat_triage"),
-      createdAt: now
-    });
-    if (!pushed.ok) {
-      const failedMessage = normalizeDashboardChatMessage(
-        {
-          threadId,
-          role: "system",
-          repository,
-          relatedIssue,
-          status: "failed",
-          text: "VPS Codex CLI が WebSocket 接続されていないため送信できませんでした。runner 接続を確認してください。",
-          createdAt: new Date(Date.parse(now) + 2).toISOString()
-        },
-        { threadId }
-      );
-      const failedMessages = store ? await store.appendMany(threadId, [failedMessage]) : [failedMessage].filter(Boolean);
-      await this.broadcastThread({ threadId, messages: failedMessages });
-    }
-  }
-
-  async acceptVpsRunnerReply(payload, socketAttachment = {}) {
-    const socketThreadId = normalizeDashboardThreadId(socketAttachment.threadId);
-    const threadId = normalizeDashboardThreadId(payload?.threadId || payload?.thread_id || socketThreadId);
-    if (!threadId) {
-      return;
-    }
-    if (socketThreadId && threadId !== socketThreadId) {
-      return;
-    }
-    const message = normalizeDashboardChatMessage(
-      {
-        threadId,
-        role: "runner",
-        repository: payload?.repository,
-        relatedIssue: payload?.relatedIssue || payload?.issueNumber,
-        status: payload?.status === "failed" ? "failed" : "replied",
-        text: payload?.text || payload?.message || payload?.body,
-        createdAt: payload?.createdAt || payload?.updatedAt
-      },
-      { threadId }
-    );
-    const store = resolveDashboardChatStore(this.env);
-    const messages = store ? await store.appendMany(threadId, [message]) : [message].filter(Boolean);
-    await this.broadcastThread({ threadId, messages });
-  }
-
-  async pushVpsRunnerJob(payload) {
-    const job = {
-      type: "dashboard_chat_job",
-      jobId: normalizeDashboardEventText(payload?.jobId) || crypto.randomUUID(),
-      threadId: normalizeDashboardThreadId(payload?.threadId || payload?.thread_id),
-      repository: normalizeCanonicalRepositoryInput(payload?.repository),
-      repositoryInput: normalizeDashboardEventText(payload?.repositoryInput || payload?.repository_input),
-      repositoryResolution: normalizeObject(payload?.repositoryResolution || payload?.repository_resolution),
-      relatedIssue: normalizePositiveInteger(payload?.relatedIssue || payload?.issueNumber),
-      text: sanitizeDashboardChatText(payload?.text || payload?.message || payload?.body),
-      codexGoal: normalizeDashboardEventText(payload?.codexGoal || "dashboard_chat_triage"),
-      createdAt: normalizeIsoTimestamp(payload?.createdAt) || new Date().toISOString()
-    };
-    const runners = this.connectedSockets().filter((socket) => this.getSocketAttachment(socket).role === "vps_runner");
-    if (runners.length === 0) {
-      return {
-        ok: false,
-        error: "vps_runner_not_connected",
-        reason: "VPS Codex CLI WebSocket is not connected"
-      };
-    }
-    const frame = JSON.stringify(job);
-    let pushed = 0;
-    for (const runner of runners) {
-      if (isSocketOpen(runner)) {
-        runner.send(frame);
-        pushed += 1;
-      }
-    }
-    return {
-      ok: pushed > 0,
-      pushed,
-      jobId: job.jobId
-    };
   }
 
   async broadcastThread({ threadId, messages = null }) {
@@ -547,10 +434,6 @@ export default {
 
     if (request.method === "GET" && isDashboardChatSocketApiPath(url.pathname)) {
       return handleDashboardChatSocketRequest(request, url, env);
-    }
-
-    if (request.method === "GET" && isApiPath(url.pathname, "/dashboard/vps-runner/ws")) {
-      return handleDashboardVpsRunnerSocketRequest(request, env);
     }
 
     if (request.method === "GET" && isApiPath(url.pathname, "/dashboard/chat/search")) {
@@ -3539,7 +3422,6 @@ async function handleDashboardChatMessageRequest(request, env) {
   }
 
   const payload = await readJson(request);
-  const wantsVpsRunnerHandoff = shouldDispatchDashboardChatToVpsRunner(payload);
   const nicknameListTurn = await buildDashboardRepositoryNicknameListTurn({ payload, env });
   if (nicknameListTurn) {
     const store = resolveDashboardChatStore(env);
@@ -3559,25 +3441,16 @@ async function handleDashboardChatMessageRequest(request, env) {
     });
   }
   const repositoryResolution = await resolveDashboardChatRepository({ payload, env });
-  if (!repositoryResolution.ok) {
-    return json(repositoryResolution.status ?? 422, {
-      ok: false,
-      error: repositoryResolution.error,
-      reason: repositoryResolution.reason,
-      issues: repositoryResolution.issues ?? [],
-      candidates: repositoryResolution.candidates ?? []
-    });
-  }
+  const repository = repositoryResolution.ok ? repositoryResolution.repository : "";
 
   const prepared = buildDashboardChatTurn(
     {
       ...payload,
-      repository: repositoryResolution.repository,
+      repository,
       relatedIssue:
         normalizePositiveInteger(payload?.relatedIssue || payload?.issueNumber) ||
         extractIssueNumberFromDashboardChatText(payload?.text || payload?.message || payload?.body)
-    },
-    { wantsVpsRunnerHandoff }
+    }
   );
   if (!prepared.ok) {
     return json(422, {
@@ -3596,51 +3469,12 @@ async function handleDashboardChatMessageRequest(request, env) {
     });
   }
 
-  let execution = null;
-  let messagesToStore = prepared.messages;
-  if (wantsVpsRunnerHandoff) {
-    const handoffPayload = buildDashboardVpsRunnerHandoffPayload({
-      payload,
-      prepared,
-      env,
-      runtimeUrl: new URL(request.url).origin
-    });
-    if (!handoffPayload.ok) {
-      return json(422, {
-        ok: false,
-        error: handoffPayload.error,
-        reason: handoffPayload.reason,
-        issues: handoffPayload.issues
-      });
-    }
-
-    const dispatched = await dispatchRemoteCodexExecution({
-      gatewayResult: { repository: prepared.repository },
-      payload: handoffPayload.payload,
-      executorTransport: "vps_runner",
-      env
-    });
-    if (!dispatched.ok) {
-      return json(dispatched.status ?? 502, {
-        ok: false,
-        error: dispatched.error ?? dispatched.blockedByRule ?? "dashboard_vps_runner_dispatch_failed",
-        reason: dispatched.reason,
-        issues: dispatched.issues ?? []
-      });
-    }
-    execution = dispatched.execution;
-    messagesToStore = [
-      ...prepared.messages,
-      buildDashboardVpsRunnerQueuedMessage({ prepared, execution })
-    ].filter(Boolean);
-  }
-
-  const messages = await store.appendMany(prepared.threadId, messagesToStore);
+  const messages = await store.appendMany(prepared.threadId, prepared.messages);
   return json(202, {
     ok: true,
     threadId: prepared.threadId,
     messages,
-    execution
+    execution: null
   });
 }
 
@@ -3683,92 +3517,6 @@ async function handleDashboardChatSocketRequest(request, url, env) {
     });
   }
   return room.fetch(request);
-}
-
-export function selectDashboardWebSocketResponseProtocol(value) {
-  const protocols = normalizeText(value)
-    .split(",")
-    .map((item) => item.trim())
-    .filter(Boolean);
-  return protocols.includes("vtdd-vps-runner") ? "vtdd-vps-runner" : "";
-}
-
-async function handleDashboardVpsRunnerSocketRequest(request, env) {
-  const auth = authorizeGatewayRequest({
-    request: withDashboardRunnerProtocolAuthorization(request),
-    env,
-    apiSuffix: "/dashboard/vps-runner/ws"
-  });
-  if (!auth.ok) {
-    return json(auth.status, {
-      ok: false,
-      error: "unauthorized",
-      reason: auth.reason
-    });
-  }
-  const url = new URL(request.url);
-  const threadId = normalizeDashboardThreadId(url.searchParams.get("threadId") || url.searchParams.get("thread_id"));
-  if (!threadId) {
-    return json(422, {
-      ok: false,
-      error: "thread_id_required",
-      reason: "threadId is required for VPS Codex CLI dashboard WebSocket"
-    });
-  }
-  const room = resolveDashboardChatRoomStub(env, threadId);
-  if (!room) {
-    return json(503, {
-      ok: false,
-      error: "dashboard_vps_runner_room_unavailable",
-      reason: "DASHBOARD_CHAT_ROOMS Durable Object binding is not configured"
-    });
-  }
-  if (request.headers.get("upgrade")?.toLowerCase() !== "websocket") {
-    return json(426, {
-      ok: false,
-      error: "websocket_upgrade_required",
-      reason: "VPS Codex CLI push channel requires a WebSocket upgrade"
-    });
-  }
-  return room.fetch(request);
-}
-
-function withDashboardRunnerProtocolAuthorization(request) {
-  if (request.headers.get("authorization")) {
-    return request;
-  }
-  const protocol = normalizeText(request.headers.get("sec-websocket-protocol"));
-  const token = protocol
-    .split(",")
-    .map((item) => item.trim())
-    .find((item) => item.startsWith("vtdd-gateway-bearer-"));
-  if (!token) {
-    return request;
-  }
-  const encoded = token.slice("vtdd-gateway-bearer-".length);
-  const bearerToken = decodeBase64UrlText(encoded);
-  if (!bearerToken) {
-    return request;
-  }
-  const headers = new Headers(request.headers);
-  headers.set("authorization", `Bearer ${bearerToken}`);
-  return new Request(request, { headers });
-}
-
-function decodeBase64UrlText(value) {
-  const normalized = normalizeText(value);
-  if (!/^[A-Za-z0-9_-]+$/.test(normalized)) {
-    return "";
-  }
-  try {
-    const base64 = normalized.replace(/-/g, "+").replace(/_/g, "/");
-    const padded = base64.padEnd(Math.ceil(base64.length / 4) * 4, "=");
-    const binary = atob(padded);
-    const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
-    return new TextDecoder().decode(bytes);
-  } catch {
-    return "";
-  }
 }
 
 async function handleDashboardChatThreadRequest(request, url, env) {
@@ -5972,14 +5720,6 @@ function createD1DashboardChatStore(d1) {
 function buildDashboardChatTurn(payload, options = {}) {
   const input = normalizeObject(payload);
   const repository = normalizeCanonicalRepositoryInput(input.repository);
-  if (!repository) {
-    return {
-      ok: false,
-      error: "repository_required",
-      reason: "repository is required for dashboard Butler chat"
-    };
-  }
-
   const text = sanitizeDashboardChatText(input.text || input.message || input.body);
   if (!text) {
     return {
@@ -5991,7 +5731,7 @@ function buildDashboardChatTurn(payload, options = {}) {
 
   const threadId =
     normalizeDashboardThreadId(input.threadId || input.thread_id) ||
-    `dashboard-main-${repository.replace("/", "-")}`;
+    (repository ? `dashboard-main-${repository.replace("/", "-")}` : "dashboard-main-unresolved");
   const relatedIssue = normalizePositiveInteger(input.relatedIssue || input.issueNumber);
   const now = new Date().toISOString();
   const ownerMessage = normalizeDashboardChatMessage(
@@ -6006,25 +5746,18 @@ function buildDashboardChatTurn(payload, options = {}) {
     },
     { threadId }
   );
-  const butlerMessage =
-    options.wantsVpsRunnerHandoff === true
-      ? null
-      : normalizeDashboardChatMessage(
-          {
-            threadId,
-            role: "butler",
-            repository,
-            relatedIssue,
-            status: "replied",
-            text: buildDeterministicButlerChatReply({
-              text,
-              repository,
-              relatedIssue
-            }),
-            createdAt: new Date(Date.parse(now) + 1).toISOString()
-          },
-          { threadId }
-        );
+  const butlerMessage = normalizeDashboardChatMessage(
+    {
+      threadId,
+      role: "butler",
+      repository,
+      relatedIssue,
+      status: "blocked",
+      text: buildDashboardAppServerNotConnectedReply({ repository, relatedIssue }),
+      createdAt: new Date(Date.parse(now) + 1).toISOString()
+    },
+    { threadId }
+  );
 
   return {
     ok: true,
@@ -6035,19 +5768,19 @@ function buildDashboardChatTurn(payload, options = {}) {
   };
 }
 
-function buildDeterministicButlerChatReply({ text, repository, relatedIssue, wantsVpsRunnerHandoff = false }) {
-  const lowerText = normalizeText(text).toLowerCase();
-  const issuePhrase = relatedIssue ? ` Issue #${relatedIssue} として扱えます。` : "";
-  if (wantsVpsRunnerHandoff) {
-    return `受け取りました。${repository} の Issue #${relatedIssue || "未指定"} に紐づけて、VPS Codex CLI への bounded handoff を作成します。runner からの進捗は同じ dashboard chat thread に返します。`.trim();
-  }
-  if (lowerText.includes("vps") || lowerText.includes("codex") || lowerText.includes("cli")) {
-    return `受け取りました。${repository} の会話として、この turn を dashboard chat thread に保存しました。VPS Codex CLI への実行 dispatch はまだ行わず、次スライスで runner の返信イベントを同じ chat thread に返します。${issuePhrase}`.trim();
-  }
-  if (lowerText.includes("issue") || lowerText.includes("作って") || lowerText.includes("実装")) {
-    return `受け取りました。${repository} の話として保存しました。ここから Issue 候補を整理し、実行が必要な場合は GO / passkey 境界を明示して開発 queue へ進めます。${issuePhrase}`.trim();
-  }
-  return `受け取りました。${repository} の Butler 会話として同じ thread に保存しました。今は dashboard chat runtime の初期接続なので、まずは会話履歴と返信を同じ画面で確認できます。${issuePhrase}`.trim();
+function buildDashboardAppServerNotConnectedReply({ repository, relatedIssue } = {}) {
+  const repoPhrase = repository ? `対象 repo: ${repository}` : "対象 repo: 未指定";
+  const issuePhrase = relatedIssue ? `関連 Issue: #${relatedIssue}` : "関連 Issue: 未指定";
+  return [
+    "Dashboard Butler の旧 `codex exec` 経路は削除済みです。",
+    "",
+    "この画面から開発実行・通常会話を続けるには、別経路の `codex app-server` ブリッジ実装が必要です。未接続の状態で VPS Codex CLI に送ったふりはしません。",
+    "",
+    `- ${repoPhrase}`,
+    `- ${issuePhrase}`,
+    "",
+    "現時点の実行 fallback は Custom GPT Butler です。Dashboard Butler は app-server 接続 PR が入るまで未完成として扱います。"
+  ].join("\n");
 }
 
 async function buildDashboardRepositoryNicknameListTurn({ payload, env }) {
@@ -6132,116 +5865,6 @@ function formatDashboardRepositoryNicknameListReply(registryResult) {
     "",
     "送信例: `ぶい #450 の残り Issue と PR を確認して`"
   ].join("\n");
-}
-
-function shouldDispatchDashboardChatToVpsRunner(payload) {
-  const input = normalizeObject(payload);
-  return (
-    input.dispatchToVpsRunner === true ||
-    input.vpsRunnerHandoff === true ||
-    normalizeDashboardEventText(input.executorTransport).toLowerCase() === "vps_runner"
-  );
-}
-
-function buildDashboardVpsRunnerHandoffPayload({ payload, prepared, env, runtimeUrl }) {
-  const input = normalizeObject(payload);
-  const issueNumber =
-    normalizePositiveInteger(input.issueNumber || input.relatedIssue) ||
-    prepared.relatedIssue ||
-    normalizePositiveInteger(env?.VTDD_DASHBOARD_CHAT_TRIAGE_ISSUE_NUMBER);
-  if (!issueNumber) {
-    return {
-      ok: false,
-      error: "dashboard_vps_runner_issue_required",
-      reason: "issueNumber or VTDD_DASHBOARD_CHAT_TRIAGE_ISSUE_NUMBER is required before dashboard can hand off a message to VPS Codex CLI",
-      issues: ["dashboard VPS runner handoff requires a GitHub Issue queue target"]
-    };
-  }
-
-  const codexGoal = normalizeDashboardEventText(input.codexGoal || input.goal || "dashboard_chat_triage").toLowerCase();
-  const branch =
-    normalizeDashboardEventText(input.branch || input.targetBranch) ||
-    `codex/issue-${issueNumber}-dashboard-vps-chat`;
-  const baseRef = normalizeDashboardEventText(input.baseRef || input.base_ref) || "main";
-  const summary =
-    normalizeDashboardEventText(input.handoffSummary || input.summary) ||
-    `Dashboard chat VPS runner handoff for Issue #${issueNumber}`;
-
-  return {
-    ok: true,
-    payload: {
-      actorRole: ActorRole.BUTLER,
-      executorTransport: "vps_runner",
-      issueContext: { issueNumber },
-      continuationContext: {
-        requiresHandoff: true,
-        executorTransport: "vps_runner",
-        codexGoal,
-        handoff: {
-          issueTraceable: true,
-          approvalScopeMatched: true,
-          relatedIssue: issueNumber,
-          summary,
-          ownerMessage: sanitizeDashboardChatText(input.text || input.message || input.body),
-          repositoryInput: normalizeDashboardRepositoryInput(
-            input.repositoryInput || input.repository_input || input.repository || prepared.repository
-          ),
-          dashboardThreadId: prepared.threadId,
-          dashboardRuntimeUrl: normalizeDashboardEventText(input.dashboardRuntimeUrl || runtimeUrl)
-        }
-      },
-      executionTarget: {
-        codexGoal,
-        branch,
-        baseRef
-      },
-      policyInput: {
-        actionType: "build",
-        mode: "execution",
-        repositoryInput: prepared.repository,
-        targetConfirmed: true,
-        approvalScopeMatched: true,
-        runtimeTruth: {
-          runtimeAvailable: true,
-          runtimeState: {
-            activeBranch: branch,
-            baseRef
-          }
-        },
-        consent: { grantedCategories: ["read", "propose", "execute"] },
-        approvalPhrase: "GO",
-        issueTraceable: true,
-        issueTraceability: {
-          relatedIssue: issueNumber,
-          intentRefs: [`#${issueNumber} Intent`],
-          successCriteriaRefs: [`#${issueNumber} Success Criteria`],
-          nonGoalRefs: [`#${issueNumber} Non-goals`]
-        },
-        go: true,
-        passkey: false
-      }
-    }
-  };
-}
-
-function buildDashboardVpsRunnerQueuedMessage({ prepared, execution }) {
-  if (!execution) {
-    return null;
-  }
-  const issuePhrase = execution.issueNumber ? `Issue #${execution.issueNumber}` : "対象Issue";
-  const queuePhrase = execution.queueCommentUrl ? ` queue: ${execution.queueCommentUrl}` : "";
-  return normalizeDashboardChatMessage(
-    {
-      threadId: prepared.threadId,
-      role: "system",
-      repository: prepared.repository,
-      relatedIssue: execution.issueNumber || prepared.relatedIssue,
-      status: "thinking",
-      text: `VPS Codex CLI queue に ${issuePhrase} の bounded handoff を渡しました。これは返信ではありません。runner からの event post だけを返信としてこの thread に表示します。${queuePhrase}`,
-      createdAt: new Date(Date.now() + 2).toISOString()
-    },
-    { threadId: prepared.threadId }
-  );
 }
 
 function normalizeDashboardChatMessage(message, defaults = {}) {
@@ -8422,7 +8045,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           <p>この画面は会話を主役にするための chat-first runtime です。管理画面は右のサイドバーへ退避しました。</p>
           <ul>
             <li>関連 repo/nickname: <code>${escapeDashboardHtml(dashboardTargetLabel)}</code></li>
-            <li>会話: この画面から送信すると、VPS Codex CLI が repo 解決・Issue/PR/RAG/進捗/承認境界を交通整理します</li>
+            <li>会話: Dashboard Butler の app-server 接続は未実装です。旧 VPS runner 直送経路は使いません</li>
           </ul>
         </article>
         <article class="bubble owner">
@@ -8431,13 +8054,13 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         <article class="bubble">
           <strong>Butler</strong>
           <p>その方針で進めます。中央はチャットだけ、状態確認・進捗・RAG・workflow・prototype cleanup の扱いはサイドバーのメニューから必要な時だけ開きます。</p>
-          <p>この dashboard からの送信は WebSocket で VPS Codex CLI に直接 push します。GitHub Issue コメント queue は通常会話では使いません。</p>
-          <span class="connection-note">接続準備中: WebSocket で Butler と VPS Codex CLI に接続します</span>
+          <p>この dashboard から VPS Codex CLI を <code>codex exec</code> で毎回起動する旧経路は削除しました。Dashboard Butler は <code>codex app-server</code> ブリッジが入るまで未完成です。</p>
+          <span class="connection-note">Dashboard thread 接続準備中: 履歴保存と未接続状態の表示だけを行います</span>
         </article>
 
       </div>
 
-      <form class="composer" id="butler-chat-form" aria-label="Butler composer" data-socket-endpoint="${escapeDashboardHtml(socketOrigin)}/v2/dashboard/chat/${escapeDashboardHtml(chatThreadId)}/ws" data-thread-endpoint="${escapeDashboardHtml(origin)}/v2/dashboard/chat/${escapeDashboardHtml(chatThreadId)}" data-thread-id="${escapeDashboardHtml(chatThreadId)}" data-repository-input="${escapeDashboardHtml(repositoryInput)}" data-issue-number="${dashboardIssueNumber || ""}" data-dispatch-to-vps-runner="true" data-codex-goal="dashboard_chat_triage">
+      <form class="composer" id="butler-chat-form" aria-label="Butler composer" data-socket-endpoint="${escapeDashboardHtml(socketOrigin)}/v2/dashboard/chat/${escapeDashboardHtml(chatThreadId)}/ws" data-thread-endpoint="${escapeDashboardHtml(origin)}/v2/dashboard/chat/${escapeDashboardHtml(chatThreadId)}" data-thread-id="${escapeDashboardHtml(chatThreadId)}" data-repository-input="${escapeDashboardHtml(repositoryInput)}" data-issue-number="${dashboardIssueNumber || ""}">
         <div class="composer-box">
           <textarea id="butler-message" name="text" placeholder="Butler V2 にメッセージ..." aria-label="Butler V2 にメッセージ"></textarea>
           <button class="send-button" type="submit" aria-label="Butler に送信">↑</button>
@@ -8465,7 +8088,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
 
         <div class="lane">
           <div class="lane-title"><h3>Issue 候補</h3><span class="pill">draft</span></div>
-          <p>トップチャットは Custom GPT 相当の自然文入口です。repo/nickname 解決、Issue/PR/RAG/進捗/承認境界を VPS Codex CLI に交通整理させます。</p>
+          <p>Dashboard Butler の自然文入口は <code>codex app-server</code> 用に作り直します。旧 VPS runner 直送では通常会話を処理しません。</p>
         </div>
 
         <div class="lane">
@@ -8511,8 +8134,6 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
       const threadId = form.dataset.threadId;
       const repositoryInput = form.dataset.repositoryInput;
       const issueNumber = Number.parseInt(form.dataset.issueNumber || "", 10);
-      const dispatchToVpsRunner = form.dataset.dispatchToVpsRunner === "true";
-      const codexGoal = form.dataset.codexGoal || "dashboard_chat_triage";
       const initialMarkup = log.innerHTML;
       let chatSocket = null;
       let reconnectTimer = null;
@@ -8543,7 +8164,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           const header = document.createElement("div");
           header.className = "bubble-header";
           const strong = document.createElement("strong");
-          strong.textContent = message.role === "runner" ? "VPS Codex CLI" : message.role === "system" ? "SYSTEM" : "Butler";
+          strong.textContent = message.role === "system" ? "SYSTEM" : "Butler";
           header.appendChild(strong);
           const copyButton = document.createElement("button");
           copyButton.className = "copy-message";
@@ -8697,7 +8318,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
             window.clearTimeout(reconnectTimer);
             reconnectTimer = null;
           }
-          setStatus("WebSocket 接続済み。送信すると VPS Codex CLI に push します。");
+          setStatus("Dashboard thread 接続済み。送信内容は保存されますが、app-server はまだ未接続です。");
           refreshThread();
         });
         chatSocket.addEventListener("message", (event) => {
@@ -8740,20 +8361,17 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           return;
         }
         if (submitButton) submitButton.disabled = true;
-        setStatus("送信中です。VPS Codex CLI に push します。");
+        setStatus("送信中です。Dashboard thread に保存します。");
         chatSocket.send(JSON.stringify({
           type: "owner_message",
           threadId,
           repositoryInput,
           text,
           issueNumber,
-          relatedIssue: issueNumber,
-          dispatchToVpsRunner,
-          executorTransport: dispatchToVpsRunner ? "vps_runner" : undefined,
-          codexGoal
+          relatedIssue: issueNumber
         }));
         textarea.value = "";
-        setStatus("送信済み。VPS Codex CLI の返信を待っています。");
+        setStatus("送信済み。app-server 未接続のため実行は開始していません。");
         if (submitButton) submitButton.disabled = false;
         textarea.focus({ preventScroll: true });
         updateComposerReserve();

--- a/test/remote-codex-executor.test.js
+++ b/test/remote-codex-executor.test.js
@@ -271,48 +271,8 @@ test("remote Codex execution request rejects wait-only continuity goal before wo
 
   assert.equal(result.ok, false);
   assert.deepEqual(result.issues, [
-    "codexGoal must be dashboard_chat_triage, open_pr, revise_pr, respond_to_review, or post_merge_verify"
+    "codexGoal must be open_pr, revise_pr, respond_to_review, or post_merge_verify"
   ]);
-});
-
-test("remote Codex execution request accepts dashboard chat triage goal", () => {
-  const result = createRemoteCodexExecutionRequest({
-    payload: {
-      actorRole: ActorRole.BUTLER,
-      issueContext: { issueNumber: 450 },
-      continuationContext: {
-        requiresHandoff: true,
-        codexGoal: RemoteCodexDispatchGoal.DASHBOARD_CHAT_TRIAGE,
-        handoff: {
-          issueTraceable: true,
-          approvalScopeMatched: true,
-          relatedIssue: 450,
-          summary: "Dashboard chat triage",
-          ownerMessage: "ぶい の残り Issue と PR を確認して",
-          repositoryInput: "ぶい",
-          dashboardThreadId: "dashboard-main-vtdd"
-        }
-      },
-      executionTarget: {
-        codexGoal: RemoteCodexDispatchGoal.DASHBOARD_CHAT_TRIAGE,
-        branch: "codex/issue-450-dashboard-chat-triage"
-      },
-      policyInput: {
-        approvalPhrase: "GO",
-        targetConfirmed: true,
-        approvalScopeMatched: true
-      }
-    },
-    gatewayResult: {
-      repository: "sample-org/vtdd-v2"
-    }
-  });
-
-  assert.equal(result.ok, true);
-  assert.equal(result.request.codexGoal, RemoteCodexDispatchGoal.DASHBOARD_CHAT_TRIAGE);
-  assert.equal(result.request.handoff.dashboardThreadId, "dashboard-main-vtdd");
-  assert.equal(result.request.handoff.ownerMessage, "ぶい の残り Issue と PR を確認して");
-  assert.equal(result.request.handoff.repositoryInput, "ぶい");
 });
 
 test("remote Codex execution request rejects non-string handoff approval refs", () => {
@@ -761,73 +721,6 @@ test("remote Codex vps_runner dispatch posts a GitHub-backed queue comment", asy
   assert.equal(body.includes('"docs/butler/thread-independent-startup-contract.md"'), true);
   assert.equal(body.includes("## This PR satisfies Intent"), true);
   assert.equal(body.includes("## Surface Update Checklist"), true);
-});
-
-test("remote Codex vps_runner dashboard chat triage queue does not masquerade as PR work", async () => {
-  const calls = [];
-  const dispatched = await dispatchRemoteCodexExecution({
-    payload: {
-      actorRole: ActorRole.BUTLER,
-      executorTransport: RemoteCodexExecutorTransport.VPS_RUNNER,
-      issueContext: { issueNumber: 450 },
-      policyInput: {
-        approvalPhrase: "GO",
-        targetConfirmed: true,
-        approvalScopeMatched: true,
-        runtimeTruth: {
-          runtimeState: {
-            activeBranch: "codex/issue-450-dashboard-vps-chat"
-          }
-        },
-        approvalActor: "owner"
-      },
-      continuationContext: {
-        requiresHandoff: true,
-        handoff: {
-          issueTraceable: true,
-          approvalScopeMatched: true,
-          relatedIssue: 450,
-          summary: "Dashboard chat handoff",
-          ownerMessage: "ぶい の残り Issue と PR を確認して交通整理して",
-          repositoryInput: "ぶい",
-          dashboardThreadId: "dashboard-main-vtdd"
-        }
-      }
-    },
-    gatewayResult: {
-      repository: "marushu/vtdd-v2-p",
-      executionContinuity: {
-        codexGoal: RemoteCodexDispatchGoal.DASHBOARD_CHAT_TRIAGE
-      }
-    },
-    env: {
-      GITHUB_APP_INSTALLATION_TOKEN: "ghs_dispatch_token",
-      GITHUB_API_FETCH: async (url, init) => {
-        calls.push({ url, init });
-        return new Response(
-          JSON.stringify({
-            id: 45001,
-            html_url: "https://github.com/marushu/vtdd-v2-p/issues/450#issuecomment-45001"
-          }),
-          { status: 201, headers: { "content-type": "application/json" } }
-        );
-      }
-    }
-  });
-
-  assert.equal(dispatched.ok, true);
-  const body = JSON.parse(calls[0].init.body).body;
-  assert.equal(body.includes('"codexGoal": "dashboard_chat_triage"'), true);
-  assert.equal(body.includes('"ownerMessage": "ぶい の残り Issue と PR を確認して交通整理して"'), true);
-  assert.equal(body.includes('"repositoryInput": "ぶい"'), true);
-  assert.equal(body.includes("完了条件: dashboard chat triage の返信 event を同じ thread に返す"), true);
-  assert.equal(body.includes("dashboard chat triage は PR を作成・更新しません"), true);
-  assert.equal(body.includes("PR を作成・更新しない。"), true);
-  assert.equal(body.includes("完了条件: pull request を作成または更新する"), false);
-  assert.equal(body.includes("Required PR body markers"), false);
-  assert.equal(body.includes("docs/pr-template-model.md"), false);
-  assert.equal(body.includes("scripts/render-pr-body.mjs"), false);
-  assert.equal(body.includes('"requiredRepoFiles": [\n      "AGENTS.md",\n      "docs/butler/thread-independent-startup-contract.md"\n    ]'), true);
 });
 
 test("remote Codex vps_runner dispatch preserves bounded PR revision goal", async () => {

--- a/test/vps-runner-script.test.js
+++ b/test/vps-runner-script.test.js
@@ -6,12 +6,6 @@ import path from "node:path";
 import {
   buildFreshExecutionBranchCandidates,
   buildCodexExecutionPrompt,
-  buildDashboardChatTriagePrompt,
-  buildDashboardGeneralChatPrompt,
-  buildVpsDashboardSocketExecutionPayload,
-  buildVpsDashboardActionBridgeGuide,
-  buildVpsDashboardActionReadBridgeGuide,
-  buildDashboardRunnerWebSocketUrl,
   buildCodexExecArgs,
   buildCodexExecutionEnv,
   buildGuardedPullRequestBody,
@@ -25,7 +19,6 @@ import {
   buildVpsRunnerPullRequestContext,
   checkoutVpsRunnerBranch,
   classifyVpsRunnerFailure,
-  connectVpsDashboardWebSocketClient,
   formatPullRequestContext,
   isNonFastForwardPushFailure,
   loadVpsRunnerRepositoryPolicies,
@@ -36,7 +29,6 @@ import {
   postVpsRunnerEvent,
   runVpsRunnerOnce,
   resolveRoleGitHubAppInstallationToken,
-  summarizeDashboardReplyText,
   summarizeDiagnosticText,
   selectPendingVpsReviewerFallbacks,
   selectPendingVpsRunnerExecutions
@@ -516,10 +508,10 @@ test("VPS runner event posts dashboard thread events to runtime", async () => {
     },
     event: {
       status: "completed",
-      lastEvent: "dashboard_chat_triage_completed",
-      finalEvent: "dashboard_chat_triage_completed",
-      currentStep: "dashboard_chat_triage",
-      message: "分類: answer\n次は Issue #450 の live E2E を確認します。"
+      lastEvent: "branch_pushed",
+      finalEvent: "branch_pushed",
+      currentStep: "branch_pushed",
+      message: "実装ブランチを push しました。"
     }
   });
 
@@ -530,8 +522,8 @@ test("VPS runner event posts dashboard thread events to runtime", async () => {
   const runtimeBody = JSON.parse(runtimeCalls[0].init.body);
   assert.equal(runtimeBody.threadId, "dashboard-main-marushu-vtdd-v2-p");
   assert.equal(runtimeBody.status, "completed");
-  assert.equal(runtimeBody.lastEvent, "dashboard_chat_triage_completed");
-  assert.equal(runtimeBody.message.includes("分類: answer"), true);
+  assert.equal(runtimeBody.lastEvent, "branch_pushed");
+  assert.equal(runtimeBody.message.includes("実装ブランチ"), true);
 
   const parsed = parseVpsRunnerEventComment(githubCalls[0].init.body.body);
   assert.equal(parsed.ok, true);
@@ -559,8 +551,8 @@ test("VPS runner event records missing runtime dashboard delivery configuration"
     },
     event: {
       status: "completed",
-      lastEvent: "dashboard_chat_triage_completed",
-      currentStep: "dashboard_chat_triage",
+      lastEvent: "branch_pushed",
+      currentStep: "branch_pushed",
       message: "完了"
     },
     env: {}
@@ -573,160 +565,6 @@ test("VPS runner event records missing runtime dashboard delivery configuration"
     parsed.event.dashboardDelivery.reason,
     "VTDD_RUNTIME_URL or VTDD_GATEWAY_BEARER_TOKEN is missing"
   );
-});
-
-test("VPS runner builds dashboard WebSocket endpoint with machine thread id", () => {
-  assert.equal(
-    buildDashboardRunnerWebSocketUrl({
-      runtimeUrl: "https://vtdd-v2-mvp.example.workers.dev",
-      threadId: "dashboard-main-marushu-vtdd-v2-p"
-    }),
-    "wss://vtdd-v2-mvp.example.workers.dev/v2/dashboard/vps-runner/ws?threadId=dashboard-main-marushu-vtdd-v2-p"
-  );
-});
-
-test("VPS runner dashboard WebSocket client authenticates and handles dashboard jobs", async () => {
-  const sockets = [];
-  class FakeWebSocket {
-    constructor(url, protocols, options) {
-      this.url = url;
-      this.protocols = protocols;
-      this.options = options;
-      this.listeners = new Map();
-      this.sent = [];
-      sockets.push(this);
-    }
-    addEventListener(eventName, handler) {
-      this.listeners.set(eventName, handler);
-    }
-    send(body) {
-      this.sent.push(body);
-    }
-    emit(eventName, event) {
-      return this.listeners.get(eventName)?.(event);
-    }
-  }
-
-  const jobs = [];
-  const socket = await connectVpsDashboardWebSocketClient({
-    runtimeUrl: "https://vtdd-v2-mvp.example.workers.dev",
-    bearerToken: "gateway-token-for-test",
-    threadId: "dashboard-main-marushu-vtdd-v2-p",
-    WebSocketImpl: FakeWebSocket,
-    logger: { log() {}, error() {} },
-    onJob: async (job, runnerSocket) => {
-      jobs.push(job);
-      runnerSocket.send(
-        JSON.stringify({
-          type: "vps_runner_reply",
-          threadId: job.threadId,
-          repository: job.repository,
-          issueNumber: job.relatedIssue,
-          status: "completed",
-          message: "VPS Codex CLI からの返信です。"
-        })
-      );
-    }
-  });
-
-  assert.equal(sockets.length, 1);
-  assert.equal(
-    sockets[0].url,
-    "wss://vtdd-v2-mvp.example.workers.dev/v2/dashboard/vps-runner/ws?threadId=dashboard-main-marushu-vtdd-v2-p"
-  );
-  assert.equal(sockets[0].options.headers.authorization, "Bearer gateway-token-for-test");
-  assert.equal(sockets[0].protocols[0], "vtdd-vps-runner");
-  assert.equal(sockets[0].protocols[1].startsWith("vtdd-gateway-bearer-"), true);
-
-  await socket.emit("message", {
-    data: JSON.stringify({
-      type: "dashboard_chat_job",
-      threadId: "dashboard-main-marushu-vtdd-v2-p",
-      repository: "marushu/vtdd-v2-p",
-      relatedIssue: 450,
-      text: "進捗は？"
-    })
-  });
-
-  assert.equal(jobs.length, 1);
-  assert.equal(jobs[0].text, "進捗は？");
-  assert.equal(JSON.parse(socket.sent[0]).type, "vps_runner_reply");
-  assert.equal(JSON.parse(socket.sent[0]).message, "VPS Codex CLI からの返信です。");
-});
-
-test("VPS runner dashboard WebSocket client reconnects after disconnect", async () => {
-  const sockets = [];
-  const timers = [];
-  class FakeWebSocket {
-    constructor(url, protocols, options) {
-      this.url = url;
-      this.protocols = protocols;
-      this.options = options;
-      this.listeners = new Map();
-      sockets.push(this);
-    }
-    addEventListener(eventName, handler) {
-      this.listeners.set(eventName, handler);
-    }
-    emit(eventName, event) {
-      return this.listeners.get(eventName)?.(event);
-    }
-  }
-
-  const socket = await connectVpsDashboardWebSocketClient({
-    runtimeUrl: "https://vtdd-v2-mvp.example.workers.dev",
-    bearerToken: "gateway-token-for-test",
-    threadId: "dashboard-main-marushu-vtdd-v2-p",
-    WebSocketImpl: FakeWebSocket,
-    logger: { log() {}, error() {} },
-    onJob: async () => {},
-    reconnectDelays: [250],
-    setTimeoutFn: (callback, delay) => {
-      timers.push({ callback, delay });
-    }
-  });
-
-  socket.emit("close");
-  assert.equal(timers.length, 1);
-  assert.equal(timers[0].delay, 250);
-
-  await timers[0].callback();
-  assert.equal(sockets.length, 2);
-  assert.equal(sockets[1].url, sockets[0].url);
-  assert.equal(sockets[1].protocols[0], "vtdd-vps-runner");
-});
-
-test("VPS runner treats unresolved dashboard issue-only jobs as conversation without readable Issue context", () => {
-  const payload = buildVpsDashboardSocketExecutionPayload({
-    type: "dashboard_chat_job",
-    threadId: "dashboard-main-unresolved",
-    repository: "",
-    repositoryResolution: { ok: false, error: "repository_required" },
-    relatedIssue: 450,
-    text: "今の #450 の残りを短く返して"
-  });
-
-  assert.equal(payload.repository, "");
-  assert.equal(payload.issueNumber, 450);
-  assert.equal(payload.conversationOnly, true);
-  assert.equal(payload.issueContextReadable, false);
-});
-
-test("VPS runner preserves readable Issue context only after repository resolution", () => {
-  const payload = buildVpsDashboardSocketExecutionPayload({
-    type: "dashboard_chat_job",
-    threadId: "dashboard-main-marushu-vtdd-v2-p",
-    repository: "marushu/vtdd-v2-p",
-    repositoryInput: "ぶい",
-    repositoryResolution: { ok: true, via: "alias" },
-    relatedIssue: 450,
-    text: "#450 の残り Issue と PR を確認して"
-  });
-
-  assert.equal(payload.repository, "marushu/vtdd-v2-p");
-  assert.equal(payload.issueNumber, 450);
-  assert.equal(payload.conversationOnly, false);
-  assert.equal(payload.issueContextReadable, true);
 });
 
 test("VPS runner milestone event mentions queue comment author", () => {
@@ -1140,28 +978,6 @@ test("VPS runner diagnostic summaries redact secrets and stay short", () => {
   assert.equal(summary.includes("[REDACTED_API_KEY]"), true);
   assert.equal(summary.endsWith("[truncated]"), true);
   assert.equal(summary.length <= 192, true);
-});
-
-test("VPS runner dashboard replies preserve readable line breaks", () => {
-  const summary = summarizeDashboardReplyText(
-    [
-      "分類: `answer / existing_issue_link`",
-      "",
-      "#450 の残りはこれだけです。",
-      "",
-      "- #450 はまだ OPEN",
-      "- open PR は 0 件",
-      "",
-      "残り作業:",
-      "1. dashboard live E2E",
-      "2. 証跡を残す"
-    ].join("\n"),
-    4000
-  );
-
-  assert.equal(summary.includes("\n\n- #450 はまだ OPEN\n- open PR は 0 件"), true);
-  assert.equal(summary.includes("OPEN - open PR"), false);
-  assert.equal(summary.includes("\n1. dashboard live E2E\n2. 証跡を残す"), true);
 });
 
 test("VPS runner dry run reports selected execution without side effects", async () => {
@@ -1744,122 +1560,6 @@ test("VPS runner Codex prompt preserves high-risk boundaries", () => {
   assert.equal(prompt.includes("## File / Line Hypotheses"), true);
   assert.equal(prompt.includes("## Hypothesis Retrospective"), true);
   assert.equal(prompt.includes("## Surface Update Checklist"), true);
-});
-
-test("VPS runner dashboard chat triage prompt preserves Custom GPT parity and blocks mutation", () => {
-  const prompt = buildDashboardChatTriagePrompt({
-    payload: {
-      repository: "marushu/vtdd-v2-p",
-      issueNumber: 450,
-      codexGoal: "dashboard_chat_triage",
-      handoff: {
-        ownerMessage: "ぶい の残り Issue と PR 確認して交通整理して",
-        repositoryInput: "ぶい",
-        dashboardThreadId: "dashboard-main-vtdd"
-      }
-    },
-    issue: {
-      title: "Dashboard Butler chat",
-      body: "Top chat must preserve Custom GPT Butler capabilities."
-    },
-    preflight: {
-      ok: true,
-      mode: "auto_receipt",
-      onMissingContract: "owner_decision_required",
-      issue: {
-        number: 450,
-        title: "Dashboard Butler chat",
-        bodyExcerpt: "Top chat must preserve Custom GPT Butler capabilities."
-      },
-      handoffNote: {
-        currentSurface: "VPS Codex CLI",
-        repository: "marushu/vtdd-v2-p",
-        issueNumber: 450,
-        codexGoal: "dashboard_chat_triage",
-        nextSafeAction: "resume from the canonical Issue, GitHub runtime truth, RAG checkpoints, and this preflight receipt",
-        blockedReturnRoute: "If the issue/runtime truth is insufficient, stop and return a Japanese blocker comment for Butler/owner instead of guessing."
-      },
-      artifacts: [{ path: "AGENTS.md", sha1: "abc123" }],
-      missing: []
-    }
-  });
-
-  assert.equal(prompt.includes("Custom GPT parity requirement:"), true);
-  assert.equal(prompt.includes("natural-language Butler entrypoint"), true);
-  assert.equal(prompt.includes("repository/nickname"), true);
-  assert.equal(prompt.includes("Issue split proposal"), true);
-  assert.equal(prompt.includes("existing Issue linkage"), true);
-  assert.equal(prompt.includes("GitHub runtime truth"), true);
-  assert.equal(prompt.includes("RAG"), true);
-  assert.equal(prompt.includes("approval URL needed"), true);
-  assert.equal(prompt.includes("Do not edit files, commit, push, create PRs, merge, deploy"), true);
-  assert.equal(prompt.includes("ぶい の残り Issue と PR 確認して交通整理して"), true);
-  assert.equal(prompt.includes("Context preflight receipt:"), true);
-  assert.equal(prompt.includes("AGENTS.md sha1=abc123"), true);
-  assert.equal(prompt.includes("Runtime read-only bridge:"), true);
-  assert.equal(prompt.includes("Runtime write/action bridge for Issue-backed bounded VTDD work:"), true);
-  assert.equal(prompt.includes("vtddExecute: POST /v2/action/execute"), true);
-  assert.equal(prompt.includes("vtddDeployProduction: POST /v2/action/deploy"), true);
-  assert.equal(prompt.includes("GO alone does not authorize deploy"), true);
-});
-
-test("VPS runner general dashboard chat prompt allows normal conversation without Issue preflight", () => {
-  const prompt = buildDashboardGeneralChatPrompt({
-    payload: {
-      conversationOnly: true,
-      issueNumber: 450,
-      repositoryResolution: { ok: false, error: "repository_required" },
-      handoff: {
-        ownerMessage: "今日は何月何日？日本時間を答えて",
-        repositoryInput: "missing",
-        dashboardThreadId: "dashboard-main"
-      }
-    }
-  });
-
-  assert.equal(prompt.includes("Owner dashboard message:"), true);
-  assert.equal(prompt.includes("今日は何月何日？日本時間を答えて"), true);
-  assert.equal(prompt.includes("Answer as a normal Butler conversation"), true);
-  assert.equal(prompt.includes("Do not require GitHub Issue preflight for general chat"), true);
-  assert.equal(prompt.includes("detectedIssueNumber: #450"), true);
-  assert.equal(prompt.includes("repositoryResolution: repository_required"), true);
-  assert.equal(prompt.includes("do not answer as if you read that Issue"), true);
-  assert.equal(prompt.includes("before VTDD can read GitHub truth or continue development"), true);
-  assert.equal(prompt.includes("ordinary conversation reveals a new actionable development need"), true);
-  assert.equal(prompt.includes("issue_split_proposal or execution_handoff_needed"), true);
-  assert.equal(prompt.includes("Runtime read-only bridge:"), false);
-  assert.equal(prompt.includes("vtddRetrieveRepositoryNicknames: GET /v2/retrieve/repository-nicknames"), false);
-  assert.equal(prompt.includes("vtddWriteOperationalMemory: POST /v2/action/memory-write"), false);
-  assert.equal(prompt.includes("vtddDeployProduction: POST /v2/action/deploy"), false);
-  assert.equal(prompt.includes("Do not edit files, commit, push, create PRs, merge, deploy"), true);
-});
-
-test("VPS runner dashboard action bridge exposes Action Schema operations without secret values", () => {
-  const guide = buildVpsDashboardActionBridgeGuide();
-
-  assert.equal(guide.includes("${VTDD_RUNTIME_URL}"), true);
-  assert.equal(guide.includes("${VTDD_GATEWAY_BEARER_TOKEN}"), true);
-  assert.equal(guide.includes("gateway-token-for-test"), false);
-  assert.equal(guide.includes("Runtime write/action bridge for Issue-backed bounded VTDD work:"), true);
-  assert.equal(guide.includes("vtddGateway: POST /v2/gateway"), true);
-  assert.equal(guide.includes("vtddGitHubAuthority: POST /v2/action/github-authority"), true);
-  assert.equal(guide.includes("vtddSyncGitHubActionsSecret: POST /v2/action/github-actions-secret"), true);
-  assert.equal(guide.includes("High-risk operation guidance:"), true);
-  assert.equal(guide.includes("Do not call high-risk routes from dashboard chat just because they are listed here."), true);
-  assert.equal(guide.includes("return approval_needed with the required scoped passkey boundary"), true);
-  assert.equal(guide.includes("GO alone does not authorize deploy"), true);
-});
-
-test("VPS runner action read bridge excludes sensitive and high-risk retrieval operations", () => {
-  const guide = buildVpsDashboardActionReadBridgeGuide();
-
-  assert.equal(guide.includes("Runtime read-only bridge:"), true);
-  assert.equal(guide.includes("vtddRetrieveGitHub: GET /v2/retrieve/github"), true);
-  assert.equal(guide.includes("vtddRetrieveApprovalGrant: GET /v2/retrieve/approval-grant"), false);
-  assert.equal(guide.includes("vtddRetrieveSetupDiagnostics: GET /v2/retrieve/setup-diagnostics"), false);
-  assert.equal(guide.includes("vtddRetrieveSetupArtifact: GET /v2/retrieve/setup-artifact"), false);
-  assert.equal(guide.includes("vtddWriteGitHub: POST /v2/action/github"), false);
-  assert.equal(guide.includes("vtddDeployProduction: POST /v2/action/deploy"), false);
 });
 
 test("VPS runner Codex execution env keeps runtime bridge credentials scoped opt-in", () => {

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import worker from "../src/worker.js";
-import { DashboardChatRoom, selectDashboardWebSocketResponseProtocol } from "../src/worker.js";
+import { DashboardChatRoom } from "../src/worker.js";
 import {
   ActionType,
   ActorRole,
@@ -460,10 +460,10 @@ test("worker serves v2 dashboard for allowed owner identity without exposing sec
   assert.equal(body.includes("overflow: hidden"), true);
   assert.equal(body.includes("grid-template-columns: minmax(0, 1fr) auto"), true);
   assert.equal(body.includes("WebSocket"), true);
-  assert.equal(body.includes("接続準備中: WebSocket で Butler と VPS Codex CLI に接続します"), true);
+  assert.equal(body.includes("Dashboard thread 接続準備中"), true);
   assert.equal(body.includes("repo/nickname 未指定"), true);
-  assert.equal(body.includes("WebSocket で VPS Codex CLI に直接 push します"), true);
-  assert.equal(body.includes("GitHub Issue コメント queue は通常会話では使いません"), true);
+  assert.equal(body.includes("旧 VPS runner 直送経路は使いません"), true);
+  assert.equal(body.includes("codex app-server"), true);
   assert.equal(body.includes("deploy 用 passkey URL"), false);
   assert.equal(body.includes("vtdd-v3-orchestrator.polished-tree-da7c.workers.dev"), false);
   assert.equal(body.includes('id="mobile-menu-toggle"'), true);
@@ -476,17 +476,17 @@ test("worker serves v2 dashboard for allowed owner identity without exposing sec
   assert.equal(body.includes("/v2/dashboard/chat/messages"), false);
   assert.equal(body.includes('data-thread-endpoint="https://example.com/v2/dashboard/chat/dashboard-main-unresolved"'), true);
   assert.equal(body.includes('data-socket-endpoint="wss://example.com/v2/dashboard/chat/dashboard-main-unresolved/ws"'), true);
-  assert.equal(body.includes('data-dispatch-to-vps-runner="true"'), true);
+  assert.equal(body.includes('data-dispatch-to-vps-runner="true"'), false);
   assert.equal(body.includes('data-issue-number=""'), true);
-  assert.equal(body.includes('data-codex-goal="dashboard_chat_triage"'), true);
-  assert.equal(body.includes('executorTransport: dispatchToVpsRunner ? "vps_runner" : undefined'), true);
+  assert.equal(body.includes('data-codex-goal="dashboard_chat_triage"'), false);
+  assert.equal(body.includes('executorTransport: dispatchToVpsRunner ? "vps_runner" : undefined'), false);
   assert.equal(body.includes("new WebSocket(socketEndpoint)"), true);
   assert.equal(body.includes("function refreshThread()"), true);
   assert.equal(body.includes("function scheduleReconnect()"), true);
   assert.equal(body.includes("履歴を再取得して再接続します"), true);
   assert.equal(body.includes("document.addEventListener(\"visibilitychange\""), true);
   assert.equal(body.includes("window.addEventListener(\"online\""), true);
-  assert.equal(body.includes("VPS Codex CLI に push します"), true);
+  assert.equal(body.includes("VPS Codex CLI に push します"), false);
   assert.equal(body.includes("function updateComposerReserve()"), true);
   assert.equal(body.includes("function scrollToLatest()"), true);
   assert.equal(body.includes("function showThinking()"), false);
@@ -719,7 +719,7 @@ test("worker appends dashboard Butler chat turn with dashboard passkey session c
   assert.equal(body.messages[1].role, "butler");
 });
 
-test("worker dispatches authenticated dashboard chat handoff to VPS runner queue", async () => {
+test("worker does not dispatch dashboard chat to the VPS runner queue", async () => {
   const store = createInMemoryDashboardChatStore();
   const calls = [];
   const response = await worker.fetch(
@@ -731,7 +731,6 @@ test("worker dispatches authenticated dashboard chat handoff to VPS runner queue
         repository: "marushu/vtdd-v2-p",
         issueNumber: 450,
         dispatchToVpsRunner: true,
-        codexGoal: "dashboard_chat_triage",
         branch: "codex/issue-450-dashboard-vps-chat",
         text: "VPS Codex CLI とこの dashboard thread で会話したい"
       })
@@ -759,21 +758,13 @@ test("worker dispatches authenticated dashboard chat handoff to VPS runner queue
   assert.equal(response.status, 202);
   const body = await response.json();
   assert.equal(body.ok, true);
-  assert.equal(body.execution.transport, "vps_runner");
-  assert.equal(body.execution.issueNumber, 450);
-  assert.equal(body.execution.codexGoal, "dashboard_chat_triage");
-  assert.equal(body.execution.branch, "codex/issue-450-dashboard-vps-chat");
-  assert.equal(body.execution.queueCommentId, 45001);
+  assert.equal(body.execution, null);
   assert.equal(body.messages.length, 2);
-  assert.equal(body.messages[1].role, "system");
-  assert.match(body.messages[1].text, /これは返信ではありません/);
-
-  const queueBody = JSON.parse(calls[0].init.body).body;
-  assert.equal(queueBody.includes("vtdd:vps-runner-execution:"), true);
-  assert.equal(queueBody.includes('"transport": "vps_runner"'), true);
-  assert.equal(queueBody.includes('"codexGoal": "dashboard_chat_triage"'), true);
-  assert.equal(queueBody.includes('"ownerMessage": "VPS Codex CLI とこの dashboard thread で会話したい"'), true);
-  assert.equal(queueBody.includes('"dashboardThreadId": "dashboard-main-marushu-vtdd-v2-p"'), true);
+  assert.equal(body.messages[1].role, "butler");
+  assert.equal(body.messages[1].status, "blocked");
+  assert.match(body.messages[1].text, /codex app-server/);
+  assert.match(body.messages[1].text, /旧 `codex exec` 経路は削除済み/);
+  assert.equal(calls.length, 0);
 
   const retrieveResponse = await worker.fetch(
     new Request("https://example.com/v2/dashboard/chat/dashboard-main-marushu-vtdd-v2-p", {
@@ -783,10 +774,10 @@ test("worker dispatches authenticated dashboard chat handoff to VPS runner queue
   );
   const retrieveBody = await retrieveResponse.json();
   assert.equal(retrieveBody.messages.length, 2);
-  assert.equal(retrieveBody.messages[1].status, "thinking");
+  assert.equal(retrieveBody.messages[1].status, "blocked");
 });
 
-test("worker allows dashboard passkey session to hand off chat to VPS runner queue", async () => {
+test("worker allows dashboard passkey session chat without VPS runner handoff", async () => {
   const provider = createInMemoryMemoryProvider();
   await provider.store({
     id: "approval:dashboard-vps-session",
@@ -844,7 +835,6 @@ test("worker allows dashboard passkey session to hand off chat to VPS runner que
       MEMORY_PROVIDER: provider,
       DASHBOARD_CHAT_STORE: store,
       GITHUB_APP_INSTALLATION_TOKEN: "ghs_dashboard_passkey_vps",
-      VTDD_DASHBOARD_CHAT_TRIAGE_ISSUE_NUMBER: "450",
       GITHUB_API_FETCH: async (url, init) => {
         calls.push({ url, init });
         return new Response(
@@ -861,16 +851,11 @@ test("worker allows dashboard passkey session to hand off chat to VPS runner que
   assert.equal(response.status, 202);
   const body = await response.json();
   assert.equal(body.ok, true);
-  assert.equal(body.execution.transport, "vps_runner");
-  assert.equal(body.execution.targetRepository, "marushu/vtdd-v2-p");
-  assert.equal(body.execution.issueNumber, 450);
-  assert.equal(body.execution.codexGoal, "dashboard_chat_triage");
-  assert.equal(body.messages[1].role, "system");
-  assert.equal(calls.length, 1);
-  const queueBody = JSON.parse(calls[0].init.body).body;
-  assert.equal(queueBody.includes('"dashboardThreadId": "dashboard-main-marushu-vtdd-v2-p"'), true);
-  assert.equal(queueBody.includes('"repositoryInput": "ぶい"'), true);
-  assert.equal(queueBody.includes('"ownerMessage": "ぶい #450 の残り Issue と PR を確認して交通整理して"'), true);
+  assert.equal(body.execution, null);
+  assert.equal(body.messages[1].role, "butler");
+  assert.equal(body.messages[1].status, "blocked");
+  assert.match(body.messages[1].text, /app-server 接続 PR/);
+  assert.equal(calls.length, 0);
 });
 
 test("worker returns registered dashboard repository nicknames in Japanese without VPS handoff", async () => {
@@ -916,7 +901,7 @@ test("worker returns registered dashboard repository nicknames in Japanese witho
   assert.equal(body.messages[1].text.includes("- marushu/vtdd-v2-p: ぶい, vtdd"), true);
 });
 
-test("worker rejects dashboard chat handoff without repository using Japanese owner-facing reason", async () => {
+test("worker stores dashboard chat without repository instead of dispatching handoff", async () => {
   const response = await worker.fetch(
     new Request("https://example.com/v2/dashboard/chat/messages", {
       method: "POST",
@@ -933,12 +918,14 @@ test("worker rejects dashboard chat handoff without repository using Japanese ow
     }
   );
 
-  assert.equal(response.status, 422);
+  assert.equal(response.status, 202);
   const body = await response.json();
-  assert.equal(body.ok, false);
-  assert.equal(body.error, "repository_unresolved");
-  assert.equal(body.reason.includes("対象 repository nickname を登録済み alias から解決できませんでした"), true);
-  assert.equal(body.reason.includes("target repository could not be resolved"), false);
+  assert.equal(body.ok, true);
+  assert.equal(body.execution, null);
+  assert.equal(body.messages[1].role, "butler");
+  assert.equal(body.messages[1].status, "blocked");
+  assert.equal(body.messages[1].text.includes("対象 repo: 未指定"), true);
+  assert.equal(body.messages[1].text.includes("app-server"), true);
 });
 
 test("worker rejects unauthenticated dashboard chat VPS runner dispatch", async () => {
@@ -1017,7 +1004,7 @@ test("worker requires WebSocket upgrade for dashboard chat live updates", async 
   assert.equal(rooms.calls.length, 0);
 });
 
-test("worker exposes machine-authenticated VPS runner WebSocket push channel", async () => {
+test("worker no longer exposes the dashboard VPS runner WebSocket push channel", async () => {
   const rooms = createMockDashboardChatRoomNamespace();
   const response = await worker.fetch(
     new Request("https://example.com/v2/dashboard/vps-runner/ws?threadId=dashboard-main-marushu-vtdd-v2-p", {
@@ -1026,104 +1013,12 @@ test("worker exposes machine-authenticated VPS runner WebSocket push channel", a
     { ...gatewayAuthEnv, DASHBOARD_CHAT_ROOMS: rooms.namespace }
   );
 
-  assert.equal(response.status, 426);
-  const body = await response.json();
-  assert.equal(body.error, "websocket_upgrade_required");
+  assert.equal(response.status, 404);
   assert.equal(rooms.calls.length, 0);
-
-  const protocolToken = Buffer.from(gatewayAuthEnv.VTDD_GATEWAY_BEARER_TOKEN, "utf8").toString("base64url");
-  const protocolAuthorized = await worker.fetch(
-    new Request("https://example.com/v2/dashboard/vps-runner/ws?threadId=dashboard-main-marushu-vtdd-v2-p", {
-      headers: {
-        "sec-websocket-protocol": `vtdd-vps-runner, vtdd-gateway-bearer-${protocolToken}`
-      }
-    }),
-    { ...gatewayAuthEnv, DASHBOARD_CHAT_ROOMS: rooms.namespace }
-  );
-  assert.equal(protocolAuthorized.status, 426);
-  const protocolBody = await protocolAuthorized.json();
-  assert.equal(protocolBody.error, "websocket_upgrade_required");
-
-  const unauthorized = await worker.fetch(
-    new Request("https://example.com/v2/dashboard/vps-runner/ws?threadId=dashboard-main-marushu-vtdd-v2-p"),
-    { ...gatewayAuthEnv, DASHBOARD_CHAT_ROOMS: rooms.namespace }
-  );
-  assert.equal(unauthorized.status, 401);
-
-  const missingThread = await worker.fetch(
-    new Request("https://example.com/v2/dashboard/vps-runner/ws", {
-      headers: gatewayAuthHeaders
-    }),
-    { ...gatewayAuthEnv, DASHBOARD_CHAT_ROOMS: rooms.namespace }
-  );
-  assert.equal(missingThread.status, 422);
-  const missingBody = await missingThread.json();
-  assert.equal(missingBody.error, "thread_id_required");
 });
 
-test("DashboardChatRoom selects VPS runner WebSocket subprotocol without echoing bearer token", () => {
-  const selected = selectDashboardWebSocketResponseProtocol(
-    "vtdd-vps-runner, vtdd-gateway-bearer-redacted-test-token"
-  );
-
-  assert.equal(selected, "vtdd-vps-runner");
-  assert.equal(selected.includes("bearer"), false);
-});
-
-test("DashboardChatRoom pushes owner messages to a runner socket in the same thread room", async () => {
-  const store = createInMemoryDashboardChatStore();
-  const room = new DashboardChatRoom(
-    {
-      getWebSockets() {
-        return [dashboardSocket, runnerSocket];
-      }
-    },
-    { DASHBOARD_CHAT_STORE: store }
-  );
-  const dashboardSocket = createMockSocket("dashboard", "dashboard-main-marushu-vtdd-v2-p");
-  const runnerSocket = createMockSocket("vps_runner", "dashboard-main-marushu-vtdd-v2-p");
-
-  await room.webSocketMessage(
-    dashboardSocket,
-    JSON.stringify({
-      type: "owner_message",
-      threadId: "dashboard-main-marushu-vtdd-v2-p",
-      repositoryInput: "marushu/vtdd-v2-p",
-      issueNumber: 450,
-      text: "進捗は？"
-    })
-  );
-
-  assert.equal(runnerSocket.sent.length, 1);
-  const job = JSON.parse(runnerSocket.sent[0]);
-  assert.equal(job.type, "dashboard_chat_job");
-  assert.equal(job.threadId, "dashboard-main-marushu-vtdd-v2-p");
-  assert.equal(job.repository, "marushu/vtdd-v2-p");
-  assert.equal(job.relatedIssue, 450);
-  assert.equal(job.text, "進捗は？");
-
-  assert.equal(dashboardSocket.sent.length, 1);
-  const broadcast = JSON.parse(dashboardSocket.sent[0]);
-  assert.equal(broadcast.type, "thread");
-  assert.equal(broadcast.messages.length, 2);
-  assert.equal(broadcast.messages[0].role, "owner");
-  assert.equal(broadcast.messages[1].status, "thinking");
-});
-
-test("DashboardChatRoom resolves repository nicknames before pushing unresolved-thread owner messages", async () => {
+test("DashboardChatRoom stores owner messages without pushing a VPS runner job", async () => {
   const provider = createInMemoryMemoryProvider();
-  await provider.store({
-    id: "alias_registry:marushu/vtdd-v2-p",
-    type: MemoryRecordType.ALIAS_REGISTRY,
-    content: {
-      canonicalRepo: "marushu/vtdd-v2-p",
-      aliases: ["ぶい", "vtdd"]
-    },
-    metadata: { source: "test" },
-    priority: 60,
-    tags: ["alias_registry", "marushu/vtdd-v2-p"],
-    createdAt: "2026-05-20T00:00:00.000Z"
-  });
   const store = createInMemoryDashboardChatStore();
   const dashboardSocket = createMockSocket("dashboard", "dashboard-main-unresolved");
   const runnerSocket = createMockSocket("vps_runner", "dashboard-main-unresolved");
@@ -1134,194 +1029,6 @@ test("DashboardChatRoom resolves repository nicknames before pushing unresolved-
       }
     },
     { DASHBOARD_CHAT_STORE: store, MEMORY_PROVIDER: provider }
-  );
-
-  await room.webSocketMessage(
-    dashboardSocket,
-    JSON.stringify({
-      type: "owner_message",
-      threadId: "dashboard-main-unresolved",
-      text: "ぶい #450 の残りを短く返して"
-    })
-  );
-
-  assert.equal(runnerSocket.sent.length, 1);
-  const job = JSON.parse(runnerSocket.sent[0]);
-  assert.equal(job.threadId, "dashboard-main-unresolved");
-  assert.equal(job.repository, "marushu/vtdd-v2-p");
-  assert.equal(job.repositoryInput, "ぶい");
-  assert.equal(job.relatedIssue, 450);
-});
-
-test("DashboardChatRoom resolves Japanese no-particle nickname requests before VPS handoff", async () => {
-  const provider = createInMemoryMemoryProvider();
-  await provider.store({
-    id: "alias_registry:marushu/vtdd-v2-p",
-    type: MemoryRecordType.ALIAS_REGISTRY,
-    content: {
-      canonicalRepo: "marushu/vtdd-v2-p",
-      aliases: ["ぶい", "vtdd"]
-    },
-    metadata: { source: "test" },
-    priority: 60,
-    tags: ["alias_registry", "marushu/vtdd-v2-p"],
-    createdAt: "2026-05-20T00:00:00.000Z"
-  });
-  const store = createInMemoryDashboardChatStore();
-  const dashboardSocket = createMockSocket("dashboard", "dashboard-main-unresolved");
-  const runnerSocket = createMockSocket("vps_runner", "dashboard-main-unresolved");
-  const room = new DashboardChatRoom(
-    {
-      getWebSockets() {
-        return [dashboardSocket, runnerSocket];
-      }
-    },
-    { DASHBOARD_CHAT_STORE: store, MEMORY_PROVIDER: provider }
-  );
-
-  await room.webSocketMessage(
-    dashboardSocket,
-    JSON.stringify({
-      type: "owner_message",
-      threadId: "dashboard-main-unresolved",
-      text: "ぶいの残りタスクを確認して"
-    })
-  );
-
-  assert.equal(runnerSocket.sent.length, 1);
-  const job = JSON.parse(runnerSocket.sent[0]);
-  assert.equal(job.repository, "marushu/vtdd-v2-p");
-  assert.equal(job.repositoryInput, "ぶい");
-});
-
-test("DashboardChatRoom forwards unresolved repository work to VPS runner for conversational handling", async () => {
-  const store = createInMemoryDashboardChatStore();
-  const dashboardSocket = createMockSocket("dashboard", "dashboard-main-unresolved");
-  const runnerSocket = createMockSocket("vps_runner", "dashboard-main-unresolved");
-  const room = new DashboardChatRoom(
-    {
-      getWebSockets() {
-        return [dashboardSocket, runnerSocket];
-      }
-    },
-    { DASHBOARD_CHAT_STORE: store, MEMORY_PROVIDER: createInMemoryMemoryProvider() }
-  );
-
-  await room.webSocketMessage(
-    dashboardSocket,
-    JSON.stringify({
-      type: "owner_message",
-      threadId: "dashboard-main-unresolved",
-      text: "VPS Codex CLI 疎通テスト。今の #450 の残りを短く返して。"
-    })
-  );
-
-  assert.equal(runnerSocket.sent.length, 1);
-  const job = JSON.parse(runnerSocket.sent[0]);
-  assert.equal(job.text, "VPS Codex CLI 疎通テスト。今の #450 の残りを短く返して。");
-  assert.equal(job.repository, "");
-  assert.equal(job.relatedIssue, 450);
-  assert.equal(job.repositoryResolution.ok, false);
-  assert.equal(dashboardSocket.sent.length, 1);
-  const broadcast = JSON.parse(dashboardSocket.sent[0]);
-  assert.equal(broadcast.messages.length, 2);
-  assert.equal(broadcast.messages[0].role, "owner");
-  assert.equal(broadcast.messages[0].text, "VPS Codex CLI 疎通テスト。今の #450 の残りを短く返して。");
-  assert.equal(broadcast.messages[1].status, "thinking");
-  assert.equal(broadcast.messages[1].text.includes("VPS Codex CLI に送信しました"), true);
-  assert.equal(broadcast.messages[1].relatedIssue, 450);
-});
-
-test("DashboardChatRoom forwards identity questions to VPS runner instead of answering in the Worker", async () => {
-  const store = createInMemoryDashboardChatStore();
-  const dashboardSocket = createMockSocket("dashboard", "dashboard-main-unresolved");
-  const runnerSocket = createMockSocket("vps_runner", "dashboard-main-unresolved");
-  const room = new DashboardChatRoom(
-    {
-      getWebSockets() {
-        return [dashboardSocket, runnerSocket];
-      }
-    },
-    { DASHBOARD_CHAT_STORE: store, MEMORY_PROVIDER: createInMemoryMemoryProvider() }
-  );
-
-  await room.webSocketMessage(
-    dashboardSocket,
-    JSON.stringify({
-      type: "owner_message",
-      threadId: "dashboard-main-unresolved",
-      text: "君は誰？"
-    })
-  );
-
-  assert.equal(runnerSocket.sent.length, 1);
-  const job = JSON.parse(runnerSocket.sent[0]);
-  assert.equal(job.text, "君は誰？");
-  assert.equal(job.repository, "");
-  assert.equal(job.repositoryResolution.ok, false);
-  assert.equal(dashboardSocket.sent.length, 1);
-  const broadcast = JSON.parse(dashboardSocket.sent[0]);
-  assert.equal(broadcast.messages.length, 2);
-  assert.equal(broadcast.messages[0].role, "owner");
-  assert.equal(broadcast.messages[1].role, "system");
-  assert.equal(broadcast.messages[1].status, "thinking");
-});
-
-test("DashboardChatRoom forwards capability questions to VPS runner instead of answering in the Worker", async () => {
-  const store = createInMemoryDashboardChatStore();
-  const dashboardSocket = createMockSocket("dashboard", "dashboard-main-unresolved");
-  const runnerSocket = createMockSocket("vps_runner", "dashboard-main-unresolved");
-  const room = new DashboardChatRoom(
-    {
-      getWebSockets() {
-        return [dashboardSocket, runnerSocket];
-      }
-    },
-    { DASHBOARD_CHAT_STORE: store, MEMORY_PROVIDER: createInMemoryMemoryProvider() }
-  );
-
-  await room.webSocketMessage(
-    dashboardSocket,
-    JSON.stringify({
-      type: "owner_message",
-      threadId: "dashboard-main-unresolved",
-      text: "何ができる？"
-    })
-  );
-
-  assert.equal(runnerSocket.sent.length, 1);
-  const job = JSON.parse(runnerSocket.sent[0]);
-  assert.equal(job.text, "何ができる？");
-  assert.equal(job.repository, "");
-  assert.equal(job.repositoryResolution.ok, false);
-  const broadcast = JSON.parse(dashboardSocket.sent[0]);
-  assert.equal(broadcast.messages.length, 2);
-  assert.equal(broadcast.messages[0].role, "owner");
-  assert.equal(broadcast.messages[1].role, "system");
-  assert.equal(broadcast.messages[1].status, "thinking");
-});
-
-test("DashboardChatRoom forwards general date questions to VPS runner even when thread has repository context", async () => {
-  const store = createInMemoryDashboardChatStore();
-  await store.appendMany("dashboard-main-unresolved", [
-    {
-      role: "runner",
-      repository: "marushu/vtdd-v2-p",
-      relatedIssue: 450,
-      status: "replied",
-      text: "Issue #450 の返答です。",
-      createdAt: "2026-05-21T00:00:00.000Z"
-    }
-  ]);
-  const dashboardSocket = createMockSocket("dashboard", "dashboard-main-unresolved");
-  const runnerSocket = createMockSocket("vps_runner", "dashboard-main-unresolved");
-  const room = new DashboardChatRoom(
-    {
-      getWebSockets() {
-        return [dashboardSocket, runnerSocket];
-      }
-    },
-    { DASHBOARD_CHAT_STORE: store, MEMORY_PROVIDER: createInMemoryMemoryProvider() }
   );
 
   await room.webSocketMessage(
@@ -1333,57 +1040,15 @@ test("DashboardChatRoom forwards general date questions to VPS runner even when 
     })
   );
 
-  assert.equal(runnerSocket.sent.length, 1);
-  const job = JSON.parse(runnerSocket.sent[0]);
-  assert.equal(job.text, "今日は何月何日？日本時間を答えて");
-  assert.equal(job.repository, "");
-  assert.equal(job.repositoryResolution.ok, false);
+  assert.equal(runnerSocket.sent.length, 0);
   assert.equal(dashboardSocket.sent.length, 1);
   const broadcast = JSON.parse(dashboardSocket.sent[0]);
   assert.equal(broadcast.messages.length, 2);
   assert.equal(broadcast.messages[0].role, "owner");
   assert.equal(broadcast.messages[0].text, "今日は何月何日？日本時間を答えて");
-  assert.equal(broadcast.messages[1].role, "system");
-  assert.equal(broadcast.messages[1].status, "thinking");
-});
-
-test("DashboardChatRoom uses same-thread repository context for follow-up owner messages", async () => {
-  const store = createInMemoryDashboardChatStore();
-  await store.appendMany("dashboard-main-unresolved", [
-    {
-      role: "runner",
-      repository: "marushu/vtdd-v2-p",
-      relatedIssue: 450,
-      status: "replied",
-      text: "Issue #450 の返答です。",
-      createdAt: "2026-05-21T00:00:00.000Z"
-    }
-  ]);
-  const dashboardSocket = createMockSocket("dashboard", "dashboard-main-unresolved");
-  const runnerSocket = createMockSocket("vps_runner", "dashboard-main-unresolved");
-  const room = new DashboardChatRoom(
-    {
-      getWebSockets() {
-        return [dashboardSocket, runnerSocket];
-      }
-    },
-    { DASHBOARD_CHAT_STORE: store, MEMORY_PROVIDER: createInMemoryMemoryProvider() }
-  );
-
-  await room.webSocketMessage(
-    dashboardSocket,
-    JSON.stringify({
-      type: "owner_message",
-      threadId: "dashboard-main-unresolved",
-      text: "進捗は？"
-    })
-  );
-
-  assert.equal(runnerSocket.sent.length, 1);
-  const job = JSON.parse(runnerSocket.sent[0]);
-  assert.equal(job.repository, "marushu/vtdd-v2-p");
-  assert.equal(job.repositoryInput, "marushu/vtdd-v2-p");
-  assert.equal(job.text, "進捗は？");
+  assert.equal(broadcast.messages[1].role, "butler");
+  assert.equal(broadcast.messages[1].status, "blocked");
+  assert.equal(broadcast.messages[1].text.includes("app-server"), true);
 });
 
 test("DashboardChatRoom returns nickname list without repository handoff", async () => {
@@ -1427,104 +1092,6 @@ test("DashboardChatRoom returns nickname list without repository handoff", async
   assert.equal(broadcast.messages[0].role, "owner");
   assert.equal(broadcast.messages[1].text.includes("登録済みニックネームです。"), true);
   assert.equal(broadcast.messages[1].text.includes("- marushu/vtdd-v2-p: ぶい, vtdd"), true);
-});
-
-test("DashboardChatRoom broadcasts VPS runner replies to dashboard sockets in the same thread room", async () => {
-  const store = createInMemoryDashboardChatStore();
-  const dashboardSocket = createMockSocket("dashboard", "dashboard-main-marushu-vtdd-v2-p");
-  const runnerSocket = createMockSocket("vps_runner", "dashboard-main-marushu-vtdd-v2-p");
-  const room = new DashboardChatRoom(
-    {
-      getWebSockets() {
-        return [dashboardSocket, runnerSocket];
-      }
-    },
-    { DASHBOARD_CHAT_STORE: store }
-  );
-
-  await room.webSocketMessage(
-    runnerSocket,
-    JSON.stringify({
-      threadId: "dashboard-main-marushu-vtdd-v2-p",
-      repository: "marushu/vtdd-v2-p",
-      issueNumber: 450,
-      status: "completed",
-      message: "VPS Codex CLI からの返信です。"
-    })
-  );
-
-  assert.equal(dashboardSocket.sent.length, 1);
-  const broadcast = JSON.parse(dashboardSocket.sent[0]);
-  assert.equal(broadcast.threadId, "dashboard-main-marushu-vtdd-v2-p");
-  assert.equal(broadcast.messages.length, 1);
-  assert.equal(broadcast.messages[0].role, "runner");
-  assert.equal(broadcast.messages[0].status, "replied");
-  assert.equal(broadcast.messages[0].text, "VPS Codex CLI からの返信です。");
-  assert.equal(runnerSocket.sent.length, 0);
-});
-
-test("DashboardChatRoom rejects VPS runner replies for a different thread room", async () => {
-  const store = createInMemoryDashboardChatStore();
-  const dashboardSocket = createMockSocket("dashboard", "dashboard-main-marushu-vtdd-v2-p");
-  const runnerSocket = createMockSocket("vps_runner", "dashboard-main-marushu-vtdd-v2-p");
-  const room = new DashboardChatRoom(
-    {
-      getWebSockets() {
-        return [dashboardSocket, runnerSocket];
-      }
-    },
-    { DASHBOARD_CHAT_STORE: store }
-  );
-
-  await room.webSocketMessage(
-    runnerSocket,
-    JSON.stringify({
-      threadId: "dashboard-main-other",
-      repository: "marushu/vtdd-v2-p",
-      issueNumber: 450,
-      status: "completed",
-      message: "別 thread に混ざってはいけない返信"
-    })
-  );
-
-  assert.equal(dashboardSocket.sent.length, 0);
-  assert.equal(runnerSocket.sent.length, 0);
-  assert.equal((await store.listThread("dashboard-main-marushu-vtdd-v2-p")).length, 0);
-  assert.equal((await store.listThread("dashboard-main-other")).length, 0);
-});
-
-test("DashboardChatRoom stores a visible failure when no runner socket is connected", async () => {
-  const store = createInMemoryDashboardChatStore();
-  const dashboardSocket = createMockSocket("dashboard", "dashboard-main-marushu-vtdd-v2-p");
-  const room = new DashboardChatRoom(
-    {
-      getWebSockets() {
-        return [dashboardSocket];
-      }
-    },
-    { DASHBOARD_CHAT_STORE: store }
-  );
-
-  await room.webSocketMessage(
-    dashboardSocket,
-    JSON.stringify({
-      type: "owner_message",
-      threadId: "dashboard-main-marushu-vtdd-v2-p",
-      repositoryInput: "marushu/vtdd-v2-p",
-      issueNumber: 450,
-      text: "返事ある？"
-    })
-  );
-
-  assert.equal(dashboardSocket.sent.length, 2);
-  const failureBroadcast = JSON.parse(dashboardSocket.sent[1]);
-  assert.equal(failureBroadcast.messages.length, 1);
-  assert.equal(failureBroadcast.messages[0].status, "failed");
-  assert.equal(failureBroadcast.messages[0].text.includes("WebSocket 接続されていない"), true);
-
-  const stored = await store.listThread("dashboard-main-marushu-vtdd-v2-p");
-  assert.equal(stored.length, 3);
-  assert.equal(stored[2].status, "failed");
 });
 
 test("worker redacts dashboard Butler chat sensitive material before returning and storing", async () => {

--- a/worker.js
+++ b/worker.js
@@ -33131,7 +33131,6 @@ var VpsRunnerCancelMode = Object.freeze({
   DRAIN_PENDING: "drain_pending"
 });
 var RemoteCodexDispatchGoal = Object.freeze({
-  DASHBOARD_CHAT_TRIAGE: "dashboard_chat_triage",
   OPEN_PR: "open_pr",
   REVISE_PR: "revise_pr",
   RESPOND_TO_REVIEW: "respond_to_review",
@@ -33212,7 +33211,7 @@ function createRemoteCodexExecutionRequest(input = {}) {
   if (!request.codexGoal) {
     issues.push("codexGoal is required");
   } else if (!REMOTE_CODEX_DISPATCH_GOALS.has(request.codexGoal)) {
-    issues.push("codexGoal must be dashboard_chat_triage, open_pr, revise_pr, respond_to_review, or post_merge_verify");
+    issues.push("codexGoal must be open_pr, revise_pr, respond_to_review, or post_merge_verify");
   }
   if (!request.baseRef) {
     issues.push("baseRef is required");
@@ -34676,7 +34675,6 @@ function buildCodexCloudGitHubComment({ request }) {
   return lines.join("\n");
 }
 function buildVpsRunnerGitHubQueueComment({ request }) {
-  const isDashboardChatTriage = request.codexGoal === RemoteCodexDispatchGoal.DASHBOARD_CHAT_TRIAGE;
   const payload = {
     executionId: request.executionId,
     transport: RemoteCodexExecutorTransport.VPS_RUNNER,
@@ -34695,8 +34693,6 @@ function buildVpsRunnerGitHubQueueComment({ request }) {
   const lines = [
     `<!-- vtdd:vps-runner-execution:${request.executionId} -->`,
     "VTDD \u7BA1\u7406\u306E VPS runner \u5B9F\u884C\u30AD\u30E5\u30FC\u3067\u3059\u3002",
-    "",
-    "\u3053\u306E\u30B3\u30E1\u30F3\u30C8\u306F dashboard \u3078\u306E\u8FD4\u4FE1\u3067\u306F\u3042\u308A\u307E\u305B\u3093\u3002VPS Codex CLI \u304C\u62FE\u3044\u3001\u5B8C\u4E86 event \u3092 runtime \u306B\u8FD4\u3057\u305F\u3082\u306E\u3060\u3051\u3092 dashboard \u306E\u8FD4\u4FE1\u3068\u3057\u3066\u6271\u3044\u307E\u3059\u3002",
     "",
     "\u5B9F\u884C\u5883\u754C:",
     `- \u30EA\u30DD\u30B8\u30C8\u30EA: ${request.repository}`,
@@ -34719,20 +34715,14 @@ function buildVpsRunnerGitHubQueueComment({ request }) {
     ] : [],
     "- \u6B63\u672C: \u3053\u306E GitHub Issue",
     "- runtime truth: \u73FE\u5728\u306E GitHub branch / diff / PR / review comments",
-    isDashboardChatTriage ? "- \u5B8C\u4E86\u6761\u4EF6: dashboard chat triage \u306E\u8FD4\u4FE1 event \u3092\u540C\u3058 thread \u306B\u8FD4\u3059" : request.codexGoal === RemoteCodexDispatchGoal.POST_MERGE_VERIFY ? "- \u5B8C\u4E86\u6761\u4EF6: merge \u5F8C runtime truth \u3092\u691C\u8A3C\u3057\u3001GitHub-visible evidence \u3092\u6B8B\u3059" : "- \u5B8C\u4E86\u6761\u4EF6: pull request \u3092\u4F5C\u6210\u307E\u305F\u306F\u66F4\u65B0\u3059\u308B",
-    ...isDashboardChatTriage ? [
-      "- PR body requirement: \u4E0D\u8981\u3002dashboard chat triage \u306F PR \u3092\u4F5C\u6210\u30FB\u66F4\u65B0\u3057\u307E\u305B\u3093\u3002",
-      "- context preflight: VPS runner \u306F `AGENTS.md`\u3001`docs/butler/thread-independent-startup-contract.md`\u3001\u6B63\u672C Issue \u3092\u8AAD\u3093\u3067\u304B\u3089 triage \u3092\u958B\u59CB\u3057\u307E\u3059\u3002"
-    ] : [
-      "- PR body requirement: Codex \u306F `docs/pr-template-model.md`\u3001`scripts/render-pr-body.mjs`\u3001`scripts/validate-pr-body.mjs` \u3092\u78BA\u8A8D\u3057\u307E\u3059\u3002VPS runner \u3082 PR create/update \u524D\u306B\u691C\u8A3C\u30FB\u6B63\u898F\u5316\u3057\u307E\u3059\u3002",
-      "- context preflight: VPS runner \u306F `AGENTS.md`\u3001`docs/butler/thread-independent-startup-contract.md`\u3001\u6B63\u672C Issue\u3001PR body contract files \u3092\u8AAD\u3093\u3067\u304B\u3089\u7DE8\u96C6\u3092\u958B\u59CB\u3057\u307E\u3059\u3002",
-      "- \u5FC5\u9808 PR body markers: `## This PR satisfies Intent`, `## Satisfied Success Criteria`, `## Unsatisfied Success Criteria`, `## Verification Evidence`, `## Surface Update Checklist`."
-    ],
+    request.codexGoal === RemoteCodexDispatchGoal.POST_MERGE_VERIFY ? "- \u5B8C\u4E86\u6761\u4EF6: merge \u5F8C runtime truth \u3092\u691C\u8A3C\u3057\u3001GitHub-visible evidence \u3092\u6B8B\u3059" : "- \u5B8C\u4E86\u6761\u4EF6: pull request \u3092\u4F5C\u6210\u307E\u305F\u306F\u66F4\u65B0\u3059\u308B",
+    "- PR body requirement: Codex \u306F `docs/pr-template-model.md`\u3001`scripts/render-pr-body.mjs`\u3001`scripts/validate-pr-body.mjs` \u3092\u78BA\u8A8D\u3057\u307E\u3059\u3002VPS runner \u3082 PR create/update \u524D\u306B\u691C\u8A3C\u30FB\u6B63\u898F\u5316\u3057\u307E\u3059\u3002",
+    "- context preflight: VPS runner \u306F `AGENTS.md`\u3001`docs/butler/thread-independent-startup-contract.md`\u3001\u6B63\u672C Issue\u3001PR body contract files \u3092\u8AAD\u3093\u3067\u304B\u3089\u7DE8\u96C6\u3092\u958B\u59CB\u3057\u307E\u3059\u3002",
+    "- \u5FC5\u9808 PR body markers: `## This PR satisfies Intent`, `## Satisfied Success Criteria`, `## Unsatisfied Success Criteria`, `## Verification Evidence`, `## Surface Update Checklist`.",
     "- preflight \u5165\u529B\u304C\u4E0D\u8DB3\u3057\u3066\u3044\u308B\u5834\u5408\u3001\u63A8\u6E2C\u5B9F\u88C5\u306F\u7981\u6B62\u3067\u3059\u3002runner \u306F Butler/owner \u306B\u6B21\u306E\u5224\u65AD\u3092\u6C42\u3081\u3001bounded request \u306E\u518D\u767A\u884C\u3092\u5F85\u3061\u307E\u3059\u3002",
     "",
     "\u30EB\u30FC\u30EB:",
     "- Issue \u306E\u7BC4\u56F2\u3092\u52DD\u624B\u306B\u5E83\u3052\u306A\u3044\u3002",
-    ...isDashboardChatTriage ? ["- \u30D5\u30A1\u30A4\u30EB\u7DE8\u96C6\u3057\u306A\u3044\u3002", "- commit \u3057\u306A\u3044\u3002", "- push \u3057\u306A\u3044\u3002", "- PR \u3092\u4F5C\u6210\u30FB\u66F4\u65B0\u3057\u306A\u3044\u3002"] : [],
     "- merge \u3057\u306A\u3044\u3002",
     "- deploy \u3057\u306A\u3044\u3002",
     "- reviewer objection \u306F Butler/human judgment \u7528\u306B\u6B8B\u3059\u3002",
@@ -34746,15 +34736,11 @@ function buildVpsRunnerGitHubQueueComment({ request }) {
 function buildExecutionPreflightPolicy({ codexGoal } = {}) {
   const requiredRepoFiles = [
     "AGENTS.md",
-    "docs/butler/thread-independent-startup-contract.md"
+    "docs/butler/thread-independent-startup-contract.md",
+    "docs/pr-template-model.md",
+    "scripts/render-pr-body.mjs",
+    "scripts/validate-pr-body.mjs"
   ];
-  if (codexGoal !== RemoteCodexDispatchGoal.DASHBOARD_CHAT_TRIAGE) {
-    requiredRepoFiles.push(
-      "docs/pr-template-model.md",
-      "scripts/render-pr-body.mjs",
-      "scripts/validate-pr-body.mjs"
-    );
-  }
   return {
     mode: "auto_receipt",
     onMissingContract: "owner_decision_required",
@@ -55869,11 +55855,6 @@ var DashboardChatRoom = class {
       });
       return json(202, { ok: true, threadId: threadId2 });
     }
-    if (request.method === "POST" && url.pathname === "/dispatch") {
-      const payload = await readJson(request);
-      const result = await this.pushVpsRunnerJob(payload);
-      return json(result.ok ? 202 : 503, result);
-    }
     if (request.headers.get("upgrade")?.toLowerCase() !== "websocket") {
       return json(426, {
         ok: false,
@@ -55888,8 +55869,7 @@ var DashboardChatRoom = class {
         reason: "WebSocketPair is not available in this runtime"
       });
     }
-    const isVpsRunnerSocket = url.pathname.endsWith("/dashboard/vps-runner/ws") || url.pathname === "/vps-runner/ws";
-    const threadId = isVpsRunnerSocket ? normalizeDashboardThreadId(url.searchParams.get("threadId") || url.searchParams.get("thread_id")) : extractDashboardChatSocketThreadId(url.pathname);
+    const threadId = extractDashboardChatSocketThreadId(url.pathname);
     if (!threadId) {
       return json(422, {
         ok: false,
@@ -55899,7 +55879,7 @@ var DashboardChatRoom = class {
     }
     const pair = new WebSocketPair();
     const [client, server] = Object.values(pair);
-    const attachment = isVpsRunnerSocket ? { role: "vps_runner", threadId } : { role: "dashboard", threadId };
+    const attachment = { role: "dashboard", threadId };
     if (typeof this.ctx?.acceptWebSocket === "function") {
       server.serializeAttachment(attachment);
       this.ctx.acceptWebSocket(server);
@@ -55910,19 +55890,9 @@ var DashboardChatRoom = class {
       server.addEventListener("error", () => this.sessions.delete(server));
       server.addEventListener("message", (event) => this.handleSocketMessage(server, event?.data, attachment));
     }
-    if (isVpsRunnerSocket && isSocketOpen(server)) {
-      server.send(JSON.stringify({ type: "vps_runner_connected", ok: true }));
-    } else {
-      await this.sendThread(server, threadId);
-    }
-    const responseHeaders = new Headers();
-    const responseProtocol = selectDashboardWebSocketResponseProtocol(request.headers.get("sec-websocket-protocol"));
-    if (responseProtocol) {
-      responseHeaders.set("sec-websocket-protocol", responseProtocol);
-    }
+    await this.sendThread(server, threadId);
     return new Response(null, {
       status: 101,
-      headers: responseHeaders,
       webSocket: client
     });
   }
@@ -55950,10 +55920,6 @@ var DashboardChatRoom = class {
       payload = text ? JSON.parse(text) : null;
     } catch {
       payload = null;
-    }
-    if (socketAttachment.role === "vps_runner") {
-      await this.acceptVpsRunnerReply(payload, socketAttachment);
-      return;
     }
     if (payload?.type === "owner_message") {
       await this.acceptOwnerMessage({ socket, threadId, payload });
@@ -56008,107 +55974,20 @@ var DashboardChatRoom = class {
       },
       { threadId }
     );
-    const thinkingMessage = normalizeDashboardChatMessage(
+    const butlerMessage = normalizeDashboardChatMessage(
       {
         threadId,
-        role: "system",
+        role: "butler",
         repository,
         relatedIssue,
-        status: "thinking",
-        text: "VPS Codex CLI \u306B\u9001\u4FE1\u3057\u307E\u3057\u305F\u3002\u8FD4\u4FE1\u3092\u5F85\u3063\u3066\u3044\u307E\u3059\u3002",
+        status: "blocked",
+        text: buildDashboardAppServerNotConnectedReply({ repository, relatedIssue }),
         createdAt: new Date(Date.parse(now) + 1).toISOString()
       },
       { threadId }
     );
-    const messages = store ? await store.appendMany(threadId, [ownerMessage, thinkingMessage]) : [ownerMessage, thinkingMessage].filter(Boolean);
+    const messages = store ? await store.appendMany(threadId, [ownerMessage, butlerMessage]) : [ownerMessage, butlerMessage].filter(Boolean);
     await this.broadcastThread({ threadId, messages });
-    const pushed = await this.pushVpsRunnerJob({
-      type: "dashboard_chat_job",
-      threadId,
-      repository,
-      repositoryInput: repositoryResolution.input || payload?.repositoryInput || payload?.repository,
-      repositoryResolution,
-      relatedIssue,
-      text,
-      codexGoal: normalizeDashboardEventText(payload?.codexGoal || "dashboard_chat_triage"),
-      createdAt: now
-    });
-    if (!pushed.ok) {
-      const failedMessage = normalizeDashboardChatMessage(
-        {
-          threadId,
-          role: "system",
-          repository,
-          relatedIssue,
-          status: "failed",
-          text: "VPS Codex CLI \u304C WebSocket \u63A5\u7D9A\u3055\u308C\u3066\u3044\u306A\u3044\u305F\u3081\u9001\u4FE1\u3067\u304D\u307E\u305B\u3093\u3067\u3057\u305F\u3002runner \u63A5\u7D9A\u3092\u78BA\u8A8D\u3057\u3066\u304F\u3060\u3055\u3044\u3002",
-          createdAt: new Date(Date.parse(now) + 2).toISOString()
-        },
-        { threadId }
-      );
-      const failedMessages = store ? await store.appendMany(threadId, [failedMessage]) : [failedMessage].filter(Boolean);
-      await this.broadcastThread({ threadId, messages: failedMessages });
-    }
-  }
-  async acceptVpsRunnerReply(payload, socketAttachment = {}) {
-    const socketThreadId = normalizeDashboardThreadId(socketAttachment.threadId);
-    const threadId = normalizeDashboardThreadId(payload?.threadId || payload?.thread_id || socketThreadId);
-    if (!threadId) {
-      return;
-    }
-    if (socketThreadId && threadId !== socketThreadId) {
-      return;
-    }
-    const message = normalizeDashboardChatMessage(
-      {
-        threadId,
-        role: "runner",
-        repository: payload?.repository,
-        relatedIssue: payload?.relatedIssue || payload?.issueNumber,
-        status: payload?.status === "failed" ? "failed" : "replied",
-        text: payload?.text || payload?.message || payload?.body,
-        createdAt: payload?.createdAt || payload?.updatedAt
-      },
-      { threadId }
-    );
-    const store = resolveDashboardChatStore(this.env);
-    const messages = store ? await store.appendMany(threadId, [message]) : [message].filter(Boolean);
-    await this.broadcastThread({ threadId, messages });
-  }
-  async pushVpsRunnerJob(payload) {
-    const job = {
-      type: "dashboard_chat_job",
-      jobId: normalizeDashboardEventText(payload?.jobId) || crypto.randomUUID(),
-      threadId: normalizeDashboardThreadId(payload?.threadId || payload?.thread_id),
-      repository: normalizeCanonicalRepositoryInput(payload?.repository),
-      repositoryInput: normalizeDashboardEventText(payload?.repositoryInput || payload?.repository_input),
-      repositoryResolution: normalizeObject11(payload?.repositoryResolution || payload?.repository_resolution),
-      relatedIssue: normalizePositiveInteger9(payload?.relatedIssue || payload?.issueNumber),
-      text: sanitizeDashboardChatText(payload?.text || payload?.message || payload?.body),
-      codexGoal: normalizeDashboardEventText(payload?.codexGoal || "dashboard_chat_triage"),
-      createdAt: normalizeIsoTimestamp(payload?.createdAt) || (/* @__PURE__ */ new Date()).toISOString()
-    };
-    const runners = this.connectedSockets().filter((socket) => this.getSocketAttachment(socket).role === "vps_runner");
-    if (runners.length === 0) {
-      return {
-        ok: false,
-        error: "vps_runner_not_connected",
-        reason: "VPS Codex CLI WebSocket is not connected"
-      };
-    }
-    const frame = JSON.stringify(job);
-    let pushed = 0;
-    for (const runner of runners) {
-      if (isSocketOpen(runner)) {
-        runner.send(frame);
-        pushed += 1;
-      }
-    }
-    return {
-      ok: pushed > 0,
-      pushed,
-      jobId: job.jobId
-    };
   }
   async broadcastThread({ threadId, messages = null }) {
     const resolvedMessages = Array.isArray(messages) ? messages : await this.listThreadMessages(threadId);
@@ -56266,9 +56145,6 @@ var runtime_default = {
     }
     if (request.method === "GET" && isDashboardChatSocketApiPath(url.pathname)) {
       return handleDashboardChatSocketRequest(request, url, env);
-    }
-    if (request.method === "GET" && isApiPath(url.pathname, "/dashboard/vps-runner/ws")) {
-      return handleDashboardVpsRunnerSocketRequest(request, env);
     }
     if (request.method === "GET" && isApiPath(url.pathname, "/dashboard/chat/search")) {
       return handleDashboardChatSearchRequest(request, url, env);
@@ -58855,7 +58731,6 @@ async function handleDashboardChatMessageRequest(request, env) {
     });
   }
   const payload = await readJson(request);
-  const wantsVpsRunnerHandoff = shouldDispatchDashboardChatToVpsRunner(payload);
   const nicknameListTurn = await buildDashboardRepositoryNicknameListTurn({ payload, env });
   if (nicknameListTurn) {
     const store2 = resolveDashboardChatStore(env);
@@ -58875,22 +58750,13 @@ async function handleDashboardChatMessageRequest(request, env) {
     });
   }
   const repositoryResolution = await resolveDashboardChatRepository({ payload, env });
-  if (!repositoryResolution.ok) {
-    return json(repositoryResolution.status ?? 422, {
-      ok: false,
-      error: repositoryResolution.error,
-      reason: repositoryResolution.reason,
-      issues: repositoryResolution.issues ?? [],
-      candidates: repositoryResolution.candidates ?? []
-    });
-  }
+  const repository = repositoryResolution.ok ? repositoryResolution.repository : "";
   const prepared = buildDashboardChatTurn(
     {
       ...payload,
-      repository: repositoryResolution.repository,
+      repository,
       relatedIssue: normalizePositiveInteger9(payload?.relatedIssue || payload?.issueNumber) || extractIssueNumberFromDashboardChatText(payload?.text || payload?.message || payload?.body)
-    },
-    { wantsVpsRunnerHandoff }
+    }
   );
   if (!prepared.ok) {
     return json(422, {
@@ -58907,49 +58773,12 @@ async function handleDashboardChatMessageRequest(request, env) {
       reason: "dashboard Butler chat store is not configured"
     });
   }
-  let execution = null;
-  let messagesToStore = prepared.messages;
-  if (wantsVpsRunnerHandoff) {
-    const handoffPayload = buildDashboardVpsRunnerHandoffPayload({
-      payload,
-      prepared,
-      env,
-      runtimeUrl: new URL(request.url).origin
-    });
-    if (!handoffPayload.ok) {
-      return json(422, {
-        ok: false,
-        error: handoffPayload.error,
-        reason: handoffPayload.reason,
-        issues: handoffPayload.issues
-      });
-    }
-    const dispatched = await dispatchRemoteCodexExecution({
-      gatewayResult: { repository: prepared.repository },
-      payload: handoffPayload.payload,
-      executorTransport: "vps_runner",
-      env
-    });
-    if (!dispatched.ok) {
-      return json(dispatched.status ?? 502, {
-        ok: false,
-        error: dispatched.error ?? dispatched.blockedByRule ?? "dashboard_vps_runner_dispatch_failed",
-        reason: dispatched.reason,
-        issues: dispatched.issues ?? []
-      });
-    }
-    execution = dispatched.execution;
-    messagesToStore = [
-      ...prepared.messages,
-      buildDashboardVpsRunnerQueuedMessage({ prepared, execution })
-    ].filter(Boolean);
-  }
-  const messages = await store.appendMany(prepared.threadId, messagesToStore);
+  const messages = await store.appendMany(prepared.threadId, prepared.messages);
   return json(202, {
     ok: true,
     threadId: prepared.threadId,
     messages,
-    execution
+    execution: null
   });
 }
 async function handleDashboardChatSocketRequest(request, url, env) {
@@ -58989,82 +58818,6 @@ async function handleDashboardChatSocketRequest(request, url, env) {
     });
   }
   return room.fetch(request);
-}
-function selectDashboardWebSocketResponseProtocol(value) {
-  const protocols = normalizeText30(value).split(",").map((item) => item.trim()).filter(Boolean);
-  return protocols.includes("vtdd-vps-runner") ? "vtdd-vps-runner" : "";
-}
-async function handleDashboardVpsRunnerSocketRequest(request, env) {
-  const auth = authorizeGatewayRequest({
-    request: withDashboardRunnerProtocolAuthorization(request),
-    env,
-    apiSuffix: "/dashboard/vps-runner/ws"
-  });
-  if (!auth.ok) {
-    return json(auth.status, {
-      ok: false,
-      error: "unauthorized",
-      reason: auth.reason
-    });
-  }
-  const url = new URL(request.url);
-  const threadId = normalizeDashboardThreadId(url.searchParams.get("threadId") || url.searchParams.get("thread_id"));
-  if (!threadId) {
-    return json(422, {
-      ok: false,
-      error: "thread_id_required",
-      reason: "threadId is required for VPS Codex CLI dashboard WebSocket"
-    });
-  }
-  const room = resolveDashboardChatRoomStub(env, threadId);
-  if (!room) {
-    return json(503, {
-      ok: false,
-      error: "dashboard_vps_runner_room_unavailable",
-      reason: "DASHBOARD_CHAT_ROOMS Durable Object binding is not configured"
-    });
-  }
-  if (request.headers.get("upgrade")?.toLowerCase() !== "websocket") {
-    return json(426, {
-      ok: false,
-      error: "websocket_upgrade_required",
-      reason: "VPS Codex CLI push channel requires a WebSocket upgrade"
-    });
-  }
-  return room.fetch(request);
-}
-function withDashboardRunnerProtocolAuthorization(request) {
-  if (request.headers.get("authorization")) {
-    return request;
-  }
-  const protocol = normalizeText30(request.headers.get("sec-websocket-protocol"));
-  const token = protocol.split(",").map((item) => item.trim()).find((item) => item.startsWith("vtdd-gateway-bearer-"));
-  if (!token) {
-    return request;
-  }
-  const encoded = token.slice("vtdd-gateway-bearer-".length);
-  const bearerToken = decodeBase64UrlText(encoded);
-  if (!bearerToken) {
-    return request;
-  }
-  const headers = new Headers(request.headers);
-  headers.set("authorization", `Bearer ${bearerToken}`);
-  return new Request(request, { headers });
-}
-function decodeBase64UrlText(value) {
-  const normalized = normalizeText30(value);
-  if (!/^[A-Za-z0-9_-]+$/.test(normalized)) {
-    return "";
-  }
-  try {
-    const base643 = normalized.replace(/-/g, "+").replace(/_/g, "/");
-    const padded = base643.padEnd(Math.ceil(base643.length / 4) * 4, "=");
-    const binary = atob(padded);
-    const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
-    return new TextDecoder().decode(bytes);
-  } catch {
-    return "";
-  }
 }
 async function handleDashboardChatThreadRequest(request, url, env) {
   const auth = await authorizeDashboardRequest({
@@ -60923,13 +60676,6 @@ function createD1DashboardChatStore(d1) {
 function buildDashboardChatTurn(payload, options = {}) {
   const input = normalizeObject11(payload);
   const repository = normalizeCanonicalRepositoryInput(input.repository);
-  if (!repository) {
-    return {
-      ok: false,
-      error: "repository_required",
-      reason: "repository is required for dashboard Butler chat"
-    };
-  }
   const text = sanitizeDashboardChatText(input.text || input.message || input.body);
   if (!text) {
     return {
@@ -60938,7 +60684,7 @@ function buildDashboardChatTurn(payload, options = {}) {
       reason: "message text is required"
     };
   }
-  const threadId = normalizeDashboardThreadId(input.threadId || input.thread_id) || `dashboard-main-${repository.replace("/", "-")}`;
+  const threadId = normalizeDashboardThreadId(input.threadId || input.thread_id) || (repository ? `dashboard-main-${repository.replace("/", "-")}` : "dashboard-main-unresolved");
   const relatedIssue = normalizePositiveInteger9(input.relatedIssue || input.issueNumber);
   const now = (/* @__PURE__ */ new Date()).toISOString();
   const ownerMessage = normalizeDashboardChatMessage(
@@ -60953,18 +60699,14 @@ function buildDashboardChatTurn(payload, options = {}) {
     },
     { threadId }
   );
-  const butlerMessage = options.wantsVpsRunnerHandoff === true ? null : normalizeDashboardChatMessage(
+  const butlerMessage = normalizeDashboardChatMessage(
     {
       threadId,
       role: "butler",
       repository,
       relatedIssue,
-      status: "replied",
-      text: buildDeterministicButlerChatReply({
-        text,
-        repository,
-        relatedIssue
-      }),
+      status: "blocked",
+      text: buildDashboardAppServerNotConnectedReply({ repository, relatedIssue }),
       createdAt: new Date(Date.parse(now) + 1).toISOString()
     },
     { threadId }
@@ -60977,19 +60719,19 @@ function buildDashboardChatTurn(payload, options = {}) {
     messages: [ownerMessage, butlerMessage].filter(Boolean)
   };
 }
-function buildDeterministicButlerChatReply({ text, repository, relatedIssue, wantsVpsRunnerHandoff = false }) {
-  const lowerText = normalizeText30(text).toLowerCase();
-  const issuePhrase = relatedIssue ? ` Issue #${relatedIssue} \u3068\u3057\u3066\u6271\u3048\u307E\u3059\u3002` : "";
-  if (wantsVpsRunnerHandoff) {
-    return `\u53D7\u3051\u53D6\u308A\u307E\u3057\u305F\u3002${repository} \u306E Issue #${relatedIssue || "\u672A\u6307\u5B9A"} \u306B\u7D10\u3065\u3051\u3066\u3001VPS Codex CLI \u3078\u306E bounded handoff \u3092\u4F5C\u6210\u3057\u307E\u3059\u3002runner \u304B\u3089\u306E\u9032\u6357\u306F\u540C\u3058 dashboard chat thread \u306B\u8FD4\u3057\u307E\u3059\u3002`.trim();
-  }
-  if (lowerText.includes("vps") || lowerText.includes("codex") || lowerText.includes("cli")) {
-    return `\u53D7\u3051\u53D6\u308A\u307E\u3057\u305F\u3002${repository} \u306E\u4F1A\u8A71\u3068\u3057\u3066\u3001\u3053\u306E turn \u3092 dashboard chat thread \u306B\u4FDD\u5B58\u3057\u307E\u3057\u305F\u3002VPS Codex CLI \u3078\u306E\u5B9F\u884C dispatch \u306F\u307E\u3060\u884C\u308F\u305A\u3001\u6B21\u30B9\u30E9\u30A4\u30B9\u3067 runner \u306E\u8FD4\u4FE1\u30A4\u30D9\u30F3\u30C8\u3092\u540C\u3058 chat thread \u306B\u8FD4\u3057\u307E\u3059\u3002${issuePhrase}`.trim();
-  }
-  if (lowerText.includes("issue") || lowerText.includes("\u4F5C\u3063\u3066") || lowerText.includes("\u5B9F\u88C5")) {
-    return `\u53D7\u3051\u53D6\u308A\u307E\u3057\u305F\u3002${repository} \u306E\u8A71\u3068\u3057\u3066\u4FDD\u5B58\u3057\u307E\u3057\u305F\u3002\u3053\u3053\u304B\u3089 Issue \u5019\u88DC\u3092\u6574\u7406\u3057\u3001\u5B9F\u884C\u304C\u5FC5\u8981\u306A\u5834\u5408\u306F GO / passkey \u5883\u754C\u3092\u660E\u793A\u3057\u3066\u958B\u767A queue \u3078\u9032\u3081\u307E\u3059\u3002${issuePhrase}`.trim();
-  }
-  return `\u53D7\u3051\u53D6\u308A\u307E\u3057\u305F\u3002${repository} \u306E Butler \u4F1A\u8A71\u3068\u3057\u3066\u540C\u3058 thread \u306B\u4FDD\u5B58\u3057\u307E\u3057\u305F\u3002\u4ECA\u306F dashboard chat runtime \u306E\u521D\u671F\u63A5\u7D9A\u306A\u306E\u3067\u3001\u307E\u305A\u306F\u4F1A\u8A71\u5C65\u6B74\u3068\u8FD4\u4FE1\u3092\u540C\u3058\u753B\u9762\u3067\u78BA\u8A8D\u3067\u304D\u307E\u3059\u3002${issuePhrase}`.trim();
+function buildDashboardAppServerNotConnectedReply({ repository, relatedIssue } = {}) {
+  const repoPhrase = repository ? `\u5BFE\u8C61 repo: ${repository}` : "\u5BFE\u8C61 repo: \u672A\u6307\u5B9A";
+  const issuePhrase = relatedIssue ? `\u95A2\u9023 Issue: #${relatedIssue}` : "\u95A2\u9023 Issue: \u672A\u6307\u5B9A";
+  return [
+    "Dashboard Butler \u306E\u65E7 `codex exec` \u7D4C\u8DEF\u306F\u524A\u9664\u6E08\u307F\u3067\u3059\u3002",
+    "",
+    "\u3053\u306E\u753B\u9762\u304B\u3089\u958B\u767A\u5B9F\u884C\u30FB\u901A\u5E38\u4F1A\u8A71\u3092\u7D9A\u3051\u308B\u306B\u306F\u3001\u5225\u7D4C\u8DEF\u306E `codex app-server` \u30D6\u30EA\u30C3\u30B8\u5B9F\u88C5\u304C\u5FC5\u8981\u3067\u3059\u3002\u672A\u63A5\u7D9A\u306E\u72B6\u614B\u3067 VPS Codex CLI \u306B\u9001\u3063\u305F\u3075\u308A\u306F\u3057\u307E\u305B\u3093\u3002",
+    "",
+    `- ${repoPhrase}`,
+    `- ${issuePhrase}`,
+    "",
+    "\u73FE\u6642\u70B9\u306E\u5B9F\u884C fallback \u306F Custom GPT Butler \u3067\u3059\u3002Dashboard Butler \u306F app-server \u63A5\u7D9A PR \u304C\u5165\u308B\u307E\u3067\u672A\u5B8C\u6210\u3068\u3057\u3066\u6271\u3044\u307E\u3059\u3002"
+  ].join("\n");
 }
 async function buildDashboardRepositoryNicknameListTurn({ payload, env }) {
   const input = normalizeObject11(payload);
@@ -61061,100 +60803,6 @@ function formatDashboardRepositoryNicknameListReply(registryResult) {
     "",
     "\u9001\u4FE1\u4F8B: `\u3076\u3044 #450 \u306E\u6B8B\u308A Issue \u3068 PR \u3092\u78BA\u8A8D\u3057\u3066`"
   ].join("\n");
-}
-function shouldDispatchDashboardChatToVpsRunner(payload) {
-  const input = normalizeObject11(payload);
-  return input.dispatchToVpsRunner === true || input.vpsRunnerHandoff === true || normalizeDashboardEventText(input.executorTransport).toLowerCase() === "vps_runner";
-}
-function buildDashboardVpsRunnerHandoffPayload({ payload, prepared, env, runtimeUrl }) {
-  const input = normalizeObject11(payload);
-  const issueNumber = normalizePositiveInteger9(input.issueNumber || input.relatedIssue) || prepared.relatedIssue || normalizePositiveInteger9(env?.VTDD_DASHBOARD_CHAT_TRIAGE_ISSUE_NUMBER);
-  if (!issueNumber) {
-    return {
-      ok: false,
-      error: "dashboard_vps_runner_issue_required",
-      reason: "issueNumber or VTDD_DASHBOARD_CHAT_TRIAGE_ISSUE_NUMBER is required before dashboard can hand off a message to VPS Codex CLI",
-      issues: ["dashboard VPS runner handoff requires a GitHub Issue queue target"]
-    };
-  }
-  const codexGoal = normalizeDashboardEventText(input.codexGoal || input.goal || "dashboard_chat_triage").toLowerCase();
-  const branch = normalizeDashboardEventText(input.branch || input.targetBranch) || `codex/issue-${issueNumber}-dashboard-vps-chat`;
-  const baseRef = normalizeDashboardEventText(input.baseRef || input.base_ref) || "main";
-  const summary = normalizeDashboardEventText(input.handoffSummary || input.summary) || `Dashboard chat VPS runner handoff for Issue #${issueNumber}`;
-  return {
-    ok: true,
-    payload: {
-      actorRole: ActorRole.BUTLER,
-      executorTransport: "vps_runner",
-      issueContext: { issueNumber },
-      continuationContext: {
-        requiresHandoff: true,
-        executorTransport: "vps_runner",
-        codexGoal,
-        handoff: {
-          issueTraceable: true,
-          approvalScopeMatched: true,
-          relatedIssue: issueNumber,
-          summary,
-          ownerMessage: sanitizeDashboardChatText(input.text || input.message || input.body),
-          repositoryInput: normalizeDashboardRepositoryInput(
-            input.repositoryInput || input.repository_input || input.repository || prepared.repository
-          ),
-          dashboardThreadId: prepared.threadId,
-          dashboardRuntimeUrl: normalizeDashboardEventText(input.dashboardRuntimeUrl || runtimeUrl)
-        }
-      },
-      executionTarget: {
-        codexGoal,
-        branch,
-        baseRef
-      },
-      policyInput: {
-        actionType: "build",
-        mode: "execution",
-        repositoryInput: prepared.repository,
-        targetConfirmed: true,
-        approvalScopeMatched: true,
-        runtimeTruth: {
-          runtimeAvailable: true,
-          runtimeState: {
-            activeBranch: branch,
-            baseRef
-          }
-        },
-        consent: { grantedCategories: ["read", "propose", "execute"] },
-        approvalPhrase: "GO",
-        issueTraceable: true,
-        issueTraceability: {
-          relatedIssue: issueNumber,
-          intentRefs: [`#${issueNumber} Intent`],
-          successCriteriaRefs: [`#${issueNumber} Success Criteria`],
-          nonGoalRefs: [`#${issueNumber} Non-goals`]
-        },
-        go: true,
-        passkey: false
-      }
-    }
-  };
-}
-function buildDashboardVpsRunnerQueuedMessage({ prepared, execution }) {
-  if (!execution) {
-    return null;
-  }
-  const issuePhrase = execution.issueNumber ? `Issue #${execution.issueNumber}` : "\u5BFE\u8C61Issue";
-  const queuePhrase = execution.queueCommentUrl ? ` queue: ${execution.queueCommentUrl}` : "";
-  return normalizeDashboardChatMessage(
-    {
-      threadId: prepared.threadId,
-      role: "system",
-      repository: prepared.repository,
-      relatedIssue: execution.issueNumber || prepared.relatedIssue,
-      status: "thinking",
-      text: `VPS Codex CLI queue \u306B ${issuePhrase} \u306E bounded handoff \u3092\u6E21\u3057\u307E\u3057\u305F\u3002\u3053\u308C\u306F\u8FD4\u4FE1\u3067\u306F\u3042\u308A\u307E\u305B\u3093\u3002runner \u304B\u3089\u306E event post \u3060\u3051\u3092\u8FD4\u4FE1\u3068\u3057\u3066\u3053\u306E thread \u306B\u8868\u793A\u3057\u307E\u3059\u3002${queuePhrase}`,
-      createdAt: new Date(Date.now() + 2).toISOString()
-    },
-    { threadId: prepared.threadId }
-  );
 }
 function normalizeDashboardChatMessage(message, defaults = {}) {
   const input = normalizeObject11(message);
@@ -63129,7 +62777,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           <p>\u3053\u306E\u753B\u9762\u306F\u4F1A\u8A71\u3092\u4E3B\u5F79\u306B\u3059\u308B\u305F\u3081\u306E chat-first runtime \u3067\u3059\u3002\u7BA1\u7406\u753B\u9762\u306F\u53F3\u306E\u30B5\u30A4\u30C9\u30D0\u30FC\u3078\u9000\u907F\u3057\u307E\u3057\u305F\u3002</p>
           <ul>
             <li>\u95A2\u9023 repo/nickname: <code>${escapeDashboardHtml(dashboardTargetLabel)}</code></li>
-            <li>\u4F1A\u8A71: \u3053\u306E\u753B\u9762\u304B\u3089\u9001\u4FE1\u3059\u308B\u3068\u3001VPS Codex CLI \u304C repo \u89E3\u6C7A\u30FBIssue/PR/RAG/\u9032\u6357/\u627F\u8A8D\u5883\u754C\u3092\u4EA4\u901A\u6574\u7406\u3057\u307E\u3059</li>
+            <li>\u4F1A\u8A71: Dashboard Butler \u306E app-server \u63A5\u7D9A\u306F\u672A\u5B9F\u88C5\u3067\u3059\u3002\u65E7 VPS runner \u76F4\u9001\u7D4C\u8DEF\u306F\u4F7F\u3044\u307E\u305B\u3093</li>
           </ul>
         </article>
         <article class="bubble owner">
@@ -63138,13 +62786,13 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         <article class="bubble">
           <strong>Butler</strong>
           <p>\u305D\u306E\u65B9\u91DD\u3067\u9032\u3081\u307E\u3059\u3002\u4E2D\u592E\u306F\u30C1\u30E3\u30C3\u30C8\u3060\u3051\u3001\u72B6\u614B\u78BA\u8A8D\u30FB\u9032\u6357\u30FBRAG\u30FBworkflow\u30FBprototype cleanup \u306E\u6271\u3044\u306F\u30B5\u30A4\u30C9\u30D0\u30FC\u306E\u30E1\u30CB\u30E5\u30FC\u304B\u3089\u5FC5\u8981\u306A\u6642\u3060\u3051\u958B\u304D\u307E\u3059\u3002</p>
-          <p>\u3053\u306E dashboard \u304B\u3089\u306E\u9001\u4FE1\u306F WebSocket \u3067 VPS Codex CLI \u306B\u76F4\u63A5 push \u3057\u307E\u3059\u3002GitHub Issue \u30B3\u30E1\u30F3\u30C8 queue \u306F\u901A\u5E38\u4F1A\u8A71\u3067\u306F\u4F7F\u3044\u307E\u305B\u3093\u3002</p>
-          <span class="connection-note">\u63A5\u7D9A\u6E96\u5099\u4E2D: WebSocket \u3067 Butler \u3068 VPS Codex CLI \u306B\u63A5\u7D9A\u3057\u307E\u3059</span>
+          <p>\u3053\u306E dashboard \u304B\u3089 VPS Codex CLI \u3092 <code>codex exec</code> \u3067\u6BCE\u56DE\u8D77\u52D5\u3059\u308B\u65E7\u7D4C\u8DEF\u306F\u524A\u9664\u3057\u307E\u3057\u305F\u3002Dashboard Butler \u306F <code>codex app-server</code> \u30D6\u30EA\u30C3\u30B8\u304C\u5165\u308B\u307E\u3067\u672A\u5B8C\u6210\u3067\u3059\u3002</p>
+          <span class="connection-note">Dashboard thread \u63A5\u7D9A\u6E96\u5099\u4E2D: \u5C65\u6B74\u4FDD\u5B58\u3068\u672A\u63A5\u7D9A\u72B6\u614B\u306E\u8868\u793A\u3060\u3051\u3092\u884C\u3044\u307E\u3059</span>
         </article>
 
       </div>
 
-      <form class="composer" id="butler-chat-form" aria-label="Butler composer" data-socket-endpoint="${escapeDashboardHtml(socketOrigin)}/v2/dashboard/chat/${escapeDashboardHtml(chatThreadId)}/ws" data-thread-endpoint="${escapeDashboardHtml(origin)}/v2/dashboard/chat/${escapeDashboardHtml(chatThreadId)}" data-thread-id="${escapeDashboardHtml(chatThreadId)}" data-repository-input="${escapeDashboardHtml(repositoryInput)}" data-issue-number="${dashboardIssueNumber || ""}" data-dispatch-to-vps-runner="true" data-codex-goal="dashboard_chat_triage">
+      <form class="composer" id="butler-chat-form" aria-label="Butler composer" data-socket-endpoint="${escapeDashboardHtml(socketOrigin)}/v2/dashboard/chat/${escapeDashboardHtml(chatThreadId)}/ws" data-thread-endpoint="${escapeDashboardHtml(origin)}/v2/dashboard/chat/${escapeDashboardHtml(chatThreadId)}" data-thread-id="${escapeDashboardHtml(chatThreadId)}" data-repository-input="${escapeDashboardHtml(repositoryInput)}" data-issue-number="${dashboardIssueNumber || ""}">
         <div class="composer-box">
           <textarea id="butler-message" name="text" placeholder="Butler V2 \u306B\u30E1\u30C3\u30BB\u30FC\u30B8..." aria-label="Butler V2 \u306B\u30E1\u30C3\u30BB\u30FC\u30B8"></textarea>
           <button class="send-button" type="submit" aria-label="Butler \u306B\u9001\u4FE1">\u2191</button>
@@ -63172,7 +62820,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
 
         <div class="lane">
           <div class="lane-title"><h3>Issue \u5019\u88DC</h3><span class="pill">draft</span></div>
-          <p>\u30C8\u30C3\u30D7\u30C1\u30E3\u30C3\u30C8\u306F Custom GPT \u76F8\u5F53\u306E\u81EA\u7136\u6587\u5165\u53E3\u3067\u3059\u3002repo/nickname \u89E3\u6C7A\u3001Issue/PR/RAG/\u9032\u6357/\u627F\u8A8D\u5883\u754C\u3092 VPS Codex CLI \u306B\u4EA4\u901A\u6574\u7406\u3055\u305B\u307E\u3059\u3002</p>
+          <p>Dashboard Butler \u306E\u81EA\u7136\u6587\u5165\u53E3\u306F <code>codex app-server</code> \u7528\u306B\u4F5C\u308A\u76F4\u3057\u307E\u3059\u3002\u65E7 VPS runner \u76F4\u9001\u3067\u306F\u901A\u5E38\u4F1A\u8A71\u3092\u51E6\u7406\u3057\u307E\u305B\u3093\u3002</p>
         </div>
 
         <div class="lane">
@@ -63218,8 +62866,6 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
       const threadId = form.dataset.threadId;
       const repositoryInput = form.dataset.repositoryInput;
       const issueNumber = Number.parseInt(form.dataset.issueNumber || "", 10);
-      const dispatchToVpsRunner = form.dataset.dispatchToVpsRunner === "true";
-      const codexGoal = form.dataset.codexGoal || "dashboard_chat_triage";
       const initialMarkup = log.innerHTML;
       let chatSocket = null;
       let reconnectTimer = null;
@@ -63250,7 +62896,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           const header = document.createElement("div");
           header.className = "bubble-header";
           const strong = document.createElement("strong");
-          strong.textContent = message.role === "runner" ? "VPS Codex CLI" : message.role === "system" ? "SYSTEM" : "Butler";
+          strong.textContent = message.role === "system" ? "SYSTEM" : "Butler";
           header.appendChild(strong);
           const copyButton = document.createElement("button");
           copyButton.className = "copy-message";
@@ -63404,7 +63050,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
             window.clearTimeout(reconnectTimer);
             reconnectTimer = null;
           }
-          setStatus("WebSocket \u63A5\u7D9A\u6E08\u307F\u3002\u9001\u4FE1\u3059\u308B\u3068 VPS Codex CLI \u306B push \u3057\u307E\u3059\u3002");
+          setStatus("Dashboard thread \u63A5\u7D9A\u6E08\u307F\u3002\u9001\u4FE1\u5185\u5BB9\u306F\u4FDD\u5B58\u3055\u308C\u307E\u3059\u304C\u3001app-server \u306F\u307E\u3060\u672A\u63A5\u7D9A\u3067\u3059\u3002");
           refreshThread();
         });
         chatSocket.addEventListener("message", (event) => {
@@ -63447,20 +63093,17 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           return;
         }
         if (submitButton) submitButton.disabled = true;
-        setStatus("\u9001\u4FE1\u4E2D\u3067\u3059\u3002VPS Codex CLI \u306B push \u3057\u307E\u3059\u3002");
+        setStatus("\u9001\u4FE1\u4E2D\u3067\u3059\u3002Dashboard thread \u306B\u4FDD\u5B58\u3057\u307E\u3059\u3002");
         chatSocket.send(JSON.stringify({
           type: "owner_message",
           threadId,
           repositoryInput,
           text,
           issueNumber,
-          relatedIssue: issueNumber,
-          dispatchToVpsRunner,
-          executorTransport: dispatchToVpsRunner ? "vps_runner" : undefined,
-          codexGoal
+          relatedIssue: issueNumber
         }));
         textarea.value = "";
-        setStatus("\u9001\u4FE1\u6E08\u307F\u3002VPS Codex CLI \u306E\u8FD4\u4FE1\u3092\u5F85\u3063\u3066\u3044\u307E\u3059\u3002");
+        setStatus("\u9001\u4FE1\u6E08\u307F\u3002app-server \u672A\u63A5\u7D9A\u306E\u305F\u3081\u5B9F\u884C\u306F\u958B\u59CB\u3057\u3066\u3044\u307E\u305B\u3093\u3002");
         if (submitButton) submitButton.disabled = false;
         textarea.focus({ preventScroll: true });
         updateComposerReserve();
@@ -63650,6 +63293,5 @@ function isApiPath(pathname, suffix) {
 var worker_default = runtime_default;
 export {
   DashboardChatRoom,
-  worker_default as default,
-  selectDashboardWebSocketResponseProtocol
+  worker_default as default
 };


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #450 の Dashboard Butler から、旧 `codex exec` / VPS runner 直送チャット経路を削除します。
- Dashboard Butler は `codex app-server` ブリッジが入るまで未完成として明示し、実行 fallback は Custom GPT Butler に戻します。

## Satisfied Success Criteria

- Worker の Dashboard chat WebSocket は owner message を保存し、未接続状態を返すだけにしました。VPS runner job は作りません。
- `/v2/dashboard/vps-runner/ws` の machine WebSocket push route を削除しました。
- `scripts/run-vps-runner.mjs` から `--dashboard-ws`、dashboard WebSocket client、dashboard socket job 実行、dashboard chat triage prompt、`codex exec` per-turn 実行を削除しました。
- Remote Codex dispatch goal から `dashboard_chat_triage` を削除しました。
- Dashboard UI 文言を、旧経路削除済み / app-server 未接続 / Custom GPT fallback に合わせました。

## Unsatisfied Success Criteria

- `codex app-server` bridge 実装は未実施です。
- Dashboard thread と Codex app-server thread/session の mapping は未実施です。
- iPhone/iPad Dashboard Butler live E2E は未実施です。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #450
- Implementing Success Criteria: Dashboard Butler を期待通りの chat にする前提として、誤った `codex exec` runner 経路を削除する。
- Explicit Non-goals: app-server bridge 実装、deploy、merge、Issue close、credential/permission mutation、VPS systemd 操作。
- Expected touched files/routes/workflows: `src/worker/runtime.js`, `src/worker.js`, `scripts/run-vps-runner.mjs`, `src/core/remote-codex-executor.js`, related tests, `docs/butler/dashboard-butler-app-server-live-path.md`
- Affected Issues: Issue #450
- Affected PRs: PR #478 は app-server 方針固定済み。この PR は runtime/script 側の旧経路削除。
- Affected workflows: なし。
- Affected runtime/operator surfaces: Dashboard Butler, VPS runner script, Remote Codex dispatch validation.
- What may break if we patch narrowly: 旧経路が残ると Dashboard Butler が chat ではなく job submitter のままになる。
- Unknowns to investigate before coding: app-server daemon auth, thread mapping, event mapping, reconnect recovery。
- Validation needed: `node --check`, targeted worker / vps runner / remote codex tests。
- Stop condition: `codex exec` を Dashboard Butler fallback として再導入しようとする変更。

## File / Line Hypotheses

- file: `src/worker/runtime.js`
  - hypothesis: Dashboard chat room が runner socket を持つ限り、UI は chat ではなく job submitter として振る舞う。
  - risk if changed narrowly: 返信遅延、follow-up 断絶、repo 優先の誤分類が残る。
  - validation: worker tests assert no dashboard VPS runner route/job dispatch.
  - related Issue: Issue #450
- file: `scripts/run-vps-runner.mjs`
  - hypothesis: `--dashboard-ws` と dashboard prompt が残る限り、VPS 側で per-turn `codex exec` が再利用される。
  - risk if changed narrowly: app-server ではなく drift code が本線に戻る。
  - validation: grep で旧 symbol が消えていること、vps runner tests pass.
  - related Issue: Issue #450
- file: `src/core/remote-codex-executor.js`
  - hypothesis: `dashboard_chat_triage` goal が残る限り、Custom GPT fallback と Dashboard live path が混線する。
  - risk if changed narrowly: Issue queue 経由の dashboard reply が復活する。
  - validation: remote codex tests reject non-supported goals and pass bounded PR goals.
  - related Issue: Issue #450

## Hypothesis Retrospective

- expected: Dashboard `codex exec` / VPS runner direct chat path が runtime/script/dispatch goal から消える。
- actual: Worker route/job dispatch、VPS runner WebSocket mode、dashboard triage goal を削除した。
- mismatch: app-server bridge はまだ未実装なので、Dashboard Butler は未完成表示に留めた。
- lesson: UI polish で隠さず、間違った実行経路は先に消す必要がある。
- should become RAG candidate: true

## Verification Evidence

- Unit: `node --test test/worker.test.js`
- Unit: `node --test test/vps-runner-script.test.js test/remote-codex-executor.test.js`
- Static: `node --check src/worker/runtime.js && node --check scripts/run-vps-runner.mjs && node --check src/core/remote-codex-executor.js`
- E2E: Not run. app-server bridge 未実装のため Dashboard live E2E は未実施。
- Manual: `rg` で `--dashboard-ws`, `/dashboard/vps-runner/ws`, `DASHBOARD_CHAT_TRIAGE`, dashboard prompt/client symbols が production source から消えていることを確認。
- Evidence path/link: `docs/butler/dashboard-butler-app-server-live-path.md`

## Butler Completion Contract

- Owner goal: Dashboard Butler を Custom GPT fallback とは別経路の app-server backed live chat として完成させる。
- Butler entrypoint: Dashboard Butler PWA。現時点では旧経路削除済みで app-server 未接続。
- Action Schema exposure: Custom GPT Action Schema は fallback path として維持。Dashboard 専用 app-server bridge は未実装。
- Runtime path: Dashboard PWA -> Worker/Durable Object の保存までは残す。VPS runner / `codex exec` direct path は削除。
- Runner/runtime truth: VPS runner は bounded implementation / revision / post-merge verification 用に残す。Dashboard live chat 用には使わない。
- Authority boundary: 未変更。実行/merge/deploy/secret/permission/Issue close は既存 GO/passkey 境界。
- E2E evidence: 未実施。#450 は incomplete。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 未実施。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: app-server bridge 実装後に必要。

## Related Constitution Rules

- Butler Completion Gate
- Butler-First Operating Principle
- Drift Stop Protocol
- Evidence Discipline

## Out-of-scope but NOT implemented

- codex app-server bridge 実装
- VPS daemon / systemd 設定
- Cloudflare deploy
- Issue close

## Extra changes (if any)

PR #478 の docs 方針を「旧経路は削除済み」に更新。

<!-- VTDD metadata -->
- Issue: Issue #450
- Execution ID: local-codex-issue450-remove-dashboard-exec-path
- Goal: remove_dashboard_exec_runner_path
