### PR TITLE
#450 Dashboard Butler app-server bridge を追加

### DIFF
--- a/docs/butler/dashboard-butler-app-server-live-path.md
+++ b/docs/butler/dashboard-butler-app-server-live-path.md
@@ -80,9 +80,35 @@ Shared durable truth:
 - deploy evidence
 - dashboard thread records
 
+## Implemented bridge slice
+
+PR for this slice introduces the first separate Dashboard app-server route:
+
+- Worker route: `GET /v2/dashboard/app-server/ws`
+- Durable Object role: `app_server_bridge`
+- Dashboard -> bridge message: `app_server_turn_requested`
+- Bridge -> Dashboard messages:
+  - `app_server_status`
+  - `app_server_reply_delta`
+  - `app_server_reply`
+  - `app_server_turn_failed`
+- VPS bridge script: `scripts/run-dashboard-app-server-bridge.mjs`
+
+The bridge uses the generated `codex app-server` protocol shape:
+
+- `initialize`
+- `thread/start`
+- `thread/resume`
+- `turn/start`
+- notifications including `item/agentMessage/delta` and `turn/completed`
+
+The old Dashboard `codex exec` runner WebSocket remains deleted. If no
+Dashboard app-server bridge is connected, Dashboard Butler records the owner
+message and reports the bridge as unavailable; it does not pretend to have sent
+the turn to VPS Codex CLI.
+
 ## Non-goals for this decision
 
-- Do not implement the app-server bridge in this document.
 - Do not deploy.
 - Do not mutate credentials, permissions, repository settings, or secrets.
 - Do not close Issue #450.

--- a/scripts/run-dashboard-app-server-bridge.mjs
+++ b/scripts/run-dashboard-app-server-bridge.mjs
@@ -226,7 +226,13 @@ export class JsonLineAppServerClient {
   }
 }
 
-export async function handleDashboardTurnRequest({ request, appServer, sendDashboardEvent, cwd = process.cwd() }) {
+export async function handleDashboardTurnRequest({
+  request,
+  appServer,
+  sendDashboardEvent,
+  cwd = process.cwd(),
+  turnTimeoutMs = 10 * 60 * 1000
+}) {
   const dashboardThreadId = String(request.threadId || "");
   const text = String(request.text || "");
   if (!dashboardThreadId || !text) {
@@ -256,6 +262,23 @@ export async function handleDashboardTurnRequest({ request, appServer, sendDashb
   }
 
   let accumulatedText = "";
+  let turnSettled = false;
+  let timeoutHandle = null;
+  let resolveTurn = () => {};
+  let rejectTurn = () => {};
+  const turnCompletion = new Promise((resolve, reject) => {
+    resolveTurn = resolve;
+    rejectTurn = reject;
+    timeoutHandle = setTimeout(() => {
+      reject(new Error("codex app-server turn timed out before completion"));
+    }, turnTimeoutMs);
+  });
+  const finishTurn = (callback) => {
+    if (turnSettled) return;
+    turnSettled = true;
+    clearTimeout(timeoutHandle);
+    callback();
+  };
   const unsubscribe = appServer.onNotification((message) => {
     const event = mapAppServerNotificationToDashboardEvent(message, {
       dashboardThreadId,
@@ -271,12 +294,22 @@ export async function handleDashboardTurnRequest({ request, appServer, sendDashb
     if (event.type === "app_server_status" && event.status === "replied") {
       event.type = "app_server_reply";
       event.text = accumulatedText || event.text;
+      void sendDashboardEvent(event);
+      finishTurn(resolveTurn);
+      return;
+    }
+    if (event.type === "app_server_turn_failed") {
+      void sendDashboardEvent(event);
+      finishTurn(() => rejectTurn(new Error(event.text || "codex app-server turn failed")));
+      return;
     }
     void sendDashboardEvent(event);
   });
   try {
     await appServer.request(buildAppServerTurnStartRequest({ id: appServer.nextRequestId(), codexThreadId, text, cwd }));
+    await turnCompletion;
   } finally {
+    clearTimeout(timeoutHandle);
     unsubscribe();
   }
 }

--- a/scripts/run-dashboard-app-server-bridge.mjs
+++ b/scripts/run-dashboard-app-server-bridge.mjs
@@ -122,6 +122,26 @@ export function mapAppServerNotificationToDashboardEvent(message, context = {}) 
   return null;
 }
 
+export function extractAppServerNotificationTurnId(message) {
+  const params = message?.params && typeof message.params === "object" ? message.params : {};
+  return String(params.turnId || params.turn?.id || "");
+}
+
+export function matchesAppServerTurnNotification(message, context = {}) {
+  const params = message?.params && typeof message.params === "object" ? message.params : {};
+  const expectedThreadId = String(context.codexThreadId || "");
+  const actualThreadId = String(params.threadId || "");
+  if (expectedThreadId && actualThreadId && actualThreadId !== expectedThreadId) {
+    return false;
+  }
+  const expectedTurnId = String(context.turnId || "");
+  const actualTurnId = extractAppServerNotificationTurnId(message);
+  if (expectedTurnId && actualTurnId && actualTurnId !== expectedTurnId) {
+    return false;
+  }
+  return true;
+}
+
 export class JsonLineAppServerClient {
   constructor({ command = "codex", args = ["app-server", "--listen", "stdio://"], cwd = process.cwd() } = {}) {
     this.command = command;
@@ -262,6 +282,7 @@ export async function handleDashboardTurnRequest({
   }
 
   let accumulatedText = "";
+  let activeTurnId = "";
   let turnSettled = false;
   let timeoutHandle = null;
   let resolveTurn = () => {};
@@ -280,6 +301,13 @@ export async function handleDashboardTurnRequest({
     callback();
   };
   const unsubscribe = appServer.onNotification((message) => {
+    if (!matchesAppServerTurnNotification(message, { codexThreadId, turnId: activeTurnId })) {
+      return;
+    }
+    const notificationTurnId = extractAppServerNotificationTurnId(message);
+    if (!activeTurnId && notificationTurnId) {
+      activeTurnId = notificationTurnId;
+    }
     const event = mapAppServerNotificationToDashboardEvent(message, {
       dashboardThreadId,
       codexThreadId,
@@ -306,7 +334,14 @@ export async function handleDashboardTurnRequest({
     void sendDashboardEvent(event);
   });
   try {
-    await appServer.request(buildAppServerTurnStartRequest({ id: appServer.nextRequestId(), codexThreadId, text, cwd }));
+    const startedTurn = await appServer.request(buildAppServerTurnStartRequest({ id: appServer.nextRequestId(), codexThreadId, text, cwd }));
+    const startedTurnId = String(startedTurn?.turn?.id || "");
+    if (activeTurnId && startedTurnId && activeTurnId !== startedTurnId) {
+      throw new Error("codex app-server returned a different turn id than the active notification stream");
+    }
+    if (!activeTurnId && startedTurnId) {
+      activeTurnId = startedTurnId;
+    }
     await turnCompletion;
   } finally {
     clearTimeout(timeoutHandle);
@@ -338,13 +373,14 @@ export async function runDashboardAppServerBridge(options = parseBridgeArgs()) {
   if (!options.token) {
     throw new Error("VTDD_GATEWAY_BEARER_TOKEN or --token is required");
   }
+  if (!options.threadId) {
+    throw new Error("VTDD_DASHBOARD_THREAD_ID or --thread-id is required so the bridge joins the same dashboard thread Durable Object");
+  }
   if (typeof WebSocket !== "function") {
     throw new Error("global WebSocket is required. Run with Node.js that provides WebSocket.");
   }
   const endpoint = new URL("/v2/dashboard/app-server/ws", options.runtimeUrl);
-  if (options.threadId) {
-    endpoint.searchParams.set("threadId", options.threadId);
-  }
+  endpoint.searchParams.set("threadId", options.threadId);
   endpoint.protocol = endpoint.protocol === "https:" ? "wss:" : "ws:";
 
   const appServer = new JsonLineAppServerClient({ cwd: options.cwd });
@@ -355,6 +391,7 @@ export async function runDashboardAppServerBridge(options = parseBridgeArgs()) {
   const sendDashboardEvent = async (event) => {
     socket.send(JSON.stringify(event));
   };
+  let turnQueue = Promise.resolve();
   socket.addEventListener("message", (event) => {
     let payload;
     try {
@@ -363,21 +400,26 @@ export async function runDashboardAppServerBridge(options = parseBridgeArgs()) {
       return;
     }
     if (payload?.type === "app_server_turn_requested") {
-      void handleDashboardTurnRequest({
-        request: payload,
-        appServer,
-        sendDashboardEvent,
-        cwd: options.cwd
-      }).catch((error) => {
-        socket.send(
-          JSON.stringify({
-            type: "app_server_turn_failed",
-            schema: DEFAULT_SCHEMA,
-            threadId: payload.threadId,
-            text: error?.message || "codex app-server bridge failed"
+      turnQueue = turnQueue
+        .catch(() => {})
+        .then(() =>
+          handleDashboardTurnRequest({
+            request: payload,
+            appServer,
+            sendDashboardEvent,
+            cwd: options.cwd
           })
-        );
-      });
+        )
+        .catch((error) => {
+          socket.send(
+            JSON.stringify({
+              type: "app_server_turn_failed",
+              schema: DEFAULT_SCHEMA,
+              threadId: payload.threadId,
+              text: error?.message || "codex app-server bridge failed"
+            })
+          );
+        });
     }
   });
 }

--- a/scripts/run-dashboard-app-server-bridge.mjs
+++ b/scripts/run-dashboard-app-server-bridge.mjs
@@ -1,0 +1,357 @@
+#!/usr/bin/env node
+import { spawn } from "node:child_process";
+import process from "node:process";
+
+const DEFAULT_SCHEMA = "vtdd.dashboard.app_server_bridge.v1";
+
+export function buildAppServerInitializeRequest(id = 1) {
+  return {
+    method: "initialize",
+    id,
+    params: {
+      clientInfo: {
+        name: "vtdd-dashboard-bridge",
+        title: "VTDD Dashboard Bridge",
+        version: "0.1.0"
+      },
+      capabilities: {
+        experimentalApi: true,
+        requestAttestation: false
+      }
+    }
+  };
+}
+
+export function buildAppServerThreadStartRequest({ id, cwd = process.cwd(), developerInstructions = "" } = {}) {
+  return {
+    method: "thread/start",
+    id,
+    params: {
+      cwd,
+      approvalPolicy: "on-request",
+      developerInstructions:
+        developerInstructions ||
+        [
+          "You are backing VTDD Dashboard Butler.",
+          "Treat ordinary messages as conversation unless the owner asks for repository, Issue, PR, deploy, credential, or permission work.",
+          "High-risk work requires explicit GO or passkey approval through VTDD runtime boundaries.",
+          "Reply in Japanese by default."
+        ].join("\n"),
+      threadSource: "app_server",
+      experimentalRawEvents: false,
+      persistExtendedHistory: false
+    }
+  };
+}
+
+export function buildAppServerThreadResumeRequest({ id, codexThreadId, cwd = process.cwd() } = {}) {
+  return {
+    method: "thread/resume",
+    id,
+    params: {
+      threadId: codexThreadId,
+      cwd,
+      approvalPolicy: "on-request",
+      excludeTurns: true,
+      persistExtendedHistory: false
+    }
+  };
+}
+
+export function buildAppServerTurnStartRequest({ id, codexThreadId, text, cwd = process.cwd() } = {}) {
+  return {
+    method: "turn/start",
+    id,
+    params: {
+      threadId: codexThreadId,
+      input: [
+        {
+          type: "text",
+          text,
+          text_elements: []
+        }
+      ],
+      cwd,
+      approvalPolicy: "on-request"
+    }
+  };
+}
+
+export function mapAppServerNotificationToDashboardEvent(message, context = {}) {
+  const method = String(message?.method || "");
+  const params = message?.params && typeof message.params === "object" ? message.params : {};
+  if (method === "item/agentMessage/delta" && params.delta) {
+    return {
+      type: "app_server_reply_delta",
+      schema: DEFAULT_SCHEMA,
+      threadId: context.dashboardThreadId,
+      codexThreadId: params.threadId || context.codexThreadId || null,
+      turnId: params.turnId || null,
+      text: String(params.delta)
+    };
+  }
+  if (method === "turn/started") {
+    return {
+      type: "app_server_status",
+      schema: DEFAULT_SCHEMA,
+      threadId: context.dashboardThreadId,
+      codexThreadId: params.threadId || context.codexThreadId || null,
+      status: "thinking",
+      text: "codex app-server が応答を生成しています。"
+    };
+  }
+  if (method === "turn/completed") {
+    return {
+      type: "app_server_status",
+      schema: DEFAULT_SCHEMA,
+      threadId: context.dashboardThreadId,
+      codexThreadId: params.threadId || context.codexThreadId || null,
+      status: "replied",
+      text: context.accumulatedText || "codex app-server の turn が完了しました。"
+    };
+  }
+  if (method === "error") {
+    return {
+      type: "app_server_turn_failed",
+      schema: DEFAULT_SCHEMA,
+      threadId: context.dashboardThreadId,
+      codexThreadId: context.codexThreadId || null,
+      text: params.message || params.reason || "codex app-server returned an error"
+    };
+  }
+  return null;
+}
+
+export class JsonLineAppServerClient {
+  constructor({ command = "codex", args = ["app-server", "--listen", "stdio://"], cwd = process.cwd() } = {}) {
+    this.command = command;
+    this.args = args;
+    this.cwd = cwd;
+    this.nextId = 1;
+    this.pending = new Map();
+    this.notificationHandlers = new Set();
+    this.buffer = "";
+    this.child = null;
+  }
+
+  start() {
+    if (this.child) return;
+    this.child = spawn(this.command, this.args, {
+      cwd: this.cwd,
+      stdio: ["pipe", "pipe", "inherit"]
+    });
+    this.child.stdout.setEncoding("utf8");
+    this.child.stdout.on("data", (chunk) => this.handleChunk(chunk));
+    this.child.on("exit", (code, signal) => {
+      const error = new Error(`codex app-server exited: code=${code ?? "null"} signal=${signal ?? "null"}`);
+      for (const { reject } of this.pending.values()) {
+        reject(error);
+      }
+      this.pending.clear();
+      this.child = null;
+    });
+  }
+
+  async initialize() {
+    this.start();
+    await this.request(buildAppServerInitializeRequest(this.nextRequestId()));
+    this.notify({ method: "initialized" });
+  }
+
+  nextRequestId() {
+    const id = this.nextId;
+    this.nextId += 1;
+    return id;
+  }
+
+  request(message) {
+    this.start();
+    const id = message.id ?? this.nextRequestId();
+    const request = { ...message, id };
+    return new Promise((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
+      this.write(request);
+    });
+  }
+
+  notify(message) {
+    this.start();
+    this.write(message);
+  }
+
+  write(message) {
+    this.child.stdin.write(`${JSON.stringify(message)}\n`);
+  }
+
+  onNotification(handler) {
+    this.notificationHandlers.add(handler);
+    return () => this.notificationHandlers.delete(handler);
+  }
+
+  handleChunk(chunk) {
+    this.buffer += chunk;
+    for (;;) {
+      const newline = this.buffer.indexOf("\n");
+      if (newline < 0) break;
+      const line = this.buffer.slice(0, newline).trim();
+      this.buffer = this.buffer.slice(newline + 1);
+      if (!line) continue;
+      let message;
+      try {
+        message = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      if (message.id && this.pending.has(message.id)) {
+        const pending = this.pending.get(message.id);
+        this.pending.delete(message.id);
+        if (message.error) {
+          pending.reject(new Error(message.error.message || JSON.stringify(message.error)));
+        } else {
+          pending.resolve(message.result);
+        }
+        continue;
+      }
+      for (const handler of this.notificationHandlers) {
+        handler(message);
+      }
+    }
+  }
+
+  stop() {
+    if (this.child) {
+      this.child.kill();
+      this.child = null;
+    }
+  }
+}
+
+export async function handleDashboardTurnRequest({ request, appServer, sendDashboardEvent, cwd = process.cwd() }) {
+  const dashboardThreadId = String(request.threadId || "");
+  const text = String(request.text || "");
+  if (!dashboardThreadId || !text) {
+    await sendDashboardEvent({
+      type: "app_server_turn_failed",
+      schema: DEFAULT_SCHEMA,
+      threadId: dashboardThreadId,
+      text: "dashboard threadId and text are required"
+    });
+    return;
+  }
+
+  let codexThreadId = request.codexThreadId || null;
+  if (codexThreadId) {
+    await appServer.request(buildAppServerThreadResumeRequest({ id: appServer.nextRequestId(), codexThreadId, cwd }));
+  } else {
+    const started = await appServer.request(buildAppServerThreadStartRequest({ id: appServer.nextRequestId(), cwd }));
+    codexThreadId = started?.thread?.id || null;
+    await sendDashboardEvent({
+      type: "app_server_status",
+      schema: DEFAULT_SCHEMA,
+      threadId: dashboardThreadId,
+      codexThreadId,
+      status: "thinking",
+      text: "codex app-server thread を開始しました。"
+    });
+  }
+
+  let accumulatedText = "";
+  const unsubscribe = appServer.onNotification((message) => {
+    const event = mapAppServerNotificationToDashboardEvent(message, {
+      dashboardThreadId,
+      codexThreadId,
+      accumulatedText
+    });
+    if (!event) return;
+    if (event.type === "app_server_reply_delta") {
+      accumulatedText += event.text;
+      void sendDashboardEvent(event);
+      return;
+    }
+    if (event.type === "app_server_status" && event.status === "replied") {
+      event.type = "app_server_reply";
+      event.text = accumulatedText || event.text;
+    }
+    void sendDashboardEvent(event);
+  });
+  try {
+    await appServer.request(buildAppServerTurnStartRequest({ id: appServer.nextRequestId(), codexThreadId, text, cwd }));
+  } finally {
+    unsubscribe();
+  }
+}
+
+export function parseBridgeArgs(argv = process.argv.slice(2), env = process.env) {
+  const options = {
+    runtimeUrl: env.VTDD_RUNTIME_URL || "",
+    token: env.VTDD_GATEWAY_BEARER_TOKEN || env.MVP_GATEWAY_BEARER_TOKEN || "",
+    threadId: env.VTDD_DASHBOARD_THREAD_ID || "",
+    cwd: env.VTDD_DASHBOARD_CODEX_CWD || process.cwd()
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--runtime-url") options.runtimeUrl = argv[++index] || "";
+    if (arg === "--token") options.token = argv[++index] || "";
+    if (arg === "--thread-id") options.threadId = argv[++index] || "";
+    if (arg === "--cwd") options.cwd = argv[++index] || "";
+  }
+  return options;
+}
+
+export async function runDashboardAppServerBridge(options = parseBridgeArgs()) {
+  if (!options.runtimeUrl) {
+    throw new Error("VTDD_RUNTIME_URL or --runtime-url is required");
+  }
+  if (!options.token) {
+    throw new Error("VTDD_GATEWAY_BEARER_TOKEN or --token is required");
+  }
+  if (typeof WebSocket !== "function") {
+    throw new Error("global WebSocket is required. Run with Node.js that provides WebSocket.");
+  }
+  const endpoint = new URL("/v2/dashboard/app-server/ws", options.runtimeUrl);
+  if (options.threadId) {
+    endpoint.searchParams.set("threadId", options.threadId);
+  }
+  endpoint.protocol = endpoint.protocol === "https:" ? "wss:" : "ws:";
+
+  const appServer = new JsonLineAppServerClient({ cwd: options.cwd });
+  await appServer.initialize();
+  const bearerProtocol = `vtdd-bearer.${Buffer.from(options.token, "utf8").toString("base64url")}`;
+  const socket = new WebSocket(endpoint, ["vtdd-dashboard-bridge", bearerProtocol]);
+
+  const sendDashboardEvent = async (event) => {
+    socket.send(JSON.stringify(event));
+  };
+  socket.addEventListener("message", (event) => {
+    let payload;
+    try {
+      payload = JSON.parse(String(event.data || ""));
+    } catch {
+      return;
+    }
+    if (payload?.type === "app_server_turn_requested") {
+      void handleDashboardTurnRequest({
+        request: payload,
+        appServer,
+        sendDashboardEvent,
+        cwd: options.cwd
+      }).catch((error) => {
+        socket.send(
+          JSON.stringify({
+            type: "app_server_turn_failed",
+            schema: DEFAULT_SCHEMA,
+            threadId: payload.threadId,
+            text: error?.message || "codex app-server bridge failed"
+          })
+        );
+      });
+    }
+  });
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  runDashboardAppServerBridge().catch((error) => {
+    console.error(error?.stack || error?.message || String(error));
+    process.exitCode = 1;
+  });
+}

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -206,7 +206,7 @@ export class DashboardChatRoom {
       await this.acceptOwnerMessage({ socket, threadId, payload });
       return;
     }
-    if (socketAttachment.role === "app_server_bridge" || String(payload?.type || "").startsWith("app_server_")) {
+    if (socketAttachment.role === "app_server_bridge") {
       await this.acceptAppServerBridgeMessage({ socket, attachment: socketAttachment, payload });
     }
   }

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -314,9 +314,7 @@ export class DashboardChatRoom {
       },
       authority: buildDashboardAppServerAuthorityHint({ repository, relatedIssue, text })
     };
-    for (const bridgeSocket of bridgeSockets) {
-      this.sendSocket(bridgeSocket, turnRequest);
-    }
+    this.sendSocket(bridgeSockets[0], turnRequest);
   }
 
   async acceptAppServerBridgeMessage({ socket, attachment, payload }) {
@@ -328,6 +326,15 @@ export class DashboardChatRoom {
         type: "error",
         ok: false,
         reason: normalized.reason
+      });
+      return;
+    }
+    const attachmentThreadId = normalizeDashboardThreadId(attachment?.threadId);
+    if (attachmentThreadId && normalized.threadId !== attachmentThreadId) {
+      this.sendSocket(socket, {
+        type: "error",
+        ok: false,
+        reason: "bridge threadId does not match the connected dashboard thread"
       });
       return;
     }

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -120,7 +120,13 @@ export class DashboardChatRoom {
       });
     }
 
-    const threadId = extractDashboardChatSocketThreadId(url.pathname);
+    const appServerBridgeSocket = isDashboardAppServerBridgeSocketPath(url.pathname);
+    const threadId = appServerBridgeSocket
+      ? normalizeDashboardThreadId(url.searchParams.get("threadId") || url.searchParams.get("thread_id"))
+      : extractDashboardChatSocketThreadId(url.pathname);
+    if (appServerBridgeSocket) {
+      return this.acceptSocket({ request, role: "app_server_bridge", threadId });
+    }
     if (!threadId) {
       return json(422, {
         ok: false,
@@ -129,9 +135,13 @@ export class DashboardChatRoom {
       });
     }
 
+    return this.acceptSocket({ request, role: "dashboard", threadId });
+  }
+
+  async acceptSocket({ request, role, threadId }) {
     const pair = new WebSocketPair();
     const [client, server] = Object.values(pair);
-    const attachment = { role: "dashboard", threadId };
+    const attachment = { role, threadId };
     if (typeof this.ctx?.acceptWebSocket === "function") {
       server.serializeAttachment(attachment);
       this.ctx.acceptWebSocket(server);
@@ -142,10 +152,24 @@ export class DashboardChatRoom {
       server.addEventListener("error", () => this.sessions.delete(server));
       server.addEventListener("message", (event) => this.handleSocketMessage(server, event?.data, attachment));
     }
-    await this.sendThread(server, threadId);
+    if (role === "app_server_bridge") {
+      this.sendSocket(server, {
+        type: "app_server_bridge_connected",
+        ok: true,
+        threadId: threadId || null,
+        schema: "vtdd.dashboard.app_server_bridge.v1"
+      });
+    } else {
+      await this.sendThread(server, threadId);
+    }
 
+    const headers =
+      role === "app_server_bridge" && normalizeDashboardEventText(request.headers.get("sec-websocket-protocol")).includes("vtdd-dashboard-bridge")
+        ? { "sec-websocket-protocol": "vtdd-dashboard-bridge" }
+        : {};
     return new Response(null, {
       status: 101,
+      headers,
       webSocket: client
     });
   }
@@ -180,6 +204,10 @@ export class DashboardChatRoom {
     }
     if (payload?.type === "owner_message") {
       await this.acceptOwnerMessage({ socket, threadId, payload });
+      return;
+    }
+    if (socketAttachment.role === "app_server_bridge" || String(payload?.type || "").startsWith("app_server_")) {
+      await this.acceptAppServerBridgeMessage({ socket, attachment: socketAttachment, payload });
     }
   }
 
@@ -235,20 +263,89 @@ export class DashboardChatRoom {
       },
       { threadId }
     );
-    const butlerMessage = normalizeDashboardChatMessage(
+    const bridgeSockets = this.connectedAppServerBridgeSockets(threadId);
+    if (bridgeSockets.length === 0) {
+      const butlerMessage = normalizeDashboardChatMessage(
+        {
+          threadId,
+          role: "butler",
+          repository,
+          relatedIssue,
+          status: "blocked",
+          text: buildDashboardAppServerNotConnectedReply({ repository, relatedIssue }),
+          createdAt: new Date(Date.parse(now) + 1).toISOString()
+        },
+        { threadId }
+      );
+      const messages = store ? await store.appendMany(threadId, [ownerMessage, butlerMessage]) : [ownerMessage, butlerMessage].filter(Boolean);
+      await this.broadcastThread({ threadId, messages });
+      return;
+    }
+
+    const pendingMessage = normalizeDashboardChatMessage(
       {
         threadId,
         role: "butler",
         repository,
         relatedIssue,
-        status: "blocked",
-        text: buildDashboardAppServerNotConnectedReply({ repository, relatedIssue }),
+        status: "thinking",
+        text: "codex app-server に送信しました。返信を待っています。",
         createdAt: new Date(Date.parse(now) + 1).toISOString()
       },
       { threadId }
     );
-    const messages = store ? await store.appendMany(threadId, [ownerMessage, butlerMessage]) : [ownerMessage, butlerMessage].filter(Boolean);
+    const messages = store ? await store.appendMany(threadId, [ownerMessage, pendingMessage]) : [ownerMessage, pendingMessage].filter(Boolean);
     await this.broadcastThread({ threadId, messages });
+    const mapping = await this.readAppServerThreadMapping(threadId);
+    const turnRequest = {
+      type: "app_server_turn_requested",
+      schema: "vtdd.dashboard.app_server_bridge.v1",
+      requestId: createDashboardRequestId("app-server-turn"),
+      threadId,
+      codexThreadId: mapping.codexThreadId || null,
+      repository: repository || null,
+      relatedIssue: relatedIssue || null,
+      text,
+      messageId: ownerMessage.messageId,
+      createdAt: now,
+      appServer: {
+        startThreadMethod: mapping.codexThreadId ? "thread/resume" : "thread/start",
+        turnMethod: "turn/start"
+      },
+      authority: buildDashboardAppServerAuthorityHint({ repository, relatedIssue, text })
+    };
+    for (const bridgeSocket of bridgeSockets) {
+      this.sendSocket(bridgeSocket, turnRequest);
+    }
+  }
+
+  async acceptAppServerBridgeMessage({ socket, attachment, payload }) {
+    const normalized = normalizeDashboardAppServerBridgeEvent(payload, {
+      fallbackThreadId: attachment?.threadId
+    });
+    if (!normalized.ok) {
+      this.sendSocket(socket, {
+        type: "error",
+        ok: false,
+        reason: normalized.reason
+      });
+      return;
+    }
+    if (normalized.codexThreadId) {
+      await this.writeAppServerThreadMapping(normalized.threadId, {
+        codexThreadId: normalized.codexThreadId,
+        updatedAt: normalized.createdAt
+      });
+    }
+    if (normalized.messages.length === 0) {
+      await this.broadcastThread({ threadId: normalized.threadId });
+      return;
+    }
+    const store = resolveDashboardChatStore(this.env);
+    const messages = store
+      ? await store.appendMany(normalized.threadId, normalized.messages)
+      : normalized.messages;
+    await this.broadcastThread({ threadId: normalized.threadId, messages });
   }
 
   async broadcastThread({ threadId, messages = null }) {
@@ -261,7 +358,12 @@ export class DashboardChatRoom {
     });
     for (const socket of this.connectedSockets()) {
       const attachment = this.getSocketAttachment(socket);
-      if (attachment.role !== "vps_runner" && (!attachment.threadId || attachment.threadId === threadId) && isSocketOpen(socket)) {
+      if (
+        attachment.role !== "vps_runner" &&
+        attachment.role !== "app_server_bridge" &&
+        (!attachment.threadId || attachment.threadId === threadId) &&
+        isSocketOpen(socket)
+      ) {
         socket.send(payload);
       }
     }
@@ -311,6 +413,54 @@ export class DashboardChatRoom {
       return socket.deserializeAttachment() || {};
     }
     return this.sessions.get(socket) || {};
+  }
+
+  connectedAppServerBridgeSockets(threadId) {
+    return this.connectedSockets().filter((socket) => {
+      const attachment = this.getSocketAttachment(socket);
+      return (
+        attachment.role === "app_server_bridge" &&
+        (!attachment.threadId || attachment.threadId === threadId) &&
+        isSocketOpen(socket)
+      );
+    });
+  }
+
+  sendSocket(socket, payload) {
+    if (!isSocketOpen(socket)) {
+      return false;
+    }
+    socket.send(JSON.stringify(payload));
+    return true;
+  }
+
+  async readAppServerThreadMapping(threadId) {
+    const key = `app_server_thread:${normalizeDashboardThreadId(threadId)}`;
+    if (!key || typeof this.ctx?.storage?.get !== "function") {
+      return {};
+    }
+    try {
+      const record = await this.ctx.storage.get(key);
+      return normalizeObject(record);
+    } catch {
+      return {};
+    }
+  }
+
+  async writeAppServerThreadMapping(threadId, mapping) {
+    const normalizedThreadId = normalizeDashboardThreadId(threadId);
+    if (!normalizedThreadId || typeof this.ctx?.storage?.put !== "function") {
+      return false;
+    }
+    const codexThreadId = normalizeDashboardEventText(mapping?.codexThreadId || mapping?.codex_thread_id);
+    if (!codexThreadId) {
+      return false;
+    }
+    await this.ctx.storage.put(`app_server_thread:${normalizedThreadId}`, {
+      codexThreadId,
+      updatedAt: normalizeIsoTimestamp(mapping?.updatedAt) || new Date().toISOString()
+    });
+    return true;
   }
 }
 const CLOUDFLARE_ACCESS_JWKS_CACHE_TTL_MS = 5 * 60 * 1000;
@@ -434,6 +584,10 @@ export default {
 
     if (request.method === "GET" && isDashboardChatSocketApiPath(url.pathname)) {
       return handleDashboardChatSocketRequest(request, url, env);
+    }
+
+    if (request.method === "GET" && isDashboardAppServerBridgeSocketPath(url.pathname)) {
+      return handleDashboardAppServerBridgeSocketRequest(request, url, env);
     }
 
     if (request.method === "GET" && isApiPath(url.pathname, "/dashboard/chat/search")) {
@@ -3519,6 +3673,59 @@ async function handleDashboardChatSocketRequest(request, url, env) {
   return room.fetch(request);
 }
 
+async function handleDashboardAppServerBridgeSocketRequest(request, url, env) {
+  const auth = authorizeDashboardAppServerBridgeRequest({
+    request,
+    env,
+    apiSuffix: "/dashboard/app-server/ws"
+  });
+  if (!auth.ok) {
+    return json(auth.status, {
+      ok: false,
+      error: "unauthorized",
+      reason: auth.reason
+    });
+  }
+
+  const threadId = normalizeDashboardThreadId(url.searchParams.get("threadId") || url.searchParams.get("thread_id"));
+  const room = resolveDashboardChatRoomStub(env, threadId || "dashboard-app-server-bridge");
+  if (!room) {
+    return json(503, {
+      ok: false,
+      error: "dashboard_chat_room_unavailable",
+      reason: "DASHBOARD_CHAT_ROOMS Durable Object binding is not configured"
+    });
+  }
+
+  if (request.headers.get("upgrade")?.toLowerCase() !== "websocket") {
+    return json(426, {
+      ok: false,
+      error: "websocket_upgrade_required",
+      reason: "dashboard app-server bridge requires a WebSocket upgrade"
+    });
+  }
+  return room.fetch(request);
+}
+
+function authorizeDashboardAppServerBridgeRequest({ request, env, apiSuffix }) {
+  const direct = authorizeGatewayRequest({ request, env, apiSuffix });
+  if (direct.ok || normalizeText(request.headers.get("authorization"))) {
+    return direct;
+  }
+  const bearerToken = normalizeText(env?.VTDD_GATEWAY_BEARER_TOKEN ?? env?.MVP_GATEWAY_BEARER_TOKEN);
+  const protocolToken = extractDashboardBridgeBearerProtocol(request.headers.get("sec-websocket-protocol"));
+  if (bearerToken && protocolToken) {
+    return protocolToken === bearerToken
+      ? { ok: true }
+      : {
+          ok: false,
+          status: 403,
+          reason: `provided websocket bearer protocol token is invalid for /${CANONICAL_API_PREFIX.replace(/^\//, "")}${apiSuffix}`
+        };
+  }
+  return direct;
+}
+
 async function handleDashboardChatThreadRequest(request, url, env) {
   const auth = await authorizeDashboardRequest({
     request,
@@ -5308,6 +5515,103 @@ function shouldUseDashboardThreadRepositoryContext(value) {
   );
 }
 
+function createDashboardRequestId(prefix) {
+  const normalizedPrefix = normalizeDashboardEventText(prefix) || "dashboard";
+  if (typeof globalThis.crypto?.randomUUID === "function") {
+    return `${normalizedPrefix}:${globalThis.crypto.randomUUID()}`;
+  }
+  return `${normalizedPrefix}:${Date.now().toString(36)}`;
+}
+
+function buildDashboardAppServerAuthorityHint({ repository, relatedIssue, text }) {
+  const needsRepositoryContext = Boolean(repository || relatedIssue || shouldUseDashboardThreadRepositoryContext(text));
+  return {
+    ordinaryConversationAllowed: true,
+    repositoryRequired: false,
+    repository: repository || null,
+    relatedIssue: relatedIssue || null,
+    escalation:
+      needsRepositoryContext
+        ? "Repository / Issue context may be used, but high-risk actions still require explicit GO or passkey approval."
+        : "Treat as ordinary conversation unless the owner asks for repository, Issue, PR, deploy, credential, or permission work.",
+    highRiskActionsRequire: ["GO", "passkey_approval"]
+  };
+}
+
+function normalizeDashboardAppServerBridgeEvent(payload, { fallbackThreadId = "" } = {}) {
+  const input = normalizeObject(payload);
+  const threadId = normalizeDashboardThreadId(input.threadId || input.thread_id || fallbackThreadId);
+  if (!threadId) {
+    return {
+      ok: false,
+      reason: "threadId is required for app-server bridge events"
+    };
+  }
+  const eventType = normalizeDashboardEventText(input.type).toLowerCase();
+  const status = normalizeDashboardEventText(input.status).toLowerCase();
+  const codexThreadId = normalizeDashboardEventText(input.codexThreadId || input.codex_thread_id);
+  const text = sanitizeDashboardChatText(input.text || input.message || input.delta || input.finalText || input.final_text);
+  const repository = normalizeCanonicalRepositoryInput(input.repository);
+  const relatedIssue = normalizePositiveInteger(input.relatedIssue || input.issueNumber);
+  const createdAt = normalizeIsoTimestamp(input.createdAt) || new Date().toISOString();
+  const messages = [];
+  if (eventType === "app_server_reply_delta" || eventType === "app_server_reply") {
+    if (text) {
+      messages.push(
+        normalizeDashboardChatMessage(
+          {
+            threadId,
+            role: "butler",
+            repository,
+            relatedIssue,
+            status: eventType === "app_server_reply_delta" ? "thinking" : "replied",
+            text,
+            createdAt
+          },
+          { threadId }
+        )
+      );
+    }
+  } else if (eventType === "app_server_turn_failed" || status === "failed") {
+    messages.push(
+      normalizeDashboardChatMessage(
+        {
+          threadId,
+          role: "system",
+          repository,
+          relatedIssue,
+          status: "failed",
+          text: text || "codex app-server bridge failed before returning a reply.",
+          createdAt
+        },
+        { threadId }
+      )
+    );
+  } else if (eventType === "app_server_status") {
+    messages.push(
+      normalizeDashboardChatMessage(
+        {
+          threadId,
+          role: "system",
+          repository,
+          relatedIssue,
+          status: status === "replied" ? "replied" : "thinking",
+          text: text || "codex app-server is working.",
+          createdAt
+        },
+        { threadId }
+      )
+    );
+  }
+  return {
+    ok: true,
+    threadId,
+    codexThreadId,
+    createdAt,
+    messages: messages.filter(Boolean)
+  };
+}
+
 async function notifyDashboardChatRoom({ env, threadId, messages }) {
   const room = resolveDashboardChatRoomStub(env, threadId);
   if (!room || typeof room.fetch !== "function") {
@@ -5967,6 +6271,28 @@ function isDashboardChatSocketApiPath(pathname) {
     pathname.startsWith(`${CANONICAL_API_PREFIX}/dashboard/chat/`) ||
     pathname.startsWith(`${LEGACY_API_PREFIX}/dashboard/chat/`)
   ) && pathname.endsWith("/ws");
+}
+
+function isDashboardAppServerBridgeSocketPath(pathname) {
+  return pathname === `${CANONICAL_API_PREFIX}/dashboard/app-server/ws` || pathname === `${LEGACY_API_PREFIX}/dashboard/app-server/ws`;
+}
+
+function extractDashboardBridgeBearerProtocol(value) {
+  const protocols = normalizeText(value)
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+  const encoded = protocols.find((item) => item.startsWith("vtdd-bearer."))?.slice("vtdd-bearer.".length);
+  if (!encoded) {
+    return "";
+  }
+  try {
+    const base64 = encoded.replace(/-/g, "+").replace(/_/g, "/");
+    const padded = `${base64}${"=".repeat((4 - (base64.length % 4)) % 4)}`;
+    return normalizeText(atob(padded));
+  } catch {
+    return "";
+  }
 }
 
 function isDashboardPagePath(pathname) {
@@ -8045,7 +8371,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           <p>この画面は会話を主役にするための chat-first runtime です。管理画面は右のサイドバーへ退避しました。</p>
           <ul>
             <li>関連 repo/nickname: <code>${escapeDashboardHtml(dashboardTargetLabel)}</code></li>
-            <li>会話: Dashboard Butler の app-server 接続は未実装です。旧 VPS runner 直送経路は使いません</li>
+            <li>会話: Dashboard Butler は app-server bridge 経路を使います。旧 VPS runner 直送経路は使いません</li>
           </ul>
         </article>
         <article class="bubble owner">
@@ -8054,8 +8380,8 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         <article class="bubble">
           <strong>Butler</strong>
           <p>その方針で進めます。中央はチャットだけ、状態確認・進捗・RAG・workflow・prototype cleanup の扱いはサイドバーのメニューから必要な時だけ開きます。</p>
-          <p>この dashboard から VPS Codex CLI を <code>codex exec</code> で毎回起動する旧経路は削除しました。Dashboard Butler は <code>codex app-server</code> ブリッジが入るまで未完成です。</p>
-          <span class="connection-note">Dashboard thread 接続準備中: 履歴保存と未接続状態の表示だけを行います</span>
+          <p>この dashboard から VPS Codex CLI を <code>codex exec</code> で毎回起動する旧経路は削除しました。Dashboard Butler は <code>codex app-server</code> bridge が常駐している時だけ live Codex thread に渡します。</p>
+          <span class="connection-note">Dashboard thread 接続準備中: bridge が未接続なら Custom GPT Butler が fallback です</span>
         </article>
 
       </div>
@@ -8318,7 +8644,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
             window.clearTimeout(reconnectTimer);
             reconnectTimer = null;
           }
-          setStatus("Dashboard thread 接続済み。送信内容は保存されますが、app-server はまだ未接続です。");
+          setStatus("Dashboard thread 接続済み。app-server bridge が接続中なら live Codex thread に送ります。");
           refreshThread();
         });
         chatSocket.addEventListener("message", (event) => {
@@ -8371,7 +8697,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           relatedIssue: issueNumber
         }));
         textarea.value = "";
-        setStatus("送信済み。app-server 未接続のため実行は開始していません。");
+        setStatus("送信済み。app-server bridge の返信を待っています。");
         if (submitButton) submitButton.disabled = false;
         textarea.focus({ preventScroll: true });
         updateComposerReserve();

--- a/test/dashboard-app-server-bridge.test.js
+++ b/test/dashboard-app-server-bridge.test.js
@@ -1,0 +1,156 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  buildAppServerInitializeRequest,
+  buildAppServerThreadResumeRequest,
+  buildAppServerThreadStartRequest,
+  buildAppServerTurnStartRequest,
+  handleDashboardTurnRequest,
+  mapAppServerNotificationToDashboardEvent,
+  parseBridgeArgs
+} from "../scripts/run-dashboard-app-server-bridge.mjs";
+
+test("dashboard app-server bridge builds initialize and thread requests from Codex app-server protocol", () => {
+  assert.deepEqual(buildAppServerInitializeRequest(10), {
+    method: "initialize",
+    id: 10,
+    params: {
+      clientInfo: {
+        name: "vtdd-dashboard-bridge",
+        title: "VTDD Dashboard Bridge",
+        version: "0.1.0"
+      },
+      capabilities: {
+        experimentalApi: true,
+        requestAttestation: false
+      }
+    }
+  });
+
+  const start = buildAppServerThreadStartRequest({ id: 11, cwd: "/repo" });
+  assert.equal(start.method, "thread/start");
+  assert.equal(start.params.cwd, "/repo");
+  assert.equal(start.params.approvalPolicy, "on-request");
+  assert.equal(start.params.experimentalRawEvents, false);
+  assert.equal(start.params.persistExtendedHistory, false);
+
+  const resume = buildAppServerThreadResumeRequest({ id: 12, codexThreadId: "codex-thread-1", cwd: "/repo" });
+  assert.equal(resume.method, "thread/resume");
+  assert.equal(resume.params.threadId, "codex-thread-1");
+  assert.equal(resume.params.excludeTurns, true);
+
+  const turn = buildAppServerTurnStartRequest({
+    id: 13,
+    codexThreadId: "codex-thread-1",
+    text: "今日は何日？",
+    cwd: "/repo"
+  });
+  assert.equal(turn.method, "turn/start");
+  assert.equal(turn.params.threadId, "codex-thread-1");
+  assert.deepEqual(turn.params.input, [{ type: "text", text: "今日は何日？", text_elements: [] }]);
+});
+
+test("dashboard app-server bridge maps Codex app-server notifications to dashboard events", () => {
+  const delta = mapAppServerNotificationToDashboardEvent(
+    {
+      method: "item/agentMessage/delta",
+      params: {
+        threadId: "codex-thread-1",
+        turnId: "turn-1",
+        delta: "返答"
+      }
+    },
+    { dashboardThreadId: "dashboard-main", codexThreadId: "codex-thread-1" }
+  );
+  assert.equal(delta.type, "app_server_reply_delta");
+  assert.equal(delta.threadId, "dashboard-main");
+  assert.equal(delta.codexThreadId, "codex-thread-1");
+  assert.equal(delta.text, "返答");
+
+  const completed = mapAppServerNotificationToDashboardEvent(
+    { method: "turn/completed", params: { threadId: "codex-thread-1" } },
+    { dashboardThreadId: "dashboard-main", codexThreadId: "codex-thread-1", accumulatedText: "最終返答" }
+  );
+  assert.equal(completed.type, "app_server_status");
+  assert.equal(completed.status, "replied");
+  assert.equal(completed.text, "最終返答");
+});
+
+test("dashboard app-server bridge handles a fresh dashboard turn through thread/start and turn/start", async () => {
+  const requests = [];
+  const events = [];
+  const handlers = new Set();
+  let nextId = 1;
+  const appServer = {
+    nextRequestId() {
+      const id = nextId;
+      nextId += 1;
+      return id;
+    },
+    onNotification(handler) {
+      handlers.add(handler);
+      return () => handlers.delete(handler);
+    },
+    async request(message) {
+      requests.push(message);
+      if (message.method === "thread/start") {
+        return { thread: { id: "codex-thread-1" } };
+      }
+      if (message.method === "turn/start") {
+        for (const handler of handlers) {
+          handler({
+            method: "item/agentMessage/delta",
+            params: {
+              threadId: "codex-thread-1",
+              turnId: "turn-1",
+              delta: "今日は2026年5月22日です。"
+            }
+          });
+          handler({
+            method: "turn/completed",
+            params: {
+              threadId: "codex-thread-1",
+              turn: { id: "turn-1", status: "completed" }
+            }
+          });
+        }
+        return { turn: { id: "turn-1" } };
+      }
+      throw new Error(`unexpected method ${message.method}`);
+    }
+  };
+
+  await handleDashboardTurnRequest({
+    request: {
+      threadId: "dashboard-main",
+      codexThreadId: null,
+      text: "今日は何日？"
+    },
+    appServer,
+    sendDashboardEvent: async (event) => events.push(event),
+    cwd: "/repo"
+  });
+
+  assert.deepEqual(
+    requests.map((request) => request.method),
+    ["thread/start", "turn/start"]
+  );
+  assert.equal(requests[1].params.threadId, "codex-thread-1");
+  assert.equal(events[0].type, "app_server_status");
+  assert.equal(events[0].codexThreadId, "codex-thread-1");
+  assert.equal(events[1].type, "app_server_reply_delta");
+  assert.equal(events[2].type, "app_server_reply");
+  assert.equal(events[2].text, "今日は2026年5月22日です。");
+});
+
+test("dashboard app-server bridge args read runtime and token from environment", () => {
+  const parsed = parseBridgeArgs(["--thread-id", "dashboard-main"], {
+    VTDD_RUNTIME_URL: "https://runtime.example",
+    VTDD_GATEWAY_BEARER_TOKEN: "secret-token",
+    VTDD_DASHBOARD_CODEX_CWD: "/repo"
+  });
+  assert.equal(parsed.runtimeUrl, "https://runtime.example");
+  assert.equal(parsed.token, "secret-token");
+  assert.equal(parsed.threadId, "dashboard-main");
+  assert.equal(parsed.cwd, "/repo");
+});

--- a/test/dashboard-app-server-bridge.test.js
+++ b/test/dashboard-app-server-bridge.test.js
@@ -5,9 +5,12 @@ import {
   buildAppServerThreadResumeRequest,
   buildAppServerThreadStartRequest,
   buildAppServerTurnStartRequest,
+  extractAppServerNotificationTurnId,
   handleDashboardTurnRequest,
   mapAppServerNotificationToDashboardEvent,
-  parseBridgeArgs
+  matchesAppServerTurnNotification,
+  parseBridgeArgs,
+  runDashboardAppServerBridge
 } from "../scripts/run-dashboard-app-server-bridge.mjs";
 
 test("dashboard app-server bridge builds initialize and thread requests from Codex app-server protocol", () => {
@@ -74,6 +77,31 @@ test("dashboard app-server bridge maps Codex app-server notifications to dashboa
   assert.equal(completed.type, "app_server_status");
   assert.equal(completed.status, "replied");
   assert.equal(completed.text, "最終返答");
+});
+
+test("dashboard app-server bridge filters app-server notifications by Codex thread and turn", () => {
+  assert.equal(
+    matchesAppServerTurnNotification(
+      { method: "item/agentMessage/delta", params: { threadId: "codex-thread-1", turnId: "turn-1" } },
+      { codexThreadId: "codex-thread-1", turnId: "turn-1" }
+    ),
+    true
+  );
+  assert.equal(
+    matchesAppServerTurnNotification(
+      { method: "item/agentMessage/delta", params: { threadId: "codex-thread-2", turnId: "turn-1" } },
+      { codexThreadId: "codex-thread-1", turnId: "turn-1" }
+    ),
+    false
+  );
+  assert.equal(
+    matchesAppServerTurnNotification(
+      { method: "turn/completed", params: { threadId: "codex-thread-1", turn: { id: "turn-2" } } },
+      { codexThreadId: "codex-thread-1", turnId: "turn-1" }
+    ),
+    false
+  );
+  assert.equal(extractAppServerNotificationTurnId({ params: { turn: { id: "turn-2" } } }), "turn-2");
 });
 
 test("dashboard app-server bridge handles a fresh dashboard turn through thread/start and turn/start", async () => {
@@ -211,7 +239,97 @@ test("dashboard app-server bridge keeps listening for async turn notifications a
   assert.equal(handlers.size, 0);
 });
 
-test("dashboard app-server bridge args read runtime and token from environment", () => {
+test("dashboard app-server bridge ignores notifications for a different Codex turn", async () => {
+  const events = [];
+  const handlers = new Set();
+  let nextId = 1;
+  const appServer = {
+    nextRequestId() {
+      const id = nextId;
+      nextId += 1;
+      return id;
+    },
+    onNotification(handler) {
+      handlers.add(handler);
+      return () => handlers.delete(handler);
+    },
+    async request(message) {
+      if (message.method === "thread/start") {
+        return { thread: { id: "codex-thread-filtered" } };
+      }
+      if (message.method === "turn/start") {
+        setTimeout(() => {
+          for (const handler of handlers) {
+            handler({
+              method: "item/agentMessage/delta",
+              params: {
+                threadId: "codex-thread-filtered",
+                turnId: "other-turn",
+                delta: "混線"
+              }
+            });
+            handler({
+              method: "item/agentMessage/delta",
+              params: {
+                threadId: "codex-thread-filtered",
+                turnId: "turn-filtered",
+                delta: "正しい返信"
+              }
+            });
+            handler({
+              method: "turn/completed",
+              params: {
+                threadId: "codex-thread-filtered",
+                turn: { id: "turn-filtered", status: "completed" }
+              }
+            });
+          }
+        }, 0);
+        return { turn: { id: "turn-filtered" } };
+      }
+      throw new Error(`unexpected method ${message.method}`);
+    }
+  };
+
+  await handleDashboardTurnRequest({
+    request: {
+      threadId: "dashboard-main",
+      codexThreadId: null,
+      text: "混線しない？"
+    },
+    appServer,
+    sendDashboardEvent: async (event) => events.push(event),
+    cwd: "/repo",
+    turnTimeoutMs: 1000
+  });
+
+  assert.equal(events.some((event) => event.text === "混線"), false);
+  assert.equal(events.at(-1).type, "app_server_reply");
+  assert.equal(events.at(-1).text, "正しい返信");
+});
+
+test("dashboard app-server bridge args require a dashboard thread id for runtime connection", () => {
+  const parsed = parseBridgeArgs([], {
+    VTDD_RUNTIME_URL: "https://runtime.example",
+    VTDD_GATEWAY_BEARER_TOKEN: "secret-token",
+    VTDD_DASHBOARD_CODEX_CWD: "/repo"
+  });
+  assert.equal(parsed.threadId, "");
+});
+
+test("dashboard app-server bridge refuses to connect without a dashboard thread id", async () => {
+  await assert.rejects(
+    runDashboardAppServerBridge({
+      runtimeUrl: "https://runtime.example",
+      token: "secret-token",
+      threadId: "",
+      cwd: "/repo"
+    }),
+    /--thread-id is required/
+  );
+});
+
+test("dashboard app-server bridge args read runtime, token, and thread from environment", () => {
   const parsed = parseBridgeArgs(["--thread-id", "dashboard-main"], {
     VTDD_RUNTIME_URL: "https://runtime.example",
     VTDD_GATEWAY_BEARER_TOKEN: "secret-token",

--- a/test/dashboard-app-server-bridge.test.js
+++ b/test/dashboard-app-server-bridge.test.js
@@ -143,6 +143,74 @@ test("dashboard app-server bridge handles a fresh dashboard turn through thread/
   assert.equal(events[2].text, "今日は2026年5月22日です。");
 });
 
+test("dashboard app-server bridge keeps listening for async turn notifications after turn/start response", async () => {
+  const requests = [];
+  const events = [];
+  const handlers = new Set();
+  let nextId = 1;
+  const appServer = {
+    nextRequestId() {
+      const id = nextId;
+      nextId += 1;
+      return id;
+    },
+    onNotification(handler) {
+      handlers.add(handler);
+      return () => handlers.delete(handler);
+    },
+    async request(message) {
+      requests.push(message);
+      if (message.method === "thread/start") {
+        return { thread: { id: "codex-thread-async" } };
+      }
+      if (message.method === "turn/start") {
+        setTimeout(() => {
+          for (const handler of handlers) {
+            handler({
+              method: "item/agentMessage/delta",
+              params: {
+                threadId: "codex-thread-async",
+                turnId: "turn-async",
+                delta: "非同期で返りました。"
+              }
+            });
+            handler({
+              method: "turn/completed",
+              params: {
+                threadId: "codex-thread-async",
+                turn: { id: "turn-async", status: "completed" }
+              }
+            });
+          }
+        }, 0);
+        return { turn: { id: "turn-async" } };
+      }
+      throw new Error(`unexpected method ${message.method}`);
+    }
+  };
+
+  await handleDashboardTurnRequest({
+    request: {
+      threadId: "dashboard-main",
+      codexThreadId: null,
+      text: "続きは？"
+    },
+    appServer,
+    sendDashboardEvent: async (event) => events.push(event),
+    cwd: "/repo",
+    turnTimeoutMs: 1000
+  });
+
+  assert.deepEqual(
+    requests.map((request) => request.method),
+    ["thread/start", "turn/start"]
+  );
+  assert.equal(events.at(-2).type, "app_server_reply_delta");
+  assert.equal(events.at(-1).type, "app_server_reply");
+  assert.equal(events.at(-1).text, "非同期で返りました。");
+  assert.equal(handlers.size, 0);
+});
+
 test("dashboard app-server bridge args read runtime and token from environment", () => {
   const parsed = parseBridgeArgs(["--thread-id", "dashboard-main"], {
     VTDD_RUNTIME_URL: "https://runtime.example",

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -1175,6 +1175,35 @@ test("DashboardChatRoom maps app-server replies back into the dashboard thread",
   assert.equal(broadcast.messages[0].text, "今日は日本時間で 2026年5月22日です。");
 });
 
+test("DashboardChatRoom rejects spoofed app-server events from dashboard sockets", async () => {
+  const store = createInMemoryDashboardChatStore();
+  const dashboardSocket = createMockSocket("dashboard", "dashboard-main-unresolved");
+  const storage = createMockDurableObjectStorage();
+  const room = new DashboardChatRoom(
+    {
+      storage,
+      getWebSockets() {
+        return [dashboardSocket];
+      }
+    },
+    { DASHBOARD_CHAT_STORE: store }
+  );
+
+  await room.webSocketMessage(
+    dashboardSocket,
+    JSON.stringify({
+      type: "app_server_reply",
+      threadId: "dashboard-main-unresolved",
+      codexThreadId: "spoofed-thread",
+      text: "偽装返信"
+    })
+  );
+
+  assert.equal(storage.values.has("app_server_thread:dashboard-main-unresolved"), false);
+  assert.equal(dashboardSocket.sent.length, 0);
+  assert.deepEqual(await store.listThread("dashboard-main-unresolved"), []);
+});
+
 test("DashboardChatRoom returns nickname list without repository handoff", async () => {
   const provider = createInMemoryMemoryProvider();
   await provider.store({

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -1140,6 +1140,35 @@ test("DashboardChatRoom sends ordinary owner turns to connected app-server bridg
   assert.match(broadcast.messages[1].text, /app-server/);
 });
 
+test("DashboardChatRoom sends each owner turn to only one app-server bridge for a thread", async () => {
+  const provider = createInMemoryMemoryProvider();
+  const store = createInMemoryDashboardChatStore();
+  const dashboardSocket = createMockSocket("dashboard", "dashboard-main-unresolved");
+  const primaryBridgeSocket = createMockSocket("app_server_bridge", "dashboard-main-unresolved");
+  const duplicateBridgeSocket = createMockSocket("app_server_bridge", "dashboard-main-unresolved");
+  const room = new DashboardChatRoom(
+    {
+      getWebSockets() {
+        return [dashboardSocket, primaryBridgeSocket, duplicateBridgeSocket];
+      }
+    },
+    { DASHBOARD_CHAT_STORE: store, MEMORY_PROVIDER: provider }
+  );
+
+  await room.webSocketMessage(
+    dashboardSocket,
+    JSON.stringify({
+      type: "owner_message",
+      threadId: "dashboard-main-unresolved",
+      text: "重複実行しない？"
+    })
+  );
+
+  assert.equal(primaryBridgeSocket.sent.length, 1);
+  assert.equal(duplicateBridgeSocket.sent.length, 0);
+  assert.equal(JSON.parse(primaryBridgeSocket.sent[0]).type, "app_server_turn_requested");
+});
+
 test("DashboardChatRoom maps app-server replies back into the dashboard thread", async () => {
   const store = createInMemoryDashboardChatStore();
   const dashboardSocket = createMockSocket("dashboard", "dashboard-main-unresolved");
@@ -1173,6 +1202,40 @@ test("DashboardChatRoom maps app-server replies back into the dashboard thread",
   assert.equal(broadcast.messages[0].role, "butler");
   assert.equal(broadcast.messages[0].status, "replied");
   assert.equal(broadcast.messages[0].text, "今日は日本時間で 2026年5月22日です。");
+});
+
+test("DashboardChatRoom rejects app-server bridge events for a different dashboard thread", async () => {
+  const store = createInMemoryDashboardChatStore();
+  const dashboardSocket = createMockSocket("dashboard", "dashboard-main-unresolved");
+  const bridgeSocket = createMockSocket("app_server_bridge", "dashboard-main-unresolved");
+  const storage = createMockDurableObjectStorage();
+  const room = new DashboardChatRoom(
+    {
+      storage,
+      getWebSockets() {
+        return [dashboardSocket, bridgeSocket];
+      }
+    },
+    { DASHBOARD_CHAT_STORE: store }
+  );
+
+  await room.webSocketMessage(
+    bridgeSocket,
+    JSON.stringify({
+      type: "app_server_reply",
+      threadId: "dashboard-other",
+      codexThreadId: "codex-thread-other",
+      text: "別 thread への返信"
+    })
+  );
+
+  assert.equal(storage.values.has("app_server_thread:dashboard-other"), false);
+  assert.equal(dashboardSocket.sent.length, 0);
+  assert.equal(bridgeSocket.sent.length, 1);
+  const error = JSON.parse(bridgeSocket.sent[0]);
+  assert.equal(error.type, "error");
+  assert.equal(error.ok, false);
+  assert.match(error.reason, /threadId/);
 });
 
 test("DashboardChatRoom rejects spoofed app-server events from dashboard sockets", async () => {

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -189,6 +189,19 @@ function createMockDashboardChatRoomNamespace() {
   };
 }
 
+function createMockDurableObjectStorage() {
+  const values = new Map();
+  return {
+    values,
+    async get(key) {
+      return values.get(key);
+    },
+    async put(key, value) {
+      values.set(key, value);
+    }
+  };
+}
+
 function createMockSocket(role, threadId) {
   const sent = [];
   return {
@@ -1017,6 +1030,38 @@ test("worker no longer exposes the dashboard VPS runner WebSocket push channel",
   assert.equal(rooms.calls.length, 0);
 });
 
+test("worker requires WebSocket upgrade for dashboard app-server bridge", async () => {
+  const rooms = createMockDashboardChatRoomNamespace();
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/dashboard/app-server/ws?threadId=dashboard-main-marushu-vtdd-v2-p", {
+      headers: gatewayAuthHeaders
+    }),
+    { ...gatewayAuthEnv, DASHBOARD_CHAT_ROOMS: rooms.namespace }
+  );
+
+  assert.equal(response.status, 426);
+  const body = await response.json();
+  assert.equal(body.error, "websocket_upgrade_required");
+  assert.equal(rooms.calls.length, 0);
+});
+
+test("worker accepts dashboard app-server bridge bearer token through WebSocket subprotocol", async () => {
+  const rooms = createMockDashboardChatRoomNamespace();
+  const tokenProtocol = `vtdd-bearer.${Buffer.from("test-token", "utf8").toString("base64url")}`;
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/dashboard/app-server/ws?threadId=dashboard-main-marushu-vtdd-v2-p", {
+      headers: {
+        "sec-websocket-protocol": `vtdd-dashboard-bridge, ${tokenProtocol}`
+      }
+    }),
+    { ...gatewayAuthEnv, DASHBOARD_CHAT_ROOMS: rooms.namespace }
+  );
+
+  assert.equal(response.status, 426);
+  const body = await response.json();
+  assert.equal(body.error, "websocket_upgrade_required");
+});
+
 test("DashboardChatRoom stores owner messages without pushing a VPS runner job", async () => {
   const provider = createInMemoryMemoryProvider();
   const store = createInMemoryDashboardChatStore();
@@ -1049,6 +1094,85 @@ test("DashboardChatRoom stores owner messages without pushing a VPS runner job",
   assert.equal(broadcast.messages[1].role, "butler");
   assert.equal(broadcast.messages[1].status, "blocked");
   assert.equal(broadcast.messages[1].text.includes("app-server"), true);
+});
+
+test("DashboardChatRoom sends ordinary owner turns to connected app-server bridge without repository resolution", async () => {
+  const provider = createInMemoryMemoryProvider();
+  const store = createInMemoryDashboardChatStore();
+  const dashboardSocket = createMockSocket("dashboard", "dashboard-main-unresolved");
+  const bridgeSocket = createMockSocket("app_server_bridge", "dashboard-main-unresolved");
+  const storage = createMockDurableObjectStorage();
+  const room = new DashboardChatRoom(
+    {
+      storage,
+      getWebSockets() {
+        return [dashboardSocket, bridgeSocket];
+      }
+    },
+    { DASHBOARD_CHAT_STORE: store, MEMORY_PROVIDER: provider }
+  );
+
+  await room.webSocketMessage(
+    dashboardSocket,
+    JSON.stringify({
+      type: "owner_message",
+      threadId: "dashboard-main-unresolved",
+      text: "今日は何月何日？日本時間を答えて"
+    })
+  );
+
+  assert.equal(bridgeSocket.sent.length, 1);
+  const turnRequest = JSON.parse(bridgeSocket.sent[0]);
+  assert.equal(turnRequest.type, "app_server_turn_requested");
+  assert.equal(turnRequest.threadId, "dashboard-main-unresolved");
+  assert.equal(turnRequest.repository, null);
+  assert.equal(turnRequest.codexThreadId, null);
+  assert.equal(turnRequest.appServer.startThreadMethod, "thread/start");
+  assert.equal(turnRequest.appServer.turnMethod, "turn/start");
+  assert.equal(turnRequest.authority.ordinaryConversationAllowed, true);
+
+  assert.equal(dashboardSocket.sent.length, 1);
+  const broadcast = JSON.parse(dashboardSocket.sent[0]);
+  assert.equal(broadcast.messages.length, 2);
+  assert.equal(broadcast.messages[0].role, "owner");
+  assert.equal(broadcast.messages[1].role, "butler");
+  assert.equal(broadcast.messages[1].status, "thinking");
+  assert.match(broadcast.messages[1].text, /app-server/);
+});
+
+test("DashboardChatRoom maps app-server replies back into the dashboard thread", async () => {
+  const store = createInMemoryDashboardChatStore();
+  const dashboardSocket = createMockSocket("dashboard", "dashboard-main-unresolved");
+  const bridgeSocket = createMockSocket("app_server_bridge", "dashboard-main-unresolved");
+  const storage = createMockDurableObjectStorage();
+  const room = new DashboardChatRoom(
+    {
+      storage,
+      getWebSockets() {
+        return [dashboardSocket, bridgeSocket];
+      }
+    },
+    { DASHBOARD_CHAT_STORE: store }
+  );
+
+  await room.webSocketMessage(
+    bridgeSocket,
+    JSON.stringify({
+      type: "app_server_reply",
+      threadId: "dashboard-main-unresolved",
+      codexThreadId: "codex-thread-450",
+      text: "今日は日本時間で 2026年5月22日です。"
+    })
+  );
+
+  assert.equal(storage.values.get("app_server_thread:dashboard-main-unresolved").codexThreadId, "codex-thread-450");
+  assert.equal(bridgeSocket.sent.length, 0);
+  assert.equal(dashboardSocket.sent.length, 1);
+  const broadcast = JSON.parse(dashboardSocket.sent[0]);
+  assert.equal(broadcast.messages.length, 1);
+  assert.equal(broadcast.messages[0].role, "butler");
+  assert.equal(broadcast.messages[0].status, "replied");
+  assert.equal(broadcast.messages[0].text, "今日は日本時間で 2026年5月22日です。");
 });
 
 test("DashboardChatRoom returns nickname list without repository handoff", async () => {

--- a/worker.js
+++ b/worker.js
@@ -55943,7 +55943,7 @@ var DashboardChatRoom = class {
       await this.acceptOwnerMessage({ socket, threadId, payload });
       return;
     }
-    if (socketAttachment.role === "app_server_bridge" || String(payload?.type || "").startsWith("app_server_")) {
+    if (socketAttachment.role === "app_server_bridge") {
       await this.acceptAppServerBridgeMessage({ socket, attachment: socketAttachment, payload });
     }
   }

--- a/worker.js
+++ b/worker.js
@@ -55869,7 +55869,11 @@ var DashboardChatRoom = class {
         reason: "WebSocketPair is not available in this runtime"
       });
     }
-    const threadId = extractDashboardChatSocketThreadId(url.pathname);
+    const appServerBridgeSocket = isDashboardAppServerBridgeSocketPath(url.pathname);
+    const threadId = appServerBridgeSocket ? normalizeDashboardThreadId(url.searchParams.get("threadId") || url.searchParams.get("thread_id")) : extractDashboardChatSocketThreadId(url.pathname);
+    if (appServerBridgeSocket) {
+      return this.acceptSocket({ request, role: "app_server_bridge", threadId });
+    }
     if (!threadId) {
       return json(422, {
         ok: false,
@@ -55877,9 +55881,12 @@ var DashboardChatRoom = class {
         reason: "threadId is required"
       });
     }
+    return this.acceptSocket({ request, role: "dashboard", threadId });
+  }
+  async acceptSocket({ request, role, threadId }) {
     const pair = new WebSocketPair();
     const [client, server] = Object.values(pair);
-    const attachment = { role: "dashboard", threadId };
+    const attachment = { role, threadId };
     if (typeof this.ctx?.acceptWebSocket === "function") {
       server.serializeAttachment(attachment);
       this.ctx.acceptWebSocket(server);
@@ -55890,9 +55897,20 @@ var DashboardChatRoom = class {
       server.addEventListener("error", () => this.sessions.delete(server));
       server.addEventListener("message", (event) => this.handleSocketMessage(server, event?.data, attachment));
     }
-    await this.sendThread(server, threadId);
+    if (role === "app_server_bridge") {
+      this.sendSocket(server, {
+        type: "app_server_bridge_connected",
+        ok: true,
+        threadId: threadId || null,
+        schema: "vtdd.dashboard.app_server_bridge.v1"
+      });
+    } else {
+      await this.sendThread(server, threadId);
+    }
+    const headers = role === "app_server_bridge" && normalizeDashboardEventText(request.headers.get("sec-websocket-protocol")).includes("vtdd-dashboard-bridge") ? { "sec-websocket-protocol": "vtdd-dashboard-bridge" } : {};
     return new Response(null, {
       status: 101,
+      headers,
       webSocket: client
     });
   }
@@ -55923,6 +55941,10 @@ var DashboardChatRoom = class {
     }
     if (payload?.type === "owner_message") {
       await this.acceptOwnerMessage({ socket, threadId, payload });
+      return;
+    }
+    if (socketAttachment.role === "app_server_bridge" || String(payload?.type || "").startsWith("app_server_")) {
+      await this.acceptAppServerBridgeMessage({ socket, attachment: socketAttachment, payload });
     }
   }
   async acceptOwnerMessage({ socket, threadId, payload }) {
@@ -55974,20 +55996,85 @@ var DashboardChatRoom = class {
       },
       { threadId }
     );
-    const butlerMessage = normalizeDashboardChatMessage(
+    const bridgeSockets = this.connectedAppServerBridgeSockets(threadId);
+    if (bridgeSockets.length === 0) {
+      const butlerMessage = normalizeDashboardChatMessage(
+        {
+          threadId,
+          role: "butler",
+          repository,
+          relatedIssue,
+          status: "blocked",
+          text: buildDashboardAppServerNotConnectedReply({ repository, relatedIssue }),
+          createdAt: new Date(Date.parse(now) + 1).toISOString()
+        },
+        { threadId }
+      );
+      const messages2 = store ? await store.appendMany(threadId, [ownerMessage, butlerMessage]) : [ownerMessage, butlerMessage].filter(Boolean);
+      await this.broadcastThread({ threadId, messages: messages2 });
+      return;
+    }
+    const pendingMessage = normalizeDashboardChatMessage(
       {
         threadId,
         role: "butler",
         repository,
         relatedIssue,
-        status: "blocked",
-        text: buildDashboardAppServerNotConnectedReply({ repository, relatedIssue }),
+        status: "thinking",
+        text: "codex app-server \u306B\u9001\u4FE1\u3057\u307E\u3057\u305F\u3002\u8FD4\u4FE1\u3092\u5F85\u3063\u3066\u3044\u307E\u3059\u3002",
         createdAt: new Date(Date.parse(now) + 1).toISOString()
       },
       { threadId }
     );
-    const messages = store ? await store.appendMany(threadId, [ownerMessage, butlerMessage]) : [ownerMessage, butlerMessage].filter(Boolean);
+    const messages = store ? await store.appendMany(threadId, [ownerMessage, pendingMessage]) : [ownerMessage, pendingMessage].filter(Boolean);
     await this.broadcastThread({ threadId, messages });
+    const mapping = await this.readAppServerThreadMapping(threadId);
+    const turnRequest = {
+      type: "app_server_turn_requested",
+      schema: "vtdd.dashboard.app_server_bridge.v1",
+      requestId: createDashboardRequestId("app-server-turn"),
+      threadId,
+      codexThreadId: mapping.codexThreadId || null,
+      repository: repository || null,
+      relatedIssue: relatedIssue || null,
+      text,
+      messageId: ownerMessage.messageId,
+      createdAt: now,
+      appServer: {
+        startThreadMethod: mapping.codexThreadId ? "thread/resume" : "thread/start",
+        turnMethod: "turn/start"
+      },
+      authority: buildDashboardAppServerAuthorityHint({ repository, relatedIssue, text })
+    };
+    for (const bridgeSocket of bridgeSockets) {
+      this.sendSocket(bridgeSocket, turnRequest);
+    }
+  }
+  async acceptAppServerBridgeMessage({ socket, attachment, payload }) {
+    const normalized = normalizeDashboardAppServerBridgeEvent(payload, {
+      fallbackThreadId: attachment?.threadId
+    });
+    if (!normalized.ok) {
+      this.sendSocket(socket, {
+        type: "error",
+        ok: false,
+        reason: normalized.reason
+      });
+      return;
+    }
+    if (normalized.codexThreadId) {
+      await this.writeAppServerThreadMapping(normalized.threadId, {
+        codexThreadId: normalized.codexThreadId,
+        updatedAt: normalized.createdAt
+      });
+    }
+    if (normalized.messages.length === 0) {
+      await this.broadcastThread({ threadId: normalized.threadId });
+      return;
+    }
+    const store = resolveDashboardChatStore(this.env);
+    const messages = store ? await store.appendMany(normalized.threadId, normalized.messages) : normalized.messages;
+    await this.broadcastThread({ threadId: normalized.threadId, messages });
   }
   async broadcastThread({ threadId, messages = null }) {
     const resolvedMessages = Array.isArray(messages) ? messages : await this.listThreadMessages(threadId);
@@ -55999,7 +56086,7 @@ var DashboardChatRoom = class {
     });
     for (const socket of this.connectedSockets()) {
       const attachment = this.getSocketAttachment(socket);
-      if (attachment.role !== "vps_runner" && (!attachment.threadId || attachment.threadId === threadId) && isSocketOpen(socket)) {
+      if (attachment.role !== "vps_runner" && attachment.role !== "app_server_bridge" && (!attachment.threadId || attachment.threadId === threadId) && isSocketOpen(socket)) {
         socket.send(payload);
       }
     }
@@ -56045,6 +56132,46 @@ var DashboardChatRoom = class {
       return socket.deserializeAttachment() || {};
     }
     return this.sessions.get(socket) || {};
+  }
+  connectedAppServerBridgeSockets(threadId) {
+    return this.connectedSockets().filter((socket) => {
+      const attachment = this.getSocketAttachment(socket);
+      return attachment.role === "app_server_bridge" && (!attachment.threadId || attachment.threadId === threadId) && isSocketOpen(socket);
+    });
+  }
+  sendSocket(socket, payload) {
+    if (!isSocketOpen(socket)) {
+      return false;
+    }
+    socket.send(JSON.stringify(payload));
+    return true;
+  }
+  async readAppServerThreadMapping(threadId) {
+    const key = `app_server_thread:${normalizeDashboardThreadId(threadId)}`;
+    if (!key || typeof this.ctx?.storage?.get !== "function") {
+      return {};
+    }
+    try {
+      const record2 = await this.ctx.storage.get(key);
+      return normalizeObject11(record2);
+    } catch {
+      return {};
+    }
+  }
+  async writeAppServerThreadMapping(threadId, mapping) {
+    const normalizedThreadId = normalizeDashboardThreadId(threadId);
+    if (!normalizedThreadId || typeof this.ctx?.storage?.put !== "function") {
+      return false;
+    }
+    const codexThreadId = normalizeDashboardEventText(mapping?.codexThreadId || mapping?.codex_thread_id);
+    if (!codexThreadId) {
+      return false;
+    }
+    await this.ctx.storage.put(`app_server_thread:${normalizedThreadId}`, {
+      codexThreadId,
+      updatedAt: normalizeIsoTimestamp(mapping?.updatedAt) || (/* @__PURE__ */ new Date()).toISOString()
+    });
+    return true;
   }
 };
 var CLOUDFLARE_ACCESS_JWKS_CACHE_TTL_MS = 5 * 60 * 1e3;
@@ -56145,6 +56272,9 @@ var runtime_default = {
     }
     if (request.method === "GET" && isDashboardChatSocketApiPath(url.pathname)) {
       return handleDashboardChatSocketRequest(request, url, env);
+    }
+    if (request.method === "GET" && isDashboardAppServerBridgeSocketPath(url.pathname)) {
+      return handleDashboardAppServerBridgeSocketRequest(request, url, env);
     }
     if (request.method === "GET" && isApiPath(url.pathname, "/dashboard/chat/search")) {
       return handleDashboardChatSearchRequest(request, url, env);
@@ -58819,6 +58949,53 @@ async function handleDashboardChatSocketRequest(request, url, env) {
   }
   return room.fetch(request);
 }
+async function handleDashboardAppServerBridgeSocketRequest(request, url, env) {
+  const auth = authorizeDashboardAppServerBridgeRequest({
+    request,
+    env,
+    apiSuffix: "/dashboard/app-server/ws"
+  });
+  if (!auth.ok) {
+    return json(auth.status, {
+      ok: false,
+      error: "unauthorized",
+      reason: auth.reason
+    });
+  }
+  const threadId = normalizeDashboardThreadId(url.searchParams.get("threadId") || url.searchParams.get("thread_id"));
+  const room = resolveDashboardChatRoomStub(env, threadId || "dashboard-app-server-bridge");
+  if (!room) {
+    return json(503, {
+      ok: false,
+      error: "dashboard_chat_room_unavailable",
+      reason: "DASHBOARD_CHAT_ROOMS Durable Object binding is not configured"
+    });
+  }
+  if (request.headers.get("upgrade")?.toLowerCase() !== "websocket") {
+    return json(426, {
+      ok: false,
+      error: "websocket_upgrade_required",
+      reason: "dashboard app-server bridge requires a WebSocket upgrade"
+    });
+  }
+  return room.fetch(request);
+}
+function authorizeDashboardAppServerBridgeRequest({ request, env, apiSuffix }) {
+  const direct = authorizeGatewayRequest({ request, env, apiSuffix });
+  if (direct.ok || normalizeText30(request.headers.get("authorization"))) {
+    return direct;
+  }
+  const bearerToken = normalizeText30(env?.VTDD_GATEWAY_BEARER_TOKEN ?? env?.MVP_GATEWAY_BEARER_TOKEN);
+  const protocolToken = extractDashboardBridgeBearerProtocol(request.headers.get("sec-websocket-protocol"));
+  if (bearerToken && protocolToken) {
+    return protocolToken === bearerToken ? { ok: true } : {
+      ok: false,
+      status: 403,
+      reason: `provided websocket bearer protocol token is invalid for /${CANONICAL_API_PREFIX.replace(/^\//, "")}${apiSuffix}`
+    };
+  }
+  return direct;
+}
 async function handleDashboardChatThreadRequest(request, url, env) {
   const auth = await authorizeDashboardRequest({
     request,
@@ -60323,6 +60500,97 @@ function shouldUseDashboardThreadRepositoryContext(value) {
     text
   );
 }
+function createDashboardRequestId(prefix) {
+  const normalizedPrefix = normalizeDashboardEventText(prefix) || "dashboard";
+  if (typeof globalThis.crypto?.randomUUID === "function") {
+    return `${normalizedPrefix}:${globalThis.crypto.randomUUID()}`;
+  }
+  return `${normalizedPrefix}:${Date.now().toString(36)}`;
+}
+function buildDashboardAppServerAuthorityHint({ repository, relatedIssue, text }) {
+  const needsRepositoryContext = Boolean(repository || relatedIssue || shouldUseDashboardThreadRepositoryContext(text));
+  return {
+    ordinaryConversationAllowed: true,
+    repositoryRequired: false,
+    repository: repository || null,
+    relatedIssue: relatedIssue || null,
+    escalation: needsRepositoryContext ? "Repository / Issue context may be used, but high-risk actions still require explicit GO or passkey approval." : "Treat as ordinary conversation unless the owner asks for repository, Issue, PR, deploy, credential, or permission work.",
+    highRiskActionsRequire: ["GO", "passkey_approval"]
+  };
+}
+function normalizeDashboardAppServerBridgeEvent(payload, { fallbackThreadId = "" } = {}) {
+  const input = normalizeObject11(payload);
+  const threadId = normalizeDashboardThreadId(input.threadId || input.thread_id || fallbackThreadId);
+  if (!threadId) {
+    return {
+      ok: false,
+      reason: "threadId is required for app-server bridge events"
+    };
+  }
+  const eventType = normalizeDashboardEventText(input.type).toLowerCase();
+  const status = normalizeDashboardEventText(input.status).toLowerCase();
+  const codexThreadId = normalizeDashboardEventText(input.codexThreadId || input.codex_thread_id);
+  const text = sanitizeDashboardChatText(input.text || input.message || input.delta || input.finalText || input.final_text);
+  const repository = normalizeCanonicalRepositoryInput(input.repository);
+  const relatedIssue = normalizePositiveInteger9(input.relatedIssue || input.issueNumber);
+  const createdAt = normalizeIsoTimestamp(input.createdAt) || (/* @__PURE__ */ new Date()).toISOString();
+  const messages = [];
+  if (eventType === "app_server_reply_delta" || eventType === "app_server_reply") {
+    if (text) {
+      messages.push(
+        normalizeDashboardChatMessage(
+          {
+            threadId,
+            role: "butler",
+            repository,
+            relatedIssue,
+            status: eventType === "app_server_reply_delta" ? "thinking" : "replied",
+            text,
+            createdAt
+          },
+          { threadId }
+        )
+      );
+    }
+  } else if (eventType === "app_server_turn_failed" || status === "failed") {
+    messages.push(
+      normalizeDashboardChatMessage(
+        {
+          threadId,
+          role: "system",
+          repository,
+          relatedIssue,
+          status: "failed",
+          text: text || "codex app-server bridge failed before returning a reply.",
+          createdAt
+        },
+        { threadId }
+      )
+    );
+  } else if (eventType === "app_server_status") {
+    messages.push(
+      normalizeDashboardChatMessage(
+        {
+          threadId,
+          role: "system",
+          repository,
+          relatedIssue,
+          status: status === "replied" ? "replied" : "thinking",
+          text: text || "codex app-server is working.",
+          createdAt
+        },
+        { threadId }
+      )
+    );
+  }
+  return {
+    ok: true,
+    threadId,
+    codexThreadId,
+    createdAt,
+    messages: messages.filter(Boolean)
+  };
+}
 async function notifyDashboardChatRoom({ env, threadId, messages }) {
   const room = resolveDashboardChatRoomStub(env, threadId);
   if (!room || typeof room.fetch !== "function") {
@@ -60875,6 +61143,23 @@ function isDashboardChatThreadApiPath(pathname) {
 }
 function isDashboardChatSocketApiPath(pathname) {
   return (pathname.startsWith(`${CANONICAL_API_PREFIX}/dashboard/chat/`) || pathname.startsWith(`${LEGACY_API_PREFIX}/dashboard/chat/`)) && pathname.endsWith("/ws");
+}
+function isDashboardAppServerBridgeSocketPath(pathname) {
+  return pathname === `${CANONICAL_API_PREFIX}/dashboard/app-server/ws` || pathname === `${LEGACY_API_PREFIX}/dashboard/app-server/ws`;
+}
+function extractDashboardBridgeBearerProtocol(value) {
+  const protocols = normalizeText30(value).split(",").map((item) => item.trim()).filter(Boolean);
+  const encoded = protocols.find((item) => item.startsWith("vtdd-bearer."))?.slice("vtdd-bearer.".length);
+  if (!encoded) {
+    return "";
+  }
+  try {
+    const base643 = encoded.replace(/-/g, "+").replace(/_/g, "/");
+    const padded = `${base643}${"=".repeat((4 - base643.length % 4) % 4)}`;
+    return normalizeText30(atob(padded));
+  } catch {
+    return "";
+  }
 }
 function isDashboardPagePath(pathname) {
   return pathname === "/dashboard" || pathname.startsWith("/dashboard/") || pathname === "/orchestrator" || pathname.startsWith("/orchestrator/");
@@ -62777,7 +63062,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           <p>\u3053\u306E\u753B\u9762\u306F\u4F1A\u8A71\u3092\u4E3B\u5F79\u306B\u3059\u308B\u305F\u3081\u306E chat-first runtime \u3067\u3059\u3002\u7BA1\u7406\u753B\u9762\u306F\u53F3\u306E\u30B5\u30A4\u30C9\u30D0\u30FC\u3078\u9000\u907F\u3057\u307E\u3057\u305F\u3002</p>
           <ul>
             <li>\u95A2\u9023 repo/nickname: <code>${escapeDashboardHtml(dashboardTargetLabel)}</code></li>
-            <li>\u4F1A\u8A71: Dashboard Butler \u306E app-server \u63A5\u7D9A\u306F\u672A\u5B9F\u88C5\u3067\u3059\u3002\u65E7 VPS runner \u76F4\u9001\u7D4C\u8DEF\u306F\u4F7F\u3044\u307E\u305B\u3093</li>
+            <li>\u4F1A\u8A71: Dashboard Butler \u306F app-server bridge \u7D4C\u8DEF\u3092\u4F7F\u3044\u307E\u3059\u3002\u65E7 VPS runner \u76F4\u9001\u7D4C\u8DEF\u306F\u4F7F\u3044\u307E\u305B\u3093</li>
           </ul>
         </article>
         <article class="bubble owner">
@@ -62786,8 +63071,8 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         <article class="bubble">
           <strong>Butler</strong>
           <p>\u305D\u306E\u65B9\u91DD\u3067\u9032\u3081\u307E\u3059\u3002\u4E2D\u592E\u306F\u30C1\u30E3\u30C3\u30C8\u3060\u3051\u3001\u72B6\u614B\u78BA\u8A8D\u30FB\u9032\u6357\u30FBRAG\u30FBworkflow\u30FBprototype cleanup \u306E\u6271\u3044\u306F\u30B5\u30A4\u30C9\u30D0\u30FC\u306E\u30E1\u30CB\u30E5\u30FC\u304B\u3089\u5FC5\u8981\u306A\u6642\u3060\u3051\u958B\u304D\u307E\u3059\u3002</p>
-          <p>\u3053\u306E dashboard \u304B\u3089 VPS Codex CLI \u3092 <code>codex exec</code> \u3067\u6BCE\u56DE\u8D77\u52D5\u3059\u308B\u65E7\u7D4C\u8DEF\u306F\u524A\u9664\u3057\u307E\u3057\u305F\u3002Dashboard Butler \u306F <code>codex app-server</code> \u30D6\u30EA\u30C3\u30B8\u304C\u5165\u308B\u307E\u3067\u672A\u5B8C\u6210\u3067\u3059\u3002</p>
-          <span class="connection-note">Dashboard thread \u63A5\u7D9A\u6E96\u5099\u4E2D: \u5C65\u6B74\u4FDD\u5B58\u3068\u672A\u63A5\u7D9A\u72B6\u614B\u306E\u8868\u793A\u3060\u3051\u3092\u884C\u3044\u307E\u3059</span>
+          <p>\u3053\u306E dashboard \u304B\u3089 VPS Codex CLI \u3092 <code>codex exec</code> \u3067\u6BCE\u56DE\u8D77\u52D5\u3059\u308B\u65E7\u7D4C\u8DEF\u306F\u524A\u9664\u3057\u307E\u3057\u305F\u3002Dashboard Butler \u306F <code>codex app-server</code> bridge \u304C\u5E38\u99D0\u3057\u3066\u3044\u308B\u6642\u3060\u3051 live Codex thread \u306B\u6E21\u3057\u307E\u3059\u3002</p>
+          <span class="connection-note">Dashboard thread \u63A5\u7D9A\u6E96\u5099\u4E2D: bridge \u304C\u672A\u63A5\u7D9A\u306A\u3089 Custom GPT Butler \u304C fallback \u3067\u3059</span>
         </article>
 
       </div>
@@ -63050,7 +63335,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
             window.clearTimeout(reconnectTimer);
             reconnectTimer = null;
           }
-          setStatus("Dashboard thread \u63A5\u7D9A\u6E08\u307F\u3002\u9001\u4FE1\u5185\u5BB9\u306F\u4FDD\u5B58\u3055\u308C\u307E\u3059\u304C\u3001app-server \u306F\u307E\u3060\u672A\u63A5\u7D9A\u3067\u3059\u3002");
+          setStatus("Dashboard thread \u63A5\u7D9A\u6E08\u307F\u3002app-server bridge \u304C\u63A5\u7D9A\u4E2D\u306A\u3089 live Codex thread \u306B\u9001\u308A\u307E\u3059\u3002");
           refreshThread();
         });
         chatSocket.addEventListener("message", (event) => {
@@ -63103,7 +63388,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           relatedIssue: issueNumber
         }));
         textarea.value = "";
-        setStatus("\u9001\u4FE1\u6E08\u307F\u3002app-server \u672A\u63A5\u7D9A\u306E\u305F\u3081\u5B9F\u884C\u306F\u958B\u59CB\u3057\u3066\u3044\u307E\u305B\u3093\u3002");
+        setStatus("\u9001\u4FE1\u6E08\u307F\u3002app-server bridge \u306E\u8FD4\u4FE1\u3092\u5F85\u3063\u3066\u3044\u307E\u3059\u3002");
         if (submitButton) submitButton.disabled = false;
         textarea.focus({ preventScroll: true });
         updateComposerReserve();

--- a/worker.js
+++ b/worker.js
@@ -56046,9 +56046,7 @@ var DashboardChatRoom = class {
       },
       authority: buildDashboardAppServerAuthorityHint({ repository, relatedIssue, text })
     };
-    for (const bridgeSocket of bridgeSockets) {
-      this.sendSocket(bridgeSocket, turnRequest);
-    }
+    this.sendSocket(bridgeSockets[0], turnRequest);
   }
   async acceptAppServerBridgeMessage({ socket, attachment, payload }) {
     const normalized = normalizeDashboardAppServerBridgeEvent(payload, {
@@ -56059,6 +56057,15 @@ var DashboardChatRoom = class {
         type: "error",
         ok: false,
         reason: normalized.reason
+      });
+      return;
+    }
+    const attachmentThreadId = normalizeDashboardThreadId(attachment?.threadId);
+    if (attachmentThreadId && normalized.threadId !== attachmentThreadId) {
+      this.sendSocket(socket, {
+        type: "error",
+        ok: false,
+        reason: "bridge threadId does not match the connected dashboard thread"
       });
       return;
     }


### PR DESCRIPTION
## This PR satisfies Intent

Issue #450 の Dashboard Butler を、旧 `codex exec` 直送ではなく `codex app-server` を使う別経路へ進める。iPhone/iPad の Dashboard chat から通常会話と継続 turn を app-server bridge に渡せる runtime path を追加する。

## Satisfied Success Criteria

- [x] Dashboard 専用の app-server bridge WebSocket route を追加する。
- [x] DashboardChatRoom に `app_server_bridge` role を追加し、owner message を `app_server_turn_requested` として bridge へ送る。
- [x] 普通の会話は repository 解決を必須にせず、bridge 接続時は app-server turn として流す。
- [x] bridge からの `app_server_status` / `app_server_reply_delta` / `app_server_reply` / `app_server_turn_failed` を dashboard thread message に反映する。
- [x] Dashboard thread と Codex thread id の mapping を Durable Object storage に保持する。
- [x] VPS 側 bridge script で `codex app-server` protocol の `initialize` / `thread/start` / `thread/resume` / `turn/start` を使う。
- [x] 旧 Dashboard `codex exec` runner path は再導入しない。

## Unsatisfied Success Criteria

- production deploy はこのPRでは実施していません。
- VPS 上で bridge を systemd 等に常駐設定する作業はこのPRでは実施していません。
- iPhone PWA での live E2E は未実施です。
- Issue #450 close 判定は未実施です。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: #450
- Implementing Success Criteria: Dashboard Butler app-server live bridge の runtime/schema/script slice
- Explicit Non-goals: deploy、credential mutation、permission mutation、systemd 設定、Issue close、Custom GPT fallback の置換、`codex exec` 再導入
- Expected touched files/routes/workflows: `src/worker/runtime.js`, `worker.js`, `scripts/run-dashboard-app-server-bridge.mjs`, `test/dashboard-app-server-bridge.test.js`, `test/worker.test.js`, `docs/butler/dashboard-butler-app-server-live-path.md`, route `GET /v2/dashboard/app-server/ws`
- Affected Issues: #450
- Affected PRs: PR #478/#479 の app-server 決定・旧経路削除の後続
- Affected workflows: test / guarded-policy / reviewer only
- Affected runtime/operator surfaces: Dashboard Butler chat, DashboardChatRoom Durable Object, VPS bridge script
- What may break if we patch narrowly: bridge 未起動時は Dashboard が blocked fallback を表示する。live E2E なしでは #450 完了扱い不可。
- Unknowns to investigate before coding: managed daemon start は local standalone install 不在で失敗したため、このsliceは direct `codex app-server --listen stdio://` を使う。
- Validation needed: unit/integration tests、generated worker parity、live runtime deploy 後の iPhone PWA E2E
- Stop condition: app-server protocol が現行 CLI と合わない、または bridge 常駐/認証境界が実環境で通らない場合は #450 未完了として止める

## File / Line Hypotheses

- file: `src/worker/runtime.js`
  - hypothesis: DashboardChatRoom に bridge role と app-server event mapping を追加すれば、Dashboard WebSocket はフォーム的な保存処理ではなく live chat handoff になる。
  - risk if changed narrowly: bridge 未接続時の UX はまだ fallback 表示に留まる。
  - validation: `node --test test/worker.test.js`, `npm test`
  - related Issue: #450
- file: `scripts/run-dashboard-app-server-bridge.mjs`
  - hypothesis: VPS bridge は `codex app-server --listen stdio://` と Worker WebSocket の間で protocol translation できる。
  - risk if changed narrowly: VPS 常駐管理は未設定なので live E2E には別途 runtime 設定が必要。
  - validation: `node --test test/dashboard-app-server-bridge.test.js`, local app-server initialize smoke
  - related Issue: #450

## Hypothesis Retrospective

- expected: app-server protocol は generated TS に `thread/start` / `turn/start` / event notifications を持つ。
- actual: `codex app-server generate-ts --experimental` で該当 protocol を確認し、`codex app-server --listen stdio://` は initialize に応答した。
- mismatch: `codex app-server daemon start` は local standalone install 不在で失敗したため daemon 前提にしなかった。
- lesson: Dashboard Butler は daemon 管理ではなく、まず bridge script が直接 app-server stdio を所有する形にする。
- should become RAG candidate: yes, #450 app-server bridge implementation note

## Verification Evidence

- Unit: `node --test test/dashboard-app-server-bridge.test.js test/worker.test.js` passed, 166 tests; `node --test test/dashboard-app-server-bridge.test.js` passed, 9 tests; `node --test test/worker.test.js` passed, 163 tests
- Integration: `npm test` passed, 897 tests, 896 pass, 1 skipped
- E2E: 未実施。deploy と iPhone PWA live run はこのPR外
- Manual: `codex app-server generate-ts --out /tmp/codex-app-server-protocol --experimental`; `codex app-server --listen stdio://` initialize response confirmed
- Evidence path/link: local test output on branch `codex/issue-450-dashboard-app-server-bridge`

## Butler Completion Contract

- Owner goal: Dashboard Butler を app-server backed の継続チャットに戻すための runtime bridge path を追加する。
- Butler entrypoint: Dashboard chat WebSocket owner message から `app_server_turn_requested` へ接続。
- Action Schema exposure: Custom GPT fallback は未変更。Dashboard 専用別経路なので Action Schema はこのPRでは変更しない。
- Runtime path: Dashboard PWA -> Worker/Durable Object `/v2/dashboard/chat/:thread/ws` -> `app_server_bridge` -> `codex app-server` -> bridge reply event -> Dashboard thread。
- Runner/runtime truth: test evidence と bridge schema/doc を追加。production runtime truth は未実施。
- Authority boundary: 新しい high-risk authority は追加しない。bridge payload に GO/passkey required hint を含める。
- E2E evidence: このPRでは未実施。live Dashboard E2E は deploy/bridge 常駐後に必要。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 未実施
- Custom GPT Action Schema update: 不要。このPRは Dashboard 専用別経路
- Custom GPT Instructions update: 未変更。fallback として維持
- iPhone Butler live E2E: 未実施

## Related Constitution Rules

- Butler Completion Gate
- Butler-First Operating Principle
- Conversation UX Contract
- Evidence Discipline
- Safety Invariants

## Out-of-scope but NOT implemented

- VPS bridge の systemd/daemon 設定
- production deploy
- credential / permission mutation
- Issue #450 close
- Custom GPT fallback の削除または置換
- generated-worker check 自体の改善

## Extra changes (if any)

None.



