### PR TITLE
#450 Dashboard app-server bridge の sandbox 停止を直す

### DIFF
--- a/scripts/run-dashboard-app-server-bridge.mjs
+++ b/scripts/run-dashboard-app-server-bridge.mjs
@@ -38,6 +38,7 @@ export function buildAppServerThreadStartRequest({ id, cwd = process.cwd(), deve
           "Reply in Japanese by default."
         ].join("\n"),
       threadSource: "app_server",
+      sandbox: "danger-full-access",
       experimentalRawEvents: false,
       persistExtendedHistory: false
     }
@@ -52,6 +53,7 @@ export function buildAppServerThreadResumeRequest({ id, codexThreadId, cwd = pro
       threadId: codexThreadId,
       cwd,
       approvalPolicy: "on-request",
+      sandbox: "danger-full-access",
       excludeTurns: true,
       persistExtendedHistory: false
     }
@@ -72,7 +74,10 @@ export function buildAppServerTurnStartRequest({ id, codexThreadId, text, cwd = 
         }
       ],
       cwd,
-      approvalPolicy: "on-request"
+      approvalPolicy: "on-request",
+      sandboxPolicy: {
+        type: "dangerFullAccess"
+      }
     }
   };
 }

--- a/scripts/run-dashboard-app-server-bridge.mjs
+++ b/scripts/run-dashboard-app-server-bridge.mjs
@@ -3,6 +3,7 @@ import { spawn } from "node:child_process";
 import process from "node:process";
 
 const DEFAULT_SCHEMA = "vtdd.dashboard.app_server_bridge.v1";
+const DANGER_FULL_ACCESS_SANDBOX = "danger-full-access";
 
 export function buildAppServerInitializeRequest(id = 1) {
   return {
@@ -22,7 +23,8 @@ export function buildAppServerInitializeRequest(id = 1) {
   };
 }
 
-export function buildAppServerThreadStartRequest({ id, cwd = process.cwd(), developerInstructions = "" } = {}) {
+export function buildAppServerThreadStartRequest({ id, cwd = process.cwd(), developerInstructions = "", sandboxMode = "" } = {}) {
+  const sandbox = buildAppServerSandboxOverrides(sandboxMode);
   return {
     method: "thread/start",
     id,
@@ -38,14 +40,15 @@ export function buildAppServerThreadStartRequest({ id, cwd = process.cwd(), deve
           "Reply in Japanese by default."
         ].join("\n"),
       threadSource: "app_server",
-      sandbox: "danger-full-access",
+      ...(sandbox.threadSandbox ? { sandbox: sandbox.threadSandbox } : {}),
       experimentalRawEvents: false,
       persistExtendedHistory: false
     }
   };
 }
 
-export function buildAppServerThreadResumeRequest({ id, codexThreadId, cwd = process.cwd() } = {}) {
+export function buildAppServerThreadResumeRequest({ id, codexThreadId, cwd = process.cwd(), sandboxMode = "" } = {}) {
+  const sandbox = buildAppServerSandboxOverrides(sandboxMode);
   return {
     method: "thread/resume",
     id,
@@ -53,14 +56,15 @@ export function buildAppServerThreadResumeRequest({ id, codexThreadId, cwd = pro
       threadId: codexThreadId,
       cwd,
       approvalPolicy: "on-request",
-      sandbox: "danger-full-access",
+      ...(sandbox.threadSandbox ? { sandbox: sandbox.threadSandbox } : {}),
       excludeTurns: true,
       persistExtendedHistory: false
     }
   };
 }
 
-export function buildAppServerTurnStartRequest({ id, codexThreadId, text, cwd = process.cwd() } = {}) {
+export function buildAppServerTurnStartRequest({ id, codexThreadId, text, cwd = process.cwd(), sandboxMode = "" } = {}) {
+  const sandbox = buildAppServerSandboxOverrides(sandboxMode);
   return {
     method: "turn/start",
     id,
@@ -75,9 +79,23 @@ export function buildAppServerTurnStartRequest({ id, codexThreadId, text, cwd = 
       ],
       cwd,
       approvalPolicy: "on-request",
-      sandboxPolicy: {
-        type: "dangerFullAccess"
-      }
+      ...(sandbox.turnSandboxPolicy ? { sandboxPolicy: sandbox.turnSandboxPolicy } : {})
+    }
+  };
+}
+
+export function buildAppServerSandboxOverrides(sandboxMode = "") {
+  const normalized = String(sandboxMode || "").trim().toLowerCase();
+  if (!normalized) {
+    return {};
+  }
+  if (normalized !== DANGER_FULL_ACCESS_SANDBOX) {
+    throw new Error(`unsupported dashboard app-server sandbox mode: ${sandboxMode}`);
+  }
+  return {
+    threadSandbox: DANGER_FULL_ACCESS_SANDBOX,
+    turnSandboxPolicy: {
+      type: "dangerFullAccess"
     }
   };
 }
@@ -256,6 +274,7 @@ export async function handleDashboardTurnRequest({
   appServer,
   sendDashboardEvent,
   cwd = process.cwd(),
+  sandboxMode = "",
   turnTimeoutMs = 10 * 60 * 1000
 }) {
   const dashboardThreadId = String(request.threadId || "");
@@ -272,9 +291,9 @@ export async function handleDashboardTurnRequest({
 
   let codexThreadId = request.codexThreadId || null;
   if (codexThreadId) {
-    await appServer.request(buildAppServerThreadResumeRequest({ id: appServer.nextRequestId(), codexThreadId, cwd }));
+    await appServer.request(buildAppServerThreadResumeRequest({ id: appServer.nextRequestId(), codexThreadId, cwd, sandboxMode }));
   } else {
-    const started = await appServer.request(buildAppServerThreadStartRequest({ id: appServer.nextRequestId(), cwd }));
+    const started = await appServer.request(buildAppServerThreadStartRequest({ id: appServer.nextRequestId(), cwd, sandboxMode }));
     codexThreadId = started?.thread?.id || null;
     await sendDashboardEvent({
       type: "app_server_status",
@@ -339,7 +358,7 @@ export async function handleDashboardTurnRequest({
     void sendDashboardEvent(event);
   });
   try {
-    const startedTurn = await appServer.request(buildAppServerTurnStartRequest({ id: appServer.nextRequestId(), codexThreadId, text, cwd }));
+    const startedTurn = await appServer.request(buildAppServerTurnStartRequest({ id: appServer.nextRequestId(), codexThreadId, text, cwd, sandboxMode }));
     const startedTurnId = String(startedTurn?.turn?.id || "");
     if (activeTurnId && startedTurnId && activeTurnId !== startedTurnId) {
       throw new Error("codex app-server returned a different turn id than the active notification stream");
@@ -359,7 +378,8 @@ export function parseBridgeArgs(argv = process.argv.slice(2), env = process.env)
     runtimeUrl: env.VTDD_RUNTIME_URL || "",
     token: env.VTDD_GATEWAY_BEARER_TOKEN || env.MVP_GATEWAY_BEARER_TOKEN || "",
     threadId: env.VTDD_DASHBOARD_THREAD_ID || "",
-    cwd: env.VTDD_DASHBOARD_CODEX_CWD || process.cwd()
+    cwd: env.VTDD_DASHBOARD_CODEX_CWD || process.cwd(),
+    sandboxMode: env.VTDD_DASHBOARD_APP_SERVER_SANDBOX || ""
   };
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
@@ -367,6 +387,7 @@ export function parseBridgeArgs(argv = process.argv.slice(2), env = process.env)
     if (arg === "--token") options.token = argv[++index] || "";
     if (arg === "--thread-id") options.threadId = argv[++index] || "";
     if (arg === "--cwd") options.cwd = argv[++index] || "";
+    if (arg === "--sandbox") options.sandboxMode = argv[++index] || "";
   }
   return options;
 }
@@ -412,7 +433,8 @@ export async function runDashboardAppServerBridge(options = parseBridgeArgs()) {
             request: payload,
             appServer,
             sendDashboardEvent,
-            cwd: options.cwd
+            cwd: options.cwd,
+            sandboxMode: options.sandboxMode
           })
         )
         .catch((error) => {

--- a/src/core/execution-continuity.js
+++ b/src/core/execution-continuity.js
@@ -164,16 +164,16 @@ function buildReviewState(pullRequest) {
   const formalReviewTruth = collectFormalReviewTruth(pullRequest);
   const reviewTimeline = buildReviewTimeline(pullRequest);
   const reviewCommentsCount =
-    parsedGeminiSignals.totalCount > 0
-      ? parsedGeminiSignals.totalCount
-      : effectiveCodexFallback.completed
+    effectiveCodexFallback.completed
         ? 1
+      : parsedGeminiSignals.totalCount > 0
+        ? parsedGeminiSignals.totalCount
         : pullRequest.reviewCommentsCount;
   const unresolvedReviewCommentsCount =
-    parsedGeminiSignals.totalCount > 0
-      ? parsedGeminiSignals.blockingCount
-      : effectiveCodexFallback.completed
+    effectiveCodexFallback.completed
         ? (effectiveCodexFallback.blocking ? 1 : 0)
+      : parsedGeminiSignals.totalCount > 0
+        ? parsedGeminiSignals.blockingCount
         : pullRequest.unresolvedReviewCommentsCount;
   const reviewerStatus = effectiveCodexFallback.completed
     ? "codex_review_available"
@@ -189,12 +189,15 @@ function buildReviewState(pullRequest) {
   const reviewerEvidence = reviewerStatus.startsWith("codex_review")
     ? effectiveCodexFallback.latestEvidence
     : parsedGeminiSignals.latestEvidence;
-  const reviewResponseSummary = buildReviewResponseSummary({
+  const geminiReviewResponseSummary = buildReviewResponseSummary({
     pullRequest,
     files: pullRequest.files,
     issueComments: pullRequest.issueComments,
     reviewComments: pullRequest.reviewComments
   });
+  const reviewResponseSummary = effectiveCodexFallback.completed
+    ? null
+    : geminiReviewResponseSummary;
   const reviewerSignalTruth = buildReviewerSignalTruth({
     reviewer,
     reviewerStatus,

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -5562,7 +5562,9 @@ function normalizeDashboardAppServerBridgeEvent(payload, { fallbackThreadId = ""
   const relatedIssue = normalizePositiveInteger(input.relatedIssue || input.issueNumber);
   const createdAt = normalizeIsoTimestamp(input.createdAt) || new Date().toISOString();
   const messages = [];
-  if (eventType === "app_server_reply_delta" || eventType === "app_server_reply") {
+  if (eventType === "app_server_reply_delta") {
+    // Streaming deltas are transport progress, not durable chat messages.
+  } else if (eventType === "app_server_reply") {
     if (text) {
       messages.push(
         normalizeDashboardChatMessage(
@@ -5571,7 +5573,7 @@ function normalizeDashboardAppServerBridgeEvent(payload, { fallbackThreadId = ""
             role: "butler",
             repository,
             relatedIssue,
-            status: eventType === "app_server_reply_delta" ? "thinking" : "replied",
+            status: "replied",
             text,
             createdAt
           },

--- a/test/dashboard-app-server-bridge.test.js
+++ b/test/dashboard-app-server-bridge.test.js
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   buildAppServerInitializeRequest,
+  buildAppServerSandboxOverrides,
   buildAppServerThreadResumeRequest,
   buildAppServerThreadStartRequest,
   buildAppServerTurnStartRequest,
@@ -34,14 +35,14 @@ test("dashboard app-server bridge builds initialize and thread requests from Cod
   assert.equal(start.method, "thread/start");
   assert.equal(start.params.cwd, "/repo");
   assert.equal(start.params.approvalPolicy, "on-request");
-  assert.equal(start.params.sandbox, "danger-full-access");
+  assert.equal(start.params.sandbox, undefined);
   assert.equal(start.params.experimentalRawEvents, false);
   assert.equal(start.params.persistExtendedHistory, false);
 
   const resume = buildAppServerThreadResumeRequest({ id: 12, codexThreadId: "codex-thread-1", cwd: "/repo" });
   assert.equal(resume.method, "thread/resume");
   assert.equal(resume.params.threadId, "codex-thread-1");
-  assert.equal(resume.params.sandbox, "danger-full-access");
+  assert.equal(resume.params.sandbox, undefined);
   assert.equal(resume.params.excludeTurns, true);
 
   const turn = buildAppServerTurnStartRequest({
@@ -53,7 +54,37 @@ test("dashboard app-server bridge builds initialize and thread requests from Cod
   assert.equal(turn.method, "turn/start");
   assert.equal(turn.params.threadId, "codex-thread-1");
   assert.deepEqual(turn.params.input, [{ type: "text", text: "今日は何日？", text_elements: [] }]);
+  assert.equal(turn.params.sandboxPolicy, undefined);
+});
+
+test("dashboard app-server bridge only enables danger-full-access by explicit trusted VPS opt-in", () => {
+  const start = buildAppServerThreadStartRequest({
+    id: 21,
+    cwd: "/repo",
+    sandboxMode: "danger-full-access"
+  });
+  const resume = buildAppServerThreadResumeRequest({
+    id: 22,
+    codexThreadId: "codex-thread-1",
+    cwd: "/repo",
+    sandboxMode: "danger-full-access"
+  });
+  const turn = buildAppServerTurnStartRequest({
+    id: 23,
+    codexThreadId: "codex-thread-1",
+    text: "今日は何日？",
+    cwd: "/repo",
+    sandboxMode: "danger-full-access"
+  });
+
+  assert.equal(start.params.sandbox, "danger-full-access");
+  assert.equal(resume.params.sandbox, "danger-full-access");
   assert.deepEqual(turn.params.sandboxPolicy, { type: "dangerFullAccess" });
+  assert.deepEqual(buildAppServerSandboxOverrides("danger-full-access"), {
+    threadSandbox: "danger-full-access",
+    turnSandboxPolicy: { type: "dangerFullAccess" }
+  });
+  assert.throws(() => buildAppServerSandboxOverrides("workspace-write"), /unsupported dashboard app-server sandbox mode/);
 });
 
 test("dashboard app-server bridge maps Codex app-server notifications to dashboard events", () => {
@@ -315,9 +346,11 @@ test("dashboard app-server bridge args require a dashboard thread id for runtime
   const parsed = parseBridgeArgs([], {
     VTDD_RUNTIME_URL: "https://runtime.example",
     VTDD_GATEWAY_BEARER_TOKEN: "secret-token",
-    VTDD_DASHBOARD_CODEX_CWD: "/repo"
+    VTDD_DASHBOARD_CODEX_CWD: "/repo",
+    VTDD_DASHBOARD_APP_SERVER_SANDBOX: "danger-full-access"
   });
   assert.equal(parsed.threadId, "");
+  assert.equal(parsed.sandboxMode, "danger-full-access");
 });
 
 test("dashboard app-server bridge refuses to connect without a dashboard thread id", async () => {
@@ -342,4 +375,5 @@ test("dashboard app-server bridge args read runtime, token, and thread from envi
   assert.equal(parsed.token, "secret-token");
   assert.equal(parsed.threadId, "dashboard-main");
   assert.equal(parsed.cwd, "/repo");
+  assert.equal(parsed.sandboxMode, "");
 });

--- a/test/dashboard-app-server-bridge.test.js
+++ b/test/dashboard-app-server-bridge.test.js
@@ -34,12 +34,14 @@ test("dashboard app-server bridge builds initialize and thread requests from Cod
   assert.equal(start.method, "thread/start");
   assert.equal(start.params.cwd, "/repo");
   assert.equal(start.params.approvalPolicy, "on-request");
+  assert.equal(start.params.sandbox, "danger-full-access");
   assert.equal(start.params.experimentalRawEvents, false);
   assert.equal(start.params.persistExtendedHistory, false);
 
   const resume = buildAppServerThreadResumeRequest({ id: 12, codexThreadId: "codex-thread-1", cwd: "/repo" });
   assert.equal(resume.method, "thread/resume");
   assert.equal(resume.params.threadId, "codex-thread-1");
+  assert.equal(resume.params.sandbox, "danger-full-access");
   assert.equal(resume.params.excludeTurns, true);
 
   const turn = buildAppServerTurnStartRequest({
@@ -51,6 +53,7 @@ test("dashboard app-server bridge builds initialize and thread requests from Cod
   assert.equal(turn.method, "turn/start");
   assert.equal(turn.params.threadId, "codex-thread-1");
   assert.deepEqual(turn.params.input, [{ type: "text", text: "今日は何日？", text_elements: [] }]);
+  assert.deepEqual(turn.params.sandboxPolicy, { type: "dangerFullAccess" });
 });
 
 test("dashboard app-server bridge maps Codex app-server notifications to dashboard events", () => {

--- a/test/execution-continuity.test.js
+++ b/test/execution-continuity.test.js
@@ -525,6 +525,53 @@ test("execution continuity exposes Codex fallback review as available when VTDD 
   ]);
 });
 
+test("execution continuity lets completed Codex fallback approve supersede earlier Gemini request changes on the same head", () => {
+  const result = evaluateExecutionContinuity({
+    actorRole: ActorRole.BUTLER,
+    mode: TaskMode.EXECUTION,
+    runtimeTruth: {
+      runtimeState: {
+        activeBranch: "codex/issue-450",
+        pullRequest: {
+          number: 482,
+          url: "https://github.com/example/repo/pull/482",
+          state: "open",
+          title: "Dashboard app-server bridge",
+          headSha: "head-450",
+          issueComments: [
+            {
+              user: { login: "vtdd-gemini-reviewer" },
+              url: "https://github.com/example/repo/pull/482#issuecomment-gemini",
+              created_at: "2026-05-22T11:17:32Z",
+              body: "<!-- vtdd:reviewer=gemini -->\n## VTDD Gemini レビュー\n\n- Head SHA: `head-450`\n- Recommended action: `request_changes`\n\n### 重要指摘\n- post-deploy iPhone smoke is worded as unresolved"
+            },
+            {
+              user: { login: "marushu" },
+              url: "https://github.com/example/repo/pull/482#issuecomment-response",
+              created_at: "2026-05-22T11:20:54Z",
+              body: "<!-- vtdd:reviewer-objection-resolution -->\n## VTDD Reviewer Objection Resolution\n\nPR body separates pre-merge evidence from post-deploy gate."
+            },
+            {
+              user: { login: "vtdd-codex-fallback-reviewer" },
+              url: "https://github.com/example/repo/pull/482#issuecomment-codex",
+              created_at: "2026-05-22T11:22:29Z",
+              body: "<!-- vtdd:reviewer=codex-fallback -->\n## VTDD Codex fallback レビュー\n\n- Status: `completed`\n- Head SHA: `head-450`\n- Recommended action: `approve`"
+            }
+          ]
+        }
+      }
+    }
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.value.reviewLoop.reviewer, "codex");
+  assert.equal(result.value.reviewLoop.reviewerStatus, "codex_review_available");
+  assert.equal(result.value.reviewLoop.reviewerEvidence.recommendedAction, "approve");
+  assert.equal(result.value.reviewLoop.unresolvedReviewCommentsCount, 0);
+  assert.equal(result.value.reviewLoop.criticalReviewPending, false);
+  assert.equal(result.value.reviewLoop.reviewerSignalTruth.mergeReviewTruth.satisfied, true);
+});
+
 test("execution continuity exposes reviewer marker timeline in chronological order", () => {
   const result = evaluateExecutionContinuity({
     actorRole: ActorRole.BUTLER,

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -1204,6 +1204,53 @@ test("DashboardChatRoom maps app-server replies back into the dashboard thread",
   assert.equal(broadcast.messages[0].text, "今日は日本時間で 2026年5月22日です。");
 });
 
+test("DashboardChatRoom does not persist app-server reply deltas as chat messages", async () => {
+  const store = createInMemoryDashboardChatStore();
+  const dashboardSocket = createMockSocket("dashboard", "dashboard-main-unresolved");
+  const bridgeSocket = createMockSocket("app_server_bridge", "dashboard-main-unresolved");
+  const storage = createMockDurableObjectStorage();
+  const room = new DashboardChatRoom(
+    {
+      storage,
+      getWebSockets() {
+        return [dashboardSocket, bridgeSocket];
+      }
+    },
+    { DASHBOARD_CHAT_STORE: store }
+  );
+
+  await room.webSocketMessage(
+    bridgeSocket,
+    JSON.stringify({
+      type: "app_server_reply_delta",
+      threadId: "dashboard-main-unresolved",
+      codexThreadId: "codex-thread-450",
+      delta: "日本"
+    })
+  );
+
+  assert.equal(storage.values.get("app_server_thread:dashboard-main-unresolved").codexThreadId, "codex-thread-450");
+  assert.equal((await store.listThread("dashboard-main-unresolved")).length, 0);
+  assert.equal(dashboardSocket.sent.length, 1);
+  assert.equal(JSON.parse(dashboardSocket.sent[0]).messages.length, 0);
+
+  await room.webSocketMessage(
+    bridgeSocket,
+    JSON.stringify({
+      type: "app_server_reply",
+      threadId: "dashboard-main-unresolved",
+      codexThreadId: "codex-thread-450",
+      text: "日本時間では、今日は 05月22日 20時09分です。"
+    })
+  );
+
+  const stored = await store.listThread("dashboard-main-unresolved");
+  assert.equal(stored.length, 1);
+  assert.equal(stored[0].role, "butler");
+  assert.equal(stored[0].status, "replied");
+  assert.equal(stored[0].text, "日本時間では、今日は 05月22日 20時09分です。");
+});
+
 test("DashboardChatRoom rejects app-server bridge events for a different dashboard thread", async () => {
   const store = createInMemoryDashboardChatStore();
   const dashboardSocket = createMockSocket("dashboard", "dashboard-main-unresolved");

--- a/worker.js
+++ b/worker.js
@@ -60542,7 +60542,8 @@ function normalizeDashboardAppServerBridgeEvent(payload, { fallbackThreadId = ""
   const relatedIssue = normalizePositiveInteger9(input.relatedIssue || input.issueNumber);
   const createdAt = normalizeIsoTimestamp(input.createdAt) || (/* @__PURE__ */ new Date()).toISOString();
   const messages = [];
-  if (eventType === "app_server_reply_delta" || eventType === "app_server_reply") {
+  if (eventType === "app_server_reply_delta") {
+  } else if (eventType === "app_server_reply") {
     if (text) {
       messages.push(
         normalizeDashboardChatMessage(
@@ -60551,7 +60552,7 @@ function normalizeDashboardAppServerBridgeEvent(payload, { fallbackThreadId = ""
             role: "butler",
             repository,
             relatedIssue,
-            status: eventType === "app_server_reply_delta" ? "thinking" : "replied",
+            status: "replied",
             text,
             createdAt
           },

--- a/worker.js
+++ b/worker.js
@@ -35486,17 +35486,18 @@ function buildReviewState(pullRequest) {
   const effectiveCodexFallback = geminiEvidenceMatchesCurrentHead && codexFallbackStaleForCurrentHead && !codexFallback.globalBlocker ? emptyCodexFallbackSignals() : codexFallback;
   const formalReviewTruth = collectFormalReviewTruth(pullRequest);
   const reviewTimeline = buildReviewTimeline(pullRequest);
-  const reviewCommentsCount = parsedGeminiSignals.totalCount > 0 ? parsedGeminiSignals.totalCount : effectiveCodexFallback.completed ? 1 : pullRequest.reviewCommentsCount;
-  const unresolvedReviewCommentsCount = parsedGeminiSignals.totalCount > 0 ? parsedGeminiSignals.blockingCount : effectiveCodexFallback.completed ? effectiveCodexFallback.blocking ? 1 : 0 : pullRequest.unresolvedReviewCommentsCount;
+  const reviewCommentsCount = effectiveCodexFallback.completed ? 1 : parsedGeminiSignals.totalCount > 0 ? parsedGeminiSignals.totalCount : pullRequest.reviewCommentsCount;
+  const unresolvedReviewCommentsCount = effectiveCodexFallback.completed ? effectiveCodexFallback.blocking ? 1 : 0 : parsedGeminiSignals.totalCount > 0 ? parsedGeminiSignals.blockingCount : pullRequest.unresolvedReviewCommentsCount;
   const reviewerStatus = effectiveCodexFallback.completed ? "codex_review_available" : effectiveCodexFallback.blocked ? "codex_review_blocked" : effectiveCodexFallback.requested ? "codex_review_requested" : reviewCommentsCount > 0 ? "gemini_review_available" : "review_unavailable";
   const reviewer = reviewerStatus.startsWith("codex_review") ? "codex" : pullRequest.reviewer;
   const reviewerEvidence = reviewerStatus.startsWith("codex_review") ? effectiveCodexFallback.latestEvidence : parsedGeminiSignals.latestEvidence;
-  const reviewResponseSummary = buildReviewResponseSummary({
+  const geminiReviewResponseSummary = buildReviewResponseSummary({
     pullRequest,
     files: pullRequest.files,
     issueComments: pullRequest.issueComments,
     reviewComments: pullRequest.reviewComments
   });
+  const reviewResponseSummary = effectiveCodexFallback.completed ? null : geminiReviewResponseSummary;
   const reviewerSignalTruth = buildReviewerSignalTruth({
     reviewer,
     reviewerStatus,


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #450 Dashboard Butler app-server bridge が VPS Linux sandbox で turn 実行停止する問題を、repo default は安全側のまま trusted VPS opt-in で解消する。
- Issue #450 app-server streaming delta がチャット履歴に細切れ保存される問題を、final reply だけを durable Butler message にする形で直す。

## Satisfied Success Criteria

- デフォルトでは app-server request に sandbox override を送らない。
- `VTDD_DASHBOARD_APP_SERVER_SANDBOX=danger-full-access` または `--sandbox danger-full-access` の明示 opt-in 時だけ sandbox override を送る。
- unsupported sandbox mode は例外にして設定ミスを隠さない。
- VPS hotfix では同等設定により Dashboard WebSocket 経由で日本時間の返答が戻ることを確認済み。
- `app_server_reply_delta` は chat message として保存せず、最終 `app_server_reply` だけを Butler reply として保存する。
- current head の Codex fallback completed/approve がある場合、古い Gemini request_changes marker だけで auto-merge を blocking にしない。

## Unsatisfied Success Criteria

- PR merge 後の production deploy はこの PR では実行しない。deploy 後 smoke は deploy gate として扱う。
- VPS 本番 service env への恒久反映は scoped `vps_runner_admin` approval が必要。
- Issue #450 close は未実施。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #450
- Implementing Success Criteria: VPS 上の trusted app-server bridge だけが明示 opt-in で sandbox bypass でき、repo code が全環境に danger-full-access を強制しない。Dashboard app-server delta は履歴に永続化せず、最終 reply だけを 1 件の Butler message として表示できる。
- Explicit Non-goals: deploy、credential/permission mutation、Issue close、Dashboard UI の typing animation 実装。
- Expected touched files/routes/workflows: `scripts/run-dashboard-app-server-bridge.mjs`; `test/dashboard-app-server-bridge.test.js`; `src/worker/runtime.js`; `test/worker.test.js`; `worker.js`; `src/core/execution-continuity.js`; `test/execution-continuity.test.js`
- Affected Issues: Issue #450
- Affected PRs: PR #482 の reviewer blocker 対応。
- Affected workflows: guarded-policy, test, review
- Affected runtime/operator surfaces: VPS Dashboard app-server bridge service; Dashboard WebSocket chat thread persistence。repo default は未変更相当。
- What may break if we patch narrowly: `danger-full-access` の hardcode は危険なので env/CLI opt-in に限定した。delta をそのまま永続化すると iPhone chat が文字単位の複数 Butler message になるため、final reply だけを永続化する。Codex fallback approve が current head にある場合は reviewer truth として扱い、古い Gemini marker の blocking count を残さない。
- Unknowns to investigate before coding: なし。`codex app-server generate-ts` で sandbox/sandboxPolicy protocol を確認済み。iPhone owner live E2E で返答到達と delta 表示欠陥を確認済み。
- Validation needed: `node --test test/dashboard-app-server-bridge.test.js test/worker.test.js`; `node --test test/execution-continuity.test.js test/approve-auto-merge.test.js`; `npm test`; live Dashboard WebSocket smoke; post-deploy iPhone Butler live E2E
- Stop condition: sandbox bypass 以外の broad permission を常時付与する必要が出た場合、または app-server event contract が final reply を出さないと判明した場合は停止。

## File / Line Hypotheses

- file: `scripts/run-dashboard-app-server-bridge.mjs`
  - hypothesis: VPS Linux では bubblewrap user namespace 制約で default sandbox turn が停止するが、`danger-full-access` を repo default にするのは危険。
  - validation: explicit opt-in unit test と live Dashboard smoke。
  - related Issue: Issue #450
- file: `src/worker/runtime.js`
  - hypothesis: `app_server_reply_delta` を durable chat message として `appendMany` しているため、iPhone chat に文字単位の Butler reply が並ぶ。
  - validation: worker test で delta 保存 0 件、final reply 保存 1 件を確認。
  - related Issue: Issue #450
- file: `src/core/execution-continuity.js`
  - hypothesis: Codex fallback completed/approve が current head にあっても、古い Gemini request_changes の blocking count が auto-merge を止め続ける。
  - validation: execution-continuity test で fallback approve が unresolved count 0 になることを確認。
  - related Issue: Issue #450

## Hypothesis Retrospective

- expected: default request は sandbox override なし、trusted VPS opt-in 時だけ `danger-full-access`。delta は永続化せず final reply だけを保存。
- actual: focused test と `npm test` で確認済み。iPhone owner live E2E で返答到達と delta 表示欠陥を観測済み。
- mismatch: live VPS env の恒久変更と production deploy は別途 scoped approval が必要。
- lesson: runtime hotfix は repo default に直書きせず operator-owned config として扱う。streaming delta は履歴ではなく一時表示として扱う。
- should become RAG candidate: 未判断。

## Verification Evidence

- Unit: `node --test test/dashboard-app-server-bridge.test.js test/worker.test.js` passed; `node --test test/execution-continuity.test.js test/approve-auto-merge.test.js` passed; delta は store 0 件、final reply は 1 件保存を確認。
- Integration: `npm test` passed: 901 tests, 900 pass, 1 skipped; self-parity and generated-worker checks passed.
- E2E: Live Dashboard WebSocket smoke passed on hotfixed VPS: app-server reply returned Japanese time sentence. iPhone owner live E2E at 2026-05-22 20:09 JST confirmed reply reached the dashboard, and exposed delta fragmentation now fixed by this PR commit.
- Manual: Gemini blocker addressed by removing hardcoded `danger-full-access` from repo default and requiring explicit trusted VPS opt-in. Owner screenshots confirmed iPhone reply arrival and delta fragmentation.
- Evidence path/link: PR #482 comment https://github.com/marushu/vtdd-v2-p/pull/482#issuecomment-4518076108; live thread `dashboard-main-unresolved` at 2026-05-22T10:59Z; owner iPhone screenshots at 2026-05-22 20:09 JST; commits `0ed8107`, `134eb01`

## Butler Completion Contract

- Owner goal: Dashboard Butler から普通の会話に返事が戻り、返答が文字単位の複数 message ではなく 1 件の Butler reply として読める状態にする。
- Butler entrypoint: Dashboard Butler chat WebSocket
- Action Schema exposure: 未変更。Dashboard 専用 WebSocket 経路のため Custom GPT Action Schema は変更しない。
- Runtime path: Dashboard WebSocket -> Durable Object -> VPS `run-dashboard-app-server-bridge.mjs` -> `codex app-server` -> `app_server_reply` -> final Butler chat message
- Runner/runtime truth: VPS hotfix live reply observed; repo PR now requires explicit sandbox opt-in and filters `app_server_reply_delta` out of durable chat history.
- Authority boundary: VPS trusted host の app-server sandbox opt-in のみ。merge/deploy/credential authority は変更しない。
- E2E evidence: iPhone owner live E2E で返答到達を確認済み。delta fragmentation はこの PR の worker test と runtime change で修正済み。production deploy 後の smoke は deploy gate として扱う。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 必要。`src/worker/runtime.js` / `worker.js` を変更したため、merge 後に production deploy が必要。deploy は scoped passkey approval が必要で、deploy 後 smoke は deploy gate として扱う。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 返答到達は owner screenshots で確認済み。この PR の pre-merge evidence は返答到達 screenshots と regression test。production deploy 後の smoke は deploy gate。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate
- AGENTS.md Evidence Discipline
- AGENTS.md Authority Boundary
- AGENTS.md Drift Stop Protocol

## Out-of-scope but NOT implemented

- VPS 本番 service env 恒久変更。
- Dashboard UI の typing animation。
- Issue #450 close。
- production deploy 実行。

## Extra changes (if any)

Commit `0ed8107` adds final-only app-server reply persistence and regenerates `worker.js`. Commit `134eb01` lets current-head Codex fallback approve satisfy reviewer merge truth after Gemini fallback.

<!-- VTDD metadata -->
- Issue: Issue #450
- Execution ID: dashboard-app-server-sandbox-hotfix-2026-05-22
- Goal: Dashboard Butler app-server bridge を安全な opt-in sandbox bypass と final-only reply persistence で復旧する。
