### PR TITLE
#450 Dashboard bridge reconnects after WebSocket close

### DIFF
--- a/scripts/run-dashboard-app-server-bridge.mjs
+++ b/scripts/run-dashboard-app-server-bridge.mjs
@@ -379,7 +379,8 @@ export function parseBridgeArgs(argv = process.argv.slice(2), env = process.env)
     token: env.VTDD_GATEWAY_BEARER_TOKEN || env.MVP_GATEWAY_BEARER_TOKEN || "",
     threadId: env.VTDD_DASHBOARD_THREAD_ID || "",
     cwd: env.VTDD_DASHBOARD_CODEX_CWD || process.cwd(),
-    sandboxMode: env.VTDD_DASHBOARD_APP_SERVER_SANDBOX || ""
+    sandboxMode: env.VTDD_DASHBOARD_APP_SERVER_SANDBOX || "",
+    reconnectDelayMs: Number(env.VTDD_DASHBOARD_BRIDGE_RECONNECT_DELAY_MS || 1000)
   };
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
@@ -388,6 +389,7 @@ export function parseBridgeArgs(argv = process.argv.slice(2), env = process.env)
     if (arg === "--thread-id") options.threadId = argv[++index] || "";
     if (arg === "--cwd") options.cwd = argv[++index] || "";
     if (arg === "--sandbox") options.sandboxMode = argv[++index] || "";
+    if (arg === "--reconnect-delay-ms") options.reconnectDelayMs = Number(argv[++index] || 1000);
   }
   return options;
 }
@@ -405,19 +407,66 @@ export async function runDashboardAppServerBridge(options = parseBridgeArgs()) {
   if (typeof WebSocket !== "function") {
     throw new Error("global WebSocket is required. Run with Node.js that provides WebSocket.");
   }
+  const endpoint = buildDashboardAppServerBridgeEndpoint(options);
+  const appServer = options.appServer || new JsonLineAppServerClient({ cwd: options.cwd });
+  await appServer.initialize();
+  let reconnects = 0;
+  for (;;) {
+    await connectDashboardAppServerBridgeOnce({
+      ...options,
+      endpoint,
+      appServer,
+      WebSocketImpl: options.WebSocketImpl || WebSocket
+    });
+    if (options.reconnect === false) {
+      return;
+    }
+    if (Number.isFinite(options.reconnectLimit) && reconnects >= options.reconnectLimit) {
+      return;
+    }
+    reconnects += 1;
+    await delay(normalizeReconnectDelayMs(options.reconnectDelayMs));
+  }
+}
+
+export function buildDashboardAppServerBridgeEndpoint(options = {}) {
   const endpoint = new URL("/v2/dashboard/app-server/ws", options.runtimeUrl);
   endpoint.searchParams.set("threadId", options.threadId);
   endpoint.protocol = endpoint.protocol === "https:" ? "wss:" : "ws:";
+  return endpoint;
+}
 
-  const appServer = new JsonLineAppServerClient({ cwd: options.cwd });
-  await appServer.initialize();
-  const bearerProtocol = `vtdd-bearer.${Buffer.from(options.token, "utf8").toString("base64url")}`;
-  const socket = new WebSocket(endpoint, ["vtdd-dashboard-bridge", bearerProtocol]);
-
-  const sendDashboardEvent = async (event) => {
-    socket.send(JSON.stringify(event));
-  };
+export async function connectDashboardAppServerBridgeOnce({
+  endpoint,
+  token,
+  appServer,
+  cwd = process.cwd(),
+  sandboxMode = "",
+  WebSocketImpl = WebSocket
+} = {}) {
+  const bearerProtocol = `vtdd-bearer.${Buffer.from(token, "utf8").toString("base64url")}`;
+  const socket = new WebSocketImpl(endpoint, ["vtdd-dashboard-bridge", bearerProtocol]);
   let turnQueue = Promise.resolve();
+  let settled = false;
+
+  const safeSend = (payload) => {
+    try {
+      socket.send(JSON.stringify(payload));
+    } catch {
+      // The reconnect loop owns transport recovery; failed sends cannot be replayed safely.
+    }
+  };
+
+  const disconnected = new Promise((resolve) => {
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      resolve();
+    };
+    socket.addEventListener("close", finish);
+    socket.addEventListener("error", finish);
+  });
+
   socket.addEventListener("message", (event) => {
     let payload;
     try {
@@ -432,23 +481,32 @@ export async function runDashboardAppServerBridge(options = parseBridgeArgs()) {
           handleDashboardTurnRequest({
             request: payload,
             appServer,
-            sendDashboardEvent,
-            cwd: options.cwd,
-            sandboxMode: options.sandboxMode
+            sendDashboardEvent: async (dashboardEvent) => safeSend(dashboardEvent),
+            cwd,
+            sandboxMode
           })
         )
         .catch((error) => {
-          socket.send(
-            JSON.stringify({
-              type: "app_server_turn_failed",
-              schema: DEFAULT_SCHEMA,
-              threadId: payload.threadId,
-              text: error?.message || "codex app-server bridge failed"
-            })
-          );
+          safeSend({
+            type: "app_server_turn_failed",
+            schema: DEFAULT_SCHEMA,
+            threadId: payload.threadId,
+            text: error?.message || "codex app-server bridge failed"
+          });
         });
     }
   });
+
+  await disconnected;
+}
+
+function normalizeReconnectDelayMs(value) {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) && numeric >= 0 ? numeric : 1000;
+}
+
+function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {

--- a/test/dashboard-app-server-bridge.test.js
+++ b/test/dashboard-app-server-bridge.test.js
@@ -1,11 +1,13 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  buildDashboardAppServerBridgeEndpoint,
   buildAppServerInitializeRequest,
   buildAppServerSandboxOverrides,
   buildAppServerThreadResumeRequest,
   buildAppServerThreadStartRequest,
   buildAppServerTurnStartRequest,
+  connectDashboardAppServerBridgeOnce,
   extractAppServerNotificationTurnId,
   handleDashboardTurnRequest,
   mapAppServerNotificationToDashboardEvent,
@@ -376,4 +378,143 @@ test("dashboard app-server bridge args read runtime, token, and thread from envi
   assert.equal(parsed.threadId, "dashboard-main");
   assert.equal(parsed.cwd, "/repo");
   assert.equal(parsed.sandboxMode, "");
+  assert.equal(parsed.reconnectDelayMs, 1000);
 });
+
+test("dashboard app-server bridge endpoint uses the dashboard app-server thread WebSocket", () => {
+  const endpoint = buildDashboardAppServerBridgeEndpoint({
+    runtimeUrl: "https://runtime.example",
+    threadId: "dashboard-main-unresolved"
+  });
+
+  assert.equal(
+    String(endpoint),
+    "wss://runtime.example/v2/dashboard/app-server/ws?threadId=dashboard-main-unresolved"
+  );
+});
+
+test("dashboard app-server bridge resolves one connection when the WebSocket closes", async () => {
+  const sockets = [];
+  class MockWebSocket {
+    constructor(endpoint, protocols) {
+      this.endpoint = endpoint;
+      this.protocols = protocols;
+      this.listeners = new Map();
+      this.sent = [];
+      sockets.push(this);
+    }
+
+    addEventListener(type, handler) {
+      if (!this.listeners.has(type)) {
+        this.listeners.set(type, new Set());
+      }
+      this.listeners.get(type).add(handler);
+    }
+
+    send(payload) {
+      this.sent.push(payload);
+    }
+
+    emit(type, event = {}) {
+      for (const handler of this.listeners.get(type) || []) {
+        handler(event);
+      }
+    }
+  }
+  const appServer = {
+    nextRequestId() {
+      return 1;
+    },
+    onNotification() {
+      return () => {};
+    },
+    async request() {
+      throw new Error("turn handling should not run in this close-only test");
+    }
+  };
+
+  const once = connectDashboardAppServerBridgeOnce({
+    endpoint: new URL("wss://runtime.example/v2/dashboard/app-server/ws?threadId=dashboard-main"),
+    token: "secret-token",
+    appServer,
+    WebSocketImpl: MockWebSocket
+  });
+  assert.equal(sockets.length, 1);
+  assert.equal(sockets[0].protocols[0], "vtdd-dashboard-bridge");
+  assert.match(sockets[0].protocols[1], /^vtdd-bearer\./);
+
+  sockets[0].emit("close");
+  await once;
+});
+
+test("dashboard app-server bridge reconnects the dashboard WebSocket without reinitializing app-server", async () => {
+  const sockets = [];
+  class MockWebSocket {
+    constructor(endpoint, protocols) {
+      this.endpoint = endpoint;
+      this.protocols = protocols;
+      this.listeners = new Map();
+      sockets.push(this);
+    }
+
+    addEventListener(type, handler) {
+      if (!this.listeners.has(type)) {
+        this.listeners.set(type, new Set());
+      }
+      this.listeners.get(type).add(handler);
+    }
+
+    send() {}
+
+    emit(type, event = {}) {
+      for (const handler of this.listeners.get(type) || []) {
+        handler(event);
+      }
+    }
+  }
+  let initializeCount = 0;
+  const appServer = {
+    async initialize() {
+      initializeCount += 1;
+    },
+    nextRequestId() {
+      return 1;
+    },
+    onNotification() {
+      return () => {};
+    },
+    async request() {
+      throw new Error("turn handling should not run in this reconnect test");
+    }
+  };
+
+  const running = runDashboardAppServerBridge({
+    runtimeUrl: "https://runtime.example",
+    token: "secret-token",
+    threadId: "dashboard-main",
+    cwd: "/repo",
+    appServer,
+    WebSocketImpl: MockWebSocket,
+    reconnectDelayMs: 0,
+    reconnectLimit: 1
+  });
+  await waitFor(() => sockets.length === 1);
+  sockets[0].emit("close");
+  await waitFor(() => sockets.length === 2);
+  sockets[1].emit("close");
+  await running;
+
+  assert.equal(initializeCount, 1);
+  assert.equal(String(sockets[0].endpoint), "wss://runtime.example/v2/dashboard/app-server/ws?threadId=dashboard-main");
+  assert.equal(String(sockets[1].endpoint), "wss://runtime.example/v2/dashboard/app-server/ws?threadId=dashboard-main");
+});
+
+async function waitFor(predicate, { timeoutMs = 1000 } = {}) {
+  const start = Date.now();
+  while (!predicate()) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error("timed out waiting for condition");
+    }
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+}


### PR DESCRIPTION
## This PR satisfies Intent

- Dashboard Butler の app-server bridge が Cloudflare deploy などで WebSocket close/error になった後も、Codex app-server を毎回起動し直さずに同じ app-server client を維持して Dashboard WebSocket だけ再接続する。

## Satisfied Success Criteria

- scripts/run-dashboard-app-server-bridge.mjs が WebSocket close/error を待ち受け、app-server initialize は1回のまま dashboard bridge WebSocket を再接続する。
- WebSocket endpoint 生成を buildDashboardAppServerBridgeEndpoint として分離し、threadId 付き /v2/dashboard/app-server/ws に固定する。
- test/dashboard-app-server-bridge.test.js に close 解決と reconnect-without-reinitialize の回帰テストを追加した。

## Unsatisfied Success Criteria

- この PR は VPS 常駐サービスの本番再起動や iPhone live E2E 完了までは含めない。merge 後に VPS 側の repo 更新または service restart が必要。

## Non-goal violations

Deploy, credential mutation, permission mutation, Issue close, Custom GPT fallback 変更はしない。

## Dry-run Impact Report

- Target Issue: Issue #450
- Implementing Success Criteria: Dashboard Butler が app-server bridge 切断後も次の通常会話を live Codex thread に届けられるよう、bridge 側の WebSocket transport recovery を追加する。
- Explicit Non-goals: Cloudflare Worker route 変更なし。UI 文言変更なし。VPS systemd 常駐設定変更なし。
- Expected touched files/routes/workflows: scripts/run-dashboard-app-server-bridge.mjs, test/dashboard-app-server-bridge.test.js
- Affected Issues: Issue #450
- Affected PRs: PR #482 の app-server path を前提にした後続修正。
- Affected workflows: GitHub Actions test / guarded-policy / review。
- Affected runtime/operator surfaces: Dashboard Butler app-server bridge on VPS。Worker route と Custom GPT Butler は未変更。
- What may break if we patch narrowly: 再接続時に app-server initialize まで繰り返すと、ユーザーが指摘した毎回起動に近い遅延へ戻る。
- Unknowns to investigate before coding: 本番 VPS では deploy 後に bridge WebSocket が切断されたまま再接続されないことを systemd/ss で確認済み。
- Validation needed: node --test test/dashboard-app-server-bridge.test.js; npm test; merge 後の VPS service restart と iPhone live E2E は別 approval で実施。
- Stop condition: app-server protocol 自体の再初期化が必要だと判明した場合、transport reconnect だけで続行すると drift になる。

## File / Line Hypotheses

- file: scripts/run-dashboard-app-server-bridge.mjs
  - hypothesis: runDashboardAppServerBridge が WebSocket close/error を待たず、プロセス存続中に接続だけ死んでも復旧しない。
  - risk if changed narrowly: reconnect ごとに JsonLineAppServerClient.initialize を呼ぶと常駐 app-server の利点を失う。
  - validation: close-only test と reconnect-without-reinitialize test。
  - related Issue: Issue #450

## Hypothesis Retrospective

- expected: close/error 後、app-server initialize は1回のまま dashboard WebSocket のみ再接続する。
- actual: focused test と npm test で確認。
- mismatch: なし。
- lesson: Cloudflare deploy による WebSocket close を bridge 側で通常運用イベントとして扱う必要がある。
- should become RAG candidate: はい。Issue #450 の運用復旧知見として候補。

## Verification Evidence

- Unit: node --test test/dashboard-app-server-bridge.test.js passed.
- Integration: npm test passed, including check:self-parity and check:generated-worker.
- E2E: 未実施。この PR merge 後に VPS service restart/update と iPhone Dashboard live E2E が必要。
- Manual: approval:092d526a-4844-4882-8fe1-74c65e05af76 の範囲で既存 VPS service を restart し、WebSocket established 回復を ss -tpn で確認済み。ただしこの PR のコードは未deploy。
- Evidence path/link: test/dashboard-app-server-bridge.test.js; scripts/run-dashboard-app-server-bridge.mjs

## Butler Completion Contract

- Owner goal: iPhone Dashboard Butler で、deploy や Worker/DO の WebSocket 切断後も返事が返らなくなる状態を避ける。
- Butler entrypoint: Dashboard /dashboard の通常チャット入力。
- Action Schema exposure: 変更なし。Dashboard app-server bridge 専用経路の内部修正。
- Runtime path: scripts/run-dashboard-app-server-bridge.mjs -> /v2/dashboard/app-server/ws -> DashboardChatRoom -> codex app-server.
- Runner/runtime truth: ローカルテストで reconnect behavior を確認。本番反映には merge 後の VPS 側更新または service restart が必要。
- Authority boundary: 新しい high-risk authority は追加しない。VPS restart/update は別途 scoped passkey approval が必要。
- E2E evidence: 未完了。merge 後に iPhone Dashboard から通常会話が返ること、deploy/reconnect 後も返ることを確認する。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 不要。この PR は Worker 生成物に影響しない。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: merge 後に必要。

## Related Constitution Rules

- Butler Completion Gate
- Drift Stop Protocol
- Evidence Discipline
- Authority Boundary

## Out-of-scope but NOT implemented

- VPS 常駐 unit の変更。
- Dashboard UI の読みやすさ改善。
- Issue #450 close 判断。

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #450
- Execution ID: mac-codex-2026-05-22-dashboard-bridge-reconnect
- Goal: Issue #450 Dashboard app-server bridge reconnect after WebSocket close
