### PR TITLE
#450 Dashboard bridge answers app-server approval requests

### DIFF
--- a/scripts/run-dashboard-app-server-bridge.mjs
+++ b/scripts/run-dashboard-app-server-bridge.mjs
@@ -140,10 +140,9 @@ export function buildAppServerRequestApprovalResponse(message) {
   if (method === "item/permissions/requestApproval") {
     return {
       id: message.id,
-      result: {
-        permissions: {},
-        scope: "turn",
-        strictAutoReview: true
+      error: {
+        code: -32001,
+        message: "Dashboard bridge does not grant app-server permission escalation"
       }
     };
   }

--- a/scripts/run-dashboard-app-server-bridge.mjs
+++ b/scripts/run-dashboard-app-server-bridge.mjs
@@ -301,7 +301,7 @@ export class JsonLineAppServerClient {
       } catch {
         continue;
       }
-      if (message.id && this.pending.has(message.id)) {
+      if (message.id !== undefined && message.id !== null && this.pending.has(message.id)) {
         const pending = this.pending.get(message.id);
         this.pending.delete(message.id);
         if (message.error) {

--- a/scripts/run-dashboard-app-server-bridge.mjs
+++ b/scripts/run-dashboard-app-server-bridge.mjs
@@ -100,6 +100,62 @@ export function buildAppServerSandboxOverrides(sandboxMode = "") {
   };
 }
 
+export function buildAppServerRequestApprovalResponse(message) {
+  const method = String(message?.method || "");
+  if ((message?.id === undefined || message?.id === null) || !method) {
+    return null;
+  }
+  if (method === "item/commandExecution/requestApproval") {
+    return {
+      id: message.id,
+      result: {
+        decision: "decline"
+      }
+    };
+  }
+  if (method === "execCommandApproval") {
+    return {
+      id: message.id,
+      result: {
+        decision: "denied"
+      }
+    };
+  }
+  if (method === "item/fileChange/requestApproval") {
+    return {
+      id: message.id,
+      result: {
+        decision: "decline"
+      }
+    };
+  }
+  if (method === "applyPatchApproval") {
+    return {
+      id: message.id,
+      result: {
+        decision: "denied"
+      }
+    };
+  }
+  if (method === "item/permissions/requestApproval") {
+    return {
+      id: message.id,
+      result: {
+        permissions: {},
+        scope: "turn",
+        strictAutoReview: true
+      }
+    };
+  }
+  return {
+    id: message.id,
+    error: {
+      code: -32601,
+      message: `Dashboard bridge does not support app-server request method: ${method}`
+    }
+  };
+}
+
 export function mapAppServerNotificationToDashboardEvent(message, context = {}) {
   const method = String(message?.method || "");
   const params = message?.params && typeof message.params === "object" ? message.params : {};
@@ -253,6 +309,11 @@ export class JsonLineAppServerClient {
         } else {
           pending.resolve(message.result);
         }
+        continue;
+      }
+      const approvalResponse = buildAppServerRequestApprovalResponse(message);
+      if (approvalResponse) {
+        this.write(approvalResponse);
         continue;
       }
       for (const handler of this.notificationHandlers) {

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -284,6 +284,11 @@ export class DashboardChatRoom {
 
     const messages = store ? await store.appendMany(threadId, [ownerMessage]) : [ownerMessage].filter(Boolean);
     await this.broadcastThread({ threadId, messages });
+    await this.broadcastTransientStatus({
+      threadId,
+      status: "thinking",
+      text: "app-server bridge の返信を待っています"
+    });
     const mapping = await this.readAppServerThreadMapping(threadId);
     const turnRequest = {
       type: "app_server_turn_requested",

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -282,19 +282,7 @@ export class DashboardChatRoom {
       return;
     }
 
-    const pendingMessage = normalizeDashboardChatMessage(
-      {
-        threadId,
-        role: "butler",
-        repository,
-        relatedIssue,
-        status: "thinking",
-        text: "codex app-server に送信しました。返信を待っています。",
-        createdAt: new Date(Date.parse(now) + 1).toISOString()
-      },
-      { threadId }
-    );
-    const messages = store ? await store.appendMany(threadId, [ownerMessage, pendingMessage]) : [ownerMessage, pendingMessage].filter(Boolean);
+    const messages = store ? await store.appendMany(threadId, [ownerMessage]) : [ownerMessage].filter(Boolean);
     await this.broadcastThread({ threadId, messages });
     const mapping = await this.readAppServerThreadMapping(threadId);
     const turnRequest = {
@@ -344,8 +332,14 @@ export class DashboardChatRoom {
         updatedAt: normalized.createdAt
       });
     }
+    if (normalized.transientStatus) {
+      await this.broadcastTransientStatus({
+        threadId: normalized.threadId,
+        status: normalized.transientStatus,
+        text: normalized.text
+      });
+    }
     if (normalized.messages.length === 0) {
-      await this.broadcastThread({ threadId: normalized.threadId });
       return;
     }
     const store = resolveDashboardChatStore(this.env);
@@ -362,6 +356,27 @@ export class DashboardChatRoom {
       ok: true,
       threadId,
       messages: resolvedMessages
+    });
+    for (const socket of this.connectedSockets()) {
+      const attachment = this.getSocketAttachment(socket);
+      if (
+        attachment.role !== "vps_runner" &&
+        attachment.role !== "app_server_bridge" &&
+        (!attachment.threadId || attachment.threadId === threadId) &&
+        isSocketOpen(socket)
+      ) {
+        socket.send(payload);
+      }
+    }
+  }
+
+  async broadcastTransientStatus({ threadId, status, text }) {
+    const payload = JSON.stringify({
+      type: "transient_status",
+      ok: true,
+      threadId,
+      status,
+      text
     });
     for (const socket of this.connectedSockets()) {
       const attachment = this.getSocketAttachment(socket);
@@ -5562,6 +5577,7 @@ function normalizeDashboardAppServerBridgeEvent(payload, { fallbackThreadId = ""
   const relatedIssue = normalizePositiveInteger(input.relatedIssue || input.issueNumber);
   const createdAt = normalizeIsoTimestamp(input.createdAt) || new Date().toISOString();
   const messages = [];
+  let transientStatus = "";
   if (eventType === "app_server_reply_delta") {
     // Streaming deltas are transport progress, not durable chat messages.
   } else if (eventType === "app_server_reply") {
@@ -5597,26 +5613,15 @@ function normalizeDashboardAppServerBridgeEvent(payload, { fallbackThreadId = ""
       )
     );
   } else if (eventType === "app_server_status") {
-    messages.push(
-      normalizeDashboardChatMessage(
-        {
-          threadId,
-          role: "system",
-          repository,
-          relatedIssue,
-          status: status === "replied" ? "replied" : "thinking",
-          text: text || "codex app-server is working.",
-          createdAt
-        },
-        { threadId }
-      )
-    );
+    transientStatus = status === "replied" ? "replied" : "thinking";
   }
   return {
     ok: true,
     threadId,
     codexThreadId,
     createdAt,
+    text,
+    transientStatus,
     messages: messages.filter(Boolean)
   };
 }
@@ -8266,7 +8271,8 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
     textarea { width: 100%; min-height: 44px; max-height: 160px; border: 0; outline: 0; resize: vertical; padding: 10px 2px; color: var(--text); background: transparent; font: inherit; line-height: 1.45; }
     textarea::placeholder { color: var(--muted); }
     .send-button { width: 44px; height: 44px; border-radius: 999px; background: var(--text); color: var(--page-bg); font-size: 22px; }
-    .composer-status { padding-left: 16px; color: var(--muted); font-size: 12px; }
+    .composer-status { min-height: 18px; padding-left: 16px; color: var(--muted); font-size: 12px; }
+    .composer-status.thinking::after { content: ""; display: inline-block; width: 1.4em; text-align: left; animation: thinkingDots 1.2s steps(4, end) infinite; }
     .sidebar { position: sticky; top: 16px; align-self: start; max-height: calc(100dvh - 32px); overflow: auto; border: 1px solid var(--border); border-radius: 18px; background: var(--panel); }
     .sidebar > summary { display: flex; justify-content: space-between; align-items: center; gap: 10px; min-height: 58px; padding: 14px; list-style: none; }
     .sidebar > summary::-webkit-details-marker { display: none; }
@@ -8488,8 +8494,17 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         });
       }
 
-      function setStatus(text) {
+      function setStatus(text, options = {}) {
         status.textContent = text;
+        status.classList.toggle("thinking", options.thinking === true);
+        if (options.temporary === true) {
+          const expected = text;
+          window.setTimeout(() => {
+            if (status.textContent === expected) {
+              setStatus("Dashboard thread 接続済み。");
+            }
+          }, 2400);
+        }
       }
 
       function appendMessage(message) {
@@ -8661,6 +8676,16 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
             const body = JSON.parse(event.data || "{}");
             if (body.type === "thread" && body.ok) {
               renderThread(body.messages || [], { replace: false });
+              const lastMessage = Array.isArray(body.messages) ? body.messages[body.messages.length - 1] : null;
+              if (lastMessage?.role === "butler" && lastMessage?.status === "replied") {
+                setStatus("返信を受信しました。", { temporary: true });
+              }
+            } else if (body.type === "transient_status" && body.ok) {
+              const isThinking = body.status === "thinking";
+              setStatus(body.text || (isThinking ? "codex app-server が応答を生成しています" : "codex app-server の応答が完了しました。"), {
+                thinking: isThinking,
+                temporary: !isThinking
+              });
             } else if (body.type === "error") {
               appendError(body.reason || "WebSocket message error");
             }
@@ -8696,7 +8721,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           return;
         }
         if (submitButton) submitButton.disabled = true;
-        setStatus("送信中です。Dashboard thread に保存します。");
+        setStatus("送信中です", { thinking: true });
         chatSocket.send(JSON.stringify({
           type: "owner_message",
           threadId,
@@ -8706,7 +8731,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           relatedIssue: issueNumber
         }));
         textarea.value = "";
-        setStatus("送信済み。app-server bridge の返信を待っています。");
+        setStatus("app-server bridge の返信を待っています", { thinking: true });
         if (submitButton) submitButton.disabled = false;
         textarea.focus({ preventScroll: true });
         updateComposerReserve();

--- a/test/dashboard-app-server-bridge.test.js
+++ b/test/dashboard-app-server-bridge.test.js
@@ -3,6 +3,7 @@ import test from "node:test";
 import {
   buildDashboardAppServerBridgeEndpoint,
   buildAppServerInitializeRequest,
+  buildAppServerRequestApprovalResponse,
   buildAppServerSandboxOverrides,
   buildAppServerThreadResumeRequest,
   buildAppServerThreadStartRequest,
@@ -10,6 +11,7 @@ import {
   connectDashboardAppServerBridgeOnce,
   extractAppServerNotificationTurnId,
   handleDashboardTurnRequest,
+  JsonLineAppServerClient,
   mapAppServerNotificationToDashboardEvent,
   matchesAppServerTurnNotification,
   parseBridgeArgs,
@@ -87,6 +89,131 @@ test("dashboard app-server bridge only enables danger-full-access by explicit tr
     turnSandboxPolicy: { type: "dangerFullAccess" }
   });
   assert.throws(() => buildAppServerSandboxOverrides("workspace-write"), /unsupported dashboard app-server sandbox mode/);
+});
+
+test("dashboard app-server bridge answers command approvals without granting execution", () => {
+  assert.deepEqual(
+    buildAppServerRequestApprovalResponse({
+      id: 0,
+      method: "item/commandExecution/requestApproval",
+      params: { commandActions: [{ type: "read" }] }
+    }),
+    { id: 0, result: { decision: "decline" } }
+  );
+  assert.deepEqual(
+    buildAppServerRequestApprovalResponse({
+      id: 32,
+      method: "execCommandApproval",
+      params: { parsedCmd: [{ type: "search" }] }
+    }),
+    { id: 32, result: { decision: "denied" } }
+  );
+});
+
+test("dashboard app-server bridge declines write, patch, permission, and unsafe command approvals", () => {
+  assert.deepEqual(
+    buildAppServerRequestApprovalResponse({
+      id: 41,
+      method: "item/commandExecution/requestApproval",
+      params: { commandActions: [{ type: "write" }] }
+    }),
+    { id: 41, result: { decision: "decline" } }
+  );
+  assert.deepEqual(
+    buildAppServerRequestApprovalResponse({
+      id: 42,
+      method: "item/fileChange/requestApproval",
+      params: {}
+    }),
+    { id: 42, result: { decision: "decline" } }
+  );
+  assert.deepEqual(
+    buildAppServerRequestApprovalResponse({
+      id: 43,
+      method: "applyPatchApproval",
+      params: {}
+    }),
+    { id: 43, result: { decision: "denied" } }
+  );
+  assert.deepEqual(
+    buildAppServerRequestApprovalResponse({
+      id: 44,
+      method: "item/permissions/requestApproval",
+      params: {}
+    }),
+    {
+      id: 44,
+      result: {
+        permissions: {},
+        scope: "turn",
+        strictAutoReview: true
+      }
+    }
+  );
+  assert.deepEqual(
+    buildAppServerRequestApprovalResponse({
+      id: 45,
+      method: "future/requestApproval",
+      params: {}
+    }),
+    {
+      id: 45,
+      error: {
+        code: -32601,
+        message: "Dashboard bridge does not support app-server request method: future/requestApproval"
+      }
+    }
+  );
+});
+
+test("dashboard app-server bridge writes JSON-RPC responses for app-server approval requests", () => {
+  const client = new JsonLineAppServerClient({ command: "unused" });
+  const writes = [];
+  const notifications = [];
+  client.child = {
+    stdin: {
+      write(chunk) {
+        writes.push(JSON.parse(String(chunk).trim()));
+      }
+    },
+    kill() {}
+  };
+  client.onNotification((message) => notifications.push(message));
+
+  client.handleChunk(
+    [
+      JSON.stringify({
+        id: 0,
+        method: "item/commandExecution/requestApproval",
+        params: {
+          cwd: "/repo",
+          commandActions: [{ type: "read", path: "package.json" }]
+        }
+      }),
+      JSON.stringify({
+        id: 1,
+        method: "future/requestApproval",
+        params: {}
+      }),
+      JSON.stringify({
+        method: "turn/started",
+        params: { threadId: "codex-thread-1" }
+      })
+    ].join("\n") + "\n"
+  );
+
+  assert.deepEqual(writes, [
+    { id: 0, result: { decision: "decline" } },
+    {
+      id: 1,
+      error: {
+        code: -32601,
+        message: "Dashboard bridge does not support app-server request method: future/requestApproval"
+      }
+    }
+  ]);
+  assert.equal(notifications.length, 1);
+  assert.equal(notifications[0].method, "turn/started");
 });
 
 test("dashboard app-server bridge maps Codex app-server notifications to dashboard events", () => {

--- a/test/dashboard-app-server-bridge.test.js
+++ b/test/dashboard-app-server-bridge.test.js
@@ -216,6 +216,26 @@ test("dashboard app-server bridge writes JSON-RPC responses for app-server appro
   assert.equal(notifications[0].method, "turn/started");
 });
 
+test("dashboard app-server bridge resolves pending JSON-RPC response id zero", async () => {
+  const client = new JsonLineAppServerClient({ command: "unused" });
+  const writes = [];
+  client.nextId = 0;
+  client.child = {
+    stdin: {
+      write(chunk) {
+        writes.push(JSON.parse(String(chunk).trim()));
+      }
+    },
+    kill() {}
+  };
+
+  const pending = client.request({ method: "thread/start", params: {} });
+  assert.equal(writes[0].id, 0);
+  client.handleChunk(JSON.stringify({ id: 0, result: { thread: { id: "codex-thread-0" } } }) + "\n");
+
+  assert.deepEqual(await pending, { thread: { id: "codex-thread-0" } });
+});
+
 test("dashboard app-server bridge maps Codex app-server notifications to dashboard events", () => {
   const delta = mapAppServerNotificationToDashboardEvent(
     {

--- a/test/dashboard-app-server-bridge.test.js
+++ b/test/dashboard-app-server-bridge.test.js
@@ -143,10 +143,9 @@ test("dashboard app-server bridge declines write, patch, permission, and unsafe 
     }),
     {
       id: 44,
-      result: {
-        permissions: {},
-        scope: "turn",
-        strictAutoReview: true
+      error: {
+        code: -32001,
+        message: "Dashboard bridge does not grant app-server permission escalation"
       }
     }
   );

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -1131,11 +1131,15 @@ test("DashboardChatRoom sends ordinary owner turns to connected app-server bridg
   assert.equal(turnRequest.appServer.turnMethod, "turn/start");
   assert.equal(turnRequest.authority.ordinaryConversationAllowed, true);
 
-  assert.equal(dashboardSocket.sent.length, 1);
+  assert.equal(dashboardSocket.sent.length, 2);
   const broadcast = JSON.parse(dashboardSocket.sent[0]);
   assert.equal(broadcast.messages.length, 1);
   assert.equal(broadcast.messages[0].role, "owner");
   assert.equal(broadcast.messages[0].text, "今日は何月何日？日本時間を答えて");
+  const status = JSON.parse(dashboardSocket.sent[1]);
+  assert.equal(status.type, "transient_status");
+  assert.equal(status.status, "thinking");
+  assert.equal(status.text, "app-server bridge の返信を待っています");
 });
 
 test("DashboardChatRoom sends each owner turn to only one app-server bridge for a thread", async () => {

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -1133,11 +1133,9 @@ test("DashboardChatRoom sends ordinary owner turns to connected app-server bridg
 
   assert.equal(dashboardSocket.sent.length, 1);
   const broadcast = JSON.parse(dashboardSocket.sent[0]);
-  assert.equal(broadcast.messages.length, 2);
+  assert.equal(broadcast.messages.length, 1);
   assert.equal(broadcast.messages[0].role, "owner");
-  assert.equal(broadcast.messages[1].role, "butler");
-  assert.equal(broadcast.messages[1].status, "thinking");
-  assert.match(broadcast.messages[1].text, /app-server/);
+  assert.equal(broadcast.messages[0].text, "今日は何月何日？日本時間を答えて");
 });
 
 test("DashboardChatRoom sends each owner turn to only one app-server bridge for a thread", async () => {
@@ -1231,8 +1229,7 @@ test("DashboardChatRoom does not persist app-server reply deltas as chat message
 
   assert.equal(storage.values.get("app_server_thread:dashboard-main-unresolved").codexThreadId, "codex-thread-450");
   assert.equal((await store.listThread("dashboard-main-unresolved")).length, 0);
-  assert.equal(dashboardSocket.sent.length, 1);
-  assert.equal(JSON.parse(dashboardSocket.sent[0]).messages.length, 0);
+  assert.equal(dashboardSocket.sent.length, 0);
 
   await room.webSocketMessage(
     bridgeSocket,
@@ -1249,6 +1246,41 @@ test("DashboardChatRoom does not persist app-server reply deltas as chat message
   assert.equal(stored[0].role, "butler");
   assert.equal(stored[0].status, "replied");
   assert.equal(stored[0].text, "日本時間では、今日は 05月22日 20時09分です。");
+});
+
+test("DashboardChatRoom sends app-server thinking status as transient UI state", async () => {
+  const store = createInMemoryDashboardChatStore();
+  const dashboardSocket = createMockSocket("dashboard", "dashboard-main-unresolved");
+  const bridgeSocket = createMockSocket("app_server_bridge", "dashboard-main-unresolved");
+  const storage = createMockDurableObjectStorage();
+  const room = new DashboardChatRoom(
+    {
+      storage,
+      getWebSockets() {
+        return [dashboardSocket, bridgeSocket];
+      }
+    },
+    { DASHBOARD_CHAT_STORE: store }
+  );
+
+  await room.webSocketMessage(
+    bridgeSocket,
+    JSON.stringify({
+      type: "app_server_status",
+      status: "thinking",
+      threadId: "dashboard-main-unresolved",
+      codexThreadId: "codex-thread-450",
+      text: "codex app-server が応答を生成しています。"
+    })
+  );
+
+  assert.equal(storage.values.get("app_server_thread:dashboard-main-unresolved").codexThreadId, "codex-thread-450");
+  assert.equal((await store.listThread("dashboard-main-unresolved")).length, 0);
+  assert.equal(dashboardSocket.sent.length, 1);
+  const status = JSON.parse(dashboardSocket.sent[0]);
+  assert.equal(status.type, "transient_status");
+  assert.equal(status.status, "thinking");
+  assert.equal(status.text, "codex app-server が応答を生成しています。");
 });
 
 test("DashboardChatRoom rejects app-server bridge events for a different dashboard thread", async () => {

--- a/worker.js
+++ b/worker.js
@@ -56017,6 +56017,11 @@ var DashboardChatRoom = class {
     }
     const messages = store ? await store.appendMany(threadId, [ownerMessage]) : [ownerMessage].filter(Boolean);
     await this.broadcastThread({ threadId, messages });
+    await this.broadcastTransientStatus({
+      threadId,
+      status: "thinking",
+      text: "app-server bridge \u306E\u8FD4\u4FE1\u3092\u5F85\u3063\u3066\u3044\u307E\u3059"
+    });
     const mapping = await this.readAppServerThreadMapping(threadId);
     const turnRequest = {
       type: "app_server_turn_requested",

--- a/worker.js
+++ b/worker.js
@@ -56015,19 +56015,7 @@ var DashboardChatRoom = class {
       await this.broadcastThread({ threadId, messages: messages2 });
       return;
     }
-    const pendingMessage = normalizeDashboardChatMessage(
-      {
-        threadId,
-        role: "butler",
-        repository,
-        relatedIssue,
-        status: "thinking",
-        text: "codex app-server \u306B\u9001\u4FE1\u3057\u307E\u3057\u305F\u3002\u8FD4\u4FE1\u3092\u5F85\u3063\u3066\u3044\u307E\u3059\u3002",
-        createdAt: new Date(Date.parse(now) + 1).toISOString()
-      },
-      { threadId }
-    );
-    const messages = store ? await store.appendMany(threadId, [ownerMessage, pendingMessage]) : [ownerMessage, pendingMessage].filter(Boolean);
+    const messages = store ? await store.appendMany(threadId, [ownerMessage]) : [ownerMessage].filter(Boolean);
     await this.broadcastThread({ threadId, messages });
     const mapping = await this.readAppServerThreadMapping(threadId);
     const turnRequest = {
@@ -56076,8 +56064,14 @@ var DashboardChatRoom = class {
         updatedAt: normalized.createdAt
       });
     }
+    if (normalized.transientStatus) {
+      await this.broadcastTransientStatus({
+        threadId: normalized.threadId,
+        status: normalized.transientStatus,
+        text: normalized.text
+      });
+    }
     if (normalized.messages.length === 0) {
-      await this.broadcastThread({ threadId: normalized.threadId });
       return;
     }
     const store = resolveDashboardChatStore(this.env);
@@ -56091,6 +56085,21 @@ var DashboardChatRoom = class {
       ok: true,
       threadId,
       messages: resolvedMessages
+    });
+    for (const socket of this.connectedSockets()) {
+      const attachment = this.getSocketAttachment(socket);
+      if (attachment.role !== "vps_runner" && attachment.role !== "app_server_bridge" && (!attachment.threadId || attachment.threadId === threadId) && isSocketOpen(socket)) {
+        socket.send(payload);
+      }
+    }
+  }
+  async broadcastTransientStatus({ threadId, status, text }) {
+    const payload = JSON.stringify({
+      type: "transient_status",
+      ok: true,
+      threadId,
+      status,
+      text
     });
     for (const socket of this.connectedSockets()) {
       const attachment = this.getSocketAttachment(socket);
@@ -60543,6 +60552,7 @@ function normalizeDashboardAppServerBridgeEvent(payload, { fallbackThreadId = ""
   const relatedIssue = normalizePositiveInteger9(input.relatedIssue || input.issueNumber);
   const createdAt = normalizeIsoTimestamp(input.createdAt) || (/* @__PURE__ */ new Date()).toISOString();
   const messages = [];
+  let transientStatus = "";
   if (eventType === "app_server_reply_delta") {
   } else if (eventType === "app_server_reply") {
     if (text) {
@@ -60577,26 +60587,15 @@ function normalizeDashboardAppServerBridgeEvent(payload, { fallbackThreadId = ""
       )
     );
   } else if (eventType === "app_server_status") {
-    messages.push(
-      normalizeDashboardChatMessage(
-        {
-          threadId,
-          role: "system",
-          repository,
-          relatedIssue,
-          status: status === "replied" ? "replied" : "thinking",
-          text: text || "codex app-server is working.",
-          createdAt
-        },
-        { threadId }
-      )
-    );
+    transientStatus = status === "replied" ? "replied" : "thinking";
   }
   return {
     ok: true,
     threadId,
     codexThreadId,
     createdAt,
+    text,
+    transientStatus,
     messages: messages.filter(Boolean)
   };
 }
@@ -62957,7 +62956,8 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
     textarea { width: 100%; min-height: 44px; max-height: 160px; border: 0; outline: 0; resize: vertical; padding: 10px 2px; color: var(--text); background: transparent; font: inherit; line-height: 1.45; }
     textarea::placeholder { color: var(--muted); }
     .send-button { width: 44px; height: 44px; border-radius: 999px; background: var(--text); color: var(--page-bg); font-size: 22px; }
-    .composer-status { padding-left: 16px; color: var(--muted); font-size: 12px; }
+    .composer-status { min-height: 18px; padding-left: 16px; color: var(--muted); font-size: 12px; }
+    .composer-status.thinking::after { content: ""; display: inline-block; width: 1.4em; text-align: left; animation: thinkingDots 1.2s steps(4, end) infinite; }
     .sidebar { position: sticky; top: 16px; align-self: start; max-height: calc(100dvh - 32px); overflow: auto; border: 1px solid var(--border); border-radius: 18px; background: var(--panel); }
     .sidebar > summary { display: flex; justify-content: space-between; align-items: center; gap: 10px; min-height: 58px; padding: 14px; list-style: none; }
     .sidebar > summary::-webkit-details-marker { display: none; }
@@ -63179,8 +63179,17 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         });
       }
 
-      function setStatus(text) {
+      function setStatus(text, options = {}) {
         status.textContent = text;
+        status.classList.toggle("thinking", options.thinking === true);
+        if (options.temporary === true) {
+          const expected = text;
+          window.setTimeout(() => {
+            if (status.textContent === expected) {
+              setStatus("Dashboard thread \u63A5\u7D9A\u6E08\u307F\u3002");
+            }
+          }, 2400);
+        }
       }
 
       function appendMessage(message) {
@@ -63352,6 +63361,16 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
             const body = JSON.parse(event.data || "{}");
             if (body.type === "thread" && body.ok) {
               renderThread(body.messages || [], { replace: false });
+              const lastMessage = Array.isArray(body.messages) ? body.messages[body.messages.length - 1] : null;
+              if (lastMessage?.role === "butler" && lastMessage?.status === "replied") {
+                setStatus("\u8FD4\u4FE1\u3092\u53D7\u4FE1\u3057\u307E\u3057\u305F\u3002", { temporary: true });
+              }
+            } else if (body.type === "transient_status" && body.ok) {
+              const isThinking = body.status === "thinking";
+              setStatus(body.text || (isThinking ? "codex app-server \u304C\u5FDC\u7B54\u3092\u751F\u6210\u3057\u3066\u3044\u307E\u3059" : "codex app-server \u306E\u5FDC\u7B54\u304C\u5B8C\u4E86\u3057\u307E\u3057\u305F\u3002"), {
+                thinking: isThinking,
+                temporary: !isThinking
+              });
             } else if (body.type === "error") {
               appendError(body.reason || "WebSocket message error");
             }
@@ -63387,7 +63406,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           return;
         }
         if (submitButton) submitButton.disabled = true;
-        setStatus("\u9001\u4FE1\u4E2D\u3067\u3059\u3002Dashboard thread \u306B\u4FDD\u5B58\u3057\u307E\u3059\u3002");
+        setStatus("\u9001\u4FE1\u4E2D\u3067\u3059", { thinking: true });
         chatSocket.send(JSON.stringify({
           type: "owner_message",
           threadId,
@@ -63397,7 +63416,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           relatedIssue: issueNumber
         }));
         textarea.value = "";
-        setStatus("\u9001\u4FE1\u6E08\u307F\u3002app-server bridge \u306E\u8FD4\u4FE1\u3092\u5F85\u3063\u3066\u3044\u307E\u3059\u3002");
+        setStatus("app-server bridge \u306E\u8FD4\u4FE1\u3092\u5F85\u3063\u3066\u3044\u307E\u3059", { thinking: true });
         if (submitButton) submitButton.disabled = false;
         textarea.focus({ preventScroll: true });
         updateComposerReserve();


### PR DESCRIPTION
## This PR satisfies Intent

- Dashboard Butler の app-server bridge が Codex app-server の approval/server request や JSON-RPC id=0 response を取りこぼして turn を固着させる問題を直す。あわせて app-server 待機状態をチャット履歴メッセージではなく一時ステータスとして表示し、返信が来たら消える通常チャット寄りの UX にする。

## Satisfied Success Criteria

- JsonLineAppServerClient が id 付き app-server request を検出して JSON-RPC response を返す。\nJsonLineAppServerClient が pending response の id=0 も正しく resolve する。\ncommand execution approval は内容に関係なく decline/denied し、Dashboard bridge から command 実行権限を自動付与しない。\nfile change と apply patch は decline/denied、permission escalation と unknown request method は JSON-RPC error として応答し、無応答による turn 固着を避ける。\nDashboard chat は owner message だけを履歴保存し、送信待ち/生成中 status は transient_status と composer 下表示にする。\n送信直後の待機状態は送信者ローカルだけでなく同一 thread の dashboard socket に transient_status として broadcast する。\napp-server reply delta と status は durable chat message として保存しない。

## Unsatisfied Success Criteria

- read-only repo 確認を app-server command approval で安全に自動許可する設計は未実装。VPS 反映、service restart、iPhone live E2E も未実施。

## Non-goal violations

Deploy, credential mutation, permission mutation, Issue close, command execution の自動承認、read-only repo command approval 設計、nickname registry 変更はしない。

## Dry-run Impact Report

- Target Issue: Issue #450
- Implementing Success Criteria: Dashboard Butler が app-server approval/server request 待ちで無期限に止まらず、待機表示をチャット履歴ではなく一時 UI 状態として扱うこと。
- Explicit Non-goals: deploy / VPS restart / credential mutation / permission mutation / Issue close / command auto-approval / nickname registry 変更はしない。
- Expected touched files/routes/workflows: scripts/run-dashboard-app-server-bridge.mjs, src/worker/runtime.js, test/dashboard-app-server-bridge.test.js, test/worker.test.js, worker.js
- Affected Issues: Issue #450
- Affected PRs: PR #480, PR #482, PR #483 の app-server bridge path の後続修正。
- Affected workflows: GitHub Actions test / guarded-policy / review。
- Affected runtime/operator surfaces: Dashboard Butler chat UI, Dashboard app-server bridge on VPS。
- What may break if we patch narrowly: command approval を自動承認すると危険操作が通る。permission escalation を result で返すと権限付与に見える。無応答だと現在のように turn が固着する。status を durable message にするとチャット履歴が汚れる。
- Unknowns to investigate before coding: read-only repo 確認を安全に許可する設計は未確定。この PR では扱わない。
- Validation needed: node --test test/dashboard-app-server-bridge.test.js; node --test test/worker.test.js; npm test; merge/deploy 後に iPhone Dashboard live E2E。
- Stop condition: read-only command を許可する必要がある場合、または nickname registry を変更する必要が出た場合は、この PR に継ぎ足さず別 scope に分ける。

## File / Line Hypotheses

- file: scripts/run-dashboard-app-server-bridge.mjs\n  - hypothesis: pending response と server request の id 判定が id=0 を取りこぼし、app-server turn が止まる。\n  - risk if changed narrowly: command approval や permission escalation を成功承認すると危険操作が通る。\n  - validation: approval response/id=0 unit tests と npm test。\n  - related Issue: Issue #450\n- file: src/worker/runtime.js\n  - hypothesis: 送信待ち/生成中 status を chat message として保存しているため、通常チャットの履歴がノイズ化する。\n  - risk if changed narrowly: 返信失敗や thinking 状態が見えなくなる、または複数端末で待機状態が揃わない。\n  - validation: DashboardChatRoom transient_status tests と worker tests。\n  - related Issue: Issue #450

## Hypothesis Retrospective

- expected: id 付き approval/server request へ必ず応答し、command/file/patch/permission は自動権限付与しない。\n- actual: focused tests と npm test で確認。\n- mismatch: read-only repo 確認の自動許可と live E2E は未実装として残す。\n- lesson: app-server bridge は WebSocket だけでなく JSON-RPC server request と transient UI state を分けて扱う必要がある。\n- should become RAG candidate: はい。Issue #450 の app-server bridge 運用知見。

## Verification Evidence

- Unit: node --test test/dashboard-app-server-bridge.test.js passed; node --test test/worker.test.js passed.
- Integration: npm test passed, including check:self-parity and check:generated-worker.
- E2E: 未実施。この PR merge/deploy 後に iPhone Dashboard live E2E が必要。
- Manual: codex app-server generate-json-schema で protocol schema を確認したうえで、permission escalation は success result ではなく JSON-RPC error に倒した。
- Evidence path/link: scripts/run-dashboard-app-server-bridge.mjs; src/worker/runtime.js; test/dashboard-app-server-bridge.test.js; test/worker.test.js

## Butler Completion Contract

- Owner goal: iPhone Dashboard Butler で、app-server の内部 approval/server request 待ちや待機 status 履歴ノイズでチャットが詰まったように見える状態を避ける。
- Butler entrypoint: Dashboard /dashboard の通常チャット入力。
- Action Schema exposure: 変更なし。Dashboard app-server bridge 専用経路と Worker UI の内部修正。
- Runtime path: src/worker/runtime.js DashboardChatRoom -> /v2/dashboard/chat/:thread/ws transient_status; scripts/run-dashboard-app-server-bridge.mjs -> codex app-server JSON-RPC server request/response -> /v2/dashboard/app-server/ws。
- Runner/runtime truth: ローカルテストで approval/server request response, id=0 response, transient status behavior を確認。本番反映には merge/deploy/VPS update/restart が必要。
- Authority boundary: command execution は常に decline/denied。file change / apply patch も拒否。permission escalation / unknown request は JSON-RPC error。新しい high-risk authority は追加しない。
- E2E evidence: 未完了。merge/deploy 後に iPhone Dashboard で pending/status が履歴に残らず、返信または拒否/失敗に進むことを確認する。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 必要。Worker UI/runtime 変更を含むため、merge 後に production deploy が必要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 必要。deploy と VPS restart 後に live Dashboard で確認する。

## Related Constitution Rules

- Butler Completion Gate\nDrift Stop Protocol\nAuthority Boundary\nEvidence Discipline\nConversation UX Contract

## Out-of-scope but NOT implemented

- read-only repo command approval 設計。\nVPS 常駐 unit 変更。\nnickname registry 変更。\nIssue #450 close 判断。

## Extra changes (if any)

worker.js は src/worker/runtime.js から再生成済み。

<!-- VTDD metadata -->
- Issue: Issue #450
- Execution ID: mac-codex-2026-05-22-dashboard-bridge-transient-status
- Goal: Issue #450 Dashboard app-server bridge request handling and transient waiting UI without auto command authority
