### PR TITLE
#450 Dashboard nickname requests go through app-server

### DIFF
--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -223,29 +223,6 @@ export class DashboardChatRoom {
       normalizePositiveInteger(payload?.relatedIssue || payload?.issueNumber) || extractIssueNumberFromDashboardChatText(text);
     const now = new Date().toISOString();
     const store = resolveDashboardChatStore(this.env);
-    const nicknameListTurn = await buildDashboardRepositoryNicknameListTurn({
-      payload: { ...normalizeObject(payload), text, threadId },
-      env: this.env
-    });
-    if (nicknameListTurn) {
-      const ownerMessage = normalizeDashboardChatMessage(
-        {
-          threadId: nicknameListTurn.threadId,
-          role: "owner",
-          relatedIssue,
-          status: "sent",
-          text,
-          createdAt: now
-        },
-        { threadId: nicknameListTurn.threadId }
-      );
-      const replyMessages = nicknameListTurn.messages.filter((message) => message.role !== "owner");
-      const messages = store
-        ? await store.appendMany(nicknameListTurn.threadId, [ownerMessage, ...replyMessages])
-        : [ownerMessage, ...replyMessages].filter(Boolean);
-      await this.broadcastThread({ threadId: nicknameListTurn.threadId, messages });
-      return;
-    }
     const repositoryResolution = await resolveDashboardChatRepository({
       payload: { ...normalizeObject(payload), text, threadId },
       env: this.env
@@ -3603,24 +3580,6 @@ async function handleDashboardChatMessageRequest(request, env) {
   }
 
   const payload = await readJson(request);
-  const nicknameListTurn = await buildDashboardRepositoryNicknameListTurn({ payload, env });
-  if (nicknameListTurn) {
-    const store = resolveDashboardChatStore(env);
-    if (!store) {
-      return json(503, {
-        ok: false,
-        error: "dashboard_chat_store_unavailable",
-        reason: "dashboard Butler chat store is not configured"
-      });
-    }
-    const messages = await store.appendMany(nicknameListTurn.threadId, nicknameListTurn.messages);
-    return json(202, {
-      ok: true,
-      threadId: nicknameListTurn.threadId,
-      messages,
-      execution: null
-    });
-  }
   const repositoryResolution = await resolveDashboardChatRepository({ payload, env });
   const repository = repositoryResolution.ok ? repositoryResolution.repository : "";
 
@@ -5474,7 +5433,7 @@ async function resolveDashboardChatRepository({ payload, env }) {
       status: 422,
       error: "repository_required",
       reason:
-        "対象 repository が未指定です。VPS Codex CLI に渡す前に、repo/nickname を指定してください。例: `ぶい #450 の残り Issue と PR を確認して`。登録済み nickname を確認する場合は `登録済みのニックネーム出して` と送ってください。",
+        "repository 文脈が必要な依頼では、owner/repo 形式か登録済み nickname を本文に含めてください。例: `ぶい #450 の残り Issue と PR を確認して`。",
       issues: ["dashboard top chat requires a repository target before VPS Codex CLI handoff"]
     };
   }
@@ -5501,7 +5460,7 @@ async function resolveDashboardChatRepository({ payload, env }) {
     error: resolved.ambiguous ? "repository_nickname_ambiguous" : "repository_unresolved",
     reason: resolved.ambiguous
       ? "対象 repository nickname が曖昧です。候補から 1 つを owner/repo 形式で指定してください。"
-      : "対象 repository nickname を登録済み alias から解決できませんでした。`登録済みのニックネーム出して` で候補を確認するか、owner/repo 形式で指定してください。",
+      : "対象 repository nickname を登録済み alias から解決できませんでした。repository 文脈が必要な依頼では owner/repo 形式で指定してください。",
     issues: registryResult.ok
       ? ["repository nickname could not be resolved"]
       : [registryResult.reason || "repository nickname registry could not be read"],
@@ -6103,90 +6062,6 @@ function buildDashboardAppServerNotConnectedReply({ repository, relatedIssue } =
     `- ${issuePhrase}`,
     "",
     "現時点の実行 fallback は Custom GPT Butler です。Dashboard Butler は app-server 接続 PR が入るまで未完成として扱います。"
-  ].join("\n");
-}
-
-async function buildDashboardRepositoryNicknameListTurn({ payload, env }) {
-  const input = normalizeObject(payload);
-  const text = sanitizeDashboardChatText(input.text || input.message || input.body);
-  if (!isDashboardRepositoryNicknameListRequest(text)) {
-    return null;
-  }
-  const threadId =
-    normalizeDashboardThreadId(input.threadId || input.thread_id) ||
-    normalizeDashboardThreadId("dashboard-main-unresolved");
-  const now = new Date().toISOString();
-  const ownerMessage = normalizeDashboardChatMessage(
-    {
-      threadId,
-      role: "owner",
-      status: "sent",
-      text,
-      createdAt: now
-    },
-    { threadId }
-  );
-  const registryResult = await safeRetrieveStoredAliasRegistry(resolveMemoryProvider(env));
-  const butlerMessage = normalizeDashboardChatMessage(
-    {
-      threadId,
-      role: "butler",
-      status: registryResult.ok ? "replied" : "blocked",
-      text: formatDashboardRepositoryNicknameListReply(registryResult),
-      createdAt: new Date(Date.parse(now) + 1).toISOString()
-    },
-    { threadId }
-  );
-  return {
-    threadId,
-    messages: [ownerMessage, butlerMessage].filter(Boolean)
-  };
-}
-
-function isDashboardRepositoryNicknameListRequest(text) {
-  const normalized = normalizeDashboardEventText(text).toLowerCase();
-  if (!normalized) {
-    return false;
-  }
-  return (
-    normalized.includes("ニックネーム") &&
-    (normalized.includes("一覧") ||
-      normalized.includes("登録済") ||
-      normalized.includes("登録ずみ") ||
-      normalized.includes("出して") ||
-      normalized.includes("見せて") ||
-      normalized.includes("教えて"))
-  );
-}
-
-function formatDashboardRepositoryNicknameListReply(registryResult) {
-  if (!registryResult?.ok) {
-    return [
-      "登録済みニックネームを読めませんでした。",
-      "",
-      `理由: ${registryResult?.reason || "memory provider が利用できません。"}`,
-      "",
-      "この状態では repo/nickname 未指定のまま VPS Codex CLI に渡せないため、owner/repo 形式で対象 repository を指定してください。"
-    ].join("\n");
-  }
-  const entries = Array.isArray(registryResult.aliasRegistry) ? registryResult.aliasRegistry : [];
-  if (entries.length === 0) {
-    return [
-      "登録済みニックネームはありません。",
-      "",
-      "この状態では repo/nickname 未指定のまま VPS Codex CLI に渡せません。",
-      "まず `marushu/vtdd-v2-p` のように owner/repo 形式で対象 repository を指定してください。"
-    ].join("\n");
-  }
-  return [
-    "登録済みニックネームです。",
-    "",
-    ...entries.map((entry) => {
-      const aliases = Array.isArray(entry.aliases) && entry.aliases.length > 0 ? entry.aliases.join(", ") : "なし";
-      return `- ${entry.canonicalRepo}: ${aliases}`;
-    }),
-    "",
-    "送信例: `ぶい #450 の残り Issue と PR を確認して`"
   ].join("\n");
 }
 

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -3581,6 +3581,8 @@ async function handleDashboardChatMessageRequest(request, env) {
 
   const payload = await readJson(request);
   const repositoryResolution = await resolveDashboardChatRepository({ payload, env });
+  // HTTP chat writes are the non-live persistence fallback. Live Codex delivery
+  // happens through DashboardChatRoom WebSocket owner_message events.
   const repository = repositoryResolution.ok ? repositoryResolution.repository : "";
 
   const prepared = buildDashboardChatTurn(

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -871,7 +871,7 @@ test("worker allows dashboard passkey session chat without VPS runner handoff", 
   assert.equal(calls.length, 0);
 });
 
-test("worker returns registered dashboard repository nicknames in Japanese without VPS handoff", async () => {
+test("worker does not answer dashboard nickname requests from the alias registry shortcut", async () => {
   const provider = createInMemoryMemoryProvider();
   await provider.store({
     id: "alias_registry:marushu/vtdd-v2-p",
@@ -909,9 +909,13 @@ test("worker returns registered dashboard repository nicknames in Japanese witho
   assert.equal(body.ok, true);
   assert.equal(body.execution, null);
   assert.equal(body.messages.length, 2);
+  assert.equal(body.messages[0].role, "owner");
+  assert.equal(body.messages[0].text, "登録済みのニックネーム出して");
   assert.equal(body.messages[1].role, "butler");
-  assert.equal(body.messages[1].text.includes("登録済みニックネームです。"), true);
-  assert.equal(body.messages[1].text.includes("- marushu/vtdd-v2-p: ぶい, vtdd"), true);
+  assert.equal(body.messages[1].status, "blocked");
+  assert.equal(body.messages[1].text.includes("登録済みニックネームです。"), false);
+  assert.equal(body.messages[1].text.includes("- marushu/vtdd-v2-p: ぶい, vtdd"), false);
+  assert.match(body.messages[1].text, /app-server/);
 });
 
 test("worker stores dashboard chat without repository instead of dispatching handoff", async () => {
@@ -1350,7 +1354,7 @@ test("DashboardChatRoom rejects spoofed app-server events from dashboard sockets
   assert.deepEqual(await store.listThread("dashboard-main-unresolved"), []);
 });
 
-test("DashboardChatRoom returns nickname list without repository handoff", async () => {
+test("DashboardChatRoom sends nickname requests to connected app-server bridge", async () => {
   const provider = createInMemoryMemoryProvider();
   await provider.store({
     id: "alias_registry:marushu/vtdd-v2-p",
@@ -1366,11 +1370,11 @@ test("DashboardChatRoom returns nickname list without repository handoff", async
   });
   const store = createInMemoryDashboardChatStore();
   const dashboardSocket = createMockSocket("dashboard", "dashboard-main-unresolved");
-  const runnerSocket = createMockSocket("vps_runner", "dashboard-main-unresolved");
+  const bridgeSocket = createMockSocket("app_server_bridge", "dashboard-main-unresolved");
   const room = new DashboardChatRoom(
     {
       getWebSockets() {
-        return [dashboardSocket, runnerSocket];
+        return [dashboardSocket, bridgeSocket];
       }
     },
     { DASHBOARD_CHAT_STORE: store, MEMORY_PROVIDER: provider }
@@ -1385,12 +1389,20 @@ test("DashboardChatRoom returns nickname list without repository handoff", async
     })
   );
 
-  assert.equal(runnerSocket.sent.length, 0);
+  assert.equal(bridgeSocket.sent.length, 1);
+  const turnRequest = JSON.parse(bridgeSocket.sent[0]);
+  assert.equal(turnRequest.type, "app_server_turn_requested");
+  assert.equal(turnRequest.text, "登録済みのニックネーム出して");
+  assert.equal(turnRequest.repository, null);
+  assert.equal(turnRequest.authority.ordinaryConversationAllowed, true);
+
   const broadcast = JSON.parse(dashboardSocket.sent[0]);
-  assert.equal(broadcast.messages.length, 2);
+  assert.equal(broadcast.messages.length, 1);
   assert.equal(broadcast.messages[0].role, "owner");
-  assert.equal(broadcast.messages[1].text.includes("登録済みニックネームです。"), true);
-  assert.equal(broadcast.messages[1].text.includes("- marushu/vtdd-v2-p: ぶい, vtdd"), true);
+  assert.equal(broadcast.messages[0].text, "登録済みのニックネーム出して");
+  const status = JSON.parse(dashboardSocket.sent[1]);
+  assert.equal(status.type, "transient_status");
+  assert.equal(status.status, "thinking");
 });
 
 test("worker redacts dashboard Butler chat sensitive material before returning and storing", async () => {

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -871,7 +871,7 @@ test("worker allows dashboard passkey session chat without VPS runner handoff", 
   assert.equal(calls.length, 0);
 });
 
-test("worker does not answer dashboard nickname requests from the alias registry shortcut", async () => {
+test("worker HTTP dashboard nickname requests use non-live fallback instead of alias registry shortcut", async () => {
   const provider = createInMemoryMemoryProvider();
   await provider.store({
     id: "alias_registry:marushu/vtdd-v2-p",
@@ -916,6 +916,7 @@ test("worker does not answer dashboard nickname requests from the alias registry
   assert.equal(body.messages[1].text.includes("登録済みニックネームです。"), false);
   assert.equal(body.messages[1].text.includes("- marushu/vtdd-v2-p: ぶい, vtdd"), false);
   assert.match(body.messages[1].text, /app-server/);
+  assert.match(body.messages[1].text, /未接続の状態で VPS Codex CLI に送ったふりはしません/);
 });
 
 test("worker stores dashboard chat without repository instead of dispatching handoff", async () => {

--- a/worker.js
+++ b/worker.js
@@ -55959,27 +55959,6 @@ var DashboardChatRoom = class {
     const relatedIssue = normalizePositiveInteger9(payload?.relatedIssue || payload?.issueNumber) || extractIssueNumberFromDashboardChatText(text);
     const now = (/* @__PURE__ */ new Date()).toISOString();
     const store = resolveDashboardChatStore(this.env);
-    const nicknameListTurn = await buildDashboardRepositoryNicknameListTurn({
-      payload: { ...normalizeObject11(payload), text, threadId },
-      env: this.env
-    });
-    if (nicknameListTurn) {
-      const ownerMessage2 = normalizeDashboardChatMessage(
-        {
-          threadId: nicknameListTurn.threadId,
-          role: "owner",
-          relatedIssue,
-          status: "sent",
-          text,
-          createdAt: now
-        },
-        { threadId: nicknameListTurn.threadId }
-      );
-      const replyMessages = nicknameListTurn.messages.filter((message) => message.role !== "owner");
-      const messages2 = store ? await store.appendMany(nicknameListTurn.threadId, [ownerMessage2, ...replyMessages]) : [ownerMessage2, ...replyMessages].filter(Boolean);
-      await this.broadcastThread({ threadId: nicknameListTurn.threadId, messages: messages2 });
-      return;
-    }
     const repositoryResolution = await resolveDashboardChatRepository({
       payload: { ...normalizeObject11(payload), text, threadId },
       env: this.env
@@ -58883,24 +58862,6 @@ async function handleDashboardChatMessageRequest(request, env) {
     });
   }
   const payload = await readJson(request);
-  const nicknameListTurn = await buildDashboardRepositoryNicknameListTurn({ payload, env });
-  if (nicknameListTurn) {
-    const store2 = resolveDashboardChatStore(env);
-    if (!store2) {
-      return json(503, {
-        ok: false,
-        error: "dashboard_chat_store_unavailable",
-        reason: "dashboard Butler chat store is not configured"
-      });
-    }
-    const messages2 = await store2.appendMany(nicknameListTurn.threadId, nicknameListTurn.messages);
-    return json(202, {
-      ok: true,
-      threadId: nicknameListTurn.threadId,
-      messages: messages2,
-      execution: null
-    });
-  }
   const repositoryResolution = await resolveDashboardChatRepository({ payload, env });
   const repository = repositoryResolution.ok ? repositoryResolution.repository : "";
   const prepared = buildDashboardChatTurn(
@@ -60464,7 +60425,7 @@ async function resolveDashboardChatRepository({ payload, env }) {
       ok: false,
       status: 422,
       error: "repository_required",
-      reason: "\u5BFE\u8C61 repository \u304C\u672A\u6307\u5B9A\u3067\u3059\u3002VPS Codex CLI \u306B\u6E21\u3059\u524D\u306B\u3001repo/nickname \u3092\u6307\u5B9A\u3057\u3066\u304F\u3060\u3055\u3044\u3002\u4F8B: `\u3076\u3044 #450 \u306E\u6B8B\u308A Issue \u3068 PR \u3092\u78BA\u8A8D\u3057\u3066`\u3002\u767B\u9332\u6E08\u307F nickname \u3092\u78BA\u8A8D\u3059\u308B\u5834\u5408\u306F `\u767B\u9332\u6E08\u307F\u306E\u30CB\u30C3\u30AF\u30CD\u30FC\u30E0\u51FA\u3057\u3066` \u3068\u9001\u3063\u3066\u304F\u3060\u3055\u3044\u3002",
+      reason: "repository \u6587\u8108\u304C\u5FC5\u8981\u306A\u4F9D\u983C\u3067\u306F\u3001owner/repo \u5F62\u5F0F\u304B\u767B\u9332\u6E08\u307F nickname \u3092\u672C\u6587\u306B\u542B\u3081\u3066\u304F\u3060\u3055\u3044\u3002\u4F8B: `\u3076\u3044 #450 \u306E\u6B8B\u308A Issue \u3068 PR \u3092\u78BA\u8A8D\u3057\u3066`\u3002",
       issues: ["dashboard top chat requires a repository target before VPS Codex CLI handoff"]
     };
   }
@@ -60488,7 +60449,7 @@ async function resolveDashboardChatRepository({ payload, env }) {
     ok: false,
     status: resolved.ambiguous ? 409 : 422,
     error: resolved.ambiguous ? "repository_nickname_ambiguous" : "repository_unresolved",
-    reason: resolved.ambiguous ? "\u5BFE\u8C61 repository nickname \u304C\u66D6\u6627\u3067\u3059\u3002\u5019\u88DC\u304B\u3089 1 \u3064\u3092 owner/repo \u5F62\u5F0F\u3067\u6307\u5B9A\u3057\u3066\u304F\u3060\u3055\u3044\u3002" : "\u5BFE\u8C61 repository nickname \u3092\u767B\u9332\u6E08\u307F alias \u304B\u3089\u89E3\u6C7A\u3067\u304D\u307E\u305B\u3093\u3067\u3057\u305F\u3002`\u767B\u9332\u6E08\u307F\u306E\u30CB\u30C3\u30AF\u30CD\u30FC\u30E0\u51FA\u3057\u3066` \u3067\u5019\u88DC\u3092\u78BA\u8A8D\u3059\u308B\u304B\u3001owner/repo \u5F62\u5F0F\u3067\u6307\u5B9A\u3057\u3066\u304F\u3060\u3055\u3044\u3002",
+    reason: resolved.ambiguous ? "\u5BFE\u8C61 repository nickname \u304C\u66D6\u6627\u3067\u3059\u3002\u5019\u88DC\u304B\u3089 1 \u3064\u3092 owner/repo \u5F62\u5F0F\u3067\u6307\u5B9A\u3057\u3066\u304F\u3060\u3055\u3044\u3002" : "\u5BFE\u8C61 repository nickname \u3092\u767B\u9332\u6E08\u307F alias \u304B\u3089\u89E3\u6C7A\u3067\u304D\u307E\u305B\u3093\u3067\u3057\u305F\u3002repository \u6587\u8108\u304C\u5FC5\u8981\u306A\u4F9D\u983C\u3067\u306F owner/repo \u5F62\u5F0F\u3067\u6307\u5B9A\u3057\u3066\u304F\u3060\u3055\u3044\u3002",
     issues: registryResult.ok ? ["repository nickname could not be resolved"] : [registryResult.reason || "repository nickname registry could not be read"],
     candidates: resolved.candidates || []
   };
@@ -61012,77 +60973,6 @@ function buildDashboardAppServerNotConnectedReply({ repository, relatedIssue } =
     `- ${issuePhrase}`,
     "",
     "\u73FE\u6642\u70B9\u306E\u5B9F\u884C fallback \u306F Custom GPT Butler \u3067\u3059\u3002Dashboard Butler \u306F app-server \u63A5\u7D9A PR \u304C\u5165\u308B\u307E\u3067\u672A\u5B8C\u6210\u3068\u3057\u3066\u6271\u3044\u307E\u3059\u3002"
-  ].join("\n");
-}
-async function buildDashboardRepositoryNicknameListTurn({ payload, env }) {
-  const input = normalizeObject11(payload);
-  const text = sanitizeDashboardChatText(input.text || input.message || input.body);
-  if (!isDashboardRepositoryNicknameListRequest(text)) {
-    return null;
-  }
-  const threadId = normalizeDashboardThreadId(input.threadId || input.thread_id) || normalizeDashboardThreadId("dashboard-main-unresolved");
-  const now = (/* @__PURE__ */ new Date()).toISOString();
-  const ownerMessage = normalizeDashboardChatMessage(
-    {
-      threadId,
-      role: "owner",
-      status: "sent",
-      text,
-      createdAt: now
-    },
-    { threadId }
-  );
-  const registryResult = await safeRetrieveStoredAliasRegistry(resolveMemoryProvider(env));
-  const butlerMessage = normalizeDashboardChatMessage(
-    {
-      threadId,
-      role: "butler",
-      status: registryResult.ok ? "replied" : "blocked",
-      text: formatDashboardRepositoryNicknameListReply(registryResult),
-      createdAt: new Date(Date.parse(now) + 1).toISOString()
-    },
-    { threadId }
-  );
-  return {
-    threadId,
-    messages: [ownerMessage, butlerMessage].filter(Boolean)
-  };
-}
-function isDashboardRepositoryNicknameListRequest(text) {
-  const normalized = normalizeDashboardEventText(text).toLowerCase();
-  if (!normalized) {
-    return false;
-  }
-  return normalized.includes("\u30CB\u30C3\u30AF\u30CD\u30FC\u30E0") && (normalized.includes("\u4E00\u89A7") || normalized.includes("\u767B\u9332\u6E08") || normalized.includes("\u767B\u9332\u305A\u307F") || normalized.includes("\u51FA\u3057\u3066") || normalized.includes("\u898B\u305B\u3066") || normalized.includes("\u6559\u3048\u3066"));
-}
-function formatDashboardRepositoryNicknameListReply(registryResult) {
-  if (!registryResult?.ok) {
-    return [
-      "\u767B\u9332\u6E08\u307F\u30CB\u30C3\u30AF\u30CD\u30FC\u30E0\u3092\u8AAD\u3081\u307E\u305B\u3093\u3067\u3057\u305F\u3002",
-      "",
-      `\u7406\u7531: ${registryResult?.reason || "memory provider \u304C\u5229\u7528\u3067\u304D\u307E\u305B\u3093\u3002"}`,
-      "",
-      "\u3053\u306E\u72B6\u614B\u3067\u306F repo/nickname \u672A\u6307\u5B9A\u306E\u307E\u307E VPS Codex CLI \u306B\u6E21\u305B\u306A\u3044\u305F\u3081\u3001owner/repo \u5F62\u5F0F\u3067\u5BFE\u8C61 repository \u3092\u6307\u5B9A\u3057\u3066\u304F\u3060\u3055\u3044\u3002"
-    ].join("\n");
-  }
-  const entries = Array.isArray(registryResult.aliasRegistry) ? registryResult.aliasRegistry : [];
-  if (entries.length === 0) {
-    return [
-      "\u767B\u9332\u6E08\u307F\u30CB\u30C3\u30AF\u30CD\u30FC\u30E0\u306F\u3042\u308A\u307E\u305B\u3093\u3002",
-      "",
-      "\u3053\u306E\u72B6\u614B\u3067\u306F repo/nickname \u672A\u6307\u5B9A\u306E\u307E\u307E VPS Codex CLI \u306B\u6E21\u305B\u307E\u305B\u3093\u3002",
-      "\u307E\u305A `marushu/vtdd-v2-p` \u306E\u3088\u3046\u306B owner/repo \u5F62\u5F0F\u3067\u5BFE\u8C61 repository \u3092\u6307\u5B9A\u3057\u3066\u304F\u3060\u3055\u3044\u3002"
-    ].join("\n");
-  }
-  return [
-    "\u767B\u9332\u6E08\u307F\u30CB\u30C3\u30AF\u30CD\u30FC\u30E0\u3067\u3059\u3002",
-    "",
-    ...entries.map((entry) => {
-      const aliases = Array.isArray(entry.aliases) && entry.aliases.length > 0 ? entry.aliases.join(", ") : "\u306A\u3057";
-      return `- ${entry.canonicalRepo}: ${aliases}`;
-    }),
-    "",
-    "\u9001\u4FE1\u4F8B: `\u3076\u3044 #450 \u306E\u6B8B\u308A Issue \u3068 PR \u3092\u78BA\u8A8D\u3057\u3066`"
   ].join("\n");
 }
 function normalizeDashboardChatMessage(message, defaults = {}) {


### PR DESCRIPTION
## This PR satisfies Intent

- Dashboard Butler の会話入力で nickname 一覧要求だけを Worker が固定応答せず、通常の owner turn と同じく codex app-server bridge に渡す。

## Satisfied Success Criteria

- DashboardChatRoom の owner_message から nickname 一覧用の Worker 固定応答を削除した。
- HTTP chat message path からも nickname list shortcut を削除し、Worker 側で alias registry 一覧を Butler reply として返さない。
- repository 未指定時の案内から `登録済みのニックネーム出して` を勧める文言を削除した。
- connected app-server bridge がある場合、`登録済みのニックネーム出して` は `app_server_turn_requested` として bridge に送られる。

## Unsatisfied Success Criteria

- production deploy と VPS bridge restart はこの PR では未実施。
- merge/deploy/restart 後の iPhone/PWA live E2E は未実施。
- HTTP POST fallback path は bridge に直接送らず、WebSocket chat room 経路が live app-server path である。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #450
- Implementing Success Criteria: #450: Dashboard Butler PWA の会話入力を Worker 固定応答で横取りせず、app-server bridge backed chat として扱う。
- Explicit Non-goals: Alias registry storage/retrieval API の削除、Custom GPT Butler の nickname retrieve action 変更、deploy、VPS restart、Issue close。
- Expected touched files/routes/workflows: src/worker/runtime.js, test/worker.test.js, worker.js。Routes/workflows/docs は変更しない。
- Affected Issues: #450 のみ。
- Affected PRs: #485。過去 PR #482/#484 の app-server bridge 方針に追従する小修正。
- Affected workflows: guarded-autonomy-required-checks, gemini-pr-review。deploy-production はこの PR では実行しない。
- Affected runtime/operator surfaces: Dashboard Butler PWA chat, Worker Durable Object DashboardChatRoom, VPS Dashboard Bridge handoff event。Custom GPT surface は対象外。
- What may break if we patch narrowly: HTTP-only caller は app-server bridge に直接送られず blocked reply のままになる可能性がある。実際の live PWA は WebSocket owner_message 経路を使うため、post-deploy E2E で確認する。
- Unknowns to investigate before coding: 本番 iPhone/PWA で nickname request が WebSocket owner_message 経路を通り、VPS app-server が自然言語として応答するか。
- Validation needed: Unit: worker chat room tests. Integration: npm test. Live: merge/deploy/restart 後の iPhone Dashboard Butler E2E。
- Stop condition: alias registry API 自体を削除する必要が出た場合、または Custom GPT Butler の既存 retrieve operation を変更する必要が出た場合は、この PR 範囲を超えるため停止。

## File / Line Hypotheses

- file: `src/worker/runtime.js`
  - hypothesis: `DashboardChatRoom.acceptOwnerMessage` と `handleDashboardChatMessageRequest` が nickname list request を app-server 前に固定応答している。
  - risk if changed narrowly: WebSocket live path と HTTP fallback path の差が残る。
  - validation: nickname request が connected app-server bridge に `app_server_turn_requested` として送られる unit test。
  - related Issue: #450
- file: `test/worker.test.js`
  - hypothesis: 既存テストが Worker 固定応答を正として固定している。
  - risk if changed narrowly: 旧 UX を期待する regression test が残る。
  - validation: 固定応答しないこと、bridge に送ることを検証するテストへ更新。
  - related Issue: #450

## Hypothesis Retrospective

- expected: nickname request は alias registry shortcut で処理されず、DashboardChatRoom から app-server bridge に送られる。
- actual: `DashboardChatRoom sends nickname requests to connected app-server bridge` で `app_server_turn_requested` を確認。HTTP path は固定一覧応答を返さない。
- mismatch: HTTP path は bridge 送信ではなく not-connected reply のまま。PWA live path は WebSocket 経路のため post-deploy E2E で確認する。
- lesson: Dashboard Butler では便利な Worker shortcut が chat 体験を壊すため、通常入力は app-server に寄せる。
- should become RAG candidate: yes, #450 の working memory candidate。

## Verification Evidence

- Unit: node --test test/worker.test.js passed: 165 tests.
- Integration: npm test passed: 909 tests, 908 pass, 1 skipped; self-parity and generated-worker checks passed.
- E2E: Not run in production. Post-deploy Dashboard Butler live E2E remains required for #450.
- Manual: Owner iPhone screenshots showed ordinary conversation improved, while  still returned Worker-prepared alias registry text. This PR removes that shortcut.
- Evidence path/link: src/worker/runtime.js
test/worker.test.js
worker.js
https://github.com/marushu/vtdd-v2-p/pull/485

## Butler Completion Contract

- Owner goal: Dashboard Butler では事前準備済み nickname 一覧を Worker が返さず、都度 VPS Codex CLI / codex app-server から応答させる。
- Butler entrypoint: Dashboard Butler PWA chat input over DashboardChatRoom WebSocket.
- Action Schema exposure: Not changed. This is Dashboard app-server bridge behavior, not Custom GPT Action Schema.
- Runtime path: DashboardChatRoom owner_message -> app_server_turn_requested -> VPS Dashboard Bridge -> codex app-server. HTTP POST remains a non-live fallback and does not prove live Butler completion.
- Runner/runtime truth: GitHub PR checks plus post-deploy Dashboard/VPS bridge live evidence.
- Authority boundary: No deploy, merge, credential mutation, permission mutation, or Issue close in this PR.
- E2E evidence: Unit coverage verifies nickname request goes to app-server bridge when connected; production iPhone live E2E remains required after deploy/restart.
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 必要。Worker runtime が変わるため merge 後に scoped passkey approval で production deploy が必要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 必要。merge/deploy/VPS bridge restart 後、iPhone/PWA Dashboard Butler で nickname request が VPS Codex CLI/app-server から返ることを確認する。

## Related Constitution Rules

- Butler Completion Gate
- Drift Stop Protocol
- Evidence Discipline
- Change Size and PR Discipline

## Out-of-scope but NOT implemented

- Alias registry storage/retrieval APIs
- Custom GPT Butler nickname retrieval
- Deploy
- VPS bridge restart
- Issue #450 closure

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #450
- Execution ID: Not provided.
- Goal: Not provided.
