### PR TITLE
#450 Render Dashboard Butler markdown

### DIFF
--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -8137,7 +8137,13 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
     .bubble-header { display: flex; align-items: center; gap: 10px; margin-bottom: 8px; }
     .bubble strong { display: block; color: var(--muted); font-size: 12px; letter-spacing: .08em; text-transform: uppercase; margin-bottom: 8px; }
     .bubble-header strong { margin-bottom: 0; }
-    .bubble p { color: var(--text); margin-bottom: 12px; white-space: pre-wrap; }
+    .bubble p { color: var(--text); margin-bottom: 12px; }
+    .bubble .message-body { display: grid; gap: 12px; }
+    .bubble .message-body p { margin: 0; white-space: pre-wrap; }
+    .bubble .message-body ul { margin: 0; }
+    .bubble .message-body li + li { margin-top: 4px; }
+    .bubble .message-body code { font-size: .94em; }
+    .bubble .message-body strong { display: inline; color: inherit; font-size: inherit; letter-spacing: 0; text-transform: none; margin: 0; font-weight: 800; }
     .copy-message { display: inline-flex; align-items: center; justify-content: center; width: 30px; height: 30px; border: 1px solid var(--border); border-radius: 999px; background: var(--button); color: var(--text); font-size: 15px; line-height: 1; cursor: pointer; }
     .copy-message:focus-visible { outline: 2px solid var(--text); outline-offset: 2px; }
     .bubble ul { margin: 0; padding-left: 22px; color: var(--text); line-height: 1.85; }
@@ -8408,30 +8414,79 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           header.appendChild(copyButton);
           article.appendChild(header);
         }
-        const paragraph = document.createElement("p");
-        renderMessageText(paragraph, message.text || "（空のメッセージ）");
-        article.appendChild(paragraph);
+        const body = document.createElement("div");
+        body.className = "message-body";
+        renderMessageText(body, message.text || "（空のメッセージ）");
+        article.appendChild(body);
         log.appendChild(article);
         scrollToLatest();
       }
 
       function renderMessageText(container, text) {
         const source = String(text || "");
-        const urlPattern = /https?:\\/\\/[^\\s<>"']+/g;
+        const lines = source.replace(/\\r\\n/g, "\\n").split("\\n");
+        let index = 0;
+        while (index < lines.length) {
+          if (!lines[index].trim()) {
+            index += 1;
+            continue;
+          }
+          if (/^\\s*-\\s+/.test(lines[index])) {
+            const list = document.createElement("ul");
+            while (index < lines.length && /^\\s*-\\s+/.test(lines[index])) {
+              const item = document.createElement("li");
+              renderInlineMarkdown(item, lines[index].replace(/^\\s*-\\s+/, ""));
+              list.appendChild(item);
+              index += 1;
+            }
+            container.appendChild(list);
+            continue;
+          }
+          const paragraph = document.createElement("p");
+          const paragraphLines = [];
+          while (index < lines.length && lines[index].trim() && !/^\\s*-\\s+/.test(lines[index])) {
+            paragraphLines.push(lines[index]);
+            index += 1;
+          }
+          paragraphLines.forEach((line, lineIndex) => {
+            if (lineIndex > 0) paragraph.appendChild(document.createTextNode("\\n"));
+            renderInlineMarkdown(paragraph, line);
+          });
+          container.appendChild(paragraph);
+        }
+      }
+
+      function renderInlineMarkdown(container, text) {
+        const source = String(text || "");
+        const backtick = String.fromCharCode(96);
+        const tokenPattern = new RegExp(
+          "(https?:\\\\/\\\\/[^\\\\s<>\\\"']+)|\\\\*\\\\*([\\\\s\\\\S]+?)\\\\*\\\\*|" + backtick + "([^" + backtick + "]+)" + backtick,
+          "g"
+        );
         let cursor = 0;
-        for (const match of source.matchAll(urlPattern)) {
+        for (const match of source.matchAll(tokenPattern)) {
           if (match.index > cursor) {
             container.appendChild(document.createTextNode(source.slice(cursor, match.index)));
           }
-          const href = match[0];
-          const link = document.createElement("a");
-          link.className = "chat-link";
-          link.href = href;
-          link.textContent = href;
-          link.target = "_blank";
-          link.rel = "noreferrer";
-          container.appendChild(link);
-          cursor = match.index + href.length;
+          if (match[1]) {
+            const href = match[1];
+            const link = document.createElement("a");
+            link.className = "chat-link";
+            link.href = href;
+            link.textContent = href;
+            link.target = "_blank";
+            link.rel = "noreferrer";
+            container.appendChild(link);
+          } else if (match[2]) {
+            const strong = document.createElement("strong");
+            renderInlineMarkdown(strong, match[2]);
+            container.appendChild(strong);
+          } else if (match[3]) {
+            const code = document.createElement("code");
+            code.textContent = match[3];
+            container.appendChild(code);
+          }
+          cursor = match.index + match[0].length;
         }
         if (cursor < source.length) {
           container.appendChild(document.createTextNode(source.slice(cursor)));

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -505,6 +505,13 @@ test("worker serves v2 dashboard for allowed owner identity without exposing sec
   assert.equal(body.includes("function showThinking()"), false);
   assert.equal(body.includes("function removeThinking("), false);
   assert.equal(body.includes("function renderMessageText("), true);
+  assert.equal(body.includes("function renderInlineMarkdown("), true);
+  assert.equal(body.includes('body.className = "message-body"'), true);
+  assert.equal(body.includes('document.createElement("ul")'), true);
+  assert.equal(body.includes('document.createElement("li")'), true);
+  assert.equal(body.includes('document.createElement("strong")'), true);
+  assert.equal(body.includes('document.createElement("code")'), true);
+  assert.equal(body.includes("renderInlineMarkdown(strong"), true);
   assert.equal(body.includes("function copyMessageText("), true);
   assert.equal(body.includes("navigator.clipboard.writeText"), true);
   assert.equal(body.includes("返信をコピー"), true);
@@ -516,7 +523,7 @@ test("worker serves v2 dashboard for allowed owner identity without exposing sec
   assert.equal(body.includes('renderThread(body.messages || [], { replace: true })'), true);
   assert.equal(body.includes('renderThread(body.messages || [], { replace: false })'), true);
   assert.equal(body.includes("white-space: pre-wrap"), true);
-  assert.equal(body.includes("urlPattern"), true);
+  assert.equal(body.includes("tokenPattern"), true);
   assert.equal(body.includes('link.className = "chat-link"'), true);
   assert.equal(body.includes("考えています"), false);
   assert.equal(body.includes("thinking-dots"), true);

--- a/worker.js
+++ b/worker.js
@@ -62835,7 +62835,13 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
     .bubble-header { display: flex; align-items: center; gap: 10px; margin-bottom: 8px; }
     .bubble strong { display: block; color: var(--muted); font-size: 12px; letter-spacing: .08em; text-transform: uppercase; margin-bottom: 8px; }
     .bubble-header strong { margin-bottom: 0; }
-    .bubble p { color: var(--text); margin-bottom: 12px; white-space: pre-wrap; }
+    .bubble p { color: var(--text); margin-bottom: 12px; }
+    .bubble .message-body { display: grid; gap: 12px; }
+    .bubble .message-body p { margin: 0; white-space: pre-wrap; }
+    .bubble .message-body ul { margin: 0; }
+    .bubble .message-body li + li { margin-top: 4px; }
+    .bubble .message-body code { font-size: .94em; }
+    .bubble .message-body strong { display: inline; color: inherit; font-size: inherit; letter-spacing: 0; text-transform: none; margin: 0; font-weight: 800; }
     .copy-message { display: inline-flex; align-items: center; justify-content: center; width: 30px; height: 30px; border: 1px solid var(--border); border-radius: 999px; background: var(--button); color: var(--text); font-size: 15px; line-height: 1; cursor: pointer; }
     .copy-message:focus-visible { outline: 2px solid var(--text); outline-offset: 2px; }
     .bubble ul { margin: 0; padding-left: 22px; color: var(--text); line-height: 1.85; }
@@ -63106,30 +63112,79 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           header.appendChild(copyButton);
           article.appendChild(header);
         }
-        const paragraph = document.createElement("p");
-        renderMessageText(paragraph, message.text || "\uFF08\u7A7A\u306E\u30E1\u30C3\u30BB\u30FC\u30B8\uFF09");
-        article.appendChild(paragraph);
+        const body = document.createElement("div");
+        body.className = "message-body";
+        renderMessageText(body, message.text || "\uFF08\u7A7A\u306E\u30E1\u30C3\u30BB\u30FC\u30B8\uFF09");
+        article.appendChild(body);
         log.appendChild(article);
         scrollToLatest();
       }
 
       function renderMessageText(container, text) {
         const source = String(text || "");
-        const urlPattern = /https?:\\/\\/[^\\s<>"']+/g;
+        const lines = source.replace(/\\r\\n/g, "\\n").split("\\n");
+        let index = 0;
+        while (index < lines.length) {
+          if (!lines[index].trim()) {
+            index += 1;
+            continue;
+          }
+          if (/^\\s*-\\s+/.test(lines[index])) {
+            const list = document.createElement("ul");
+            while (index < lines.length && /^\\s*-\\s+/.test(lines[index])) {
+              const item = document.createElement("li");
+              renderInlineMarkdown(item, lines[index].replace(/^\\s*-\\s+/, ""));
+              list.appendChild(item);
+              index += 1;
+            }
+            container.appendChild(list);
+            continue;
+          }
+          const paragraph = document.createElement("p");
+          const paragraphLines = [];
+          while (index < lines.length && lines[index].trim() && !/^\\s*-\\s+/.test(lines[index])) {
+            paragraphLines.push(lines[index]);
+            index += 1;
+          }
+          paragraphLines.forEach((line, lineIndex) => {
+            if (lineIndex > 0) paragraph.appendChild(document.createTextNode("\\n"));
+            renderInlineMarkdown(paragraph, line);
+          });
+          container.appendChild(paragraph);
+        }
+      }
+
+      function renderInlineMarkdown(container, text) {
+        const source = String(text || "");
+        const backtick = String.fromCharCode(96);
+        const tokenPattern = new RegExp(
+          "(https?:\\\\/\\\\/[^\\\\s<>\\"']+)|\\\\*\\\\*([\\\\s\\\\S]+?)\\\\*\\\\*|" + backtick + "([^" + backtick + "]+)" + backtick,
+          "g"
+        );
         let cursor = 0;
-        for (const match of source.matchAll(urlPattern)) {
+        for (const match of source.matchAll(tokenPattern)) {
           if (match.index > cursor) {
             container.appendChild(document.createTextNode(source.slice(cursor, match.index)));
           }
-          const href = match[0];
-          const link = document.createElement("a");
-          link.className = "chat-link";
-          link.href = href;
-          link.textContent = href;
-          link.target = "_blank";
-          link.rel = "noreferrer";
-          container.appendChild(link);
-          cursor = match.index + href.length;
+          if (match[1]) {
+            const href = match[1];
+            const link = document.createElement("a");
+            link.className = "chat-link";
+            link.href = href;
+            link.textContent = href;
+            link.target = "_blank";
+            link.rel = "noreferrer";
+            container.appendChild(link);
+          } else if (match[2]) {
+            const strong = document.createElement("strong");
+            renderInlineMarkdown(strong, match[2]);
+            container.appendChild(strong);
+          } else if (match[3]) {
+            const code = document.createElement("code");
+            code.textContent = match[3];
+            container.appendChild(code);
+          }
+          cursor = match.index + match[0].length;
         }
         if (cursor < source.length) {
           container.appendChild(document.createTextNode(source.slice(cursor)));


### PR DESCRIPTION
## This PR satisfies Intent

- Dashboard Butler の app-server 返信をチャットとして読みやすく表示するため、保存済み Markdown 風テキストを安全な DOM 生成で HTML 表示へ変換する。

## Satisfied Success Criteria

- Butler 返信本文で **bold** を strong 表示する。
- Butler 返信本文で inline code を code 表示する。
- Butler 返信本文で - item の連続行を ul/li 表示する。
- URL auto-link は維持する。
- 保存本文とコピー本文はプレーンテキストのまま維持する。

## Unsatisfied Success Criteria

- production deploy と iPhone Dashboard Butler live E2E は merge 後に必要。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #450
- Implementing Success Criteria: Dashboard Butler の返信文章が読みづらい問題に対し、app-server 返信の Markdown サブセットをチャットUIで HTML 表示する。
- Explicit Non-goals: Markdown ライブラリ追加、任意 HTML 許可、app-server 返答内容変更、alias registry 復活、Custom GPT Action Schema 変更、VPS bridge 変更はしない。
- Expected touched files/routes/workflows: src/worker/runtime.js, test/worker.test.js, worker.js
- Affected Issues: #450
- Affected PRs: #485 の live path 表示改善。新規 PR として分離。
- Affected workflows: guarded-policy, test, review
- Affected runtime/operator surfaces: Dashboard Butler chat UI。Worker runtime HTML/JS。VPS/app-server protocol は未変更。
- What may break if we patch narrowly: client-side renderer のみを変えるため、Markdown の全仕様は扱わない。箇条書き、bold、code、URL 以外はプレーン表示のまま残る。
- Unknowns to investigate before coding: 実機 Safari/PWA で ul/li の余白が読みやすいかは deploy 後 E2E で確認する。
- Validation needed: node --test test/worker.test.js, npm test, deploy 後 iPhone Dashboard Butler live E2E
- Stop condition: 保存データ形式変更、任意 HTML 挿入、app-server 返答内容変更が必要になる場合は別 Issue/PR に分離する。

## File / Line Hypotheses

- file: `src/worker/runtime.js:8137`
  - hypothesis: chat bubble CSS が p の pre-wrap だけで Markdown 構造を表現できていない。
  - risk if changed narrowly: header の strong 表示まで壊す可能性がある。
  - validation: message-body 配下だけ strong/code/ul の CSS を限定する。
  - related Issue: #450
- file: `src/worker/runtime.js:8414`
  - hypothesis: renderMessageText が URL link 化だけで Markdown token を DOM 化していない。
  - risk if changed narrowly: innerHTML を使うと app-server 返信中の HTML が実行可能になる。
  - validation: createElement/createTextNode のみで bold/code/list/link を作る。
  - related Issue: #450
- file: `test/worker.test.js:505`
  - hypothesis: dashboard HTML の renderer contract を最低限固定できる。
  - risk if changed narrowly: 実ブラウザ描画までは証明できない。
  - validation: renderer 関数と DOM 生成要素の存在を unit で確認し、live E2E は merge/deploy 後に残す。
  - related Issue: #450

## Hypothesis Retrospective

- expected: URL link 化だけの renderer を Markdown サブセット renderer に置き換えれば、スクリーンショット上の **bold** と - list が自然な HTML になる。
- actual: message-body DOM を追加し、strong/code/ul/li/link を createElement で生成する実装になった。
- mismatch: 生のバッククォートを template literal 内に置くと build が落ちたため、String.fromCharCode(96) を使う RegExp 生成に変更した。
- lesson: Worker HTML テンプレート内 JS では Markdown token 自体が template literal と衝突し得る。
- should become RAG candidate: いいえ。実装上の局所注意として PR evidence に残す。

## Verification Evidence

- Unit: npm test passed: 909 tests, 908 pass, 1 skipped; worker dashboard renderer assertions updated.
- Integration: npm test includes check:self-parity and check:generated-worker passed after staging generated worker.js.
- E2E: 未実施。merge/deploy 後に iPhone Dashboard Butler live E2E が必要。
- Manual: 未実施。
- Evidence path/link: local npm test output in Codex session; PR checks will provide GitHub evidence.

## Butler Completion Contract

- Owner goal: Dashboard Butler の返信を ChatGPT 風に読みやすく表示する。
- Butler entrypoint: Dashboard Butler chat UI。自然文入力経路は既存 app-server bridge のまま。
- Action Schema exposure: 不要。Dashboard UI 表示のみ。
- Runtime path: Worker が返す dashboard HTML の client-side renderer: message.text -> renderMessageText -> renderInlineMarkdown -> DOM nodes.
- Runner/runtime truth: 保存済み message.text は変更せず、表示時だけ変換。runtime truth/API payload 形式は未変更。
- Authority boundary: 未変更。表示改善のみで high-risk authority は追加しない。
- E2E evidence: 未実施。merge/deploy 後、iPhone Dashboard Butler で bold/code/list 表示を確認する。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 必要。merge 後 production deploy が必要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 必要。deploy 後、app-server 返信の **bold** と - list が HTML 表示されることを確認する。

## Related Constitution Rules

- Issue traceability / Evidence Discipline / Butler Completion Gate / No speculative implementation

## Out-of-scope but NOT implemented

- Markdown 全仕様対応。
- 任意 HTML 許可。
- app-server の回答プロンプト変更。
- alias registry 固定返信の復活。
- VPS bridge restart/deploy/Issue close。

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #450
- Execution ID: Not provided.
- Goal: Not provided.
