### PR TITLE
#450 Dashboard chat owner copy and iOS input hints

### DIFF
--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -8143,6 +8143,8 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
     .bubble .message-body ul { margin: 0; }
     .bubble .message-body li + li { margin-top: 4px; }
     .bubble .message-body code { font-size: .94em; }
+    .bubble .message-body pre { margin: 0; padding: 14px; border: 1px solid var(--border); border-radius: 12px; background: var(--panel-strong); overflow-x: auto; white-space: pre; }
+    .bubble .message-body pre code { display: block; font-size: 14px; line-height: 1.55; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace; }
     .bubble .message-body strong { display: inline; color: inherit; font-size: inherit; letter-spacing: 0; text-transform: none; margin: 0; font-weight: 800; }
     .copy-message { display: inline-flex; align-items: center; justify-content: center; width: 30px; height: 30px; border: 1px solid var(--border); border-radius: 999px; background: var(--button); color: var(--text); font-size: 15px; line-height: 1; cursor: pointer; }
     .copy-message:focus-visible { outline: 2px solid var(--text); outline-offset: 2px; }
@@ -8445,10 +8447,32 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
       function renderMessageText(container, text) {
         const source = String(text || "");
         const lines = source.replace(/\\r\\n/g, "\\n").split("\\n");
+        const fence = String.fromCharCode(96, 96, 96);
         let index = 0;
         while (index < lines.length) {
           if (!lines[index].trim()) {
             index += 1;
+            continue;
+          }
+          if (lines[index].trim().startsWith(fence)) {
+            const language = lines[index].trim().slice(fence.length).trim();
+            const codeLines = [];
+            index += 1;
+            while (index < lines.length && !lines[index].trim().startsWith(fence)) {
+              codeLines.push(lines[index]);
+              index += 1;
+            }
+            if (index < lines.length && lines[index].trim().startsWith(fence)) {
+              index += 1;
+            }
+            const pre = document.createElement("pre");
+            const code = document.createElement("code");
+            if (language) {
+              code.dataset.language = language;
+            }
+            code.textContent = codeLines.join("\\n");
+            pre.appendChild(code);
+            container.appendChild(pre);
             continue;
           }
           if (/^\\s*-\\s+/.test(lines[index])) {

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -8147,8 +8147,10 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
     .copy-message { display: inline-flex; align-items: center; justify-content: center; width: 30px; height: 30px; border: 1px solid var(--border); border-radius: 999px; background: var(--button); color: var(--text); font-size: 15px; line-height: 1; cursor: pointer; }
     .copy-message:focus-visible { outline: 2px solid var(--text); outline-offset: 2px; }
     .bubble ul { margin: 0; padding-left: 22px; color: var(--text); line-height: 1.85; }
-    .bubble.owner { align-self: flex-end; background: var(--owner-bubble); color: var(--owner-text); border-radius: 24px; padding: 12px 16px; }
+    .bubble.owner { position: relative; align-self: flex-end; background: var(--owner-bubble); color: var(--owner-text); border-radius: 24px; padding: 12px 16px; }
     .bubble.owner p { color: var(--owner-text); margin: 0; }
+    .bubble.owner .copy-message { position: absolute; top: -12px; left: -12px; width: 28px; height: 28px; background: var(--panel-strong); color: var(--text); opacity: .86; }
+    .bubble.owner .copy-message:hover, .bubble.owner .copy-message:focus-visible { opacity: 1; }
     .bubble.thinking { color: var(--muted); }
     .thinking-dots::after { content: ""; display: inline-block; width: 1.4em; text-align: left; animation: thinkingDots 1.2s steps(4, end) infinite; }
     @keyframes thinkingDots { 0% { content: ""; } 25% { content: "."; } 50% { content: ".."; } 75%, 100% { content: "..."; } }
@@ -8289,9 +8291,9 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
 
       </div>
 
-      <form class="composer" id="butler-chat-form" aria-label="Butler composer" data-socket-endpoint="${escapeDashboardHtml(socketOrigin)}/v2/dashboard/chat/${escapeDashboardHtml(chatThreadId)}/ws" data-thread-endpoint="${escapeDashboardHtml(origin)}/v2/dashboard/chat/${escapeDashboardHtml(chatThreadId)}" data-thread-id="${escapeDashboardHtml(chatThreadId)}" data-repository-input="${escapeDashboardHtml(repositoryInput)}" data-issue-number="${dashboardIssueNumber || ""}">
+      <form class="composer" id="butler-chat-form" aria-label="Butler composer" autocomplete="off" data-socket-endpoint="${escapeDashboardHtml(socketOrigin)}/v2/dashboard/chat/${escapeDashboardHtml(chatThreadId)}/ws" data-thread-endpoint="${escapeDashboardHtml(origin)}/v2/dashboard/chat/${escapeDashboardHtml(chatThreadId)}" data-thread-id="${escapeDashboardHtml(chatThreadId)}" data-repository-input="${escapeDashboardHtml(repositoryInput)}" data-issue-number="${dashboardIssueNumber || ""}">
         <div class="composer-box">
-          <textarea id="butler-message" name="text" placeholder="Butler V2 にメッセージ..." aria-label="Butler V2 にメッセージ"></textarea>
+          <textarea id="butler-message" name="text" placeholder="Butler V2 にメッセージ..." aria-label="Butler V2 にメッセージ" autocomplete="off" autocorrect="off" autocapitalize="sentences" spellcheck="false" enterkeyhint="send"></textarea>
           <button class="send-button" type="submit" aria-label="Butler に送信">↑</button>
         </div>
         <div class="composer-status" id="butler-chat-status">接続準備中です。WebSocket 接続後に送信できます。</div>
@@ -8422,6 +8424,15 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           copyButton.addEventListener("click", () => copyMessageText(copyButton, message.text || ""));
           header.appendChild(copyButton);
           article.appendChild(header);
+        } else {
+          const copyButton = document.createElement("button");
+          copyButton.className = "copy-message";
+          copyButton.type = "button";
+          copyButton.textContent = "⧉";
+          copyButton.setAttribute("aria-label", "自分の発言をコピー");
+          copyButton.title = "自分の発言をコピー";
+          copyButton.addEventListener("click", () => copyMessageText(copyButton, message.text || ""));
+          article.appendChild(copyButton);
         }
         const body = document.createElement("div");
         body.className = "message-body";

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -8411,11 +8411,20 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
       function appendMessage(message) {
         const article = document.createElement("article");
         article.className = message.role === "owner" ? "bubble owner" : "bubble";
-        if (message.role !== "owner") {
+        if (message.role === "owner") {
+          const copyButton = document.createElement("button");
+          copyButton.className = "copy-message";
+          copyButton.type = "button";
+          copyButton.textContent = "⧉";
+          copyButton.setAttribute("aria-label", "自分の発言をコピー");
+          copyButton.title = "自分の発言をコピー";
+          copyButton.addEventListener("click", () => copyMessageText(copyButton, message.text || ""));
+          article.appendChild(copyButton);
+        } else if (message.role === "butler") {
           const header = document.createElement("div");
           header.className = "bubble-header";
           const strong = document.createElement("strong");
-          strong.textContent = message.role === "system" ? "SYSTEM" : "Butler";
+          strong.textContent = "Butler";
           header.appendChild(strong);
           const copyButton = document.createElement("button");
           copyButton.className = "copy-message";
@@ -8426,15 +8435,13 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           copyButton.addEventListener("click", () => copyMessageText(copyButton, message.text || ""));
           header.appendChild(copyButton);
           article.appendChild(header);
-        } else {
-          const copyButton = document.createElement("button");
-          copyButton.className = "copy-message";
-          copyButton.type = "button";
-          copyButton.textContent = "⧉";
-          copyButton.setAttribute("aria-label", "自分の発言をコピー");
-          copyButton.title = "自分の発言をコピー";
-          copyButton.addEventListener("click", () => copyMessageText(copyButton, message.text || ""));
-          article.appendChild(copyButton);
+        } else if (message.role === "system") {
+          const header = document.createElement("div");
+          header.className = "bubble-header";
+          const strong = document.createElement("strong");
+          strong.textContent = "SYSTEM";
+          header.appendChild(strong);
+          article.appendChild(header);
         }
         const body = document.createElement("div");
         body.className = "message-body";

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -8295,7 +8295,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
 
       <form class="composer" id="butler-chat-form" aria-label="Butler composer" autocomplete="off" data-socket-endpoint="${escapeDashboardHtml(socketOrigin)}/v2/dashboard/chat/${escapeDashboardHtml(chatThreadId)}/ws" data-thread-endpoint="${escapeDashboardHtml(origin)}/v2/dashboard/chat/${escapeDashboardHtml(chatThreadId)}" data-thread-id="${escapeDashboardHtml(chatThreadId)}" data-repository-input="${escapeDashboardHtml(repositoryInput)}" data-issue-number="${dashboardIssueNumber || ""}">
         <div class="composer-box">
-          <textarea id="butler-message" name="text" placeholder="Butler V2 にメッセージ..." aria-label="Butler V2 にメッセージ" autocomplete="off" autocorrect="off" autocapitalize="sentences" spellcheck="false" enterkeyhint="send"></textarea>
+          <textarea id="butler-message" name="text" placeholder="Butler V2 にメッセージ..." aria-label="Butler V2 にメッセージ" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" enterkeyhint="send"></textarea>
           <button class="send-button" type="submit" aria-label="Butler に送信">↑</button>
         </div>
         <div class="composer-status" id="butler-chat-status">接続準備中です。WebSocket 接続後に送信できます。</div>

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -525,6 +525,9 @@ test("worker serves v2 dashboard for allowed owner identity without exposing sec
   assert.equal(body.includes("navigator.clipboard.writeText"), true);
   assert.equal(body.includes("返信をコピー"), true);
   assert.equal(body.includes("自分の発言をコピー"), true);
+  assert.equal(body.includes('if (message.role === "owner")'), true);
+  assert.equal(body.includes('} else if (message.role === "butler") {'), true);
+  assert.equal(body.includes('} else if (message.role === "system") {'), true);
   assert.equal(body.includes('className = "copy-message"'), true);
   assert.equal(body.includes('autocomplete="off" autocorrect="off" autocapitalize="sentences" spellcheck="false" enterkeyhint="send"'), true);
   assert.equal(body.includes("const messagesById = new Map()"), true);

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -529,7 +529,7 @@ test("worker serves v2 dashboard for allowed owner identity without exposing sec
   assert.equal(body.includes('} else if (message.role === "butler") {'), true);
   assert.equal(body.includes('} else if (message.role === "system") {'), true);
   assert.equal(body.includes('className = "copy-message"'), true);
-  assert.equal(body.includes('autocomplete="off" autocorrect="off" autocapitalize="sentences" spellcheck="false" enterkeyhint="send"'), true);
+  assert.equal(body.includes('autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" enterkeyhint="send"'), true);
   assert.equal(body.includes("const messagesById = new Map()"), true);
   assert.equal(body.includes("messagesById.set(messageKey(message), message)"), true);
   assert.equal(body.includes("messagesById.clear()"), true);

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -521,7 +521,9 @@ test("worker serves v2 dashboard for allowed owner identity without exposing sec
   assert.equal(body.includes("function copyMessageText("), true);
   assert.equal(body.includes("navigator.clipboard.writeText"), true);
   assert.equal(body.includes("返信をコピー"), true);
+  assert.equal(body.includes("自分の発言をコピー"), true);
   assert.equal(body.includes('className = "copy-message"'), true);
+  assert.equal(body.includes('autocomplete="off" autocorrect="off" autocapitalize="sentences" spellcheck="false" enterkeyhint="send"'), true);
   assert.equal(body.includes("const messagesById = new Map()"), true);
   assert.equal(body.includes("messagesById.set(messageKey(message), message)"), true);
   assert.equal(body.includes("messagesById.clear()"), true);

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -515,8 +515,11 @@ test("worker serves v2 dashboard for allowed owner identity without exposing sec
   assert.equal(body.includes('body.className = "message-body"'), true);
   assert.equal(body.includes('document.createElement("ul")'), true);
   assert.equal(body.includes('document.createElement("li")'), true);
+  assert.equal(body.includes('document.createElement("pre")'), true);
   assert.equal(body.includes('document.createElement("strong")'), true);
   assert.equal(body.includes('document.createElement("code")'), true);
+  assert.equal(body.includes("String.fromCharCode(96, 96, 96)"), true);
+  assert.equal(body.includes("code.dataset.language = language"), true);
   assert.equal(body.includes("renderInlineMarkdown(strong"), true);
   assert.equal(body.includes("function copyMessageText("), true);
   assert.equal(body.includes("navigator.clipboard.writeText"), true);

--- a/worker.js
+++ b/worker.js
@@ -63109,11 +63109,20 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
       function appendMessage(message) {
         const article = document.createElement("article");
         article.className = message.role === "owner" ? "bubble owner" : "bubble";
-        if (message.role !== "owner") {
+        if (message.role === "owner") {
+          const copyButton = document.createElement("button");
+          copyButton.className = "copy-message";
+          copyButton.type = "button";
+          copyButton.textContent = "\u29C9";
+          copyButton.setAttribute("aria-label", "\u81EA\u5206\u306E\u767A\u8A00\u3092\u30B3\u30D4\u30FC");
+          copyButton.title = "\u81EA\u5206\u306E\u767A\u8A00\u3092\u30B3\u30D4\u30FC";
+          copyButton.addEventListener("click", () => copyMessageText(copyButton, message.text || ""));
+          article.appendChild(copyButton);
+        } else if (message.role === "butler") {
           const header = document.createElement("div");
           header.className = "bubble-header";
           const strong = document.createElement("strong");
-          strong.textContent = message.role === "system" ? "SYSTEM" : "Butler";
+          strong.textContent = "Butler";
           header.appendChild(strong);
           const copyButton = document.createElement("button");
           copyButton.className = "copy-message";
@@ -63124,15 +63133,13 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           copyButton.addEventListener("click", () => copyMessageText(copyButton, message.text || ""));
           header.appendChild(copyButton);
           article.appendChild(header);
-        } else {
-          const copyButton = document.createElement("button");
-          copyButton.className = "copy-message";
-          copyButton.type = "button";
-          copyButton.textContent = "\u29C9";
-          copyButton.setAttribute("aria-label", "\u81EA\u5206\u306E\u767A\u8A00\u3092\u30B3\u30D4\u30FC");
-          copyButton.title = "\u81EA\u5206\u306E\u767A\u8A00\u3092\u30B3\u30D4\u30FC";
-          copyButton.addEventListener("click", () => copyMessageText(copyButton, message.text || ""));
-          article.appendChild(copyButton);
+        } else if (message.role === "system") {
+          const header = document.createElement("div");
+          header.className = "bubble-header";
+          const strong = document.createElement("strong");
+          strong.textContent = "SYSTEM";
+          header.appendChild(strong);
+          article.appendChild(header);
         }
         const body = document.createElement("div");
         body.className = "message-body";

--- a/worker.js
+++ b/worker.js
@@ -62841,6 +62841,8 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
     .bubble .message-body ul { margin: 0; }
     .bubble .message-body li + li { margin-top: 4px; }
     .bubble .message-body code { font-size: .94em; }
+    .bubble .message-body pre { margin: 0; padding: 14px; border: 1px solid var(--border); border-radius: 12px; background: var(--panel-strong); overflow-x: auto; white-space: pre; }
+    .bubble .message-body pre code { display: block; font-size: 14px; line-height: 1.55; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace; }
     .bubble .message-body strong { display: inline; color: inherit; font-size: inherit; letter-spacing: 0; text-transform: none; margin: 0; font-weight: 800; }
     .copy-message { display: inline-flex; align-items: center; justify-content: center; width: 30px; height: 30px; border: 1px solid var(--border); border-radius: 999px; background: var(--button); color: var(--text); font-size: 15px; line-height: 1; cursor: pointer; }
     .copy-message:focus-visible { outline: 2px solid var(--text); outline-offset: 2px; }
@@ -63143,10 +63145,32 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
       function renderMessageText(container, text) {
         const source = String(text || "");
         const lines = source.replace(/\\r\\n/g, "\\n").split("\\n");
+        const fence = String.fromCharCode(96, 96, 96);
         let index = 0;
         while (index < lines.length) {
           if (!lines[index].trim()) {
             index += 1;
+            continue;
+          }
+          if (lines[index].trim().startsWith(fence)) {
+            const language = lines[index].trim().slice(fence.length).trim();
+            const codeLines = [];
+            index += 1;
+            while (index < lines.length && !lines[index].trim().startsWith(fence)) {
+              codeLines.push(lines[index]);
+              index += 1;
+            }
+            if (index < lines.length && lines[index].trim().startsWith(fence)) {
+              index += 1;
+            }
+            const pre = document.createElement("pre");
+            const code = document.createElement("code");
+            if (language) {
+              code.dataset.language = language;
+            }
+            code.textContent = codeLines.join("\\n");
+            pre.appendChild(code);
+            container.appendChild(pre);
             continue;
           }
           if (/^\\s*-\\s+/.test(lines[index])) {

--- a/worker.js
+++ b/worker.js
@@ -62845,8 +62845,10 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
     .copy-message { display: inline-flex; align-items: center; justify-content: center; width: 30px; height: 30px; border: 1px solid var(--border); border-radius: 999px; background: var(--button); color: var(--text); font-size: 15px; line-height: 1; cursor: pointer; }
     .copy-message:focus-visible { outline: 2px solid var(--text); outline-offset: 2px; }
     .bubble ul { margin: 0; padding-left: 22px; color: var(--text); line-height: 1.85; }
-    .bubble.owner { align-self: flex-end; background: var(--owner-bubble); color: var(--owner-text); border-radius: 24px; padding: 12px 16px; }
+    .bubble.owner { position: relative; align-self: flex-end; background: var(--owner-bubble); color: var(--owner-text); border-radius: 24px; padding: 12px 16px; }
     .bubble.owner p { color: var(--owner-text); margin: 0; }
+    .bubble.owner .copy-message { position: absolute; top: -12px; left: -12px; width: 28px; height: 28px; background: var(--panel-strong); color: var(--text); opacity: .86; }
+    .bubble.owner .copy-message:hover, .bubble.owner .copy-message:focus-visible { opacity: 1; }
     .bubble.thinking { color: var(--muted); }
     .thinking-dots::after { content: ""; display: inline-block; width: 1.4em; text-align: left; animation: thinkingDots 1.2s steps(4, end) infinite; }
     @keyframes thinkingDots { 0% { content: ""; } 25% { content: "."; } 50% { content: ".."; } 75%, 100% { content: "..."; } }
@@ -62987,9 +62989,9 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
 
       </div>
 
-      <form class="composer" id="butler-chat-form" aria-label="Butler composer" data-socket-endpoint="${escapeDashboardHtml(socketOrigin)}/v2/dashboard/chat/${escapeDashboardHtml(chatThreadId)}/ws" data-thread-endpoint="${escapeDashboardHtml(origin)}/v2/dashboard/chat/${escapeDashboardHtml(chatThreadId)}" data-thread-id="${escapeDashboardHtml(chatThreadId)}" data-repository-input="${escapeDashboardHtml(repositoryInput)}" data-issue-number="${dashboardIssueNumber || ""}">
+      <form class="composer" id="butler-chat-form" aria-label="Butler composer" autocomplete="off" data-socket-endpoint="${escapeDashboardHtml(socketOrigin)}/v2/dashboard/chat/${escapeDashboardHtml(chatThreadId)}/ws" data-thread-endpoint="${escapeDashboardHtml(origin)}/v2/dashboard/chat/${escapeDashboardHtml(chatThreadId)}" data-thread-id="${escapeDashboardHtml(chatThreadId)}" data-repository-input="${escapeDashboardHtml(repositoryInput)}" data-issue-number="${dashboardIssueNumber || ""}">
         <div class="composer-box">
-          <textarea id="butler-message" name="text" placeholder="Butler V2 \u306B\u30E1\u30C3\u30BB\u30FC\u30B8..." aria-label="Butler V2 \u306B\u30E1\u30C3\u30BB\u30FC\u30B8"></textarea>
+          <textarea id="butler-message" name="text" placeholder="Butler V2 \u306B\u30E1\u30C3\u30BB\u30FC\u30B8..." aria-label="Butler V2 \u306B\u30E1\u30C3\u30BB\u30FC\u30B8" autocomplete="off" autocorrect="off" autocapitalize="sentences" spellcheck="false" enterkeyhint="send"></textarea>
           <button class="send-button" type="submit" aria-label="Butler \u306B\u9001\u4FE1">\u2191</button>
         </div>
         <div class="composer-status" id="butler-chat-status">\u63A5\u7D9A\u6E96\u5099\u4E2D\u3067\u3059\u3002WebSocket \u63A5\u7D9A\u5F8C\u306B\u9001\u4FE1\u3067\u304D\u307E\u3059\u3002</div>
@@ -63120,6 +63122,15 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           copyButton.addEventListener("click", () => copyMessageText(copyButton, message.text || ""));
           header.appendChild(copyButton);
           article.appendChild(header);
+        } else {
+          const copyButton = document.createElement("button");
+          copyButton.className = "copy-message";
+          copyButton.type = "button";
+          copyButton.textContent = "\u29C9";
+          copyButton.setAttribute("aria-label", "\u81EA\u5206\u306E\u767A\u8A00\u3092\u30B3\u30D4\u30FC");
+          copyButton.title = "\u81EA\u5206\u306E\u767A\u8A00\u3092\u30B3\u30D4\u30FC";
+          copyButton.addEventListener("click", () => copyMessageText(copyButton, message.text || ""));
+          article.appendChild(copyButton);
         }
         const body = document.createElement("div");
         body.className = "message-body";

--- a/worker.js
+++ b/worker.js
@@ -62993,7 +62993,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
 
       <form class="composer" id="butler-chat-form" aria-label="Butler composer" autocomplete="off" data-socket-endpoint="${escapeDashboardHtml(socketOrigin)}/v2/dashboard/chat/${escapeDashboardHtml(chatThreadId)}/ws" data-thread-endpoint="${escapeDashboardHtml(origin)}/v2/dashboard/chat/${escapeDashboardHtml(chatThreadId)}" data-thread-id="${escapeDashboardHtml(chatThreadId)}" data-repository-input="${escapeDashboardHtml(repositoryInput)}" data-issue-number="${dashboardIssueNumber || ""}">
         <div class="composer-box">
-          <textarea id="butler-message" name="text" placeholder="Butler V2 \u306B\u30E1\u30C3\u30BB\u30FC\u30B8..." aria-label="Butler V2 \u306B\u30E1\u30C3\u30BB\u30FC\u30B8" autocomplete="off" autocorrect="off" autocapitalize="sentences" spellcheck="false" enterkeyhint="send"></textarea>
+          <textarea id="butler-message" name="text" placeholder="Butler V2 \u306B\u30E1\u30C3\u30BB\u30FC\u30B8..." aria-label="Butler V2 \u306B\u30E1\u30C3\u30BB\u30FC\u30B8" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" enterkeyhint="send"></textarea>
           <button class="send-button" type="submit" aria-label="Butler \u306B\u9001\u4FE1">\u2191</button>
         </div>
         <div class="composer-status" id="butler-chat-status">\u63A5\u7D9A\u6E96\u5099\u4E2D\u3067\u3059\u3002WebSocket \u63A5\u7D9A\u5F8C\u306B\u9001\u4FE1\u3067\u304D\u307E\u3059\u3002</div>


### PR DESCRIPTION
## This PR satisfies Intent

- #450 Dashboard Butler live chat runtime のチャット体験改善スライスです。
- owner発言もコピー可能にし、Butler返信だけに返信コピーを維持します。
- Markdown の fenced code block を読みやすい pre/code 表示にします。
- iOS Safari/PWA の入力補助バーを抑えるため、composer の入力属性を整理します。

## Satisfied Success Criteria

- owner発言に role-scoped なコピー操作を追加し、owner発言をコピーできるようにしました。
- Butler返信コピーは Butler role のみ、system message にはコピー操作を出さない分岐にしました。
- Markdown の fenced code block を pre/code に変換して表示します。
- composer に autocomplete=off / autocorrect=off / autocapitalize=off / spellcheck=false / enterkeyhint=send を設定しました。
- worker.js は src/worker/runtime.js から再生成済みです。
- Codex fallback reviewer の request changes 2件、owner copy role scope と autocapitalize off を反映済みです。

## Unsatisfied Success Criteria

- #450 全体の完了条件である iPhone/PWA live E2E は、このPR単体では未実施です。
- merge後の deploy と iPhone/PWA Dashboard Butler での owner-facing 確認が残ります。
- Dashboard Butler が同じ live Codex app-server session で追質問、通常会話、repo/Issue context turn を継続できることは、このPRでは未完了です。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #450
- Implementing Success Criteria: Dashboard Butler live chat runtime の表示・入力 UX 改善。owner発言コピー、Butler返信コピーの role scope、fenced code block 表示、iOS composer 入力補助抑制。
- Explicit Non-goals: app-server bridge 経路、VPS常駐、deploy workflow、Custom GPT Action Schema、repository resolver は変更しない。
- Expected touched files/routes/workflows: src/worker/runtime.js, worker.js, test/worker.test.js
- Affected Issues: #450
- Affected PRs: #488
- Affected workflows: guarded-autonomy-required-checks, gemini-pr-review
- Affected runtime/operator surfaces: Dashboard Butler chat UI on Cloudflare Worker. No Custom GPT schema/runtime authority change.
- What may break if we patch narrowly: role分岐を誤ると system message に不要な copy UI が出る。入力属性を誤ると iOS Safari/PWA の日本語入力補助が残る。worker.js 再生成漏れで deploy artifact が古くなる。
- Unknowns to investigate before coding: live iPhone/PWA でキーボード accessory bar が完全に消えるかは deploy 後の実機確認が必要。
- Validation needed: node --test test/worker.test.js, npm test, merge/deploy後の iPhone/PWA live E2E.
- Stop condition: Issue #450 外の bridge、approval、repository resolver、Custom GPT schema に触る必要が出たら停止して別スライスにする。

## File / Line Hypotheses

- file: src/worker/runtime.js
  - hypothesis: appendMessage の role 分岐と composer textarea 属性が Dashboard Butler chat UX の対象。
  - risk if changed narrowly: owner/butler/system の表示責務が混ざる、または iOS 入力補助抑制が効かない。
  - validation: test/worker.test.js の静的 contract と npm test。
  - related Issue: #450

## Hypothesis Retrospective

- expected: owner copy は owner role のみに出る。Butler返信コピーは butler role のみに出る。system message には copy UI を出さない。textarea は autocapitalize off になる。
- actual: 実装・テストで確認済み。
- mismatch: live iPhone/PWA 実機確認は deploy 後。
- lesson: iOS入力属性は reviewer 指摘で sentences が不適切と判明したため off に修正。
- should become RAG candidate: #450 の live E2E 後に判断。

## Verification Evidence

- Unit: `node --test test/worker.test.js` passed.
- Integration: `npm test` passed: 909 tests, 908 pass, 1 skipped; self-parity passed; generated-worker check passed.
- E2E: 未実施。merge/deploy後に iPhone/PWA Dashboard Butler live E2E が必要。
- Manual: 未実施。owner-facing live verification pending.
- Evidence path/link: src/worker/runtime.js, test/worker.test.js, worker.js, GitHub Actions checks on PR #488 after push.

## Butler Completion Contract

- Owner goal: Dashboard Butler をチャットとして扱いやすくし、owner発言コピー、読みやすいコード表示、iOS入力欄の不要UI抑制を入れる。
- Butler entrypoint: /dashboard
- Action Schema exposure: 不要。このPRは Dashboard UI 表示と入力欄の変更のみ。
- Runtime path: Cloudflare Worker dashboard HTML/JS generated from src/worker/runtime.js into worker.js.
- Runner/runtime truth: Local test truth: npm test passed. Production runtime truth is pending until merge/deploy.
- Authority boundary: 未変更。copy/render/input属性のみで high-risk authority を追加しない。
- E2E evidence: 未実施。merge/deploy後に iPhone/PWA Dashboard Butler で owner copy, Butler reply copy, fenced code block, composer input を確認する。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: このPRでは未実施。merge後に scoped passkey approval 付き deploy が必要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。merge/deploy後に必要。

## Related Constitution Rules

- Butler Completion Gate: completionStatus は incomplete。
- Drift Stop Protocol: #450 のUI/入力UXスライスに限定。
- Change Size and PR Discipline: runtime PR として topic branch で実施。
- Evidence Discipline: local tests と未実施E2Eを分けて記載。

## Out-of-scope but NOT implemented

- app-server bridge の接続修正。
- VPS bridge 常駐設定。
- repository nickname/alias registry。
- Custom GPT Butler fallback。
- Issue #450 close 判断。

## Extra changes (if any)

Codex fallback reviewer の未完了通知を確認し、autocapitalize="sentences" を autocapitalize="off" に修正しました。

<!-- VTDD metadata -->
- Issue: Issue #450
- Execution ID: Not provided.
- Goal: Not provided.
