### PR TITLE
#450 Preflight Cloudflare deploy entitlement before approval

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -72,6 +72,57 @@ jobs:
             exit 1
           fi
 
+      - name: Preflight Cloudflare Workers deploy entitlement
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        shell: bash
+        run: |
+          response_file="$(mktemp)"
+          http_code="$(
+            curl --show-error --silent \
+              -o "$response_file" \
+              -w "%{http_code}" \
+              -H "authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
+              -H "content-type: application/json" \
+              "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/workers/scripts" || true
+          )"
+
+          if [ "$http_code" -ge 200 ] && [ "$http_code" -lt 300 ]; then
+            rm -f "$response_file"
+            echo "Cloudflare Workers deploy entitlement preflight passed."
+            exit 0
+          fi
+
+          echo "Cloudflare Workers deploy entitlement preflight failed before passkey approval validation."
+          echo "HTTP status: ${http_code}"
+          node - "$response_file" <<'NODE'
+          const fs = require("node:fs");
+          const path = process.argv[2];
+          const raw = fs.readFileSync(path, "utf8");
+          let body;
+          try {
+            body = JSON.parse(raw);
+          } catch {
+            const redacted = raw.replace(/([A-Za-z0-9_-]{24,})/g, "[redacted]");
+            console.log(redacted.slice(0, 1000));
+            process.exit(0);
+          }
+          const errors = Array.isArray(body?.errors) ? body.errors : [];
+          const messages = errors.map((error) => ({
+            code: error?.code ?? null,
+            message: String(error?.message ?? "unknown_error").replace(/([A-Za-z0-9_-]{24,})/g, "[redacted]")
+          }));
+          if (messages.length > 0) {
+            console.log(JSON.stringify({ errors: messages }, null, 2));
+          } else {
+            console.log(JSON.stringify({ success: body?.success ?? null }, null, 2));
+          }
+          NODE
+          rm -f "$response_file"
+          echo "Cloudflare account/token is not currently able to access Workers Scripts deploy API. Do not consume another deploy approval until this passes."
+          exit 1
+
       - name: Checkout
         uses: actions/checkout@v6
 

--- a/docs/mvp/production-deploy-path.md
+++ b/docs/mvp/production-deploy-path.md
@@ -98,8 +98,11 @@ Service-to-service dashboard event ingestion still uses machine auth.
 
 This encodes the MVP high-risk policy as:
 
-1. real WebAuthn/passkey approval grant validated against the worker runtime
-2. protected environment confirmation
+1. deploy credential presence checked without printing secret values
+2. Cloudflare Workers Scripts deploy API entitlement checked before approval
+   grant validation
+3. real WebAuthn/passkey approval grant validated against the worker runtime
+4. protected environment confirmation
 
 The workflow validates the grant through `/v2/retrieve/approval-grant` using
 `VTDD_GATEWAY_BEARER_TOKEN`, and the grant scope must match:
@@ -111,7 +114,12 @@ The workflow validates the grant through `/v2/retrieve/approval-grant` using
 ## Notes
 
 - Branch restriction: deploy job runs only when ref is `main`
-- Pre-deploy checks: approval grant validation and `npm test`
+- Pre-deploy checks: Cloudflare Workers deploy entitlement, approval grant
+  validation, and `npm test`
+- If Cloudflare returns `entitlements.not_available` from the Workers Scripts
+  API, the workflow fails before validating the passkey approval grant. Do not
+  consume another deploy approval until the Cloudflare account/token entitlement
+  issue is resolved.
 - Deploy completion notification: optional GitHub Issue comment controlled by
   `VTDD_DEPLOY_NOTIFICATION_ISSUE_NUMBER`
 - Future hardening (out-of-scope for MVP): external passkey attestation service, staged rollout, rollback automation

--- a/test/production-deploy-path.test.js
+++ b/test/production-deploy-path.test.js
@@ -71,7 +71,25 @@ test("deploy-production workflow enforces the MVP production deploy boundary", (
   assert.equal(workflow.includes("Missing required Actions secret: CLOUDFLARE_API_TOKEN"), true);
   assert.equal(workflow.includes("Missing required Actions secret: CLOUDFLARE_ACCOUNT_ID"), true);
   assert.equal(workflow.includes("Missing required Actions secret: CLOUDFLARE_D1_DATABASE_ID"), true);
+  assert.equal(workflow.includes("Preflight Cloudflare Workers deploy entitlement"), true);
+  assert.equal(
+    workflow.includes(
+      "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/workers/scripts"
+    ),
+    true
+  );
+  assert.equal(
+    workflow.includes(
+      "Cloudflare Workers deploy entitlement preflight failed before passkey approval validation."
+    ),
+    true
+  );
   assert.equal(workflow.includes("Validate real passkey approval grant"), true);
+  assert.equal(
+    workflow.indexOf("Preflight Cloudflare Workers deploy entitlement") <
+      workflow.indexOf("Validate real passkey approval grant"),
+    true
+  );
   assert.equal(
     workflow.includes('VTDD_GATEWAY_BEARER_TOKEN: ${{ secrets.VTDD_GATEWAY_BEARER_TOKEN }}'),
     true


### PR DESCRIPTION
## This PR satisfies Intent

- #450 Dashboard Butler live E2E の deploy gate を改善する小スライスです。
- Cloudflare Workers deploy API が entitlements.not_available 等で失敗する状態を、passkey approval grant 検証前に検出します。
- 関連して #417 の post-action orchestration / 失敗理由可視化に沿います。

## Satisfied Success Criteria

- deploy-production workflow に Cloudflare Workers Scripts API entitlement preflight を追加しました。
- preflight は /accounts/${CLOUDFLARE_ACCOUNT_ID}/workers/scripts を bearer token で確認し、2xx以外なら approval grant validation 前に停止します。
- 失敗時は HTTP status と Cloudflare API errors の code/message だけを出し、token/account id は出しません。
- production deploy path doc に approval 前 preflight と entitlements.not_available 時の停止方針を追記しました。
- test/production-deploy-path.test.js で preflight step と approval validation より前の順序を検証しました。

## Unsatisfied Success Criteria

- #450 の本体である iPhone/PWA Dashboard Butler live E2E は未実施です。
- このPRは Cloudflare 側 deploy API/entitlement 失敗を事前検知するだけで、Cloudflare account plan/token 自体は変更しません。
- 現在発生している entitlements.not_available の根本解消は Cloudflare dashboard/token/account 側の確認が必要です。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #450; related #417.
- Implementing Success Criteria: Cloudflare deploy entitlement/token/account failure is detected before passkey approval grant validation; deploy logs expose non-secret failure reason.
- Explicit Non-goals: Cloudflare secret mutation、plan変更、deploy実行、runtime code変更、RAG保存、Issue closeはしない。
- Expected touched files/routes/workflows: .github/workflows/deploy-production.yml, docs/mvp/production-deploy-path.md, test/production-deploy-path.test.js
- Affected Issues: #450, #417
- Affected PRs: new PR
- Affected workflows: deploy-production, guarded-autonomy-required-checks, gemini-pr-review
- Affected runtime/operator surfaces: GitHub Actions deploy-production only. Worker runtime and dashboard UI are unchanged.
- What may break if we patch narrowly: Cloudflare API may still fail after preflight due to transient deploy-time conditions, but approval grant is no longer validated after an already-visible Workers Scripts entitlement failure.
- Unknowns to investigate before coding: Whether the live Cloudflare account is over a plan/account entitlement limit or token permission boundary requires Cloudflare dashboard/API truth outside this PR.
- Validation needed: node --test test/production-deploy-path.test.js; npm test; after merge, deploy workflow should fail before approval validation if Cloudflare entitlement remains blocked.
- Stop condition: If fixing requires Cloudflare plan/token/secret mutation, stop for scoped passkey approval and owner decision.

## File / Line Hypotheses

file: .github/workflows/deploy-production.yml
  - hypothesis: The deploy workflow can check Cloudflare Workers Scripts API reachability before approval validation.
  - risk if changed narrowly: A read/list preflight cannot prove the later deploy upload will succeed, but it catches the observed entitlement/token/account class early.
  - validation: test/production-deploy-path.test.js and npm test.
  - related Issue: #450/#417
file: docs/mvp/production-deploy-path.md
  - hypothesis: The high-risk deploy path doc must state the new pre-approval Cloudflare preflight boundary.
  - risk if changed narrowly: Operators may still retry approval while Cloudflare account/token is blocked.
  - validation: test/production-deploy-path.test.js.

## Hypothesis Retrospective

expected: Cloudflare entitlement/token/account failure is surfaced before passkey approval validation.
actual: workflow, docs, and tests updated; local tests passed.
mismatch: This PR does not resolve the Cloudflare account entitlement itself.
lesson: Deploy provider preflight should happen before short-lived high-risk approval validation when possible.
should become RAG candidate: yes, after live deploy recovery confirms the failure class.

## Verification Evidence

- Unit: `node --test test/production-deploy-path.test.js` passed.
- Integration: `npm test` passed: 913 tests, 912 pass, 1 skipped; self-parity passed; generated-worker check passed.
- E2E: Workflow-path E2E covered by production-deploy-path test: preflight step exists and appears before approval grant validation. Live deploy is not run in this PR.
- Manual: Inspected failed deploy runs 26296580935 and 26296845248: both reached wrangler deploy and failed with Cloudflare API entitlements.not_available [code: 10007] after tests passed.
- Evidence path/link: .github/workflows/deploy-production.yml, docs/mvp/production-deploy-path.md, test/production-deploy-path.test.js

## Butler Completion Contract

- Owner goal: Cloudflare側のdeploy APIが落ちる時に、短命のpasskey approvalを無駄に消費せず、失敗理由をButler/Actionsで読めるようにする。
- Butler entrypoint: Dashboard/Butler governed deploy -> deploy-production workflow -> Cloudflare entitlement preflight -> approval validation only if provider preflight passes.
- Action Schema exposure: 不要。既存 deploy path の GitHub Actions workflow 内部ガードのみ。
- Runtime path: deploy-production.yml preflight step calls Cloudflare Workers Scripts API before scripts/validate-deploy-approval-grant.mjs.
- Runner/runtime truth: Local tests passed. Production deploy truth pending until this PR is merged and the workflow is run.
- Authority boundary: Cloudflare secret/plan/token mutationはしない。read-only Cloudflare API preflight only. deploy itself remains scoped passkey approval gated.
- E2E evidence: Workflow-path E2E is covered by test. iPhone/PWA live deploy recovery remains pending after merge/deploy attempt.
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 未実施。これは deploy workflow の前段ガードPRであり、merge後に新しい approval が必要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。

## Related Constitution Rules

- Butler Completion Gate: #450 completionStatus は incomplete。
- Authority Boundary: Cloudflare secret/plan mutationなし。
- Evidence Discipline: failed run evidence and local tests recorded。
- Change Size and PR Discipline: deploy guard onlyの小PR。

## Out-of-scope but NOT implemented

- Cloudflare plan変更。
- Cloudflare token/secret mutation。
- deploy再実行。
- Worker runtime変更。
- Dashboard UI変更。
- Issue #450 close判断。

## Extra changes (if any)

Cloudflare docs indicate Workers Free daily request exhaustion returns Error 1027, and Free Worker size limit is 3 MB. Current worker.js is about 2.29 MB, so the observed entitlements.not_available [code: 10007] is more likely account/token/Cloudflare entitlement/API availability than normal request quota exhaustion.

<!-- VTDD metadata -->
- Issue: Issue #450
- Execution ID: Not provided.
- Goal: Not provided.
