### PR TITLE
#444 Dashboard iOS PWA notification entry

### DIFF
--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -6257,12 +6257,8 @@ function createD1DashboardPushSubscriptionStore(d1) {
           normalized.updatedAt,
           JSON.stringify({
             endpointHash: normalized.endpointHash,
-            endpoint: normalized.endpoint,
             expirationTime: normalized.expirationTime,
-            keys: {
-              p256dh: normalized.p256dh,
-              auth: normalized.auth
-            },
+            rawMaterial: "stored_in_columns_for_server_side_web_push_send_only",
             userAgent: normalized.userAgent,
             ownerIdentity: normalized.ownerIdentity,
             updatedAt: normalized.updatedAt
@@ -8110,7 +8106,8 @@ async function renderDashboardNotificationsPage({ runtimeOrigin, dashboardEventS
         <section class="lane">
           <div class="lane-title"><h2>Authority boundary</h2><span class="pill">read/write</span></div>
           <p>push subscription は dashboard owner session から保存します。HTML には endpoint、auth key、p256dh key を埋め込みません。</p>
-          <p class="muted">Web Push 送信には server-side VAPID secret が必要です。この画面には public key だけを渡します。</p>
+          <p class="muted">同一 origin の dashboard owner session cookie / Cloudflare Access identity を使うため、購読保存 fetch は credentials: same-origin で送ります。</p>
+          <p class="muted">Web Push 送信には server-side VAPID secret と subscription raw material が必要です。D1 には送信用に保持し、response / HTML / payload_json には raw key を返しません。</p>
         </section>
       </div>
       <div class="grid single">
@@ -8155,7 +8152,7 @@ async function renderDashboardNotificationsPage({ runtimeOrigin, dashboardEventS
 
           async function registration() {
             if (!("serviceWorker" in navigator)) return null;
-            return navigator.serviceWorker.register("/dashboard-sw.js", { scope: "/" });
+            return navigator.serviceWorker.register("/dashboard-sw.js", { scope: "/dashboard/" });
           }
 
           async function refreshState() {
@@ -8190,6 +8187,7 @@ async function renderDashboardNotificationsPage({ runtimeOrigin, dashboardEventS
             });
             const response = await fetch("/v2/dashboard/push/subscription", {
               method: "POST",
+              credentials: "same-origin",
               headers: { "content-type": "application/json" },
               body: JSON.stringify({ subscription: subscription.toJSON(), userAgent: navigator.userAgent })
             });
@@ -8230,7 +8228,7 @@ function buildDashboardWebManifest(url) {
     name: "VTDD Butler",
     short_name: "VTDD",
     start_url: "/dashboard",
-    scope: "/",
+    scope: "/dashboard/",
     display: "standalone",
     background_color: "#050505",
     theme_color: "#050505",
@@ -8275,9 +8273,25 @@ self.addEventListener("push", (event) => {
   event.waitUntil(self.registration.showNotification(title, options));
 });
 
+function safeDashboardNotificationUrl(value) {
+  let parsed;
+  try {
+    parsed = new URL(value || "/dashboard/notifications", self.location.origin);
+  } catch {
+    parsed = new URL("/dashboard/notifications", self.location.origin);
+  }
+  if (parsed.origin !== self.location.origin) {
+    return new URL("/dashboard/notifications", self.location.origin).toString();
+  }
+  if (parsed.pathname !== "/dashboard" && !parsed.pathname.startsWith("/dashboard/")) {
+    return new URL("/dashboard/notifications", self.location.origin).toString();
+  }
+  return parsed.toString();
+}
+
 self.addEventListener("notificationclick", (event) => {
   event.notification.close();
-  const targetUrl = new URL(event.notification.data && event.notification.data.url || "/dashboard/notifications", self.location.origin).toString();
+  const targetUrl = safeDashboardNotificationUrl(event.notification.data && event.notification.data.url);
   event.waitUntil((async () => {
     const clients = await self.clients.matchAll({ type: "window", includeUncontrolled: true });
     for (const client of clients) {

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -476,12 +476,14 @@ const LEGACY_AUTONOMY_MODE_ENV = "MVP_AUTONOMY_MODE";
 const MEMORY_D1_BINDING = "VTDD_MEMORY_D1";
 const MEMORY_R2_BINDING = "VTDD_MEMORY_R2";
 const MEMORY_BLOB_THRESHOLD_ENV = "VTDD_MEMORY_BLOB_THRESHOLD";
+const WEB_PUSH_PUBLIC_KEY_ENV = "VTDD_WEB_PUSH_PUBLIC_KEY";
 const DEFAULT_MEMORY_LIMIT = 20;
 const MAX_MEMORY_LIMIT = 200;
 const memoryProviderCache = new WeakMap();
 const d1AdapterCache = new WeakMap();
 const dashboardEventStoreCache = new WeakMap();
 const dashboardChatStoreCache = new WeakMap();
+const dashboardPushSubscriptionStoreCache = new WeakMap();
 
 export default {
   async fetch(request, env) {
@@ -528,6 +530,20 @@ export default {
           mcpPath: MCP_PATH
         })
       );
+    }
+
+    if (request.method === "GET" && url.pathname === "/dashboard.webmanifest") {
+      return json(200, buildDashboardWebManifest(url), {
+        "content-type": "application/manifest+json; charset=utf-8"
+      });
+    }
+
+    if (request.method === "GET" && url.pathname === "/dashboard-sw.js") {
+      return javascript(200, renderDashboardServiceWorkerScript());
+    }
+
+    if (request.method === "GET" && url.pathname === "/dashboard-icon.svg") {
+      return svg(200, renderDashboardIconSvg());
     }
 
     if (request.method === "GET" && isDashboardPagePath(url.pathname)) {
@@ -577,13 +593,18 @@ export default {
         200,
         await renderDashboardNotificationsPage({
           runtimeOrigin: url.origin,
-          dashboardEventStore: resolveDashboardEventStore(env)
+          dashboardEventStore: resolveDashboardEventStore(env),
+          env
         })
       );
     }
 
     if (request.method === "POST" && isApiPath(url.pathname, "/dashboard/chat/messages")) {
       return handleDashboardChatMessageRequest(request, env);
+    }
+
+    if (request.method === "POST" && isApiPath(url.pathname, "/dashboard/push/subscription")) {
+      return handleDashboardPushSubscriptionRequest(request, env);
     }
 
     if (request.method === "GET" && isDashboardChatSocketApiPath(url.pathname)) {
@@ -3620,6 +3641,56 @@ async function handleDashboardChatMessageRequest(request, env) {
   });
 }
 
+async function handleDashboardPushSubscriptionRequest(request, env) {
+  const dashboardAuth = await authorizeDashboardRequest({
+    request,
+    env,
+    apiSuffix: "/dashboard/push/subscription"
+  });
+  if (!dashboardAuth.ok) {
+    return json(dashboardAuth.status, {
+      ok: false,
+      error: "dashboard_auth_required",
+      reason: dashboardAuth.reason
+    });
+  }
+
+  const store = resolveDashboardPushSubscriptionStore(env);
+  if (!store) {
+    return json(503, {
+      ok: false,
+      error: "dashboard_push_subscription_store_unavailable",
+      reason: "dashboard push subscription store is not configured"
+    });
+  }
+
+  const payload = await readJson(request);
+  const subscription = await normalizeDashboardPushSubscription(payload?.subscription || payload);
+  if (!subscription.ok) {
+    return json(422, {
+      ok: false,
+      error: "dashboard_push_subscription_invalid",
+      reason: subscription.reason
+    });
+  }
+
+  const saved = await store.put({
+    ...subscription.record,
+    userAgent: sanitizeDashboardChatText(payload?.userAgent || request.headers.get("user-agent") || ""),
+    ownerIdentity: normalizeDashboardEventText(dashboardAuth.subject) || normalizeDashboardEventText(dashboardAuth.authType) || "dashboard_owner",
+    updatedAt: new Date().toISOString()
+  });
+
+  return json(202, {
+    ok: true,
+    subscription: {
+      endpointHash: saved.endpointHash,
+      updatedAt: saved.updatedAt,
+      status: "saved"
+    }
+  });
+}
+
 async function handleDashboardChatSocketRequest(request, url, env) {
   const auth = await authorizeDashboardRequest({
     request,
@@ -5516,6 +5587,27 @@ function resolveDashboardChatStore(env) {
   return store;
 }
 
+function resolveDashboardPushSubscriptionStore(env) {
+  if (!env || typeof env !== "object") {
+    return null;
+  }
+  const injectedStore = env.DASHBOARD_PUSH_SUBSCRIPTION_STORE ?? null;
+  if (injectedStore && typeof injectedStore.put === "function") {
+    return injectedStore;
+  }
+
+  const d1Binding = env[MEMORY_D1_BINDING] ?? null;
+  if (!d1Binding || typeof d1Binding.prepare !== "function") {
+    return null;
+  }
+  if (dashboardPushSubscriptionStoreCache.has(d1Binding)) {
+    return dashboardPushSubscriptionStoreCache.get(d1Binding);
+  }
+  const store = createD1DashboardPushSubscriptionStore(d1Binding);
+  dashboardPushSubscriptionStoreCache.set(d1Binding, store);
+  return store;
+}
+
 function resolveDashboardChatRoomStub(env, threadId) {
   const namespace = env?.DASHBOARD_CHAT_ROOMS ?? null;
   const roomName = normalizeDashboardThreadId(threadId);
@@ -6132,6 +6224,70 @@ function createD1DashboardChatStore(d1) {
   }
 }
 
+function createD1DashboardPushSubscriptionStore(d1) {
+  let schemaPromise = null;
+  return {
+    async put(subscription) {
+      const normalized = {
+        endpointHash: normalizeDashboardEventText(subscription.endpointHash),
+        endpoint: normalizeDashboardEventText(subscription.endpoint),
+        expirationTime: subscription.expirationTime ?? null,
+        p256dh: normalizeDashboardEventText(subscription.p256dh),
+        auth: normalizeDashboardEventText(subscription.auth),
+        userAgent: sanitizeDashboardChatText(subscription.userAgent),
+        ownerIdentity: normalizeDashboardEventText(subscription.ownerIdentity) || "dashboard_owner",
+        updatedAt: normalizeIsoTimestamp(subscription.updatedAt) || new Date().toISOString()
+      };
+      await ensureSchema();
+      await d1
+        .prepare(
+          `INSERT OR REPLACE INTO vtdd_dashboard_push_subscriptions (
+             endpoint_hash, endpoint, expiration_time, p256dh, auth, user_agent,
+             owner_identity, updated_at, payload_json
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+        )
+        .bind(
+          normalized.endpointHash,
+          normalized.endpoint,
+          normalized.expirationTime,
+          normalized.p256dh,
+          normalized.auth,
+          normalized.userAgent,
+          normalized.ownerIdentity,
+          normalized.updatedAt,
+          JSON.stringify({
+            endpointHash: normalized.endpointHash,
+            endpoint: normalized.endpoint,
+            expirationTime: normalized.expirationTime,
+            keys: {
+              p256dh: normalized.p256dh,
+              auth: normalized.auth
+            },
+            userAgent: normalized.userAgent,
+            ownerIdentity: normalized.ownerIdentity,
+            updatedAt: normalized.updatedAt
+          })
+        )
+        .run();
+      return normalized;
+    }
+  };
+
+  function ensureSchema() {
+    if (!schemaPromise) {
+      schemaPromise = (async () => {
+        await d1.exec(
+          "CREATE TABLE IF NOT EXISTS vtdd_dashboard_push_subscriptions (endpoint_hash TEXT PRIMARY KEY, endpoint TEXT NOT NULL, expiration_time INTEGER, p256dh TEXT NOT NULL, auth TEXT NOT NULL, user_agent TEXT, owner_identity TEXT NOT NULL, updated_at TEXT NOT NULL, payload_json TEXT NOT NULL);"
+        );
+        await d1.exec(
+          "CREATE INDEX IF NOT EXISTS idx_vtdd_dashboard_push_subscriptions_updated_at ON vtdd_dashboard_push_subscriptions (updated_at DESC);"
+        );
+      })();
+    }
+    return schemaPromise;
+  }
+}
+
 function buildDashboardChatTurn(payload, options = {}) {
   const input = normalizeObject(payload);
   const repository = normalizeCanonicalRepositoryInput(input.repository);
@@ -6216,6 +6372,49 @@ function normalizeDashboardChatMessage(message, defaults = {}) {
     text: sanitizeDashboardChatText(input.text || input.message || input.body) || "（空のメッセージ）",
     createdAt
   };
+}
+
+async function normalizeDashboardPushSubscription(value) {
+  const input = normalizeObject(value);
+  const endpoint = normalizeDashboardUrl(input.endpoint);
+  const keys = normalizeObject(input.keys);
+  const p256dh = normalizeDashboardEventText(keys.p256dh);
+  const auth = normalizeDashboardEventText(keys.auth);
+  if (!endpoint) {
+    return {
+      ok: false,
+      reason: "push subscription endpoint is required"
+    };
+  }
+  if (!p256dh || !auth) {
+    return {
+      ok: false,
+      reason: "push subscription keys.p256dh and keys.auth are required"
+    };
+  }
+  const endpointHash = await sha256Hex(endpoint);
+  return {
+    ok: true,
+    record: {
+      endpointHash,
+      endpoint,
+      expirationTime: Number.isFinite(Number(input.expirationTime)) ? Number(input.expirationTime) : null,
+      p256dh,
+      auth
+    }
+  };
+}
+
+async function sha256Hex(value) {
+  const text = normalizeText(value);
+  if (!text) {
+    return "";
+  }
+  if (globalThis.crypto?.subtle && typeof TextEncoder !== "undefined") {
+    const digest = await globalThis.crypto.subtle.digest("SHA-256", new TextEncoder().encode(text));
+    return [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+  }
+  return btoa(text).replace(/[^A-Za-z0-9]/g, "").slice(0, 64);
 }
 
 function normalizeDashboardThreadSummary(summary, defaults = {}) {
@@ -7871,7 +8070,7 @@ async function renderDashboardSelfParityPage({ url, env } = {}) {
   });
 }
 
-async function renderDashboardNotificationsPage({ runtimeOrigin, dashboardEventStore } = {}) {
+async function renderDashboardNotificationsPage({ runtimeOrigin, dashboardEventStore, env } = {}) {
   const origin = normalize(runtimeOrigin);
   const recentSince = new Date(Date.now() - 5 * 60 * 1000).toISOString();
   const recentEvents = await retrieveRecentDashboardEvents({
@@ -7879,24 +8078,222 @@ async function renderDashboardNotificationsPage({ runtimeOrigin, dashboardEventS
     since: recentSince,
     limit: 20
   });
+  const publicKey = normalizeDashboardEventText(env?.[WEB_PUSH_PUBLIC_KEY_ENV]);
   return renderDashboardUtilityPage({
     title: "通知センター",
     subtitle: "dashboard events",
     backHref: `${origin}/dashboard`,
     body: `
       <section class="hero">
-        <p>今は iOS Push / 音 / PWA badge ではなく、Worker に届いた dashboard event の人間向け表示です。</p>
+        <p>Dashboard Butler の通知入口です。iOS PWA Web Push、OS の通知音、未読 badge はこの画面から許可・確認します。</p>
         <p class="muted">VTDD だけでなく、他 repo / 並行開発 / queue / workflow から届いたイベントを直近5分だけ表示します。</p>
-        <p class="muted">次の段階で Web Push 購読、通知 permission、通知タップ遷移を追加します。</p>
       </section>
+      <div class="grid">
+        <section class="lane">
+          <div class="lane-title"><h2>iOS PWA 通知</h2><span class="pill" id="push-support-pill">確認中</span></div>
+          <p id="push-state" class="muted">通知状態を確認しています。</p>
+          <div class="actions">
+            <button class="dashboard-action" id="push-permission-button" type="button">通知を許可</button>
+            <button class="dashboard-action" id="push-subscribe-button" type="button">購読を保存</button>
+            <button class="dashboard-action" id="push-test-button" type="button">テスト通知</button>
+          </div>
+          <p class="muted">通知タップは通知センターへ戻ります。音は iOS 側の通知設定に従います。</p>
+        </section>
+        <section class="lane">
+          <div class="lane-title"><h2>Badge</h2><span class="pill" id="badge-support-pill">確認中</span></div>
+          <p id="badge-state" class="muted">Badging API の対応状況を確認しています。</p>
+          <div class="actions">
+            <button class="dashboard-action" id="badge-set-button" type="button">未読数を反映</button>
+            <button class="dashboard-action" id="badge-clear-button" type="button">Badge を消す</button>
+          </div>
+        </section>
+        <section class="lane">
+          <div class="lane-title"><h2>Authority boundary</h2><span class="pill">read/write</span></div>
+          <p>push subscription は dashboard owner session から保存します。HTML には endpoint、auth key、p256dh key を埋め込みません。</p>
+          <p class="muted">Web Push 送信には server-side VAPID secret が必要です。この画面には public key だけを渡します。</p>
+        </section>
+      </div>
       <div class="grid single">
         <section class="lane">
           <div class="lane-title"><h2>最新通知</h2><span class="pill">直近5分</span></div>
           ${recentEvents.length > 0 ? recentEvents.map((event) => renderDashboardNotificationEvent(event)).join("") : `<p class="muted">直近5分の通知はありません。</p>`}
         </section>
       </div>
+      <script>
+        (() => {
+          const vapidPublicKey = ${JSON.stringify(publicKey)};
+          const pushState = document.getElementById("push-state");
+          const pushSupportPill = document.getElementById("push-support-pill");
+          const badgeState = document.getElementById("badge-state");
+          const badgeSupportPill = document.getElementById("badge-support-pill");
+          const permissionButton = document.getElementById("push-permission-button");
+          const subscribeButton = document.getElementById("push-subscribe-button");
+          const testButton = document.getElementById("push-test-button");
+          const badgeSetButton = document.getElementById("badge-set-button");
+          const badgeClearButton = document.getElementById("badge-clear-button");
+          const unreadCount = ${recentEvents.length};
+
+          function setText(node, text) {
+            if (node) node.textContent = text;
+          }
+
+          function setPill(node, text, ok) {
+            if (!node) return;
+            node.textContent = text;
+            node.classList.toggle("success", ok === true);
+            node.classList.toggle("danger", ok === false);
+          }
+
+          function base64UrlToUint8Array(value) {
+            const padding = "=".repeat((4 - value.length % 4) % 4);
+            const base64 = (value + padding).replace(/-/g, "+").replace(/_/g, "/");
+            const raw = atob(base64);
+            const output = new Uint8Array(raw.length);
+            for (let index = 0; index < raw.length; index += 1) output[index] = raw.charCodeAt(index);
+            return output;
+          }
+
+          async function registration() {
+            if (!("serviceWorker" in navigator)) return null;
+            return navigator.serviceWorker.register("/dashboard-sw.js", { scope: "/" });
+          }
+
+          async function refreshState() {
+            const pushSupported = "serviceWorker" in navigator && "PushManager" in window && "Notification" in window;
+            setPill(pushSupportPill, pushSupported ? "対応" : "未対応", pushSupported);
+            setText(pushState, pushSupported
+              ? "通知 permission: " + Notification.permission + (vapidPublicKey ? "" : " / VAPID public key 未設定")
+              : "この環境は Web Push に未対応です。iOS はホーム画面に追加した PWA が必要です。");
+            const badgeSupported = "setAppBadge" in navigator && "clearAppBadge" in navigator;
+            setPill(badgeSupportPill, badgeSupported ? "対応" : "未対応", badgeSupported);
+            setText(badgeState, badgeSupported ? "未読通知数をホーム画面 badge に反映できます。" : "この環境では Badging API が未対応です。");
+            if (subscribeButton) subscribeButton.disabled = !pushSupported || !vapidPublicKey || Notification.permission !== "granted";
+            if (permissionButton) permissionButton.disabled = !pushSupported || Notification.permission === "granted";
+            if (testButton) testButton.disabled = !pushSupported || Notification.permission !== "granted";
+            if (badgeSetButton) badgeSetButton.disabled = !badgeSupported;
+            if (badgeClearButton) badgeClearButton.disabled = !badgeSupported;
+          }
+
+          permissionButton?.addEventListener("click", async () => {
+            if (!("Notification" in window)) return refreshState();
+            await Notification.requestPermission();
+            await registration();
+            await refreshState();
+          });
+
+          subscribeButton?.addEventListener("click", async () => {
+            const reg = await registration();
+            if (!reg || !vapidPublicKey) return refreshState();
+            const subscription = await reg.pushManager.subscribe({
+              userVisibleOnly: true,
+              applicationServerKey: base64UrlToUint8Array(vapidPublicKey)
+            });
+            const response = await fetch("/v2/dashboard/push/subscription", {
+              method: "POST",
+              headers: { "content-type": "application/json" },
+              body: JSON.stringify({ subscription: subscription.toJSON(), userAgent: navigator.userAgent })
+            });
+            setText(pushState, response.ok ? "push subscription を保存しました。" : "push subscription の保存に失敗しました。");
+            await refreshState();
+          });
+
+          testButton?.addEventListener("click", async () => {
+            const reg = await registration();
+            if (!reg) return refreshState();
+            await reg.showNotification("VTDD Butler", {
+              body: "Dashboard Butler の通知テストです。",
+              tag: "vtdd-dashboard-test",
+              renotify: true,
+              silent: false,
+              data: { url: "/dashboard/notifications" }
+            });
+          });
+
+          badgeSetButton?.addEventListener("click", async () => {
+            if ("setAppBadge" in navigator) await navigator.setAppBadge(Math.max(1, unreadCount));
+          });
+
+          badgeClearButton?.addEventListener("click", async () => {
+            if ("clearAppBadge" in navigator) await navigator.clearAppBadge();
+          });
+
+          refreshState();
+        })();
+      </script>
     `
   });
+}
+
+function buildDashboardWebManifest(url) {
+  const origin = normalize(url?.origin);
+  return {
+    name: "VTDD Butler",
+    short_name: "VTDD",
+    start_url: "/dashboard",
+    scope: "/",
+    display: "standalone",
+    background_color: "#050505",
+    theme_color: "#050505",
+    icons: [
+      {
+        src: `${origin}/dashboard-icon.svg`,
+        sizes: "any",
+        type: "image/svg+xml",
+        purpose: "any maskable"
+      }
+    ]
+  };
+}
+
+function renderDashboardServiceWorkerScript() {
+  return `
+self.addEventListener("install", () => {
+  self.skipWaiting();
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(self.clients.claim());
+});
+
+self.addEventListener("push", (event) => {
+  let payload = {};
+  try {
+    payload = event.data ? event.data.json() : {};
+  } catch {
+    payload = { body: event.data ? event.data.text() : "" };
+  }
+  const title = String(payload.title || "VTDD Butler");
+  const options = {
+    body: String(payload.body || payload.message || "Dashboard Butler の通知です。"),
+    tag: String(payload.tag || "vtdd-dashboard"),
+    renotify: payload.renotify !== false,
+    silent: payload.silent === true,
+    data: {
+      url: String(payload.url || "/dashboard/notifications")
+    }
+  };
+  event.waitUntil(self.registration.showNotification(title, options));
+});
+
+self.addEventListener("notificationclick", (event) => {
+  event.notification.close();
+  const targetUrl = new URL(event.notification.data && event.notification.data.url || "/dashboard/notifications", self.location.origin).toString();
+  event.waitUntil((async () => {
+    const clients = await self.clients.matchAll({ type: "window", includeUncontrolled: true });
+    for (const client of clients) {
+      if ("focus" in client) {
+        await client.navigate(targetUrl);
+        return client.focus();
+      }
+    }
+    return self.clients.openWindow(targetUrl);
+  })());
+});
+`.trim();
+}
+
+function renderDashboardIconSvg() {
+  return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><rect width="512" height="512" rx="112" fill="#050505"/><path d="M144 128h224v52H144zM144 230h224v52H144zM144 332h148v52H144z" fill="#f7f7f4"/></svg>`;
 }
 
 function renderGitHubTruthLane(title, result, renderCard) {
@@ -8038,6 +8435,8 @@ function renderDashboardUtilityPage({ title, subtitle, backHref, body }) {
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="manifest" href="/dashboard.webmanifest">
+  <meta name="theme-color" content="#050505">
   <title>${escapeDashboardHtml(title)} - VTDD Butler</title>
   <style>
     :root { color-scheme: light dark; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; --bg: #f7f7f4; --panel: #fff; --text: #151515; --muted: #62625d; --border: #deded6; --soft: #f0f0eb; }
@@ -8051,7 +8450,8 @@ function renderDashboardUtilityPage({ title, subtitle, backHref, body }) {
     h2 { font-size: 18px; margin: 0; }
     p { line-height: 1.6; margin: 0 0 10px; }
     a { color: inherit; text-underline-offset: 4px; }
-    .back, .actions a { display: inline-flex; min-height: 38px; align-items: center; justify-content: center; border: 1px solid var(--border); border-radius: 999px; padding: 6px 12px; background: var(--soft); text-decoration: none; font-weight: 750; }
+    .back, .actions a, .dashboard-action { display: inline-flex; min-height: 38px; align-items: center; justify-content: center; border: 1px solid var(--border); border-radius: 999px; padding: 6px 12px; background: var(--soft); color: var(--text); text-decoration: none; font: inherit; font-weight: 750; }
+    .dashboard-action:disabled { opacity: .45; }
     .hero, .lane, .notice { border: 1px solid var(--border); border-radius: 16px; background: var(--panel); padding: 14px; margin-bottom: 14px; }
     .actions { display: flex; flex-wrap: wrap; gap: 8px; }
     .grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 14px; }
@@ -8208,6 +8608,8 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="manifest" href="/dashboard.webmanifest">
+  <meta name="theme-color" content="#050505">
   <title>VTDD v2 Dashboard</title>
   <style>
     :root {
@@ -9015,6 +9417,27 @@ function html(status, body) {
       "content-type": "text/html; charset=utf-8",
       "cache-control": "no-store, no-cache, must-revalidate, max-age=0",
       pragma: "no-cache"
+    }
+  });
+}
+
+function javascript(status, body) {
+  return new Response(body, {
+    status,
+    headers: {
+      "content-type": "application/javascript; charset=utf-8",
+      "cache-control": "no-store, no-cache, must-revalidate, max-age=0",
+      pragma: "no-cache"
+    }
+  });
+}
+
+function svg(status, body) {
+  return new Response(body, {
+    status,
+    headers: {
+      "content-type": "image/svg+xml; charset=utf-8",
+      "cache-control": "public, max-age=3600"
     }
   });
 }

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -1642,9 +1642,12 @@ test("worker serves dashboard notification center for recent events across repos
   assert.equal(body.includes("id=\"push-subscribe-button\""), true);
   assert.equal(body.includes("id=\"badge-set-button\""), true);
   assert.equal(body.includes("/v2/dashboard/push/subscription"), true);
+  assert.equal(body.includes("credentials: \"same-origin\""), true);
+  assert.equal(body.includes("D1 には送信用に保持し、response / HTML / payload_json には raw key を返しません"), true);
   assert.equal(body.includes("navigator.setAppBadge"), true);
   assert.equal(body.includes("Notification.requestPermission"), true);
   assert.equal(body.includes("serviceWorker.register(\"/dashboard-sw.js\""), true);
+  assert.equal(body.includes("scope: \"/dashboard/\""), true);
   assert.equal(body.includes("secret-must-not-persist"), false);
   assert.equal(body.includes("他 repo / 並行開発 / queue / workflow"), true);
   assert.equal(body.includes("最新通知"), true);
@@ -1666,6 +1669,7 @@ test("worker serves dashboard PWA manifest and service worker notification handl
   const manifest = await manifestResponse.json();
   assert.equal(manifest.name, "VTDD Butler");
   assert.equal(manifest.start_url, "/dashboard");
+  assert.equal(manifest.scope, "/dashboard/");
   assert.equal(manifest.display, "standalone");
   assert.equal(manifest.icons[0].src, "https://example.com/dashboard-icon.svg");
 
@@ -1677,6 +1681,9 @@ test("worker serves dashboard PWA manifest and service worker notification handl
   assert.equal(serviceWorker.includes("showNotification"), true);
   assert.equal(serviceWorker.includes('self.addEventListener("notificationclick"'), true);
   assert.equal(serviceWorker.includes("/dashboard/notifications"), true);
+  assert.equal(serviceWorker.includes("safeDashboardNotificationUrl"), true);
+  assert.equal(serviceWorker.includes("parsed.origin !== self.location.origin"), true);
+  assert.equal(serviceWorker.includes('!parsed.pathname.startsWith("/dashboard/")'), true);
 
   const iconResponse = await worker.fetch(new Request("https://example.com/dashboard-icon.svg"));
   assert.equal(iconResponse.status, 200);
@@ -1741,6 +1748,61 @@ test("worker stores dashboard push subscription only for an authenticated owner 
   assert.equal(saved.p256dh, "p256dh-key");
   assert.equal(saved.auth, "auth-key");
   assert.equal(saved.ownerIdentity, "owner@example.com");
+});
+
+test("worker redacts dashboard push subscription raw material from D1 payload_json", async () => {
+  const prepared = [];
+  const d1 = {
+    async exec(statement) {
+      prepared.push({ type: "exec", statement });
+      return {};
+    },
+    prepare(statement) {
+      const call = { type: "prepare", statement, values: [] };
+      prepared.push(call);
+      return {
+        bind(...values) {
+          call.values = values;
+          return {
+            async run() {
+              return {};
+            }
+          };
+        }
+      };
+    }
+  };
+
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/dashboard/push/subscription", {
+      method: "POST",
+      headers: {
+        ...dashboardAccessHeaders,
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({
+        subscription: {
+          endpoint: "https://push.example/subscription/raw-endpoint",
+          keys: { p256dh: "raw-p256dh-key", auth: "raw-auth-key" }
+        }
+      })
+    }),
+    {
+      ...dashboardAccessEnv,
+      VTDD_MEMORY_D1: d1
+    }
+  );
+
+  assert.equal(response.status, 202);
+  const insert = prepared.find((call) =>
+    String(call.statement || "").includes("INSERT OR REPLACE INTO vtdd_dashboard_push_subscriptions")
+  );
+  assert.ok(insert);
+  const payloadJson = insert.values[8];
+  assert.equal(payloadJson.includes("raw-endpoint"), false);
+  assert.equal(payloadJson.includes("raw-p256dh-key"), false);
+  assert.equal(payloadJson.includes("raw-auth-key"), false);
+  assert.equal(payloadJson.includes("stored_in_columns_for_server_side_web_push_send_only"), true);
 });
 
 test("worker ingests GitHub Actions deploy completion event and shows it on dashboard", async () => {

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -169,6 +169,17 @@ function createInMemoryDashboardChatStore() {
   };
 }
 
+function createInMemoryDashboardPushSubscriptionStore() {
+  const subscriptions = new Map();
+  return {
+    subscriptions,
+    async put(subscription) {
+      subscriptions.set(subscription.endpointHash, subscription);
+      return subscription;
+    }
+  };
+}
+
 function createMockDashboardChatRoomNamespace() {
   const calls = [];
   return {
@@ -1625,7 +1636,16 @@ test("worker serves dashboard notification center for recent events across repos
   assert.match(response.headers.get("content-type"), /text\/html/);
   const body = await response.text();
   assert.equal(body.includes("通知センター"), true);
-  assert.equal(body.includes("iOS Push / 音 / PWA badge ではなく"), true);
+  assert.equal(body.includes("Dashboard Butler の通知入口です"), true);
+  assert.equal(body.includes("iOS PWA Web Push"), true);
+  assert.equal(body.includes("id=\"push-permission-button\""), true);
+  assert.equal(body.includes("id=\"push-subscribe-button\""), true);
+  assert.equal(body.includes("id=\"badge-set-button\""), true);
+  assert.equal(body.includes("/v2/dashboard/push/subscription"), true);
+  assert.equal(body.includes("navigator.setAppBadge"), true);
+  assert.equal(body.includes("Notification.requestPermission"), true);
+  assert.equal(body.includes("serviceWorker.register(\"/dashboard-sw.js\""), true);
+  assert.equal(body.includes("secret-must-not-persist"), false);
   assert.equal(body.includes("他 repo / 並行開発 / queue / workflow"), true);
   assert.equal(body.includes("最新通知"), true);
   assert.equal(body.includes("success"), true);
@@ -1637,6 +1657,90 @@ test("worker serves dashboard notification center for recent events across repos
   assert.equal(body.includes("dashboard-notification-center"), true);
   assert.equal(body.includes("2分前"), true);
   assert.equal(body.includes("old notification"), false);
+});
+
+test("worker serves dashboard PWA manifest and service worker notification handlers", async () => {
+  const manifestResponse = await worker.fetch(new Request("https://example.com/dashboard.webmanifest"));
+  assert.equal(manifestResponse.status, 200);
+  assert.match(manifestResponse.headers.get("content-type"), /application\/manifest\+json/);
+  const manifest = await manifestResponse.json();
+  assert.equal(manifest.name, "VTDD Butler");
+  assert.equal(manifest.start_url, "/dashboard");
+  assert.equal(manifest.display, "standalone");
+  assert.equal(manifest.icons[0].src, "https://example.com/dashboard-icon.svg");
+
+  const serviceWorkerResponse = await worker.fetch(new Request("https://example.com/dashboard-sw.js"));
+  assert.equal(serviceWorkerResponse.status, 200);
+  assert.match(serviceWorkerResponse.headers.get("content-type"), /application\/javascript/);
+  const serviceWorker = await serviceWorkerResponse.text();
+  assert.equal(serviceWorker.includes('self.addEventListener("push"'), true);
+  assert.equal(serviceWorker.includes("showNotification"), true);
+  assert.equal(serviceWorker.includes('self.addEventListener("notificationclick"'), true);
+  assert.equal(serviceWorker.includes("/dashboard/notifications"), true);
+
+  const iconResponse = await worker.fetch(new Request("https://example.com/dashboard-icon.svg"));
+  assert.equal(iconResponse.status, 200);
+  assert.match(iconResponse.headers.get("content-type"), /image\/svg\+xml/);
+});
+
+test("worker stores dashboard push subscription only for an authenticated owner session", async () => {
+  const store = createInMemoryDashboardPushSubscriptionStore();
+  const unauthenticated = await worker.fetch(
+    new Request("https://example.com/v2/dashboard/push/subscription", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        subscription: {
+          endpoint: "https://push.example/subscription/secret-endpoint",
+          keys: { p256dh: "p256dh-key", auth: "auth-key" }
+        }
+      })
+    }),
+    {
+      ...dashboardAccessEnv,
+      DASHBOARD_PUSH_SUBSCRIPTION_STORE: store
+    }
+  );
+  assert.equal(unauthenticated.status, 401);
+  assert.equal(store.subscriptions.size, 0);
+
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/dashboard/push/subscription", {
+      method: "POST",
+      headers: {
+        ...dashboardAccessHeaders,
+        "content-type": "application/json",
+        "user-agent": "iPhone PWA test"
+      },
+      body: JSON.stringify({
+        subscription: {
+          endpoint: "https://push.example/subscription/secret-endpoint",
+          expirationTime: null,
+          keys: { p256dh: "p256dh-key", auth: "auth-key" }
+        },
+        userAgent: "iPhone PWA test"
+      })
+    }),
+    {
+      ...dashboardAccessEnv,
+      DASHBOARD_PUSH_SUBSCRIPTION_STORE: store
+    }
+  );
+  assert.equal(response.status, 202);
+  const body = await response.json();
+  assert.equal(body.ok, true);
+  assert.equal(body.subscription.status, "saved");
+  assert.equal(typeof body.subscription.endpointHash, "string");
+  assert.equal(body.subscription.endpointHash.length > 12, true);
+  assert.equal(JSON.stringify(body).includes("secret-endpoint"), false);
+  assert.equal(JSON.stringify(body).includes("p256dh-key"), false);
+  assert.equal(JSON.stringify(body).includes("auth-key"), false);
+  assert.equal(store.subscriptions.size, 1);
+  const [saved] = [...store.subscriptions.values()];
+  assert.equal(saved.endpoint, "https://push.example/subscription/secret-endpoint");
+  assert.equal(saved.p256dh, "p256dh-key");
+  assert.equal(saved.auth, "auth-key");
+  assert.equal(saved.ownerIdentity, "owner@example.com");
 });
 
 test("worker ingests GitHub Actions deploy completion event and shows it on dashboard", async () => {

--- a/worker.js
+++ b/worker.js
@@ -56326,12 +56326,14 @@ var LEGACY_AUTONOMY_MODE_ENV = "MVP_AUTONOMY_MODE";
 var MEMORY_D1_BINDING = "VTDD_MEMORY_D1";
 var MEMORY_R2_BINDING = "VTDD_MEMORY_R2";
 var MEMORY_BLOB_THRESHOLD_ENV = "VTDD_MEMORY_BLOB_THRESHOLD";
+var WEB_PUSH_PUBLIC_KEY_ENV = "VTDD_WEB_PUSH_PUBLIC_KEY";
 var DEFAULT_MEMORY_LIMIT = 20;
 var MAX_MEMORY_LIMIT = 200;
 var memoryProviderCache = /* @__PURE__ */ new WeakMap();
 var d1AdapterCache = /* @__PURE__ */ new WeakMap();
 var dashboardEventStoreCache = /* @__PURE__ */ new WeakMap();
 var dashboardChatStoreCache = /* @__PURE__ */ new WeakMap();
+var dashboardPushSubscriptionStoreCache = /* @__PURE__ */ new WeakMap();
 var runtime_default = {
   async fetch(request, env) {
     const url = new URL(request.url);
@@ -56366,6 +56368,17 @@ var runtime_default = {
           mcpPath: MCP_PATH
         })
       );
+    }
+    if (request.method === "GET" && url.pathname === "/dashboard.webmanifest") {
+      return json(200, buildDashboardWebManifest(url), {
+        "content-type": "application/manifest+json; charset=utf-8"
+      });
+    }
+    if (request.method === "GET" && url.pathname === "/dashboard-sw.js") {
+      return javascript(200, renderDashboardServiceWorkerScript());
+    }
+    if (request.method === "GET" && url.pathname === "/dashboard-icon.svg") {
+      return svg(200, renderDashboardIconSvg());
     }
     if (request.method === "GET" && isDashboardPagePath(url.pathname)) {
       const auth = await authorizeDashboardRequest({ request, env, apiSuffix: url.pathname });
@@ -56406,12 +56419,16 @@ var runtime_default = {
         200,
         await renderDashboardNotificationsPage({
           runtimeOrigin: url.origin,
-          dashboardEventStore: resolveDashboardEventStore(env)
+          dashboardEventStore: resolveDashboardEventStore(env),
+          env
         })
       );
     }
     if (request.method === "POST" && isApiPath(url.pathname, "/dashboard/chat/messages")) {
       return handleDashboardChatMessageRequest(request, env);
+    }
+    if (request.method === "POST" && isApiPath(url.pathname, "/dashboard/push/subscription")) {
+      return handleDashboardPushSubscriptionRequest(request, env);
     }
     if (request.method === "GET" && isDashboardChatSocketApiPath(url.pathname)) {
       return handleDashboardChatSocketRequest(request, url, env);
@@ -59036,6 +59053,51 @@ async function handleDashboardChatMessageRequest(request, env) {
     execution: null
   });
 }
+async function handleDashboardPushSubscriptionRequest(request, env) {
+  const dashboardAuth = await authorizeDashboardRequest({
+    request,
+    env,
+    apiSuffix: "/dashboard/push/subscription"
+  });
+  if (!dashboardAuth.ok) {
+    return json(dashboardAuth.status, {
+      ok: false,
+      error: "dashboard_auth_required",
+      reason: dashboardAuth.reason
+    });
+  }
+  const store = resolveDashboardPushSubscriptionStore(env);
+  if (!store) {
+    return json(503, {
+      ok: false,
+      error: "dashboard_push_subscription_store_unavailable",
+      reason: "dashboard push subscription store is not configured"
+    });
+  }
+  const payload = await readJson(request);
+  const subscription = await normalizeDashboardPushSubscription(payload?.subscription || payload);
+  if (!subscription.ok) {
+    return json(422, {
+      ok: false,
+      error: "dashboard_push_subscription_invalid",
+      reason: subscription.reason
+    });
+  }
+  const saved = await store.put({
+    ...subscription.record,
+    userAgent: sanitizeDashboardChatText(payload?.userAgent || request.headers.get("user-agent") || ""),
+    ownerIdentity: normalizeDashboardEventText(dashboardAuth.subject) || normalizeDashboardEventText(dashboardAuth.authType) || "dashboard_owner",
+    updatedAt: (/* @__PURE__ */ new Date()).toISOString()
+  });
+  return json(202, {
+    ok: true,
+    subscription: {
+      endpointHash: saved.endpointHash,
+      updatedAt: saved.updatedAt,
+      status: "saved"
+    }
+  });
+}
 async function handleDashboardChatSocketRequest(request, url, env) {
   const auth = await authorizeDashboardRequest({
     request,
@@ -60638,6 +60700,25 @@ function resolveDashboardChatStore(env) {
   dashboardChatStoreCache.set(d1Binding, store);
   return store;
 }
+function resolveDashboardPushSubscriptionStore(env) {
+  if (!env || typeof env !== "object") {
+    return null;
+  }
+  const injectedStore = env.DASHBOARD_PUSH_SUBSCRIPTION_STORE ?? null;
+  if (injectedStore && typeof injectedStore.put === "function") {
+    return injectedStore;
+  }
+  const d1Binding = env[MEMORY_D1_BINDING] ?? null;
+  if (!d1Binding || typeof d1Binding.prepare !== "function") {
+    return null;
+  }
+  if (dashboardPushSubscriptionStoreCache.has(d1Binding)) {
+    return dashboardPushSubscriptionStoreCache.get(d1Binding);
+  }
+  const store = createD1DashboardPushSubscriptionStore(d1Binding);
+  dashboardPushSubscriptionStoreCache.set(d1Binding, store);
+  return store;
+}
 function resolveDashboardChatRoomStub(env, threadId) {
   const namespace = env?.DASHBOARD_CHAT_ROOMS ?? null;
   const roomName = normalizeDashboardThreadId(threadId);
@@ -61174,6 +61255,65 @@ function createD1DashboardChatStore(d1) {
     return schemaPromise;
   }
 }
+function createD1DashboardPushSubscriptionStore(d1) {
+  let schemaPromise = null;
+  return {
+    async put(subscription) {
+      const normalized = {
+        endpointHash: normalizeDashboardEventText(subscription.endpointHash),
+        endpoint: normalizeDashboardEventText(subscription.endpoint),
+        expirationTime: subscription.expirationTime ?? null,
+        p256dh: normalizeDashboardEventText(subscription.p256dh),
+        auth: normalizeDashboardEventText(subscription.auth),
+        userAgent: sanitizeDashboardChatText(subscription.userAgent),
+        ownerIdentity: normalizeDashboardEventText(subscription.ownerIdentity) || "dashboard_owner",
+        updatedAt: normalizeIsoTimestamp(subscription.updatedAt) || (/* @__PURE__ */ new Date()).toISOString()
+      };
+      await ensureSchema();
+      await d1.prepare(
+        `INSERT OR REPLACE INTO vtdd_dashboard_push_subscriptions (
+             endpoint_hash, endpoint, expiration_time, p256dh, auth, user_agent,
+             owner_identity, updated_at, payload_json
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      ).bind(
+        normalized.endpointHash,
+        normalized.endpoint,
+        normalized.expirationTime,
+        normalized.p256dh,
+        normalized.auth,
+        normalized.userAgent,
+        normalized.ownerIdentity,
+        normalized.updatedAt,
+        JSON.stringify({
+          endpointHash: normalized.endpointHash,
+          endpoint: normalized.endpoint,
+          expirationTime: normalized.expirationTime,
+          keys: {
+            p256dh: normalized.p256dh,
+            auth: normalized.auth
+          },
+          userAgent: normalized.userAgent,
+          ownerIdentity: normalized.ownerIdentity,
+          updatedAt: normalized.updatedAt
+        })
+      ).run();
+      return normalized;
+    }
+  };
+  function ensureSchema() {
+    if (!schemaPromise) {
+      schemaPromise = (async () => {
+        await d1.exec(
+          "CREATE TABLE IF NOT EXISTS vtdd_dashboard_push_subscriptions (endpoint_hash TEXT PRIMARY KEY, endpoint TEXT NOT NULL, expiration_time INTEGER, p256dh TEXT NOT NULL, auth TEXT NOT NULL, user_agent TEXT, owner_identity TEXT NOT NULL, updated_at TEXT NOT NULL, payload_json TEXT NOT NULL);"
+        );
+        await d1.exec(
+          "CREATE INDEX IF NOT EXISTS idx_vtdd_dashboard_push_subscriptions_updated_at ON vtdd_dashboard_push_subscriptions (updated_at DESC);"
+        );
+      })();
+    }
+    return schemaPromise;
+  }
+}
 function buildDashboardChatTurn(payload, options = {}) {
   const input = normalizeObject11(payload);
   const repository = normalizeCanonicalRepositoryInput(input.repository);
@@ -61252,6 +61392,47 @@ function normalizeDashboardChatMessage(message, defaults = {}) {
     text: sanitizeDashboardChatText(input.text || input.message || input.body) || "\uFF08\u7A7A\u306E\u30E1\u30C3\u30BB\u30FC\u30B8\uFF09",
     createdAt
   };
+}
+async function normalizeDashboardPushSubscription(value) {
+  const input = normalizeObject11(value);
+  const endpoint = normalizeDashboardUrl(input.endpoint);
+  const keys = normalizeObject11(input.keys);
+  const p256dh = normalizeDashboardEventText(keys.p256dh);
+  const auth = normalizeDashboardEventText(keys.auth);
+  if (!endpoint) {
+    return {
+      ok: false,
+      reason: "push subscription endpoint is required"
+    };
+  }
+  if (!p256dh || !auth) {
+    return {
+      ok: false,
+      reason: "push subscription keys.p256dh and keys.auth are required"
+    };
+  }
+  const endpointHash = await sha256Hex(endpoint);
+  return {
+    ok: true,
+    record: {
+      endpointHash,
+      endpoint,
+      expirationTime: Number.isFinite(Number(input.expirationTime)) ? Number(input.expirationTime) : null,
+      p256dh,
+      auth
+    }
+  };
+}
+async function sha256Hex(value) {
+  const text = normalizeText30(value);
+  if (!text) {
+    return "";
+  }
+  if (globalThis.crypto?.subtle && typeof TextEncoder !== "undefined") {
+    const digest2 = await globalThis.crypto.subtle.digest("SHA-256", new TextEncoder().encode(text));
+    return [...new Uint8Array(digest2)].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+  }
+  return btoa(text).replace(/[^A-Za-z0-9]/g, "").slice(0, 64);
 }
 function normalizeDashboardThreadSummary(summary, defaults = {}) {
   const input = normalizeObject11(summary);
@@ -62716,7 +62897,7 @@ async function renderDashboardSelfParityPage({ url, env } = {}) {
     `
   });
 }
-async function renderDashboardNotificationsPage({ runtimeOrigin, dashboardEventStore } = {}) {
+async function renderDashboardNotificationsPage({ runtimeOrigin, dashboardEventStore, env } = {}) {
   const origin = normalize7(runtimeOrigin);
   const recentSince = new Date(Date.now() - 5 * 60 * 1e3).toISOString();
   const recentEvents = await retrieveRecentDashboardEvents({
@@ -62724,24 +62905,219 @@ async function renderDashboardNotificationsPage({ runtimeOrigin, dashboardEventS
     since: recentSince,
     limit: 20
   });
+  const publicKey = normalizeDashboardEventText(env?.[WEB_PUSH_PUBLIC_KEY_ENV]);
   return renderDashboardUtilityPage({
     title: "\u901A\u77E5\u30BB\u30F3\u30BF\u30FC",
     subtitle: "dashboard events",
     backHref: `${origin}/dashboard`,
     body: `
       <section class="hero">
-        <p>\u4ECA\u306F iOS Push / \u97F3 / PWA badge \u3067\u306F\u306A\u304F\u3001Worker \u306B\u5C4A\u3044\u305F dashboard event \u306E\u4EBA\u9593\u5411\u3051\u8868\u793A\u3067\u3059\u3002</p>
+        <p>Dashboard Butler \u306E\u901A\u77E5\u5165\u53E3\u3067\u3059\u3002iOS PWA Web Push\u3001OS \u306E\u901A\u77E5\u97F3\u3001\u672A\u8AAD badge \u306F\u3053\u306E\u753B\u9762\u304B\u3089\u8A31\u53EF\u30FB\u78BA\u8A8D\u3057\u307E\u3059\u3002</p>
         <p class="muted">VTDD \u3060\u3051\u3067\u306A\u304F\u3001\u4ED6 repo / \u4E26\u884C\u958B\u767A / queue / workflow \u304B\u3089\u5C4A\u3044\u305F\u30A4\u30D9\u30F3\u30C8\u3092\u76F4\u8FD15\u5206\u3060\u3051\u8868\u793A\u3057\u307E\u3059\u3002</p>
-        <p class="muted">\u6B21\u306E\u6BB5\u968E\u3067 Web Push \u8CFC\u8AAD\u3001\u901A\u77E5 permission\u3001\u901A\u77E5\u30BF\u30C3\u30D7\u9077\u79FB\u3092\u8FFD\u52A0\u3057\u307E\u3059\u3002</p>
       </section>
+      <div class="grid">
+        <section class="lane">
+          <div class="lane-title"><h2>iOS PWA \u901A\u77E5</h2><span class="pill" id="push-support-pill">\u78BA\u8A8D\u4E2D</span></div>
+          <p id="push-state" class="muted">\u901A\u77E5\u72B6\u614B\u3092\u78BA\u8A8D\u3057\u3066\u3044\u307E\u3059\u3002</p>
+          <div class="actions">
+            <button class="dashboard-action" id="push-permission-button" type="button">\u901A\u77E5\u3092\u8A31\u53EF</button>
+            <button class="dashboard-action" id="push-subscribe-button" type="button">\u8CFC\u8AAD\u3092\u4FDD\u5B58</button>
+            <button class="dashboard-action" id="push-test-button" type="button">\u30C6\u30B9\u30C8\u901A\u77E5</button>
+          </div>
+          <p class="muted">\u901A\u77E5\u30BF\u30C3\u30D7\u306F\u901A\u77E5\u30BB\u30F3\u30BF\u30FC\u3078\u623B\u308A\u307E\u3059\u3002\u97F3\u306F iOS \u5074\u306E\u901A\u77E5\u8A2D\u5B9A\u306B\u5F93\u3044\u307E\u3059\u3002</p>
+        </section>
+        <section class="lane">
+          <div class="lane-title"><h2>Badge</h2><span class="pill" id="badge-support-pill">\u78BA\u8A8D\u4E2D</span></div>
+          <p id="badge-state" class="muted">Badging API \u306E\u5BFE\u5FDC\u72B6\u6CC1\u3092\u78BA\u8A8D\u3057\u3066\u3044\u307E\u3059\u3002</p>
+          <div class="actions">
+            <button class="dashboard-action" id="badge-set-button" type="button">\u672A\u8AAD\u6570\u3092\u53CD\u6620</button>
+            <button class="dashboard-action" id="badge-clear-button" type="button">Badge \u3092\u6D88\u3059</button>
+          </div>
+        </section>
+        <section class="lane">
+          <div class="lane-title"><h2>Authority boundary</h2><span class="pill">read/write</span></div>
+          <p>push subscription \u306F dashboard owner session \u304B\u3089\u4FDD\u5B58\u3057\u307E\u3059\u3002HTML \u306B\u306F endpoint\u3001auth key\u3001p256dh key \u3092\u57CB\u3081\u8FBC\u307F\u307E\u305B\u3093\u3002</p>
+          <p class="muted">Web Push \u9001\u4FE1\u306B\u306F server-side VAPID secret \u304C\u5FC5\u8981\u3067\u3059\u3002\u3053\u306E\u753B\u9762\u306B\u306F public key \u3060\u3051\u3092\u6E21\u3057\u307E\u3059\u3002</p>
+        </section>
+      </div>
       <div class="grid single">
         <section class="lane">
           <div class="lane-title"><h2>\u6700\u65B0\u901A\u77E5</h2><span class="pill">\u76F4\u8FD15\u5206</span></div>
           ${recentEvents.length > 0 ? recentEvents.map((event) => renderDashboardNotificationEvent(event)).join("") : `<p class="muted">\u76F4\u8FD15\u5206\u306E\u901A\u77E5\u306F\u3042\u308A\u307E\u305B\u3093\u3002</p>`}
         </section>
       </div>
+      <script>
+        (() => {
+          const vapidPublicKey = ${JSON.stringify(publicKey)};
+          const pushState = document.getElementById("push-state");
+          const pushSupportPill = document.getElementById("push-support-pill");
+          const badgeState = document.getElementById("badge-state");
+          const badgeSupportPill = document.getElementById("badge-support-pill");
+          const permissionButton = document.getElementById("push-permission-button");
+          const subscribeButton = document.getElementById("push-subscribe-button");
+          const testButton = document.getElementById("push-test-button");
+          const badgeSetButton = document.getElementById("badge-set-button");
+          const badgeClearButton = document.getElementById("badge-clear-button");
+          const unreadCount = ${recentEvents.length};
+
+          function setText(node, text) {
+            if (node) node.textContent = text;
+          }
+
+          function setPill(node, text, ok) {
+            if (!node) return;
+            node.textContent = text;
+            node.classList.toggle("success", ok === true);
+            node.classList.toggle("danger", ok === false);
+          }
+
+          function base64UrlToUint8Array(value) {
+            const padding = "=".repeat((4 - value.length % 4) % 4);
+            const base64 = (value + padding).replace(/-/g, "+").replace(/_/g, "/");
+            const raw = atob(base64);
+            const output = new Uint8Array(raw.length);
+            for (let index = 0; index < raw.length; index += 1) output[index] = raw.charCodeAt(index);
+            return output;
+          }
+
+          async function registration() {
+            if (!("serviceWorker" in navigator)) return null;
+            return navigator.serviceWorker.register("/dashboard-sw.js", { scope: "/" });
+          }
+
+          async function refreshState() {
+            const pushSupported = "serviceWorker" in navigator && "PushManager" in window && "Notification" in window;
+            setPill(pushSupportPill, pushSupported ? "\u5BFE\u5FDC" : "\u672A\u5BFE\u5FDC", pushSupported);
+            setText(pushState, pushSupported
+              ? "\u901A\u77E5 permission: " + Notification.permission + (vapidPublicKey ? "" : " / VAPID public key \u672A\u8A2D\u5B9A")
+              : "\u3053\u306E\u74B0\u5883\u306F Web Push \u306B\u672A\u5BFE\u5FDC\u3067\u3059\u3002iOS \u306F\u30DB\u30FC\u30E0\u753B\u9762\u306B\u8FFD\u52A0\u3057\u305F PWA \u304C\u5FC5\u8981\u3067\u3059\u3002");
+            const badgeSupported = "setAppBadge" in navigator && "clearAppBadge" in navigator;
+            setPill(badgeSupportPill, badgeSupported ? "\u5BFE\u5FDC" : "\u672A\u5BFE\u5FDC", badgeSupported);
+            setText(badgeState, badgeSupported ? "\u672A\u8AAD\u901A\u77E5\u6570\u3092\u30DB\u30FC\u30E0\u753B\u9762 badge \u306B\u53CD\u6620\u3067\u304D\u307E\u3059\u3002" : "\u3053\u306E\u74B0\u5883\u3067\u306F Badging API \u304C\u672A\u5BFE\u5FDC\u3067\u3059\u3002");
+            if (subscribeButton) subscribeButton.disabled = !pushSupported || !vapidPublicKey || Notification.permission !== "granted";
+            if (permissionButton) permissionButton.disabled = !pushSupported || Notification.permission === "granted";
+            if (testButton) testButton.disabled = !pushSupported || Notification.permission !== "granted";
+            if (badgeSetButton) badgeSetButton.disabled = !badgeSupported;
+            if (badgeClearButton) badgeClearButton.disabled = !badgeSupported;
+          }
+
+          permissionButton?.addEventListener("click", async () => {
+            if (!("Notification" in window)) return refreshState();
+            await Notification.requestPermission();
+            await registration();
+            await refreshState();
+          });
+
+          subscribeButton?.addEventListener("click", async () => {
+            const reg = await registration();
+            if (!reg || !vapidPublicKey) return refreshState();
+            const subscription = await reg.pushManager.subscribe({
+              userVisibleOnly: true,
+              applicationServerKey: base64UrlToUint8Array(vapidPublicKey)
+            });
+            const response = await fetch("/v2/dashboard/push/subscription", {
+              method: "POST",
+              headers: { "content-type": "application/json" },
+              body: JSON.stringify({ subscription: subscription.toJSON(), userAgent: navigator.userAgent })
+            });
+            setText(pushState, response.ok ? "push subscription \u3092\u4FDD\u5B58\u3057\u307E\u3057\u305F\u3002" : "push subscription \u306E\u4FDD\u5B58\u306B\u5931\u6557\u3057\u307E\u3057\u305F\u3002");
+            await refreshState();
+          });
+
+          testButton?.addEventListener("click", async () => {
+            const reg = await registration();
+            if (!reg) return refreshState();
+            await reg.showNotification("VTDD Butler", {
+              body: "Dashboard Butler \u306E\u901A\u77E5\u30C6\u30B9\u30C8\u3067\u3059\u3002",
+              tag: "vtdd-dashboard-test",
+              renotify: true,
+              silent: false,
+              data: { url: "/dashboard/notifications" }
+            });
+          });
+
+          badgeSetButton?.addEventListener("click", async () => {
+            if ("setAppBadge" in navigator) await navigator.setAppBadge(Math.max(1, unreadCount));
+          });
+
+          badgeClearButton?.addEventListener("click", async () => {
+            if ("clearAppBadge" in navigator) await navigator.clearAppBadge();
+          });
+
+          refreshState();
+        })();
+      <\/script>
     `
   });
+}
+function buildDashboardWebManifest(url) {
+  const origin = normalize7(url?.origin);
+  return {
+    name: "VTDD Butler",
+    short_name: "VTDD",
+    start_url: "/dashboard",
+    scope: "/",
+    display: "standalone",
+    background_color: "#050505",
+    theme_color: "#050505",
+    icons: [
+      {
+        src: `${origin}/dashboard-icon.svg`,
+        sizes: "any",
+        type: "image/svg+xml",
+        purpose: "any maskable"
+      }
+    ]
+  };
+}
+function renderDashboardServiceWorkerScript() {
+  return `
+self.addEventListener("install", () => {
+  self.skipWaiting();
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(self.clients.claim());
+});
+
+self.addEventListener("push", (event) => {
+  let payload = {};
+  try {
+    payload = event.data ? event.data.json() : {};
+  } catch {
+    payload = { body: event.data ? event.data.text() : "" };
+  }
+  const title = String(payload.title || "VTDD Butler");
+  const options = {
+    body: String(payload.body || payload.message || "Dashboard Butler \u306E\u901A\u77E5\u3067\u3059\u3002"),
+    tag: String(payload.tag || "vtdd-dashboard"),
+    renotify: payload.renotify !== false,
+    silent: payload.silent === true,
+    data: {
+      url: String(payload.url || "/dashboard/notifications")
+    }
+  };
+  event.waitUntil(self.registration.showNotification(title, options));
+});
+
+self.addEventListener("notificationclick", (event) => {
+  event.notification.close();
+  const targetUrl = new URL(event.notification.data && event.notification.data.url || "/dashboard/notifications", self.location.origin).toString();
+  event.waitUntil((async () => {
+    const clients = await self.clients.matchAll({ type: "window", includeUncontrolled: true });
+    for (const client of clients) {
+      if ("focus" in client) {
+        await client.navigate(targetUrl);
+        return client.focus();
+      }
+    }
+    return self.clients.openWindow(targetUrl);
+  })());
+});
+`.trim();
+}
+function renderDashboardIconSvg() {
+  return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><rect width="512" height="512" rx="112" fill="#050505"/><path d="M144 128h224v52H144zM144 230h224v52H144zM144 332h148v52H144z" fill="#f7f7f4"/></svg>`;
 }
 function renderGitHubTruthLane(title, result, renderCard) {
   if (!result.ok) {
@@ -62868,6 +63244,8 @@ function renderDashboardUtilityPage({ title, subtitle, backHref, body }) {
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="manifest" href="/dashboard.webmanifest">
+  <meta name="theme-color" content="#050505">
   <title>${escapeDashboardHtml(title)} - VTDD Butler</title>
   <style>
     :root { color-scheme: light dark; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; --bg: #f7f7f4; --panel: #fff; --text: #151515; --muted: #62625d; --border: #deded6; --soft: #f0f0eb; }
@@ -62881,7 +63259,8 @@ function renderDashboardUtilityPage({ title, subtitle, backHref, body }) {
     h2 { font-size: 18px; margin: 0; }
     p { line-height: 1.6; margin: 0 0 10px; }
     a { color: inherit; text-underline-offset: 4px; }
-    .back, .actions a { display: inline-flex; min-height: 38px; align-items: center; justify-content: center; border: 1px solid var(--border); border-radius: 999px; padding: 6px 12px; background: var(--soft); text-decoration: none; font-weight: 750; }
+    .back, .actions a, .dashboard-action { display: inline-flex; min-height: 38px; align-items: center; justify-content: center; border: 1px solid var(--border); border-radius: 999px; padding: 6px 12px; background: var(--soft); color: var(--text); text-decoration: none; font: inherit; font-weight: 750; }
+    .dashboard-action:disabled { opacity: .45; }
     .hero, .lane, .notice { border: 1px solid var(--border); border-radius: 16px; background: var(--panel); padding: 14px; margin-bottom: 14px; }
     .actions { display: flex; flex-wrap: wrap; gap: 8px; }
     .grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 14px; }
@@ -63034,6 +63413,8 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="manifest" href="/dashboard.webmanifest">
+  <meta name="theme-color" content="#050505">
   <title>VTDD v2 Dashboard</title>
   <style>
     :root {
@@ -63830,6 +64211,25 @@ function html(status, body) {
       "content-type": "text/html; charset=utf-8",
       "cache-control": "no-store, no-cache, must-revalidate, max-age=0",
       pragma: "no-cache"
+    }
+  });
+}
+function javascript(status, body) {
+  return new Response(body, {
+    status,
+    headers: {
+      "content-type": "application/javascript; charset=utf-8",
+      "cache-control": "no-store, no-cache, must-revalidate, max-age=0",
+      pragma: "no-cache"
+    }
+  });
+}
+function svg(status, body) {
+  return new Response(body, {
+    status,
+    headers: {
+      "content-type": "image/svg+xml; charset=utf-8",
+      "cache-control": "public, max-age=3600"
     }
   });
 }

--- a/worker.js
+++ b/worker.js
@@ -61286,12 +61286,8 @@ function createD1DashboardPushSubscriptionStore(d1) {
         normalized.updatedAt,
         JSON.stringify({
           endpointHash: normalized.endpointHash,
-          endpoint: normalized.endpoint,
           expirationTime: normalized.expirationTime,
-          keys: {
-            p256dh: normalized.p256dh,
-            auth: normalized.auth
-          },
+          rawMaterial: "stored_in_columns_for_server_side_web_push_send_only",
           userAgent: normalized.userAgent,
           ownerIdentity: normalized.ownerIdentity,
           updatedAt: normalized.updatedAt
@@ -62937,7 +62933,8 @@ async function renderDashboardNotificationsPage({ runtimeOrigin, dashboardEventS
         <section class="lane">
           <div class="lane-title"><h2>Authority boundary</h2><span class="pill">read/write</span></div>
           <p>push subscription \u306F dashboard owner session \u304B\u3089\u4FDD\u5B58\u3057\u307E\u3059\u3002HTML \u306B\u306F endpoint\u3001auth key\u3001p256dh key \u3092\u57CB\u3081\u8FBC\u307F\u307E\u305B\u3093\u3002</p>
-          <p class="muted">Web Push \u9001\u4FE1\u306B\u306F server-side VAPID secret \u304C\u5FC5\u8981\u3067\u3059\u3002\u3053\u306E\u753B\u9762\u306B\u306F public key \u3060\u3051\u3092\u6E21\u3057\u307E\u3059\u3002</p>
+          <p class="muted">\u540C\u4E00 origin \u306E dashboard owner session cookie / Cloudflare Access identity \u3092\u4F7F\u3046\u305F\u3081\u3001\u8CFC\u8AAD\u4FDD\u5B58 fetch \u306F credentials: same-origin \u3067\u9001\u308A\u307E\u3059\u3002</p>
+          <p class="muted">Web Push \u9001\u4FE1\u306B\u306F server-side VAPID secret \u3068 subscription raw material \u304C\u5FC5\u8981\u3067\u3059\u3002D1 \u306B\u306F\u9001\u4FE1\u7528\u306B\u4FDD\u6301\u3057\u3001response / HTML / payload_json \u306B\u306F raw key \u3092\u8FD4\u3057\u307E\u305B\u3093\u3002</p>
         </section>
       </div>
       <div class="grid single">
@@ -62982,7 +62979,7 @@ async function renderDashboardNotificationsPage({ runtimeOrigin, dashboardEventS
 
           async function registration() {
             if (!("serviceWorker" in navigator)) return null;
-            return navigator.serviceWorker.register("/dashboard-sw.js", { scope: "/" });
+            return navigator.serviceWorker.register("/dashboard-sw.js", { scope: "/dashboard/" });
           }
 
           async function refreshState() {
@@ -63017,6 +63014,7 @@ async function renderDashboardNotificationsPage({ runtimeOrigin, dashboardEventS
             });
             const response = await fetch("/v2/dashboard/push/subscription", {
               method: "POST",
+              credentials: "same-origin",
               headers: { "content-type": "application/json" },
               body: JSON.stringify({ subscription: subscription.toJSON(), userAgent: navigator.userAgent })
             });
@@ -63056,7 +63054,7 @@ function buildDashboardWebManifest(url) {
     name: "VTDD Butler",
     short_name: "VTDD",
     start_url: "/dashboard",
-    scope: "/",
+    scope: "/dashboard/",
     display: "standalone",
     background_color: "#050505",
     theme_color: "#050505",
@@ -63100,9 +63098,25 @@ self.addEventListener("push", (event) => {
   event.waitUntil(self.registration.showNotification(title, options));
 });
 
+function safeDashboardNotificationUrl(value) {
+  let parsed;
+  try {
+    parsed = new URL(value || "/dashboard/notifications", self.location.origin);
+  } catch {
+    parsed = new URL("/dashboard/notifications", self.location.origin);
+  }
+  if (parsed.origin !== self.location.origin) {
+    return new URL("/dashboard/notifications", self.location.origin).toString();
+  }
+  if (parsed.pathname !== "/dashboard" && !parsed.pathname.startsWith("/dashboard/")) {
+    return new URL("/dashboard/notifications", self.location.origin).toString();
+  }
+  return parsed.toString();
+}
+
 self.addEventListener("notificationclick", (event) => {
   event.notification.close();
-  const targetUrl = new URL(event.notification.data && event.notification.data.url || "/dashboard/notifications", self.location.origin).toString();
+  const targetUrl = safeDashboardNotificationUrl(event.notification.data && event.notification.data.url);
   event.waitUntil((async () => {
     const clients = await self.clients.matchAll({ type: "window", includeUncontrolled: true });
     for (const client of clients) {


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #444 の最初の実装スライスとして、Dashboard Butler の通知センターを iOS PWA 通知・音・badge の入口に接続します。PR #493 の Codex fallback reviewer 指摘に対応し、Service Worker scope / subscription保存認証前提 / notificationclick URL境界 / raw material保持方針を締めました。本PRは本番 push 送信と iPhone 実機 live E2E を完了扱いにしません。Cloudflare deploy/API 回復後に続けます。

## Satisfied Success Criteria

- Dashboard utility/main pages expose PWA manifest link and dashboard.webmanifest / dashboard-sw.js / dashboard-icon.svg routes.
- 通知センターに通知許可、push subscription 保存、テスト通知、badge 操作 UI を追加。
- manifest scope と Service Worker register scope を /dashboard/ に限定。
- service worker が push と notificationclick を処理し、通知タップ先を同一originかつ /dashboard 配下に制限。
- subscription保存fetchは credentials: same-origin を明示し、dashboard owner session / Cloudflare Access identity 前提をUIに表示。
- POST /v2/dashboard/push/subscription は dashboard owner auth を要求し、response に endpoint/auth/p256dh を返さない。
- D1 payload_json から endpoint/auth/p256dh raw material を除外し、送信用raw materialは専用column保持として明示。
- Badging API 未対応環境では UI が未対応として扱う。

## Unsatisfied Success Criteria

- server-side Web Push 送信 path は未実装。VAPID secret と送信 authority boundary は次スライス。
- production deploy は Cloudflare API/deploy 障害中のため未実施。
- iPhone ホーム画面 PWA live push / 音 / badge E2E は未実施。
- ウィジェット的な常時表示は未実装。

## Non-goal violations

None. 本PRは外部有料通知サービス、ChatGPT/Codex scraping、Cloudflare deploy、iOS widget 実装、high-risk authority 変更を含めません。

## Dry-run Impact Report

- Target Issue: Issue #444
- Implementing Success Criteria: 通知許可 UI、Service Worker asset route、notificationclick target、Badging API fallback、push subscription 保存 path、raw subscription material 非HTML/非response/非payload_json露出、Dashboard限定Service Worker scope。
- Explicit Non-goals: 本番 deploy、iPhone 実機 live push E2E、Web Push server-side send、VAPID secret mutation、外部有料通知サービス、ウィジェット実装。
- Expected touched files/routes/workflows: src/worker/runtime.js, worker.js, test/worker.test.js; routes /dashboard.webmanifest, /dashboard-sw.js, /dashboard-icon.svg, /v2/dashboard/push/subscription, /dashboard/notifications
- Affected Issues: Issue #444。Issue #450 の Dashboard Butler surface には manifest link 追加のみ影響。
- Affected PRs: PR #493 reviewer request_changes 指摘に対応。
- Affected workflows: deploy-production は未実行。worker.js generated check に影響。
- Affected runtime/operator surfaces: Dashboard / dashboard notification center / Service Worker / D1-backed dashboard push subscription store.
- What may break if we patch narrowly: Service Worker scope と PWA manifest の追加が dashboard 全体に効くため、認証が必要なページ内容や subscription raw material を静的 asset / response / payload_json に出すと漏洩リスク。
- Unknowns to investigate before coding: iOS PWA 実機での Notification/PushManager/Badging API support、VAPID public/secret configuration、本番 Cloudflare deploy recovery timing。
- Validation needed: worker tests、self-parity、generated worker check、deploy 回復後の iPhone PWA live E2E。
- Stop condition: VAPID secret / push送信 / deploy / permission mutation をこのPRで進める必要が出た場合は別approval/次PR。

## File / Line Hypotheses

- file: src/worker/runtime.js
  - hypothesis: dashboard notification center owns owner-facing notification UI and can host PWA manifest/service worker routes without changing chat execution.
  - risk if changed narrowly: owner-facing auth boundary or static asset route may leak subscription material if response shaping is wrong, and root-scoped Service Worker can expand blast radius.
  - validation: worker tests assert dashboard-only manifest/service worker scope, authenticated subscription save, same-origin credentials, safe notificationclick URL, and no raw subscription material in response/payload_json.
  - related Issue: Issue #444
- file: test/worker.test.js
  - hypothesis: existing worker tests are the right layer for route/UI/security assertions before production E2E.
  - risk if changed narrowly: live iPhone PWA support cannot be proven by unit tests.
  - validation: npm test plus documented unsatisfied live E2E.
  - related Issue: Issue #444

## Hypothesis Retrospective

- expected: notification center could become a PWA notification entry without implementing server-side push send.
- actual: manifest/service worker/subscription save/badge UI landed; reviewer-requested scope/auth/url/raw-material boundaries were tightened; push send and live E2E remain intentionally unsatisfied.
- mismatch: original scope was too broad and subscription/auth assumptions were insufficiently explicit; fixed in this revision.
- lesson: keep PWA entry, dashboard scope, and push delivery separated so Cloudflare deploy outage does not block PR-level implementation while avoiding origin-wide Service Worker blast radius.
- should become RAG candidate: yes, after live E2E confirms or rejects the split.

## Verification Evidence

- Unit: node --test test/worker.test.js --test-name-pattern "dashboard (notification|PWA|push)|push subscription|notification center" passed; node --test passed as part of npm test.
- Integration: npm run check:self-parity passed; npm run check:generated-worker passed; npm test passed.
- E2E: Not run. Production Cloudflare deploy and iPhone PWA live push E2E are blocked/deferred until Cloudflare deploy API recovers.
- Manual: Not run.
- Evidence path/link: local npm test output; PR checks after push.

## Butler Completion Contract

- Owner goal: Dashboard Butler から GitHub iOS 通知に頼らず iOS PWA通知・音・badge を受け取る入口を作る。
- Butler entrypoint: /dashboard/notifications
- Action Schema exposure: 不要。このPRは Dashboard surface/Worker routes で、Custom GPT Action Schema は変更しない。
- Runtime path: /dashboard/notifications -> /dashboard-sw.js scoped to /dashboard/ -> /v2/dashboard/push/subscription -> VTDD_MEMORY_D1/DASHBOARD_PUSH_SUBSCRIPTION_STORE
- Runner/runtime truth: runtime route tests, dashboard auth tests, notificationclick boundary tests, D1 payload_json redaction test, and generated worker check. Production runtime truth is undeployed/unverified.
- Authority boundary: dashboard owner auth required for subscription save; same-origin credentials used by browser fetch; static manifest/service worker expose no secrets; notification clicks are constrained to same-origin /dashboard; no push send/high-risk mutation.
- E2E evidence: 未実施。Cloudflare deploy 回復後に iPhone PWA live push/音/badge を確認する。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 必要。ただし現時点では Cloudflare API/deploy 障害により未実施。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 必要。Cloudflare deploy 回復後。

## Related Constitution Rules

- Issue #444
- AGENTS.md Butler Completion Gate
- AGENTS.md Authority Boundary
- AGENTS.md Conversation UX Contract
- AGENTS.md Evidence Discipline

## Out-of-scope but NOT implemented

- server-side Web Push send
- VAPID secret mutation
- iOS widget
- production deploy/live E2E

## Extra changes (if any)

Codex fallback reviewer の request_changes 指摘へ対応。

<!-- VTDD metadata -->
- Issue: Issue #444
- Execution ID: Not provided.
- Goal: Not provided.
