### PR TITLE
Fix flaky memory recordId assertion blocking deploy

### DIFF
--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -3321,7 +3321,8 @@ test("worker includes post-write retrieval for working memory writes", async () 
   assert.equal(body.memoryWritePersisted.relatedIssue, 251);
   assert.match(body.memoryWritePersisted.recordId, /^mem_[0-9a-f-]{36}$/);
   assert.equal(body.memoryWritePersisted.recordId.includes("working_memory"), false);
-  assert.equal(body.memoryWritePersisted.recordId.includes("251"), false);
+  assert.equal(body.memoryWritePersisted.recordId.includes("working_memory_251"), false);
+  assert.equal(body.memoryWritePersisted.recordId.includes("issue_251"), false);
   assert.equal(body.memoryWritePersisted.recordId.includes("Butler"), false);
   assert.equal(body.postWriteRetrieval.relatedIssue, 251);
 });


### PR DESCRIPTION
## This PR satisfies Intent

- PR #493 merge 後の deploy-production が Cloudflare deploy ではなく Run tests で落ちたため、デプロイ前テストを flaky にしていた memory recordId assertion を修正します。原因は recordId が mem_<uuid> なのに、UUID 内に偶然 251 が含まれないことまで要求していた点です。

## Satisfied Success Criteria

- deploy-production run 26301232715 の失敗原因を Cloudflare API ではなく test/worker.test.js の UUID substring flake と特定。
- recordId が working_memory_251 や issue_251 のような意味情報を含まないことを検証しつつ、UUID 偶然値 251 では失敗しない assertion に変更。
- npm test passed。

## Unsatisfied Success Criteria

- production deploy の再実行は未実施。
- #444 の iPhone PWA live push / 音 / badge E2E は未実施。

## Non-goal violations

None. 本PRは runtime behavior、Cloudflare secrets、deploy workflow、VAPID、iOS通知実装を変更しません。

## Dry-run Impact Report

- Target Issue: Issue #444 deploy unblock follow-up
- Implementing Success Criteria: PR #493 merge後deployを止めた flaky test を修正し、deploy前 npm test がランダムUUID値で落ちないようにする。
- Explicit Non-goals: production deploy再実行、Cloudflare設定変更、runtime実装変更、Issue close、merge。
- Expected touched files/routes/workflows: test/worker.test.js only.
- Affected Issues: Issue #444 の deploy unblock。
- Affected PRs: PR #493 merge後の deploy-production failure を受けた follow-up。
- Affected workflows: deploy-production の Run tests step。
- Affected runtime/operator surfaces: なし。テストのみ。
- What may break if we patch narrowly: recordId redaction test の意図を弱めすぎると、working_memory_251 のような意味情報入りIDを見逃す可能性。
- Unknowns to investigate before coding: なし。Actionsログとローカル npm test で原因を確認済み。
- Validation needed: npm test。
- Stop condition: runtime behavior変更が必要になった場合は、このテスト修正PRから分離する。

## File / Line Hypotheses

- file: test/worker.test.js
  - hypothesis: deployment failed because recordId substring assertion treated random UUID contents as semantic leakage.
  - risk if changed narrowly: overly broad relaxation would stop checking semantic leakage.
  - validation: keep regex mem_<uuid>, keep checks against working_memory_251 and issue_251, run npm test.
  - related Issue: Issue #444 deploy unblock follow-up

## Hypothesis Retrospective

- expected: deploy-production failed before Cloudflare deploy because a random UUID contained 251.
- actual: local latest-main npm test passes after changing the assertion to semantic patterns instead of raw substring 251.
- mismatch: Cloudflare status was not the root cause for this run.
- lesson: tests for redaction must check semantic encodings, not arbitrary substrings that can appear inside random IDs.
- should become RAG candidate: yes, as flaky-test/deploy-blocker memory.

## Verification Evidence

- Unit: npm test passed.
- Integration: npm run check:self-parity and npm run check:generated-worker passed as part of npm test.
- E2E: Not run. This is a test-only deploy unblock follow-up.
- Manual: Inspected deploy-production run 26301232715 logs; Cloudflare Workers deploy entitlement preflight passed, Run tests failed on test/worker.test.js:3324.
- Evidence path/link: https://github.com/marushu/vtdd-v2-p/actions/runs/26301232715/job/77426633783#step:9:1 and local npm test output.

## Butler Completion Contract

- Owner goal: PR #493 merge後の #444 deploy を、Cloudflare障害ではない flaky test blocker で止まらない状態に戻す。
- Butler entrypoint: なし。テストのみ。
- Action Schema exposure: 不要。
- Runtime path: 変更なし。
- Runner/runtime truth: deploy run log and local npm test.
- Authority boundary: 変更なし。deploy、secret、permission mutation はしない。
- E2E evidence: 未実施。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 未実施。このPR後に別途 passkey approval 付き deploy が必要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 不要。このPRでは未実施。

## Related Constitution Rules

- AGENTS.md Evidence Discipline
- AGENTS.md Change Size and PR Discipline
- AGENTS.md Authority Boundary

## Out-of-scope but NOT implemented

- production deploy rerun
- Cloudflare configuration change
- runtime behavior change
- Issue close

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #444
- Execution ID: Not provided.
- Goal: Not provided.
