### PR TITLE
#444 Dashboard server-side Web Push send path

### DIFF
--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -6339,6 +6339,19 @@ function createD1DashboardPushSubscriptionStore(d1) {
           updatedAt: normalizeIsoTimestamp(row?.updated_at) || null
         }))
         .filter((record) => record.endpoint && record.p256dh && record.auth);
+    },
+
+    async delete(endpointHash) {
+      const normalizedEndpointHash = normalizeDashboardEventText(endpointHash);
+      if (!normalizedEndpointHash) {
+        return { deleted: false };
+      }
+      await ensureSchema();
+      const result = await d1
+        .prepare("DELETE FROM vtdd_dashboard_push_subscriptions WHERE endpoint_hash = ?")
+        .bind(normalizedEndpointHash)
+        .run();
+      return { deleted: Number(result?.meta?.changes || 0) > 0 };
     }
   };
 
@@ -6379,8 +6392,17 @@ async function dispatchDashboardWebPushForEvent(env, event) {
 
   const payload = buildDashboardWebPushPayload(event);
   const results = [];
+  let cleaned = 0;
   for (const subscription of subscriptions) {
-    results.push(await sendDashboardWebPush({ env, subscription, payload }));
+    const result = await sendDashboardWebPush({ env, subscription, payload });
+    if (result.stale && result.endpointHash && typeof store.delete === "function") {
+      const cleanup = await store.delete(result.endpointHash);
+      if (cleanup?.deleted) {
+        cleaned += 1;
+        result.cleaned = true;
+      }
+    }
+    results.push(result);
   }
   const delivered = results.filter((result) => result.ok).length;
   const firstFailure = results.find((result) => !result.ok);
@@ -6390,13 +6412,16 @@ async function dispatchDashboardWebPushForEvent(env, event) {
     error: delivered > 0 ? undefined : firstFailure?.error,
     reason: delivered > 0 ? undefined : firstFailure?.reason,
     delivered,
+    cleaned,
     attempted: results.length,
     results: results.map((result) => ({
       ok: result.ok,
       endpointHash: result.endpointHash,
       status: result.status,
       reason: result.reason,
-      error: result.error
+      error: result.error,
+      stale: result.stale || undefined,
+      cleaned: result.cleaned || undefined
     }))
   };
 }
@@ -6435,11 +6460,17 @@ async function sendDashboardWebPush({ env, subscription, payload }) {
       urgency: "normal"
     }
   });
+  const stale = response.status === 404 || response.status === 410;
   return {
     ok: response.status >= 200 && response.status < 300,
     endpointHash,
     status: response.status,
-    reason: response.status >= 200 && response.status < 300 ? "accepted" : "push service rejected the request"
+    reason: response.status >= 200 && response.status < 300
+      ? "accepted"
+      : stale
+        ? "push subscription is stale and should be deleted"
+        : "push service rejected the request",
+    stale
   };
 }
 

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -477,6 +477,8 @@ const MEMORY_D1_BINDING = "VTDD_MEMORY_D1";
 const MEMORY_R2_BINDING = "VTDD_MEMORY_R2";
 const MEMORY_BLOB_THRESHOLD_ENV = "VTDD_MEMORY_BLOB_THRESHOLD";
 const WEB_PUSH_PUBLIC_KEY_ENV = "VTDD_WEB_PUSH_PUBLIC_KEY";
+const WEB_PUSH_PRIVATE_KEY_ENV = "VTDD_WEB_PUSH_PRIVATE_KEY";
+const WEB_PUSH_SUBJECT_ENV = "VTDD_WEB_PUSH_SUBJECT";
 const DEFAULT_MEMORY_LIMIT = 20;
 const MAX_MEMORY_LIMIT = 200;
 const memoryProviderCache = new WeakMap();
@@ -605,6 +607,10 @@ export default {
 
     if (request.method === "POST" && isApiPath(url.pathname, "/dashboard/push/subscription")) {
       return handleDashboardPushSubscriptionRequest(request, env);
+    }
+
+    if (request.method === "POST" && isApiPath(url.pathname, "/dashboard/push/test")) {
+      return handleDashboardPushTestRequest(request, env);
     }
 
     if (request.method === "GET" && isDashboardChatSocketApiPath(url.pathname)) {
@@ -3525,9 +3531,11 @@ async function handleGitHubActionsEventRequest(request, env) {
   }
 
   await store.put(event.event);
+  const webPush = await dispatchDashboardWebPushForEvent(env, event.event);
   return json(202, {
     ok: true,
-    event: event.event
+    event: event.event,
+    webPush
   });
 }
 
@@ -3561,6 +3569,7 @@ async function handleVpsRunnerEventRequest(request, env) {
   }
 
   await eventStore.put(event.event);
+  const webPush = await dispatchDashboardWebPushForEvent(env, event.event);
   let messages;
   try {
     messages = await chatStore.appendMany(event.threadId, [event.chatMessage]);
@@ -3582,7 +3591,8 @@ async function handleVpsRunnerEventRequest(request, env) {
     event: event.event,
     threadId: event.threadId,
     messages,
-    webSocketBroadcast
+    webSocketBroadcast,
+    webPush
   });
 }
 
@@ -3688,6 +3698,42 @@ async function handleDashboardPushSubscriptionRequest(request, env) {
       updatedAt: saved.updatedAt,
       status: "saved"
     }
+  });
+}
+
+async function handleDashboardPushTestRequest(request, env) {
+  const dashboardAuth = await authorizeDashboardRequest({
+    request,
+    env,
+    apiSuffix: "/dashboard/push/test"
+  });
+  if (!dashboardAuth.ok) {
+    return json(dashboardAuth.status, {
+      ok: false,
+      error: "dashboard_auth_required",
+      reason: dashboardAuth.reason
+    });
+  }
+
+  const payload = await readJson(request);
+  const event = normalizeDashboardEventRecord({
+    id: `dashboard-push-test:${crypto.randomUUID()}`,
+    kind: "dashboard_push_test",
+    repository: normalizeCanonicalRepositoryInput(payload?.repository) || "marushu/vtdd-v2-p",
+    workflowName: "dashboard-push-test",
+    runId: crypto.randomUUID(),
+    status: "completed",
+    conclusion: "success",
+    title: sanitizeDashboardChatText(payload?.title || "Dashboard Butler server push test"),
+    runUrl: "/dashboard/notifications",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString()
+  });
+  const webPush = await dispatchDashboardWebPushForEvent(env, event);
+  return json(webPush.ok ? 202 : webPush.status || 503, {
+    ok: webPush.ok,
+    event,
+    webPush
   });
 }
 
@@ -5592,7 +5638,7 @@ function resolveDashboardPushSubscriptionStore(env) {
     return null;
   }
   const injectedStore = env.DASHBOARD_PUSH_SUBSCRIPTION_STORE ?? null;
-  if (injectedStore && typeof injectedStore.put === "function") {
+  if (injectedStore && typeof injectedStore.put === "function" && typeof injectedStore.list === "function") {
     return injectedStore;
   }
 
@@ -6266,6 +6312,33 @@ function createD1DashboardPushSubscriptionStore(d1) {
         )
         .run();
       return normalized;
+    },
+
+    async list(filter = {}) {
+      await ensureSchema();
+      const limit = normalizeLimit(filter.limit, 50);
+      const result = await d1
+        .prepare(
+          `SELECT endpoint_hash, endpoint, expiration_time, p256dh, auth, user_agent,
+                  owner_identity, updated_at
+             FROM vtdd_dashboard_push_subscriptions
+             ORDER BY updated_at DESC
+             LIMIT ?`
+        )
+        .bind(limit)
+        .all();
+      return (Array.isArray(result?.results) ? result.results : [])
+        .map((row) => ({
+          endpointHash: normalizeDashboardEventText(row?.endpoint_hash),
+          endpoint: normalizeDashboardEventText(row?.endpoint),
+          expirationTime: row?.expiration_time ?? null,
+          p256dh: normalizeDashboardEventText(row?.p256dh),
+          auth: normalizeDashboardEventText(row?.auth),
+          userAgent: sanitizeDashboardChatText(row?.user_agent),
+          ownerIdentity: normalizeDashboardEventText(row?.owner_identity),
+          updatedAt: normalizeIsoTimestamp(row?.updated_at) || null
+        }))
+        .filter((record) => record.endpoint && record.p256dh && record.auth);
     }
   };
 
@@ -6282,6 +6355,219 @@ function createD1DashboardPushSubscriptionStore(d1) {
     }
     return schemaPromise;
   }
+}
+
+async function dispatchDashboardWebPushForEvent(env, event) {
+  const store = resolveDashboardPushSubscriptionStore(env);
+  if (!store || typeof store.list !== "function") {
+    return {
+      ok: false,
+      status: 503,
+      error: "dashboard_push_subscription_store_unavailable",
+      reason: "dashboard push subscription store cannot list subscriptions"
+    };
+  }
+  const subscriptions = await store.list({ limit: 50 });
+  if (subscriptions.length === 0) {
+    return {
+      ok: false,
+      status: 404,
+      error: "dashboard_push_subscription_not_found",
+      reason: "no dashboard push subscriptions are stored"
+    };
+  }
+
+  const payload = buildDashboardWebPushPayload(event);
+  const results = [];
+  for (const subscription of subscriptions) {
+    results.push(await sendDashboardWebPush({ env, subscription, payload }));
+  }
+  const delivered = results.filter((result) => result.ok).length;
+  const firstFailure = results.find((result) => !result.ok);
+  return {
+    ok: delivered > 0,
+    status: delivered > 0 ? 202 : firstFailure?.status || 502,
+    error: delivered > 0 ? undefined : firstFailure?.error,
+    reason: delivered > 0 ? undefined : firstFailure?.reason,
+    delivered,
+    attempted: results.length,
+    results: results.map((result) => ({
+      ok: result.ok,
+      endpointHash: result.endpointHash,
+      status: result.status,
+      reason: result.reason,
+      error: result.error
+    }))
+  };
+}
+
+function buildDashboardWebPushPayload(event) {
+  const record = normalizeDashboardEventRecord(event);
+  const title = record.kind === "dashboard_push_test" ? "VTDD Butler test" : "VTDD Butler";
+  const statusText = [record.status, record.conclusion].filter(Boolean).join("/");
+  const body = [record.title, record.repository, statusText].filter(Boolean).join(" - ");
+  return {
+    title,
+    body: body || "Dashboard Butler の通知です。",
+    tag: `vtdd-${record.kind || "dashboard"}-${record.runId || record.id || "event"}`.slice(0, 120),
+    url: record.runUrl || "/dashboard/notifications"
+  };
+}
+
+async function sendDashboardWebPush({ env, subscription, payload }) {
+  const endpoint = normalizeDashboardUrl(subscription?.endpoint);
+  const endpointHash = normalizeDashboardEventText(subscription?.endpointHash) || (endpoint ? await sha256Hex(endpoint) : "");
+  if (!endpoint) {
+    return { ok: false, endpointHash, status: 422, error: "push_endpoint_required", reason: "subscription endpoint is missing" };
+  }
+
+  const vapid = await buildDashboardVapidAuthorization({ env, endpoint });
+  if (!vapid.ok) {
+    return { ...vapid, endpointHash };
+  }
+
+  const fetcher = typeof env?.DASHBOARD_WEB_PUSH_FETCH === "function" ? env.DASHBOARD_WEB_PUSH_FETCH : fetch;
+  const response = await fetcher(endpoint, {
+    method: "POST",
+    headers: {
+      authorization: vapid.authorization,
+      ttl: "300",
+      urgency: "normal"
+    }
+  });
+  return {
+    ok: response.status >= 200 && response.status < 300,
+    endpointHash,
+    status: response.status,
+    reason: response.status >= 200 && response.status < 300 ? "accepted" : "push service rejected the request"
+  };
+}
+
+async function buildDashboardVapidAuthorization({ env, endpoint }) {
+  const publicKey = normalizeDashboardEventText(env?.[WEB_PUSH_PUBLIC_KEY_ENV]);
+  const privateKey = normalizeDashboardEventText(env?.[WEB_PUSH_PRIVATE_KEY_ENV]);
+  const subject = normalizeDashboardEventText(env?.[WEB_PUSH_SUBJECT_ENV]);
+  if (!publicKey || !privateKey || !subject) {
+    return {
+      ok: false,
+      status: 503,
+      error: "dashboard_web_push_vapid_unconfigured",
+      reason: "VTDD_WEB_PUSH_PUBLIC_KEY, VTDD_WEB_PUSH_PRIVATE_KEY, and VTDD_WEB_PUSH_SUBJECT are required"
+    };
+  }
+  const endpointUrl = new URL(endpoint);
+  const jwt = await signDashboardVapidJwt({
+    audience: endpointUrl.origin,
+    subject,
+    publicKey,
+    privateKey
+  });
+  if (!jwt.ok) {
+    return jwt;
+  }
+  return {
+    ok: true,
+    authorization: `vapid t=${jwt.token}, k=${publicKey}`
+  };
+}
+
+async function signDashboardVapidJwt({ audience, subject, publicKey, privateKey }) {
+  const publicBytes = base64UrlToBytes(publicKey);
+  if (publicBytes.length !== 65 || publicBytes[0] !== 4) {
+    return {
+      ok: false,
+      status: 503,
+      error: "dashboard_web_push_public_key_invalid",
+      reason: "VTDD_WEB_PUSH_PUBLIC_KEY must be an uncompressed P-256 public key encoded as base64url"
+    };
+  }
+  const privateJwk = buildDashboardVapidPrivateJwk({ publicBytes, privateKey });
+  if (!privateJwk.ok) {
+    return privateJwk;
+  }
+  const cryptoKey = await crypto.subtle.importKey(
+    "jwk",
+    privateJwk.jwk,
+    { name: "ECDSA", namedCurve: "P-256" },
+    false,
+    ["sign"]
+  );
+  const header = base64UrlEncodeJson({ typ: "JWT", alg: "ES256" });
+  const body = base64UrlEncodeJson({
+    aud: audience,
+    exp: Math.floor(Date.now() / 1000) + 12 * 60 * 60,
+    sub: subject
+  });
+  const signingInput = `${header}.${body}`;
+  const signature = await crypto.subtle.sign(
+    { name: "ECDSA", hash: "SHA-256" },
+    cryptoKey,
+    new TextEncoder().encode(signingInput)
+  );
+  return {
+    ok: true,
+    token: `${signingInput}.${base64UrlEncodeBytes(new Uint8Array(signature))}`
+  };
+}
+
+function buildDashboardVapidPrivateJwk({ publicBytes, privateKey }) {
+  if (privateKey.trim().startsWith("{")) {
+    try {
+      const jwk = JSON.parse(privateKey);
+      return { ok: true, jwk: { ...jwk, key_ops: ["sign"], ext: false } };
+    } catch {
+      return {
+        ok: false,
+        status: 503,
+        error: "dashboard_web_push_private_key_invalid",
+        reason: "VTDD_WEB_PUSH_PRIVATE_KEY JWK JSON is invalid"
+      };
+    }
+  }
+  const privateBytes = base64UrlToBytes(privateKey);
+  if (privateBytes.length !== 32) {
+    return {
+      ok: false,
+      status: 503,
+      error: "dashboard_web_push_private_key_invalid",
+      reason: "VTDD_WEB_PUSH_PRIVATE_KEY must be a P-256 private scalar encoded as base64url or a JWK JSON string"
+    };
+  }
+  return {
+    ok: true,
+    jwk: {
+      kty: "EC",
+      crv: "P-256",
+      x: base64UrlEncodeBytes(publicBytes.slice(1, 33)),
+      y: base64UrlEncodeBytes(publicBytes.slice(33, 65)),
+      d: base64UrlEncodeBytes(privateBytes),
+      key_ops: ["sign"],
+      ext: false
+    }
+  };
+}
+
+function base64UrlEncodeJson(value) {
+  return base64UrlEncodeBytes(new TextEncoder().encode(JSON.stringify(value)));
+}
+
+function base64UrlEncodeBytes(bytes) {
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+}
+
+function base64UrlToBytes(value) {
+  const normalized = normalizeDashboardEventText(value).replace(/-/g, "+").replace(/_/g, "/");
+  const padded = normalized + "=".repeat((4 - (normalized.length % 4)) % 4);
+  const raw = atob(padded);
+  const bytes = new Uint8Array(raw.length);
+  for (let index = 0; index < raw.length; index += 1) {
+    bytes[index] = raw.charCodeAt(index);
+  }
+  return bytes;
 }
 
 function buildDashboardChatTurn(payload, options = {}) {
@@ -8092,6 +8378,7 @@ async function renderDashboardNotificationsPage({ runtimeOrigin, dashboardEventS
             <button class="dashboard-action" id="push-permission-button" type="button">通知を許可</button>
             <button class="dashboard-action" id="push-subscribe-button" type="button">購読を保存</button>
             <button class="dashboard-action" id="push-test-button" type="button">テスト通知</button>
+            <button class="dashboard-action" id="push-server-test-button" type="button">サーバ送信テスト</button>
           </div>
           <p class="muted">通知タップは通知センターへ戻ります。音は iOS 側の通知設定に従います。</p>
         </section>
@@ -8126,6 +8413,7 @@ async function renderDashboardNotificationsPage({ runtimeOrigin, dashboardEventS
           const permissionButton = document.getElementById("push-permission-button");
           const subscribeButton = document.getElementById("push-subscribe-button");
           const testButton = document.getElementById("push-test-button");
+          const serverTestButton = document.getElementById("push-server-test-button");
           const badgeSetButton = document.getElementById("badge-set-button");
           const badgeClearButton = document.getElementById("badge-clear-button");
           const unreadCount = ${recentEvents.length};
@@ -8167,6 +8455,7 @@ async function renderDashboardNotificationsPage({ runtimeOrigin, dashboardEventS
             if (subscribeButton) subscribeButton.disabled = !pushSupported || !vapidPublicKey || Notification.permission !== "granted";
             if (permissionButton) permissionButton.disabled = !pushSupported || Notification.permission === "granted";
             if (testButton) testButton.disabled = !pushSupported || Notification.permission !== "granted";
+            if (serverTestButton) serverTestButton.disabled = !pushSupported || !vapidPublicKey || Notification.permission !== "granted";
             if (badgeSetButton) badgeSetButton.disabled = !badgeSupported;
             if (badgeClearButton) badgeClearButton.disabled = !badgeSupported;
           }
@@ -8205,6 +8494,17 @@ async function renderDashboardNotificationsPage({ runtimeOrigin, dashboardEventS
               silent: false,
               data: { url: "/dashboard/notifications" }
             });
+          });
+
+          serverTestButton?.addEventListener("click", async () => {
+            const response = await fetch("/v2/dashboard/push/test", {
+              method: "POST",
+              credentials: "same-origin",
+              headers: { "content-type": "application/json" },
+              body: JSON.stringify({ title: "Dashboard Butler server push test" })
+            });
+            setText(pushState, response.ok ? "server-side Web Push を送信しました。" : "server-side Web Push の送信に失敗しました。");
+            await refreshState();
           });
 
           badgeSetButton?.addEventListener("click", async () => {

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -176,7 +176,33 @@ function createInMemoryDashboardPushSubscriptionStore() {
     async put(subscription) {
       subscriptions.set(subscription.endpointHash, subscription);
       return subscription;
+    },
+    async list(filter = {}) {
+      const limit = Number(filter.limit) || 50;
+      return [...subscriptions.values()].slice(0, limit);
     }
+  };
+}
+
+function base64UrlEncodeTestBytes(bytes) {
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+}
+
+async function createTestVapidEnv(extra = {}) {
+  const keyPair = await crypto.subtle.generateKey(
+    { name: "ECDSA", namedCurve: "P-256" },
+    true,
+    ["sign", "verify"]
+  );
+  const publicKey = base64UrlEncodeTestBytes(new Uint8Array(await crypto.subtle.exportKey("raw", keyPair.publicKey)));
+  const privateJwk = await crypto.subtle.exportKey("jwk", keyPair.privateKey);
+  return {
+    VTDD_WEB_PUSH_PUBLIC_KEY: publicKey,
+    VTDD_WEB_PUSH_PRIVATE_KEY: JSON.stringify(privateJwk),
+    VTDD_WEB_PUSH_SUBJECT: "mailto:owner@example.com",
+    ...extra
   };
 }
 
@@ -1640,8 +1666,10 @@ test("worker serves dashboard notification center for recent events across repos
   assert.equal(body.includes("iOS PWA Web Push"), true);
   assert.equal(body.includes("id=\"push-permission-button\""), true);
   assert.equal(body.includes("id=\"push-subscribe-button\""), true);
+  assert.equal(body.includes("id=\"push-server-test-button\""), true);
   assert.equal(body.includes("id=\"badge-set-button\""), true);
   assert.equal(body.includes("/v2/dashboard/push/subscription"), true);
+  assert.equal(body.includes("/v2/dashboard/push/test"), true);
   assert.equal(body.includes("credentials: \"same-origin\""), true);
   assert.equal(body.includes("D1 には送信用に保持し、response / HTML / payload_json には raw key を返しません"), true);
   assert.equal(body.includes("navigator.setAppBadge"), true);
@@ -1750,6 +1778,94 @@ test("worker stores dashboard push subscription only for an authenticated owner 
   assert.equal(saved.ownerIdentity, "owner@example.com");
 });
 
+test("worker sends server-side dashboard Web Push test only for authenticated owner session", async () => {
+  const store = createInMemoryDashboardPushSubscriptionStore();
+  await store.put({
+    endpointHash: "endpoint-hash",
+    endpoint: "https://push.example/send/endpoint-hash",
+    p256dh: "p256dh-key",
+    auth: "auth-key",
+    ownerIdentity: "owner@example.com",
+    updatedAt: new Date().toISOString()
+  });
+  const calls = [];
+  const vapidEnv = await createTestVapidEnv({
+    DASHBOARD_WEB_PUSH_FETCH: async (input, init) => {
+      calls.push({ input, init });
+      return new Response(null, { status: 201 });
+    }
+  });
+
+  const unauthenticated = await worker.fetch(
+    new Request("https://example.com/v2/dashboard/push/test", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ title: "must not send" })
+    }),
+    {
+      ...dashboardAccessEnv,
+      ...vapidEnv,
+      DASHBOARD_PUSH_SUBSCRIPTION_STORE: store
+    }
+  );
+  assert.equal(unauthenticated.status, 401);
+  assert.equal(calls.length, 0);
+
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/dashboard/push/test", {
+      method: "POST",
+      headers: { ...dashboardAccessHeaders, "content-type": "application/json" },
+      body: JSON.stringify({ title: "server push test" })
+    }),
+    {
+      ...dashboardAccessEnv,
+      ...vapidEnv,
+      DASHBOARD_PUSH_SUBSCRIPTION_STORE: store
+    }
+  );
+  assert.equal(response.status, 202);
+  const body = await response.json();
+  assert.equal(body.ok, true);
+  assert.equal(body.webPush.delivered, 1);
+  assert.equal(body.webPush.results[0].endpointHash, "endpoint-hash");
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].input, "https://push.example/send/endpoint-hash");
+  assert.equal(calls[0].init.method, "POST");
+  assert.match(calls[0].init.headers.authorization, /^vapid t=.+, k=.+/);
+  assert.equal(calls[0].init.headers.ttl, "300");
+  assert.equal(calls[0].init.headers.urgency, "normal");
+  assert.equal("body" in calls[0].init, false);
+  assert.equal(JSON.stringify(body).includes("p256dh-key"), false);
+  assert.equal(JSON.stringify(body).includes("auth-key"), false);
+});
+
+test("worker reports server-side dashboard Web Push configuration blockers", async () => {
+  const store = createInMemoryDashboardPushSubscriptionStore();
+  await store.put({
+    endpointHash: "endpoint-hash",
+    endpoint: "https://push.example/send/endpoint-hash",
+    p256dh: "p256dh-key",
+    auth: "auth-key",
+    ownerIdentity: "owner@example.com",
+    updatedAt: new Date().toISOString()
+  });
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/dashboard/push/test", {
+      method: "POST",
+      headers: { ...dashboardAccessHeaders, "content-type": "application/json" },
+      body: JSON.stringify({ title: "server push test" })
+    }),
+    {
+      ...dashboardAccessEnv,
+      DASHBOARD_PUSH_SUBSCRIPTION_STORE: store
+    }
+  );
+  assert.equal(response.status, 503);
+  const body = await response.json();
+  assert.equal(body.ok, false);
+  assert.equal(body.webPush.error, "dashboard_web_push_vapid_unconfigured");
+});
+
 test("worker redacts dashboard push subscription raw material from D1 payload_json", async () => {
   const prepared = [];
   const d1 = {
@@ -1807,6 +1923,22 @@ test("worker redacts dashboard push subscription raw material from D1 payload_js
 
 test("worker ingests GitHub Actions deploy completion event and shows it on dashboard", async () => {
   const store = createInMemoryDashboardEventStore();
+  const pushStore = createInMemoryDashboardPushSubscriptionStore();
+  await pushStore.put({
+    endpointHash: "deploy-push-endpoint",
+    endpoint: "https://push.example/send/deploy",
+    p256dh: "p256dh-key",
+    auth: "auth-key",
+    ownerIdentity: "owner@example.com",
+    updatedAt: new Date().toISOString()
+  });
+  const pushCalls = [];
+  const vapidEnv = await createTestVapidEnv({
+    DASHBOARD_WEB_PUSH_FETCH: async (input, init) => {
+      pushCalls.push({ input, init });
+      return new Response(null, { status: 201 });
+    }
+  });
   const eventResponse = await worker.fetch(
     new Request("https://example.com/v2/events/github-actions", {
       method: "POST",
@@ -1828,7 +1960,9 @@ test("worker ingests GitHub Actions deploy completion event and shows it on dash
     }),
     {
       ...gatewayAuthEnv,
-      DASHBOARD_EVENT_STORE: store
+      ...vapidEnv,
+      DASHBOARD_EVENT_STORE: store,
+      DASHBOARD_PUSH_SUBSCRIPTION_STORE: pushStore
     }
   );
 
@@ -1836,6 +1970,10 @@ test("worker ingests GitHub Actions deploy completion event and shows it on dash
   const eventBody = await eventResponse.json();
   assert.equal(eventBody.ok, true);
   assert.equal(eventBody.event.runId, "26133044458");
+  assert.equal(eventBody.webPush.delivered, 1);
+  assert.equal(pushCalls.length, 1);
+  assert.equal(pushCalls[0].input, "https://push.example/send/deploy");
+  assert.match(pushCalls[0].init.headers.authorization, /^vapid t=.+, k=.+/);
   assert.equal("approvalGrantId" in eventBody.event, false);
   assert.equal("token" in eventBody.event, false);
 

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -180,6 +180,10 @@ function createInMemoryDashboardPushSubscriptionStore() {
     async list(filter = {}) {
       const limit = Number(filter.limit) || 50;
       return [...subscriptions.values()].slice(0, limit);
+    },
+    async delete(endpointHash) {
+      const deleted = subscriptions.delete(endpointHash);
+      return { deleted };
     }
   };
 }
@@ -1864,6 +1868,43 @@ test("worker reports server-side dashboard Web Push configuration blockers", asy
   const body = await response.json();
   assert.equal(body.ok, false);
   assert.equal(body.webPush.error, "dashboard_web_push_vapid_unconfigured");
+});
+
+test("worker cleans up stale dashboard Web Push subscriptions rejected by push service", async () => {
+  const store = createInMemoryDashboardPushSubscriptionStore();
+  await store.put({
+    endpointHash: "stale-endpoint-hash",
+    endpoint: "https://push.example/send/stale-endpoint-hash",
+    p256dh: "p256dh-key",
+    auth: "auth-key",
+    ownerIdentity: "owner@example.com",
+    updatedAt: new Date().toISOString()
+  });
+  const vapidEnv = await createTestVapidEnv({
+    DASHBOARD_WEB_PUSH_FETCH: async () => new Response(null, { status: 410 })
+  });
+
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/dashboard/push/test", {
+      method: "POST",
+      headers: { ...dashboardAccessHeaders, "content-type": "application/json" },
+      body: JSON.stringify({ title: "server push test" })
+    }),
+    {
+      ...dashboardAccessEnv,
+      ...vapidEnv,
+      DASHBOARD_PUSH_SUBSCRIPTION_STORE: store
+    }
+  );
+
+  assert.equal(response.status, 410);
+  const body = await response.json();
+  assert.equal(body.ok, false);
+  assert.equal(body.webPush.delivered, 0);
+  assert.equal(body.webPush.cleaned, 1);
+  assert.equal(body.webPush.results[0].stale, true);
+  assert.equal(body.webPush.results[0].cleaned, true);
+  assert.equal(store.subscriptions.has("stale-endpoint-hash"), false);
 });
 
 test("worker redacts dashboard push subscription raw material from D1 payload_json", async () => {

--- a/worker.js
+++ b/worker.js
@@ -61358,6 +61358,15 @@ function createD1DashboardPushSubscriptionStore(d1) {
         ownerIdentity: normalizeDashboardEventText(row?.owner_identity),
         updatedAt: normalizeIsoTimestamp(row?.updated_at) || null
       })).filter((record2) => record2.endpoint && record2.p256dh && record2.auth);
+    },
+    async delete(endpointHash) {
+      const normalizedEndpointHash = normalizeDashboardEventText(endpointHash);
+      if (!normalizedEndpointHash) {
+        return { deleted: false };
+      }
+      await ensureSchema();
+      const result = await d1.prepare("DELETE FROM vtdd_dashboard_push_subscriptions WHERE endpoint_hash = ?").bind(normalizedEndpointHash).run();
+      return { deleted: Number(result?.meta?.changes || 0) > 0 };
     }
   };
   function ensureSchema() {
@@ -61395,8 +61404,17 @@ async function dispatchDashboardWebPushForEvent(env, event) {
   }
   const payload = buildDashboardWebPushPayload(event);
   const results = [];
+  let cleaned = 0;
   for (const subscription of subscriptions) {
-    results.push(await sendDashboardWebPush({ env, subscription, payload }));
+    const result = await sendDashboardWebPush({ env, subscription, payload });
+    if (result.stale && result.endpointHash && typeof store.delete === "function") {
+      const cleanup = await store.delete(result.endpointHash);
+      if (cleanup?.deleted) {
+        cleaned += 1;
+        result.cleaned = true;
+      }
+    }
+    results.push(result);
   }
   const delivered = results.filter((result) => result.ok).length;
   const firstFailure = results.find((result) => !result.ok);
@@ -61406,13 +61424,16 @@ async function dispatchDashboardWebPushForEvent(env, event) {
     error: delivered > 0 ? void 0 : firstFailure?.error,
     reason: delivered > 0 ? void 0 : firstFailure?.reason,
     delivered,
+    cleaned,
     attempted: results.length,
     results: results.map((result) => ({
       ok: result.ok,
       endpointHash: result.endpointHash,
       status: result.status,
       reason: result.reason,
-      error: result.error
+      error: result.error,
+      stale: result.stale || void 0,
+      cleaned: result.cleaned || void 0
     }))
   };
 }
@@ -61447,11 +61468,13 @@ async function sendDashboardWebPush({ env, subscription, payload }) {
       urgency: "normal"
     }
   });
+  const stale = response.status === 404 || response.status === 410;
   return {
     ok: response.status >= 200 && response.status < 300,
     endpointHash,
     status: response.status,
-    reason: response.status >= 200 && response.status < 300 ? "accepted" : "push service rejected the request"
+    reason: response.status >= 200 && response.status < 300 ? "accepted" : stale ? "push subscription is stale and should be deleted" : "push service rejected the request",
+    stale
   };
 }
 async function buildDashboardVapidAuthorization({ env, endpoint }) {

--- a/worker.js
+++ b/worker.js
@@ -56327,6 +56327,8 @@ var MEMORY_D1_BINDING = "VTDD_MEMORY_D1";
 var MEMORY_R2_BINDING = "VTDD_MEMORY_R2";
 var MEMORY_BLOB_THRESHOLD_ENV = "VTDD_MEMORY_BLOB_THRESHOLD";
 var WEB_PUSH_PUBLIC_KEY_ENV = "VTDD_WEB_PUSH_PUBLIC_KEY";
+var WEB_PUSH_PRIVATE_KEY_ENV = "VTDD_WEB_PUSH_PRIVATE_KEY";
+var WEB_PUSH_SUBJECT_ENV = "VTDD_WEB_PUSH_SUBJECT";
 var DEFAULT_MEMORY_LIMIT = 20;
 var MAX_MEMORY_LIMIT = 200;
 var memoryProviderCache = /* @__PURE__ */ new WeakMap();
@@ -56429,6 +56431,9 @@ var runtime_default = {
     }
     if (request.method === "POST" && isApiPath(url.pathname, "/dashboard/push/subscription")) {
       return handleDashboardPushSubscriptionRequest(request, env);
+    }
+    if (request.method === "POST" && isApiPath(url.pathname, "/dashboard/push/test")) {
+      return handleDashboardPushTestRequest(request, env);
     }
     if (request.method === "GET" && isDashboardChatSocketApiPath(url.pathname)) {
       return handleDashboardChatSocketRequest(request, url, env);
@@ -58951,9 +58956,11 @@ async function handleGitHubActionsEventRequest(request, env) {
     });
   }
   await store.put(event.event);
+  const webPush = await dispatchDashboardWebPushForEvent(env, event.event);
   return json(202, {
     ok: true,
-    event: event.event
+    event: event.event,
+    webPush
   });
 }
 async function handleVpsRunnerEventRequest(request, env) {
@@ -58983,6 +58990,7 @@ async function handleVpsRunnerEventRequest(request, env) {
     });
   }
   await eventStore.put(event.event);
+  const webPush = await dispatchDashboardWebPushForEvent(env, event.event);
   let messages;
   try {
     messages = await chatStore.appendMany(event.threadId, [event.chatMessage]);
@@ -59004,7 +59012,8 @@ async function handleVpsRunnerEventRequest(request, env) {
     event: event.event,
     threadId: event.threadId,
     messages,
-    webSocketBroadcast
+    webSocketBroadcast,
+    webPush
   });
 }
 async function handleDashboardChatMessageRequest(request, env) {
@@ -59096,6 +59105,40 @@ async function handleDashboardPushSubscriptionRequest(request, env) {
       updatedAt: saved.updatedAt,
       status: "saved"
     }
+  });
+}
+async function handleDashboardPushTestRequest(request, env) {
+  const dashboardAuth = await authorizeDashboardRequest({
+    request,
+    env,
+    apiSuffix: "/dashboard/push/test"
+  });
+  if (!dashboardAuth.ok) {
+    return json(dashboardAuth.status, {
+      ok: false,
+      error: "dashboard_auth_required",
+      reason: dashboardAuth.reason
+    });
+  }
+  const payload = await readJson(request);
+  const event = normalizeDashboardEventRecord({
+    id: `dashboard-push-test:${crypto.randomUUID()}`,
+    kind: "dashboard_push_test",
+    repository: normalizeCanonicalRepositoryInput(payload?.repository) || "marushu/vtdd-v2-p",
+    workflowName: "dashboard-push-test",
+    runId: crypto.randomUUID(),
+    status: "completed",
+    conclusion: "success",
+    title: sanitizeDashboardChatText(payload?.title || "Dashboard Butler server push test"),
+    runUrl: "/dashboard/notifications",
+    createdAt: (/* @__PURE__ */ new Date()).toISOString(),
+    updatedAt: (/* @__PURE__ */ new Date()).toISOString()
+  });
+  const webPush = await dispatchDashboardWebPushForEvent(env, event);
+  return json(webPush.ok ? 202 : webPush.status || 503, {
+    ok: webPush.ok,
+    event,
+    webPush
   });
 }
 async function handleDashboardChatSocketRequest(request, url, env) {
@@ -60705,7 +60748,7 @@ function resolveDashboardPushSubscriptionStore(env) {
     return null;
   }
   const injectedStore = env.DASHBOARD_PUSH_SUBSCRIPTION_STORE ?? null;
-  if (injectedStore && typeof injectedStore.put === "function") {
+  if (injectedStore && typeof injectedStore.put === "function" && typeof injectedStore.list === "function") {
     return injectedStore;
   }
   const d1Binding = env[MEMORY_D1_BINDING] ?? null;
@@ -61294,6 +61337,27 @@ function createD1DashboardPushSubscriptionStore(d1) {
         })
       ).run();
       return normalized;
+    },
+    async list(filter = {}) {
+      await ensureSchema();
+      const limit = normalizeLimit7(filter.limit, 50);
+      const result = await d1.prepare(
+        `SELECT endpoint_hash, endpoint, expiration_time, p256dh, auth, user_agent,
+                  owner_identity, updated_at
+             FROM vtdd_dashboard_push_subscriptions
+             ORDER BY updated_at DESC
+             LIMIT ?`
+      ).bind(limit).all();
+      return (Array.isArray(result?.results) ? result.results : []).map((row) => ({
+        endpointHash: normalizeDashboardEventText(row?.endpoint_hash),
+        endpoint: normalizeDashboardEventText(row?.endpoint),
+        expirationTime: row?.expiration_time ?? null,
+        p256dh: normalizeDashboardEventText(row?.p256dh),
+        auth: normalizeDashboardEventText(row?.auth),
+        userAgent: sanitizeDashboardChatText(row?.user_agent),
+        ownerIdentity: normalizeDashboardEventText(row?.owner_identity),
+        updatedAt: normalizeIsoTimestamp(row?.updated_at) || null
+      })).filter((record2) => record2.endpoint && record2.p256dh && record2.auth);
     }
   };
   function ensureSchema() {
@@ -61309,6 +61373,207 @@ function createD1DashboardPushSubscriptionStore(d1) {
     }
     return schemaPromise;
   }
+}
+async function dispatchDashboardWebPushForEvent(env, event) {
+  const store = resolveDashboardPushSubscriptionStore(env);
+  if (!store || typeof store.list !== "function") {
+    return {
+      ok: false,
+      status: 503,
+      error: "dashboard_push_subscription_store_unavailable",
+      reason: "dashboard push subscription store cannot list subscriptions"
+    };
+  }
+  const subscriptions = await store.list({ limit: 50 });
+  if (subscriptions.length === 0) {
+    return {
+      ok: false,
+      status: 404,
+      error: "dashboard_push_subscription_not_found",
+      reason: "no dashboard push subscriptions are stored"
+    };
+  }
+  const payload = buildDashboardWebPushPayload(event);
+  const results = [];
+  for (const subscription of subscriptions) {
+    results.push(await sendDashboardWebPush({ env, subscription, payload }));
+  }
+  const delivered = results.filter((result) => result.ok).length;
+  const firstFailure = results.find((result) => !result.ok);
+  return {
+    ok: delivered > 0,
+    status: delivered > 0 ? 202 : firstFailure?.status || 502,
+    error: delivered > 0 ? void 0 : firstFailure?.error,
+    reason: delivered > 0 ? void 0 : firstFailure?.reason,
+    delivered,
+    attempted: results.length,
+    results: results.map((result) => ({
+      ok: result.ok,
+      endpointHash: result.endpointHash,
+      status: result.status,
+      reason: result.reason,
+      error: result.error
+    }))
+  };
+}
+function buildDashboardWebPushPayload(event) {
+  const record2 = normalizeDashboardEventRecord(event);
+  const title = record2.kind === "dashboard_push_test" ? "VTDD Butler test" : "VTDD Butler";
+  const statusText = [record2.status, record2.conclusion].filter(Boolean).join("/");
+  const body = [record2.title, record2.repository, statusText].filter(Boolean).join(" - ");
+  return {
+    title,
+    body: body || "Dashboard Butler \u306E\u901A\u77E5\u3067\u3059\u3002",
+    tag: `vtdd-${record2.kind || "dashboard"}-${record2.runId || record2.id || "event"}`.slice(0, 120),
+    url: record2.runUrl || "/dashboard/notifications"
+  };
+}
+async function sendDashboardWebPush({ env, subscription, payload }) {
+  const endpoint = normalizeDashboardUrl(subscription?.endpoint);
+  const endpointHash = normalizeDashboardEventText(subscription?.endpointHash) || (endpoint ? await sha256Hex(endpoint) : "");
+  if (!endpoint) {
+    return { ok: false, endpointHash, status: 422, error: "push_endpoint_required", reason: "subscription endpoint is missing" };
+  }
+  const vapid = await buildDashboardVapidAuthorization({ env, endpoint });
+  if (!vapid.ok) {
+    return { ...vapid, endpointHash };
+  }
+  const fetcher = typeof env?.DASHBOARD_WEB_PUSH_FETCH === "function" ? env.DASHBOARD_WEB_PUSH_FETCH : fetch;
+  const response = await fetcher(endpoint, {
+    method: "POST",
+    headers: {
+      authorization: vapid.authorization,
+      ttl: "300",
+      urgency: "normal"
+    }
+  });
+  return {
+    ok: response.status >= 200 && response.status < 300,
+    endpointHash,
+    status: response.status,
+    reason: response.status >= 200 && response.status < 300 ? "accepted" : "push service rejected the request"
+  };
+}
+async function buildDashboardVapidAuthorization({ env, endpoint }) {
+  const publicKey = normalizeDashboardEventText(env?.[WEB_PUSH_PUBLIC_KEY_ENV]);
+  const privateKey = normalizeDashboardEventText(env?.[WEB_PUSH_PRIVATE_KEY_ENV]);
+  const subject = normalizeDashboardEventText(env?.[WEB_PUSH_SUBJECT_ENV]);
+  if (!publicKey || !privateKey || !subject) {
+    return {
+      ok: false,
+      status: 503,
+      error: "dashboard_web_push_vapid_unconfigured",
+      reason: "VTDD_WEB_PUSH_PUBLIC_KEY, VTDD_WEB_PUSH_PRIVATE_KEY, and VTDD_WEB_PUSH_SUBJECT are required"
+    };
+  }
+  const endpointUrl = new URL(endpoint);
+  const jwt = await signDashboardVapidJwt({
+    audience: endpointUrl.origin,
+    subject,
+    publicKey,
+    privateKey
+  });
+  if (!jwt.ok) {
+    return jwt;
+  }
+  return {
+    ok: true,
+    authorization: `vapid t=${jwt.token}, k=${publicKey}`
+  };
+}
+async function signDashboardVapidJwt({ audience, subject, publicKey, privateKey }) {
+  const publicBytes = base64UrlToBytes(publicKey);
+  if (publicBytes.length !== 65 || publicBytes[0] !== 4) {
+    return {
+      ok: false,
+      status: 503,
+      error: "dashboard_web_push_public_key_invalid",
+      reason: "VTDD_WEB_PUSH_PUBLIC_KEY must be an uncompressed P-256 public key encoded as base64url"
+    };
+  }
+  const privateJwk = buildDashboardVapidPrivateJwk({ publicBytes, privateKey });
+  if (!privateJwk.ok) {
+    return privateJwk;
+  }
+  const cryptoKey = await crypto.subtle.importKey(
+    "jwk",
+    privateJwk.jwk,
+    { name: "ECDSA", namedCurve: "P-256" },
+    false,
+    ["sign"]
+  );
+  const header = base64UrlEncodeJson({ typ: "JWT", alg: "ES256" });
+  const body = base64UrlEncodeJson({
+    aud: audience,
+    exp: Math.floor(Date.now() / 1e3) + 12 * 60 * 60,
+    sub: subject
+  });
+  const signingInput = `${header}.${body}`;
+  const signature = await crypto.subtle.sign(
+    { name: "ECDSA", hash: "SHA-256" },
+    cryptoKey,
+    new TextEncoder().encode(signingInput)
+  );
+  return {
+    ok: true,
+    token: `${signingInput}.${base64UrlEncodeBytes2(new Uint8Array(signature))}`
+  };
+}
+function buildDashboardVapidPrivateJwk({ publicBytes, privateKey }) {
+  if (privateKey.trim().startsWith("{")) {
+    try {
+      const jwk = JSON.parse(privateKey);
+      return { ok: true, jwk: { ...jwk, key_ops: ["sign"], ext: false } };
+    } catch {
+      return {
+        ok: false,
+        status: 503,
+        error: "dashboard_web_push_private_key_invalid",
+        reason: "VTDD_WEB_PUSH_PRIVATE_KEY JWK JSON is invalid"
+      };
+    }
+  }
+  const privateBytes = base64UrlToBytes(privateKey);
+  if (privateBytes.length !== 32) {
+    return {
+      ok: false,
+      status: 503,
+      error: "dashboard_web_push_private_key_invalid",
+      reason: "VTDD_WEB_PUSH_PRIVATE_KEY must be a P-256 private scalar encoded as base64url or a JWK JSON string"
+    };
+  }
+  return {
+    ok: true,
+    jwk: {
+      kty: "EC",
+      crv: "P-256",
+      x: base64UrlEncodeBytes2(publicBytes.slice(1, 33)),
+      y: base64UrlEncodeBytes2(publicBytes.slice(33, 65)),
+      d: base64UrlEncodeBytes2(privateBytes),
+      key_ops: ["sign"],
+      ext: false
+    }
+  };
+}
+function base64UrlEncodeJson(value) {
+  return base64UrlEncodeBytes2(new TextEncoder().encode(JSON.stringify(value)));
+}
+function base64UrlEncodeBytes2(bytes) {
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+}
+function base64UrlToBytes(value) {
+  const normalized = normalizeDashboardEventText(value).replace(/-/g, "+").replace(/_/g, "/");
+  const padded = normalized + "=".repeat((4 - normalized.length % 4) % 4);
+  const raw = atob(padded);
+  const bytes = new Uint8Array(raw.length);
+  for (let index = 0; index < raw.length; index += 1) {
+    bytes[index] = raw.charCodeAt(index);
+  }
+  return bytes;
 }
 function buildDashboardChatTurn(payload, options = {}) {
   const input = normalizeObject11(payload);
@@ -62919,6 +63184,7 @@ async function renderDashboardNotificationsPage({ runtimeOrigin, dashboardEventS
             <button class="dashboard-action" id="push-permission-button" type="button">\u901A\u77E5\u3092\u8A31\u53EF</button>
             <button class="dashboard-action" id="push-subscribe-button" type="button">\u8CFC\u8AAD\u3092\u4FDD\u5B58</button>
             <button class="dashboard-action" id="push-test-button" type="button">\u30C6\u30B9\u30C8\u901A\u77E5</button>
+            <button class="dashboard-action" id="push-server-test-button" type="button">\u30B5\u30FC\u30D0\u9001\u4FE1\u30C6\u30B9\u30C8</button>
           </div>
           <p class="muted">\u901A\u77E5\u30BF\u30C3\u30D7\u306F\u901A\u77E5\u30BB\u30F3\u30BF\u30FC\u3078\u623B\u308A\u307E\u3059\u3002\u97F3\u306F iOS \u5074\u306E\u901A\u77E5\u8A2D\u5B9A\u306B\u5F93\u3044\u307E\u3059\u3002</p>
         </section>
@@ -62953,6 +63219,7 @@ async function renderDashboardNotificationsPage({ runtimeOrigin, dashboardEventS
           const permissionButton = document.getElementById("push-permission-button");
           const subscribeButton = document.getElementById("push-subscribe-button");
           const testButton = document.getElementById("push-test-button");
+          const serverTestButton = document.getElementById("push-server-test-button");
           const badgeSetButton = document.getElementById("badge-set-button");
           const badgeClearButton = document.getElementById("badge-clear-button");
           const unreadCount = ${recentEvents.length};
@@ -62994,6 +63261,7 @@ async function renderDashboardNotificationsPage({ runtimeOrigin, dashboardEventS
             if (subscribeButton) subscribeButton.disabled = !pushSupported || !vapidPublicKey || Notification.permission !== "granted";
             if (permissionButton) permissionButton.disabled = !pushSupported || Notification.permission === "granted";
             if (testButton) testButton.disabled = !pushSupported || Notification.permission !== "granted";
+            if (serverTestButton) serverTestButton.disabled = !pushSupported || !vapidPublicKey || Notification.permission !== "granted";
             if (badgeSetButton) badgeSetButton.disabled = !badgeSupported;
             if (badgeClearButton) badgeClearButton.disabled = !badgeSupported;
           }
@@ -63032,6 +63300,17 @@ async function renderDashboardNotificationsPage({ runtimeOrigin, dashboardEventS
               silent: false,
               data: { url: "/dashboard/notifications" }
             });
+          });
+
+          serverTestButton?.addEventListener("click", async () => {
+            const response = await fetch("/v2/dashboard/push/test", {
+              method: "POST",
+              credentials: "same-origin",
+              headers: { "content-type": "application/json" },
+              body: JSON.stringify({ title: "Dashboard Butler server push test" })
+            });
+            setText(pushState, response.ok ? "server-side Web Push \u3092\u9001\u4FE1\u3057\u307E\u3057\u305F\u3002" : "server-side Web Push \u306E\u9001\u4FE1\u306B\u5931\u6557\u3057\u307E\u3057\u305F\u3002");
+            await refreshState();
           });
 
           badgeSetButton?.addEventListener("click", async () => {


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #444 の server-side Web Push 最小スライスとして、保存済み dashboard push subscription を Worker が読み、VAPID署名付き Web Push を push service に送れるようにします。
- Dashboard Butler を開いていない iPhone / Apple Watch へ VTDD 側から通知できる経路の runtime 実装を追加します。
- このPRは payload暗号化による任意本文送信ではなく、payloadless push により Service Worker の既定通知を鳴らす入口です。

## Satisfied Success Criteria

- 認証済み dashboard owner だけが実行できる `POST /v2/dashboard/push/test` を追加しました。
- D1 / injected push subscription store が保存済み subscription を `list` できるようにしました。
- Worker が `VTDD_WEB_PUSH_PUBLIC_KEY` / `VTDD_WEB_PUSH_PRIVATE_KEY` / `VTDD_WEB_PUSH_SUBJECT` から VAPID JWT を生成し、push endpoint へ POST できるようにしました。
- GitHub Actions event と VPS runner event の ingest 後に server-side Web Push dispatch を試行し、runtime truth に `webPush` 結果を含めるようにしました。
- Dashboard 通知センターに `サーバ送信テスト` ボタンを追加しました。
- push service が `404` / `410` を返した subscription を stale として削除し、runtime truth に `cleaned` 件数を含めるようにしました。
- 認証境界、VAPID header、未設定 blocker、stale subscription cleanup、subscription raw key 非漏洩をテストで確認しました。

## Unsatisfied Success Criteria

- production の VAPID secret / subject 設定は未実施です。secret mutation は scoped passkey approval が必要です。
- production deploy はこのPRでは未実施です。deploy は scoped passkey approval が必要です。
- iPhone / Apple Watch の live Web Push E2E は未実施です。
- encrypted payload による通知 title/body の個別送信は未実装です。
- VAPID鍵のローテーション自動化は未実装です。運用は Cloudflare Workers Secrets に保存し、設定・変更は scoped passkey approval を必須にします。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #444
- Implementing Success Criteria: server-side Web Push send path、manual test route、event ingest 後 dispatch attempt、Dashboard notification center の test entrypoint、stale subscription cleanup。
- Explicit Non-goals: deploy、secret mutation、payload encryption、iOS live E2E、Issue close、Custom GPT Action Schema 変更、VPS Codex CLI skill parity 実装。
- Expected touched files/routes/workflows: `src/worker/runtime.js`, `test/worker.test.js`, `worker.js`; routes `POST /v2/dashboard/push/test`, `/v2/events/github-actions`, `/v2/events/vps-runner`, `/dashboard/notifications`。
- Affected Issues: Issue #444。Issue #495 は関連設計 Issue として作成済みだが、このPRでは実装しません。
- Affected PRs: なし。
- Affected workflows: GitHub Actions deploy completion event の runtime event ingest response に `webPush` が追加されます。workflow YAML は変更しません。
- Affected runtime/operator surfaces: Cloudflare Worker dashboard routes、D1 push subscription store、Dashboard 通知センター、GitHub Actions / VPS runner event ingest surface。
- What may break if we patch narrowly: iOS Web Push は VAPID設定と Service Worker subscription に依存するため、payloadless push だけでは通知文面は既定文言になります。404 / 410 以外の一時的な push service 失敗は cleanup せず、再送や backoff は次スライスに残します。
- Unknowns to investigate before coding: production VAPID secret の未設定状態、iOS PWA live push の実機挙動、payload encryption の要否。
- Validation needed: unit/integration test、generated worker parity、production deploy 後の iPhone / Apple Watch live E2E、VAPID secret 設定後の `/v2/dashboard/push/test` 実機確認。
- Stop condition: secret mutation、deploy、payload encryption、retry / backoff、または Issue #495 の VPS Codex CLI skill/plugin parity 実装に踏み込む場合。

## File / Line Hypotheses

- file: `src/worker/runtime.js`
  - hypothesis: Dashboard push subscription store に `list` を追加し、VAPID署名付き送信関数と test route を Worker runtime に追加すれば、Cloudflare Worker 上で server-side Web Push の送信経路を持てる。
  - risk if changed narrowly: payload暗号化なしでは通知本文は Service Worker の既定表示になる。VAPID env 未設定時は明示 blocker にする必要がある。404 / 410 cleanup を入れないと stale subscription が蓄積する。
  - validation: authenticated/unauthenticated route test、VAPID header test、stale subscription cleanup test、event ingest response test。
  - related Issue: Issue #444
- file: `test/worker.test.js`
  - hypothesis: WebCrypto で test VAPID key pair を生成し、mock fetch を注入すれば secret を置かずに server-side push path を検証できる。
  - risk if changed narrowly: raw subscription key や private key を response / fixture に漏らす可能性がある。
  - validation: raw key 非漏洩 assertion と full `npm test`。
  - related Issue: Issue #444
- file: `worker.js`
  - hypothesis: runtime edit 後に generated worker を再生成しないと deploy artifact と source が乖離する。
  - risk if changed narrowly: `check:generated-worker` が落ちる、または production が古い runtime を配信する。
  - validation: `npm run build:worker` と `npm test`。
  - related Issue: Issue #444

## Hypothesis Retrospective

- expected: Worker runtime に payloadless Web Push send path と test route を追加し、generated worker parity まで通す。
- actual: `src/worker/runtime.js`, `test/worker.test.js`, `worker.js` を更新し、stale subscription cleanup も追加しました。full `npm test` が通過しました。
- mismatch: encrypted payload と iPhone live E2E はこのPRスライス外として残しました。
- lesson: まず payloadless push で「端末へ通知を起こす経路」を作り、次に VAPID secret 設定と live E2E、必要なら payload encryption に進むのが小さく検証しやすい。
- should become RAG candidate: はい。server-side Web Push は secret / deploy / live E2E の境界を分けるべきという判断を記録候補にできます。

## Verification Evidence

- Unit: `npm test` passed。Node tests 919、pass 918、fail 0、skipped 1。targeted `node --test test/worker.test.js --test-name-pattern "server-side dashboard Web Push|stale dashboard Web Push|GitHub Actions deploy completion|notification center"` も passed。
- Integration: `npm test` 内で `check:self-parity` と `check:generated-worker` passed。
- E2E: 未実施。production deploy、VAPID secret 設定、iPhone / Apple Watch live Web Push 確認はこのPR後の scoped approval 工程です。
- Manual: Issue #495 `vps: Codex CLI skill/plugin/MCP parity with mac Codex` を作成済み。Cloudflare Workers skill を確認し、Workers runtime 実装として進めました。
- Evidence path/link: local test output `npm test`; Issue #495 https://github.com/marushu/vtdd-v2-p/issues/495

## Butler Completion Contract

- Owner goal: Dashboard Butler を開いていなくても、VTDD側から iPhone / Apple Watch に通知できる server-side Web Push 経路を作る。
- Butler entrypoint: `/dashboard/notifications` の `サーバ送信テスト` ボタン。machine event 経路は `/v2/events/github-actions` と `/v2/events/vps-runner`。
- Action Schema exposure: 変更なし。Dashboard same-origin UI と machine event routes の runtime slice です。
- Runtime path: `/dashboard/notifications -> POST /v2/dashboard/push/test -> subscription list -> VAPID signed POST to push endpoint`。event routes は event store 書き込み後に同じ dispatch を試行します。push service が `404` / `410` を返した場合は該当 endpoint hash を削除します。
- Runner/runtime truth: test route と event ingest response が `webPush` の delivered / failed / skipped / errors / reason / cleaned を返します。
- Authority boundary: manual test は dashboard owner auth 必須。event ingest は既存 machine auth 境界。VAPID private key は Cloudflare Workers Secrets として保存する前提で、secret 設定・変更・ローテーションは scoped passkey approval 必須です。このPRでは secret mutation と deploy は行いません。
- E2E evidence: 未実施。production deploy、VAPID secret 設定、iPhone / Apple Watch live E2E が必要です。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 未実施。scoped passkey approval が必要です。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。production deploy と VAPID secret 設定後に必要です。

## Related Constitution Rules

- Butler Completion Gate: owner-facing workflow は live E2E まで incomplete として扱う。
- Authority Boundary: deploy と secret mutation は scoped passkey approval が必要。
- Evidence Discipline: completion claim には file path、test result、E2E result を分けて記載する。
- RAG Memory Capture and Cost Boundary: 今回は RAG write behavior を変更しない。

## Out-of-scope but NOT implemented

- encrypted Web Push payload による通知 title/body の個別送信。
- 404 / 410 以外の push service failure に対する retry / backoff。
- VAPID鍵ローテーション自動化。
- production VAPID secret 設定。
- production deploy と iPhone / Apple Watch live E2E。
- Issue #495 の VPS Codex CLI skill/plugin/MCP parity 実装。

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #444
- Execution ID: mac_codex_only_probe
- Goal: Cloudflare Workers 上の server-side Web Push runtime send path を追加する
