### PR TITLE
dashboard: コードブロック右上コピーを追加する

### DIFF
--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -9021,11 +9021,13 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
     .bubble .message-body ul { margin: 0; }
     .bubble .message-body li + li { margin-top: 4px; }
     .bubble .message-body code { font-size: .94em; }
-    .bubble .message-body pre { margin: 0; padding: 14px; border: 1px solid var(--border); border-radius: 12px; background: var(--panel-strong); overflow-x: auto; white-space: pre; }
+    .bubble .message-body pre { position: relative; margin: 0; padding: 42px 14px 14px; border: 1px solid var(--border); border-radius: 12px; background: var(--panel-strong); overflow-x: auto; white-space: pre; }
     .bubble .message-body pre code { display: block; font-size: 14px; line-height: 1.55; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace; }
     .bubble .message-body strong { display: inline; color: inherit; font-size: inherit; letter-spacing: 0; text-transform: none; margin: 0; font-weight: 800; }
-    .copy-message { display: inline-flex; align-items: center; justify-content: center; width: 30px; height: 30px; border: 1px solid var(--border); border-radius: 999px; background: var(--button); color: var(--text); font-size: 15px; line-height: 1; cursor: pointer; }
-    .copy-message:focus-visible { outline: 2px solid var(--text); outline-offset: 2px; }
+    .copy-message, .copy-code { display: inline-flex; align-items: center; justify-content: center; width: 30px; height: 30px; border: 1px solid var(--border); border-radius: 999px; background: var(--button); color: var(--text); font-size: 15px; line-height: 1; cursor: pointer; }
+    .copy-message:focus-visible, .copy-code:focus-visible { outline: 2px solid var(--text); outline-offset: 2px; }
+    .copy-code { position: absolute; top: 8px; right: 8px; z-index: 1; opacity: .88; }
+    .copy-code:hover, .copy-code:focus-visible { opacity: 1; }
     .bubble ul { margin: 0; padding-left: 22px; color: var(--text); line-height: 1.85; }
     .bubble.owner { position: relative; align-self: flex-end; background: var(--owner-bubble); color: var(--owner-text); border-radius: 24px; padding: 12px 16px; }
     .bubble.owner p { color: var(--owner-text); margin: 0; }
@@ -9351,11 +9353,20 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
               index += 1;
             }
             const pre = document.createElement("pre");
+            const codeText = codeLines.join("\\n");
+            const copyButton = document.createElement("button");
+            copyButton.className = "copy-code";
+            copyButton.type = "button";
+            copyButton.textContent = "⧉";
+            copyButton.setAttribute("aria-label", "コードをコピー");
+            copyButton.title = "コードをコピー";
+            copyButton.addEventListener("click", () => copyMessageText(copyButton, codeText));
             const code = document.createElement("code");
             if (language) {
               code.dataset.language = language;
             }
-            code.textContent = codeLines.join("\\n");
+            code.textContent = codeText;
+            pre.appendChild(copyButton);
             pre.appendChild(code);
             container.appendChild(pre);
             continue;

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -566,6 +566,10 @@ test("worker serves v2 dashboard for allowed owner identity without exposing sec
   assert.equal(body.includes("navigator.clipboard.writeText"), true);
   assert.equal(body.includes("返信をコピー"), true);
   assert.equal(body.includes("自分の発言をコピー"), true);
+  assert.equal(body.includes('className = "copy-code"'), true);
+  assert.equal(body.includes("コードをコピー"), true);
+  assert.equal(body.includes("copyButton.addEventListener(\"click\", () => copyMessageText(copyButton, codeText))"), true);
+  assert.equal(body.includes(".copy-code { position: absolute; top: 8px; right: 8px;"), true);
   assert.equal(body.includes('if (message.role === "owner")'), true);
   assert.equal(body.includes('} else if (message.role === "butler") {'), true);
   assert.equal(body.includes('} else if (message.role === "system") {'), true);

--- a/worker.js
+++ b/worker.js
@@ -63797,11 +63797,13 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
     .bubble .message-body ul { margin: 0; }
     .bubble .message-body li + li { margin-top: 4px; }
     .bubble .message-body code { font-size: .94em; }
-    .bubble .message-body pre { margin: 0; padding: 14px; border: 1px solid var(--border); border-radius: 12px; background: var(--panel-strong); overflow-x: auto; white-space: pre; }
+    .bubble .message-body pre { position: relative; margin: 0; padding: 42px 14px 14px; border: 1px solid var(--border); border-radius: 12px; background: var(--panel-strong); overflow-x: auto; white-space: pre; }
     .bubble .message-body pre code { display: block; font-size: 14px; line-height: 1.55; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace; }
     .bubble .message-body strong { display: inline; color: inherit; font-size: inherit; letter-spacing: 0; text-transform: none; margin: 0; font-weight: 800; }
-    .copy-message { display: inline-flex; align-items: center; justify-content: center; width: 30px; height: 30px; border: 1px solid var(--border); border-radius: 999px; background: var(--button); color: var(--text); font-size: 15px; line-height: 1; cursor: pointer; }
-    .copy-message:focus-visible { outline: 2px solid var(--text); outline-offset: 2px; }
+    .copy-message, .copy-code { display: inline-flex; align-items: center; justify-content: center; width: 30px; height: 30px; border: 1px solid var(--border); border-radius: 999px; background: var(--button); color: var(--text); font-size: 15px; line-height: 1; cursor: pointer; }
+    .copy-message:focus-visible, .copy-code:focus-visible { outline: 2px solid var(--text); outline-offset: 2px; }
+    .copy-code { position: absolute; top: 8px; right: 8px; z-index: 1; opacity: .88; }
+    .copy-code:hover, .copy-code:focus-visible { opacity: 1; }
     .bubble ul { margin: 0; padding-left: 22px; color: var(--text); line-height: 1.85; }
     .bubble.owner { position: relative; align-self: flex-end; background: var(--owner-bubble); color: var(--owner-text); border-radius: 24px; padding: 12px 16px; }
     .bubble.owner p { color: var(--owner-text); margin: 0; }
@@ -64127,11 +64129,20 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
               index += 1;
             }
             const pre = document.createElement("pre");
+            const codeText = codeLines.join("\\n");
+            const copyButton = document.createElement("button");
+            copyButton.className = "copy-code";
+            copyButton.type = "button";
+            copyButton.textContent = "\u29C9";
+            copyButton.setAttribute("aria-label", "\u30B3\u30FC\u30C9\u3092\u30B3\u30D4\u30FC");
+            copyButton.title = "\u30B3\u30FC\u30C9\u3092\u30B3\u30D4\u30FC";
+            copyButton.addEventListener("click", () => copyMessageText(copyButton, codeText));
             const code = document.createElement("code");
             if (language) {
               code.dataset.language = language;
             }
-            code.textContent = codeLines.join("\\n");
+            code.textContent = codeText;
+            pre.appendChild(copyButton);
             pre.appendChild(code);
             container.appendChild(pre);
             continue;


### PR DESCRIPTION
## This PR satisfies Intent

- #450 Dashboard chat の fenced code block に右上コピー操作を追加し、iPhone/PWA でコード断片を本文全体から探さずコピーできるようにする部分進捗です。

## Satisfied Success Criteria

- Dashboard chat の fenced code block レンダリングで、コード本文だけをコピーする右上ボタンを生成する。
- 既存の本文コピー fallback を再利用し、Clipboard API 非対応時も textarea fallback を使う。
- Dashboard HTML の固定テストで copy-code UI とコード本文コピー handler を検証する。

## Unsatisfied Success Criteria

- #450 全体の live Butler E2E completion はこのPRでは未完了。
- #498 の画像/ファイル添付、短命R2保存、VPS画像解析は未実装。
- #495 のVPS skill/plugin/MCP inventory と自動skill提案は未実装。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #450
- Implementing Success Criteria: Dashboard chat surface の表示操作性改善。fenced code block 右上にコピー操作を出し、コード本文だけをコピーできること。
- Explicit Non-goals: #498 画像/ファイル添付、Gmail/Figma connector、#495 skill/plugin/MCP parity、deploy、credential mutation、Action Schema変更。
- Expected touched files/routes/workflows: src/worker/runtime.js, test/worker.test.js, worker.js. Routes/workflows are unchanged.
- Affected Issues: #450 partial. #498/#495 are related but not implemented.
- Affected PRs: なし。
- Affected workflows: なし。
- Affected runtime/operator surfaces: Dashboard Butler chat HTML/JS only.
- What may break if we patch narrowly: コードブロックの上部paddingが増えるため、狭い画面で表示密度が少し下がる可能性。ボタンは絶対配置で本文コピーとは別classに分離。
- Unknowns to investigate before coding: Browser plugin のNode REPL toolはこのターンで露出せず、visual screenshot は未取得。local Worker HTML smokeで代替確認。
- Validation needed: focused worker test, full node --test, self-parity, generated-worker check, local Worker HTML smoke.
- Stop condition: 画像/ファイル添付や外部connector接続を実装済みに見せるUIを追加する必要が出たら停止し、#498/#495へ切り出す。

## File / Line Hypotheses

- file: `src/worker/runtime.js`
  - hypothesis: `renderMessageText` の fenced code block branch に copy button を追加すれば、Dashboard chat内のコード断片だけをコピーできる。
  - risk if changed narrowly: pre内のabsolute配置が横スクロールや本文コピーUIと干渉する可能性。
  - validation: focused worker HTML test と local Worker HTML smokeで class/handler/label を確認。
  - related Issue: #450
- file: `test/worker.test.js`
  - hypothesis: 既存Dashboard HTML guard testに copy-code 固定確認を追加すれば回帰を止められる。
  - risk if changed narrowly: DOM実操作までは検証しない。
  - validation: `node --test --test-name-pattern "worker serves v2 dashboard" test/worker.test.js`。
  - related Issue: #450

## Hypothesis Retrospective

- expected: fenced code block生成時に右上コピーbuttonがHTML/JSに含まれる。
- actual: `copy-code` class、`コードをコピー` label、`copyMessageText(copyButton, codeText)` handlerを確認。
- mismatch: visual screenshotはBrowser Node REPL tool未露出のため未取得。local Worker HTML smokeで代替。
- lesson: #498/#495 相当の接続UIは、未接続機能を見せないため別Issueのまま扱う。
- should become RAG candidate: 未判断。

## Verification Evidence

- Unit: node --test --test-name-pattern "worker serves v2 dashboard" test/worker.test.js (pass, 2 tests).
- Integration: npm run build:worker (pass); npm run check:self-parity (pass); npm run check:generated-worker (pass after temporarily staging worker.js because the checker uses git diff against unstaged generated output).
- E2E: npm test -- --test-name-pattern "worker serves v2 dashboard" accidentally ran full `node --test` and self-parity before failing only because the extra args were forwarded to check-generated-worker; node tests: 918 pass, 1 skipped, 0 fail. Live iPhone Butler E2Eは未実施。
- Manual: Local Worker smoke: `npx wrangler dev --local --ip 127.0.0.1 --port 8787 --var VTDD_GATEWAY_BEARER_TOKEN:local-test-token`; `curl -H "Authorization: Bearer local-test-token" /dashboard` returned 200 and contained `copy-code` / `コードをコピー`.
- Evidence path/link: src/worker/runtime.js; test/worker.test.js; worker.js; local curl output in this Codex run.

## Butler Completion Contract

- Owner goal: Dashboard Butler のコードブロックをiPhone/PWAから素早くコピーできるようにする。
- Butler entrypoint: /dashboard の Dashboard Butler chat surface。
- Action Schema exposure: 未変更。Custom GPT Action Schema には新operationIdを追加しない。
- Runtime path: GET /dashboard renders chat HTML; client-side `renderMessageText` adds copy button to fenced code blocks.
- Runner/runtime truth: Local Worker `/dashboard` returned 200 with `copy-code` and `コードをコピー` in HTML.
- Authority boundary: 未変更。Clipboard操作のみ。GO/passkey/deploy/credential authority は追加しない。
- E2E evidence: このPRでは未接続。iPhone live E2Eは未実施。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 不要。deployは実行していない。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。local Worker HTML smokeまで。

## Related Constitution Rules

- AGENTS.md Drift Stop Protocol
- AGENTS.md Butler Completion Gate
- AGENTS.md Evidence Discipline
- AGENTS.md Change Size and PR Discipline
- AGENTS.md Conversation UX Contract

## Out-of-scope but NOT implemented

- #498: 画像/ファイル添付、短命R2 storage、VPS Codex画像解析。
- #495: VPS skill/plugin/MCP parity、自動skill提案、Gmail/Figma connector利用。
- Issue closure、merge、deploy、credential mutation。

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #450
- Execution ID: mac-codex-local-2026-05-23-code-block-copy
- Goal: dashboard_code_block_copy_partial
