### PR TITLE
#498 R2/D1 メディア保存仕様を固定する

### DIFF
--- a/docs/media/cloudflare-r2-media-storage.md
+++ b/docs/media/cloudflare-r2-media-storage.md
@@ -1,0 +1,228 @@
+# VTDD Media Storage Spec: Cloudflare R2
+
+Issue: #498
+
+## Purpose
+
+VTDD / Dashboard Butler / RAG / Issue / PR で扱う画像、スクリーンショット、動画、音声、添付ファイルは Cloudflare R2 に保存し、D1 には検索、参照、権限、紐付けに必要な metadata だけを保持する。
+
+R2 は大きい binary object の保存先、D1 は object key と参照関係の管理先として分離する。
+
+## Scope
+
+この仕様は Issue #498 の storage contract と first implementation slice を固定する。
+
+初期 E2E は iPhone / PWA Dashboard Butler からの screenshot upload を対象にする。storage schema と route contract は image 以外の media / file も扱える形にするが、動画変換、サムネイル生成、画像編集、大量 upload 最適化は first slice の対象外とする。
+
+## Storage
+
+Cloudflare R2 bucket:
+
+```text
+production: vtdd-media-prod
+preview/dev: vtdd-media-dev
+```
+
+Worker binding:
+
+```text
+VTDD_MEDIA_R2
+```
+
+Object key format:
+
+```text
+media/{repoOwner}/{repoName}/{yyyy}/{mm}/{dd}/{uuid}/{filename}
+```
+
+Example:
+
+```text
+media/sample-owner/sample-repo/2026/05/23/01J.../dashboard-screenshot.png
+```
+
+The object key must not contain tokens, approval grant IDs, private URLs, or user-entered secret material.
+
+## D1 Metadata
+
+Media metadata is stored in the existing Worker D1 plane, using this table:
+
+```sql
+CREATE TABLE IF NOT EXISTS vtdd_media_objects (
+  id TEXT PRIMARY KEY,
+  repository TEXT,
+  related_issue INTEGER,
+  related_pr INTEGER,
+  source_surface TEXT NOT NULL,
+  source_event_id TEXT,
+  object_key TEXT NOT NULL,
+  filename TEXT NOT NULL,
+  content_type TEXT NOT NULL,
+  byte_size INTEGER NOT NULL,
+  sha256 TEXT NOT NULL,
+  visibility TEXT NOT NULL,
+  summary TEXT,
+  ocr_text TEXT,
+  created_by TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_vtdd_media_repo
+  ON vtdd_media_objects(repository, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_vtdd_media_issue
+  ON vtdd_media_objects(repository, related_issue, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_vtdd_media_pr
+  ON vtdd_media_objects(repository, related_pr, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_vtdd_media_source
+  ON vtdd_media_objects(source_surface, source_event_id);
+```
+
+`sha256` is calculated before metadata insert. A failed R2 put or failed D1 insert must not be reported as a saved media object.
+
+## Visibility
+
+Default visibility is `private`.
+
+```text
+private
+  owner / authorized Butler only
+
+repo_internal
+  repository context 内で参照可能
+
+public_evidence
+  Issue / PR / E2E 証跡として公開してよいもの
+```
+
+Promotion from `private` or `repo_internal` to `public_evidence` requires explicit `GO`. Secret-looking media must not be promoted to public evidence.
+
+## Routes
+
+```text
+POST   /v2/media/upload
+GET    /v2/media/:id
+GET    /v2/media/:id/download
+GET    /v2/media/search
+DELETE /v2/media/:id
+```
+
+`POST /v2/media/upload` accepts the media body and context metadata, performs auth and authority checks, calculates `sha256`, writes the R2 object, inserts D1 metadata, optionally creates OCR / summary text, and returns a media reference.
+
+`GET /v2/media/:id` returns metadata and non-sensitive summary fields. It must not return raw binary media.
+
+`GET /v2/media/:id/download` returns the binary object through a same-origin authorized route or a short-lived signed URL equivalent.
+
+`DELETE /v2/media/:id` requires scoped approval. It must delete or tombstone metadata consistently with R2 object deletion semantics defined by the implementation.
+
+## Authority Boundary
+
+- upload: authenticated owner / trusted runner
+- read private media: authenticated owner / trusted Butler
+- delete: scoped approval required
+- public evidence promotion: explicit `GO` required
+- secret-looking media: public promotion forbidden
+- deploy, credential mutation, permission mutation, Cloudflare bucket creation, and binding mutation: scoped passkey approval required
+
+If the R2 binding or D1 binding is missing at runtime, media routes must fail closed with owner-facing Japanese error text. They must not silently fall back to chat history, RAG, GitHub Issue comments, PR bodies, or local filesystem persistence.
+
+## Upload Flow
+
+```text
+Dashboard Butler / runner / API
+  -> media upload route
+  -> auth / approval boundary check
+  -> sha256 calculate
+  -> R2 put
+  -> D1 metadata insert
+  -> optional OCR / summary
+  -> optional RAG memory reference
+  -> dashboard thread に media reference を返す
+```
+
+Dashboard durable thread history stores only the media reference and safe metadata. Raw media binary is never stored in dashboard chat durable history.
+
+## RAG Integration
+
+RAG may store:
+
+```json
+{
+  "type": "media_reference",
+  "mediaId": "med_...",
+  "repository": "sample-owner/sample-repo",
+  "relatedIssue": 498,
+  "contentType": "image/png",
+  "summary": "Dashboard Butler の iPhone PWA 画面。返信待ち表示が残っている。",
+  "ocrText": "VPS Codex CLI に送信しました...",
+  "objectKey": "media/...",
+  "visibility": "private"
+}
+```
+
+RAG must not store:
+
+- raw image binary
+- raw audio / video binary
+- secrets
+- tokens
+- credentials
+- private screenshots containing sensitive data without filtering
+
+Any PR that changes RAG media write behavior must state expected write volume and cost impact.
+
+## Butler Behavior
+
+When the user sends an image, video, audio, or file:
+
+1. Butler uploads the attachment to R2 through the media upload route.
+2. Butler stores metadata in D1.
+3. Butler creates OCR / summary when needed and allowed.
+4. Butler places a media reference and summary into conversation context.
+5. Butler asks whether the media should be used as Issue / PR / E2E evidence.
+
+Example owner-facing reply:
+
+```text
+画像を保存しました。
+
+- mediaId: med_...
+- repository: sample-owner/sample-repo
+- relatedIssue: #498
+- visibility: private
+
+この画像は Dashboard Butler の返信待ち UI の証跡として使えます。
+Issue #498 に証跡コメントとして残す場合は GO と言ってください。
+```
+
+## First Implementation Slice
+
+The first implementation slice is incomplete until all of these are connected and verified:
+
+1. R2 binding `VTDD_MEDIA_R2` is declared without owner-specific account IDs in the public repo.
+2. D1 table `vtdd_media_objects` is created or migrated.
+3. `POST /v2/media/upload` is implemented.
+4. `GET /v2/media/:id` is implemented.
+5. Dashboard Butler thread can display a media reference.
+6. RAG stores only media summary/reference, never raw media.
+7. E2E proves iPhone screenshot upload -> dashboard thread media reference -> R2/D1 confirmation.
+
+## Non-goals for First Slice
+
+- video conversion
+- thumbnail generation
+- image editing
+- automatic public promotion
+- automatic long-term retention policy
+- bulk upload optimization
+- Cloudflare account setup automation
+- deploy or credential mutation without scoped passkey approval
+
+## Completion Boundary
+
+This document is a specification anchor only. It does not complete Issue #498 by itself.
+
+Issue #498 remains incomplete until Butler natural-language intent, Custom GPT Action Schema, runtime route, runner path, authority boundary, runtime truth, and mapped E2E evidence are all connected.

--- a/test/media-storage-spec.test.js
+++ b/test/media-storage-spec.test.js
@@ -1,0 +1,58 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const DOC_PATH = path.join(process.cwd(), "docs", "media", "cloudflare-r2-media-storage.md");
+
+test("media storage spec anchors Cloudflare R2 and D1 metadata contract", () => {
+  const doc = fs.readFileSync(DOC_PATH, "utf8");
+
+  assert.equal(doc.includes("Issue: #498"), true);
+  assert.equal(doc.includes("vtdd-media-prod"), true);
+  assert.equal(doc.includes("vtdd-media-dev"), true);
+  assert.equal(doc.includes("VTDD_MEDIA_R2"), true);
+  assert.equal(doc.includes("media/{repoOwner}/{repoName}/{yyyy}/{mm}/{dd}/{uuid}/{filename}"), true);
+  assert.equal(doc.includes("vtdd_media_objects"), true);
+  assert.equal(doc.includes("sha256 TEXT NOT NULL"), true);
+});
+
+test("media storage spec defines routes and visibility authority", () => {
+  const doc = fs.readFileSync(DOC_PATH, "utf8");
+
+  for (const route of [
+    "POST   /v2/media/upload",
+    "GET    /v2/media/:id",
+    "GET    /v2/media/:id/download",
+    "GET    /v2/media/search",
+    "DELETE /v2/media/:id"
+  ]) {
+    assert.equal(doc.includes(route), true, `${route} should be documented`);
+  }
+
+  assert.equal(doc.includes("private"), true);
+  assert.equal(doc.includes("repo_internal"), true);
+  assert.equal(doc.includes("public_evidence"), true);
+  assert.equal(doc.includes("explicit `GO` required"), true);
+  assert.equal(doc.includes("scoped passkey approval required"), true);
+});
+
+test("media storage spec prevents raw media persistence in RAG and chat history", () => {
+  const doc = fs.readFileSync(DOC_PATH, "utf8");
+
+  assert.equal(doc.includes("Raw media binary is never stored in dashboard chat durable history."), true);
+  assert.equal(doc.includes("RAG must not store:"), true);
+  assert.equal(doc.includes("raw image binary"), true);
+  assert.equal(doc.includes("raw audio / video binary"), true);
+  assert.equal(doc.includes("secrets"), true);
+  assert.equal(doc.includes("tokens"), true);
+  assert.equal(doc.includes("credentials"), true);
+});
+
+test("media storage spec keeps implementation completion separate from documentation", () => {
+  const doc = fs.readFileSync(DOC_PATH, "utf8");
+
+  assert.equal(doc.includes("This document is a specification anchor only."), true);
+  assert.equal(doc.includes("does not complete Issue #498 by itself"), true);
+  assert.equal(doc.includes("E2E proves iPhone screenshot upload -> dashboard thread media reference -> R2/D1 confirmation"), true);
+});


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #498 の storage contract を、Cloudflare R2 に binary、D1 に metadata を置く仕様として repo に固定しました。
- Dashboard Butler / RAG / Issue / PR が raw media を保存しない境界を仕様化しました。
- first implementation slice の route、binding、D1 table、E2E 条件を明記しました。

## Satisfied Success Criteria

- R2 bucket 名、Worker binding `VTDD_MEDIA_R2`、object key format を仕様化しました。
- `vtdd_media_objects` D1 table と index を仕様化しました。
- `/v2/media/upload` と `/v2/media/:id` を含む media route contract を仕様化しました。
- RAG と dashboard durable history には media summary/reference のみ保存する境界を仕様化しました。
- 仕様欠落を検知する doc test を追加しました。

## Unsatisfied Success Criteria

- Dashboard Butler の media add button はこのPRでは未実装です。
- R2 binding、D1 migration、runtime route、Custom GPT Action Schema、runner path はこのPRでは未接続です。
- iPhone screenshot upload -> dashboard thread -> R2/D1 確認 E2E はこのPRでは未実施です。
- Cloudflare bucket 作成、binding mutation、本番 deploy は scoped passkey approval が必要なため未実行です。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #498
- Implementing Success Criteria: R2/D1 media storage spec、authority boundary、RAG raw media 禁止、first implementation slice / E2E completion gate の durable 化。
- Explicit Non-goals: runtime route 実装、R2 bucket 作成、D1 migration 適用、Cloudflare binding mutation、deploy、Issue close。
- Expected touched files/routes/workflows: docs/media/cloudflare-r2-media-storage.md, test/media-storage-spec.test.js。runtime route / workflow / wrangler config は未変更。
- Affected Issues: Issue #498。関連して #495 の skill/plugin 方向に影響し得るが、このPRでは実装しない。
- Affected PRs: 既存PRへの変更なし。
- Affected workflows: GitHub Actions workflow は未変更。test suite のみ確認。
- Affected runtime/operator surfaces: Dashboard Butler / Worker / VPS runner / Custom GPT surface の将来仕様に影響するが、このPRでは runtime surface は未接続。
- What may break if we patch narrowly: 仕様なしで upload UI から入ると raw media が RAG / chat history / Issue に流れる drift、または owner-specific Cloudflare 設定を public repo に混ぜる risk がある。
- Unknowns to investigate before coding: 実装前に R2 bucket 実在、binding 注入方法、D1 migration 適用経路、upload body format、download route の same-origin 認可方式を確認する必要がある。
- Validation needed: doc test、full npm test。runtime slice では unit/integration/E2E と Cloudflare runtime truth が別途必要。
- Stop condition: Cloudflare account/bucket/binding/deploy/credential mutation が必要になった時点で scoped passkey approval なしに進めない。

## File / Line Hypotheses

- file: `docs/media/cloudflare-r2-media-storage.md`
  - hypothesis: #498 の R2/D1 media storage contract は repo doc として固定するのが drift を防ぐ。
  - risk if changed narrowly: runtime だけを先に触ると raw media 保存先や authority boundary が曖昧になる。
  - validation: `test/media-storage-spec.test.js` と `npm test`。
  - related Issue: #498
- file: `test/media-storage-spec.test.js`
  - hypothesis: storage route、visibility、RAG raw media 禁止、completion boundary は doc test で最低限守れる。
  - risk if changed narrowly: doc 変更だけでは Butler runtime は使えないため PR body で incomplete と明記する必要がある。
  - validation: `node --test test/media-storage-spec.test.js`。
  - related Issue: #498

## Hypothesis Retrospective

- expected: R2/D1 仕様を repo に固定し、runtime 未接続を明記する。
- actual: `docs/media/cloudflare-r2-media-storage.md` と doc test を追加した。
- mismatch: runtime route / binding / migration は意図的に未実装。
- lesson: #498 は先に storage authority と RAG 境界を固定してから実装に入る必要がある。
- should become RAG candidate: merge 後に #498 storage contract として working_memory 候補。

## Verification Evidence

- Unit: `node --test test/media-storage-spec.test.js` passed: 4 tests.
- Integration: `npm test` passed: 922 pass, 1 skipped, 0 fail, plus runtime self-parity and generated-worker checks passed.
- E2E: 未実施。このPRは仕様 anchor であり、iPhone Butler media upload E2E は runtime slice で必要。
- Manual: Issue #498 の現行 body と thread-independent startup contract を確認し、user 提示 spec を repo doc に反映。
- Evidence path/link: docs/media/cloudflare-r2-media-storage.md; test/media-storage-spec.test.js

## Butler Completion Contract

- Owner goal: Dashboard Butler から送った画像・動画・音声・ファイルを R2 に保存し、D1 と RAG には安全な参照だけを残す仕様を固定する。
- Butler entrypoint: このPRでは未接続。次 slice で Dashboard Butler の media add button と upload route を接続する。
- Action Schema exposure: このPRでは未変更。次 slice で必要 operationId / route exposure を設計する。
- Runtime path: このPRでは未接続。仕様上は `POST /v2/media/upload` と `GET /v2/media/:id` を first implementation slice に固定。
- Runner/runtime truth: runtime route、R2 binding、D1 table は未接続。doc test と npm test のみ確認済み。
- Authority boundary: upload/read/delete/promotion/deploy/binding mutation の boundary を docs に固定。Cloudflare mutation と deploy は scoped passkey approval required。
- E2E evidence: 未実施。Issue #498 完了には iPhone screenshot upload -> dashboard thread media reference -> R2/D1 confirmation が必要。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 不要。このPRでは deploy しない。
- Custom GPT Action Schema update: 不要。このPRでは Action Schema を変更しない。
- Custom GPT Instructions update: 不要。このPRでは Custom GPT Instructions を変更しない。
- iPhone Butler live E2E: 未実施。runtime 実装 slice で必要。

## Related Constitution Rules

- AGENTS.md Drift Stop Protocol
- AGENTS.md Butler Completion Gate
- AGENTS.md RAG Memory Capture and Cost Boundary
- AGENTS.md Authority Boundary
- AGENTS.md Evidence Discipline

## Out-of-scope but NOT implemented

- R2 bucket 作成、D1 migration 適用、Cloudflare binding mutation、runtime route 実装、Dashboard UI 実装、RAG write 実装、E2E 実行。

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #498
- Execution ID: mac_codex_only_probe-2026-05-23-media-storage-spec
- Goal: Issue #498 の R2/D1 media storage 仕様を repo に固定する。
