### PR TITLE
#501 same-head fallback 後の Gemini approve を採用する

### DIFF
--- a/src/core/execution-continuity.js
+++ b/src/core/execution-continuity.js
@@ -157,8 +157,16 @@ function buildReviewState(pullRequest) {
     codexFallback.latestSignal ?? codexFallback.latestEvidence,
     currentHeadSha
   );
+  const newerGeminiApproveSupersedesRequestedFallback =
+    shouldPreferNewerGeminiApproveOverRequestedFallback({
+      geminiEvidence: parsedGeminiSignals.latestEvidence,
+      codexFallbackSignal: codexFallback.latestSignal,
+      currentHeadSha
+    });
   const effectiveCodexFallback =
-    geminiEvidenceMatchesCurrentHead && codexFallbackStaleForCurrentHead && !codexFallback.globalBlocker
+    geminiEvidenceMatchesCurrentHead &&
+    !codexFallback.globalBlocker &&
+    (codexFallbackStaleForCurrentHead || newerGeminiApproveSupersedesRequestedFallback)
       ? emptyCodexFallbackSignals()
       : codexFallback;
   const formalReviewTruth = collectFormalReviewTruth(pullRequest);
@@ -319,6 +327,26 @@ function evidenceTargetsDifferentHead(evidence, headSha) {
   const normalizedHead = normalizeText(headSha);
   const evidenceHead = normalizeText(evidence?.headSha);
   return Boolean(normalizedHead && evidenceHead && evidenceHead !== normalizedHead);
+}
+
+function shouldPreferNewerGeminiApproveOverRequestedFallback({
+  geminiEvidence,
+  codexFallbackSignal,
+  currentHeadSha
+}) {
+  if (normalizeText(geminiEvidence?.recommendedAction).toLowerCase() !== "approve") {
+    return false;
+  }
+  if (normalizeText(codexFallbackSignal?.status) !== "requested") {
+    return false;
+  }
+  if (!evidenceMatchesHead(geminiEvidence, currentHeadSha)) {
+    return false;
+  }
+  if (!evidenceMatchesHead(codexFallbackSignal, currentHeadSha)) {
+    return false;
+  }
+  return timelineTimestamp(geminiEvidence) > timelineTimestamp(codexFallbackSignal);
 }
 
 function buildReviewTimeline(pullRequest) {

--- a/test/execution-continuity.test.js
+++ b/test/execution-continuity.test.js
@@ -179,6 +179,89 @@ test("execution continuity prefers current-head Gemini approve over stale Codex 
   assert.equal(result.value.nextSuggestedActions.includes("apply_pr_feedback"), false);
 });
 
+test("execution continuity prefers newer current-head Gemini approve over same-head Codex fallback request", () => {
+  const result = evaluateExecutionContinuity({
+    actorRole: ActorRole.BUTLER,
+    mode: TaskMode.EXECUTION,
+    runtimeTruth: {
+      runtimeState: {
+        activeBranch: "codex/issue-501",
+        pullRequest: {
+          number: 500,
+          url: "https://github.com/example/repo/pull/500",
+          state: "open",
+          title: "R2 media storage spec",
+          reviewer: "gemini",
+          headSha: "same-head-500",
+          mergeable: true,
+          mergeableState: "clean",
+          issueComments: [
+            {
+              user: { login: "vtdd-gemini-reviewer" },
+              createdAt: "2026-05-23T00:42:28.000Z",
+              body: "<!-- vtdd:reviewer=codex-fallback -->\n## VTDD Codex fallback レビュー\n\n- Status: `requested`\n- Head SHA: `same-head-500`\n\nGemini reviewer は一時的に利用できません。"
+            },
+            {
+              user: { login: "vtdd-gemini-reviewer" },
+              createdAt: "2026-05-23T00:43:14.000Z",
+              body: "<!-- vtdd:reviewer=gemini -->\n## VTDD Gemini レビュー\n\n- Head SHA: `same-head-500`\n- Recommended action: `approve`\n\n### 重要指摘\n- 報告なし。"
+            }
+          ]
+        }
+      }
+    }
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.value.reviewLoop.reviewer, "gemini");
+  assert.equal(result.value.reviewLoop.reviewerStatus, "gemini_review_available");
+  assert.equal(result.value.reviewLoop.reviewerEvidence.recommendedAction, "approve");
+  assert.equal(result.value.reviewLoop.reviewerEvidence.headSha, "same-head-500");
+  assert.equal(result.value.reviewLoop.criticalReviewPending, false);
+  assert.equal(result.value.reviewLoop.reviewerSignalTruth.mergeReviewTruth.satisfied, true);
+});
+
+test("execution continuity keeps same-head completed Codex fallback changes requested despite newer Gemini approve", () => {
+  const result = evaluateExecutionContinuity({
+    actorRole: ActorRole.BUTLER,
+    mode: TaskMode.EXECUTION,
+    runtimeTruth: {
+      runtimeState: {
+        activeBranch: "codex/issue-501",
+        pullRequest: {
+          number: 500,
+          url: "https://github.com/example/repo/pull/500",
+          state: "open",
+          title: "R2 media storage spec",
+          reviewer: "gemini",
+          headSha: "same-head-500",
+          mergeable: true,
+          mergeableState: "clean",
+          issueComments: [
+            {
+              user: { login: "vtdd-codex[bot]" },
+              createdAt: "2026-05-23T00:42:28.000Z",
+              body: "<!-- vtdd:reviewer=codex-fallback -->\n## VTDD Codex fallback レビュー\n\n- Status: `completed`\n- Head SHA: `same-head-500`\n- Recommended action: `request_changes`\n\n### 重要指摘\n- same head still needs changes"
+            },
+            {
+              user: { login: "vtdd-gemini-reviewer" },
+              createdAt: "2026-05-23T00:43:14.000Z",
+              body: "<!-- vtdd:reviewer=gemini -->\n## VTDD Gemini レビュー\n\n- Head SHA: `same-head-500`\n- Recommended action: `approve`\n\n### 重要指摘\n- 報告なし。"
+            }
+          ]
+        }
+      }
+    }
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.value.reviewLoop.reviewer, "codex");
+  assert.equal(result.value.reviewLoop.reviewerStatus, "codex_review_available");
+  assert.equal(result.value.reviewLoop.reviewerEvidence.recommendedAction, "request_changes");
+  assert.equal(result.value.reviewLoop.criticalReviewPending, true);
+  assert.equal(result.value.reviewLoop.reviewerSignalTruth.mergeReviewTruth.satisfied, false);
+});
+
 test("execution continuity does not satisfy review truth from stale Gemini approve when current head is unreviewed", () => {
   const result = evaluateExecutionContinuity({
     actorRole: ActorRole.BUTLER,

--- a/worker.js
+++ b/worker.js
@@ -35483,7 +35483,12 @@ function buildReviewState(pullRequest) {
     codexFallback.latestSignal ?? codexFallback.latestEvidence,
     currentHeadSha
   );
-  const effectiveCodexFallback = geminiEvidenceMatchesCurrentHead && codexFallbackStaleForCurrentHead && !codexFallback.globalBlocker ? emptyCodexFallbackSignals() : codexFallback;
+  const newerGeminiApproveSupersedesRequestedFallback = shouldPreferNewerGeminiApproveOverRequestedFallback({
+    geminiEvidence: parsedGeminiSignals.latestEvidence,
+    codexFallbackSignal: codexFallback.latestSignal,
+    currentHeadSha
+  });
+  const effectiveCodexFallback = geminiEvidenceMatchesCurrentHead && !codexFallback.globalBlocker && (codexFallbackStaleForCurrentHead || newerGeminiApproveSupersedesRequestedFallback) ? emptyCodexFallbackSignals() : codexFallback;
   const formalReviewTruth = collectFormalReviewTruth(pullRequest);
   const reviewTimeline = buildReviewTimeline(pullRequest);
   const reviewCommentsCount = effectiveCodexFallback.completed ? 1 : parsedGeminiSignals.totalCount > 0 ? parsedGeminiSignals.totalCount : pullRequest.reviewCommentsCount;
@@ -35588,6 +35593,25 @@ function evidenceTargetsDifferentHead(evidence, headSha) {
   const normalizedHead = normalizeText5(headSha);
   const evidenceHead = normalizeText5(evidence?.headSha);
   return Boolean(normalizedHead && evidenceHead && evidenceHead !== normalizedHead);
+}
+function shouldPreferNewerGeminiApproveOverRequestedFallback({
+  geminiEvidence,
+  codexFallbackSignal,
+  currentHeadSha
+}) {
+  if (normalizeText5(geminiEvidence?.recommendedAction).toLowerCase() !== "approve") {
+    return false;
+  }
+  if (normalizeText5(codexFallbackSignal?.status) !== "requested") {
+    return false;
+  }
+  if (!evidenceMatchesHead(geminiEvidence, currentHeadSha)) {
+    return false;
+  }
+  if (!evidenceMatchesHead(codexFallbackSignal, currentHeadSha)) {
+    return false;
+  }
+  return timelineTimestamp(geminiEvidence) > timelineTimestamp(codexFallbackSignal);
 }
 function buildReviewTimeline(pullRequest) {
   const comments = [


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #501 の reviewer continuity regression を修正します。
- 同じ head SHA の `codex-fallback requested` が残った後、より新しい Gemini `approve` が来た場合に Gemini approve を reviewer truth として採用できるようにします。
- 既存の stale fallback 対策と blocker 保護は維持します。

## Satisfied Success Criteria

- same-head `codex-fallback requested` より新しい current-head Gemini approve を優先する分岐を追加しました。
- 同じ head の `codex-fallback completed request_changes` は Gemini approve で消えない regression test を追加しました。
- 既存の stale fallback test は維持して通しています。
- PR #500 型の入力で approve-auto-merge evaluation が `allowed: true` になることをローカル検証しました。

## Unsatisfied Success Criteria

- PR #500 の live workflow_dispatch 再評価はこのPRでは未実行です。
- このPRは merge 前なので Issue #501 はまだ close-ready ではありません。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #501
- Implementing Success Criteria: current head Gemini approve が同じ head のより古い codex-fallback requested を上書きし、completed/blocking/global blocker は上書きしない。
- Explicit Non-goals: PR #500 の media storage spec 変更、Cloudflare deploy、credential/permission mutation、GitHub settings mutation、Issue #498 の media route 実装。
- Expected touched files/routes/workflows: src/core/execution-continuity.js, test/execution-continuity.test.js, worker.js。
- Affected Issues: Issue #501。PR #500 の auto-merge 再評価に影響する。Issue #498 の仕様PR内容は変更しない。
- Affected PRs: PR #500 の auto-merge blocker 解消候補。既存PR本文や差分は変更しない。
- Affected workflows: approve-auto-merge の reviewer truth evaluation に影響。workflow YAML は未変更。
- Affected runtime/operator surfaces: Worker bundled code と GitHub Actions approve-auto-merge script が参照する shared core logic。Dashboard UI / Cloudflare runtime route は未変更。
- What may break if we patch narrowly: same-head fallback completed request_changes や actor identity / connector blocker まで Gemini approve で消すと reviewer stop role を壊すため、requested のみを newer Gemini approve で上書きする。
- Unknowns to investigate before coding: PR #500 の live auto-merge 再評価は merge 後に workflow_dispatch するか自然 trigger に任せるか人間判断が必要。
- Validation needed: execution-continuity unit、approve-auto-merge unit、PR #500 型 local evaluation、npm test。
- Stop condition: completed request_changes / blocked / global blocker を消す実装になりそうなら停止する。deploy や credential mutation が必要になったら停止する。

## File / Line Hypotheses

- file: `src/core/execution-continuity.js`
  - hypothesis: `buildReviewState` の effectiveCodexFallback selection が same-head requested fallback を優先し続けるため PR #500 の approve を隠した。
  - risk if changed narrowly: stale fallback 対策や blocker 保護を壊すと危険。
  - validation: same-head requested と completed request_changes の regression tests。
  - related Issue: #501
- file: `test/execution-continuity.test.js`
  - hypothesis: PR #500 の順序を unit test 化すれば再発を防げる。
  - risk if changed narrowly: approved path だけでは blocker 保護の退行を見逃す。
  - validation: requested superseded / completed retained の2系統。
  - related Issue: #501

## Hypothesis Retrospective

- expected: same-head requested fallback の後に newer Gemini approve が来た場合だけ Gemini を採用する。
- actual: `shouldPreferNewerGeminiApproveOverRequestedFallback` を追加し、requested のみ timestamp 比較で上書きするようにした。
- mismatch: なし。
- lesson: fallback requested は一時状態なので、同じ head の後続 approve があれば resolved と扱う必要がある。
- should become RAG candidate: 既に `mem_dc11495a-2b1c-48bc-8b90-3102a7824bff` として保存済み。

## Verification Evidence

- Unit: `node --test test/execution-continuity.test.js` passed: 24 tests. `node --test test/approve-auto-merge.test.js` passed: 8 tests.
- Integration: PR #500 型の local evaluation で reviewer=gemini, reviewerStatus=gemini_review_available, action=approve, allowed=true, reasons=[] を確認。
- E2E: 未実施。live PR #500 workflow_dispatch 再評価はこのPR merge 後の人間判断。
- Manual: `npm test` passed: 920 pass, 1 skipped, 0 fail; runtime self-parity and generated-worker checks passed.
- Evidence path/link: src/core/execution-continuity.js; test/execution-continuity.test.js; worker.js; RAG mem_dc11495a-2b1c-48bc-8b90-3102a7824bff

## Butler Completion Contract

- Owner goal: PR #500 のような draft/opened fallback requested 後の Gemini approve で auto-merge が止まり続けないようにする。
- Butler entrypoint: このPRでは未変更。Butler からは PR/check 状態確認として見える修正。
- Action Schema exposure: このPRでは未変更。
- Runtime path: approve-auto-merge workflow -> scripts/run-approve-auto-merge.mjs -> evaluateExecutionContinuity -> buildReviewState。
- Runner/runtime truth: ローカルで PR #500 型 evaluation を確認。live workflow 再評価は未実行。
- Authority boundary: merge/deploy/credential mutation は実行しない。auto-merge の既存 gate だけを修正。
- E2E evidence: 未実施。merge 後に PR #500 の workflow_dispatch または自然 trigger で確認可能。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 不要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 不要。

## Related Constitution Rules

- AGENTS.md Drift Stop Protocol
- AGENTS.md Reviewer as Stop Role
- AGENTS.md Evidence Discipline
- AGENTS.md Change Size and PR Discipline

## Out-of-scope but NOT implemented

- PR #500 の media storage spec 変更。Issue #498 の media button / R2 route 実装。Cloudflare deploy。GitHub credential / permission mutation。Issue close。

## Extra changes (if any)

Generated worker.js を `npm run build:worker` で同期。

<!-- VTDD metadata -->
- Issue: Issue #501
- Execution ID: mac_codex_only_probe-2026-05-23-issue-501
- Goal: same-head fallback requested 後の Gemini approve を auto-merge reviewer truth に反映する。
