### PR TITLE
Issue #503 D1 memory database 名の canonical source を揃える

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -48,6 +48,7 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_D1_DATABASE_ID: ${{ secrets.CLOUDFLARE_D1_DATABASE_ID }}
+          CLOUDFLARE_D1_DATABASE_NAME: ${{ vars.CLOUDFLARE_D1_DATABASE_NAME }}
         shell: bash
         run: |
           missing=0
@@ -67,8 +68,12 @@ jobs:
             echo "Missing required Actions secret: CLOUDFLARE_D1_DATABASE_ID"
             missing=1
           fi
+          if [ -z "$CLOUDFLARE_D1_DATABASE_NAME" ]; then
+            echo "Missing required Actions variable: CLOUDFLARE_D1_DATABASE_NAME"
+            missing=1
+          fi
           if [ "$missing" -ne 0 ]; then
-            echo "Configure the missing secrets before requesting passkey approval for production deploy."
+            echo "Configure the missing secrets or variables before requesting passkey approval for production deploy."
             exit 1
           fi
 
@@ -149,7 +154,7 @@ jobs:
       - name: Generate production Wrangler config
         env:
           CLOUDFLARE_D1_DATABASE_ID: ${{ secrets.CLOUDFLARE_D1_DATABASE_ID }}
-          CLOUDFLARE_D1_DATABASE_NAME: ${{ vars.CLOUDFLARE_D1_DATABASE_NAME || 'vtdd-memory' }}
+          CLOUDFLARE_D1_DATABASE_NAME: ${{ vars.CLOUDFLARE_D1_DATABASE_NAME }}
           VTDD_GITHUB_ACTIONS_REPOSITORY: ${{ github.repository }}
           VTDD_KNOWN_GOOD_COMMIT_SHA: ${{ vars.VTDD_KNOWN_GOOD_COMMIT_SHA }}
           VTDD_DASHBOARD_ALLOWED_EMAILS: ${{ vars.VTDD_DASHBOARD_ALLOWED_EMAILS }}

--- a/docs/memory/vtdd-memory-bridge.md
+++ b/docs/memory/vtdd-memory-bridge.md
@@ -38,6 +38,13 @@ Do not commit runtime URLs, database IDs, bearer tokens, account IDs, or owner
 specific bootstrap values into this repository.
 Do not pass bearer tokens as command-line flags; use the environment variable
 so the token is less likely to land in shell history or process logs.
+
+For direct Wrangler/D1 operations, set `VTDD_MEMORY_D1_DATABASE_NAME` to the
+actual database name shown by `wrangler d1 list`, not to the Worker binding name
+and not to an old display name. The Worker binding name is always
+`VTDD_MEMORY_D1`, but direct D1 repair commands resolve the database argument
+through Wrangler and can fail if the configured database name is stale.
+
 If neither the environment variable nor the bootstrap vault token path is
 available, the runtime memory commands must fail with `desktop maintenance
 required` instead of falling back to D1 direct writes or asking the operator to

--- a/docs/mvp/production-deploy-path.md
+++ b/docs/mvp/production-deploy-path.md
@@ -31,9 +31,13 @@ Set repository or environment secrets:
 
 The token should be scoped to minimum required Worker deploy permissions.
 
-These secrets are hard prerequisites. The workflow must check them before
-validating the passkey grant or running tests so a missing deploy credential is
-reported before operator approval time is wasted.
+Set repository or environment variables:
+
+- `CLOUDFLARE_D1_DATABASE_NAME`
+
+These secrets and variables are hard prerequisites. The workflow must check
+them before validating the passkey grant or running tests so a missing deploy
+credential or D1 name is reported before operator approval time is wasted.
 
 Use `docs/setup/cloudflare-deploy-secret-sync.md` as the canonical operator
 sync path. Do not treat Worker runtime secrets as equivalent to GitHub Actions
@@ -55,8 +59,15 @@ before deploying production.
 
 For local/operator deploys, store owner-specific bindings in an ignored file
 such as `wrangler.production.local.toml`. For GitHub Actions deploys, store the
-D1 database id in `CLOUDFLARE_D1_DATABASE_ID`; the workflow generates an
+D1 database id in `CLOUDFLARE_D1_DATABASE_ID` and the actual Cloudflare D1
+database name in `CLOUDFLARE_D1_DATABASE_NAME`; the workflow generates an
 uncommitted `wrangler.production.generated.toml` at deploy time.
+
+Do not rely on a generic fallback database name. The D1 database name must
+match the operator-owned Cloudflare database returned by `wrangler d1 list`,
+while the binding name remains the stable runtime contract
+`VTDD_MEMORY_D1`. A stale display name can make direct D1 repair commands fail
+even when the Worker binding still points at the correct database id.
 
 If `/setup/known-good` should expose a rollback bundle, the preferred source of
 truth is `docs/setup/known-good.json` with the last human-verified stable setup

--- a/test/production-deploy-path.test.js
+++ b/test/production-deploy-path.test.js
@@ -28,6 +28,7 @@ test("production deploy doc defines the governed GitHub Actions deploy path", ()
   assert.equal(doc.includes("`CLOUDFLARE_API_TOKEN`"), true);
   assert.equal(doc.includes("`CLOUDFLARE_ACCOUNT_ID`"), true);
   assert.equal(doc.includes("`CLOUDFLARE_D1_DATABASE_ID`"), true);
+  assert.equal(doc.includes("`CLOUDFLARE_D1_DATABASE_NAME`"), true);
   assert.equal(doc.includes("`VTDD_GATEWAY_BEARER_TOKEN`"), true);
   assert.equal(doc.includes("hard prerequisites"), true);
   assert.equal(doc.includes("docs/setup/cloudflare-deploy-secret-sync.md"), true);
@@ -38,6 +39,8 @@ test("production deploy doc defines the governed GitHub Actions deploy path", ()
   assert.equal(doc.includes("must not be committed"), true);
   assert.equal(doc.includes("`wrangler.production.local.toml`"), true);
   assert.equal(doc.includes("`wrangler.production.generated.toml`"), true);
+  assert.equal(doc.includes("Do not rely on a generic fallback database name"), true);
+  assert.equal(doc.includes("`wrangler d1 list`"), true);
   assert.equal(doc.includes("`VTDD_KNOWN_GOOD_COMMIT_SHA`"), true);
   assert.equal(doc.includes("must not silently treat `main` as known-good"), true);
   assert.equal(doc.includes("`VTDD_DEPLOY_NOTIFICATION_ISSUE_NUMBER`"), true);
@@ -71,6 +74,11 @@ test("deploy-production workflow enforces the MVP production deploy boundary", (
   assert.equal(workflow.includes("Missing required Actions secret: CLOUDFLARE_API_TOKEN"), true);
   assert.equal(workflow.includes("Missing required Actions secret: CLOUDFLARE_ACCOUNT_ID"), true);
   assert.equal(workflow.includes("Missing required Actions secret: CLOUDFLARE_D1_DATABASE_ID"), true);
+  assert.equal(workflow.includes("Missing required Actions variable: CLOUDFLARE_D1_DATABASE_NAME"), true);
+  assert.equal(
+    workflow.includes("Configure the missing secrets or variables before requesting passkey approval"),
+    true
+  );
   assert.equal(workflow.includes("Preflight Cloudflare Workers deploy entitlement"), true);
   assert.equal(
     workflow.includes(
@@ -101,6 +109,8 @@ test("deploy-production workflow enforces the MVP production deploy boundary", (
     true
   );
   assert.equal(workflow.includes("Generate production Wrangler config"), true);
+  assert.equal(workflow.includes("CLOUDFLARE_D1_DATABASE_NAME: ${{ vars.CLOUDFLARE_D1_DATABASE_NAME }}"), true);
+  assert.equal(workflow.includes("vars.CLOUDFLARE_D1_DATABASE_NAME || 'vtdd-memory'"), false);
   assert.equal(workflow.includes("VTDD_GITHUB_ACTIONS_REPOSITORY: ${{ github.repository }}"), true);
   assert.equal(workflow.includes("VTDD_KNOWN_GOOD_COMMIT_SHA: ${{ vars.VTDD_KNOWN_GOOD_COMMIT_SHA }}"), true);
   assert.equal(workflow.includes("VTDD_DASHBOARD_ALLOWED_EMAILS: ${{ vars.VTDD_DASHBOARD_ALLOWED_EMAILS }}"), true);
@@ -144,6 +154,7 @@ test("deploy-production workflow enforces the MVP production deploy boundary", (
   );
   assert.equal(workflow.includes("[[env.production.d1_databases]]"), true);
   assert.equal(workflow.includes('binding = "VTDD_MEMORY_D1"'), true);
+  assert.equal(workflow.includes('database_name = "$CLOUDFLARE_D1_DATABASE_NAME"'), true);
   assert.equal(workflow.includes('database_id = "$CLOUDFLARE_D1_DATABASE_ID"'), true);
   assert.equal(
     workflow.includes("command: deploy --config wrangler.production.generated.toml --env production"),


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #503 の部分実装です。RAG / memory bridge と production deploy workflow で D1 database 名の canonical source が揺れ、direct D1 repair が古い表示名で失敗した問題を、誤った fallback 除去と docs 明記で再発防止します。

## Satisfied Success Criteria

- [x] Cloudflare 実 database 名、database_id、runtime binding 名、GitHub Actions 変数、ローカル operator 設定の関係を docs に明記
- [x] GitHub Actions deploy workflow が generic fallback database 名を使わず、CLOUDFLARE_D1_DATABASE_NAME を必須変数として検査
- [x] runtime binding 名 VTDD_MEMORY_D1 は維持
- [x] owner-specific database 名や id を shared wrangler.toml に追加しない

## Unsatisfied Success Criteria

- Butler からの live RAG decision_log 保存 E2E はこの PR では未実施。
- GitHub repository variable CLOUDFLARE_D1_DATABASE_NAME の実設定変更は high-risk / permission-adjacent 運用作業のため未実施。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #503
- Implementing Success Criteria: D1 database name canonical source の docs/workflow 固定。runtime binding 名は維持。
- Explicit Non-goals: R2 media storage 実装、Cloudflare database_id 変更、deploy 実行、credential / permission mutation。
- Expected touched files/routes/workflows: .github/workflows/deploy-production.yml, docs/mvp/production-deploy-path.md, docs/memory/vtdd-memory-bridge.md, test/production-deploy-path.test.js
- Affected Issues: Issue #503, Issue #501 の RAG 保存失敗原因に関連
- Affected PRs: PR #502 の deploy path には影響し得るが、この PR 自体は deploy 未実行
- Affected workflows: deploy-production
- Affected runtime/operator surfaces: GitHub Actions production deploy, Mac/VPS direct D1 memory bridge repair commands
- What may break if we patch narrowly: database_id と binding 名まで変更すると runtime D1 binding を壊す可能性があるため、名前解決と docs に限定。
- Unknowns to investigate before coding: repository variable CLOUDFLARE_D1_DATABASE_NAME の現在値はこの PR では変更・検証していない。
- Validation needed: node --test test/production-deploy-path.test.js; npm test
- Stop condition: Cloudflare database_id 変更、secret/variable mutation、deploy 実行が必要になったら passkey approval なしでは停止。

## File / Line Hypotheses

- file: `.github/workflows/deploy-production.yml`
  - hypothesis: `vars.CLOUDFLARE_D1_DATABASE_NAME || 'vtdd-memory'` が古い fallback を残している。
  - risk if changed narrowly: variable 未設定の deploy が早期失敗するが、誤った database 名で進むより安全。
  - validation: production deploy path test と workflow text assertion。
  - related Issue: Issue #503
- file: `docs/mvp/production-deploy-path.md`
  - hypothesis: D1 name/id/binding の関係説明が不足している。
  - risk if changed narrowly: owner-specific 値を public docs に固定しないよう注意。
  - validation: doc assertion test。
  - related Issue: Issue #503
- file: `docs/memory/vtdd-memory-bridge.md`
  - hypothesis: direct D1 repair では actual database name が必要という注意が不足。
  - risk if changed narrowly: runtime write path と direct repair path の違いを曖昧にしない。
  - validation: doc review。
  - related Issue: Issue #503

## Hypothesis Retrospective

- expected: generic fallback を消し、actual D1 name を operator variable と docs に寄せる。
- actual: workflow で CLOUDFLARE_D1_DATABASE_NAME を必須化し、docs に direct D1 と binding 名の違いを追記。
- mismatch: なし。
- lesson: D1 database_id が正しくても direct Wrangler repair は database 名の stale 設定で失敗する。
- should become RAG candidate: はい。

## Verification Evidence

- Unit: `node --test test/production-deploy-path.test.js` pass
- Integration: `npm test` pass; includes self-parity and generated-worker checks
- E2E: Not run. Deploy and live Butler RAG write require scoped passkey approval / runtime operation.
- Manual: `wrangler d1 list` で実 database 名 `vtdd-v2-memory-production` と id `a544d950-4a6a-4c6f-87e7-4671fe87b70d` を確認済み。
- Evidence path/link: local test output in this PR; GitHub Actions will provide PR checks after push

## Butler Completion Contract

- Owner goal: D1 database 名の不整合で RAG / deploy 周辺作業が失敗しないようにする。
- Butler entrypoint: 未変更。Butler Action Schema には触れていません。
- Action Schema exposure: 未変更。
- Runtime path: GitHub Actions deploy-production workflow の generated Wrangler config と direct D1 memory bridge docs。
- Runner/runtime truth: PR checks と workflow text assertions。live deploy は未実施。
- Authority boundary: deploy / secret / variable mutation は scoped passkey approval 必須。この PR では実行しない。
- E2E evidence: 未実施。Issue #503 の live RAG write E2E は後続の承認付き運用で確認。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 未実行。PR #502 の本番反映には別途 deploy_production passkey grant が必要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。

## Related Constitution Rules

- AGENTS.md Authority Boundary
- AGENTS.md Public Repo Collaboration Boundary
- AGENTS.md Drift Stop Protocol
- AGENTS.md Evidence Discipline

## Out-of-scope but NOT implemented

- Cloudflare variable の実変更
- production deploy 実行
- R2 media storage 実装
- Issue #501 close

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #503
- Execution ID: Not provided.
- Goal: D1 memory database 名の canonical source を揃える
