### PR TITLE
Issue #503 PR #504 を revert して deploy preflight を復旧する

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -48,7 +48,6 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_D1_DATABASE_ID: ${{ secrets.CLOUDFLARE_D1_DATABASE_ID }}
-          CLOUDFLARE_D1_DATABASE_NAME: ${{ vars.CLOUDFLARE_D1_DATABASE_NAME }}
         shell: bash
         run: |
           missing=0
@@ -68,12 +67,8 @@ jobs:
             echo "Missing required Actions secret: CLOUDFLARE_D1_DATABASE_ID"
             missing=1
           fi
-          if [ -z "$CLOUDFLARE_D1_DATABASE_NAME" ]; then
-            echo "Missing required Actions variable: CLOUDFLARE_D1_DATABASE_NAME"
-            missing=1
-          fi
           if [ "$missing" -ne 0 ]; then
-            echo "Configure the missing secrets or variables before requesting passkey approval for production deploy."
+            echo "Configure the missing secrets before requesting passkey approval for production deploy."
             exit 1
           fi
 
@@ -154,7 +149,7 @@ jobs:
       - name: Generate production Wrangler config
         env:
           CLOUDFLARE_D1_DATABASE_ID: ${{ secrets.CLOUDFLARE_D1_DATABASE_ID }}
-          CLOUDFLARE_D1_DATABASE_NAME: ${{ vars.CLOUDFLARE_D1_DATABASE_NAME }}
+          CLOUDFLARE_D1_DATABASE_NAME: ${{ vars.CLOUDFLARE_D1_DATABASE_NAME || 'vtdd-memory' }}
           VTDD_GITHUB_ACTIONS_REPOSITORY: ${{ github.repository }}
           VTDD_KNOWN_GOOD_COMMIT_SHA: ${{ vars.VTDD_KNOWN_GOOD_COMMIT_SHA }}
           VTDD_DASHBOARD_ALLOWED_EMAILS: ${{ vars.VTDD_DASHBOARD_ALLOWED_EMAILS }}

--- a/docs/memory/vtdd-memory-bridge.md
+++ b/docs/memory/vtdd-memory-bridge.md
@@ -38,13 +38,6 @@ Do not commit runtime URLs, database IDs, bearer tokens, account IDs, or owner
 specific bootstrap values into this repository.
 Do not pass bearer tokens as command-line flags; use the environment variable
 so the token is less likely to land in shell history or process logs.
-
-For direct Wrangler/D1 operations, set `VTDD_MEMORY_D1_DATABASE_NAME` to the
-actual database name shown by `wrangler d1 list`, not to the Worker binding name
-and not to an old display name. The Worker binding name is always
-`VTDD_MEMORY_D1`, but direct D1 repair commands resolve the database argument
-through Wrangler and can fail if the configured database name is stale.
-
 If neither the environment variable nor the bootstrap vault token path is
 available, the runtime memory commands must fail with `desktop maintenance
 required` instead of falling back to D1 direct writes or asking the operator to

--- a/docs/mvp/production-deploy-path.md
+++ b/docs/mvp/production-deploy-path.md
@@ -31,13 +31,9 @@ Set repository or environment secrets:
 
 The token should be scoped to minimum required Worker deploy permissions.
 
-Set repository or environment variables:
-
-- `CLOUDFLARE_D1_DATABASE_NAME`
-
-These secrets and variables are hard prerequisites. The workflow must check
-them before validating the passkey grant or running tests so a missing deploy
-credential or D1 name is reported before operator approval time is wasted.
+These secrets are hard prerequisites. The workflow must check them before
+validating the passkey grant or running tests so a missing deploy credential is
+reported before operator approval time is wasted.
 
 Use `docs/setup/cloudflare-deploy-secret-sync.md` as the canonical operator
 sync path. Do not treat Worker runtime secrets as equivalent to GitHub Actions
@@ -59,15 +55,8 @@ before deploying production.
 
 For local/operator deploys, store owner-specific bindings in an ignored file
 such as `wrangler.production.local.toml`. For GitHub Actions deploys, store the
-D1 database id in `CLOUDFLARE_D1_DATABASE_ID` and the actual Cloudflare D1
-database name in `CLOUDFLARE_D1_DATABASE_NAME`; the workflow generates an
+D1 database id in `CLOUDFLARE_D1_DATABASE_ID`; the workflow generates an
 uncommitted `wrangler.production.generated.toml` at deploy time.
-
-Do not rely on a generic fallback database name. The D1 database name must
-match the operator-owned Cloudflare database returned by `wrangler d1 list`,
-while the binding name remains the stable runtime contract
-`VTDD_MEMORY_D1`. A stale display name can make direct D1 repair commands fail
-even when the Worker binding still points at the correct database id.
 
 If `/setup/known-good` should expose a rollback bundle, the preferred source of
 truth is `docs/setup/known-good.json` with the last human-verified stable setup

--- a/test/production-deploy-path.test.js
+++ b/test/production-deploy-path.test.js
@@ -28,7 +28,6 @@ test("production deploy doc defines the governed GitHub Actions deploy path", ()
   assert.equal(doc.includes("`CLOUDFLARE_API_TOKEN`"), true);
   assert.equal(doc.includes("`CLOUDFLARE_ACCOUNT_ID`"), true);
   assert.equal(doc.includes("`CLOUDFLARE_D1_DATABASE_ID`"), true);
-  assert.equal(doc.includes("`CLOUDFLARE_D1_DATABASE_NAME`"), true);
   assert.equal(doc.includes("`VTDD_GATEWAY_BEARER_TOKEN`"), true);
   assert.equal(doc.includes("hard prerequisites"), true);
   assert.equal(doc.includes("docs/setup/cloudflare-deploy-secret-sync.md"), true);
@@ -39,8 +38,6 @@ test("production deploy doc defines the governed GitHub Actions deploy path", ()
   assert.equal(doc.includes("must not be committed"), true);
   assert.equal(doc.includes("`wrangler.production.local.toml`"), true);
   assert.equal(doc.includes("`wrangler.production.generated.toml`"), true);
-  assert.equal(doc.includes("Do not rely on a generic fallback database name"), true);
-  assert.equal(doc.includes("`wrangler d1 list`"), true);
   assert.equal(doc.includes("`VTDD_KNOWN_GOOD_COMMIT_SHA`"), true);
   assert.equal(doc.includes("must not silently treat `main` as known-good"), true);
   assert.equal(doc.includes("`VTDD_DEPLOY_NOTIFICATION_ISSUE_NUMBER`"), true);
@@ -74,11 +71,6 @@ test("deploy-production workflow enforces the MVP production deploy boundary", (
   assert.equal(workflow.includes("Missing required Actions secret: CLOUDFLARE_API_TOKEN"), true);
   assert.equal(workflow.includes("Missing required Actions secret: CLOUDFLARE_ACCOUNT_ID"), true);
   assert.equal(workflow.includes("Missing required Actions secret: CLOUDFLARE_D1_DATABASE_ID"), true);
-  assert.equal(workflow.includes("Missing required Actions variable: CLOUDFLARE_D1_DATABASE_NAME"), true);
-  assert.equal(
-    workflow.includes("Configure the missing secrets or variables before requesting passkey approval"),
-    true
-  );
   assert.equal(workflow.includes("Preflight Cloudflare Workers deploy entitlement"), true);
   assert.equal(
     workflow.includes(
@@ -109,8 +101,6 @@ test("deploy-production workflow enforces the MVP production deploy boundary", (
     true
   );
   assert.equal(workflow.includes("Generate production Wrangler config"), true);
-  assert.equal(workflow.includes("CLOUDFLARE_D1_DATABASE_NAME: ${{ vars.CLOUDFLARE_D1_DATABASE_NAME }}"), true);
-  assert.equal(workflow.includes("vars.CLOUDFLARE_D1_DATABASE_NAME || 'vtdd-memory'"), false);
   assert.equal(workflow.includes("VTDD_GITHUB_ACTIONS_REPOSITORY: ${{ github.repository }}"), true);
   assert.equal(workflow.includes("VTDD_KNOWN_GOOD_COMMIT_SHA: ${{ vars.VTDD_KNOWN_GOOD_COMMIT_SHA }}"), true);
   assert.equal(workflow.includes("VTDD_DASHBOARD_ALLOWED_EMAILS: ${{ vars.VTDD_DASHBOARD_ALLOWED_EMAILS }}"), true);
@@ -154,7 +144,6 @@ test("deploy-production workflow enforces the MVP production deploy boundary", (
   );
   assert.equal(workflow.includes("[[env.production.d1_databases]]"), true);
   assert.equal(workflow.includes('binding = "VTDD_MEMORY_D1"'), true);
-  assert.equal(workflow.includes('database_name = "$CLOUDFLARE_D1_DATABASE_NAME"'), true);
   assert.equal(workflow.includes('database_id = "$CLOUDFLARE_D1_DATABASE_ID"'), true);
   assert.equal(
     workflow.includes("command: deploy --config wrangler.production.generated.toml --env production"),


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #503 の復旧対応です。PR #504 が `CLOUDFLARE_D1_DATABASE_NAME` を必須化した結果、production deploy が step 3 で連続失敗したため、PR #504 の変更を revert して deploy 復旧を優先します。

## Satisfied Success Criteria

- [x] PR #504 の deploy workflow 変更を取り消し、`CLOUDFLARE_D1_DATABASE_NAME` 未設定でも従来どおり fallback で進む状態に戻す
- [x] PR #504 の docs / test 変更も合わせて戻し、仕様と workflow の不一致を残さない
- [x] PR #502 の auto-merge 判定修正は取り消さない

## Unsatisfied Success Criteria

- Issue #503 の本来の D1 database 名 canonicalization は未完了に戻ります。
- direct D1 repair command の database 名不整合は、deploy 復旧後に別方針で再検討が必要です。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #503
- Implementing Success Criteria: PR #504 を revert して production deploy blocker を解除する。
- Explicit Non-goals: GitHub variable mutation、Cloudflare deploy 実行、database_id 変更、R2 media storage 実装。
- Expected touched files/routes/workflows: .github/workflows/deploy-production.yml, docs/mvp/production-deploy-path.md, docs/memory/vtdd-memory-bridge.md, test/production-deploy-path.test.js
- Affected Issues: Issue #503
- Affected PRs: PR #504 を revert。PR #502 は維持。
- Affected workflows: deploy-production
- Affected runtime/operator surfaces: production deploy workflow の preflight
- What may break if we patch narrowly: D1 database 名の canonicalization は未解決に戻るが、deploy を止め続けるより復旧を優先する。
- Unknowns to investigate before coding: なし。失敗 run は step 3 で `Missing required Actions variable: CLOUDFLARE_D1_DATABASE_NAME`。
- Validation needed: node --test test/production-deploy-path.test.js
- Stop condition: PR #502 の変更まで巻き戻しそうになった場合は停止。

## File / Line Hypotheses

- file: `.github/workflows/deploy-production.yml`
  - hypothesis: PR #504 の必須 variable preflight が deploy を止めている。
  - risk if changed narrowly: fallback 復帰により database name canonicalization は先送りになる。
  - validation: production deploy path test。
  - related Issue: Issue #503

## Hypothesis Retrospective

- expected: PR #504 revert で step 3 の missing variable blocker が消える。
- actual: revert commit で workflow/docs/test が PR #504 前に戻った。
- mismatch: なし。
- lesson: deploy path の必須 preflight 追加は、repo variable が実際に存在することを live 確認してから入れるべきだった。
- should become RAG candidate: はい。

## Verification Evidence

- Unit: `node --test test/production-deploy-path.test.js` pass
- Integration: Not run.
- E2E: Not run. Deploy retryはこのPR merge後、scoped deploy approval grant で実行。
- Manual: failed deploy run 26319657310 step 3 が `Missing required Actions variable: CLOUDFLARE_D1_DATABASE_NAME` で停止したことを確認。
- Evidence path/link: https://github.com/marushu/vtdd-v2-p/actions/runs/26319657310/job/77486069214

## Butler Completion Contract

- Owner goal: production deploy を PR #504 導入前の通る状態へ戻す。
- Butler entrypoint: 未変更。
- Action Schema exposure: 未変更。
- Runtime path: GitHub Actions deploy-production workflow preflight。
- Runner/runtime truth: failed deploy run 26319657310 と local test evidence。
- Authority boundary: このPRはコード revert のみ。deploy 実行は別途 scoped passkey approval。
- E2E evidence: 未実施。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 未実行。merge後に再実行が必要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。

## Related Constitution Rules

- AGENTS.md Authority Boundary
- AGENTS.md Drift Stop Protocol
- AGENTS.md Evidence Discipline

## Out-of-scope but NOT implemented

- GitHub variable 設定
- production deploy 実行
- Issue #503 close

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #503
- Execution ID: Not provided.
- Goal: PR #504 revert による deploy 復旧
