### PR TITLE
Issue #498 Dashboard media upload runtime slice

### DIFF
--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -212,6 +212,7 @@ export class DashboardChatRoom {
   }
 
   async acceptOwnerMessage({ socket, threadId, payload }) {
+    const clientMessageId = sanitizeDashboardChatText(payload?.clientMessageId || payload?.client_message_id);
     const inputMediaReferences = payload?.mediaReferences || payload?.media_references || payload?.media;
     const mediaReferences = normalizeMediaReferences(inputMediaReferences);
     const text =
@@ -219,7 +220,12 @@ export class DashboardChatRoom {
       (mediaReferences.length > 0 ? "添付を追加しました。" : "");
     if (!threadId || !text) {
       if (isSocketOpen(socket)) {
-        socket.send(JSON.stringify({ type: "error", ok: false, reason: "message text is required" }));
+        socket.send(JSON.stringify({
+          type: "error",
+          ok: false,
+          reason: "message text is required",
+          clientMessageId
+        }));
       }
       return;
     }
@@ -240,7 +246,12 @@ export class DashboardChatRoom {
     });
     if (!mediaValidation.ok) {
       if (isSocketOpen(socket)) {
-        socket.send(JSON.stringify({ type: "error", ok: false, reason: mediaValidation.reason }));
+        socket.send(JSON.stringify({
+          type: "error",
+          ok: false,
+          reason: mediaValidation.reason,
+          clientMessageId
+        }));
       }
       return;
     }
@@ -273,11 +284,23 @@ export class DashboardChatRoom {
       );
       const messages = store ? await store.appendMany(threadId, [ownerMessage, butlerMessage]) : [ownerMessage, butlerMessage].filter(Boolean);
       await this.broadcastThread({ threadId, messages });
+      this.sendSocket(socket, {
+        type: "owner_message_accepted",
+        ok: true,
+        clientMessageId,
+        messageId: ownerMessage.messageId
+      });
       return;
     }
 
     const messages = store ? await store.appendMany(threadId, [ownerMessage]) : [ownerMessage].filter(Boolean);
     await this.broadcastThread({ threadId, messages });
+    this.sendSocket(socket, {
+      type: "owner_message_accepted",
+      ok: true,
+      clientMessageId,
+      messageId: ownerMessage.messageId
+    });
     await this.broadcastTransientStatus({
       threadId,
       status: "thinking",
@@ -3770,9 +3793,16 @@ async function handleMediaUploadRequest(request, env) {
   }
 
   const filename = sanitizeMediaFilename(file.name || "attachment");
-  const repository =
-    normalizeCanonicalRepositoryInput(form.get("repository") || form.get("repositoryInput") || form.get("repository_input")) ||
-    "unresolved";
+  const repository = normalizeCanonicalRepositoryInput(
+    form.get("repository") || form.get("repositoryInput") || form.get("repository_input")
+  );
+  if (!repository) {
+    return json(422, {
+      ok: false,
+      error: "repository_required",
+      reason: "media upload requires a resolved owner/repo repository before R2 storage"
+    });
+  }
   const relatedIssue = normalizePositiveInteger(form.get("relatedIssue") || form.get("issueNumber") || form.get("related_issue"));
   const relatedPr = normalizePositiveInteger(form.get("relatedPr") || form.get("pullRequestNumber") || form.get("related_pr"));
   const sourceSurface = normalizeMediaSourceSurface(form.get("sourceSurface") || form.get("source_surface")) || "dashboard_butler";
@@ -3811,7 +3841,7 @@ async function handleMediaUploadRequest(request, env) {
   try {
     record = await store.put({
       id: mediaId,
-      repository: repository === "unresolved" ? null : repository,
+      repository,
       relatedIssue,
       relatedPr,
       sourceSurface,
@@ -3939,8 +3969,16 @@ async function handleMediaSearchRequest(request, url, env) {
       reason: "D1 media metadata store is not configured"
     });
   }
+  const repository = normalizeCanonicalRepositoryInput(url.searchParams.get("repository"));
+  if (!repository) {
+    return json(422, {
+      ok: false,
+      error: "repository_required",
+      reason: "media search requires a resolved owner/repo repository filter"
+    });
+  }
   const records = await store.search({
-    repository: url.searchParams.get("repository"),
+    repository,
     relatedIssue: url.searchParams.get("relatedIssue") || url.searchParams.get("issueNumber"),
     relatedPr: url.searchParams.get("relatedPr") || url.searchParams.get("pullRequestNumber"),
     limit: url.searchParams.get("limit")
@@ -3965,11 +4003,74 @@ async function handleMediaDeleteRequest(request, env, mediaRoute) {
       reason: dashboardAuth.reason
     });
   }
+  const url = new URL(request.url);
+  const cleanup = normalizeDashboardEventText(url.searchParams.get("cleanup"));
+  if (cleanup === "abandoned_send") {
+    return handleAbandonedMediaSendRollback({ env, mediaRoute, url });
+  }
   return json(403, {
     ok: false,
     error: "scoped_approval_required",
     reason: "media delete requires scoped approval and is not part of Issue #498 first slice",
     mediaId: mediaRoute.id
+  });
+}
+
+async function handleAbandonedMediaSendRollback({ env, mediaRoute, url }) {
+  const store = resolveMediaObjectStore(env);
+  if (!store || typeof store.get !== "function" || typeof store.delete !== "function") {
+    return json(503, {
+      ok: false,
+      error: "media_metadata_store_unavailable",
+      reason: "D1 media metadata store is not configured for abandoned send rollback"
+    });
+  }
+  const r2 = env?.[MEDIA_R2_BINDING] ?? null;
+  if (!r2 || typeof r2.delete !== "function") {
+    return json(503, {
+      ok: false,
+      error: "media_r2_unavailable",
+      reason: "Cloudflare R2 binding VTDD_MEDIA_R2 is not configured for abandoned send rollback"
+    });
+  }
+  const record = await store.get(mediaRoute.id);
+  if (!record) {
+    return json(404, {
+      ok: false,
+      error: "media_not_found",
+      reason: "media object was not found"
+    });
+  }
+  const repository = normalizeCanonicalRepositoryInput(url.searchParams.get("repository"));
+  const relatedIssue = normalizePositiveInteger(url.searchParams.get("relatedIssue") || url.searchParams.get("issueNumber"));
+  const requestedSourceEventId = sanitizeDashboardChatText(url.searchParams.get("sourceEventId") || url.searchParams.get("source_event_id"));
+  const sourceEventId = normalizeDashboardEventText(record.sourceEventId);
+  const isRollbackScoped =
+    record.visibility === "private" &&
+    record.sourceSurface === "dashboard_butler" &&
+    sourceEventId.startsWith("dashboard_owner_message:") &&
+    requestedSourceEventId === sourceEventId &&
+    Boolean(repository) &&
+    record.repository === repository &&
+    (!relatedIssue || record.relatedIssue === relatedIssue);
+  if (!isRollbackScoped) {
+    return json(403, {
+      ok: false,
+      error: "scoped_approval_required",
+      reason: "media delete is only allowed here as rollback for private dashboard media from the abandoned owner message send",
+      mediaId: mediaRoute.id
+    });
+  }
+  await r2.delete(record.objectKey);
+  await store.delete(record.id);
+  return json(200, {
+    ok: true,
+    mediaId: record.id,
+    deleted: {
+      r2: true,
+      d1: true
+    },
+    authority: "same_send_abandoned_private_media_rollback"
   });
 }
 
@@ -6671,6 +6772,16 @@ function createD1MediaObjectStore(d1) {
       return row ? mediaObjectRecordFromRow(row) : null;
     },
 
+    async delete(id) {
+      const mediaId = normalizeMediaId(id);
+      if (!mediaId) {
+        return false;
+      }
+      await ensureSchema();
+      await d1.prepare("DELETE FROM vtdd_media_objects WHERE id = ?").bind(mediaId).run();
+      return true;
+    },
+
     async search(filter = {}) {
       await ensureSchema();
       const repository = normalizeCanonicalRepositoryInput(filter.repository);
@@ -7166,6 +7277,21 @@ function detectMediaContentType({ declaredType, filename, arrayBuffer }) {
       reason: `declared content type ${declared} does not match a supported audio signature`
     };
   }
+  const expectedByFilename = expectedMediaContentTypeFromFilename(filename);
+  if (!sniffed && (requiresStrictMediaSignature(declared) || expectedByFilename)) {
+    return {
+      ok: false,
+      error: "media_content_type_mismatch",
+      reason: `declared content type ${declared} or filename ${sanitizeMediaFilename(filename)} does not match a supported binary signature`
+    };
+  }
+  if (!sniffed && declared !== "text/plain") {
+    return {
+      ok: false,
+      error: "media_content_type_unsupported",
+      reason: `content type ${declared} is not supported in this first slice without a recognized safe signature`
+    };
+  }
   return {
     ok: true,
     contentType: sniffed || declared || "application/octet-stream"
@@ -7173,6 +7299,10 @@ function detectMediaContentType({ declaredType, filename, arrayBuffer }) {
 }
 
 function sniffContentType(bytes) {
+  const prefixText = asciiAt(bytes, 0, Math.min(bytes?.length || 0, 64)).trimStart().toLowerCase();
+  if (prefixText.startsWith("<!doctype html") || prefixText.startsWith("<html") || prefixText.startsWith("<script")) {
+    return "text/html";
+  }
   if (startsWithBytes(bytes, [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])) return "image/png";
   if (startsWithBytes(bytes, [0xff, 0xd8, 0xff])) return "image/jpeg";
   if (startsWithAscii(bytes, "GIF87a") || startsWithAscii(bytes, "GIF89a")) return "image/gif";
@@ -7214,6 +7344,16 @@ function isCompatibleDeclaredMediaType(declared, sniffed) {
   if (declared === "application/x-zip-compressed" && sniffed === "application/zip") {
     return true;
   }
+  if (
+    sniffed === "application/zip" &&
+    [
+      "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+      "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+    ].includes(declared)
+  ) {
+    return true;
+  }
   if ((declared === "audio/mp3" || declared === "audio/x-mpeg") && sniffed === "audio/mpeg") {
     return true;
   }
@@ -7221,6 +7361,32 @@ function isCompatibleDeclaredMediaType(declared, sniffed) {
     return true;
   }
   return false;
+}
+
+function requiresStrictMediaSignature(type) {
+  const normalized = normalizeMediaContentType(type);
+  return [
+    "application/pdf",
+    "application/zip",
+    "application/x-zip-compressed",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+  ].includes(normalized);
+}
+
+function expectedMediaContentTypeFromFilename(filename) {
+  const sanitized = sanitizeMediaFilename(filename).toLowerCase();
+  if (/\.(png)$/i.test(sanitized)) return "image/png";
+  if (/\.(jpe?g)$/i.test(sanitized)) return "image/jpeg";
+  if (/\.(gif)$/i.test(sanitized)) return "image/gif";
+  if (/\.(webp)$/i.test(sanitized)) return "image/webp";
+  if (/\.(pdf)$/i.test(sanitized)) return "application/pdf";
+  if (/\.(zip|docx|xlsx|pptx)$/i.test(sanitized)) return "application/zip";
+  if (/\.(mp4|m4v)$/i.test(sanitized)) return "video/mp4";
+  if (/\.(mp3)$/i.test(sanitized)) return "audio/mpeg";
+  if (/\.(wav)$/i.test(sanitized)) return "audio/wav";
+  return "";
 }
 
 function isForbiddenUploadContentType(type) {
@@ -7336,8 +7502,6 @@ function toMediaReference(record) {
     relatedIssue: normalized.relatedIssue,
     relatedPr: normalized.relatedPr,
     sourceSurface: normalized.sourceSurface,
-    sourceEventId: normalized.sourceEventId || null,
-    objectKey: normalized.objectKey,
     filename: normalized.filename,
     contentType: normalized.contentType,
     byteSize: normalized.byteSize,
@@ -10111,6 +10275,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
       let reconnectAttempt = 0;
       let refreshingThread = false;
       let pendingMediaItems = [];
+      const pendingSendRollbacks = new Map();
       const messagesById = new Map();
 
       function updateComposerReserve() {
@@ -10398,6 +10563,13 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         }
       }
 
+      function createClientMessageId() {
+        if (window.crypto && typeof window.crypto.randomUUID === "function") {
+          return "dashboard_owner_message:" + window.crypto.randomUUID();
+        }
+        return "dashboard_owner_message:" + Date.now().toString(36);
+      }
+
       async function uploadSelectedMedia(file, options = {}) {
         const preparedFile = await prepareUploadFile(file);
         const formData = new FormData();
@@ -10405,6 +10577,9 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         formData.append("repositoryInput", repositoryInput || "");
         formData.append("threadId", threadId || "");
         formData.append("sourceSurface", "dashboard_butler");
+        if (options.sourceEventId) {
+          formData.append("sourceEventId", options.sourceEventId);
+        }
         formData.append("visibility", "private");
         if (Number.isFinite(issueNumber)) {
           formData.append("relatedIssue", String(issueNumber));
@@ -10421,7 +10596,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         const body = await response.json().catch(() => ({}));
         if (response.status === 413 && body.error === "media_large_confirmation_required") {
           if (window.confirm("5MB を超える添付です。private として保存しますか？")) {
-            return uploadSelectedMedia(preparedFile, { allowLarge: true });
+            return uploadSelectedMedia(preparedFile, { ...options, allowLarge: true });
           }
         }
         if (!response.ok || !body.ok || !body.media) {
@@ -10430,12 +10605,33 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         return body.media;
       }
 
-      async function uploadPendingMedia() {
+      async function uploadPendingMedia(sourceEventId) {
         const uploaded = [];
-        for (const item of pendingMediaItems) {
-          uploaded.push(await uploadSelectedMedia(item.file));
+        try {
+          for (const item of pendingMediaItems) {
+            uploaded.push(await uploadSelectedMedia(item.file, { sourceEventId }));
+          }
+        } catch (error) {
+          await rollbackAbandonedMedia(uploaded, sourceEventId);
+          throw error;
         }
         return uploaded;
+      }
+
+      async function rollbackAbandonedMedia(mediaReferences, sourceEventId) {
+        const references = Array.isArray(mediaReferences) ? mediaReferences : [];
+        await Promise.allSettled(references.map(async (media) => {
+          if (!media || !media.mediaId) return;
+          const params = new URLSearchParams({ cleanup: "abandoned_send" });
+          if (repositoryInput) params.set("repository", repositoryInput);
+          if (Number.isFinite(issueNumber)) params.set("relatedIssue", String(issueNumber));
+          if (sourceEventId) params.set("sourceEventId", sourceEventId);
+          await fetch("/v2/media/" + encodeURIComponent(media.mediaId) + "?" + params.toString(), {
+            method: "DELETE",
+            credentials: "same-origin",
+            headers: { "accept": "application/json" }
+          });
+        }));
       }
 
       function appendError(text) {
@@ -10542,7 +10738,18 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
                 thinking: isThinking,
                 temporary: !isThinking
               });
+            } else if (body.type === "owner_message_accepted" && body.ok) {
+              const clientMessageId = body.clientMessageId || body.client_message_id || "";
+              if (clientMessageId) {
+                pendingSendRollbacks.delete(clientMessageId);
+              }
             } else if (body.type === "error") {
+              const clientMessageId = body.clientMessageId || body.client_message_id || "";
+              if (clientMessageId && pendingSendRollbacks.has(clientMessageId)) {
+                const mediaReferences = pendingSendRollbacks.get(clientMessageId) || [];
+                pendingSendRollbacks.delete(clientMessageId);
+                rollbackAbandonedMedia(mediaReferences, clientMessageId).catch(() => {});
+              }
               appendError(body.reason || "WebSocket message error");
             }
           } catch {
@@ -10579,23 +10786,42 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         if (submitButton) submitButton.disabled = true;
         setStatus(pendingMediaItems.length > 0 ? "添付を保存してから送信しています" : "送信中です", { thinking: true });
         let mediaReferences = [];
+        const clientMessageId = createClientMessageId();
         try {
-          mediaReferences = await uploadPendingMedia();
+          mediaReferences = await uploadPendingMedia(clientMessageId);
         } catch (error) {
           setStatus((error && error.message) || "添付の保存に失敗しました。");
           if (submitButton) submitButton.disabled = false;
           textarea.focus({ preventScroll: true });
           return;
         }
-        chatSocket.send(JSON.stringify({
-          type: "owner_message",
-          threadId,
-          repositoryInput,
-          text,
-          issueNumber,
-          relatedIssue: issueNumber,
-          mediaReferences
-        }));
+        pendingSendRollbacks.set(clientMessageId, mediaReferences);
+        try {
+          chatSocket.send(JSON.stringify({
+            type: "owner_message",
+            threadId,
+            clientMessageId,
+            repositoryInput,
+            text,
+            issueNumber,
+            relatedIssue: issueNumber,
+            mediaReferences
+          }));
+          window.setTimeout(() => {
+            if (!pendingSendRollbacks.has(clientMessageId)) return;
+            const rollbackMediaReferences = pendingSendRollbacks.get(clientMessageId) || [];
+            pendingSendRollbacks.delete(clientMessageId);
+            rollbackAbandonedMedia(rollbackMediaReferences, clientMessageId).catch(() => {});
+            setStatus("送信確認が返らなかったため、保存済み添付を破棄しました。");
+          }, 30000);
+        } catch (error) {
+          pendingSendRollbacks.delete(clientMessageId);
+          await rollbackAbandonedMedia(mediaReferences, clientMessageId);
+          setStatus((error && error.message) || "送信に失敗したため、保存済み添付を破棄しました。");
+          if (submitButton) submitButton.disabled = false;
+          textarea.focus({ preventScroll: true });
+          return;
+        }
         pendingMediaItems = [];
         renderPendingMedia();
         textarea.value = "";

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -212,7 +212,10 @@ export class DashboardChatRoom {
   }
 
   async acceptOwnerMessage({ socket, threadId, payload }) {
-    const text = sanitizeDashboardChatText(payload?.text || payload?.message || payload?.body);
+    const mediaReferences = normalizeMediaReferences(payload?.mediaReferences || payload?.media_references || payload?.media);
+    const text =
+      sanitizeDashboardChatText(payload?.text || payload?.message || payload?.body) ||
+      (mediaReferences.length > 0 ? "添付を追加しました。" : "");
     if (!threadId || !text) {
       if (isSocketOpen(socket)) {
         socket.send(JSON.stringify({ type: "error", ok: false, reason: "message text is required" }));
@@ -236,6 +239,7 @@ export class DashboardChatRoom {
         relatedIssue,
         status: "sent",
         text,
+        mediaReferences,
         createdAt: now
       },
       { threadId }
@@ -276,6 +280,7 @@ export class DashboardChatRoom {
       repository: repository || null,
       relatedIssue: relatedIssue || null,
       text,
+      mediaReferences,
       messageId: ownerMessage.messageId,
       createdAt: now,
       appServer: {
@@ -475,6 +480,7 @@ const AUTONOMY_MODE_ENV = "VTDD_AUTONOMY_MODE";
 const LEGACY_AUTONOMY_MODE_ENV = "MVP_AUTONOMY_MODE";
 const MEMORY_D1_BINDING = "VTDD_MEMORY_D1";
 const MEMORY_R2_BINDING = "VTDD_MEMORY_R2";
+const MEDIA_R2_BINDING = "VTDD_MEDIA_R2";
 const MEMORY_BLOB_THRESHOLD_ENV = "VTDD_MEMORY_BLOB_THRESHOLD";
 const WEB_PUSH_PUBLIC_KEY_ENV = "VTDD_WEB_PUSH_PUBLIC_KEY";
 const WEB_PUSH_PRIVATE_KEY_ENV = "VTDD_WEB_PUSH_PRIVATE_KEY";
@@ -486,6 +492,10 @@ const d1AdapterCache = new WeakMap();
 const dashboardEventStoreCache = new WeakMap();
 const dashboardChatStoreCache = new WeakMap();
 const dashboardPushSubscriptionStoreCache = new WeakMap();
+const mediaObjectStoreCache = new WeakMap();
+const MEDIA_UPLOAD_SOFT_LIMIT_BYTES = 5 * 1024 * 1024;
+const MEDIA_UPLOAD_HARD_LIMIT_BYTES = 20 * 1024 * 1024;
+const MEDIA_REFERENCE_LIMIT = 12;
 
 export default {
   async fetch(request, env) {
@@ -603,6 +613,23 @@ export default {
 
     if (request.method === "POST" && isApiPath(url.pathname, "/dashboard/chat/messages")) {
       return handleDashboardChatMessageRequest(request, env);
+    }
+
+    if (request.method === "POST" && isApiPath(url.pathname, "/media/upload")) {
+      return handleMediaUploadRequest(request, env);
+    }
+
+    if (request.method === "GET" && isApiPath(url.pathname, "/media/search")) {
+      return handleMediaSearchRequest(request, url, env);
+    }
+
+    const mediaRoute = matchMediaObjectRoute(url.pathname);
+    if (mediaRoute && request.method === "GET") {
+      return handleMediaObjectRequest(request, env, mediaRoute);
+    }
+
+    if (mediaRoute && request.method === "DELETE") {
+      return handleMediaDeleteRequest(request, env, mediaRoute);
     }
 
     if (request.method === "POST" && isApiPath(url.pathname, "/dashboard/push/subscription")) {
@@ -3651,6 +3678,257 @@ async function handleDashboardChatMessageRequest(request, env) {
   });
 }
 
+async function handleMediaUploadRequest(request, env) {
+  const dashboardAuth = await authorizeDashboardRequest({
+    request,
+    env,
+    apiSuffix: "/media/upload"
+  });
+  if (!dashboardAuth.ok) {
+    return json(dashboardAuth.status, {
+      ok: false,
+      error: "dashboard_auth_required",
+      reason: dashboardAuth.reason
+    });
+  }
+
+  const r2 = env?.[MEDIA_R2_BINDING] ?? null;
+  if (!r2 || typeof r2.put !== "function") {
+    return json(503, {
+      ok: false,
+      error: "media_r2_unavailable",
+      reason: "Cloudflare R2 binding VTDD_MEDIA_R2 is not configured"
+    });
+  }
+  const store = resolveMediaObjectStore(env);
+  if (!store) {
+    return json(503, {
+      ok: false,
+      error: "media_metadata_store_unavailable",
+      reason: "D1 media metadata store is not configured"
+    });
+  }
+
+  let form = null;
+  try {
+    form = await request.formData();
+  } catch {
+    return json(400, {
+      ok: false,
+      error: "multipart_form_required",
+      reason: "multipart/form-data with a file field is required"
+    });
+  }
+
+  const file = form.get("file");
+  if (!isUploadFileLike(file)) {
+    return json(422, {
+      ok: false,
+      error: "media_file_required",
+      reason: "file field is required"
+    });
+  }
+
+  const byteSize = Number(file.size) || 0;
+  if (byteSize <= 0) {
+    return json(422, {
+      ok: false,
+      error: "media_file_empty",
+      reason: "empty media files are not accepted"
+    });
+  }
+  if (byteSize > MEDIA_UPLOAD_HARD_LIMIT_BYTES) {
+    return json(413, {
+      ok: false,
+      error: "media_file_too_large",
+      reason: "20MB を超える添付は first slice では保存しません。縮小してから送ってください。",
+      limitBytes: MEDIA_UPLOAD_HARD_LIMIT_BYTES
+    });
+  }
+  const allowLarge = normalizeText(form.get("allowLarge") || form.get("allow_large")).toLowerCase() === "true";
+  if (byteSize > MEDIA_UPLOAD_SOFT_LIMIT_BYTES && !allowLarge) {
+    return json(413, {
+      ok: false,
+      error: "media_large_confirmation_required",
+      reason: "5MB を超える添付です。保存する場合は確認してから再送してください。",
+      limitBytes: MEDIA_UPLOAD_SOFT_LIMIT_BYTES
+    });
+  }
+
+  const contentType = normalizeMediaContentType(file.type);
+  const filename = sanitizeMediaFilename(file.name || "attachment");
+  const repository =
+    normalizeCanonicalRepositoryInput(form.get("repository") || form.get("repositoryInput") || form.get("repository_input")) ||
+    "unresolved";
+  const relatedIssue = normalizePositiveInteger(form.get("relatedIssue") || form.get("issueNumber") || form.get("related_issue"));
+  const relatedPr = normalizePositiveInteger(form.get("relatedPr") || form.get("pullRequestNumber") || form.get("related_pr"));
+  const sourceSurface = normalizeMediaSourceSurface(form.get("sourceSurface") || form.get("source_surface")) || "dashboard_butler";
+  const sourceEventId = sanitizeDashboardChatText(form.get("sourceEventId") || form.get("source_event_id"));
+  const visibility = normalizeMediaVisibility(form.get("visibility")) || "private";
+  const now = new Date().toISOString();
+  const mediaId = `med_${crypto.randomUUID()}`;
+  const objectKey = buildMediaObjectKey({ repository, createdAt: now, mediaId, filename });
+  const arrayBuffer = await file.arrayBuffer();
+  const sha256 = await sha256ArrayBufferHex(arrayBuffer);
+
+  await r2.put(objectKey, arrayBuffer, {
+    httpMetadata: { contentType },
+    customMetadata: {
+      mediaId,
+      repository,
+      visibility,
+      sha256
+    }
+  });
+
+  const record = await store.put({
+    id: mediaId,
+    repository: repository === "unresolved" ? null : repository,
+    relatedIssue,
+    relatedPr,
+    sourceSurface,
+    sourceEventId,
+    objectKey,
+    filename,
+    contentType,
+    byteSize,
+    sha256,
+    visibility,
+    summary: "",
+    ocrText: "",
+    createdBy: dashboardAuth.email || dashboardAuth.login || dashboardAuth.authType || "dashboard",
+    createdAt: now,
+    updatedAt: now
+  });
+
+  return json(201, {
+    ok: true,
+    media: toMediaReference(record),
+    stored: {
+      r2: true,
+      d1: true,
+      rawBinaryReturned: false
+    }
+  });
+}
+
+async function handleMediaObjectRequest(request, env, mediaRoute) {
+  const dashboardAuth = await authorizeDashboardRequest({
+    request,
+    env,
+    apiSuffix: mediaRoute.download ? "/media/:id/download" : "/media/:id"
+  });
+  if (!dashboardAuth.ok) {
+    return json(dashboardAuth.status, {
+      ok: false,
+      error: "dashboard_auth_required",
+      reason: dashboardAuth.reason
+    });
+  }
+  const store = resolveMediaObjectStore(env);
+  if (!store) {
+    return json(503, {
+      ok: false,
+      error: "media_metadata_store_unavailable",
+      reason: "D1 media metadata store is not configured"
+    });
+  }
+  const record = await store.get(mediaRoute.id);
+  if (!record) {
+    return json(404, {
+      ok: false,
+      error: "media_not_found",
+      reason: "media object was not found"
+    });
+  }
+  if (!mediaRoute.download) {
+    return json(200, {
+      ok: true,
+      media: toMediaReference(record),
+      rawBinaryReturned: false
+    });
+  }
+  const r2 = env?.[MEDIA_R2_BINDING] ?? null;
+  if (!r2 || typeof r2.get !== "function") {
+    return json(503, {
+      ok: false,
+      error: "media_r2_unavailable",
+      reason: "Cloudflare R2 binding VTDD_MEDIA_R2 is not configured"
+    });
+  }
+  const object = await r2.get(record.objectKey);
+  if (!object) {
+    return json(404, {
+      ok: false,
+      error: "media_binary_not_found",
+      reason: "R2 object was not found for this media record"
+    });
+  }
+  return new Response(object.body ?? object, {
+    status: 200,
+    headers: {
+      "content-type": record.contentType || "application/octet-stream",
+      "content-disposition": `attachment; filename="${record.filename.replace(/["\\]/g, "_")}"`,
+      "cache-control": "private, no-store"
+    }
+  });
+}
+
+async function handleMediaSearchRequest(request, url, env) {
+  const dashboardAuth = await authorizeDashboardRequest({
+    request,
+    env,
+    apiSuffix: "/media/search"
+  });
+  if (!dashboardAuth.ok) {
+    return json(dashboardAuth.status, {
+      ok: false,
+      error: "dashboard_auth_required",
+      reason: dashboardAuth.reason
+    });
+  }
+  const store = resolveMediaObjectStore(env);
+  if (!store || typeof store.search !== "function") {
+    return json(503, {
+      ok: false,
+      error: "media_metadata_store_unavailable",
+      reason: "D1 media metadata store is not configured"
+    });
+  }
+  const records = await store.search({
+    repository: url.searchParams.get("repository"),
+    relatedIssue: url.searchParams.get("relatedIssue") || url.searchParams.get("issueNumber"),
+    relatedPr: url.searchParams.get("relatedPr") || url.searchParams.get("pullRequestNumber"),
+    limit: url.searchParams.get("limit")
+  });
+  return json(200, {
+    ok: true,
+    media: records.map((record) => toMediaReference(record)).filter(Boolean),
+    rawBinaryReturned: false
+  });
+}
+
+async function handleMediaDeleteRequest(request, env, mediaRoute) {
+  const dashboardAuth = await authorizeDashboardRequest({
+    request,
+    env,
+    apiSuffix: "/media/:id"
+  });
+  if (!dashboardAuth.ok) {
+    return json(dashboardAuth.status, {
+      ok: false,
+      error: "dashboard_auth_required",
+      reason: dashboardAuth.reason
+    });
+  }
+  return json(403, {
+    ok: false,
+    error: "scoped_approval_required",
+    reason: "media delete requires scoped approval and is not part of Issue #498 first slice",
+    mediaId: mediaRoute.id
+  });
+}
+
 async function handleDashboardPushSubscriptionRequest(request, env) {
   const dashboardAuth = await authorizeDashboardRequest({
     request,
@@ -5633,6 +5911,31 @@ function resolveDashboardChatStore(env) {
   return store;
 }
 
+function resolveMediaObjectStore(env) {
+  if (!env || typeof env !== "object") {
+    return null;
+  }
+  const injectedStore = env.MEDIA_OBJECT_STORE ?? null;
+  if (
+    injectedStore &&
+    typeof injectedStore.put === "function" &&
+    typeof injectedStore.get === "function"
+  ) {
+    return injectedStore;
+  }
+
+  const d1Binding = env[MEMORY_D1_BINDING] ?? null;
+  if (!d1Binding || typeof d1Binding.prepare !== "function") {
+    return null;
+  }
+  if (mediaObjectStoreCache.has(d1Binding)) {
+    return mediaObjectStoreCache.get(d1Binding);
+  }
+  const store = createD1MediaObjectStore(d1Binding);
+  mediaObjectStoreCache.set(d1Binding, store);
+  return store;
+}
+
 function resolveDashboardPushSubscriptionStore(env) {
   if (!env || typeof env !== "object") {
     return null;
@@ -6270,6 +6573,128 @@ function createD1DashboardChatStore(d1) {
   }
 }
 
+function createD1MediaObjectStore(d1) {
+  let schemaPromise = null;
+  return {
+    async put(record) {
+      const normalized = normalizeMediaObjectRecord(record);
+      if (!normalized) {
+        return null;
+      }
+      await ensureSchema();
+      await d1
+        .prepare(
+          `INSERT OR REPLACE INTO vtdd_media_objects (
+             id, repository, related_issue, related_pr, source_surface, source_event_id,
+             object_key, filename, content_type, byte_size, sha256, visibility,
+             summary, ocr_text, created_by, created_at, updated_at
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+        )
+        .bind(
+          normalized.id,
+          normalized.repository,
+          normalized.relatedIssue,
+          normalized.relatedPr,
+          normalized.sourceSurface,
+          normalized.sourceEventId,
+          normalized.objectKey,
+          normalized.filename,
+          normalized.contentType,
+          normalized.byteSize,
+          normalized.sha256,
+          normalized.visibility,
+          normalized.summary,
+          normalized.ocrText,
+          normalized.createdBy,
+          normalized.createdAt,
+          normalized.updatedAt
+        )
+        .run();
+      return normalized;
+    },
+
+    async get(id) {
+      const mediaId = normalizeMediaId(id);
+      if (!mediaId) {
+        return null;
+      }
+      await ensureSchema();
+      const result = await d1
+        .prepare("SELECT * FROM vtdd_media_objects WHERE id = ? LIMIT 1")
+        .bind(mediaId)
+        .all();
+      const row = Array.isArray(result?.results) ? result.results[0] : null;
+      return row ? mediaObjectRecordFromRow(row) : null;
+    },
+
+    async search(filter = {}) {
+      await ensureSchema();
+      const repository = normalizeCanonicalRepositoryInput(filter.repository);
+      const relatedIssue = normalizePositiveInteger(filter.relatedIssue || filter.issueNumber);
+      const relatedPr = normalizePositiveInteger(filter.relatedPr || filter.pullRequestNumber);
+      const limit = normalizeLimit(filter.limit, 20);
+      const clauses = [];
+      const params = [];
+      if (repository) {
+        clauses.push("repository = ?");
+        params.push(repository);
+      }
+      if (relatedIssue) {
+        clauses.push("related_issue = ?");
+        params.push(relatedIssue);
+      }
+      if (relatedPr) {
+        clauses.push("related_pr = ?");
+        params.push(relatedPr);
+      }
+      const where = clauses.length > 0 ? `WHERE ${clauses.join(" AND ")}` : "";
+      const result = await d1
+        .prepare(
+          `SELECT * FROM vtdd_media_objects
+           ${where}
+           ORDER BY created_at DESC
+           LIMIT ?`
+        )
+        .bind(...params, limit)
+        .all();
+      return (Array.isArray(result?.results) ? result.results : []).map(mediaObjectRecordFromRow).filter(Boolean);
+    }
+  };
+
+  function ensureSchema() {
+    if (!schemaPromise) {
+      schemaPromise = (async () => {
+        await d1.exec(
+          `CREATE TABLE IF NOT EXISTS vtdd_media_objects (
+            id TEXT PRIMARY KEY,
+            repository TEXT,
+            related_issue INTEGER,
+            related_pr INTEGER,
+            source_surface TEXT NOT NULL,
+            source_event_id TEXT,
+            object_key TEXT NOT NULL,
+            filename TEXT NOT NULL,
+            content_type TEXT NOT NULL,
+            byte_size INTEGER NOT NULL,
+            sha256 TEXT NOT NULL,
+            visibility TEXT NOT NULL,
+            summary TEXT,
+            ocr_text TEXT,
+            created_by TEXT,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+          );`
+        );
+        await d1.exec("CREATE INDEX IF NOT EXISTS idx_vtdd_media_repo ON vtdd_media_objects(repository, created_at DESC);");
+        await d1.exec("CREATE INDEX IF NOT EXISTS idx_vtdd_media_issue ON vtdd_media_objects(repository, related_issue, created_at DESC);");
+        await d1.exec("CREATE INDEX IF NOT EXISTS idx_vtdd_media_pr ON vtdd_media_objects(repository, related_pr, created_at DESC);");
+        await d1.exec("CREATE INDEX IF NOT EXISTS idx_vtdd_media_source ON vtdd_media_objects(source_surface, source_event_id);");
+      })();
+    }
+    return schemaPromise;
+  }
+}
+
 function createD1DashboardPushSubscriptionStore(d1) {
   let schemaPromise = null;
   return {
@@ -6601,10 +7026,196 @@ function base64UrlToBytes(value) {
   return bytes;
 }
 
+function matchMediaObjectRoute(pathname) {
+  for (const prefix of [CANONICAL_API_PREFIX, LEGACY_API_PREFIX]) {
+    const base = `${prefix}/media/`;
+    if (!pathname.startsWith(base)) {
+      continue;
+    }
+    const tail = pathname.slice(base.length);
+    const parts = tail.split("/").filter(Boolean);
+    if (parts.length === 1) {
+      const id = normalizeMediaId(parts[0]);
+      return id ? { id, download: false } : null;
+    }
+    if (parts.length === 2 && parts[1] === "download") {
+      const id = normalizeMediaId(parts[0]);
+      return id ? { id, download: true } : null;
+    }
+  }
+  return null;
+}
+
+function isUploadFileLike(value) {
+  return value && typeof value === "object" && typeof value.arrayBuffer === "function" && Number(value.size) >= 0;
+}
+
+function normalizeMediaId(value) {
+  const text = normalizeDashboardEventText(value);
+  return /^med_[A-Za-z0-9_-]{8,80}$/.test(text) ? text : "";
+}
+
+function normalizeMediaContentType(value) {
+  const type = normalize(String(value || "application/octet-stream").split(";")[0]);
+  return /^[a-z0-9.+-]+\/[a-z0-9.+-]+$/.test(type) ? type : "application/octet-stream";
+}
+
+function sanitizeMediaFilename(value) {
+  const text = normalizeDashboardEventText(value).split(/[\\/]/).pop() || "attachment";
+  const sanitized = text.replace(/[^A-Za-z0-9._ -]+/g, "_").replace(/\s+/g, " ").trim();
+  return (sanitized || "attachment").slice(0, 120);
+}
+
+function normalizeMediaSourceSurface(value) {
+  const text = normalizeDashboardEventText(value).toLowerCase().replace(/[^a-z0-9_-]+/g, "_");
+  return text.slice(0, 80);
+}
+
+function normalizeMediaVisibility(value) {
+  const visibility = normalize(value);
+  return ["private", "repo_internal", "public_evidence"].includes(visibility) ? visibility : "";
+}
+
+function buildMediaObjectKey({ repository, createdAt, mediaId, filename }) {
+  const repo = normalizeCanonicalRepositoryInput(repository) || "unresolved/repository";
+  const [owner, name] = repo.split("/");
+  const date = new Date(createdAt);
+  const yyyy = String(date.getUTCFullYear()).padStart(4, "0");
+  const mm = String(date.getUTCMonth() + 1).padStart(2, "0");
+  const dd = String(date.getUTCDate()).padStart(2, "0");
+  return `media/${owner}/${name}/${yyyy}/${mm}/${dd}/${mediaId}/${sanitizeMediaFilename(filename)}`;
+}
+
+async function sha256ArrayBufferHex(arrayBuffer) {
+  if (globalThis.crypto?.subtle) {
+    const digest = await globalThis.crypto.subtle.digest("SHA-256", arrayBuffer);
+    return [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+  }
+  const bytes = new Uint8Array(arrayBuffer);
+  let text = "";
+  for (const byte of bytes) {
+    text += String.fromCharCode(byte);
+  }
+  return btoa(text).replace(/[^A-Za-z0-9]/g, "").slice(0, 64);
+}
+
+function normalizeMediaObjectRecord(record) {
+  const input = normalizeObject(record);
+  const id = normalizeMediaId(input.id || input.mediaId || input.media_id);
+  const objectKey = normalizeDashboardEventText(input.objectKey || input.object_key);
+  const filename = sanitizeMediaFilename(input.filename);
+  const contentType = normalizeMediaContentType(input.contentType || input.content_type);
+  const byteSize = Number(input.byteSize || input.byte_size);
+  const sha256 = normalizeDashboardEventText(input.sha256).toLowerCase();
+  if (!id || !objectKey || !filename || !Number.isFinite(byteSize) || byteSize <= 0 || !sha256) {
+    return null;
+  }
+  const createdAt = normalizeIsoTimestamp(input.createdAt || input.created_at) || new Date().toISOString();
+  return {
+    id,
+    repository: normalizeCanonicalRepositoryInput(input.repository) || null,
+    relatedIssue: normalizePositiveInteger(input.relatedIssue || input.related_issue || input.issueNumber),
+    relatedPr: normalizePositiveInteger(input.relatedPr || input.related_pr || input.pullRequestNumber),
+    sourceSurface: normalizeMediaSourceSurface(input.sourceSurface || input.source_surface) || "dashboard_butler",
+    sourceEventId: sanitizeDashboardChatText(input.sourceEventId || input.source_event_id),
+    objectKey,
+    filename,
+    contentType,
+    byteSize: Math.floor(byteSize),
+    sha256,
+    visibility: normalizeMediaVisibility(input.visibility) || "private",
+    summary: sanitizeDashboardChatText(input.summary),
+    ocrText: sanitizeDashboardChatText(input.ocrText || input.ocr_text),
+    createdBy: sanitizeDashboardChatText(input.createdBy || input.created_by),
+    createdAt,
+    updatedAt: normalizeIsoTimestamp(input.updatedAt || input.updated_at) || createdAt
+  };
+}
+
+function mediaObjectRecordFromRow(row) {
+  return normalizeMediaObjectRecord({
+    id: row?.id,
+    repository: row?.repository,
+    relatedIssue: row?.related_issue,
+    relatedPr: row?.related_pr,
+    sourceSurface: row?.source_surface,
+    sourceEventId: row?.source_event_id,
+    objectKey: row?.object_key,
+    filename: row?.filename,
+    contentType: row?.content_type,
+    byteSize: row?.byte_size,
+    sha256: row?.sha256,
+    visibility: row?.visibility,
+    summary: row?.summary,
+    ocrText: row?.ocr_text,
+    createdBy: row?.created_by,
+    createdAt: row?.created_at,
+    updatedAt: row?.updated_at
+  });
+}
+
+function toMediaReference(record) {
+  const normalized = normalizeMediaObjectRecord(record);
+  if (!normalized) {
+    return null;
+  }
+  return {
+    mediaId: normalized.id,
+    repository: normalized.repository,
+    relatedIssue: normalized.relatedIssue,
+    relatedPr: normalized.relatedPr,
+    sourceSurface: normalized.sourceSurface,
+    sourceEventId: normalized.sourceEventId || null,
+    objectKey: normalized.objectKey,
+    filename: normalized.filename,
+    contentType: normalized.contentType,
+    byteSize: normalized.byteSize,
+    sha256: normalized.sha256,
+    visibility: normalized.visibility,
+    summary: normalized.summary || "",
+    ocrText: normalized.ocrText || "",
+    createdAt: normalized.createdAt,
+    updatedAt: normalized.updatedAt,
+    metadataUrl: `/v2/media/${normalized.id}`,
+    downloadUrl: `/v2/media/${normalized.id}/download`
+  };
+}
+
+function normalizeMediaReferences(value) {
+  const list = Array.isArray(value) ? value : value ? [value] : [];
+  return list
+    .map((item) => {
+      const input = normalizeObject(item);
+      const mediaId = normalizeMediaId(input.mediaId || input.id || input.media_id);
+      if (!mediaId) {
+        return null;
+      }
+      return {
+        mediaId,
+        repository: normalizeCanonicalRepositoryInput(input.repository) || null,
+        relatedIssue: normalizePositiveInteger(input.relatedIssue || input.related_issue || input.issueNumber),
+        relatedPr: normalizePositiveInteger(input.relatedPr || input.related_pr || input.pullRequestNumber),
+        filename: sanitizeMediaFilename(input.filename || "attachment"),
+        contentType: normalizeMediaContentType(input.contentType || input.content_type),
+        byteSize: normalizePositiveInteger(input.byteSize || input.byte_size),
+        sha256: normalizeDashboardEventText(input.sha256).toLowerCase().slice(0, 64),
+        visibility: normalizeMediaVisibility(input.visibility) || "private",
+        summary: sanitizeDashboardChatText(input.summary),
+        metadataUrl: `/v2/media/${mediaId}`,
+        downloadUrl: `/v2/media/${mediaId}/download`
+      };
+    })
+    .filter(Boolean)
+    .slice(0, MEDIA_REFERENCE_LIMIT);
+}
+
 function buildDashboardChatTurn(payload, options = {}) {
   const input = normalizeObject(payload);
   const repository = normalizeCanonicalRepositoryInput(input.repository);
-  const text = sanitizeDashboardChatText(input.text || input.message || input.body);
+  const mediaReferences = normalizeMediaReferences(input.mediaReferences || input.media_references || input.media);
+  const text =
+    sanitizeDashboardChatText(input.text || input.message || input.body) ||
+    (mediaReferences.length > 0 ? "添付を追加しました。" : "");
   if (!text) {
     return {
       ok: false,
@@ -6624,11 +7235,12 @@ function buildDashboardChatTurn(payload, options = {}) {
       role: "owner",
       repository,
       relatedIssue,
-      status: "sent",
-      text,
-      createdAt: now
-    },
-    { threadId }
+        status: "sent",
+        text,
+        mediaReferences,
+        createdAt: now
+      },
+      { threadId }
   );
   const butlerMessage = normalizeDashboardChatMessage(
     {
@@ -6683,6 +7295,7 @@ function normalizeDashboardChatMessage(message, defaults = {}) {
     relatedIssue: normalizePositiveInteger(input.relatedIssue || input.issueNumber || input.related_issue),
     status: normalizeDashboardChatStatus(input.status),
     text: sanitizeDashboardChatText(input.text || input.message || input.body) || "（空のメッセージ）",
+    mediaReferences: normalizeMediaReferences(input.mediaReferences || input.media_references || input.media),
     createdAt
   };
 }
@@ -9039,10 +9652,16 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
     .connection-note { display: inline-flex; align-items: center; width: fit-content; border: 1px solid var(--border); border-radius: 999px; padding: 5px 10px; color: var(--muted); font-size: 13px; }
     .chat-link { color: var(--text); text-decoration-thickness: 1px; text-underline-offset: 4px; font-weight: 750; }
     .composer { min-width: 0; display: grid; gap: 8px; z-index: 4; padding: 14px 0 max(16px, env(safe-area-inset-bottom)); background: var(--page-bg); }
-    .composer-box { display: grid; grid-template-columns: minmax(0, 1fr) 44px; align-items: end; gap: 8px; min-height: 62px; padding: 8px; border: 1px solid var(--border); border-radius: 28px; background: var(--panel-strong); box-shadow: 0 16px 60px var(--shadow); }
+    .composer-box { display: grid; grid-template-columns: 44px minmax(0, 1fr) 44px; align-items: end; gap: 8px; min-height: 62px; padding: 8px; border: 1px solid var(--border); border-radius: 28px; background: var(--panel-strong); box-shadow: 0 16px 60px var(--shadow); }
     textarea { width: 100%; min-height: 44px; max-height: max(88px, min(160px, 24dvh)); border: 0; outline: 0; resize: none; overflow-y: hidden; padding: 10px 2px; color: var(--text); background: transparent; font: inherit; line-height: 1.45; }
     textarea::placeholder { color: var(--muted); }
+    .media-button { width: 44px; height: 44px; border-radius: 999px; border: 1px solid var(--border); background: var(--button); color: var(--text); font: inherit; font-size: 24px; line-height: 1; display: inline-flex; align-items: center; justify-content: center; cursor: pointer; }
     .send-button { width: 44px; height: 44px; border-radius: 999px; background: var(--text); color: var(--page-bg); font-size: 22px; }
+    .pending-media, .message-media { display: flex; flex-wrap: wrap; gap: 8px; padding: 0 8px; }
+    .pending-media:empty, .message-media:empty { display: none; }
+    .media-chip { display: inline-flex; align-items: center; max-width: 100%; min-height: 34px; border: 1px solid var(--border); border-radius: 999px; padding: 5px 10px; gap: 6px; color: var(--text); background: var(--soft); font-size: 12px; text-decoration: none; }
+    .media-chip span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: min(48vw, 320px); }
+    .media-remove { border: 0; background: transparent; color: var(--muted); font: inherit; font-weight: 900; padding: 0 2px; cursor: pointer; }
     .composer-status { min-height: 18px; padding-left: 16px; color: var(--muted); font-size: 12px; }
     .composer-status.thinking::after { content: ""; display: inline-block; width: 1.4em; text-align: left; animation: thinkingDots 1.2s steps(4, end) infinite; }
     .sidebar { position: sticky; top: 16px; align-self: start; max-height: calc(100dvh - 32px); overflow: auto; border: 1px solid var(--border); border-radius: 18px; background: var(--panel); }
@@ -9089,10 +9708,10 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
     @media (max-width: 460px) {
       main { padding: 12px 10px 0; }
       .app-shell { height: calc(100dvh - 12px); }
-      .composer-box { grid-template-columns: minmax(0, 1fr) 40px; border-radius: 24px; }
+      .composer-box { grid-template-columns: 40px minmax(0, 1fr) 40px; border-radius: 24px; }
       .round-button { width: 40px; height: 40px; }
       .tool-button { min-height: 38px; padding: 0 12px; }
-      .send-button { width: 40px; height: 40px; }
+      .media-button, .send-button { width: 40px; height: 40px; }
     }
   </style>
 </head>
@@ -9174,7 +9793,10 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
       </div>
 
       <form class="composer" id="butler-chat-form" aria-label="Butler composer" autocomplete="off" data-socket-endpoint="${escapeDashboardHtml(socketOrigin)}/v2/dashboard/chat/${escapeDashboardHtml(chatThreadId)}/ws" data-thread-endpoint="${escapeDashboardHtml(origin)}/v2/dashboard/chat/${escapeDashboardHtml(chatThreadId)}" data-thread-id="${escapeDashboardHtml(chatThreadId)}" data-repository-input="${escapeDashboardHtml(repositoryInput)}" data-issue-number="${dashboardIssueNumber || ""}">
+        <div class="pending-media" id="butler-pending-media" aria-live="polite"></div>
         <div class="composer-box">
+          <button class="media-button" id="butler-media-button" type="button" aria-label="画像やファイルを追加" title="画像やファイルを追加">+</button>
+          <input id="butler-media-input" type="file" accept="image/*" hidden>
           <textarea id="butler-message" name="text" placeholder="Butler V2 にメッセージ..." aria-label="Butler V2 にメッセージ" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" enterkeyhint="send"></textarea>
           <button class="send-button" type="submit" aria-label="Butler に送信">↑</button>
         </div>
@@ -9240,10 +9862,14 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
       const log = document.getElementById("butler-chat-log");
       const textarea = document.getElementById("butler-message");
       const status = document.getElementById("butler-chat-status");
+      const mediaButton = document.getElementById("butler-media-button");
+      const mediaInput = document.getElementById("butler-media-input");
+      const pendingMedia = document.getElementById("butler-pending-media");
       if (!form || !log || !textarea || !status) return;
 
       const socketEndpoint = form.dataset.socketEndpoint;
       const threadEndpoint = form.dataset.threadEndpoint;
+      const mediaUploadEndpoint = "/v2/media/upload";
       const threadId = form.dataset.threadId;
       const repositoryInput = form.dataset.repositoryInput;
       const issueNumber = Number.parseInt(form.dataset.issueNumber || "", 10);
@@ -9252,6 +9878,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
       let reconnectTimer = null;
       let reconnectAttempt = 0;
       let refreshingThread = false;
+      let pendingMediaReferences = [];
       const messagesById = new Map();
 
       function updateComposerReserve() {
@@ -9327,8 +9954,60 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         body.className = "message-body";
         renderMessageText(body, message.text || "（空のメッセージ）");
         article.appendChild(body);
+        const media = renderMediaReferences(message.mediaReferences || message.media_references || []);
+        if (media) {
+          article.appendChild(media);
+        }
         log.appendChild(article);
         scrollToLatest();
+      }
+
+      function renderMediaReferences(references) {
+        const list = Array.isArray(references) ? references : [];
+        if (list.length === 0) return null;
+        const wrapper = document.createElement("div");
+        wrapper.className = "message-media";
+        for (const reference of list) {
+          const link = document.createElement("a");
+          link.className = "media-chip";
+          link.href = reference.downloadUrl || (reference.mediaId ? "/v2/media/" + reference.mediaId + "/download" : "#");
+          link.target = "_blank";
+          link.rel = "noreferrer";
+          link.textContent = "";
+          const icon = document.createElement("span");
+          icon.textContent = "添付";
+          const label = document.createElement("span");
+          label.textContent = reference.filename || reference.mediaId || "media";
+          link.appendChild(icon);
+          link.appendChild(label);
+          wrapper.appendChild(link);
+        }
+        return wrapper;
+      }
+
+      function renderPendingMedia() {
+        if (!pendingMedia) return;
+        pendingMedia.replaceChildren();
+        for (const reference of pendingMediaReferences) {
+          const chip = document.createElement("span");
+          chip.className = "media-chip";
+          const label = document.createElement("span");
+          label.textContent = reference.filename || reference.mediaId || "media";
+          const remove = document.createElement("button");
+          remove.className = "media-remove";
+          remove.type = "button";
+          remove.textContent = "×";
+          remove.setAttribute("aria-label", "添付を外す");
+          remove.addEventListener("click", () => {
+            pendingMediaReferences = pendingMediaReferences.filter((item) => item.mediaId !== reference.mediaId);
+            renderPendingMedia();
+            updateComposerReserve();
+          });
+          chip.appendChild(label);
+          chip.appendChild(remove);
+          pendingMedia.appendChild(chip);
+        }
+        updateComposerReserve();
       }
 
       function renderMessageText(container, text) {
@@ -9459,6 +10138,66 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         }
       }
 
+      async function prepareUploadFile(file) {
+        if (!file || !file.type || !file.type.startsWith("image/")) {
+          return file;
+        }
+        if (file.size <= 5 * 1024 * 1024 || typeof createImageBitmap !== "function") {
+          return file;
+        }
+        try {
+          const bitmap = await createImageBitmap(file);
+          const maxSide = 1600;
+          const scale = Math.min(1, maxSide / Math.max(bitmap.width, bitmap.height));
+          const width = Math.max(1, Math.round(bitmap.width * scale));
+          const height = Math.max(1, Math.round(bitmap.height * scale));
+          const canvas = document.createElement("canvas");
+          canvas.width = width;
+          canvas.height = height;
+          const context = canvas.getContext("2d");
+          context.drawImage(bitmap, 0, 0, width, height);
+          const blob = await new Promise((resolve) => canvas.toBlob(resolve, "image/jpeg", 0.82));
+          if (!blob || blob.size >= file.size) {
+            return file;
+          }
+          return new File([blob], file.name.replace(/\.[^.]+$/, "") + ".jpg", { type: "image/jpeg" });
+        } catch {
+          return file;
+        }
+      }
+
+      async function uploadSelectedMedia(file, options = {}) {
+        const preparedFile = await prepareUploadFile(file);
+        const formData = new FormData();
+        formData.append("file", preparedFile, preparedFile.name || file.name || "attachment");
+        formData.append("repositoryInput", repositoryInput || "");
+        formData.append("threadId", threadId || "");
+        formData.append("sourceSurface", "dashboard_butler");
+        formData.append("visibility", "private");
+        if (Number.isFinite(issueNumber)) {
+          formData.append("relatedIssue", String(issueNumber));
+        }
+        if (options.allowLarge === true) {
+          formData.append("allowLarge", "true");
+        }
+        const response = await fetch(mediaUploadEndpoint, {
+          method: "POST",
+          body: formData,
+          credentials: "same-origin",
+          headers: { "accept": "application/json" }
+        });
+        const body = await response.json().catch(() => ({}));
+        if (response.status === 413 && body.error === "media_large_confirmation_required") {
+          if (window.confirm("5MB を超える添付です。private として保存しますか？")) {
+            return uploadSelectedMedia(preparedFile, { allowLarge: true });
+          }
+        }
+        if (!response.ok || !body.ok || !body.media) {
+          throw new Error(body.reason || "media upload failed");
+        }
+        return body.media;
+      }
+
       function appendError(text) {
         appendMessage({ role: "butler", text });
       }
@@ -9584,7 +10323,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
 
       form.addEventListener("submit", async (event) => {
         event.preventDefault();
-        const text = textarea.value.trim();
+        const text = textarea.value.trim() || (pendingMediaReferences.length > 0 ? "添付を追加しました。" : "");
         if (!text) {
           textarea.focus();
           return;
@@ -9605,8 +10344,11 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           repositoryInput,
           text,
           issueNumber,
-          relatedIssue: issueNumber
+          relatedIssue: issueNumber,
+          mediaReferences: pendingMediaReferences
         }));
+        pendingMediaReferences = [];
+        renderPendingMedia();
         textarea.value = "";
         resizeComposerInput();
         setStatus("app-server bridge の返信を待っています", { thinking: true });
@@ -9614,6 +10356,29 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         textarea.focus({ preventScroll: true });
         updateComposerReserve();
       });
+
+      if (mediaButton && mediaInput) {
+        mediaButton.addEventListener("click", () => mediaInput.click());
+        mediaInput.addEventListener("change", async () => {
+          const file = mediaInput.files && mediaInput.files[0];
+          mediaInput.value = "";
+          if (!file) return;
+          try {
+            mediaButton.disabled = true;
+            setStatus("添付を保存しています", { thinking: true });
+            const media = await uploadSelectedMedia(file);
+            pendingMediaReferences = [...pendingMediaReferences, media].slice(0, 12);
+            renderPendingMedia();
+            setStatus("添付を private media reference として保存しました。", { temporary: true });
+            textarea.focus({ preventScroll: true });
+          } catch (error) {
+            setStatus((error && error.message) || "添付の保存に失敗しました。");
+          } finally {
+            mediaButton.disabled = false;
+            updateComposerReserve();
+          }
+        });
+      }
 
       resizeComposerInput();
       textarea.addEventListener("input", resizeComposerInput);

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -212,7 +212,8 @@ export class DashboardChatRoom {
   }
 
   async acceptOwnerMessage({ socket, threadId, payload }) {
-    const mediaReferences = normalizeMediaReferences(payload?.mediaReferences || payload?.media_references || payload?.media);
+    const inputMediaReferences = payload?.mediaReferences || payload?.media_references || payload?.media;
+    const mediaReferences = normalizeMediaReferences(inputMediaReferences);
     const text =
       sanitizeDashboardChatText(payload?.text || payload?.message || payload?.body) ||
       (mediaReferences.length > 0 ? "添付を追加しました。" : "");
@@ -231,6 +232,18 @@ export class DashboardChatRoom {
       env: this.env
     });
     const repository = repositoryResolution.ok ? repositoryResolution.repository : "";
+    const mediaValidation = await resolveDashboardChatMediaReferences({
+      env: this.env,
+      mediaReferences: inputMediaReferences,
+      repository,
+      relatedIssue
+    });
+    if (!mediaValidation.ok) {
+      if (isSocketOpen(socket)) {
+        socket.send(JSON.stringify({ type: "error", ok: false, reason: mediaValidation.reason }));
+      }
+      return;
+    }
     const ownerMessage = normalizeDashboardChatMessage(
       {
         threadId,
@@ -239,7 +252,7 @@ export class DashboardChatRoom {
         relatedIssue,
         status: "sent",
         text,
-        mediaReferences,
+        mediaReferences: mediaValidation.mediaReferences,
         createdAt: now
       },
       { threadId }
@@ -280,7 +293,7 @@ export class DashboardChatRoom {
       repository: repository || null,
       relatedIssue: relatedIssue || null,
       text,
-      mediaReferences,
+      mediaReferences: mediaValidation.mediaReferences,
       messageId: ownerMessage.messageId,
       createdAt: now,
       appServer: {
@@ -3643,14 +3656,15 @@ async function handleDashboardChatMessageRequest(request, env) {
   // happens through DashboardChatRoom WebSocket owner_message events.
   const repository = repositoryResolution.ok ? repositoryResolution.repository : "";
 
-  const prepared = buildDashboardChatTurn(
+  const prepared = await buildDashboardChatTurn(
     {
       ...payload,
       repository,
       relatedIssue:
         normalizePositiveInteger(payload?.relatedIssue || payload?.issueNumber) ||
         extractIssueNumberFromDashboardChatText(payload?.text || payload?.message || payload?.body)
-    }
+    },
+    { env }
   );
   if (!prepared.ok) {
     return json(422, {
@@ -3755,7 +3769,6 @@ async function handleMediaUploadRequest(request, env) {
     });
   }
 
-  const contentType = normalizeMediaContentType(file.type);
   const filename = sanitizeMediaFilename(file.name || "attachment");
   const repository =
     normalizeCanonicalRepositoryInput(form.get("repository") || form.get("repositoryInput") || form.get("repository_input")) ||
@@ -3769,6 +3782,19 @@ async function handleMediaUploadRequest(request, env) {
   const mediaId = `med_${crypto.randomUUID()}`;
   const objectKey = buildMediaObjectKey({ repository, createdAt: now, mediaId, filename });
   const arrayBuffer = await file.arrayBuffer();
+  const contentTypeValidation = detectMediaContentType({
+    declaredType: file.type,
+    filename,
+    arrayBuffer
+  });
+  if (!contentTypeValidation.ok) {
+    return json(415, {
+      ok: false,
+      error: contentTypeValidation.error,
+      reason: contentTypeValidation.reason
+    });
+  }
+  const contentType = contentTypeValidation.contentType;
   const sha256 = await sha256ArrayBufferHex(arrayBuffer);
 
   await r2.put(objectKey, arrayBuffer, {
@@ -3781,25 +3807,43 @@ async function handleMediaUploadRequest(request, env) {
     }
   });
 
-  const record = await store.put({
-    id: mediaId,
-    repository: repository === "unresolved" ? null : repository,
-    relatedIssue,
-    relatedPr,
-    sourceSurface,
-    sourceEventId,
-    objectKey,
-    filename,
-    contentType,
-    byteSize,
-    sha256,
-    visibility,
-    summary: "",
-    ocrText: "",
-    createdBy: dashboardAuth.email || dashboardAuth.login || dashboardAuth.authType || "dashboard",
-    createdAt: now,
-    updatedAt: now
-  });
+  let record = null;
+  try {
+    record = await store.put({
+      id: mediaId,
+      repository: repository === "unresolved" ? null : repository,
+      relatedIssue,
+      relatedPr,
+      sourceSurface,
+      sourceEventId,
+      objectKey,
+      filename,
+      contentType,
+      byteSize,
+      sha256,
+      visibility,
+      summary: "",
+      ocrText: "",
+      createdBy: dashboardAuth.email || dashboardAuth.login || dashboardAuth.authType || "dashboard",
+      createdAt: now,
+      updatedAt: now
+    });
+  } catch (error) {
+    await cleanupOrphanMediaObject(r2, objectKey);
+    return json(500, {
+      ok: false,
+      error: "media_metadata_insert_failed",
+      reason: `D1 media metadata insert failed after R2 put; orphan cleanup was attempted: ${sanitizeErrorMessage(error)}`
+    });
+  }
+  if (!record) {
+    await cleanupOrphanMediaObject(r2, objectKey);
+    return json(500, {
+      ok: false,
+      error: "media_metadata_insert_failed",
+      reason: "D1 media metadata insert returned no record after R2 put; orphan cleanup was attempted"
+    });
+  }
 
   return json(201, {
     ok: true,
@@ -7076,6 +7120,126 @@ function normalizeMediaVisibility(value) {
   return ["private", "repo_internal", "public_evidence"].includes(visibility) ? visibility : "";
 }
 
+function detectMediaContentType({ declaredType, filename, arrayBuffer }) {
+  const declared = normalizeMediaContentType(declaredType);
+  if (isForbiddenUploadContentType(declared) || isForbiddenUploadFilename(filename)) {
+    return {
+      ok: false,
+      error: "media_content_type_forbidden",
+      reason: "HTML, SVG, script, and executable-looking attachments are not accepted in this first slice"
+    };
+  }
+  const bytes = new Uint8Array(arrayBuffer || new ArrayBuffer(0));
+  const sniffed = sniffContentType(bytes);
+  if (sniffed && isForbiddenUploadContentType(sniffed)) {
+    return {
+      ok: false,
+      error: "media_content_type_forbidden",
+      reason: "この添付の実体は安全に扱えない content type です"
+    };
+  }
+  if (sniffed && declared !== "application/octet-stream" && declared !== sniffed && !isCompatibleDeclaredMediaType(declared, sniffed)) {
+    return {
+      ok: false,
+      error: "media_content_type_mismatch",
+      reason: `declared content type ${declared} does not match detected content type ${sniffed}`
+    };
+  }
+  if (!sniffed && declared.startsWith("image/")) {
+    return {
+      ok: false,
+      error: "media_content_type_mismatch",
+      reason: `declared content type ${declared} does not match a supported image signature`
+    };
+  }
+  if (!sniffed && declared.startsWith("video/")) {
+    return {
+      ok: false,
+      error: "media_content_type_mismatch",
+      reason: `declared content type ${declared} does not match a supported video signature`
+    };
+  }
+  if (!sniffed && declared.startsWith("audio/")) {
+    return {
+      ok: false,
+      error: "media_content_type_mismatch",
+      reason: `declared content type ${declared} does not match a supported audio signature`
+    };
+  }
+  return {
+    ok: true,
+    contentType: sniffed || declared || "application/octet-stream"
+  };
+}
+
+function sniffContentType(bytes) {
+  if (startsWithBytes(bytes, [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])) return "image/png";
+  if (startsWithBytes(bytes, [0xff, 0xd8, 0xff])) return "image/jpeg";
+  if (startsWithAscii(bytes, "GIF87a") || startsWithAscii(bytes, "GIF89a")) return "image/gif";
+  if (startsWithAscii(bytes, "RIFF") && asciiAt(bytes, 8, 4) === "WEBP") return "image/webp";
+  if (startsWithAscii(bytes, "%PDF-")) return "application/pdf";
+  if (startsWithBytes(bytes, [0x50, 0x4b, 0x03, 0x04]) || startsWithBytes(bytes, [0x50, 0x4b, 0x05, 0x06])) return "application/zip";
+  if (startsWithAscii(bytes, "RIFF") && asciiAt(bytes, 8, 4) === "WAVE") return "audio/wav";
+  if (startsWithAscii(bytes, "ID3") || startsWithBytes(bytes, [0xff, 0xfb]) || startsWithBytes(bytes, [0xff, 0xf3])) return "audio/mpeg";
+  if (bytes.length >= 12 && asciiAt(bytes, 4, 4) === "ftyp") return "video/mp4";
+  return "";
+}
+
+function startsWithBytes(bytes, prefix) {
+  if (!bytes || bytes.length < prefix.length) {
+    return false;
+  }
+  return prefix.every((byte, index) => bytes[index] === byte);
+}
+
+function startsWithAscii(bytes, prefix) {
+  return asciiAt(bytes, 0, prefix.length) === prefix;
+}
+
+function asciiAt(bytes, offset, length) {
+  if (!bytes || bytes.length < offset + length) {
+    return "";
+  }
+  let text = "";
+  for (let index = offset; index < offset + length; index += 1) {
+    text += String.fromCharCode(bytes[index]);
+  }
+  return text;
+}
+
+function isCompatibleDeclaredMediaType(declared, sniffed) {
+  if (declared === sniffed) {
+    return true;
+  }
+  if (declared === "application/x-zip-compressed" && sniffed === "application/zip") {
+    return true;
+  }
+  if ((declared === "audio/mp3" || declared === "audio/x-mpeg") && sniffed === "audio/mpeg") {
+    return true;
+  }
+  if (declared === "audio/x-wav" && sniffed === "audio/wav") {
+    return true;
+  }
+  return false;
+}
+
+function isForbiddenUploadContentType(type) {
+  const normalized = normalizeMediaContentType(type);
+  return [
+    "image/svg+xml",
+    "text/html",
+    "application/xhtml+xml",
+    "application/javascript",
+    "text/javascript",
+    "application/x-msdownload",
+    "application/x-sh"
+  ].includes(normalized);
+}
+
+function isForbiddenUploadFilename(filename) {
+  return /\.(html?|svg|mjs|cjs|js|jsx|ts|tsx|sh|bash|zsh|exe|dll|dmg|pkg)$/i.test(sanitizeMediaFilename(filename));
+}
+
 function buildMediaObjectKey({ repository, createdAt, mediaId, filename }) {
   const repo = normalizeCanonicalRepositoryInput(repository) || "unresolved/repository";
   const [owner, name] = repo.split("/");
@@ -7091,12 +7255,19 @@ async function sha256ArrayBufferHex(arrayBuffer) {
     const digest = await globalThis.crypto.subtle.digest("SHA-256", arrayBuffer);
     return [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, "0")).join("");
   }
-  const bytes = new Uint8Array(arrayBuffer);
-  let text = "";
-  for (const byte of bytes) {
-    text += String.fromCharCode(byte);
+  throw new Error("SHA-256 digest is not available in this runtime");
+}
+
+async function cleanupOrphanMediaObject(r2, objectKey) {
+  if (!r2 || typeof r2.delete !== "function" || !objectKey) {
+    return false;
   }
-  return btoa(text).replace(/[^A-Za-z0-9]/g, "").slice(0, 64);
+  try {
+    await r2.delete(objectKey);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function normalizeMediaObjectRecord(record) {
@@ -7209,7 +7380,59 @@ function normalizeMediaReferences(value) {
     .slice(0, MEDIA_REFERENCE_LIMIT);
 }
 
-function buildDashboardChatTurn(payload, options = {}) {
+async function resolveDashboardChatMediaReferences({ env, mediaReferences, repository, relatedIssue }) {
+  const requested = normalizeMediaReferences(mediaReferences);
+  if (requested.length === 0) {
+    return { ok: true, mediaReferences: [] };
+  }
+  const store = resolveMediaObjectStore(env);
+  if (!store || typeof store.get !== "function") {
+    return {
+      ok: false,
+      error: "media_metadata_store_unavailable",
+      reason: "media reference validation requires D1 media metadata store"
+    };
+  }
+  const resolvedRepository = normalizeCanonicalRepositoryInput(repository);
+  const resolvedIssue = normalizePositiveInteger(relatedIssue);
+  const resolved = [];
+  for (const reference of requested) {
+    const record = await store.get(reference.mediaId);
+    if (!record) {
+      return {
+        ok: false,
+        error: "media_reference_not_found",
+        reason: `media reference ${reference.mediaId} was not found`
+      };
+    }
+    const media = toMediaReference(record);
+    if (!media) {
+      return {
+        ok: false,
+        error: "media_reference_invalid",
+        reason: `media reference ${reference.mediaId} is malformed`
+      };
+    }
+    if (resolvedRepository && media.repository !== resolvedRepository) {
+      return {
+        ok: false,
+        error: "media_reference_repository_mismatch",
+        reason: `media reference ${reference.mediaId} does not belong to ${resolvedRepository}`
+      };
+    }
+    if (resolvedIssue && media.relatedIssue !== resolvedIssue) {
+      return {
+        ok: false,
+        error: "media_reference_issue_mismatch",
+        reason: `media reference ${reference.mediaId} does not belong to Issue #${resolvedIssue}`
+      };
+    }
+    resolved.push(media);
+  }
+  return { ok: true, mediaReferences: resolved };
+}
+
+async function buildDashboardChatTurn(payload, options = {}) {
   const input = normalizeObject(payload);
   const repository = normalizeCanonicalRepositoryInput(input.repository);
   const mediaReferences = normalizeMediaReferences(input.mediaReferences || input.media_references || input.media);
@@ -7228,16 +7451,25 @@ function buildDashboardChatTurn(payload, options = {}) {
     normalizeDashboardThreadId(input.threadId || input.thread_id) ||
     (repository ? `dashboard-main-${repository.replace("/", "-")}` : "dashboard-main-unresolved");
   const relatedIssue = normalizePositiveInteger(input.relatedIssue || input.issueNumber);
+  const mediaValidation = await resolveDashboardChatMediaReferences({
+    env: options.env,
+    mediaReferences: input.mediaReferences || input.media_references || input.media,
+    repository,
+    relatedIssue
+  });
+  if (!mediaValidation.ok) {
+    return mediaValidation;
+  }
   const now = new Date().toISOString();
   const ownerMessage = normalizeDashboardChatMessage(
     {
       threadId,
       role: "owner",
       repository,
-      relatedIssue,
+        relatedIssue,
         status: "sent",
         text,
-        mediaReferences,
+        mediaReferences: mediaValidation.mediaReferences,
         createdAt: now
       },
       { threadId }
@@ -9796,7 +10028,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         <div class="pending-media" id="butler-pending-media" aria-live="polite"></div>
         <div class="composer-box">
           <button class="media-button" id="butler-media-button" type="button" aria-label="画像やファイルを追加" title="画像やファイルを追加">+</button>
-          <input id="butler-media-input" type="file" accept="image/*" hidden>
+          <input id="butler-media-input" type="file" hidden>
           <textarea id="butler-message" name="text" placeholder="Butler V2 にメッセージ..." aria-label="Butler V2 にメッセージ" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" enterkeyhint="send"></textarea>
           <button class="send-button" type="submit" aria-label="Butler に送信">↑</button>
         </div>
@@ -9878,7 +10110,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
       let reconnectTimer = null;
       let reconnectAttempt = 0;
       let refreshingThread = false;
-      let pendingMediaReferences = [];
+      let pendingMediaItems = [];
       const messagesById = new Map();
 
       function updateComposerReserve() {
@@ -9988,18 +10220,18 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
       function renderPendingMedia() {
         if (!pendingMedia) return;
         pendingMedia.replaceChildren();
-        for (const reference of pendingMediaReferences) {
+        for (const item of pendingMediaItems) {
           const chip = document.createElement("span");
           chip.className = "media-chip";
           const label = document.createElement("span");
-          label.textContent = reference.filename || reference.mediaId || "media";
+          label.textContent = item.filename || "attachment";
           const remove = document.createElement("button");
           remove.className = "media-remove";
           remove.type = "button";
           remove.textContent = "×";
           remove.setAttribute("aria-label", "添付を外す");
           remove.addEventListener("click", () => {
-            pendingMediaReferences = pendingMediaReferences.filter((item) => item.mediaId !== reference.mediaId);
+            pendingMediaItems = pendingMediaItems.filter((candidate) => candidate.clientId !== item.clientId);
             renderPendingMedia();
             updateComposerReserve();
           });
@@ -10198,6 +10430,14 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         return body.media;
       }
 
+      async function uploadPendingMedia() {
+        const uploaded = [];
+        for (const item of pendingMediaItems) {
+          uploaded.push(await uploadSelectedMedia(item.file));
+        }
+        return uploaded;
+      }
+
       function appendError(text) {
         appendMessage({ role: "butler", text });
       }
@@ -10323,7 +10563,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
 
       form.addEventListener("submit", async (event) => {
         event.preventDefault();
-        const text = textarea.value.trim() || (pendingMediaReferences.length > 0 ? "添付を追加しました。" : "");
+        const text = textarea.value.trim() || (pendingMediaItems.length > 0 ? "添付を追加しました。" : "");
         if (!text) {
           textarea.focus();
           return;
@@ -10337,7 +10577,16 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           return;
         }
         if (submitButton) submitButton.disabled = true;
-        setStatus("送信中です", { thinking: true });
+        setStatus(pendingMediaItems.length > 0 ? "添付を保存してから送信しています" : "送信中です", { thinking: true });
+        let mediaReferences = [];
+        try {
+          mediaReferences = await uploadPendingMedia();
+        } catch (error) {
+          setStatus((error && error.message) || "添付の保存に失敗しました。");
+          if (submitButton) submitButton.disabled = false;
+          textarea.focus({ preventScroll: true });
+          return;
+        }
         chatSocket.send(JSON.stringify({
           type: "owner_message",
           threadId,
@@ -10345,9 +10594,9 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           text,
           issueNumber,
           relatedIssue: issueNumber,
-          mediaReferences: pendingMediaReferences
+          mediaReferences
         }));
-        pendingMediaReferences = [];
+        pendingMediaItems = [];
         renderPendingMedia();
         textarea.value = "";
         resizeComposerInput();
@@ -10365,11 +10614,17 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           if (!file) return;
           try {
             mediaButton.disabled = true;
-            setStatus("添付を保存しています", { thinking: true });
-            const media = await uploadSelectedMedia(file);
-            pendingMediaReferences = [...pendingMediaReferences, media].slice(0, 12);
+            const preparedFile = await prepareUploadFile(file);
+            pendingMediaItems = [
+              ...pendingMediaItems,
+              {
+                clientId: Date.now() + "_" + Math.random().toString(36).slice(2),
+                filename: preparedFile.name || file.name || "attachment",
+                file: preparedFile
+              }
+            ].slice(0, 12);
             renderPendingMedia();
-            setStatus("添付を private media reference として保存しました。", { temporary: true });
+            setStatus("添付を送信待ちに追加しました。送信時に private media として保存します。", { temporary: true });
             textarea.focus({ preventScroll: true });
           } catch (error) {
             setStatus((error && error.message) || "添付の保存に失敗しました。");

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -179,6 +179,9 @@ function createInMemoryMediaObjectStore() {
     async get(id) {
       return records.get(id) ?? null;
     },
+    async delete(id) {
+      return records.delete(id);
+    },
     async search(filter = {}) {
       const matches = [...records.values()].filter((record) => {
         if (filter.repository && record.repository !== filter.repository) {
@@ -746,6 +749,8 @@ test("worker serves dashboard media add controls for iPhone-first upload", async
   assert.equal(body.includes("createImageBitmap"), true);
   assert.equal(body.includes("送信時に private media として保存します"), true);
   assert.equal(body.includes("mediaReferences"), true);
+  assert.equal(body.includes("pendingSendRollbacks"), true);
+  assert.equal(body.includes("owner_message_accepted"), true);
 });
 
 test("worker uploads dashboard media to R2 and stores D1 metadata reference only", async () => {
@@ -791,7 +796,9 @@ test("worker uploads dashboard media to R2 and stores D1 metadata reference only
   );
   assert.equal(metadataResponse.status, 200);
   const metadataBody = await metadataResponse.json();
-  assert.equal(metadataBody.media.objectKey, body.media.objectKey);
+  assert.equal(metadataBody.media.mediaId, body.media.mediaId);
+  assert.equal(metadataBody.media.objectKey, undefined);
+  assert.equal(metadataBody.media.sourceEventId, undefined);
   assert.equal(JSON.stringify(metadataBody).includes("fake image bytes"), false);
 
   const downloadResponse = await worker.fetch(
@@ -825,6 +832,32 @@ test("worker rejects media upload without R2 binding before metadata drift", asy
   assert.equal(body.error, "media_r2_unavailable");
 });
 
+test("worker rejects media upload without resolved repository before R2 put", async () => {
+  const mediaStore = createInMemoryMediaObjectStore();
+  const r2 = createInMemoryR2Binding();
+  const form = new FormData();
+  form.append("repositoryInput", "未指定");
+  form.append("file", createPngBlob(), "dashboard.png");
+
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/media/upload", {
+      method: "POST",
+      headers: dashboardAccessHeaders,
+      body: form
+    }),
+    {
+      ...dashboardAccessEnv,
+      MEDIA_OBJECT_STORE: mediaStore,
+      VTDD_MEDIA_R2: r2
+    }
+  );
+
+  assert.equal(response.status, 422);
+  const body = await response.json();
+  assert.equal(body.error, "repository_required");
+  assert.equal(r2.objects.size, 0);
+});
+
 test("worker rejects spoofed dashboard media content type before R2 put", async () => {
   const mediaStore = createInMemoryMediaObjectStore();
   const r2 = createInMemoryR2Binding();
@@ -849,6 +882,87 @@ test("worker rejects spoofed dashboard media content type before R2 put", async 
   assert.equal(response.status, 415);
   const body = await response.json();
   assert.equal(body.error, "media_content_type_mismatch");
+  assert.equal(r2.objects.size, 0);
+});
+
+test("worker rejects HTML/script-looking media even when uploaded as octet stream", async () => {
+  const mediaStore = createInMemoryMediaObjectStore();
+  const r2 = createInMemoryR2Binding();
+  const form = new FormData();
+  form.append("repositoryInput", "marushu/vtdd-v2-p");
+  form.append("relatedIssue", "498");
+  form.append("file", new Blob(["<script>alert(1)</script>"], { type: "application/octet-stream" }), "evidence.bin");
+
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/media/upload", {
+      method: "POST",
+      headers: dashboardAccessHeaders,
+      body: form
+    }),
+    {
+      ...dashboardAccessEnv,
+      MEDIA_OBJECT_STORE: mediaStore,
+      VTDD_MEDIA_R2: r2
+    }
+  );
+
+  assert.equal(response.status, 415);
+  const body = await response.json();
+  assert.equal(body.error, "media_content_type_forbidden");
+  assert.equal(r2.objects.size, 0);
+});
+
+test("worker rejects unknown octet-stream binary in the first media slice", async () => {
+  const mediaStore = createInMemoryMediaObjectStore();
+  const r2 = createInMemoryR2Binding();
+  const form = new FormData();
+  form.append("repositoryInput", "marushu/vtdd-v2-p");
+  form.append("relatedIssue", "498");
+  form.append("file", new Blob([new Uint8Array([0, 1, 2, 3, 4, 5])], { type: "application/octet-stream" }), "evidence.bin");
+
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/media/upload", {
+      method: "POST",
+      headers: dashboardAccessHeaders,
+      body: form
+    }),
+    {
+      ...dashboardAccessEnv,
+      MEDIA_OBJECT_STORE: mediaStore,
+      VTDD_MEDIA_R2: r2
+    }
+  );
+
+  assert.equal(response.status, 415);
+  const body = await response.json();
+  assert.equal(body.error, "media_content_type_unsupported");
+  assert.equal(r2.objects.size, 0);
+});
+
+test("worker rejects strict document media when declared type and filename have no matching signature", async () => {
+  const mediaStore = createInMemoryMediaObjectStore();
+  const r2 = createInMemoryR2Binding();
+  const form = new FormData();
+  form.append("repositoryInput", "marushu/vtdd-v2-p");
+  form.append("relatedIssue", "498");
+  form.append("file", new Blob(["<script>alert(1)</script>"], { type: "application/pdf" }), "evidence.pdf");
+
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/media/upload", {
+      method: "POST",
+      headers: dashboardAccessHeaders,
+      body: form
+    }),
+    {
+      ...dashboardAccessEnv,
+      MEDIA_OBJECT_STORE: mediaStore,
+      VTDD_MEDIA_R2: r2
+    }
+  );
+
+  assert.equal(response.status, 415);
+  const body = await response.json();
+  assert.equal(body.error, "media_content_type_forbidden");
   assert.equal(r2.objects.size, 0);
 });
 
@@ -883,6 +997,106 @@ test("worker cleans up R2 object when media metadata insert fails", async () => 
   const body = await response.json();
   assert.equal(body.error, "media_metadata_insert_failed");
   assert.equal(r2.objects.size, 0);
+});
+
+test("worker allows rollback delete only for private dashboard media from an abandoned owner message send", async () => {
+  const mediaStore = createInMemoryMediaObjectStore();
+  const r2 = createInMemoryR2Binding();
+  const form = new FormData();
+  form.append("repositoryInput", "marushu/vtdd-v2-p");
+  form.append("relatedIssue", "498");
+  form.append("sourceSurface", "dashboard_butler");
+  form.append("sourceEventId", "dashboard_owner_message:test-rollback");
+  form.append("file", createPngBlob(), "dashboard.png");
+
+  const uploadResponse = await worker.fetch(
+    new Request("https://example.com/v2/media/upload", {
+      method: "POST",
+      headers: dashboardAccessHeaders,
+      body: form
+    }),
+    {
+      ...dashboardAccessEnv,
+      MEDIA_OBJECT_STORE: mediaStore,
+      VTDD_MEDIA_R2: r2
+    }
+  );
+  assert.equal(uploadResponse.status, 201);
+  const uploadBody = await uploadResponse.json();
+  assert.equal(r2.objects.size, 1);
+
+  const deleteResponse = await worker.fetch(
+    new Request(`https://example.com/v2/media/${uploadBody.media.mediaId}?cleanup=abandoned_send&repository=marushu/vtdd-v2-p&relatedIssue=498&sourceEventId=dashboard_owner_message%3Atest-rollback`, {
+      method: "DELETE",
+      headers: dashboardAccessHeaders
+    }),
+    {
+      ...dashboardAccessEnv,
+      MEDIA_OBJECT_STORE: mediaStore,
+      VTDD_MEDIA_R2: r2
+    }
+  );
+
+  assert.equal(deleteResponse.status, 200);
+  const deleteBody = await deleteResponse.json();
+  assert.equal(deleteBody.authority, "same_send_abandoned_private_media_rollback");
+  assert.equal(r2.objects.size, 0);
+  assert.equal(await mediaStore.get(uploadBody.media.mediaId), null);
+});
+
+test("worker rejects abandoned media rollback without exact source event scope", async () => {
+  const mediaStore = createInMemoryMediaObjectStore();
+  const r2 = createInMemoryR2Binding();
+  await mediaStore.put({
+    id: "med_rollbackscope",
+    repository: "marushu/vtdd-v2-p",
+    relatedIssue: 498,
+    sourceSurface: "dashboard_butler",
+    sourceEventId: "dashboard_owner_message:test-rollback",
+    objectKey: "media/marushu/vtdd-v2-p/2026/05/23/med_rollbackscope/dashboard.png",
+    filename: "dashboard.png",
+    contentType: "image/png",
+    byteSize: 16,
+    sha256: "0123456789abcdef",
+    visibility: "private",
+    createdAt: "2026-05-23T00:00:00.000Z",
+    updatedAt: "2026-05-23T00:00:00.000Z"
+  });
+  await r2.put("media/marushu/vtdd-v2-p/2026/05/23/med_rollbackscope/dashboard.png", new Uint8Array([1, 2, 3]));
+
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/media/med_rollbackscope?cleanup=abandoned_send&repository=marushu/vtdd-v2-p&relatedIssue=498", {
+      method: "DELETE",
+      headers: dashboardAccessHeaders
+    }),
+    {
+      ...dashboardAccessEnv,
+      MEDIA_OBJECT_STORE: mediaStore,
+      VTDD_MEDIA_R2: r2
+    }
+  );
+
+  assert.equal(response.status, 403);
+  const body = await response.json();
+  assert.equal(body.error, "scoped_approval_required");
+  assert.equal(r2.objects.size, 1);
+  assert.notEqual(await mediaStore.get("med_rollbackscope"), null);
+});
+
+test("worker requires repository filter before media metadata search", async () => {
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/media/search", {
+      headers: dashboardAccessHeaders
+    }),
+    {
+      ...dashboardAccessEnv,
+      MEDIA_OBJECT_STORE: createInMemoryMediaObjectStore()
+    }
+  );
+
+  assert.equal(response.status, 422);
+  const body = await response.json();
+  assert.equal(body.error, "repository_required");
 });
 
 test("worker stores dashboard media references in chat without raw binary", async () => {
@@ -1451,7 +1665,7 @@ test("DashboardChatRoom stores owner messages without pushing a VPS runner job",
   );
 
   assert.equal(runnerSocket.sent.length, 0);
-  assert.equal(dashboardSocket.sent.length, 1);
+  assert.equal(dashboardSocket.sent.length, 2);
   const broadcast = JSON.parse(dashboardSocket.sent[0]);
   assert.equal(broadcast.messages.length, 2);
   assert.equal(broadcast.messages[0].role, "owner");
@@ -1459,6 +1673,9 @@ test("DashboardChatRoom stores owner messages without pushing a VPS runner job",
   assert.equal(broadcast.messages[1].role, "butler");
   assert.equal(broadcast.messages[1].status, "blocked");
   assert.equal(broadcast.messages[1].text.includes("app-server"), true);
+  const ack = JSON.parse(dashboardSocket.sent[1]);
+  assert.equal(ack.type, "owner_message_accepted");
+  assert.equal(ack.ok, true);
 });
 
 test("DashboardChatRoom sends ordinary owner turns to connected app-server bridge without repository resolution", async () => {
@@ -1496,12 +1713,15 @@ test("DashboardChatRoom sends ordinary owner turns to connected app-server bridg
   assert.equal(turnRequest.appServer.turnMethod, "turn/start");
   assert.equal(turnRequest.authority.ordinaryConversationAllowed, true);
 
-  assert.equal(dashboardSocket.sent.length, 2);
+  assert.equal(dashboardSocket.sent.length, 3);
   const broadcast = JSON.parse(dashboardSocket.sent[0]);
   assert.equal(broadcast.messages.length, 1);
   assert.equal(broadcast.messages[0].role, "owner");
   assert.equal(broadcast.messages[0].text, "今日は何月何日？日本時間を答えて");
-  const status = JSON.parse(dashboardSocket.sent[1]);
+  const ack = JSON.parse(dashboardSocket.sent[1]);
+  assert.equal(ack.type, "owner_message_accepted");
+  assert.equal(ack.ok, true);
+  const status = JSON.parse(dashboardSocket.sent[2]);
   assert.equal(status.type, "transient_status");
   assert.equal(status.status, "thinking");
   assert.equal(status.text, "app-server bridge の返信を待っています");
@@ -1761,7 +1981,10 @@ test("DashboardChatRoom sends nickname requests to connected app-server bridge",
   assert.equal(broadcast.messages.length, 1);
   assert.equal(broadcast.messages[0].role, "owner");
   assert.equal(broadcast.messages[0].text, "登録済みのニックネーム出して");
-  const status = JSON.parse(dashboardSocket.sent[1]);
+  const ack = JSON.parse(dashboardSocket.sent[1]);
+  assert.equal(ack.type, "owner_message_accepted");
+  assert.equal(ack.ok, true);
+  const status = JSON.parse(dashboardSocket.sent[2]);
   assert.equal(status.type, "transient_status");
   assert.equal(status.status, "thinking");
 });

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -169,6 +169,48 @@ function createInMemoryDashboardChatStore() {
   };
 }
 
+function createInMemoryMediaObjectStore() {
+  const records = new Map();
+  return {
+    async put(record) {
+      records.set(record.id, record);
+      return record;
+    },
+    async get(id) {
+      return records.get(id) ?? null;
+    },
+    async search(filter = {}) {
+      const matches = [...records.values()].filter((record) => {
+        if (filter.repository && record.repository !== filter.repository) {
+          return false;
+        }
+        if (filter.relatedIssue && record.relatedIssue !== Number(filter.relatedIssue)) {
+          return false;
+        }
+        if (filter.relatedPr && record.relatedPr !== Number(filter.relatedPr)) {
+          return false;
+        }
+        return true;
+      });
+      return matches.slice(0, Number(filter.limit) || 20);
+    }
+  };
+}
+
+function createInMemoryR2Binding() {
+  const objects = new Map();
+  return {
+    objects,
+    async put(key, value, options = {}) {
+      objects.set(key, { value, options, body: value });
+      return null;
+    },
+    async get(key) {
+      return objects.get(key) ?? null;
+    }
+  };
+}
+
 function createInMemoryDashboardPushSubscriptionStore() {
   const subscriptions = new Map();
   return {
@@ -677,6 +719,135 @@ test("worker appends dashboard Butler chat turn and retrieves the same thread", 
   assert.equal(retrieveBody.messages.length, 2);
   assert.equal(retrieveBody.messages[0].text, "VPS Codex CLI とリアルタイムに会話したい");
   assert.equal(retrieveBody.summary, null);
+});
+
+test("worker serves dashboard media add controls for iPhone-first upload", async () => {
+  const response = await worker.fetch(
+    new Request("https://example.com/dashboard", {
+      headers: dashboardAccessHeaders
+    }),
+    dashboardAccessEnv
+  );
+  assert.equal(response.status, 200);
+  const body = await response.text();
+  assert.equal(body.includes("id=\"butler-media-button\""), true);
+  assert.equal(body.includes("id=\"butler-media-input\""), true);
+  assert.equal(body.includes("/v2/media/upload"), true);
+  assert.equal(body.includes("createImageBitmap"), true);
+  assert.equal(body.includes("mediaReferences"), true);
+});
+
+test("worker uploads dashboard media to R2 and stores D1 metadata reference only", async () => {
+  const mediaStore = createInMemoryMediaObjectStore();
+  const r2 = createInMemoryR2Binding();
+  const form = new FormData();
+  form.append("repositoryInput", "marushu/vtdd-v2-p");
+  form.append("relatedIssue", "498");
+  form.append("sourceSurface", "dashboard_butler");
+  form.append("file", new Blob(["fake image bytes"], { type: "image/png" }), "dashboard.png");
+
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/media/upload", {
+      method: "POST",
+      headers: dashboardAccessHeaders,
+      body: form
+    }),
+    {
+      ...dashboardAccessEnv,
+      MEDIA_OBJECT_STORE: mediaStore,
+      VTDD_MEDIA_R2: r2
+    }
+  );
+
+  assert.equal(response.status, 201);
+  const body = await response.json();
+  assert.equal(body.ok, true);
+  assert.match(body.media.mediaId, /^med_/);
+  assert.equal(body.media.repository, "marushu/vtdd-v2-p");
+  assert.equal(body.media.relatedIssue, 498);
+  assert.equal(body.media.filename, "dashboard.png");
+  assert.equal(body.media.contentType, "image/png");
+  assert.equal(body.media.visibility, "private");
+  assert.equal(body.stored.rawBinaryReturned, false);
+  assert.equal(JSON.stringify(body).includes("fake image bytes"), false);
+  assert.equal(r2.objects.size, 1);
+
+  const metadataResponse = await worker.fetch(
+    new Request(`https://example.com${body.media.metadataUrl}`, {
+      headers: dashboardAccessHeaders
+    }),
+    { ...dashboardAccessEnv, MEDIA_OBJECT_STORE: mediaStore, VTDD_MEDIA_R2: r2 }
+  );
+  assert.equal(metadataResponse.status, 200);
+  const metadataBody = await metadataResponse.json();
+  assert.equal(metadataBody.media.objectKey, body.media.objectKey);
+  assert.equal(JSON.stringify(metadataBody).includes("fake image bytes"), false);
+
+  const downloadResponse = await worker.fetch(
+    new Request(`https://example.com${body.media.downloadUrl}`, {
+      headers: dashboardAccessHeaders
+    }),
+    { ...dashboardAccessEnv, MEDIA_OBJECT_STORE: mediaStore, VTDD_MEDIA_R2: r2 }
+  );
+  assert.equal(downloadResponse.status, 200);
+  assert.equal(await downloadResponse.text(), "fake image bytes");
+});
+
+test("worker rejects media upload without R2 binding before metadata drift", async () => {
+  const form = new FormData();
+  form.append("file", new Blob(["fake image bytes"], { type: "image/png" }), "dashboard.png");
+
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/media/upload", {
+      method: "POST",
+      headers: dashboardAccessHeaders,
+      body: form
+    }),
+    {
+      ...dashboardAccessEnv,
+      MEDIA_OBJECT_STORE: createInMemoryMediaObjectStore()
+    }
+  );
+
+  assert.equal(response.status, 503);
+  const body = await response.json();
+  assert.equal(body.error, "media_r2_unavailable");
+});
+
+test("worker stores dashboard media references in chat without raw binary", async () => {
+  const store = createInMemoryDashboardChatStore();
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/dashboard/chat/messages", {
+      method: "POST",
+      headers: { ...dashboardAccessHeaders, "content-type": "application/json" },
+      body: JSON.stringify({
+        threadId: "dashboard-main-marushu-vtdd-v2-p",
+        repository: "marushu/vtdd-v2-p",
+        text: "",
+        mediaReferences: [
+          {
+            mediaId: "med_testmedia1234",
+            repository: "marushu/vtdd-v2-p",
+            relatedIssue: 498,
+            filename: "dashboard.png",
+            contentType: "image/png",
+            byteSize: 16,
+            sha256: "0123456789abcdef",
+            visibility: "private",
+            rawBinary: "fake image bytes"
+          }
+        ]
+      })
+    }),
+    { ...dashboardAccessEnv, DASHBOARD_CHAT_STORE: store }
+  );
+
+  assert.equal(response.status, 202);
+  const body = await response.json();
+  assert.equal(body.messages[0].text, "添付を追加しました。");
+  assert.equal(body.messages[0].mediaReferences.length, 1);
+  assert.equal(body.messages[0].mediaReferences[0].mediaId, "med_testmedia1234");
+  assert.equal(JSON.stringify(body).includes("fake image bytes"), false);
 });
 
 test("worker stores dashboard Butler thread summaries and searches archived context", async () => {

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -207,8 +207,17 @@ function createInMemoryR2Binding() {
     },
     async get(key) {
       return objects.get(key) ?? null;
+    },
+    async delete(key) {
+      objects.delete(key);
     }
   };
+}
+
+function createPngBlob() {
+  return new Blob([
+    new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d])
+  ], { type: "image/png" });
 }
 
 function createInMemoryDashboardPushSubscriptionStore() {
@@ -732,8 +741,10 @@ test("worker serves dashboard media add controls for iPhone-first upload", async
   const body = await response.text();
   assert.equal(body.includes("id=\"butler-media-button\""), true);
   assert.equal(body.includes("id=\"butler-media-input\""), true);
+  assert.equal(body.includes("accept=\"image/*\""), false);
   assert.equal(body.includes("/v2/media/upload"), true);
   assert.equal(body.includes("createImageBitmap"), true);
+  assert.equal(body.includes("送信時に private media として保存します"), true);
   assert.equal(body.includes("mediaReferences"), true);
 });
 
@@ -744,7 +755,7 @@ test("worker uploads dashboard media to R2 and stores D1 metadata reference only
   form.append("repositoryInput", "marushu/vtdd-v2-p");
   form.append("relatedIssue", "498");
   form.append("sourceSurface", "dashboard_butler");
-  form.append("file", new Blob(["fake image bytes"], { type: "image/png" }), "dashboard.png");
+  form.append("file", createPngBlob(), "dashboard.png");
 
   const response = await worker.fetch(
     new Request("https://example.com/v2/media/upload", {
@@ -790,12 +801,12 @@ test("worker uploads dashboard media to R2 and stores D1 metadata reference only
     { ...dashboardAccessEnv, MEDIA_OBJECT_STORE: mediaStore, VTDD_MEDIA_R2: r2 }
   );
   assert.equal(downloadResponse.status, 200);
-  assert.equal(await downloadResponse.text(), "fake image bytes");
+  assert.equal(new Uint8Array(await downloadResponse.arrayBuffer())[0], 0x89);
 });
 
 test("worker rejects media upload without R2 binding before metadata drift", async () => {
   const form = new FormData();
-  form.append("file", new Blob(["fake image bytes"], { type: "image/png" }), "dashboard.png");
+  form.append("file", createPngBlob(), "dashboard.png");
 
   const response = await worker.fetch(
     new Request("https://example.com/v2/media/upload", {
@@ -814,8 +825,83 @@ test("worker rejects media upload without R2 binding before metadata drift", asy
   assert.equal(body.error, "media_r2_unavailable");
 });
 
+test("worker rejects spoofed dashboard media content type before R2 put", async () => {
+  const mediaStore = createInMemoryMediaObjectStore();
+  const r2 = createInMemoryR2Binding();
+  const form = new FormData();
+  form.append("repositoryInput", "marushu/vtdd-v2-p");
+  form.append("relatedIssue", "498");
+  form.append("file", new Blob(["not actually a png"], { type: "image/png" }), "dashboard.png");
+
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/media/upload", {
+      method: "POST",
+      headers: dashboardAccessHeaders,
+      body: form
+    }),
+    {
+      ...dashboardAccessEnv,
+      MEDIA_OBJECT_STORE: mediaStore,
+      VTDD_MEDIA_R2: r2
+    }
+  );
+
+  assert.equal(response.status, 415);
+  const body = await response.json();
+  assert.equal(body.error, "media_content_type_mismatch");
+  assert.equal(r2.objects.size, 0);
+});
+
+test("worker cleans up R2 object when media metadata insert fails", async () => {
+  const r2 = createInMemoryR2Binding();
+  const form = new FormData();
+  form.append("repositoryInput", "marushu/vtdd-v2-p");
+  form.append("relatedIssue", "498");
+  form.append("file", createPngBlob(), "dashboard.png");
+
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/media/upload", {
+      method: "POST",
+      headers: dashboardAccessHeaders,
+      body: form
+    }),
+    {
+      ...dashboardAccessEnv,
+      MEDIA_OBJECT_STORE: {
+        async put() {
+          throw new Error("d1 unavailable");
+        },
+        async get() {
+          return null;
+        }
+      },
+      VTDD_MEDIA_R2: r2
+    }
+  );
+
+  assert.equal(response.status, 500);
+  const body = await response.json();
+  assert.equal(body.error, "media_metadata_insert_failed");
+  assert.equal(r2.objects.size, 0);
+});
+
 test("worker stores dashboard media references in chat without raw binary", async () => {
   const store = createInMemoryDashboardChatStore();
+  const mediaStore = createInMemoryMediaObjectStore();
+  await mediaStore.put({
+    id: "med_testmedia1234",
+    repository: "marushu/vtdd-v2-p",
+    relatedIssue: 498,
+    sourceSurface: "dashboard_butler",
+    objectKey: "media/marushu/vtdd-v2-p/2026/05/23/med_testmedia1234/dashboard.png",
+    filename: "dashboard.png",
+    contentType: "image/png",
+    byteSize: 16,
+    sha256: "0123456789abcdef",
+    visibility: "private",
+    createdAt: "2026-05-23T00:00:00.000Z",
+    updatedAt: "2026-05-23T00:00:00.000Z"
+  });
   const response = await worker.fetch(
     new Request("https://example.com/v2/dashboard/chat/messages", {
       method: "POST",
@@ -839,7 +925,7 @@ test("worker stores dashboard media references in chat without raw binary", asyn
         ]
       })
     }),
-    { ...dashboardAccessEnv, DASHBOARD_CHAT_STORE: store }
+    { ...dashboardAccessEnv, DASHBOARD_CHAT_STORE: store, MEDIA_OBJECT_STORE: mediaStore }
   );
 
   assert.equal(response.status, 202);
@@ -848,6 +934,43 @@ test("worker stores dashboard media references in chat without raw binary", asyn
   assert.equal(body.messages[0].mediaReferences.length, 1);
   assert.equal(body.messages[0].mediaReferences[0].mediaId, "med_testmedia1234");
   assert.equal(JSON.stringify(body).includes("fake image bytes"), false);
+});
+
+test("worker rejects chat media references outside the repository or issue context", async () => {
+  const store = createInMemoryDashboardChatStore();
+  const mediaStore = createInMemoryMediaObjectStore();
+  await mediaStore.put({
+    id: "med_wrongissue123",
+    repository: "marushu/vtdd-v2-p",
+    relatedIssue: 999,
+    sourceSurface: "dashboard_butler",
+    objectKey: "media/marushu/vtdd-v2-p/2026/05/23/med_wrongissue123/dashboard.png",
+    filename: "dashboard.png",
+    contentType: "image/png",
+    byteSize: 16,
+    sha256: "0123456789abcdef",
+    visibility: "private",
+    createdAt: "2026-05-23T00:00:00.000Z",
+    updatedAt: "2026-05-23T00:00:00.000Z"
+  });
+
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/dashboard/chat/messages", {
+      method: "POST",
+      headers: { ...dashboardAccessHeaders, "content-type": "application/json" },
+      body: JSON.stringify({
+        threadId: "dashboard-main-marushu-vtdd-v2-p",
+        repository: "marushu/vtdd-v2-p",
+        relatedIssue: 498,
+        mediaReferences: [{ mediaId: "med_wrongissue123" }]
+      })
+    }),
+    { ...dashboardAccessEnv, DASHBOARD_CHAT_STORE: store, MEDIA_OBJECT_STORE: mediaStore }
+  );
+
+  assert.equal(response.status, 422);
+  const body = await response.json();
+  assert.equal(body.error, "media_reference_issue_mismatch");
 });
 
 test("worker stores dashboard Butler thread summaries and searches archived context", async () => {

--- a/worker.js
+++ b/worker.js
@@ -56115,12 +56115,18 @@ var DashboardChatRoom = class {
     }
   }
   async acceptOwnerMessage({ socket, threadId, payload }) {
+    const clientMessageId = sanitizeDashboardChatText(payload?.clientMessageId || payload?.client_message_id);
     const inputMediaReferences = payload?.mediaReferences || payload?.media_references || payload?.media;
     const mediaReferences = normalizeMediaReferences(inputMediaReferences);
     const text = sanitizeDashboardChatText(payload?.text || payload?.message || payload?.body) || (mediaReferences.length > 0 ? "\u6DFB\u4ED8\u3092\u8FFD\u52A0\u3057\u307E\u3057\u305F\u3002" : "");
     if (!threadId || !text) {
       if (isSocketOpen(socket)) {
-        socket.send(JSON.stringify({ type: "error", ok: false, reason: "message text is required" }));
+        socket.send(JSON.stringify({
+          type: "error",
+          ok: false,
+          reason: "message text is required",
+          clientMessageId
+        }));
       }
       return;
     }
@@ -56140,7 +56146,12 @@ var DashboardChatRoom = class {
     });
     if (!mediaValidation.ok) {
       if (isSocketOpen(socket)) {
-        socket.send(JSON.stringify({ type: "error", ok: false, reason: mediaValidation.reason }));
+        socket.send(JSON.stringify({
+          type: "error",
+          ok: false,
+          reason: mediaValidation.reason,
+          clientMessageId
+        }));
       }
       return;
     }
@@ -56173,10 +56184,22 @@ var DashboardChatRoom = class {
       );
       const messages2 = store ? await store.appendMany(threadId, [ownerMessage, butlerMessage]) : [ownerMessage, butlerMessage].filter(Boolean);
       await this.broadcastThread({ threadId, messages: messages2 });
+      this.sendSocket(socket, {
+        type: "owner_message_accepted",
+        ok: true,
+        clientMessageId,
+        messageId: ownerMessage.messageId
+      });
       return;
     }
     const messages = store ? await store.appendMany(threadId, [ownerMessage]) : [ownerMessage].filter(Boolean);
     await this.broadcastThread({ threadId, messages });
+    this.sendSocket(socket, {
+      type: "owner_message_accepted",
+      ok: true,
+      clientMessageId,
+      messageId: ownerMessage.messageId
+    });
     await this.broadcastTransientStatus({
       threadId,
       status: "thinking",
@@ -59194,7 +59217,16 @@ async function handleMediaUploadRequest(request, env) {
     });
   }
   const filename = sanitizeMediaFilename(file.name || "attachment");
-  const repository = normalizeCanonicalRepositoryInput(form.get("repository") || form.get("repositoryInput") || form.get("repository_input")) || "unresolved";
+  const repository = normalizeCanonicalRepositoryInput(
+    form.get("repository") || form.get("repositoryInput") || form.get("repository_input")
+  );
+  if (!repository) {
+    return json(422, {
+      ok: false,
+      error: "repository_required",
+      reason: "media upload requires a resolved owner/repo repository before R2 storage"
+    });
+  }
   const relatedIssue = normalizePositiveInteger9(form.get("relatedIssue") || form.get("issueNumber") || form.get("related_issue"));
   const relatedPr = normalizePositiveInteger9(form.get("relatedPr") || form.get("pullRequestNumber") || form.get("related_pr"));
   const sourceSurface = normalizeMediaSourceSurface(form.get("sourceSurface") || form.get("source_surface")) || "dashboard_butler";
@@ -59231,7 +59263,7 @@ async function handleMediaUploadRequest(request, env) {
   try {
     record2 = await store.put({
       id: mediaId,
-      repository: repository === "unresolved" ? null : repository,
+      repository,
       relatedIssue,
       relatedPr,
       sourceSurface,
@@ -59356,8 +59388,16 @@ async function handleMediaSearchRequest(request, url, env) {
       reason: "D1 media metadata store is not configured"
     });
   }
+  const repository = normalizeCanonicalRepositoryInput(url.searchParams.get("repository"));
+  if (!repository) {
+    return json(422, {
+      ok: false,
+      error: "repository_required",
+      reason: "media search requires a resolved owner/repo repository filter"
+    });
+  }
   const records = await store.search({
-    repository: url.searchParams.get("repository"),
+    repository,
     relatedIssue: url.searchParams.get("relatedIssue") || url.searchParams.get("issueNumber"),
     relatedPr: url.searchParams.get("relatedPr") || url.searchParams.get("pullRequestNumber"),
     limit: url.searchParams.get("limit")
@@ -59381,11 +59421,66 @@ async function handleMediaDeleteRequest(request, env, mediaRoute) {
       reason: dashboardAuth.reason
     });
   }
+  const url = new URL(request.url);
+  const cleanup = normalizeDashboardEventText(url.searchParams.get("cleanup"));
+  if (cleanup === "abandoned_send") {
+    return handleAbandonedMediaSendRollback({ env, mediaRoute, url });
+  }
   return json(403, {
     ok: false,
     error: "scoped_approval_required",
     reason: "media delete requires scoped approval and is not part of Issue #498 first slice",
     mediaId: mediaRoute.id
+  });
+}
+async function handleAbandonedMediaSendRollback({ env, mediaRoute, url }) {
+  const store = resolveMediaObjectStore(env);
+  if (!store || typeof store.get !== "function" || typeof store.delete !== "function") {
+    return json(503, {
+      ok: false,
+      error: "media_metadata_store_unavailable",
+      reason: "D1 media metadata store is not configured for abandoned send rollback"
+    });
+  }
+  const r2 = env?.[MEDIA_R2_BINDING] ?? null;
+  if (!r2 || typeof r2.delete !== "function") {
+    return json(503, {
+      ok: false,
+      error: "media_r2_unavailable",
+      reason: "Cloudflare R2 binding VTDD_MEDIA_R2 is not configured for abandoned send rollback"
+    });
+  }
+  const record2 = await store.get(mediaRoute.id);
+  if (!record2) {
+    return json(404, {
+      ok: false,
+      error: "media_not_found",
+      reason: "media object was not found"
+    });
+  }
+  const repository = normalizeCanonicalRepositoryInput(url.searchParams.get("repository"));
+  const relatedIssue = normalizePositiveInteger9(url.searchParams.get("relatedIssue") || url.searchParams.get("issueNumber"));
+  const requestedSourceEventId = sanitizeDashboardChatText(url.searchParams.get("sourceEventId") || url.searchParams.get("source_event_id"));
+  const sourceEventId = normalizeDashboardEventText(record2.sourceEventId);
+  const isRollbackScoped = record2.visibility === "private" && record2.sourceSurface === "dashboard_butler" && sourceEventId.startsWith("dashboard_owner_message:") && requestedSourceEventId === sourceEventId && Boolean(repository) && record2.repository === repository && (!relatedIssue || record2.relatedIssue === relatedIssue);
+  if (!isRollbackScoped) {
+    return json(403, {
+      ok: false,
+      error: "scoped_approval_required",
+      reason: "media delete is only allowed here as rollback for private dashboard media from the abandoned owner message send",
+      mediaId: mediaRoute.id
+    });
+  }
+  await r2.delete(record2.objectKey);
+  await store.delete(record2.id);
+  return json(200, {
+    ok: true,
+    mediaId: record2.id,
+    deleted: {
+      r2: true,
+      d1: true
+    },
+    authority: "same_send_abandoned_private_media_rollback"
   });
 }
 async function handleDashboardPushSubscriptionRequest(request, env) {
@@ -61689,6 +61784,15 @@ function createD1MediaObjectStore(d1) {
       const row = Array.isArray(result?.results) ? result.results[0] : null;
       return row ? mediaObjectRecordFromRow(row) : null;
     },
+    async delete(id) {
+      const mediaId = normalizeMediaId(id);
+      if (!mediaId) {
+        return false;
+      }
+      await ensureSchema();
+      await d1.prepare("DELETE FROM vtdd_media_objects WHERE id = ?").bind(mediaId).run();
+      return true;
+    },
     async search(filter = {}) {
       await ensureSchema();
       const repository = normalizeCanonicalRepositoryInput(filter.repository);
@@ -62141,12 +62245,31 @@ function detectMediaContentType({ declaredType, filename, arrayBuffer }) {
       reason: `declared content type ${declared} does not match a supported audio signature`
     };
   }
+  const expectedByFilename = expectedMediaContentTypeFromFilename(filename);
+  if (!sniffed && (requiresStrictMediaSignature(declared) || expectedByFilename)) {
+    return {
+      ok: false,
+      error: "media_content_type_mismatch",
+      reason: `declared content type ${declared} or filename ${sanitizeMediaFilename(filename)} does not match a supported binary signature`
+    };
+  }
+  if (!sniffed && declared !== "text/plain") {
+    return {
+      ok: false,
+      error: "media_content_type_unsupported",
+      reason: `content type ${declared} is not supported in this first slice without a recognized safe signature`
+    };
+  }
   return {
     ok: true,
     contentType: sniffed || declared || "application/octet-stream"
   };
 }
 function sniffContentType(bytes) {
+  const prefixText = asciiAt(bytes, 0, Math.min(bytes?.length || 0, 64)).trimStart().toLowerCase();
+  if (prefixText.startsWith("<!doctype html") || prefixText.startsWith("<html") || prefixText.startsWith("<script")) {
+    return "text/html";
+  }
   if (startsWithBytes(bytes, [137, 80, 78, 71, 13, 10, 26, 10])) return "image/png";
   if (startsWithBytes(bytes, [255, 216, 255])) return "image/jpeg";
   if (startsWithAscii(bytes, "GIF87a") || startsWithAscii(bytes, "GIF89a")) return "image/gif";
@@ -62184,6 +62307,13 @@ function isCompatibleDeclaredMediaType(declared, sniffed) {
   if (declared === "application/x-zip-compressed" && sniffed === "application/zip") {
     return true;
   }
+  if (sniffed === "application/zip" && [
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+  ].includes(declared)) {
+    return true;
+  }
   if ((declared === "audio/mp3" || declared === "audio/x-mpeg") && sniffed === "audio/mpeg") {
     return true;
   }
@@ -62191,6 +62321,30 @@ function isCompatibleDeclaredMediaType(declared, sniffed) {
     return true;
   }
   return false;
+}
+function requiresStrictMediaSignature(type) {
+  const normalized = normalizeMediaContentType(type);
+  return [
+    "application/pdf",
+    "application/zip",
+    "application/x-zip-compressed",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+  ].includes(normalized);
+}
+function expectedMediaContentTypeFromFilename(filename) {
+  const sanitized = sanitizeMediaFilename(filename).toLowerCase();
+  if (/\.(png)$/i.test(sanitized)) return "image/png";
+  if (/\.(jpe?g)$/i.test(sanitized)) return "image/jpeg";
+  if (/\.(gif)$/i.test(sanitized)) return "image/gif";
+  if (/\.(webp)$/i.test(sanitized)) return "image/webp";
+  if (/\.(pdf)$/i.test(sanitized)) return "application/pdf";
+  if (/\.(zip|docx|xlsx|pptx)$/i.test(sanitized)) return "application/zip";
+  if (/\.(mp4|m4v)$/i.test(sanitized)) return "video/mp4";
+  if (/\.(mp3)$/i.test(sanitized)) return "audio/mpeg";
+  if (/\.(wav)$/i.test(sanitized)) return "audio/wav";
+  return "";
 }
 function isForbiddenUploadContentType(type) {
   const normalized = normalizeMediaContentType(type);
@@ -62298,8 +62452,6 @@ function toMediaReference(record2) {
     relatedIssue: normalized.relatedIssue,
     relatedPr: normalized.relatedPr,
     sourceSurface: normalized.sourceSurface,
-    sourceEventId: normalized.sourceEventId || null,
-    objectKey: normalized.objectKey,
     filename: normalized.filename,
     contentType: normalized.contentType,
     byteSize: normalized.byteSize,
@@ -64844,6 +64996,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
       let reconnectAttempt = 0;
       let refreshingThread = false;
       let pendingMediaItems = [];
+      const pendingSendRollbacks = new Map();
       const messagesById = new Map();
 
       function updateComposerReserve() {
@@ -65131,6 +65284,13 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         }
       }
 
+      function createClientMessageId() {
+        if (window.crypto && typeof window.crypto.randomUUID === "function") {
+          return "dashboard_owner_message:" + window.crypto.randomUUID();
+        }
+        return "dashboard_owner_message:" + Date.now().toString(36);
+      }
+
       async function uploadSelectedMedia(file, options = {}) {
         const preparedFile = await prepareUploadFile(file);
         const formData = new FormData();
@@ -65138,6 +65298,9 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         formData.append("repositoryInput", repositoryInput || "");
         formData.append("threadId", threadId || "");
         formData.append("sourceSurface", "dashboard_butler");
+        if (options.sourceEventId) {
+          formData.append("sourceEventId", options.sourceEventId);
+        }
         formData.append("visibility", "private");
         if (Number.isFinite(issueNumber)) {
           formData.append("relatedIssue", String(issueNumber));
@@ -65154,7 +65317,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         const body = await response.json().catch(() => ({}));
         if (response.status === 413 && body.error === "media_large_confirmation_required") {
           if (window.confirm("5MB \u3092\u8D85\u3048\u308B\u6DFB\u4ED8\u3067\u3059\u3002private \u3068\u3057\u3066\u4FDD\u5B58\u3057\u307E\u3059\u304B\uFF1F")) {
-            return uploadSelectedMedia(preparedFile, { allowLarge: true });
+            return uploadSelectedMedia(preparedFile, { ...options, allowLarge: true });
           }
         }
         if (!response.ok || !body.ok || !body.media) {
@@ -65163,12 +65326,33 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         return body.media;
       }
 
-      async function uploadPendingMedia() {
+      async function uploadPendingMedia(sourceEventId) {
         const uploaded = [];
-        for (const item of pendingMediaItems) {
-          uploaded.push(await uploadSelectedMedia(item.file));
+        try {
+          for (const item of pendingMediaItems) {
+            uploaded.push(await uploadSelectedMedia(item.file, { sourceEventId }));
+          }
+        } catch (error) {
+          await rollbackAbandonedMedia(uploaded, sourceEventId);
+          throw error;
         }
         return uploaded;
+      }
+
+      async function rollbackAbandonedMedia(mediaReferences, sourceEventId) {
+        const references = Array.isArray(mediaReferences) ? mediaReferences : [];
+        await Promise.allSettled(references.map(async (media) => {
+          if (!media || !media.mediaId) return;
+          const params = new URLSearchParams({ cleanup: "abandoned_send" });
+          if (repositoryInput) params.set("repository", repositoryInput);
+          if (Number.isFinite(issueNumber)) params.set("relatedIssue", String(issueNumber));
+          if (sourceEventId) params.set("sourceEventId", sourceEventId);
+          await fetch("/v2/media/" + encodeURIComponent(media.mediaId) + "?" + params.toString(), {
+            method: "DELETE",
+            credentials: "same-origin",
+            headers: { "accept": "application/json" }
+          });
+        }));
       }
 
       function appendError(text) {
@@ -65275,7 +65459,18 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
                 thinking: isThinking,
                 temporary: !isThinking
               });
+            } else if (body.type === "owner_message_accepted" && body.ok) {
+              const clientMessageId = body.clientMessageId || body.client_message_id || "";
+              if (clientMessageId) {
+                pendingSendRollbacks.delete(clientMessageId);
+              }
             } else if (body.type === "error") {
+              const clientMessageId = body.clientMessageId || body.client_message_id || "";
+              if (clientMessageId && pendingSendRollbacks.has(clientMessageId)) {
+                const mediaReferences = pendingSendRollbacks.get(clientMessageId) || [];
+                pendingSendRollbacks.delete(clientMessageId);
+                rollbackAbandonedMedia(mediaReferences, clientMessageId).catch(() => {});
+              }
               appendError(body.reason || "WebSocket message error");
             }
           } catch {
@@ -65312,23 +65507,42 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         if (submitButton) submitButton.disabled = true;
         setStatus(pendingMediaItems.length > 0 ? "\u6DFB\u4ED8\u3092\u4FDD\u5B58\u3057\u3066\u304B\u3089\u9001\u4FE1\u3057\u3066\u3044\u307E\u3059" : "\u9001\u4FE1\u4E2D\u3067\u3059", { thinking: true });
         let mediaReferences = [];
+        const clientMessageId = createClientMessageId();
         try {
-          mediaReferences = await uploadPendingMedia();
+          mediaReferences = await uploadPendingMedia(clientMessageId);
         } catch (error) {
           setStatus((error && error.message) || "\u6DFB\u4ED8\u306E\u4FDD\u5B58\u306B\u5931\u6557\u3057\u307E\u3057\u305F\u3002");
           if (submitButton) submitButton.disabled = false;
           textarea.focus({ preventScroll: true });
           return;
         }
-        chatSocket.send(JSON.stringify({
-          type: "owner_message",
-          threadId,
-          repositoryInput,
-          text,
-          issueNumber,
-          relatedIssue: issueNumber,
-          mediaReferences
-        }));
+        pendingSendRollbacks.set(clientMessageId, mediaReferences);
+        try {
+          chatSocket.send(JSON.stringify({
+            type: "owner_message",
+            threadId,
+            clientMessageId,
+            repositoryInput,
+            text,
+            issueNumber,
+            relatedIssue: issueNumber,
+            mediaReferences
+          }));
+          window.setTimeout(() => {
+            if (!pendingSendRollbacks.has(clientMessageId)) return;
+            const rollbackMediaReferences = pendingSendRollbacks.get(clientMessageId) || [];
+            pendingSendRollbacks.delete(clientMessageId);
+            rollbackAbandonedMedia(rollbackMediaReferences, clientMessageId).catch(() => {});
+            setStatus("\u9001\u4FE1\u78BA\u8A8D\u304C\u8FD4\u3089\u306A\u304B\u3063\u305F\u305F\u3081\u3001\u4FDD\u5B58\u6E08\u307F\u6DFB\u4ED8\u3092\u7834\u68C4\u3057\u307E\u3057\u305F\u3002");
+          }, 30000);
+        } catch (error) {
+          pendingSendRollbacks.delete(clientMessageId);
+          await rollbackAbandonedMedia(mediaReferences, clientMessageId);
+          setStatus((error && error.message) || "\u9001\u4FE1\u306B\u5931\u6557\u3057\u305F\u305F\u3081\u3001\u4FDD\u5B58\u6E08\u307F\u6DFB\u4ED8\u3092\u7834\u68C4\u3057\u307E\u3057\u305F\u3002");
+          if (submitButton) submitButton.disabled = false;
+          textarea.focus({ preventScroll: true });
+          return;
+        }
         pendingMediaItems = [];
         renderPendingMedia();
         textarea.value = "";

--- a/worker.js
+++ b/worker.js
@@ -56115,7 +56115,8 @@ var DashboardChatRoom = class {
     }
   }
   async acceptOwnerMessage({ socket, threadId, payload }) {
-    const text = sanitizeDashboardChatText(payload?.text || payload?.message || payload?.body);
+    const mediaReferences = normalizeMediaReferences(payload?.mediaReferences || payload?.media_references || payload?.media);
+    const text = sanitizeDashboardChatText(payload?.text || payload?.message || payload?.body) || (mediaReferences.length > 0 ? "\u6DFB\u4ED8\u3092\u8FFD\u52A0\u3057\u307E\u3057\u305F\u3002" : "");
     if (!threadId || !text) {
       if (isSocketOpen(socket)) {
         socket.send(JSON.stringify({ type: "error", ok: false, reason: "message text is required" }));
@@ -56138,6 +56139,7 @@ var DashboardChatRoom = class {
         relatedIssue,
         status: "sent",
         text,
+        mediaReferences,
         createdAt: now
       },
       { threadId }
@@ -56177,6 +56179,7 @@ var DashboardChatRoom = class {
       repository: repository || null,
       relatedIssue: relatedIssue || null,
       text,
+      mediaReferences,
       messageId: ownerMessage.messageId,
       createdAt: now,
       appServer: {
@@ -56349,6 +56352,7 @@ var AUTONOMY_MODE_ENV = "VTDD_AUTONOMY_MODE";
 var LEGACY_AUTONOMY_MODE_ENV = "MVP_AUTONOMY_MODE";
 var MEMORY_D1_BINDING = "VTDD_MEMORY_D1";
 var MEMORY_R2_BINDING = "VTDD_MEMORY_R2";
+var MEDIA_R2_BINDING = "VTDD_MEDIA_R2";
 var MEMORY_BLOB_THRESHOLD_ENV = "VTDD_MEMORY_BLOB_THRESHOLD";
 var WEB_PUSH_PUBLIC_KEY_ENV = "VTDD_WEB_PUSH_PUBLIC_KEY";
 var WEB_PUSH_PRIVATE_KEY_ENV = "VTDD_WEB_PUSH_PRIVATE_KEY";
@@ -56360,6 +56364,10 @@ var d1AdapterCache = /* @__PURE__ */ new WeakMap();
 var dashboardEventStoreCache = /* @__PURE__ */ new WeakMap();
 var dashboardChatStoreCache = /* @__PURE__ */ new WeakMap();
 var dashboardPushSubscriptionStoreCache = /* @__PURE__ */ new WeakMap();
+var mediaObjectStoreCache = /* @__PURE__ */ new WeakMap();
+var MEDIA_UPLOAD_SOFT_LIMIT_BYTES = 5 * 1024 * 1024;
+var MEDIA_UPLOAD_HARD_LIMIT_BYTES = 20 * 1024 * 1024;
+var MEDIA_REFERENCE_LIMIT = 12;
 var runtime_default = {
   async fetch(request, env) {
     const url = new URL(request.url);
@@ -56452,6 +56460,19 @@ var runtime_default = {
     }
     if (request.method === "POST" && isApiPath(url.pathname, "/dashboard/chat/messages")) {
       return handleDashboardChatMessageRequest(request, env);
+    }
+    if (request.method === "POST" && isApiPath(url.pathname, "/media/upload")) {
+      return handleMediaUploadRequest(request, env);
+    }
+    if (request.method === "GET" && isApiPath(url.pathname, "/media/search")) {
+      return handleMediaSearchRequest(request, url, env);
+    }
+    const mediaRoute = matchMediaObjectRoute(url.pathname);
+    if (mediaRoute && request.method === "GET") {
+      return handleMediaObjectRequest(request, env, mediaRoute);
+    }
+    if (mediaRoute && request.method === "DELETE") {
+      return handleMediaDeleteRequest(request, env, mediaRoute);
     }
     if (request.method === "POST" && isApiPath(url.pathname, "/dashboard/push/subscription")) {
       return handleDashboardPushSubscriptionRequest(request, env);
@@ -59086,6 +59107,243 @@ async function handleDashboardChatMessageRequest(request, env) {
     execution: null
   });
 }
+async function handleMediaUploadRequest(request, env) {
+  const dashboardAuth = await authorizeDashboardRequest({
+    request,
+    env,
+    apiSuffix: "/media/upload"
+  });
+  if (!dashboardAuth.ok) {
+    return json(dashboardAuth.status, {
+      ok: false,
+      error: "dashboard_auth_required",
+      reason: dashboardAuth.reason
+    });
+  }
+  const r2 = env?.[MEDIA_R2_BINDING] ?? null;
+  if (!r2 || typeof r2.put !== "function") {
+    return json(503, {
+      ok: false,
+      error: "media_r2_unavailable",
+      reason: "Cloudflare R2 binding VTDD_MEDIA_R2 is not configured"
+    });
+  }
+  const store = resolveMediaObjectStore(env);
+  if (!store) {
+    return json(503, {
+      ok: false,
+      error: "media_metadata_store_unavailable",
+      reason: "D1 media metadata store is not configured"
+    });
+  }
+  let form = null;
+  try {
+    form = await request.formData();
+  } catch {
+    return json(400, {
+      ok: false,
+      error: "multipart_form_required",
+      reason: "multipart/form-data with a file field is required"
+    });
+  }
+  const file = form.get("file");
+  if (!isUploadFileLike(file)) {
+    return json(422, {
+      ok: false,
+      error: "media_file_required",
+      reason: "file field is required"
+    });
+  }
+  const byteSize = Number(file.size) || 0;
+  if (byteSize <= 0) {
+    return json(422, {
+      ok: false,
+      error: "media_file_empty",
+      reason: "empty media files are not accepted"
+    });
+  }
+  if (byteSize > MEDIA_UPLOAD_HARD_LIMIT_BYTES) {
+    return json(413, {
+      ok: false,
+      error: "media_file_too_large",
+      reason: "20MB \u3092\u8D85\u3048\u308B\u6DFB\u4ED8\u306F first slice \u3067\u306F\u4FDD\u5B58\u3057\u307E\u305B\u3093\u3002\u7E2E\u5C0F\u3057\u3066\u304B\u3089\u9001\u3063\u3066\u304F\u3060\u3055\u3044\u3002",
+      limitBytes: MEDIA_UPLOAD_HARD_LIMIT_BYTES
+    });
+  }
+  const allowLarge = normalizeText30(form.get("allowLarge") || form.get("allow_large")).toLowerCase() === "true";
+  if (byteSize > MEDIA_UPLOAD_SOFT_LIMIT_BYTES && !allowLarge) {
+    return json(413, {
+      ok: false,
+      error: "media_large_confirmation_required",
+      reason: "5MB \u3092\u8D85\u3048\u308B\u6DFB\u4ED8\u3067\u3059\u3002\u4FDD\u5B58\u3059\u308B\u5834\u5408\u306F\u78BA\u8A8D\u3057\u3066\u304B\u3089\u518D\u9001\u3057\u3066\u304F\u3060\u3055\u3044\u3002",
+      limitBytes: MEDIA_UPLOAD_SOFT_LIMIT_BYTES
+    });
+  }
+  const contentType = normalizeMediaContentType(file.type);
+  const filename = sanitizeMediaFilename(file.name || "attachment");
+  const repository = normalizeCanonicalRepositoryInput(form.get("repository") || form.get("repositoryInput") || form.get("repository_input")) || "unresolved";
+  const relatedIssue = normalizePositiveInteger9(form.get("relatedIssue") || form.get("issueNumber") || form.get("related_issue"));
+  const relatedPr = normalizePositiveInteger9(form.get("relatedPr") || form.get("pullRequestNumber") || form.get("related_pr"));
+  const sourceSurface = normalizeMediaSourceSurface(form.get("sourceSurface") || form.get("source_surface")) || "dashboard_butler";
+  const sourceEventId = sanitizeDashboardChatText(form.get("sourceEventId") || form.get("source_event_id"));
+  const visibility = normalizeMediaVisibility(form.get("visibility")) || "private";
+  const now = (/* @__PURE__ */ new Date()).toISOString();
+  const mediaId = `med_${crypto.randomUUID()}`;
+  const objectKey = buildMediaObjectKey({ repository, createdAt: now, mediaId, filename });
+  const arrayBuffer = await file.arrayBuffer();
+  const sha2562 = await sha256ArrayBufferHex(arrayBuffer);
+  await r2.put(objectKey, arrayBuffer, {
+    httpMetadata: { contentType },
+    customMetadata: {
+      mediaId,
+      repository,
+      visibility,
+      sha256: sha2562
+    }
+  });
+  const record2 = await store.put({
+    id: mediaId,
+    repository: repository === "unresolved" ? null : repository,
+    relatedIssue,
+    relatedPr,
+    sourceSurface,
+    sourceEventId,
+    objectKey,
+    filename,
+    contentType,
+    byteSize,
+    sha256: sha2562,
+    visibility,
+    summary: "",
+    ocrText: "",
+    createdBy: dashboardAuth.email || dashboardAuth.login || dashboardAuth.authType || "dashboard",
+    createdAt: now,
+    updatedAt: now
+  });
+  return json(201, {
+    ok: true,
+    media: toMediaReference(record2),
+    stored: {
+      r2: true,
+      d1: true,
+      rawBinaryReturned: false
+    }
+  });
+}
+async function handleMediaObjectRequest(request, env, mediaRoute) {
+  const dashboardAuth = await authorizeDashboardRequest({
+    request,
+    env,
+    apiSuffix: mediaRoute.download ? "/media/:id/download" : "/media/:id"
+  });
+  if (!dashboardAuth.ok) {
+    return json(dashboardAuth.status, {
+      ok: false,
+      error: "dashboard_auth_required",
+      reason: dashboardAuth.reason
+    });
+  }
+  const store = resolveMediaObjectStore(env);
+  if (!store) {
+    return json(503, {
+      ok: false,
+      error: "media_metadata_store_unavailable",
+      reason: "D1 media metadata store is not configured"
+    });
+  }
+  const record2 = await store.get(mediaRoute.id);
+  if (!record2) {
+    return json(404, {
+      ok: false,
+      error: "media_not_found",
+      reason: "media object was not found"
+    });
+  }
+  if (!mediaRoute.download) {
+    return json(200, {
+      ok: true,
+      media: toMediaReference(record2),
+      rawBinaryReturned: false
+    });
+  }
+  const r2 = env?.[MEDIA_R2_BINDING] ?? null;
+  if (!r2 || typeof r2.get !== "function") {
+    return json(503, {
+      ok: false,
+      error: "media_r2_unavailable",
+      reason: "Cloudflare R2 binding VTDD_MEDIA_R2 is not configured"
+    });
+  }
+  const object3 = await r2.get(record2.objectKey);
+  if (!object3) {
+    return json(404, {
+      ok: false,
+      error: "media_binary_not_found",
+      reason: "R2 object was not found for this media record"
+    });
+  }
+  return new Response(object3.body ?? object3, {
+    status: 200,
+    headers: {
+      "content-type": record2.contentType || "application/octet-stream",
+      "content-disposition": `attachment; filename="${record2.filename.replace(/["\\]/g, "_")}"`,
+      "cache-control": "private, no-store"
+    }
+  });
+}
+async function handleMediaSearchRequest(request, url, env) {
+  const dashboardAuth = await authorizeDashboardRequest({
+    request,
+    env,
+    apiSuffix: "/media/search"
+  });
+  if (!dashboardAuth.ok) {
+    return json(dashboardAuth.status, {
+      ok: false,
+      error: "dashboard_auth_required",
+      reason: dashboardAuth.reason
+    });
+  }
+  const store = resolveMediaObjectStore(env);
+  if (!store || typeof store.search !== "function") {
+    return json(503, {
+      ok: false,
+      error: "media_metadata_store_unavailable",
+      reason: "D1 media metadata store is not configured"
+    });
+  }
+  const records = await store.search({
+    repository: url.searchParams.get("repository"),
+    relatedIssue: url.searchParams.get("relatedIssue") || url.searchParams.get("issueNumber"),
+    relatedPr: url.searchParams.get("relatedPr") || url.searchParams.get("pullRequestNumber"),
+    limit: url.searchParams.get("limit")
+  });
+  return json(200, {
+    ok: true,
+    media: records.map((record2) => toMediaReference(record2)).filter(Boolean),
+    rawBinaryReturned: false
+  });
+}
+async function handleMediaDeleteRequest(request, env, mediaRoute) {
+  const dashboardAuth = await authorizeDashboardRequest({
+    request,
+    env,
+    apiSuffix: "/media/:id"
+  });
+  if (!dashboardAuth.ok) {
+    return json(dashboardAuth.status, {
+      ok: false,
+      error: "dashboard_auth_required",
+      reason: dashboardAuth.reason
+    });
+  }
+  return json(403, {
+    ok: false,
+    error: "scoped_approval_required",
+    reason: "media delete requires scoped approval and is not part of Issue #498 first slice",
+    mediaId: mediaRoute.id
+  });
+}
 async function handleDashboardPushSubscriptionRequest(request, env) {
   const dashboardAuth = await authorizeDashboardRequest({
     request,
@@ -60767,6 +61025,25 @@ function resolveDashboardChatStore(env) {
   dashboardChatStoreCache.set(d1Binding, store);
   return store;
 }
+function resolveMediaObjectStore(env) {
+  if (!env || typeof env !== "object") {
+    return null;
+  }
+  const injectedStore = env.MEDIA_OBJECT_STORE ?? null;
+  if (injectedStore && typeof injectedStore.put === "function" && typeof injectedStore.get === "function") {
+    return injectedStore;
+  }
+  const d1Binding = env[MEMORY_D1_BINDING] ?? null;
+  if (!d1Binding || typeof d1Binding.prepare !== "function") {
+    return null;
+  }
+  if (mediaObjectStoreCache.has(d1Binding)) {
+    return mediaObjectStoreCache.get(d1Binding);
+  }
+  const store = createD1MediaObjectStore(d1Binding);
+  mediaObjectStoreCache.set(d1Binding, store);
+  return store;
+}
 function resolveDashboardPushSubscriptionStore(env) {
   if (!env || typeof env !== "object") {
     return null;
@@ -61322,6 +61599,115 @@ function createD1DashboardChatStore(d1) {
     return schemaPromise;
   }
 }
+function createD1MediaObjectStore(d1) {
+  let schemaPromise = null;
+  return {
+    async put(record2) {
+      const normalized = normalizeMediaObjectRecord(record2);
+      if (!normalized) {
+        return null;
+      }
+      await ensureSchema();
+      await d1.prepare(
+        `INSERT OR REPLACE INTO vtdd_media_objects (
+             id, repository, related_issue, related_pr, source_surface, source_event_id,
+             object_key, filename, content_type, byte_size, sha256, visibility,
+             summary, ocr_text, created_by, created_at, updated_at
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      ).bind(
+        normalized.id,
+        normalized.repository,
+        normalized.relatedIssue,
+        normalized.relatedPr,
+        normalized.sourceSurface,
+        normalized.sourceEventId,
+        normalized.objectKey,
+        normalized.filename,
+        normalized.contentType,
+        normalized.byteSize,
+        normalized.sha256,
+        normalized.visibility,
+        normalized.summary,
+        normalized.ocrText,
+        normalized.createdBy,
+        normalized.createdAt,
+        normalized.updatedAt
+      ).run();
+      return normalized;
+    },
+    async get(id) {
+      const mediaId = normalizeMediaId(id);
+      if (!mediaId) {
+        return null;
+      }
+      await ensureSchema();
+      const result = await d1.prepare("SELECT * FROM vtdd_media_objects WHERE id = ? LIMIT 1").bind(mediaId).all();
+      const row = Array.isArray(result?.results) ? result.results[0] : null;
+      return row ? mediaObjectRecordFromRow(row) : null;
+    },
+    async search(filter = {}) {
+      await ensureSchema();
+      const repository = normalizeCanonicalRepositoryInput(filter.repository);
+      const relatedIssue = normalizePositiveInteger9(filter.relatedIssue || filter.issueNumber);
+      const relatedPr = normalizePositiveInteger9(filter.relatedPr || filter.pullRequestNumber);
+      const limit = normalizeLimit7(filter.limit, 20);
+      const clauses = [];
+      const params = [];
+      if (repository) {
+        clauses.push("repository = ?");
+        params.push(repository);
+      }
+      if (relatedIssue) {
+        clauses.push("related_issue = ?");
+        params.push(relatedIssue);
+      }
+      if (relatedPr) {
+        clauses.push("related_pr = ?");
+        params.push(relatedPr);
+      }
+      const where = clauses.length > 0 ? `WHERE ${clauses.join(" AND ")}` : "";
+      const result = await d1.prepare(
+        `SELECT * FROM vtdd_media_objects
+           ${where}
+           ORDER BY created_at DESC
+           LIMIT ?`
+      ).bind(...params, limit).all();
+      return (Array.isArray(result?.results) ? result.results : []).map(mediaObjectRecordFromRow).filter(Boolean);
+    }
+  };
+  function ensureSchema() {
+    if (!schemaPromise) {
+      schemaPromise = (async () => {
+        await d1.exec(
+          `CREATE TABLE IF NOT EXISTS vtdd_media_objects (
+            id TEXT PRIMARY KEY,
+            repository TEXT,
+            related_issue INTEGER,
+            related_pr INTEGER,
+            source_surface TEXT NOT NULL,
+            source_event_id TEXT,
+            object_key TEXT NOT NULL,
+            filename TEXT NOT NULL,
+            content_type TEXT NOT NULL,
+            byte_size INTEGER NOT NULL,
+            sha256 TEXT NOT NULL,
+            visibility TEXT NOT NULL,
+            summary TEXT,
+            ocr_text TEXT,
+            created_by TEXT,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+          );`
+        );
+        await d1.exec("CREATE INDEX IF NOT EXISTS idx_vtdd_media_repo ON vtdd_media_objects(repository, created_at DESC);");
+        await d1.exec("CREATE INDEX IF NOT EXISTS idx_vtdd_media_issue ON vtdd_media_objects(repository, related_issue, created_at DESC);");
+        await d1.exec("CREATE INDEX IF NOT EXISTS idx_vtdd_media_pr ON vtdd_media_objects(repository, related_pr, created_at DESC);");
+        await d1.exec("CREATE INDEX IF NOT EXISTS idx_vtdd_media_source ON vtdd_media_objects(source_surface, source_event_id);");
+      })();
+    }
+    return schemaPromise;
+  }
+}
 function createD1DashboardPushSubscriptionStore(d1) {
   let schemaPromise = null;
   return {
@@ -61622,10 +62008,178 @@ function base64UrlToBytes(value) {
   }
   return bytes;
 }
+function matchMediaObjectRoute(pathname) {
+  for (const prefix of [CANONICAL_API_PREFIX, LEGACY_API_PREFIX]) {
+    const base = `${prefix}/media/`;
+    if (!pathname.startsWith(base)) {
+      continue;
+    }
+    const tail = pathname.slice(base.length);
+    const parts = tail.split("/").filter(Boolean);
+    if (parts.length === 1) {
+      const id = normalizeMediaId(parts[0]);
+      return id ? { id, download: false } : null;
+    }
+    if (parts.length === 2 && parts[1] === "download") {
+      const id = normalizeMediaId(parts[0]);
+      return id ? { id, download: true } : null;
+    }
+  }
+  return null;
+}
+function isUploadFileLike(value) {
+  return value && typeof value === "object" && typeof value.arrayBuffer === "function" && Number(value.size) >= 0;
+}
+function normalizeMediaId(value) {
+  const text = normalizeDashboardEventText(value);
+  return /^med_[A-Za-z0-9_-]{8,80}$/.test(text) ? text : "";
+}
+function normalizeMediaContentType(value) {
+  const type = normalize7(String(value || "application/octet-stream").split(";")[0]);
+  return /^[a-z0-9.+-]+\/[a-z0-9.+-]+$/.test(type) ? type : "application/octet-stream";
+}
+function sanitizeMediaFilename(value) {
+  const text = normalizeDashboardEventText(value).split(/[\\/]/).pop() || "attachment";
+  const sanitized = text.replace(/[^A-Za-z0-9._ -]+/g, "_").replace(/\s+/g, " ").trim();
+  return (sanitized || "attachment").slice(0, 120);
+}
+function normalizeMediaSourceSurface(value) {
+  const text = normalizeDashboardEventText(value).toLowerCase().replace(/[^a-z0-9_-]+/g, "_");
+  return text.slice(0, 80);
+}
+function normalizeMediaVisibility(value) {
+  const visibility = normalize7(value);
+  return ["private", "repo_internal", "public_evidence"].includes(visibility) ? visibility : "";
+}
+function buildMediaObjectKey({ repository, createdAt, mediaId, filename }) {
+  const repo = normalizeCanonicalRepositoryInput(repository) || "unresolved/repository";
+  const [owner, name] = repo.split("/");
+  const date3 = new Date(createdAt);
+  const yyyy = String(date3.getUTCFullYear()).padStart(4, "0");
+  const mm = String(date3.getUTCMonth() + 1).padStart(2, "0");
+  const dd = String(date3.getUTCDate()).padStart(2, "0");
+  return `media/${owner}/${name}/${yyyy}/${mm}/${dd}/${mediaId}/${sanitizeMediaFilename(filename)}`;
+}
+async function sha256ArrayBufferHex(arrayBuffer) {
+  if (globalThis.crypto?.subtle) {
+    const digest2 = await globalThis.crypto.subtle.digest("SHA-256", arrayBuffer);
+    return [...new Uint8Array(digest2)].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+  }
+  const bytes = new Uint8Array(arrayBuffer);
+  let text = "";
+  for (const byte of bytes) {
+    text += String.fromCharCode(byte);
+  }
+  return btoa(text).replace(/[^A-Za-z0-9]/g, "").slice(0, 64);
+}
+function normalizeMediaObjectRecord(record2) {
+  const input = normalizeObject11(record2);
+  const id = normalizeMediaId(input.id || input.mediaId || input.media_id);
+  const objectKey = normalizeDashboardEventText(input.objectKey || input.object_key);
+  const filename = sanitizeMediaFilename(input.filename);
+  const contentType = normalizeMediaContentType(input.contentType || input.content_type);
+  const byteSize = Number(input.byteSize || input.byte_size);
+  const sha2562 = normalizeDashboardEventText(input.sha256).toLowerCase();
+  if (!id || !objectKey || !filename || !Number.isFinite(byteSize) || byteSize <= 0 || !sha2562) {
+    return null;
+  }
+  const createdAt = normalizeIsoTimestamp(input.createdAt || input.created_at) || (/* @__PURE__ */ new Date()).toISOString();
+  return {
+    id,
+    repository: normalizeCanonicalRepositoryInput(input.repository) || null,
+    relatedIssue: normalizePositiveInteger9(input.relatedIssue || input.related_issue || input.issueNumber),
+    relatedPr: normalizePositiveInteger9(input.relatedPr || input.related_pr || input.pullRequestNumber),
+    sourceSurface: normalizeMediaSourceSurface(input.sourceSurface || input.source_surface) || "dashboard_butler",
+    sourceEventId: sanitizeDashboardChatText(input.sourceEventId || input.source_event_id),
+    objectKey,
+    filename,
+    contentType,
+    byteSize: Math.floor(byteSize),
+    sha256: sha2562,
+    visibility: normalizeMediaVisibility(input.visibility) || "private",
+    summary: sanitizeDashboardChatText(input.summary),
+    ocrText: sanitizeDashboardChatText(input.ocrText || input.ocr_text),
+    createdBy: sanitizeDashboardChatText(input.createdBy || input.created_by),
+    createdAt,
+    updatedAt: normalizeIsoTimestamp(input.updatedAt || input.updated_at) || createdAt
+  };
+}
+function mediaObjectRecordFromRow(row) {
+  return normalizeMediaObjectRecord({
+    id: row?.id,
+    repository: row?.repository,
+    relatedIssue: row?.related_issue,
+    relatedPr: row?.related_pr,
+    sourceSurface: row?.source_surface,
+    sourceEventId: row?.source_event_id,
+    objectKey: row?.object_key,
+    filename: row?.filename,
+    contentType: row?.content_type,
+    byteSize: row?.byte_size,
+    sha256: row?.sha256,
+    visibility: row?.visibility,
+    summary: row?.summary,
+    ocrText: row?.ocr_text,
+    createdBy: row?.created_by,
+    createdAt: row?.created_at,
+    updatedAt: row?.updated_at
+  });
+}
+function toMediaReference(record2) {
+  const normalized = normalizeMediaObjectRecord(record2);
+  if (!normalized) {
+    return null;
+  }
+  return {
+    mediaId: normalized.id,
+    repository: normalized.repository,
+    relatedIssue: normalized.relatedIssue,
+    relatedPr: normalized.relatedPr,
+    sourceSurface: normalized.sourceSurface,
+    sourceEventId: normalized.sourceEventId || null,
+    objectKey: normalized.objectKey,
+    filename: normalized.filename,
+    contentType: normalized.contentType,
+    byteSize: normalized.byteSize,
+    sha256: normalized.sha256,
+    visibility: normalized.visibility,
+    summary: normalized.summary || "",
+    ocrText: normalized.ocrText || "",
+    createdAt: normalized.createdAt,
+    updatedAt: normalized.updatedAt,
+    metadataUrl: `/v2/media/${normalized.id}`,
+    downloadUrl: `/v2/media/${normalized.id}/download`
+  };
+}
+function normalizeMediaReferences(value) {
+  const list = Array.isArray(value) ? value : value ? [value] : [];
+  return list.map((item) => {
+    const input = normalizeObject11(item);
+    const mediaId = normalizeMediaId(input.mediaId || input.id || input.media_id);
+    if (!mediaId) {
+      return null;
+    }
+    return {
+      mediaId,
+      repository: normalizeCanonicalRepositoryInput(input.repository) || null,
+      relatedIssue: normalizePositiveInteger9(input.relatedIssue || input.related_issue || input.issueNumber),
+      relatedPr: normalizePositiveInteger9(input.relatedPr || input.related_pr || input.pullRequestNumber),
+      filename: sanitizeMediaFilename(input.filename || "attachment"),
+      contentType: normalizeMediaContentType(input.contentType || input.content_type),
+      byteSize: normalizePositiveInteger9(input.byteSize || input.byte_size),
+      sha256: normalizeDashboardEventText(input.sha256).toLowerCase().slice(0, 64),
+      visibility: normalizeMediaVisibility(input.visibility) || "private",
+      summary: sanitizeDashboardChatText(input.summary),
+      metadataUrl: `/v2/media/${mediaId}`,
+      downloadUrl: `/v2/media/${mediaId}/download`
+    };
+  }).filter(Boolean).slice(0, MEDIA_REFERENCE_LIMIT);
+}
 function buildDashboardChatTurn(payload, options = {}) {
   const input = normalizeObject11(payload);
   const repository = normalizeCanonicalRepositoryInput(input.repository);
-  const text = sanitizeDashboardChatText(input.text || input.message || input.body);
+  const mediaReferences = normalizeMediaReferences(input.mediaReferences || input.media_references || input.media);
+  const text = sanitizeDashboardChatText(input.text || input.message || input.body) || (mediaReferences.length > 0 ? "\u6DFB\u4ED8\u3092\u8FFD\u52A0\u3057\u307E\u3057\u305F\u3002" : "");
   if (!text) {
     return {
       ok: false,
@@ -61644,6 +62198,7 @@ function buildDashboardChatTurn(payload, options = {}) {
       relatedIssue,
       status: "sent",
       text,
+      mediaReferences,
       createdAt: now
     },
     { threadId }
@@ -61698,6 +62253,7 @@ function normalizeDashboardChatMessage(message, defaults = {}) {
     relatedIssue: normalizePositiveInteger9(input.relatedIssue || input.issueNumber || input.related_issue),
     status: normalizeDashboardChatStatus(input.status),
     text: sanitizeDashboardChatText(input.text || input.message || input.body) || "\uFF08\u7A7A\u306E\u30E1\u30C3\u30BB\u30FC\u30B8\uFF09",
+    mediaReferences: normalizeMediaReferences(input.mediaReferences || input.media_references || input.media),
     createdAt
   };
 }
@@ -63839,10 +64395,16 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
     .connection-note { display: inline-flex; align-items: center; width: fit-content; border: 1px solid var(--border); border-radius: 999px; padding: 5px 10px; color: var(--muted); font-size: 13px; }
     .chat-link { color: var(--text); text-decoration-thickness: 1px; text-underline-offset: 4px; font-weight: 750; }
     .composer { min-width: 0; display: grid; gap: 8px; z-index: 4; padding: 14px 0 max(16px, env(safe-area-inset-bottom)); background: var(--page-bg); }
-    .composer-box { display: grid; grid-template-columns: minmax(0, 1fr) 44px; align-items: end; gap: 8px; min-height: 62px; padding: 8px; border: 1px solid var(--border); border-radius: 28px; background: var(--panel-strong); box-shadow: 0 16px 60px var(--shadow); }
+    .composer-box { display: grid; grid-template-columns: 44px minmax(0, 1fr) 44px; align-items: end; gap: 8px; min-height: 62px; padding: 8px; border: 1px solid var(--border); border-radius: 28px; background: var(--panel-strong); box-shadow: 0 16px 60px var(--shadow); }
     textarea { width: 100%; min-height: 44px; max-height: max(88px, min(160px, 24dvh)); border: 0; outline: 0; resize: none; overflow-y: hidden; padding: 10px 2px; color: var(--text); background: transparent; font: inherit; line-height: 1.45; }
     textarea::placeholder { color: var(--muted); }
+    .media-button { width: 44px; height: 44px; border-radius: 999px; border: 1px solid var(--border); background: var(--button); color: var(--text); font: inherit; font-size: 24px; line-height: 1; display: inline-flex; align-items: center; justify-content: center; cursor: pointer; }
     .send-button { width: 44px; height: 44px; border-radius: 999px; background: var(--text); color: var(--page-bg); font-size: 22px; }
+    .pending-media, .message-media { display: flex; flex-wrap: wrap; gap: 8px; padding: 0 8px; }
+    .pending-media:empty, .message-media:empty { display: none; }
+    .media-chip { display: inline-flex; align-items: center; max-width: 100%; min-height: 34px; border: 1px solid var(--border); border-radius: 999px; padding: 5px 10px; gap: 6px; color: var(--text); background: var(--soft); font-size: 12px; text-decoration: none; }
+    .media-chip span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: min(48vw, 320px); }
+    .media-remove { border: 0; background: transparent; color: var(--muted); font: inherit; font-weight: 900; padding: 0 2px; cursor: pointer; }
     .composer-status { min-height: 18px; padding-left: 16px; color: var(--muted); font-size: 12px; }
     .composer-status.thinking::after { content: ""; display: inline-block; width: 1.4em; text-align: left; animation: thinkingDots 1.2s steps(4, end) infinite; }
     .sidebar { position: sticky; top: 16px; align-self: start; max-height: calc(100dvh - 32px); overflow: auto; border: 1px solid var(--border); border-radius: 18px; background: var(--panel); }
@@ -63889,10 +64451,10 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
     @media (max-width: 460px) {
       main { padding: 12px 10px 0; }
       .app-shell { height: calc(100dvh - 12px); }
-      .composer-box { grid-template-columns: minmax(0, 1fr) 40px; border-radius: 24px; }
+      .composer-box { grid-template-columns: 40px minmax(0, 1fr) 40px; border-radius: 24px; }
       .round-button { width: 40px; height: 40px; }
       .tool-button { min-height: 38px; padding: 0 12px; }
-      .send-button { width: 40px; height: 40px; }
+      .media-button, .send-button { width: 40px; height: 40px; }
     }
   </style>
 </head>
@@ -63974,7 +64536,10 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
       </div>
 
       <form class="composer" id="butler-chat-form" aria-label="Butler composer" autocomplete="off" data-socket-endpoint="${escapeDashboardHtml(socketOrigin)}/v2/dashboard/chat/${escapeDashboardHtml(chatThreadId)}/ws" data-thread-endpoint="${escapeDashboardHtml(origin)}/v2/dashboard/chat/${escapeDashboardHtml(chatThreadId)}" data-thread-id="${escapeDashboardHtml(chatThreadId)}" data-repository-input="${escapeDashboardHtml(repositoryInput)}" data-issue-number="${dashboardIssueNumber || ""}">
+        <div class="pending-media" id="butler-pending-media" aria-live="polite"></div>
         <div class="composer-box">
+          <button class="media-button" id="butler-media-button" type="button" aria-label="\u753B\u50CF\u3084\u30D5\u30A1\u30A4\u30EB\u3092\u8FFD\u52A0" title="\u753B\u50CF\u3084\u30D5\u30A1\u30A4\u30EB\u3092\u8FFD\u52A0">+</button>
+          <input id="butler-media-input" type="file" accept="image/*" hidden>
           <textarea id="butler-message" name="text" placeholder="Butler V2 \u306B\u30E1\u30C3\u30BB\u30FC\u30B8..." aria-label="Butler V2 \u306B\u30E1\u30C3\u30BB\u30FC\u30B8" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" enterkeyhint="send"></textarea>
           <button class="send-button" type="submit" aria-label="Butler \u306B\u9001\u4FE1">\u2191</button>
         </div>
@@ -64040,10 +64605,14 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
       const log = document.getElementById("butler-chat-log");
       const textarea = document.getElementById("butler-message");
       const status = document.getElementById("butler-chat-status");
+      const mediaButton = document.getElementById("butler-media-button");
+      const mediaInput = document.getElementById("butler-media-input");
+      const pendingMedia = document.getElementById("butler-pending-media");
       if (!form || !log || !textarea || !status) return;
 
       const socketEndpoint = form.dataset.socketEndpoint;
       const threadEndpoint = form.dataset.threadEndpoint;
+      const mediaUploadEndpoint = "/v2/media/upload";
       const threadId = form.dataset.threadId;
       const repositoryInput = form.dataset.repositoryInput;
       const issueNumber = Number.parseInt(form.dataset.issueNumber || "", 10);
@@ -64052,6 +64621,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
       let reconnectTimer = null;
       let reconnectAttempt = 0;
       let refreshingThread = false;
+      let pendingMediaReferences = [];
       const messagesById = new Map();
 
       function updateComposerReserve() {
@@ -64127,8 +64697,60 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         body.className = "message-body";
         renderMessageText(body, message.text || "\uFF08\u7A7A\u306E\u30E1\u30C3\u30BB\u30FC\u30B8\uFF09");
         article.appendChild(body);
+        const media = renderMediaReferences(message.mediaReferences || message.media_references || []);
+        if (media) {
+          article.appendChild(media);
+        }
         log.appendChild(article);
         scrollToLatest();
+      }
+
+      function renderMediaReferences(references) {
+        const list = Array.isArray(references) ? references : [];
+        if (list.length === 0) return null;
+        const wrapper = document.createElement("div");
+        wrapper.className = "message-media";
+        for (const reference of list) {
+          const link = document.createElement("a");
+          link.className = "media-chip";
+          link.href = reference.downloadUrl || (reference.mediaId ? "/v2/media/" + reference.mediaId + "/download" : "#");
+          link.target = "_blank";
+          link.rel = "noreferrer";
+          link.textContent = "";
+          const icon = document.createElement("span");
+          icon.textContent = "\u6DFB\u4ED8";
+          const label = document.createElement("span");
+          label.textContent = reference.filename || reference.mediaId || "media";
+          link.appendChild(icon);
+          link.appendChild(label);
+          wrapper.appendChild(link);
+        }
+        return wrapper;
+      }
+
+      function renderPendingMedia() {
+        if (!pendingMedia) return;
+        pendingMedia.replaceChildren();
+        for (const reference of pendingMediaReferences) {
+          const chip = document.createElement("span");
+          chip.className = "media-chip";
+          const label = document.createElement("span");
+          label.textContent = reference.filename || reference.mediaId || "media";
+          const remove = document.createElement("button");
+          remove.className = "media-remove";
+          remove.type = "button";
+          remove.textContent = "\xD7";
+          remove.setAttribute("aria-label", "\u6DFB\u4ED8\u3092\u5916\u3059");
+          remove.addEventListener("click", () => {
+            pendingMediaReferences = pendingMediaReferences.filter((item) => item.mediaId !== reference.mediaId);
+            renderPendingMedia();
+            updateComposerReserve();
+          });
+          chip.appendChild(label);
+          chip.appendChild(remove);
+          pendingMedia.appendChild(chip);
+        }
+        updateComposerReserve();
       }
 
       function renderMessageText(container, text) {
@@ -64259,6 +64881,66 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         }
       }
 
+      async function prepareUploadFile(file) {
+        if (!file || !file.type || !file.type.startsWith("image/")) {
+          return file;
+        }
+        if (file.size <= 5 * 1024 * 1024 || typeof createImageBitmap !== "function") {
+          return file;
+        }
+        try {
+          const bitmap = await createImageBitmap(file);
+          const maxSide = 1600;
+          const scale = Math.min(1, maxSide / Math.max(bitmap.width, bitmap.height));
+          const width = Math.max(1, Math.round(bitmap.width * scale));
+          const height = Math.max(1, Math.round(bitmap.height * scale));
+          const canvas = document.createElement("canvas");
+          canvas.width = width;
+          canvas.height = height;
+          const context = canvas.getContext("2d");
+          context.drawImage(bitmap, 0, 0, width, height);
+          const blob = await new Promise((resolve) => canvas.toBlob(resolve, "image/jpeg", 0.82));
+          if (!blob || blob.size >= file.size) {
+            return file;
+          }
+          return new File([blob], file.name.replace(/.[^.]+$/, "") + ".jpg", { type: "image/jpeg" });
+        } catch {
+          return file;
+        }
+      }
+
+      async function uploadSelectedMedia(file, options = {}) {
+        const preparedFile = await prepareUploadFile(file);
+        const formData = new FormData();
+        formData.append("file", preparedFile, preparedFile.name || file.name || "attachment");
+        formData.append("repositoryInput", repositoryInput || "");
+        formData.append("threadId", threadId || "");
+        formData.append("sourceSurface", "dashboard_butler");
+        formData.append("visibility", "private");
+        if (Number.isFinite(issueNumber)) {
+          formData.append("relatedIssue", String(issueNumber));
+        }
+        if (options.allowLarge === true) {
+          formData.append("allowLarge", "true");
+        }
+        const response = await fetch(mediaUploadEndpoint, {
+          method: "POST",
+          body: formData,
+          credentials: "same-origin",
+          headers: { "accept": "application/json" }
+        });
+        const body = await response.json().catch(() => ({}));
+        if (response.status === 413 && body.error === "media_large_confirmation_required") {
+          if (window.confirm("5MB \u3092\u8D85\u3048\u308B\u6DFB\u4ED8\u3067\u3059\u3002private \u3068\u3057\u3066\u4FDD\u5B58\u3057\u307E\u3059\u304B\uFF1F")) {
+            return uploadSelectedMedia(preparedFile, { allowLarge: true });
+          }
+        }
+        if (!response.ok || !body.ok || !body.media) {
+          throw new Error(body.reason || "media upload failed");
+        }
+        return body.media;
+      }
+
       function appendError(text) {
         appendMessage({ role: "butler", text });
       }
@@ -64384,7 +65066,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
 
       form.addEventListener("submit", async (event) => {
         event.preventDefault();
-        const text = textarea.value.trim();
+        const text = textarea.value.trim() || (pendingMediaReferences.length > 0 ? "\u6DFB\u4ED8\u3092\u8FFD\u52A0\u3057\u307E\u3057\u305F\u3002" : "");
         if (!text) {
           textarea.focus();
           return;
@@ -64405,8 +65087,11 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           repositoryInput,
           text,
           issueNumber,
-          relatedIssue: issueNumber
+          relatedIssue: issueNumber,
+          mediaReferences: pendingMediaReferences
         }));
+        pendingMediaReferences = [];
+        renderPendingMedia();
         textarea.value = "";
         resizeComposerInput();
         setStatus("app-server bridge \u306E\u8FD4\u4FE1\u3092\u5F85\u3063\u3066\u3044\u307E\u3059", { thinking: true });
@@ -64414,6 +65099,29 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         textarea.focus({ preventScroll: true });
         updateComposerReserve();
       });
+
+      if (mediaButton && mediaInput) {
+        mediaButton.addEventListener("click", () => mediaInput.click());
+        mediaInput.addEventListener("change", async () => {
+          const file = mediaInput.files && mediaInput.files[0];
+          mediaInput.value = "";
+          if (!file) return;
+          try {
+            mediaButton.disabled = true;
+            setStatus("\u6DFB\u4ED8\u3092\u4FDD\u5B58\u3057\u3066\u3044\u307E\u3059", { thinking: true });
+            const media = await uploadSelectedMedia(file);
+            pendingMediaReferences = [...pendingMediaReferences, media].slice(0, 12);
+            renderPendingMedia();
+            setStatus("\u6DFB\u4ED8\u3092 private media reference \u3068\u3057\u3066\u4FDD\u5B58\u3057\u307E\u3057\u305F\u3002", { temporary: true });
+            textarea.focus({ preventScroll: true });
+          } catch (error) {
+            setStatus((error && error.message) || "\u6DFB\u4ED8\u306E\u4FDD\u5B58\u306B\u5931\u6557\u3057\u307E\u3057\u305F\u3002");
+          } finally {
+            mediaButton.disabled = false;
+            updateComposerReserve();
+          }
+        });
+      }
 
       resizeComposerInput();
       textarea.addEventListener("input", resizeComposerInput);

--- a/worker.js
+++ b/worker.js
@@ -56115,7 +56115,8 @@ var DashboardChatRoom = class {
     }
   }
   async acceptOwnerMessage({ socket, threadId, payload }) {
-    const mediaReferences = normalizeMediaReferences(payload?.mediaReferences || payload?.media_references || payload?.media);
+    const inputMediaReferences = payload?.mediaReferences || payload?.media_references || payload?.media;
+    const mediaReferences = normalizeMediaReferences(inputMediaReferences);
     const text = sanitizeDashboardChatText(payload?.text || payload?.message || payload?.body) || (mediaReferences.length > 0 ? "\u6DFB\u4ED8\u3092\u8FFD\u52A0\u3057\u307E\u3057\u305F\u3002" : "");
     if (!threadId || !text) {
       if (isSocketOpen(socket)) {
@@ -56131,6 +56132,18 @@ var DashboardChatRoom = class {
       env: this.env
     });
     const repository = repositoryResolution.ok ? repositoryResolution.repository : "";
+    const mediaValidation = await resolveDashboardChatMediaReferences({
+      env: this.env,
+      mediaReferences: inputMediaReferences,
+      repository,
+      relatedIssue
+    });
+    if (!mediaValidation.ok) {
+      if (isSocketOpen(socket)) {
+        socket.send(JSON.stringify({ type: "error", ok: false, reason: mediaValidation.reason }));
+      }
+      return;
+    }
     const ownerMessage = normalizeDashboardChatMessage(
       {
         threadId,
@@ -56139,7 +56152,7 @@ var DashboardChatRoom = class {
         relatedIssue,
         status: "sent",
         text,
-        mediaReferences,
+        mediaReferences: mediaValidation.mediaReferences,
         createdAt: now
       },
       { threadId }
@@ -56179,7 +56192,7 @@ var DashboardChatRoom = class {
       repository: repository || null,
       relatedIssue: relatedIssue || null,
       text,
-      mediaReferences,
+      mediaReferences: mediaValidation.mediaReferences,
       messageId: ownerMessage.messageId,
       createdAt: now,
       appServer: {
@@ -59077,12 +59090,13 @@ async function handleDashboardChatMessageRequest(request, env) {
   const payload = await readJson(request);
   const repositoryResolution = await resolveDashboardChatRepository({ payload, env });
   const repository = repositoryResolution.ok ? repositoryResolution.repository : "";
-  const prepared = buildDashboardChatTurn(
+  const prepared = await buildDashboardChatTurn(
     {
       ...payload,
       repository,
       relatedIssue: normalizePositiveInteger9(payload?.relatedIssue || payload?.issueNumber) || extractIssueNumberFromDashboardChatText(payload?.text || payload?.message || payload?.body)
-    }
+    },
+    { env }
   );
   if (!prepared.ok) {
     return json(422, {
@@ -59179,7 +59193,6 @@ async function handleMediaUploadRequest(request, env) {
       limitBytes: MEDIA_UPLOAD_SOFT_LIMIT_BYTES
     });
   }
-  const contentType = normalizeMediaContentType(file.type);
   const filename = sanitizeMediaFilename(file.name || "attachment");
   const repository = normalizeCanonicalRepositoryInput(form.get("repository") || form.get("repositoryInput") || form.get("repository_input")) || "unresolved";
   const relatedIssue = normalizePositiveInteger9(form.get("relatedIssue") || form.get("issueNumber") || form.get("related_issue"));
@@ -59191,6 +59204,19 @@ async function handleMediaUploadRequest(request, env) {
   const mediaId = `med_${crypto.randomUUID()}`;
   const objectKey = buildMediaObjectKey({ repository, createdAt: now, mediaId, filename });
   const arrayBuffer = await file.arrayBuffer();
+  const contentTypeValidation = detectMediaContentType({
+    declaredType: file.type,
+    filename,
+    arrayBuffer
+  });
+  if (!contentTypeValidation.ok) {
+    return json(415, {
+      ok: false,
+      error: contentTypeValidation.error,
+      reason: contentTypeValidation.reason
+    });
+  }
+  const contentType = contentTypeValidation.contentType;
   const sha2562 = await sha256ArrayBufferHex(arrayBuffer);
   await r2.put(objectKey, arrayBuffer, {
     httpMetadata: { contentType },
@@ -59201,25 +59227,43 @@ async function handleMediaUploadRequest(request, env) {
       sha256: sha2562
     }
   });
-  const record2 = await store.put({
-    id: mediaId,
-    repository: repository === "unresolved" ? null : repository,
-    relatedIssue,
-    relatedPr,
-    sourceSurface,
-    sourceEventId,
-    objectKey,
-    filename,
-    contentType,
-    byteSize,
-    sha256: sha2562,
-    visibility,
-    summary: "",
-    ocrText: "",
-    createdBy: dashboardAuth.email || dashboardAuth.login || dashboardAuth.authType || "dashboard",
-    createdAt: now,
-    updatedAt: now
-  });
+  let record2 = null;
+  try {
+    record2 = await store.put({
+      id: mediaId,
+      repository: repository === "unresolved" ? null : repository,
+      relatedIssue,
+      relatedPr,
+      sourceSurface,
+      sourceEventId,
+      objectKey,
+      filename,
+      contentType,
+      byteSize,
+      sha256: sha2562,
+      visibility,
+      summary: "",
+      ocrText: "",
+      createdBy: dashboardAuth.email || dashboardAuth.login || dashboardAuth.authType || "dashboard",
+      createdAt: now,
+      updatedAt: now
+    });
+  } catch (error2) {
+    await cleanupOrphanMediaObject(r2, objectKey);
+    return json(500, {
+      ok: false,
+      error: "media_metadata_insert_failed",
+      reason: `D1 media metadata insert failed after R2 put; orphan cleanup was attempted: ${sanitizeErrorMessage(error2)}`
+    });
+  }
+  if (!record2) {
+    await cleanupOrphanMediaObject(r2, objectKey);
+    return json(500, {
+      ok: false,
+      error: "media_metadata_insert_failed",
+      reason: "D1 media metadata insert returned no record after R2 put; orphan cleanup was attempted"
+    });
+  }
   return json(201, {
     ok: true,
     media: toMediaReference(record2),
@@ -62051,6 +62095,118 @@ function normalizeMediaVisibility(value) {
   const visibility = normalize7(value);
   return ["private", "repo_internal", "public_evidence"].includes(visibility) ? visibility : "";
 }
+function detectMediaContentType({ declaredType, filename, arrayBuffer }) {
+  const declared = normalizeMediaContentType(declaredType);
+  if (isForbiddenUploadContentType(declared) || isForbiddenUploadFilename(filename)) {
+    return {
+      ok: false,
+      error: "media_content_type_forbidden",
+      reason: "HTML, SVG, script, and executable-looking attachments are not accepted in this first slice"
+    };
+  }
+  const bytes = new Uint8Array(arrayBuffer || new ArrayBuffer(0));
+  const sniffed = sniffContentType(bytes);
+  if (sniffed && isForbiddenUploadContentType(sniffed)) {
+    return {
+      ok: false,
+      error: "media_content_type_forbidden",
+      reason: "\u3053\u306E\u6DFB\u4ED8\u306E\u5B9F\u4F53\u306F\u5B89\u5168\u306B\u6271\u3048\u306A\u3044 content type \u3067\u3059"
+    };
+  }
+  if (sniffed && declared !== "application/octet-stream" && declared !== sniffed && !isCompatibleDeclaredMediaType(declared, sniffed)) {
+    return {
+      ok: false,
+      error: "media_content_type_mismatch",
+      reason: `declared content type ${declared} does not match detected content type ${sniffed}`
+    };
+  }
+  if (!sniffed && declared.startsWith("image/")) {
+    return {
+      ok: false,
+      error: "media_content_type_mismatch",
+      reason: `declared content type ${declared} does not match a supported image signature`
+    };
+  }
+  if (!sniffed && declared.startsWith("video/")) {
+    return {
+      ok: false,
+      error: "media_content_type_mismatch",
+      reason: `declared content type ${declared} does not match a supported video signature`
+    };
+  }
+  if (!sniffed && declared.startsWith("audio/")) {
+    return {
+      ok: false,
+      error: "media_content_type_mismatch",
+      reason: `declared content type ${declared} does not match a supported audio signature`
+    };
+  }
+  return {
+    ok: true,
+    contentType: sniffed || declared || "application/octet-stream"
+  };
+}
+function sniffContentType(bytes) {
+  if (startsWithBytes(bytes, [137, 80, 78, 71, 13, 10, 26, 10])) return "image/png";
+  if (startsWithBytes(bytes, [255, 216, 255])) return "image/jpeg";
+  if (startsWithAscii(bytes, "GIF87a") || startsWithAscii(bytes, "GIF89a")) return "image/gif";
+  if (startsWithAscii(bytes, "RIFF") && asciiAt(bytes, 8, 4) === "WEBP") return "image/webp";
+  if (startsWithAscii(bytes, "%PDF-")) return "application/pdf";
+  if (startsWithBytes(bytes, [80, 75, 3, 4]) || startsWithBytes(bytes, [80, 75, 5, 6])) return "application/zip";
+  if (startsWithAscii(bytes, "RIFF") && asciiAt(bytes, 8, 4) === "WAVE") return "audio/wav";
+  if (startsWithAscii(bytes, "ID3") || startsWithBytes(bytes, [255, 251]) || startsWithBytes(bytes, [255, 243])) return "audio/mpeg";
+  if (bytes.length >= 12 && asciiAt(bytes, 4, 4) === "ftyp") return "video/mp4";
+  return "";
+}
+function startsWithBytes(bytes, prefix) {
+  if (!bytes || bytes.length < prefix.length) {
+    return false;
+  }
+  return prefix.every((byte, index) => bytes[index] === byte);
+}
+function startsWithAscii(bytes, prefix) {
+  return asciiAt(bytes, 0, prefix.length) === prefix;
+}
+function asciiAt(bytes, offset, length) {
+  if (!bytes || bytes.length < offset + length) {
+    return "";
+  }
+  let text = "";
+  for (let index = offset; index < offset + length; index += 1) {
+    text += String.fromCharCode(bytes[index]);
+  }
+  return text;
+}
+function isCompatibleDeclaredMediaType(declared, sniffed) {
+  if (declared === sniffed) {
+    return true;
+  }
+  if (declared === "application/x-zip-compressed" && sniffed === "application/zip") {
+    return true;
+  }
+  if ((declared === "audio/mp3" || declared === "audio/x-mpeg") && sniffed === "audio/mpeg") {
+    return true;
+  }
+  if (declared === "audio/x-wav" && sniffed === "audio/wav") {
+    return true;
+  }
+  return false;
+}
+function isForbiddenUploadContentType(type) {
+  const normalized = normalizeMediaContentType(type);
+  return [
+    "image/svg+xml",
+    "text/html",
+    "application/xhtml+xml",
+    "application/javascript",
+    "text/javascript",
+    "application/x-msdownload",
+    "application/x-sh"
+  ].includes(normalized);
+}
+function isForbiddenUploadFilename(filename) {
+  return /\.(html?|svg|mjs|cjs|js|jsx|ts|tsx|sh|bash|zsh|exe|dll|dmg|pkg)$/i.test(sanitizeMediaFilename(filename));
+}
 function buildMediaObjectKey({ repository, createdAt, mediaId, filename }) {
   const repo = normalizeCanonicalRepositoryInput(repository) || "unresolved/repository";
   const [owner, name] = repo.split("/");
@@ -62065,12 +62221,18 @@ async function sha256ArrayBufferHex(arrayBuffer) {
     const digest2 = await globalThis.crypto.subtle.digest("SHA-256", arrayBuffer);
     return [...new Uint8Array(digest2)].map((byte) => byte.toString(16).padStart(2, "0")).join("");
   }
-  const bytes = new Uint8Array(arrayBuffer);
-  let text = "";
-  for (const byte of bytes) {
-    text += String.fromCharCode(byte);
+  throw new Error("SHA-256 digest is not available in this runtime");
+}
+async function cleanupOrphanMediaObject(r2, objectKey) {
+  if (!r2 || typeof r2.delete !== "function" || !objectKey) {
+    return false;
   }
-  return btoa(text).replace(/[^A-Za-z0-9]/g, "").slice(0, 64);
+  try {
+    await r2.delete(objectKey);
+    return true;
+  } catch {
+    return false;
+  }
 }
 function normalizeMediaObjectRecord(record2) {
   const input = normalizeObject11(record2);
@@ -62175,7 +62337,58 @@ function normalizeMediaReferences(value) {
     };
   }).filter(Boolean).slice(0, MEDIA_REFERENCE_LIMIT);
 }
-function buildDashboardChatTurn(payload, options = {}) {
+async function resolveDashboardChatMediaReferences({ env, mediaReferences, repository, relatedIssue }) {
+  const requested = normalizeMediaReferences(mediaReferences);
+  if (requested.length === 0) {
+    return { ok: true, mediaReferences: [] };
+  }
+  const store = resolveMediaObjectStore(env);
+  if (!store || typeof store.get !== "function") {
+    return {
+      ok: false,
+      error: "media_metadata_store_unavailable",
+      reason: "media reference validation requires D1 media metadata store"
+    };
+  }
+  const resolvedRepository = normalizeCanonicalRepositoryInput(repository);
+  const resolvedIssue = normalizePositiveInteger9(relatedIssue);
+  const resolved = [];
+  for (const reference of requested) {
+    const record2 = await store.get(reference.mediaId);
+    if (!record2) {
+      return {
+        ok: false,
+        error: "media_reference_not_found",
+        reason: `media reference ${reference.mediaId} was not found`
+      };
+    }
+    const media = toMediaReference(record2);
+    if (!media) {
+      return {
+        ok: false,
+        error: "media_reference_invalid",
+        reason: `media reference ${reference.mediaId} is malformed`
+      };
+    }
+    if (resolvedRepository && media.repository !== resolvedRepository) {
+      return {
+        ok: false,
+        error: "media_reference_repository_mismatch",
+        reason: `media reference ${reference.mediaId} does not belong to ${resolvedRepository}`
+      };
+    }
+    if (resolvedIssue && media.relatedIssue !== resolvedIssue) {
+      return {
+        ok: false,
+        error: "media_reference_issue_mismatch",
+        reason: `media reference ${reference.mediaId} does not belong to Issue #${resolvedIssue}`
+      };
+    }
+    resolved.push(media);
+  }
+  return { ok: true, mediaReferences: resolved };
+}
+async function buildDashboardChatTurn(payload, options = {}) {
   const input = normalizeObject11(payload);
   const repository = normalizeCanonicalRepositoryInput(input.repository);
   const mediaReferences = normalizeMediaReferences(input.mediaReferences || input.media_references || input.media);
@@ -62189,6 +62402,15 @@ function buildDashboardChatTurn(payload, options = {}) {
   }
   const threadId = normalizeDashboardThreadId(input.threadId || input.thread_id) || (repository ? `dashboard-main-${repository.replace("/", "-")}` : "dashboard-main-unresolved");
   const relatedIssue = normalizePositiveInteger9(input.relatedIssue || input.issueNumber);
+  const mediaValidation = await resolveDashboardChatMediaReferences({
+    env: options.env,
+    mediaReferences: input.mediaReferences || input.media_references || input.media,
+    repository,
+    relatedIssue
+  });
+  if (!mediaValidation.ok) {
+    return mediaValidation;
+  }
   const now = (/* @__PURE__ */ new Date()).toISOString();
   const ownerMessage = normalizeDashboardChatMessage(
     {
@@ -62198,7 +62420,7 @@ function buildDashboardChatTurn(payload, options = {}) {
       relatedIssue,
       status: "sent",
       text,
-      mediaReferences,
+      mediaReferences: mediaValidation.mediaReferences,
       createdAt: now
     },
     { threadId }
@@ -64539,7 +64761,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         <div class="pending-media" id="butler-pending-media" aria-live="polite"></div>
         <div class="composer-box">
           <button class="media-button" id="butler-media-button" type="button" aria-label="\u753B\u50CF\u3084\u30D5\u30A1\u30A4\u30EB\u3092\u8FFD\u52A0" title="\u753B\u50CF\u3084\u30D5\u30A1\u30A4\u30EB\u3092\u8FFD\u52A0">+</button>
-          <input id="butler-media-input" type="file" accept="image/*" hidden>
+          <input id="butler-media-input" type="file" hidden>
           <textarea id="butler-message" name="text" placeholder="Butler V2 \u306B\u30E1\u30C3\u30BB\u30FC\u30B8..." aria-label="Butler V2 \u306B\u30E1\u30C3\u30BB\u30FC\u30B8" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" enterkeyhint="send"></textarea>
           <button class="send-button" type="submit" aria-label="Butler \u306B\u9001\u4FE1">\u2191</button>
         </div>
@@ -64621,7 +64843,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
       let reconnectTimer = null;
       let reconnectAttempt = 0;
       let refreshingThread = false;
-      let pendingMediaReferences = [];
+      let pendingMediaItems = [];
       const messagesById = new Map();
 
       function updateComposerReserve() {
@@ -64731,18 +64953,18 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
       function renderPendingMedia() {
         if (!pendingMedia) return;
         pendingMedia.replaceChildren();
-        for (const reference of pendingMediaReferences) {
+        for (const item of pendingMediaItems) {
           const chip = document.createElement("span");
           chip.className = "media-chip";
           const label = document.createElement("span");
-          label.textContent = reference.filename || reference.mediaId || "media";
+          label.textContent = item.filename || "attachment";
           const remove = document.createElement("button");
           remove.className = "media-remove";
           remove.type = "button";
           remove.textContent = "\xD7";
           remove.setAttribute("aria-label", "\u6DFB\u4ED8\u3092\u5916\u3059");
           remove.addEventListener("click", () => {
-            pendingMediaReferences = pendingMediaReferences.filter((item) => item.mediaId !== reference.mediaId);
+            pendingMediaItems = pendingMediaItems.filter((candidate) => candidate.clientId !== item.clientId);
             renderPendingMedia();
             updateComposerReserve();
           });
@@ -64941,6 +65163,14 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         return body.media;
       }
 
+      async function uploadPendingMedia() {
+        const uploaded = [];
+        for (const item of pendingMediaItems) {
+          uploaded.push(await uploadSelectedMedia(item.file));
+        }
+        return uploaded;
+      }
+
       function appendError(text) {
         appendMessage({ role: "butler", text });
       }
@@ -65066,7 +65296,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
 
       form.addEventListener("submit", async (event) => {
         event.preventDefault();
-        const text = textarea.value.trim() || (pendingMediaReferences.length > 0 ? "\u6DFB\u4ED8\u3092\u8FFD\u52A0\u3057\u307E\u3057\u305F\u3002" : "");
+        const text = textarea.value.trim() || (pendingMediaItems.length > 0 ? "\u6DFB\u4ED8\u3092\u8FFD\u52A0\u3057\u307E\u3057\u305F\u3002" : "");
         if (!text) {
           textarea.focus();
           return;
@@ -65080,7 +65310,16 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           return;
         }
         if (submitButton) submitButton.disabled = true;
-        setStatus("\u9001\u4FE1\u4E2D\u3067\u3059", { thinking: true });
+        setStatus(pendingMediaItems.length > 0 ? "\u6DFB\u4ED8\u3092\u4FDD\u5B58\u3057\u3066\u304B\u3089\u9001\u4FE1\u3057\u3066\u3044\u307E\u3059" : "\u9001\u4FE1\u4E2D\u3067\u3059", { thinking: true });
+        let mediaReferences = [];
+        try {
+          mediaReferences = await uploadPendingMedia();
+        } catch (error) {
+          setStatus((error && error.message) || "\u6DFB\u4ED8\u306E\u4FDD\u5B58\u306B\u5931\u6557\u3057\u307E\u3057\u305F\u3002");
+          if (submitButton) submitButton.disabled = false;
+          textarea.focus({ preventScroll: true });
+          return;
+        }
         chatSocket.send(JSON.stringify({
           type: "owner_message",
           threadId,
@@ -65088,9 +65327,9 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           text,
           issueNumber,
           relatedIssue: issueNumber,
-          mediaReferences: pendingMediaReferences
+          mediaReferences
         }));
-        pendingMediaReferences = [];
+        pendingMediaItems = [];
         renderPendingMedia();
         textarea.value = "";
         resizeComposerInput();
@@ -65108,11 +65347,17 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           if (!file) return;
           try {
             mediaButton.disabled = true;
-            setStatus("\u6DFB\u4ED8\u3092\u4FDD\u5B58\u3057\u3066\u3044\u307E\u3059", { thinking: true });
-            const media = await uploadSelectedMedia(file);
-            pendingMediaReferences = [...pendingMediaReferences, media].slice(0, 12);
+            const preparedFile = await prepareUploadFile(file);
+            pendingMediaItems = [
+              ...pendingMediaItems,
+              {
+                clientId: Date.now() + "_" + Math.random().toString(36).slice(2),
+                filename: preparedFile.name || file.name || "attachment",
+                file: preparedFile
+              }
+            ].slice(0, 12);
             renderPendingMedia();
-            setStatus("\u6DFB\u4ED8\u3092 private media reference \u3068\u3057\u3066\u4FDD\u5B58\u3057\u307E\u3057\u305F\u3002", { temporary: true });
+            setStatus("\u6DFB\u4ED8\u3092\u9001\u4FE1\u5F85\u3061\u306B\u8FFD\u52A0\u3057\u307E\u3057\u305F\u3002\u9001\u4FE1\u6642\u306B private media \u3068\u3057\u3066\u4FDD\u5B58\u3057\u307E\u3059\u3002", { temporary: true });
             textarea.focus({ preventScroll: true });
           } catch (error) {
             setStatus((error && error.message) || "\u6DFB\u4ED8\u306E\u4FDD\u5B58\u306B\u5931\u6557\u3057\u307E\u3057\u305F\u3002");


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #498 の Cloudflare R2 media storage first implementation sliceとして、Dashboard Butler から画像/ファイルを添付し、raw binary は R2、metadata/reference は D1/chat payload に分離する実行経路を追加します。
- ユーザーが iPhone PWA の composer から `+` で添付を選び、送信時に保存済み media reference を会話に添えられるようにします。
- Codex fallback reviewer の blocker に対応し、MIME type 偽装、media reference 偽装、R2 orphan、送信前キャンセル時の不要保存を防ぎます。

## Satisfied Success Criteria

- Dashboard Butler composer に media 追加ボタンと hidden file input を追加しました。`accept="image/*"` 限定は外し、一般ファイル導線にしました。
- UI はファイル選択時点では upload せず、送信時だけ `/v2/media/upload` を呼びます。送信前に chip を外した添付は R2/D1 に保存されません。
- `POST /v2/media/upload` を追加し、owner/dashboard auth 後に sha256 を計算して `VTDD_MEDIA_R2` へ put し、D1 metadata store に `vtdd_media_objects` を作成/insert します。
- upload は `file.type` を信用せず、先頭バイトで PNG/JPEG/GIF/WebP/PDF/ZIP/MP4/MP3/WAV を sniff し、宣言 MIME と実体が矛盾する場合は R2 put 前に 415 で拒否します。
- D1 metadata insert が失敗した場合は R2 object cleanup を試み、binary orphan を残さないテストを追加しました。
- `GET /v2/media/:id` と `GET /v2/media/:id/download` を追加し、metadata と same-origin download を分離しました。
- chat message payload は `mediaReferences` のみ保持し、保存前に D1 media metadata の実在、repository、Issue 整合を検証します。
- R2 binding 未設定時は metadata drift を起こさず `media_r2_unavailable` で停止します。

## Unsatisfied Success Criteria

- Cloudflare production の R2 bucket 作成/権限設定/deploy binding はこのPRでは実行していません。deploy/credential mutation は scoped passkey approval が必要です。
- Custom GPT Action Schema には media upload operationId をまだ露出していません。
- OCR/summary/RAG reference 自動投入は未実装です。chat payload には media reference のみ保存します。
- iPhone live E2E は未実施です。ローカル Browser plugin の制御ツールがこのセッションで露出せず、DOM/test までの検証です。
- Issue #498 はこのPRだけでは close できません。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #498
- Implementing Success Criteria: R2/D1 media upload route、metadata route、download route、Dashboard composer media reference 表示、raw binary 非保持、MIME sniff、reference 整合検証、R2 orphan cleanup。
- Explicit Non-goals: bucket 作成、Cloudflare secret/variable mutation、production deploy、動画変換、OCR、public evidence promotion、Issue close。
- Expected touched files/routes/workflows: `src/worker/runtime.js`, `worker.js`, `test/worker.test.js`, `/v2/media/upload`, `/v2/media/:id`, `/v2/media/:id/download`, `/v2/media/search`, `DELETE /v2/media/:id` forbidden stub。
- Affected Issues: Issue #498。
- Affected PRs: PR #506。
- Affected workflows: deploy workflow は変更なし。`VTDD_MEDIA_R2` が未設定なら route が 503 で停止します。
- Affected runtime/operator surfaces: Dashboard Butler, Worker API, D1 metadata, R2 binding, dashboard chat payload。
- What may break if we patch narrowly: production binding を強制追加すると bucket 未作成環境で deploy を壊すため、このPRでは未設定を明示 503 にしています。
- Unknowns to investigate before coding: 既存 dashboard chat payload 形式、D1 store pattern、production deploy binding の安全境界、reviewer blocker の security 指摘。
- Validation needed: unit/integration tests, generated worker check, production R2 binding 後の iPhone live E2E。
- Stop condition: Cloudflare bucket/credential/deploy mutation が必要になった時点で passkey approval なしでは停止。

## File / Line Hypotheses

- file: `src/worker/runtime.js`
  - hypothesis: dashboard chat の payload_json は structured reference を保持できるため、raw media を入れず D1 で検証済みの `mediaReferences` だけを追加できる。
  - risk if changed narrowly: normalize 時に media reference を落とすと UI には添付済み表示が残らず、逆に未検証 reference や raw binary を payload に混ぜると RAG/secret boundary を破る。
  - validation: worker tests で `mediaReferences` が保持され raw binary 文字列が response に出ないこと、別 Issue の media reference が拒否されることを確認。
  - related Issue: Issue #498
- file: `src/worker/runtime.js`
  - hypothesis: upload route は R2 put 後の D1 insert 失敗時に `r2.delete(objectKey)` を試みれば binary orphan を抑制できる。
  - risk if changed narrowly: cleanup を入れないと metadata なし binary が残り、delete route が未実装の first slice では owner-facing recovery がない。
  - validation: D1 put failure test で R2 object が残らないことを確認。
  - related Issue: Issue #498
- file: `test/worker.test.js`
  - hypothesis: in-memory R2/store で upload -> metadata -> download、MIME spoof rejection、reference mismatch rejection を production credentials なしで検証できる。
  - risk if changed narrowly: production binding 未設定時や spoofed MIME の停止条件を確認しないと、deploy 後に unsafe media が保存される。
  - validation: R2 binding missing、MIME mismatch、R2 cleanup、reference mismatch tests を追加。
  - related Issue: Issue #498

## Hypothesis Retrospective

- expected: chat payload は media reference を保持でき、R2 未設定時は fail closed にできる。
- actual: `normalizeDashboardChatMessage` に reference normalization を足し、upload route は R2 未設定で D1 insert 前に 503 停止できた。さらに D1 metadata insert 失敗時は R2 cleanup を試みるようにした。
- mismatch: 初版では画像限定 input、未検証 `mediaReferences`、即 upload、R2 orphan cleanup なしが reviewer blocker になった。
- lesson: media は owner-facing UI と storage route の両方で security boundary を持つ必要がある。`file.type` は信用せず、chat reference も D1 truth で検証する。
- should become RAG candidate: はい。R2 media upload は MIME sniff、reference existence/context validation、R2 orphan cleanup、send-time upload を baseline にする。

## Verification Evidence

- Unit: `node --test test/worker.test.js --test-name-pattern "media|dashboard Butler chat turn|media references"` pass。
- Integration: `npm test` pass。931 passed, 1 skipped。`check:self-parity` と `check:generated-worker` も pass。
- E2E: 未実施。production R2 binding と iPhone live upload は次 slice。
- Manual: ローカル Worker wrapper は起動確認済み。Browser plugin の標準制御ツールが露出せず、画面操作 screenshot は未実施。
- Evidence path/link: test output in this run; changed tests in `test/worker.test.js`。

## Butler Completion Contract

- Owner goal: Dashboard Butler からメディアを追加し、R2/D1 分離で会話へ検証済み media reference を残す。
- Butler entrypoint: Dashboard Butler composer に `+` media button を追加。Custom GPT Butler 自然文 action は未接続。
- Action Schema exposure: 未変更。Custom GPT Action Schema の media operationId は未追加。
- Runtime path: `POST /v2/media/upload`, `GET /v2/media/:id`, `GET /v2/media/:id/download`, dashboard chat `mediaReferences`。
- Runner/runtime truth: Worker tests と route response で確認。production R2 binding truth は未確認。
- Authority boundary: upload/read は authenticated owner/dashboard auth。delete は scoped approval required として 403 停止。public evidence promotion は未実装。
- E2E evidence: 未実施。production R2 binding 後に iPhone screenshot upload -> dashboard thread -> R2/D1確認が必要。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: このPRでは未実行。production R2 binding が必要なため、deploy は passkey approval 付きの別手順。
- Custom GPT Action Schema update: 未実施。
- Custom GPT Instructions update: 未実施。
- iPhone Butler live E2E: 未実施。

## Related Constitution Rules

- Issue-backed implementation only: Issue #498 に限定。
- Butler-first completion gate: live E2E 未実施なので incomplete と明記。
- Authority boundary: deploy/credential mutation は passkey approval なしでは実行しない。
- Memory safety: raw media binary は RAG/chat payload に保存しない。
- Security boundary: MIME type 偽装、未検証 media reference、orphan binary を防ぐ。

## Out-of-scope but NOT implemented

- Cloudflare R2 bucket 作成。
- production deploy workflow の強制 R2 binding 追加。
- OCR/summary/RAG自動投入。
- video/audio conversion。
- public evidence promotion。
- Issue #498 close。

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #498
- Execution ID: codex/498-media-upload-runtime
- Goal: Dashboard Butler media upload first runtime slice with security blocker fixes
