### PR TITLE
Issue #498 production deploy に media R2 binding を追加

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -150,6 +150,7 @@ jobs:
         env:
           CLOUDFLARE_D1_DATABASE_ID: ${{ secrets.CLOUDFLARE_D1_DATABASE_ID }}
           CLOUDFLARE_D1_DATABASE_NAME: ${{ vars.CLOUDFLARE_D1_DATABASE_NAME || 'vtdd-memory' }}
+          CLOUDFLARE_MEDIA_R2_BUCKET_NAME: ${{ vars.CLOUDFLARE_MEDIA_R2_BUCKET_NAME || 'vtdd-media-prod' }}
           VTDD_GITHUB_ACTIONS_REPOSITORY: ${{ github.repository }}
           VTDD_KNOWN_GOOD_COMMIT_SHA: ${{ vars.VTDD_KNOWN_GOOD_COMMIT_SHA }}
           VTDD_DASHBOARD_ALLOWED_EMAILS: ${{ vars.VTDD_DASHBOARD_ALLOWED_EMAILS }}
@@ -198,6 +199,10 @@ jobs:
           binding = "VTDD_MEMORY_D1"
           database_name = "$CLOUDFLARE_D1_DATABASE_NAME"
           database_id = "$CLOUDFLARE_D1_DATABASE_ID"
+
+          [[env.production.r2_buckets]]
+          binding = "VTDD_MEDIA_R2"
+          bucket_name = "$CLOUDFLARE_MEDIA_R2_BUCKET_NAME"
           EOF
 
       - name: Deploy to Cloudflare Workers

--- a/docs/mvp/production-deploy-path.md
+++ b/docs/mvp/production-deploy-path.md
@@ -41,12 +41,20 @@ secrets.
 
 ### 3. Worker Bindings
 
-Production must bind the VTDD memory D1 database as `VTDD_MEMORY_D1`.
+Production must bind:
+
+- the VTDD memory D1 database as `VTDD_MEMORY_D1`
+- the media R2 bucket as `VTDD_MEDIA_R2`
 
 This binding is required for real passkey registration, approval challenge
 persistence, and approval grant retrieval. A production deploy that drops this
 binding breaks scoped passkey approval issuance and therefore blocks high-risk
 runtime operations.
+
+The media R2 binding is required for Dashboard Butler attachments. A production
+deploy that drops `VTDD_MEDIA_R2` must fail closed instead of storing raw media
+in chat history, RAG, GitHub Issue comments, PR bodies, or local filesystem
+persistence.
 
 Because this repository is public and reusable, owner-specific Cloudflare
 resource identifiers must not be committed to the shared `wrangler.toml`.
@@ -55,8 +63,10 @@ before deploying production.
 
 For local/operator deploys, store owner-specific bindings in an ignored file
 such as `wrangler.production.local.toml`. For GitHub Actions deploys, store the
-D1 database id in `CLOUDFLARE_D1_DATABASE_ID`; the workflow generates an
-uncommitted `wrangler.production.generated.toml` at deploy time.
+D1 database id in `CLOUDFLARE_D1_DATABASE_ID`. The media bucket name defaults
+to `vtdd-media-prod` and can be overridden with repository variable
+`CLOUDFLARE_MEDIA_R2_BUCKET_NAME`. The workflow generates an uncommitted
+`wrangler.production.generated.toml` at deploy time.
 
 If `/setup/known-good` should expose a rollback bundle, the preferred source of
 truth is `docs/setup/known-good.json` with the last human-verified stable setup

--- a/test/production-deploy-path.test.js
+++ b/test/production-deploy-path.test.js
@@ -33,6 +33,9 @@ test("production deploy doc defines the governed GitHub Actions deploy path", ()
   assert.equal(doc.includes("docs/setup/cloudflare-deploy-secret-sync.md"), true);
   assert.equal(doc.includes("Worker runtime secrets"), true);
   assert.equal(doc.includes("`VTDD_MEMORY_D1`"), true);
+  assert.equal(doc.includes("`VTDD_MEDIA_R2`"), true);
+  assert.equal(doc.includes("`CLOUDFLARE_MEDIA_R2_BUCKET_NAME`"), true);
+  assert.equal(doc.includes("`vtdd-media-prod`"), true);
   assert.equal(doc.includes("real passkey registration"), true);
   assert.equal(doc.includes("owner-specific Cloudflare"), true);
   assert.equal(doc.includes("must not be committed"), true);
@@ -102,6 +105,7 @@ test("deploy-production workflow enforces the MVP production deploy boundary", (
   );
   assert.equal(workflow.includes("Generate production Wrangler config"), true);
   assert.equal(workflow.includes("VTDD_GITHUB_ACTIONS_REPOSITORY: ${{ github.repository }}"), true);
+  assert.equal(workflow.includes("CLOUDFLARE_MEDIA_R2_BUCKET_NAME: ${{ vars.CLOUDFLARE_MEDIA_R2_BUCKET_NAME || 'vtdd-media-prod' }}"), true);
   assert.equal(workflow.includes("VTDD_KNOWN_GOOD_COMMIT_SHA: ${{ vars.VTDD_KNOWN_GOOD_COMMIT_SHA }}"), true);
   assert.equal(workflow.includes("VTDD_DASHBOARD_ALLOWED_EMAILS: ${{ vars.VTDD_DASHBOARD_ALLOWED_EMAILS }}"), true);
   assert.equal(
@@ -145,6 +149,9 @@ test("deploy-production workflow enforces the MVP production deploy boundary", (
   assert.equal(workflow.includes("[[env.production.d1_databases]]"), true);
   assert.equal(workflow.includes('binding = "VTDD_MEMORY_D1"'), true);
   assert.equal(workflow.includes('database_id = "$CLOUDFLARE_D1_DATABASE_ID"'), true);
+  assert.equal(workflow.includes("[[env.production.r2_buckets]]"), true);
+  assert.equal(workflow.includes('binding = "VTDD_MEDIA_R2"'), true);
+  assert.equal(workflow.includes('bucket_name = "$CLOUDFLARE_MEDIA_R2_BUCKET_NAME"'), true);
   assert.equal(
     workflow.includes("command: deploy --config wrangler.production.generated.toml --env production"),
     true


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #498 の Dashboard Butler media upload を production deploy で R2 binding missing にしないため、Cloudflare Workers production config 生成に VTDD_MEDIA_R2 を接続します。

## Satisfied Success Criteria

- Dashboard Butler upload runtime が要求する VTDD_MEDIA_R2 binding を production deploy の generated Wrangler config に追加しました。
Issue #498 の R2/D1 分離方針に合わせ、bucket 名は vtdd-media-prod を既定値にし、CLOUDFLARE_MEDIA_R2_BUCKET_NAME で operator が差し替え可能にしました。
production deploy path doc と workflow contract test に R2 binding を追加しました。

## Unsatisfied Success Criteria

- Issue #498 全体の iPhone live E2E、client-side resize/compress、OCR/summary/RAG reference 自動接続、VPS Codex 画像解析接続はこの PR では未完了です。
Cloudflare R2 bucket 作成や credential/permission mutation はこの PR では実行していません。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #498
- Implementing Success Criteria: Dashboard Butler chat の画像添付が production runtime で R2 binding missing によって失敗しないこと。画像本体を R2、metadata を D1 に分離する runtime 前提を deploy config に接続すること。
- Explicit Non-goals: R2 bucket 作成、Cloudflare credential mutation、permission mutation、deploy 実行、OCR/RAG 自動要約、Issue #498 close は対象外。
- Expected touched files/routes/workflows: .github/workflows/deploy-production.yml、docs/mvp/production-deploy-path.md、test/production-deploy-path.test.js
- Affected Issues: Issue #498
- Affected PRs: PR #506 の production deploy 後に発覚した binding 接続漏れを修正します。
- Affected workflows: deploy-production workflow の generated Wrangler config。passkey approval boundary と production environment gate は維持します。
- Affected runtime/operator surfaces: Dashboard Butler media upload route /v2/media/upload、Cloudflare Worker production runtime、Cloudflare R2 binding VTDD_MEDIA_R2。
- What may break if we patch narrowly: bucket 名や R2 binding を owner-specific config に固定すると public/core 再利用性を壊すため、repo 仕様の既定値と GitHub variable override に限定します。
- Unknowns to investigate before coding: production account に vtdd-media-prod bucket が存在するかはこの PR では作成しません。存在しない場合、次の deploy で Cloudflare 側が明示的に失敗します。
- Validation needed: node --test test/production-deploy-path.test.js test/media-storage-spec.test.js と npm test。merge 後は scoped passkey deploy と iPhone Dashboard Butler upload 再確認が必要です。
- Stop condition: R2 bucket 作成、secret/variable mutation、permission mutation、deploy 実行が必要になった場合は passkey approval が必要なので、この PR では停止します。

## File / Line Hypotheses

- file: .github/workflows/deploy-production.yml
  - hypothesis: generated production TOML に [[env.production.r2_buckets]] がないため、runtime env.VTDD_MEDIA_R2 が未設定になる。
  - risk if changed narrowly: passkey approval/deploy boundary を壊すと high-risk deploy 経路が弱くなる。
  - validation: workflow contract test と npm test。
  - related Issue: Issue #498
- file: docs/mvp/production-deploy-path.md
  - hypothesis: production binding requirements が D1 のみで、R2 media binding が deploy 前提に入っていない。
  - risk if changed narrowly: operator が deploy 後に同じ binding missing を再発させる。
  - validation: doc contract test。
  - related Issue: Issue #498

## Hypothesis Retrospective

- expected: PR #506 deploy 後、/v2/media/upload が VTDD_MEDIA_R2 missing で失敗した原因は deploy generated config の binding 漏れ。
- actual: .github/workflows/deploy-production.yml は VTDD_MEMORY_D1 のみを generated config に追加していた。
- mismatch: runtime implementation と deploy config の接続が PR #506 で揃っていなかった。
- lesson: R2/D1 runtime slice では deploy generated config も Success Criteria に含める。
- should become RAG candidate: はい。Issue #498 の deploy binding 漏れとして残す価値があります。

## Verification Evidence

- Unit: node --test test/production-deploy-path.test.js test/media-storage-spec.test.js: pass 8/8
- Integration: npm test: pass 938/939, skipped 1。check:self-parity と check:generated-worker も pass。
- E2E: 未実施。merge 後に scoped passkey deploy と iPhone Dashboard Butler upload を再確認します。
- Manual: iPhone Dashboard Butler で Cloudflare R2 binding VTDD_MEDIA_R2 is not configured を確認済み。
- Evidence path/link: test/production-deploy-path.test.js、docs/mvp/production-deploy-path.md、.github/workflows/deploy-production.yml

## Butler Completion Contract

- Owner goal: iPhone Dashboard Butler から画像を添付したとき、production runtime が R2 binding missing で止まらないようにする。
- Butler entrypoint: Dashboard Butler の + 添付ボタンから /v2/media/upload に到達する既存導線。
- Action Schema exposure: Custom GPT Action Schema は対象外。Dashboard Butler の runtime/deploy 接続のみ。
- Runtime path: Dashboard Butler -> /v2/media/upload -> VTDD_MEDIA_R2 put -> VTDD_MEMORY_D1 vtdd_media_objects metadata。
- Runner/runtime truth: PR #506 deploy 後に production runtime で VTDD_MEDIA_R2 missing が表示されたため、deploy generated config に binding を追加。
- Authority boundary: deploy 実行、Cloudflare bucket 作成、credential/permission mutation は scoped passkey approval が必要。この PR では実行しません。
- E2E evidence: 未実施。merge/deploy 後に iPhone Dashboard Butler upload で再確認が必要。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 必要。merge 後、scoped passkey deploy で PR 内容を production に反映する。
- Custom GPT Action Schema update: 不要。Dashboard Butler 対象のため Custom GPT 更新はしません。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 必要。deploy 後に画像添付が R2 binding missing で止まらないことを確認する。

## Related Constitution Rules

- AGENTS.md Drift Stop Protocol
AGENTS.md Authority Boundary
AGENTS.md Public Repo Collaboration Boundary
Issue #498 Success Criteria
docs/media/cloudflare-r2-media-storage.md

## Out-of-scope but NOT implemented

- R2 bucket 作成は未実施。
Issue #498 close は未実施。
OCR/RAG 自動要約と VPS Codex 画像解析は未実装。

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #498
- Execution ID: mac_codex_only_probe:issue-498-r2-binding
- Goal: Issue #498 production R2 binding gap fix
