### PR TITLE
Issue #498 deploy operator を passkey 承認後に自動 dispatch する

### DIFF
--- a/src/core/passkey-operator-page.js
+++ b/src/core/passkey-operator-page.js
@@ -232,13 +232,13 @@ export function renderPasskeyOperatorPage(input = {}) {
 
         <section data-operator-section="production-deploy"${hiddenAttribute(!sectionVisibility.productionDeploy)}>
           <h2>4. Production Deploy</h2>
-          <p class="muted">deploy stale を検知したあと、取得済みの <code>approvalGrantId</code> を使って same-origin の governed deploy path を dispatch します。</p>
+          <p class="muted">deploy stale を検知したあと、real passkey approval が成功したら同じ <code>approvalGrantId</code> で same-origin の governed deploy path を自動 dispatch します。</p>
           <div class="row">
             <button id="deploy-button">Dispatch production deploy</button>
             <a class="button-link" id="deploy-run-link" href="#" target="_blank" rel="noopener noreferrer" hidden>Open deploy run</a>
             <a class="button-link" id="return-to-butler-link" href="${returnUrl}" rel="noopener noreferrer"${returnUrl ? "" : " hidden"}>Return to Butler</a>
           </div>
-          <p class="muted">この Worker origin を <code>runtimeUrl</code> として使います。実行後は deploy run link で完了状態を確認できます。</p>
+          <p class="muted">この Worker origin を <code>runtimeUrl</code> として使います。手動ボタンは失敗時の再実行用です。完了または失敗は Dashboard 通知センターと保存済み Web Push 購読へ届きます。</p>
           <pre id="deploy-output"></pre>
         </section>
 
@@ -540,6 +540,40 @@ export function renderPasskeyOperatorPage(input = {}) {
         return readNumberInput("pull-number-input");
       }
 
+      function shouldAutoDispatchProductionDeploy() {
+        return operatorMode === "deploy" &&
+          document.getElementById("action-type-input").value === "deploy_production" &&
+          document.getElementById("risk-kind-input").value === "deploy_production";
+      }
+
+      async function dispatchProductionDeploy({ source = "manual" } = {}) {
+        if (!latestApprovalGrantId) {
+          throw new Error("approvalGrantId is required before production deploy");
+        }
+        const repositoryInput = readRequiredRepositoryInput();
+        clearDeployRunLink();
+        deployOutput.textContent = source === "approval"
+          ? "passkey approval accepted. production deploy request..."
+          : "production deploy request...";
+        const deployResponse = await fetch("${apiBase}/action/deploy", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            repository: repositoryInput,
+            issueNumber: Number(document.getElementById("issue-input").value || 0) || null,
+            policyInput: {
+              approvalGrantId: latestApprovalGrantId
+            }
+          })
+        });
+        const deployBody = await readResponseBody(deployResponse);
+        if (!deployResponse.ok) {
+          throw responseError(deployBody, "production deploy failed");
+        }
+        showDeployRunLink(deployBody);
+        deployOutput.textContent = JSON.stringify(deployBody, null, 2);
+      }
+
       copyApprovalGrantButton.addEventListener("click", async () => {
         try {
           await copyApprovalGrantIdToClipboard();
@@ -645,6 +679,13 @@ export function renderPasskeyOperatorPage(input = {}) {
               approveOutput.textContent = approveOutput.textContent + "\\n\\nAuto-copy failed: " + String(error);
             }
           }
+          if (shouldAutoDispatchProductionDeploy()) {
+            try {
+              await dispatchProductionDeploy({ source: "approval" });
+            } catch (error) {
+              deployOutput.textContent = String(error);
+            }
+          }
         } catch (error) {
           approveOutput.textContent = String(error);
         }
@@ -682,29 +723,7 @@ export function renderPasskeyOperatorPage(input = {}) {
 
       document.getElementById("deploy-button").addEventListener("click", async () => {
         try {
-          if (!latestApprovalGrantId) {
-            throw new Error("approvalGrantId is required before production deploy");
-          }
-          const repositoryInput = readRequiredRepositoryInput();
-          clearDeployRunLink();
-          deployOutput.textContent = "production deploy request...";
-          const deployResponse = await fetch("${apiBase}/action/deploy", {
-            method: "POST",
-            headers: { "content-type": "application/json" },
-            body: JSON.stringify({
-              repository: repositoryInput,
-              issueNumber: Number(document.getElementById("issue-input").value || 0) || null,
-              policyInput: {
-                approvalGrantId: latestApprovalGrantId
-              }
-            })
-          });
-          const deployBody = await readResponseBody(deployResponse);
-          if (!deployResponse.ok) {
-            throw responseError(deployBody, "production deploy failed");
-          }
-          showDeployRunLink(deployBody);
-          deployOutput.textContent = JSON.stringify(deployBody, null, 2);
+          await dispatchProductionDeploy();
         } catch (error) {
           deployOutput.textContent = String(error);
         }
@@ -1014,8 +1033,9 @@ export function resolvePasskeyOperatorMode(input = {}) {
 function resolveSectionVisibility(operatorMode, options = {}) {
   const full = operatorMode === "full";
   const passkeyEnabled = options.passkeyEnabled !== false;
+  const registrationMode = full || operatorMode === "register";
   return {
-    registration: passkeyEnabled,
+    registration: passkeyEnabled && registrationMode,
     approval: passkeyEnabled,
     githubAppSecretSync: full || operatorMode === "github_app_secret_sync",
     productionDeploy: full || operatorMode === "deploy",
@@ -1038,7 +1058,7 @@ function renderGithubAppRoleOption(value, label, selectedValue) {
 
 function normalizeOperatorMode(value) {
   const token = normalizeOperatorToken(value);
-  if (["full", "deploy", "merge", "issue_close", "github_app_secret_sync", "github_actions_secret_sync", "gateway_bearer_vault", "vps", "dashboard"].includes(token)) {
+  if (["full", "register", "deploy", "merge", "issue_close", "github_app_secret_sync", "github_actions_secret_sync", "gateway_bearer_vault", "vps", "dashboard"].includes(token)) {
     return token;
   }
   if (token === "dashboard_access") {

--- a/test/passkey-operator-page.test.js
+++ b/test/passkey-operator-page.test.js
@@ -121,7 +121,7 @@ test("passkey operator page focuses deploy mode on deploy approval and dispatch 
     returnUrl: "https://chatgpt.com/g/example-butler"
   });
 
-  assert.equal(html.includes('<section data-operator-section="registration">'), true);
+  assert.equal(html.includes('<section data-operator-section="registration" hidden>'), true);
   assert.equal(html.includes('<section data-operator-section="approval">'), true);
   assert.equal(html.includes('<section data-operator-section="production-deploy">'), true);
   assert.equal(html.includes('<section data-operator-section="pr-merge" hidden>'), true);
@@ -129,10 +129,19 @@ test("passkey operator page focuses deploy mode on deploy approval and dispatch 
   assert.equal(html.includes('<section data-operator-section="github-app-secret-sync" hidden>'), true);
   assert.equal(html.includes('<section data-operator-section="github-actions-secret-sync" hidden>'), true);
   assert.equal(html.includes("Dispatch production deploy"), true);
+  assert.equal(html.includes("自動 dispatch"), true);
+  assert.equal(html.includes("手動ボタンは失敗時の再実行用です"), true);
+  assert.equal(html.includes("Dashboard 通知センターと保存済み Web Push 購読へ届きます"), true);
   assert.equal(html.includes("Return to Butler"), true);
   assert.equal(html.includes('id="issue-input" value=""'), true);
   assert.equal(html.includes('id="pull-number-input" value=""'), true);
   assert.equal(html.includes('repository: repositoryInput'), true);
+  assert.equal(html.includes("function shouldAutoDispatchProductionDeploy()"), true);
+  assert.equal(html.includes('operatorMode === "deploy"'), true);
+  assert.equal(html.includes('document.getElementById("action-type-input").value === "deploy_production"'), true);
+  assert.equal(html.includes('document.getElementById("risk-kind-input").value === "deploy_production"'), true);
+  assert.equal(html.includes('await dispatchProductionDeploy({ source: "approval" });'), true);
+  assert.equal(html.includes('passkey approval accepted. production deploy request...'), true);
 });
 
 test("passkey operator page blocks approval and deploy before repositoryInput is present", () => {
@@ -147,6 +156,7 @@ test("passkey operator page blocks approval and deploy before repositoryInput is
   assert.equal(html.includes("repositoryInput is required before approval/deploy"), true);
   assert.equal(html.includes("Deploy does not require issueNumber or pullNumber"), true);
   assert.equal(html.includes("repository: repositoryInput"), true);
+  assert.equal(html.includes("async function dispatchProductionDeploy"), true);
 });
 
 test("passkey operator page fills safe approval defaults from explicit mode", () => {
@@ -155,6 +165,7 @@ test("passkey operator page fills safe approval defaults from explicit mode", ()
     repositoryInput: "marushu/vtdd-v2-p"
   });
 
+  assert.equal(deployHtml.includes('<section data-operator-section="registration" hidden>'), true);
   assert.equal(deployHtml.includes('id="action-type-input" value="deploy_production"'), true);
   assert.equal(deployHtml.includes('id="risk-kind-input" value="deploy_production"'), true);
   assert.equal(deployHtml.includes('<section data-operator-section="production-deploy">'), true);
@@ -167,6 +178,7 @@ test("passkey operator page fills safe approval defaults from explicit mode", ()
 
   assert.equal(mergeHtml.includes('id="action-type-input" value="merge"'), true);
   assert.equal(mergeHtml.includes('id="risk-kind-input" value="pull_merge"'), true);
+  assert.equal(mergeHtml.includes('<section data-operator-section="registration" hidden>'), true);
   assert.equal(mergeHtml.includes('<section data-operator-section="pr-merge">'), true);
   assert.equal(mergeHtml.includes('<section data-operator-section="issue-close" hidden>'), true);
 
@@ -198,6 +210,28 @@ test("passkey operator page fills safe approval defaults from explicit mode", ()
   );
 });
 
+test("passkey operator page shows registration only for full or explicit registration mode", () => {
+  const fullHtml = renderPasskeyOperatorPage({
+    operatorMode: "full",
+    repositoryInput: "marushu/vtdd-v2-p"
+  });
+  assert.equal(fullHtml.includes('<section data-operator-section="registration">'), true);
+
+  const registerHtml = renderPasskeyOperatorPage({
+    operatorMode: "register",
+    repositoryInput: "marushu/vtdd-v2-p"
+  });
+  assert.equal(registerHtml.includes('<section data-operator-section="registration">'), true);
+  assert.equal(registerHtml.includes('<section data-operator-section="production-deploy" hidden>'), true);
+
+  const dashboardHtml = renderPasskeyOperatorPage({
+    operatorMode: "dashboard",
+    repositoryInput: "marushu/vtdd-v2-p"
+  });
+  assert.equal(dashboardHtml.includes('<section data-operator-section="registration" hidden>'), true);
+  assert.equal(dashboardHtml.includes('<section data-operator-section="approval">'), true);
+});
+
 test("passkey operator page focuses merge mode on approval and PR merge sections", () => {
   const html = renderPasskeyOperatorPage({
     repositoryInput: "marushu/vtdd-v2-p",
@@ -206,7 +240,7 @@ test("passkey operator page focuses merge mode on approval and PR merge sections
     highRiskKind: "pull_merge"
   });
 
-  assert.equal(html.includes('<section data-operator-section="registration">'), true);
+  assert.equal(html.includes('<section data-operator-section="registration" hidden>'), true);
   assert.equal(html.includes('<section data-operator-section="approval">'), true);
   assert.equal(html.includes('<section data-operator-section="pr-merge">'), true);
   assert.equal(html.includes('<section data-operator-section="issue-close" hidden>'), true);

--- a/worker.js
+++ b/worker.js
@@ -27473,13 +27473,13 @@ function renderPasskeyOperatorPage(input = {}) {
 
         <section data-operator-section="production-deploy"${hiddenAttribute(!sectionVisibility.productionDeploy)}>
           <h2>4. Production Deploy</h2>
-          <p class="muted">deploy stale \u3092\u691C\u77E5\u3057\u305F\u3042\u3068\u3001\u53D6\u5F97\u6E08\u307F\u306E <code>approvalGrantId</code> \u3092\u4F7F\u3063\u3066 same-origin \u306E governed deploy path \u3092 dispatch \u3057\u307E\u3059\u3002</p>
+          <p class="muted">deploy stale \u3092\u691C\u77E5\u3057\u305F\u3042\u3068\u3001real passkey approval \u304C\u6210\u529F\u3057\u305F\u3089\u540C\u3058 <code>approvalGrantId</code> \u3067 same-origin \u306E governed deploy path \u3092\u81EA\u52D5 dispatch \u3057\u307E\u3059\u3002</p>
           <div class="row">
             <button id="deploy-button">Dispatch production deploy</button>
             <a class="button-link" id="deploy-run-link" href="#" target="_blank" rel="noopener noreferrer" hidden>Open deploy run</a>
             <a class="button-link" id="return-to-butler-link" href="${returnUrl}" rel="noopener noreferrer"${returnUrl ? "" : " hidden"}>Return to Butler</a>
           </div>
-          <p class="muted">\u3053\u306E Worker origin \u3092 <code>runtimeUrl</code> \u3068\u3057\u3066\u4F7F\u3044\u307E\u3059\u3002\u5B9F\u884C\u5F8C\u306F deploy run link \u3067\u5B8C\u4E86\u72B6\u614B\u3092\u78BA\u8A8D\u3067\u304D\u307E\u3059\u3002</p>
+          <p class="muted">\u3053\u306E Worker origin \u3092 <code>runtimeUrl</code> \u3068\u3057\u3066\u4F7F\u3044\u307E\u3059\u3002\u624B\u52D5\u30DC\u30BF\u30F3\u306F\u5931\u6557\u6642\u306E\u518D\u5B9F\u884C\u7528\u3067\u3059\u3002\u5B8C\u4E86\u307E\u305F\u306F\u5931\u6557\u306F Dashboard \u901A\u77E5\u30BB\u30F3\u30BF\u30FC\u3068\u4FDD\u5B58\u6E08\u307F Web Push \u8CFC\u8AAD\u3078\u5C4A\u304D\u307E\u3059\u3002</p>
           <pre id="deploy-output"></pre>
         </section>
 
@@ -27781,6 +27781,40 @@ function renderPasskeyOperatorPage(input = {}) {
         return readNumberInput("pull-number-input");
       }
 
+      function shouldAutoDispatchProductionDeploy() {
+        return operatorMode === "deploy" &&
+          document.getElementById("action-type-input").value === "deploy_production" &&
+          document.getElementById("risk-kind-input").value === "deploy_production";
+      }
+
+      async function dispatchProductionDeploy({ source = "manual" } = {}) {
+        if (!latestApprovalGrantId) {
+          throw new Error("approvalGrantId is required before production deploy");
+        }
+        const repositoryInput = readRequiredRepositoryInput();
+        clearDeployRunLink();
+        deployOutput.textContent = source === "approval"
+          ? "passkey approval accepted. production deploy request..."
+          : "production deploy request...";
+        const deployResponse = await fetch("${apiBase}/action/deploy", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            repository: repositoryInput,
+            issueNumber: Number(document.getElementById("issue-input").value || 0) || null,
+            policyInput: {
+              approvalGrantId: latestApprovalGrantId
+            }
+          })
+        });
+        const deployBody = await readResponseBody(deployResponse);
+        if (!deployResponse.ok) {
+          throw responseError(deployBody, "production deploy failed");
+        }
+        showDeployRunLink(deployBody);
+        deployOutput.textContent = JSON.stringify(deployBody, null, 2);
+      }
+
       copyApprovalGrantButton.addEventListener("click", async () => {
         try {
           await copyApprovalGrantIdToClipboard();
@@ -27886,6 +27920,13 @@ function renderPasskeyOperatorPage(input = {}) {
               approveOutput.textContent = approveOutput.textContent + "\\n\\nAuto-copy failed: " + String(error);
             }
           }
+          if (shouldAutoDispatchProductionDeploy()) {
+            try {
+              await dispatchProductionDeploy({ source: "approval" });
+            } catch (error) {
+              deployOutput.textContent = String(error);
+            }
+          }
         } catch (error) {
           approveOutput.textContent = String(error);
         }
@@ -27923,29 +27964,7 @@ function renderPasskeyOperatorPage(input = {}) {
 
       document.getElementById("deploy-button").addEventListener("click", async () => {
         try {
-          if (!latestApprovalGrantId) {
-            throw new Error("approvalGrantId is required before production deploy");
-          }
-          const repositoryInput = readRequiredRepositoryInput();
-          clearDeployRunLink();
-          deployOutput.textContent = "production deploy request...";
-          const deployResponse = await fetch("${apiBase}/action/deploy", {
-            method: "POST",
-            headers: { "content-type": "application/json" },
-            body: JSON.stringify({
-              repository: repositoryInput,
-              issueNumber: Number(document.getElementById("issue-input").value || 0) || null,
-              policyInput: {
-                approvalGrantId: latestApprovalGrantId
-              }
-            })
-          });
-          const deployBody = await readResponseBody(deployResponse);
-          if (!deployResponse.ok) {
-            throw responseError(deployBody, "production deploy failed");
-          }
-          showDeployRunLink(deployBody);
-          deployOutput.textContent = JSON.stringify(deployBody, null, 2);
+          await dispatchProductionDeploy();
         } catch (error) {
           deployOutput.textContent = String(error);
         }
@@ -28250,8 +28269,9 @@ function resolvePasskeyOperatorMode(input = {}) {
 function resolveSectionVisibility(operatorMode, options = {}) {
   const full = operatorMode === "full";
   const passkeyEnabled = options.passkeyEnabled !== false;
+  const registrationMode = full || operatorMode === "register";
   return {
-    registration: passkeyEnabled,
+    registration: passkeyEnabled && registrationMode,
     approval: passkeyEnabled,
     githubAppSecretSync: full || operatorMode === "github_app_secret_sync",
     productionDeploy: full || operatorMode === "deploy",
@@ -28271,7 +28291,7 @@ function renderGithubAppRoleOption(value, label, selectedValue) {
 }
 function normalizeOperatorMode(value) {
   const token = normalizeOperatorToken(value);
-  if (["full", "deploy", "merge", "issue_close", "github_app_secret_sync", "github_actions_secret_sync", "gateway_bearer_vault", "vps", "dashboard"].includes(token)) {
+  if (["full", "register", "deploy", "merge", "issue_close", "github_app_secret_sync", "github_actions_secret_sync", "gateway_bearer_vault", "vps", "dashboard"].includes(token)) {
     return token;
   }
   if (token === "dashboard_access") {


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #498 の deploy recovery/operator UX を iPhone-first に寄せ、scoped passkey approval 後に production deploy を自動 dispatch し、不要な Passkey 登録表示を scoped operator から外します。

## Satisfied Success Criteria

- deploy_production scope の passkey approval verify 成功後、same-origin /v2/action/deploy を同じ approvalGrantId で自動 dispatch するようにしました。
Dispatch production deploy ボタンは失敗時の再実行用として残しました。
deploy/merge/dashboard など scoped operator mode では Passkey 登録セクションを hidden にし、full/register mode の初回登録・復旧用だけ表示するようにしました。
operator 画面に、deploy 完了/失敗は Dashboard 通知センターと保存済み Web Push 購読へ届くことを明記しました。

## Unsatisfied Success Criteria

- Issue #498 全体の iPhone live E2E、OCR/summary/RAG reference 自動接続、VPS Codex 画像解析接続、Issue close はこの PR では未完了です。
Web Push 購読自体の新規設定や OS 通知 permission 変更はこの PR では実行していません。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #498
- Implementing Success Criteria: Passkey deploy operator で承認後に追加の手動 deploy ボタン押下を不要にする。毎回不要な Passkey 登録フォームを scoped deploy/merge/dashboard operator で表示しない。
- Explicit Non-goals: passkey 省略、deploy authority 境界の緩和、credential/permission mutation、Cloudflare deploy 実行、OS 通知 permission 操作、Issue #498 close は対象外。
- Expected touched files/routes/workflows: src/core/passkey-operator-page.js、test/passkey-operator-page.test.js、worker.js
- Affected Issues: Issue #498
- Affected PRs: PR #507 の deploy operator URL 体験を改善する後続 UX 修正です。
- Affected workflows: deploy-production workflow は未変更。既存の dashboard deploy event / Web Push 通知経路を前提にします。
- Affected runtime/operator surfaces: Passkey operator page、/v2/action/deploy same-origin dispatch、Dashboard 通知センター、保存済み Web Push 購読。
- What may break if we patch narrowly: passkey 登録を完全に消すと初回 bootstrap/復旧導線が失われるため、full/register mode には残し、scoped operator だけ hidden にします。
- Unknowns to investigate before coding: 実機 iOS/macOS の Web Push 購読状態は operator UI からは確認していません。deploy completion event の server-side path は既存テストで確認済みです。
- Validation needed: node --test test/passkey-operator-page.test.js test/worker.test.js --test-name-pattern 'passkey operator|governed production deploy|deploy completion event' と npm test。merge/deploy 後に iPhone で passkey approval -> auto deploy dispatch -> 通知確認が必要です。
- Stop condition: deploy 実行、push permission 操作、credential/permission mutation が必要になった場合は passkey approval または owner 操作が必要なので、この PR では停止します。

## File / Line Hypotheses

- file: src/core/passkey-operator-page.js
  - hypothesis: approval verify success 後に latestApprovalGrantId を保持しているため、deploy mode では同じ grant で /v2/action/deploy を自動 dispatch できる。
  - risk if changed narrowly: deploy 以外の high-risk action まで自動実行すると authority boundary を壊す。
  - validation: deploy_production actionType/highRiskKind/operatorMode の三条件で限定し、passkey operator tests と worker deploy tests を実行。
  - related Issue: Issue #498
- file: test/passkey-operator-page.test.js
  - hypothesis: scoped operator では registration section hidden、full/register mode では visible を contract として固定できる。
  - risk if changed narrowly: 初回登録/復旧手段を消すと bootstrap が詰まる。
  - validation: registration visibility tests。
  - related Issue: Issue #498

## Hypothesis Retrospective

- expected: iPhone operator では passkey approval 後に deploy が自動 dispatch され、登録フォームは scoped mode で見えない。
- actual: 実装は deploy_production scope のみに auto dispatch を限定し、registration は full/register mode のみに残した。
- mismatch: なし。
- lesson: high-risk UX は承認そのものを唯一の明示操作にし、同一 scope の後続 dispatch は同じ画面内で自動化する。
- should become RAG candidate: はい。deploy operator UX と registration visibility の判断として残す価値があります。

## Verification Evidence

- Unit: node --test test/passkey-operator-page.test.js test/worker.test.js --test-name-pattern 'passkey operator|governed production deploy|deploy completion event': pass 210/210
- Integration: npm test: pass 939/940, skipped 1。check:self-parity と check:generated-worker も pass。
- E2E: 未実施。merge/deploy 後に iPhone operator で passkey approval だけで deploy dispatch されることを確認します。
- Manual: ユーザーの iPhone 画面で Passkey 登録が毎回出ること、Dispatch production deploy の二度押しが必要なことを確認済み。
- Evidence path/link: src/core/passkey-operator-page.js、test/passkey-operator-page.test.js、worker.js

## Butler Completion Contract

- Owner goal: iPhone で deploy operator を開いたら、Passkey 承認だけで deploy が走り、完了/失敗は Butler/Dashboard/iOS/macOS 通知で追えるようにする。
- Butler entrypoint: Dashboard/Butler から出す deploy operator URL。
- Action Schema exposure: Custom GPT Action Schema は対象外。Dashboard Butler/passkey operator の UX 修正のみ。
- Runtime path: Passkey operator -> /v2/approval/passkey/challenge -> /v2/approval/passkey/verify -> /v2/action/deploy -> deploy-production -> /v2/events/github-actions -> Dashboard 通知/Web Push。
- Runner/runtime truth: 既存 workflow は deploy completion event を runtime に通知し、worker tests は dashboard event と Web Push delivery を確認済み。
- Authority boundary: deploy は引き続き real passkey approval が必須。approvalGrantId 取得後の同一 scoped deploy dispatch だけを自動化し、passkey 省略はしません。
- E2E evidence: 未実施。merge/deploy 後に iPhone 実機で確認します。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 必要。merge 後、scoped passkey deploy で operator UI を production に反映する。
- Custom GPT Action Schema update: 不要。Dashboard Butler 対象のため Custom GPT 更新はしません。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 必要。deploy 後に iPhone operator で registration hidden、passkey approval 後 auto deploy dispatch、通知到達を確認する。

## Related Constitution Rules

- AGENTS.md Authority Boundary
AGENTS.md Butler Completion Gate
AGENTS.md Evidence Discipline
Issue #498 Success Criteria

## Out-of-scope but NOT implemented

- passkey 登録機能そのものの削除は未実施。
Web Push permission 自動変更は未実施。
Issue #498 close は未実施。

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #498
- Execution ID: mac_codex_only_probe:issue-498-deploy-operator-auto-dispatch
- Goal: Issue #498 deploy operator passkey UX
