### PR TITLE
Issue #498 deploy 前に R2 media bucket を preflight する

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -123,6 +123,61 @@ jobs:
           echo "Cloudflare account/token is not currently able to access Workers Scripts deploy API. Do not consume another deploy approval until this passes."
           exit 1
 
+      - name: Preflight Cloudflare R2 media bucket
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_MEDIA_R2_BUCKET_NAME: ${{ vars.CLOUDFLARE_MEDIA_R2_BUCKET_NAME || 'vtdd-media-prod' }}
+        shell: bash
+        run: |
+          response_file="$(mktemp)"
+          encoded_bucket="$(
+            node -e 'console.log(encodeURIComponent(process.argv[1] || ""))' "$CLOUDFLARE_MEDIA_R2_BUCKET_NAME"
+          )"
+          http_code="$(
+            curl --show-error --silent \
+              -o "$response_file" \
+              -w "%{http_code}" \
+              -H "authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
+              -H "content-type: application/json" \
+              "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/r2/buckets/${encoded_bucket}" || true
+          )"
+
+          if [ "$http_code" -ge 200 ] && [ "$http_code" -lt 300 ]; then
+            rm -f "$response_file"
+            echo "Cloudflare R2 media bucket preflight passed."
+            exit 0
+          fi
+
+          echo "Cloudflare R2 media bucket preflight failed before passkey approval validation."
+          echo "HTTP status: ${http_code}"
+          node - "$response_file" <<'NODE'
+          const fs = require("node:fs");
+          const path = process.argv[2];
+          const raw = fs.readFileSync(path, "utf8");
+          let body;
+          try {
+            body = JSON.parse(raw);
+          } catch {
+            const redacted = raw.replace(/([A-Za-z0-9_-]{24,})/g, "[redacted]");
+            console.log(redacted.slice(0, 1000));
+            process.exit(0);
+          }
+          const errors = Array.isArray(body?.errors) ? body.errors : [];
+          const messages = errors.map((error) => ({
+            code: error?.code ?? null,
+            message: String(error?.message ?? "unknown_error").replace(/([A-Za-z0-9_-]{24,})/g, "[redacted]")
+          }));
+          if (messages.length > 0) {
+            console.log(JSON.stringify({ errors: messages }, null, 2));
+          } else {
+            console.log(JSON.stringify({ success: body?.success ?? null }, null, 2));
+          }
+          NODE
+          rm -f "$response_file"
+          echo "Cloudflare account/token cannot access the configured R2 media bucket. Enable R2 in the Cloudflare Dashboard, create or select the bucket, and ensure the deploy token can read R2 buckets before requesting another deploy approval."
+          exit 1
+
       - name: Checkout
         uses: actions/checkout@v6
 

--- a/test/production-deploy-path.test.js
+++ b/test/production-deploy-path.test.js
@@ -87,9 +87,22 @@ test("deploy-production workflow enforces the MVP production deploy boundary", (
     ),
     true
   );
+  assert.equal(workflow.includes("Preflight Cloudflare R2 media bucket"), true);
+  assert.equal(workflow.includes("/r2/buckets/${encoded_bucket}"), true);
+  assert.equal(workflow.includes("Cloudflare R2 media bucket preflight failed before passkey approval validation."), true);
+  assert.equal(workflow.includes("Please enable R2"), false);
+  assert.equal(
+    workflow.includes("Enable R2 in the Cloudflare Dashboard, create or select the bucket"),
+    true
+  );
   assert.equal(workflow.includes("Validate real passkey approval grant"), true);
   assert.equal(
     workflow.indexOf("Preflight Cloudflare Workers deploy entitlement") <
+      workflow.indexOf("Validate real passkey approval grant"),
+    true
+  );
+  assert.equal(
+    workflow.indexOf("Preflight Cloudflare R2 media bucket") <
       workflow.indexOf("Validate real passkey approval grant"),
     true
   );


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #498 の production deploy で R2 media bucket が未有効または未到達な場合、passkey approval を消費する前に workflow が明示的に止まるようにする。

## Satisfied Success Criteria

- production deploy workflow に Cloudflare R2 media bucket preflight を追加した。\npreflight は Validate real passkey approval grant より前に実行され、R2 未有効・bucket 未作成・token 権限不足を早期に表示する。\ntest/production-deploy-path.test.js で R2 preflight の存在、順序、Cloudflare dashboard での有効化案内を固定した。

## Unsatisfied Success Criteria

- Cloudflare アカウント側の R2 有効化、vtdd-media-prod bucket 作成、deploy token 権限調整は未実施。外部設定変更のため scoped passkey approval が必要。\nIssue #498 の production deploy 成功は未確認。

## Non-goal violations

Cloudflare R2 の有効化、bucket 作成、secret/variable/permission mutation、deploy 実行、Issue close は行わない。

## Dry-run Impact Report

- Target Issue: Issue #498
- Implementing Success Criteria: R2 binding 導入後の production deploy が R2 未設定で落ちる場合、passkey approval validation 前に原因を検出して owner に次の外部設定を提示する。
- Explicit Non-goals: Cloudflare account mutation、R2 bucket creation、deploy token permission mutation、production deploy 実行、Issue close。
- Expected touched files/routes/workflows: .github/workflows/deploy-production.yml / test/production-deploy-path.test.js
- Affected Issues: Issue #498
- Affected PRs: PR #506, PR #507, PR #508 の deploy 経路に関係するが、既存 runtime code は変更しない。
- Affected workflows: deploy-production.yml のみ。
- Affected runtime/operator surfaces: GitHub Actions production deploy operator surface。Butler runtime / Custom GPT Action Schema / Worker route は未変更。
- What may break if we patch narrowly: Cloudflare 側 R2 が未有効なままでは deploy 成功にはならない。この PR は失敗位置を passkey approval 前に移すだけ。
- Unknowns to investigate before coding: Cloudflare account で R2 が有効化済みか、vtdd-media-prod bucket が存在するか、deploy token に R2 bucket read/write 権限があるか。
- Validation needed: node --test test/production-deploy-path.test.js / npm test / GitHub Actions required checks。live deploy は外部 R2 設定後に別途必要。
- Stop condition: R2 有効化や token 権限変更が必要になった場合は、repo code change ではなく scoped passkey approval 境界として停止する。

## File / Line Hypotheses

- file: .github/workflows/deploy-production.yml\n  - hypothesis: Cloudflare Workers entitlement preflight 後、approval validation 前に R2 bucket read preflight を置けば承認消費前に外部設定不足を検出できる。\n  - risk if changed narrowly: R2 API response の secret-like 値をそのまま出すと漏洩リスクがあるため、長い token-like 文字列を redaction する。\n  - validation: workflow text test と npm test。\n  - related Issue: Issue #498\n- file: test/production-deploy-path.test.js\n  - hypothesis: workflow 順序と案内文をテストで固定すれば次回の deploy path 退行を検出できる。\n  - risk if changed narrowly: Cloudflare の exact error 文に依存すると脆いため、repo 側の一般案内文を検証する。\n  - validation: node --test test/production-deploy-path.test.js。\n  - related Issue: Issue #498

## Hypothesis Retrospective

- expected: R2 無効・bucket 不在・token 権限不足のとき Validate real passkey approval grant より前に失敗する。\n- actual: workflow に preflight step を追加し、順序をテストで確認した。live deploy は未実施。\n- mismatch: なし。ただし Cloudflare 側の実設定は未修正。\n- lesson: deploy に必要な外部 storage entitlement は approval 前 preflight に含めるべき。\n- should become RAG candidate: はい。R2 未有効で deploy が失敗した再発防止として記録対象。

## Verification Evidence

- Unit: node --test test/production-deploy-path.test.js passed (4/4).
- Integration: npm test passed: 940 tests, 939 pass, 1 skipped; check:self-parity passed; check:generated-worker passed.
- E2E: 未実施。Cloudflare R2 account setup が未完了のため live production deploy は未確認。
- Manual: GitHub Actions run 26322266858 job 77493439796 failed at Deploy to Cloudflare Workers with Cloudflare R2 code 10042: R2 を Cloudflare Dashboard で有効化する必要あり。
- Evidence path/link: https://github.com/marushu/vtdd-v2-p/actions/runs/26322266858/job/77493439796#step:11:1

## Butler Completion Contract

- Owner goal: production deploy が R2 外部設定不足で落ちる場合、owner が passkey approval を再消費する前に不足設定を把握できる。
- Butler entrypoint: 未変更。今回は GitHub Actions deploy workflow の preflight 改善のみ。
- Action Schema exposure: 未変更。
- Runtime path: deploy-production.yml: Preflight Cloudflare Workers deploy entitlement -> Preflight Cloudflare R2 media bucket -> Validate real passkey approval grant -> Deploy to Cloudflare Workers。
- Runner/runtime truth: 失敗 run は R2 code 10042。修正後は同種不備を approval validation 前に止める想定。
- Authority boundary: R2 有効化、bucket 作成、token 権限変更、deploy 実行は scoped passkey approval が必要。この PR では実行しない。
- E2E evidence: 未実施。deploy 成功 E2E は Cloudflare R2 設定後に必要。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 不要。この PR 自体は deploy workflow の改善で、production deploy 実行はしない。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。

## Related Constitution Rules

- AGENTS.md Drift Stop Protocol。\nAGENTS.md Authority Boundary: deploy / credential / permission mutation は scoped passkey approval 必須。\nAGENTS.md Evidence Discipline。

## Out-of-scope but NOT implemented

- Cloudflare Dashboard での R2 enable。\nvtdd-media-prod bucket 作成または bucket variable 変更。\ndeploy token の R2 権限変更。\nIssue #498 close。

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #498
- Execution ID: mac_codex_only_probe:actions-run-26322266858
- Goal: Issue #498 production deploy R2 blocker を承認前 preflight に移す
