### PR TITLE
Issue #498 repo 未指定 Dashboard media を private unscoped 保存する

### DIFF
--- a/docs/media/cloudflare-r2-media-storage.md
+++ b/docs/media/cloudflare-r2-media-storage.md
@@ -41,6 +41,14 @@ Example:
 media/sample-owner/sample-repo/2026/05/23/01J.../dashboard-screenshot.png
 ```
 
+Dashboard Butler の通常会話で repository がまだ決まっていない private media は、default repository を作らず、unscoped namespace に保存する:
+
+```text
+media/_dashboard/unscoped/{yyyy}/{mm}/{dd}/{uuid}/{filename}
+```
+
+Unscoped media は private conversation attachment としてだけ扱う。Issue / PR / E2E 証跡、`repo_internal`、`public_evidence`、repository search に使う場合は、昇格前に canonical `owner/repo` を明示的に解決する。
+
 The object key must not contain tokens, approval grant IDs, private URLs, or user-entered secret material.
 
 ## D1 Metadata
@@ -118,11 +126,15 @@ DELETE /v2/media/:id
 
 `DELETE /v2/media/:id` requires scoped approval. It must delete or tombstone metadata consistently with R2 object deletion semantics defined by the implementation.
 
+Exception: the Dashboard composer may rollback a private `dashboard_butler` media object from the same abandoned owner send without separate scoped approval. The rollback scope is the exact `source_event_id`; repository-scoped media must also match repository, while unscoped media must remain repository-null.
+
 ## Authority Boundary
 
 - upload: authenticated owner / trusted runner
+- unscoped upload: authenticated owner, `private` visibility only, no related Issue/PR
 - read private media: authenticated owner / trusted Butler
 - delete: scoped approval required
+- same-send abandoned upload rollback: exact `source_event_id` scope required
 - public evidence promotion: explicit `GO` required
 - secret-looking media: public promotion forbidden
 - deploy, credential mutation, permission mutation, Cloudflare bucket creation, and binding mutation: scoped passkey approval required

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -3796,18 +3796,18 @@ async function handleMediaUploadRequest(request, env) {
   const repository = normalizeCanonicalRepositoryInput(
     form.get("repository") || form.get("repositoryInput") || form.get("repository_input")
   );
-  if (!repository) {
-    return json(422, {
-      ok: false,
-      error: "repository_required",
-      reason: "media upload requires a resolved owner/repo repository before R2 storage"
-    });
-  }
   const relatedIssue = normalizePositiveInteger(form.get("relatedIssue") || form.get("issueNumber") || form.get("related_issue"));
   const relatedPr = normalizePositiveInteger(form.get("relatedPr") || form.get("pullRequestNumber") || form.get("related_pr"));
   const sourceSurface = normalizeMediaSourceSurface(form.get("sourceSurface") || form.get("source_surface")) || "dashboard_butler";
   const sourceEventId = sanitizeDashboardChatText(form.get("sourceEventId") || form.get("source_event_id"));
   const visibility = normalizeMediaVisibility(form.get("visibility")) || "private";
+  if (!repository && (relatedIssue || relatedPr || visibility !== "private")) {
+    return json(422, {
+      ok: false,
+      error: "repository_required",
+      reason: "media upload without a resolved owner/repo is allowed only for private unscoped Dashboard conversation media"
+    });
+  }
   const now = new Date().toISOString();
   const mediaId = `med_${crypto.randomUUID()}`;
   const objectKey = buildMediaObjectKey({ repository, createdAt: now, mediaId, filename });
@@ -3831,7 +3831,7 @@ async function handleMediaUploadRequest(request, env) {
     httpMetadata: { contentType },
     customMetadata: {
       mediaId,
-      repository,
+      repository: repository || "unscoped",
       visibility,
       sha256
     }
@@ -4045,13 +4045,15 @@ async function handleAbandonedMediaSendRollback({ env, mediaRoute, url }) {
   const relatedIssue = normalizePositiveInteger(url.searchParams.get("relatedIssue") || url.searchParams.get("issueNumber"));
   const requestedSourceEventId = sanitizeDashboardChatText(url.searchParams.get("sourceEventId") || url.searchParams.get("source_event_id"));
   const sourceEventId = normalizeDashboardEventText(record.sourceEventId);
+  const repositoryScopeMatches = record.repository
+    ? Boolean(repository) && record.repository === repository
+    : !repository;
   const isRollbackScoped =
     record.visibility === "private" &&
     record.sourceSurface === "dashboard_butler" &&
     sourceEventId.startsWith("dashboard_owner_message:") &&
     requestedSourceEventId === sourceEventId &&
-    Boolean(repository) &&
-    record.repository === repository &&
+    repositoryScopeMatches &&
     (!relatedIssue || record.relatedIssue === relatedIssue);
   if (!isRollbackScoped) {
     return json(403, {
@@ -7407,8 +7409,8 @@ function isForbiddenUploadFilename(filename) {
 }
 
 function buildMediaObjectKey({ repository, createdAt, mediaId, filename }) {
-  const repo = normalizeCanonicalRepositoryInput(repository) || "unresolved/repository";
-  const [owner, name] = repo.split("/");
+  const repo = normalizeCanonicalRepositoryInput(repository);
+  const [owner, name] = repo ? repo.split("/") : ["_dashboard", "unscoped"];
   const date = new Date(createdAt);
   const yyyy = String(date.getUTCFullYear()).padStart(4, "0");
   const mm = String(date.getUTCMonth() + 1).padStart(2, "0");
@@ -10850,7 +10852,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
               }
             ].slice(0, 12);
             renderPendingMedia();
-            setStatus("添付を送信待ちに追加しました。送信時に private media として保存します。", { temporary: true });
+            setStatus("添付を送信待ちに追加しました。repo 未指定の通常会話では private media として保存します。", { temporary: true });
             textarea.focus({ preventScroll: true });
           } catch (error) {
             setStatus((error && error.message) || "添付の保存に失敗しました。");

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -747,7 +747,7 @@ test("worker serves dashboard media add controls for iPhone-first upload", async
   assert.equal(body.includes("accept=\"image/*\""), false);
   assert.equal(body.includes("/v2/media/upload"), true);
   assert.equal(body.includes("createImageBitmap"), true);
-  assert.equal(body.includes("送信時に private media として保存します"), true);
+  assert.equal(body.includes("repo 未指定の通常会話では private media として保存します"), true);
   assert.equal(body.includes("mediaReferences"), true);
   assert.equal(body.includes("pendingSendRollbacks"), true);
   assert.equal(body.includes("owner_message_accepted"), true);
@@ -832,11 +832,46 @@ test("worker rejects media upload without R2 binding before metadata drift", asy
   assert.equal(body.error, "media_r2_unavailable");
 });
 
-test("worker rejects media upload without resolved repository before R2 put", async () => {
+test("worker uploads private dashboard media without repository for ordinary chat", async () => {
   const mediaStore = createInMemoryMediaObjectStore();
   const r2 = createInMemoryR2Binding();
   const form = new FormData();
   form.append("repositoryInput", "未指定");
+  form.append("sourceSurface", "dashboard_butler");
+  form.append("file", createPngBlob(), "dashboard.png");
+
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/media/upload", {
+      method: "POST",
+      headers: dashboardAccessHeaders,
+      body: form
+    }),
+    {
+      ...dashboardAccessEnv,
+      MEDIA_OBJECT_STORE: mediaStore,
+      VTDD_MEDIA_R2: r2
+    }
+  );
+
+  assert.equal(response.status, 201);
+  const body = await response.json();
+  assert.equal(body.ok, true);
+  assert.equal(body.media.repository, null);
+  assert.equal(body.media.visibility, "private");
+  assert.match(body.media.downloadUrl, /^\/v2\/media\/med_/);
+  assert.equal(r2.objects.size, 1);
+  const [objectKey, stored] = [...r2.objects.entries()][0];
+  assert.match(objectKey, /^media\/_dashboard\/unscoped\//);
+  assert.equal(stored.options.customMetadata.repository, "unscoped");
+});
+
+test("worker rejects public or evidence media without resolved repository before R2 put", async () => {
+  const mediaStore = createInMemoryMediaObjectStore();
+  const r2 = createInMemoryR2Binding();
+  const form = new FormData();
+  form.append("repositoryInput", "");
+  form.append("relatedIssue", "498");
+  form.append("visibility", "public_evidence");
   form.append("file", createPngBlob(), "dashboard.png");
 
   const response = await worker.fetch(
@@ -1081,6 +1116,48 @@ test("worker rejects abandoned media rollback without exact source event scope",
   assert.equal(body.error, "scoped_approval_required");
   assert.equal(r2.objects.size, 1);
   assert.notEqual(await mediaStore.get("med_rollbackscope"), null);
+});
+
+test("worker allows rollback delete for private unscoped dashboard media from an abandoned owner message send", async () => {
+  const mediaStore = createInMemoryMediaObjectStore();
+  const r2 = createInMemoryR2Binding();
+  await mediaStore.put({
+    id: "med_unscopedrollback",
+    repository: null,
+    relatedIssue: null,
+    sourceSurface: "dashboard_butler",
+    sourceEventId: "dashboard_owner_message:unscoped",
+    objectKey: "media/_dashboard/unscoped/2026/05/23/med_unscopedrollback/dashboard.png",
+    filename: "dashboard.png",
+    contentType: "image/png",
+    byteSize: 16,
+    sha256: "0123456789abcdef",
+    visibility: "private",
+    createdAt: "2026-05-23T00:00:00.000Z",
+    updatedAt: "2026-05-23T00:00:00.000Z"
+  });
+  await r2.put("media/_dashboard/unscoped/2026/05/23/med_unscopedrollback/dashboard.png", new Uint8Array([1, 2, 3]));
+
+  const response = await worker.fetch(
+    new Request(
+      "https://example.com/v2/media/med_unscopedrollback?cleanup=abandoned_send&sourceEventId=dashboard_owner_message%3Aunscoped",
+      {
+        method: "DELETE",
+        headers: dashboardAccessHeaders
+      }
+    ),
+    {
+      ...dashboardAccessEnv,
+      MEDIA_OBJECT_STORE: mediaStore,
+      VTDD_MEDIA_R2: r2
+    }
+  );
+
+  assert.equal(response.status, 200);
+  const body = await response.json();
+  assert.equal(body.authority, "same_send_abandoned_private_media_rollback");
+  assert.equal(r2.objects.size, 0);
+  assert.equal(await mediaStore.get("med_unscopedrollback"), null);
 });
 
 test("worker requires repository filter before media metadata search", async () => {

--- a/worker.js
+++ b/worker.js
@@ -59240,18 +59240,18 @@ async function handleMediaUploadRequest(request, env) {
   const repository = normalizeCanonicalRepositoryInput(
     form.get("repository") || form.get("repositoryInput") || form.get("repository_input")
   );
-  if (!repository) {
-    return json(422, {
-      ok: false,
-      error: "repository_required",
-      reason: "media upload requires a resolved owner/repo repository before R2 storage"
-    });
-  }
   const relatedIssue = normalizePositiveInteger9(form.get("relatedIssue") || form.get("issueNumber") || form.get("related_issue"));
   const relatedPr = normalizePositiveInteger9(form.get("relatedPr") || form.get("pullRequestNumber") || form.get("related_pr"));
   const sourceSurface = normalizeMediaSourceSurface(form.get("sourceSurface") || form.get("source_surface")) || "dashboard_butler";
   const sourceEventId = sanitizeDashboardChatText(form.get("sourceEventId") || form.get("source_event_id"));
   const visibility = normalizeMediaVisibility(form.get("visibility")) || "private";
+  if (!repository && (relatedIssue || relatedPr || visibility !== "private")) {
+    return json(422, {
+      ok: false,
+      error: "repository_required",
+      reason: "media upload without a resolved owner/repo is allowed only for private unscoped Dashboard conversation media"
+    });
+  }
   const now = (/* @__PURE__ */ new Date()).toISOString();
   const mediaId = `med_${crypto.randomUUID()}`;
   const objectKey = buildMediaObjectKey({ repository, createdAt: now, mediaId, filename });
@@ -59274,7 +59274,7 @@ async function handleMediaUploadRequest(request, env) {
     httpMetadata: { contentType },
     customMetadata: {
       mediaId,
-      repository,
+      repository: repository || "unscoped",
       visibility,
       sha256: sha2562
     }
@@ -59482,7 +59482,8 @@ async function handleAbandonedMediaSendRollback({ env, mediaRoute, url }) {
   const relatedIssue = normalizePositiveInteger9(url.searchParams.get("relatedIssue") || url.searchParams.get("issueNumber"));
   const requestedSourceEventId = sanitizeDashboardChatText(url.searchParams.get("sourceEventId") || url.searchParams.get("source_event_id"));
   const sourceEventId = normalizeDashboardEventText(record2.sourceEventId);
-  const isRollbackScoped = record2.visibility === "private" && record2.sourceSurface === "dashboard_butler" && sourceEventId.startsWith("dashboard_owner_message:") && requestedSourceEventId === sourceEventId && Boolean(repository) && record2.repository === repository && (!relatedIssue || record2.relatedIssue === relatedIssue);
+  const repositoryScopeMatches = record2.repository ? Boolean(repository) && record2.repository === repository : !repository;
+  const isRollbackScoped = record2.visibility === "private" && record2.sourceSurface === "dashboard_butler" && sourceEventId.startsWith("dashboard_owner_message:") && requestedSourceEventId === sourceEventId && repositoryScopeMatches && (!relatedIssue || record2.relatedIssue === relatedIssue);
   if (!isRollbackScoped) {
     return json(403, {
       ok: false,
@@ -62382,8 +62383,8 @@ function isForbiddenUploadFilename(filename) {
   return /\.(html?|svg|mjs|cjs|js|jsx|ts|tsx|sh|bash|zsh|exe|dll|dmg|pkg)$/i.test(sanitizeMediaFilename(filename));
 }
 function buildMediaObjectKey({ repository, createdAt, mediaId, filename }) {
-  const repo = normalizeCanonicalRepositoryInput(repository) || "unresolved/repository";
-  const [owner, name] = repo.split("/");
+  const repo = normalizeCanonicalRepositoryInput(repository);
+  const [owner, name] = repo ? repo.split("/") : ["_dashboard", "unscoped"];
   const date3 = new Date(createdAt);
   const yyyy = String(date3.getUTCFullYear()).padStart(4, "0");
   const mm = String(date3.getUTCMonth() + 1).padStart(2, "0");
@@ -65591,7 +65592,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
               }
             ].slice(0, 12);
             renderPendingMedia();
-            setStatus("\u6DFB\u4ED8\u3092\u9001\u4FE1\u5F85\u3061\u306B\u8FFD\u52A0\u3057\u307E\u3057\u305F\u3002\u9001\u4FE1\u6642\u306B private media \u3068\u3057\u3066\u4FDD\u5B58\u3057\u307E\u3059\u3002", { temporary: true });
+            setStatus("\u6DFB\u4ED8\u3092\u9001\u4FE1\u5F85\u3061\u306B\u8FFD\u52A0\u3057\u307E\u3057\u305F\u3002repo \u672A\u6307\u5B9A\u306E\u901A\u5E38\u4F1A\u8A71\u3067\u306F private media \u3068\u3057\u3066\u4FDD\u5B58\u3057\u307E\u3059\u3002", { temporary: true });
             textarea.focus({ preventScroll: true });
           } catch (error) {
             setStatus((error && error.message) || "\u6DFB\u4ED8\u306E\u4FDD\u5B58\u306B\u5931\u6557\u3057\u307E\u3057\u305F\u3002");


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #498 の Dashboard Butler media storage 部分進捗です。repo 未指定の通常会話でも private media として R2/D1 に保存できるようにします。
- Issue #498 の証跡昇格や live iPhone E2E 完了はこの PR では閉じません。

## Satisfied Success Criteria

- Dashboard Butler の通常会話で repository が未解決でも private media を保存できる。
- repo 未指定 media は D1 metadata の repository を null、R2 object key を media/_dashboard/unscoped/... として保存する。
- Issue / PR / public_evidence / repo_internal に使う repo 未指定 upload は repository_required で R2 put 前に拒否する。
- 同じ owner message send を破棄した場合、private unscoped media も exact sourceEventId で rollback delete できる。
- Cloudflare R2 media storage doc に unscoped namespace と rollback 例外を追記した。

## Unsatisfied Success Criteria

- merge 後の production deploy と iPhone Butler live E2E は未実施です。
- Issue #498 全体の完了判定と Issue close はこの PR では行いません。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #498
- Implementing Success Criteria: repo 未指定の Dashboard Butler 通常会話で private media upload を許可し、証跡用途は repo 解決を維持する。
- Explicit Non-goals: default repository の導入、public evidence 自動昇格、repository search の repo-less 対応、deploy、Issue close はしない。
- Expected touched files/routes/workflows: src/worker/runtime.js, worker.js, test/worker.test.js, docs/media/cloudflare-r2-media-storage.md
- Affected Issues: Issue #498
- Affected PRs: なし
- Affected workflows: GitHub Actions workflow は変更なし。生成 worker.js 同期チェックのみ影響。
- Affected runtime/operator surfaces: Dashboard Butler / Worker media upload route / media delete rollback route / Cloudflare R2 object key
- What may break if we patch narrowly: repo-less upload を広げすぎると public evidence や Issue / PR 証跡が repository なしで混入するため、private 通常会話だけに限定した。
- Unknowns to investigate before coding: production deploy 後の iPhone 実機 upload E2E は未確認。
- Validation needed: node --test test/worker.test.js と npm test。merge/deploy 後に iPhone Butler live E2E が必要。
- Stop condition: repo 未指定の public_evidence / relatedIssue / relatedPr を許可する必要が出た場合は authority boundary が変わるため停止して再設計する。

## File / Line Hypotheses

- file: `src/worker/runtime.js`
  - hypothesis: `handleMediaUploadRequest` の repository_required が通常会話 upload を止めている。
  - risk if changed narrowly: 証跡 media まで repo なしで保存すると traceability が壊れる。
  - validation: repo-less private upload は 201、repo-less public/evidence upload は 422 をテストする。
  - related Issue: Issue #498
- file: `src/worker/runtime.js`
  - hypothesis: `handleAbandonedMediaSendRollback` も repository match 必須で unscoped rollback を止める。
  - risk if changed narrowly: sourceEventId を緩めると別添付削除になる。
  - validation: exact sourceEventId の unscoped rollback だけ削除できることをテストする。
  - related Issue: Issue #498

## Hypothesis Retrospective

- expected: repo 未指定通常会話だけ private unscoped 保存を許可できる。
- actual: `repository === null` / `media/_dashboard/unscoped/...` / exact sourceEventId rollback で実装した。
- mismatch: なし。
- lesson: repository 解決は証跡用途の境界として残し、通常会話添付だけ unscoped namespace に逃がす。
- should become RAG candidate: はい。Issue #498 の media upload boundary として有用。

## Verification Evidence

- Unit: node --test test/worker.test.js: pass 189/189
- Integration: npm test: pass 941/942, skipped 1, fail 0; check:self-parity pass; check:generated-worker pass
- E2E: 未実施。merge/deploy 後に iPhone Butler で repo 未指定画像 upload を確認する。
- Manual: 未実施。
- Evidence path/link: test/worker.test.js; docs/media/cloudflare-r2-media-storage.md

## Butler Completion Contract

- Owner goal: repo 未指定の普通の Butler 会話でも画像やファイルを添付でき、送信破棄時は同じ範囲で片付けられる。
- Butler entrypoint: Dashboard Butler composer の media add button と /v2/media/upload。
- Action Schema exposure: 不要。Dashboard Butler runtime route の変更で、Custom GPT Action Schema は変更しない。
- Runtime path: /v2/media/upload, /v2/media/:id?cleanup=abandoned_send
- Runner/runtime truth: テストで private unscoped upload、public/evidence repo-required block、unscoped rollback を確認。production runtime truth は deploy 後に確認する。
- Authority boundary: repo 未指定 upload は authenticated owner の private media のみ許可。Issue/PR/public evidence は canonical owner/repo 必須。破棄 rollback は exact sourceEventId 必須。
- E2E evidence: 未実施。merge/deploy 後に iPhone Butler で live E2E が必要。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: merge 後に必要。deploy はこの PR では実行しない。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: merge/deploy 後に必要。

## Related Constitution Rules

- Issue traceability: Issue #498 に限定。
- No default repository: repo 未指定は unscoped private namespace に保存し、repo 解決済み扱いにしない。
- Authority boundary: public evidence promotion と deploy はこの PR 外。
- Memory safety: raw media を RAG に入れず metadata/reference のみにする。

## Out-of-scope but NOT implemented

- repository search の repo-less 対応。
- public_evidence / repo_internal の repo-less upload。
- production deploy と live iPhone E2E。
- Issue #498 close。

## Extra changes (if any)

Generated worker.js was rebuilt from src/worker.js.

<!-- VTDD metadata -->
- Issue: Issue #498
- Execution ID: codex/498-unscoped-dashboard-media
- Goal: Issue #498 repo 未指定 Dashboard Butler media upload の private unscoped 対応
