### PR TITLE
Issue #498 media D1 schema bootstrap の incomplete input を直す

### DIFF
--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -6821,27 +6821,7 @@ function createD1MediaObjectStore(d1) {
   function ensureSchema() {
     if (!schemaPromise) {
       schemaPromise = (async () => {
-        await d1.exec(
-          `CREATE TABLE IF NOT EXISTS vtdd_media_objects (
-            id TEXT PRIMARY KEY,
-            repository TEXT,
-            related_issue INTEGER,
-            related_pr INTEGER,
-            source_surface TEXT NOT NULL,
-            source_event_id TEXT,
-            object_key TEXT NOT NULL,
-            filename TEXT NOT NULL,
-            content_type TEXT NOT NULL,
-            byte_size INTEGER NOT NULL,
-            sha256 TEXT NOT NULL,
-            visibility TEXT NOT NULL,
-            summary TEXT,
-            ocr_text TEXT,
-            created_by TEXT,
-            created_at TEXT NOT NULL,
-            updated_at TEXT NOT NULL
-          );`
-        );
+        await d1.exec("CREATE TABLE IF NOT EXISTS vtdd_media_objects (id TEXT PRIMARY KEY, repository TEXT, related_issue INTEGER, related_pr INTEGER, source_surface TEXT NOT NULL, source_event_id TEXT, object_key TEXT NOT NULL, filename TEXT NOT NULL, content_type TEXT NOT NULL, byte_size INTEGER NOT NULL, sha256 TEXT NOT NULL, visibility TEXT NOT NULL, summary TEXT, ocr_text TEXT, created_by TEXT, created_at TEXT NOT NULL, updated_at TEXT NOT NULL);");
         await d1.exec("CREATE INDEX IF NOT EXISTS idx_vtdd_media_repo ON vtdd_media_objects(repository, created_at DESC);");
         await d1.exec("CREATE INDEX IF NOT EXISTS idx_vtdd_media_issue ON vtdd_media_objects(repository, related_issue, created_at DESC);");
         await d1.exec("CREATE INDEX IF NOT EXISTS idx_vtdd_media_pr ON vtdd_media_objects(repository, related_pr, created_at DESC);");

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -217,6 +217,76 @@ function createInMemoryR2Binding() {
   };
 }
 
+function createStrictMediaD1Binding() {
+  const execStatements = [];
+  const rows = new Map();
+  return {
+    execStatements,
+    rows,
+    async exec(statement) {
+      execStatements.push(statement);
+      if (/CREATE TABLE IF NOT EXISTS vtdd_media_objects \(\s*\n/.test(String(statement))) {
+        throw new Error("D1_EXEC_ERROR: Error in line 1: CREATE TABLE IF NOT EXISTS vtdd_media_objects (: incomplete input: SQLITE_ERROR");
+      }
+      return { success: true };
+    },
+    prepare(sql) {
+      return {
+        bind(...params) {
+          return {
+            async run() {
+              if (String(sql).includes("INSERT OR REPLACE INTO vtdd_media_objects")) {
+                const [
+                  id,
+                  repository,
+                  relatedIssue,
+                  relatedPr,
+                  sourceSurface,
+                  sourceEventId,
+                  objectKey,
+                  filename,
+                  contentType,
+                  byteSize,
+                  sha256,
+                  visibility,
+                  summary,
+                  ocrText,
+                  createdBy,
+                  createdAt,
+                  updatedAt
+                ] = params;
+                rows.set(id, {
+                  id,
+                  repository,
+                  related_issue: relatedIssue,
+                  related_pr: relatedPr,
+                  source_surface: sourceSurface,
+                  source_event_id: sourceEventId,
+                  object_key: objectKey,
+                  filename,
+                  content_type: contentType,
+                  byte_size: byteSize,
+                  sha256,
+                  visibility,
+                  summary,
+                  ocr_text: ocrText,
+                  created_by: createdBy,
+                  created_at: createdAt,
+                  updated_at: updatedAt
+                });
+              }
+              return { success: true };
+            },
+            async all() {
+              return { results: [] };
+            }
+          };
+        }
+      };
+    }
+  };
+}
+
 function createPngBlob() {
   return new Blob([
     new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d])
@@ -863,6 +933,39 @@ test("worker uploads private dashboard media without repository for ordinary cha
   const [objectKey, stored] = [...r2.objects.entries()][0];
   assert.match(objectKey, /^media\/_dashboard\/unscoped\//);
   assert.equal(stored.options.customMetadata.repository, "unscoped");
+});
+
+test("worker creates media D1 schema without multiline exec truncation", async () => {
+  const d1 = createStrictMediaD1Binding();
+  const r2 = createInMemoryR2Binding();
+  const form = new FormData();
+  form.append("repositoryInput", "");
+  form.append("sourceSurface", "dashboard_butler");
+  form.append("file", createPngBlob(), "dashboard.png");
+
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/media/upload", {
+      method: "POST",
+      headers: dashboardAccessHeaders,
+      body: form
+    }),
+    {
+      ...dashboardAccessEnv,
+      VTDD_MEMORY_D1: d1,
+      VTDD_MEDIA_R2: r2
+    }
+  );
+
+  assert.equal(response.status, 201);
+  const body = await response.json();
+  assert.equal(body.ok, true);
+  assert.equal(d1.rows.size, 1);
+  assert.equal(r2.objects.size, 1);
+  const createTableStatement = d1.execStatements.find((statement) =>
+    String(statement).startsWith("CREATE TABLE IF NOT EXISTS vtdd_media_objects")
+  );
+  assert.ok(createTableStatement);
+  assert.equal(createTableStatement.includes("\n"), false);
 });
 
 test("worker rejects public or evidence media without resolved repository before R2 put", async () => {

--- a/worker.js
+++ b/worker.js
@@ -61847,27 +61847,7 @@ function createD1MediaObjectStore(d1) {
   function ensureSchema() {
     if (!schemaPromise) {
       schemaPromise = (async () => {
-        await d1.exec(
-          `CREATE TABLE IF NOT EXISTS vtdd_media_objects (
-            id TEXT PRIMARY KEY,
-            repository TEXT,
-            related_issue INTEGER,
-            related_pr INTEGER,
-            source_surface TEXT NOT NULL,
-            source_event_id TEXT,
-            object_key TEXT NOT NULL,
-            filename TEXT NOT NULL,
-            content_type TEXT NOT NULL,
-            byte_size INTEGER NOT NULL,
-            sha256 TEXT NOT NULL,
-            visibility TEXT NOT NULL,
-            summary TEXT,
-            ocr_text TEXT,
-            created_by TEXT,
-            created_at TEXT NOT NULL,
-            updated_at TEXT NOT NULL
-          );`
-        );
+        await d1.exec("CREATE TABLE IF NOT EXISTS vtdd_media_objects (id TEXT PRIMARY KEY, repository TEXT, related_issue INTEGER, related_pr INTEGER, source_surface TEXT NOT NULL, source_event_id TEXT, object_key TEXT NOT NULL, filename TEXT NOT NULL, content_type TEXT NOT NULL, byte_size INTEGER NOT NULL, sha256 TEXT NOT NULL, visibility TEXT NOT NULL, summary TEXT, ocr_text TEXT, created_by TEXT, created_at TEXT NOT NULL, updated_at TEXT NOT NULL);");
         await d1.exec("CREATE INDEX IF NOT EXISTS idx_vtdd_media_repo ON vtdd_media_objects(repository, created_at DESC);");
         await d1.exec("CREATE INDEX IF NOT EXISTS idx_vtdd_media_issue ON vtdd_media_objects(repository, related_issue, created_at DESC);");
         await d1.exec("CREATE INDEX IF NOT EXISTS idx_vtdd_media_pr ON vtdd_media_objects(repository, related_pr, created_at DESC);");


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #498 の Dashboard Butler media storage 修正です。production D1 で vtdd_media_objects schema 作成が途中で切れ、R2 put 後の metadata insert が失敗する問題を直します。
- Issue #498 全体の完了や live iPhone E2E 完了はこの PR では閉じません。

## Satisfied Success Criteria

- vtdd_media_objects の CREATE TABLE SQL を Cloudflare D1 exec で途中切れしない 1 行 statement に変更した。
- R2 put 後に D1 schema 作成と metadata insert が成功する回帰テストを追加した。
- 既存の repo 未指定 private media upload、mime 偽装拒否、破棄 rollback のテストは維持した。

## Unsatisfied Success Criteria

- merge 後の production deploy と iPhone Butler live E2E は未実施です。
- Issue #498 全体の完了判定と Issue close はこの PR では行いません。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #498
- Implementing Success Criteria: production D1 の vtdd_media_objects schema 作成が incomplete input で失敗せず、media metadata insert まで進む。
- Explicit Non-goals: media upload 仕様拡張、R2 bucket/binding 変更、deploy、Issue close はしない。
- Expected touched files/routes/workflows: src/worker/runtime.js, worker.js, test/worker.test.js
- Affected Issues: Issue #498
- Affected PRs: PR #510 の follow-up。
- Affected workflows: GitHub Actions workflow は変更なし。生成 worker.js 同期チェックのみ影響。
- Affected runtime/operator surfaces: Dashboard Butler / Worker media upload route / Cloudflare D1 metadata schema creation
- What may break if we patch narrowly: D1 schema 作成だけを直す。media authority や repository boundary を触ると PR #510 の安全境界を壊すため変更しない。
- Unknowns to investigate before coding: production deploy 後の実機 upload 成功は未確認。
- Validation needed: node --test test/worker.test.js と npm test。merge/deploy 後に iPhone Butler live E2E が必要。
- Stop condition: D1 binding や bucket 権限の mutation が必要になった場合は deploy/credential/permission 境界になるため停止する。

## File / Line Hypotheses

- file: `src/worker/runtime.js`
  - hypothesis: `createD1MediaObjectStore.ensureSchema` の multi-line `CREATE TABLE` が production D1 exec で `CREATE TABLE IF NOT EXISTS vtdd_media_objects (` だけとして評価され、incomplete input になる。
  - risk if changed narrowly: SQL の列定義を変えると既存 metadata insert と不整合になる。
  - validation: 改行入り CREATE TABLE を拒否する fake D1 で media upload が 201 になることをテストする。
  - related Issue: Issue #498

## Hypothesis Retrospective

- expected: CREATE TABLE statement を 1 行にすれば D1 exec の incomplete input を避けられる。
- actual: 1 行 SQL に変更し、strict fake D1 で R2 put 後の D1 insert 成功を確認した。
- mismatch: なし。
- lesson: Cloudflare D1 exec に渡す runtime schema bootstrap SQL は 1 statement / 1 line で固定する。
- should become RAG candidate: はい。Issue #498 の production D1 media schema blocker として有用。

## Verification Evidence

- Unit: node --test test/worker.test.js: pass 190/190
- Integration: npm test: pass 942/943, skipped 1, fail 0; check:self-parity pass; check:generated-worker pass
- E2E: 未実施。merge/deploy 後に iPhone Butler で repo 未指定画像 upload を確認する。
- Manual: User reported production error: D1 media metadata insert failed after R2 put; CREATE TABLE IF NOT EXISTS vtdd_media_objects (: incomplete input.
- Evidence path/link: test/worker.test.js; src/worker/runtime.js

## Butler Completion Contract

- Owner goal: Butler の画像添付で R2 保存後に D1 metadata insert が落ちず、普通の会話に media reference を戻せる。
- Butler entrypoint: Dashboard Butler composer の media add button と /v2/media/upload。
- Action Schema exposure: 不要。Dashboard Butler runtime route の内部 D1 schema bootstrap 修正で、Custom GPT Action Schema は変更しない。
- Runtime path: /v2/media/upload -> R2 put -> D1 vtdd_media_objects schema ensure -> metadata insert
- Runner/runtime truth: テストで strict fake D1 による schema exec と metadata insert 成功を確認。production runtime truth は deploy 後に確認する。
- Authority boundary: 未変更。repo 未指定 upload は authenticated owner の private media のみ許可。deploy はこの PR では実行しない。
- E2E evidence: 未実施。merge/deploy 後に iPhone Butler で live E2E が必要。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: merge 後に必要。deploy はこの PR では実行しない。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: merge/deploy 後に必要。

## Related Constitution Rules

- Issue traceability: Issue #498 に限定。
- Authority boundary: deploy / credential / permission mutation はこの PR 外。
- Memory safety: raw media は RAG に入れず D1 metadata/R2 object に分離。
- No default repository: PR #510 の repo 未指定 private unscoped 方針は維持。

## Out-of-scope but NOT implemented

- R2 bucket/binding 変更。
- D1 database 作成や permission mutation。
- production deploy と live iPhone E2E。
- Issue #498 close。

## Extra changes (if any)

Generated worker.js was rebuilt from src/worker.js.

<!-- VTDD metadata -->
- Issue: Issue #498
- Execution ID: codex/498-media-d1-schema-exec
- Goal: Issue #498 media D1 schema exec incomplete input 修正
