### PR TITLE
Issue #498 app-server failure の二重 SYSTEM 表示を止める

### DIFF
--- a/scripts/run-dashboard-app-server-bridge.mjs
+++ b/scripts/run-dashboard-app-server-bridge.mjs
@@ -4,6 +4,9 @@ import process from "node:process";
 
 const DEFAULT_SCHEMA = "vtdd.dashboard.app_server_bridge.v1";
 const DANGER_FULL_ACCESS_SANDBOX = "danger-full-access";
+const APP_SERVER_FAILURE_ALREADY_SENT = Symbol("appServerFailureAlreadySent");
+const DEFAULT_APP_SERVER_ERROR_TEXT =
+  "codex app-server が応答生成中に失敗しました。画像を解析できなかった可能性があります。もう一度送るか、画像なしで内容を短く説明してください。";
 
 export function buildAppServerInitializeRequest(id = 1) {
   return {
@@ -194,10 +197,20 @@ export function mapAppServerNotificationToDashboardEvent(message, context = {}) 
       schema: DEFAULT_SCHEMA,
       threadId: context.dashboardThreadId,
       codexThreadId: context.codexThreadId || null,
-      text: params.message || params.reason || "codex app-server returned an error"
+      text: params.message || params.reason || DEFAULT_APP_SERVER_ERROR_TEXT
     };
   }
   return null;
+}
+
+function createAppServerFailureAlreadySentError(message) {
+  const error = new Error(message || DEFAULT_APP_SERVER_ERROR_TEXT);
+  error[APP_SERVER_FAILURE_ALREADY_SENT] = true;
+  return error;
+}
+
+function isAppServerFailureAlreadySent(error) {
+  return Boolean(error && error[APP_SERVER_FAILURE_ALREADY_SENT]);
 }
 
 export function extractAppServerNotificationTurnId(message) {
@@ -412,7 +425,7 @@ export async function handleDashboardTurnRequest({
     }
     if (event.type === "app_server_turn_failed") {
       void sendDashboardEvent(event);
-      finishTurn(() => rejectTurn(new Error(event.text || "codex app-server turn failed")));
+      finishTurn(() => rejectTurn(createAppServerFailureAlreadySentError(event.text)));
       return;
     }
     void sendDashboardEvent(event);
@@ -547,11 +560,14 @@ export async function connectDashboardAppServerBridgeOnce({
           })
         )
         .catch((error) => {
+          if (isAppServerFailureAlreadySent(error)) {
+            return;
+          }
           safeSend({
             type: "app_server_turn_failed",
             schema: DEFAULT_SCHEMA,
             threadId: payload.threadId,
-            text: error?.message || "codex app-server bridge failed"
+            text: error?.message || DEFAULT_APP_SERVER_ERROR_TEXT
           });
         });
     }

--- a/test/dashboard-app-server-bridge.test.js
+++ b/test/dashboard-app-server-bridge.test.js
@@ -490,6 +490,90 @@ test("dashboard app-server bridge ignores notifications for a different Codex tu
   assert.equal(events.at(-1).text, "正しい返信");
 });
 
+test("dashboard app-server bridge sends one Japanese failure for app-server error notifications", async () => {
+  const sockets = [];
+  const handlers = new Set();
+  class MockWebSocket {
+    constructor(endpoint, protocols) {
+      this.endpoint = endpoint;
+      this.protocols = protocols;
+      this.listeners = new Map();
+      this.sent = [];
+      sockets.push(this);
+    }
+
+    addEventListener(type, handler) {
+      if (!this.listeners.has(type)) {
+        this.listeners.set(type, new Set());
+      }
+      this.listeners.get(type).add(handler);
+    }
+
+    send(payload) {
+      this.sent.push(payload);
+    }
+
+    emit(type, event = {}) {
+      for (const handler of this.listeners.get(type) || []) {
+        handler(event);
+      }
+    }
+  }
+  const appServer = {
+    nextRequestId() {
+      return 1;
+    },
+    onNotification(handler) {
+      handlers.add(handler);
+      return () => handlers.delete(handler);
+    },
+    async request(message) {
+      if (message.method === "thread/start") {
+        return { thread: { id: "codex-thread-error" } };
+      }
+      if (message.method === "turn/start") {
+        for (const handler of handlers) {
+          handler({
+            method: "error",
+            params: {
+              threadId: "codex-thread-error",
+              turnId: "turn-error"
+            }
+          });
+        }
+        return { turn: { id: "turn-error" } };
+      }
+      throw new Error(`unexpected method ${message.method}`);
+    }
+  };
+
+  const once = connectDashboardAppServerBridgeOnce({
+    endpoint: new URL("wss://runtime.example/v2/dashboard/app-server/ws?threadId=dashboard-main"),
+    token: "secret-token",
+    appServer,
+    WebSocketImpl: MockWebSocket
+  });
+  const socket = sockets[0];
+  socket.emit("message", {
+    data: JSON.stringify({
+      type: "app_server_turn_requested",
+      threadId: "dashboard-main",
+      text: "画像アップロードテスト"
+    })
+  });
+
+  await waitFor(() => socket.sent.map((payload) => JSON.parse(payload)).some((payload) => payload.type === "app_server_turn_failed"));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  const failures = socket.sent.map((payload) => JSON.parse(payload)).filter((payload) => payload.type === "app_server_turn_failed");
+  assert.equal(failures.length, 1);
+  const failure = failures[0];
+  assert.equal(failure.type, "app_server_turn_failed");
+  assert.equal(failure.threadId, "dashboard-main");
+  assert.match(failure.text, /codex app-server が応答生成中に失敗しました/);
+  socket.emit("close");
+  await once;
+});
+
 test("dashboard app-server bridge args require a dashboard thread id for runtime connection", () => {
   const parsed = parseBridgeArgs([], {
     VTDD_RUNTIME_URL: "https://runtime.example",


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #498 の Dashboard Butler app-server failure 表示修正です。画像添付後に codex app-server returned an error が SYSTEM に 2 回出る問題を、bridge 側で同一 turn の failure を重複送信しないように直します。
- Issue #498 全体の画像解析 completion や thumbnail UI はこの PR では閉じません。

## Satisfied Success Criteria

- codex app-server の error notification で dashboard に app_server_turn_failed を 1 回だけ送る。
- 同じ failure を外側 catch が再送しないように sent marker を追加した。
- generic English fallback を owner-facing 日本語エラーに変更した。
- 回帰テストで app-server error notification 時の failure が 1 件だけであることを確認した。

## Unsatisfied Success Criteria

- 画像内容を app-server が attachmentId から取得して解析する経路は未実装です。
- 画像サムネイル表示は未実装です。
- merge 後の app-server bridge 再起動/live E2E は未実施です。
- Issue #498 全体の完了判定と Issue close はこの PR では行いません。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #498
- Implementing Success Criteria: app-server / VPS が画像取得や応答生成に失敗した時、Dashboard は raw/generic English ではなく日本語 failure を 1 回だけ表示する。
- Explicit Non-goals: 画像解析本体、thumbnail UI、Worker route 変更、Cloudflare deploy、Issue close はしない。
- Expected touched files/routes/workflows: scripts/run-dashboard-app-server-bridge.mjs, test/dashboard-app-server-bridge.test.js
- Affected Issues: Issue #498
- Affected PRs: PR #510 / PR #511 の live upload follow-up。
- Affected workflows: GitHub Actions workflow は変更なし。
- Affected runtime/operator surfaces: Dashboard app-server bridge script / dashboard SYSTEM failure message
- What may break if we patch narrowly: failure 重複だけを止める。画像 attachment protocol まで同時に触ると app-server 入力形式の検証範囲が大きくなるため分ける。
- Unknowns to investigate before coding: 実際の app-server error 原因は live bridge/app-server 側ログで別途確認が必要。今回の PR は二重表示と英語 fallback を止める。
- Validation needed: node --test test/dashboard-app-server-bridge.test.js と npm test。merge 後に bridge restart と iPhone Butler live E2E が必要。
- Stop condition: app-server の画像入力 protocol を変更する必要が出た場合は thumbnail/attachment解析スライスとして分ける。

## File / Line Hypotheses

- file: `scripts/run-dashboard-app-server-bridge.mjs`
  - hypothesis: app-server `error` notification で `app_server_turn_failed` を送った後、Promise reject が outer catch に流れて同じ failure を再送している。
  - risk if changed narrowly: request throw など notification なしの failure まで消すと owner に失敗が見えなくなる。
  - validation: notification 由来の failure は 1 件、outer catch 由来の failure は維持する。
  - related Issue: Issue #498

## Hypothesis Retrospective

- expected: sent marker を持つ Error だけ outer catch で suppress すれば、notification 由来の二重 SYSTEM を止められる。
- actual: Symbol marker で sent failure を識別し、generic fallback を日本語化した。
- mismatch: なし。
- lesson: bridge は app-server notification と transport catch の両方から failure を出すため、turn 単位で重複抑止が必要。
- should become RAG candidate: はい。Issue #498 の app-server failure 表示 blocker として有用。

## Verification Evidence

- Unit: node --test test/dashboard-app-server-bridge.test.js: pass 18/18
- Integration: npm test: pass 943/944, skipped 1, fail 0; check:self-parity pass; check:generated-worker pass
- E2E: 未実施。merge 後に app-server bridge を更新/再起動し、iPhone Butler で画像添付後の SYSTEM failure が重複しないことを確認する。
- Manual: User reported: Dashboard shows SYSTEM codex app-server returned an error twice after successful image upload.
- Evidence path/link: test/dashboard-app-server-bridge.test.js; scripts/run-dashboard-app-server-bridge.mjs

## Butler Completion Contract

- Owner goal: 画像添付後に app-server が失敗しても、Dashboard に同じ SYSTEM エラーを 2 回出さず、日本語で再試行可能な失敗理由を出す。
- Butler entrypoint: Dashboard Butler composer -> app-server bridge turn request.
- Action Schema exposure: 不要。Dashboard app-server bridge script の修正で、Custom GPT Action Schema は変更しない。
- Runtime path: scripts/run-dashboard-app-server-bridge.mjs -> codex app-server notification -> /v2/dashboard/app-server/ws event
- Runner/runtime truth: テストで app-server error notification に対して app_server_turn_failed が 1 件だけ送られることを確認。live runtime truth は bridge restart 後に確認する。
- Authority boundary: 未変更。deploy / credential / permission mutation はこの PR 外。
- E2E evidence: 未実施。merge 後に iPhone Butler で live E2E が必要。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 不要。Worker code は変更していない。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: merge 後に app-server bridge restart 後、画像添付で SYSTEM failure が重複しないことを確認する。

## Related Constitution Rules

- Issue traceability: Issue #498 に限定。
- Butler Completion Gate: live E2E 未実施のため incomplete。
- Authority boundary: deploy / credential / permission mutation はしない。
- Evidence discipline: thumbnail と画像解析本体は未実装として明記。

## Out-of-scope but NOT implemented

- 画像サムネイル表示。
- attachmentId から app-server が画像を取得して解析する protocol。
- Cloudflare deploy。
- Issue #498 close。

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #498
- Execution ID: codex/498-app-server-failure-dedupe
- Goal: Issue #498 app-server failure 二重 SYSTEM 表示の抑止
