### PR TITLE
Issue #498 Dashboard Butler に media サムネイルを表示する

### DIFF
--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -10356,7 +10356,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           link.rel = "noreferrer";
           link.textContent = "";
           const isImage = String(reference.contentType || "").startsWith("image/");
-          if (isImage && reference.mediaId) {
+          if (isImage && link.href && link.href !== "#") {
             const image = document.createElement("img");
             image.className = "media-thumb";
             image.src = link.href;

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -10351,15 +10351,16 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         for (const reference of list) {
           const link = document.createElement("a");
           link.className = "media-chip";
-          link.href = reference.downloadUrl || (reference.mediaId ? "/v2/media/" + reference.mediaId + "/download" : "#");
+          const downloadHref = reference.downloadUrl || (reference.mediaId ? "/v2/media/" + reference.mediaId + "/download" : "#");
+          link.href = downloadHref;
           link.target = "_blank";
           link.rel = "noreferrer";
           link.textContent = "";
           const isImage = String(reference.contentType || "").startsWith("image/");
-          if (isImage && link.href && link.href !== "#") {
+          if (isImage && downloadHref !== "#") {
             const image = document.createElement("img");
             image.className = "media-thumb";
-            image.src = link.href;
+            image.src = downloadHref;
             image.alt = reference.filename || "添付画像";
             image.loading = "lazy";
             link.appendChild(image);

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -10037,8 +10037,10 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
     .send-button { width: 44px; height: 44px; border-radius: 999px; background: var(--text); color: var(--page-bg); font-size: 22px; }
     .pending-media, .message-media { display: flex; flex-wrap: wrap; gap: 8px; padding: 0 8px; }
     .pending-media:empty, .message-media:empty { display: none; }
-    .media-chip { display: inline-flex; align-items: center; max-width: 100%; min-height: 34px; border: 1px solid var(--border); border-radius: 999px; padding: 5px 10px; gap: 6px; color: var(--text); background: var(--soft); font-size: 12px; text-decoration: none; }
+    .media-chip { display: inline-flex; align-items: center; max-width: 100%; min-height: 34px; border: 1px solid var(--border); border-radius: 14px; padding: 5px 10px; gap: 8px; color: var(--text); background: var(--soft); font-size: 12px; text-decoration: none; }
     .media-chip span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: min(48vw, 320px); }
+    .media-thumb { width: 48px; height: 48px; flex: 0 0 auto; border-radius: 10px; object-fit: cover; background: var(--border); }
+    .media-chip.pending-preview { padding: 5px 8px 5px 5px; }
     .media-remove { border: 0; background: transparent; color: var(--muted); font: inherit; font-weight: 900; padding: 0 2px; cursor: pointer; }
     .composer-status { min-height: 18px; padding-left: 16px; color: var(--muted); font-size: 12px; }
     .composer-status.thinking::after { content: ""; display: inline-block; width: 1.4em; text-align: left; animation: thinkingDots 1.2s steps(4, end) infinite; }
@@ -10353,15 +10355,37 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           link.target = "_blank";
           link.rel = "noreferrer";
           link.textContent = "";
-          const icon = document.createElement("span");
-          icon.textContent = "添付";
+          const isImage = String(reference.contentType || "").startsWith("image/");
+          if (isImage && reference.mediaId) {
+            const image = document.createElement("img");
+            image.className = "media-thumb";
+            image.src = link.href;
+            image.alt = reference.filename || "添付画像";
+            image.loading = "lazy";
+            link.appendChild(image);
+          } else {
+            const icon = document.createElement("span");
+            icon.textContent = "添付";
+            link.appendChild(icon);
+          }
           const label = document.createElement("span");
           label.textContent = reference.filename || reference.mediaId || "media";
-          link.appendChild(icon);
           link.appendChild(label);
           wrapper.appendChild(link);
         }
         return wrapper;
+      }
+
+      function revokePendingMediaPreview(item) {
+        if (item && item.previewUrl && typeof URL !== "undefined" && typeof URL.revokeObjectURL === "function") {
+          URL.revokeObjectURL(item.previewUrl);
+        }
+      }
+
+      function revokePendingMediaPreviews(items = pendingMediaItems) {
+        for (const item of Array.isArray(items) ? items : []) {
+          revokePendingMediaPreview(item);
+        }
       }
 
       function renderPendingMedia() {
@@ -10370,6 +10394,14 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         for (const item of pendingMediaItems) {
           const chip = document.createElement("span");
           chip.className = "media-chip";
+          if (item.previewUrl) {
+            chip.classList.add("pending-preview");
+            const image = document.createElement("img");
+            image.className = "media-thumb";
+            image.src = item.previewUrl;
+            image.alt = item.filename || "送信待ち画像";
+            chip.appendChild(image);
+          }
           const label = document.createElement("span");
           label.textContent = item.filename || "attachment";
           const remove = document.createElement("button");
@@ -10378,6 +10410,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           remove.textContent = "×";
           remove.setAttribute("aria-label", "添付を外す");
           remove.addEventListener("click", () => {
+            revokePendingMediaPreview(item);
             pendingMediaItems = pendingMediaItems.filter((candidate) => candidate.clientId !== item.clientId);
             renderPendingMedia();
             updateComposerReserve();
@@ -10804,6 +10837,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           textarea.focus({ preventScroll: true });
           return;
         }
+        revokePendingMediaPreviews();
         pendingMediaItems = [];
         renderPendingMedia();
         textarea.value = "";
@@ -10823,14 +10857,24 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           try {
             mediaButton.disabled = true;
             const preparedFile = await prepareUploadFile(file);
-            pendingMediaItems = [
+            const previewUrl =
+              preparedFile && preparedFile.type && preparedFile.type.startsWith("image/") && typeof URL !== "undefined" && typeof URL.createObjectURL === "function"
+                ? URL.createObjectURL(preparedFile)
+                : "";
+            const nextPendingMediaItems = [
               ...pendingMediaItems,
               {
                 clientId: Date.now() + "_" + Math.random().toString(36).slice(2),
                 filename: preparedFile.name || file.name || "attachment",
+                previewUrl,
                 file: preparedFile
               }
-            ].slice(0, 12);
+            ];
+            const retainedPendingMediaItems = nextPendingMediaItems.slice(-12);
+            for (const dropped of nextPendingMediaItems.slice(0, Math.max(0, nextPendingMediaItems.length - 12))) {
+              revokePendingMediaPreview(dropped);
+            }
+            pendingMediaItems = retainedPendingMediaItems;
             renderPendingMedia();
             setStatus("添付を送信待ちに追加しました。repo 未指定の通常会話では private media として保存します。", { temporary: true });
             textarea.focus({ preventScroll: true });

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -10351,7 +10351,10 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         for (const reference of list) {
           const link = document.createElement("a");
           link.className = "media-chip";
-          const downloadHref = reference.downloadUrl || (reference.mediaId ? "/v2/media/" + reference.mediaId + "/download" : "#");
+          const mediaRouteHref = reference.mediaId ? "/v2/media/" + reference.mediaId + "/download" : "";
+          const referenceDownloadUrl = typeof reference.downloadUrl === "string" ? reference.downloadUrl : "";
+          const safeDownloadHref = referenceDownloadUrl.startsWith("/v2/media/") ? referenceDownloadUrl : "";
+          const downloadHref = mediaRouteHref || safeDownloadHref || "#";
           link.href = downloadHref;
           link.target = "_blank";
           link.rel = "noreferrer";

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -818,8 +818,10 @@ test("worker serves dashboard media add controls for iPhone-first upload", async
   assert.equal(body.includes("/v2/media/upload"), true);
   assert.equal(body.includes("createImageBitmap"), true);
   assert.equal(body.includes("className = \"media-thumb\""), true);
-  assert.equal(body.includes("isImage && link.href && link.href !== \"#\""), true);
-  assert.equal(body.includes("link.href = reference.downloadUrl || (reference.mediaId ? \"/v2/media/\" + reference.mediaId + \"/download\" : \"#\")"), true);
+  assert.equal(body.includes("const downloadHref = reference.downloadUrl || (reference.mediaId ? \"/v2/media/\" + reference.mediaId + \"/download\" : \"#\")"), true);
+  assert.equal(body.includes("link.href = downloadHref"), true);
+  assert.equal(body.includes("isImage && downloadHref !== \"#\""), true);
+  assert.equal(body.includes("image.src = downloadHref"), true);
   assert.equal(body.includes("URL.createObjectURL"), true);
   assert.equal(body.includes("URL.revokeObjectURL"), true);
   assert.equal(body.includes("repo 未指定の通常会話では private media として保存します"), true);

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -817,6 +817,9 @@ test("worker serves dashboard media add controls for iPhone-first upload", async
   assert.equal(body.includes("accept=\"image/*\""), false);
   assert.equal(body.includes("/v2/media/upload"), true);
   assert.equal(body.includes("createImageBitmap"), true);
+  assert.equal(body.includes("className = \"media-thumb\""), true);
+  assert.equal(body.includes("URL.createObjectURL"), true);
+  assert.equal(body.includes("URL.revokeObjectURL"), true);
   assert.equal(body.includes("repo 未指定の通常会話では private media として保存します"), true);
   assert.equal(body.includes("mediaReferences"), true);
   assert.equal(body.includes("pendingSendRollbacks"), true);

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -818,6 +818,8 @@ test("worker serves dashboard media add controls for iPhone-first upload", async
   assert.equal(body.includes("/v2/media/upload"), true);
   assert.equal(body.includes("createImageBitmap"), true);
   assert.equal(body.includes("className = \"media-thumb\""), true);
+  assert.equal(body.includes("isImage && link.href && link.href !== \"#\""), true);
+  assert.equal(body.includes("link.href = reference.downloadUrl || (reference.mediaId ? \"/v2/media/\" + reference.mediaId + \"/download\" : \"#\")"), true);
   assert.equal(body.includes("URL.createObjectURL"), true);
   assert.equal(body.includes("URL.revokeObjectURL"), true);
   assert.equal(body.includes("repo 未指定の通常会話では private media として保存します"), true);

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -818,7 +818,9 @@ test("worker serves dashboard media add controls for iPhone-first upload", async
   assert.equal(body.includes("/v2/media/upload"), true);
   assert.equal(body.includes("createImageBitmap"), true);
   assert.equal(body.includes("className = \"media-thumb\""), true);
-  assert.equal(body.includes("const downloadHref = reference.downloadUrl || (reference.mediaId ? \"/v2/media/\" + reference.mediaId + \"/download\" : \"#\")"), true);
+  assert.equal(body.includes("const mediaRouteHref = reference.mediaId ? \"/v2/media/\" + reference.mediaId + \"/download\" : \"\""), true);
+  assert.equal(body.includes("const safeDownloadHref = referenceDownloadUrl.startsWith(\"/v2/media/\") ? referenceDownloadUrl : \"\""), true);
+  assert.equal(body.includes("const downloadHref = mediaRouteHref || safeDownloadHref || \"#\""), true);
   assert.equal(body.includes("link.href = downloadHref"), true);
   assert.equal(body.includes("isImage && downloadHref !== \"#\""), true);
   assert.equal(body.includes("image.src = downloadHref"), true);
@@ -1334,6 +1336,8 @@ test("worker stores dashboard media references in chat without raw binary", asyn
   assert.equal(body.messages[0].text, "添付を追加しました。");
   assert.equal(body.messages[0].mediaReferences.length, 1);
   assert.equal(body.messages[0].mediaReferences[0].mediaId, "med_testmedia1234");
+  assert.equal(body.messages[0].mediaReferences[0].contentType, "image/png");
+  assert.equal(body.messages[0].mediaReferences[0].downloadUrl, "/v2/media/med_testmedia1234/download");
   assert.equal(JSON.stringify(body).includes("fake image bytes"), false);
 });
 

--- a/worker.js
+++ b/worker.js
@@ -64777,8 +64777,10 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
     .send-button { width: 44px; height: 44px; border-radius: 999px; background: var(--text); color: var(--page-bg); font-size: 22px; }
     .pending-media, .message-media { display: flex; flex-wrap: wrap; gap: 8px; padding: 0 8px; }
     .pending-media:empty, .message-media:empty { display: none; }
-    .media-chip { display: inline-flex; align-items: center; max-width: 100%; min-height: 34px; border: 1px solid var(--border); border-radius: 999px; padding: 5px 10px; gap: 6px; color: var(--text); background: var(--soft); font-size: 12px; text-decoration: none; }
+    .media-chip { display: inline-flex; align-items: center; max-width: 100%; min-height: 34px; border: 1px solid var(--border); border-radius: 14px; padding: 5px 10px; gap: 8px; color: var(--text); background: var(--soft); font-size: 12px; text-decoration: none; }
     .media-chip span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: min(48vw, 320px); }
+    .media-thumb { width: 48px; height: 48px; flex: 0 0 auto; border-radius: 10px; object-fit: cover; background: var(--border); }
+    .media-chip.pending-preview { padding: 5px 8px 5px 5px; }
     .media-remove { border: 0; background: transparent; color: var(--muted); font: inherit; font-weight: 900; padding: 0 2px; cursor: pointer; }
     .composer-status { min-height: 18px; padding-left: 16px; color: var(--muted); font-size: 12px; }
     .composer-status.thinking::after { content: ""; display: inline-block; width: 1.4em; text-align: left; animation: thinkingDots 1.2s steps(4, end) infinite; }
@@ -65093,15 +65095,37 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           link.target = "_blank";
           link.rel = "noreferrer";
           link.textContent = "";
-          const icon = document.createElement("span");
-          icon.textContent = "\u6DFB\u4ED8";
+          const isImage = String(reference.contentType || "").startsWith("image/");
+          if (isImage && reference.mediaId) {
+            const image = document.createElement("img");
+            image.className = "media-thumb";
+            image.src = link.href;
+            image.alt = reference.filename || "\u6DFB\u4ED8\u753B\u50CF";
+            image.loading = "lazy";
+            link.appendChild(image);
+          } else {
+            const icon = document.createElement("span");
+            icon.textContent = "\u6DFB\u4ED8";
+            link.appendChild(icon);
+          }
           const label = document.createElement("span");
           label.textContent = reference.filename || reference.mediaId || "media";
-          link.appendChild(icon);
           link.appendChild(label);
           wrapper.appendChild(link);
         }
         return wrapper;
+      }
+
+      function revokePendingMediaPreview(item) {
+        if (item && item.previewUrl && typeof URL !== "undefined" && typeof URL.revokeObjectURL === "function") {
+          URL.revokeObjectURL(item.previewUrl);
+        }
+      }
+
+      function revokePendingMediaPreviews(items = pendingMediaItems) {
+        for (const item of Array.isArray(items) ? items : []) {
+          revokePendingMediaPreview(item);
+        }
       }
 
       function renderPendingMedia() {
@@ -65110,6 +65134,14 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         for (const item of pendingMediaItems) {
           const chip = document.createElement("span");
           chip.className = "media-chip";
+          if (item.previewUrl) {
+            chip.classList.add("pending-preview");
+            const image = document.createElement("img");
+            image.className = "media-thumb";
+            image.src = item.previewUrl;
+            image.alt = item.filename || "\u9001\u4FE1\u5F85\u3061\u753B\u50CF";
+            chip.appendChild(image);
+          }
           const label = document.createElement("span");
           label.textContent = item.filename || "attachment";
           const remove = document.createElement("button");
@@ -65118,6 +65150,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           remove.textContent = "\xD7";
           remove.setAttribute("aria-label", "\u6DFB\u4ED8\u3092\u5916\u3059");
           remove.addEventListener("click", () => {
+            revokePendingMediaPreview(item);
             pendingMediaItems = pendingMediaItems.filter((candidate) => candidate.clientId !== item.clientId);
             renderPendingMedia();
             updateComposerReserve();
@@ -65544,6 +65577,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           textarea.focus({ preventScroll: true });
           return;
         }
+        revokePendingMediaPreviews();
         pendingMediaItems = [];
         renderPendingMedia();
         textarea.value = "";
@@ -65563,14 +65597,24 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           try {
             mediaButton.disabled = true;
             const preparedFile = await prepareUploadFile(file);
-            pendingMediaItems = [
+            const previewUrl =
+              preparedFile && preparedFile.type && preparedFile.type.startsWith("image/") && typeof URL !== "undefined" && typeof URL.createObjectURL === "function"
+                ? URL.createObjectURL(preparedFile)
+                : "";
+            const nextPendingMediaItems = [
               ...pendingMediaItems,
               {
                 clientId: Date.now() + "_" + Math.random().toString(36).slice(2),
                 filename: preparedFile.name || file.name || "attachment",
+                previewUrl,
                 file: preparedFile
               }
-            ].slice(0, 12);
+            ];
+            const retainedPendingMediaItems = nextPendingMediaItems.slice(-12);
+            for (const dropped of nextPendingMediaItems.slice(0, Math.max(0, nextPendingMediaItems.length - 12))) {
+              revokePendingMediaPreview(dropped);
+            }
+            pendingMediaItems = retainedPendingMediaItems;
             renderPendingMedia();
             setStatus("\u6DFB\u4ED8\u3092\u9001\u4FE1\u5F85\u3061\u306B\u8FFD\u52A0\u3057\u307E\u3057\u305F\u3002repo \u672A\u6307\u5B9A\u306E\u901A\u5E38\u4F1A\u8A71\u3067\u306F private media \u3068\u3057\u3066\u4FDD\u5B58\u3057\u307E\u3059\u3002", { temporary: true });
             textarea.focus({ preventScroll: true });

--- a/worker.js
+++ b/worker.js
@@ -65091,7 +65091,10 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         for (const reference of list) {
           const link = document.createElement("a");
           link.className = "media-chip";
-          const downloadHref = reference.downloadUrl || (reference.mediaId ? "/v2/media/" + reference.mediaId + "/download" : "#");
+          const mediaRouteHref = reference.mediaId ? "/v2/media/" + reference.mediaId + "/download" : "";
+          const referenceDownloadUrl = typeof reference.downloadUrl === "string" ? reference.downloadUrl : "";
+          const safeDownloadHref = referenceDownloadUrl.startsWith("/v2/media/") ? referenceDownloadUrl : "";
+          const downloadHref = mediaRouteHref || safeDownloadHref || "#";
           link.href = downloadHref;
           link.target = "_blank";
           link.rel = "noreferrer";

--- a/worker.js
+++ b/worker.js
@@ -65091,15 +65091,16 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         for (const reference of list) {
           const link = document.createElement("a");
           link.className = "media-chip";
-          link.href = reference.downloadUrl || (reference.mediaId ? "/v2/media/" + reference.mediaId + "/download" : "#");
+          const downloadHref = reference.downloadUrl || (reference.mediaId ? "/v2/media/" + reference.mediaId + "/download" : "#");
+          link.href = downloadHref;
           link.target = "_blank";
           link.rel = "noreferrer";
           link.textContent = "";
           const isImage = String(reference.contentType || "").startsWith("image/");
-          if (isImage && link.href && link.href !== "#") {
+          if (isImage && downloadHref !== "#") {
             const image = document.createElement("img");
             image.className = "media-thumb";
-            image.src = link.href;
+            image.src = downloadHref;
             image.alt = reference.filename || "\u6DFB\u4ED8\u753B\u50CF";
             image.loading = "lazy";
             link.appendChild(image);

--- a/worker.js
+++ b/worker.js
@@ -65096,7 +65096,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           link.rel = "noreferrer";
           link.textContent = "";
           const isImage = String(reference.contentType || "").startsWith("image/");
-          if (isImage && reference.mediaId) {
+          if (isImage && link.href && link.href !== "#") {
             const image = document.createElement("img");
             image.className = "media-thumb";
             image.src = link.href;


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #498 の Dashboard Butler media UI 改善です。画像添付が成功したあと、送信待ち添付と thread 内 media reference にサムネイルを表示します。
- 画像解析本体、OCR、Issue #498 全体の完了はこの PR では閉じません。

## Satisfied Success Criteria

- 送信待ち画像に object URL の一時サムネイルを表示する。
- 送信済み画像 reference は既存 downloadUrl / mediaId route を使ってサムネイル表示する。
- 送信待ち preview URL は削除、上限超過による drop、送信成功時に revoke する。
- raw image binary は dashboard chat durable history / RAG / Issue / PR に保存しない既存方針を維持する。

## Unsatisfied Success Criteria

- app-server が attachmentId から画像を取得して解析する経路は未実装です。
- OCR / summary 自動生成は未実装です。
- merge 後の production deploy と iPhone Butler live E2E は未実施です。
- Issue #498 全体の完了判定と Issue close はこの PR では行いません。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #498
- Implementing Success Criteria: Dashboard Butler で画像添付後にサムネイルが見え、raw binary を durable history に保存しない。
- Explicit Non-goals: 画像解析本体、OCR、サムネイル生成物の R2 永続化、動画対応、deploy、Issue close はしない。
- Expected touched files/routes/workflows: src/worker/runtime.js, worker.js, test/worker.test.js
- Affected Issues: Issue #498
- Affected PRs: PR #510 / PR #511 / PR #512 の follow-up。
- Affected workflows: GitHub Actions workflow は変更なし。生成 worker.js 同期チェックのみ影響。
- Affected runtime/operator surfaces: Dashboard Butler composer / thread media rendering / Worker dashboard HTML
- What may break if we patch narrowly: サムネイル表示だけを行う。画像解析 protocol と混ぜると app-server boundary と media retrieval authority が大きく変わるため分ける。
- Unknowns to investigate before coding: production deploy 後の iPhone 実機表示は未確認。
- Validation needed: node --test test/worker.test.js と npm test。merge/deploy 後に iPhone Butler live E2E が必要。
- Stop condition: raw image binary を chat history/RAG/Issue/PR に保存する必要が出た場合は停止して再設計する。

## File / Line Hypotheses

- file: `src/worker/runtime.js`
  - hypothesis: `renderMediaReferences` と `renderPendingMedia` は filename chip だけで、画像 contentType / local File から preview を作っていない。
  - risk if changed narrowly: object URL を revoke しないと iPhone PWA でメモリが残る。
  - validation: dashboard HTML に `media-thumb`, `URL.createObjectURL`, `URL.revokeObjectURL` が含まれ、worker tests が通ること。
  - related Issue: Issue #498

## Hypothesis Retrospective

- expected: existing media reference metadata と same-origin download route だけで thread thumbnail を出せる。
- actual: 送信待ちは temporary object URL、送信済みは downloadUrl/mediaId route を `img.media-thumb` に使う実装にした。
- mismatch: なし。
- lesson: thumbnail UI は raw binary persistence なしで成立する。解析用 attachment retrieval は別スライスに分ける。
- should become RAG candidate: はい。Issue #498 の media UI 境界として有用。

## Verification Evidence

- Unit: node --test test/worker.test.js: pass 190/190
- Integration: npm test: pass 943/944, skipped 1, fail 0; check:self-parity pass; check:generated-worker pass
- E2E: 未実施。merge/deploy 後に iPhone Butler で画像添付サムネイル表示を確認する。
- Manual: 未実施。
- Evidence path/link: test/worker.test.js; src/worker/runtime.js

## Butler Completion Contract

- Owner goal: 画像を添付した時に、ファイル名だけでなくサムネイルで何を送ったか分かるようにする。
- Butler entrypoint: Dashboard Butler composer の media add button と dashboard thread rendering。
- Action Schema exposure: 不要。Dashboard runtime UI の変更で、Custom GPT Action Schema は変更しない。
- Runtime path: Dashboard HTML/JS renderPendingMedia / renderMediaReferences -> /v2/media/:id/download image route
- Runner/runtime truth: テストで dashboard HTML に thumbnail/object URL/revoke hook があることを確認。production runtime truth は deploy 後に確認する。
- Authority boundary: 未変更。private media の same-origin read のみ。deploy はこの PR では実行しない。
- E2E evidence: 未実施。merge/deploy 後に iPhone Butler で live E2E が必要。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: merge 後に必要。deploy はこの PR では実行しない。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: merge/deploy 後に必要。

## Related Constitution Rules

- Issue traceability: Issue #498 に限定。
- Memory safety: raw media binary を durable history/RAG/Issue/PR に保存しない。
- Authority boundary: private media read は same-origin route 経由。
- Butler Completion Gate: live E2E 未実施のため incomplete。

## Out-of-scope but NOT implemented

- app-server 画像解析。
- OCR / summary generation。
- R2 thumbnail object generation。
- production deploy と live iPhone E2E。
- Issue #498 close。

## Extra changes (if any)

Generated worker.js was rebuilt from src/worker.js.

<!-- VTDD metadata -->
- Issue: Issue #498
- Execution ID: codex/498-media-thumbnails
- Goal: Issue #498 Dashboard Butler media thumbnail UI
