### PR TITLE
Improve Dashboard Web Push notification copy

### DIFF
--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -7075,17 +7075,93 @@ async function dispatchDashboardWebPushForEvent(env, event) {
   };
 }
 
-function buildDashboardWebPushPayload(event) {
+export function buildDashboardWebPushPayload(event) {
   const record = normalizeDashboardEventRecord(event);
-  const title = record.kind === "dashboard_push_test" ? "VTDD Butler test" : "VTDD Butler";
-  const statusText = [record.status, record.conclusion].filter(Boolean).join("/");
-  const body = [record.title, record.repository, statusText].filter(Boolean).join(" - ");
+  const title = buildDashboardWebPushTitle(record);
+  const body = buildDashboardWebPushBody(record);
   return {
     title,
     body: body || "Dashboard Butler の通知です。",
     tag: `vtdd-${record.kind || "dashboard"}-${record.runId || record.id || "event"}`.slice(0, 120),
     url: record.runUrl || "/dashboard/notifications"
   };
+}
+
+function buildDashboardWebPushTitle(record) {
+  const repository = shortRepositoryName(record.repository);
+  if (record.kind === "dashboard_push_test") {
+    return "VTDD Butler テスト通知";
+  }
+  if (record.kind === "vps_runner_execution") {
+    return `VPS ${dashboardPushStatusLabel(record)}${repository ? `: ${repository}` : ""}`.slice(0, 80);
+  }
+  if (record.kind === "github_actions_workflow_run") {
+    const isDeploy = normalize(record.workflowName).includes("deploy");
+    const label = dashboardPushStatusLabel(record);
+    if (isDeploy) {
+      return `デプロイ${label}${repository ? `: ${repository}` : ""}`.slice(0, 80);
+    }
+    const workflow = compactNotificationText(record.workflowName || "workflow", 24);
+    return `Actions ${label}: ${workflow}${repository ? ` / ${repository}` : ""}`.slice(0, 80);
+  }
+  return `VTDD Butler ${dashboardPushStatusLabel(record)}${repository ? `: ${repository}` : ""}`.slice(0, 80);
+}
+
+function buildDashboardWebPushBody(record) {
+  if (record.kind === "dashboard_push_test") {
+    return "通知経路は正常です。iPhone PWA にサーバ送信できました。";
+  }
+
+  const details = [];
+  const title = compactNotificationText(record.title, 58);
+  if (title && title !== record.workflowName) {
+    details.push(title);
+  }
+  if (record.workflowName) {
+    details.push(`workflow: ${compactNotificationText(record.workflowName, 36)}`);
+  }
+  if (record.headBranch) {
+    details.push(`branch: ${compactNotificationText(record.headBranch, 34)}`);
+  }
+  if (record.headSha) {
+    details.push(`sha: ${record.headSha.slice(0, 7)}`);
+  }
+  if (record.runId) {
+    details.push(`run: ${compactNotificationText(record.runId, 26)}`);
+  }
+  return details.join(" / ").slice(0, 180);
+}
+
+function dashboardPushStatusLabel(record) {
+  const status = normalize(record.status);
+  const conclusion = normalize(record.conclusion);
+  if (status === "completed") {
+    if (conclusion === "success") return "完了";
+    if (conclusion === "failure" || conclusion === "timed_out") return "失敗";
+    if (conclusion === "cancelled") return "キャンセル";
+    if (conclusion === "skipped") return "スキップ";
+    if (conclusion === "action_required") return "要対応";
+    return "完了";
+  }
+  if (status === "in_progress" || status === "running") return "実行中";
+  if (status === "queued" || status === "requested" || status === "waiting") return "待機中";
+  if (status === "failed") return "失敗";
+  if (status === "canceled" || status === "cancelled") return "キャンセル";
+  return "更新";
+}
+
+function shortRepositoryName(repository) {
+  const text = normalizeDashboardEventText(repository);
+  const parts = text.split("/");
+  return parts.length === 2 ? parts[1] : text;
+}
+
+function compactNotificationText(value, limit) {
+  const text = normalizeDashboardEventText(value).replace(/\s+/g, " ");
+  if (text.length <= limit) {
+    return text;
+  }
+  return `${text.slice(0, Math.max(0, limit - 1))}…`;
 }
 
 async function sendDashboardWebPush({ env, subscription, payload }) {

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import worker from "../src/worker.js";
 import { DashboardChatRoom } from "../src/worker.js";
+import { buildDashboardWebPushPayload } from "../src/worker/runtime.js";
 import {
   ActionType,
   ActorRole,
@@ -2623,6 +2624,65 @@ test("worker sends server-side dashboard Web Push test only for authenticated ow
   assert.equal("body" in calls[0].init, false);
   assert.equal(JSON.stringify(body).includes("p256dh-key"), false);
   assert.equal(JSON.stringify(body).includes("auth-key"), false);
+});
+
+test("worker builds distinct dashboard Web Push copy by event type", () => {
+  const deploySuccess = buildDashboardWebPushPayload({
+    kind: "github_actions_workflow_run",
+    repository: "marushu/vtdd-v2-p",
+    workflowName: "deploy-production",
+    runId: "26323724369",
+    status: "completed",
+    conclusion: "success",
+    headSha: "0a9e0b8587aa684de3dbd08b57909fe271192662",
+    headBranch: "main",
+    title: "deploy-production",
+    runUrl: "https://github.com/marushu/vtdd-v2-p/actions/runs/26323724369"
+  });
+  assert.equal(deploySuccess.title, "デプロイ完了: vtdd-v2-p");
+  assert.equal(deploySuccess.body.includes("workflow: deploy-production"), true);
+  assert.equal(deploySuccess.body.includes("branch: main"), true);
+  assert.equal(deploySuccess.body.includes("sha: 0a9e0b8"), true);
+  assert.equal(deploySuccess.body.includes("run: 26323724369"), true);
+
+  const deployFailure = buildDashboardWebPushPayload({
+    kind: "github_actions_workflow_run",
+    repository: "marushu/vtdd-v2-p",
+    workflowName: "deploy-production",
+    runId: "26323724370",
+    status: "completed",
+    conclusion: "failure",
+    headBranch: "main",
+    title: "deploy-production"
+  });
+  assert.equal(deployFailure.title, "デプロイ失敗: vtdd-v2-p");
+
+  const testPush = buildDashboardWebPushPayload({
+    kind: "dashboard_push_test",
+    repository: "marushu/vtdd-v2-p",
+    workflowName: "dashboard-push-test",
+    runId: "test-run",
+    status: "completed",
+    conclusion: "success",
+    title: "server push test"
+  });
+  assert.equal(testPush.title, "VTDD Butler テスト通知");
+  assert.equal(testPush.body, "通知経路は正常です。iPhone PWA にサーバ送信できました。");
+
+  const runner = buildDashboardWebPushPayload({
+    kind: "vps_runner_execution",
+    repository: "marushu/vtdd-v2-p",
+    workflowName: "vps-runner",
+    runId: "remote-codex-issue514",
+    status: "running",
+    conclusion: "",
+    headBranch: "codex/514-push-notification-copy",
+    title: "VPS Codex CLI が作業を開始しました"
+  });
+  assert.equal(runner.title, "VPS 実行中: vtdd-v2-p");
+  assert.equal(runner.body.includes("VPS Codex CLI が作業を開始しました"), true);
+  assert.equal(runner.body.includes("workflow: vps-runner"), true);
+  assert.equal(runner.body.includes("branch: codex/514-push-notification-copy"), true);
 });
 
 test("worker reports server-side dashboard Web Push configuration blockers", async () => {

--- a/worker.js
+++ b/worker.js
@@ -62075,15 +62075,85 @@ async function dispatchDashboardWebPushForEvent(env, event) {
 }
 function buildDashboardWebPushPayload(event) {
   const record2 = normalizeDashboardEventRecord(event);
-  const title = record2.kind === "dashboard_push_test" ? "VTDD Butler test" : "VTDD Butler";
-  const statusText = [record2.status, record2.conclusion].filter(Boolean).join("/");
-  const body = [record2.title, record2.repository, statusText].filter(Boolean).join(" - ");
+  const title = buildDashboardWebPushTitle(record2);
+  const body = buildDashboardWebPushBody(record2);
   return {
     title,
     body: body || "Dashboard Butler \u306E\u901A\u77E5\u3067\u3059\u3002",
     tag: `vtdd-${record2.kind || "dashboard"}-${record2.runId || record2.id || "event"}`.slice(0, 120),
     url: record2.runUrl || "/dashboard/notifications"
   };
+}
+function buildDashboardWebPushTitle(record2) {
+  const repository = shortRepositoryName(record2.repository);
+  if (record2.kind === "dashboard_push_test") {
+    return "VTDD Butler \u30C6\u30B9\u30C8\u901A\u77E5";
+  }
+  if (record2.kind === "vps_runner_execution") {
+    return `VPS ${dashboardPushStatusLabel(record2)}${repository ? `: ${repository}` : ""}`.slice(0, 80);
+  }
+  if (record2.kind === "github_actions_workflow_run") {
+    const isDeploy = normalize7(record2.workflowName).includes("deploy");
+    const label = dashboardPushStatusLabel(record2);
+    if (isDeploy) {
+      return `\u30C7\u30D7\u30ED\u30A4${label}${repository ? `: ${repository}` : ""}`.slice(0, 80);
+    }
+    const workflow = compactNotificationText(record2.workflowName || "workflow", 24);
+    return `Actions ${label}: ${workflow}${repository ? ` / ${repository}` : ""}`.slice(0, 80);
+  }
+  return `VTDD Butler ${dashboardPushStatusLabel(record2)}${repository ? `: ${repository}` : ""}`.slice(0, 80);
+}
+function buildDashboardWebPushBody(record2) {
+  if (record2.kind === "dashboard_push_test") {
+    return "\u901A\u77E5\u7D4C\u8DEF\u306F\u6B63\u5E38\u3067\u3059\u3002iPhone PWA \u306B\u30B5\u30FC\u30D0\u9001\u4FE1\u3067\u304D\u307E\u3057\u305F\u3002";
+  }
+  const details = [];
+  const title = compactNotificationText(record2.title, 58);
+  if (title && title !== record2.workflowName) {
+    details.push(title);
+  }
+  if (record2.workflowName) {
+    details.push(`workflow: ${compactNotificationText(record2.workflowName, 36)}`);
+  }
+  if (record2.headBranch) {
+    details.push(`branch: ${compactNotificationText(record2.headBranch, 34)}`);
+  }
+  if (record2.headSha) {
+    details.push(`sha: ${record2.headSha.slice(0, 7)}`);
+  }
+  if (record2.runId) {
+    details.push(`run: ${compactNotificationText(record2.runId, 26)}`);
+  }
+  return details.join(" / ").slice(0, 180);
+}
+function dashboardPushStatusLabel(record2) {
+  const status = normalize7(record2.status);
+  const conclusion = normalize7(record2.conclusion);
+  if (status === "completed") {
+    if (conclusion === "success") return "\u5B8C\u4E86";
+    if (conclusion === "failure" || conclusion === "timed_out") return "\u5931\u6557";
+    if (conclusion === "cancelled") return "\u30AD\u30E3\u30F3\u30BB\u30EB";
+    if (conclusion === "skipped") return "\u30B9\u30AD\u30C3\u30D7";
+    if (conclusion === "action_required") return "\u8981\u5BFE\u5FDC";
+    return "\u5B8C\u4E86";
+  }
+  if (status === "in_progress" || status === "running") return "\u5B9F\u884C\u4E2D";
+  if (status === "queued" || status === "requested" || status === "waiting") return "\u5F85\u6A5F\u4E2D";
+  if (status === "failed") return "\u5931\u6557";
+  if (status === "canceled" || status === "cancelled") return "\u30AD\u30E3\u30F3\u30BB\u30EB";
+  return "\u66F4\u65B0";
+}
+function shortRepositoryName(repository) {
+  const text = normalizeDashboardEventText(repository);
+  const parts = text.split("/");
+  return parts.length === 2 ? parts[1] : text;
+}
+function compactNotificationText(value, limit) {
+  const text = normalizeDashboardEventText(value).replace(/\s+/g, " ");
+  if (text.length <= limit) {
+    return text;
+  }
+  return `${text.slice(0, Math.max(0, limit - 1))}\u2026`;
 }
 async function sendDashboardWebPush({ env, subscription, payload }) {
   const endpoint = normalizeDashboardUrl(subscription?.endpoint);


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #514 の通知センター/Web Push 改善として、iPhone のOS通知に出るタイトルと本文をイベント種別ごとに分かりやすくする。

## Satisfied Success Criteria

- deploy workflow の Web Push タイトルを デプロイ完了/デプロイ失敗 で判別できるようにした。
- GitHub Actions、VPS runner、サーバ送信テストの通知タイトルをそれぞれ別文言にした。
- 通知本文に workflow、branch、sha、run id を短く含め、GitHub モバイル通知に近い判断材料を出す。
- endpoint/auth/p256dh などの push subscription raw material は通知 payload に追加していない。

## Unsatisfied Success Criteria

- iPhone PWA 実機で deploy 完了通知の文言を確認する E2E は、このPR merge/deploy後に実施する。
- Issue #514 の close は human approval と実機 evidence 後に判断する。

## Non-goal violations

マイクモード/音声入力/Butler読み上げは実装しない。
VAPID鍵、購読保存、deploy workflow、通知購読ストアは変更しない。
Issue #514 はこのPRだけでは自動 close しない。

## Dry-run Impact Report

- Target Issue: Issue #514
- Implementing Success Criteria: deploy/Actions/VPS runner/test の Web Push 通知タイトル・本文を内容別に読みやすくする。
- Explicit Non-goals: 音声機能、VAPID/購読保存、deploy workflow、credential/permission mutation は対象外。
- Expected touched files/routes/workflows: src/worker/runtime.js, worker.js, test/worker.test.js
- Affected Issues: Issue #514
- Affected PRs: なし
- Affected workflows: GitHub Actions event と VPS runner event から送られる Dashboard Web Push payload の文言のみ。workflow dispatch 自体は未変更。
- Affected runtime/operator surfaces: Dashboard Butler notification center / iOS PWA Web Push / Worker runtime
- What may break if we patch narrowly: 通知 payload に秘密情報を入れる、または generic な VTDD Butler 通知に戻ると iPhone 上で内容判別できない。
- Unknowns to investigate before coding: iOS 実機での表示幅は端末側に依存するため、merge/deploy後の実機確認が必要。
- Validation needed: node --test test/worker.test.js; npm test; merge/deploy後の iPhone PWA Web Push 実機確認。
- Stop condition: 通知文言改善を超えて deploy workflow や権限/鍵に触る必要が出た場合は停止。

## File / Line Hypotheses

- file: src/worker/runtime.js
  - hypothesis: buildDashboardWebPushPayload が OS 通知の title/body を決めている。
  - risk if changed narrowly: subscription raw material を出さず、既存の dispatch/cleanup 経路を壊さない必要がある。
  - validation: payload helper の unit test と worker 全体テスト。
  - related Issue: Issue #514

## Hypothesis Retrospective

- expected: Web Push payload 生成だけを差し替えれば通知内容を改善できる。
- actual: buildDashboardWebPushPayload にイベント種別別 title/body helper を追加し、dispatch 経路は未変更。
- mismatch: なし。
- lesson: 通知到達性と通知本文の分かりやすさは別の Success Criteria として検証する必要がある。
- should become RAG candidate: はい。通知は generic 文言ではなくイベント種別別にする。

## Verification Evidence

- Unit: node --test test/worker.test.js: pass
- Integration: npm test: pass (945 pass, 1 skipped)
- E2E: 未実施。merge/deploy 後に iPhone PWA で deploy/test 通知文言を確認する。
- Manual: Payload unit test で deploy success/failure, dashboard_push_test, vps_runner_execution の title/body を確認。
- Evidence path/link: PR checks と npm test output

## Butler Completion Contract

- Owner goal: iPhone の通知一覧だけで deploy 成功/失敗、Actions、VPS runner、テスト通知の内容をぱっと判別できる。
- Butler entrypoint: Dashboard 通知センターと保存済み Web Push 購読。
- Action Schema exposure: 不要。既存の notification center/runtime route の payload 文言のみ変更。
- Runtime path: GitHub Actions/VPS runner/dashboard push test -> dispatchDashboardWebPushForEvent -> buildDashboardWebPushPayload -> Web Push subscription
- Runner/runtime truth: webPush delivered/attempted と通知センターのサーバ送信結果を引き続き利用する。
- Authority boundary: 新しい high-risk authority なし。deploy は引き続き scoped passkey approval が必要。
- E2E evidence: 未完了。PR merge/deploy 後に iPhone PWA Web Push 表示で確認する。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 必要。PR merge 後に production deploy approval URL で実施する。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 必要。deploy 後に実機通知の title/body を確認する。

## Related Constitution Rules

- Butler Completion Gate
- Evidence Discipline
- Authority Boundary
- RAG Memory Capture and Cost Boundary

## Out-of-scope but NOT implemented

- マイクモード/音声入力/Butler読み上げ。
- Issue #514 の自動 close。
- Cloudflare/Web Push credential mutation。

## Extra changes (if any)

buildDashboardWebPushPayload を unit test 可能にするため named export にした。

<!-- VTDD metadata -->
- Issue: Issue #514
- Execution ID: Not provided.
- Goal: Not provided.
