### PR TITLE
Issue #450 Dashboard reconnect draft preserve

### DIFF
--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -233,6 +233,17 @@ export class DashboardChatRoom {
       normalizePositiveInteger(payload?.relatedIssue || payload?.issueNumber) || extractIssueNumberFromDashboardChatText(text);
     const now = new Date().toISOString();
     const store = resolveDashboardChatStore(this.env);
+    if (clientMessageId && await this.hasAcceptedOwnerMessage({ threadId, clientMessageId, store })) {
+      this.sendSocket(socket, {
+        type: "owner_message_accepted",
+        ok: true,
+        clientMessageId,
+        messageId: clientMessageId,
+        duplicate: true
+      });
+      await this.broadcastThread({ threadId });
+      return;
+    }
     const repositoryResolution = await resolveDashboardChatRepository({
       payload: { ...normalizeObject(payload), text, threadId },
       env: this.env
@@ -263,6 +274,7 @@ export class DashboardChatRoom {
         relatedIssue,
         status: "sent",
         text,
+        messageId: clientMessageId || undefined,
         mediaReferences: mediaValidation.mediaReferences,
         createdAt: now
       },
@@ -283,6 +295,7 @@ export class DashboardChatRoom {
         { threadId }
       );
       const messages = store ? await store.appendMany(threadId, [ownerMessage, butlerMessage]) : [ownerMessage, butlerMessage].filter(Boolean);
+      await this.writeAcceptedOwnerMessage({ threadId, clientMessageId, messageId: ownerMessage.messageId, acceptedAt: now });
       await this.broadcastThread({ threadId, messages });
       this.sendSocket(socket, {
         type: "owner_message_accepted",
@@ -294,6 +307,7 @@ export class DashboardChatRoom {
     }
 
     const messages = store ? await store.appendMany(threadId, [ownerMessage]) : [ownerMessage].filter(Boolean);
+    await this.writeAcceptedOwnerMessage({ threadId, clientMessageId, messageId: ownerMessage.messageId, acceptedAt: now });
     await this.broadcastThread({ threadId, messages });
     this.sendSocket(socket, {
       type: "owner_message_accepted",
@@ -504,6 +518,46 @@ export class DashboardChatRoom {
     await this.ctx.storage.put(`app_server_thread:${normalizedThreadId}`, {
       codexThreadId,
       updatedAt: normalizeIsoTimestamp(mapping?.updatedAt) || new Date().toISOString()
+    });
+    return true;
+  }
+
+  async hasAcceptedOwnerMessage({ threadId, clientMessageId, store }) {
+    const normalizedThreadId = normalizeDashboardThreadId(threadId);
+    const normalizedClientMessageId = normalizeDashboardEventText(clientMessageId);
+    if (!normalizedThreadId || !normalizedClientMessageId) {
+      return false;
+    }
+    if (typeof this.ctx?.storage?.get === "function") {
+      try {
+        const record = await this.ctx.storage.get(`owner_message:${normalizedThreadId}:${normalizedClientMessageId}`);
+        if (record) {
+          return true;
+        }
+      } catch {
+        // Fall back to thread history below.
+      }
+    }
+    if (store && typeof store.listThread === "function") {
+      try {
+        const messages = await store.listThread(normalizedThreadId, { limit: 80 });
+        return messages.some((message) => message?.role === "owner" && message?.messageId === normalizedClientMessageId);
+      } catch {
+        return false;
+      }
+    }
+    return false;
+  }
+
+  async writeAcceptedOwnerMessage({ threadId, clientMessageId, messageId, acceptedAt }) {
+    const normalizedThreadId = normalizeDashboardThreadId(threadId);
+    const normalizedClientMessageId = normalizeDashboardEventText(clientMessageId);
+    if (!normalizedThreadId || !normalizedClientMessageId || typeof this.ctx?.storage?.put !== "function") {
+      return false;
+    }
+    await this.ctx.storage.put(`owner_message:${normalizedThreadId}:${normalizedClientMessageId}`, {
+      messageId: normalizeDashboardEventText(messageId) || normalizedClientMessageId,
+      acceptedAt: normalizeIsoTimestamp(acceptedAt) || new Date().toISOString()
     });
     return true;
   }
@@ -10494,6 +10548,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
       const pendingSendRollbacks = new Map();
       const messagesById = new Map();
       let pendingOwnerSend = null;
+      let retryClientMessageId = "";
 
       function updateComposerReserve() {
         log.style.setProperty("--composer-reserve", Math.ceil(form.getBoundingClientRect().height) + "px");
@@ -10546,6 +10601,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           pending.submitButton.disabled = false;
         }
         if (options.clearComposer === true) {
+          retryClientMessageId = "";
           if (textarea.value.trim() === pending.text) {
             textarea.value = "";
           }
@@ -10553,6 +10609,8 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           pendingMediaItems = [];
           renderPendingMedia();
           resizeComposerInput();
+        } else {
+          retryClientMessageId = pending.clientMessageId;
         }
         updateComposerReserve();
         return true;
@@ -11081,7 +11139,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         setComposerLocked(true);
         setStatus(pendingMediaItems.length > 0 ? "添付を保存してから送信しています" : "送信中です", { thinking: true });
         let mediaReferences = [];
-        const clientMessageId = createClientMessageId();
+        const clientMessageId = retryClientMessageId || createClientMessageId();
         try {
           mediaReferences = await uploadPendingMedia(clientMessageId);
         } catch (error) {

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -10493,6 +10493,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
       let pendingMediaItems = [];
       const pendingSendRollbacks = new Map();
       const messagesById = new Map();
+      let pendingOwnerSend = null;
 
       function updateComposerReserve() {
         log.style.setProperty("--composer-reserve", Math.ceil(form.getBoundingClientRect().height) + "px");
@@ -10526,6 +10527,35 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
             }
           }, 2400);
         }
+      }
+
+      function setComposerLocked(locked) {
+        textarea.readOnly = locked === true;
+        if (mediaButton) mediaButton.disabled = locked === true;
+      }
+
+      function releasePendingOwnerSend(clientMessageId, options = {}) {
+        if (!pendingOwnerSend || pendingOwnerSend.clientMessageId !== clientMessageId) return false;
+        const pending = pendingOwnerSend;
+        pendingOwnerSend = null;
+        if (pending.timeoutId && options.keepRollbackTimer !== true) {
+          window.clearTimeout(pending.timeoutId);
+        }
+        setComposerLocked(false);
+        if (pending.submitButton) {
+          pending.submitButton.disabled = false;
+        }
+        if (options.clearComposer === true) {
+          if (textarea.value.trim() === pending.text) {
+            textarea.value = "";
+          }
+          revokePendingMediaPreviews();
+          pendingMediaItems = [];
+          renderPendingMedia();
+          resizeComposerInput();
+        }
+        updateComposerReserve();
+        return true;
       }
 
       function appendMessage(message) {
@@ -10993,12 +11023,15 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
               const clientMessageId = body.clientMessageId || body.client_message_id || "";
               if (clientMessageId) {
                 pendingSendRollbacks.delete(clientMessageId);
+                releasePendingOwnerSend(clientMessageId, { clearComposer: true });
+                setStatus("送信を保存しました。app-server bridge の返信を待っています", { thinking: true });
               }
             } else if (body.type === "error") {
               const clientMessageId = body.clientMessageId || body.client_message_id || "";
               if (clientMessageId && pendingSendRollbacks.has(clientMessageId)) {
                 const mediaReferences = pendingSendRollbacks.get(clientMessageId) || [];
                 pendingSendRollbacks.delete(clientMessageId);
+                releasePendingOwnerSend(clientMessageId, { clearComposer: false });
                 rollbackAbandonedMedia(mediaReferences, clientMessageId).catch(() => {});
               }
               appendError(body.reason || "WebSocket message error");
@@ -11008,12 +11041,22 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           }
         });
         chatSocket.addEventListener("close", () => {
-          setStatus("WebSocket が切れました。履歴を再取得して再接続します。");
+          if (pendingOwnerSend) {
+            releasePendingOwnerSend(pendingOwnerSend.clientMessageId, { clearComposer: false, keepRollbackTimer: true });
+            setStatus("送信確認前に WebSocket が切れました。入力は残しています。履歴再取得後にもう一度送信できます。");
+          } else {
+            setStatus("WebSocket が切れました。履歴を再取得して再接続します。");
+          }
           refreshThread();
           scheduleReconnect();
         });
         chatSocket.addEventListener("error", () => {
-          setStatus("WebSocket 接続に失敗しました。履歴を再取得して再接続します。");
+          if (pendingOwnerSend) {
+            releasePendingOwnerSend(pendingOwnerSend.clientMessageId, { clearComposer: false, keepRollbackTimer: true });
+            setStatus("送信確認前に WebSocket 接続が失敗しました。入力は残しています。再接続後にもう一度送信できます。");
+          } else {
+            setStatus("WebSocket 接続に失敗しました。履歴を再取得して再接続します。");
+          }
           refreshThread();
           scheduleReconnect();
         });
@@ -11035,6 +11078,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           return;
         }
         if (submitButton) submitButton.disabled = true;
+        setComposerLocked(true);
         setStatus(pendingMediaItems.length > 0 ? "添付を保存してから送信しています" : "送信中です", { thinking: true });
         let mediaReferences = [];
         const clientMessageId = createClientMessageId();
@@ -11042,11 +11086,26 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           mediaReferences = await uploadPendingMedia(clientMessageId);
         } catch (error) {
           setStatus((error && error.message) || "添付の保存に失敗しました。");
+          setComposerLocked(false);
           if (submitButton) submitButton.disabled = false;
           textarea.focus({ preventScroll: true });
           return;
         }
         pendingSendRollbacks.set(clientMessageId, mediaReferences);
+        pendingOwnerSend = {
+          clientMessageId,
+          text,
+          mediaReferences,
+          submitButton,
+          timeoutId: window.setTimeout(() => {
+            if (!pendingSendRollbacks.has(clientMessageId)) return;
+            const rollbackMediaReferences = pendingSendRollbacks.get(clientMessageId) || [];
+            pendingSendRollbacks.delete(clientMessageId);
+            releasePendingOwnerSend(clientMessageId, { clearComposer: false });
+            rollbackAbandonedMedia(rollbackMediaReferences, clientMessageId).catch(() => {});
+            setStatus("送信確認が返りませんでした。入力は残しています。再接続後にもう一度送信してください。");
+          }, 30000)
+        };
         try {
           chatSocket.send(JSON.stringify({
             type: "owner_message",
@@ -11058,28 +11117,15 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
             relatedIssue: issueNumber,
             mediaReferences
           }));
-          window.setTimeout(() => {
-            if (!pendingSendRollbacks.has(clientMessageId)) return;
-            const rollbackMediaReferences = pendingSendRollbacks.get(clientMessageId) || [];
-            pendingSendRollbacks.delete(clientMessageId);
-            rollbackAbandonedMedia(rollbackMediaReferences, clientMessageId).catch(() => {});
-            setStatus("送信確認が返らなかったため、保存済み添付を破棄しました。");
-          }, 30000);
         } catch (error) {
           pendingSendRollbacks.delete(clientMessageId);
+          releasePendingOwnerSend(clientMessageId, { clearComposer: false });
           await rollbackAbandonedMedia(mediaReferences, clientMessageId);
           setStatus((error && error.message) || "送信に失敗したため、保存済み添付を破棄しました。");
-          if (submitButton) submitButton.disabled = false;
           textarea.focus({ preventScroll: true });
           return;
         }
-        revokePendingMediaPreviews();
-        pendingMediaItems = [];
-        renderPendingMedia();
-        textarea.value = "";
-        resizeComposerInput();
-        setStatus("app-server bridge の返信を待っています", { thinking: true });
-        if (submitButton) submitButton.disabled = false;
+        setStatus("送信確認を待っています。入力は保存確認まで残します。", { thinking: true });
         textarea.focus({ preventScroll: true });
         updateComposerReserve();
       });

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -710,6 +710,7 @@ test("worker serves v2 dashboard for allowed owner identity without exposing sec
   assert.equal(body.includes('autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" enterkeyhint="send"'), true);
   assert.equal(body.includes("const messagesById = new Map()"), true);
   assert.equal(body.includes("let pendingOwnerSend = null"), true);
+  assert.equal(body.includes("let retryClientMessageId = \"\""), true);
   assert.equal(body.includes("function releasePendingOwnerSend("), true);
   assert.equal(body.includes("送信確認を待っています。入力は保存確認まで残します。"), true);
   assert.equal(body.includes("送信確認前に WebSocket が切れました。入力は残しています。履歴再取得後にもう一度送信できます。"), true);
@@ -844,6 +845,8 @@ test("worker serves dashboard media add controls for iPhone-first upload", async
   assert.equal(body.includes("mediaReferences"), true);
   assert.equal(body.includes("pendingSendRollbacks"), true);
   assert.equal(body.includes("pendingOwnerSend"), true);
+  assert.equal(body.includes("const clientMessageId = retryClientMessageId || createClientMessageId()"), true);
+  assert.equal(body.includes("retryClientMessageId = pending.clientMessageId"), true);
   assert.equal(body.includes("setComposerLocked(true)"), true);
   assert.equal(body.includes("releasePendingOwnerSend(clientMessageId, { clearComposer: true })"), true);
   assert.equal(body.includes("owner_message_accepted"), true);
@@ -1962,6 +1965,42 @@ test("DashboardChatRoom sends each owner turn to only one app-server bridge for 
   assert.equal(primaryBridgeSocket.sent.length, 1);
   assert.equal(duplicateBridgeSocket.sent.length, 0);
   assert.equal(JSON.parse(primaryBridgeSocket.sent[0]).type, "app_server_turn_requested");
+});
+
+test("DashboardChatRoom dedupes retried owner sends by client message id", async () => {
+  const provider = createInMemoryMemoryProvider();
+  const store = createInMemoryDashboardChatStore();
+  const dashboardSocket = createMockSocket("dashboard", "dashboard-main-unresolved");
+  const bridgeSocket = createMockSocket("app_server_bridge", "dashboard-main-unresolved");
+  const storage = createMockDurableObjectStorage();
+  const room = new DashboardChatRoom(
+    {
+      storage,
+      getWebSockets() {
+        return [dashboardSocket, bridgeSocket];
+      }
+    },
+    { DASHBOARD_CHAT_STORE: store, MEMORY_PROVIDER: provider }
+  );
+  const payload = JSON.stringify({
+    type: "owner_message",
+    threadId: "dashboard-main-unresolved",
+    clientMessageId: "dashboard_owner_message:retry-1",
+    text: "再送しても二重実行しない？"
+  });
+
+  await room.webSocketMessage(dashboardSocket, payload);
+  await room.webSocketMessage(dashboardSocket, payload);
+
+  assert.equal(bridgeSocket.sent.length, 1);
+  const stored = await store.listThread("dashboard-main-unresolved");
+  assert.equal(stored.filter((message) => message.role === "owner").length, 1);
+  assert.equal(stored[0].messageId, "dashboard_owner_message:retry-1");
+  const acknowledgements = dashboardSocket.sent
+    .map((message) => JSON.parse(message))
+    .filter((message) => message.type === "owner_message_accepted");
+  assert.equal(acknowledgements.length, 2);
+  assert.equal(acknowledgements[1].duplicate, true);
 });
 
 test("DashboardChatRoom maps app-server replies back into the dashboard thread", async () => {

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -709,6 +709,11 @@ test("worker serves v2 dashboard for allowed owner identity without exposing sec
   assert.equal(body.includes('className = "copy-message"'), true);
   assert.equal(body.includes('autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" enterkeyhint="send"'), true);
   assert.equal(body.includes("const messagesById = new Map()"), true);
+  assert.equal(body.includes("let pendingOwnerSend = null"), true);
+  assert.equal(body.includes("function releasePendingOwnerSend("), true);
+  assert.equal(body.includes("送信確認を待っています。入力は保存確認まで残します。"), true);
+  assert.equal(body.includes("送信確認前に WebSocket が切れました。入力は残しています。履歴再取得後にもう一度送信できます。"), true);
+  assert.equal(body.includes("送信確認が返りませんでした。入力は残しています。再接続後にもう一度送信してください。"), true);
   assert.equal(body.includes("messagesById.set(messageKey(message), message)"), true);
   assert.equal(body.includes("messagesById.clear()"), true);
   assert.equal(body.includes("message?.createdAt"), true);
@@ -838,6 +843,9 @@ test("worker serves dashboard media add controls for iPhone-first upload", async
   assert.equal(body.includes("repo 未指定の通常会話では private media として保存します"), true);
   assert.equal(body.includes("mediaReferences"), true);
   assert.equal(body.includes("pendingSendRollbacks"), true);
+  assert.equal(body.includes("pendingOwnerSend"), true);
+  assert.equal(body.includes("setComposerLocked(true)"), true);
+  assert.equal(body.includes("releasePendingOwnerSend(clientMessageId, { clearComposer: true })"), true);
   assert.equal(body.includes("owner_message_accepted"), true);
 });
 

--- a/worker.js
+++ b/worker.js
@@ -56153,6 +56153,17 @@ var DashboardChatRoom = class {
     const relatedIssue = normalizePositiveInteger9(payload?.relatedIssue || payload?.issueNumber) || extractIssueNumberFromDashboardChatText(text);
     const now = (/* @__PURE__ */ new Date()).toISOString();
     const store = resolveDashboardChatStore(this.env);
+    if (clientMessageId && await this.hasAcceptedOwnerMessage({ threadId, clientMessageId, store })) {
+      this.sendSocket(socket, {
+        type: "owner_message_accepted",
+        ok: true,
+        clientMessageId,
+        messageId: clientMessageId,
+        duplicate: true
+      });
+      await this.broadcastThread({ threadId });
+      return;
+    }
     const repositoryResolution = await resolveDashboardChatRepository({
       payload: { ...normalizeObject11(payload), text, threadId },
       env: this.env
@@ -56183,6 +56194,7 @@ var DashboardChatRoom = class {
         relatedIssue,
         status: "sent",
         text,
+        messageId: clientMessageId || void 0,
         mediaReferences: mediaValidation.mediaReferences,
         createdAt: now
       },
@@ -56203,6 +56215,7 @@ var DashboardChatRoom = class {
         { threadId }
       );
       const messages2 = store ? await store.appendMany(threadId, [ownerMessage, butlerMessage]) : [ownerMessage, butlerMessage].filter(Boolean);
+      await this.writeAcceptedOwnerMessage({ threadId, clientMessageId, messageId: ownerMessage.messageId, acceptedAt: now });
       await this.broadcastThread({ threadId, messages: messages2 });
       this.sendSocket(socket, {
         type: "owner_message_accepted",
@@ -56213,6 +56226,7 @@ var DashboardChatRoom = class {
       return;
     }
     const messages = store ? await store.appendMany(threadId, [ownerMessage]) : [ownerMessage].filter(Boolean);
+    await this.writeAcceptedOwnerMessage({ threadId, clientMessageId, messageId: ownerMessage.messageId, acceptedAt: now });
     await this.broadcastThread({ threadId, messages });
     this.sendSocket(socket, {
       type: "owner_message_accepted",
@@ -56396,6 +56410,43 @@ var DashboardChatRoom = class {
     await this.ctx.storage.put(`app_server_thread:${normalizedThreadId}`, {
       codexThreadId,
       updatedAt: normalizeIsoTimestamp(mapping?.updatedAt) || (/* @__PURE__ */ new Date()).toISOString()
+    });
+    return true;
+  }
+  async hasAcceptedOwnerMessage({ threadId, clientMessageId, store }) {
+    const normalizedThreadId = normalizeDashboardThreadId(threadId);
+    const normalizedClientMessageId = normalizeDashboardEventText(clientMessageId);
+    if (!normalizedThreadId || !normalizedClientMessageId) {
+      return false;
+    }
+    if (typeof this.ctx?.storage?.get === "function") {
+      try {
+        const record2 = await this.ctx.storage.get(`owner_message:${normalizedThreadId}:${normalizedClientMessageId}`);
+        if (record2) {
+          return true;
+        }
+      } catch {
+      }
+    }
+    if (store && typeof store.listThread === "function") {
+      try {
+        const messages = await store.listThread(normalizedThreadId, { limit: 80 });
+        return messages.some((message) => message?.role === "owner" && message?.messageId === normalizedClientMessageId);
+      } catch {
+        return false;
+      }
+    }
+    return false;
+  }
+  async writeAcceptedOwnerMessage({ threadId, clientMessageId, messageId, acceptedAt }) {
+    const normalizedThreadId = normalizeDashboardThreadId(threadId);
+    const normalizedClientMessageId = normalizeDashboardEventText(clientMessageId);
+    if (!normalizedThreadId || !normalizedClientMessageId || typeof this.ctx?.storage?.put !== "function") {
+      return false;
+    }
+    await this.ctx.storage.put(`owner_message:${normalizedThreadId}:${normalizedClientMessageId}`, {
+      messageId: normalizeDashboardEventText(messageId) || normalizedClientMessageId,
+      acceptedAt: normalizeIsoTimestamp(acceptedAt) || (/* @__PURE__ */ new Date()).toISOString()
     });
     return true;
   }
@@ -65218,6 +65269,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
       const pendingSendRollbacks = new Map();
       const messagesById = new Map();
       let pendingOwnerSend = null;
+      let retryClientMessageId = "";
 
       function updateComposerReserve() {
         log.style.setProperty("--composer-reserve", Math.ceil(form.getBoundingClientRect().height) + "px");
@@ -65270,6 +65322,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           pending.submitButton.disabled = false;
         }
         if (options.clearComposer === true) {
+          retryClientMessageId = "";
           if (textarea.value.trim() === pending.text) {
             textarea.value = "";
           }
@@ -65277,6 +65330,8 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           pendingMediaItems = [];
           renderPendingMedia();
           resizeComposerInput();
+        } else {
+          retryClientMessageId = pending.clientMessageId;
         }
         updateComposerReserve();
         return true;
@@ -65805,7 +65860,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         setComposerLocked(true);
         setStatus(pendingMediaItems.length > 0 ? "\u6DFB\u4ED8\u3092\u4FDD\u5B58\u3057\u3066\u304B\u3089\u9001\u4FE1\u3057\u3066\u3044\u307E\u3059" : "\u9001\u4FE1\u4E2D\u3067\u3059", { thinking: true });
         let mediaReferences = [];
-        const clientMessageId = createClientMessageId();
+        const clientMessageId = retryClientMessageId || createClientMessageId();
         try {
           mediaReferences = await uploadPendingMedia(clientMessageId);
         } catch (error) {

--- a/worker.js
+++ b/worker.js
@@ -65217,6 +65217,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
       let pendingMediaItems = [];
       const pendingSendRollbacks = new Map();
       const messagesById = new Map();
+      let pendingOwnerSend = null;
 
       function updateComposerReserve() {
         log.style.setProperty("--composer-reserve", Math.ceil(form.getBoundingClientRect().height) + "px");
@@ -65250,6 +65251,35 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
             }
           }, 2400);
         }
+      }
+
+      function setComposerLocked(locked) {
+        textarea.readOnly = locked === true;
+        if (mediaButton) mediaButton.disabled = locked === true;
+      }
+
+      function releasePendingOwnerSend(clientMessageId, options = {}) {
+        if (!pendingOwnerSend || pendingOwnerSend.clientMessageId !== clientMessageId) return false;
+        const pending = pendingOwnerSend;
+        pendingOwnerSend = null;
+        if (pending.timeoutId && options.keepRollbackTimer !== true) {
+          window.clearTimeout(pending.timeoutId);
+        }
+        setComposerLocked(false);
+        if (pending.submitButton) {
+          pending.submitButton.disabled = false;
+        }
+        if (options.clearComposer === true) {
+          if (textarea.value.trim() === pending.text) {
+            textarea.value = "";
+          }
+          revokePendingMediaPreviews();
+          pendingMediaItems = [];
+          renderPendingMedia();
+          resizeComposerInput();
+        }
+        updateComposerReserve();
+        return true;
       }
 
       function appendMessage(message) {
@@ -65717,12 +65747,15 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
               const clientMessageId = body.clientMessageId || body.client_message_id || "";
               if (clientMessageId) {
                 pendingSendRollbacks.delete(clientMessageId);
+                releasePendingOwnerSend(clientMessageId, { clearComposer: true });
+                setStatus("\u9001\u4FE1\u3092\u4FDD\u5B58\u3057\u307E\u3057\u305F\u3002app-server bridge \u306E\u8FD4\u4FE1\u3092\u5F85\u3063\u3066\u3044\u307E\u3059", { thinking: true });
               }
             } else if (body.type === "error") {
               const clientMessageId = body.clientMessageId || body.client_message_id || "";
               if (clientMessageId && pendingSendRollbacks.has(clientMessageId)) {
                 const mediaReferences = pendingSendRollbacks.get(clientMessageId) || [];
                 pendingSendRollbacks.delete(clientMessageId);
+                releasePendingOwnerSend(clientMessageId, { clearComposer: false });
                 rollbackAbandonedMedia(mediaReferences, clientMessageId).catch(() => {});
               }
               appendError(body.reason || "WebSocket message error");
@@ -65732,12 +65765,22 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           }
         });
         chatSocket.addEventListener("close", () => {
-          setStatus("WebSocket \u304C\u5207\u308C\u307E\u3057\u305F\u3002\u5C65\u6B74\u3092\u518D\u53D6\u5F97\u3057\u3066\u518D\u63A5\u7D9A\u3057\u307E\u3059\u3002");
+          if (pendingOwnerSend) {
+            releasePendingOwnerSend(pendingOwnerSend.clientMessageId, { clearComposer: false, keepRollbackTimer: true });
+            setStatus("\u9001\u4FE1\u78BA\u8A8D\u524D\u306B WebSocket \u304C\u5207\u308C\u307E\u3057\u305F\u3002\u5165\u529B\u306F\u6B8B\u3057\u3066\u3044\u307E\u3059\u3002\u5C65\u6B74\u518D\u53D6\u5F97\u5F8C\u306B\u3082\u3046\u4E00\u5EA6\u9001\u4FE1\u3067\u304D\u307E\u3059\u3002");
+          } else {
+            setStatus("WebSocket \u304C\u5207\u308C\u307E\u3057\u305F\u3002\u5C65\u6B74\u3092\u518D\u53D6\u5F97\u3057\u3066\u518D\u63A5\u7D9A\u3057\u307E\u3059\u3002");
+          }
           refreshThread();
           scheduleReconnect();
         });
         chatSocket.addEventListener("error", () => {
-          setStatus("WebSocket \u63A5\u7D9A\u306B\u5931\u6557\u3057\u307E\u3057\u305F\u3002\u5C65\u6B74\u3092\u518D\u53D6\u5F97\u3057\u3066\u518D\u63A5\u7D9A\u3057\u307E\u3059\u3002");
+          if (pendingOwnerSend) {
+            releasePendingOwnerSend(pendingOwnerSend.clientMessageId, { clearComposer: false, keepRollbackTimer: true });
+            setStatus("\u9001\u4FE1\u78BA\u8A8D\u524D\u306B WebSocket \u63A5\u7D9A\u304C\u5931\u6557\u3057\u307E\u3057\u305F\u3002\u5165\u529B\u306F\u6B8B\u3057\u3066\u3044\u307E\u3059\u3002\u518D\u63A5\u7D9A\u5F8C\u306B\u3082\u3046\u4E00\u5EA6\u9001\u4FE1\u3067\u304D\u307E\u3059\u3002");
+          } else {
+            setStatus("WebSocket \u63A5\u7D9A\u306B\u5931\u6557\u3057\u307E\u3057\u305F\u3002\u5C65\u6B74\u3092\u518D\u53D6\u5F97\u3057\u3066\u518D\u63A5\u7D9A\u3057\u307E\u3059\u3002");
+          }
           refreshThread();
           scheduleReconnect();
         });
@@ -65759,6 +65802,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           return;
         }
         if (submitButton) submitButton.disabled = true;
+        setComposerLocked(true);
         setStatus(pendingMediaItems.length > 0 ? "\u6DFB\u4ED8\u3092\u4FDD\u5B58\u3057\u3066\u304B\u3089\u9001\u4FE1\u3057\u3066\u3044\u307E\u3059" : "\u9001\u4FE1\u4E2D\u3067\u3059", { thinking: true });
         let mediaReferences = [];
         const clientMessageId = createClientMessageId();
@@ -65766,11 +65810,26 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           mediaReferences = await uploadPendingMedia(clientMessageId);
         } catch (error) {
           setStatus((error && error.message) || "\u6DFB\u4ED8\u306E\u4FDD\u5B58\u306B\u5931\u6557\u3057\u307E\u3057\u305F\u3002");
+          setComposerLocked(false);
           if (submitButton) submitButton.disabled = false;
           textarea.focus({ preventScroll: true });
           return;
         }
         pendingSendRollbacks.set(clientMessageId, mediaReferences);
+        pendingOwnerSend = {
+          clientMessageId,
+          text,
+          mediaReferences,
+          submitButton,
+          timeoutId: window.setTimeout(() => {
+            if (!pendingSendRollbacks.has(clientMessageId)) return;
+            const rollbackMediaReferences = pendingSendRollbacks.get(clientMessageId) || [];
+            pendingSendRollbacks.delete(clientMessageId);
+            releasePendingOwnerSend(clientMessageId, { clearComposer: false });
+            rollbackAbandonedMedia(rollbackMediaReferences, clientMessageId).catch(() => {});
+            setStatus("\u9001\u4FE1\u78BA\u8A8D\u304C\u8FD4\u308A\u307E\u305B\u3093\u3067\u3057\u305F\u3002\u5165\u529B\u306F\u6B8B\u3057\u3066\u3044\u307E\u3059\u3002\u518D\u63A5\u7D9A\u5F8C\u306B\u3082\u3046\u4E00\u5EA6\u9001\u4FE1\u3057\u3066\u304F\u3060\u3055\u3044\u3002");
+          }, 30000)
+        };
         try {
           chatSocket.send(JSON.stringify({
             type: "owner_message",
@@ -65782,28 +65841,15 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
             relatedIssue: issueNumber,
             mediaReferences
           }));
-          window.setTimeout(() => {
-            if (!pendingSendRollbacks.has(clientMessageId)) return;
-            const rollbackMediaReferences = pendingSendRollbacks.get(clientMessageId) || [];
-            pendingSendRollbacks.delete(clientMessageId);
-            rollbackAbandonedMedia(rollbackMediaReferences, clientMessageId).catch(() => {});
-            setStatus("\u9001\u4FE1\u78BA\u8A8D\u304C\u8FD4\u3089\u306A\u304B\u3063\u305F\u305F\u3081\u3001\u4FDD\u5B58\u6E08\u307F\u6DFB\u4ED8\u3092\u7834\u68C4\u3057\u307E\u3057\u305F\u3002");
-          }, 30000);
         } catch (error) {
           pendingSendRollbacks.delete(clientMessageId);
+          releasePendingOwnerSend(clientMessageId, { clearComposer: false });
           await rollbackAbandonedMedia(mediaReferences, clientMessageId);
           setStatus((error && error.message) || "\u9001\u4FE1\u306B\u5931\u6557\u3057\u305F\u305F\u3081\u3001\u4FDD\u5B58\u6E08\u307F\u6DFB\u4ED8\u3092\u7834\u68C4\u3057\u307E\u3057\u305F\u3002");
-          if (submitButton) submitButton.disabled = false;
           textarea.focus({ preventScroll: true });
           return;
         }
-        revokePendingMediaPreviews();
-        pendingMediaItems = [];
-        renderPendingMedia();
-        textarea.value = "";
-        resizeComposerInput();
-        setStatus("app-server bridge \u306E\u8FD4\u4FE1\u3092\u5F85\u3063\u3066\u3044\u307E\u3059", { thinking: true });
-        if (submitButton) submitButton.disabled = false;
+        setStatus("\u9001\u4FE1\u78BA\u8A8D\u3092\u5F85\u3063\u3066\u3044\u307E\u3059\u3002\u5165\u529B\u306F\u4FDD\u5B58\u78BA\u8A8D\u307E\u3067\u6B8B\u3057\u307E\u3059\u3002", { thinking: true });
         textarea.focus({ preventScroll: true });
         updateComposerReserve();
       });


### PR DESCRIPTION
## This PR satisfies Intent

- #450 の Dashboard Butler chat で、送信ACK前に WebSocket 切断や画面復帰が発生しても owner の入力と添付プレビューを失わないようにする部分進捗です。

## Satisfied Success Criteria

- 送信後、Worker の `owner_message_accepted` が返るまで composer の入力を保持する。
- WebSocket close/error が送信ACK前に起きた場合、日本語の回復可能な状態表示を出す。
- 送信ACK後だけ composer と添付プレビューを片付ける。
- 再送時は同じ `clientMessageId` を使い、Worker/Durable Object 側で同じ owner send を二重に app-server bridge へ流さない。
- Dashboard HTML の回帰テストで未ACK入力保護を確認する。

## Unsatisfied Success Criteria

- #450 全体の live E2E は未完了です。
- 同じ `codex app-server` session で follow-up が安定することは、このPRだけでは完了判定しません。
- PWA復帰後の実機 live E2E 証跡は未実施です。
- Issue close はしません。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #450
- Implementing Success Criteria: chat surface の thread/reconnect recovery、raw JSON ではない日本語エラー/状態表示、no polling/no reload 方針を崩さない UI 回復。
- Explicit Non-goals: deploy、credential/permission mutation、Issue close、`codex exec` 経路復活、app-server protocol 大規模変更、#498 画像解析完了判定。
- Expected touched files/routes/workflows: `src/worker/runtime.js`、`worker.js`、`test/worker.test.js`。route/workflow は変更なし。
- Affected Issues: #450 のみ。#498 の media rollback と接するが、画像解析や保存仕様は変更しない。
- Affected PRs: なし。新規PR。
- Affected workflows: テストと generated worker check のみ。deploy workflow は未変更。
- Affected runtime/operator surfaces: Dashboard Butler PWA、Worker dashboard HTML、DashboardChatRoom WebSocket client。
- What may break if we patch narrowly: ACK前の送信を楽観的に消すと、iPhone の画面復帰/切断で owner 入力が消える。逆に保持しすぎると二重送信リスクがあるため、ACK後だけ片付け、再送時は同じ client message id で dedupe する。
- Unknowns to investigate before coding: 実機 iPhone/PWA で Safari が close/error をどの順に発火するかは live E2E で確認が必要。
- Validation needed: `node --test test/worker.test.js test/dashboard-app-server-bridge.test.js`、`npm run check:self-parity`、`npm run check:generated-worker`、必要に応じて live iPhone E2E。
- Stop condition: 新しい authority boundary、deploy、credential mutation、または app-server protocol の仕様不明に踏み込む場合は停止。

## File / Line Hypotheses

- file: `src/worker/runtime.js:10493`
  - hypothesis: Dashboard composer は pending owner send を保持する状態を持つ必要がある。
  - risk if changed narrowly: ACK前に入力を消すと、WebSocket切断時に owner のコメントが失われる。
  - validation: dashboard HTML 回帰テストと worker test。
  - related Issue: #450
- file: `src/worker/runtime.js:10993`
  - hypothesis: `owner_message_accepted` を保存確定点として composer cleanup する。
  - risk if changed narrowly: ACK前cleanupは thread retrieval failure 時の入力消失につながる。
  - validation: HTML snippet assertions。
  - related Issue: #450

## Hypothesis Retrospective

- expected: ACK前は入力/添付プレビューが残り、ACK後だけ片付く。
- actual: 実装は `pendingOwnerSend` を持ち、close/error/timeout では入力を残す。
- mismatch: 初回レビューで二重送信リスクが指摘されたため、同一 `clientMessageId` の retried send を dedupe する修正を追加した。live iPhone/PWA 実機確認は未実施。
- lesson: Dashboard recovery は送信成功ではなく runtime ACK を境界にする。
- should become RAG candidate: live E2E で同症状が再発しなければ候補。

## Verification Evidence

- Unit: `node --test test/worker.test.js test/dashboard-app-server-bridge.test.js`: pass
- Integration: `npm run check:self-parity`: pass; `npm run check:generated-worker`: pass after commit on topic branch
- E2E: 未実施。#450 全体 close には owner iPhone/PWA live E2E が必要。
- Manual: `npm test` は 946件中942件 pass、3件 fail。fail は gateway bearer vault / role App token がローカル環境・vault を拾う既存環境依存で、このPR差分外。Gemini 指摘の二重送信リスクは `DashboardChatRoom dedupes retried owner sends by client message id` で追加検証。
- Evidence path/link: `test/worker.test.js`、`test/dashboard-app-server-bridge.test.js`、`src/worker/runtime.js`、`worker.js`

## Butler Completion Contract

- Owner goal: Dashboard Butler で画面を離れたり WebSocket が切れたりしても、送信確認前のコメントを失わず再送/回復できること。
- Butler entrypoint: Dashboard Butler PWA の既存 composer。Action Schema は未変更。
- Action Schema exposure: 未変更。Custom GPT Action Schema には影響なし。
- Runtime path: Dashboard PWA composer -> WebSocket `owner_message` -> DashboardChatRoom -> `owner_message_accepted` を保存確定点として扱う。
- Runner/runtime truth: テストと generated worker の一致を確認。deploy/runtime live truth は未実施。
- Authority boundary: 未変更。新しい high-risk authority は追加しない。
- E2E evidence: 未実施。#450 残 gate として iPhone/PWA live E2E が必要。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 未実施。このPRでは deploy しない。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。merge/deploy 後に owner iPhone/PWA で画面復帰と再接続を確認する。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate
- AGENTS.md Drift Stop Protocol
- AGENTS.md Conversation UX Contract
- `docs/butler/dashboard-butler-app-server-live-path.md`

## Out-of-scope but NOT implemented

- Issue #450 close
- production deploy
- credential/permission mutation
- #498 画像解析完了
- app-server bridge service restart

## Extra changes (if any)

`worker.js` は `npm run build:worker` で `src/worker/runtime.js` から再生成。

<!-- VTDD metadata -->
- Issue: Issue #450
- Execution ID: Not provided.
- Goal: dashboard_chat_reconnect_draft_preserve
