### PR TITLE
Issue #520 Dashboard PWA reconnect send fallback

### DIFF
--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -10458,7 +10458,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
 
       </div>
 
-      <form class="composer" id="butler-chat-form" aria-label="Butler composer" autocomplete="off" data-socket-endpoint="${escapeDashboardHtml(socketOrigin)}/v2/dashboard/chat/${escapeDashboardHtml(chatThreadId)}/ws" data-thread-endpoint="${escapeDashboardHtml(origin)}/v2/dashboard/chat/${escapeDashboardHtml(chatThreadId)}" data-thread-id="${escapeDashboardHtml(chatThreadId)}" data-repository-input="${escapeDashboardHtml(repositoryInput)}" data-issue-number="${dashboardIssueNumber || ""}">
+      <form class="composer" id="butler-chat-form" aria-label="Butler composer" autocomplete="off" data-socket-endpoint="${escapeDashboardHtml(socketOrigin)}/v2/dashboard/chat/${escapeDashboardHtml(chatThreadId)}/ws" data-thread-endpoint="${escapeDashboardHtml(origin)}/v2/dashboard/chat/${escapeDashboardHtml(chatThreadId)}" data-message-endpoint="${escapeDashboardHtml(origin)}/v2/dashboard/chat/messages" data-thread-id="${escapeDashboardHtml(chatThreadId)}" data-repository-input="${escapeDashboardHtml(repositoryInput)}" data-issue-number="${dashboardIssueNumber || ""}">
         <div class="pending-media" id="butler-pending-media" aria-live="polite"></div>
         <div class="composer-box">
           <button class="media-button" id="butler-media-button" type="button" aria-label="画像やファイルを追加" title="画像やファイルを追加">+</button>
@@ -10535,6 +10535,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
 
       const socketEndpoint = form.dataset.socketEndpoint;
       const threadEndpoint = form.dataset.threadEndpoint;
+      const messageEndpoint = form.dataset.messageEndpoint;
       const mediaUploadEndpoint = "/v2/media/upload";
       const threadId = form.dataset.threadId;
       const repositoryInput = form.dataset.repositoryInput;
@@ -10587,6 +10588,22 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
       function setComposerLocked(locked) {
         textarea.readOnly = locked === true;
         if (mediaButton) mediaButton.disabled = locked === true;
+      }
+
+      function isChatSocketOpen() {
+        return Boolean(chatSocket && chatSocket.readyState === WebSocket.OPEN);
+      }
+
+      function isAuthExpiredResponse(response, body = {}) {
+        return (
+          response &&
+          (response.status === 401 || response.status === 403) &&
+          (body.error === "dashboard_auth_required" || String(body.reason || "").includes("passkey session"))
+        );
+      }
+
+      function setDashboardSessionExpiredStatus() {
+        setStatus("Dashboard のログインが切れています。入力は残したまま、右上の Passkey から再ログインしてください。");
       }
 
       function releasePendingOwnerSend(clientMessageId, options = {}) {
@@ -11012,26 +11029,33 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
       }
 
       async function refreshThread() {
-        if (!threadEndpoint || refreshingThread) return;
+        if (!threadEndpoint || refreshingThread) return { ok: false, skipped: true };
         refreshingThread = true;
         try {
           const response = await fetch(threadEndpoint, {
             headers: { "accept": "application/json" },
             credentials: "same-origin"
           });
+          const body = await response.json().catch(() => ({}));
           if (!response.ok) {
-            setStatus("履歴の再取得に失敗しました。WebSocket を再接続しています。");
-            return;
+            if (isAuthExpiredResponse(response, body)) {
+              setDashboardSessionExpiredStatus();
+              return { ok: false, authExpired: true };
+            }
+            setStatus("履歴の再取得に失敗しました。入力は保持しています。WebSocket を再接続しています。");
+            return { ok: false, status: response.status };
           }
-          const body = await response.json();
           if (body && body.ok) {
             renderThread(body.messages || [], { replace: true });
+            return { ok: true };
           }
         } catch {
-          setStatus("履歴の再取得に失敗しました。WebSocket を再接続しています。");
+          setStatus("履歴の再取得に失敗しました。入力は保持しています。WebSocket を再接続しています。");
+          return { ok: false, network: true };
         } finally {
           refreshingThread = false;
         }
+        return { ok: false };
       }
 
       function scheduleReconnect() {
@@ -11120,6 +11144,35 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         });
       }
 
+      async function sendOwnerMessageByHttp(payload, clientMessageId) {
+        if (!messageEndpoint) {
+          throw new Error("HTTP fallback endpoint is not configured");
+        }
+        const response = await fetch(messageEndpoint, {
+          method: "POST",
+          headers: {
+            "accept": "application/json",
+            "content-type": "application/json"
+          },
+          credentials: "same-origin",
+          body: JSON.stringify(payload)
+        });
+        const body = await response.json().catch(() => ({}));
+        if (isAuthExpiredResponse(response, body)) {
+          const error = new Error("dashboard session expired");
+          error.authExpired = true;
+          throw error;
+        }
+        if (!response.ok || !body.ok) {
+          throw new Error(body.reason || "dashboard chat fallback failed");
+        }
+        pendingSendRollbacks.delete(clientMessageId);
+        releasePendingOwnerSend(clientMessageId, { clearComposer: true });
+        renderThread(body.messages || [], { replace: false });
+        setStatus("WebSocket 未接続のため HTTP fallback で保存しました。再接続を続けています。", { temporary: true });
+        scheduleReconnect();
+      }
+
       form.addEventListener("submit", async (event) => {
         event.preventDefault();
         const text = textarea.value.trim() || (pendingMediaItems.length > 0 ? "添付を追加しました。" : "");
@@ -11128,16 +11181,15 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           return;
         }
         const submitButton = form.querySelector("button[type='submit']");
-        if (!chatSocket || chatSocket.readyState !== WebSocket.OPEN) {
-          setStatus("WebSocket 再接続中です。履歴を再取得しています。接続後にもう一度送信してください。");
-          await refreshThread();
-          scheduleReconnect();
-          textarea.focus({ preventScroll: true });
-          return;
-        }
         if (submitButton) submitButton.disabled = true;
         setComposerLocked(true);
-        setStatus(pendingMediaItems.length > 0 ? "添付を保存してから送信しています" : "送信中です", { thinking: true });
+        const willUseHttpFallback = !isChatSocketOpen();
+        if (willUseHttpFallback) {
+          setStatus("WebSocket 再接続中です。入力は保持したまま HTTP fallback で保存します。", { thinking: true });
+          scheduleReconnect();
+        } else {
+          setStatus(pendingMediaItems.length > 0 ? "添付を保存してから送信しています" : "送信中です", { thinking: true });
+        }
         let mediaReferences = [];
         const clientMessageId = retryClientMessageId || createClientMessageId();
         try {
@@ -11164,17 +11216,34 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
             setStatus("送信確認が返りませんでした。入力は残しています。再接続後にもう一度送信してください。");
           }, 30000)
         };
+        const ownerPayload = {
+          type: "owner_message",
+          threadId,
+          clientMessageId,
+          repositoryInput,
+          text,
+          issueNumber,
+          relatedIssue: issueNumber,
+          mediaReferences
+        };
+        if (!isChatSocketOpen()) {
+          try {
+            await sendOwnerMessageByHttp(ownerPayload, clientMessageId);
+          } catch (error) {
+            pendingSendRollbacks.delete(clientMessageId);
+            releasePendingOwnerSend(clientMessageId, { clearComposer: false });
+            if (error && error.authExpired) {
+              setDashboardSessionExpiredStatus();
+            } else {
+              setStatus((error && error.message) || "WebSocket と HTTP fallback の両方で送信できませんでした。入力は残しています。");
+            }
+            textarea.focus({ preventScroll: true });
+          }
+          updateComposerReserve();
+          return;
+        }
         try {
-          chatSocket.send(JSON.stringify({
-            type: "owner_message",
-            threadId,
-            clientMessageId,
-            repositoryInput,
-            text,
-            issueNumber,
-            relatedIssue: issueNumber,
-            mediaReferences
-          }));
+          chatSocket.send(JSON.stringify(ownerPayload));
         } catch (error) {
           pendingSendRollbacks.delete(clientMessageId);
           releasePendingOwnerSend(clientMessageId, { clearComposer: false });

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -660,7 +660,7 @@ test("worker serves v2 dashboard for allowed owner identity without exposing sec
   assert.equal(body.includes('class="icon-button"'), false);
   assert.equal(body.includes('aria-hidden="true">＋</span>'), false);
   assert.equal(body.includes('aria-hidden="true">♪</span>'), false);
-  assert.equal(body.includes("/v2/dashboard/chat/messages"), false);
+  assert.equal(body.includes('data-message-endpoint="https://example.com/v2/dashboard/chat/messages"'), true);
   assert.equal(body.includes('data-thread-endpoint="https://example.com/v2/dashboard/chat/dashboard-main-unresolved"'), true);
   assert.equal(body.includes('data-socket-endpoint="wss://example.com/v2/dashboard/chat/dashboard-main-unresolved/ws"'), true);
   assert.equal(body.includes('data-dispatch-to-vps-runner="true"'), false);
@@ -670,7 +670,15 @@ test("worker serves v2 dashboard for allowed owner identity without exposing sec
   assert.equal(body.includes("new WebSocket(socketEndpoint)"), true);
   assert.equal(body.includes("function refreshThread()"), true);
   assert.equal(body.includes("function scheduleReconnect()"), true);
+  assert.equal(body.includes("function sendOwnerMessageByHttp("), true);
+  assert.equal(body.includes("function isChatSocketOpen()"), true);
+  assert.equal(body.includes("function isAuthExpiredResponse("), true);
+  assert.equal(body.includes("HTTP fallback"), true);
+  assert.equal(body.includes("Dashboard のログインが切れています。入力は残したまま、右上の Passkey から再ログインしてください。"), true);
+  assert.equal(body.includes("WebSocket 再接続中です。入力は保持したまま HTTP fallback で保存します。"), true);
+  assert.equal(body.includes("WebSocket 未接続のため HTTP fallback で保存しました。再接続を続けています。"), true);
   assert.equal(body.includes("履歴を再取得して再接続します"), true);
+  assert.equal(body.includes("履歴の再取得に失敗しました。入力は保持しています。WebSocket を再接続しています。"), true);
   assert.equal(body.includes("document.addEventListener(\"visibilitychange\""), true);
   assert.equal(body.includes("window.addEventListener(\"online\""), true);
   assert.equal(body.includes("VPS Codex CLI に push します"), false);

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -677,6 +677,8 @@ test("worker serves v2 dashboard for allowed owner identity without exposing sec
   assert.equal(body.includes("Dashboard のログインが切れています。入力は残したまま、右上の Passkey から再ログインしてください。"), true);
   assert.equal(body.includes("WebSocket 再接続中です。入力は保持したまま HTTP fallback で保存します。"), true);
   assert.equal(body.includes("WebSocket 未接続のため HTTP fallback で保存しました。再接続を続けています。"), true);
+  assert.equal(body.includes("sendOwnerMessageByHttp(ownerPayload, clientMessageId)"), true);
+  assert.equal(body.includes("refreshThread().then"), false);
   assert.equal(body.includes("履歴を再取得して再接続します"), true);
   assert.equal(body.includes("履歴の再取得に失敗しました。入力は保持しています。WebSocket を再接続しています。"), true);
   assert.equal(body.includes("document.addEventListener(\"visibilitychange\""), true);

--- a/worker.js
+++ b/worker.js
@@ -65179,7 +65179,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
 
       </div>
 
-      <form class="composer" id="butler-chat-form" aria-label="Butler composer" autocomplete="off" data-socket-endpoint="${escapeDashboardHtml(socketOrigin)}/v2/dashboard/chat/${escapeDashboardHtml(chatThreadId)}/ws" data-thread-endpoint="${escapeDashboardHtml(origin)}/v2/dashboard/chat/${escapeDashboardHtml(chatThreadId)}" data-thread-id="${escapeDashboardHtml(chatThreadId)}" data-repository-input="${escapeDashboardHtml(repositoryInput)}" data-issue-number="${dashboardIssueNumber || ""}">
+      <form class="composer" id="butler-chat-form" aria-label="Butler composer" autocomplete="off" data-socket-endpoint="${escapeDashboardHtml(socketOrigin)}/v2/dashboard/chat/${escapeDashboardHtml(chatThreadId)}/ws" data-thread-endpoint="${escapeDashboardHtml(origin)}/v2/dashboard/chat/${escapeDashboardHtml(chatThreadId)}" data-message-endpoint="${escapeDashboardHtml(origin)}/v2/dashboard/chat/messages" data-thread-id="${escapeDashboardHtml(chatThreadId)}" data-repository-input="${escapeDashboardHtml(repositoryInput)}" data-issue-number="${dashboardIssueNumber || ""}">
         <div class="pending-media" id="butler-pending-media" aria-live="polite"></div>
         <div class="composer-box">
           <button class="media-button" id="butler-media-button" type="button" aria-label="\u753B\u50CF\u3084\u30D5\u30A1\u30A4\u30EB\u3092\u8FFD\u52A0" title="\u753B\u50CF\u3084\u30D5\u30A1\u30A4\u30EB\u3092\u8FFD\u52A0">+</button>
@@ -65256,6 +65256,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
 
       const socketEndpoint = form.dataset.socketEndpoint;
       const threadEndpoint = form.dataset.threadEndpoint;
+      const messageEndpoint = form.dataset.messageEndpoint;
       const mediaUploadEndpoint = "/v2/media/upload";
       const threadId = form.dataset.threadId;
       const repositoryInput = form.dataset.repositoryInput;
@@ -65308,6 +65309,22 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
       function setComposerLocked(locked) {
         textarea.readOnly = locked === true;
         if (mediaButton) mediaButton.disabled = locked === true;
+      }
+
+      function isChatSocketOpen() {
+        return Boolean(chatSocket && chatSocket.readyState === WebSocket.OPEN);
+      }
+
+      function isAuthExpiredResponse(response, body = {}) {
+        return (
+          response &&
+          (response.status === 401 || response.status === 403) &&
+          (body.error === "dashboard_auth_required" || String(body.reason || "").includes("passkey session"))
+        );
+      }
+
+      function setDashboardSessionExpiredStatus() {
+        setStatus("Dashboard \u306E\u30ED\u30B0\u30A4\u30F3\u304C\u5207\u308C\u3066\u3044\u307E\u3059\u3002\u5165\u529B\u306F\u6B8B\u3057\u305F\u307E\u307E\u3001\u53F3\u4E0A\u306E Passkey \u304B\u3089\u518D\u30ED\u30B0\u30A4\u30F3\u3057\u3066\u304F\u3060\u3055\u3044\u3002");
       }
 
       function releasePendingOwnerSend(clientMessageId, options = {}) {
@@ -65733,26 +65750,33 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
       }
 
       async function refreshThread() {
-        if (!threadEndpoint || refreshingThread) return;
+        if (!threadEndpoint || refreshingThread) return { ok: false, skipped: true };
         refreshingThread = true;
         try {
           const response = await fetch(threadEndpoint, {
             headers: { "accept": "application/json" },
             credentials: "same-origin"
           });
+          const body = await response.json().catch(() => ({}));
           if (!response.ok) {
-            setStatus("\u5C65\u6B74\u306E\u518D\u53D6\u5F97\u306B\u5931\u6557\u3057\u307E\u3057\u305F\u3002WebSocket \u3092\u518D\u63A5\u7D9A\u3057\u3066\u3044\u307E\u3059\u3002");
-            return;
+            if (isAuthExpiredResponse(response, body)) {
+              setDashboardSessionExpiredStatus();
+              return { ok: false, authExpired: true };
+            }
+            setStatus("\u5C65\u6B74\u306E\u518D\u53D6\u5F97\u306B\u5931\u6557\u3057\u307E\u3057\u305F\u3002\u5165\u529B\u306F\u4FDD\u6301\u3057\u3066\u3044\u307E\u3059\u3002WebSocket \u3092\u518D\u63A5\u7D9A\u3057\u3066\u3044\u307E\u3059\u3002");
+            return { ok: false, status: response.status };
           }
-          const body = await response.json();
           if (body && body.ok) {
             renderThread(body.messages || [], { replace: true });
+            return { ok: true };
           }
         } catch {
-          setStatus("\u5C65\u6B74\u306E\u518D\u53D6\u5F97\u306B\u5931\u6557\u3057\u307E\u3057\u305F\u3002WebSocket \u3092\u518D\u63A5\u7D9A\u3057\u3066\u3044\u307E\u3059\u3002");
+          setStatus("\u5C65\u6B74\u306E\u518D\u53D6\u5F97\u306B\u5931\u6557\u3057\u307E\u3057\u305F\u3002\u5165\u529B\u306F\u4FDD\u6301\u3057\u3066\u3044\u307E\u3059\u3002WebSocket \u3092\u518D\u63A5\u7D9A\u3057\u3066\u3044\u307E\u3059\u3002");
+          return { ok: false, network: true };
         } finally {
           refreshingThread = false;
         }
+        return { ok: false };
       }
 
       function scheduleReconnect() {
@@ -65841,6 +65865,35 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         });
       }
 
+      async function sendOwnerMessageByHttp(payload, clientMessageId) {
+        if (!messageEndpoint) {
+          throw new Error("HTTP fallback endpoint is not configured");
+        }
+        const response = await fetch(messageEndpoint, {
+          method: "POST",
+          headers: {
+            "accept": "application/json",
+            "content-type": "application/json"
+          },
+          credentials: "same-origin",
+          body: JSON.stringify(payload)
+        });
+        const body = await response.json().catch(() => ({}));
+        if (isAuthExpiredResponse(response, body)) {
+          const error = new Error("dashboard session expired");
+          error.authExpired = true;
+          throw error;
+        }
+        if (!response.ok || !body.ok) {
+          throw new Error(body.reason || "dashboard chat fallback failed");
+        }
+        pendingSendRollbacks.delete(clientMessageId);
+        releasePendingOwnerSend(clientMessageId, { clearComposer: true });
+        renderThread(body.messages || [], { replace: false });
+        setStatus("WebSocket \u672A\u63A5\u7D9A\u306E\u305F\u3081 HTTP fallback \u3067\u4FDD\u5B58\u3057\u307E\u3057\u305F\u3002\u518D\u63A5\u7D9A\u3092\u7D9A\u3051\u3066\u3044\u307E\u3059\u3002", { temporary: true });
+        scheduleReconnect();
+      }
+
       form.addEventListener("submit", async (event) => {
         event.preventDefault();
         const text = textarea.value.trim() || (pendingMediaItems.length > 0 ? "\u6DFB\u4ED8\u3092\u8FFD\u52A0\u3057\u307E\u3057\u305F\u3002" : "");
@@ -65849,16 +65902,15 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           return;
         }
         const submitButton = form.querySelector("button[type='submit']");
-        if (!chatSocket || chatSocket.readyState !== WebSocket.OPEN) {
-          setStatus("WebSocket \u518D\u63A5\u7D9A\u4E2D\u3067\u3059\u3002\u5C65\u6B74\u3092\u518D\u53D6\u5F97\u3057\u3066\u3044\u307E\u3059\u3002\u63A5\u7D9A\u5F8C\u306B\u3082\u3046\u4E00\u5EA6\u9001\u4FE1\u3057\u3066\u304F\u3060\u3055\u3044\u3002");
-          await refreshThread();
-          scheduleReconnect();
-          textarea.focus({ preventScroll: true });
-          return;
-        }
         if (submitButton) submitButton.disabled = true;
         setComposerLocked(true);
-        setStatus(pendingMediaItems.length > 0 ? "\u6DFB\u4ED8\u3092\u4FDD\u5B58\u3057\u3066\u304B\u3089\u9001\u4FE1\u3057\u3066\u3044\u307E\u3059" : "\u9001\u4FE1\u4E2D\u3067\u3059", { thinking: true });
+        const willUseHttpFallback = !isChatSocketOpen();
+        if (willUseHttpFallback) {
+          setStatus("WebSocket \u518D\u63A5\u7D9A\u4E2D\u3067\u3059\u3002\u5165\u529B\u306F\u4FDD\u6301\u3057\u305F\u307E\u307E HTTP fallback \u3067\u4FDD\u5B58\u3057\u307E\u3059\u3002", { thinking: true });
+          scheduleReconnect();
+        } else {
+          setStatus(pendingMediaItems.length > 0 ? "\u6DFB\u4ED8\u3092\u4FDD\u5B58\u3057\u3066\u304B\u3089\u9001\u4FE1\u3057\u3066\u3044\u307E\u3059" : "\u9001\u4FE1\u4E2D\u3067\u3059", { thinking: true });
+        }
         let mediaReferences = [];
         const clientMessageId = retryClientMessageId || createClientMessageId();
         try {
@@ -65885,17 +65937,34 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
             setStatus("\u9001\u4FE1\u78BA\u8A8D\u304C\u8FD4\u308A\u307E\u305B\u3093\u3067\u3057\u305F\u3002\u5165\u529B\u306F\u6B8B\u3057\u3066\u3044\u307E\u3059\u3002\u518D\u63A5\u7D9A\u5F8C\u306B\u3082\u3046\u4E00\u5EA6\u9001\u4FE1\u3057\u3066\u304F\u3060\u3055\u3044\u3002");
           }, 30000)
         };
+        const ownerPayload = {
+          type: "owner_message",
+          threadId,
+          clientMessageId,
+          repositoryInput,
+          text,
+          issueNumber,
+          relatedIssue: issueNumber,
+          mediaReferences
+        };
+        if (!isChatSocketOpen()) {
+          try {
+            await sendOwnerMessageByHttp(ownerPayload, clientMessageId);
+          } catch (error) {
+            pendingSendRollbacks.delete(clientMessageId);
+            releasePendingOwnerSend(clientMessageId, { clearComposer: false });
+            if (error && error.authExpired) {
+              setDashboardSessionExpiredStatus();
+            } else {
+              setStatus((error && error.message) || "WebSocket \u3068 HTTP fallback \u306E\u4E21\u65B9\u3067\u9001\u4FE1\u3067\u304D\u307E\u305B\u3093\u3067\u3057\u305F\u3002\u5165\u529B\u306F\u6B8B\u3057\u3066\u3044\u307E\u3059\u3002");
+            }
+            textarea.focus({ preventScroll: true });
+          }
+          updateComposerReserve();
+          return;
+        }
         try {
-          chatSocket.send(JSON.stringify({
-            type: "owner_message",
-            threadId,
-            clientMessageId,
-            repositoryInput,
-            text,
-            issueNumber,
-            relatedIssue: issueNumber,
-            mediaReferences
-          }));
+          chatSocket.send(JSON.stringify(ownerPayload));
         } catch (error) {
           pendingSendRollbacks.delete(clientMessageId);
           releasePendingOwnerSend(clientMessageId, { clearComposer: false });


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #520 の Dashboard Butler PWA で、アプリ切り替え後の WebSocket / 履歴再取得 failure が投稿不能状態を作らないようにする。
- WebSocket が open でない場合でも、入力を保持したまま `/v2/dashboard/chat/messages` の HTTP fallback で通常チャットを保存する。

## Satisfied Success Criteria

- WebSocket が `OPEN` でない submit で即 return せず、HTTP fallback 送信へ進む。
- `refreshThread()` failure は入力を保持する status を出し、戻り値で auth/session failure を区別できる。
- dashboard passkey session 切れは WebSocket 汎用エラーではなく、再ログインが必要な状態として表示する。
- fallback 成功時は pending send を解放し、返却 messages を同じ thread に描画する。
- reconnect は継続するが、fallback 送信中に古い履歴再取得が後から上書きしないようにした。
- Worker HTML 回帰テストで fallback endpoint、auth expired 表示、fallback status、refresh failure status を確認する。

## Unsatisfied Success Criteria

- iPhone/PWA live E2E は未実施。
- dashboard session を長めの trusted-device session にする設計変更は未実装。
- Issue #520 close はしない。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #520
- Implementing Success Criteria: WebSocket reconnect failure / history refresh failure 時の投稿不能回避、入力保持、HTTP fallback、session expired 表示。
- Explicit Non-goals: deploy、credential/permission mutation、high-risk boundary 緩和、Issue #518 の時刻表示拡張、app-server protocol 大規模変更。
- Expected touched files/routes/workflows: `src/worker/runtime.js`、`test/worker.test.js`、`worker.js`。既存 route `/v2/dashboard/chat/messages` を fallback として利用し、新規 route/workflow は追加しない。
- Affected Issues: Issue #520、関連して Issue #450 / Issue #518 / Issue #413。
- Affected PRs: PR #521。このPRの後続レビューで PR #519 とは分けて扱う。
- Affected workflows: test / guarded-policy / reviewer のみ。deploy workflow は未変更。
- Affected runtime/operator surfaces: Dashboard Butler PWA の chat composer / reconnect / session expired status。
- What may break if we patch narrowly: WebSocket live app-server 返信ではなく HTTP fallback の deterministic Butler reply になる場合がある。これは投稿不能より優先する degraded mode として扱う。
- Unknowns to investigate before coding: 実機 iPhone/PWA で background 復帰時に fallback が期待通り動くか。
- Validation needed: `node --test test/worker.test.js test/dashboard-app-server-bridge.test.js`、`npm run build:worker`、`npm run check:self-parity`、`npm run check:generated-worker`、`git diff --check`。
- Stop condition: deploy、credential mutation、permission mutation、passkey high-risk boundary の緩和へ踏み込む場合は停止。

## File / Line Hypotheses

- file: `src/worker/runtime.js`
  - hypothesis: submit handler の WebSocket open 必須 return をやめ、既存 HTTP message endpoint へ fallback すれば PWA復帰後の投稿不能を避けられる。
  - risk if changed narrowly: live app-server bridge が切れている時は fallback reply になり、live Codex thread には届かない。
  - validation: Worker HTML 回帰テストと dashboard chat message route 既存テスト。
  - related Issue: Issue #520
- file: `src/worker/runtime.js`
  - hypothesis: `refreshThread()` が 401/403/passkey session failure を区別すれば、WebSocket failure と再ログイン必要状態を混同しない。
  - risk if changed narrowly: 実機では Cloudflare Access 側の認証失効表現が別 status になる可能性がある。
  - validation: HTML script assertion と live E2E follow-up。
  - related Issue: Issue #520

## Hypothesis Retrospective

- expected: WebSocket が切れても submit で詰まらず、fallback で投稿を保存できる。
- actual: `data-message-endpoint`、`sendOwnerMessageByHttp()`、`isChatSocketOpen()`、auth expired status を追加し、WebSocket 未接続時の即 return を削除した。
- mismatch: live iPhone/PWA 実機確認は未実施。
- lesson: PWAの通常チャットは WebSocket を最適経路、HTTP fallback を復旧経路として扱うべき。high-risk step-up passkey とは分離する。
- should become RAG candidate: live E2E 後に判断。

## Verification Evidence

- Unit: `node --test test/worker.test.js test/dashboard-app-server-bridge.test.js`: pass
- Integration: `npm run build:worker`: pass; `npm run check:self-parity`: pass; `npm run check:generated-worker`: pass; `git diff --check`: pass
- E2E: 未実施。iPhone/PWA live E2E は merge/deploy 後または preview 環境で必要。
- Manual: 未実施。
- Evidence path/link: `src/worker/runtime.js`、`test/worker.test.js`、`worker.js`

## Butler Completion Contract

- Owner goal: PWA復帰後に `履歴の再取得に失敗しました。WebSocket を再接続しています。` が出ても、投稿不能で詰まらず通常チャットを継続できること。
- Butler entrypoint: Dashboard Butler PWA の既存 chat UI。Action Schema は未変更。
- Action Schema exposure: 未変更。
- Runtime path: Dashboard composer submit -> WebSocket live send when open; otherwise `/v2/dashboard/chat/messages` HTTP fallback.
- Runner/runtime truth: テストと generated worker の一致を確認。deploy/runtime live truth は未実施。
- Authority boundary: 通常チャットの fallback のみ。merge / deploy / secret mutation / permission mutation の `GO + real passkey` 境界は未変更。
- E2E evidence: 未実施。Issue #520 close には iPhone/PWA live E2E が必要。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 未実施。このPRでは deploy しない。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate
- AGENTS.md Butler-First Operating Principle
- AGENTS.md Conversation UX Contract
- AGENTS.md Authority Boundary
- AGENTS.md Evidence Discipline

## Out-of-scope but NOT implemented

- production deploy
- Issue #520 close
- dashboard trusted-device long session
- high-risk passkey boundary の緩和
- app-server protocol 大規模変更

## Extra changes (if any)

`worker.js` は `npm run build:worker` で `src/worker/runtime.js` から再生成。

<!-- VTDD metadata -->
- Issue: Issue #520
- Execution ID: Not provided.
- Goal: dashboard_pwa_reconnect_send_fallback
