### PR TITLE
Issue #524 Dashboard chat のURL表示とコピーを安定化

### DIFF
--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -10298,8 +10298,10 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
     .bubble .message-body ul { margin: 0; }
     .bubble .message-body li + li { margin-top: 4px; }
     .bubble .message-body code { font-size: .94em; }
-    .bubble .message-body pre { position: relative; margin: 0; padding: 42px 14px 14px; border: 1px solid var(--border); border-radius: 12px; background: var(--panel-strong); overflow-x: auto; white-space: pre; }
+    .bubble .message-body pre { position: relative; margin: 0; padding: 42px 14px 14px; border: 1px solid var(--border); border-radius: 12px; background: var(--panel-strong); overflow-x: auto; white-space: pre; max-width: 100%; }
+    .bubble .message-body pre.wrap-code { overflow-x: visible; white-space: pre-wrap; }
     .bubble .message-body pre code { display: block; font-size: 14px; line-height: 1.55; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace; }
+    .bubble .message-body pre.wrap-code code { white-space: pre-wrap; overflow-wrap: anywhere; word-break: break-word; }
     .bubble .message-body strong { display: inline; color: inherit; font-size: inherit; letter-spacing: 0; text-transform: none; margin: 0; font-weight: 800; }
     .copy-message, .copy-code { display: inline-flex; align-items: center; justify-content: center; width: 30px; height: 30px; border: 1px solid var(--border); border-radius: 999px; background: var(--button); color: var(--text); font-size: 15px; line-height: 1; cursor: pointer; }
     .copy-message:focus-visible, .copy-code:focus-visible { outline: 2px solid var(--text); outline-offset: 2px; }
@@ -10314,7 +10316,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
     .thinking-dots::after { content: ""; display: inline-block; width: 1.4em; text-align: left; animation: thinkingDots 1.2s steps(4, end) infinite; }
     @keyframes thinkingDots { 0% { content: ""; } 25% { content: "."; } 50% { content: ".."; } 75%, 100% { content: "..."; } }
     .connection-note { display: inline-flex; align-items: center; width: fit-content; border: 1px solid var(--border); border-radius: 999px; padding: 5px 10px; color: var(--muted); font-size: 13px; }
-    .chat-link { color: var(--text); text-decoration-thickness: 1px; text-underline-offset: 4px; font-weight: 750; }
+    .chat-link { color: var(--text); text-decoration-thickness: 1px; text-underline-offset: 4px; font-weight: 750; overflow-wrap: anywhere; word-break: break-word; }
     .composer { min-width: 0; display: grid; gap: 8px; z-index: 4; padding: 14px 0 max(16px, env(safe-area-inset-bottom)); background: var(--page-bg); }
     .composer-box { display: grid; grid-template-columns: 44px minmax(0, 1fr) 44px; align-items: end; gap: 8px; min-height: 62px; padding: 8px; border: 1px solid var(--border); border-radius: 28px; background: var(--panel-strong); box-shadow: 0 16px 60px var(--shadow); }
     textarea { width: 100%; min-height: 44px; max-height: max(88px, min(160px, 24dvh)); border: 0; outline: 0; resize: none; overflow-y: hidden; padding: 10px 2px; color: var(--text); background: transparent; font: inherit; line-height: 1.45; }
@@ -10643,7 +10645,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           copyButton.textContent = "⧉";
           copyButton.setAttribute("aria-label", "自分の発言をコピー");
           copyButton.title = "自分の発言をコピー";
-          copyButton.addEventListener("click", () => copyMessageText(copyButton, message.text || ""));
+          copyButton.addEventListener("click", () => copyMessageText(copyButton, normalizeMessageCopyText(message.text || "")));
           article.appendChild(copyButton);
         } else if (message.role === "butler") {
           const header = document.createElement("div");
@@ -10657,7 +10659,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           copyButton.textContent = "⧉";
           copyButton.setAttribute("aria-label", "返信をコピー");
           copyButton.title = "返信をコピー";
-          copyButton.addEventListener("click", () => copyMessageText(copyButton, message.text || ""));
+          copyButton.addEventListener("click", () => copyMessageText(copyButton, normalizeMessageCopyText(message.text || "")));
           header.appendChild(copyButton);
           article.appendChild(header);
         } else if (message.role === "system") {
@@ -10670,7 +10672,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         }
         const body = document.createElement("div");
         body.className = "message-body";
-        renderMessageText(body, message.text || "（空のメッセージ）");
+        renderMessageText(body, normalizeMessageDisplayText(message.text || "（空のメッセージ）"));
         article.appendChild(body);
         const media = renderMediaReferences(message.mediaReferences || message.media_references || []);
         if (media) {
@@ -10763,6 +10765,42 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         updateComposerReserve();
       }
 
+      function normalizeMessageDisplayText(text) {
+        return decodeSafeChatCommandText(String(text || ""));
+      }
+
+      function normalizeMessageCopyText(text) {
+        return decodeSafeChatCommandText(String(text || ""));
+      }
+
+      function decodeSafeChatCommandText(text) {
+        const source = String(text || "");
+        return source
+          .split("\\n")
+          .map((line) => {
+            if (!/^[a-z][a-z0-9+.-]*:%[0-9a-f]{2}/i.test(line)) {
+              return line;
+            }
+            if (/^https?:/i.test(line)) {
+              return line;
+            }
+            try {
+              return decodeURIComponent(line);
+            } catch {
+              return line;
+            }
+          })
+          .join("\\n");
+      }
+
+      function shouldWrapCodeBlock(text) {
+        const source = String(text || "").trim();
+        if (!source) return false;
+        if (/^https?:\\/\\//i.test(source)) return true;
+        if (/^[a-z][a-z0-9+.-]*:%[0-9a-f]{2}/i.test(source)) return true;
+        return source.length > 80 && !/\\s/.test(source);
+      }
+
       function renderMessageText(container, text) {
         const source = String(text || "");
         const lines = source.replace(/\\r\\n/g, "\\n").split("\\n");
@@ -10786,6 +10824,9 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
             }
             const pre = document.createElement("pre");
             const codeText = codeLines.join("\\n");
+            if (shouldWrapCodeBlock(codeText)) {
+              pre.className = "wrap-code";
+            }
             const copyButton = document.createElement("button");
             copyButton.className = "copy-code";
             copyButton.type = "button";

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -705,6 +705,12 @@ test("worker serves v2 dashboard for allowed owner identity without exposing sec
   assert.equal(body.includes("String.fromCharCode(96, 96, 96)"), true);
   assert.equal(body.includes("code.dataset.language = language"), true);
   assert.equal(body.includes("renderInlineMarkdown(strong"), true);
+  assert.equal(body.includes("function normalizeMessageDisplayText("), true);
+  assert.equal(body.includes("function normalizeMessageCopyText("), true);
+  assert.equal(body.includes("function decodeSafeChatCommandText("), true);
+  assert.equal(body.includes("decodeURIComponent(line)"), true);
+  assert.equal(body.includes("function shouldWrapCodeBlock("), true);
+  assert.equal(body.includes('pre.className = "wrap-code"'), true);
   assert.equal(body.includes("function copyMessageText("), true);
   assert.equal(body.includes("navigator.clipboard.writeText"), true);
   assert.equal(body.includes("返信をコピー"), true);
@@ -731,6 +737,8 @@ test("worker serves v2 dashboard for allowed owner identity without exposing sec
   assert.equal(body.includes('renderThread(body.messages || [], { replace: true })'), true);
   assert.equal(body.includes('renderThread(body.messages || [], { replace: false })'), true);
   assert.equal(body.includes("white-space: pre-wrap"), true);
+  assert.equal(body.includes(".bubble .message-body pre.wrap-code"), true);
+  assert.equal(body.includes("overflow-wrap: anywhere; word-break: break-word;"), true);
   assert.equal(body.includes("tokenPattern"), true);
   assert.equal(body.includes('link.className = "chat-link"'), true);
   assert.equal(body.includes("考えています"), false);

--- a/worker.js
+++ b/worker.js
@@ -65036,8 +65036,10 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
     .bubble .message-body ul { margin: 0; }
     .bubble .message-body li + li { margin-top: 4px; }
     .bubble .message-body code { font-size: .94em; }
-    .bubble .message-body pre { position: relative; margin: 0; padding: 42px 14px 14px; border: 1px solid var(--border); border-radius: 12px; background: var(--panel-strong); overflow-x: auto; white-space: pre; }
+    .bubble .message-body pre { position: relative; margin: 0; padding: 42px 14px 14px; border: 1px solid var(--border); border-radius: 12px; background: var(--panel-strong); overflow-x: auto; white-space: pre; max-width: 100%; }
+    .bubble .message-body pre.wrap-code { overflow-x: visible; white-space: pre-wrap; }
     .bubble .message-body pre code { display: block; font-size: 14px; line-height: 1.55; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace; }
+    .bubble .message-body pre.wrap-code code { white-space: pre-wrap; overflow-wrap: anywhere; word-break: break-word; }
     .bubble .message-body strong { display: inline; color: inherit; font-size: inherit; letter-spacing: 0; text-transform: none; margin: 0; font-weight: 800; }
     .copy-message, .copy-code { display: inline-flex; align-items: center; justify-content: center; width: 30px; height: 30px; border: 1px solid var(--border); border-radius: 999px; background: var(--button); color: var(--text); font-size: 15px; line-height: 1; cursor: pointer; }
     .copy-message:focus-visible, .copy-code:focus-visible { outline: 2px solid var(--text); outline-offset: 2px; }
@@ -65052,7 +65054,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
     .thinking-dots::after { content: ""; display: inline-block; width: 1.4em; text-align: left; animation: thinkingDots 1.2s steps(4, end) infinite; }
     @keyframes thinkingDots { 0% { content: ""; } 25% { content: "."; } 50% { content: ".."; } 75%, 100% { content: "..."; } }
     .connection-note { display: inline-flex; align-items: center; width: fit-content; border: 1px solid var(--border); border-radius: 999px; padding: 5px 10px; color: var(--muted); font-size: 13px; }
-    .chat-link { color: var(--text); text-decoration-thickness: 1px; text-underline-offset: 4px; font-weight: 750; }
+    .chat-link { color: var(--text); text-decoration-thickness: 1px; text-underline-offset: 4px; font-weight: 750; overflow-wrap: anywhere; word-break: break-word; }
     .composer { min-width: 0; display: grid; gap: 8px; z-index: 4; padding: 14px 0 max(16px, env(safe-area-inset-bottom)); background: var(--page-bg); }
     .composer-box { display: grid; grid-template-columns: 44px minmax(0, 1fr) 44px; align-items: end; gap: 8px; min-height: 62px; padding: 8px; border: 1px solid var(--border); border-radius: 28px; background: var(--panel-strong); box-shadow: 0 16px 60px var(--shadow); }
     textarea { width: 100%; min-height: 44px; max-height: max(88px, min(160px, 24dvh)); border: 0; outline: 0; resize: none; overflow-y: hidden; padding: 10px 2px; color: var(--text); background: transparent; font: inherit; line-height: 1.45; }
@@ -65381,7 +65383,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           copyButton.textContent = "\u29C9";
           copyButton.setAttribute("aria-label", "\u81EA\u5206\u306E\u767A\u8A00\u3092\u30B3\u30D4\u30FC");
           copyButton.title = "\u81EA\u5206\u306E\u767A\u8A00\u3092\u30B3\u30D4\u30FC";
-          copyButton.addEventListener("click", () => copyMessageText(copyButton, message.text || ""));
+          copyButton.addEventListener("click", () => copyMessageText(copyButton, normalizeMessageCopyText(message.text || "")));
           article.appendChild(copyButton);
         } else if (message.role === "butler") {
           const header = document.createElement("div");
@@ -65395,7 +65397,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           copyButton.textContent = "\u29C9";
           copyButton.setAttribute("aria-label", "\u8FD4\u4FE1\u3092\u30B3\u30D4\u30FC");
           copyButton.title = "\u8FD4\u4FE1\u3092\u30B3\u30D4\u30FC";
-          copyButton.addEventListener("click", () => copyMessageText(copyButton, message.text || ""));
+          copyButton.addEventListener("click", () => copyMessageText(copyButton, normalizeMessageCopyText(message.text || "")));
           header.appendChild(copyButton);
           article.appendChild(header);
         } else if (message.role === "system") {
@@ -65408,7 +65410,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         }
         const body = document.createElement("div");
         body.className = "message-body";
-        renderMessageText(body, message.text || "\uFF08\u7A7A\u306E\u30E1\u30C3\u30BB\u30FC\u30B8\uFF09");
+        renderMessageText(body, normalizeMessageDisplayText(message.text || "\uFF08\u7A7A\u306E\u30E1\u30C3\u30BB\u30FC\u30B8\uFF09"));
         article.appendChild(body);
         const media = renderMediaReferences(message.mediaReferences || message.media_references || []);
         if (media) {
@@ -65501,6 +65503,42 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         updateComposerReserve();
       }
 
+      function normalizeMessageDisplayText(text) {
+        return decodeSafeChatCommandText(String(text || ""));
+      }
+
+      function normalizeMessageCopyText(text) {
+        return decodeSafeChatCommandText(String(text || ""));
+      }
+
+      function decodeSafeChatCommandText(text) {
+        const source = String(text || "");
+        return source
+          .split("\\n")
+          .map((line) => {
+            if (!/^[a-z][a-z0-9+.-]*:%[0-9a-f]{2}/i.test(line)) {
+              return line;
+            }
+            if (/^https?:/i.test(line)) {
+              return line;
+            }
+            try {
+              return decodeURIComponent(line);
+            } catch {
+              return line;
+            }
+          })
+          .join("\\n");
+      }
+
+      function shouldWrapCodeBlock(text) {
+        const source = String(text || "").trim();
+        if (!source) return false;
+        if (/^https?:\\/\\//i.test(source)) return true;
+        if (/^[a-z][a-z0-9+.-]*:%[0-9a-f]{2}/i.test(source)) return true;
+        return source.length > 80 && !/\\s/.test(source);
+      }
+
       function renderMessageText(container, text) {
         const source = String(text || "");
         const lines = source.replace(/\\r\\n/g, "\\n").split("\\n");
@@ -65524,6 +65562,9 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
             }
             const pre = document.createElement("pre");
             const codeText = codeLines.join("\\n");
+            if (shouldWrapCodeBlock(codeText)) {
+              pre.className = "wrap-code";
+            }
             const copyButton = document.createElement("button");
             copyButton.className = "copy-code";
             copyButton.type = "button";


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #524: Dashboard Butler chat で URL エンコード済み `go:%0A...` がそのまま見えたり、長い URL / command 風テキストが横スクロールで読みにくくなる問題を修正する。

## Satisfied Success Criteria

- `go:%0A...` のような safe chat command 風 percent-encoded text を、表示・コピー前に一度だけ decode する helper を追加した。
- `http://` / `https://` の通常リンクは linkifier として維持し、percent decode 対象から除外した。
- 通常本文と chat link は `overflow-wrap:anywhere` / `word-break:break-word` で端折り返しできるようにした。
- URL だけ、または長い空白なし文字列の code block は `wrap-code` にして横スクロールではなく折り返す。
- Dashboard HTML の構造テストに copy/display normalize と wrap-code の検出を追加した。

## Unsatisfied Success Criteria

- production deploy は未実施。live Dashboard での iPhone/PWA 目視 E2E は merge/deploy 後に必要。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #524
- Implementing Success Criteria: URL エンコード済み chat command 風テキストの表示/コピー正規化、長い URL / code block の折り返し、既存 http(s) linkifier の維持。
- Explicit Non-goals: passkey deploy operator、production deploy workflow、GitHub token scope、WebSocket reconnect 全体、app-server 実行能力は変更しない。
- Expected touched files/routes/workflows: `src/worker/runtime.js`、`worker.js`、`test/worker.test.js`
- Affected Issues: Issue #524、Issue #518、Issue #520
- Affected PRs: なし。
- Affected workflows: なし。
- Affected runtime/operator surfaces: Dashboard Butler chat の message rendering / copy helper / CSS wrap policy。
- What may break if we patch narrowly: 通常 URL を誤って decode すると link href が変わる。今回は `http(s)` 行は decode しない。
- Unknowns to investigate before coding: `go:` scheme をリンク化するかは未決。今回は通常テキストとして復元表示する。
- Validation needed: `node --test test/worker.test.js`、`npm run build:worker`、`npm run check:self-parity`、`git diff --check`、`npm run check:generated-worker`。merge/deploy 後に live Dashboard E2E。
- Stop condition: secret / approval grant redaction や high-risk approval boundary に触れる必要が出た場合は停止する。

## File / Line Hypotheses

- file: `src/worker/runtime.js`
- hypothesis: Dashboard chat の `renderMessageText` / `copyMessageText` は保存済み本文をそのまま扱うため、`go:%0A...` のような percent-encoded text が表示・コピーで揺れる。
- risk if changed narrowly: URL linkifier や code block copy を壊す可能性がある。
- validation: worker HTML structure test と generated worker parity。
- related Issue: Issue #524

## Hypothesis Retrospective

- expected: 表示と message copy は `go:%0A...` を readable text に戻し、通常 URL は link のまま保持する。
- actual: `decodeSafeChatCommandText` を表示・message copy に適用し、`http(s)` は decode 対象外にした。
- mismatch: live PWA 目視 E2E は production deploy 後に残る。
- lesson: chat UI では表示用の linkify と copy 用の正規化を分ける必要がある。
- should become RAG candidate: Dashboard chat UX 再発防止候補。

## Verification Evidence

- Unit: `node --test test/worker.test.js`: pass 193
- Integration: `npm run build:worker`: pass。`npm run check:self-parity`: pass。`git diff --check`: pass。`npm run check:generated-worker`: pass after commit.
- E2E: 未実施。production deploy 後に Dashboard chat で `go:%0A...` と長い URL の表示・コピーを確認する。
- Manual: 未実施。
- Evidence path/link: local command output in this PR session; commit `751fa21`

## Butler Completion Contract

- Owner goal: Dashboard chat の URL エンコード表示、コピー内容の揺れ、長い URL 横スクロールを減らす。
- Butler entrypoint: Dashboard Butler chat。
- Action Schema exposure: 未変更。
- Runtime path: `GET /dashboard` が返す Dashboard chat HTML/JS/CSS の message rendering / copy path。
- Runner/runtime truth: 手元テストと generated worker parity は通過。production runtime truth は merge/deploy 後に確認が必要。
- Authority boundary: 未変更。この PR は high-risk authority を追加・緩和しない。
- E2E evidence: 未実施。merge/deploy 後に iPhone/PWA で確認する。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 必要。merge 後に production deploy が必要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 必要。merge/deploy 後に Dashboard chat 上で確認。

## Related Constitution Rules

- Issue traceability / Drift Stop Protocol / Conversation UX Contract / Evidence Discipline / Change Size and PR Discipline。

## Out-of-scope but NOT implemented

- PR #523 production deploy の break-glass 解決。
- Dashboard login / reconnect 全体の再設計。
- app-server event 通知文言の全面修正。

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #524
- Execution ID: Not provided.
- Goal: Dashboard chat URL/copy wrap fix
