### PR TITLE
Issue #528 AGENTS に執事長 guardrail を追加

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,41 @@ This principle is not stylistic. It is the core product constraint:
 the owner should not have to keep a MacBook awake, powered, or physically
 available for normal VTDD development.
 
+## Chief Butler Operating Principle
+
+The assistant must act as chief butler, not as a passive task runner.
+
+Before implementing what the owner just said, especially for Butler,
+Dashboard, iPhone/iPad UX, handoff, notification, attachment, approval, or
+runtime-observation work, first ask what a competent chief butler should have
+noticed without being told line by line.
+
+Required behavior:
+
+- Read the relevant Issues, docs, tests, and source before proposing or editing.
+- Proactively surface predictable product, UX, completion, authority, and E2E
+  gaps that are visible from the code or existing Issues.
+- If the current implementation can be predicted to be unpleasant, confusing,
+  incomplete, or less useful than Custom GPT, stop and say so before coding.
+- Convert owner frustration into durable Issue work, PR scope, or RAG candidate
+  instead of treating each complaint as an isolated fix request.
+- Propose the smallest Issue-backed path that makes the owner-facing workflow
+  genuinely better, including what should be deferred or hidden.
+- When Dashboard Butler is involved, evaluate the normal chat surface against
+  the baseline of ChatGPT iOS app usability plus VTDD-only capabilities such as
+  PWA recovery, notifications, attachments, runtime truth, and scoped approval.
+- Debug, ops, setup, runtime, RAG, self-parity, workflow, passkey, and deploy
+  surfaces must not dominate the normal chat experience. If they are needed,
+  isolate them behind an explicitly named debug/development/operations area.
+- Do not wait for the owner to enumerate every obvious UI/UX failure. If a
+  failure is visible from code, tests, screenshots, Issues, or runtime truth,
+  raise it as a blocking concern or Issue candidate before implementation.
+
+If this principle conflicts with a narrow implementation request, report the
+conflict and ask whether to proceed narrowly or first create/update the
+necessary Issue. Do not silently choose the narrower path when it would preserve
+a broken owner-facing workflow.
+
 ## Non-Negotiable Rules
 
 1. Do not reinterpret scope words (including "MVP") on your own.


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #528 の Dashboard Butler UX baseline に対して、実装前に上位UX破綻を予測・提案・Issue化する「Chief Butler Operating Principle」を AGENTS.md に追加します。

## Satisfied Success Criteria

- AGENTS.md に、assistant が passive task runner ではなく chief butler として動くことを明文化した。
- Butler / Dashboard / iPhone UX / handoff / notification / attachment / approval / runtime-observation 作業前に、コードや Issue から見える product / UX / completion / authority / E2E gap を先に出すことを必須化した。
- Dashboard Butler では ChatGPT iOS app usability と VTDD-only capability を baseline に評価し、debug/ops/passkey/deploy surfaces を通常チャット面に出しすぎないことを明文化した。

## Unsatisfied Success Criteria

- Issue #528 の Dashboard UI 実装修正は未実施。
- #526 / #524 / #498 / #520 / #518 / #450 / #413 の個別実装と E2E は未実施。
- iPhone/PWA live E2E は未実施。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #528
- Implementing Success Criteria: Chief Butler guardrail を AGENTS.md に durable rule として追加する。
- Explicit Non-goals: runtime/UI 実装、deploy、credential/permission mutation、既存 Issue close、Custom GPT Action Schema 変更。
- Expected touched files/routes/workflows: AGENTS.md のみ。
- Affected Issues: Issue #528、関連して Issue #526 / #524 / #498 / #520 / #518 / #450 / #413。
- Affected PRs: なし。
- Affected workflows: 通常 CI / review のみ。deploy workflow は未変更。
- Affected runtime/operator surfaces: なし。ドキュメント guardrail のみ。
- What may break if we patch narrowly: AGENTS.md だけでは Dashboard UI は直らないため、Issue #528 completion は incomplete のまま。
- Unknowns to investigate before coding: なし。
- Validation needed: git diff --check、PR review。
- Stop condition: runtime/UI 実装、deploy、credential/permission mutation に踏み込む場合は停止。

## File / Line Hypotheses

- file: `AGENTS.md:69`
  - hypothesis: Butler-First の直後に chief butler principle を置くと、Dashboard/Butler 作業前の判断ルールとして読まれやすい。
  - risk if changed narrowly: guardrail 追加だけでは UI は改善しない。
  - validation: diff review。
  - related Issue: Issue #528

## Hypothesis Retrospective

- expected: assistant が言われた作業に直行せず、予測できる UX/Issue/E2E gap を先に出す durable rule が追加される。
- actual: AGENTS.md に Chief Butler Operating Principle を追加した。
- mismatch: runtime behavior は未変更。
- lesson: Dashboard Butler のような owner-facing surface では、実装前に product-level failure を先に止める必要がある。
- should become RAG candidate: 必要なら Issue #528 の実装開始前 checkpoint として候補化する。

## Verification Evidence

- Unit: Not run; docs-only guardrail change.
- Integration: git diff --check: pass.
- E2E: Not run; AGENTS.md docs-only change and Dashboard runtime is unchanged.
- Manual: AGENTS.md diff reviewed locally.
- Evidence path/link: AGENTS.md、/tmp/pr-issue-528-chief-butler-guardrail.md

## Butler Completion Contract

- Owner goal: owner が Dashboard Butler の obvious UX failure を毎回指摘しなくても、assistant が先に予測・提案・Issue化すること。
- Butler entrypoint: Repository startup/process guardrail in AGENTS.md.
- Action Schema exposure: 不要。Action Schema は未変更。
- Runtime path: なし。runtime code は未変更。
- Runner/runtime truth: git diff --check pass; local docs diff only.
- Authority boundary: GO/passkey/deploy/credential 境界は未変更。
- E2E evidence: 未実施。docs-only guardrail のため Dashboard Butler completion は incomplete。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 不要。未実施。
- Custom GPT Action Schema update: 不要。未実施。
- Custom GPT Instructions update: AGENTS.md を更新。Custom GPT Instructions は未変更。
- iPhone Butler live E2E: 未実施。Issue #528 の実装PRで必要。

## Related Constitution Rules

- AGENTS.md Butler-First Operating Principle
- AGENTS.md Change Size and PR Discipline
- AGENTS.md Evidence Discipline
- AGENTS.md Conversation UX Contract

## Out-of-scope but NOT implemented

- Dashboard runtime UI の修正
- debug menu の実装
- image upload / reconnect / URL wrapping の修正
- production deploy
- Issue close

## Extra changes (if any)

新しい process guardrail のため、実装PRとは分離した docs-only PR として作成。

<!-- VTDD metadata -->
- Issue: Issue #528
- Execution ID: Not provided.
- Goal: chief_butler_guardrail
