### PR TITLE
Issue #528 VPS recovery も Dashboard Butler 本体に含める

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,6 +92,13 @@ Required behavior:
 - When Dashboard Butler is involved, evaluate the normal chat surface against
   the baseline of ChatGPT iOS app usability plus VTDD-only capabilities such as
   PWA recovery, notifications, attachments, runtime truth, and scoped approval.
+- Dashboard Butler is also the owner-facing recovery surface for VPS-side
+  trouble. If a VPS Codex CLI, runner, queue, app-server bridge, deployment,
+  credential boundary, or host/runtime failure occurs, the expected product
+  path is not "open mac Codex and debug manually"; it is for Dashboard Butler to
+  understand the natural-language problem, read the relevant VPS/runtime truth,
+  hand off executable recovery to VPS Codex CLI or a declared runner, and report
+  progress, blocker, before/after state, and next owner action.
 - Debug, ops, setup, runtime, RAG, self-parity, workflow, passkey, and deploy
   surfaces must not dominate the normal chat experience. If they are needed,
   isolate them behind an explicitly named debug/development/operations area.


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #528 の Dashboard Butler UX baseline に対して、VPS 側トラブルの解決も Dashboard Butler / VPS Codex CLI が担うべき owner-facing recovery path として AGENTS.md に追記します。

## Satisfied Success Criteria

- AGENTS.md の Chief Butler Operating Principle に、VPS Codex CLI、runner、queue、app-server bridge、deployment、credential boundary、host/runtime failure が起きた場合の期待 product path を追記した。
- mac Codex 手動デバッグではなく、Dashboard Butler が自然文問題を理解し、VPS/runtime truth を読み、VPS Codex CLI または宣言済み runner に復旧を handoff し、progress/blocker/before-after/next action を返すことを明文化した。
- Issue #528 に VPS recovery surface の追記コメントを残した。

## Unsatisfied Success Criteria

- Dashboard runtime UI 実装は未実施。
- VPS recovery route / runner / Dashboard status UI の実装は未実施。
- iPhone/PWA live E2E は未実施。
- Issue #528 close はしない。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #528
- Implementing Success Criteria: Dashboard Butler が VPS トラブル解決の owner-facing recovery surface でもあることを durable rule として追加する。
- Explicit Non-goals: runtime/UI 実装、VPS 設定変更、deploy、credential/permission mutation、Issue close。
- Expected touched files/routes/workflows: AGENTS.md のみ。GitHub Issue #528 にコメント追加。
- Affected Issues: Issue #528、関連して Issue #520 / Issue #450 / Issue #413 / Issue #495。
- Affected PRs: PR #529 の follow-up。
- Affected workflows: 通常 CI / review のみ。deploy workflow は未変更。
- Affected runtime/operator surfaces: なし。process guardrail のみ。
- What may break if we patch narrowly: AGENTS.md だけでは Dashboard Butler / VPS recovery は実装されないため、Issue #528 completion は incomplete のまま。
- Unknowns to investigate before coding: VPS recovery の具体的な runner route / Dashboard UI は後続 Issue/PR で確認する。
- Validation needed: git diff --check、PR review。
- Stop condition: runtime/UI 実装、VPS設定変更、deploy、credential/permission mutation に踏み込む場合は停止。

## File / Line Hypotheses

- file: `AGENTS.md:92`
  - hypothesis: Chief Butler Operating Principle の Dashboard Butler 評価基準の直後に VPS recovery surface を置くと、Dashboard/VPS 作業前の判断ルールとして読まれやすい。
  - risk if changed narrowly: guardrail 追加だけでは VPS recovery は実装されない。
  - validation: diff review。
  - related Issue: Issue #528

## Hypothesis Retrospective

- expected: VPS トラブルも Dashboard Butler / VPS Codex CLI が解決できるべきという durable rule が追加される。
- actual: AGENTS.md に VPS-side trouble recovery path を追記し、Issue #528 にコメントを残した。
- mismatch: runtime behavior は未変更。
- lesson: Dashboard Butler は通常チャットだけでなく、VPS トラブル復旧の owner-facing surface でもある。
- should become RAG candidate: 必要なら Issue #528 実装開始前 checkpoint として候補化する。

## Verification Evidence

- Unit: Not run; docs-only guardrail change.
- Integration: git diff --check: pass.
- E2E: Not run; AGENTS.md docs-only change and Dashboard runtime is unchanged.
- Manual: AGENTS.md diff reviewed locally; Issue #528 comment posted: https://github.com/marushu/vtdd-v2-p/issues/528#issuecomment-4532390825
- Evidence path/link: AGENTS.md、Issue #528 comment、/tmp/pr-issue-528-vps-recovery-guardrail.md

## Butler Completion Contract

- Owner goal: owner が VPS トラブルを mac Codex 手動デバッグに戻されず、Dashboard Butler から観測・復旧・進捗確認できる状態にするための guardrail を残す。
- Butler entrypoint: Repository startup/process guardrail in AGENTS.md; Issue #528 baseline comment.
- Action Schema exposure: 不要。Action Schema は未変更。
- Runtime path: なし。runtime code は未変更。
- Runner/runtime truth: git diff --check pass; Issue #528 comment posted.
- Authority boundary: GO/passkey/deploy/credential 境界は未変更。
- E2E evidence: 未実施。docs-only guardrail のため Dashboard/VPS recovery completion は incomplete。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 不要。未実施。
- Custom GPT Action Schema update: 不要。未実施。
- Custom GPT Instructions update: AGENTS.md を更新。Custom GPT Instructions は未変更。
- iPhone Butler live E2E: 未実施。Issue #528 の実装PRで必要。

## Related Constitution Rules

- AGENTS.md Butler-First Operating Principle
- AGENTS.md Chief Butler Operating Principle
- AGENTS.md Change Size and PR Discipline
- AGENTS.md Evidence Discipline

## Out-of-scope but NOT implemented

- Dashboard runtime UI の修正
- VPS runner / queue / app-server bridge recovery 実装
- production deploy
- credential / permission mutation
- Issue close

## Extra changes (if any)

PR #529 の follow-up guardrail。VPS recovery を Dashboard Butler 本体機能として明文化。

<!-- VTDD metadata -->
- Issue: Issue #528
- Execution ID: Not provided.
- Goal: vps_recovery_guardrail
