### PR TITLE
Issue #514 Dashboard Web Push payload を暗号化して通知本文を届ける

### DIFF
--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -7218,6 +7218,104 @@ function compactNotificationText(value, limit) {
   return `${text.slice(0, Math.max(0, limit - 1))}…`;
 }
 
+async function encryptDashboardWebPushPayload({ subscription, payload }) {
+  const userPublicBytes = base64UrlToBytes(subscription?.p256dh);
+  const authSecretBytes = base64UrlToBytes(subscription?.auth);
+  if (userPublicBytes.length !== 65 || userPublicBytes[0] !== 4 || authSecretBytes.length < 16) {
+    return {
+      ok: false,
+      status: 422,
+      error: "dashboard_web_push_subscription_keys_invalid",
+      reason: "push subscription p256dh/auth keys are required for encrypted Web Push payloads"
+    };
+  }
+
+  const serverKeyPair = await crypto.subtle.generateKey(
+    { name: "ECDH", namedCurve: "P-256" },
+    true,
+    ["deriveBits"]
+  );
+  const userPublicKey = await crypto.subtle.importKey(
+    "raw",
+    userPublicBytes,
+    { name: "ECDH", namedCurve: "P-256" },
+    false,
+    []
+  );
+  const sharedSecret = new Uint8Array(await crypto.subtle.deriveBits(
+    { name: "ECDH", public: userPublicKey },
+    serverKeyPair.privateKey,
+    256
+  ));
+  const serverPublicBytes = new Uint8Array(await crypto.subtle.exportKey("raw", serverKeyPair.publicKey));
+  const salt = crypto.getRandomValues(new Uint8Array(16));
+  const keyInfo = concatBytes(
+    new TextEncoder().encode("WebPush: info"),
+    new Uint8Array([0]),
+    userPublicBytes,
+    serverPublicBytes
+  );
+  const prkKey = await hmacSha256(authSecretBytes, sharedSecret);
+  const ikm = (await hmacSha256(prkKey, concatBytes(keyInfo, new Uint8Array([1])))).slice(0, 32);
+  const prk = await hmacSha256(salt, ikm);
+  const contentEncryptionKey = (await hmacSha256(
+    prk,
+    concatBytes(new TextEncoder().encode("Content-Encoding: aes128gcm"), new Uint8Array([0, 1]))
+  )).slice(0, 16);
+  const nonce = (await hmacSha256(
+    prk,
+    concatBytes(new TextEncoder().encode("Content-Encoding: nonce"), new Uint8Array([0, 1]))
+  )).slice(0, 12);
+  const plaintext = concatBytes(
+    new TextEncoder().encode(JSON.stringify(payload)),
+    new Uint8Array([2])
+  );
+  const aesKey = await crypto.subtle.importKey(
+    "raw",
+    contentEncryptionKey,
+    { name: "AES-GCM" },
+    false,
+    ["encrypt"]
+  );
+  const ciphertext = new Uint8Array(await crypto.subtle.encrypt(
+    { name: "AES-GCM", iv: nonce, tagLength: 128 },
+    aesKey,
+    plaintext
+  ));
+  const recordSize = 4096;
+  const header = new Uint8Array(21 + serverPublicBytes.length);
+  header.set(salt, 0);
+  new DataView(header.buffer).setUint32(16, recordSize);
+  header[20] = serverPublicBytes.length;
+  header.set(serverPublicBytes, 21);
+  return {
+    ok: true,
+    body: concatBytes(header, ciphertext)
+  };
+}
+
+async function hmacSha256(keyBytes, dataBytes) {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    keyBytes,
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"]
+  );
+  return new Uint8Array(await crypto.subtle.sign("HMAC", key, dataBytes));
+}
+
+function concatBytes(...chunks) {
+  const total = chunks.reduce((sum, chunk) => sum + chunk.length, 0);
+  const result = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    result.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return result;
+}
+
 async function sendDashboardWebPush({ env, subscription, payload }) {
   const endpoint = normalizeDashboardUrl(subscription?.endpoint);
   const endpointHash = normalizeDashboardEventText(subscription?.endpointHash) || (endpoint ? await sha256Hex(endpoint) : "");
@@ -7230,14 +7328,22 @@ async function sendDashboardWebPush({ env, subscription, payload }) {
     return { ...vapid, endpointHash };
   }
 
+  const encryptedPayload = await encryptDashboardWebPushPayload({ subscription, payload });
+  if (!encryptedPayload.ok) {
+    return { ...encryptedPayload, endpointHash };
+  }
+
   const fetcher = typeof env?.DASHBOARD_WEB_PUSH_FETCH === "function" ? env.DASHBOARD_WEB_PUSH_FETCH : fetch;
   const response = await fetcher(endpoint, {
     method: "POST",
     headers: {
       authorization: vapid.authorization,
+      "content-encoding": "aes128gcm",
+      "content-type": "application/octet-stream",
       ttl: "300",
       urgency: "normal"
-    }
+    },
+    body: encryptedPayload.body
   });
   const stale = response.status === 404 || response.status === 410;
   return {

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -322,6 +322,103 @@ function base64UrlEncodeTestBytes(bytes) {
   return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
 }
 
+function base64UrlToTestBytes(value) {
+  const normalized = String(value || "").replace(/-/g, "+").replace(/_/g, "/");
+  const padded = normalized.padEnd(Math.ceil(normalized.length / 4) * 4, "=");
+  const binary = atob(padded);
+  return Uint8Array.from(binary, (char) => char.charCodeAt(0));
+}
+
+function concatTestBytes(...chunks) {
+  const total = chunks.reduce((sum, chunk) => sum + chunk.length, 0);
+  const result = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    result.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return result;
+}
+
+async function hmacSha256Test(keyBytes, dataBytes) {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    keyBytes,
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"]
+  );
+  return new Uint8Array(await crypto.subtle.sign("HMAC", key, dataBytes));
+}
+
+async function createTestPushSubscription(fields = {}) {
+  const keyPair = await crypto.subtle.generateKey(
+    { name: "ECDH", namedCurve: "P-256" },
+    true,
+    ["deriveBits"]
+  );
+  const publicBytes = new Uint8Array(await crypto.subtle.exportKey("raw", keyPair.publicKey));
+  const authBytes = crypto.getRandomValues(new Uint8Array(16));
+  return {
+    subscription: {
+      endpointHash: fields.endpointHash || "endpoint-hash",
+      endpoint: fields.endpoint || "https://push.example/send/endpoint-hash",
+      p256dh: base64UrlEncodeTestBytes(publicBytes),
+      auth: base64UrlEncodeTestBytes(authBytes),
+      ownerIdentity: "owner@example.com",
+      updatedAt: new Date().toISOString()
+    },
+    privateKey: keyPair.privateKey,
+    publicBytes,
+    authBytes
+  };
+}
+
+async function decryptTestWebPushPayload(body, pushKeys) {
+  const encrypted = new Uint8Array(await new Response(body).arrayBuffer());
+  const salt = encrypted.slice(0, 16);
+  const recordSize = new DataView(encrypted.buffer, encrypted.byteOffset + 16, 4).getUint32(0);
+  const keyIdLength = encrypted[20];
+  const serverPublicBytes = encrypted.slice(21, 21 + keyIdLength);
+  const ciphertext = encrypted.slice(21 + keyIdLength);
+
+  assert.equal(recordSize, 4096);
+  assert.equal(keyIdLength, 65);
+  assert.equal(serverPublicBytes[0], 4);
+
+  const serverPublicKey = await crypto.subtle.importKey(
+    "raw",
+    serverPublicBytes,
+    { name: "ECDH", namedCurve: "P-256" },
+    false,
+    []
+  );
+  const sharedSecret = new Uint8Array(await crypto.subtle.deriveBits(
+    { name: "ECDH", public: serverPublicKey },
+    pushKeys.privateKey,
+    256
+  ));
+  const prkKey = await hmacSha256Test(pushKeys.authBytes, sharedSecret);
+  const keyInfo = concatTestBytes(
+    new TextEncoder().encode("WebPush: info"),
+    new Uint8Array([0]),
+    pushKeys.publicBytes,
+    serverPublicBytes
+  );
+  const ikm = (await hmacSha256Test(prkKey, concatTestBytes(keyInfo, new Uint8Array([1])))).slice(0, 32);
+  const prk = await hmacSha256Test(salt, ikm);
+  const cek = (await hmacSha256Test(prk, concatTestBytes(new TextEncoder().encode("Content-Encoding: aes128gcm"), new Uint8Array([0, 1])))).slice(0, 16);
+  const nonce = (await hmacSha256Test(prk, concatTestBytes(new TextEncoder().encode("Content-Encoding: nonce"), new Uint8Array([0, 1])))).slice(0, 12);
+  const key = await crypto.subtle.importKey("raw", cek, { name: "AES-GCM" }, false, ["decrypt"]);
+  const plaintext = new Uint8Array(await crypto.subtle.decrypt(
+    { name: "AES-GCM", iv: nonce, tagLength: 128 },
+    key,
+    ciphertext
+  ));
+  assert.equal(plaintext[plaintext.length - 1], 2);
+  return new TextDecoder().decode(plaintext.slice(0, -1));
+}
+
 async function sha256HexTest(value) {
   const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(String(value)));
   return [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, "0")).join("");
@@ -2640,14 +2737,8 @@ test("worker reports dashboard push subscription server save status without raw 
 
 test("worker sends server-side dashboard Web Push test only for authenticated owner session", async () => {
   const store = createInMemoryDashboardPushSubscriptionStore();
-  await store.put({
-    endpointHash: "endpoint-hash",
-    endpoint: "https://push.example/send/endpoint-hash",
-    p256dh: "p256dh-key",
-    auth: "auth-key",
-    ownerIdentity: "owner@example.com",
-    updatedAt: new Date().toISOString()
-  });
+  const pushKeys = await createTestPushSubscription();
+  await store.put(pushKeys.subscription);
   const calls = [];
   const vapidEnv = await createTestVapidEnv({
     DASHBOARD_WEB_PUSH_FETCH: async (input, init) => {
@@ -2694,7 +2785,13 @@ test("worker sends server-side dashboard Web Push test only for authenticated ow
   assert.match(calls[0].init.headers.authorization, /^vapid t=.+, k=.+/);
   assert.equal(calls[0].init.headers.ttl, "300");
   assert.equal(calls[0].init.headers.urgency, "normal");
-  assert.equal("body" in calls[0].init, false);
+  assert.equal(calls[0].init.headers["content-encoding"], "aes128gcm");
+  assert.equal(calls[0].init.headers["content-type"], "application/octet-stream");
+  assert.equal("body" in calls[0].init, true);
+  const decrypted = JSON.parse(await decryptTestWebPushPayload(calls[0].init.body, pushKeys));
+  assert.equal(decrypted.title, "VTDD Butler テスト通知");
+  assert.equal(decrypted.body, "通知経路は正常です。iPhone PWA にサーバ送信できました。");
+  assert.equal(decrypted.url, "/dashboard/notifications");
   assert.equal(JSON.stringify(body).includes("p256dh-key"), false);
   assert.equal(JSON.stringify(body).includes("auth-key"), false);
 });
@@ -2787,14 +2884,11 @@ test("worker reports server-side dashboard Web Push configuration blockers", asy
 
 test("worker cleans up stale dashboard Web Push subscriptions rejected by push service", async () => {
   const store = createInMemoryDashboardPushSubscriptionStore();
-  await store.put({
+  const pushKeys = await createTestPushSubscription({
     endpointHash: "stale-endpoint-hash",
-    endpoint: "https://push.example/send/stale-endpoint-hash",
-    p256dh: "p256dh-key",
-    auth: "auth-key",
-    ownerIdentity: "owner@example.com",
-    updatedAt: new Date().toISOString()
+    endpoint: "https://push.example/send/stale-endpoint-hash"
   });
+  await store.put(pushKeys.subscription);
   const vapidEnv = await createTestVapidEnv({
     DASHBOARD_WEB_PUSH_FETCH: async () => new Response(null, { status: 410 })
   });
@@ -2880,14 +2974,11 @@ test("worker redacts dashboard push subscription raw material from D1 payload_js
 test("worker ingests GitHub Actions deploy completion event and shows it on dashboard", async () => {
   const store = createInMemoryDashboardEventStore();
   const pushStore = createInMemoryDashboardPushSubscriptionStore();
-  await pushStore.put({
+  const pushKeys = await createTestPushSubscription({
     endpointHash: "deploy-push-endpoint",
-    endpoint: "https://push.example/send/deploy",
-    p256dh: "p256dh-key",
-    auth: "auth-key",
-    ownerIdentity: "owner@example.com",
-    updatedAt: new Date().toISOString()
+    endpoint: "https://push.example/send/deploy"
   });
+  await pushStore.put(pushKeys.subscription);
   const pushCalls = [];
   const vapidEnv = await createTestVapidEnv({
     DASHBOARD_WEB_PUSH_FETCH: async (input, init) => {
@@ -2930,6 +3021,10 @@ test("worker ingests GitHub Actions deploy completion event and shows it on dash
   assert.equal(pushCalls.length, 1);
   assert.equal(pushCalls[0].input, "https://push.example/send/deploy");
   assert.match(pushCalls[0].init.headers.authorization, /^vapid t=.+, k=.+/);
+  assert.equal(pushCalls[0].init.headers["content-encoding"], "aes128gcm");
+  const decryptedPush = JSON.parse(await decryptTestWebPushPayload(pushCalls[0].init.body, pushKeys));
+  assert.equal(decryptedPush.title, "デプロイ完了: vtdd-v2-p");
+  assert.equal(decryptedPush.body.includes("workflow: deploy-production"), true);
   assert.equal("approvalGrantId" in eventBody.event, false);
   assert.equal("token" in eventBody.event, false);
 

--- a/worker.js
+++ b/worker.js
@@ -62223,6 +62223,100 @@ function compactNotificationText(value, limit) {
   }
   return `${text.slice(0, Math.max(0, limit - 1))}\u2026`;
 }
+async function encryptDashboardWebPushPayload({ subscription, payload }) {
+  const userPublicBytes = base64UrlToBytes(subscription?.p256dh);
+  const authSecretBytes = base64UrlToBytes(subscription?.auth);
+  if (userPublicBytes.length !== 65 || userPublicBytes[0] !== 4 || authSecretBytes.length < 16) {
+    return {
+      ok: false,
+      status: 422,
+      error: "dashboard_web_push_subscription_keys_invalid",
+      reason: "push subscription p256dh/auth keys are required for encrypted Web Push payloads"
+    };
+  }
+  const serverKeyPair = await crypto.subtle.generateKey(
+    { name: "ECDH", namedCurve: "P-256" },
+    true,
+    ["deriveBits"]
+  );
+  const userPublicKey = await crypto.subtle.importKey(
+    "raw",
+    userPublicBytes,
+    { name: "ECDH", namedCurve: "P-256" },
+    false,
+    []
+  );
+  const sharedSecret = new Uint8Array(await crypto.subtle.deriveBits(
+    { name: "ECDH", public: userPublicKey },
+    serverKeyPair.privateKey,
+    256
+  ));
+  const serverPublicBytes = new Uint8Array(await crypto.subtle.exportKey("raw", serverKeyPair.publicKey));
+  const salt = crypto.getRandomValues(new Uint8Array(16));
+  const keyInfo = concatBytes2(
+    new TextEncoder().encode("WebPush: info"),
+    new Uint8Array([0]),
+    userPublicBytes,
+    serverPublicBytes
+  );
+  const prkKey = await hmacSha256(authSecretBytes, sharedSecret);
+  const ikm = (await hmacSha256(prkKey, concatBytes2(keyInfo, new Uint8Array([1])))).slice(0, 32);
+  const prk = await hmacSha256(salt, ikm);
+  const contentEncryptionKey = (await hmacSha256(
+    prk,
+    concatBytes2(new TextEncoder().encode("Content-Encoding: aes128gcm"), new Uint8Array([0, 1]))
+  )).slice(0, 16);
+  const nonce2 = (await hmacSha256(
+    prk,
+    concatBytes2(new TextEncoder().encode("Content-Encoding: nonce"), new Uint8Array([0, 1]))
+  )).slice(0, 12);
+  const plaintext = concatBytes2(
+    new TextEncoder().encode(JSON.stringify(payload)),
+    new Uint8Array([2])
+  );
+  const aesKey = await crypto.subtle.importKey(
+    "raw",
+    contentEncryptionKey,
+    { name: "AES-GCM" },
+    false,
+    ["encrypt"]
+  );
+  const ciphertext = new Uint8Array(await crypto.subtle.encrypt(
+    { name: "AES-GCM", iv: nonce2, tagLength: 128 },
+    aesKey,
+    plaintext
+  ));
+  const recordSize = 4096;
+  const header = new Uint8Array(21 + serverPublicBytes.length);
+  header.set(salt, 0);
+  new DataView(header.buffer).setUint32(16, recordSize);
+  header[20] = serverPublicBytes.length;
+  header.set(serverPublicBytes, 21);
+  return {
+    ok: true,
+    body: concatBytes2(header, ciphertext)
+  };
+}
+async function hmacSha256(keyBytes, dataBytes) {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    keyBytes,
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"]
+  );
+  return new Uint8Array(await crypto.subtle.sign("HMAC", key, dataBytes));
+}
+function concatBytes2(...chunks) {
+  const total = chunks.reduce((sum, chunk) => sum + chunk.length, 0);
+  const result = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    result.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return result;
+}
 async function sendDashboardWebPush({ env, subscription, payload }) {
   const endpoint = normalizeDashboardUrl(subscription?.endpoint);
   const endpointHash = normalizeDashboardEventText(subscription?.endpointHash) || (endpoint ? await sha256Hex(endpoint) : "");
@@ -62233,14 +62327,21 @@ async function sendDashboardWebPush({ env, subscription, payload }) {
   if (!vapid.ok) {
     return { ...vapid, endpointHash };
   }
+  const encryptedPayload = await encryptDashboardWebPushPayload({ subscription, payload });
+  if (!encryptedPayload.ok) {
+    return { ...encryptedPayload, endpointHash };
+  }
   const fetcher = typeof env?.DASHBOARD_WEB_PUSH_FETCH === "function" ? env.DASHBOARD_WEB_PUSH_FETCH : fetch;
   const response = await fetcher(endpoint, {
     method: "POST",
     headers: {
       authorization: vapid.authorization,
+      "content-encoding": "aes128gcm",
+      "content-type": "application/octet-stream",
       ttl: "300",
       urgency: "normal"
-    }
+    },
+    body: encryptedPayload.body
   });
   const stale = response.status === 404 || response.status === 410;
   return {


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #514 の通知センター/Web Push 経路で、server-side Web Push が意味のある payload を送らず、iPhone PWA 側で `Dashboard Butler の通知です。` fallback になる問題を止血します。

## Satisfied Success Criteria

- `sendDashboardWebPush` が RFC 8291 の `aes128gcm` 形式で Dashboard Web Push payload を暗号化し、push endpoint へ request body として送るようにした。
- server-side Web Push test で、push request に `content-encoding: aes128gcm` と encrypted body があり、テスト内で復号すると `VTDD Butler テスト通知` / `通知経路は正常です。iPhone PWA にサーバ送信できました。` が読めることを確認した。
- deploy completion event の Web Push でも encrypted payload を復号し、`デプロイ完了: vtdd-v2-p` と workflow detail が含まれることを確認した。
- 既存の `body` なし Web Push を正とするテスト期待を解消した。

## Unsatisfied Success Criteria

- iPhone/PWA 実機での OS 通知表示確認は未実施。
- notificationclick、badge、音、通知センター UI 全体の改善は未実施。
- Issue #514 / Issue #444 close はしない。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #514
- Implementing Success Criteria: server-side Web Push が generic fallback ではなく event-specific encrypted payload を送る。
- Explicit Non-goals: 通知センター UI 全体、badge、音、deploy workflow、VAPID secret 再生成、credential/permission mutation、Dashboard 通常チャット面 Issue #528 / Issue #526。
- Expected touched files/routes/workflows: src/worker/runtime.js、worker.js、test/worker.test.js。
- Affected Issues: Issue #514、関連して Issue #444 / Issue #528。
- Affected PRs: なし。
- Affected workflows: 通常 CI / review のみ。deploy workflow は未変更。
- Affected runtime/operator surfaces: Dashboard server-side Web Push send path。Service worker handler の fallback は未変更。
- What may break if we patch narrowly: iPhone 実機 Web Push では push service / browser 実装差が残るため、live E2E までは Issue #514 completion は incomplete。
- Unknowns to investigate before coding: iOS PWA 実機で encrypted payload が期待通り表示されるかは deploy 後 E2E が必要。
- Validation needed: node --test、npm run check:self-parity、npm run build:worker、npm run check:generated-worker、git diff --check、iPhone/PWA live E2E。
- Stop condition: 通知センター UI 全体、badge、音、deploy workflow、credential/permission mutation に踏み込む場合は停止。

## File / Line Hypotheses

- file: `src/worker/runtime.js:7221`
  - hypothesis: `sendDashboardWebPush` が payload body を送っていないため、service worker が generic fallback `Dashboard Butler の通知です。` を表示している。
  - risk if changed narrowly: 暗号化 payload は unit で復号確認できるが、iOS PWA live 表示は deploy 後確認が必要。
  - validation: encrypted payload decrypt unit test、deploy event Web Push test。
  - related Issue: Issue #514
- file: `test/worker.test.js:2641`
  - hypothesis: 既存 test が `body` なし送信を正として固定しており、意味ある通知 payload の欠落を見逃していた。
  - risk if changed narrowly: test helper が RFC 8291 とズレると false confidence になる。
  - validation: generated encrypted body を test-side ECDH/HKDF/AES-GCM で復号する。
  - related Issue: Issue #514

## Hypothesis Retrospective

- expected: server-side Web Push request に encrypted payload body が付き、generic fallback 通知を通常成功経路にしない。
- actual: RFC 8291 `aes128gcm` body を生成し、test push/deploy push の payload 復号を unit test で確認した。
- mismatch: iPhone/PWA live notification は未確認。
- lesson: Web Push は VAPID だけでは通知本文を届けられない。subscription `p256dh` / `auth` で encrypted payload を送る必要がある。
- should become RAG candidate: Issue #514 live E2E 後に判断。

## Verification Evidence

- Unit: node --test: pass. Targeted worker Web Push tests pass and encrypted payload decrypts in test.
- Integration: npm run build:worker: pass; npm run check:self-parity: pass; npm run check:generated-worker: pass; git diff --check: pass.
- E2E: 未実施。iPhone/PWA live notification display は deploy 後に必要。
- Manual: Issue #514 に調査メモを投稿済み: https://github.com/marushu/vtdd-v2-p/issues/514#issuecomment-4532463538
- Evidence path/link: src/worker/runtime.js、test/worker.test.js、worker.js、PR body、Issue #514 comment

## Butler Completion Contract

- Owner goal: iPhone に届く Dashboard Butler 通知が `Dashboard Butler の通知です。` だけの意味不明な邪魔通知にならず、何が起きた通知なのか分かること。
- Butler entrypoint: Dashboard notification center / server-side Web Push route `/v2/dashboard/push/test` and event ingestion routes.
- Action Schema exposure: 不要。Custom GPT Action Schema は未変更。
- Runtime path: Dashboard event/test push -> buildDashboardWebPushPayload -> encryptDashboardWebPushPayload -> sendDashboardWebPush -> service worker push handler.
- Runner/runtime truth: Local tests prove encrypted payload body is sent and decryptable. Production/live push display is not yet verified.
- Authority boundary: Dashboard auth and machine auth boundariesは未変更。VAPID secret / credential / permission mutation は未実施。
- E2E evidence: 未実施。iPhone/PWA live notification E2E が Issue #514 close には必要。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 未実施。このPRでは deploy しない。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate
- AGENTS.md Chief Butler Operating Principle
- AGENTS.md Evidence Discipline
- AGENTS.md Conversation UX Contract
- AGENTS.md Authority Boundary

## Out-of-scope but NOT implemented

- notificationclick / badge / sound の本格実装
- 通知センター UI 全体の redesign
- deploy workflow 変更
- VAPID secret 再生成
- Dashboard 通常チャット面 Issue #528 / Issue #526 の実装
- Issue close

## Extra changes (if any)

Web Push encryption は RFC 8291 の `aes128gcm` single-record payload を実装。暗号化 helper は runtime 内に限定し、外部 dependency は追加していない。

<!-- VTDD metadata -->
- Issue: Issue #514
- Execution ID: Not provided.
- Goal: dashboard_web_push_payload_stopgap
