### PR TITLE
Issue #532 deploy approval をパスキー1ボタン化する

### DIFF
--- a/src/core/passkey-operator-page.js
+++ b/src/core/passkey-operator-page.js
@@ -1,5 +1,6 @@
 export function renderPasskeyOperatorPage(input = {}) {
   const operatorMode = resolvePasskeyOperatorMode(input);
+  const deployOneTapMode = operatorMode === "deploy";
   const passkeyEnabled = input.passkeyEnabled !== false;
   const sectionVisibility = resolveSectionVisibility(operatorMode, { passkeyEnabled });
   const origin = escapeHtml(input.origin || "");
@@ -23,6 +24,16 @@ export function renderPasskeyOperatorPage(input = {}) {
         ? "approvalGrantId が取得済みなら実行できます。desktop helper bridge に接続します。"
         : "desktop maintenance required: local secret sync bridge が未接続です。")
   );
+  const approvalSectionAttributes = deployOneTapMode
+    ? ' data-owner-flow="one-tap-deploy"'
+    : "";
+  const approveButtonLabel = deployOneTapMode ? "パスキー" : "Approve high-risk action";
+  const deployScopeSummary = renderDeployScopeSummary({
+    repositoryInput: repoDefault,
+    issueNumber: issueDefault,
+    actionType: actionTypeDefault,
+    highRiskKind: highRiskKindDefault
+  });
 
   return `<!doctype html>
 <html lang="ja">
@@ -186,9 +197,25 @@ export function renderPasskeyOperatorPage(input = {}) {
           <pre id="register-output"></pre>
         </section>
 
-        <section data-operator-section="approval"${hiddenAttribute(!sectionVisibility.approval)}>
-          <h2>2. High-risk Approval</h2>
-          <label for="repo-input">Repository</label>
+        <section data-operator-section="approval"${approvalSectionAttributes}${hiddenAttribute(!sectionVisibility.approval)}>
+          <h2>${deployOneTapMode ? "本番反映の承認" : "2. High-risk Approval"}</h2>
+          ${
+            deployOneTapMode
+              ? `<p>production deploy を承認して、そのまま反映を開始します。</p>
+          <p class="muted">${deployScopeSummary}</p>
+          <div class="approval-internal" hidden>
+            <label for="repo-input">Repository</label>
+            <input id="repo-input" value="${repoDefault}" placeholder="marushu/vtdd-v2-p" />
+            <label for="issue-input">Issue Number</label>
+            <input id="issue-input" value="${issueDefault}" placeholder="15" />
+            <label for="phase-input">Phase</label>
+            <input id="phase-input" value="${phaseDefault}" />
+            <label for="action-type-input">Action Type</label>
+            <input id="action-type-input" value="${actionTypeDefault}" />
+            <label for="risk-kind-input">High-risk Kind</label>
+            <input id="risk-kind-input" value="${highRiskKindDefault}" />
+          </div>`
+              : `<label for="repo-input">Repository</label>
           <input id="repo-input" value="${repoDefault}" placeholder="marushu/vtdd-v2-p" />
           <label for="issue-input">Issue Number</label>
           <input id="issue-input" value="${issueDefault}" placeholder="15" />
@@ -197,17 +224,22 @@ export function renderPasskeyOperatorPage(input = {}) {
           <label for="action-type-input">Action Type</label>
           <input id="action-type-input" value="${actionTypeDefault}" />
           <label for="risk-kind-input">High-risk Kind</label>
-          <input id="risk-kind-input" value="${highRiskKindDefault}" />
+          <input id="risk-kind-input" value="${highRiskKindDefault}" />`
+          }
           <div class="row">
-            <button class="secondary" id="approve-button">Approve high-risk action</button>
-            <button class="ghost" id="copy-approval-grant-button" type="button">Copy approvalGrantId</button>
+            <button class="secondary" id="approve-button">${approveButtonLabel}</button>
+            ${deployOneTapMode ? "" : '<button class="ghost" id="copy-approval-grant-button" type="button">Copy approvalGrantId</button>'}
           </div>
-          <label class="inline-check" for="auto-copy-approval-grant-input">
+          ${
+            deployOneTapMode
+              ? '<input id="auto-copy-approval-grant-input" type="checkbox" hidden />'
+              : `<label class="inline-check" for="auto-copy-approval-grant-input">
             <input id="auto-copy-approval-grant-input" type="checkbox" />
             Auto-copy approvalGrantId after approval
-          </label>
-          <p class="muted">GitHub App secret sync なら <code>actionType=destructive</code> / <code>highRiskKind=github_app_secret_sync</code>、production deploy なら <code>actionType=deploy_production</code> / <code>highRiskKind=deploy_production</code>、PR merge なら <code>actionType=merge</code> / <code>highRiskKind=pull_merge</code> を使います。</p>
-          <pre id="approve-output"></pre>
+          </label>`
+          }
+          ${deployOneTapMode ? "" : '<p class="muted">GitHub App secret sync なら <code>actionType=destructive</code> / <code>highRiskKind=github_app_secret_sync</code>、production deploy なら <code>actionType=deploy_production</code> / <code>highRiskKind=deploy_production</code>、PR merge なら <code>actionType=merge</code> / <code>highRiskKind=pull_merge</code> を使います。</p>'}
+          <pre id="approve-output"${deployOneTapMode ? " hidden" : ""}></pre>
         </section>
 
         <section data-operator-section="github-app-secret-sync"${hiddenAttribute(!sectionVisibility.githubAppSecretSync)}>
@@ -232,14 +264,19 @@ export function renderPasskeyOperatorPage(input = {}) {
 
         <section data-operator-section="production-deploy"${hiddenAttribute(!sectionVisibility.productionDeploy)}>
           <h2>4. Production Deploy</h2>
-          <p class="muted">deploy stale を検知したあと、real passkey approval が成功したら同じ <code>approvalGrantId</code> で same-origin の governed deploy path を自動 dispatch します。</p>
+          <p class="muted">deploy stale を検知したあと、real passkey approval が成功したら same-origin の governed deploy path を自動 dispatch します。</p>
           <div class="row">
-            <button id="deploy-button">Dispatch production deploy</button>
-            <a class="button-link" id="deploy-run-link" href="#" target="_blank" rel="noopener noreferrer" hidden>Open deploy run</a>
+            <button id="deploy-button"${deployOneTapMode ? " hidden" : ""}>Dispatch production deploy</button>
+            ${deployOneTapMode ? "" : '<a class="button-link" id="deploy-run-link" href="#" target="_blank" rel="noopener noreferrer" hidden>Open deploy run</a>'}
             <a class="button-link" id="return-to-butler-link" href="${returnUrl}" rel="noopener noreferrer"${returnUrl ? "" : " hidden"}>Return to Butler</a>
           </div>
-          <p class="muted">この Worker origin を <code>runtimeUrl</code> として使います。手動ボタンは失敗時の再実行用です。完了または失敗は Dashboard 通知センターと保存済み Web Push 購読へ届きます。</p>
+          <p class="muted">完了または失敗は Dashboard 通知センターと保存済み Web Push 購読へ届きます。</p>
           <pre id="deploy-output"></pre>
+          <details>
+            <summary>詳細</summary>
+            ${deployOneTapMode ? '<a class="button-link" id="deploy-run-link" href="#" target="_blank" rel="noopener noreferrer" hidden>Open deploy run</a>' : ""}
+            <pre id="deploy-debug-output"></pre>
+          </details>
         </section>
 
         <section data-operator-section="pr-merge"${hiddenAttribute(!sectionVisibility.prMerge)}>
@@ -321,6 +358,7 @@ export function renderPasskeyOperatorPage(input = {}) {
       const copyApprovalGrantButton = document.getElementById("copy-approval-grant-button");
       const autoCopyApprovalGrantInput = document.getElementById("auto-copy-approval-grant-input");
       const deployRunLink = document.getElementById("deploy-run-link");
+      const deployDebugOutput = document.getElementById("deploy-debug-output");
       const mergePrLink = document.getElementById("merge-pr-link");
       const issueCloseLink = document.getElementById("issue-close-link");
       const operatorMode = "${escapeHtml(operatorMode)}";
@@ -445,6 +483,17 @@ export function renderPasskeyOperatorPage(input = {}) {
         }
         deployRunLink.href = runUrl;
         deployRunLink.hidden = false;
+      }
+
+      function buildDeployResultText(body) {
+        const deploy = body?.deploy || {};
+        if (deploy.status === "dispatched") {
+          return "deploy を開始しました。完了通知を待ってください。";
+        }
+        if (deploy.status === "dispatch_accepted_unverified") {
+          return "deploy request は受理されました。GitHub Actions の run 確認は未確定です。";
+        }
+        return "deploy request を受け付けました。";
       }
 
       function extractMergePullRequestUrl(body) {
@@ -585,16 +634,21 @@ export function renderPasskeyOperatorPage(input = {}) {
           throw responseError(deployBody, "production deploy failed");
         }
         showDeployRunLink(deployBody);
-        deployOutput.textContent = JSON.stringify(deployBody, null, 2);
+        deployOutput.textContent = buildDeployResultText(deployBody);
+        if (deployDebugOutput) {
+          deployDebugOutput.textContent = JSON.stringify(deployBody, null, 2);
+        }
       }
 
-      copyApprovalGrantButton.addEventListener("click", async () => {
-        try {
-          await copyApprovalGrantIdToClipboard();
-        } catch (error) {
-          approveOutput.textContent = approveOutput.textContent + "\\n\\n" + String(error);
-        }
-      });
+      if (copyApprovalGrantButton) {
+        copyApprovalGrantButton.addEventListener("click", async () => {
+          try {
+            await copyApprovalGrantIdToClipboard();
+          } catch (error) {
+            approveOutput.textContent = approveOutput.textContent + "\\n\\n" + String(error);
+          }
+        });
+      }
 
       document.getElementById("register-button").addEventListener("click", async () => {
         try {
@@ -686,7 +740,7 @@ export function renderPasskeyOperatorPage(input = {}) {
             window.location.assign("/dashboard");
             return;
           }
-          if (latestApprovalGrantId && autoCopyApprovalGrantInput.checked) {
+          if (latestApprovalGrantId && autoCopyApprovalGrantInput?.checked) {
             try {
               await copyApprovalGrantIdToClipboard({ quiet: true });
               approveOutput.textContent = approveOutput.textContent + "\\n\\nCopied approvalGrantId to clipboard.";
@@ -1071,6 +1125,12 @@ function hiddenAttribute(hidden) {
 function renderGithubAppRoleOption(value, label, selectedValue) {
   const selected = value === selectedValue ? " selected" : "";
   return `<option value="${escapeHtml(value)}"${selected}>${escapeHtml(label)}</option>`;
+}
+
+function renderDeployScopeSummary({ repositoryInput, issueNumber, actionType, highRiskKind }) {
+  const repository = repositoryInput || "未指定";
+  const issue = issueNumber ? ` / Issue: ${issueNumber}` : "";
+  return `承認対象: Repository: ${repository}${issue} / Action: ${actionType} / ${highRiskKind}`;
 }
 
 function normalizeOperatorMode(value) {

--- a/test/passkey-operator-page.test.js
+++ b/test/passkey-operator-page.test.js
@@ -5,6 +5,7 @@ import { renderPasskeyOperatorPage } from "../src/core/index.js";
 
 test("passkey operator page can target explicit api base and sync endpoint", () => {
   const html = renderPasskeyOperatorPage({
+    operatorMode: "full",
     apiBase: "/api",
     syncApiBase: "http://127.0.0.1:8789/api",
     actionType: "deploy_production",
@@ -122,16 +123,28 @@ test("passkey operator page focuses deploy mode on deploy approval and dispatch 
   });
 
   assert.equal(html.includes('<section data-operator-section="registration" hidden>'), true);
-  assert.equal(html.includes('<section data-operator-section="approval">'), true);
+  assert.equal(
+    html.includes('<section data-operator-section="approval" data-owner-flow="one-tap-deploy">'),
+    true
+  );
   assert.equal(html.includes('<section data-operator-section="production-deploy">'), true);
   assert.equal(html.includes('<section data-operator-section="pr-merge" hidden>'), true);
   assert.equal(html.includes('<section data-operator-section="issue-close" hidden>'), true);
   assert.equal(html.includes('<section data-operator-section="github-app-secret-sync" hidden>'), true);
   assert.equal(html.includes('<section data-operator-section="github-actions-secret-sync" hidden>'), true);
-  assert.equal(html.includes("Dispatch production deploy"), true);
-  assert.equal(html.includes("自動 dispatch"), true);
-  assert.equal(html.includes("手動ボタンは失敗時の再実行用です"), true);
+  assert.equal(html.includes('id="approve-button">パスキー</button>'), true);
+  assert.equal(html.includes("production deploy を承認して、そのまま反映を開始します。"), true);
+  assert.equal(html.includes("承認対象"), true);
+  assert.equal(html.includes("Repository: marushu/vtdd-v2-p"), true);
+  assert.equal(html.includes("Action: deploy_production / deploy_production"), true);
+  assert.equal(html.includes("Approve high-risk action"), false);
+  assert.equal(html.includes("Copy approvalGrantId"), false);
+  assert.equal(html.includes("Auto-copy approvalGrantId after approval"), false);
+  assert.equal(html.includes('id="deploy-button" hidden>Dispatch production deploy</button>'), true);
   assert.equal(html.includes("Dashboard 通知センターと保存済み Web Push 購読へ届きます"), true);
+  assert.equal(html.includes("deploy を開始しました。完了通知を待ってください。"), true);
+  assert.equal(html.includes("deploy-debug-output"), true);
+  assert.equal(html.includes("<summary>詳細</summary>"), true);
   assert.equal(html.includes("Return to Butler"), true);
   assert.equal(html.includes('id="issue-input" value=""'), true);
   assert.equal(html.includes('id="pull-number-input" value=""'), true);

--- a/worker.js
+++ b/worker.js
@@ -27245,6 +27245,7 @@ function normalize(value) {
 // src/core/passkey-operator-page.js
 function renderPasskeyOperatorPage(input = {}) {
   const operatorMode = resolvePasskeyOperatorMode(input);
+  const deployOneTapMode = operatorMode === "deploy";
   const passkeyEnabled = input.passkeyEnabled !== false;
   const sectionVisibility = resolveSectionVisibility(operatorMode, { passkeyEnabled });
   const origin = escapeHtml(input.origin || "");
@@ -27265,6 +27266,14 @@ function renderPasskeyOperatorPage(input = {}) {
   const syncMessage = escapeHtml(
     input.syncMessage || (syncEnabled ? "approvalGrantId \u304C\u53D6\u5F97\u6E08\u307F\u306A\u3089\u5B9F\u884C\u3067\u304D\u307E\u3059\u3002desktop helper bridge \u306B\u63A5\u7D9A\u3057\u307E\u3059\u3002" : "desktop maintenance required: local secret sync bridge \u304C\u672A\u63A5\u7D9A\u3067\u3059\u3002")
   );
+  const approvalSectionAttributes = deployOneTapMode ? ' data-owner-flow="one-tap-deploy"' : "";
+  const approveButtonLabel = deployOneTapMode ? "\u30D1\u30B9\u30AD\u30FC" : "Approve high-risk action";
+  const deployScopeSummary = renderDeployScopeSummary({
+    repositoryInput: repoDefault,
+    issueNumber: issueDefault,
+    actionType: actionTypeDefault,
+    highRiskKind: highRiskKindDefault
+  });
   return `<!doctype html>
 <html lang="ja">
   <head>
@@ -27427,9 +27436,22 @@ function renderPasskeyOperatorPage(input = {}) {
           <pre id="register-output"></pre>
         </section>
 
-        <section data-operator-section="approval"${hiddenAttribute(!sectionVisibility.approval)}>
-          <h2>2. High-risk Approval</h2>
-          <label for="repo-input">Repository</label>
+        <section data-operator-section="approval"${approvalSectionAttributes}${hiddenAttribute(!sectionVisibility.approval)}>
+          <h2>${deployOneTapMode ? "\u672C\u756A\u53CD\u6620\u306E\u627F\u8A8D" : "2. High-risk Approval"}</h2>
+          ${deployOneTapMode ? `<p>production deploy \u3092\u627F\u8A8D\u3057\u3066\u3001\u305D\u306E\u307E\u307E\u53CD\u6620\u3092\u958B\u59CB\u3057\u307E\u3059\u3002</p>
+          <p class="muted">${deployScopeSummary}</p>
+          <div class="approval-internal" hidden>
+            <label for="repo-input">Repository</label>
+            <input id="repo-input" value="${repoDefault}" placeholder="marushu/vtdd-v2-p" />
+            <label for="issue-input">Issue Number</label>
+            <input id="issue-input" value="${issueDefault}" placeholder="15" />
+            <label for="phase-input">Phase</label>
+            <input id="phase-input" value="${phaseDefault}" />
+            <label for="action-type-input">Action Type</label>
+            <input id="action-type-input" value="${actionTypeDefault}" />
+            <label for="risk-kind-input">High-risk Kind</label>
+            <input id="risk-kind-input" value="${highRiskKindDefault}" />
+          </div>` : `<label for="repo-input">Repository</label>
           <input id="repo-input" value="${repoDefault}" placeholder="marushu/vtdd-v2-p" />
           <label for="issue-input">Issue Number</label>
           <input id="issue-input" value="${issueDefault}" placeholder="15" />
@@ -27438,17 +27460,17 @@ function renderPasskeyOperatorPage(input = {}) {
           <label for="action-type-input">Action Type</label>
           <input id="action-type-input" value="${actionTypeDefault}" />
           <label for="risk-kind-input">High-risk Kind</label>
-          <input id="risk-kind-input" value="${highRiskKindDefault}" />
+          <input id="risk-kind-input" value="${highRiskKindDefault}" />`}
           <div class="row">
-            <button class="secondary" id="approve-button">Approve high-risk action</button>
-            <button class="ghost" id="copy-approval-grant-button" type="button">Copy approvalGrantId</button>
+            <button class="secondary" id="approve-button">${approveButtonLabel}</button>
+            ${deployOneTapMode ? "" : '<button class="ghost" id="copy-approval-grant-button" type="button">Copy approvalGrantId</button>'}
           </div>
-          <label class="inline-check" for="auto-copy-approval-grant-input">
+          ${deployOneTapMode ? '<input id="auto-copy-approval-grant-input" type="checkbox" hidden />' : `<label class="inline-check" for="auto-copy-approval-grant-input">
             <input id="auto-copy-approval-grant-input" type="checkbox" />
             Auto-copy approvalGrantId after approval
-          </label>
-          <p class="muted">GitHub App secret sync \u306A\u3089 <code>actionType=destructive</code> / <code>highRiskKind=github_app_secret_sync</code>\u3001production deploy \u306A\u3089 <code>actionType=deploy_production</code> / <code>highRiskKind=deploy_production</code>\u3001PR merge \u306A\u3089 <code>actionType=merge</code> / <code>highRiskKind=pull_merge</code> \u3092\u4F7F\u3044\u307E\u3059\u3002</p>
-          <pre id="approve-output"></pre>
+          </label>`}
+          ${deployOneTapMode ? "" : '<p class="muted">GitHub App secret sync \u306A\u3089 <code>actionType=destructive</code> / <code>highRiskKind=github_app_secret_sync</code>\u3001production deploy \u306A\u3089 <code>actionType=deploy_production</code> / <code>highRiskKind=deploy_production</code>\u3001PR merge \u306A\u3089 <code>actionType=merge</code> / <code>highRiskKind=pull_merge</code> \u3092\u4F7F\u3044\u307E\u3059\u3002</p>'}
+          <pre id="approve-output"${deployOneTapMode ? " hidden" : ""}></pre>
         </section>
 
         <section data-operator-section="github-app-secret-sync"${hiddenAttribute(!sectionVisibility.githubAppSecretSync)}>
@@ -27473,14 +27495,19 @@ function renderPasskeyOperatorPage(input = {}) {
 
         <section data-operator-section="production-deploy"${hiddenAttribute(!sectionVisibility.productionDeploy)}>
           <h2>4. Production Deploy</h2>
-          <p class="muted">deploy stale \u3092\u691C\u77E5\u3057\u305F\u3042\u3068\u3001real passkey approval \u304C\u6210\u529F\u3057\u305F\u3089\u540C\u3058 <code>approvalGrantId</code> \u3067 same-origin \u306E governed deploy path \u3092\u81EA\u52D5 dispatch \u3057\u307E\u3059\u3002</p>
+          <p class="muted">deploy stale \u3092\u691C\u77E5\u3057\u305F\u3042\u3068\u3001real passkey approval \u304C\u6210\u529F\u3057\u305F\u3089 same-origin \u306E governed deploy path \u3092\u81EA\u52D5 dispatch \u3057\u307E\u3059\u3002</p>
           <div class="row">
-            <button id="deploy-button">Dispatch production deploy</button>
-            <a class="button-link" id="deploy-run-link" href="#" target="_blank" rel="noopener noreferrer" hidden>Open deploy run</a>
+            <button id="deploy-button"${deployOneTapMode ? " hidden" : ""}>Dispatch production deploy</button>
+            ${deployOneTapMode ? "" : '<a class="button-link" id="deploy-run-link" href="#" target="_blank" rel="noopener noreferrer" hidden>Open deploy run</a>'}
             <a class="button-link" id="return-to-butler-link" href="${returnUrl}" rel="noopener noreferrer"${returnUrl ? "" : " hidden"}>Return to Butler</a>
           </div>
-          <p class="muted">\u3053\u306E Worker origin \u3092 <code>runtimeUrl</code> \u3068\u3057\u3066\u4F7F\u3044\u307E\u3059\u3002\u624B\u52D5\u30DC\u30BF\u30F3\u306F\u5931\u6557\u6642\u306E\u518D\u5B9F\u884C\u7528\u3067\u3059\u3002\u5B8C\u4E86\u307E\u305F\u306F\u5931\u6557\u306F Dashboard \u901A\u77E5\u30BB\u30F3\u30BF\u30FC\u3068\u4FDD\u5B58\u6E08\u307F Web Push \u8CFC\u8AAD\u3078\u5C4A\u304D\u307E\u3059\u3002</p>
+          <p class="muted">\u5B8C\u4E86\u307E\u305F\u306F\u5931\u6557\u306F Dashboard \u901A\u77E5\u30BB\u30F3\u30BF\u30FC\u3068\u4FDD\u5B58\u6E08\u307F Web Push \u8CFC\u8AAD\u3078\u5C4A\u304D\u307E\u3059\u3002</p>
           <pre id="deploy-output"></pre>
+          <details>
+            <summary>\u8A73\u7D30</summary>
+            ${deployOneTapMode ? '<a class="button-link" id="deploy-run-link" href="#" target="_blank" rel="noopener noreferrer" hidden>Open deploy run</a>' : ""}
+            <pre id="deploy-debug-output"></pre>
+          </details>
         </section>
 
         <section data-operator-section="pr-merge"${hiddenAttribute(!sectionVisibility.prMerge)}>
@@ -27562,6 +27589,7 @@ function renderPasskeyOperatorPage(input = {}) {
       const copyApprovalGrantButton = document.getElementById("copy-approval-grant-button");
       const autoCopyApprovalGrantInput = document.getElementById("auto-copy-approval-grant-input");
       const deployRunLink = document.getElementById("deploy-run-link");
+      const deployDebugOutput = document.getElementById("deploy-debug-output");
       const mergePrLink = document.getElementById("merge-pr-link");
       const issueCloseLink = document.getElementById("issue-close-link");
       const operatorMode = "${escapeHtml(operatorMode)}";
@@ -27686,6 +27714,17 @@ function renderPasskeyOperatorPage(input = {}) {
         }
         deployRunLink.href = runUrl;
         deployRunLink.hidden = false;
+      }
+
+      function buildDeployResultText(body) {
+        const deploy = body?.deploy || {};
+        if (deploy.status === "dispatched") {
+          return "deploy \u3092\u958B\u59CB\u3057\u307E\u3057\u305F\u3002\u5B8C\u4E86\u901A\u77E5\u3092\u5F85\u3063\u3066\u304F\u3060\u3055\u3044\u3002";
+        }
+        if (deploy.status === "dispatch_accepted_unverified") {
+          return "deploy request \u306F\u53D7\u7406\u3055\u308C\u307E\u3057\u305F\u3002GitHub Actions \u306E run \u78BA\u8A8D\u306F\u672A\u78BA\u5B9A\u3067\u3059\u3002";
+        }
+        return "deploy request \u3092\u53D7\u3051\u4ED8\u3051\u307E\u3057\u305F\u3002";
       }
 
       function extractMergePullRequestUrl(body) {
@@ -27826,16 +27865,21 @@ function renderPasskeyOperatorPage(input = {}) {
           throw responseError(deployBody, "production deploy failed");
         }
         showDeployRunLink(deployBody);
-        deployOutput.textContent = JSON.stringify(deployBody, null, 2);
+        deployOutput.textContent = buildDeployResultText(deployBody);
+        if (deployDebugOutput) {
+          deployDebugOutput.textContent = JSON.stringify(deployBody, null, 2);
+        }
       }
 
-      copyApprovalGrantButton.addEventListener("click", async () => {
-        try {
-          await copyApprovalGrantIdToClipboard();
-        } catch (error) {
-          approveOutput.textContent = approveOutput.textContent + "\\n\\n" + String(error);
-        }
-      });
+      if (copyApprovalGrantButton) {
+        copyApprovalGrantButton.addEventListener("click", async () => {
+          try {
+            await copyApprovalGrantIdToClipboard();
+          } catch (error) {
+            approveOutput.textContent = approveOutput.textContent + "\\n\\n" + String(error);
+          }
+        });
+      }
 
       document.getElementById("register-button").addEventListener("click", async () => {
         try {
@@ -27927,7 +27971,7 @@ function renderPasskeyOperatorPage(input = {}) {
             window.location.assign("/dashboard");
             return;
           }
-          if (latestApprovalGrantId && autoCopyApprovalGrantInput.checked) {
+          if (latestApprovalGrantId && autoCopyApprovalGrantInput?.checked) {
             try {
               await copyApprovalGrantIdToClipboard({ quiet: true });
               approveOutput.textContent = approveOutput.textContent + "\\n\\nCopied approvalGrantId to clipboard.";
@@ -28305,6 +28349,11 @@ function hiddenAttribute(hidden) {
 function renderGithubAppRoleOption(value, label, selectedValue) {
   const selected = value === selectedValue ? " selected" : "";
   return `<option value="${escapeHtml(value)}"${selected}>${escapeHtml(label)}</option>`;
+}
+function renderDeployScopeSummary({ repositoryInput, issueNumber, actionType, highRiskKind }) {
+  const repository = repositoryInput || "\u672A\u6307\u5B9A";
+  const issue2 = issueNumber ? ` / Issue: ${issueNumber}` : "";
+  return `\u627F\u8A8D\u5BFE\u8C61: Repository: ${repository}${issue2} / Action: ${actionType} / ${highRiskKind}`;
 }
 function normalizeOperatorMode(value) {
   const token = normalizeOperatorToken(value);


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #532 の deploy approval UX を、owner-facing には `パスキー` 1ボタンで承認し、そのまま production deploy dispatch へ進む形に寄せます。`approvalGrantId` copy、manual dispatch、raw workflow input を通常の deploy mode 主操作から外し、内部実装は詳細へ隔離します。

## Satisfied Success Criteria

- deploy-scoped operator page は `data-owner-flow="one-tap-deploy"` になり、主操作が `パスキー` ボタンになる。
- `パスキー` 認証成功後、既存の `/v2/action/deploy` へ自動 dispatch する既存 flow を維持した。
- 承認対象として repository / Issue / actionType / highRiskKind を短い scope summary で表示する。
- deploy mode では `Copy approvalGrantId`、auto-copy、手動 `Dispatch production deploy` を主表示から外した。
- deploy dispatch の成功表示は raw JSON ではなく `deploy を開始しました。完了通知を待ってください。` の owner-facing 表示にし、raw JSON と run link は `詳細` 配下に隔離した。
- `GO + real passkey` / scoped passkey approval と既存 `/action/deploy` authority boundary は緩めていない。

## Unsatisfied Success Criteria

- iPhone/PWA 実機での passkey -> deploy dispatch E2E は未実施。
- deploy 実行そのものはこのPRでは行っていない。
- Dashboard 通常チャット面から必要時だけこの one-tap flow を出す導線全体は Issue #528 側に残る。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #532
- Implementing Success Criteria: deploy-scoped passkey operator を owner-facing 1ボタン承認 + 自動 deploy dispatch 表示にする。
- Explicit Non-goals: passkey 境界の迂回、credential/permission mutation、Cloudflare production deploy 実行、Issue #514 close、Dashboard 通常チャット UX 全体の作り直し。
- Expected touched files/routes/workflows: `src/core/passkey-operator-page.js`、`test/passkey-operator-page.test.js`、`worker.js`。
- Affected Issues: Issue #532、関連して Issue #528 / Issue #514 / Issue #91。
- Affected PRs: なし。
- Affected workflows: 通常 CI / review のみ。`.github/workflows/deploy-production.yml` は未変更。
- Affected runtime/operator surfaces: `/v2/approval/passkey/operator?mode=deploy...` と actionType/highRiskKind から deploy mode inferred される passkey operator page。
- What may break if we patch narrowly: deploy mode の HTML/JS 表示変更により、既存の手動 copy/dispatch 前提の運用が見えなくなる。ただし full/operator maintenance mode は維持する。
- Unknowns to investigate before coding: iPhone Safari/PWA で passkey prompt 後の auto dispatch 表示が十分分かりやすいかは live確認が必要。
- Validation needed: `node --test test/passkey-operator-page.test.js test/deploy-production-plane.test.js`、`node --test`、`npm run build:worker`、`npm run check:self-parity`、`npm run check:generated-worker`、`git diff --check`、iPhone/PWA live E2E。
- Stop condition: deploy credential、GitHub Actions secret、Cloudflare permission、production deploy 実行、Dashboard 通常チャット全体修正へ踏み込む場合は停止。

## File / Line Hypotheses

- file: `src/core/passkey-operator-page.js:1`
  - hypothesis: deploy mode でも汎用 operator helper のUIがそのまま露出しているため、owner が URL/grant/workflow/manual dispatch を理解して操作する必要がある。
  - risk if changed narrowly: deploy mode の表示だけ変えても、Dashboard 通常チャット面からの到達 UX は残る。
  - validation: passkey operator page test で one-tap deploy表示と auto dispatch JS を検証。
  - related Issue: Issue #532
- file: `test/passkey-operator-page.test.js:116`
  - hypothesis: 既存 test が `Dispatch production deploy` や approvalGrant copy を deploy mode の正しい表示として固定していた。
  - risk if changed narrowly: HTML文字列テストだけでは実機 passkey prompt 後の見た目までは保証できない。
  - validation: deploy mode の visible owner-facing contract を test に固定し、full maintenance mode は別テストで維持。
  - related Issue: Issue #532

## Hypothesis Retrospective

- expected: deploy-scoped operator page は owner-facing には `パスキー` 1ボタン主操作になり、内部 grant/workflow details を主表示から外せる。
- actual: deploy mode は `data-owner-flow="one-tap-deploy"`、`パスキー` ボタン、scope summary、auto dispatch、owner-facing deploy status、details隔離になった。full maintenance mode は copy/manual helper を維持。
- mismatch: iPhone/PWA live E2E は未実施。
- lesson: passkey境界は必要だが、approvalGrantId/workflow/runtimeUrlを人間に触らせる表示は owner-facing UX ではなく debug/operator UX。
- should become RAG candidate: Issue #532 の live E2E 後に判断。

## Verification Evidence

- Unit: `node --test test/passkey-operator-page.test.js test/deploy-production-plane.test.js`: pass。
- Integration: `node --test`: pass, 947 tests / 946 pass / 1 skipped。`npm run build:worker`: pass。`npm run check:self-parity`: pass。`npm run check:generated-worker`: pass after commit。`git diff --check`: pass。
- E2E: 未実施。iPhone/PWA passkey -> deploy dispatch live確認が必要。
- Manual: Issue #532 を作成済み。
- Evidence path/link: `src/core/passkey-operator-page.js`、`test/passkey-operator-page.test.js`、`worker.js`、Issue #532。

## Butler Completion Contract

- Owner goal: production deploy approval を、owner が URL/grant/workflow入力を扱わず `パスキー` 1ボタンで進められるようにする。
- Butler entrypoint: deploy-scoped passkey operator URL。Dashboard通常チャットからの必要時提示はこのPRでは未変更。
- Action Schema exposure: 未変更。
- Runtime path: `/v2/approval/passkey/operator?...deploy_production...` -> passkey challenge/verify -> existing `/v2/action/deploy` auto dispatch。
- Runner/runtime truth: Local tests prove generated page contract and deploy plane dispatch contract. Production deploy/live iPhone truth is not verified.
- Authority boundary: `GO + real passkey` / scoped passkey approval は維持。credential、permission、deploy実行はしていない。
- E2E evidence: 未実施。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 必要。runtime UI変更なので merge後に本番Dashboardへ反映するには deploy が必要。ただしこのPRでは deploy しない。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。deploy後に必要。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate
- AGENTS.md Butler-First Operating Principle
- AGENTS.md Conversation UX Contract
- AGENTS.md Authority Boundary
- AGENTS.md Evidence Discipline

## Out-of-scope but NOT implemented

- Cloudflare production deploy 実行
- deploy credential / GitHub Actions secret / Cloudflare permission mutation
- Issue #514 notification live E2E
- Issue close
- Dashboard 通常チャット面の全面修正

## Extra changes (if any)

None.
