### PR TITLE
Issue #534 Dashboard 通知と進捗を優先表示に直す

### DIFF
--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -9715,6 +9715,12 @@ async function renderDashboardNotificationsPage({ runtimeOrigin, dashboardEventS
         <p>Dashboard Butler の通知入口です。iOS PWA Web Push、OS の通知音、未読 badge はこの画面から許可・確認します。</p>
         <p class="muted">VTDD だけでなく、他 repo / 並行開発 / queue / workflow から届いたイベントを直近5分だけ表示します。</p>
       </section>
+      <div class="grid single">
+        <section class="lane">
+          <div class="lane-title"><h2>最新通知</h2><span class="pill">直近5分</span></div>
+          ${recentEvents.length > 0 ? recentEvents.map((event) => renderDashboardNotificationEvent(event)).join("") : `<p class="muted">直近5分の通知はありません。</p>`}
+        </section>
+      </div>
       <div class="grid">
         <section class="lane">
           <div class="lane-title"><h2>iOS PWA 通知</h2><span class="pill" id="push-support-pill">確認中</span></div>
@@ -9738,18 +9744,15 @@ async function renderDashboardNotificationsPage({ runtimeOrigin, dashboardEventS
             <button class="dashboard-action" id="badge-clear-button" type="button">Badge を消す</button>
           </div>
         </section>
-        <section class="lane">
+      </div>
+      <div class="grid single">
+        <details class="lane" data-debug-section="notification-authority-boundary">
+          <summary>通知の詳細設定と安全境界</summary>
           <div class="lane-title"><h2>Authority boundary</h2><span class="pill">read/write</span></div>
           <p>push subscription は dashboard owner session から保存します。HTML には endpoint、auth key、p256dh key を埋め込みません。</p>
           <p class="muted">同一 origin の dashboard owner session cookie / Cloudflare Access identity を使うため、購読保存 fetch は credentials: same-origin で送ります。</p>
           <p class="muted">Web Push 送信には server-side VAPID secret と subscription raw material が必要です。D1 には送信用に保持し、response / HTML / payload_json には raw key を返しません。</p>
-        </section>
-      </div>
-      <div class="grid single">
-        <section class="lane">
-          <div class="lane-title"><h2>最新通知</h2><span class="pill">直近5分</span></div>
-          ${recentEvents.length > 0 ? recentEvents.map((event) => renderDashboardNotificationEvent(event)).join("") : `<p class="muted">直近5分の通知はありません。</p>`}
-        </section>
+        </details>
       </div>
       <script>
         (() => {
@@ -10509,8 +10512,8 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           </div>
         </div>
         <div class="top-right">
-          <a class="tool-button top-action" href="${escapeDashboardHtml(origin)}/v2/approval/passkey/operator?repositoryInput=${encodedRepository}" aria-label="Passkey operator">Passkey</a>
-          <a class="tool-button top-action" href="${escapeDashboardHtml(origin)}/v2/approval/passkey/operator?repositoryInput=${encodedRepository}&phase=execution&actionType=deploy_production&highRiskKind=deploy_production" aria-label="Deploy operator">Deploy</a>
+          <a class="tool-button top-action" href="${escapeDashboardHtml(origin)}/dashboard/notifications" aria-label="通知センター">通知</a>
+          <a class="tool-button top-action" href="${escapeDashboardHtml(origin)}/dashboard/progress?repository=${encodedRepository}" aria-label="進捗を見る">進捗</a>
         </div>
       </header>
 

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -754,8 +754,10 @@ test("worker serves v2 dashboard for allowed owner identity without exposing sec
   assert.equal(body.includes("vtdd-v3-orchestrator.polished-tree-da7c.workers.dev"), false);
   assert.equal(body.includes('id="mobile-menu-toggle"'), true);
   assert.equal(body.includes('for="mobile-menu-toggle"'), true);
-  assert.equal(body.includes('aria-label="Passkey operator">Passkey</a>'), true);
-  assert.equal(body.includes('aria-label="Deploy operator">Deploy</a>'), true);
+  assert.equal(body.includes('aria-label="Passkey operator">Passkey</a>'), false);
+  assert.equal(body.includes('aria-label="Deploy operator">Deploy</a>'), false);
+  assert.equal(body.includes('aria-label="通知センター">通知</a>'), true);
+  assert.equal(body.includes('aria-label="進捗を見る">進捗</a>'), true);
   assert.equal(body.includes('aria-label="Passkey">◇</a>'), false);
   assert.equal(body.includes('<label class="tool-button menu-open" for="mobile-menu-toggle">管理</label>'), false);
   assert.equal(body.includes('class="tool-button top-action"'), true);
@@ -2559,6 +2561,11 @@ test("worker serves dashboard notification center for recent events across repos
   assert.equal(body.includes("通知センター"), true);
   assert.equal(body.includes("Dashboard Butler の通知入口です"), true);
   assert.equal(body.includes("iOS PWA Web Push"), true);
+  assert.equal(body.indexOf("最新通知") < body.indexOf("iOS PWA 通知"), true);
+  assert.equal(body.indexOf("最新通知") < body.indexOf("Badge"), true);
+  assert.equal(body.indexOf("最新通知") < body.indexOf("Authority boundary"), true);
+  assert.equal(body.includes('data-debug-section="notification-authority-boundary"'), true);
+  assert.equal(body.includes("<summary>通知の詳細設定と安全境界</summary>"), true);
   assert.equal(body.includes("id=\"push-permission-button\""), true);
   assert.equal(body.includes("id=\"push-subscribe-button\""), true);
   assert.equal(body.includes("id=\"push-server-test-button\""), true);

--- a/worker.js
+++ b/worker.js
@@ -64519,6 +64519,12 @@ async function renderDashboardNotificationsPage({ runtimeOrigin, dashboardEventS
         <p>Dashboard Butler \u306E\u901A\u77E5\u5165\u53E3\u3067\u3059\u3002iOS PWA Web Push\u3001OS \u306E\u901A\u77E5\u97F3\u3001\u672A\u8AAD badge \u306F\u3053\u306E\u753B\u9762\u304B\u3089\u8A31\u53EF\u30FB\u78BA\u8A8D\u3057\u307E\u3059\u3002</p>
         <p class="muted">VTDD \u3060\u3051\u3067\u306A\u304F\u3001\u4ED6 repo / \u4E26\u884C\u958B\u767A / queue / workflow \u304B\u3089\u5C4A\u3044\u305F\u30A4\u30D9\u30F3\u30C8\u3092\u76F4\u8FD15\u5206\u3060\u3051\u8868\u793A\u3057\u307E\u3059\u3002</p>
       </section>
+      <div class="grid single">
+        <section class="lane">
+          <div class="lane-title"><h2>\u6700\u65B0\u901A\u77E5</h2><span class="pill">\u76F4\u8FD15\u5206</span></div>
+          ${recentEvents.length > 0 ? recentEvents.map((event) => renderDashboardNotificationEvent(event)).join("") : `<p class="muted">\u76F4\u8FD15\u5206\u306E\u901A\u77E5\u306F\u3042\u308A\u307E\u305B\u3093\u3002</p>`}
+        </section>
+      </div>
       <div class="grid">
         <section class="lane">
           <div class="lane-title"><h2>iOS PWA \u901A\u77E5</h2><span class="pill" id="push-support-pill">\u78BA\u8A8D\u4E2D</span></div>
@@ -64542,18 +64548,15 @@ async function renderDashboardNotificationsPage({ runtimeOrigin, dashboardEventS
             <button class="dashboard-action" id="badge-clear-button" type="button">Badge \u3092\u6D88\u3059</button>
           </div>
         </section>
-        <section class="lane">
+      </div>
+      <div class="grid single">
+        <details class="lane" data-debug-section="notification-authority-boundary">
+          <summary>\u901A\u77E5\u306E\u8A73\u7D30\u8A2D\u5B9A\u3068\u5B89\u5168\u5883\u754C</summary>
           <div class="lane-title"><h2>Authority boundary</h2><span class="pill">read/write</span></div>
           <p>push subscription \u306F dashboard owner session \u304B\u3089\u4FDD\u5B58\u3057\u307E\u3059\u3002HTML \u306B\u306F endpoint\u3001auth key\u3001p256dh key \u3092\u57CB\u3081\u8FBC\u307F\u307E\u305B\u3093\u3002</p>
           <p class="muted">\u540C\u4E00 origin \u306E dashboard owner session cookie / Cloudflare Access identity \u3092\u4F7F\u3046\u305F\u3081\u3001\u8CFC\u8AAD\u4FDD\u5B58 fetch \u306F credentials: same-origin \u3067\u9001\u308A\u307E\u3059\u3002</p>
           <p class="muted">Web Push \u9001\u4FE1\u306B\u306F server-side VAPID secret \u3068 subscription raw material \u304C\u5FC5\u8981\u3067\u3059\u3002D1 \u306B\u306F\u9001\u4FE1\u7528\u306B\u4FDD\u6301\u3057\u3001response / HTML / payload_json \u306B\u306F raw key \u3092\u8FD4\u3057\u307E\u305B\u3093\u3002</p>
-        </section>
-      </div>
-      <div class="grid single">
-        <section class="lane">
-          <div class="lane-title"><h2>\u6700\u65B0\u901A\u77E5</h2><span class="pill">\u76F4\u8FD15\u5206</span></div>
-          ${recentEvents.length > 0 ? recentEvents.map((event) => renderDashboardNotificationEvent(event)).join("") : `<p class="muted">\u76F4\u8FD15\u5206\u306E\u901A\u77E5\u306F\u3042\u308A\u307E\u305B\u3093\u3002</p>`}
-        </section>
+        </details>
       </div>
       <script>
         (() => {
@@ -65289,8 +65292,8 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           </div>
         </div>
         <div class="top-right">
-          <a class="tool-button top-action" href="${escapeDashboardHtml(origin)}/v2/approval/passkey/operator?repositoryInput=${encodedRepository}" aria-label="Passkey operator">Passkey</a>
-          <a class="tool-button top-action" href="${escapeDashboardHtml(origin)}/v2/approval/passkey/operator?repositoryInput=${encodedRepository}&phase=execution&actionType=deploy_production&highRiskKind=deploy_production" aria-label="Deploy operator">Deploy</a>
+          <a class="tool-button top-action" href="${escapeDashboardHtml(origin)}/dashboard/notifications" aria-label="\u901A\u77E5\u30BB\u30F3\u30BF\u30FC">\u901A\u77E5</a>
+          <a class="tool-button top-action" href="${escapeDashboardHtml(origin)}/dashboard/progress?repository=${encodedRepository}" aria-label="\u9032\u6357\u3092\u898B\u308B">\u9032\u6357</a>
         </div>
       </header>
 


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #534 の最初の UI 情報設計スライスとして、Dashboard Butler の通知センターで `最新通知` を最上位に戻し、設定/実装説明を下位または詳細へ隔離します。Dashboard topbar から Passkey / Deploy の常設 high-risk 導線を外し、owner-facing な `通知` / `進捗` を優先します。

## Satisfied Success Criteria

- 通知センターは `最新通知` を `iOS PWA 通知`、`Badge`、`Authority boundary` より前に描画する。
- 通知許可、購読保存、サーバ送信テスト、Badge は最新通知の下に置き、設定/確認項目として扱う。
- `Authority boundary`、raw key非露出、VAPID/D1/payload_json 説明は通常カードから外し、`通知の詳細設定と安全境界` の details に隔離した。
- Dashboard topbar の常設 `Passkey` / `Deploy` を外し、`通知` / `進捗` を主操作にした。
- Dashboard/通知センターのセクション順序とデバッグ隔離を `test/worker.test.js` で固定した。

## Unsatisfied Success Criteria

- Dashboard drawer/sidebar 全体の再編成は未完了。
- mobile viewport / PWA 実機 screenshot E2E は未実施。
- Issue #534 全体の completion は未完了。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #534
- Implementing Success Criteria: 通知センターの通知優先順序、Authority boundary の詳細隔離、Dashboard topbar の owner-facing 優先化。
- Explicit Non-goals: passkey authority boundary 変更、Cloudflare deploy 実行、credential/permission mutation、Issue #514 close、Dashboard 全体完成主張。
- Expected touched files/routes/workflows: `src/worker/runtime.js`、`test/worker.test.js`、`worker.js`。
- Affected Issues: Issue #534、関連して Issue #528 / Issue #514 / Issue #532。
- Affected PRs: なし。
- Affected workflows: 通常 CI / review のみ。deploy workflow は未変更。
- Affected runtime/operator surfaces: `/dashboard` topbar、`/dashboard/notifications`。
- What may break if we patch narrowly: 既存 topbar から passkey/deploy へ直接行っていた導線は drawer/sidebar 側に残るが、常設ではなくなる。
- Unknowns to investigate before coding: iPhone/PWA 実機で通知カードが最上部に見え、details が期待通り閉じているかは live確認が必要。
- Validation needed: `node --test test/worker.test.js --test-name-pattern "allowed owner identity|dashboard notification center"`、`node --test`、`npm run build:worker`、`npm run check:self-parity`、`npm run check:generated-worker`、`git diff --check`、mobile/PWA E2E。
- Stop condition: deploy実行、passkey境界変更、dashboard全体の未Issue化改修へ踏み込む場合は停止。

## File / Line Hypotheses

- file: `src/worker/runtime.js:9700`
  - hypothesis: `renderDashboardNotificationsPage` が設定/Badge/Authority boundary を先に描画し、最新通知を下へ追いやっている。
  - risk if changed narrowly: 通知センター以外の Dashboard menu 情報設計はまだ残る。
  - validation: notification center test で `最新通知` の順序と details 隔離を固定。
  - related Issue: Issue #534
- file: `src/worker/runtime.js:10512`
  - hypothesis: Dashboard topbar に Passkey / Deploy が常設され、owner-facing な通常操作より high-risk/debug 導線が目立っている。
  - risk if changed narrowly: drawer/sidebar の debug/ops 整理はまだ必要。
  - validation: dashboard HTML test で topbar の Passkey/Deploy 非常設と通知/進捗優先を固定。
  - related Issue: Issue #534

## Hypothesis Retrospective

- expected: 通知センターは最新通知が先、設定/実装説明は後、Dashboard topbar は通知/進捗を優先できる。
- actual: 最新通知を最上位へ移動し、Authority boundary を details へ隔離し、topbar を通知/進捗に差し替えた。
- mismatch: drawer/sidebar の情報設計、mobile screenshot E2E は未完了。
- lesson: 通知/チャット画面に実装説明を直接置くと、owner-facing UX ではなくデバッグ画面になる。
- should become RAG candidate: Issue #534 の続きと live E2E 後に判断。

## Verification Evidence

- Unit: `node --test test/worker.test.js --test-name-pattern "allowed owner identity|dashboard notification center"`: pass。
- Integration: `node --test`: pass, 947 tests / 946 pass / 1 skipped。`npm run build:worker`: pass。`npm run check:self-parity`: pass。`npm run check:generated-worker`: pass after commit。`git diff --check`: pass。
- E2E: 未実施。iPhone/PWA screenshot verification は残る。
- Manual: Issue #534 に基づく bounded slice。
- Evidence path/link: `src/worker/runtime.js`、`test/worker.test.js`、`worker.js`、Issue #534。

## Butler Completion Contract

- Owner goal: Dashboard Butler で通知/チャットが主、設定/デバッグが従になるようにする。
- Butler entrypoint: `/dashboard`、`/dashboard/notifications`。
- Action Schema exposure: 未変更。
- Runtime path: Dashboard HTML render path only。Worker routes and high-risk authority path are unchanged.
- Runner/runtime truth: Local tests prove HTML order and topbar contract. Production runtime and mobile viewport are not verified.
- Authority boundary: passkey/deploy 境界は緩めていない。topbar常設を外しただけ。
- E2E evidence: 未実施。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 必要。runtime UI変更なので merge後に本番Dashboardへ反映するには deploy が必要。ただしこのPRでは deploy しない。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。deploy後に必要。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate
- AGENTS.md Butler-First Operating Principle
- AGENTS.md Conversation UX Contract
- AGENTS.md Evidence Discipline

## Out-of-scope but NOT implemented

- drawer/sidebar 全体の情報設計再編
- Cloudflare production deploy 実行
- Issue #514 Web Push live E2E
- Issue close

## Extra changes (if any)

None.
