### PR TITLE
Issue #536 Dashboard通常閲覧でstale passkey cookieをAccess認証へfallbackする

### DIFF
--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -8555,9 +8555,6 @@ async function authorizeDashboardRequest({ request, env, apiSuffix = "/dashboard
   if (passkeyAuth.ok) {
     return passkeyAuth;
   }
-  if (passkeyAuth.blocking) {
-    return passkeyAuth;
-  }
 
   const routeLabel = `dashboard surface ${apiSuffix}`;
   const allowedEmails = parseAuthList(
@@ -8575,6 +8572,9 @@ async function authorizeDashboardRequest({ request, env, apiSuffix = "/dashboard
   const accessJwt = normalizeText(request.headers.get("cf-access-jwt-assertion"));
 
   if (!accessEmail && !accessLogin) {
+    if (passkeyAuth.blocking) {
+      return passkeyAuth;
+    }
     return {
       ok: false,
       status: 401,

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -682,6 +682,26 @@ test("worker rejects stale dashboard passkey session cookies", async () => {
   assert.equal(body.includes("dashboard passkey session was not found"), true);
 });
 
+test("worker ignores stale dashboard passkey cookie when Cloudflare Access owner identity is valid", async () => {
+  const response = await worker.fetch(
+    new Request("https://example.com/dashboard", {
+      headers: {
+        cookie: "vtdd_dashboard_session=approval%3Amissing",
+        ...dashboardAccessHeaders
+      }
+    }),
+    {
+      ...dashboardAccessEnv,
+      MEMORY_PROVIDER: createInMemoryMemoryProvider()
+    }
+  );
+
+  assert.equal(response.status, 200);
+  const body = await response.text();
+  assert.equal(body.includes("VTDD v2 Dashboard"), true);
+  assert.equal(body.includes("dashboard passkey session was not found"), false);
+});
+
 test("worker rejects dashboard access when Access email header has no matching JWT email claim", async () => {
   const response = await worker.fetch(
     new Request("https://example.com/dashboard", {

--- a/worker.js
+++ b/worker.js
@@ -63446,9 +63446,6 @@ async function authorizeDashboardRequest({ request, env, apiSuffix = "/dashboard
   if (passkeyAuth.ok) {
     return passkeyAuth;
   }
-  if (passkeyAuth.blocking) {
-    return passkeyAuth;
-  }
   const routeLabel = `dashboard surface ${apiSuffix}`;
   const allowedEmails = parseAuthList(
     runtimeEnv.VTDD_DASHBOARD_ALLOWED_EMAILS ?? runtimeEnv.CF_ACCESS_ALLOWED_EMAILS
@@ -63462,6 +63459,9 @@ async function authorizeDashboardRequest({ request, env, apiSuffix = "/dashboard
   );
   const accessJwt = normalizeText30(request.headers.get("cf-access-jwt-assertion"));
   if (!accessEmail && !accessLogin) {
+    if (passkeyAuth.blocking) {
+      return passkeyAuth;
+    }
     return {
       ok: false,
       status: 401,


### PR DESCRIPTION
## This PR satisfies Intent

Issue #536 の Intent に対して、Dashboard 通常閲覧で stale / missing scope の `vtdd_dashboard_session` cookie が Cloudflare Access owner identity の成功を邪魔する問題を修正します。通常 Dashboard は Cloudflare Access + owner allowlist を主認証にし、passkey は fallback session と高リスク操作の承認境界として残します。

## Satisfied Success Criteria

- [x] stale/missing/expired/wrong-scope `vtdd_dashboard_session` cookie があっても、Cloudflare Access が有効なら Dashboard 表示を妨げない。
- [x] passkey dashboard session は fallback login として残し、Cloudflare Access より強い blocking cookie にはしない。
- [x] deploy、merge、secret sync、permission mutation、destructive/high-risk operation の scoped real passkey approval 境界は変更しない。
- [x] テストで stale passkey cookie + valid Cloudflare Access は Dashboard 表示OK、stale passkey cookie + no Access は拒否を固定する。

## Unsatisfied Success Criteria

- `/dashboard/notifications` と通常チャット送信の live iPhone/PWA E2E は未実施です。worker test では Dashboard auth 経路と chat auth 経路の既存テストが通っています。
- Dashboard auth failure 画面の文言整理はこのPRでは追加実装していません。既存の拒否理由は維持しています。
- 高リスク deploy の live 実行 E2E は未実施です。既存の governed production deploy / GitHub authority plane tests で passkey 境界の回帰がないことを確認しています。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #536
- Implementing Success Criteria: stale dashboard passkey cookie + valid Cloudflare Access を Dashboard 通常閲覧で許可する。passkey session fallback と high-risk scoped passkey approval を維持する。
- Explicit Non-goals: passkey approval boundary を高リスク操作から外さない。Cloudflare Access allowlist をなくさない。public unauthenticated Dashboard を許可しない。deploy / credential mutation / permission mutation / repository settings mutation は実行しない。Dashboard UI 全体の情報設計は Issue #534 側で追跡する。
- Expected touched files/routes/workflows: `src/worker/runtime.js`, `worker.js`, `test/worker.test.js`, `/dashboard` auth path.
- Affected Issues: Issue #536, Issue #534, Issue #532
- Affected PRs: なし
- Affected workflows: なし
- Affected runtime/operator surfaces: Dashboard normal view auth, Dashboard Butler chat auth, notification center auth. High-risk operator approval routes are intended to remain unchanged.
- What may break if we patch narrowly: Cloudflare Access が無効な環境では stale passkey cookie のエラーが従来どおり表示される。Access header が存在するが allowlist/JWT が不正な場合は Access 側の拒否になる。
- Unknowns to investigate before coding: live iPhone/PWA で Cloudflare Access cookie と dashboard passkey cookie が同時に存在する実機状態。
- Validation needed: worker auth tests, full `node --test`, generated worker check, self-parity check, deploy後の iPhone/PWA live E2E。
- Stop condition: high-risk deploy / merge / secret sync の scoped passkey approval が不要になる差分が出た場合は停止する。

## File / Line Hypotheses

- file: `src/worker/runtime.js:8547`
  - hypothesis: `authorizeDashboardRequest` が passkeyAuth.blocking を Cloudflare Access 評価前に返しているため、valid Access identity があっても stale passkey cookie が Dashboard 表示を止めている。
  - risk if changed narrowly: Access がない場合まで stale cookie を無視すると fallback passkey failure の説明が消える。
  - validation: stale cookie + valid Access は 200、stale cookie + no Access は 401、high-risk authority tests は pass。
  - related Issue: Issue #536

## Hypothesis Retrospective

- expected: passkeyAuth.blocking の早期 return を Access identity 不在時に限定すれば、通常 Dashboard 閲覧は Access 主認証へ戻り、passkey fallback と高リスク境界は残る。
- actual: targeted worker tests、full `node --test`、`npm run check:self-parity`、`npm run check:generated-worker` が通った。
- mismatch: `check:generated-worker` はコミット前に生成物差分を out-of-date として報告したため、`build:worker` 後にコミットしてから再実行した。
- lesson: Dashboard auth は「passkey fallback」と「high-risk approval」を同じ passkey 語で扱うと owner-facing 体験が悪化する。通常閲覧では Access を主、passkey は高リスク承認に寄せる。
- should become RAG candidate: yes, Issue #536 の判断として「stale dashboard passkey cookie must not outrank valid Cloudflare Access for normal Dashboard viewing」を記録候補にする。

## Verification Evidence

- Unit: `node --test test/worker.test.js --test-name-pattern "stale dashboard passkey|Cloudflare Access owner identity|high-risk deploy|deploy"` pass, 194 tests.
- Integration: `npm run build:worker` pass. `npm run check:self-parity` pass. `npm run check:generated-worker` pass after commit. `node --test` pass, 947 pass / 1 skipped / 0 fail.
- E2E: 未実施。merge後 deploy して iPhone/PWA で Cloudflare Access 認証済み Dashboard が passkey なしで開けること、高リスク deploy は passkey が出ることを確認する必要があります。
- Manual: `git diff --check` pass.
- Evidence path/link: `src/worker/runtime.js`, `test/worker.test.js`, `worker.js`.

## Butler Completion Contract

- Owner goal: iPhone/iPad の Dashboard Butler 通常閲覧で、不要な passkey 認証画面を挟まずに通知・チャット・進捗へ到達できる状態に近づける。
- Butler entrypoint: Dashboard 通常閲覧 auth path を修正。Custom GPT/Butler natural language entrypoint は未変更。
- Action Schema exposure: 未変更。
- Runtime path: `/dashboard` 系 auth path の `authorizeDashboardRequest`。
- Runner/runtime truth: worker tests と generated worker check で runtime path の差分を確認。
- Authority boundary: 通常閲覧は Cloudflare Access + owner allowlist。高リスク deploy / merge / secret sync / destructive は scoped real passkey approval のまま。
- E2E evidence: 未実施。iPhone/PWA live E2E は merge + deploy 後に必要。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: required after merge. Runtime auth behavior changes are not live until deploy.
- Custom GPT Action Schema update: not required.
- Custom GPT Instructions update: not required.
- iPhone Butler live E2E: required after deploy; not run in this PR.

## Related Constitution Rules

- AGENTS.md Butler Completion Gate
- AGENTS.md Butler-First Operating Principle
- AGENTS.md Chief Butler Operating Principle
- AGENTS.md Authority Boundary
- AGENTS.md Evidence Discipline

## Out-of-scope but NOT implemented

- Dashboard auth failure 画面の日本語文言整理。
- Dashboard UI 全体の情報設計修正。
- passkey-only fallback login の正式UX再設計。
- Cloudflare Access policy / allowlist / credential / permission mutation。
- production deploy 実行。

## Extra changes (if any)

None.
