### PR TITLE
Issue #538 reviewer objection resolution後にauto-mergeを復帰させる

### DIFF
--- a/scripts/run-approve-auto-merge.mjs
+++ b/scripts/run-approve-auto-merge.mjs
@@ -24,7 +24,12 @@ async function main() {
   const eventName = process.env.GITHUB_EVENT_NAME || "";
   const eventPath = process.env.GITHUB_EVENT_PATH || "";
   const payload = eventPath ? JSON.parse(await fs.readFile(eventPath, "utf8")) : {};
-  const pullNumbers = resolvePullNumbers({ payload, env: process.env });
+  const pullNumbers = await resolvePullNumbers({
+    payload,
+    env: process.env,
+    repository,
+    githubFetch
+  });
 
   if (pullNumbers.length === 0) {
     console.log("No pull request candidate for approve auto merge.");
@@ -330,7 +335,7 @@ async function readResponseJson(response) {
   }
 }
 
-function resolvePullNumbers({ payload, env }) {
+export async function resolvePullNumbers({ payload, env, repository, githubFetch }) {
   const explicit = normalizePositiveInteger(env.TARGET_PR_NUMBER);
   if (explicit) {
     return [explicit];
@@ -345,6 +350,40 @@ function resolvePullNumbers({ payload, env }) {
   for (const pull of payload?.workflow_run?.pull_requests || []) {
     if (normalizePositiveInteger(pull?.number)) {
       pullNumbers.add(Number(pull.number));
+    }
+  }
+  if (pullNumbers.size === 0 && payload?.workflow_run && githubFetch && repository) {
+    for (const number of await resolveWorkflowRunPullNumbers({ payload, repository, githubFetch })) {
+      pullNumbers.add(number);
+    }
+  }
+  return [...pullNumbers];
+}
+
+async function resolveWorkflowRunPullNumbers({ payload, repository, githubFetch }) {
+  const pullNumbers = new Set();
+  const headSha = String(payload?.workflow_run?.head_sha || "").trim();
+  if (headSha) {
+    const pulls = await githubFetch(
+      `/repos/${repository}/commits/${encodeURIComponent(headSha)}/pulls`
+    );
+    const openMatches = (Array.isArray(pulls) ? pulls : []).filter(
+      (pull) => String(pull?.state || "").toLowerCase() === "open" && normalizePositiveInteger(pull?.number)
+    );
+    if (openMatches.length === 1) {
+      pullNumbers.add(Number(openMatches[0].number));
+    }
+  }
+  if (pullNumbers.size === 0) {
+    const title = String(payload?.workflow_run?.display_title || "").trim();
+    if (title) {
+      const pulls = await githubFetch(`/repos/${repository}/pulls?state=open&per_page=100`);
+      const exactMatches = (Array.isArray(pulls) ? pulls : []).filter(
+        (pull) => String(pull?.title || "").trim() === title && normalizePositiveInteger(pull?.number)
+      );
+      if (exactMatches.length === 1) {
+        pullNumbers.add(Number(exactMatches[0].number));
+      }
     }
   }
   return [...pullNumbers];

--- a/src/core/execution-continuity.js
+++ b/src/core/execution-continuity.js
@@ -255,12 +255,80 @@ function collectGeminiReviewerSignals(pullRequest) {
   const activeSignals = currentHeadSha
     ? currentHeadSignals
     : parsed;
+  const latestEvidence = activeSignals.at(-1) ?? null;
+  const latestBlockingSignal = [...activeSignals].reverse().find((signal) => signal.blocking === true);
 
   return {
     totalCount: activeSignals.length,
-    blockingCount: activeSignals.filter((signal) => signal.blocking).length,
-    latestEvidence: activeSignals.at(-1) ?? null
+    blockingCount: latestGeminiEvidenceLeavesBlockingReview({
+      comments,
+      latestEvidence,
+      latestBlockingSignal
+    }) ? 1 : 0,
+    latestEvidence
   };
+}
+
+function latestGeminiEvidenceLeavesBlockingReview({ comments, latestEvidence, latestBlockingSignal }) {
+  if (!latestBlockingSignal) {
+    return false;
+  }
+  if (latestEvidence?.blocking === true) {
+    return true;
+  }
+  if (normalizeText(latestEvidence?.recommendedAction).toLowerCase() !== "approve") {
+    return true;
+  }
+  return !hasReviewerObjectionResolutionBetween({
+    comments,
+    blockingSignal: latestBlockingSignal,
+    approvingSignal: latestEvidence
+  });
+}
+
+function hasReviewerObjectionResolutionBetween({ comments, blockingSignal, approvingSignal }) {
+  const blockingTime = timelineTimestamp(blockingSignal);
+  const approvingTime = timelineTimestamp(approvingSignal);
+  if (
+    !Number.isFinite(blockingTime) ||
+    !Number.isFinite(approvingTime) ||
+    blockingTime === Number.MAX_SAFE_INTEGER ||
+    approvingTime === Number.MAX_SAFE_INTEGER ||
+    blockingTime >= approvingTime
+  ) {
+    return false;
+  }
+  return comments.some((comment) => {
+    if (!normalizeText(comment?.body).includes(REVIEWER_OBJECTION_RESOLUTION_MARKER)) {
+      return false;
+    }
+    if (!isTrustedObjectionResolutionAuthor(comment)) {
+      return false;
+    }
+    const responseBody = normalizeText(comment?.body);
+    const blockingHeadSha = normalizeText(blockingSignal?.headSha);
+    if (blockingHeadSha && !responseBody.includes(blockingHeadSha)) {
+      return false;
+    }
+    const responseTime = timelineTimestamp({
+      createdAt: normalizeCommentCreatedAt(comment),
+      updatedAt: normalizeCommentUpdatedAt(comment),
+      url: normalizeCommentUrl(comment)
+    });
+    return responseTime > blockingTime && responseTime < approvingTime;
+  });
+}
+
+function isTrustedObjectionResolutionAuthor(comment) {
+  const author = normalizeCommentAuthor(comment).toLowerCase();
+  const association = normalizeText(comment?.authorAssociation ?? comment?.author_association).toUpperCase();
+  return (
+    author === "vtdd-codex" ||
+    author === "vtdd-codex[bot]" ||
+    association === "OWNER" ||
+    association === "MEMBER" ||
+    association === "COLLABORATOR"
+  );
 }
 
 function collectCodexFallbackSignals(pullRequest) {
@@ -500,6 +568,10 @@ function timelineTimestamp(item) {
 
 function normalizeCommentUrl(comment) {
   return normalizeText(comment?.url ?? comment?.htmlUrl ?? comment?.html_url) || null;
+}
+
+function normalizeCommentAuthor(comment) {
+  return normalizeText(comment?.user?.login ?? comment?.author?.login ?? comment?.author);
 }
 
 function normalizeCommentCreatedAt(comment) {

--- a/test/approve-auto-merge-workflow.test.js
+++ b/test/approve-auto-merge-workflow.test.js
@@ -1,7 +1,10 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import fs from "node:fs";
-import { isMergeAlreadyInProgressError } from "../scripts/run-approve-auto-merge.mjs";
+import {
+  isMergeAlreadyInProgressError,
+  resolvePullNumbers
+} from "../scripts/run-approve-auto-merge.mjs";
 
 const workflow = fs.readFileSync(".github/workflows/approve-auto-merge.yml", "utf8");
 const script = fs.readFileSync("scripts/run-approve-auto-merge.mjs", "utf8");
@@ -45,4 +48,115 @@ test("approve auto merge treats concurrent GitHub merge race as idempotent", () 
   const unrelatedMergeError = new Error("GitHub API 500: Merge already in progress");
   unrelatedMergeError.status = 500;
   assert.equal(isMergeAlreadyInProgressError(unrelatedMergeError), false);
+});
+
+test("approve auto merge resolves workflow_run PR candidate from head SHA when payload omits pull_requests", async () => {
+  const calls = [];
+  const pullNumbers = await resolvePullNumbers({
+    payload: {
+      workflow_run: {
+        head_sha: "head-536",
+        pull_requests: []
+      }
+    },
+    env: {},
+    repository: "sample-org/vtdd-v2-p",
+    githubFetch: async (path) => {
+      calls.push(path);
+      assert.equal(path, "/repos/sample-org/vtdd-v2-p/commits/head-536/pulls");
+      return [
+        { number: 537, state: "open" },
+        { number: 530, state: "closed" }
+      ];
+    }
+  });
+
+  assert.deepEqual(pullNumbers, [537]);
+  assert.deepEqual(calls, ["/repos/sample-org/vtdd-v2-p/commits/head-536/pulls"]);
+});
+
+test("approve auto merge does not resolve ambiguous workflow_run head SHA PR candidates", async () => {
+  const pullNumbers = await resolvePullNumbers({
+    payload: {
+      workflow_run: {
+        head_sha: "shared-head",
+        pull_requests: []
+      }
+    },
+    env: {},
+    repository: "sample-org/vtdd-v2-p",
+    githubFetch: async (path) => {
+      assert.equal(path, "/repos/sample-org/vtdd-v2-p/commits/shared-head/pulls");
+      return [
+        { number: 537, state: "open" },
+        { number: 538, state: "open" }
+      ];
+    }
+  });
+
+  assert.deepEqual(pullNumbers, []);
+});
+
+test("approve auto merge resolves workflow_run PR candidate from display title when head SHA is trusted main", async () => {
+  const calls = [];
+  const pullNumbers = await resolvePullNumbers({
+    payload: {
+      workflow_run: {
+        head_sha: "main-sha",
+        display_title: "Issue #536 Dashboard通常閲覧でstale passkey cookieをAccess認証へfallbackする",
+        pull_requests: []
+      }
+    },
+    env: {},
+    repository: "sample-org/vtdd-v2-p",
+    githubFetch: async (path) => {
+      calls.push(path);
+      if (path === "/repos/sample-org/vtdd-v2-p/commits/main-sha/pulls") {
+        return [];
+      }
+      assert.equal(path, "/repos/sample-org/vtdd-v2-p/pulls?state=open&per_page=100");
+      return [
+        {
+          number: 537,
+          title: "Issue #536 Dashboard通常閲覧でstale passkey cookieをAccess認証へfallbackする"
+        },
+        {
+          number: 536,
+          title: "unrelated"
+        }
+      ];
+    }
+  });
+
+  assert.deepEqual(pullNumbers, [537]);
+  assert.deepEqual(calls, [
+    "/repos/sample-org/vtdd-v2-p/commits/main-sha/pulls",
+    "/repos/sample-org/vtdd-v2-p/pulls?state=open&per_page=100"
+  ]);
+});
+
+test("approve auto merge does not resolve ambiguous workflow_run display title matches", async () => {
+  const pullNumbers = await resolvePullNumbers({
+    payload: {
+      workflow_run: {
+        head_sha: "main-sha",
+        display_title: "Shared title",
+        pull_requests: []
+      }
+    },
+    env: {},
+    repository: "sample-org/vtdd-v2-p",
+    githubFetch: async (path) => {
+      if (path === "/repos/sample-org/vtdd-v2-p/commits/main-sha/pulls") {
+        return [];
+      }
+      assert.equal(path, "/repos/sample-org/vtdd-v2-p/pulls?state=open&per_page=100");
+      return [
+        { number: 539, title: "Shared title" },
+        { number: 540, title: "Shared title" }
+      ];
+    }
+  });
+
+  assert.deepEqual(pullNumbers, []);
 });

--- a/test/execution-continuity.test.js
+++ b/test/execution-continuity.test.js
@@ -544,6 +544,201 @@ test("execution continuity blocks readiness when request_changes finding is not 
   );
 });
 
+test("execution continuity treats latest same-head Gemini approve as resolving older request_changes after objection response", () => {
+  const result = evaluateExecutionContinuity({
+    actorRole: ActorRole.BUTLER,
+    mode: TaskMode.EXECUTION,
+    runtimeTruth: {
+      runtimeState: {
+        activeBranch: "codex/issue-536",
+        pullRequest: {
+          number: 537,
+          url: "https://github.com/example/repo/pull/537",
+          state: "open",
+          title: "Dashboard auth fallback",
+          headSha: "head-536",
+          mergeable: true,
+          mergeableState: "clean",
+          issueComments: [
+            {
+              user: { login: "vtdd-gemini-reviewer" },
+              url: "https://github.com/example/repo/pull/537#issuecomment-request",
+              created_at: "2026-05-25T10:37:04Z",
+              updated_at: "2026-05-25T10:37:04Z",
+              body: "<!-- vtdd:reviewer=gemini -->\n## VTDD Gemini レビュー\n\n- Head SHA: `head-536`\n- Recommended action: `request_changes`\n\n### 重要指摘\n- PR本文が未記入\n\n### 残リスク\n- generated worker evidence missing"
+            },
+            {
+              user: { login: "marushu" },
+              author_association: "OWNER",
+              url: "https://github.com/example/repo/pull/537#issuecomment-response",
+              created_at: "2026-05-25T10:40:14Z",
+              body: "<!-- vtdd:reviewer-objection-resolution -->\n## VTDD Reviewer Objection Resolution\n\nHead SHA: `head-536`\n\nAddresses:\n- PR本文が未記入\n\nEvidence:\n- node --test"
+            },
+            {
+              user: { login: "vtdd-gemini-reviewer" },
+              url: "https://github.com/example/repo/pull/537#issuecomment-approve",
+              created_at: "2026-05-25T10:40:31Z",
+              updated_at: "2026-05-25T10:40:31Z",
+              body: "<!-- vtdd:reviewer=gemini -->\n## VTDD Gemini レビュー\n\n- Head SHA: `head-536`\n- Recommended action: `approve`\n\n### 重要指摘\n- 報告なし。\n\n### 残リスク\n- live E2E は未実施"
+            }
+          ]
+        }
+      }
+    }
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.value.reviewLoop.reviewerEvidence.recommendedAction, "approve");
+  assert.equal(result.value.reviewLoop.unresolvedReviewCommentsCount, 0);
+  assert.equal(result.value.reviewLoop.criticalReviewPending, false);
+  assert.equal(result.value.reviewLoop.reviewerSignalTruth.mergeReviewTruth.satisfied, true);
+  assert.deepEqual(result.value.nextSuggestedActions, ["summarize_for_human", "wait_for_human_go"]);
+});
+
+test("execution continuity keeps older request_changes blocking when objection response is untrusted", () => {
+  const result = evaluateExecutionContinuity({
+    actorRole: ActorRole.BUTLER,
+    mode: TaskMode.EXECUTION,
+    runtimeTruth: {
+      runtimeState: {
+        activeBranch: "codex/issue-538",
+        pullRequest: {
+          number: 539,
+          url: "https://github.com/example/repo/pull/539",
+          state: "open",
+          title: "Auto merge review gate",
+          headSha: "head-538",
+          mergeable: true,
+          mergeableState: "clean",
+          issueComments: [
+            {
+              user: { login: "vtdd-gemini-reviewer" },
+              url: "https://github.com/example/repo/pull/539#issuecomment-request",
+              created_at: "2026-05-25T13:10:00Z",
+              updated_at: "2026-05-25T13:10:00Z",
+              body: "<!-- vtdd:reviewer=gemini -->\n## VTDD Gemini レビュー\n\n- Head SHA: `head-538`\n- Recommended action: `request_changes`\n\n### 重要指摘\n- explicit objection response is missing"
+            },
+            {
+              user: { login: "drive-by-user" },
+              author_association: "NONE",
+              url: "https://github.com/example/repo/pull/539#issuecomment-response",
+              created_at: "2026-05-25T13:12:00Z",
+              body: "<!-- vtdd:reviewer-objection-resolution -->\nHead SHA: `head-538`\n\nLooks fixed."
+            },
+            {
+              user: { login: "vtdd-gemini-reviewer" },
+              url: "https://github.com/example/repo/pull/539#issuecomment-approve",
+              created_at: "2026-05-25T13:15:00Z",
+              updated_at: "2026-05-25T13:15:00Z",
+              body: "<!-- vtdd:reviewer=gemini -->\n## VTDD Gemini レビュー\n\n- Head SHA: `head-538`\n- Recommended action: `approve`\n\n### 重要指摘\n- 報告なし。"
+            }
+          ]
+        }
+      }
+    }
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.value.reviewLoop.unresolvedReviewCommentsCount, 1);
+  assert.equal(result.value.reviewLoop.criticalReviewPending, true);
+});
+
+test("execution continuity keeps older request_changes blocking when objection response omits head SHA", () => {
+  const result = evaluateExecutionContinuity({
+    actorRole: ActorRole.BUTLER,
+    mode: TaskMode.EXECUTION,
+    runtimeTruth: {
+      runtimeState: {
+        activeBranch: "codex/issue-538",
+        pullRequest: {
+          number: 539,
+          url: "https://github.com/example/repo/pull/539",
+          state: "open",
+          title: "Auto merge review gate",
+          headSha: "head-538",
+          mergeable: true,
+          mergeableState: "clean",
+          issueComments: [
+            {
+              user: { login: "vtdd-gemini-reviewer" },
+              url: "https://github.com/example/repo/pull/539#issuecomment-request",
+              created_at: "2026-05-25T13:10:00Z",
+              updated_at: "2026-05-25T13:10:00Z",
+              body: "<!-- vtdd:reviewer=gemini -->\n## VTDD Gemini レビュー\n\n- Head SHA: `head-538`\n- Recommended action: `request_changes`\n\n### 重要指摘\n- explicit objection response is missing"
+            },
+            {
+              user: { login: "marushu" },
+              author_association: "OWNER",
+              url: "https://github.com/example/repo/pull/539#issuecomment-response",
+              created_at: "2026-05-25T13:12:00Z",
+              body: "<!-- vtdd:reviewer-objection-resolution -->\nAddresses:\n- explicit objection response is missing"
+            },
+            {
+              user: { login: "vtdd-gemini-reviewer" },
+              url: "https://github.com/example/repo/pull/539#issuecomment-approve",
+              created_at: "2026-05-25T13:15:00Z",
+              updated_at: "2026-05-25T13:15:00Z",
+              body: "<!-- vtdd:reviewer=gemini -->\n## VTDD Gemini レビュー\n\n- Head SHA: `head-538`\n- Recommended action: `approve`\n\n### 重要指摘\n- 報告なし。"
+            }
+          ]
+        }
+      }
+    }
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.value.reviewLoop.unresolvedReviewCommentsCount, 1);
+  assert.equal(result.value.reviewLoop.criticalReviewPending, true);
+});
+
+test("execution continuity keeps older request_changes blocking when latest approve lacks objection response", () => {
+  const result = evaluateExecutionContinuity({
+    actorRole: ActorRole.BUTLER,
+    mode: TaskMode.EXECUTION,
+    runtimeTruth: {
+      runtimeState: {
+        activeBranch: "codex/issue-538",
+        pullRequest: {
+          number: 539,
+          url: "https://github.com/example/repo/pull/539",
+          state: "open",
+          title: "Auto merge review gate",
+          headSha: "head-538",
+          mergeable: true,
+          mergeableState: "clean",
+          issueComments: [
+            {
+              user: { login: "vtdd-gemini-reviewer" },
+              url: "https://github.com/example/repo/pull/539#issuecomment-approve",
+              created_at: "2026-05-25T13:15:00Z",
+              updated_at: "2026-05-25T13:15:00Z",
+              body: "<!-- vtdd:reviewer=gemini -->\n## VTDD Gemini レビュー\n\n- Head SHA: `head-538`\n- Recommended action: `approve`\n\n### 重要指摘\n- 報告なし。"
+            },
+            {
+              user: { login: "vtdd-gemini-reviewer" },
+              url: "https://github.com/example/repo/pull/539#issuecomment-request",
+              created_at: "2026-05-25T13:10:00Z",
+              updated_at: "2026-05-25T13:10:00Z",
+              body: "<!-- vtdd:reviewer=gemini -->\n## VTDD Gemini レビュー\n\n- Head SHA: `head-538`\n- Recommended action: `request_changes`\n\n### 重要指摘\n- explicit objection response is missing"
+            }
+          ]
+        }
+      }
+    }
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.value.reviewLoop.reviewerEvidence.recommendedAction, "approve");
+  assert.equal(result.value.reviewLoop.unresolvedReviewCommentsCount, 1);
+  assert.equal(result.value.reviewLoop.criticalReviewPending, true);
+  assert.equal(result.value.reviewLoop.reviewerSignalTruth.mergeReviewTruth.satisfied, true);
+  assert.deepEqual(result.value.nextSuggestedActions, [
+    "apply_pr_feedback",
+    "reply_on_pull_request",
+    "rerun_gemini_review"
+  ]);
+});
+
 test("execution continuity exposes Codex fallback requested when Gemini is temporarily unavailable", () => {
   const result = evaluateExecutionContinuity({
     actorRole: ActorRole.BUTLER,

--- a/worker.js
+++ b/worker.js
@@ -35620,11 +35620,64 @@ function collectGeminiReviewerSignals(pullRequest) {
   const currentHeadSha = normalizeText5(pullRequest.headSha);
   const currentHeadSignals = currentHeadSha ? parsed.filter((signal) => evidenceMatchesHead(signal, currentHeadSha)) : [];
   const activeSignals = currentHeadSha ? currentHeadSignals : parsed;
+  const latestEvidence = activeSignals.at(-1) ?? null;
+  const latestBlockingSignal = [...activeSignals].reverse().find((signal) => signal.blocking === true);
   return {
     totalCount: activeSignals.length,
-    blockingCount: activeSignals.filter((signal) => signal.blocking).length,
-    latestEvidence: activeSignals.at(-1) ?? null
+    blockingCount: latestGeminiEvidenceLeavesBlockingReview({
+      comments,
+      latestEvidence,
+      latestBlockingSignal
+    }) ? 1 : 0,
+    latestEvidence
   };
+}
+function latestGeminiEvidenceLeavesBlockingReview({ comments, latestEvidence, latestBlockingSignal }) {
+  if (!latestBlockingSignal) {
+    return false;
+  }
+  if (latestEvidence?.blocking === true) {
+    return true;
+  }
+  if (normalizeText5(latestEvidence?.recommendedAction).toLowerCase() !== "approve") {
+    return true;
+  }
+  return !hasReviewerObjectionResolutionBetween({
+    comments,
+    blockingSignal: latestBlockingSignal,
+    approvingSignal: latestEvidence
+  });
+}
+function hasReviewerObjectionResolutionBetween({ comments, blockingSignal, approvingSignal }) {
+  const blockingTime = timelineTimestamp(blockingSignal);
+  const approvingTime = timelineTimestamp(approvingSignal);
+  if (!Number.isFinite(blockingTime) || !Number.isFinite(approvingTime) || blockingTime === Number.MAX_SAFE_INTEGER || approvingTime === Number.MAX_SAFE_INTEGER || blockingTime >= approvingTime) {
+    return false;
+  }
+  return comments.some((comment) => {
+    if (!normalizeText5(comment?.body).includes(REVIEWER_OBJECTION_RESOLUTION_MARKER)) {
+      return false;
+    }
+    if (!isTrustedObjectionResolutionAuthor(comment)) {
+      return false;
+    }
+    const responseBody = normalizeText5(comment?.body);
+    const blockingHeadSha = normalizeText5(blockingSignal?.headSha);
+    if (blockingHeadSha && !responseBody.includes(blockingHeadSha)) {
+      return false;
+    }
+    const responseTime = timelineTimestamp({
+      createdAt: normalizeCommentCreatedAt(comment),
+      updatedAt: normalizeCommentUpdatedAt(comment),
+      url: normalizeCommentUrl(comment)
+    });
+    return responseTime > blockingTime && responseTime < approvingTime;
+  });
+}
+function isTrustedObjectionResolutionAuthor(comment) {
+  const author = normalizeCommentAuthor2(comment).toLowerCase();
+  const association = normalizeText5(comment?.authorAssociation ?? comment?.author_association).toUpperCase();
+  return author === "vtdd-codex" || author === "vtdd-codex[bot]" || association === "OWNER" || association === "MEMBER" || association === "COLLABORATOR";
 }
 function collectCodexFallbackSignals(pullRequest) {
   const comments = [...Array.isArray(pullRequest.issueComments) ? pullRequest.issueComments : []];
@@ -35835,6 +35888,9 @@ function timelineTimestamp(item) {
 }
 function normalizeCommentUrl(comment) {
   return normalizeText5(comment?.url ?? comment?.htmlUrl ?? comment?.html_url) || null;
+}
+function normalizeCommentAuthor2(comment) {
+  return normalizeText5(comment?.user?.login ?? comment?.author?.login ?? comment?.author);
 }
 function normalizeCommentCreatedAt(comment) {
   return normalizeText5(comment?.createdAt ?? comment?.created_at) || null;


### PR DESCRIPTION
## This PR satisfies Intent

Issue #538 の Intent に対して、`approve-auto-merge` が古い reviewer request_changes 停止状態から、同じ head SHA の objection-resolution と最新 Gemini approve を受けて自動マージ候補へ復帰できるようにします。PR #537 で起きた「最新 reviewer は approve なのに、古い unresolved reviewer objections / critical review pending が残って gate を止める」状態をテストで固定し、対象 PR 解決も `workflow_run.pull_requests` だけに依存しないようにします。

## Satisfied Success Criteria

- [x] `<!-- vtdd:reviewer-objection-resolution -->` が古い request_changes と最新 approve の間にあり、信頼できる投稿者が対象 head SHA を明示している場合だけ、同じ head SHA の最新 Gemini reviewer approve が古い request_changes の blocking count を残さない。
- [x] `approve-auto-merge` の `workflow_run` で `pull_requests` が空でも、head SHA または workflow run display title から open PR を復元できる。ただし head SHA / display title fallback は open PR がちょうど1件に絞れる場合だけ採用し、複数一致は候補なしで止める。
- [x] 最新 reviewer が request_changes、head SHA 不一致、checks failure などの場合の既存 gate は維持する。
- [x] PR #537 型の時系列をテストで固定した。

## Unsatisfied Success Criteria

- 実 PR での live auto-merge E2E は未実施です。PR #537 はすでに手動 merge 済みのため、このPRでは再現 fixture と unit/integration tests で固定しています。
- Dashboard 通知タイトルの live 確認は未実施です。既存の `自動マージ停止: PR #...` / `自動マージ候補: PR #...` / `自動マージ完了: PR #...` event title path は維持しています。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #538
- Implementing Success Criteria: latest same-head Gemini approve should supersede older request_changes for auto-merge gate; workflow_run without pull_requests can recover target PR from head SHA or display title.
- Explicit Non-goals: reviewer approve だけで checks / mergeability / Issue linkage / head SHA gate を飛ばさない。passkey high-risk GitHub authority plane は変更しない。GitHub branch protection / repository settings は変更しない。deploy production 自動化は扱わない。
- Expected touched files/routes/workflows: `src/core/execution-continuity.js`, `scripts/run-approve-auto-merge.mjs`, `worker.js`, `test/execution-continuity.test.js`, `test/approve-auto-merge-workflow.test.js`
- Affected Issues: Issue #538, Issue #536
- Affected PRs: PR #537 の再現時系列を fixture として参照
- Affected workflows: `approve-auto-merge`
- Affected runtime/operator surfaces: GitHub Actions 自動マージ、Dashboard event notification title path
- What may break if we patch narrowly: 古い request_changes を無条件に消すと reviewer objection を無視する危険がある。workflow_run fallback は同じ head SHA や同名 PR が複数ある場合に誤PRを拾う危険があるため、1件に絞れない場合は止める。
- Unknowns to investigate before coding: GitHub workflow_run payload が常に PR number を持つとは限らない。PR #537 では後続 run が main SHA / empty pull_requests になった。
- Validation needed: approve-auto-merge tests、execution-continuity tests、gemini-pr-review tests、full `node --test`。
- Stop condition: reviewer request_changes / formal changes_requested / failed checks / merge conflict / head SHA mismatch を通す差分が出たら停止。

## File / Line Hypotheses

- file: `src/core/execution-continuity.js:258`
  - hypothesis: `collectGeminiReviewerSignals` が current head の全 Gemini marker の blocking count を合算しており、最新 approve 後も古い request_changes が unresolved として残る。
  - risk if changed narrowly: 最新 marker ではなく単に blocking を消すと、最新 request_changes を通してしまう。
- validation: request_changes -> trusted objection-resolution with head SHA -> approve の時系列は allowed、untrusted objection-resolution / head SHA 不明の objection-resolution / objection-resolution なしの approve / 最新 request_changes / stale head は block。
  - related Issue: Issue #538
- file: `scripts/run-approve-auto-merge.mjs:333`
  - hypothesis: `resolvePullNumbers` が `workflow_run.pull_requests` に依存しすぎて、issue_comment / workflow_run 派生 run の対象 PR を復元できない。
  - risk if changed narrowly: unrelated PR を誤って拾う。
- validation: 単一 head SHA fallback、複数 head SHA ambiguous stop、単一 display title fallback、複数 display title ambiguous stop を unit test で固定。
  - related Issue: Issue #538

## Hypothesis Retrospective

- expected: 最新 same-head Gemini approve の blocking state を canonical にすれば、古い request_changes は merge gate を止めない。workflow_run payload が PR number を落としても head SHA / title で候補復元できる。
- actual: targeted tests、周辺 tests、generated worker check、self-parity、full `node --test` が通った。
- mismatch: PR #537 自体はすでに手動 merge 済みなので live auto-merge executed E2E はこのPRではできない。
- lesson: reviewer marker は「同一 head の最新 marker」を gate の canonical state として扱う必要がある。古い blocker は timeline evidence として残し、最新 approve を上書きしてはならない。
- should become RAG candidate: yes, 自動マージ gate の reviewer truth 解釈として記録候補。

## Verification Evidence

- Unit: `node --test test/execution-continuity.test.js test/approve-auto-merge-workflow.test.js --test-name-pattern "latest same-head Gemini approve|untrusted|omits head SHA|workflow_run PR candidate|ambiguous workflow_run"` pass, 35 tests.
- Integration: `node --test test/approve-auto-merge.test.js test/approve-auto-merge-workflow.test.js test/execution-continuity.test.js test/gemini-pr-review.test.js` pass, 84 tests.
- Integration: `node --test` pass, 956 tests / 955 pass / 1 skipped / 0 fail.
- Integration: `npm run check:generated-worker` pass.
- Integration: `npm run check:self-parity` pass.
- Manual: `git diff --check` pass.
- E2E: 未実施。次の実 PR で request_changes -> objection-resolution -> approve -> checks pass の順を踏んだ時に auto-merge candidate / executed evidence を確認する。
- Evidence path/link: `src/core/execution-continuity.js`, `scripts/run-approve-auto-merge.mjs`, `test/execution-continuity.test.js`, `test/approve-auto-merge-workflow.test.js`

## Butler Completion Contract

- Owner goal: owner が毎回手動で「自動マージが止まった理由」を追わなくても、reviewer objection 解消後は自動マージ gate が最新 truth で復帰する。
- Butler entrypoint: 未変更。GitHub Actions / reviewer truth の自動処理を修正。
- Action Schema exposure: 未変更。
- Runtime path: `approve-auto-merge` GitHub Actions script と `evaluateExecutionContinuity`。
- Runner/runtime truth: tests と PR checks で確認予定。
- Authority boundary: 自動マージは既存 `approve_auto_merge` policy / checks / mergeability / reviewer approve gate 内。passkey high-risk authority plane は変更なし。
- E2E evidence: 未実施。次の live PR で確認が必要。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: merge後は必要。approve-auto-merge GitHub Actions script は deploy なしで反映されるが、Worker/Dashboard/MCP 側の review truth 表示は worker.js 変更を含むため deploy 後に一致する。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 不要。ただし Dashboard 通知の live 表示確認は次回 auto-merge 実行時に必要。

## Related Constitution Rules

- AGENTS.md Butler and Reviewer as Stop Roles
- AGENTS.md Evidence Discipline
- AGENTS.md Authority Boundary
- AGENTS.md Chief Butler Operating Principle

## Out-of-scope but NOT implemented

- production deploy 自動化
- GitHub repository settings / branch protection 変更
- PR #537 の retroactive 自動マージ化
- reviewer approve なしの auto merge
- failed checks / merge conflict / stale head SHA の bypass

## Extra changes (if any)

None.
