### PR TITLE
Issue #524 Dashboard chat のURL/percent-encoded表示と折り返しを固定する

### DIFF
--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -10237,6 +10237,38 @@ function uniqueTextList(value) {
   return [...new Set(normalizeTextList(value))];
 }
 
+export function normalizeDashboardChatMessageText(text) {
+  return decodeSafeDashboardChatCommandText(String(text || ""));
+}
+
+export function shouldWrapDashboardChatCodeBlock(text) {
+  const source = String(text || "").trim();
+  if (!source) return false;
+  if (/^https?:\/\//i.test(source)) return true;
+  if (/^go:%[0-9a-f]{2}/i.test(source)) return true;
+  return source.length > 80 && !/\s/.test(source);
+}
+
+function decodeSafeDashboardChatCommandText(text) {
+  const source = String(text || "");
+  return source
+    .split("\n")
+    .map((line) => {
+      if (!/^go:%[0-9a-f]{2}/i.test(line)) {
+        return line;
+      }
+      if (/^https?:/i.test(line)) {
+        return line;
+      }
+      try {
+        return decodeURIComponent(line);
+      } catch {
+        return line;
+      }
+    })
+    .join("\n");
+}
+
 async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore } = {}) {
   const origin = normalize(runtimeOrigin);
   const repositoryInput = normalizeDashboardRepositoryInput(
@@ -10409,10 +10441,11 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
     .bubble strong { display: block; color: var(--muted); font-size: 12px; letter-spacing: .08em; text-transform: uppercase; margin-bottom: 8px; }
     .bubble-header strong { margin-bottom: 0; }
     .bubble p { color: var(--text); margin-bottom: 12px; }
-    .bubble .message-body { display: grid; gap: 12px; }
-    .bubble .message-body p { margin: 0; white-space: pre-wrap; }
+    .bubble .message-body { display: grid; gap: 12px; min-width: 0; }
+    .bubble .message-body p { margin: 0; white-space: pre-wrap; overflow-wrap: anywhere; word-break: break-word; }
     .bubble .message-body ul { margin: 0; }
     .bubble .message-body li + li { margin-top: 4px; }
+    .bubble .message-body a, .bubble .message-body code { overflow-wrap: anywhere; word-break: break-word; }
     .bubble .message-body code { font-size: .94em; }
     .bubble .message-body pre { position: relative; margin: 0; padding: 42px 14px 14px; border: 1px solid var(--border); border-radius: 12px; background: var(--panel-strong); overflow-x: auto; white-space: pre; max-width: 100%; }
     .bubble .message-body pre.wrap-code { overflow-x: visible; white-space: pre-wrap; }
@@ -10937,7 +10970,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         return source
           .split("\\n")
           .map((line) => {
-            if (!/^[a-z][a-z0-9+.-]*:%[0-9a-f]{2}/i.test(line)) {
+            if (!/^go:%[0-9a-f]{2}/i.test(line)) {
               return line;
             }
             if (/^https?:/i.test(line)) {
@@ -10956,7 +10989,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         const source = String(text || "").trim();
         if (!source) return false;
         if (/^https?:\\/\\//i.test(source)) return true;
-        if (/^[a-z][a-z0-9+.-]*:%[0-9a-f]{2}/i.test(source)) return true;
+        if (/^go:%[0-9a-f]{2}/i.test(source)) return true;
         return source.length > 80 && !/\\s/.test(source);
       }
 

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -2,7 +2,11 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import worker from "../src/worker.js";
 import { DashboardChatRoom } from "../src/worker.js";
-import { buildDashboardWebPushPayload } from "../src/worker/runtime.js";
+import {
+  buildDashboardWebPushPayload,
+  normalizeDashboardChatMessageText,
+  shouldWrapDashboardChatCodeBlock
+} from "../src/worker/runtime.js";
 import {
   ActionType,
   ActorRole,
@@ -52,6 +56,179 @@ const dashboardAccessEnv = {
     payload: token === "test-access-jwt" ? { email: "owner@example.com", exp: 4102444800 } : null
   })
 };
+
+function extractDashboardInlineFunction(html, name) {
+  const script = String(html || "").match(/<script>([\s\S]*?)<\/script>/)?.[1] || "";
+  const asyncStart = script.indexOf(`async function ${name}(`);
+  const start = asyncStart === -1 ? script.indexOf(`function ${name}(`) : asyncStart;
+  assert.notEqual(start, -1, `dashboard inline function ${name} is missing`);
+  const braceStart = script.indexOf("{", start);
+  assert.notEqual(braceStart, -1, `dashboard inline function ${name} has no body`);
+  let depth = 0;
+  for (let index = braceStart; index < script.length; index += 1) {
+    const char = script[index];
+    if (char === "{") depth += 1;
+    if (char === "}") depth -= 1;
+    if (depth === 0) {
+      return script.slice(start, index + 1);
+    }
+  }
+  assert.fail(`dashboard inline function ${name} body is incomplete`);
+}
+
+function createMinimalDashboardDocument() {
+  class TextNode {
+    constructor(text) {
+      this.nodeType = 3;
+      this.textContent = String(text || "");
+      this.parentNode = null;
+    }
+  }
+
+  class ElementNode {
+    constructor(tagName) {
+      this.nodeType = 1;
+      this.tagName = String(tagName || "").toUpperCase();
+      this.children = [];
+      this.parentNode = null;
+      this.attributes = new Map();
+      this.dataset = {};
+      this.style = {};
+      this._textContent = "";
+      this.className = "";
+      this.type = "";
+      this.href = "";
+      this.target = "";
+      this.rel = "";
+      this.title = "";
+      this.value = "";
+      this.listeners = new Map();
+    }
+
+    appendChild(child) {
+      child.parentNode = this;
+      this.children.push(child);
+      return child;
+    }
+
+    replaceChildren(...children) {
+      this.children = [];
+      for (const child of children) {
+        this.appendChild(child);
+      }
+    }
+
+    remove() {
+      if (!this.parentNode) return;
+      this.parentNode.children = this.parentNode.children.filter((child) => child !== this);
+      this.parentNode = null;
+    }
+
+    select() {
+      this.selected = true;
+    }
+
+    setAttribute(name, value) {
+      this.attributes.set(name, String(value));
+    }
+
+    getAttribute(name) {
+      return this.attributes.get(name) || null;
+    }
+
+    addEventListener(type, listener) {
+      this.listeners.set(type, listener);
+    }
+
+    async click() {
+      const listener = this.listeners.get("click");
+      if (listener) {
+        await listener({ target: this });
+      }
+    }
+
+    get textContent() {
+      if (this.children.length === 0) return this._textContent;
+      return this.children.map((child) => child.textContent).join("");
+    }
+
+    set textContent(value) {
+      this.children = [];
+      this._textContent = String(value || "");
+    }
+
+    querySelectorAll(tagName) {
+      const matches = [];
+      const expected = String(tagName || "").toUpperCase();
+      const visit = (node) => {
+        if (node.nodeType === 1 && node.tagName === expected) {
+          matches.push(node);
+        }
+        for (const child of node.children || []) {
+          visit(child);
+        }
+      };
+      visit(this);
+      return matches;
+    }
+  }
+
+  const document = {
+    body: new ElementNode("body"),
+    createElement: (tagName) => new ElementNode(tagName),
+    createTextNode: (text) => new TextNode(text),
+    execCommand(command) {
+      document.lastExecCommand = command;
+      return true;
+    }
+  };
+  return document;
+}
+
+function loadDashboardInlineChatHelpers(html) {
+  const names = [
+    "normalizeMessageDisplayText",
+    "normalizeMessageCopyText",
+    "decodeSafeChatCommandText",
+    "shouldWrapCodeBlock",
+    "renderMessageText",
+    "renderInlineMarkdown",
+    "copyMessageText"
+  ];
+  const sources = names.map((name) => extractDashboardInlineFunction(html, name)).join("\n");
+  return Function(
+    "document",
+    "navigator",
+    "window",
+    "setStatus",
+    `${sources}\nreturn { ${names.join(", ")} };`
+  );
+}
+
+test("dashboard chat message text safely decodes command-like percent encoded lines", () => {
+  assert.equal(
+    normalizeDashboardChatMessageText("go:%0Adeploy%20production%0Aissue%20%23524"),
+    "go:\ndeploy production\nissue #524"
+  );
+  assert.equal(
+    normalizeDashboardChatMessageText("https://example.com/path%20with%20encoded?x=1"),
+    "https://example.com/path%20with%20encoded?x=1"
+  );
+  assert.equal(normalizeDashboardChatMessageText("go:%E0%A4%A"), "go:%E0%A4%A");
+  assert.equal(normalizeDashboardChatMessageText("slack:%20do-not-decode"), "slack:%20do-not-decode");
+  assert.equal(
+    normalizeDashboardChatMessageText("before\ngo:%0Aone%20two\nafter"),
+    "before\ngo:\none two\nafter"
+  );
+});
+
+test("dashboard chat code block wrap policy keeps URL and command text readable", () => {
+  assert.equal(shouldWrapDashboardChatCodeBlock("https://example.com/" + "a".repeat(96)), true);
+  assert.equal(shouldWrapDashboardChatCodeBlock("go:%0A" + "deploy%20".repeat(20)), true);
+  assert.equal(shouldWrapDashboardChatCodeBlock("slack:%20" + "x".repeat(96)), true);
+  assert.equal(shouldWrapDashboardChatCodeBlock("x".repeat(96)), true);
+  assert.equal(shouldWrapDashboardChatCodeBlock("const value = 1;\nconsole.log(value);"), false);
+});
 
 function createInMemoryDashboardEventStore() {
   const events = new Map();
@@ -843,7 +1020,13 @@ test("worker serves v2 dashboard for allowed owner identity without exposing sec
   assert.equal(body.includes("function normalizeMessageCopyText("), true);
   assert.equal(body.includes("function decodeSafeChatCommandText("), true);
   assert.equal(body.includes("decodeURIComponent(line)"), true);
+  assert.equal(body.includes('if (/^https?:/i.test(line))'), true);
   assert.equal(body.includes("function shouldWrapCodeBlock("), true);
+  assert.equal(body.includes('if (/^https?:\\/\\//i.test(source)) return true;'), true);
+  assert.equal(body.includes('if (/^go:%[0-9a-f]{2}/i.test(source)) return true;'), true);
+  assert.equal(body.includes("return source.length > 80 && !/\\s/.test(source);"), true);
+  assert.equal(body.includes('renderMessageText(body, normalizeMessageDisplayText(message.text || "（空のメッセージ）"))'), true);
+  assert.equal(body.includes('copyMessageText(copyButton, normalizeMessageCopyText(message.text || ""))'), true);
   assert.equal(body.includes('pre.className = "wrap-code"'), true);
   assert.equal(body.includes("function copyMessageText("), true);
   assert.equal(body.includes("navigator.clipboard.writeText"), true);
@@ -873,6 +1056,8 @@ test("worker serves v2 dashboard for allowed owner identity without exposing sec
   assert.equal(body.includes("white-space: pre-wrap"), true);
   assert.equal(body.includes(".bubble .message-body pre.wrap-code"), true);
   assert.equal(body.includes("overflow-wrap: anywhere; word-break: break-word;"), true);
+  assert.equal(body.includes(".bubble .message-body { display: grid; gap: 12px; min-width: 0; }"), true);
+  assert.equal(body.includes(".bubble .message-body p { margin: 0; white-space: pre-wrap; overflow-wrap: anywhere; word-break: break-word; }"), true);
   assert.equal(body.includes("tokenPattern"), true);
   assert.equal(body.includes('link.className = "chat-link"'), true);
   assert.equal(body.includes("考えています"), false);
@@ -931,6 +1116,78 @@ test("worker serves v2 dashboard for allowed owner identity without exposing sec
   assert.equal(aliasBody.includes("dashboard main chat"), true);
   assert.equal(aliasBody.includes("管理メニュー"), true);
   assert.equal(aliasBody.includes("WebSocket"), true);
+});
+
+test("served dashboard inline chat renderer executes decode, link, wrap, and copy behavior", async () => {
+  const response = await worker.fetch(
+    new Request("https://example.com/dashboard", {
+      headers: dashboardAccessHeaders
+    }),
+    dashboardAccessEnv
+  );
+  assert.equal(response.status, 200);
+  const html = await response.text();
+  const document = createMinimalDashboardDocument();
+  const copied = [];
+  const helpers = loadDashboardInlineChatHelpers(html)(
+    document,
+    {
+      clipboard: {
+        async writeText(text) {
+          copied.push(String(text));
+        }
+      }
+    },
+    {
+      isSecureContext: true,
+      setTimeout(callback) {
+        callback();
+      }
+    },
+    (text) => {
+      document.lastStatus = text;
+    }
+  );
+
+  assert.equal(
+    helpers.normalizeMessageDisplayText("go:%0Adeploy%20production%0Aissue%20%23524"),
+    "go:\ndeploy production\nissue #524"
+  );
+  assert.equal(
+    helpers.normalizeMessageCopyText("https://example.com/path%20with%20encoded?x=1"),
+    "https://example.com/path%20with%20encoded?x=1"
+  );
+  assert.equal(helpers.normalizeMessageCopyText("go:%E0%A4%A"), "go:%E0%A4%A");
+  assert.equal(helpers.normalizeMessageCopyText("slack:%20do-not-decode"), "slack:%20do-not-decode");
+
+  const textContainer = document.createElement("div");
+  helpers.renderMessageText(
+    textContainer,
+    helpers.normalizeMessageDisplayText("go:%0Adeploy%20production%0Ahttps://example.com/" + "a".repeat(96))
+  );
+  assert.equal(textContainer.textContent.includes("go:\ndeploy production"), true);
+  const links = textContainer.querySelectorAll("a");
+  assert.equal(links.length, 1);
+  assert.equal(links[0].className, "chat-link");
+  assert.equal(links[0].href.startsWith("https://example.com/"), true);
+
+  const codeContainer = document.createElement("div");
+  helpers.renderMessageText(codeContainer, "```\nhttps://example.com/" + "b".repeat(96) + "\n```");
+  const codeBlocks = codeContainer.querySelectorAll("pre");
+  assert.equal(codeBlocks.length, 1);
+  assert.equal(codeBlocks[0].className, "wrap-code");
+  const codeCopyButtons = codeContainer.querySelectorAll("button");
+  assert.equal(codeCopyButtons.length, 1);
+  await codeCopyButtons[0].click();
+  assert.equal(copied.at(-1), "https://example.com/" + "b".repeat(96));
+
+  const messageCopyButton = document.createElement("button");
+  await helpers.copyMessageText(
+    messageCopyButton,
+    helpers.normalizeMessageCopyText("go:%0Adeploy%20production%0Aissue%20%23524")
+  );
+  assert.equal(copied.at(-1), "go:\ndeploy production\nissue #524");
+  assert.equal(document.lastStatus, undefined);
 });
 
 test("worker appends dashboard Butler chat turn and retrieves the same thread", async () => {

--- a/worker.js
+++ b/worker.js
@@ -65245,10 +65245,11 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
     .bubble strong { display: block; color: var(--muted); font-size: 12px; letter-spacing: .08em; text-transform: uppercase; margin-bottom: 8px; }
     .bubble-header strong { margin-bottom: 0; }
     .bubble p { color: var(--text); margin-bottom: 12px; }
-    .bubble .message-body { display: grid; gap: 12px; }
-    .bubble .message-body p { margin: 0; white-space: pre-wrap; }
+    .bubble .message-body { display: grid; gap: 12px; min-width: 0; }
+    .bubble .message-body p { margin: 0; white-space: pre-wrap; overflow-wrap: anywhere; word-break: break-word; }
     .bubble .message-body ul { margin: 0; }
     .bubble .message-body li + li { margin-top: 4px; }
+    .bubble .message-body a, .bubble .message-body code { overflow-wrap: anywhere; word-break: break-word; }
     .bubble .message-body code { font-size: .94em; }
     .bubble .message-body pre { position: relative; margin: 0; padding: 42px 14px 14px; border: 1px solid var(--border); border-radius: 12px; background: var(--panel-strong); overflow-x: auto; white-space: pre; max-width: 100%; }
     .bubble .message-body pre.wrap-code { overflow-x: visible; white-space: pre-wrap; }
@@ -65773,7 +65774,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         return source
           .split("\\n")
           .map((line) => {
-            if (!/^[a-z][a-z0-9+.-]*:%[0-9a-f]{2}/i.test(line)) {
+            if (!/^go:%[0-9a-f]{2}/i.test(line)) {
               return line;
             }
             if (/^https?:/i.test(line)) {
@@ -65792,7 +65793,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         const source = String(text || "").trim();
         if (!source) return false;
         if (/^https?:\\/\\//i.test(source)) return true;
-        if (/^[a-z][a-z0-9+.-]*:%[0-9a-f]{2}/i.test(source)) return true;
+        if (/^go:%[0-9a-f]{2}/i.test(source)) return true;
         return source.length > 80 && !/\\s/.test(source);
       }
 


### PR DESCRIPTION
## This PR satisfies Intent

Issue #524 の Dashboard Butler チャットで、`go:%0A...` のような安全な percent-encoded コマンド表示と、長いURL/コマンド/無空白文字列の折り返しポリシーをコード上で検証可能に固定します。

このPRは、Dashboardの実CSSと既存Dashboard内スクリプトにある表示方針を修正し、配信されるDashboard HTMLのdisplay/copy経路まで統合テストで固定します。

## Satisfied Success Criteria

- `go:%0Adeploy%20production%0Aissue%20%23524` は表示用に `go:\ndeploy production\nissue #524` へ安全に正規化される。
- `https://example.com/path%20with%20encoded?x=1` はリンクとして扱う前提を壊さないため、percent-encoded のまま保持される。
- 壊れたpercent encodingは例外にせず元文字列を保持する。
- URL、command-like percent encoded text、長い無空白テキストは code block wrap 対象になる。
- 通常の複数行コードは不要なwrap対象にしない。
- 実際に配信されるDashboard HTMLで、チャット本文のdisplay経路が `normalizeMessageDisplayText` を通り、copy経路が `normalizeMessageCopyText` を通る。
- `.message-body` / 通常段落 / link / inline code / wrap-code block のCSSが、長いURLや無空白文字列を横幅計算で押し広げない条件を持つ。
- 配信Dashboard HTMLからinline script関数を抽出し、最小DOM上で `go:%0A...` の表示decode、httpsリンク化、URL code blockの `wrap-code` 付与、code copy、message copy正規化を実行して検証する。
- `go:` 以外の任意schemeはpercent decodeしない。

## Unsatisfied Success Criteria

- なし。

## Dry-run Impact Report

- Target Issue: #524
- Implementing Success Criteria: safe `go:` percent-encoded command display normalization, URL preservation, long text/code block wrap policy, actual Dashboard CSS wrap behavior, and served Dashboard HTML display/copy/render execution coverage.
- Explicit Non-goals: passkey/auth境界、通知、画像添付、VPS runner handoff、deploy権限、Dashboardメニュー再編、Issue closure。
- Expected touched files/routes/workflows: `src/worker/runtime.js`, `test/worker.test.js`; runtime route/workflow変更なし。
- Affected Issues: Issue #524。
- Affected PRs: このPRのみ。
- Affected workflows: CI test/checkのみ。GitHub Actions workflow定義は変更しない。
- Affected runtime/operator surfaces: Dashboard Butler chat display policy only; operator/passkey/deploy surfaces are unchanged.
- What may break if we patch narrowly: actual inline browser scriptとexported helperが将来乖離すると、テストは通っても実ブラウザ表示が壊れる可能性が残るため、served Dashboard HTML側の実行テストも追加する。
- Unknowns to investigate before coding: Browser pluginによる実ブラウザ確認はこの環境で `iab` unavailable のため取得不能。代替として配信HTML統合テストでCSS/display/copy接続を固定する。
- Validation needed: `node --test`, `npm run check:generated-worker`, `npm run check:self-parity`, `git diff --check`, served Dashboard HTML integration assertions.
- Stop condition: inline Dashboard scriptの実挙動とhelperテストのポリシーが矛盾する場合、追加実装前に#524の完了条件を再確認する。

## File / Line Hypotheses

- `src/worker/runtime.js`: Dashboard Butlerチャット本文の正規化・折り返し判断がHTML内inline scriptに閉じているため、テストがDOM断片/文字列検査に寄り、`go:%0A...` や長いURLの退行を見逃しやすい。また `.message-body` / `p` / link / inline code のCSSが、長いURLをグリッド内で押し広げる余地を残している。
- `test/worker.test.js`: Issue #524 の本質である「安全に読める表示」と「不要な横スクロール回避」の境界ケースを直接固定するテストが不足している。

## Hypothesis Retrospective

- 予想通り、既存コードにはinline script側の正規化・wrap方針が存在したが、純粋関数として直接テストできる入口がなかった。
- 追加確認で、通常本文の実レンダリング先である `.message-body` と `p` には `min-width: 0` / `word-break` がなく、長いURLが横幅計算を押し広げる余地があったため、実CSSも修正した。
- 今回は表示方針をexported helperとして固定し、served Dashboard HTMLからinline script関数を抽出して最小DOMで実行することで、display/copy/render接続、URL保持、`go:` percent decode、壊れたencoding保持、任意scheme非decode、長い無空白文字列wrap、通常コード非wrap、通常本文CSS wrapをテストで固定した。

## Verification Evidence

- `npm run check:generated-worker`: pass
- `npm run check:self-parity`: pass, 26 routes / 26 operationIds
- `git diff --check HEAD~1..HEAD`: pass
- `node --test`: pass, 958 pass / 1 skip
- `node --test test/worker.test.js --test-name-pattern "dashboard inline chat renderer|dashboard chat message text|dashboard chat code block wrap|worker serves v2 dashboard"`: pass, 197 pass
- Browser plugin verification attempt: blocked because `iab` browser was unavailable in this environment; served Dashboard HTML integration test is used as the available E2E evidence.
- Evidence path/link: local test output on branch `codex/issue-524-dashboard-message-wrapping`

## Butler Completion Contract

- Owner goal: iPhone/iPadのDashboard Butlerチャットで、長いURLや `go:%0A...` が横スクロール地獄にならず、人間が読める表示になる。
- Butler entrypoint: Dashboard Butler chat surface; this PR strengthens the display policy under that surface.
- Action Schema exposure: 不要。Dashboard内表示ポリシーのためCustom GPT Action Schema operationId追加はしない。
- Runtime path: `renderV2DashboardPage` 配下のDashboard HTML/inline chat rendering policy and exported runtime helpers.
- Runner/runtime truth: worker test and self-parity checks passed locally; deployed runtime truth is not changed until post-merge deploy.
- Authority boundary: low-risk code/test change. mergeは人間GO後。deployは別途passkey承認が必要。
- E2E evidence: served Dashboard HTML integration test extracts and executes inline chat renderer/copy helpers against a minimal DOM, verifying decode/link/wrap/copy behavior; browser plugin visual check was attempted but unavailable (`iab` unavailable).
- Completion status: complete

## Surface Update Checklist

- Dashboard Butler chat: display/wrap policy regression coverage added.
- Custom GPT Action Schema: no change required.
- Runtime route: no new route.
- VPS runner: no change.
- Approval/passkey: no change.
- Notification: no change.
- Deploy: merge後にWorker deployが必要。
