### PR TITLE
docs: define Dashboard Butler surface contract

### DIFF
--- a/docs/butler/surface-independence.md
+++ b/docs/butler/surface-independence.md
@@ -39,9 +39,90 @@ Memory retrieval, runtime truth retrieval, proposal handling, approval orchestra
 - CLI
 - future provider-specific surfaces
 
+## Custom GPT And Dashboard Butler
+
+Custom GPT Butler remains a supported Butler surface and fallback. Dashboard
+Butler does not replace it as a fallback, and Dashboard work must not let Custom
+GPT Instructions, Action Schema, setup artifacts, or operationId coverage drift.
+
+Dashboard Butler should eventually exceed Custom GPT for the VTDD owner
+workflow. The target is not a weaker homegrown chat UI. The target is a
+Dashboard surface whose normal conversation is good enough to use every day and
+whose VTDD-only capabilities make it more useful than Custom GPT for operating
+VTDD from iPhone or iPad.
+
+The two surfaces may share VTDD core actions when the operation is the same:
+
+- GitHub read and write actions
+- runtime truth retrieval
+- operational RAG retrieval and write candidates
+- repository nickname resolution
+- self-parity and setup diagnostics
+- setup artifact retrieval
+- approval grant retrieval
+- governed operator URL generation
+
+Sharing an action does not make the surface the same. The surface contract must
+still record which owner-facing path is expected to call the action and what
+evidence proves that path.
+
+Custom GPT path:
+
+```text
+Custom GPT Butler
+  -> Action Schema operationId
+  -> Worker /v2 route
+  -> VTDD core runtime
+```
+
+Dashboard Butler path:
+
+```text
+Dashboard Butler PWA
+  -> Worker / Durable Object dashboard chat room
+  -> VPS Dashboard Bridge
+  -> codex app-server
+  -> VTDD core runtime and dashboard thread
+```
+
+Dashboard-only capabilities are the reason Dashboard Butler exists. They must
+not be hidden as generic debug tools:
+
+- iOS/PWA notifications, badges, and notification recovery
+- live VPS/Codex/app-server progress visible from iPhone or iPad
+- Action Schema and Instructions update guidance with owner-facing next steps
+- Dashboard thread recovery after PWA background/foreground transitions
+- owner-facing setup recovery for Custom GPT Action Schema and Instructions
+- runtime/self-parity drift detection with next owner action
+- passkey step-up only when a high-risk action scope requires it
+
+Custom GPT-only or Custom GPT-primary capabilities must also remain explicit:
+
+- ChatGPT-native conversation quality, thread handling, and memory affordances
+- Action Schema operationId exposure
+- canonical Custom GPT Instructions and short paste targets
+- Custom GPT Action Authentication guidance
+- Custom GPT as the fallback owner surface when Dashboard live chat is
+  unavailable
+
 ## Requirement
 
 Replacing the surface must not redefine Butler's judgment model or memory model.
+
+Adding Dashboard Butler must not remove or stale the Custom GPT fallback. When a
+PR changes a Butler-facing capability, its PR body must say whether the change
+requires:
+
+- Custom GPT Action Schema update
+- Custom GPT Instructions update
+- Cloudflare deploy update
+- Dashboard Butler UI/runtime update
+- iPhone/PWA live E2E evidence
+
+Self-parity and setup diagnostics must report Custom GPT and Dashboard surface
+needs separately. `runtimeParity=in_sync` is not proof that the current Custom
+GPT editor has the latest Action Schema or Instructions, because the runtime
+cannot read the editor's pasted state.
 
 ## Goal
 

--- a/test/surface-independence.test.js
+++ b/test/surface-independence.test.js
@@ -22,6 +22,40 @@ test("surface independence doc defines role/contract/runtime/surface separation"
   );
 });
 
+test("surface independence doc preserves Custom GPT fallback while defining Dashboard Butler path", () => {
+  const doc = fs.readFileSync(DOC_PATH, "utf8");
+  const compact = doc.replace(/\s+/g, " ");
+  assert.equal(doc.includes("Custom GPT Butler remains a supported Butler surface and fallback."), true);
+  assert.equal(compact.includes("Dashboard Butler does not replace it as a fallback"), true);
+  assert.equal(compact.includes("Dashboard Butler should eventually exceed Custom GPT for the VTDD owner workflow."), true);
+  assert.equal(doc.includes("The target is not a weaker homegrown chat UI."), true);
+  assert.equal(compact.includes("more useful than Custom GPT for operating VTDD from iPhone or iPad"), true);
+  assert.equal(doc.includes("Custom GPT Butler\n  -> Action Schema operationId"), true);
+  assert.equal(doc.includes("Dashboard Butler PWA\n  -> Worker / Durable Object dashboard chat room"), true);
+  assert.equal(compact.includes("The two surfaces may share VTDD core actions when the operation is the same"), true);
+  assert.equal(doc.includes("Dashboard-only capabilities are the reason Dashboard Butler exists."), true);
+  assert.equal(doc.includes("iOS/PWA notifications, badges, and notification recovery"), true);
+  assert.equal(doc.includes("Action Schema and Instructions update guidance with owner-facing next steps"), true);
+  assert.equal(doc.includes("owner-facing setup recovery for Custom GPT Action Schema and Instructions"), true);
+  assert.equal(doc.includes("Action Schema operationId exposure"), true);
+  assert.equal(doc.includes("Custom GPT Action Authentication guidance"), true);
+});
+
+test("surface independence doc requires separate surface update reporting", () => {
+  const doc = fs.readFileSync(DOC_PATH, "utf8");
+  const compact = doc.replace(/\s+/g, " ");
+  assert.equal(doc.includes("Custom GPT Action Schema update"), true);
+  assert.equal(doc.includes("Custom GPT Instructions update"), true);
+  assert.equal(doc.includes("Cloudflare deploy update"), true);
+  assert.equal(doc.includes("Dashboard Butler UI/runtime update"), true);
+  assert.equal(doc.includes("iPhone/PWA live E2E evidence"), true);
+  assert.equal(doc.includes("runtimeParity=in_sync"), true);
+  assert.equal(
+    compact.includes("the runtime cannot read the editor's pasted state"),
+    true
+  );
+});
+
 test("surface independence allows supported surfaces when judgment model is unchanged", () => {
   for (const surface of [
     ButlerSurface.CUSTOM_GPT,


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #528 の前提として、Dashboard Butler は Custom GPT の劣化コピーではなく、Custom GPT fallback を維持しながら VTDD owner workflow では Custom GPT を超える surface であることを docs に固定します。

## Satisfied Success Criteria

- Custom GPT Butler を fallback として維持することを明記。
- Dashboard Butler と Custom GPT の別経路を明記。
- Action は共有可能だが surface contract と evidence は別に必要だと明記。
- Dashboard-only capability と Custom GPT-primary capability を分類。
- Surface update reporting に Dashboard Butler UI/runtime update を追加。

## Unsatisfied Success Criteria

- Dashboard UI 自体の整理は未実装。
- Dashboard自然文から self-parity/setup recovery へ到達する runtime UX は未実装。
- iPhone/PWA live E2E は未実施。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #528
- Implementing Success Criteria: Dashboard Butler の通常チャットUX基準化に入る前提として、Custom GPT fallback / Dashboard専用経路 / shared Action / setup更新責務を固定する。
- Explicit Non-goals: runtime behavior変更なし。Cloudflare deployなし。credential/permission mutationなし。Issue closeなし。
- Expected touched files/routes/workflows: docs/butler/surface-independence.md; test/surface-independence.test.js
- Affected Issues: Issue #528, Issue #534, Issue #450, Issue #514, Issue #536
- Affected PRs: なし
- Affected workflows: なし
- Affected runtime/operator surfaces: Custom GPT Butler fallback, Dashboard Butler PWA, setup/self-parity surface, PR Surface Update Checklist
- What may break if we patch narrowly: UIだけ先に直すと Dashboard Butler の存在理由が管理コンソール化または Custom GPT劣化コピーへ drift する。
- Unknowns to investigate before coding: Dashboard自然文から setup/self-parity 更新導線へどう接続するかは次スライスで検証する。
- Validation needed: node --test test/surface-independence.test.js; docs関連テスト
- Stop condition: runtime経路やUI実装へ踏み込む場合は別の bounded change contract が必要。

## File / Line Hypotheses

- file: docs/butler/surface-independence.md
  - hypothesis: surface contract の正本として Custom GPT fallback と Dashboard Butler専用経路を固定する場所。
  - risk if changed narrowly: app-server live path docsだけに書くと Custom GPT fallback維持や Action Schema更新責務が抜ける。
  - validation: surface-independence docs testで固定する。
  - related Issue: #528

## Hypothesis Retrospective

- expected: surface-independence docが最小の正本として機能する。
- actual: Custom GPT fallback維持、Dashboard ButlerがVTDD workflowでCustom GPTを超える目標、shared Action、Dashboard-only capability、surface update checklistを追記した。
- mismatch: なし。
- lesson: Dashboard ButlerはUI修正前に product/surface contract を固定する必要がある。
- should become RAG candidate: 必要なら次回。

## Verification Evidence

- Unit: node --test test/surface-independence.test.js => pass
- Integration: node --test test/canonical-docs-restoration.test.js test/butler-capability-matrix.test.js test/custom-gpt-setup-docs.test.js => pass
- E2E: 未実施。このPRはdocs/testのみで owner-facing Dashboard runtime は未接続。
- Manual: git diff --check => pass
- Evidence path/link: docs/butler/surface-independence.md; test/surface-independence.test.js

## Butler Completion Contract

- Owner goal: Dashboard Butler を Custom GPT fallback と共存しつつ、VTDD owner workflowではCustom GPTを超える専用surfaceとして実装していく前提を固定する。
- Butler entrypoint: 未変更。このPRは契約docsのみ。
- Action Schema exposure: 未変更。共有Actionは許容するが、このPRではoperationIdを追加しない。
- Runtime path: 未変更。Dashboard PWA / app-server bridge 実装には触れない。
- Runner/runtime truth: docs/test evidenceのみ。runtime truth pathは未変更。
- Authority boundary: 未変更。高リスク操作は引き続き scoped passkey step-up。
- E2E evidence: 未実施。Dashboard UI/runtimeは未接続のため completion は incomplete。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 不要。docs/testのみ。
- Custom GPT Action Schema update: 不要。このPRはCustom GPT fallback維持方針を固定するがschema変更なし。
- Custom GPT Instructions update: 不要。このPRはInstructions本文変更なし。
- iPhone Butler live E2E: 未実施。次のUI/runtimeスライスで必要。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate
- AGENTS.md Butler-First Operating Principle
- AGENTS.md Chief Butler Operating Principle
- AGENTS.md Evidence Discipline
- AGENTS.md Change Size and PR Discipline

## Out-of-scope but NOT implemented

- Dashboard初期画面のUI整理。
- Dashboard自然文intentからsetup/self-parity更新導線へのruntime接続。
- iOS通知/Web Push実機E2E。
- Cloudflare deploy。

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #528
- Execution ID: Not provided.
- Goal: Not provided.
