### PR TITLE
fix: prefer Access for Dashboard notification auth

### DIFF
--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -651,7 +651,15 @@ export default {
     if (request.method === "GET" && isDashboardPagePath(url.pathname)) {
       const auth = await authorizeDashboardRequest({ request, env, apiSuffix: url.pathname });
       if (!auth.ok) {
-        return html(auth.status, renderDashboardAuthRequiredPage({ runtimeOrigin: url.origin, reason: auth.reason }));
+        return html(
+          auth.status,
+          renderDashboardAuthRequiredPage({
+            runtimeOrigin: url.origin,
+            returnPath: `${url.pathname}${url.search}`,
+            reason: auth.reason,
+            passkeyFallbackReason: auth.passkeyFallbackReason
+          })
+        );
       }
     }
 
@@ -8573,7 +8581,12 @@ async function authorizeDashboardRequest({ request, env, apiSuffix = "/dashboard
 
   if (!accessEmail && !accessLogin) {
     if (passkeyAuth.blocking) {
-      return passkeyAuth;
+      return {
+        ok: false,
+        status: 401,
+        reason: `Cloudflare Access authenticated owner identity is required for ${routeLabel}`,
+        passkeyFallbackReason: passkeyAuth.reason
+      };
     }
     return {
       ok: false,
@@ -11563,8 +11576,9 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
 </html>`;
 }
 
-function renderDashboardAuthRequiredPage({ runtimeOrigin, reason } = {}) {
+function renderDashboardAuthRequiredPage({ runtimeOrigin, returnPath = "/dashboard", reason, passkeyFallbackReason } = {}) {
   const origin = normalizeText(runtimeOrigin);
+  const dashboardAccessHref = `${origin || ""}${sanitizeDashboardReturnPath(returnPath)}`;
   const dashboardSignInUrl = `${origin || ""}/v2/approval/passkey/operator?mode=dashboard&repositoryInput=marushu%2Fvtdd-v2-p&phase=execution&actionType=read&highRiskKind=dashboard_access`;
   return `<!doctype html>
 <html lang="ja">
@@ -11580,6 +11594,11 @@ function renderDashboardAuthRequiredPage({ runtimeOrigin, reason } = {}) {
     h1 { margin: 0 0 12px; font-size: 30px; }
     p { line-height: 1.7; color: #4d5c56; }
     a { color: #176b4d; font-weight: 750; }
+    .actions { display: flex; flex-wrap: wrap; gap: 10px; margin: 18px 0; }
+    .button { display: inline-flex; align-items: center; justify-content: center; min-height: 40px; border: 1px solid #b9cabe; border-radius: 7px; padding: 9px 12px; color: #0f513b; text-decoration: none; background: #f8fbf8; }
+    .primary { background: #247a5b; color: #fff; border-color: #247a5b; }
+    details { margin-top: 16px; border-top: 1px solid #e2e9e4; padding-top: 14px; }
+    summary { cursor: pointer; font-weight: 800; color: #24342e; }
     code { color: #5f6c66; }
   </style>
 </head>
@@ -11587,14 +11606,39 @@ function renderDashboardAuthRequiredPage({ runtimeOrigin, reason } = {}) {
   <main>
     <section class="panel">
       <h1>Dashboard auth required</h1>
-      <p>この dashboard は owner-facing surface です。対象の GitHub / Cloudflare Access identity で認証されたユーザー、または machine-authenticated service だけが利用できます。</p>
+      <p>この dashboard は owner-facing surface です。通常閲覧、通知確認、通常チャットは Cloudflare Access の owner identity で開きます。通知をタップしただけでは、未認証の相手に通知詳細や Dashboard 内容は返しません。</p>
       <p><code>${escapeDashboardHtml(reason || "dashboard authentication required")}</code></p>
-      <p><a href="${escapeDashboardHtml(dashboardSignInUrl)}">Passkey で dashboard に入る</a></p>
-      <p><a href="${escapeDashboardHtml(origin || "/status")}/status">Status</a></p>
+      <div class="actions">
+        <a class="button primary" href="${escapeDashboardHtml(dashboardAccessHref)}">Cloudflare Access で開く</a>
+        <a class="button" href="${escapeDashboardHtml(`${origin || ""}/status`)}">Status</a>
+      </div>
+      <details>
+        <summary>Passkey fallback</summary>
+        <p>passkey dashboard session は Cloudflare Access が使えない時の補助導線です。deploy、merge、secret sync などの高リスク操作は引き続き scope 明示済み real passkey approval が必要です。</p>
+        ${passkeyFallbackReason ? `<p><code>${escapeDashboardHtml(passkeyFallbackReason)}</code></p>` : ""}
+        <p><a href="${escapeDashboardHtml(dashboardSignInUrl)}">Passkey fallback を開く</a></p>
+      </details>
     </section>
   </main>
 </body>
 </html>`;
+}
+
+function sanitizeDashboardReturnPath(value) {
+  const normalized = normalizeText(value) || "/dashboard";
+  let parsed;
+  try {
+    parsed = new URL(normalized, "https://dashboard.local");
+  } catch {
+    return "/dashboard";
+  }
+  if (parsed.origin !== "https://dashboard.local") {
+    return "/dashboard";
+  }
+  if (parsed.pathname !== "/dashboard" && !parsed.pathname.startsWith("/dashboard/")) {
+    return "/dashboard";
+  }
+  return `${parsed.pathname}${parsed.search}`;
 }
 
 function renderV2StatusPage({ runtimeOrigin, autonomyMode }) {

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -778,6 +778,10 @@ test("worker rejects dashboard access without owner identity", async () => {
   const body = await response.text();
   assert.equal(body.includes("Dashboard auth required"), true);
   assert.equal(body.includes("owner-facing surface"), true);
+  assert.equal(body.includes("Cloudflare Access で開く"), true);
+  assert.equal(body.includes("Passkey fallback"), true);
+  assert.equal(body.includes("Passkey で dashboard に入る"), false);
+  assert.equal(body.includes("未認証の相手に通知詳細や Dashboard 内容は返しません"), true);
 });
 
 test("worker rejects unlisted dashboard subpaths before they can become public pages", async () => {
@@ -856,7 +860,42 @@ test("worker rejects stale dashboard passkey session cookies", async () => {
 
   assert.equal(response.status, 401);
   const body = await response.text();
+  assert.equal(body.includes("Cloudflare Access authenticated owner identity is required"), true);
+  assert.equal(body.includes("Cloudflare Access で開く"), true);
+  assert.equal(body.includes("Passkey fallback"), true);
   assert.equal(body.includes("dashboard passkey session was not found"), true);
+  assert.equal(body.includes("Passkey で dashboard に入る"), false);
+});
+
+test("worker does not expose dashboard notification details before Access auth", async () => {
+  const store = createInMemoryDashboardEventStore();
+  await store.put({
+    id: "github_actions_workflow_run:marushu/vtdd-v2-p:deploy-production:private-run",
+    kind: "github_actions_workflow_run",
+    repository: "marushu/vtdd-v2-p",
+    workflowName: "deploy-production",
+    runId: "private-run",
+    runUrl: "https://github.com/marushu/vtdd-v2-p/actions/runs/private-run",
+    status: "completed",
+    conclusion: "success",
+    headSha: "privateabcdef1234567890",
+    headBranch: "main",
+    title: "private deploy notification",
+    updatedAt: new Date().toISOString()
+  });
+
+  const response = await worker.fetch(
+    new Request("https://example.com/dashboard/notifications"),
+    { DASHBOARD_EVENT_STORE: store }
+  );
+
+  assert.equal(response.status, 401);
+  const body = await response.text();
+  assert.equal(body.includes("Dashboard auth required"), true);
+  assert.equal(body.includes("Cloudflare Access で開く"), true);
+  assert.equal(body.includes("private deploy notification"), false);
+  assert.equal(body.includes("private-run"), false);
+  assert.equal(body.includes("privateabcdef"), false);
 });
 
 test("worker ignores stale dashboard passkey cookie when Cloudflare Access owner identity is valid", async () => {

--- a/worker.js
+++ b/worker.js
@@ -56646,7 +56646,15 @@ var runtime_default = {
     if (request.method === "GET" && isDashboardPagePath(url.pathname)) {
       const auth = await authorizeDashboardRequest({ request, env, apiSuffix: url.pathname });
       if (!auth.ok) {
-        return html(auth.status, renderDashboardAuthRequiredPage({ runtimeOrigin: url.origin, reason: auth.reason }));
+        return html(
+          auth.status,
+          renderDashboardAuthRequiredPage({
+            runtimeOrigin: url.origin,
+            returnPath: `${url.pathname}${url.search}`,
+            reason: auth.reason,
+            passkeyFallbackReason: auth.passkeyFallbackReason
+          })
+        );
       }
     }
     if (request.method === "GET" && (url.pathname === "/dashboard" || url.pathname === "/orchestrator")) {
@@ -63516,7 +63524,12 @@ async function authorizeDashboardRequest({ request, env, apiSuffix = "/dashboard
   const accessJwt = normalizeText30(request.headers.get("cf-access-jwt-assertion"));
   if (!accessEmail && !accessLogin) {
     if (passkeyAuth.blocking) {
-      return passkeyAuth;
+      return {
+        ok: false,
+        status: 401,
+        reason: `Cloudflare Access authenticated owner identity is required for ${routeLabel}`,
+        passkeyFallbackReason: passkeyAuth.reason
+      };
     }
     return {
       ok: false,
@@ -66366,8 +66379,9 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
 </body>
 </html>`;
 }
-function renderDashboardAuthRequiredPage({ runtimeOrigin, reason } = {}) {
+function renderDashboardAuthRequiredPage({ runtimeOrigin, returnPath = "/dashboard", reason, passkeyFallbackReason } = {}) {
   const origin = normalizeText30(runtimeOrigin);
+  const dashboardAccessHref = `${origin || ""}${sanitizeDashboardReturnPath(returnPath)}`;
   const dashboardSignInUrl = `${origin || ""}/v2/approval/passkey/operator?mode=dashboard&repositoryInput=marushu%2Fvtdd-v2-p&phase=execution&actionType=read&highRiskKind=dashboard_access`;
   return `<!doctype html>
 <html lang="ja">
@@ -66383,6 +66397,11 @@ function renderDashboardAuthRequiredPage({ runtimeOrigin, reason } = {}) {
     h1 { margin: 0 0 12px; font-size: 30px; }
     p { line-height: 1.7; color: #4d5c56; }
     a { color: #176b4d; font-weight: 750; }
+    .actions { display: flex; flex-wrap: wrap; gap: 10px; margin: 18px 0; }
+    .button { display: inline-flex; align-items: center; justify-content: center; min-height: 40px; border: 1px solid #b9cabe; border-radius: 7px; padding: 9px 12px; color: #0f513b; text-decoration: none; background: #f8fbf8; }
+    .primary { background: #247a5b; color: #fff; border-color: #247a5b; }
+    details { margin-top: 16px; border-top: 1px solid #e2e9e4; padding-top: 14px; }
+    summary { cursor: pointer; font-weight: 800; color: #24342e; }
     code { color: #5f6c66; }
   </style>
 </head>
@@ -66390,14 +66409,38 @@ function renderDashboardAuthRequiredPage({ runtimeOrigin, reason } = {}) {
   <main>
     <section class="panel">
       <h1>Dashboard auth required</h1>
-      <p>\u3053\u306E dashboard \u306F owner-facing surface \u3067\u3059\u3002\u5BFE\u8C61\u306E GitHub / Cloudflare Access identity \u3067\u8A8D\u8A3C\u3055\u308C\u305F\u30E6\u30FC\u30B6\u30FC\u3001\u307E\u305F\u306F machine-authenticated service \u3060\u3051\u304C\u5229\u7528\u3067\u304D\u307E\u3059\u3002</p>
+      <p>\u3053\u306E dashboard \u306F owner-facing surface \u3067\u3059\u3002\u901A\u5E38\u95B2\u89A7\u3001\u901A\u77E5\u78BA\u8A8D\u3001\u901A\u5E38\u30C1\u30E3\u30C3\u30C8\u306F Cloudflare Access \u306E owner identity \u3067\u958B\u304D\u307E\u3059\u3002\u901A\u77E5\u3092\u30BF\u30C3\u30D7\u3057\u305F\u3060\u3051\u3067\u306F\u3001\u672A\u8A8D\u8A3C\u306E\u76F8\u624B\u306B\u901A\u77E5\u8A73\u7D30\u3084 Dashboard \u5185\u5BB9\u306F\u8FD4\u3057\u307E\u305B\u3093\u3002</p>
       <p><code>${escapeDashboardHtml(reason || "dashboard authentication required")}</code></p>
-      <p><a href="${escapeDashboardHtml(dashboardSignInUrl)}">Passkey \u3067 dashboard \u306B\u5165\u308B</a></p>
-      <p><a href="${escapeDashboardHtml(origin || "/status")}/status">Status</a></p>
+      <div class="actions">
+        <a class="button primary" href="${escapeDashboardHtml(dashboardAccessHref)}">Cloudflare Access \u3067\u958B\u304F</a>
+        <a class="button" href="${escapeDashboardHtml(`${origin || ""}/status`)}">Status</a>
+      </div>
+      <details>
+        <summary>Passkey fallback</summary>
+        <p>passkey dashboard session \u306F Cloudflare Access \u304C\u4F7F\u3048\u306A\u3044\u6642\u306E\u88DC\u52A9\u5C0E\u7DDA\u3067\u3059\u3002deploy\u3001merge\u3001secret sync \u306A\u3069\u306E\u9AD8\u30EA\u30B9\u30AF\u64CD\u4F5C\u306F\u5F15\u304D\u7D9A\u304D scope \u660E\u793A\u6E08\u307F real passkey approval \u304C\u5FC5\u8981\u3067\u3059\u3002</p>
+        ${passkeyFallbackReason ? `<p><code>${escapeDashboardHtml(passkeyFallbackReason)}</code></p>` : ""}
+        <p><a href="${escapeDashboardHtml(dashboardSignInUrl)}">Passkey fallback \u3092\u958B\u304F</a></p>
+      </details>
     </section>
   </main>
 </body>
 </html>`;
+}
+function sanitizeDashboardReturnPath(value) {
+  const normalized = normalizeText30(value) || "/dashboard";
+  let parsed;
+  try {
+    parsed = new URL(normalized, "https://dashboard.local");
+  } catch {
+    return "/dashboard";
+  }
+  if (parsed.origin !== "https://dashboard.local") {
+    return "/dashboard";
+  }
+  if (parsed.pathname !== "/dashboard" && !parsed.pathname.startsWith("/dashboard/")) {
+    return "/dashboard";
+  }
+  return `${parsed.pathname}${parsed.search}`;
 }
 function renderV2StatusPage({ runtimeOrigin, autonomyMode }) {
   const origin = normalize7(runtimeOrigin);


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #536 の部分進捗として、Dashboard Butler の通知タップ後の通常認証を Passkey-first から Cloudflare Access owner identity-first に戻す。
- 未認証の通知リンク閲覧時に dashboard / notification / event detail を外部へ漏らさない。
- Passkey は fallback と high-risk step-up 境界として残す。

## Satisfied Success Criteria

- Dashboard ページ未認証時の案内は Cloudflare Access を primary action として表示する。
- stale dashboard passkey cookie がある場合も Access primary の 401 とし、passkey stale 理由は fallback detail に隔離する。
- /dashboard/notifications 未認証レスポンスに notification title / run id / commit sha を含めない worker test を追加した。
- valid Cloudflare Access identity や既存 passkey / deploy authority 境界の回帰テストを維持した。

## Unsatisfied Success Criteria

- Cloudflare 本番 deploy は実施していない。
- iPhone / iPad PWA から通知を踏む live E2E evidence は未実施。
- Issue #536 全体の dashboard UX / recovery / ChatGPT parity はこの PR だけでは完了しない。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #536
- Implementing Success Criteria: Dashboard Butler の notification/deep-link auth は Access-first、passkey fallback/high-risk step-up、pre-auth detail leak を禁止する範囲。
- Explicit Non-goals: Web Push payload redesign (#514)、Custom GPT Action Schema 変更、deploy、credential/permission mutation、Dashboard 全体 UI redesign は対象外。
- Expected touched files/routes/workflows: src/worker/runtime.js, worker.js, test/worker.test.js; route: /dashboard/* auth gate and /dashboard/notifications pre-auth behavior.
- Affected Issues: Issue #536; related but not implemented: #514.
- Affected PRs: なし。
- Affected workflows: GitHub Actions / deploy workflow は未変更。
- Affected runtime/operator surfaces: Cloudflare Worker Dashboard surface, Butler notification/deep-link entry, passkey fallback page. Custom GPT surface は未変更。
- What may break if we patch narrowly: Access-first copyだけ直すと pre-auth notification detail leak や high-risk passkey boundary regression を見落とすため、worker testsで両方を固定した。
- Unknowns to investigate before coding: live Cloudflare Access / iOS PWA 通知 tap の実機挙動は deploy 後に確認が必要。
- Validation needed: npm run check:generated-worker; node --test test/deploy-production-plane.test.js test/passkey-operator-page.test.js test/worker.test.js; deploy後の iPhone Butler live E2E.
- Stop condition: Access bypass、notification detail pre-auth leak、passkey high-risk authority weakening、deploy/credential mutationが必要になった場合は停止。

## File / Line Hypotheses

- file: `src/worker/runtime.js`
  - hypothesis: `authorizeDashboardRequest` が stale passkey を dashboard auth primary failure として返しているため、通知tap後に必ず passkey 認証に見える。
  - risk if changed narrowly: Access なしの pre-auth page が通知内容を漏らす、または passkey fallback を壊す。
  - validation: worker auth tests and notification pre-auth leak test.
  - related Issue: #536

## Hypothesis Retrospective

- expected: Access identity がない通常 dashboard access は Access-first 401 になり、passkey は fallback に残る。
- actual: tests show stale/no passkey cases now render Access primary while passkey reason remains fallback detail.
- mismatch: live iPhone/PWA/Cloudflare Access flow is still unverified because this PR does not deploy.
- lesson: Dashboard notification auth must separate normal owner identity from high-risk passkey step-up.
- should become RAG candidate: はい。Issue #536 の live E2E 後に判断。

## Verification Evidence

- Unit: node --test test/deploy-production-plane.test.js test/passkey-operator-page.test.js test/worker.test.js (225 tests passed)
- Integration: npm run check:generated-worker (passed)
- E2E: 未実施。Cloudflare deploy and iPhone/PWA notification tap live E2E are required before Issue #536 completion.
- Manual: git diff --check (passed before commit); git status clean before PR creation.
- Evidence path/link: local command output in this Codex session

## Butler Completion Contract

- Owner goal: Butler notification tap should open a safe Access-first Dashboard surface without requiring passkey for normal viewing, while preventing pre-auth leakage.
- Butler entrypoint: Notification deep link to `/dashboard/...`, especially `/dashboard/notifications`, then Worker dashboard auth gate.
- Action Schema exposure: 不要。このPRは Custom GPT Action Schema / tool exposure を変更しない。
- Runtime path: Cloudflare Worker `src/worker/runtime.js`: `isDashboardPagePath` auth gate -> `authorizeDashboardRequest` -> `renderDashboardAuthRequiredPage`; generated `worker.js` updated.
- Runner/runtime truth: Worker tests verify 401/auth page behavior, stale passkey fallback reason, and absence of private notification fields before auth.
- Authority boundary: 通常 dashboard view/chat/notification entry は Cloudflare Access owner identity。Passkey は fallback and high-risk step-up only. Deploy/credential/permission mutationなし。
- E2E evidence: 未実施。Butler-facing live E2E は deploy 後に iPhone/iPad PWA notification tapで確認が必要。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 必要だがこのPRでは未実施。production observation requires a later scoped deploy/passkey approval if applicable.
- Custom GPT Action Schema update: 不要。Action operationId/schema is unchanged.
- Custom GPT Instructions update: 不要。このPRは Dashboard auth runtime behavior only.
- iPhone Butler live E2E: 未実施。Issue #536 completionには必要。

## Related Constitution Rules

- Butler Completion Gate: runtime path and E2E evidence must be explicit; this PR remains incomplete without live Butler E2E.
- Authority Boundary: deploy/credential/permission mutation not authorized or performed.
- Conversation UX Contract: normal owner operation must not require raw paths/JSON; notification tap remains a natural entrypoint.
- Safety Invariants: high-risk actions require scoped passkey approval; no default repository or credential model changes.

## Out-of-scope but NOT implemented

- Web Push payload redesign / notification payload minimization work tracked separately (#514).
- Dashboard Butler full ChatGPT parity and recovery UX.
- Cloudflare production deployment and live iPhone/iPad notification E2E.
- Custom GPT Action Schema / instruction auto-update path.

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #536
- Execution ID: codex-issue-536-notification-access-first-2026-05-26
- Goal: Dashboard Butler notification tap auth should be Access-first, passkey fallback/high-risk only, with no pre-auth notification detail leakage.
