### PR TITLE
fix: strip Dashboard auth return query before auth

### DIFF
--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -11578,7 +11578,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
 
 function renderDashboardAuthRequiredPage({ runtimeOrigin, returnPath = "/dashboard", reason, passkeyFallbackReason } = {}) {
   const origin = normalizeText(runtimeOrigin);
-  const dashboardAccessHref = `${origin || ""}${sanitizeDashboardReturnPath(returnPath)}`;
+  const dashboardAccessHref = `${origin || ""}${sanitizeDashboardPreAuthReturnPath(returnPath)}`;
   const dashboardSignInUrl = `${origin || ""}/v2/approval/passkey/operator?mode=dashboard&repositoryInput=marushu%2Fvtdd-v2-p&phase=execution&actionType=read&highRiskKind=dashboard_access`;
   return `<!doctype html>
 <html lang="ja">
@@ -11624,7 +11624,7 @@ function renderDashboardAuthRequiredPage({ runtimeOrigin, returnPath = "/dashboa
 </html>`;
 }
 
-function sanitizeDashboardReturnPath(value) {
+function sanitizeDashboardPreAuthReturnPath(value) {
   const normalized = normalizeText(value) || "/dashboard";
   let parsed;
   try {
@@ -11638,7 +11638,7 @@ function sanitizeDashboardReturnPath(value) {
   if (parsed.pathname !== "/dashboard" && !parsed.pathname.startsWith("/dashboard/")) {
     return "/dashboard";
   }
-  return `${parsed.pathname}${parsed.search}`;
+  return parsed.pathname;
 }
 
 function renderV2StatusPage({ runtimeOrigin, autonomyMode }) {

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -885,7 +885,9 @@ test("worker does not expose dashboard notification details before Access auth",
   });
 
   const response = await worker.fetch(
-    new Request("https://example.com/dashboard/notifications"),
+    new Request(
+      "https://example.com/dashboard/notifications?runId=private-run&title=private%20deploy%20notification&sha=privateabcdef1234567890"
+    ),
     { DASHBOARD_EVENT_STORE: store }
   );
 
@@ -893,6 +895,10 @@ test("worker does not expose dashboard notification details before Access auth",
   const body = await response.text();
   assert.equal(body.includes("Dashboard auth required"), true);
   assert.equal(body.includes("Cloudflare Access で開く"), true);
+  assert.equal(body.includes('href="https://example.com/dashboard/notifications"'), true);
+  assert.equal(body.includes("?runId="), false);
+  assert.equal(body.includes("title="), false);
+  assert.equal(body.includes("sha="), false);
   assert.equal(body.includes("private deploy notification"), false);
   assert.equal(body.includes("private-run"), false);
   assert.equal(body.includes("privateabcdef"), false);

--- a/worker.js
+++ b/worker.js
@@ -66381,7 +66381,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
 }
 function renderDashboardAuthRequiredPage({ runtimeOrigin, returnPath = "/dashboard", reason, passkeyFallbackReason } = {}) {
   const origin = normalizeText30(runtimeOrigin);
-  const dashboardAccessHref = `${origin || ""}${sanitizeDashboardReturnPath(returnPath)}`;
+  const dashboardAccessHref = `${origin || ""}${sanitizeDashboardPreAuthReturnPath(returnPath)}`;
   const dashboardSignInUrl = `${origin || ""}/v2/approval/passkey/operator?mode=dashboard&repositoryInput=marushu%2Fvtdd-v2-p&phase=execution&actionType=read&highRiskKind=dashboard_access`;
   return `<!doctype html>
 <html lang="ja">
@@ -66426,7 +66426,7 @@ function renderDashboardAuthRequiredPage({ runtimeOrigin, returnPath = "/dashboa
 </body>
 </html>`;
 }
-function sanitizeDashboardReturnPath(value) {
+function sanitizeDashboardPreAuthReturnPath(value) {
   const normalized = normalizeText30(value) || "/dashboard";
   let parsed;
   try {
@@ -66440,7 +66440,7 @@ function sanitizeDashboardReturnPath(value) {
   if (parsed.pathname !== "/dashboard" && !parsed.pathname.startsWith("/dashboard/")) {
     return "/dashboard";
   }
-  return `${parsed.pathname}${parsed.search}`;
+  return parsed.pathname;
 }
 function renderV2StatusPage({ runtimeOrigin, autonomyMode }) {
   const origin = normalize7(runtimeOrigin);


### PR DESCRIPTION
## This PR satisfies Intent

- PR #543 の reviewer request_changes に対する hotfix。未認証 Dashboard 401 HTML の Cloudflare Access link に notification deep-link query を残さず、pre-auth detail leak を塞ぐ。
- Issue #536 の部分進捗として、通知tap時の外部漏れ防止を優先する。

## Satisfied Success Criteria

- `sanitizeDashboardReturnPath` が `/dashboard` 配下の pathname のみを返し、query string を pre-auth HTML に出さない。
- `/dashboard/notifications?runId=...&title=...&sha=...` 未認証レスポンスに query key/value と notification detail が出ない worker test を追加した。
- PR #543 の request_changes 重要指摘を直接対象にした。

## Unsatisfied Success Criteria

- Cloudflare deploy は実施していない。
- iPhone / iPad PWA notification tap live E2E は未実施。
- Issue #536 全体の Dashboard Butler UX / recovery / ChatGPT parity はこの PR だけでは完了しない。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #536; PR #543 reviewer request_changes
- Implementing Success Criteria: pre-auth Dashboard auth page must not leak notification/event detail via return path query while keeping Access-first auth and passkey fallback boundary.
- Explicit Non-goals: Deploy, Issue close, Dashboard UI redesign, Web Push payload redesign (#514), credential/permission mutation.
- Expected touched files/routes/workflows: src/worker/runtime.js, worker.js, test/worker.test.js
- Affected Issues: Issue #536; related but not implemented: #514.
- Affected PRs: PR #543 already merged with unresolved reviewer request_changes; this PR remediates that specific blocker.
- Affected workflows: No workflow files changed. Deploy-production remains blocked until merge + scoped passkey approval.
- Affected runtime/operator surfaces: Cloudflare Worker Dashboard pre-auth auth page and notification deep-link entry.
- What may break if we patch narrowly: If only event store output is tested, query-string leakage through auth return links remains invisible. This PR tests query-bearing notification URL directly.
- Unknowns to investigate before coding: Live Cloudflare Access redirect behavior and iPhone/PWA notification tap remain deploy-time E2E unknowns.
- Validation needed: node --test test/worker.test.js; node --test test/deploy-production-plane.test.js test/passkey-operator-page.test.js test/worker.test.js; npm run check:generated-worker; git diff --check.
- Stop condition: If fixing the leak requires deploy, credential mutation, permission mutation, or weakening passkey high-risk approval, stop.

## File / Line Hypotheses

- file: `src/worker/runtime.js`
  - hypothesis: `sanitizeDashboardReturnPath` preserves `parsed.search`, so `/dashboard/notifications?...` leaks query detail through the Access link before auth.
  - risk if changed narrowly: legitimate same-origin Dashboard paths could be blocked; notification page path should still be preserved without query.
  - validation: query-bearing notification pre-auth worker test.
  - related Issue: #536 / PR #543 reviewer request_changes

## Hypothesis Retrospective

- expected: pre-auth 401 HTML keeps `/dashboard/notifications` but drops `runId`, `title`, and `sha` query values.
- actual: local worker test verifies the Access href is path-only and query/detail strings are absent.
- mismatch: no live deploy/iPhone E2E yet.
- lesson: reviewer comments with `request_changes` must be treated as stop-role even when GitHub `reviewDecision` is empty.
- should become RAG candidate: はい。Reviewer-as-stop-role failure and remediation should be captured after this PR.

## Verification Evidence

- Unit: node --test test/worker.test.js (198 tests passed); node --test test/deploy-production-plane.test.js test/passkey-operator-page.test.js test/worker.test.js (225 tests passed)
- Integration: npm run check:generated-worker (passed after commit)
- E2E: 未実施。Cloudflare deploy and iPhone/PWA notification tap live E2E remain required before Issue #536 completion.
- Manual: git diff --check (passed); verified no new deploy-production run for merge commit c76a3e4 before hotfix.
- Evidence path/link: local command output in this Codex session

## Butler Completion Contract

- Owner goal: Notification deep links should not force passkey for normal viewing and must not leak notification details before owner auth.
- Butler entrypoint: Notification deep link to `/dashboard/notifications` with possible query parameters, then Worker dashboard auth gate.
- Action Schema exposure: 不要。このPRは Custom GPT Action Schema / tool exposure を変更しない。
- Runtime path: Cloudflare Worker `src/worker/runtime.js`: dashboard auth page return href sanitization; generated `worker.js` updated.
- Runner/runtime truth: Worker tests verify path-only Access href and absence of query/detail strings before auth.
- Authority boundary: 通常 dashboard view/chat/notification entry remains Cloudflare Access owner identity; Passkey remains fallback/high-risk step-up only. Deploy/credential/permission mutationなし。
- E2E evidence: 未実施。Butler-facing live E2E は deploy 後に iPhone/iPad PWA notification tapで確認が必要。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 必要だがこのPRでは未実施。PR #543 merged code must not be deployed until this hotfix is merged and reviewed.
- Custom GPT Action Schema update: 不要。Action operationId/schema is unchanged.
- Custom GPT Instructions update: 不要。このPRは Dashboard auth runtime behavior only.
- iPhone Butler live E2E: 未実施。Issue #536 completionには必要。

## Related Constitution Rules

- Reviewer as Stop Role: request_changes must block merge/deploy until addressed.
- Butler Completion Gate: this PR remains incomplete without live Butler E2E.
- Authority Boundary: deploy/credential/permission mutation not performed.
- Safety Invariants: high-risk actions require scoped passkey approval; pre-auth dashboard must not leak details.

## Out-of-scope but NOT implemented

- Cloudflare deploy and production live E2E.
- Dashboard Butler full ChatGPT parity/recovery UX.
- Web Push payload redesign / notification payload minimization work tracked separately (#514).
- Custom GPT Action Schema / Instructions update path.

## Extra changes (if any)

This PR is a remediation for mistakenly merging PR #543 after a codex-fallback reviewer `request_changes` comment appeared.

<!-- VTDD metadata -->
- Issue: Issue #536
- Execution ID: codex-issue-536-strip-preauth-return-query-2026-05-26
- Goal: Remediate PR #543 reviewer blocker by stripping notification deep-link query from unauthenticated Dashboard auth HTML.
