### PR TITLE
fix: start Dashboard Cloudflare Access login

### DIFF
--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -11573,7 +11573,8 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
 
 function renderDashboardAuthRequiredPage({ runtimeOrigin, returnPath = "/dashboard", reason, passkeyFallbackReason } = {}) {
   const origin = normalizeText(runtimeOrigin);
-  const dashboardAccessHref = `${origin || ""}${sanitizeDashboardPreAuthReturnPath(returnPath)}`;
+  const dashboardAccessReturnPath = sanitizeDashboardPreAuthReturnPath(returnPath);
+  const dashboardAccessHref = buildCloudflareAccessLoginHref({ origin, returnPath: dashboardAccessReturnPath });
   const dashboardSignInUrl = `${origin || ""}/v2/approval/passkey/operator?mode=dashboard&repositoryInput=marushu%2Fvtdd-v2-p&phase=execution&actionType=read&highRiskKind=dashboard_access`;
   return `<!doctype html>
 <html lang="ja">
@@ -11617,6 +11618,13 @@ function renderDashboardAuthRequiredPage({ runtimeOrigin, returnPath = "/dashboa
   </main>
 </body>
 </html>`;
+}
+
+function buildCloudflareAccessLoginHref({ origin, returnPath = "/dashboard" } = {}) {
+  const normalizedOrigin = normalizeText(origin);
+  const sanitizedReturnPath = sanitizeDashboardPreAuthReturnPath(returnPath);
+  const redirectUrl = normalizedOrigin ? `${normalizedOrigin}${sanitizedReturnPath}` : sanitizedReturnPath;
+  return `${normalizedOrigin || ""}/cdn-cgi/access/login?redirect_url=${encodeURIComponent(redirectUrl)}`;
 }
 
 function sanitizeDashboardPreAuthReturnPath(value) {

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -779,6 +779,12 @@ test("worker rejects dashboard access without owner identity", async () => {
   assert.equal(body.includes("Dashboard auth required"), true);
   assert.equal(body.includes("owner-facing surface"), true);
   assert.equal(body.includes("Cloudflare Access で開く"), true);
+  assert.equal(
+    body.includes(
+      'href="https://example.com/cdn-cgi/access/login?redirect_url=https%3A%2F%2Fexample.com%2Fdashboard"'
+    ),
+    true
+  );
   assert.equal(body.includes("Passkey fallback"), true);
   assert.equal(body.includes("Passkey で dashboard に入る"), false);
   assert.equal(body.includes("未認証の相手に通知詳細や Dashboard 内容は返しません"), true);
@@ -862,6 +868,12 @@ test("worker rejects stale dashboard passkey session cookies", async () => {
   const body = await response.text();
   assert.equal(body.includes("Cloudflare Access authenticated owner identity is required"), true);
   assert.equal(body.includes("Cloudflare Access で開く"), true);
+  assert.equal(
+    body.includes(
+      'href="https://example.com/cdn-cgi/access/login?redirect_url=https%3A%2F%2Fexample.com%2Fdashboard"'
+    ),
+    true
+  );
   assert.equal(body.includes("Passkey fallback"), true);
   assert.equal(body.includes("dashboard passkey session was not found"), true);
   assert.equal(body.includes("Passkey で dashboard に入る"), false);
@@ -895,7 +907,13 @@ test("worker does not expose dashboard notification details before Access auth",
   const body = await response.text();
   assert.equal(body.includes("Dashboard auth required"), true);
   assert.equal(body.includes("Cloudflare Access で開く"), true);
-  assert.equal(body.includes('href="https://example.com/dashboard/notifications"'), true);
+  assert.equal(
+    body.includes(
+      'href="https://example.com/cdn-cgi/access/login?redirect_url=https%3A%2F%2Fexample.com%2Fdashboard%2Fnotifications"'
+    ),
+    true
+  );
+  assert.equal(body.includes('href="https://example.com/dashboard/notifications"'), false);
   assert.equal(body.includes("?runId="), false);
   assert.equal(body.includes("title="), false);
   assert.equal(body.includes("sha="), false);

--- a/worker.js
+++ b/worker.js
@@ -66376,7 +66376,8 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
 }
 function renderDashboardAuthRequiredPage({ runtimeOrigin, returnPath = "/dashboard", reason, passkeyFallbackReason } = {}) {
   const origin = normalizeText30(runtimeOrigin);
-  const dashboardAccessHref = `${origin || ""}${sanitizeDashboardPreAuthReturnPath(returnPath)}`;
+  const dashboardAccessReturnPath = sanitizeDashboardPreAuthReturnPath(returnPath);
+  const dashboardAccessHref = buildCloudflareAccessLoginHref({ origin, returnPath: dashboardAccessReturnPath });
   const dashboardSignInUrl = `${origin || ""}/v2/approval/passkey/operator?mode=dashboard&repositoryInput=marushu%2Fvtdd-v2-p&phase=execution&actionType=read&highRiskKind=dashboard_access`;
   return `<!doctype html>
 <html lang="ja">
@@ -66420,6 +66421,12 @@ function renderDashboardAuthRequiredPage({ runtimeOrigin, returnPath = "/dashboa
   </main>
 </body>
 </html>`;
+}
+function buildCloudflareAccessLoginHref({ origin, returnPath = "/dashboard" } = {}) {
+  const normalizedOrigin = normalizeText30(origin);
+  const sanitizedReturnPath = sanitizeDashboardPreAuthReturnPath(returnPath);
+  const redirectUrl = normalizedOrigin ? `${normalizedOrigin}${sanitizedReturnPath}` : sanitizedReturnPath;
+  return `${normalizedOrigin || ""}/cdn-cgi/access/login?redirect_url=${encodeURIComponent(redirectUrl)}`;
 }
 function sanitizeDashboardPreAuthReturnPath(value) {
   const normalized = normalizeText30(value) || "/dashboard";


### PR DESCRIPTION
## This PR satisfies Intent

- #534 Dashboard Butler のlive利用を妨げていた auth failure page の Access導線を修正します。\n関連 #536 のAccess-first境界を維持しつつ、未認証時の `Cloudflare Access で開く` が同じ401ページではなく Access login endpoint を開くようにします。

## Satisfied Success Criteria

- Dashboard auth failure page の primary button は `/cdn-cgi/access/login?redirect_url=...` へ向きます。\nredirect_url は `sanitizeDashboardPreAuthReturnPath` 後の安全なpathだけを使います。\n通知deep-linkの `runId/title/sha` は引き続き未認証HTMLに出しません。\nstale passkey cookie + no Access のfallback表示も Access login endpoint を使います。\nCloudflare Access成功時は既存のAccess-first Dashboard閲覧を維持します。\nhigh-risk deploy/merge/secret境界は変更しません。

## Unsatisfied Success Criteria

- Cloudflare deploy とiPhone live確認は未実施です。deployには別途 passkey approval が必要です。\n#534 のIssue close判断は未実施です。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #534; related closed Issue #536 regression.
- Implementing Success Criteria: Dashboard auth failure page のAccess buttonをログイン開始URLへ変更し、pre-auth query漏えいを防いだまま通常Dashboardへ戻す。
- Explicit Non-goals: Cloudflare Access policy変更、deploy、credential/permission mutation、passkey境界変更、通知UI追加改修、Issue close。
- Expected touched files/routes/workflows: src/worker/runtime.js, worker.js, test/worker.test.js
- Affected Issues: Issue #534 in scope; Issue #536 related auth boundary regression.
- Affected PRs: New hotfix PR only; follows merged PR #545.
- Affected workflows: guarded-autonomy-required-checks, gemini-pr-review.
- Affected runtime/operator surfaces: Dashboard auth failure page only; `/dashboard` and `/dashboard/notifications` pre-auth HTML.
- What may break if we patch narrowly: Access URL形式がCloudflare側仕様と異なる場合、live確認で再修正が必要。query漏えい再発を避けるためredirect_urlは安全化済みpathだけに限定。
- Unknowns to investigate before coding: Production Access endpointの実機挙動はdeploy後live確認が必要。
- Validation needed: worker auth tests, generated worker parity, self parity, deploy/passkey regression tests.
- Stop condition: Access login URLが本番で起動しない、またはpre-auth通知詳細が再露出する場合は停止して再設計。

## File / Line Hypotheses

- file: `src/worker/runtime.js`\n  - hypothesis: `renderDashboardAuthRequiredPage` の primary link が sanitized Dashboard path を直接指しているため、未認証時にAccessログイン開始ではなく同じ401画面へ戻る。\n  - validation: auth failure HTML tests assert `/cdn-cgi/access/login?redirect_url=...` and no direct dashboard notification href.\n  - related Issue: #534 / #536

## Hypothesis Retrospective

- expected: primary auth button starts Cloudflare Access login while preserving #544 leak fix.\n- actual: button href now uses same-origin `/cdn-cgi/access/login` with an encoded sanitized redirect_url.\n- mismatch: none in local tests; production live still pending.\n- lesson: pre-auth leak prevention must not remove the actual Access login transition.\n- should become RAG candidate: yes, Access auth recovery link must be tested as a login-start URL, not just as a safe return path.

## Verification Evidence

- Unit: `node --test test/worker.test.js` passed: 199 tests.\n`node --test test/deploy-production-plane.test.js test/passkey-operator-page.test.js test/worker.test.js` passed: 226 tests.
- Integration: `npm run check:generated-worker` passed.\n`npm run check:self-parity` passed.\n`git diff --check` passed.
- E2E: Local HTTP/render tests prove auth failure HTML emits Access login endpoint and does not leak notification query. Production/iPhone live E2E is pending deploy.
- Manual: None.
- Evidence path/link: src/worker/runtime.js; test/worker.test.js; worker.js; PR checks.

## Butler Completion Contract

- Owner goal: Owner can tap Dashboard/notification auth button and actually begin Cloudflare Access login instead of looping on the auth required page.
- Butler entrypoint: `/dashboard` and `/dashboard/notifications` auth failure page.
- Action Schema exposure: 不要。Custom GPT Action Schema変更なし。
- Runtime path: Worker pre-auth Dashboard HTML route through `renderDashboardAuthRequiredPage`.
- Runner/runtime truth: HTML tests assert before/after observable href and leak boundary.
- Authority boundary: 未変更。通常閲覧はCloudflare Access owner identity; high-risk operations still require scoped passkey approval.
- E2E evidence: Pending production/iPhone live E2E after deploy. Local render evidence included in tests.
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 未実施。このPR後、deployするなら scoped passkey approval が必要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。今回のPRはdeploy前hotfix。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate\nAGENTS.md Authority Boundary\nAGENTS.md Evidence Discipline\nAGENTS.md Issue Lifecycle Gate

## Out-of-scope but NOT implemented

- Cloudflare Access policy changes.\nPasskey boundary changes.\nIssue #534 close.\nDeploy/live verification.

## Extra changes (if any)

ユーザー報告: `Cloudflare Access で開く` が開けない。原因はリンクがログイン開始ではなく安全化済みDashboard pathへ戻っていたこと。

<!-- VTDD metadata -->
- Issue: Issue #534
- Execution ID: mac_codex_only_probe-pr-access-login-link
- Goal: Fix Dashboard auth primary link without regressing pre-auth notification detail redaction.
