### PR TITLE
Fix deploy passkey scope guard

### DIFF
--- a/src/core/passkey-operator-page.js
+++ b/src/core/passkey-operator-page.js
@@ -12,8 +12,12 @@ export function renderPasskeyOperatorPage(input = {}) {
   const issueDefault = escapeHtml(input.issueNumber || "");
   const pullNumberDefault = escapeHtml(input.pullNumber || "");
   const phaseDefault = escapeHtml(input.phase || "execution");
-  const actionTypeDefault = escapeHtml(input.actionType || defaultActionTypeForMode(operatorMode));
-  const highRiskKindDefault = escapeHtml(input.highRiskKind || defaultHighRiskKindForMode(operatorMode));
+  const actionTypeDefault = escapeHtml(
+    deployOneTapMode ? "deploy_production" : input.actionType || defaultActionTypeForMode(operatorMode)
+  );
+  const highRiskKindDefault = escapeHtml(
+    deployOneTapMode ? "deploy_production" : input.highRiskKind || defaultHighRiskKindForMode(operatorMode)
+  );
   const mergeMethodDefault = escapeHtml(input.mergeMethod || "squash");
   const returnUrl = escapeHtml(input.returnUrl || "");
   const githubAppRoleDefault = escapeHtml(input.githubAppRole || "legacy");
@@ -211,9 +215,9 @@ export function renderPasskeyOperatorPage(input = {}) {
             <label for="phase-input">Phase</label>
             <input id="phase-input" value="${phaseDefault}" />
             <label for="action-type-input">Action Type</label>
-            <input id="action-type-input" value="${actionTypeDefault}" />
+            <input id="action-type-input" value="${actionTypeDefault}" autocomplete="off"${deployOneTapMode ? ' readonly data-deploy-scope-locked="true"' : ""} />
             <label for="risk-kind-input">High-risk Kind</label>
-            <input id="risk-kind-input" value="${highRiskKindDefault}" />
+            <input id="risk-kind-input" value="${highRiskKindDefault}" autocomplete="off"${deployOneTapMode ? ' readonly data-deploy-scope-locked="true"' : ""} />
           </div>`
               : `<label for="repo-input">Repository</label>
           <input id="repo-input" value="${repoDefault}" placeholder="marushu/vtdd-v2-p" />
@@ -363,6 +367,7 @@ export function renderPasskeyOperatorPage(input = {}) {
       const issueCloseLink = document.getElementById("issue-close-link");
       const operatorMode = "${escapeHtml(operatorMode)}";
       let latestApprovalGrantId = "";
+      let latestApprovalGrant = null;
 
       async function readResponseBody(response) {
         const contentType = response.headers.get("content-type") || "";
@@ -589,10 +594,17 @@ export function renderPasskeyOperatorPage(input = {}) {
         return readNumberInput("pull-number-input");
       }
 
-      function applyOperatorModeDefaults() {
+      function forceDeployApprovalScope() {
         if (operatorMode === "deploy") {
           document.getElementById("action-type-input").value = "deploy_production";
           document.getElementById("risk-kind-input").value = "deploy_production";
+          return true;
+        }
+        return false;
+      }
+
+      function applyOperatorModeDefaults() {
+        if (forceDeployApprovalScope()) {
           return;
         }
         if (operatorMode === "dashboard") {
@@ -602,10 +614,27 @@ export function renderPasskeyOperatorPage(input = {}) {
       }
 
       function shouldAutoDispatchProductionDeploy() {
-        applyOperatorModeDefaults();
+        forceDeployApprovalScope();
         return operatorMode === "deploy" &&
           document.getElementById("action-type-input").value === "deploy_production" &&
           document.getElementById("risk-kind-input").value === "deploy_production";
+      }
+
+      function approvalGrantHasDeployScope(approvalGrant) {
+        const scope = approvalGrant?.scope || {};
+        return scope.actionType === "deploy_production" &&
+          scope.highRiskKind === "deploy_production";
+      }
+
+      function requireDeployApprovalGrantScope() {
+        if (operatorMode !== "deploy") {
+          return;
+        }
+        forceDeployApprovalScope();
+        if (!approvalGrantHasDeployScope(latestApprovalGrant)) {
+          latestApprovalGrantId = "";
+          throw new Error("deploy 用の承認ではありません。パスキーで production deploy を再承認してください。");
+        }
       }
 
       async function dispatchProductionDeploy({ source = "manual" } = {}) {
@@ -613,6 +642,7 @@ export function renderPasskeyOperatorPage(input = {}) {
         if (!latestApprovalGrantId) {
           throw new Error("approvalGrantId is required before production deploy");
         }
+        requireDeployApprovalGrantScope();
         const repositoryInput = readRequiredRepositoryInput();
         clearDeployRunLink();
         deployOutput.textContent = source === "approval"
@@ -734,7 +764,8 @@ export function renderPasskeyOperatorPage(input = {}) {
           if (!verifyResponse.ok) {
             throw responseError(verifyBody, "approval verify failed");
           }
-          latestApprovalGrantId = verifyBody?.approvalGrant?.approvalId || verifyBody?.approvalGrantId || "";
+          latestApprovalGrant = verifyBody?.approvalGrant || null;
+          latestApprovalGrantId = latestApprovalGrant?.approvalId || verifyBody?.approvalGrantId || "";
           approveOutput.textContent = JSON.stringify(verifyBody, null, 2);
           if (operatorMode === "dashboard") {
             window.location.assign("/dashboard");

--- a/test/passkey-operator-page.test.js
+++ b/test/passkey-operator-page.test.js
@@ -151,11 +151,17 @@ test("passkey operator page focuses deploy mode on deploy approval and dispatch 
   assert.equal(html.includes('repository: repositoryInput'), true);
   assert.equal(html.includes("function shouldAutoDispatchProductionDeploy()"), true);
   assert.equal(html.includes("function applyOperatorModeDefaults()"), true);
+  assert.equal(html.includes("function forceDeployApprovalScope()"), true);
+  assert.equal(html.includes("function requireDeployApprovalGrantScope()"), true);
+  assert.equal(html.includes("function approvalGrantHasDeployScope(approvalGrant)"), true);
   assert.equal(html.includes('document.getElementById("action-type-input").value = "deploy_production"'), true);
   assert.equal(html.includes('document.getElementById("risk-kind-input").value = "deploy_production"'), true);
+  assert.equal(html.includes('data-deploy-scope-locked="true"'), true);
   assert.equal(html.includes("applyOperatorModeDefaults();"), true);
   assert.equal(html.includes("const repositoryInput = readRequiredRepositoryInput();"), true);
   assert.equal(html.includes("if (!latestApprovalGrantId)"), true);
+  assert.equal(html.includes("requireDeployApprovalGrantScope();"), true);
+  assert.equal(html.includes("deploy 用の承認ではありません。パスキーで production deploy を再承認してください。"), true);
   assert.equal(html.includes("return operatorMode === \"deploy\""), true);
   assert.equal(html.includes('operatorMode === "deploy"'), true);
   assert.equal(html.includes('document.getElementById("action-type-input").value === "deploy_production"'), true);
@@ -177,6 +183,24 @@ test("passkey operator page blocks approval and deploy before repositoryInput is
   assert.equal(html.includes("Deploy does not require issueNumber or pullNumber"), true);
   assert.equal(html.includes("repository: repositoryInput"), true);
   assert.equal(html.includes("async function dispatchProductionDeploy"), true);
+});
+
+test("passkey operator deploy mode ignores stale action scope from restored input", () => {
+  const html = renderPasskeyOperatorPage({
+    operatorMode: "deploy",
+    repositoryInput: "marushu/vtdd-v2-p",
+    actionType: "merge",
+    highRiskKind: "pull_merge"
+  });
+
+  assert.equal(html.includes('id="action-type-input" value="deploy_production"'), true);
+  assert.equal(html.includes('id="risk-kind-input" value="deploy_production"'), true);
+  assert.equal(html.includes('id="action-type-input" value="merge"'), false);
+  assert.equal(html.includes('id="risk-kind-input" value="pull_merge"'), false);
+  assert.equal(html.includes('autocomplete="off" readonly data-deploy-scope-locked="true"'), true);
+  assert.equal(html.includes('highRiskKind: document.getElementById("risk-kind-input").value'), true);
+  assert.equal(html.includes('actionType: document.getElementById("action-type-input").value'), true);
+  assert.equal(html.includes("forceDeployApprovalScope();"), true);
 });
 
 test("passkey operator page fills safe approval defaults from explicit mode", () => {

--- a/worker.js
+++ b/worker.js
@@ -27257,8 +27257,12 @@ function renderPasskeyOperatorPage(input = {}) {
   const issueDefault = escapeHtml(input.issueNumber || "");
   const pullNumberDefault = escapeHtml(input.pullNumber || "");
   const phaseDefault = escapeHtml(input.phase || "execution");
-  const actionTypeDefault = escapeHtml(input.actionType || defaultActionTypeForMode(operatorMode));
-  const highRiskKindDefault = escapeHtml(input.highRiskKind || defaultHighRiskKindForMode(operatorMode));
+  const actionTypeDefault = escapeHtml(
+    deployOneTapMode ? "deploy_production" : input.actionType || defaultActionTypeForMode(operatorMode)
+  );
+  const highRiskKindDefault = escapeHtml(
+    deployOneTapMode ? "deploy_production" : input.highRiskKind || defaultHighRiskKindForMode(operatorMode)
+  );
   const mergeMethodDefault = escapeHtml(input.mergeMethod || "squash");
   const returnUrl = escapeHtml(input.returnUrl || "");
   const githubAppRoleDefault = escapeHtml(input.githubAppRole || "legacy");
@@ -27448,9 +27452,9 @@ function renderPasskeyOperatorPage(input = {}) {
             <label for="phase-input">Phase</label>
             <input id="phase-input" value="${phaseDefault}" />
             <label for="action-type-input">Action Type</label>
-            <input id="action-type-input" value="${actionTypeDefault}" />
+            <input id="action-type-input" value="${actionTypeDefault}" autocomplete="off"${deployOneTapMode ? ' readonly data-deploy-scope-locked="true"' : ""} />
             <label for="risk-kind-input">High-risk Kind</label>
-            <input id="risk-kind-input" value="${highRiskKindDefault}" />
+            <input id="risk-kind-input" value="${highRiskKindDefault}" autocomplete="off"${deployOneTapMode ? ' readonly data-deploy-scope-locked="true"' : ""} />
           </div>` : `<label for="repo-input">Repository</label>
           <input id="repo-input" value="${repoDefault}" placeholder="marushu/vtdd-v2-p" />
           <label for="issue-input">Issue Number</label>
@@ -27594,6 +27598,7 @@ function renderPasskeyOperatorPage(input = {}) {
       const issueCloseLink = document.getElementById("issue-close-link");
       const operatorMode = "${escapeHtml(operatorMode)}";
       let latestApprovalGrantId = "";
+      let latestApprovalGrant = null;
 
       async function readResponseBody(response) {
         const contentType = response.headers.get("content-type") || "";
@@ -27820,10 +27825,17 @@ function renderPasskeyOperatorPage(input = {}) {
         return readNumberInput("pull-number-input");
       }
 
-      function applyOperatorModeDefaults() {
+      function forceDeployApprovalScope() {
         if (operatorMode === "deploy") {
           document.getElementById("action-type-input").value = "deploy_production";
           document.getElementById("risk-kind-input").value = "deploy_production";
+          return true;
+        }
+        return false;
+      }
+
+      function applyOperatorModeDefaults() {
+        if (forceDeployApprovalScope()) {
           return;
         }
         if (operatorMode === "dashboard") {
@@ -27833,10 +27845,27 @@ function renderPasskeyOperatorPage(input = {}) {
       }
 
       function shouldAutoDispatchProductionDeploy() {
-        applyOperatorModeDefaults();
+        forceDeployApprovalScope();
         return operatorMode === "deploy" &&
           document.getElementById("action-type-input").value === "deploy_production" &&
           document.getElementById("risk-kind-input").value === "deploy_production";
+      }
+
+      function approvalGrantHasDeployScope(approvalGrant) {
+        const scope = approvalGrant?.scope || {};
+        return scope.actionType === "deploy_production" &&
+          scope.highRiskKind === "deploy_production";
+      }
+
+      function requireDeployApprovalGrantScope() {
+        if (operatorMode !== "deploy") {
+          return;
+        }
+        forceDeployApprovalScope();
+        if (!approvalGrantHasDeployScope(latestApprovalGrant)) {
+          latestApprovalGrantId = "";
+          throw new Error("deploy \u7528\u306E\u627F\u8A8D\u3067\u306F\u3042\u308A\u307E\u305B\u3093\u3002\u30D1\u30B9\u30AD\u30FC\u3067 production deploy \u3092\u518D\u627F\u8A8D\u3057\u3066\u304F\u3060\u3055\u3044\u3002");
+        }
       }
 
       async function dispatchProductionDeploy({ source = "manual" } = {}) {
@@ -27844,6 +27873,7 @@ function renderPasskeyOperatorPage(input = {}) {
         if (!latestApprovalGrantId) {
           throw new Error("approvalGrantId is required before production deploy");
         }
+        requireDeployApprovalGrantScope();
         const repositoryInput = readRequiredRepositoryInput();
         clearDeployRunLink();
         deployOutput.textContent = source === "approval"
@@ -27965,7 +27995,8 @@ function renderPasskeyOperatorPage(input = {}) {
           if (!verifyResponse.ok) {
             throw responseError(verifyBody, "approval verify failed");
           }
-          latestApprovalGrantId = verifyBody?.approvalGrant?.approvalId || verifyBody?.approvalGrantId || "";
+          latestApprovalGrant = verifyBody?.approvalGrant || null;
+          latestApprovalGrantId = latestApprovalGrant?.approvalId || verifyBody?.approvalGrantId || "";
           approveOutput.textContent = JSON.stringify(verifyBody, null, 2);
           if (operatorMode === "dashboard") {
             window.location.assign("/dashboard");


### PR DESCRIPTION
## This PR satisfies Intent

- #522: production deploy 用 passkey operator の `mode=deploy` が stale form state / wrong grant scope を production deploy に流さないようにする部分実装です。
- owner が iPhone/PWA で passkey 承認後、そのまま deploy へ進める前提の scope guard を固めます。

## Satisfied Success Criteria

- `mode=deploy` の初期 HTML で stale `actionType` / `highRiskKind` を採用せず `deploy_production` に固定します。
- deploy approval 前に `forceDeployApprovalScope()` を通し、challenge payload が `deploy_production` scope を読む状態へ補正します。
- dispatch 前に verify 後の `approvalGrant.scope` を確認し、deploy scope でない場合は日本語の再承認エラーで停止します。
- deploy mode では copy / paste grant 導線を使わず、verify 後の grant から自動 dispatch する既存導線を維持します。
- Unit/HTML test で stale input 補正と deploy scope guard の存在を確認します。

## Unsatisfied Success Criteria

- production deploy operator の iPhone/PWA live E2E は未実施です。
- Cloudflare production deploy は未実施です。
- code merged / Issue close は未完了です。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #522
- Implementing Success Criteria: deploy mode 入力補正、approval challenge 前の deploy scope 強制、dispatch 前の grant scope guard、paste grant 導線への依存回避、unit/html coverage
- Explicit Non-goals: deploy approval なしの production deploy 許可なし。approvalGrantId をチャットへ貼る運用へ戻さない。Cloudflare credential mutation なし。PR #521 の PWA投稿E2E完了判定なし。
- Expected touched files/routes/workflows: `src/core/passkey-operator-page.js`, `test/passkey-operator-page.test.js`, `worker.js`
- Affected Issues: #522。post-merge live E2E では #521/#520 に影響し得ます。
- Affected PRs: なし。新規 PR として作成します。
- Affected workflows: production deploy workflow の dispatch 前 operator guard。GitHub Actions workflow 定義は未変更です。
- Affected runtime/operator surfaces: Passkey Operator / Cloudflare Worker generated bundle。Dashboard Butler / Custom GPT Action Schema は未変更です。
- What may break if we patch narrowly: client-only guard だけに寄せると server-side validation とのズレが残るため、既存 server-side `validateDeployApprovalGrant` は維持し、operator では dispatch 前に追加停止します。
- Unknowns to investigate before coding: Safari/PWA live form restoration の実機再現と production deploy workflow dispatch は post-merge/live E2E で確認が必要です。
- Validation needed: `node --test test/passkey-operator-page.test.js`; `node --test test/worker.test.js`; `npm run check:self-parity`; `npm run check:generated-worker`; post-merge Cloudflare deploy; iPhone/PWA live E2E
- Stop condition: approval scope を緩める必要が出た場合、deploy credential/permission mutation が必要になった場合、Issue #522 外の #521 completion 判定へ踏み込む場合は停止します。

## File / Line Hypotheses

- file: `src/core/passkey-operator-page.js:12`
  - hypothesis: deploy mode の default が `input.actionType` / `input.highRiskKind` を優先すると stale URL/form state を初期 HTML に持ち込みます。
  - risk if changed narrowly: merge/issue_close/full maintenance mode の明示 scope を壊します。
  - validation: deploy mode のみ stale input を無視する HTML test。
  - related Issue: #522
- file: `src/core/passkey-operator-page.js:594`
  - hypothesis: approval challenge/auto dispatch 前に deploy scope を強制すれば PWA form restoration の影響を受けにくくなります。
  - risk if changed narrowly: dashboard mode/read approval の default を上書きします。
  - validation: existing dashboard/full/merge tests plus targeted deploy tests。
  - related Issue: #522
- file: `src/core/passkey-operator-page.js:626`
  - hypothesis: verify 後 grant scope を dispatch 前に確認すれば wrong grant を deploy route に送らず owner-facing に再承認を促せます。
  - risk if changed narrowly: full maintenance view の manual deploy/paste path を意図せず壊します。
  - validation: guard は `operatorMode=deploy` のみに限定し worker tests を通します。
  - related Issue: #522

## Hypothesis Retrospective

- expected: deploy mode だけを固定すれば stale `merge/pull_merge` が deploy approval に混入しません。
- actual: `deployOneTapMode` の初期値固定、`forceDeployApprovalScope()`、`requireDeployApprovalGrantScope()` で operator 側の誤 dispatch を停止できました。
- mismatch: live Safari/PWA での復元挙動と production deploy dispatch は未検証です。
- lesson: server-side scope validation は正しかったため、owner-facing operator が dispatch 前に同じ境界を早く説明する必要がありました。
- should become RAG candidate: live E2E 後に、deploy operator は verify grant scope を client/server 二重で確認する判断を記録候補にします。

## Verification Evidence

- Unit: `node --test test/passkey-operator-page.test.js`: 24 pass
- Integration: `node --test test/worker.test.js`: 200 pass; `npm run check:self-parity`: passed; `npm run check:generated-worker`: passed after commit
- E2E: 未実施。post-merge production deploy と iPhone/PWA live E2E が必要です。
- Manual: 未実施。Cloudflare deploy / iPhone PWA 操作は未実施です。
- Evidence path/link: `src/core/passkey-operator-page.js`; `test/passkey-operator-page.test.js`; `worker.js`; local test output in PR description

## Butler Completion Contract

- Owner goal: iPhone/PWA で passkey 承認した deploy operator が、誤 scope で production deploy を失敗させず、安全に再承認または dispatch できること。
- Butler entrypoint: 未変更。Dashboard/Custom GPT から operator URL を開く既存 deploy recovery path に乗ります。
- Action Schema exposure: 未変更。Action Schema / Custom GPT instruction 更新なし。
- Runtime path: `/v2/operator/passkey?mode=deploy` rendered by Worker passkey operator page; `/v2/approval/passkey/challenge`; `/v2/approval/passkey/verify`; `/v2/action/deploy` dispatch path。
- Runner/runtime truth: local unit/integration only。production runtime truth は post-merge deploy/live E2E まで未確認です。
- Authority boundary: scoped passkey approval の `deploy_production` scope を維持。wrong scope grant は dispatch 前に停止。deploy/credential/permission mutation は未実行です。
- E2E evidence: 未実施。iPhone/PWA で passkey 承認後に deploy dispatch が scope mismatch しないことを post-merge/live で確認します。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 未実施。merge 後に scoped passkey approval が必要です。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。#522 close 前に必要です。

## Related Constitution Rules

- AGENTS.md Authority Boundary
- AGENTS.md Butler Completion Gate
- AGENTS.md Evidence Discipline
- Issue #522 Success Criteria

## Out-of-scope but NOT implemented

- Cloudflare deploy 実行
- Credential / permission mutation
- PR #521 completion 判定
- Issue #522 close

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #522
- Execution ID: mac-codex-issue-522-passkey-scope
- Goal: Issue #522 deploy passkey operator scope guard implementation
