### PR TITLE
Improve notification auth passkey fallback

### DIFF
--- a/src/core/passkey-operator-page.js
+++ b/src/core/passkey-operator-page.js
@@ -20,6 +20,7 @@ export function renderPasskeyOperatorPage(input = {}) {
   );
   const mergeMethodDefault = escapeHtml(input.mergeMethod || "squash");
   const returnUrl = escapeHtml(input.returnUrl || "");
+  const dashboardReturnPath = escapeHtml(sanitizePasskeyDashboardReturnPath(input.dashboardReturnPath));
   const githubAppRoleDefault = escapeHtml(input.githubAppRole || "legacy");
   const syncEnabled = input.syncEnabled === true;
   const syncMessage = escapeHtml(
@@ -768,7 +769,7 @@ export function renderPasskeyOperatorPage(input = {}) {
           latestApprovalGrantId = latestApprovalGrant?.approvalId || verifyBody?.approvalGrantId || "";
           approveOutput.textContent = JSON.stringify(verifyBody, null, 2);
           if (operatorMode === "dashboard") {
-            window.location.assign("/dashboard");
+            window.location.assign("${dashboardReturnPath}");
             return;
           }
           if (latestApprovalGrantId && autoCopyApprovalGrantInput?.checked) {
@@ -1229,6 +1230,23 @@ function normalizeOperatorToken(value) {
   return String(value || "")
     .trim()
     .toLowerCase();
+}
+
+function sanitizePasskeyDashboardReturnPath(value) {
+  const normalized = String(value || "").trim() || "/dashboard";
+  let parsed;
+  try {
+    parsed = new URL(normalized, "https://dashboard.local");
+  } catch {
+    return "/dashboard";
+  }
+  if (parsed.origin !== "https://dashboard.local") {
+    return "/dashboard";
+  }
+  if (parsed.pathname !== "/dashboard" && !parsed.pathname.startsWith("/dashboard/")) {
+    return "/dashboard";
+  }
+  return parsed.pathname;
 }
 
 function escapeHtml(value) {

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -4622,6 +4622,7 @@ function handlePasskeyOperatorPageRequest(request) {
     highRiskKind: requestedHighRiskKind,
     mergeMethod: url.searchParams.get("mergeMethod") || "squash",
     returnUrl: normalizeOperatorReturnUrl(url.searchParams.get("returnUrl")),
+    dashboardReturnPath: sanitizeDashboardPreAuthReturnPath(url.searchParams.get("dashboardReturnPath")),
     operatorId: url.searchParams.get("operatorId") || "vtdd-operator",
     operatorLabel: url.searchParams.get("operatorLabel") || "VTDD Operator",
     githubAppRole: url.searchParams.get("githubAppRole") || "legacy",
@@ -11704,7 +11705,9 @@ function renderDashboardAuthRequiredPage({ runtimeOrigin, returnPath = "/dashboa
   const origin = normalizeText(runtimeOrigin);
   const dashboardAccessReturnPath = sanitizeDashboardPreAuthReturnPath(returnPath);
   const dashboardAccessHref = buildCloudflareAccessLoginHref({ origin, returnPath: dashboardAccessReturnPath });
-  const dashboardSignInUrl = `${origin || ""}/v2/approval/passkey/operator?mode=dashboard&repositoryInput=marushu%2Fvtdd-v2-p&phase=execution&actionType=read&highRiskKind=dashboard_access`;
+  const dashboardSignInUrl = `${origin || ""}/v2/approval/passkey/operator?mode=dashboard&repositoryInput=marushu%2Fvtdd-v2-p&phase=execution&actionType=read&highRiskKind=dashboard_access&dashboardReturnPath=${encodeURIComponent(dashboardAccessReturnPath)}`;
+  const passkeyButtonLabel =
+    dashboardAccessReturnPath === "/dashboard/notifications" ? "Passkey で通知を見る" : "Passkey で dashboard に入る";
   return `<!doctype html>
 <html lang="ja">
 <head>
@@ -11735,6 +11738,7 @@ function renderDashboardAuthRequiredPage({ runtimeOrigin, returnPath = "/dashboa
       <p><code>${escapeDashboardHtml(reason || "dashboard authentication required")}</code></p>
       <div class="actions">
         <a class="button primary" href="${escapeDashboardHtml(dashboardAccessHref)}">Cloudflare Access で開く</a>
+        <a class="button" href="${escapeDashboardHtml(dashboardSignInUrl)}">${escapeDashboardHtml(passkeyButtonLabel)}</a>
         <a class="button" href="${escapeDashboardHtml(`${origin || ""}/status`)}">Status</a>
       </div>
       <details>

--- a/test/passkey-operator-page.test.js
+++ b/test/passkey-operator-page.test.js
@@ -276,6 +276,24 @@ test("passkey operator page shows registration only for full or explicit registr
   assert.equal(dashboardHtml.includes('<section data-operator-section="approval">'), true);
 });
 
+test("passkey operator dashboard mode returns to sanitized dashboard path after approval", () => {
+  const notificationsHtml = renderPasskeyOperatorPage({
+    operatorMode: "dashboard",
+    repositoryInput: "marushu/vtdd-v2-p",
+    dashboardReturnPath: "/dashboard/notifications?runId=private"
+  });
+  assert.equal(notificationsHtml.includes('window.location.assign("/dashboard/notifications")'), true);
+  assert.equal(notificationsHtml.includes("runId=private"), false);
+
+  const unsafeHtml = renderPasskeyOperatorPage({
+    operatorMode: "dashboard",
+    repositoryInput: "marushu/vtdd-v2-p",
+    dashboardReturnPath: "https://evil.example/dashboard/notifications"
+  });
+  assert.equal(unsafeHtml.includes('window.location.assign("/dashboard")'), true);
+  assert.equal(unsafeHtml.includes("evil.example"), false);
+});
+
 test("passkey operator page focuses merge mode on approval and PR merge sections", () => {
   const html = renderPasskeyOperatorPage({
     repositoryInput: "marushu/vtdd-v2-p",

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -786,7 +786,13 @@ test("worker rejects dashboard access without owner identity", async () => {
     true
   );
   assert.equal(body.includes("Passkey fallback"), true);
-  assert.equal(body.includes("Passkey で dashboard に入る"), false);
+  assert.equal(body.includes("Passkey で dashboard に入る"), true);
+  assert.equal(
+    body.includes(
+      'href="https://example.com/v2/approval/passkey/operator?mode=dashboard&amp;repositoryInput=marushu%2Fvtdd-v2-p&amp;phase=execution&amp;actionType=read&amp;highRiskKind=dashboard_access&amp;dashboardReturnPath=%2Fdashboard"'
+    ),
+    true
+  );
   assert.equal(body.includes("未認証の相手に通知詳細や Dashboard 内容は返しません"), true);
 });
 
@@ -876,7 +882,7 @@ test("worker rejects stale dashboard passkey session cookies", async () => {
   );
   assert.equal(body.includes("Passkey fallback"), true);
   assert.equal(body.includes("dashboard passkey session was not found"), true);
-  assert.equal(body.includes("Passkey で dashboard に入る"), false);
+  assert.equal(body.includes("Passkey で dashboard に入る"), true);
 });
 
 test("worker does not expose dashboard notification details before Access auth", async () => {
@@ -907,9 +913,16 @@ test("worker does not expose dashboard notification details before Access auth",
   const body = await response.text();
   assert.equal(body.includes("Dashboard auth required"), true);
   assert.equal(body.includes("Cloudflare Access で開く"), true);
+  assert.equal(body.includes("Passkey で通知を見る"), true);
   assert.equal(
     body.includes(
       'href="https://example.com/cdn-cgi/access/login?redirect_url=https%3A%2F%2Fexample.com%2Fdashboard%2Fnotifications"'
+    ),
+    true
+  );
+  assert.equal(
+    body.includes(
+      'href="https://example.com/v2/approval/passkey/operator?mode=dashboard&amp;repositoryInput=marushu%2Fvtdd-v2-p&amp;phase=execution&amp;actionType=read&amp;highRiskKind=dashboard_access&amp;dashboardReturnPath=%2Fdashboard%2Fnotifications"'
     ),
     true
   );
@@ -6411,7 +6424,9 @@ test("worker serves passkey operator page", async () => {
 
 test("worker serves dashboard passkey operator mode", async () => {
   const response = await worker.fetch(
-    new Request("https://example.com/v2/approval/passkey/operator?mode=dashboard&repositoryInput=marushu%2Fvtdd-v2-p"),
+    new Request(
+      "https://example.com/v2/approval/passkey/operator?mode=dashboard&repositoryInput=marushu%2Fvtdd-v2-p&dashboardReturnPath=%2Fdashboard%2Fnotifications"
+    ),
     gatewayAuthEnv
   );
 
@@ -6420,6 +6435,7 @@ test("worker serves dashboard passkey operator mode", async () => {
   assert.equal(html.includes('id="action-type-input" value="read"'), true);
   assert.equal(html.includes('id="risk-kind-input" value="dashboard_access"'), true);
   assert.equal(html.includes('const operatorMode = "dashboard"'), true);
+  assert.equal(html.includes('window.location.assign("/dashboard/notifications")'), true);
 });
 
 test("worker serves issue close operator mode without falling back to PR merge UI", async () => {

--- a/worker.js
+++ b/worker.js
@@ -27265,6 +27265,7 @@ function renderPasskeyOperatorPage(input = {}) {
   );
   const mergeMethodDefault = escapeHtml(input.mergeMethod || "squash");
   const returnUrl = escapeHtml(input.returnUrl || "");
+  const dashboardReturnPath = escapeHtml(sanitizePasskeyDashboardReturnPath(input.dashboardReturnPath));
   const githubAppRoleDefault = escapeHtml(input.githubAppRole || "legacy");
   const syncEnabled = input.syncEnabled === true;
   const syncMessage = escapeHtml(
@@ -27999,7 +28000,7 @@ function renderPasskeyOperatorPage(input = {}) {
           latestApprovalGrantId = latestApprovalGrant?.approvalId || verifyBody?.approvalGrantId || "";
           approveOutput.textContent = JSON.stringify(verifyBody, null, 2);
           if (operatorMode === "dashboard") {
-            window.location.assign("/dashboard");
+            window.location.assign("${dashboardReturnPath}");
             return;
           }
           if (latestApprovalGrantId && autoCopyApprovalGrantInput?.checked) {
@@ -28446,6 +28447,22 @@ function defaultHighRiskKindForMode(operatorMode) {
 }
 function normalizeOperatorToken(value) {
   return String(value || "").trim().toLowerCase();
+}
+function sanitizePasskeyDashboardReturnPath(value) {
+  const normalized = String(value || "").trim() || "/dashboard";
+  let parsed;
+  try {
+    parsed = new URL(normalized, "https://dashboard.local");
+  } catch {
+    return "/dashboard";
+  }
+  if (parsed.origin !== "https://dashboard.local") {
+    return "/dashboard";
+  }
+  if (parsed.pathname !== "/dashboard" && !parsed.pathname.startsWith("/dashboard/")) {
+    return "/dashboard";
+  }
+  return parsed.pathname;
 }
 function escapeHtml(value) {
   return String(value ?? "").replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;").replaceAll('"', "&quot;");
@@ -60155,6 +60172,7 @@ function handlePasskeyOperatorPageRequest(request) {
     highRiskKind: requestedHighRiskKind,
     mergeMethod: url.searchParams.get("mergeMethod") || "squash",
     returnUrl: normalizeOperatorReturnUrl(url.searchParams.get("returnUrl")),
+    dashboardReturnPath: sanitizeDashboardPreAuthReturnPath(url.searchParams.get("dashboardReturnPath")),
     operatorId: url.searchParams.get("operatorId") || "vtdd-operator",
     operatorLabel: url.searchParams.get("operatorLabel") || "VTDD Operator",
     githubAppRole: url.searchParams.get("githubAppRole") || "legacy",
@@ -66531,7 +66549,8 @@ function renderDashboardAuthRequiredPage({ runtimeOrigin, returnPath = "/dashboa
   const origin = normalizeText30(runtimeOrigin);
   const dashboardAccessReturnPath = sanitizeDashboardPreAuthReturnPath(returnPath);
   const dashboardAccessHref = buildCloudflareAccessLoginHref({ origin, returnPath: dashboardAccessReturnPath });
-  const dashboardSignInUrl = `${origin || ""}/v2/approval/passkey/operator?mode=dashboard&repositoryInput=marushu%2Fvtdd-v2-p&phase=execution&actionType=read&highRiskKind=dashboard_access`;
+  const dashboardSignInUrl = `${origin || ""}/v2/approval/passkey/operator?mode=dashboard&repositoryInput=marushu%2Fvtdd-v2-p&phase=execution&actionType=read&highRiskKind=dashboard_access&dashboardReturnPath=${encodeURIComponent(dashboardAccessReturnPath)}`;
+  const passkeyButtonLabel = dashboardAccessReturnPath === "/dashboard/notifications" ? "Passkey \u3067\u901A\u77E5\u3092\u898B\u308B" : "Passkey \u3067 dashboard \u306B\u5165\u308B";
   return `<!doctype html>
 <html lang="ja">
 <head>
@@ -66562,6 +66581,7 @@ function renderDashboardAuthRequiredPage({ runtimeOrigin, returnPath = "/dashboa
       <p><code>${escapeDashboardHtml(reason || "dashboard authentication required")}</code></p>
       <div class="actions">
         <a class="button primary" href="${escapeDashboardHtml(dashboardAccessHref)}">Cloudflare Access \u3067\u958B\u304F</a>
+        <a class="button" href="${escapeDashboardHtml(dashboardSignInUrl)}">${escapeDashboardHtml(passkeyButtonLabel)}</a>
         <a class="button" href="${escapeDashboardHtml(`${origin || ""}/status`)}">Status</a>
       </div>
       <details>


### PR DESCRIPTION
## This PR satisfies Intent

- #444 の通知タップ復帰導線について、未認証の owner が `Dashboard auth required` で止まった時に、通知詳細を漏らさず passkey fallback から通知センターへ戻れるようにします。
- PR #546 の Cloudflare Access login button は維持しつつ、Access が iOS/PWA/外部ブラウザ文脈で詰まる場合の owner-facing 回復導線を前面に出します。

## Satisfied Success Criteria

- `/dashboard/notifications` の pre-auth 画面に `Passkey で通知を見る` を折り畳み外のボタンとして表示します。
- passkey dashboard approval 後の redirect 先を `/dashboard` 固定から sanitized dashboard path に変更します。
- 通知 deep-link の `runId/title/sha` query は未認証 HTML と passkey return path に出さず、`/dashboard/notifications` path だけを保持します。
- unsafe external return path は `/dashboard` に落とします。
- Unit/HTML tests で Access login link、visible passkey fallback、query redaction、dashboard return path sanitization を固定します。

## Unsatisfied Success Criteria

- iPhone 実機 PWA の本番 Web Push notificationclick からの live E2E は未実施です。
- Cloudflare production deploy は未実施です。
- #444 close 判定は未実施です。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #444
- Implementing Success Criteria: notificationclick で通知画面へ戻れる owner-facing recovery path。pre-auth detail redaction。Passkey fallback visibility。
- Explicit Non-goals: Cloudflare Access policy 変更、deploy、credential/permission mutation、通知詳細の未認証公開、Issue close。
- Expected touched files/routes/workflows: `src/worker/runtime.js`, `src/core/passkey-operator-page.js`, `test/worker.test.js`, `test/passkey-operator-page.test.js`, `worker.js`
- Affected Issues: #444。関連 #514/#534 の通知センター UX にも接続します。
- Affected PRs: なし。PR #546 の Access login link 修正の上に追加します。
- Affected workflows: GitHub Actions workflow 定義は未変更です。
- Affected runtime/operator surfaces: `/dashboard/notifications` pre-auth page、dashboard passkey operator mode。
- What may break if we patch narrowly: return path を query 付きで渡すと未認証通知詳細漏えいに戻るため、path だけを保持します。
- Unknowns to investigate before coding: 本番 iOS PWA notificationclick が Safari/PWA/外部ブラウザのどれで開くかは live E2E が必要です。
- Validation needed: targeted unit tests、full `npm test`、Simulator render check、post-merge deploy/live iPhone PWA E2E。
- Stop condition: 未認証 HTML に通知詳細が出る、passkey dashboard scope 以外で dashboard session を作る、Access/passkey authority boundary を緩める必要が出た場合は停止します。

## File / Line Hypotheses

- file: `src/worker/runtime.js:11705`
  - hypothesis: auth required page の fallback が details 内だけだと、通知タップ後の owner-facing 回復導線として弱い。
  - risk if changed narrowly: 未認証ページに通知詳細を再露出する。
  - validation: worker tests assert visible passkey button and no `runId/title/sha` leak.
  - related Issue: #444
- file: `src/core/passkey-operator-page.js:769`
  - hypothesis: dashboard passkey approval 後に `/dashboard` 固定 redirect だと、通知タップから通知センターへ復帰できない。
  - risk if changed narrowly: arbitrary redirect/open redirect を作る。
  - validation: passkey operator tests assert dashboard-only sanitized return path and external URL fallback.
  - related Issue: #444

## Hypothesis Retrospective

- expected: visible passkey fallback と sanitized return path で、通知タップ後に Access が詰まっても通知センターへ戻る選択肢を出せる。
- actual: local Worker HTML と iOS Simulator 表示で `Passkey で通知を見る` が折り畳み外に表示され、query detail は出ていない。
- mismatch: production iPhone PWA notificationclick は未検証。
- lesson: 通知導線は security-only では足りず、owner-facing recovery を同じ画面の主要アクションとして出す必要がある。
- should become RAG candidate: live E2E 後に、Dashboard notification auth recovery の判断を記録候補にする。

## Verification Evidence

- Unit: `node --test test/passkey-operator-page.test.js`: 25 pass; `node --test test/worker.test.js`: 200 pass
- Integration: `npm test`: test body 971 pass / 1 skip, then dirty generated-worker diff before commit; after commit `npm run check:generated-worker`: passed; `npm run check:self-parity`: passed
- E2E: iOS Simulator local render check: `/dashboard/notifications?...` auth page shows `Passkey で通知を見る` without notification query leak. Screenshot: `/tmp/vtdd-notification-auth-simulator.png`
- Manual: No production deploy. No real iPhone PWA notificationclick yet.
- Evidence path/link: `src/worker/runtime.js`; `src/core/passkey-operator-page.js`; `test/worker.test.js`; `test/passkey-operator-page.test.js`; `worker.js`

## Butler Completion Contract

- Owner goal: Butler/PWA 通知を踏んだ owner が auth required 画面で詰まらず、Access または passkey fallback から通知センターへ戻れること。
- Butler entrypoint: Dashboard Web Push notificationclick -> `/dashboard/notifications`。
- Action Schema exposure: 不要。Custom GPT Action Schema は未変更です。
- Runtime path: Worker `/dashboard/notifications` auth failure page -> `/v2/approval/passkey/operator?mode=dashboard&dashboardReturnPath=/dashboard/notifications` -> dashboard passkey session cookie -> `/dashboard/notifications`。
- Runner/runtime truth: local Worker tests and iOS Simulator render check only。production runtime truth は未確認です。
- Authority boundary: 通常閲覧は Cloudflare Access owner identity または dashboard passkey session。高リスク操作の passkey approval scope は未変更です。
- E2E evidence: local Simulator render only。real iPhone PWA notificationclick は未実施です。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 未実施。deploy には scoped passkey approval が必要です。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。#444 close 前に必要です。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate
- AGENTS.md Butler-First Operating Principle
- AGENTS.md Authority Boundary
- AGENTS.md Evidence Discipline
- Issue #444 Success Criteria

## Out-of-scope but NOT implemented

- Cloudflare Access policy changes
- Credential / permission mutation
- Production deploy
- Real iPhone PWA Web Push notificationclick E2E
- Issue #444 close

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #444
- Execution ID: mac-codex-issue-444-notification-passkey-return
- Goal: Fix notification auth recovery without leaking pre-auth notification details
