### PR TITLE
Make dashboard passkey repo optional

### DIFF
--- a/src/core/passkey-operator-page.js
+++ b/src/core/passkey-operator-page.js
@@ -421,6 +421,13 @@ export function renderPasskeyOperatorPage(input = {}) {
         return repositoryInput;
       }
 
+      function readApprovalRepositoryInput() {
+        if (operatorMode === "dashboard") {
+          return document.getElementById("repo-input").value.trim();
+        }
+        return readRequiredRepositoryInput();
+      }
+
       async function copyText(text) {
         const value = String(text || "");
         if (!value) {
@@ -725,7 +732,7 @@ export function renderPasskeyOperatorPage(input = {}) {
       document.getElementById("approve-button").addEventListener("click", async () => {
         try {
           applyOperatorModeDefaults();
-          const repositoryInput = readRequiredRepositoryInput();
+          const repositoryInput = readApprovalRepositoryInput();
           approveOutput.textContent = "approval challenge request...";
           const challengeResponse = await fetch("${apiBase}/approval/passkey/challenge", {
             method: "POST",

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -10393,7 +10393,8 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
   const encodedRepository = encodeURIComponent(repositoryInput);
   const chatThreadId = `dashboard-main-${(repositoryInput || "unresolved").replace(/[^a-z0-9_.-]+/gi, "-")}`;
   const socketOrigin = origin.replace(/^http/i, "ws");
-  const dashboardSignInUrl = `${origin}/v2/approval/passkey/operator?mode=dashboard&repositoryInput=${encodedRepository}&phase=execution&actionType=read&highRiskKind=dashboard_access`;
+  const dashboardSignInRepositoryParam = repositoryInput ? `&repositoryInput=${encodedRepository}` : "";
+  const dashboardSignInUrl = `${origin}/v2/approval/passkey/operator?mode=dashboard${dashboardSignInRepositoryParam}&phase=execution&actionType=read&highRiskKind=dashboard_access`;
   const latestDeployEvent = await retrieveLatestDashboardEvent({
     store: dashboardEventStore,
     kind: "github_actions_workflow_run",
@@ -11705,7 +11706,7 @@ function renderDashboardAuthRequiredPage({ runtimeOrigin, returnPath = "/dashboa
   const origin = normalizeText(runtimeOrigin);
   const dashboardAccessReturnPath = sanitizeDashboardPreAuthReturnPath(returnPath);
   const dashboardAccessHref = buildCloudflareAccessLoginHref({ origin, returnPath: dashboardAccessReturnPath });
-  const dashboardSignInUrl = `${origin || ""}/v2/approval/passkey/operator?mode=dashboard&repositoryInput=marushu%2Fvtdd-v2-p&phase=execution&actionType=read&highRiskKind=dashboard_access&dashboardReturnPath=${encodeURIComponent(dashboardAccessReturnPath)}`;
+  const dashboardSignInUrl = `${origin || ""}/v2/approval/passkey/operator?mode=dashboard&phase=execution&actionType=read&highRiskKind=dashboard_access&dashboardReturnPath=${encodeURIComponent(dashboardAccessReturnPath)}`;
   const passkeyButtonLabel =
     dashboardAccessReturnPath === "/dashboard/notifications" ? "Passkey で通知を見る" : "Passkey で dashboard に入る";
   return `<!doctype html>
@@ -11834,7 +11835,7 @@ function renderV2StatusPage({ runtimeOrigin, autonomyMode }) {
       <p>Worker は応答しています。ここでは secret、token、approval grant は表示しません。</p>
       <div class="actions">
         <a class="primary" href="${escapeDashboardHtml(origin)}/dashboard">Butler dashboard</a>
-        <a href="${escapeDashboardHtml(origin)}/v2/approval/passkey/operator?repositoryInput=marushu%2Fvtdd-v2-p">Passkey operator</a>
+        <a href="${escapeDashboardHtml(origin)}/v2/approval/passkey/operator">Passkey operator</a>
       </div>
     </section>
 

--- a/test/passkey-operator-page.test.js
+++ b/test/passkey-operator-page.test.js
@@ -269,17 +269,18 @@ test("passkey operator page shows registration only for full or explicit registr
   assert.equal(registerHtml.includes('<section data-operator-section="production-deploy" hidden>'), true);
 
   const dashboardHtml = renderPasskeyOperatorPage({
-    operatorMode: "dashboard",
-    repositoryInput: "marushu/vtdd-v2-p"
+    operatorMode: "dashboard"
   });
   assert.equal(dashboardHtml.includes('<section data-operator-section="registration" hidden>'), true);
   assert.equal(dashboardHtml.includes('<section data-operator-section="approval">'), true);
+  assert.equal(dashboardHtml.includes('id="repo-input" value=""'), true);
+  assert.equal(dashboardHtml.includes("function readApprovalRepositoryInput()"), true);
+  assert.equal(dashboardHtml.includes("const repositoryInput = readApprovalRepositoryInput();"), true);
 });
 
 test("passkey operator dashboard mode returns to sanitized dashboard path after approval", () => {
   const notificationsHtml = renderPasskeyOperatorPage({
     operatorMode: "dashboard",
-    repositoryInput: "marushu/vtdd-v2-p",
     dashboardReturnPath: "/dashboard/notifications?runId=private"
   });
   assert.equal(notificationsHtml.includes('window.location.assign("/dashboard/notifications")'), true);
@@ -287,7 +288,6 @@ test("passkey operator dashboard mode returns to sanitized dashboard path after 
 
   const unsafeHtml = renderPasskeyOperatorPage({
     operatorMode: "dashboard",
-    repositoryInput: "marushu/vtdd-v2-p",
     dashboardReturnPath: "https://evil.example/dashboard/notifications"
   });
   assert.equal(unsafeHtml.includes('window.location.assign("/dashboard")'), true);

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -6809,10 +6809,8 @@ test("worker sets dashboard session cookie after dashboard passkey approval", as
       body: JSON.stringify({
         phase: "execution",
         highRiskKind: "dashboard_access",
-        repositoryInput: "marushu/vtdd-v2-p",
         policyInput: {
           actionType: ActionType.READ,
-          repositoryInput: "marushu/vtdd-v2-p",
           highRiskKind: "dashboard_access"
         }
       })
@@ -6853,6 +6851,8 @@ test("worker sets dashboard session cookie after dashboard passkey approval", as
   assert.match(verify.headers.get("set-cookie"), /SameSite=Lax/);
   const verifyBody = await verify.json();
   assert.equal(verifyBody.approvalGrant.scope.highRiskKind, "dashboard_access");
+  assert.equal(verifyBody.approvalGrant.scope.repositoryInput || "", "");
+  assert.notEqual(verifyBody.approvalGrant.scope.repositoryInput, "marushu/vtdd-v2-p");
 });
 
 test("worker gateway accepts high-risk approval grant resolved from memory", async () => {

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -766,7 +766,8 @@ test("worker serves human-facing status page without raw JSON links", async () =
   assert.equal(body.includes("Runtime Status"), true);
   assert.equal(body.includes("raw /health JSON"), false);
   assert.equal(body.includes("/dashboard"), true);
-  assert.equal(body.includes("/v2/approval/passkey/operator?repositoryInput=marushu%2Fvtdd-v2-p"), true);
+  assert.equal(body.includes("/v2/approval/passkey/operator"), true);
+  assert.equal(body.includes("repositoryInput=marushu%2Fvtdd-v2-p"), false);
   assert.equal(body.includes("approvalGrantId"), false);
   assert.equal(body.includes("CLOUDFLARE_API_TOKEN"), false);
 });
@@ -789,10 +790,11 @@ test("worker rejects dashboard access without owner identity", async () => {
   assert.equal(body.includes("Passkey で dashboard に入る"), true);
   assert.equal(
     body.includes(
-      'href="https://example.com/v2/approval/passkey/operator?mode=dashboard&amp;repositoryInput=marushu%2Fvtdd-v2-p&amp;phase=execution&amp;actionType=read&amp;highRiskKind=dashboard_access&amp;dashboardReturnPath=%2Fdashboard"'
+      'href="https://example.com/v2/approval/passkey/operator?mode=dashboard&amp;phase=execution&amp;actionType=read&amp;highRiskKind=dashboard_access&amp;dashboardReturnPath=%2Fdashboard"'
     ),
     true
   );
+  assert.equal(body.includes("repositoryInput=marushu%2Fvtdd-v2-p"), false);
   assert.equal(body.includes("未認証の相手に通知詳細や Dashboard 内容は返しません"), true);
 });
 
@@ -883,6 +885,7 @@ test("worker rejects stale dashboard passkey session cookies", async () => {
   assert.equal(body.includes("Passkey fallback"), true);
   assert.equal(body.includes("dashboard passkey session was not found"), true);
   assert.equal(body.includes("Passkey で dashboard に入る"), true);
+  assert.equal(body.includes("repositoryInput=marushu%2Fvtdd-v2-p"), false);
 });
 
 test("worker does not expose dashboard notification details before Access auth", async () => {
@@ -922,10 +925,11 @@ test("worker does not expose dashboard notification details before Access auth",
   );
   assert.equal(
     body.includes(
-      'href="https://example.com/v2/approval/passkey/operator?mode=dashboard&amp;repositoryInput=marushu%2Fvtdd-v2-p&amp;phase=execution&amp;actionType=read&amp;highRiskKind=dashboard_access&amp;dashboardReturnPath=%2Fdashboard%2Fnotifications"'
+      'href="https://example.com/v2/approval/passkey/operator?mode=dashboard&amp;phase=execution&amp;actionType=read&amp;highRiskKind=dashboard_access&amp;dashboardReturnPath=%2Fdashboard%2Fnotifications"'
     ),
     true
   );
+  assert.equal(body.includes("repositoryInput=marushu%2Fvtdd-v2-p"), false);
   assert.equal(body.includes('href="https://example.com/dashboard/notifications"'), false);
   assert.equal(body.includes("?runId="), false);
   assert.equal(body.includes("title="), false);
@@ -6425,17 +6429,20 @@ test("worker serves passkey operator page", async () => {
 test("worker serves dashboard passkey operator mode", async () => {
   const response = await worker.fetch(
     new Request(
-      "https://example.com/v2/approval/passkey/operator?mode=dashboard&repositoryInput=marushu%2Fvtdd-v2-p&dashboardReturnPath=%2Fdashboard%2Fnotifications"
+      "https://example.com/v2/approval/passkey/operator?mode=dashboard&dashboardReturnPath=%2Fdashboard%2Fnotifications"
     ),
     gatewayAuthEnv
   );
 
   assert.equal(response.status, 200);
   const html = await response.text();
+  assert.equal(html.includes('id="repo-input" value=""'), true);
   assert.equal(html.includes('id="action-type-input" value="read"'), true);
   assert.equal(html.includes('id="risk-kind-input" value="dashboard_access"'), true);
   assert.equal(html.includes('const operatorMode = "dashboard"'), true);
   assert.equal(html.includes('window.location.assign("/dashboard/notifications")'), true);
+  assert.equal(html.includes("repositoryInput is required before approval/deploy"), true);
+  assert.equal(html.includes("const repositoryInput = readApprovalRepositoryInput();"), true);
 });
 
 test("worker serves issue close operator mode without falling back to PR merge UI", async () => {

--- a/worker.js
+++ b/worker.js
@@ -27652,6 +27652,13 @@ function renderPasskeyOperatorPage(input = {}) {
         return repositoryInput;
       }
 
+      function readApprovalRepositoryInput() {
+        if (operatorMode === "dashboard") {
+          return document.getElementById("repo-input").value.trim();
+        }
+        return readRequiredRepositoryInput();
+      }
+
       async function copyText(text) {
         const value = String(text || "");
         if (!value) {
@@ -27956,7 +27963,7 @@ function renderPasskeyOperatorPage(input = {}) {
       document.getElementById("approve-button").addEventListener("click", async () => {
         try {
           applyOperatorModeDefaults();
-          const repositoryInput = readRequiredRepositoryInput();
+          const repositoryInput = readApprovalRepositoryInput();
           approveOutput.textContent = "approval challenge request...";
           const challengeResponse = await fetch("${apiBase}/approval/passkey/challenge", {
             method: "POST",
@@ -65239,7 +65246,8 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
   const encodedRepository = encodeURIComponent(repositoryInput);
   const chatThreadId = `dashboard-main-${(repositoryInput || "unresolved").replace(/[^a-z0-9_.-]+/gi, "-")}`;
   const socketOrigin = origin.replace(/^http/i, "ws");
-  const dashboardSignInUrl = `${origin}/v2/approval/passkey/operator?mode=dashboard&repositoryInput=${encodedRepository}&phase=execution&actionType=read&highRiskKind=dashboard_access`;
+  const dashboardSignInRepositoryParam = repositoryInput ? `&repositoryInput=${encodedRepository}` : "";
+  const dashboardSignInUrl = `${origin}/v2/approval/passkey/operator?mode=dashboard${dashboardSignInRepositoryParam}&phase=execution&actionType=read&highRiskKind=dashboard_access`;
   const latestDeployEvent = await retrieveLatestDashboardEvent({
     store: dashboardEventStore,
     kind: "github_actions_workflow_run",
@@ -66549,7 +66557,7 @@ function renderDashboardAuthRequiredPage({ runtimeOrigin, returnPath = "/dashboa
   const origin = normalizeText30(runtimeOrigin);
   const dashboardAccessReturnPath = sanitizeDashboardPreAuthReturnPath(returnPath);
   const dashboardAccessHref = buildCloudflareAccessLoginHref({ origin, returnPath: dashboardAccessReturnPath });
-  const dashboardSignInUrl = `${origin || ""}/v2/approval/passkey/operator?mode=dashboard&repositoryInput=marushu%2Fvtdd-v2-p&phase=execution&actionType=read&highRiskKind=dashboard_access&dashboardReturnPath=${encodeURIComponent(dashboardAccessReturnPath)}`;
+  const dashboardSignInUrl = `${origin || ""}/v2/approval/passkey/operator?mode=dashboard&phase=execution&actionType=read&highRiskKind=dashboard_access&dashboardReturnPath=${encodeURIComponent(dashboardAccessReturnPath)}`;
   const passkeyButtonLabel = dashboardAccessReturnPath === "/dashboard/notifications" ? "Passkey \u3067\u901A\u77E5\u3092\u898B\u308B" : "Passkey \u3067 dashboard \u306B\u5165\u308B";
   return `<!doctype html>
 <html lang="ja">
@@ -66673,7 +66681,7 @@ function renderV2StatusPage({ runtimeOrigin, autonomyMode }) {
       <p>Worker \u306F\u5FDC\u7B54\u3057\u3066\u3044\u307E\u3059\u3002\u3053\u3053\u3067\u306F secret\u3001token\u3001approval grant \u306F\u8868\u793A\u3057\u307E\u305B\u3093\u3002</p>
       <div class="actions">
         <a class="primary" href="${escapeDashboardHtml(origin)}/dashboard">Butler dashboard</a>
-        <a href="${escapeDashboardHtml(origin)}/v2/approval/passkey/operator?repositoryInput=marushu%2Fvtdd-v2-p">Passkey operator</a>
+        <a href="${escapeDashboardHtml(origin)}/v2/approval/passkey/operator">Passkey operator</a>
       </div>
     </section>
 


### PR DESCRIPTION
## This PR satisfies Intent

- #526 の repo 未指定 / Passkey 導線整理として、Dashboard passkey fallback から owner 固有の `repositoryInput=marushu/vtdd-v2-p` を外します。
- Dashboard access は repo 固有の high-risk 操作ではないため、repo 未指定のまま dashboard passkey session を作れるようにします。

## Satisfied Success Criteria

- Dashboard auth required page の passkey fallback URL が default repo を暗黙注入しません。
- Status page の Passkey operator URL から owner 固有 repo を外します。
- Dashboard passkey operator mode は repo 未指定でも approval challenge を開始できます。
- deploy/merge/secret sync など repo が必要な操作の `repositoryInput` 必須ガードは維持します。
- Unit/HTML tests で pre-auth fallback URL に `repositoryInput=marushu%2Fvtdd-v2-p` が出ないことを固定します。

## Unsatisfied Success Criteria

- Dashboard topbar / drawer 全体の役割分離と mobile visual E2E はこの PR では未完了です。
- production deploy / iPhone live E2E は未実施です。
- #526 close 判定は未実施です。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #526
- Implementing Success Criteria: repo 未指定時に default repo を暗黙注入しない。Passkey fallback の owner 固有 URL を除去する。
- Explicit Non-goals: high-risk deploy/merge/secret scope 変更、Cloudflare deploy、Cloudflare Access policy 変更、Issue close。
- Expected touched files/routes/workflows: `src/worker/runtime.js`, `src/core/passkey-operator-page.js`, `test/worker.test.js`, `test/passkey-operator-page.test.js`, `worker.js`
- Affected Issues: #526。PR #548 reviewer residual risk の follow-up。
- Affected PRs: PR #548 の残リスクを解消する追加 PR。
- Affected workflows: GitHub Actions workflow 定義は未変更です。
- Affected runtime/operator surfaces: Dashboard auth required page、status page、dashboard passkey operator mode。
- What may break if we patch narrowly: dashboard passkey approval が repositoryInput 必須のままだと fallback が壊れるため、dashboard mode のみ repo optional に限定します。
- Unknowns to investigate before coding: live Cloudflare Access / passkey session の本番挙動は deploy 後に確認が必要です。
- Validation needed: targeted unit tests、generated worker parity、self parity、post-merge live E2E。
- Stop condition: high-risk operation の repo 必須境界を緩める必要が出た場合、または dashboard_access 以外の scope に repo optional が広がる場合は停止します。

## File / Line Hypotheses

- file: `src/worker/runtime.js:11706`
  - hypothesis: auth required page が hard-coded `repositoryInput=marushu/vtdd-v2-p` を出しており、public/core branch と repo未指定 UX の両方に反する。
  - risk if changed narrowly: passkey dashboard fallback が repositoryInput 必須で失敗する。
  - validation: worker tests assert fallback URL has no owner repo and dashboard passkey operator renders empty repo input.
  - related Issue: #526
- file: `src/core/passkey-operator-page.js:421`
  - hypothesis: approval flow が常に `readRequiredRepositoryInput()` を呼ぶため、dashboard_access まで repo 必須になっている。
  - risk if changed narrowly: deploy/merge/secret sync の repo required invariant を壊す。
  - validation: dashboard mode only uses optional repo helper; deploy missing-repo test still passes.
  - related Issue: #526

## Hypothesis Retrospective

- expected: dashboard mode のみ repo optional にすれば、owner 固有 fallback URL を消しても session approval path は保てる。
- actual: targeted worker/passkey tests passed, generated Worker parity passed, and reviewer-requested runtime proof was added. The worker test now posts `/v2/approval/passkey/challenge` without `repositoryInput`, verifies the passkey grant, asserts the dashboard session cookie, and asserts no owner repo is injected into the approval scope.
- mismatch: full mobile topbar/drawer UX は未対応。
- lesson: dashboard_access と high-risk repo operations は approval repository requirement を分ける必要がある。
- should become RAG candidate: yes。Dashboard access passkey は repo-scoped high-risk approval ではない、という判断を live E2E 後に記録候補にする。

## Verification Evidence

- Unit: `node --test test/passkey-operator-page.test.js`: 25 pass; `node --test test/worker.test.js`: 200 pass; combined targeted run: 225 pass
- Runtime route proof: `worker sets dashboard session cookie after dashboard passkey approval` covers `/v2/approval/passkey/challenge` and `/v2/approval/passkey/verify` with no `repositoryInput`, then verifies the dashboard session cookie and empty/non-owner `approvalGrant.scope.repositoryInput`.
- Integration: `npm run build:worker`: passed; `npm run check:self-parity`: passed; `npm run check:generated-worker`: passed after reviewer follow-up commit
- E2E: 未実施。mobile visual / live iPhone E2E は別途必要です。
- Manual: 未実施。Cloudflare deploy なし。
- Evidence path/link: `src/worker/runtime.js`; `src/core/passkey-operator-page.js`; `test/worker.test.js`; `test/passkey-operator-page.test.js`; `worker.js`

## Butler Completion Contract

- Owner goal: Dashboard/通知の passkey fallback が repo 未指定時に owner 固有 repo を暗黙注入せず、public/core branch と owner-facing recovery の両方で自然に使えること。
- Butler entrypoint: Dashboard auth required page and dashboard passkey operator.
- Action Schema exposure: 不要。Custom GPT Action Schema は未変更です。
- Runtime path: `/dashboard` or `/dashboard/notifications` pre-auth page -> `/v2/approval/passkey/operator?mode=dashboard...` -> dashboard passkey session.
- Runner/runtime truth: local unit/integration only。production runtime truth は未確認です。
- Authority boundary: dashboard_access のみ repo optional。deploy/merge/secret sync の repo必須境界と scoped passkey approval は維持。
- E2E evidence: 未実施。iPhone/PWA live E2E は未完了です。Reviewer 指摘の repo-less dashboard passkey runtime route proof は unit/runtime test で追加済みです。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 未実施。deploy には scoped passkey approval が必要です。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。#526 close 前に必要です。

## Related Constitution Rules

- AGENTS.md Safety Invariants
- AGENTS.md Butler Completion Gate
- AGENTS.md Evidence Discipline
- Issue #526 Success Criteria

## Out-of-scope but NOT implemented

- Dashboard topbar / drawer 全体の再設計
- Production deploy
- Real iPhone/PWA live E2E
- Issue #526 close

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #526
- Execution ID: mac-codex-issue-526-dashboard-passkey-repo-optional
- Goal: Remove owner-specific dashboard passkey fallback repo while preserving high-risk repo boundaries

