### PR TITLE
Clarify dashboard action roles

### DIFF
--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -10921,10 +10921,16 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         return "不明";
       }
 
-      function buildReconnectStatus(prefix) {
+      function setConnectionRecoveryStatus(message) {
         const attempt = Math.max(1, reconnectAttempt + 1);
-        const refreshPart = lastRefreshFailure ? " 最後の履歴取得: " + lastRefreshFailure + "。" : "";
-        return prefix + " 再接続 " + attempt + "回目 / WebSocket: " + describeChatSocketState() + "。" + refreshPart;
+        status.dataset.reconnectAttempt = String(attempt);
+        status.dataset.websocketState = describeChatSocketState();
+        status.dataset.lastRefreshFailure = lastRefreshFailure || "";
+        setStatus(message);
+      }
+
+      function buildReconnectStatus(prefix) {
+        return prefix + " 入力は保持しています。";
       }
 
       function dropStaleSocketIfNeeded() {
@@ -11464,7 +11470,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
               return { ok: false, authExpired: true };
             }
             lastRefreshFailure = "HTTP " + response.status;
-            setStatus(buildReconnectStatus("履歴の再取得に失敗しました。入力は保持しています。"));
+            setConnectionRecoveryStatus("履歴の再取得に失敗しました。入力は保持しています。");
             return { ok: false, status: response.status };
           }
           if (body && body.ok) {
@@ -11474,7 +11480,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           }
         } catch {
           lastRefreshFailure = "ネットワーク";
-          setStatus(buildReconnectStatus("履歴の再取得に失敗しました。入力は保持しています。"));
+          setConnectionRecoveryStatus("履歴の再取得に失敗しました。入力は保持しています。");
           return { ok: false, network: true };
         } finally {
           refreshingThread = false;
@@ -11485,7 +11491,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
       function scheduleReconnect() {
         if (reconnectTimer || !socketEndpoint || typeof WebSocket !== "function") return;
         const delay = Math.min(10000, 1000 * Math.pow(2, reconnectAttempt));
-        setStatus(buildReconnectStatus("WebSocket を再接続します。入力は保持しています。"));
+        setConnectionRecoveryStatus("接続を復帰しています。入力は保持しています。");
         reconnectAttempt += 1;
         reconnectTimer = window.setTimeout(() => {
           reconnectTimer = null;
@@ -11554,7 +11560,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
             releasePendingOwnerSend(pendingOwnerSend.clientMessageId, { clearComposer: false, keepRollbackTimer: true });
             setStatus("送信確認前に WebSocket が切れました。入力は残しています。履歴再取得後にもう一度送信できます。");
           } else {
-            setStatus(buildReconnectStatus("WebSocket が切れました。履歴を再取得して再接続します。"));
+            setConnectionRecoveryStatus("接続が切れました。履歴を確認しながら復帰しています。");
           }
           dropStaleSocketIfNeeded();
           refreshThread();
@@ -11565,7 +11571,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
             releasePendingOwnerSend(pendingOwnerSend.clientMessageId, { clearComposer: false, keepRollbackTimer: true });
             setStatus("送信確認前に WebSocket 接続が失敗しました。入力は残しています。再接続後にもう一度送信できます。");
           } else {
-            setStatus(buildReconnectStatus("WebSocket 接続に失敗しました。履歴を再取得して再接続します。"));
+            setConnectionRecoveryStatus("接続できませんでした。履歴を確認しながら復帰しています。");
           }
           dropStaleSocketIfNeeded();
           refreshThread();
@@ -11730,14 +11736,14 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
       textarea.addEventListener("input", resizeComposerInput);
       window.addEventListener("resize", resizeComposerInput);
       window.addEventListener("online", () => {
-        setStatus(buildReconnectStatus("ネットワーク復帰を検知しました。履歴を再取得して再接続します。"));
+        setConnectionRecoveryStatus("ネットワーク復帰を検知しました。接続を復帰しています。");
         dropStaleSocketIfNeeded();
         refreshThread();
         scheduleReconnect();
       });
       document.addEventListener("visibilitychange", () => {
         if (document.visibilityState === "visible" && (!chatSocket || chatSocket.readyState !== WebSocket.OPEN)) {
-          setStatus(buildReconnectStatus("画面復帰を検知しました。履歴を再取得して再接続します。"));
+          setConnectionRecoveryStatus("画面復帰を検知しました。接続を復帰しています。");
           dropStaleSocketIfNeeded();
           refreshThread();
           scheduleReconnect();

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -10389,7 +10389,15 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
     ? `<p><strong>${escapeDashboardHtml(repositoryInput)}</strong></p>
           <p class="muted">この repo で Issue / PR 操作が必要な時だけ対象にします。通常会話はこのまま続けられます。</p>`
     : `<p><strong>対象 repo 未指定</strong></p>
-          <p class="muted">通常会話は続けられます。Issue / PR 操作が必要になった時に対象 repo を選びます。</p>`;
+          <p class="muted">通常会話は続けられます。Issue / PR / deploy など repo が必要な操作を始める時だけ、ここで対象 repo を設定します。</p>
+          <form class="target-form" method="get" action="${escapeDashboardHtml(origin)}/dashboard">
+            <label for="dashboard-repository-input">対象 repo</label>
+            <div class="target-form-row">
+              <input id="dashboard-repository-input" name="repository" placeholder="owner/repo" autocomplete="off" autocapitalize="off" spellcheck="false">
+              ${dashboardIssueNumber ? `<input type="hidden" name="issueNumber" value="${dashboardIssueNumber}">` : ""}
+              <button type="submit">設定</button>
+            </div>
+          </form>`;
   const encodedRepository = encodeURIComponent(repositoryInput);
   const chatThreadId = `dashboard-main-${(repositoryInput || "unresolved").replace(/[^a-z0-9_.-]+/gi, "-")}`;
   const socketOrigin = origin.replace(/^http/i, "ws");
@@ -10410,22 +10418,26 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
     {
       title: "Startup preflight",
       body: "AGENTS.md、thread-independent startup、runtime truth、RAG、self parity を最初に読む入口。",
-      href: `${origin}/dashboard/preflight?repository=${encodedRepository}`
+      href: repositoryInput ? `${origin}/dashboard/preflight?repository=${encodedRepository}` : "",
+      disabledReason: "repo 設定後に開けます"
     },
     {
       title: "Execution progress",
       body: "VPS Codex CLI / remote Codex execution の進捗確認。",
-      href: `${origin}/dashboard/progress?repository=${encodedRepository}`
+      href: repositoryInput ? `${origin}/dashboard/progress?repository=${encodedRepository}` : "",
+      disabledReason: "repo 設定後に開けます"
     },
     {
       title: "VPS runner status",
       body: "runner health、queue、対象 execution の状態確認。",
-      href: `${origin}/dashboard/vps-runner?repository=${encodedRepository}`
+      href: repositoryInput ? `${origin}/dashboard/vps-runner?repository=${encodedRepository}` : "",
+      disabledReason: "repo 設定後に開けます"
     },
     {
       title: "GitHub runtime truth",
       body: "Issues、PRs、checks、workflow runs、reviewer comments を読む入口。",
-      href: `${origin}/dashboard/github?repository=${encodedRepository}`
+      href: repositoryInput ? `${origin}/dashboard/github?repository=${encodedRepository}` : "",
+      disabledReason: "repo 設定後に開けます"
     },
     {
       title: "通知センター",
@@ -10435,22 +10447,28 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
     {
       title: "Operational RAG",
       body: "decision / proposal / working memory の compact retrieval。runtime truth の代替ではない。",
-      href: `${origin}/dashboard/memory?repository=${encodedRepository}`
+      href: repositoryInput ? `${origin}/dashboard/memory?repository=${encodedRepository}` : "",
+      disabledReason: "repo 設定後に開けます"
     },
     {
       title: "Self parity",
       body: "Action Schema、Instructions、Cloudflare deploy freshness、operator URL を確認。",
-      href: `${origin}/dashboard/self-parity?repository=${encodedRepository}`
+      href: repositoryInput ? `${origin}/dashboard/self-parity?repository=${encodedRepository}` : "",
+      disabledReason: "repo 設定後に開けます"
     },
     {
       title: "Setup diagnostics",
       body: "Butler / Custom GPT / deploy drift の診断ページ。",
-      href: `${origin}/setup/diagnostics?repository=${encodedRepository}`
+      href: repositoryInput ? `${origin}/setup/diagnostics?repository=${encodedRepository}` : "",
+      disabledReason: "repo 設定後に開けます"
     },
     {
-      title: "Deploy operator",
-      body: "production deploy は scope 明示済み passkey approval の後ろ。approval grant や secret は dashboard に保存しない。",
-      href: `${origin}/v2/approval/passkey/operator?repositoryInput=${encodedRepository}&phase=execution&actionType=deploy_production&highRiskKind=deploy_production`
+      title: "本番反映 / Passkey 承認",
+      body: "production deploy は対象 repo 設定後、scope 明示済み passkey approval の後ろで開きます。",
+      href: repositoryInput
+        ? `${origin}/v2/approval/passkey/operator?repositoryInput=${encodedRepository}&phase=execution&actionType=deploy_production&highRiskKind=deploy_production`
+        : "",
+      disabledReason: "repo 設定後に開けます"
     }
   ];
   const workflows = [
@@ -10465,14 +10483,36 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
       href: `${origin}/dashboard/notifications`
     },
     {
+      label: "Passkey",
+      href: dashboardSignInUrl
+    },
+    {
       label: "進捗を見る",
-      href: `${origin}/dashboard/progress?repository=${encodedRepository}`
+      href: repositoryInput ? `${origin}/dashboard/progress?repository=${encodedRepository}` : "",
+      disabledReason: "repo 設定後"
     },
     {
       label: "GitHub状況",
-      href: `${origin}/dashboard/github?repository=${encodedRepository}`
+      href: repositoryInput ? `${origin}/dashboard/github?repository=${encodedRepository}` : "",
+      disabledReason: "repo 設定後"
     }
   ];
+  const renderDashboardActionList = (actions) =>
+    actions
+      .map((action) =>
+        action.href
+          ? `<a href="${escapeDashboardHtml(action.href)}">${escapeDashboardHtml(action.label || action.title)}</a>`
+          : `<span class="disabled-action" aria-disabled="true"><strong>${escapeDashboardHtml(action.label || action.title)}</strong><small>${escapeDashboardHtml(action.disabledReason || "利用できません")}</small></span>`
+      )
+      .join("");
+  const renderDashboardSurfaceList = (items) =>
+    items
+      .map((surface) =>
+        surface.href
+          ? `<a href="${escapeDashboardHtml(surface.href)}">${escapeDashboardHtml(surface.title)}</a>`
+          : `<span class="disabled-action" aria-disabled="true"><strong>${escapeDashboardHtml(surface.title)}</strong><small>${escapeDashboardHtml(surface.disabledReason || "利用できません")}</small></span>`
+      )
+      .join("");
 
   return `<!doctype html>
 <html lang="ja">
@@ -10601,7 +10641,15 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
     .deploy-event p { margin-bottom: 6px; font-size: 13px; line-height: 1.45; }
     .quick-actions, .surface-list { display: grid; gap: 8px; }
     .quick-actions { grid-template-columns: repeat(2, minmax(0, 1fr)); }
-    .quick-actions a, .surface-list a { display: inline-flex; align-items: center; justify-content: center; min-height: 36px; border: 1px solid var(--border); border-radius: 10px; padding: 7px 9px; color: var(--text); text-decoration: none; background: var(--soft); font-weight: 750; font-size: 13px; text-align: center; }
+    .quick-actions a, .surface-list a, .disabled-action { display: inline-flex; align-items: center; justify-content: center; min-height: 36px; border: 1px solid var(--border); border-radius: 10px; padding: 7px 9px; color: var(--text); text-decoration: none; background: var(--soft); font-weight: 750; font-size: 13px; text-align: center; }
+    .disabled-action { flex-direction: column; gap: 2px; color: var(--muted); background: transparent; cursor: not-allowed; }
+    .disabled-action strong { font-size: 13px; }
+    .disabled-action small { font-size: 11px; font-weight: 650; line-height: 1.2; }
+    .target-form { display: grid; gap: 6px; margin-top: 10px; }
+    .target-form label { color: var(--muted); font-size: 12px; font-weight: 800; }
+    .target-form-row { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 6px; }
+    .target-form input { min-width: 0; min-height: 38px; border: 1px solid var(--border); border-radius: 10px; padding: 7px 9px; color: var(--text); background: var(--panel); font: inherit; }
+    .target-form button { min-height: 38px; border: 1px solid var(--border); border-radius: 10px; padding: 7px 10px; color: var(--text); background: var(--button); font: inherit; font-weight: 800; }
     summary { cursor: pointer; color: var(--text); font-weight: 800; }
     .muted { color: var(--muted); }
     code { color: var(--text); overflow-wrap: anywhere; }
@@ -10652,7 +10700,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         </div>
         <div class="top-right">
           <a class="tool-button top-action" href="${escapeDashboardHtml(origin)}/dashboard/notifications" aria-label="通知センター">通知</a>
-          <a class="tool-button top-action" href="${escapeDashboardHtml(origin)}/dashboard/progress?repository=${encodedRepository}" aria-label="進捗を見る">進捗</a>
+          <a class="tool-button top-action" href="${escapeDashboardHtml(dashboardSignInUrl)}" aria-label="Passkey で dashboard session を更新">Passkey</a>
         </div>
       </header>
 
@@ -10677,12 +10725,12 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
             ${renderDashboardDeployEvent(latestDeployEvent)}
           </div>
           <div class="quick-actions">
-            ${cockpitActions.map((action) => `<a href="${escapeDashboardHtml(action.href)}">${escapeDashboardHtml(action.label)}</a>`).join("")}
+            ${renderDashboardActionList(cockpitActions)}
           </div>
           <details data-debug-section="dashboard-development-operations">
             <summary>開発/運用</summary>
             <div class="surface-list">
-              ${surfaces.map((surface) => `<a href="${escapeDashboardHtml(surface.href)}">${escapeDashboardHtml(surface.title)}</a>`).join("")}
+              ${renderDashboardSurfaceList(surfaces)}
             </div>
           </details>
           <details>
@@ -10757,14 +10805,14 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           <p>直近の反映、失敗、進行中の作業があればここに出します。</p>
           ${renderDashboardDeployEvent(latestDeployEvent)}
           <div class="quick-actions">
-            ${cockpitActions.map((action) => `<a href="${escapeDashboardHtml(action.href)}">${escapeDashboardHtml(action.label)}</a>`).join("")}
+            ${renderDashboardActionList(cockpitActions)}
           </div>
         </div>
 
         <details data-debug-section="dashboard-development-operations">
           <summary>開発/運用</summary>
           <div class="surface-list">
-            ${surfaces.map((surface) => `<a href="${escapeDashboardHtml(surface.href)}">${escapeDashboardHtml(surface.title)}</a>`).join("")}
+            ${renderDashboardSurfaceList(surfaces)}
           </div>
         </details>
 

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -1034,10 +1034,15 @@ test("worker serves v2 dashboard for allowed owner identity without exposing sec
   assert.equal(body.includes('aria-label="Passkey operator">Passkey</a>'), false);
   assert.equal(body.includes('aria-label="Deploy operator">Deploy</a>'), false);
   assert.equal(body.includes('aria-label="通知センター">通知</a>'), true);
-  assert.equal(body.includes('aria-label="進捗を見る">進捗</a>'), true);
+  assert.equal(body.includes('aria-label="進捗を見る">進捗</a>'), false);
+  assert.equal(body.includes('aria-label="Passkey で dashboard session を更新">Passkey</a>'), true);
   assert.equal(body.includes('aria-label="Passkey">◇</a>'), false);
   assert.equal(body.includes('<label class="tool-button menu-open" for="mobile-menu-toggle">管理</label>'), false);
   assert.equal(body.includes('class="tool-button top-action"'), true);
+  assert.equal(body.includes('id="dashboard-repository-input"'), true);
+  assert.equal(body.includes('placeholder="owner/repo"'), true);
+  assert.equal(body.includes('aria-disabled="true"'), true);
+  assert.equal(body.includes("repo 設定後に開けます"), true);
   assert.equal(body.includes('id="butler-chat-form"'), true);
   assert.equal(body.includes('id="butler-chat-log"'), true);
   assert.equal(body.includes('class="icon-button"'), false);
@@ -1170,7 +1175,8 @@ test("worker serves v2 dashboard for allowed owner identity without exposing sec
   assert.equal(body.includes("/dashboard/github?repository=marushu%2Fvtdd-v2-p"), false);
   assert.equal(body.includes("/dashboard/notifications"), true);
   assert.equal(body.includes(">通知センター</a>"), true);
-  assert.equal(body.includes(">Deploy operator</a>"), true);
+  assert.equal(body.includes(">本番反映 / Passkey 承認</a>"), false);
+  assert.equal(body.includes("<strong>本番反映 / Passkey 承認</strong>"), true);
   assert.equal(body.includes("include=open_prs"), false);
   assert.equal(body.includes('name="text"'), true);
   assert.equal(/<meta[^>]+http-equiv=["']?refresh/i.test(body), false);
@@ -2957,7 +2963,8 @@ test("worker serves dashboard chat-first shell with debug and ops surfaces isola
   const debugSectionIndex = body.indexOf('data-debug-section="dashboard-development-operations"');
   assert.notEqual(debugSectionIndex, -1);
   assert.equal(body.indexOf("Operational RAG") > debugSectionIndex, true);
-  assert.equal(body.indexOf("Deploy operator") > debugSectionIndex, true);
+  assert.equal(body.indexOf("本番反映 / Passkey 承認") > debugSectionIndex, true);
+  assert.equal(body.includes(">本番反映 / Passkey 承認</a>"), true);
   assert.equal(body.indexOf("GitHub workflows") > debugSectionIndex, true);
   assert.equal(body.includes("<summary>開発/運用</summary>"), true);
   assert.equal(body.includes("<summary>Runtime surfaces</summary>"), false);

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -1061,6 +1061,7 @@ test("worker serves v2 dashboard for allowed owner identity without exposing sec
   assert.equal(body.includes("function sendOwnerMessageByHttp("), true);
   assert.equal(body.includes("function isChatSocketOpen()"), true);
   assert.equal(body.includes("function describeChatSocketState()"), true);
+  assert.equal(body.includes("function setConnectionRecoveryStatus("), true);
   assert.equal(body.includes("function buildReconnectStatus("), true);
   assert.equal(body.includes("function dropStaleSocketIfNeeded()"), true);
   assert.equal(body.includes('let lastRefreshFailure = ""'), true);
@@ -1073,10 +1074,13 @@ test("worker serves v2 dashboard for allowed owner identity without exposing sec
   assert.equal(body.includes("WebSocket 未接続のため HTTP fallback で保存しました。再接続を続けています。"), true);
   assert.equal(body.includes("sendOwnerMessageByHttp(ownerPayload, clientMessageId)"), true);
   assert.equal(body.includes("refreshThread().then"), false);
-  assert.equal(body.includes("履歴を再取得して再接続します"), true);
   assert.equal(body.includes("履歴の再取得に失敗しました。入力は保持しています。"), true);
-  assert.equal(body.includes("最後の履歴取得"), true);
-  assert.equal(body.includes("WebSocket: "), true);
+  assert.equal(body.includes("再接続 \" + attempt + \"回目"), false);
+  assert.equal(body.includes("最後の履歴取得"), false);
+  assert.equal(body.includes("WebSocket: "), false);
+  assert.equal(body.includes("status.dataset.reconnectAttempt"), true);
+  assert.equal(body.includes("status.dataset.websocketState"), true);
+  assert.equal(body.includes("接続を復帰しています。入力は保持しています。"), true);
   assert.equal(body.includes("document.addEventListener(\"visibilitychange\""), true);
   assert.equal(body.includes("window.addEventListener(\"online\""), true);
   assert.equal(body.includes("VPS Codex CLI に push します"), false);

--- a/worker.js
+++ b/worker.js
@@ -65242,7 +65242,15 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
   const dashboardTargetLabel = repositoryInput || "\u5BFE\u8C61 repo \u672A\u6307\u5B9A";
   const targetStatusMarkup = repositoryInput ? `<p><strong>${escapeDashboardHtml(repositoryInput)}</strong></p>
           <p class="muted">\u3053\u306E repo \u3067 Issue / PR \u64CD\u4F5C\u304C\u5FC5\u8981\u306A\u6642\u3060\u3051\u5BFE\u8C61\u306B\u3057\u307E\u3059\u3002\u901A\u5E38\u4F1A\u8A71\u306F\u3053\u306E\u307E\u307E\u7D9A\u3051\u3089\u308C\u307E\u3059\u3002</p>` : `<p><strong>\u5BFE\u8C61 repo \u672A\u6307\u5B9A</strong></p>
-          <p class="muted">\u901A\u5E38\u4F1A\u8A71\u306F\u7D9A\u3051\u3089\u308C\u307E\u3059\u3002Issue / PR \u64CD\u4F5C\u304C\u5FC5\u8981\u306B\u306A\u3063\u305F\u6642\u306B\u5BFE\u8C61 repo \u3092\u9078\u3073\u307E\u3059\u3002</p>`;
+          <p class="muted">\u901A\u5E38\u4F1A\u8A71\u306F\u7D9A\u3051\u3089\u308C\u307E\u3059\u3002Issue / PR / deploy \u306A\u3069 repo \u304C\u5FC5\u8981\u306A\u64CD\u4F5C\u3092\u59CB\u3081\u308B\u6642\u3060\u3051\u3001\u3053\u3053\u3067\u5BFE\u8C61 repo \u3092\u8A2D\u5B9A\u3057\u307E\u3059\u3002</p>
+          <form class="target-form" method="get" action="${escapeDashboardHtml(origin)}/dashboard">
+            <label for="dashboard-repository-input">\u5BFE\u8C61 repo</label>
+            <div class="target-form-row">
+              <input id="dashboard-repository-input" name="repository" placeholder="owner/repo" autocomplete="off" autocapitalize="off" spellcheck="false">
+              ${dashboardIssueNumber ? `<input type="hidden" name="issueNumber" value="${dashboardIssueNumber}">` : ""}
+              <button type="submit">\u8A2D\u5B9A</button>
+            </div>
+          </form>`;
   const encodedRepository = encodeURIComponent(repositoryInput);
   const chatThreadId = `dashboard-main-${(repositoryInput || "unresolved").replace(/[^a-z0-9_.-]+/gi, "-")}`;
   const socketOrigin = origin.replace(/^http/i, "ws");
@@ -65263,22 +65271,26 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
     {
       title: "Startup preflight",
       body: "AGENTS.md\u3001thread-independent startup\u3001runtime truth\u3001RAG\u3001self parity \u3092\u6700\u521D\u306B\u8AAD\u3080\u5165\u53E3\u3002",
-      href: `${origin}/dashboard/preflight?repository=${encodedRepository}`
+      href: repositoryInput ? `${origin}/dashboard/preflight?repository=${encodedRepository}` : "",
+      disabledReason: "repo \u8A2D\u5B9A\u5F8C\u306B\u958B\u3051\u307E\u3059"
     },
     {
       title: "Execution progress",
       body: "VPS Codex CLI / remote Codex execution \u306E\u9032\u6357\u78BA\u8A8D\u3002",
-      href: `${origin}/dashboard/progress?repository=${encodedRepository}`
+      href: repositoryInput ? `${origin}/dashboard/progress?repository=${encodedRepository}` : "",
+      disabledReason: "repo \u8A2D\u5B9A\u5F8C\u306B\u958B\u3051\u307E\u3059"
     },
     {
       title: "VPS runner status",
       body: "runner health\u3001queue\u3001\u5BFE\u8C61 execution \u306E\u72B6\u614B\u78BA\u8A8D\u3002",
-      href: `${origin}/dashboard/vps-runner?repository=${encodedRepository}`
+      href: repositoryInput ? `${origin}/dashboard/vps-runner?repository=${encodedRepository}` : "",
+      disabledReason: "repo \u8A2D\u5B9A\u5F8C\u306B\u958B\u3051\u307E\u3059"
     },
     {
       title: "GitHub runtime truth",
       body: "Issues\u3001PRs\u3001checks\u3001workflow runs\u3001reviewer comments \u3092\u8AAD\u3080\u5165\u53E3\u3002",
-      href: `${origin}/dashboard/github?repository=${encodedRepository}`
+      href: repositoryInput ? `${origin}/dashboard/github?repository=${encodedRepository}` : "",
+      disabledReason: "repo \u8A2D\u5B9A\u5F8C\u306B\u958B\u3051\u307E\u3059"
     },
     {
       title: "\u901A\u77E5\u30BB\u30F3\u30BF\u30FC",
@@ -65288,22 +65300,26 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
     {
       title: "Operational RAG",
       body: "decision / proposal / working memory \u306E compact retrieval\u3002runtime truth \u306E\u4EE3\u66FF\u3067\u306F\u306A\u3044\u3002",
-      href: `${origin}/dashboard/memory?repository=${encodedRepository}`
+      href: repositoryInput ? `${origin}/dashboard/memory?repository=${encodedRepository}` : "",
+      disabledReason: "repo \u8A2D\u5B9A\u5F8C\u306B\u958B\u3051\u307E\u3059"
     },
     {
       title: "Self parity",
       body: "Action Schema\u3001Instructions\u3001Cloudflare deploy freshness\u3001operator URL \u3092\u78BA\u8A8D\u3002",
-      href: `${origin}/dashboard/self-parity?repository=${encodedRepository}`
+      href: repositoryInput ? `${origin}/dashboard/self-parity?repository=${encodedRepository}` : "",
+      disabledReason: "repo \u8A2D\u5B9A\u5F8C\u306B\u958B\u3051\u307E\u3059"
     },
     {
       title: "Setup diagnostics",
       body: "Butler / Custom GPT / deploy drift \u306E\u8A3A\u65AD\u30DA\u30FC\u30B8\u3002",
-      href: `${origin}/setup/diagnostics?repository=${encodedRepository}`
+      href: repositoryInput ? `${origin}/setup/diagnostics?repository=${encodedRepository}` : "",
+      disabledReason: "repo \u8A2D\u5B9A\u5F8C\u306B\u958B\u3051\u307E\u3059"
     },
     {
-      title: "Deploy operator",
-      body: "production deploy \u306F scope \u660E\u793A\u6E08\u307F passkey approval \u306E\u5F8C\u308D\u3002approval grant \u3084 secret \u306F dashboard \u306B\u4FDD\u5B58\u3057\u306A\u3044\u3002",
-      href: `${origin}/v2/approval/passkey/operator?repositoryInput=${encodedRepository}&phase=execution&actionType=deploy_production&highRiskKind=deploy_production`
+      title: "\u672C\u756A\u53CD\u6620 / Passkey \u627F\u8A8D",
+      body: "production deploy \u306F\u5BFE\u8C61 repo \u8A2D\u5B9A\u5F8C\u3001scope \u660E\u793A\u6E08\u307F passkey approval \u306E\u5F8C\u308D\u3067\u958B\u304D\u307E\u3059\u3002",
+      href: repositoryInput ? `${origin}/v2/approval/passkey/operator?repositoryInput=${encodedRepository}&phase=execution&actionType=deploy_production&highRiskKind=deploy_production` : "",
+      disabledReason: "repo \u8A2D\u5B9A\u5F8C\u306B\u958B\u3051\u307E\u3059"
     }
   ];
   const workflows = [
@@ -65318,14 +65334,26 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
       href: `${origin}/dashboard/notifications`
     },
     {
+      label: "Passkey",
+      href: dashboardSignInUrl
+    },
+    {
       label: "\u9032\u6357\u3092\u898B\u308B",
-      href: `${origin}/dashboard/progress?repository=${encodedRepository}`
+      href: repositoryInput ? `${origin}/dashboard/progress?repository=${encodedRepository}` : "",
+      disabledReason: "repo \u8A2D\u5B9A\u5F8C"
     },
     {
       label: "GitHub\u72B6\u6CC1",
-      href: `${origin}/dashboard/github?repository=${encodedRepository}`
+      href: repositoryInput ? `${origin}/dashboard/github?repository=${encodedRepository}` : "",
+      disabledReason: "repo \u8A2D\u5B9A\u5F8C"
     }
   ];
+  const renderDashboardActionList = (actions) => actions.map(
+    (action) => action.href ? `<a href="${escapeDashboardHtml(action.href)}">${escapeDashboardHtml(action.label || action.title)}</a>` : `<span class="disabled-action" aria-disabled="true"><strong>${escapeDashboardHtml(action.label || action.title)}</strong><small>${escapeDashboardHtml(action.disabledReason || "\u5229\u7528\u3067\u304D\u307E\u305B\u3093")}</small></span>`
+  ).join("");
+  const renderDashboardSurfaceList = (items) => items.map(
+    (surface) => surface.href ? `<a href="${escapeDashboardHtml(surface.href)}">${escapeDashboardHtml(surface.title)}</a>` : `<span class="disabled-action" aria-disabled="true"><strong>${escapeDashboardHtml(surface.title)}</strong><small>${escapeDashboardHtml(surface.disabledReason || "\u5229\u7528\u3067\u304D\u307E\u305B\u3093")}</small></span>`
+  ).join("");
   return `<!doctype html>
 <html lang="ja">
 <head>
@@ -65453,7 +65481,15 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
     .deploy-event p { margin-bottom: 6px; font-size: 13px; line-height: 1.45; }
     .quick-actions, .surface-list { display: grid; gap: 8px; }
     .quick-actions { grid-template-columns: repeat(2, minmax(0, 1fr)); }
-    .quick-actions a, .surface-list a { display: inline-flex; align-items: center; justify-content: center; min-height: 36px; border: 1px solid var(--border); border-radius: 10px; padding: 7px 9px; color: var(--text); text-decoration: none; background: var(--soft); font-weight: 750; font-size: 13px; text-align: center; }
+    .quick-actions a, .surface-list a, .disabled-action { display: inline-flex; align-items: center; justify-content: center; min-height: 36px; border: 1px solid var(--border); border-radius: 10px; padding: 7px 9px; color: var(--text); text-decoration: none; background: var(--soft); font-weight: 750; font-size: 13px; text-align: center; }
+    .disabled-action { flex-direction: column; gap: 2px; color: var(--muted); background: transparent; cursor: not-allowed; }
+    .disabled-action strong { font-size: 13px; }
+    .disabled-action small { font-size: 11px; font-weight: 650; line-height: 1.2; }
+    .target-form { display: grid; gap: 6px; margin-top: 10px; }
+    .target-form label { color: var(--muted); font-size: 12px; font-weight: 800; }
+    .target-form-row { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 6px; }
+    .target-form input { min-width: 0; min-height: 38px; border: 1px solid var(--border); border-radius: 10px; padding: 7px 9px; color: var(--text); background: var(--panel); font: inherit; }
+    .target-form button { min-height: 38px; border: 1px solid var(--border); border-radius: 10px; padding: 7px 10px; color: var(--text); background: var(--button); font: inherit; font-weight: 800; }
     summary { cursor: pointer; color: var(--text); font-weight: 800; }
     .muted { color: var(--muted); }
     code { color: var(--text); overflow-wrap: anywhere; }
@@ -65504,7 +65540,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         </div>
         <div class="top-right">
           <a class="tool-button top-action" href="${escapeDashboardHtml(origin)}/dashboard/notifications" aria-label="\u901A\u77E5\u30BB\u30F3\u30BF\u30FC">\u901A\u77E5</a>
-          <a class="tool-button top-action" href="${escapeDashboardHtml(origin)}/dashboard/progress?repository=${encodedRepository}" aria-label="\u9032\u6357\u3092\u898B\u308B">\u9032\u6357</a>
+          <a class="tool-button top-action" href="${escapeDashboardHtml(dashboardSignInUrl)}" aria-label="Passkey \u3067 dashboard session \u3092\u66F4\u65B0">Passkey</a>
         </div>
       </header>
 
@@ -65529,12 +65565,12 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
             ${renderDashboardDeployEvent(latestDeployEvent)}
           </div>
           <div class="quick-actions">
-            ${cockpitActions.map((action) => `<a href="${escapeDashboardHtml(action.href)}">${escapeDashboardHtml(action.label)}</a>`).join("")}
+            ${renderDashboardActionList(cockpitActions)}
           </div>
           <details data-debug-section="dashboard-development-operations">
             <summary>\u958B\u767A/\u904B\u7528</summary>
             <div class="surface-list">
-              ${surfaces.map((surface) => `<a href="${escapeDashboardHtml(surface.href)}">${escapeDashboardHtml(surface.title)}</a>`).join("")}
+              ${renderDashboardSurfaceList(surfaces)}
             </div>
           </details>
           <details>
@@ -65609,14 +65645,14 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           <p>\u76F4\u8FD1\u306E\u53CD\u6620\u3001\u5931\u6557\u3001\u9032\u884C\u4E2D\u306E\u4F5C\u696D\u304C\u3042\u308C\u3070\u3053\u3053\u306B\u51FA\u3057\u307E\u3059\u3002</p>
           ${renderDashboardDeployEvent(latestDeployEvent)}
           <div class="quick-actions">
-            ${cockpitActions.map((action) => `<a href="${escapeDashboardHtml(action.href)}">${escapeDashboardHtml(action.label)}</a>`).join("")}
+            ${renderDashboardActionList(cockpitActions)}
           </div>
         </div>
 
         <details data-debug-section="dashboard-development-operations">
           <summary>\u958B\u767A/\u904B\u7528</summary>
           <div class="surface-list">
-            ${surfaces.map((surface) => `<a href="${escapeDashboardHtml(surface.href)}">${escapeDashboardHtml(surface.title)}</a>`).join("")}
+            ${renderDashboardSurfaceList(surfaces)}
           </div>
         </details>
 

--- a/worker.js
+++ b/worker.js
@@ -65761,10 +65761,16 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         return "\u4E0D\u660E";
       }
 
-      function buildReconnectStatus(prefix) {
+      function setConnectionRecoveryStatus(message) {
         const attempt = Math.max(1, reconnectAttempt + 1);
-        const refreshPart = lastRefreshFailure ? " \u6700\u5F8C\u306E\u5C65\u6B74\u53D6\u5F97: " + lastRefreshFailure + "\u3002" : "";
-        return prefix + " \u518D\u63A5\u7D9A " + attempt + "\u56DE\u76EE / WebSocket: " + describeChatSocketState() + "\u3002" + refreshPart;
+        status.dataset.reconnectAttempt = String(attempt);
+        status.dataset.websocketState = describeChatSocketState();
+        status.dataset.lastRefreshFailure = lastRefreshFailure || "";
+        setStatus(message);
+      }
+
+      function buildReconnectStatus(prefix) {
+        return prefix + " \u5165\u529B\u306F\u4FDD\u6301\u3057\u3066\u3044\u307E\u3059\u3002";
       }
 
       function dropStaleSocketIfNeeded() {
@@ -66304,7 +66310,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
               return { ok: false, authExpired: true };
             }
             lastRefreshFailure = "HTTP " + response.status;
-            setStatus(buildReconnectStatus("\u5C65\u6B74\u306E\u518D\u53D6\u5F97\u306B\u5931\u6557\u3057\u307E\u3057\u305F\u3002\u5165\u529B\u306F\u4FDD\u6301\u3057\u3066\u3044\u307E\u3059\u3002"));
+            setConnectionRecoveryStatus("\u5C65\u6B74\u306E\u518D\u53D6\u5F97\u306B\u5931\u6557\u3057\u307E\u3057\u305F\u3002\u5165\u529B\u306F\u4FDD\u6301\u3057\u3066\u3044\u307E\u3059\u3002");
             return { ok: false, status: response.status };
           }
           if (body && body.ok) {
@@ -66314,7 +66320,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           }
         } catch {
           lastRefreshFailure = "\u30CD\u30C3\u30C8\u30EF\u30FC\u30AF";
-          setStatus(buildReconnectStatus("\u5C65\u6B74\u306E\u518D\u53D6\u5F97\u306B\u5931\u6557\u3057\u307E\u3057\u305F\u3002\u5165\u529B\u306F\u4FDD\u6301\u3057\u3066\u3044\u307E\u3059\u3002"));
+          setConnectionRecoveryStatus("\u5C65\u6B74\u306E\u518D\u53D6\u5F97\u306B\u5931\u6557\u3057\u307E\u3057\u305F\u3002\u5165\u529B\u306F\u4FDD\u6301\u3057\u3066\u3044\u307E\u3059\u3002");
           return { ok: false, network: true };
         } finally {
           refreshingThread = false;
@@ -66325,7 +66331,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
       function scheduleReconnect() {
         if (reconnectTimer || !socketEndpoint || typeof WebSocket !== "function") return;
         const delay = Math.min(10000, 1000 * Math.pow(2, reconnectAttempt));
-        setStatus(buildReconnectStatus("WebSocket \u3092\u518D\u63A5\u7D9A\u3057\u307E\u3059\u3002\u5165\u529B\u306F\u4FDD\u6301\u3057\u3066\u3044\u307E\u3059\u3002"));
+        setConnectionRecoveryStatus("\u63A5\u7D9A\u3092\u5FA9\u5E30\u3057\u3066\u3044\u307E\u3059\u3002\u5165\u529B\u306F\u4FDD\u6301\u3057\u3066\u3044\u307E\u3059\u3002");
         reconnectAttempt += 1;
         reconnectTimer = window.setTimeout(() => {
           reconnectTimer = null;
@@ -66394,7 +66400,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
             releasePendingOwnerSend(pendingOwnerSend.clientMessageId, { clearComposer: false, keepRollbackTimer: true });
             setStatus("\u9001\u4FE1\u78BA\u8A8D\u524D\u306B WebSocket \u304C\u5207\u308C\u307E\u3057\u305F\u3002\u5165\u529B\u306F\u6B8B\u3057\u3066\u3044\u307E\u3059\u3002\u5C65\u6B74\u518D\u53D6\u5F97\u5F8C\u306B\u3082\u3046\u4E00\u5EA6\u9001\u4FE1\u3067\u304D\u307E\u3059\u3002");
           } else {
-            setStatus(buildReconnectStatus("WebSocket \u304C\u5207\u308C\u307E\u3057\u305F\u3002\u5C65\u6B74\u3092\u518D\u53D6\u5F97\u3057\u3066\u518D\u63A5\u7D9A\u3057\u307E\u3059\u3002"));
+            setConnectionRecoveryStatus("\u63A5\u7D9A\u304C\u5207\u308C\u307E\u3057\u305F\u3002\u5C65\u6B74\u3092\u78BA\u8A8D\u3057\u306A\u304C\u3089\u5FA9\u5E30\u3057\u3066\u3044\u307E\u3059\u3002");
           }
           dropStaleSocketIfNeeded();
           refreshThread();
@@ -66405,7 +66411,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
             releasePendingOwnerSend(pendingOwnerSend.clientMessageId, { clearComposer: false, keepRollbackTimer: true });
             setStatus("\u9001\u4FE1\u78BA\u8A8D\u524D\u306B WebSocket \u63A5\u7D9A\u304C\u5931\u6557\u3057\u307E\u3057\u305F\u3002\u5165\u529B\u306F\u6B8B\u3057\u3066\u3044\u307E\u3059\u3002\u518D\u63A5\u7D9A\u5F8C\u306B\u3082\u3046\u4E00\u5EA6\u9001\u4FE1\u3067\u304D\u307E\u3059\u3002");
           } else {
-            setStatus(buildReconnectStatus("WebSocket \u63A5\u7D9A\u306B\u5931\u6557\u3057\u307E\u3057\u305F\u3002\u5C65\u6B74\u3092\u518D\u53D6\u5F97\u3057\u3066\u518D\u63A5\u7D9A\u3057\u307E\u3059\u3002"));
+            setConnectionRecoveryStatus("\u63A5\u7D9A\u3067\u304D\u307E\u305B\u3093\u3067\u3057\u305F\u3002\u5C65\u6B74\u3092\u78BA\u8A8D\u3057\u306A\u304C\u3089\u5FA9\u5E30\u3057\u3066\u3044\u307E\u3059\u3002");
           }
           dropStaleSocketIfNeeded();
           refreshThread();
@@ -66570,14 +66576,14 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
       textarea.addEventListener("input", resizeComposerInput);
       window.addEventListener("resize", resizeComposerInput);
       window.addEventListener("online", () => {
-        setStatus(buildReconnectStatus("\u30CD\u30C3\u30C8\u30EF\u30FC\u30AF\u5FA9\u5E30\u3092\u691C\u77E5\u3057\u307E\u3057\u305F\u3002\u5C65\u6B74\u3092\u518D\u53D6\u5F97\u3057\u3066\u518D\u63A5\u7D9A\u3057\u307E\u3059\u3002"));
+        setConnectionRecoveryStatus("\u30CD\u30C3\u30C8\u30EF\u30FC\u30AF\u5FA9\u5E30\u3092\u691C\u77E5\u3057\u307E\u3057\u305F\u3002\u63A5\u7D9A\u3092\u5FA9\u5E30\u3057\u3066\u3044\u307E\u3059\u3002");
         dropStaleSocketIfNeeded();
         refreshThread();
         scheduleReconnect();
       });
       document.addEventListener("visibilitychange", () => {
         if (document.visibilityState === "visible" && (!chatSocket || chatSocket.readyState !== WebSocket.OPEN)) {
-          setStatus(buildReconnectStatus("\u753B\u9762\u5FA9\u5E30\u3092\u691C\u77E5\u3057\u307E\u3057\u305F\u3002\u5C65\u6B74\u3092\u518D\u53D6\u5F97\u3057\u3066\u518D\u63A5\u7D9A\u3057\u307E\u3059\u3002"));
+          setConnectionRecoveryStatus("\u753B\u9762\u5FA9\u5E30\u3092\u691C\u77E5\u3057\u307E\u3057\u305F\u3002\u63A5\u7D9A\u3092\u5FA9\u5E30\u3057\u3066\u3044\u307E\u3059\u3002");
           dropStaleSocketIfNeeded();
           refreshThread();
           scheduleReconnect();


### PR DESCRIPTION
## This PR satisfies Intent

- #526 の残 UI scope として、Dashboard topbar / drawer / Passkey / deploy operator の役割を分けます。
- repo 未指定時はただ「未指定」と表示するだけでなく、対象 repo 入力フォームを管理メニュー内に出します。
- repo が必要な進捗/GitHub/deploy/operator は、repo 未指定時にリンクとして開かず disabled 表示にします。

## Satisfied Success Criteria

- repo 未指定時に、理由と `owner/repo` 入力導線を表示します。
- topbar は通知と Passkey dashboard session に絞り、管理ドロワーとは役割を分けます。
- deploy/operator は `本番反映 / Passkey 承認` という短いラベルにし、意味不明アイコンや raw operator 感を避けます。
- repo 未指定時の deploy/operator は disabled 表示になり、No default repository を維持します。
- chat-first shell と debug/ops 隔離の既存挙動を維持します。
- WebSocket reconnect の試行回数や内部状態を owner-facing status に出さず、短い入力保持メッセージだけを表示します。

## Unsatisfied Success Criteria

- production deploy / live iPhone PWA E2E は未実施です。
- Cloudflare Access 越しの本番 visual E2E は未実施です。
- #526 close 判定は未実施です。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #526
- Implementing Success Criteria: repo 未指定表示と入力導線、topbar/drawer/Passkey/deploy operator の役割分離、mobile label overflow 回避、Dashboard chat 通常操作を邪魔しないこと。
- Explicit Non-goals: Cloudflare deploy、Cloudflare Access policy 変更、passkey authority boundary 変更、deploy workflow / GitHub token scope 変更、Issue close。
- Expected touched files/routes/workflows: `src/worker/runtime.js`, `test/worker.test.js`, `worker.js`。
- Affected Issues: #526。
- Affected PRs: PR #549 の repo optional 化に続く UI role clarity slice。
- Affected workflows: GitHub Actions workflow 定義は未変更です。
- Affected runtime/operator surfaces: `/dashboard`, `/orchestrator`, dashboard passkey operator URL, dashboard runtime surface links。
- What may break if we patch narrowly: repo 未指定時に repo-required pages をリンクとして開けるまま残すと、owner が iPhone で何を押せばよいか分からない状態が続きます。
- Unknowns to investigate before coding: live Cloudflare Access / PWA 表示は deploy 後に確認が必要です。
- Validation needed: worker tests、generated worker parity、self parity、mobile visual local E2E。
- Stop condition: passkey/deploy authority 境界を変える必要が出た場合、または default repository を暗黙設定したくなった場合は停止します。

## File / Line Hypotheses

- file: `src/worker/runtime.js`
  - hypothesis: dashboard topbar と drawer の link rendering が repo 未指定でも repo-required surfaces を通常リンクとして出すため、iPhone で操作判断が難しい。
  - risk if changed narrowly: dashboard_access まで repo 必須に戻すと PR #549 の修正を壊す。
  - validation: worker tests assert Passkey remains top-level, repo input exists, repo-required deploy/operator is disabled without repo, and deploy/operator link appears after repo is set.
  - related Issue: #526

## Hypothesis Retrospective

- expected: Dashboard access/passkey は repo-independent、進捗/GitHub/deploy は repo-dependent と分ければ、No default repository と owner-facing UX を両立できる。
- actual: worker tests passed, generated Worker parity passed, and iOS Simulator local Safari visual check showed topbar labels fit at mobile width. Follow-up also confirmed the reconnect status no longer shows `再接続27回目 / WebSocket 未接続` style debug details.
- mismatch: local simulator server has no production chat/D1/WebSocket bindings, so composer status shows local 503/reconnect text. This is not production runtime evidence.
- lesson: Dashboard Butler は chat-first で、debug/ops/deploy は repo context がある時だけ進められる形にするのが自然。
- should become RAG candidate: yes。#526 close 前の live E2E 後に、Dashboard access は repo-independent / repo-required ops are disabled until target selection、という decision を記録候補にする。

## Verification Evidence

- Unit: `node --test test/worker.test.js`: 200 pass
- Unit: `node --test test/worker.test.js test/passkey-operator-page.test.js`: 225 pass
- Integration: `npm run build:worker`: passed
- Integration: `npm run check:self-parity`: passed
- Integration: `npm run check:generated-worker`: passed after commit
- Full: `npm test`: 971 pass / 1 skip, self-parity passed, generated-worker passed
- Local mobile visual: iOS Simulator Safari opened `http://127.0.0.1:8787/dashboard`; screenshot captured at `/tmp/vtdd-dashboard-issue526-simulator.png`. Topbar showed `通知` and `Passkey` without overflow.
- Local reconnect visual follow-up: iOS Simulator screenshot captured at `/tmp/vtdd-dashboard-issue526-reconnect-status.png`; reconnect/debug details such as attempt count and WebSocket state are no longer visible in the composer status. Local server lacks production chat bindings, so this is not counted as production E2E.
- E2E: production iPhone/PWA live E2E 未実施。
- Evidence path/link: `src/worker/runtime.js`; `test/worker.test.js`; `worker.js`

## Butler Completion Contract

- Owner goal: iPhone/iPad の Dashboard Butler で、repo 未指定、管理ドロワー、Passkey、deploy/operator の意味が分かり、通常チャットが邪魔されないこと。
- Butler entrypoint: `/dashboard` and `/orchestrator`.
- Action Schema exposure: 不要。Custom GPT Action Schema は未変更です。
- Runtime path: authenticated dashboard render -> chat-first shell -> topbar Passkey / notifications -> drawer target repo and repo-required ops.
- Runner/runtime truth: local unit/integration and local iOS Simulator visual only。production runtime truth は未確認です。
- Authority boundary: dashboard_access remains repo-optional. deploy/merge/secret sync remain scoped passkey approval and repo-required.
- E2E evidence: local simulator visual only。production iPhone/PWA live E2E は未完了です。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 未実施。deploy には scoped passkey approval が必要です。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: production は未実施。local Simulator visual check のみ。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate
- AGENTS.md Chief Butler Operating Principle
- AGENTS.md Safety Invariants
- AGENTS.md Evidence Discipline
- Issue #526 Success Criteria

## Out-of-scope but NOT implemented

- Cloudflare deploy
- Cloudflare Access policy change
- Production iPhone/PWA live E2E
- Issue #526 close
- Deploy workflow / GitHub token scope changes

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #526
- Execution ID: mac-codex-issue-526-dashboard-actions-ux
- Goal: Clarify Dashboard Butler action roles and repo-required operations without changing authority boundaries

