### PR TITLE
Fix dashboard passkey scope isolation

### DIFF
--- a/src/core/passkey-operator-page.js
+++ b/src/core/passkey-operator-page.js
@@ -1,6 +1,7 @@
 export function renderPasskeyOperatorPage(input = {}) {
   const operatorMode = resolvePasskeyOperatorMode(input);
   const deployOneTapMode = operatorMode === "deploy";
+  const dashboardMode = operatorMode === "dashboard";
   const passkeyEnabled = input.passkeyEnabled !== false;
   const sectionVisibility = resolveSectionVisibility(operatorMode, { passkeyEnabled });
   const origin = escapeHtml(input.origin || "");
@@ -8,9 +9,9 @@ export function renderPasskeyOperatorPage(input = {}) {
   const syncApiBase = escapeHtml(input.syncApiBase || "");
   const registrationDefaultOperatorId = escapeHtml(input.operatorId || "vtdd-operator");
   const registrationDefaultOperatorLabel = escapeHtml(input.operatorLabel || "VTDD Operator");
-  const repoDefault = escapeHtml(input.repositoryInput || "");
-  const issueDefault = escapeHtml(input.issueNumber || "");
-  const pullNumberDefault = escapeHtml(input.pullNumber || "");
+  const repoDefault = escapeHtml(dashboardMode ? "" : input.repositoryInput || "");
+  const issueDefault = escapeHtml(dashboardMode ? "" : input.issueNumber || "");
+  const pullNumberDefault = escapeHtml(dashboardMode ? "" : input.pullNumber || "");
   const phaseDefault = escapeHtml(input.phase || "execution");
   const actionTypeDefault = escapeHtml(
     deployOneTapMode ? "deploy_production" : input.actionType || defaultActionTypeForMode(operatorMode)
@@ -219,6 +220,20 @@ export function renderPasskeyOperatorPage(input = {}) {
             <input id="action-type-input" value="${actionTypeDefault}" autocomplete="off"${deployOneTapMode ? ' readonly data-deploy-scope-locked="true"' : ""} />
             <label for="risk-kind-input">High-risk Kind</label>
             <input id="risk-kind-input" value="${highRiskKindDefault}" autocomplete="off"${deployOneTapMode ? ' readonly data-deploy-scope-locked="true"' : ""} />
+          </div>`
+              : dashboardMode
+                ? `<p>dashboard session を更新します。通知や通常 dashboard を開くための read-only 補助認証で、repo / Issue / PR scope は使いません。</p>
+          <div class="approval-internal" hidden>
+            <label for="repo-input">Repository</label>
+            <input id="repo-input" value="" placeholder="marushu/vtdd-v2-p" />
+            <label for="issue-input">Issue Number</label>
+            <input id="issue-input" value="" placeholder="15" />
+            <label for="phase-input">Phase</label>
+            <input id="phase-input" value="${phaseDefault}" />
+            <label for="action-type-input">Action Type</label>
+            <input id="action-type-input" value="read" autocomplete="off" readonly />
+            <label for="risk-kind-input">High-risk Kind</label>
+            <input id="risk-kind-input" value="dashboard_access" autocomplete="off" readonly />
           </div>`
               : `<label for="repo-input">Repository</label>
           <input id="repo-input" value="${repoDefault}" placeholder="marushu/vtdd-v2-p" />
@@ -616,6 +631,12 @@ export function renderPasskeyOperatorPage(input = {}) {
           return;
         }
         if (operatorMode === "dashboard") {
+          document.getElementById("repo-input").value = "";
+          document.getElementById("issue-input").value = "";
+          const pullNumberInput = document.getElementById("pull-number-input");
+          if (pullNumberInput) {
+            pullNumberInput.value = "";
+          }
           document.getElementById("action-type-input").value = "read";
           document.getElementById("risk-kind-input").value = "dashboard_access";
         }

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -4610,13 +4610,16 @@ function handlePasskeyOperatorPageRequest(request) {
   const syncEnabled = Boolean(syncApiBase);
   const requestedActionType = url.searchParams.get("actionType");
   const requestedHighRiskKind = url.searchParams.get("highRiskKind");
+  const requestedOperatorMode = url.searchParams.get("mode") || (requestedActionType || requestedHighRiskKind ? "" : "full");
+  const dashboardSessionMode =
+    normalizeText(requestedOperatorMode) === "dashboard" || normalizeText(requestedHighRiskKind) === "dashboard_access";
   const html = renderPasskeyOperatorPage({
     origin: url.origin,
     syncApiBase,
-    operatorMode: url.searchParams.get("mode") || (requestedActionType || requestedHighRiskKind ? "" : "full"),
-    repositoryInput: url.searchParams.get("repositoryInput"),
-    issueNumber: url.searchParams.get("issueNumber"),
-    pullNumber: url.searchParams.get("pullNumber"),
+    operatorMode: requestedOperatorMode,
+    repositoryInput: dashboardSessionMode ? "" : url.searchParams.get("repositoryInput"),
+    issueNumber: dashboardSessionMode ? "" : url.searchParams.get("issueNumber"),
+    pullNumber: dashboardSessionMode ? "" : url.searchParams.get("pullNumber"),
     phase: url.searchParams.get("phase") || "execution",
     actionType: requestedActionType,
     highRiskKind: requestedHighRiskKind,
@@ -10401,8 +10404,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
   const encodedRepository = encodeURIComponent(repositoryInput);
   const chatThreadId = `dashboard-main-${(repositoryInput || "unresolved").replace(/[^a-z0-9_.-]+/gi, "-")}`;
   const socketOrigin = origin.replace(/^http/i, "ws");
-  const dashboardSignInRepositoryParam = repositoryInput ? `&repositoryInput=${encodedRepository}` : "";
-  const dashboardSignInUrl = `${origin}/v2/approval/passkey/operator?mode=dashboard${dashboardSignInRepositoryParam}&phase=execution&actionType=read&highRiskKind=dashboard_access`;
+  const dashboardSignInUrl = `${origin}/v2/approval/passkey/operator?mode=dashboard&phase=execution&actionType=read&highRiskKind=dashboard_access`;
   const latestDeployEvent = await retrieveLatestDashboardEvent({
     store: dashboardEventStore,
     kind: "github_actions_workflow_run",

--- a/test/passkey-operator-page.test.js
+++ b/test/passkey-operator-page.test.js
@@ -269,11 +269,22 @@ test("passkey operator page shows registration only for full or explicit registr
   assert.equal(registerHtml.includes('<section data-operator-section="production-deploy" hidden>'), true);
 
   const dashboardHtml = renderPasskeyOperatorPage({
-    operatorMode: "dashboard"
+    operatorMode: "dashboard",
+    repositoryInput: "marushu/vtdd-v2-p",
+    issueNumber: 15,
+    pullNumber: 148,
+    actionType: "merge",
+    highRiskKind: "pull_merge"
   });
   assert.equal(dashboardHtml.includes('<section data-operator-section="registration" hidden>'), true);
   assert.equal(dashboardHtml.includes('<section data-operator-section="approval">'), true);
   assert.equal(dashboardHtml.includes('id="repo-input" value=""'), true);
+  assert.equal(dashboardHtml.includes('id="issue-input" value=""'), true);
+  assert.equal(dashboardHtml.includes('id="pull-number-input" value="148"'), false);
+  assert.equal(dashboardHtml.includes("repo / Issue / PR scope は使いません"), true);
+  assert.equal(dashboardHtml.includes('value="marushu/vtdd-v2-p"'), false);
+  assert.equal(dashboardHtml.includes('value="merge"'), false);
+  assert.equal(dashboardHtml.includes('value="pull_merge"'), false);
   assert.equal(dashboardHtml.includes("function readApprovalRepositoryInput()"), true);
   assert.equal(dashboardHtml.includes("const repositoryInput = readApprovalRepositoryInput();"), true);
 });

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -1036,6 +1036,13 @@ test("worker serves v2 dashboard for allowed owner identity without exposing sec
   assert.equal(body.includes('aria-label="通知センター">通知</a>'), true);
   assert.equal(body.includes('aria-label="進捗を見る">進捗</a>'), false);
   assert.equal(body.includes('aria-label="Passkey で dashboard session を更新">Passkey</a>'), true);
+  assert.equal(
+    body.includes(
+      '/v2/approval/passkey/operator?mode=dashboard&amp;phase=execution&amp;actionType=read&amp;highRiskKind=dashboard_access"'
+    ),
+    true
+  );
+  assert.equal(body.includes("mode=dashboard&amp;repositoryInput="), false);
   assert.equal(body.includes('aria-label="Passkey">◇</a>'), false);
   assert.equal(body.includes('<label class="tool-button menu-open" for="mobile-menu-toggle">管理</label>'), false);
   assert.equal(body.includes('class="tool-button top-action"'), true);
@@ -6440,7 +6447,7 @@ test("worker serves passkey operator page", async () => {
 test("worker serves dashboard passkey operator mode", async () => {
   const response = await worker.fetch(
     new Request(
-      "https://example.com/v2/approval/passkey/operator?mode=dashboard&dashboardReturnPath=%2Fdashboard%2Fnotifications"
+      "https://example.com/v2/approval/passkey/operator?mode=dashboard&repositoryInput=marushu%2Fvtdd-v2-p&issueNumber=15&pullNumber=148&dashboardReturnPath=%2Fdashboard%2Fnotifications"
     ),
     gatewayAuthEnv
   );
@@ -6448,10 +6455,14 @@ test("worker serves dashboard passkey operator mode", async () => {
   assert.equal(response.status, 200);
   const html = await response.text();
   assert.equal(html.includes('id="repo-input" value=""'), true);
+  assert.equal(html.includes('id="issue-input" value=""'), true);
+  assert.equal(html.includes('id="pull-number-input" value="148"'), false);
   assert.equal(html.includes('id="action-type-input" value="read"'), true);
   assert.equal(html.includes('id="risk-kind-input" value="dashboard_access"'), true);
   assert.equal(html.includes('const operatorMode = "dashboard"'), true);
   assert.equal(html.includes('window.location.assign("/dashboard/notifications")'), true);
+  assert.equal(html.includes("repo / Issue / PR scope は使いません"), true);
+  assert.equal(html.includes('value="marushu/vtdd-v2-p"'), false);
   assert.equal(html.includes("repositoryInput is required before approval/deploy"), true);
   assert.equal(html.includes("const repositoryInput = readApprovalRepositoryInput();"), true);
 });

--- a/worker.js
+++ b/worker.js
@@ -27246,6 +27246,7 @@ function normalize(value) {
 function renderPasskeyOperatorPage(input = {}) {
   const operatorMode = resolvePasskeyOperatorMode(input);
   const deployOneTapMode = operatorMode === "deploy";
+  const dashboardMode = operatorMode === "dashboard";
   const passkeyEnabled = input.passkeyEnabled !== false;
   const sectionVisibility = resolveSectionVisibility(operatorMode, { passkeyEnabled });
   const origin = escapeHtml(input.origin || "");
@@ -27253,9 +27254,9 @@ function renderPasskeyOperatorPage(input = {}) {
   const syncApiBase = escapeHtml(input.syncApiBase || "");
   const registrationDefaultOperatorId = escapeHtml(input.operatorId || "vtdd-operator");
   const registrationDefaultOperatorLabel = escapeHtml(input.operatorLabel || "VTDD Operator");
-  const repoDefault = escapeHtml(input.repositoryInput || "");
-  const issueDefault = escapeHtml(input.issueNumber || "");
-  const pullNumberDefault = escapeHtml(input.pullNumber || "");
+  const repoDefault = escapeHtml(dashboardMode ? "" : input.repositoryInput || "");
+  const issueDefault = escapeHtml(dashboardMode ? "" : input.issueNumber || "");
+  const pullNumberDefault = escapeHtml(dashboardMode ? "" : input.pullNumber || "");
   const phaseDefault = escapeHtml(input.phase || "execution");
   const actionTypeDefault = escapeHtml(
     deployOneTapMode ? "deploy_production" : input.actionType || defaultActionTypeForMode(operatorMode)
@@ -27456,6 +27457,18 @@ function renderPasskeyOperatorPage(input = {}) {
             <input id="action-type-input" value="${actionTypeDefault}" autocomplete="off"${deployOneTapMode ? ' readonly data-deploy-scope-locked="true"' : ""} />
             <label for="risk-kind-input">High-risk Kind</label>
             <input id="risk-kind-input" value="${highRiskKindDefault}" autocomplete="off"${deployOneTapMode ? ' readonly data-deploy-scope-locked="true"' : ""} />
+          </div>` : dashboardMode ? `<p>dashboard session \u3092\u66F4\u65B0\u3057\u307E\u3059\u3002\u901A\u77E5\u3084\u901A\u5E38 dashboard \u3092\u958B\u304F\u305F\u3081\u306E read-only \u88DC\u52A9\u8A8D\u8A3C\u3067\u3001repo / Issue / PR scope \u306F\u4F7F\u3044\u307E\u305B\u3093\u3002</p>
+          <div class="approval-internal" hidden>
+            <label for="repo-input">Repository</label>
+            <input id="repo-input" value="" placeholder="marushu/vtdd-v2-p" />
+            <label for="issue-input">Issue Number</label>
+            <input id="issue-input" value="" placeholder="15" />
+            <label for="phase-input">Phase</label>
+            <input id="phase-input" value="${phaseDefault}" />
+            <label for="action-type-input">Action Type</label>
+            <input id="action-type-input" value="read" autocomplete="off" readonly />
+            <label for="risk-kind-input">High-risk Kind</label>
+            <input id="risk-kind-input" value="dashboard_access" autocomplete="off" readonly />
           </div>` : `<label for="repo-input">Repository</label>
           <input id="repo-input" value="${repoDefault}" placeholder="marushu/vtdd-v2-p" />
           <label for="issue-input">Issue Number</label>
@@ -27847,6 +27860,12 @@ function renderPasskeyOperatorPage(input = {}) {
           return;
         }
         if (operatorMode === "dashboard") {
+          document.getElementById("repo-input").value = "";
+          document.getElementById("issue-input").value = "";
+          const pullNumberInput = document.getElementById("pull-number-input");
+          if (pullNumberInput) {
+            pullNumberInput.value = "";
+          }
           document.getElementById("action-type-input").value = "read";
           document.getElementById("risk-kind-input").value = "dashboard_access";
         }
@@ -60167,13 +60186,15 @@ function handlePasskeyOperatorPageRequest(request) {
   const syncEnabled = Boolean(syncApiBase);
   const requestedActionType = url.searchParams.get("actionType");
   const requestedHighRiskKind = url.searchParams.get("highRiskKind");
+  const requestedOperatorMode = url.searchParams.get("mode") || (requestedActionType || requestedHighRiskKind ? "" : "full");
+  const dashboardSessionMode = normalizeText30(requestedOperatorMode) === "dashboard" || normalizeText30(requestedHighRiskKind) === "dashboard_access";
   const html2 = renderPasskeyOperatorPage({
     origin: url.origin,
     syncApiBase,
-    operatorMode: url.searchParams.get("mode") || (requestedActionType || requestedHighRiskKind ? "" : "full"),
-    repositoryInput: url.searchParams.get("repositoryInput"),
-    issueNumber: url.searchParams.get("issueNumber"),
-    pullNumber: url.searchParams.get("pullNumber"),
+    operatorMode: requestedOperatorMode,
+    repositoryInput: dashboardSessionMode ? "" : url.searchParams.get("repositoryInput"),
+    issueNumber: dashboardSessionMode ? "" : url.searchParams.get("issueNumber"),
+    pullNumber: dashboardSessionMode ? "" : url.searchParams.get("pullNumber"),
     phase: url.searchParams.get("phase") || "execution",
     actionType: requestedActionType,
     highRiskKind: requestedHighRiskKind,
@@ -65254,8 +65275,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
   const encodedRepository = encodeURIComponent(repositoryInput);
   const chatThreadId = `dashboard-main-${(repositoryInput || "unresolved").replace(/[^a-z0-9_.-]+/gi, "-")}`;
   const socketOrigin = origin.replace(/^http/i, "ws");
-  const dashboardSignInRepositoryParam = repositoryInput ? `&repositoryInput=${encodedRepository}` : "";
-  const dashboardSignInUrl = `${origin}/v2/approval/passkey/operator?mode=dashboard${dashboardSignInRepositoryParam}&phase=execution&actionType=read&highRiskKind=dashboard_access`;
+  const dashboardSignInUrl = `${origin}/v2/approval/passkey/operator?mode=dashboard&phase=execution&actionType=read&highRiskKind=dashboard_access`;
   const latestDeployEvent = await retrieveLatestDashboardEvent({
     store: dashboardEventStore,
     kind: "github_actions_workflow_run",


### PR DESCRIPTION
## This PR satisfies Intent

- #526: Dashboard Butler の通知・auth・passkey fallback を iPhone/PWA owner-facing workflow として扱い、dashboard_access と deploy/merge 等の高リスク approval scope を混同しない。

## Satisfied Success Criteria

- Dashboard 上部の Passkey session 更新 URL から repositoryInput を外し、通常 dashboard chat の repo 未指定状態と同じ read-only dashboard_access 導線にした。
- /v2/approval/passkey/operator?mode=dashboard は repositoryInput / issueNumber / pullNumber が付いていても UI と送信 scope から除外する。
- operator page の dashboard mode は repo / Issue / PR scope を使わないことを明示し、actionType=read / highRiskKind=dashboard_access に固定する。

## Unsatisfied Success Criteria

- Production deploy 後の live iPhone/PWA E2E と Issue close はこのPR単体では未実施。merge 後、deploy と実機/PWA確認が必要。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: #526
- Implementing Success Criteria: 通知から dashboard fallback に入っても未認証相手に通知詳細は漏らさず、passkey fallback は dashboard_access 専用で repo / Issue / PR / deploy scope を持たない。
- Explicit Non-goals: Cloudflare Access policy 変更、credential/secret 変更、production deploy 実行、Issue close。
- Expected touched files/routes/workflows: src/core/passkey-operator-page.js, src/worker/runtime.js, test/passkey-operator-page.test.js, test/worker.test.js, worker.js
- Affected Issues: #526
- Affected PRs: #550 の live E2E で発見した追加 gap の follow-up。
- Affected workflows: deploy-production は未変更。merge 後の production deploy で反映確認が必要。
- Affected runtime/operator surfaces: Dashboard auth page, Dashboard topbar Passkey link, /v2/approval/passkey/operator dashboard mode, generated worker.js
- What may break if we patch narrowly: deploy/merge/secret sync operator modeまで repo を外すと高リスク操作の authority boundary が壊れるため、dashboard mode だけに限定した。
- Unknowns to investigate before coding: 本番反映後に iOS PWA / real notification tap で passkey session cookie が期待通り dashboard に戻るかは live E2E が必要。
- Validation needed: node --test test/passkey-operator-page.test.js, node --test test/worker.test.js, npm test after commit, iOS Simulator/PWA live E2E after deploy.
- Stop condition: dashboard_access 以外の high-risk operator scope に repo optional 挙動が漏れる場合は停止。

## File / Line Hypotheses

- file: `src/worker/runtime.js:4610`
  - hypothesis: handler が mode=dashboard でも URL の repositoryInput/issueNumber/pullNumber を render に渡すと dashboard_access UI が古い high-risk context を表示する。
  - risk if changed narrowly: deploy/merge operator の repo-required path を壊す。
  - validation: worker dashboard operator mode test で dashboard mode のみ stale scope を無視する。
  - related Issue: #526
- file: `src/worker/runtime.js:10404`
  - hypothesis: authenticated dashboard topbar の Passkey URL が repo 付きで dashboard_access を作ると read-only session 更新と repo-scoped operation が混ざる。
  - risk if changed narrowly: repo 設定済み dashboard の通常管理リンクまで外すと GitHub/deploy pages が使いにくくなる。
  - validation: dashboard shell test で topbar Passkey に repositoryInput が含まれないことを確認する。
  - related Issue: #526
- file: `src/core/passkey-operator-page.js:1`
  - hypothesis: render 層でも dashboardMode を repo/Issue/PR scope から切り離す二重防御が必要。
  - risk if changed narrowly: hidden input に stale value が残ると challenge body に混入する。
  - validation: passkey operator page test で stale merge input を渡しても dashboard UI に出ないことを確認する。
  - related Issue: #526

## Hypothesis Retrospective

- expected: auth required page は既に repo-free だが、authenticated dashboard または malformed dashboard operator URL で stale repo/issue が混ざる。
- actual: production auth page と direct dashboard operator は repo-free。コード上、authenticated dashboard topbar は repo 付き URL を生成し、handler は dashboard mode の repo/issue query を無視していなかった。
- mismatch: ブラウザ localStorage 復元ではなく、URL scope 混入が主因だった。
- lesson: dashboard_access は route handler と renderer の両方で repo/Issue/PR scope を拒否する必要がある。
- should become RAG candidate: true

## Verification Evidence

- Unit: node --test test/passkey-operator-page.test.js: 25 pass
- Integration: node --test test/worker.test.js: 200 pass
- E2E: 未実施。merge/deploy 後に iOS Simulator/PWA live E2E を実行する。
- Manual: production auth page/direct operator curl で repo-free URL と empty dashboard operator を確認済み。
- Evidence path/link: PR body verification section and post-merge live E2E予定。

## Butler Completion Contract

- Owner goal: 通知や dashboard からの passkey fallback を踏んでも、dashboard_access が deploy/merge/repo scope と混ざらず dashboard に入れる補助認証にする。
- Butler entrypoint: Dashboard auth page と dashboard topbar の Passkey fallback。Custom GPT Action Schema は未変更。
- Action Schema exposure: 未変更。既存 runtime route /v2/approval/passkey/operator の dashboard mode を補正。
- Runtime path: /dashboard, /dashboard/notifications, /v2/approval/passkey/operator?mode=dashboard
- Runner/runtime truth: worker tests と generated worker.js で runtime path を検証。production runtime truth は merge/deploy 後に確認。
- Authority boundary: dashboard_access は read-only dashboard session。deploy/merge/secret sync の high-risk approval は repo-required のまま維持。
- E2E evidence: このPRではローカル/worker E2E相当まで。merge/deploy 後に iOS Simulator/PWA live E2E を実施する。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: merge 後に scoped passkey approval が必要。
- Custom GPT Action Schema update: 不要。Action schema ではなく dashboard runtime fallback の修正。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: merge/deploy 後に実施。

## Related Constitution Rules

- Butler Completion Gate
- Butler-First Operating Principle
- Authority Boundary
- Evidence Discipline
- Current Reality Guard

## Out-of-scope but NOT implemented

- Cloudflare Access ログインループそのものの policy/browser compatibility 改修。
- Dashboard chat の通常会話 UX 改修。
- Issue #526 の closure judgment。

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #526
- Execution ID: Not provided.
- Goal: Not provided.
