### PR TITLE
Constrain dashboard passkey mode guard

### DIFF
--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -4611,8 +4611,7 @@ function handlePasskeyOperatorPageRequest(request) {
   const requestedActionType = url.searchParams.get("actionType");
   const requestedHighRiskKind = url.searchParams.get("highRiskKind");
   const requestedOperatorMode = url.searchParams.get("mode") || (requestedActionType || requestedHighRiskKind ? "" : "full");
-  const dashboardSessionMode =
-    normalizeText(requestedOperatorMode) === "dashboard" || normalizeText(requestedHighRiskKind) === "dashboard_access";
+  const dashboardSessionMode = normalizeText(requestedOperatorMode) === "dashboard";
   const html = renderPasskeyOperatorPage({
     origin: url.origin,
     syncApiBase,

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -6467,6 +6467,24 @@ test("worker serves dashboard passkey operator mode", async () => {
   assert.equal(html.includes("const repositoryInput = readApprovalRepositoryInput();"), true);
 });
 
+test("worker keeps explicit non-dashboard operator modes repo-scoped even with dashboard_access conflict", async () => {
+  const response = await worker.fetch(
+    new Request(
+      "https://example.com/v2/approval/passkey/operator?mode=deploy&repositoryInput=marushu%2Fvtdd-v2-p&issueNumber=15&phase=execution&highRiskKind=dashboard_access"
+    ),
+    gatewayAuthEnv
+  );
+
+  assert.equal(response.status, 200);
+  const html = await response.text();
+  assert.equal(html.includes('const operatorMode = "deploy"'), true);
+  assert.equal(html.includes('id="repo-input" value="marushu/vtdd-v2-p"'), true);
+  assert.equal(html.includes('id="issue-input" value="15"'), true);
+  assert.equal(html.includes('id="action-type-input" value="deploy_production"'), true);
+  assert.equal(html.includes('id="risk-kind-input" value="deploy_production"'), true);
+  assert.equal(html.includes("repo / Issue / PR scope は使いません"), false);
+});
+
 test("worker serves issue close operator mode without falling back to PR merge UI", async () => {
   const response = await worker.fetch(
     new Request(

--- a/worker.js
+++ b/worker.js
@@ -60187,7 +60187,7 @@ function handlePasskeyOperatorPageRequest(request) {
   const requestedActionType = url.searchParams.get("actionType");
   const requestedHighRiskKind = url.searchParams.get("highRiskKind");
   const requestedOperatorMode = url.searchParams.get("mode") || (requestedActionType || requestedHighRiskKind ? "" : "full");
-  const dashboardSessionMode = normalizeText30(requestedOperatorMode) === "dashboard" || normalizeText30(requestedHighRiskKind) === "dashboard_access";
+  const dashboardSessionMode = normalizeText30(requestedOperatorMode) === "dashboard";
   const html2 = renderPasskeyOperatorPage({
     origin: url.origin,
     syncApiBase,


### PR DESCRIPTION
## This PR satisfies Intent

- #526: Dashboard passkey fallback の dashboard_access 専用化に対して、明示的な非dashboard operator mode の repo-required authority boundary を保持する。

## Satisfied Success Criteria

- mode=dashboard の時だけ dashboard session scope として repositoryInput / issueNumber / pullNumber を破棄する。
- mode=deploy 等の明示 operator mode では highRiskKind=dashboard_access が混入しても deploy_production の repo-required scope に固定されることを回帰テストした。
- PR #551 reviewer が指摘した residual risk を deploy 前に狭く解消した。

## Unsatisfied Success Criteria

- Production deploy 後の live iOS/PWA E2E と Issue close はこのPR単体では未実施。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: #526
- Implementing Success Criteria: dashboard_access の補助認証は dashboard mode に限定し、deploy/merge/secret sync の high-risk operator scope は repo-required のまま壊さない。
- Explicit Non-goals: Cloudflare Access policy 変更、credential/secret 変更、production deploy 実行、Issue close。
- Expected touched files/routes/workflows: src/worker/runtime.js, test/worker.test.js, worker.js
- Affected Issues: #526
- Affected PRs: #551 の Codex fallback reviewer residual risk follow-up。
- Affected workflows: deploy-production は未変更。merge 後に production deploy で反映確認が必要。
- Affected runtime/operator surfaces: /v2/approval/passkey/operator handler, dashboard/deploy operator mode rendering, generated worker.js
- What may break if we patch narrowly: dashboard_access highRiskKind だけで dashboard扱いすると mode=deploy 等の明示 operator URL の repo-required scope を消す可能性がある。
- Unknowns to investigate before coding: 実機/PWA の通知タップ後 dashboard session cookie 挙動は deploy 後 live E2E が必要。
- Validation needed: node --test test/worker.test.js, npm test, post-deploy iOS Simulator/PWA live E2E.
- Stop condition: 非dashboard operator mode で repo/issue/pull scope が消える場合は停止。

## File / Line Hypotheses

- file: `src/worker/runtime.js:4610`
  - hypothesis: dashboardSessionMode は mode=dashboard だけで判定すべき。highRiskKind=dashboard_access だけで true にすると明示 mode と衝突する。
  - risk if changed narrowly: highRiskKind だけの legacy dashboard URL では handler が repo を渡すが、renderer 側 dashboardMode が repo/issue/pull を消すため dashboard fallback は維持される。
  - validation: explicit mode=deploy + highRiskKind=dashboard_access の worker test。
  - related Issue: #526

## Hypothesis Retrospective

- expected: PR #551 の reviewer residual risk は handler predicate を mode=dashboard 限定にすれば潰せる。
- actual: mode=deploy + highRiskKind=dashboard_access は repo と issue を保持し、deploy_production scope に固定されるテストを追加した。
- mismatch: なし。
- lesson: dashboard fallback の safety は handler と renderer で分担し、handler は明示 mode を尊重する。
- should become RAG candidate: true

## Verification Evidence

- Unit: node --test test/worker.test.js: 201 pass
- Integration: npm test: 972 pass / 1 skip; self-parity passed; generated-worker passed
- E2E: 未実施。merge/deploy 後に iOS Simulator/PWA live E2E を実施する。
- Manual: PR #551 reviewer residual risk をコード上で確認し、follow-up test に変換した。
- Evidence path/link: PR #551 reviewer comment and this PR verification evidence.

## Butler Completion Contract

- Owner goal: 通知/dashboard passkey fallback を安全にしつつ、deploy/merge 等の高リスク operator が repo-required のまま動く状態を守る。
- Butler entrypoint: Dashboard auth/topbar Passkey fallback。Action Schema は未変更。
- Action Schema exposure: 未変更。runtime handler の mode guard のみ。
- Runtime path: /v2/approval/passkey/operator?mode=dashboard と明示 mode=deploy の衝突ケース。
- Runner/runtime truth: worker test と generated worker.js で検証。production runtime truth は merge/deploy 後。
- Authority boundary: dashboard_access は dashboard mode 限定の read-only session。deploy mode は deploy_production に固定し repo-required を維持。
- E2E evidence: このPRではローカル/worker evidence まで。merge/deploy 後に live E2E。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: merge 後に scoped passkey approval が必要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: merge/deploy 後に実施。

## Related Constitution Rules

- Butler Completion Gate
- Butler-First Operating Principle
- Authority Boundary
- Evidence Discipline
- Reviewer role as blocking risk signal

## Out-of-scope but NOT implemented

- Cloudflare Access login loop policy/browser compatibility。
- Issue #526 closure judgment。

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #526
- Execution ID: Not provided.
- Goal: Not provided.
