### PR TITLE
dashboard: passkey fallback を読み取り用表示に分離する

### DIFF
--- a/src/core/passkey-operator-page.js
+++ b/src/core/passkey-operator-page.js
@@ -22,6 +22,7 @@ export function renderPasskeyOperatorPage(input = {}) {
   const mergeMethodDefault = escapeHtml(input.mergeMethod || "squash");
   const returnUrl = escapeHtml(input.returnUrl || "");
   const dashboardReturnPath = escapeHtml(sanitizePasskeyDashboardReturnPath(input.dashboardReturnPath));
+  const dashboardNotificationMode = dashboardMode && dashboardReturnPath === "/dashboard/notifications";
   const githubAppRoleDefault = escapeHtml(input.githubAppRole || "legacy");
   const syncEnabled = input.syncEnabled === true;
   const syncMessage = escapeHtml(
@@ -33,7 +34,24 @@ export function renderPasskeyOperatorPage(input = {}) {
   const approvalSectionAttributes = deployOneTapMode
     ? ' data-owner-flow="one-tap-deploy"'
     : "";
-  const approveButtonLabel = deployOneTapMode ? "パスキー" : "Approve high-risk action";
+  const approveButtonLabel = deployOneTapMode
+    ? "パスキー"
+    : dashboardNotificationMode
+      ? "パスキーで通知を見る"
+      : dashboardMode
+        ? "パスキーで開く"
+        : "Approve high-risk action";
+  const heroTitle = dashboardMode ? "Dashboard Passkey" : "VTDD Passkey Operator";
+  const heroDescription = dashboardMode
+    ? "このページは Dashboard Butler を開くための読み取り専用パスキー確認です。Cloudflare Access が使えない時だけ、同一 origin の passkey で dashboard session を更新します。"
+    : "このページは real WebAuthn/passkey approval 用の operator helper です。登録と high-risk approval の両方を same-origin で実行し、最終的に <code>approvalGrantId</code> を取得できます。";
+  const approvalHeading = deployOneTapMode
+    ? "本番反映の承認"
+    : dashboardNotificationMode
+      ? "通知を見る"
+      : dashboardMode
+        ? "Dashboard を開く"
+        : "2. High-risk Approval";
   const deployScopeSummary = renderDeployScopeSummary({
     repositoryInput: repoDefault,
     issueNumber: issueDefault,
@@ -182,8 +200,8 @@ export function renderPasskeyOperatorPage(input = {}) {
   <body>
     <main>
       <div class="hero">
-        <h1>VTDD Passkey Operator</h1>
-        <p>このページは real WebAuthn/passkey approval 用の operator helper です。登録と high-risk approval の両方を same-origin で実行し、最終的に <code>approvalGrantId</code> を取得できます。</p>
+        <h1>${heroTitle}</h1>
+        <p>${heroDescription}</p>
         <p class="muted">origin: ${origin || "[same-origin]"}</p>
       </div>
 
@@ -204,7 +222,7 @@ export function renderPasskeyOperatorPage(input = {}) {
         </section>
 
         <section data-operator-section="approval"${approvalSectionAttributes}${hiddenAttribute(!sectionVisibility.approval)}>
-          <h2>${deployOneTapMode ? "本番反映の承認" : "2. High-risk Approval"}</h2>
+          <h2>${approvalHeading}</h2>
           ${
             deployOneTapMode
               ? `<p>production deploy を承認して、そのまま反映を開始します。</p>
@@ -222,7 +240,7 @@ export function renderPasskeyOperatorPage(input = {}) {
             <input id="risk-kind-input" value="${highRiskKindDefault}" autocomplete="off"${deployOneTapMode ? ' readonly data-deploy-scope-locked="true"' : ""} />
           </div>`
               : dashboardMode
-                ? `<p>dashboard session を更新します。通知や通常 dashboard を開くための read-only 補助認証で、repo / Issue / PR scope は使いません。</p>
+                ? `<p>${dashboardNotificationMode ? "通知センター" : "Dashboard"}を開くための read-only session を更新します。この確認では repo / Issue / PR scope は使いません。</p>
           <div class="approval-internal" hidden>
             <label for="repo-input">Repository</label>
             <input id="repo-input" value="" placeholder="marushu/vtdd-v2-p" />
@@ -248,10 +266,10 @@ export function renderPasskeyOperatorPage(input = {}) {
           }
           <div class="row">
             <button class="secondary" id="approve-button">${approveButtonLabel}</button>
-            ${deployOneTapMode ? "" : '<button class="ghost" id="copy-approval-grant-button" type="button">Copy approvalGrantId</button>'}
+            ${deployOneTapMode || dashboardMode ? "" : '<button class="ghost" id="copy-approval-grant-button" type="button">Copy approvalGrantId</button>'}
           </div>
           ${
-            deployOneTapMode
+            deployOneTapMode || dashboardMode
               ? '<input id="auto-copy-approval-grant-input" type="checkbox" hidden />'
               : `<label class="inline-check" for="auto-copy-approval-grant-input">
             <input id="auto-copy-approval-grant-input" type="checkbox" />

--- a/test/passkey-operator-page.test.js
+++ b/test/passkey-operator-page.test.js
@@ -278,6 +278,13 @@ test("passkey operator page shows registration only for full or explicit registr
   });
   assert.equal(dashboardHtml.includes('<section data-operator-section="registration" hidden>'), true);
   assert.equal(dashboardHtml.includes('<section data-operator-section="approval">'), true);
+  assert.equal(dashboardHtml.includes("<h1>Dashboard Passkey</h1>"), true);
+  assert.equal(dashboardHtml.includes("<h2>Dashboard を開く</h2>"), true);
+  assert.equal(dashboardHtml.includes('id="approve-button">パスキーで開く</button>'), true);
+  assert.equal(dashboardHtml.includes("読み取り専用パスキー確認"), true);
+  assert.equal(dashboardHtml.includes("Copy approvalGrantId"), false);
+  assert.equal(dashboardHtml.includes("Auto-copy approvalGrantId after approval"), false);
+  assert.equal(dashboardHtml.includes("Approve high-risk action"), false);
   assert.equal(dashboardHtml.includes('id="repo-input" value=""'), true);
   assert.equal(dashboardHtml.includes('id="issue-input" value=""'), true);
   assert.equal(dashboardHtml.includes('id="pull-number-input" value="148"'), false);
@@ -294,6 +301,10 @@ test("passkey operator dashboard mode returns to sanitized dashboard path after 
     operatorMode: "dashboard",
     dashboardReturnPath: "/dashboard/notifications?runId=private"
   });
+  assert.equal(notificationsHtml.includes("<h2>通知を見る</h2>"), true);
+  assert.equal(notificationsHtml.includes('id="approve-button">パスキーで通知を見る</button>'), true);
+  assert.equal(notificationsHtml.includes("通知センターを開くための read-only session"), true);
+  assert.equal(notificationsHtml.includes("Approve high-risk action"), false);
   assert.equal(notificationsHtml.includes('window.location.assign("/dashboard/notifications")'), true);
   assert.equal(notificationsHtml.includes("runId=private"), false);
 

--- a/worker.js
+++ b/worker.js
@@ -27267,13 +27267,17 @@ function renderPasskeyOperatorPage(input = {}) {
   const mergeMethodDefault = escapeHtml(input.mergeMethod || "squash");
   const returnUrl = escapeHtml(input.returnUrl || "");
   const dashboardReturnPath = escapeHtml(sanitizePasskeyDashboardReturnPath(input.dashboardReturnPath));
+  const dashboardNotificationMode = dashboardMode && dashboardReturnPath === "/dashboard/notifications";
   const githubAppRoleDefault = escapeHtml(input.githubAppRole || "legacy");
   const syncEnabled = input.syncEnabled === true;
   const syncMessage = escapeHtml(
     input.syncMessage || (syncEnabled ? "approvalGrantId \u304C\u53D6\u5F97\u6E08\u307F\u306A\u3089\u5B9F\u884C\u3067\u304D\u307E\u3059\u3002desktop helper bridge \u306B\u63A5\u7D9A\u3057\u307E\u3059\u3002" : "desktop maintenance required: local secret sync bridge \u304C\u672A\u63A5\u7D9A\u3067\u3059\u3002")
   );
   const approvalSectionAttributes = deployOneTapMode ? ' data-owner-flow="one-tap-deploy"' : "";
-  const approveButtonLabel = deployOneTapMode ? "\u30D1\u30B9\u30AD\u30FC" : "Approve high-risk action";
+  const approveButtonLabel = deployOneTapMode ? "\u30D1\u30B9\u30AD\u30FC" : dashboardNotificationMode ? "\u30D1\u30B9\u30AD\u30FC\u3067\u901A\u77E5\u3092\u898B\u308B" : dashboardMode ? "\u30D1\u30B9\u30AD\u30FC\u3067\u958B\u304F" : "Approve high-risk action";
+  const heroTitle = dashboardMode ? "Dashboard Passkey" : "VTDD Passkey Operator";
+  const heroDescription = dashboardMode ? "\u3053\u306E\u30DA\u30FC\u30B8\u306F Dashboard Butler \u3092\u958B\u304F\u305F\u3081\u306E\u8AAD\u307F\u53D6\u308A\u5C02\u7528\u30D1\u30B9\u30AD\u30FC\u78BA\u8A8D\u3067\u3059\u3002Cloudflare Access \u304C\u4F7F\u3048\u306A\u3044\u6642\u3060\u3051\u3001\u540C\u4E00 origin \u306E passkey \u3067 dashboard session \u3092\u66F4\u65B0\u3057\u307E\u3059\u3002" : "\u3053\u306E\u30DA\u30FC\u30B8\u306F real WebAuthn/passkey approval \u7528\u306E operator helper \u3067\u3059\u3002\u767B\u9332\u3068 high-risk approval \u306E\u4E21\u65B9\u3092 same-origin \u3067\u5B9F\u884C\u3057\u3001\u6700\u7D42\u7684\u306B <code>approvalGrantId</code> \u3092\u53D6\u5F97\u3067\u304D\u307E\u3059\u3002";
+  const approvalHeading = deployOneTapMode ? "\u672C\u756A\u53CD\u6620\u306E\u627F\u8A8D" : dashboardNotificationMode ? "\u901A\u77E5\u3092\u898B\u308B" : dashboardMode ? "Dashboard \u3092\u958B\u304F" : "2. High-risk Approval";
   const deployScopeSummary = renderDeployScopeSummary({
     repositoryInput: repoDefault,
     issueNumber: issueDefault,
@@ -27421,8 +27425,8 @@ function renderPasskeyOperatorPage(input = {}) {
   <body>
     <main>
       <div class="hero">
-        <h1>VTDD Passkey Operator</h1>
-        <p>\u3053\u306E\u30DA\u30FC\u30B8\u306F real WebAuthn/passkey approval \u7528\u306E operator helper \u3067\u3059\u3002\u767B\u9332\u3068 high-risk approval \u306E\u4E21\u65B9\u3092 same-origin \u3067\u5B9F\u884C\u3057\u3001\u6700\u7D42\u7684\u306B <code>approvalGrantId</code> \u3092\u53D6\u5F97\u3067\u304D\u307E\u3059\u3002</p>
+        <h1>${heroTitle}</h1>
+        <p>${heroDescription}</p>
         <p class="muted">origin: ${origin || "[same-origin]"}</p>
       </div>
 
@@ -27443,7 +27447,7 @@ function renderPasskeyOperatorPage(input = {}) {
         </section>
 
         <section data-operator-section="approval"${approvalSectionAttributes}${hiddenAttribute(!sectionVisibility.approval)}>
-          <h2>${deployOneTapMode ? "\u672C\u756A\u53CD\u6620\u306E\u627F\u8A8D" : "2. High-risk Approval"}</h2>
+          <h2>${approvalHeading}</h2>
           ${deployOneTapMode ? `<p>production deploy \u3092\u627F\u8A8D\u3057\u3066\u3001\u305D\u306E\u307E\u307E\u53CD\u6620\u3092\u958B\u59CB\u3057\u307E\u3059\u3002</p>
           <p class="muted">${deployScopeSummary}</p>
           <div class="approval-internal" hidden>
@@ -27457,7 +27461,7 @@ function renderPasskeyOperatorPage(input = {}) {
             <input id="action-type-input" value="${actionTypeDefault}" autocomplete="off"${deployOneTapMode ? ' readonly data-deploy-scope-locked="true"' : ""} />
             <label for="risk-kind-input">High-risk Kind</label>
             <input id="risk-kind-input" value="${highRiskKindDefault}" autocomplete="off"${deployOneTapMode ? ' readonly data-deploy-scope-locked="true"' : ""} />
-          </div>` : dashboardMode ? `<p>dashboard session \u3092\u66F4\u65B0\u3057\u307E\u3059\u3002\u901A\u77E5\u3084\u901A\u5E38 dashboard \u3092\u958B\u304F\u305F\u3081\u306E read-only \u88DC\u52A9\u8A8D\u8A3C\u3067\u3001repo / Issue / PR scope \u306F\u4F7F\u3044\u307E\u305B\u3093\u3002</p>
+          </div>` : dashboardMode ? `<p>${dashboardNotificationMode ? "\u901A\u77E5\u30BB\u30F3\u30BF\u30FC" : "Dashboard"}\u3092\u958B\u304F\u305F\u3081\u306E read-only session \u3092\u66F4\u65B0\u3057\u307E\u3059\u3002\u3053\u306E\u78BA\u8A8D\u3067\u306F repo / Issue / PR scope \u306F\u4F7F\u3044\u307E\u305B\u3093\u3002</p>
           <div class="approval-internal" hidden>
             <label for="repo-input">Repository</label>
             <input id="repo-input" value="" placeholder="marushu/vtdd-v2-p" />
@@ -27481,9 +27485,9 @@ function renderPasskeyOperatorPage(input = {}) {
           <input id="risk-kind-input" value="${highRiskKindDefault}" />`}
           <div class="row">
             <button class="secondary" id="approve-button">${approveButtonLabel}</button>
-            ${deployOneTapMode ? "" : '<button class="ghost" id="copy-approval-grant-button" type="button">Copy approvalGrantId</button>'}
+            ${deployOneTapMode || dashboardMode ? "" : '<button class="ghost" id="copy-approval-grant-button" type="button">Copy approvalGrantId</button>'}
           </div>
-          ${deployOneTapMode ? '<input id="auto-copy-approval-grant-input" type="checkbox" hidden />' : `<label class="inline-check" for="auto-copy-approval-grant-input">
+          ${deployOneTapMode || dashboardMode ? '<input id="auto-copy-approval-grant-input" type="checkbox" hidden />' : `<label class="inline-check" for="auto-copy-approval-grant-input">
             <input id="auto-copy-approval-grant-input" type="checkbox" />
             Auto-copy approvalGrantId after approval
           </label>`}


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #532 の passkey operator owner-facing flow の部分進捗です。
- Dashboard 通知 fallback が read-only なのに high-risk approval / approvalGrantId copy を通常表示していたため、通知閲覧用のパスキー確認として表示を分離しました。

## Satisfied Success Criteria

- Dashboard mode の hero を `Dashboard Passkey` / 読み取り専用パスキー確認に変更。
- Dashboard 通知 return path では主ボタンを `パスキーで通知を見る` に変更。
- Dashboard mode では `Copy approvalGrantId` と `Auto-copy approvalGrantId` を通常表示しない。
- repo / Issue / PR scope を使わない read-only session 更新であることを表示し、redirect sanitize は維持。

## Unsatisfied Success Criteria

- Issue #532 全体の deploy approval 1ボタン flow completion はこのPRだけでは完了扱いにしない。
- 本番 deploy と iPhone/PWA live E2E はこのPRでは未実施。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #532
- Implementing Success Criteria: passkey operator の owner-facing 表示から dashboard read-only fallback に不要な high-risk/copy 表現を外す。
- Explicit Non-goals: Cloudflare Access 設定、passkey 安全境界、credential/permission/deploy workflow は変更しない。
- Expected touched files/routes/workflows: `src/core/passkey-operator-page.js`, `test/passkey-operator-page.test.js`, `worker.js`
- Affected Issues: Issue #532, Issue #528, Issue #534
- Affected PRs: PR #553 の post-deploy live observation で見つかった UX gap を受けた小修正。
- Affected workflows: なし。
- Affected runtime/operator surfaces: Passkey operator page / Dashboard auth fallback.
- What may break if we patch narrowly: dashboard mode だけを変え、deploy/merge/secret sync の high-risk operator 表示を崩さない必要がある。
- Unknowns to investigate before coding: 実機 passkey 成功後の dashboardReturnPath 復帰は既存テストで sanitize 済み。実機 live E2E は別途必要。
- Validation needed: `node --test test/passkey-operator-page.test.js test/worker.test.js`; `npm run build:worker`; `npm run check:generated-worker`; `npm run check:self-parity`
- Stop condition: passkey approval scope や Cloudflare Access 境界を緩める必要が出た場合は停止。

## File / Line Hypotheses

- file: `src/core/passkey-operator-page.js`
  - hypothesis: `operatorMode=dashboard` の表示分岐だけで、read-only fallback の不快な high-risk/copy 表現を消せる。
  - risk if changed narrowly: deploy/merge/secret sync の approvalGrantId flow を誤って隠すと運用操作が壊れる。
  - validation: dashboard/deploy/full mode の HTML tests と worker tests。
  - related Issue: #532

## Hypothesis Retrospective

- expected: dashboard mode だけで `Dashboard Passkey` / `パスキーで通知を見る` が出て、`Copy approvalGrantId` と `Approve high-risk action` は出ない。
- actual: `test/passkey-operator-page.test.js` と `test/worker.test.js` で確認。
- mismatch: なし。
- lesson: dashboard read-only fallback は high-risk operator と同じテンプレートを使っても、表示上は別導線として扱う必要がある。
- should become RAG candidate: はい。Dashboard Butler の通常導線では debug/approvalGrantId 表示を隔離する判断。

## Verification Evidence

- Unit: `node --test test/passkey-operator-page.test.js test/worker.test.js`: 227 pass / 0 fail
- Integration: `npm run build:worker`; `npm run check:generated-worker`; `npm run check:self-parity`: pass
- E2E: 未実施。このPRは表示分岐の unit/integration スライス。
- Manual: PR #553 post-deploy Simulator 観察で dashboard passkey fallback が high-risk 表示になっていたことを確認し、本PRで表示を分離。
- Evidence path/link: `test/passkey-operator-page.test.js`; `test/worker.test.js`; `src/core/passkey-operator-page.js`

## Butler Completion Contract

- Owner goal: Cloudflare Access が開けない時も、通知を見る fallback が owner-facing に見えること。
- Butler entrypoint: Dashboard auth required page の `Passkey で通知を見る` から `/v2/approval/passkey/operator?mode=dashboard...` へ入る。
- Action Schema exposure: 不要。Custom GPT Action Schema は変更しない。
- Runtime path: `/v2/approval/passkey/operator?mode=dashboard&dashboardReturnPath=/dashboard/notifications`
- Runner/runtime truth: Unit/worker tests で HTML と redirect sanitize を確認。
- Authority boundary: 未変更。read-only dashboard session 用 passkey fallback の表示だけ変更し、高リスク操作の approval scope は維持。
- E2E evidence: 未実施。production deploy 後の実機/PWA確認は別途必要。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 未実施。merge 後に必要なら scoped passkey approval が必要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate
- AGENTS.md Chief Butler Operating Principle
- AGENTS.md Authority Boundary
- AGENTS.md Evidence Discipline

## Out-of-scope but NOT implemented

- Issue #534 の close。
- Production deploy。
- Cloudflare Access / passkey credential 設定変更。

## Extra changes (if any)

Generated `worker.js` rebuilt.

<!-- VTDD metadata -->
- Issue: Issue #532
- Execution ID: Not provided.
- Goal: Fix dashboard passkey fallback copy
