### PR TITLE
dashboard: passkey fallback の内部説明を隠す

### DIFF
--- a/src/core/passkey-operator-page.js
+++ b/src/core/passkey-operator-page.js
@@ -276,7 +276,7 @@ export function renderPasskeyOperatorPage(input = {}) {
             Auto-copy approvalGrantId after approval
           </label>`
           }
-          ${deployOneTapMode ? "" : '<p class="muted">GitHub App secret sync なら <code>actionType=destructive</code> / <code>highRiskKind=github_app_secret_sync</code>、production deploy なら <code>actionType=deploy_production</code> / <code>highRiskKind=deploy_production</code>、PR merge なら <code>actionType=merge</code> / <code>highRiskKind=pull_merge</code> を使います。</p>'}
+          ${deployOneTapMode || dashboardMode ? "" : '<p class="muted">GitHub App secret sync なら <code>actionType=destructive</code> / <code>highRiskKind=github_app_secret_sync</code>、production deploy なら <code>actionType=deploy_production</code> / <code>highRiskKind=deploy_production</code>、PR merge なら <code>actionType=merge</code> / <code>highRiskKind=pull_merge</code> を使います。</p>'}
           <pre id="approve-output"${deployOneTapMode ? " hidden" : ""}></pre>
         </section>
 

--- a/test/passkey-operator-page.test.js
+++ b/test/passkey-operator-page.test.js
@@ -285,6 +285,8 @@ test("passkey operator page shows registration only for full or explicit registr
   assert.equal(dashboardHtml.includes("Copy approvalGrantId"), false);
   assert.equal(dashboardHtml.includes("Auto-copy approvalGrantId after approval"), false);
   assert.equal(dashboardHtml.includes("Approve high-risk action"), false);
+  assert.equal(dashboardHtml.includes("GitHub App secret sync なら"), false);
+  assert.equal(dashboardHtml.includes("highRiskKind=github_app_secret_sync"), false);
   assert.equal(dashboardHtml.includes('id="repo-input" value=""'), true);
   assert.equal(dashboardHtml.includes('id="issue-input" value=""'), true);
   assert.equal(dashboardHtml.includes('id="pull-number-input" value="148"'), false);
@@ -305,6 +307,8 @@ test("passkey operator dashboard mode returns to sanitized dashboard path after 
   assert.equal(notificationsHtml.includes('id="approve-button">パスキーで通知を見る</button>'), true);
   assert.equal(notificationsHtml.includes("通知センターを開くための read-only session"), true);
   assert.equal(notificationsHtml.includes("Approve high-risk action"), false);
+  assert.equal(notificationsHtml.includes("GitHub App secret sync なら"), false);
+  assert.equal(notificationsHtml.includes("highRiskKind=github_app_secret_sync"), false);
   assert.equal(notificationsHtml.includes('window.location.assign("/dashboard/notifications")'), true);
   assert.equal(notificationsHtml.includes("runId=private"), false);
 

--- a/worker.js
+++ b/worker.js
@@ -27491,7 +27491,7 @@ function renderPasskeyOperatorPage(input = {}) {
             <input id="auto-copy-approval-grant-input" type="checkbox" />
             Auto-copy approvalGrantId after approval
           </label>`}
-          ${deployOneTapMode ? "" : '<p class="muted">GitHub App secret sync \u306A\u3089 <code>actionType=destructive</code> / <code>highRiskKind=github_app_secret_sync</code>\u3001production deploy \u306A\u3089 <code>actionType=deploy_production</code> / <code>highRiskKind=deploy_production</code>\u3001PR merge \u306A\u3089 <code>actionType=merge</code> / <code>highRiskKind=pull_merge</code> \u3092\u4F7F\u3044\u307E\u3059\u3002</p>'}
+          ${deployOneTapMode || dashboardMode ? "" : '<p class="muted">GitHub App secret sync \u306A\u3089 <code>actionType=destructive</code> / <code>highRiskKind=github_app_secret_sync</code>\u3001production deploy \u306A\u3089 <code>actionType=deploy_production</code> / <code>highRiskKind=deploy_production</code>\u3001PR merge \u306A\u3089 <code>actionType=merge</code> / <code>highRiskKind=pull_merge</code> \u3092\u4F7F\u3044\u307E\u3059\u3002</p>'}
           <pre id="approve-output"${deployOneTapMode ? " hidden" : ""}></pre>
         </section>
 


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #532 の passkey operator owner-facing flow の部分進捗です。
- PR #554 後の live Simulator 確認で、Dashboard 通知用の read-only passkey fallback に high-risk operator の内部説明が残っていることを確認しました。
- 本PRでは dashboard mode だけ、その内部説明を通常表示から外します。

## Satisfied Success Criteria

- Dashboard mode では `GitHub App secret sync なら actionType=...` の high-risk operator guidance を表示しない。
- Dashboard 通知 fallback は `Dashboard Passkey` / `通知を見る` / `パスキーで通知を見る` を維持する。
- deploy / merge / secret sync など非 dashboard mode の operator guidance は維持する。
- redirect sanitize と repo / Issue / PR scope 非使用の dashboard behavior は維持する。

## Unsatisfied Success Criteria

- Issue #532 全体の deploy approval 1ボタン flow completion はこのPRだけでは完了扱いにしない。
- 本番 deploy と iPhone/PWA live E2E はこのPRでは未実施。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #532
- Implementing Success Criteria: dashboard read-only fallback の通常表示から high-risk operator 用の内部説明を外す。
- Explicit Non-goals: passkey scope、redirect、deploy/merge/secret sync の operator 表示、Cloudflare Access 設定は変更しない。
- Expected touched files/routes/workflows: `src/core/passkey-operator-page.js`, `test/passkey-operator-page.test.js`, `worker.js`
- Affected Issues: Issue #532, Issue #528, Issue #534
- Affected PRs: PR #554 の post-deploy live observation を受けた小修正。
- Affected workflows: なし。
- Affected runtime/operator surfaces: Passkey operator page / Dashboard auth fallback.
- What may break if we patch narrowly: dashboard mode 以外で必要な operator guidance まで消すと、secret sync / merge / deploy 運用が不親切になる。
- Unknowns to investigate before coding: なし。live Simulator screenshot で残存表示を確認済み。
- Validation needed: `node --test test/passkey-operator-page.test.js test/worker.test.js`; `npm run build:worker`; `npm run check:generated-worker`; `npm run check:self-parity`
- Stop condition: authority scope や Cloudflare Access 境界を変更する必要が出た場合は停止。

## File / Line Hypotheses

- file: `src/core/passkey-operator-page.js`
  - hypothesis: high-risk operator guidance の表示条件を `deployOneTapMode || dashboardMode` で隠せば、dashboard fallback から内部説明を除去できる。
  - risk if changed narrowly: 非 dashboard mode の operator guidance が消えると既存運用が分かりにくくなる。
  - validation: dashboard mode に guidance が出ないこと、既存 full mode の copy test が残ること、worker tests。
  - related Issue: #532

## Hypothesis Retrospective

- expected: dashboard mode では `GitHub App secret sync なら` と `highRiskKind=github_app_secret_sync` が出ない。
- actual: `test/passkey-operator-page.test.js` で確認。
- mismatch: なし。
- lesson: owner-facing fallback は、主ボタンだけでなく下部の補助テキストまで運用/デバッグ情報を隔離する必要がある。
- should become RAG candidate: はい。Dashboard Butler の通常導線では内部 operator guidance を出さない判断。

## Verification Evidence

- Unit: `node --test test/passkey-operator-page.test.js test/worker.test.js`: 227 pass / 0 fail
- Integration: `npm run build:worker`; `npm run check:generated-worker`; `npm run check:self-parity`: pass
- E2E: 未実施。このPRは PR #554 post-deploy live observation で見つかった表示残りの修正。
- Manual: `docs/mvp/e2e/assets/issue-532/ios-simulator-dashboard-passkey-live-after-pr554.png` で internal guidance の残存を確認。
- Evidence path/link: `src/core/passkey-operator-page.js`; `test/passkey-operator-page.test.js`; `worker.js`

## Butler Completion Contract

- Owner goal: 通知を見る fallback が Dashboard Butler の通常導線として内部実装説明なしに見えること。
- Butler entrypoint: Dashboard auth required page の `Passkey で通知を見る` から `/v2/approval/passkey/operator?mode=dashboard...` へ入る。
- Action Schema exposure: 不要。Custom GPT Action Schema は変更しない。
- Runtime path: `/v2/approval/passkey/operator?mode=dashboard&dashboardReturnPath=/dashboard/notifications`
- Runner/runtime truth: Unit/worker tests で HTML 表示条件を確認。
- Authority boundary: 未変更。read-only dashboard session 用 passkey fallback の表示だけ変更し、高リスク操作の approval scope は維持。
- E2E evidence: 未実施。merge/deploy 後に live Simulator で再確認する。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 未実施。merge 後に必要なら scoped passkey approval が必要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate
- AGENTS.md Chief Butler Operating Principle
- AGENTS.md Authority Boundary
- AGENTS.md Evidence Discipline

## Out-of-scope but NOT implemented

- Issue #534 の close。
- Production deploy。
- Cloudflare Access / passkey credential 設定変更。

## Extra changes (if any)

Generated `worker.js` rebuilt.

<!-- VTDD metadata -->
- Issue: Issue #532
- Execution ID: Not provided.
- Goal: Hide dashboard passkey internal help
