### PR TITLE
dashboard: passkey operator を no-store にする

### DIFF
--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -4637,7 +4637,9 @@ function handlePasskeyOperatorPageRequest(request) {
   return new Response(html, {
     status: 200,
     headers: {
-      "content-type": "text/html; charset=utf-8"
+      "content-type": "text/html; charset=utf-8",
+      "cache-control": "no-store, no-cache, must-revalidate, max-age=0",
+      pragma: "no-cache"
     }
   });
 }

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -6473,6 +6473,8 @@ test("worker serves passkey operator page", async () => {
 
   assert.equal(response.status, 200);
   assert.equal(response.headers.get("content-type"), "text/html; charset=utf-8");
+  assert.match(response.headers.get("cache-control"), /no-store/);
+  assert.equal(response.headers.get("pragma"), "no-cache");
   const html = await response.text();
   assert.equal(html.includes("VTDD Passkey Operator"), true);
   assert.equal(html.includes("/v2/approval/passkey/challenge"), true);
@@ -6499,6 +6501,8 @@ test("worker serves dashboard passkey operator mode", async () => {
   );
 
   assert.equal(response.status, 200);
+  assert.match(response.headers.get("cache-control"), /no-store/);
+  assert.equal(response.headers.get("pragma"), "no-cache");
   const html = await response.text();
   assert.equal(html.includes('id="repo-input" value=""'), true);
   assert.equal(html.includes('id="issue-input" value=""'), true);

--- a/worker.js
+++ b/worker.js
@@ -60214,7 +60214,9 @@ function handlePasskeyOperatorPageRequest(request) {
   return new Response(html2, {
     status: 200,
     headers: {
-      "content-type": "text/html; charset=utf-8"
+      "content-type": "text/html; charset=utf-8",
+      "cache-control": "no-store, no-cache, must-revalidate, max-age=0",
+      pragma: "no-cache"
     }
   });
 }


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #532 の passkey operator owner-facing flow の部分進捗です。
- PR #555 の deploy 後、cache bust 付き URL では修正済み HTML が返る一方、通常 URL では古い passkey operator HTML が残ることを確認しました。
- 本PRでは passkey operator HTML に no-store/no-cache headers を付け、古い owner-facing approval/fallback UI が残らないようにします。

## Satisfied Success Criteria

- `/v2/approval/passkey/operator` の HTML response に `Cache-Control: no-store, no-cache, must-revalidate, max-age=0` を追加。
- 同 response に `Pragma: no-cache` を追加。
- 通常 passkey operator と dashboard passkey operator mode の worker tests で cache headers を固定。
- generated `worker.js` を更新。

## Unsatisfied Success Criteria

- Issue #532 全体の deploy approval 1ボタン flow completion はこのPRだけでは完了扱いにしない。
- 本番 deploy と iPhone/PWA live E2E はこのPRでは未実施。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #532
- Implementing Success Criteria: passkey operator / dashboard fallback の owner-facing HTML が古いまま残らないようにする。
- Explicit Non-goals: Cloudflare global cache 設定、credential、permission、passkey scope、deploy workflow は変更しない。
- Expected touched files/routes/workflows: `src/worker/runtime.js`, `test/worker.test.js`, `worker.js`
- Affected Issues: Issue #532, Issue #355, Issue #534
- Affected PRs: PR #555 の post-deploy live verification で見つかった cache gap の修正。
- Affected workflows: なし。
- Affected runtime/operator surfaces: Passkey operator page / Dashboard auth fallback.
- What may break if we patch narrowly: HTML response cache headers だけなので authority behavior は変わらない。過剰に広げると unrelated status/help pages に影響する。
- Unknowns to investigate before coding: なし。cache bust で新 HTML、通常 URL で旧 HTML が返ることを確認済み。
- Validation needed: `node --test test/worker.test.js`; `npm run build:worker`; `npm run check:generated-worker`; `npm run check:self-parity`
- Stop condition: Cloudflare permission/cache setting mutation が必要になる場合は停止。

## File / Line Hypotheses

- file: `src/worker/runtime.js`
  - hypothesis: `handlePasskeyOperatorPageRequest()` response に no-store/no-cache を追加すれば、operator/fallback HTML の stale 表示を防げる。
  - risk if changed narrowly: なし。passkey operator HTML は approval/fallback 画面なので cache すべきではない。
  - validation: worker tests の response header assertions と live deploy 後の plain URL check。
  - related Issue: #532

## Hypothesis Retrospective

- expected: passkey operator response が `no-store` と `pragma: no-cache` を返す。
- actual: `test/worker.test.js` で通常 operator と dashboard operator mode の両方を確認。
- mismatch: なし。
- lesson: owner-facing approval/fallback UI は query URL であっても stale HTML を避けるため明示 no-store が必要。
- should become RAG candidate: はい。passkey/operator pages must be no-store。

## Verification Evidence

- Unit: `node --test test/worker.test.js`: 202 pass / 0 fail
- Integration: `npm run build:worker`; `npm run check:generated-worker`; `npm run check:self-parity`: pass
- E2E: 未実施。このPRは header fix。merge/deploy 後に live plain URL で再確認する。
- Manual: PR #555 deploy 後、cache-bust URL では修正済み HTML、通常 URL では旧 HTML が返ることを確認。
- Evidence path/link: `src/worker/runtime.js`; `test/worker.test.js`; `worker.js`

## Butler Completion Contract

- Owner goal: iPhone/PWA で古い passkey fallback UI が残らないこと。
- Butler entrypoint: Dashboard auth required page の `Passkey で通知を見る` から `/v2/approval/passkey/operator?mode=dashboard...` へ入る。
- Action Schema exposure: 不要。Custom GPT Action Schema は変更しない。
- Runtime path: `/v2/approval/passkey/operator`
- Runner/runtime truth: Unit tests で cache headers を確認。
- Authority boundary: 未変更。cache headers のみ。
- E2E evidence: 未実施。merge/deploy 後に live plain URL と iOS Simulator で再確認する。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 未実施。merge 後に scoped passkey approval が必要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate
- AGENTS.md Chief Butler Operating Principle
- AGENTS.md Authority Boundary
- AGENTS.md Evidence Discipline

## Out-of-scope but NOT implemented

- Issue #534 の close。
- Cloudflare cache setting mutation。
- Credential / permission / passkey scope changes。

## Extra changes (if any)

Generated `worker.js` rebuilt.

<!-- VTDD metadata -->
- Issue: Issue #532
- Execution ID: Not provided.
- Goal: Prevent stale passkey operator page
