### PR TITLE
dashboard: passkey fallback の文言を開く導線に直す

### DIFF
--- a/src/core/passkey-operator-page.js
+++ b/src/core/passkey-operator-page.js
@@ -36,9 +36,7 @@ export function renderPasskeyOperatorPage(input = {}) {
     : "";
   const approveButtonLabel = deployOneTapMode
     ? "パスキー"
-    : dashboardNotificationMode
-      ? "パスキーで通知を見る"
-      : dashboardMode
+    : dashboardMode
         ? "パスキーで開く"
         : "Approve high-risk action";
   const heroTitle = dashboardMode ? "Dashboard Passkey" : "VTDD Passkey Operator";
@@ -47,9 +45,7 @@ export function renderPasskeyOperatorPage(input = {}) {
     : "このページは real WebAuthn/passkey approval 用の operator helper です。登録と high-risk approval の両方を same-origin で実行し、最終的に <code>approvalGrantId</code> を取得できます。";
   const approvalHeading = deployOneTapMode
     ? "本番反映の承認"
-    : dashboardNotificationMode
-      ? "通知を見る"
-      : dashboardMode
+    : dashboardMode
         ? "Dashboard を開く"
         : "2. High-risk Approval";
   const deployScopeSummary = renderDeployScopeSummary({
@@ -240,7 +236,7 @@ export function renderPasskeyOperatorPage(input = {}) {
             <input id="risk-kind-input" value="${highRiskKindDefault}" autocomplete="off"${deployOneTapMode ? ' readonly data-deploy-scope-locked="true"' : ""} />
           </div>`
               : dashboardMode
-                ? `<p>${dashboardNotificationMode ? "通知センター" : "Dashboard"}を開くための read-only session を更新します。この確認では repo / Issue / PR scope は使いません。</p>
+                ? `<p>Dashboard を開くための read-only session を更新します。この確認では repo / Issue / PR scope は使いません。${dashboardNotificationMode ? "認証後は通知センターへ戻ります。" : ""}</p>
           <div class="approval-internal" hidden>
             <label for="repo-input">Repository</label>
             <input id="repo-input" value="" placeholder="marushu/vtdd-v2-p" />

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -11840,8 +11840,9 @@ function renderDashboardAuthRequiredPage({ runtimeOrigin, returnPath = "/dashboa
   const dashboardAccessReturnPath = sanitizeDashboardPreAuthReturnPath(returnPath);
   const dashboardAccessHref = buildCloudflareAccessLoginHref({ origin, returnPath: dashboardAccessReturnPath });
   const dashboardSignInUrl = `${origin || ""}/v2/approval/passkey/operator?mode=dashboard&phase=execution&actionType=read&highRiskKind=dashboard_access&dashboardReturnPath=${encodeURIComponent(dashboardAccessReturnPath)}`;
-  const passkeyButtonLabel =
-    dashboardAccessReturnPath === "/dashboard/notifications" ? "Passkey で通知を見る" : "Passkey で dashboard に入る";
+  const passkeyButtonLabel = "Passkey で開く";
+  const passkeyReturnNote =
+    dashboardAccessReturnPath === "/dashboard/notifications" ? "認証後は通知センターへ戻ります。" : "";
   return `<!doctype html>
 <html lang="ja">
 <head>
@@ -11877,7 +11878,7 @@ function renderDashboardAuthRequiredPage({ runtimeOrigin, returnPath = "/dashboa
       </div>
       <details>
         <summary>Passkey fallback</summary>
-        <p>passkey dashboard session は Cloudflare Access が使えない時の補助導線です。deploy、merge、secret sync などの高リスク操作は引き続き scope 明示済み real passkey approval が必要です。</p>
+        <p>passkey dashboard session は Cloudflare Access が使えない時の補助導線です。${escapeDashboardHtml(passkeyReturnNote)} deploy、merge、secret sync などの高リスク操作は引き続き scope 明示済み real passkey approval が必要です。</p>
         ${passkeyFallbackReason ? `<p><code>${escapeDashboardHtml(passkeyFallbackReason)}</code></p>` : ""}
         <p><a href="${escapeDashboardHtml(dashboardSignInUrl)}">Passkey fallback を開く</a></p>
       </details>

--- a/test/passkey-operator-page.test.js
+++ b/test/passkey-operator-page.test.js
@@ -303,9 +303,11 @@ test("passkey operator dashboard mode returns to sanitized dashboard path after 
     operatorMode: "dashboard",
     dashboardReturnPath: "/dashboard/notifications?runId=private"
   });
-  assert.equal(notificationsHtml.includes("<h2>通知を見る</h2>"), true);
-  assert.equal(notificationsHtml.includes('id="approve-button">パスキーで通知を見る</button>'), true);
-  assert.equal(notificationsHtml.includes("通知センターを開くための read-only session"), true);
+  assert.equal(notificationsHtml.includes("<h2>Dashboard を開く</h2>"), true);
+  assert.equal(notificationsHtml.includes('id="approve-button">パスキーで開く</button>'), true);
+  assert.equal(notificationsHtml.includes("Dashboard を開くための read-only session"), true);
+  assert.equal(notificationsHtml.includes("認証後は通知センターへ戻ります。"), true);
+  assert.equal(notificationsHtml.includes("パスキーで通知を見る"), false);
   assert.equal(notificationsHtml.includes("Approve high-risk action"), false);
   assert.equal(notificationsHtml.includes("GitHub App secret sync なら"), false);
   assert.equal(notificationsHtml.includes("highRiskKind=github_app_secret_sync"), false);

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -787,7 +787,8 @@ test("worker rejects dashboard access without owner identity", async () => {
     true
   );
   assert.equal(body.includes("Passkey fallback"), true);
-  assert.equal(body.includes("Passkey で dashboard に入る"), true);
+  assert.equal(body.includes("Passkey で開く"), true);
+  assert.equal(body.includes("Passkey で dashboard に入る"), false);
   assert.equal(
     body.includes(
       'href="https://example.com/v2/approval/passkey/operator?mode=dashboard&amp;phase=execution&amp;actionType=read&amp;highRiskKind=dashboard_access&amp;dashboardReturnPath=%2Fdashboard"'
@@ -884,7 +885,8 @@ test("worker rejects stale dashboard passkey session cookies", async () => {
   );
   assert.equal(body.includes("Passkey fallback"), true);
   assert.equal(body.includes("dashboard passkey session was not found"), true);
-  assert.equal(body.includes("Passkey で dashboard に入る"), true);
+  assert.equal(body.includes("Passkey で開く"), true);
+  assert.equal(body.includes("Passkey で dashboard に入る"), false);
   assert.equal(body.includes("repositoryInput=marushu%2Fvtdd-v2-p"), false);
 });
 
@@ -916,7 +918,9 @@ test("worker does not expose dashboard notification details before Access auth",
   const body = await response.text();
   assert.equal(body.includes("Dashboard auth required"), true);
   assert.equal(body.includes("Cloudflare Access で開く"), true);
-  assert.equal(body.includes("Passkey で通知を見る"), true);
+  assert.equal(body.includes("Passkey で開く"), true);
+  assert.equal(body.includes("Passkey で通知を見る"), false);
+  assert.equal(body.includes("認証後は通知センターへ戻ります。"), true);
   assert.equal(
     body.includes(
       'href="https://example.com/cdn-cgi/access/login?redirect_url=https%3A%2F%2Fexample.com%2Fdashboard%2Fnotifications"'

--- a/worker.js
+++ b/worker.js
@@ -27274,10 +27274,10 @@ function renderPasskeyOperatorPage(input = {}) {
     input.syncMessage || (syncEnabled ? "approvalGrantId \u304C\u53D6\u5F97\u6E08\u307F\u306A\u3089\u5B9F\u884C\u3067\u304D\u307E\u3059\u3002desktop helper bridge \u306B\u63A5\u7D9A\u3057\u307E\u3059\u3002" : "desktop maintenance required: local secret sync bridge \u304C\u672A\u63A5\u7D9A\u3067\u3059\u3002")
   );
   const approvalSectionAttributes = deployOneTapMode ? ' data-owner-flow="one-tap-deploy"' : "";
-  const approveButtonLabel = deployOneTapMode ? "\u30D1\u30B9\u30AD\u30FC" : dashboardNotificationMode ? "\u30D1\u30B9\u30AD\u30FC\u3067\u901A\u77E5\u3092\u898B\u308B" : dashboardMode ? "\u30D1\u30B9\u30AD\u30FC\u3067\u958B\u304F" : "Approve high-risk action";
+  const approveButtonLabel = deployOneTapMode ? "\u30D1\u30B9\u30AD\u30FC" : dashboardMode ? "\u30D1\u30B9\u30AD\u30FC\u3067\u958B\u304F" : "Approve high-risk action";
   const heroTitle = dashboardMode ? "Dashboard Passkey" : "VTDD Passkey Operator";
   const heroDescription = dashboardMode ? "\u3053\u306E\u30DA\u30FC\u30B8\u306F Dashboard Butler \u3092\u958B\u304F\u305F\u3081\u306E\u8AAD\u307F\u53D6\u308A\u5C02\u7528\u30D1\u30B9\u30AD\u30FC\u78BA\u8A8D\u3067\u3059\u3002Cloudflare Access \u304C\u4F7F\u3048\u306A\u3044\u6642\u3060\u3051\u3001\u540C\u4E00 origin \u306E passkey \u3067 dashboard session \u3092\u66F4\u65B0\u3057\u307E\u3059\u3002" : "\u3053\u306E\u30DA\u30FC\u30B8\u306F real WebAuthn/passkey approval \u7528\u306E operator helper \u3067\u3059\u3002\u767B\u9332\u3068 high-risk approval \u306E\u4E21\u65B9\u3092 same-origin \u3067\u5B9F\u884C\u3057\u3001\u6700\u7D42\u7684\u306B <code>approvalGrantId</code> \u3092\u53D6\u5F97\u3067\u304D\u307E\u3059\u3002";
-  const approvalHeading = deployOneTapMode ? "\u672C\u756A\u53CD\u6620\u306E\u627F\u8A8D" : dashboardNotificationMode ? "\u901A\u77E5\u3092\u898B\u308B" : dashboardMode ? "Dashboard \u3092\u958B\u304F" : "2. High-risk Approval";
+  const approvalHeading = deployOneTapMode ? "\u672C\u756A\u53CD\u6620\u306E\u627F\u8A8D" : dashboardMode ? "Dashboard \u3092\u958B\u304F" : "2. High-risk Approval";
   const deployScopeSummary = renderDeployScopeSummary({
     repositoryInput: repoDefault,
     issueNumber: issueDefault,
@@ -27461,7 +27461,7 @@ function renderPasskeyOperatorPage(input = {}) {
             <input id="action-type-input" value="${actionTypeDefault}" autocomplete="off"${deployOneTapMode ? ' readonly data-deploy-scope-locked="true"' : ""} />
             <label for="risk-kind-input">High-risk Kind</label>
             <input id="risk-kind-input" value="${highRiskKindDefault}" autocomplete="off"${deployOneTapMode ? ' readonly data-deploy-scope-locked="true"' : ""} />
-          </div>` : dashboardMode ? `<p>${dashboardNotificationMode ? "\u901A\u77E5\u30BB\u30F3\u30BF\u30FC" : "Dashboard"}\u3092\u958B\u304F\u305F\u3081\u306E read-only session \u3092\u66F4\u65B0\u3057\u307E\u3059\u3002\u3053\u306E\u78BA\u8A8D\u3067\u306F repo / Issue / PR scope \u306F\u4F7F\u3044\u307E\u305B\u3093\u3002</p>
+          </div>` : dashboardMode ? `<p>Dashboard \u3092\u958B\u304F\u305F\u3081\u306E read-only session \u3092\u66F4\u65B0\u3057\u307E\u3059\u3002\u3053\u306E\u78BA\u8A8D\u3067\u306F repo / Issue / PR scope \u306F\u4F7F\u3044\u307E\u305B\u3093\u3002${dashboardNotificationMode ? "\u8A8D\u8A3C\u5F8C\u306F\u901A\u77E5\u30BB\u30F3\u30BF\u30FC\u3078\u623B\u308A\u307E\u3059\u3002" : ""}</p>
           <div class="approval-internal" hidden>
             <label for="repo-input">Repository</label>
             <input id="repo-input" value="" placeholder="marushu/vtdd-v2-p" />
@@ -66693,7 +66693,8 @@ function renderDashboardAuthRequiredPage({ runtimeOrigin, returnPath = "/dashboa
   const dashboardAccessReturnPath = sanitizeDashboardPreAuthReturnPath(returnPath);
   const dashboardAccessHref = buildCloudflareAccessLoginHref({ origin, returnPath: dashboardAccessReturnPath });
   const dashboardSignInUrl = `${origin || ""}/v2/approval/passkey/operator?mode=dashboard&phase=execution&actionType=read&highRiskKind=dashboard_access&dashboardReturnPath=${encodeURIComponent(dashboardAccessReturnPath)}`;
-  const passkeyButtonLabel = dashboardAccessReturnPath === "/dashboard/notifications" ? "Passkey \u3067\u901A\u77E5\u3092\u898B\u308B" : "Passkey \u3067 dashboard \u306B\u5165\u308B";
+  const passkeyButtonLabel = "Passkey \u3067\u958B\u304F";
+  const passkeyReturnNote = dashboardAccessReturnPath === "/dashboard/notifications" ? "\u8A8D\u8A3C\u5F8C\u306F\u901A\u77E5\u30BB\u30F3\u30BF\u30FC\u3078\u623B\u308A\u307E\u3059\u3002" : "";
   return `<!doctype html>
 <html lang="ja">
 <head>
@@ -66729,7 +66730,7 @@ function renderDashboardAuthRequiredPage({ runtimeOrigin, returnPath = "/dashboa
       </div>
       <details>
         <summary>Passkey fallback</summary>
-        <p>passkey dashboard session \u306F Cloudflare Access \u304C\u4F7F\u3048\u306A\u3044\u6642\u306E\u88DC\u52A9\u5C0E\u7DDA\u3067\u3059\u3002deploy\u3001merge\u3001secret sync \u306A\u3069\u306E\u9AD8\u30EA\u30B9\u30AF\u64CD\u4F5C\u306F\u5F15\u304D\u7D9A\u304D scope \u660E\u793A\u6E08\u307F real passkey approval \u304C\u5FC5\u8981\u3067\u3059\u3002</p>
+        <p>passkey dashboard session \u306F Cloudflare Access \u304C\u4F7F\u3048\u306A\u3044\u6642\u306E\u88DC\u52A9\u5C0E\u7DDA\u3067\u3059\u3002${escapeDashboardHtml(passkeyReturnNote)} deploy\u3001merge\u3001secret sync \u306A\u3069\u306E\u9AD8\u30EA\u30B9\u30AF\u64CD\u4F5C\u306F\u5F15\u304D\u7D9A\u304D scope \u660E\u793A\u6E08\u307F real passkey approval \u304C\u5FC5\u8981\u3067\u3059\u3002</p>
         ${passkeyFallbackReason ? `<p><code>${escapeDashboardHtml(passkeyFallbackReason)}</code></p>` : ""}
         <p><a href="${escapeDashboardHtml(dashboardSignInUrl)}">Passkey fallback \u3092\u958B\u304F</a></p>
       </details>


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #532 の passkey operator owner-facing flow の部分進捗です。
- `パスキーで通知を見る` は実態より狭く、通知を見る操作そのものに見えるため、Dashboard fallback 認証として `パスキーで開く` に寄せました。
- 通知センターへ戻る説明はボタン名ではなく補助説明に移しました。

## Satisfied Success Criteria

- Dashboard auth required page の passkey fallback ボタンを `Passkey で開く` に統一。
- 通知センター return path の場合は fallback 説明に `認証後は通知センターへ戻ります。` を表示。
- Passkey operator dashboard mode の主見出しを `Dashboard を開く`、主ボタンを `パスキーで開く` に統一。
- Passkey operator dashboard mode では通知 return path の説明として `認証後は通知センターへ戻ります。` を表示。
- passkey/session/auth/Cloudflare Access/deploy workflow は変更しない。

## Unsatisfied Success Criteria

- Issue #532 全体の deploy approval 1ボタン flow completion はこのPRだけでは完了扱いにしない。
- 本番 deploy と iPhone/PWA live E2E はこのPRでは未実施。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #532
- Implementing Success Criteria: Dashboard passkey fallback を「通知を見る」ではなく「Dashboard を開く fallback」として表現する。
- Explicit Non-goals: passkey/session/auth/Cloudflare Access/deploy workflow は触らない。
- Expected touched files/routes/workflows: `src/worker/runtime.js`, `src/core/passkey-operator-page.js`, `test/worker.test.js`, `test/passkey-operator-page.test.js`, `worker.js`
- Affected Issues: Issue #532, Issue #528, Issue #534
- Affected PRs: PR #554-#556 の passkey fallback UX 修正の続き。
- Affected workflows: なし。
- Affected runtime/operator surfaces: Dashboard auth required page / passkey operator dashboard mode.
- What may break if we patch narrowly: 文言だけなので authority behavior は変わらない。説明を消しすぎると通知センターへ戻ることが分かりにくくなる。
- Unknowns to investigate before coding: なし。ユーザー確認によりボタン名の違和感を確認済み。
- Validation needed: `node --test test/passkey-operator-page.test.js test/worker.test.js`; `npm run build:worker`; `npm run check:generated-worker`; `npm run check:self-parity`
- Stop condition: passkey/session/auth behavior の変更が必要になった場合は停止。

## File / Line Hypotheses

- file: `src/worker/runtime.js`
  - hypothesis: auth required page のボタン名を `Passkey で開く` に統一し、通知 return note は説明文へ移せる。
  - risk if changed narrowly: notification path で戻り先が分かりにくくなる。
  - validation: worker tests の auth required HTML assertions。
  - related Issue: #532
- file: `src/core/passkey-operator-page.js`
  - hypothesis: dashboard mode の見出し/ボタンを Dashboard open に統一し、通知 return note を本文へ置ける。
  - risk if changed narrowly: deploy/merge operator の high-risk label を誤って変える。
  - validation: passkey operator tests。
  - related Issue: #532

## Hypothesis Retrospective

- expected: `パスキーで通知を見る` は出ず、`パスキーで開く` / `Passkey で開く` が出る。通知 return path では `認証後は通知センターへ戻ります。` が出る。
- actual: `test/passkey-operator-page.test.js` と `test/worker.test.js` で確認。
- mismatch: なし。
- lesson: fallback 認証ボタンは対象コンテンツ名ではなく、実際の認証動作を表す名前にする。
- should become RAG candidate: はい。Dashboard passkey fallback は `open dashboard` copy に寄せる。

## Verification Evidence

- Unit: `node --test test/passkey-operator-page.test.js test/worker.test.js`: 227 pass / 0 fail
- Integration: `npm run build:worker`; `npm run check:generated-worker`; `npm run check:self-parity`: pass
- E2E: 未実施。このPRは copy-only。merge/deploy 後に live plain URL と iOS Simulator で再確認する。
- Manual: ユーザーから `パスキーで通知を見るってこれなに？` と指摘があり、実態が fallback 認証であるため文言を修正。
- Evidence path/link: `src/worker/runtime.js`; `src/core/passkey-operator-page.js`; `test/worker.test.js`; `test/passkey-operator-page.test.js`; `worker.js`

## Butler Completion Contract

- Owner goal: passkey fallback が「通知閲覧」ではなく「Dashboard を開く fallback 認証」として理解できること。
- Butler entrypoint: Dashboard auth required page の `Passkey で開く` から `/v2/approval/passkey/operator?mode=dashboard...` へ入る。
- Action Schema exposure: 不要。Custom GPT Action Schema は変更しない。
- Runtime path: `/dashboard`, `/dashboard/notifications`, `/v2/approval/passkey/operator?mode=dashboard...`
- Runner/runtime truth: Unit tests で表示と redirect note を確認。
- Authority boundary: 未変更。copy-only。
- E2E evidence: 未実施。merge/deploy 後に live plain URL と iOS Simulator で再確認する。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 未実施。merge 後に scoped passkey approval が必要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate
- AGENTS.md Chief Butler Operating Principle
- AGENTS.md Conversation UX Contract
- AGENTS.md Evidence Discipline

## Out-of-scope but NOT implemented

- Issue #534 の close。
- Cloudflare Access setting mutation。
- passkey/session/auth behavior changes。

## Extra changes (if any)

Generated `worker.js` rebuilt.

<!-- VTDD metadata -->
- Issue: Issue #532
- Execution ID: Not provided.
- Goal: Rename dashboard passkey fallback copy
