### PR TITLE
dashboard: passkey fallback の空出力枠を隠す

### DIFF
--- a/src/core/passkey-operator-page.js
+++ b/src/core/passkey-operator-page.js
@@ -614,9 +614,17 @@ export function renderPasskeyOperatorPage(input = {}) {
           return;
         }
         approveOutput.textContent = String(text || "");
-        if (show) {
-          approveOutput.hidden = false;
+        approveOutput.hidden = !show;
+      }
+
+      function shouldShowApproveOutput(kind = "status") {
+        if (operatorMode === "deploy") {
+          return false;
         }
+        if (operatorMode === "dashboard") {
+          return kind === "error";
+        }
+        return true;
       }
 
       function showIssueCloseLink(body) {
@@ -778,7 +786,7 @@ export function renderPasskeyOperatorPage(input = {}) {
         try {
           applyOperatorModeDefaults();
           const repositoryInput = readApprovalRepositoryInput();
-          setApproveOutput("approval challenge request...", { show: operatorMode !== "dashboard" });
+          setApproveOutput("approval challenge request...", { show: shouldShowApproveOutput("status") });
           const challengeResponse = await fetch("${apiBase}/approval/passkey/challenge", {
             method: "POST",
             headers: { "content-type": "application/json" },
@@ -819,7 +827,7 @@ export function renderPasskeyOperatorPage(input = {}) {
           }
           latestApprovalGrant = verifyBody?.approvalGrant || null;
           latestApprovalGrantId = latestApprovalGrant?.approvalId || verifyBody?.approvalGrantId || "";
-          setApproveOutput(JSON.stringify(verifyBody, null, 2), { show: operatorMode !== "dashboard" });
+          setApproveOutput(JSON.stringify(verifyBody, null, 2), { show: shouldShowApproveOutput("status") });
           if (operatorMode === "dashboard") {
             window.location.assign("${dashboardReturnPath}");
             return;
@@ -840,7 +848,7 @@ export function renderPasskeyOperatorPage(input = {}) {
             }
           }
         } catch (error) {
-          setApproveOutput(String(error));
+          setApproveOutput(String(error), { show: shouldShowApproveOutput("error") });
         }
       });
 

--- a/src/core/passkey-operator-page.js
+++ b/src/core/passkey-operator-page.js
@@ -273,7 +273,7 @@ export function renderPasskeyOperatorPage(input = {}) {
           </label>`
           }
           ${deployOneTapMode || dashboardMode ? "" : '<p class="muted">GitHub App secret sync なら <code>actionType=destructive</code> / <code>highRiskKind=github_app_secret_sync</code>、production deploy なら <code>actionType=deploy_production</code> / <code>highRiskKind=deploy_production</code>、PR merge なら <code>actionType=merge</code> / <code>highRiskKind=pull_merge</code> を使います。</p>'}
-          <pre id="approve-output"${deployOneTapMode ? " hidden" : ""}></pre>
+          <pre id="approve-output"${deployOneTapMode || dashboardMode ? " hidden" : ""}></pre>
         </section>
 
         <section data-operator-section="github-app-secret-sync"${hiddenAttribute(!sectionVisibility.githubAppSecretSync)}>
@@ -609,6 +609,16 @@ export function renderPasskeyOperatorPage(input = {}) {
         issueCloseLink.hidden = true;
       }
 
+      function setApproveOutput(text, { show = true } = {}) {
+        if (!approveOutput) {
+          return;
+        }
+        approveOutput.textContent = String(text || "");
+        if (show) {
+          approveOutput.hidden = false;
+        }
+      }
+
       function showIssueCloseLink(body) {
         const issueUrl = normalizeGitHubIssueUrl(extractIssueCloseUrl(body));
         if (!issueUrl || !issueCloseLink) {
@@ -768,7 +778,7 @@ export function renderPasskeyOperatorPage(input = {}) {
         try {
           applyOperatorModeDefaults();
           const repositoryInput = readApprovalRepositoryInput();
-          approveOutput.textContent = "approval challenge request...";
+          setApproveOutput("approval challenge request...", { show: operatorMode !== "dashboard" });
           const challengeResponse = await fetch("${apiBase}/approval/passkey/challenge", {
             method: "POST",
             headers: { "content-type": "application/json" },
@@ -809,7 +819,7 @@ export function renderPasskeyOperatorPage(input = {}) {
           }
           latestApprovalGrant = verifyBody?.approvalGrant || null;
           latestApprovalGrantId = latestApprovalGrant?.approvalId || verifyBody?.approvalGrantId || "";
-          approveOutput.textContent = JSON.stringify(verifyBody, null, 2);
+          setApproveOutput(JSON.stringify(verifyBody, null, 2), { show: operatorMode !== "dashboard" });
           if (operatorMode === "dashboard") {
             window.location.assign("${dashboardReturnPath}");
             return;
@@ -830,7 +840,7 @@ export function renderPasskeyOperatorPage(input = {}) {
             }
           }
         } catch (error) {
-          approveOutput.textContent = String(error);
+          setApproveOutput(String(error));
         }
       });
 

--- a/test/passkey-operator-page.test.js
+++ b/test/passkey-operator-page.test.js
@@ -312,10 +312,10 @@ test("passkey operator dashboard mode returns to sanitized dashboard path after 
   assert.equal(notificationsHtml.includes('<pre id="approve-output" hidden></pre>'), true);
   assert.equal(notificationsHtml.includes("function setApproveOutput("), true);
   assert.equal(
-    notificationsHtml.includes('setApproveOutput("approval challenge request...", { show: operatorMode !== "dashboard" });'),
+    notificationsHtml.includes('setApproveOutput("approval challenge request...", { show: shouldShowApproveOutput("status") });'),
     true
   );
-  assert.equal(notificationsHtml.includes("setApproveOutput(String(error));"), true);
+  assert.equal(notificationsHtml.includes("setApproveOutput(String(error), { show: shouldShowApproveOutput(\"error\") });"), true);
   assert.equal(notificationsHtml.includes("GitHub App secret sync なら"), false);
   assert.equal(notificationsHtml.includes("highRiskKind=github_app_secret_sync"), false);
   assert.equal(notificationsHtml.includes('window.location.assign("/dashboard/notifications")'), true);
@@ -327,6 +327,40 @@ test("passkey operator dashboard mode returns to sanitized dashboard path after 
   });
   assert.equal(unsafeHtml.includes('window.location.assign("/dashboard")'), true);
   assert.equal(unsafeHtml.includes("evil.example"), false);
+});
+
+test("passkey operator approve output visibility preserves deploy and dashboard policy", () => {
+  const html = renderPasskeyOperatorPage({
+    operatorMode: "dashboard",
+    dashboardReturnPath: "/dashboard/notifications"
+  });
+
+  const deployPolicy = evaluateApproveOutputPolicy(html, "deploy");
+  deployPolicy.setApproveOutput("deploy status", {
+    show: deployPolicy.shouldShowApproveOutput("status")
+  });
+  assert.equal(deployPolicy.approveOutput.hidden, true);
+  deployPolicy.setApproveOutput("deploy error", {
+    show: deployPolicy.shouldShowApproveOutput("error")
+  });
+  assert.equal(deployPolicy.approveOutput.hidden, true);
+
+  const dashboardPolicy = evaluateApproveOutputPolicy(html, "dashboard");
+  dashboardPolicy.setApproveOutput("dashboard status", {
+    show: dashboardPolicy.shouldShowApproveOutput("status")
+  });
+  assert.equal(dashboardPolicy.approveOutput.hidden, true);
+  dashboardPolicy.setApproveOutput("dashboard error", {
+    show: dashboardPolicy.shouldShowApproveOutput("error")
+  });
+  assert.equal(dashboardPolicy.approveOutput.hidden, false);
+  assert.equal(dashboardPolicy.approveOutput.textContent, "dashboard error");
+
+  const mergePolicy = evaluateApproveOutputPolicy(html, "merge");
+  mergePolicy.setApproveOutput("merge status", {
+    show: mergePolicy.shouldShowApproveOutput("status")
+  });
+  assert.equal(mergePolicy.approveOutput.hidden, false);
 });
 
 test("passkey operator page focuses merge mode on approval and PR merge sections", () => {
@@ -754,4 +788,63 @@ function loadOperatorPageHelpers(overrides = {}) {
   vm.runInNewContext(script, context);
   assert.equal(typeof context.readResponseBody, "function");
   return context;
+}
+
+function evaluateApproveOutputPolicy(html, operatorMode) {
+  const script = html.match(/<script>([\s\S]*)<\/script>/)?.[1];
+  assert.ok(script);
+  const approveOutput = {
+    hidden: true,
+    textContent: ""
+  };
+  const context = {
+    approveOutput
+  };
+  const source = [
+    `const operatorMode = ${JSON.stringify(operatorMode)};`,
+    "const approveOutput = globalThis.approveOutput;",
+    extractScriptFunction(script, "setApproveOutput"),
+    extractScriptFunction(script, "shouldShowApproveOutput"),
+    "globalThis.setApproveOutput = setApproveOutput;",
+    "globalThis.shouldShowApproveOutput = shouldShowApproveOutput;"
+  ].join("\n");
+  vm.runInNewContext(source, context);
+  return context;
+}
+
+function extractScriptFunction(script, name) {
+  const start = script.indexOf(`function ${name}`);
+  assert.notEqual(start, -1, `${name} function should exist`);
+  const parametersStart = script.indexOf("(", start);
+  assert.notEqual(parametersStart, -1, `${name} function parameters should exist`);
+  let parameterDepth = 0;
+  let parametersEnd = -1;
+  for (let index = parametersStart; index < script.length; index += 1) {
+    const character = script[index];
+    if (character === "(") {
+      parameterDepth += 1;
+    } else if (character === ")") {
+      parameterDepth -= 1;
+      if (parameterDepth === 0) {
+        parametersEnd = index;
+        break;
+      }
+    }
+  }
+  assert.notEqual(parametersEnd, -1, `${name} function parameters should close`);
+  const bodyStart = script.indexOf("{", parametersEnd);
+  assert.notEqual(bodyStart, -1, `${name} function body should exist`);
+  let depth = 0;
+  for (let index = bodyStart; index < script.length; index += 1) {
+    const character = script[index];
+    if (character === "{") {
+      depth += 1;
+    } else if (character === "}") {
+      depth -= 1;
+      if (depth === 0) {
+        return script.slice(start, index + 1);
+      }
+    }
+  }
+  assert.fail(`${name} function body should close`);
 }

--- a/test/passkey-operator-page.test.js
+++ b/test/passkey-operator-page.test.js
@@ -309,6 +309,13 @@ test("passkey operator dashboard mode returns to sanitized dashboard path after 
   assert.equal(notificationsHtml.includes("認証後は通知センターへ戻ります。"), true);
   assert.equal(notificationsHtml.includes("パスキーで通知を見る"), false);
   assert.equal(notificationsHtml.includes("Approve high-risk action"), false);
+  assert.equal(notificationsHtml.includes('<pre id="approve-output" hidden></pre>'), true);
+  assert.equal(notificationsHtml.includes("function setApproveOutput("), true);
+  assert.equal(
+    notificationsHtml.includes('setApproveOutput("approval challenge request...", { show: operatorMode !== "dashboard" });'),
+    true
+  );
+  assert.equal(notificationsHtml.includes("setApproveOutput(String(error));"), true);
   assert.equal(notificationsHtml.includes("GitHub App secret sync なら"), false);
   assert.equal(notificationsHtml.includes("highRiskKind=github_app_secret_sync"), false);
   assert.equal(notificationsHtml.includes('window.location.assign("/dashboard/notifications")'), true);

--- a/worker.js
+++ b/worker.js
@@ -27492,7 +27492,7 @@ function renderPasskeyOperatorPage(input = {}) {
             Auto-copy approvalGrantId after approval
           </label>`}
           ${deployOneTapMode || dashboardMode ? "" : '<p class="muted">GitHub App secret sync \u306A\u3089 <code>actionType=destructive</code> / <code>highRiskKind=github_app_secret_sync</code>\u3001production deploy \u306A\u3089 <code>actionType=deploy_production</code> / <code>highRiskKind=deploy_production</code>\u3001PR merge \u306A\u3089 <code>actionType=merge</code> / <code>highRiskKind=pull_merge</code> \u3092\u4F7F\u3044\u307E\u3059\u3002</p>'}
-          <pre id="approve-output"${deployOneTapMode ? " hidden" : ""}></pre>
+          <pre id="approve-output"${deployOneTapMode || dashboardMode ? " hidden" : ""}></pre>
         </section>
 
         <section data-operator-section="github-app-secret-sync"${hiddenAttribute(!sectionVisibility.githubAppSecretSync)}>
@@ -27828,6 +27828,16 @@ function renderPasskeyOperatorPage(input = {}) {
         issueCloseLink.hidden = true;
       }
 
+      function setApproveOutput(text, { show = true } = {}) {
+        if (!approveOutput) {
+          return;
+        }
+        approveOutput.textContent = String(text || "");
+        if (show) {
+          approveOutput.hidden = false;
+        }
+      }
+
       function showIssueCloseLink(body) {
         const issueUrl = normalizeGitHubIssueUrl(extractIssueCloseUrl(body));
         if (!issueUrl || !issueCloseLink) {
@@ -27987,7 +27997,7 @@ function renderPasskeyOperatorPage(input = {}) {
         try {
           applyOperatorModeDefaults();
           const repositoryInput = readApprovalRepositoryInput();
-          approveOutput.textContent = "approval challenge request...";
+          setApproveOutput("approval challenge request...", { show: operatorMode !== "dashboard" });
           const challengeResponse = await fetch("${apiBase}/approval/passkey/challenge", {
             method: "POST",
             headers: { "content-type": "application/json" },
@@ -28028,7 +28038,7 @@ function renderPasskeyOperatorPage(input = {}) {
           }
           latestApprovalGrant = verifyBody?.approvalGrant || null;
           latestApprovalGrantId = latestApprovalGrant?.approvalId || verifyBody?.approvalGrantId || "";
-          approveOutput.textContent = JSON.stringify(verifyBody, null, 2);
+          setApproveOutput(JSON.stringify(verifyBody, null, 2), { show: operatorMode !== "dashboard" });
           if (operatorMode === "dashboard") {
             window.location.assign("${dashboardReturnPath}");
             return;
@@ -28049,7 +28059,7 @@ function renderPasskeyOperatorPage(input = {}) {
             }
           }
         } catch (error) {
-          approveOutput.textContent = String(error);
+          setApproveOutput(String(error));
         }
       });
 

--- a/worker.js
+++ b/worker.js
@@ -27833,9 +27833,17 @@ function renderPasskeyOperatorPage(input = {}) {
           return;
         }
         approveOutput.textContent = String(text || "");
-        if (show) {
-          approveOutput.hidden = false;
+        approveOutput.hidden = !show;
+      }
+
+      function shouldShowApproveOutput(kind = "status") {
+        if (operatorMode === "deploy") {
+          return false;
         }
+        if (operatorMode === "dashboard") {
+          return kind === "error";
+        }
+        return true;
       }
 
       function showIssueCloseLink(body) {
@@ -27997,7 +28005,7 @@ function renderPasskeyOperatorPage(input = {}) {
         try {
           applyOperatorModeDefaults();
           const repositoryInput = readApprovalRepositoryInput();
-          setApproveOutput("approval challenge request...", { show: operatorMode !== "dashboard" });
+          setApproveOutput("approval challenge request...", { show: shouldShowApproveOutput("status") });
           const challengeResponse = await fetch("${apiBase}/approval/passkey/challenge", {
             method: "POST",
             headers: { "content-type": "application/json" },
@@ -28038,7 +28046,7 @@ function renderPasskeyOperatorPage(input = {}) {
           }
           latestApprovalGrant = verifyBody?.approvalGrant || null;
           latestApprovalGrantId = latestApprovalGrant?.approvalId || verifyBody?.approvalGrantId || "";
-          setApproveOutput(JSON.stringify(verifyBody, null, 2), { show: operatorMode !== "dashboard" });
+          setApproveOutput(JSON.stringify(verifyBody, null, 2), { show: shouldShowApproveOutput("status") });
           if (operatorMode === "dashboard") {
             window.location.assign("${dashboardReturnPath}");
             return;
@@ -28059,7 +28067,7 @@ function renderPasskeyOperatorPage(input = {}) {
             }
           }
         } catch (error) {
-          setApproveOutput(String(error));
+          setApproveOutput(String(error), { show: shouldShowApproveOutput("error") });
         }
       });
 


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #532 の passkey operator owner-facing flow の部分進捗です。
- iOS Simulator live evidence で、Dashboard passkey fallback の通常表示に空の `approve-output` 枠が残っていることを確認しました。
- 本PRでは dashboard mode の通常表示から空枠を消し、エラー時だけ表示します。

## Satisfied Success Criteria

- Dashboard mode の `approve-output` を初期状態で hidden にする。
- Dashboard mode の challenge/progress/success JSON は通常表示しない。
- エラー時は `approve-output` を表示し、理由を owner に見せる。
- deploy/merge/secret sync など非 dashboard mode の approve output 表示は維持する。

## Unsatisfied Success Criteria

- Issue #532 全体の deploy approval 1ボタン flow completion はこのPRだけでは完了扱いにしない。
- 本番 deploy と iPhone/PWA live E2E はこのPRでは未実施。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #532
- Implementing Success Criteria: dashboard passkey fallback の通常表示から空の出力枠を消す。エラー時は表示して理由を見せる。
- Explicit Non-goals: passkey/session/auth/redirect/Cloudflare Access/deploy workflow は変更しない。
- Expected touched files/routes/workflows: `src/core/passkey-operator-page.js`, `test/passkey-operator-page.test.js`, `worker.js`
- Affected Issues: Issue #532, Issue #528
- Affected PRs: PR #557 の post-deploy live observation で見つかった UX gap の修正。
- Affected workflows: なし。
- Affected runtime/operator surfaces: Passkey operator dashboard mode.
- What may break if we patch narrowly: エラー表示まで隠すと owner が fallback 失敗理由を見られない。
- Unknowns to investigate before coding: なし。live Simulator screenshot で空枠を確認済み。
- Validation needed: `node --test test/passkey-operator-page.test.js test/worker.test.js`; `npm run build:worker`; `npm run check:generated-worker`; `npm run check:self-parity`
- Stop condition: passkey/session/auth behavior の変更が必要になった場合は停止。

## File / Line Hypotheses

- file: `src/core/passkey-operator-page.js`
  - hypothesis: `approve-output` を dashboard mode では初期 hidden にし、`setApproveOutput()` でエラー時だけ表示すれば空枠を消せる。
  - risk if changed narrowly: エラー時の表示まで消すと recovery が悪くなる。
  - validation: dashboard mode HTML assertions と worker tests。
  - related Issue: #532

## Hypothesis Retrospective

- expected: dashboard mode HTML には `<pre id="approve-output" hidden>` があり、progress/success は表示せず、catch では表示する。
- actual: `test/passkey-operator-page.test.js` で確認。
- mismatch: なし。
- lesson: owner-facing fallback では空の debug/output region も通常表示から外す。
- should become RAG candidate: はい。Dashboard Butler 通常導線では空 debug/output frame を出さない。

## Verification Evidence

- Unit: `node --test test/passkey-operator-page.test.js test/worker.test.js`: 227 pass / 0 fail
- Integration: `npm run build:worker`; `npm run check:generated-worker`; `npm run check:self-parity`: pass
- E2E: 未実施。このPRは UX display slice。merge/deploy 後に live plain URL と iOS Simulator で再確認する。
- Manual: PR #557 deploy 後の Simulator screenshot で空の `approve-output` 枠が残っていることを確認。
- Evidence path/link: `src/core/passkey-operator-page.js`; `test/passkey-operator-page.test.js`; `worker.js`

## Butler Completion Contract

- Owner goal: Dashboard passkey fallback が空の debug/output 枠なしで通常操作に見えること。
- Butler entrypoint: Dashboard auth required page の `Passkey で開く` から `/v2/approval/passkey/operator?mode=dashboard...` へ入る。
- Action Schema exposure: 不要。Custom GPT Action Schema は変更しない。
- Runtime path: `/v2/approval/passkey/operator?mode=dashboard...`
- Runner/runtime truth: Unit tests で initial hidden と error display path を確認。
- Authority boundary: 未変更。UI display only。
- E2E evidence: 未実施。merge/deploy 後に live plain URL と iOS Simulator で再確認する。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 未実施。merge 後に scoped passkey approval が必要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate
- AGENTS.md Chief Butler Operating Principle
- AGENTS.md Conversation UX Contract
- AGENTS.md Evidence Discipline

## Out-of-scope but NOT implemented

- Issue #532 の close。
- Issue #534 の close。
- passkey/session/auth behavior changes。

## Extra changes (if any)

Generated `worker.js` rebuilt.

<!-- VTDD metadata -->
- Issue: Issue #532
- Execution ID: Not provided.
- Goal: Hide empty dashboard passkey output
