### PR TITLE
dashboard: passkey fallback 後も対象 repo context を保持する

### DIFF
--- a/src/core/passkey-operator-page.js
+++ b/src/core/passkey-operator-page.js
@@ -1308,7 +1308,23 @@ function sanitizePasskeyDashboardReturnPath(value) {
   if (parsed.pathname !== "/dashboard" && !parsed.pathname.startsWith("/dashboard/")) {
     return "/dashboard";
   }
-  return parsed.pathname;
+  const allowedSearchParams = new URLSearchParams();
+  for (const key of ["repository", "repositoryInput", "issueNumber"]) {
+    const rawValue = normalizeDashboardReturnQueryValue(parsed.searchParams.get(key));
+    if (rawValue) {
+      allowedSearchParams.set(key, rawValue);
+    }
+  }
+  const query = allowedSearchParams.toString();
+  return query ? `${parsed.pathname}?${query}` : parsed.pathname;
+}
+
+function normalizeDashboardReturnQueryValue(value) {
+  const normalized = String(value ?? "").trim();
+  if (!normalized || normalized.length > 256) {
+    return "";
+  }
+  return normalized;
 }
 
 function escapeHtml(value) {

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -10481,7 +10481,10 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
   const encodedRepository = encodeURIComponent(repositoryInput);
   const chatThreadId = `dashboard-main-${(repositoryInput || "unresolved").replace(/[^a-z0-9_.-]+/gi, "-")}`;
   const socketOrigin = origin.replace(/^http/i, "ws");
-  const dashboardSignInUrl = `${origin}/v2/approval/passkey/operator?mode=dashboard&phase=execution&actionType=read&highRiskKind=dashboard_access`;
+  const currentDashboardReturnPath = sanitizeDashboardPreAuthReturnPath(
+    `${url?.pathname || "/dashboard"}${url?.search || ""}`
+  );
+  const dashboardSignInUrl = `${origin}/v2/approval/passkey/operator?mode=dashboard&phase=execution&actionType=read&highRiskKind=dashboard_access&dashboardReturnPath=${encodeURIComponent(currentDashboardReturnPath)}`;
   const latestDeployEvent = await retrieveLatestDashboardEvent({
     store: dashboardEventStore,
     kind: "github_actions_workflow_run",
@@ -11896,7 +11899,7 @@ function buildCloudflareAccessLoginHref({ origin, returnPath = "/dashboard" } = 
 }
 
 function sanitizeDashboardPreAuthReturnPath(value) {
-  const normalized = normalizeText(value) || "/dashboard";
+  const normalized = String(value ?? "").trim() || "/dashboard";
   let parsed;
   try {
     parsed = new URL(normalized, "https://dashboard.local");
@@ -11909,7 +11912,23 @@ function sanitizeDashboardPreAuthReturnPath(value) {
   if (parsed.pathname !== "/dashboard" && !parsed.pathname.startsWith("/dashboard/")) {
     return "/dashboard";
   }
-  return parsed.pathname;
+  const allowedSearchParams = new URLSearchParams();
+  for (const key of ["repository", "repositoryInput", "issueNumber"]) {
+    const rawValue = normalizeDashboardReturnQueryValue(parsed.searchParams.get(key));
+    if (rawValue) {
+      allowedSearchParams.set(key, rawValue);
+    }
+  }
+  const query = allowedSearchParams.toString();
+  return query ? `${parsed.pathname}?${query}` : parsed.pathname;
+}
+
+function normalizeDashboardReturnQueryValue(value) {
+  const normalized = String(value ?? "").trim();
+  if (!normalized || normalized.length > 256) {
+    return "";
+  }
+  return normalized;
 }
 
 function renderV2StatusPage({ runtimeOrigin, autonomyMode }) {

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -799,6 +799,32 @@ test("worker rejects dashboard access without owner identity", async () => {
   assert.equal(body.includes("未認証の相手に通知詳細や Dashboard 内容は返しません"), true);
 });
 
+test("worker preserves dashboard repository context across auth fallback links", async () => {
+  const tooLongRepository = `${"a".repeat(257)}/repo`;
+  const response = await worker.fetch(
+    new Request(
+      `https://example.com/dashboard?repository=marushu%2Fvtdd-v2-p&repositoryInput=${tooLongRepository}&runId=private-run&title=private`
+    )
+  );
+  assert.equal(response.status, 401);
+  const body = await response.text();
+  assert.equal(
+    body.includes(
+      'href="https://example.com/cdn-cgi/access/login?redirect_url=https%3A%2F%2Fexample.com%2Fdashboard%3Frepository%3Dmarushu%252Fvtdd-v2-p"'
+    ),
+    true
+  );
+  assert.equal(
+    body.includes(
+      'href="https://example.com/v2/approval/passkey/operator?mode=dashboard&amp;phase=execution&amp;actionType=read&amp;highRiskKind=dashboard_access&amp;dashboardReturnPath=%2Fdashboard%3Frepository%3Dmarushu%252Fvtdd-v2-p"'
+    ),
+    true
+  );
+  assert.equal(body.includes("runId=private-run"), false);
+  assert.equal(body.includes("title=private"), false);
+  assert.equal(body.includes("repositoryInput="), false);
+});
+
 test("worker rejects unlisted dashboard subpaths before they can become public pages", async () => {
   const response = await worker.fetch(new Request("https://example.com/dashboard/future-page"));
   assert.equal(response.status, 401);
@@ -1042,7 +1068,7 @@ test("worker serves v2 dashboard for allowed owner identity without exposing sec
   assert.equal(body.includes('aria-label="Passkey で dashboard session を更新">Passkey</a>'), true);
   assert.equal(
     body.includes(
-      '/v2/approval/passkey/operator?mode=dashboard&amp;phase=execution&amp;actionType=read&amp;highRiskKind=dashboard_access"'
+      '/v2/approval/passkey/operator?mode=dashboard&amp;phase=execution&amp;actionType=read&amp;highRiskKind=dashboard_access&amp;dashboardReturnPath=%2Fdashboard"'
     ),
     true
   );
@@ -2966,6 +2992,12 @@ test("worker serves dashboard chat-first shell with debug and ops surfaces isola
   assert.equal(body.includes("通知と進捗はこの画面から戻って確認できます"), true);
   assert.equal(body.includes("対象 repo"), true);
   assert.equal(body.includes("Issue / PR 操作が必要になった時だけ"), true);
+  assert.equal(
+    body.includes(
+      '/v2/approval/passkey/operator?mode=dashboard&amp;phase=execution&amp;actionType=read&amp;highRiskKind=dashboard_access&amp;dashboardReturnPath=%2Fdashboard%3Frepository%3Dsample-org%252Fvtdd-v2-p'
+    ),
+    true
+  );
   const initialChat = body.slice(
     body.indexOf('<div class="chat-scroll"'),
     body.indexOf('<form class="composer"')
@@ -6519,6 +6551,36 @@ test("worker serves dashboard passkey operator mode", async () => {
   assert.equal(html.includes('value="marushu/vtdd-v2-p"'), false);
   assert.equal(html.includes("repositoryInput is required before approval/deploy"), true);
   assert.equal(html.includes("const repositoryInput = readApprovalRepositoryInput();"), true);
+});
+
+test("worker serves dashboard passkey operator mode with safe query return path", async () => {
+  const response = await worker.fetch(
+    new Request(
+      "https://example.com/v2/approval/passkey/operator?mode=dashboard&dashboardReturnPath=%2Fdashboard%3Frepository%3Dmarushu%252Fvtdd-v2-p%26runId%3Dprivate-run"
+    ),
+    gatewayAuthEnv
+  );
+
+  assert.equal(response.status, 200);
+  const html = await response.text();
+  assert.equal(html.includes('window.location.assign("/dashboard?repository=marushu%2Fvtdd-v2-p")'), true);
+  assert.equal(html.includes("runId=private-run"), false);
+  assert.equal(html.includes("repo / Issue / PR scope は使いません"), true);
+});
+
+test("worker strips overlong dashboard passkey return query values", async () => {
+  const tooLongRepository = encodeURIComponent(`${"a".repeat(257)}/repo`);
+  const response = await worker.fetch(
+    new Request(
+      `https://example.com/v2/approval/passkey/operator?mode=dashboard&dashboardReturnPath=%2Fdashboard%3Frepository%3D${tooLongRepository}`
+    ),
+    gatewayAuthEnv
+  );
+
+  assert.equal(response.status, 200);
+  const html = await response.text();
+  assert.equal(html.includes('window.location.assign("/dashboard")'), true);
+  assert.equal(html.includes("repository="), false);
 });
 
 test("worker keeps explicit non-dashboard operator modes repo-scoped even with dashboard_access conflict", async () => {

--- a/worker.js
+++ b/worker.js
@@ -28510,7 +28510,22 @@ function sanitizePasskeyDashboardReturnPath(value) {
   if (parsed.pathname !== "/dashboard" && !parsed.pathname.startsWith("/dashboard/")) {
     return "/dashboard";
   }
-  return parsed.pathname;
+  const allowedSearchParams = new URLSearchParams();
+  for (const key of ["repository", "repositoryInput", "issueNumber"]) {
+    const rawValue = normalizeDashboardReturnQueryValue(parsed.searchParams.get(key));
+    if (rawValue) {
+      allowedSearchParams.set(key, rawValue);
+    }
+  }
+  const query = allowedSearchParams.toString();
+  return query ? `${parsed.pathname}?${query}` : parsed.pathname;
+}
+function normalizeDashboardReturnQueryValue(value) {
+  const normalized = String(value ?? "").trim();
+  if (!normalized || normalized.length > 256) {
+    return "";
+  }
+  return normalized;
 }
 function escapeHtml(value) {
   return String(value ?? "").replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;").replaceAll('"', "&quot;");
@@ -65366,7 +65381,10 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
   const encodedRepository = encodeURIComponent(repositoryInput);
   const chatThreadId = `dashboard-main-${(repositoryInput || "unresolved").replace(/[^a-z0-9_.-]+/gi, "-")}`;
   const socketOrigin = origin.replace(/^http/i, "ws");
-  const dashboardSignInUrl = `${origin}/v2/approval/passkey/operator?mode=dashboard&phase=execution&actionType=read&highRiskKind=dashboard_access`;
+  const currentDashboardReturnPath = sanitizeDashboardPreAuthReturnPath(
+    `${url?.pathname || "/dashboard"}${url?.search || ""}`
+  );
+  const dashboardSignInUrl = `${origin}/v2/approval/passkey/operator?mode=dashboard&phase=execution&actionType=read&highRiskKind=dashboard_access&dashboardReturnPath=${encodeURIComponent(currentDashboardReturnPath)}`;
   const latestDeployEvent = await retrieveLatestDashboardEvent({
     store: dashboardEventStore,
     kind: "github_actions_workflow_run",
@@ -66764,7 +66782,7 @@ function buildCloudflareAccessLoginHref({ origin, returnPath = "/dashboard" } = 
   return `${normalizedOrigin || ""}/cdn-cgi/access/login?redirect_url=${encodeURIComponent(redirectUrl)}`;
 }
 function sanitizeDashboardPreAuthReturnPath(value) {
-  const normalized = normalizeText30(value) || "/dashboard";
+  const normalized = String(value ?? "").trim() || "/dashboard";
   let parsed;
   try {
     parsed = new URL(normalized, "https://dashboard.local");
@@ -66777,7 +66795,22 @@ function sanitizeDashboardPreAuthReturnPath(value) {
   if (parsed.pathname !== "/dashboard" && !parsed.pathname.startsWith("/dashboard/")) {
     return "/dashboard";
   }
-  return parsed.pathname;
+  const allowedSearchParams = new URLSearchParams();
+  for (const key of ["repository", "repositoryInput", "issueNumber"]) {
+    const rawValue = normalizeDashboardReturnQueryValue2(parsed.searchParams.get(key));
+    if (rawValue) {
+      allowedSearchParams.set(key, rawValue);
+    }
+  }
+  const query = allowedSearchParams.toString();
+  return query ? `${parsed.pathname}?${query}` : parsed.pathname;
+}
+function normalizeDashboardReturnQueryValue2(value) {
+  const normalized = String(value ?? "").trim();
+  if (!normalized || normalized.length > 256) {
+    return "";
+  }
+  return normalized;
 }
 function renderV2StatusPage({ runtimeOrigin, autonomyMode }) {
   const origin = normalize7(runtimeOrigin);


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #560 の実装スライスです。Dashboard passkey fallback / Cloudflare Access pre-auth 導線で /dashboard?repository=<owner/repo> の対象 repo context を保持します。\n- 未認証画面と authenticated dashboard topbar の Passkey 更新リンク、passkey operator redirect の sanitizer を揃えます。\n- Gemini request_changes の sanitizer 一貫性指摘に対応し、return query value の 256 文字 allowlist helper を worker/operator 双方に追加しました。

## Satisfied Success Criteria

- /dashboard?repository=<owner/repo> の未認証画面で Cloudflare Access と Passkey fallback の戻り先が repository query を保持する。\n- dashboard passkey operator approval 後の redirect が /dashboard?repository=<owner/repo> を保持する。\n- runId/title など通知詳細由来の query は戻り先から除外する。\n- overlong query value は保持せず、長大URLや不正 context の持ち越しを防ぐ。\n- dashboard_access read-only scope のままで、deploy / merge / secret sync approval とは混ぜない。\n- regression test で query preservation / query stripping / overlong query stripping を固定する。

## Unsatisfied Success Criteria

- production deploy 後の authenticated live / iPhone/PWA E2E は未実施。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #560
- Implementing Success Criteria: /dashboard?repository=... の pre-auth / passkey fallback / operator redirect で repository context を保持し、漏えい候補 query と overlong query を捨てる。
- Explicit Non-goals: Cloudflare Access provider 設定変更なし、authority boundary 緩和なし、deploy/merge/secret sync なし、#528 全体 UX 完了主張なし。
- Expected touched files/routes/workflows: src/worker/runtime.js, src/core/passkey-operator-page.js, test/worker.test.js, worker.js
- Affected Issues: Issue #560, Issue #528, closed Issue #534 の live 検証で見つかった residual gap
- Affected PRs: PR #561
- Affected workflows: test / guarded-policy / Gemini review / deploy-production は merge 後に通常通り影響
- Affected runtime/operator surfaces: Dashboard auth required page, Dashboard topbar Passkey link, Passkey operator dashboard mode, generated Worker
- What may break if we patch narrowly: query を丸ごと保持すると通知 event details や外部 redirect を漏らす危険があるため、repository/repositoryInput/issueNumber の allowlist と 256 文字上限に限定。
- Unknowns to investigate before coding: Cloudflare Access provider 側が redirect_url query を保持するかは production live E2E で確認する。Worker 側 href 生成は unit で固定済み。
- Validation needed: node --test test/worker.test.js の dashboard/auth/operator 系、node --test test/passkey-operator-page.test.js、build:worker、check:generated-worker、check:self-parity、post-deploy live E2E
- Stop condition: dashboard_access 以外の high-risk approval scope に影響する場合、または query allowlist 以外を保持する必要が出た場合は停止。

## File / Line Hypotheses

- file: src/worker/runtime.js sanitizeDashboardPreAuthReturnPath\n  - hypothesis: path only return が repository query 消失の原因。allowlist query を返せば pre-auth href と dashboard topbar が context を保持する。\n  - risk if changed narrowly: event/private query を残すと未認証画面 href に情報が混ざる。\n  - validation: worker test で repository は保持し runId/title/overlong values は落とす。\n  - related Issue: Issue #560\n- file: src/core/passkey-operator-page.js sanitizePasskeyDashboardReturnPath\n  - hypothesis: operator 側 sanitizer も path only なので approval 後 redirect で repo context が落ちる。\n  - risk if changed narrowly: external URL や未許可 path を許すと open redirect に近い挙動になる。\n  - validation: operator mode test で safe query のみ window.location.assign に残し、overlong value は落とす。\n  - related Issue: Issue #560

## Hypothesis Retrospective

- expected: repository query だけ保持し、runId/title/overlong values は捨てる。\n- actual: unit tests で期待通り。Gemini request_changes 後に sanitizer 一貫性も明示した。\n- mismatch: production live は deploy 後に確認が必要。\n- lesson: dashboardReturnPath は path だけでなく owner-facing context の allowlist query と長さ境界を扱う必要がある。\n- should become RAG candidate: はい。Dashboard auth fallback の context retention 方針として候補。

## Verification Evidence

- Unit: node --test test/worker.test.js --test-name-pattern 'dashboard repository context|dashboard passkey operator mode|overlong dashboard passkey|dashboard chat-first|notification details before Access': pass 205 / fail 0; node --test test/passkey-operator-page.test.js: pass 26 / fail 0
- Integration: npm run build:worker: pass; npm run check:generated-worker: pass; npm run check:self-parity: pass; git diff --check: pass
- E2E: 未実施。production deploy 後に /dashboard?repository=marushu%2Fvtdd-v2-p -> passkey fallback -> /dashboard?repository=... resolved 表示を確認する。
- Manual: #534 live close-readiness 中に /dashboard?repository=... から fallback 後 /dashboard へ戻って repo context が落ちることを確認。
- Evidence path/link: Issue #560, PR #561, src/worker/runtime.js, src/core/passkey-operator-page.js, test/worker.test.js

## Butler Completion Contract

- Owner goal: iPhone/PWA で Dashboard Butler を開き直す時、対象 repo を失わず通常チャット/Issue/PR 操作の文脈を維持する。
- Butler entrypoint: /dashboard?repository=<owner/repo> の Cloudflare Access / Passkey fallback
- Action Schema exposure: 不要。この PR は Custom GPT Action Schema の operationId を変更しない。
- Runtime path: Worker の Dashboard auth required page と Passkey operator dashboard mode が dashboardReturnPath を allowlist query 付きで共有する。
- Runner/runtime truth: unit/integration evidence は pass。production runtime truth は deploy 後に確認する。
- Authority boundary: dashboard_access read-only session のみ。deploy / merge / secret sync など high-risk approval は変更しない。
- E2E evidence: PR 時点では未実施。post-deploy live E2E で補完する。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: merge 後に必要。deploy は scoped passkey approval が必要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: merge/deploy 後に /dashboard?repository=... の passkey fallback live E2E が必要。

## Related Constitution Rules

- AGENTS.md Drift Stop Protocol\n- AGENTS.md Butler Completion Gate\n- AGENTS.md Evidence Discipline\n- AGENTS.md Authority Boundary\n- Reviewer request_changes は blocking risk として扱う

## Out-of-scope but NOT implemented

- Issue #514 Web Push 実機配信 E2E\n- Issue #528 全体の ChatGPT iOS 相当 UX baseline\n- Cloudflare Access provider 設定変更\n- deploy/merge/secret sync high-risk authority変更

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #560
- Execution ID: Not provided.
- Goal: Not provided.
