### PR TITLE
dashboard: message copy controls を通常チャット面で常時主張しない

### DIFF
--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -10618,6 +10618,8 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
       --button: #f4f4ef;
       --owner-bubble: #171717;
       --owner-text: #f7f7f4;
+      --link: #0b6b65;
+      --owner-link: #9ee7ff;
       --shadow: rgba(20, 20, 20, .12);
       color: var(--text);
       background: var(--page-bg);
@@ -10634,6 +10636,8 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         --button: #171717;
         --owner-bubble: #f2f2ee;
         --owner-text: #111;
+        --link: #90cdf4;
+        --owner-link: #075985;
         --shadow: rgba(0, 0, 0, .42);
       }
     }
@@ -10678,20 +10682,23 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
     .bubble .message-body strong { display: inline; color: inherit; font-size: inherit; letter-spacing: 0; text-transform: none; margin: 0; font-weight: 800; }
     .message-meta { margin-top: 6px; color: var(--muted); font-size: 11px; line-height: 1.2; opacity: .86; }
     .bubble.owner .message-meta { color: var(--owner-text); opacity: .76; text-align: right; }
+    .bubble.has-copy-action { position: relative; }
     .copy-message, .copy-code { display: inline-flex; align-items: center; justify-content: center; width: 30px; height: 30px; border: 1px solid var(--border); border-radius: 999px; background: var(--button); color: var(--text); font-size: 15px; line-height: 1; cursor: pointer; }
+    .copy-message { position: absolute; top: -8px; right: -8px; z-index: 2; opacity: 0; pointer-events: none; transform: translateY(-2px) scale(.96); transition: opacity .16s ease, transform .16s ease; }
+    .bubble.has-copy-action:hover .copy-message, .bubble.has-copy-action:focus-within .copy-message, .bubble.actions-visible .copy-message { opacity: .92; pointer-events: auto; transform: translateY(0) scale(1); }
     .copy-message:focus-visible, .copy-code:focus-visible { outline: 2px solid var(--text); outline-offset: 2px; }
     .copy-code { position: absolute; top: 8px; right: 8px; z-index: 1; opacity: .88; }
     .copy-code:hover, .copy-code:focus-visible { opacity: 1; }
     .bubble ul { margin: 0; padding-left: 22px; color: var(--text); line-height: 1.85; }
     .bubble.owner { position: relative; align-self: flex-end; background: var(--owner-bubble); color: var(--owner-text); border-radius: 24px; padding: 12px 16px; }
     .bubble.owner p { color: var(--owner-text); margin: 0; }
-    .bubble.owner .copy-message { position: absolute; top: -12px; left: -12px; width: 28px; height: 28px; background: var(--panel-strong); color: var(--text); opacity: .86; }
-    .bubble.owner .copy-message:hover, .bubble.owner .copy-message:focus-visible { opacity: 1; }
+    .bubble.owner .copy-message { top: -10px; left: -10px; right: auto; width: 28px; height: 28px; background: var(--panel-strong); color: var(--text); }
     .bubble.thinking { color: var(--muted); }
     .thinking-dots::after { content: ""; display: inline-block; width: 1.4em; text-align: left; animation: thinkingDots 1.2s steps(4, end) infinite; }
     @keyframes thinkingDots { 0% { content: ""; } 25% { content: "."; } 50% { content: ".."; } 75%, 100% { content: "..."; } }
     .connection-note { display: inline-flex; align-items: center; width: fit-content; border: 1px solid var(--border); border-radius: 999px; padding: 5px 10px; color: var(--muted); font-size: 13px; }
-    .chat-link { color: var(--text); text-decoration-thickness: 1px; text-underline-offset: 4px; font-weight: 750; overflow-wrap: anywhere; word-break: break-word; }
+    .chat-link { color: var(--link); text-decoration-thickness: 1px; text-underline-offset: 4px; font-weight: 750; overflow-wrap: anywhere; word-break: break-word; }
+    .bubble.owner .chat-link { color: var(--owner-link); }
     .composer { min-width: 0; display: grid; gap: 8px; z-index: 4; padding: 14px 0 max(16px, env(safe-area-inset-bottom)); background: var(--page-bg); }
     .composer-box { display: grid; grid-template-columns: 44px minmax(0, 1fr) 44px; align-items: end; gap: 8px; min-height: 62px; padding: 8px; border: 1px solid var(--border); border-radius: 28px; background: var(--panel-strong); box-shadow: 0 16px 60px var(--shadow); }
     textarea { width: 100%; min-height: 44px; max-height: max(88px, min(160px, 24dvh)); border: 0; outline: 0; resize: none; overflow-y: hidden; padding: 10px 2px; color: var(--text); background: transparent; font: inherit; line-height: 1.45; }
@@ -11071,6 +11078,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         const article = document.createElement("article");
         article.className = message.role === "owner" ? "bubble owner" : "bubble";
         if (message.role === "owner") {
+          attachMessageActionReveal(article);
           const copyButton = document.createElement("button");
           copyButton.className = "copy-message";
           copyButton.type = "button";
@@ -11094,6 +11102,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           copyButton.addEventListener("click", () => copyMessageText(copyButton, normalizeMessageCopyText(message.text || "")));
           header.appendChild(copyButton);
           article.appendChild(header);
+          attachMessageActionReveal(article);
         } else if (message.role === "system") {
           const header = document.createElement("div");
           header.className = "bubble-header";
@@ -11120,6 +11129,20 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         }
         log.appendChild(article);
         scrollToLatest();
+      }
+
+      function attachMessageActionReveal(article) {
+        article.classList.add("has-copy-action");
+        article.tabIndex = 0;
+        article.addEventListener("click", (event) => {
+          if (event.target.closest("a, button, input, textarea, select, summary")) return;
+          article.classList.toggle("actions-visible");
+        });
+        article.addEventListener("keydown", (event) => {
+          if (event.key !== "Enter" && event.key !== " ") return;
+          event.preventDefault();
+          article.classList.toggle("actions-visible");
+        });
       }
 
       function formatMessageTimestamp(value) {

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -1048,6 +1048,10 @@ test("worker serves v2 dashboard for allowed owner identity without exposing sec
   assert.equal(body.includes("必要な時だけ開く"), true);
   assert.equal(body.includes("color-scheme: light dark"), true);
   assert.equal(body.includes("prefers-color-scheme: dark"), true);
+  assert.equal(body.includes("--link: #0b6b65;"), true);
+  assert.equal(body.includes("--owner-link: #9ee7ff;"), true);
+  assert.equal(body.includes("--link: #90cdf4;"), true);
+  assert.equal(body.includes("--owner-link: #075985;"), true);
   assert.equal(body.includes("overflow: hidden"), true);
   assert.equal(body.includes("grid-template-columns: minmax(0, 1fr) auto"), true);
   assert.equal(body.includes("WebSocket"), true);
@@ -1143,6 +1147,11 @@ test("worker serves v2 dashboard for allowed owner identity without exposing sec
   assert.equal(body.includes("new Intl.DateTimeFormat(locale"), true);
   assert.equal(body.includes(".message-meta { margin-top: 6px; color: var(--muted); font-size: 11px; line-height: 1.2; opacity: .86; }"), true);
   assert.equal(body.includes(".bubble.owner .message-meta { color: var(--owner-text); opacity: .76; text-align: right; }"), true);
+  assert.equal(body.includes(".bubble.has-copy-action { position: relative; }"), true);
+  assert.equal(body.includes(".copy-message { position: absolute; top: -8px; right: -8px;"), true);
+  assert.equal(body.includes("opacity: 0; pointer-events: none;"), true);
+  assert.equal(body.includes(".bubble.has-copy-action:hover .copy-message"), true);
+  assert.equal(body.includes(".bubble.actions-visible .copy-message"), true);
   assert.equal(body.includes('document.createElement("ul")'), true);
   assert.equal(body.includes('document.createElement("li")'), true);
   assert.equal(body.includes('document.createElement("pre")'), true);
@@ -1160,6 +1169,8 @@ test("worker serves v2 dashboard for allowed owner identity without exposing sec
   assert.equal(body.includes('if (/^https?:\\/\\//i.test(source)) return true;'), true);
   assert.equal(body.includes('if (/^go:%[0-9a-f]{2}/i.test(source)) return true;'), true);
   assert.equal(body.includes("return source.length > 80 && !/\\s/.test(source);"), true);
+  assert.equal(body.includes(".chat-link { color: var(--link);"), true);
+  assert.equal(body.includes(".bubble.owner .chat-link { color: var(--owner-link); }"), true);
   assert.equal(body.includes('renderMessageText(body, normalizeMessageDisplayText(message.text || "（空のメッセージ）"))'), true);
   assert.equal(body.includes('copyMessageText(copyButton, normalizeMessageCopyText(message.text || ""))'), true);
   assert.equal(body.includes('pre.className = "wrap-code"'), true);
@@ -1171,6 +1182,10 @@ test("worker serves v2 dashboard for allowed owner identity without exposing sec
   assert.equal(body.includes("コードをコピー"), true);
   assert.equal(body.includes("copyButton.addEventListener(\"click\", () => copyMessageText(copyButton, codeText))"), true);
   assert.equal(body.includes(".copy-code { position: absolute; top: 8px; right: 8px;"), true);
+  assert.equal(body.includes("function attachMessageActionReveal("), true);
+  assert.equal(body.includes('article.classList.add("has-copy-action")'), true);
+  assert.equal(body.includes('article.classList.toggle("actions-visible")'), true);
+  assert.equal(body.includes('event.target.closest("a, button, input, textarea, select, summary")'), true);
   assert.equal(body.includes('if (message.role === "owner")'), true);
   assert.equal(body.includes('} else if (message.role === "butler") {'), true);
   assert.equal(body.includes('} else if (message.role === "system") {'), true);

--- a/worker.js
+++ b/worker.js
@@ -65505,6 +65505,8 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
       --button: #f4f4ef;
       --owner-bubble: #171717;
       --owner-text: #f7f7f4;
+      --link: #0b6b65;
+      --owner-link: #9ee7ff;
       --shadow: rgba(20, 20, 20, .12);
       color: var(--text);
       background: var(--page-bg);
@@ -65521,6 +65523,8 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         --button: #171717;
         --owner-bubble: #f2f2ee;
         --owner-text: #111;
+        --link: #90cdf4;
+        --owner-link: #075985;
         --shadow: rgba(0, 0, 0, .42);
       }
     }
@@ -65565,20 +65569,23 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
     .bubble .message-body strong { display: inline; color: inherit; font-size: inherit; letter-spacing: 0; text-transform: none; margin: 0; font-weight: 800; }
     .message-meta { margin-top: 6px; color: var(--muted); font-size: 11px; line-height: 1.2; opacity: .86; }
     .bubble.owner .message-meta { color: var(--owner-text); opacity: .76; text-align: right; }
+    .bubble.has-copy-action { position: relative; }
     .copy-message, .copy-code { display: inline-flex; align-items: center; justify-content: center; width: 30px; height: 30px; border: 1px solid var(--border); border-radius: 999px; background: var(--button); color: var(--text); font-size: 15px; line-height: 1; cursor: pointer; }
+    .copy-message { position: absolute; top: -8px; right: -8px; z-index: 2; opacity: 0; pointer-events: none; transform: translateY(-2px) scale(.96); transition: opacity .16s ease, transform .16s ease; }
+    .bubble.has-copy-action:hover .copy-message, .bubble.has-copy-action:focus-within .copy-message, .bubble.actions-visible .copy-message { opacity: .92; pointer-events: auto; transform: translateY(0) scale(1); }
     .copy-message:focus-visible, .copy-code:focus-visible { outline: 2px solid var(--text); outline-offset: 2px; }
     .copy-code { position: absolute; top: 8px; right: 8px; z-index: 1; opacity: .88; }
     .copy-code:hover, .copy-code:focus-visible { opacity: 1; }
     .bubble ul { margin: 0; padding-left: 22px; color: var(--text); line-height: 1.85; }
     .bubble.owner { position: relative; align-self: flex-end; background: var(--owner-bubble); color: var(--owner-text); border-radius: 24px; padding: 12px 16px; }
     .bubble.owner p { color: var(--owner-text); margin: 0; }
-    .bubble.owner .copy-message { position: absolute; top: -12px; left: -12px; width: 28px; height: 28px; background: var(--panel-strong); color: var(--text); opacity: .86; }
-    .bubble.owner .copy-message:hover, .bubble.owner .copy-message:focus-visible { opacity: 1; }
+    .bubble.owner .copy-message { top: -10px; left: -10px; right: auto; width: 28px; height: 28px; background: var(--panel-strong); color: var(--text); }
     .bubble.thinking { color: var(--muted); }
     .thinking-dots::after { content: ""; display: inline-block; width: 1.4em; text-align: left; animation: thinkingDots 1.2s steps(4, end) infinite; }
     @keyframes thinkingDots { 0% { content: ""; } 25% { content: "."; } 50% { content: ".."; } 75%, 100% { content: "..."; } }
     .connection-note { display: inline-flex; align-items: center; width: fit-content; border: 1px solid var(--border); border-radius: 999px; padding: 5px 10px; color: var(--muted); font-size: 13px; }
-    .chat-link { color: var(--text); text-decoration-thickness: 1px; text-underline-offset: 4px; font-weight: 750; overflow-wrap: anywhere; word-break: break-word; }
+    .chat-link { color: var(--link); text-decoration-thickness: 1px; text-underline-offset: 4px; font-weight: 750; overflow-wrap: anywhere; word-break: break-word; }
+    .bubble.owner .chat-link { color: var(--owner-link); }
     .composer { min-width: 0; display: grid; gap: 8px; z-index: 4; padding: 14px 0 max(16px, env(safe-area-inset-bottom)); background: var(--page-bg); }
     .composer-box { display: grid; grid-template-columns: 44px minmax(0, 1fr) 44px; align-items: end; gap: 8px; min-height: 62px; padding: 8px; border: 1px solid var(--border); border-radius: 28px; background: var(--panel-strong); box-shadow: 0 16px 60px var(--shadow); }
     textarea { width: 100%; min-height: 44px; max-height: max(88px, min(160px, 24dvh)); border: 0; outline: 0; resize: none; overflow-y: hidden; padding: 10px 2px; color: var(--text); background: transparent; font: inherit; line-height: 1.45; }
@@ -65958,6 +65965,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         const article = document.createElement("article");
         article.className = message.role === "owner" ? "bubble owner" : "bubble";
         if (message.role === "owner") {
+          attachMessageActionReveal(article);
           const copyButton = document.createElement("button");
           copyButton.className = "copy-message";
           copyButton.type = "button";
@@ -65981,6 +65989,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           copyButton.addEventListener("click", () => copyMessageText(copyButton, normalizeMessageCopyText(message.text || "")));
           header.appendChild(copyButton);
           article.appendChild(header);
+          attachMessageActionReveal(article);
         } else if (message.role === "system") {
           const header = document.createElement("div");
           header.className = "bubble-header";
@@ -66007,6 +66016,20 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         }
         log.appendChild(article);
         scrollToLatest();
+      }
+
+      function attachMessageActionReveal(article) {
+        article.classList.add("has-copy-action");
+        article.tabIndex = 0;
+        article.addEventListener("click", (event) => {
+          if (event.target.closest("a, button, input, textarea, select, summary")) return;
+          article.classList.toggle("actions-visible");
+        });
+        article.addEventListener("keydown", (event) => {
+          if (event.key !== "Enter" && event.key !== " ") return;
+          event.preventDefault();
+          article.classList.toggle("actions-visible");
+        });
       }
 
       function formatMessageTimestamp(value) {


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #562 の実装スライスです。Dashboard Butler の通常チャット面で message copy controls が常時主張して本文や吹き出しに割り込む問題を直します。\n- 会話吹き出しの背景色とリンク色が同化して読みにくい問題も、同じ通常チャット読解性の範囲として修正します。

## Satisfied Success Criteria

- owner / Butler message のコピー操作は維持。\n- copy message action は通常表示では opacity 0 / pointer-events none で主張せず、hover / focus / tap-to-reveal で到達できる。\n- owner message の copy action は absolute action として本文レイアウトに割り込まない。\n- code block copy は code block 内の必要操作として維持。\n- chat links は通常リンク色と owner bubble 専用リンク色に分け、背景と同化しない。\n- regression test で message action reveal policy と link color variables を固定。

## Unsatisfied Success Criteria

- production deploy 後の live / iPhone/PWA E2E は未実施。\n- Issue #528 全体の ChatGPT iOS 相当 UX baseline は未完了。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #562
- Implementing Success Criteria: message copy controls を残しながら通常チャット面では常時主張しない。desktop は hover/focus、touch は tap-to-reveal。リンク色は owner bubble 背景と同化しない。
- Explicit Non-goals: copy 削除なし、WebSocket/添付/通知/deploy/passkey authority boundary 変更なし、#528 全体 completion 主張なし、Action Schema/Instructions 変更なし。
- Expected touched files/routes/workflows: src/worker/runtime.js, test/worker.test.js, worker.js
- Affected Issues: Issue #562, parent Issue #528
- Affected PRs: なし
- Affected workflows: test / guarded-policy / Gemini review / deploy-production は merge 後に通常通り影響
- Affected runtime/operator surfaces: Dashboard Butler chat shell, message rendering, generated Worker
- What may break if we patch narrowly: copy controls を完全に隠すと iPhone/PWA でコピーできなくなるため、tap-to-reveal と focus/hover を併用する。リンク色は light/dark owner bubble の両方で contrast を保つ。
- Unknowns to investigate before coding: 実機 PWA で tap-to-reveal の操作感が十分かは deploy 後の live E2E で確認する。
- Validation needed: targeted node --test, build:worker, check:generated-worker, check:self-parity, post-deploy live screenshot/E2E
- Stop condition: message copy を削除する必要が出た場合、または action menu 全体設計に広がる場合は停止して Issue を分ける。

## File / Line Hypotheses

- file: src/worker/runtime.js Dashboard CSS\n  - hypothesis: .copy-message の常時表示と owner absolute positioning が本文近くに割り込み、通常チャット読解を邪魔している。\n  - risk if changed narrowly: copy 操作が到達不能になる。\n  - validation: CSS/JS で hover/focus/tap-to-reveal を固定し、copyMessageText は維持。\n  - related Issue: Issue #562\n- file: src/worker/runtime.js .chat-link\n  - hypothesis: .chat-link が var(--text) を使っているため owner bubble 上で背景と同化する。\n  - risk if changed narrowly: dark mode / owner bubble のどちらかで contrast が落ちる。\n  - validation: --link / --owner-link を light/dark で分け、tests で固定。\n  - related Issue: Issue #562

## Hypothesis Retrospective

- expected: copy controls は通常表示から退き、hover/focus/tap で出る。owner bubble links は専用色で読める。\n- actual: unit/static regression tests は期待通り。\n- mismatch: live PWA 操作感は deploy 後に確認する。\n- lesson: ChatGPT iOS baseline では補助操作を常設しない。リンク色も bubble context ごとに分ける必要がある。\n- should become RAG candidate: はい。Dashboard chat visual baseline の候補。

## Verification Evidence

- Unit: node --test test/worker.test.js --test-name-pattern 'allowed owner identity|inline chat renderer|dashboard chat-first': pass 205 / fail 0
- Integration: npm run build:worker: pass; npm run check:generated-worker: pass; npm run check:self-parity: pass; git diff --check: pass
- E2E: 未実施。production deploy 後に Dashboard chat first view / tap-to-reveal / link contrast を確認する。
- Manual: live Dashboard で copy controls が常時見え、owner bubble 内 link が背景と同化する owner report を受けて修正。
- Evidence path/link: Issue #562, PR body, src/worker/runtime.js, test/worker.test.js

## Butler Completion Contract

- Owner goal: Dashboard Butler の通常会話を読んでいる時、補助操作やリンク色が本文読解を邪魔しない。
- Butler entrypoint: /dashboard の chat shell
- Action Schema exposure: 不要。この PR は Custom GPT Action Schema の operationId を変更しない。
- Runtime path: Worker が配信する Dashboard HTML/CSS/inline JS の message rendering path。
- Runner/runtime truth: unit/integration evidence は pass。production runtime truth は deploy 後に確認する。
- Authority boundary: 未変更。copy UI / link color の表示修正のみで high-risk authority は追加しない。
- E2E evidence: PR 時点では未実施。post-deploy live E2E で補完する。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: merge 後に必要。deploy は scoped passkey approval が必要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: merge/deploy 後に iPhone/PWA 相当で chat first view と tap-to-reveal を確認する。

## Related Constitution Rules

- AGENTS.md Drift Stop Protocol\n- AGENTS.md Chief Butler Operating Principle\n- AGENTS.md Conversation UX Contract\n- AGENTS.md Evidence Discipline

## Out-of-scope but NOT implemented

- Issue #528 全体 close\n- WebSocket reconnect / app-server bridge\n- multiple image attachments\n- Web Push delivery\n- deploy/passkey authority changes

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #562
- Execution ID: Not provided.
- Goal: Not provided.
