### PR TITLE
Issue #503 D1 memory database canonical source

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -47,6 +47,7 @@ jobs:
           VTDD_GATEWAY_BEARER_TOKEN: ${{ secrets.VTDD_GATEWAY_BEARER_TOKEN }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_D1_DATABASE_NAME: ${{ vars.CLOUDFLARE_D1_DATABASE_NAME }}
           CLOUDFLARE_D1_DATABASE_ID: ${{ secrets.CLOUDFLARE_D1_DATABASE_ID }}
         shell: bash
         run: |
@@ -61,6 +62,10 @@ jobs:
           fi
           if [ -z "$CLOUDFLARE_ACCOUNT_ID" ]; then
             echo "Missing required Actions secret: CLOUDFLARE_ACCOUNT_ID"
+            missing=1
+          fi
+          if [ -z "$CLOUDFLARE_D1_DATABASE_NAME" ]; then
+            echo "Missing required Actions variable: CLOUDFLARE_D1_DATABASE_NAME"
             missing=1
           fi
           if [ -z "$CLOUDFLARE_D1_DATABASE_ID" ]; then
@@ -204,7 +209,7 @@ jobs:
       - name: Generate production Wrangler config
         env:
           CLOUDFLARE_D1_DATABASE_ID: ${{ secrets.CLOUDFLARE_D1_DATABASE_ID }}
-          CLOUDFLARE_D1_DATABASE_NAME: ${{ vars.CLOUDFLARE_D1_DATABASE_NAME || 'vtdd-memory' }}
+          CLOUDFLARE_D1_DATABASE_NAME: ${{ vars.CLOUDFLARE_D1_DATABASE_NAME }}
           CLOUDFLARE_MEDIA_R2_BUCKET_NAME: ${{ vars.CLOUDFLARE_MEDIA_R2_BUCKET_NAME || 'vtdd-media-prod' }}
           VTDD_GITHUB_ACTIONS_REPOSITORY: ${{ github.repository }}
           VTDD_KNOWN_GOOD_COMMIT_SHA: ${{ vars.VTDD_KNOWN_GOOD_COMMIT_SHA }}

--- a/docs/memory/vtdd-memory-bridge.md
+++ b/docs/memory/vtdd-memory-bridge.md
@@ -25,7 +25,9 @@ The target operating model is:
 Use environment variables or equivalent command flags:
 
 - `VTDD_MEMORY_D1_DATABASE_NAME`: Cloudflare D1 database name for direct
-  Wrangler operations.
+  Wrangler operations. If this is absent, the CLI also accepts
+  `CLOUDFLARE_D1_DATABASE_NAME` so local repair commands can use the same
+  operator-owned name as GitHub Actions.
 - `VTDD_RUNTIME_URL`: Worker runtime base URL for retrieve operations.
 - `VTDD_GATEWAY_BEARER_TOKEN`: machine-auth token for runtime retrieve/write
   operations.
@@ -36,6 +38,18 @@ Use environment variables or equivalent command flags:
 
 Do not commit runtime URLs, database IDs, bearer tokens, account IDs, or owner
 specific bootstrap values into this repository.
+Direct `wrangler d1 execute` uses a database name or binding, not the
+Cloudflare `database_id` secret. Keep the relationship explicit:
+
+- runtime Worker binding name: `VTDD_MEMORY_D1`
+- GitHub Actions D1 database name variable: `CLOUDFLARE_D1_DATABASE_NAME`
+- GitHub Actions D1 database id secret: `CLOUDFLARE_D1_DATABASE_ID`
+- local direct-D1 name: `VTDD_MEMORY_D1_DATABASE_NAME` or
+  `CLOUDFLARE_D1_DATABASE_NAME`
+
+The database name and id must point at the same operator-owned Cloudflare D1
+database. This repository must not pin the owner's production database name as
+the public default.
 Do not pass bearer tokens as command-line flags; use the environment variable
 so the token is less likely to land in shell history or process logs.
 If neither the environment variable nor the bootstrap vault token path is

--- a/docs/mvp/production-deploy-path.md
+++ b/docs/mvp/production-deploy-path.md
@@ -29,6 +29,10 @@ Set repository or environment secrets:
 - `CLOUDFLARE_D1_DATABASE_ID`
 - `VTDD_GATEWAY_BEARER_TOKEN`
 
+Set repository or environment variables:
+
+- `CLOUDFLARE_D1_DATABASE_NAME`
+
 The token should be scoped to minimum required Worker deploy permissions.
 
 These secrets are hard prerequisites. The workflow must check them before
@@ -63,8 +67,12 @@ before deploying production.
 
 For local/operator deploys, store owner-specific bindings in an ignored file
 such as `wrangler.production.local.toml`. For GitHub Actions deploys, store the
-D1 database id in `CLOUDFLARE_D1_DATABASE_ID`. The media bucket name defaults
-to `vtdd-media-prod` and can be overridden with repository variable
+D1 database id in `CLOUDFLARE_D1_DATABASE_ID` and the matching Cloudflare D1
+database name in repository variable `CLOUDFLARE_D1_DATABASE_NAME`. The runtime
+binding remains `VTDD_MEMORY_D1`; the database name/id are operator-owned deployment settings, not public repo defaults. Direct operator D1 repair
+commands should use the same database name through
+`VTDD_MEMORY_D1_DATABASE_NAME` or `CLOUDFLARE_D1_DATABASE_NAME`.
+The media bucket name defaults to `vtdd-media-prod` and can be overridden with repository variable
 `CLOUDFLARE_MEDIA_R2_BUCKET_NAME`. The workflow generates an uncommitted
 `wrangler.production.generated.toml` at deploy time.
 

--- a/scripts/vtdd-memory.mjs
+++ b/scripts/vtdd-memory.mjs
@@ -511,11 +511,23 @@ function runWranglerD1({ database, command }) {
   };
 }
 
-function resolveDatabase(options) {
-  return normalizeRequiredText(
-    options.database ?? process.env.VTDD_MEMORY_D1_DATABASE_NAME,
-    "database"
-  );
+export function resolveDatabase(options = {}, env = process.env) {
+  const database =
+    normalizeOptionalText(options.database) ||
+    normalizeOptionalText(env.VTDD_MEMORY_D1_DATABASE_NAME) ||
+    normalizeOptionalText(env.CLOUDFLARE_D1_DATABASE_NAME);
+  if (database) {
+    return database;
+  }
+  const databaseId =
+    normalizeOptionalText(env.VTDD_MEMORY_D1_DATABASE_ID) ||
+    normalizeOptionalText(env.CLOUDFLARE_D1_DATABASE_ID);
+  if (databaseId) {
+    throw new Error(
+      "database is required; wrangler d1 execute requires a database name or binding, not database_id. Set VTDD_MEMORY_D1_DATABASE_NAME or CLOUDFLARE_D1_DATABASE_NAME."
+    );
+  }
+  throw new Error("database is required");
 }
 
 function inferTransport(options) {

--- a/test/production-deploy-path.test.js
+++ b/test/production-deploy-path.test.js
@@ -28,6 +28,7 @@ test("production deploy doc defines the governed GitHub Actions deploy path", ()
   assert.equal(doc.includes("`CLOUDFLARE_API_TOKEN`"), true);
   assert.equal(doc.includes("`CLOUDFLARE_ACCOUNT_ID`"), true);
   assert.equal(doc.includes("`CLOUDFLARE_D1_DATABASE_ID`"), true);
+  assert.equal(doc.includes("`CLOUDFLARE_D1_DATABASE_NAME`"), true);
   assert.equal(doc.includes("`VTDD_GATEWAY_BEARER_TOKEN`"), true);
   assert.equal(doc.includes("hard prerequisites"), true);
   assert.equal(doc.includes("docs/setup/cloudflare-deploy-secret-sync.md"), true);
@@ -39,6 +40,8 @@ test("production deploy doc defines the governed GitHub Actions deploy path", ()
   assert.equal(doc.includes("real passkey registration"), true);
   assert.equal(doc.includes("owner-specific Cloudflare"), true);
   assert.equal(doc.includes("must not be committed"), true);
+  assert.equal(doc.includes("the database name/id are operator-owned deployment settings, not public repo defaults"), true);
+  assert.equal(doc.includes("`VTDD_MEMORY_D1_DATABASE_NAME`"), true);
   assert.equal(doc.includes("`wrangler.production.local.toml`"), true);
   assert.equal(doc.includes("`wrangler.production.generated.toml`"), true);
   assert.equal(doc.includes("`VTDD_KNOWN_GOOD_COMMIT_SHA`"), true);
@@ -74,6 +77,7 @@ test("deploy-production workflow enforces the MVP production deploy boundary", (
   assert.equal(workflow.includes("Missing required Actions secret: VTDD_GATEWAY_BEARER_TOKEN"), true);
   assert.equal(workflow.includes("Missing required Actions secret: CLOUDFLARE_API_TOKEN"), true);
   assert.equal(workflow.includes("Missing required Actions secret: CLOUDFLARE_ACCOUNT_ID"), true);
+  assert.equal(workflow.includes("Missing required Actions variable: CLOUDFLARE_D1_DATABASE_NAME"), true);
   assert.equal(workflow.includes("Missing required Actions secret: CLOUDFLARE_D1_DATABASE_ID"), true);
   assert.equal(workflow.includes("Preflight Cloudflare Workers deploy entitlement"), true);
   assert.equal(
@@ -118,6 +122,11 @@ test("deploy-production workflow enforces the MVP production deploy boundary", (
     true
   );
   assert.equal(workflow.includes("Generate production Wrangler config"), true);
+  assert.equal(
+    workflow.includes("CLOUDFLARE_D1_DATABASE_NAME: ${{ vars.CLOUDFLARE_D1_DATABASE_NAME }}"),
+    true
+  );
+  assert.equal(workflow.includes("CLOUDFLARE_D1_DATABASE_NAME || 'vtdd-memory'"), false);
   assert.equal(workflow.includes("VTDD_GITHUB_ACTIONS_REPOSITORY: ${{ github.repository }}"), true);
   assert.equal(workflow.includes("CLOUDFLARE_MEDIA_R2_BUCKET_NAME: ${{ vars.CLOUDFLARE_MEDIA_R2_BUCKET_NAME || 'vtdd-media-prod' }}"), true);
   assert.equal(workflow.includes("VTDD_KNOWN_GOOD_COMMIT_SHA: ${{ vars.VTDD_KNOWN_GOOD_COMMIT_SHA }}"), true);
@@ -162,6 +171,7 @@ test("deploy-production workflow enforces the MVP production deploy boundary", (
   );
   assert.equal(workflow.includes("[[env.production.d1_databases]]"), true);
   assert.equal(workflow.includes('binding = "VTDD_MEMORY_D1"'), true);
+  assert.equal(workflow.includes('database_name = "$CLOUDFLARE_D1_DATABASE_NAME"'), true);
   assert.equal(workflow.includes('database_id = "$CLOUDFLARE_D1_DATABASE_ID"'), true);
   assert.equal(workflow.includes("[[env.production.r2_buckets]]"), true);
   assert.equal(workflow.includes('binding = "VTDD_MEDIA_R2"'), true);

--- a/test/vtdd-memory-cli.test.js
+++ b/test/vtdd-memory-cli.test.js
@@ -15,6 +15,7 @@ import {
   buildRuntimeMemoryWriteRequest,
   buildRuntimeOperationalMemoryRequest,
   parseArgs,
+  resolveDatabase,
   withRuntimeMachineAuth
 } from "../scripts/vtdd-memory.mjs";
 
@@ -46,6 +47,22 @@ test("parseArgs maps record-id CLI option to runtime recordId", () => {
   assert.equal(parsed.command, "retrieve-operational");
   assert.equal(parsed.options.recordId, "working_memory_405_repo_null_example");
   assert.equal(parsed.options.runtimeUrl, "https://example.invalid");
+});
+
+test("resolveDatabase aligns direct D1 name with deploy variable and rejects id-only config", () => {
+  assert.equal(resolveDatabase({ database: "explicit-db" }, {}), "explicit-db");
+  assert.equal(
+    resolveDatabase({}, { VTDD_MEMORY_D1_DATABASE_NAME: "memory-from-operator-env" }),
+    "memory-from-operator-env"
+  );
+  assert.equal(
+    resolveDatabase({}, { CLOUDFLARE_D1_DATABASE_NAME: "memory-from-actions-var" }),
+    "memory-from-actions-var"
+  );
+  assert.throws(
+    () => resolveDatabase({}, { CLOUDFLARE_D1_DATABASE_ID: "00000000-0000-0000-0000-000000000000" }),
+    /wrangler d1 execute requires a database name or binding, not database_id/
+  );
 });
 
 test("buildDecisionRecord creates canonical decision_log memory", () => {


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #503 の D1 memory database name/id/binding の canonical source を揃え、direct D1 操作が古い既定名で失敗する再発を防ぎます。
GitHub Actions deploy config と local operator CLI が同じ operator-owned database name を参照する境界を docs / workflow / tests に固定します。

## Satisfied Success Criteria

- Cloudflare D1 database name/id/runtime binding/GitHub Actions/local operator env の関係を docs に明記した。
Direct D1 操作は explicit --database、VTDD_MEMORY_D1_DATABASE_NAME、CLOUDFLARE_D1_DATABASE_NAME の順で解決し、database_id だけしかない場合は Wrangler の制約を説明して停止する。
Production deploy workflow は CLOUDFLARE_D1_DATABASE_NAME variable を必須 preflight にし、vtdd-memory という public default を使わない。
Runtime binding 名 VTDD_MEMORY_D1 は維持し、wrangler.toml に owner-specific database_id/name を固定しない。
PR / Issue 番号表記ルールの RAG direct write 失敗原因だった name/id 揺れを再発防止できるテストを追加した。

## Unsatisfied Success Criteria

- 実 Cloudflare への direct D1 read/write はこのPRでは実行していない。
GitHub repository variable CLOUDFLARE_D1_DATABASE_NAME の設定変更はこのPRでは実行していない。
Issue #503 close は merge 後、必要な runtime/operator確認と human GO 後。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #503
- Implementing Success Criteria: D1 database name/id/binding/Actions/local relation docs、direct D1 database name resolution、VTDD_MEMORY_D1 binding compatibility、owner-specific boundary、RAG direct write failure prevention.
- Explicit Non-goals: Cloudflare database_id 変更、runtime binding 名変更、deploy、credential/permission mutation、実D1への書き込み。
- Expected touched files/routes/workflows: scripts/vtdd-memory.mjs、docs/memory/vtdd-memory-bridge.md、docs/mvp/production-deploy-path.md、.github/workflows/deploy-production.yml、test/vtdd-memory-cli.test.js、test/production-deploy-path.test.js。
- Affected Issues: Issue #503。関連して RAG / memory bridge 運用。
- Affected PRs: なし。
- Affected workflows: deploy-production workflow の preflight と generated wrangler config。
- Affected runtime/operator surfaces: Mac/VPS operator の vtdd-memory direct D1 repair path。Worker runtime route / Custom GPT Action Schema は未変更。
- What may break if we patch narrowly: CLOUDFLARE_D1_DATABASE_NAME variable が未設定の production deploy は preflight で止まる。これは古い既定名で silently deploy するより明示的な停止を優先したもの。
- Unknowns to investigate before coding: 現在の GitHub variable CLOUDFLARE_D1_DATABASE_NAME が production に設定済みかはこのPRでは変更・確認していない。
- Validation needed: node --test test/vtdd-memory-cli.test.js test/production-deploy-path.test.js、npm test、git diff --check。
- Stop condition: Cloudflare variable/secret mutation、deploy、実D1 write/read を行う場合は別途 scoped approval が必要。

## File / Line Hypotheses

- file: scripts/vtdd-memory.mjs
  - hypothesis: direct D1 CLI が VTDD_MEMORY_D1_DATABASE_NAME だけを見るため、Actions 側の canonical name とズレる。
  - risk if changed narrowly: database_id を positional に使うと Wrangler の仕様と合わず失敗する。
  - validation: resolveDatabase unit test。
  - related Issue: Issue #503
- file: .github/workflows/deploy-production.yml
  - hypothesis: CLOUDFLARE_D1_DATABASE_NAME の vtdd-memory default が owner実DB名とのズレを隠す。
  - risk if changed narrowly: variable 未設定 deploy は止まるが、誤った既定名を使わない。
  - validation: production deploy path test。
  - related Issue: Issue #503

## Hypothesis Retrospective

- expected: database name canonical source を Actions variable/local env に寄せれば direct D1 操作の名前ズレを防げる。
- actual: CLI は CLOUDFLARE_D1_DATABASE_NAME fallback を追加し、id-only config を説明付きで拒否した。workflow は name variable を必須化し、docs に name/id/binding の関係を明記した。
- mismatch: Wrangler d1 execute は database_id 優先にできず、name/binding が必要だった。
- lesson: deploy binding の database_id と direct D1 operator の database name は別物として docs/test に固定する必要がある。
- should become RAG candidate: true

## Verification Evidence

- Unit: node --test test/vtdd-memory-cli.test.js test/production-deploy-path.test.js: pass
- Integration: npm test: pass（978 pass / 1 skip）; check:self-parity pass; check:generated-worker pass; git diff --check pass
- E2E: Direct live D1 read/write は未実施。このPRは config/docs/script guardrail slice。
- Manual: npx wrangler d1 execute --help で positional が database name or binding であり database_id ではないことを確認。
- Evidence path/link: scripts/vtdd-memory.mjs; docs/memory/vtdd-memory-bridge.md; docs/mvp/production-deploy-path.md; .github/workflows/deploy-production.yml; test/vtdd-memory-cli.test.js; test/production-deploy-path.test.js

## Butler Completion Contract

- Owner goal: RAG / memory bridge の direct D1 操作が、古い database name default や name/id 混同で失敗しないこと。
- Butler entrypoint: 未変更。Butler-facing runtime memory retrieve/write path は既存 route のまま。
- Action Schema exposure: 未変更。
- Runtime path: Local/VPS operator CLI direct D1 path: resolveDatabase -> wrangler d1 execute。Production deploy path: GitHub Actions variable/secret -> generated wrangler config -> VTDD_MEMORY_D1 binding。
- Runner/runtime truth: Local tests and workflow/docs assertions verify the canonical source relation. Production variable presence is not mutated by this PR.
- Authority boundary: Deploy、credential mutation、permission mutation、GitHub variable mutation、実D1 write は未実行。
- E2E evidence: 未実施。このPRは Butler chat surface ではなく operator repair path の再発防止。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 未実施。merge 後に deploy する場合は CLOUDFLARE_D1_DATABASE_NAME variable が必要で、deploy自体は scoped passkey approval が必要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 不要。

## Related Constitution Rules

- AGENTS.md Drift Stop Protocol
AGENTS.md Authority Boundary
AGENTS.md Public Repo Collaboration Boundary
AGENTS.md Evidence Discipline

## Out-of-scope but NOT implemented

- Cloudflare database / variable / secret mutation
Production deploy
Actual D1 write/read smoke
Runtime Worker binding rename
Owner-specific database name commit

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #503
- Execution ID: Not provided.
- Goal: issue_503_d1_memory_canonical_source
