### PR TITLE
Issue #503 avoid D1 name variable requirement

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -47,7 +47,6 @@ jobs:
           VTDD_GATEWAY_BEARER_TOKEN: ${{ secrets.VTDD_GATEWAY_BEARER_TOKEN }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          CLOUDFLARE_D1_DATABASE_NAME: ${{ vars.CLOUDFLARE_D1_DATABASE_NAME }}
           CLOUDFLARE_D1_DATABASE_ID: ${{ secrets.CLOUDFLARE_D1_DATABASE_ID }}
         shell: bash
         run: |
@@ -62,10 +61,6 @@ jobs:
           fi
           if [ -z "$CLOUDFLARE_ACCOUNT_ID" ]; then
             echo "Missing required Actions secret: CLOUDFLARE_ACCOUNT_ID"
-            missing=1
-          fi
-          if [ -z "$CLOUDFLARE_D1_DATABASE_NAME" ]; then
-            echo "Missing required Actions variable: CLOUDFLARE_D1_DATABASE_NAME"
             missing=1
           fi
           if [ -z "$CLOUDFLARE_D1_DATABASE_ID" ]; then
@@ -209,7 +204,6 @@ jobs:
       - name: Generate production Wrangler config
         env:
           CLOUDFLARE_D1_DATABASE_ID: ${{ secrets.CLOUDFLARE_D1_DATABASE_ID }}
-          CLOUDFLARE_D1_DATABASE_NAME: ${{ vars.CLOUDFLARE_D1_DATABASE_NAME }}
           CLOUDFLARE_MEDIA_R2_BUCKET_NAME: ${{ vars.CLOUDFLARE_MEDIA_R2_BUCKET_NAME || 'vtdd-media-prod' }}
           VTDD_GITHUB_ACTIONS_REPOSITORY: ${{ github.repository }}
           VTDD_KNOWN_GOOD_COMMIT_SHA: ${{ vars.VTDD_KNOWN_GOOD_COMMIT_SHA }}
@@ -257,7 +251,6 @@ jobs:
 
           [[env.production.d1_databases]]
           binding = "VTDD_MEMORY_D1"
-          database_name = "$CLOUDFLARE_D1_DATABASE_NAME"
           database_id = "$CLOUDFLARE_D1_DATABASE_ID"
 
           [[env.production.r2_buckets]]

--- a/docs/mvp/production-deploy-path.md
+++ b/docs/mvp/production-deploy-path.md
@@ -29,10 +29,6 @@ Set repository or environment secrets:
 - `CLOUDFLARE_D1_DATABASE_ID`
 - `VTDD_GATEWAY_BEARER_TOKEN`
 
-Set repository or environment variables:
-
-- `CLOUDFLARE_D1_DATABASE_NAME`
-
 The token should be scoped to minimum required Worker deploy permissions.
 
 These secrets are hard prerequisites. The workflow must check them before
@@ -67,10 +63,9 @@ before deploying production.
 
 For local/operator deploys, store owner-specific bindings in an ignored file
 such as `wrangler.production.local.toml`. For GitHub Actions deploys, store the
-D1 database id in `CLOUDFLARE_D1_DATABASE_ID` and the matching Cloudflare D1
-database name in repository variable `CLOUDFLARE_D1_DATABASE_NAME`. The runtime
-binding remains `VTDD_MEMORY_D1`; the database name/id are operator-owned deployment settings, not public repo defaults. Direct operator D1 repair
-commands should use the same database name through
+D1 database id in `CLOUDFLARE_D1_DATABASE_ID`. The runtime binding remains
+`VTDD_MEMORY_D1`; the database id is the production deploy source of truth, and
+the owner-specific database name is not required as a GitHub variable. Direct operator D1 repair commands should use the database name through
 `VTDD_MEMORY_D1_DATABASE_NAME` or `CLOUDFLARE_D1_DATABASE_NAME`.
 The media bucket name defaults to `vtdd-media-prod` and can be overridden with repository variable
 `CLOUDFLARE_MEDIA_R2_BUCKET_NAME`. The workflow generates an uncommitted

--- a/test/production-deploy-path.test.js
+++ b/test/production-deploy-path.test.js
@@ -28,7 +28,6 @@ test("production deploy doc defines the governed GitHub Actions deploy path", ()
   assert.equal(doc.includes("`CLOUDFLARE_API_TOKEN`"), true);
   assert.equal(doc.includes("`CLOUDFLARE_ACCOUNT_ID`"), true);
   assert.equal(doc.includes("`CLOUDFLARE_D1_DATABASE_ID`"), true);
-  assert.equal(doc.includes("`CLOUDFLARE_D1_DATABASE_NAME`"), true);
   assert.equal(doc.includes("`VTDD_GATEWAY_BEARER_TOKEN`"), true);
   assert.equal(doc.includes("hard prerequisites"), true);
   assert.equal(doc.includes("docs/setup/cloudflare-deploy-secret-sync.md"), true);
@@ -40,7 +39,8 @@ test("production deploy doc defines the governed GitHub Actions deploy path", ()
   assert.equal(doc.includes("real passkey registration"), true);
   assert.equal(doc.includes("owner-specific Cloudflare"), true);
   assert.equal(doc.includes("must not be committed"), true);
-  assert.equal(doc.includes("the database name/id are operator-owned deployment settings, not public repo defaults"), true);
+  assert.equal(doc.includes("the database id is the production deploy source of truth"), true);
+  assert.equal(doc.includes("not required as a GitHub variable"), true);
   assert.equal(doc.includes("`VTDD_MEMORY_D1_DATABASE_NAME`"), true);
   assert.equal(doc.includes("`wrangler.production.local.toml`"), true);
   assert.equal(doc.includes("`wrangler.production.generated.toml`"), true);
@@ -77,7 +77,7 @@ test("deploy-production workflow enforces the MVP production deploy boundary", (
   assert.equal(workflow.includes("Missing required Actions secret: VTDD_GATEWAY_BEARER_TOKEN"), true);
   assert.equal(workflow.includes("Missing required Actions secret: CLOUDFLARE_API_TOKEN"), true);
   assert.equal(workflow.includes("Missing required Actions secret: CLOUDFLARE_ACCOUNT_ID"), true);
-  assert.equal(workflow.includes("Missing required Actions variable: CLOUDFLARE_D1_DATABASE_NAME"), true);
+  assert.equal(workflow.includes("Missing required Actions variable: CLOUDFLARE_D1_DATABASE_NAME"), false);
   assert.equal(workflow.includes("Missing required Actions secret: CLOUDFLARE_D1_DATABASE_ID"), true);
   assert.equal(workflow.includes("Preflight Cloudflare Workers deploy entitlement"), true);
   assert.equal(
@@ -122,10 +122,7 @@ test("deploy-production workflow enforces the MVP production deploy boundary", (
     true
   );
   assert.equal(workflow.includes("Generate production Wrangler config"), true);
-  assert.equal(
-    workflow.includes("CLOUDFLARE_D1_DATABASE_NAME: ${{ vars.CLOUDFLARE_D1_DATABASE_NAME }}"),
-    true
-  );
+  assert.equal(workflow.includes("CLOUDFLARE_D1_DATABASE_NAME: ${{ vars.CLOUDFLARE_D1_DATABASE_NAME }}"), false);
   assert.equal(workflow.includes("CLOUDFLARE_D1_DATABASE_NAME || 'vtdd-memory'"), false);
   assert.equal(workflow.includes("VTDD_GITHUB_ACTIONS_REPOSITORY: ${{ github.repository }}"), true);
   assert.equal(workflow.includes("CLOUDFLARE_MEDIA_R2_BUCKET_NAME: ${{ vars.CLOUDFLARE_MEDIA_R2_BUCKET_NAME || 'vtdd-media-prod' }}"), true);
@@ -171,7 +168,7 @@ test("deploy-production workflow enforces the MVP production deploy boundary", (
   );
   assert.equal(workflow.includes("[[env.production.d1_databases]]"), true);
   assert.equal(workflow.includes('binding = "VTDD_MEMORY_D1"'), true);
-  assert.equal(workflow.includes('database_name = "$CLOUDFLARE_D1_DATABASE_NAME"'), true);
+  assert.equal(workflow.includes("database_name ="), false);
   assert.equal(workflow.includes('database_id = "$CLOUDFLARE_D1_DATABASE_ID"'), true);
   assert.equal(workflow.includes("[[env.production.r2_buckets]]"), true);
   assert.equal(workflow.includes('binding = "VTDD_MEDIA_R2"'), true);


### PR DESCRIPTION
## This PR satisfies Intent

- PR #569 後に production deploy が CLOUDFLARE_D1_DATABASE_NAME 未設定で停止したため、GitHub variable を増やさず既存 CLOUDFLARE_D1_DATABASE_ID secret だけで deploy できる状態へ戻します。
Direct D1 repair 用の database name 境界は CLI/docs に残し、production deploy の大元の仕組みは変えません。

## Satisfied Success Criteria

- deploy-production workflow から CLOUDFLARE_D1_DATABASE_NAME variable preflight を削除した。
generated wrangler production config は VTDD_MEMORY_D1 binding に database_id だけを出すように戻した。
production deploy docs は database_id が deploy source of truth、database name は direct operator D1 repair 用と分けて明記した。
CLOUDFLARE_D1_DATABASE_NAME GitHub variable を新設しなくても deploy が preflight で止まらないことをテストで固定した。

## Unsatisfied Success Criteria

- PR #569 の失敗 run 再実行と production deploy はこのPRでは未実施。
Issue #503 close は merge/deploy確認後に human GO が必要。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #503
- Implementing Success Criteria: GitHub variable 追加なしで production deploy が既存 D1 database_id secret を使う。Direct D1 repair の database name boundary は維持する。
- Explicit Non-goals: GitHub secret/variable mutation、Cloudflare mutation、deploy実行、runtime binding rename、大元の deploy/passkey authority 変更。
- Expected touched files/routes/workflows: .github/workflows/deploy-production.yml、docs/mvp/production-deploy-path.md、test/production-deploy-path.test.js。
- Affected Issues: Issue #503。
- Affected PRs: PR #569 follow-up。
- Affected workflows: deploy-production workflow の D1 binding config generation。
- Affected runtime/operator surfaces: Production deploy workflow only。Worker runtime / Custom GPT Action Schema / Butler chat surface は未変更。
- What may break if we patch narrowly: database_name を generated wrangler config から外すため、Cloudflare wrangler-action が database_id-only binding を受け付ける前提に戻す。これは #569 前から既存テストで固定されていた deploy path。
- Unknowns to investigate before coding: このPR merge 後の actual deploy run はまだ未実施。
- Validation needed: node --test test/production-deploy-path.test.js test/vtdd-memory-cli.test.js、git diff --check、PR checks。
- Stop condition: GitHub variable/secret mutation や deploy 再実行は scoped approval/GO boundary へ戻す。

## File / Line Hypotheses

- file: .github/workflows/deploy-production.yml
  - hypothesis: CLOUDFLARE_D1_DATABASE_NAME variable 必須化が deploy failure の直接原因。
  - risk if changed narrowly: direct D1 repair と production deploy の source を混同し直す可能性。
  - validation: workflow text test と failed run log。
  - related Issue: Issue #503
- file: docs/mvp/production-deploy-path.md
  - hypothesis: docs は deploy source of truth と direct repair source of truth を分けて書けば GitHub variable 追加を避けられる。
  - risk if changed narrowly: operator が direct D1 repair に database_id を使おうとして失敗する可能性。
  - validation: production deploy path test と vtdd-memory CLI test。
  - related Issue: Issue #503

## Hypothesis Retrospective

- expected: deploy failure は code bug ではなく GitHub variable requirement の過剰追加だった。
- actual: run 26444993319 は Missing required Actions variable: CLOUDFLARE_D1_DATABASE_NAME で停止。variable 必須化を撤回し、database_id-only deploy path に戻した。
- mismatch: #503 の再発防止を GitHub variable 増加で解決するのは owner preference と運用負荷に合わなかった。
- lesson: direct D1 repair と production deploy は source truth を分ける。
- should become RAG candidate: true

## Verification Evidence

- Unit: node --test test/production-deploy-path.test.js test/vtdd-memory-cli.test.js: pass
- Integration: git diff --check: pass
- E2E: 未実施。merge 後に deploy run で確認する。
- Manual: Failed deploy run 26444993319 log confirmed CLOUDFLARE_D1_DATABASE_NAME missing variable as the stop reason.
- Evidence path/link: .github/workflows/deploy-production.yml; docs/mvp/production-deploy-path.md; test/production-deploy-path.test.js; run 26444993319

## Butler Completion Contract

- Owner goal: GitHub secrets/variables を増やさず、#503 の D1 name/id 混同対策を維持しながら production deploy failure を解消する。
- Butler entrypoint: 未変更。
- Action Schema exposure: 未変更。
- Runtime path: GitHub Actions deploy-production -> generated wrangler config -> VTDD_MEMORY_D1 binding by CLOUDFLARE_D1_DATABASE_ID。
- Runner/runtime truth: Failed run log and tests verify the change. Production deploy rerun is post-merge.
- Authority boundary: GitHub variable mutation / deploy / credential mutation は未実行。
- E2E evidence: 未実施。このPRは deploy workflow guardrail fix。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 未実施。merge 後に scoped deploy approval/GO が必要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 不要。

## Related Constitution Rules

- AGENTS.md Drift Stop Protocol
AGENTS.md Authority Boundary
AGENTS.md Evidence Discipline

## Out-of-scope but NOT implemented

- GitHub variable creation
Cloudflare resource mutation
Production deploy rerun
Direct D1 write smoke
Runtime binding rename

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #503
- Execution ID: Not provided.
- Goal: issue_503_avoid_d1_name_variable_requirement
