### PR TITLE
Issue #514 make deploy notifications owner-facing

### DIFF
--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -7258,7 +7258,8 @@ function buildDashboardWebPushTitle(record) {
     const isDeploy = normalize(record.workflowName).includes("deploy");
     const label = dashboardPushStatusLabel(record);
     if (isDeploy) {
-      return `デプロイ${label}${repository ? `: ${repository}` : ""}`.slice(0, 80);
+      const subject = buildDashboardEventSubject(record, { limit: 58 });
+      return `デプロイ${label}: ${subject || repository || "repository"}`.slice(0, 80);
     }
     const workflow = compactNotificationText(record.workflowName || "workflow", 24);
     return `Actions ${label}: ${workflow}${repository ? ` / ${repository}` : ""}`.slice(0, 80);
@@ -8335,6 +8336,15 @@ function inferPullNumberFromText(value) {
     return null;
   }
   const explicit = text.match(/\b(?:PR|pull request)\s*#?(\d+)\b/i);
+  return explicit ? normalizeIssue(explicit[1]) : null;
+}
+
+function inferIssueNumberFromText(value) {
+  const text = normalizeDashboardEventText(value);
+  if (!text) {
+    return null;
+  }
+  const explicit = text.match(/\bIssue\s*#?(\d+)\b/i);
   return explicit ? normalizeIssue(explicit[1]) : null;
 }
 
@@ -9648,21 +9658,41 @@ function renderDashboardNotificationEvent(event) {
 function buildDashboardEventDisplayTitle(event, { workflowName, conclusion } = {}) {
   const record = normalizeDashboardEventRecord(event);
   const statusLabel = dashboardPushStatusLabel(record);
-  const summary = normalizeDashboardEventText(record.changeSummary || record.title);
   const isDeploy = record.kind === "github_actions_workflow_run" && normalize(workflowName || record.workflowName).includes("deploy");
-  const baseSummary = summary && summary !== record.workflowName ? summary : "";
+  const baseSummary = buildDashboardEventSubject(record, { limit: 96 });
   const pullPrefix = record.pullNumber ? `PR #${record.pullNumber}` : "";
   if (isDeploy) {
-    const subject = [pullPrefix, baseSummary].filter(Boolean).join(" ");
-    return subject ? `デプロイ${statusLabel}: ${subject}` : `デプロイ${statusLabel}: ${record.repository || "repository"} ${record.headSha ? record.headSha.slice(0, 7) : ""}`.trim();
+    return baseSummary ? `デプロイ${statusLabel}: ${baseSummary}` : `デプロイ${statusLabel}: ${record.repository || "repository"} ${record.headSha ? record.headSha.slice(0, 7) : ""}`.trim();
   }
   if (pullPrefix && baseSummary) {
-    return `${pullPrefix}: ${baseSummary}`;
+    return baseSummary.startsWith(pullPrefix) ? baseSummary : `${pullPrefix}: ${baseSummary}`;
   }
   if (pullPrefix) {
     return `${workflowName || record.workflowName || "Actions"} ${dashboardPushStatusLabel(record)}: ${pullPrefix}`;
   }
   return baseSummary || workflowName || record.kind || conclusion || "dashboard event";
+}
+
+function buildDashboardEventSubject(event, { limit = 80 } = {}) {
+  const record = normalizeDashboardEventRecord(event);
+  const rawSummary = normalizeDashboardEventText(record.changeSummary || record.title);
+  const summary = rawSummary && rawSummary !== record.workflowName ? rawSummary : "";
+  const pullPrefix = record.pullNumber ? `PR #${record.pullNumber}` : "";
+  const issueNumber = record.issueNumber || inferIssueNumberFromText(summary);
+  const issuePrefix = issueNumber ? `Issue #${issueNumber}` : "";
+  const withoutDuplicatedPull = pullPrefix
+    ? summary.replace(new RegExp(`\\bPR\\s*#?${record.pullNumber}\\b\\s*[:：-]?\\s*`, "i"), "").trim()
+    : summary;
+  const withoutDuplicatedIssue = issueNumber
+    ? withoutDuplicatedPull
+        .replace(new RegExp(`\\bIssue\\s*#?${issueNumber}\\b\\s*[:：-]?\\s*`, "i"), "")
+        .replace(new RegExp(`#${issueNumber}\\b\\s*[:：-]?\\s*`, "i"), "")
+        .trim()
+    : withoutDuplicatedPull;
+  return compactNotificationText(
+    [pullPrefix, issuePrefix, withoutDuplicatedIssue].filter(Boolean).join(" "),
+    limit
+  );
 }
 
 function formatDashboardRelativeTime(value, now = new Date()) {

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -3186,6 +3186,7 @@ test("worker serves dashboard notification center for recent events across repos
   assert.equal(body.includes("scope: \"/dashboard/\""), true);
   assert.equal(body.includes("secret-must-not-persist"), false);
   assert.equal(body.includes("他 repo / 並行開発 / queue / workflow"), true);
+  assert.equal(body.includes("deploy-production / run 26134526815 / sha daad4fb"), true);
   assert.equal(body.includes("最新通知"), true);
   assert.equal(body.includes("success"), true);
   assert.equal(body.includes("デプロイ完了: PR #552 dashboard: 通知設定を折り畳む (#534)"), true);
@@ -3408,14 +3409,18 @@ test("worker builds distinct dashboard Web Push copy by event type", () => {
     conclusion: "success",
     headSha: "0a9e0b8587aa684de3dbd08b57909fe271192662",
     headBranch: "main",
-    title: "deploy-production",
+    title: "Issue #514 owner-facing deploy notification title",
+    changeSummary: "Issue #514 owner-facing deploy notification title",
+    pullNumber: 571,
     runUrl: "https://github.com/marushu/vtdd-v2-p/actions/runs/26323724369"
   });
-  assert.equal(deploySuccess.title, "デプロイ完了: vtdd-v2-p");
+  assert.equal(deploySuccess.title, "デプロイ完了: PR #571 Issue #514 owner-facing deploy notification title");
   assert.equal(deploySuccess.body.includes("workflow: deploy-production"), true);
   assert.equal(deploySuccess.body.includes("branch: main"), true);
   assert.equal(deploySuccess.body.includes("sha: 0a9e0b8"), true);
   assert.equal(deploySuccess.body.includes("run: 26323724369"), true);
+  assert.equal(deploySuccess.body.includes("PR #571"), true);
+  assert.equal(deploySuccess.body.includes("Issue #514"), true);
 
   const deployFailure = buildDashboardWebPushPayload({
     kind: "github_actions_workflow_run",
@@ -3629,7 +3634,7 @@ test("worker ingests GitHub Actions deploy completion event and shows it on dash
   assert.match(pushCalls[0].init.headers.authorization, /^vapid t=.+, k=.+/);
   assert.equal(pushCalls[0].init.headers["content-encoding"], "aes128gcm");
   const decryptedPush = JSON.parse(await decryptTestWebPushPayload(pushCalls[0].init.body, pushKeys));
-  assert.equal(decryptedPush.title, "デプロイ完了: vtdd-v2-p");
+  assert.equal(decryptedPush.title, "デプロイ完了: PR #552 dashboard: 通知カードにPR概要を出す (#534)");
   assert.equal(decryptedPush.body.includes("dashboard: 通知カードにPR概要を出す"), true);
   assert.equal(decryptedPush.body.includes("PR #552"), true);
   assert.equal(decryptedPush.body.includes("workflow: deploy-production"), true);
@@ -3650,6 +3655,7 @@ test("worker ingests GitHub Actions deploy completion event and shows it on dash
   assert.equal(dashboardBody.includes("最新 deploy"), true);
   assert.equal(dashboardBody.includes("success"), true);
   assert.equal(dashboardBody.includes("ef55709"), true);
+  assert.equal(dashboardBody.includes("デプロイ完了: PR #552 dashboard: 通知カードにPR概要を出す (#534)"), true);
   assert.equal(dashboardBody.includes("dashboard: 通知カードにPR概要を出す"), true);
   assert.equal(dashboardBody.includes("PR #552"), true);
   assert.equal(

--- a/worker.js
+++ b/worker.js
@@ -62478,7 +62478,8 @@ function buildDashboardWebPushTitle(record2) {
     const isDeploy = normalize7(record2.workflowName).includes("deploy");
     const label = dashboardPushStatusLabel(record2);
     if (isDeploy) {
-      return `\u30C7\u30D7\u30ED\u30A4${label}${repository ? `: ${repository}` : ""}`.slice(0, 80);
+      const subject = buildDashboardEventSubject(record2, { limit: 58 });
+      return `\u30C7\u30D7\u30ED\u30A4${label}: ${subject || repository || "repository"}`.slice(0, 80);
     }
     const workflow = compactNotificationText(record2.workflowName || "workflow", 24);
     return `Actions ${label}: ${workflow}${repository ? ` / ${repository}` : ""}`.slice(0, 80);
@@ -63436,6 +63437,14 @@ function inferPullNumberFromText(value) {
     return null;
   }
   const explicit = text.match(/\b(?:PR|pull request)\s*#?(\d+)\b/i);
+  return explicit ? normalizeIssue6(explicit[1]) : null;
+}
+function inferIssueNumberFromText(value) {
+  const text = normalizeDashboardEventText(value);
+  if (!text) {
+    return null;
+  }
+  const explicit = text.match(/\bIssue\s*#?(\d+)\b/i);
   return explicit ? normalizeIssue6(explicit[1]) : null;
 }
 function createD1MemoryIndexAdapter(d1) {
@@ -64611,21 +64620,33 @@ function renderDashboardNotificationEvent(event) {
 function buildDashboardEventDisplayTitle(event, { workflowName, conclusion } = {}) {
   const record2 = normalizeDashboardEventRecord(event);
   const statusLabel = dashboardPushStatusLabel(record2);
-  const summary = normalizeDashboardEventText(record2.changeSummary || record2.title);
   const isDeploy = record2.kind === "github_actions_workflow_run" && normalize7(workflowName || record2.workflowName).includes("deploy");
-  const baseSummary = summary && summary !== record2.workflowName ? summary : "";
+  const baseSummary = buildDashboardEventSubject(record2, { limit: 96 });
   const pullPrefix = record2.pullNumber ? `PR #${record2.pullNumber}` : "";
   if (isDeploy) {
-    const subject = [pullPrefix, baseSummary].filter(Boolean).join(" ");
-    return subject ? `\u30C7\u30D7\u30ED\u30A4${statusLabel}: ${subject}` : `\u30C7\u30D7\u30ED\u30A4${statusLabel}: ${record2.repository || "repository"} ${record2.headSha ? record2.headSha.slice(0, 7) : ""}`.trim();
+    return baseSummary ? `\u30C7\u30D7\u30ED\u30A4${statusLabel}: ${baseSummary}` : `\u30C7\u30D7\u30ED\u30A4${statusLabel}: ${record2.repository || "repository"} ${record2.headSha ? record2.headSha.slice(0, 7) : ""}`.trim();
   }
   if (pullPrefix && baseSummary) {
-    return `${pullPrefix}: ${baseSummary}`;
+    return baseSummary.startsWith(pullPrefix) ? baseSummary : `${pullPrefix}: ${baseSummary}`;
   }
   if (pullPrefix) {
     return `${workflowName || record2.workflowName || "Actions"} ${dashboardPushStatusLabel(record2)}: ${pullPrefix}`;
   }
   return baseSummary || workflowName || record2.kind || conclusion || "dashboard event";
+}
+function buildDashboardEventSubject(event, { limit = 80 } = {}) {
+  const record2 = normalizeDashboardEventRecord(event);
+  const rawSummary = normalizeDashboardEventText(record2.changeSummary || record2.title);
+  const summary = rawSummary && rawSummary !== record2.workflowName ? rawSummary : "";
+  const pullPrefix = record2.pullNumber ? `PR #${record2.pullNumber}` : "";
+  const issueNumber = record2.issueNumber || inferIssueNumberFromText(summary);
+  const issuePrefix = issueNumber ? `Issue #${issueNumber}` : "";
+  const withoutDuplicatedPull = pullPrefix ? summary.replace(new RegExp(`\\bPR\\s*#?${record2.pullNumber}\\b\\s*[:\uFF1A-]?\\s*`, "i"), "").trim() : summary;
+  const withoutDuplicatedIssue = issueNumber ? withoutDuplicatedPull.replace(new RegExp(`\\bIssue\\s*#?${issueNumber}\\b\\s*[:\uFF1A-]?\\s*`, "i"), "").replace(new RegExp(`#${issueNumber}\\b\\s*[:\uFF1A-]?\\s*`, "i"), "").trim() : withoutDuplicatedPull;
+  return compactNotificationText(
+    [pullPrefix, issuePrefix, withoutDuplicatedIssue].filter(Boolean).join(" "),
+    limit
+  );
 }
 function formatDashboardRelativeTime(value, now = /* @__PURE__ */ new Date()) {
   const timestamp = new Date(normalizeText30(value));


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #514 の追加 gap に対し、deploy 完了/失敗通知の主語を workflow 名ではなく PR/Issue/変更名へ寄せる。owner が通知カードや iOS Web Push title だけで何が反映されたか判断できるようにする。

## Satisfied Success Criteria

- deploy Web Push title は PR番号と変更名を含む owner-facing title になる。
Dashboard 通知センターと最新 deploy 表示の primary line は PR番号と変更名を先頭に出す。
workflow/run/sha は本文・meta の詳細行に残る。
Issue #514 の通知タイトル gap を regression test で固定した。

## Unsatisfied Success Criteria

- iPhone/PWA 実機 Web Push の live screenshot は未実施。
Issue #514 全体の Web Push 状態可視化・購読保存・最後の送信結果は既存実装の範囲で、このPRでは追加変更していない。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #514
- Implementing Success Criteria: deploy 完了/失敗通知の title または primary line に PR番号またはIssue番号と人間が分かる変更名を含める。workflow 名、run id、sha は主タイトルではなく詳細行に下げる。
- Explicit Non-goals: VAPID/購読/credential/deploy workflow authority の変更、通知センター全体の再設計、production deploy 実行、Issue #444/#514 全体完了の主張。
- Expected touched files/routes/workflows: src/worker/runtime.js、test/worker.test.js
- Affected Issues: Issue #514
- Affected PRs: なし
- Affected workflows: なし。deploy-production workflow の event payload 送信自体は既存のまま。
- Affected runtime/operator surfaces: Dashboard 通知センター、Dashboard 最新deploy、server-side Web Push payload title/body
- What may break if we patch narrowly: イベント payload に changeSummary/pullNumber がない場合は従来通り repository/sha fallback になる。GitHub API から associated PR を取れない deploy では完全な変更名は出ない。
- Unknowns to investigate before coding: production iPhone/PWA の実通知 title は未確認。
- Validation needed: node --test test/worker.test.js、git diff --check、PR checks。
- Stop condition: Web Push credential、GitHub secret/variable、deploy workflow authority、通知購読保存方式へ変更が必要になったら別Issue/別PRへ止める。

## File / Line Hypotheses

- file: src/worker/runtime.js
  - hypothesis: buildDashboardWebPushTitle と buildDashboardEventDisplayTitle が owner-facing subject を title へ上げれば、通知カードの主語不足は小さく解消できる。
  - risk if changed narrowly: changeSummary がない deploy は fallback のままになる。
  - validation: worker notification tests。
  - related Issue: Issue #514
- file: test/worker.test.js
  - hypothesis: Web Push title、notification center、latest deploy の表示期待を固定すれば regression を防げる。
  - risk if changed narrowly: live iOS notification title は deploy 後まで未確認。
  - validation: node --test test/worker.test.js。
  - related Issue: Issue #514

## Hypothesis Retrospective

- expected: deploy event には既に changeSummary/pullNumber が入り、表示 title 生成だけが弱い。
- actual: runtime は changeSummary/pullNumber を保持しており、title builder を owner-facing subject に寄せるだけでテスト上の primary line は改善した。
- mismatch: iPhone live Web Push title は未確認。
- lesson: workflow 名は詳細、PR/Issue/変更名は主タイトル。
- should become RAG candidate: true

## Verification Evidence

- Unit: node --test test/worker.test.js: pass (205 tests)
- Integration: git diff --check: pass
- E2E: 未実施。PR merge/deploy 後に iPhone/PWA 通知または通知センター live で確認する。
- Manual: なし
- Evidence path/link: src/worker/runtime.js; test/worker.test.js

## Butler Completion Contract

- Owner goal: 通知を見ただけで、どのPR/Issue/変更が反映されたのか分かるようにする。
- Butler entrypoint: Dashboard 通知センターと iOS/PWA Web Push 通知。
- Action Schema exposure: 未変更。
- Runtime path: GitHub Actions deploy event -> /v2/events/github-actions -> dashboard event store -> notification center / Web Push payload。
- Runner/runtime truth: worker tests verify owner-facing title generation and metadata placement。
- Authority boundary: 未変更。credential/deploy/permission mutation はしていない。
- E2E evidence: 未実施。live deploy/Web Push evidence は post-merge。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 未実施。merge 後に必要なら scoped passkey approval。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。

## Related Constitution Rules

- AGENTS.md Drift Stop Protocol
AGENTS.md Evidence Discipline
AGENTS.md Chief Butler Operating Principle
AGENTS.md Conversation UX Contract

## Out-of-scope but NOT implemented

- VAPID/購読保存/通知音/バッジの変更
Production deploy 実行
GitHub secret/variable mutation
Issue #514 全体 close

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #514
- Execution ID: Not provided.
- Goal: issue_514_owner_facing_deploy_notification_title
