### PR TITLE
Issue #528 remove dashboard passkey topbar

### DIFF
--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -10595,10 +10595,6 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
       href: `${origin}/dashboard/notifications`
     },
     {
-      label: "Passkey",
-      href: dashboardSignInUrl
-    },
-    {
       label: "進捗を見る",
       href: repositoryInput ? `${origin}/dashboard/progress?repository=${encodedRepository}` : "",
       disabledReason: "repo 設定後"
@@ -10819,7 +10815,6 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         </div>
         <div class="top-right">
           <a class="tool-button top-action" href="${escapeDashboardHtml(origin)}/dashboard/notifications" aria-label="通知センター">通知</a>
-          <a class="tool-button top-action" href="${escapeDashboardHtml(dashboardSignInUrl)}" aria-label="Passkey で dashboard session を更新">Passkey</a>
         </div>
       </header>
 

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -10670,7 +10670,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
     * { box-sizing: border-box; }
     html, body { max-width: 100%; height: 100%; overflow: hidden; }
     body { margin: 0; background: var(--page-bg); }
-    main { width: 100%; height: 100dvh; min-height: 0; display: grid; grid-template-columns: minmax(0, 1fr) minmax(220px, 320px); gap: 18px; padding: 16px; overflow: hidden; }
+    main { width: 100%; height: 100dvh; min-height: 0; display: block; padding: 16px; overflow: hidden; }
     h1, h2, h3, p { margin-top: 0; }
     h1 { font-size: 22px; line-height: 1.1; margin-bottom: 4px; }
     h2 { font-size: 19px; margin-bottom: 12px; }
@@ -10741,11 +10741,6 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
     .composer-status:empty { min-height: 0; padding-left: 0; }
     .composer-status a { color: var(--text); font-weight: 800; text-underline-offset: 3px; }
     .composer-status.thinking::after { content: ""; display: inline-block; width: 1.4em; text-align: left; animation: thinkingDots 1.2s steps(4, end) infinite; }
-    .sidebar { position: sticky; top: 16px; align-self: start; max-height: calc(100dvh - 32px); overflow: auto; border: 1px solid var(--border); border-radius: 18px; background: var(--panel); }
-    .sidebar > summary { display: flex; justify-content: space-between; align-items: center; gap: 10px; min-height: 58px; padding: 14px; list-style: none; }
-    .sidebar > summary::-webkit-details-marker { display: none; }
-    .sidebar-content { display: grid; gap: 12px; padding: 0 14px 14px; }
-    .sidebar-header { display: flex; justify-content: space-between; align-items: center; gap: 10px; }
     .eyebrow { color: var(--muted); font-size: 11px; font-weight: 850; letter-spacing: .1em; text-transform: uppercase; }
     .lane, details { border: 1px solid var(--border); border-radius: 14px; padding: 12px; background: var(--panel-strong); }
     .lane-title { display: flex; justify-content: space-between; gap: 8px; align-items: baseline; }
@@ -10770,21 +10765,20 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
     code { color: var(--text); overflow-wrap: anywhere; }
     .menu-toggle { position: fixed; width: 1px; height: 1px; opacity: 0; pointer-events: none; }
     .mobile-backdrop, .mobile-drawer { display: none; }
+    .mobile-backdrop { position: fixed; inset: 0; z-index: 10; background: rgba(0, 0, 0, .38); backdrop-filter: blur(2px); }
+    .mobile-drawer { position: fixed; top: 0; bottom: 0; left: 0; z-index: 11; width: min(86vw, 380px); overflow: auto; padding: max(16px, env(safe-area-inset-top)) 14px max(18px, env(safe-area-inset-bottom)); border-right: 1px solid var(--border); background: var(--panel); box-shadow: 18px 0 60px var(--shadow); }
+    .menu-toggle:checked ~ .mobile-backdrop, .menu-toggle:checked ~ .mobile-drawer { display: block; }
+    .mobile-drawer-header { display: flex; justify-content: space-between; align-items: center; gap: 12px; margin-bottom: 14px; }
+    .mobile-drawer-content { display: grid; gap: 12px; }
     .menu-callout { color: var(--muted); font-size: 12px; line-height: 1.55; }
     @media (min-width: 1180px) {
       .chat-scroll { align-items: center; }
       .bubble.owner { margin-right: calc((100% - 760px) / 2); }
     }
     @media (max-width: 900px) {
-      main { display: block; padding: 14px 14px 0; }
+      main { padding: 14px 14px 0; }
       .app-shell { height: calc(100dvh - 14px); }
       .topbar { display: grid; grid-template-columns: minmax(0, 1fr) auto; align-items: center; }
-      .sidebar { display: none; }
-      .mobile-backdrop { position: fixed; inset: 0; z-index: 10; background: rgba(0, 0, 0, .38); backdrop-filter: blur(2px); }
-      .mobile-drawer { position: fixed; top: 0; bottom: 0; left: 0; z-index: 11; width: min(86vw, 360px); overflow: auto; padding: max(16px, env(safe-area-inset-top)) 14px max(18px, env(safe-area-inset-bottom)); border-right: 1px solid var(--border); background: var(--panel); box-shadow: 18px 0 60px var(--shadow); }
-      .menu-toggle:checked ~ .mobile-backdrop, .menu-toggle:checked ~ .mobile-drawer { display: block; }
-      .mobile-drawer-header { display: flex; justify-content: space-between; align-items: center; gap: 12px; margin-bottom: 14px; }
-      .mobile-drawer-content { display: grid; gap: 12px; }
       .chat-scroll { padding-bottom: 28px; }
       .bubble { max-width: 100%; font-size: 16px; }
       .bubble.owner { max-width: 82%; }
@@ -10834,12 +10828,16 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
             ${targetStatusMarkup}
           </div>
           <div class="lane">
+            <div class="lane-title"><h3>Issue 候補</h3><span class="pill">draft</span></div>
+            <p>Issue / PR 操作が必要になった時だけ、会話の中で対象と範囲を確認します。</p>
+          </div>
+          <div class="lane">
             <div class="lane-title"><h3>進行中</h3><span class="pill">状態</span></div>
             <p>直近の反映、失敗、進行中の作業があればここに出します。</p>
             ${renderDashboardDeployEvent(latestDeployEvent)}
-          </div>
-          <div class="quick-actions">
-            ${renderDashboardActionList(cockpitActions)}
+            <div class="quick-actions">
+              ${renderDashboardActionList(cockpitActions)}
+            </div>
           </div>
           <details data-debug-section="dashboard-development-operations">
             <summary>開発/運用</summary>
@@ -10847,11 +10845,15 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
               ${renderDashboardSurfaceList(surfaces)}
             </div>
           </details>
-          <details>
+          <details data-debug-section="dashboard-workflows">
             <summary>GitHub workflows</summary>
             <div class="surface-list">
               ${workflows.map(([title, href]) => `<a href="${escapeDashboardHtml(href)}">${escapeDashboardHtml(title)}</a>`).join("")}
             </div>
+          </details>
+          <details data-debug-section="dashboard-prototype-cleanup">
+            <summary>Prototype cleanup</summary>
+            <p>v3 Worker prototype の削除や移行は destructive operation 扱いです。必要になった時だけ、対象 runtime と scope を明示した passkey approval で扱います。</p>
           </details>
         </div>
       </aside>
@@ -10891,57 +10893,6 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         <div class="composer-status" id="butler-chat-status">接続準備中です。送信できる状態になったら知らせます。</div>
       </form>
     </section>
-
-    <details id="tools" class="sidebar" aria-label="管理サイドバーメニュー">
-      <summary>
-        <span>
-          <span class="eyebrow">メニュー</span>
-          <strong>必要な時だけ開く</strong>
-        </span>
-        <span class="pill">WebSocket</span>
-      </summary>
-      <div class="sidebar-content">
-        <p class="menu-callout">通知、進捗、対象 repo の確認を優先します。開発/運用の詳細は下に隔離しています。</p>
-
-        <div class="lane">
-          <div class="lane-title"><h3>対象 repo</h3><span class="pill">${repositoryInput ? "resolved" : "未指定"}</span></div>
-          ${targetStatusMarkup}
-        </div>
-
-        <div class="lane">
-          <div class="lane-title"><h3>Issue 候補</h3><span class="pill">draft</span></div>
-          <p>Issue / PR 操作が必要になった時だけ、会話の中で対象と範囲を確認します。</p>
-        </div>
-
-        <div class="lane">
-          <div class="lane-title"><h3>進行中</h3><span class="pill">状態</span></div>
-          <p>直近の反映、失敗、進行中の作業があればここに出します。</p>
-          ${renderDashboardDeployEvent(latestDeployEvent)}
-          <div class="quick-actions">
-            ${renderDashboardActionList(cockpitActions)}
-          </div>
-        </div>
-
-        <details data-debug-section="dashboard-development-operations">
-          <summary>開発/運用</summary>
-          <div class="surface-list">
-            ${renderDashboardSurfaceList(surfaces)}
-          </div>
-        </details>
-
-        <details data-debug-section="dashboard-workflows">
-          <summary>GitHub workflows</summary>
-          <div class="surface-list">
-            ${workflows.map(([title, href]) => `<a href="${escapeDashboardHtml(href)}">${escapeDashboardHtml(title)}</a>`).join("")}
-          </div>
-        </details>
-
-        <details data-debug-section="dashboard-prototype-cleanup">
-          <summary>Prototype cleanup</summary>
-          <p>v3 Worker prototype の削除や移行は destructive operation 扱いです。必要になった時だけ、対象 runtime と scope を明示した passkey approval で扱います。</p>
-        </details>
-      </div>
-    </details>
   </main>
   <script>
     (() => {

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -1087,6 +1087,10 @@ test("worker serves v2 dashboard for allowed owner identity without exposing sec
   assert.equal(body.includes("--owner-link: #075985;"), true);
   assert.equal(body.includes("overflow: hidden"), true);
   assert.equal(body.includes("grid-template-columns: minmax(0, 1fr) auto"), true);
+  assert.equal(body.includes("minmax(220px, 320px)"), false);
+  assert.equal(body.includes('id="tools" class="sidebar"'), false);
+  assert.equal(body.includes(".mobile-drawer { position: fixed;"), true);
+  assert.equal(body.includes(".menu-toggle:checked ~ .mobile-backdrop, .menu-toggle:checked ~ .mobile-drawer { display: block; }"), true);
   assert.equal(body.includes(".composer-status:empty"), true);
   assert.equal(body.includes("WebSocket"), true);
   assert.equal(body.includes("接続準備中: 送信できる状態になったらここで知らせます"), false);

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -1107,12 +1107,12 @@ test("worker serves v2 dashboard for allowed owner identity without exposing sec
   assert.equal(body.includes('aria-label="Deploy operator">Deploy</a>'), false);
   assert.equal(body.includes('aria-label="通知センター">通知</a>'), true);
   assert.equal(body.includes('aria-label="進捗を見る">進捗</a>'), false);
-  assert.equal(body.includes('aria-label="Passkey で dashboard session を更新">Passkey</a>'), true);
+  assert.equal(body.includes('aria-label="Passkey で dashboard session を更新">Passkey</a>'), false);
   assert.equal(
     body.includes(
       '/v2/approval/passkey/operator?mode=dashboard&amp;phase=execution&amp;actionType=read&amp;highRiskKind=dashboard_access&amp;dashboardReturnPath=%2Fdashboard"'
     ),
-    true
+    false
   );
   assert.equal(body.includes("mode=dashboard&amp;repositoryInput="), false);
   assert.equal(body.includes('aria-label="Passkey">◇</a>'), false);
@@ -1275,6 +1275,7 @@ test("worker serves v2 dashboard for allowed owner identity without exposing sec
   assert.equal(body.includes("Butler V2 にメッセージ"), true);
   assert.equal(body.includes("GitHub状況"), true);
   assert.equal(body.includes(">通知</a>"), true);
+  assert.equal(body.includes(">Passkey</a>"), false);
   assert.equal(body.includes("/dashboard/github?repository=marushu%2Fvtdd-v2-p"), false);
   assert.equal(body.includes("/dashboard/notifications"), true);
   assert.equal(body.includes(">通知センター</a>"), true);
@@ -3058,7 +3059,7 @@ test("worker serves dashboard chat-first shell with debug and ops surfaces isola
     body.includes(
       '/v2/approval/passkey/operator?mode=dashboard&amp;phase=execution&amp;actionType=read&amp;highRiskKind=dashboard_access&amp;dashboardReturnPath=%2Fdashboard%3Frepository%3Dsample-org%252Fvtdd-v2-p'
     ),
-    true
+    false
   );
   const initialChat = body.slice(
     body.indexOf('<div class="chat-scroll"'),

--- a/worker.js
+++ b/worker.js
@@ -65484,10 +65484,6 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
       href: `${origin}/dashboard/notifications`
     },
     {
-      label: "Passkey",
-      href: dashboardSignInUrl
-    },
-    {
       label: "\u9032\u6357\u3092\u898B\u308B",
       href: repositoryInput ? `${origin}/dashboard/progress?repository=${encodedRepository}` : "",
       disabledReason: "repo \u8A2D\u5B9A\u5F8C"
@@ -65697,7 +65693,6 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         </div>
         <div class="top-right">
           <a class="tool-button top-action" href="${escapeDashboardHtml(origin)}/dashboard/notifications" aria-label="\u901A\u77E5\u30BB\u30F3\u30BF\u30FC">\u901A\u77E5</a>
-          <a class="tool-button top-action" href="${escapeDashboardHtml(dashboardSignInUrl)}" aria-label="Passkey \u3067 dashboard session \u3092\u66F4\u65B0">Passkey</a>
         </div>
       </header>
 

--- a/worker.js
+++ b/worker.js
@@ -65548,7 +65548,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
     * { box-sizing: border-box; }
     html, body { max-width: 100%; height: 100%; overflow: hidden; }
     body { margin: 0; background: var(--page-bg); }
-    main { width: 100%; height: 100dvh; min-height: 0; display: grid; grid-template-columns: minmax(0, 1fr) minmax(220px, 320px); gap: 18px; padding: 16px; overflow: hidden; }
+    main { width: 100%; height: 100dvh; min-height: 0; display: block; padding: 16px; overflow: hidden; }
     h1, h2, h3, p { margin-top: 0; }
     h1 { font-size: 22px; line-height: 1.1; margin-bottom: 4px; }
     h2 { font-size: 19px; margin-bottom: 12px; }
@@ -65619,11 +65619,6 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
     .composer-status:empty { min-height: 0; padding-left: 0; }
     .composer-status a { color: var(--text); font-weight: 800; text-underline-offset: 3px; }
     .composer-status.thinking::after { content: ""; display: inline-block; width: 1.4em; text-align: left; animation: thinkingDots 1.2s steps(4, end) infinite; }
-    .sidebar { position: sticky; top: 16px; align-self: start; max-height: calc(100dvh - 32px); overflow: auto; border: 1px solid var(--border); border-radius: 18px; background: var(--panel); }
-    .sidebar > summary { display: flex; justify-content: space-between; align-items: center; gap: 10px; min-height: 58px; padding: 14px; list-style: none; }
-    .sidebar > summary::-webkit-details-marker { display: none; }
-    .sidebar-content { display: grid; gap: 12px; padding: 0 14px 14px; }
-    .sidebar-header { display: flex; justify-content: space-between; align-items: center; gap: 10px; }
     .eyebrow { color: var(--muted); font-size: 11px; font-weight: 850; letter-spacing: .1em; text-transform: uppercase; }
     .lane, details { border: 1px solid var(--border); border-radius: 14px; padding: 12px; background: var(--panel-strong); }
     .lane-title { display: flex; justify-content: space-between; gap: 8px; align-items: baseline; }
@@ -65648,21 +65643,20 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
     code { color: var(--text); overflow-wrap: anywhere; }
     .menu-toggle { position: fixed; width: 1px; height: 1px; opacity: 0; pointer-events: none; }
     .mobile-backdrop, .mobile-drawer { display: none; }
+    .mobile-backdrop { position: fixed; inset: 0; z-index: 10; background: rgba(0, 0, 0, .38); backdrop-filter: blur(2px); }
+    .mobile-drawer { position: fixed; top: 0; bottom: 0; left: 0; z-index: 11; width: min(86vw, 380px); overflow: auto; padding: max(16px, env(safe-area-inset-top)) 14px max(18px, env(safe-area-inset-bottom)); border-right: 1px solid var(--border); background: var(--panel); box-shadow: 18px 0 60px var(--shadow); }
+    .menu-toggle:checked ~ .mobile-backdrop, .menu-toggle:checked ~ .mobile-drawer { display: block; }
+    .mobile-drawer-header { display: flex; justify-content: space-between; align-items: center; gap: 12px; margin-bottom: 14px; }
+    .mobile-drawer-content { display: grid; gap: 12px; }
     .menu-callout { color: var(--muted); font-size: 12px; line-height: 1.55; }
     @media (min-width: 1180px) {
       .chat-scroll { align-items: center; }
       .bubble.owner { margin-right: calc((100% - 760px) / 2); }
     }
     @media (max-width: 900px) {
-      main { display: block; padding: 14px 14px 0; }
+      main { padding: 14px 14px 0; }
       .app-shell { height: calc(100dvh - 14px); }
       .topbar { display: grid; grid-template-columns: minmax(0, 1fr) auto; align-items: center; }
-      .sidebar { display: none; }
-      .mobile-backdrop { position: fixed; inset: 0; z-index: 10; background: rgba(0, 0, 0, .38); backdrop-filter: blur(2px); }
-      .mobile-drawer { position: fixed; top: 0; bottom: 0; left: 0; z-index: 11; width: min(86vw, 360px); overflow: auto; padding: max(16px, env(safe-area-inset-top)) 14px max(18px, env(safe-area-inset-bottom)); border-right: 1px solid var(--border); background: var(--panel); box-shadow: 18px 0 60px var(--shadow); }
-      .menu-toggle:checked ~ .mobile-backdrop, .menu-toggle:checked ~ .mobile-drawer { display: block; }
-      .mobile-drawer-header { display: flex; justify-content: space-between; align-items: center; gap: 12px; margin-bottom: 14px; }
-      .mobile-drawer-content { display: grid; gap: 12px; }
       .chat-scroll { padding-bottom: 28px; }
       .bubble { max-width: 100%; font-size: 16px; }
       .bubble.owner { max-width: 82%; }
@@ -65712,12 +65706,16 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
             ${targetStatusMarkup}
           </div>
           <div class="lane">
+            <div class="lane-title"><h3>Issue \u5019\u88DC</h3><span class="pill">draft</span></div>
+            <p>Issue / PR \u64CD\u4F5C\u304C\u5FC5\u8981\u306B\u306A\u3063\u305F\u6642\u3060\u3051\u3001\u4F1A\u8A71\u306E\u4E2D\u3067\u5BFE\u8C61\u3068\u7BC4\u56F2\u3092\u78BA\u8A8D\u3057\u307E\u3059\u3002</p>
+          </div>
+          <div class="lane">
             <div class="lane-title"><h3>\u9032\u884C\u4E2D</h3><span class="pill">\u72B6\u614B</span></div>
             <p>\u76F4\u8FD1\u306E\u53CD\u6620\u3001\u5931\u6557\u3001\u9032\u884C\u4E2D\u306E\u4F5C\u696D\u304C\u3042\u308C\u3070\u3053\u3053\u306B\u51FA\u3057\u307E\u3059\u3002</p>
             ${renderDashboardDeployEvent(latestDeployEvent)}
-          </div>
-          <div class="quick-actions">
-            ${renderDashboardActionList(cockpitActions)}
+            <div class="quick-actions">
+              ${renderDashboardActionList(cockpitActions)}
+            </div>
           </div>
           <details data-debug-section="dashboard-development-operations">
             <summary>\u958B\u767A/\u904B\u7528</summary>
@@ -65725,11 +65723,15 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
               ${renderDashboardSurfaceList(surfaces)}
             </div>
           </details>
-          <details>
+          <details data-debug-section="dashboard-workflows">
             <summary>GitHub workflows</summary>
             <div class="surface-list">
               ${workflows.map(([title, href]) => `<a href="${escapeDashboardHtml(href)}">${escapeDashboardHtml(title)}</a>`).join("")}
             </div>
+          </details>
+          <details data-debug-section="dashboard-prototype-cleanup">
+            <summary>Prototype cleanup</summary>
+            <p>v3 Worker prototype \u306E\u524A\u9664\u3084\u79FB\u884C\u306F destructive operation \u6271\u3044\u3067\u3059\u3002\u5FC5\u8981\u306B\u306A\u3063\u305F\u6642\u3060\u3051\u3001\u5BFE\u8C61 runtime \u3068 scope \u3092\u660E\u793A\u3057\u305F passkey approval \u3067\u6271\u3044\u307E\u3059\u3002</p>
           </details>
         </div>
       </aside>
@@ -65769,57 +65771,6 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         <div class="composer-status" id="butler-chat-status">\u63A5\u7D9A\u6E96\u5099\u4E2D\u3067\u3059\u3002\u9001\u4FE1\u3067\u304D\u308B\u72B6\u614B\u306B\u306A\u3063\u305F\u3089\u77E5\u3089\u305B\u307E\u3059\u3002</div>
       </form>
     </section>
-
-    <details id="tools" class="sidebar" aria-label="\u7BA1\u7406\u30B5\u30A4\u30C9\u30D0\u30FC\u30E1\u30CB\u30E5\u30FC">
-      <summary>
-        <span>
-          <span class="eyebrow">\u30E1\u30CB\u30E5\u30FC</span>
-          <strong>\u5FC5\u8981\u306A\u6642\u3060\u3051\u958B\u304F</strong>
-        </span>
-        <span class="pill">WebSocket</span>
-      </summary>
-      <div class="sidebar-content">
-        <p class="menu-callout">\u901A\u77E5\u3001\u9032\u6357\u3001\u5BFE\u8C61 repo \u306E\u78BA\u8A8D\u3092\u512A\u5148\u3057\u307E\u3059\u3002\u958B\u767A/\u904B\u7528\u306E\u8A73\u7D30\u306F\u4E0B\u306B\u9694\u96E2\u3057\u3066\u3044\u307E\u3059\u3002</p>
-
-        <div class="lane">
-          <div class="lane-title"><h3>\u5BFE\u8C61 repo</h3><span class="pill">${repositoryInput ? "resolved" : "\u672A\u6307\u5B9A"}</span></div>
-          ${targetStatusMarkup}
-        </div>
-
-        <div class="lane">
-          <div class="lane-title"><h3>Issue \u5019\u88DC</h3><span class="pill">draft</span></div>
-          <p>Issue / PR \u64CD\u4F5C\u304C\u5FC5\u8981\u306B\u306A\u3063\u305F\u6642\u3060\u3051\u3001\u4F1A\u8A71\u306E\u4E2D\u3067\u5BFE\u8C61\u3068\u7BC4\u56F2\u3092\u78BA\u8A8D\u3057\u307E\u3059\u3002</p>
-        </div>
-
-        <div class="lane">
-          <div class="lane-title"><h3>\u9032\u884C\u4E2D</h3><span class="pill">\u72B6\u614B</span></div>
-          <p>\u76F4\u8FD1\u306E\u53CD\u6620\u3001\u5931\u6557\u3001\u9032\u884C\u4E2D\u306E\u4F5C\u696D\u304C\u3042\u308C\u3070\u3053\u3053\u306B\u51FA\u3057\u307E\u3059\u3002</p>
-          ${renderDashboardDeployEvent(latestDeployEvent)}
-          <div class="quick-actions">
-            ${renderDashboardActionList(cockpitActions)}
-          </div>
-        </div>
-
-        <details data-debug-section="dashboard-development-operations">
-          <summary>\u958B\u767A/\u904B\u7528</summary>
-          <div class="surface-list">
-            ${renderDashboardSurfaceList(surfaces)}
-          </div>
-        </details>
-
-        <details data-debug-section="dashboard-workflows">
-          <summary>GitHub workflows</summary>
-          <div class="surface-list">
-            ${workflows.map(([title, href]) => `<a href="${escapeDashboardHtml(href)}">${escapeDashboardHtml(title)}</a>`).join("")}
-          </div>
-        </details>
-
-        <details data-debug-section="dashboard-prototype-cleanup">
-          <summary>Prototype cleanup</summary>
-          <p>v3 Worker prototype \u306E\u524A\u9664\u3084\u79FB\u884C\u306F destructive operation \u6271\u3044\u3067\u3059\u3002\u5FC5\u8981\u306B\u306A\u3063\u305F\u6642\u3060\u3051\u3001\u5BFE\u8C61 runtime \u3068 scope \u3092\u660E\u793A\u3057\u305F passkey approval \u3067\u6271\u3044\u307E\u3059\u3002</p>
-        </details>
-      </div>
-    </details>
   </main>
   <script>
     (() => {


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #528 の部分進捗として、通常チャット topbar に Passkey / high-risk 導線を常設しない baseline を実装する。owner が通常会話を始める初期画面で、認証更新ボタンが通知や入力より目立つ状態を解消する。
- PC 幅で管理メニューを右側の常設サイドバーとして表示せず、ハンバーガーから開く overlay drawer に統一する。チャット本文幅を削る空カラムを作らない。

## Satisfied Success Criteria

- Dashboard 通常 topbar から Passkey session 更新リンクを削除した。
管理メニューの cockpitActions から Passkey を外し、通常チャット面の常設導線に戻らないようにした。
Dashboard HTML テストで Passkey topbar link と dashboard_access passkey operator URL が通常画面に出ないことを固定した。
- PC / mobile 共通で管理メニューを drawer overlay に統一した。
常設 sidebar markup と `minmax(220px, 320px)` の右カラムを削除し、main は chat 1 カラムにした。
Google Chrome local E2E で 1280px desktop viewport の drawer 挙動を確認した。

## Unsatisfied Success Criteria

- Issue #528 全体のうち、複数画像添付、production iPhone/PWA live E2E、repo 未指定表示、初期本文の内部設計説明撤去、WebSocket/PWA 復帰表示などは未実装。
このPRは Issue #528 を close しない部分スライス。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #528
- Implementing Success Criteria: Passkey / deploy / destructive / high-risk 導線は通常チャット topbar に常設せず、必要な action scope が明示された時だけ説明付きで到達できる。debug/ops surfaces は通常チャット幅を奪わない drawer に隔離する。
- Explicit Non-goals: passkey authority boundary の緩和、auth required/fallback 画面の削除、deploy/operator route 変更、通知/添付/WebSocket root fix、Issue #528 全体完了の主張。
- Expected touched files/routes/workflows: src/worker/runtime.js、test/worker.test.js、worker.js
- Affected Issues: Issue #528
- Affected PRs: なし
- Affected workflows: なし
- Affected runtime/operator surfaces: Dashboard Butler 通常チャット topbar、Dashboard drawer menu、Dashboard cockpit action list。Auth required / passkey fallback route は未変更。
- What may break if we patch narrowly: Passkey 自体を削ると認証切れ recovery が壊れるため、通常チャット面の常設表示だけ外し、必要時の auth/fallback path は残す。drawer 内の管理項目を消すと運用面に到達できなくなるため、右カラムから drawer 内へ移す。
- Unknowns to investigate before coding: 実機 iOS/PWA で topbar と drawer の見た目がどこまで改善したかは post-merge/deploy 後に確認が必要。
- Validation needed: node --test test/worker.test.js、npm run build:worker、npm run check:generated-worker、git diff --check、Google Chrome desktop viewport E2E、PR checks。
- Stop condition: auth boundary の変更、deploy/credential mutation、通常画面以外の operator path 削除が必要になったら別Issue/別PRで止める。

## File / Line Hypotheses

- file: src/worker/runtime.js
  - hypothesis: renderV2DashboardPage の top-right と cockpitActions から Passkey を外せば、通常チャット面で high-risk/認証導線が常設されない。
  - risk if changed narrowly: auth required 画面や session recovery まで削ると owner が入れなくなる。今回は通常 topbar のみ対象。
  - validation: Dashboard HTML tests and generated worker check。
  - related Issue: Issue #528
- file: src/worker/runtime.js
  - hypothesis: PC 幅で `main` が chat + sidebar の grid になっているため、drawer を閉じても右側に管理面の空間が残り、通常チャットが主役にならない。
  - risk if changed narrowly: sidebar 内の repo/status/debug/workflow/prototype cleanup 導線を消すと隔離ではなく削除になる。
  - validation: Chrome desktop viewport E2E で main が 1 カラム、drawer が fixed overlay、drawer open/close で chat shell width が変わらないことを確認する。
  - related Issue: Issue #528
- file: test/worker.test.js
  - hypothesis: topbar Passkey anchor と dashboard_access operator URL の absence assertion、常設 sidebar / right column absence assertion が regression を防ぐ。
  - risk if changed narrowly: mobile viewport の見た目改善は文字列テストだけでは証明できない。
  - validation: node --test test/worker.test.js。
  - related Issue: Issue #528

## Hypothesis Retrospective

- expected: 通常 dashboard topbar は 通知 だけを残し、Passkey は常設しない。PC 幅でも管理面は右カラムとして居座らず drawer で必要時だけ開く。
- actual: runtime HTML と cockpit action list から Passkey 常設導線を削除し、PC/mobile 共通 drawer に管理面を統合した。worker tests 205 件と Chrome desktop drawer E2E が通った。
- mismatch: production iPhone/PWA live screenshot は未実施。
- lesson: Passkey と debug/ops は owner action が必要な時の認証/復帰/開発面に残し、通常チャット面には居座らせない。
- should become RAG candidate: true

## Verification Evidence

- Unit: node --test test/worker.test.js: pass (205 tests)
- Integration: npm run build:worker: pass; npm run check:generated-worker: pass; git diff --check: pass
- E2E: `npx playwright test .tmp/e2e-dashboard-drawer-layout.spec.mjs --browser=chromium --reporter=line`: pass, 2 tests。Google Chrome channel で desktop 1280x820 は main 1 カラム、drawer 初期非表示、hamburger overlay 表示、drawer open 後も chat shell width 不変を確認。mobile 390x844 は drawer 初期非表示、hamburger overlay 表示、horizontal overflow なしを確認。
- Manual: なし
- Evidence path/link: src/worker/runtime.js; test/worker.test.js; worker.js

## Butler Completion Contract

- Owner goal: Dashboard Butler の通常チャット画面で、Passkey/high-risk/debug/ops 導線が目立って会話開始を邪魔しないようにする。PC 幅でも管理面は drawer として必要時だけ開く。
- Butler entrypoint: Dashboard Butler /dashboard の通常チャット topbar と drawer menu。
- Action Schema exposure: 未変更。Action schema 追加はない。
- Runtime path: renderV2DashboardPage -> Dashboard HTML topbar/drawer/cockpitActions。
- Runner/runtime truth: worker tests verify absence of Passkey topbar link, dashboard_access operator URL, persistent sidebar column, and desktop sidebar markup in normal dashboard HTML。
- Authority boundary: 未変更。Passkey/session authority は必要時の auth/fallback path に残す。
- E2E evidence: Google Chrome desktop and mobile viewport drawer layout E2E 済み。live iPhone/PWA production evidence は post-merge/deploy。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 未実施。merge 後に必要なら scoped passkey approval。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。

## Related Constitution Rules

- AGENTS.md Drift Stop Protocol
AGENTS.md Chief Butler Operating Principle
AGENTS.md Conversation UX Contract
AGENTS.md Evidence Discipline

## Out-of-scope but NOT implemented

- Issue #528 全体 close
- Passkey fallback/auth required UI の削除
- Deploy/credential/permission mutation
- 複数添付/WebSocket/PWA復帰の root fix
- production iPhone/PWA live E2E

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #528
- Execution ID: Not provided.
- Goal: issue_528_remove_dashboard_passkey_topbar
