### PR TITLE
Issue #575 dashboard link trailing punctuation

### DIFF
--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -11386,7 +11386,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         const source = String(text || "");
         const backtick = String.fromCharCode(96);
         const tokenPattern = new RegExp(
-          "(https?:\\\\/\\\\/[^\\\\s<>\\\"']+)|\\\\*\\\\*([\\\\s\\\\S]+?)\\\\*\\\\*|" + backtick + "([^" + backtick + "]+)" + backtick,
+          "(https?:\\\\/\\\\/[^\\\\s<>\\\"'\\\\)\\\\]）】』」〉》、。，．,！？]+)|\\\\*\\\\*([\\\\s\\\\S]+?)\\\\*\\\\*|" + backtick + "([^" + backtick + "]+)" + backtick,
           "g"
         );
         let cursor = 0;
@@ -11395,7 +11395,8 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
             container.appendChild(document.createTextNode(source.slice(cursor, match.index)));
           }
           if (match[1]) {
-            const href = match[1];
+            const linkToken = splitTrailingLinkPunctuation(match[1]);
+            const href = linkToken.href;
             const link = document.createElement("a");
             link.className = "chat-link";
             link.href = href;
@@ -11403,6 +11404,9 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
             link.target = "_blank";
             link.rel = "noreferrer";
             container.appendChild(link);
+            if (linkToken.trailing) {
+              container.appendChild(document.createTextNode(linkToken.trailing));
+            }
           } else if (match[2]) {
             const strong = document.createElement("strong");
             renderInlineMarkdown(strong, match[2]);
@@ -11417,6 +11421,22 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         if (cursor < source.length) {
           container.appendChild(document.createTextNode(source.slice(cursor)));
         }
+      }
+
+      function splitTrailingLinkPunctuation(value) {
+        const source = String(value || "");
+        const trailingPunctuation = ")]）】』」〉》、。，．,.;:!?！？";
+        let hrefEnd = source.length;
+        while (hrefEnd > 0 && trailingPunctuation.includes(source[hrefEnd - 1])) {
+          hrefEnd -= 1;
+        }
+        if (hrefEnd === source.length || hrefEnd === 0) {
+          return { href: source, trailing: "" };
+        }
+        return {
+          href: source.slice(0, hrefEnd),
+          trailing: source.slice(hrefEnd)
+        };
       }
 
       async function copyMessageText(button, text) {

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -193,6 +193,7 @@ function loadDashboardInlineChatHelpers(html) {
     "shouldWrapCodeBlock",
     "renderMessageText",
     "renderInlineMarkdown",
+    "splitTrailingLinkPunctuation",
     "copyMessageText"
   ];
   const sources = names.map((name) => extractDashboardInlineFunction(html, name)).join("\n");
@@ -1370,6 +1371,21 @@ test("served dashboard inline chat renderer executes decode, link, wrap, and cop
   assert.equal(links.length, 1);
   assert.equal(links[0].className, "chat-link");
   assert.equal(links[0].href.startsWith("https://example.com/"), true);
+
+  const parenthesizedLinkContainer = document.createElement("div");
+  helpers.renderMessageText(parenthesizedLinkContainer, "開いて（https://example.com/path?x=1）");
+  const parenthesizedLinks = parenthesizedLinkContainer.querySelectorAll("a");
+  assert.equal(parenthesizedLinks.length, 1);
+  assert.equal(parenthesizedLinks[0].href, "https://example.com/path?x=1");
+  assert.equal(parenthesizedLinks[0].textContent, "https://example.com/path?x=1");
+  assert.equal(parenthesizedLinkContainer.textContent, "開いて（https://example.com/path?x=1）");
+
+  const commaLinkContainer = document.createElement("div");
+  helpers.renderMessageText(commaLinkContainer, "次: https://example.com/path、確認");
+  const commaLinks = commaLinkContainer.querySelectorAll("a");
+  assert.equal(commaLinks.length, 1);
+  assert.equal(commaLinks[0].href, "https://example.com/path");
+  assert.equal(commaLinkContainer.textContent, "次: https://example.com/path、確認");
 
   const codeContainer = document.createElement("div");
   helpers.renderMessageText(codeContainer, "```\nhttps://example.com/" + "b".repeat(96) + "\n```");

--- a/worker.js
+++ b/worker.js
@@ -66264,7 +66264,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         const source = String(text || "");
         const backtick = String.fromCharCode(96);
         const tokenPattern = new RegExp(
-          "(https?:\\\\/\\\\/[^\\\\s<>\\"']+)|\\\\*\\\\*([\\\\s\\\\S]+?)\\\\*\\\\*|" + backtick + "([^" + backtick + "]+)" + backtick,
+          "(https?:\\\\/\\\\/[^\\\\s<>\\"'\\\\)\\\\]\uFF09\u3011\u300F\u300D\u3009\u300B\u3001\u3002\uFF0C\uFF0E,\uFF01\uFF1F]+)|\\\\*\\\\*([\\\\s\\\\S]+?)\\\\*\\\\*|" + backtick + "([^" + backtick + "]+)" + backtick,
           "g"
         );
         let cursor = 0;
@@ -66273,7 +66273,8 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
             container.appendChild(document.createTextNode(source.slice(cursor, match.index)));
           }
           if (match[1]) {
-            const href = match[1];
+            const linkToken = splitTrailingLinkPunctuation(match[1]);
+            const href = linkToken.href;
             const link = document.createElement("a");
             link.className = "chat-link";
             link.href = href;
@@ -66281,6 +66282,9 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
             link.target = "_blank";
             link.rel = "noreferrer";
             container.appendChild(link);
+            if (linkToken.trailing) {
+              container.appendChild(document.createTextNode(linkToken.trailing));
+            }
           } else if (match[2]) {
             const strong = document.createElement("strong");
             renderInlineMarkdown(strong, match[2]);
@@ -66295,6 +66299,22 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         if (cursor < source.length) {
           container.appendChild(document.createTextNode(source.slice(cursor)));
         }
+      }
+
+      function splitTrailingLinkPunctuation(value) {
+        const source = String(value || "");
+        const trailingPunctuation = ")]\uFF09\u3011\u300F\u300D\u3009\u300B\u3001\u3002\uFF0C\uFF0E,.;:!?\uFF01\uFF1F";
+        let hrefEnd = source.length;
+        while (hrefEnd > 0 && trailingPunctuation.includes(source[hrefEnd - 1])) {
+          hrefEnd -= 1;
+        }
+        if (hrefEnd === source.length || hrefEnd === 0) {
+          return { href: source, trailing: "" };
+        }
+        return {
+          href: source.slice(0, hrefEnd),
+          trailing: source.slice(hrefEnd)
+        };
       }
 
       async function copyMessageText(button, text) {


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #575 の Dashboard Butler chat 自動リンク化回帰を修正します。URL 直後の閉じ括弧や句読点を href に含めず、リンク外の本文として残します。

## Satisfied Success Criteria

- `https://example.com/path）` は href が `https://example.com/path` になり、`）` はリンク外テキストとして残ります。
- `https://example.com/path、確認` は href が `https://example.com/path` になり、`、確認` は通常本文として残ります。
- URL 内のクエリ `?x=1` は維持します。
- 既存の `go:%0A...` 表示復元、長い URL の折り返し、コピー挙動の既存テストを維持しました。

## Unsatisfied Success Criteria

None.

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #575
- Implementing Success Criteria: Dashboard chat の URL 自動リンク化で、URL 末尾の全角/半角閉じ括弧や句読点を a[href] に含めない。
- Explicit Non-goals: passkey approval / deploy operator / GitHub Actions dispatch / Dashboard 横揺れ / ログイン再認証 / 通知文言固定問題は変更しない。
- Expected touched files/routes/workflows: `src/worker/runtime.js`, `test/worker.test.js`, generated `worker.js`
- Affected Issues: Issue #575, related Issue #524
- Affected PRs: なし
- Affected workflows: GitHub Actions workflow 定義は未変更
- Affected runtime/operator surfaces: Dashboard Butler chat message renderer のみ
- What may break if we patch narrowly: URL tokenization を狭く変えると `go:%0A...` 復元、長い URL 折り返し、copy button helper が退行する可能性があるため既存 renderer helper test へ追加した。
- Unknowns to investigate before coding: `renderInlineMarkdown()` の token 正規表現が URL 後続の日本語句読点をどこまで食うか。
- Validation needed: `node --test test/worker.test.js`, `npm run build:worker`, `npm run check:generated-worker`, `git diff --check --cached`
- Stop condition: passkey/deploy/operator/authentication/横揺れ問題へ変更範囲が広がる場合は停止し、別 Issue に分ける。

## File / Line Hypotheses

- file: `src/worker/runtime.js`
  - hypothesis: `renderInlineMarkdown()` の URL token 正規表現が `https://...）` や `https://...、確認` を URL として広く取りすぎる。
  - risk if changed narrowly: URL の正当な query/hash や既存 copy/link rendering を壊す。
  - validation: inline helper を抽出する既存 worker test に、閉じ括弧・読点付き URL の href/textContent 検証を追加する。
  - related Issue: Issue #575

## Hypothesis Retrospective

- expected: `renderInlineMarkdown()` の URL tokenization が原因。
- actual: 正しかった。URL token 正規表現を日本語句読点で止め、残った末尾記号を `splitTrailingLinkPunctuation()` でリンク外へ戻した。
- mismatch: 最初の正規表現は test helper の関数抽出と相性が悪かったため、brace を含む regex から文字列 includes 判定へ変更した。
- lesson: inline script の helper はテスト抽出器が JS 構文を完全 parse しないため、正規表現内の brace でも壊れ得る。
- should become RAG candidate: yes

## Verification Evidence

- Unit: `node --test test/worker.test.js` passed, 205 tests.
- Integration: `npm run build:worker` passed; `npm run check:generated-worker` passed after staging generated `worker.js`; `git diff --check --cached` passed.
- E2E: Dashboard inline chat renderer helper で `開いて（https://example.com/path?x=1）` と `次: https://example.com/path、確認` を描画し、a[href] と textContent を検証した。
- Manual: full `npm test` は unrelated vault / VPS credential tests 3 件で failed。今回の Dashboard link renderer test は通過。
- Evidence path/link: `test/worker.test.js`

## Butler Completion Contract

- Owner goal: Dashboard chat で返した URL を iPhone でタップした時、文末の `）` までリンクに入って 404 にならないようにする。
- Butler entrypoint: Dashboard Butler chat message rendering
- Action Schema exposure: 不要。この PR は Action Schema を変更しない。
- Runtime path: `/dashboard` の inline chat renderer `renderInlineMarkdown()`
- Runner/runtime truth: local worker test が served dashboard HTML から inline helper を抽出して検証
- Authority boundary: 未変更。新しい high-risk authority は追加しない。
- E2E evidence: `test/worker.test.js` の Dashboard inline chat renderer helper 検証
- Completion status: complete

## Surface Update Checklist

- Cloudflare deploy: 未実施。merge 後に通常 production deploy 判断が必要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。local renderer helper で URL href/textContent を検証。

## Related Constitution Rules

- Conversation UX Contract
- Evidence Discipline
- Drift Stop Protocol
- Butler Completion Gate

## Out-of-scope but NOT implemented

- Dashboard 横揺れ Issue #573
- 投稿時刻右下 Issue #574
- PR #572 checks retrigger
- passkey / deploy approval URL 生成
- ログイン再認証 UX

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #575
- Execution ID: local-codex-2026-05-26-issue-575
- Goal: dashboard-link-trailing-punctuation
