### PR TITLE
Issue #577 normalize dashboard composer command paste

### DIFF
--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -10992,6 +10992,18 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         updateComposerReserve();
       }
 
+      function normalizeComposerInputText(text) {
+        return decodeSafeChatCommandText(String(text || ""));
+      }
+
+      function normalizeComposerInput() {
+        const normalized = normalizeComposerInputText(textarea.value);
+        if (normalized !== textarea.value) {
+          textarea.value = normalized;
+        }
+        resizeComposerInput();
+      }
+
       function scrollToLatest() {
         updateComposerReserve();
         log.scrollTop = log.scrollHeight;
@@ -11881,7 +11893,10 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
       }
 
       resizeComposerInput();
-      textarea.addEventListener("input", resizeComposerInput);
+      textarea.addEventListener("input", normalizeComposerInput);
+      textarea.addEventListener("paste", () => {
+        window.setTimeout(normalizeComposerInput, 0);
+      });
       window.addEventListener("resize", resizeComposerInput);
       window.addEventListener("online", () => {
         setConnectionRecoveryStatus("ネットワーク復帰を検知しました。接続を復帰しています。");

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -189,6 +189,7 @@ function loadDashboardInlineChatHelpers(html) {
   const names = [
     "normalizeMessageDisplayText",
     "normalizeMessageCopyText",
+    "normalizeComposerInputText",
     "decodeSafeChatCommandText",
     "shouldWrapCodeBlock",
     "renderMessageText",
@@ -1176,7 +1177,10 @@ test("worker serves v2 dashboard for allowed owner identity without exposing sec
   assert.equal(body.includes("Math.min(160, Math.floor(window.innerHeight * 0.24))"), true);
   assert.equal(body.includes('textarea.style.height = "auto"'), true);
   assert.equal(body.includes('textarea.style.overflowY = textarea.scrollHeight > maxHeight ? "auto" : "hidden"'), true);
-  assert.equal(body.includes('textarea.addEventListener("input", resizeComposerInput)'), true);
+  assert.equal(body.includes("function normalizeComposerInputText("), true);
+  assert.equal(body.includes("function normalizeComposerInput()"), true);
+  assert.equal(body.includes('textarea.addEventListener("input", normalizeComposerInput)'), true);
+  assert.equal(body.includes('textarea.addEventListener("paste"'), true);
   assert.equal(body.includes("function scrollToLatest()"), true);
   assert.equal(body.includes("function showThinking()"), false);
   assert.equal(body.includes("function removeThinking("), false);
@@ -1356,6 +1360,18 @@ test("served dashboard inline chat renderer executes decode, link, wrap, and cop
   );
   assert.equal(
     helpers.normalizeMessageCopyText("https://example.com/path%20with%20encoded?x=1"),
+    "https://example.com/path%20with%20encoded?x=1"
+  );
+  assert.equal(
+    helpers.normalizeComposerInputText("go:%20Issue%20%23575%20close%20and%20delete"),
+    "go: Issue #575 close and delete"
+  );
+  assert.equal(
+    helpers.normalizeComposerInputText("go:%0AIssue%20%23575%20close"),
+    "go:\nIssue #575 close"
+  );
+  assert.equal(
+    helpers.normalizeComposerInputText("https://example.com/path%20with%20encoded?x=1"),
     "https://example.com/path%20with%20encoded?x=1"
   );
   assert.equal(helpers.normalizeMessageCopyText("go:%E0%A4%A"), "go:%E0%A4%A");

--- a/worker.js
+++ b/worker.js
@@ -65870,6 +65870,18 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         updateComposerReserve();
       }
 
+      function normalizeComposerInputText(text) {
+        return decodeSafeChatCommandText(String(text || ""));
+      }
+
+      function normalizeComposerInput() {
+        const normalized = normalizeComposerInputText(textarea.value);
+        if (normalized !== textarea.value) {
+          textarea.value = normalized;
+        }
+        resizeComposerInput();
+      }
+
       function scrollToLatest() {
         updateComposerReserve();
         log.scrollTop = log.scrollHeight;
@@ -66759,7 +66771,10 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
       }
 
       resizeComposerInput();
-      textarea.addEventListener("input", resizeComposerInput);
+      textarea.addEventListener("input", normalizeComposerInput);
+      textarea.addEventListener("paste", () => {
+        window.setTimeout(normalizeComposerInput, 0);
+      });
       window.addEventListener("resize", resizeComposerInput);
       window.addEventListener("online", () => {
         setConnectionRecoveryStatus("\u30CD\u30C3\u30C8\u30EF\u30FC\u30AF\u5FA9\u5E30\u3092\u691C\u77E5\u3057\u307E\u3057\u305F\u3002\u63A5\u7D9A\u3092\u5FA9\u5E30\u3057\u3066\u3044\u307E\u3059\u3002");


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #577 の Dashboard Butler chat composer 貼り付け回帰を修正します。`go:%20...` や `go:%0A...` を送信前の入力欄で読める形へ戻します。

## Satisfied Success Criteria

- composer helper で `go:%20Issue%20%23575%20close%20and%20delete` が `go: Issue #575 close and delete` へ正規化されます。
- composer helper で `go:%0AIssue%20%23575%20close` が改行付きの `go:\nIssue #575 close` へ正規化されます。
- `https://example.com/path%20with%20encoded?x=1` は通常 URL として decode しません。
- 不正な percent escape は既存の decode guard により壊さず維持します。
- 既存の送信後表示、コピー、リンク化、画像添付 composer の worker tests を維持しました。

## Unsatisfied Success Criteria

None.

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #577
- Implementing Success Criteria: composer paste/input で command-like percent encoded text を送信前に正規化する。
- Explicit Non-goals: passkey approval / deploy operator / GitHub Actions dispatch / Dashboard 横揺れ / ログイン再認証 / 通知文言固定問題は変更しない。
- Expected touched files/routes/workflows: `src/worker/runtime.js`, `test/worker.test.js`, generated `worker.js`
- Affected Issues: Issue #577, related Issue #524, related Issue #575
- Affected PRs: なし
- Affected workflows: GitHub Actions workflow 定義は未変更
- Affected runtime/operator surfaces: Dashboard Butler chat composer のみ
- What may break if we patch narrowly: textarea input handler が resize だけを担当していたため、正規化追加で composer height 更新や通常 URL paste を壊す可能性がある。
- Unknowns to investigate before coding: iOS paste event の timing 差異に対して `paste` 後の delayed normalization と `input` normalization の両方が必要か。
- Validation needed: `node --test test/worker.test.js`, `npm run build:worker`, `npm run check:generated-worker`, `git diff --check --cached`
- Stop condition: setup textarea や passkey operator textarea など Dashboard composer 以外に変更範囲が広がる場合は停止し、別 Issue に分ける。

## File / Line Hypotheses

- file: `src/worker/runtime.js`
  - hypothesis: `decodeSafeChatCommandText()` は送信後表示と copy には使われているが、composer textarea の paste/input には使われていない。
  - risk if changed narrowly: input resize や通常 URL の percent encoding を壊す。
  - validation: served dashboard inline helper で composer normalization と既存 renderer behavior を同時に検証する。
  - related Issue: Issue #577

## Hypothesis Retrospective

- expected: composer textarea が decode helper を通していない。
- actual: 正しかった。`normalizeComposerInputText()` と `normalizeComposerInput()` を追加し、input/paste で呼ぶようにした。
- mismatch: なし。
- lesson: URL 表示修正だけでは、送信前 composer UX には届かない。composer / display / copy の三面を別々に検証する必要がある。
- should become RAG candidate: yes

## Verification Evidence

- Unit: `node --test test/worker.test.js` passed, 205 tests.
- Integration: `npm run build:worker` passed; `npm run check:generated-worker` passed; `git diff --check --cached` passed.
- E2E: served dashboard inline helper で composer normalization helper を検証した。
- Manual: 未実施。
- Evidence path/link: `test/worker.test.js`

## Butler Completion Contract

- Owner goal: Dashboard chat に `go:%20...` を貼った時、送信前に読める形へ戻して確認できるようにする。
- Butler entrypoint: Dashboard Butler chat composer
- Action Schema exposure: 不要。この PR は Action Schema を変更しない。
- Runtime path: `/dashboard` inline composer script
- Runner/runtime truth: local worker test が served dashboard HTML から inline helper を抽出して検証
- Authority boundary: 未変更。新しい high-risk authority は追加しない。
- E2E evidence: `test/worker.test.js` の served dashboard inline helper 検証
- Completion status: complete

## Surface Update Checklist

- Cloudflare deploy: 未実施。merge 後に通常 production deploy 判断が必要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。local renderer/helper で composer 正規化を検証。

## Related Constitution Rules

- Conversation UX Contract
- Evidence Discipline
- Drift Stop Protocol
- Butler Completion Gate

## Out-of-scope but NOT implemented

- Dashboard 横揺れ Issue #573
- 投稿時刻右下 Issue #574
- passkey / deploy approval URL 生成
- ログイン再認証 UX

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #577
- Execution ID: local-codex-2026-05-26-issue-577
- Goal: dashboard-composer-paste-decode
