### PR TITLE
Issue #580 strip encoded trailing link punctuation

### DIFF
--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -11438,6 +11438,18 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
       function splitTrailingLinkPunctuation(value) {
         const source = String(value || "");
         const trailingPunctuation = ")]）】』」〉》、。，．,.;:!?！？";
+        const rawSplit = splitRawTrailingLinkPunctuation(source, trailingPunctuation);
+        const encodedSplit = splitEncodedTrailingLinkPunctuation(rawSplit.href, trailingPunctuation);
+        if (!rawSplit.trailing && !encodedSplit.trailing) {
+          return { href: source, trailing: "" };
+        }
+        return {
+          href: encodedSplit.href,
+          trailing: encodedSplit.trailing + rawSplit.trailing
+        };
+      }
+
+      function splitRawTrailingLinkPunctuation(source, trailingPunctuation) {
         let hrefEnd = source.length;
         while (hrefEnd > 0 && trailingPunctuation.includes(source[hrefEnd - 1])) {
           hrefEnd -= 1;
@@ -11449,6 +11461,47 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           href: source.slice(0, hrefEnd),
           trailing: source.slice(hrefEnd)
         };
+      }
+
+      function splitEncodedTrailingLinkPunctuation(source, trailingPunctuation) {
+        let hrefEnd = source.length;
+        let trailing = "";
+        while (hrefEnd >= 3) {
+          let encodedStart = hrefEnd;
+          while (encodedStart >= 3 && source[encodedStart - 3] === "%" && isHexPair(source[encodedStart - 2], source[encodedStart - 1])) {
+            encodedStart -= 3;
+          }
+          if (encodedStart === hrefEnd) {
+            break;
+          }
+          const encodedTrailing = source.slice(encodedStart, hrefEnd);
+          let decodedTrailing = "";
+          try {
+            decodedTrailing = decodeURIComponent(encodedTrailing);
+          } catch {
+            break;
+          }
+          if (!decodedTrailing || !Array.from(decodedTrailing).every((char) => trailingPunctuation.includes(char))) {
+            break;
+          }
+          trailing = decodedTrailing + trailing;
+          hrefEnd = encodedStart;
+        }
+        if (!trailing) {
+          return { href: source, trailing: "" };
+        }
+        return {
+          href: source.slice(0, hrefEnd),
+          trailing
+        };
+      }
+
+      function isHexPair(first, second) {
+        return isHexDigit(first) && isHexDigit(second);
+      }
+
+      function isHexDigit(value) {
+        return "0123456789abcdefABCDEF".includes(String(value || ""));
       }
 
       async function copyMessageText(button, text) {

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -195,6 +195,10 @@ function loadDashboardInlineChatHelpers(html) {
     "renderMessageText",
     "renderInlineMarkdown",
     "splitTrailingLinkPunctuation",
+    "splitRawTrailingLinkPunctuation",
+    "splitEncodedTrailingLinkPunctuation",
+    "isHexPair",
+    "isHexDigit",
     "copyMessageText"
   ];
   const sources = names.map((name) => extractDashboardInlineFunction(html, name)).join("\n");
@@ -1402,6 +1406,26 @@ test("served dashboard inline chat renderer executes decode, link, wrap, and cop
   assert.equal(commaLinks.length, 1);
   assert.equal(commaLinks[0].href, "https://example.com/path");
   assert.equal(commaLinkContainer.textContent, "次: https://example.com/path、確認");
+
+  const encodedFullWidthParenContainer = document.createElement("div");
+  helpers.renderMessageText(encodedFullWidthParenContainer, "開いて https://example.com/path%EF%BC%89");
+  const encodedFullWidthParenLinks = encodedFullWidthParenContainer.querySelectorAll("a");
+  assert.equal(encodedFullWidthParenLinks.length, 1);
+  assert.equal(encodedFullWidthParenLinks[0].href, "https://example.com/path");
+  assert.equal(encodedFullWidthParenContainer.textContent, "開いて https://example.com/path）");
+
+  const encodedAsciiParenContainer = document.createElement("div");
+  helpers.renderMessageText(encodedAsciiParenContainer, "open https://example.com/path%29");
+  const encodedAsciiParenLinks = encodedAsciiParenContainer.querySelectorAll("a");
+  assert.equal(encodedAsciiParenLinks.length, 1);
+  assert.equal(encodedAsciiParenLinks[0].href, "https://example.com/path");
+  assert.equal(encodedAsciiParenContainer.textContent, "open https://example.com/path)");
+
+  const encodedSpaceContainer = document.createElement("div");
+  helpers.renderMessageText(encodedSpaceContainer, "open https://example.com/path%20with%20encoded?x=1");
+  const encodedSpaceLinks = encodedSpaceContainer.querySelectorAll("a");
+  assert.equal(encodedSpaceLinks.length, 1);
+  assert.equal(encodedSpaceLinks[0].href, "https://example.com/path%20with%20encoded?x=1");
 
   const codeContainer = document.createElement("div");
   helpers.renderMessageText(codeContainer, "```\nhttps://example.com/" + "b".repeat(96) + "\n```");

--- a/worker.js
+++ b/worker.js
@@ -66316,6 +66316,18 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
       function splitTrailingLinkPunctuation(value) {
         const source = String(value || "");
         const trailingPunctuation = ")]\uFF09\u3011\u300F\u300D\u3009\u300B\u3001\u3002\uFF0C\uFF0E,.;:!?\uFF01\uFF1F";
+        const rawSplit = splitRawTrailingLinkPunctuation(source, trailingPunctuation);
+        const encodedSplit = splitEncodedTrailingLinkPunctuation(rawSplit.href, trailingPunctuation);
+        if (!rawSplit.trailing && !encodedSplit.trailing) {
+          return { href: source, trailing: "" };
+        }
+        return {
+          href: encodedSplit.href,
+          trailing: encodedSplit.trailing + rawSplit.trailing
+        };
+      }
+
+      function splitRawTrailingLinkPunctuation(source, trailingPunctuation) {
         let hrefEnd = source.length;
         while (hrefEnd > 0 && trailingPunctuation.includes(source[hrefEnd - 1])) {
           hrefEnd -= 1;
@@ -66327,6 +66339,47 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           href: source.slice(0, hrefEnd),
           trailing: source.slice(hrefEnd)
         };
+      }
+
+      function splitEncodedTrailingLinkPunctuation(source, trailingPunctuation) {
+        let hrefEnd = source.length;
+        let trailing = "";
+        while (hrefEnd >= 3) {
+          let encodedStart = hrefEnd;
+          while (encodedStart >= 3 && source[encodedStart - 3] === "%" && isHexPair(source[encodedStart - 2], source[encodedStart - 1])) {
+            encodedStart -= 3;
+          }
+          if (encodedStart === hrefEnd) {
+            break;
+          }
+          const encodedTrailing = source.slice(encodedStart, hrefEnd);
+          let decodedTrailing = "";
+          try {
+            decodedTrailing = decodeURIComponent(encodedTrailing);
+          } catch {
+            break;
+          }
+          if (!decodedTrailing || !Array.from(decodedTrailing).every((char) => trailingPunctuation.includes(char))) {
+            break;
+          }
+          trailing = decodedTrailing + trailing;
+          hrefEnd = encodedStart;
+        }
+        if (!trailing) {
+          return { href: source, trailing: "" };
+        }
+        return {
+          href: source.slice(0, hrefEnd),
+          trailing
+        };
+      }
+
+      function isHexPair(first, second) {
+        return isHexDigit(first) && isHexDigit(second);
+      }
+
+      function isHexDigit(value) {
+        return "0123456789abcdefABCDEF".includes(String(value || ""));
       }
 
       async function copyMessageText(button, text) {


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #580 の Dashboard Butler chat link 回帰を修正します。URL 末尾の閉じ括弧が `%29` / `%EF%BC%89` のように encoded trailing punctuation になっても href に含めません。

## Satisfied Success Criteria

- `https://example.com/path%EF%BC%89` は href が `https://example.com/path` になり、表示本文では `）` がリンク外に残ります。
- `https://example.com/path%29` は href が `https://example.com/path` になり、表示本文では `)` がリンク外に残ります。
- 生の `https://example.com/path）` と `https://example.com/path、` の既存挙動を維持しました。
- 通常 URL の `path%20with%20encoded?x=1` は decode せず href に維持します。
- Dashboard chat renderer の copy / composer normalization / long URL wrapping の既存テストを維持しました。

## Unsatisfied Success Criteria

None.

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #580
- Implementing Success Criteria: URL 末尾の encoded closing punctuation を href から外し、表示本文には decoded punctuation として残す。
- Explicit Non-goals: passkey approval / deploy operator / GitHub Actions dispatch / WebSocket reconnect / auth 復帰は変更しない。
- Expected touched files/routes/workflows: `src/worker/runtime.js`, `test/worker.test.js`, generated `worker.js`
- Affected Issues: Issue #580, related Issue #575, related Issue #577
- Affected PRs: なし
- Affected workflows: GitHub Actions workflow 定義は未変更
- Affected runtime/operator surfaces: Dashboard Butler chat message renderer のみ
- What may break if we patch narrowly: percent-encoded path を誤って decode すると通常 URL が壊れるため、末尾が punctuation として decode できる場合だけ剥がす。
- Unknowns to investigate before coding: ユーザー環境で混ざる括弧が raw `）` か encoded `%EF%BC%89` / `%29` か。
- Validation needed: `node --test test/worker.test.js`, `npm run build:worker`, `npm run check:generated-worker`, `git diff --check --cached`
- Stop condition: Markdown parser 全体の作り直しや別 surface の linkification へ広がる場合は停止し、別 Issue に分ける。

## File / Line Hypotheses

- file: `src/worker/runtime.js`
  - hypothesis: `splitTrailingLinkPunctuation()` は raw punctuation を剥がすが、encoded trailing punctuation を href に残していた。
  - risk if changed narrowly: 通常の percent-encoded URL path/query を壊す。
  - validation: served dashboard inline helper で `%EF%BC%89` / `%29` / `%20` の href と textContent を検証する。
  - related Issue: Issue #580

## Hypothesis Retrospective

- expected: encoded trailing punctuation が未処理。
- actual: 正しかった。raw split の後に encoded trailing punctuation split を追加した。
- mismatch: なし。
- lesson: chat linkification は raw punctuation と encoded punctuation の両方をテストする必要がある。
- should become RAG candidate: yes

## Verification Evidence

- Unit: `node --test test/worker.test.js` passed, 205 tests.
- Integration: `npm run build:worker` passed; `npm run check:generated-worker` passed; `git diff --check --cached` passed.
- E2E: served dashboard inline helper で encoded trailing punctuation の href と textContent を検証した。
- Manual: 未実施。
- Evidence path/link: `test/worker.test.js`

## Butler Completion Contract

- Owner goal: Dashboard chat のリンク末尾に括弧が混ざって 404 になる問題を、encoded punctuation 経路でも止める。
- Butler entrypoint: Dashboard Butler chat message rendering
- Action Schema exposure: 不要。この PR は Action Schema を変更しない。
- Runtime path: `/dashboard` inline chat renderer `renderInlineMarkdown()`
- Runner/runtime truth: local worker test が served dashboard HTML から inline helper を抽出して検証
- Authority boundary: 未変更。新しい high-risk authority は追加しない。
- E2E evidence: `test/worker.test.js` の served dashboard inline helper 検証
- Completion status: complete

## Surface Update Checklist

- Cloudflare deploy: 未実施。merge 後に通常 production deploy 判断が必要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。local renderer/helper で encoded trailing punctuation を検証。

## Related Constitution Rules

- Conversation UX Contract
- Evidence Discipline
- Drift Stop Protocol
- Butler Completion Gate

## Out-of-scope but NOT implemented

- Dashboard WebSocket reconnect / auth 復帰 Issue #579
- passkey / deploy approval URL 生成
- Markdown parser 全体の作り直し

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #580
- Execution ID: local-codex-2026-05-27-issue-580
- Goal: dashboard-link-encoded-trailing-punctuation
