### PR TITLE
Issue #528 allow multiple dashboard attachments

### DIFF
--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -10889,7 +10889,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         <div class="pending-media" id="butler-pending-media" aria-live="polite"></div>
         <div class="composer-box">
           <button class="media-button" id="butler-media-button" type="button" aria-label="画像やファイルを追加" title="画像やファイルを追加">+</button>
-          <input id="butler-media-input" type="file" hidden>
+          <input id="butler-media-input" type="file" multiple hidden>
           <textarea id="butler-message" name="text" placeholder="Butler V2 にメッセージ..." aria-label="Butler V2 にメッセージ" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" enterkeyhint="send"></textarea>
           <button class="send-button" type="submit" aria-label="Butler に送信">↑</button>
         </div>
@@ -11909,32 +11909,34 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
       if (mediaButton && mediaInput) {
         mediaButton.addEventListener("click", () => mediaInput.click());
         mediaInput.addEventListener("change", async () => {
-          const file = mediaInput.files && mediaInput.files[0];
+          const files = Array.from(mediaInput.files || []);
           mediaInput.value = "";
-          if (!file) return;
+          if (files.length === 0) return;
           try {
             mediaButton.disabled = true;
-            const preparedFile = await prepareUploadFile(file);
-            const previewUrl =
-              preparedFile && preparedFile.type && preparedFile.type.startsWith("image/") && typeof URL !== "undefined" && typeof URL.createObjectURL === "function"
-                ? URL.createObjectURL(preparedFile)
-                : "";
-            const nextPendingMediaItems = [
-              ...pendingMediaItems,
-              {
+            const selectedItems = [];
+            for (const file of files) {
+              const preparedFile = await prepareUploadFile(file);
+              const previewUrl =
+                preparedFile && preparedFile.type && preparedFile.type.startsWith("image/") && typeof URL !== "undefined" && typeof URL.createObjectURL === "function"
+                  ? URL.createObjectURL(preparedFile)
+                  : "";
+              selectedItems.push({
                 clientId: Date.now() + "_" + Math.random().toString(36).slice(2),
                 filename: preparedFile.name || file.name || "attachment",
                 previewUrl,
                 file: preparedFile
-              }
-            ];
+              });
+            }
+            const nextPendingMediaItems = [...pendingMediaItems, ...selectedItems];
             const retainedPendingMediaItems = nextPendingMediaItems.slice(-12);
             for (const dropped of nextPendingMediaItems.slice(0, Math.max(0, nextPendingMediaItems.length - 12))) {
               revokePendingMediaPreview(dropped);
             }
             pendingMediaItems = retainedPendingMediaItems;
             renderPendingMedia();
-            setStatus("添付を送信待ちに追加しました。repo 未指定の通常会話では private media として保存します。", { temporary: true });
+            const addedCount = Math.min(selectedItems.length, 12);
+            setStatus(String(addedCount) + "件の添付を送信待ちに追加しました。repo 未指定の通常会話では private media として保存します。", { temporary: true });
             textarea.focus({ preventScroll: true });
           } catch (error) {
             setStatus((error && error.message) || "添付の保存に失敗しました。");

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -11912,9 +11912,9 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           const files = Array.from(mediaInput.files || []);
           mediaInput.value = "";
           if (files.length === 0) return;
+          const selectedItems = [];
           try {
             mediaButton.disabled = true;
-            const selectedItems = [];
             for (const file of files) {
               const preparedFile = await prepareUploadFile(file);
               const previewUrl =
@@ -11939,6 +11939,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
             setStatus(String(addedCount) + "件の添付を送信待ちに追加しました。repo 未指定の通常会話では private media として保存します。", { temporary: true });
             textarea.focus({ preventScroll: true });
           } catch (error) {
+            revokePendingMediaPreviews(selectedItems);
             setStatus((error && error.message) || "添付の保存に失敗しました。");
           } finally {
             mediaButton.disabled = false;

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -1510,6 +1510,8 @@ test("worker serves dashboard media add controls for iPhone-first upload", async
   assert.equal(body.includes("URL.revokeObjectURL"), true);
   assert.equal(body.includes("const files = Array.from(mediaInput.files || [])"), true);
   assert.equal(body.includes("for (const file of files)"), true);
+  assert.equal(body.includes("const selectedItems = []"), true);
+  assert.equal(body.includes("revokePendingMediaPreviews(selectedItems)"), true);
   assert.equal(body.includes("const nextPendingMediaItems = [...pendingMediaItems, ...selectedItems]"), true);
   assert.equal(body.includes("Math.min(selectedItems.length, 12)"), true);
   assert.equal(body.includes("repo 未指定の通常会話では private media として保存します"), true);

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -1495,6 +1495,7 @@ test("worker serves dashboard media add controls for iPhone-first upload", async
   const body = await response.text();
   assert.equal(body.includes("id=\"butler-media-button\""), true);
   assert.equal(body.includes("id=\"butler-media-input\""), true);
+  assert.equal(body.includes('id="butler-media-input" type="file" multiple hidden'), true);
   assert.equal(body.includes("accept=\"image/*\""), false);
   assert.equal(body.includes("/v2/media/upload"), true);
   assert.equal(body.includes("createImageBitmap"), true);
@@ -1507,6 +1508,10 @@ test("worker serves dashboard media add controls for iPhone-first upload", async
   assert.equal(body.includes("image.src = downloadHref"), true);
   assert.equal(body.includes("URL.createObjectURL"), true);
   assert.equal(body.includes("URL.revokeObjectURL"), true);
+  assert.equal(body.includes("const files = Array.from(mediaInput.files || [])"), true);
+  assert.equal(body.includes("for (const file of files)"), true);
+  assert.equal(body.includes("const nextPendingMediaItems = [...pendingMediaItems, ...selectedItems]"), true);
+  assert.equal(body.includes("Math.min(selectedItems.length, 12)"), true);
   assert.equal(body.includes("repo 未指定の通常会話では private media として保存します"), true);
   assert.equal(body.includes("mediaReferences"), true);
   assert.equal(body.includes("pendingSendRollbacks"), true);

--- a/worker.js
+++ b/worker.js
@@ -65767,7 +65767,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         <div class="pending-media" id="butler-pending-media" aria-live="polite"></div>
         <div class="composer-box">
           <button class="media-button" id="butler-media-button" type="button" aria-label="\u753B\u50CF\u3084\u30D5\u30A1\u30A4\u30EB\u3092\u8FFD\u52A0" title="\u753B\u50CF\u3084\u30D5\u30A1\u30A4\u30EB\u3092\u8FFD\u52A0">+</button>
-          <input id="butler-media-input" type="file" hidden>
+          <input id="butler-media-input" type="file" multiple hidden>
           <textarea id="butler-message" name="text" placeholder="Butler V2 \u306B\u30E1\u30C3\u30BB\u30FC\u30B8..." aria-label="Butler V2 \u306B\u30E1\u30C3\u30BB\u30FC\u30B8" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" enterkeyhint="send"></textarea>
           <button class="send-button" type="submit" aria-label="Butler \u306B\u9001\u4FE1">\u2191</button>
         </div>
@@ -66787,32 +66787,34 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
       if (mediaButton && mediaInput) {
         mediaButton.addEventListener("click", () => mediaInput.click());
         mediaInput.addEventListener("change", async () => {
-          const file = mediaInput.files && mediaInput.files[0];
+          const files = Array.from(mediaInput.files || []);
           mediaInput.value = "";
-          if (!file) return;
+          if (files.length === 0) return;
           try {
             mediaButton.disabled = true;
-            const preparedFile = await prepareUploadFile(file);
-            const previewUrl =
-              preparedFile && preparedFile.type && preparedFile.type.startsWith("image/") && typeof URL !== "undefined" && typeof URL.createObjectURL === "function"
-                ? URL.createObjectURL(preparedFile)
-                : "";
-            const nextPendingMediaItems = [
-              ...pendingMediaItems,
-              {
+            const selectedItems = [];
+            for (const file of files) {
+              const preparedFile = await prepareUploadFile(file);
+              const previewUrl =
+                preparedFile && preparedFile.type && preparedFile.type.startsWith("image/") && typeof URL !== "undefined" && typeof URL.createObjectURL === "function"
+                  ? URL.createObjectURL(preparedFile)
+                  : "";
+              selectedItems.push({
                 clientId: Date.now() + "_" + Math.random().toString(36).slice(2),
                 filename: preparedFile.name || file.name || "attachment",
                 previewUrl,
                 file: preparedFile
-              }
-            ];
+              });
+            }
+            const nextPendingMediaItems = [...pendingMediaItems, ...selectedItems];
             const retainedPendingMediaItems = nextPendingMediaItems.slice(-12);
             for (const dropped of nextPendingMediaItems.slice(0, Math.max(0, nextPendingMediaItems.length - 12))) {
               revokePendingMediaPreview(dropped);
             }
             pendingMediaItems = retainedPendingMediaItems;
             renderPendingMedia();
-            setStatus("\u6DFB\u4ED8\u3092\u9001\u4FE1\u5F85\u3061\u306B\u8FFD\u52A0\u3057\u307E\u3057\u305F\u3002repo \u672A\u6307\u5B9A\u306E\u901A\u5E38\u4F1A\u8A71\u3067\u306F private media \u3068\u3057\u3066\u4FDD\u5B58\u3057\u307E\u3059\u3002", { temporary: true });
+            const addedCount = Math.min(selectedItems.length, 12);
+            setStatus(String(addedCount) + "\u4EF6\u306E\u6DFB\u4ED8\u3092\u9001\u4FE1\u5F85\u3061\u306B\u8FFD\u52A0\u3057\u307E\u3057\u305F\u3002repo \u672A\u6307\u5B9A\u306E\u901A\u5E38\u4F1A\u8A71\u3067\u306F private media \u3068\u3057\u3066\u4FDD\u5B58\u3057\u307E\u3059\u3002", { temporary: true });
             textarea.focus({ preventScroll: true });
           } catch (error) {
             setStatus((error && error.message) || "\u6DFB\u4ED8\u306E\u4FDD\u5B58\u306B\u5931\u6557\u3057\u307E\u3057\u305F\u3002");

--- a/worker.js
+++ b/worker.js
@@ -66790,9 +66790,9 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           const files = Array.from(mediaInput.files || []);
           mediaInput.value = "";
           if (files.length === 0) return;
+          const selectedItems = [];
           try {
             mediaButton.disabled = true;
-            const selectedItems = [];
             for (const file of files) {
               const preparedFile = await prepareUploadFile(file);
               const previewUrl =
@@ -66817,6 +66817,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
             setStatus(String(addedCount) + "\u4EF6\u306E\u6DFB\u4ED8\u3092\u9001\u4FE1\u5F85\u3061\u306B\u8FFD\u52A0\u3057\u307E\u3057\u305F\u3002repo \u672A\u6307\u5B9A\u306E\u901A\u5E38\u4F1A\u8A71\u3067\u306F private media \u3068\u3057\u3066\u4FDD\u5B58\u3057\u307E\u3059\u3002", { temporary: true });
             textarea.focus({ preventScroll: true });
           } catch (error) {
+            revokePendingMediaPreviews(selectedItems);
             setStatus((error && error.message) || "\u6DFB\u4ED8\u306E\u4FDD\u5B58\u306B\u5931\u6557\u3057\u307E\u3057\u305F\u3002");
           } finally {
             mediaButton.disabled = false;


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #528 の巨大 UX baseline のうち、Dashboard Butler composer の添付体験を ChatGPT iOS 相当に近づける小スライスです。
- iPhone/PWA で複数ファイルを一括選択できるようにし、選択した複数添付をまとめて pending media に追加します。

## Satisfied Success Criteria

- `butler-media-input` に `multiple` を追加しました。
- file picker の `FileList` を `Array.from(mediaInput.files || [])` で扱い、複数ファイルを順に `prepareUploadFile()` へ通します。
- 既存 pending media と新規 selected items を結合し、既存上限の最後 12 件だけを保持します。
- 上限超過で落ちた preview object URL は既存 revoke 経路で破棄します。
- 複数ファイル選択中に一部成功後、一部失敗した場合も、その選択で作成済みの preview object URL を catch 経路で破棄します。
- 追加数を `N件の添付を送信待ちに追加しました` として短く表示します。
- Dashboard HTML test で `multiple` 属性、複数選択 loop、12件保持境界、失敗時の selected preview cleanup を確認しました。

## Unsatisfied Success Criteria

- Issue #528 全体の debug/ops 隔離、passkey 非常設、通常チャット主役化、WebSocket/PWA復帰改善はこの PR では完了しません。
- 実機 iPhone/PWA の file picker で複数画像/ファイルを選択する live E2E は未実施です。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #528
- Implementing Success Criteria: 複数添付を一括選択でき、12枚までなら 12 回プラスボタンを押させない。
- Explicit Non-goals: debug/ops surface の再配置、passkey/deploy authority、WebSocket reconnect、履歴復帰、media upload backend の再設計は変更しない。
- Expected touched files/routes/workflows: `src/worker/runtime.js`, `test/worker.test.js`, generated `worker.js`
- Affected Issues: Issue #528, related Issue #498
- Affected PRs: なし
- Affected workflows: GitHub Actions workflow 定義は未変更
- Affected runtime/operator surfaces: Dashboard Butler composer media input and pending media state
- What may break if we patch narrowly: 複数ファイルのうち途中で `prepareUploadFile()` が失敗すると、今回選択分全体が追加されない。既存の安全側失敗挙動を維持し、成功済み selected preview URL は catch で revoke する。
- Unknowns to investigate before coding: iOS PWA file picker の複数選択 UI が file type によってどう見えるか。
- Validation needed: `node --test test/worker.test.js`, `npm run build:worker`, `npm run check:generated-worker`, `git diff --check`
- Stop condition: 実機 file picker UX や upload queue/cancel UI が必要なら別 Issue / PR に分ける。

## File / Line Hypotheses

- file: `src/worker/runtime.js`
  - hypothesis: media input が単一ファイル前提なので、iPhone で複数スクショを選ぶ時に 12 回プラスボタンを押す UX になる。
  - risk if changed narrowly: 複数選択時に pendingMediaItems の上限処理や preview revoke が漏れる。
  - validation: selected items を既存 pending に結合し、最後 12 件だけ残す文字列検証を追加する。
  - related Issue: Issue #528

## Hypothesis Retrospective

- expected: `multiple` と FileList loop だけで既存 upload/pending pipeline を再利用できる。
- actual: `selectedItems` を作って既存 `pendingMediaItems` に結合する形で実装した。review 指摘を受け、一部成功後の一部失敗でも selected preview URL を `revokePendingMediaPreviews(selectedItems)` で破棄するようにした。
- mismatch: 実機 PWA file picker の体験は未確認。
- lesson: ChatGPT iOS 相当の composer では、添付は1個ずつではなく一括選択できるのが最低ライン。
- should become RAG candidate: no

## Verification Evidence

- Unit: `node --test test/worker.test.js` passed, 205 tests.
- Integration: `npm run build:worker` passed.
- Integration: `npm run check:generated-worker` passed.
- Static: `git diff --check` passed.
- E2E: 未実施。実機 iPhone/PWA multiple file picker live evidence は残っています。
- Evidence path/link: `test/worker.test.js`

## Butler Completion Contract

- Owner goal: Dashboard Butler composer で複数添付を一括選択できるようにする。
- Butler entrypoint: Dashboard Butler composer media button
- Action Schema exposure: 不要。この PR は Action Schema を変更しない。
- Runtime path: `/dashboard` inline composer media input and pending media JS
- Runner/runtime truth: local worker test が served dashboard HTML の複数添付 path を検証
- Authority boundary: 未変更。新しい high-risk authority は追加しない。
- E2E evidence: 未実施。実機 iPhone/PWA multiple file picker live evidence は残ギャップ。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 未実施。merge 後に通常 production deploy 判断が必要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。

## Related Constitution Rules

- Butler Completion Gate
- Butler-First Operating Principle
- Conversation UX Contract
- Evidence Discipline

## Out-of-scope but NOT implemented

- Issue #528 全体完了
- debug/ops surface の再配置
- passkey/deploy authority UX
- upload queue/cancel UI

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #528
- Execution ID: local-codex-2026-05-27-issue-528-multiple-attachments
- Goal: dashboard-multiple-attachments
