### PR TITLE
Issue #585 render dashboard markdown links

### DIFF
--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -11398,7 +11398,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         const source = String(text || "");
         const backtick = String.fromCharCode(96);
         const tokenPattern = new RegExp(
-          "(https?:\\\\/\\\\/[^\\\\s<>\\\"'\\\\)\\\\]）】』」〉》、。，．,！？]+)|\\\\*\\\\*([\\\\s\\\\S]+?)\\\\*\\\\*|" + backtick + "([^" + backtick + "]+)" + backtick,
+          "\\\\[([^\\\\]\\\\n]+)\\\\]\\\\((https?:\\\\/\\\\/[^\\\\s<>\\\"']+)\\\\)|(https?:\\\\/\\\\/[^\\\\s<>\\\"'\\\\)\\\\]）】』」〉》、。，．,！？]+)|\\\\*\\\\*([\\\\s\\\\S]+?)\\\\*\\\\*|" + backtick + "([^" + backtick + "]+)" + backtick,
           "g"
         );
         let cursor = 0;
@@ -11406,8 +11406,21 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           if (match.index > cursor) {
             container.appendChild(document.createTextNode(source.slice(cursor, match.index)));
           }
-          if (match[1]) {
-            const linkToken = splitTrailingLinkPunctuation(match[1]);
+          if (match[1] && match[2]) {
+            const linkToken = splitTrailingLinkPunctuation(match[2]);
+            const href = linkToken.href;
+            const link = document.createElement("a");
+            link.className = "chat-link";
+            link.href = href;
+            link.textContent = match[1];
+            link.target = "_blank";
+            link.rel = "noreferrer";
+            container.appendChild(link);
+            if (linkToken.trailing) {
+              container.appendChild(document.createTextNode(linkToken.trailing));
+            }
+          } else if (match[3]) {
+            const linkToken = splitTrailingLinkPunctuation(match[3]);
             const href = linkToken.href;
             const link = document.createElement("a");
             link.className = "chat-link";
@@ -11419,13 +11432,13 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
             if (linkToken.trailing) {
               container.appendChild(document.createTextNode(linkToken.trailing));
             }
-          } else if (match[2]) {
+          } else if (match[4]) {
             const strong = document.createElement("strong");
-            renderInlineMarkdown(strong, match[2]);
+            renderInlineMarkdown(strong, match[4]);
             container.appendChild(strong);
-          } else if (match[3]) {
+          } else if (match[5]) {
             const code = document.createElement("code");
-            code.textContent = match[3];
+            code.textContent = match[5];
             container.appendChild(code);
           }
           cursor = match.index + match[0].length;

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -1395,17 +1395,17 @@ test("served dashboard inline chat renderer executes decode, link, wrap, and cop
   const markdownLinkContainer = document.createElement("div");
   helpers.renderMessageText(
     markdownLinkContainer,
-    "[Deploy approval を開く](https://vtdd-v2-mvp.polished-tree-da7c.workers.dev/v2/approval/passkey/operator?mode=deploy&repositoryInput=marushu%2Fvtdd-v2-p&phase=execution&issueNumber=575&actionType=deploy_production&highRiskKind=deploy_production)"
+    "[GitHub Actions を開く](https://github.com/example/repo/actions/runs/1234567890)"
   );
   const markdownLinks = markdownLinkContainer.querySelectorAll("a");
   assert.equal(markdownLinks.length, 1);
   assert.equal(markdownLinks[0].className, "chat-link");
-  assert.equal(markdownLinks[0].textContent, "Deploy approval を開く");
+  assert.equal(markdownLinks[0].textContent, "GitHub Actions を開く");
   assert.equal(
     markdownLinks[0].href,
-    "https://vtdd-v2-mvp.polished-tree-da7c.workers.dev/v2/approval/passkey/operator?mode=deploy&repositoryInput=marushu%2Fvtdd-v2-p&phase=execution&issueNumber=575&actionType=deploy_production&highRiskKind=deploy_production"
+    "https://github.com/example/repo/actions/runs/1234567890"
   );
-  assert.equal(markdownLinkContainer.textContent, "Deploy approval を開く");
+  assert.equal(markdownLinkContainer.textContent, "GitHub Actions を開く");
 
   const parenthesizedLinkContainer = document.createElement("div");
   helpers.renderMessageText(parenthesizedLinkContainer, "開いて（https://example.com/path?x=1）");

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -1392,6 +1392,21 @@ test("served dashboard inline chat renderer executes decode, link, wrap, and cop
   assert.equal(links[0].className, "chat-link");
   assert.equal(links[0].href.startsWith("https://example.com/"), true);
 
+  const markdownLinkContainer = document.createElement("div");
+  helpers.renderMessageText(
+    markdownLinkContainer,
+    "[Deploy approval を開く](https://vtdd-v2-mvp.polished-tree-da7c.workers.dev/v2/approval/passkey/operator?mode=deploy&repositoryInput=marushu%2Fvtdd-v2-p&phase=execution&issueNumber=575&actionType=deploy_production&highRiskKind=deploy_production)"
+  );
+  const markdownLinks = markdownLinkContainer.querySelectorAll("a");
+  assert.equal(markdownLinks.length, 1);
+  assert.equal(markdownLinks[0].className, "chat-link");
+  assert.equal(markdownLinks[0].textContent, "Deploy approval を開く");
+  assert.equal(
+    markdownLinks[0].href,
+    "https://vtdd-v2-mvp.polished-tree-da7c.workers.dev/v2/approval/passkey/operator?mode=deploy&repositoryInput=marushu%2Fvtdd-v2-p&phase=execution&issueNumber=575&actionType=deploy_production&highRiskKind=deploy_production"
+  );
+  assert.equal(markdownLinkContainer.textContent, "Deploy approval を開く");
+
   const parenthesizedLinkContainer = document.createElement("div");
   helpers.renderMessageText(parenthesizedLinkContainer, "開いて（https://example.com/path?x=1）");
   const parenthesizedLinks = parenthesizedLinkContainer.querySelectorAll("a");

--- a/worker.js
+++ b/worker.js
@@ -66276,7 +66276,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         const source = String(text || "");
         const backtick = String.fromCharCode(96);
         const tokenPattern = new RegExp(
-          "(https?:\\\\/\\\\/[^\\\\s<>\\"'\\\\)\\\\]\uFF09\u3011\u300F\u300D\u3009\u300B\u3001\u3002\uFF0C\uFF0E,\uFF01\uFF1F]+)|\\\\*\\\\*([\\\\s\\\\S]+?)\\\\*\\\\*|" + backtick + "([^" + backtick + "]+)" + backtick,
+          "\\\\[([^\\\\]\\\\n]+)\\\\]\\\\((https?:\\\\/\\\\/[^\\\\s<>\\"']+)\\\\)|(https?:\\\\/\\\\/[^\\\\s<>\\"'\\\\)\\\\]\uFF09\u3011\u300F\u300D\u3009\u300B\u3001\u3002\uFF0C\uFF0E,\uFF01\uFF1F]+)|\\\\*\\\\*([\\\\s\\\\S]+?)\\\\*\\\\*|" + backtick + "([^" + backtick + "]+)" + backtick,
           "g"
         );
         let cursor = 0;
@@ -66284,8 +66284,21 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           if (match.index > cursor) {
             container.appendChild(document.createTextNode(source.slice(cursor, match.index)));
           }
-          if (match[1]) {
-            const linkToken = splitTrailingLinkPunctuation(match[1]);
+          if (match[1] && match[2]) {
+            const linkToken = splitTrailingLinkPunctuation(match[2]);
+            const href = linkToken.href;
+            const link = document.createElement("a");
+            link.className = "chat-link";
+            link.href = href;
+            link.textContent = match[1];
+            link.target = "_blank";
+            link.rel = "noreferrer";
+            container.appendChild(link);
+            if (linkToken.trailing) {
+              container.appendChild(document.createTextNode(linkToken.trailing));
+            }
+          } else if (match[3]) {
+            const linkToken = splitTrailingLinkPunctuation(match[3]);
             const href = linkToken.href;
             const link = document.createElement("a");
             link.className = "chat-link";
@@ -66297,13 +66310,13 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
             if (linkToken.trailing) {
               container.appendChild(document.createTextNode(linkToken.trailing));
             }
-          } else if (match[2]) {
+          } else if (match[4]) {
             const strong = document.createElement("strong");
-            renderInlineMarkdown(strong, match[2]);
+            renderInlineMarkdown(strong, match[4]);
             container.appendChild(strong);
-          } else if (match[3]) {
+          } else if (match[5]) {
             const code = document.createElement("code");
-            code.textContent = match[3];
+            code.textContent = match[5];
             container.appendChild(code);
           }
           cursor = match.index + match[0].length;


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #585 のリンク操作改善のうち、Dashboard Butler chat が返す markdown link `[label](https://...)` を通常の tappable link として描画できるようにします。
- 既存の raw URL 自動リンク、末尾カッコ除外、URL encode された末尾 `)` / `）` 除外、copy/render helper を壊さない範囲に限定しています。

## Satisfied Success Criteria

- markdown link `[GitHub Actions を開く](https://github.com/example/repo/actions/runs/1234567890)` を `a.chat-link` として描画します。
- link text は label のみになり、href は markdown link URL になります。
- raw URL 自動リンクの既存挙動を維持します。
- 末尾カッコ除外の既存挙動を維持します。
- URL encode された `)` / `）` の除外挙動を維持します。
- test fixture から owner 固有 runtime URL / passkey operator URL を外し、中立の GitHub URL に置き換えました。

## Unsatisfied Success Criteria

- 実機 iPhone/PWA で「1回タップで遷移する」live E2E は未実施です。
- message action reveal と link tap の競合を browser DOM event として実行する E2E は未実施です。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #585
- Implementing Success Criteria: markdown link を chat-link として描画し、既存 raw URL / punctuation handling を退行させない。
- Explicit Non-goals: 外部ブラウザ/PWA内ブラウザのポリシー、passkey approval、WebSocket reconnect、末尾 punctuation parser の全面再設計は変更しない。
- Expected touched files/routes/workflows: `src/worker/runtime.js`, `test/worker.test.js`, generated `worker.js`
- Affected Issues: Issue #585, related Issue #575, Issue #577, Issue #580
- Affected PRs: なし
- Affected workflows: GitHub Actions workflow 定義は未変更
- Affected runtime/operator surfaces: Dashboard Butler chat message renderer
- What may break if we patch narrowly: markdown link parser が raw URL parser と capture group を共有するため、bold/code/raw URL の既存 capture index を壊すリスクがある。
- Unknowns to investigate before coding: iPhone/PWA の actual tap propagation が article action reveal に吸われていないか。
- Validation needed: `node --test test/worker.test.js`, `npm run build:worker`, `npm run check:generated-worker`, `git diff --check`
- Stop condition: link tap propagation の runtime bug が残る場合は、DOM event E2E を追加するか別 PR で action reveal handler を修正する。

## File / Line Hypotheses

- file: `src/worker/runtime.js`
  - hypothesis: Butler/runner が markdown link を返すと、既存 renderer は `[label](url)` を link として扱えず、owner はURLを直接開きづらい。
  - risk if changed narrowly: regex capture group 変更で bold/code/raw URL の描画が壊れる。
  - validation: served dashboard inline helper test で markdown link / raw URL / punctuation / copy を同じ test 内で確認する。
  - related Issue: Issue #585

## Hypothesis Retrospective

- expected: markdown link support can be added inside `renderInlineMarkdown()` without changing action reveal behavior.
- actual: markdown link branch を追加し、raw URL / strong / code の capture groups を更新した。
- mismatch: 実機 tap propagation は未確認。この PR は markdown link rendering の部分スライス。
- lesson: Butler が自然文で「詳細を開く」リンクを返すなら、raw URL だけでなく markdown link も chat renderer で扱う必要がある。
- should become RAG candidate: no

## Verification Evidence

- Unit: `node --test test/worker.test.js` passed, 205 tests.
- Integration: `npm run build:worker` passed.
- Integration: `npm run check:generated-worker` passed.
- Static: `git diff --check` passed.
- E2E: 未実施。実機 iPhone/PWA 1-tap live evidence は残っています。
- Evidence path/link: `test/worker.test.js`

## Butler Completion Contract

- Owner goal: Dashboard Butler chat のリンクを自然な chat link として1回で開けるようにする。
- Butler entrypoint: Dashboard Butler chat message renderer
- Action Schema exposure: 不要。この PR は Action Schema を変更しない。
- Runtime path: `/dashboard` inline message renderer
- Runner/runtime truth: local worker test が served dashboard inline helper の markdown link rendering を検証
- Authority boundary: 未変更。新しい high-risk authority は追加しない。
- E2E evidence: 未実施。実機 iPhone/PWA tap propagation live evidence は残ギャップ。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 未実施。merge 後に通常 production deploy 判断が必要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。

## Related Constitution Rules

- Butler Completion Gate
- Conversation UX Contract
- Evidence Discipline
- Drift Stop Protocol

## Out-of-scope but NOT implemented

- passkey approval link policy
- 外部ブラウザ / PWA 内遷移ポリシー
- article action reveal handler の全面変更

## Extra changes (if any)

- Test fixture から owner 固有 runtime URL を除去しました。

<!-- VTDD metadata -->
- Issue: Issue #585
- Execution ID: local-codex-2026-05-27-issue-585
- Goal: dashboard-markdown-link-rendering
