### PR TITLE
Fix deploy-scoped passkey operator fallback

### DIFF
--- a/src/core/passkey-operator-page.js
+++ b/src/core/passkey-operator-page.js
@@ -1167,7 +1167,7 @@ export function resolvePasskeyOperatorMode(input = {}) {
   if (!actionType && !highRiskKind) {
     return "full";
   }
-  if (actionType === "deploy_production" || highRiskKind === "deploy_production") {
+  if (isDeployProductionToken(actionType) || isDeployProductionToken(highRiskKind)) {
     return "deploy";
   }
   if (actionType === "merge" || highRiskKind === "pull_merge") {
@@ -1292,6 +1292,10 @@ function normalizeOperatorToken(value) {
   return String(value || "")
     .trim()
     .toLowerCase();
+}
+
+function isDeployProductionToken(value) {
+  return value === "deploy_production" || value === "production_deploy" || value === "deploy";
 }
 
 function sanitizePasskeyDashboardReturnPath(value) {

--- a/test/passkey-operator-page.test.js
+++ b/test/passkey-operator-page.test.js
@@ -178,6 +178,32 @@ test("passkey operator page focuses deploy mode on deploy approval and dispatch 
   assert.equal(html.includes('passkey approval accepted. production deploy request...'), true);
 });
 
+test("passkey operator page treats legacy deploy tokens as deploy-only scope", () => {
+  const html = renderPasskeyOperatorPage({
+    repositoryInput: "marushu/vtdd-v2-p",
+    issueNumber: 528,
+    phase: "execution",
+    actionType: "deploy",
+    highRiskKind: "production_deploy"
+  });
+
+  assert.equal(
+    html.includes('<section data-operator-section="approval" data-owner-flow="one-tap-deploy">'),
+    true
+  );
+  assert.equal(html.includes('<section data-operator-section="production-deploy">'), true);
+  assert.equal(html.includes('<section data-operator-section="registration" hidden>'), true);
+  assert.equal(html.includes('<section data-operator-section="pr-merge" hidden>'), true);
+  assert.equal(html.includes('<section data-operator-section="issue-close" hidden>'), true);
+  assert.equal(html.includes('<section data-operator-section="github-app-secret-sync" hidden>'), true);
+  assert.equal(html.includes('<section data-operator-section="github-actions-secret-sync" hidden>'), true);
+  assert.equal(html.includes('<section data-operator-section="gateway-bearer-vault" hidden>'), true);
+  assert.equal(html.includes('<section data-operator-section="vps-runner-admin" hidden>'), true);
+  assert.equal(html.includes('id="action-type-input" value="deploy_production"'), true);
+  assert.equal(html.includes('id="risk-kind-input" value="deploy_production"'), true);
+  assert.equal(html.includes("Action: deploy_production / deploy_production"), true);
+});
+
 test("passkey operator page blocks approval and deploy before repositoryInput is present", () => {
   const html = renderPasskeyOperatorPage({
     operatorMode: "deploy",

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -6937,6 +6937,30 @@ test("worker keeps explicit non-dashboard operator modes repo-scoped even with d
   assert.equal(html.includes("repo / Issue / PR scope は使いません"), false);
 });
 
+test("worker serves legacy deploy operator links as deploy-only scope", async () => {
+  const response = await worker.fetch(
+    new Request(
+      "https://example.com/v2/approval/passkey/operator?repositoryInput=marushu%2Fvtdd-v2-p&issueNumber=528&phase=execution&actionType=deploy&highRiskKind=production_deploy"
+    ),
+    gatewayAuthEnv
+  );
+
+  assert.equal(response.status, 200);
+  const html = await response.text();
+  assert.equal(html.includes('const operatorMode = "deploy"'), true);
+  assert.equal(html.includes('id="action-type-input" value="deploy_production"'), true);
+  assert.equal(html.includes('id="risk-kind-input" value="deploy_production"'), true);
+  assert.equal(
+    html.includes('<section data-operator-section="approval" data-owner-flow="one-tap-deploy">'),
+    true
+  );
+  assert.equal(html.includes('<section data-operator-section="production-deploy">'), true);
+  assert.equal(html.includes('<section data-operator-section="registration" hidden>'), true);
+  assert.equal(html.includes('<section data-operator-section="github-app-secret-sync" hidden>'), true);
+  assert.equal(html.includes('<section data-operator-section="pr-merge" hidden>'), true);
+  assert.equal(html.includes('<section data-operator-section="issue-close" hidden>'), true);
+});
+
 test("worker serves issue close operator mode without falling back to PR merge UI", async () => {
   const response = await worker.fetch(
     new Request(

--- a/worker.js
+++ b/worker.js
@@ -28381,7 +28381,7 @@ function resolvePasskeyOperatorMode(input = {}) {
   if (!actionType && !highRiskKind) {
     return "full";
   }
-  if (actionType === "deploy_production" || highRiskKind === "deploy_production") {
+  if (isDeployProductionToken(actionType) || isDeployProductionToken(highRiskKind)) {
     return "deploy";
   }
   if (actionType === "merge" || highRiskKind === "pull_merge") {
@@ -28495,6 +28495,9 @@ function defaultHighRiskKindForMode(operatorMode) {
 }
 function normalizeOperatorToken(value) {
   return String(value || "").trim().toLowerCase();
+}
+function isDeployProductionToken(value) {
+  return value === "deploy_production" || value === "production_deploy" || value === "deploy";
 }
 function sanitizePasskeyDashboardReturnPath(value) {
   const normalized = String(value || "").trim() || "/dashboard";


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #528 の部分進捗。deploy 用 passkey operator URL が旧/誤 token を含んでも full maintenance view に落ちず、deploy 承認と production deploy dispatch だけを可視化する。

## Satisfied Success Criteria

- Passkey / deploy / high-risk 導線で action scope が deploy 系の場合、operator 表示を deploy 専用に絞る。
- 旧/誤 token actionType=deploy または highRiskKind=production_deploy を受けても、表示値と送信 scope は deploy_production / deploy_production に補正する。
- 通常の full maintenance operator は mode=full または未スコープ時だけ残す。

## Unsatisfied Success Criteria

- Issue #528 全体の ChatGPT iOS 相当 UX は未完了。
- Dashboard 添付、復帰、長文表示、PWA live E2E、通常チャット全体の UX 完了はこの PR では主張しない。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #528
- Implementing Success Criteria: Passkey / deploy / destructive / high-risk 導線は通常チャット topbar に常設せず、必要な action scope が明示された時だけ説明付きで到達できる。今回は deploy operator の scoped view fallback のみ。
- Explicit Non-goals: production deploy 実行、credential mutation、permission mutation、secret sync / PR merge / Issue close / VPS admin の挙動変更、Issue close はしない。
- Expected touched files/routes/workflows: src/core/passkey-operator-page.js, test/passkey-operator-page.test.js, test/worker.test.js, worker.js
- Affected Issues: Issue #528 の部分進捗。Issue #355/#417 の完了は主張しない。
- Affected PRs: PR #572 の後続小修正。既存 PR #591 とは別スコープ。
- Affected workflows: GitHub Actions workflow は未変更。deploy workflow dispatch は未実行。
- Affected runtime/operator surfaces: /v2/approval/passkey/operator の HTML 表示モード推論。
- What may break if we patch narrowly: 旧 token を full に落とすと、deploy approval だけのつもりで secret sync / merge / issue close / VPS admin が同一画面に露出する。
- Unknowns to investigate before coding: なし。既存 render/worker tests で mode inference と section visibility を確認済み。
- Validation needed: node --test test/passkey-operator-page.test.js; node --test test/worker.test.js; npm run build:worker; npm run check:generated-worker; git diff --check; manual render visible section probe.
- Stop condition: deploy 実行や authority boundary 変更が必要になった場合は停止し、passkey approval を要求する。

## File / Line Hypotheses

- file: src/core/passkey-operator-page.js
  - hypothesis: resolvePasskeyOperatorMode が deploy_production 以外の deploy 系 token を full とみなし、全 operator section 表示に落ちる。
  - risk if changed narrowly: deploy 以外の secret sync / merge / issue close の mode 推論を壊す。
  - validation: scoped unit test と worker route test で deploy-only section visibility と corrected scope fields を確認。
  - related Issue: #528

## Hypothesis Retrospective

- expected: actionType=deploy / highRiskKind=production_deploy でも visible sections は approval と production-deploy のみに限定される。
- actual: manual render probe で visible=[approval, production-deploy]、action/risk fields は deploy_production に補正。
- mismatch: なし。
- lesson: deploy operator URL は mode パラメータだけに依存せず、scope token からも安全側に推論する必要がある。
- should become RAG candidate: はい。operator URL は scope token から最小画面へ収束させる。

## Verification Evidence

- Unit: node --test test/passkey-operator-page.test.js: 27/27 pass
- Integration: node --test test/worker.test.js: 209/209 pass; npm run build:worker pass; npm run check:generated-worker pass; git diff --check pass
- E2E: Manual render probe: legacy deploy URL input produced visible sections [approval, production-deploy] and corrected deploy_production fields. Browser/live E2E は未実施。
- Manual: No production deploy executed.
- Evidence path/link: PR body verification evidence; tests in test/passkey-operator-page.test.js and test/worker.test.js

## Butler Completion Contract

- Owner goal: deploy passkey operator を開いた時、必要な承認/反映操作だけを見せ、full maintenance operator を露出しない。
- Butler entrypoint: /v2/approval/passkey/operator?repositoryInput=...&actionType=deploy&highRiskKind=production_deploy または deploy_production scope
- Action Schema exposure: 未変更。既存 Action Schema の deploy_production 境界を補助する UI fallback。
- Runtime path: Worker route /v2/approval/passkey/operator -> renderPasskeyOperatorPage -> resolvePasskeyOperatorMode
- Runner/runtime truth: worker route test で operatorMode=deploy と補正済み field を確認。
- Authority boundary: 未変更。deploy execution は real passkey approval grant scoped to deploy_production が必要。
- E2E evidence: 未接続。今回は operator page route/render regression。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 未実施。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。

## Related Constitution Rules

- AGENTS.md Drift Stop Protocol
- AGENTS.md Authority Boundary
- AGENTS.md Evidence Discipline
- AGENTS.md Chief Butler Operating Principle

## Out-of-scope but NOT implemented

- production deploy 実行。
- Dashboard chat UX 全体の完了。
- Issue #528 close。

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #528
- Execution ID: mac-codex-2026-05-28-passkey-operator-deploy-focus
- Goal: Fix deploy scoped passkey operator fallback
