### PR TITLE
Add dashboard-wide utility navigation

### DIFF
--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -7242,7 +7242,7 @@ export function buildDashboardWebPushPayload(event) {
     title,
     body: body || "Dashboard Butler の通知です。",
     tag: `vtdd-${record.kind || "dashboard"}-${record.runId || record.id || "event"}`.slice(0, 120),
-    url: record.runUrl || "/dashboard/notifications"
+    url: "/dashboard/notifications"
   };
 }
 
@@ -9657,6 +9657,42 @@ function renderDashboardNotificationEvent(event) {
           </div>`;
 }
 
+function collapseDashboardNotificationEvents(events = []) {
+  const latestByKey = new Map();
+  for (const event of Array.isArray(events) ? events : []) {
+    const record = normalizeDashboardEventRecord(event);
+    const key = dashboardNotificationCollapseKey(record);
+    const existing = latestByKey.get(key);
+    if (!existing || compareDashboardEventRecency(record, existing) > 0) {
+      latestByKey.set(key, record);
+    }
+  }
+  return [...latestByKey.values()].sort((a, b) => compareDashboardEventRecency(b, a));
+}
+
+function dashboardNotificationCollapseKey(event) {
+  const record = normalizeDashboardEventRecord(event);
+  const repository = normalizeCanonicalRepositoryInput(record.repository) || "repo-unknown";
+  const workflowName = normalizeDashboardEventText(record.workflowName || record.kind) || "workflow-unknown";
+  if (record.pullNumber) {
+    return `${repository}:pr:${record.pullNumber}:${workflowName}`;
+  }
+  const branch = normalizeDashboardEventText(record.headBranch);
+  const sha = normalizeDashboardEventText(record.headSha).slice(0, 12);
+  return `${repository}:workflow:${workflowName}:${branch || sha || record.runId || "unknown"}`;
+}
+
+function compareDashboardEventRecency(left, right) {
+  const leftTime = new Date(normalizeDashboardEventText(left?.updatedAt || left?.createdAt)).getTime();
+  const rightTime = new Date(normalizeDashboardEventText(right?.updatedAt || right?.createdAt)).getTime();
+  const normalizedLeft = Number.isNaN(leftTime) ? 0 : leftTime;
+  const normalizedRight = Number.isNaN(rightTime) ? 0 : rightTime;
+  if (normalizedLeft !== normalizedRight) {
+    return normalizedLeft - normalizedRight;
+  }
+  return String(left?.runId || left?.id || "").localeCompare(String(right?.runId || right?.id || ""));
+}
+
 function buildDashboardEventDisplayTitle(event, { workflowName, conclusion } = {}) {
   const record = normalizeDashboardEventRecord(event);
   const statusLabel = dashboardPushStatusLabel(record);
@@ -9915,6 +9951,7 @@ async function renderDashboardNotificationsPage({ runtimeOrigin, dashboardEventS
     since: recentSince,
     limit: 20
   });
+  const visibleRecentEvents = collapseDashboardNotificationEvents(recentEvents);
   const publicKey = normalizeDashboardEventText(env?.[WEB_PUSH_PUBLIC_KEY_ENV]);
   return renderDashboardUtilityPage({
     title: "通知センター",
@@ -9924,7 +9961,7 @@ async function renderDashboardNotificationsPage({ runtimeOrigin, dashboardEventS
       <div class="grid single">
         <section class="lane">
           <div class="lane-title"><h2>最新通知</h2><span class="pill">直近5分</span></div>
-          ${recentEvents.length > 0 ? recentEvents.map((event) => renderDashboardNotificationEvent(event)).join("") : `<p class="muted">直近5分の通知はありません。</p>`}
+          ${visibleRecentEvents.length > 0 ? visibleRecentEvents.map((event) => renderDashboardNotificationEvent(event)).join("") : `<p class="muted">直近5分の通知はありません。</p>`}
         </section>
       </div>
       <div class="grid single">
@@ -10378,7 +10415,24 @@ function summarizeObjectValue(value) {
   return String(value);
 }
 
+function renderDashboardUtilityNavLinks() {
+  const items = [
+    ["Dashboard", "/dashboard"],
+    ["通知センター", "/dashboard/notifications"],
+    ["GitHub truth", "/dashboard/github-truth"],
+    ["Startup preflight", "/dashboard/preflight"],
+    ["Execution progress", "/dashboard/progress"],
+    ["VPS runner", "/dashboard/vps-runner"],
+    ["Operational RAG", "/dashboard/memory"],
+    ["Self parity", "/dashboard/self-parity"]
+  ];
+  return items
+    .map(([label, href]) => `<a class="dashboard-nav-link" href="${escapeDashboardHtml(href)}">${escapeDashboardHtml(label)}</a>`)
+    .join("");
+}
+
 function renderDashboardUtilityPage({ title, subtitle, backHref, body }) {
+  const navLinks = renderDashboardUtilityNavLinks();
   return `<!doctype html>
 <html lang="ja">
 <head>
@@ -10393,13 +10447,29 @@ function renderDashboardUtilityPage({ title, subtitle, backHref, body }) {
     * { box-sizing: border-box; }
     html, body { max-width: 100%; overflow-x: hidden; }
     body { margin: 0; background: var(--bg); color: var(--text); }
-    main { width: min(1120px, 100%); margin: 0 auto; padding: 16px; }
+    main { width: min(1280px, 100%); margin: 0 auto; padding: 16px; }
     header { display: flex; justify-content: space-between; align-items: center; gap: 12px; margin-bottom: 18px; }
     h1 { font-size: 24px; margin: 0 0 4px; }
     h2 { font-size: 18px; margin: 0; }
     p { line-height: 1.6; margin: 0 0 10px; }
     a { color: inherit; text-underline-offset: 4px; }
-    .back, .actions a, .dashboard-action { display: inline-flex; min-height: 38px; align-items: center; justify-content: center; border: 1px solid var(--border); border-radius: 999px; padding: 6px 12px; background: var(--soft); color: var(--text); text-decoration: none; font: inherit; font-weight: 750; }
+    .back, .actions a, .dashboard-action, .menu-button { display: inline-flex; min-height: 38px; align-items: center; justify-content: center; border: 1px solid var(--border); border-radius: 999px; padding: 6px 12px; background: var(--soft); color: var(--text); text-decoration: none; font: inherit; font-weight: 750; }
+    .menu-button { width: 42px; height: 42px; padding: 0; font-size: 22px; cursor: pointer; flex: 0 0 auto; }
+    .utility-shell { display: grid; grid-template-columns: 240px minmax(0, 1fr); gap: 24px; align-items: start; }
+    .utility-content { min-width: 0; }
+    .utility-title-row { display: flex; align-items: center; gap: 12px; min-width: 0; }
+    .desktop-nav { position: sticky; top: 16px; display: grid; gap: 8px; border: 1px solid var(--border); border-radius: 18px; background: var(--panel); padding: 12px; }
+    .desktop-nav-title { color: var(--muted); font-size: 12px; font-weight: 850; letter-spacing: .08em; text-transform: uppercase; padding: 4px 8px 8px; }
+    .dashboard-nav-link { display: flex; align-items: center; min-height: 38px; border-radius: 10px; padding: 8px 10px; color: var(--text); text-decoration: none; font-weight: 750; }
+    .dashboard-nav-link:hover, .dashboard-nav-link:focus-visible { background: var(--soft); outline: none; }
+    .dashboard-nav-toggle { position: fixed; width: 1px; height: 1px; opacity: 0; pointer-events: none; }
+    .dashboard-nav-backdrop, .dashboard-nav-drawer { display: none; }
+    .dashboard-nav-backdrop { position: fixed; inset: 0; z-index: 20; background: rgba(0, 0, 0, .36); backdrop-filter: blur(2px); }
+    .dashboard-nav-drawer { position: fixed; inset: 0 auto 0 0; z-index: 21; width: min(86vw, 360px); overflow: auto; padding: max(16px, env(safe-area-inset-top)) 14px max(18px, env(safe-area-inset-bottom)); border-right: 1px solid var(--border); background: var(--panel); box-shadow: 18px 0 60px rgba(0, 0, 0, .22); }
+    .dashboard-nav-toggle:checked ~ .dashboard-nav-backdrop, .dashboard-nav-toggle:checked ~ .dashboard-nav-drawer { display: block; }
+    .drawer-header { display: flex; justify-content: space-between; align-items: center; gap: 12px; margin-bottom: 12px; }
+    .drawer-header strong { display: block; }
+    .drawer-nav { display: grid; gap: 8px; }
     .dashboard-action:disabled { opacity: .45; }
     .hero, .lane, .notice { border: 1px solid var(--border); border-radius: 16px; background: var(--panel); padding: 14px; margin-bottom: 14px; }
     .actions { display: flex; flex-wrap: wrap; gap: 8px; }
@@ -10426,21 +10496,50 @@ function renderDashboardUtilityPage({ title, subtitle, backHref, body }) {
     @media (max-width: 760px) {
       main { padding: 12px; }
       header { align-items: flex-start; }
+      .utility-shell { display: block; }
+      .desktop-nav { display: none; }
+      .back { display: none; }
       .grid { grid-template-columns: minmax(0, 1fr); }
       .summary-list div { grid-template-columns: minmax(0, 1fr); }
+    }
+    @media (min-width: 761px) {
+      .utility-title-row .menu-button { display: none; }
     }
   </style>
 </head>
 <body>
   <main>
-    <header>
-      <div>
-        <h1>${escapeDashboardHtml(title)}</h1>
-        <p class="muted">${escapeDashboardHtml(subtitle || "")}</p>
+    <input class="dashboard-nav-toggle" type="checkbox" id="dashboard-nav-toggle" aria-hidden="true">
+    <label class="dashboard-nav-backdrop" for="dashboard-nav-toggle" aria-label="メニューを閉じる"></label>
+    <aside class="dashboard-nav-drawer" aria-label="Dashboard メニュー">
+      <div class="drawer-header">
+        <span>
+          <span class="desktop-nav-title">Dashboard</span>
+          <strong>メニュー</strong>
+        </span>
+        <label class="menu-button" for="dashboard-nav-toggle" aria-label="メニューを閉じる">×</label>
       </div>
-      <a class="back" href="${escapeDashboardHtml(backHref || "/dashboard")}">Dashboard</a>
-    </header>
-    ${body}
+      <nav class="drawer-nav" aria-label="Dashboard メニュー項目">${navLinks}</nav>
+    </aside>
+    <div class="utility-shell">
+      <nav class="desktop-nav" aria-label="Dashboard メニュー">
+        <span class="desktop-nav-title">Dashboard</span>
+        ${navLinks}
+      </nav>
+      <section class="utility-content" aria-label="${escapeDashboardHtml(title)}">
+        <header>
+          <div class="utility-title-row">
+            <label class="menu-button" for="dashboard-nav-toggle" aria-label="メニューを開く">≡</label>
+            <div>
+              <h1>${escapeDashboardHtml(title)}</h1>
+              <p class="muted">${escapeDashboardHtml(subtitle || "")}</p>
+            </div>
+          </div>
+          <a class="back" href="${escapeDashboardHtml(backHref || "/dashboard")}">Dashboard</a>
+        </header>
+        ${body}
+      </section>
+    </div>
   </main>
 </body>
 </html>`;

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -3303,6 +3303,11 @@ test("worker serves human-facing dashboard pages for every management menu", asy
     assert.equal(body.includes(title), true);
     assert.equal(body.includes(rawLabel), false);
     assert.equal(body.includes("{\"ok\""), false);
+    assert.equal(body.includes('class="desktop-nav" aria-label="Dashboard メニュー"'), true);
+    assert.equal(body.includes('class="dashboard-nav-drawer" aria-label="Dashboard メニュー"'), true);
+    assert.equal(body.includes('for="dashboard-nav-toggle" aria-label="メニューを開く"'), true);
+    assert.equal(body.includes('href="/dashboard/notifications"'), true);
+    assert.equal(body.includes('href="/dashboard"'), true);
   }
 });
 
@@ -3370,6 +3375,38 @@ test("worker serves dashboard notification center for recent events across repos
     updatedAt: fourMinutesAgo
   });
   await store.put({
+    id: "github_actions_workflow_run:marushu/vtdd-v2-p:deploy-production:26134526816",
+    kind: "github_actions_workflow_run",
+    repository: "marushu/vtdd-v2-p",
+    workflowName: "deploy-production",
+    runId: "26134526816",
+    runUrl: "https://github.com/marushu/vtdd-v2-p/actions/runs/26134526816",
+    status: "in_progress",
+    conclusion: "",
+    headSha: "daad4fb023cf699b3ad531e0394e064fde2b5515",
+    headBranch: "main",
+    title: "dashboard: 通知設定を折り畳む (#534)",
+    changeSummary: "dashboard: 通知設定を折り畳む (#534)",
+    pullNumber: 552,
+    updatedAt: twoMinutesAgo
+  });
+  await store.put({
+    id: "github_actions_workflow_run:marushu/vtdd-v2-p:deploy-production:26134526817",
+    kind: "github_actions_workflow_run",
+    repository: "marushu/vtdd-v2-p",
+    workflowName: "deploy-production",
+    runId: "26134526817",
+    runUrl: "https://github.com/marushu/vtdd-v2-p/actions/runs/26134526817",
+    status: "completed",
+    conclusion: "success",
+    headSha: "daad4fb023cf699b3ad531e0394e064fde2b5515",
+    headBranch: "main",
+    title: "dashboard: 通知設定を折り畳む (#534)",
+    changeSummary: "dashboard: 通知設定を折り畳む (#534)",
+    pullNumber: 552,
+    updatedAt: new Date(Date.now() - 60 * 1000).toISOString()
+  });
+  await store.put({
     id: "vps_runner_execution:marushu/sunabaeye:remote-codex-issue9",
     kind: "vps_runner_execution",
     repository: "marushu/sunabaeye",
@@ -3411,6 +3448,15 @@ test("worker serves dashboard notification center for recent events across repos
   assert.match(response.headers.get("content-type"), /text\/html/);
   const body = await response.text();
   assert.equal(body.includes("通知センター"), true);
+  assert.equal(body.includes('class="desktop-nav" aria-label="Dashboard メニュー"'), true);
+  assert.equal(body.includes('class="dashboard-nav-drawer" aria-label="Dashboard メニュー"'), true);
+  assert.equal(body.includes('for="dashboard-nav-toggle" aria-label="メニューを開く"'), true);
+  assert.equal(body.includes('href="/dashboard"'), true);
+  assert.equal(body.includes('href="/dashboard/preflight"'), true);
+  assert.equal(body.includes('href="/dashboard/self-parity"'), true);
+  assert.equal(body.includes("run 26134526817"), true);
+  assert.equal(body.includes("run 26134526816"), false);
+  assert.equal(body.includes("run 26134526815"), false);
   assert.equal(body.includes("Dashboard Butler の通知入口です"), true);
   assert.equal(body.includes("iOS PWA Web Push"), true);
   assert.equal(body.includes('data-debug-section="notification-center-context"'), true);
@@ -3454,13 +3500,14 @@ test("worker serves dashboard notification center for recent events across repos
   assert.equal(body.includes("scope: \"/dashboard/\""), true);
   assert.equal(body.includes("secret-must-not-persist"), false);
   assert.equal(body.includes("他 repo / 並行開発 / queue / workflow"), true);
-  assert.equal(body.includes("deploy-production / run 26134526815 / sha daad4fb"), true);
+  assert.equal(body.includes("deploy-production / run 26134526817 / sha daad4fb"), true);
   assert.equal(body.includes("最新通知"), true);
   assert.equal(body.includes("success"), true);
   assert.equal(body.includes("デプロイ完了: PR #552 dashboard: 通知設定を折り畳む (#534)"), true);
-  assert.equal(body.includes("26134526815"), true);
-  assert.equal(body.includes("4分前"), true);
-  assert.equal(body.includes(fourMinutesAgo), true);
+  assert.equal(body.includes("26134526817"), true);
+  assert.equal(body.includes("26134526816"), false);
+  assert.equal(body.includes("26134526815"), false);
+  assert.equal(body.includes(fourMinutesAgo), false);
   assert.equal(body.includes("SunabaEye queue pickup with long notification title"), true);
   assert.equal(body.includes("marushu/sunabaeye"), true);
   assert.equal(body.includes("dashboard-notification-center"), true);
@@ -3689,6 +3736,7 @@ test("worker builds distinct dashboard Web Push copy by event type", () => {
   assert.equal(deploySuccess.body.includes("run: 26323724369"), true);
   assert.equal(deploySuccess.body.includes("PR #571"), true);
   assert.equal(deploySuccess.body.includes("Issue #514"), true);
+  assert.equal(deploySuccess.url, "/dashboard/notifications");
 
   const deployFailure = buildDashboardWebPushPayload({
     kind: "github_actions_workflow_run",
@@ -3701,6 +3749,7 @@ test("worker builds distinct dashboard Web Push copy by event type", () => {
     title: "deploy-production"
   });
   assert.equal(deployFailure.title, "デプロイ失敗: vtdd-v2-p");
+  assert.equal(deployFailure.url, "/dashboard/notifications");
 
   const testPush = buildDashboardWebPushPayload({
     kind: "dashboard_push_test",

--- a/worker.js
+++ b/worker.js
@@ -62466,7 +62466,7 @@ function buildDashboardWebPushPayload(event) {
     title,
     body: body || "Dashboard Butler \u306E\u901A\u77E5\u3067\u3059\u3002",
     tag: `vtdd-${record2.kind || "dashboard"}-${record2.runId || record2.id || "event"}`.slice(0, 120),
-    url: record2.runUrl || "/dashboard/notifications"
+    url: "/dashboard/notifications"
   };
 }
 function buildDashboardWebPushTitle(record2) {
@@ -64622,6 +64622,39 @@ function renderDashboardNotificationEvent(event) {
             <p class="muted">${escapeDashboardHtml(relativeUpdatedAt || "\u6642\u523B\u672A\u53D7\u4FE1")} \u30FB ${escapeDashboardHtml(updatedAt || "updatedAt \u672A\u53D7\u4FE1")} \u30FB ${runLabel}</p>
           </div>`;
 }
+function collapseDashboardNotificationEvents(events = []) {
+  const latestByKey = /* @__PURE__ */ new Map();
+  for (const event of Array.isArray(events) ? events : []) {
+    const record2 = normalizeDashboardEventRecord(event);
+    const key = dashboardNotificationCollapseKey(record2);
+    const existing = latestByKey.get(key);
+    if (!existing || compareDashboardEventRecency(record2, existing) > 0) {
+      latestByKey.set(key, record2);
+    }
+  }
+  return [...latestByKey.values()].sort((a, b) => compareDashboardEventRecency(b, a));
+}
+function dashboardNotificationCollapseKey(event) {
+  const record2 = normalizeDashboardEventRecord(event);
+  const repository = normalizeCanonicalRepositoryInput(record2.repository) || "repo-unknown";
+  const workflowName = normalizeDashboardEventText(record2.workflowName || record2.kind) || "workflow-unknown";
+  if (record2.pullNumber) {
+    return `${repository}:pr:${record2.pullNumber}:${workflowName}`;
+  }
+  const branch = normalizeDashboardEventText(record2.headBranch);
+  const sha = normalizeDashboardEventText(record2.headSha).slice(0, 12);
+  return `${repository}:workflow:${workflowName}:${branch || sha || record2.runId || "unknown"}`;
+}
+function compareDashboardEventRecency(left, right) {
+  const leftTime = new Date(normalizeDashboardEventText(left?.updatedAt || left?.createdAt)).getTime();
+  const rightTime = new Date(normalizeDashboardEventText(right?.updatedAt || right?.createdAt)).getTime();
+  const normalizedLeft = Number.isNaN(leftTime) ? 0 : leftTime;
+  const normalizedRight = Number.isNaN(rightTime) ? 0 : rightTime;
+  if (normalizedLeft !== normalizedRight) {
+    return normalizedLeft - normalizedRight;
+  }
+  return String(left?.runId || left?.id || "").localeCompare(String(right?.runId || right?.id || ""));
+}
 function buildDashboardEventDisplayTitle(event, { workflowName, conclusion } = {}) {
   const record2 = normalizeDashboardEventRecord(event);
   const statusLabel = dashboardPushStatusLabel(record2);
@@ -64864,6 +64897,7 @@ async function renderDashboardNotificationsPage({ runtimeOrigin, dashboardEventS
     since: recentSince,
     limit: 20
   });
+  const visibleRecentEvents = collapseDashboardNotificationEvents(recentEvents);
   const publicKey = normalizeDashboardEventText(env?.[WEB_PUSH_PUBLIC_KEY_ENV]);
   return renderDashboardUtilityPage({
     title: "\u901A\u77E5\u30BB\u30F3\u30BF\u30FC",
@@ -64873,7 +64907,7 @@ async function renderDashboardNotificationsPage({ runtimeOrigin, dashboardEventS
       <div class="grid single">
         <section class="lane">
           <div class="lane-title"><h2>\u6700\u65B0\u901A\u77E5</h2><span class="pill">\u76F4\u8FD15\u5206</span></div>
-          ${recentEvents.length > 0 ? recentEvents.map((event) => renderDashboardNotificationEvent(event)).join("") : `<p class="muted">\u76F4\u8FD15\u5206\u306E\u901A\u77E5\u306F\u3042\u308A\u307E\u305B\u3093\u3002</p>`}
+          ${visibleRecentEvents.length > 0 ? visibleRecentEvents.map((event) => renderDashboardNotificationEvent(event)).join("") : `<p class="muted">\u76F4\u8FD15\u5206\u306E\u901A\u77E5\u306F\u3042\u308A\u307E\u305B\u3093\u3002</p>`}
         </section>
       </div>
       <div class="grid single">
@@ -65309,7 +65343,21 @@ function summarizeObjectValue(value) {
   }
   return String(value);
 }
+function renderDashboardUtilityNavLinks() {
+  const items = [
+    ["Dashboard", "/dashboard"],
+    ["\u901A\u77E5\u30BB\u30F3\u30BF\u30FC", "/dashboard/notifications"],
+    ["GitHub truth", "/dashboard/github-truth"],
+    ["Startup preflight", "/dashboard/preflight"],
+    ["Execution progress", "/dashboard/progress"],
+    ["VPS runner", "/dashboard/vps-runner"],
+    ["Operational RAG", "/dashboard/memory"],
+    ["Self parity", "/dashboard/self-parity"]
+  ];
+  return items.map(([label, href]) => `<a class="dashboard-nav-link" href="${escapeDashboardHtml(href)}">${escapeDashboardHtml(label)}</a>`).join("");
+}
 function renderDashboardUtilityPage({ title, subtitle, backHref, body }) {
+  const navLinks = renderDashboardUtilityNavLinks();
   return `<!doctype html>
 <html lang="ja">
 <head>
@@ -65324,13 +65372,29 @@ function renderDashboardUtilityPage({ title, subtitle, backHref, body }) {
     * { box-sizing: border-box; }
     html, body { max-width: 100%; overflow-x: hidden; }
     body { margin: 0; background: var(--bg); color: var(--text); }
-    main { width: min(1120px, 100%); margin: 0 auto; padding: 16px; }
+    main { width: min(1280px, 100%); margin: 0 auto; padding: 16px; }
     header { display: flex; justify-content: space-between; align-items: center; gap: 12px; margin-bottom: 18px; }
     h1 { font-size: 24px; margin: 0 0 4px; }
     h2 { font-size: 18px; margin: 0; }
     p { line-height: 1.6; margin: 0 0 10px; }
     a { color: inherit; text-underline-offset: 4px; }
-    .back, .actions a, .dashboard-action { display: inline-flex; min-height: 38px; align-items: center; justify-content: center; border: 1px solid var(--border); border-radius: 999px; padding: 6px 12px; background: var(--soft); color: var(--text); text-decoration: none; font: inherit; font-weight: 750; }
+    .back, .actions a, .dashboard-action, .menu-button { display: inline-flex; min-height: 38px; align-items: center; justify-content: center; border: 1px solid var(--border); border-radius: 999px; padding: 6px 12px; background: var(--soft); color: var(--text); text-decoration: none; font: inherit; font-weight: 750; }
+    .menu-button { width: 42px; height: 42px; padding: 0; font-size: 22px; cursor: pointer; flex: 0 0 auto; }
+    .utility-shell { display: grid; grid-template-columns: 240px minmax(0, 1fr); gap: 24px; align-items: start; }
+    .utility-content { min-width: 0; }
+    .utility-title-row { display: flex; align-items: center; gap: 12px; min-width: 0; }
+    .desktop-nav { position: sticky; top: 16px; display: grid; gap: 8px; border: 1px solid var(--border); border-radius: 18px; background: var(--panel); padding: 12px; }
+    .desktop-nav-title { color: var(--muted); font-size: 12px; font-weight: 850; letter-spacing: .08em; text-transform: uppercase; padding: 4px 8px 8px; }
+    .dashboard-nav-link { display: flex; align-items: center; min-height: 38px; border-radius: 10px; padding: 8px 10px; color: var(--text); text-decoration: none; font-weight: 750; }
+    .dashboard-nav-link:hover, .dashboard-nav-link:focus-visible { background: var(--soft); outline: none; }
+    .dashboard-nav-toggle { position: fixed; width: 1px; height: 1px; opacity: 0; pointer-events: none; }
+    .dashboard-nav-backdrop, .dashboard-nav-drawer { display: none; }
+    .dashboard-nav-backdrop { position: fixed; inset: 0; z-index: 20; background: rgba(0, 0, 0, .36); backdrop-filter: blur(2px); }
+    .dashboard-nav-drawer { position: fixed; inset: 0 auto 0 0; z-index: 21; width: min(86vw, 360px); overflow: auto; padding: max(16px, env(safe-area-inset-top)) 14px max(18px, env(safe-area-inset-bottom)); border-right: 1px solid var(--border); background: var(--panel); box-shadow: 18px 0 60px rgba(0, 0, 0, .22); }
+    .dashboard-nav-toggle:checked ~ .dashboard-nav-backdrop, .dashboard-nav-toggle:checked ~ .dashboard-nav-drawer { display: block; }
+    .drawer-header { display: flex; justify-content: space-between; align-items: center; gap: 12px; margin-bottom: 12px; }
+    .drawer-header strong { display: block; }
+    .drawer-nav { display: grid; gap: 8px; }
     .dashboard-action:disabled { opacity: .45; }
     .hero, .lane, .notice { border: 1px solid var(--border); border-radius: 16px; background: var(--panel); padding: 14px; margin-bottom: 14px; }
     .actions { display: flex; flex-wrap: wrap; gap: 8px; }
@@ -65357,21 +65421,50 @@ function renderDashboardUtilityPage({ title, subtitle, backHref, body }) {
     @media (max-width: 760px) {
       main { padding: 12px; }
       header { align-items: flex-start; }
+      .utility-shell { display: block; }
+      .desktop-nav { display: none; }
+      .back { display: none; }
       .grid { grid-template-columns: minmax(0, 1fr); }
       .summary-list div { grid-template-columns: minmax(0, 1fr); }
+    }
+    @media (min-width: 761px) {
+      .utility-title-row .menu-button { display: none; }
     }
   </style>
 </head>
 <body>
   <main>
-    <header>
-      <div>
-        <h1>${escapeDashboardHtml(title)}</h1>
-        <p class="muted">${escapeDashboardHtml(subtitle || "")}</p>
+    <input class="dashboard-nav-toggle" type="checkbox" id="dashboard-nav-toggle" aria-hidden="true">
+    <label class="dashboard-nav-backdrop" for="dashboard-nav-toggle" aria-label="\u30E1\u30CB\u30E5\u30FC\u3092\u9589\u3058\u308B"></label>
+    <aside class="dashboard-nav-drawer" aria-label="Dashboard \u30E1\u30CB\u30E5\u30FC">
+      <div class="drawer-header">
+        <span>
+          <span class="desktop-nav-title">Dashboard</span>
+          <strong>\u30E1\u30CB\u30E5\u30FC</strong>
+        </span>
+        <label class="menu-button" for="dashboard-nav-toggle" aria-label="\u30E1\u30CB\u30E5\u30FC\u3092\u9589\u3058\u308B">\xD7</label>
       </div>
-      <a class="back" href="${escapeDashboardHtml(backHref || "/dashboard")}">Dashboard</a>
-    </header>
-    ${body}
+      <nav class="drawer-nav" aria-label="Dashboard \u30E1\u30CB\u30E5\u30FC\u9805\u76EE">${navLinks}</nav>
+    </aside>
+    <div class="utility-shell">
+      <nav class="desktop-nav" aria-label="Dashboard \u30E1\u30CB\u30E5\u30FC">
+        <span class="desktop-nav-title">Dashboard</span>
+        ${navLinks}
+      </nav>
+      <section class="utility-content" aria-label="${escapeDashboardHtml(title)}">
+        <header>
+          <div class="utility-title-row">
+            <label class="menu-button" for="dashboard-nav-toggle" aria-label="\u30E1\u30CB\u30E5\u30FC\u3092\u958B\u304F">\u2261</label>
+            <div>
+              <h1>${escapeDashboardHtml(title)}</h1>
+              <p class="muted">${escapeDashboardHtml(subtitle || "")}</p>
+            </div>
+          </div>
+          <a class="back" href="${escapeDashboardHtml(backHref || "/dashboard")}">Dashboard</a>
+        </header>
+        ${body}
+      </section>
+    </div>
   </main>
 </body>
 </html>`;


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #528 の部分進捗です。Dashboard 配下の通知/管理/運用ページを、PC/SP ともに共通メニューから戻れる owner-facing surface に寄せます。
- PWA 通知タップは GitHub など外部URLへ飛ばさず、必ず Dashboard 通知センターへ復帰するようにします。
- 通知センターでは同じ PR/workflow の進行中/完了イベントを最新状態1件に集約し、owner に重複通知として見せないようにします。

## Satisfied Success Criteria

- Dashboard 配下の utility pages に PC 左ナビと SP drawer を追加し、どの画面でも Dashboard / 通知センター / preflight / progress / VPS runner / RAG / self parity へ戻れる。
- Web Push payload の click URL を `/dashboard/notifications` に固定し、PWA 通知タップ後の白画面/外部遷移リスクを下げる。
- 通知センターの直近イベント表示を `repository + pullNumber + workflowName` などで集約し、同一 PR の `in_progress -> success` を最新状態1件にする。

## Unsatisfied Success Criteria

- Issue #528 全体の ChatGPT iOS 相当 UX は未完了。
- Dashboard chat composer、WebSocket 復帰、添付UX、iPhone/PWA live E2E の完全カバレッジはこの PR では完了扱いにしない。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #528
- Implementing Success Criteria: Dashboard の通常チャット/通知/管理ページから debug/ops surfaces を隔離しつつ、必要な画面へ PC/SP 共通導線で戻れるようにする。通知クリックは Dashboard 内部へ復帰させ、同一 PR の通知は最新状態へ集約する。
- Explicit Non-goals: production deploy 実行、credential mutation、permission mutation、main chat composer/WebSocket 挙動変更、Issue close はしない。
- Expected touched files/routes/workflows: `src/worker/runtime.js`, `test/worker.test.js`, `worker.js`; routes `/dashboard/*`, `/dashboard/notifications`, `/dashboard-sw.js` payload behavior.
- Affected Issues: Issue #528 の部分進捗。
- Affected PRs: PR #592 merged 後の main を取り込んだ後続 PR。
- Affected workflows: GitHub Actions workflow は未変更。通知表示と Web Push payload のみ変更。
- Affected runtime/operator surfaces: Dashboard utility pages, notification center, Dashboard Web Push payload.
- What may break if we patch narrowly: 個別ページだけに戻るボタンを置くと、PC/SP で画面ごとに操作感が分裂し、通知タップや管理ページから迷子になる。
- Unknowns to investigate before coding: 実機PWA live tap は未実施。今回のPRでは unit/integration で URL 固定と HTML 導線を検証。
- Validation needed: `node --test test/worker.test.js`, `node --test test/passkey-operator-page.test.js`, `npm run build:worker`, `npm run check:generated-worker`, `git diff --check`。
- Stop condition: deploy 実行、credential/permission mutation、Cloudflare production 反映が必要になった場合は停止し、scoped passkey approval を要求する。

## File / Line Hypotheses

- file: `src/worker/runtime.js`
  - hypothesis: `renderDashboardUtilityPage` が `/dashboard` の drawer shell と分離しており、通知/管理ページに共通メニューがない。
  - risk if changed narrowly: 通知センターだけ直しても preflight/progress/RAG/self-parity で同じ迷子が残る。
  - validation: management menu routes と notification center test で desktop nav / SP drawer / links を検証。
  - related Issue: #528
- file: `src/worker/runtime.js`
  - hypothesis: `buildDashboardWebPushPayload` が `record.runUrl` を payload URL に使うと、PWA通知タップが Dashboard 外へ逸れる可能性がある。
  - risk if changed narrowly: Service Worker の防御に依存し、iOS/PWA の通知復帰で白画面になる。
  - validation: Web Push payload test で `url === "/dashboard/notifications"` を検証。
  - related Issue: #528
- file: `src/worker/runtime.js`
  - hypothesis: 通知センターがイベントログをそのまま表示するため、同じ PR の `in_progress` と `success` が二重表示される。
  - risk if changed narrowly: owner が「同じPRが複数ある」と誤認し、最新状態を判定しづらい。
  - validation: notification center test で古い run id が表示されず最新 run id のみ表示されることを検証。
  - related Issue: #528

## Hypothesis Retrospective

- expected: Dashboard utility pages は PC で左ナビ、SP で drawer を持つ。
- actual: tests confirm `desktop-nav`, `dashboard-nav-drawer`, and `dashboard-nav-toggle` exist on management routes and notification center.
- mismatch: なし。
- lesson: `/dashboard` だけでなく `/dashboard/*` 全体を一つのアプリ構造として扱う必要がある。
- should become RAG candidate: はい。Dashboard 配下の新規ページは共通ナビ/復帰導線を必須にする。

## Verification Evidence

- Unit: `node --test test/worker.test.js`: 209/209 pass; `node --test test/passkey-operator-page.test.js`: 27/27 pass
- Integration: `npm run build:worker` pass; `npm run check:generated-worker` pass; `git diff --check` pass
- E2E: Not run. This PR covers route/render and payload regression; iPhone/PWA live tap remains unverified.
- Manual: No production deploy executed.
- Evidence path/link: `test/worker.test.js`, `src/worker/runtime.js`

## Butler Completion Contract

- Owner goal: Dashboard の通知/管理/運用画面から PC/SP ともに迷わずメニューへ戻り、PWA通知タップ時も Dashboard 内へ復帰し、同じPRの通知を重複表示しない。
- Butler entrypoint: `/dashboard/notifications`, `/dashboard/preflight`, `/dashboard/progress`, `/dashboard/vps-runner`, `/dashboard/memory`, `/dashboard/self-parity`, Dashboard Web Push notification click.
- Action Schema exposure: 未変更。
- Runtime path: Worker dashboard routes -> `renderDashboardUtilityPage`; Web Push payload -> service worker notification click -> `/dashboard/notifications`.
- Runner/runtime truth: worker tests verify HTML navigation, notification collapse, and payload URL.
- Authority boundary: 未変更。deploy/credential/permission mutation は実行しない。
- E2E evidence: 未接続。iPhone/PWA live tap は未実施。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 未実施。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。

## Related Constitution Rules

- AGENTS.md Chief Butler Operating Principle
- AGENTS.md Butler-First Operating Principle
- AGENTS.md Drift Stop Protocol
- AGENTS.md Evidence Discipline

## Out-of-scope but NOT implemented

- production deploy 実行。
- Issue #528 close。
- Dashboard chat composer/WebSocket 復帰全体の完成。
- 実機 iPhone/PWA live tap E2E。

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #528
- Execution ID: mac-codex-2026-05-28-dashboard-global-menu
- Goal: Add dashboard-wide utility navigation and safer notification behavior
