### PR TITLE
Issue #444 通知の遷移先を PR に向ける

### DIFF
--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -7242,7 +7242,7 @@ export function buildDashboardWebPushPayload(event) {
     title,
     body: body || "Dashboard Butler の通知です。",
     tag: `vtdd-${record.kind || "dashboard"}-${record.runId || record.id || "event"}`.slice(0, 120),
-    url: "/dashboard/notifications"
+    url: buildDashboardEventOwnerTargetUrl(record)
   };
 }
 
@@ -7320,6 +7320,32 @@ function shortRepositoryName(repository) {
   const text = normalizeDashboardEventText(repository);
   const parts = text.split("/");
   return parts.length === 2 ? parts[1] : text;
+}
+
+function buildDashboardEventOwnerTargetUrl(event) {
+  return buildDashboardPullRequestUrl(event) || "/dashboard/notifications";
+}
+
+function buildDashboardPullRequestUrl(event) {
+  const record = normalizeDashboardEventRecord(event);
+  const repository = normalizeCanonicalRepositoryInput(record.repository);
+  const pullNumber = normalizeIssue(record.pullNumber);
+  if (!repository || !pullNumber) {
+    return "";
+  }
+  return `https://github.com/${repository}/pull/${pullNumber}`;
+}
+
+function buildDashboardEventLinkHtml(event, fallbackText = "詳細を開く") {
+  const pullRequestUrl = buildDashboardPullRequestUrl(event);
+  if (pullRequestUrl) {
+    return `<a class="chat-link" href="${escapeDashboardHtml(pullRequestUrl)}">PRを開く</a>`;
+  }
+  const runUrl = normalizeDashboardEventText(event?.runUrl);
+  if (runUrl && !/github\.com\/[^/]+\/[^/]+\/actions\/runs\//i.test(runUrl)) {
+    return `<a class="chat-link" href="${escapeDashboardHtml(runUrl)}">${escapeDashboardHtml(fallbackText)}</a>`;
+  }
+  return "詳細リンク未受信";
 }
 
 function compactNotificationText(value, limit) {
@@ -9606,8 +9632,7 @@ function renderDashboardDeployEvent(event) {
   const relativeUpdatedAt = formatDashboardRelativeTime(updatedAt);
   const sha = normalizeDashboardEventText(event.headSha);
   const shortSha = sha ? sha.slice(0, 7) : "unknown";
-  const runUrl = normalizeDashboardEventText(event.runUrl);
-  const runLabel = runUrl ? `<a class="chat-link" href="${escapeDashboardHtml(runUrl)}">Actions run</a>` : "Actions run 未設定";
+  const runLabel = buildDashboardEventLinkHtml(event);
   const title = buildDashboardEventDisplayTitle(event, {
     workflowName: normalizeDashboardEventText(event.workflowName) || "deploy-production",
     conclusion
@@ -9640,8 +9665,7 @@ function renderDashboardNotificationEvent(event) {
   const runId = normalizeDashboardEventText(event.runId);
   const sha = normalizeDashboardEventText(event.headSha);
   const shortSha = sha ? sha.slice(0, 7) : "";
-  const runUrl = normalizeDashboardEventText(event.runUrl);
-  const runLabel = runUrl ? `<a class="chat-link" href="${escapeDashboardHtml(runUrl)}">詳細を開く</a>` : "詳細リンク未受信";
+  const runLabel = buildDashboardEventLinkHtml(event);
   const meta = [
     repository,
     event.pullNumber ? `PR #${event.pullNumber}` : "",
@@ -10251,6 +10275,9 @@ function safeDashboardNotificationUrl(value) {
     parsed = new URL(value || "/dashboard/notifications", self.location.origin);
   } catch {
     parsed = new URL("/dashboard/notifications", self.location.origin);
+  }
+  if (parsed.origin === "https://github.com" && /^\\/[^/]+\\/[^/]+\\/pull\\/\\d+\\/?$/.test(parsed.pathname)) {
+    return parsed.toString();
   }
   if (parsed.origin !== self.location.origin) {
     return new URL("/dashboard/notifications", self.location.origin).toString();

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -3515,6 +3515,9 @@ test("worker serves dashboard notification center for recent events across repos
   assert.equal(body.includes("secret-must-not-persist"), false);
   assert.equal(body.includes("他 repo / 並行開発 / queue / workflow"), true);
   assert.equal(body.includes("deploy-production / run 26134526817 / sha daad4fb"), true);
+  assert.equal(body.includes('href="https://github.com/marushu/vtdd-v2-p/pull/552"'), true);
+  assert.equal(body.includes('href="https://github.com/marushu/vtdd-v2-p/actions/runs/26134526817"'), false);
+  assert.equal(body.includes("PRを開く"), true);
   assert.equal(body.includes("最新通知"), true);
   assert.equal(body.includes("success"), true);
   assert.equal(body.includes("デプロイ完了: PR #552 dashboard: 通知設定を折り畳む (#534)"), true);
@@ -3549,6 +3552,8 @@ test("worker serves dashboard PWA manifest and service worker notification handl
   assert.equal(serviceWorker.includes('self.addEventListener("notificationclick"'), true);
   assert.equal(serviceWorker.includes("/dashboard/notifications"), true);
   assert.equal(serviceWorker.includes("safeDashboardNotificationUrl"), true);
+  assert.equal(serviceWorker.includes('parsed.origin === "https://github.com"'), true);
+  assert.equal(serviceWorker.includes('pull\\/\\d+'), true);
   assert.equal(serviceWorker.includes("parsed.origin !== self.location.origin"), true);
   assert.equal(serviceWorker.includes('!parsed.pathname.startsWith("/dashboard/")'), true);
 
@@ -3750,7 +3755,7 @@ test("worker builds distinct dashboard Web Push copy by event type", () => {
   assert.equal(deploySuccess.body.includes("run: 26323724369"), true);
   assert.equal(deploySuccess.body.includes("PR #571"), true);
   assert.equal(deploySuccess.body.includes("Issue #514"), true);
-  assert.equal(deploySuccess.url, "/dashboard/notifications");
+  assert.equal(deploySuccess.url, "https://github.com/marushu/vtdd-v2-p/pull/571");
 
   const deployFailure = buildDashboardWebPushPayload({
     kind: "github_actions_workflow_run",
@@ -3969,6 +3974,7 @@ test("worker ingests GitHub Actions deploy completion event and shows it on dash
   assert.equal(decryptedPush.body.includes("dashboard: 通知カードにPR概要を出す"), true);
   assert.equal(decryptedPush.body.includes("PR #552"), true);
   assert.equal(decryptedPush.body.includes("workflow: deploy-production"), true);
+  assert.equal(decryptedPush.url, "https://github.com/marushu/vtdd-v2-p/pull/552");
   assert.equal("approvalGrantId" in eventBody.event, false);
   assert.equal("token" in eventBody.event, false);
 
@@ -3989,10 +3995,8 @@ test("worker ingests GitHub Actions deploy completion event and shows it on dash
   assert.equal(dashboardBody.includes("デプロイ完了: PR #552 dashboard: 通知カードにPR概要を出す (#534)"), true);
   assert.equal(dashboardBody.includes("dashboard: 通知カードにPR概要を出す"), true);
   assert.equal(dashboardBody.includes("PR #552"), true);
-  assert.equal(
-    dashboardBody.includes("https://github.com/marushu/vtdd-v2-p/actions/runs/26133044458"),
-    true
-  );
+  assert.equal(dashboardBody.includes("https://github.com/marushu/vtdd-v2-p/pull/552"), true);
+  assert.equal(dashboardBody.includes("https://github.com/marushu/vtdd-v2-p/actions/runs/26133044458"), false);
   assert.equal(dashboardBody.includes("approval:must-not-persist"), false);
   assert.equal(dashboardBody.includes("secret-must-not-persist"), false);
   assert.equal(dashboardBody.includes("setInterval("), false);

--- a/worker.js
+++ b/worker.js
@@ -62466,7 +62466,7 @@ function buildDashboardWebPushPayload(event) {
     title,
     body: body || "Dashboard Butler \u306E\u901A\u77E5\u3067\u3059\u3002",
     tag: `vtdd-${record2.kind || "dashboard"}-${record2.runId || record2.id || "event"}`.slice(0, 120),
-    url: "/dashboard/notifications"
+    url: buildDashboardEventOwnerTargetUrl(record2)
   };
 }
 function buildDashboardWebPushTitle(record2) {
@@ -62539,6 +62539,29 @@ function shortRepositoryName(repository) {
   const text = normalizeDashboardEventText(repository);
   const parts = text.split("/");
   return parts.length === 2 ? parts[1] : text;
+}
+function buildDashboardEventOwnerTargetUrl(event) {
+  return buildDashboardPullRequestUrl(event) || "/dashboard/notifications";
+}
+function buildDashboardPullRequestUrl(event) {
+  const record2 = normalizeDashboardEventRecord(event);
+  const repository = normalizeCanonicalRepositoryInput(record2.repository);
+  const pullNumber = normalizeIssue6(record2.pullNumber);
+  if (!repository || !pullNumber) {
+    return "";
+  }
+  return `https://github.com/${repository}/pull/${pullNumber}`;
+}
+function buildDashboardEventLinkHtml(event, fallbackText = "\u8A73\u7D30\u3092\u958B\u304F") {
+  const pullRequestUrl = buildDashboardPullRequestUrl(event);
+  if (pullRequestUrl) {
+    return `<a class="chat-link" href="${escapeDashboardHtml(pullRequestUrl)}">PR\u3092\u958B\u304F</a>`;
+  }
+  const runUrl = normalizeDashboardEventText(event?.runUrl);
+  if (runUrl && !/github\.com\/[^/]+\/[^/]+\/actions\/runs\//i.test(runUrl)) {
+    return `<a class="chat-link" href="${escapeDashboardHtml(runUrl)}">${escapeDashboardHtml(fallbackText)}</a>`;
+  }
+  return "\u8A73\u7D30\u30EA\u30F3\u30AF\u672A\u53D7\u4FE1";
 }
 function compactNotificationText(value, limit) {
   const text = normalizeDashboardEventText(value).replace(/\s+/g, " ");
@@ -64573,8 +64596,7 @@ function renderDashboardDeployEvent(event) {
   const relativeUpdatedAt = formatDashboardRelativeTime(updatedAt);
   const sha = normalizeDashboardEventText(event.headSha);
   const shortSha = sha ? sha.slice(0, 7) : "unknown";
-  const runUrl = normalizeDashboardEventText(event.runUrl);
-  const runLabel = runUrl ? `<a class="chat-link" href="${escapeDashboardHtml(runUrl)}">Actions run</a>` : "Actions run \u672A\u8A2D\u5B9A";
+  const runLabel = buildDashboardEventLinkHtml(event);
   const title = buildDashboardEventDisplayTitle(event, {
     workflowName: normalizeDashboardEventText(event.workflowName) || "deploy-production",
     conclusion
@@ -64606,8 +64628,7 @@ function renderDashboardNotificationEvent(event) {
   const runId = normalizeDashboardEventText(event.runId);
   const sha = normalizeDashboardEventText(event.headSha);
   const shortSha = sha ? sha.slice(0, 7) : "";
-  const runUrl = normalizeDashboardEventText(event.runUrl);
-  const runLabel = runUrl ? `<a class="chat-link" href="${escapeDashboardHtml(runUrl)}">\u8A73\u7D30\u3092\u958B\u304F</a>` : "\u8A73\u7D30\u30EA\u30F3\u30AF\u672A\u53D7\u4FE1";
+  const runLabel = buildDashboardEventLinkHtml(event);
   const meta2 = [
     repository,
     event.pullNumber ? `PR #${event.pullNumber}` : "",
@@ -65195,6 +65216,9 @@ function safeDashboardNotificationUrl(value) {
     parsed = new URL(value || "/dashboard/notifications", self.location.origin);
   } catch {
     parsed = new URL("/dashboard/notifications", self.location.origin);
+  }
+  if (parsed.origin === "https://github.com" && /^\\/[^/]+\\/[^/]+\\/pull\\/\\d+\\/?$/.test(parsed.pathname)) {
+    return parsed.toString();
   }
   if (parsed.origin !== self.location.origin) {
     return new URL("/dashboard/notifications", self.location.origin).toString();


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #444 の notificationclick target URL 要件に対する部分進捗です。GitHub Actions event が PR 番号を持つ場合、iOS PWA Web Push の通知タップと通知センターの主リンクを Actions run ではなく GitHub PR に向けます。owner は Action 実行詳細ではなく、何が動いたかを確認する PR と証跡へ直接到達できます。

## Satisfied Success Criteria

- PR 番号付き dashboard event から GitHub PR URL を生成する。\nWeb Push payload の url を PR URL にする。\n通知センターと最新 deploy 表示の主リンクを PRを開く にする。\nservice worker の notificationclick は同一 origin dashboard URL に加えて github.com の PR URL だけを許可する。\nActions run URL は PR 番号があるイベントの主導線に出さない。

## Unsatisfied Success Criteria

- Issue #444 全体の iPhone 実機 Web Push / 音 / badge E2E は未完了です。
- 失敗時の自動復旧キュー化は Issue #448 / Issue #413 側の残作業です。
- 管理メニュー文言の削減は Issue #528 の別スライスとして残します。

## Non-goal violations

失敗した Actions の自動復旧キュー実装はこのPRでは扱いません。\n自動マージ policy 全体はこのPRでは扱いません。\n管理メニュー文言変更はこのPRに混ぜません。\ndeploy、credential、permission、repository settings は変更しません。

## Dry-run Impact Report

- Target Issue: Issue #444
- Implementing Success Criteria: Issue #444: notificationclick で /dashboard/notifications または event target URL へ遷移できる。今回の event target URL は PR 番号付きイベントの GitHub PR URL。
- Explicit Non-goals: 自動復旧キュー、auto merge policy、管理メニュー文言、credential/deploy/permission mutation は対象外。
- Expected touched files/routes/workflows: src/worker/runtime.js, worker.js, test/worker.test.js
- Affected Issues: Issue #444 を部分進捗。Issue #528 の文言指摘は未実装として残す。Issue #448 / Issue #413 の復旧/進捗責務は未実装として残す。
- Affected PRs: PR #597 / PR #598 はマージ済みで履歴は変更しない。
- Affected workflows: GitHub Actions workflow 定義は変更なし。dashboard event 由来の通知 payload と表示リンクのみ変更。
- Affected runtime/operator surfaces: Dashboard notification center, iOS PWA service worker notificationclick, Web Push payload, generated worker.js
- What may break if we patch narrowly: Actions URL を単純に隠すだけだと PR が無い VPS runner event の進捗リンクまで消えるため、PR 番号がある時だけ PR 優先にし、非 Actions の runUrl は維持する。
- Unknowns to investigate before coding: 既存 event store が pullNumber を保持しているか確認済み。GitHub PR URL は repository + pullNumber から生成できる。
- Validation needed: node --test test/worker.test.js と npm test。通知センター HTML、Web Push payload、service worker script をテストで確認。
- Stop condition: PR 番号なしイベントの復帰リンクまで壊す場合、または GitHub Actions run を owner 主導線として残す設計になる場合は停止。

## Execution Queue Delta

- Queue position before: Issue #444 は Root Blockers / notification recovery 系の active Issue。owner の通知スクリーンショットで Actions run へ誘導している破綻が判明。
- Preemption decision: ROOT: owner が責任を持つ対象は Actions run ではなく PR と証跡であり、通知導線が大前提を崩していたため先に直します。
- Queue delta: Issue #444 の通知 tap target / event target URL slice を進める。Issue #528 の管理メニュー文言、Issue #448 / Issue #413 の失敗復旧/進捗 orchestration は Queue に残す。
- Why this PR is next: 通知が Actions run を見せる限り、owner が Action を読む前提になり VTDD の iPhone-first/責任証跡モデルに反するため。
- Active Issues not downscoped: Active Issues は縮小しません。Issue #444 全体、Issue #528、Issue #448、Issue #413 は未完了として残します。

## File / Line Hypotheses

- file: src/worker/runtime.js
  - hypothesis: buildDashboardWebPushPayload と renderDashboardNotificationEvent が runUrl を主リンクにしている。
  - risk if changed narrowly: PR なしの VPS runner event の progress link を壊す。
  - validation: test/worker.test.js で PR URL 優先と Actions URL 非表示を確認。
  - related Issue: Issue #444

## Hypothesis Retrospective

- expected: PR 番号付き event は PR URL へ飛び、PR なし event は dashboard/notification fallback または非 Actions runUrl を維持する。
- actual: buildDashboardEventOwnerTargetUrl/buildDashboardEventLinkHtml を追加し、Web Push payload と通知センターリンクを PR 優先にした。
- mismatch: なし。
- lesson: 通知の主語は Actions ではなく PR/証跡である。
- should become RAG candidate: はい。owner-facing notification target は PR-first。

## Verification Evidence

- Unit: node --test test/worker.test.js: pass (209 tests)。npm test: pass (990 pass, 1 skipped, self-parity pass, generated worker check pass)。
- Integration: npm test に含まれる check:self-parity と check:generated-worker が pass。
- E2E: 自動化された worker-level E2E 相当で Web Push payload / service worker notificationclick / dashboard notification center を確認。iPhone 実機 live E2E は未実施。
- Manual: スクリーンショット指摘から、Actions run ではなく PR を主導線にする方針へ修正。
- Evidence path/link: src/worker/runtime.js, test/worker.test.js, worker.js

## Butler Completion Contract

- Owner goal: owner はアイディアを出し、マージされたものに責任を持つ。その責任証跡として通知から PR を直接開ける。
- Butler entrypoint: iOS PWA Web Push notificationclick と /dashboard/notifications の PRを開く link。
- Action Schema exposure: 不要。このPRは Dashboard/PWA 通知導線の runtime UI 修正であり Custom GPT Action Schema は変更しません。
- Runtime path: POST /v2/events/github-actions -> dashboard event store -> buildDashboardWebPushPayload -> service worker notificationclick、または /dashboard/notifications render path。
- Runner/runtime truth: dashboard event の repository/pullNumber から GitHub PR URL を生成し、テストで payload.url と HTML link を確認。
- Authority boundary: 新しい high-risk authority は追加しません。PR URL を開くだけで merge/deploy/credential mutation は実行しません。
- E2E evidence: worker-level evidence は pass。iPhone 実機 live E2E は Issue #444 全体の残作業として未実施。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 未実施。このPRは runtime code 変更のみで、deploy は別 authority boundary。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。Issue #444 全体の E2E として残す。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate。\nAGENTS.md Butler-First Operating Principle。\nAGENTS.md Evidence Discipline。\nAGENTS.md Active-Issue Coverage Policy。

## Out-of-scope but NOT implemented

- Issue #528: 管理メニュー文言の削減。
- Issue #448 / Issue #413: 失敗時の復旧 orchestration / progress truth。
- Issue #599: PR/Issue タイトル日本語-first guard。

## Extra changes (if any)

worker.js は npm run build:worker で生成更新。

<!-- VTDD metadata -->
- Issue: Issue #444
- Execution ID: Not provided.
- Goal: Not provided.
