### PR TITLE
Issue #450: Preserve dashboard traffic-control context

### DIFF
--- a/docs/butler/dashboard-butler-app-server-live-path.md
+++ b/docs/butler/dashboard-butler-app-server-live-path.md
@@ -102,6 +102,14 @@ The bridge uses the generated `codex app-server` protocol shape:
 - `turn/start`
 - notifications including `item/agentMessage/delta` and `turn/completed`
 
+Dashboard turn requests must preserve traffic-control context when present:
+
+- repository and related Issue from the Dashboard thread
+- Dashboard authority hints for GO / passkey boundaries
+- media reference count without raw binary material
+- instructions to read durable Issue / PR / runtime truth before separating
+  blockers, next actions, authority boundaries, and evidence gaps
+
 The old Dashboard `codex exec` runner WebSocket remains deleted. If no
 Dashboard app-server bridge is connected, Dashboard Butler records the owner
 message and reports the bridge as unavailable; it does not pretend to have sent

--- a/docs/butler/dashboard-butler-app-server-live-path.md
+++ b/docs/butler/dashboard-butler-app-server-live-path.md
@@ -109,6 +109,8 @@ Dashboard turn requests must preserve traffic-control context when present:
 - media reference count without raw binary material
 - instructions to read durable Issue / PR / runtime truth before separating
   blockers, next actions, authority boundaries, and evidence gaps
+- the mechanical bridge boundary that app-server command, file-change, patch,
+  and permission escalation approvals are not granted by the Dashboard bridge
 
 The old Dashboard `codex exec` runner WebSocket remains deleted. If no
 Dashboard app-server bridge is connected, Dashboard Butler records the owner

--- a/scripts/run-dashboard-app-server-bridge.mjs
+++ b/scripts/run-dashboard-app-server-bridge.mjs
@@ -39,6 +39,7 @@ export function buildAppServerThreadStartRequest({ id, cwd = process.cwd(), deve
         [
           "You are backing VTDD Dashboard Butler.",
           "Treat ordinary messages as conversation unless the owner asks for repository, Issue, PR, deploy, credential, or permission work.",
+          "For traffic-control requests, read durable Issue/PR/runtime truth first, separate blockers from next actions, and do not claim VTDD completion without Butler-facing evidence.",
           "High-risk work requires explicit GO or passkey approval through VTDD runtime boundaries.",
           "Reply in Japanese by default."
         ].join("\n"),
@@ -85,6 +86,36 @@ export function buildAppServerTurnStartRequest({ id, codexThreadId, text, cwd = 
       ...(sandbox.turnSandboxPolicy ? { sandboxPolicy: sandbox.turnSandboxPolicy } : {})
     }
   };
+}
+
+export function buildDashboardTurnInputText(request = {}) {
+  const ownerText = String(request.text || "").trim();
+  const repository = String(request.repository || "").trim();
+  const relatedIssue = request.relatedIssue || request.issueNumber || "";
+  const authority = request.authority && typeof request.authority === "object" ? request.authority : null;
+  const mediaReferences = Array.isArray(request.mediaReferences) ? request.mediaReferences : [];
+  const hasDashboardContext = Boolean(repository || relatedIssue || authority || mediaReferences.length > 0);
+  if (!hasDashboardContext) {
+    return ownerText;
+  }
+
+  const lines = [
+    "Dashboard Butler turn context:",
+    `- repository: ${repository || "未指定"}`,
+    `- relatedIssue: ${relatedIssue ? `#${relatedIssue}` : "未指定"}`,
+    `- mediaReferences: ${mediaReferences.length}`,
+    "- surface: Dashboard Butler PWA via VPS Dashboard Bridge / codex app-server",
+    "- trafficControlRule: Issue/PR/docs/runtime truth を先に読み、blocker / next action / authority boundary / evidence gap を分けて報告する。",
+    "- completionRule: Butler Completion Gate と E2E evidence が揃うまで Dashboard Butler 完了とは言わない。",
+    "- authorityRule: merge / deploy / credential / permission / destructive work は GO または passkey approval が必要。権限が無い場合は実行せず不足を報告する。"
+  ];
+
+  if (authority) {
+    lines.push(`- authority: ${JSON.stringify(authority)}`);
+  }
+
+  lines.push("", "Owner message:", ownerText);
+  return lines.join("\n");
 }
 
 export function buildAppServerSandboxOverrides(sandboxMode = "") {
@@ -431,7 +462,22 @@ export async function handleDashboardTurnRequest({
     void sendDashboardEvent(event);
   });
   try {
-    const startedTurn = await appServer.request(buildAppServerTurnStartRequest({ id: appServer.nextRequestId(), codexThreadId, text, cwd, sandboxMode }));
+    const turnInputText = buildDashboardTurnInputText({
+      text,
+      repository: request.repository,
+      relatedIssue: request.relatedIssue || request.issueNumber,
+      authority: request.authority,
+      mediaReferences: request.mediaReferences
+    });
+    const startedTurn = await appServer.request(
+      buildAppServerTurnStartRequest({
+        id: appServer.nextRequestId(),
+        codexThreadId,
+        text: turnInputText,
+        cwd,
+        sandboxMode
+      })
+    );
     const startedTurnId = String(startedTurn?.turn?.id || "");
     if (activeTurnId && startedTurnId && activeTurnId !== startedTurnId) {
       throw new Error("codex app-server returned a different turn id than the active notification stream");

--- a/scripts/run-dashboard-app-server-bridge.mjs
+++ b/scripts/run-dashboard-app-server-bridge.mjs
@@ -107,7 +107,8 @@ export function buildDashboardTurnInputText(request = {}) {
     "- surface: Dashboard Butler PWA via VPS Dashboard Bridge / codex app-server",
     "- trafficControlRule: Issue/PR/docs/runtime truth を先に読み、blocker / next action / authority boundary / evidence gap を分けて報告する。",
     "- completionRule: Butler Completion Gate と E2E evidence が揃うまで Dashboard Butler 完了とは言わない。",
-    "- authorityRule: merge / deploy / credential / permission / destructive work は GO または passkey approval が必要。権限が無い場合は実行せず不足を報告する。"
+    "- authorityRule: merge / deploy / credential / permission / destructive work は GO または passkey approval が必要。権限が無い場合は実行せず不足を報告する。",
+    "- mechanicalBoundary: Dashboard bridge does not grant app-server command, file-change, patch, or permission escalation approvals."
   ];
 
   if (authority) {

--- a/test/dashboard-app-server-bridge.test.js
+++ b/test/dashboard-app-server-bridge.test.js
@@ -79,6 +79,8 @@ test("dashboard app-server bridge wraps repository traffic-control context into 
   assert.match(text, /trafficControlRule/);
   assert.match(text, /Butler Completion Gate/);
   assert.match(text, /GO.*passkey approval/);
+  assert.match(text, /mechanicalBoundary/);
+  assert.match(text, /does not grant app-server command, file-change, patch, or permission escalation approvals/);
   assert.match(text, /Owner message:\nDashboard Butler が交通整理できるようにして/);
 });
 
@@ -442,6 +444,7 @@ test("dashboard app-server bridge passes traffic-control context to codex app-se
   assert.match(inputText, /repository: marushu\/vtdd-v2-p/);
   assert.match(inputText, /relatedIssue: #450/);
   assert.match(inputText, /trafficControlRule/);
+  assert.match(inputText, /mechanicalBoundary/);
   assert.match(inputText, /Owner message:\nDashboard Butler が交通整理できるか確認して/);
   assert.equal(events.at(-1).type, "app_server_reply");
 });

--- a/test/dashboard-app-server-bridge.test.js
+++ b/test/dashboard-app-server-bridge.test.js
@@ -8,6 +8,7 @@ import {
   buildAppServerThreadResumeRequest,
   buildAppServerThreadStartRequest,
   buildAppServerTurnStartRequest,
+  buildDashboardTurnInputText,
   connectDashboardAppServerBridgeOnce,
   extractAppServerNotificationTurnId,
   handleDashboardTurnRequest,
@@ -59,6 +60,26 @@ test("dashboard app-server bridge builds initialize and thread requests from Cod
   assert.equal(turn.params.threadId, "codex-thread-1");
   assert.deepEqual(turn.params.input, [{ type: "text", text: "今日は何日？", text_elements: [] }]);
   assert.equal(turn.params.sandboxPolicy, undefined);
+});
+
+test("dashboard app-server bridge wraps repository traffic-control context into turn input", () => {
+  const text = buildDashboardTurnInputText({
+    repository: "marushu/vtdd-v2-p",
+    relatedIssue: 450,
+    text: "Dashboard Butler が交通整理できるようにして",
+    authority: {
+      ordinaryConversationAllowed: true,
+      highRiskActionsRequire: ["GO", "passkey_approval"]
+    }
+  });
+
+  assert.match(text, /Dashboard Butler turn context/);
+  assert.match(text, /repository: marushu\/vtdd-v2-p/);
+  assert.match(text, /relatedIssue: #450/);
+  assert.match(text, /trafficControlRule/);
+  assert.match(text, /Butler Completion Gate/);
+  assert.match(text, /GO.*passkey approval/);
+  assert.match(text, /Owner message:\nDashboard Butler が交通整理できるようにして/);
 });
 
 test("dashboard app-server bridge only enables danger-full-access by explicit trusted VPS opt-in", () => {
@@ -351,6 +372,78 @@ test("dashboard app-server bridge handles a fresh dashboard turn through thread/
   assert.equal(events[1].type, "app_server_reply_delta");
   assert.equal(events[2].type, "app_server_reply");
   assert.equal(events[2].text, "今日は2026年5月22日です。");
+});
+
+test("dashboard app-server bridge passes traffic-control context to codex app-server turns", async () => {
+  const requests = [];
+  const events = [];
+  const handlers = new Set();
+  let nextId = 1;
+  const appServer = {
+    nextRequestId() {
+      const id = nextId;
+      nextId += 1;
+      return id;
+    },
+    onNotification(handler) {
+      handlers.add(handler);
+      return () => handlers.delete(handler);
+    },
+    async request(message) {
+      requests.push(message);
+      if (message.method === "thread/start") {
+        return { thread: { id: "codex-thread-traffic" } };
+      }
+      if (message.method === "turn/start") {
+        for (const handler of handlers) {
+          handler({
+            method: "item/agentMessage/delta",
+            params: {
+              threadId: "codex-thread-traffic",
+              turnId: "turn-traffic",
+              delta: "交通整理します。"
+            }
+          });
+          handler({
+            method: "turn/completed",
+            params: {
+              threadId: "codex-thread-traffic",
+              turn: { id: "turn-traffic", status: "completed" }
+            }
+          });
+        }
+        return { turn: { id: "turn-traffic" } };
+      }
+      throw new Error(`unexpected method ${message.method}`);
+    }
+  };
+
+  await handleDashboardTurnRequest({
+    request: {
+      threadId: "dashboard-main",
+      codexThreadId: null,
+      repository: "marushu/vtdd-v2-p",
+      relatedIssue: 450,
+      text: "Dashboard Butler が交通整理できるか確認して",
+      authority: {
+        ordinaryConversationAllowed: true,
+        repositoryRequired: false,
+        highRiskActionsRequire: ["GO", "passkey_approval"]
+      }
+    },
+    appServer,
+    sendDashboardEvent: async (event) => events.push(event),
+    cwd: "/repo"
+  });
+
+  const turnStart = requests.find((request) => request.method === "turn/start");
+  assert.ok(turnStart);
+  const inputText = turnStart.params.input[0].text;
+  assert.match(inputText, /repository: marushu\/vtdd-v2-p/);
+  assert.match(inputText, /relatedIssue: #450/);
+  assert.match(inputText, /trafficControlRule/);
+  assert.match(inputText, /Owner message:\nDashboard Butler が交通整理できるか確認して/);
+  assert.equal(events.at(-1).type, "app_server_reply");
 });
 
 test("dashboard app-server bridge keeps listening for async turn notifications after turn/start response", async () => {


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #450 の部分進捗として、Dashboard Butler app-server bridge が repo / Issue / authority boundary を持つ自然文依頼を Codex app-server turn へ文脈付きで渡せるようにする。

## Satisfied Success Criteria

- Dashboard bridge の developer instructions に、交通整理時は Issue / PR / runtime truth を先に読み、blocker / next action / authority boundary / evidence gap を分ける指示を追加した。
- Dashboard turn input に repository、related Issue、media reference count、GO/passkey authority hints、Butler Completion Gate を同梱する helper を追加した。
- handleDashboardTurnRequest が context-wrapped input を turn/start に渡すよう接続した。
- #450 の app-server live path doc に traffic-control context preservation を追記した。
- Dashboard bridge が app-server command / file-change / patch / permission escalation approval を grant しない mechanical boundary を turn context、docs、test に固定した。

## Unsatisfied Success Criteria

- Live VPS Dashboard Bridge / codex app-server 接続の本番E2Eは未実施。
- iPhone/iPad Dashboard Butler から実際に同一 live Codex thread で交通整理できる証跡は未取得。
- Issue #450 全体の completion criteria は未完了。

## Non-goal violations

Deploy、credential mutation、permission mutation、Issue close、旧 codex exec fallback 復活、Dashboard Butler 完了宣言は行わない。

## Dry-run Impact Report

- Target Issue: Issue #450
- Implementing Success Criteria: Dashboard Butler app-server bridge が repo / Issue / authority context を turn input に保持し、traffic-control request が durable truth / boundary / evidence gap を分けられるようにする。高リスク承認は LLM 解釈だけに依存せず、bridge が escalation approval を grant しない mechanical boundary を明示する。
- Explicit Non-goals: Deploy、credential/permission mutation、Issue close、Custom GPT Action Schema 変更、旧 codex exec fallback 復活、live E2E 完了宣言。
- Expected touched files/routes/workflows: scripts/run-dashboard-app-server-bridge.mjs, test/dashboard-app-server-bridge.test.js, docs/butler/dashboard-butler-app-server-live-path.md
- Affected Issues: Issue #450。Dashboard Butler live path の部分進捗。
- Affected PRs: PR #603。
- Affected workflows: CI の Node test。GitHub Actions workflow 定義は未変更。
- Affected runtime/operator surfaces: Dashboard Butler PWA -> VPS Dashboard Bridge -> codex app-server の turn input と approval request handling。Custom GPT Action Schema は未変更。
- What may break if we patch narrowly: 本文だけを app-server に渡すと、repo/Issue/authority boundary が失われる。authorityRule だけをプロンプトに置くと、LLM解釈頼みと見なされるため、bridge approval denial の mechanical boundary と併せて固定する。
- Unknowns to investigate before coding: Live VPS bridge と iPhone Dashboard E2E はこのPRでは未確認。
- Validation needed: node --test test/dashboard-app-server-bridge.test.js; node --test test/worker.test.js; git diff --check。Live E2E は後続。
- Stop condition: deploy、credential/permission mutation、Issue close、または #450 完了宣言が必要になった場合は停止する。

## Execution Queue Delta

- Queue position before: Issue #450 は Dashboard Butler live app-server path の未完了 blocker。PR #603 は ready_for_review 後に live E2E/LLM解釈/authority boundary の residual risk を指摘された。
- Preemption decision: NEXT。owner-facing Dashboard Butler が交通整理できないという直接 blocker に対する bounded implementation。
- Queue delta: Issue #450 の Queue item を進め、Dashboard bridge が traffic-control context と mechanical approval boundary を保持する実装 slice を追加。live E2E と完了判定は未完了として残す。
- Why this PR is next: Dashboard Butler が repo/Issue/authority 文脈や mechanical boundary を失うと、交通整理以前に live Codex turn が判断材料と実行境界を欠くため。
- Active Issues not downscoped: Active Issues は縮小しない。このPRは #450 の部分進捗のみ。

## File / Line Hypotheses

- file: `scripts/run-dashboard-app-server-bridge.mjs`
  - hypothesis: `handleDashboardTurnRequest` が owner text だけを `turn/start` に渡すと、Dashboard 側で解決した repository / Issue / authority hints が Codex app-server に届かない。さらに authorityRule がプロンプトだけだと高リスク境界が LLM 解釈依存に見える。
  - risk if changed narrowly: ordinary conversation を repo 必須にしてしまうと Dashboard Butler の通常会話が壊れる。approval denial を弱めると高リスク実行境界が漏れる。
  - validation: context なしでは raw owner text のまま、context ありでは wrapped input になる unit test。command/file/patch/permission approval request は bridge が grant しない unit test。
  - related Issue: #450

## Hypothesis Retrospective

- expected: traffic-control context を turn input に同梱し、通常会話は raw text のまま維持する。高リスク権限境界は prompt だけでなく bridge approval denial として固定する。
- actual: `buildDashboardTurnInputText` を追加し、context ありの場合のみ repository / Issue / authority / completion boundary / mechanicalBoundary を付与した。既存 approval denial tests と context tests を更新した。
- mismatch: live VPS/iPhone E2E はこのPRでは未実施。
- lesson: Dashboard Butler の交通整理能力は UI だけでなく bridge input contract と approval boundary contract に依存する。
- should become RAG candidate: yes。Dashboard app-server turn は owner text だけでなく Dashboard 解決済み context と mechanical approval boundary を保持する。

## Verification Evidence

- Unit: node --test test/dashboard-app-server-bridge.test.js (pass, 20 tests)
- Integration: node --test test/worker.test.js (pass, 209 tests)
- E2E: 未実施。このPRは live VPS bridge / iPhone Dashboard E2E を完了条件として主張しない。
- Manual: git diff --check (pass)
- Evidence path/link: test/dashboard-app-server-bridge.test.js; test/worker.test.js

## Butler Completion Contract

- Owner goal: Dashboard Butler が交通整理依頼を live Codex app-server に渡す時、repo / Issue / authority boundary / evidence gap の文脈を失わず、高リスク approval escalation は bridge が grant しない境界を維持する。
- Butler entrypoint: /dashboard chat thread -> /v2/dashboard/app-server/ws -> scripts/run-dashboard-app-server-bridge.mjs -> codex app-server turn/start。
- Action Schema exposure: 未変更。Dashboard app-server bridge path のみ。Custom GPT Action Schema は変更しない。
- Runtime path: Dashboard owner message -> Durable Object app_server_turn_requested -> VPS Dashboard Bridge handleDashboardTurnRequest -> codex app-server turn/start。Approval request は JsonLineAppServerClient が decline/deny/error で返し、bridge は escalation を grant しない。
- Runner/runtime truth: Unit/integration test で turn input、Worker bridge contract、approval denial boundary を検証。live runtime truth は未取得。
- Authority boundary: High-risk actions require GO or passkey approval を turn context に明示。bridge は command/file-change/patch/permission escalation approval を grant しない mechanical boundary を維持。
- E2E evidence: 未実施。Dashboard Butler 完了ではなく #450 部分進捗。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 不要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。後続で live VPS bridge / iPhone Dashboard E2E が必要。

## Related Constitution Rules

- Butler Completion Gate。Drift Stop Protocol。Issue #450 Dashboard Butler app-server live path。High-risk authority boundary。

## Out-of-scope but NOT implemented

- 本番 deploy。
- credential / permission mutation。
- Issue #450 close。
- Dashboard Butler completion claim。
- 旧 codex exec fallback 復活。
- live VPS/iPhone E2E completion claim。

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #450
- Execution ID: local-codex-2026-05-28-dashboard-traffic-control-context
- Goal: Dashboard Butler app-server bridge traffic-control context preservation with mechanical approval boundary
