### PR TITLE
Issue #413: VPS runner PRをreadyデフォルトにする

### DIFF
--- a/docs/butler/remote-codex-cli-executor.md
+++ b/docs/butler/remote-codex-cli-executor.md
@@ -186,6 +186,11 @@ runner events, create the target branch, run Codex CLI in a cloned workspace,
 push changes, and open a ready PR for reviewer/automation. It is intentionally an operator-owned script,
 not a hosted VTDD service.
 
+Ready PR means reviewer and automation can inspect the handoff result. It is
+not an Issue-completion claim and it is not merge authority. Merge remains
+behind reviewer approval, required checks, head-SHA consistency, mergeability,
+the configured auto-merge policy, or a governed approval path.
+
 Required runner environment:
 
 - `GITHUB_TOKEN` or `GH_TOKEN`: token available to `gh`, GitHub API reads,

--- a/docs/butler/remote-codex-cli-executor.md
+++ b/docs/butler/remote-codex-cli-executor.md
@@ -183,7 +183,7 @@ those minutes remain visible GitHub Actions usage.
 The public/core repository includes a minimal user-owned runner entrypoint at
 `scripts/run-vps-runner.mjs`. It can poll the GitHub queue contract, report
 runner events, create the target branch, run Codex CLI in a cloned workspace,
-push changes, and open a draft PR. It is intentionally an operator-owned script,
+push changes, and open a ready PR for reviewer/automation. It is intentionally an operator-owned script,
 not a hosted VTDD service.
 
 Required runner environment:

--- a/scripts/run-vps-runner.mjs
+++ b/scripts/run-vps-runner.mjs
@@ -2170,19 +2170,22 @@ function buildPullRequestBody(payload) {
       "VPS runner が target branch を作成した。",
       "VPS runner が GitHub-visible runtime truth として ready PR を作成した。"
     ].join("\n"),
-    unsatisfied: "human review と merge は未完了。Issue固有のE2E evidence も別途記録が必要。",
+    unsatisfied:
+      "Issue固有のE2E evidence は別途記録が必要。ready PR は reviewer/automation が読める状態を意味し、Issue完了やmerge許可を意味しない。",
     nonGoals: "None.",
     unit: "VPS runner では未実行。",
     integration: "VPS runner では未実行。",
     e2e: "GitHub branch / PR creation は handoff の証拠のみ。Issue固有の live E2E は別途記録する必要がある。",
     manual: "VPS runner が bounded Codex handoff を実行した。",
     evidencePath: `Issue #${payload.issueNumber}, branch ${payload.branch || "not provided"}, execution ${payload.executionId}`,
-    ownerGoal: "Butler/VPS runner 経由で bounded Codex implementation PR を作る。ただし merge-ready completion とは主張しない。",
+    ownerGoal:
+      "Butler/VPS runner 経由で bounded Codex implementation PR を作る。ready PR は review開始状態であり、Issue完了やmerge許可とは扱わない。",
     butlerEntrypoint: "Butler が bounded request を dispatch し、vtddExecutionProgress / GitHub runtime truth で進捗を読む。",
     actionSchemaExposure: "既存の Butler execution/progress surface。今回のPR body は Action Schema operation を追加しない。",
     runtimePath: "VPS runner queue comment -> scripts/run-vps-runner.mjs -> Git branch/commit/push -> ready PR。",
     runtimeTruth: `GitHub issue/PR comments、branch ${payload.branch || "not provided"}、execution ${payload.executionId || "not provided"}。`,
-    authorityBoundary: "VPS runner は ready PR 作成のみ。merge、Issue close、deploy、credential、permission、cleanup は明示的な governed approval なしでは blocked。",
+    authorityBoundary:
+      "VPS runner は ready PR 作成のみ。ready PR は Draft 解除済みのレビュー入口であり、merge は reviewer approve、required checks、head SHA一致、mergeability、approve_auto_merge policy、または governed approval なしでは blocked。",
     butlerE2E: "handoff PR creation のみ。Issue固有の Butler-facing E2E は scoped implementation PR で記録されるまで未完了。",
     completionStatus: "incomplete",
     cloudflareDeploy: "実行しない。",
@@ -2192,6 +2195,7 @@ function buildPullRequestBody(payload) {
     rules: [
       "queued handoff だけでは成功ではない。",
       "GitHub branch / PR / raw failure が runtime truth。",
+      "ready PR は Issue完了やmerge許可ではない。merge判断は reviewer/check/policy/approval gate が保持する。",
       "VPS runner は merge も deploy も実行しない。"
     ].join("\n"),
     outOfScope: [

--- a/scripts/run-vps-runner.mjs
+++ b/scripts/run-vps-runner.mjs
@@ -362,21 +362,13 @@ async function executeVpsRunnerExecution({
         payload,
         candidateBody: extractCodexPrBodyDraft(payload)
       });
+      const prCreateArgs = buildVpsRunnerPrCreateArgs({
+        payload,
+        bodyFile
+      });
       const pr = await runTrackedVpsCommand(
         "gh",
-        [
-          "pr",
-          "create",
-          "--draft",
-          "--base",
-          payload.baseRef || "main",
-          "--head",
-          payload.branch,
-          "--title",
-          `Issue #${payload.issueNumber}: VTDD VPS runner handoff`,
-          "--body-file",
-          bodyFile
-        ],
+        prCreateArgs,
         {
           cwd: workspace,
           env,
@@ -2173,10 +2165,10 @@ function buildPullRequestBody(payload) {
     issue: payload.issueNumber,
     executionId: payload.executionId,
     codexGoal: payload.codexGoal || "open_pr",
-    intent: `Issue #${payload.issueNumber} の bounded handoff を VPS runner で実行し、後でownerが再開できるようにGitHub-visibleなdraft PRとして残す。`,
+    intent: `Issue #${payload.issueNumber} の bounded handoff を VPS runner で実行し、後でownerとreviewerが再開できるようにGitHub-visibleなready PRとして残す。`,
     satisfied: [
       "VPS runner が target branch を作成した。",
-      "VPS runner が GitHub-visible runtime truth として draft PR を作成した。"
+      "VPS runner が GitHub-visible runtime truth として ready PR を作成した。"
     ].join("\n"),
     unsatisfied: "human review と merge は未完了。Issue固有のE2E evidence も別途記録が必要。",
     nonGoals: "None.",
@@ -2188,9 +2180,9 @@ function buildPullRequestBody(payload) {
     ownerGoal: "Butler/VPS runner 経由で bounded Codex implementation PR を作る。ただし merge-ready completion とは主張しない。",
     butlerEntrypoint: "Butler が bounded request を dispatch し、vtddExecutionProgress / GitHub runtime truth で進捗を読む。",
     actionSchemaExposure: "既存の Butler execution/progress surface。今回のPR body は Action Schema operation を追加しない。",
-    runtimePath: "VPS runner queue comment -> scripts/run-vps-runner.mjs -> Git branch/commit/push -> draft PR。",
+    runtimePath: "VPS runner queue comment -> scripts/run-vps-runner.mjs -> Git branch/commit/push -> ready PR。",
     runtimeTruth: `GitHub issue/PR comments、branch ${payload.branch || "not provided"}、execution ${payload.executionId || "not provided"}。`,
-    authorityBoundary: "VPS runner は draft PR 作成のみ。merge、Issue close、deploy、credential、permission、cleanup は明示的な governed approval なしでは blocked。",
+    authorityBoundary: "VPS runner は ready PR 作成のみ。merge、Issue close、deploy、credential、permission、cleanup は明示的な governed approval なしでは blocked。",
     butlerE2E: "handoff PR creation のみ。Issue固有の Butler-facing E2E は scoped implementation PR で記録されるまで未完了。",
     completionStatus: "incomplete",
     cloudflareDeploy: "実行しない。",
@@ -2208,6 +2200,21 @@ function buildPullRequestBody(payload) {
       "secret、permission、repository settings mutation。"
     ].join("\n")
   });
+}
+
+function buildVpsRunnerPrCreateArgs({ payload = {}, bodyFile = "" } = {}) {
+  return [
+    "pr",
+    "create",
+    "--base",
+    payload.baseRef || "main",
+    "--head",
+    payload.branch,
+    "--title",
+    `Issue #${payload.issueNumber}: VTDD VPS runner handoff`,
+    "--body-file",
+    bodyFile
+  ];
 }
 
 function buildGuardedPullRequestBody({ payload, candidateBody } = {}) {
@@ -2572,6 +2579,7 @@ export {
   buildCodexExecArgs,
   buildCodexExecutionEnv,
   buildVpsRunnerPreflightReceipt,
+  buildVpsRunnerPrCreateArgs,
   buildGuardedPullRequestBody,
   buildPostMergePullTruth,
   buildPullRequestBody,

--- a/test/vps-runner-script.test.js
+++ b/test/vps-runner-script.test.js
@@ -1010,6 +1010,8 @@ test("VPS runner PR body describes ready PR handoff without draft blocking seman
   assert.equal(body.includes("ready PR"), true);
   assert.equal(body.includes("draft PR"), false);
   assert.equal(body.includes("VPS runner は ready PR 作成のみ。"), true);
+  assert.equal(body.includes("ready PR は Issue完了やmerge許可ではない"), true);
+  assert.equal(body.includes("reviewer approve、required checks、head SHA一致、mergeability、approve_auto_merge policy"), true);
 });
 
 test("VPS runner dry run reports selected execution without side effects", async () => {

--- a/test/vps-runner-script.test.js
+++ b/test/vps-runner-script.test.js
@@ -12,6 +12,7 @@ import {
   buildPostMergePullTruth,
   buildPullRequestBody,
   buildVpsRunnerPreflightReceipt,
+  buildVpsRunnerPrCreateArgs,
   buildVpsRunnerCompletionFinalEvent,
   buildVpsRunnerEventComment,
   buildVpsReviewerFallbackActorIdentityIncident,
@@ -978,6 +979,37 @@ test("VPS runner diagnostic summaries redact secrets and stay short", () => {
   assert.equal(summary.includes("[REDACTED_API_KEY]"), true);
   assert.equal(summary.endsWith("[truncated]"), true);
   assert.equal(summary.length <= 192, true);
+});
+
+test("VPS runner creates ready PRs by default instead of blocking review as draft", () => {
+  const args = buildVpsRunnerPrCreateArgs({
+    payload: {
+      issueNumber: 413,
+      branch: "codex/issue-413-ready-pr-default",
+      baseRef: "main"
+    },
+    bodyFile: "/tmp/vtdd-vps-runner-pr-body.md"
+  });
+
+  assert.deepEqual(args.slice(0, 2), ["pr", "create"]);
+  assert.equal(args.includes("--draft"), false);
+  assert.equal(args.includes("--base"), true);
+  assert.equal(args.includes("--head"), true);
+  assert.equal(args.includes("--body-file"), true);
+});
+
+test("VPS runner PR body describes ready PR handoff without draft blocking semantics", () => {
+  const body = buildPullRequestBody({
+    repository: "sample-org/vtdd-v2",
+    issueNumber: 413,
+    executionId: "remote-codex-issue413-ready-test",
+    branch: "codex/issue-413",
+    codexGoal: "open_pr"
+  });
+
+  assert.equal(body.includes("ready PR"), true);
+  assert.equal(body.includes("draft PR"), false);
+  assert.equal(body.includes("VPS runner は ready PR 作成のみ。"), true);
 });
 
 test("VPS runner dry run reports selected execution without side effects", async () => {
@@ -1963,8 +1995,10 @@ test("VPS runner normalizes malformed PR body candidates with canonical template
 test("VPS runner create path uses prepared body-file helper instead of freehand --body", async () => {
   const source = await fs.readFile(path.join(process.cwd(), "scripts", "run-vps-runner.mjs"), "utf8");
   assert.equal(source.includes('import { prepareGuardedPullRequestBody, prepareGuardedPullRequestBodyFile } from "./prepare-pr-body-file.mjs";'), true);
-  assert.equal(source.includes('"--body-file",\n          bodyFile'), true);
+  assert.equal(source.includes('const prCreateArgs = buildVpsRunnerPrCreateArgs'), true);
+  assert.equal(source.includes('"--body-file",\n    bodyFile'), true);
   assert.equal(source.includes('"--body",\n          normalized.body'), false);
+  assert.equal(source.includes('"--draft"'), false);
 });
 
 test("VPS runner classifies unauthenticated Codex CLI as raw auth failure", () => {


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #413 の VPS runner / Codex execution progress の部分進捗として、VPS runner が作る implementation PR を Draft ではなく ready PR デフォルトにし、reviewer / approve_auto_merge を不必要に止めない。

## Satisfied Success Criteria

- scripts/run-vps-runner.mjs の gh pr create 引数から --draft を削除した。
- VPS runner PR body の runtime path / authority boundary / satisfied criteria を ready PR 前提に更新した。
- テストで buildVpsRunnerPrCreateArgs が --draft を含まないこと、PR body が draft PR semantics を含まないことを固定した。
- docs/butler/remote-codex-cli-executor.md の VPS runner 説明を ready PR for reviewer/automation に更新した。

## Unsatisfied Success Criteria

- 既存の Draft PR #603 の ready 化はこのPRでは実施しない。ready-for-review は別の GitHub authority action。VPS runner 以外の手動PR作成経路の自動制約は未実装。

## Non-goal violations

PR #603 のready化、merge、Issue close、deploy、credential/permission mutation は行わない。

## Dry-run Impact Report

- Target Issue: Issue #413
- Implementing Success Criteria: VPS runner / Codex execution progress が reviewer と automation を止めない ready PR をデフォルトで作成する。
- Explicit Non-goals: 既存PRの状態変更、merge、deploy、credential/permission mutation、GitHub authority plane の変更。
- Expected touched files/routes/workflows: scripts/run-vps-runner.mjs, test/vps-runner-script.test.js, docs/butler/remote-codex-cli-executor.md
- Affected Issues: Issue #413。VPS runner progress/PR creation semantics の部分進捗。
- Affected PRs: PR #603 は runtime truth として Draft blocking が確認されたが、このPRでは状態変更しない。
- Affected workflows: VPS runner が gh pr create する経路。GitHub Actions workflow 定義は未変更。
- Affected runtime/operator surfaces: VPS runner / Codex execution progress / reviewer / approve_auto_merge。
- What may break if we patch narrowly: Draft を未完了の印として使うと、Gemini approve と checks success 後でも approve_auto_merge が pull request is still draft で止まる。
- Unknowns to investigate before coding: 手動 mac Codex の gh pr create 経路は人間/agent運用規律で防ぐ必要がある。
- Validation needed: node --test test/vps-runner-script.test.js; git diff --check。
- Stop condition: ready-for-review mutation、merge、deploy、credential/permission mutation が必要になったら停止する。

## Execution Queue Delta

- Queue position before: Issue #413 は VPS runner progress / PR runtime truth の active queue。PR #603 で Draft が approve_auto_merge を止めた runtime truth がある。
- Preemption decision: NEXT。Draft default が reviewer/automation を止める直接 blocker として確認されたため。
- Queue delta: Issue #413 の Queue item を進め、VPS runner PR creation を ready PR default に変更する。PR #603 の状態変更は別判断として残す。
- Why this PR is next: Draft はレビュー不能状態であり、VTDD の reviewer / auto-merge loop に対して安全装置ではなくブロッカーになったため。
- Active Issues not downscoped: Active Issues は縮小しない。このPRは #413 の VPS runner PR creation semantics のみ。

## File / Line Hypotheses

- file: `scripts/run-vps-runner.mjs`
  - hypothesis: `gh pr create --draft` が reviewer と approve_auto_merge の正常経路を止める。
  - risk if changed narrowly: PR本文だけ ready と書いても GitHub metadata が Draft のままだと自動マージは止まる。
  - validation: create args に `--draft` が含まれない unit test。
  - related Issue: #413

## Hypothesis Retrospective

- expected: VPS runner の PR create args から `--draft` を削除し、body/docs/test を ready PR 前提に揃える。
- actual: `buildVpsRunnerPrCreateArgs` を追加し、`--draft` なしをテスト固定した。
- mismatch: なし。
- lesson: Draft は未完了表現ではなくレビュー/automation停止状態なので、VTDDのデフォルトにしてはいけない。
- should become RAG candidate: yes。PRの incomplete status は本文で表現し、GitHub Draft は明示的にレビューを止める時だけ使う。

## Verification Evidence

- Unit: node --test test/vps-runner-script.test.js (pass, 66 tests)
- Integration: git diff --check (pass)
- E2E: 未実施。VPS runner live execution はこのPRでは走らせない。
- Manual: rg confirmed no --draft/draft PR semantics in VPS runner source/docs except tests that assert absence or unrelated ready-for-review coverage.
- Evidence path/link: test/vps-runner-script.test.js; scripts/run-vps-runner.mjs

## Butler Completion Contract

- Owner goal: VPS runner がレビュー可能なPRを作り、Draft によって reviewer / approve_auto_merge を止めないようにする。
- Butler entrypoint: Butler -> VPS runner queue -> scripts/run-vps-runner.mjs -> gh pr create ready PR。
- Action Schema exposure: 未変更。VPS runner implementation path のみ。
- Runtime path: VPS runner queue comment -> scripts/run-vps-runner.mjs -> buildVpsRunnerPrCreateArgs -> gh pr create without --draft。
- Runner/runtime truth: Unit test で PR create args と PR body semantics を検証。live runner truth は未取得。
- Authority boundary: ready PR 作成のみ。merge、Issue close、deploy、credential、permission、destructive cleanup は引き続き governed approval なしでは blocked。
- E2E evidence: 未実施。このPRは VPS runner PR creation semantics のガードレール。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 不要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 不要。このPRは VPS runner script behavior の変更。

## Related Constitution Rules

- Change Size and PR Discipline。Evidence Discipline。Current Reality Guard。Issue #413 VPS runner progress visibility。

## Out-of-scope but NOT implemented

- PR #603 ready-for-review mutation。
- merge。
- Issue close。
- deploy。
- credential / permission mutation。

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #413
- Execution ID: local-codex-2026-05-28-ready-pr-default
- Goal: Make VPS runner create ready PRs by default
