### PR TITLE
Issue #609 Dashboard Butler chat に実行キュー文脈を渡す

### DIFF
--- a/scripts/run-dashboard-app-server-bridge.mjs
+++ b/scripts/run-dashboard-app-server-bridge.mjs
@@ -93,8 +93,18 @@ export function buildDashboardTurnInputText(request = {}) {
   const repository = String(request.repository || "").trim();
   const relatedIssue = request.relatedIssue || request.issueNumber || "";
   const authority = request.authority && typeof request.authority === "object" ? request.authority : null;
+  const trafficControl =
+    request.trafficControl && typeof request.trafficControl === "object"
+      ? request.trafficControl
+      : null;
   const mediaReferences = Array.isArray(request.mediaReferences) ? request.mediaReferences : [];
-  const hasDashboardContext = Boolean(repository || relatedIssue || authority || mediaReferences.length > 0);
+  const hasDashboardContext = Boolean(
+    repository ||
+      relatedIssue ||
+      authority ||
+      trafficControl ||
+      mediaReferences.length > 0
+  );
   if (!hasDashboardContext) {
     return ownerText;
   }
@@ -110,6 +120,10 @@ export function buildDashboardTurnInputText(request = {}) {
     "- authorityRule: merge / deploy / credential / permission / destructive work は GO または passkey approval が必要。権限が無い場合は実行せず不足を報告する。",
     "- mechanicalBoundary: Dashboard bridge does not grant app-server command, file-change, patch, or permission escalation approvals."
   ];
+
+  if (trafficControl) {
+    lines.push(`- trafficControl: ${JSON.stringify(trafficControl)}`);
+  }
 
   if (authority) {
     lines.push(`- authority: ${JSON.stringify(authority)}`);
@@ -468,6 +482,7 @@ export async function handleDashboardTurnRequest({
       repository: request.repository,
       relatedIssue: request.relatedIssue || request.issueNumber,
       authority: request.authority,
+      trafficControl: request.trafficControl,
       mediaReferences: request.mediaReferences
     });
     const startedTurn = await appServer.request(

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -320,6 +320,12 @@ export class DashboardChatRoom {
       status: "thinking",
       text: "app-server bridge の返信を待っています"
     });
+    const trafficControl = await buildDashboardChatTrafficControlContext({
+      env: this.env,
+      repository,
+      relatedIssue,
+      text
+    });
     const mapping = await this.readAppServerThreadMapping(threadId);
     const turnRequest = {
       type: "app_server_turn_requested",
@@ -337,7 +343,8 @@ export class DashboardChatRoom {
         startThreadMethod: mapping.codexThreadId ? "thread/resume" : "thread/start",
         turnMethod: "turn/start"
       },
-      authority: buildDashboardAppServerAuthorityHint({ repository, relatedIssue, text })
+      authority: buildDashboardAppServerAuthorityHint({ repository, relatedIssue, text }),
+      trafficControl
     };
     this.sendSocket(bridgeSockets[0], turnRequest);
   }
@@ -6486,6 +6493,59 @@ function buildDashboardAppServerAuthorityHint({ repository, relatedIssue, text }
         : "Treat as ordinary conversation unless the owner asks for repository, Issue, PR, deploy, credential, or permission work.",
     highRiskActionsRequire: ["GO", "passkey_approval"]
   };
+}
+
+async function buildDashboardChatTrafficControlContext({ env, repository, relatedIssue, text }) {
+  const normalizedRepository = normalizeCanonicalRepositoryInput(repository);
+  if (!normalizedRepository) {
+    return {
+      status: "未確認",
+      reason: "repository is required before Dashboard Butler can read execution queue truth",
+      currentSurface: "dashboard_butler",
+      authorityBoundary: "read_only_preflight",
+      nextSafeAction: "対象 repository を解決してから execution queue preflight を読む。"
+    };
+  }
+  try {
+    const startupPreflight = await buildStartupPreflight({
+      repository: normalizedRepository,
+      ref: "main",
+      issueNumber: normalizePositiveInteger(relatedIssue),
+      phase: "execution",
+      currentSurface: "dashboard_butler",
+      queryText:
+        normalizeText(text) ||
+        `Dashboard Butler traffic control ${relatedIssue ? `Issue #${relatedIssue}` : ""}`,
+      runtimeOrigin: normalizeText(env?.VTDD_RUNTIME_URL) || "https://dashboard-butler.local",
+      env
+    });
+    return {
+      status: startupPreflight.executionQueue?.status || "未確認",
+      repository: normalizedRepository,
+      relatedIssue: normalizePositiveInteger(relatedIssue) || null,
+      currentSurface: startupPreflight.currentSurface,
+      threadLocalAssumptionsPromoted: startupPreflight.threadLocalAssumptionsPromoted,
+      currentNow: startupPreflight.executionQueue?.currentNow || null,
+      next: startupPreflight.executionQueue?.next || [],
+      sectionSummaries: startupPreflight.executionQueue?.sectionSummaries || {},
+      missingSources: startupPreflight.missingSources || [],
+      missingSections: startupPreflight.executionQueue?.missingSections || [],
+      ownerFacingSummary: startupPreflight.executionQueue?.ownerFacingSummary || "現在の Now は未確認です。",
+      trafficControlRule: startupPreflight.executionQueue?.trafficControlRule || null,
+      authorityBoundary: "read_only_preflight",
+      nextSafeAction: startupPreflight.nextSafeAction
+    };
+  } catch (error) {
+    return {
+      status: "未確認",
+      repository: normalizedRepository,
+      relatedIssue: normalizePositiveInteger(relatedIssue) || null,
+      reason: normalizeText(error?.message) || "startup preflight failed",
+      currentSurface: "dashboard_butler",
+      authorityBoundary: "read_only_preflight",
+      nextSafeAction: "preflight failure を owner-facing blocker として報告する。"
+    };
+  }
 }
 
 function normalizeDashboardAppServerBridgeEvent(payload, { fallbackThreadId = "" } = {}) {

--- a/test/dashboard-app-server-bridge.test.js
+++ b/test/dashboard-app-server-bridge.test.js
@@ -70,6 +70,12 @@ test("dashboard app-server bridge wraps repository traffic-control context into 
     authority: {
       ordinaryConversationAllowed: true,
       highRiskActionsRequire: ["GO", "passkey_approval"]
+    },
+    trafficControl: {
+      status: "read",
+      currentSurface: "dashboard_butler",
+      currentNow: "Issue #590: app-server turn timeout must become recoverable.",
+      ownerFacingSummary: "現在の Now は Issue #590"
     }
   });
 
@@ -77,6 +83,8 @@ test("dashboard app-server bridge wraps repository traffic-control context into 
   assert.match(text, /repository: marushu\/vtdd-v2-p/);
   assert.match(text, /relatedIssue: #450/);
   assert.match(text, /trafficControlRule/);
+  assert.match(text, /"currentSurface":"dashboard_butler"/);
+  assert.match(text, /"currentNow":"Issue #590: app-server turn timeout must become recoverable\."/);
   assert.match(text, /Butler Completion Gate/);
   assert.match(text, /GO.*passkey approval/);
   assert.match(text, /mechanicalBoundary/);
@@ -431,6 +439,16 @@ test("dashboard app-server bridge passes traffic-control context to codex app-se
         ordinaryConversationAllowed: true,
         repositoryRequired: false,
         highRiskActionsRequire: ["GO", "passkey_approval"]
+      },
+      trafficControl: {
+        status: "read",
+        currentSurface: "dashboard_butler",
+        currentNow: "Issue #590: app-server turn timeout must become recoverable.",
+        sectionSummaries: {
+          "Root Blockers": {
+            firstBullet: "Issue #450: Dashboard Butler live runtime remains central."
+          }
+        }
       }
     },
     appServer,
@@ -444,6 +462,8 @@ test("dashboard app-server bridge passes traffic-control context to codex app-se
   assert.match(inputText, /repository: marushu\/vtdd-v2-p/);
   assert.match(inputText, /relatedIssue: #450/);
   assert.match(inputText, /trafficControlRule/);
+  assert.match(inputText, /"currentSurface":"dashboard_butler"/);
+  assert.match(inputText, /"currentNow":"Issue #590: app-server turn timeout must become recoverable\."/);
   assert.match(inputText, /mechanicalBoundary/);
   assert.match(inputText, /Owner message:\nDashboard Butler が交通整理できるか確認して/);
   assert.equal(events.at(-1).type, "app_server_reply");

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -2743,6 +2743,9 @@ test("DashboardChatRoom sends ordinary owner turns to connected app-server bridg
   assert.equal(turnRequest.appServer.startThreadMethod, "thread/start");
   assert.equal(turnRequest.appServer.turnMethod, "turn/start");
   assert.equal(turnRequest.authority.ordinaryConversationAllowed, true);
+  assert.equal(turnRequest.trafficControl.status, "未確認");
+  assert.equal(turnRequest.trafficControl.currentSurface, "dashboard_butler");
+  assert.match(turnRequest.trafficControl.reason, /repository is required/);
 
   assert.equal(dashboardSocket.sent.length, 3);
   const broadcast = JSON.parse(dashboardSocket.sent[0]);
@@ -2756,6 +2759,134 @@ test("DashboardChatRoom sends ordinary owner turns to connected app-server bridg
   assert.equal(status.type, "transient_status");
   assert.equal(status.status, "thinking");
   assert.equal(status.text, "app-server bridge の返信を待っています");
+});
+
+test("DashboardChatRoom attaches execution queue preflight to repository app-server turns", async () => {
+  const provider = createInMemoryMemoryProvider();
+  const store = createInMemoryDashboardChatStore();
+  const dashboardSocket = createMockSocket("dashboard", "dashboard-main-marushu-vtdd-v2-p");
+  const bridgeSocket = createMockSocket("app_server_bridge", "dashboard-main-marushu-vtdd-v2-p");
+  const room = new DashboardChatRoom(
+    {
+      storage: createMockDurableObjectStorage(),
+      getWebSockets() {
+        return [dashboardSocket, bridgeSocket];
+      }
+    },
+    {
+      DASHBOARD_CHAT_STORE: store,
+      MEMORY_PROVIDER: provider,
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_dashboard_preflight",
+      GITHUB_API_FETCH: async (url) => {
+        const parsed = new URL(url);
+        if (parsed.pathname.endsWith("/docs/setup/known-good.json")) {
+          return new Response(JSON.stringify({ message: "Not Found" }), {
+            status: 404,
+            headers: { "content-type": "application/json" }
+          });
+        }
+        if (parsed.pathname.endsWith("/issues/609")) {
+          return new Response(
+            JSON.stringify({
+              number: 609,
+              title: "Dashboard Butler traffic-control preflight",
+              body: "Intent: expose execution queue truth to Dashboard Butler.",
+              state: "open",
+              html_url: "https://github.com/marushu/vtdd-v2-p/issues/609",
+              user: { login: "marushu" }
+            }),
+            { status: 200, headers: { "content-type": "application/json" } }
+          );
+        }
+        if (parsed.pathname.endsWith("/issues")) {
+          return new Response(JSON.stringify([]), {
+            status: 200,
+            headers: { "content-type": "application/json" }
+          });
+        }
+        if (parsed.pathname.includes("/contents/")) {
+          const decodedPath = decodeURIComponent(
+            parsed.pathname.split("/contents/")[1] || ""
+          );
+          const sourceContent = {
+            "AGENTS.md": "## Butler-First Operating Principle\nVTDD is iPhone/iPad-first.",
+            "docs/butler/thread-independent-startup-contract.md":
+              "threadLocalAssumptionsPromoted=false",
+            "docs/butler/execution-queue-contract.md":
+              "Owner input is a queue update event before implementation.\n`EMERGENCY` `ROOT` `NEXT` `QUEUE` `EVIDENCE` `QUESTION`",
+            "docs/mvp/active-issue-execution-queue.md": [
+              "# Active Issue Execution Queue",
+              "## Now",
+              "- Issue #590: app-server turn timeout must become recoverable.",
+              "## Next",
+              "- Issue #579: reconnect/auth recovery follows timeout recovery.",
+              "## Root Blockers",
+              "- Issue #450: Dashboard Butler live runtime remains central.",
+              "## Evidence Gaps",
+              "- Issue #609: live Dashboard Butler chat preflight evidence is pending.",
+              "## Blocked",
+              "- Issue #355: deploy requires passkey approval.",
+              "## Queue",
+              "- Issue #599: Japanese-first titles remain active.",
+              "## Questions",
+              "- Issue #595: runtime auto-classification remains incomplete."
+            ].join("\n"),
+            "docs/butler/capability-matrix.md": "Startup Surface Dependency Reading",
+            "docs/setup/custom-gpt-instructions.md": "vtddStartupPreflight",
+            "docs/setup/custom-gpt-actions-openapi.yaml":
+              "paths:\n  /v2/retrieve/startup-preflight:\n    get:\n      operationId: vtddStartupPreflight"
+          };
+          const content = sourceContent[decodedPath];
+          if (!content) {
+            return new Response(JSON.stringify({ message: "Not Found" }), {
+              status: 404,
+              headers: { "content-type": "application/json" }
+            });
+          }
+          return new Response(
+            JSON.stringify({
+              path: decodedPath,
+              type: "file",
+              sha: `${decodedPath.replace(/[^a-z0-9]/gi, "-")}-sha`,
+              html_url: `https://github.com/marushu/vtdd-v2-p/blob/main/${decodedPath}`,
+              encoding: "base64",
+              content: Buffer.from(content, "utf8").toString("base64")
+            }),
+            { status: 200, headers: { "content-type": "application/json" } }
+          );
+        }
+        throw new Error(`unexpected GitHub API url: ${parsed.pathname}`);
+      }
+    }
+  );
+
+  await room.webSocketMessage(
+    dashboardSocket,
+    JSON.stringify({
+      type: "owner_message",
+      threadId: "dashboard-main-marushu-vtdd-v2-p",
+      repository: "marushu/vtdd-v2-p",
+      issueNumber: 609,
+      text: "Dashboard Butler の交通整理をして"
+    })
+  );
+
+  const turnRequest = JSON.parse(bridgeSocket.sent[0]);
+  assert.equal(turnRequest.type, "app_server_turn_requested");
+  assert.equal(turnRequest.repository, "marushu/vtdd-v2-p");
+  assert.equal(turnRequest.relatedIssue, 609);
+  assert.equal(turnRequest.trafficControl.status, "read");
+  assert.equal(turnRequest.trafficControl.currentSurface, "dashboard_butler");
+  assert.equal(
+    turnRequest.trafficControl.currentNow,
+    "Issue #590: app-server turn timeout must become recoverable."
+  );
+  assert.equal(
+    turnRequest.trafficControl.sectionSummaries["Root Blockers"].firstBullet,
+    "Issue #450: Dashboard Butler live runtime remains central."
+  );
+  assert.match(turnRequest.trafficControl.ownerFacingSummary, /Issue #590/);
+  assert.equal(turnRequest.trafficControl.authorityBoundary, "read_only_preflight");
 });
 
 test("DashboardChatRoom broadcasts thread truth before owner ack for ack-drop recovery", async () => {

--- a/worker.js
+++ b/worker.js
@@ -56475,6 +56475,12 @@ var DashboardChatRoom = class {
       status: "thinking",
       text: "app-server bridge \u306E\u8FD4\u4FE1\u3092\u5F85\u3063\u3066\u3044\u307E\u3059"
     });
+    const trafficControl = await buildDashboardChatTrafficControlContext({
+      env: this.env,
+      repository,
+      relatedIssue,
+      text
+    });
     const mapping = await this.readAppServerThreadMapping(threadId);
     const turnRequest = {
       type: "app_server_turn_requested",
@@ -56492,7 +56498,8 @@ var DashboardChatRoom = class {
         startThreadMethod: mapping.codexThreadId ? "thread/resume" : "thread/start",
         turnMethod: "turn/start"
       },
-      authority: buildDashboardAppServerAuthorityHint({ repository, relatedIssue, text })
+      authority: buildDashboardAppServerAuthorityHint({ repository, relatedIssue, text }),
+      trafficControl
     };
     this.sendSocket(bridgeSockets[0], turnRequest);
   }
@@ -61797,6 +61804,56 @@ function buildDashboardAppServerAuthorityHint({ repository, relatedIssue, text }
     escalation: needsRepositoryContext ? "Repository / Issue context may be used, but high-risk actions still require explicit GO or passkey approval." : "Treat as ordinary conversation unless the owner asks for repository, Issue, PR, deploy, credential, or permission work.",
     highRiskActionsRequire: ["GO", "passkey_approval"]
   };
+}
+async function buildDashboardChatTrafficControlContext({ env, repository, relatedIssue, text }) {
+  const normalizedRepository = normalizeCanonicalRepositoryInput(repository);
+  if (!normalizedRepository) {
+    return {
+      status: "\u672A\u78BA\u8A8D",
+      reason: "repository is required before Dashboard Butler can read execution queue truth",
+      currentSurface: "dashboard_butler",
+      authorityBoundary: "read_only_preflight",
+      nextSafeAction: "\u5BFE\u8C61 repository \u3092\u89E3\u6C7A\u3057\u3066\u304B\u3089 execution queue preflight \u3092\u8AAD\u3080\u3002"
+    };
+  }
+  try {
+    const startupPreflight = await buildStartupPreflight({
+      repository: normalizedRepository,
+      ref: "main",
+      issueNumber: normalizePositiveInteger9(relatedIssue),
+      phase: "execution",
+      currentSurface: "dashboard_butler",
+      queryText: normalizeText30(text) || `Dashboard Butler traffic control ${relatedIssue ? `Issue #${relatedIssue}` : ""}`,
+      runtimeOrigin: normalizeText30(env?.VTDD_RUNTIME_URL) || "https://dashboard-butler.local",
+      env
+    });
+    return {
+      status: startupPreflight.executionQueue?.status || "\u672A\u78BA\u8A8D",
+      repository: normalizedRepository,
+      relatedIssue: normalizePositiveInteger9(relatedIssue) || null,
+      currentSurface: startupPreflight.currentSurface,
+      threadLocalAssumptionsPromoted: startupPreflight.threadLocalAssumptionsPromoted,
+      currentNow: startupPreflight.executionQueue?.currentNow || null,
+      next: startupPreflight.executionQueue?.next || [],
+      sectionSummaries: startupPreflight.executionQueue?.sectionSummaries || {},
+      missingSources: startupPreflight.missingSources || [],
+      missingSections: startupPreflight.executionQueue?.missingSections || [],
+      ownerFacingSummary: startupPreflight.executionQueue?.ownerFacingSummary || "\u73FE\u5728\u306E Now \u306F\u672A\u78BA\u8A8D\u3067\u3059\u3002",
+      trafficControlRule: startupPreflight.executionQueue?.trafficControlRule || null,
+      authorityBoundary: "read_only_preflight",
+      nextSafeAction: startupPreflight.nextSafeAction
+    };
+  } catch (error2) {
+    return {
+      status: "\u672A\u78BA\u8A8D",
+      repository: normalizedRepository,
+      relatedIssue: normalizePositiveInteger9(relatedIssue) || null,
+      reason: normalizeText30(error2?.message) || "startup preflight failed",
+      currentSurface: "dashboard_butler",
+      authorityBoundary: "read_only_preflight",
+      nextSafeAction: "preflight failure \u3092 owner-facing blocker \u3068\u3057\u3066\u5831\u544A\u3059\u308B\u3002"
+    };
+  }
 }
 function normalizeDashboardAppServerBridgeEvent(payload, { fallbackThreadId = "" } = {}) {
   const input = normalizeObject11(payload);


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #609 の follow-up です。前回 PR #610 は `vtddStartupPreflight` の runtime response に execution queue truth を載せましたが、Dashboard Butler の通常チャット turn にはまだ自動で入っていませんでした。
- この PR では Dashboard Butler chat -> app-server bridge -> codex app-server turn の request に `trafficControl` context を添付し、Dashboard Butler が通常チャットでも `Now` / `Next` / Root Blockers / Evidence Gaps を読んでから返答できるようにします。

## Satisfied Success Criteria

- DashboardChatRoom が repository 解決済みの owner turn で startup preflight を読み、`trafficControl.currentNow`、section summaries、missing source、owner-facing summary を app-server turn request に添付します。
- repository 未解決の owner turn では、推測せず `trafficControl.status = 未確認` と `repository is required` reason を添付します。
- app-server bridge が `trafficControl` JSON を Codex app-server の turn input text に含めます。
- tests で DashboardChatRoom から app-server bridge へ execution queue preflight が渡ること、bridge が codex app-server turn input に含めることを確認しました。

## Unsatisfied Success Criteria

- live Dashboard Butler PWA での実操作 E2E は未実施です。
- Issue #590 timeout recovery は未実装です。
- Custom GPT editor 更新確認や Issue #609 close はこの PR では行いません。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #609
- Implementing Success Criteria: Dashboard Butler normal chat turn に execution queue preflight context を接続する。
- Explicit Non-goals: Issue #590 timeout recovery、UI layout/reconnect/attachment/notification delivery、deploy、credential / permission mutation、Issue close、GitHub runtime truth からの完全自動 queue 生成はしない。
- Expected touched files/routes/workflows: `src/worker/runtime.js`, `worker.js`, `scripts/run-dashboard-app-server-bridge.mjs`, `test/worker.test.js`, `test/dashboard-app-server-bridge.test.js`
- Affected Issues: Issue #609, Issue #595, Issue #590, Issue #579, Issue #450
- Affected PRs: PR #610 as prior merged preflight source exposure
- Affected workflows: none. GitHub Actions workflow files are not changed.
- Affected runtime/operator surfaces: Dashboard Butler chat WebSocket, Dashboard app-server bridge WebSocket, codex app-server turn input.
- What may break if we patch narrowly: static traffic-control instructions can still leave codex app-server without current queue truth; structured `trafficControl` avoids relying on memory.
- Unknowns to investigate before coding: live app-server bridge availability on VPS remains separate runtime evidence.
- Validation needed: `npm run verify:worker`, `node --test test/worker.test.js`, `node --test test/dashboard-app-server-bridge.test.js`, `git diff --check`, PR body validation.
- Stop condition: if this requires deploy, credential/permission mutation, or implementing Issue #590 timeout recovery, stop and keep it out of this PR.

## Execution Queue Delta

- Queue position before: Issue #609 had source/runtime preflight exposure via PR #610, but Dashboard Butler normal chat still sent only static traffic-control text to app-server.
- Preemption decision: ROOT - Dashboard Butler cannot be called traffic-control capable if its normal chat path does not pass current queue truth into the app-server turn.
- Queue delta: Issue #609 advances from source/runtime preflight exposure to Dashboard chat/app-server turn integration; durable post-merge `Now` remains Issue #590.
- Why this PR is next: owner explicitly pointed out that the Dashboard Butler path, not just Custom GPT, must be connected.
- Active Issues not downscoped: Active Issues are not downscoped. Issue #590, Issue #579, Issue #450, Issue #413, Issue #528, Issue #595, and the rest of the active queue remain active unless their own gates are met.

## File / Line Hypotheses

- file: `src/worker/runtime.js`
  - hypothesis: DashboardChatRoom has repository/Issue context at owner turn time and can attach read-only startup preflight truth before sending the app-server turn request.
  - risk if changed narrowly: unresolved repository turns could fabricate queue truth; this PR returns `未確認` instead.
  - validation: `test/worker.test.js` covers resolved and unresolved repository turns.
  - related Issue: Issue #609
- file: `scripts/run-dashboard-app-server-bridge.mjs`
  - hypothesis: the bridge already wraps dashboard context into input text, so adding `trafficControl` there sends the structured queue truth to codex app-server without changing app-server protocol.
  - risk if changed narrowly: if bridge drops the field, DashboardChatRoom would produce truth but Codex app-server would never see it.
  - validation: `test/dashboard-app-server-bridge.test.js` asserts turn input includes `trafficControl`.
  - related Issue: Issue #609

## Hypothesis Retrospective

- expected: PR #610 made preflight readable, but not automatically used by Dashboard chat.
- actual: DashboardChatRoom now attaches `trafficControl` to each repository-scoped app-server turn, and the bridge includes it in the Codex turn input.
- mismatch: the previous answer over-focused on Custom GPT/editor update and under-stated the normal Dashboard Butler chat gap.
- lesson: Dashboard Butler completion must follow the actual chat path, not only Action Schema/read-route availability.
- should become RAG candidate: yes

## Verification Evidence

- Unit: `node --test test/worker.test.js` passed, 212/212 tests.
- Unit: `node --test test/dashboard-app-server-bridge.test.js` passed, 20/20 tests.
- Integration: `npm run verify:worker` passed, including `npm run build:worker`, `npm test`, `check:self-parity`, and `check:generated-worker`.
- Static: `git diff --check` passed.
- E2E: local worker-level Dashboard chat/app-server bridge route equivalent is tested; live PWA/app-server bridge E2E is not performed.
- Evidence path/link: `src/worker/runtime.js`
- Evidence path/link: `scripts/run-dashboard-app-server-bridge.mjs`
- Evidence path/link: `test/worker.test.js`
- Evidence path/link: `test/dashboard-app-server-bridge.test.js`

## Butler Completion Contract

- Owner goal: Dashboard Butler の通常チャットが、owner の自然文入力を app-server に渡す前に execution queue truth を添えて交通整理できるようにする。
- Butler entrypoint: Dashboard Butler PWA chat WebSocket owner turn -> DashboardChatRoom -> app-server bridge -> codex app-server turn.
- Action Schema exposure: no new Custom GPT operationId. This PR is Dashboard Butler chat/runtime integration.
- Runtime path: `DashboardChatRoom.acceptOwnerMessage` -> `buildDashboardChatTrafficControlContext` -> `buildStartupPreflight` -> app-server turn request `trafficControl` -> `buildDashboardTurnInputText`.
- Runner/runtime truth: GitHub App-backed repository contents read supplies execution queue source truth. Missing repository/source returns `未確認` instead of guessing.
- Authority boundary: read-only preflight context. No deploy, credential, permission, merge, Issue close, or destructive mutation.
- E2E evidence: worker-level Dashboard chat/app-server bridge route equivalent is tested; live production PWA/app-server evidence is not included.
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: required after merge because Worker runtime and bridge script changed.
- Custom GPT Action Schema update: not changed by this PR.
- Custom GPT Instructions update: not changed by this PR.
- iPhone Butler live E2E: not performed.

## Related Constitution Rules

- Butler Completion Gate
- Butler-First Operating Principle
- Chief Butler Operating Principle
- Thread-Independent Startup Contract
- Drift Stop Protocol
- Evidence Discipline

## Out-of-scope but NOT implemented

- Issue #590 app-server timeout recovery
- Issue #579 PWA reconnect/auth/session/input recovery
- live Cloudflare deploy
- live Dashboard Butler PWA/app-server E2E
- Issue close
- GitHub runtime truthからの完全自動 queue 生成

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #609
- Execution ID: local-codex-2026-05-28-dashboard-chat-traffic-control-context
- Goal: dashboard_butler_chat_execution_queue_context
