### PR TITLE
Issue #590 app-server timeout をチャット復帰可能にする

### DIFF
--- a/scripts/run-dashboard-app-server-bridge.mjs
+++ b/scripts/run-dashboard-app-server-bridge.mjs
@@ -7,6 +7,8 @@ const DANGER_FULL_ACCESS_SANDBOX = "danger-full-access";
 const APP_SERVER_FAILURE_ALREADY_SENT = Symbol("appServerFailureAlreadySent");
 const DEFAULT_APP_SERVER_ERROR_TEXT =
   "codex app-server が応答生成中に失敗しました。画像を解析できなかった可能性があります。もう一度送るか、画像なしで内容を短く説明してください。";
+const APP_SERVER_TURN_TIMEOUT_TEXT =
+  "codex app-server の応答生成が時間切れになりました。入力は Dashboard thread に保存済みです。同じ thread で続けるか、内容を短くしてもう一度送れます。";
 
 export function buildAppServerInitializeRequest(id = 1) {
   return {
@@ -255,6 +257,24 @@ function createAppServerFailureAlreadySentError(message) {
   return error;
 }
 
+function buildAppServerTurnTimeoutEvent({
+  dashboardThreadId,
+  codexThreadId,
+  repository,
+  relatedIssue
+} = {}) {
+  return {
+    type: "app_server_turn_failed",
+    schema: DEFAULT_SCHEMA,
+    threadId: dashboardThreadId,
+    codexThreadId: codexThreadId || null,
+    repository: repository || null,
+    relatedIssue: relatedIssue || null,
+    status: "timeout",
+    text: APP_SERVER_TURN_TIMEOUT_TEXT
+  };
+}
+
 function isAppServerFailureAlreadySent(error) {
   return Boolean(error && error[APP_SERVER_FAILURE_ALREADY_SENT]);
 }
@@ -434,7 +454,14 @@ export async function handleDashboardTurnRequest({
     resolveTurn = resolve;
     rejectTurn = reject;
     timeoutHandle = setTimeout(() => {
-      reject(new Error("codex app-server turn timed out before completion"));
+      const timeoutEvent = buildAppServerTurnTimeoutEvent({
+        dashboardThreadId,
+        codexThreadId,
+        repository: request.repository,
+        relatedIssue: request.relatedIssue || request.issueNumber
+      });
+      void sendDashboardEvent(timeoutEvent);
+      reject(createAppServerFailureAlreadySentError(timeoutEvent.text));
     }, turnTimeoutMs);
   });
   const finishTurn = (callback) => {

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -6589,6 +6589,7 @@ function normalizeDashboardAppServerBridgeEvent(payload, { fallbackThreadId = ""
     transientStatus = "replied";
     transientText = "Dashboard thread 接続済み。";
   } else if (eventType === "app_server_turn_failed" || status === "failed") {
+    const failureText = buildDashboardAppServerFailureThreadText({ text, status });
     messages.push(
       normalizeDashboardChatMessage(
         {
@@ -6597,7 +6598,7 @@ function normalizeDashboardAppServerBridgeEvent(payload, { fallbackThreadId = ""
           repository,
           relatedIssue,
           status: "failed",
-          text: text || "codex app-server bridge failed before returning a reply.",
+          text: failureText,
           createdAt
         },
         { threadId }
@@ -6621,6 +6622,18 @@ function normalizeDashboardAppServerBridgeEvent(payload, { fallbackThreadId = ""
     transientStatus,
     messages: messages.filter(Boolean)
   };
+}
+
+function buildDashboardAppServerFailureThreadText({ text = "", status = "" } = {}) {
+  const normalizedText = sanitizeDashboardChatText(text);
+  const normalizedStatus = normalizeDashboardEventText(status).toLowerCase();
+  if (
+    normalizedStatus === "timeout" ||
+    /timed out before completion/i.test(normalizedText)
+  ) {
+    return "codex app-server の応答生成が時間切れになりました。入力は Dashboard thread に保存済みです。同じ thread で続けるか、内容を短くしてもう一度送れます。";
+  }
+  return normalizedText || "codex app-server が返信前に失敗しました。同じ thread で続けるか、内容を短くしてもう一度送れます。";
 }
 
 const DASHBOARD_APP_SERVER_STAGE_TEXT = {

--- a/test/dashboard-app-server-bridge.test.js
+++ b/test/dashboard-app-server-bridge.test.js
@@ -537,6 +537,58 @@ test("dashboard app-server bridge keeps listening for async turn notifications a
   assert.equal(handlers.size, 0);
 });
 
+test("dashboard app-server bridge sends Japanese recoverable timeout failure", async () => {
+  const events = [];
+  const handlers = new Set();
+  let nextId = 1;
+  const appServer = {
+    nextRequestId() {
+      const id = nextId;
+      nextId += 1;
+      return id;
+    },
+    onNotification(handler) {
+      handlers.add(handler);
+      return () => handlers.delete(handler);
+    },
+    async request(message) {
+      if (message.method === "thread/start") {
+        return { thread: { id: "codex-thread-timeout" } };
+      }
+      if (message.method === "turn/start") {
+        return { turn: { id: "turn-timeout" } };
+      }
+      throw new Error(`unexpected method ${message.method}`);
+    }
+  };
+
+  await assert.rejects(
+    handleDashboardTurnRequest({
+      request: {
+        threadId: "dashboard-main",
+        repository: "marushu/vtdd-v2-p",
+        relatedIssue: 590,
+        text: "timeout を再現して"
+      },
+      appServer,
+      sendDashboardEvent: async (event) => events.push(event),
+      cwd: "/repo",
+      turnTimeoutMs: 1
+    }),
+    /応答生成が時間切れ/
+  );
+
+  const timeoutEvent = events.find((event) => event.type === "app_server_turn_failed");
+  assert.ok(timeoutEvent);
+  assert.equal(timeoutEvent.status, "timeout");
+  assert.equal(timeoutEvent.threadId, "dashboard-main");
+  assert.equal(timeoutEvent.repository, "marushu/vtdd-v2-p");
+  assert.equal(timeoutEvent.relatedIssue, 590);
+  assert.match(timeoutEvent.text, /入力は Dashboard thread に保存済み/);
+  assert.doesNotMatch(timeoutEvent.text, /timed out before completion/);
+  assert.equal(handlers.size, 0);
+});
+
 test("dashboard app-server bridge ignores notifications for a different Codex turn", async () => {
   const events = [];
   const handlers = new Set();

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -3129,6 +3129,47 @@ test("DashboardChatRoom does not persist app-server reply deltas as chat message
   assert.equal(stored[0].text, "日本時間では、今日は 05月22日 20時09分です。");
 });
 
+test("DashboardChatRoom persists app-server timeout as recoverable Japanese thread message", async () => {
+  const store = createInMemoryDashboardChatStore();
+  const dashboardSocket = createMockSocket("dashboard", "dashboard-main-unresolved");
+  const bridgeSocket = createMockSocket("app_server_bridge", "dashboard-main-unresolved");
+  const room = new DashboardChatRoom(
+    {
+      storage: createMockDurableObjectStorage(),
+      getWebSockets() {
+        return [dashboardSocket, bridgeSocket];
+      }
+    },
+    { DASHBOARD_CHAT_STORE: store }
+  );
+
+  await room.webSocketMessage(
+    bridgeSocket,
+    JSON.stringify({
+      type: "app_server_turn_failed",
+      status: "timeout",
+      threadId: "dashboard-main-unresolved",
+      repository: "marushu/vtdd-v2-p",
+      relatedIssue: 590,
+      text: "codex app-server turn timed out before completion"
+    })
+  );
+
+  const stored = await store.listThread("dashboard-main-unresolved");
+  assert.equal(stored.length, 1);
+  assert.equal(stored[0].role, "system");
+  assert.equal(stored[0].status, "failed");
+  assert.equal(stored[0].repository, "marushu/vtdd-v2-p");
+  assert.equal(stored[0].relatedIssue, 590);
+  assert.match(stored[0].text, /応答生成が時間切れ/);
+  assert.match(stored[0].text, /同じ thread で続ける/);
+  assert.doesNotMatch(stored[0].text, /timed out before completion/);
+
+  const broadcast = dashboardSocket.sent.map((message) => JSON.parse(message)).find((message) => message.type === "thread");
+  assert.ok(broadcast);
+  assert.equal(broadcast.messages[0].text, stored[0].text);
+});
+
 test("DashboardChatRoom sends app-server thinking status as transient UI state", async () => {
   const store = createInMemoryDashboardChatStore();
   const dashboardSocket = createMockSocket("dashboard", "dashboard-main-unresolved");

--- a/worker.js
+++ b/worker.js
@@ -61895,6 +61895,7 @@ function normalizeDashboardAppServerBridgeEvent(payload, { fallbackThreadId = ""
     transientStatus = "replied";
     transientText = "Dashboard thread \u63A5\u7D9A\u6E08\u307F\u3002";
   } else if (eventType === "app_server_turn_failed" || status === "failed") {
+    const failureText = buildDashboardAppServerFailureThreadText({ text, status });
     messages.push(
       normalizeDashboardChatMessage(
         {
@@ -61903,7 +61904,7 @@ function normalizeDashboardAppServerBridgeEvent(payload, { fallbackThreadId = ""
           repository,
           relatedIssue,
           status: "failed",
-          text: text || "codex app-server bridge failed before returning a reply.",
+          text: failureText,
           createdAt
         },
         { threadId }
@@ -61927,6 +61928,14 @@ function normalizeDashboardAppServerBridgeEvent(payload, { fallbackThreadId = ""
     transientStatus,
     messages: messages.filter(Boolean)
   };
+}
+function buildDashboardAppServerFailureThreadText({ text = "", status = "" } = {}) {
+  const normalizedText = sanitizeDashboardChatText(text);
+  const normalizedStatus = normalizeDashboardEventText(status).toLowerCase();
+  if (normalizedStatus === "timeout" || /timed out before completion/i.test(normalizedText)) {
+    return "codex app-server \u306E\u5FDC\u7B54\u751F\u6210\u304C\u6642\u9593\u5207\u308C\u306B\u306A\u308A\u307E\u3057\u305F\u3002\u5165\u529B\u306F Dashboard thread \u306B\u4FDD\u5B58\u6E08\u307F\u3067\u3059\u3002\u540C\u3058 thread \u3067\u7D9A\u3051\u308B\u304B\u3001\u5185\u5BB9\u3092\u77ED\u304F\u3057\u3066\u3082\u3046\u4E00\u5EA6\u9001\u308C\u307E\u3059\u3002";
+  }
+  return normalizedText || "codex app-server \u304C\u8FD4\u4FE1\u524D\u306B\u5931\u6557\u3057\u307E\u3057\u305F\u3002\u540C\u3058 thread \u3067\u7D9A\u3051\u308B\u304B\u3001\u5185\u5BB9\u3092\u77ED\u304F\u3057\u3066\u3082\u3046\u4E00\u5EA6\u9001\u308C\u307E\u3059\u3002";
 }
 var DASHBOARD_APP_SERVER_STAGE_TEXT = {
   read_context: "\u65E2\u5B58 Issue / PR / docs \u3092\u78BA\u8A8D\u3057\u3066\u3044\u307E\u3059\u3002",


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #590 の実装です。`codex app-server turn timed out before completion` が発生した時、Dashboard Butler の thread に日本語の復帰可能メッセージを残し、owner が同じ thread で続けられる状態にします。
- owner message の保存確認 timeout と app-server turn 応答 timeout を分け、app-server 側 timeout を `app_server_turn_failed` / `status=timeout` として扱います。
- 英語の生 timeout error を owner-facing thread に出さないよう、bridge と Worker の両方で日本語化します。

## Satisfied Success Criteria

- app-server bridge が turn timeout 時に `app_server_turn_failed` event を Dashboard に送ります。
- timeout event には `status: "timeout"`、repository、relatedIssue、codexThreadId、復帰可能な日本語 text を含めます。
- Worker は timeout event を transient status だけで流さず、thread に残る system failed message として保存/配信します。
- 古い bridge などから `codex app-server turn timed out before completion` が来ても、Worker 側で日本語の復帰可能メッセージへ正規化します。
- composer の保存確認 timeout path は変更せず、owner message 保存 timeout と app-server 応答 timeout を別状態として保ちます。

## Unsatisfied Success Criteria

- live Dashboard Butler PWA / VPS app-server bridge での実 timeout 再現 E2E は未実施です。
- app-server が timeout 後に遅延 completion を返した場合の UI 表示方針は、今回の bridge unsubscribe により後続通知を取り込まない挙動として固定しますが、遅延返信履歴として追加する設計は未実装です。
- Issue #579 の PWA background/foreground reconnect / auth expiry / input retention 全体は未実装です。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #590
- Implementing Success Criteria: app-server turn timeout を owner-facing Japanese recoverable thread message として扱う。
- Explicit Non-goals: Issue #579 PWA reconnect/auth/input retention 全体、app-server performance tuning、timeout 延長のみの対処、deploy、credential / permission mutation、voice implementation。
- Expected touched files/routes/workflows: `scripts/run-dashboard-app-server-bridge.mjs`, `src/worker/runtime.js`, `worker.js`, `test/dashboard-app-server-bridge.test.js`, `test/worker.test.js`
- Affected Issues: Issue #590, Issue #579, Issue #450, Issue #528, Issue #613
- Affected PRs: no open PRs affected.
- Affected workflows: none. GitHub Actions workflow files are not changed.
- Affected runtime/operator surfaces: Dashboard Butler chat WebSocket, Dashboard app-server bridge event mapping, generated Worker bundle.
- What may break if we patch narrowly: if only the bridge text changes, older timeout errors can still persist as English; Worker-side normalization prevents that.
- Unknowns to investigate before coding: live VPS app-server timeout reproduction remains a post-merge evidence step.
- Validation needed: `node --test test/dashboard-app-server-bridge.test.js`, `node --test test/worker.test.js`, `npm run verify:worker`, `git diff --check`.
- Stop condition: if this requires deploy, credential/permission mutation, app-server performance work, or Issue #579 PWA lifecycle changes, stop and keep it out of this PR.

## Execution Queue Delta

- Queue position before: Issue #590 is `Now` after Issue #613 queue refresh.
- Preemption decision: NEXT - this PR implements the current `Now` lane without changing queue order.
- Queue delta: Issue #590 moved from `Now` to implementation PR with tests; Issue #579 remains `Next`; Issue #613 remains Root Blocker for the broader T-first / inline voice direction.
- Why this PR is next: timeout recovery must be stable before adding voice transcript turns, because voice would be unusable if app-server timeout leaves chat stuck.
- Active Issues not downscoped: Issue #579, Issue #450, Issue #528, Issue #613, and related Dashboard Butler root work remain active and incomplete.

## File / Line Hypotheses

- file: `scripts/run-dashboard-app-server-bridge.mjs`
  - hypothesis: the current turn timeout rejects with a raw English error and relies on the outer catch, so Dashboard receives an owner-hostile failure.
  - risk if changed narrowly: the bridge could still duplicate failures if timeout and later notification both settle the turn.
  - validation: new timeout test asserts one Japanese `app_server_turn_failed` event and handler cleanup.
  - related Issue: Issue #590
- file: `src/worker/runtime.js`
  - hypothesis: Worker already persists `app_server_turn_failed`, but it persists raw text if provided.
  - risk if changed narrowly: old bridge/raw errors can still leak English into owner thread.
  - validation: new Worker test sends raw English timeout and asserts stored Japanese recovery message.
  - related Issue: Issue #590

## Hypothesis Retrospective

- expected: timeout handling lived mainly in the Dashboard app-server bridge promise timeout and Worker failure mapping.
- actual: bridge timeout used the raw English error, and Worker persisted bridge failure text as-is.
- mismatch: none.
- lesson: owner-facing recovery must be normalized at both producer and consumer boundaries.
- should become RAG candidate: yes

## Verification Evidence

- Unit: `node --test test/dashboard-app-server-bridge.test.js` passed, 21/21 tests.
- Unit: `node --test test/worker.test.js` passed, 213/213 tests.
- Integration: `npm run build:worker` passed.
- Integration: `npm run check:generated-worker` passed.
- Static: `git diff --check` passed.
- Full verification: `npm run verify:worker` passed, 1004 passed / 1 skipped.
- E2E: simulated timeout path in bridge and Worker tests; live PWA/VPS timeout reproduction not performed.
- Evidence path/link: `test/dashboard-app-server-bridge.test.js`
- Evidence path/link: `test/worker.test.js`

## Butler Completion Contract

- Owner goal: Dashboard Butler が app-server turn timeout 後も、入力保存済みで同じ thread から続けられることを owner に日本語で示す。
- Butler entrypoint: Dashboard Butler PWA chat WebSocket -> Dashboard app-server bridge -> codex app-server turn timeout -> Worker thread message.
- Action Schema exposure: not changed.
- Runtime path: `handleDashboardTurnRequest` timeout -> `app_server_turn_failed status=timeout` -> `normalizeDashboardAppServerBridgeEvent` -> durable Dashboard thread message.
- Runner/runtime truth: timeout event includes repository / relatedIssue / codexThreadId when available.
- Authority boundary: error/recovery messaging only. No deploy, credential, permission, merge, Issue close, or destructive mutation.
- E2E evidence: simulated bridge/Worker timeout path tests; live production PWA/VPS evidence is not included.
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: required after merge because Worker runtime and bridge script changed.
- Custom GPT Action Schema update: not changed.
- Custom GPT Instructions update: not changed.
- iPhone Butler live E2E: not performed.

## Related Constitution Rules

- Butler Completion Gate
- Butler-First Operating Principle
- Chief Butler Operating Principle
- Conversation UX Contract
- Drift Stop Protocol
- Evidence Discipline

## Out-of-scope but NOT implemented

- Issue #579 PWA reconnect/auth/input retention
- Issue #613 inline voice transcript / readout
- live deploy
- live VPS timeout reproduction

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #590
- Execution ID: local-codex-2026-05-28-dashboard-app-server-timeout-recovery
- Goal: dashboard_app_server_timeout_recovery
