### PR TITLE
Issue #589 deploy 通知未達原因をログに残す

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -390,6 +390,30 @@ jobs:
             )"
             if [ "$http_code" -ge 200 ] && [ "$http_code" -lt 300 ]; then
               event_sent=1
+              echo "dashboard deploy event reached Worker with HTTP ${http_code}. Owner-facing notification truth:"
+              node - "$response_file" <<'NODE'
+const fs = require("node:fs");
+const file = process.argv[2];
+let body = {};
+try {
+  body = JSON.parse(fs.readFileSync(file, "utf8"));
+} catch {
+  console.log("- response: unreadable");
+  process.exit(0);
+}
+const webPush = body.webPush || {};
+const event = body.event || {};
+console.log(`- eventRunId: ${event.runId || "unknown"}`);
+console.log(`- eventConclusion: ${event.conclusion || "unknown"}`);
+console.log(`- webPushOk: ${webPush.ok === true}`);
+console.log(`- webPushAttempted: ${Number.isFinite(webPush.attempted) ? webPush.attempted : "unknown"}`);
+console.log(`- webPushDelivered: ${Number.isFinite(webPush.delivered) ? webPush.delivered : "unknown"}`);
+console.log(`- webPushCleaned: ${Number.isFinite(webPush.cleaned) ? webPush.cleaned : "unknown"}`);
+if (webPush.error || webPush.reason) {
+  console.log(`- webPushError: ${webPush.error || "unknown"}`);
+  console.log(`- webPushReason: ${webPush.reason || "unknown"}`);
+}
+NODE
               rm -f "$response_file"
               break
             fi

--- a/test/production-deploy-path.test.js
+++ b/test/production-deploy-path.test.js
@@ -197,6 +197,11 @@ test("deploy-production workflow enforces the MVP production deploy boundary", (
   assert.equal(workflow.includes("pullNumber:"), true);
   assert.equal(workflow.includes("for attempt in 1 2 3 4 5 6"), true);
   assert.equal(workflow.includes("retrying after Worker propagation delay"), true);
+  assert.equal(workflow.includes("dashboard deploy event reached Worker with HTTP ${http_code}. Owner-facing notification truth:"), true);
+  assert.equal(workflow.includes("webPushOk:"), true);
+  assert.equal(workflow.includes("webPushAttempted:"), true);
+  assert.equal(workflow.includes("webPushDelivered:"), true);
+  assert.equal(workflow.includes("webPushError:"), true);
   assert.equal(workflow.includes("deploy remains successful, but dashboard may be stale until the next event"), true);
   assert.equal(workflow.includes("authorization: Bearer ${VTDD_GATEWAY_BEARER_TOKEN}"), true);
   assert.equal(workflow.includes('approvalGrantId'), false);


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #589 の実装です。production deploy は成功したのに PWA / Dashboard 通知が owner に届かなかった場合、次回 deploy で原因を Actions log から読めるようにします。
- 現状の deploy workflow は Worker の `/v2/events/github-actions` へ deploy event を送っていますが、HTTP 2xx の response body を捨てているため、`webPush` の attempted / delivered / error / reason が owner-facing に残りません。
- この PR では deploy event が Worker に届いた時も、response body から sanitized notification truth をログへ出します。

## Satisfied Success Criteria

- Dashboard deploy event ingest が HTTP 2xx で Worker に届いたことを Actions log に明示します。
- response body の `event.runId` / `event.conclusion` / `webPush.ok` / `webPush.attempted` / `webPush.delivered` / `webPush.cleaned` をログへ出します。
- `webPush.error` / `webPush.reason` がある場合、subscription 未登録、VAPID 未設定、push service failure などの原因をログで読めるようにします。
- GitHub Issue mention notification skip は既存の `VTDD_DEPLOY_NOTIFICATION_ISSUE_NUMBER is not set` ログを維持します。
- raw token、approval grant、push subscription raw keys はログへ出しません。

## Unsatisfied Success Criteria

- 既に完了した deploy run #26571286289 の Web Push response body は後から復元できないため、今回の未達原因そのものは確定できません。
- Dashboard 通知センター内で Web Push delivery summary を表示する UI は未実装です。
- owner 端末の notification permission / subscription 再登録はこの PR では扱いません。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #589
- Implementing Success Criteria: deploy-production workflow log に Dashboard event ingest と Web Push delivery summary を出す。
- Explicit Non-goals: deploy 権限変更、Cloudflare credential mutation、passkey approval boundary 変更、通知 permission 変更、subscription 再登録 UI、production deploy 実行。
- Expected touched files/routes/workflows: `.github/workflows/deploy-production.yml`, `test/production-deploy-path.test.js`
- Affected Issues: Issue #589, Issue #514, Issue #444, Issue #579
- Affected PRs: no open PRs affected.
- Affected workflows: `.github/workflows/deploy-production.yml`
- Affected runtime/operator surfaces: deploy-production Actions log only.
- What may break if we patch narrowly: if only failure responses are logged, successful ingest with failed Web Push remains invisible; this PR logs success response summary too.
- Unknowns to investigate before coding: none for workflow log visibility.
- Validation needed: `node --test test/production-deploy-path.test.js`, `git diff --check`.
- Stop condition: if this requires deploy execution, credential/permission mutation, or PWA subscription changes, stop and split to another PR.

## Execution Queue Delta

- Queue position before: Issue #579 is next after Issue #590 merge, but owner reported deploy notification did not arrive.
- Preemption decision: EVIDENCE - this PR records missing notification truth so notification failures stop being invisible; it does not replace Issue #579.
- Queue delta: Issue #589 moved from evidence gap to implementation PR for deploy notification truth logging; Issue #579 remains `Next`; Issue #613 remains Root Blocker.
- Why this PR is next: owner just observed a real deploy notification miss after PR #615 deploy, and current logs cannot identify Web Push delivery cause.
- Active Issues not downscoped: Issue #514, Issue #444, Issue #579, Issue #613 remain active and incomplete.

## File / Line Hypotheses

- file: `.github/workflows/deploy-production.yml`
  - hypothesis: the Worker already returns `webPush` delivery summary, but the workflow discards response body on HTTP 2xx.
  - risk if changed narrowly: deploy succeeds yet PWA notification failure remains invisible.
  - validation: `test/production-deploy-path.test.js` asserts the log fields exist.
  - related Issue: Issue #589
- file: `test/production-deploy-path.test.js`
  - hypothesis: deploy workflow contract tests are the right place to lock owner-facing notification truth logging.
  - risk if changed narrowly: future workflow cleanup can remove the diagnostic log again.
  - validation: `node --test test/production-deploy-path.test.js`.
  - related Issue: Issue #589

## Hypothesis Retrospective

- expected: deploy event reached Worker, but notification delivery cause was not visible.
- actual: latest deploy run shows `Notify dashboard deploy event` succeeded, while GitHub mention notification was skipped because `VTDD_DEPLOY_NOTIFICATION_ISSUE_NUMBER` is unset. The success response body that could have shown Web Push delivery was discarded.
- mismatch: none.
- lesson: successful runtime ingest must still log notification delivery truth, because notification failure can be downstream of ingest.
- should become RAG candidate: yes

## Verification Evidence

- Unit: `node --test test/production-deploy-path.test.js` passed, 4/4 tests.
- Static: `git diff --check` passed.
- Runtime observation: deploy run #26571286289 succeeded, `Notify dashboard deploy event` completed, GitHub mention notification skipped because `VTDD_DEPLOY_NOTIFICATION_ISSUE_NUMBER` was not set.
- E2E: not performed; this PR changes future deploy log observability only.
- Evidence path/link: `.github/workflows/deploy-production.yml`
- Evidence path/link: `test/production-deploy-path.test.js`

## Butler Completion Contract

- Owner goal: deploy が成功したのに通知が来なかった時、どの通知経路が失敗したか owner-facing に分かるようにする。
- Butler entrypoint: deploy-production workflow log; future Dashboard Butler can read workflow job logs / runtime truth.
- Action Schema exposure: not changed.
- Runtime path: deploy-production -> `/v2/events/github-actions` -> Worker response `webPush` summary -> Actions log.
- Runner/runtime truth: future deploy logs include `webPushOk`, attempted, delivered, cleaned, error, reason.
- Authority boundary: workflow observability only. No deploy execution, credential, permission, merge, Issue close, or destructive mutation in this PR.
- E2E evidence: not applicable for the already-completed deploy miss; future deploy run will produce the evidence.
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: not required for this workflow-only change to affect future GitHub Actions runs.
- Custom GPT Action Schema update: not changed.
- Custom GPT Instructions update: not changed.
- iPhone Butler live E2E: not performed.

## Related Constitution Rules

- Butler Completion Gate
- Butler-First Operating Principle
- Chief Butler Operating Principle
- Conversation UX Contract
- Evidence Discipline
- Authority Boundary

## Out-of-scope but NOT implemented

- Dashboard notification center Web Push summary UI
- PWA notification permission / subscription repair
- iOS notification live resend
- production deploy execution

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #589
- Execution ID: local-codex-2026-05-28-deploy-webpush-truth
- Goal: deploy_notification_webpush_truth_logging
