### PR TITLE
Issue #589 deploy workflow YAML を復旧する

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -392,28 +392,28 @@ jobs:
               event_sent=1
               echo "dashboard deploy event reached Worker with HTTP ${http_code}. Owner-facing notification truth:"
               node - "$response_file" <<'NODE'
-const fs = require("node:fs");
-const file = process.argv[2];
-let body = {};
-try {
-  body = JSON.parse(fs.readFileSync(file, "utf8"));
-} catch {
-  console.log("- response: unreadable");
-  process.exit(0);
-}
-const webPush = body.webPush || {};
-const event = body.event || {};
-console.log(`- eventRunId: ${event.runId || "unknown"}`);
-console.log(`- eventConclusion: ${event.conclusion || "unknown"}`);
-console.log(`- webPushOk: ${webPush.ok === true}`);
-console.log(`- webPushAttempted: ${Number.isFinite(webPush.attempted) ? webPush.attempted : "unknown"}`);
-console.log(`- webPushDelivered: ${Number.isFinite(webPush.delivered) ? webPush.delivered : "unknown"}`);
-console.log(`- webPushCleaned: ${Number.isFinite(webPush.cleaned) ? webPush.cleaned : "unknown"}`);
-if (webPush.error || webPush.reason) {
-  console.log(`- webPushError: ${webPush.error || "unknown"}`);
-  console.log(`- webPushReason: ${webPush.reason || "unknown"}`);
-}
-NODE
+          const fs = require("node:fs");
+          const file = process.argv[2];
+          let body = {};
+          try {
+            body = JSON.parse(fs.readFileSync(file, "utf8"));
+          } catch {
+            console.log("- response: unreadable");
+            process.exit(0);
+          }
+          const webPush = body.webPush || {};
+          const event = body.event || {};
+          console.log(`- eventRunId: ${event.runId || "unknown"}`);
+          console.log(`- eventConclusion: ${event.conclusion || "unknown"}`);
+          console.log(`- webPushOk: ${webPush.ok === true}`);
+          console.log(`- webPushAttempted: ${Number.isFinite(webPush.attempted) ? webPush.attempted : "unknown"}`);
+          console.log(`- webPushDelivered: ${Number.isFinite(webPush.delivered) ? webPush.delivered : "unknown"}`);
+          console.log(`- webPushCleaned: ${Number.isFinite(webPush.cleaned) ? webPush.cleaned : "unknown"}`);
+          if (webPush.error || webPush.reason) {
+            console.log(`- webPushError: ${webPush.error || "unknown"}`);
+            console.log(`- webPushReason: ${webPush.reason || "unknown"}`);
+          }
+          NODE
               rm -f "$response_file"
               break
             fi

--- a/test/production-deploy-path.test.js
+++ b/test/production-deploy-path.test.js
@@ -202,6 +202,9 @@ test("deploy-production workflow enforces the MVP production deploy boundary", (
   assert.equal(workflow.includes("webPushAttempted:"), true);
   assert.equal(workflow.includes("webPushDelivered:"), true);
   assert.equal(workflow.includes("webPushError:"), true);
+  assert.equal(workflow.includes("\nconst fs = require(\"node:fs\");"), false);
+  assert.equal(workflow.includes("          const fs = require(\"node:fs\");"), true);
+  assert.equal(workflow.includes("          NODE\n              rm -f \"$response_file\""), true);
   assert.equal(workflow.includes("deploy remains successful, but dashboard may be stale until the next event"), true);
   assert.equal(workflow.includes("authorization: Bearer ${VTDD_GATEWAY_BEARER_TOKEN}"), true);
   assert.equal(workflow.includes('approvalGrantId'), false);


### PR DESCRIPTION
## This PR satisfies Intent

- #589 の PWA Web Push truth ログ追加後に、deploy-production workflow が YAML 構文エラーで job 開始前に落ちないよう復旧する。

## Satisfied Success Criteria

- deploy-production workflow の Web Push truth 出力用 heredoc を YAML block scalar 内へ戻した。
- YAML 展開後、shell 上の heredoc 終端 NODE が行頭に来る形に調整した。
- deploy workflow の YAML parse と production deploy path test が通る。

## Unsatisfied Success Criteria

- PWA通知の live 到達確認は merge 後の production deploy で webPushAttempted / webPushDelivered / webPushError を見て判断する。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #589
- Implementing Success Criteria: deploy-production workflow が構文エラーで job 開始前に落ちない。PWA Web Push truth ログ出力の heredoc が shell 上でも成立する。
- Explicit Non-goals: PWA subscription 修復、通知権限変更、secret/credential 変更、production deploy 実行。
- Expected touched files/routes/workflows: .github/workflows/deploy-production.yml; test/production-deploy-path.test.js
- Affected Issues: #589
- Affected PRs: #616 の follow-up hotfix
- Affected workflows: deploy-production.yml
- Affected runtime/operator surfaces: GitHub Actions deploy workflow; Dashboard PWA notification truth logging
- What may break if we patch narrowly: YAML だけ通しても shell heredoc 終端が行頭に来なければ deploy job 内で失敗する。
- Unknowns to investigate before coding: 今回の PWA通知未達原因そのものは次回 deploy の Web Push truth ログが出るまで未確定。
- Validation needed: YAML parse; production deploy path unit test; git diff whitespace check; merge 後 production deploy live log.
- Stop condition: workflow 構文または shell heredoc 成立性が未確認なら進めない。

## Execution Queue Delta

- Queue position before: #589 は PWA通知未達原因を owner-facing に見えるようにする active issue。#616 merge 後の deploy workflow failure により hotfix が必要。
- Preemption decision: EMERGENCY: #616 が deploy workflow を壊しているため、#589 の調査を進める前に即時 hotfix として優先。
- Queue delta: Issue #589 / PR #616 follow-up hotfix。Issue #589 の deploy workflow 復旧 slice を進める。通知未達原因の live 判定は次回 deploy evidence に残す。
- Why this PR is next: workflow が job 開始前に落ちると PWA通知 truth が取れず、#589 の本筋に進めないため。
- Active Issues not downscoped: #589 以外の active Issues は縮小しない。#589 も live PWA evidence 取得まで未完了として残す。

## File / Line Hypotheses

- file: .github/workflows/deploy-production.yml
  - hypothesis: Notify dashboard deploy event の heredoc 本文が YAML block scalar 外に出て workflow parse failure を起こしている。
  - risk if changed narrowly: YAML は通っても shell heredoc terminator が行頭にならず job 内 failure になる。
  - validation: Ruby YAML parse と extracted shell heredoc 終端確認、production deploy path test。
  - related Issue: #589

## Hypothesis Retrospective

- expected: workflow parse failure は heredoc インデント修正で解消する。
- actual: local YAML parse と production deploy path test は通過。
- mismatch: なし。live deploy は merge 後。
- lesson: workflow 内 heredoc 追加時は YAML parse と shell terminator の両方を検証する。
- should become RAG candidate: はい。

## Verification Evidence

- Unit: node --test test/production-deploy-path.test.js
- Integration: ruby -e "require 'yaml'; YAML.load_file('.github/workflows/deploy-production.yml'); puts 'yaml ok'"
- E2E: 未実施。production deploy は passkey approval が必要。
- Manual: git diff --check
- Evidence path/link: local command output; GitHub Actions evidence after PR checks

## Butler Completion Contract

- Owner goal: PWA通知が届かなかった原因を deploy workflow 上で確認できる状態に戻す。
- Butler entrypoint: 未変更。Dashboard/Butler から deploy 承認後に workflow が PWA truth を出す前提を復旧する。
- Action Schema exposure: 未変更。
- Runtime path: GitHub Actions deploy-production.yml -> /v2/events/github-actions -> Dashboard PWA Web Push dispatch truth logging
- Runner/runtime truth: merge 後の production deploy workflow log に webPushAttempted / webPushDelivered / webPushError が出る予定。
- Authority boundary: deploy 実行は scoped passkey approval 必須。この PR では deploy しない。
- E2E evidence: 未実施。merge 後に iPhone/PWA通知 live evidence が必要。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: この PR では実行しない。merge 後に passkey 承認付き deploy が必要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。次回 deploy 後に PWA通知有無と workflow log を確認する。

## Related Constitution Rules

- Butler Completion Gate: live PWA evidence なしに完了扱いしない。
- Authority Boundary: production deploy は passkey approval 必須。
- Evidence Discipline: workflow 構文とテスト結果を PR に記録する。

## Out-of-scope but NOT implemented

- PWA subscription 保存・権限・端末設定の修復。
- GitHub mention 通知の設定変更。

## Extra changes (if any)

#616 の hotfix。

<!-- VTDD metadata -->
- Issue: Issue #589
- Execution ID: local-codex-2026-05-28-pwa-notification-hotfix
- Goal: #589 PWA通知未達の真因を次回 deploy で取れる状態へ復旧
