### PR TITLE
Issue #589 PWA push receive ack を記録する

### DIFF
--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -749,6 +749,10 @@ export default {
       return handleDashboardPushTestRequest(request, env);
     }
 
+    if (request.method === "POST" && isApiPath(url.pathname, "/dashboard/push/ack")) {
+      return handleDashboardPushAckRequest(request, env);
+    }
+
     if (request.method === "GET" && isDashboardChatSocketApiPath(url.pathname)) {
       return handleDashboardChatSocketRequest(request, url, env);
     }
@@ -4407,6 +4411,92 @@ async function handleDashboardPushTestRequest(request, env) {
   });
 }
 
+async function handleDashboardPushAckRequest(request, env) {
+  if (normalizeText(request.headers.get("content-type")).split(";")[0].toLowerCase() !== "application/json") {
+    return json(415, {
+      ok: false,
+      error: "dashboard_push_ack_content_type_required",
+      reason: "dashboard push ack requires application/json"
+    });
+  }
+  if (request.headers.get("x-vtdd-dashboard-push-ack") !== "service-worker") {
+    return json(403, {
+      ok: false,
+      error: "dashboard_push_ack_boundary_required",
+      reason: "dashboard push ack requires the service worker boundary header"
+    });
+  }
+
+  const dashboardAuth = await authorizeDashboardRequest({
+    request,
+    env,
+    apiSuffix: "/dashboard/push/ack"
+  });
+  if (!dashboardAuth.ok) {
+    return json(dashboardAuth.status, {
+      ok: false,
+      error: "dashboard_auth_required",
+      reason: dashboardAuth.reason
+    });
+  }
+
+  const eventStore = resolveDashboardEventStore(env);
+  if (!eventStore) {
+    return json(503, {
+      ok: false,
+      error: "dashboard_event_store_unavailable",
+      reason: "dashboard event store is not configured"
+    });
+  }
+
+  const payload = await readJson(request);
+  const tag = sanitizeDashboardChatText(payload?.tag || "vtdd-dashboard");
+  const sourceEventId = sanitizeDashboardChatText(payload?.sourceEventId || payload?.source_event_id || "");
+  if (!isSupportedDashboardPushAckSourceEventId(sourceEventId)) {
+    return json(422, {
+      ok: false,
+      error: "dashboard_push_ack_source_invalid",
+      reason: "dashboard push ack requires a supported sourceEventId"
+    });
+  }
+  const sourceRunId = sanitizeDashboardChatText(payload?.runId || payload?.run_id || "");
+  const title = sanitizeDashboardChatText(payload?.title || "Dashboard PWA push received");
+  const ackEvent = normalizeDashboardEventRecord({
+    id: `dashboard-push-ack:${tag || sourceEventId || crypto.randomUUID()}`,
+    kind: "dashboard_push_received",
+    repository: normalizeCanonicalRepositoryInput(payload?.repository) || null,
+    workflowName: sanitizeDashboardChatText(payload?.workflowName || payload?.workflow_name || "dashboard-push-ack"),
+    runId: sourceRunId || sourceEventId || tag || crypto.randomUUID(),
+    status: "completed",
+    conclusion: "success",
+    title,
+    changeSummary: sanitizeDashboardChatText(payload?.body || payload?.message || "PWA Service Worker が push event を受信しました。"),
+    pullNumber: normalizeIssue(payload?.pullNumber || payload?.pull_number),
+    issueNumber: normalizeIssue(payload?.issueNumber || payload?.issue_number),
+    runUrl: "/dashboard/notifications",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString()
+  });
+  await eventStore.put(ackEvent);
+  return json(202, {
+    ok: true,
+    ack: {
+      id: ackEvent.id,
+      status: "received",
+      receivedAt: ackEvent.updatedAt
+    }
+  });
+}
+
+function isSupportedDashboardPushAckSourceEventId(value) {
+  const text = normalizeText(value);
+  return (
+    text.startsWith("github-actions:") ||
+    text.startsWith("vps-runner:") ||
+    text.startsWith("dashboard-push-test:")
+  );
+}
+
 async function handleDashboardChatSocketRequest(request, url, env) {
   const auth = await authorizeDashboardRequest({
     request,
@@ -7435,7 +7525,16 @@ export function buildDashboardWebPushPayload(event) {
     title,
     body: body || "Dashboard Butler の通知です。",
     tag: `vtdd-${record.kind || "dashboard"}-${record.runId || record.id || "event"}`.slice(0, 120),
-    url: buildDashboardEventOwnerTargetUrl(record)
+    url: buildDashboardEventOwnerTargetUrl(record),
+    sourceEventId: record.id || null,
+    kind: record.kind || null,
+    repository: record.repository || null,
+    workflowName: record.workflowName || null,
+    runId: record.runId || null,
+    status: record.status || null,
+    conclusion: record.conclusion || null,
+    pullNumber: record.pullNumber || null,
+    issueNumber: record.issueNumber || null
   };
 }
 
@@ -7464,7 +7563,6 @@ function buildDashboardWebPushBody(record) {
   if (record.kind === "dashboard_push_test") {
     return "通知経路は正常です。iPhone PWA にサーバ送信できました。";
   }
-
   const details = [];
   const title = compactNotificationText(record.changeSummary || record.title, 58);
   if (title && title !== record.workflowName) {
@@ -10459,7 +10557,29 @@ self.addEventListener("push", (event) => {
       url: String(payload.url || "/dashboard/notifications")
     }
   };
-  event.waitUntil(self.registration.showNotification(title, options));
+  const ack = fetch("/v2/dashboard/push/ack", {
+    method: "POST",
+    credentials: "same-origin",
+    headers: {
+      "content-type": "application/json",
+      "x-vtdd-dashboard-push-ack": "service-worker"
+    },
+    body: JSON.stringify({
+      sourceEventId: payload.sourceEventId || "",
+      kind: payload.kind || "",
+      repository: payload.repository || "",
+      workflowName: payload.workflowName || "",
+      runId: payload.runId || "",
+      status: payload.status || "",
+      conclusion: payload.conclusion || "",
+      pullNumber: payload.pullNumber || null,
+      issueNumber: payload.issueNumber || null,
+      tag: options.tag,
+      title,
+      body: options.body
+    })
+  }).catch(() => null);
+  event.waitUntil(Promise.allSettled([ack, self.registration.showNotification(title, options)]));
 });
 
 function safeDashboardNotificationUrl(value) {

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -3745,6 +3745,10 @@ test("worker serves dashboard PWA manifest and service worker notification handl
   const serviceWorker = await serviceWorkerResponse.text();
   assert.equal(serviceWorker.includes('self.addEventListener("push"'), true);
   assert.equal(serviceWorker.includes("showNotification"), true);
+  assert.equal(serviceWorker.includes("/v2/dashboard/push/ack"), true);
+  assert.equal(serviceWorker.includes("Promise.allSettled([ack, self.registration.showNotification"), true);
+  assert.equal(serviceWorker.includes('credentials: "same-origin"'), true);
+  assert.equal(serviceWorker.includes('"x-vtdd-dashboard-push-ack": "service-worker"'), true);
   assert.equal(serviceWorker.includes('self.addEventListener("notificationclick"'), true);
   assert.equal(serviceWorker.includes("/dashboard/notifications"), true);
   assert.equal(serviceWorker.includes("safeDashboardNotificationUrl"), true);
@@ -4171,6 +4175,14 @@ test("worker ingests GitHub Actions deploy completion event and shows it on dash
   assert.equal(decryptedPush.body.includes("PR #552"), true);
   assert.equal(decryptedPush.body.includes("workflow: deploy-production"), true);
   assert.equal(decryptedPush.url, "https://github.com/marushu/vtdd-v2-p/pull/552");
+  assert.equal(decryptedPush.sourceEventId, "github-actions:marushu/vtdd-v2-p:deploy-production:26133044458");
+  assert.equal(decryptedPush.kind, "github_actions_workflow_run");
+  assert.equal(decryptedPush.repository, "marushu/vtdd-v2-p");
+  assert.equal(decryptedPush.workflowName, "deploy-production");
+  assert.equal(decryptedPush.runId, "26133044458");
+  assert.equal(decryptedPush.status, "completed");
+  assert.equal(decryptedPush.conclusion, "success");
+  assert.equal(decryptedPush.pullNumber, 552);
   assert.equal("approvalGrantId" in eventBody.event, false);
   assert.equal("token" in eventBody.event, false);
 
@@ -4197,6 +4209,123 @@ test("worker ingests GitHub Actions deploy completion event and shows it on dash
   assert.equal(dashboardBody.includes("secret-must-not-persist"), false);
   assert.equal(dashboardBody.includes("setInterval("), false);
   assert.equal(dashboardBody.includes("fetch(threadEndpoint"), true);
+});
+
+test("worker records dashboard PWA push receive ack only for authenticated owner session", async () => {
+  const store = createInMemoryDashboardEventStore();
+  const unauthenticated = await worker.fetch(
+    new Request("https://example.com/v2/dashboard/push/ack", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-vtdd-dashboard-push-ack": "service-worker"
+      },
+      body: JSON.stringify({
+        sourceEventId: "github-actions:marushu/vtdd-v2-p:deploy-production:26133044458",
+        repository: "marushu/vtdd-v2-p",
+        workflowName: "deploy-production",
+        runId: "26133044458",
+        title: "must not store"
+      })
+    }),
+    {
+      ...dashboardAccessEnv,
+      DASHBOARD_EVENT_STORE: store
+    }
+  );
+  assert.equal(unauthenticated.status, 401);
+  assert.equal((await store.listRecent()).length, 0);
+
+  const missingBoundary = await worker.fetch(
+    new Request("https://example.com/v2/dashboard/push/ack", {
+      method: "POST",
+      headers: { ...dashboardAccessHeaders, "content-type": "application/json" },
+      body: JSON.stringify({
+        sourceEventId: "github-actions:marushu/vtdd-v2-p:deploy-production:26133044458"
+      })
+    }),
+    {
+      ...dashboardAccessEnv,
+      DASHBOARD_EVENT_STORE: store
+    }
+  );
+  assert.equal(missingBoundary.status, 403);
+
+  const invalidSource = await worker.fetch(
+    new Request("https://example.com/v2/dashboard/push/ack", {
+      method: "POST",
+      headers: {
+        ...dashboardAccessHeaders,
+        "content-type": "application/json",
+        "x-vtdd-dashboard-push-ack": "service-worker"
+      },
+      body: JSON.stringify({
+        sourceEventId: "unknown-source",
+        repository: "marushu/vtdd-v2-p"
+      })
+    }),
+    {
+      ...dashboardAccessEnv,
+      DASHBOARD_EVENT_STORE: store
+    }
+  );
+  assert.equal(invalidSource.status, 422);
+  assert.equal((await store.listRecent()).length, 0);
+
+  const pushCalls = [];
+  const pushStore = createInMemoryDashboardPushSubscriptionStore();
+  const pushKeys = await createTestPushSubscription({
+    endpointHash: "ack-loop-endpoint",
+    endpoint: "https://push.example/send/ack-loop"
+  });
+  await pushStore.put(pushKeys.subscription);
+  const vapidEnv = await createTestVapidEnv({
+    DASHBOARD_WEB_PUSH_FETCH: async (input, init) => {
+      pushCalls.push({ input, init });
+      return new Response(null, { status: 201 });
+    }
+  });
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/dashboard/push/ack", {
+      method: "POST",
+      headers: {
+        ...dashboardAccessHeaders,
+        "content-type": "application/json",
+        "x-vtdd-dashboard-push-ack": "service-worker"
+      },
+      body: JSON.stringify({
+        sourceEventId: "github-actions:marushu/vtdd-v2-p:deploy-production:26133044458",
+        repository: "marushu/vtdd-v2-p",
+        workflowName: "deploy-production",
+        runId: "26133044458",
+        status: "completed",
+        conclusion: "success",
+        pullNumber: 552,
+        tag: "vtdd-github-actions-workflow-run-26133044458",
+        title: "デプロイ完了: PR #552 dashboard: 通知カードにPR概要を出す (#534)",
+        body: "PWA Service Worker ack"
+      })
+    }),
+    {
+      ...dashboardAccessEnv,
+      ...vapidEnv,
+      DASHBOARD_EVENT_STORE: store,
+      DASHBOARD_PUSH_SUBSCRIPTION_STORE: pushStore
+    }
+  );
+  assert.equal(response.status, 202);
+  const body = await response.json();
+  assert.equal(body.ok, true);
+  assert.equal(body.ack.status, "received");
+  const events = await store.listRecent();
+  assert.equal(events.length, 1);
+  assert.equal(events[0].kind, "dashboard_push_received");
+  assert.equal(events[0].repository, "marushu/vtdd-v2-p");
+  assert.equal(events[0].workflowName, "deploy-production");
+  assert.equal(events[0].runId, "26133044458");
+  assert.equal(events[0].pullNumber, 552);
+  assert.equal(JSON.stringify(events[0]).includes("secret"), false);
+  assert.equal(pushCalls.length, 0);
 });
 
 test("worker rejects GitHub Actions deploy completion event without machine auth", async () => {

--- a/worker.js
+++ b/worker.js
@@ -56841,6 +56841,9 @@ var runtime_default = {
     if (request.method === "POST" && isApiPath(url.pathname, "/dashboard/push/test")) {
       return handleDashboardPushTestRequest(request, env);
     }
+    if (request.method === "POST" && isApiPath(url.pathname, "/dashboard/push/ack")) {
+      return handleDashboardPushAckRequest(request, env);
+    }
     if (request.method === "GET" && isDashboardChatSocketApiPath(url.pathname)) {
       return handleDashboardChatSocketRequest(request, url, env);
     }
@@ -60038,6 +60041,83 @@ async function handleDashboardPushTestRequest(request, env) {
     webPush
   });
 }
+async function handleDashboardPushAckRequest(request, env) {
+  if (normalizeText30(request.headers.get("content-type")).split(";")[0].toLowerCase() !== "application/json") {
+    return json(415, {
+      ok: false,
+      error: "dashboard_push_ack_content_type_required",
+      reason: "dashboard push ack requires application/json"
+    });
+  }
+  if (request.headers.get("x-vtdd-dashboard-push-ack") !== "service-worker") {
+    return json(403, {
+      ok: false,
+      error: "dashboard_push_ack_boundary_required",
+      reason: "dashboard push ack requires the service worker boundary header"
+    });
+  }
+  const dashboardAuth = await authorizeDashboardRequest({
+    request,
+    env,
+    apiSuffix: "/dashboard/push/ack"
+  });
+  if (!dashboardAuth.ok) {
+    return json(dashboardAuth.status, {
+      ok: false,
+      error: "dashboard_auth_required",
+      reason: dashboardAuth.reason
+    });
+  }
+  const eventStore = resolveDashboardEventStore(env);
+  if (!eventStore) {
+    return json(503, {
+      ok: false,
+      error: "dashboard_event_store_unavailable",
+      reason: "dashboard event store is not configured"
+    });
+  }
+  const payload = await readJson(request);
+  const tag = sanitizeDashboardChatText(payload?.tag || "vtdd-dashboard");
+  const sourceEventId = sanitizeDashboardChatText(payload?.sourceEventId || payload?.source_event_id || "");
+  if (!isSupportedDashboardPushAckSourceEventId(sourceEventId)) {
+    return json(422, {
+      ok: false,
+      error: "dashboard_push_ack_source_invalid",
+      reason: "dashboard push ack requires a supported sourceEventId"
+    });
+  }
+  const sourceRunId = sanitizeDashboardChatText(payload?.runId || payload?.run_id || "");
+  const title = sanitizeDashboardChatText(payload?.title || "Dashboard PWA push received");
+  const ackEvent = normalizeDashboardEventRecord({
+    id: `dashboard-push-ack:${tag || sourceEventId || crypto.randomUUID()}`,
+    kind: "dashboard_push_received",
+    repository: normalizeCanonicalRepositoryInput(payload?.repository) || null,
+    workflowName: sanitizeDashboardChatText(payload?.workflowName || payload?.workflow_name || "dashboard-push-ack"),
+    runId: sourceRunId || sourceEventId || tag || crypto.randomUUID(),
+    status: "completed",
+    conclusion: "success",
+    title,
+    changeSummary: sanitizeDashboardChatText(payload?.body || payload?.message || "PWA Service Worker \u304C push event \u3092\u53D7\u4FE1\u3057\u307E\u3057\u305F\u3002"),
+    pullNumber: normalizeIssue6(payload?.pullNumber || payload?.pull_number),
+    issueNumber: normalizeIssue6(payload?.issueNumber || payload?.issue_number),
+    runUrl: "/dashboard/notifications",
+    createdAt: (/* @__PURE__ */ new Date()).toISOString(),
+    updatedAt: (/* @__PURE__ */ new Date()).toISOString()
+  });
+  await eventStore.put(ackEvent);
+  return json(202, {
+    ok: true,
+    ack: {
+      id: ackEvent.id,
+      status: "received",
+      receivedAt: ackEvent.updatedAt
+    }
+  });
+}
+function isSupportedDashboardPushAckSourceEventId(value) {
+  const text = normalizeText30(value);
+  return text.startsWith("github-actions:") || text.startsWith("vps-runner:") || text.startsWith("dashboard-push-test:");
+}
 async function handleDashboardChatSocketRequest(request, url, env) {
   const auth = await authorizeDashboardRequest({
     request,
@@ -62635,7 +62715,16 @@ function buildDashboardWebPushPayload(event) {
     title,
     body: body || "Dashboard Butler \u306E\u901A\u77E5\u3067\u3059\u3002",
     tag: `vtdd-${record2.kind || "dashboard"}-${record2.runId || record2.id || "event"}`.slice(0, 120),
-    url: buildDashboardEventOwnerTargetUrl(record2)
+    url: buildDashboardEventOwnerTargetUrl(record2),
+    sourceEventId: record2.id || null,
+    kind: record2.kind || null,
+    repository: record2.repository || null,
+    workflowName: record2.workflowName || null,
+    runId: record2.runId || null,
+    status: record2.status || null,
+    conclusion: record2.conclusion || null,
+    pullNumber: record2.pullNumber || null,
+    issueNumber: record2.issueNumber || null
   };
 }
 function buildDashboardWebPushTitle(record2) {
@@ -65376,7 +65465,29 @@ self.addEventListener("push", (event) => {
       url: String(payload.url || "/dashboard/notifications")
     }
   };
-  event.waitUntil(self.registration.showNotification(title, options));
+  const ack = fetch("/v2/dashboard/push/ack", {
+    method: "POST",
+    credentials: "same-origin",
+    headers: {
+      "content-type": "application/json",
+      "x-vtdd-dashboard-push-ack": "service-worker"
+    },
+    body: JSON.stringify({
+      sourceEventId: payload.sourceEventId || "",
+      kind: payload.kind || "",
+      repository: payload.repository || "",
+      workflowName: payload.workflowName || "",
+      runId: payload.runId || "",
+      status: payload.status || "",
+      conclusion: payload.conclusion || "",
+      pullNumber: payload.pullNumber || null,
+      issueNumber: payload.issueNumber || null,
+      tag: options.tag,
+      title,
+      body: options.body
+    })
+  }).catch(() => null);
+  event.waitUntil(Promise.allSettled([ack, self.registration.showNotification(title, options)]));
 });
 
 function safeDashboardNotificationUrl(value) {


### PR DESCRIPTION
## This PR satisfies Intent

- #589 の PWA通知未達調査で、server-side Web Push が accepted/delivered なのに iPhone に表示されない場合を切り分けるため、PWA Service Worker の push receive ack を Dashboard runtime truth に残す。

## Satisfied Success Criteria

- Dashboard Web Push payload に source event / repo / workflow / run / PR / Issue metadata を追加し、raw subscription keys や approval grant を含めずに Service Worker へ渡す。
- Service Worker が push event を受け取った時、通知表示と並行して `/v2/dashboard/push/ack` へ same-origin ack を送る。
- `/v2/dashboard/push/ack` は Dashboard owner session がある時だけ ack event を保存し、未認証では保存しない。
- ack event は `dashboard_push_received` として Dashboard event store に残り、次回から「push service accepted」と「PWA が実際に受信」を分けられる。

## Unsatisfied Success Criteria

- iPhone 実機での live PWA receive ack evidence は merge / deploy 後に確認する。
- 認証成功 -> デプロイ実行中 -> デプロイ完了 のライフサイクル通知は、この PR では未実装。次の #589 slice として扱う。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #589
- Implementing Success Criteria: Dashboard Web Push が server accepted で止まったのか、PWA Service Worker が受信したのかを owner-facing runtime truth として分ける。
- Explicit Non-goals: iOS 通知設定変更、Focus/通知要約制御、PWA subscription 強制再作成、production deploy 実行、credential/permission mutation。
- Expected touched files/routes/workflows: `src/worker/runtime.js`; `test/worker.test.js`; generated `worker.js`
- Affected Issues: Issue #589
- Affected PRs: PR #616 / PR #617 の follow-up
- Affected workflows: deploy-production は直接変更しない。次回 deploy の event payload が PWA receive ack metadata を含む。
- Affected runtime/operator surfaces: Dashboard PWA Service Worker; `/v2/dashboard/push/ack`; Dashboard event store; Dashboard notification center
- What may break if we patch narrowly: server accepted を配信成功と誤認し続ける。逆に ack を未認証 public endpoint にすると event store spam になる。
- Unknowns to investigate before coding: iOS が accepted push を Service Worker に届けているかは live ack まで未確定。
- Validation needed: worker tests; generated worker parity; live deploy + iPhone PWA ack evidence.
- Stop condition: raw push subscription keys / approvalGrantId / token を payload、ack、event store に残すなら停止。

## Execution Queue Delta

- Queue position before: Issue #589 は PWA通知未達原因を owner-facing に見えるようにする active issue。
- Preemption decision: EVIDENCE: latest deploy run 26573776159 で `webPushAttempted=1` / `webPushDelivered=1` だが iPhone 表示が無いので、次の evidence gap を埋める。
- Queue delta: Issue #589 の PWA receive ack slice を進める。ライフサイクル通知は残作業として残す。
- Why this PR is next: server-side delivered だけでは、Apple Push accepted 後に PWA が受け取ったか判定できないため。
- Active Issues not downscoped: 他 active Issues は縮小しない。Issue #589 も live PWA evidence と lifecycle notification 実装まで未完了。

## File / Line Hypotheses

- file: `src/worker/runtime.js`
  - hypothesis: `dispatchDashboardWebPushForEvent()` は push service accepted までは分かるが、PWA Service Worker receive truth を持っていない。
  - risk if changed narrowly: delivered=1 をユーザー可視通知成功と誤認する。
  - validation: Web Push payload metadata test、Service Worker ack script test、authenticated ack route test。
  - related Issue: #589

## Hypothesis Retrospective

- expected: push payload に source metadata を入れ、Service Worker ack route を追加すれば receive truth を Dashboard event store に残せる。
- actual: local worker tests and verify:worker passed.
- mismatch: live iPhone ack は deploy 後まで未確認。
- lesson: PWA通知は server accepted / service worker received / notification displayed を別々の truth として扱う必要がある。
- should become RAG candidate: はい。

## Verification Evidence

- Unit: `node --test test/worker.test.js`
- Integration: `npm run verify:worker`
- E2E: 未実施。production deploy と iPhone PWA live ack 確認が必要。
- Manual: `git diff --check`
- Evidence path/link: local command output; PR checks after push

## Butler Completion Contract

- Owner goal: PWA通知が来ない時、Dashboard Butler 側で「server accepted か」「PWA が受信したか」を切り分けられるようにする。
- Butler entrypoint: Dashboard PWA notification center / Dashboard runtime truth。Butler natural-language answer はこの truth を読む後続 slice が必要。
- Action Schema exposure: 未変更。
- Runtime path: GitHub Actions deploy event -> Worker Web Push dispatch -> iPhone PWA Service Worker push -> `/v2/dashboard/push/ack` -> Dashboard event store
- Runner/runtime truth: `dashboard_push_received` event が保存されれば PWA receive confirmed。無ければ server accepted 後に端末/PWA未受信の疑い。
- Authority boundary: ack は Dashboard owner session が必要。deploy 実行は scoped passkey approval 必須、この PR では deploy しない。
- E2E evidence: 未実施。merge/deploy 後に iPhone 実機で確認する。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: この PR では実行しない。merge 後に passkey 承認付き deploy が必要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。次回 deploy 後、PWA通知表示と `dashboard_push_received` event の有無を確認する。

## Related Constitution Rules

- Butler Completion Gate: live PWA evidence なしに通知修復完了扱いしない。
- Evidence Discipline: server accepted と owner-visible receive truth を分ける。
- Authority Boundary: deploy 実行は passkey approval 必須。
- RAG Memory Capture and Cost Boundary: raw subscription material / secrets / approval grant を保存しない。

## Out-of-scope but NOT implemented

- 認証成功 -> デプロイ実行中 -> デプロイ完了 の段階通知。
- PWA subscription 再登録 UX。
- iOS Focus / 通知要約 / 通知許可設定の変更。

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #589
- Execution ID: local-codex-2026-05-28-pwa-receive-ack
- Goal: #589 PWA通知未達を server accepted と PWA received に切り分ける
