### PR TITLE
Issue #589 current-device Web Push truth を直す

### DIFF
--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -4403,12 +4403,72 @@ async function handleDashboardPushTestRequest(request, env) {
     createdAt: new Date().toISOString(),
     updatedAt: new Date().toISOString()
   });
-  const webPush = await dispatchDashboardWebPushForEvent(env, event);
+  const targetEndpointHash = await resolveDashboardPushTargetEndpointHash(payload, env);
+  if (!targetEndpointHash.ok) {
+    return json(targetEndpointHash.status, {
+      ok: false,
+      event,
+      webPush: {
+        ok: false,
+        status: targetEndpointHash.status,
+        error: targetEndpointHash.error,
+        reason: targetEndpointHash.reason,
+        attempted: 0,
+        delivered: 0,
+        cleaned: 0,
+        currentDevice: {
+          status: targetEndpointHash.currentDeviceStatus || "not_saved"
+        }
+      }
+    });
+  }
+  const webPush = await dispatchDashboardWebPushForEvent(env, event, {
+    endpointHash: targetEndpointHash.endpointHash
+  });
   return json(webPush.ok ? 202 : webPush.status || 503, {
     ok: webPush.ok,
     event,
     webPush
   });
+}
+
+async function resolveDashboardPushTargetEndpointHash(payload, env) {
+  const endpoint = normalizeDashboardUrl(payload?.endpoint);
+  if (!endpoint) {
+    return {
+      ok: false,
+      status: 422,
+      error: "dashboard_push_current_endpoint_required",
+      reason: "server push test requires the current device subscription endpoint",
+      currentDeviceStatus: "unknown"
+    };
+  }
+  const endpointHash = await sha256Hex(endpoint);
+  const store = resolveDashboardPushSubscriptionStore(env);
+  if (!store || typeof store.get !== "function") {
+    return {
+      ok: false,
+      status: 503,
+      error: "dashboard_push_subscription_status_unavailable",
+      reason: "dashboard push subscription store cannot verify the current device subscription",
+      currentDeviceStatus: "unknown"
+    };
+  }
+  const subscription = await store.get(endpointHash);
+  if (!subscription) {
+    return {
+      ok: false,
+      status: 404,
+      error: "dashboard_push_current_subscription_not_saved",
+      reason: "current device push subscription is not saved on the server",
+      currentDeviceStatus: "not_saved"
+    };
+  }
+  return {
+    ok: true,
+    endpointHash,
+    currentDeviceStatus: "saved"
+  };
 }
 
 async function handleDashboardPushAckRequest(request, env) {
@@ -7461,7 +7521,7 @@ function createD1DashboardPushSubscriptionStore(d1) {
   }
 }
 
-async function dispatchDashboardWebPushForEvent(env, event) {
+async function dispatchDashboardWebPushForEvent(env, event, options = {}) {
   const store = resolveDashboardPushSubscriptionStore(env);
   if (!store || typeof store.list !== "function") {
     return {
@@ -7471,13 +7531,16 @@ async function dispatchDashboardWebPushForEvent(env, event) {
       reason: "dashboard push subscription store cannot list subscriptions"
     };
   }
-  const subscriptions = await store.list({ limit: 50 });
+  const targetEndpointHash = normalizeDashboardEventText(options.endpointHash);
+  const subscriptions = targetEndpointHash && typeof store.get === "function"
+    ? [await store.get(targetEndpointHash)].filter(Boolean)
+    : await store.list({ limit: 50 });
   if (subscriptions.length === 0) {
     return {
       ok: false,
       status: 404,
-      error: "dashboard_push_subscription_not_found",
-      reason: "no dashboard push subscriptions are stored"
+      error: targetEndpointHash ? "dashboard_push_target_subscription_not_found" : "dashboard_push_subscription_not_found",
+      reason: targetEndpointHash ? "target dashboard push subscription is not stored" : "no dashboard push subscriptions are stored"
     };
   }
 
@@ -10474,11 +10537,20 @@ async function renderDashboardNotificationsPage({ runtimeOrigin, dashboardEventS
           });
 
           serverTestButton?.addEventListener("click", async () => {
+            const reg = await registration();
+            const subscription = await reg?.pushManager?.getSubscription?.();
+            if (!subscription) {
+              serverPushDelivered = false;
+              lastServerPushResult = "最後のサーバ送信結果: rejected (0/0) / current device subscription missing";
+              setText(pushServerResult, lastServerPushResult);
+              await refreshState();
+              return;
+            }
             const response = await fetch("/v2/dashboard/push/test", {
               method: "POST",
               credentials: "same-origin",
               headers: { "content-type": "application/json" },
-              body: JSON.stringify({ title: "Dashboard Butler server push test" })
+              body: JSON.stringify({ title: "Dashboard Butler server push test", endpoint: subscription.endpoint })
             });
             const body = await response.json().catch(() => ({}));
             const webPush = body && body.webPush ? body.webPush : {};
@@ -10557,6 +10629,7 @@ self.addEventListener("push", (event) => {
       url: String(payload.url || "/dashboard/notifications")
     }
   };
+  const shown = self.registration.showNotification(title, options);
   const ack = fetch("/v2/dashboard/push/ack", {
     method: "POST",
     credentials: "same-origin",
@@ -10579,7 +10652,8 @@ self.addEventListener("push", (event) => {
       body: options.body
     })
   }).catch(() => null);
-  event.waitUntil(Promise.allSettled([ack, self.registration.showNotification(title, options)]));
+  event.waitUntil(shown);
+  event.waitUntil(ack);
 });
 
 function safeDashboardNotificationUrl(value) {

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -3695,6 +3695,8 @@ test("worker serves dashboard notification center for recent events across repos
   assert.equal(body.includes("/v2/dashboard/push/status"), true);
   assert.equal(body.includes("/v2/dashboard/push/test"), true);
   assert.equal(body.includes("credentials: \"same-origin\""), true);
+  assert.equal(body.includes("endpoint: subscription.endpoint"), true);
+  assert.equal(body.includes("current device subscription missing"), true);
   assert.equal(body.includes("サーバ送信設定: あり"), true);
   assert.equal(body.includes("サーバ送信: 設定あり。deploy 通知到達性はサーバ送信テスト成功後に確認済みになります。"), true);
   assert.equal(body.includes("購読保存: あり。サーバ送信テストはまだ未確認です。"), true);
@@ -3746,7 +3748,9 @@ test("worker serves dashboard PWA manifest and service worker notification handl
   assert.equal(serviceWorker.includes('self.addEventListener("push"'), true);
   assert.equal(serviceWorker.includes("showNotification"), true);
   assert.equal(serviceWorker.includes("/v2/dashboard/push/ack"), true);
-  assert.equal(serviceWorker.includes("Promise.allSettled([ack, self.registration.showNotification"), true);
+  assert.equal(serviceWorker.includes("event.waitUntil(shown);"), true);
+  assert.equal(serviceWorker.includes("event.waitUntil(ack);"), true);
+  assert.equal(serviceWorker.includes("Promise.allSettled([ack, self.registration.showNotification"), false);
   assert.equal(serviceWorker.includes('credentials: "same-origin"'), true);
   assert.equal(serviceWorker.includes('"x-vtdd-dashboard-push-ack": "service-worker"'), true);
   assert.equal(serviceWorker.includes('self.addEventListener("notificationclick"'), true);
@@ -3875,7 +3879,11 @@ test("worker reports dashboard push subscription server save status without raw 
 test("worker sends server-side dashboard Web Push test only for authenticated owner session", async () => {
   const store = createInMemoryDashboardPushSubscriptionStore();
   const pushKeys = await createTestPushSubscription();
-  await store.put(pushKeys.subscription);
+  const currentEndpointHash = await sha256HexTest(pushKeys.subscription.endpoint);
+  await store.put({
+    ...pushKeys.subscription,
+    endpointHash: currentEndpointHash
+  });
   const calls = [];
   const vapidEnv = await createTestVapidEnv({
     DASHBOARD_WEB_PUSH_FETCH: async (input, init) => {
@@ -3903,7 +3911,7 @@ test("worker sends server-side dashboard Web Push test only for authenticated ow
     new Request("https://example.com/v2/dashboard/push/test", {
       method: "POST",
       headers: { ...dashboardAccessHeaders, "content-type": "application/json" },
-      body: JSON.stringify({ title: "server push test" })
+      body: JSON.stringify({ title: "server push test", endpoint: pushKeys.subscription.endpoint })
     }),
     {
       ...dashboardAccessEnv,
@@ -3915,9 +3923,9 @@ test("worker sends server-side dashboard Web Push test only for authenticated ow
   const body = await response.json();
   assert.equal(body.ok, true);
   assert.equal(body.webPush.delivered, 1);
-  assert.equal(body.webPush.results[0].endpointHash, "endpoint-hash");
+  assert.equal(body.webPush.results[0].endpointHash, currentEndpointHash);
   assert.equal(calls.length, 1);
-  assert.equal(calls[0].input, "https://push.example/send/endpoint-hash");
+  assert.equal(calls[0].input, pushKeys.subscription.endpoint);
   assert.equal(calls[0].init.method, "POST");
   assert.match(calls[0].init.headers.authorization, /^vapid t=.+, k=.+/);
   assert.equal(calls[0].init.headers.ttl, "300");
@@ -3931,6 +3939,31 @@ test("worker sends server-side dashboard Web Push test only for authenticated ow
   assert.equal(decrypted.url, "/dashboard/notifications");
   assert.equal(JSON.stringify(body).includes("p256dh-key"), false);
   assert.equal(JSON.stringify(body).includes("auth-key"), false);
+});
+
+test("worker refuses server-side dashboard Web Push test when current device subscription is not saved", async () => {
+  const store = createInMemoryDashboardPushSubscriptionStore();
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/dashboard/push/test", {
+      method: "POST",
+      headers: { ...dashboardAccessHeaders, "content-type": "application/json" },
+      body: JSON.stringify({
+        title: "server push test",
+        endpoint: "https://push.example/send/current-device"
+      })
+    }),
+    {
+      ...dashboardAccessEnv,
+      DASHBOARD_PUSH_SUBSCRIPTION_STORE: store
+    }
+  );
+  assert.equal(response.status, 404);
+  const body = await response.json();
+  assert.equal(body.ok, false);
+  assert.equal(body.webPush.error, "dashboard_push_current_subscription_not_saved");
+  assert.equal(body.webPush.currentDevice.status, "not_saved");
+  assert.equal(body.webPush.attempted, 0);
+  assert.equal(JSON.stringify(body).includes("current-device"), false);
 });
 
 test("worker builds distinct dashboard Web Push copy by event type", () => {
@@ -4000,9 +4033,10 @@ test("worker builds distinct dashboard Web Push copy by event type", () => {
 
 test("worker reports server-side dashboard Web Push configuration blockers", async () => {
   const store = createInMemoryDashboardPushSubscriptionStore();
+  const endpoint = "https://push.example/send/endpoint-hash";
   await store.put({
-    endpointHash: "endpoint-hash",
-    endpoint: "https://push.example/send/endpoint-hash",
+    endpointHash: await sha256HexTest(endpoint),
+    endpoint,
     p256dh: "p256dh-key",
     auth: "auth-key",
     ownerIdentity: "owner@example.com",
@@ -4012,7 +4046,7 @@ test("worker reports server-side dashboard Web Push configuration blockers", asy
     new Request("https://example.com/v2/dashboard/push/test", {
       method: "POST",
       headers: { ...dashboardAccessHeaders, "content-type": "application/json" },
-      body: JSON.stringify({ title: "server push test" })
+      body: JSON.stringify({ title: "server push test", endpoint })
     }),
     {
       ...dashboardAccessEnv,
@@ -4027,9 +4061,10 @@ test("worker reports server-side dashboard Web Push configuration blockers", asy
 
 test("worker cleans up stale dashboard Web Push subscriptions rejected by push service", async () => {
   const store = createInMemoryDashboardPushSubscriptionStore();
+  const endpoint = "https://push.example/send/stale-endpoint-hash";
   const pushKeys = await createTestPushSubscription({
-    endpointHash: "stale-endpoint-hash",
-    endpoint: "https://push.example/send/stale-endpoint-hash"
+    endpointHash: await sha256HexTest(endpoint),
+    endpoint
   });
   await store.put(pushKeys.subscription);
   const vapidEnv = await createTestVapidEnv({
@@ -4040,7 +4075,7 @@ test("worker cleans up stale dashboard Web Push subscriptions rejected by push s
     new Request("https://example.com/v2/dashboard/push/test", {
       method: "POST",
       headers: { ...dashboardAccessHeaders, "content-type": "application/json" },
-      body: JSON.stringify({ title: "server push test" })
+      body: JSON.stringify({ title: "server push test", endpoint })
     }),
     {
       ...dashboardAccessEnv,
@@ -4056,7 +4091,7 @@ test("worker cleans up stale dashboard Web Push subscriptions rejected by push s
   assert.equal(body.webPush.cleaned, 1);
   assert.equal(body.webPush.results[0].stale, true);
   assert.equal(body.webPush.results[0].cleaned, true);
-  assert.equal(store.subscriptions.has("stale-endpoint-hash"), false);
+  assert.equal(store.subscriptions.has(pushKeys.subscription.endpointHash), false);
 });
 
 test("worker redacts dashboard push subscription raw material from D1 payload_json", async () => {

--- a/worker.js
+++ b/worker.js
@@ -60034,12 +60034,71 @@ async function handleDashboardPushTestRequest(request, env) {
     createdAt: (/* @__PURE__ */ new Date()).toISOString(),
     updatedAt: (/* @__PURE__ */ new Date()).toISOString()
   });
-  const webPush = await dispatchDashboardWebPushForEvent(env, event);
+  const targetEndpointHash = await resolveDashboardPushTargetEndpointHash(payload, env);
+  if (!targetEndpointHash.ok) {
+    return json(targetEndpointHash.status, {
+      ok: false,
+      event,
+      webPush: {
+        ok: false,
+        status: targetEndpointHash.status,
+        error: targetEndpointHash.error,
+        reason: targetEndpointHash.reason,
+        attempted: 0,
+        delivered: 0,
+        cleaned: 0,
+        currentDevice: {
+          status: targetEndpointHash.currentDeviceStatus || "not_saved"
+        }
+      }
+    });
+  }
+  const webPush = await dispatchDashboardWebPushForEvent(env, event, {
+    endpointHash: targetEndpointHash.endpointHash
+  });
   return json(webPush.ok ? 202 : webPush.status || 503, {
     ok: webPush.ok,
     event,
     webPush
   });
+}
+async function resolveDashboardPushTargetEndpointHash(payload, env) {
+  const endpoint = normalizeDashboardUrl(payload?.endpoint);
+  if (!endpoint) {
+    return {
+      ok: false,
+      status: 422,
+      error: "dashboard_push_current_endpoint_required",
+      reason: "server push test requires the current device subscription endpoint",
+      currentDeviceStatus: "unknown"
+    };
+  }
+  const endpointHash = await sha256Hex(endpoint);
+  const store = resolveDashboardPushSubscriptionStore(env);
+  if (!store || typeof store.get !== "function") {
+    return {
+      ok: false,
+      status: 503,
+      error: "dashboard_push_subscription_status_unavailable",
+      reason: "dashboard push subscription store cannot verify the current device subscription",
+      currentDeviceStatus: "unknown"
+    };
+  }
+  const subscription = await store.get(endpointHash);
+  if (!subscription) {
+    return {
+      ok: false,
+      status: 404,
+      error: "dashboard_push_current_subscription_not_saved",
+      reason: "current device push subscription is not saved on the server",
+      currentDeviceStatus: "not_saved"
+    };
+  }
+  return {
+    ok: true,
+    endpointHash,
+    currentDeviceStatus: "saved"
+  };
 }
 async function handleDashboardPushAckRequest(request, env) {
   if (normalizeText30(request.headers.get("content-type")).split(";")[0].toLowerCase() !== "application/json") {
@@ -62653,7 +62712,7 @@ function createD1DashboardPushSubscriptionStore(d1) {
     return schemaPromise;
   }
 }
-async function dispatchDashboardWebPushForEvent(env, event) {
+async function dispatchDashboardWebPushForEvent(env, event, options = {}) {
   const store = resolveDashboardPushSubscriptionStore(env);
   if (!store || typeof store.list !== "function") {
     return {
@@ -62663,13 +62722,14 @@ async function dispatchDashboardWebPushForEvent(env, event) {
       reason: "dashboard push subscription store cannot list subscriptions"
     };
   }
-  const subscriptions = await store.list({ limit: 50 });
+  const targetEndpointHash = normalizeDashboardEventText(options.endpointHash);
+  const subscriptions = targetEndpointHash && typeof store.get === "function" ? [await store.get(targetEndpointHash)].filter(Boolean) : await store.list({ limit: 50 });
   if (subscriptions.length === 0) {
     return {
       ok: false,
       status: 404,
-      error: "dashboard_push_subscription_not_found",
-      reason: "no dashboard push subscriptions are stored"
+      error: targetEndpointHash ? "dashboard_push_target_subscription_not_found" : "dashboard_push_subscription_not_found",
+      reason: targetEndpointHash ? "target dashboard push subscription is not stored" : "no dashboard push subscriptions are stored"
     };
   }
   const payload = buildDashboardWebPushPayload(event);
@@ -65384,11 +65444,20 @@ async function renderDashboardNotificationsPage({ runtimeOrigin, dashboardEventS
           });
 
           serverTestButton?.addEventListener("click", async () => {
+            const reg = await registration();
+            const subscription = await reg?.pushManager?.getSubscription?.();
+            if (!subscription) {
+              serverPushDelivered = false;
+              lastServerPushResult = "\u6700\u5F8C\u306E\u30B5\u30FC\u30D0\u9001\u4FE1\u7D50\u679C: rejected (0/0) / current device subscription missing";
+              setText(pushServerResult, lastServerPushResult);
+              await refreshState();
+              return;
+            }
             const response = await fetch("/v2/dashboard/push/test", {
               method: "POST",
               credentials: "same-origin",
               headers: { "content-type": "application/json" },
-              body: JSON.stringify({ title: "Dashboard Butler server push test" })
+              body: JSON.stringify({ title: "Dashboard Butler server push test", endpoint: subscription.endpoint })
             });
             const body = await response.json().catch(() => ({}));
             const webPush = body && body.webPush ? body.webPush : {};
@@ -65465,6 +65534,7 @@ self.addEventListener("push", (event) => {
       url: String(payload.url || "/dashboard/notifications")
     }
   };
+  const shown = self.registration.showNotification(title, options);
   const ack = fetch("/v2/dashboard/push/ack", {
     method: "POST",
     credentials: "same-origin",
@@ -65487,7 +65557,8 @@ self.addEventListener("push", (event) => {
       body: options.body
     })
   }).catch(() => null);
-  event.waitUntil(Promise.allSettled([ack, self.registration.showNotification(title, options)]));
+  event.waitUntil(shown);
+  event.waitUntil(ack);
 });
 
 function safeDashboardNotificationUrl(value) {


### PR DESCRIPTION
## This PR satisfies Intent

- #589 の PWA通知未達調査で、`テスト通知` は表示されるのに `サーバ送信テスト` / deploy 通知が無反応になる状態を、現在端末の subscription truth で切り分けられるようにする。
- #618 で追加した Service Worker ack が通知表示を巻き添えにし得る形だったため、通知表示を最優先に戻す。

## Satisfied Success Criteria

- Dashboard のサーバ送信テストは、保存済み subscription のどれかではなく、現在開いている PWA 端末の subscription endpoint がサーバ保存済みの場合だけ送信する。
- 現在端末の subscription が未保存なら `dashboard_push_current_subscription_not_saved` として、deploy 通知到達性を成功扱いしない。
- Service Worker の push handler は `showNotification()` を先に `event.waitUntil(shown)` へ渡し、ack fetch は別の `event.waitUntil(ack)` に分離する。ack の遅延・認証失敗が通知表示を巻き添えにしない。
- raw endpoint / p256dh / auth key は response / HTML / event payload に出さない。

## Unsatisfied Success Criteria

- iPhone 実機で、修正版 deploy 後の `サーバ送信テスト` と deploy 完了通知の live 表示確認が必要。
- `認証成功 -> デプロイ実行中 -> デプロイ完了` の段階通知は、この PR では未実装。
- Dashboard 通知センター上で deploy event と PWA receive ack を同一カードにまとめる表示は、次 slice に残る。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #589
- Implementing Success Criteria: Web Push 未達を owner-facing に切り分け、通知だけ未達を deploy 成功と分ける。
- Explicit Non-goals: production deploy 実行、credential/permission mutation、iOS 通知設定変更、subscription raw key 表示、段階通知の新規実装。
- Expected touched files/routes/workflows: `src/worker/runtime.js`; `test/worker.test.js`; generated `worker.js`
- Affected Issues: Issue #589
- Affected PRs: PR #618 follow-up
- Affected workflows: deploy-production workflow は変更しない。
- Affected runtime/operator surfaces: Dashboard notification center; `/v2/dashboard/push/test`; Dashboard PWA Service Worker
- What may break if we patch narrowly: 現在端末以外への accepted を「この iPhone に届く」と誤認し続ける。Service Worker ack が通知表示を妨げる可能性を残す。
- Unknowns to investigate before coding: iOS PWA が ack fetch を background push 中にどの程度許容するかは live evidence まで未確定。
- Validation needed: worker tests; generated worker parity; live iPhone PWA test after deploy.
- Stop condition: endpoint / auth key / p256dh / approval grant を response / logs / RAG に出すなら停止。

## Execution Queue Delta

- Queue position before: Issue #589 は PWA通知未達原因を owner-facing に見えるようにする active issue。
- Preemption decision: EVIDENCE: user reported notifications worked until around 2026-05-28 daytime, but after the #589 notification-truth slices the deployed PWA showed local test notifications while server-side push/deploy notifications did not appear.
- Queue delta: Issue #589 の current-device server push truth / Service Worker display-priority slice を進める。Issue #589 自体は live PWA evidence まで未完了。
- Why this PR is next: current production can show `accepted (1/1)` for a server push that is not proven to target the current iPhone PWA, and #618 may have made ack fetch affect notification display.
- Active Issues not downscoped: 他 active Issues は縮小しない。Issue #589 の lifecycle notification と notification center ack grouping は残作業として明示する。

## Regression Analysis

- Last known likely-good window: owner report says 2026-05-28 daytime / noon-ish notifications arrived.
- Relevant changes after that:
  - PR #600 (`cce2b96`, 2026-05-28 12:17 JST): notification click target changed from Dashboard notifications to GitHub PR URL.
  - PR #616 (`6adb29c`, 2026-05-28 20:21 JST): deploy workflow logs Web Push delivery summary only.
  - PR #618 (`a07da0d`, 2026-05-28 21:24 JST): Service Worker push handler added ack fetch and changed waitUntil to `Promise.allSettled([ack, showNotification])`.
- Most likely regression source: PR #618. It put ack fetch and notification display into the same waitUntil promise group. On iOS PWA background push, ack fetch/auth delay or rejection could affect notification display timing. This PR separates them and makes `showNotification()` the primary waitUntil.
- Separate truth bug found: server-side test previously sent to any saved subscription. The UI could show `accepted (1/1)` even when the current iPhone PWA subscription was not the one that received the push. This PR targets the current device endpoint only.
- Drift note: initial investigation should have started with this regression timeline before patching. This PR records that timeline explicitly to keep #589 evidence auditable.

## File / Line Hypotheses

- file: `src/worker/runtime.js`
  - hypothesis: #618 changed Service Worker push handling from direct `showNotification()` to a combined ack/display promise. On iOS PWA background push, this can make ack failure or delay interfere with visible notification display.
  - risk if changed narrowly: deploy Web Push can remain accepted by the push service while no visible iPhone notification appears.
  - validation: service worker script test asserts `event.waitUntil(shown)` and `event.waitUntil(ack)` are separate and the old `Promise.allSettled([ack, showNotification])` pattern is absent.
  - related Issue: #589
- file: `src/worker/runtime.js`
  - hypothesis: `/v2/dashboard/push/test` sent to all saved subscriptions, so accepted/delivered did not prove the current iPhone PWA received the server push.
  - risk if changed narrowly: Dashboard displays a false-positive `accepted (1/1)` for another device or stale subscription.
  - validation: current-device endpoint is required; unsaved current endpoint returns `dashboard_push_current_subscription_not_saved`; tests assert no raw endpoint leak.
  - related Issue: #589

## Hypothesis Retrospective

- expected: separating Service Worker notification display from ack and targeting the current device endpoint should restore visible push behavior and remove false-positive server test results.
- actual: local worker tests and verify:worker passed. Live iPhone PWA evidence is still required after deploy.
- mismatch: owner-visible notification display cannot be proven from local tests because iOS PWA Web Push behavior is runtime-only.
- lesson: when a user says a behavior worked earlier the same day, first bisect the regression window and name suspect commits before coding.
- should become RAG candidate: はい。

## Verification Evidence

- Unit: `node --test test/worker.test.js` passed.
- Integration: `npm run verify:worker` passed (`1007 tests`, `1006 pass`, `1 skipped`; self-parity passed; generated worker check passed).
- Manual: `git diff --check` passed.
- E2E: not yet run; requires merge/deploy and iPhone PWA live check.

## Butler Completion Contract

- Owner goal: PWA通知が来ない時に、Dashboard Butler 側で「端末内通知はOK」「現在端末 subscription は保存済み」「現在端末へのサーバ送信が成功/失敗」を分けて見えるようにする。
- Butler entrypoint: Dashboard notification center / PWA notification settings.
- Action Schema exposure: 不要。
- Runtime path: Dashboard notification center -> current PWA subscription endpoint -> `/v2/dashboard/push/test` -> targeted Web Push -> Service Worker showNotification.
- Runner/runtime truth: current device missingなら `dashboard_push_current_subscription_not_saved`; acceptedなら current endpoint への `webPush.delivered=1`。
- Authority boundary: dashboard owner session required. deploy is not executed in this PR.
- E2E evidence: 未実施。merge/deploy後に iPhone 実機で確認する。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: この PR では実行しない。merge 後に passkey 承認付き deploy が必要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。次回 deploy 後、PWA `サーバ送信テスト` と deploy 完了通知の live 表示を確認する。

## Related Constitution Rules

- Butler Completion Gate: live iPhone evidence なしに #589 完了扱いしない。
- Evidence Discipline: server accepted / current-device accepted / PWA received / visible notification を分ける。
- Authority Boundary: deploy 実行は passkey approval 必須。
- RAG Memory Capture and Cost Boundary: raw push subscription material を保存・表示しない。

## Out-of-scope but NOT implemented

- 認証成功 -> デプロイ実行中 -> デプロイ完了 の段階通知。
- Dashboard 通知センターで deploy event と receive ack を同一カードにまとめる表示。
- iOS Focus / 通知要約 / 通知許可設定の変更。

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #589
- Execution ID: local-codex-2026-05-28-current-device-push-truth
- Goal: #589 current-device server push truth and Service Worker display priority
