### PR TITLE
dashboard: cache-bust PWA icon path

### DIFF
--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -79,6 +79,8 @@ const MCP_SERVER_INFO = Object.freeze({
 });
 const MCP_INSTRUCTIONS =
   "VTDD MCP は Butler と同じ runtime truth / review truth / operational memory を読むための read-first surface です。現在の truth は runtime truth を優先し、memory は補助として扱ってください。";
+const DASHBOARD_ICON_VERSION = "20260529-butler";
+const DASHBOARD_ICON_PNG_PATH = `/dashboard-icon-${DASHBOARD_ICON_VERSION}.png`;
 
 export class DashboardChatRoom {
   constructor(state, env) {
@@ -656,7 +658,13 @@ export default {
       return svg(200, renderDashboardIconSvg());
     }
 
-    if (request.method === "GET" && url.pathname === "/dashboard-icon.png") {
+    if (
+      request.method === "GET" &&
+      (url.pathname === "/dashboard-icon.png" ||
+        url.pathname === DASHBOARD_ICON_PNG_PATH ||
+        url.pathname === "/apple-touch-icon.png" ||
+        url.pathname === "/apple-touch-icon-precomposed.png")
+    ) {
       return png(200, dashboardButlerIconPngDataUrl);
     }
 
@@ -10624,7 +10632,7 @@ function buildDashboardWebManifest(url) {
     theme_color: "#050505",
     icons: [
       {
-        src: `${origin}/dashboard-icon.png`,
+        src: `${origin}${DASHBOARD_ICON_PNG_PATH}`,
         sizes: "512x512",
         type: "image/png",
         purpose: "any maskable"
@@ -10947,6 +10955,7 @@ function renderDashboardUtilityPage({ title, subtitle, backHref, body }) {
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="manifest" href="/dashboard.webmanifest">
+  <link rel="apple-touch-icon" sizes="512x512" href="${DASHBOARD_ICON_PNG_PATH}">
   <meta name="theme-color" content="#050505">
   <title>${escapeDashboardHtml(title)} - VTDD Butler</title>
   <style>
@@ -11344,6 +11353,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="manifest" href="/dashboard.webmanifest">
+  <link rel="apple-touch-icon" sizes="512x512" href="${DASHBOARD_ICON_PNG_PATH}">
   <meta name="theme-color" content="#050505">
   <title>VTDD v2 Dashboard</title>
   <style>
@@ -12880,6 +12890,7 @@ function renderDashboardAuthRequiredPage({ runtimeOrigin, returnPath = "/dashboa
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="apple-touch-icon" sizes="512x512" href="${DASHBOARD_ICON_PNG_PATH}">
   <title>Dashboard auth required</title>
   <style>
     :root { color-scheme: light; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; color: #17211d; background: #f8faf8; }

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -3534,6 +3534,8 @@ test("worker serves dashboard chat-first shell with debug and ops surfaces isola
   assert.equal(body.includes("ここではまず普通に会話できます"), true);
   assert.equal(body.includes("通知と進捗はこの画面から戻って確認できます"), true);
   assert.equal(body.includes("AI news"), true);
+  assert.equal(body.includes('rel="apple-touch-icon"'), true);
+  assert.equal(body.includes("/dashboard-icon-20260529-butler.png"), true);
   assert.equal(body.includes("この作業の対象 repo"), true);
   assert.equal(body.includes("固定ではありません"), true);
   assert.equal(body.includes("deploy 先と承認境界は repo ごとに確認します"), true);
@@ -3742,7 +3744,7 @@ test("worker serves dashboard PWA manifest and service worker notification handl
   assert.equal(manifest.start_url, "/dashboard");
   assert.equal(manifest.scope, "/dashboard/");
   assert.equal(manifest.display, "standalone");
-  assert.equal(manifest.icons[0].src, "https://example.com/dashboard-icon.png");
+  assert.equal(manifest.icons[0].src, "https://example.com/dashboard-icon-20260529-butler.png");
   assert.equal(manifest.icons[0].sizes, "512x512");
   assert.equal(manifest.icons[0].type, "image/png");
   assert.equal(manifest.icons[1].src, "https://example.com/dashboard-icon.svg");
@@ -3771,7 +3773,7 @@ test("worker serves dashboard PWA manifest and service worker notification handl
   assert.equal(iconResponse.status, 200);
   assert.match(iconResponse.headers.get("content-type"), /image\/svg\+xml/);
 
-  const pngIconResponse = await worker.fetch(new Request("https://example.com/dashboard-icon.png"));
+  const pngIconResponse = await worker.fetch(new Request("https://example.com/dashboard-icon-20260529-butler.png"));
   assert.equal(pngIconResponse.status, 200);
   assert.match(pngIconResponse.headers.get("content-type"), /image\/png/);
   const pngIcon = new Uint8Array(await pngIconResponse.arrayBuffer());
@@ -3779,6 +3781,10 @@ test("worker serves dashboard PWA manifest and service worker notification handl
   assert.equal(pngIcon[1], 0x50);
   assert.equal(pngIcon[2], 0x4e);
   assert.equal(pngIcon[3], 0x47);
+
+  const appleTouchIconResponse = await worker.fetch(new Request("https://example.com/apple-touch-icon.png"));
+  assert.equal(appleTouchIconResponse.status, 200);
+  assert.match(appleTouchIconResponse.headers.get("content-type"), /image\/png/);
 });
 
 test("worker stores dashboard push subscription only for an authenticated owner session", async () => {

--- a/worker.js
+++ b/worker.js
@@ -56258,6 +56258,8 @@ var MCP_SERVER_INFO = Object.freeze({
   version: "0.1.0"
 });
 var MCP_INSTRUCTIONS = "VTDD MCP \u306F Butler \u3068\u540C\u3058 runtime truth / review truth / operational memory \u3092\u8AAD\u3080\u305F\u3081\u306E read-first surface \u3067\u3059\u3002\u73FE\u5728\u306E truth \u306F runtime truth \u3092\u512A\u5148\u3057\u3001memory \u306F\u88DC\u52A9\u3068\u3057\u3066\u6271\u3063\u3066\u304F\u3060\u3055\u3044\u3002";
+var DASHBOARD_ICON_VERSION = "20260529-butler";
+var DASHBOARD_ICON_PNG_PATH = `/dashboard-icon-${DASHBOARD_ICON_VERSION}.png`;
 var DashboardChatRoom = class {
   constructor(state, env) {
     this.ctx = state;
@@ -56768,7 +56770,7 @@ var runtime_default = {
     if (request.method === "GET" && url.pathname === "/dashboard-icon.svg") {
       return svg(200, renderDashboardIconSvg());
     }
-    if (request.method === "GET" && url.pathname === "/dashboard-icon.png") {
+    if (request.method === "GET" && (url.pathname === "/dashboard-icon.png" || url.pathname === DASHBOARD_ICON_PNG_PATH || url.pathname === "/apple-touch-icon.png" || url.pathname === "/apple-touch-icon-precomposed.png")) {
       return png(200, dashboard_butler_icon_512_default);
     }
     if (request.method === "GET" && isDashboardPagePath(url.pathname)) {
@@ -65529,7 +65531,7 @@ function buildDashboardWebManifest(url) {
     theme_color: "#050505",
     icons: [
       {
-        src: `${origin}/dashboard-icon.png`,
+        src: `${origin}${DASHBOARD_ICON_PNG_PATH}`,
         sizes: "512x512",
         type: "image/png",
         purpose: "any maskable"
@@ -65831,6 +65833,7 @@ function renderDashboardUtilityPage({ title, subtitle, backHref, body }) {
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="manifest" href="/dashboard.webmanifest">
+  <link rel="apple-touch-icon" sizes="512x512" href="${DASHBOARD_ICON_PNG_PATH}">
   <meta name="theme-color" content="#050505">
   <title>${escapeDashboardHtml(title)} - VTDD Butler</title>
   <style>
@@ -66165,6 +66168,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="manifest" href="/dashboard.webmanifest">
+  <link rel="apple-touch-icon" sizes="512x512" href="${DASHBOARD_ICON_PNG_PATH}">
   <meta name="theme-color" content="#050505">
   <title>VTDD v2 Dashboard</title>
   <style>
@@ -67699,6 +67703,7 @@ function renderDashboardAuthRequiredPage({ runtimeOrigin, returnPath = "/dashboa
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="apple-touch-icon" sizes="512x512" href="${DASHBOARD_ICON_PNG_PATH}">
   <title>Dashboard auth required</title>
   <style>
     :root { color-scheme: light; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; color: #17211d; background: #f8faf8; }


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #620 の追加修正です。Dashboard Butler PWA icon が iOS 側で古い icon URL / apple-touch-icon 探索に引っかからないよう、versioned icon URL と iOS向け touch icon route を追加します。
- 既存 `/dashboard-icon.png` は互換として残しつつ、manifest の先頭 icon を `/dashboard-icon-20260529-butler.png` に切り替えます。

## Satisfied Success Criteria

- PWA manifest の先頭 icon が cache-busted versioned PNG URL になります。
- Dashboard HTML に `apple-touch-icon` を明示します。
- iOS が直接探しに来る `/apple-touch-icon.png` と `/apple-touch-icon-precomposed.png` でも同じ PNG を返します。
- 既存 `/dashboard-icon.png` と `/dashboard-icon.svg` は互換 fallback として残します。

## Unsatisfied Success Criteria

- iOS ホーム画面に既に追加済みのショートカット icon を Web 側から必ず強制更新する保証はありません。OS 側キャッシュのため、再追加が必要になる可能性があります。
- Cloudflare Pages の本番URL設定、朝昼夕 publisher、news item 永続保存はこのPR外です。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #620
- Implementing Success Criteria: PWA icon の cache-busted URL、apple-touch-icon の明示、iOS touch icon fallback route。
- Explicit Non-goals: deploy 実行、credential / permission mutation、アイコン再デザイン、既存iOSホーム画面ショートカットのOSキャッシュ強制消去。
- Expected touched files/routes/workflows: `src/worker/runtime.js`, `worker.js`, `test/worker.test.js`, routes `/dashboard-icon-20260529-butler.png`, `/apple-touch-icon.png`, `/apple-touch-icon-precomposed.png`。
- Affected Issues: Issue #620。
- Affected PRs: PR #621 の post-merge icon follow-up。
- Affected workflows: なし。
- Affected runtime/operator surfaces: Dashboard PWA manifest, Dashboard HTML head, iOS home-screen icon fetch path。
- What may break if we patch narrowly: 同じ `/dashboard-icon.png` のままだと iOS / CDN / Safari キャッシュが古い icon を保持し続ける可能性があります。
- Unknowns to investigate before coding: 既存iOSホーム画面ショートカットが再取得するかはOS挙動依存で、Web標準APIからは強制不可。
- Validation needed: `npm run build:worker`, `npm test -- --test-name-pattern "dashboard PWA manifest"`。
- Stop condition: iOSのOS管理領域をWebから操作する必要が出た場合は実装不可として止めます。

## Execution Queue Delta

- Queue position before: Issue #620 の post-deploy evidence gap です。
- Preemption decision: EVIDENCE。PR #621 deploy 後に iPhone home-screen icon が変わらない実機 evidence が出たため、cache path を補正します。
- Queue delta: Issue #620 の PWA icon fetch path evidence gap を埋めます。publisher / Pages deploy URL / news storage は残します。
- Why this PR is next: owner が実機で icon 未更新を確認したため、PWA追加/再追加時の icon path を先に安定させる必要があります。
- Active Issues not downscoped: Active Issues は縮小しません。このPRで扱わない active Issue は未完了として残します。

## File / Line Hypotheses

- file: `src/worker/runtime.js`
  - hypothesis: manifest icon URL を versioned PNG にし、`apple-touch-icon` と fallback route を追加すれば、iOS が次回 icon を取得する時に古い path cache を踏みにくくなる。
  - risk if changed narrowly: versioned URL だけだと iOS が `apple-touch-icon.png` を直接探した時に古い/未指定扱いになる可能性がある。
  - validation: manifest と icon route の worker tests。
  - related Issue: Issue #620
- file: `test/worker.test.js`
  - hypothesis: manifest 先頭 icon、PNG signature、apple touch fallback を固定すれば再発防止になる。
  - risk if changed narrowly: SVG fallback だけを確認して、iOSが使うPNG経路を見落とす。
  - validation: dashboard PWA manifest test。
  - related Issue: Issue #620

## Hypothesis Retrospective

- expected: manifest の先頭 icon が versioned PNG になり、Dashboard HTML と Apple touch icon fallback routes が同じ画像へ向く。
- actual: 実装どおり。
- mismatch: 既存ホーム画面ショートカットのOSキャッシュ更新はWeb側から保証できません。
- lesson: iOS PWA icon は通常のCSS/JS更新より強いキャッシュ/固定化を前提に、versioned icon URL と apple-touch-icon を最初から入れる必要があります。
- should become RAG candidate: decision_log 候補。iOS PWA icon は manifest だけでなく versioned PNG + apple-touch-icon + fallback routes を標準にする。

## Verification Evidence

- Unit: `npm test -- --test-name-pattern "dashboard PWA manifest"` passed.
- Integration: `npm run build:worker` passed; generated `worker.js` is synced.
- E2E: 未実施。deploy 後に iPhone PWA で再追加して確認します。
- Manual: 本番 `/dashboard-icon.png` が 512x512 PNG であることはPR前に確認済み。このPRは追加 cache-busting path。
- Evidence path/link: local command output in this Codex run.

## Butler Completion Contract

- Owner goal: Dashboard Butler PWA icon を新画像で取得できる経路にする。
- Butler entrypoint: `/dashboard.webmanifest`, `/dashboard-icon-20260529-butler.png`, `/apple-touch-icon.png`。
- Action Schema exposure: 変更なし。
- Runtime path: Worker GET icon routes and Dashboard HTML head.
- Runner/runtime truth: tests で manifest と icon route を確認。
- Authority boundary: deploy はこのPR外。deploy には scoped passkey approval が必要です。
- E2E evidence: このPRスライスでは未実施。iPhone PWA live E2E は deploy 後。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 未実施。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。deploy 後に確認します。

## Related Constitution Rules

- AGENTS.md Evidence Discipline
- AGENTS.md PR / Deploy Discipline
- AGENTS.md Butler-First Operating Principle

## Out-of-scope but NOT implemented

- 既存iOSホーム画面ショートカットのOSキャッシュ強制更新。
- 朝刊・昼刊・夕刊 publisher。
- Cloudflare Pages 本番公開URL設定。

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #620
- Execution ID: mac-codex-2026-05-29-dashboard-pwa-icon-cache
