### PR TITLE
dashboard: show server push test feedback

### DIFF
--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -10472,13 +10472,21 @@ async function renderDashboardNotificationsPage({ runtimeOrigin, dashboardEventS
           function safePushResultDetail(value) {
             const normalized = String(value || "");
             if (!normalized) return "";
+            if (normalized.includes("exception")) return "browser exception";
             if (normalized.includes("accepted")) return "accepted";
             if (normalized.includes("stale")) return "stale subscription";
             if (normalized.includes("not found")) return "subscription not found";
             if (normalized.includes("unconfigured")) return "server push unconfigured";
             if (normalized.includes("rejected")) return "push service rejected";
             if (normalized.includes("required")) return "required setting missing";
+            if (normalized.includes("unauthorized") || normalized.includes("forbidden")) return "session/auth required";
             return "details redacted";
+          }
+
+          function setButtonBusy(button, busy) {
+            if (!button) return;
+            button.disabled = Boolean(busy);
+            button.setAttribute("aria-busy", busy ? "true" : "false");
           }
 
           async function registration() {
@@ -10579,33 +10587,52 @@ async function renderDashboardNotificationsPage({ runtimeOrigin, dashboardEventS
           });
 
           serverTestButton?.addEventListener("click", async () => {
-            const reg = await registration();
-            const subscription = await reg?.pushManager?.getSubscription?.();
-            if (!subscription) {
-              serverPushDelivered = false;
-              lastServerPushResult = "最後のサーバ送信結果: rejected (0/0) / current device subscription missing";
+            setButtonBusy(serverTestButton, true);
+            serverPushDelivered = false;
+            lastServerPushResult = "最後のサーバ送信結果: 送信中...";
+            setText(pushServerResult, lastServerPushResult);
+            try {
+              const reg = await registration();
+              const subscription = await reg?.pushManager?.getSubscription?.();
+              if (!subscription) {
+                lastServerPushResult = "最後のサーバ送信結果: rejected (0/0) / current device subscription missing";
+                setText(pushServerResult, lastServerPushResult);
+                await refreshState();
+                return;
+              }
+              const response = await fetch("/v2/dashboard/push/test", {
+                method: "POST",
+                credentials: "same-origin",
+                headers: { "content-type": "application/json" },
+                body: JSON.stringify({ title: "Dashboard Butler server push test", endpoint: subscription.endpoint })
+              });
+              const body = await response.json().catch(() => ({}));
+              const webPush = body && body.webPush ? body.webPush : {};
+              const attempted = Number(webPush.attempted || 0);
+              const delivered = Number(webPush.delivered || 0);
+              const firstResult = Array.isArray(webPush.results) ? webPush.results[0] : null;
+              const detail = safePushResultDetail(
+                firstResult?.reason ||
+                  firstResult?.error ||
+                  webPush.reason ||
+                  webPush.error ||
+                  (response.ok ? "" : response.status === 401 ? "unauthorized" : response.status === 403 ? "forbidden" : "rejected")
+              );
+              serverPushDelivered = response.ok && delivered > 0 && delivered === attempted;
+              lastServerPushResult = serverPushDelivered
+                ? "最後のサーバ送信結果: accepted (" + delivered + "/" + attempted + ")"
+                : "最後のサーバ送信結果: rejected (" + delivered + "/" + attempted + ")" + (detail ? " / " + detail : "");
               setText(pushServerResult, lastServerPushResult);
               await refreshState();
-              return;
+            } catch (error) {
+              serverPushDelivered = false;
+              const detail = safePushResultDetail("exception " + (error && error.name ? error.name : ""));
+              lastServerPushResult = "最後のサーバ送信結果: rejected (0/0)" + (detail ? " / " + detail : "");
+              setText(pushServerResult, lastServerPushResult);
+              await refreshState();
+            } finally {
+              setButtonBusy(serverTestButton, false);
             }
-            const response = await fetch("/v2/dashboard/push/test", {
-              method: "POST",
-              credentials: "same-origin",
-              headers: { "content-type": "application/json" },
-              body: JSON.stringify({ title: "Dashboard Butler server push test", endpoint: subscription.endpoint })
-            });
-            const body = await response.json().catch(() => ({}));
-            const webPush = body && body.webPush ? body.webPush : {};
-            const attempted = Number(webPush.attempted || 0);
-            const delivered = Number(webPush.delivered || 0);
-            const firstResult = Array.isArray(webPush.results) ? webPush.results[0] : null;
-            const detail = safePushResultDetail(firstResult?.reason || firstResult?.error || webPush.reason || webPush.error || "");
-            serverPushDelivered = delivered > 0 && delivered === attempted;
-            lastServerPushResult = serverPushDelivered
-              ? "最後のサーバ送信結果: accepted (" + delivered + "/" + attempted + ")"
-              : "最後のサーバ送信結果: rejected (" + delivered + "/" + attempted + ")" + (detail ? " / " + detail : "");
-            setText(pushServerResult, lastServerPushResult);
-            await refreshState();
           });
 
           badgeSetButton?.addEventListener("click", async () => {

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -3710,6 +3710,10 @@ test("worker serves dashboard notification center for recent events across repos
   assert.equal(body.includes("購読保存: あり。サーバ送信テストも成功済みです。deploy 完了/失敗通知は同じ経路で届きます。"), true);
   assert.equal(body.includes("端末に購読はありますが、サーバ保存は未確認です"), true);
   assert.equal(body.includes("safePushResultDetail"), true);
+  assert.equal(body.includes("setButtonBusy(serverTestButton, true)"), true);
+  assert.equal(body.includes("最後のサーバ送信結果: 送信中..."), true);
+  assert.equal(body.includes("browser exception"), true);
+  assert.equal(body.includes("session/auth required"), true);
   assert.equal(body.includes("最後のサーバ送信結果: accepted"), true);
   assert.equal(body.includes("最後のサーバ送信結果: rejected"), true);
   assert.equal(body.includes("D1 には送信用に保持し、response / HTML / payload_json には raw key を返しません"), true);

--- a/worker.js
+++ b/worker.js
@@ -65372,13 +65372,21 @@ async function renderDashboardNotificationsPage({ runtimeOrigin, dashboardEventS
           function safePushResultDetail(value) {
             const normalized = String(value || "");
             if (!normalized) return "";
+            if (normalized.includes("exception")) return "browser exception";
             if (normalized.includes("accepted")) return "accepted";
             if (normalized.includes("stale")) return "stale subscription";
             if (normalized.includes("not found")) return "subscription not found";
             if (normalized.includes("unconfigured")) return "server push unconfigured";
             if (normalized.includes("rejected")) return "push service rejected";
             if (normalized.includes("required")) return "required setting missing";
+            if (normalized.includes("unauthorized") || normalized.includes("forbidden")) return "session/auth required";
             return "details redacted";
+          }
+
+          function setButtonBusy(button, busy) {
+            if (!button) return;
+            button.disabled = Boolean(busy);
+            button.setAttribute("aria-busy", busy ? "true" : "false");
           }
 
           async function registration() {
@@ -65479,33 +65487,52 @@ async function renderDashboardNotificationsPage({ runtimeOrigin, dashboardEventS
           });
 
           serverTestButton?.addEventListener("click", async () => {
-            const reg = await registration();
-            const subscription = await reg?.pushManager?.getSubscription?.();
-            if (!subscription) {
-              serverPushDelivered = false;
-              lastServerPushResult = "\u6700\u5F8C\u306E\u30B5\u30FC\u30D0\u9001\u4FE1\u7D50\u679C: rejected (0/0) / current device subscription missing";
+            setButtonBusy(serverTestButton, true);
+            serverPushDelivered = false;
+            lastServerPushResult = "\u6700\u5F8C\u306E\u30B5\u30FC\u30D0\u9001\u4FE1\u7D50\u679C: \u9001\u4FE1\u4E2D...";
+            setText(pushServerResult, lastServerPushResult);
+            try {
+              const reg = await registration();
+              const subscription = await reg?.pushManager?.getSubscription?.();
+              if (!subscription) {
+                lastServerPushResult = "\u6700\u5F8C\u306E\u30B5\u30FC\u30D0\u9001\u4FE1\u7D50\u679C: rejected (0/0) / current device subscription missing";
+                setText(pushServerResult, lastServerPushResult);
+                await refreshState();
+                return;
+              }
+              const response = await fetch("/v2/dashboard/push/test", {
+                method: "POST",
+                credentials: "same-origin",
+                headers: { "content-type": "application/json" },
+                body: JSON.stringify({ title: "Dashboard Butler server push test", endpoint: subscription.endpoint })
+              });
+              const body = await response.json().catch(() => ({}));
+              const webPush = body && body.webPush ? body.webPush : {};
+              const attempted = Number(webPush.attempted || 0);
+              const delivered = Number(webPush.delivered || 0);
+              const firstResult = Array.isArray(webPush.results) ? webPush.results[0] : null;
+              const detail = safePushResultDetail(
+                firstResult?.reason ||
+                  firstResult?.error ||
+                  webPush.reason ||
+                  webPush.error ||
+                  (response.ok ? "" : response.status === 401 ? "unauthorized" : response.status === 403 ? "forbidden" : "rejected")
+              );
+              serverPushDelivered = response.ok && delivered > 0 && delivered === attempted;
+              lastServerPushResult = serverPushDelivered
+                ? "\u6700\u5F8C\u306E\u30B5\u30FC\u30D0\u9001\u4FE1\u7D50\u679C: accepted (" + delivered + "/" + attempted + ")"
+                : "\u6700\u5F8C\u306E\u30B5\u30FC\u30D0\u9001\u4FE1\u7D50\u679C: rejected (" + delivered + "/" + attempted + ")" + (detail ? " / " + detail : "");
               setText(pushServerResult, lastServerPushResult);
               await refreshState();
-              return;
+            } catch (error) {
+              serverPushDelivered = false;
+              const detail = safePushResultDetail("exception " + (error && error.name ? error.name : ""));
+              lastServerPushResult = "\u6700\u5F8C\u306E\u30B5\u30FC\u30D0\u9001\u4FE1\u7D50\u679C: rejected (0/0)" + (detail ? " / " + detail : "");
+              setText(pushServerResult, lastServerPushResult);
+              await refreshState();
+            } finally {
+              setButtonBusy(serverTestButton, false);
             }
-            const response = await fetch("/v2/dashboard/push/test", {
-              method: "POST",
-              credentials: "same-origin",
-              headers: { "content-type": "application/json" },
-              body: JSON.stringify({ title: "Dashboard Butler server push test", endpoint: subscription.endpoint })
-            });
-            const body = await response.json().catch(() => ({}));
-            const webPush = body && body.webPush ? body.webPush : {};
-            const attempted = Number(webPush.attempted || 0);
-            const delivered = Number(webPush.delivered || 0);
-            const firstResult = Array.isArray(webPush.results) ? webPush.results[0] : null;
-            const detail = safePushResultDetail(firstResult?.reason || firstResult?.error || webPush.reason || webPush.error || "");
-            serverPushDelivered = delivered > 0 && delivered === attempted;
-            lastServerPushResult = serverPushDelivered
-              ? "\u6700\u5F8C\u306E\u30B5\u30FC\u30D0\u9001\u4FE1\u7D50\u679C: accepted (" + delivered + "/" + attempted + ")"
-              : "\u6700\u5F8C\u306E\u30B5\u30FC\u30D0\u9001\u4FE1\u7D50\u679C: rejected (" + delivered + "/" + attempted + ")" + (detail ? " / " + detail : "");
-            setText(pushServerResult, lastServerPushResult);
-            await refreshState();
           });
 
           badgeSetButton?.addEventListener("click", async () => {


### PR DESCRIPTION
## This PR satisfies Intent

- #589 の PWA通知未達調査で、Dashboard 通知センターの `サーバ送信テスト` を押しても UI が無反応に見える状態をなくす。
- サーバ送信テストの開始、成功、失敗、認証切れ、ブラウザ例外を owner-facing に表示し、次の実機切り分けへ進める。

## Satisfied Success Criteria

- サーバ送信テストを押した瞬間に `最後のサーバ送信結果: 送信中...` を表示する。
- current device subscription missing / 401 / 403 / push service rejection / browser exception を `最後のサーバ送信結果` に表示する。
- テスト中のボタンを busy/disabled にして、二重タップや反応なしに見える状態を避ける。
- raw endpoint / p256dh / auth key / approvalGrantId は response / HTML 表示に出さない。

## Unsatisfied Success Criteria

- iPhone 実機で、修正版 deploy 後の `サーバ送信テスト` が visible feedback を出すことは未確認。
- iOS 通知バナーが必ず表示されることは、この PR では保証しない。
- `認証成功 -> デプロイ実行中 -> デプロイ完了` の段階通知は、この PR では未実装。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #589
- Implementing Success Criteria: Web Push 未達時に owner-facing runtime truth を残す入口として、サーバ送信テストの UI 結果を silent no-op にしない。
- Explicit Non-goals: production deploy 実行、credential/permission mutation、iOS 通知設定変更、subscription raw key 表示、PWA icon/favicon 調整、通知表示保証。
- Expected touched files/routes/workflows: `src/worker/runtime.js`; `test/worker.test.js`; generated `worker.js`
- Affected Issues: Issue #589
- Affected PRs: PR #623 後の deploy 確認から見つかった follow-up。PR #620/#618 の通知センター/Push truth 系にも関連。
- Affected workflows: deploy-production workflow は変更しない。
- Affected runtime/operator surfaces: Dashboard notification center; `/dashboard/notifications`; `/v2/dashboard/push/test`
- What may break if we patch narrowly: サーバ送信が認証切れ・例外・subscription missing で止まっても、owner には無反応に見えて原因調査がまた手作業になる。
- Unknowns to investigate before coding: iOS PWA が実際に通知バナーを表示しない原因は、OS通知設定/Focus/通知要約/APNs/Service Worker 起動条件のどれかまではこの PR だけでは確定できない。
- Validation needed: worker tests; generated worker parity; merge/deploy 後の iPhone PWA live check。
- Stop condition: endpoint / auth key / p256dh / approval grant を response / logs / RAG に出すなら停止。

## Execution Queue Delta

- Queue position before: Issue #589 は PWA通知未達原因を owner-facing に見えるようにする active issue。
- Preemption decision: EVIDENCE: PR #623 deploy 後、workflow 側は Web Push accepted を記録したが owner の iPhone には通知が表示されず、さらに `サーバ送信テスト` タップが無反応に見えた。
- Queue delta: Issue #589 の notification center server test feedback slice を進める。Issue #589 自体は live PWA evidence まで未完了。
- Why this PR is next: 配信経路の deeper fix より先に、owner が iPhone だけで「押した」「送信中」「失敗理由」を確認できないと回帰調査が成立しない。
- Active Issues not downscoped: 他 active Issues は縮小しない。Issue #589 の lifecycle notification と iOS 実機表示確認は残作業として明示する。

## Regression Analysis

- Last known likely-good window: owner report says 2026-05-28 daytime / noon-ish notifications arrived.
- First bad window: 2026-05-28 evening/night, deploy notifications did not visibly arrive on iPhone after notification-related changes.
- Confirming runtime truth before this PR: deploy workflow log for run `26587221859` reported Worker event ingest accepted and `webPushDelivered=1`, so GitHub Actions -> Worker -> Web Push service accepted was not enough to prove iPhone visible display.
- Follow-up symptom: Dashboard 通知センターで `サーバ送信テスト` をタップしても画面上の表示が変わらず、browser exception / auth / subscription missing の切り分けができなかった。
- This PR addresses: silent UI feedback during server-side push test. It does not claim APNs/iOS visible notification root cause is fixed.
- Drift note: accepted/delivered と iPhone visible display は分けて扱う必要がある。

## File / Line Hypotheses

- file: `src/worker/runtime.js`
  - hypothesis: server-side push test click handler had no start state and no catch/finally path, so fetch/auth/browser errors could look like a no-op to the owner.
  - risk if changed narrowly: Dashboard says server push settings exist but the owner cannot tell whether the tap is running, failed, unauthorized, or exceptioned.
  - validation: notification center test asserts `送信中...`, busy state, browser exception, and session/auth required strings are present.
  - related Issue: #589
- file: `test/worker.test.js`
  - hypothesis: existing notification center test covered accepted/rejected strings but not start/error feedback, allowing silent no-op UX to regress.
  - risk if changed narrowly: future edits could again remove click feedback without a test failure.
  - validation: HTML test now asserts the start/error feedback hooks.
  - related Issue: #589

## Hypothesis Retrospective

- expected: adding explicit start/error/finally UI feedback makes the server test never look silent, even when current device subscription, auth, or browser fetch fails.
- actual: local worker tests, generated worker build, and generated worker parity passed.
- mismatch: iPhone visible notification display cannot be proven from local tests; it requires merge/deploy and live PWA check.
- lesson: Web Push `accepted` is delivery pipeline evidence, not the same as owner-visible iPhone notification evidence.
- should become RAG candidate: はい。

## Verification Evidence

- Unit/integration focused command:

```bash
node --test test/worker.test.js --test-name-pattern "dashboard notification center|dashboard PWA manifest|server-side dashboard Web Push test" && npm run build:worker && npm run check:generated-worker
```

- Result: 215 tests passed; `build:worker` passed; `check:generated-worker` passed.
- Manual: `git diff --check -- src/worker/runtime.js test/worker.test.js worker.js` passed.
- E2E: not yet run; requires merge/deploy and iPhone PWA live check.

## Butler Completion Contract

- Owner goal: PWA通知が来ない時に、Dashboard 通知センターからサーバ送信テストを押して、反応なしではなく送信中/成功/失敗理由を確認できるようにする。
- Butler entrypoint: Dashboard notification center / PWA notification settings.
- Action Schema exposure: 不要。
- Runtime path: Dashboard notification center -> current PWA subscription -> `/v2/dashboard/push/test` -> UI result text.
- Runner/runtime truth: accepted/rejected/browser exception/session auth required/current device subscription missing を owner-facing text に出す。
- Authority boundary: dashboard owner session required. deploy is not executed in this PR.
- E2E evidence: 未実施。merge/deploy後に iPhone 実機で確認する。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: この PR では実行しない。merge 後に passkey 承認付き deploy が必要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。次回 deploy 後、PWA `サーバ送信テスト` の visible feedback と通知到達性を確認する。

## Related Constitution Rules

- Butler Completion Gate: live iPhone evidence なしに #589 完了扱いしない。
- Evidence Discipline: server accepted / current-device accepted / PWA received / visible notification を分ける。
- Authority Boundary: deploy 実行は passkey approval 必須。
- RAG Memory Capture and Cost Boundary: raw push subscription material を保存・表示しない。

## Out-of-scope but NOT implemented

- 認証成功 -> デプロイ実行中 -> デプロイ完了 の段階通知。
- iOS Focus / 通知要約 / 通知許可設定の変更。
- PWA icon/favicon の再調整。

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #589
- Execution ID: local-codex-2026-05-29-server-push-test-feedback
- Goal: #589 server-side PWA push test visible feedback
