### PR TITLE
repo-backed Skill共有gateとGit PR preflightを追加する

### DIFF
--- a/.agents/skills/vtdd-status-advisor/SKILL.md
+++ b/.agents/skills/vtdd-status-advisor/SKILL.md
@@ -24,6 +24,11 @@ If this Skill is found only in local mac Codex state, report
 `mac_codex_only_probe` and promote the behavior into the repository before
 claiming VTDD progress.
 
+Do not call a Skill update repository-backed until the files are committed,
+pushed, and represented in a Japanese-first PR body. If Dashboard Butler or VPS
+Codex CLI cannot yet discover or execute the Skill, say `unconnected` or
+`incomplete` and name the missing runtime connection.
+
 Use Japanese-first owner-facing language for Issue, PR, review, and status
 prose. Issue / PR titles, bodies, comments, review responses, and RAG
 candidates must be Japanese by default unless the owner explicitly requests

--- a/.agents/skills/vtdd-status-advisor/SKILL.md
+++ b/.agents/skills/vtdd-status-advisor/SKILL.md
@@ -29,6 +29,13 @@ pushed, and represented in a Japanese-first PR body. If Dashboard Butler or VPS
 Codex CLI cannot yet discover or execute the Skill, say `unconnected` or
 `incomplete` and name the missing runtime connection.
 
+If the owner is frustrated, angry, or says the assistant is drifting, slow down.
+Before any commit, push, PR create/update, or review response, verify current
+git and PR truth: branch/upstream, recent commits, latest `origin/main`, related
+PR state, head SHA, merged/closed/open status, checks/reviews, and auto-merge
+risk. If the related PR is merged, do not push follow-up work to that branch;
+use a fresh branch from latest `origin/main`.
+
 Use Japanese-first owner-facing language for Issue, PR, review, and status
 prose. Issue / PR titles, bodies, comments, review responses, and RAG
 candidates must be Japanese by default unless the owner explicitly requests
@@ -103,6 +110,7 @@ Stop and report instead of proceeding when:
 - the request changes from Read to Execute
 - the Issue/PR target is unresolved
 - runtime truth conflicts with memory or assumptions
+- the current git branch or related PR state has not been checked in this turn
 - the next action requires GO, passkey approval, deploy authority, merge, close,
   credential mutation, or permission mutation
 - the answer would depend on mac Codex-only state

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,6 +126,12 @@ Skills must be repository-backed or otherwise readable by Dashboard Butler and
 VPS Codex CLI. A local mac Codex Skill is not a VTDD product capability by
 itself.
 
+Do not claim a Skill, contract, guardrail, or operating rule is repo-backed or
+durable until the repository files are committed on a topic branch, pushed, and
+represented in a Japanese-first PR body. If Dashboard Butler / VPS Codex CLI
+runtime discovery, Action Schema, VPS inventory, or E2E is still missing, mark
+the PR and status as `unconnected` or `incomplete` instead of shared completion.
+
 VTDD does not want a passive assistant that only does exactly what the owner
 spelled out. The assistant must use autonomy for judgment, critique, proposal,
 risk detection, and saying when an idea should stop or become a smaller

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,6 +132,14 @@ represented in a Japanese-first PR body. If Dashboard Butler / VPS Codex CLI
 runtime discovery, Action Schema, VPS inventory, or E2E is still missing, mark
 the PR and status as `unconnected` or `incomplete` instead of shared completion.
 
+When the owner is frustrated or points out drift, do not rush into edits. First
+verify current git and PR truth: `git status --short --branch`, recent commits,
+latest `origin/main`, related PR state, head SHA, merged/closed/open status,
+checks/reviews, and auto-merge risk. If the related PR is merged, do not push to
+that merged PR branch; create a fresh branch from latest `origin/main` and open
+or update a separate Japanese-first PR. After creating or updating a PR, check
+the PR state again before claiming the work is safely shared.
+
 VTDD does not want a passive assistant that only does exactly what the owner
 spelled out. The assistant must use autonomy for judgment, critique, proposal,
 risk detection, and saying when an idea should stop or become a smaller

--- a/docs/butler/intent-mode-contract.md
+++ b/docs/butler/intent-mode-contract.md
@@ -24,6 +24,25 @@ Therefore VTDD Skills must be repository-backed and usable by Dashboard Butler
 and VPS Codex CLI. A Skill that only lives in a local mac Codex install is not a
 product capability.
 
+## Repository Sharing Gate
+
+Do not say a Skill, contract, guardrail, or operating rule has been
+`repo-backed`, `repository-backed`, `durable`, `共有済み`, or `リポジトリに入れた`
+unless all applicable sharing steps are true:
+
+- the change is in repository files, not only local mac Codex memory or
+  `~/.codex`
+- the changed files are committed on a topic branch
+- the branch is pushed to the remote repository
+- a Japanese-first PR is opened or updated with the change
+- the PR body states whether Dashboard Butler / VPS Codex CLI can actually read
+  or execute the behavior today
+- if runtime discovery, Action Schema, VPS inventory, or E2E is missing, the PR
+  marks the work `unconnected` or `incomplete`
+
+If any step is missing, report the work as a draft, local probe, or
+`mac_codex_only_probe`; do not present it as shared VTDD progress.
+
 ## Core Principle
 
 AI autonomy is required for judgment, critique, and proposal.
@@ -140,7 +159,8 @@ Skills belong in the repository or another declared shared source that Butler
 and VPS Codex CLI can read. Do not treat a local mac Codex Skill as the canonical
 implementation. If mac Codex drafts a Skill first, the next step is to promote
 the behavior into repository docs / `.agents/skills` / runtime truth so
-Dashboard Butler can own the workflow.
+Dashboard Butler can own the workflow, then commit, push, and open or update the
+PR before claiming the behavior is repository-backed.
 
 The first Skill is `vtdd-status-advisor`:
 

--- a/docs/butler/intent-mode-contract.md
+++ b/docs/butler/intent-mode-contract.md
@@ -43,6 +43,33 @@ unless all applicable sharing steps are true:
 If any step is missing, report the work as a draft, local probe, or
 `mac_codex_only_probe`; do not present it as shared VTDD progress.
 
+## Calm Git / PR Preflight
+
+When the owner is frustrated, angry, or pointing out drift, do not rush into
+more edits. The first action is to slow down and verify operational truth.
+
+Before committing, pushing, opening a PR, updating a PR, or responding to review
+comments, run or retrieve the equivalent of:
+
+- current branch and upstream: `git status --short --branch`
+- recent local commits: `git log --oneline --decorate -5`
+- latest remote main: `git fetch origin main`
+- base freshness: confirm `origin/main` is an ancestor of the topic branch or
+  rebase/create a fresh branch before continuing
+- PR state for any related branch: open / closed / merged, head SHA, base,
+  merge commit, and review/check status
+- reviewer / auto-merge truth: whether a reviewer approval, required check, or
+  auto-merge path may already have merged the PR
+
+If the related PR is merged, do not push follow-up work to that merged PR
+branch. Create a new branch from latest `origin/main`, cherry-pick or reapply
+only the intended follow-up, then open or update a separate Japanese-first PR.
+
+After opening or updating a PR, the assistant remains responsible for checking
+the PR state it just changed. At minimum, retrieve PR state, checks/reviews when
+available, and whether the PR has already merged before making another branch or
+push decision.
+
 ## Core Principle
 
 AI autonomy is required for judgment, critique, and proposal.

--- a/test/intent-mode-contract.test.js
+++ b/test/intent-mode-contract.test.js
@@ -21,6 +21,12 @@ test("intent mode contract preserves autonomy without allowing drift", () => {
   assert.equal(doc.includes("the branch is pushed to the remote repository"), true);
   assert.equal(doc.includes("a Japanese-first PR is opened or updated with the change"), true);
   assert.equal(doc.includes("marks the work `unconnected` or `incomplete`"), true);
+  assert.equal(doc.includes("## Calm Git / PR Preflight"), true);
+  assert.equal(doc.includes("When the owner is frustrated, angry, or pointing out drift"), true);
+  assert.equal(doc.includes("git status --short --branch"), true);
+  assert.equal(doc.includes("reviewer / auto-merge truth"), true);
+  assert.equal(doc.includes("If the related PR is merged, do not push follow-up work to that merged PR\nbranch."), true);
+  assert.equal(doc.includes("After opening or updating a PR, the assistant remains responsible for checking\nthe PR state it just changed."), true);
   assert.equal(doc.includes("判断・批評・提案は、AIが主体的にやる。"), true);
   assert.equal(doc.includes("実行・外部効果・完了宣言は、Issue / GO / approval / evidence なしに進めない。"), true);
   assert.equal(doc.includes("Issue / PR titles, bodies, comments, review responses, and RAG"), true);
@@ -35,6 +41,9 @@ test("intent mode contract preserves autonomy without allowing drift", () => {
   assert.equal(agents.includes("A local mac Codex Skill is not a VTDD product capability by\nitself."), true);
   assert.equal(agents.includes("committed on a topic branch, pushed, and\nrepresented in a Japanese-first PR body"), true);
   assert.equal(agents.includes("mark\nthe PR and status as `unconnected` or `incomplete`"), true);
+  assert.equal(agents.includes("When the owner is frustrated or points out drift, do not rush into edits."), true);
+  assert.equal(agents.includes("checks/reviews, and auto-merge risk"), true);
+  assert.equal(agents.includes("After creating or updating a PR, check\nthe PR state again"), true);
   assert.equal(agents.includes(".agents/skills/vtdd-status-advisor/SKILL.md"), true);
   assert.equal(agents.includes("readonly does not mean\npassive"), true);
 });
@@ -50,6 +59,9 @@ test("vtdd status advisor skill is readonly but still gives judgment", () => {
   assert.equal(skill.includes("`mac_codex_only_probe`"), true);
   assert.equal(skill.includes("committed,\npushed, and represented in a Japanese-first PR body"), true);
   assert.equal(skill.includes("say `unconnected` or\n`incomplete`"), true);
+  assert.equal(skill.includes("If the owner is frustrated, angry, or says the assistant is drifting, slow down."), true);
+  assert.equal(skill.includes("checks/reviews, and auto-merge\nrisk"), true);
+  assert.equal(skill.includes("the current git branch or related PR state has not been checked in this turn"), true);
   assert.equal(skill.includes("Use Japanese-first owner-facing language"), true);
   assert.equal(skill.includes("Issue / PR titles, bodies, comments, review responses, and RAG"), true);
   assert.equal(skill.includes("launch VPS runner, reviewer, deploy"), true);

--- a/test/intent-mode-contract.test.js
+++ b/test/intent-mode-contract.test.js
@@ -16,6 +16,11 @@ test("intent mode contract preserves autonomy without allowing drift", () => {
   assert.equal(doc.includes("Dashboard Butler is the intended primary operator surface."), true);
   assert.equal(doc.includes("VPS Codex CLI is the\nalways-on execution surface behind it."), true);
   assert.equal(doc.includes("A Skill that only lives in a local mac Codex install is not a\nproduct capability."), true);
+  assert.equal(doc.includes("## Repository Sharing Gate"), true);
+  assert.equal(doc.includes("the changed files are committed on a topic branch"), true);
+  assert.equal(doc.includes("the branch is pushed to the remote repository"), true);
+  assert.equal(doc.includes("a Japanese-first PR is opened or updated with the change"), true);
+  assert.equal(doc.includes("marks the work `unconnected` or `incomplete`"), true);
   assert.equal(doc.includes("判断・批評・提案は、AIが主体的にやる。"), true);
   assert.equal(doc.includes("実行・外部効果・完了宣言は、Issue / GO / approval / evidence なしに進めない。"), true);
   assert.equal(doc.includes("Issue / PR titles, bodies, comments, review responses, and RAG"), true);
@@ -28,6 +33,8 @@ test("intent mode contract preserves autonomy without allowing drift", () => {
   assert.equal(agents.includes(CONTRACT_PATH), true);
   assert.equal(agents.includes("Dashboard Butler is the intended primary operator surface."), true);
   assert.equal(agents.includes("A local mac Codex Skill is not a VTDD product capability by\nitself."), true);
+  assert.equal(agents.includes("committed on a topic branch, pushed, and\nrepresented in a Japanese-first PR body"), true);
+  assert.equal(agents.includes("mark\nthe PR and status as `unconnected` or `incomplete`"), true);
   assert.equal(agents.includes(".agents/skills/vtdd-status-advisor/SKILL.md"), true);
   assert.equal(agents.includes("readonly does not mean\npassive"), true);
 });
@@ -41,6 +48,8 @@ test("vtdd status advisor skill is readonly but still gives judgment", () => {
   assert.equal(skill.includes("Dashboard Butler is the intended primary surface for this Skill."), true);
   assert.equal(skill.includes("VPS Codex CLI\nmust be able to read and follow the same repo-backed behavior."), true);
   assert.equal(skill.includes("`mac_codex_only_probe`"), true);
+  assert.equal(skill.includes("committed,\npushed, and represented in a Japanese-first PR body"), true);
+  assert.equal(skill.includes("say `unconnected` or\n`incomplete`"), true);
   assert.equal(skill.includes("Use Japanese-first owner-facing language"), true);
   assert.equal(skill.includes("Issue / PR titles, bodies, comments, review responses, and RAG"), true);
   assert.equal(skill.includes("launch VPS runner, reviewer, deploy"), true);


### PR DESCRIPTION
## This PR satisfies Intent

- PR #625 merge 後に同じ merged branch へ追加 push してしまった `Repository Sharing Gate` を、main 起点の新しい topic branch / PR として正しく出し直します。
- Skill / contract / guardrail を `repo-backed` と呼ぶ条件を、commit / push / 日本語-first PR / unconnected明記まで含む仕組みとして固定します。

## Satisfied Success Criteria

- [x] `repo-backed` / `リポジトリに入れた` と言える条件を `docs/butler/intent-mode-contract.md` に追加しました。
- [x] `AGENTS.md` からも、commit / push / 日本語-first PR / unconnected明記を要求するようにしました。
- [x] `vtdd-status-advisor` Skill に、local mac Codex だけで完結させない共有 gate を追加しました。
- [x] owner が怒っている時・drift を指摘している時に、編集より先に Git / PR / reviewer / auto-merge truth を確認する `Calm Git / PR Preflight` を追加しました。
- [x] `test/intent-mode-contract.test.js` で Repository Sharing Gate の文言を固定しました。

## Unsatisfied Success Criteria

- このPRは process guardrail の追加です。Dashboard Butler runtime の Skill discovery、VPS Codex CLI inventory、Action Schema、iPhone/PWA E2E は未接続です。
- Issue #594 / Issue #455 / Issue #495 / Issue #595 は、このPRだけでは完了しません。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #594, Issue #455, Issue #495, Issue #595
- Implementing Success Criteria: Skill / contract / guardrail を shared progress と呼ぶための commit / push / PR / unconnected明記 gate と、慌てた push / PR 更新を防ぐ Git / PR preflight を追加する。
- Explicit Non-goals: runtime route 追加、Custom GPT Action Schema 変更、VPS 設定変更、deploy、merge、Issue close、runner/reviewer 起動、credential/permission mutation。
- Expected touched files/routes/workflows: `AGENTS.md`, `docs/butler/intent-mode-contract.md`, `.agents/skills/vtdd-status-advisor/SKILL.md`, `test/intent-mode-contract.test.js`。
- Affected Issues: Issue #594, Issue #455, Issue #495, Issue #595。
- Affected PRs: PR #625 の merge 後追加 push を正しい follow-up PR に出し直します。
- Affected workflows: GitHub Actions / deploy / reviewer workflow は変更しません。
- Affected runtime/operator surfaces: Dashboard Butler / VPS Codex CLI / mac Codex の Skill 共有判断。runtime 実装は未変更です。
- What may break if we patch narrowly: merged branch への追加 push を放置すると、PR evidence と main の内容がずれ、mac Codex が自分の作業だけで共有済みと錯覚する drift が残ります。Git / PR / reviewer / auto-merge truth を確認しないまま急ぐと同じ失敗を繰り返します。
- Unknowns to investigate before coding: Repository Sharing Gate を将来 PR validator まで機械 enforcement するか。VPS Codex CLI が `.agents/skills` をどう inventory するか。
- Validation needed: docs invariant unit test。後続では PR validator enforcement / VPS inventory integration が必要です。
- Stop condition: runtime 接続や VPS 設定変更に進む場合は、別の Issue-backed bounded contract と GO/passkey 境界が必要です。

## Execution Queue Delta

- Queue position before: Issue #594 / Issue #455 / Issue #495 / Issue #595 は active queue の Queue / Questions / Evidence-adjacent な設計・parity 課題で、`Now` の Issue #590 を置き換えません。
- Preemption decision: QUESTION。owner が指摘した drift の仕組み化であり、EMERGENCY として `Now` を差し替えません。
- Queue delta: Issue #594 / Issue #455 / Issue #495 / Issue #595 に Repository Sharing Gate の部分進捗を追加します。`Now` は Issue #590 のまま残します。
- Why this PR is next: PR #625 merge 後に同じ branch へ追加 push した事実があり、repo-backed progress の定義を機械的に近い gate として残す必要があります。
- Active Issues not downscoped: Active Issues は縮小しません。このPRで扱わない Issue #590, Issue #579, Issue #450, Issue #528, Issue #613 などは未完了として残します。

## File / Line Hypotheses

- file: `docs/butler/intent-mode-contract.md:27`
  - hypothesis: repo-backed と言う条件を明文化しないと、mac Codex が local / merged branch push を共有済みと誤認する。
  - risk if changed narrowly: PR evidence と main の内容がずれ、Dashboard Butler / VPS Codex CLI が読めない rule を共有済み扱いする。
  - validation: `test/intent-mode-contract.test.js`
  - related Issue: Issue #495, Issue #595
- file: `docs/butler/intent-mode-contract.md`
  - hypothesis: owner が怒っている時ほど、最初に Git / PR / reviewer / auto-merge truth を確認する gate が必要。
  - risk if changed narrowly: 反省文だけでは、次のスレッドでまた慌てて merged branch push や未確認 PR 更新をする。
  - validation: `test/intent-mode-contract.test.js`
  - related Issue: Issue #455, Issue #595
- file: `AGENTS.md:125`
  - hypothesis: スレッド再開時に AGENTS から gate を読むことで、同じ失敗を減らせる。
  - risk if changed narrowly: docs contract だけでは startup 時に見落とされる。
  - validation: `test/intent-mode-contract.test.js`
  - related Issue: Issue #595
- file: `.agents/skills/vtdd-status-advisor/SKILL.md:23`
  - hypothesis: Skill 自身にも共有 gate を置くことで、local-only Skill からの過剰 claim を止められる。
  - risk if changed narrowly: Skill を使う場面で contract を読まず、mac Codex-only の進捗誤認が残る。
  - validation: `test/intent-mode-contract.test.js`
  - related Issue: Issue #495

## Hypothesis Retrospective

- expected: commit / push / PR / unconnected明記を gate 化することで、mac Codex が自分だけの世界で repo-backed と言い張る失敗を減らす。
- actual: main 起点の新 branch に merge 後追加 push 分を移し、docs / Skill / AGENTS / test に Repository Sharing Gate と Calm Git / PR Preflight を追加しました。
- mismatch: runtime discovery / VPS Codex CLI inventory までは未実装のため、Butler Completion Gate は未接続です。
- lesson: repo-backed claim はローカル編集や branch push ではなく、PR evidence と main への到達可能性で扱う必要があります。
- should become RAG candidate: yes。merged PR branch へ追加 push した場合は、新しい main 起点PRに出し直す。repo-backed claim は commit / push / Japanese-first PR / unconnected明記が揃うまで禁止。

## Verification Evidence

- Unit: `node --test test/intent-mode-contract.test.js` passed。2 tests pass。Repository Sharing Gate と Calm Git / PR Preflight の assertion を含みます。
- Integration: 未実施。このPRは runtime route / VPS inventory を変更しません。
- E2E: 未実施。Dashboard Butler / iPhone/PWA E2E は後続 runtime 接続 PR が必要です。
- Manual: `gh pr view 625` で PR #625 が `MERGED`、head が `c62f292`、merge commit が `03997c5` であることを確認し、追加 commit `5b210b9` は main 起点 branch に cherry-pick しました。`git status --short --branch` と `git log --oneline --decorate -5` で current branch / ahead state も確認しました。
- Evidence path/link: `test/intent-mode-contract.test.js`

## Butler Completion Contract

- Owner goal: Skill / contract / guardrail を shared progress と呼ぶ条件を仕組みとして残し、mac Codex-only drift を防ぐ。
- Butler entrypoint: 未接続。このPRでは Dashboard Butler runtime の Skill discovery は追加しません。
- Action Schema exposure: 未変更。このPRでは Custom GPT Action Schema は変更しません。
- Runtime path: 未変更。このPRは docs / Skill contract / test のみです。
- Runner/runtime truth: 未接続。VPS Codex CLI が `.agents/skills` を読む inventory / runtime truth は後続 Issue #495 の作業です。
- Authority boundary: 未変更。deploy、credential mutation、permission mutation、merge、Issue close は行いません。
- E2E evidence: 未実施。Butler-facing E2E は後続 runtime 接続で必要です。
- Completion status: unconnected

## Surface Update Checklist

- Cloudflare deploy: 不要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。後続 runtime 接続で必要です。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate
- AGENTS.md Butler-First Operating Principle
- AGENTS.md Chief Butler Operating Principle
- AGENTS.md Thread-Independent Startup Contract
- AGENTS.md Change Size and PR Discipline
- AGENTS.md Conversation UX Contract

## Out-of-scope but NOT implemented

- Dashboard Butler runtime Skill discovery
- VPS Codex CLI `.agents/skills` inventory
- Custom GPT Action Schema operationId 追加
- deploy / merge / Issue close
- reviewer / runner 起動
- credential / permission mutation

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #594, Issue #455, Issue #495, Issue #595
- Execution ID: mac-codex-vtdd-skill-sharing-gate
- Goal: open_pr
