### PR TITLE
#606 Dashboard通常閲覧sessionをapproval grantから分離する

### DIFF
--- a/docs/mvp/active-issue-execution-queue.md
+++ b/docs/mvp/active-issue-execution-queue.md
@@ -9,7 +9,7 @@ This file is not a scope reducer. Active Issues remain in scope unless the owner
 explicitly narrows the implementation window. This file records execution order,
 preemption decisions, blockers, and evidence gaps.
 
-Last rebuilt from GitHub runtime truth: 2026-05-28
+Last rebuilt from GitHub runtime truth: 2026-05-29
 
 ## Queue Policy
 
@@ -32,7 +32,7 @@ Last rebuilt from GitHub runtime truth: 2026-05-28
   Issue #498, Issue #501, Issue #514, Issue #528, Issue #565,
   Issue #574, Issue #577, Issue #579, Issue #580, Issue #582, Issue #585,
   Issue #587, Issue #589, Issue #590, Issue #594, Issue #595, Issue #599,
-  Issue #604, Issue #605, Issue #606, Issue #613.
+  Issue #604, Issue #605, Issue #606, Issue #613, Issue #620.
 - Recently closed as completed with evidence and owner approval: Issue #573,
   Issue #601, Issue #609.
 - Open PRs read before this queue refresh PR was opened: none.
@@ -40,15 +40,22 @@ Last rebuilt from GitHub runtime truth: 2026-05-28
   PR #602, PR #603, PR #607, PR #608, PR #610, PR #611, PR #612.
 - Current queue rebuild scope: classify all open Issues without closing,
   downscoping, or treating any unverified Issue as done.
+- 2026-05-29 owner input classified Issue #606 as `ROOT`: the 2-minute
+  passkey grant coupling blocks the ordinary iPhone/PWA chat recovery path for
+  Issue #579, Issue #590, Issue #604, and Issue #605. Issue #606 moves to
+  `Now`; Issue #590 remains active and resumes after the read-session blocker
+  no longer causes short-cycle reauthentication.
 
 ## Now
 
-- Issue #590: app-server turn timeout must become a recoverable Dashboard chat
-  state. This is the next implementation slice after this Issue #595 queue
-  refresh merges.
+- Issue #606: ordinary Dashboard read sessions must be separated from
+  high-risk passkey approval so the iPhone/PWA Dashboard no longer falls back
+  into 2-minute reauthentication during normal Butler use.
 
 ## Next
 
+- Issue #590: app-server turn timeout must become a recoverable Dashboard chat
+  state after the short-cycle authentication blocker is removed.
 - Issue #579: after timeout recovery, handle PWA background/foreground,
   WebSocket reconnect, auth/session expiry, and input/media retention.
 - Issue #450 + Issue #413: continue the Dashboard Butler live runtime /
@@ -72,6 +79,10 @@ Root blockers hold multiple active Issues open. They should shape `Now` and
   panel. It gates the product direction for Issue #528, Issue #450, Issue #413,
   Issue #415, Issue #498, Issue #514, Issue #590, Issue #594, Issue #604,
   Issue #605, and Issue #606.
+- Issue #606: ordinary Dashboard read sessions must not reuse the same
+  short-lived approval grant used for high-risk operations. It gates practical
+  iPhone/PWA recovery for Issue #579, timeout recovery acceptance for Issue
+  #590, and notification/context return for Issue #604 and Issue #605.
 - Issue #413: VPS runner / Codex execution progress must be visible as
   owner-facing runtime truth. It gates completion claims for Issue #450,
   Issue #594, Issue #495, and recovery/ops workflows.
@@ -192,8 +203,7 @@ These Issues remain active and required, but they do not preempt the current
   context directly.
 - Issue #605: PR / deploy context drawer should be recoverable from
   notifications and conversation.
-- Issue #606: ordinary dashboard read sessions should be separated from
-  high-risk passkey approval.
+- Issue #620: dashboard AI news radar with PWA notifications.
 - Issue #574: subtle lower-right chat timestamps.
 - Issue #589: deploy notification non-delivery root-cause visibility.
 - Issue #594: fast status intent / preflight index. This is important, but it is

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -577,6 +577,7 @@ export class DashboardChatRoom {
 }
 const CLOUDFLARE_ACCESS_JWKS_CACHE_TTL_MS = 5 * 60 * 1000;
 const DASHBOARD_PASSKEY_SESSION_COOKIE = "vtdd_dashboard_session";
+const DASHBOARD_READ_SESSION_KIND = "dashboard_read_session";
 const DASHBOARD_PASSKEY_SESSION_MAX_AGE_SECONDS = 60 * 60 * 8;
 const cloudflareAccessJwksCache = new Map();
 const AUTONOMY_MODE_ENV = "VTDD_AUTONOMY_MODE";
@@ -5696,7 +5697,27 @@ async function handlePasskeyApprovalVerifyRequest(request, env) {
 
   const extraHeaders = {};
   if (isDashboardPasskeyScope(verified.approvalGrant?.scope)) {
-    extraHeaders["set-cookie"] = buildDashboardPasskeySessionCookie(verified.approvalGrant);
+    const dashboardSession = createDashboardReadSessionRecord({
+      approvalGrant: verified.approvalGrant,
+      credentialId: verified.grantRecord?.content?.credentialId,
+      userAgent: request.headers.get("user-agent")
+    });
+    if (!dashboardSession.ok) {
+      return json(422, {
+        ok: false,
+        error: "dashboard_session_invalid",
+        issues: dashboardSession.issues ?? []
+      });
+    }
+    const storedDashboardSession = await provider.store(dashboardSession.record);
+    if (!storedDashboardSession?.ok) {
+      return json(503, {
+        ok: false,
+        error: "dashboard_session_write_failed",
+        reason: "failed to persist dashboard read session"
+      });
+    }
+    extraHeaders["set-cookie"] = buildDashboardPasskeySessionCookie(dashboardSession.record);
   }
 
   return json(200, {
@@ -9215,8 +9236,8 @@ async function authorizeDashboardRequest({ request, env, apiSuffix = "/dashboard
 }
 
 async function authorizeDashboardPasskeySession({ request, env }) {
-  const approvalId = parseCookieHeader(request.headers.get("cookie"))[DASHBOARD_PASSKEY_SESSION_COOKIE];
-  if (!approvalId) {
+  const sessionId = parseCookieHeader(request.headers.get("cookie"))[DASHBOARD_PASSKEY_SESSION_COOKIE];
+  if (!sessionId) {
     return { ok: false, blocking: false };
   }
 
@@ -9231,13 +9252,38 @@ async function authorizeDashboardPasskeySession({ request, env }) {
     };
   }
 
-  const record = await findApprovalRecordById(provider, approvalId);
-  if (!record || normalizeText(record?.content?.kind) !== "passkey_grant") {
+  const record = await findApprovalRecordById(provider, sessionId);
+  if (!record) {
     return {
       ok: false,
       blocking: true,
       status: 401,
-      reason: "dashboard passkey session was not found; open the dashboard passkey sign-in link again"
+      reason: "dashboard session was not found; open the dashboard passkey sign-in link again"
+    };
+  }
+
+  if (normalizeText(record?.content?.kind) === DASHBOARD_READ_SESSION_KIND) {
+    if (isExpiredDashboardReadSessionRecord(record)) {
+      return {
+        ok: false,
+        blocking: true,
+        status: 401,
+        reason: "dashboard session expired; open the dashboard passkey sign-in link again"
+      };
+    }
+    return {
+      ok: true,
+      authType: "dashboard_read_session",
+      subject: normalizeText(record?.content?.deviceLabel) || "dashboard session"
+    };
+  }
+
+  if (normalizeText(record?.content?.kind) !== "passkey_grant") {
+    return {
+      ok: false,
+      blocking: true,
+      status: 401,
+      reason: "dashboard session record is not valid; open the dashboard passkey sign-in link again"
     };
   }
   if (isExpiredPasskeyEphemeralRecord(record)) {
@@ -9245,7 +9291,8 @@ async function authorizeDashboardPasskeySession({ request, env }) {
       ok: false,
       blocking: true,
       status: 401,
-      reason: "dashboard passkey session expired; open the dashboard passkey sign-in link again"
+      reason:
+        "legacy dashboard passkey grant expired; open the dashboard passkey sign-in link again"
     };
   }
   if (!isDashboardPasskeyScope(record?.content?.scope)) {
@@ -9267,10 +9314,68 @@ function isDashboardPasskeyScope(scope = {}) {
   return normalizeText(scope?.actionType) === "read" && normalizeText(scope?.highRiskKind) === "dashboard_access";
 }
 
-function buildDashboardPasskeySessionCookie(approvalGrant = {}) {
-  const approvalId = normalizeText(approvalGrant.approvalId);
+function createDashboardReadSessionRecord({ approvalGrant = {}, credentialId, userAgent } = {}) {
+  const sessionId = createDashboardRequestId("dashboard-session");
+  const createdAt = new Date().toISOString();
+  const expiresAt = new Date(Date.now() + DASHBOARD_PASSKEY_SESSION_MAX_AGE_SECONDS * 1000).toISOString();
+  const record = createMemoryRecord({
+    id: sessionId,
+    type: MemoryRecordType.APPROVAL_LOG,
+    content: {
+      kind: DASHBOARD_READ_SESSION_KIND,
+      status: "active",
+      sessionId,
+      sourceApprovalId: normalizeText(approvalGrant.approvalId),
+      credentialId: normalizeText(credentialId),
+      deviceLabel: normalizeDashboardDeviceLabel(userAgent),
+      createdAt,
+      lastSeenAt: createdAt,
+      expiresAt,
+      scope: {
+        actionType: "read",
+        highRiskKind: "dashboard_access"
+      }
+    },
+    metadata: {
+      source: "dashboard_passkey_session_verify",
+      sourceApprovalId: normalizeText(approvalGrant.approvalId)
+    },
+    priority: 95,
+    tags: [DASHBOARD_READ_SESSION_KIND, "dashboard_session"],
+    createdAt
+  });
+  return record;
+}
+
+function isExpiredDashboardReadSessionRecord(record) {
+  const expiresAt = normalizeText(record?.content?.expiresAt);
+  return !expiresAt || Date.parse(expiresAt) <= Date.now();
+}
+
+function normalizeDashboardDeviceLabel(userAgent) {
+  const value = normalizeText(userAgent);
+  if (!value) {
+    return "dashboard device";
+  }
+  if (/iPhone/i.test(value)) {
+    return "iPhone";
+  }
+  if (/iPad/i.test(value)) {
+    return "iPad";
+  }
+  if (/Macintosh|Mac OS X/i.test(value)) {
+    return "Mac";
+  }
+  if (/Android/i.test(value)) {
+    return "Android";
+  }
+  return "dashboard device";
+}
+
+function buildDashboardPasskeySessionCookie(sessionRecord = {}) {
+  const sessionId = normalizeText(sessionRecord.id || sessionRecord.sessionId || sessionRecord.approvalId);
   return [
-    `${DASHBOARD_PASSKEY_SESSION_COOKIE}=${encodeURIComponent(approvalId)}`,
+    `${DASHBOARD_PASSKEY_SESSION_COOKIE}=${encodeURIComponent(sessionId)}`,
     "Path=/",
     `Max-Age=${DASHBOARD_PASSKEY_SESSION_MAX_AGE_SECONDS}`,
     "HttpOnly",

--- a/test/active-issue-execution-queue.test.js
+++ b/test/active-issue-execution-queue.test.js
@@ -4,10 +4,10 @@ import fs from "node:fs";
 
 const doc = fs.readFileSync("docs/mvp/active-issue-execution-queue.md", "utf8");
 
-const OPEN_ISSUES_ON_2026_05_28 = [
+const OPEN_ISSUES_ON_2026_05_29 = [
   354, 355, 356, 358, 412, 413, 415, 417, 421, 444, 448, 450, 455, 491, 492,
   495, 497, 498, 501, 514, 528, 565, 574, 577, 579, 580, 582, 585, 587, 589,
-  590, 594, 595, 599, 604, 605, 606, 613
+  590, 594, 595, 599, 604, 605, 606, 613, 620
 ];
 
 const CLASSIFICATION_SECTIONS = [
@@ -35,7 +35,7 @@ function sectionBody(sectionName) {
 const classifiedIssueText = CLASSIFICATION_SECTIONS.map(sectionBody).join("\n");
 
 test("active issue execution queue records every open issue from the rebuild snapshot", () => {
-  for (const issueNumber of OPEN_ISSUES_ON_2026_05_28) {
+  for (const issueNumber of OPEN_ISSUES_ON_2026_05_29) {
     assert.equal(
       doc.includes(`Issue #${issueNumber}`),
       true,
@@ -45,7 +45,7 @@ test("active issue execution queue records every open issue from the rebuild sna
 });
 
 test("active issue execution queue classifies every open issue outside the runtime snapshot", () => {
-  for (const issueNumber of OPEN_ISSUES_ON_2026_05_28) {
+  for (const issueNumber of OPEN_ISSUES_ON_2026_05_29) {
     assert.equal(
       new RegExp(`^- Issue #${issueNumber}:`, "m").test(classifiedIssueText),
       true,
@@ -79,6 +79,7 @@ test("active issue execution queue names current open PR hygiene", () => {
 });
 
 test("active issue execution queue names the next automatic implementation lane", () => {
-  assert.equal(sectionBody("Now").includes("Issue #590: app-server turn timeout"), true);
+  assert.equal(sectionBody("Now").includes("Issue #606: ordinary Dashboard read sessions"), true);
+  assert.equal(sectionBody("Next").includes("Issue #590: app-server turn timeout"), true);
   assert.equal(doc.includes("Issue #579: after timeout recovery"), true);
 });

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -931,6 +931,69 @@ test("worker serves v2 dashboard for valid dashboard passkey session", async () 
   assert.equal(body.includes("VTDD v2 Dashboard"), true);
 });
 
+test("worker serves v2 dashboard from dashboard read session after source passkey grant expires", async () => {
+  const provider = createInMemoryMemoryProvider();
+  await provider.store({
+    id: "approval:expired-dashboard-grant",
+    type: MemoryRecordType.APPROVAL_LOG,
+    content: {
+      kind: "passkey_grant",
+      status: "verified",
+      approvalId: "approval:expired-dashboard-grant",
+      credentialId: "AQIDBA",
+      verifiedAt: "2026-05-20T00:00:00.000Z",
+      expiresAt: "2026-05-20T00:02:00.000Z",
+      scope: {
+        actionType: "read",
+        highRiskKind: "dashboard_access",
+        phase: "execution"
+      }
+    },
+    metadata: { source: "test" },
+    priority: 96,
+    tags: ["passkey_grant", "passkey_approval", "verified"],
+    createdAt: "2026-05-20T00:00:00.000Z"
+  });
+  await provider.store({
+    id: "dashboard-session:still-valid",
+    type: MemoryRecordType.APPROVAL_LOG,
+    content: {
+      kind: "dashboard_read_session",
+      status: "active",
+      sessionId: "dashboard-session:still-valid",
+      sourceApprovalId: "approval:expired-dashboard-grant",
+      credentialId: "AQIDBA",
+      deviceLabel: "iPhone",
+      createdAt: "2026-05-20T00:00:00.000Z",
+      lastSeenAt: "2026-05-20T00:00:00.000Z",
+      expiresAt: "2999-01-01T00:00:00.000Z",
+      scope: {
+        actionType: "read",
+        highRiskKind: "dashboard_access"
+      }
+    },
+    metadata: { source: "test", sourceApprovalId: "approval:expired-dashboard-grant" },
+    priority: 95,
+    tags: ["dashboard_read_session", "dashboard_session"],
+    createdAt: "2026-05-20T00:00:00.000Z"
+  });
+
+  const response = await worker.fetch(
+    new Request("https://example.com/dashboard", {
+      headers: {
+        cookie: "vtdd_dashboard_session=dashboard-session%3Astill-valid"
+      }
+    }),
+    {
+      MEMORY_PROVIDER: provider
+    }
+  );
+
+  assert.equal(response.status, 200);
+  const body = await response.text();
+  assert.equal(body.includes("VTDD v2 Dashboard"), true);
+});
+
 test("worker rejects stale dashboard passkey session cookies", async () => {
   const response = await worker.fetch(
     new Request("https://example.com/dashboard", {
@@ -954,7 +1017,7 @@ test("worker rejects stale dashboard passkey session cookies", async () => {
     true
   );
   assert.equal(body.includes("Cloudflare Access / fallback"), true);
-  assert.equal(body.includes("dashboard passkey session was not found"), true);
+  assert.equal(body.includes("dashboard session was not found"), true);
   assert.equal(body.includes("Passkey で開く"), true);
   assert.equal(body.includes("Passkey で dashboard に入る"), false);
   assert.equal(
@@ -1046,7 +1109,7 @@ test("worker ignores stale dashboard passkey cookie when Cloudflare Access owner
   assert.equal(response.status, 200);
   const body = await response.text();
   assert.equal(body.includes("VTDD v2 Dashboard"), true);
-  assert.equal(body.includes("dashboard passkey session was not found"), false);
+  assert.equal(body.includes("dashboard session was not found"), false);
 });
 
 test("worker rejects dashboard access when Access email header has no matching JWT email claim", async () => {
@@ -7831,7 +7894,7 @@ test("worker sets dashboard session cookie after dashboard passkey approval", as
   );
 
   assert.equal(verify.status, 200);
-  assert.match(verify.headers.get("set-cookie"), /vtdd_dashboard_session=approval%3A/);
+  assert.match(verify.headers.get("set-cookie"), /vtdd_dashboard_session=dashboard-session%3A/);
   assert.match(verify.headers.get("set-cookie"), /HttpOnly/);
   assert.match(verify.headers.get("set-cookie"), /SameSite=Lax/);
   const verifyBody = await verify.json();
@@ -7910,6 +7973,80 @@ test("worker gateway accepts high-risk approval grant resolved from memory", asy
   assert.equal(response.status, 200);
   const body = await response.json();
   assert.equal(body.allowed, true);
+});
+
+test("worker gateway does not accept dashboard read session as high-risk approval grant", async () => {
+  const provider = createInMemoryMemoryProvider();
+  await provider.store({
+    id: "dashboard-session:read-only",
+    type: MemoryRecordType.APPROVAL_LOG,
+    content: {
+      kind: "dashboard_read_session",
+      status: "active",
+      sessionId: "dashboard-session:read-only",
+      sourceApprovalId: "approval:dashboard-read",
+      credentialId: "AQIDBA",
+      deviceLabel: "iPhone",
+      createdAt: "2026-05-20T00:00:00.000Z",
+      lastSeenAt: "2026-05-20T00:00:00.000Z",
+      expiresAt: "2999-01-01T00:00:00.000Z",
+      scope: {
+        actionType: "read",
+        highRiskKind: "dashboard_access"
+      }
+    },
+    metadata: { source: "test" },
+    priority: 95,
+    tags: ["dashboard_read_session", "dashboard_session"],
+    createdAt: "2026-05-20T00:00:00.000Z"
+  });
+
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/gateway", {
+      method: "POST",
+      headers: gatewayAuthHeaders,
+      body: JSON.stringify({
+        phase: "execution",
+        actorRole: ActorRole.EXECUTOR,
+        surfaceContext: {
+          surface: "custom_gpt",
+          judgmentModelId: "vtdd-butler-core-v1"
+        },
+        judgmentTrace: validButlerJudgmentTrace,
+        issueContext: { issueNumber: 14 },
+        policyInput: {
+          actionType: ActionType.DEPLOY_PRODUCTION,
+          mode: TaskMode.EXECUTION,
+          repositoryInput: "vtdd",
+          aliasRegistry,
+          targetConfirmed: true,
+          constitutionConsulted: true,
+          runtimeTruth: { runtimeAvailable: true },
+          credential: {
+            model: "github_app",
+            tier: CredentialTier.HIGH_RISK,
+            shortLived: true,
+            boundApprovalId: "dashboard-session:read-only"
+          },
+          consent: { grantedCategories: [ConsentCategory.EXECUTE] },
+          approvalPhrase: "GO deploy request",
+          approvalScopeMatched: true,
+          approvalGrantId: "dashboard-session:read-only",
+          issueTraceable: true,
+          go: true,
+          passkey: false
+        }
+      })
+    }),
+    {
+      ...gatewayAuthEnv,
+      MEMORY_PROVIDER: provider
+    }
+  );
+
+  assert.equal(response.status, 422);
+  const body = await response.json();
+  assert.equal(body.allowed, false);
 });
 
 test("worker returns approval grant through retrieve route", async () => {

--- a/worker.js
+++ b/worker.js
@@ -56705,6 +56705,7 @@ var DashboardChatRoom = class {
 };
 var CLOUDFLARE_ACCESS_JWKS_CACHE_TTL_MS = 5 * 60 * 1e3;
 var DASHBOARD_PASSKEY_SESSION_COOKIE = "vtdd_dashboard_session";
+var DASHBOARD_READ_SESSION_KIND = "dashboard_read_session";
 var DASHBOARD_PASSKEY_SESSION_MAX_AGE_SECONDS = 60 * 60 * 8;
 var cloudflareAccessJwksCache = /* @__PURE__ */ new Map();
 var AUTONOMY_MODE_ENV = "VTDD_AUTONOMY_MODE";
@@ -61141,7 +61142,27 @@ async function handlePasskeyApprovalVerifyRequest(request, env) {
   await provider.store(verified.grantRecord);
   const extraHeaders = {};
   if (isDashboardPasskeyScope(verified.approvalGrant?.scope)) {
-    extraHeaders["set-cookie"] = buildDashboardPasskeySessionCookie(verified.approvalGrant);
+    const dashboardSession = createDashboardReadSessionRecord({
+      approvalGrant: verified.approvalGrant,
+      credentialId: verified.grantRecord?.content?.credentialId,
+      userAgent: request.headers.get("user-agent")
+    });
+    if (!dashboardSession.ok) {
+      return json(422, {
+        ok: false,
+        error: "dashboard_session_invalid",
+        issues: dashboardSession.issues ?? []
+      });
+    }
+    const storedDashboardSession = await provider.store(dashboardSession.record);
+    if (!storedDashboardSession?.ok) {
+      return json(503, {
+        ok: false,
+        error: "dashboard_session_write_failed",
+        reason: "failed to persist dashboard read session"
+      });
+    }
+    extraHeaders["set-cookie"] = buildDashboardPasskeySessionCookie(dashboardSession.record);
   }
   return json(200, {
     ok: true,
@@ -64212,8 +64233,8 @@ async function authorizeDashboardRequest({ request, env, apiSuffix = "/dashboard
   };
 }
 async function authorizeDashboardPasskeySession({ request, env }) {
-  const approvalId = parseCookieHeader(request.headers.get("cookie"))[DASHBOARD_PASSKEY_SESSION_COOKIE];
-  if (!approvalId) {
+  const sessionId = parseCookieHeader(request.headers.get("cookie"))[DASHBOARD_PASSKEY_SESSION_COOKIE];
+  if (!sessionId) {
     return { ok: false, blocking: false };
   }
   const provider = resolveMemoryProvider(env);
@@ -64226,13 +64247,36 @@ async function authorizeDashboardPasskeySession({ request, env }) {
       reason: "dashboard passkey session cannot be verified because memory provider is unavailable"
     };
   }
-  const record2 = await findApprovalRecordById(provider, approvalId);
-  if (!record2 || normalizeText30(record2?.content?.kind) !== "passkey_grant") {
+  const record2 = await findApprovalRecordById(provider, sessionId);
+  if (!record2) {
     return {
       ok: false,
       blocking: true,
       status: 401,
-      reason: "dashboard passkey session was not found; open the dashboard passkey sign-in link again"
+      reason: "dashboard session was not found; open the dashboard passkey sign-in link again"
+    };
+  }
+  if (normalizeText30(record2?.content?.kind) === DASHBOARD_READ_SESSION_KIND) {
+    if (isExpiredDashboardReadSessionRecord(record2)) {
+      return {
+        ok: false,
+        blocking: true,
+        status: 401,
+        reason: "dashboard session expired; open the dashboard passkey sign-in link again"
+      };
+    }
+    return {
+      ok: true,
+      authType: "dashboard_read_session",
+      subject: normalizeText30(record2?.content?.deviceLabel) || "dashboard session"
+    };
+  }
+  if (normalizeText30(record2?.content?.kind) !== "passkey_grant") {
+    return {
+      ok: false,
+      blocking: true,
+      status: 401,
+      reason: "dashboard session record is not valid; open the dashboard passkey sign-in link again"
     };
   }
   if (isExpiredPasskeyEphemeralRecord(record2)) {
@@ -64240,7 +64284,7 @@ async function authorizeDashboardPasskeySession({ request, env }) {
       ok: false,
       blocking: true,
       status: 401,
-      reason: "dashboard passkey session expired; open the dashboard passkey sign-in link again"
+      reason: "legacy dashboard passkey grant expired; open the dashboard passkey sign-in link again"
     };
   }
   if (!isDashboardPasskeyScope(record2?.content?.scope)) {
@@ -64260,10 +64304,65 @@ async function authorizeDashboardPasskeySession({ request, env }) {
 function isDashboardPasskeyScope(scope = {}) {
   return normalizeText30(scope?.actionType) === "read" && normalizeText30(scope?.highRiskKind) === "dashboard_access";
 }
-function buildDashboardPasskeySessionCookie(approvalGrant = {}) {
-  const approvalId = normalizeText30(approvalGrant.approvalId);
+function createDashboardReadSessionRecord({ approvalGrant = {}, credentialId, userAgent } = {}) {
+  const sessionId = createDashboardRequestId("dashboard-session");
+  const createdAt = (/* @__PURE__ */ new Date()).toISOString();
+  const expiresAt = new Date(Date.now() + DASHBOARD_PASSKEY_SESSION_MAX_AGE_SECONDS * 1e3).toISOString();
+  const record2 = createMemoryRecord({
+    id: sessionId,
+    type: MemoryRecordType.APPROVAL_LOG,
+    content: {
+      kind: DASHBOARD_READ_SESSION_KIND,
+      status: "active",
+      sessionId,
+      sourceApprovalId: normalizeText30(approvalGrant.approvalId),
+      credentialId: normalizeText30(credentialId),
+      deviceLabel: normalizeDashboardDeviceLabel(userAgent),
+      createdAt,
+      lastSeenAt: createdAt,
+      expiresAt,
+      scope: {
+        actionType: "read",
+        highRiskKind: "dashboard_access"
+      }
+    },
+    metadata: {
+      source: "dashboard_passkey_session_verify",
+      sourceApprovalId: normalizeText30(approvalGrant.approvalId)
+    },
+    priority: 95,
+    tags: [DASHBOARD_READ_SESSION_KIND, "dashboard_session"],
+    createdAt
+  });
+  return record2;
+}
+function isExpiredDashboardReadSessionRecord(record2) {
+  const expiresAt = normalizeText30(record2?.content?.expiresAt);
+  return !expiresAt || Date.parse(expiresAt) <= Date.now();
+}
+function normalizeDashboardDeviceLabel(userAgent) {
+  const value = normalizeText30(userAgent);
+  if (!value) {
+    return "dashboard device";
+  }
+  if (/iPhone/i.test(value)) {
+    return "iPhone";
+  }
+  if (/iPad/i.test(value)) {
+    return "iPad";
+  }
+  if (/Macintosh|Mac OS X/i.test(value)) {
+    return "Mac";
+  }
+  if (/Android/i.test(value)) {
+    return "Android";
+  }
+  return "dashboard device";
+}
+function buildDashboardPasskeySessionCookie(sessionRecord = {}) {
+  const sessionId = normalizeText30(sessionRecord.id || sessionRecord.sessionId || sessionRecord.approvalId);
   return [
-    `${DASHBOARD_PASSKEY_SESSION_COOKIE}=${encodeURIComponent(approvalId)}`,
+    `${DASHBOARD_PASSKEY_SESSION_COOKIE}=${encodeURIComponent(sessionId)}`,
     "Path=/",
     `Max-Age=${DASHBOARD_PASSKEY_SESSION_MAX_AGE_SECONDS}`,
     "HttpOnly",


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #606: Dashboard通常閲覧sessionを高リスクpasskey approval grantから分離し、2分grant TTLに引きずられたiPhone/PWA再認証頻発を止める。

## Satisfied Success Criteria

- Dashboard passkey verify後、cookieには短命approval grant IDではなく dashboard_read_session record IDを保存する。\nDashboard read sessionは8時間のserver-side recordとしてAPPROVAL_LOGに保存し、sessionId / expiresAt / lastSeenAt / deviceLabel / sourceApprovalIdのみを保持する。\n既存legacy passkey grant cookieは互換で読み取り可能だが、新規sessionは2分grant TTLに依存しない。\n高リスクgatewayはdashboard_read_sessionをpasskey_grantとして扱わず、deploy系approvalGrantIdに使われた場合は拒否する。\nactive issue execution queueで #606 をROOT / Nowへ昇格し、#590/#579/#604/#605 の前提blockerとして記録した。

## Unsatisfied Success Criteria

- iPhone実機/PWAでの数分後通知復帰E2Eは未実施。\nlogout/revoke UIはIssue #606のNon-goal通り後続。\n#579のWebSocket/画面オフ復帰、#590のapp-server timeout recovery自体は未実装。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #606
- Implementing Success Criteria: 通常閲覧sessionと高リスクapproval grantを別recordへ分離し、通常閲覧sessionが2分grant TTLに引きずられないこと。通常閲覧sessionが高リスク操作を承認しないこと。
- Explicit Non-goals: deploy、merge、secret sync、permission mutation、Cloudflare Access設定変更、logout/revoke UI、#579/#590本体の実装は対象外。
- Expected touched files/routes/workflows: src/worker/runtime.js, worker.js, test/worker.test.js, docs/mvp/active-issue-execution-queue.md
- Affected Issues: #606, #579, #590, #604, #605, #528, #613
- Affected PRs: なし
- Affected workflows: GitHub Actions / deploy workflowは未変更。
- Affected runtime/operator surfaces: Cloudflare Worker Dashboard auth, passkey operator verify route, gateway high-risk approval lookup, Dashboard PWA auth recovery path.
- What may break if we patch narrowly: cookie TTLだけ延ばすと高リスクapproval grantも長命化してしまうため、通常閲覧sessionを別recordに分ける必要がある。
- Unknowns to investigate before coding: production iPhone/PWAでCloudflare Access JWT側の期限切れが同時に発生するかは未検証。
- Validation needed: node --test test/worker.test.js; npm run build:worker; npm run check:generated-worker; git diff --check; production iPhone/PWA E2Eは後続。
- Stop condition: dashboard_read_sessionがdeploy/merge/secret sync等の高リスクapprovalとして使える兆候が出た場合は停止。

## Execution Queue Delta

- Queue position before: Queue文書上のNowは #590、#606 はQueueだった。
- Preemption decision: ROOT
- Queue delta: Issue #606をRoot Blockers / Nowへ昇格。Issue #590はNextへ戻し、Issue #579/#604/#605は#606の影響下として維持。Issue #620はQueueへ追記。
- Why this PR is next: 2分passkey grantに通常閲覧が依存したままだと、#579/#590の復帰UXを直してもiPhone/PWAが再認証で塞がれ、手戻りになるため。
- Active Issues not downscoped: Active Issues は縮小しません。#579/#590/#604/#605/#528/#613は未完了として残します。

## File / Line Hypotheses

- file: src/worker/runtime.js\n  - hypothesis: handlePasskeyApprovalVerifyRequestがdashboard_accessでも短命passkey_grantをcookieに入れている。\n  - validation: verify後cookieがdashboard-session prefixになり、authorizeDashboardPasskeySessionがdashboard_read_sessionを読むことをunit testで確認。\n  - related Issue: #606\n- file: test/worker.test.js\n  - hypothesis: 2分grant期限切れ後もread sessionが有効で、高リスクgatewayはread sessionを拒否する必要がある。\n  - validation: 追加unit tests。\n  - related Issue: #606

## Hypothesis Retrospective

- expected: dashboard access cookieがapproval grant IDを保持していた。\n- actual: 新規verify flowはdashboard_read_session IDをcookieへ設定し、legacy grant cookieは互換維持。\n- mismatch: なし。\n- lesson: 通常閲覧と高リスク承認のrecord kindを分けないとTTLだけでは安全に直せない。\n- should become RAG candidate: yes, after owner approval if reusable.

## Verification Evidence

- Unit: node --test test/worker.test.js: pass, 217 tests.
- Integration: npm run build:worker: pass. npm run check:generated-worker: pass. git diff --check: pass.
- E2E: 未実施。production iPhone/PWAの数分後復帰はPR merge/deploy後のmapped evidenceが必要。
- Manual: なし。
- Evidence path/link: test/worker.test.js の dashboard_read_session / high-risk rejection tests; docs/mvp/active-issue-execution-queue.md の #606 ROOT delta.

## Butler Completion Contract

- Owner goal: iPhone/PWAでDashboard Butlerを通常閲覧・通知確認するだけなら2分ごとにpasskeyへ戻されないようにする。
- Butler entrypoint: Dashboard passkey operatorからのdashboard_access verify後、同一origin Dashboard cookieで通常閲覧sessionを利用する。
- Action Schema exposure: 不要。Custom GPT Action Schemaは未変更。
- Runtime path: POST /v2/approval/passkey/verify -> dashboard_read_session record作成 -> vtdd_dashboard_session cookie -> authorizeDashboardRequest。
- Runner/runtime truth: unit testsでruntime pathを検証。production runtime truthは未取得。
- Authority boundary: 高リスクdeploy/merge/secret sync等は従来通りpasskey_grantを要求する。dashboard_read_sessionはgateway high-risk approvalとして拒否される。
- E2E evidence: 未実施。iPhone/PWA実機E2Eは後続のmerge/deploy後に必要。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 未実施。deployには別途passkey approvalが必要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。

## Related Constitution Rules

- AGENTS.md Authority Boundary\nAGENTS.md Butler Completion Gate\ndocs/butler/execution-queue-contract.md\nIssue #606 Success Criteria

## Out-of-scope but NOT implemented

- #579 WebSocket/PWA復帰本体\n#590 app-server timeout recovery本体\n#604/#605 通知タップ後の文脈drawer復帰\nCloudflare Access設定変更\nlogout/revoke UI

## Extra changes (if any)

worker.jsは npm run build:worker による生成差分。

<!-- VTDD metadata -->
- Issue: Issue #606
- Execution ID: codex-issue-606-dashboard-read-session
- Goal: Dashboard通常閲覧sessionを2分passkey grantから分離する
