### PR TITLE
#590 app-server timeout後のDashboard復帰状態を明示する

### DIFF
--- a/docs/mvp/active-issue-execution-queue.md
+++ b/docs/mvp/active-issue-execution-queue.md
@@ -45,17 +45,20 @@ Last rebuilt from GitHub runtime truth: 2026-05-29
   Issue #579, Issue #590, Issue #604, and Issue #605. Issue #606 moves to
   `Now`; Issue #590 remains active and resumes after the read-session blocker
   no longer causes short-cycle reauthentication.
+- 2026-05-29 Issue #606 was merged and production deployed. Owner live iPhone
+  evidence reported Dashboard Butler still connected after 11 minutes, so the
+  short-cycle passkey blocker no longer preempts Issue #590. Issue #590 moves
+  back to `Now`; Issue #606 remains open until mapped completion evidence and
+  human closure approval are complete.
 
 ## Now
 
-- Issue #606: ordinary Dashboard read sessions must be separated from
-  high-risk passkey approval so the iPhone/PWA Dashboard no longer falls back
-  into 2-minute reauthentication during normal Butler use.
+- Issue #590: app-server turn timeout must become a recoverable Dashboard chat
+  state after the short-cycle authentication blocker was removed by Issue #606
+  implementation and production evidence.
 
 ## Next
 
-- Issue #590: app-server turn timeout must become a recoverable Dashboard chat
-  state after the short-cycle authentication blocker is removed.
 - Issue #579: after timeout recovery, handle PWA background/foreground,
   WebSocket reconnect, auth/session expiry, and input/media retention.
 - Issue #450 + Issue #413: continue the Dashboard Butler live runtime /
@@ -162,6 +165,9 @@ Evidence gaps are active. They are not deferred out of scope.
 - Issue #613: owner provided ChatGPT iOS app screenshots and live iPhone /
   QuickTime observations that define the Text-first / Voice-ready baseline, but
   Dashboard Butler implementation still needs mapped iPhone/PWA E2E.
+- Issue #606: PR #627 merged and production deployed; owner live iPhone evidence
+  reported Dashboard Butler still connected after 11 minutes. Issue closure still
+  needs mapped completion evidence and explicit human closure approval.
 - Issue #444: PR #600 points PR-numbered notifications at the PR instead of the
   Actions run, but live iPhone/PWA notification tap, sound, badge, and recovery
   evidence remain incomplete.

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -6796,6 +6796,8 @@ function normalizeDashboardAppServerBridgeEvent(payload, { fallbackThreadId = ""
         { threadId }
       )
     );
+    transientStatus = "failed";
+    transientText = failureText;
   } else if (eventType === "app_server_status") {
     transientStatus = status === "replied" ? "replied" : "thinking";
     transientText = buildDashboardOwnerFacingTransientStatusText(input, {
@@ -12719,6 +12721,8 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
               const lastMessage = Array.isArray(body.messages) ? body.messages[body.messages.length - 1] : null;
               if (lastMessage?.role === "butler" && lastMessage?.status === "replied") {
                 setStatus("返信を受信しました。", { temporary: true });
+              } else if (lastMessage?.status === "failed") {
+                setStatus(lastMessage.text || "応答生成が時間切れになりました。同じ thread で続けられます。");
               } else if (releasedFromThread) {
                 setStatus("送信を保存しました。app-server bridge の返信を待っています", { thinking: true });
               }

--- a/test/active-issue-execution-queue.test.js
+++ b/test/active-issue-execution-queue.test.js
@@ -79,7 +79,7 @@ test("active issue execution queue names current open PR hygiene", () => {
 });
 
 test("active issue execution queue names the next automatic implementation lane", () => {
-  assert.equal(sectionBody("Now").includes("Issue #606: ordinary Dashboard read sessions"), true);
-  assert.equal(sectionBody("Next").includes("Issue #590: app-server turn timeout"), true);
+  assert.equal(sectionBody("Now").includes("Issue #590: app-server turn timeout"), true);
+  assert.equal(sectionBody("Evidence Gaps").includes("Issue #606: PR #627 merged and production deployed"), true);
   assert.equal(doc.includes("Issue #579: after timeout recovery"), true);
 });

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -1391,6 +1391,8 @@ test("worker serves v2 dashboard for allowed owner identity without exposing sec
   assert.equal(body.includes('renderThread(body.messages || [], { replace: true })'), true);
   assert.equal(body.includes('renderThread(body.messages || [], { replace: false })'), true);
   assert.equal(body.includes('body.type === "transient_status"'), true);
+  assert.equal(body.includes('lastMessage?.status === "failed"'), true);
+  assert.equal(body.includes("応答生成が時間切れになりました。同じ thread で続けられます。"), true);
   assert.equal(body.includes("appendMessage(body"), false);
   assert.equal(body.includes("white-space: pre-wrap"), true);
   assert.equal(body.includes(".bubble .message-body pre.wrap-code"), true);
@@ -3231,6 +3233,11 @@ test("DashboardChatRoom persists app-server timeout as recoverable Japanese thre
   const broadcast = dashboardSocket.sent.map((message) => JSON.parse(message)).find((message) => message.type === "thread");
   assert.ok(broadcast);
   assert.equal(broadcast.messages[0].text, stored[0].text);
+
+  const failedStatus = dashboardSocket.sent.map((message) => JSON.parse(message)).find((message) => message.type === "transient_status");
+  assert.ok(failedStatus);
+  assert.equal(failedStatus.status, "failed");
+  assert.equal(failedStatus.text, stored[0].text);
 });
 
 test("DashboardChatRoom sends app-server thinking status as transient UI state", async () => {

--- a/worker.js
+++ b/worker.js
@@ -62085,6 +62085,8 @@ function normalizeDashboardAppServerBridgeEvent(payload, { fallbackThreadId = ""
         { threadId }
       )
     );
+    transientStatus = "failed";
+    transientText = failureText;
   } else if (eventType === "app_server_status") {
     transientStatus = status === "replied" ? "replied" : "thinking";
     transientText = buildDashboardOwnerFacingTransientStatusText(input, {
@@ -67528,6 +67530,8 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
               const lastMessage = Array.isArray(body.messages) ? body.messages[body.messages.length - 1] : null;
               if (lastMessage?.role === "butler" && lastMessage?.status === "replied") {
                 setStatus("\u8FD4\u4FE1\u3092\u53D7\u4FE1\u3057\u307E\u3057\u305F\u3002", { temporary: true });
+              } else if (lastMessage?.status === "failed") {
+                setStatus(lastMessage.text || "\u5FDC\u7B54\u751F\u6210\u304C\u6642\u9593\u5207\u308C\u306B\u306A\u308A\u307E\u3057\u305F\u3002\u540C\u3058 thread \u3067\u7D9A\u3051\u3089\u308C\u307E\u3059\u3002");
               } else if (releasedFromThread) {
                 setStatus("\u9001\u4FE1\u3092\u4FDD\u5B58\u3057\u307E\u3057\u305F\u3002app-server bridge \u306E\u8FD4\u4FE1\u3092\u5F85\u3063\u3066\u3044\u307E\u3059", { thinking: true });
               }


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #590: codex app-server応答生成timeout後もDashboard threadが壊れたように見えず、同じthreadで続けられる状態を明示する。

## Satisfied Success Criteria

- app_server_turn_failed / timeout のthread保存時に transient_status=failed を同時にbroadcastし、UIのthinking状態を解除する。\nDashboard JSがthread broadcastの最後のmessage status=failedを見た時、失敗本文をstatusへ出して考え中表示を残さない。\ntimeout本文は既存の日本語復帰文を使い、英語生エラーをownerに出さない。\n#606 merge/deploy/11分実機観測をqueueに反映し、#590をNowへ戻した。

## Unsatisfied Success Criteria

- app-server自体のtimeout閾値調整や性能改善は未実施。\n後からcompletionが届いた時の完全な二重返信制御は既存turn filteringの範囲で、production実機E2Eは未実施。\n#579の画面オフ/PWA復帰全体は未実装。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #590
- Implementing Success Criteria: timeoutをapp_server_turn_failedとしてthreadに残し、owner-facing日本語で保存済み/同じthreadで継続可能と示し、UIのthinking状態とcomposer復帰を壊さない。
- Explicit Non-goals: app-server性能改善、timeout延長、#579 PWA復帰全体、deploy、credential mutation、permission mutationは対象外。
- Expected touched files/routes/workflows: src/worker/runtime.js, worker.js, test/worker.test.js, test/active-issue-execution-queue.test.js, docs/mvp/active-issue-execution-queue.md
- Affected Issues: #590, #606, #579, #450, #528, #613
- Affected PRs: PR #627 はmerge/deploy済み証跡としてqueueに記録。
- Affected workflows: GitHub Actions / deploy workflowは未変更。
- Affected runtime/operator surfaces: Dashboard Worker runtime, Dashboard chat WebSocket client, app-server bridge event handling.
- What may break if we patch narrowly: thread保存だけだとUI statusがthinkingのまま残り、ownerにはまだ待っているように見える。transient statusとthread failed handlingの両方が必要。
- Unknowns to investigate before coding: production iPhone/PWAで実際のtimeout後にステータス表示がどのタイミングで消えるかは未検証。
- Validation needed: node --test test/worker.test.js test/dashboard-app-server-bridge.test.js test/active-issue-execution-queue.test.js; npm run build:worker; npm run check:generated-worker; git diff --check.
- Stop condition: app-server timeout時にowner入力が失われる、または高リスク/権限境界へ波及する変更が必要になった場合は停止。

## Execution Queue Delta

- Queue position before: Issue #606 がNow、Issue #590 がNextだった。#606はPR #627 merge/deploy済み、owner実機で11分接続維持を確認済み。
- Preemption decision: NEXT
- Queue delta: Issue #590 moves to Now. Issue #606 moves to Evidence Gaps until mapped completion evidence and explicit human closure approval. Issue #579 remains Next.
- Why this PR is next: #606で2分passkey blockerが外れたため、次の通常チャット阻害要因であるapp-server timeout復帰を扱う。
- Active Issues not downscoped: Active Issues は縮小しません。#579/#450/#528/#613/#606 は未完了またはEvidence Gapとして残します。

## File / Line Hypotheses

- file: src/worker/runtime.js\n  - hypothesis: app_server_turn_failed はthread messageとして残るが、transient status failedが出ないためUIがthinkingに残り得る。\n  - validation: DashboardChatRoom timeout testでtransient_status failedを確認。\n  - related Issue: #590\n- file: src/worker/runtime.js inline Dashboard JS\n  - hypothesis: thread broadcastのlastMessage failedをUIがstatus解除に使っていない。\n  - validation: worker.test.jsでJS断片を確認。\n  - related Issue: #590

## Hypothesis Retrospective

- expected: bridge/workerのtimeout保存は既にあり、UI復帰状態が不足している。\n- actual: failed transient statusとlast failed message handlingを足す小変更でthinking残留を防ぐ形にできた。\n- mismatch: #590全体の一部は既に実装済みだった。\n- lesson: timeout復帰はserver event保存だけでなく、client status解除まで見る必要がある。\n- should become RAG candidate: yes, after owner approval if reusable.

## Verification Evidence

- Unit: node --test test/worker.test.js test/dashboard-app-server-bridge.test.js test/active-issue-execution-queue.test.js: pass, 243 tests.
- Integration: npm run build:worker: pass. npm run check:generated-worker: pass. git diff --check: pass.
- E2E: 未実施。production iPhone/PWAでtimeout後の継続操作はmerge/deploy後に確認が必要。
- Manual: なし。
- Evidence path/link: test/worker.test.js の DashboardChatRoom timeout / inline JS assertions; test/dashboard-app-server-bridge.test.js の recoverable timeout test; docs/mvp/active-issue-execution-queue.md の Now更新。

## Butler Completion Contract

- Owner goal: codex app-serverの応答生成が時間切れになっても、Dashboard Butlerが壊れたように見えず、同じthreadで次の発言を続けられる。
- Butler entrypoint: Dashboard chat WebSocket -> app_server_turn_failed -> failed transient status + durable failed system message.
- Action Schema exposure: 不要。Custom GPT Action Schemaは未変更。
- Runtime path: scripts/run-dashboard-app-server-bridge.mjs timeout event -> DashboardChatRoom.acceptAppServerBridgeMessage -> normalizeDashboardAppServerBridgeEvent -> browser thread/transient handling.
- Runner/runtime truth: unit testsでruntime pathを検証。production runtime truthは未取得。
- Authority boundary: 未変更。deploy/merge/secret sync等の高リスク境界には触れていない。
- E2E evidence: 未実施。iPhone/PWA実機でtimeout後に同じthreadへ続けられるかは後続確認が必要。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 未実施。deployには別途passkey approvalが必要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate\nAGENTS.md Conversation UX Contract\ndocs/butler/execution-queue-contract.md\nIssue #590 Success Criteria

## Out-of-scope but NOT implemented

- #579 WebSocket/PWA復帰全体\napp-server性能改善またはtimeout延長\ndeploy/credential/permission mutation\nIssue #606 closure

## Extra changes (if any)

worker.jsは npm run build:worker による生成差分。

<!-- VTDD metadata -->
- Issue: Issue #590
- Execution ID: codex-issue-590-app-server-timeout-recovery
- Goal: app-server timeout後のDashboard UI復帰を明示する
