### PR TITLE
#498 Dashboard media delivery truth for app-server bridge

### DIFF
--- a/docs/butler/dashboard-butler-app-server-live-path.md
+++ b/docs/butler/dashboard-butler-app-server-live-path.md
@@ -106,7 +106,11 @@ Dashboard turn requests must preserve traffic-control context when present:
 
 - repository and related Issue from the Dashboard thread
 - Dashboard authority hints for GO / passkey boundaries
-- media reference count without raw binary material
+- media reference count plus attachment delivery truth without raw binary material
+- for Dashboard media references, the VPS bridge may fetch the short-lived
+  media through the runtime bearer boundary and pass a local temporary file path
+  to the Codex turn; if fetch fails, the turn context must say so instead of
+  letting Butler claim it saw the image
 - instructions to read durable Issue / PR / runtime truth before separating
   blockers, next actions, authority boundaries, and evidence gaps
 - the mechanical bridge boundary that app-server command, file-change, patch,

--- a/scripts/run-dashboard-app-server-bridge.mjs
+++ b/scripts/run-dashboard-app-server-bridge.mjs
@@ -1,4 +1,7 @@
 #!/usr/bin/env node
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { spawn } from "node:child_process";
 import process from "node:process";
 
@@ -9,6 +12,7 @@ const DEFAULT_APP_SERVER_ERROR_TEXT =
   "codex app-server が応答生成中に失敗しました。画像を解析できなかった可能性があります。もう一度送るか、画像なしで内容を短く説明してください。";
 const APP_SERVER_TURN_TIMEOUT_TEXT =
   "codex app-server の応答生成が時間切れになりました。入力は Dashboard thread に保存済みです。同じ thread で続けるか、内容を短くしてもう一度送れます。";
+const DASHBOARD_MEDIA_TMP_DIR = "vtdd-dashboard-media";
 
 export function buildAppServerInitializeRequest(id = 1) {
   return {
@@ -123,6 +127,14 @@ export function buildDashboardTurnInputText(request = {}) {
     "- mechanicalBoundary: Dashboard bridge does not grant app-server command, file-change, patch, or permission escalation approvals."
   ];
 
+  const mediaLines = formatDashboardMediaReferenceLines(mediaReferences);
+  if (mediaLines.length > 0) {
+    lines.push(
+      "- mediaDelivery: Dashboard bridge materialized attachment metadata for this turn. Use localPath when present; do not claim image analysis if localPath is missing or fetchStatus is not fetched."
+    );
+    lines.push(...mediaLines);
+  }
+
   if (trafficControl) {
     lines.push(`- trafficControl: ${JSON.stringify(trafficControl)}`);
   }
@@ -133,6 +145,157 @@ export function buildDashboardTurnInputText(request = {}) {
 
   lines.push("", "Owner message:", ownerText);
   return lines.join("\n");
+}
+
+export function formatDashboardMediaReferenceLines(mediaReferences = []) {
+  const references = Array.isArray(mediaReferences) ? mediaReferences : [];
+  return references.slice(0, 12).map((reference, index) => {
+    const mediaId = normalizeBridgeText(reference?.mediaId || reference?.id) || "unknown";
+    const filename = normalizeBridgeText(reference?.filename || reference?.name) || "attachment";
+    const contentType = normalizeBridgeText(reference?.contentType || reference?.type) || "application/octet-stream";
+    const byteSize = Number(reference?.byteSize || reference?.size || 0);
+    const downloadUrl = normalizeBridgeText(reference?.downloadUrl || reference?.download_url);
+    const localPath = normalizeBridgeText(reference?.localPath || reference?.local_path);
+    const fetchStatus =
+      normalizeBridgeText(reference?.fetchStatus || reference?.fetch_status) || (localPath ? "fetched" : "metadata_only");
+    const parts = [
+      `  - media[${index + 1}].mediaId: ${mediaId}`,
+      `filename: ${filename}`,
+      `contentType: ${contentType}`,
+      `byteSize: ${Number.isFinite(byteSize) && byteSize > 0 ? byteSize : "unknown"}`,
+      `downloadUrl: ${downloadUrl || "unavailable"}`,
+      `fetchStatus: ${fetchStatus}`
+    ];
+    if (localPath) {
+      parts.push(`localPath: ${localPath}`);
+    }
+    const fetchError = normalizeBridgeText(reference?.fetchError || reference?.fetch_error);
+    if (fetchError) {
+      parts.push(`fetchError: ${fetchError}`);
+    }
+    return parts.join("; ");
+  });
+}
+
+export async function materializeDashboardMediaReferences({
+  mediaReferences = [],
+  runtimeUrl = "",
+  token = "",
+  fetchImpl = globalThis.fetch,
+  tmpRoot = os.tmpdir()
+} = {}) {
+  const references = Array.isArray(mediaReferences) ? mediaReferences : [];
+  if (references.length === 0) {
+    return [];
+  }
+  return Promise.all(
+    references
+      .slice(0, 12)
+      .map((reference) => materializeDashboardMediaReference({ reference, runtimeUrl, token, fetchImpl, tmpRoot }))
+  );
+}
+
+async function materializeDashboardMediaReference({ reference, runtimeUrl, token, fetchImpl, tmpRoot }) {
+  const normalized = normalizeDashboardMediaReferenceForBridge(reference);
+  if (!normalized.mediaId) {
+    return {
+      ...normalized,
+      fetchStatus: "metadata_invalid",
+      fetchError: "mediaId is missing"
+    };
+  }
+  if (!runtimeUrl || !token || !normalized.downloadUrl || typeof fetchImpl !== "function") {
+    return {
+      ...normalized,
+      fetchStatus: "metadata_only",
+      fetchError: "runtimeUrl, token, downloadUrl, or fetch is unavailable"
+    };
+  }
+  let url;
+  try {
+    url = new URL(normalized.downloadUrl, runtimeUrl);
+  } catch {
+    return {
+      ...normalized,
+      fetchStatus: "fetch_failed",
+      fetchError: "downloadUrl is invalid"
+    };
+  }
+  try {
+    const response = await fetchImpl(url, {
+      headers: {
+        accept: normalized.contentType || "application/octet-stream",
+        authorization: `Bearer ${token}`
+      }
+    });
+    if (!response.ok) {
+      return {
+        ...normalized,
+        fetchStatus: "fetch_failed",
+        fetchError: `media download failed with HTTP ${response.status}`
+      };
+    }
+    const arrayBuffer = await response.arrayBuffer();
+    const byteSize = Number(arrayBuffer.byteLength || 0);
+    if (byteSize <= 0) {
+      return {
+        ...normalized,
+        fetchStatus: "fetch_failed",
+        fetchError: "media download returned an empty body"
+      };
+    }
+    const directory = path.join(tmpRoot, DASHBOARD_MEDIA_TMP_DIR);
+    await fs.mkdir(directory, { recursive: true });
+    const localPath = path.join(
+      directory,
+      `${sanitizeBridgeFilename(normalized.mediaId)}-${sanitizeBridgeFilename(normalized.filename || "attachment")}`
+    );
+    await fs.writeFile(localPath, Buffer.from(arrayBuffer));
+    return {
+      ...normalized,
+      byteSize: normalized.byteSize || byteSize,
+      localPath,
+      fetchStatus: "fetched"
+    };
+  } catch (error) {
+    return {
+      ...normalized,
+      fetchStatus: "fetch_failed",
+      fetchError: sanitizeBridgeError(error)
+    };
+  }
+}
+
+function normalizeDashboardMediaReferenceForBridge(reference) {
+  const input = reference && typeof reference === "object" ? reference : {};
+  const mediaId = normalizeBridgeText(input.mediaId || input.id);
+  return {
+    mediaId,
+    filename: normalizeBridgeText(input.filename || input.name) || "attachment",
+    contentType: normalizeBridgeText(input.contentType || input.type) || "application/octet-stream",
+    byteSize: Number(input.byteSize || input.size || 0) || 0,
+    downloadUrl: normalizeBridgeText(input.downloadUrl || input.download_url || (mediaId ? `/v2/media/${mediaId}/download` : "")),
+    metadataUrl: normalizeBridgeText(input.metadataUrl || input.metadata_url || (mediaId ? `/v2/media/${mediaId}` : "")),
+    repository: normalizeBridgeText(input.repository),
+    relatedIssue: Number(input.relatedIssue || input.issueNumber || input.related_issue) || null
+  };
+}
+
+function normalizeBridgeText(value) {
+  return String(value ?? "").replace(/[\u0000-\u001f\u007f]/g, " ").trim().slice(0, 500);
+}
+
+function sanitizeBridgeFilename(value) {
+  return (
+    normalizeBridgeText(value)
+      .replace(/[^a-zA-Z0-9._-]+/g, "_")
+      .replace(/^_+|_+$/g, "")
+      .slice(0, 120) || "attachment"
+  );
+}
+
+function sanitizeBridgeError(error) {
+  return normalizeBridgeText(error?.message || error || "media fetch failed").slice(0, 240);
 }
 
 export function buildAppServerSandboxOverrides(sandboxMode = "") {
@@ -414,7 +577,11 @@ export async function handleDashboardTurnRequest({
   sendDashboardEvent,
   cwd = process.cwd(),
   sandboxMode = "",
-  turnTimeoutMs = 10 * 60 * 1000
+  turnTimeoutMs = 10 * 60 * 1000,
+  runtimeUrl = "",
+  token = "",
+  fetchImpl = globalThis.fetch,
+  mediaTmpRoot = os.tmpdir()
 }) {
   const dashboardThreadId = String(request.threadId || "");
   const text = String(request.text || "");
@@ -504,13 +671,20 @@ export async function handleDashboardTurnRequest({
     void sendDashboardEvent(event);
   });
   try {
+    const materializedMediaReferences = await materializeDashboardMediaReferences({
+      mediaReferences: request.mediaReferences,
+      runtimeUrl,
+      token,
+      fetchImpl,
+      tmpRoot: mediaTmpRoot
+    });
     const turnInputText = buildDashboardTurnInputText({
       text,
       repository: request.repository,
       relatedIssue: request.relatedIssue || request.issueNumber,
       authority: request.authority,
       trafficControl: request.trafficControl,
-      mediaReferences: request.mediaReferences
+      mediaReferences: materializedMediaReferences
     });
     const startedTurn = await appServer.request(
       buildAppServerTurnStartRequest({
@@ -604,6 +778,9 @@ export async function connectDashboardAppServerBridgeOnce({
   appServer,
   cwd = process.cwd(),
   sandboxMode = "",
+  runtimeUrl = "",
+  fetchImpl = globalThis.fetch,
+  mediaTmpRoot = os.tmpdir(),
   WebSocketImpl = WebSocket
 } = {}) {
   const bearerProtocol = `vtdd-bearer.${Buffer.from(token, "utf8").toString("base64url")}`;
@@ -645,7 +822,11 @@ export async function connectDashboardAppServerBridgeOnce({
             appServer,
             sendDashboardEvent: async (dashboardEvent) => safeSend(dashboardEvent),
             cwd,
-            sandboxMode
+            sandboxMode,
+            runtimeUrl,
+            token,
+            fetchImpl,
+            mediaTmpRoot
           })
         )
         .catch((error) => {

--- a/test/dashboard-app-server-bridge.test.js
+++ b/test/dashboard-app-server-bridge.test.js
@@ -1,4 +1,7 @@
 import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import test from "node:test";
 import {
   buildDashboardAppServerBridgeEndpoint,
@@ -11,10 +14,12 @@ import {
   buildDashboardTurnInputText,
   connectDashboardAppServerBridgeOnce,
   extractAppServerNotificationTurnId,
+  formatDashboardMediaReferenceLines,
   handleDashboardTurnRequest,
   JsonLineAppServerClient,
   mapAppServerNotificationToDashboardEvent,
   matchesAppServerTurnNotification,
+  materializeDashboardMediaReferences,
   parseBridgeArgs,
   runDashboardAppServerBridge
 } from "../scripts/run-dashboard-app-server-bridge.mjs";
@@ -90,6 +95,86 @@ test("dashboard app-server bridge wraps repository traffic-control context into 
   assert.match(text, /mechanicalBoundary/);
   assert.match(text, /does not grant app-server command, file-change, patch, or permission escalation approvals/);
   assert.match(text, /Owner message:\nDashboard Butler が交通整理できるようにして/);
+});
+
+test("dashboard app-server bridge includes attachment delivery truth in turn input", () => {
+  const text = buildDashboardTurnInputText({
+    repository: "marushu/vtdd-v2-p",
+    relatedIssue: 498,
+    text: "添付画像を確認して",
+    mediaReferences: [
+      {
+        mediaId: "med_dashboard_image",
+        filename: "dashboard.png",
+        contentType: "image/png",
+        byteSize: 1234,
+        downloadUrl: "/v2/media/med_dashboard_image/download",
+        localPath: "/tmp/vtdd-dashboard-media/med_dashboard_image-dashboard.png",
+        fetchStatus: "fetched"
+      }
+    ]
+  });
+
+  assert.match(text, /mediaReferences: 1/);
+  assert.match(text, /mediaDelivery/);
+  assert.match(text, /media\[1\]\.mediaId: med_dashboard_image/);
+  assert.match(text, /filename: dashboard\.png/);
+  assert.match(text, /contentType: image\/png/);
+  assert.match(text, /downloadUrl: \/v2\/media\/med_dashboard_image\/download/);
+  assert.match(text, /fetchStatus: fetched/);
+  assert.match(text, /localPath: \/tmp\/vtdd-dashboard-media\/med_dashboard_image-dashboard\.png/);
+  assert.match(text, /do not claim image analysis if localPath is missing/);
+});
+
+test("dashboard app-server bridge formats failed media delivery without raw binary", () => {
+  const lines = formatDashboardMediaReferenceLines([
+    {
+      mediaId: "med_missing",
+      filename: "screen.png",
+      contentType: "image/png",
+      fetchStatus: "fetch_failed",
+      fetchError: "media download failed with HTTP 404",
+      rawBinary: "fake image bytes"
+    }
+  ]);
+
+  assert.equal(lines.length, 1);
+  assert.match(lines[0], /media\[1\]\.mediaId: med_missing/);
+  assert.match(lines[0], /fetchStatus: fetch_failed/);
+  assert.match(lines[0], /fetchError: media download failed with HTTP 404/);
+  assert.equal(lines[0].includes("fake image bytes"), false);
+});
+
+test("dashboard app-server bridge materializes dashboard media with bearer auth", async () => {
+  const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "vtdd-bridge-media-test-"));
+  const requested = [];
+  const references = await materializeDashboardMediaReferences({
+    runtimeUrl: "https://runtime.example",
+    token: "runtime-token",
+    tmpRoot,
+    mediaReferences: [
+      {
+        mediaId: "med_fetchable",
+        filename: "screen shot.png",
+        contentType: "image/png",
+        downloadUrl: "/v2/media/med_fetchable/download"
+      }
+    ],
+    fetchImpl: async (url, options) => {
+      requested.push({ url: String(url), authorization: options.headers.authorization });
+      return new Response(new Uint8Array([0x89, 0x50, 0x4e, 0x47]), {
+        status: 200,
+        headers: { "content-type": "image/png" }
+      });
+    }
+  });
+
+  assert.equal(requested[0].url, "https://runtime.example/v2/media/med_fetchable/download");
+  assert.equal(requested[0].authorization, "Bearer runtime-token");
+  assert.equal(references[0].fetchStatus, "fetched");
+  assert.match(references[0].localPath, /vtdd-dashboard-media/);
+  assert.match(references[0].localPath, /med_fetchable-screen_shot\.png$/);
+  assert.deepEqual([...await fs.readFile(references[0].localPath)], [0x89, 0x50, 0x4e, 0x47]);
 });
 
 test("dashboard app-server bridge only enables danger-full-access by explicit trusted VPS opt-in", () => {
@@ -466,6 +551,77 @@ test("dashboard app-server bridge passes traffic-control context to codex app-se
   assert.match(inputText, /"currentNow":"Issue #590: app-server turn timeout must become recoverable\."/);
   assert.match(inputText, /mechanicalBoundary/);
   assert.match(inputText, /Owner message:\nDashboard Butler が交通整理できるか確認して/);
+  assert.equal(events.at(-1).type, "app_server_reply");
+});
+
+test("dashboard app-server bridge passes materialized media paths to codex app-server turns", async () => {
+  const requests = [];
+  const events = [];
+  const handlers = new Set();
+  const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "vtdd-bridge-turn-media-test-"));
+  let nextId = 1;
+  const appServer = {
+    nextRequestId() {
+      const id = nextId;
+      nextId += 1;
+      return id;
+    },
+    onNotification(handler) {
+      handlers.add(handler);
+      return () => handlers.delete(handler);
+    },
+    async request(message) {
+      requests.push(message);
+      if (message.method === "thread/start") {
+        return { thread: { id: "codex-thread-media" } };
+      }
+      if (message.method === "turn/start") {
+        for (const handler of handlers) {
+          handler({
+            method: "turn/completed",
+            params: {
+              threadId: "codex-thread-media",
+              turn: { id: "turn-media", status: "completed" }
+            }
+          });
+        }
+        return { turn: { id: "turn-media" } };
+      }
+      throw new Error(`unexpected method ${message.method}`);
+    }
+  };
+
+  await handleDashboardTurnRequest({
+    request: {
+      threadId: "dashboard-main",
+      codexThreadId: null,
+      repository: "marushu/vtdd-v2-p",
+      relatedIssue: 498,
+      text: "添付画像を確認して",
+      mediaReferences: [
+        {
+          mediaId: "med_turn_image",
+          filename: "dashboard.png",
+          contentType: "image/png",
+          downloadUrl: "/v2/media/med_turn_image/download"
+        }
+      ]
+    },
+    appServer,
+    sendDashboardEvent: async (event) => events.push(event),
+    cwd: "/repo",
+    runtimeUrl: "https://runtime.example",
+    token: "runtime-token",
+    mediaTmpRoot: tmpRoot,
+    fetchImpl: async () => new Response(new Uint8Array([1, 2, 3]), { status: 200 })
+  });
+
+  const turnStart = requests.find((request) => request.method === "turn/start");
+  assert.ok(turnStart);
+  const inputText = turnStart.params.input[0].text;
+  assert.match(inputText, /mediaReferences: 1/);
+  assert.match(inputText, /fetchStatus: fetched/);
+  assert.match(inputText, /localPath: .*med_turn_image-dashboard\.png/);
   assert.equal(events.at(-1).type, "app_server_reply");
 });
 


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #498 の添付メディア到達保証スライスとして、Dashboard が保存した mediaReferences を app-server bridge が bearer 認証で短命 download し、Codex turn に localPath / fetchStatus / metadata を渡す。

## Satisfied Success Criteria

- Dashboard mediaReferences が bridge turn context に件数だけでなく filename/contentType/downloadUrl/fetchStatus/localPath として渡る。\nbridge が runtime bearer で /v2/media/:id/download を取得し、/tmp/vtdd-dashboard-media 配下の短命 local file として materialize できる。\n取得失敗時は fetchStatus/fetchError を明示し、Butler が画像を見たふりをしない。\nraw binary は PR body / docs / turn context に保存しない。

## Unsatisfied Success Criteria

- 画像解析モデル/アプリ側が localPath を実際に画像入力として読む live E2E は未実施。\niPhone/PWA 実機で添付送信から Codex 画像解析返信までの end-to-end evidence は未実施。\nTTL cleanup / lightbox / 拡大表示 UX はこのPR外。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #498
- Implementing Success Criteria: 添付した画像/動画が会話ターンに紐づき、Butler/Codex 側で届いた/届かないを判定できる。送信後の添付参照が app-server bridge に渡り、届いたふりをしない。
- Explicit Non-goals: 画像解析モデル本体、無期限保存、GitHub/RAG への raw 画像保存、deploy、Issue close。
- Expected touched files/routes/workflows: scripts/run-dashboard-app-server-bridge.mjs, test/dashboard-app-server-bridge.test.js, docs/butler/dashboard-butler-app-server-live-path.md
- Affected Issues: Issue #498, Issue #587, Issue #413
- Affected PRs: なし
- Affected workflows: CI tests only. Deploy workflow は未実行。
- Affected runtime/operator surfaces: Dashboard Butler PWA, VPS Dashboard app-server bridge, codex app-server turn context, short-lived media download route.
- What may break if we patch narrowly: localPath を渡しても app-server 側の画像入力 item として自動認識されない可能性がある。fetch 可能にしても live E2E なしでは画像解析完了とは言えない。
- Unknowns to investigate before coding: codex app-server の turn/start が画像 input item を公式に受けるかは未確認。このPRでは local temp path と到達 truth までに限定する。
- Validation needed: node --test test/dashboard-app-server-bridge.test.js; node --test test/worker.test.js; npm run check:self-parity
- Stop condition: raw binary を durable history/RAG/GitHub に入れる必要が出た場合、または app-server image input protocol を仮定しないと完了主張できない場合。

## Execution Queue Delta

- Queue position before: Issue #498 は添付画像が Codex に届かない owner-facing blocker として扱う。
- Preemption decision: EMERGENCY ではありません。現在の root blocker / active queue に対する scoped progress として扱います。
- Queue delta: Issue #498 の bridge 到達保証を進める。残る lightbox/TTL/live image analysis E2E は未完了として残す。
- Why this PR is next: owner が添付した画像が Codex に届かない状態は意思疎通不能で、添付保存期間や動画解析より先に到達 truth が必要。
- Active Issues not downscoped: Active Issues は縮小しない。Issue #498 の残 criteria と Issue #587/#413/#444 は未完了として残す。

## File / Line Hypotheses

- file: scripts/run-dashboard-app-server-bridge.mjs\n  - hypothesis: buildDashboardTurnInputText が mediaReferences の件数しか渡しておらず、app-server turn が画像本体/取得先を知らない。\n  - risk if changed narrowly: raw binary を渡すと履歴/RAG/ログ保存リスクがあるため、localPath/fetchStatus/metadata に限定する。\n  - validation: dashboard-app-server-bridge unit で fetch/materialize/turn input を検証。\n  - related Issue: #498

## Hypothesis Retrospective

- expected: bridge が mediaReferences 件数だけを text context に入れている。\n- actual: その通り。Dashboard ChatRoom から mediaReferences は渡っていたが、bridge text は count のみだった。\n- mismatch: なし。\n- lesson: 添付保存と Codex 到達は別の completion gate として扱う必要がある。\n- should become RAG candidate: はい。添付メディアは mediaReferences 保存だけでは Butler-complete ではない。

## Verification Evidence

- Unit: node --test test/dashboard-app-server-bridge.test.js: pass 25
- Integration: node --test test/worker.test.js: pass 217; npm run check:self-parity: pass
- E2E: 未実施。iPhone/PWA live E2E は残。
- Manual: git diff --check: pass
- Evidence path/link: test/dashboard-app-server-bridge.test.js; test/worker.test.js; docs/butler/dashboard-butler-app-server-live-path.md

## Butler Completion Contract

- Owner goal: 添付した画像/動画が消えたり届かない状態をやめ、Butler/Codex が届いた/届かないを判断できるようにする。
- Butler entrypoint: Dashboard Butler chat の添付送信。
- Action Schema exposure: 不要。このPRは Dashboard app-server bridge の runtime path 変更。
- Runtime path: Dashboard chat mediaReferences -> app_server_turn_requested -> run-dashboard-app-server-bridge -> bearer media download -> local temp file path in turn/start text.
- Runner/runtime truth: fetchStatus=fetched/localPath または fetchStatus=fetch_failed/fetchError を Codex turn context に出す。
- Authority boundary: 既存の runtime bearer machine auth を media download に使う。新しい high-risk authority は追加しない。
- E2E evidence: 未実施。画像解析 live E2E は次スライス。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 未実行。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate\nAGENTS.md Drift Stop Protocol\nAGENTS.md Evidence Discipline\nAGENTS.md RAG Memory Capture and Cost Boundary\nIssue #498 Success Criteria

## Out-of-scope but NOT implemented

- iPhone lightbox / TTL表示 / 拡大表示 UX\n画像解析モデル連携の live E2E\n動画解析本体\nproduction deploy

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #498
- Execution ID: Not provided.
- Goal: Not provided.
