### PR TITLE
#590 Dashboard app-server の固定turn timeoutを無効化する

### DIFF
--- a/scripts/run-dashboard-app-server-bridge.mjs
+++ b/scripts/run-dashboard-app-server-bridge.mjs
@@ -577,7 +577,7 @@ export async function handleDashboardTurnRequest({
   sendDashboardEvent,
   cwd = process.cwd(),
   sandboxMode = "",
-  turnTimeoutMs = 10 * 60 * 1000,
+  turnTimeoutMs = 0,
   lateCompletionTimeoutMs = 30 * 60 * 1000,
   runtimeUrl = "",
   token = "",
@@ -624,6 +624,9 @@ export async function handleDashboardTurnRequest({
   const turnCompletion = new Promise((resolve, reject) => {
     resolveTurn = resolve;
     rejectTurn = reject;
+    if (!Number.isFinite(turnTimeoutMs) || turnTimeoutMs <= 0) {
+      return;
+    }
     timeoutHandle = setTimeout(() => {
       timedOut = true;
       const timeoutEvent = buildAppServerTurnTimeoutEvent({
@@ -738,6 +741,7 @@ export function parseBridgeArgs(argv = process.argv.slice(2), env = process.env)
     threadId: env.VTDD_DASHBOARD_THREAD_ID || "",
     cwd: env.VTDD_DASHBOARD_CODEX_CWD || process.cwd(),
     sandboxMode: env.VTDD_DASHBOARD_APP_SERVER_SANDBOX || "",
+    turnTimeoutMs: Number(env.VTDD_DASHBOARD_APP_SERVER_TURN_TIMEOUT_MS || 0),
     reconnectDelayMs: Number(env.VTDD_DASHBOARD_BRIDGE_RECONNECT_DELAY_MS || 1000)
   };
   for (let index = 0; index < argv.length; index += 1) {
@@ -747,6 +751,7 @@ export function parseBridgeArgs(argv = process.argv.slice(2), env = process.env)
     if (arg === "--thread-id") options.threadId = argv[++index] || "";
     if (arg === "--cwd") options.cwd = argv[++index] || "";
     if (arg === "--sandbox") options.sandboxMode = argv[++index] || "";
+    if (arg === "--turn-timeout-ms") options.turnTimeoutMs = Number(argv[++index] || 0);
     if (arg === "--reconnect-delay-ms") options.reconnectDelayMs = Number(argv[++index] || 1000);
   }
   return options;
@@ -800,6 +805,7 @@ export async function connectDashboardAppServerBridgeOnce({
   appServer,
   cwd = process.cwd(),
   sandboxMode = "",
+  turnTimeoutMs = 0,
   runtimeUrl = "",
   fetchImpl = globalThis.fetch,
   mediaTmpRoot = os.tmpdir(),
@@ -845,6 +851,7 @@ export async function connectDashboardAppServerBridgeOnce({
             sendDashboardEvent: async (dashboardEvent) => safeSend(dashboardEvent),
             cwd,
             sandboxMode,
+            turnTimeoutMs,
             runtimeUrl,
             token,
             fetchImpl,

--- a/scripts/run-dashboard-app-server-bridge.mjs
+++ b/scripts/run-dashboard-app-server-bridge.mjs
@@ -578,6 +578,7 @@ export async function handleDashboardTurnRequest({
   cwd = process.cwd(),
   sandboxMode = "",
   turnTimeoutMs = 10 * 60 * 1000,
+  lateCompletionTimeoutMs = 30 * 60 * 1000,
   runtimeUrl = "",
   token = "",
   fetchImpl = globalThis.fetch,
@@ -614,13 +615,17 @@ export async function handleDashboardTurnRequest({
   let accumulatedText = "";
   let activeTurnId = "";
   let turnSettled = false;
+  let timedOut = false;
   let timeoutHandle = null;
+  let lateCompletionCleanupHandle = null;
+  let cleanupNotifications = () => {};
   let resolveTurn = () => {};
   let rejectTurn = () => {};
   const turnCompletion = new Promise((resolve, reject) => {
     resolveTurn = resolve;
     rejectTurn = reject;
     timeoutHandle = setTimeout(() => {
+      timedOut = true;
       const timeoutEvent = buildAppServerTurnTimeoutEvent({
         dashboardThreadId,
         codexThreadId,
@@ -628,7 +633,10 @@ export async function handleDashboardTurnRequest({
         relatedIssue: request.relatedIssue || request.issueNumber
       });
       void sendDashboardEvent(timeoutEvent);
-      reject(createAppServerFailureAlreadySentError(timeoutEvent.text));
+      lateCompletionCleanupHandle = setTimeout(() => {
+        cleanupNotifications();
+      }, lateCompletionTimeoutMs);
+      finishTurn(resolveTurn);
     }, turnTimeoutMs);
   });
   const finishTurn = (callback) => {
@@ -660,16 +668,28 @@ export async function handleDashboardTurnRequest({
       event.type = "app_server_reply";
       event.text = accumulatedText || event.text;
       void sendDashboardEvent(event);
+      if (timedOut) {
+        cleanupNotifications();
+        return;
+      }
       finishTurn(resolveTurn);
       return;
     }
     if (event.type === "app_server_turn_failed") {
       void sendDashboardEvent(event);
+      if (timedOut) {
+        cleanupNotifications();
+        return;
+      }
       finishTurn(() => rejectTurn(createAppServerFailureAlreadySentError(event.text)));
       return;
     }
     void sendDashboardEvent(event);
   });
+  cleanupNotifications = () => {
+    clearTimeout(lateCompletionCleanupHandle);
+    unsubscribe();
+  };
   try {
     const materializedMediaReferences = await materializeDashboardMediaReferences({
       mediaReferences: request.mediaReferences,
@@ -705,7 +725,9 @@ export async function handleDashboardTurnRequest({
     await turnCompletion;
   } finally {
     clearTimeout(timeoutHandle);
-    unsubscribe();
+    if (!timedOut) {
+      cleanupNotifications();
+    }
   }
 }
 

--- a/test/dashboard-app-server-bridge.test.js
+++ b/test/dashboard-app-server-bridge.test.js
@@ -679,8 +679,7 @@ test("dashboard app-server bridge keeps listening for async turn notifications a
     },
     appServer,
     sendDashboardEvent: async (event) => events.push(event),
-    cwd: "/repo",
-    turnTimeoutMs: 1000
+    cwd: "/repo"
   });
 
   assert.deepEqual(
@@ -690,6 +689,7 @@ test("dashboard app-server bridge keeps listening for async turn notifications a
   assert.equal(events.at(-2).type, "app_server_reply_delta");
   assert.equal(events.at(-1).type, "app_server_reply");
   assert.equal(events.at(-1).text, "非同期で返りました。");
+  assert.equal(events.some((event) => event.type === "app_server_turn_failed"), false);
   assert.equal(handlers.size, 0);
 });
 
@@ -974,6 +974,7 @@ test("dashboard app-server bridge args require a dashboard thread id for runtime
   });
   assert.equal(parsed.threadId, "");
   assert.equal(parsed.sandboxMode, "danger-full-access");
+  assert.equal(parsed.turnTimeoutMs, 0);
 });
 
 test("dashboard app-server bridge refuses to connect without a dashboard thread id", async () => {
@@ -989,16 +990,18 @@ test("dashboard app-server bridge refuses to connect without a dashboard thread 
 });
 
 test("dashboard app-server bridge args read runtime, token, and thread from environment", () => {
-  const parsed = parseBridgeArgs(["--thread-id", "dashboard-main"], {
+  const parsed = parseBridgeArgs(["--thread-id", "dashboard-main", "--turn-timeout-ms", "1500"], {
     VTDD_RUNTIME_URL: "https://runtime.example",
     VTDD_GATEWAY_BEARER_TOKEN: "secret-token",
-    VTDD_DASHBOARD_CODEX_CWD: "/repo"
+    VTDD_DASHBOARD_CODEX_CWD: "/repo",
+    VTDD_DASHBOARD_APP_SERVER_TURN_TIMEOUT_MS: "0"
   });
   assert.equal(parsed.runtimeUrl, "https://runtime.example");
   assert.equal(parsed.token, "secret-token");
   assert.equal(parsed.threadId, "dashboard-main");
   assert.equal(parsed.cwd, "/repo");
   assert.equal(parsed.sandboxMode, "");
+  assert.equal(parsed.turnTimeoutMs, 1500);
   assert.equal(parsed.reconnectDelayMs, 1000);
 });
 

--- a/test/dashboard-app-server-bridge.test.js
+++ b/test/dashboard-app-server-bridge.test.js
@@ -718,8 +718,7 @@ test("dashboard app-server bridge sends Japanese recoverable timeout failure", a
     }
   };
 
-  await assert.rejects(
-    handleDashboardTurnRequest({
+  await handleDashboardTurnRequest({
       request: {
         threadId: "dashboard-main",
         repository: "marushu/vtdd-v2-p",
@@ -729,10 +728,9 @@ test("dashboard app-server bridge sends Japanese recoverable timeout failure", a
       appServer,
       sendDashboardEvent: async (event) => events.push(event),
       cwd: "/repo",
-      turnTimeoutMs: 1
-    }),
-    /応答生成が時間切れ/
-  );
+      turnTimeoutMs: 1,
+      lateCompletionTimeoutMs: 1
+    });
 
   const timeoutEvent = events.find((event) => event.type === "app_server_turn_failed");
   assert.ok(timeoutEvent);
@@ -742,6 +740,75 @@ test("dashboard app-server bridge sends Japanese recoverable timeout failure", a
   assert.equal(timeoutEvent.relatedIssue, 590);
   assert.match(timeoutEvent.text, /入力は Dashboard thread に保存済み/);
   assert.doesNotMatch(timeoutEvent.text, /timed out before completion/);
+  await new Promise((resolve) => setTimeout(resolve, 10));
+  assert.equal(handlers.size, 0);
+});
+
+test("dashboard app-server bridge persists late completion after timeout instead of losing the final reply", async () => {
+  const events = [];
+  const handlers = new Set();
+  let nextId = 1;
+  const appServer = {
+    nextRequestId() {
+      const id = nextId;
+      nextId += 1;
+      return id;
+    },
+    onNotification(handler) {
+      handlers.add(handler);
+      return () => handlers.delete(handler);
+    },
+    async request(message) {
+      if (message.method === "thread/start") {
+        return { thread: { id: "codex-thread-late" } };
+      }
+      if (message.method === "turn/start") {
+        return { turn: { id: "turn-late" } };
+      }
+      throw new Error(`unexpected method ${message.method}`);
+    }
+  };
+
+  await handleDashboardTurnRequest({
+    request: {
+      threadId: "dashboard-main",
+      repository: "marushu/vtdd-v2-p",
+      relatedIssue: 590,
+      text: "PR 作成まで進めて"
+    },
+    appServer,
+    sendDashboardEvent: async (event) => events.push(event),
+    cwd: "/repo",
+    turnTimeoutMs: 1,
+    lateCompletionTimeoutMs: 1000
+  });
+
+  assert.equal(events.filter((event) => event.type === "app_server_turn_failed").length, 1);
+  assert.equal(handlers.size, 1);
+
+  for (const handler of handlers) {
+    handler({
+      method: "item/agentMessage/delta",
+      params: {
+        threadId: "codex-thread-late",
+        turnId: "turn-late",
+        delta: "PR #632 を Draft で作成済みです。"
+      }
+    });
+    handler({
+      method: "turn/completed",
+      params: {
+        threadId: "codex-thread-late",
+        turn: { id: "turn-late", status: "completed" }
+      }
+    });
+  }
+
+  const finalReply = events.find((event) => event.type === "app_server_reply");
+  assert.ok(finalReply);
+  assert.equal(finalReply.threadId, "dashboard-main");
+  assert.equal(finalReply.codexThreadId, "codex-thread-late");
+  assert.equal(finalReply.text, "PR #632 を Draft で作成済みです。");
   assert.equal(handlers.size, 0);
 });
 


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #590 の残バグとして、`codex app-server` / VPS Codex CLI の長い turn を Dashboard bridge 側の固定 10分 timeout で失敗扱いにしないようにします。
- PR #633 既存の late completion 保持に加えて、既定では `turnTimeoutMs=0` とし、明示的に `VTDD_DASHBOARD_APP_SERVER_TURN_TIMEOUT_MS` または `--turn-timeout-ms` を設定した場合だけ recoverable timeout failure を出します。
- owner の直近指示「割り込み chat の改悪を戻してから、VPS Codex CLI のタイムアウトをしないように修正」に対し、この PR は timeout 側の bounded slice です。割り込み composer rollback は PR #635 で別PRに分けています。

## Satisfied Success Criteria

- [x] Dashboard app-server bridge の既定 turn timeout を 10分から無効化しました。
- [x] 明示的な timeout 設定がある場合だけ、既存の日本語 recoverable timeout failure を出せるようにしました。
- [x] `VTDD_DASHBOARD_APP_SERVER_TURN_TIMEOUT_MS` と `--turn-timeout-ms` を追加し、必要な環境だけ timeout guard を再有効化できます。
- [x] default path では async `turn/completed` まで待ち、`app_server_turn_failed` を出さない regression assertion を追加しました。
- [x] 明示 timeout path と late completion path の既存 regression test は維持しました。

## Unsatisfied Success Criteria

- Production VPS / Dashboard app-server live E2E は未実施です。
- app-server が完全に無応答で止まった場合の heartbeat / stale detection / owner-facing recovery はこの PR では未実装です。
- Issue #413 の progress indicator / phase visibility 全体はこの PR では扱っていません。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #590
- Implementing Success Criteria: Dashboard app-server bridge が通常の長時間 Codex turn を固定 10分 timeout で失敗扱いしない。明示設定時のみ recoverable timeout を残す。
- Explicit Non-goals: app-server 自体の高速化、VPS process supervisor変更、#413 progress UI、#635 rollback merge、deploy、credential mutation、permission mutation、Issue close、merge。
- Expected touched files/routes/workflows: `scripts/run-dashboard-app-server-bridge.mjs`, `test/dashboard-app-server-bridge.test.js`
- Affected Issues: Issue #590 を直接進める。Issue #413 は progress/recovery の親文脈として未完了。
- Affected PRs: PR #633 を更新する。PR #635 は割り込み composer rollback として別PR。
- Affected workflows: GitHub Actions workflow は変更しない。
- Affected runtime/operator surfaces: VPS Dashboard Bridge / `codex app-server` turn lifecycle only.
- What may break if we patch narrowly: timeout を完全削除するだけだと無応答 app-server の検知が弱くなるため、明示 timeout 設定を残し、stale detection は後続 #413/#590 recovery work として残す。
- Unknowns to investigate before coding: production app-server の実際の long turn 所要時間と、無応答時の heartbeat/stale signal 設計。
- Validation needed: bridge unit test、diff check、PR checks。
- Stop condition: VPS service manager / deploy / runtime env mutation に進む場合は passkey approval または別 bounded contract が必要。

## Execution Queue Delta

- Queue position before: Issue #590 is `Now`; PR #633 was already open for late completion after timeout.
- Preemption decision: ROOT-adjacent EVIDENCE。owner-facing timeout が通常の長時間作業を失敗に見せるため、#590 の同一PRに追加する。
- Queue delta: PR #633 expands within Issue #590 from late completion preservation to default no turn timeout. Issue #413/#528/#579/#450 remain active and not complete.
- Why this PR is next: PR #635 で割り込み composer regression を戻した後、owner が待っている本来の問題は Dashboard/VPS Codex CLI turn が timeout で失敗に見えることだから。
- Active Issues not downscoped: active Issues は縮小しません。Issue #413/#528/#590/#579/#450/#606 は未完了として残します。

## File / Line Hypotheses

- file: `scripts/run-dashboard-app-server-bridge.mjs`
  - hypothesis: `turnTimeoutMs = 10 * 60 * 1000` が長い Codex turn を Dashboard 側で失敗扱いにしている。
  - risk if changed narrowly: 無期限待ちだけにすると無応答検知が弱くなる。明示 timeout opt-in と既存 recoverable timeout path を残す。
  - validation: default async completion test で timeout failure が出ないこと、explicit timeout test で日本語 failure が出ることを確認する。
  - related Issue: Issue #590
- file: `test/dashboard-app-server-bridge.test.js`
  - hypothesis: timeout default と explicit opt-in の両方を固定しないと、将来また固定短時間 timeout に戻る。
  - validation: `node --test test/dashboard-app-server-bridge.test.js`
  - related Issue: Issue #590

## Hypothesis Retrospective

- expected: fixed 10-minute bridge timeout が VPS Codex CLI / app-server 長時間 turn を失敗に見せる。
- actual: default timeout を無効化し、明示設定時だけ timeout failure を出す形に変更した。late completion handling は残した。
- mismatch: production live long-running turn E2E は未実施。
- lesson: timeout は「実行失敗」ではなく運用上の stale/recovery signal として扱うべきで、通常 turn の固定失敗閾値にしてはいけない。
- should become RAG candidate: yes。Dashboard bridge は固定短時間 timeout で Codex turn を失敗扱いしない。

## Verification Evidence

- Unit: `node --test test/dashboard-app-server-bridge.test.js` passed: 26 pass, 0 fail.
- Static: `git diff --check` passed.
- Integration: Not run. `worker.js` is not touched by this PR update.
- E2E: Production VPS / iPhone PWA live E2E not run.

## Butler Completion Contract

- Owner goal: VPS Codex CLI / app-server の長い turn が Dashboard bridge の固定 timeout で失敗扱いにならないようにする。
- Butler entrypoint: Existing Dashboard Butler thread via app-server bridge.
- Action Schema exposure: Unchanged.
- Runtime path: `scripts/run-dashboard-app-server-bridge.mjs` handles Dashboard turn request and waits for app-server completion by default.
- Runner/runtime truth: local unit evidence only. Live runtime evidence is not included.
- Authority boundary: Unchanged. No high-risk operation or approval boundary change.
- E2E evidence: Not completed; live long-running Dashboard/VPS turn evidence remains required before closing #590.
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: Not performed.
- Custom GPT Action Schema update: Not required.
- Custom GPT Instructions update: Not required.
- iPhone Butler live E2E: Not performed.

## Related Constitution Rules

- Butler Completion Gate: do not claim completion without owner-facing E2E.
- Chief Butler Operating Principle: owner-facing runtime truth must not disappear after timeout.
- Evidence Discipline: local unit evidence only; live E2E remains missing.
- Drift Stop Protocol: scoped to Issue #590 timeout lifecycle.

## Out-of-scope but NOT implemented

- #413 progress bar / current phase indicator.
- #444 notifications and notification sound.
- #528 full ChatGPT iOS-like chat UX baseline.
- #606 passkey/session TTL and auth recovery.
- Production deploy.

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #590
- Execution ID: local-codex-2026-05-29-issue-590-disable-default-turn-timeout
- Goal: Disable default Dashboard app-server turn timeout
