### PR TITLE
#637 owner action required PWA notification routeを追加

### DIFF
--- a/docs/butler/vps-privileged-maintenance-capability-lifecycle.md
+++ b/docs/butler/vps-privileged-maintenance-capability-lifecycle.md
@@ -97,14 +97,24 @@ planes with their own scoped passkey contracts.
 ## Notification Boundary
 
 Existing Dashboard Web Push support can send a server-side test notification to
-the current saved device subscription, but it is not yet a general "owner action
-required" dispatch path for Butler/VPS recovery. Issue #637 treats that as a
-required connection, not as existing completion.
+the current saved device subscription. The Worker also exposes a
+machine-authenticated owner action event route:
+
+`POST /v2/events/owner-action-required`
+
+That route stores an `owner_action_required` Dashboard event and attempts Web
+Push delivery to saved PWA subscriptions. It is the runtime entry point for
+notifying the owner when Butler, VPS Codex CLI, a helper proposal, or another
+machine process needs owner attention.
 
 When owner action is required, the runtime must attempt PWA notification and
 report send result truth. If push delivery is unavailable, Butler must mark
 `pwa_notification_unavailable` and still preserve the recovery link in
 Dashboard notifications and GitHub-visible runtime truth.
+
+This route is not permission to execute privileged work. It carries the
+attention request and recovery link only. The privileged operation still needs
+the scoped passkey approval and root-owned helper lifecycle described above.
 
 ## Completion Boundary
 

--- a/docs/butler/vps-privileged-maintenance-capability-lifecycle.md
+++ b/docs/butler/vps-privileged-maintenance-capability-lifecycle.md
@@ -107,6 +107,10 @@ Push delivery to saved PWA subscriptions. It is the runtime entry point for
 notifying the owner when Butler, VPS Codex CLI, a helper proposal, or another
 machine process needs owner attention.
 
+The recovery link for this route must be a same-origin `/dashboard` URL. The
+route must reject external URLs, protocol-relative URLs, and underspecified
+requests that lack a stable action id or owner-facing title/summary.
+
 When owner action is required, the runtime must attempt PWA notification and
 report send result truth. If push delivery is unavailable, Butler must mark
 `pwa_notification_unavailable` and still preserve the recovery link in

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -3914,11 +3914,20 @@ async function handleOwnerActionRequiredEventRequest(request, env) {
     });
   }
 
-  await eventStore.put(event.event);
   const webPush = await dispatchDashboardWebPushForEvent(env, event.event);
+  const eventWithNotificationTruth = normalizeDashboardEventRecord({
+    ...event.event,
+    pwaNotificationStatus: webPush.ok ? "sent" : "pwa_notification_unavailable",
+    pwaNotificationError: webPush.ok ? null : webPush.error || "dashboard_web_push_unavailable",
+    pwaNotificationReason: webPush.ok ? null : webPush.reason || null,
+    pwaNotificationAttempted: webPush.attempted ?? 0,
+    pwaNotificationDelivered: webPush.delivered ?? 0,
+    updatedAt: new Date().toISOString()
+  });
+  await eventStore.put(eventWithNotificationTruth);
   return json(webPush.ok ? 202 : webPush.status || 503, {
     ok: webPush.ok,
-    event: event.event,
+    event: eventWithNotificationTruth,
     webPush
   });
 }
@@ -8832,6 +8841,11 @@ function normalizeDashboardEventRecord(event) {
     changeSummary: changeSummary || null,
     pullNumber: normalizeIssue(input.pullNumber) || inferPullNumberFromText(`${title} ${changeSummary}`),
     issueNumber: normalizeIssue(input.issueNumber),
+    pwaNotificationStatus: normalizeDashboardEventText(input.pwaNotificationStatus) || null,
+    pwaNotificationError: normalizeDashboardEventText(input.pwaNotificationError) || null,
+    pwaNotificationReason: normalizeDashboardEventText(input.pwaNotificationReason) || null,
+    pwaNotificationAttempted: normalizeNonNegativeInteger(input.pwaNotificationAttempted),
+    pwaNotificationDelivered: normalizeNonNegativeInteger(input.pwaNotificationDelivered),
     createdAt,
     updatedAt
   };
@@ -10010,16 +10024,13 @@ function normalizeVpsRunnerDashboardEvent(payload) {
 function normalizeOwnerActionRequiredDashboardEvent(payload) {
   const input = normalizeObject(payload);
   const repository = normalizeCanonicalRepositoryInput(input.repository || input.repositoryInput);
-  const actionId = normalizeDashboardEventText(input.actionId || input.action_id || input.runId || input.run_id || crypto.randomUUID());
-  const title = sanitizeDashboardChatText(input.title || "Owner action required");
+  const actionId = normalizeDashboardEventText(input.actionId || input.action_id || input.runId || input.run_id);
+  const title = sanitizeDashboardChatText(input.title);
   const changeSummary = sanitizeDashboardChatText(input.summary || input.message || input.reason || input.changeSummary);
   const issueNumber = normalizeIssue(input.issueNumber || input.issue_number || input.relatedIssue);
   const pullNumber = normalizeIssue(input.pullNumber || input.pull_number);
   const rawRunUrl = normalizeDashboardEventText(input.url || input.runUrl || input.run_url);
-  const runUrl =
-    rawRunUrl.startsWith("/") && !rawRunUrl.startsWith("//")
-      ? rawRunUrl
-      : normalizeDashboardUrl(rawRunUrl) || "/dashboard/notifications";
+  const runUrl = normalizeOwnerActionRequiredRunUrl(rawRunUrl);
   const workflowName = sanitizeDashboardChatText(input.workflowName || input.workflow_name || "owner-action-required");
   const updatedAt = normalizeIsoTimestamp(input.updatedAt || input.updated_at) || new Date().toISOString();
   const createdAt = normalizeIsoTimestamp(input.createdAt || input.created_at) || updatedAt;
@@ -10031,11 +10042,25 @@ function normalizeOwnerActionRequiredDashboardEvent(payload) {
       reason: "owner action notification repository is required"
     };
   }
+  if (!actionId) {
+    return {
+      ok: false,
+      error: "owner_action_required_action_id_required",
+      reason: "owner action notification requires a stable actionId or runId"
+    };
+  }
   if (!title && !changeSummary) {
     return {
       ok: false,
       error: "owner_action_required_title_required",
       reason: "owner action notification requires a title or summary"
+    };
+  }
+  if (!runUrl) {
+    return {
+      ok: false,
+      error: "owner_action_required_recovery_url_required",
+      reason: "owner action notification requires a same-origin /dashboard recovery url"
     };
   }
 
@@ -10058,6 +10083,17 @@ function normalizeOwnerActionRequiredDashboardEvent(payload) {
       updatedAt
     })
   };
+}
+
+function normalizeOwnerActionRequiredRunUrl(value) {
+  const text = normalizeDashboardEventText(value);
+  if (!text || text.startsWith("//")) {
+    return "";
+  }
+  if (text === "/dashboard" || text.startsWith("/dashboard/") || text.startsWith("/dashboard?")) {
+    return text;
+  }
+  return "";
 }
 
 function normalizeVpsRunnerDashboardStatus(value) {
@@ -13398,6 +13434,11 @@ function normalizeText(value) {
 function normalizePositiveInteger(value) {
   const number = Number(value);
   return Number.isInteger(number) && number > 0 ? number : null;
+}
+
+function normalizeNonNegativeInteger(value) {
+  const number = Number(value);
+  return Number.isInteger(number) && number >= 0 ? number : 0;
 }
 
 function isSocketOpen(socket) {

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -1011,6 +1011,23 @@ export default {
       return handleVpsRunnerEventRequest(request, env);
     }
 
+    if (request.method === "POST" && isApiPath(url.pathname, "/events/owner-action-required")) {
+      const auth = authorizeGatewayRequest({
+        request,
+        env,
+        apiSuffix: "/events/owner-action-required"
+      });
+      if (!auth.ok) {
+        return json(auth.status, {
+          ok: false,
+          error: "unauthorized",
+          reason: auth.reason
+        });
+      }
+
+      return handleOwnerActionRequiredEventRequest(request, env);
+    }
+
     if (request.method === "POST" && isApiPath(url.pathname, "/action/github-actions-secret")) {
       const auth = authorizePasskeyBrowserOrMachineRequest({
         request,
@@ -3877,6 +3894,35 @@ async function handleVpsRunnerEventRequest(request, env) {
   });
 }
 
+async function handleOwnerActionRequiredEventRequest(request, env) {
+  const payload = await readJson(request);
+  const event = normalizeOwnerActionRequiredDashboardEvent(payload);
+  if (!event.ok) {
+    return json(422, {
+      ok: false,
+      error: event.error,
+      reason: event.reason
+    });
+  }
+
+  const eventStore = resolveDashboardEventStore(env);
+  if (!eventStore) {
+    return json(503, {
+      ok: false,
+      error: "dashboard_event_store_unavailable",
+      reason: "dashboard event store is not configured"
+    });
+  }
+
+  await eventStore.put(event.event);
+  const webPush = await dispatchDashboardWebPushForEvent(env, event.event);
+  return json(webPush.ok ? 202 : webPush.status || 503, {
+    ok: webPush.ok,
+    event: event.event,
+    webPush
+  });
+}
+
 async function handleDashboardChatMessageRequest(request, env) {
   const dashboardAuth = await authorizeDashboardRequest({
     request,
@@ -4575,6 +4621,7 @@ function isSupportedDashboardPushAckSourceEventId(value) {
     text.startsWith("github-actions:") ||
     text.startsWith("vps-runner:") ||
     text.startsWith("ai-news:") ||
+    text.startsWith("owner-action-required:") ||
     text.startsWith("dashboard-push-test:")
   );
 }
@@ -7650,6 +7697,10 @@ function buildDashboardWebPushTitle(record) {
   if (record.kind === "dashboard_push_test") {
     return "VTDD Butler テスト通知";
   }
+  if (record.kind === "owner_action_required") {
+    const subject = compactNotificationText(record.changeSummary || record.title || "確認が必要です", 52);
+    return `要対応: ${subject}`.slice(0, 80);
+  }
   if (record.kind === "ai_news_radar") {
     const edition = dashboardAiNewsEditionLabel(record);
     const subject = compactNotificationText(record.changeSummary || record.title || "AI 開発運用ニュース", 44);
@@ -7674,6 +7725,15 @@ function buildDashboardWebPushTitle(record) {
 function buildDashboardWebPushBody(record) {
   if (record.kind === "dashboard_push_test") {
     return "通知経路は正常です。iPhone PWA にサーバ送信できました。";
+  }
+  if (record.kind === "owner_action_required") {
+    const details = [];
+    const title = compactNotificationText(record.title || record.changeSummary || "VTDD Butler が確認を待っています", 74);
+    if (title) details.push(title);
+    if (record.issueNumber) details.push(`Issue #${record.issueNumber}`);
+    if (record.pullNumber) details.push(`PR #${record.pullNumber}`);
+    if (record.workflowName) details.push(`source: ${compactNotificationText(record.workflowName, 32)}`);
+    return details.join(" / ").slice(0, 180);
   }
   if (record.kind === "ai_news_radar") {
     const title = compactNotificationText(record.changeSummary || record.title || "VTDD に関係する更新があります", 96);
@@ -7739,8 +7799,12 @@ function shortRepositoryName(repository) {
 }
 
 function buildDashboardEventOwnerTargetUrl(event) {
-  if (normalizeDashboardEventRecord(event).kind === "ai_news_radar") {
+  const record = normalizeDashboardEventRecord(event);
+  if (record.kind === "ai_news_radar") {
     return "/dashboard/news";
+  }
+  if (record.kind === "owner_action_required" && record.runUrl) {
+    return record.runUrl;
   }
   return buildDashboardPullRequestUrl(event) || "/dashboard/notifications";
 }
@@ -9940,6 +10004,59 @@ function normalizeVpsRunnerDashboardEvent(payload) {
     event,
     threadId,
     chatMessage
+  };
+}
+
+function normalizeOwnerActionRequiredDashboardEvent(payload) {
+  const input = normalizeObject(payload);
+  const repository = normalizeCanonicalRepositoryInput(input.repository || input.repositoryInput);
+  const actionId = normalizeDashboardEventText(input.actionId || input.action_id || input.runId || input.run_id || crypto.randomUUID());
+  const title = sanitizeDashboardChatText(input.title || "Owner action required");
+  const changeSummary = sanitizeDashboardChatText(input.summary || input.message || input.reason || input.changeSummary);
+  const issueNumber = normalizeIssue(input.issueNumber || input.issue_number || input.relatedIssue);
+  const pullNumber = normalizeIssue(input.pullNumber || input.pull_number);
+  const rawRunUrl = normalizeDashboardEventText(input.url || input.runUrl || input.run_url);
+  const runUrl =
+    rawRunUrl.startsWith("/") && !rawRunUrl.startsWith("//")
+      ? rawRunUrl
+      : normalizeDashboardUrl(rawRunUrl) || "/dashboard/notifications";
+  const workflowName = sanitizeDashboardChatText(input.workflowName || input.workflow_name || "owner-action-required");
+  const updatedAt = normalizeIsoTimestamp(input.updatedAt || input.updated_at) || new Date().toISOString();
+  const createdAt = normalizeIsoTimestamp(input.createdAt || input.created_at) || updatedAt;
+
+  if (!repository) {
+    return {
+      ok: false,
+      error: "repository_required",
+      reason: "owner action notification repository is required"
+    };
+  }
+  if (!title && !changeSummary) {
+    return {
+      ok: false,
+      error: "owner_action_required_title_required",
+      reason: "owner action notification requires a title or summary"
+    };
+  }
+
+  return {
+    ok: true,
+    event: normalizeDashboardEventRecord({
+      id: `owner-action-required:${repository}:${actionId}`,
+      kind: "owner_action_required",
+      repository,
+      workflowName,
+      runId: actionId,
+      status: "waiting",
+      conclusion: "action_required",
+      title,
+      changeSummary,
+      pullNumber,
+      issueNumber,
+      runUrl,
+      createdAt,
+      updatedAt
+    })
   };
 }
 

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -4156,6 +4156,116 @@ test("worker sends owner-action-required PWA notification through machine event 
   assert.equal(decrypted.url, "/dashboard/notifications?focus=owner-action");
   const stored = await eventStore.latest({ kind: "owner_action_required", repository: "marushu/vtdd-v2-p" });
   assert.equal(stored.id, "owner-action-required:marushu/vtdd-v2-p:issue-637-passkey-needed");
+  assert.equal(stored.pwaNotificationStatus, "sent");
+  assert.equal(stored.pwaNotificationDelivered, 1);
+  assert.equal(stored.pwaNotificationAttempted, 1);
+});
+
+test("worker rejects unsafe or underspecified owner-action-required notifications", async () => {
+  const eventStore = createInMemoryDashboardEventStore();
+
+  const missingAction = await worker.fetch(
+    new Request("https://example.com/v2/events/owner-action-required", {
+      method: "POST",
+      headers: gatewayAuthHeaders,
+      body: JSON.stringify({
+        repository: "marushu/vtdd-v2-p",
+        title: "Passkey approval needed",
+        url: "/dashboard/notifications?focus=owner-action"
+      })
+    }),
+    {
+      ...gatewayAuthEnv,
+      DASHBOARD_EVENT_STORE: eventStore
+    }
+  );
+  assert.equal(missingAction.status, 422);
+  assert.equal((await missingAction.json()).error, "owner_action_required_action_id_required");
+
+  const unsafeExternalUrl = await worker.fetch(
+    new Request("https://example.com/v2/events/owner-action-required", {
+      method: "POST",
+      headers: gatewayAuthHeaders,
+      body: JSON.stringify({
+        repository: "marushu/vtdd-v2-p",
+        actionId: "unsafe-url",
+        title: "Passkey approval needed",
+        url: "https://evil.example/phish"
+      })
+    }),
+    {
+      ...gatewayAuthEnv,
+      DASHBOARD_EVENT_STORE: eventStore
+    }
+  );
+  assert.equal(unsafeExternalUrl.status, 422);
+  assert.equal((await unsafeExternalUrl.json()).error, "owner_action_required_recovery_url_required");
+
+  const protocolRelativeUrl = await worker.fetch(
+    new Request("https://example.com/v2/events/owner-action-required", {
+      method: "POST",
+      headers: gatewayAuthHeaders,
+      body: JSON.stringify({
+        repository: "marushu/vtdd-v2-p",
+        actionId: "protocol-relative-url",
+        title: "Passkey approval needed",
+        url: "//evil.example/phish"
+      })
+    }),
+    {
+      ...gatewayAuthEnv,
+      DASHBOARD_EVENT_STORE: eventStore
+    }
+  );
+  assert.equal(protocolRelativeUrl.status, 422);
+  assert.equal((await protocolRelativeUrl.json()).error, "owner_action_required_recovery_url_required");
+});
+
+test("worker records owner-action-required PWA unavailable truth when push delivery fails", async () => {
+  const store = createInMemoryDashboardPushSubscriptionStore();
+  const pushKeys = await createTestPushSubscription();
+  const currentEndpointHash = await sha256HexTest(pushKeys.subscription.endpoint);
+  await store.put({
+    ...pushKeys.subscription,
+    endpointHash: currentEndpointHash
+  });
+  const eventStore = createInMemoryDashboardEventStore();
+  const vapidEnv = await createTestVapidEnv({
+    DASHBOARD_WEB_PUSH_FETCH: async () => new Response(null, { status: 500 })
+  });
+
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/events/owner-action-required", {
+      method: "POST",
+      headers: gatewayAuthHeaders,
+      body: JSON.stringify({
+        repository: "marushu/vtdd-v2-p",
+        actionId: "push-unavailable",
+        title: "Passkey approval needed",
+        summary: "VPS helper proposal still needs owner approval",
+        issueNumber: 637,
+        url: "/dashboard/notifications?focus=push-unavailable"
+      })
+    }),
+    {
+      ...gatewayAuthEnv,
+      ...vapidEnv,
+      DASHBOARD_EVENT_STORE: eventStore,
+      DASHBOARD_PUSH_SUBSCRIPTION_STORE: store
+    }
+  );
+  assert.equal(response.status, 500);
+  const body = await response.json();
+  assert.equal(body.ok, false);
+  assert.equal(body.event.pwaNotificationStatus, "pwa_notification_unavailable");
+  assert.equal(body.event.pwaNotificationReason, "push service rejected the request");
+  assert.equal(body.event.pwaNotificationAttempted, 1);
+  assert.equal(body.event.pwaNotificationDelivered, 0);
+  assert.equal(body.event.runUrl, "/dashboard/notifications?focus=push-unavailable");
+  const stored = await eventStore.latest({ kind: "owner_action_required", repository: "marushu/vtdd-v2-p" });
+  assert.equal(stored.id, "owner-action-required:marushu/vtdd-v2-p:push-unavailable");
+  assert.equal(stored.pwaNotificationStatus, "pwa_notification_unavailable");
+  assert.equal(stored.runUrl, "/dashboard/notifications?focus=push-unavailable");
 });
 
 test("worker builds distinct dashboard Web Push copy by event type", () => {

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -4091,6 +4091,73 @@ test("worker refuses server-side dashboard Web Push test when current device sub
   assert.equal(JSON.stringify(body).includes("current-device"), false);
 });
 
+test("worker sends owner-action-required PWA notification through machine event route", async () => {
+  const store = createInMemoryDashboardPushSubscriptionStore();
+  const pushKeys = await createTestPushSubscription();
+  const currentEndpointHash = await sha256HexTest(pushKeys.subscription.endpoint);
+  await store.put({
+    ...pushKeys.subscription,
+    endpointHash: currentEndpointHash
+  });
+  const eventStore = createInMemoryDashboardEventStore();
+  const calls = [];
+  const vapidEnv = await createTestVapidEnv({
+    DASHBOARD_WEB_PUSH_FETCH: async (input, init) => {
+      calls.push({ input, init });
+      return new Response(null, { status: 201 });
+    }
+  });
+
+  const unauthenticated = await worker.fetch(
+    new Request("https://example.com/v2/events/owner-action-required", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ repository: "marushu/vtdd-v2-p", title: "must not send" })
+    }),
+    {
+      ...gatewayAuthEnv,
+      ...vapidEnv,
+      DASHBOARD_EVENT_STORE: eventStore,
+      DASHBOARD_PUSH_SUBSCRIPTION_STORE: store
+    }
+  );
+  assert.equal(unauthenticated.status, 401);
+  assert.equal(calls.length, 0);
+
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/events/owner-action-required", {
+      method: "POST",
+      headers: gatewayAuthHeaders,
+      body: JSON.stringify({
+        repository: "marushu/vtdd-v2-p",
+        actionId: "issue-637-passkey-needed",
+        title: "Passkey approval needed",
+        summary: "VPS capability proposal requires owner approval",
+        issueNumber: 637,
+        url: "/dashboard/notifications?focus=owner-action"
+      })
+    }),
+    {
+      ...gatewayAuthEnv,
+      ...vapidEnv,
+      DASHBOARD_EVENT_STORE: eventStore,
+      DASHBOARD_PUSH_SUBSCRIPTION_STORE: store
+    }
+  );
+  assert.equal(response.status, 202);
+  const body = await response.json();
+  assert.equal(body.ok, true);
+  assert.equal(body.event.kind, "owner_action_required");
+  assert.equal(body.webPush.delivered, 1);
+  assert.equal(calls.length, 1);
+  const decrypted = JSON.parse(await decryptTestWebPushPayload(calls[0].init.body, pushKeys));
+  assert.equal(decrypted.title, "要対応: VPS capability proposal requires owner approval");
+  assert.equal(decrypted.body.includes("Issue #637"), true);
+  assert.equal(decrypted.url, "/dashboard/notifications?focus=owner-action");
+  const stored = await eventStore.latest({ kind: "owner_action_required", repository: "marushu/vtdd-v2-p" });
+  assert.equal(stored.id, "owner-action-required:marushu/vtdd-v2-p:issue-637-passkey-needed");
+});
+
 test("worker builds distinct dashboard Web Push copy by event type", () => {
   const deploySuccess = buildDashboardWebPushPayload({
     kind: "github_actions_workflow_run",
@@ -4139,6 +4206,24 @@ test("worker builds distinct dashboard Web Push copy by event type", () => {
   });
   assert.equal(testPush.title, "VTDD Butler テスト通知");
   assert.equal(testPush.body, "通知経路は正常です。iPhone PWA にサーバ送信できました。");
+
+  const ownerAction = buildDashboardWebPushPayload({
+    id: "owner-action-required:marushu/vtdd-v2-p:issue-637-passkey-needed",
+    kind: "owner_action_required",
+    repository: "marushu/vtdd-v2-p",
+    workflowName: "vps-maintenance",
+    runId: "issue-637-passkey-needed",
+    status: "waiting",
+    conclusion: "action_required",
+    title: "Passkey approval needed",
+    changeSummary: "VPS capability proposal requires owner approval",
+    issueNumber: 637,
+    runUrl: "/dashboard/notifications?focus=owner-action"
+  });
+  assert.equal(ownerAction.title, "要対応: VPS capability proposal requires owner approval");
+  assert.equal(ownerAction.body.includes("Issue #637"), true);
+  assert.equal(ownerAction.url, "/dashboard/notifications?focus=owner-action");
+  assert.equal(ownerAction.sourceEventId, "owner-action-required:marushu/vtdd-v2-p:issue-637-passkey-needed");
 
   const aiNews = buildDashboardWebPushPayload({
     id: "ai-news:morning:2026-05-28",

--- a/worker.js
+++ b/worker.js
@@ -57059,6 +57059,21 @@ var runtime_default = {
       }
       return handleVpsRunnerEventRequest(request, env);
     }
+    if (request.method === "POST" && isApiPath(url.pathname, "/events/owner-action-required")) {
+      const auth = authorizeGatewayRequest({
+        request,
+        env,
+        apiSuffix: "/events/owner-action-required"
+      });
+      if (!auth.ok) {
+        return json(auth.status, {
+          ok: false,
+          error: "unauthorized",
+          reason: auth.reason
+        });
+      }
+      return handleOwnerActionRequiredEventRequest(request, env);
+    }
     if (request.method === "POST" && isApiPath(url.pathname, "/action/github-actions-secret")) {
       const auth = authorizePasskeyBrowserOrMachineRequest({
         request,
@@ -59544,6 +59559,32 @@ async function handleVpsRunnerEventRequest(request, env) {
     webPush
   });
 }
+async function handleOwnerActionRequiredEventRequest(request, env) {
+  const payload = await readJson(request);
+  const event = normalizeOwnerActionRequiredDashboardEvent(payload);
+  if (!event.ok) {
+    return json(422, {
+      ok: false,
+      error: event.error,
+      reason: event.reason
+    });
+  }
+  const eventStore = resolveDashboardEventStore(env);
+  if (!eventStore) {
+    return json(503, {
+      ok: false,
+      error: "dashboard_event_store_unavailable",
+      reason: "dashboard event store is not configured"
+    });
+  }
+  await eventStore.put(event.event);
+  const webPush = await dispatchDashboardWebPushForEvent(env, event.event);
+  return json(webPush.ok ? 202 : webPush.status || 503, {
+    ok: webPush.ok,
+    event: event.event,
+    webPush
+  });
+}
 async function handleDashboardChatMessageRequest(request, env) {
   const dashboardAuth = await authorizeDashboardRequest({
     request,
@@ -60191,7 +60232,7 @@ async function handleDashboardPushAckRequest(request, env) {
 }
 function isSupportedDashboardPushAckSourceEventId(value) {
   const text = normalizeText30(value);
-  return text.startsWith("github-actions:") || text.startsWith("vps-runner:") || text.startsWith("ai-news:") || text.startsWith("dashboard-push-test:");
+  return text.startsWith("github-actions:") || text.startsWith("vps-runner:") || text.startsWith("ai-news:") || text.startsWith("owner-action-required:") || text.startsWith("dashboard-push-test:");
 }
 async function handleDashboardChatSocketRequest(request, url, env) {
   const auth = await authorizeDashboardRequest({
@@ -62830,6 +62871,10 @@ function buildDashboardWebPushTitle(record2) {
   if (record2.kind === "dashboard_push_test") {
     return "VTDD Butler \u30C6\u30B9\u30C8\u901A\u77E5";
   }
+  if (record2.kind === "owner_action_required") {
+    const subject = compactNotificationText(record2.changeSummary || record2.title || "\u78BA\u8A8D\u304C\u5FC5\u8981\u3067\u3059", 52);
+    return `\u8981\u5BFE\u5FDC: ${subject}`.slice(0, 80);
+  }
   if (record2.kind === "ai_news_radar") {
     const edition = dashboardAiNewsEditionLabel(record2);
     const subject = compactNotificationText(record2.changeSummary || record2.title || "AI \u958B\u767A\u904B\u7528\u30CB\u30E5\u30FC\u30B9", 44);
@@ -62853,6 +62898,15 @@ function buildDashboardWebPushTitle(record2) {
 function buildDashboardWebPushBody(record2) {
   if (record2.kind === "dashboard_push_test") {
     return "\u901A\u77E5\u7D4C\u8DEF\u306F\u6B63\u5E38\u3067\u3059\u3002iPhone PWA \u306B\u30B5\u30FC\u30D0\u9001\u4FE1\u3067\u304D\u307E\u3057\u305F\u3002";
+  }
+  if (record2.kind === "owner_action_required") {
+    const details2 = [];
+    const title2 = compactNotificationText(record2.title || record2.changeSummary || "VTDD Butler \u304C\u78BA\u8A8D\u3092\u5F85\u3063\u3066\u3044\u307E\u3059", 74);
+    if (title2) details2.push(title2);
+    if (record2.issueNumber) details2.push(`Issue #${record2.issueNumber}`);
+    if (record2.pullNumber) details2.push(`PR #${record2.pullNumber}`);
+    if (record2.workflowName) details2.push(`source: ${compactNotificationText(record2.workflowName, 32)}`);
+    return details2.join(" / ").slice(0, 180);
   }
   if (record2.kind === "ai_news_radar") {
     const title2 = compactNotificationText(record2.changeSummary || record2.title || "VTDD \u306B\u95A2\u4FC2\u3059\u308B\u66F4\u65B0\u304C\u3042\u308A\u307E\u3059", 96);
@@ -62914,8 +62968,12 @@ function shortRepositoryName(repository) {
   return parts.length === 2 ? parts[1] : text;
 }
 function buildDashboardEventOwnerTargetUrl(event) {
-  if (normalizeDashboardEventRecord(event).kind === "ai_news_radar") {
+  const record2 = normalizeDashboardEventRecord(event);
+  if (record2.kind === "ai_news_radar") {
     return "/dashboard/news";
+  }
+  if (record2.kind === "owner_action_required" && record2.runUrl) {
+    return record2.runUrl;
   }
   return buildDashboardPullRequestUrl(event) || "/dashboard/notifications";
 }
@@ -64866,6 +64924,53 @@ function normalizeVpsRunnerDashboardEvent(payload) {
     event,
     threadId,
     chatMessage
+  };
+}
+function normalizeOwnerActionRequiredDashboardEvent(payload) {
+  const input = normalizeObject11(payload);
+  const repository = normalizeCanonicalRepositoryInput(input.repository || input.repositoryInput);
+  const actionId = normalizeDashboardEventText(input.actionId || input.action_id || input.runId || input.run_id || crypto.randomUUID());
+  const title = sanitizeDashboardChatText(input.title || "Owner action required");
+  const changeSummary = sanitizeDashboardChatText(input.summary || input.message || input.reason || input.changeSummary);
+  const issueNumber = normalizeIssue6(input.issueNumber || input.issue_number || input.relatedIssue);
+  const pullNumber = normalizeIssue6(input.pullNumber || input.pull_number);
+  const rawRunUrl = normalizeDashboardEventText(input.url || input.runUrl || input.run_url);
+  const runUrl = rawRunUrl.startsWith("/") && !rawRunUrl.startsWith("//") ? rawRunUrl : normalizeDashboardUrl(rawRunUrl) || "/dashboard/notifications";
+  const workflowName = sanitizeDashboardChatText(input.workflowName || input.workflow_name || "owner-action-required");
+  const updatedAt = normalizeIsoTimestamp(input.updatedAt || input.updated_at) || (/* @__PURE__ */ new Date()).toISOString();
+  const createdAt = normalizeIsoTimestamp(input.createdAt || input.created_at) || updatedAt;
+  if (!repository) {
+    return {
+      ok: false,
+      error: "repository_required",
+      reason: "owner action notification repository is required"
+    };
+  }
+  if (!title && !changeSummary) {
+    return {
+      ok: false,
+      error: "owner_action_required_title_required",
+      reason: "owner action notification requires a title or summary"
+    };
+  }
+  return {
+    ok: true,
+    event: normalizeDashboardEventRecord({
+      id: `owner-action-required:${repository}:${actionId}`,
+      kind: "owner_action_required",
+      repository,
+      workflowName,
+      runId: actionId,
+      status: "waiting",
+      conclusion: "action_required",
+      title,
+      changeSummary,
+      pullNumber,
+      issueNumber,
+      runUrl,
+      createdAt,
+      updatedAt
+    })
   };
 }
 function normalizeVpsRunnerDashboardStatus(value) {

--- a/worker.js
+++ b/worker.js
@@ -59577,11 +59577,20 @@ async function handleOwnerActionRequiredEventRequest(request, env) {
       reason: "dashboard event store is not configured"
     });
   }
-  await eventStore.put(event.event);
   const webPush = await dispatchDashboardWebPushForEvent(env, event.event);
+  const eventWithNotificationTruth = normalizeDashboardEventRecord({
+    ...event.event,
+    pwaNotificationStatus: webPush.ok ? "sent" : "pwa_notification_unavailable",
+    pwaNotificationError: webPush.ok ? null : webPush.error || "dashboard_web_push_unavailable",
+    pwaNotificationReason: webPush.ok ? null : webPush.reason || null,
+    pwaNotificationAttempted: webPush.attempted ?? 0,
+    pwaNotificationDelivered: webPush.delivered ?? 0,
+    updatedAt: (/* @__PURE__ */ new Date()).toISOString()
+  });
+  await eventStore.put(eventWithNotificationTruth);
   return json(webPush.ok ? 202 : webPush.status || 503, {
     ok: webPush.ok,
-    event: event.event,
+    event: eventWithNotificationTruth,
     webPush
   });
 }
@@ -63886,6 +63895,11 @@ function normalizeDashboardEventRecord(event) {
     changeSummary: changeSummary || null,
     pullNumber: normalizeIssue6(input.pullNumber) || inferPullNumberFromText(`${title} ${changeSummary}`),
     issueNumber: normalizeIssue6(input.issueNumber),
+    pwaNotificationStatus: normalizeDashboardEventText(input.pwaNotificationStatus) || null,
+    pwaNotificationError: normalizeDashboardEventText(input.pwaNotificationError) || null,
+    pwaNotificationReason: normalizeDashboardEventText(input.pwaNotificationReason) || null,
+    pwaNotificationAttempted: normalizeNonNegativeInteger2(input.pwaNotificationAttempted),
+    pwaNotificationDelivered: normalizeNonNegativeInteger2(input.pwaNotificationDelivered),
     createdAt,
     updatedAt
   };
@@ -64929,13 +64943,13 @@ function normalizeVpsRunnerDashboardEvent(payload) {
 function normalizeOwnerActionRequiredDashboardEvent(payload) {
   const input = normalizeObject11(payload);
   const repository = normalizeCanonicalRepositoryInput(input.repository || input.repositoryInput);
-  const actionId = normalizeDashboardEventText(input.actionId || input.action_id || input.runId || input.run_id || crypto.randomUUID());
-  const title = sanitizeDashboardChatText(input.title || "Owner action required");
+  const actionId = normalizeDashboardEventText(input.actionId || input.action_id || input.runId || input.run_id);
+  const title = sanitizeDashboardChatText(input.title);
   const changeSummary = sanitizeDashboardChatText(input.summary || input.message || input.reason || input.changeSummary);
   const issueNumber = normalizeIssue6(input.issueNumber || input.issue_number || input.relatedIssue);
   const pullNumber = normalizeIssue6(input.pullNumber || input.pull_number);
   const rawRunUrl = normalizeDashboardEventText(input.url || input.runUrl || input.run_url);
-  const runUrl = rawRunUrl.startsWith("/") && !rawRunUrl.startsWith("//") ? rawRunUrl : normalizeDashboardUrl(rawRunUrl) || "/dashboard/notifications";
+  const runUrl = normalizeOwnerActionRequiredRunUrl(rawRunUrl);
   const workflowName = sanitizeDashboardChatText(input.workflowName || input.workflow_name || "owner-action-required");
   const updatedAt = normalizeIsoTimestamp(input.updatedAt || input.updated_at) || (/* @__PURE__ */ new Date()).toISOString();
   const createdAt = normalizeIsoTimestamp(input.createdAt || input.created_at) || updatedAt;
@@ -64946,11 +64960,25 @@ function normalizeOwnerActionRequiredDashboardEvent(payload) {
       reason: "owner action notification repository is required"
     };
   }
+  if (!actionId) {
+    return {
+      ok: false,
+      error: "owner_action_required_action_id_required",
+      reason: "owner action notification requires a stable actionId or runId"
+    };
+  }
   if (!title && !changeSummary) {
     return {
       ok: false,
       error: "owner_action_required_title_required",
       reason: "owner action notification requires a title or summary"
+    };
+  }
+  if (!runUrl) {
+    return {
+      ok: false,
+      error: "owner_action_required_recovery_url_required",
+      reason: "owner action notification requires a same-origin /dashboard recovery url"
     };
   }
   return {
@@ -64972,6 +65000,16 @@ function normalizeOwnerActionRequiredDashboardEvent(payload) {
       updatedAt
     })
   };
+}
+function normalizeOwnerActionRequiredRunUrl(value) {
+  const text = normalizeDashboardEventText(value);
+  if (!text || text.startsWith("//")) {
+    return "";
+  }
+  if (text === "/dashboard" || text.startsWith("/dashboard/") || text.startsWith("/dashboard?")) {
+    return text;
+  }
+  return "";
 }
 function normalizeVpsRunnerDashboardStatus(value) {
   const status = normalizeDashboardEventText(value).toLowerCase();
@@ -68172,6 +68210,10 @@ function normalizeText30(value) {
 function normalizePositiveInteger9(value) {
   const number3 = Number(value);
   return Number.isInteger(number3) && number3 > 0 ? number3 : null;
+}
+function normalizeNonNegativeInteger2(value) {
+  const number3 = Number(value);
+  return Number.isInteger(number3) && number3 >= 0 ? number3 : 0;
 }
 function isSocketOpen(socket) {
   return socket?.readyState === 1 || typeof WebSocket !== "undefined" && socket?.readyState === WebSocket.OPEN;


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #637 の部分進捗として、owner action が必要になった時に machine-authenticated runtime route から Dashboard event store と PWA Web Push へ通知できる入口を追加します。
- これにより「俺に必要な操作がある場合、PWA 通知で飛ばせ」という運用要件を、少なくとも Worker runtime の通知経路として接続します。
- このPRは root helper や sudoers を実装せず、owner attention request と回復リンクだけを扱います。

## Satisfied Success Criteria

- `POST /v2/events/owner-action-required` を gateway machine auth 必須の route として追加しました。
- `owner_action_required` Dashboard event を保存し、保存済み PWA subscription へ Web Push を試行します。
- Web Push title/body/url/sourceEventId を owner action 用に分離し、通知タイトルを `要対応:` から始めます。
- 未認証 request が push を送らないこと、認証済み request が暗号化 Web Push payload と event store に到達することを unit test で検証しました。
- recovery URL は same-origin `/dashboard` URL のみに限定し、外部 URL / protocol-relative URL / actionId 欠落を 422 で拒否します。
- push delivery 失敗時も `pwa_notification_unavailable` truth、attempted/delivered 件数、recovery URL を event store に残します。
- #637 の lifecycle doc に、この route が通知入口であり privileged execution 権限ではないことを明記しました。

## Unsatisfied Success Criteria

- Dashboard Butler の自然言語 intent からこの route を呼ぶ接続は未実装です。
- Custom GPT Action Schema 露出は未実装です。
- VPS root-owned helper、capability manifest の実ファイル配置、sudoers/systemd 連携は未実装です。
- passkey proposal UI と scoped approval grant から helper 実行へ進む runtime path は未実装です。
- iPhone 実機 PWA での live delivery E2E は未実施です。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #637
- Implementing Success Criteria: owner action required 時に PWA 通知を飛ばす machine-authenticated Worker route と Dashboard event / Web Push 接続。
- Explicit Non-goals: root helper install、sudoers/systemd mutation、credential mutation、permission mutation、deploy、VPS command execution、Issue close は行いません。
- Expected touched files/routes/workflows: `src/worker/runtime.js`, `worker.js`, `test/worker.test.js`, `docs/butler/vps-privileged-maintenance-capability-lifecycle.md`, route `POST /v2/events/owner-action-required`。
- Affected Issues: Issue #637 のみ。Issue #631 は完了済み blocker の背景としてのみ参照し、このPRでは変更しません。
- Affected PRs: なし。新規PRとして main へ出します。
- Affected workflows: GitHub Actions reviewer/test workflows は通常どおり。workflow 定義は変更しません。
- Affected runtime/operator surfaces: Worker runtime、Dashboard notification center、PWA Web Push、machine gateway auth。owner/operator passkey surface は未変更です。
- What may break if we patch narrowly: 通知 route だけでは Butler/VPS helper 実行は完結しないため、PR本文で incomplete と明記します。
- Unknowns to investigate before coding: route の event copy、safe relative URL handling、unauthenticated request が push を送らないこと、push failure truth が event store に残ることを test で確認済み。
- Validation needed: `npm run build:worker`, `node --test test/worker.test.js`, `npm test`。
- Stop condition: root helper、sudoers、permission mutation、deploy、Action Schema 更新が必要になった場合はこのPRでは止め、別スライスまたは passkey approval へ分離します。

## Execution Queue Delta

- Queue position before: Issue #637 は active issue execution queue の高優先 root blocker で、前PR #639 の core manifest contract の次スライスです。
- Preemption decision: ROOT として継続します。新しい owner 入力は「必要操作はPWA通知」要件の明確化であり、並行開発への preemption ではありません。
- Queue delta: Issue #637 の `Now` を owner-action PWA notification route まで前進させます。root helper / passkey execution / live iPhone E2E は Evidence Gaps として残します。
- Why this PR is next: owner が外出中でも必要操作を把握できなければ privileged maintenance lifecycle が詰まるため、helper 実行前に通知入口を先に作る必要があります。
- Active Issues not downscoped: Active Issues は縮小しません。このPRで扱わない active Issue と #637 の残スコープは未完了として残します。

## File / Line Hypotheses

- file: `src/worker/runtime.js`
  - hypothesis: 既存の Dashboard Web Push と event store 経路に `owner_action_required` kind を追加すれば、PWA 通知入口を最小差分で接続できる。
  - risk if changed narrowly: helper 実行まで完了したように見せるリスクがあるため、route は attention request のみとし、doc/PRで incomplete を明記する。
  - validation: unauthenticated request、authenticated request、payload copy、target url、event store 保存を worker test で検証する。
  - related Issue: Issue #637
- file: `test/worker.test.js`
  - hypothesis: Web Push payload を復号して title/body/url を検証すれば、通知が単に status だけでなく owner-facing copy まで届くことを確認できる。
  - risk if changed narrowly: live iPhone delivery は unit では証明できないため、Butler Completion Contract では E2E 未実施とする。
  - validation: `node --test test/worker.test.js` と `npm test`。
  - related Issue: Issue #637

## Hypothesis Retrospective

- expected: gateway auth 付き route から `owner_action_required` event が保存され、PWA Web Push payload が `要対応:` title と recovery URL を持つ。
- actual: unit test で unauthenticated request は 401 かつ push なし、authenticated request は 202、Web Push delivered 1、復号 payload と event store 保存を確認。reviewer request_changes 後に、外部URL拒否、protocol-relative URL拒否、actionId必須、push失敗時の `pwa_notification_unavailable` 保存を追加検証しました。
- mismatch: 実機 iPhone PWA delivery と Butler natural-language entrypoint はこのPRでは未接続。
- lesson: #637 は helper より前に owner attention delivery を独立スライスとして持つべき。ユーザー操作が必要な時に chat だけへ残すと VTDD の iPhone-first 要件を満たさない。
- should become RAG candidate: はい。owner action required は PWA 通知を必須にし、chat-only blocker 報告を不足として扱う。

## Verification Evidence

- Unit: `node --test test/worker.test.js` passed. 220 tests passed in this file.
- Integration: `npm run build:worker` passed and regenerated `worker.js`.
- E2E: `npm test` passed: 1026 passed, 1 skipped, 0 failed; self-parity and generated-worker checks passed.
- Manual: PR本文作成前に `git diff` で変更範囲が Issue #637 の通知スライスに収まることを確認。
- Evidence path/link: `test/worker.test.js`, `docs/butler/vps-privileged-maintenance-capability-lifecycle.md`

## Butler Completion Contract

- Owner goal: owner に必要操作が発生したら、chat だけでなく PWA 通知で iPhone/iPad に飛ばす。
- Butler entrypoint: このPRでは machine event route のみ。Dashboard Butler natural-language intent からの呼び出しは未接続です。
- Action Schema exposure: このPRでは未変更です。Custom GPT Action Schema 露出は未実装です。
- Runtime path: `POST /v2/events/owner-action-required` -> gateway auth -> same-origin `/dashboard` recovery URL validation -> Web Push dispatch -> Dashboard event store with notification truth。
- Runner/runtime truth: route response に event と webPush result を返し、event store に `owner_action_required` record と `sent` / `pwa_notification_unavailable` truth を残します。
- Authority boundary: 新しい high-risk authority は追加しません。この route は通知と recovery link のみで、privileged execution は passkey approval と root-owned helper が別途必要です。
- E2E evidence: このPRでは live iPhone PWA E2E は未実施。unit/integration で Web Push payload と event store 到達を検証しました。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 未実施。deploy はこのPRの非目標です。
- Custom GPT Action Schema update: 未実施。このPRでは Worker machine route のみです。
- Custom GPT Instructions update: 未実施。
- iPhone Butler live E2E: 未実施。live PWA delivery は #637 の残 evidence gap です。

## Related Constitution Rules

- Butler は iPhone/iPad-first であり、owner が Mac を開かなくても必要操作を把握できる必要がある。
- 高リスク操作は scoped passkey approval が必要であり、通知 route は権限昇格や permission mutation を実行しない。
- 実装PRは Draft にしない。blocker はPR本文、checks、review、または hold label で明示する。
- active Issues は縮小しない。部分進捗は incomplete として残スコープを明記する。

## Out-of-scope but NOT implemented

- VPS root-owned helper の実装。
- sudoers / systemd / package install など VPS 権限変更。
- passkey proposal UI と helper execution dispatch。
- Custom GPT Action Schema 追加。
- live iPhone PWA E2E。
- Issue #637 close。

## Extra changes (if any)

- Codex fallback reviewer の request_changes に対応し、外部URL誘導リスク、push delivery unavailable truth、不十分な title/actionId 要件を修正しました。

<!-- VTDD metadata -->
- Issue: Issue #637
- Execution ID: issue-637-owner-action-pwa-notification
- Goal: owner action required PWA notification route
