### PR TITLE
#637 app-server approval requestをPWA通知へ接続

### DIFF
--- a/docs/butler/vps-privileged-maintenance-capability-lifecycle.md
+++ b/docs/butler/vps-privileged-maintenance-capability-lifecycle.md
@@ -111,6 +111,11 @@ The recovery link for this route must be a same-origin `/dashboard` URL. The
 route must reject external URLs, protocol-relative URLs, and underspecified
 requests that lack a stable action id or owner-facing title/summary.
 
+The Dashboard app-server bridge must call this route when Codex app-server asks
+for command, file-change, patch, or permission approval. The bridge still
+declines the app-server request mechanically; the PWA notification is an owner
+attention signal, not an execution grant.
+
 When owner action is required, the runtime must attempt PWA notification and
 report send result truth. If push delivery is unavailable, Butler must mark
 `pwa_notification_unavailable` and still preserve the recovery link in

--- a/scripts/run-dashboard-app-server-bridge.mjs
+++ b/scripts/run-dashboard-app-server-bridge.mjs
@@ -401,6 +401,7 @@ export function buildOwnerActionRequiredPayloadForAppServerApproval({
     "app-server-approval",
     dashboardThreadId || request.threadId || "dashboard-thread",
     codexThreadId || request.codexThreadId || "codex-thread",
+    method || "approval-request",
     messageId || method || "request"
   ]
     .map((part) => sanitizeBridgeActionId(part))
@@ -438,19 +439,29 @@ export async function postOwnerActionRequiredEvent({
       reason: "runtimeUrl, token, payload, and fetch are required"
     };
   }
-  const url = new URL("/v2/events/owner-action-required", runtimeUrl);
-  const response = await fetchImpl(url, {
-    method: "POST",
-    headers: {
-      authorization: `Bearer ${token}`,
-      "content-type": "application/json"
-    },
-    body: JSON.stringify(payload)
-  });
-  return {
-    ok: response.ok,
-    status: response.status
-  };
+  try {
+    const url = new URL("/v2/events/owner-action-required", runtimeUrl);
+    const response = await fetchImpl(url, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${token}`,
+        "content-type": "application/json"
+      },
+      body: JSON.stringify(payload)
+    });
+    return {
+      ok: response.ok,
+      status: response.status,
+      reason: response.ok ? "accepted" : `runtime returned HTTP ${response.status}`
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      status: 0,
+      error: "owner_action_required_post_failed",
+      reason: sanitizeBridgeError(error)
+    };
+  }
 }
 
 export function mapAppServerNotificationToDashboardEvent(message, context = {}) {
@@ -557,6 +568,7 @@ export class JsonLineAppServerClient {
     this.buffer = "";
     this.child = null;
     this.onApprovalRequest = typeof onApprovalRequest === "function" ? onApprovalRequest : null;
+    this.approvalRequestTasks = new Set();
   }
 
   start() {
@@ -621,6 +633,29 @@ export class JsonLineAppServerClient {
     };
   }
 
+  notifyApprovalRequest(input) {
+    if (!this.onApprovalRequest) {
+      return null;
+    }
+    const task = Promise.resolve()
+      .then(() => this.onApprovalRequest(input))
+      .catch((error) => {
+        this.lastApprovalRequestError = sanitizeBridgeError(error);
+        return {
+          ok: false,
+          error: "approval_request_handler_failed",
+          reason: this.lastApprovalRequestError
+        };
+      });
+    this.approvalRequestTasks.add(task);
+    task.finally(() => this.approvalRequestTasks.delete(task));
+    return task;
+  }
+
+  async drainApprovalRequests() {
+    await Promise.allSettled([...this.approvalRequestTasks]);
+  }
+
   handleChunk(chunk) {
     this.buffer += chunk;
     for (;;) {
@@ -647,9 +682,7 @@ export class JsonLineAppServerClient {
       }
       const approvalResponse = buildAppServerRequestApprovalResponse(message);
       if (approvalResponse) {
-        if (this.onApprovalRequest) {
-          void this.onApprovalRequest({ message, approvalResponse });
-        }
+        this.notifyApprovalRequest({ message, approvalResponse });
         this.write(approvalResponse);
         continue;
       }
@@ -798,12 +831,24 @@ export async function handleDashboardTurnRequest({
           if (!payload) {
             return;
           }
-          await postOwnerActionRequiredEvent({
+          const result = await postOwnerActionRequiredEvent({
             runtimeUrl,
             token,
             payload,
             fetchImpl
           });
+          if (!result.ok) {
+            await sendDashboardEvent({
+              type: "app_server_turn_failed",
+              schema: DEFAULT_SCHEMA,
+              threadId: dashboardThreadId,
+              codexThreadId: codexThreadId || null,
+              repository: request.repository || null,
+              relatedIssue: request.relatedIssue || request.issueNumber || null,
+              status: "owner_action_notification_failed",
+              text: `owner action PWA通知を送信できませんでした。${result.reason || result.error || "runtime event route failed"}`
+            });
+          }
         })
       : () => {};
   cleanupNotifications = () => {

--- a/scripts/run-dashboard-app-server-bridge.mjs
+++ b/scripts/run-dashboard-app-server-bridge.mjs
@@ -285,6 +285,23 @@ function normalizeBridgeText(value) {
   return String(value ?? "").replace(/[\u0000-\u001f\u007f]/g, " ").trim().slice(0, 500);
 }
 
+function normalizeBridgeRepository(value) {
+  const text = normalizeBridgeText(value).toLowerCase();
+  return /^[a-z0-9_.-]+\/[a-z0-9_.-]+$/.test(text) ? text : "";
+}
+
+function normalizePositiveInteger(value) {
+  const number = Number(value);
+  return Number.isInteger(number) && number > 0 ? number : null;
+}
+
+function sanitizeBridgeActionId(value) {
+  return normalizeBridgeText(value)
+    .replace(/[^a-zA-Z0-9._:-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 80);
+}
+
 function sanitizeBridgeFilename(value) {
   return (
     normalizeBridgeText(value)
@@ -366,6 +383,73 @@ export function buildAppServerRequestApprovalResponse(message) {
       code: -32601,
       message: `Dashboard bridge does not support app-server request method: ${method}`
     }
+  };
+}
+
+export function buildOwnerActionRequiredPayloadForAppServerApproval({
+  message,
+  request = {},
+  codexThreadId = "",
+  dashboardThreadId = "",
+  approvalResponse = null
+} = {}) {
+  const method = String(message?.method || "");
+  const repository = normalizeBridgeRepository(request.repository);
+  const relatedIssue = normalizePositiveInteger(request.relatedIssue || request.issueNumber);
+  const messageId = String(message?.id ?? "");
+  const actionId = [
+    "app-server-approval",
+    dashboardThreadId || request.threadId || "dashboard-thread",
+    codexThreadId || request.codexThreadId || "codex-thread",
+    messageId || method || "request"
+  ]
+    .map((part) => sanitizeBridgeActionId(part))
+    .filter(Boolean)
+    .join(":");
+  if (!repository || !actionId) {
+    return null;
+  }
+  const decision = approvalResponse?.result?.decision || approvalResponse?.error?.message || "declined";
+  return {
+    repository,
+    actionId,
+    title: "Codex app-server approval request",
+    summary: `Dashboard bridge declined ${method || "approval request"}; owner attention may be required.`,
+    issueNumber: relatedIssue || undefined,
+    workflowName: "dashboard-app-server-bridge",
+    url: "/dashboard/notifications?focus=owner-action",
+    source: {
+      method,
+      decision: String(decision)
+    }
+  };
+}
+
+export async function postOwnerActionRequiredEvent({
+  runtimeUrl = "",
+  token = "",
+  payload = null,
+  fetchImpl = globalThis.fetch
+} = {}) {
+  if (!runtimeUrl || !token || !payload || typeof fetchImpl !== "function") {
+    return {
+      ok: false,
+      skipped: true,
+      reason: "runtimeUrl, token, payload, and fetch are required"
+    };
+  }
+  const url = new URL("/v2/events/owner-action-required", runtimeUrl);
+  const response = await fetchImpl(url, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${token}`,
+      "content-type": "application/json"
+    },
+    body: JSON.stringify(payload)
+  });
+  return {
+    ok: response.ok,
+    status: response.status
   };
 }
 
@@ -463,7 +547,7 @@ export function matchesAppServerTurnNotification(message, context = {}) {
 }
 
 export class JsonLineAppServerClient {
-  constructor({ command = "codex", args = ["app-server", "--listen", "stdio://"], cwd = process.cwd() } = {}) {
+  constructor({ command = "codex", args = ["app-server", "--listen", "stdio://"], cwd = process.cwd(), onApprovalRequest = null } = {}) {
     this.command = command;
     this.args = args;
     this.cwd = cwd;
@@ -472,6 +556,7 @@ export class JsonLineAppServerClient {
     this.notificationHandlers = new Set();
     this.buffer = "";
     this.child = null;
+    this.onApprovalRequest = typeof onApprovalRequest === "function" ? onApprovalRequest : null;
   }
 
   start() {
@@ -528,6 +613,14 @@ export class JsonLineAppServerClient {
     return () => this.notificationHandlers.delete(handler);
   }
 
+  setApprovalRequestHandler(handler) {
+    const previous = this.onApprovalRequest;
+    this.onApprovalRequest = typeof handler === "function" ? handler : null;
+    return () => {
+      this.onApprovalRequest = previous;
+    };
+  }
+
   handleChunk(chunk) {
     this.buffer += chunk;
     for (;;) {
@@ -554,6 +647,9 @@ export class JsonLineAppServerClient {
       }
       const approvalResponse = buildAppServerRequestApprovalResponse(message);
       if (approvalResponse) {
+        if (this.onApprovalRequest) {
+          void this.onApprovalRequest({ message, approvalResponse });
+        }
         this.write(approvalResponse);
         continue;
       }
@@ -689,9 +785,31 @@ export async function handleDashboardTurnRequest({
     }
     void sendDashboardEvent(event);
   });
+  const restoreApprovalRequestHandler =
+    typeof appServer.setApprovalRequestHandler === "function"
+      ? appServer.setApprovalRequestHandler(async ({ message, approvalResponse }) => {
+          const payload = buildOwnerActionRequiredPayloadForAppServerApproval({
+            message,
+            request,
+            codexThreadId,
+            dashboardThreadId,
+            approvalResponse
+          });
+          if (!payload) {
+            return;
+          }
+          await postOwnerActionRequiredEvent({
+            runtimeUrl,
+            token,
+            payload,
+            fetchImpl
+          });
+        })
+      : () => {};
   cleanupNotifications = () => {
     clearTimeout(lateCompletionCleanupHandle);
     unsubscribe();
+    restoreApprovalRequestHandler();
   };
   try {
     const materializedMediaReferences = await materializeDashboardMediaReferences({

--- a/test/dashboard-app-server-bridge.test.js
+++ b/test/dashboard-app-server-bridge.test.js
@@ -283,7 +283,7 @@ test("dashboard app-server bridge declines write, patch, permission, and unsafe 
   );
 });
 
-test("dashboard app-server bridge writes JSON-RPC responses for app-server approval requests", () => {
+test("dashboard app-server bridge writes JSON-RPC responses for app-server approval requests", async () => {
   const client = new JsonLineAppServerClient({ command: "unused" });
   const writes = [];
   const notifications = [];
@@ -322,6 +322,7 @@ test("dashboard app-server bridge writes JSON-RPC responses for app-server appro
       })
     ].join("\n") + "\n"
   );
+  await client.drainApprovalRequests();
 
   assert.deepEqual(writes, [
     { id: 0, result: { decision: "decline" } },
@@ -338,6 +339,35 @@ test("dashboard app-server bridge writes JSON-RPC responses for app-server appro
   assert.deepEqual(approvals[0].approvalResponse, { id: 0, result: { decision: "decline" } });
   assert.equal(notifications.length, 1);
   assert.equal(notifications[0].method, "turn/started");
+});
+
+test("dashboard app-server bridge captures approval notification handler failures", async () => {
+  const client = new JsonLineAppServerClient({
+    command: "unused",
+    onApprovalRequest: async () => {
+      throw new Error("runtime unavailable");
+    }
+  });
+  const writes = [];
+  client.child = {
+    stdin: {
+      write(chunk) {
+        writes.push(JSON.parse(String(chunk).trim()));
+      }
+    },
+    kill() {}
+  };
+
+  client.handleChunk(
+    JSON.stringify({
+      id: 7,
+      method: "item/commandExecution/requestApproval",
+      params: {}
+    }) + "\n"
+  );
+  await client.drainApprovalRequests();
+  assert.deepEqual(writes, [{ id: 7, result: { decision: "decline" } }]);
+  assert.equal(client.lastApprovalRequestError, "runtime unavailable");
 });
 
 test("dashboard app-server bridge builds owner-action-required payloads for approval requests", () => {
@@ -364,7 +394,7 @@ test("dashboard app-server bridge builds owner-action-required payloads for appr
     }
   });
   assert.equal(payload.repository, "marushu/vtdd-v2-p");
-  assert.equal(payload.actionId, "app-server-approval:dashboard-main:codex-thread-1:44");
+  assert.equal(payload.actionId, "app-server-approval:dashboard-main:codex-thread-1:item-permissions-requestApproval:44");
   assert.equal(payload.issueNumber, 637);
   assert.equal(payload.workflowName, "dashboard-app-server-bridge");
   assert.equal(payload.url, "/dashboard/notifications?focus=owner-action");
@@ -385,7 +415,7 @@ test("dashboard app-server bridge posts owner-action-required event with bearer 
     token: "runtime-token",
     payload: {
       repository: "marushu/vtdd-v2-p",
-      actionId: "app-server-approval:dashboard-main:codex-thread-1:44",
+      actionId: "app-server-approval:dashboard-main:codex-thread-1:item-permissions-requestApproval:44",
       title: "Codex app-server approval request",
       summary: "Dashboard bridge declined item/permissions/requestApproval; owner attention may be required.",
       issueNumber: 637,
@@ -401,6 +431,23 @@ test("dashboard app-server bridge posts owner-action-required event with bearer 
   assert.equal(calls[0].url, "https://runtime.example/v2/events/owner-action-required");
   assert.equal(calls[0].init.headers.authorization, "Bearer runtime-token");
   assert.equal(JSON.parse(calls[0].init.body).issueNumber, 637);
+});
+
+test("dashboard app-server bridge returns structured owner-action-required post failures", async () => {
+  const failed = await postOwnerActionRequiredEvent({
+    runtimeUrl: "not a url",
+    token: "runtime-token",
+    payload: {
+      repository: "marushu/vtdd-v2-p",
+      actionId: "app-server-approval",
+      title: "Codex app-server approval request",
+      summary: "approval needed",
+      url: "/dashboard/notifications?focus=owner-action"
+    },
+    fetchImpl: async () => new Response(null, { status: 202 })
+  });
+  assert.equal(failed.ok, false);
+  assert.equal(failed.error, "owner_action_required_post_failed");
 });
 
 test("dashboard app-server bridge resolves pending JSON-RPC response id zero", async () => {
@@ -614,10 +661,79 @@ test("dashboard app-server bridge posts owner-action-required when app-server re
   assert.equal(runtimeCalls[0].url, "https://runtime.example/v2/events/owner-action-required");
   const body = JSON.parse(runtimeCalls[0].init.body);
   assert.equal(body.repository, "marushu/vtdd-v2-p");
-  assert.equal(body.actionId, "app-server-approval:dashboard-main:codex-thread-approval:7");
+  assert.equal(body.actionId, "app-server-approval:dashboard-main:codex-thread-approval:item-commandExecution-requestApproval:7");
   assert.equal(body.issueNumber, 637);
   assert.equal(body.url, "/dashboard/notifications?focus=owner-action");
   assert.equal(events.at(-1).type, "app_server_reply");
+});
+
+test("dashboard app-server bridge records owner-action notification failure in dashboard thread", async () => {
+  const events = [];
+  let approvalHandler = null;
+  const handlers = new Set();
+  let nextId = 1;
+  const appServer = {
+    nextRequestId() {
+      const id = nextId;
+      nextId += 1;
+      return id;
+    },
+    onNotification(handler) {
+      handlers.add(handler);
+      return () => handlers.delete(handler);
+    },
+    setApprovalRequestHandler(handler) {
+      approvalHandler = handler;
+      return () => {
+        approvalHandler = null;
+      };
+    },
+    async request(message) {
+      if (message.method === "thread/start") {
+        return { thread: { id: "codex-thread-failed-notify" } };
+      }
+      if (message.method === "turn/start") {
+        await approvalHandler({
+          message: {
+            id: 8,
+            method: "item/permissions/requestApproval",
+            params: {}
+          },
+          approvalResponse: { id: 8, error: { code: -32001, message: "denied" } }
+        });
+        for (const handler of handlers) {
+          handler({
+            method: "turn/completed",
+            params: {
+              threadId: "codex-thread-failed-notify",
+              turn: { id: "turn-failed-notify", status: "completed" }
+            }
+          });
+        }
+        return { turn: { id: "turn-failed-notify" } };
+      }
+      throw new Error(`unexpected method ${message.method}`);
+    }
+  };
+
+  await handleDashboardTurnRequest({
+    request: {
+      threadId: "dashboard-main",
+      repository: "marushu/vtdd-v2-p",
+      relatedIssue: 637,
+      text: "権限が必要な確認をして"
+    },
+    appServer,
+    sendDashboardEvent: async (event) => events.push(event),
+    runtimeUrl: "https://runtime.example",
+    token: "runtime-token",
+    fetchImpl: async () => new Response(null, { status: 503 })
+  });
+
+  const failure = events.find((event) => event.status === "owner_action_notification_failed");
+  assert.ok(failure);
+  assert.equal(failure.type, "app_server_turn_failed");
+  assert.match(failure.text, /owner action PWA通知を送信できませんでした/);
 });
 
 test("dashboard app-server bridge passes traffic-control context to codex app-server turns", async () => {

--- a/test/dashboard-app-server-bridge.test.js
+++ b/test/dashboard-app-server-bridge.test.js
@@ -6,6 +6,7 @@ import test from "node:test";
 import {
   buildDashboardAppServerBridgeEndpoint,
   buildAppServerInitializeRequest,
+  buildOwnerActionRequiredPayloadForAppServerApproval,
   buildAppServerRequestApprovalResponse,
   buildAppServerSandboxOverrides,
   buildAppServerThreadResumeRequest,
@@ -21,6 +22,7 @@ import {
   matchesAppServerTurnNotification,
   materializeDashboardMediaReferences,
   parseBridgeArgs,
+  postOwnerActionRequiredEvent,
   runDashboardAppServerBridge
 } from "../scripts/run-dashboard-app-server-bridge.mjs";
 
@@ -285,6 +287,7 @@ test("dashboard app-server bridge writes JSON-RPC responses for app-server appro
   const client = new JsonLineAppServerClient({ command: "unused" });
   const writes = [];
   const notifications = [];
+  const approvals = [];
   client.child = {
     stdin: {
       write(chunk) {
@@ -294,6 +297,9 @@ test("dashboard app-server bridge writes JSON-RPC responses for app-server appro
     kill() {}
   };
   client.onNotification((message) => notifications.push(message));
+  client.setApprovalRequestHandler(({ message, approvalResponse }) => {
+    approvals.push({ message, approvalResponse });
+  });
 
   client.handleChunk(
     [
@@ -327,8 +333,74 @@ test("dashboard app-server bridge writes JSON-RPC responses for app-server appro
       }
     }
   ]);
+  assert.equal(approvals.length, 2);
+  assert.equal(approvals[0].message.method, "item/commandExecution/requestApproval");
+  assert.deepEqual(approvals[0].approvalResponse, { id: 0, result: { decision: "decline" } });
   assert.equal(notifications.length, 1);
   assert.equal(notifications[0].method, "turn/started");
+});
+
+test("dashboard app-server bridge builds owner-action-required payloads for approval requests", () => {
+  const payload = buildOwnerActionRequiredPayloadForAppServerApproval({
+    message: {
+      id: 44,
+      method: "item/permissions/requestApproval",
+      params: { reason: "needs permission escalation" }
+    },
+    request: {
+      threadId: "dashboard-main",
+      codexThreadId: "codex-thread-1",
+      repository: "marushu/vtdd-v2-p",
+      relatedIssue: 637
+    },
+    dashboardThreadId: "dashboard-main",
+    codexThreadId: "codex-thread-1",
+    approvalResponse: {
+      id: 44,
+      error: {
+        code: -32001,
+        message: "Dashboard bridge does not grant app-server permission escalation"
+      }
+    }
+  });
+  assert.equal(payload.repository, "marushu/vtdd-v2-p");
+  assert.equal(payload.actionId, "app-server-approval:dashboard-main:codex-thread-1:44");
+  assert.equal(payload.issueNumber, 637);
+  assert.equal(payload.workflowName, "dashboard-app-server-bridge");
+  assert.equal(payload.url, "/dashboard/notifications?focus=owner-action");
+  assert.match(payload.summary, /item\/permissions\/requestApproval/);
+  assert.equal(
+    buildOwnerActionRequiredPayloadForAppServerApproval({
+      message: { id: 1, method: "item/commandExecution/requestApproval" },
+      request: { repository: "", threadId: "dashboard-main" }
+    }),
+    null
+  );
+});
+
+test("dashboard app-server bridge posts owner-action-required event with bearer auth", async () => {
+  const calls = [];
+  const result = await postOwnerActionRequiredEvent({
+    runtimeUrl: "https://runtime.example",
+    token: "runtime-token",
+    payload: {
+      repository: "marushu/vtdd-v2-p",
+      actionId: "app-server-approval:dashboard-main:codex-thread-1:44",
+      title: "Codex app-server approval request",
+      summary: "Dashboard bridge declined item/permissions/requestApproval; owner attention may be required.",
+      issueNumber: 637,
+      workflowName: "dashboard-app-server-bridge",
+      url: "/dashboard/notifications?focus=owner-action"
+    },
+    fetchImpl: async (url, init) => {
+      calls.push({ url: String(url), init });
+      return new Response(null, { status: 202 });
+    }
+  });
+  assert.equal(result.ok, true);
+  assert.equal(calls[0].url, "https://runtime.example/v2/events/owner-action-required");
+  assert.equal(calls[0].init.headers.authorization, "Bearer runtime-token");
+  assert.equal(JSON.parse(calls[0].init.body).issueNumber, 637);
 });
 
 test("dashboard app-server bridge resolves pending JSON-RPC response id zero", async () => {
@@ -467,6 +539,85 @@ test("dashboard app-server bridge handles a fresh dashboard turn through thread/
   assert.equal(events[1].type, "app_server_reply_delta");
   assert.equal(events[2].type, "app_server_reply");
   assert.equal(events[2].text, "今日は2026年5月22日です。");
+});
+
+test("dashboard app-server bridge posts owner-action-required when app-server requests approval during a turn", async () => {
+  const events = [];
+  const runtimeCalls = [];
+  const handlers = new Set();
+  let nextId = 1;
+  let approvalHandler = null;
+  const appServer = {
+    nextRequestId() {
+      const id = nextId;
+      nextId += 1;
+      return id;
+    },
+    onNotification(handler) {
+      handlers.add(handler);
+      return () => handlers.delete(handler);
+    },
+    setApprovalRequestHandler(handler) {
+      approvalHandler = handler;
+      return () => {
+        approvalHandler = null;
+      };
+    },
+    async request(message) {
+      if (message.method === "thread/start") {
+        return { thread: { id: "codex-thread-approval" } };
+      }
+      if (message.method === "turn/start") {
+        await approvalHandler({
+          message: {
+            id: 7,
+            method: "item/commandExecution/requestApproval",
+            params: { commandActions: [{ type: "read", path: "package.json" }] }
+          },
+          approvalResponse: { id: 7, result: { decision: "decline" } }
+        });
+        for (const handler of handlers) {
+          handler({
+            method: "turn/completed",
+            params: {
+              threadId: "codex-thread-approval",
+              turn: { id: "turn-approval", status: "completed" }
+            }
+          });
+        }
+        return { turn: { id: "turn-approval" } };
+      }
+      throw new Error(`unexpected method ${message.method}`);
+    }
+  };
+
+  await handleDashboardTurnRequest({
+    request: {
+      threadId: "dashboard-main",
+      codexThreadId: null,
+      repository: "marushu/vtdd-v2-p",
+      relatedIssue: 637,
+      text: "VPS の状態を見て"
+    },
+    appServer,
+    sendDashboardEvent: async (event) => events.push(event),
+    cwd: "/repo",
+    runtimeUrl: "https://runtime.example",
+    token: "runtime-token",
+    fetchImpl: async (url, init) => {
+      runtimeCalls.push({ url: String(url), init });
+      return new Response(JSON.stringify({ ok: true }), { status: 202 });
+    }
+  });
+
+  assert.equal(runtimeCalls.length, 1);
+  assert.equal(runtimeCalls[0].url, "https://runtime.example/v2/events/owner-action-required");
+  const body = JSON.parse(runtimeCalls[0].init.body);
+  assert.equal(body.repository, "marushu/vtdd-v2-p");
+  assert.equal(body.actionId, "app-server-approval:dashboard-main:codex-thread-approval:7");
+  assert.equal(body.issueNumber, 637);
+  assert.equal(body.url, "/dashboard/notifications?focus=owner-action");
+  assert.equal(events.at(-1).type, "app_server_reply");
 });
 
 test("dashboard app-server bridge passes traffic-control context to codex app-server turns", async () => {


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #637 の部分進捗として、Dashboard app-server bridge が Codex app-server の approval request を受けた時、単に decline するだけでなく `owner-action-required` route へ通知を送る接続を追加します。
- owner が iPhone/PWA から離れていても、app-server が権限待ちに入った事実を PWA 通知で受け取れるようにします。
- このPRは approval を許可せず、bridge は引き続き app-server command / file-change / patch / permission escalation を機械的に拒否します。

## Satisfied Success Criteria

- Dashboard app-server bridge に owner-action-required payload builder を追加しました。
- app-server approval request の JSON-RPC response 書き込み時に、同じ request から owner-action-required 通知 payload を組み立てます。
- `VTDD_RUNTIME_URL` / `VTDD_GATEWAY_BEARER_TOKEN` 由来の既存 runtime/token で `POST /v2/events/owner-action-required` へ送ります。
- repository が解決できない場合は通知 payload を作らず、raw token や secret を保存・表示しません。
- bridge unit test で bearer auth、payload、turn 中 approval request から runtime event route へ到達することを検証しました。
- 通知 handler の失敗を fire-and-forget の unhandled rejection にせず、bridge 内で捕捉できるようにしました。
- owner-action-required POST の失敗は structured result として返し、Dashboard thread に `owner_action_notification_failed` truth を残します。
- owner action `actionId` に approval method を含め、同一thread内の request 衝突とノイズを減らしました。

## Unsatisfied Success Criteria

- VPS root-owned helper と capability manifest の実配置は未実装です。
- passkey proposal UI から helper execution へ進む path は未実装です。
- Custom GPT Action Schema 露出は未実装です。
- live iPhone PWA delivery E2E は未実施です。
- Issue #637 全体完了ではありません。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #637
- Implementing Success Criteria: Dashboard app-server approval request を owner-action-required PWA 通知経路へ接続する。
- Explicit Non-goals: approval許可、権限昇格、root helper、sudoers/systemd mutation、deploy、credential mutation、permission mutation、Issue close は行いません。
- Expected touched files/routes/workflows: `scripts/run-dashboard-app-server-bridge.mjs`, `test/dashboard-app-server-bridge.test.js`, `docs/butler/vps-privileged-maintenance-capability-lifecycle.md`。
- Affected Issues: Issue #637 のみ。Issue #450/#590 の app-server bridge と隣接しますが、このPRでは権限待ち通知だけを扱います。
- Affected PRs: なし。新規PRとして main へ出します。
- Affected workflows: GitHub Actions workflow 定義は変更しません。通常の test / guarded-policy / reviewer を通します。
- Affected runtime/operator surfaces: Dashboard app-server bridge、owner-action-required event route、PWA notification surface。
- What may break if we patch narrowly: approval request を通知しても、実際の high-risk operation はまだ実行できません。PR本文で incomplete と明記します。
- Unknowns to investigate before coding: app-server approval request の handler 位置、runtime route POST の bearer auth、repository 未解決時の扱いを unit test で確認済み。
- Validation needed: `node --test test/dashboard-app-server-bridge.test.js`, `npm test`。
- Stop condition: bridge が approval を許可する、権限変更する、deploy/credential/permission mutation が必要になる場合はこのPRでは止めます。

## Execution Queue Delta

- Queue position before: Issue #637 は `Now` の root blocker で、PR #640 の owner-action-required route 追加後の次スライスです。
- Preemption decision: ROOT として継続します。新しい並行 Issue へは移らず、#637 の通知接続を前進させます。
- Queue delta: Issue #637 の `Now` を app-server approval request から PWA notification route へ接続するところまで進めます。helper execution / passkey proposal / live E2E は Evidence Gaps として残します。
- Why this PR is next: route があっても app-server approval 待ちで鳴らなければ、owner は iPhone で必要操作を知れません。helper 実行前に owner attention delivery を実運用に接続する必要があります。
- Active Issues not downscoped: Active Issues は縮小しません。このPRで扱わない #637 残スコープと他 active Issue は未完了として残します。

## File / Line Hypotheses

- file: `scripts/run-dashboard-app-server-bridge.mjs`
  - hypothesis: JSON-RPC approval request response を書く直前に owner-action-required route へ POST すれば、approval を許可せず owner attention だけ通知できる。
  - risk if changed narrowly: 通知を execution grant と誤解させるリスクがあるため、bridge は decline を維持し、doc/PRで attention signal と明記する。
  - validation: approval response、payload builder、bearer auth POST、turn 中 approval request の unit test。
  - related Issue: Issue #637
- file: `test/dashboard-app-server-bridge.test.js`
  - hypothesis: app-server approval request から runtime event route への POST を unit test すれば、PWA route が実運用の待ち状態に接続されたことを確認できる。
  - risk if changed narrowly: live PWA delivery はこのtestでは証明できないため、completion status は incomplete とする。
  - validation: `node --test test/dashboard-app-server-bridge.test.js`, `npm test`。
  - related Issue: Issue #637

## Hypothesis Retrospective

- expected: app-server bridge が approval request を decline しつつ、owner-action-required event route へ bearer auth 付きで通知 payload を送る。通知失敗時は silent failure にせず、owner-facing truth を残す。
- actual: unit test で JSON-RPC decline response、payload generation、runtime POST、turn 中 approval request からの notification dispatch、handler failure capture、runtime POST failure truth を確認しました。
- mismatch: live iPhone PWA delivery と privileged helper execution は未実施。
- lesson: PWA 通知 route だけでは不足で、owner action が発生する実際の runner/bridge 側から呼ばせる必要がある。
- should become RAG candidate: はい。owner action required は route だけでなく、app-server approval request 発生点から通知する。

## Verification Evidence

- Unit: `node --test test/dashboard-app-server-bridge.test.js` passed: 32 passed, 0 failed。
- Integration: `npm test` passed: 1032 passed, 1 skipped, 0 failed; self-parity / generated-worker checks passed。
- E2E: live iPhone PWA E2E は未実施。
- Manual: `git diff --stat` で変更範囲が #637 app-server approval notification slice に収まることを確認。
- Evidence path/link: `test/dashboard-app-server-bridge.test.js`, `scripts/run-dashboard-app-server-bridge.mjs`, `docs/butler/vps-privileged-maintenance-capability-lifecycle.md`

## Butler Completion Contract

- Owner goal: app-server が owner 操作待ちになった時、chatだけでなく PWA 通知で知らせる。
- Butler entrypoint: Dashboard app-server bridge の Codex approval request 発生点。自然言語から helper proposal へ進む path は未接続です。
- Action Schema exposure: このPRでは未変更です。
- Runtime path: app-server approval request -> bridge decline response -> owner-action-required payload -> `POST /v2/events/owner-action-required` -> Dashboard event / Web Push route。
- Runner/runtime truth: bridge は approval request を許可せず、runtime route response に委ねて event/webPush truth を残します。
- Authority boundary: 新しい high-risk authority は追加しません。通知は owner attention signal であり execution grant ではありません。
- E2E evidence: live iPhone PWA E2E は未実施。unit/integration で route POST まで検証しました。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 未実施。deploy はこのPRの非目標です。
- Custom GPT Action Schema update: 未実施。
- Custom GPT Instructions update: 未実施。
- iPhone Butler live E2E: 未実施。

## Related Constitution Rules

- owner に必要な操作がある場合は PWA 通知で飛ばす。
- Butler は iPhone/iPad-first で、Mac を通常回復 path にしない。
- high-risk action は scoped passkey approval が必要で、bridge は app-server approval を直接許可しない。
- active Issues は縮小しない。部分進捗は incomplete として残スコープを明記する。

## Out-of-scope but NOT implemented

- root-owned VPS helper。
- capability manifest 実配置と sudoers/systemd 連携。
- passkey proposal UI / approvalGrant から helper execution へ進む path。
- live iPhone PWA delivery E2E。
- Issue #637 close。

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #637
- Execution ID: issue-637-app-server-approval-pwa-notification
- Goal: connect app-server approval request to owner-action-required PWA notification
