### PR TITLE
#637 app-server approval通知をcleanup前にdrain

### DIFF
--- a/scripts/run-dashboard-app-server-bridge.mjs
+++ b/scripts/run-dashboard-app-server-bridge.mjs
@@ -297,7 +297,7 @@ function normalizePositiveInteger(value) {
 
 function sanitizeBridgeActionId(value) {
   return normalizeBridgeText(value)
-    .replace(/[^a-zA-Z0-9._:-]+/g, "-")
+    .replace(/[^a-zA-Z0-9._-]+/g, "-")
     .replace(/^-+|-+$/g, "")
     .slice(0, 80);
 }
@@ -891,6 +891,9 @@ export async function handleDashboardTurnRequest({
     await turnCompletion;
   } finally {
     clearTimeout(timeoutHandle);
+    if (!timedOut && typeof appServer.drainApprovalRequests === "function") {
+      await appServer.drainApprovalRequests();
+    }
     if (!timedOut) {
       cleanupNotifications();
     }

--- a/test/dashboard-app-server-bridge.test.js
+++ b/test/dashboard-app-server-bridge.test.js
@@ -408,6 +408,31 @@ test("dashboard app-server bridge builds owner-action-required payloads for appr
   );
 });
 
+test("dashboard app-server bridge removes colon ambiguity from owner-action action id components", () => {
+  const payload = buildOwnerActionRequiredPayloadForAppServerApproval({
+    message: {
+      id: "request:44",
+      method: "item/permissions/requestApproval"
+    },
+    request: {
+      threadId: "dashboard:main",
+      repository: "marushu/vtdd-v2-p",
+      relatedIssue: 637
+    },
+    dashboardThreadId: "dashboard:main",
+    codexThreadId: "codex:thread:1",
+    approvalResponse: {
+      id: "request:44",
+      error: {
+        code: -32001,
+        message: "Dashboard bridge does not grant app-server permission escalation"
+      }
+    }
+  });
+
+  assert.equal(payload.actionId, "app-server-approval:dashboard-main:codex-thread-1:item-permissions-requestApproval:request-44");
+});
+
 test("dashboard app-server bridge posts owner-action-required event with bearer auth", async () => {
   const calls = [];
   const result = await postOwnerActionRequiredEvent({
@@ -734,6 +759,85 @@ test("dashboard app-server bridge records owner-action notification failure in d
   assert.ok(failure);
   assert.equal(failure.type, "app_server_turn_failed");
   assert.match(failure.text, /owner action PWA通知を送信できませんでした/);
+});
+
+test("dashboard app-server bridge drains real client approval notification tasks before normal turn cleanup", async () => {
+  const events = [];
+  const runtimeCalls = [];
+  let postFinished = false;
+  const client = new JsonLineAppServerClient({ command: "unused" });
+  client.child = {
+    stdin: {
+      write(chunk) {
+        const message = JSON.parse(String(chunk).trim());
+        if (message.method === "thread/start") {
+          setTimeout(() => {
+            client.handleChunk(
+              JSON.stringify({
+                id: message.id,
+                result: { thread: { id: "codex-thread-drain" } }
+              }) + "\n"
+            );
+          }, 0);
+          return;
+        }
+        if (message.method === "turn/start") {
+          setTimeout(() => {
+            client.handleChunk(
+              JSON.stringify({
+                id: 99,
+                method: "item/commandExecution/requestApproval",
+                params: {}
+              }) + "\n"
+            );
+            client.handleChunk(
+              JSON.stringify({
+                id: message.id,
+                result: { turn: { id: "turn-drain" } }
+              }) + "\n"
+            );
+            client.handleChunk(
+              JSON.stringify({
+                method: "turn/completed",
+                params: {
+                  threadId: "codex-thread-drain",
+                  turn: { id: "turn-drain", status: "completed" }
+                }
+              }) + "\n"
+            );
+          }, 0);
+        }
+      }
+    },
+    kill() {}
+  };
+
+  await handleDashboardTurnRequest({
+    request: {
+      threadId: "dashboard-main",
+      repository: "marushu/vtdd-v2-p",
+      relatedIssue: 637,
+      text: "権限が必要な確認をして"
+    },
+    appServer: client,
+    sendDashboardEvent: async (event) => events.push(event),
+    runtimeUrl: "https://runtime.example",
+    token: "runtime-token",
+    fetchImpl: async (url, init) => {
+      runtimeCalls.push({ url: String(url), init });
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      postFinished = true;
+      return new Response(null, { status: 202 });
+    }
+  });
+
+  assert.equal(postFinished, true);
+  assert.equal(runtimeCalls.length, 1);
+  assert.equal(
+    JSON.parse(runtimeCalls[0].init.body).actionId,
+    "app-server-approval:dashboard-main:codex-thread-drain:item-commandExecution-requestApproval:99"
+  );
+  assert.equal(events.at(-1).type, "app_server_reply");
 });
 
 test("dashboard app-server bridge passes traffic-control context to codex app-server turns", async () => {


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #637 / PR #641 の post-merge reviewer 指摘に対するフォローアップです。
- Dashboard app-server bridge の実クライアント経路で、approval request 通知 task を通常 turn cleanup 前に drain します。
- owner-action-required POST / notification failure truth が、turn 完了直後の handler cleanup で外へ漏れないことをテストで確認します。
- owner action `actionId` component から `:` を除去し、colon 連結による識別曖昧さを減らします。

## Satisfied Success Criteria

- `handleDashboardTurnRequest()` の通常終了時に、`appServer.drainApprovalRequests()` が存在する場合は cleanup 前に await します。
- 実 `JsonLineAppServerClient.handleChunk()` 経路で approval request -> async owner-action POST -> turn completed の順に流しても、関数 return 前に POST 完了を待つテストを追加しました。
- `sanitizeBridgeActionId()` は component 内の colon を `-` に正規化し、join separator の colon と混ざらないようにしました。

## Unsatisfied Success Criteria

- Issue #637 全体は未完了です。
- live iPhone PWA delivery E2E、Custom GPT Action Schema、passkey proposal UI、root-owned helper execution は未接続です。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #637
- Implementing Success Criteria: app-server approval request の owner-action-required notification task を実クライアント経路で cleanup 前に待ち、actionId component の識別曖昧さを消す。
- Explicit Non-goals: approval許可、権限昇格、root helper、sudoers/systemd mutation、deploy、credential mutation、permission mutation、Issue close は行いません。
- Expected touched files/routes/workflows: `scripts/run-dashboard-app-server-bridge.mjs`, `test/dashboard-app-server-bridge.test.js`。
- Affected Issues: Issue #637 のみ。
- Affected PRs: PR #641 の merged follow-up。マージ済みPRへ追いpushしません。
- Affected workflows: GitHub Actions workflow 定義は変更しません。
- Affected runtime/operator surfaces: Dashboard app-server bridge、owner-action-required event route 呼び出し順序。
- What may break if we patch narrowly: 通常 turn cleanup 前に notification task を待つため、runtime POST が遅い場合は通常 turn return がその分遅れます。timeout path では既存 recovery behavior を保つため drain しません。
- Unknowns to investigate before coding: merged PR #641 の post-merge reviewer request_changes を確認済み。
- Validation needed: `node --test test/dashboard-app-server-bridge.test.js`, `npm test`。
- Stop condition: approval許可、権限変更、deploy/credential/permission mutation が必要になる場合はこのPRでは止めます。

## Execution Queue Delta

- Queue position before: Issue #637 は `Now` の root blocker。PR #641 は merged だが post-merge reviewer request_changes が同一headに到着しました。
- Preemption decision: ROOT として #637 内で継続します。並行 Issue へは移りません。
- Queue delta: Issue #637 app-server approval notification slice の post-merge reviewer 指摘を、新規フォローアップPRで解消します。
- Why this PR is next: マージ済みPRに後追い blocker が残ると、iPhone/PWA owner attention delivery の信頼性が落ちます。次の helper/passkey slice に進む前に reviewer 指摘を潰します。
- Active Issues not downscoped: Active Issues は縮小しません。このPRで扱わない #637 残スコープと他 active Issue は未完了として残します。

## File / Line Hypotheses

- file: `scripts/run-dashboard-app-server-bridge.mjs`
  - hypothesis: 通常 turn 終了時に approval notification tasks を drain すれば、cleanup 前に owner-action POST / failure truth が完了する。
  - risk if changed narrowly: runtime POST が遅い場合に通常 turn return が遅れる。timeout path では drain しない。
  - validation: real client `handleChunk()` 経路の async POST drain test。
  - related Issue: Issue #637
- file: `test/dashboard-app-server-bridge.test.js`
  - hypothesis: fake handler direct-await ではなく `JsonLineAppServerClient.handleChunk()` から approval request を流す test で reviewer 指摘を再現防止できる。
  - risk if changed narrowly: live PWA delivery はこのtestでは証明できないため、completion status は incomplete とする。
  - validation: `node --test test/dashboard-app-server-bridge.test.js`, `npm test`。
  - related Issue: Issue #637

## Hypothesis Retrospective

- expected: PR #641 の owner-action notification task は実クライアント経路でも cleanup 前に完了し、actionId は component と separator が曖昧にならない。
- actual: bridge unit test で real client `handleChunk()` 経路から async POST 完了を待つこと、colon component が hyphen 化されることを確認しました。
- mismatch: live iPhone PWA delivery と privileged helper execution は未実施。
- lesson: reviewer approve 後でも post-merge reviewer race があり得るため、マージ済みPRへの後追い指摘は新規PRで閉じる。
- should become RAG candidate: はい。auto-merge直後の同一head request_changes は follow-up PR として扱う。

## Verification Evidence

- Unit: `node --test test/dashboard-app-server-bridge.test.js` passed: 34 passed, 0 failed。
- Integration: `npm test` passed: 1034 passed, 1 skipped, 0 failed; self-parity / generated-worker checks passed。
- E2E: live iPhone PWA E2E は未実施。
- Manual: `git diff --stat` で変更範囲が #637 app-server approval notification drain slice に収まることを確認。
- Evidence path/link: `test/dashboard-app-server-bridge.test.js`, `scripts/run-dashboard-app-server-bridge.mjs`

## Butler Completion Contract

- Owner goal: 必要な owner 操作がある場合は PWA 通知へ飛ばし、通知失敗truthも cleanup 前に残す。
- Butler entrypoint: Dashboard app-server bridge の Codex approval request 発生点。
- Action Schema exposure: このPRでは未変更です。
- Runtime path: app-server approval request -> bridge decline response -> owner-action-required payload -> notification task drain before normal cleanup。
- Runner/runtime truth: runtime route response / failure event が cleanup 前に処理されるようになります。
- Authority boundary: 新しい high-risk authority は追加しません。通知は owner attention signal であり execution grant ではありません。
- E2E evidence: live iPhone PWA E2E は未実施。unit/integration で実クライアント経路の drain まで検証しました。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 未実施。deploy はこのPRの非目標です。
- Custom GPT Action Schema update: 未実施。
- Custom GPT Instructions update: 未実施。
- iPhone Butler live E2E: 未実施。

## Related Constitution Rules

- owner に必要な操作がある場合は PWA 通知で飛ばす。
- Butler は iPhone/iPad-first で、Mac を通常回復 path にしない。
- high-risk action は scoped passkey approval が必要で、bridge は app-server approval を直接許可しない。
- active Issues は縮小しない。部分進捗は incomplete として残スコープを明記する。

## Out-of-scope but NOT implemented

- root-owned VPS helper。
- capability manifest 実配置と sudoers/systemd 連携。
- passkey proposal UI / approvalGrant から helper execution へ進む path。
- live iPhone PWA delivery E2E。
- Issue #637 close。

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #637
- Execution ID: issue-637-app-server-approval-drain
- Goal: drain app-server approval notification tasks before normal cleanup
