### PR TITLE
#637 VPS helper dry-run contractを追加

### DIFF
--- a/scripts/run-vps-privileged-maintenance-helper.mjs
+++ b/scripts/run-vps-privileged-maintenance-helper.mjs
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+
+import fs from "node:fs/promises";
+
+import { planVpsPrivilegedMaintenanceHelperExecution } from "../src/core/index.js";
+
+function parseArgs(argv) {
+  const result = {
+    mode: "dry_run"
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--dry-run") {
+      result.mode = "dry_run";
+    } else if (arg === "--input") {
+      result.inputPath = argv[index + 1] || "";
+      index += 1;
+    }
+  }
+  return result;
+}
+
+async function readInput(inputPath) {
+  if (inputPath) {
+    return fs.readFile(inputPath, "utf8");
+  }
+  let text = "";
+  for await (const chunk of process.stdin) {
+    text += chunk;
+  }
+  return text;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const raw = await readInput(args.inputPath);
+  const input = raw.trim() ? JSON.parse(raw) : {};
+  const result = planVpsPrivilegedMaintenanceHelperExecution({
+    manifest: input.manifest,
+    helperRequest: input.helperRequest,
+    mode: args.mode,
+    now: input.now
+  });
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+  if (!result.ok) {
+    process.exitCode = 1;
+  }
+}
+
+await main();

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -246,6 +246,7 @@ export {
   buildVpsCapabilityReview,
   buildVpsMaintenanceApprovalScope,
   applyVpsCapabilityLifecycleOperation,
+  planVpsPrivilegedMaintenanceHelperExecution,
   normalizeVpsCapability,
   normalizeVpsCapabilityManifest
 } from "./vps-privileged-maintenance.js";

--- a/src/core/vps-privileged-maintenance.js
+++ b/src/core/vps-privileged-maintenance.js
@@ -2,6 +2,7 @@ const CAPABILITY_STATUSES = new Set(["enabled", "disabled"]);
 const CAPABILITY_OPERATIONS = new Set(["add", "enable", "disable", "remove", "rollback", "review"]);
 const RISK_LEVELS = new Set(["low", "medium", "high"]);
 const DEFAULT_MANIFEST_VERSION = 1;
+const HELPER_EXECUTION_MODES = new Set(["dry_run"]);
 
 function normalizeVpsCapabilityManifest(input = {}) {
   const issues = [];
@@ -226,6 +227,101 @@ function buildVpsCapabilityReview(manifest) {
   };
 }
 
+function planVpsPrivilegedMaintenanceHelperExecution(input = {}) {
+  const mode = normalizeText(input.mode || input.executionMode || input.execution_mode) || "dry_run";
+  const manifestResult = normalizeVpsCapabilityManifest(input.manifest);
+  const helperRequest = normalizeHelperRequest(input.helperRequest || input.helper_request);
+  const now = normalizeText(input.now) || new Date().toISOString();
+  const issues = [...manifestResult.issues, ...helperRequest.issues];
+  if (!HELPER_EXECUTION_MODES.has(mode)) {
+    issues.push("helper execution mode must be dry_run");
+  }
+  if (issues.length > 0) {
+    return {
+      ok: false,
+      error: "vps_helper_request_invalid",
+      issues
+    };
+  }
+
+  const manifest = manifestResult.manifest;
+  const request = helperRequest.request;
+  const capability = manifest.capabilities.find((item) => item.id === request.capability.id);
+  if (!capability) {
+    return {
+      ok: false,
+      error: "vps_helper_capability_not_found",
+      issues: [`capability not found: ${request.capability.id}`]
+    };
+  }
+  if (capability.status !== "enabled") {
+    return {
+      ok: false,
+      error: "vps_helper_capability_disabled",
+      issues: [`capability is not enabled: ${request.capability.id}`]
+    };
+  }
+  const mismatch = compareHelperRequestToCapability({ request, capability, manifest });
+  if (mismatch.length > 0) {
+    return {
+      ok: false,
+      error: "vps_helper_request_manifest_mismatch",
+      issues: mismatch
+    };
+  }
+
+  return {
+    ok: true,
+    helperPlan: {
+      kind: "vps_privileged_maintenance_helper_plan",
+      mode,
+      status: "dry_run_ready",
+      requestId: request.requestId,
+      host: request.host,
+      repository: request.repository,
+      relatedIssue: request.relatedIssue,
+      operation: request.operation,
+      capability: sanitizeHelperCapability(capability),
+      commandPreview: {
+        commandClass: capability.commandClass,
+        workingDirectories: capability.workingDirectories,
+        allowedArgs: capability.allowedArgs
+      },
+      audit: {
+        redactionRules: capability.redactionRules,
+        expectedRuntimeTruth: capability.expectedRuntimeTruth,
+        rollbackPlan: capability.rollbackPlan
+      },
+      rootExecutionStarted: false,
+      helperExecutionStarted: false,
+      redacted: true,
+      plannedAt: now
+    },
+    runtimeTruth: {
+      ok: true,
+      kind: "vps_privileged_maintenance_helper_dry_run",
+      status: "dry_run_ready",
+      host: request.host,
+      repository: request.repository,
+      relatedIssue: request.relatedIssue,
+      operation: request.operation,
+      capabilityId: capability.id,
+      commandClass: capability.commandClass,
+      before: {
+        manifestVersion: manifest.version,
+        capabilityStatus: capability.status
+      },
+      after: null,
+      exitCode: null,
+      redactedLogSummary: "dry-run only; privileged command was not executed",
+      rootExecutionStarted: false,
+      helperExecutionStarted: false,
+      redacted: true,
+      updatedAt: now
+    }
+  };
+}
+
 function buildRuntimeTruth({ operation, capabilityId, before, after, now }) {
   return {
     ok: true,
@@ -248,6 +344,81 @@ function containsForbiddenPrivilegedPattern(capability) {
     capability.rollbackPlan
   ].join(" ");
   return /\bNOPASSWD\s*:\s*ALL\b/i.test(joined) || /\bsudo\s+su\b/i.test(joined) || /\b(root\s+shell|\/bin\/bash|\/bin\/sh)\b/i.test(joined);
+}
+
+function normalizeHelperRequest(input = {}) {
+  const capability = normalizeVpsCapability(input.capability || {});
+  const issues = [...capability.issues];
+  const request = {
+    kind: normalizeText(input.kind),
+    status: normalizeText(input.status),
+    requestId: normalizeText(input.requestId || input.request_id),
+    vpsProposalId: normalizeText(input.vpsProposalId || input.vps_proposal_id),
+    approvalGrantId: normalizeText(input.approvalGrantId || input.approval_grant_id),
+    host: normalizeText(input.host),
+    repository: normalizeRepository(input.repository),
+    relatedIssue: normalizePositiveInteger(input.relatedIssue || input.related_issue || input.issueNumber),
+    operation: normalizeText(input.operation),
+    capability: capability.capability
+  };
+
+  if (request.kind !== "vps_privileged_maintenance_helper_request") {
+    issues.push("helperRequest kind must be vps_privileged_maintenance_helper_request");
+  }
+  if (request.status !== "ready_for_vps_helper") {
+    issues.push("helperRequest status must be ready_for_vps_helper");
+  }
+  if (!request.requestId) issues.push("helperRequest requestId is required");
+  if (!request.vpsProposalId) issues.push("helperRequest vpsProposalId is required");
+  if (!request.approvalGrantId) issues.push("helperRequest approvalGrantId is required");
+  if (!request.host) issues.push("helperRequest host is required");
+  if (!request.repository) issues.push("helperRequest repository is required");
+  if (!request.relatedIssue) issues.push("helperRequest relatedIssue is required");
+  if (!CAPABILITY_OPERATIONS.has(request.operation)) {
+    issues.push("helperRequest operation must be add, enable, disable, remove, rollback, or review");
+  }
+
+  return {
+    ok: issues.length === 0,
+    request,
+    issues
+  };
+}
+
+function compareHelperRequestToCapability({ request, capability, manifest }) {
+  const issues = [];
+  if (request.host !== manifest.host) issues.push("helperRequest host must match manifest host");
+  if (request.repository !== manifest.repository) issues.push("helperRequest repository must match manifest repository");
+  if (request.capability.commandClass !== capability.commandClass) {
+    issues.push("helperRequest capability.commandClass must match manifest capability");
+  }
+  if (!sameStringList(request.capability.workingDirectories, capability.workingDirectories)) {
+    issues.push("helperRequest capability.workingDirectories must match manifest capability");
+  }
+  if (!sameStringList(request.capability.allowedArgs, capability.allowedArgs)) {
+    issues.push("helperRequest capability.allowedArgs must match manifest capability");
+  }
+  return issues;
+}
+
+function sanitizeHelperCapability(capability) {
+  return {
+    id: capability.id,
+    title: capability.title,
+    status: capability.status,
+    commandClass: capability.commandClass,
+    riskLevel: capability.riskLevel,
+    workingDirectories: capability.workingDirectories,
+    allowedArgs: capability.allowedArgs,
+    affectedPaths: capability.affectedPaths,
+    redactionRules: capability.redactionRules,
+    rollbackPlan: capability.rollbackPlan,
+    expectedRuntimeTruth: capability.expectedRuntimeTruth
+  };
+}
+
+function sameStringList(left, right) {
+  return JSON.stringify(normalizeStringList(left)) === JSON.stringify(normalizeStringList(right));
 }
 
 function cloneManifest(manifest) {
@@ -296,6 +467,7 @@ export {
   buildVpsCapabilityReview,
   buildVpsMaintenanceApprovalScope,
   applyVpsCapabilityLifecycleOperation,
+  planVpsPrivilegedMaintenanceHelperExecution,
   normalizeVpsCapability,
   normalizeVpsCapabilityManifest
 };

--- a/test/vps-privileged-maintenance-helper-script.test.js
+++ b/test/vps-privileged-maintenance-helper-script.test.js
@@ -1,0 +1,95 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+
+const manifest = {
+  version: 1,
+  host: "x85-131-245-163",
+  repository: "marushu/vtdd-v2-p",
+  updatedAt: "2026-05-29T00:00:00.000Z",
+  capabilities: [
+    {
+      id: "playwright.chromium.deps",
+      title: "Playwright Chromium dependency install",
+      status: "enabled",
+      commandClass: "playwright_install_deps_chromium",
+      riskLevel: "high",
+      workingDirectories: ["/home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p"],
+      allowedArgs: ["npx playwright install-deps chromium"],
+      affectedPaths: ["/usr/lib", "/usr/share/fonts"],
+      redactionRules: ["no secrets", "summarize package list"],
+      rollbackPlan: "disable capability and keep audit history",
+      expectedRuntimeTruth: ["before package check", "exit code", "after Chromium launch check"],
+      createdAt: "2026-05-29T00:00:00.000Z",
+      updatedAt: "2026-05-29T00:00:00.000Z"
+    }
+  ]
+};
+
+test("VPS privileged maintenance helper script dry-runs a bounded helper request", () => {
+  const helperRequest = {
+    kind: "vps_privileged_maintenance_helper_request",
+    status: "ready_for_vps_helper",
+    requestId: "vps-maintenance-helper-request:test",
+    vpsProposalId: "vps-maintenance-proposal:test",
+    approvalGrantId: "approval:test",
+    host: "x85-131-245-163",
+    repository: "marushu/vtdd-v2-p",
+    relatedIssue: 637,
+    operation: "add",
+    capability: manifest.capabilities[0]
+  };
+
+  const result = spawnSync(
+    process.execPath,
+    ["scripts/run-vps-privileged-maintenance-helper.mjs", "--dry-run"],
+    {
+      input: JSON.stringify({
+        manifest,
+        helperRequest,
+        now: "2026-05-29T02:00:00.000Z"
+      }),
+      encoding: "utf8"
+    }
+  );
+
+  assert.equal(result.status, 0);
+  const body = JSON.parse(result.stdout);
+  assert.equal(body.ok, true);
+  assert.equal(body.runtimeTruth.status, "dry_run_ready");
+  assert.equal(body.runtimeTruth.rootExecutionStarted, false);
+});
+
+test("VPS privileged maintenance helper script exits nonzero for disabled capability", () => {
+  const helperRequest = {
+    kind: "vps_privileged_maintenance_helper_request",
+    status: "ready_for_vps_helper",
+    requestId: "vps-maintenance-helper-request:test",
+    vpsProposalId: "vps-maintenance-proposal:test",
+    approvalGrantId: "approval:test",
+    host: "x85-131-245-163",
+    repository: "marushu/vtdd-v2-p",
+    relatedIssue: 637,
+    operation: "add",
+    capability: manifest.capabilities[0]
+  };
+
+  const result = spawnSync(
+    process.execPath,
+    ["scripts/run-vps-privileged-maintenance-helper.mjs", "--dry-run"],
+    {
+      input: JSON.stringify({
+        manifest: {
+          ...manifest,
+          capabilities: [{ ...manifest.capabilities[0], status: "disabled" }]
+        },
+        helperRequest
+      }),
+      encoding: "utf8"
+    }
+  );
+
+  assert.equal(result.status, 1);
+  const body = JSON.parse(result.stdout);
+  assert.equal(body.error, "vps_helper_capability_disabled");
+});

--- a/test/vps-privileged-maintenance.test.js
+++ b/test/vps-privileged-maintenance.test.js
@@ -4,7 +4,8 @@ import {
   applyVpsCapabilityLifecycleOperation,
   buildVpsCapabilityProposal,
   buildVpsMaintenanceApprovalScope,
-  normalizeVpsCapabilityManifest
+  normalizeVpsCapabilityManifest,
+  planVpsPrivilegedMaintenanceHelperExecution
 } from "../src/core/index.js";
 
 const baseManifest = {
@@ -167,4 +168,83 @@ test("VPS privileged maintenance approval scope preserves existing passkey opera
   assert.equal(scope.vpsExpiresAt, "2026-05-29T01:10:00.000Z");
   assert.equal(scope.display.capabilityId, "playwright.chromium.deps");
   assert.equal(scope.display.host, "x85-131-245-163");
+});
+
+test("VPS helper dry-run contract validates enabled manifest capability without executing root", () => {
+  const manifest = {
+    ...baseManifest,
+    capabilities: [
+      {
+        ...baseManifest.capabilities[0],
+        status: "enabled"
+      }
+    ]
+  };
+  const helperRequest = {
+    kind: "vps_privileged_maintenance_helper_request",
+    status: "ready_for_vps_helper",
+    requestId: "vps-maintenance-helper-request:test",
+    vpsProposalId: "vps-maintenance-proposal:test",
+    approvalGrantId: "approval:test",
+    host: "x85-131-245-163",
+    repository: "marushu/vtdd-v2-p",
+    relatedIssue: 637,
+    operation: "add",
+    capability: manifest.capabilities[0]
+  };
+
+  const result = planVpsPrivilegedMaintenanceHelperExecution({
+    manifest,
+    helperRequest,
+    mode: "dry_run",
+    now: "2026-05-29T02:00:00.000Z"
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.helperPlan.status, "dry_run_ready");
+  assert.equal(result.helperPlan.rootExecutionStarted, false);
+  assert.equal(result.helperPlan.helperExecutionStarted, false);
+  assert.deepEqual(result.helperPlan.commandPreview.allowedArgs, ["npx playwright install-deps chromium"]);
+  assert.equal(result.runtimeTruth.status, "dry_run_ready");
+  assert.equal(result.runtimeTruth.exitCode, null);
+  assert.equal(result.runtimeTruth.redactedLogSummary, "dry-run only; privileged command was not executed");
+});
+
+test("VPS helper dry-run rejects disabled or mismatched capabilities", () => {
+  const helperRequest = {
+    kind: "vps_privileged_maintenance_helper_request",
+    status: "ready_for_vps_helper",
+    requestId: "vps-maintenance-helper-request:test",
+    vpsProposalId: "vps-maintenance-proposal:test",
+    approvalGrantId: "approval:test",
+    host: "x85-131-245-163",
+    repository: "marushu/vtdd-v2-p",
+    relatedIssue: 637,
+    operation: "add",
+    capability: baseManifest.capabilities[0]
+  };
+
+  const disabled = planVpsPrivilegedMaintenanceHelperExecution({
+    manifest: baseManifest,
+    helperRequest
+  });
+  assert.equal(disabled.ok, false);
+  assert.equal(disabled.error, "vps_helper_capability_disabled");
+
+  const mismatched = planVpsPrivilegedMaintenanceHelperExecution({
+    manifest: {
+      ...baseManifest,
+      capabilities: [
+        {
+          ...baseManifest.capabilities[0],
+          status: "enabled",
+          allowedArgs: ["npx playwright install-deps firefox"]
+        }
+      ]
+    },
+    helperRequest
+  });
+  assert.equal(mismatched.ok, false);
+  assert.equal(mismatched.error, "vps_helper_request_manifest_mismatch");
+  assert.equal(mismatched.issues.includes("helperRequest capability.allowedArgs must match manifest capability"), true);
 });


### PR DESCRIPTION
# #637 VPS helper dry-run contractを追加

## This PR satisfies Intent

Issue #637 の部分進捗として、VPS privileged maintenance helper が実 root 実行へ進む前に満たすべき dry-run 契約を repo-backed にします。

この PR は実 root 実行を開始しません。#644 の `vtddCreateVpsMaintenanceHelperRequest` が作る helper request と capability manifest を照合し、enabled capability だけを `dry_run_ready` として計画化し、mismatch / disabled capability を明示的に拒否します。

## Satisfied Success Criteria

- `planVpsPrivilegedMaintenanceHelperExecution` が manifest と helper request を検証する。
- capability が存在しない、disabled、または helper request と manifest が一致しない場合に失敗する。
- `scripts/run-vps-privileged-maintenance-helper.mjs --dry-run` が stdin / `--input` の JSON を読み、同じ dry-run runtime truth を返す。
- dry-run runtime truth は `rootExecutionStarted:false` / `helperExecutionStarted:false` / `exitCode:null` を返し、特権コマンドが未実行であることを明示する。

## Unsatisfied Success Criteria

- root-owned helper の VPS への install は未実装。
- sudoers / systemd / root 権限変更は行わない。
- 実 package install や Chromium 起動確認は行わない。
- Dashboard Butler / Custom GPT Action Schema の新 operationId は追加しない。
- iPhone/PWA E2E は未実行。
- #637 は閉じない。

## Dry-run Impact Report

- Target Issue: #637
- Implementing Success Criteria: root helper 実行前の request / manifest 照合、dry-run runtime truth、拒否条件
- Explicit Non-goals: 実 root 実行、VPS 権限変更、deploy、Issue close
- Expected touched files/routes/workflows: `src/core/vps-privileged-maintenance.js`, `src/core/index.js`, `scripts/run-vps-privileged-maintenance-helper.mjs`, `test/vps-privileged-maintenance.test.js`, `test/vps-privileged-maintenance-helper-script.test.js`
- Affected Issues: #637 は進捗するが未完了
- Affected PRs: PR #644 の helper request 生成後続
- Affected workflows: Node test のみ
- Affected runtime/operator surfaces: deploy 済み route はなし。repo-backed CLI / core contract のみ
- What may break if we patch narrowly: dry-run 契約を実 helper 完了と誤読すること
- Unknowns to investigate before coding: root-owned install path、sudoers wrapper、audit log location、manifest file ownership
- Validation needed: targeted tests、full `npm test`
- Stop condition: 実 root 実行・権限変更へ進む場合は scoped passkey / PWA approval が必要

## Execution Queue Delta

- Queue position before: Issue #637 が `Now`。PR #644 で helper request route まで merged。
- Preemption decision: ROOT
- Queue delta: Issue #637 を `Now` に維持し、PR #644 の helper request から root helper 実装へ進む前の dry-run 契約を追加。
- Why this PR is next: root-owned helper を安全に実装するには、まず受け入れ条件、拒否条件、runtime truth を固定する必要があるため。
- Active Issues not downscoped: active Issues は縮小しない。この PR は Issue #637 の小スライスであり、#637 全体完了は主張しない。

## File / Line Hypotheses

- `src/core/vps-privileged-maintenance.js`: helper request と manifest の照合、dry-run plan/runtime truth 生成。
- `src/core/index.js`: core export 追加。
- `scripts/run-vps-privileged-maintenance-helper.mjs`: VPS helper dry-run CLI。
- `test/vps-privileged-maintenance.test.js`: core contract の成功/失敗条件。
- `test/vps-privileged-maintenance-helper-script.test.js`: CLI の成功/失敗 exit code。

## Hypothesis Retrospective

想定どおり、root 実行を開始せずに helper request の妥当性を repo 内で検証できる形になりました。実 root 実行、sudoers、systemd、VPS install は authority boundary が変わるため次 PR 以降に分離します。

## Verification Evidence

- `node --test test/vps-privileged-maintenance.test.js test/vps-privileged-maintenance-helper-script.test.js`
  - pass: 9
- `npm test`
  - Node tests: 1044 pass / 1 skip / 0 fail
  - `check:self-parity`: passed
  - `check:generated-worker`: passed

## Butler Completion Contract

- Owner goal: VPS privileged helper が何を受け入れ、何を拒否するかを実 install 前に確認できる。
- Butler entrypoint: 新規追加なし。PR #644 の helper request 生成後に使う repo-backed contract。
- Action Schema exposure: 新 operationId なし。
- Runtime path: deployed route なし。repo-backed CLI / core contract のみ。
- Runner/runtime truth: `vps_privileged_maintenance_helper_dry_run` を返す。
- Authority boundary: dry-run のため root 実行なし。実 root 実行・権限変更は scoped passkey / PWA approval が必要。
- E2E evidence: 未実行。CLI/core contract の unit evidence のみ。
- Completion status: incomplete

## Surface Update Checklist

- Custom GPT Action Schema: 変更なし
- Dashboard Butler UX: 変更なし
- Passkey approval: 既存 helper request の前提を検証するが、grant raw material は扱わない
- VPS runner/helper: helper dry-run contract / CLI を追加。install / 実 execution は未接続
- Docs/RAG: この PR では新規 RAG 書き込みなし
- Public/core safety: owner-specific runtime URL、secret、sudo password は追加なし
