### PR TITLE
#637 VPS helper argv registryを追加

### DIFF
--- a/docs/butler/vps-privileged-maintenance-capability-lifecycle.md
+++ b/docs/butler/vps-privileged-maintenance-capability-lifecycle.md
@@ -85,7 +85,9 @@ must bind to the repo-backed helper command registry in
 `src/core/vps-privileged-maintenance.js`. The registry is the bridge between a
 reviewed capability and the root-owned helper implementation: dry-run rejects
 unknown `commandClass` values and rejects registered commands whose risk level
-or allowed arguments do not match the registry.
+or allowed arguments do not match the registry. The registry must also carry an
+argv-form command preview for the root-owned helper. Future execution must use
+that argv boundary rather than passing manifest strings through a shell.
 
 ## Initial Presets
 

--- a/src/core/vps-privileged-maintenance.js
+++ b/src/core/vps-privileged-maintenance.js
@@ -8,6 +8,7 @@ const HELPER_COMMAND_REGISTRY = defineHelperCommandRegistry([
     commandClass: "playwright_install_deps_chromium",
     title: "Playwright Chromium dependency install",
     allowedArgs: ["npx playwright install-deps chromium"],
+    argv: ["npx", "playwright", "install-deps", "chromium"],
     requiredRiskLevel: "high",
     requiresRoot: true,
     initialPreset: true
@@ -16,6 +17,7 @@ const HELPER_COMMAND_REGISTRY = defineHelperCommandRegistry([
     commandClass: "codex_sandbox_sysctl_apply",
     title: "Codex sandbox sysctl apply",
     allowedArgs: ["sysctl --system"],
+    argv: ["sysctl", "--system"],
     requiredRiskLevel: "high",
     requiresRoot: true,
     initialPreset: true
@@ -24,6 +26,7 @@ const HELPER_COMMAND_REGISTRY = defineHelperCommandRegistry([
     commandClass: "systemd_user_runner_restart",
     title: "Restart VTDD runner user service",
     allowedArgs: ["systemctl --user restart vtdd-vps-runner.timer"],
+    argv: ["systemctl", "--user", "restart", "vtdd-vps-runner.timer"],
     requiredRiskLevel: "medium",
     requiresRoot: false,
     initialPreset: true
@@ -320,6 +323,7 @@ function planVpsPrivilegedMaintenanceHelperExecution(input = {}) {
         commandClass: capability.commandClass,
         workingDirectories: capability.workingDirectories,
         allowedArgs: capability.allowedArgs,
+        argv: registryBinding.binding.argv,
         registryBinding: registryBinding.binding
       },
       audit: {
@@ -342,6 +346,7 @@ function planVpsPrivilegedMaintenanceHelperExecution(input = {}) {
       operation: request.operation,
       capabilityId: capability.id,
       commandClass: capability.commandClass,
+      commandArgv: registryBinding.binding.argv,
       registryBinding: registryBinding.binding,
       before: {
         manifestVersion: manifest.version,
@@ -420,7 +425,8 @@ function defineHelperCommandRegistry(entries) {
   for (const entry of entries) {
     const normalized = {
       ...entry,
-      allowedArgs: Object.freeze(normalizeStringList(entry.allowedArgs))
+      allowedArgs: Object.freeze(normalizeStringList(entry.allowedArgs)),
+      argv: Object.freeze(normalizeStringList(entry.argv))
     };
     registry[normalized.commandClass] = Object.freeze(normalized);
   }
@@ -432,6 +438,7 @@ function cloneHelperCommandRegistryEntry(entry) {
     commandClass: entry.commandClass,
     title: entry.title,
     allowedArgs: [...entry.allowedArgs],
+    argv: [...entry.argv],
     requiredRiskLevel: entry.requiredRiskLevel,
     requiresRoot: entry.requiresRoot,
     initialPreset: entry.initialPreset

--- a/test/vps-privileged-maintenance.test.js
+++ b/test/vps-privileged-maintenance.test.js
@@ -52,16 +52,22 @@ test("VPS privileged maintenance helper command registry exposes initial presets
     registry.every((entry) => Array.isArray(entry.allowedArgs) && entry.allowedArgs.length > 0),
     true
   );
+  assert.equal(
+    registry.every((entry) => Array.isArray(entry.argv) && entry.argv.length > 0),
+    true
+  );
 });
 
 test("VPS privileged maintenance helper command registry does not expose mutable internal arrays", () => {
   const registry = listVpsPrivilegedMaintenanceCommandRegistry();
   const playwright = registry.find((entry) => entry.commandClass === "playwright_install_deps_chromium");
   playwright.allowedArgs.push("npx playwright install-deps firefox");
+  playwright.argv.push("firefox");
 
   const freshRegistry = listVpsPrivilegedMaintenanceCommandRegistry();
   const freshPlaywright = freshRegistry.find((entry) => entry.commandClass === "playwright_install_deps_chromium");
   assert.deepEqual(freshPlaywright.allowedArgs, ["npx playwright install-deps chromium"]);
+  assert.deepEqual(freshPlaywright.argv, ["npx", "playwright", "install-deps", "chromium"]);
 });
 
 test("VPS privileged maintenance proposal requires PWA notification and rollback plan", () => {
@@ -228,8 +234,10 @@ test("VPS helper dry-run contract validates enabled manifest capability without 
   assert.equal(result.helperPlan.rootExecutionStarted, false);
   assert.equal(result.helperPlan.helperExecutionStarted, false);
   assert.deepEqual(result.helperPlan.commandPreview.allowedArgs, ["npx playwright install-deps chromium"]);
+  assert.deepEqual(result.helperPlan.commandPreview.argv, ["npx", "playwright", "install-deps", "chromium"]);
   assert.equal(result.runtimeTruth.status, "dry_run_ready");
   assert.equal(result.runtimeTruth.registryBinding.commandClass, "playwright_install_deps_chromium");
+  assert.deepEqual(result.runtimeTruth.commandArgv, ["npx", "playwright", "install-deps", "chromium"]);
   assert.equal(result.runtimeTruth.exitCode, null);
   assert.equal(result.runtimeTruth.redactedLogSummary, "dry-run only; privileged command was not executed");
 });

--- a/worker.js
+++ b/worker.js
@@ -37260,6 +37260,7 @@ var HELPER_COMMAND_REGISTRY = defineHelperCommandRegistry([
     commandClass: "playwright_install_deps_chromium",
     title: "Playwright Chromium dependency install",
     allowedArgs: ["npx playwright install-deps chromium"],
+    argv: ["npx", "playwright", "install-deps", "chromium"],
     requiredRiskLevel: "high",
     requiresRoot: true,
     initialPreset: true
@@ -37268,6 +37269,7 @@ var HELPER_COMMAND_REGISTRY = defineHelperCommandRegistry([
     commandClass: "codex_sandbox_sysctl_apply",
     title: "Codex sandbox sysctl apply",
     allowedArgs: ["sysctl --system"],
+    argv: ["sysctl", "--system"],
     requiredRiskLevel: "high",
     requiresRoot: true,
     initialPreset: true
@@ -37276,6 +37278,7 @@ var HELPER_COMMAND_REGISTRY = defineHelperCommandRegistry([
     commandClass: "systemd_user_runner_restart",
     title: "Restart VTDD runner user service",
     allowedArgs: ["systemctl --user restart vtdd-vps-runner.timer"],
+    argv: ["systemctl", "--user", "restart", "vtdd-vps-runner.timer"],
     requiredRiskLevel: "medium",
     requiresRoot: false,
     initialPreset: true
@@ -37469,6 +37472,7 @@ function planVpsPrivilegedMaintenanceHelperExecution(input = {}) {
         commandClass: capability.commandClass,
         workingDirectories: capability.workingDirectories,
         allowedArgs: capability.allowedArgs,
+        argv: registryBinding.binding.argv,
         registryBinding: registryBinding.binding
       },
       audit: {
@@ -37491,6 +37495,7 @@ function planVpsPrivilegedMaintenanceHelperExecution(input = {}) {
       operation: request.operation,
       capabilityId: capability.id,
       commandClass: capability.commandClass,
+      commandArgv: registryBinding.binding.argv,
       registryBinding: registryBinding.binding,
       before: {
         manifestVersion: manifest.version,
@@ -37548,7 +37553,8 @@ function defineHelperCommandRegistry(entries) {
   for (const entry of entries) {
     const normalized = {
       ...entry,
-      allowedArgs: Object.freeze(normalizeStringList(entry.allowedArgs))
+      allowedArgs: Object.freeze(normalizeStringList(entry.allowedArgs)),
+      argv: Object.freeze(normalizeStringList(entry.argv))
     };
     registry2[normalized.commandClass] = Object.freeze(normalized);
   }
@@ -37559,6 +37565,7 @@ function cloneHelperCommandRegistryEntry(entry) {
     commandClass: entry.commandClass,
     title: entry.title,
     allowedArgs: [...entry.allowedArgs],
+    argv: [...entry.argv],
     requiredRiskLevel: entry.requiredRiskLevel,
     requiresRoot: entry.requiresRoot,
     initialPreset: entry.initialPreset


### PR DESCRIPTION
# Issue #637 VPS helper argv registryを追加

## This PR satisfies Intent

Issue #637 の部分進捗です。PR #647 で追加した VPS privileged maintenance helper command registry に、将来の root-owned helper 実行で使う argv 形式の command boundary を追加します。

この PR は実行権限を増やしません。dry-run の runtime truth と command preview が、表示用の shell 文字列だけでなく、実行時に `spawn` 相当へ渡せる argv 配列を返せるようにします。

## Satisfied Success Criteria

- helper command registry の各 initial preset が `argv` 配列を持つ。
- helper dry-run の `commandPreview` と `runtimeTruth` が registry 由来の argv を返す。
- registry list / binding が `allowedArgs` と同様に `argv` も clone し、内部配列を外部変更から守る。
- lifecycle doc に、将来の実行は manifest 文字列を shell へ流さず argv boundary を使うことを明記する。

## Unsatisfied Success Criteria

- root-owned helper install は未実装。
- sudoers / systemd / root-owned manifest の実配置は未実装。
- 実コマンド実行は未実装。
- iPhone/PWA live E2E は未実行。
- Issue #637 は未完了であり、この PR では close しない。

## Dry-run Impact Report

- Target Issue: Issue #637
- Implementing Success Criteria: command registry argv boundary and runtime truth preview
- Explicit Non-goals: real root execution, VPS permission mutation, sudoers/systemd, deploy, Issue close
- Expected touched files/routes/workflows: `src/core/vps-privileged-maintenance.js`, `test/vps-privileged-maintenance.test.js`, `docs/butler/vps-privileged-maintenance-capability-lifecycle.md`, `worker.js`
- Affected Issues: #637 progresses but remains incomplete
- Affected PRs: follows PR #647
- Affected workflows: Worker build, Node tests, generated worker parity
- Affected runtime/operator surfaces: dry-run output gains argv preview; no new route or operationId
- What may break if we patch narrowly: downstream code must continue treating `allowedArgs` as display/compatibility text, not as the future execution boundary.
- Unknowns to investigate before coding: root helper install path, sudoers wrapper, actual `child_process.spawn` boundary, audit log location, manifest ownership.
- Validation needed: targeted tests, `npm run build:worker`, full `npm test`.
- Stop condition: real execution, permission mutation, deploy, sudoers/systemd changes require scoped passkey/PWA approval.

## Execution Queue Delta

- Queue position before: Issue #637 is `Now`; PR #647 was merged.
- Preemption decision: `NEXT`
- Queue delta: Issue #637 remains `Now`; PR #647 follow-up residual risk moves into this PR as an argv boundary slice.
- Why this PR is next: reviewer residual risk after #647 specifically identified shell-string execution risk.
- Active Issues not downscoped: active Issues are not downscoped; this is a bounded #637 slice only.

## File / Line Hypotheses

- `src/core/vps-privileged-maintenance.js`: registry entries and dry-run runtime truth need argv output.
- `test/vps-privileged-maintenance.test.js`: registry clone safety and dry-run argv evidence need assertions.
- `docs/butler/vps-privileged-maintenance-capability-lifecycle.md`: future execution boundary needs durable documentation.
- `worker.js`: generated worker bundle must match source changes.

## Hypothesis Retrospective

The expected narrow change was sufficient. The argv boundary can be represented in the existing registry/dry-run model without adding new authority, routes, schemas, or execution behavior.

## Verification Evidence

- `node --test test/vps-privileged-maintenance.test.js test/vps-privileged-maintenance-helper-script.test.js`
  - Result: 11 pass
- `npm run build:worker`
  - Result: pass
- `npm test`
  - Result: 1047 pass / 1 skip / 0 fail
  - `check:self-parity`: 29 routes / 29 operationIds
  - `check:generated-worker`: pass

## Butler Completion Contract

- Owner goal: Butler/root helper work can show exact argv preview before any real privileged execution implementation.
- Butler entrypoint: existing `vtddDryRunVpsMaintenanceHelper`
- Action Schema exposure: no change; existing operationId remains connected.
- Runtime path: existing `/v2/vps/privileged-maintenance/helper-dry-runs`; real VPS helper execution remains unconnected.
- Authority boundary: no root execution; real execution requires scoped passkey/PWA approval.
- Runner/runtime truth: dry-run truth includes `commandArgv`; actual VPS helper runner execution remains unconnected.
- E2E evidence: none in this PR; unit/build/generated-worker evidence only.
- Completion status: incomplete

## Surface Update Checklist

- Custom GPT Action Schema: no change
- Dashboard Butler UX: no change
- Passkey approval: no change
- VPS runner/helper: argv preview only; no execution
- Docs/RAG: lifecycle doc updated; no new RAG write in this PR
- Public/core safety: no owner URL, sudo password, secret, or operator-specific runtime destination added
