### PR TITLE
#637 VPS helper execution boundaryを追加

### DIFF
--- a/docs/butler/vps-privileged-maintenance-capability-lifecycle.md
+++ b/docs/butler/vps-privileged-maintenance-capability-lifecycle.md
@@ -88,6 +88,11 @@ unknown `commandClass` values and rejects registered commands whose risk level
 or allowed arguments do not match the registry. The registry must also carry an
 argv-form command preview for the root-owned helper. Future execution must use
 that argv boundary rather than passing manifest strings through a shell.
+The dry-run runtime truth must expose the normalized execution boundary as
+`executable + args + shell:false`. The root-owned helper is responsible for
+resolving `executable` through a controlled PATH allowlist; the repository
+contract must not bake an operator-specific Node/NVM path into public runtime
+truth.
 
 ## Initial Presets
 

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -244,6 +244,7 @@ export { executeDeployProductionPlane } from "./deploy-production-plane.js";
 export {
   buildVpsCapabilityProposal,
   buildVpsCapabilityReview,
+  buildVpsHelperCommandExecutionBoundary,
   buildVpsMaintenanceApprovalScope,
   applyVpsCapabilityLifecycleOperation,
   planVpsPrivilegedMaintenanceHelperExecution,

--- a/src/core/vps-privileged-maintenance.js
+++ b/src/core/vps-privileged-maintenance.js
@@ -306,6 +306,14 @@ function planVpsPrivilegedMaintenanceHelperExecution(input = {}) {
       issues: registryBinding.issues
     };
   }
+  const executionBoundary = buildVpsHelperCommandExecutionBoundary(registryBinding.binding);
+  if (!executionBoundary.ok) {
+    return {
+      ok: false,
+      error: executionBoundary.error,
+      issues: executionBoundary.issues
+    };
+  }
 
   return {
     ok: true,
@@ -324,6 +332,7 @@ function planVpsPrivilegedMaintenanceHelperExecution(input = {}) {
         workingDirectories: capability.workingDirectories,
         allowedArgs: capability.allowedArgs,
         argv: registryBinding.binding.argv,
+        executionBoundary: executionBoundary.boundary,
         registryBinding: registryBinding.binding
       },
       audit: {
@@ -347,6 +356,7 @@ function planVpsPrivilegedMaintenanceHelperExecution(input = {}) {
       capabilityId: capability.id,
       commandClass: capability.commandClass,
       commandArgv: registryBinding.binding.argv,
+      commandExecutionBoundary: executionBoundary.boundary,
       registryBinding: registryBinding.binding,
       before: {
         manifestVersion: manifest.version,
@@ -445,6 +455,44 @@ function cloneHelperCommandRegistryEntry(entry) {
   };
 }
 
+function buildVpsHelperCommandExecutionBoundary(registryEntry = {}) {
+  const argv = normalizeStringList(registryEntry.argv);
+  const issues = [];
+  if (argv.length === 0) {
+    issues.push("registered helper command argv is required");
+  }
+  const [executable, ...args] = argv;
+  if (executable && executable.includes("/")) {
+    issues.push("registered helper command executable must be a command name resolved by the root helper path allowlist");
+  }
+  if (isShellInterpreter(executable)) {
+    issues.push("registered helper command executable must not be a shell interpreter");
+  }
+  if (argv.some((part) => containsShellSyntax(part))) {
+    issues.push("registered helper command argv must not contain shell syntax");
+  }
+  if (issues.length > 0) {
+    return {
+      ok: false,
+      error: "vps_helper_command_execution_boundary_invalid",
+      issues
+    };
+  }
+  return {
+    ok: true,
+    boundary: {
+      executable,
+      args,
+      shell: false,
+      pathResolution: "root_helper_controlled_path_allowlist",
+      stdin: "none",
+      commandClass: registryEntry.commandClass,
+      requiresRoot: registryEntry.requiresRoot,
+      riskLevel: registryEntry.requiredRiskLevel
+    }
+  };
+}
+
 function normalizeHelperRequest(input = {}) {
   const capability = normalizeVpsCapability(input.capability || {});
   const issues = [...capability.issues];
@@ -520,6 +568,14 @@ function sameStringList(left, right) {
   return JSON.stringify(normalizeStringList(left)) === JSON.stringify(normalizeStringList(right));
 }
 
+function containsShellSyntax(value) {
+  return /[;&|`$<>*?()[\]{}!\\\n\r]/.test(String(value ?? ""));
+}
+
+function isShellInterpreter(value) {
+  return /^(?:sh|bash|zsh|dash|fish|ksh|csh|tcsh)$/.test(normalizeText(value));
+}
+
 function cloneManifest(manifest) {
   return {
     ...manifest,
@@ -565,6 +621,7 @@ export {
   buildVpsCapabilityProposal,
   buildVpsCapabilityReview,
   buildVpsMaintenanceApprovalScope,
+  buildVpsHelperCommandExecutionBoundary,
   applyVpsCapabilityLifecycleOperation,
   planVpsPrivilegedMaintenanceHelperExecution,
   listVpsPrivilegedMaintenanceCommandRegistry,

--- a/test/vps-privileged-maintenance.test.js
+++ b/test/vps-privileged-maintenance.test.js
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import {
   applyVpsCapabilityLifecycleOperation,
+  buildVpsHelperCommandExecutionBoundary,
   buildVpsCapabilityProposal,
   buildVpsMaintenanceApprovalScope,
   listVpsPrivilegedMaintenanceCommandRegistry,
@@ -235,11 +236,53 @@ test("VPS helper dry-run contract validates enabled manifest capability without 
   assert.equal(result.helperPlan.helperExecutionStarted, false);
   assert.deepEqual(result.helperPlan.commandPreview.allowedArgs, ["npx playwright install-deps chromium"]);
   assert.deepEqual(result.helperPlan.commandPreview.argv, ["npx", "playwright", "install-deps", "chromium"]);
+  assert.deepEqual(result.helperPlan.commandPreview.executionBoundary, {
+    executable: "npx",
+    args: ["playwright", "install-deps", "chromium"],
+    shell: false,
+    pathResolution: "root_helper_controlled_path_allowlist",
+    stdin: "none",
+    commandClass: "playwright_install_deps_chromium",
+    requiresRoot: true,
+    riskLevel: "high"
+  });
   assert.equal(result.runtimeTruth.status, "dry_run_ready");
   assert.equal(result.runtimeTruth.registryBinding.commandClass, "playwright_install_deps_chromium");
   assert.deepEqual(result.runtimeTruth.commandArgv, ["npx", "playwright", "install-deps", "chromium"]);
+  assert.equal(result.runtimeTruth.commandExecutionBoundary.shell, false);
+  assert.deepEqual(result.runtimeTruth.commandExecutionBoundary.args, ["playwright", "install-deps", "chromium"]);
   assert.equal(result.runtimeTruth.exitCode, null);
   assert.equal(result.runtimeTruth.redactedLogSummary, "dry-run only; privileged command was not executed");
+});
+
+test("VPS helper command execution boundary rejects shell syntax before any execution path exists", () => {
+  const boundary = buildVpsHelperCommandExecutionBoundary({
+    commandClass: "unsafe",
+    argv: ["sh", "-c", "npx playwright install-deps chromium"],
+    requiredRiskLevel: "high",
+    requiresRoot: true
+  });
+
+  assert.equal(boundary.ok, false);
+  assert.equal(boundary.error, "vps_helper_command_execution_boundary_invalid");
+  assert.equal(boundary.issues.includes("registered helper command executable must not be a shell interpreter"), true);
+});
+
+test("VPS helper command execution boundary requires helper-controlled path resolution", () => {
+  const boundary = buildVpsHelperCommandExecutionBoundary({
+    commandClass: "absolute",
+    argv: ["/usr/bin/npx", "playwright", "install-deps", "chromium"],
+    requiredRiskLevel: "high",
+    requiresRoot: true
+  });
+
+  assert.equal(boundary.ok, false);
+  assert.equal(
+    boundary.issues.includes(
+      "registered helper command executable must be a command name resolved by the root helper path allowlist"
+    ),
+    true
+  );
 });
 
 test("VPS helper dry-run rejects disabled, mismatched, or unregistered capabilities", () => {

--- a/worker.js
+++ b/worker.js
@@ -37456,6 +37456,14 @@ function planVpsPrivilegedMaintenanceHelperExecution(input = {}) {
       issues: registryBinding.issues
     };
   }
+  const executionBoundary = buildVpsHelperCommandExecutionBoundary(registryBinding.binding);
+  if (!executionBoundary.ok) {
+    return {
+      ok: false,
+      error: executionBoundary.error,
+      issues: executionBoundary.issues
+    };
+  }
   return {
     ok: true,
     helperPlan: {
@@ -37473,6 +37481,7 @@ function planVpsPrivilegedMaintenanceHelperExecution(input = {}) {
         workingDirectories: capability.workingDirectories,
         allowedArgs: capability.allowedArgs,
         argv: registryBinding.binding.argv,
+        executionBoundary: executionBoundary.boundary,
         registryBinding: registryBinding.binding
       },
       audit: {
@@ -37496,6 +37505,7 @@ function planVpsPrivilegedMaintenanceHelperExecution(input = {}) {
       capabilityId: capability.id,
       commandClass: capability.commandClass,
       commandArgv: registryBinding.binding.argv,
+      commandExecutionBoundary: executionBoundary.boundary,
       registryBinding: registryBinding.binding,
       before: {
         manifestVersion: manifest.version,
@@ -37571,6 +37581,43 @@ function cloneHelperCommandRegistryEntry(entry) {
     initialPreset: entry.initialPreset
   };
 }
+function buildVpsHelperCommandExecutionBoundary(registryEntry = {}) {
+  const argv = normalizeStringList(registryEntry.argv);
+  const issues = [];
+  if (argv.length === 0) {
+    issues.push("registered helper command argv is required");
+  }
+  const [executable, ...args] = argv;
+  if (executable && executable.includes("/")) {
+    issues.push("registered helper command executable must be a command name resolved by the root helper path allowlist");
+  }
+  if (isShellInterpreter(executable)) {
+    issues.push("registered helper command executable must not be a shell interpreter");
+  }
+  if (argv.some((part) => containsShellSyntax(part))) {
+    issues.push("registered helper command argv must not contain shell syntax");
+  }
+  if (issues.length > 0) {
+    return {
+      ok: false,
+      error: "vps_helper_command_execution_boundary_invalid",
+      issues
+    };
+  }
+  return {
+    ok: true,
+    boundary: {
+      executable,
+      args,
+      shell: false,
+      pathResolution: "root_helper_controlled_path_allowlist",
+      stdin: "none",
+      commandClass: registryEntry.commandClass,
+      requiresRoot: registryEntry.requiresRoot,
+      riskLevel: registryEntry.requiredRiskLevel
+    }
+  };
+}
 function normalizeHelperRequest(input = {}) {
   const capability = normalizeVpsCapability(input.capability || {});
   const issues = [...capability.issues];
@@ -37639,6 +37686,12 @@ function sanitizeHelperCapability(capability) {
 }
 function sameStringList(left, right) {
   return JSON.stringify(normalizeStringList(left)) === JSON.stringify(normalizeStringList(right));
+}
+function containsShellSyntax(value) {
+  return /[;&|`$<>*?()[\]{}!\\\n\r]/.test(String(value ?? ""));
+}
+function isShellInterpreter(value) {
+  return /^(?:sh|bash|zsh|dash|fish|ksh|csh|tcsh)$/.test(normalizeText24(value));
 }
 function normalizeCapabilityId(value) {
   return normalizeText24(value).toLowerCase().replace(/[^a-z0-9_.:-]+/g, "-").replace(/^-+|-+$/g, "");


### PR DESCRIPTION
# Issue #637 VPS helper execution boundaryを追加

## This PR satisfies Intent

Issue #637 の部分進捗です。PR #648 の残リスクだった「argv が将来の実行時に shell 文字列へ再変換される」「`npx` の PATH 境界が曖昧になる」を、実行権限を増やさず dry-run contract 側で先に塞ぎます。

helper dry-run が registry 由来 argv から `executable + args + shell:false` の execution boundary を作り、runtime truth に返します。root-owned helper の実装は、この boundary を `spawn` 相当へ渡す前提になります。

## Satisfied Success Criteria

- helper dry-run が command argv から execution boundary を正規化する。
- execution boundary は `shell:false`、`executable`、`args`、`pathResolution`、`stdin:none` を runtime truth に出す。
- shell interpreter と shell syntax を registry argv 境界で拒否する。
- 絶対パス executable を拒否し、root helper controlled PATH allowlist で解決する契約に寄せる。
- lifecycle doc に、operator-specific Node/NVM path を public runtime truth に焼かないことを明記する。

## Unsatisfied Success Criteria

- root-owned helper install は未実装。
- sudoers / systemd / root-owned manifest の実配置は未実装。
- 実コマンド実行は未実装。
- root helper controlled PATH allowlist の実装は未実装。
- iPhone/PWA live E2E は未実行。
- Issue #637 は未完了であり、この PR では close しない。

## Dry-run Impact Report

- Target Issue: Issue #637
- Implementing Success Criteria: root-owned helper execution boundary contract for argv-based execution
- Explicit Non-goals: real root execution, VPS permission mutation, sudoers/systemd, deploy, Issue close
- Expected touched files/routes/workflows: `src/core/vps-privileged-maintenance.js`, `src/core/index.js`, `test/vps-privileged-maintenance.test.js`, `docs/butler/vps-privileged-maintenance-capability-lifecycle.md`, `worker.js`
- Affected Issues: Issue #637 progresses but remains incomplete
- Affected PRs: follows PR #648
- Affected workflows: Worker build, Node tests, generated worker parity
- Affected runtime/operator surfaces: dry-run runtime truth gains `commandExecutionBoundary`; no new route or operationId
- What may break if we patch narrowly: any future execution code that expects raw shell command strings must adapt to `executable + args + shell:false`.
- Unknowns to investigate before coding: root helper controlled PATH allowlist source, root-owned manifest install path, sudoers wrapper, audit log write path, actual `child_process.spawn` call site.
- Validation needed: targeted tests, `npm run build:worker`, full `npm test`.
- Stop condition: real execution, permission mutation, deploy, sudoers/systemd changes require scoped passkey/PWA approval.

## Execution Queue Delta

- Queue position before: Issue #637 is `Now`; PR #648 was merged.
- Preemption decision: `NEXT`
- Queue delta: Issue #637 remains `Now`; PR #648 follow-up residual risk moves into this PR as an execution-boundary dry-run slice.
- Why this PR is next: fallback reviewer approved PR #648 but explicitly called out shell reconversion and PATH boundary risk.
- Active Issues not downscoped: active Issues are not downscoped; this is a bounded Issue #637 slice only.

## File / Line Hypotheses

- `src/core/vps-privileged-maintenance.js`: build and validate execution boundary from registry argv.
- `src/core/index.js`: expose the boundary helper for direct tests and future helper wiring.
- `test/vps-privileged-maintenance.test.js`: assert dry-run truth and boundary rejection cases.
- `docs/butler/vps-privileged-maintenance-capability-lifecycle.md`: document root helper controlled PATH boundary.
- `worker.js`: generated worker bundle must match source changes.

## Hypothesis Retrospective

The narrow boundary change was sufficient. The PR adds a machine-readable execution boundary without expanding authority, adding a route, or starting privileged execution.

## Verification Evidence

- `node --test test/vps-privileged-maintenance.test.js test/vps-privileged-maintenance-helper-script.test.js`
  - Result: 13 pass
- `npm run build:worker`
  - Result: pass
- `npm test`
  - Result: 1049 pass / 1 skip / 0 fail
  - `check:self-parity`: 29 routes / 29 operationIds
  - `check:generated-worker`: pass

## Butler Completion Contract

- Owner goal: Butler/root helper work can expose a shell-free execution boundary before any privileged execution implementation.
- Butler entrypoint: existing `vtddDryRunVpsMaintenanceHelper`
- Action Schema exposure: no change; existing operationId remains connected.
- Runtime path: existing `/v2/vps/privileged-maintenance/helper-dry-runs`; real VPS helper execution remains unconnected.
- Runner/runtime truth: dry-run truth includes `commandExecutionBoundary`; actual VPS helper runner execution remains unconnected.
- Authority boundary: no root execution; real execution requires scoped passkey/PWA approval.
- E2E evidence: none in this PR; unit/build/generated-worker evidence only.
- Completion status: incomplete

## Surface Update Checklist

- Custom GPT Action Schema: no change
- Dashboard Butler UX: no change
- Passkey approval: no change
- VPS runner/helper: execution boundary preview only; no execution
- Docs/RAG: lifecycle doc updated; no new RAG write in this PR
- Public/core safety: no owner URL, sudo password, secret, operator-specific Node/NVM path, or runtime destination added
