### PR TITLE
#637 VPS helper shell boundary指摘を修正

### DIFF
--- a/docs/butler/vps-privileged-maintenance-capability-lifecycle.md
+++ b/docs/butler/vps-privileged-maintenance-capability-lifecycle.md
@@ -92,7 +92,8 @@ The dry-run runtime truth must expose the normalized execution boundary as
 `executable + args + shell:false`. The root-owned helper is responsible for
 resolving `executable` through a controlled PATH allowlist; the repository
 contract must not bake an operator-specific Node/NVM path into public runtime
-truth.
+truth. `allowedArgs` is display-only review text and must not be used as the
+helper execution input.
 
 ## Initial Presets
 

--- a/src/core/vps-privileged-maintenance.js
+++ b/src/core/vps-privileged-maintenance.js
@@ -331,6 +331,7 @@ function planVpsPrivilegedMaintenanceHelperExecution(input = {}) {
         commandClass: capability.commandClass,
         workingDirectories: capability.workingDirectories,
         allowedArgs: capability.allowedArgs,
+        allowedArgsPurpose: "display_only_not_execution_input",
         argv: registryBinding.binding.argv,
         executionBoundary: executionBoundary.boundary,
         registryBinding: registryBinding.binding
@@ -356,6 +357,7 @@ function planVpsPrivilegedMaintenanceHelperExecution(input = {}) {
       capabilityId: capability.id,
       commandClass: capability.commandClass,
       commandArgv: registryBinding.binding.argv,
+      allowedArgsPurpose: "display_only_not_execution_input",
       commandExecutionBoundary: executionBoundary.boundary,
       registryBinding: registryBinding.binding,
       before: {
@@ -465,8 +467,11 @@ function buildVpsHelperCommandExecutionBoundary(registryEntry = {}) {
   if (executable && executable.includes("/")) {
     issues.push("registered helper command executable must be a command name resolved by the root helper path allowlist");
   }
-  if (isShellInterpreter(executable)) {
-    issues.push("registered helper command executable must not be a shell interpreter");
+  if (isShellInterpreter(executable) || args.some(isShellInterpreter)) {
+    issues.push("registered helper command argv must not include a shell interpreter");
+  }
+  if (executable === "env" && args.some((part) => part === "-S" || part === "-c")) {
+    issues.push("registered helper command argv must not use env to invoke command parsing");
   }
   if (argv.some((part) => containsShellSyntax(part))) {
     issues.push("registered helper command argv must not contain shell syntax");

--- a/test/vps-privileged-maintenance.test.js
+++ b/test/vps-privileged-maintenance.test.js
@@ -235,6 +235,7 @@ test("VPS helper dry-run contract validates enabled manifest capability without 
   assert.equal(result.helperPlan.rootExecutionStarted, false);
   assert.equal(result.helperPlan.helperExecutionStarted, false);
   assert.deepEqual(result.helperPlan.commandPreview.allowedArgs, ["npx playwright install-deps chromium"]);
+  assert.equal(result.helperPlan.commandPreview.allowedArgsPurpose, "display_only_not_execution_input");
   assert.deepEqual(result.helperPlan.commandPreview.argv, ["npx", "playwright", "install-deps", "chromium"]);
   assert.deepEqual(result.helperPlan.commandPreview.executionBoundary, {
     executable: "npx",
@@ -249,6 +250,7 @@ test("VPS helper dry-run contract validates enabled manifest capability without 
   assert.equal(result.runtimeTruth.status, "dry_run_ready");
   assert.equal(result.runtimeTruth.registryBinding.commandClass, "playwright_install_deps_chromium");
   assert.deepEqual(result.runtimeTruth.commandArgv, ["npx", "playwright", "install-deps", "chromium"]);
+  assert.equal(result.runtimeTruth.allowedArgsPurpose, "display_only_not_execution_input");
   assert.equal(result.runtimeTruth.commandExecutionBoundary.shell, false);
   assert.deepEqual(result.runtimeTruth.commandExecutionBoundary.args, ["playwright", "install-deps", "chromium"]);
   assert.equal(result.runtimeTruth.exitCode, null);
@@ -265,7 +267,7 @@ test("VPS helper command execution boundary rejects shell syntax before any exec
 
   assert.equal(boundary.ok, false);
   assert.equal(boundary.error, "vps_helper_command_execution_boundary_invalid");
-  assert.equal(boundary.issues.includes("registered helper command executable must not be a shell interpreter"), true);
+  assert.equal(boundary.issues.includes("registered helper command argv must not include a shell interpreter"), true);
 });
 
 test("VPS helper command execution boundary requires helper-controlled path resolution", () => {
@@ -283,6 +285,19 @@ test("VPS helper command execution boundary requires helper-controlled path reso
     ),
     true
   );
+});
+
+test("VPS helper command execution boundary rejects env shell trampoline argv", () => {
+  const boundary = buildVpsHelperCommandExecutionBoundary({
+    commandClass: "unsafe-env",
+    argv: ["env", "bash", "-c", "npx playwright install-deps chromium"],
+    requiredRiskLevel: "high",
+    requiresRoot: true
+  });
+
+  assert.equal(boundary.ok, false);
+  assert.equal(boundary.error, "vps_helper_command_execution_boundary_invalid");
+  assert.equal(boundary.issues.includes("registered helper command argv must not include a shell interpreter"), true);
 });
 
 test("VPS helper dry-run rejects disabled, mismatched, or unregistered capabilities", () => {

--- a/worker.js
+++ b/worker.js
@@ -37480,6 +37480,7 @@ function planVpsPrivilegedMaintenanceHelperExecution(input = {}) {
         commandClass: capability.commandClass,
         workingDirectories: capability.workingDirectories,
         allowedArgs: capability.allowedArgs,
+        allowedArgsPurpose: "display_only_not_execution_input",
         argv: registryBinding.binding.argv,
         executionBoundary: executionBoundary.boundary,
         registryBinding: registryBinding.binding
@@ -37505,6 +37506,7 @@ function planVpsPrivilegedMaintenanceHelperExecution(input = {}) {
       capabilityId: capability.id,
       commandClass: capability.commandClass,
       commandArgv: registryBinding.binding.argv,
+      allowedArgsPurpose: "display_only_not_execution_input",
       commandExecutionBoundary: executionBoundary.boundary,
       registryBinding: registryBinding.binding,
       before: {
@@ -37591,8 +37593,11 @@ function buildVpsHelperCommandExecutionBoundary(registryEntry = {}) {
   if (executable && executable.includes("/")) {
     issues.push("registered helper command executable must be a command name resolved by the root helper path allowlist");
   }
-  if (isShellInterpreter(executable)) {
-    issues.push("registered helper command executable must not be a shell interpreter");
+  if (isShellInterpreter(executable) || args.some(isShellInterpreter)) {
+    issues.push("registered helper command argv must not include a shell interpreter");
+  }
+  if (executable === "env" && args.some((part) => part === "-S" || part === "-c")) {
+    issues.push("registered helper command argv must not use env to invoke command parsing");
   }
   if (argv.some((part) => containsShellSyntax(part))) {
     issues.push("registered helper command argv must not contain shell syntax");


### PR DESCRIPTION
# Issue #637 VPS helper shell boundary指摘を修正

## This PR satisfies Intent

Issue #637 / PR #649 の follow-up です。PR #649 は自動マージされましたが、同じ head に fallback reviewer の `request_changes` が残っていました。この PR はその指摘を正面から潰します。

具体的には、`env bash -c ...` のように executable が shell でなくても args 側から shell interpreter を起動する argv を拒否します。また、`allowedArgs` が将来の実行入力ではなく display-only review text であることを dry-run plan と runtime truth に明示します。

## Satisfied Success Criteria

- helper execution boundary が argv 内の shell interpreter trampoline を拒否する。
- `env bash -c ...` 形式を test で明示的に拒否する。
- dry-run `commandPreview` と `runtimeTruth` に `allowedArgsPurpose: display_only_not_execution_input` を追加する。
- lifecycle doc に `allowedArgs` を helper execution input として使わないことを明記する。
- generated `worker.js` を source と同期する。

## Unsatisfied Success Criteria

- root-owned helper install は未実装。
- sudoers / systemd / root-owned manifest の実配置は未実装。
- 実コマンド実行は未実装。
- root helper controlled PATH allowlist の実装は未実装。
- iPhone/PWA live E2E は未実行。
- Issue #637 は未完了であり、この PR では close しない。

## Dry-run Impact Report

- Target Issue: Issue #637
- Implementing Success Criteria: PR #649 reviewer request_changes follow-up for shell trampoline rejection and display-only allowedArgs truth
- Explicit Non-goals: real root execution, VPS permission mutation, sudoers/systemd, deploy, Issue close
- Expected touched files/routes/workflows: `src/core/vps-privileged-maintenance.js`, `test/vps-privileged-maintenance.test.js`, `docs/butler/vps-privileged-maintenance-capability-lifecycle.md`, `worker.js`
- Affected Issues: Issue #637 progresses but remains incomplete
- Affected PRs: follows PR #649
- Affected workflows: Worker build, Node tests, generated worker parity
- Affected runtime/operator surfaces: dry-run output gains `allowedArgsPurpose`; no new route or operationId
- What may break if we patch narrowly: consumers that interpreted `allowedArgs` as executable input must switch to `commandExecutionBoundary`.
- Unknowns to investigate before coding: root helper controlled PATH allowlist source, root-owned manifest install path, sudoers wrapper, audit log write path, actual `child_process.spawn` call site.
- Validation needed: targeted tests, `npm run build:worker`, full `npm test`.
- Stop condition: real execution, permission mutation, deploy, sudoers/systemd changes require scoped passkey/PWA approval.

## Execution Queue Delta

- Queue position before: Issue #637 is `Now`; PR #649 was merged with a same-head request_changes comment still present.
- Preemption decision: `EVIDENCE`
- Queue delta: Issue #637 remains `Now`; PR #649 reviewer objection is moved into this corrective PR.
- Why this PR is next: leaving the request_changes comment unresolved would preserve a known shell-boundary hole and repeat the review-gate mistake.
- Active Issues not downscoped: active Issues are not downscoped; this is a bounded Issue #637 correction only.

## File / Line Hypotheses

- `src/core/vps-privileged-maintenance.js`: reject shell interpreter args and expose `allowedArgsPurpose`.
- `test/vps-privileged-maintenance.test.js`: add env trampoline rejection and display-only assertions.
- `docs/butler/vps-privileged-maintenance-capability-lifecycle.md`: document display-only allowedArgs boundary.
- `worker.js`: generated worker bundle must match source changes.

## Hypothesis Retrospective

The reviewer finding was valid. The previous boundary rejected direct `sh`/`bash` executable usage but did not reject `env bash -c ...`. This PR closes that specific path and makes the display-vs-execution boundary visible in runtime truth.

## Verification Evidence

- `node --test test/vps-privileged-maintenance.test.js test/vps-privileged-maintenance-helper-script.test.js`
  - Result: 14 pass
- `npm run build:worker`
  - Result: pass
- `npm test`
  - Result: 1050 pass / 1 skip / 0 fail
  - `check:self-parity`: 29 routes / 29 operationIds
  - `check:generated-worker`: pass

## Butler Completion Contract

- Owner goal: Butler/root helper work can expose a shell-free execution boundary and unambiguous display-only allowedArgs before privileged execution exists.
- Butler entrypoint: existing `vtddDryRunVpsMaintenanceHelper`
- Action Schema exposure: no change; existing operationId remains connected.
- Runtime path: existing `/v2/vps/privileged-maintenance/helper-dry-runs`; real VPS helper execution remains unconnected.
- Runner/runtime truth: dry-run truth includes `commandExecutionBoundary` and `allowedArgsPurpose`; actual VPS helper runner execution remains unconnected.
- Authority boundary: no root execution; real execution requires scoped passkey/PWA approval.
- E2E evidence: none in this PR; unit/build/generated-worker evidence only.
- Completion status: incomplete

## Surface Update Checklist

- Custom GPT Action Schema: no change
- Dashboard Butler UX: no change
- Passkey approval: no change
- VPS runner/helper: shell-boundary preview only; no execution
- Docs/RAG: lifecycle doc updated; no new RAG write in this PR
- Public/core safety: no owner URL, sudo password, secret, operator-specific Node/NVM path, or runtime destination added
