### PR TITLE
#651 auto-merge conflicting reviewer evidenceを停止

### DIFF
--- a/scripts/run-approve-auto-merge.mjs
+++ b/scripts/run-approve-auto-merge.mjs
@@ -210,6 +210,11 @@ async function processPullRequest({ githubFetch, repository, pullNumber, eventNa
     pullRequest: contextPull,
     mergeResult
   });
+  const latestIssueComments = await githubFetchAll(githubFetch, `/repos/${repository}/issues/${pullNumber}/comments?per_page=100`);
+  if (hasExecutedAutoMergeComment({ issueComments: latestIssueComments, headSha: pullRequest.head?.sha })) {
+    console.log(`Skipping PR #${pullNumber}: auto merge executed comment already exists after merge.`);
+    return;
+  }
 
   await githubFetch(`/repos/${repository}/issues/${pullNumber}/comments`, {
     method: "POST",

--- a/src/core/approve-auto-merge.js
+++ b/src/core/approve-auto-merge.js
@@ -39,6 +39,11 @@ export function evaluateApproveAutoMerge(input = {}) {
   const reasons = [];
   const evidence = [];
   const blockingLabels = labels.filter((label) => AUTO_MERGE_BLOCK_LABELS.has(label));
+  const unresolvedReviewerEvidence = findUnresolvedReviewerEvidenceConflict({
+    timeline: reviewLoop.reviewTimeline,
+    headSha: pullRequest.headSha,
+    reviewerEvidence: reviewLoop.reviewerEvidence
+  });
 
   if (policyMode !== ApproveAutoMergePolicyMode.APPROVE_AUTO_MERGE) {
     reasons.push("approve_auto_merge policy is not enabled for this repository, Issue, or PR.");
@@ -92,6 +97,11 @@ export function evaluateApproveAutoMerge(input = {}) {
   if (reviewLoop.unresolvedReviewCommentsCount > 0) {
     reasons.push("unresolved reviewer objections remain.");
   }
+  if (unresolvedReviewerEvidence) {
+    reasons.push(
+      `unresolved reviewer request_changes remains for current head: ${unresolvedReviewerEvidence.reviewer || "unknown"} ${unresolvedReviewerEvidence.url || "unknown url"}.`
+    );
+  }
   if (reviewLoop.criticalReviewPending) {
     reasons.push("critical review is still pending.");
   }
@@ -126,6 +136,7 @@ export function evaluateApproveAutoMerge(input = {}) {
   evidence.push(`reviewer=${reviewLoop.reviewer || "unknown"}`);
   evidence.push(`reviewerAction=${reviewLoop.reviewerEvidence?.recommendedAction || "none"}`);
   evidence.push(`reviewerHeadSha=${reviewLoop.reviewerEvidence?.headSha || "unknown"}`);
+  evidence.push(`reviewerConflict=${unresolvedReviewerEvidence ? "unresolved_request_changes" : "none"}`);
   evidence.push(`mergeable=${String(pullRequest.mergeability.mergeable)}`);
   evidence.push(`mergeableState=${pullRequest.mergeability.mergeableState || "unknown"}`);
   evidence.push(`checks=${checkTruth.summary}`);
@@ -376,8 +387,70 @@ function normalizeReviewLoop(value) {
       : null,
     unresolvedReviewCommentsCount: normalizeCount(input.unresolvedReviewCommentsCount),
     criticalReviewPending: input.criticalReviewPending === true,
+    reviewTimeline: timeline,
     hasRunawayIncident: timeline.some((item) => normalizeText(item?.type) === "reviewer_runaway"),
     hasActorIdentityIncident: timeline.some((item) => normalizeText(item?.type) === "vtdd_incident")
+  };
+}
+
+function findUnresolvedReviewerEvidenceConflict({ timeline, headSha, reviewerEvidence } = {}) {
+  const normalizedHeadSha = normalizeText(headSha);
+  if (normalizeText(reviewerEvidence?.recommendedAction).toLowerCase() !== "approve") {
+    return null;
+  }
+  const reviewerHeadSha = normalizeText(reviewerEvidence?.headSha);
+  if (normalizedHeadSha && reviewerHeadSha && reviewerHeadSha !== normalizedHeadSha) {
+    return null;
+  }
+
+  const sorted = (Array.isArray(timeline) ? timeline : [])
+    .map(normalizeReviewTimelineItem)
+    .filter(Boolean)
+    .filter((item) => !normalizedHeadSha || !item.headSha || item.headSha === normalizedHeadSha)
+    .sort((left, right) => left.time - right.time);
+  const latestApprove = [...sorted]
+    .reverse()
+    .find((item) => normalizeText(item.recommendedAction).toLowerCase() === "approve");
+  if (!latestApprove) {
+    return null;
+  }
+
+  const blocking = [...sorted]
+    .reverse()
+    .find((item) => {
+      if (item.time >= latestApprove.time) {
+        return false;
+      }
+      const action = normalizeText(item.recommendedAction).toLowerCase();
+      return action === "request_changes" || action === "manual_review";
+    });
+  if (!blocking) {
+    return null;
+  }
+
+  const resolved = sorted.some((item) => {
+    if (item.type !== "reviewer_objection_resolution") {
+      return false;
+    }
+    return item.time > blocking.time && item.time < latestApprove.time;
+  });
+  return resolved ? null : blocking;
+}
+
+function normalizeReviewTimelineItem(item) {
+  if (!item || typeof item !== "object") {
+    return null;
+  }
+  const createdAt = normalizeText(item.createdAt || item.created_at);
+  const updatedAt = normalizeText(item.updatedAt || item.updated_at);
+  return {
+    type: normalizeText(item.type),
+    reviewer: normalizeText(item.reviewer),
+    recommendedAction: normalizeText(item.recommendedAction).toLowerCase(),
+    blocking: item.blocking === true,
+    headSha: normalizeText(item.headSha),
+    url: normalizeText(item.url),
+    time: Date.parse(createdAt || updatedAt) || 0
   };
 }
 

--- a/test/approve-auto-merge-workflow.test.js
+++ b/test/approve-auto-merge-workflow.test.js
@@ -49,6 +49,8 @@ test("approve auto merge treats concurrent GitHub merge race as idempotent", () 
 
   assert.equal(isMergeAlreadyInProgressError(raceError), true);
   assert.equal(script.includes("merge is already in progress by another approve-auto-merge run"), true);
+  assert.equal(script.includes("auto merge executed comment already exists after merge"), true);
+  assert.equal(script.includes("const latestIssueComments = await githubFetchAll"), true);
 
   const unrelated405 = new Error("GitHub API 405: Method Not Allowed");
   unrelated405.status = 405;

--- a/test/approve-auto-merge.test.js
+++ b/test/approve-auto-merge.test.js
@@ -108,6 +108,83 @@ test("approve auto merge blocks stale reviewer head SHA", () => {
   assert.equal(result.reasons.includes("reviewer evidence head SHA does not match current PR head SHA."), true);
 });
 
+test("approve auto merge blocks same-head request changes even when a later approve exists", () => {
+  const result = evaluateApproveAutoMerge({
+    policyMode: ApproveAutoMergePolicyMode.APPROVE_AUTO_MERGE,
+    pullRequest: mergeablePullRequest,
+    reviewLoop: {
+      ...approvedReviewLoop,
+      reviewTimeline: [
+        {
+          type: "codex_fallback",
+          reviewer: "codex",
+          recommendedAction: "request_changes",
+          headSha: "abc123",
+          url: "https://github.com/sample-org/vtdd-v2-p/pull/10#issuecomment-request",
+          createdAt: "2026-05-29T10:23:40Z"
+        },
+        {
+          type: "codex_fallback",
+          reviewer: "codex",
+          recommendedAction: "approve",
+          headSha: "abc123",
+          url: "https://github.com/sample-org/vtdd-v2-p/pull/10#issuecomment-approve",
+          createdAt: "2026-05-29T10:23:45Z"
+        }
+      ]
+    },
+    checkRuns: successChecks
+  });
+
+  assert.equal(result.allowed, false);
+  assert.equal(
+    result.reasons.some((reason) =>
+      reason.includes("unresolved reviewer request_changes remains for current head")
+    ),
+    true
+  );
+  assert.equal(result.evidence.includes("reviewerConflict=unresolved_request_changes"), true);
+});
+
+test("approve auto merge allows same-head approve after trusted objection resolution marker", () => {
+  const result = evaluateApproveAutoMerge({
+    policyMode: ApproveAutoMergePolicyMode.APPROVE_AUTO_MERGE,
+    pullRequest: mergeablePullRequest,
+    reviewLoop: {
+      ...approvedReviewLoop,
+      reviewTimeline: [
+        {
+          type: "codex_fallback",
+          reviewer: "codex",
+          recommendedAction: "request_changes",
+          headSha: "abc123",
+          url: "https://github.com/sample-org/vtdd-v2-p/pull/10#issuecomment-request",
+          createdAt: "2026-05-29T10:23:40Z"
+        },
+        {
+          type: "reviewer_objection_resolution",
+          reviewer: "vtdd-codex",
+          headSha: "abc123",
+          url: "https://github.com/sample-org/vtdd-v2-p/pull/10#issuecomment-response",
+          createdAt: "2026-05-29T10:23:43Z"
+        },
+        {
+          type: "codex_fallback",
+          reviewer: "codex",
+          recommendedAction: "approve",
+          headSha: "abc123",
+          url: "https://github.com/sample-org/vtdd-v2-p/pull/10#issuecomment-approve",
+          createdAt: "2026-05-29T10:23:45Z"
+        }
+      ]
+    },
+    checkRuns: successChecks
+  });
+
+  assert.equal(result.allowed, true);
+  assert.equal(result.evidence.includes("reviewerConflict=none"), true);
+});
+
 test("approve auto merge remains opt-in by policy or labels", () => {
   assert.equal(resolveApproveAutoMergePolicy({}), ApproveAutoMergePolicyMode.MANUAL);
   assert.equal(


### PR DESCRIPTION
# Issue #651 auto-merge conflicting reviewer evidenceを停止

## This PR satisfies Intent

Issue #651 の実装です。2026-05-29 の PR #649 で、同じ head に Codex fallback `request_changes` と後続 `approve` が並んだにもかかわらず auto-merge が通った事故を regression として扱います。

この PR は、approve-auto-merge gate が同一 head の未解決 `request_changes` / `manual_review` reviewer marker を検出したら、後続 approve があっても自動マージを止めるようにします。trusted objection resolution marker が request_changes と approve の間にある場合だけ解消済みとして扱います。

## Satisfied Success Criteria

- approve-auto-merge が同一 head の未解決 `request_changes` reviewer marker を検出したら停止する。
- PR #649 相当の request_changes -> approve timeline を unit test で再現した。
- trusted objection resolution marker が間にある場合は、同一 head approve を許可する。
- stop 理由に reviewer / URL / head conflict evidence を含める。
- merge 後に executed comment を投稿する直前、最新 issue comments を再取得して duplicate executed comment を抑止する。

## Unsatisfied Success Criteria

- live GitHub E2E は未実行。
- Issue #651 の close は、この PR merge と reviewer/CI evidence 確認後に別途判断する。

## Dry-run Impact Report

- Target Issue: Issue #651
- Implementing Success Criteria: conflicting reviewer evidence blocker and duplicate executed comment suppression
- Explicit Non-goals: deploy, credential mutation, permission mutation, PR #649 revert, Issue #637 root helper implementation
- Expected touched files/routes/workflows: `src/core/approve-auto-merge.js`, `scripts/run-approve-auto-merge.mjs`, `test/approve-auto-merge.test.js`, `test/approve-auto-merge-workflow.test.js`
- Affected Issues: Issue #651
- Affected PRs: follows PR #649 and PR #650
- Affected workflows: approve-auto-merge, guarded Node tests
- Affected runtime/operator surfaces: auto-merge stop comment may appear when reviewer evidence conflicts; no route or operationId change
- What may break if we patch narrowly: PRs with same-head request_changes followed by approve but no trusted objection response will no longer auto-merge.
- Unknowns to investigate before coding: whether GitHub formal CHANGES_REQUESTED should share the exact same timeline conflict mechanism in a later slice.
- Validation needed: targeted approve-auto-merge tests, full `npm test`.
- Stop condition: repository administration, branch protection, or deploy changes are out of scope and require scoped approval.

## Execution Queue Delta

- Queue position before: Issue #637 was `Now`; PR #650 merged as corrective follow-up.
- Preemption decision: `EMERGENCY`
- Queue delta: Issue #651 moves to `Now` as a safety preemption; Issue #637 remains active but is temporarily paused while this review/merge gate is fixed.
- Why this PR is next: continuing more #637 PRs while auto-merge can ignore same-head request_changes would make the serial queue unsafe.
- Active Issues not downscoped: active Issues are not downscoped; this PR fixes a newly discovered gate bug, then work returns to Issue #637.

## File / Line Hypotheses

- `src/core/approve-auto-merge.js`: evaluate reviewer timeline conflicts before allowing merge.
- `scripts/run-approve-auto-merge.mjs`: re-read comments after merge to avoid duplicate executed evidence.
- `test/approve-auto-merge.test.js`: regression fixture for PR #649-style conflicting reviewer evidence.
- `test/approve-auto-merge-workflow.test.js`: script evidence for post-merge executed comment duplicate check.

## Hypothesis Retrospective

The gate bug was in auto-merge evaluation rather than in PR #650's code. `execution-continuity` may still report the latest approve as available for status, but auto-merge now applies the stricter same-head unresolved-objection gate before merging.

## Verification Evidence

- `node --test test/approve-auto-merge.test.js test/approve-auto-merge-workflow.test.js test/execution-continuity.test.js`
  - Result: 47 pass
- `npm run build:worker`
  - Result: pass
- `npm test`
  - Result: 1052 pass / 1 skip / 0 fail
  - `check:self-parity`: 29 routes / 29 operationIds
  - `check:generated-worker`: pass

## Butler Completion Contract

- Owner goal: reviewer objection が残った PR を Butler/automation が勝手に merge しない。
- Butler entrypoint: GitHub PR / auto-merge workflow truth; no new natural-language operationId.
- Action Schema exposure: no change.
- Runtime path: GitHub Actions `approve-auto-merge`; no Worker route change.
- Runner/runtime truth: blocked/candidate/executed PR comments remain the runtime truth surface.
- Authority boundary: no deploy, credential, permission, or destructive runtime mutation.
- E2E evidence: no live E2E; unit/workflow-script/full-test evidence only.
- Completion status: incomplete

## Surface Update Checklist

- Custom GPT Action Schema: no change
- Dashboard Butler UX: no change
- Passkey approval: no change
- VPS runner/helper: no change
- Docs/RAG: no new RAG write in this PR body; auto-merge may persist working memory after merge
- Public/core safety: no owner URL, secret, credential, or operator-specific runtime destination added
