### PR TITLE
Issue #495 repo-backed chief-butler skillを追加

### DIFF
--- a/.agents/skills/vtdd-chief-butler/SKILL.md
+++ b/.agents/skills/vtdd-chief-butler/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: vtdd-chief-butler
+description: Use for VTDD, Dashboard Butler, marushu/vtdd-v2-p, Butler handoff, traffic control, RAG, preflight, Issue/PR/deploy work, notification regressions, passkey/approval boundaries, voice/text Butler UX, and owner drift reports. Enforces issue traceability, repository sharing, authority boundaries, and Butler-first completion before coding.
+---
+
+# VTDD Chief Butler
+
+This Skill is a repository-backed traffic-control contract. It must not exist
+only in a local mac Codex install.
+
+Use it before acting on VTDD / Dashboard Butler work. The purpose is to prevent
+drift: do not treat a fresh complaint as an isolated fix if Issue, PR, deploy,
+runtime truth, RAG history, or execution queue state can explain it.
+
+## Product Premise
+
+VTDD's normal operating center is:
+
+`Owner on iPhone/iPad -> Dashboard Butler -> VTDD runtime -> VPS Codex CLI`
+
+mac Codex is a bootstrap, debug, or emergency support surface while Dashboard
+Butler and VPS Codex CLI are incomplete. It is not the canonical owner-facing
+operator.
+
+If a capability needed for VTDD exists only on mac Codex, treat that as a
+defect, not as an acceptable operating mode. Either promote it to repository /
+runtime / VPS-readable truth or remove the dependency.
+
+Use these labels for discovery and repair tracking only:
+
+- `mac_codex_only_probe`: useful local investigation only
+- `butler_gap_found`: Dashboard Butler cannot use or observe it
+- `vps_handoff_gap_found`: VPS Codex CLI cannot reproduce or execute it
+- `recovery_gap_found`: iPhone/iPad recovery is still missing
+
+## Required Startup
+
+Before non-trivial work, read or explicitly mark missing:
+
+- `AGENTS.md`
+- `docs/butler/intent-mode-contract.md`
+- `docs/butler/thread-independent-startup-contract.md` when startup, handoff,
+  RAG recall, or cross-surface consistency matters
+- `docs/butler/execution-queue-contract.md`
+- `docs/mvp/active-issue-execution-queue.md`
+- exact Issue / PR / branch / review / check truth for the current request
+
+Report whether thread-local assumptions have been promoted into durable repo or
+RAG state: `threadLocalAssumptionsPromoted=true`, `false`, or `未確認`.
+
+## Traffic-Control Snapshot
+
+For non-trivial work, produce a short Japanese-first snapshot before coding:
+
+- `対象`: current owner request in one sentence
+- `Issue/PR`: scoped Issue and related PR/deploy/run if known
+- `現状`: runtime truth, not guesswork
+- `境界`: GO/passkey/approval/forbidden boundary
+- `次`: the next concrete action
+
+## Bounded Change Contract
+
+Before runtime code edits, state:
+
+- target Issue number(s)
+- exact Success Criteria being implemented
+- explicit Non-goals
+- files expected to change
+- planned validation
+- whether archived wizard artifacts or owner-specific runtime values are touched
+- whether the change is safe for public/core reuse
+
+If no Issue maps to the change, do not code. Create or propose a bounded Issue
+candidate first.
+
+## Repository Sharing Gate
+
+Do not say a Skill, guardrail, operating rule, or traffic-control behavior is
+shared, repo-backed, durable, or complete unless:
+
+- the rule is in repository files, not only `~/.codex/skills`, plugin cache, or
+  chat memory
+- the changed files are committed on a topic branch
+- the branch is pushed
+- a Japanese-first PR maps the Issue criteria, evidence, and unconnected parts
+- Dashboard Butler / VPS Codex CLI readability is stated honestly
+
+If Dashboard Butler runtime discovery, Custom GPT Action Schema, VPS inventory,
+or E2E is missing, mark the work `unconnected` or `incomplete`.
+
+## Authority Boundary
+
+- Ordinary read/status/proposal work may proceed without high-risk authority.
+- Implementation requires Issue-backed scope and the appropriate GO boundary.
+- Merge, post-merge Issue closure, and merged-branch deletion require explicit
+  scoped `GO`.
+- Deploy, credential mutation, permission mutation, destructive work, or
+  privileged host maintenance require scoped passkey approval.
+- Never ask the owner to paste raw secrets or sudo passwords into Butler chat.
+
+## Operator URL Rule
+
+When the owner asks to show or open a deploy/operator screen, do not only open a
+local browser or describe the route. Return a short clickable Markdown link
+whose href is the complete same-origin absolute URL.
+
+Prefer runtime truth fields such as `selfParity.deployOperatorMarkdownLink`,
+`selfParity.deployOperatorUrl`, or `selfParity.deployRecovery.operatorUrl`.
+Never hard-code an owner-specific production URL into public repository files.
+
+## RAG Candidate Rule
+
+Propose a compact RAG candidate when a durable judgment or failure mode is
+discovered, especially:
+
+- a regression timeline or root cause
+- owner frustration that identifies repeated assistant drift
+- a mac Codex-only capability gap
+- an authority boundary clarification
+- a handoff/preflight/startup rule needed in future threads
+
+Do not persist full transcripts by default. Exclude secrets and raw sensitive
+material.
+
+## Completion Boundary
+
+Using this Skill is not completion evidence. Butler-facing completion still
+requires natural-language reachability, schema/tool exposure, runtime route or
+runner connection, authority boundary, runtime truth, E2E evidence, and PR
+mapping.

--- a/docs/butler/intent-mode-contract.md
+++ b/docs/butler/intent-mode-contract.md
@@ -189,13 +189,27 @@ the behavior into repository docs / `.agents/skills` / runtime truth so
 Dashboard Butler can own the workflow, then commit, push, and open or update the
 PR before claiming the behavior is repository-backed.
 
-The first Skill is `vtdd-status-advisor`:
+The first read-only Skill is `vtdd-status-advisor`:
 
 - mode: Read
 - role: read truth, classify state, surface blockers, advise next action, stop
   before execution
 - authority: readonly
 - completion: never enough by itself for Butler Completion Gate
+
+The central traffic-control Skill is `vtdd-chief-butler`:
+
+- mode: Read / Think / Execute boundary keeper
+- role: preserve Issue traceability, execution queue state, authority boundary,
+  repository sharing, RAG candidate discipline, and Butler-first completion
+- authority: no authority by itself; execution still requires Issue scope, GO,
+  passkey approval, or an explicit forbidden result
+- completion: never enough by itself for Butler Completion Gate
+
+`vtdd-chief-butler` is a core VTDD operating surface, not a personal mac Codex
+convenience. If it exists only under `~/.codex/skills`, that is a defect and a
+ROOT-class `butler_gap_found` / `vps_handoff_gap_found` until the behavior is
+repository-backed and connected to Dashboard Butler / VPS Codex CLI discovery.
 
 Local skills under `~/.codex/skills` are useful bootstrap aids, but they are not
 VTDD completion unless Butler and VPS Codex CLI can read equivalent repo-backed

--- a/docs/mvp/active-issue-execution-queue.md
+++ b/docs/mvp/active-issue-execution-queue.md
@@ -32,7 +32,8 @@ Last rebuilt from GitHub runtime truth: 2026-05-29
   Issue #498, Issue #501, Issue #514, Issue #528, Issue #565,
   Issue #574, Issue #577, Issue #579, Issue #580, Issue #582, Issue #585,
   Issue #587, Issue #589, Issue #590, Issue #594, Issue #595, Issue #599,
-  Issue #604, Issue #605, Issue #606, Issue #613, Issue #620.
+  Issue #604, Issue #605, Issue #606, Issue #613, Issue #620, Issue #637,
+  Issue #651.
 - Recently closed as completed with evidence and owner approval: Issue #573,
   Issue #601, Issue #609.
 - Open PRs read before this queue refresh PR was opened: none.
@@ -57,6 +58,15 @@ Last rebuilt from GitHub runtime truth: 2026-05-29
   Issue #590, Issue #631, and future VPS Codex CLI work. Issue #637 moves to
   `Now`; Issue #590 and PR #632 remain active but should not run in parallel
   while the privileged-maintenance authority path is being organized.
+- 2026-05-29 PR #652 merged Issue #651 same-head conflicting reviewer evidence
+  gate. Issue #651 remains open because mapped live/E2E close-readiness is not
+  complete.
+- 2026-05-29 owner input classified the missing repo-backed
+  `vtdd-chief-butler` traffic-control Skill as `ROOT`: mac Codex had a local
+  chief-butler Skill that Dashboard Butler and VPS Codex CLI could not
+  necessarily read. This is Issue #495 / Issue #595 partial scope and must be
+  treated as `butler_gap_found` plus `vps_handoff_gap_found` until repo-backed
+  Skill, runtime discovery, VPS inventory, and E2E evidence are connected.
 
 ## Now
 
@@ -91,6 +101,11 @@ Root blockers hold multiple active Issues open. They should shape `Now` and
   execution, capability add/disable/remove/rollback/review, and redacted runtime
   truth. It gates Issue #413, Issue #450, Issue #514, Issue #590, Issue #631,
   and future VPS Codex CLI work whenever root/sudo host capability is missing.
+- Issue #495: VPS Codex CLI skill/plugin/MCP parity is a root blocker whenever
+  mac Codex uses local Skills, plugins, or connectors that Dashboard Butler and
+  VPS Codex CLI cannot inventory or reproduce. The `vtdd-chief-butler` gap is
+  evidence that traffic-control behavior must be repo-backed and then connected
+  to runtime discovery before VTDD can claim cross-surface consistency.
 - Issue #528: Dashboard Butler must remain ChatGPT iOS-equivalent while debug /
   ops surfaces are isolated. It gates user-facing acceptance for Issue #574,
   Issue #577, Issue #580, Issue #582, Issue #585, Issue #587, Issue #589, and
@@ -175,6 +190,14 @@ Evidence gaps are active. They are not deferred out of scope.
   still missing and Playwright now fails on missing `ownerPre` contrast target.
   The manual host repair is evidence for Issue #637, not completion of Issue
   #631.
+- Issue #651: PR #652 merged a same-head conflicting reviewer evidence gate, but
+  live/mapped E2E close-readiness evidence is still missing, so the Issue remains
+  open.
+- Issue #495 / Issue #595: repo-backed `vtdd-chief-butler` Skill can remove the
+  immediate mac-local-only traffic-control document gap, but Dashboard Butler
+  runtime discovery, Custom GPT exposure, VPS Codex CLI inventory, and mapped
+  E2E remain incomplete until follow-up implementation proves those surfaces can
+  read and apply the same Skill.
 - Issue #565: connection recovery status has local evidence, but completion still
   depends on the normal chat surface not being dominated by status noise.
 - Issue #577: composer paste normalization has merged implementation slices, but

--- a/scripts/run-dashboard-app-server-bridge.mjs
+++ b/scripts/run-dashboard-app-server-bridge.mjs
@@ -121,9 +121,10 @@ export function buildDashboardTurnInputText(request = {}) {
     `- relatedIssue: ${relatedIssue ? `#${relatedIssue}` : "未指定"}`,
     `- mediaReferences: ${mediaReferences.length}`,
     "- surface: Dashboard Butler PWA via VPS Dashboard Bridge / codex app-server",
-    "- trafficControlRule: Issue/PR/docs/runtime truth を先に読み、blocker / next action / authority boundary / evidence gap を分けて報告する。",
+    "- trafficControlRule: repo-backed vtdd-chief-butler / Issue/PR/docs/runtime truth を先に読み、blocker / next action / authority boundary / evidence gap を分けて報告する。",
     "- completionRule: Butler Completion Gate と E2E evidence が揃うまで Dashboard Butler 完了とは言わない。",
     "- authorityRule: merge / deploy / credential / permission / destructive work は GO または passkey approval が必要。権限が無い場合は実行せず不足を報告する。",
+    "- operatorUrlRule: owner が deploy/operator 画面を出せと言った時は、local browser を開くだけでなく、完全な same-origin absolute URL を href にした短い Markdown link を返す。",
     "- mechanicalBoundary: Dashboard bridge does not grant app-server command, file-change, patch, or permission escalation approvals."
   ];
 

--- a/test/dashboard-app-server-bridge.test.js
+++ b/test/dashboard-app-server-bridge.test.js
@@ -90,6 +90,9 @@ test("dashboard app-server bridge wraps repository traffic-control context into 
   assert.match(text, /repository: marushu\/vtdd-v2-p/);
   assert.match(text, /relatedIssue: #450/);
   assert.match(text, /trafficControlRule/);
+  assert.match(text, /repo-backed vtdd-chief-butler/);
+  assert.match(text, /operatorUrlRule/);
+  assert.match(text, /same-origin absolute URL/);
   assert.match(text, /"currentSurface":"dashboard_butler"/);
   assert.match(text, /"currentNow":"Issue #590: app-server turn timeout must become recoverable\."/);
   assert.match(text, /Butler Completion Gate/);
@@ -918,6 +921,9 @@ test("dashboard app-server bridge passes traffic-control context to codex app-se
   assert.match(inputText, /repository: marushu\/vtdd-v2-p/);
   assert.match(inputText, /relatedIssue: #450/);
   assert.match(inputText, /trafficControlRule/);
+  assert.match(inputText, /repo-backed vtdd-chief-butler/);
+  assert.match(inputText, /operatorUrlRule/);
+  assert.match(inputText, /same-origin absolute URL/);
   assert.match(inputText, /"currentSurface":"dashboard_butler"/);
   assert.match(inputText, /"currentNow":"Issue #590: app-server turn timeout must become recoverable\."/);
   assert.match(inputText, /mechanicalBoundary/);

--- a/test/intent-mode-contract.test.js
+++ b/test/intent-mode-contract.test.js
@@ -4,6 +4,7 @@ import fs from "node:fs";
 
 const CONTRACT_PATH = "docs/butler/intent-mode-contract.md";
 const SKILL_PATH = ".agents/skills/vtdd-status-advisor/SKILL.md";
+const CHIEF_BUTLER_SKILL_PATH = ".agents/skills/vtdd-chief-butler/SKILL.md";
 
 test("intent mode contract preserves autonomy without allowing drift", () => {
   const doc = fs.readFileSync(CONTRACT_PATH, "utf8");
@@ -36,6 +37,9 @@ test("intent mode contract preserves autonomy without allowing drift", () => {
   assert.equal(doc.includes("cost_boundary"), true);
   assert.equal(doc.includes("Dashboard Butler must not become a worse normal chat surface than Custom GPT."), true);
   assert.equal(doc.includes("The historical setup-wizard line is not reactivated by this contract."), true);
+  assert.equal(doc.includes("The central traffic-control Skill is `vtdd-chief-butler`:"), true);
+  assert.equal(doc.includes("`vtdd-chief-butler` is a core VTDD operating surface"), true);
+  assert.equal(doc.includes("ROOT-class `butler_gap_found` / `vps_handoff_gap_found`"), true);
   assert.equal(agents.includes(CONTRACT_PATH), true);
   assert.equal(agents.includes("Dashboard Butler is the intended primary operator surface."), true);
   assert.equal(agents.includes("A local mac Codex Skill is not a VTDD product capability by\nitself."), true);
@@ -46,6 +50,27 @@ test("intent mode contract preserves autonomy without allowing drift", () => {
   assert.equal(agents.includes("After creating or updating a PR, check\nthe PR state again"), true);
   assert.equal(agents.includes(".agents/skills/vtdd-status-advisor/SKILL.md"), true);
   assert.equal(agents.includes("readonly does not mean\npassive"), true);
+});
+
+test("vtdd chief butler skill is repository-backed traffic control", () => {
+  const skill = fs.readFileSync(CHIEF_BUTLER_SKILL_PATH, "utf8");
+
+  assert.equal(skill.includes("name: vtdd-chief-butler"), true);
+  assert.equal(skill.includes("repository-backed traffic-control contract"), true);
+  assert.equal(skill.includes("must not exist\nonly in a local mac Codex install"), true);
+  assert.equal(skill.includes("Owner on iPhone/iPad -> Dashboard Butler -> VTDD runtime -> VPS Codex CLI"), true);
+  assert.equal(skill.includes("defect, not as an acceptable operating mode"), true);
+  assert.equal(skill.includes("`mac_codex_only_probe`"), true);
+  assert.equal(skill.includes("`butler_gap_found`"), true);
+  assert.equal(skill.includes("`vps_handoff_gap_found`"), true);
+  assert.equal(skill.includes("`recovery_gap_found`"), true);
+  assert.equal(skill.includes("Before runtime code edits"), true);
+  assert.equal(skill.includes("Repository Sharing Gate"), true);
+  assert.equal(skill.includes("Dashboard Butler / VPS Codex CLI readability is stated honestly"), true);
+  assert.equal(skill.includes("Operator URL Rule"), true);
+  assert.equal(skill.includes("short clickable Markdown link"), true);
+  assert.equal(skill.includes("complete same-origin absolute URL"), true);
+  assert.equal(skill.includes("Using this Skill is not completion evidence."), true);
 });
 
 test("vtdd status advisor skill is readonly but still gives judgment", () => {


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #495 / Issue #595 の部分進捗として、mac Codex local にだけ存在していた `vtdd-chief-butler` を repo-backed Skill として追加します。
- Dashboard app-server bridge の turn context に repo-backed `vtdd-chief-butler` と operator URL rule を含め、Dashboard Butler 側の入力にも同じ交通整理前提を渡します。
- これは `mac-only capability` を許容する変更ではありません。mac-only 中核能力が見つかった場合は defect / root blocker として扱う、という事故原因の固定です。

## Satisfied Success Criteria

- [x] `.agents/skills/vtdd-chief-butler/SKILL.md` を追加し、交通整理 / bounded change / repository sharing / authority / operator URL / RAG candidate / completion boundary を repo に固定しました。
- [x] `docs/butler/intent-mode-contract.md` に `vtdd-chief-butler` を central traffic-control Skill として明記しました。
- [x] Dashboard app-server bridge の turn input に `repo-backed vtdd-chief-butler` と deploy/operator URL提示 rule を含めました。
- [x] `test/intent-mode-contract.test.js` と `test/dashboard-app-server-bridge.test.js` で、Skill 欠落と bridge context 欠落を検知できるようにしました。
- [x] `docs/mvp/active-issue-execution-queue.md` に Issue #651 の open/evidence gap と、今回の `vtdd-chief-butler` gap を Issue #495 / Issue #595 の root blocker として反映しました。

## Unsatisfied Success Criteria

- Dashboard Butler runtime discovery が `.agents/skills/vtdd-chief-butler/SKILL.md` を実際に inventory して owner-facing runtime truth に出す実装は未完了です。
- VPS Codex CLI が同じ repo-backed Skill を実際に読んで使えることの inventory / E2E evidence は未完了です。
- Custom GPT Action Schema の新 operationId は追加していません。この PR は skill/docs/bridge context/test の接続スライスです。
- Issue #495 / Issue #595 / Issue #637 / Issue #651 はこの PR だけでは close できません。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #495, Issue #595
- Implementing Success Criteria: mac Codex local-only だった chief-butler traffic-control contract を repo-backed Skill に移し、Dashboard bridge input と tests で欠落検知できるようにする。
- Explicit Non-goals: deploy、credential mutation、permission mutation、VPS 設定変更、Custom GPT Action Schema 変更、Issue close、merge、VPS skill inventory 完了宣言。
- Expected touched files/routes/workflows: `.agents/skills/vtdd-chief-butler/SKILL.md`, `docs/butler/intent-mode-contract.md`, `docs/mvp/active-issue-execution-queue.md`, `scripts/run-dashboard-app-server-bridge.mjs`, `test/intent-mode-contract.test.js`, `test/dashboard-app-server-bridge.test.js`。
- Affected Issues: Issue #495, Issue #595。Queue/evidence truth として Issue #637, Issue #651 にも触れますが完了扱いしません。
- Affected PRs: PR #652 の merge 後 truth を queue に反映します。既存 merged PR branch への push はしません。
- Affected workflows: GitHub Actions / reviewer / deploy workflow は変更しません。
- Affected runtime/operator surfaces: Dashboard Butler app-server bridge turn input。Worker runtime route / Custom GPT Action Schema / VPS daemon は変更しません。
- What may break if we patch narrowly: local Skill を repo に置くだけで Dashboard/VPS discovery を完了扱いすると、再び mac Codex だけが便利な状態を隠します。そのため completion status は `unconnected` とし、runtime discovery / VPS inventory / E2E を未完了として明記します。
- Unknowns to investigate before coding: VPS Codex CLI が `.agents/skills` をどの起動時 inventory / prompt context / runtime truth として読むか。Dashboard Butler が Skill discovery を owner-facing にどう表示するか。
- Validation needed: Skill/docs invariant unit test、Dashboard bridge context test、full `npm test`、self-parity、generated-worker check。
- Stop condition: runtime discovery、VPS 設定変更、deploy、credential/permission mutation に進む場合は別の bounded contract と GO/passkey approval が必要です。

## Execution Queue Delta

- Queue position before: Issue #637 が `Now` の root blocker。Issue #495 / Issue #595 は、mac-only 中核 traffic-control capability が発覚したため root blocker として現在の修正対象に割り込む必要があります。
- Preemption decision: ROOT。owner が「mac-only はあってはならない」と明示し、chief-butler が local-only だったため、Issue #637 の実装継続前に共有不能な交通整理能力を repo-backed 化します。
- Queue delta: Issue #495 / Issue #595 に repo-backed chief-butler Skill の部分進捗を追加します。Issue #637 は `Now` として残り、Issue #651 は evidence gap open として残します。
- Why this PR is next: 交通整理役そのものが mac Codex local-only だと、以降の全 Issue で owner が求める Dashboard Butler / VPS Codex CLI 中心の運用判断を再現できません。
- Active Issues not downscoped: Active Issues は縮小しません。このPRで扱わない Issue #637, Issue #651, Issue #631, Issue #590 などは未完了として残します。

## File / Line Hypotheses

- file: `.agents/skills/vtdd-chief-butler/SKILL.md`
  - hypothesis: chief-butler 交通整理ルールを repo-backed Skill に置かない限り、mac Codex だけが中核判断を持つ defect が残る。
  - risk if changed narrowly: local Skill を使った進捗が Dashboard Butler / VPS Codex CLI に共有されず、また drift する。
  - validation: `test/intent-mode-contract.test.js`
  - related Issue: Issue #495, Issue #595
- file: `scripts/run-dashboard-app-server-bridge.mjs`
  - hypothesis: Dashboard app-server bridge の turn input に repo-backed chief-butler と operator URL rule が入らないと、Dashboard Butler が同じ文脈で交通整理できない。
  - risk if changed narrowly: mac Codex ではURLを出せても、Dashboard Butler では「画面を開く」だけで URL を返さない事故が再発する。
  - validation: `test/dashboard-app-server-bridge.test.js`
  - related Issue: Issue #495, Issue #595
- file: `docs/mvp/active-issue-execution-queue.md`
  - hypothesis: Issue #651 open truth と chief-butler gap を queue に反映しないと、次の実装で既知 blocker を見落とす。
  - risk if changed narrowly: merge済み PR の成功だけが残り、未完了 E2E / close-readiness と root blocker が消える。
  - validation: `npm test`
  - related Issue: Issue #595, Issue #651

## Hypothesis Retrospective

- expected: repo-backed Skill / bridge context / tests により、chief-butler が mac Codex local-only に戻った場合に検知できる。
- actual: `.agents/skills/vtdd-chief-butler/SKILL.md` を追加し、intent-mode contract、Dashboard bridge context、queue、unit tests を更新しました。
- mismatch: Dashboard Butler runtime discovery と VPS Codex CLI inventory はまだ未実装です。repo に載せたことは共有可能性の前提であり、VTDD completion ではありません。
- lesson: VTDD 中核判断は local Skill / plugin cache / chat memory に置いてはいけない。見つかった時点で defect / root blocker として repo-backed 化と runtime discovery の両方を追う必要があります。
- should become RAG candidate: yes。`vtdd-chief-butler` が mac local-only だった事故は、今後の skill/plugin/capability provenance gate として残すべきです。

## Verification Evidence

- Unit: `node --test test/intent-mode-contract.test.js test/dashboard-app-server-bridge.test.js` passed。37 tests pass。
- Integration: `npm test` passed。1053 pass / 1 skip。`check:self-parity` passed。29 routes / 29 operationIds。`check:generated-worker` exit 0。
- E2E: 未実施。このPRは repo-backed Skill / bridge context / docs invariant の接続スライスであり、Dashboard/VPS runtime discovery E2E は後続 Issue #495 で必要です。
- Manual: `find .agents/skills -maxdepth 2 -name SKILL.md` で repo-backed Skill が `vtdd-status-advisor` だけだった状態を確認し、`vtdd-chief-butler` を追加しました。`git status --short --branch` で main ではなく topic branch 上の変更であることを確認しました。
- Evidence path/link: `.agents/skills/vtdd-chief-butler/SKILL.md`, `test/intent-mode-contract.test.js`, `test/dashboard-app-server-bridge.test.js`

## Butler Completion Contract

- Owner goal: chief-butler / 交通整理役を mac Codex local-only から repo-backed に移し、Dashboard Butler / VPS Codex CLI へ共有できない状態を defect として固定する。
- Butler entrypoint: 部分接続。Dashboard app-server bridge の turn input は repo-backed `vtdd-chief-butler` を含むが、runtime Skill discovery UI/API は未実装。
- Action Schema exposure: 未変更。このPRでは Custom GPT Action Schema operationId を追加しません。
- Runtime path: 部分接続。`scripts/run-dashboard-app-server-bridge.mjs` の Dashboard turn input に traffic-control / operator URL rule を追加。
- Runner/runtime truth: 未接続。VPS Codex CLI skill inventory / plugin inventory / runtime truth は Issue #495 の後続作業。
- Authority boundary: 未変更。deploy、credential mutation、permission mutation、destructive work、merge、Issue close は行いません。
- E2E evidence: 未実施。Dashboard/VPS が実際に Skill を読めることの mapped E2E は未完了。
- Completion status: unconnected

## Surface Update Checklist

- Cloudflare deploy: 不要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。後続 runtime discovery / VPS inventory 接続で必要です。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate
- AGENTS.md Butler-First Operating Principle
- AGENTS.md Chief Butler Operating Principle
- AGENTS.md Intent Mode / Skill Autonomy Boundary
- AGENTS.md Thread-Independent Startup Contract
- AGENTS.md Change Size and PR Discipline

## Out-of-scope but NOT implemented

- Dashboard Butler runtime Skill discovery
- VPS Codex CLI `.agents/skills` inventory
- plugin / MCP parity implementation
- Custom GPT Action Schema operationId 追加
- deploy / merge / Issue close
- credential / permission mutation

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #495, Issue #595
- Execution ID: mac-codex-repo-backed-chief-butler-skill
- Goal: open_pr
