### PR TITLE
Issue #637 VPS maintenance初期preset registryを拡張

### DIFF
--- a/src/core/vps-privileged-maintenance.js
+++ b/src/core/vps-privileged-maintenance.js
@@ -23,11 +23,101 @@ const HELPER_COMMAND_REGISTRY = defineHelperCommandRegistry([
     initialPreset: true
   },
   {
+    commandClass: "systemd_user_daemon_reload",
+    title: "Reload user systemd units",
+    allowedArgs: ["systemctl --user daemon-reload"],
+    argv: ["systemctl", "--user", "daemon-reload"],
+    requiredRiskLevel: "medium",
+    requiresRoot: false,
+    initialPreset: true
+  },
+  {
+    commandClass: "systemd_user_runner_status",
+    title: "Check VTDD runner user service status",
+    allowedArgs: ["systemctl --user is-active vtdd-vps-runner.timer vtdd-vps-runner.service"],
+    argv: ["systemctl", "--user", "is-active", "vtdd-vps-runner.timer", "vtdd-vps-runner.service"],
+    requiredRiskLevel: "low",
+    requiresRoot: false,
+    initialPreset: true
+  },
+  {
+    commandClass: "systemd_user_runner_enable",
+    title: "Enable VTDD runner user timer",
+    allowedArgs: ["systemctl --user enable --now vtdd-vps-runner.timer"],
+    argv: ["systemctl", "--user", "enable", "--now", "vtdd-vps-runner.timer"],
+    requiredRiskLevel: "medium",
+    requiresRoot: false,
+    initialPreset: true
+  },
+  {
     commandClass: "systemd_user_runner_restart",
     title: "Restart VTDD runner user service",
     allowedArgs: ["systemctl --user restart vtdd-vps-runner.timer"],
     argv: ["systemctl", "--user", "restart", "vtdd-vps-runner.timer"],
     requiredRiskLevel: "medium",
+    requiresRoot: false,
+    initialPreset: true
+  },
+  {
+    commandClass: "systemd_user_runner_logs",
+    title: "Read redacted VTDD runner journal summary",
+    allowedArgs: ["journalctl --user -u vtdd-vps-runner.service -u vtdd-vps-runner.timer --no-pager -n 200"],
+    argv: [
+      "journalctl",
+      "--user",
+      "-u",
+      "vtdd-vps-runner.service",
+      "-u",
+      "vtdd-vps-runner.timer",
+      "--no-pager",
+      "-n",
+      "200"
+    ],
+    requiredRiskLevel: "low",
+    requiresRoot: false,
+    initialPreset: true
+  },
+  {
+    commandClass: "systemd_user_app_server_bridge_status",
+    title: "Check Dashboard app-server bridge status",
+    allowedArgs: ["systemctl --user is-active vtdd-dashboard-app-server-bridge.service"],
+    argv: ["systemctl", "--user", "is-active", "vtdd-dashboard-app-server-bridge.service"],
+    requiredRiskLevel: "low",
+    requiresRoot: false,
+    initialPreset: true
+  },
+  {
+    commandClass: "systemd_user_app_server_bridge_restart",
+    title: "Restart Dashboard app-server bridge",
+    allowedArgs: ["systemctl --user restart vtdd-dashboard-app-server-bridge.service"],
+    argv: ["systemctl", "--user", "restart", "vtdd-dashboard-app-server-bridge.service"],
+    requiredRiskLevel: "medium",
+    requiresRoot: false,
+    initialPreset: true
+  },
+  {
+    commandClass: "systemd_user_app_server_bridge_logs",
+    title: "Read redacted Dashboard app-server bridge journal summary",
+    allowedArgs: ["journalctl --user -u vtdd-dashboard-app-server-bridge.service --no-pager -n 200"],
+    argv: [
+      "journalctl",
+      "--user",
+      "-u",
+      "vtdd-dashboard-app-server-bridge.service",
+      "--no-pager",
+      "-n",
+      "200"
+    ],
+    requiredRiskLevel: "low",
+    requiresRoot: false,
+    initialPreset: true
+  },
+  {
+    commandClass: "vps_runner_status_dry_run",
+    title: "Check VPS runner queue status without executing work",
+    allowedArgs: ["node scripts/run-vps-runner.mjs --dry-run"],
+    argv: ["node", "scripts/run-vps-runner.mjs", "--dry-run"],
+    requiredRiskLevel: "low",
     requiresRoot: false,
     initialPreset: true
   }

--- a/test/vps-privileged-maintenance.test.js
+++ b/test/vps-privileged-maintenance.test.js
@@ -45,10 +45,19 @@ test("VPS privileged maintenance manifest normalizes reviewable capabilities", (
 
 test("VPS privileged maintenance helper command registry exposes initial presets", () => {
   const registry = listVpsPrivilegedMaintenanceCommandRegistry();
+  const commandClasses = registry.map((entry) => entry.commandClass);
 
-  assert.equal(registry.some((entry) => entry.commandClass === "playwright_install_deps_chromium"), true);
-  assert.equal(registry.some((entry) => entry.commandClass === "codex_sandbox_sysctl_apply"), true);
-  assert.equal(registry.some((entry) => entry.commandClass === "systemd_user_runner_restart"), true);
+  assert.equal(commandClasses.includes("playwright_install_deps_chromium"), true);
+  assert.equal(commandClasses.includes("codex_sandbox_sysctl_apply"), true);
+  assert.equal(commandClasses.includes("systemd_user_daemon_reload"), true);
+  assert.equal(commandClasses.includes("systemd_user_runner_status"), true);
+  assert.equal(commandClasses.includes("systemd_user_runner_enable"), true);
+  assert.equal(commandClasses.includes("systemd_user_runner_restart"), true);
+  assert.equal(commandClasses.includes("systemd_user_runner_logs"), true);
+  assert.equal(commandClasses.includes("systemd_user_app_server_bridge_status"), true);
+  assert.equal(commandClasses.includes("systemd_user_app_server_bridge_restart"), true);
+  assert.equal(commandClasses.includes("systemd_user_app_server_bridge_logs"), true);
+  assert.equal(commandClasses.includes("vps_runner_status_dry_run"), true);
   assert.equal(
     registry.every((entry) => Array.isArray(entry.allowedArgs) && entry.allowedArgs.length > 0),
     true
@@ -57,6 +66,7 @@ test("VPS privileged maintenance helper command registry exposes initial presets
     registry.every((entry) => Array.isArray(entry.argv) && entry.argv.length > 0),
     true
   );
+  assert.equal(registry.every((entry) => entry.initialPreset === true), true);
 });
 
 test("VPS privileged maintenance helper command registry does not expose mutable internal arrays", () => {

--- a/worker.js
+++ b/worker.js
@@ -37275,11 +37275,101 @@ var HELPER_COMMAND_REGISTRY = defineHelperCommandRegistry([
     initialPreset: true
   },
   {
+    commandClass: "systemd_user_daemon_reload",
+    title: "Reload user systemd units",
+    allowedArgs: ["systemctl --user daemon-reload"],
+    argv: ["systemctl", "--user", "daemon-reload"],
+    requiredRiskLevel: "medium",
+    requiresRoot: false,
+    initialPreset: true
+  },
+  {
+    commandClass: "systemd_user_runner_status",
+    title: "Check VTDD runner user service status",
+    allowedArgs: ["systemctl --user is-active vtdd-vps-runner.timer vtdd-vps-runner.service"],
+    argv: ["systemctl", "--user", "is-active", "vtdd-vps-runner.timer", "vtdd-vps-runner.service"],
+    requiredRiskLevel: "low",
+    requiresRoot: false,
+    initialPreset: true
+  },
+  {
+    commandClass: "systemd_user_runner_enable",
+    title: "Enable VTDD runner user timer",
+    allowedArgs: ["systemctl --user enable --now vtdd-vps-runner.timer"],
+    argv: ["systemctl", "--user", "enable", "--now", "vtdd-vps-runner.timer"],
+    requiredRiskLevel: "medium",
+    requiresRoot: false,
+    initialPreset: true
+  },
+  {
     commandClass: "systemd_user_runner_restart",
     title: "Restart VTDD runner user service",
     allowedArgs: ["systemctl --user restart vtdd-vps-runner.timer"],
     argv: ["systemctl", "--user", "restart", "vtdd-vps-runner.timer"],
     requiredRiskLevel: "medium",
+    requiresRoot: false,
+    initialPreset: true
+  },
+  {
+    commandClass: "systemd_user_runner_logs",
+    title: "Read redacted VTDD runner journal summary",
+    allowedArgs: ["journalctl --user -u vtdd-vps-runner.service -u vtdd-vps-runner.timer --no-pager -n 200"],
+    argv: [
+      "journalctl",
+      "--user",
+      "-u",
+      "vtdd-vps-runner.service",
+      "-u",
+      "vtdd-vps-runner.timer",
+      "--no-pager",
+      "-n",
+      "200"
+    ],
+    requiredRiskLevel: "low",
+    requiresRoot: false,
+    initialPreset: true
+  },
+  {
+    commandClass: "systemd_user_app_server_bridge_status",
+    title: "Check Dashboard app-server bridge status",
+    allowedArgs: ["systemctl --user is-active vtdd-dashboard-app-server-bridge.service"],
+    argv: ["systemctl", "--user", "is-active", "vtdd-dashboard-app-server-bridge.service"],
+    requiredRiskLevel: "low",
+    requiresRoot: false,
+    initialPreset: true
+  },
+  {
+    commandClass: "systemd_user_app_server_bridge_restart",
+    title: "Restart Dashboard app-server bridge",
+    allowedArgs: ["systemctl --user restart vtdd-dashboard-app-server-bridge.service"],
+    argv: ["systemctl", "--user", "restart", "vtdd-dashboard-app-server-bridge.service"],
+    requiredRiskLevel: "medium",
+    requiresRoot: false,
+    initialPreset: true
+  },
+  {
+    commandClass: "systemd_user_app_server_bridge_logs",
+    title: "Read redacted Dashboard app-server bridge journal summary",
+    allowedArgs: ["journalctl --user -u vtdd-dashboard-app-server-bridge.service --no-pager -n 200"],
+    argv: [
+      "journalctl",
+      "--user",
+      "-u",
+      "vtdd-dashboard-app-server-bridge.service",
+      "--no-pager",
+      "-n",
+      "200"
+    ],
+    requiredRiskLevel: "low",
+    requiresRoot: false,
+    initialPreset: true
+  },
+  {
+    commandClass: "vps_runner_status_dry_run",
+    title: "Check VPS runner queue status without executing work",
+    allowedArgs: ["node scripts/run-vps-runner.mjs --dry-run"],
+    argv: ["node", "scripts/run-vps-runner.mjs", "--dry-run"],
+    requiredRiskLevel: "low",
     requiresRoot: false,
     initialPreset: true
   }


### PR DESCRIPTION
## This PR satisfies Intent

Issue #637 の「初期 preset として runner/app-server bridge status/restart/logs、systemd enable/daemon-reload、Playwright Chromium deps install、Codex sandbox sysctl apply、runner drain/cancel/status を扱える」要求に向けた registry 拡張スライスです。

既存の proposal / passkey / helper request / dry-run path は維持し、実 root 実行は追加しません。このPRでは root-owned helper が将来実行に使う repo-backed command registry を広げ、`allowedArgs` は display-only、実行境界は `argv` + `shell:false` のままにします。

## Satisfied Success Criteria

- [x] Playwright Chromium deps install preset を維持した。
- [x] Codex sandbox sysctl apply preset を維持した。
- [x] systemd user daemon-reload preset を追加した。
- [x] VPS runner timer/service status、enable、restart、journal summary preset を追加した。
- [x] Dashboard app-server bridge status、restart、journal summary preset を追加した。
- [x] VPS runner queue status dry-run preset を追加した。
- [x] helper command registry が全 initial preset を argv-form で公開する test を追加した。
- [x] `worker.js` を再生成した。

## Unsatisfied Success Criteria

- 実際の root-owned helper install、sudoers 設定、manifest 配置は未実装です。
- real execution route は未実装です。今回も dry-run / registry truth のみです。
- runner drain / cancel はまだ専用実行 preset として未接続です。今回入れたのは `vps_runner_status_dry_run` までです。
- iPhone Dashboard Butler から proposal、passkey approval、helper execution、disable/remove/rollback を通す mapped E2E は未実施です。
- Issue #637 は close しません。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: #637
- Implementing Success Criteria: initial preset registry を Issue #637 / docs 要求に近づけ、runner/app-server/systemd/Playwright/Codex sandbox の dry-run helper planning 対象を増やす。
- Explicit Non-goals: 実 root 実行、sudoers変更、VPS host設定、deploy、credential mutation、permission mutation、Issue close。
- Expected touched files/routes/workflows: `src/core/vps-privileged-maintenance.js`, `test/vps-privileged-maintenance.test.js`, `worker.js`
- Affected Issues: #637。#495 / #595 は前PRで進んだが、このPRでは扱わない。
- Affected PRs: none open at start.
- Affected workflows: local targeted tests, full `npm test`, self-parity, generated-worker check。
- Affected runtime/operator surfaces: `/v2/vps/privileged-maintenance/helper-dry-runs` の registry-backed dry-run planning。
- What may break if we patch narrowly: registry preset が増えても実行 helper が未接続なので、owner が「実行できる」と誤解すると drift する。
- Unknowns to investigate before coding: VPS の実際の app-server bridge systemd unit 名、runner drain/cancel の canonical command boundary。
- Validation needed: targeted vps privileged maintenance tests、worker build、full test。
- Stop condition: shell trampoline / arbitrary command execution / operator-specific absolute path を registry に入れる必要が出たら停止。

## Execution Queue Delta

- Queue position before: `Now` は Issue #637。
- Preemption decision: NEXT
- Queue delta: Issue #637 stays `Now`; this PR advances the initial preset registry slice inside the current root blocker.
- Why this PR is next: #637 の helper lifecycle は registry が狭いままだと iPhone/PWA から復旧できる操作が足りず、また mac SSH fallback に戻る。実行経路の前に argv 境界つき preset を repo-backed に固定する必要がある。
- Active Issues not downscoped: active Issues are not downscoped。active Issues は縮小しません。#637 は残作業ありとして維持します。

## File / Line Hypotheses

- file: `src/core/vps-privileged-maintenance.js`
  - hypothesis: `HELPER_COMMAND_REGISTRY` に initial preset を追加すれば、既存 dry-run planner が同じ argv boundary で受け入れ/拒否できる。
  - risk if changed narrowly: 実行 helper が未接続なのに実行可能と誤解される。
  - validation: targeted helper tests and full test.
  - related Issue: #637
- file: `test/vps-privileged-maintenance.test.js`
  - hypothesis: registry coverage test に required initial preset を明示すれば、将来 preset が抜け落ちにくくなる。
  - risk if changed narrowly: app-server bridge unit 名や runner drain/cancel は今後の実機 truth で更新が必要。
  - validation: `node --test test/vps-privileged-maintenance.test.js test/vps-privileged-maintenance-helper-script.test.js`
  - related Issue: #637

## Hypothesis Retrospective

- expected: registry の追加だけなら既存 helper dry-run, shell-boundary, generated worker checks を壊さない。
- actual: targeted tests and full tests passed.
- mismatch: runner drain/cancel は専用 command boundary が未確定なので、このPRでは status dry-run までに止めた。
- lesson: root execution に進む前に repo-backed registry と argv 境界を広げ、未接続部分をPR本文で明示する必要がある。
- should become RAG candidate: yes. `#637 registry preset 拡張は実 root 実行ではなく dry-run truth。runner drain/cancel と実機 unit 名は次スライスで要確認。`

## Verification Evidence

- Unit: `node --test test/vps-privileged-maintenance.test.js test/vps-privileged-maintenance-helper-script.test.js` passed. 14 tests passed.
- Integration: `npm run build:worker && npm test` passed. 1053 tests passed / 1 skipped.
- Integration: `npm run check:self-parity` passed inside `npm test`. 29 routes / 29 operationIds.
- Integration: `npm run check:generated-worker` completed with exit 0 inside `npm test`.
- E2E: Not run. Live iPhone/PWA helper lifecycle E2E remains required before Issue #637 completion.
- Manual: Issue #637 body and `docs/butler/vps-privileged-maintenance-capability-lifecycle.md` were read before the slice.
- Evidence path/link: this PR body and tests above.

## Butler Completion Contract

- Owner goal: iPhone/PWA から足りない VPS privileged maintenance capability を増やし、不要なものを減らせる運用に近づける。
- Butler entrypoint: existing `vtddCreateVpsMaintenanceProposal`, `vtddCreateVpsMaintenanceHelperRequest`, `vtddDryRunVpsMaintenanceHelper`。
- Action Schema exposure: unchanged. Existing VPS privileged maintenance Actions are reused.
- Runtime path: helper dry-run planner can now bind more initial preset command classes.
- Runner/runtime truth: dry-run truth only. `rootExecutionStarted=false` / `helperExecutionStarted=false` remains true.
- Authority boundary: unchanged. No deploy, credential mutation, permission mutation, sudoers mutation, or real root execution.
- E2E evidence: not run.
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: not performed.
- Custom GPT Action Schema update: not required.
- Custom GPT Instructions update: not changed.
- iPhone Butler live E2E: not performed.

## Related Constitution Rules

- AGENTS.md Butler Completion Gate
- AGENTS.md Butler-First Operating Principle
- AGENTS.md Authority Boundary
- docs/security/consent-approval-model.md
- docs/butler/vps-privileged-maintenance-capability-lifecycle.md

## Out-of-scope but NOT implemented

- root-owned helper installation on VPS.
- sudoers configuration.
- real privileged command execution.
- runner drain/cancel command boundary.
- live Dashboard/iPhone passkey approval E2E.
- deploy, credential mutation, permission mutation, Issue close.

## Extra changes (if any)

None.
