### PR TITLE
Issue #637 VPS install inventory collectorを追加

### DIFF
--- a/scripts/collect-vps-maintenance-install-inventory.mjs
+++ b/scripts/collect-vps-maintenance-install-inventory.mjs
@@ -1,0 +1,162 @@
+#!/usr/bin/env node
+
+import fs from "node:fs/promises";
+
+import { buildVpsPrivilegedMaintenanceInstallInventory } from "../src/core/index.js";
+
+const DEFAULT_HELPER_INSTALL_PATH = "/usr/local/sbin/vtdd-vps-maintenance-helper";
+const DEFAULT_MANIFEST_PATH = "/etc/vtdd/privileged-maintenance-capabilities.json";
+const DEFAULT_SUDOERS_PATH = "/etc/sudoers.d/vtdd-vps-maintenance-helper";
+
+function parseArgs(argv) {
+  const result = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (!arg.startsWith("--")) {
+      continue;
+    }
+    const key = arg.slice(2);
+    const next = argv[index + 1];
+    if (!next || next.startsWith("--")) {
+      result[key] = "true";
+      continue;
+    }
+    result[key] = next;
+    index += 1;
+  }
+  return result;
+}
+
+async function observePath(filePath) {
+  try {
+    const stat = await fs.stat(filePath);
+    return {
+      installed: true,
+      owner: ownerLabel(stat)
+    };
+  } catch (error) {
+    if (error?.code === "ENOENT") {
+      return {
+        installed: false,
+        owner: null
+      };
+    }
+    return {
+      installed: null,
+      owner: null,
+      error: summarizeError(error)
+    };
+  }
+}
+
+async function observeSudoersPolicy(filePath) {
+  try {
+    const content = await fs.readFile(filePath, "utf8");
+    return {
+      readable: true,
+      allowsAll: containsBroadSudoersGrant(content)
+    };
+  } catch (error) {
+    if (error?.code === "ENOENT") {
+      return {
+        readable: false,
+        allowsAll: false
+      };
+    }
+    return {
+      readable: false,
+      allowsAll: null,
+      error: summarizeError(error)
+    };
+  }
+}
+
+function containsBroadSudoersGrant(content) {
+  return /\bNOPASSWD\s*:\s*ALL\b/i.test(String(content || ""));
+}
+
+function ownerLabel(stat) {
+  if (stat?.uid === 0) return "root";
+  return Number.isInteger(stat?.uid) ? String(stat.uid) : null;
+}
+
+function summarizeError(error) {
+  const code = typeof error?.code === "string" ? error.code : "UNKNOWN";
+  return code.replace(/[^A-Z0-9_]/gi, "").slice(0, 80) || "UNKNOWN";
+}
+
+async function collectVpsMaintenanceInstallInventory(input = {}) {
+  const host = String(input.host || "").trim();
+  const repository = String(input.repository || "").trim();
+  const helperPath = String(input.helperPath || input["helper-path"] || DEFAULT_HELPER_INSTALL_PATH).trim();
+  const manifestPath = String(input.manifestPath || input["manifest-path"] || DEFAULT_MANIFEST_PATH).trim();
+  const sudoersPath = String(input.sudoersPath || input["sudoers-path"] || DEFAULT_SUDOERS_PATH).trim();
+  const runnerUser = String(input.runnerUser || input["runner-user"] || "vtdd-runner").trim();
+
+  const [helper, manifest, sudoers, sudoersPolicy] = await Promise.all([
+    observePath(helperPath),
+    observePath(manifestPath),
+    observePath(sudoersPath),
+    observeSudoersPolicy(sudoersPath)
+  ]);
+
+  const installInventory = buildVpsPrivilegedMaintenanceInstallInventory({
+    host,
+    repository,
+    helperPath,
+    manifestPath,
+    sudoersPath,
+    runnerUser,
+    helperInstalled: helper.installed,
+    manifestInstalled: manifest.installed,
+    sudoersInstalled: sudoers.installed,
+    helperOwner: helper.owner,
+    manifestOwner: manifest.owner,
+    sudoersOwner: sudoers.owner,
+    sudoersAllowsAll: sudoersPolicy.allowsAll
+  });
+
+  return {
+    ok: installInventory.ok,
+    source: "vps_local_filesystem_observer",
+    installInventory,
+    runtimeTruth: {
+      ...installInventory.runtimeTruth,
+      observer: "scripts/collect-vps-maintenance-install-inventory.mjs",
+      sudoersContentReadable: sudoersPolicy.readable,
+      rootExecutionStarted: false,
+      helperExecutionStarted: false,
+      redacted: true
+    },
+    observation: {
+      helper: redactObservation(helper),
+      manifest: redactObservation(manifest),
+      sudoers: redactObservation(sudoers),
+      sudoersContentReadable: sudoersPolicy.readable,
+      sudoersPolicyError: sudoersPolicy.error || null
+    }
+  };
+}
+
+function redactObservation(value) {
+  return {
+    installed: value.installed,
+    owner: value.owner,
+    error: value.error || null
+  };
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const result = await collectVpsMaintenanceInstallInventory(args);
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+  if (!result.ok) {
+    process.exitCode = 1;
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  await main();
+}
+
+export { collectVpsMaintenanceInstallInventory, containsBroadSudoersGrant };

--- a/src/core/vps-privileged-maintenance.js
+++ b/src/core/vps-privileged-maintenance.js
@@ -124,6 +124,15 @@ const HELPER_COMMAND_REGISTRY = defineHelperCommandRegistry([
     requiredRiskLevel: "low",
     requiresRoot: false,
     initialPreset: true
+  },
+  {
+    commandClass: "vps_maintenance_install_inventory_collect",
+    title: "Collect VPS privileged maintenance install inventory without root execution",
+    allowedArgs: ["node scripts/collect-vps-maintenance-install-inventory.mjs --host <host> --repository <owner/repo>"],
+    argv: ["node", "scripts/collect-vps-maintenance-install-inventory.mjs"],
+    requiredRiskLevel: "low",
+    requiresRoot: false,
+    initialPreset: true
   }
 ]);
 

--- a/test/vps-maintenance-install-inventory-collector.test.js
+++ b/test/vps-maintenance-install-inventory-collector.test.js
@@ -1,0 +1,80 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+import { containsBroadSudoersGrant } from "../scripts/collect-vps-maintenance-install-inventory.mjs";
+
+test("VPS maintenance install inventory collector reports missing paths without root execution", async () => {
+  const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "vtdd-vps-install-inventory-"));
+  const result = spawnSync(
+    process.execPath,
+    [
+      "scripts/collect-vps-maintenance-install-inventory.mjs",
+      "--host",
+      "x85-131-245-163",
+      "--repository",
+      "marushu/vtdd-v2-p",
+      "--helper-path",
+      path.join(tempRoot, "missing-helper"),
+      "--manifest-path",
+      path.join(tempRoot, "missing-manifest.json"),
+      "--sudoers-path",
+      path.join(tempRoot, "missing-sudoers")
+    ],
+    { encoding: "utf8" }
+  );
+
+  assert.equal(result.status, 0);
+  const body = JSON.parse(result.stdout);
+  assert.equal(body.ok, true);
+  assert.equal(body.source, "vps_local_filesystem_observer");
+  assert.equal(body.installInventory.status, "missing");
+  assert.equal(body.installInventory.checks.every((check) => check.status === "missing"), true);
+  assert.equal(body.runtimeTruth.rootExecutionStarted, false);
+  assert.equal(body.runtimeTruth.helperExecutionStarted, false);
+  assert.equal(JSON.stringify(body).includes("vtdd-runner ALL=(ALL) NOPASSWD:ALL"), false);
+});
+
+test("VPS maintenance install inventory collector blocks broad sudoers grants without leaking file content", async () => {
+  const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "vtdd-vps-install-inventory-"));
+  const helperPath = path.join(tempRoot, "helper");
+  const manifestPath = path.join(tempRoot, "manifest.json");
+  const sudoersPath = path.join(tempRoot, "sudoers");
+  await fs.writeFile(helperPath, "#!/bin/sh\n", "utf8");
+  await fs.writeFile(manifestPath, "{}\n", "utf8");
+  await fs.writeFile(sudoersPath, "vtdd-runner ALL=(ALL) NOPASSWD:ALL\n", "utf8");
+
+  const result = spawnSync(
+    process.execPath,
+    [
+      "scripts/collect-vps-maintenance-install-inventory.mjs",
+      "--host",
+      "x85-131-245-163",
+      "--repository",
+      "marushu/vtdd-v2-p",
+      "--helper-path",
+      helperPath,
+      "--manifest-path",
+      manifestPath,
+      "--sudoers-path",
+      sudoersPath
+    ],
+    { encoding: "utf8" }
+  );
+
+  assert.equal(result.status, 1);
+  const body = JSON.parse(result.stdout);
+  assert.equal(body.ok, false);
+  assert.equal(body.installInventory.status, "blocked");
+  assert.equal(body.installInventory.issues.includes("sudoers must not allow NOPASSWD:ALL"), true);
+  assert.equal(body.runtimeTruth.sudoersContentReadable, true);
+  assert.equal(JSON.stringify(body).includes("vtdd-runner ALL=(ALL) NOPASSWD:ALL"), false);
+});
+
+test("VPS maintenance install inventory collector detects broad sudoers grants", () => {
+  assert.equal(containsBroadSudoersGrant("vtdd-runner ALL=(ALL) NOPASSWD:ALL"), true);
+  assert.equal(containsBroadSudoersGrant("vtdd-runner ALL=(root) NOPASSWD:/usr/local/sbin/vtdd-helper"), false);
+});

--- a/test/vps-privileged-maintenance.test.js
+++ b/test/vps-privileged-maintenance.test.js
@@ -93,6 +93,7 @@ test("VPS privileged maintenance helper command registry exposes initial presets
   assert.equal(commandClasses.includes("systemd_user_app_server_bridge_restart"), true);
   assert.equal(commandClasses.includes("systemd_user_app_server_bridge_logs"), true);
   assert.equal(commandClasses.includes("vps_runner_status_dry_run"), true);
+  assert.equal(commandClasses.includes("vps_maintenance_install_inventory_collect"), true);
   assert.equal(
     registry.every((entry) => Array.isArray(entry.allowedArgs) && entry.allowedArgs.length > 0),
     true

--- a/worker.js
+++ b/worker.js
@@ -37376,6 +37376,15 @@ var HELPER_COMMAND_REGISTRY = defineHelperCommandRegistry([
     requiredRiskLevel: "low",
     requiresRoot: false,
     initialPreset: true
+  },
+  {
+    commandClass: "vps_maintenance_install_inventory_collect",
+    title: "Collect VPS privileged maintenance install inventory without root execution",
+    allowedArgs: ["node scripts/collect-vps-maintenance-install-inventory.mjs --host <host> --repository <owner/repo>"],
+    argv: ["node", "scripts/collect-vps-maintenance-install-inventory.mjs"],
+    requiredRiskLevel: "low",
+    requiresRoot: false,
+    initialPreset: true
   }
 ]);
 function normalizeVpsCapabilityManifest(input = {}) {


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #637 の部分進捗として、VPS privileged maintenance helper / manifest / sudoers の実ファイル状態を、VPS Codex CLI 側で root 実行なしに観測できる repo-backed collector を追加します。
- PR #661 で production runtime route は接続済みになったが、live evidence は `unverified` だったため、次に VPS 側の観測値を安全に作れる最小スライスです。

## Satisfied Success Criteria

- [x] VPS 上で helper / manifest / sudoers の存在と owner を観測する `scripts/collect-vps-maintenance-install-inventory.mjs` を追加。
- [x] sudoers file の本文は出力せず、`NOPASSWD:ALL` の検出結果だけを `sudoersAllowsAll` として inventory に渡す。
- [x] collector は `rootExecutionStarted=false` / `helperExecutionStarted=false` を返し、root 実行や sudoers 変更をしない。
- [x] helper command registry に `vps_maintenance_install_inventory_collect` を low-risk / requiresRoot=false preset として追加。

## Unsatisfied Success Criteria

- root-owned helper の実インストール、sudoers 配置、manifest 配置はこのPRでは実行しない。
- collector の production VPS 実行 evidence は merge/deploy 後の後続確認。
- Butler が自然文から VPS runner に collector 実行を直接依頼し、結果を production runtime に保存・再取得する E2E は未完了。
- helper capability の追加・有効化・無効化・削除・rollback・review の iPhone 完結E2Eは未完了。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #637
- Implementing Success Criteria: VPS 側で helper / manifest / scoped sudoers の観測値を作れる repo-backed script と low-risk registry preset を追加する。
- Explicit Non-goals: root-owned helper install、sudoers mutation、root command execution、deploy、credential mutation、permission mutation、Issue close は実施しない。
- Expected touched files/routes/workflows: `scripts/collect-vps-maintenance-install-inventory.mjs`, `src/core/vps-privileged-maintenance.js`, `test/vps-maintenance-install-inventory-collector.test.js`, `test/vps-privileged-maintenance.test.js`, `worker.js`
- Affected Issues: Issue #637 を進める。Issue #495 / #595 の VPS executable candidate parity に関係するが、完了扱いにはしない。
- Affected PRs: PR #661 の follow-up。
- Affected workflows: Node test、runtime self-parity、generated-worker check。
- Affected runtime/operator surfaces: VPS Codex CLI script、helper command registry、generated worker bundle。
- What may break if we patch narrowly: sudoers本文をそのまま出すと secret/raw host policy leak になる。registry に載せないと VPS側で使える共有能力として扱いにくい。
- Unknowns to investigate before coding: 実VPS上で sudoers file が `vtdd-runner` から readable かどうかは未確認。
- Validation needed: collector script test、VPS privileged maintenance unit、full `npm test`。
- Stop condition: root権限、sudoers変更、runtimeへの永続保存、deployが必要になった場合はこのPRから分離する。

## Execution Queue Delta

- Queue position before: Issue #637 は active issue execution queue の `Now`。
- Preemption decision: ROOT。PR #661 後の `unverified` live evidence を進める scoped progress。
- Queue delta: Issue #637 に VPS local filesystem collector と low-risk preset を追加。Issue #637 全体は open のまま。
- Why this PR is next: Butler route は接続済みだが、観測値が無いため production result は `unverified`。次に VPS 側で観測値を安全に作れる必要がある。
- Active Issues not downscoped: Active Issues は縮小しない。このPRで扱わない #637 の install / execution / lifecycle / iPhone E2E は未完了として残す。

## File / Line Hypotheses

- file: `scripts/collect-vps-maintenance-install-inventory.mjs`
  - hypothesis: VPS local filesystem observation は Worker route ではなく VPS-side script に分けるのが public/core と Cloudflare runtime の境界に合う。
  - risk if changed narrowly: sudoers本文を出す、または root 実行と混ぜると安全境界が壊れる。
  - validation: `test/vps-maintenance-install-inventory-collector.test.js`
  - related Issue: #637
- file: `src/core/vps-privileged-maintenance.js`
  - hypothesis: collector を helper command registry の low-risk preset に載せることで、VPS Codex CLI 側の共有能力として扱いやすくなる。
  - risk if changed narrowly: registry に載らない script は mac/local-only probe と同じ扱いになりやすい。
  - validation: `test/vps-privileged-maintenance.test.js`
  - related Issue: #637

## Hypothesis Retrospective

- expected: collector script と preset を追加すれば、次回 VPS 上で実観測値を生成し、PR #661 の route に渡せる。
- actual: collector script / low-risk preset / tests を追加し、full `npm test` が通過。
- mismatch: production VPS 実行と runtime保存はこのPRでは未実施。
- lesson: privileged maintenance は route と observer を分け、observer は raw sudoers content を出さず boolean truth に落とす必要がある。
- should become RAG candidate: yes。#637 の install inventory 観測パターンとして再利用価値がある。

## Verification Evidence

- Unit: `node --test test/vps-maintenance-install-inventory-collector.test.js test/vps-privileged-maintenance.test.js` -> 16 pass
- Integration: `npm test` -> 1058 pass / 1 skip
- E2E: 未実施。このPRは VPS-side collector slice であり、production VPS live run / Butler E2E は後続。
- Manual: `npm run build:worker`; self-parity 30 routes / 30 operationIds; generated-worker check pass
- Evidence path/link: PR checks and this PR body

## Butler Completion Contract

- Owner goal: iPhone/PWA Butler の install inventory 判断に使う VPS 実観測値を、VPS Codex CLI 側で安全に作れるようにする。
- Butler entrypoint: PR #661 の `vtddRetrieveVpsMaintenanceInstallInventory` に渡す観測値を作る VPS-side script。
- Action Schema exposure: このPRでは変更なし。
- Runtime path: このPRでは新規 Worker route なし。VPS collector output is local runtime truth candidate.
- Runner/runtime truth: collector output includes `installInventory`, `runtimeTruth`, `rootExecutionStarted=false`, `helperExecutionStarted=false`, and redacted observation.
- Authority boundary: low-risk read-only filesystem observation。root 実行、sudoers変更、credential/permission mutation は行わない。
- E2E evidence: このPRスライスでは未接続。production VPS live run と Butler-facing evidence は後続。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 必要。core registry と generated `worker.js` が変わるため、merge 後に deploy が必要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 後続。production deploy 後、VPS collector run evidence と runtime inventory evidence を #637 に残す。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate
- AGENTS.md Butler-First Operating Principle
- AGENTS.md Authority Boundary
- docs/butler/intent-mode-contract.md
- docs/butler/execution-queue-contract.md

## Out-of-scope but NOT implemented

- root-owned helper の実インストール
- sudoers ファイルの作成・変更
- capability manifest の実VPS配置
- real privileged execution
- runtime 永続保存 route
- deploy / credential / permission mutation
- Issue #637 close

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #637
- Execution ID: mac-codex-2026-05-30-vps-install-inventory-collector
- Codex Goal: Issue #637 の VPS-side install inventory collector と low-risk preset を追加
