### PR TITLE
Issue #637 VPS maintenance helper installerを追加

### DIFF
--- a/scripts/install-vps-privileged-maintenance-helper.mjs
+++ b/scripts/install-vps-privileged-maintenance-helper.mjs
@@ -1,0 +1,212 @@
+#!/usr/bin/env node
+
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { listVpsPrivilegedMaintenanceCommandRegistry } from "../src/core/index.js";
+
+const DEFAULT_HELPER_INSTALL_PATH = "/usr/local/sbin/vtdd-vps-maintenance-helper";
+const DEFAULT_MANIFEST_PATH = "/etc/vtdd/privileged-maintenance-capabilities.json";
+const DEFAULT_SUDOERS_PATH = "/etc/sudoers.d/vtdd-vps-maintenance-helper";
+const DEFAULT_RUNNER_USER = "vtdd-runner";
+
+function parseArgs(argv) {
+  const result = {
+    dryRun: false,
+    stagingDir: "",
+    helperPath: DEFAULT_HELPER_INSTALL_PATH,
+    manifestPath: DEFAULT_MANIFEST_PATH,
+    sudoersPath: DEFAULT_SUDOERS_PATH,
+    runnerUser: DEFAULT_RUNNER_USER,
+    host: os.hostname(),
+    repository: "",
+    repoDir: process.cwd(),
+    nodeBin: process.execPath
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--dry-run") {
+      result.dryRun = true;
+    } else if (arg === "--staging-dir") {
+      result.stagingDir = argv[index + 1] || "";
+      index += 1;
+    } else if (arg === "--helper-path") {
+      result.helperPath = argv[index + 1] || "";
+      index += 1;
+    } else if (arg === "--manifest-path") {
+      result.manifestPath = argv[index + 1] || "";
+      index += 1;
+    } else if (arg === "--sudoers-path") {
+      result.sudoersPath = argv[index + 1] || "";
+      index += 1;
+    } else if (arg === "--runner-user") {
+      result.runnerUser = argv[index + 1] || "";
+      index += 1;
+    } else if (arg === "--host") {
+      result.host = argv[index + 1] || "";
+      index += 1;
+    } else if (arg === "--repository") {
+      result.repository = argv[index + 1] || "";
+      index += 1;
+    } else if (arg === "--repo-dir") {
+      result.repoDir = argv[index + 1] || "";
+      index += 1;
+    } else if (arg === "--node-bin") {
+      result.nodeBin = argv[index + 1] || "";
+      index += 1;
+    }
+  }
+  return result;
+}
+
+function validateConfig(config) {
+  const issues = [];
+  if (!config.host) issues.push("host is required");
+  if (!/^[^/\s]+\/[^/\s]+$/.test(config.repository)) issues.push("repository must be owner/repo");
+  for (const [field, value] of [
+    ["helperPath", config.helperPath],
+    ["manifestPath", config.manifestPath],
+    ["sudoersPath", config.sudoersPath],
+    ["repoDir", config.repoDir],
+    ["nodeBin", config.nodeBin]
+  ]) {
+    if (!String(value || "").startsWith("/")) issues.push(`${field} must be absolute`);
+  }
+  if (!/^[a-z_][a-z0-9_-]*[$]?$/i.test(config.runnerUser)) issues.push("runnerUser is invalid");
+  if (config.helperPath.includes("\n") || config.runnerUser.includes("\n")) {
+    issues.push("paths and runnerUser must be single-line values");
+  }
+  return issues;
+}
+
+function buildInitialManifest(config, now = new Date().toISOString()) {
+  const capabilities = listVpsPrivilegedMaintenanceCommandRegistry().map((entry) => ({
+    id: entry.commandClass.replaceAll("_", "."),
+    title: entry.title,
+    status: "enabled",
+    commandClass: entry.commandClass,
+    riskLevel: entry.requiredRiskLevel,
+    workingDirectories: [config.repoDir],
+    allowedArgs: entry.allowedArgs,
+    affectedPaths: entry.requiresRoot ? ["/usr", "/etc", "/var"] : [config.repoDir],
+    redactionRules: ["no secrets", "summarize stdout/stderr", "redact tokens and credentials"],
+    rollbackPlan: "disable capability in the root-owned manifest and keep audit history",
+    expectedRuntimeTruth: ["before state", "exit code", "redacted log summary", "after state", "next action"],
+    createdAt: now,
+    updatedAt: now
+  }));
+  return {
+    version: 1,
+    host: config.host,
+    repository: config.repository,
+    updatedAt: now,
+    capabilities
+  };
+}
+
+function buildHelperScript(config) {
+  return `#!/usr/bin/env sh
+set -eu
+
+NODE_BIN=${JSON.stringify(config.nodeBin)}
+REPO_DIR=${JSON.stringify(config.repoDir)}
+HELPER_SCRIPT="$REPO_DIR/scripts/run-vps-privileged-maintenance-helper.mjs"
+
+if [ "\${1:-}" = "--version" ]; then
+  printf '%s\\n' "vtdd-vps-maintenance-helper repo=${config.repository} host=${config.host}"
+  exit 0
+fi
+
+exec "$NODE_BIN" "$HELPER_SCRIPT" "$@"
+`;
+}
+
+function buildSudoers(config) {
+  return `${config.runnerUser} ALL=(root) NOPASSWD: ${config.helperPath}\n`;
+}
+
+function targetPath(config, absolutePath) {
+  if (!config.stagingDir) return absolutePath;
+  return path.join(config.stagingDir, absolutePath.replace(/^\/+/, ""));
+}
+
+async function writeFileWithParents(filePath, content, mode) {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, content, { mode });
+  await fs.chmod(filePath, mode);
+}
+
+async function install(config, artifacts) {
+  const helperTarget = targetPath(config, config.helperPath);
+  const manifestTarget = targetPath(config, config.manifestPath);
+  const sudoersTarget = targetPath(config, config.sudoersPath);
+  await writeFileWithParents(helperTarget, artifacts.helperScript, 0o755);
+  await writeFileWithParents(manifestTarget, `${JSON.stringify(artifacts.manifest, null, 2)}\n`, 0o644);
+  await writeFileWithParents(sudoersTarget, artifacts.sudoers, 0o440);
+  if (!config.stagingDir && typeof process.setuid === "function" && process.getuid?.() === 0) {
+    await Promise.all([fs.chown(helperTarget, 0, 0), fs.chown(manifestTarget, 0, 0), fs.chown(sudoersTarget, 0, 0)]);
+  }
+  return { helperTarget, manifestTarget, sudoersTarget };
+}
+
+async function main() {
+  const config = parseArgs(process.argv.slice(2));
+  const issues = validateConfig(config);
+  if (!config.dryRun && !config.stagingDir && process.getuid?.() !== 0) {
+    issues.push("root is required unless --dry-run or --staging-dir is used");
+  }
+  const manifest = buildInitialManifest(config);
+  const artifacts = {
+    helperScript: buildHelperScript(config),
+    manifest,
+    sudoers: buildSudoers(config)
+  };
+  if (/\bNOPASSWD\s*:\s*ALL\b/i.test(artifacts.sudoers)) {
+    issues.push("sudoers must not allow NOPASSWD:ALL");
+  }
+  if (issues.length > 0) {
+    process.stdout.write(`${JSON.stringify({ ok: false, error: "vps_maintenance_helper_install_invalid", issues }, null, 2)}\n`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const result = {
+    ok: true,
+    kind: "vps_privileged_maintenance_helper_install",
+    mode: config.dryRun ? "dry_run" : config.stagingDir ? "staging" : "install",
+    host: config.host,
+    repository: config.repository,
+    rootExecutionStarted: !config.dryRun && !config.stagingDir,
+    helperExecutionStarted: false,
+    redacted: true,
+    paths: {
+      helperPath: config.helperPath,
+      manifestPath: config.manifestPath,
+      sudoersPath: config.sudoersPath
+    },
+    sudoersShape: {
+      user: config.runnerUser,
+      runAs: "root",
+      allowedCommand: config.helperPath,
+      forbidden: ["NOPASSWD:ALL", "sudo su", "root shell"]
+    },
+    manifestSummary: {
+      version: manifest.version,
+      capabilityCount: manifest.capabilities.length,
+      highRiskCapabilities: manifest.capabilities.filter((capability) => capability.riskLevel === "high").map((capability) => capability.id)
+    }
+  };
+
+  if (!config.dryRun) {
+    result.written = await install(config, artifacts);
+  }
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] || "").href) {
+  await main();
+}
+
+export { buildHelperScript, buildInitialManifest, buildSudoers, parseArgs, validateConfig };

--- a/test/vps-maintenance-helper-installer.test.js
+++ b/test/vps-maintenance-helper-installer.test.js
@@ -1,0 +1,108 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+import { buildSudoers } from "../scripts/install-vps-privileged-maintenance-helper.mjs";
+
+const script = "scripts/install-vps-privileged-maintenance-helper.mjs";
+
+test("VPS maintenance helper installer dry-run reports scoped install plan without writing root files", () => {
+  const result = spawnSync(
+    process.execPath,
+    [
+      script,
+      "--dry-run",
+      "--host",
+      "x85-131-245-163",
+      "--repository",
+      "marushu/vtdd-v2-p",
+      "--repo-dir",
+      "/home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p",
+      "--node-bin",
+      "/home/vtdd-runner/.nvm/versions/node/v24.15.0/bin/node"
+    ],
+    { encoding: "utf8" }
+  );
+
+  assert.equal(result.status, 0);
+  const body = JSON.parse(result.stdout);
+  assert.equal(body.ok, true);
+  assert.equal(body.mode, "dry_run");
+  assert.equal(body.rootExecutionStarted, false);
+  assert.equal(body.helperExecutionStarted, false);
+  assert.equal(body.sudoersShape.allowedCommand, "/usr/local/sbin/vtdd-vps-maintenance-helper");
+  assert.equal(body.sudoersShape.forbidden.includes("NOPASSWD:ALL"), true);
+  assert.equal(body.manifestSummary.highRiskCapabilities.includes("playwright.install.deps.chromium"), true);
+});
+
+test("VPS maintenance helper installer staging writes helper manifest and scoped sudoers", async () => {
+  const stagingDir = await fs.mkdtemp(path.join(os.tmpdir(), "vtdd-helper-install-"));
+  const result = spawnSync(
+    process.execPath,
+    [
+      script,
+      "--staging-dir",
+      stagingDir,
+      "--host",
+      "x85-131-245-163",
+      "--repository",
+      "marushu/vtdd-v2-p",
+      "--repo-dir",
+      "/home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p",
+      "--node-bin",
+      "/home/vtdd-runner/.nvm/versions/node/v24.15.0/bin/node"
+    ],
+    { encoding: "utf8" }
+  );
+
+  assert.equal(result.status, 0);
+  const body = JSON.parse(result.stdout);
+  assert.equal(body.mode, "staging");
+  const helper = await fs.readFile(path.join(stagingDir, "usr/local/sbin/vtdd-vps-maintenance-helper"), "utf8");
+  const manifest = JSON.parse(await fs.readFile(path.join(stagingDir, "etc/vtdd/privileged-maintenance-capabilities.json"), "utf8"));
+  const sudoers = await fs.readFile(path.join(stagingDir, "etc/sudoers.d/vtdd-vps-maintenance-helper"), "utf8");
+
+  assert.equal(helper.includes("vtdd-v2-mvp.polished-tree-da7c.workers.dev"), false);
+  assert.equal(helper.includes("exec \"$NODE_BIN\" \"$HELPER_SCRIPT\" \"$@\""), true);
+  assert.equal(manifest.repository, "marushu/vtdd-v2-p");
+  assert.equal(manifest.capabilities.some((capability) => capability.commandClass === "playwright_install_deps_chromium"), true);
+  assert.equal(/\bNOPASSWD\s*:\s*ALL\b/i.test(sudoers), false);
+  assert.equal(sudoers, "vtdd-runner ALL=(root) NOPASSWD: /usr/local/sbin/vtdd-vps-maintenance-helper\n");
+});
+
+test("VPS maintenance helper installer requires root for real install mode", () => {
+  if (process.getuid?.() === 0) {
+    return;
+  }
+  const result = spawnSync(
+    process.execPath,
+    [
+      script,
+      "--host",
+      "x85-131-245-163",
+      "--repository",
+      "marushu/vtdd-v2-p",
+      "--repo-dir",
+      "/home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p",
+      "--node-bin",
+      "/home/vtdd-runner/.nvm/versions/node/v24.15.0/bin/node"
+    ],
+    { encoding: "utf8" }
+  );
+
+  assert.equal(result.status, 1);
+  const body = JSON.parse(result.stdout);
+  assert.equal(body.issues.includes("root is required unless --dry-run or --staging-dir is used"), true);
+});
+
+test("VPS maintenance helper installer never emits broad sudoers grants", () => {
+  const sudoers = buildSudoers({
+    runnerUser: "vtdd-runner",
+    helperPath: "/usr/local/sbin/vtdd-vps-maintenance-helper"
+  });
+  assert.equal(/\bNOPASSWD\s*:\s*ALL\b/i.test(sudoers), false);
+  assert.equal(sudoers.includes("sudo su"), false);
+});


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #637 の部分進捗です。VPS の root-owned privileged maintenance helper / capability manifest / scoped sudoers を、Mac 手作業のメモではなく repo-backed installer として再現できる状態にします。
- #662 の VPS 実機 evidence で `root_owned_helper=missing` / `root_owned_manifest=missing` が確認されたため、次の owner/passkey 実行に渡せる設置物を先に固定します。

## Satisfied Success Criteria

- VPS 上に root-owned helper と root-owned capability manifest を設置するための installer を repo-backed にした。
- `vtdd-runner` 向け sudoers は `NOPASSWD:ALL` ではなく `/usr/local/sbin/vtdd-vps-maintenance-helper` だけを許可する scoped command として生成する。
- dry-run / staging では root execution と helper execution を開始しない。
- sudo password、raw secret、approval token raw material は生成物、test、runtime truth に含めない。

## Unsatisfied Success Criteria

- 実機 VPS への root install は未実行。
- iPhone passkey approval から installer を実行する route は未接続。
- helper capability の add / enable / disable / remove / rollback / review の実機 E2E は未完了。
- Dashboard Butler 自然文から root helper install を完了する owner-facing workflow は未完了。
- Issue #637 は close しない。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #637
- Implementing Success Criteria: root-owned helper / root-owned capability manifest / scoped sudoers を設置できる repo-backed installer と dry-run/staging 検証を追加する。
- Explicit Non-goals: このPRでは実機 root install、sudoers 実機変更、passkey からの real execution route、Issue close、deploy は行わない。
- Expected touched files/routes/workflows: `scripts/install-vps-privileged-maintenance-helper.mjs`, `test/vps-maintenance-helper-installer.test.js`; Worker route / GitHub Actions workflow は変更しない。
- Affected Issues: Issue #637。Issue #355 / #412 / #413 / #450 / #631 には authority/recovery 関連の影響があるが、このPRでは実装範囲を広げない。
- Affected PRs: PR #662 の install inventory evidence を受けた後続。既存 open PR は変更しない。
- Affected workflows: GitHub Actions workflow は変更しないが、PR validation と reviewer automation は通常通り走る。
- Affected runtime/operator surfaces: VPS maintenance helper install path、VPS install inventory collector、future passkey operator VPS maintenance flow。
- What may break if we patch narrowly: installer が broad sudoers や owner 固有 runtime URL / Node path を repo に固定すると public/core branch と authority boundary が壊れる。
- Unknowns to investigate before coding: 実機 root install は後続の owner/passkey 境界で検証する必要がある。root helper real execution route は未接続。
- Validation needed: installer unit、既存 #637 collector/helper contract tests、full `npm test`。
- Stop condition: `NOPASSWD:ALL`、root shell、owner-specific production URL、またはこのPR内の実機 root mutation が混ざったら停止する。

## Execution Queue Delta

- Queue position before: Issue #637 is `Now`.
- Preemption decision: `ROOT`。#637 は複数 Issue の iPhone/PWA recovery を止める root blocker。
- Queue delta: Issue #637 remains `Now`; this PR moves Issue #637 from `Evidence Gaps` / install inventory `missing` toward root-owned install readiness.
- Why this PR is next: PR #662 の production/VPS evidence で helper と manifest が missing と判明したため、install inventory を `ready` に近づける repo-backed installer が次の最小 slice。
- Active Issues not downscoped: Active Issues は縮小しません。このPRで扱わない active Issue は未完了として残します。

## File / Line Hypotheses

- file: `scripts/install-vps-privileged-maintenance-helper.mjs`
  - hypothesis: #637 の missing 状態は repo-backed install artifact がないため、root が実行できる installer と dry-run/staging 出力が必要。
  - risk if changed narrowly: root path や Node path を owner 固定にすると public/core reuse が壊れる。
  - validation: dry-run / staging / non-root rejection / sudoers safety tests。
  - related Issue: Issue #637
- file: `test/vps-maintenance-helper-installer.test.js`
  - hypothesis: installer の authority boundary は tests で固定しないと再び `NOPASSWD:ALL` や root shell に近づく。
  - risk if changed narrowly: install plan だけできても sudoers shape の安全性が証明されない。
  - validation: generated sudoers に `NOPASSWD:ALL` が含まれないこと、helper script に owner production URL が含まれないこと。
  - related Issue: Issue #637

## Hypothesis Retrospective

- expected: #662 の collector evidence で missing だった helper / manifest / sudoers を、repo-backed installer の dry-run/staging で次の root install 手順に渡せる。
- actual: installer は dry-run で root/helper execution を開始せず、staging で helper / manifest / scoped sudoers を生成した。
- mismatch: real root install と passkey route はまだ未接続なので、Issue #637 completion ではない。
- lesson: install inventory evidence は `missing` を返した時点で、次に root-owned install artifact を要求する queue signal として扱う。
- should become RAG candidate: はい。#637 の root helper install missing -> repo-backed installer -> owner/passkey実行へ進む判断は今後の VPS recovery に効く。

## Verification Evidence

- Unit: `node --test test/vps-maintenance-helper-installer.test.js test/vps-maintenance-install-inventory-collector.test.js test/vps-privileged-maintenance-helper-script.test.js test/vps-privileged-maintenance.test.js` -> tests 22 / pass 22 / fail 0
- Integration: `npm test` -> tests 1063 / pass 1062 / skip 1 / fail 0; self-parity 30 routes / 30 operationIds; generated-worker pass
- E2E: 未実施。このPRは installer artifact slice であり、Butler/iPhone E2E は後続。
- Manual: #662 deploy 後の VPS collector evidence: https://github.com/marushu/vtdd-v2-p/issues/637#issuecomment-4577089395
- Evidence path/link: `test/vps-maintenance-helper-installer.test.js`, `scripts/install-vps-privileged-maintenance-helper.mjs`, Issue #637 comment https://github.com/marushu/vtdd-v2-p/issues/637#issuecomment-4577089395

## Butler Completion Contract

- Owner goal: iPhone/PWA から VPS privileged maintenance helper を安全に設置・観測できるようにする。
- Butler entrypoint: 未完了。Dashboard Butler からの natural-language install completion はこのPRでは未接続。
- Action Schema exposure: 変更なし。既存の VPS maintenance proposal / helper request / dry-run / install inventory operationIds は維持。
- Runtime path: repo-backed installer script を追加。Worker runtime route は変更しない。
- Runner/runtime truth: installer は dry-run/staging の redacted JSON を返す。実機 root install runtime truth は後続。
- Authority boundary: real install は root または future scoped passkey approval が必要。このPRは non-root real install を拒否し、dry-run/staging のみ通常実行可能。
- E2E evidence: 未実施。Butler-facing E2E は root install route 接続後に必要。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 不要。Worker route / `worker.js` は変更なし。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。Issue #637 completion 前に必要。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate
- AGENTS.md Butler-First Operating Principle
- AGENTS.md Authority Boundary
- AGENTS.md Drift Stop Protocol
- docs/butler/vps-privileged-maintenance-capability-lifecycle.md
- docs/butler/execution-queue-contract.md

## Out-of-scope but NOT implemented

- 実機 VPS root install
- passkey approval から installer を起動する runtime route
- helper real execution
- disable/remove/rollback の実機 lifecycle E2E
- Issue #637 close

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #637
- Execution ID: Not provided.
- Goal: VPS privileged maintenance helper install readiness
