### PR TITLE
Issue #637 install inventoryにscoped sudo probeを追加

### DIFF
--- a/scripts/collect-vps-maintenance-install-inventory.mjs
+++ b/scripts/collect-vps-maintenance-install-inventory.mjs
@@ -9,6 +9,8 @@ import { buildVpsPrivilegedMaintenanceInstallInventory } from "../src/core/index
 const DEFAULT_HELPER_INSTALL_PATH = "/usr/local/sbin/vtdd-vps-maintenance-helper";
 const DEFAULT_MANIFEST_PATH = "/etc/vtdd/privileged-maintenance-capabilities.json";
 const DEFAULT_SUDOERS_PATH = "/etc/sudoers.d/vtdd-vps-maintenance-helper";
+const DEFAULT_SUDO_PROBE_TIMEOUT_MS = 3000;
+const DEFAULT_SUDO_PROBE_MAX_BUFFER = 16 * 1024;
 const execFileAsync = promisify(execFile);
 
 function parseArgs(argv) {
@@ -74,7 +76,7 @@ async function observeSudoersPolicy(filePath) {
   }
 }
 
-async function probeScopedSudoHelper({ helperPath, enabled }) {
+async function probeScopedSudoHelper({ helperPath, enabled, timeoutMs, maxBuffer }) {
   if (!enabled) {
     return {
       started: false,
@@ -82,14 +84,14 @@ async function probeScopedSudoHelper({ helperPath, enabled }) {
     };
   }
   try {
-    const result = await execFileAsync("sudo", ["-n", helperPath, "--version"], {
-      timeout: 5000,
+    await execFileAsync("sudo", ["-n", helperPath, "--version"], {
+      timeout: timeoutMs,
       encoding: "utf8",
-      maxBuffer: 64 * 1024
+      maxBuffer
     });
     return {
       started: true,
-      ok: result.stdout.includes("vtdd-vps-maintenance-helper"),
+      ok: true,
       error: null
     };
   } catch (error) {
@@ -123,6 +125,14 @@ async function collectVpsMaintenanceInstallInventory(input = {}) {
   const sudoersPath = String(input.sudoersPath || input["sudoers-path"] || DEFAULT_SUDOERS_PATH).trim();
   const runnerUser = String(input.runnerUser || input["runner-user"] || "vtdd-runner").trim();
   const verifyScopedSudo = input.verifyScopedSudo === "true" || input["verify-scoped-sudo"] === "true";
+  const sudoProbeTimeoutMs = normalizePositiveInteger(
+    input.sudoProbeTimeoutMs || input["sudo-probe-timeout-ms"],
+    DEFAULT_SUDO_PROBE_TIMEOUT_MS
+  );
+  const sudoProbeMaxBuffer = normalizePositiveInteger(
+    input.sudoProbeMaxBuffer || input["sudo-probe-max-buffer"],
+    DEFAULT_SUDO_PROBE_MAX_BUFFER
+  );
 
   const [helper, manifest, sudoers, sudoersPolicy] = await Promise.all([
     observePath(helperPath),
@@ -132,7 +142,9 @@ async function collectVpsMaintenanceInstallInventory(input = {}) {
   ]);
   const sudoersHelperProbe = await probeScopedSudoHelper({
     helperPath,
-    enabled: verifyScopedSudo && helper.installed === true
+    enabled: verifyScopedSudo && helper.installed === true,
+    timeoutMs: sudoProbeTimeoutMs,
+    maxBuffer: sudoProbeMaxBuffer
   });
 
   const installInventory = buildVpsPrivilegedMaintenanceInstallInventory({
@@ -161,6 +173,7 @@ async function collectVpsMaintenanceInstallInventory(input = {}) {
       observer: "scripts/collect-vps-maintenance-install-inventory.mjs",
       sudoersContentReadable: sudoersPolicy.readable,
       sudoersHelperProbeStarted: sudoersHelperProbe.started,
+      sudoersHelperProbeTimeoutMs: sudoersHelperProbe.started ? sudoProbeTimeoutMs : null,
       rootExecutionStarted: false,
       helperExecutionStarted: false,
       redacted: true
@@ -174,10 +187,18 @@ async function collectVpsMaintenanceInstallInventory(input = {}) {
       sudoersHelperProbe: {
         started: sudoersHelperProbe.started,
         ok: sudoersHelperProbe.ok,
-        error: sudoersHelperProbe.error || null
+        error: sudoersHelperProbe.error || null,
+        command: sudoersHelperProbe.started ? "sudo -n <helper> --version" : null,
+        timeoutMs: sudoersHelperProbe.started ? sudoProbeTimeoutMs : null
       }
     }
   };
+}
+
+function normalizePositiveInteger(value, fallback) {
+  const numeric = Number(value);
+  if (!Number.isSafeInteger(numeric) || numeric <= 0) return fallback;
+  return numeric;
 }
 
 function redactObservation(value) {

--- a/scripts/collect-vps-maintenance-install-inventory.mjs
+++ b/scripts/collect-vps-maintenance-install-inventory.mjs
@@ -1,12 +1,15 @@
 #!/usr/bin/env node
 
 import fs from "node:fs/promises";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
 
 import { buildVpsPrivilegedMaintenanceInstallInventory } from "../src/core/index.js";
 
 const DEFAULT_HELPER_INSTALL_PATH = "/usr/local/sbin/vtdd-vps-maintenance-helper";
 const DEFAULT_MANIFEST_PATH = "/etc/vtdd/privileged-maintenance-capabilities.json";
 const DEFAULT_SUDOERS_PATH = "/etc/sudoers.d/vtdd-vps-maintenance-helper";
+const execFileAsync = promisify(execFile);
 
 function parseArgs(argv) {
   const result = {};
@@ -71,6 +74,33 @@ async function observeSudoersPolicy(filePath) {
   }
 }
 
+async function probeScopedSudoHelper({ helperPath, enabled }) {
+  if (!enabled) {
+    return {
+      started: false,
+      ok: null
+    };
+  }
+  try {
+    const result = await execFileAsync("sudo", ["-n", helperPath, "--version"], {
+      timeout: 5000,
+      encoding: "utf8",
+      maxBuffer: 64 * 1024
+    });
+    return {
+      started: true,
+      ok: result.stdout.includes("vtdd-vps-maintenance-helper"),
+      error: null
+    };
+  } catch (error) {
+    return {
+      started: true,
+      ok: false,
+      error: summarizeError(error)
+    };
+  }
+}
+
 function containsBroadSudoersGrant(content) {
   return /\bNOPASSWD\s*:\s*ALL\b/i.test(String(content || ""));
 }
@@ -92,6 +122,7 @@ async function collectVpsMaintenanceInstallInventory(input = {}) {
   const manifestPath = String(input.manifestPath || input["manifest-path"] || DEFAULT_MANIFEST_PATH).trim();
   const sudoersPath = String(input.sudoersPath || input["sudoers-path"] || DEFAULT_SUDOERS_PATH).trim();
   const runnerUser = String(input.runnerUser || input["runner-user"] || "vtdd-runner").trim();
+  const verifyScopedSudo = input.verifyScopedSudo === "true" || input["verify-scoped-sudo"] === "true";
 
   const [helper, manifest, sudoers, sudoersPolicy] = await Promise.all([
     observePath(helperPath),
@@ -99,6 +130,10 @@ async function collectVpsMaintenanceInstallInventory(input = {}) {
     observePath(sudoersPath),
     observeSudoersPolicy(sudoersPath)
   ]);
+  const sudoersHelperProbe = await probeScopedSudoHelper({
+    helperPath,
+    enabled: verifyScopedSudo && helper.installed === true
+  });
 
   const installInventory = buildVpsPrivilegedMaintenanceInstallInventory({
     host,
@@ -113,7 +148,8 @@ async function collectVpsMaintenanceInstallInventory(input = {}) {
     helperOwner: helper.owner,
     manifestOwner: manifest.owner,
     sudoersOwner: sudoers.owner,
-    sudoersAllowsAll: sudoersPolicy.allowsAll
+    sudoersAllowsAll: sudoersPolicy.allowsAll,
+    sudoersHelperProbe: sudoersHelperProbe.ok
   });
 
   return {
@@ -124,6 +160,7 @@ async function collectVpsMaintenanceInstallInventory(input = {}) {
       ...installInventory.runtimeTruth,
       observer: "scripts/collect-vps-maintenance-install-inventory.mjs",
       sudoersContentReadable: sudoersPolicy.readable,
+      sudoersHelperProbeStarted: sudoersHelperProbe.started,
       rootExecutionStarted: false,
       helperExecutionStarted: false,
       redacted: true
@@ -133,7 +170,12 @@ async function collectVpsMaintenanceInstallInventory(input = {}) {
       manifest: redactObservation(manifest),
       sudoers: redactObservation(sudoers),
       sudoersContentReadable: sudoersPolicy.readable,
-      sudoersPolicyError: sudoersPolicy.error || null
+      sudoersPolicyError: sudoersPolicy.error || null,
+      sudoersHelperProbe: {
+        started: sudoersHelperProbe.started,
+        ok: sudoersHelperProbe.ok,
+        error: sudoersHelperProbe.error || null
+      }
     }
   };
 }

--- a/scripts/collect-vps-maintenance-install-inventory.mjs
+++ b/scripts/collect-vps-maintenance-install-inventory.mjs
@@ -80,7 +80,8 @@ async function probeScopedSudoHelper({ helperPath, enabled, timeoutMs, maxBuffer
   if (!enabled) {
     return {
       started: false,
-      ok: null
+      ok: null,
+      skippedReason: "preconditions_not_met"
     };
   }
   try {
@@ -101,6 +102,19 @@ async function probeScopedSudoHelper({ helperPath, enabled, timeoutMs, maxBuffer
       error: summarizeError(error)
     };
   }
+}
+
+function shouldProbeScopedSudoHelper({ verifyScopedSudo, helper, manifest, sudoers, sudoersPolicy }) {
+  return (
+    verifyScopedSudo === true &&
+    helper.installed === true &&
+    helper.owner === "root" &&
+    manifest.installed === true &&
+    manifest.owner === "root" &&
+    sudoers.installed === true &&
+    sudoers.owner === "root" &&
+    sudoersPolicy.allowsAll !== true
+  );
 }
 
 function containsBroadSudoersGrant(content) {
@@ -140,9 +154,16 @@ async function collectVpsMaintenanceInstallInventory(input = {}) {
     observePath(sudoersPath),
     observeSudoersPolicy(sudoersPath)
   ]);
+  const shouldProbe = shouldProbeScopedSudoHelper({
+    verifyScopedSudo,
+    helper,
+    manifest,
+    sudoers,
+    sudoersPolicy
+  });
   const sudoersHelperProbe = await probeScopedSudoHelper({
     helperPath,
-    enabled: verifyScopedSudo && helper.installed === true,
+    enabled: shouldProbe,
     timeoutMs: sudoProbeTimeoutMs,
     maxBuffer: sudoProbeMaxBuffer
   });
@@ -161,7 +182,8 @@ async function collectVpsMaintenanceInstallInventory(input = {}) {
     manifestOwner: manifest.owner,
     sudoersOwner: sudoers.owner,
     sudoersAllowsAll: sudoersPolicy.allowsAll,
-    sudoersHelperProbe: sudoersHelperProbe.ok
+    sudoersHelperProbe: sudoersHelperProbe.ok,
+    sudoersHelperProbeStarted: sudoersHelperProbe.started
   });
 
   return {
@@ -188,6 +210,7 @@ async function collectVpsMaintenanceInstallInventory(input = {}) {
         started: sudoersHelperProbe.started,
         ok: sudoersHelperProbe.ok,
         error: sudoersHelperProbe.error || null,
+        skippedReason: sudoersHelperProbe.skippedReason || null,
         command: sudoersHelperProbe.started ? "sudo -n <helper> --version" : null,
         timeoutMs: sudoersHelperProbe.started ? sudoProbeTimeoutMs : null
       }

--- a/src/core/vps-privileged-maintenance.js
+++ b/src/core/vps-privileged-maintenance.js
@@ -260,6 +260,8 @@ function buildVpsPrivilegedMaintenanceInstallInventory(input = {}) {
   const sudoersOwner = normalizeText(observed.sudoersOwner || input.sudoersOwner);
   const sudoersAllowsAll = normalizeBoolean(observed.sudoersAllowsAll ?? input.sudoersAllowsAll);
   const sudoersHelperProbe = normalizeBoolean(observed.sudoersHelperProbe ?? input.sudoersHelperProbe);
+  const sudoersHelperProbeStarted = normalizeBoolean(observed.sudoersHelperProbeStarted ?? input.sudoersHelperProbeStarted);
+  const functionalProbeStarted = sudoersHelperProbeStarted ?? sudoersHelperProbe !== null;
   const issues = [];
   if (!host) issues.push("host is required");
   if (!repository) issues.push("repository is required");
@@ -267,6 +269,7 @@ function buildVpsPrivilegedMaintenanceInstallInventory(input = {}) {
   if (!manifestPath.startsWith("/")) issues.push("manifestPath must be absolute");
   if (!sudoersPath.startsWith("/")) issues.push("sudoersPath must be absolute");
   if (sudoersAllowsAll === true) issues.push("sudoers must not allow NOPASSWD:ALL");
+  if (sudoersHelperProbe === false) issues.push("helper sudo functional probe failed");
 
   const checks = [
     {
@@ -340,10 +343,12 @@ function buildVpsPrivilegedMaintenanceInstallInventory(input = {}) {
       repository,
       rootExecutionStarted: false,
       helperExecutionStarted: false,
-      sudoersHelperProbeStarted: sudoersHelperProbe === true,
+      sudoersHelperProbeStarted: functionalProbeStarted,
       redacted: true,
       nextAction:
-        status === "ready"
+        sudoersHelperProbe === false
+          ? "fix scoped helper sudo before claiming VPS privileged maintenance is ready"
+          : status === "ready"
           ? "helper install inventory is ready for scoped helper requests"
           : "verify or install root-owned helper, manifest, and scoped sudoers before claiming iPhone-complete privileged maintenance"
     },

--- a/src/core/vps-privileged-maintenance.js
+++ b/src/core/vps-privileged-maintenance.js
@@ -259,6 +259,7 @@ function buildVpsPrivilegedMaintenanceInstallInventory(input = {}) {
   const manifestOwner = normalizeText(observed.manifestOwner || input.manifestOwner);
   const sudoersOwner = normalizeText(observed.sudoersOwner || input.sudoersOwner);
   const sudoersAllowsAll = normalizeBoolean(observed.sudoersAllowsAll ?? input.sudoersAllowsAll);
+  const sudoersHelperProbe = normalizeBoolean(observed.sudoersHelperProbe ?? input.sudoersHelperProbe);
   const issues = [];
   if (!host) issues.push("host is required");
   if (!repository) issues.push("repository is required");
@@ -286,11 +287,19 @@ function buildVpsPrivilegedMaintenanceInstallInventory(input = {}) {
     },
     {
       id: "scoped_sudoers_entry",
-      status: sudoersInstalled === true && sudoersOwner === "root" && sudoersAllowsAll !== true ? "pass" : sudoersInstalled === false ? "missing" : "unverified",
+      status:
+        sudoersInstalled === true && sudoersOwner === "root" && sudoersAllowsAll !== true
+          ? "pass"
+          : sudoersHelperProbe === true && sudoersAllowsAll !== true
+            ? "pass"
+            : sudoersInstalled === false
+              ? "missing"
+              : "unverified",
       required: true,
       path: sudoersPath,
       expectedOwner: "root",
-      observedOwner: sudoersOwner || null
+      observedOwner: sudoersOwner || null,
+      functionalProbe: sudoersHelperProbe === true ? "sudo_helper_version" : null
     }
   ];
   const status =
@@ -325,6 +334,7 @@ function buildVpsPrivilegedMaintenanceInstallInventory(input = {}) {
       repository,
       rootExecutionStarted: false,
       helperExecutionStarted: false,
+      sudoersHelperProbeStarted: sudoersHelperProbe === true,
       redacted: true,
       nextAction:
         status === "ready"

--- a/src/core/vps-privileged-maintenance.js
+++ b/src/core/vps-privileged-maintenance.js
@@ -290,24 +290,30 @@ function buildVpsPrivilegedMaintenanceInstallInventory(input = {}) {
       status:
         sudoersInstalled === true && sudoersOwner === "root" && sudoersAllowsAll !== true
           ? "pass"
-          : sudoersHelperProbe === true && sudoersAllowsAll !== true
-            ? "pass"
-            : sudoersInstalled === false
-              ? "missing"
-              : "unverified",
+          : sudoersInstalled === false
+            ? "missing"
+            : "unverified",
       required: true,
       path: sudoersPath,
       expectedOwner: "root",
-      observedOwner: sudoersOwner || null,
+      observedOwner: sudoersOwner || null
+    },
+    {
+      id: "helper_sudo_functional_probe",
+      status: sudoersHelperProbe === true ? "pass" : sudoersHelperProbe === false ? "blocked" : "unverified",
+      required: false,
+      path: helperPath,
+      expectedOwner: "root",
+      observedOwner: null,
       functionalProbe: sudoersHelperProbe === true ? "sudo_helper_version" : null
     }
   ];
   const status =
     issues.length > 0
       ? "blocked"
-      : checks.every((check) => check.status === "pass")
+      : checks.filter((check) => check.required).every((check) => check.status === "pass")
         ? "ready"
-        : checks.some((check) => check.status === "missing")
+        : checks.filter((check) => check.required).some((check) => check.status === "missing")
           ? "missing"
           : "unverified";
 

--- a/test/vps-maintenance-install-inventory-collector.test.js
+++ b/test/vps-maintenance-install-inventory-collector.test.js
@@ -88,7 +88,7 @@ test("VPS maintenance install inventory collector can verify scoped sudo helper 
   });
   await fs.writeFile(
     path.join(fakeBin, "sudo"),
-    "#!/bin/sh\nif [ \"$1\" = \"-n\" ] && [ \"$3\" = \"--version\" ]; then echo vtdd-vps-maintenance-helper; exit 0; fi\nexit 1\n",
+    "#!/bin/sh\nif [ \"$1\" = \"-n\" ] && [ \"$3\" = \"--version\" ]; then echo helper-version-output-may-change; exit 0; fi\nexit 1\n",
     { mode: 0o755 }
   );
 
@@ -106,7 +106,11 @@ test("VPS maintenance install inventory collector can verify scoped sudo helper 
       manifestPath,
       "--sudoers-path",
       sudoersPath,
-      "--verify-scoped-sudo"
+      "--verify-scoped-sudo",
+      "--sudo-probe-timeout-ms",
+      "1000",
+      "--sudo-probe-max-buffer",
+      "4096"
     ],
     {
       encoding: "utf8",
@@ -122,9 +126,11 @@ test("VPS maintenance install inventory collector can verify scoped sudo helper 
   assert.equal(body.installInventory.status, "unverified");
   assert.equal(body.installInventory.checks.find((check) => check.id === "scoped_sudoers_entry").status, "pass");
   assert.equal(body.runtimeTruth.sudoersHelperProbeStarted, true);
+  assert.equal(body.runtimeTruth.sudoersHelperProbeTimeoutMs, 1000);
   assert.equal(body.runtimeTruth.rootExecutionStarted, false);
   assert.equal(body.runtimeTruth.helperExecutionStarted, false);
   assert.equal(body.observation.sudoersHelperProbe.ok, true);
+  assert.equal(body.observation.sudoersHelperProbe.timeoutMs, 1000);
 });
 
 test("VPS maintenance install inventory collector detects broad sudoers grants", () => {

--- a/test/vps-maintenance-install-inventory-collector.test.js
+++ b/test/vps-maintenance-install-inventory-collector.test.js
@@ -74,7 +74,7 @@ test("VPS maintenance install inventory collector blocks broad sudoers grants wi
   assert.equal(JSON.stringify(body).includes("vtdd-runner ALL=(ALL) NOPASSWD:ALL"), false);
 });
 
-test("VPS maintenance install inventory collector can verify scoped sudo helper without reading sudoers content", async () => {
+test("VPS maintenance install inventory collector skips sudo probe until root-owned install preconditions are met", async () => {
   const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "vtdd-vps-install-inventory-"));
   const helperPath = path.join(tempRoot, "helper");
   const manifestPath = path.join(tempRoot, "manifest.json");
@@ -125,13 +125,14 @@ test("VPS maintenance install inventory collector can verify scoped sudo helper 
   const body = JSON.parse(result.stdout);
   assert.equal(body.installInventory.status, "unverified");
   assert.equal(body.installInventory.checks.find((check) => check.id === "scoped_sudoers_entry").status, "unverified");
-  assert.equal(body.installInventory.checks.find((check) => check.id === "helper_sudo_functional_probe").status, "pass");
-  assert.equal(body.runtimeTruth.sudoersHelperProbeStarted, true);
-  assert.equal(body.runtimeTruth.sudoersHelperProbeTimeoutMs, 1000);
+  assert.equal(body.installInventory.checks.find((check) => check.id === "helper_sudo_functional_probe").status, "unverified");
+  assert.equal(body.runtimeTruth.sudoersHelperProbeStarted, false);
+  assert.equal(body.runtimeTruth.sudoersHelperProbeTimeoutMs, null);
   assert.equal(body.runtimeTruth.rootExecutionStarted, false);
   assert.equal(body.runtimeTruth.helperExecutionStarted, false);
-  assert.equal(body.observation.sudoersHelperProbe.ok, true);
-  assert.equal(body.observation.sudoersHelperProbe.timeoutMs, 1000);
+  assert.equal(body.observation.sudoersHelperProbe.ok, null);
+  assert.equal(body.observation.sudoersHelperProbe.skippedReason, "preconditions_not_met");
+  assert.equal(body.observation.sudoersHelperProbe.timeoutMs, null);
 });
 
 test("VPS maintenance install inventory collector detects broad sudoers grants", () => {

--- a/test/vps-maintenance-install-inventory-collector.test.js
+++ b/test/vps-maintenance-install-inventory-collector.test.js
@@ -135,6 +135,94 @@ test("VPS maintenance install inventory collector skips sudo probe until root-ow
   assert.equal(body.observation.sudoersHelperProbe.timeoutMs, null);
 });
 
+test("VPS maintenance install inventory collector starts sudo probe for bare flag when preconditions pass", async () => {
+  const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "vtdd-vps-install-inventory-"));
+  const fakeBin = path.join(tempRoot, "bin");
+  await fs.mkdir(fakeBin, { recursive: true });
+  await fs.writeFile(
+    path.join(fakeBin, "sudo"),
+    "#!/bin/sh\nif [ \"$1\" = \"-n\" ] && [ \"$3\" = \"--version\" ]; then echo helper-version-output-may-change; exit 0; fi\nexit 1\n",
+    { mode: 0o755 }
+  );
+
+  const result = spawnSync(
+    process.execPath,
+    [
+      "scripts/collect-vps-maintenance-install-inventory.mjs",
+      "--host",
+      "x85-131-245-163",
+      "--repository",
+      "marushu/vtdd-v2-p",
+      "--helper-path",
+      "/bin/sh",
+      "--manifest-path",
+      "/etc/hosts",
+      "--sudoers-path",
+      "/etc/hosts",
+      "--verify-scoped-sudo",
+      "--sudo-probe-timeout-ms",
+      "1000",
+      "--sudo-probe-max-buffer",
+      "4096"
+    ],
+    {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${fakeBin}:${process.env.PATH}`
+      }
+    }
+  );
+
+  assert.equal(result.status, 0);
+  const body = JSON.parse(result.stdout);
+  assert.equal(body.installInventory.status, "ready");
+  assert.equal(body.installInventory.checks.find((check) => check.id === "helper_sudo_functional_probe").status, "pass");
+  assert.equal(body.runtimeTruth.sudoersHelperProbeStarted, true);
+  assert.equal(body.observation.sudoersHelperProbe.ok, true);
+  assert.equal(body.observation.sudoersHelperProbe.command, "sudo -n <helper> --version");
+});
+
+test("VPS maintenance install inventory collector blocks when started sudo probe fails", async () => {
+  const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "vtdd-vps-install-inventory-"));
+  const fakeBin = path.join(tempRoot, "bin");
+  await fs.mkdir(fakeBin, { recursive: true });
+  await fs.writeFile(path.join(fakeBin, "sudo"), "#!/bin/sh\nexit 42\n", { mode: 0o755 });
+
+  const result = spawnSync(
+    process.execPath,
+    [
+      "scripts/collect-vps-maintenance-install-inventory.mjs",
+      "--host",
+      "x85-131-245-163",
+      "--repository",
+      "marushu/vtdd-v2-p",
+      "--helper-path",
+      "/bin/sh",
+      "--manifest-path",
+      "/etc/hosts",
+      "--sudoers-path",
+      "/etc/hosts",
+      "--verify-scoped-sudo"
+    ],
+    {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${fakeBin}:${process.env.PATH}`
+      }
+    }
+  );
+
+  assert.equal(result.status, 1);
+  const body = JSON.parse(result.stdout);
+  assert.equal(body.ok, false);
+  assert.equal(body.installInventory.status, "blocked");
+  assert.equal(body.installInventory.checks.find((check) => check.id === "helper_sudo_functional_probe").status, "blocked");
+  assert.equal(body.runtimeTruth.sudoersHelperProbeStarted, true);
+  assert.equal(body.observation.sudoersHelperProbe.ok, false);
+});
+
 test("VPS maintenance install inventory collector detects broad sudoers grants", () => {
   assert.equal(containsBroadSudoersGrant("vtdd-runner ALL=(ALL) NOPASSWD:ALL"), true);
   assert.equal(containsBroadSudoersGrant("vtdd-runner ALL=(root) NOPASSWD:/usr/local/sbin/vtdd-helper"), false);

--- a/test/vps-maintenance-install-inventory-collector.test.js
+++ b/test/vps-maintenance-install-inventory-collector.test.js
@@ -74,6 +74,59 @@ test("VPS maintenance install inventory collector blocks broad sudoers grants wi
   assert.equal(JSON.stringify(body).includes("vtdd-runner ALL=(ALL) NOPASSWD:ALL"), false);
 });
 
+test("VPS maintenance install inventory collector can verify scoped sudo helper without reading sudoers content", async () => {
+  const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "vtdd-vps-install-inventory-"));
+  const helperPath = path.join(tempRoot, "helper");
+  const manifestPath = path.join(tempRoot, "manifest.json");
+  const sudoersPath = path.join(tempRoot, "sudoers");
+  const fakeBin = path.join(tempRoot, "bin");
+  await fs.mkdir(fakeBin, { recursive: true });
+  await fs.writeFile(helperPath, "#!/bin/sh\n", { mode: 0o755 });
+  await fs.writeFile(manifestPath, "{}\n", "utf8");
+  await fs.writeFile(sudoersPath, "vtdd-runner ALL=(root) NOPASSWD: /usr/local/sbin/vtdd-vps-maintenance-helper\n", {
+    mode: 0o000
+  });
+  await fs.writeFile(
+    path.join(fakeBin, "sudo"),
+    "#!/bin/sh\nif [ \"$1\" = \"-n\" ] && [ \"$3\" = \"--version\" ]; then echo vtdd-vps-maintenance-helper; exit 0; fi\nexit 1\n",
+    { mode: 0o755 }
+  );
+
+  const result = spawnSync(
+    process.execPath,
+    [
+      "scripts/collect-vps-maintenance-install-inventory.mjs",
+      "--host",
+      "x85-131-245-163",
+      "--repository",
+      "marushu/vtdd-v2-p",
+      "--helper-path",
+      helperPath,
+      "--manifest-path",
+      manifestPath,
+      "--sudoers-path",
+      sudoersPath,
+      "--verify-scoped-sudo"
+    ],
+    {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${fakeBin}:${process.env.PATH}`
+      }
+    }
+  );
+
+  assert.equal(result.status, 0);
+  const body = JSON.parse(result.stdout);
+  assert.equal(body.installInventory.status, "unverified");
+  assert.equal(body.installInventory.checks.find((check) => check.id === "scoped_sudoers_entry").status, "pass");
+  assert.equal(body.runtimeTruth.sudoersHelperProbeStarted, true);
+  assert.equal(body.runtimeTruth.rootExecutionStarted, false);
+  assert.equal(body.runtimeTruth.helperExecutionStarted, false);
+  assert.equal(body.observation.sudoersHelperProbe.ok, true);
+});
+
 test("VPS maintenance install inventory collector detects broad sudoers grants", () => {
   assert.equal(containsBroadSudoersGrant("vtdd-runner ALL=(ALL) NOPASSWD:ALL"), true);
   assert.equal(containsBroadSudoersGrant("vtdd-runner ALL=(root) NOPASSWD:/usr/local/sbin/vtdd-helper"), false);

--- a/test/vps-maintenance-install-inventory-collector.test.js
+++ b/test/vps-maintenance-install-inventory-collector.test.js
@@ -32,7 +32,7 @@ test("VPS maintenance install inventory collector reports missing paths without 
   assert.equal(body.ok, true);
   assert.equal(body.source, "vps_local_filesystem_observer");
   assert.equal(body.installInventory.status, "missing");
-  assert.equal(body.installInventory.checks.every((check) => check.status === "missing"), true);
+  assert.equal(body.installInventory.checks.filter((check) => check.required).every((check) => check.status === "missing"), true);
   assert.equal(body.runtimeTruth.rootExecutionStarted, false);
   assert.equal(body.runtimeTruth.helperExecutionStarted, false);
   assert.equal(JSON.stringify(body).includes("vtdd-runner ALL=(ALL) NOPASSWD:ALL"), false);
@@ -124,7 +124,8 @@ test("VPS maintenance install inventory collector can verify scoped sudo helper 
   assert.equal(result.status, 0);
   const body = JSON.parse(result.stdout);
   assert.equal(body.installInventory.status, "unverified");
-  assert.equal(body.installInventory.checks.find((check) => check.id === "scoped_sudoers_entry").status, "pass");
+  assert.equal(body.installInventory.checks.find((check) => check.id === "scoped_sudoers_entry").status, "unverified");
+  assert.equal(body.installInventory.checks.find((check) => check.id === "helper_sudo_functional_probe").status, "pass");
   assert.equal(body.runtimeTruth.sudoersHelperProbeStarted, true);
   assert.equal(body.runtimeTruth.sudoersHelperProbeTimeoutMs, 1000);
   assert.equal(body.runtimeTruth.rootExecutionStarted, false);

--- a/test/vps-privileged-maintenance.test.js
+++ b/test/vps-privileged-maintenance.test.js
@@ -66,7 +66,7 @@ test("VPS privileged maintenance install inventory reports root-owned helper rea
   assert.equal(ready.requiredSudoersShape.allowedCommand, ready.helperPath);
   assert.equal(ready.runtimeTruth.rootExecutionStarted, false);
   assert.equal(ready.runtimeTruth.helperExecutionStarted, false);
-  assert.equal(ready.checks.every((check) => check.status === "pass"), true);
+  assert.equal(ready.checks.filter((check) => check.required).every((check) => check.status === "pass"), true);
 
   const unsafe = buildVpsPrivilegedMaintenanceInstallInventory({
     host: "x85-131-245-163",
@@ -89,7 +89,9 @@ test("VPS privileged maintenance install inventory reports root-owned helper rea
     sudoersAllowsAll: null,
     sudoersHelperProbe: true
   });
-  assert.equal(sudoProbeReady.status, "ready");
+  assert.equal(sudoProbeReady.status, "unverified");
+  assert.equal(sudoProbeReady.checks.find((check) => check.id === "scoped_sudoers_entry").status, "unverified");
+  assert.equal(sudoProbeReady.checks.find((check) => check.id === "helper_sudo_functional_probe").status, "pass");
   assert.equal(sudoProbeReady.runtimeTruth.sudoersHelperProbeStarted, true);
 });
 

--- a/test/vps-privileged-maintenance.test.js
+++ b/test/vps-privileged-maintenance.test.js
@@ -76,6 +76,21 @@ test("VPS privileged maintenance install inventory reports root-owned helper rea
   assert.equal(unsafe.ok, false);
   assert.equal(unsafe.status, "blocked");
   assert.equal(unsafe.issues.includes("sudoers must not allow NOPASSWD:ALL"), true);
+
+  const sudoProbeReady = buildVpsPrivilegedMaintenanceInstallInventory({
+    host: "x85-131-245-163",
+    repository: "marushu/vtdd-v2-p",
+    helperInstalled: true,
+    manifestInstalled: true,
+    sudoersInstalled: null,
+    helperOwner: "root",
+    manifestOwner: "root",
+    sudoersOwner: null,
+    sudoersAllowsAll: null,
+    sudoersHelperProbe: true
+  });
+  assert.equal(sudoProbeReady.status, "ready");
+  assert.equal(sudoProbeReady.runtimeTruth.sudoersHelperProbeStarted, true);
 });
 
 test("VPS privileged maintenance helper command registry exposes initial presets", () => {

--- a/test/vps-privileged-maintenance.test.js
+++ b/test/vps-privileged-maintenance.test.js
@@ -93,6 +93,29 @@ test("VPS privileged maintenance install inventory reports root-owned helper rea
   assert.equal(sudoProbeReady.checks.find((check) => check.id === "scoped_sudoers_entry").status, "unverified");
   assert.equal(sudoProbeReady.checks.find((check) => check.id === "helper_sudo_functional_probe").status, "pass");
   assert.equal(sudoProbeReady.runtimeTruth.sudoersHelperProbeStarted, true);
+
+  const sudoProbeFailed = buildVpsPrivilegedMaintenanceInstallInventory({
+    host: "x85-131-245-163",
+    repository: "marushu/vtdd-v2-p",
+    helperInstalled: true,
+    manifestInstalled: true,
+    sudoersInstalled: true,
+    helperOwner: "root",
+    manifestOwner: "root",
+    sudoersOwner: "root",
+    sudoersAllowsAll: false,
+    sudoersHelperProbe: false,
+    sudoersHelperProbeStarted: true
+  });
+  assert.equal(sudoProbeFailed.ok, false);
+  assert.equal(sudoProbeFailed.status, "blocked");
+  assert.equal(sudoProbeFailed.checks.find((check) => check.id === "helper_sudo_functional_probe").status, "blocked");
+  assert.equal(sudoProbeFailed.issues.includes("helper sudo functional probe failed"), true);
+  assert.equal(sudoProbeFailed.runtimeTruth.sudoersHelperProbeStarted, true);
+  assert.equal(
+    sudoProbeFailed.runtimeTruth.nextAction,
+    "fix scoped helper sudo before claiming VPS privileged maintenance is ready"
+  );
 });
 
 test("VPS privileged maintenance helper command registry exposes initial presets", () => {

--- a/worker.js
+++ b/worker.js
@@ -37527,15 +37527,23 @@ function buildVpsPrivilegedMaintenanceInstallInventory(input = {}) {
     },
     {
       id: "scoped_sudoers_entry",
-      status: sudoersInstalled === true && sudoersOwner === "root" && sudoersAllowsAll !== true ? "pass" : sudoersHelperProbe === true && sudoersAllowsAll !== true ? "pass" : sudoersInstalled === false ? "missing" : "unverified",
+      status: sudoersInstalled === true && sudoersOwner === "root" && sudoersAllowsAll !== true ? "pass" : sudoersInstalled === false ? "missing" : "unverified",
       required: true,
       path: sudoersPath,
       expectedOwner: "root",
-      observedOwner: sudoersOwner || null,
+      observedOwner: sudoersOwner || null
+    },
+    {
+      id: "helper_sudo_functional_probe",
+      status: sudoersHelperProbe === true ? "pass" : sudoersHelperProbe === false ? "blocked" : "unverified",
+      required: false,
+      path: helperPath,
+      expectedOwner: "root",
+      observedOwner: null,
       functionalProbe: sudoersHelperProbe === true ? "sudo_helper_version" : null
     }
   ];
-  const status = issues.length > 0 ? "blocked" : checks.every((check) => check.status === "pass") ? "ready" : checks.some((check) => check.status === "missing") ? "missing" : "unverified";
+  const status = issues.length > 0 ? "blocked" : checks.filter((check) => check.required).every((check) => check.status === "pass") ? "ready" : checks.filter((check) => check.required).some((check) => check.status === "missing") ? "missing" : "unverified";
   return {
     ok: issues.length === 0,
     kind: "vps_privileged_maintenance_install_inventory",

--- a/worker.js
+++ b/worker.js
@@ -37500,6 +37500,7 @@ function buildVpsPrivilegedMaintenanceInstallInventory(input = {}) {
   const manifestOwner = normalizeText24(observed.manifestOwner || input.manifestOwner);
   const sudoersOwner = normalizeText24(observed.sudoersOwner || input.sudoersOwner);
   const sudoersAllowsAll = normalizeBoolean(observed.sudoersAllowsAll ?? input.sudoersAllowsAll);
+  const sudoersHelperProbe = normalizeBoolean(observed.sudoersHelperProbe ?? input.sudoersHelperProbe);
   const issues = [];
   if (!host) issues.push("host is required");
   if (!repository) issues.push("repository is required");
@@ -37526,11 +37527,12 @@ function buildVpsPrivilegedMaintenanceInstallInventory(input = {}) {
     },
     {
       id: "scoped_sudoers_entry",
-      status: sudoersInstalled === true && sudoersOwner === "root" && sudoersAllowsAll !== true ? "pass" : sudoersInstalled === false ? "missing" : "unverified",
+      status: sudoersInstalled === true && sudoersOwner === "root" && sudoersAllowsAll !== true ? "pass" : sudoersHelperProbe === true && sudoersAllowsAll !== true ? "pass" : sudoersInstalled === false ? "missing" : "unverified",
       required: true,
       path: sudoersPath,
       expectedOwner: "root",
-      observedOwner: sudoersOwner || null
+      observedOwner: sudoersOwner || null,
+      functionalProbe: sudoersHelperProbe === true ? "sudo_helper_version" : null
     }
   ];
   const status = issues.length > 0 ? "blocked" : checks.every((check) => check.status === "pass") ? "ready" : checks.some((check) => check.status === "missing") ? "missing" : "unverified";
@@ -37557,6 +37559,7 @@ function buildVpsPrivilegedMaintenanceInstallInventory(input = {}) {
       repository,
       rootExecutionStarted: false,
       helperExecutionStarted: false,
+      sudoersHelperProbeStarted: sudoersHelperProbe === true,
       redacted: true,
       nextAction: status === "ready" ? "helper install inventory is ready for scoped helper requests" : "verify or install root-owned helper, manifest, and scoped sudoers before claiming iPhone-complete privileged maintenance"
     },

--- a/worker.js
+++ b/worker.js
@@ -37501,6 +37501,8 @@ function buildVpsPrivilegedMaintenanceInstallInventory(input = {}) {
   const sudoersOwner = normalizeText24(observed.sudoersOwner || input.sudoersOwner);
   const sudoersAllowsAll = normalizeBoolean(observed.sudoersAllowsAll ?? input.sudoersAllowsAll);
   const sudoersHelperProbe = normalizeBoolean(observed.sudoersHelperProbe ?? input.sudoersHelperProbe);
+  const sudoersHelperProbeStarted = normalizeBoolean(observed.sudoersHelperProbeStarted ?? input.sudoersHelperProbeStarted);
+  const functionalProbeStarted = sudoersHelperProbeStarted ?? sudoersHelperProbe !== null;
   const issues = [];
   if (!host) issues.push("host is required");
   if (!repository) issues.push("repository is required");
@@ -37508,6 +37510,7 @@ function buildVpsPrivilegedMaintenanceInstallInventory(input = {}) {
   if (!manifestPath.startsWith("/")) issues.push("manifestPath must be absolute");
   if (!sudoersPath.startsWith("/")) issues.push("sudoersPath must be absolute");
   if (sudoersAllowsAll === true) issues.push("sudoers must not allow NOPASSWD:ALL");
+  if (sudoersHelperProbe === false) issues.push("helper sudo functional probe failed");
   const checks = [
     {
       id: "root_owned_helper",
@@ -37567,9 +37570,9 @@ function buildVpsPrivilegedMaintenanceInstallInventory(input = {}) {
       repository,
       rootExecutionStarted: false,
       helperExecutionStarted: false,
-      sudoersHelperProbeStarted: sudoersHelperProbe === true,
+      sudoersHelperProbeStarted: functionalProbeStarted,
       redacted: true,
-      nextAction: status === "ready" ? "helper install inventory is ready for scoped helper requests" : "verify or install root-owned helper, manifest, and scoped sudoers before claiming iPhone-complete privileged maintenance"
+      nextAction: sudoersHelperProbe === false ? "fix scoped helper sudo before claiming VPS privileged maintenance is ready" : status === "ready" ? "helper install inventory is ready for scoped helper requests" : "verify or install root-owned helper, manifest, and scoped sudoers before claiming iPhone-complete privileged maintenance"
     },
     issues
   };


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #637 の部分進捗です。初回 bootstrap 後、helper / manifest は root-owned として観測できた一方、`vtdd-runner` は sudoers file を読めないため install inventory が `unverified` のままでした。
- この PR は sudoers 内容を読まず、`sudo -n <helper> --version` の functional probe を `scoped_sudoers_entry` とは別の runtime truth として反映します。

## Satisfied Success Criteria

- helper / manifest / scoped sudoers file truth と helper sudo functional truth を分離して報告できる。
- collector は `--verify-scoped-sudo` 指定時だけ functional probe を行う。
- probe は helper `--version` のみで、root maintenance command は実行しない。
- probe は root-owned helper / manifest / sudoers file の install precondition を満たす場合だけ起動する。
- probe failure は top-level `blocked` として扱い、`ready` とは報告しない。
- bare flag `--verify-scoped-sudo` で probe が起動する成功/失敗経路を test で固定する。
- broad `NOPASSWD:ALL` 検出は維持し、sudoers content は出力しない。

## Unsatisfied Success Criteria

- Butler/passkey approval から helper request を作り、VPS helper real execution に渡す route は未完了。
- helper capability の add / enable / disable / remove / rollback / review の実機 E2E は未完了。
- Issue #637 は close しない。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #637
- Implementing Success Criteria: sudoers file を読めない環境でも helper sudo functional truth を install inventory に反映し、管理対象 sudoers entry の file truth とは混同しない。probe failure は top-level blocked として扱う。
- Explicit Non-goals: root maintenance execution、sudoers content disclosure、credential mutation、Issue close はしない。
- Expected touched files/routes/workflows: `scripts/collect-vps-maintenance-install-inventory.mjs`, `src/core/vps-privileged-maintenance.js`, `test/vps-maintenance-install-inventory-collector.test.js`, `test/vps-privileged-maintenance.test.js`, `worker.js`; workflow は変更しない。
- Affected Issues: Issue #637。Issue #355 / #412 に authority boundary 観点で関連するが、このPRで権限範囲は広げない。
- Affected PRs: PR #663 / PR #664 の root bootstrap install evidence follow-up。
- Affected workflows: GitHub Actions workflow は変更しない。PR validation と reviewer automation は通常通り走る。
- Affected runtime/operator surfaces: VPS install inventory collector、production worker core inventory truth、future Dashboard Butler install readiness report。
- What may break if we patch narrowly: helper `--version` probe を root maintenance execution と混同すると authority truth が曖昧になる。
- Unknowns to investigate before coding: production Action route から実VPS probe を自動実行する path はまだ未接続。
- Validation needed: collector/core targeted tests、`npm run build:worker`、full `npm test`、VPS live collector run after merge/deploy。
- Stop condition: sudoers content を出す、`sudo -n` で helper 以外を許可する、または helper `--version` 以外の privileged command を probe に混ぜる場合は停止。

## Execution Queue Delta

- Queue position before: Issue #637 is `Now`.
- Preemption decision: `ROOT`。#637 は iPhone/PWA-only VPS recovery の root blocker。
- Queue delta: Issue #637 remains `Now`; this PR moves Issue #637 install inventory from single `unverified` truth to separate file truth / functional truth. `ready` とは扱わない。
- Why this PR is next: root bootstrap install 後に helper/scoped sudo は機能したが、collector が sudoers file を読めず `unverified` のままだったため、Butler-facing runtime truth が現実とズレる。
- Active Issues not downscoped: Active Issues は縮小しません。このPRで扱わない active Issue は未完了として残します。

## File / Line Hypotheses

- file: `scripts/collect-vps-maintenance-install-inventory.mjs`
  - hypothesis: sudoers file read が `EACCES` の場合でも、scoped helper `--version` が成功すれば sudoers functional readiness は検証できる。
  - risk if changed narrowly: non-root helper や未検証 manifest/sudoers でも privileged probe を起動すると authority boundary が緩む。
  - validation: fake sudo skip test と VPS live probe。
  - related Issue: Issue #637
- file: `src/core/vps-privileged-maintenance.js`
  - hypothesis: `sudoersHelperProbe=true` は `helper_sudo_functional_probe` として pass できるが、`scoped_sudoers_entry` の pass 条件には使わない。
  - risk if changed narrowly: functional sudo 成功を管理対象 sudoers entry verified と誤表現してはいけない。
  - validation: core test で broad sudoers block、sudoers unreadable、helper probe pass の分離を確認する。
  - related Issue: Issue #637

## Hypothesis Retrospective

- expected: optional functional probe で sudoers unreadable でも helper scoped sudo を検証できる。
- actual: `--verify-scoped-sudo` で root-owned helper / manifest / sudoers file precondition を満たす場合だけ `sudo -n <helper> --version` を実行し、sudoers content を出さずに `helper_sudo_functional_probe` として報告する。`scoped_sudoers_entry` は file truth のまま保持する。
- mismatch: production Action route から VPS local probe を直接走らせる path は未接続。sudoers file が unreadable の場合、install inventory 全体は `unverified` のままになる。
- lesson: root-owned sudoers file は unreadable が自然なので、file read truth と functional sudo truth を同じ `pass` に混ぜない。
- should become RAG candidate: はい。sudoers content を読めないことは安全上自然で、functional probe が必要。

## Verification Evidence

- Unit: `node --test test/vps-maintenance-install-inventory-collector.test.js test/vps-privileged-maintenance.test.js` -> tests 19 / pass 19 / fail 0
- Integration: `npm run build:worker && npm test` -> tests 1064 / pass 1063 / skip 1 / fail 0; self-parity 30 routes / 30 operationIds; generated-worker pass
- E2E: 未実施。このPR後に VPS live collector `--verify-scoped-sudo` と production deploy evidence が必要。
- Manual: root bootstrap install evidence: https://github.com/marushu/vtdd-v2-p/issues/637#issuecomment-4577572307
- Evidence path/link: `scripts/collect-vps-maintenance-install-inventory.mjs`, `src/core/vps-privileged-maintenance.js`, `test/vps-maintenance-install-inventory-collector.test.js`, `test/vps-privileged-maintenance.test.js`

## Butler Completion Contract

- Owner goal: Dashboard Butler が VPS helper install readiness を現実通り報告できるようにする。
- Butler entrypoint: 未完了。Dashboard Butler 自然文から VPS local probe 実行までの path はこのPRでは未接続。
- Action Schema exposure: 既存 install inventory operationId は維持。schema parameter 追加はこのPRでは未実施。
- Runtime path: core inventory truth と VPS collector を更新。Worker bundle は再生成。
- Runner/runtime truth: `sudoersHelperProbeStarted`、`helper_sudo_functional_probe`、probe skip/failure truth を redacted runtime truth に追加。
- Authority boundary: probe は `sudo -n <helper> --version` のみ。root maintenance command は実行しない。
- E2E evidence: 未実施。Butler-facing E2E は helper request / real execution route 接続後に必要。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: required。`src/core` と `worker.js` 変更あり。
- Custom GPT Action Schema update: 不要。このPRでは production route parameter は増やさない。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。Issue #637 completion 前に必要。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate
- AGENTS.md Butler-First Operating Principle
- AGENTS.md Authority Boundary
- AGENTS.md Drift Stop Protocol
- docs/butler/vps-privileged-maintenance-capability-lifecycle.md
- docs/butler/execution-queue-contract.md

## Out-of-scope but NOT implemented

- helper real execution route
- production Action から VPS local collector を直接起動する runner path
- sudoers content disclosure
- Issue #637 close

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #637
- Execution ID: Not provided.
- Goal: VPS install inventory scoped sudo functional probe
