### PR TITLE
Issue #637 unreadable sudoersをunverifiedに戻す

### DIFF
--- a/scripts/collect-vps-maintenance-install-inventory.mjs
+++ b/scripts/collect-vps-maintenance-install-inventory.mjs
@@ -113,7 +113,7 @@ function shouldProbeScopedSudoHelper({ verifyScopedSudo, helper, manifest, sudoe
     manifest.owner === "root" &&
     sudoers.installed === true &&
     sudoers.owner === "root" &&
-    sudoersPolicy.allowsAll !== true
+    sudoersPolicy.allowsAll === false
   );
 }
 

--- a/src/core/vps-privileged-maintenance.js
+++ b/src/core/vps-privileged-maintenance.js
@@ -291,7 +291,7 @@ function buildVpsPrivilegedMaintenanceInstallInventory(input = {}) {
     {
       id: "scoped_sudoers_entry",
       status:
-        sudoersInstalled === true && sudoersOwner === "root" && sudoersAllowsAll !== true
+        sudoersInstalled === true && sudoersOwner === "root" && sudoersAllowsAll === false
           ? "pass"
           : sudoersInstalled === false
             ? "missing"

--- a/test/vps-privileged-maintenance.test.js
+++ b/test/vps-privileged-maintenance.test.js
@@ -94,6 +94,20 @@ test("VPS privileged maintenance install inventory reports root-owned helper rea
   assert.equal(sudoProbeReady.checks.find((check) => check.id === "helper_sudo_functional_probe").status, "pass");
   assert.equal(sudoProbeReady.runtimeTruth.sudoersHelperProbeStarted, true);
 
+  const unreadableSudoers = buildVpsPrivilegedMaintenanceInstallInventory({
+    host: "x85-131-245-163",
+    repository: "marushu/vtdd-v2-p",
+    helperInstalled: true,
+    manifestInstalled: true,
+    sudoersInstalled: true,
+    helperOwner: "root",
+    manifestOwner: "root",
+    sudoersOwner: "root",
+    sudoersAllowsAll: null
+  });
+  assert.equal(unreadableSudoers.status, "unverified");
+  assert.equal(unreadableSudoers.checks.find((check) => check.id === "scoped_sudoers_entry").status, "unverified");
+
   const sudoProbeFailed = buildVpsPrivilegedMaintenanceInstallInventory({
     host: "x85-131-245-163",
     repository: "marushu/vtdd-v2-p",

--- a/worker.js
+++ b/worker.js
@@ -37530,7 +37530,7 @@ function buildVpsPrivilegedMaintenanceInstallInventory(input = {}) {
     },
     {
       id: "scoped_sudoers_entry",
-      status: sudoersInstalled === true && sudoersOwner === "root" && sudoersAllowsAll !== true ? "pass" : sudoersInstalled === false ? "missing" : "unverified",
+      status: sudoersInstalled === true && sudoersOwner === "root" && sudoersAllowsAll === false ? "pass" : sudoersInstalled === false ? "missing" : "unverified",
       required: true,
       path: sudoersPath,
       expectedOwner: "root",


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #637 / merged PR #665 の post-merge reviewer blocker 対応です。
- #665 は `sudoersAllowsAll !== true` を pass 条件にしていたため、sudoers content が unreadable で `null` の場合でも `scoped_sudoers_entry=pass` / `ready` に到達し得ました。
- この PR は `sudoersAllowsAll === false` のときだけ sudoers entry を pass にし、probe 起動も同じ precondition に揃えます。

## Satisfied Success Criteria

- unreadable sudoers file を safe/scoped と過大判定しない。
- broad grant 非存在を確認できた場合だけ `scoped_sudoers_entry=pass` にする。
- functional probe は broad grant 非存在確認済みの場合だけ起動する。
- worker bundle を再生成する。

## Unsatisfied Success Criteria

- sudoers file が unreadable な VPS 実機では install inventory は `unverified` のまま残る。
- iPhone/PWA だけでこの unverified を解消するには、後続で root helper self-audit などの root-readable runtime truth が必要。
- Issue #637 は close しない。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #637
- Implementing Success Criteria: sudoers file unreadable / broad grant unknown を `ready` と誤報告しない。
- Explicit Non-goals: root maintenance execution、sudoers content disclosure、credential mutation、Issue close、OS update はしない。
- Expected touched files/routes/workflows: `src/core/vps-privileged-maintenance.js`, `scripts/collect-vps-maintenance-install-inventory.mjs`, `test/vps-privileged-maintenance.test.js`, `worker.js`; workflow は変更しない。
- Affected Issues: Issue #637。
- Affected PRs: PR #665 の post-merge reviewer blocker follow-up。
- Affected workflows: GitHub Actions workflow は変更しない。
- Affected runtime/operator surfaces: VPS install inventory truth、Dashboard Butler install readiness report。
- What may break if we patch narrowly: VPS 実機の sudoers file が unreadable のため `ready` にはならず `unverified` が残る。ただしこれは安全な truth。
- Unknowns to investigate before coding: root helper self-audit をどの capability として追加するかは後続 slice。
- Validation needed: targeted tests、`npm run build:worker`、full `npm test`、reviewer/check truth。
- Stop condition: unreadable sudoers を pass/ready と表現する場合は停止。

## Execution Queue Delta

- Queue position before: Issue #637 is `Now`; PR #665 merged but post-merge reviewer blocker exists.
- Preemption decision: `ROOT`。#637 の authority truth 過大報告は iPhone/PWA-only VPS recovery の根を壊す。
- Queue delta: Issue #637 remains `Now`; this PR repairs PR #665 merged regression before proceeding to the next helper execution slice.
- Why this PR is next: merged main が unsafe readiness truth を返し得るため、後続開発より先に runtime truth を安全側へ戻す必要がある。
- Active Issues not downscoped: Active Issues は縮小しません。このPRで扱わない active Issue は未完了として残します。

## File / Line Hypotheses

- file: `src/core/vps-privileged-maintenance.js`
  - hypothesis: `sudoersAllowsAll === false` のみ pass にすれば unreadable/null は `unverified` のまま残る。
  - risk if changed narrowly: helper functional success を sudoers entry verified と誤読してはいけない。
  - validation: core test で `sudoersAllowsAll:null` が `unverified` になることを固定する。
  - related Issue: Issue #637
- file: `scripts/collect-vps-maintenance-install-inventory.mjs`
  - hypothesis: probe 起動 precondition も `sudoersPolicy.allowsAll === false` に揃えると broad grant unknown で sudo probe を起動しない。
  - risk if changed narrowly: VPS 実機 evidence は unverified のまま残るが、これは正しい blocker 表現。
  - validation: collector targeted tests と full test。
  - related Issue: Issue #637

## Hypothesis Retrospective

- expected: unreadable sudoers を pass とせず、helper probe 起動条件も安全側へ揃える。
- actual: `sudoersAllowsAll === false` の場合だけ pass/probe にした。
- mismatch: #665 で reviewer approve 後に stale/late fallback request_changes が出た。merged PR には push せず follow-up PR とした。
- lesson: sudoers unreadable は安全上自然だが、ready にするには root-readable self-audit が必要。functional probe だけで authority truth を埋めない。
- should become RAG candidate: はい。post-merge reviewer blocker は follow-up PR で即修正する。

## Verification Evidence

- Unit: `node --test test/vps-maintenance-install-inventory-collector.test.js test/vps-privileged-maintenance.test.js` -> tests 19 / pass 19 / fail 0
- Integration: `npm run build:worker && npm test` -> tests 1066 / pass 1065 / skip 1 / fail 0; self-parity 30 routes / 30 operationIds; generated-worker pass
- E2E: 未実施。Butler-facing E2E は helper request / real execution route 接続後に必要。
- Manual: PR #665 post-merge reviewer blocker: https://github.com/marushu/vtdd-v2-p/pull/665#issuecomment-4577698768
- Evidence path/link: `src/core/vps-privileged-maintenance.js`, `scripts/collect-vps-maintenance-install-inventory.mjs`, `test/vps-privileged-maintenance.test.js`, `worker.js`

## Butler Completion Contract

- Owner goal: Dashboard Butler が VPS helper install readiness を過大報告しない。
- Butler entrypoint: 既存 install inventory route の truth を修正。自然文から VPS local probe 実行までの path はこのPRでは未接続。
- Action Schema exposure: 既存 operationId を維持。
- Runtime path: core inventory truth と collector を修正。Worker bundle は再生成。
- Runner/runtime truth: unreadable sudoers は `unverified` のまま残す。
- Authority boundary: root maintenance command は実行しない。sudoers content は出力しない。
- E2E evidence: 未実施。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: required。`src/core` と `worker.js` 変更あり。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate
- AGENTS.md Butler-First Operating Principle
- AGENTS.md Authority Boundary
- AGENTS.md Drift Stop Protocol
- docs/butler/execution-queue-contract.md

## Out-of-scope but NOT implemented

- root helper self-audit
- helper real execution route
- sudoers content disclosure
- Issue #637 close

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #637
- Execution ID: Not provided.
- Goal: Repair #665 sudoers unreadable readiness truth
