### PR TITLE
Issue #667 auto-mergeが後着reviewerを待つ

### DIFF
--- a/src/core/approve-auto-merge.js
+++ b/src/core/approve-auto-merge.js
@@ -98,9 +98,15 @@ export function evaluateApproveAutoMerge(input = {}) {
     reasons.push("unresolved reviewer objections remain.");
   }
   if (unresolvedReviewerEvidence) {
-    reasons.push(
-      `unresolved reviewer request_changes remains for current head: ${unresolvedReviewerEvidence.reviewer || "unknown"} ${unresolvedReviewerEvidence.url || "unknown url"}.`
-    );
+    if (unresolvedReviewerEvidence.conflictKind === "post_approve_review_pending") {
+      reasons.push(
+        `reviewer review is pending after latest approve for current head: ${unresolvedReviewerEvidence.reviewer || "unknown"} ${unresolvedReviewerEvidence.url || "unknown url"}.`
+      );
+    } else {
+      reasons.push(
+        `unresolved reviewer request_changes remains for current head: ${unresolvedReviewerEvidence.reviewer || "unknown"} ${unresolvedReviewerEvidence.url || "unknown url"}.`
+      );
+    }
   }
   if (reviewLoop.criticalReviewPending) {
     reasons.push("critical review is still pending.");
@@ -136,7 +142,7 @@ export function evaluateApproveAutoMerge(input = {}) {
   evidence.push(`reviewer=${reviewLoop.reviewer || "unknown"}`);
   evidence.push(`reviewerAction=${reviewLoop.reviewerEvidence?.recommendedAction || "none"}`);
   evidence.push(`reviewerHeadSha=${reviewLoop.reviewerEvidence?.headSha || "unknown"}`);
-  evidence.push(`reviewerConflict=${unresolvedReviewerEvidence ? "unresolved_request_changes" : "none"}`);
+  evidence.push(`reviewerConflict=${unresolvedReviewerEvidence?.conflictKind || (unresolvedReviewerEvidence ? "unresolved_request_changes" : "none")}`);
   evidence.push(`mergeable=${String(pullRequest.mergeability.mergeable)}`);
   evidence.push(`mergeableState=${pullRequest.mergeability.mergeableState || "unknown"}`);
   evidence.push(`checks=${checkTruth.summary}`);
@@ -415,6 +421,22 @@ function findUnresolvedReviewerEvidenceConflict({ timeline, headSha, reviewerEvi
     return null;
   }
 
+  const postApproveBlocker = sorted.find((item) => {
+    if (item.time <= latestApprove.time) {
+      return false;
+    }
+    const action = normalizeText(item.recommendedAction).toLowerCase();
+    const status = normalizeText(item.status).toLowerCase();
+    return action === "request_changes" || action === "manual_review" || status === "requested" || status === "pending";
+  });
+  if (postApproveBlocker) {
+    const action = normalizeText(postApproveBlocker.recommendedAction).toLowerCase();
+    return {
+      ...postApproveBlocker,
+      conflictKind: action === "request_changes" || action === "manual_review" ? "post_approve_request_changes" : "post_approve_review_pending"
+    };
+  }
+
   const blocking = [...sorted]
     .reverse()
     .find((item) => {
@@ -434,7 +456,7 @@ function findUnresolvedReviewerEvidenceConflict({ timeline, headSha, reviewerEvi
     }
     return item.time > blocking.time && item.time < latestApprove.time;
   });
-  return resolved ? null : blocking;
+  return resolved ? null : { ...blocking, conflictKind: "unresolved_request_changes" };
 }
 
 function normalizeReviewTimelineItem(item) {
@@ -446,6 +468,7 @@ function normalizeReviewTimelineItem(item) {
   return {
     type: normalizeText(item.type),
     reviewer: normalizeText(item.reviewer),
+    status: normalizeText(item.status).toLowerCase(),
     recommendedAction: normalizeText(item.recommendedAction).toLowerCase(),
     blocking: item.blocking === true,
     headSha: normalizeText(item.headSha),

--- a/test/approve-auto-merge.test.js
+++ b/test/approve-auto-merge.test.js
@@ -185,6 +185,83 @@ test("approve auto merge allows same-head approve after trusted objection resolu
   assert.equal(result.evidence.includes("reviewerConflict=none"), true);
 });
 
+test("approve auto merge blocks reviewer pending marker after same-head approve", () => {
+  const result = evaluateApproveAutoMerge({
+    policyMode: ApproveAutoMergePolicyMode.APPROVE_AUTO_MERGE,
+    pullRequest: mergeablePullRequest,
+    reviewLoop: {
+      ...approvedReviewLoop,
+      reviewTimeline: [
+        {
+          type: "gemini_review",
+          reviewer: "gemini",
+          recommendedAction: "approve",
+          headSha: "abc123",
+          url: "https://github.com/sample-org/vtdd-v2-p/pull/10#issuecomment-approve",
+          createdAt: "2026-05-29T10:23:45Z"
+        },
+        {
+          type: "codex_fallback",
+          reviewer: "codex",
+          status: "requested",
+          headSha: "abc123",
+          url: "https://github.com/sample-org/vtdd-v2-p/pull/10#issuecomment-requested",
+          createdAt: "2026-05-29T10:23:50Z"
+        }
+      ]
+    },
+    checkRuns: successChecks
+  });
+
+  assert.equal(result.allowed, false);
+  assert.equal(
+    result.reasons.some((reason) =>
+      reason.includes("reviewer review is pending after latest approve for current head")
+    ),
+    true
+  );
+  assert.equal(result.evidence.includes("reviewerConflict=post_approve_review_pending"), true);
+});
+
+test("approve auto merge blocks request changes marker after same-head approve", () => {
+  const result = evaluateApproveAutoMerge({
+    policyMode: ApproveAutoMergePolicyMode.APPROVE_AUTO_MERGE,
+    pullRequest: mergeablePullRequest,
+    reviewLoop: {
+      ...approvedReviewLoop,
+      reviewTimeline: [
+        {
+          type: "gemini_review",
+          reviewer: "gemini",
+          recommendedAction: "approve",
+          headSha: "abc123",
+          url: "https://github.com/sample-org/vtdd-v2-p/pull/10#issuecomment-approve",
+          createdAt: "2026-05-29T10:23:45Z"
+        },
+        {
+          type: "codex_fallback",
+          reviewer: "codex",
+          status: "completed",
+          recommendedAction: "request_changes",
+          headSha: "abc123",
+          url: "https://github.com/sample-org/vtdd-v2-p/pull/10#issuecomment-request",
+          createdAt: "2026-05-29T10:23:55Z"
+        }
+      ]
+    },
+    checkRuns: successChecks
+  });
+
+  assert.equal(result.allowed, false);
+  assert.equal(
+    result.reasons.some((reason) =>
+      reason.includes("unresolved reviewer request_changes remains for current head")
+    ),
+    true
+  );
+  assert.equal(result.evidence.includes("reviewerConflict=post_approve_request_changes"), true);
+});
+
 test("approve auto merge remains opt-in by policy or labels", () => {
   assert.equal(resolveApproveAutoMergePolicy({}), ApproveAutoMergePolicyMode.MANUAL);
   assert.equal(


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #667 の ROOT follow-up です。
- PR #665 では approve と required checks が揃った後に auto-merge が先に成立し、その後で同じ head に対する fallback reviewer の `request_changes` が到着しました。
- この PR は同じ head SHA の reviewer timeline を approve 後まで読み、後着 pending / requested / request_changes がある場合は auto-merge を止めます。

## Satisfied Success Criteria

- auto-merge gate は同じ head SHA の reviewer marker timeline を時系列で評価する。
- 同じ head SHA に reviewer fallback requested / review 未完了 marker が approve 後に存在する場合、auto-merge を停止する。
- 同じ head SHA に approve 後の request_changes marker が存在する場合、auto-merge を停止する。
- PR body edit / issue_comment trigger によって reviewer が再走中の場合、review 完了 marker なしに merge しない。
- PR #665 事故に近い timeline を synthetic regression test として追加する。

## Unsatisfied Success Criteria

- GitHub live E2E はこの PR では実施しない。
- owner-facing evidence comment の自動投稿経路はこの PR では追加しない。auto-merge evidence には conflict kind を残す。
- Issue #667 は close しない。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #667
- Implementing Success Criteria: approve 後の同一 head reviewer pending/request_changes を auto-merge stop 条件にする。
- Explicit Non-goals: reviewer 無効化、auto-merge 全体の恒久停止、PR #665/#666 履歴改変、deploy、credential mutation、permission mutation、Issue close はしない。
- Expected touched files/routes/workflows: `src/core/approve-auto-merge.js`, `test/approve-auto-merge.test.js`; route/workflow は変更しない。
- Affected Issues: Issue #667, Issue #637, Issue #651, Issue #448。
- Affected PRs: PR #665 の post-merge reviewer blocker follow-up。今後の auto-merge 対象 PR。
- Affected workflows: auto-merge policy evaluation。GitHub Actions workflow YAML は変更しない。
- Affected runtime/operator surfaces: reviewer-approved auto-merge gate evidence。Dashboard Butler UI / Custom GPT Action Schema は変更しない。
- What may break if we patch narrowly: reviewer marker が pending のまま残る PR は auto-merge が停止する。これは安全側の blocker だが、stuck marker cleanup は後続課題になり得る。
- Unknowns to investigate before coding: live GitHub event で fallback reviewer marker がどの duration で completed へ遷移するか。今回は synthetic regression で gate を固定する。
- Validation needed: targeted auto-merge tests、execution continuity tests、`npm run build:worker`、full `npm test`、PR review/check truth。
- Stop condition: approve 後の同一 head pending/request_changes を merge 許可として扱う場合は停止。

## Execution Queue Delta

- Queue position before: Issue #637 is `Now`; PR #665 merged but post-merge reviewer blocker exposed a ROOT auto-merge gate gap.
- Preemption decision: `ROOT`
- Queue delta: Issue #667 moves to `Now` temporarily; Issue #637 remains active and resumes after this auto-merge gate repair. Issue #651 stays evidence gap until mapped close-readiness exists.
- Why this PR is next: この gate が壊れたままだと、#637 以降の PR でも reviewer blocker を後着で踏み抜き、merge 済み blocker を増やす。
- Active Issues not downscoped: Active Issues は縮小しません。この PR で扱わない active Issue は未完了・未接続として残します。

## File / Line Hypotheses

- file: `src/core/approve-auto-merge.js`
  - hypothesis: latest approve 後の同一 head reviewer pending/request_changes を conflict として返せば、auto-merge は reviewer 完了前に走らない。
  - risk if changed narrowly: stale pending marker が残ると merge が止まり続ける可能性があるが、reviewer を stop role とするなら安全側。
  - validation: approve 後 pending / approve 後 request_changes の regression tests。
  - related Issue: Issue #667
- file: `test/approve-auto-merge.test.js`
  - hypothesis: PR #665 の事故形を synthetic timeline で固定できる。
  - risk if changed narrowly: GitHub live event sequence の完全再現ではないため、live E2E は後続 evidence として残る。
  - validation: targeted tests と full `npm test`。
  - related Issue: Issue #667

## Hypothesis Retrospective

- expected: approve 後の同一 head reviewer pending/request_changes で auto-merge が停止する。
- actual: `post_approve_review_pending` と `post_approve_request_changes` を conflict evidence として返し、`allowed=false` になる。
- mismatch: GitHub live E2E はこの slice では未実施。synthetic regression で policy hole を先に塞ぐ。
- lesson: approve は reviewer timeline の終端ではない。PR body/comment update が reviewer を再走させる場合、後着 marker を stop role として扱う必要がある。
- should become RAG candidate: はい。auto-merge は approve だけでなく同一 head の後着 reviewer marker を待つ。

## Verification Evidence

- Build: `npm run build:worker` -> pass
- Unit: `node --test test/approve-auto-merge.test.js test/execution-continuity.test.js` -> tests 41 / pass 41 / fail 0
- Integration: `npm test` -> tests 1068 / pass 1067 / skip 1 / fail 0; self-parity 30 routes / 30 operationIds; generated-worker pass
- E2E: 未実施。GitHub live E2E は後続 evidence。
- Manual: PR #665 post-merge reviewer blocker: https://github.com/marushu/vtdd-v2-p/pull/665#issuecomment-4577698768
- Evidence path/link: `src/core/approve-auto-merge.js`, `test/approve-auto-merge.test.js`

## Butler Completion Contract

- Owner goal: reviewer blocker が後着する可能性がある PR を auto-merge しない。
- Butler entrypoint: なし。この PR は auto-merge policy guardrail。
- Action Schema exposure: 不要。schema change なし。
- Runtime path: auto-merge evaluation core のみ。
- Runner/runtime truth: auto-merge evidence に `reviewerConflict=post_approve_review_pending` / `reviewerConflict=post_approve_request_changes` を残す。
- Authority boundary: deploy / credential / permission mutation なし。merge は既存 approve/check/auto-merge gate に委ねる。
- E2E evidence: synthetic regression tests のみ。live GitHub E2E は未実施。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 不要。worker bundle は再生成確認のみで差分なし。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。

## Related Constitution Rules

- AGENTS.md Butler and Reviewer as Stop Roles
- AGENTS.md Issue Lifecycle Gate
- AGENTS.md Authority Boundary
- docs/butler/execution-queue-contract.md

## Out-of-scope but NOT implemented

- GitHub live E2E fixture
- stale pending marker cleanup
- reviewer disabling
- Issue #667 close
- Issue #637 VPS maintenance capability continuation

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #667
- Execution ID: Not provided.
- Goal: Block auto-merge when same-head reviewer marker arrives after approve
