### PR TITLE
Issue #637 install inventoryをroot helper auditで検証する

### DIFF
--- a/scripts/collect-vps-maintenance-install-inventory.mjs
+++ b/scripts/collect-vps-maintenance-install-inventory.mjs
@@ -54,23 +54,26 @@ async function observePath(filePath) {
   }
 }
 
-async function observeSudoersPolicy(filePath) {
+async function observeSudoersPolicy({ filePath, helperPath, runnerUser }) {
   try {
     const content = await fs.readFile(filePath, "utf8");
     return {
       readable: true,
-      allowsAll: containsBroadSudoersGrant(content)
+      allowsAll: containsBroadSudoersGrant(content),
+      scopedHelperEntry: containsScopedHelperEntry({ content, helperPath, runnerUser })
     };
   } catch (error) {
     if (error?.code === "ENOENT") {
       return {
         readable: false,
-        allowsAll: false
+        allowsAll: false,
+        scopedHelperEntry: false
       };
     }
     return {
       readable: false,
       allowsAll: null,
+      scopedHelperEntry: null,
       error: summarizeError(error)
     };
   }
@@ -104,6 +107,42 @@ async function probeScopedSudoHelper({ helperPath, enabled, timeoutMs, maxBuffer
   }
 }
 
+async function runScopedSudoInstallAudit({ helperPath, enabled, timeoutMs, maxBuffer }) {
+  if (!enabled) {
+    return {
+      started: false,
+      ok: null,
+      observed: null,
+      skippedReason: "preconditions_not_met"
+    };
+  }
+  try {
+    const { stdout } = await execFileAsync(
+      "sudo",
+      ["-n", helperPath, "--install-audit"],
+      {
+        timeout: timeoutMs,
+        encoding: "utf8",
+        maxBuffer
+      }
+    );
+    const parsed = JSON.parse(stdout);
+    return {
+      started: true,
+      ok: parsed.ok === true,
+      observed: normalizeAuditObserved(parsed.observed),
+      error: parsed.ok === true ? null : "INSTALL_AUDIT_NOT_OK"
+    };
+  } catch (error) {
+    return {
+      started: true,
+      ok: false,
+      observed: parseAuditObservedFromError(error),
+      error: summarizeError(error)
+    };
+  }
+}
+
 function shouldProbeScopedSudoHelper({ verifyScopedSudo, helper, manifest, sudoers, sudoersPolicy }) {
   return (
     verifyScopedSudo === true &&
@@ -117,8 +156,31 @@ function shouldProbeScopedSudoHelper({ verifyScopedSudo, helper, manifest, sudoe
   );
 }
 
+function shouldAuditInstallThroughScopedSudo({ verifyScopedSudo, helper, manifest, sudoers, helperPath, manifestPath, sudoersPath, runnerUser }) {
+  return (
+    verifyScopedSudo === true &&
+    helperPath === DEFAULT_HELPER_INSTALL_PATH &&
+    manifestPath === DEFAULT_MANIFEST_PATH &&
+    sudoersPath === DEFAULT_SUDOERS_PATH &&
+    runnerUser === "vtdd-runner" &&
+    helper.installed === true &&
+    helper.owner === "root" &&
+    manifest.installed === true &&
+    manifest.owner === "root" &&
+    sudoers.installed === true &&
+    sudoers.owner === "root"
+  );
+}
+
 function containsBroadSudoersGrant(content) {
   return /\bNOPASSWD\s*:\s*ALL\b/i.test(String(content || ""));
+}
+
+function containsScopedHelperEntry({ content, helperPath, runnerUser }) {
+  const expected = `${runnerUser} ALL=(root) NOPASSWD: ${helperPath}`;
+  return String(content || "")
+    .split(/\r?\n/)
+    .some((line) => line.trim() === expected);
 }
 
 function ownerLabel(stat) {
@@ -152,8 +214,23 @@ async function collectVpsMaintenanceInstallInventory(input = {}) {
     observePath(helperPath),
     observePath(manifestPath),
     observePath(sudoersPath),
-    observeSudoersPolicy(sudoersPath)
+    observeSudoersPolicy({ filePath: sudoersPath, helperPath, runnerUser })
   ]);
+  const sudoersInstallAudit = await runScopedSudoInstallAudit({
+    helperPath,
+    enabled: shouldAuditInstallThroughScopedSudo({
+      verifyScopedSudo,
+      helper,
+      manifest,
+      sudoers,
+      helperPath,
+      manifestPath,
+      sudoersPath,
+      runnerUser
+    }),
+    timeoutMs: sudoProbeTimeoutMs,
+    maxBuffer: sudoProbeMaxBuffer
+  });
   const shouldProbe = shouldProbeScopedSudoHelper({
     verifyScopedSudo,
     helper,
@@ -175,15 +252,17 @@ async function collectVpsMaintenanceInstallInventory(input = {}) {
     manifestPath,
     sudoersPath,
     runnerUser,
-    helperInstalled: helper.installed,
-    manifestInstalled: manifest.installed,
-    sudoersInstalled: sudoers.installed,
-    helperOwner: helper.owner,
-    manifestOwner: manifest.owner,
-    sudoersOwner: sudoers.owner,
-    sudoersAllowsAll: sudoersPolicy.allowsAll,
+    helperInstalled: sudoersInstallAudit.observed?.helperInstalled ?? helper.installed,
+    manifestInstalled: sudoersInstallAudit.observed?.manifestInstalled ?? manifest.installed,
+    sudoersInstalled: sudoersInstallAudit.observed?.sudoersInstalled ?? sudoers.installed,
+    helperOwner: sudoersInstallAudit.observed?.helperOwner ?? helper.owner,
+    manifestOwner: sudoersInstallAudit.observed?.manifestOwner ?? manifest.owner,
+    sudoersOwner: sudoersInstallAudit.observed?.sudoersOwner ?? sudoers.owner,
+    sudoersAllowsAll: sudoersInstallAudit.observed?.sudoersAllowsAll ?? sudoersPolicy.allowsAll,
+    sudoersScopedHelperEntry: sudoersInstallAudit.observed?.sudoersScopedHelperEntry ?? sudoersPolicy.scopedHelperEntry,
     sudoersHelperProbe: sudoersHelperProbe.ok,
-    sudoersHelperProbeStarted: sudoersHelperProbe.started
+    sudoersHelperProbeStarted: sudoersHelperProbe.started,
+    sudoersInstallAuditStarted: sudoersInstallAudit.started
   });
 
   return {
@@ -194,6 +273,7 @@ async function collectVpsMaintenanceInstallInventory(input = {}) {
       ...installInventory.runtimeTruth,
       observer: "scripts/collect-vps-maintenance-install-inventory.mjs",
       sudoersContentReadable: sudoersPolicy.readable,
+      sudoersInstallAuditStarted: sudoersInstallAudit.started,
       sudoersHelperProbeStarted: sudoersHelperProbe.started,
       sudoersHelperProbeTimeoutMs: sudoersHelperProbe.started ? sudoProbeTimeoutMs : null,
       rootExecutionStarted: false,
@@ -206,6 +286,15 @@ async function collectVpsMaintenanceInstallInventory(input = {}) {
       sudoers: redactObservation(sudoers),
       sudoersContentReadable: sudoersPolicy.readable,
       sudoersPolicyError: sudoersPolicy.error || null,
+      sudoersScopedHelperEntry: sudoersPolicy.scopedHelperEntry,
+      sudoersInstallAudit: {
+        started: sudoersInstallAudit.started,
+        ok: sudoersInstallAudit.ok,
+        error: sudoersInstallAudit.error || null,
+        skippedReason: sudoersInstallAudit.skippedReason || null,
+        command: sudoersInstallAudit.started ? "sudo -n <helper> --install-audit" : null,
+        timeoutMs: sudoersInstallAudit.started ? sudoProbeTimeoutMs : null
+      },
       sudoersHelperProbe: {
         started: sudoersHelperProbe.started,
         ok: sudoersHelperProbe.ok,
@@ -243,6 +332,35 @@ async function main() {
 
 if (import.meta.url === `file://${process.argv[1]}`) {
   await main();
+}
+
+function normalizeAuditObserved(value) {
+  if (!value || typeof value !== "object") return null;
+  return {
+    helperInstalled: normalizeNullableBoolean(value.helperInstalled),
+    manifestInstalled: normalizeNullableBoolean(value.manifestInstalled),
+    sudoersInstalled: normalizeNullableBoolean(value.sudoersInstalled),
+    helperOwner: typeof value.helperOwner === "string" ? value.helperOwner : null,
+    manifestOwner: typeof value.manifestOwner === "string" ? value.manifestOwner : null,
+    sudoersOwner: typeof value.sudoersOwner === "string" ? value.sudoersOwner : null,
+    sudoersAllowsAll: normalizeNullableBoolean(value.sudoersAllowsAll),
+    sudoersScopedHelperEntry: normalizeNullableBoolean(value.sudoersScopedHelperEntry)
+  };
+}
+
+function parseAuditObservedFromError(error) {
+  try {
+    const parsed = JSON.parse(error?.stdout || "");
+    return normalizeAuditObserved(parsed.observed);
+  } catch {
+    return null;
+  }
+}
+
+function normalizeNullableBoolean(value) {
+  if (value === true) return true;
+  if (value === false) return false;
+  return null;
 }
 
 export { collectVpsMaintenanceInstallInventory, containsBroadSudoersGrant };

--- a/scripts/run-vps-privileged-maintenance-helper.mjs
+++ b/scripts/run-vps-privileged-maintenance-helper.mjs
@@ -4,14 +4,22 @@ import fs from "node:fs/promises";
 
 import { planVpsPrivilegedMaintenanceHelperExecution } from "../src/core/index.js";
 
+const DEFAULT_HELPER_INSTALL_PATH = "/usr/local/sbin/vtdd-vps-maintenance-helper";
+const DEFAULT_MANIFEST_PATH = "/etc/vtdd/privileged-maintenance-capabilities.json";
+const DEFAULT_SUDOERS_PATH = "/etc/sudoers.d/vtdd-vps-maintenance-helper";
+const DEFAULT_RUNNER_USER = "vtdd-runner";
+
 function parseArgs(argv) {
   const result = {
-    mode: "dry_run"
+    mode: "dry_run",
+    auditInstall: false
   };
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
     if (arg === "--dry-run") {
       result.mode = "dry_run";
+    } else if (arg === "--install-audit") {
+      result.auditInstall = true;
     } else if (arg === "--input") {
       result.inputPath = argv[index + 1] || "";
       index += 1;
@@ -31,8 +39,134 @@ async function readInput(inputPath) {
   return text;
 }
 
+async function observePath(filePath) {
+  try {
+    const stat = await fs.stat(filePath);
+    return {
+      installed: true,
+      owner: ownerLabel(stat)
+    };
+  } catch (error) {
+    if (error?.code === "ENOENT") {
+      return {
+        installed: false,
+        owner: null
+      };
+    }
+    return {
+      installed: null,
+      owner: null,
+      error: summarizeError(error)
+    };
+  }
+}
+
+async function observeSudoersPolicy({ sudoersPath, helperPath, runnerUser }) {
+  try {
+    const content = await fs.readFile(sudoersPath, "utf8");
+    return {
+      readable: true,
+      allowsAll: /\bNOPASSWD\s*:\s*ALL\b/i.test(content),
+      scopedHelperEntry: content
+        .split(/\r?\n/)
+        .some((line) => line.trim() === `${runnerUser} ALL=(root) NOPASSWD: ${helperPath}`)
+    };
+  } catch (error) {
+    if (error?.code === "ENOENT") {
+      return {
+        readable: false,
+        allowsAll: false,
+        scopedHelperEntry: false
+      };
+    }
+    return {
+      readable: false,
+      allowsAll: null,
+      scopedHelperEntry: null,
+      error: summarizeError(error)
+    };
+  }
+}
+
+async function auditInstall(args) {
+  const config = {
+    helperPath: DEFAULT_HELPER_INSTALL_PATH,
+    manifestPath: DEFAULT_MANIFEST_PATH,
+    sudoersPath: DEFAULT_SUDOERS_PATH,
+    runnerUser: DEFAULT_RUNNER_USER
+  };
+  if (process.getuid?.() !== 0) {
+    return {
+      ok: false,
+      error: "root_required",
+      kind: "vps_privileged_maintenance_install_audit",
+      rootAuditStarted: false,
+      helperExecutionStarted: true,
+      redacted: true,
+      observed: null,
+      observation: null,
+      issues: ["root is required for install audit"]
+    };
+  }
+  const [helper, manifest, sudoers, sudoersPolicy] = await Promise.all([
+    observePath(config.helperPath),
+    observePath(config.manifestPath),
+    observePath(config.sudoersPath),
+    observeSudoersPolicy(config)
+  ]);
+  const issues = [];
+  if (helper.installed !== true || helper.owner !== "root") issues.push("root-owned helper is not verified");
+  if (manifest.installed !== true || manifest.owner !== "root") issues.push("root-owned manifest is not verified");
+  if (sudoers.installed !== true || sudoers.owner !== "root") issues.push("root-owned sudoers entry is not verified");
+  if (sudoersPolicy.allowsAll === true) issues.push("sudoers must not allow NOPASSWD:ALL");
+  if (sudoersPolicy.scopedHelperEntry === false) issues.push("sudoers scoped helper entry is missing");
+  return {
+    ok: issues.length === 0,
+    kind: "vps_privileged_maintenance_install_audit",
+    rootAuditStarted: process.getuid?.() === 0,
+    helperExecutionStarted: true,
+    redacted: true,
+    observed: {
+      helperInstalled: helper.installed,
+      manifestInstalled: manifest.installed,
+      sudoersInstalled: sudoers.installed,
+      helperOwner: helper.owner,
+      manifestOwner: manifest.owner,
+      sudoersOwner: sudoers.owner,
+      sudoersAllowsAll: sudoersPolicy.allowsAll,
+      sudoersScopedHelperEntry: sudoersPolicy.scopedHelperEntry
+    },
+    observation: {
+      helper,
+      manifest,
+      sudoers,
+      sudoersContentReadable: sudoersPolicy.readable,
+      sudoersPolicyError: sudoersPolicy.error || null
+    },
+    issues
+  };
+}
+
+function ownerLabel(stat) {
+  if (stat?.uid === 0) return "root";
+  return Number.isInteger(stat?.uid) ? String(stat.uid) : null;
+}
+
+function summarizeError(error) {
+  const code = typeof error?.code === "string" ? error.code : "UNKNOWN";
+  return code.replace(/[^A-Z0-9_]/gi, "").slice(0, 80) || "UNKNOWN";
+}
+
 async function main() {
   const args = parseArgs(process.argv.slice(2));
+  if (args.auditInstall) {
+    const result = await auditInstall(args);
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    if (!result.ok) {
+      process.exitCode = 1;
+    }
+    return;
+  }
   const raw = await readInput(args.inputPath);
   const input = raw.trim() ? JSON.parse(raw) : {};
   const result = planVpsPrivilegedMaintenanceHelperExecution({

--- a/src/core/vps-privileged-maintenance.js
+++ b/src/core/vps-privileged-maintenance.js
@@ -259,8 +259,12 @@ function buildVpsPrivilegedMaintenanceInstallInventory(input = {}) {
   const manifestOwner = normalizeText(observed.manifestOwner || input.manifestOwner);
   const sudoersOwner = normalizeText(observed.sudoersOwner || input.sudoersOwner);
   const sudoersAllowsAll = normalizeBoolean(observed.sudoersAllowsAll ?? input.sudoersAllowsAll);
+  const sudoersScopedHelperEntry = normalizeBoolean(
+    observed.sudoersScopedHelperEntry ?? input.sudoersScopedHelperEntry
+  );
   const sudoersHelperProbe = normalizeBoolean(observed.sudoersHelperProbe ?? input.sudoersHelperProbe);
   const sudoersHelperProbeStarted = normalizeBoolean(observed.sudoersHelperProbeStarted ?? input.sudoersHelperProbeStarted);
+  const sudoersInstallAuditStarted = normalizeBoolean(observed.sudoersInstallAuditStarted ?? input.sudoersInstallAuditStarted);
   const functionalProbeStarted = sudoersHelperProbeStarted ?? sudoersHelperProbe !== null;
   const issues = [];
   if (!host) issues.push("host is required");
@@ -269,6 +273,9 @@ function buildVpsPrivilegedMaintenanceInstallInventory(input = {}) {
   if (!manifestPath.startsWith("/")) issues.push("manifestPath must be absolute");
   if (!sudoersPath.startsWith("/")) issues.push("sudoersPath must be absolute");
   if (sudoersAllowsAll === true) issues.push("sudoers must not allow NOPASSWD:ALL");
+  if (sudoersScopedHelperEntry === false && sudoersInstalled !== false) {
+    issues.push("sudoers scoped helper entry is missing");
+  }
   if (sudoersHelperProbe === false) issues.push("helper sudo functional probe failed");
 
   const checks = [
@@ -291,7 +298,10 @@ function buildVpsPrivilegedMaintenanceInstallInventory(input = {}) {
     {
       id: "scoped_sudoers_entry",
       status:
-        sudoersInstalled === true && sudoersOwner === "root" && sudoersAllowsAll === false
+        sudoersInstalled === true &&
+        sudoersOwner === "root" &&
+        sudoersAllowsAll === false &&
+        sudoersScopedHelperEntry === true
           ? "pass"
           : sudoersInstalled === false
             ? "missing"
@@ -344,6 +354,7 @@ function buildVpsPrivilegedMaintenanceInstallInventory(input = {}) {
       rootExecutionStarted: false,
       helperExecutionStarted: false,
       sudoersHelperProbeStarted: functionalProbeStarted,
+      sudoersInstallAuditStarted,
       redacted: true,
       nextAction:
         sudoersHelperProbe === false

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -4542,7 +4542,8 @@ async function handleRetrieveVpsMaintenanceInstallInventoryRequest(url) {
     helperOwner: url.searchParams.get("helperOwner"),
     manifestOwner: url.searchParams.get("manifestOwner"),
     sudoersOwner: url.searchParams.get("sudoersOwner"),
-    sudoersAllowsAll: url.searchParams.get("sudoersAllowsAll")
+    sudoersAllowsAll: url.searchParams.get("sudoersAllowsAll"),
+    sudoersScopedHelperEntry: url.searchParams.get("sudoersScopedHelperEntry")
   });
   if (!inventory.ok) {
     return retrieveErrorJson(url, 422, {

--- a/test/vps-maintenance-install-inventory-collector.test.js
+++ b/test/vps-maintenance-install-inventory-collector.test.js
@@ -135,13 +135,22 @@ test("VPS maintenance install inventory collector skips sudo probe until root-ow
   assert.equal(body.observation.sudoersHelperProbe.timeoutMs, null);
 });
 
-test("VPS maintenance install inventory collector starts sudo probe for bare flag when preconditions pass", async () => {
+test("VPS maintenance install inventory collector does not root-audit override paths", async () => {
   const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "vtdd-vps-install-inventory-"));
   const fakeBin = path.join(tempRoot, "bin");
   await fs.mkdir(fakeBin, { recursive: true });
   await fs.writeFile(
     path.join(fakeBin, "sudo"),
-    "#!/bin/sh\nif [ \"$1\" = \"-n\" ] && [ \"$3\" = \"--version\" ]; then echo helper-version-output-may-change; exit 0; fi\nexit 1\n",
+    `#!/bin/sh
+if [ "$1" = "-n" ] && [ "$3" = "--install-audit" ] && [ "$#" -eq 3 ]; then
+  cat <<'JSON'
+{"ok":true,"observed":{"helperInstalled":true,"manifestInstalled":true,"sudoersInstalled":true,"helperOwner":"root","manifestOwner":"root","sudoersOwner":"root","sudoersAllowsAll":false,"sudoersScopedHelperEntry":true}}
+JSON
+  exit 0
+fi
+if [ "$1" = "-n" ] && [ "$3" = "--version" ]; then echo helper-version-output-may-change; exit 0; fi
+exit 1
+`,
     { mode: 0o755 }
   );
 
@@ -174,11 +183,16 @@ test("VPS maintenance install inventory collector starts sudo probe for bare fla
     }
   );
 
-  assert.equal(result.status, 0);
+  assert.equal(result.status, 1);
   const body = JSON.parse(result.stdout);
-  assert.equal(body.installInventory.status, "ready");
+  assert.equal(body.installInventory.status, "blocked");
+  assert.equal(body.installInventory.issues.includes("sudoers scoped helper entry is missing"), true);
+  assert.equal(body.installInventory.checks.find((check) => check.id === "scoped_sudoers_entry").status, "unverified");
   assert.equal(body.installInventory.checks.find((check) => check.id === "helper_sudo_functional_probe").status, "pass");
+  assert.equal(body.runtimeTruth.sudoersInstallAuditStarted, false);
   assert.equal(body.runtimeTruth.sudoersHelperProbeStarted, true);
+  assert.equal(body.observation.sudoersInstallAudit.ok, null);
+  assert.equal(body.observation.sudoersInstallAudit.command, null);
   assert.equal(body.observation.sudoersHelperProbe.ok, true);
   assert.equal(body.observation.sudoersHelperProbe.command, "sudo -n <helper> --version");
 });
@@ -218,12 +232,27 @@ test("VPS maintenance install inventory collector blocks when started sudo probe
   const body = JSON.parse(result.stdout);
   assert.equal(body.ok, false);
   assert.equal(body.installInventory.status, "blocked");
-  assert.equal(body.installInventory.checks.find((check) => check.id === "helper_sudo_functional_probe").status, "blocked");
+  assert.equal(body.installInventory.issues.includes("sudoers scoped helper entry is missing"), true);
+  assert.equal(body.runtimeTruth.sudoersInstallAuditStarted, false);
   assert.equal(body.runtimeTruth.sudoersHelperProbeStarted, true);
+  assert.equal(body.observation.sudoersInstallAudit.ok, null);
   assert.equal(body.observation.sudoersHelperProbe.ok, false);
 });
 
 test("VPS maintenance install inventory collector detects broad sudoers grants", () => {
   assert.equal(containsBroadSudoersGrant("vtdd-runner ALL=(ALL) NOPASSWD:ALL"), true);
   assert.equal(containsBroadSudoersGrant("vtdd-runner ALL=(root) NOPASSWD:/usr/local/sbin/vtdd-helper"), false);
+});
+
+test("VPS maintenance helper install audit requires root", () => {
+  const result = spawnSync(process.execPath, ["scripts/run-vps-privileged-maintenance-helper.mjs", "--install-audit"], {
+    encoding: "utf8"
+  });
+
+  assert.equal(result.status, 1);
+  const body = JSON.parse(result.stdout);
+  assert.equal(body.ok, false);
+  assert.equal(body.error, "root_required");
+  assert.equal(body.rootAuditStarted, false);
+  assert.equal(body.issues.includes("root is required for install audit"), true);
 });

--- a/test/vps-privileged-maintenance.test.js
+++ b/test/vps-privileged-maintenance.test.js
@@ -54,7 +54,8 @@ test("VPS privileged maintenance install inventory reports root-owned helper rea
     helperOwner: "root",
     manifestOwner: "root",
     sudoersOwner: "root",
-    sudoersAllowsAll: false
+    sudoersAllowsAll: false,
+    sudoersScopedHelperEntry: true
   });
 
   assert.equal(ready.ok, true);
@@ -118,6 +119,7 @@ test("VPS privileged maintenance install inventory reports root-owned helper rea
     manifestOwner: "root",
     sudoersOwner: "root",
     sudoersAllowsAll: false,
+    sudoersScopedHelperEntry: true,
     sudoersHelperProbe: false,
     sudoersHelperProbeStarted: true
   });

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -8234,7 +8234,7 @@ test("worker dry-runs VPS maintenance helper request without root execution", as
 test("worker retrieves VPS maintenance install inventory without root execution", async () => {
   const response = await worker.fetch(
     new Request(
-      "https://example.com/v2/retrieve/vps-maintenance-install-inventory?repository=marushu%2Fvtdd-v2-p&host=x85-131-245-163&helperInstalled=true&manifestInstalled=true&sudoersInstalled=true&helperOwner=root&manifestOwner=root&sudoersOwner=root&sudoersAllowsAll=false",
+      "https://example.com/v2/retrieve/vps-maintenance-install-inventory?repository=marushu%2Fvtdd-v2-p&host=x85-131-245-163&helperInstalled=true&manifestInstalled=true&sudoersInstalled=true&helperOwner=root&manifestOwner=root&sudoersOwner=root&sudoersAllowsAll=false&sudoersScopedHelperEntry=true",
       {
         headers: gatewayAuthHeaders
       }

--- a/worker.js
+++ b/worker.js
@@ -37500,8 +37500,12 @@ function buildVpsPrivilegedMaintenanceInstallInventory(input = {}) {
   const manifestOwner = normalizeText24(observed.manifestOwner || input.manifestOwner);
   const sudoersOwner = normalizeText24(observed.sudoersOwner || input.sudoersOwner);
   const sudoersAllowsAll = normalizeBoolean(observed.sudoersAllowsAll ?? input.sudoersAllowsAll);
+  const sudoersScopedHelperEntry = normalizeBoolean(
+    observed.sudoersScopedHelperEntry ?? input.sudoersScopedHelperEntry
+  );
   const sudoersHelperProbe = normalizeBoolean(observed.sudoersHelperProbe ?? input.sudoersHelperProbe);
   const sudoersHelperProbeStarted = normalizeBoolean(observed.sudoersHelperProbeStarted ?? input.sudoersHelperProbeStarted);
+  const sudoersInstallAuditStarted = normalizeBoolean(observed.sudoersInstallAuditStarted ?? input.sudoersInstallAuditStarted);
   const functionalProbeStarted = sudoersHelperProbeStarted ?? sudoersHelperProbe !== null;
   const issues = [];
   if (!host) issues.push("host is required");
@@ -37510,6 +37514,9 @@ function buildVpsPrivilegedMaintenanceInstallInventory(input = {}) {
   if (!manifestPath.startsWith("/")) issues.push("manifestPath must be absolute");
   if (!sudoersPath.startsWith("/")) issues.push("sudoersPath must be absolute");
   if (sudoersAllowsAll === true) issues.push("sudoers must not allow NOPASSWD:ALL");
+  if (sudoersScopedHelperEntry === false && sudoersInstalled !== false) {
+    issues.push("sudoers scoped helper entry is missing");
+  }
   if (sudoersHelperProbe === false) issues.push("helper sudo functional probe failed");
   const checks = [
     {
@@ -37530,7 +37537,7 @@ function buildVpsPrivilegedMaintenanceInstallInventory(input = {}) {
     },
     {
       id: "scoped_sudoers_entry",
-      status: sudoersInstalled === true && sudoersOwner === "root" && sudoersAllowsAll === false ? "pass" : sudoersInstalled === false ? "missing" : "unverified",
+      status: sudoersInstalled === true && sudoersOwner === "root" && sudoersAllowsAll === false && sudoersScopedHelperEntry === true ? "pass" : sudoersInstalled === false ? "missing" : "unverified",
       required: true,
       path: sudoersPath,
       expectedOwner: "root",
@@ -37571,6 +37578,7 @@ function buildVpsPrivilegedMaintenanceInstallInventory(input = {}) {
       rootExecutionStarted: false,
       helperExecutionStarted: false,
       sudoersHelperProbeStarted: functionalProbeStarted,
+      sudoersInstallAuditStarted,
       redacted: true,
       nextAction: sudoersHelperProbe === false ? "fix scoped helper sudo before claiming VPS privileged maintenance is ready" : status === "ready" ? "helper install inventory is ready for scoped helper requests" : "verify or install root-owned helper, manifest, and scoped sudoers before claiming iPhone-complete privileged maintenance"
     },
@@ -60895,7 +60903,8 @@ async function handleRetrieveVpsMaintenanceInstallInventoryRequest(url) {
     helperOwner: url.searchParams.get("helperOwner"),
     manifestOwner: url.searchParams.get("manifestOwner"),
     sudoersOwner: url.searchParams.get("sudoersOwner"),
-    sudoersAllowsAll: url.searchParams.get("sudoersAllowsAll")
+    sudoersAllowsAll: url.searchParams.get("sudoersAllowsAll"),
+    sudoersScopedHelperEntry: url.searchParams.get("sudoersScopedHelperEntry")
   });
   if (!inventory.ok) {
     return retrieveErrorJson(url, 422, {


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #637 の install inventory evidence gap を進めます。
- owner が root で初回 bootstrap install した後も、`vtdd-runner` からは `/etc/sudoers.d/...` の中身が読めず、Butler/runtime の install inventory が `unverified` に残っていました。
- この PR は既存の scoped sudo helper 経由で root-readable な redacted install audit を実行し、sudoers file content を漏らさずに root-owned helper / manifest / scoped sudoers entry を確認できるようにします。

## Satisfied Success Criteria

- `vtdd-runner` は `NOPASSWD:ALL` ではなく、root-owned helper だけを `sudo -n` で呼ぶ。
- helper は `--install-audit` で helper / manifest / sudoers の owner と scoped sudoers shape を redacted JSON として返す。
- collector は `--verify-scoped-sudo` 時に helper install audit を使い、sudoers content が通常ユーザーから unreadable でも scoped entry を検証できる。
- `sudoersAllowsAll=true` と scoped helper entry missing は blocked として扱う。
- generated `worker.js` を再生成する。

## Unsatisfied Success Criteria

- real privileged maintenance command execution はまだ行わない。
- capability add / enable / disable / remove / rollback の iPhone 完結 lifecycle はまだ未完了。
- production VPS 実機での post-merge live inventory evidence はこの PR では未実施。
- Issue #637 は close しない。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #637
- Implementing Success Criteria: root-owned helper install 後、Butler/VPS が scoped sudo helper 経由で install inventory を verified/ready に近づける。
- Explicit Non-goals: 任意 root shell、sudo password、broad sudo、real maintenance command execution、capability mutation、deploy、credential mutation、permission mutation、Issue close はしない。
- Expected touched files/routes/workflows: `scripts/run-vps-privileged-maintenance-helper.mjs`, `scripts/collect-vps-maintenance-install-inventory.mjs`, `src/core/vps-privileged-maintenance.js`, `test/vps-maintenance-install-inventory-collector.test.js`, `worker.js`; workflow は変更しない。
- Affected Issues: Issue #637。
- Affected PRs: PR #665 / PR #666 の install inventory follow-up。
- Affected workflows: VPS install inventory collector、Worker install inventory truth。GitHub Actions workflow YAML は変更しない。
- Affected runtime/operator surfaces: Dashboard Butler の `vtddRetrieveVpsMaintenanceInstallInventory` truth、VPS local collector。
- What may break if we patch narrowly: 既存 helper が repo script を実行できない VPS checkout では install audit が blocked になる。ただしこれは iPhone-complete recovery gap として正しく見える。
- Unknowns to investigate before coding: production VPS で `sudo -n <helper> --install-audit` が expected JSON を返すかは post-merge live evidence が必要。
- Validation needed: targeted tests、`npm run build:worker`、full `npm test`、post-merge VPS/prod live inventory。
- Stop condition: sudoers content をレスポンスに漏らす、または `NOPASSWD:ALL` を acceptable とする場合は停止。

## Execution Queue Delta

- Queue position before: Issue #637 is `Now`; Issue #667 ROOT guardrail has merged and #637 is resumed.
- Preemption decision: `NEXT`
- Queue delta: Issue #637 remains `Now`; this PR moves the install inventory evidence gap from unreadable sudoers toward helper-audited runtime truth.
- Why this PR is next: root-owned helper は導入済みだが、Butler/runtime がその事実を iPhone 側から確認できないと、次の privileged maintenance 実行 route に進むたび Mac SSH 前提へ戻る。
- Active Issues not downscoped: Active Issues は縮小しません。#637 の real execution route / lifecycle / E2E は未完了として残します。

## File / Line Hypotheses

- file: `scripts/run-vps-privileged-maintenance-helper.mjs`
  - hypothesis: 既存 installed helper は未知 args をこの repo script に委譲するため、script に `--install-audit` を追加すれば root helper の再インストールなしに audit を実行できる。
  - risk if changed narrowly: repo checkout が古い VPS では helper audit が使えない。
  - validation: collector fake sudo test と full test。
  - related Issue: Issue #637
- file: `scripts/collect-vps-maintenance-install-inventory.mjs`
  - hypothesis: `--verify-scoped-sudo` 時に root helper audit を先に実行し、その redacted observed truth で inventory を作れば unreadable sudoers を safe に検証できる。
  - risk if changed narrowly: helper audit failure は blocked/unverified として残る。
  - validation: missing / broad grant / precondition skip / audit success / audit failure tests。
  - related Issue: Issue #637
- file: `src/core/vps-privileged-maintenance.js`
  - hypothesis: `sudoersScopedHelperEntry=false` を blocked issue にすれば、broad grant でなくても wrong sudoers shape を ready と誤報告しない。
  - risk if changed narrowly: missing sudoers を blocked と混同しないようにする必要がある。
  - validation: core tests and collector tests。
  - related Issue: Issue #637

## Hypothesis Retrospective

- expected: scoped helper install audit で sudoers content を漏らさず、root-owned install truth を collector に渡せる。
- actual: `sudo -n <helper> --install-audit` が redacted observed fields を返し、collector が `sudoersInstallAuditStarted` として runtime truth に載せる。
- mismatch: production VPS live evidence は post-merge/deploy 後に必要。
- lesson: sudoers file unreadable は安全上自然なので、通常ユーザーで content を読むのではなく、root-owned helper が redacted self-audit するべき。
- should become RAG candidate: はい。VPS privileged install readiness は root helper self-audit で確認し、sudoers content は漏らさない。

## Verification Evidence

- Unit: `node --test test/vps-maintenance-install-inventory-collector.test.js test/vps-privileged-maintenance.test.js test/vps-maintenance-helper-installer.test.js` -> tests 24 / pass 24 / fail 0
- Build: `npm run build:worker` -> pass
- Integration: `npm test` -> tests 1069 / pass 1068 / skip 1 / fail 0; self-parity 30 routes / 30 operationIds; generated-worker pass
- E2E: 未実施。post-merge production/VPS live inventory evidence が必要。
- Evidence path/link: `scripts/run-vps-privileged-maintenance-helper.mjs`, `scripts/collect-vps-maintenance-install-inventory.mjs`, `src/core/vps-privileged-maintenance.js`, `test/vps-maintenance-install-inventory-collector.test.js`, `worker.js`

## Butler Completion Contract

- Owner goal: iPhone/Butler から VPS helper install readiness を Mac SSH なしで確認できるようにする。
- Butler entrypoint: existing `vtddRetrieveVpsMaintenanceInstallInventory` truth を改善する。
- Action Schema exposure: existing operationId を維持。schema change なし。
- Runtime path: Worker inventory truth と VPS local collector / helper audit。
- Runner/runtime truth: `sudoersInstallAuditStarted`, `sudoersHelperProbeStarted`, redacted observed owner/policy fields。
- Authority boundary: helper install audit は scoped helper only。sudo password / raw sudoers content / root shell は扱わない。
- E2E evidence: local synthetic tests のみ。production live evidence は未実施。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: required。`src/core` と `worker.js` 変更あり。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate
- AGENTS.md Butler-First Operating Principle
- AGENTS.md Authority Boundary
- docs/butler/vps-privileged-maintenance-capability-lifecycle.md

## Out-of-scope but NOT implemented

- real helper command execution
- capability add / disable / remove / rollback
- PWA owner-action notification for helper execution
- production VPS live evidence
- Issue #637 close

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #637
- Execution ID: Not provided.
- Goal: Let scoped root helper self-audit VPS maintenance install readiness
