### PR TITLE
Issue #637 VPS helper runner pickupを追加

### DIFF
--- a/docs/butler/remote-codex-cli-executor.md
+++ b/docs/butler/remote-codex-cli-executor.md
@@ -196,6 +196,27 @@ an allowlisted capability, PWA notification is used when owner action is
 required, and redacted runtime truth is returned. Mac SSH/root work remains
 break-glass bootstrap evidence, not Butler-complete recovery.
 
+For privileged maintenance pickup, the same user-owned runner entrypoint also
+recognizes a distinct GitHub Issue comment marker:
+
+- `<!-- vtdd:vps-privileged-maintenance-execution:<executionId> -->`
+- JSON payload `transport` must be `vps_privileged_maintenance_helper`
+- payload must include the canonical repository, Issue number,
+  `approvalScopeMatched=true`, `issueTraceability.issueTraceable=true`, and
+  the `executionEnvelope` returned by
+  `vtddCreateVpsMaintenanceHelperExecution`
+- the runner accepts only the bounded helper invocation
+  `sudo -n /usr/local/sbin/vtdd-vps-maintenance-helper --execute --input <helper-execution-input-json>`
+  with `shell:false`
+- the runner writes `helperExecutionInput` to a temporary local file with
+  restricted permissions, invokes the root-owned helper, removes the file, and
+  reports redacted runtime truth through normal
+  `<!-- vtdd:vps-runner-event:<executionId> -->` comments
+
+This marker is not a Codex implementation queue and must not be used for
+branch/PR creation. It is only for scoped, passkey-approved Issue #637 helper
+execution handoff.
+
 Ready PR means reviewer and automation can inspect the handoff result. It is
 not an Issue-completion claim and it is not merge authority. Merge remains
 behind reviewer approval, required checks, head-SHA consistency, mergeability,

--- a/docs/butler/vps-privileged-maintenance-capability-lifecycle.md
+++ b/docs/butler/vps-privileged-maintenance-capability-lifecycle.md
@@ -106,6 +106,17 @@ exit code, and next-action evidence. Adding such a script path is still not
 Butler Completion Gate success until Dashboard Butler / Custom GPT Action Schema
 and VPS runtime observation can reach it with E2E evidence.
 
+The declared VPS runner pickup contract is a GitHub Issue comment with marker
+`<!-- vtdd:vps-privileged-maintenance-execution:<executionId> -->`. The payload
+must use `transport=vps_privileged_maintenance_helper`, must be issue-traceable,
+must carry `approvalScopeMatched=true`, and must include the execution envelope
+returned by `vtddCreateVpsMaintenanceHelperExecution`. The runner rejects
+payloads that change the helper argv, request `shell:true`, omit
+`helperExecutionInput`, or claim root/helper execution has already started.
+Runner pickup reports normal `vtdd:vps-runner-event` comments so Butler can
+observe picked-up, completed, failed, or blocked runtime truth without Mac
+Codex.
+
 ## Initial Presets
 
 The first preset set should cover the failure classes already observed:

--- a/scripts/run-vps-runner.mjs
+++ b/scripts/run-vps-runner.mjs
@@ -19,8 +19,11 @@ import { prepareGuardedPullRequestBody, prepareGuardedPullRequestBodyFile } from
 import { renderPrBody } from "./render-pr-body.mjs";
 
 const QUEUE_MARKER_RE = /<!--\s*vtdd:vps-runner-execution:([a-zA-Z0-9._:-]+)\s*-->/;
+const PRIVILEGED_MAINTENANCE_QUEUE_MARKER_RE =
+  /<!--\s*vtdd:vps-privileged-maintenance-execution:([a-zA-Z0-9._:-]+)\s*-->/;
 const EVENT_MARKER_RE = /<!--\s*vtdd:vps-runner-event:([a-zA-Z0-9._:-]+)\s*-->/;
 const CANCELED_MARKER_RE = /<!--\s*vtdd:vps-runner-canceled:([a-zA-Z0-9._:-]+)\s*-->/;
+const DEFAULT_PRIVILEGED_MAINTENANCE_HELPER_PATH = "/usr/local/sbin/vtdd-vps-maintenance-helper";
 const DEFAULT_API_BASE_URL = "https://api.github.com";
 const DEFAULT_HEARTBEAT_SECONDS = 120;
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
@@ -105,9 +108,42 @@ async function runVpsRunnerOnce({
   dryRun = false
 }) {
   const policies = normalizeRepositoryPolicies({ allowedRepositories, repositoryPolicies });
+  const issueCommentsByRepository = new Map();
+  for (const repository of policies.map((policy) => policy.repository)) {
+    issueCommentsByRepository.set(repository, await readRecentIssueComments({ githubFetch, repository }));
+  }
+
+  const privilegedMaintenanceCandidates = [];
+  for (const repository of policies.map((policy) => policy.repository)) {
+    const comments = issueCommentsByRepository.get(repository) || [];
+    privilegedMaintenanceCandidates.push(
+      ...selectPendingVpsPrivilegedMaintenanceExecutions({
+        comments,
+        repositoryPolicies: policies
+      })
+    );
+  }
+
+  const privilegedMaintenanceExecution = privilegedMaintenanceCandidates.sort(
+    (a, b) => new Date(a.createdAt) - new Date(b.createdAt)
+  )[0];
+  if (privilegedMaintenanceExecution) {
+    if (dryRun) {
+      return {
+        ok: true,
+        message: `Dry run selected privileged maintenance ${privilegedMaintenanceExecution.payload.executionId} for ${privilegedMaintenanceExecution.payload.repository}#${privilegedMaintenanceExecution.payload.issueNumber}.`
+      };
+    }
+
+    return executeVpsPrivilegedMaintenanceRunnerExecution({
+      githubFetch,
+      execution: privilegedMaintenanceExecution
+    });
+  }
+
   const candidates = [];
   for (const repository of policies.map((policy) => policy.repository)) {
-    const comments = await readRecentIssueComments({ githubFetch, repository });
+    const comments = issueCommentsByRepository.get(repository) || [];
     candidates.push(...selectPendingVpsRunnerExecutions({ comments, repositoryPolicies: policies }));
   }
 
@@ -148,6 +184,86 @@ async function runVpsRunnerOnce({
   }
 
   return executeVpsReviewerFallback({ token, reviewerFallback });
+}
+
+async function executeVpsPrivilegedMaintenanceRunnerExecution({ githubFetch, execution }) {
+  const payload = { ...execution.payload };
+  const notification = buildVpsRunnerNotificationContext({
+    queueCommentAuthor: execution?.actors?.queueCommentAuthor,
+    approvalActor: payload?.approvalActor
+  });
+  await postVpsRunnerEvent({
+    githubFetch,
+    payload,
+    notification,
+    event: {
+      status: "running",
+      lastEvent: "privileged_maintenance_picked_up",
+      currentStep: "vps_privileged_maintenance_helper",
+      queueCommentId: execution.commentId,
+      rootExecutionStarted: false,
+      helperExecutionStarted: false
+    }
+  });
+
+  const helperPath = normalizeText(payload.executionEnvelope?.helperInvocation?.args?.[1]) ||
+    DEFAULT_PRIVILEGED_MAINTENANCE_HELPER_PATH;
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "vtdd-vps-helper-execution-"));
+  const inputPath = path.join(tempDir, "helper-execution-input.json");
+  try {
+    await fs.writeFile(inputPath, JSON.stringify(payload.executionEnvelope.helperExecutionInput, null, 2), {
+      mode: 0o600
+    });
+    const result = await runCommand("sudo", ["-n", helperPath, "--execute", "--input", inputPath], {
+      maxBuffer: 1024 * 1024
+    });
+    const parsed = parseJsonObject(result.stdout);
+    await postVpsRunnerEvent({
+      githubFetch,
+      payload,
+      notification,
+      event: {
+        status: "completed",
+        lastEvent: "privileged_maintenance_completed",
+        currentStep: "vps_privileged_maintenance_helper",
+        rootExecutionStarted: true,
+        helperExecutionStarted: true,
+        runtimeTruth: parsed?.runtimeTruth || null,
+        helperResult: redactVpsPrivilegedMaintenanceHelperResult(parsed)
+      }
+    });
+    return {
+      ok: true,
+      message: `VPS privileged maintenance helper execution ${payload.executionId} completed.`
+    };
+  } catch (error) {
+    const parsed = parseJsonObject(error?.stdout);
+    const runtimeTruth = parsed?.runtimeTruth && typeof parsed.runtimeTruth === "object" ? parsed.runtimeTruth : null;
+    await postVpsRunnerEvent({
+      githubFetch,
+      payload,
+      notification,
+      event: {
+        status: "failed",
+        lastEvent: "privileged_maintenance_failed",
+        currentStep: "vps_privileged_maintenance_helper",
+        rootExecutionStarted: runtimeTruth?.rootExecutionStarted === true,
+        helperExecutionStarted: runtimeTruth?.helperExecutionStarted === true,
+        runtimeTruth,
+        helperResult: redactVpsPrivilegedMaintenanceHelperResult(parsed),
+        rawFailure: {
+          error: "vps_privileged_maintenance_helper_failed",
+          reason: summarizeDiagnosticText(error?.stderr || error?.message || String(error), 500)
+        }
+      }
+    });
+    return {
+      ok: false,
+      reason: "VPS privileged maintenance helper execution failed."
+    };
+  } finally {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
 }
 
 async function executeVpsRunnerExecution({
@@ -699,6 +815,59 @@ function selectPendingVpsRunnerExecutions({ comments, allowedRepositories, repos
   );
 }
 
+function selectPendingVpsPrivilegedMaintenanceExecutions({ comments, allowedRepositories, repositoryPolicies }) {
+  const policies = normalizeRepositoryPolicies({ allowedRepositories, repositoryPolicies });
+  const queues = new Map();
+  const terminalEvents = new Set();
+  const runningEvents = new Set();
+
+  for (const comment of comments) {
+    const queue = parseVpsPrivilegedMaintenanceQueueComment(comment.body);
+    if (queue.ok && validateVpsPrivilegedMaintenancePayloadPolicy(queue.payload, policies).ok) {
+      const cancellation = parseVpsRunnerCancellationMarker(comment.body, {
+        executionId: queue.payload.executionId
+      });
+      queues.set(queue.payload.executionId, {
+        ...queue,
+        cancellation,
+        commentId: comment.id,
+        commentUrl: comment.html_url,
+        createdAt: comment.created_at,
+        actors: {
+          queueCommentAuthor: normalizeGitHubLogin(comment?.user?.login)
+        }
+      });
+      continue;
+    }
+
+    const event = parseVpsRunnerEventComment(comment.body);
+    if (!event.ok) {
+      continue;
+    }
+    if (["completed", "failed", "blocked", "canceled"].includes(event.event.status)) {
+      terminalEvents.add(event.executionId);
+    }
+    if (event.event.status === "running") {
+      runningEvents.add(event.executionId);
+    }
+  }
+
+  return [...queues.values()].filter(
+    (queue) =>
+      !queue.cancellation &&
+      !terminalEvents.has(queue.payload.executionId) &&
+      !runningEvents.has(queue.payload.executionId)
+  );
+}
+
+function validateVpsPrivilegedMaintenancePayloadPolicy(payload, policies) {
+  const policy = policies.find((item) => item.repository === payload.repository);
+  if (!policy) {
+    return { ok: false, reason: "repository_not_allowlisted" };
+  }
+  return { ok: true, policy };
+}
+
 function buildVpsRunnerCompletionFinalEvent({ payload } = {}) {
   if (isPostMergeVerificationGoal(payload?.codexGoal)) {
     return "post_merge_verification_completed";
@@ -899,6 +1068,129 @@ function parseVpsRunnerQueueComment(body) {
   }
 
   return { ok: true, executionId: normalized.executionId, payload: normalized };
+}
+
+function parseVpsPrivilegedMaintenanceQueueComment(body) {
+  const text = String(body || "");
+  const marker = text.match(PRIVILEGED_MAINTENANCE_QUEUE_MARKER_RE);
+  if (!marker) {
+    return { ok: false, reason: "vps_privileged_maintenance_queue_marker_missing" };
+  }
+
+  const payload = extractFirstJsonFence(text);
+  if (!payload) {
+    return {
+      ok: false,
+      reason: "vps_privileged_maintenance_payload_missing",
+      executionId: marker[1]
+    };
+  }
+
+  const normalized = {
+    executionId: normalizeText(payload.executionId),
+    transport: normalizeText(payload.transport),
+    repository: normalizeRepository(payload.repository),
+    issueNumber: normalizePositiveInteger(payload.issueNumber),
+    approvalScopeMatched: payload.approvalScopeMatched === true,
+    approvalActor: normalizeGitHubLogin(payload.approvalActor),
+    executionEnvelope: normalizeVpsPrivilegedMaintenanceExecutionEnvelope(payload.executionEnvelope),
+    issueTraceability: payload.issueTraceability || null
+  };
+
+  const issues = [];
+  if (normalized.executionId !== marker[1]) {
+    issues.push("executionId does not match privileged maintenance queue marker");
+  }
+  if (normalized.transport !== "vps_privileged_maintenance_helper") {
+    issues.push("transport must be vps_privileged_maintenance_helper");
+  }
+  if (!normalized.repository) {
+    issues.push("repository is required");
+  }
+  if (!normalized.issueNumber) {
+    issues.push("issueNumber is required");
+  }
+  if (!normalized.approvalScopeMatched) {
+    issues.push("approvalScopeMatched must be true");
+  }
+  if (normalized.issueTraceability?.issueTraceable !== true) {
+    issues.push("issueTraceability.issueTraceable must be true");
+  }
+  issues.push(...validateVpsPrivilegedMaintenanceExecutionEnvelope(normalized.executionEnvelope));
+
+  if (issues.length > 0) {
+    return {
+      ok: false,
+      reason: "vps_privileged_maintenance_payload_invalid",
+      executionId: marker[1],
+      issues
+    };
+  }
+
+  return { ok: true, executionId: normalized.executionId, payload: normalized };
+}
+
+function normalizeVpsPrivilegedMaintenanceExecutionEnvelope(value) {
+  const input = value && typeof value === "object" ? value : {};
+  const invocation = input.helperInvocation && typeof input.helperInvocation === "object" ? input.helperInvocation : {};
+  return {
+    kind: normalizeText(input.kind),
+    status: normalizeText(input.status),
+    repository: normalizeRepository(input.repository),
+    requestId: normalizeText(input.requestId),
+    capabilityId: normalizeText(input.capabilityId),
+    mode: normalizeText(input.mode),
+    helperInvocation: {
+      executable: normalizeText(invocation.executable),
+      args: Array.isArray(invocation.args) ? invocation.args.map(normalizeText) : [],
+      shell: invocation.shell === true,
+      inputFile: normalizeText(invocation.inputFile)
+    },
+    helperExecutionInput:
+      input.helperExecutionInput && typeof input.helperExecutionInput === "object" ? input.helperExecutionInput : null,
+    rootExecutionStarted: input.rootExecutionStarted === true,
+    helperExecutionStarted: input.helperExecutionStarted === true
+  };
+}
+
+function validateVpsPrivilegedMaintenanceExecutionEnvelope(envelope) {
+  const issues = [];
+  if (envelope.kind !== "vps_privileged_maintenance_helper_execution_envelope") {
+    issues.push("executionEnvelope.kind must be vps_privileged_maintenance_helper_execution_envelope");
+  }
+  if (envelope.status !== "ready_for_vps_helper_execution") {
+    issues.push("executionEnvelope.status must be ready_for_vps_helper_execution");
+  }
+  if (envelope.mode !== "execute") {
+    issues.push("executionEnvelope.mode must be execute");
+  }
+  if (envelope.helperInvocation.executable !== "sudo") {
+    issues.push("executionEnvelope.helperInvocation.executable must be sudo");
+  }
+  const args = envelope.helperInvocation.args;
+  if (
+    args.length !== 5 ||
+    args[0] !== "-n" ||
+    args[1] !== DEFAULT_PRIVILEGED_MAINTENANCE_HELPER_PATH ||
+    args[2] !== "--execute" ||
+    args[3] !== "--input" ||
+    args[4] !== "<helper-execution-input-json>"
+  ) {
+    issues.push("executionEnvelope.helperInvocation.args must match the bounded root helper invocation");
+  }
+  if (envelope.helperInvocation.shell !== false) {
+    issues.push("executionEnvelope.helperInvocation.shell must be false");
+  }
+  if (envelope.helperInvocation.inputFile !== "helperExecutionInput") {
+    issues.push("executionEnvelope.helperInvocation.inputFile must be helperExecutionInput");
+  }
+  if (!envelope.helperExecutionInput) {
+    issues.push("executionEnvelope.helperExecutionInput is required");
+  }
+  if (envelope.rootExecutionStarted || envelope.helperExecutionStarted) {
+    issues.push("executionEnvelope must not claim root/helper execution has already started");
+  }
+  return issues;
 }
 
 function validateQueuedPostMergeVerificationTarget(payload) {
@@ -2497,6 +2789,35 @@ function extractFirstJsonFence(text) {
   }
 }
 
+function parseJsonObject(value) {
+  try {
+    const parsed = JSON.parse(String(value || ""));
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function redactVpsPrivilegedMaintenanceHelperResult(value) {
+  const input = value && typeof value === "object" ? value : {};
+  return {
+    ok: input.ok === true,
+    status: normalizeText(input.status),
+    requestId: normalizeText(input.requestId),
+    runtimeTruth:
+      input.runtimeTruth && typeof input.runtimeTruth === "object"
+        ? {
+            kind: normalizeText(input.runtimeTruth.kind),
+            status: normalizeText(input.runtimeTruth.status),
+            exitCode: Number.isInteger(input.runtimeTruth.exitCode) ? input.runtimeTruth.exitCode : null,
+            rootExecutionStarted: input.runtimeTruth.rootExecutionStarted === true,
+            helperExecutionStarted: input.runtimeTruth.helperExecutionStarted === true,
+            redacted: true
+          }
+        : null
+  };
+}
+
 function fencedJson(value) {
   return `\`\`\`json\n${JSON.stringify(value, null, 2)}\n\`\`\``;
 }
@@ -2599,11 +2920,13 @@ export {
   normalizeRepositoryPolicies,
   parseVpsRunnerCancellationMarker,
   parseVpsRunnerEventComment,
+  parseVpsPrivilegedMaintenanceQueueComment,
   parseVpsRunnerQueueComment,
   postVpsRunnerEvent,
   runVpsRunnerOnce,
   resolveRoleGitHubAppInstallationToken,
   summarizeDiagnosticText,
   selectPendingVpsReviewerFallbacks,
+  selectPendingVpsPrivilegedMaintenanceExecutions,
   selectPendingVpsRunnerExecutions
 };

--- a/test/vps-runner-script.test.js
+++ b/test/vps-runner-script.test.js
@@ -26,12 +26,14 @@ import {
   normalizeRepositoryPolicies,
   parseVpsRunnerCancellationMarker,
   parseVpsRunnerEventComment,
+  parseVpsPrivilegedMaintenanceQueueComment,
   parseVpsRunnerQueueComment,
   postVpsRunnerEvent,
   runVpsRunnerOnce,
   resolveRoleGitHubAppInstallationToken,
   summarizeDiagnosticText,
   selectPendingVpsReviewerFallbacks,
+  selectPendingVpsPrivilegedMaintenanceExecutions,
   selectPendingVpsRunnerExecutions
 } from "../scripts/run-vps-runner.mjs";
 
@@ -63,6 +65,67 @@ VTDD 管理の VPS runner 実行キューです。
   assert.equal(parsed.payload.repository, "sample-org/vtdd-v2");
   assert.equal(parsed.payload.issueNumber, 157);
   assert.equal(parsed.payload.branch, "codex/issue-157");
+});
+
+test("VPS runner parses privileged maintenance helper queue payload", () => {
+  const parsed = parseVpsPrivilegedMaintenanceQueueComment(privilegedMaintenanceQueueComment({
+    executionId: "vps-maint-637-a"
+  }));
+
+  assert.equal(parsed.ok, true);
+  assert.equal(parsed.executionId, "vps-maint-637-a");
+  assert.equal(parsed.payload.transport, "vps_privileged_maintenance_helper");
+  assert.equal(parsed.payload.repository, "sample-org/vtdd-v2");
+  assert.equal(parsed.payload.issueNumber, 637);
+  assert.equal(parsed.payload.approvalScopeMatched, true);
+  assert.equal(parsed.payload.executionEnvelope.status, "ready_for_vps_helper_execution");
+  assert.equal(parsed.payload.executionEnvelope.helperInvocation.shell, false);
+  assert.equal(parsed.payload.executionEnvelope.helperExecutionInput.mode, "execute");
+});
+
+test("VPS runner rejects privileged maintenance queue payload that changes helper argv", () => {
+  const parsed = parseVpsPrivilegedMaintenanceQueueComment(privilegedMaintenanceQueueComment({
+    executionId: "vps-maint-637-b",
+    helperArgs: ["-n", "/bin/sh", "-c", "echo unsafe", "<helper-execution-input-json>"]
+  }));
+
+  assert.equal(parsed.ok, false);
+  assert.equal(parsed.reason, "vps_privileged_maintenance_payload_invalid");
+  assert.equal(
+    parsed.issues.includes("executionEnvelope.helperInvocation.args must match the bounded root helper invocation"),
+    true
+  );
+});
+
+test("VPS runner selects pending privileged maintenance queue only once", () => {
+  const comments = [
+    {
+      id: 1,
+      html_url: "https://github.example/comment/1",
+      created_at: "2026-05-30T00:00:00Z",
+      user: { login: "owner" },
+      body: privilegedMaintenanceQueueComment({ executionId: "vps-maint-637-c" })
+    },
+    {
+      id: 2,
+      created_at: "2026-05-30T00:01:00Z",
+      body: "<!-- vtdd:vps-runner-event:vps-maint-637-d -->\n```json\n{\"status\":\"completed\"}\n```"
+    },
+    {
+      id: 3,
+      created_at: "2026-05-30T00:02:00Z",
+      body: privilegedMaintenanceQueueComment({ executionId: "vps-maint-637-d" })
+    }
+  ];
+
+  const selected = selectPendingVpsPrivilegedMaintenanceExecutions({
+    comments,
+    repositoryPolicies: normalizeRepositoryPolicies({ allowedRepositories: ["sample-org/vtdd-v2"] })
+  });
+
+  assert.equal(selected.length, 1);
+  assert.equal(selected[0].payload.executionId, "vps-maint-637-c");
+  assert.equal(selected[0].actors.queueCommentAuthor, "owner");
 });
 
 test("VPS runner rejects queue comments without scoped approval", () => {
@@ -2059,6 +2122,61 @@ function queueComment({
     "issueNumber": ${issueNumber},
     "relatedIssue": ${issueNumber},
     "issueTraceable": true
+  }
+}
+\`\`\``;
+}
+
+function privilegedMaintenanceQueueComment({
+  executionId,
+  helperArgs = ["-n", "/usr/local/sbin/vtdd-vps-maintenance-helper", "--execute", "--input", "<helper-execution-input-json>"]
+}) {
+  return `<!-- vtdd:vps-privileged-maintenance-execution:${executionId} -->
+\`\`\`json
+{
+  "executionId": "${executionId}",
+  "transport": "vps_privileged_maintenance_helper",
+  "repository": "sample-org/vtdd-v2",
+  "issueNumber": 637,
+  "approvalScopeMatched": true,
+  "approvalActor": "requester",
+  "issueTraceability": {
+    "canonicalSpec": "github_issue",
+    "issueNumber": 637,
+    "relatedIssue": 637,
+    "issueTraceable": true
+  },
+  "executionEnvelope": {
+    "kind": "vps_privileged_maintenance_helper_execution_envelope",
+    "status": "ready_for_vps_helper_execution",
+    "repository": "sample-org/vtdd-v2",
+    "requestId": "vps-maint-req-637",
+    "capabilityId": "vtdd-vps-runner-status",
+    "mode": "execute",
+    "helperInvocation": {
+      "executable": "sudo",
+      "args": ${JSON.stringify(helperArgs)},
+      "shell": false,
+      "inputFile": "helperExecutionInput"
+    },
+    "helperExecutionInput": {
+      "manifest": {
+        "version": 1,
+        "host": "vps",
+        "repository": "sample-org/vtdd-v2",
+        "capabilities": []
+      },
+      "helperRequest": {
+        "requestId": "vps-maint-req-637",
+        "relatedIssue": 637,
+        "capabilityId": "vtdd-vps-runner-status",
+        "approvalGrantId": "grant_637"
+      },
+      "mode": "execute",
+      "now": "2026-05-30T00:00:00.000Z"
+    },
+    "rootExecutionStarted": false,
+    "helperExecutionStarted": false
   }
 }
 \`\`\``;


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #637 の VPS runner pickup contract を追加します。
- `vtddCreateVpsMaintenanceHelperExecution` が返す execution envelope を、Mac SSH 前提に戻さず、GitHub Issue comment queue から user-owned VPS runner が拾える形にします。
- 通常の Codex implementation queue とは別 marker にし、root-owned helper に渡す payload だけを受け付けます。

## Satisfied Success Criteria

- `scripts/run-vps-runner.mjs` が `<!-- vtdd:vps-privileged-maintenance-execution:<executionId> -->` を認識します。
- payload は `transport=vps_privileged_maintenance_helper`、allowlisted repository、Issue number、`approvalScopeMatched=true`、`issueTraceability.issueTraceable=true`、bounded execution envelope を必須にしました。
- runner は helper argv を固定し、`sudo -n /usr/local/sbin/vtdd-vps-maintenance-helper --execute --input <helper-execution-input-json>` / `shell:false` 以外を拒否します。
- pickup 時は `helperExecutionInput` を 0600 の一時ファイルへ materialize し、root-owned helper 実行後に削除し、redacted runtime truth を `vtdd:vps-runner-event` で返します。
- tests は valid queue、unsafe argv rejection、pending selection、通常 queue の非回帰を確認します。

## Unsatisfied Success Criteria

- Worker/Butler からこの privileged maintenance queue comment を投稿する Action はまだ未接続です。
- production VPS で root-owned helper の実 execution は未実施です。
- iPhone/PWA live E2E と production deploy/live evidence は未実施です。
- Issue #637 は close しません。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #637
- Implementing Success Criteria: #672 の helper execution envelope を、VPS runner が GitHub queue から安全に pickup して root-owned helper へ渡せる runner-side contract に接続する。
- Explicit Non-goals: Worker/Butler queue posting Action、production root command 実行、deploy、credential mutation、permission mutation、Issue close、normal Codex queue の挙動変更、Butler completion claim はしない。
- Expected touched files/routes/workflows: `scripts/run-vps-runner.mjs`, `test/vps-runner-script.test.js`, `docs/butler/remote-codex-cli-executor.md`, `docs/butler/vps-privileged-maintenance-capability-lifecycle.md`
- Affected Issues: Issue #637。Issue #450/#413/#495 は completion gate 上の関連 blocker として残る。
- Affected PRs: PR #672 の helper execution route 後続。
- Affected workflows: GitHub Actions workflow YAML は変更しない。review / auto-merge は通常通り。
- Affected runtime/operator surfaces: user-owned VPS runner script、Issue comment queue contract、GitHub-visible runner event truth。
- What may break if we patch narrowly: 通常の `vps_runner` Codex queue と root maintenance queue を混ぜると branch/PR automation と privileged host maintenance の authority boundary が壊れる。
- Unknowns to investigate before coding: Butler/Worker が privileged maintenance queue comment を投稿する Action/route は次スライス。production VPS live execution evidence も次スライス。
- Validation needed: `node --check`, targeted runner/docs tests、`npm test`。
- Stop condition: runner が allowlist / issue traceability / approvalScopeMatched / fixed helper argv / `shell:false` を迂回する場合は停止。

## Execution Queue Delta

- Queue position before: Issue #637 is Now. PR #672 merged, but production deploy for PR #672 is still pending passkey approval, and the runner pickup path was missing.
- Preemption decision: NEXT
- Queue delta: Issue #637 remains Now; this PR connects the next runner-side pickup contract without claiming completion.
- Why this PR is next: Action Schema/Worker が execution envelope を作れるようになった後、VPS runner が安全に拾う queue contract がないと Mac SSH 前提に戻るため。
- Active Issues not downscoped: Active Issues は縮小しません。#637 の Worker queue posting / production root execution / iPhone E2E / deploy evidence は未完了として残します。

## File / Line Hypotheses

- file: `scripts/run-vps-runner.mjs`
  - hypothesis: privileged maintenance marker を通常 queue と分離すれば、Codex branch/PR execution と root helper execution の authority boundary を保てる。
  - risk if changed narrowly: 通常 queue payload に root helper envelope を混ぜ、Codex runner が意図しない高リスク処理を開始する。
  - validation: vps-runner script tests / full npm test。
  - related Issue: Issue #637
- file: `test/vps-runner-script.test.js`
  - hypothesis: argv tampering rejection と pending selection をテストすれば、runner pickup の最小 safety regression を拾える。
  - risk if changed narrowly: `shell:true` や helper path 差し替えを検出できない。
  - validation: targeted runner tests / npm test。
  - related Issue: Issue #637
- file: `docs/butler/remote-codex-cli-executor.md`
  - hypothesis: marker/payload contract を docs に残すと、Butler/Worker route の次スライスが既存 runner contract と揃う。
  - risk if changed narrowly: Mac SSH root work と Butler-complete recovery が混同される。
  - validation: docs tests / PR review。
  - related Issue: Issue #637

## Hypothesis Retrospective

- expected: runner can parse/select a distinct privileged maintenance queue and reject unsafe envelopes without changing normal Codex queue behavior.
- actual: targeted tests and full `npm test` passed. An initial full run had one unrelated install-inventory collector transient failure; the same test passed standalone, and the second full `npm test` passed.
- mismatch: Worker/Butler queue posting and production live root helper execution are still missing.
- lesson: runner pickup must be a separate marker and transport, not an extension of normal Codex branch/PR queue semantics.
- should become RAG candidate: はい。VPS privileged maintenance pickup uses a separate Issue comment marker and fixed helper argv; normal Codex queue remains separate.

## Verification Evidence

- Unit/Integration: `node --check scripts/run-vps-runner.mjs && node --test test/vps-runner-script.test.js test/cost-account-boundary.test.js` -> tests 74 / pass 74 / fail 0
- Full: `npm test` -> tests 1074 / pass 1073 / skip 1 / fail 0; self-parity 31 routes / 31 operationIds; generated-worker pass
- E2E: 未実施。production root helper execution と iPhone/PWA E2E は次スライス。
- Manual: 実VPS root command は実行していない。
- Evidence path/link: `scripts/run-vps-runner.mjs`; `test/vps-runner-script.test.js`; `docs/butler/remote-codex-cli-executor.md`; `docs/butler/vps-privileged-maintenance-capability-lifecycle.md`

## Butler Completion Contract

- Owner goal: iPhone/Butler から承認済み VPS maintenance helper execution を Mac SSH 前提に戻さず VPS runner pickup へ渡せるようにする。
- Butler entrypoint: 未接続。#672 の `vtddCreateVpsMaintenanceHelperExecution` は envelope を作るが、queue comment 投稿 Action はまだない。
- Action Schema exposure: 今回は変更なし。
- Runtime path: user-owned VPS runner script が privileged maintenance queue marker を pickup 可能。
- Runner/runtime truth: `vtdd:vps-runner-event` comment で picked_up/completed/failed truth を返す。production live truth は未実施。
- Authority boundary: scoped passkey approval 済み payload と `approvalScopeMatched=true` が前提。runner は fixed helper argv / `shell:false` のみ受け付ける。deploy/credential/permission mutation なし。
- E2E evidence: 未実施。Butler Completion Gate は incomplete。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 不要。この PR は Worker / Action Schema / generated `worker.js` を変更しない。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。次の Worker/Butler queue posting route で更新する。
- iPhone Butler live E2E: 未実施。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate
- AGENTS.md Butler-First Operating Principle
- AGENTS.md Authority Boundary
- docs/butler/vps-privileged-maintenance-capability-lifecycle.md

## Out-of-scope but NOT implemented

- Worker/Butler queue posting Action for privileged maintenance execution
- production VPS root helper execution
- production deploy/live iPhone evidence
- Issue #637 closure

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #637
- Execution ID: Not provided.
- Goal: Add VPS privileged maintenance helper runner pickup contract for Issue #637
