### PR TITLE
Issue #637 sudoers EACCESでもhelper install auditへ進む

### DIFF
--- a/scripts/collect-vps-maintenance-install-inventory.mjs
+++ b/scripts/collect-vps-maintenance-install-inventory.mjs
@@ -143,16 +143,15 @@ async function runScopedSudoInstallAudit({ helperPath, enabled, timeoutMs, maxBu
   }
 }
 
-function shouldProbeScopedSudoHelper({ verifyScopedSudo, helper, manifest, sudoers, sudoersPolicy }) {
+function shouldProbeScopedSudoHelper({ verifyScopedSudo, helper, manifest, sudoers, sudoersPolicy, sudoersInstallAudit }) {
   return (
     verifyScopedSudo === true &&
     helper.installed === true &&
     helper.owner === "root" &&
     manifest.installed === true &&
     manifest.owner === "root" &&
-    sudoers.installed === true &&
-    sudoers.owner === "root" &&
-    sudoersPolicy.allowsAll === false
+    ((sudoers.installed === true && sudoers.owner === "root" && sudoersPolicy.allowsAll === false) ||
+      sudoersInstallAudit?.ok === true)
   );
 }
 
@@ -167,8 +166,7 @@ function shouldAuditInstallThroughScopedSudo({ verifyScopedSudo, helper, manifes
     helper.owner === "root" &&
     manifest.installed === true &&
     manifest.owner === "root" &&
-    sudoers.installed === true &&
-    sudoers.owner === "root"
+    sudoers.installed !== false
   );
 }
 
@@ -236,7 +234,8 @@ async function collectVpsMaintenanceInstallInventory(input = {}) {
     helper,
     manifest,
     sudoers,
-    sudoersPolicy
+    sudoersPolicy,
+    sudoersInstallAudit
   });
   const sudoersHelperProbe = await probeScopedSudoHelper({
     helperPath,
@@ -260,8 +259,8 @@ async function collectVpsMaintenanceInstallInventory(input = {}) {
     sudoersOwner: sudoersInstallAudit.observed?.sudoersOwner ?? sudoers.owner,
     sudoersAllowsAll: sudoersInstallAudit.observed?.sudoersAllowsAll ?? sudoersPolicy.allowsAll,
     sudoersScopedHelperEntry: sudoersInstallAudit.observed?.sudoersScopedHelperEntry ?? sudoersPolicy.scopedHelperEntry,
-    sudoersHelperProbe: sudoersHelperProbe.ok,
-    sudoersHelperProbeStarted: sudoersHelperProbe.started,
+    sudoersHelperProbe: sudoersHelperProbe.ok ?? sudoersInstallAudit.ok,
+    sudoersHelperProbeStarted: sudoersHelperProbe.started || sudoersInstallAudit.started,
     sudoersInstallAuditStarted: sudoersInstallAudit.started
   });
 
@@ -363,4 +362,9 @@ function normalizeNullableBoolean(value) {
   return null;
 }
 
-export { collectVpsMaintenanceInstallInventory, containsBroadSudoersGrant };
+export {
+  collectVpsMaintenanceInstallInventory,
+  containsBroadSudoersGrant,
+  shouldAuditInstallThroughScopedSudo,
+  shouldProbeScopedSudoHelper
+};

--- a/test/vps-maintenance-install-inventory-collector.test.js
+++ b/test/vps-maintenance-install-inventory-collector.test.js
@@ -5,7 +5,11 @@ import os from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 
-import { containsBroadSudoersGrant } from "../scripts/collect-vps-maintenance-install-inventory.mjs";
+import {
+  containsBroadSudoersGrant,
+  shouldAuditInstallThroughScopedSudo,
+  shouldProbeScopedSudoHelper
+} from "../scripts/collect-vps-maintenance-install-inventory.mjs";
 
 test("VPS maintenance install inventory collector reports missing paths without root execution", async () => {
   const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "vtdd-vps-install-inventory-"));
@@ -133,6 +137,38 @@ test("VPS maintenance install inventory collector skips sudo probe until root-ow
   assert.equal(body.observation.sudoersHelperProbe.ok, null);
   assert.equal(body.observation.sudoersHelperProbe.skippedReason, "preconditions_not_met");
   assert.equal(body.observation.sudoersHelperProbe.timeoutMs, null);
+});
+
+test("VPS maintenance install inventory collector allows scoped helper audit when sudoers file is unreadable", () => {
+  const helper = { installed: true, owner: "root" };
+  const manifest = { installed: true, owner: "root" };
+  const sudoers = { installed: null, owner: null, error: "EACCES" };
+
+  assert.equal(
+    shouldAuditInstallThroughScopedSudo({
+      verifyScopedSudo: true,
+      helper,
+      manifest,
+      sudoers,
+      helperPath: "/usr/local/sbin/vtdd-vps-maintenance-helper",
+      manifestPath: "/etc/vtdd/privileged-maintenance-capabilities.json",
+      sudoersPath: "/etc/sudoers.d/vtdd-vps-maintenance-helper",
+      runnerUser: "vtdd-runner"
+    }),
+    true
+  );
+
+  assert.equal(
+    shouldProbeScopedSudoHelper({
+      verifyScopedSudo: true,
+      helper,
+      manifest,
+      sudoers,
+      sudoersPolicy: { allowsAll: null },
+      sudoersInstallAudit: { ok: true }
+    }),
+    true
+  );
 });
 
 test("VPS maintenance install inventory collector does not root-audit override paths", async () => {


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #637 の部分進捗です。VPS 上の root-owned helper / manifest は設置済みでも、`vtdd-runner` が `/etc/sudoers.d/...` を直接読めず `EACCES` になるため install inventory が `unverified` のまま残る gap を、scoped helper の read-only `--install-audit` で判定できるようにします。

## Satisfied Success Criteria

- VPS 上に root-owned helper と root-owned capability manifest がある場合、sudoers file を `vtdd-runner` が直接読めなくても、default path / default runner user の scoped helper audit で readiness を確認できるようにします。
- broad `NOPASSWD:ALL` や任意 root shell を許可せず、default helper path 以外では install audit を起動しません。
- audit / version probe は runtime truth に `rootExecutionStarted=false` / `helperExecutionStarted=false` として残し、root maintenance command 実行とは区別します。

## Unsatisfied Success Criteria

- live passkey approval → VPS runner pickup → root-owned helper の実 command 実行 → before/after runtime truth writeback は未完了です。
- capability add / enable / disable / remove / rollback / review 全体の iPhone/PWA E2E は未完了です。
- Issue #637 close 条件は満たしていません。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #637
- Implementing Success Criteria: root-owned helper / manifest / scoped sudoers readiness を、sudoers file EACCES でも scoped helper audit で読めること
- Explicit Non-goals: root maintenance command 実行、manifest mutation、sudoers mutation、deploy、credential / permission mutation、Issue close
- Expected touched files/routes/workflows: `scripts/collect-vps-maintenance-install-inventory.mjs`, `test/vps-maintenance-install-inventory-collector.test.js`
- Affected Issues: Issue #637。Issue #355 / #412 の authority boundary を尊重します。
- Affected PRs: PR #663 / #664 の installer evidence と、PR #675 の Dashboard helper queue evidence の後続 slice です。
- Affected workflows: `npm test`。Worker route / generated `worker.js` は変更しません。
- Affected runtime/operator surfaces: VPS install inventory collector、Dashboard/Butler が読む install inventory evidence
- What may break if we patch narrowly: sudoers file を読めないことを未設置と誤判定し続けると、root-owned helper が実際に scoped sudo 可能でも #637 readiness が進みません。
- Unknowns to investigate before coding: live VPS checkout へ merge 後に反映して `--verify-scoped-sudo` 実行した時、install inventory が `ready` になるかはこのPR merge後に確認します。
- Validation needed: collector unit、VPS privileged maintenance unit、full `npm test`
- Stop condition: default helper path 以外で root audit を起動する必要が出た場合、または `NOPASSWD:ALL` を許可する必要が出た場合は停止します。

## Execution Queue Delta

- Queue position before: Issue #637 は `Now` の root blocker です。
- Preemption decision: EVIDENCE。既存 install/bootstrap evidence の `sudoers EACCES -> unverified` gap を潰す evidence slice です。
- Queue delta: Issue #637 の install inventory readiness gap を前進させます。live passkey + VPS runner pickup は Queue / Evidence Gap に残します。
- Why this PR is next: PR #675 merge 後も #637 の次の blocker は live helper readiness であり、VPS 実機確認で collector が `--install-audit` に進めないことが確認できたためです。
- Active Issues not downscoped: Active Issues は縮小しません。このPRで扱わない #637 success criteria と他 active Issues は未完了として残します。

## File / Line Hypotheses

- file: `scripts/collect-vps-maintenance-install-inventory.mjs`
  - hypothesis: `shouldAuditInstallThroughScopedSudo` が `sudoers.installed === true` と `sudoers.owner === "root"` を要求しており、`vtdd-runner` から sudoers stat が EACCES の場合に root-owned helper audit へ進めない。
  - risk if changed narrowly: default path guard を外すと任意 helper path へ sudo audit を起動する危険がある。
  - validation: default path / runner user の時だけ EACCES でも audit を許可し、override path test を維持する。
  - related Issue: Issue #637

## Hypothesis Retrospective

- expected: EACCES の sudoers file でも default scoped helper audit を許可すれば、root-owned helper 自身が sudoers readiness を read-only に返せる。
- actual: unit test で EACCES 状態の audit/probe gate が true になること、override path では root audit しない既存境界が維持されることを確認しました。
- mismatch: live VPS で `ready` になる確認は、このPR merge 後に VPS checkout を更新して実施します。
- lesson: root-owned file を非root runner が読めないことは正常な hardening なので、readiness は scoped helper の read-only audit で観測する必要があります。
- should become RAG candidate: yes。sudoers EACCES は missing ではなく scoped helper audit に進めるべき状態。

## Verification Evidence

- Unit: `node --test test/vps-maintenance-install-inventory-collector.test.js test/vps-privileged-maintenance.test.js` passed。22 passed。
- Integration: `npm test` passed。1075 passed, 1 skipped。Self-parity 32 routes / 32 operationIds passed。generated worker check passed。
- E2E: 未実施。このPRは collector readiness slice で、live VPS evidence は merge 後に取得します。
- Manual: merge 前の VPS checkout `db2198e...` では `--verify-scoped-sudo` 実行時に helper/manifest は pass、sudoers は EACCES、audit/probe は preconditions_not_met で `unverified`。このPRはその exact gap を修正します。
- Evidence path/link: PR body と Issue #637 の既存 root bootstrap / install inventory comments。

## Butler Completion Contract

- Owner goal: iPhone/Dashboard Butler から VPS privileged maintenance readiness を Mac SSH に戻らず判断できるようにする。
- Butler entrypoint: `vtddRetrieveVpsMaintenanceInstallInventory` と VPS collector evidence。Dashboard Butler はこの runtime truth を読む想定です。
- Action Schema exposure: 既存 `vtddRetrieveVpsMaintenanceInstallInventory`。このPRでは Action Schema を変更しません。
- Runtime path: VPS checkout の `scripts/collect-vps-maintenance-install-inventory.mjs --verify-scoped-sudo`。
- Runner/runtime truth: merge 前実機では `unverified`。merge 後に same command で `ready` へ進むか確認する必要があります。
- Authority boundary: read-only audit/version probe だけ。root maintenance command、credential mutation、permission mutation、deploy は行いません。
- E2E evidence: 未実施。merge 後 VPS live inventory evidence が必要です。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 不要。Worker route / generated worker は変更しません。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。merge 後に VPS live inventory evidence を取得します。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate
- AGENTS.md Butler-First Operating Principle
- AGENTS.md Authority Boundary
- AGENTS.md Evidence Discipline
- docs/butler/execution-queue-contract.md

## Out-of-scope but NOT implemented

- live root helper command execution
- live passkey approval
- VPS runner pickup execution
- Issue #637 close

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #637
- Execution ID: issue637-install-audit-eacces
- Goal: Allow scoped helper install audit when sudoers file is unreadable to vtdd-runner
