### PR TITLE
Issue #637 non-root helper presetをvtdd-runnerへ降格実行する

### DIFF
--- a/docs/butler/vps-privileged-maintenance-capability-lifecycle.md
+++ b/docs/butler/vps-privileged-maintenance-capability-lifecycle.md
@@ -102,13 +102,17 @@ execution belongs to the VPS root-owned helper path. The helper must block
 before spawning when it is not running as root for a root-required capability,
 must execute non-root capabilities only through the fixed `vtdd-runner` run-as
 contract, must use `shell:false`, and must return redacted runtime truth with
-before/after, exit code, run-as user, and next-action evidence. The non-root
-run-as contract is intentionally narrow: the root-owned helper must start as
-root, must invoke `/usr/sbin/runuser -u vtdd-runner -- <registered argv>`, and
-must keep default helper registry argv validation as the source of executable
-truth. Adding such a script path is still not Butler Completion Gate success
-until Dashboard Butler / Custom GPT Action Schema and VPS runtime observation
-can reach it with E2E evidence.
+before/after, exit code, run-as user, and next-action evidence. Runtime truth
+must distinguish root-owned helper startup from root-required command execution:
+`helperStartedAsRoot=true` means the helper was allowed to perform the run-as
+transition, while `rootExecutionStarted=true` is reserved for capabilities whose
+registered command itself must run as root. The non-root run-as contract is
+intentionally narrow: the root-owned helper must start as root, must invoke
+`/usr/sbin/runuser -u vtdd-runner -- <registered argv>`, and must keep default
+helper registry argv validation as the source of executable truth. Adding such
+a script path is still not Butler Completion Gate success until Dashboard
+Butler / Custom GPT Action Schema and VPS runtime observation can reach it with
+E2E evidence.
 
 The declared VPS runner pickup contract is a GitHub Issue comment with marker
 `<!-- vtdd:vps-privileged-maintenance-execution:<executionId> -->`. The payload

--- a/docs/butler/vps-privileged-maintenance-capability-lifecycle.md
+++ b/docs/butler/vps-privileged-maintenance-capability-lifecycle.md
@@ -100,11 +100,15 @@ registry binding succeeds. Execution must remain separate from the pure Worker
 planning contract: the Worker may report `execute_ready`, but root command
 execution belongs to the VPS root-owned helper path. The helper must block
 before spawning when it is not running as root for a root-required capability,
-must keep non-root run-as commands blocked until a run-as contract exists, must
-use `shell:false`, and must return redacted runtime truth with before/after,
-exit code, and next-action evidence. Adding such a script path is still not
-Butler Completion Gate success until Dashboard Butler / Custom GPT Action Schema
-and VPS runtime observation can reach it with E2E evidence.
+must execute non-root capabilities only through the fixed `vtdd-runner` run-as
+contract, must use `shell:false`, and must return redacted runtime truth with
+before/after, exit code, run-as user, and next-action evidence. The non-root
+run-as contract is intentionally narrow: the root-owned helper must start as
+root, must invoke `/usr/sbin/runuser -u vtdd-runner -- <registered argv>`, and
+must keep default helper registry argv validation as the source of executable
+truth. Adding such a script path is still not Butler Completion Gate success
+until Dashboard Butler / Custom GPT Action Schema and VPS runtime observation
+can reach it with E2E evidence.
 
 The declared VPS runner pickup contract is a GitHub Issue comment with marker
 `<!-- vtdd:vps-privileged-maintenance-execution:<executionId> -->`. The payload

--- a/scripts/run-vps-privileged-maintenance-helper.mjs
+++ b/scripts/run-vps-privileged-maintenance-helper.mjs
@@ -9,6 +9,7 @@ const DEFAULT_HELPER_INSTALL_PATH = "/usr/local/sbin/vtdd-vps-maintenance-helper
 const DEFAULT_MANIFEST_PATH = "/etc/vtdd/privileged-maintenance-capabilities.json";
 const DEFAULT_SUDOERS_PATH = "/etc/sudoers.d/vtdd-vps-maintenance-helper";
 const DEFAULT_RUNNER_USER = "vtdd-runner";
+const DEFAULT_RUNUSER_PATH = "/usr/sbin/runuser";
 
 function parseArgs(argv) {
   const result = {
@@ -178,14 +179,15 @@ function executeHelperPlan({ helperPlan, timeoutMs }) {
     updatedAt: now
   };
 
-  if (boundary.requiresRoot !== true) {
+  const runAsUser = boundary.requiresRoot === true ? "root" : DEFAULT_RUNNER_USER;
+  if (boundary.requiresRoot !== true && process.getuid?.() !== 0) {
     return {
       ok: false,
-      error: "vps_helper_non_root_execution_unconnected",
-      issues: ["non-root helper execution requires a run-as user contract before it can be executed safely"],
+      error: "root_required_for_run_as",
+      issues: ["root-owned helper must start as root before dropping privileges for non-root helper execution"],
       runtimeTruth: {
         ...baseTruth,
-        redactedLogSummary: "blocked before execution; non-root run-as contract is not connected"
+        redactedLogSummary: "blocked before execution; root-owned helper was not running as root for run-as transition"
       }
     };
   }
@@ -214,8 +216,10 @@ function executeHelperPlan({ helperPlan, timeoutMs }) {
 
   const executable = String(boundary.executable || "").trim();
   const args = Array.isArray(boundary.args) ? boundary.args.map((part) => String(part)) : [];
+  const spawnExecutable = boundary.requiresRoot === true ? executable : DEFAULT_RUNUSER_PATH;
+  const spawnArgs = boundary.requiresRoot === true ? args : ["-u", runAsUser, "--", executable, ...args];
   const timeout = normalizeTimeoutMs(timeoutMs);
-  const spawned = spawnSync(executable, args, {
+  const spawned = spawnSync(spawnExecutable, spawnArgs, {
     cwd: workingDirectory,
     encoding: "utf8",
     shell: false,
@@ -234,13 +238,14 @@ function executeHelperPlan({ helperPlan, timeoutMs }) {
       ...baseTruth,
       ok: exitCode === 0,
       status: exitCode === 0 ? "completed" : "failed",
+      runAsUser,
       after: {
         completedAt,
         timedOut: spawned.error?.code === "ETIMEDOUT"
       },
       exitCode,
       redactedLogSummary: summarizeProcessOutput(spawned),
-      rootExecutionStarted: true,
+      rootExecutionStarted: boundary.requiresRoot === true,
       updatedAt: completedAt
     }
   };

--- a/scripts/run-vps-privileged-maintenance-helper.mjs
+++ b/scripts/run-vps-privileged-maintenance-helper.mjs
@@ -2,6 +2,7 @@
 
 import fs from "node:fs/promises";
 import { spawnSync } from "node:child_process";
+import { pathToFileURL } from "node:url";
 
 import { planVpsPrivilegedMaintenanceHelperExecution } from "../src/core/index.js";
 
@@ -151,10 +152,18 @@ async function auditInstall(args) {
   };
 }
 
-function executeHelperPlan({ helperPlan, timeoutMs }) {
+export function executeHelperPlan({
+  helperPlan,
+  timeoutMs,
+  getuid = process.getuid,
+  spawnSyncFn = spawnSync,
+  runuserPath = DEFAULT_RUNUSER_PATH,
+  nowFn = () => new Date()
+}) {
   const boundary = helperPlan?.commandPreview?.executionBoundary ?? {};
   const workingDirectory = String(helperPlan?.capability?.workingDirectories?.[0] ?? "").trim();
-  const now = new Date().toISOString();
+  const helperStartedAsRoot = getuid?.() === 0;
+  const now = nowFn().toISOString();
   const baseTruth = {
     ok: false,
     kind: "vps_privileged_maintenance_helper_execution",
@@ -175,12 +184,13 @@ function executeHelperPlan({ helperPlan, timeoutMs }) {
     redactedLogSummary: "",
     rootExecutionStarted: false,
     helperExecutionStarted: true,
+    helperStartedAsRoot,
     redacted: true,
     updatedAt: now
   };
 
   const runAsUser = boundary.requiresRoot === true ? "root" : DEFAULT_RUNNER_USER;
-  if (boundary.requiresRoot !== true && process.getuid?.() !== 0) {
+  if (boundary.requiresRoot !== true && !helperStartedAsRoot) {
     return {
       ok: false,
       error: "root_required_for_run_as",
@@ -191,7 +201,7 @@ function executeHelperPlan({ helperPlan, timeoutMs }) {
       }
     };
   }
-  if (process.getuid?.() !== 0) {
+  if (!helperStartedAsRoot) {
     return {
       ok: false,
       error: "root_required",
@@ -216,10 +226,10 @@ function executeHelperPlan({ helperPlan, timeoutMs }) {
 
   const executable = String(boundary.executable || "").trim();
   const args = Array.isArray(boundary.args) ? boundary.args.map((part) => String(part)) : [];
-  const spawnExecutable = boundary.requiresRoot === true ? executable : DEFAULT_RUNUSER_PATH;
+  const spawnExecutable = boundary.requiresRoot === true ? executable : runuserPath;
   const spawnArgs = boundary.requiresRoot === true ? args : ["-u", runAsUser, "--", executable, ...args];
   const timeout = normalizeTimeoutMs(timeoutMs);
-  const spawned = spawnSync(spawnExecutable, spawnArgs, {
+  const spawned = spawnSyncFn(spawnExecutable, spawnArgs, {
     cwd: workingDirectory,
     encoding: "utf8",
     shell: false,
@@ -230,7 +240,7 @@ function executeHelperPlan({ helperPlan, timeoutMs }) {
       CI: process.env.CI || "1"
     }
   });
-  const completedAt = new Date().toISOString();
+  const completedAt = nowFn().toISOString();
   const exitCode = typeof spawned.status === "number" ? spawned.status : spawned.error ? 124 : 1;
   return {
     ok: exitCode === 0,
@@ -320,4 +330,6 @@ async function main() {
   }
 }
 
-await main();
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  await main();
+}

--- a/test/vps-privileged-maintenance-helper-script.test.js
+++ b/test/vps-privileged-maintenance-helper-script.test.js
@@ -26,6 +26,30 @@ const manifest = {
   ]
 };
 
+const nonRootManifest = {
+  version: 1,
+  host: "x85-131-245-163",
+  repository: "marushu/vtdd-v2-p",
+  updatedAt: "2026-05-30T00:00:00.000Z",
+  capabilities: [
+    {
+      id: "vps.runner.status.dry.run",
+      title: "Check VPS runner queue status without executing work",
+      status: "enabled",
+      commandClass: "vps_runner_status_dry_run",
+      riskLevel: "low",
+      workingDirectories: ["/home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p"],
+      allowedArgs: ["node scripts/run-vps-runner.mjs --dry-run"],
+      affectedPaths: [],
+      redactionRules: ["no secrets"],
+      rollbackPlan: "no state change",
+      expectedRuntimeTruth: ["dry-run queue selection status"],
+      createdAt: "2026-05-30T00:00:00.000Z",
+      updatedAt: "2026-05-30T00:00:00.000Z"
+    }
+  ]
+};
+
 test("VPS privileged maintenance helper script dry-runs a bounded helper request", () => {
   const helperRequest = {
     kind: "vps_privileged_maintenance_helper_request",
@@ -128,4 +152,40 @@ test("VPS privileged maintenance helper script blocks execute mode when not root
   assert.equal(body.runtimeTruth.rootExecutionStarted, false);
   assert.equal(body.runtimeTruth.helperExecutionStarted, true);
   assert.equal(body.runtimeTruth.status, "blocked");
+});
+
+test("VPS privileged maintenance helper script blocks non-root run-as execution when helper is not root", () => {
+  const helperRequest = {
+    kind: "vps_privileged_maintenance_helper_request",
+    status: "ready_for_vps_helper",
+    requestId: "vps-maintenance-helper-request:non-root",
+    vpsProposalId: "vps-maintenance-proposal:non-root",
+    approvalGrantId: "approval:non-root",
+    host: "x85-131-245-163",
+    repository: "marushu/vtdd-v2-p",
+    relatedIssue: 637,
+    operation: "review",
+    capability: nonRootManifest.capabilities[0]
+  };
+
+  const result = spawnSync(
+    process.execPath,
+    ["scripts/run-vps-privileged-maintenance-helper.mjs", "--execute"],
+    {
+      input: JSON.stringify({
+        manifest: nonRootManifest,
+        helperRequest,
+        now: "2026-05-30T00:00:00.000Z"
+      }),
+      encoding: "utf8"
+    }
+  );
+
+  assert.equal(result.status, 1);
+  const body = JSON.parse(result.stdout);
+  assert.equal(body.ok, false);
+  assert.equal(body.error, "root_required_for_run_as");
+  assert.equal(body.runtimeTruth.rootExecutionStarted, false);
+  assert.equal(body.runtimeTruth.helperExecutionStarted, true);
+  assert.equal(body.runtimeTruth.commandExecutionBoundary.requiresRoot, false);
 });

--- a/test/vps-privileged-maintenance-helper-script.test.js
+++ b/test/vps-privileged-maintenance-helper-script.test.js
@@ -1,6 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
+import { executeHelperPlan } from "../scripts/run-vps-privileged-maintenance-helper.mjs";
 
 const manifest = {
   version: 1,
@@ -188,4 +189,58 @@ test("VPS privileged maintenance helper script blocks non-root run-as execution 
   assert.equal(body.runtimeTruth.rootExecutionStarted, false);
   assert.equal(body.runtimeTruth.helperExecutionStarted, true);
   assert.equal(body.runtimeTruth.commandExecutionBoundary.requiresRoot, false);
+});
+
+test("VPS privileged maintenance helper executes non-root capabilities through fixed vtdd-runner run-as argv", () => {
+  const helperPlan = {
+    host: "x85-131-245-163",
+    repository: "marushu/vtdd-v2-p",
+    relatedIssue: 637,
+    operation: "review",
+    capability: nonRootManifest.capabilities[0],
+    commandPreview: {
+      executionBoundary: {
+        commandClass: "vps_runner_status_dry_run",
+        riskLevel: "low",
+        requiresRoot: false,
+        executable: "node",
+        args: ["scripts/run-vps-runner.mjs", "--dry-run"],
+        shell: false
+      }
+    }
+  };
+  const spawnCalls = [];
+
+  const result = executeHelperPlan({
+    helperPlan,
+    timeoutMs: 1000,
+    getuid: () => 0,
+    nowFn: () => new Date("2026-05-30T00:00:00.000Z"),
+    spawnSyncFn: (executable, args, options) => {
+      spawnCalls.push({ executable, args, options });
+      return {
+        status: 0,
+        stdout: "dry-run queue empty",
+        stderr: ""
+      };
+    }
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(spawnCalls.length, 1);
+  assert.equal(spawnCalls[0].executable, "/usr/sbin/runuser");
+  assert.deepEqual(spawnCalls[0].args, [
+    "-u",
+    "vtdd-runner",
+    "--",
+    "node",
+    "scripts/run-vps-runner.mjs",
+    "--dry-run"
+  ]);
+  assert.equal(spawnCalls[0].options.shell, false);
+  assert.equal(result.runtimeTruth.status, "completed");
+  assert.equal(result.runtimeTruth.runAsUser, "vtdd-runner");
+  assert.equal(result.runtimeTruth.rootExecutionStarted, false);
+  assert.equal(result.runtimeTruth.helperStartedAsRoot, true);
+  assert.equal(result.runtimeTruth.exitCode, 0);
 });


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #637 の部分進捗です。root-owned helper が `requiresRoot:false` の初期 preset を安全に実行できず、runner pickup live E2E の低リスク seed が詰まる gap を、固定 `vtdd-runner` run-as contract で解消します。

## Satisfied Success Criteria

- 初期 preset のうち root を要求しない command を、root-owned helper が `/usr/sbin/runuser -u vtdd-runner -- <registered argv>` で権限降格して実行する contract を定義します。
- helper は `shell:false` と registry-bound argv を維持し、manifest `allowedArgs` を実行入力にしません。
- helper が root として起動していない場合、non-root run-as execution も実行前に block します。

## Unsatisfied Success Criteria

- live VPS runner pickup から low-risk `vps_runner_status_dry_run` を実行する E2E は、このPR merge 後に実施します。
- high-risk root-required command execution、capability add/remove/rollback/review の iPhone/PWA E2E は未完了です。
- Issue #637 close 条件は満たしていません。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #637
- Implementing Success Criteria: 初期 preset の runner/app-server status/logs/dry-run を helper 経由で扱うための non-root run-as contract
- Explicit Non-goals: root-required high-risk command 実行、systemd restart の live 実行、manifest mutation、credential / permission mutation、deploy、Issue close
- Expected touched files/routes/workflows: `scripts/run-vps-privileged-maintenance-helper.mjs`, `test/vps-privileged-maintenance-helper-script.test.js`, `docs/butler/vps-privileged-maintenance-capability-lifecycle.md`
- Affected Issues: Issue #637。Issue #413 / #450 の runner/runtime truth へ後続影響があります。
- Affected PRs: PR #676 の install readiness 後続 slice です。
- Affected workflows: `npm test`。Worker route / generated `worker.js` は変更しません。
- Affected runtime/operator surfaces: VPS root-owned helper, VPS runner pickup, Dashboard-visible helper runtime truth
- What may break if we patch narrowly: root helper が非root preset を root のまま実行すると権限境界が曖昧になります。逆に block のままだと low-risk live E2E ができません。
- Unknowns to investigate before coding: VPS 上で `/usr/sbin/runuser` と `vtdd-runner` の環境で `node scripts/run-vps-runner.mjs --dry-run` が実行できるかは merge 後 live E2E で確認します。
- Validation needed: helper script unit、core helper unit、full `npm test`
- Stop condition: shell 経由、任意 user 指定、manifest allowedArgs 実行、または root-required command を passkey なしで実行する必要が出た場合は停止します。

## Execution Queue Delta

- Queue position before: Issue #637 は `Now` の root blocker です。
- Preemption decision: NEXT。install inventory readiness が ready になったため、次の live runner pickup seed に必要な helper run-as contract を先に接続します。
- Queue delta: Issue #637 の helper execution readiness を前進させます。live runner pickup E2E はこのPR merge 後の次 step に残します。
- Why this PR is next: 現 helper は non-root preset を block するため、high-risk root command に行く前の安全な low-risk runner pickup E2E が実施できません。
- Active Issues not downscoped: Active Issues は縮小しません。このPRで扱わない #637 success criteria と他 active Issues は未完了として残します。

## File / Line Hypotheses

- file: `scripts/run-vps-privileged-maintenance-helper.mjs`
  - hypothesis: `boundary.requiresRoot !== true` を無条件 block しているため、low-risk preset の runner pickup E2E ができない。
  - risk if changed narrowly: run-as user を payload から受けると任意 user execution になり危険。registry argv と fixed `vtdd-runner` に限定する必要がある。
  - validation: non-root run-as contract を docs に記録し、helper が root でない時は execute 前 block する test を追加する。
  - related Issue: Issue #637

## Hypothesis Retrospective

- expected: fixed `vtdd-runner` run-as contract により、non-root preset を root のままではなく権限降格して実行できる。
- actual: helper script unit と full `npm test` は通過。live VPS runner pickup は merge 後に検証予定です。
- mismatch: root としての positive execution test は local unit では実施していません。VPS live E2E で検証します。
- lesson: high-risk root execution へ進む前に、低リスク preset で runner pickup と helper event writeback を証明する必要があります。
- should become RAG candidate: yes。Issue #637 の live seed は `vps_runner_status_dry_run` を fixed `vtdd-runner` run-as で使う。

## Verification Evidence

- Unit: `node --test test/vps-privileged-maintenance-helper-script.test.js test/vps-privileged-maintenance.test.js` passed。18 passed。
- Integration: `npm test` passed。1076 passed, 1 skipped。Self-parity 32 routes / 32 operationIds passed。generated worker check passed。
- E2E: 未実施。このPRは live low-risk helper pickup E2E の前提 contract です。
- Manual: なし。
- Evidence path/link: PR body。

## Butler Completion Contract

- Owner goal: iPhone/Dashboard Butler から VPS helper execution を安全に pickup し、まず low-risk preset で runtime truth を観測できるようにする。
- Butler entrypoint: Dashboard Butler の #637 privileged maintenance flow。次 step で queue comment / VPS runner pickup を使います。
- Action Schema exposure: 既存 `vtddQueueVpsMaintenanceHelperExecution` / helper execution routes。Action Schema は変更しません。
- Runtime path: `scripts/run-vps-runner.mjs` が queue comment を pickup し、`scripts/run-vps-privileged-maintenance-helper.mjs --execute` が non-root preset を fixed run-as で実行する path。
- Runner/runtime truth: local unit まで。live pickup event / completed event は未検証。
- Authority boundary: non-root preset だけ fixed `vtdd-runner` に降格。root-required command は従来通り root helper + passkey boundary が必要です。
- E2E evidence: 未実施。merge 後に low-risk `vps_runner_status_dry_run` live pickup E2E が必要です。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 不要。Worker route / generated worker は変更しません。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。merge 後の次 step で low-risk runner pickup E2E を実施します。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate
- AGENTS.md Butler-First Operating Principle
- AGENTS.md Authority Boundary
- AGENTS.md Evidence Discipline
- docs/butler/execution-queue-contract.md
- docs/butler/vps-privileged-maintenance-capability-lifecycle.md

## Out-of-scope but NOT implemented

- high-risk root-required command execution
- live passkey approval
- live runner pickup E2E
- Issue #637 close

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #637
- Execution ID: issue637-non-root-helper-runas
- Goal: Connect fixed vtdd-runner run-as contract for non-root helper presets
