### PR TITLE
Issue #637 non-root helperにuser systemd envを渡す

### DIFF
--- a/docs/butler/vps-privileged-maintenance-capability-lifecycle.md
+++ b/docs/butler/vps-privileged-maintenance-capability-lifecycle.md
@@ -108,11 +108,15 @@ must distinguish root-owned helper startup from root-required command execution:
 transition, while `rootExecutionStarted=true` is reserved for capabilities whose
 registered command itself must run as root. The non-root run-as contract is
 intentionally narrow: the root-owned helper must start as root, must invoke
-`/usr/sbin/runuser -u vtdd-runner -- <registered argv>`, and must keep default
-helper registry argv validation as the source of executable truth. Adding such
-a script path is still not Butler Completion Gate success until Dashboard
-Butler / Custom GPT Action Schema and VPS runtime observation can reach it with
-E2E evidence.
+`/usr/sbin/runuser -u vtdd-runner -- /usr/bin/env <fixed run-as env>
+<registered argv>`, and must keep default helper registry argv validation as
+the source of executable truth. The fixed run-as environment must include
+`HOME=/home/vtdd-runner`, `XDG_RUNTIME_DIR=/run/user/<vtdd-runner uid>`,
+`DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/<vtdd-runner uid>/bus`, and
+`CI=1` so user systemd and journal presets can observe the owner-owned runner
+services without becoming root command execution. Adding such a script path is
+still not Butler Completion Gate success until Dashboard Butler / Custom GPT
+Action Schema and VPS runtime observation can reach it with E2E evidence.
 
 The declared VPS runner pickup contract is a GitHub Issue comment with marker
 `<!-- vtdd:vps-privileged-maintenance-execution:<executionId> -->`. The payload

--- a/scripts/run-vps-privileged-maintenance-helper.mjs
+++ b/scripts/run-vps-privileged-maintenance-helper.mjs
@@ -158,6 +158,8 @@ export function executeHelperPlan({
   getuid = process.getuid,
   spawnSyncFn = spawnSync,
   runuserPath = DEFAULT_RUNUSER_PATH,
+  envPath = "/usr/bin/env",
+  resolveRunAsUid = defaultResolveRunAsUid,
   nowFn = () => new Date()
 }) {
   const boundary = helperPlan?.commandPreview?.executionBoundary ?? {};
@@ -226,8 +228,24 @@ export function executeHelperPlan({
 
   const executable = String(boundary.executable || "").trim();
   const args = Array.isArray(boundary.args) ? boundary.args.map((part) => String(part)) : [];
+  const runAsUid = boundary.requiresRoot === true ? "" : resolveRunAsUid(runAsUser);
+  if (boundary.requiresRoot !== true && !runAsUid) {
+    return {
+      ok: false,
+      error: "run_as_uid_unresolved",
+      issues: [`unable to resolve uid for ${runAsUser}`],
+      runtimeTruth: {
+        ...baseTruth,
+        redactedLogSummary: "blocked before execution; run-as user uid could not be resolved"
+      }
+    };
+  }
   const spawnExecutable = boundary.requiresRoot === true ? executable : runuserPath;
-  const spawnArgs = boundary.requiresRoot === true ? args : ["-u", runAsUser, "--", executable, ...args];
+  const runAsEnvArgs = boundary.requiresRoot === true ? [] : buildRunAsEnvArgs({ runAsUser, runAsUid });
+  const spawnArgs =
+    boundary.requiresRoot === true
+      ? args
+      : ["-u", runAsUser, "--", envPath, ...runAsEnvArgs, executable, ...args];
   const timeout = normalizeTimeoutMs(timeoutMs);
   const spawned = spawnSyncFn(spawnExecutable, spawnArgs, {
     cwd: workingDirectory,
@@ -256,9 +274,33 @@ export function executeHelperPlan({
       exitCode,
       redactedLogSummary: summarizeProcessOutput(spawned),
       rootExecutionStarted: boundary.requiresRoot === true,
+      runAsUserUid: runAsUid || null,
       updatedAt: completedAt
     }
   };
+}
+
+function defaultResolveRunAsUid(runAsUser) {
+  const result = spawnSync("id", ["-u", runAsUser], {
+    encoding: "utf8",
+    shell: false,
+    timeout: 3000,
+    env: {
+      PATH: "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+    }
+  });
+  if (result.status !== 0) return "";
+  const uid = String(result.stdout || "").trim();
+  return /^\d+$/.test(uid) ? uid : "";
+}
+
+function buildRunAsEnvArgs({ runAsUser, runAsUid }) {
+  return [
+    `HOME=/home/${runAsUser}`,
+    `XDG_RUNTIME_DIR=/run/user/${runAsUid}`,
+    `DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/${runAsUid}/bus`,
+    "CI=1"
+  ];
 }
 
 function ownerLabel(stat) {

--- a/test/vps-privileged-maintenance-helper-script.test.js
+++ b/test/vps-privileged-maintenance-helper-script.test.js
@@ -215,6 +215,7 @@ test("VPS privileged maintenance helper executes non-root capabilities through f
     helperPlan,
     timeoutMs: 1000,
     getuid: () => 0,
+    resolveRunAsUid: () => "1001",
     nowFn: () => new Date("2026-05-30T00:00:00.000Z"),
     spawnSyncFn: (executable, args, options) => {
       spawnCalls.push({ executable, args, options });
@@ -233,6 +234,11 @@ test("VPS privileged maintenance helper executes non-root capabilities through f
     "-u",
     "vtdd-runner",
     "--",
+    "/usr/bin/env",
+    "HOME=/home/vtdd-runner",
+    "XDG_RUNTIME_DIR=/run/user/1001",
+    "DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1001/bus",
+    "CI=1",
     "node",
     "scripts/run-vps-runner.mjs",
     "--dry-run"
@@ -242,5 +248,41 @@ test("VPS privileged maintenance helper executes non-root capabilities through f
   assert.equal(result.runtimeTruth.runAsUser, "vtdd-runner");
   assert.equal(result.runtimeTruth.rootExecutionStarted, false);
   assert.equal(result.runtimeTruth.helperStartedAsRoot, true);
+  assert.equal(result.runtimeTruth.runAsUserUid, "1001");
   assert.equal(result.runtimeTruth.exitCode, 0);
+});
+
+test("VPS privileged maintenance helper blocks non-root run-as execution when runner uid is unresolved", () => {
+  const helperPlan = {
+    host: "x85-131-245-163",
+    repository: "marushu/vtdd-v2-p",
+    relatedIssue: 637,
+    operation: "review",
+    capability: nonRootManifest.capabilities[0],
+    commandPreview: {
+      executionBoundary: {
+        commandClass: "vps_runner_status_dry_run",
+        riskLevel: "low",
+        requiresRoot: false,
+        executable: "node",
+        args: ["scripts/run-vps-runner.mjs", "--dry-run"],
+        shell: false
+      }
+    }
+  };
+
+  const result = executeHelperPlan({
+    helperPlan,
+    timeoutMs: 1000,
+    getuid: () => 0,
+    resolveRunAsUid: () => "",
+    spawnSyncFn: () => {
+      throw new Error("spawn must not start without a run-as uid");
+    }
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.error, "run_as_uid_unresolved");
+  assert.equal(result.runtimeTruth.helperStartedAsRoot, true);
+  assert.equal(result.runtimeTruth.rootExecutionStarted, false);
 });


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #637 の部分進捗です。#677 merge 後の VPS live probe で、root-owned helper は `vtdd-runner` へ降格できたものの、user systemd bus 環境がないため `systemctl --user` が `Failed to connect to bus: No medium found` で失敗しました。この PR は non-root user systemd preset が root command execution にならずに観測できるよう、固定 run-as env を helper argv に追加します。

## Satisfied Success Criteria

- 初期 preset のうち `systemd_user_*` command が `vtdd-runner` の user runtime に到達できるよう、`HOME` / `XDG_RUNTIME_DIR` / `DBUS_SESSION_BUS_ADDRESS` / `CI` を固定 env として渡します。
- helper は `/usr/sbin/runuser -u vtdd-runner -- /usr/bin/env <fixed env> <registered argv>` を使い、`shell:false` と registry-bound argv を維持します。
- run-as uid が解決できない場合は `run_as_uid_unresolved` で spawn 前に block し、runtime truth に残します。

## Unsatisfied Success Criteria

- Dashboard Butler / passkey / Action Schema 経由の live E2E は未実施です。
- restart / enable / daemon-reload の live 実行はしていません。
- Issue #637 close 条件は満たしていません。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #637
- Implementing Success Criteria: 初期 preset runner/app-server status/logs を root-owned helper から `vtdd-runner` user systemd runtime として観測する。
- Explicit Non-goals: restart / enable / daemon-reload の live 実行、deploy、credential mutation、permission mutation、root-required high-risk command 実行、Issue close
- Expected touched files/routes/workflows: `scripts/run-vps-privileged-maintenance-helper.mjs`, `test/vps-privileged-maintenance-helper-script.test.js`, `docs/butler/vps-privileged-maintenance-capability-lifecycle.md`
- Affected Issues: Issue #637。Issue #413 / #450 の VPS runner runtime truth E2E へ後続影響があります。
- Affected PRs: PR #677 の post-merge live probe で見つかった blocker の後続 slice です。
- Affected workflows: `npm test`。Worker route / generated `worker.js` は変更しません。
- Affected runtime/operator surfaces: VPS root-owned helper, user systemd preset, Dashboard-visible helper runtime truth
- What may break if we patch narrowly: env がないままだと status/logs preset が live VPS で失敗し続けます。env を payload 由来にすると任意環境注入になるため、fixed env に限定します。
- Unknowns to investigate before coding: merge 後に installed helper wrapper が最新 checkout を参照した状態で、VPS live `systemd_user_runner_status` が完了するか。
- Validation needed: helper script unit、core helper unit、full `npm test`、merge 後 VPS live low-risk probe
- Stop condition: shell 経由、payload 由来 env、任意 user 指定、または passkey なしの high-risk command execution が必要になった場合は停止します。

## Execution Queue Delta

- Queue position before: Issue #637 は `Now` の VPS privileged maintenance root blocker です。
- Preemption decision: NEXT。#677 merge 後の live probe が同じ #637 の初期 preset blocker を示したため、queue は動かさず同一 Issue 内で続行します。
- Queue delta: Issue #637 の non-root helper execution readiness を前進させます。Dashboard/passkey E2E と Issue close は残します。
- Why this PR is next: `systemd_user_runner_status` が user bus 不足で失敗し、初期 preset status/logs が実用できない状態だったため。
- Active Issues not downscoped: Active Issues は縮小しません。このPRで扱わない #637 success criteria と他 active Issues は未完了として残します。

## File / Line Hypotheses

- file: `scripts/run-vps-privileged-maintenance-helper.mjs`
  - hypothesis: `runuser -u vtdd-runner -- systemctl --user ...` だけでは user systemd bus に接続できず、初期 preset status/logs が VPS live で失敗する。
  - risk if changed narrowly: env を自由入力にすると helper が環境注入面を持つ。fixed `vtdd-runner` env と uid 解決に限定する必要がある。
  - validation: run-as argv unit、uid unresolved block unit、full `npm test`、merge 後 live probe。
  - related Issue: Issue #637

## Hypothesis Retrospective

- expected: fixed run-as env により、user systemd preset が `vtdd-runner` の `/run/user/<uid>/bus` に接続できる。
- actual: local helper unit と full `npm test` は通過。merge 後に installed helper で live probe が必要です。
- mismatch: live VPS での positive result はこの PR 作成時点では未実施です。#677 post-merge probe は blocker 発見 evidence として扱います。
- lesson: non-root run-as は user id だけでなく user runtime env まで含めて helper contract に固定する必要があります。
- should become RAG candidate: yes。Issue #637 の user systemd preset は fixed `XDG_RUNTIME_DIR` / `DBUS_SESSION_BUS_ADDRESS` が必要です。

## Verification Evidence

- Unit: `node --test test/vps-privileged-maintenance-helper-script.test.js test/vps-privileged-maintenance.test.js` passed。20 passed。
- Integration: `npm test` passed。1078 passed, 1 skipped。Self-parity 32 routes / 32 operationIds passed。generated worker check passed。
- E2E: 未実施。このPRは live low-risk helper status probe の前提修正です。
- Manual: #677 merge 後の VPS live probe で `helperStartedAsRoot=true`, `runAsUser=vtdd-runner`, `rootExecutionStarted=false`, failure `Failed to connect to bus: No medium found` を確認しました。
- Evidence path/link: PR body。

## Butler Completion Contract

- Owner goal: iPhone/Dashboard Butler から VPS helper status/logs preset を安全に観測し、VPS runner/app-server bridge の回復判断に使えるようにする。
- Butler entrypoint: Dashboard Butler の #637 privileged maintenance flow。通常完了には passkey approval と helper request/runner pickup が必要です。
- Action Schema exposure: 既存 `vtddQueueVpsMaintenanceHelperExecution` / helper execution routes。Action Schema は変更しません。
- Runtime path: `scripts/run-vps-runner.mjs` が queue comment を pickup し、`scripts/run-vps-privileged-maintenance-helper.mjs --execute` が non-root preset を fixed run-as env で実行する path。
- Runner/runtime truth: local unit と mac_codex_only_probe の blocker evidence まで。merge 後 live completed event は未検証です。
- Authority boundary: non-root preset は fixed `vtdd-runner` に降格。root-required command は従来通り root helper + scoped passkey boundary が必要です。
- E2E evidence: 未実施。merge 後に low-risk `systemd_user_runner_status` live probe と Dashboard/passkey path evidence が必要です。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 不要。Worker route / generated worker は変更しません。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。merge 後の次 step で low-risk status probe を再実行します。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate
- AGENTS.md Butler-First Operating Principle
- AGENTS.md Authority Boundary
- AGENTS.md Evidence Discipline
- docs/butler/execution-queue-contract.md
- docs/butler/vps-privileged-maintenance-capability-lifecycle.md

## Out-of-scope but NOT implemented

- high-risk root-required command execution
- live passkey approval
- Dashboard/passkey E2E
- Issue #637 close

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #637
- Execution ID: issue637-non-root-systemd-env
- Goal: Add fixed user systemd run-as environment for non-root VPS helper presets
