### PR TITLE
Issue #637 helper run-asでNode実行ファイルを解決する

### DIFF
--- a/docs/butler/vps-privileged-maintenance-capability-lifecycle.md
+++ b/docs/butler/vps-privileged-maintenance-capability-lifecycle.md
@@ -111,12 +111,17 @@ intentionally narrow: the root-owned helper must start as root, must invoke
 `/usr/sbin/runuser -u vtdd-runner -- /usr/bin/env <fixed run-as env>
 <registered argv>`, and must keep default helper registry argv validation as
 the source of executable truth. The fixed run-as environment must include
-`HOME=/home/vtdd-runner`, `XDG_RUNTIME_DIR=/run/user/<vtdd-runner uid>`,
+`HOME=/home/vtdd-runner`,
+`PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin`,
+`XDG_RUNTIME_DIR=/run/user/<vtdd-runner uid>`,
 `DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/<vtdd-runner uid>/bus`, and
 `CI=1` so user systemd and journal presets can observe the owner-owned runner
-services without becoming root command execution. Adding such a script path is
-still not Butler Completion Gate success until Dashboard Butler / Custom GPT
-Action Schema and VPS runtime observation can reach it with E2E evidence.
+services without becoming root command execution. Registry command `node` is
+resolved by the helper to the helper process `execPath` before `runuser` so the
+installed helper does not depend on an interactive shell or NVM profile. Adding
+such a script path is still not Butler Completion Gate success until Dashboard
+Butler / Custom GPT Action Schema and VPS runtime observation can reach it with
+E2E evidence.
 
 The declared VPS runner pickup contract is a GitHub Issue comment with marker
 `<!-- vtdd:vps-privileged-maintenance-execution:<executionId> -->`. The payload

--- a/scripts/run-vps-privileged-maintenance-helper.mjs
+++ b/scripts/run-vps-privileged-maintenance-helper.mjs
@@ -242,10 +242,11 @@ export function executeHelperPlan({
   }
   const spawnExecutable = boundary.requiresRoot === true ? executable : runuserPath;
   const runAsEnvArgs = boundary.requiresRoot === true ? [] : buildRunAsEnvArgs({ runAsUser, runAsUid });
+  const registeredExecutable = resolveRegisteredExecutableForSpawn(executable);
   const spawnArgs =
     boundary.requiresRoot === true
       ? args
-      : ["-u", runAsUser, "--", envPath, ...runAsEnvArgs, executable, ...args];
+      : ["-u", runAsUser, "--", envPath, ...runAsEnvArgs, registeredExecutable, ...args];
   const timeout = normalizeTimeoutMs(timeoutMs);
   const spawned = spawnSyncFn(spawnExecutable, spawnArgs, {
     cwd: workingDirectory,
@@ -275,6 +276,7 @@ export function executeHelperPlan({
       redactedLogSummary: summarizeProcessOutput(spawned),
       rootExecutionStarted: boundary.requiresRoot === true,
       runAsUserUid: runAsUid || null,
+      resolvedExecutable: registeredExecutable,
       updatedAt: completedAt
     }
   };
@@ -297,10 +299,18 @@ function defaultResolveRunAsUid(runAsUser) {
 function buildRunAsEnvArgs({ runAsUser, runAsUid }) {
   return [
     `HOME=/home/${runAsUser}`,
+    "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
     `XDG_RUNTIME_DIR=/run/user/${runAsUid}`,
     `DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/${runAsUid}/bus`,
     "CI=1"
   ];
+}
+
+function resolveRegisteredExecutableForSpawn(executable) {
+  if (executable === "node") {
+    return process.execPath;
+  }
+  return executable;
 }
 
 function ownerLabel(stat) {

--- a/test/vps-privileged-maintenance-helper-script.test.js
+++ b/test/vps-privileged-maintenance-helper-script.test.js
@@ -236,10 +236,11 @@ test("VPS privileged maintenance helper executes non-root capabilities through f
     "--",
     "/usr/bin/env",
     "HOME=/home/vtdd-runner",
+    "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
     "XDG_RUNTIME_DIR=/run/user/1001",
     "DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1001/bus",
     "CI=1",
-    "node",
+    process.execPath,
     "scripts/run-vps-runner.mjs",
     "--dry-run"
   ]);
@@ -249,6 +250,7 @@ test("VPS privileged maintenance helper executes non-root capabilities through f
   assert.equal(result.runtimeTruth.rootExecutionStarted, false);
   assert.equal(result.runtimeTruth.helperStartedAsRoot, true);
   assert.equal(result.runtimeTruth.runAsUserUid, "1001");
+  assert.equal(result.runtimeTruth.resolvedExecutable, process.execPath);
   assert.equal(result.runtimeTruth.exitCode, 0);
 });
 


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #637 の部分進捗です。#678 merge 後の VPS live probe で `systemd_user_runner_status` は成功しましたが、次の low-risk seed `vps_runner_status_dry_run` は `runuser` 後に `node` を解決できず、`/usr/bin/env: 'node': No such file or directory` で失敗しました。この PR は registry command `node` を helper process `execPath` に解決してから `runuser` に渡し、interactive shell / NVM profile に依存しない実行境界にします。

## Satisfied Success Criteria

- `vps_runner_status_dry_run` preset の `node` executable を helper の `process.execPath` に解決し、run-as 後も Node 実行ファイルに到達できるようにします。
- fixed run-as env に標準 PATH を追加し、systemd / journalctl / env などの標準コマンド解決を明示します。
- runtime truth に `resolvedExecutable` を追加し、実際に helper が渡した executable を確認できるようにします。

## Unsatisfied Success Criteria

- `vps_runner_status_dry_run` が GitHub token / service env まで含めて完了するかは、merge 後 live probe で確認します。
- Dashboard Butler / passkey / Action Schema 経由の live E2E は未実施です。
- Issue #637 close 条件は満たしていません。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #637
- Implementing Success Criteria: 初期 preset `vps_runner_status_dry_run` を root-owned helper の non-root run-as 経由で実行可能にするための executable resolution
- Explicit Non-goals: GitHub token 注入、credential mutation、runner queue 実行、deploy、permission mutation、root-required high-risk command 実行、Issue close
- Expected touched files/routes/workflows: `scripts/run-vps-privileged-maintenance-helper.mjs`, `test/vps-privileged-maintenance-helper-script.test.js`, `docs/butler/vps-privileged-maintenance-capability-lifecycle.md`
- Affected Issues: Issue #637。Issue #413 / #450 の VPS runner runtime truth E2E へ後続影響があります。
- Affected PRs: PR #678 の post-merge live probe で見つかった blocker の後続 slice です。
- Affected workflows: `npm test`。Worker route / generated `worker.js` は変更しません。
- Affected runtime/operator surfaces: VPS root-owned helper, VPS runner dry-run preset, Dashboard-visible helper runtime truth
- What may break if we patch narrowly: `node` を PATH 任せにすると service shell / login shell / NVM profile 差分で落ちます。逆に payload 由来 executable を許すと registry boundary が壊れます。
- Unknowns to investigate before coding: merge 後に `vps_runner_status_dry_run` が token/env blocker に進むか、完了するか。
- Validation needed: helper script unit、core helper unit、full `npm test`、merge 後 VPS live low-risk probe
- Stop condition: token/secret を helper env に注入する必要が出た場合は停止し、別の credential-bound Issue slice として扱います。

## Execution Queue Delta

- Queue position before: Issue #637 は `Now` の VPS privileged maintenance root blocker です。
- Preemption decision: NEXT。#678 merge 後の live probe が同じ #637 の `vps_runner_status_dry_run` executable blocker を示したため、queue は動かさず同一 Issue 内で続行します。
- Queue delta: Issue #637 の runner dry-run helper execution readiness を前進させます。Dashboard/passkey E2E と Issue close は残します。
- Why this PR is next: `vps_runner_status_dry_run` が `node` 解決不能で失敗し、runner pickup seed として使えない状態だったため。
- Active Issues not downscoped: Active Issues は縮小しません。このPRで扱わない #637 success criteria と他 active Issues は未完了として残します。

## File / Line Hypotheses

- file: `scripts/run-vps-privileged-maintenance-helper.mjs`
  - hypothesis: registry argv の `node` は run-as 後の non-login environment では解決できないため、helper install 時の Node executable を `process.execPath` として使う必要がある。
  - risk if changed narrowly: registry executable 全般を自由に解決すると public runtime truth が operator-specific になる。`node` だけ helper process executable に限定する。
  - validation: run-as argv unit、runtime truth `resolvedExecutable` assert、full `npm test`、merge 後 live probe。
  - related Issue: Issue #637

## Hypothesis Retrospective

- expected: `node` を helper `process.execPath` に解決すれば、runuser 後も NVM/profile に依存せず `scripts/run-vps-runner.mjs --dry-run` を起動できる。
- actual: local helper unit と full `npm test` は通過。merge 後に installed helper で live probe が必要です。
- mismatch: GitHub token / service env が次 blocker になる可能性は残します。secret 注入はこの PR の non-goal です。
- lesson: root-owned helper の registry boundary は command argv だけでなく executable resolution の source of truth も固定する必要があります。
- should become RAG candidate: yes。Issue #637 の `vps_runner_status_dry_run` は helper `process.execPath` による Node resolution が必要です。

## Verification Evidence

- Unit: `node --test test/vps-privileged-maintenance-helper-script.test.js test/vps-privileged-maintenance.test.js` passed。20 passed。
- Integration: `npm test` passed。1078 passed, 1 skipped。Self-parity 32 routes / 32 operationIds passed。generated worker check passed。
- E2E: 未実施。このPRは live low-risk runner dry-run probe の前提修正です。
- Manual: #678 merge 後の VPS live probe で `helperStartedAsRoot=true`, `runAsUser=vtdd-runner`, `rootExecutionStarted=false`, failure `/usr/bin/env: 'node': No such file or directory` を確認しました。
- Evidence path/link: PR body。

## Butler Completion Contract

- Owner goal: iPhone/Dashboard Butler から VPS runner dry-run preset を安全に観測し、runner pickup / queue 状態の回復判断に使えるようにする。
- Butler entrypoint: Dashboard Butler の #637 privileged maintenance flow。通常完了には passkey approval と helper request/runner pickup が必要です。
- Action Schema exposure: 既存 `vtddQueueVpsMaintenanceHelperExecution` / helper execution routes。Action Schema は変更しません。
- Runtime path: `scripts/run-vps-runner.mjs` が queue comment を pickup し、`scripts/run-vps-privileged-maintenance-helper.mjs --execute` が `node` を helper `execPath` に解決して non-root preset を実行する path。
- Runner/runtime truth: local unit と mac_codex_only_probe の blocker evidence まで。merge 後 live completed event は未検証です。
- Authority boundary: non-root preset は fixed `vtdd-runner` に降格。credential/secret は渡しません。root-required command は従来通り root helper + scoped passkey boundary が必要です。
- E2E evidence: 未実施。merge 後に low-risk `vps_runner_status_dry_run` live probe と Dashboard/passkey path evidence が必要です。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 不要。Worker route / generated worker は変更しません。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。merge 後の次 step で low-risk runner dry-run probe を再実行します。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate
- AGENTS.md Butler-First Operating Principle
- AGENTS.md Authority Boundary
- AGENTS.md Evidence Discipline
- docs/butler/execution-queue-contract.md
- docs/butler/vps-privileged-maintenance-capability-lifecycle.md

## Out-of-scope but NOT implemented

- GitHub token / secret injection
- high-risk root-required command execution
- live passkey approval
- Dashboard/passkey E2E
- Issue #637 close

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #637
- Execution ID: issue637-helper-node-resolution
- Goal: Resolve registry node executable through helper process execPath for non-root run-as presets
