### PR TITLE
Issue #637 VPS runner push truth

### DIFF
--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -4151,13 +4151,22 @@ async function handleVpsRunnerEventRequest(request, env) {
     });
   }
 
-  await eventStore.put(event.event);
   const webPush = await dispatchDashboardWebPushForEvent(env, event.event);
+  const eventWithNotificationTruth = normalizeDashboardEventRecord({
+    ...event.event,
+    pwaNotificationStatus: webPush.ok ? "sent" : "pwa_notification_unavailable",
+    pwaNotificationError: webPush.ok ? null : webPush.error || "dashboard_web_push_unavailable",
+    pwaNotificationReason: webPush.ok ? null : webPush.reason || null,
+    pwaNotificationAttempted: webPush.attempted ?? 0,
+    pwaNotificationDelivered: webPush.delivered ?? 0,
+    updatedAt: new Date().toISOString()
+  });
+  await eventStore.put(eventWithNotificationTruth);
   let messages;
   try {
     messages = await chatStore.appendMany(event.threadId, [event.chatMessage]);
   } catch (error) {
-    await eventStore.delete(event.event.id);
+    await eventStore.delete(eventWithNotificationTruth.id);
     return json(502, {
       ok: false,
       error: "dashboard_event_chat_append_failed",
@@ -4171,7 +4180,7 @@ async function handleVpsRunnerEventRequest(request, env) {
   const webSocketBroadcast = await notifyDashboardChatRoom({ env, threadId: event.threadId, messages });
   return json(202, {
     ok: true,
-    event: event.event,
+    event: eventWithNotificationTruth,
     threadId: event.threadId,
     messages,
     webSocketBroadcast,

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -4901,11 +4901,23 @@ test("worker ingests VPS runner event into notifications and Butler chat thread"
   assert.equal(eventBody.event.repository, "marushu/vtdd-v2-p");
   assert.equal(eventBody.event.runId, "remote-codex-issue452-chat");
   assert.equal(eventBody.event.status, "running");
+  assert.equal(eventBody.event.pwaNotificationStatus, "pwa_notification_unavailable");
+  assert.equal(eventBody.event.pwaNotificationError, "dashboard_push_subscription_store_unavailable");
+  assert.equal(eventBody.event.pwaNotificationAttempted, 0);
+  assert.equal(eventBody.event.pwaNotificationDelivered, 0);
   assert.equal(eventBody.event.runUrl.includes("secret-must-not-persist"), false);
   assert.equal(JSON.stringify(eventBody).includes("approval:15b6f20d"), false);
   assert.equal(JSON.stringify(eventBody).includes("secret-must-not-persist"), false);
   assert.equal(eventBody.threadId, "dashboard-main-marushu-vtdd-v2-p");
   assert.equal(eventBody.webSocketBroadcast, true);
+  assert.equal(eventBody.webPush.ok, false);
+  assert.equal(eventBody.webPush.error, "dashboard_push_subscription_store_unavailable");
+  const storedRunnerEvent = await eventStore.latest({
+    kind: "vps_runner_execution",
+    repository: "marushu/vtdd-v2-p"
+  });
+  assert.equal(storedRunnerEvent.pwaNotificationStatus, "pwa_notification_unavailable");
+  assert.equal(storedRunnerEvent.pwaNotificationError, "dashboard_push_subscription_store_unavailable");
   assert.equal(eventBody.messages[0].role, "runner");
   assert.equal(eventBody.messages[0].status, "thinking");
   assert.equal(eventBody.messages[0].relatedIssue, 452);

--- a/worker.js
+++ b/worker.js
@@ -60539,13 +60539,22 @@ async function handleVpsRunnerEventRequest(request, env) {
       reason: "dashboard Butler chat store is not configured"
     });
   }
-  await eventStore.put(event.event);
   const webPush = await dispatchDashboardWebPushForEvent(env, event.event);
+  const eventWithNotificationTruth = normalizeDashboardEventRecord({
+    ...event.event,
+    pwaNotificationStatus: webPush.ok ? "sent" : "pwa_notification_unavailable",
+    pwaNotificationError: webPush.ok ? null : webPush.error || "dashboard_web_push_unavailable",
+    pwaNotificationReason: webPush.ok ? null : webPush.reason || null,
+    pwaNotificationAttempted: webPush.attempted ?? 0,
+    pwaNotificationDelivered: webPush.delivered ?? 0,
+    updatedAt: (/* @__PURE__ */ new Date()).toISOString()
+  });
+  await eventStore.put(eventWithNotificationTruth);
   let messages;
   try {
     messages = await chatStore.appendMany(event.threadId, [event.chatMessage]);
   } catch (error2) {
-    await eventStore.delete(event.event.id);
+    await eventStore.delete(eventWithNotificationTruth.id);
     return json(502, {
       ok: false,
       error: "dashboard_event_chat_append_failed",
@@ -60559,7 +60568,7 @@ async function handleVpsRunnerEventRequest(request, env) {
   const webSocketBroadcast = await notifyDashboardChatRoom({ env, threadId: event.threadId, messages });
   return json(202, {
     ok: true,
-    event: event.event,
+    event: eventWithNotificationTruth,
     threadId: event.threadId,
     messages,
     webSocketBroadcast,


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #637 の VPS runner event 受信時に、Dashboard Butler が PWA push の送信成否を runtime truth として追えるようにします。
- Dashboard thread への返送だけでなく、owner action / completion / blocked 通知が届いたか、届かなかったかを Dashboard event record に保存します。

## Satisfied Success Criteria

- `/v2/events/vps-runner` が Web Push 送信結果を `pwaNotificationStatus` / `pwaNotificationError` / attempted / delivered として event truth に残す。
- Push subscription store が無い場合も `pwa_notification_unavailable` として観測でき、成功扱いで隠さない。
- VPS runner event の Dashboard chat thread append / WebSocket broadcast は維持する。

## Unsatisfied Success Criteria

- 本PRは production deploy を実行しません。
- 本PRは live VPS helper execution や root command execution を起動しません。
- Issue #637 全体の close 判断は、merge、deploy、live Dashboard delivery / PWA delivery evidence 後に残します。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #637
- Implementing Success Criteria: 実行結果を Dashboard Butler と runtime truth に返す際、PWA notification の送信結果も owner-facing truth として残す。
- Explicit Non-goals: live root execution、deploy dispatch、credential/permission mutation、Issue close、通知UIの広範な再設計は行わない。
- Expected touched files/routes/workflows: `src/worker/runtime.js`, `worker.js`, `test/worker.test.js`
- Affected Issues: Issue #637。通知 truth として Issue #589 / Issue #514 にも関連するが、このPRの実装 scope は #637 の VPS runner event truth に限定する。
- Affected PRs: なし。新規PRとして main へ向ける。
- Affected workflows: GitHub reviewer / auto-merge checks は通常通り。deploy workflow は本PRでは dispatch しない。
- Affected runtime/operator surfaces: Worker `/v2/events/vps-runner`、Dashboard notifications event store、Dashboard Butler chat thread append。passkey operator は変更しない。
- What may break if we patch narrowly: event store へ保存する event の `updatedAt` が push attempt 時刻へ更新されるため、通知並び順が変わる可能性がある。ただし latest event truth としては望ましい。
- Unknowns to investigate before coding: Web Push 成功実機は production PWA subscription 依存。local test では unavailable truth を固定する。
- Validation needed: `npm run build:worker`, target worker test, `npm run verify:worker`。
- Stop condition: PWA subscription 作成、deploy、credential、root/helper live execution が必要になった場合はこのPRでは止める。

## Execution Queue Delta

- Queue position before: Issue #637 は `Now` / ROOT blocker の継続。PR #682 merge 後も deploy/live Dashboard delivery evidence が残っている。
- Preemption decision: ROOT。新規割り込みではなく、Issue #637 の Dashboard Butler completion gap を続行する。
- Queue delta: `Now` Queue / Issue #637 の Evidence Gaps から「VPS runner event の PWA delivery truth が event record に残らない」をこのPRで解消する。
- Why this PR is next: Dashboard Butler 目線では実行イベントが返っても、owner action / completion / blocked の通知成否が不明だと iPhone/iPad-only recovery の判断ができないため。
- Active Issues not downscoped: Active Issues は縮小しません。このPRで扱わない open Issue は未完了として queue に残します。

## File / Line Hypotheses

- file: `src/worker/runtime.js`
  - hypothesis: `handleVpsRunnerEventRequest` は `dispatchDashboardWebPushForEvent` を呼ぶが、`eventStore.put` する record に push result を反映していない。
  - risk if changed narrowly: chat append 失敗時の rollback が保存済み event id とずれると、通知だけ残ってしまう。
  - validation: event response / event store / chat append rollback の既存テストを維持し、push unavailable truth を assert する。
  - related Issue: Issue #637

## Hypothesis Retrospective

- expected: VPS runner event response と event store が `pwa_notification_unavailable` を保持し、Dashboard chat thread append は維持される。
- actual: target test と `npm run verify:worker` で期待通り。
- mismatch: なし。
- lesson: Dashboard Butler completion では push attempt の戻り値だけでは足りず、後から Dashboard が読める event truth に保存する必要がある。
- should become RAG candidate: はい。Issue #637 の deploy/live notification evidence と合わせて structured memory に残す候補。

## Verification Evidence

- Unit: `npm run build:worker && node --test test/worker.test.js --test-name-pattern 'VPS runner event into notifications|owner-action-required PWA'` passed、229 tests pass。
- Integration: `npm run verify:worker` passed、1082 pass / 1 skip、self-parity と generated-worker check passed。
- E2E: このPRでは未実施。live PWA delivery evidence は merge/deploy 後に残す。
- Manual: `git diff` で Issue #637 scope の tracked files のみ確認。未追跡の過去証跡ファイルは stage しない。
- Evidence path/link: `test/worker.test.js` の VPS runner event notification truth assertion。

## Butler Completion Contract

- Primary owner surface: Dashboard Butler。
- Fallback surface: フォールバック surface はこのPRでは変更しません。主経路にはしません。
- Owner goal: owner が iPhone/iPad の Dashboard Butler で VPS runner progress / completion / blocked を追う時、PWA push の送信成否を runtime truth として確認できる。
- Butler entrypoint: Dashboard Butler notification center と通常チャット thread。runner からは `/v2/events/vps-runner` に機械投稿される。
- Dashboard Butler natural-language path: Dashboard Butler の自然文 / 通常チャット入口から queued execution に進んだ後、VPS runner event が同じ Dashboard Butler thread と notification truth に返る経路を補強します。
- Action Schema exposure: Action Schema は fallback 用の露出であり、主経路とは扱わない。このPRでは変更しません。
- Runtime path: VPS runner -> `/v2/events/vps-runner` -> Dashboard event store with PWA truth -> Dashboard Butler chat thread append -> Dashboard chat room broadcast。
- Runner/runtime truth: event record に `pwaNotificationStatus`, `pwaNotificationError`, `pwaNotificationAttempted`, `pwaNotificationDelivered` を保存する。
- Authority boundary: 新しい high-risk authority は追加しません。root/helper execution、deploy、credential mutation は実行しません。
- E2E evidence: このPRでは unit/integration evidence のみ。production iPhone/PWA delivery E2E は merge/deploy 後の残作業。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 本PRでは未実行。merge 後に scoped passkey deploy と production runtime truth が必要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。production PWA subscription を使う live evidence が必要。

## Related Constitution Rules

- Dashboard Butler First: owner-facing recovery truth を Dashboard Butler から読めるようにする。
- Butler Completion Gate: runtime truth と E2E evidence なしに完了 claim しない。
- Authority Boundary: deploy/root/credential mutation へ踏み込まない。
- Evidence Discipline: push delivery 成否を後から読める event truth に保存する。

## Out-of-scope but NOT implemented

- live VPS root helper execution。
- production deploy dispatch。
- Issue #637 close。
- PWA subscription 登録や通知UIの広範な変更。

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #637
- Execution ID: issue637-vps-runner-push-truth
- Goal: VPS runner event の PWA notification truth を Dashboard event に保存する。
