### PR TITLE
Issue #579 #654 preserve Dashboard thread on reauth

### DIFF
--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -12964,6 +12964,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
     url?.searchParams?.get("repositoryInput") || url?.searchParams?.get("repository")
   );
   const dashboardIssueNumber = normalizePositiveInteger(url?.searchParams?.get("issueNumber"));
+  const requestedChatThreadId = normalizeDashboardThreadId(url?.searchParams?.get("threadId") || url?.searchParams?.get("thread_id"));
   const dashboardTargetLabel = repositoryInput ? `この作業: ${repositoryInput}` : "作業対象 repo 未指定";
   const targetStatusMarkup = repositoryInput
     ? `<p><strong>${escapeDashboardHtml(repositoryInput)}</strong></p>
@@ -12979,10 +12980,11 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
             </div>
           </form>`;
   const encodedRepository = encodeURIComponent(repositoryInput);
-  const chatThreadId = `dashboard-main-${(repositoryInput || "unresolved").replace(/[^a-z0-9_.-]+/gi, "-")}`;
+  const chatThreadId = requestedChatThreadId || `dashboard-main-${(repositoryInput || "unresolved").replace(/[^a-z0-9_.-]+/gi, "-")}`;
   const socketOrigin = origin.replace(/^http/i, "ws");
-  const currentDashboardReturnPath = sanitizeDashboardPreAuthReturnPath(
-    `${url?.pathname || "/dashboard"}${url?.search || ""}`
+  const currentDashboardReturnPath = withDashboardReturnThreadId(
+    sanitizeDashboardPreAuthReturnPath(`${url?.pathname || "/dashboard"}${url?.search || ""}`),
+    chatThreadId
   );
   const dashboardSignInUrl = `${origin}/v2/approval/passkey/operator?mode=dashboard&phase=execution&actionType=read&highRiskKind=dashboard_access&dashboardReturnPath=${encodeURIComponent(currentDashboardReturnPath)}`;
   const latestDeployEvent = await retrieveLatestDashboardEvent({
@@ -14729,14 +14731,34 @@ function sanitizeDashboardPreAuthReturnPath(value) {
     return "/dashboard";
   }
   const allowedSearchParams = new URLSearchParams();
-  for (const key of ["repository", "repositoryInput", "issueNumber"]) {
-    const rawValue = normalizeDashboardReturnQueryValue(parsed.searchParams.get(key));
+  for (const key of ["repository", "repositoryInput", "issueNumber", "threadId"]) {
+    const rawValue = key === "threadId"
+      ? normalizeDashboardThreadId(parsed.searchParams.get(key))
+      : normalizeDashboardReturnQueryValue(parsed.searchParams.get(key));
     if (rawValue) {
       allowedSearchParams.set(key, rawValue);
     }
   }
   const query = allowedSearchParams.toString();
   return query ? `${parsed.pathname}?${query}` : parsed.pathname;
+}
+
+function withDashboardReturnThreadId(returnPath, threadId) {
+  const sanitizedReturnPath = sanitizeDashboardPreAuthReturnPath(returnPath);
+  const normalizedThreadId = normalizeDashboardThreadId(threadId);
+  if (!normalizedThreadId) {
+    return sanitizedReturnPath;
+  }
+  let parsed;
+  try {
+    parsed = new URL(sanitizedReturnPath, "https://dashboard.local");
+  } catch {
+    return sanitizedReturnPath;
+  }
+  if (!parsed.searchParams.get("threadId")) {
+    parsed.searchParams.set("threadId", normalizedThreadId);
+  }
+  return `${parsed.pathname}${parsed.search}`;
 }
 
 function normalizeDashboardReturnQueryValue(value) {

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -869,6 +869,27 @@ test("worker preserves dashboard repository context across auth fallback links",
   assert.equal(body.includes("repositoryInput="), false);
 });
 
+test("worker preserves dashboard thread context across auth fallback links", async () => {
+  const response = await worker.fetch(
+    new Request("https://example.com/dashboard?threadId=dashboard-main-unresolved&runId=private-run")
+  );
+  assert.equal(response.status, 401);
+  const body = await response.text();
+  assert.equal(
+    body.includes(
+      'href="https://example.com/cdn-cgi/access/login?redirect_url=https%3A%2F%2Fexample.com%2Fdashboard%3FthreadId%3Ddashboard-main-unresolved"'
+    ),
+    true
+  );
+  assert.equal(
+    body.includes(
+      'class="button primary" href="https://example.com/v2/approval/passkey/operator?mode=dashboard&amp;phase=execution&amp;actionType=read&amp;highRiskKind=dashboard_access&amp;dashboardReturnPath=%2Fdashboard%3FthreadId%3Ddashboard-main-unresolved"'
+    ),
+    true
+  );
+  assert.equal(body.includes("runId=private-run"), false);
+});
+
 test("worker rejects unlisted dashboard subpaths before they can become public pages", async () => {
   const response = await worker.fetch(new Request("https://example.com/dashboard/future-page"));
   assert.equal(response.status, 401);
@@ -3778,6 +3799,27 @@ test("worker serves dashboard chat-first shell with debug and ops surfaces isola
   assert.equal(body.includes("<summary>開発/運用</summary>"), true);
   assert.equal(body.includes("<summary>Runtime surfaces</summary>"), false);
   assert.equal(body.includes("RAG を読む"), false);
+});
+
+test("worker uses explicit dashboard thread id for chat shell and passkey return", async () => {
+  const response = await worker.fetch(
+    new Request("https://example.com/dashboard?repository=marushu%2Fvtdd-v2-p&threadId=dashboard-main-unresolved", {
+      headers: dashboardAccessHeaders
+    }),
+    dashboardAccessEnv
+  );
+  assert.equal(response.status, 200);
+  const body = await response.text();
+  assert.equal(body.includes('data-thread-id="dashboard-main-unresolved"'), true);
+  assert.equal(body.includes('data-thread-endpoint="https://example.com/v2/dashboard/chat/dashboard-main-unresolved"'), true);
+  assert.equal(body.includes('data-socket-endpoint="wss://example.com/v2/dashboard/chat/dashboard-main-unresolved/ws"'), true);
+  assert.equal(body.includes('data-thread-id="dashboard-main-marushu-vtdd-v2-p"'), false);
+  assert.equal(
+    body.includes(
+      'dashboardReturnPath=%2Fdashboard%3Frepository%3Dmarushu%252Fvtdd-v2-p%26threadId%3Ddashboard-main-unresolved'
+    ),
+    true
+  );
 });
 
 test("worker serves dashboard notification center for recent events across repositories", async () => {

--- a/worker.js
+++ b/worker.js
@@ -68411,6 +68411,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
     url?.searchParams?.get("repositoryInput") || url?.searchParams?.get("repository")
   );
   const dashboardIssueNumber = normalizePositiveInteger10(url?.searchParams?.get("issueNumber"));
+  const requestedChatThreadId = normalizeDashboardThreadId(url?.searchParams?.get("threadId") || url?.searchParams?.get("thread_id"));
   const dashboardTargetLabel = repositoryInput ? `\u3053\u306E\u4F5C\u696D: ${repositoryInput}` : "\u4F5C\u696D\u5BFE\u8C61 repo \u672A\u6307\u5B9A";
   const targetStatusMarkup = repositoryInput ? `<p><strong>${escapeDashboardHtml(repositoryInput)}</strong></p>
           <p class="muted">\u56FA\u5B9A\u3067\u306F\u3042\u308A\u307E\u305B\u3093\u3002\u3053\u306E\u4F1A\u8A71\u3067 Issue / PR / deploy \u306A\u3069 repo \u304C\u5FC5\u8981\u306A\u4F5C\u696D\u3092\u3059\u308B\u9593\u3060\u3051\u5BFE\u8C61\u306B\u3057\u307E\u3059\u3002deploy \u5148\u3068\u627F\u8A8D\u5883\u754C\u306F repo \u3054\u3068\u306B\u78BA\u8A8D\u3057\u307E\u3059\u3002</p>` : `<p><strong>\u4F5C\u696D\u5BFE\u8C61 repo \u672A\u6307\u5B9A</strong></p>
@@ -68424,10 +68425,11 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
             </div>
           </form>`;
   const encodedRepository = encodeURIComponent(repositoryInput);
-  const chatThreadId = `dashboard-main-${(repositoryInput || "unresolved").replace(/[^a-z0-9_.-]+/gi, "-")}`;
+  const chatThreadId = requestedChatThreadId || `dashboard-main-${(repositoryInput || "unresolved").replace(/[^a-z0-9_.-]+/gi, "-")}`;
   const socketOrigin = origin.replace(/^http/i, "ws");
-  const currentDashboardReturnPath = sanitizeDashboardPreAuthReturnPath(
-    `${url?.pathname || "/dashboard"}${url?.search || ""}`
+  const currentDashboardReturnPath = withDashboardReturnThreadId(
+    sanitizeDashboardPreAuthReturnPath(`${url?.pathname || "/dashboard"}${url?.search || ""}`),
+    chatThreadId
   );
   const dashboardSignInUrl = `${origin}/v2/approval/passkey/operator?mode=dashboard&phase=execution&actionType=read&highRiskKind=dashboard_access&dashboardReturnPath=${encodeURIComponent(currentDashboardReturnPath)}`;
   const latestDeployEvent = await retrieveLatestDashboardEvent({
@@ -70157,14 +70159,31 @@ function sanitizeDashboardPreAuthReturnPath(value) {
     return "/dashboard";
   }
   const allowedSearchParams = new URLSearchParams();
-  for (const key of ["repository", "repositoryInput", "issueNumber"]) {
-    const rawValue = normalizeDashboardReturnQueryValue2(parsed.searchParams.get(key));
+  for (const key of ["repository", "repositoryInput", "issueNumber", "threadId"]) {
+    const rawValue = key === "threadId" ? normalizeDashboardThreadId(parsed.searchParams.get(key)) : normalizeDashboardReturnQueryValue2(parsed.searchParams.get(key));
     if (rawValue) {
       allowedSearchParams.set(key, rawValue);
     }
   }
   const query = allowedSearchParams.toString();
   return query ? `${parsed.pathname}?${query}` : parsed.pathname;
+}
+function withDashboardReturnThreadId(returnPath, threadId) {
+  const sanitizedReturnPath = sanitizeDashboardPreAuthReturnPath(returnPath);
+  const normalizedThreadId = normalizeDashboardThreadId(threadId);
+  if (!normalizedThreadId) {
+    return sanitizedReturnPath;
+  }
+  let parsed;
+  try {
+    parsed = new URL(sanitizedReturnPath, "https://dashboard.local");
+  } catch {
+    return sanitizedReturnPath;
+  }
+  if (!parsed.searchParams.get("threadId")) {
+    parsed.searchParams.set("threadId", normalizedThreadId);
+  }
+  return `${parsed.pathname}${parsed.search}`;
 }
 function normalizeDashboardReturnQueryValue2(value) {
   const normalized = String(value ?? "").trim();


### PR DESCRIPTION
## This PR satisfies Intent

Issue #579 / Issue #654 の Dashboard Butler reconnect/resume 本丸に向けて、passkey / reauth 後に現在の Dashboard chat thread へ戻る前提を修正します。

owner の iPhone 画面では `作業対象 repo 未指定 ・ dashboard main chat` を見ていたのに、こちらが出した repo 付き passkey URL では `この作業: marushu/vtdd-v2-p ・ dashboard main chat` へ戻っていました。これは同じ Dashboard Butler 会話への復帰ではなく、#579 live E2E と #654 same-thread reconnect/resume の前提を壊します。

この PR は `repository` から thread を再構成するだけの挙動を補正し、Dashboard auth / passkey return path と chat shell が明示 `threadId` を保持・優先できるようにします。

## Satisfied Success Criteria

- Dashboard auth fallback link が `threadId` を safe query として保持する。
- passkey operator の dashboard return path が `threadId` を保持する。
- 認証済み Dashboard chat shell が、`repository` 由来の thread 推測よりも明示 `threadId` を優先する。
- `runId` など不要な return query は引き続き落とす。
- `worker.js` を `npm run build:worker` で再生成する。

## Unsatisfied Success Criteria

- production iPhone/PWA live E2E は未実施です。
- #579 の添付候補保持/再選択 UX は未実装です。
- #654 の「HTTP fallback で保存した owner message を bridge 復帰後に同じ thread で再送/継続する」本体は未完了です。
- この PR だけでは Issue #579 / #654 を close しません。

## Dry-run Impact Report

- Target Issue: Issue #579, Issue #654
- Implementing Success Criteria: passkey / reauth return が現在の Dashboard chat thread を保持し、repo 指定の別 thread にずれないこと。
- Explicit Non-goals: deploy、credential mutation、permission mutation、destructive action、Custom GPT fallback、Issue close、添付候補 UX、bridge 復帰後の自動再送本体。
- Expected touched files/routes/workflows: `src/worker/runtime.js`, `worker.js`, `test/worker.test.js`, `/dashboard`, `/v2/approval/passkey/operator`。
- Affected Issues: Issue #579, Issue #654。Issue #637/#590 は active のまま。
- Affected PRs: new PR only。既存 merged PR は変更しません。
- Affected workflows: worker build/test only。GitHub Actions workflow 定義は変更しません。
- Affected runtime/operator surfaces: Dashboard Butler, Dashboard auth required page, passkey operator dashboard mode, Dashboard chat WebSocket/HTTP endpoints via selected `threadId`。
- What may break if we patch narrowly: `threadId` を持たない古い URL は従来通り repository 由来の `dashboard-main-*` に戻るため、過去に作られた外部リンクは現在 thread を復元できません。
- Unknowns to investigate before coding: production PWA が現在 URL に `threadId` を持たない場合、初回表示から同一 thread をどのように共有するかは追加 UX 検証が必要です。
- Validation needed: worker tests, generated worker check, production deploy 後の Dashboard Butler live E2E。
- Stop condition: `threadId` が auth return path に残らない、または明示 `threadId` でも repo 由来の別 thread に戻る場合は停止。

## File / Line Hypotheses

- `src/worker/runtime.js`: `renderV2DashboardPage` が `repository` から `chatThreadId` を組み立てており、明示 `threadId` を優先していなかった。
- `src/worker/runtime.js`: `sanitizeDashboardPreAuthReturnPath` が `threadId` を許可 query として保持していなかった。
- `test/worker.test.js`: auth fallback / chat shell の thread 復帰テストがなかったため、repo main chat へのドリフトを検出できなかった。

## Hypothesis Retrospective

仮説は当たっていました。`renderV2DashboardPage` は `dashboard-main-${repository || unresolved}` で thread を作り、auth return path の safe query も `repository`, `repositoryInput`, `issueNumber` のみ許可していました。

修正後は、明示 `threadId` があれば chat shell の thread endpoint / socket endpoint / draft key の基準 thread として使い、passkey return path にも `threadId` を追加します。

## Butler Completion Contract

- Primary owner surface: Dashboard Butler
- Fallback surface: none for this PR. Custom GPT fallback は対象外です。
- Owner goal: passkey / reauth 後も、いま使っている Dashboard Butler chat thread に戻る。
- Dashboard Butler natural-language path: Dashboard Butler natural-language chat entrypoint is the normal chat composer at `/dashboard`; owner sends ordinary Japanese text there, and after reauth the same `threadId` chat continues.
- Butler entrypoint: Dashboard Butler normal chat at `/dashboard` with the current `threadId`.
- Action Schema exposure: not applicable for this Dashboard Butler runtime PR. Action Schema fallback 強化ではありません。
- Runtime path: `/dashboard`, `/v2/approval/passkey/operator?mode=dashboard...`, `/v2/dashboard/chat/:threadId`, `/v2/dashboard/chat/:threadId/ws`。
- Runner/runtime truth: worker tests verify `threadId` preservation in auth links and authenticated chat shell endpoints.
- Authority boundary: dashboard read session passkey boundary only. deploy / credential / permission / destructive actions are outside this PR.
- E2E evidence: local worker test evidence only in this PR; production iPhone/PWA live E2E remains pending after deploy.
- Completion status: incomplete

## Verification Evidence

- `node --test test/worker.test.js` passed: 231 tests.
- `npm run build:worker` passed.
- `npm run verify:worker` passed: 1084 passed, 1 skipped, self-parity passed, generated-worker check passed.
- `git diff --check` passed.

## Surface Update Checklist

- Dashboard Butler: updated.
- Custom GPT Action Schema: not touched; this is not fallback work.
- Worker runtime: updated.
- Generated `worker.js`: updated.
- Production deploy: not performed in this PR.
- Production iPhone/PWA E2E: pending after merge/deploy.

## Execution Queue Delta

- Queue position before: Issue #637 remains durable queue `Now`.
- Preemption decision: EVIDENCE bounded interruption. Owner live Dashboard Butler E2E revealed passkey return moved to a different Dashboard thread, blocking Issue #579/#654 validation.
- Queue delta: EVIDENCE bucket: Issue #579 and Issue #654 get this PR as partial reconnect/resume prerequisite evidence; Issue #637 stays `Now`, Issue #590/Issue #579/Issue #654 remain open, and no active Issue is removed from scope.
- Why this PR is next: same-thread return is a prerequisite for the production Dashboard Butler E2E the owner is actively running.
- Active Issues not downscoped: true. Active Issues are not downscoped.
