### PR TITLE
#637 Dashboard Butler VPS status intent

### DIFF
--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -9,6 +9,7 @@ import {
   buildVpsCapabilityProposal,
   buildVpsPrivilegedMaintenanceInstallInventory,
   buildVpsMaintenanceApprovalScope,
+  listVpsPrivilegedMaintenanceCommandRegistry,
   planVpsPrivilegedMaintenanceHelperExecution,
   createCloudflareMemoryProvider,
   createPasskeyApprovalOptions,
@@ -10068,6 +10069,36 @@ function buildDashboardVpsMaintenanceProposalPayload({ payload, repository, rela
   const workingDirectory = normalizeText(
     payload?.workingDirectory || payload?.working_directory || env?.VTDD_DASHBOARD_VPS_MAINTENANCE_WORKDIR
   );
+  const preset = resolveDashboardVpsMaintenanceNaturalLanguagePreset({ payload, workingDirectory });
+  if (preset) {
+    return {
+      host: normalizeText(payload?.vpsHost || payload?.host || env?.VTDD_DASHBOARD_VPS_MAINTENANCE_HOST),
+      repository,
+      relatedIssue,
+      operation: normalizeText(payload?.vpsOperation || payload?.operation) || preset.operation,
+      id: normalizeText(payload?.capabilityId || payload?.id) || preset.id,
+      title: normalizeText(payload?.capabilityTitle || payload?.title) || preset.title,
+      commandClass: normalizeText(payload?.commandClass || payload?.command_class) || preset.commandClass,
+      riskLevel: normalizeText(payload?.riskLevel || payload?.risk_level) || preset.riskLevel,
+      workingDirectories: Array.isArray(payload?.workingDirectories)
+        ? payload.workingDirectories
+        : workingDirectory
+          ? [workingDirectory]
+          : [],
+      allowedArgs: Array.isArray(payload?.allowedArgs) ? payload.allowedArgs : preset.allowedArgs,
+      affectedPaths: Array.isArray(payload?.affectedPaths) ? payload.affectedPaths : preset.affectedPaths,
+      redactionRules: Array.isArray(payload?.redactionRules)
+        ? payload.redactionRules
+        : ["no secrets", "summarize stdout/stderr", "redact tokens and credentials"],
+      rollbackPlan: normalizeText(payload?.rollbackPlan) || "disable capability in the root-owned manifest and keep audit history",
+      expectedRuntimeTruth: Array.isArray(payload?.expectedRuntimeTruth)
+        ? payload.expectedRuntimeTruth
+        : ["before state", "exit code", "redacted log summary", "after state", "next action"],
+      reason:
+        normalizeText(payload?.reason) ||
+        `Issue #637 Dashboard Butler natural-language flow: ${preset.id} queue handoff only`
+    };
+  }
   return {
     host: normalizeText(payload?.vpsHost || payload?.host || env?.VTDD_DASHBOARD_VPS_MAINTENANCE_HOST),
     repository,
@@ -10096,6 +10127,56 @@ function buildDashboardVpsMaintenanceProposalPayload({ payload, repository, rela
     reason:
       normalizeText(payload?.reason) ||
       "Issue #637 Dashboard Butler natural-language flow: queue handoff only, no root execution"
+  };
+}
+
+function resolveDashboardVpsMaintenanceNaturalLanguagePreset({ payload, workingDirectory } = {}) {
+  if (
+    normalizeText(payload?.capabilityId || payload?.id) ||
+    normalizeText(payload?.commandClass || payload?.command_class)
+  ) {
+    return null;
+  }
+  const text = normalizeText(payload?.text || payload?.message || payload?.ownerMessage || payload?.owner_message);
+  if (!text) return null;
+  const lower = text.toLowerCase();
+  const wantsLogs = lower.includes("logs") || lower.includes("log") || text.includes("ログ");
+  const wantsRestart = lower.includes("restart") || lower.includes("再起動") || text.includes("再起動");
+  const wantsStatus =
+    lower.includes("status") ||
+    lower.includes("health") ||
+    lower.includes("state") ||
+    text.includes("状態") ||
+    text.includes("確認") ||
+    text.includes("生存") ||
+    text.includes("稼働");
+  const mentionsBridge =
+    lower.includes("app-server") ||
+    lower.includes("app server") ||
+    lower.includes("bridge") ||
+    text.includes("ブリッジ");
+  const mentionsRunner = lower.includes("runner") || text.includes("ランナー") || text.includes("実行器");
+  if (!mentionsBridge && !mentionsRunner) return null;
+
+  let commandClass = "";
+  if (mentionsBridge && wantsLogs) commandClass = "systemd_user_app_server_bridge_logs";
+  else if (mentionsBridge && wantsRestart) commandClass = "systemd_user_app_server_bridge_restart";
+  else if (mentionsBridge && wantsStatus) commandClass = "systemd_user_app_server_bridge_status";
+  else if (mentionsRunner && wantsLogs) commandClass = "systemd_user_runner_logs";
+  else if (mentionsRunner && wantsRestart) commandClass = "systemd_user_runner_restart";
+  else if (mentionsRunner && wantsStatus) commandClass = "systemd_user_runner_status";
+  if (!commandClass) return null;
+
+  const registryEntry = listVpsPrivilegedMaintenanceCommandRegistry().find((entry) => entry.commandClass === commandClass);
+  if (!registryEntry) return null;
+  return {
+    id: commandClass.replaceAll("_", "."),
+    title: registryEntry.title,
+    commandClass: registryEntry.commandClass,
+    riskLevel: registryEntry.requiredRiskLevel,
+    allowedArgs: registryEntry.allowedArgs,
+    affectedPaths: [workingDirectory, "/home/vtdd-runner/.config/systemd/user", "/run/user"].filter(Boolean),
+    operation: wantsRestart ? "enable" : "review"
   };
 }
 

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -2627,6 +2627,47 @@ test("worker connects VPS privileged maintenance intent from Dashboard Butler ch
   assert.equal(queueCommentBody.includes('"handoff"'), true);
 });
 
+test("worker maps Dashboard Butler VPS runner status text to the low-risk preset", async () => {
+  const store = createInMemoryDashboardChatStore();
+  const provider = createInMemoryMemoryProvider();
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/dashboard/chat/messages", {
+      method: "POST",
+      headers: gatewayAuthHeaders,
+      body: JSON.stringify({
+        threadId: "dashboard-main-marushu-vtdd-v2-p",
+        repository: "marushu/vtdd-v2-p",
+        issueNumber: 637,
+        text: "Dashboard Butler から VPS runner status を確認して。root 実行は passkey 境界で止める。"
+      })
+    }),
+    {
+      ...gatewayAuthEnv,
+      DASHBOARD_CHAT_STORE: store,
+      MEMORY_PROVIDER: provider,
+      VTDD_DASHBOARD_VPS_MAINTENANCE_HOST: "x85-131-245-163",
+      VTDD_DASHBOARD_VPS_MAINTENANCE_WORKDIR: "/home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p"
+    }
+  );
+
+  assert.equal(response.status, 202);
+  const body = await response.json();
+  assert.equal(body.ok, true);
+  assert.equal(body.execution.status, "approval_required");
+  assert.equal(body.execution.approvalScope.vpsCapabilityId, "systemd.user.runner.status");
+  assert.equal(body.execution.approvalScope.vpsOperation, "review");
+  assert.equal(body.execution.runtimeTruth.capabilityId, "systemd.user.runner.status");
+  assert.equal(body.execution.runtimeTruth.rootExecutionStarted, false);
+
+  const records = await provider.retrieve({ ids: [body.execution.vpsProposalId] });
+  const proposalRecord = records[0];
+  assert.equal(proposalRecord.content.proposal.capability.commandClass, "systemd_user_runner_status");
+  assert.equal(proposalRecord.content.proposal.capability.riskLevel, "low");
+  assert.deepEqual(proposalRecord.content.proposal.capability.allowedArgs, [
+    "systemctl --user is-active vtdd-vps-runner.timer vtdd-vps-runner.service"
+  ]);
+});
+
 test("worker allows dashboard passkey session chat without VPS runner handoff", async () => {
   const provider = createInMemoryMemoryProvider();
   await provider.store({

--- a/worker.js
+++ b/worker.js
@@ -37738,6 +37738,9 @@ function containsForbiddenPrivilegedPattern(capability) {
   ].join(" ");
   return /\bNOPASSWD\s*:\s*ALL\b/i.test(joined) || /\bsudo\s+su\b/i.test(joined) || /\b(root\s+shell|\/bin\/bash|\/bin\/sh)\b/i.test(joined);
 }
+function listVpsPrivilegedMaintenanceCommandRegistry() {
+  return Object.values(HELPER_COMMAND_REGISTRY).map(cloneHelperCommandRegistryEntry);
+}
 function bindHelperCommandRegistry(capability) {
   const entry = HELPER_COMMAND_REGISTRY[capability.commandClass];
   if (!entry) {
@@ -65821,6 +65824,26 @@ function buildDashboardVpsMaintenanceProposalPayload({ payload, repository, rela
   const workingDirectory = normalizeText31(
     payload?.workingDirectory || payload?.working_directory || env?.VTDD_DASHBOARD_VPS_MAINTENANCE_WORKDIR
   );
+  const preset = resolveDashboardVpsMaintenanceNaturalLanguagePreset({ payload, workingDirectory });
+  if (preset) {
+    return {
+      host: normalizeText31(payload?.vpsHost || payload?.host || env?.VTDD_DASHBOARD_VPS_MAINTENANCE_HOST),
+      repository,
+      relatedIssue,
+      operation: normalizeText31(payload?.vpsOperation || payload?.operation) || preset.operation,
+      id: normalizeText31(payload?.capabilityId || payload?.id) || preset.id,
+      title: normalizeText31(payload?.capabilityTitle || payload?.title) || preset.title,
+      commandClass: normalizeText31(payload?.commandClass || payload?.command_class) || preset.commandClass,
+      riskLevel: normalizeText31(payload?.riskLevel || payload?.risk_level) || preset.riskLevel,
+      workingDirectories: Array.isArray(payload?.workingDirectories) ? payload.workingDirectories : workingDirectory ? [workingDirectory] : [],
+      allowedArgs: Array.isArray(payload?.allowedArgs) ? payload.allowedArgs : preset.allowedArgs,
+      affectedPaths: Array.isArray(payload?.affectedPaths) ? payload.affectedPaths : preset.affectedPaths,
+      redactionRules: Array.isArray(payload?.redactionRules) ? payload.redactionRules : ["no secrets", "summarize stdout/stderr", "redact tokens and credentials"],
+      rollbackPlan: normalizeText31(payload?.rollbackPlan) || "disable capability in the root-owned manifest and keep audit history",
+      expectedRuntimeTruth: Array.isArray(payload?.expectedRuntimeTruth) ? payload.expectedRuntimeTruth : ["before state", "exit code", "redacted log summary", "after state", "next action"],
+      reason: normalizeText31(payload?.reason) || `Issue #637 Dashboard Butler natural-language flow: ${preset.id} queue handoff only`
+    };
+  }
   return {
     host: normalizeText31(payload?.vpsHost || payload?.host || env?.VTDD_DASHBOARD_VPS_MAINTENANCE_HOST),
     repository,
@@ -65837,6 +65860,39 @@ function buildDashboardVpsMaintenanceProposalPayload({ payload, repository, rela
     rollbackPlan: normalizeText31(payload?.rollbackPlan) || "disable capability and keep audit history",
     expectedRuntimeTruth: Array.isArray(payload?.expectedRuntimeTruth) ? payload.expectedRuntimeTruth : ["before package check", "exit code", "after Chromium launch check"],
     reason: normalizeText31(payload?.reason) || "Issue #637 Dashboard Butler natural-language flow: queue handoff only, no root execution"
+  };
+}
+function resolveDashboardVpsMaintenanceNaturalLanguagePreset({ payload, workingDirectory } = {}) {
+  if (normalizeText31(payload?.capabilityId || payload?.id) || normalizeText31(payload?.commandClass || payload?.command_class)) {
+    return null;
+  }
+  const text = normalizeText31(payload?.text || payload?.message || payload?.ownerMessage || payload?.owner_message);
+  if (!text) return null;
+  const lower = text.toLowerCase();
+  const wantsLogs = lower.includes("logs") || lower.includes("log") || text.includes("\u30ED\u30B0");
+  const wantsRestart = lower.includes("restart") || lower.includes("\u518D\u8D77\u52D5") || text.includes("\u518D\u8D77\u52D5");
+  const wantsStatus = lower.includes("status") || lower.includes("health") || lower.includes("state") || text.includes("\u72B6\u614B") || text.includes("\u78BA\u8A8D") || text.includes("\u751F\u5B58") || text.includes("\u7A3C\u50CD");
+  const mentionsBridge = lower.includes("app-server") || lower.includes("app server") || lower.includes("bridge") || text.includes("\u30D6\u30EA\u30C3\u30B8");
+  const mentionsRunner = lower.includes("runner") || text.includes("\u30E9\u30F3\u30CA\u30FC") || text.includes("\u5B9F\u884C\u5668");
+  if (!mentionsBridge && !mentionsRunner) return null;
+  let commandClass = "";
+  if (mentionsBridge && wantsLogs) commandClass = "systemd_user_app_server_bridge_logs";
+  else if (mentionsBridge && wantsRestart) commandClass = "systemd_user_app_server_bridge_restart";
+  else if (mentionsBridge && wantsStatus) commandClass = "systemd_user_app_server_bridge_status";
+  else if (mentionsRunner && wantsLogs) commandClass = "systemd_user_runner_logs";
+  else if (mentionsRunner && wantsRestart) commandClass = "systemd_user_runner_restart";
+  else if (mentionsRunner && wantsStatus) commandClass = "systemd_user_runner_status";
+  if (!commandClass) return null;
+  const registryEntry = listVpsPrivilegedMaintenanceCommandRegistry().find((entry) => entry.commandClass === commandClass);
+  if (!registryEntry) return null;
+  return {
+    id: commandClass.replaceAll("_", "."),
+    title: registryEntry.title,
+    commandClass: registryEntry.commandClass,
+    riskLevel: registryEntry.requiredRiskLevel,
+    allowedArgs: registryEntry.allowedArgs,
+    affectedPaths: [workingDirectory, "/home/vtdd-runner/.config/systemd/user", "/run/user"].filter(Boolean),
+    operation: wantsRestart ? "enable" : "review"
   };
 }
 function buildDashboardVpsMaintenanceManifest({ helperRequest, now } = {}) {


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #637 の部分進捗です。Dashboard Butler 通常チャットの自然文 `VPS runner status` / `app-server bridge status` を、high-risk default ではなく初期 low-risk preset proposal へ接続します。
- production live E2E の前段で、owner が安全な status 確認を passkey approval 付きで通せる経路を作ります。

## Satisfied Success Criteria

- Dashboard Butler が自然文で VPS privileged maintenance intent を理解し、runner / app-server bridge の status/logs/restart intent を初期 preset に写像できる。
- 初期 preset のうち `systemd_user_runner_status` が Dashboard Butler 通常チャットから low-risk proposal として選ばれることを worker test で確認した。

## Unsatisfied Success Criteria

- production Dashboard Butler live E2E はまだ未完了です。deploy 後に Dashboard read passkey session、VPS helper proposal approval、VPS runner pickup、same Dashboard thread delivery、PWA delivery truth を確認する必要があります。
- Issue #637 全体の add/enable/disable/remove/rollback/review lifecycle completion はこの PR だけでは閉じません。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #637
- Implementing Success Criteria: Dashboard Butler natural-language intent から runner/app-server bridge の初期 preset status/logs/restart を扱えること。
- Explicit Non-goals: deploy、実 root 実行、Issue close、任意 root shell、secret/credential mutation、Action Schema 主経路化、archived wizard 変更。
- Expected touched files/routes/workflows: `src/worker/runtime.js`, `test/worker.test.js`, generated `worker.js`。route / workflow は追加しない。
- Affected Issues: Issue #637。Issue #450 / #413 は downstream evidence surface として関係するが、この PR では進捗扱いしない。
- Affected PRs: なし。
- Affected workflows: reviewer / deploy workflow は変更しない。worker generated check は影響する。
- Affected runtime/operator surfaces: Dashboard Butler 通常チャット `/v2/dashboard/chat/messages` の VPS privileged maintenance proposal payload。passkey operator の scope 表示は既存 route を使用。
- What may break if we patch narrowly: 自然文判定が広すぎると通常チャットが VPS helper proposal に誤分類される。明示的な `runner` / `app-server bridge` mention に限定して抑える。
- Unknowns to investigate before coding: production passkey prompt は mac automation で完了できないため、deploy 後の owner / real browser approval が必要。
- Validation needed: `node --test test/worker.test.js --test-name-pattern "VPS privileged maintenance intent|VPS runner status text"`、`npm run build:worker`、`npm run verify:worker`、deploy 後 production Dashboard Butler live E2E。
- Stop condition: #637 以外の UX や notification 改修に広げる、または high-risk Playwright install を owner approval なしで実行しようとする場合は停止。

## Execution Queue Delta

- Queue position before: Issue #637 は active issue execution queue の Now。
- Preemption decision: ROOT。#637 は iPhone/PWA-only privileged recovery の root blocker であり、この PR は Now を動かす bounded slice。
- Queue delta: Issue #637 Now 内で、Dashboard Butler natural-language proposal が safe status preset に到達できない gap を縮める。Issue #579/#654/#689 などは移動しない。
- Why this PR is next: production live E2E で dashboard read passkey 境界に到達し、さらに通常チャットの未指定 default が high-risk `playwright.chromium.deps` になるため、安全な live status E2E を先に成立させる必要がある。
- Active Issues not downscoped: Active Issues は縮小しない。この PR で扱わない active Issue と #637 の残り lifecycle / live E2E は未完了として残す。

## File / Line Hypotheses

- file: `src/worker/runtime.js`
  - hypothesis: `buildDashboardVpsMaintenanceProposalPayload` が payload 未指定時に常に `playwright.chromium.deps` を選ぶため、Dashboard Butler live E2E の低リスク status 確認に向かわない。
  - risk if changed narrowly: 通常チャットを誤って VPS helper proposal に流す可能性がある。
  - validation: 明示的な `runner` / `app-server bridge` mention と status/logs/restart terms のみを preset mapping し、worker test で low-risk proposal を確認する。
  - related Issue: #637
- file: `test/worker.test.js`
  - hypothesis: Dashboard Butler 自然文 `VPS runner status` が `systemd.user.runner.status` / low risk / review proposal になる regression test が必要。
  - risk if changed narrowly: PR #681 の helper queue 接続 test だけでは high-risk default drift を検出できない。
  - validation: 新規 worker test と `npm run verify:worker`。
  - related Issue: #637

## Hypothesis Retrospective

- expected: Dashboard Butler 通常チャットで `VPS runner status` と言った時、low-risk `systemd.user.runner.status` proposal が作られる。
- actual: test で `approvalScope.vpsCapabilityId=systemd.user.runner.status`、`vpsOperation=review`、proposal risk `low` を確認した。
- mismatch: なし。
- lesson: #637 live E2E の前には、高リスク default ではなく owner-facing に安全な初期 preset を自然文で選べることを固定する必要がある。
- should become RAG candidate: はい。Dashboard Butler-first の #637 live E2E では、安全な status preset を先に通す。

## Verification Evidence

- Unit: `node --test test/worker.test.js --test-name-pattern "VPS privileged maintenance intent|VPS runner status text"` pass。
- Integration: `npm run verify:worker` pass。1086 pass / 1 skipped、self-parity pass、generated-worker check pass。
- E2E: 未実施。deploy 後に production Dashboard Butler live E2E を実施する。
- Manual: #637 に dashboard read passkey boundary evidence をコメント済み。
- Evidence path/link: https://github.com/marushu/vtdd-v2-p/issues/637#issuecomment-4585423072

## Butler Completion Contract

- Primary owner surface: Dashboard Butler。
- Fallback surface: Custom GPT は fallback surface としてのみ扱う。この PR の主経路ではない。
- Owner goal: owner が Dashboard Butler 通常チャットで安全な VPS runner status 確認を依頼し、passkey approval 付き helper queue live E2E に進めること。
- Butler entrypoint: Dashboard Butler 通常チャット `/v2/dashboard/chat/messages`。
- Dashboard Butler natural-language path: Dashboard Butler の自然文通常チャットが `VPS runner status` / `app-server bridge status` を受け、初期 low-risk preset proposal へ到達する。
- Action Schema exposure: この PR では変更しない。Action Schema は主経路ではなく fallback 露出として扱う。
- Runtime path: Worker の Dashboard chat message route -> `buildDashboardVpsPrivilegedMaintenanceNaturalLanguageFlow` -> low-risk preset proposal。
- Runner/runtime truth: approval_required truth で `capabilityId=systemd.user.runner.status`、`rootExecutionStarted=false` を返す。deploy 後の runner pickup truth は未実施。
- Authority boundary: proposal 作成まで。helper queue / execution は passkey approval が必要。deploy はこの PR では行わない。
- E2E evidence: 未実施。deploy 後に production Dashboard Butler live E2E が必要。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: この PR merge 後に必要。実行には scoped passkey approval が必要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 必要。deploy 後に Dashboard read session / helper approval / VPS runner pickup / same-thread delivery を確認する。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate
- AGENTS.md Butler-First Operating Principle
- AGENTS.md Drift Stop Protocol
- docs/butler/execution-queue-contract.md
- docs/mvp/active-issue-execution-queue.md

## Out-of-scope but NOT implemented

- #637 全体 closure。
- high-risk `playwright.chromium.deps` 実行。
- passkey approval 自体の UI 修正。
- PWA notification UX の追加改修。

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #637
- Execution ID: issue-637-dashboard-status-intent
- Goal: Dashboard Butler 通常チャットから #637 low-risk status preset proposal へ到達できるようにする。
