### PR TITLE
#637 Route Dashboard VPS helper intent before app-server

### DIFF
--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -326,6 +326,19 @@ export class DashboardChatRoom {
       clientMessageId,
       messageId: ownerMessage.messageId
     });
+    const vpsMaintenanceMessages = await this.buildVpsMaintenanceIntentMessages({
+      payload,
+      threadId,
+      repository,
+      relatedIssue,
+      text,
+      now
+    });
+    if (vpsMaintenanceMessages) {
+      const butlerMessages = store ? await store.appendMany(threadId, vpsMaintenanceMessages) : vpsMaintenanceMessages;
+      await this.broadcastThread({ threadId, messages: [...messages, ...butlerMessages] });
+      return;
+    }
     await this.broadcastTransientStatus({
       threadId,
       status: "thinking",
@@ -374,6 +387,40 @@ export class DashboardChatRoom {
       trafficControl
     };
     return this.sendSocket(bridgeSocket, turnRequest);
+  }
+
+  async buildVpsMaintenanceIntentMessages({ payload, threadId, repository, relatedIssue, text, now }) {
+    if (!detectDashboardVpsPrivilegedMaintenanceIntent({ text })) {
+      return null;
+    }
+    const flow = await buildDashboardVpsPrivilegedMaintenanceNaturalLanguageFlow({
+      payload: {
+        ...normalizeObject(payload),
+        threadId,
+        repository,
+        relatedIssue,
+        issueNumber: relatedIssue,
+        text
+      },
+      repository,
+      relatedIssue,
+      origin: normalizeText(this.env?.VTDD_RUNTIME_URL || this.env?.VTDD_PASSKEY_ORIGIN) || "https://dashboard-butler.local",
+      env: this.env
+    });
+    return [
+      normalizeDashboardChatMessage(
+        {
+          threadId,
+          role: "butler",
+          repository,
+          relatedIssue,
+          status: normalizeDashboardChatStatus(flow?.messageStatus || "blocked"),
+          text: flow?.reply || buildDashboardVpsPrivilegedMaintenanceReply({ repository, relatedIssue }),
+          createdAt: new Date(Date.parse(now) + 1).toISOString()
+        },
+        { threadId }
+      )
+    ].filter(Boolean);
   }
 
   async acceptAppServerBridgeMessage({ socket, attachment, payload }) {

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -3085,6 +3085,57 @@ test("DashboardChatRoom sends ordinary owner turns to connected app-server bridg
   assert.equal(status.text, "app-server bridge の返信を待っています");
 });
 
+test("DashboardChatRoom routes VPS maintenance owner turns to Worker proposal before app-server bridge", async () => {
+  const provider = createInMemoryMemoryProvider();
+  const store = createInMemoryDashboardChatStore();
+  const dashboardSocket = createMockSocket("dashboard", "dashboard-main-marushu-vtdd-v2-p");
+  const bridgeSocket = createMockSocket("app_server_bridge", "dashboard-main-marushu-vtdd-v2-p");
+  const room = new DashboardChatRoom(
+    {
+      storage: createMockDurableObjectStorage(),
+      getWebSockets() {
+        return [dashboardSocket, bridgeSocket];
+      }
+    },
+    {
+      DASHBOARD_CHAT_STORE: store,
+      MEMORY_PROVIDER: provider,
+      VTDD_RUNTIME_URL: "https://example.com",
+      VTDD_DASHBOARD_VPS_MAINTENANCE_HOST: "x85-131-245-163",
+      VTDD_DASHBOARD_VPS_MAINTENANCE_WORKDIR: "/home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p"
+    }
+  );
+
+  await room.webSocketMessage(
+    dashboardSocket,
+    JSON.stringify({
+      type: "owner_message",
+      threadId: "dashboard-main-marushu-vtdd-v2-p",
+      repository: "marushu/vtdd-v2-p",
+      issueNumber: 637,
+      text: "Dashboard Butler から VPS runner status を確認して。root 実行は passkey 境界で止める。"
+    })
+  );
+
+  assert.equal(bridgeSocket.sent.length, 0);
+  const ack = JSON.parse(dashboardSocket.sent[1]);
+  assert.equal(ack.type, "owner_message_accepted");
+  assert.equal(ack.ok, true);
+  const finalBroadcast = JSON.parse(dashboardSocket.sent.at(-1));
+  assert.equal(finalBroadcast.type, "thread");
+  assert.equal(finalBroadcast.messages.length, 2);
+  assert.equal(finalBroadcast.messages[0].role, "owner");
+  assert.equal(finalBroadcast.messages[1].role, "butler");
+  assert.equal(finalBroadcast.messages[1].status, "blocked");
+  assert.match(finalBroadcast.messages[1].text, /approval_required/);
+  assert.match(finalBroadcast.messages[1].text, /systemd\.user\.runner\.status|approval URL/);
+
+  const records = await provider.retrieve({ type: MemoryRecordType.APPROVAL_LOG, limit: 10 });
+  const proposalRecord = records.find((record) => record.content?.kind === "vps_privileged_maintenance_approval_proposal");
+  assert.equal(proposalRecord.content.proposal.capability.id, "systemd.user.runner.status");
+  assert.equal(proposalRecord.content.proposal.capability.riskLevel, "low");
+});
+
 test("DashboardChatRoom attaches execution queue preflight to repository app-server turns", async () => {
   const provider = createInMemoryMemoryProvider();
   const store = createInMemoryDashboardChatStore();

--- a/worker.js
+++ b/worker.js
@@ -57231,6 +57231,19 @@ var DashboardChatRoom = class {
       clientMessageId,
       messageId: ownerMessage.messageId
     });
+    const vpsMaintenanceMessages = await this.buildVpsMaintenanceIntentMessages({
+      payload,
+      threadId,
+      repository,
+      relatedIssue,
+      text,
+      now
+    });
+    if (vpsMaintenanceMessages) {
+      const butlerMessages = store ? await store.appendMany(threadId, vpsMaintenanceMessages) : vpsMaintenanceMessages;
+      await this.broadcastThread({ threadId, messages: [...messages, ...butlerMessages] });
+      return;
+    }
     await this.broadcastTransientStatus({
       threadId,
       status: "thinking",
@@ -57278,6 +57291,39 @@ var DashboardChatRoom = class {
       trafficControl
     };
     return this.sendSocket(bridgeSocket, turnRequest);
+  }
+  async buildVpsMaintenanceIntentMessages({ payload, threadId, repository, relatedIssue, text, now }) {
+    if (!detectDashboardVpsPrivilegedMaintenanceIntent({ text })) {
+      return null;
+    }
+    const flow = await buildDashboardVpsPrivilegedMaintenanceNaturalLanguageFlow({
+      payload: {
+        ...normalizeObject12(payload),
+        threadId,
+        repository,
+        relatedIssue,
+        issueNumber: relatedIssue,
+        text
+      },
+      repository,
+      relatedIssue,
+      origin: normalizeText31(this.env?.VTDD_RUNTIME_URL || this.env?.VTDD_PASSKEY_ORIGIN) || "https://dashboard-butler.local",
+      env: this.env
+    });
+    return [
+      normalizeDashboardChatMessage(
+        {
+          threadId,
+          role: "butler",
+          repository,
+          relatedIssue,
+          status: normalizeDashboardChatStatus(flow?.messageStatus || "blocked"),
+          text: flow?.reply || buildDashboardVpsPrivilegedMaintenanceReply({ repository, relatedIssue }),
+          createdAt: new Date(Date.parse(now) + 1).toISOString()
+        },
+        { threadId }
+      )
+    ].filter(Boolean);
   }
   async acceptAppServerBridgeMessage({ socket, attachment, payload }) {
     const normalized = normalizeDashboardAppServerBridgeEvent(payload, {


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #637 の部分進捗です。production Dashboard Butler live evidence で、通常 UI の WebSocket 本命経路が app-server bridge に流れ、Worker の VPS helper proposal 経路に到達していないことが分かりました。
- Dashboard Butler 通常チャットの WebSocket owner turn でも、VPS privileged maintenance intent を Worker が先に扱い、low-risk `systemd.user.runner.status` proposal / `approval_required` reply を同じ Dashboard thread に保存します。

## Satisfied Success Criteria

- Dashboard Butler 通常チャットの本命 WebSocket 経路が、#637 の VPS maintenance 自然文 intent を app-server bridge へ渡す前に Worker proposal 経路へ接続する。
- `Dashboard Butler から VPS runner status を確認して。root 実行は passkey 境界で止める。` が `systemd.user.runner.status` / low risk proposal になり、app-server bridge へ送られないことを worker test で確認した。

## Unsatisfied Success Criteria

- production Dashboard Butler live E2E は deploy 後に再実行が必要です。
- passkey approval 後の helper request / helper execution queue / VPS runner pickup / same-thread runtime truth delivery はこの PR ではまだ live 実行していません。
- Issue #637 全体の add/enable/disable/remove/rollback/review lifecycle completion は未完了です。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #637
- Implementing Success Criteria: Dashboard Butler natural-language intent can reach the VPS privileged maintenance capability from the normal owner-facing chat surface.
- Explicit Non-goals: deploy、root/helper execution、Issue close、app-server bridge 全般改修、notification UX 改修、Custom GPT 主経路化、secret/credential mutation。
- Expected touched files/routes/workflows: `src/worker/runtime.js`, `test/worker.test.js`, generated `worker.js`。route / workflow は追加しない。
- Affected Issues: Issue #637。Issue #450 は app-server bridge surface と関係するが、この PR では進捗扱いしない。
- Affected PRs: PR #692 の follow-up。PR #692 は HTTP fallback 経路の status intent を接続済み。
- Affected workflows: reviewer / deploy workflow は変更しない。worker generated check は影響する。
- Affected runtime/operator surfaces: Dashboard Butler WebSocket owner turn handling in `DashboardChatRoom`。HTTP fallback handler は既存 behavior を維持。
- What may break if we patch narrowly: VPS maintenance intent を誤検出すると通常会話が app-server に届かず proposal reply になる。既存 intent detector と runner/app-server keyword 条件に限定し、ordinary conversation test を維持する。
- Unknowns to investigate before coding: deploy 後に production Dashboard Butler が実際に `approval_required` を返すか、owner read passkey session が必要。
- Validation needed: targeted worker tests, `npm run build:worker`, `npm run verify:worker`, deploy 後 production Dashboard Butler live E2E。
- Stop condition: high-risk helper execution、deploy、Issue close、または unrelated Dashboard UX fix に広げる場合は停止。

## Execution Queue Delta

- Queue position before: Issue #637 は active issue execution queue の Now。
- Preemption decision: ROOT。#637 は iPhone/PWA-only privileged recovery の root blocker であり、この PR は Now の接続不足を直す bounded slice。
- Queue delta: Issue #637 Now 内で、production live evidence により見つかった WebSocket 本命経路の unconnected gap を縮める。Issue #579/#654/#689 などは移動しない。
- Why this PR is next: deploy 後の Dashboard Butler live evidence で read-only status answer は出たが、#637 helper proposal path に入らなかった。通常 UI の本命 WebSocket 経路を先に繋がないと、production E2E が成立しない。
- Active Issues not downscoped: Active Issues は縮小しない。この PR で扱わない active Issue と #637 の残り helper queue / runner pickup / PWA delivery truth は未完了として残す。

## File / Line Hypotheses

- file: `src/worker/runtime.js`
  - hypothesis: `DashboardChatRoom.acceptOwnerMessage` は WebSocket owner turn を app-server bridge へ渡しており、HTTP fallback handler の `buildDashboardVpsPrivilegedMaintenanceNaturalLanguageFlow` が通常 UI から使われていない。
  - risk if changed narrowly: 通常会話が app-server bridge に届かなくなる。
  - validation: VPS maintenance intent の時だけ Worker proposal を返し、ordinary owner turn は app-server bridge に渡ることを tests で確認する。
  - related Issue: #637
- file: `test/worker.test.js`
  - hypothesis: connected app-server bridge がいる状態で #637 VPS maintenance owner turn を送る regression test が必要。
  - risk if changed narrowly: HTTP fallback test だけでは production UI 経路の未接続を検出できない。
  - validation: 新規 DashboardChatRoom test と `npm run verify:worker`。
  - related Issue: #637

## Hypothesis Retrospective

- expected: Dashboard Butler 通常 UI の WebSocket owner turn でも `VPS runner status` は Worker proposal 経路に入り、app-server bridge へ送られない。
- actual: test で bridge send `0`、Dashboard thread に owner + Butler `approval_required` reply、stored proposal `systemd.user.runner.status` / low risk を確認した。
- mismatch: なし。
- lesson: Dashboard Butler completion は HTTP fallback route だけでは足りず、通常 UI の WebSocket path を必ず E2E対象にする必要がある。
- should become RAG candidate: はい。#637 の drift root cause は HTTP fallback と WebSocket normal UI path の分岐。

## Verification Evidence

- Unit: `node --test test/worker.test.js --test-name-pattern "VPS maintenance owner turns|VPS runner status text|VPS privileged maintenance intent"` pass。
- Integration: `npm run verify:worker` pass。1087 pass / 1 skipped、self-parity pass、generated-worker check pass。
- E2E: 未実施。deploy 後に production Dashboard Butler live E2E を再実行する。
- Manual: owner live evidence showed read-only status answer but not helper proposal path; evidence is recorded on Issue #637.
- Evidence path/link: https://github.com/marushu/vtdd-v2-p/issues/637#issuecomment-4585453734

## Butler Completion Contract

- Primary owner surface: Dashboard Butler。
- Fallback surface: Custom GPT は fallback surface としてのみ扱う。この PR の主経路ではない。
- Owner goal: Dashboard Butler 通常チャットから #637 VPS runner status intent が Worker helper proposal path に到達し、passkey approval_required で止まること。
- Butler entrypoint: Dashboard Butler 通常チャット WebSocket owner turn。
- Dashboard Butler natural-language path: Dashboard Butler の自然文通常チャットが `VPS runner status` を受け、app-server bridge ではなく Worker の #637 proposal 経路へ到達する。
- Action Schema exposure: この PR では変更しない。Action Schema は主経路ではなく fallback 露出として扱う。
- Runtime path: DashboardChatRoom WebSocket owner_message -> Worker VPS maintenance intent detection -> `buildDashboardVpsPrivilegedMaintenanceNaturalLanguageFlow` -> same Dashboard thread reply。
- Runner/runtime truth: `approval_required` reply と stored proposal まで。runner pickup truth は deploy 後の live E2E で確認する。
- Authority boundary: proposal 作成まで。helper queue / execution は passkey approval が必要。deploy はこの PR では行わない。
- E2E evidence: 未実施。deploy 後に production Dashboard Butler live E2E が必要。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: この PR merge 後に必要。実行には scoped passkey approval が必要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 必要。deploy 後に Dashboard read session / WebSocket proposal reply / helper approval / VPS runner pickup / same-thread delivery を確認する。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate
- AGENTS.md Butler-First Operating Principle
- AGENTS.md Drift Stop Protocol
- docs/butler/execution-queue-contract.md
- docs/mvp/active-issue-execution-queue.md

## Out-of-scope but NOT implemented

- #637 全体 closure。
- high-risk `playwright.chromium.deps` 実行。
- passkey approval UI 修正。
- app-server bridge の read-only status answer 改修。
- PWA notification UX の追加改修。

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #637
- Execution ID: issue-637-websocket-helper-intent
- Goal: Dashboard Butler 通常 UI WebSocket 経路から #637 helper proposal に到達できるようにする。
