### PR TITLE
Issue #637 Dashboard VPS config preflight

### DIFF
--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -9832,7 +9832,8 @@ async function buildDashboardChatTurn(payload, options = {}) {
   const threadId =
     normalizeDashboardThreadId(input.threadId || input.thread_id) ||
     (repository ? `dashboard-main-${repository.replace("/", "-")}` : "dashboard-main-unresolved");
-  const relatedIssue = normalizePositiveInteger(input.relatedIssue || input.issueNumber);
+  const relatedIssue =
+    normalizePositiveInteger(input.relatedIssue || input.issueNumber) || extractIssueNumberFromDashboardChatText(text);
   const mediaValidation = await resolveDashboardChatMediaReferences({
     env: options.env,
     mediaReferences: input.mediaReferences || input.media_references || input.media,
@@ -9860,7 +9861,7 @@ async function buildDashboardChatTurn(payload, options = {}) {
   const hasVpsPrivilegedMaintenanceIntent = detectDashboardVpsPrivilegedMaintenanceIntent({ text });
   const vpsMaintenanceFlow = hasVpsPrivilegedMaintenanceIntent
     ? await buildDashboardVpsPrivilegedMaintenanceNaturalLanguageFlow({
-        payload: input,
+        payload: { ...input, relatedIssue, issueNumber: relatedIssue },
         repository,
         relatedIssue,
         origin: options.origin,
@@ -9935,6 +9936,39 @@ async function buildDashboardVpsPrivilegedMaintenanceNaturalLanguageFlow({
       relatedIssue,
       env
     });
+    const preflight = buildDashboardVpsMaintenanceProposalPreflight({
+      proposalPayload,
+      repository,
+      relatedIssue
+    });
+    if (!preflight.ok) {
+      return {
+        messageStatus: "blocked",
+        reply: buildDashboardVpsPrivilegedMaintenanceBlockedReply({
+          repository,
+          relatedIssue,
+          error: preflight.error,
+          reason: preflight.reason,
+          issues: preflight.issues,
+          nextAction: preflight.nextAction
+        }),
+        execution: {
+          kind: "dashboard_vps_privileged_maintenance_natural_language",
+          status: "blocked",
+          runtimeTruth: {
+            kind: "vps_privileged_maintenance_dashboard_natural_language",
+            status: preflight.status,
+            dashboardNaturalLanguagePathReached: true,
+            proposalCreated: false,
+            helperQueueReached: false,
+            missingContext: preflight.missingContext,
+            missingConfiguration: preflight.missingConfiguration,
+            rootExecutionStarted: false,
+            helperExecutionStarted: false
+          }
+        }
+      };
+    }
     const proposal = await createVpsPrivilegedMaintenanceProposal({
       payload: proposalPayload,
       provider,
@@ -10094,6 +10128,59 @@ async function buildDashboardVpsPrivilegedMaintenanceNaturalLanguageFlow({
   };
 }
 
+function buildDashboardVpsMaintenanceProposalPreflight({ proposalPayload, repository, relatedIssue } = {}) {
+  const payload = normalizeObject(proposalPayload);
+  const issues = [];
+  const missingContext = [];
+  const missingConfiguration = [];
+  const capabilityId = normalizeText(payload.id || payload.capabilityId) || "unknown capability";
+  if (!normalizeCanonicalRepositoryInput(repository || payload.repository)) {
+    missingContext.push("repository");
+    issues.push("proposal repository is required");
+  }
+  if (!normalizePositiveInteger(relatedIssue || payload.relatedIssue || payload.issueNumber)) {
+    missingContext.push("relatedIssue");
+    issues.push("relatedIssue or issueNumber is required");
+  }
+  if (!normalizeText(payload.host)) {
+    missingConfiguration.push("host");
+    issues.push("proposal host is required");
+  }
+  if (!Array.isArray(payload.workingDirectories) || payload.workingDirectories.length === 0) {
+    missingConfiguration.push("workingDirectories");
+    issues.push(`capability ${capabilityId} requires at least one working directory`);
+  }
+  if (issues.length === 0) {
+    return { ok: true };
+  }
+  const status =
+    missingContext.length > 0
+      ? "vps_privileged_maintenance_context_required"
+      : "vps_privileged_maintenance_configuration_required";
+  const nextAction = [
+    missingContext.includes("repository") ? "対象 repository を owner/repo 形式で指定してください。" : "",
+    missingContext.includes("relatedIssue") ? "関連 Issue を #番号で指定してください。" : "",
+    missingConfiguration.includes("host")
+      ? "runtime config に VTDD_DASHBOARD_VPS_MAINTENANCE_HOST を設定してください。"
+      : "",
+    missingConfiguration.includes("workingDirectories")
+      ? "runtime config に VTDD_DASHBOARD_VPS_MAINTENANCE_WORKDIR を設定してください。"
+      : ""
+  ]
+    .filter(Boolean)
+    .join(" ");
+  return {
+    ok: false,
+    status,
+    error: status,
+    reason: issues.join("; "),
+    issues,
+    missingContext,
+    missingConfiguration,
+    nextAction
+  };
+}
+
 function detectDashboardVpsPrivilegedMaintenanceIntent({ text } = {}) {
   const normalized = normalizeText(text);
   if (!normalized) return false;
@@ -10113,77 +10200,51 @@ function detectDashboardVpsPrivilegedMaintenanceIntent({ text } = {}) {
 }
 
 function buildDashboardVpsMaintenanceProposalPayload({ payload, repository, relatedIssue, env } = {}) {
-  const workingDirectory = normalizeText(
-    payload?.workingDirectory || payload?.working_directory || env?.VTDD_DASHBOARD_VPS_MAINTENANCE_WORKDIR
-  );
+  const workingDirectory = normalizeText(env?.VTDD_DASHBOARD_VPS_MAINTENANCE_WORKDIR);
   const preset = resolveDashboardVpsMaintenanceNaturalLanguagePreset({ payload, workingDirectory });
   if (preset) {
     return {
-      host: normalizeText(payload?.vpsHost || payload?.host || env?.VTDD_DASHBOARD_VPS_MAINTENANCE_HOST),
+      host: normalizeDashboardVpsMaintenanceHost({ payload, env }),
       repository,
       relatedIssue,
-      operation: normalizeText(payload?.vpsOperation || payload?.operation) || preset.operation,
-      id: normalizeText(payload?.capabilityId || payload?.id) || preset.id,
-      title: normalizeText(payload?.capabilityTitle || payload?.title) || preset.title,
-      commandClass: normalizeText(payload?.commandClass || payload?.command_class) || preset.commandClass,
-      riskLevel: normalizeText(payload?.riskLevel || payload?.risk_level) || preset.riskLevel,
-      workingDirectories: Array.isArray(payload?.workingDirectories)
-        ? payload.workingDirectories
-        : workingDirectory
-          ? [workingDirectory]
-          : [],
-      allowedArgs: Array.isArray(payload?.allowedArgs) ? payload.allowedArgs : preset.allowedArgs,
-      affectedPaths: Array.isArray(payload?.affectedPaths) ? payload.affectedPaths : preset.affectedPaths,
-      redactionRules: Array.isArray(payload?.redactionRules)
-        ? payload.redactionRules
-        : ["no secrets", "summarize stdout/stderr", "redact tokens and credentials"],
-      rollbackPlan: normalizeText(payload?.rollbackPlan) || "disable capability in the root-owned manifest and keep audit history",
-      expectedRuntimeTruth: Array.isArray(payload?.expectedRuntimeTruth)
-        ? payload.expectedRuntimeTruth
-        : ["before state", "exit code", "redacted log summary", "after state", "next action"],
-      reason:
-        normalizeText(payload?.reason) ||
-        `Issue #637 Dashboard Butler natural-language flow: ${preset.id} queue handoff only`
+      operation: preset.operation,
+      id: preset.id,
+      title: preset.title,
+      commandClass: preset.commandClass,
+      riskLevel: preset.riskLevel,
+      workingDirectories: workingDirectory ? [workingDirectory] : [],
+      allowedArgs: preset.allowedArgs,
+      affectedPaths: preset.affectedPaths,
+      redactionRules: ["no secrets", "summarize stdout/stderr", "redact tokens and credentials"],
+      rollbackPlan: "disable capability in the root-owned manifest and keep audit history",
+      expectedRuntimeTruth: ["before state", "exit code", "redacted log summary", "after state", "next action"],
+      reason: `Issue #637 Dashboard Butler natural-language flow: ${preset.id} queue handoff only`
     };
   }
   return {
-    host: normalizeText(payload?.vpsHost || payload?.host || env?.VTDD_DASHBOARD_VPS_MAINTENANCE_HOST),
+    host: normalizeDashboardVpsMaintenanceHost({ payload, env }),
     repository,
     relatedIssue,
-    operation: normalizeText(payload?.vpsOperation || payload?.operation) || "add",
-    id: normalizeText(payload?.capabilityId || payload?.id) || "playwright.chromium.deps",
-    title: normalizeText(payload?.capabilityTitle || payload?.title) || "Playwright Chromium dependency install",
-    commandClass: normalizeText(payload?.commandClass || payload?.command_class) || "playwright_install_deps_chromium",
-    riskLevel: normalizeText(payload?.riskLevel || payload?.risk_level) || "high",
-    workingDirectories: Array.isArray(payload?.workingDirectories)
-      ? payload.workingDirectories
-      : workingDirectory
-        ? [workingDirectory]
-        : [],
-    allowedArgs: Array.isArray(payload?.allowedArgs)
-      ? payload.allowedArgs
-      : ["npx playwright install-deps chromium"],
-    affectedPaths: Array.isArray(payload?.affectedPaths) ? payload.affectedPaths : ["/usr/lib", "/usr/share/fonts"],
-    redactionRules: Array.isArray(payload?.redactionRules)
-      ? payload.redactionRules
-      : ["no secrets", "summarize package list"],
-    rollbackPlan: normalizeText(payload?.rollbackPlan) || "disable capability and keep audit history",
-    expectedRuntimeTruth: Array.isArray(payload?.expectedRuntimeTruth)
-      ? payload.expectedRuntimeTruth
-      : ["before package check", "exit code", "after Chromium launch check"],
-    reason:
-      normalizeText(payload?.reason) ||
-      "Issue #637 Dashboard Butler natural-language flow: queue handoff only, no root execution"
+    operation: "add",
+    id: "playwright.chromium.deps",
+    title: "Playwright Chromium dependency install",
+    commandClass: "playwright_install_deps_chromium",
+    riskLevel: "high",
+    workingDirectories: workingDirectory ? [workingDirectory] : [],
+    allowedArgs: ["npx playwright install-deps chromium"],
+    affectedPaths: ["/usr/lib", "/usr/share/fonts"],
+    redactionRules: ["no secrets", "summarize package list"],
+    rollbackPlan: "disable capability and keep audit history",
+    expectedRuntimeTruth: ["before package check", "exit code", "after Chromium launch check"],
+    reason: "Issue #637 Dashboard Butler natural-language flow: queue handoff only, no root execution"
   };
 }
 
+function normalizeDashboardVpsMaintenanceHost({ payload, env } = {}) {
+  return normalizeText(env?.VTDD_DASHBOARD_VPS_MAINTENANCE_HOST);
+}
+
 function resolveDashboardVpsMaintenanceNaturalLanguagePreset({ payload, workingDirectory } = {}) {
-  if (
-    normalizeText(payload?.capabilityId || payload?.id) ||
-    normalizeText(payload?.commandClass || payload?.command_class)
-  ) {
-    return null;
-  }
   const text = normalizeText(payload?.text || payload?.message || payload?.ownerMessage || payload?.owner_message);
   if (!text) return null;
   const lower = text.toLowerCase();
@@ -10276,9 +10337,9 @@ function buildDashboardVpsPrivilegedMaintenanceQueuedReply({ repository, related
   ].join("\n");
 }
 
-function buildDashboardVpsPrivilegedMaintenanceBlockedReply({ repository, relatedIssue, error, reason, issues } = {}) {
+function buildDashboardVpsPrivilegedMaintenanceBlockedReply({ repository, relatedIssue, error, reason, issues, nextAction } = {}) {
   const issueText = Array.isArray(issues) && issues.length > 0 ? issues.join("; ") : reason || "blocked";
-  return [
+  const lines = [
     "Dashboard Butler の自然文 intent から VPS helper queue へ進めようとしましたが、途中で止まりました。",
     "",
     `- 対象 repo: ${repository || "未指定"}`,
@@ -10286,7 +10347,11 @@ function buildDashboardVpsPrivilegedMaintenanceBlockedReply({ repository, relate
     `- error: ${error || "unknown"}`,
     `- reason: ${issueText}`,
     "- runtime truth: rootExecutionStarted=false, helperExecutionStarted=false"
-  ].join("\n");
+  ];
+  if (nextAction) {
+    lines.push(`- next action: ${nextAction}`);
+  }
+  return lines.join("\n");
 }
 
 function buildDashboardVpsPrivilegedMaintenanceReply({ repository, relatedIssue } = {}) {

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -2638,6 +2638,12 @@ test("worker maps Dashboard Butler VPS runner status text to the low-risk preset
         threadId: "dashboard-main-marushu-vtdd-v2-p",
         repository: "marushu/vtdd-v2-p",
         issueNumber: 637,
+        vpsOperation: "add",
+        capabilityId: "playwright.chromium.deps",
+        commandClass: "playwright_install_deps_chromium",
+        riskLevel: "high",
+        workingDirectories: ["/tmp/owner-chat-workdir"],
+        allowedArgs: ["npx playwright install-deps chromium"],
         text: "Dashboard Butler から VPS runner status を確認して。root 実行は passkey 境界で止める。"
       })
     }),
@@ -2666,6 +2672,130 @@ test("worker maps Dashboard Butler VPS runner status text to the low-risk preset
   assert.deepEqual(proposalRecord.content.proposal.capability.allowedArgs, [
     "systemctl --user is-active vtdd-vps-runner.timer vtdd-vps-runner.service"
   ]);
+});
+
+test("worker reports Dashboard VPS maintenance config blockers before creating a proposal", async () => {
+  const store = createInMemoryDashboardChatStore();
+  const provider = createInMemoryMemoryProvider();
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/dashboard/chat/messages", {
+      method: "POST",
+      headers: gatewayAuthHeaders,
+      body: JSON.stringify({
+        threadId: "dashboard-main-marushu-vtdd-v2-p",
+        repository: "marushu/vtdd-v2-p",
+        text: "Dashboard Butler から VPS runner status を確認して。root 実行は passkey 境界で止める。"
+      })
+    }),
+    {
+      ...gatewayAuthEnv,
+      DASHBOARD_CHAT_STORE: store,
+      MEMORY_PROVIDER: provider
+    }
+  );
+
+  assert.equal(response.status, 202);
+  const body = await response.json();
+  assert.equal(body.ok, true);
+  assert.equal(body.execution.status, "blocked");
+  assert.equal(body.execution.runtimeTruth.status, "vps_privileged_maintenance_context_required");
+  assert.equal(body.execution.runtimeTruth.dashboardNaturalLanguagePathReached, true);
+  assert.equal(body.execution.runtimeTruth.proposalCreated, false);
+  assert.deepEqual(body.execution.runtimeTruth.missingContext, ["relatedIssue"]);
+  assert.deepEqual(body.execution.runtimeTruth.missingConfiguration, ["host", "workingDirectories"]);
+  assert.match(body.messages[1].text, /関連 Issue: 未指定/);
+  assert.match(body.messages[1].text, /relatedIssue or issueNumber is required/);
+  assert.match(body.messages[1].text, /VTDD_DASHBOARD_VPS_MAINTENANCE_HOST/);
+  assert.match(body.messages[1].text, /rootExecutionStarted=false/);
+
+  const records = await provider.retrieve({ type: MemoryRecordType.APPROVAL_LOG, limit: 10 });
+  assert.equal(records.length, 0);
+});
+
+test("worker uses only Dashboard maintenance runtime config for privileged maintenance proposals", async () => {
+  const store = createInMemoryDashboardChatStore();
+  const provider = createInMemoryMemoryProvider();
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/dashboard/chat/messages", {
+      method: "POST",
+      headers: gatewayAuthHeaders,
+      body: JSON.stringify({
+        threadId: "dashboard-main-marushu-vtdd-v2-p",
+        repository: "marushu/vtdd-v2-p",
+        issueNumber: 637,
+        vpsHost: "owner-chat-host",
+        workingDirectory: "/tmp/owner-chat-workdir",
+        text: "Dashboard Butler から VPS runner status を確認して。root 実行は passkey 境界で止める。"
+      })
+    }),
+    {
+      ...gatewayAuthEnv,
+      DASHBOARD_CHAT_STORE: store,
+      MEMORY_PROVIDER: provider,
+      VTDD_VPS_RUNNER_HOST: "generic-runner-host",
+      VTDD_VPS_RUNNER_WORKDIR: "/home/vtdd-runner/generic-runner-workdir",
+      VTDD_VPS_MAINTENANCE_HOST: "generic-maintenance-host",
+      VTDD_VPS_MAINTENANCE_WORKDIR: "/home/vtdd-runner/generic-maintenance-workdir"
+    }
+  );
+
+  assert.equal(response.status, 202);
+  const body = await response.json();
+  assert.equal(body.execution.status, "blocked");
+  assert.equal(body.execution.runtimeTruth.status, "vps_privileged_maintenance_configuration_required");
+  assert.deepEqual(body.execution.runtimeTruth.missingConfiguration, ["host", "workingDirectories"]);
+  assert.match(body.messages[1].text, /VTDD_DASHBOARD_VPS_MAINTENANCE_HOST/);
+  assert.doesNotMatch(
+    body.messages[1].text,
+    /VTDD_VPS_RUNNER_HOST|VTDD_VPS_RUNNER_WORKDIR|VTDD_VPS_MAINTENANCE_HOST|VTDD_VPS_MAINTENANCE_WORKDIR|owner-chat-host|owner-chat-workdir/
+  );
+
+  const records = await provider.retrieve({ type: MemoryRecordType.APPROVAL_LOG, limit: 10 });
+  assert.equal(records.length, 0);
+});
+
+test("DashboardChatRoom keeps VPS maintenance intent in Worker path when repo and config are missing", async () => {
+  const provider = createInMemoryMemoryProvider();
+  const store = createInMemoryDashboardChatStore();
+  const dashboardSocket = createMockSocket("dashboard", "dashboard-main-unresolved");
+  const bridgeSocket = createMockSocket("app_server_bridge", "dashboard-main-unresolved");
+  const room = new DashboardChatRoom(
+    {
+      storage: createMockDurableObjectStorage(),
+      getWebSockets() {
+        return [dashboardSocket, bridgeSocket];
+      }
+    },
+    {
+      DASHBOARD_CHAT_STORE: store,
+      MEMORY_PROVIDER: provider,
+      VTDD_RUNTIME_URL: "https://example.com"
+    }
+  );
+
+  await room.webSocketMessage(
+    dashboardSocket,
+    JSON.stringify({
+      type: "owner_message",
+      threadId: "dashboard-main-unresolved",
+      text: "Dashboard Butler から VPS runner status を確認して。root 実行は passkey 境界で止める。"
+    })
+  );
+
+  assert.equal(bridgeSocket.sent.length, 0);
+  const finalBroadcast = JSON.parse(dashboardSocket.sent.at(-1));
+  assert.equal(finalBroadcast.type, "thread");
+  assert.equal(finalBroadcast.messages.length, 2);
+  assert.equal(finalBroadcast.messages[1].role, "butler");
+  assert.equal(finalBroadcast.messages[1].status, "blocked");
+  assert.match(finalBroadcast.messages[1].text, /対象 repo: 未指定/);
+  assert.match(finalBroadcast.messages[1].text, /関連 Issue: 未指定/);
+  assert.match(finalBroadcast.messages[1].text, /proposal repository is required/);
+  assert.match(finalBroadcast.messages[1].text, /relatedIssue or issueNumber is required/);
+  assert.match(finalBroadcast.messages[1].text, /VTDD_DASHBOARD_VPS_MAINTENANCE_WORKDIR/);
+
+  const records = await provider.retrieve({ type: MemoryRecordType.APPROVAL_LOG, limit: 10 });
+  assert.equal(records.length, 0);
 });
 
 test("worker allows dashboard passkey session chat without VPS runner handoff", async () => {

--- a/worker.js
+++ b/worker.js
@@ -65612,7 +65612,7 @@ async function buildDashboardChatTurn(payload, options = {}) {
     };
   }
   const threadId = normalizeDashboardThreadId(input.threadId || input.thread_id) || (repository ? `dashboard-main-${repository.replace("/", "-")}` : "dashboard-main-unresolved");
-  const relatedIssue = normalizePositiveInteger10(input.relatedIssue || input.issueNumber);
+  const relatedIssue = normalizePositiveInteger10(input.relatedIssue || input.issueNumber) || extractIssueNumberFromDashboardChatText(text);
   const mediaValidation = await resolveDashboardChatMediaReferences({
     env: options.env,
     mediaReferences: input.mediaReferences || input.media_references || input.media,
@@ -65639,7 +65639,7 @@ async function buildDashboardChatTurn(payload, options = {}) {
   );
   const hasVpsPrivilegedMaintenanceIntent = detectDashboardVpsPrivilegedMaintenanceIntent({ text });
   const vpsMaintenanceFlow = hasVpsPrivilegedMaintenanceIntent ? await buildDashboardVpsPrivilegedMaintenanceNaturalLanguageFlow({
-    payload: input,
+    payload: { ...input, relatedIssue, issueNumber: relatedIssue },
     repository,
     relatedIssue,
     origin: options.origin,
@@ -65708,6 +65708,39 @@ async function buildDashboardVpsPrivilegedMaintenanceNaturalLanguageFlow({
       relatedIssue,
       env
     });
+    const preflight = buildDashboardVpsMaintenanceProposalPreflight({
+      proposalPayload,
+      repository,
+      relatedIssue
+    });
+    if (!preflight.ok) {
+      return {
+        messageStatus: "blocked",
+        reply: buildDashboardVpsPrivilegedMaintenanceBlockedReply({
+          repository,
+          relatedIssue,
+          error: preflight.error,
+          reason: preflight.reason,
+          issues: preflight.issues,
+          nextAction: preflight.nextAction
+        }),
+        execution: {
+          kind: "dashboard_vps_privileged_maintenance_natural_language",
+          status: "blocked",
+          runtimeTruth: {
+            kind: "vps_privileged_maintenance_dashboard_natural_language",
+            status: preflight.status,
+            dashboardNaturalLanguagePathReached: true,
+            proposalCreated: false,
+            helperQueueReached: false,
+            missingContext: preflight.missingContext,
+            missingConfiguration: preflight.missingConfiguration,
+            rootExecutionStarted: false,
+            helperExecutionStarted: false
+          }
+        }
+      };
+    }
     const proposal = await createVpsPrivilegedMaintenanceProposal({
       payload: proposalPayload,
       provider,
@@ -65858,6 +65891,49 @@ async function buildDashboardVpsPrivilegedMaintenanceNaturalLanguageFlow({
     }
   };
 }
+function buildDashboardVpsMaintenanceProposalPreflight({ proposalPayload, repository, relatedIssue } = {}) {
+  const payload = normalizeObject12(proposalPayload);
+  const issues = [];
+  const missingContext = [];
+  const missingConfiguration = [];
+  const capabilityId = normalizeText31(payload.id || payload.capabilityId) || "unknown capability";
+  if (!normalizeCanonicalRepositoryInput(repository || payload.repository)) {
+    missingContext.push("repository");
+    issues.push("proposal repository is required");
+  }
+  if (!normalizePositiveInteger10(relatedIssue || payload.relatedIssue || payload.issueNumber)) {
+    missingContext.push("relatedIssue");
+    issues.push("relatedIssue or issueNumber is required");
+  }
+  if (!normalizeText31(payload.host)) {
+    missingConfiguration.push("host");
+    issues.push("proposal host is required");
+  }
+  if (!Array.isArray(payload.workingDirectories) || payload.workingDirectories.length === 0) {
+    missingConfiguration.push("workingDirectories");
+    issues.push(`capability ${capabilityId} requires at least one working directory`);
+  }
+  if (issues.length === 0) {
+    return { ok: true };
+  }
+  const status = missingContext.length > 0 ? "vps_privileged_maintenance_context_required" : "vps_privileged_maintenance_configuration_required";
+  const nextAction = [
+    missingContext.includes("repository") ? "\u5BFE\u8C61 repository \u3092 owner/repo \u5F62\u5F0F\u3067\u6307\u5B9A\u3057\u3066\u304F\u3060\u3055\u3044\u3002" : "",
+    missingContext.includes("relatedIssue") ? "\u95A2\u9023 Issue \u3092 #\u756A\u53F7\u3067\u6307\u5B9A\u3057\u3066\u304F\u3060\u3055\u3044\u3002" : "",
+    missingConfiguration.includes("host") ? "runtime config \u306B VTDD_DASHBOARD_VPS_MAINTENANCE_HOST \u3092\u8A2D\u5B9A\u3057\u3066\u304F\u3060\u3055\u3044\u3002" : "",
+    missingConfiguration.includes("workingDirectories") ? "runtime config \u306B VTDD_DASHBOARD_VPS_MAINTENANCE_WORKDIR \u3092\u8A2D\u5B9A\u3057\u3066\u304F\u3060\u3055\u3044\u3002" : ""
+  ].filter(Boolean).join(" ");
+  return {
+    ok: false,
+    status,
+    error: status,
+    reason: issues.join("; "),
+    issues,
+    missingContext,
+    missingConfiguration,
+    nextAction
+  };
+}
 function detectDashboardVpsPrivilegedMaintenanceIntent({ text } = {}) {
   const normalized = normalizeText31(text);
   if (!normalized) return false;
@@ -65867,51 +65943,49 @@ function detectDashboardVpsPrivilegedMaintenanceIntent({ text } = {}) {
   return hasVpsMaintenance || hasJapaneseMaintenance;
 }
 function buildDashboardVpsMaintenanceProposalPayload({ payload, repository, relatedIssue, env } = {}) {
-  const workingDirectory = normalizeText31(
-    payload?.workingDirectory || payload?.working_directory || env?.VTDD_DASHBOARD_VPS_MAINTENANCE_WORKDIR
-  );
+  const workingDirectory = normalizeText31(env?.VTDD_DASHBOARD_VPS_MAINTENANCE_WORKDIR);
   const preset = resolveDashboardVpsMaintenanceNaturalLanguagePreset({ payload, workingDirectory });
   if (preset) {
     return {
-      host: normalizeText31(payload?.vpsHost || payload?.host || env?.VTDD_DASHBOARD_VPS_MAINTENANCE_HOST),
+      host: normalizeDashboardVpsMaintenanceHost({ payload, env }),
       repository,
       relatedIssue,
-      operation: normalizeText31(payload?.vpsOperation || payload?.operation) || preset.operation,
-      id: normalizeText31(payload?.capabilityId || payload?.id) || preset.id,
-      title: normalizeText31(payload?.capabilityTitle || payload?.title) || preset.title,
-      commandClass: normalizeText31(payload?.commandClass || payload?.command_class) || preset.commandClass,
-      riskLevel: normalizeText31(payload?.riskLevel || payload?.risk_level) || preset.riskLevel,
-      workingDirectories: Array.isArray(payload?.workingDirectories) ? payload.workingDirectories : workingDirectory ? [workingDirectory] : [],
-      allowedArgs: Array.isArray(payload?.allowedArgs) ? payload.allowedArgs : preset.allowedArgs,
-      affectedPaths: Array.isArray(payload?.affectedPaths) ? payload.affectedPaths : preset.affectedPaths,
-      redactionRules: Array.isArray(payload?.redactionRules) ? payload.redactionRules : ["no secrets", "summarize stdout/stderr", "redact tokens and credentials"],
-      rollbackPlan: normalizeText31(payload?.rollbackPlan) || "disable capability in the root-owned manifest and keep audit history",
-      expectedRuntimeTruth: Array.isArray(payload?.expectedRuntimeTruth) ? payload.expectedRuntimeTruth : ["before state", "exit code", "redacted log summary", "after state", "next action"],
-      reason: normalizeText31(payload?.reason) || `Issue #637 Dashboard Butler natural-language flow: ${preset.id} queue handoff only`
+      operation: preset.operation,
+      id: preset.id,
+      title: preset.title,
+      commandClass: preset.commandClass,
+      riskLevel: preset.riskLevel,
+      workingDirectories: workingDirectory ? [workingDirectory] : [],
+      allowedArgs: preset.allowedArgs,
+      affectedPaths: preset.affectedPaths,
+      redactionRules: ["no secrets", "summarize stdout/stderr", "redact tokens and credentials"],
+      rollbackPlan: "disable capability in the root-owned manifest and keep audit history",
+      expectedRuntimeTruth: ["before state", "exit code", "redacted log summary", "after state", "next action"],
+      reason: `Issue #637 Dashboard Butler natural-language flow: ${preset.id} queue handoff only`
     };
   }
   return {
-    host: normalizeText31(payload?.vpsHost || payload?.host || env?.VTDD_DASHBOARD_VPS_MAINTENANCE_HOST),
+    host: normalizeDashboardVpsMaintenanceHost({ payload, env }),
     repository,
     relatedIssue,
-    operation: normalizeText31(payload?.vpsOperation || payload?.operation) || "add",
-    id: normalizeText31(payload?.capabilityId || payload?.id) || "playwright.chromium.deps",
-    title: normalizeText31(payload?.capabilityTitle || payload?.title) || "Playwright Chromium dependency install",
-    commandClass: normalizeText31(payload?.commandClass || payload?.command_class) || "playwright_install_deps_chromium",
-    riskLevel: normalizeText31(payload?.riskLevel || payload?.risk_level) || "high",
-    workingDirectories: Array.isArray(payload?.workingDirectories) ? payload.workingDirectories : workingDirectory ? [workingDirectory] : [],
-    allowedArgs: Array.isArray(payload?.allowedArgs) ? payload.allowedArgs : ["npx playwright install-deps chromium"],
-    affectedPaths: Array.isArray(payload?.affectedPaths) ? payload.affectedPaths : ["/usr/lib", "/usr/share/fonts"],
-    redactionRules: Array.isArray(payload?.redactionRules) ? payload.redactionRules : ["no secrets", "summarize package list"],
-    rollbackPlan: normalizeText31(payload?.rollbackPlan) || "disable capability and keep audit history",
-    expectedRuntimeTruth: Array.isArray(payload?.expectedRuntimeTruth) ? payload.expectedRuntimeTruth : ["before package check", "exit code", "after Chromium launch check"],
-    reason: normalizeText31(payload?.reason) || "Issue #637 Dashboard Butler natural-language flow: queue handoff only, no root execution"
+    operation: "add",
+    id: "playwright.chromium.deps",
+    title: "Playwright Chromium dependency install",
+    commandClass: "playwright_install_deps_chromium",
+    riskLevel: "high",
+    workingDirectories: workingDirectory ? [workingDirectory] : [],
+    allowedArgs: ["npx playwright install-deps chromium"],
+    affectedPaths: ["/usr/lib", "/usr/share/fonts"],
+    redactionRules: ["no secrets", "summarize package list"],
+    rollbackPlan: "disable capability and keep audit history",
+    expectedRuntimeTruth: ["before package check", "exit code", "after Chromium launch check"],
+    reason: "Issue #637 Dashboard Butler natural-language flow: queue handoff only, no root execution"
   };
 }
+function normalizeDashboardVpsMaintenanceHost({ payload, env } = {}) {
+  return normalizeText31(env?.VTDD_DASHBOARD_VPS_MAINTENANCE_HOST);
+}
 function resolveDashboardVpsMaintenanceNaturalLanguagePreset({ payload, workingDirectory } = {}) {
-  if (normalizeText31(payload?.capabilityId || payload?.id) || normalizeText31(payload?.commandClass || payload?.command_class)) {
-    return null;
-  }
   const text = normalizeText31(payload?.text || payload?.message || payload?.ownerMessage || payload?.owner_message);
   if (!text) return null;
   const lower = text.toLowerCase();
@@ -65987,9 +66061,9 @@ function buildDashboardVpsPrivilegedMaintenanceQueuedReply({ repository, related
     "VPS runner pickup \u306E\u5B8C\u4E86 truth \u304C\u623B\u308B\u307E\u3067\u3001live root \u5B9F\u884C\u5B8C\u4E86\u3068\u306F\u6271\u3044\u307E\u305B\u3093\u3002"
   ].join("\n");
 }
-function buildDashboardVpsPrivilegedMaintenanceBlockedReply({ repository, relatedIssue, error: error2, reason, issues } = {}) {
+function buildDashboardVpsPrivilegedMaintenanceBlockedReply({ repository, relatedIssue, error: error2, reason, issues, nextAction } = {}) {
   const issueText = Array.isArray(issues) && issues.length > 0 ? issues.join("; ") : reason || "blocked";
-  return [
+  const lines = [
     "Dashboard Butler \u306E\u81EA\u7136\u6587 intent \u304B\u3089 VPS helper queue \u3078\u9032\u3081\u3088\u3046\u3068\u3057\u307E\u3057\u305F\u304C\u3001\u9014\u4E2D\u3067\u6B62\u307E\u308A\u307E\u3057\u305F\u3002",
     "",
     `- \u5BFE\u8C61 repo: ${repository || "\u672A\u6307\u5B9A"}`,
@@ -65997,7 +66071,11 @@ function buildDashboardVpsPrivilegedMaintenanceBlockedReply({ repository, relate
     `- error: ${error2 || "unknown"}`,
     `- reason: ${issueText}`,
     "- runtime truth: rootExecutionStarted=false, helperExecutionStarted=false"
-  ].join("\n");
+  ];
+  if (nextAction) {
+    lines.push(`- next action: ${nextAction}`);
+  }
+  return lines.join("\n");
 }
 function buildDashboardVpsPrivilegedMaintenanceReply({ repository, relatedIssue } = {}) {
   const repoPhrase = repository ? `\u5BFE\u8C61 repo: ${repository}` : "\u5BFE\u8C61 repo: \u672A\u6307\u5B9A";


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #637 の部分進捗です。
- PR #693 deploy 後の production Dashboard Butler live E2E で、自然文 intent は Worker の VPS helper proposal path に入ったが、repository / host / working directory 欠落で `vps_privileged_maintenance_proposal_invalid` になった実測 gap を扱います。
- Dashboard Butler 通常チャットが VPS runner status intent を受けた時、proposal 作成前に context/config blocker を owner-facing に返し、root/helper 未開始 truth を明示します。

## Satisfied Success Criteria

- Dashboard Butler が自然文で VPS privileged maintenance intent を理解し、root/sudo が必要な操作を owner-facing に説明できる、の一部。
- proposal に必要な repository / related Issue / host / working directory 欠落を、helper request や root 実行前に `vps_privileged_maintenance_configuration_required` / `vps_privileged_maintenance_context_required` として止める。
- Issue 未指定の場合は #637 に自動補完せず、`relatedIssue or issueNumber is required` として止める。

## Unsatisfied Success Criteria

- production Dashboard Butler live E2E で `approval_required` / `systemd.user.runner.status` proposal が出るには、runtime config の host / working directory 水和がまだ必要です。
- passkey approval 後の helper request / VPS runner queue pickup / root-owned helper execution / same-thread runtime truth は、このPRでは未実施です。
- Issue #637 は close しません。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #637
- Implementing Success Criteria: Dashboard Butler 自然文 intent が helper proposal path に入った後、repo/Issue/config 欠落を proposal 作成前に owner-facing blocker として返す。
- Explicit Non-goals: root/helper 実行、Cloudflare var/secret 変更、deploy、Issue close、owner 固有 host/workdir の public source 埋め込み。
- Expected touched files/routes/workflows: `src/worker/runtime.js`, `worker.js`, `test/worker.test.js`。GitHub Actions / deploy workflow は変更しません。
- Affected Issues: Issue #637。Issue #450 / #413 は runtime truth 観測の隣接影響のみで、このPRの実装 scope には含めません。
- Affected PRs: PR #693 の production E2E follow-up。既存 PR は更新しません。
- Affected workflows: local `npm run verify:worker` のみ。reviewer / deploy は PR 後の通常 gate に任せます。
- Affected runtime/operator surfaces: Dashboard Butler 通常チャット、Worker の VPS privileged maintenance proposal preflight、passkey approval 前の owner-facing blocked reply。
- What may break if we patch narrowly: repository 未指定を勝手に VTDD repo へ寄せると no-default-repository invariant を壊すため、repo は補完せず blocker として残します。
- Unknowns to investigate before coding: production runtime に host/workdir var が存在するか。GitHub Variables/Secrets 名だけ確認し、該当 config は未設定でした。
- Validation needed: targeted worker tests、generated worker build、`npm run verify:worker`。
- Stop condition: owner 固有 VPS host/workdir を public source に埋め込む必要が出た場合は停止し、passkey/config 境界へ戻す。

## Execution Queue Delta

- Queue position before: Issue #637 は durable queue の Now です。
- Preemption decision: EVIDENCE。PR #693 deploy 後の live E2E で出た evidence gap の補修で、Now を動かしません。
- Queue delta: Issue #637 の Dashboard Butler natural-language -> helper proposal path を一段進めます。runtime config 未設定は Blocked / config boundary として残ります。
- Why this PR is next: 本番で既に `vps_privileged_maintenance_proposal_invalid` が出ており、次の live E2E を正しく判断するために Butler が blocker を構造化して返す必要があります。
- Active Issues not downscoped: Active Issues は縮小しません。このPRで扱わない #637 criteria と他 active Issue は未完了として残します。

## File / Line Hypotheses

- file: `src/worker/runtime.js`
  - hypothesis: `buildDashboardVpsPrivilegedMaintenanceNaturalLanguageFlow` は proposal 作成前に context/config preflight を持たないため、Dashboard Butler が raw invalid に近い blocker を返す。
  - risk if changed narrowly: app-server bridge や通常チャット全体へ #637 補完を広げると、別 repo / 別 thread の文脈を汚す。
  - validation: Dashboard HTTP chat と DashboardChatRoom WebSocket の両方で、proposal 未作成・bridge 未dispatch・root/helper 未開始をテストする。
  - related Issue: #637
- file: `test/worker.test.js`
  - hypothesis: config 未設定時の owner-facing blocker と proposal 未作成を固定する regression test が必要。
  - risk if changed narrowly: positive path `systemd.user.runner.status` proposal を壊す。
  - validation: positive path と missing-config path を同じ targeted test group で通す。
  - related Issue: #637

## Hypothesis Retrospective

- expected: production で出た `proposal host is required` / `working directory required` を proposal 作成前の configuration blocker として返す。
- actual: local tests で HTTP chat と WebSocket chat の両方が configuration/context blocker を返し、approval proposal record を作らないことを確認した。
- mismatch: production runtime config 自体はこのPRでは設定していないため、deploy 後も config 未設定なら次の live E2E は configuration_required で止まる。
- lesson: #637 の自然文 route は到達済み。次は host/workdir を安全に水和する runtime config 境界が必要。
- should become RAG candidate: yes。Dashboard Butler helper proposal path は到達済みだが、public source に owner 固有 host/workdir を埋めず、runtime config として扱う。

## Verification Evidence

- Unit: `node --test test/worker.test.js --test-name-pattern "Dashboard VPS maintenance config blockers|repo and config are missing|VPS runner status text|VPS maintenance owner turns"` pass。
- Integration: `npm run verify:worker` pass。tests: 1090、pass: 1089、skipped: 1。self-parity pass。generated-worker check pass。
- E2E: production live E2E はこのPR deploy 後に必要。現時点では未実施。
- Manual: `gh variable list` / `gh secret list` の名前確認で Dashboard VPS maintenance host/workdir config 名は未確認、該当 var/secret 名なし。review 指摘後、generic env、payload の host/workdir、payload の capability/operation 差し替えは Dashboard privileged maintenance proposal の fallback として使わないことを追加テストで固定。
- Evidence path/link: このPR本文と Issue #637 の既存 production evidence comments。

## Butler Completion Contract

- Primary owner surface: Dashboard Butler。
- Fallback surface: Custom GPT はフォールバック surface として扱います。主経路ではありません。
- Owner goal: Dashboard Butler 通常チャットから VPS runner status helper proposal に進む際、欠落 context/config を自然文で理解できる blocker として返す。
- Butler entrypoint: Dashboard Butler 通常チャットで `VPS runner status` 系自然文を送る入口。
- Dashboard Butler natural-language path: Dashboard Butler 通常チャットの自然文 intent が Worker の VPS privileged maintenance preflight へ到達し、proposal 作成前の blocker を返します。
- Action Schema exposure: Custom GPT fallback 用の露出はこのPRでは未変更。主経路とは扱いません。
- Runtime path: Dashboard WebSocket owner turn / HTTP dashboard chat -> Worker natural-language VPS maintenance flow -> proposal preflight -> blocked reply。
- Runner/runtime truth: `dashboardNaturalLanguagePathReached=true`, `proposalCreated=false`, `helperQueueReached=false`, `rootExecutionStarted=false`, `helperExecutionStarted=false` を返す。
- Authority boundary: passkey approval 前。root/helper 実行、deploy、config mutation は行いません。
- E2E evidence: production Dashboard Butler live E2E は deploy 後に必要。このPR時点では未実施です。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: PR merge 後に必要。Worker runtime 変更のため production Dashboard Butler live E2E 前に deploy が必要です。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 必要。deploy 後、同じ Dashboard Butler prompt で `configuration_required` または config 済みなら `approval_required` を確認する。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate
- AGENTS.md Butler-First Operating Principle
- AGENTS.md Drift Stop Protocol
- AGENTS.md Authority Boundary
- docs/butler/execution-queue-contract.md

## Out-of-scope but NOT implemented

- production runtime config の maintenance 専用 host/workdir 設定。
- passkey approval 後の helper request / execution queue / VPS runner pickup。
- root-owned helper の実行。
- Issue #637 の close。

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #637
- Execution ID: codex-issue-637-dashboard-vps-config-preflight
- Goal: Dashboard Butler #637 natural-language helper proposal preflight を owner-facing blocker にする
