### PR TITLE
#637 variable sync を passkey-only proposal flow に寄せる

### DIFF
--- a/src/core/passkey-approval.js
+++ b/src/core/passkey-approval.js
@@ -422,6 +422,8 @@ export function normalizeScopeSnapshot(scope = {}) {
     pullNumber: normalizeText(scope.pullNumber),
     relatedIssue: normalizeText(scope.relatedIssue),
     phase: normalizeText(scope.phase),
+    secretName: normalizeText(scope.secretName),
+    variableName: normalizeText(scope.variableName),
     vpsProposalId: normalizeText(scope.vpsProposalId),
     vpsHost: normalizeText(scope.vpsHost),
     vpsOperation: normalizeText(scope.vpsOperation),

--- a/src/core/passkey-operator-page.js
+++ b/src/core/passkey-operator-page.js
@@ -24,6 +24,10 @@ export function renderPasskeyOperatorPage(input = {}) {
   const dashboardReturnPath = escapeHtml(sanitizePasskeyDashboardReturnPath(input.dashboardReturnPath));
   const dashboardNotificationMode = dashboardMode && dashboardReturnPath === "/dashboard/notifications";
   const githubAppRoleDefault = escapeHtml(input.githubAppRole || "legacy");
+  const githubActionsVariableProposalId = escapeHtml(String(input.githubActionsVariableProposalId || "").trim());
+  const githubActionsVariableProposalName = escapeHtml(String(input.githubActionsVariableProposalName || "").trim());
+  const githubActionsVariableProposalMode =
+    operatorMode === "github_actions_variable_sync" && Boolean(githubActionsVariableProposalId);
   const vpsScope = {
     vpsProposalId: String(input.vpsProposalId || "").trim(),
     vpsHost: String(input.vpsHost || "").trim(),
@@ -384,17 +388,23 @@ export function renderPasskeyOperatorPage(input = {}) {
         <section data-operator-section="github-actions-variable-sync"${hiddenAttribute(!sectionVisibility.githubActionsVariableSync)}>
           <h2>8. GitHub Actions Variable Sync</h2>
           <p class="muted">Dashboard VPS maintenance の production deploy へ渡す GitHub Actions repository variable を同期します。値は Butler 会話、GitHub コメント、RAG、レスポンス本文に表示しません。</p>
-          <label for="github-actions-variable-name-input">Variable name</label>
+          ${githubActionsVariableProposalMode
+            ? `<p><strong>承認対象:</strong> ${githubActionsVariableProposalName || "GitHub Actions variable"}</p>
+          <p class="muted">このページでは値を入力しません。passkey approval が成功すると、Butler が作成した proposal の値を使って自動同期します。</p>
+          <input id="github-actions-variable-name-input" type="hidden" value="${githubActionsVariableProposalName}" />
+          <input id="github-actions-variable-value-input" type="password" autocomplete="off" hidden />`
+            : `<label for="github-actions-variable-name-input">Variable name</label>
           <select id="github-actions-variable-name-input">
             <option value="VTDD_DASHBOARD_VPS_MAINTENANCE_HOST">VTDD_DASHBOARD_VPS_MAINTENANCE_HOST</option>
             <option value="VTDD_DASHBOARD_VPS_MAINTENANCE_WORKDIR">VTDD_DASHBOARD_VPS_MAINTENANCE_WORKDIR</option>
           </select>
+          <p class="muted">Variable name は passkey approval scope に固定されます。承認後に variable を変更した場合は、もう一度 passkey approval が必要です。</p>
           <label for="github-actions-variable-value-input">Variable value</label>
           <input id="github-actions-variable-value-input" type="password" autocomplete="off" placeholder="value..." />
           <div class="row">
             <button id="github-actions-variable-sync-button">Sync GitHub Actions variable</button>
-          </div>
-          <p class="muted"><code>actionType=destructive</code> / <code>highRiskKind=github_actions_variable_sync</code> の approvalGrantId が必要です。</p>
+          </div>`}
+          <p class="muted"><code>actionType=destructive</code> / <code>highRiskKind=github_actions_variable_sync</code> の passkey approval が必要です。</p>
           <pre id="github-actions-variable-sync-output"></pre>
         </section>
 
@@ -438,6 +448,8 @@ export function renderPasskeyOperatorPage(input = {}) {
       const issueCloseLink = document.getElementById("issue-close-link");
       const operatorMode = "${escapeHtml(operatorMode)}";
       const vpsApprovalScope = ${safeScriptJson(vpsScope)};
+      const githubActionsVariableProposalId = "${githubActionsVariableProposalId}";
+      const githubActionsVariableProposalMode = ${githubActionsVariableProposalMode ? "true" : "false"};
       let latestApprovalGrantId = "";
       let latestApprovalGrant = null;
 
@@ -497,6 +509,32 @@ export function renderPasskeyOperatorPage(input = {}) {
           return null;
         }
         return document.getElementById("github-actions-variable-name-input").value;
+      }
+
+      function clearGithubActionsVariableApprovalGrant(reason) {
+        if (operatorMode !== "github_actions_variable_sync") {
+          return;
+        }
+        if (!latestApprovalGrantId && !latestApprovalGrant) {
+          return;
+        }
+        latestApprovalGrantId = "";
+        latestApprovalGrant = null;
+        if (githubActionsVariableSyncOutput) {
+          githubActionsVariableSyncOutput.textContent = reason || "Variable name changed. Please approve again before sync.";
+        }
+      }
+
+      function requireGithubActionsVariableApprovalGrantScope(variableName) {
+        const scopeVariableName = latestApprovalGrant?.scope?.variableName || "";
+        if (!latestApprovalGrantId || scopeVariableName !== variableName) {
+          latestApprovalGrantId = "";
+          latestApprovalGrant = null;
+          throw new Error(
+            "選択中の variable と passkey approval の scope が一致しません。"
+            + " Variable name を確認してから、もう一度 passkey approval を実行してください。"
+          );
+        }
       }
 
       function readApprovalRepositoryInput() {
@@ -835,6 +873,7 @@ export function renderPasskeyOperatorPage(input = {}) {
         try {
           applyOperatorModeDefaults();
           const repositoryInput = readApprovalRepositoryInput();
+          const approvalVariableName = readApprovalVariableName();
           setApproveOutput("approval challenge request...", { show: shouldShowApproveOutput("status") });
           const challengeResponse = await fetch("${apiBase}/approval/passkey/challenge", {
             method: "POST",
@@ -845,7 +884,8 @@ export function renderPasskeyOperatorPage(input = {}) {
               repositoryInput,
               issueNumber: Number(document.getElementById("issue-input").value || 0) || null,
               pullNumber: readApprovalPullNumber(),
-              variableName: readApprovalVariableName(),
+              variableName: approvalVariableName,
+              variableProposalId: githubActionsVariableProposalId,
               vpsProposalId: vpsApprovalScope.vpsProposalId,
               issueContext: {
                 issueNumber: Number(document.getElementById("issue-input").value || 0) || null
@@ -854,7 +894,8 @@ export function renderPasskeyOperatorPage(input = {}) {
                 actionType: document.getElementById("action-type-input").value,
                 repositoryInput,
                 highRiskKind: document.getElementById("risk-kind-input").value,
-                variableName: readApprovalVariableName(),
+                variableName: approvalVariableName,
+                variableProposalId: githubActionsVariableProposalId,
                 vpsProposalId: vpsApprovalScope.vpsProposalId
               }
             })
@@ -880,6 +921,15 @@ export function renderPasskeyOperatorPage(input = {}) {
           }
           latestApprovalGrant = verifyBody?.approvalGrant || null;
           latestApprovalGrantId = latestApprovalGrant?.approvalId || verifyBody?.approvalGrantId || "";
+          if (operatorMode === "github_actions_variable_sync") {
+            requireGithubActionsVariableApprovalGrantScope(approvalVariableName);
+            githubActionsVariableSyncOutput.textContent = githubActionsVariableProposalMode
+              ? approvalVariableName + " approval accepted. variable sync request..."
+              : approvalVariableName + " approval accepted. Enter the value and sync.";
+            if (githubActionsVariableProposalMode) {
+              await dispatchGithubActionsVariableSync({ source: "approval" });
+            }
+          }
           setApproveOutput(JSON.stringify(verifyBody, null, 2), { show: shouldShowApproveOutput("status") });
           if (operatorMode === "dashboard") {
             window.location.assign("${dashboardReturnPath}");
@@ -906,6 +956,56 @@ export function renderPasskeyOperatorPage(input = {}) {
       });
 
       applyOperatorModeDefaults();
+
+      const githubActionsVariableNameInput = document.getElementById("github-actions-variable-name-input");
+      if (githubActionsVariableNameInput) {
+        githubActionsVariableNameInput.addEventListener("change", () => {
+          clearGithubActionsVariableApprovalGrant("Variable name changed. Please approve again before sync.");
+        });
+      }
+
+      async function dispatchGithubActionsVariableSync({ source = "manual" } = {}) {
+        if (!latestApprovalGrantId) {
+          throw new Error("approvalGrantId is required before GitHub Actions variable sync");
+        }
+        const variableName = document.getElementById("github-actions-variable-name-input").value;
+        requireGithubActionsVariableApprovalGrantScope(variableName);
+        githubActionsVariableSyncOutput.textContent = source === "approval"
+          ? variableName + " approval accepted. variable sync request..."
+          : variableName + " variable sync request...";
+        const body = githubActionsVariableProposalMode
+          ? {
+              variableProposalId: githubActionsVariableProposalId,
+              policyInput: {
+                approvalGrantId: latestApprovalGrantId
+              }
+            }
+          : {
+              repository: document.getElementById("repo-input").value,
+              variableName,
+              variableValue: document.getElementById("github-actions-variable-value-input").value,
+              policyInput: {
+                approvalGrantId: latestApprovalGrantId
+              }
+            };
+        if (!githubActionsVariableProposalMode && !body.variableValue) {
+          throw new Error(variableName + " is required");
+        }
+        const syncResponse = await fetch("${apiBase}/action/github-actions-variable", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(body)
+        });
+        const syncBody = await readResponseBody(syncResponse);
+        if (!syncResponse.ok) {
+          throw responseError(syncBody, variableName + " variable sync failed");
+        }
+        const valueInput = document.getElementById("github-actions-variable-value-input");
+        if (valueInput) {
+          valueInput.value = "";
+        }
+        githubActionsVariableSyncOutput.textContent = JSON.stringify(syncBody, null, 2);
+      }
 
       document.getElementById("sync-button").addEventListener("click", async () => {
         try {
@@ -1083,39 +1183,16 @@ export function renderPasskeyOperatorPage(input = {}) {
         }
       });
 
-      document.getElementById("github-actions-variable-sync-button").addEventListener("click", async () => {
-        try {
-          if (!latestApprovalGrantId) {
-            throw new Error("approvalGrantId is required before GitHub Actions variable sync");
+      const githubActionsVariableSyncButton = document.getElementById("github-actions-variable-sync-button");
+      if (githubActionsVariableSyncButton) {
+        githubActionsVariableSyncButton.addEventListener("click", async () => {
+          try {
+            await dispatchGithubActionsVariableSync();
+          } catch (error) {
+            githubActionsVariableSyncOutput.textContent = String(error);
           }
-          const variableName = document.getElementById("github-actions-variable-name-input").value;
-          const variableValue = document.getElementById("github-actions-variable-value-input").value;
-          if (!variableValue) {
-            throw new Error(variableName + " is required");
-          }
-          githubActionsVariableSyncOutput.textContent = variableName + " variable sync request...";
-          const syncResponse = await fetch("${apiBase}/action/github-actions-variable", {
-            method: "POST",
-            headers: { "content-type": "application/json" },
-            body: JSON.stringify({
-              repository: document.getElementById("repo-input").value,
-              variableName,
-              variableValue,
-              policyInput: {
-                approvalGrantId: latestApprovalGrantId
-              }
-            })
-          });
-          const syncBody = await readResponseBody(syncResponse);
-          if (!syncResponse.ok) {
-            throw responseError(syncBody, variableName + " variable sync failed");
-          }
-          document.getElementById("github-actions-variable-value-input").value = "";
-          githubActionsVariableSyncOutput.textContent = JSON.stringify(syncBody, null, 2);
-        } catch (error) {
-          githubActionsVariableSyncOutput.textContent = String(error);
-        }
-      });
+        });
+      }
 
       document.getElementById("gateway-bearer-vault-button").addEventListener("click", async () => {
         try {

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -1314,6 +1314,23 @@ export default {
       return handleGitHubActionsVariableSyncRequest(request, env);
     }
 
+    if (request.method === "POST" && isApiPath(url.pathname, "/action/github-actions-variable/proposals")) {
+      const auth = authorizeGatewayRequest({
+        request,
+        env,
+        apiSuffix: "/action/github-actions-variable/proposals"
+      });
+      if (!auth.ok) {
+        return json(auth.status, {
+          ok: false,
+          error: "unauthorized",
+          reason: auth.reason
+        });
+      }
+
+      return handleGitHubActionsVariableSyncProposalRequest(request, url, env);
+    }
+
     if (request.method === "POST" && isApiPath(url.pathname, "/action/repository-nickname")) {
       const auth = authorizeGatewayRequest({
         request,
@@ -6164,29 +6181,46 @@ async function handleGitHubActionsVariableSyncRequest(request, env) {
     });
   }
 
+  const provider = resolveMemoryProvider(env);
   const policyInput =
     payload.policyInput && typeof payload.policyInput === "object" ? payload.policyInput : {};
+  const proposalResolution = await resolveGitHubActionsVariableSyncProposal({
+    provider,
+    proposalId: payload.variableProposalId || payload.variable_proposal_id || policyInput.variableProposalId
+  });
+  if (!proposalResolution.ok) {
+    return json(proposalResolution.status, {
+      ok: false,
+      error: proposalResolution.error,
+      reason: proposalResolution.reason,
+      issues: proposalResolution.issues ?? []
+    });
+  }
+  const variableProposal = proposalResolution.proposal;
+  const repository = variableProposal?.repository || payload.repository;
+  const variableName = variableProposal?.variableName || payload.variableName;
+  const variableValue = variableProposal?.variableValue || payload.variableValue;
   const resolvedApprovalGrant = await resolveApprovalGrant({
     payload: {
       phase: normalizeText(payload.phase) || "execution",
       highRiskKind: "github_actions_variable_sync",
-      repositoryInput: payload.repository,
-      variableName: payload.variableName
+      repositoryInput: repository,
+      variableName
     },
     policyInput: {
       ...policyInput,
       actionType: "destructive",
-      repositoryInput: payload.repository,
+      repositoryInput: repository,
       highRiskKind: "github_actions_variable_sync",
-      variableName: payload.variableName
+      variableName
     },
     env
   });
 
   const executed = await executeGitHubActionsVariableSync({
-    repository: payload.repository,
-    variableName: payload.variableName,
-    variableValue: payload.variableValue,
+    repository,
+    variableName,
+    variableValue,
     approvalGrant:
       payload.approvalGrant ?? policyInput.approvalGrant ?? resolvedApprovalGrant.approvalGrant,
     env
@@ -6206,10 +6240,275 @@ async function handleGitHubActionsVariableSyncRequest(request, env) {
     });
   }
 
+  const ownerAction = buildGitHubActionsVariableSyncOwnerAction({
+    repository,
+    variableName,
+    proposalId: variableProposal?.proposalId,
+    issueNumber: variableProposal?.issueNumber
+  });
+  const notification = await recordGitHubActionsVariableSyncNotification({
+    ownerAction,
+    env
+  });
+
   return json(200, {
     ok: true,
-    variableSync: executed.variableSync
+    variableSync: executed.variableSync,
+    ownerAction,
+    notification,
+    runtimeTruth: {
+      kind: "github_actions_variable_sync",
+      status: executed.variableSync?.status || "synced",
+      repository,
+      variableName,
+      variableProposalId: variableProposal?.proposalId || null,
+      valueRedacted: true,
+      nextAction: "production_deploy_required",
+      pwaNotificationRequired: true,
+      pwaNotificationStatus: notification.pwaNotificationStatus
+    }
   });
+}
+
+async function handleGitHubActionsVariableSyncProposalRequest(request, url, env) {
+  const provider = resolveMemoryProvider(env);
+  const validation = validateMemoryProvider(provider);
+  if (!validation.ok) {
+    return json(503, {
+      ok: false,
+      error: "memory_provider_unavailable",
+      reason: "valid memory provider is required for GitHub Actions variable sync proposals"
+    });
+  }
+
+  const payload = await readJson(request);
+  const proposal = buildGitHubActionsVariableSyncProposal({
+    payload,
+    origin: url.origin
+  });
+  if (!proposal.ok) {
+    return json(422, {
+      ok: false,
+      error: "github_actions_variable_sync_proposal_invalid",
+      issues: proposal.issues
+    });
+  }
+
+  const record = createGitHubActionsVariableSyncProposalRecord(proposal.body);
+  const stored = await provider.store(record);
+  if (!stored?.ok) {
+    return json(503, {
+      ok: false,
+      error: "github_actions_variable_sync_proposal_write_failed",
+      reason: "failed to persist GitHub Actions variable sync proposal"
+    });
+  }
+
+  return json(200, {
+    ok: true,
+    variableProposalId: proposal.body.proposalId,
+    approvalScope: proposal.body.approvalScope,
+    approvalOperatorUrl: proposal.body.approvalOperatorUrl,
+    ownerAction: buildGitHubActionsVariableSyncOwnerAction(proposal.body),
+    runtimeTruth: {
+      kind: "github_actions_variable_sync_proposal",
+      status: "approval_required",
+      repository: proposal.body.repository,
+      variableName: proposal.body.variableName,
+      variableProposalId: proposal.body.proposalId,
+      valueRedacted: true,
+      pwaNotificationRequired: true
+    }
+  });
+}
+
+function buildGitHubActionsVariableSyncProposal({ payload, origin }) {
+  const input = normalizeObject(payload);
+  const repository = normalizeCanonicalRepositoryInput(input.repository || input.repositoryInput);
+  const variableName = normalizeText(input.variableName || input.variable_name);
+  const variableValue = normalizeText(input.variableValue || input.variable_value);
+  const issueNumber = normalizeIssue(input.issueNumber || input.issue_number || input.relatedIssue);
+  const issues = [];
+  if (!repository) issues.push("repository is required");
+  if (
+    variableName !== "VTDD_DASHBOARD_VPS_MAINTENANCE_HOST" &&
+    variableName !== "VTDD_DASHBOARD_VPS_MAINTENANCE_WORKDIR"
+  ) {
+    issues.push("variableName must be VTDD_DASHBOARD_VPS_MAINTENANCE_HOST or VTDD_DASHBOARD_VPS_MAINTENANCE_WORKDIR");
+  }
+  if (!variableValue) issues.push("variableValue is required");
+  if (issues.length > 0) {
+    return { ok: false, issues };
+  }
+
+  const proposalId =
+    normalizeText(input.variableProposalId || input.proposalId) ||
+    `github-actions-variable-sync-${safeIdentifier(repository)}-${safeIdentifier(variableName)}-${Date.now()}`;
+  const expiresAt = new Date(Date.now() + 15 * 60 * 1000).toISOString();
+  const approvalScope = normalizeScopeSnapshot({
+    actionType: "destructive",
+    highRiskKind: "github_actions_variable_sync",
+    repositoryInput: repository,
+    relatedIssue: issueNumber || undefined,
+    phase: "execution",
+    variableName
+  });
+  const approvalOperatorUrl = buildGitHubActionsVariableSyncApprovalOperatorUrl({
+    origin,
+    approvalScope,
+    variableProposalId: proposalId
+  });
+
+  return {
+    ok: true,
+    body: {
+      proposalId,
+      repository,
+      issueNumber,
+      variableName,
+      variableValue,
+      approvalScope,
+      approvalOperatorUrl,
+      expiresAt
+    }
+  };
+}
+
+function createGitHubActionsVariableSyncProposalRecord(proposal) {
+  return createMemoryRecord({
+    id: proposal.proposalId,
+    type: MemoryRecordType.APPROVAL_LOG,
+    content: {
+      kind: "github_actions_variable_sync_approval_proposal",
+      status: "pending_approval",
+      proposalId: proposal.proposalId,
+      repository: proposal.repository,
+      issueNumber: proposal.issueNumber || null,
+      variableName: proposal.variableName,
+      variableValue: proposal.variableValue,
+      approvalScope: proposal.approvalScope,
+      expiresAt: proposal.expiresAt
+    },
+    metadata: {
+      source: "github_actions_variable_sync_proposal",
+      repository: proposal.repository,
+      variableName: proposal.variableName,
+      valueRedacted: true
+    },
+    priority: 94,
+    tags: ["github_actions_variable_sync", "passkey_approval", "pending"],
+    createdAt: new Date().toISOString()
+  }).record;
+}
+
+function buildGitHubActionsVariableSyncApprovalOperatorUrl({ origin, approvalScope, variableProposalId }) {
+  const url = new URL("/v2/approval/passkey/operator", `${origin || "https://example.com"}/`);
+  url.searchParams.set("mode", "github_actions_variable_sync");
+  url.searchParams.set("variableProposalId", variableProposalId);
+  url.searchParams.set("repositoryInput", approvalScope.repositoryInput);
+  if (approvalScope.relatedIssue) {
+    url.searchParams.set("issueNumber", approvalScope.relatedIssue);
+  }
+  url.searchParams.set("phase", approvalScope.phase || "execution");
+  url.searchParams.set("actionType", approvalScope.actionType);
+  url.searchParams.set("highRiskKind", approvalScope.highRiskKind);
+  return url.href;
+}
+
+async function resolveGitHubActionsVariableSyncProposal({ provider, proposalId }) {
+  const id = normalizeText(proposalId);
+  if (!id) {
+    return { ok: true, proposal: null };
+  }
+  if (!provider || typeof provider.query !== "function") {
+    return {
+      ok: false,
+      status: 503,
+      error: "memory_provider_unavailable",
+      reason: "valid memory provider is required for GitHub Actions variable sync proposal"
+    };
+  }
+  const record = await findApprovalRecordById(provider, id);
+  if (!record || normalizeText(record?.content?.kind) !== "github_actions_variable_sync_approval_proposal") {
+    return {
+      ok: false,
+      status: 404,
+      error: "github_actions_variable_sync_proposal_not_found",
+      reason: "matching GitHub Actions variable sync proposal was not found"
+    };
+  }
+  if (Date.parse(normalizeText(record.content.expiresAt)) <= Date.now()) {
+    return {
+      ok: false,
+      status: 422,
+      error: "github_actions_variable_sync_proposal_expired",
+      issues: ["GitHub Actions variable sync proposal is expired"]
+    };
+  }
+  return {
+    ok: true,
+    proposal: {
+      proposalId: normalizeText(record.content.proposalId || record.id),
+      repository: normalizeCanonicalRepositoryInput(record.content.repository),
+      issueNumber: normalizeIssue(record.content.issueNumber),
+      variableName: normalizeText(record.content.variableName),
+      variableValue: normalizeText(record.content.variableValue),
+      approvalScope: normalizeScopeSnapshot(record.content.approvalScope),
+      expiresAt: normalizeText(record.content.expiresAt)
+    }
+  };
+}
+
+function buildGitHubActionsVariableSyncOwnerAction({ repository, variableName, proposalId, issueNumber } = {}) {
+  return {
+    actionId: proposalId || `github-actions-variable-sync-${safeIdentifier(repository)}-${safeIdentifier(variableName)}`,
+    repository,
+    issueNumber: issueNumber || null,
+    title: "GitHub Actions variable sync",
+    summary: `${variableName} を同期しました。値は表示していません。次に production deploy が必要です。`,
+    workflowName: "github-actions-variable-sync",
+    url: "/dashboard/notifications?focus=owner-action"
+  };
+}
+
+async function recordGitHubActionsVariableSyncNotification({ ownerAction, env } = {}) {
+  const event = normalizeOwnerActionRequiredDashboardEvent(ownerAction);
+  if (!event.ok) {
+    return {
+      ok: false,
+      pwaNotificationStatus: "event_invalid",
+      error: event.error,
+      reason: event.reason
+    };
+  }
+  const eventStore = resolveDashboardEventStore(env);
+  if (!eventStore) {
+    return {
+      ok: false,
+      pwaNotificationStatus: "dashboard_event_store_unavailable",
+      reason: "dashboard event store is not configured"
+    };
+  }
+  const webPush = await dispatchDashboardWebPushForEvent(env, event.event);
+  const eventWithNotificationTruth = normalizeDashboardEventRecord({
+    ...event.event,
+    status: "completed",
+    conclusion: "success",
+    pwaNotificationStatus: webPush.ok ? "sent" : "pwa_notification_unavailable",
+    pwaNotificationError: webPush.ok ? null : webPush.error || "dashboard_web_push_unavailable",
+    pwaNotificationReason: webPush.ok ? null : webPush.reason || null,
+    pwaNotificationAttempted: webPush.attempted ?? 0,
+    pwaNotificationDelivered: webPush.delivered ?? 0,
+    updatedAt: new Date().toISOString()
+  });
+  await eventStore.put(eventWithNotificationTruth);
+  return {
+    ok: true,
+    event: eventWithNotificationTruth,
+    pwaNotificationStatus: eventWithNotificationTruth.pwaNotificationStatus,
+    pwaNotificationAttempted: eventWithNotificationTruth.pwaNotificationAttempted,
+    pwaNotificationDelivered: eventWithNotificationTruth.pwaNotificationDelivered
+  };
 }
 
 async function handleCustomGptRecoveryPageRequest(url, env) {
@@ -6259,7 +6558,12 @@ async function handlePasskeyOperatorPageRequest(request, env) {
     provider: resolveMemoryProvider(env),
     proposalId: url.searchParams.get("vpsProposalId")
   });
+  const githubActionsVariableProposal = await retrieveGitHubActionsVariableSyncProposalForOperator({
+    provider: resolveMemoryProvider(env),
+    proposalId: url.searchParams.get("variableProposalId")
+  });
   const vpsScope = vpsProposal?.content?.approvalScope ?? {};
+  const githubActionsVariableScope = githubActionsVariableProposal?.content?.approvalScope ?? {};
   const html = renderPasskeyOperatorPage({
     origin: url.origin,
     syncApiBase,
@@ -6277,6 +6581,9 @@ async function handlePasskeyOperatorPageRequest(request, env) {
     vpsCapabilityId: vpsScope.vpsCapabilityId || vpsScope.display?.capabilityId || "",
     vpsImpactScope: vpsScope.vpsImpactScope || vpsScope.display?.impactScope || "",
     vpsExpiresAt: vpsScope.vpsExpiresAt || vpsScope.display?.expiresAt || "",
+    githubActionsVariableProposalId: url.searchParams.get("variableProposalId"),
+    githubActionsVariableProposalName:
+      githubActionsVariableScope.variableName || githubActionsVariableProposal?.content?.variableName || "",
     returnUrl: normalizeOperatorReturnUrl(url.searchParams.get("returnUrl")),
     dashboardReturnPath: sanitizeDashboardPreAuthReturnPath(url.searchParams.get("dashboardReturnPath")),
     operatorId: url.searchParams.get("operatorId") || "vtdd-operator",
@@ -6304,6 +6611,14 @@ async function retrieveVpsMaintenanceApprovalProposalForOperator({ provider, pro
   }
   const record = await findApprovalRecordById(provider, normalizeText(proposalId));
   return normalizeText(record?.content?.kind) === "vps_privileged_maintenance_approval_proposal" ? record : null;
+}
+
+async function retrieveGitHubActionsVariableSyncProposalForOperator({ provider, proposalId }) {
+  if (!proposalId || !provider || typeof provider.query !== "function") {
+    return null;
+  }
+  const record = await findApprovalRecordById(provider, normalizeText(proposalId));
+  return normalizeText(record?.content?.kind) === "github_actions_variable_sync_approval_proposal" ? record : null;
 }
 
 function normalizeOptionalHttpUrl(value) {
@@ -7178,12 +7493,32 @@ async function buildPasskeyApprovalScopeForRequest({ provider, payload }) {
   if (highRiskKind === "vps_runner_admin" || highRiskKind === "vps_admin") {
     return resolveVpsMaintenanceApprovalScopeForChallenge({ provider, payload });
   }
+  if (highRiskKind === "github_actions_variable_sync") {
+    const proposalId = normalizeText(payload?.variableProposalId || payload?.policyInput?.variableProposalId);
+    if (proposalId) {
+      return resolveGitHubActionsVariableSyncApprovalScopeForChallenge({ provider, proposalId });
+    }
+  }
   return {
     ok: true,
     scope: buildApprovalScopeSnapshot({
       payload,
       policyInput: payload?.policyInput
     })
+  };
+}
+
+async function resolveGitHubActionsVariableSyncApprovalScopeForChallenge({ provider, proposalId }) {
+  const resolution = await resolveGitHubActionsVariableSyncProposal({ provider, proposalId });
+  if (!resolution.ok) {
+    return {
+      ok: false,
+      issues: [resolution.reason || resolution.error || "GitHub Actions variable sync approval proposal was not found"]
+    };
+  }
+  return {
+    ok: true,
+    scope: normalizeScopeSnapshot(resolution.proposal.approvalScope)
   };
 }
 

--- a/test/passkey-operator-page.test.js
+++ b/test/passkey-operator-page.test.js
@@ -460,7 +460,8 @@ test("passkey operator page focuses secret sync modes without hiding the require
   assert.equal(actionsVariableHtml.includes('<option value="VTDD_DASHBOARD_VPS_MAINTENANCE_HOST">'), true);
   assert.equal(actionsVariableHtml.includes('<option value="VTDD_DASHBOARD_VPS_MAINTENANCE_WORKDIR">'), true);
   assert.equal(actionsVariableHtml.includes("function readApprovalVariableName()"), true);
-  assert.equal(actionsVariableHtml.includes("variableName: readApprovalVariableName()"), true);
+  assert.equal(actionsVariableHtml.includes("const approvalVariableName = readApprovalVariableName()"), true);
+  assert.equal(actionsVariableHtml.includes("variableName: approvalVariableName"), true);
   assert.equal(actionsVariableHtml.includes("Dashboard VPS maintenance"), true);
   assert.equal(actionsVariableHtml.includes('<section data-operator-section="github-actions-secret-sync" hidden>'), true);
   assert.equal(actionsVariableHtml.includes('<section data-operator-section="gateway-bearer-vault" hidden>'), true);
@@ -468,6 +469,25 @@ test("passkey operator page focuses secret sync modes without hiding the require
   assert.equal(actionsVariableHtml.includes('<section data-operator-section="production-deploy" hidden>'), true);
   assert.equal(actionsVariableHtml.includes('<section data-operator-section="pr-merge" hidden>'), true);
   assert.equal(actionsVariableHtml.includes('<section data-operator-section="issue-close" hidden>'), true);
+});
+
+test("passkey operator page supports proposal-backed variable sync as passkey-only auto dispatch", () => {
+  const html = renderPasskeyOperatorPage({
+    repositoryInput: "marushu/vtdd-v2-p",
+    actionType: "destructive",
+    highRiskKind: "github_actions_variable_sync",
+    githubActionsVariableProposalId: "github-actions-variable-sync-test",
+    githubActionsVariableProposalName: "VTDD_DASHBOARD_VPS_MAINTENANCE_HOST"
+  });
+
+  assert.equal(html.includes("このページでは値を入力しません"), true);
+  assert.equal(html.includes("githubActionsVariableProposalMode = true"), true);
+  assert.equal(html.includes("variableProposalId: githubActionsVariableProposalId"), true);
+  assert.equal(html.includes('id="github-actions-variable-sync-button"'), false);
+  assert.equal(html.includes('placeholder="value..."'), false);
+  assert.equal(html.includes('await dispatchGithubActionsVariableSync({ source: "approval" });'), true);
+  assert.equal(html.includes('const githubActionsVariableSyncButton = document.getElementById("github-actions-variable-sync-button")'), true);
+  assert.equal(html.includes("if (githubActionsVariableSyncButton)"), true);
 });
 
 test("passkey operator page supports local helper mode without passkey controls", () => {

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -12142,6 +12142,99 @@ test("worker syncs Dashboard VPS maintenance variable through approval-bound Git
   assert.equal(JSON.parse(calls[1].init.body).name, "VTDD_DASHBOARD_VPS_MAINTENANCE_HOST");
 });
 
+test("worker syncs Dashboard VPS maintenance variable from proposal after passkey only and records notification", async () => {
+  const provider = createInMemoryMemoryProvider();
+  const eventStore = createInMemoryDashboardEventStore();
+  const calls = [];
+  const proposalResponse = await worker.fetch(
+    new Request("https://sample-user-vtdd.example.workers.dev/v2/action/github-actions-variable/proposals", {
+      method: "POST",
+      headers: {
+        ...gatewayAuthHeaders,
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({
+        repository: "sample-org/vtdd-v2-p",
+        issueNumber: 637,
+        variableName: "VTDD_DASHBOARD_VPS_MAINTENANCE_HOST",
+        variableValue: "x85-131-245-163"
+      })
+    }),
+    {
+      ...gatewayAuthEnv,
+      MEMORY_PROVIDER: provider
+    }
+  );
+  assert.equal(proposalResponse.status, 200);
+  const proposalBody = await proposalResponse.json();
+  assert.equal(proposalBody.ok, true);
+  assert.equal(proposalBody.approvalOperatorUrl.includes("variableProposalId="), true);
+  assert.equal(JSON.stringify(proposalBody).includes("x85-131-245-163"), false);
+
+  await provider.store({
+    id: "approval-actions-variable-proposal-123",
+    type: MemoryRecordType.APPROVAL_LOG,
+    content: {
+      kind: "passkey_grant",
+      status: "verified",
+      approvalId: "approval-actions-variable-proposal-123",
+      expiresAt: "2099-01-01T00:00:00.000Z",
+      scope: proposalBody.approvalScope
+    },
+    metadata: { source: "test" },
+    priority: 90,
+    tags: ["passkey_grant"],
+    createdAt: "2026-04-28T00:00:00.000Z"
+  });
+
+  const response = await worker.fetch(
+    new Request("https://sample-user-vtdd.example.workers.dev/v2/action/github-actions-variable", {
+      method: "POST",
+      headers: {
+        ...gatewayAuthHeaders,
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({
+        variableProposalId: proposalBody.variableProposalId,
+        policyInput: {
+          approvalGrantId: "approval-actions-variable-proposal-123"
+        }
+      })
+    }),
+    {
+      ...gatewayAuthEnv,
+      MEMORY_PROVIDER: provider,
+      DASHBOARD_EVENT_STORE: eventStore,
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_secret",
+      GITHUB_API_FETCH: async (url, init) => {
+        calls.push({ url: String(url), init });
+        if (init?.method === "GET") {
+          return new Response(JSON.stringify({ message: "Not Found" }), {
+            status: 404,
+            headers: { "content-type": "application/json" }
+          });
+        }
+        return new Response(null, { status: 201 });
+      }
+    }
+  );
+
+  assert.equal(response.status, 200);
+  const body = await response.json();
+  assert.equal(body.ok, true);
+  assert.equal(body.variableSync.variableName, "VTDD_DASHBOARD_VPS_MAINTENANCE_HOST");
+  assert.equal(body.runtimeTruth.nextAction, "production_deploy_required");
+  assert.equal(body.notification.event.workflowName, "github-actions-variable-sync");
+  assert.equal(JSON.stringify(body).includes("x85-131-245-163"), false);
+  const stored = await eventStore.latest({
+    kind: "owner_action_required",
+    repository: "sample-org/vtdd-v2-p",
+    workflowName: "github-actions-variable-sync"
+  });
+  assert.equal(stored.conclusion, "success");
+  assert.equal(stored.changeSummary.includes("production deploy"), true);
+});
+
 test("worker syncs VTDD_GATEWAY_BEARER_TOKEN through approval-bound GitHub Actions secret route", async () => {
   const provider = createInMemoryMemoryProvider();
   const calls = [];

--- a/worker.js
+++ b/worker.js
@@ -27024,6 +27024,8 @@ function normalizeScopeSnapshot(scope = {}) {
     pullNumber: normalizeText3(scope.pullNumber),
     relatedIssue: normalizeText3(scope.relatedIssue),
     phase: normalizeText3(scope.phase),
+    secretName: normalizeText3(scope.secretName),
+    variableName: normalizeText3(scope.variableName),
     vpsProposalId: normalizeText3(scope.vpsProposalId),
     vpsHost: normalizeText3(scope.vpsHost),
     vpsOperation: normalizeText3(scope.vpsOperation),
@@ -27275,6 +27277,9 @@ function renderPasskeyOperatorPage(input = {}) {
   const dashboardReturnPath = escapeHtml(sanitizePasskeyDashboardReturnPath(input.dashboardReturnPath));
   const dashboardNotificationMode = dashboardMode && dashboardReturnPath === "/dashboard/notifications";
   const githubAppRoleDefault = escapeHtml(input.githubAppRole || "legacy");
+  const githubActionsVariableProposalId = escapeHtml(String(input.githubActionsVariableProposalId || "").trim());
+  const githubActionsVariableProposalName = escapeHtml(String(input.githubActionsVariableProposalName || "").trim());
+  const githubActionsVariableProposalMode = operatorMode === "github_actions_variable_sync" && Boolean(githubActionsVariableProposalId);
   const vpsScope = {
     vpsProposalId: String(input.vpsProposalId || "").trim(),
     vpsHost: String(input.vpsHost || "").trim(),
@@ -27607,17 +27612,21 @@ function renderPasskeyOperatorPage(input = {}) {
         <section data-operator-section="github-actions-variable-sync"${hiddenAttribute(!sectionVisibility.githubActionsVariableSync)}>
           <h2>8. GitHub Actions Variable Sync</h2>
           <p class="muted">Dashboard VPS maintenance \u306E production deploy \u3078\u6E21\u3059 GitHub Actions repository variable \u3092\u540C\u671F\u3057\u307E\u3059\u3002\u5024\u306F Butler \u4F1A\u8A71\u3001GitHub \u30B3\u30E1\u30F3\u30C8\u3001RAG\u3001\u30EC\u30B9\u30DD\u30F3\u30B9\u672C\u6587\u306B\u8868\u793A\u3057\u307E\u305B\u3093\u3002</p>
-          <label for="github-actions-variable-name-input">Variable name</label>
+          ${githubActionsVariableProposalMode ? `<p><strong>\u627F\u8A8D\u5BFE\u8C61:</strong> ${githubActionsVariableProposalName || "GitHub Actions variable"}</p>
+          <p class="muted">\u3053\u306E\u30DA\u30FC\u30B8\u3067\u306F\u5024\u3092\u5165\u529B\u3057\u307E\u305B\u3093\u3002passkey approval \u304C\u6210\u529F\u3059\u308B\u3068\u3001Butler \u304C\u4F5C\u6210\u3057\u305F proposal \u306E\u5024\u3092\u4F7F\u3063\u3066\u81EA\u52D5\u540C\u671F\u3057\u307E\u3059\u3002</p>
+          <input id="github-actions-variable-name-input" type="hidden" value="${githubActionsVariableProposalName}" />
+          <input id="github-actions-variable-value-input" type="password" autocomplete="off" hidden />` : `<label for="github-actions-variable-name-input">Variable name</label>
           <select id="github-actions-variable-name-input">
             <option value="VTDD_DASHBOARD_VPS_MAINTENANCE_HOST">VTDD_DASHBOARD_VPS_MAINTENANCE_HOST</option>
             <option value="VTDD_DASHBOARD_VPS_MAINTENANCE_WORKDIR">VTDD_DASHBOARD_VPS_MAINTENANCE_WORKDIR</option>
           </select>
+          <p class="muted">Variable name \u306F passkey approval scope \u306B\u56FA\u5B9A\u3055\u308C\u307E\u3059\u3002\u627F\u8A8D\u5F8C\u306B variable \u3092\u5909\u66F4\u3057\u305F\u5834\u5408\u306F\u3001\u3082\u3046\u4E00\u5EA6 passkey approval \u304C\u5FC5\u8981\u3067\u3059\u3002</p>
           <label for="github-actions-variable-value-input">Variable value</label>
           <input id="github-actions-variable-value-input" type="password" autocomplete="off" placeholder="value..." />
           <div class="row">
             <button id="github-actions-variable-sync-button">Sync GitHub Actions variable</button>
-          </div>
-          <p class="muted"><code>actionType=destructive</code> / <code>highRiskKind=github_actions_variable_sync</code> \u306E approvalGrantId \u304C\u5FC5\u8981\u3067\u3059\u3002</p>
+          </div>`}
+          <p class="muted"><code>actionType=destructive</code> / <code>highRiskKind=github_actions_variable_sync</code> \u306E passkey approval \u304C\u5FC5\u8981\u3067\u3059\u3002</p>
           <pre id="github-actions-variable-sync-output"></pre>
         </section>
 
@@ -27661,6 +27670,8 @@ function renderPasskeyOperatorPage(input = {}) {
       const issueCloseLink = document.getElementById("issue-close-link");
       const operatorMode = "${escapeHtml(operatorMode)}";
       const vpsApprovalScope = ${safeScriptJson(vpsScope)};
+      const githubActionsVariableProposalId = "${githubActionsVariableProposalId}";
+      const githubActionsVariableProposalMode = ${githubActionsVariableProposalMode ? "true" : "false"};
       let latestApprovalGrantId = "";
       let latestApprovalGrant = null;
 
@@ -27720,6 +27731,32 @@ function renderPasskeyOperatorPage(input = {}) {
           return null;
         }
         return document.getElementById("github-actions-variable-name-input").value;
+      }
+
+      function clearGithubActionsVariableApprovalGrant(reason) {
+        if (operatorMode !== "github_actions_variable_sync") {
+          return;
+        }
+        if (!latestApprovalGrantId && !latestApprovalGrant) {
+          return;
+        }
+        latestApprovalGrantId = "";
+        latestApprovalGrant = null;
+        if (githubActionsVariableSyncOutput) {
+          githubActionsVariableSyncOutput.textContent = reason || "Variable name changed. Please approve again before sync.";
+        }
+      }
+
+      function requireGithubActionsVariableApprovalGrantScope(variableName) {
+        const scopeVariableName = latestApprovalGrant?.scope?.variableName || "";
+        if (!latestApprovalGrantId || scopeVariableName !== variableName) {
+          latestApprovalGrantId = "";
+          latestApprovalGrant = null;
+          throw new Error(
+            "\u9078\u629E\u4E2D\u306E variable \u3068 passkey approval \u306E scope \u304C\u4E00\u81F4\u3057\u307E\u305B\u3093\u3002"
+            + " Variable name \u3092\u78BA\u8A8D\u3057\u3066\u304B\u3089\u3001\u3082\u3046\u4E00\u5EA6 passkey approval \u3092\u5B9F\u884C\u3057\u3066\u304F\u3060\u3055\u3044\u3002"
+          );
+        }
       }
 
       function readApprovalRepositoryInput() {
@@ -28058,6 +28095,7 @@ function renderPasskeyOperatorPage(input = {}) {
         try {
           applyOperatorModeDefaults();
           const repositoryInput = readApprovalRepositoryInput();
+          const approvalVariableName = readApprovalVariableName();
           setApproveOutput("approval challenge request...", { show: shouldShowApproveOutput("status") });
           const challengeResponse = await fetch("${apiBase}/approval/passkey/challenge", {
             method: "POST",
@@ -28068,7 +28106,8 @@ function renderPasskeyOperatorPage(input = {}) {
               repositoryInput,
               issueNumber: Number(document.getElementById("issue-input").value || 0) || null,
               pullNumber: readApprovalPullNumber(),
-              variableName: readApprovalVariableName(),
+              variableName: approvalVariableName,
+              variableProposalId: githubActionsVariableProposalId,
               vpsProposalId: vpsApprovalScope.vpsProposalId,
               issueContext: {
                 issueNumber: Number(document.getElementById("issue-input").value || 0) || null
@@ -28077,7 +28116,8 @@ function renderPasskeyOperatorPage(input = {}) {
                 actionType: document.getElementById("action-type-input").value,
                 repositoryInput,
                 highRiskKind: document.getElementById("risk-kind-input").value,
-                variableName: readApprovalVariableName(),
+                variableName: approvalVariableName,
+                variableProposalId: githubActionsVariableProposalId,
                 vpsProposalId: vpsApprovalScope.vpsProposalId
               }
             })
@@ -28103,6 +28143,15 @@ function renderPasskeyOperatorPage(input = {}) {
           }
           latestApprovalGrant = verifyBody?.approvalGrant || null;
           latestApprovalGrantId = latestApprovalGrant?.approvalId || verifyBody?.approvalGrantId || "";
+          if (operatorMode === "github_actions_variable_sync") {
+            requireGithubActionsVariableApprovalGrantScope(approvalVariableName);
+            githubActionsVariableSyncOutput.textContent = githubActionsVariableProposalMode
+              ? approvalVariableName + " approval accepted. variable sync request..."
+              : approvalVariableName + " approval accepted. Enter the value and sync.";
+            if (githubActionsVariableProposalMode) {
+              await dispatchGithubActionsVariableSync({ source: "approval" });
+            }
+          }
           setApproveOutput(JSON.stringify(verifyBody, null, 2), { show: shouldShowApproveOutput("status") });
           if (operatorMode === "dashboard") {
             window.location.assign("${dashboardReturnPath}");
@@ -28129,6 +28178,56 @@ function renderPasskeyOperatorPage(input = {}) {
       });
 
       applyOperatorModeDefaults();
+
+      const githubActionsVariableNameInput = document.getElementById("github-actions-variable-name-input");
+      if (githubActionsVariableNameInput) {
+        githubActionsVariableNameInput.addEventListener("change", () => {
+          clearGithubActionsVariableApprovalGrant("Variable name changed. Please approve again before sync.");
+        });
+      }
+
+      async function dispatchGithubActionsVariableSync({ source = "manual" } = {}) {
+        if (!latestApprovalGrantId) {
+          throw new Error("approvalGrantId is required before GitHub Actions variable sync");
+        }
+        const variableName = document.getElementById("github-actions-variable-name-input").value;
+        requireGithubActionsVariableApprovalGrantScope(variableName);
+        githubActionsVariableSyncOutput.textContent = source === "approval"
+          ? variableName + " approval accepted. variable sync request..."
+          : variableName + " variable sync request...";
+        const body = githubActionsVariableProposalMode
+          ? {
+              variableProposalId: githubActionsVariableProposalId,
+              policyInput: {
+                approvalGrantId: latestApprovalGrantId
+              }
+            }
+          : {
+              repository: document.getElementById("repo-input").value,
+              variableName,
+              variableValue: document.getElementById("github-actions-variable-value-input").value,
+              policyInput: {
+                approvalGrantId: latestApprovalGrantId
+              }
+            };
+        if (!githubActionsVariableProposalMode && !body.variableValue) {
+          throw new Error(variableName + " is required");
+        }
+        const syncResponse = await fetch("${apiBase}/action/github-actions-variable", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(body)
+        });
+        const syncBody = await readResponseBody(syncResponse);
+        if (!syncResponse.ok) {
+          throw responseError(syncBody, variableName + " variable sync failed");
+        }
+        const valueInput = document.getElementById("github-actions-variable-value-input");
+        if (valueInput) {
+          valueInput.value = "";
+        }
+        githubActionsVariableSyncOutput.textContent = JSON.stringify(syncBody, null, 2);
+      }
 
       document.getElementById("sync-button").addEventListener("click", async () => {
         try {
@@ -28306,39 +28405,16 @@ function renderPasskeyOperatorPage(input = {}) {
         }
       });
 
-      document.getElementById("github-actions-variable-sync-button").addEventListener("click", async () => {
-        try {
-          if (!latestApprovalGrantId) {
-            throw new Error("approvalGrantId is required before GitHub Actions variable sync");
+      const githubActionsVariableSyncButton = document.getElementById("github-actions-variable-sync-button");
+      if (githubActionsVariableSyncButton) {
+        githubActionsVariableSyncButton.addEventListener("click", async () => {
+          try {
+            await dispatchGithubActionsVariableSync();
+          } catch (error) {
+            githubActionsVariableSyncOutput.textContent = String(error);
           }
-          const variableName = document.getElementById("github-actions-variable-name-input").value;
-          const variableValue = document.getElementById("github-actions-variable-value-input").value;
-          if (!variableValue) {
-            throw new Error(variableName + " is required");
-          }
-          githubActionsVariableSyncOutput.textContent = variableName + " variable sync request...";
-          const syncResponse = await fetch("${apiBase}/action/github-actions-variable", {
-            method: "POST",
-            headers: { "content-type": "application/json" },
-            body: JSON.stringify({
-              repository: document.getElementById("repo-input").value,
-              variableName,
-              variableValue,
-              policyInput: {
-                approvalGrantId: latestApprovalGrantId
-              }
-            })
-          });
-          const syncBody = await readResponseBody(syncResponse);
-          if (!syncResponse.ok) {
-            throw responseError(syncBody, variableName + " variable sync failed");
-          }
-          document.getElementById("github-actions-variable-value-input").value = "";
-          githubActionsVariableSyncOutput.textContent = JSON.stringify(syncBody, null, 2);
-        } catch (error) {
-          githubActionsVariableSyncOutput.textContent = String(error);
-        }
-      });
+        });
+      }
 
       document.getElementById("gateway-bearer-vault-button").addEventListener("click", async () => {
         try {
@@ -58379,6 +58455,21 @@ var runtime_default = {
       }
       return handleGitHubActionsVariableSyncRequest(request, env);
     }
+    if (request.method === "POST" && isApiPath(url.pathname, "/action/github-actions-variable/proposals")) {
+      const auth = authorizeGatewayRequest({
+        request,
+        env,
+        apiSuffix: "/action/github-actions-variable/proposals"
+      });
+      if (!auth.ok) {
+        return json(auth.status, {
+          ok: false,
+          error: "unauthorized",
+          reason: auth.reason
+        });
+      }
+      return handleGitHubActionsVariableSyncProposalRequest(request, url, env);
+    }
     if (request.method === "POST" && isApiPath(url.pathname, "/action/repository-nickname")) {
       const auth = authorizeGatewayRequest({
         request,
@@ -62712,27 +62803,44 @@ async function handleGitHubActionsVariableSyncRequest(request, env) {
       reason: "valid JSON request body is required"
     });
   }
+  const provider = resolveMemoryProvider(env);
   const policyInput = payload.policyInput && typeof payload.policyInput === "object" ? payload.policyInput : {};
+  const proposalResolution = await resolveGitHubActionsVariableSyncProposal({
+    provider,
+    proposalId: payload.variableProposalId || payload.variable_proposal_id || policyInput.variableProposalId
+  });
+  if (!proposalResolution.ok) {
+    return json(proposalResolution.status, {
+      ok: false,
+      error: proposalResolution.error,
+      reason: proposalResolution.reason,
+      issues: proposalResolution.issues ?? []
+    });
+  }
+  const variableProposal = proposalResolution.proposal;
+  const repository = variableProposal?.repository || payload.repository;
+  const variableName = variableProposal?.variableName || payload.variableName;
+  const variableValue = variableProposal?.variableValue || payload.variableValue;
   const resolvedApprovalGrant = await resolveApprovalGrant({
     payload: {
       phase: normalizeText32(payload.phase) || "execution",
       highRiskKind: "github_actions_variable_sync",
-      repositoryInput: payload.repository,
-      variableName: payload.variableName
+      repositoryInput: repository,
+      variableName
     },
     policyInput: {
       ...policyInput,
       actionType: "destructive",
-      repositoryInput: payload.repository,
+      repositoryInput: repository,
       highRiskKind: "github_actions_variable_sync",
-      variableName: payload.variableName
+      variableName
     },
     env
   });
   const executed = await executeGitHubActionsVariableSync({
-    repository: payload.repository,
-    variableName: payload.variableName,
-    variableValue: payload.variableValue,
+    repository,
+    variableName,
+    variableValue,
     approvalGrant: payload.approvalGrant ?? policyInput.approvalGrant ?? resolvedApprovalGrant.approvalGrant,
     env
   }).catch((error2) => ({
@@ -62749,10 +62857,257 @@ async function handleGitHubActionsVariableSyncRequest(request, env) {
       issues: executed.issues ?? []
     });
   }
+  const ownerAction = buildGitHubActionsVariableSyncOwnerAction({
+    repository,
+    variableName,
+    proposalId: variableProposal?.proposalId,
+    issueNumber: variableProposal?.issueNumber
+  });
+  const notification = await recordGitHubActionsVariableSyncNotification({
+    ownerAction,
+    env
+  });
   return json(200, {
     ok: true,
-    variableSync: executed.variableSync
+    variableSync: executed.variableSync,
+    ownerAction,
+    notification,
+    runtimeTruth: {
+      kind: "github_actions_variable_sync",
+      status: executed.variableSync?.status || "synced",
+      repository,
+      variableName,
+      variableProposalId: variableProposal?.proposalId || null,
+      valueRedacted: true,
+      nextAction: "production_deploy_required",
+      pwaNotificationRequired: true,
+      pwaNotificationStatus: notification.pwaNotificationStatus
+    }
   });
+}
+async function handleGitHubActionsVariableSyncProposalRequest(request, url, env) {
+  const provider = resolveMemoryProvider(env);
+  const validation = validateMemoryProvider(provider);
+  if (!validation.ok) {
+    return json(503, {
+      ok: false,
+      error: "memory_provider_unavailable",
+      reason: "valid memory provider is required for GitHub Actions variable sync proposals"
+    });
+  }
+  const payload = await readJson(request);
+  const proposal = buildGitHubActionsVariableSyncProposal({
+    payload,
+    origin: url.origin
+  });
+  if (!proposal.ok) {
+    return json(422, {
+      ok: false,
+      error: "github_actions_variable_sync_proposal_invalid",
+      issues: proposal.issues
+    });
+  }
+  const record2 = createGitHubActionsVariableSyncProposalRecord(proposal.body);
+  const stored = await provider.store(record2);
+  if (!stored?.ok) {
+    return json(503, {
+      ok: false,
+      error: "github_actions_variable_sync_proposal_write_failed",
+      reason: "failed to persist GitHub Actions variable sync proposal"
+    });
+  }
+  return json(200, {
+    ok: true,
+    variableProposalId: proposal.body.proposalId,
+    approvalScope: proposal.body.approvalScope,
+    approvalOperatorUrl: proposal.body.approvalOperatorUrl,
+    ownerAction: buildGitHubActionsVariableSyncOwnerAction(proposal.body),
+    runtimeTruth: {
+      kind: "github_actions_variable_sync_proposal",
+      status: "approval_required",
+      repository: proposal.body.repository,
+      variableName: proposal.body.variableName,
+      variableProposalId: proposal.body.proposalId,
+      valueRedacted: true,
+      pwaNotificationRequired: true
+    }
+  });
+}
+function buildGitHubActionsVariableSyncProposal({ payload, origin }) {
+  const input = normalizeObject12(payload);
+  const repository = normalizeCanonicalRepositoryInput(input.repository || input.repositoryInput);
+  const variableName = normalizeText32(input.variableName || input.variable_name);
+  const variableValue = normalizeText32(input.variableValue || input.variable_value);
+  const issueNumber = normalizeIssue6(input.issueNumber || input.issue_number || input.relatedIssue);
+  const issues = [];
+  if (!repository) issues.push("repository is required");
+  if (variableName !== "VTDD_DASHBOARD_VPS_MAINTENANCE_HOST" && variableName !== "VTDD_DASHBOARD_VPS_MAINTENANCE_WORKDIR") {
+    issues.push("variableName must be VTDD_DASHBOARD_VPS_MAINTENANCE_HOST or VTDD_DASHBOARD_VPS_MAINTENANCE_WORKDIR");
+  }
+  if (!variableValue) issues.push("variableValue is required");
+  if (issues.length > 0) {
+    return { ok: false, issues };
+  }
+  const proposalId = normalizeText32(input.variableProposalId || input.proposalId) || `github-actions-variable-sync-${safeIdentifier(repository)}-${safeIdentifier(variableName)}-${Date.now()}`;
+  const expiresAt = new Date(Date.now() + 15 * 60 * 1e3).toISOString();
+  const approvalScope = normalizeScopeSnapshot({
+    actionType: "destructive",
+    highRiskKind: "github_actions_variable_sync",
+    repositoryInput: repository,
+    relatedIssue: issueNumber || void 0,
+    phase: "execution",
+    variableName
+  });
+  const approvalOperatorUrl = buildGitHubActionsVariableSyncApprovalOperatorUrl({
+    origin,
+    approvalScope,
+    variableProposalId: proposalId
+  });
+  return {
+    ok: true,
+    body: {
+      proposalId,
+      repository,
+      issueNumber,
+      variableName,
+      variableValue,
+      approvalScope,
+      approvalOperatorUrl,
+      expiresAt
+    }
+  };
+}
+function createGitHubActionsVariableSyncProposalRecord(proposal) {
+  return createMemoryRecord({
+    id: proposal.proposalId,
+    type: MemoryRecordType.APPROVAL_LOG,
+    content: {
+      kind: "github_actions_variable_sync_approval_proposal",
+      status: "pending_approval",
+      proposalId: proposal.proposalId,
+      repository: proposal.repository,
+      issueNumber: proposal.issueNumber || null,
+      variableName: proposal.variableName,
+      variableValue: proposal.variableValue,
+      approvalScope: proposal.approvalScope,
+      expiresAt: proposal.expiresAt
+    },
+    metadata: {
+      source: "github_actions_variable_sync_proposal",
+      repository: proposal.repository,
+      variableName: proposal.variableName,
+      valueRedacted: true
+    },
+    priority: 94,
+    tags: ["github_actions_variable_sync", "passkey_approval", "pending"],
+    createdAt: (/* @__PURE__ */ new Date()).toISOString()
+  }).record;
+}
+function buildGitHubActionsVariableSyncApprovalOperatorUrl({ origin, approvalScope, variableProposalId }) {
+  const url = new URL("/v2/approval/passkey/operator", `${origin || "https://example.com"}/`);
+  url.searchParams.set("mode", "github_actions_variable_sync");
+  url.searchParams.set("variableProposalId", variableProposalId);
+  url.searchParams.set("repositoryInput", approvalScope.repositoryInput);
+  if (approvalScope.relatedIssue) {
+    url.searchParams.set("issueNumber", approvalScope.relatedIssue);
+  }
+  url.searchParams.set("phase", approvalScope.phase || "execution");
+  url.searchParams.set("actionType", approvalScope.actionType);
+  url.searchParams.set("highRiskKind", approvalScope.highRiskKind);
+  return url.href;
+}
+async function resolveGitHubActionsVariableSyncProposal({ provider, proposalId }) {
+  const id = normalizeText32(proposalId);
+  if (!id) {
+    return { ok: true, proposal: null };
+  }
+  if (!provider || typeof provider.query !== "function") {
+    return {
+      ok: false,
+      status: 503,
+      error: "memory_provider_unavailable",
+      reason: "valid memory provider is required for GitHub Actions variable sync proposal"
+    };
+  }
+  const record2 = await findApprovalRecordById(provider, id);
+  if (!record2 || normalizeText32(record2?.content?.kind) !== "github_actions_variable_sync_approval_proposal") {
+    return {
+      ok: false,
+      status: 404,
+      error: "github_actions_variable_sync_proposal_not_found",
+      reason: "matching GitHub Actions variable sync proposal was not found"
+    };
+  }
+  if (Date.parse(normalizeText32(record2.content.expiresAt)) <= Date.now()) {
+    return {
+      ok: false,
+      status: 422,
+      error: "github_actions_variable_sync_proposal_expired",
+      issues: ["GitHub Actions variable sync proposal is expired"]
+    };
+  }
+  return {
+    ok: true,
+    proposal: {
+      proposalId: normalizeText32(record2.content.proposalId || record2.id),
+      repository: normalizeCanonicalRepositoryInput(record2.content.repository),
+      issueNumber: normalizeIssue6(record2.content.issueNumber),
+      variableName: normalizeText32(record2.content.variableName),
+      variableValue: normalizeText32(record2.content.variableValue),
+      approvalScope: normalizeScopeSnapshot(record2.content.approvalScope),
+      expiresAt: normalizeText32(record2.content.expiresAt)
+    }
+  };
+}
+function buildGitHubActionsVariableSyncOwnerAction({ repository, variableName, proposalId, issueNumber } = {}) {
+  return {
+    actionId: proposalId || `github-actions-variable-sync-${safeIdentifier(repository)}-${safeIdentifier(variableName)}`,
+    repository,
+    issueNumber: issueNumber || null,
+    title: "GitHub Actions variable sync",
+    summary: `${variableName} \u3092\u540C\u671F\u3057\u307E\u3057\u305F\u3002\u5024\u306F\u8868\u793A\u3057\u3066\u3044\u307E\u305B\u3093\u3002\u6B21\u306B production deploy \u304C\u5FC5\u8981\u3067\u3059\u3002`,
+    workflowName: "github-actions-variable-sync",
+    url: "/dashboard/notifications?focus=owner-action"
+  };
+}
+async function recordGitHubActionsVariableSyncNotification({ ownerAction, env } = {}) {
+  const event = normalizeOwnerActionRequiredDashboardEvent(ownerAction);
+  if (!event.ok) {
+    return {
+      ok: false,
+      pwaNotificationStatus: "event_invalid",
+      error: event.error,
+      reason: event.reason
+    };
+  }
+  const eventStore = resolveDashboardEventStore(env);
+  if (!eventStore) {
+    return {
+      ok: false,
+      pwaNotificationStatus: "dashboard_event_store_unavailable",
+      reason: "dashboard event store is not configured"
+    };
+  }
+  const webPush = await dispatchDashboardWebPushForEvent(env, event.event);
+  const eventWithNotificationTruth = normalizeDashboardEventRecord({
+    ...event.event,
+    status: "completed",
+    conclusion: "success",
+    pwaNotificationStatus: webPush.ok ? "sent" : "pwa_notification_unavailable",
+    pwaNotificationError: webPush.ok ? null : webPush.error || "dashboard_web_push_unavailable",
+    pwaNotificationReason: webPush.ok ? null : webPush.reason || null,
+    pwaNotificationAttempted: webPush.attempted ?? 0,
+    pwaNotificationDelivered: webPush.delivered ?? 0,
+    updatedAt: (/* @__PURE__ */ new Date()).toISOString()
+  });
+  await eventStore.put(eventWithNotificationTruth);
+  return {
+    ok: true,
+    event: eventWithNotificationTruth,
+    pwaNotificationStatus: eventWithNotificationTruth.pwaNotificationStatus,
+    pwaNotificationAttempted: eventWithNotificationTruth.pwaNotificationAttempted,
+    pwaNotificationDelivered: eventWithNotificationTruth.pwaNotificationDelivered
+  };
 }
 async function handleCustomGptRecoveryPageRequest(url, env) {
   const channel = url.pathname === "/setup/known-good" ? CustomGptSetupChannel.KNOWN_GOOD : CustomGptSetupChannel.LATEST;
@@ -62793,7 +63148,12 @@ async function handlePasskeyOperatorPageRequest(request, env) {
     provider: resolveMemoryProvider(env),
     proposalId: url.searchParams.get("vpsProposalId")
   });
+  const githubActionsVariableProposal = await retrieveGitHubActionsVariableSyncProposalForOperator({
+    provider: resolveMemoryProvider(env),
+    proposalId: url.searchParams.get("variableProposalId")
+  });
   const vpsScope = vpsProposal?.content?.approvalScope ?? {};
+  const githubActionsVariableScope = githubActionsVariableProposal?.content?.approvalScope ?? {};
   const html2 = renderPasskeyOperatorPage({
     origin: url.origin,
     syncApiBase,
@@ -62811,6 +63171,8 @@ async function handlePasskeyOperatorPageRequest(request, env) {
     vpsCapabilityId: vpsScope.vpsCapabilityId || vpsScope.display?.capabilityId || "",
     vpsImpactScope: vpsScope.vpsImpactScope || vpsScope.display?.impactScope || "",
     vpsExpiresAt: vpsScope.vpsExpiresAt || vpsScope.display?.expiresAt || "",
+    githubActionsVariableProposalId: url.searchParams.get("variableProposalId"),
+    githubActionsVariableProposalName: githubActionsVariableScope.variableName || githubActionsVariableProposal?.content?.variableName || "",
     returnUrl: normalizeOperatorReturnUrl(url.searchParams.get("returnUrl")),
     dashboardReturnPath: sanitizeDashboardPreAuthReturnPath(url.searchParams.get("dashboardReturnPath")),
     operatorId: url.searchParams.get("operatorId") || "vtdd-operator",
@@ -62834,6 +63196,13 @@ async function retrieveVpsMaintenanceApprovalProposalForOperator({ provider, pro
   }
   const record2 = await findApprovalRecordById(provider, normalizeText32(proposalId));
   return normalizeText32(record2?.content?.kind) === "vps_privileged_maintenance_approval_proposal" ? record2 : null;
+}
+async function retrieveGitHubActionsVariableSyncProposalForOperator({ provider, proposalId }) {
+  if (!proposalId || !provider || typeof provider.query !== "function") {
+    return null;
+  }
+  const record2 = await findApprovalRecordById(provider, normalizeText32(proposalId));
+  return normalizeText32(record2?.content?.kind) === "github_actions_variable_sync_approval_proposal" ? record2 : null;
 }
 function normalizeOptionalHttpUrl(value) {
   const text = normalizeText32(value);
@@ -63558,12 +63927,31 @@ async function buildPasskeyApprovalScopeForRequest({ provider, payload }) {
   if (highRiskKind === "vps_runner_admin" || highRiskKind === "vps_admin") {
     return resolveVpsMaintenanceApprovalScopeForChallenge({ provider, payload });
   }
+  if (highRiskKind === "github_actions_variable_sync") {
+    const proposalId = normalizeText32(payload?.variableProposalId || payload?.policyInput?.variableProposalId);
+    if (proposalId) {
+      return resolveGitHubActionsVariableSyncApprovalScopeForChallenge({ provider, proposalId });
+    }
+  }
   return {
     ok: true,
     scope: buildApprovalScopeSnapshot({
       payload,
       policyInput: payload?.policyInput
     })
+  };
+}
+async function resolveGitHubActionsVariableSyncApprovalScopeForChallenge({ provider, proposalId }) {
+  const resolution = await resolveGitHubActionsVariableSyncProposal({ provider, proposalId });
+  if (!resolution.ok) {
+    return {
+      ok: false,
+      issues: [resolution.reason || resolution.error || "GitHub Actions variable sync approval proposal was not found"]
+    };
+  }
+  return {
+    ok: true,
+    scope: normalizeScopeSnapshot(resolution.proposal.approvalScope)
   };
 }
 async function resolveVpsMaintenanceApprovalScopeForChallenge({ provider, payload }) {


### PR DESCRIPTION
## This PR satisfies Intent

- #637 の Dashboard Butler VPS maintenance path で、GitHub Actions repository variable sync を deploy と同じ passkey-only 体験へ寄せる部分進捗です。
- owner が passkey approval 後に値入力や Sync 操作をする設計をやめ、Butler / 実行面が proposal と値を保持し、owner は scope を見て passkey を押すだけにします。
- sync 成功後は値を露出せず、Dashboard 通知センター向け `ownerAction` / `runtimeTruth` に次アクション `production_deploy_required` を返します。

## Satisfied Success Criteria

- [x] `POST /v2/action/github-actions-variable/proposals` を追加し、Butler / 実行面が variable sync proposal を作成できる。
- [x] proposal-backed `mode=github_actions_variable_sync` operator では値入力フォームを出さず、passkey approval 成功後に same-origin variable sync を自動 dispatch する。
- [x] `POST /v2/action/github-actions-variable` が `variableProposalId + approvalGrantId` から repository / variableName / variableValue を解決して同期できる。
- [x] variable value は proposal response、sync response、runtime truth、notification event に echo しない。
- [x] sync 成功時に Dashboard 通知センター向け event を保存し、PWA notification truth を response に含める。
- [x] passkey approval scope 正規化に `secretName` / `variableName` を含め、scope identity field が落ちないようにする。

## Unsatisfied Success Criteria

- 本番 deploy 後、Dashboard Butler が proposal-backed variable sync URL を自然に提示し、owner が iPhone で passkey を押す live E2E が必要です。
- 実 production repository variables の同期はこの PR では実行していません。
- repository variables 同期後の production deploy と、#637 の VPS runner status live E2E は未実施です。
- GitHub Actions secret sync / Gateway bearer vault / GitHub App secret sync など他の operator surface はまだ同じ passkey-only pattern へ統一できていません。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #637
- Implementing Success Criteria: Dashboard Butler / iPhone owner flowで、owner が passkey を押すだけで Dashboard VPS maintenance repository variable sync が実行され、結果が通知センターへ残るようにする。
- Explicit Non-goals: 実 production variable mutation、production deploy、root/sudo/helper 実行、Issue close、他 secret/bootstrap surface の全面統一。
- Expected touched files/routes/workflows: `src/worker/runtime.js`, `src/core/passkey-operator-page.js`, `src/core/passkey-approval.js`, `test/passkey-operator-page.test.js`, `test/worker.test.js`, generated `worker.js`。
- Affected Issues: #637。authority boundary と passkey scope は #355/#412 の制約に従う。
- Affected PRs: PR #696 の follow-up。PR #696 branch には push せず、latest `origin/main` から新規 branch で修正。
- Affected workflows: deploy-production の入力になる repository variables。ただし workflow file 自体は変更しない。
- Affected runtime/operator surfaces: Dashboard passkey operator, Worker `/v2/action/github-actions-variable/proposals`, Worker `/v2/action/github-actions-variable`, Dashboard notification center event store。
- What may break if we patch narrowly: error message だけ直すと、owner が passkey 後に値入力と Sync を担当する危うい設計が残り、Dashboard Butler-first を破る。
- Unknowns to investigate before coding: 本番で Butler/app-server が proposal route をいつ呼ぶかは次 live E2E で確認する。今回の route は machine auth proposal creation と same-origin passkey executionの土台。
- Validation needed: focused operator/worker tests, `npm run build:worker`, `npm run verify:worker`。
- Stop condition: 実 GitHub variable mutation・deploy・root/helper execution が必要になった時点で passkey/owner action 境界として止める。

## Execution Queue Delta

- Queue position before: Issue #637 が Now。PR #696 merge/deploy 後、owner live iPhone flow で variable sync operator が post-passkey human input を要求していた。
- Preemption decision: ROOT。#637 の current root blocker 内の bounded continuation であり、新規 QUEUE 項目や #579/#654 へは移動しない。
- Queue delta: Issue #637 moves within Now from post-passkey manual variable sync blocker to Butler proposal + owner passkey-only + auto sync + notification truth. No other Issue/PR bucket moves.
- Why this PR is next: owner live error showed the current variable sync path still required human-as-system-component behavior, which directly blocks Dashboard Butler-first completion for #637.
- Active Issues not downscoped: Active Issues は縮小しません。#579/#654/#689 などは未完了/QUEUE/EVIDENCE として残し、Now は #637 のままです。

## File / Line Hypotheses

- file: `src/worker/runtime.js`
  - hypothesis: variable sync should follow the proposal-backed high-risk pattern: proposal stores sensitive value, passkey grant approves scope, action route executes and records notification truth.
  - risk if changed narrowly: same-origin operator would keep requiring owner value entry after approval, leaving the owner inside the machinery.
  - validation: `test/worker.test.js`
  - related Issue: #637
- file: `src/core/passkey-operator-page.js`
  - hypothesis: proposal-backed variable sync should mirror deploy: passkey approval triggers automatic dispatch; the page must not expose value input in owner-facing mode.
  - risk if changed narrowly: value input and manual Sync remain the primary UX and can keep producing scope/value drift.
  - validation: `test/passkey-operator-page.test.js`
  - related Issue: #637
- file: `src/core/passkey-approval.js`
  - hypothesis: `normalizeScopeSnapshot()` must preserve `variableName` and `secretName` because operation registry uses those as authority-scope identity fields.
  - risk if changed narrowly: passkey grants can lose the exact identity they are supposed to approve, causing false mismatch or unsafe generic approval.
  - validation: `test/worker.test.js`, `test/github-actions-variable-sync.test.js`
  - related Issue: #637

## Hypothesis Retrospective

- expected: adding proposal-backed variable sync and passkey auto-dispatch would align variable sync with deploy's one-tap approval pattern.
- actual: route/operator/tests now support proposal creation, proposal-backed approval scope, auto dispatch after passkey verify, redacted execution response, and notification center event truth.
- mismatch: investigation found a deeper common bug: `normalizeScopeSnapshot()` dropped `variableName`, so scope binding could not be trusted consistently.
- lesson: high-risk operator UX should not be built as "approve, then owner does more work"; approval and execution need a shared proposal contract.
- should become RAG candidate: true。高リスク操作の統一原則は「owner は scope を見て passkey を押すだけ。Butler/runner が入力保持、実行、通知、次アクション提示を担う」。

## Verification Evidence

- Unit/Integration: `node --test test/passkey-operator-page.test.js test/worker.test.js` -> 267 pass。
- Full worker verification: `npm run verify:worker` -> 1098 tests, 1097 pass, 1 skip。
- Build: `npm run build:worker` pass。
- Self-parity: `check:self-parity` passed, 33 routes / 33 operationIds。
- Generated worker: `check:generated-worker` passed。
- Evidence path/link: added tests for proposal-backed variable sync and notification event persistence in `test/passkey-operator-page.test.js` and `test/worker.test.js`。

## Butler Completion Contract

- Primary owner surface: Dashboard Butler / same-origin passkey operator。
- Fallback surface: Custom GPT fallback only。mac Codex は bootstrap/debug surface であり、この PR の owner-facing fallback ではない。
- Owner goal: Dashboard Butler が必要値を proposal として保持し、owner は iPhone で passkey を押すだけで variable sync と通知確認まで進める。
- Butler entrypoint: Butler/実行面が `/v2/action/github-actions-variable/proposals` で proposal を作り、operator URL を owner に提示する。
- Dashboard Butler natural-language path: Dashboard Butler chat で「VPS runner status / Dashboard VPS maintenance config を進めて」と依頼すると、Butler が不足 variable の proposal を作成し、owner に passkey-only operator URL を提示する入口。自然文から proposal 作成までの live E2E は deploy 後に確認が必要。
- Action Schema exposure: この PR は Dashboard Butler/runtime path 中心。fallback Action Schema の追加は行っていない。
- Runtime path: `/v2/action/github-actions-variable/proposals` -> same-origin passkey operator -> `/v2/action/github-actions-variable` -> GitHub Actions repository variables API -> Dashboard notification event。
- Runner/runtime truth: success response は repository / variableName / status / notification / `production_deploy_required` を返す。variable value は返さない。
- Authority boundary: `actionType=destructive` / `highRiskKind=github_actions_variable_sync` / `variableName` bound real passkey approvalGrant が必須。
- E2E evidence: local worker integration まで。本番 Dashboard Butler live E2E は merge/deploy 後に必要。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: merge 後に必要。deploy はこの PR では未実行。
- Custom GPT Action Schema update: なし。Dashboard Butler-first runtime path の修正。
- Custom GPT Instructions update: なし。
- iPhone Butler live E2E: 未実施。deploy 後に owner passkey-only variable sync と通知センター確認が必要。

## Related Constitution Rules

- Issue traceability
- Butler Completion Gate
- Butler-first operating principle
- High-risk actions require scoped passkey approval
- Evidence discipline

## Out-of-scope but NOT implemented

- 実 production repository variable 値の設定。
- production deploy dispatch。
- VPS root/sudo/helper execution。
- Issue #637 close judgment。
- 他 high-risk operator surface の全面 passkey-only 統一。

## Extra changes (if any)

- `normalizeScopeSnapshot()` に `secretName` / `variableName` を追加し、operation registry の authority identity field と共通正規化のズレを修正しました。
