### PR TITLE
Issue #444 notification truth を共通化する

### DIFF
--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -4293,13 +4293,78 @@ async function handleGitHubActionsEventRequest(request, env) {
     });
   }
 
-  await store.put(event.event);
-  const webPush = await dispatchDashboardWebPushForEvent(env, event.event);
+  const recorded = await recordDashboardNotificationEvent({
+    env,
+    eventStore: store,
+    event: event.event
+  });
   return json(202, {
     ok: true,
-    event: event.event,
-    webPush
+    event: recorded.event,
+    webPush: recorded.webPush
   });
+}
+
+async function recordDashboardNotificationEvent({ env, eventStore, event, overrides = {}, dispatch = true } = {}) {
+  const baseEvent = normalizeDashboardEventRecord({
+    ...event,
+    ...overrides
+  });
+  if (!eventStore || typeof eventStore.put !== "function") {
+    return {
+      ok: false,
+      event: baseEvent,
+      webPush: {
+        ok: false,
+        status: 503,
+        error: "dashboard_event_store_unavailable",
+        reason: "dashboard event store is not configured",
+        attempted: 0,
+        delivered: 0,
+        cleaned: 0
+      }
+    };
+  }
+  if (!dispatch) {
+    await eventStore.put(baseEvent);
+    return {
+      ok: true,
+      event: baseEvent,
+      webPush: {
+        ok: false,
+        status: 204,
+        reason: "dashboard notification dispatch skipped",
+        attempted: 0,
+        delivered: 0,
+        cleaned: 0
+      }
+    };
+  }
+  const webPush = await dispatchDashboardWebPushForEvent(env, baseEvent).catch((error) => ({
+    ok: false,
+    status: 502,
+    error: "dashboard_web_push_dispatch_failed",
+    reason: error instanceof Error ? error.message : "dashboard web push dispatch failed",
+    attempted: 0,
+    delivered: 0,
+    cleaned: 0
+  }));
+  const eventWithNotificationTruth = normalizeDashboardEventRecord({
+    ...baseEvent,
+    pwaNotificationStatus: webPush.ok ? "sent" : "pwa_notification_unavailable",
+    pwaNotificationError: webPush.ok ? null : webPush.error || "dashboard_web_push_unavailable",
+    pwaNotificationReason: webPush.ok ? null : webPush.reason || null,
+    pwaNotificationAttempted: webPush.attempted ?? 0,
+    pwaNotificationDelivered: webPush.delivered ?? 0,
+    pwaNotificationCleaned: webPush.cleaned ?? 0,
+    updatedAt: new Date().toISOString()
+  });
+  await eventStore.put(eventWithNotificationTruth);
+  return {
+    ok: webPush.ok,
+    event: eventWithNotificationTruth,
+    webPush
+  };
 }
 
 async function handleVpsRunnerEventRequest(request, env) {
@@ -4331,17 +4396,12 @@ async function handleVpsRunnerEventRequest(request, env) {
     });
   }
 
-  const webPush = await dispatchDashboardWebPushForEvent(env, event.event);
-  const eventWithNotificationTruth = normalizeDashboardEventRecord({
-    ...event.event,
-    pwaNotificationStatus: webPush.ok ? "sent" : "pwa_notification_unavailable",
-    pwaNotificationError: webPush.ok ? null : webPush.error || "dashboard_web_push_unavailable",
-    pwaNotificationReason: webPush.ok ? null : webPush.reason || null,
-    pwaNotificationAttempted: webPush.attempted ?? 0,
-    pwaNotificationDelivered: webPush.delivered ?? 0,
-    updatedAt: new Date().toISOString()
+  const recorded = await recordDashboardNotificationEvent({
+    env,
+    eventStore,
+    event: event.event
   });
-  await eventStore.put(eventWithNotificationTruth);
+  const eventWithNotificationTruth = recorded.event;
   let messages;
   try {
     messages = await chatStore.appendMany(event.threadId, [event.chatMessage]);
@@ -4364,7 +4424,7 @@ async function handleVpsRunnerEventRequest(request, env) {
     threadId: event.threadId,
     messages,
     webSocketBroadcast,
-    webPush
+    webPush: recorded.webPush
   });
 }
 
@@ -4388,21 +4448,15 @@ async function handleOwnerActionRequiredEventRequest(request, env) {
     });
   }
 
-  const webPush = await dispatchDashboardWebPushForEvent(env, event.event);
-  const eventWithNotificationTruth = normalizeDashboardEventRecord({
-    ...event.event,
-    pwaNotificationStatus: webPush.ok ? "sent" : "pwa_notification_unavailable",
-    pwaNotificationError: webPush.ok ? null : webPush.error || "dashboard_web_push_unavailable",
-    pwaNotificationReason: webPush.ok ? null : webPush.reason || null,
-    pwaNotificationAttempted: webPush.attempted ?? 0,
-    pwaNotificationDelivered: webPush.delivered ?? 0,
-    updatedAt: new Date().toISOString()
+  const recorded = await recordDashboardNotificationEvent({
+    env,
+    eventStore,
+    event: event.event
   });
-  await eventStore.put(eventWithNotificationTruth);
-  return json(webPush.ok ? 202 : webPush.status || 503, {
-    ok: webPush.ok,
-    event: eventWithNotificationTruth,
-    webPush
+  return json(recorded.webPush.ok ? 202 : recorded.webPush.status || 503, {
+    ok: recorded.webPush.ok,
+    event: recorded.event,
+    webPush: recorded.webPush
   });
 }
 
@@ -6489,19 +6543,16 @@ async function recordGitHubActionsVariableSyncNotification({ ownerAction, env } 
       reason: "dashboard event store is not configured"
     };
   }
-  const webPush = await dispatchDashboardWebPushForEvent(env, event.event);
-  const eventWithNotificationTruth = normalizeDashboardEventRecord({
-    ...event.event,
-    status: "completed",
-    conclusion: "success",
-    pwaNotificationStatus: webPush.ok ? "sent" : "pwa_notification_unavailable",
-    pwaNotificationError: webPush.ok ? null : webPush.error || "dashboard_web_push_unavailable",
-    pwaNotificationReason: webPush.ok ? null : webPush.reason || null,
-    pwaNotificationAttempted: webPush.attempted ?? 0,
-    pwaNotificationDelivered: webPush.delivered ?? 0,
-    updatedAt: new Date().toISOString()
+  const recorded = await recordDashboardNotificationEvent({
+    env,
+    eventStore,
+    event: event.event,
+    overrides: {
+      status: "completed",
+      conclusion: "success"
+    }
   });
-  await eventStore.put(eventWithNotificationTruth);
+  const eventWithNotificationTruth = recorded.event;
   return {
     ok: true,
     event: eventWithNotificationTruth,
@@ -11020,6 +11071,9 @@ function normalizeDashboardEventRecord(event) {
     pwaNotificationReason: normalizeDashboardEventText(input.pwaNotificationReason) || null,
     pwaNotificationAttempted: normalizeNonNegativeInteger(input.pwaNotificationAttempted),
     pwaNotificationDelivered: normalizeNonNegativeInteger(input.pwaNotificationDelivered),
+    pwaNotificationCleaned: normalizeNonNegativeInteger(input.pwaNotificationCleaned),
+    pwaReceiveStatus: normalizeDashboardEventText(input.pwaReceiveStatus) || null,
+    pwaReceivedAt: normalizeIsoTimestamp(input.pwaReceivedAt) || null,
     createdAt,
     updatedAt
   };
@@ -12452,6 +12506,62 @@ async function retrieveRecentDashboardEvents({ store, kind, repository, workflow
   return [];
 }
 
+function attachDashboardPushReceiveTruth(events = []) {
+  const ackByKey = new Map();
+  for (const event of Array.isArray(events) ? events : []) {
+    const record = normalizeDashboardEventRecord(event);
+    if (record.kind !== "dashboard_push_received") {
+      continue;
+    }
+    const key = dashboardNotificationReceiveKey(record);
+    if (!key) {
+      continue;
+    }
+    const existing = ackByKey.get(key);
+    if (!existing || compareDashboardEventRecency(record, existing) > 0) {
+      ackByKey.set(key, record);
+    }
+  }
+  const annotated = [];
+  for (const event of Array.isArray(events) ? events : []) {
+    const record = normalizeDashboardEventRecord(event);
+    if (record.kind === "dashboard_push_received") {
+      const matchingWorkflowEvent = events.some((candidate) => {
+        const candidateRecord = normalizeDashboardEventRecord(candidate);
+        return candidateRecord.kind !== "dashboard_push_received" &&
+          dashboardNotificationReceiveKey(candidateRecord) === dashboardNotificationReceiveKey(record);
+      });
+      if (matchingWorkflowEvent) {
+        continue;
+      }
+      annotated.push({
+        ...record,
+        pwaReceiveStatus: "confirmed",
+        pwaReceivedAt: record.updatedAt
+      });
+      continue;
+    }
+    const ack = ackByKey.get(dashboardNotificationReceiveKey(record));
+    annotated.push({
+      ...record,
+      pwaReceiveStatus: ack ? "confirmed" : record.pwaNotificationDelivered > 0 ? "unconfirmed" : null,
+      pwaReceivedAt: ack?.updatedAt || null
+    });
+  }
+  return annotated;
+}
+
+function dashboardNotificationReceiveKey(event) {
+  const record = normalizeDashboardEventRecord(event);
+  const repository = normalizeCanonicalRepositoryInput(record.repository);
+  const workflowName = normalizeDashboardEventText(record.workflowName);
+  const runId = normalizeDashboardEventText(record.runId);
+  if (!repository || !workflowName || !runId) {
+    return "";
+  }
+  return `${repository}:${workflowName}:${runId}`;
+}
+
 function renderDashboardDeployEvent(event) {
   if (!event) {
     return `<div class="deploy-event muted">直近 deploy event: 未受信</div>`;
@@ -12496,6 +12606,7 @@ function renderDashboardNotificationEvent(event) {
   const sha = normalizeDashboardEventText(event.headSha);
   const shortSha = sha ? sha.slice(0, 7) : "";
   const runLabel = buildDashboardEventLinkHtml(event);
+  const notificationTruth = renderDashboardNotificationTruth(event);
   const meta = [
     repository,
     event.pullNumber ? `PR #${event.pullNumber}` : "",
@@ -12507,8 +12618,40 @@ function renderDashboardNotificationEvent(event) {
   return `<div class="deploy-event">
             <div class="lane-title"><strong>${escapeDashboardHtml(title)}</strong><span class="pill ${badgeClass}">${escapeDashboardHtml(conclusion)}</span></div>
             <p>${escapeDashboardHtml(meta)}</p>
+            ${notificationTruth}
             <p class="muted">${escapeDashboardHtml(relativeUpdatedAt || "時刻未受信")} ・ ${escapeDashboardHtml(updatedAt || "updatedAt 未受信")} ・ ${runLabel}</p>
           </div>`;
+}
+
+function renderDashboardNotificationTruth(event) {
+  const record = normalizeDashboardEventRecord(event);
+  const attempted = record.pwaNotificationAttempted;
+  const delivered = record.pwaNotificationDelivered;
+  const cleaned = normalizeNonNegativeInteger(event?.pwaNotificationCleaned);
+  const receiveStatus = normalizeDashboardEventText(event?.pwaReceiveStatus);
+  const receivedAt = normalizeDashboardEventText(event?.pwaReceivedAt);
+  if (attempted === 0 && delivered === 0 && receiveStatus !== "confirmed") {
+    return "";
+  }
+  const details = [];
+  if (attempted > 0 || delivered > 0) {
+    details.push(`Web Push: push service accepted ${delivered}/${attempted}`);
+  }
+  if (cleaned > 0) {
+    details.push(`stale cleanup ${cleaned}`);
+  }
+  if (record.pwaNotificationError || record.pwaNotificationReason) {
+    details.push(record.pwaNotificationError || record.pwaNotificationReason);
+  }
+  if (receiveStatus === "confirmed") {
+    details.push(`PWA受信確認: あり${receivedAt ? ` ${formatDashboardRelativeTime(receivedAt)}` : ""}`);
+  } else if (delivered > 0) {
+    details.push("PWA受信確認: 未確認");
+  }
+  if (details.length === 0) {
+    return "";
+  }
+  return `<p class="muted">${escapeDashboardHtml(details.join(" / "))}</p>`;
 }
 
 function collapseDashboardNotificationEvents(events = []) {
@@ -12799,13 +12942,11 @@ async function renderDashboardSelfParityPage({ url, env } = {}) {
 
 async function renderDashboardNotificationsPage({ runtimeOrigin, dashboardEventStore, env } = {}) {
   const origin = normalize(runtimeOrigin);
-  const recentSince = new Date(Date.now() - 5 * 60 * 1000).toISOString();
   const recentEvents = await retrieveRecentDashboardEvents({
     store: dashboardEventStore,
-    since: recentSince,
-    limit: 20
+    limit: 30
   });
-  const visibleRecentEvents = collapseDashboardNotificationEvents(recentEvents);
+  const visibleRecentEvents = collapseDashboardNotificationEvents(attachDashboardPushReceiveTruth(recentEvents));
   const publicKey = normalizeDashboardEventText(env?.[WEB_PUSH_PUBLIC_KEY_ENV]);
   return renderDashboardUtilityPage({
     title: "通知センター",
@@ -12814,15 +12955,15 @@ async function renderDashboardNotificationsPage({ runtimeOrigin, dashboardEventS
     body: `
       <div class="grid single">
         <section class="lane">
-          <div class="lane-title"><h2>最新通知</h2><span class="pill">直近5分</span></div>
-          ${visibleRecentEvents.length > 0 ? visibleRecentEvents.map((event) => renderDashboardNotificationEvent(event)).join("") : `<p class="muted">直近5分の通知はありません。</p>`}
+          <div class="lane-title"><h2>最新通知</h2><span class="pill">直近30件</span></div>
+          ${visibleRecentEvents.length > 0 ? visibleRecentEvents.map((event) => renderDashboardNotificationEvent(event)).join("") : `<p class="muted">通知はありません。</p>`}
         </section>
       </div>
       <div class="grid single">
         <details class="lane" data-debug-section="notification-center-context">
           <summary>通知センターについて</summary>
           <p>Dashboard Butler の通知入口です。iOS PWA Web Push、OS の通知音、未読 badge はこの画面から許可・確認します。</p>
-          <p class="muted">VTDD だけでなく、他 repo / 並行開発 / queue / workflow から届いたイベントを直近5分だけ表示します。</p>
+          <p class="muted">VTDD だけでなく、他 repo / 並行開発 / queue / workflow から届いたイベントを直近30件まで表示します。Web Push は push service accepted と PWA受信確認を分けて表示します。</p>
         </details>
       </div>
       <div class="grid single">

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -4265,7 +4265,8 @@ test("worker serves dashboard notification center for recent events across repos
   assert.equal(body.includes("marushu/sunabaeye"), true);
   assert.equal(body.includes("dashboard-notification-center"), true);
   assert.equal(body.includes("2分前"), true);
-  assert.equal(body.includes("old notification"), false);
+  assert.equal(body.includes("直近30件"), true);
+  assert.equal(body.includes("old notification"), true);
 });
 
 test("worker serves dashboard PWA manifest and service worker notification handlers", async () => {
@@ -4964,6 +4965,9 @@ test("worker ingests GitHub Actions deploy completion event and shows it on dash
   assert.equal(eventBody.event.pullNumber, 552);
   assert.equal(eventBody.event.changeSummary, "dashboard: 通知カードにPR概要を出す (#534)");
   assert.equal(eventBody.webPush.delivered, 1);
+  assert.equal(eventBody.event.pwaNotificationStatus, "sent");
+  assert.equal(eventBody.event.pwaNotificationAttempted, 1);
+  assert.equal(eventBody.event.pwaNotificationDelivered, 1);
   assert.equal(pushCalls.length, 1);
   assert.equal(pushCalls[0].input, "https://push.example/send/deploy");
   assert.match(pushCalls[0].init.headers.authorization, /^vapid t=.+, k=.+/);
@@ -4984,6 +4988,14 @@ test("worker ingests GitHub Actions deploy completion event and shows it on dash
   assert.equal(decryptedPush.pullNumber, 552);
   assert.equal("approvalGrantId" in eventBody.event, false);
   assert.equal("token" in eventBody.event, false);
+  const storedDeployEvent = await store.latest({
+    kind: "github_actions_workflow_run",
+    repository: "marushu/vtdd-v2-p",
+    workflowName: "deploy-production"
+  });
+  assert.equal(storedDeployEvent.pwaNotificationStatus, "sent");
+  assert.equal(storedDeployEvent.pwaNotificationAttempted, 1);
+  assert.equal(storedDeployEvent.pwaNotificationDelivered, 1);
 
   const dashboardResponse = await worker.fetch(
     new Request("https://example.com/dashboard", {
@@ -5008,6 +5020,22 @@ test("worker ingests GitHub Actions deploy completion event and shows it on dash
   assert.equal(dashboardBody.includes("secret-must-not-persist"), false);
   assert.equal(dashboardBody.includes("setInterval("), false);
   assert.equal(dashboardBody.includes("fetch(threadEndpoint"), true);
+
+  const notificationsResponse = await worker.fetch(
+    new Request("https://example.com/dashboard/notifications", {
+      headers: dashboardAccessHeaders
+    }),
+    {
+      ...dashboardAccessEnv,
+      DASHBOARD_EVENT_STORE: store
+    }
+  );
+  assert.equal(notificationsResponse.status, 200);
+  const notificationsBody = await notificationsResponse.text();
+  assert.equal(notificationsBody.includes("直近30件"), true);
+  assert.equal(notificationsBody.includes("直近5分"), false);
+  assert.equal(notificationsBody.includes("Web Push: push service accepted 1/1"), true);
+  assert.equal(notificationsBody.includes("PWA受信確認: 未確認"), true);
 });
 
 test("worker records dashboard PWA push receive ack only for authenticated owner session", async () => {
@@ -5125,6 +5153,20 @@ test("worker records dashboard PWA push receive ack only for authenticated owner
   assert.equal(events[0].pullNumber, 552);
   assert.equal(JSON.stringify(events[0]).includes("secret"), false);
   assert.equal(pushCalls.length, 0);
+
+  const notificationsResponse = await worker.fetch(
+    new Request("https://example.com/dashboard/notifications", {
+      headers: dashboardAccessHeaders
+    }),
+    {
+      ...dashboardAccessEnv,
+      DASHBOARD_EVENT_STORE: store
+    }
+  );
+  assert.equal(notificationsResponse.status, 200);
+  const notificationsBody = await notificationsResponse.text();
+  assert.equal(notificationsBody.includes("PWA受信確認: あり"), true);
+  assert.equal(notificationsBody.includes("直近30件"), true);
 });
 
 test("worker rejects GitHub Actions deploy completion event without machine auth", async () => {

--- a/worker.js
+++ b/worker.js
@@ -61047,13 +61047,77 @@ async function handleGitHubActionsEventRequest(request, env) {
       reason: "dashboard event store is not configured"
     });
   }
-  await store.put(event.event);
-  const webPush = await dispatchDashboardWebPushForEvent(env, event.event);
+  const recorded = await recordDashboardNotificationEvent({
+    env,
+    eventStore: store,
+    event: event.event
+  });
   return json(202, {
     ok: true,
-    event: event.event,
-    webPush
+    event: recorded.event,
+    webPush: recorded.webPush
   });
+}
+async function recordDashboardNotificationEvent({ env, eventStore, event, overrides = {}, dispatch = true } = {}) {
+  const baseEvent = normalizeDashboardEventRecord({
+    ...event,
+    ...overrides
+  });
+  if (!eventStore || typeof eventStore.put !== "function") {
+    return {
+      ok: false,
+      event: baseEvent,
+      webPush: {
+        ok: false,
+        status: 503,
+        error: "dashboard_event_store_unavailable",
+        reason: "dashboard event store is not configured",
+        attempted: 0,
+        delivered: 0,
+        cleaned: 0
+      }
+    };
+  }
+  if (!dispatch) {
+    await eventStore.put(baseEvent);
+    return {
+      ok: true,
+      event: baseEvent,
+      webPush: {
+        ok: false,
+        status: 204,
+        reason: "dashboard notification dispatch skipped",
+        attempted: 0,
+        delivered: 0,
+        cleaned: 0
+      }
+    };
+  }
+  const webPush = await dispatchDashboardWebPushForEvent(env, baseEvent).catch((error2) => ({
+    ok: false,
+    status: 502,
+    error: "dashboard_web_push_dispatch_failed",
+    reason: error2 instanceof Error ? error2.message : "dashboard web push dispatch failed",
+    attempted: 0,
+    delivered: 0,
+    cleaned: 0
+  }));
+  const eventWithNotificationTruth = normalizeDashboardEventRecord({
+    ...baseEvent,
+    pwaNotificationStatus: webPush.ok ? "sent" : "pwa_notification_unavailable",
+    pwaNotificationError: webPush.ok ? null : webPush.error || "dashboard_web_push_unavailable",
+    pwaNotificationReason: webPush.ok ? null : webPush.reason || null,
+    pwaNotificationAttempted: webPush.attempted ?? 0,
+    pwaNotificationDelivered: webPush.delivered ?? 0,
+    pwaNotificationCleaned: webPush.cleaned ?? 0,
+    updatedAt: (/* @__PURE__ */ new Date()).toISOString()
+  });
+  await eventStore.put(eventWithNotificationTruth);
+  return {
+    ok: webPush.ok,
+    event: eventWithNotificationTruth,
+    webPush
+  };
 }
 async function handleVpsRunnerEventRequest(request, env) {
   const payload = await readJson(request);
@@ -61081,17 +61145,12 @@ async function handleVpsRunnerEventRequest(request, env) {
       reason: "dashboard Butler chat store is not configured"
     });
   }
-  const webPush = await dispatchDashboardWebPushForEvent(env, event.event);
-  const eventWithNotificationTruth = normalizeDashboardEventRecord({
-    ...event.event,
-    pwaNotificationStatus: webPush.ok ? "sent" : "pwa_notification_unavailable",
-    pwaNotificationError: webPush.ok ? null : webPush.error || "dashboard_web_push_unavailable",
-    pwaNotificationReason: webPush.ok ? null : webPush.reason || null,
-    pwaNotificationAttempted: webPush.attempted ?? 0,
-    pwaNotificationDelivered: webPush.delivered ?? 0,
-    updatedAt: (/* @__PURE__ */ new Date()).toISOString()
+  const recorded = await recordDashboardNotificationEvent({
+    env,
+    eventStore,
+    event: event.event
   });
-  await eventStore.put(eventWithNotificationTruth);
+  const eventWithNotificationTruth = recorded.event;
   let messages;
   try {
     messages = await chatStore.appendMany(event.threadId, [event.chatMessage]);
@@ -61114,7 +61173,7 @@ async function handleVpsRunnerEventRequest(request, env) {
     threadId: event.threadId,
     messages,
     webSocketBroadcast,
-    webPush
+    webPush: recorded.webPush
   });
 }
 async function handleOwnerActionRequiredEventRequest(request, env) {
@@ -61135,21 +61194,15 @@ async function handleOwnerActionRequiredEventRequest(request, env) {
       reason: "dashboard event store is not configured"
     });
   }
-  const webPush = await dispatchDashboardWebPushForEvent(env, event.event);
-  const eventWithNotificationTruth = normalizeDashboardEventRecord({
-    ...event.event,
-    pwaNotificationStatus: webPush.ok ? "sent" : "pwa_notification_unavailable",
-    pwaNotificationError: webPush.ok ? null : webPush.error || "dashboard_web_push_unavailable",
-    pwaNotificationReason: webPush.ok ? null : webPush.reason || null,
-    pwaNotificationAttempted: webPush.attempted ?? 0,
-    pwaNotificationDelivered: webPush.delivered ?? 0,
-    updatedAt: (/* @__PURE__ */ new Date()).toISOString()
+  const recorded = await recordDashboardNotificationEvent({
+    env,
+    eventStore,
+    event: event.event
   });
-  await eventStore.put(eventWithNotificationTruth);
-  return json(webPush.ok ? 202 : webPush.status || 503, {
-    ok: webPush.ok,
-    event: eventWithNotificationTruth,
-    webPush
+  return json(recorded.webPush.ok ? 202 : recorded.webPush.status || 503, {
+    ok: recorded.webPush.ok,
+    event: recorded.event,
+    webPush: recorded.webPush
   });
 }
 async function handleVpsPrivilegedMaintenanceProposalRequest(request, env) {
@@ -63088,19 +63141,16 @@ async function recordGitHubActionsVariableSyncNotification({ ownerAction, env } 
       reason: "dashboard event store is not configured"
     };
   }
-  const webPush = await dispatchDashboardWebPushForEvent(env, event.event);
-  const eventWithNotificationTruth = normalizeDashboardEventRecord({
-    ...event.event,
-    status: "completed",
-    conclusion: "success",
-    pwaNotificationStatus: webPush.ok ? "sent" : "pwa_notification_unavailable",
-    pwaNotificationError: webPush.ok ? null : webPush.error || "dashboard_web_push_unavailable",
-    pwaNotificationReason: webPush.ok ? null : webPush.reason || null,
-    pwaNotificationAttempted: webPush.attempted ?? 0,
-    pwaNotificationDelivered: webPush.delivered ?? 0,
-    updatedAt: (/* @__PURE__ */ new Date()).toISOString()
+  const recorded = await recordDashboardNotificationEvent({
+    env,
+    eventStore,
+    event: event.event,
+    overrides: {
+      status: "completed",
+      conclusion: "success"
+    }
   });
-  await eventStore.put(eventWithNotificationTruth);
+  const eventWithNotificationTruth = recorded.event;
   return {
     ok: true,
     event: eventWithNotificationTruth,
@@ -67027,6 +67077,9 @@ function normalizeDashboardEventRecord(event) {
     pwaNotificationReason: normalizeDashboardEventText(input.pwaNotificationReason) || null,
     pwaNotificationAttempted: normalizeNonNegativeInteger2(input.pwaNotificationAttempted),
     pwaNotificationDelivered: normalizeNonNegativeInteger2(input.pwaNotificationDelivered),
+    pwaNotificationCleaned: normalizeNonNegativeInteger2(input.pwaNotificationCleaned),
+    pwaReceiveStatus: normalizeDashboardEventText(input.pwaReceiveStatus) || null,
+    pwaReceivedAt: normalizeIsoTimestamp(input.pwaReceivedAt) || null,
     createdAt,
     updatedAt
   };
@@ -68310,6 +68363,59 @@ async function retrieveRecentDashboardEvents({ store, kind, repository, workflow
   }
   return [];
 }
+function attachDashboardPushReceiveTruth(events = []) {
+  const ackByKey = /* @__PURE__ */ new Map();
+  for (const event of Array.isArray(events) ? events : []) {
+    const record2 = normalizeDashboardEventRecord(event);
+    if (record2.kind !== "dashboard_push_received") {
+      continue;
+    }
+    const key = dashboardNotificationReceiveKey(record2);
+    if (!key) {
+      continue;
+    }
+    const existing = ackByKey.get(key);
+    if (!existing || compareDashboardEventRecency(record2, existing) > 0) {
+      ackByKey.set(key, record2);
+    }
+  }
+  const annotated = [];
+  for (const event of Array.isArray(events) ? events : []) {
+    const record2 = normalizeDashboardEventRecord(event);
+    if (record2.kind === "dashboard_push_received") {
+      const matchingWorkflowEvent = events.some((candidate) => {
+        const candidateRecord = normalizeDashboardEventRecord(candidate);
+        return candidateRecord.kind !== "dashboard_push_received" && dashboardNotificationReceiveKey(candidateRecord) === dashboardNotificationReceiveKey(record2);
+      });
+      if (matchingWorkflowEvent) {
+        continue;
+      }
+      annotated.push({
+        ...record2,
+        pwaReceiveStatus: "confirmed",
+        pwaReceivedAt: record2.updatedAt
+      });
+      continue;
+    }
+    const ack = ackByKey.get(dashboardNotificationReceiveKey(record2));
+    annotated.push({
+      ...record2,
+      pwaReceiveStatus: ack ? "confirmed" : record2.pwaNotificationDelivered > 0 ? "unconfirmed" : null,
+      pwaReceivedAt: ack?.updatedAt || null
+    });
+  }
+  return annotated;
+}
+function dashboardNotificationReceiveKey(event) {
+  const record2 = normalizeDashboardEventRecord(event);
+  const repository = normalizeCanonicalRepositoryInput(record2.repository);
+  const workflowName = normalizeDashboardEventText(record2.workflowName);
+  const runId = normalizeDashboardEventText(record2.runId);
+  if (!repository || !workflowName || !runId) {
+    return "";
+  }
+  return `${repository}:${workflowName}:${runId}`;
+}
 function renderDashboardDeployEvent(event) {
   if (!event) {
     return `<div class="deploy-event muted">\u76F4\u8FD1 deploy event: \u672A\u53D7\u4FE1</div>`;
@@ -68353,6 +68459,7 @@ function renderDashboardNotificationEvent(event) {
   const sha = normalizeDashboardEventText(event.headSha);
   const shortSha = sha ? sha.slice(0, 7) : "";
   const runLabel = buildDashboardEventLinkHtml(event);
+  const notificationTruth = renderDashboardNotificationTruth(event);
   const meta2 = [
     repository,
     event.pullNumber ? `PR #${event.pullNumber}` : "",
@@ -68364,8 +68471,39 @@ function renderDashboardNotificationEvent(event) {
   return `<div class="deploy-event">
             <div class="lane-title"><strong>${escapeDashboardHtml(title)}</strong><span class="pill ${badgeClass}">${escapeDashboardHtml(conclusion)}</span></div>
             <p>${escapeDashboardHtml(meta2)}</p>
+            ${notificationTruth}
             <p class="muted">${escapeDashboardHtml(relativeUpdatedAt || "\u6642\u523B\u672A\u53D7\u4FE1")} \u30FB ${escapeDashboardHtml(updatedAt || "updatedAt \u672A\u53D7\u4FE1")} \u30FB ${runLabel}</p>
           </div>`;
+}
+function renderDashboardNotificationTruth(event) {
+  const record2 = normalizeDashboardEventRecord(event);
+  const attempted = record2.pwaNotificationAttempted;
+  const delivered = record2.pwaNotificationDelivered;
+  const cleaned = normalizeNonNegativeInteger2(event?.pwaNotificationCleaned);
+  const receiveStatus = normalizeDashboardEventText(event?.pwaReceiveStatus);
+  const receivedAt = normalizeDashboardEventText(event?.pwaReceivedAt);
+  if (attempted === 0 && delivered === 0 && receiveStatus !== "confirmed") {
+    return "";
+  }
+  const details = [];
+  if (attempted > 0 || delivered > 0) {
+    details.push(`Web Push: push service accepted ${delivered}/${attempted}`);
+  }
+  if (cleaned > 0) {
+    details.push(`stale cleanup ${cleaned}`);
+  }
+  if (record2.pwaNotificationError || record2.pwaNotificationReason) {
+    details.push(record2.pwaNotificationError || record2.pwaNotificationReason);
+  }
+  if (receiveStatus === "confirmed") {
+    details.push(`PWA\u53D7\u4FE1\u78BA\u8A8D: \u3042\u308A${receivedAt ? ` ${formatDashboardRelativeTime(receivedAt)}` : ""}`);
+  } else if (delivered > 0) {
+    details.push("PWA\u53D7\u4FE1\u78BA\u8A8D: \u672A\u78BA\u8A8D");
+  }
+  if (details.length === 0) {
+    return "";
+  }
+  return `<p class="muted">${escapeDashboardHtml(details.join(" / "))}</p>`;
 }
 function collapseDashboardNotificationEvents(events = []) {
   const latestByKey = /* @__PURE__ */ new Map();
@@ -68636,13 +68774,11 @@ async function renderDashboardSelfParityPage({ url, env } = {}) {
 }
 async function renderDashboardNotificationsPage({ runtimeOrigin, dashboardEventStore, env } = {}) {
   const origin = normalize7(runtimeOrigin);
-  const recentSince = new Date(Date.now() - 5 * 60 * 1e3).toISOString();
   const recentEvents = await retrieveRecentDashboardEvents({
     store: dashboardEventStore,
-    since: recentSince,
-    limit: 20
+    limit: 30
   });
-  const visibleRecentEvents = collapseDashboardNotificationEvents(recentEvents);
+  const visibleRecentEvents = collapseDashboardNotificationEvents(attachDashboardPushReceiveTruth(recentEvents));
   const publicKey = normalizeDashboardEventText(env?.[WEB_PUSH_PUBLIC_KEY_ENV]);
   return renderDashboardUtilityPage({
     title: "\u901A\u77E5\u30BB\u30F3\u30BF\u30FC",
@@ -68651,15 +68787,15 @@ async function renderDashboardNotificationsPage({ runtimeOrigin, dashboardEventS
     body: `
       <div class="grid single">
         <section class="lane">
-          <div class="lane-title"><h2>\u6700\u65B0\u901A\u77E5</h2><span class="pill">\u76F4\u8FD15\u5206</span></div>
-          ${visibleRecentEvents.length > 0 ? visibleRecentEvents.map((event) => renderDashboardNotificationEvent(event)).join("") : `<p class="muted">\u76F4\u8FD15\u5206\u306E\u901A\u77E5\u306F\u3042\u308A\u307E\u305B\u3093\u3002</p>`}
+          <div class="lane-title"><h2>\u6700\u65B0\u901A\u77E5</h2><span class="pill">\u76F4\u8FD130\u4EF6</span></div>
+          ${visibleRecentEvents.length > 0 ? visibleRecentEvents.map((event) => renderDashboardNotificationEvent(event)).join("") : `<p class="muted">\u901A\u77E5\u306F\u3042\u308A\u307E\u305B\u3093\u3002</p>`}
         </section>
       </div>
       <div class="grid single">
         <details class="lane" data-debug-section="notification-center-context">
           <summary>\u901A\u77E5\u30BB\u30F3\u30BF\u30FC\u306B\u3064\u3044\u3066</summary>
           <p>Dashboard Butler \u306E\u901A\u77E5\u5165\u53E3\u3067\u3059\u3002iOS PWA Web Push\u3001OS \u306E\u901A\u77E5\u97F3\u3001\u672A\u8AAD badge \u306F\u3053\u306E\u753B\u9762\u304B\u3089\u8A31\u53EF\u30FB\u78BA\u8A8D\u3057\u307E\u3059\u3002</p>
-          <p class="muted">VTDD \u3060\u3051\u3067\u306A\u304F\u3001\u4ED6 repo / \u4E26\u884C\u958B\u767A / queue / workflow \u304B\u3089\u5C4A\u3044\u305F\u30A4\u30D9\u30F3\u30C8\u3092\u76F4\u8FD15\u5206\u3060\u3051\u8868\u793A\u3057\u307E\u3059\u3002</p>
+          <p class="muted">VTDD \u3060\u3051\u3067\u306A\u304F\u3001\u4ED6 repo / \u4E26\u884C\u958B\u767A / queue / workflow \u304B\u3089\u5C4A\u3044\u305F\u30A4\u30D9\u30F3\u30C8\u3092\u76F4\u8FD130\u4EF6\u307E\u3067\u8868\u793A\u3057\u307E\u3059\u3002Web Push \u306F push service accepted \u3068 PWA\u53D7\u4FE1\u78BA\u8A8D\u3092\u5206\u3051\u3066\u8868\u793A\u3057\u307E\u3059\u3002</p>
         </details>
       </div>
       <div class="grid single">


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #444 / Issue #514 / Issue #589 の通知未達調査で見つかった、deploy event の Web Push truth が runtime event store に残らない問題を修正します。
- 今回の本番事実では、deploy run `26705144287` は Actions log 上 `webPushAttempted=3` / `webPushDelivered=3` でしたが、D1 には `dashboard_push_received` ack が無く、通知センターにも `push service accepted` と `PWA受信未確認` の差が出ていませんでした。
- この PR は再送ボタンを追加しません。再送は原因修正ではなく、今回必要なのは「push service accepted」と「PWA Service Worker が受信した」を分けて、次回同じ状態を Dashboard Butler / 通知センターから見逃さないことです。

## Satisfied Success Criteria

- GitHub Actions deploy event ingest 時に、`dispatchDashboardWebPushForEvent()` の結果を `pwaNotificationStatus` / `pwaNotificationAttempted` / `pwaNotificationDelivered` / `pwaNotificationCleaned` として Dashboard event store に保存します。
- Web Push dispatch が例外を投げても、deploy event 自体に `dashboard_web_push_dispatch_failed` truth を保存して、通知失敗が deploy event 保存を消さないようにします。
- 通知センターを「直近5分」ではなく「直近30件」表示に変更し、古い deploy 通知証跡も確認できるようにします。
- 通知センターで `Web Push: push service accepted n/m` と `PWA受信確認: あり/未確認` を分けて表示します。
- `dashboard_push_received` ack は同じ repository / workflow / runId の workflow event に畳み込み、単一カードで deploy と PWA受信 truth を読めるようにします。
- GitHub Actions deploy event、VPS runner event、owner-action-required event、GitHub Actions variable sync owner notification を `recordDashboardNotificationEvent()` に寄せ、通知発生元ごとの個別 truth 実装を減らします。
- secrets、approvalGrantId、push subscription raw keys は保存・表示しません。

## Unsatisfied Success Criteria

- production deploy 後の iPhone/PWA live notification evidence は未実施です。merge/deploy 後に通知センターで `push service accepted` と `PWA受信確認` を確認する必要があります。
- GitHub Issue mention notification の skip reason 表示はこの PR では扱っていません。
- Issue #444 / Issue #514 / Issue #589 全体はまだ完了ではありません。
- 通知 policy/delay 設定は Issue #698 として QUEUE に作成済みです。この PR では scheduler/policy store まで実装しません。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #444 / Issue #514 / Issue #589
- Implementing Success Criteria: deploy 完了通知の未達原因を owner-facing runtime truth と通知センターで見えるようにする。
- Explicit Non-goals: 再送ボタン、production deploy 実行、VAPID鍵再生成、購読強制再登録、通知 permission 変更、credential/permission mutation、passkey/approval boundary 変更。
- Expected touched files/routes/workflows: `src/worker/runtime.js`, `test/worker.test.js`, generated `worker.js`
- Affected Issues: Issue #444, Issue #514, Issue #589, Issue #698
- Affected PRs: PR #616, PR #618, PR #619 の follow-up
- Affected workflows: deploy-production workflow の YAML は変更しない。
- Affected runtime/operator surfaces: `/v2/events/github-actions`, Dashboard event store, `/dashboard/notifications`
- What may break if we patch narrowly: push service accepted を owner-visible delivery 成功と誤認し、PWA ack 欠落を次回も見逃す。
- Unknowns to investigate before coding: 今回 run `26705144287` の iPhone 側 OS 表示可否は事後復元できない。D1 truth では ack 欠落まで確認済み。
- Validation needed: `node --test test/worker.test.js`, `npm run build:worker`, `npm run verify:worker`, `git diff --check`
- Stop condition: endpoint / auth / p256dh / approval grant / token を response, event store, logs, RAG に出すなら停止。

## Execution Queue Delta

- Queue position before: Now は Issue #637。Issue #514 / Issue #589 は Evidence Gaps。
- Preemption decision: EVIDENCE
- Queue delta: Issue #444 remains the parent notification system scope; Issue #514 and Issue #589 remain in Evidence Gaps; Issue #698 moves into Queue for notification policy/delay settings; this PR adds the shared notification recording spine and visible delivery truth without moving `Now` Issue #637.
- Why this PR is next: owner reported deploy success notification not arriving after PR #697 deploy. Investigation showed prior delivered run had `dashboard_push_received` ack, current run had no ack, yet notification center could not show that difference because Web Push truth was not persisted and the page hid events after 5 minutes.
- Active Issues not downscoped: Issue #637, Issue #444, Issue #514, Issue #589, Issue #698, Issue #528, Issue #450 and other active Issues are not treated as complete or deferred. This PR does not close Issue #444, Issue #514, Issue #589, or Issue #698.

## Regression Analysis

- Previous good evidence: deploy run `26702959198` stored both `github_actions_workflow_run` and `dashboard_push_received`.
- Current failed evidence: deploy run `26705144287` stored `github_actions_workflow_run` only; no `dashboard_push_received` ack.
- Actions log for both runs reported `webPushAttempted=3` / `webPushDelivered=3` / `webPushCleaned=0`, so Worker-to-push-service acceptance alone is insufficient evidence of owner-visible delivery.
- PR #697 did not modify deploy workflow YAML or Service Worker push handling. The missing durable truth was already present in `handleGitHubActionsEventRequest()`: it saved `event.event` before dispatch and never persisted `webPush` results into the event store.
- Owner feedback during this PR correctly identified the broader issue: passkey, deploy, VPS runner, and Butler reply notifications must attach to a standalone notification system instead of each feature inventing its own notification behavior. This PR creates the shared recording spine; Issue #698 tracks policy/delay settings on top of it.

## File / Line Hypotheses

- file: `src/worker/runtime.js`
  - hypothesis: `handleGitHubActionsEventRequest()` returns `webPush` truth to Actions but stores the event before dispatch, so Dashboard notification center loses attempted/delivered/cleaned truth.
  - risk if changed narrowly: Actions log can say delivered while Dashboard still cannot explain PWA ack absence.
  - validation: worker deploy event test asserts persisted `pwaNotificationStatus`, attempted, and delivered fields.
  - related Issue: Issue #589 / Issue #514
- file: `src/worker/runtime.js`
  - hypothesis: `/dashboard/notifications` filtering by last 5 minutes hides exactly the evidence needed after a deploy follow-up delay.
  - risk if changed narrowly: owner must use mac Codex/D1 instead of Dashboard Butler to investigate notification misses.
  - validation: notification center test asserts `直近30件`, old event visibility, and PWA receive truth text.
  - related Issue: Issue #514
- file: `src/worker/runtime.js`
  - hypothesis: notification producers are too fragmented; deploy, VPS runner, owner-action, and variable-sync notifications need one recording path before policy/delay settings can be reliable.
  - risk if changed narrowly: passkey or deploy notification fixes drift apart and future delayed-notification settings cannot apply consistently.
  - validation: existing deploy, owner-action, VPS runner, and variable-sync worker tests pass through the shared event recording behavior.
  - related Issue: Issue #444 / Issue #698

## Hypothesis Retrospective

- expected: persisting Web Push truth and rendering PWA ack status will make the current failure mode visible without adding a resend control.
- actual: local worker tests, generated worker build, and full `verify:worker` passed.
- mismatch: production iPhone/PWA live notification behavior remains unverified until deploy.
- lesson: server-side Web Push accepted is not owner-visible delivery; Dashboard must show PWA ack separately.
- should become RAG candidate: yes

## Verification Evidence

- Unit: `node --test test/worker.test.js` passed, 239/239.
- Integration: `npm run build:worker` passed.
- Integration: `npm run verify:worker` passed, 1098 tests: 1097 pass, 1 skip; self-parity passed; generated worker check passed.
- Static: `git diff --check` passed.
- E2E: not yet run; requires merge/deploy and production Dashboard notification center confirmation.

## Butler Completion Contract

- Owner goal: deploy が成功したのに通知が届かない場合、Dashboard Butler / 通知センターから原因が読めるようにする。
- Primary owner surface: Dashboard Butler notification center on iPhone/PWA.
- Fallback surface: mac Codex / D1 read-only investigation only; not the normal completion surface.
- Dashboard Butler natural-language path: Dashboard Butler 通常チャット入口で owner が自然文で "deploy 通知が来ない" or "通知を遅らせたい" と聞く経路。Butler should read notification center/runtime truth, distinguish push service accepted from PWA ack, and route policy/delay work to Issue #698.
- Butler entrypoint: Dashboard 通知センター。今後 Butler natural-language answer は同じ runtime truth を読む必要がある。
- Action Schema exposure: 変更なし。
- Runtime path: deploy-production workflow -> `/v2/events/github-actions` -> Worker Web Push dispatch -> Dashboard event store -> Dashboard notification center; PWA receive ack は `/v2/dashboard/push/ack` から同じカードへ畳み込み。
- Runner/runtime truth: `pwaNotificationAttempted` / `pwaNotificationDelivered` / `pwaNotificationCleaned` / `PWA受信確認`。
- Authority boundary: read/display/runtime truth only. Deploy, credential mutation, permission mutation, destructive operationは未実行。
- E2E evidence: 未実施。merge/deploy後に production Dashboard notification center で確認する。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: not executed in this PR.
- Custom GPT Action Schema update: not changed.
- Custom GPT Instructions update: not changed.
- iPhone Butler live E2E: not performed; post-deploy evidence required.

## Related Constitution Rules

- Butler Completion Gate
- Butler-First Operating Principle
- Chief Butler Operating Principle
- Execution Queue Contract
- Evidence Discipline
- Authority Boundary

## Out-of-scope but NOT implemented

- 再送ボタン
- iOS Focus / 通知要約 / 通知許可設定の変更
- PWA subscription 強制再作成 UX
- GitHub Issue mention fallback の再設計
- Issue closure

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #444, Issue #514, Issue #589, Issue #698
- Execution ID: local-codex-2026-05-31-deploy-push-truth
- Goal: deploy_notification_truth_persisted_and_pwa_ack_visible
