### PR TITLE
Issue #637 bridge未接続でもVPS intentを返す

### DIFF
--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -295,10 +295,29 @@ export class DashboardChatRoom {
       },
       { threadId }
     );
+    const vpsMaintenanceMessages = await this.buildVpsMaintenanceIntentMessages({
+      payload,
+      threadId,
+      repository,
+      relatedIssue,
+      text,
+      now
+    });
     const bridgeSockets = this.connectedAppServerBridgeSockets(threadId);
     if (bridgeSockets.length === 0) {
       const messages = store ? await store.appendMany(threadId, [ownerMessage]) : [ownerMessage].filter(Boolean);
       await this.writeAcceptedOwnerMessage({ threadId, clientMessageId, messageId: ownerMessage.messageId, acceptedAt: now });
+      if (vpsMaintenanceMessages) {
+        const butlerMessages = store ? await store.appendMany(threadId, vpsMaintenanceMessages) : vpsMaintenanceMessages;
+        await this.broadcastThread({ threadId, messages: [...messages, ...butlerMessages] });
+        this.sendSocket(socket, {
+          type: "owner_message_accepted",
+          ok: true,
+          clientMessageId,
+          messageId: ownerMessage.messageId
+        });
+        return;
+      }
       await this.writePendingAppServerOwnerMessage({
         threadId,
         ownerMessage,
@@ -327,14 +346,6 @@ export class DashboardChatRoom {
       ok: true,
       clientMessageId,
       messageId: ownerMessage.messageId
-    });
-    const vpsMaintenanceMessages = await this.buildVpsMaintenanceIntentMessages({
-      payload,
-      threadId,
-      repository,
-      relatedIssue,
-      text,
-      now
     });
     if (vpsMaintenanceMessages) {
       const butlerMessages = store ? await store.appendMany(threadId, vpsMaintenanceMessages) : vpsMaintenanceMessages;

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -3266,6 +3266,55 @@ test("DashboardChatRoom routes VPS maintenance owner turns to Worker proposal be
   assert.equal(proposalRecord.content.proposal.capability.riskLevel, "low");
 });
 
+test("DashboardChatRoom routes VPS maintenance owner turns without an app-server bridge socket", async () => {
+  const provider = createInMemoryMemoryProvider();
+  const store = createInMemoryDashboardChatStore();
+  const storage = createMockDurableObjectStorage();
+  const dashboardSocket = createMockSocket("dashboard", "dashboard-e2e-637-post697");
+  const room = new DashboardChatRoom(
+    {
+      storage,
+      getWebSockets() {
+        return [dashboardSocket];
+      }
+    },
+    {
+      DASHBOARD_CHAT_STORE: store,
+      MEMORY_PROVIDER: provider,
+      VTDD_RUNTIME_URL: "https://example.com",
+      VTDD_DASHBOARD_VPS_MAINTENANCE_HOST: "x85-131-245-163",
+      VTDD_DASHBOARD_VPS_MAINTENANCE_WORKDIR: "/home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p"
+    }
+  );
+
+  await room.webSocketMessage(
+    dashboardSocket,
+    JSON.stringify({
+      type: "owner_message",
+      threadId: "dashboard-e2e-637-post697",
+      repository: "marushu/vtdd-v2-p",
+      issueNumber: 637,
+      text: "Dashboard Butler から VPS runner status を確認して。root 実行は passkey 境界で止める。"
+    })
+  );
+
+  assert.equal(storage.values.has("pending_app_server_owner_messages:dashboard-e2e-637-post697"), false);
+  const ack = JSON.parse(dashboardSocket.sent.at(-1));
+  assert.equal(ack.type, "owner_message_accepted");
+  assert.equal(ack.ok, true);
+  const finalBroadcast = dashboardSocket.sent.map((message) => JSON.parse(message)).findLast((message) => message.type === "thread");
+  assert.equal(finalBroadcast.messages.length, 2);
+  assert.equal(finalBroadcast.messages[0].role, "owner");
+  assert.equal(finalBroadcast.messages[1].role, "butler");
+  assert.equal(finalBroadcast.messages[1].status, "blocked");
+  assert.match(finalBroadcast.messages[1].text, /approval_required/);
+  assert.match(finalBroadcast.messages[1].text, /systemd\.user\.runner\.status|approval URL/);
+
+  const records = await provider.retrieve({ type: MemoryRecordType.APPROVAL_LOG, limit: 10 });
+  const proposalRecord = records.find((record) => record.content?.kind === "vps_privileged_maintenance_approval_proposal");
+  assert.equal(proposalRecord.content.proposal.capability.id, "systemd.user.runner.status");
+});
+
 test("DashboardChatRoom attaches execution queue preflight to repository app-server turns", async () => {
   const provider = createInMemoryMemoryProvider();
   const store = createInMemoryDashboardChatStore();

--- a/worker.js
+++ b/worker.js
@@ -57572,10 +57572,29 @@ var DashboardChatRoom = class {
       },
       { threadId }
     );
+    const vpsMaintenanceMessages = await this.buildVpsMaintenanceIntentMessages({
+      payload,
+      threadId,
+      repository,
+      relatedIssue,
+      text,
+      now
+    });
     const bridgeSockets = this.connectedAppServerBridgeSockets(threadId);
     if (bridgeSockets.length === 0) {
       const messages2 = store ? await store.appendMany(threadId, [ownerMessage]) : [ownerMessage].filter(Boolean);
       await this.writeAcceptedOwnerMessage({ threadId, clientMessageId, messageId: ownerMessage.messageId, acceptedAt: now });
+      if (vpsMaintenanceMessages) {
+        const butlerMessages = store ? await store.appendMany(threadId, vpsMaintenanceMessages) : vpsMaintenanceMessages;
+        await this.broadcastThread({ threadId, messages: [...messages2, ...butlerMessages] });
+        this.sendSocket(socket, {
+          type: "owner_message_accepted",
+          ok: true,
+          clientMessageId,
+          messageId: ownerMessage.messageId
+        });
+        return;
+      }
       await this.writePendingAppServerOwnerMessage({
         threadId,
         ownerMessage,
@@ -57603,14 +57622,6 @@ var DashboardChatRoom = class {
       ok: true,
       clientMessageId,
       messageId: ownerMessage.messageId
-    });
-    const vpsMaintenanceMessages = await this.buildVpsMaintenanceIntentMessages({
-      payload,
-      threadId,
-      repository,
-      relatedIssue,
-      text,
-      now
     });
     if (vpsMaintenanceMessages) {
       const butlerMessages = store ? await store.appendMany(threadId, vpsMaintenanceMessages) : vpsMaintenanceMessages;


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #637 の production Dashboard Butler live E2E で、`dashboard-e2e-*` thread に owner 発言は保存されたが Butler 応答が返らない状態を確認した。
- 原因は `DashboardChatRoom.acceptOwnerMessage` が app-server bridge socket 不在を先に判定し、通常の pending bridge fallback に落として return していたこと。
- VPS privileged maintenance intent は Worker deterministic path で処理できるため、app-server bridge 接続有無に依存せず `approval_required` / blocker reply を同じ Dashboard thread に返す。

## Satisfied Success Criteria

- Dashboard Butler 自然文 VPS maintenance intent が、app-server bridge socket 不在でも Worker proposal path に到達する。
- `dashboard-e2e-*` のような bridge 未接続 thread でも owner 発言だけで止まらず Butler message が保存・broadcast される。
- 通常会話は従来どおり bridge 不在時に pending bridge fallback へ残る。

## Unsatisfied Success Criteria

- production deploy は未実行。
- production Dashboard Butler live E2E は merge/deploy 後に再実行が必要。
- root-owned helper execution / VPS runner pickup / helper result delivery まではこの PR では起動しない。
- Issue #637 全体完了や close は主張しない。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #637
- Implementing Success Criteria: Dashboard Butler 自然文 VPS privileged maintenance intent が app-server bridge 接続有無に依存せず owner-facing proposal / blocker reply へ到達する。
- Explicit Non-goals: root/helper 実行、production deploy、GitHub Actions variable/secret mutation、通知ポリシー/遅延設定 (#698)、Issue #637 close は行わない。
- Expected touched files/routes/workflows: `src/worker/runtime.js`, `test/worker.test.js`, `worker.js`。
- Affected Issues: Issue #637。
- Affected PRs: PR #699 deploy 後の live E2E で見つかった同一 Now blocker の follow-up。既存 PR は更新しない。
- Affected workflows: GitHub reviewer / guarded-policy / test は通常通り。deploy workflow は dispatch しない。
- Affected runtime/operator surfaces: Dashboard Butler chat Durable Object。passkey operator UI、GitHub Actions variable sync、VPS root helper は変更しない。
- What may break if we patch narrowly: bridge 未接続時の通常会話 fallback と deterministic Worker-handled intent の分岐順を誤ると、通常会話が pending されなくなる可能性がある。
- Unknowns to investigate before coding: live では `dashboard-e2e-*` thread に app-server bridge socket が無いことが原因候補。source で bridge 不在 return が deterministic intent より前にあることを確認済み。
- Validation needed: focused worker test、`npm run build:worker`、`npm run verify:worker`、merge/deploy 後の production Dashboard Butler live E2E。
- Stop condition: root/helper 実行、deploy、credential/variable mutation、Issue #637 以外の scope が必要になったらこの PR では止める。

## Execution Queue Delta

- Queue position before: Issue #637 は `Now` / ROOT blocker。PR #699 deploy 後、Dashboard Butler live E2E が owner 発言保存後に停止した。
- Preemption decision: ROOT。新規割り込みではなく、Issue #637 の Dashboard Butler completion blocker を同じ Now の小 slice として処理する。
- Queue delta: Issue #637 stays in Now; Queue bucket `Evidence Gaps / Issue #637` から「bridge 未接続 thread で deterministic VPS intent が pending fallback に落ちる」をこの PR で解消する。Issue #698 stays in Queue。
- Why this PR is next: #637 の次段階である passkey/helper queue E2E へ進む前に、Dashboard Butler 自然文が proposal reply へ到達しない blocker を潰す必要がある。
- Active Issues not downscoped: Active Issues are not downscoped. 他の open Issue は未完了のまま queue / evidence gap に残す。

## File / Line Hypotheses

- file: `src/worker/runtime.js`
  - hypothesis: `acceptOwnerMessage` が bridge socket 不在を先に処理して return するため、`buildVpsMaintenanceIntentMessages` に到達しない。
  - risk if changed narrowly: 通常会話の bridge pending fallback を壊す可能性。
  - validation: bridge 有り VPS intent、bridge 無し VPS intent、通常会話 bridge 無しの既存 test を通す。
  - related Issue: Issue #637
- file: `test/worker.test.js`
  - hypothesis: 既存 test は bridge socket 有りの deterministic path だけを固定しており、live E2E thread の bridge 無し条件を覆えていなかった。
  - risk if changed narrowly: production で同じ `dashboard-e2e-*` thread が再び owner-only で止まる。
  - validation: bridge socket 無しの `dashboard-e2e-*` thread で `approval_required` と `systemd.user.runner.status` を assert する。
  - related Issue: Issue #637

## Hypothesis Retrospective

- expected: bridge socket が無い `dashboard-e2e-*` thread でも #637 自然文が Worker deterministic path に入り、owner message + Butler message が同じ thread に残る。
- actual: focused worker test と full worker verification で期待通り。
- mismatch: live production は未deployのため未確認。merge/deploy 後に同じ prompt で再検証する。
- lesson: deterministic Worker-handled owner intents は app-server bridge availability より前に処理しないと、E2E thread や fallback state で owner-only 保存に落ちる。
- should become RAG candidate: はい。Issue #637 の live E2E failure/root cause として deploy 後 evidence と一緒に残す候補。

## Verification Evidence

- Unit: `node --test test/worker.test.js --test-name-pattern "VPS maintenance owner turns"` passed。
- Integration: `npm run build:worker` passed。
- Integration: `npm run verify:worker` passed。
  - tests: 1099
  - pass: 1098
  - skipped: 1
  - self-parity: pass
  - generated-worker: pass
- Static: `git diff --check` passed。
- Manual: Chrome production Dashboard tabで `dashboard-e2e-637-post697-1780208542173` に 17:46 JST の owner 発言だけが保存され、Butler response article が増えないことを確認。VPS app-server bridge / runner は read-only status で起動中、runner timer は正常。

## Butler Completion Contract

- Primary owner surface: Dashboard Butler。
- Fallback surface: mac Codex は live failure investigation と PR 作成に使用。completion surface ではない。
- Owner goal: owner が iPhone/iPad Dashboard Butler から #637 VPS runner status intent を送った時、bridge 接続状態に左右されず proposal / blocker reply を同じ thread で見られる。
- Butler entrypoint: Dashboard Butler normal chat WebSocket owner message。
- Dashboard Butler natural-language path: Dashboard Butler normal chat / natural-language owner message entrypoint (`/v2/dashboard/chat/:threadId/ws`) -> `DashboardChatRoom.acceptOwnerMessage` -> `buildVpsMaintenanceIntentMessages` -> `buildDashboardVpsPrivilegedMaintenanceNaturalLanguageFlow`。
- Action Schema exposure: この PR では変更しない。Dashboard Butler 主経路の runtime fix。
- Runtime path: `/v2/dashboard/chat/:threadId/ws` の Durable Object path。bridge 無し thread では app-server pending fallback より先に VPS maintenance deterministic path を処理する。
- Runner/runtime truth: proposal reply は `rootExecutionStarted=false` / `helperExecutionStarted=false` を含む既存 flow。runner/helper execution はこの PR では開始しない。
- Authority boundary: passkey approval required の手前まで。root/helper/deploy/credential/variable mutation は行わない。
- E2E evidence: local unit/integration evidence あり。production Dashboard Butler live E2E は merge/deploy 後に再実行が必要。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 未実行。merge 後に scoped passkey deploy が必要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: production live E2E は未完。merge/deploy 後に `dashboard-e2e-*` thread で再確認する。

## Related Constitution Rules

- Dashboard Butler First: owner-facing workflow は Dashboard Butler 通常チャットから完結に近づける。
- Butler Completion Gate: route/schema だけでなく runtime truth と E2E evidence を必要とする。
- Authority Boundary: deploy/root/credential mutation へ踏み込まない。
- Evidence Discipline: live failure と local verification を分けて記録する。

## Out-of-scope but NOT implemented

- production deploy。
- passkey approval 実行。
- VPS root/helper execution。
- Issue #637 close。
- Issue #698 通知ポリシー/遅延設定。

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #637
- Execution ID: issue637-deterministic-intent-without-bridge
- Goal: Dashboard Butler deterministic VPS intent を app-server bridge 接続有無に依存させない。
