### PR TITLE
Issue #637 VPS runner result を Dashboard thread に返す

### DIFF
--- a/scripts/run-vps-runner.mjs
+++ b/scripts/run-vps-runner.mjs
@@ -1091,11 +1091,17 @@ function parseVpsPrivilegedMaintenanceQueueComment(body) {
     transport: normalizeText(payload.transport),
     repository: normalizeRepository(payload.repository),
     issueNumber: normalizePositiveInteger(payload.issueNumber),
+    dashboardThreadId: normalizeText(
+      payload?.handoff?.dashboardThreadId || payload.dashboardThreadId || payload.dashboard_thread_id
+    ),
     approvalScopeMatched: payload.approvalScopeMatched === true,
     approvalActor: normalizeGitHubLogin(payload.approvalActor),
     executionEnvelope: normalizeVpsPrivilegedMaintenanceExecutionEnvelope(payload.executionEnvelope),
     issueTraceability: payload.issueTraceability || null
   };
+  normalized.handoff = normalized.dashboardThreadId
+    ? { dashboardThreadId: normalized.dashboardThreadId }
+    : null;
 
   const issues = [];
   if (normalized.executionId !== marker[1]) {

--- a/test/vps-runner-script.test.js
+++ b/test/vps-runner-script.test.js
@@ -69,7 +69,8 @@ VTDD 管理の VPS runner 実行キューです。
 
 test("VPS runner parses privileged maintenance helper queue payload", () => {
   const parsed = parseVpsPrivilegedMaintenanceQueueComment(privilegedMaintenanceQueueComment({
-    executionId: "vps-maint-637-a"
+    executionId: "vps-maint-637-a",
+    dashboardThreadId: "dashboard-main-sample-org-vtdd-v2"
   }));
 
   assert.equal(parsed.ok, true);
@@ -77,6 +78,8 @@ test("VPS runner parses privileged maintenance helper queue payload", () => {
   assert.equal(parsed.payload.transport, "vps_privileged_maintenance_helper");
   assert.equal(parsed.payload.repository, "sample-org/vtdd-v2");
   assert.equal(parsed.payload.issueNumber, 637);
+  assert.equal(parsed.payload.dashboardThreadId, "dashboard-main-sample-org-vtdd-v2");
+  assert.equal(parsed.payload.handoff.dashboardThreadId, "dashboard-main-sample-org-vtdd-v2");
   assert.equal(parsed.payload.approvalScopeMatched, true);
   assert.equal(parsed.payload.executionEnvelope.status, "ready_for_vps_helper_execution");
   assert.equal(parsed.payload.executionEnvelope.helperInvocation.shell, false);
@@ -2129,15 +2132,19 @@ function queueComment({
 
 function privilegedMaintenanceQueueComment({
   executionId,
+  dashboardThreadId = "",
   helperArgs = ["-n", "/usr/local/sbin/vtdd-vps-maintenance-helper", "--execute", "--input", "<helper-execution-input-json>"]
 }) {
+  const dashboardThreadJson = dashboardThreadId
+    ? `\n  "dashboardThreadId": "${dashboardThreadId}",\n  "handoff": {\n    "dashboardThreadId": "${dashboardThreadId}"\n  },`
+    : "";
   return `<!-- vtdd:vps-privileged-maintenance-execution:${executionId} -->
 \`\`\`json
 {
   "executionId": "${executionId}",
   "transport": "vps_privileged_maintenance_helper",
   "repository": "sample-org/vtdd-v2",
-  "issueNumber": 637,
+  "issueNumber": 637,${dashboardThreadJson}
   "approvalScopeMatched": true,
   "approvalActor": "requester",
   "issueTraceability": {


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #637 の Dashboard Butler live E2E で見えた `dashboardDelivery.status=skipped` を修正します。
- VPS privileged maintenance helper queue の `dashboardThreadId` / `handoff.dashboardThreadId` を VPS runner parser が保持し、runner result を Dashboard Butler thread に戻せるようにします。

## Satisfied Success Criteria

- 実行結果は Dashboard Butler と GitHub-visible runtime truth に before/after、exit code、redacted log summary、next action として返る、のうち Dashboard thread handoff preservation を満たします。
- sudo password、raw secret、approval token raw material は RAG / Issue / PR / logs に保存されない、の既存境界を変更しません。

## Unsatisfied Success Criteria

- Issue #637 全体はまだ complete ではありません。capability add / enable / disable / remove / rollback / review の全 lifecycle E2E はこのPRでは扱いません。
- 足りない capability proposal を passkey approval 後に manifest へ追加する E2E はこのPRでは扱いません。
- PR #632 Playwright Chromium deps blocker を Mac なしで復旧する seed E2E はこのPRでは扱いません。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #637
- Implementing Success Criteria: VPS privileged maintenance の実行結果が Dashboard Butler thread へ戻るための handoff thread preservation。
- Explicit Non-goals: 新しい root/sudo capability 追加、manifest 変更、sudoers 変更、deploy workflow 変更、Action Schema 変更、Issue close。
- Expected touched files/routes/workflows: `scripts/run-vps-runner.mjs`, `test/vps-runner-script.test.js`
- Affected Issues: Issue #637。Issue #413 の runtime truth visibility にも良い影響があります。
- Affected PRs: なし。
- Affected workflows: VPS runner が Issue comment queue を読む経路。GitHub Actions deploy workflow は未変更。
- Affected runtime/operator surfaces: Dashboard Butler, VPS runner, GitHub Issue runtime truth comment。passkey operator と Worker route は未変更。
- What may break if we patch narrowly: privileged maintenance queue payload の thread fields を捨て続けると、helper 実行は成功しても Dashboard Butler が結果を受け取れず #637 completion gate を満たせません。
- Unknowns to investigate before coding: queue comment には `dashboardThreadId` と `handoff.dashboardThreadId` が存在するが、runner parser が保持しているか。
- Validation needed: `node --test test/vps-runner-script.test.js --test-name-pattern 'privileged maintenance helper queue payload|dashboard thread events'`
- Stop condition: parser が threadId を保持しても runtime delivery が失敗する場合は、別の runtime event route / credential / notification gap として止めて切り分けます。

## Execution Queue Delta

- Queue position before: Issue #637 は Now。Dashboard Butler natural-language -> passkey -> helper queue -> runner pickup は通ったが、runner result の Dashboard delivery が skipped でした。
- Preemption decision: ROOT
- Queue delta: Issue #637 の current blocker を `runner result dashboard delivery skipped` として潰します。Now は #637 のままです。
- Why this PR is next: #637 の completion gate は GitHub-visible runtime truth だけでなく Dashboard Butler への結果返却を要求しており、live E2E で `dashboard threadId is missing` が出たためです。
- Active Issues not downscoped: Active Issues は縮小しません。このPRで扱わない #637 lifecycle criteria は未完了として残します。

## File / Line Hypotheses

- file: `scripts/run-vps-runner.mjs`
  - hypothesis: `parseVpsPrivilegedMaintenanceQueueComment` が queue comment の `dashboardThreadId` / `handoff.dashboardThreadId` を normalized payload に残していないため、`postVpsRunnerEvent` が `threadId` を空として扱う。
  - risk if changed narrowly: normal VPS runner queue と privileged maintenance queue の payload shape を混同すると既存 runner event の thread handling を壊す。
  - validation: privileged maintenance parse test と dashboard runtime event posting test。
  - related Issue: Issue #637
- file: `test/vps-runner-script.test.js`
  - hypothesis: privileged maintenance queue parser の test が dashboard thread preservation を見ていなかった。
  - risk if changed narrowly: live E2E でしか検出できない `dashboardDelivery=skipped` が再発する。
  - validation: privileged maintenance helper queue payload test に dashboard thread assertion を追加。
  - related Issue: Issue #637

## Hypothesis Retrospective

- expected: privileged maintenance queue comment にある dashboard thread fields を parser が捨てていた。
- actual: `parseVpsPrivilegedMaintenanceQueueComment` は `dashboardThreadId` / `handoff` を normalized payload に含めていませんでした。
- mismatch: なし。
- lesson: #637 の成功判定は helper execution completion ではなく Dashboard Butler delivery まで見る必要があります。
- should become RAG candidate: はい。helper execution 成功と Dashboard delivery 成功を分けて見る判断は future drift prevention に有用です。

## Verification Evidence

- Unit: `node --test test/vps-runner-script.test.js --test-name-pattern 'privileged maintenance helper queue payload|dashboard thread events'` pass。tests 69 / pass 69。
- Integration: 同上。runner queue parser と runtime event posting path の既存 integration test を通過。
- E2E: merge/deploy 後に #637 Dashboard Butler live E2E を再実行予定。
- Manual: 2026-05-31 live E2E で `dashboardDelivery.status=skipped`, `reason=dashboard threadId is missing` を確認済み。
- Evidence path/link: https://github.com/marushu/vtdd-v2-p/issues/637#issuecomment-4586293937

## Butler Completion Contract

- Primary owner surface: Dashboard Butler。
- Fallback surface: Custom GPT は fallback surface としてのみ扱います。主経路ではありません。
- Owner goal: Dashboard Butler の自然文から passkey 承認済み VPS helper execution result が同じ Dashboard thread に戻ること。
- Butler entrypoint: Dashboard Butler 通常チャットの自然文 #637 VPS runner status flow。
- Dashboard Butler natural-language path: Dashboard Butler 通常チャットで #637 VPS runner status intent を受け、helper queue と runner result まで接続する経路です。
- Action Schema exposure: 未変更。Custom GPT fallback を主経路として扱いません。
- Runtime path: Worker が queue comment に `dashboardThreadId` / `handoff.dashboardThreadId` を書き、VPS runner がそれを保持して `/v2/events/vps-runner` へ返す path。
- Runner/runtime truth: runner parser が privileged maintenance queue payload の dashboard thread handoff を保持します。
- Authority boundary: 新しい high-risk authority は追加しません。既存 passkey approval 済み helper handoff の後段 truth delivery だけを修正します。
- E2E evidence: merge/deploy 後に Dashboard Butler live E2E で `dashboardDelivery.status=delivered` を確認予定。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 必要。VPS runner script は VPS 側 update/pickup も必要です。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 必要。merge/deploy 後に再実施します。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate
- AGENTS.md Butler-First Operating Principle
- AGENTS.md Evidence Discipline
- docs/butler/execution-queue-contract.md

## Out-of-scope but NOT implemented

- Issue #637 の capability add / disable / remove / rollback lifecycle。
- Playwright Chromium deps blocker seed E2E。
- `/v2/action/vps-runner-status` 404 route gap。

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #637
- Execution ID: issue637-dashboard-delivery-thread-preservation
- Goal: Preserve Dashboard Butler thread handoff for VPS privileged maintenance runner result delivery.
