### PR TITLE
Issue #637 VPS runner Dashboard delivery を vault-backed にする

### DIFF
--- a/docs/setup/desktop-bootstrap-vault.md
+++ b/docs/setup/desktop-bootstrap-vault.md
@@ -108,7 +108,8 @@ Example:
     "apiTokenPath": "cloudflare/api-token.txt"
   },
   "gateway": {
-    "bearerTokenPath": "gateway/bearer-token.txt"
+    "bearerTokenPath": "gateway/bearer-token.txt",
+    "runtimeUrl": "https://your-worker.example.workers.dev"
   },
   "reviewer": {
     "geminiApiKeyPath": "reviewer/gemini-api-key.txt"
@@ -134,6 +135,8 @@ At minimum, the vault contract covers:
   - `accountId`
   - API token path
 - VTDD gateway bearer token path
+- VTDD runtime URL for VPS runner Dashboard event delivery, when the runner
+  cannot receive `VTDD_RUNTIME_URL` from its service environment
 - reviewer credential path(s), if configured
 
 ## Operational Model

--- a/scripts/run-vps-runner.mjs
+++ b/scripts/run-vps-runner.mjs
@@ -13,7 +13,10 @@ import {
   parseCodexReviewFallbackComment,
   resolveGitHubAppInstallationToken
 } from "../src/core/index.js";
-import { loadGitHubAppRoleCredentialsFromVault } from "../src/core/desktop-bootstrap-vault.js";
+import {
+  loadGatewayBearerTokenFromVault,
+  loadGitHubAppRoleCredentialsFromVault
+} from "../src/core/desktop-bootstrap-vault.js";
 import { buildExecutionLeadTime } from "../src/core/execution-lead-time.js";
 import { prepareGuardedPullRequestBody, prepareGuardedPullRequestBodyFile } from "./prepare-pr-body-file.mjs";
 import { renderPrBody } from "./render-pr-body.mjs";
@@ -2017,8 +2020,9 @@ async function postVpsRunnerDashboardEvent({ eventPayload, env = process.env, fe
       reason: "dashboard threadId is missing"
     };
   }
-  const runtimeUrl = normalizeText(env?.VTDD_RUNTIME_URL);
-  const bearerToken = normalizeText(env?.VTDD_GATEWAY_BEARER_TOKEN);
+  const deliveryConfig = await resolveVpsRunnerDashboardDeliveryConfig({ env });
+  const runtimeUrl = deliveryConfig.runtimeUrl;
+  const bearerToken = deliveryConfig.bearerToken;
   if (!runtimeUrl || !bearerToken) {
     return {
       status: "skipped",
@@ -2066,6 +2070,49 @@ async function postVpsRunnerDashboardEvent({ eventPayload, env = process.env, fe
       status: "failed",
       reason: summarizeDiagnosticText(error?.message || String(error), 240)
     };
+  }
+}
+
+async function resolveVpsRunnerDashboardDeliveryConfig({ env = process.env } = {}) {
+  const runtimeUrl =
+    normalizeText(env?.VTDD_RUNTIME_URL) ||
+    (await loadVpsRunnerRuntimeUrlFromVaultManifest({
+      manifestPath: env?.VTDD_VPS_RUNNER_CREDENTIALS_MANIFEST || env?.VTDD_CREDENTIALS_MANIFEST
+    }));
+  const envBearerToken = normalizeText(env?.VTDD_GATEWAY_BEARER_TOKEN);
+  if (envBearerToken) {
+    return {
+      runtimeUrl,
+      bearerToken: envBearerToken,
+      tokenSource: "env"
+    };
+  }
+
+  const vaultResult = await loadGatewayBearerTokenFromVault({
+    manifestPath: env?.VTDD_VPS_RUNNER_CREDENTIALS_MANIFEST || env?.VTDD_CREDENTIALS_MANIFEST
+  });
+  return {
+    runtimeUrl,
+    bearerToken: vaultResult.ok ? normalizeText(vaultResult.gateway?.bearerToken) : "",
+    tokenSource: vaultResult.ok ? "vault" : "missing"
+  };
+}
+
+async function loadVpsRunnerRuntimeUrlFromVaultManifest({ manifestPath } = {}) {
+  const normalizedManifestPath = normalizeText(manifestPath);
+  if (!normalizedManifestPath) {
+    return "";
+  }
+  try {
+    const manifest = JSON.parse(await fs.readFile(normalizedManifestPath, "utf8"));
+    return normalizeText(
+      manifest?.gateway?.runtimeUrl ||
+        manifest?.runtime?.url ||
+        manifest?.runtime?.runtimeUrl ||
+        manifest?.dashboard?.runtimeUrl
+    );
+  } catch {
+    return "";
   }
 }
 

--- a/test/vps-runner-script.test.js
+++ b/test/vps-runner-script.test.js
@@ -601,6 +601,68 @@ test("VPS runner event posts dashboard thread events to runtime", async () => {
   );
 });
 
+test("VPS runner event can read dashboard delivery token from vault manifest", async () => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "vtdd-vps-dashboard-vault-"));
+  const credentialsDir = path.join(tempDir, "credentials");
+  await fs.mkdir(path.join(credentialsDir, "gateway"), { recursive: true });
+  const manifestPath = path.join(credentialsDir, "manifest.json");
+  await fs.writeFile(path.join(credentialsDir, "gateway", "bearer-token.txt"), "vault-token-for-test\n");
+  await fs.writeFile(
+    manifestPath,
+    JSON.stringify(
+      {
+        version: 1,
+        gateway: {
+          bearerTokenPath: "gateway/bearer-token.txt",
+          runtimeUrl: "https://vtdd-v2-mvp.example.workers.dev"
+        }
+      },
+      null,
+      2
+    )
+  );
+
+  const githubCalls = [];
+  const runtimeCalls = [];
+  await postVpsRunnerEvent({
+    githubFetch: async (url, init = {}) => {
+      githubCalls.push({ url, init });
+      return { id: 45005 };
+    },
+    fetchImpl: async (url, init = {}) => {
+      runtimeCalls.push({ url: String(url), init });
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 202,
+        headers: { "content-type": "application/json" }
+      });
+    },
+    env: {
+      VTDD_VPS_RUNNER_CREDENTIALS_MANIFEST: manifestPath
+    },
+    payload: {
+      executionId: "exec-dashboard-vault-runtime",
+      repository: "marushu/vtdd-v2-p",
+      issueNumber: 637,
+      handoff: {
+        dashboardThreadId: "dashboard-main-marushu-vtdd-v2-p"
+      }
+    },
+    event: {
+      status: "completed",
+      lastEvent: "privileged_maintenance_completed",
+      currentStep: "vps_privileged_maintenance_helper",
+      message: "完了"
+    }
+  });
+
+  assert.equal(runtimeCalls.length, 1);
+  assert.equal(runtimeCalls[0].url, "https://vtdd-v2-mvp.example.workers.dev/v2/events/vps-runner");
+  assert.equal(runtimeCalls[0].init.headers.authorization, "Bearer vault-token-for-test");
+  const parsed = parseVpsRunnerEventComment(githubCalls[0].init.body.body);
+  assert.equal(parsed.ok, true);
+  assert.equal(parsed.event.dashboardDelivery.status, "delivered");
+});
+
 test("VPS runner event records missing runtime dashboard delivery configuration", async () => {
   const calls = [];
   await postVpsRunnerEvent({


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #637 の部分進捗です。PR #701 merge 後の live E2E で `threadId` は Dashboard thread に戻りましたが、VPS runner の Dashboard 配送が `VTDD_RUNTIME_URL or VTDD_GATEWAY_BEARER_TOKEN is missing` で skipped になりました。この PR は runner completed event が env だけでなく VPS vault manifest から Dashboard 配送設定を解決できるようにします。

## Satisfied Success Criteria

- VPS runner の Dashboard event 配送が、`VTDD_GATEWAY_BEARER_TOKEN` env 不在時に `~/.vtdd/credentials/manifest.json` の gateway bearer token を fallback として読めるようにしました。
- `VTDD_RUNTIME_URL` env 不在時に、vault manifest の非秘密 runtime URL フィールドから配送先を読めるようにしました。
- Dashboard thread event の `delivered` evidence を unit test で追加しました。

## Unsatisfied Success Criteria

- production VPS manifest には現時点で runtime URL がまだ入っていないため、merge 後に VPS 側 manifest へ非秘密 runtime URL を反映し、#637 live E2E を再実行する必要があります。
- Issue #637 の complete / close 条件は満たしていません。

## Non-goal violations

None.

## Dry-run Impact Report

- Target Issue: Issue #637
- Implementing Success Criteria: VPS runner の helper completed event を Dashboard Butler thread に配送するため、runner が vault-backed Dashboard delivery config を解決できるようにする。
- Explicit Non-goals: root/sudo helper 実行の追加、secret 値の表示、Worker route 変更、Custom GPT Action Schema 変更、production deploy、Issue close
- Expected touched files/routes/workflows: `scripts/run-vps-runner.mjs`, `test/vps-runner-script.test.js`, `docs/setup/desktop-bootstrap-vault.md`
- Affected Issues: Issue #637。Issue #413 / #450 の owner-facing runtime truth へ後続影響があります。
- Affected PRs: PR #701 の post-merge live E2E で見つかった Dashboard delivery skipped blocker の後続 slice です。
- Affected workflows: VPS runner one-shot poller。GitHub Actions deploy workflow は変更しません。
- Affected runtime/operator surfaces: Dashboard Butler thread event delivery, VPS runner, desktop/VPS credential vault manifest contract
- What may break if we patch narrowly: env だけを前提にすると systemd user service 側の Environment 空状態で Dashboard delivery が永続的に skipped になります。vault fallback を入れても production manifest に runtime URL が無ければ live E2E は完了しません。
- Unknowns to investigate before coding: VPS runner service の Environment が空か、VPS vault manifest に gateway token と runtime URL があるか。
- Validation needed: `node --test test/vps-runner-script.test.js --test-name-pattern 'dashboard delivery token|dashboard thread events|missing runtime dashboard delivery'`, `node --test test/desktop-bootstrap-vault.test.js`, merge 後 #637 Dashboard Butler live E2E
- Stop condition: secret 値を GitHub comment / PR / RAG / stdout に出す必要が出た場合、または runtime destination mutation を passkey 境界なしに広げる必要が出た場合は停止します。

## Execution Queue Delta

- Queue position before: Issue #637 は `Now` の VPS privileged maintenance root blocker です。
- Preemption decision: NEXT。PR #701 の live E2E で同じ #637 の Dashboard delivery blocker が残ったため、queue は動かさず同一 Issue 内で続行します。
- Queue delta: Issue #637 の runner completed event delivery を前進させます。production VPS manifest 反映と live E2E は残ります。
- Why this PR is next: helper execution は成功し threadId も preserved になった一方、Dashboard thread へ戻る最後の配送が env 欠落で skipped になっており、ここを直さないと Butler Completion Gate に到達できないため。
- Active Issues not downscoped: Active Issues は縮小しません。このPRで扱わない #637 success criteria と他 active Issues は未完了として残します。

## File / Line Hypotheses

- file: `scripts/run-vps-runner.mjs`
  - hypothesis: `postVpsRunnerDashboardEvent` が `process.env` だけを見ているため、systemd user service の `Environment=` が空だと Dashboard delivery が skipped になる。
  - risk if changed narrowly: token 値をログや GitHub comment に出すと credential leak になる。runtime URL は owner-specific なので repo に固定してはいけない。
  - validation: vault manifest を使う unit test と live #637 E2E。
  - related Issue: Issue #637
- file: `docs/setup/desktop-bootstrap-vault.md`
  - hypothesis: vault manifest は gateway bearer token path を定義しているが、VPS runner Dashboard delivery の runtime URL fallback 契約が明文化されていない。
  - risk if changed narrowly: operator-specific runtime URL を public repo に埋め込むと public/core 再利用性を壊す。
  - validation: example URL のみを docs に置き、実値は repo に入れない。
  - related Issue: Issue #637

## Hypothesis Retrospective

- expected: env が空でも vault manifest に token と runtime URL があれば Dashboard event が runtime endpoint に POST される。
- actual: local unit test で vault-backed delivery が `delivered` になりました。production live E2E は merge 後に必要です。
- mismatch: VPS production manifest は現時点で token path はあるが runtime URL が無いため、この PR だけでは live complete になりません。
- lesson: VPS runner の Dashboard delivery は env-only ではなく、VPS vault contract とセットで扱う必要があります。
- should become RAG candidate: yes。Issue #637 の runner result delivery は threadId preservation と runtime/token config の両方が必要です。

## Verification Evidence

- Unit: `node --test test/vps-runner-script.test.js --test-name-pattern 'dashboard delivery token|dashboard thread events|missing runtime dashboard delivery'` passed。70 passed。`node --test test/desktop-bootstrap-vault.test.js` passed。5 passed。
- Integration: `git diff --check` passed。
- E2E: 未実施。merge 後に production VPS manifest runtime URL 反映と #637 Dashboard Butler live E2E が必要です。
- Manual: VPS read-only で `vtdd-vps-runner.service` の `Environment=` が空、`~/.vtdd/credentials/manifest.json` に gateway token path があり token file が non-empty、runtime URL は未設定であることを確認しました。
- Evidence path/link: PR body。

## Butler Completion Contract

- Primary owner surface: Dashboard Butler。
- Fallback surface: Custom GPT は fallback surface としてのみ扱います。主経路ではありません。
- Owner goal: Dashboard Butler の自然文 VPS runner status intent から scoped passkey approval 後、VPS helper result が同じ Dashboard thread に戻ること。
- Butler entrypoint: Dashboard Butler の通常チャット自然文入口。
- Dashboard Butler natural-language path: Dashboard Butler 通常チャットで VPS runner status intent を受け、approval_required / queue / runner result / Dashboard thread delivery へ到達する経路です。
- Action Schema exposure: Custom GPT fallback 用の露出状態であり、この PR の主経路ではありません。この PR では変更しません。
- Runtime path: `scripts/run-vps-runner.mjs` の `postVpsRunnerEvent` -> `postVpsRunnerDashboardEvent` が `/v2/events/vps-runner` へ Dashboard thread event を送ります。
- Runner/runtime truth: PR #701 後の live E2E で `threadId` は present、`dashboardDelivery.status=skipped` / reason `VTDD_RUNTIME_URL or VTDD_GATEWAY_BEARER_TOKEN is missing` を確認済み。この PR はその config 解決を進めます。
- Authority boundary: secret 値は表示しません。runtime URL / token の production VPS config 反映はこの PR 外で、必要なら scoped passkey 境界として扱います。
- E2E evidence: 未実施。merge 後 #637 Dashboard Butler live E2E が必要です。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 不要。Worker runtime / generated worker は変更しません。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。merge 後に #637 live E2E を再実行します。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate
- AGENTS.md Butler-First Operating Principle
- AGENTS.md Authority Boundary
- AGENTS.md Evidence Discipline
- docs/butler/execution-queue-contract.md
- docs/mvp/active-issue-execution-queue.md

## Out-of-scope but NOT implemented

- production VPS manifest runtime URL mutation
- production deploy
- root/sudo helper execution changes
- Issue #637 close

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #637
- Execution ID: issue637-vps-runner-runtime-vault
- Goal: Allow VPS runner Dashboard delivery to use vault-backed runtime configuration
