### PR TITLE
Issue #703 Butler handoff に作戦図を接続

### DIFF
--- a/docs/development-strategy/issue-703-butler-strategy-handoff.md
+++ b/docs/development-strategy/issue-703-butler-strategy-handoff.md
@@ -1,0 +1,69 @@
+# Issue #703 Butler 作戦図 handoff 接続
+
+## 完了体験
+
+Dashboard Butler で owner が自然文のまま Issue-backed 実装 GO を出した時、Butler はコードへ飛ばず、まず対象 Issue にひもづく開発前作戦図を handoff payload に持たせる。VPS runner / remote Codex はその作戦図を PR body に反映し、作戦図なしの実装 PR は失敗する。
+
+## VTDD 全体で進める部分
+
+Issue #703 の guardrail を mac Codex / VPS runner の PR body validation だけで終わらせず、Dashboard Butler の自然文 build handoff 入口まで接続する。これにより、owner が iPhone / iPad から自然に GO した場合も、実装前の予見・予測・あたりをつける工程を通る。
+
+## 設計
+
+Dashboard Butler の `/v2/action/execute` build handoff 正規化で、Issue 番号、repository input、runtime branch、owner message、traceability refs から最小限の deterministic 作戦図ドラフトを作る。既に `continuationContext.handoff.developmentStrategy` または `payload.developmentStrategy` がある場合は、それを尊重する。`src/core/remote-codex-executor.js` は handoff の `developmentStrategy` を落とさず request / queue comment へ運ぶ。`src/core/remote-codex-handoff-scope.js` は Butler build handoff の bounded 判定に developmentStrategy の最低限の具体性を含める。
+
+## 仮説
+
+現在の root blocker は、PR #704 が VPS runner の PR body 正規化だけを塞ぎ、Dashboard Butler の natural-language build handoff が developmentStrategy を生成・保持しない点にある。`normalizeRemoteCodexHandoffPayload` と `createRemoteCodexExecutionRequest` の間で strategy を補完・保持すれば、Butler 入口から runner まで同じ guardrail が届く。
+
+## 検証計画
+
+- `test/worker.test.js`: 自然文 build GO で dispatch される `handoff_json` に `developmentStrategy` が入り、Issue #135 の evidence path を持つことを確認する。
+- `test/butler-orchestrator.test.js`: bounded remote Codex handoff は concrete developmentStrategy なしでは通らず、ありなら通ることを確認する。
+- `test/remote-codex-executor.test.js`: request normalization が handoff の developmentStrategy を落とさないことを確認する。
+- `node --test test/butler-orchestrator.test.js test/remote-codex-executor.test.js test/worker.test.js test/vps-runner-script.test.js test/pr-body-guardrail.test.js` を実行する。
+
+## 改修見積もり
+
+- `src/worker/runtime.js:6999 normalizeRemoteCodexHandoffPayload`: Butler build handoff に developmentStrategy を補完する。repository / Issue / branch / ownerMessage / traceability refs から deterministic draft を作る。
+- `src/core/remote-codex-handoff-scope.js:1 isBoundRemoteCodexHandoff`: bounded handoff 判定へ concrete developmentStrategy の最低限 validation を追加する。
+- `src/core/remote-codex-executor.js:91 createRemoteCodexExecutionRequest`: handoff.developmentStrategy を request に残し、VPS runner queue comment へ渡す。
+- `test/worker.test.js:7724 natural Butler build GO`: dispatch inputs の handoff_json に strategy が入ることを確認する。
+- `test/butler-orchestrator.test.js:99 bounded remote Codex handoff`: strategy 必須化の positive / negative を追加する。
+- `test/remote-codex-executor.test.js`: request が strategy を保持する単体確認を追加する。
+
+## 既に通っている経路
+
+PR #704 で PR body template / renderer / validator / guarded workflow / VPS runner PR body generation は作戦図を要求するようになった。`scripts/run-vps-runner.mjs` は handoff.developmentStrategy または payload.developmentStrategy を PR body に使える。
+
+## 未確認の境界
+
+Dashboard Butler に専用の編集 UI はまだ作らない。今回の範囲は自然文 build handoff の payload に作戦図を載せる runtime 接続であり、owner が画面上で作戦図を編集する UX は別 Issue 候補に残る。LLM による深い設計品質はこの PR では保証せず、deterministic draft と PR validator による最低限の gate とする。
+
+## 穴が出そうな箇所
+
+- strategy を runtime で補完しても、内容が薄ければ「形だけ」になる。PR validator の具体性 check と runner 側拒否で最低限を守る。
+- `createRemoteCodexExecutionRequest` が handoff object を再構成する時に strategy を落とすと、VPS runner へ届かない。
+- 既存テストの Custom GPT surface 名は残るが、主経路は Dashboard Butler と明記し、Action Schema fallback と混同しない。
+
+## PR 前に確認すること
+
+Issue #703、AGENTS.md、`docs/butler/pre-development-strategy-contract.md`、`src/worker/runtime.js` の handoff normalization、`src/core/remote-codex-executor.js` の request generation、`src/core/remote-codex-handoff-scope.js` の bounded 判定、関連 worker/orchestrator/runner tests を確認した。
+
+## 実装候補と捨てた案
+
+- 採用: runtime が deterministic 作戦図 draft を補完し、handoff.developmentStrategy として運ぶ。
+- 捨てた案: Dashboard 専用 UI を先に作る。UX は重要だが、この PR の root blocker は natural-language build handoff の未接続なので、UI 先行は scope が大きすぎる。
+- 捨てた案: VPS runner 側だけで欠落を拒否する。これでは Butler があたりをつけられず、owner-facing 入口が改善しない。
+
+## merge 後に通す E2E
+
+PR merge 後は deploy が必要な worker/runtime 変更として扱う。production deploy 後、Dashboard Butler から Issue-backed build handoff を試し、runtime truth / queue comment / PR body に developmentStrategy が残ることを確認する。
+
+## 次の PR を増やさない理由
+
+入口の補完、bounded 判定、request 保持、worker/orchestrator/executor tests を同じ PR に入れるため、「Butler は作ったが runner に届かない」「runner は受けるが Butler が作れない」という予測可能な穴をこの PR 内で塞ぐ。
+
+## 停止条件
+
+作戦図を補完するために LLM 呼び出し、credential mutation、deploy、root/helper、GitHub permission 変更が必要になったら止める。Dashboard 作戦図編集 UI が必須だと分かった場合は、この PR では incomplete として Issue に残す。

--- a/src/core/remote-codex-executor.js
+++ b/src/core/remote-codex-executor.js
@@ -163,6 +163,7 @@ export function createRemoteCodexExecutionRequest(input = {}) {
             ownerMessage: normalizeText(handoff.ownerMessage),
             repositoryInput: normalizeText(handoff.repositoryInput),
             dashboardThreadId: normalizeText(handoff.dashboardThreadId),
+            developmentStrategy: normalizeDevelopmentStrategy(handoff.developmentStrategy),
             targetPullRequest: revisionTarget
           }
         : null
@@ -210,6 +211,31 @@ export function createRemoteCodexExecutionRequest(input = {}) {
   }
 
   return issues.length > 0 ? { ok: false, issues } : { ok: true, request };
+}
+
+function normalizeDevelopmentStrategy(value) {
+  const strategy = normalizeObject(value);
+  if (!strategy || Object.keys(strategy).length === 0) {
+    return undefined;
+  }
+
+  return {
+    evidencePath: normalizeText(strategy.evidencePath),
+    completionExperience: normalizeText(strategy.completionExperience),
+    vtddArea: normalizeText(strategy.vtddArea),
+    design: normalizeText(strategy.design),
+    hypothesis: normalizeText(strategy.hypothesis),
+    verificationPlan: normalizeText(strategy.verificationPlan),
+    changeEstimate: normalizeText(strategy.changeEstimate),
+    knownPath: normalizeText(strategy.knownPath),
+    unknownBoundary: normalizeText(strategy.unknownBoundary),
+    likelyGaps: normalizeText(strategy.likelyGaps),
+    prePrChecks: normalizeText(strategy.prePrChecks),
+    optionsRejected: normalizeText(strategy.optionsRejected),
+    postMergeE2E: normalizeText(strategy.postMergeE2E),
+    noNextPrReason: normalizeText(strategy.noNextPrReason),
+    stopCondition: normalizeText(strategy.stopCondition)
+  };
 }
 
 function validateRevisionTarget(request) {

--- a/src/core/remote-codex-handoff-scope.js
+++ b/src/core/remote-codex-handoff-scope.js
@@ -10,10 +10,44 @@ export function isBoundRemoteCodexHandoff(input = {}) {
     handoff.issueTraceable === true &&
     handoff.approvalScopeMatched === true &&
     Boolean(normalizeText(handoff.summary)) &&
+    hasConcreteDevelopmentStrategy(handoff.developmentStrategy, issueNumber) &&
     issueNumber !== null &&
     relatedIssue === issueNumber &&
     hasBoundIssueTraceability(input?.policyInput, issueNumber)
   );
+}
+
+function hasConcreteDevelopmentStrategy(value, issueNumber) {
+  const strategy = normalizeObject(value);
+  if (!strategy || Object.keys(strategy).length === 0) {
+    return false;
+  }
+
+  const evidencePath = normalizeText(strategy.evidencePath);
+  if (
+    !new RegExp(`docs/development-strategy/issue-${issueNumber}-[^\\s)]+\\.md`).test(
+      evidencePath
+    )
+  ) {
+    return false;
+  }
+
+  return [
+    "completionExperience",
+    "vtddArea",
+    "design",
+    "hypothesis",
+    "verificationPlan",
+    "changeEstimate",
+    "knownPath",
+    "unknownBoundary",
+    "likelyGaps",
+    "prePrChecks",
+    "optionsRejected",
+    "postMergeE2E",
+    "noNextPrReason",
+    "stopCondition"
+  ].every((field) => normalizeText(strategy[field]).length >= 12);
 }
 
 function hasBoundIssueTraceability(policyInput, issueNumber) {

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -7034,9 +7034,16 @@ function normalizeRemoteCodexHandoffPayload(payload) {
     payload?.apiKeyRunnerAcknowledged === true ||
     continuationContext.apiKeyRunnerAcknowledged === true ||
     (goGranted && requestedExecutorTransport === "api_key_runner");
+  const developmentStrategy = resolveButlerHandoffDevelopmentStrategy({
+    payload,
+    handoff,
+    policyInput,
+    issueNumber
+  });
 
   return {
     ...payload,
+    developmentStrategy,
     apiKeyRunnerAcknowledged,
     continuationContext: {
       ...continuationContext,
@@ -7047,6 +7054,7 @@ function normalizeRemoteCodexHandoffPayload(payload) {
         issueTraceable: handoff.issueTraceable === false ? false : true,
         approvalScopeMatched: handoff.approvalScopeMatched === false ? false : true,
         relatedIssue: normalizeIssue(handoff.relatedIssue) ?? issueNumber,
+        developmentStrategy,
         summary:
           normalizeText(handoff.summary) ||
           `Issue #${issueNumber} bounded remote Codex handoff`
@@ -7072,6 +7080,96 @@ function normalizeRemoteCodexHandoffPayload(payload) {
       }
     }
   };
+}
+
+function resolveButlerHandoffDevelopmentStrategy({ payload, handoff, policyInput, issueNumber }) {
+  const existing =
+    normalizeDevelopmentStrategyObject(handoff.developmentStrategy) ||
+    normalizeDevelopmentStrategyObject(payload?.developmentStrategy);
+  if (existing) {
+    return existing;
+  }
+
+  return buildButlerHandoffDevelopmentStrategyDraft({
+    payload,
+    handoff,
+    policyInput,
+    issueNumber
+  });
+}
+
+function normalizeDevelopmentStrategyObject(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  const strategy = {
+    evidencePath: normalizeText(value.evidencePath),
+    completionExperience: normalizeText(value.completionExperience),
+    vtddArea: normalizeText(value.vtddArea),
+    design: normalizeText(value.design),
+    hypothesis: normalizeText(value.hypothesis),
+    verificationPlan: normalizeText(value.verificationPlan),
+    changeEstimate: normalizeText(value.changeEstimate),
+    knownPath: normalizeText(value.knownPath),
+    unknownBoundary: normalizeText(value.unknownBoundary),
+    likelyGaps: normalizeText(value.likelyGaps),
+    prePrChecks: normalizeText(value.prePrChecks),
+    optionsRejected: normalizeText(value.optionsRejected),
+    postMergeE2E: normalizeText(value.postMergeE2E),
+    noNextPrReason: normalizeText(value.noNextPrReason),
+    stopCondition: normalizeText(value.stopCondition)
+  };
+  return Object.values(strategy).some(Boolean) ? strategy : null;
+}
+
+function buildButlerHandoffDevelopmentStrategyDraft({ payload, handoff, policyInput, issueNumber }) {
+  const repositoryInput =
+    normalizeText(policyInput?.repositoryInput) ||
+    normalizeText(handoff.repositoryInput) ||
+    normalizeText(payload?.repositoryInput) ||
+    "対象 repository";
+  const branch =
+    normalizeText(payload?.executionTarget?.branch) ||
+    normalizeText(policyInput?.runtimeTruth?.runtimeState?.activeBranch) ||
+    (issueNumber ? `codex/issue-${issueNumber}` : "codex/issue");
+  const ownerIntent =
+    normalizeText(handoff.ownerMessage) ||
+    normalizeText(payload?.ownerMessage) ||
+    normalizeText(payload?.message) ||
+    `Issue #${issueNumber} の実装を進める`;
+  const traceability =
+    policyInput?.issueTraceability && typeof policyInput.issueTraceability === "object"
+      ? policyInput.issueTraceability
+      : {};
+  const intentRefs = formatTraceRefs(traceability.intentRefs, `#${issueNumber} Intent`);
+  const successRefs = formatTraceRefs(
+    traceability.successCriteriaRefs,
+    `#${issueNumber} Success Criteria`
+  );
+  const nonGoalRefs = formatTraceRefs(traceability.nonGoalRefs, `#${issueNumber} Non-goals`);
+
+  return {
+    evidencePath: `docs/development-strategy/issue-${issueNumber}-butler-handoff.md`,
+    completionExperience: `Dashboard Butler から自然文 GO した owner が、${repositoryInput} の Issue #${issueNumber} 実装前に作戦図付き handoff で進められる。`,
+    vtddArea: "Dashboard Butler の自然文 build handoff と VPS runner PR 作成前 guardrail を接続する。",
+    design: `Butler が ${ownerIntent} をすぐ実装へ渡さず、Issue #${issueNumber} の traceability と branch ${branch} をもとに作戦図を handoff.developmentStrategy へ固定する。`,
+    hypothesis: "浅い PR 連鎖の原因は、Butler build handoff が実装前の仮説と検証計画を持たずに runner へ渡ることにある。",
+    verificationPlan: "worker / orchestrator / remote Codex executor / VPS runner の tests で、作戦図なし handoff が止まり、作戦図付き handoff が PR body に届くことを確認する。",
+    changeEstimate: "src/worker/runtime.js の normalizeRemoteCodexHandoffPayload、src/core/remote-codex-handoff-scope.js、src/core/remote-codex-executor.js、関連 worker/orchestrator/runner tests を確認・改修する。",
+    knownPath: `既存の Butler execute route、issue refs (${intentRefs}, ${successRefs}, ${nonGoalRefs})、VPS runner PR body renderer は存在する。`,
+    unknownBoundary: "Dashboard 上の専用編集 UI や LLM による深い設計生成はこの handoff draft だけでは未完成として扱う。",
+    likelyGaps: "handoff 途中で developmentStrategy を落とすと、VPS runner が PR body を作れないか、作戦図なしの浅い PR に戻る。",
+    prePrChecks: "対象 Issue、AGENTS.md、pre-development strategy contract、handoff normalization、runner PR body validation、関連 tests を PR 前に確認する。",
+    optionsRejected: "VPS runner 側だけで拒否する案は捨て、Butler 入口で作戦図 draft を持たせる。",
+    postMergeE2E: "production deploy 後に Dashboard Butler から自然文 build handoff を通し、queue comment と PR body に developmentStrategy が残ることを確認する。",
+    noNextPrReason: "Butler 入口、bounded 判定、executor request 保持、runner PR body 反映を同じ実装範囲で塞ぐ。",
+    stopCondition: "作戦図なしで bounded build handoff が allowed になる場合、または deploy/root/credential mutation が必要になった場合は停止する。"
+  };
+}
+
+function formatTraceRefs(value, fallback) {
+  const refs = Array.isArray(value) ? value.map(normalizeText).filter(Boolean) : [];
+  return refs.length > 0 ? refs.join(", ") : fallback;
 }
 
 function mergeGrantedConsentCategories(current, required) {

--- a/test/butler-orchestrator.test.js
+++ b/test/butler-orchestrator.test.js
@@ -38,6 +38,26 @@ const approvalContext = {
   approvalScopeMatched: true
 };
 
+function developmentStrategy(issueNumber = 125) {
+  return {
+    evidencePath: `docs/development-strategy/issue-${issueNumber}-butler-handoff.md`,
+    completionExperience: "Dashboard Butler から自然文 GO した owner が、実装前作戦図付き handoff で進められる。",
+    vtddArea: "Dashboard Butler の自然文 build handoff と VPS runner PR 作成前 guardrail を接続する。",
+    design: "Butler が owner intent をすぐ実装へ渡さず、Issue traceability と branch をもとに作戦図を handoff に固定する。",
+    hypothesis: "浅い PR 連鎖の原因は、Butler build handoff が実装前の仮説と検証計画を持たずに runner へ渡ることにある。",
+    verificationPlan: "worker / orchestrator / remote Codex executor / VPS runner tests で作戦図が保持されることを確認する。",
+    changeEstimate: "src/worker/runtime.js、src/core/remote-codex-handoff-scope.js、src/core/remote-codex-executor.js と関連 tests を改修する。",
+    knownPath: "既存の Butler execute route、issue refs、VPS runner PR body renderer は存在する。",
+    unknownBoundary: "Dashboard 上の専用編集 UI や LLM による深い設計生成はこの handoff draft だけでは未完成として扱う。",
+    likelyGaps: "handoff 途中で developmentStrategy を落とすと、VPS runner が PR body を作れなくなる。",
+    prePrChecks: "対象 Issue、AGENTS.md、strategy contract、handoff normalization、runner validation を確認する。",
+    optionsRejected: "VPS runner 側だけで拒否する案は捨て、Butler 入口で作戦図 draft を持たせる。",
+    postMergeE2E: "production deploy 後に Dashboard Butler から自然文 build handoff を通し、queue comment と PR body を確認する。",
+    noNextPrReason: "Butler 入口、bounded 判定、executor request 保持、runner PR body 反映を同じ範囲で塞ぐ。",
+    stopCondition: "作戦図なしで bounded build handoff が allowed になる場合は停止する。"
+  };
+}
+
 test("butler orchestrator allows issue creation when all gates pass", () => {
   const result = evaluateButlerExecution({
     surfaceContext: {
@@ -115,6 +135,7 @@ test("butler orchestrator allows build only as bounded remote Codex handoff", ()
         issueTraceable: true,
         approvalScopeMatched: true,
         relatedIssue: 125,
+        developmentStrategy: developmentStrategy(125),
         summary: "Issue #125 bounded Codex handoff"
       }
     },
@@ -144,6 +165,54 @@ test("butler orchestrator allows build only as bounded remote Codex handoff", ()
   assert.equal(result.repository, "sample-org/vtdd-v2");
 });
 
+test("butler orchestrator blocks build handoff without development strategy", () => {
+  const result = evaluateButlerExecution({
+    surfaceContext: {
+      surface: "custom_gpt",
+      judgmentModelId: "vtdd-butler-core-v1"
+    },
+    judgmentTrace,
+    runtimeContext: {
+      allowButlerRemoteCodexHandoff: true
+    },
+    issueContext: {
+      issueNumber: 125
+    },
+    continuationContext: {
+      requiresHandoff: true,
+      handoff: {
+        issueTraceable: true,
+        approvalScopeMatched: true,
+        relatedIssue: 125,
+        summary: "Issue #125 bounded Codex handoff"
+      }
+    },
+    policyInput: {
+      actionType: ActionType.BUILD,
+      mode: "execution",
+      repositoryInput: "vtdd",
+      aliasRegistry: registry,
+      targetConfirmed: true,
+      constitutionConsulted: true,
+      runtimeTruth: { runtimeAvailable: true },
+      credential: { model: "github_app", tier: CredentialTier.EXECUTE },
+      consent: fullConsent,
+      ...approvalContext,
+      issueTraceable: true,
+      issueTraceability: {
+        relatedIssue: 125,
+        intentRefs: ["#125 Intent"],
+        successCriteriaRefs: ["#125 Success Criteria"],
+        nonGoalRefs: ["#125 Non-goals"]
+      },
+      go: true,
+      passkey: false
+    }
+  });
+  assert.equal(result.allowed, false);
+  assert.equal(result.blockedByRule, "role_action_boundary");
+});
+
 test("butler orchestrator derives constitution consultation from valid judgment trace", () => {
   const result = evaluateButlerExecution({
     surfaceContext: {
@@ -163,6 +232,7 @@ test("butler orchestrator derives constitution consultation from valid judgment 
         issueTraceable: true,
         approvalScopeMatched: true,
         relatedIssue: 125,
+        developmentStrategy: developmentStrategy(125),
         summary: "Issue #125 bounded Codex handoff"
       }
     },
@@ -210,6 +280,7 @@ test("butler orchestrator derives approval scope match from bounded remote hando
         issueTraceable: true,
         approvalScopeMatched: true,
         relatedIssue: 125,
+        developmentStrategy: developmentStrategy(125),
         summary: "Issue #125 bounded Codex handoff"
       }
     },
@@ -257,6 +328,7 @@ test("butler orchestrator derives GitHub App credential from bounded remote hand
         issueTraceable: true,
         approvalScopeMatched: true,
         relatedIssue: 125,
+        developmentStrategy: developmentStrategy(125),
         summary: "Issue #125 bounded Codex handoff"
       }
     },
@@ -303,6 +375,7 @@ test("butler orchestrator does not derive handoff approval from non-string summa
         issueTraceable: true,
         approvalScopeMatched: true,
         relatedIssue: 125,
+        developmentStrategy: developmentStrategy(125),
         summary: 125
       }
     },
@@ -350,6 +423,7 @@ test("butler orchestrator does not derive handoff approval from non-string refs"
         issueTraceable: true,
         approvalScopeMatched: true,
         relatedIssue: 125,
+        developmentStrategy: developmentStrategy(125),
         summary: "Issue #125 bounded Codex handoff"
       }
     },
@@ -394,6 +468,7 @@ test("butler orchestrator blocks self-asserted build handoff outside execute rou
         issueTraceable: true,
         approvalScopeMatched: true,
         relatedIssue: 125,
+        developmentStrategy: developmentStrategy(125),
         summary: "Issue #125 bounded Codex handoff"
       }
     },
@@ -478,6 +553,7 @@ test("butler orchestrator blocks build handoff without explicit issue section re
         issueTraceable: true,
         approvalScopeMatched: true,
         relatedIssue: 125,
+        developmentStrategy: developmentStrategy(125),
         summary: "Issue #125 bounded Codex handoff"
       }
     },

--- a/test/remote-codex-executor.test.js
+++ b/test/remote-codex-executor.test.js
@@ -13,6 +13,26 @@ import {
   retrieveVpsRunnerHealthStatus
 } from "../src/core/index.js";
 
+function developmentStrategy(issueNumber = 6) {
+  return {
+    evidencePath: `docs/development-strategy/issue-${issueNumber}-butler-handoff.md`,
+    completionExperience: "Dashboard Butler から自然文 GO した owner が、実装前作戦図付き handoff で進められる。",
+    vtddArea: "Dashboard Butler の自然文 build handoff と VPS runner PR 作成前 guardrail を接続する。",
+    design: "Butler が owner intent をすぐ実装へ渡さず、Issue traceability と branch をもとに作戦図を handoff に固定する。",
+    hypothesis: "浅い PR 連鎖の原因は、Butler build handoff が実装前の仮説と検証計画を持たずに runner へ渡ることにある。",
+    verificationPlan: "worker / orchestrator / remote Codex executor / VPS runner tests で作戦図が保持されることを確認する。",
+    changeEstimate: "src/worker/runtime.js、src/core/remote-codex-handoff-scope.js、src/core/remote-codex-executor.js と関連 tests を改修する。",
+    knownPath: "既存の Butler execute route、issue refs、VPS runner PR body renderer は存在する。",
+    unknownBoundary: "Dashboard 上の専用編集 UI や LLM による深い設計生成はこの handoff draft だけでは未完成として扱う。",
+    likelyGaps: "handoff 途中で developmentStrategy を落とすと、VPS runner が PR body を作れなくなる。",
+    prePrChecks: "対象 Issue、AGENTS.md、strategy contract、handoff normalization、runner validation を確認する。",
+    optionsRejected: "VPS runner 側だけで拒否する案は捨て、Butler 入口で作戦図 draft を持たせる。",
+    postMergeE2E: "production deploy 後に Dashboard Butler から自然文 build handoff を通し、queue comment と PR body を確認する。",
+    noNextPrReason: "Butler 入口、bounded 判定、executor request 保持、runner PR body 反映を同じ範囲で塞ぐ。",
+    stopCondition: "作戦図なしで bounded build handoff が allowed になる場合は停止する。"
+  };
+}
+
 test("remote Codex transport registry exposes pluggable user-owned backend choices", () => {
   const registry = getRemoteCodexExecutorTransportRegistry();
 
@@ -66,6 +86,54 @@ test("remote Codex execution request is built from gateway result and payload", 
   assert.equal(result.request.branch, "codex/issue-6");
   assert.equal(result.request.baseRef, "main");
   assert.equal(result.request.codexGoal, "open_pr");
+});
+
+test("remote Codex execution request preserves handoff development strategy", () => {
+  const result = createRemoteCodexExecutionRequest({
+    payload: {
+      actorRole: ActorRole.BUTLER,
+      issueContext: { issueNumber: 6 },
+      continuationContext: {
+        requiresHandoff: true,
+        handoff: {
+          issueTraceable: true,
+          approvalScopeMatched: true,
+          relatedIssue: 6,
+          summary: "Issue #6 bounded remote Codex handoff",
+          developmentStrategy: developmentStrategy(6)
+        }
+      },
+      policyInput: {
+        approvalPhrase: "GO",
+        targetConfirmed: true,
+        approvalScopeMatched: true,
+        issueTraceability: {
+          relatedIssue: 6,
+          intentRefs: ["#6 Intent"],
+          successCriteriaRefs: ["#6 Success Criteria"],
+          nonGoalRefs: ["#6 Non-goals"]
+        },
+        runtimeTruth: {
+          runtimeState: {
+            activeBranch: "codex/issue-6"
+          }
+        }
+      }
+    },
+    gatewayResult: {
+      repository: "sample-org/vtdd-v2",
+      executionContinuity: {
+        codexGoal: "open_pr"
+      }
+    }
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(
+    result.request.handoff.developmentStrategy.evidencePath,
+    "docs/development-strategy/issue-6-butler-handoff.md"
+  );
+  assert.match(result.request.handoff.developmentStrategy.hypothesis, /浅い PR 連鎖/);
 });
 
 test("remote Codex execution request accepts explicit bounded PR revision goal override", () => {

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -7818,7 +7818,13 @@ test("worker accepts natural Butler build GO without internal consent or approva
   assert.equal(dispatchInputs.target_issue_number, "135");
   assert.equal(dispatchInputs.codex_goal, "open_pr");
   assert.equal(dispatchInputs.approval_phrase, "GO");
-  assert.equal(JSON.parse(dispatchInputs.handoff_json).relatedIssue, 135);
+  const handoff = JSON.parse(dispatchInputs.handoff_json);
+  assert.equal(handoff.relatedIssue, 135);
+  assert.equal(
+    handoff.developmentStrategy.evidencePath,
+    "docs/development-strategy/issue-135-butler-handoff.md"
+  );
+  assert.match(handoff.developmentStrategy.hypothesis, /Butler build handoff/);
   assert.equal(calls.length, 3);
 });
 

--- a/worker.js
+++ b/worker.js
@@ -33523,7 +33523,35 @@ function isBoundRemoteCodexHandoff(input = {}) {
   const issueContext = normalizeObject7(input?.issueContext);
   const issueNumber = normalizePositiveInteger2(issueContext.issueNumber);
   const relatedIssue = normalizePositiveInteger2(handoff.relatedIssue);
-  return context.requiresHandoff === true && handoff.issueTraceable === true && handoff.approvalScopeMatched === true && Boolean(normalizeText17(handoff.summary)) && issueNumber !== null && relatedIssue === issueNumber && hasBoundIssueTraceability(input?.policyInput, issueNumber);
+  return context.requiresHandoff === true && handoff.issueTraceable === true && handoff.approvalScopeMatched === true && Boolean(normalizeText17(handoff.summary)) && hasConcreteDevelopmentStrategy(handoff.developmentStrategy, issueNumber) && issueNumber !== null && relatedIssue === issueNumber && hasBoundIssueTraceability(input?.policyInput, issueNumber);
+}
+function hasConcreteDevelopmentStrategy(value, issueNumber) {
+  const strategy = normalizeObject7(value);
+  if (!strategy || Object.keys(strategy).length === 0) {
+    return false;
+  }
+  const evidencePath = normalizeText17(strategy.evidencePath);
+  if (!new RegExp(`docs/development-strategy/issue-${issueNumber}-[^\\s)]+\\.md`).test(
+    evidencePath
+  )) {
+    return false;
+  }
+  return [
+    "completionExperience",
+    "vtddArea",
+    "design",
+    "hypothesis",
+    "verificationPlan",
+    "changeEstimate",
+    "knownPath",
+    "unknownBoundary",
+    "likelyGaps",
+    "prePrChecks",
+    "optionsRejected",
+    "postMergeE2E",
+    "noNextPrReason",
+    "stopCondition"
+  ].every((field) => normalizeText17(strategy[field]).length >= 12);
 }
 function hasBoundIssueTraceability(policyInput, issueNumber) {
   const traceability = normalizeObject7(policyInput?.issueTraceability);
@@ -33791,6 +33819,7 @@ function createRemoteCodexExecutionRequest(input = {}) {
       ownerMessage: normalizeText19(handoff.ownerMessage),
       repositoryInput: normalizeText19(handoff.repositoryInput),
       dashboardThreadId: normalizeText19(handoff.dashboardThreadId),
+      developmentStrategy: normalizeDevelopmentStrategy(handoff.developmentStrategy),
       targetPullRequest: revisionTarget
     } : null
   };
@@ -33835,6 +33864,29 @@ function createRemoteCodexExecutionRequest(input = {}) {
     issues.push(...validatePostMergeVerificationTarget(request));
   }
   return issues.length > 0 ? { ok: false, issues } : { ok: true, request };
+}
+function normalizeDevelopmentStrategy(value) {
+  const strategy = normalizeObject8(value);
+  if (!strategy || Object.keys(strategy).length === 0) {
+    return void 0;
+  }
+  return {
+    evidencePath: normalizeText19(strategy.evidencePath),
+    completionExperience: normalizeText19(strategy.completionExperience),
+    vtddArea: normalizeText19(strategy.vtddArea),
+    design: normalizeText19(strategy.design),
+    hypothesis: normalizeText19(strategy.hypothesis),
+    verificationPlan: normalizeText19(strategy.verificationPlan),
+    changeEstimate: normalizeText19(strategy.changeEstimate),
+    knownPath: normalizeText19(strategy.knownPath),
+    unknownBoundary: normalizeText19(strategy.unknownBoundary),
+    likelyGaps: normalizeText19(strategy.likelyGaps),
+    prePrChecks: normalizeText19(strategy.prePrChecks),
+    optionsRejected: normalizeText19(strategy.optionsRejected),
+    postMergeE2E: normalizeText19(strategy.postMergeE2E),
+    noNextPrReason: normalizeText19(strategy.noNextPrReason),
+    stopCondition: normalizeText19(strategy.stopCondition)
+  };
 }
 function validateRevisionTarget(request) {
   const issues = [];
@@ -63530,8 +63582,15 @@ function normalizeRemoteCodexHandoffPayload(payload) {
     payload?.executorTransport ?? continuationContext.executorTransport
   );
   const apiKeyRunnerAcknowledged = payload?.apiKeyRunnerAcknowledged === true || continuationContext.apiKeyRunnerAcknowledged === true || goGranted && requestedExecutorTransport === "api_key_runner";
+  const developmentStrategy = resolveButlerHandoffDevelopmentStrategy({
+    payload,
+    handoff,
+    policyInput,
+    issueNumber
+  });
   return {
     ...payload,
+    developmentStrategy,
     apiKeyRunnerAcknowledged,
     continuationContext: {
       ...continuationContext,
@@ -63542,6 +63601,7 @@ function normalizeRemoteCodexHandoffPayload(payload) {
         issueTraceable: handoff.issueTraceable === false ? false : true,
         approvalScopeMatched: handoff.approvalScopeMatched === false ? false : true,
         relatedIssue: normalizeIssue6(handoff.relatedIssue) ?? issueNumber,
+        developmentStrategy,
         summary: normalizeText32(handoff.summary) || `Issue #${issueNumber} bounded remote Codex handoff`
       }
     },
@@ -63565,6 +63625,74 @@ function normalizeRemoteCodexHandoffPayload(payload) {
       }
     }
   };
+}
+function resolveButlerHandoffDevelopmentStrategy({ payload, handoff, policyInput, issueNumber }) {
+  const existing = normalizeDevelopmentStrategyObject(handoff.developmentStrategy) || normalizeDevelopmentStrategyObject(payload?.developmentStrategy);
+  if (existing) {
+    return existing;
+  }
+  return buildButlerHandoffDevelopmentStrategyDraft({
+    payload,
+    handoff,
+    policyInput,
+    issueNumber
+  });
+}
+function normalizeDevelopmentStrategyObject(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  const strategy = {
+    evidencePath: normalizeText32(value.evidencePath),
+    completionExperience: normalizeText32(value.completionExperience),
+    vtddArea: normalizeText32(value.vtddArea),
+    design: normalizeText32(value.design),
+    hypothesis: normalizeText32(value.hypothesis),
+    verificationPlan: normalizeText32(value.verificationPlan),
+    changeEstimate: normalizeText32(value.changeEstimate),
+    knownPath: normalizeText32(value.knownPath),
+    unknownBoundary: normalizeText32(value.unknownBoundary),
+    likelyGaps: normalizeText32(value.likelyGaps),
+    prePrChecks: normalizeText32(value.prePrChecks),
+    optionsRejected: normalizeText32(value.optionsRejected),
+    postMergeE2E: normalizeText32(value.postMergeE2E),
+    noNextPrReason: normalizeText32(value.noNextPrReason),
+    stopCondition: normalizeText32(value.stopCondition)
+  };
+  return Object.values(strategy).some(Boolean) ? strategy : null;
+}
+function buildButlerHandoffDevelopmentStrategyDraft({ payload, handoff, policyInput, issueNumber }) {
+  const repositoryInput = normalizeText32(policyInput?.repositoryInput) || normalizeText32(handoff.repositoryInput) || normalizeText32(payload?.repositoryInput) || "\u5BFE\u8C61 repository";
+  const branch = normalizeText32(payload?.executionTarget?.branch) || normalizeText32(policyInput?.runtimeTruth?.runtimeState?.activeBranch) || (issueNumber ? `codex/issue-${issueNumber}` : "codex/issue");
+  const ownerIntent = normalizeText32(handoff.ownerMessage) || normalizeText32(payload?.ownerMessage) || normalizeText32(payload?.message) || `Issue #${issueNumber} \u306E\u5B9F\u88C5\u3092\u9032\u3081\u308B`;
+  const traceability = policyInput?.issueTraceability && typeof policyInput.issueTraceability === "object" ? policyInput.issueTraceability : {};
+  const intentRefs = formatTraceRefs(traceability.intentRefs, `#${issueNumber} Intent`);
+  const successRefs = formatTraceRefs(
+    traceability.successCriteriaRefs,
+    `#${issueNumber} Success Criteria`
+  );
+  const nonGoalRefs = formatTraceRefs(traceability.nonGoalRefs, `#${issueNumber} Non-goals`);
+  return {
+    evidencePath: `docs/development-strategy/issue-${issueNumber}-butler-handoff.md`,
+    completionExperience: `Dashboard Butler \u304B\u3089\u81EA\u7136\u6587 GO \u3057\u305F owner \u304C\u3001${repositoryInput} \u306E Issue #${issueNumber} \u5B9F\u88C5\u524D\u306B\u4F5C\u6226\u56F3\u4ED8\u304D handoff \u3067\u9032\u3081\u3089\u308C\u308B\u3002`,
+    vtddArea: "Dashboard Butler \u306E\u81EA\u7136\u6587 build handoff \u3068 VPS runner PR \u4F5C\u6210\u524D guardrail \u3092\u63A5\u7D9A\u3059\u308B\u3002",
+    design: `Butler \u304C ${ownerIntent} \u3092\u3059\u3050\u5B9F\u88C5\u3078\u6E21\u3055\u305A\u3001Issue #${issueNumber} \u306E traceability \u3068 branch ${branch} \u3092\u3082\u3068\u306B\u4F5C\u6226\u56F3\u3092 handoff.developmentStrategy \u3078\u56FA\u5B9A\u3059\u308B\u3002`,
+    hypothesis: "\u6D45\u3044 PR \u9023\u9396\u306E\u539F\u56E0\u306F\u3001Butler build handoff \u304C\u5B9F\u88C5\u524D\u306E\u4EEE\u8AAC\u3068\u691C\u8A3C\u8A08\u753B\u3092\u6301\u305F\u305A\u306B runner \u3078\u6E21\u308B\u3053\u3068\u306B\u3042\u308B\u3002",
+    verificationPlan: "worker / orchestrator / remote Codex executor / VPS runner \u306E tests \u3067\u3001\u4F5C\u6226\u56F3\u306A\u3057 handoff \u304C\u6B62\u307E\u308A\u3001\u4F5C\u6226\u56F3\u4ED8\u304D handoff \u304C PR body \u306B\u5C4A\u304F\u3053\u3068\u3092\u78BA\u8A8D\u3059\u308B\u3002",
+    changeEstimate: "src/worker/runtime.js \u306E normalizeRemoteCodexHandoffPayload\u3001src/core/remote-codex-handoff-scope.js\u3001src/core/remote-codex-executor.js\u3001\u95A2\u9023 worker/orchestrator/runner tests \u3092\u78BA\u8A8D\u30FB\u6539\u4FEE\u3059\u308B\u3002",
+    knownPath: `\u65E2\u5B58\u306E Butler execute route\u3001issue refs (${intentRefs}, ${successRefs}, ${nonGoalRefs})\u3001VPS runner PR body renderer \u306F\u5B58\u5728\u3059\u308B\u3002`,
+    unknownBoundary: "Dashboard \u4E0A\u306E\u5C02\u7528\u7DE8\u96C6 UI \u3084 LLM \u306B\u3088\u308B\u6DF1\u3044\u8A2D\u8A08\u751F\u6210\u306F\u3053\u306E handoff draft \u3060\u3051\u3067\u306F\u672A\u5B8C\u6210\u3068\u3057\u3066\u6271\u3046\u3002",
+    likelyGaps: "handoff \u9014\u4E2D\u3067 developmentStrategy \u3092\u843D\u3068\u3059\u3068\u3001VPS runner \u304C PR body \u3092\u4F5C\u308C\u306A\u3044\u304B\u3001\u4F5C\u6226\u56F3\u306A\u3057\u306E\u6D45\u3044 PR \u306B\u623B\u308B\u3002",
+    prePrChecks: "\u5BFE\u8C61 Issue\u3001AGENTS.md\u3001pre-development strategy contract\u3001handoff normalization\u3001runner PR body validation\u3001\u95A2\u9023 tests \u3092 PR \u524D\u306B\u78BA\u8A8D\u3059\u308B\u3002",
+    optionsRejected: "VPS runner \u5074\u3060\u3051\u3067\u62D2\u5426\u3059\u308B\u6848\u306F\u6368\u3066\u3001Butler \u5165\u53E3\u3067\u4F5C\u6226\u56F3 draft \u3092\u6301\u305F\u305B\u308B\u3002",
+    postMergeE2E: "production deploy \u5F8C\u306B Dashboard Butler \u304B\u3089\u81EA\u7136\u6587 build handoff \u3092\u901A\u3057\u3001queue comment \u3068 PR body \u306B developmentStrategy \u304C\u6B8B\u308B\u3053\u3068\u3092\u78BA\u8A8D\u3059\u308B\u3002",
+    noNextPrReason: "Butler \u5165\u53E3\u3001bounded \u5224\u5B9A\u3001executor request \u4FDD\u6301\u3001runner PR body \u53CD\u6620\u3092\u540C\u3058\u5B9F\u88C5\u7BC4\u56F2\u3067\u585E\u3050\u3002",
+    stopCondition: "\u4F5C\u6226\u56F3\u306A\u3057\u3067 bounded build handoff \u304C allowed \u306B\u306A\u308B\u5834\u5408\u3001\u307E\u305F\u306F deploy/root/credential mutation \u304C\u5FC5\u8981\u306B\u306A\u3063\u305F\u5834\u5408\u306F\u505C\u6B62\u3059\u308B\u3002"
+  };
+}
+function formatTraceRefs(value, fallback) {
+  const refs = Array.isArray(value) ? value.map(normalizeText32).filter(Boolean) : [];
+  return refs.length > 0 ? refs.join(", ") : fallback;
 }
 function mergeGrantedConsentCategories(current, required2) {
   const seen = /* @__PURE__ */ new Set();


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #703 のうち、Dashboard Butler の自然文 build handoff が作戦図を持たずに VPS runner / remote Codex へ進める穴を塞ぎます。
- PR #704 で入った PR body / VPS runner guardrail を、Butler の `/v2/action/execute` 入口まで接続します。
- 作戦図なしの bounded build handoff は Butler orchestrator で実行扱いにならず、作戦図付き handoff は remote Codex request / queue comment へ保持されます。

## Satisfied Success Criteria

- 開発前作戦図の契約に沿い、この PR 自体の作戦図を `docs/development-strategy/issue-703-butler-strategy-handoff.md` に作成しました。
- Dashboard Butler build handoff 正規化で `developmentStrategy` を補完し、既存 strategy があれば尊重します。
- bounded remote Codex handoff 判定に concrete `developmentStrategy` を必須化しました。
- remote Codex execution request が `handoff.developmentStrategy` を落とさず保持します。
- worker / orchestrator / remote Codex executor / VPS runner / PR body guardrail tests で、作戦図あり/なしの境界を確認しました。

## Unsatisfied Success Criteria

- Dashboard Butler 上で owner が作戦図を専用 UI として編集・更新する体験は、この PR では未接続です。
- Issue #703 の最終 close 判断は human approval と、本番 deploy 後の Dashboard Butler live evidence が必要です。

## Non-goal violations

None.

## 開発前作戦図

- 作戦図 evidence: docs/development-strategy/issue-703-butler-strategy-handoff.md
- 完了体験: Dashboard Butler で owner が自然文のまま Issue-backed 実装 GO を出した時、Butler は対象 Issue にひもづく開発前作戦図を handoff payload に持たせ、VPS runner / remote Codex はその作戦図を PR body に反映します。
- VTDD 全体で進める部分: Issue #703 の guardrail を mac Codex / VPS runner の PR body validation だけで終わらせず、Dashboard Butler の自然文 build handoff 入口まで接続します。
- 設計: Dashboard Butler の `/v2/action/execute` build handoff 正規化で、Issue 番号、repository input、runtime branch、owner message、traceability refs から最小限の deterministic 作戦図ドラフトを作ります。既存 strategy は尊重し、remote Codex request は strategy を保持します。
- 仮説: root blocker は、PR #704 が VPS runner の PR body 正規化だけを塞ぎ、Dashboard Butler の natural-language build handoff が developmentStrategy を生成・保持しない点にある。
- 検証計画: worker / orchestrator / remote Codex executor / VPS runner / PR body guardrail tests で、作戦図なし handoff が止まり、作戦図付き handoff が dispatch と PR body へ届くことを確認します。
- 改修見積もり: `src/worker/runtime.js:6999 normalizeRemoteCodexHandoffPayload`、`src/core/remote-codex-handoff-scope.js:1 isBoundRemoteCodexHandoff`、`src/core/remote-codex-executor.js:91 createRemoteCodexExecutionRequest`、`test/worker.test.js`、`test/butler-orchestrator.test.js`、`test/remote-codex-executor.test.js`、generated `worker.js` を変更します。
- 既に通っている経路: PR #704 で PR body template / renderer / validator / guarded workflow / VPS runner PR body generation は作戦図を要求するようになっています。
- 未確認の境界: Dashboard Butler に専用の作戦図編集 UI はまだ作りません。今回の範囲は自然文 build handoff の payload に作戦図を載せる runtime 接続です。
- 穴が出そうな箇所: `createRemoteCodexExecutionRequest` が handoff object を再構成する時に strategy を落とすと、VPS runner へ届きません。strategy draft が薄い場合も過信は禁物です。
- PR 前に確認すること: Issue #703、AGENTS.md、`docs/butler/pre-development-strategy-contract.md`、handoff normalization、bounded 判定、remote Codex request、worker/orchestrator/runner tests を確認しました。
- 実装候補と捨てた案: Dashboard 専用 UI 先行案は scope が大きいため捨て、runtime が deterministic 作戦図 draft を補完して `handoff.developmentStrategy` として運ぶ案を採用しました。VPS runner 側だけで欠落を拒否する案も owner-facing 入口が改善しないため捨てました。
- merge 後に通す E2E: production deploy 後に Dashboard Butler live E2E として自然文 build handoff を通し、runtime truth / queue comment / PR body に `developmentStrategy` が残ることを確認します。
- 次の PR を増やさない理由: 入口の補完、bounded 判定、request 保持、worker/orchestrator/executor tests を同じ PR に入れるため、予測可能な穴をこの PR 内で塞ぎます。
- 停止条件: 作戦図を補完するために LLM 呼び出し、credential mutation、deploy、root/helper、GitHub permission 変更が必要になったら止めます。

## Dry-run Impact Report

- Target Issue: Issue #703
- Implementing Success Criteria: Dashboard Butler の自然文 build handoff が、実装前作戦図なしで runner / remote Codex へ進めないこと。
- Explicit Non-goals: Dashboard 専用作戦図編集 UI、Issue #637 runtime fix、production deploy、credential mutation、permission mutation、root/helper 実行、Issue closure はしません。
- Expected touched files/routes/workflows: `src/worker/runtime.js`、`src/core/remote-codex-handoff-scope.js`、`src/core/remote-codex-executor.js`、`worker.js`、`test/butler-orchestrator.test.js`、`test/remote-codex-executor.test.js`、`test/worker.test.js`、作戦図 doc。
- Affected Issues: Issue #703。Issue #637 は Now に戻す対象で、この PR では触りません。
- Affected PRs: PR #704 の guardrail を runtime handoff 側へ接続する follow-up。
- Affected workflows: guarded PR body validation は直接変更しません。Worker build / generated worker check に影響します。
- Affected runtime/operator surfaces: `/v2/action/execute` の Butler build handoff normalization、remote Codex / VPS runner handoff payload、generated Worker runtime。
- What may break if we patch narrowly: runner 側だけで拒否すると、Butler があたりをつけないまま失敗するだけになります。worker 側だけで作っても executor request が strategy を落とすと PR body に届きません。
- Unknowns to investigate before coding: `normalizeRemoteCodexHandoffPayload`、`isBoundRemoteCodexHandoff`、`createRemoteCodexExecutionRequest`、VPS runner PR body generator の strategy 受け渡し。
- Validation needed: targeted node tests、`npm run build:worker`、`npm run verify:worker`。
- Stop condition: 作戦図なしで bounded build handoff が allowed になる場合、または high-risk 外部効果が必要になった場合。

## Execution Queue Delta

- Queue position before: Issue #637 が Now だが、Issue #703 は PR #704 後も Butler 自然文 handoff が未接続であるため root blocker follow-up として割り込みます。
- Preemption decision: ROOT。作戦図 guardrail が Butler 入口に効かないまま #637 へ戻ると、同じ浅い PR 連鎖を再発させるため。
- Queue delta: Issue #703 の `Butler natural-language handoff -> developmentStrategy -> runner PR body` 接続を進めます。Issue #637 は paused Now として残します。
- Why this PR is next: #703 の guardrail が mac Codex / VPS runner だけに留まると、owner が求める「Butler でもあたりをつける」が成立しません。
- Active Issues not downscoped: Active Issues は縮小しません。Issue #637 と他の active Issue は未完了として残します。

## File / Line Hypotheses

- file: `src/worker/runtime.js:6999`
  - hypothesis: `normalizeRemoteCodexHandoffPayload` が developmentStrategy を補完しないため、Butler 自然文 GO から runner へ作戦図が届かない。
  - risk if changed narrowly: strategy を payload に置くだけで handoff に入れないと executor request が落とす。
  - validation: `test/worker.test.js` の natural Butler build GO で `handoff_json.developmentStrategy` を確認する。
  - related Issue: Issue #703
- file: `src/core/remote-codex-handoff-scope.js:1`
  - hypothesis: bounded handoff 判定が strategy を見ないため、作戦図なしでも remote Codex handoff と扱える。
  - risk if changed narrowly: traceability refs だけで「予見・予測」工程をすり抜ける。
  - validation: `test/butler-orchestrator.test.js` の strategy なし negative / strategy あり positive。
  - related Issue: Issue #703
- file: `src/core/remote-codex-executor.js:91`
  - hypothesis: request normalization が handoff を再構成する時に strategy を落とす。
  - risk if changed narrowly: Butler は作戦図を作るが VPS runner / PR body に届かない。
  - validation: `test/remote-codex-executor.test.js` で strategy 保持を確認する。
  - related Issue: Issue #703

## Hypothesis Retrospective

- expected: Butler build handoff が strategy を補完し、strategy なし handoff は bounded と扱われない。
- actual: targeted tests と full worker verification で期待通り通過しました。
- mismatch: 専用 UI はまだ未接続なので completion は incomplete のままです。
- lesson: PR body validation だけでは遅く、Butler の natural-language execution入口で strategy を持たせる必要がある。
- should become RAG candidate: はい。#703 の drift stop rule として保存価値があります。

## Verification Evidence

- Unit: `node --test test/butler-orchestrator.test.js test/remote-codex-executor.test.js test/worker.test.js test/vps-runner-script.test.js test/pr-body-guardrail.test.js` passed.
- Integration: `npm run verify:worker` passed. `npm test` は 1103 pass / 1 skipped、self-parity と generated worker check も passed。
- E2E: Runtime live E2E は未実施。merge/deploy 後に Dashboard Butler から自然文 build handoff を通して確認します。
- Manual: `git diff --check` passed.
- Evidence path/link: docs/development-strategy/issue-703-butler-strategy-handoff.md

## Butler Completion Contract

- Primary owner surface: Dashboard Butler。
- Fallback surface: Custom GPT は明示された fallback surface として扱います。主経路ではありません。
- Owner goal: Butler が自然文 build handoff を進める時も、実装前に予見・予測・あたりをつける作戦図を持たせる。
- Butler entrypoint: `/v2/action/execute` の Butler build handoff normalization。
- Dashboard Butler natural-language path: Dashboard Butler の自然文 / 通常チャット入口で owner が GO すると、`normalizeRemoteCodexHandoffPayload` で `developmentStrategy` を補完してから runner / remote Codex へ進みます。
- Action Schema exposure: 既存の `vtddExecute` fallback exposure を利用します。この PR では operationId は追加しません。
- Runtime path: Dashboard Butler `/v2/action/execute` -> `normalizeRemoteCodexHandoffPayload` -> `createRemoteCodexExecutionRequest` -> remote Codex / VPS runner handoff。
- Runner/runtime truth: dispatch inputs / queue comment の `handoff_json.developmentStrategy` と PR body strategy section で確認します。
- Authority boundary: deploy、credential、permission、root/helper は不要。実装 PR 作成 handoff の GO 境界のみ。
- E2E evidence: local worker/orchestrator/executor/runner tests のみ。production Dashboard Butler live E2E は merge/deploy 後に必要です。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 必要。Worker runtime と generated `worker.js` を変更しています。
- Custom GPT Action Schema update: 不要。既存 `vtddExecute` の handoff payload 内の strategy 接続です。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: merge/deploy 後に必要。Dashboard Butler 自然文 build handoff が strategy を持つことを確認します。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate
- AGENTS.md Butler-First Operating Principle
- AGENTS.md Drift Stop Protocol
- docs/butler/pre-development-strategy-contract.md
- docs/butler/execution-queue-contract.md

## Out-of-scope but NOT implemented

- Dashboard Butler 専用の作戦図編集・更新 UI。
- LLM による深い設計生成。
- Issue #637 の VPS runner runtime URL fallback 修正。
- Issue #703 closure。

## Extra changes (if any)

None.
