### PR TITLE
Issue #637 VPS runner dashboard delivery を default vault 対応

### DIFF
--- a/docs/development-strategy/issue-637-vps-runner-dashboard-delivery-default-vault.md
+++ b/docs/development-strategy/issue-637-vps-runner-dashboard-delivery-default-vault.md
@@ -1,0 +1,14 @@
+# Issue #637 VPS runner Dashboard delivery default vault strategy
+
+- Target Issue: Issue #637
+- Queue position: Now
+- Completion slice: VPS runner privileged maintenance completion events must return to Dashboard Butler when the runner service does not have `VTDD_RUNTIME_URL` in its environment but the VPS has the standard gateway bearer vault.
+- Owner-facing success: after iPhone passkey approval and VPS helper execution, Dashboard Butler can observe the helper result in the target dashboard thread instead of leaving only GitHub comments with `dashboardDelivery: skipped`.
+- Root blocker: previous live evidence showed helper execution completed, but Dashboard delivery was skipped because `VTDD_RUNTIME_URL` or `VTDD_GATEWAY_BEARER_TOKEN` was missing from the runner service environment.
+- Hypothesis: `scripts/run-vps-runner.mjs` already reads the gateway bearer token from the default vault manifest through `loadGatewayBearerTokenFromVault`, but runtime URL lookup only used an explicit manifest path. If service env is empty, token lookup succeeds from `~/.vtdd/credentials/manifest.json` while runtime URL lookup returns empty.
+- File/line estimate: `scripts/run-vps-runner.mjs` around `resolveVpsRunnerDashboardDeliveryConfig` and `loadVpsRunnerRuntimeUrlFromVaultManifest`; `test/vps-runner-script.test.js` around Dashboard delivery vault tests.
+- Planned implementation: make runtime URL lookup use the same default vault manifest path as bearer-token lookup, while preserving existing manifest fallback keys (`gateway.runtimeUrl`, `runtime.url`, `runtime.runtimeUrl`, `dashboard.runtimeUrl`).
+- Validation plan: run targeted `node --test test/vps-runner-script.test.js`; verify the new test covers empty service env plus default vault manifest. No Worker build is required because Worker runtime is not changed.
+- Non-goals: root/helper execution, credential mutation, deploy, Issue closure, Dashboard UI changes, #703 strategy UI, and unrelated runner refactors.
+- Expected risk: if the VPS vault manifest lacks `gateway.runtimeUrl`, this slice still reports skipped. That is a runtime configuration gap, not a reason to guess a production URL in code.
+- Stop condition: if validation requires reading or mutating real VPS credentials, stop and report a passkey/config boundary instead of executing.

--- a/scripts/run-vps-runner.mjs
+++ b/scripts/run-vps-runner.mjs
@@ -2074,10 +2074,13 @@ async function postVpsRunnerDashboardEvent({ eventPayload, env = process.env, fe
 }
 
 async function resolveVpsRunnerDashboardDeliveryConfig({ env = process.env } = {}) {
+  const vaultManifestPath =
+    normalizeText(env?.VTDD_VPS_RUNNER_CREDENTIALS_MANIFEST || env?.VTDD_CREDENTIALS_MANIFEST) ||
+    resolveDefaultVtddVaultManifestPath({ env });
   const runtimeUrl =
     normalizeText(env?.VTDD_RUNTIME_URL) ||
     (await loadVpsRunnerRuntimeUrlFromVaultManifest({
-      manifestPath: env?.VTDD_VPS_RUNNER_CREDENTIALS_MANIFEST || env?.VTDD_CREDENTIALS_MANIFEST
+      manifestPath: vaultManifestPath
     }));
   const envBearerToken = normalizeText(env?.VTDD_GATEWAY_BEARER_TOKEN);
   if (envBearerToken) {
@@ -2089,7 +2092,7 @@ async function resolveVpsRunnerDashboardDeliveryConfig({ env = process.env } = {
   }
 
   const vaultResult = await loadGatewayBearerTokenFromVault({
-    manifestPath: env?.VTDD_VPS_RUNNER_CREDENTIALS_MANIFEST || env?.VTDD_CREDENTIALS_MANIFEST
+    manifestPath: vaultManifestPath
   });
   return {
     runtimeUrl,
@@ -2098,8 +2101,14 @@ async function resolveVpsRunnerDashboardDeliveryConfig({ env = process.env } = {
   };
 }
 
+function resolveDefaultVtddVaultManifestPath({ env = process.env } = {}) {
+  const homeDir = normalizeText(env?.HOME) || normalizeText(process.env.HOME) || os.homedir();
+  return homeDir ? path.join(homeDir, ".vtdd", "credentials", "manifest.json") : "";
+}
+
 async function loadVpsRunnerRuntimeUrlFromVaultManifest({ manifestPath } = {}) {
-  const normalizedManifestPath = normalizeText(manifestPath);
+  const normalizedManifestPath =
+    normalizeText(manifestPath) || resolveDefaultVtddVaultManifestPath();
   if (!normalizedManifestPath) {
     return "";
   }

--- a/test/vps-runner-script.test.js
+++ b/test/vps-runner-script.test.js
@@ -683,6 +683,71 @@ test("VPS runner event can read dashboard delivery token from vault manifest", a
   assert.equal(parsed.event.dashboardDelivery.status, "delivered");
 });
 
+test("VPS runner event reads dashboard runtime URL from default vault manifest when service env is empty", async () => {
+  const originalHome = process.env.HOME;
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "vtdd-vps-default-vault-"));
+  process.env.HOME = tempDir;
+  try {
+    const credentialsDir = path.join(tempDir, ".vtdd", "credentials");
+    await fs.mkdir(path.join(credentialsDir, "gateway"), { recursive: true });
+    await fs.writeFile(path.join(credentialsDir, "gateway", "bearer-token.txt"), "default-vault-token-for-test\n");
+    await fs.writeFile(
+      path.join(credentialsDir, "manifest.json"),
+      JSON.stringify(
+        {
+          version: 1,
+          gateway: {
+            bearerTokenPath: "gateway/bearer-token.txt",
+            runtimeUrl: "https://default-vault-runtime.example.workers.dev"
+          }
+        },
+        null,
+        2
+      )
+    );
+
+    const githubCalls = [];
+    const runtimeCalls = [];
+    await postVpsRunnerEvent({
+      githubFetch: async (url, init = {}) => {
+        githubCalls.push({ url, init });
+        return { id: 45006 };
+      },
+      fetchImpl: async (url, init = {}) => {
+        runtimeCalls.push({ url: String(url), init });
+        return new Response(JSON.stringify({ ok: true }), {
+          status: 202,
+          headers: { "content-type": "application/json" }
+        });
+      },
+      env: {},
+      payload: {
+        executionId: "exec-dashboard-default-vault-runtime",
+        repository: "marushu/vtdd-v2-p",
+        issueNumber: 637,
+        handoff: {
+          dashboardThreadId: "dashboard-main-marushu-vtdd-v2-p"
+        }
+      },
+      event: {
+        status: "completed",
+        lastEvent: "privileged_maintenance_completed",
+        currentStep: "vps_privileged_maintenance_helper",
+        message: "完了"
+      }
+    });
+
+    assert.equal(runtimeCalls.length, 1);
+    assert.equal(runtimeCalls[0].url, "https://default-vault-runtime.example.workers.dev/v2/events/vps-runner");
+    assert.equal(runtimeCalls[0].init.headers.authorization, "Bearer default-vault-token-for-test");
+    const parsed = parseVpsRunnerEventComment(githubCalls[0].init.body.body);
+    assert.equal(parsed.ok, true);
+    assert.equal(parsed.event.dashboardDelivery.status, "delivered");
+  } finally {
+    process.env.HOME = originalHome;
+  }
+});
+
 test("VPS runner event records missing runtime dashboard delivery configuration", async () => {
   const calls = [];
   await postVpsRunnerEvent({


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #637 のうち、VPS runner helper 実行結果を Dashboard Butler thread へ返す経路で、runner service env に `VTDD_RUNTIME_URL` が無い場合でも標準 gateway vault から runtime URL と bearer token を同じ manifest で解決できるようにします。
- 直近 live evidence の `dashboardDelivery: skipped` を、root/helper 再実行や credential mutation なしに、runner 側の設定解決不足として塞ぎます。

## Satisfied Success Criteria

- VPS runner completion event が `dashboardThreadId` を持つ場合、`~/.vtdd/credentials/manifest.json` の `gateway.runtimeUrl` と `gateway.bearerTokenPath` から `/v2/events/vps-runner` へ delivery できます。
- runtime URL と bearer token が別々の manifest source から解決されないよう、同じ `vaultManifestPath` を共有します。
- 既存 manifest fallback keys (`runtime.url`, `runtime.runtimeUrl`, `dashboard.runtimeUrl`) は削らず維持します。
- default vault manifest の isolated test を追加し、ローカル実 vault secret を読まない形で検証しました。

## Unsatisfied Success Criteria

- #637 全体の capability add/disable/remove/rollback/review lifecycle は未完了です。
- production Dashboard Butler live E2E は merge/deploy 後に必要です。
- Issue closure は human GO と mapped E2E evidence 後です。

## Non-goal violations

None.

## 開発前作戦図

- 作戦図 evidence: docs/development-strategy/issue-637-vps-runner-dashboard-delivery-default-vault.md
- 完了体験: iPhone passkey approval 後の VPS helper 実行結果が、GitHub comment だけでなく Dashboard Butler thread に戻る。
- VTDD 全体で進める部分: Issue #637 の runner/helper execution result delivery と owner-facing runtime truth。
- 設計: Dashboard Butler への完了通知経路を守るため、runner service env に runtime URL が無い境界では、VPS の標準 gateway vault manifest を token と runtime URL の共通 source として使う。環境変数があれば従来どおり優先する。
- 仮説: root blocker は helper execution ではなく、VPS runner service の Dashboard delivery config 解決が env-only に寄りすぎ、default vault runtime URL を読めなかった点にある。
- 検証計画: `test/vps-runner-script.test.js` で empty service env + default vault manifest から runtime post が `delivered` になることを確認する。
- 改修見積もり: `scripts/run-vps-runner.mjs:2074` 付近の `resolveVpsRunnerDashboardDeliveryConfig`、`loadVpsRunnerRuntimeUrlFromVaultManifest`、`test/vps-runner-script.test.js:683` 付近。
- 既に通っている経路: PR #701 で Dashboard thread event route、PR #702 で vault-backed bearer token delivery が入っている。
- 未確認の境界: 実VPSの current vault manifest 内容はこのPRでは読まない。production live E2E は merge/deploy 後。
- 穴が出そうな箇所: runtime URL と token が別 manifest から解決されると、テストや環境により実 secret を読んだり delivery が失敗する。
- PR 前に確認すること: Issue #637、execution queue、thread-independent startup、PR #701/#702 runtime truth、runner dashboard delivery code、vault docs/tests。
- 実装候補と捨てた案: service env に `VTDD_RUNTIME_URL` を追加するだけの案は、VPS runner が vault-backed で self-recover する体験にならないため捨てた。fallback keys を削る案も互換性低下として捨てた。
- merge 後に通す E2E: production deploy 後、Dashboard Butler live E2E として VPS runner status intent を通し、helper completion が Dashboard thread に返ることを確認する。
- 次の PR を増やさない理由: config 解決、secret-source一貫性、regression test を同じ小スライスで完結でき、既知の穴をこのPR範囲で閉じるため。
- 停止条件: real VPS credential read/write、root/helper execution、deploy、permission mutation が必要になったら passkey/owner boundary で止める。

## Dry-run Impact Report

- Target Issue: Issue #637
- Implementing Success Criteria: 実行結果は Dashboard Butler と GitHub-visible runtime truth に before/after、exit code、redacted log summary、next action として返る。
- Explicit Non-goals: root/helper 実行、credential mutation、deploy、Issue closure、Dashboard UI、Action Schema、Worker runtime、setup wizard artifact は触りません。
- Expected touched files/routes/workflows: `scripts/run-vps-runner.mjs`、`test/vps-runner-script.test.js`、`docs/development-strategy/issue-637-vps-runner-dashboard-delivery-default-vault.md`。
- Affected Issues: Issue #637。Issue #703 は guardrail baseline としてのみ関係します。
- Affected PRs: PR #701 / PR #702 の follow-up。
- Affected workflows: VPS runner service execution path。GitHub Actions workflow は未変更。
- Affected runtime/operator surfaces: VPS runner -> Worker `/v2/events/vps-runner` dashboard event delivery。
- What may break if we patch narrowly: env-only または token-only vault fallback だと、helper execution は完了しても Dashboard thread に戻らない。fallback keys を削ると既存 vault schema を壊す。
- Unknowns to investigate before coding: token と runtime URL が同じ manifest path で解決されるか、default vault test が実 secret を読まないか。
- Validation needed: `node --test test/vps-runner-script.test.js`。
- Stop condition: 実 credential / root / helper / deploy が必要になった場合。

## Execution Queue Delta

- Queue position before: Issue #637 is Now.
- Preemption decision: ROOT。#637 の helper 実行結果が Dashboard Butler に返らないと、iPhone/PWA completion gate が進まないため。
- Queue delta: Issue #637 の Dashboard delivery evidence gap を進めます。#637 全体は未完了のままです。
- Why this PR is next: PR #701/#702 後も live evidence で `dashboardDelivery: skipped` が残っており、次の #637 live E2E の前提を塞ぐ必要があるため。
- Active Issues not downscoped: Active Issues は縮小しません。このPRで扱わない #637 lifecycle criteria と他 active Issues は未完了として残します。

## File / Line Hypotheses

- file: `scripts/run-vps-runner.mjs:2074`
  - hypothesis: `resolveVpsRunnerDashboardDeliveryConfig` が runtime URL と bearer token を同じ default vault manifest から解決していない。
  - risk if changed narrowly: token だけ vault-backed になり、runtime URL 欠落で Dashboard delivery が skipped のままになる。
  - validation: empty service env + default vault manifest test で `/v2/events/vps-runner` に POST されることを確認する。
  - related Issue: Issue #637
- file: `test/vps-runner-script.test.js:683`
  - hypothesis: existing tests cover explicit manifest, but not service env empty + default vault manifest。
  - risk if changed narrowly: real local vault を読んでしまい、secret-dependent test になる。
  - validation: temp HOME の isolated vault manifest と token file を使う。
  - related Issue: Issue #637

## Hypothesis Retrospective

- expected: empty service env でも default vault manifest から runtime URL と bearer token を読んで Dashboard delivery が `delivered` になる。
- actual: 初回テストはローカル実 vault token を読んで失敗したため、runtime URL と token が別 source になり得る穴を検出した。実装を同一 `vaultManifestPath` に修正後、targeted tests は pass。
- mismatch: test isolation が不足していた。
- lesson: secret/vault fallback のテストは、片方だけ fake にすると実 credential を読む危険がある。
- should become RAG candidate: はい。vault-backed runtime delivery の再発防止知見として価値があります。

## Verification Evidence

- Unit: `node --test test/vps-runner-script.test.js` passed. 72 tests, 72 pass.
- Integration: None.
- E2E: production Dashboard Butler live E2E は merge/deploy 後に実施します。
- Manual: `git diff --check` passed.
- Evidence path/link: docs/development-strategy/issue-637-vps-runner-dashboard-delivery-default-vault.md

## Butler Completion Contract

- Primary owner surface: Dashboard Butler。
- Fallback surface: Custom GPT は明示された fallback surface として扱います。主経路ではありません。
- Owner goal: VPS helper 実行結果を iPhone/PWA の Dashboard Butler thread で見られるようにする。
- Butler entrypoint: Dashboard Butler の VPS privileged maintenance natural-language intent。
- Dashboard Butler natural-language path: Dashboard Butler の通常チャット入口で owner が runner status 等の自然文 intent を出し、passkey approval 後に VPS runner/helper が実行し、結果が Dashboard thread に戻る。
- Action Schema exposure: 既存の VPS helper / runner status route を利用。このPRでは operationId を追加しません。
- Runtime path: VPS runner event -> `/v2/events/vps-runner` -> Dashboard chat thread delivery。
- Runner/runtime truth: runner event comment の `dashboardDelivery` と Dashboard thread event。
- Authority boundary: root/helper execution、credential mutation、deploy はこのPRでは実行しません。既存 passkey approval 境界を維持します。
- E2E evidence: local targeted test のみ。production Dashboard Butler live E2E は未実施。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 不要。Worker runtime / generated `worker.js` は未変更です。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 必要。merge/deploy 後に Dashboard Butler から #637 VPS runner status intent を通して確認します。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate
- AGENTS.md Butler-First Operating Principle
- AGENTS.md Drift Stop Protocol
- docs/butler/execution-queue-contract.md
- docs/butler/pre-development-strategy-contract.md

## Out-of-scope but NOT implemented

- Issue #637 full close。
- capability add / disable / remove / rollback / review full lifecycle。
- root-owned helper execution。
- credential mutation。
- Cloudflare deploy。
- Dashboard UI changes。

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #637
- Execution ID: Not provided.
- Goal: vps_runner_dashboard_delivery_default_vault
