### PR TITLE
Issue #637 VPS passkeyをDashboard chatへ自動継続

### DIFF
--- a/docs/development-strategy/issue-637-vps-passkey-auto-continue.md
+++ b/docs/development-strategy/issue-637-vps-passkey-auto-continue.md
@@ -1,0 +1,60 @@
+# Issue #637 VPS passkey auto-continue strategy
+
+## 完了体験
+
+Owner は Dashboard Butler のチャットで VPS runner status などの自然文 intent を送る。Butler が同じ chat thread に passkey 認証リンクを出し、owner は passkey ボタンを押すだけでよい。承認後、operator page は approvalGrantId を owner にコピーさせず、同じ Dashboard Butler thread に承認イベントを返し、VPS helper queue へ自動継続する。
+
+## VTDD 全体で進める部分
+
+Issue #637 のうち、自然文 Dashboard Butler intent から passkey 承認を経て helper queue に戻る owner-facing 接続を進める。root-owned helper 実行、capability manifest、runner pickup、結果通知の既存経路は今回の変更対象ではなく、承認イベントが chat thread へ戻るかを固定する。
+
+## 設計
+
+Dashboard Butler が proposal を作る時点で `dashboardThreadId` と `executionId` を approval operator URL に埋め込む。passkey operator page は `mode=vps` かつ `dashboardThreadId` がある場合に auto-continue mode とし、承認成功後に same-origin の `/v2/dashboard/chat/messages` へ `approvalGrantId` と `vpsProposalId` を送る。Dashboard chat route は既存の #637 自然文 flow を使い、helper request、execution envelope、GitHub queue comment まで進める。
+
+## 仮説
+
+現状の詰まりは helper queue そのものではなく、passkey 認証後の `approvalGrantId` が Dashboard Butler の thread に戻らず、owner が JSON をコピーする手作業に落ちていること。承認イベントを同じ thread に戻せば、owner は passkey だけを押し、Butler が queue 継続と通知確認を担当できる。
+
+## 検証計画
+
+Worker unit/integration test で、Dashboard Butler の approval URL に `dashboardThreadId` と `executionId` が入ること、operator page が VPS auto-continue mode で copy UI を隠し、承認後に `/v2/dashboard/chat/messages` へ戻す JS を持つことを確認する。`npm run verify:worker` で generated worker と self parity を確認する。merge/deploy 後に production Dashboard Butler live E2E で、owner passkey 後に helper queue が作られることを確認する。
+
+## 改修見積もり
+
+- `src/worker/runtime.js`: `createVpsPrivilegedMaintenanceProposal`、`buildVpsMaintenanceApprovalOperatorUrl`、`handlePasskeyOperatorPageRequest`、`buildDashboardVpsPrivilegedMaintenanceNaturalLanguageFlow`。
+- `src/core/passkey-operator-page.js`: VPS scope、auto-continue mode、承認後 callback、manual copy UI 表示条件。
+- `test/worker.test.js`: Dashboard Butler approval URL、operator page auto-continue、copy UI suppression の assertions。
+- `worker.js`: generated worker。
+
+## 既に通っている経路
+
+Dashboard Butler natural-language intent、proposal 作成、scoped passkey approval、helper request 作成、execution envelope 作成、GitHub issue queue comment、VPS runner pickup/result comment は既存 PR 群で部分的に通っている。
+
+## 未確認の境界
+
+Production deploy 後の live Dashboard session cookie / auth state、PWA notification の受信表示、VPS runner pickup の実 production timing は PR 前ローカル検証だけでは完了扱いにしない。
+
+## 穴が出そうな箇所
+
+operator page が `dashboardThreadId` を持たない URL では従来の manual approvalGrantId flow を残す必要がある。Dashboard auth が切れている場合は auto-continue POST が `dashboard_auth_required` で止まる。helper queue への handoff は root/helper execution そのものではなく、rootExecutionStarted=false / helperExecutionStarted=false の境界を守る。
+
+## PR 前に確認すること
+
+Issue #637 の Success Criteria、AGENTS.md の Butler Completion Gate、execution queue contract、active queue、差分が #637 に収まること、worker generated file が更新されていること、`npm run verify:worker` が通ること。
+
+## 実装候補と捨てた案
+
+採用案は passkey operator page から same-origin Dashboard chat API へ承認イベントを戻す。捨てた案は approvalGrantId の copy/paste、通知だけで owner に次操作を促す案、mac Codex が JSON を拾って代理実行する案。どれも Butler completion ではない。
+
+## merge 後に通す E2E
+
+Production deploy 後、Dashboard Butler で #637 VPS runner status 自然文 prompt を送る。表示された passkey URL を owner が承認し、operator page が同じ Dashboard thread に戻して helper queue 作成まで進むことを確認する。結果は Dashboard Butler thread、通知センター、Issue #637 queue/result comment の三点で確認する。
+
+## 次の PR を増やさない理由
+
+今回の変更は既存 helper queue 実装に合わせ、欠けていた passkey event return だけを接続する。新しい queue protocol や notification subsystem を増やさず、既存 `/v2/dashboard/chat/messages` と #637 natural-language flow を再利用するため、この slice から予測できる別 PR を増やさない。
+
+## 停止条件
+
+Dashboard chat API が approvalGrantId を受けても helper queue に進めない場合、approval scope が proposal と一致しない場合、Dashboard auth が passkey 承認後に復帰できない場合、または root/helper execution を operator page から直接始める必要が出た場合は停止する。

--- a/src/core/passkey-operator-page.js
+++ b/src/core/passkey-operator-page.js
@@ -34,8 +34,11 @@ export function renderPasskeyOperatorPage(input = {}) {
     vpsOperation: String(input.vpsOperation || "").trim(),
     vpsCapabilityId: String(input.vpsCapabilityId || "").trim(),
     vpsImpactScope: String(input.vpsImpactScope || "").trim(),
-    vpsExpiresAt: String(input.vpsExpiresAt || "").trim()
+    vpsExpiresAt: String(input.vpsExpiresAt || "").trim(),
+    dashboardThreadId: String(input.vpsDashboardThreadId || input.dashboardThreadId || "").trim(),
+    executionId: String(input.vpsExecutionId || input.executionId || "").trim()
   };
+  const vpsAutoContinueMode = operatorMode === "vps" && Boolean(vpsScope.dashboardThreadId);
   const vpsHost = escapeHtml(vpsScope.vpsHost);
   const vpsOperation = escapeHtml(vpsScope.vpsOperation);
   const vpsCapabilityId = escapeHtml(vpsScope.vpsCapabilityId);
@@ -288,17 +291,17 @@ export function renderPasskeyOperatorPage(input = {}) {
           }
           <div class="row">
             <button class="secondary" id="approve-button">${approveButtonLabel}</button>
-            ${deployOneTapMode || dashboardMode ? "" : '<button class="ghost" id="copy-approval-grant-button" type="button">Copy approvalGrantId</button>'}
+            ${deployOneTapMode || dashboardMode || vpsAutoContinueMode ? "" : '<button class="ghost" id="copy-approval-grant-button" type="button">Copy approvalGrantId</button>'}
           </div>
           ${
-            deployOneTapMode || dashboardMode
+            deployOneTapMode || dashboardMode || vpsAutoContinueMode
               ? '<input id="auto-copy-approval-grant-input" type="checkbox" hidden />'
               : `<label class="inline-check" for="auto-copy-approval-grant-input">
             <input id="auto-copy-approval-grant-input" type="checkbox" />
             Auto-copy approvalGrantId after approval
           </label>`
           }
-          ${deployOneTapMode || dashboardMode ? "" : '<p class="muted">GitHub App secret sync なら <code>actionType=destructive</code> / <code>highRiskKind=github_app_secret_sync</code>、production deploy なら <code>actionType=deploy_production</code> / <code>highRiskKind=deploy_production</code>、PR merge なら <code>actionType=merge</code> / <code>highRiskKind=pull_merge</code> を使います。</p>'}
+          ${deployOneTapMode || dashboardMode || vpsAutoContinueMode ? "" : '<p class="muted">GitHub App secret sync なら <code>actionType=destructive</code> / <code>highRiskKind=github_app_secret_sync</code>、production deploy なら <code>actionType=deploy_production</code> / <code>highRiskKind=deploy_production</code>、PR merge なら <code>actionType=merge</code> / <code>highRiskKind=pull_merge</code> を使います。</p>'}
           <pre id="approve-output"${deployOneTapMode || dashboardMode ? " hidden" : ""}></pre>
         </section>
 
@@ -423,7 +426,7 @@ export function renderPasskeyOperatorPage(input = {}) {
 
         <section data-operator-section="vps-runner-admin"${hiddenAttribute(!sectionVisibility.vpsRunnerAdmin)}>
           <h2>10. VPS Runner Admin</h2>
-          <p class="muted">VPS runner の repo allowlist 追加、runner restart、smoke などの管理操作用 approval です。ここでは real passkey で短命の <code>approvalGrantId</code> だけを発行します。VPS 操作そのものは GitHub queue と runner event に残る bounded command として別途実行されます。</p>
+          <p class="muted">VPS runner の repo allowlist 追加、runner restart、smoke などの管理操作用 approval です。Dashboard Butler から開いた場合、passkey 承認後は同じ chat thread に戻して helper queue へ自動継続します。</p>
           ${vpsScopeSummary ? `<p class="muted">${vpsScopeSummary}</p>` : ""}
           <p class="muted"><code>actionType=destructive</code> / <code>highRiskKind=vps_runner_admin</code> の approvalGrantId が必要です。文字列としての passkey は承認ではありません。</p>
         </section>
@@ -768,6 +771,13 @@ export function renderPasskeyOperatorPage(input = {}) {
           document.getElementById("risk-kind-input").value === "deploy_production";
       }
 
+      function shouldAutoContinueVpsMaintenance() {
+        return operatorMode === "vps" &&
+          document.getElementById("risk-kind-input").value === "vps_runner_admin" &&
+          Boolean(vpsApprovalScope.vpsProposalId) &&
+          Boolean(vpsApprovalScope.dashboardThreadId);
+      }
+
       function approvalGrantHasDeployScope(approvalGrant) {
         const scope = approvalGrant?.scope || {};
         return scope.actionType === "deploy_production" &&
@@ -816,6 +826,50 @@ export function renderPasskeyOperatorPage(input = {}) {
         if (deployDebugOutput) {
           deployDebugOutput.textContent = JSON.stringify(deployBody, null, 2);
         }
+      }
+
+      async function continueVpsMaintenanceFromApproval() {
+        if (!latestApprovalGrantId) {
+          throw new Error("approvalGrantId is required before VPS helper queue handoff");
+        }
+        if (!vpsApprovalScope.vpsProposalId) {
+          throw new Error("vpsProposalId is required before VPS helper queue handoff");
+        }
+        if (!vpsApprovalScope.dashboardThreadId) {
+          throw new Error("dashboardThreadId is required before returning VPS approval to Butler chat");
+        }
+        const repositoryInput = readRequiredRepositoryInput();
+        const issueNumber = Number(document.getElementById("issue-input").value || 0) || null;
+        setApproveOutput("パスキー承認済み。Dashboard Butler へ戻して VPS helper queue へ進めています...", {
+          show: shouldShowApproveOutput("status")
+        });
+        const continueResponse = await fetch("${apiBase}/dashboard/chat/messages", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            threadId: vpsApprovalScope.dashboardThreadId,
+            repository: repositoryInput,
+            issueNumber,
+            text: "passkey 承認済みです。Dashboard Butler から VPS helper queue へ進めて。",
+            vpsProposalId: vpsApprovalScope.vpsProposalId,
+            approvalGrantId: latestApprovalGrantId,
+            executionId: vpsApprovalScope.executionId || ""
+          })
+        });
+        const continueBody = await readResponseBody(continueResponse);
+        if (!continueResponse.ok) {
+          throw responseError(continueBody, "VPS helper queue handoff failed");
+        }
+        const runtimeTruth = continueBody?.execution?.runtimeTruth || {};
+        if (continueBody?.execution?.status !== "queued_for_vps_helper_execution") {
+          throw new Error(
+            "VPS helper queue handoff did not queue. "
+            + (runtimeTruth.status || continueBody?.execution?.status || "unknown")
+          );
+        }
+        setApproveOutput("VPS helper queue へ渡しました。Dashboard Butler と通知で進捗を確認してください。", {
+          show: shouldShowApproveOutput("status")
+        });
       }
 
       if (copyApprovalGrantButton) {
@@ -948,6 +1002,16 @@ export function renderPasskeyOperatorPage(input = {}) {
               await dispatchProductionDeploy({ source: "approval" });
             } catch (error) {
               deployOutput.textContent = String(error);
+            }
+          }
+          if (shouldAutoContinueVpsMaintenance()) {
+            try {
+              await continueVpsMaintenanceFromApproval();
+            } catch (error) {
+              setApproveOutput(
+                "パスキー承認後の VPS helper queue 継続に失敗しました。原因: " + String(error),
+                { show: shouldShowApproveOutput("error") }
+              );
             }
           }
         } catch (error) {

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -4591,7 +4591,9 @@ async function createVpsPrivilegedMaintenanceProposal({ payload, provider, origi
   const approvalOperatorUrl = buildVpsMaintenanceApprovalOperatorUrl({
     origin,
     approvalScope,
-    vpsProposalId
+    vpsProposalId,
+    dashboardThreadId: payload?.dashboardThreadId || payload?.dashboard_thread_id || payload?.threadId || payload?.thread_id,
+    executionId: payload?.executionId || payload?.execution_id
   });
   const ownerAction = {
     repository: proposal.repository,
@@ -4662,7 +4664,7 @@ function createVpsMaintenanceApprovalProposalRecord({ vpsProposalId, proposal, a
   });
 }
 
-function buildVpsMaintenanceApprovalOperatorUrl({ origin, approvalScope, vpsProposalId }) {
+function buildVpsMaintenanceApprovalOperatorUrl({ origin, approvalScope, vpsProposalId, dashboardThreadId, executionId }) {
   const url = new URL("/v2/approval/passkey/operator", `${origin}/`);
   url.searchParams.set("mode", "vps");
   url.searchParams.set("vpsProposalId", vpsProposalId);
@@ -4671,6 +4673,14 @@ function buildVpsMaintenanceApprovalOperatorUrl({ origin, approvalScope, vpsProp
   url.searchParams.set("phase", approvalScope.phase || "execution");
   url.searchParams.set("actionType", approvalScope.actionType);
   url.searchParams.set("highRiskKind", approvalScope.highRiskKind);
+  const normalizedThreadId = normalizeDashboardThreadId(dashboardThreadId);
+  if (normalizedThreadId) {
+    url.searchParams.set("dashboardThreadId", normalizedThreadId);
+  }
+  const normalizedExecutionId = normalizeText(executionId);
+  if (normalizedExecutionId) {
+    url.searchParams.set("executionId", normalizedExecutionId);
+  }
   return url.href;
 }
 
@@ -6643,6 +6653,8 @@ async function handlePasskeyOperatorPageRequest(request, env) {
     vpsCapabilityId: vpsScope.vpsCapabilityId || vpsScope.display?.capabilityId || "",
     vpsImpactScope: vpsScope.vpsImpactScope || vpsScope.display?.impactScope || "",
     vpsExpiresAt: vpsScope.vpsExpiresAt || vpsScope.display?.expiresAt || "",
+    vpsDashboardThreadId: url.searchParams.get("dashboardThreadId") || url.searchParams.get("threadId"),
+    vpsExecutionId: url.searchParams.get("executionId"),
     githubActionsVariableProposalId: url.searchParams.get("variableProposalId"),
     githubActionsVariableProposalName:
       githubActionsVariableScope.variableName || githubActionsVariableProposal?.content?.variableName || "",
@@ -10544,7 +10556,11 @@ async function buildDashboardVpsPrivilegedMaintenanceNaturalLanguageFlow({
       };
     }
     const proposal = await createVpsPrivilegedMaintenanceProposal({
-      payload: proposalPayload,
+      payload: {
+        ...proposalPayload,
+        dashboardThreadId: normalizeDashboardThreadId(payload?.threadId || payload?.thread_id),
+        executionId: normalizeText(payload?.executionId || payload?.execution_id)
+      },
       provider,
       origin: origin || "https://example.com"
     });

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -2551,6 +2551,9 @@ test("worker connects VPS privileged maintenance intent from Dashboard Butler ch
   assert.match(body.messages[1].text, /approval_required/);
   assert.match(body.messages[1].text, /rootExecutionStarted=false/);
   assert.match(body.messages[1].text, /approval URL/);
+  const approvalUrl = new URL(body.execution.approvalOperatorUrl);
+  assert.equal(approvalUrl.searchParams.get("dashboardThreadId"), "dashboard-main-marushu-vtdd-v2-p");
+  assert.equal(approvalUrl.searchParams.get("vpsProposalId"), body.execution.vpsProposalId);
   assert.doesNotMatch(body.messages[1].text, /app-server 接続 PR/);
 
   await provider.store({
@@ -8372,7 +8375,9 @@ test("worker serves VPS privileged maintenance proposal with scoped passkey oper
         rollbackPlan: "disable capability and keep audit history",
         expectedRuntimeTruth: ["before package check", "exit code", "after Chromium launch check"],
         reason: "PR #632 Playwright E2E blocker requires Chromium host dependencies",
-        impactScope: "apt packages for Chromium runtime"
+        impactScope: "apt packages for Chromium runtime",
+        dashboardThreadId: "dashboard-main-marushu-vtdd-v2-p",
+        executionId: "issue637-vps-auto-continue"
       })
     }),
     { ...gatewayAuthEnv, MEMORY_PROVIDER: provider }
@@ -8402,6 +8407,8 @@ test("worker serves VPS privileged maintenance proposal with scoped passkey oper
   assert.equal(operatorUrl.searchParams.get("actionType"), "destructive");
   assert.equal(operatorUrl.searchParams.get("highRiskKind"), "vps_runner_admin");
   assert.equal(operatorUrl.searchParams.get("vpsProposalId"), body.vpsProposalId);
+  assert.equal(operatorUrl.searchParams.get("dashboardThreadId"), "dashboard-main-marushu-vtdd-v2-p");
+  assert.equal(operatorUrl.searchParams.get("executionId"), "issue637-vps-auto-continue");
   assert.equal(operatorUrl.searchParams.get("vpsHost"), null);
   assert.equal(operatorUrl.searchParams.get("vpsCapabilityId"), null);
   assert.equal(body.ownerAction.source.approvalOperatorUrl, body.approvalOperatorUrl);
@@ -8546,7 +8553,9 @@ test("worker passkey operator displays VPS maintenance approval scope details fr
         allowedArgs: ["npx playwright install-deps chromium"],
         rollbackPlan: "disable capability and keep audit history",
         reason: "PR #632 Playwright E2E blocker requires Chromium host dependencies",
-        impactScope: "apt packages"
+        impactScope: "apt packages",
+        dashboardThreadId: "dashboard-main-marushu-vtdd-v2-p",
+        executionId: "issue637-vps-auto-continue"
       })
     }),
     { ...gatewayAuthEnv, MEMORY_PROVIDER: provider }
@@ -8568,6 +8577,12 @@ test("worker passkey operator displays VPS maintenance approval scope details fr
   assert.equal(html.includes(`"vpsProposalId":"${proposalBody.vpsProposalId}"`), true);
   assert.equal(html.includes('"vpsHost":"x85-131-245-163"'), true);
   assert.equal(html.includes('"vpsCapabilityId":"playwright.chromium.deps"'), true);
+  assert.equal(html.includes('"dashboardThreadId":"dashboard-main-marushu-vtdd-v2-p"'), true);
+  assert.equal(html.includes('"executionId":"issue637-vps-auto-continue"'), true);
+  assert.equal(html.includes("continueVpsMaintenanceFromApproval"), true);
+  assert.equal(html.includes("/v2/dashboard/chat/messages"), true);
+  assert.equal(html.includes("Copy approvalGrantId"), false);
+  assert.equal(html.includes("同じ chat thread に戻して helper queue へ自動継続します"), true);
 });
 
 test("worker rejects hand-authored VPS passkey scope without stored proposal", async () => {

--- a/worker.js
+++ b/worker.js
@@ -27286,8 +27286,11 @@ function renderPasskeyOperatorPage(input = {}) {
     vpsOperation: String(input.vpsOperation || "").trim(),
     vpsCapabilityId: String(input.vpsCapabilityId || "").trim(),
     vpsImpactScope: String(input.vpsImpactScope || "").trim(),
-    vpsExpiresAt: String(input.vpsExpiresAt || "").trim()
+    vpsExpiresAt: String(input.vpsExpiresAt || "").trim(),
+    dashboardThreadId: String(input.vpsDashboardThreadId || input.dashboardThreadId || "").trim(),
+    executionId: String(input.vpsExecutionId || input.executionId || "").trim()
   };
+  const vpsAutoContinueMode = operatorMode === "vps" && Boolean(vpsScope.dashboardThreadId);
   const vpsHost = escapeHtml(vpsScope.vpsHost);
   const vpsOperation = escapeHtml(vpsScope.vpsOperation);
   const vpsCapabilityId = escapeHtml(vpsScope.vpsCapabilityId);
@@ -27516,13 +27519,13 @@ function renderPasskeyOperatorPage(input = {}) {
           <input id="risk-kind-input" value="${highRiskKindDefault}" />`}
           <div class="row">
             <button class="secondary" id="approve-button">${approveButtonLabel}</button>
-            ${deployOneTapMode || dashboardMode ? "" : '<button class="ghost" id="copy-approval-grant-button" type="button">Copy approvalGrantId</button>'}
+            ${deployOneTapMode || dashboardMode || vpsAutoContinueMode ? "" : '<button class="ghost" id="copy-approval-grant-button" type="button">Copy approvalGrantId</button>'}
           </div>
-          ${deployOneTapMode || dashboardMode ? '<input id="auto-copy-approval-grant-input" type="checkbox" hidden />' : `<label class="inline-check" for="auto-copy-approval-grant-input">
+          ${deployOneTapMode || dashboardMode || vpsAutoContinueMode ? '<input id="auto-copy-approval-grant-input" type="checkbox" hidden />' : `<label class="inline-check" for="auto-copy-approval-grant-input">
             <input id="auto-copy-approval-grant-input" type="checkbox" />
             Auto-copy approvalGrantId after approval
           </label>`}
-          ${deployOneTapMode || dashboardMode ? "" : '<p class="muted">GitHub App secret sync \u306A\u3089 <code>actionType=destructive</code> / <code>highRiskKind=github_app_secret_sync</code>\u3001production deploy \u306A\u3089 <code>actionType=deploy_production</code> / <code>highRiskKind=deploy_production</code>\u3001PR merge \u306A\u3089 <code>actionType=merge</code> / <code>highRiskKind=pull_merge</code> \u3092\u4F7F\u3044\u307E\u3059\u3002</p>'}
+          ${deployOneTapMode || dashboardMode || vpsAutoContinueMode ? "" : '<p class="muted">GitHub App secret sync \u306A\u3089 <code>actionType=destructive</code> / <code>highRiskKind=github_app_secret_sync</code>\u3001production deploy \u306A\u3089 <code>actionType=deploy_production</code> / <code>highRiskKind=deploy_production</code>\u3001PR merge \u306A\u3089 <code>actionType=merge</code> / <code>highRiskKind=pull_merge</code> \u3092\u4F7F\u3044\u307E\u3059\u3002</p>'}
           <pre id="approve-output"${deployOneTapMode || dashboardMode ? " hidden" : ""}></pre>
         </section>
 
@@ -27645,7 +27648,7 @@ function renderPasskeyOperatorPage(input = {}) {
 
         <section data-operator-section="vps-runner-admin"${hiddenAttribute(!sectionVisibility.vpsRunnerAdmin)}>
           <h2>10. VPS Runner Admin</h2>
-          <p class="muted">VPS runner \u306E repo allowlist \u8FFD\u52A0\u3001runner restart\u3001smoke \u306A\u3069\u306E\u7BA1\u7406\u64CD\u4F5C\u7528 approval \u3067\u3059\u3002\u3053\u3053\u3067\u306F real passkey \u3067\u77ED\u547D\u306E <code>approvalGrantId</code> \u3060\u3051\u3092\u767A\u884C\u3057\u307E\u3059\u3002VPS \u64CD\u4F5C\u305D\u306E\u3082\u306E\u306F GitHub queue \u3068 runner event \u306B\u6B8B\u308B bounded command \u3068\u3057\u3066\u5225\u9014\u5B9F\u884C\u3055\u308C\u307E\u3059\u3002</p>
+          <p class="muted">VPS runner \u306E repo allowlist \u8FFD\u52A0\u3001runner restart\u3001smoke \u306A\u3069\u306E\u7BA1\u7406\u64CD\u4F5C\u7528 approval \u3067\u3059\u3002Dashboard Butler \u304B\u3089\u958B\u3044\u305F\u5834\u5408\u3001passkey \u627F\u8A8D\u5F8C\u306F\u540C\u3058 chat thread \u306B\u623B\u3057\u3066 helper queue \u3078\u81EA\u52D5\u7D99\u7D9A\u3057\u307E\u3059\u3002</p>
           ${vpsScopeSummary ? `<p class="muted">${vpsScopeSummary}</p>` : ""}
           <p class="muted"><code>actionType=destructive</code> / <code>highRiskKind=vps_runner_admin</code> \u306E approvalGrantId \u304C\u5FC5\u8981\u3067\u3059\u3002\u6587\u5B57\u5217\u3068\u3057\u3066\u306E passkey \u306F\u627F\u8A8D\u3067\u306F\u3042\u308A\u307E\u305B\u3093\u3002</p>
         </section>
@@ -27990,6 +27993,13 @@ function renderPasskeyOperatorPage(input = {}) {
           document.getElementById("risk-kind-input").value === "deploy_production";
       }
 
+      function shouldAutoContinueVpsMaintenance() {
+        return operatorMode === "vps" &&
+          document.getElementById("risk-kind-input").value === "vps_runner_admin" &&
+          Boolean(vpsApprovalScope.vpsProposalId) &&
+          Boolean(vpsApprovalScope.dashboardThreadId);
+      }
+
       function approvalGrantHasDeployScope(approvalGrant) {
         const scope = approvalGrant?.scope || {};
         return scope.actionType === "deploy_production" &&
@@ -28038,6 +28048,50 @@ function renderPasskeyOperatorPage(input = {}) {
         if (deployDebugOutput) {
           deployDebugOutput.textContent = JSON.stringify(deployBody, null, 2);
         }
+      }
+
+      async function continueVpsMaintenanceFromApproval() {
+        if (!latestApprovalGrantId) {
+          throw new Error("approvalGrantId is required before VPS helper queue handoff");
+        }
+        if (!vpsApprovalScope.vpsProposalId) {
+          throw new Error("vpsProposalId is required before VPS helper queue handoff");
+        }
+        if (!vpsApprovalScope.dashboardThreadId) {
+          throw new Error("dashboardThreadId is required before returning VPS approval to Butler chat");
+        }
+        const repositoryInput = readRequiredRepositoryInput();
+        const issueNumber = Number(document.getElementById("issue-input").value || 0) || null;
+        setApproveOutput("\u30D1\u30B9\u30AD\u30FC\u627F\u8A8D\u6E08\u307F\u3002Dashboard Butler \u3078\u623B\u3057\u3066 VPS helper queue \u3078\u9032\u3081\u3066\u3044\u307E\u3059...", {
+          show: shouldShowApproveOutput("status")
+        });
+        const continueResponse = await fetch("${apiBase}/dashboard/chat/messages", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            threadId: vpsApprovalScope.dashboardThreadId,
+            repository: repositoryInput,
+            issueNumber,
+            text: "passkey \u627F\u8A8D\u6E08\u307F\u3067\u3059\u3002Dashboard Butler \u304B\u3089 VPS helper queue \u3078\u9032\u3081\u3066\u3002",
+            vpsProposalId: vpsApprovalScope.vpsProposalId,
+            approvalGrantId: latestApprovalGrantId,
+            executionId: vpsApprovalScope.executionId || ""
+          })
+        });
+        const continueBody = await readResponseBody(continueResponse);
+        if (!continueResponse.ok) {
+          throw responseError(continueBody, "VPS helper queue handoff failed");
+        }
+        const runtimeTruth = continueBody?.execution?.runtimeTruth || {};
+        if (continueBody?.execution?.status !== "queued_for_vps_helper_execution") {
+          throw new Error(
+            "VPS helper queue handoff did not queue. "
+            + (runtimeTruth.status || continueBody?.execution?.status || "unknown")
+          );
+        }
+        setApproveOutput("VPS helper queue \u3078\u6E21\u3057\u307E\u3057\u305F\u3002Dashboard Butler \u3068\u901A\u77E5\u3067\u9032\u6357\u3092\u78BA\u8A8D\u3057\u3066\u304F\u3060\u3055\u3044\u3002", {
+          show: shouldShowApproveOutput("status")
+        });
       }
 
       if (copyApprovalGrantButton) {
@@ -28170,6 +28224,16 @@ function renderPasskeyOperatorPage(input = {}) {
               await dispatchProductionDeploy({ source: "approval" });
             } catch (error) {
               deployOutput.textContent = String(error);
+            }
+          }
+          if (shouldAutoContinueVpsMaintenance()) {
+            try {
+              await continueVpsMaintenanceFromApproval();
+            } catch (error) {
+              setApproveOutput(
+                "\u30D1\u30B9\u30AD\u30FC\u627F\u8A8D\u5F8C\u306E VPS helper queue \u7D99\u7D9A\u306B\u5931\u6557\u3057\u307E\u3057\u305F\u3002\u539F\u56E0: " + String(error),
+                { show: shouldShowApproveOutput("error") }
+              );
             }
           }
         } catch (error) {
@@ -61382,7 +61446,9 @@ async function createVpsPrivilegedMaintenanceProposal({ payload, provider, origi
   const approvalOperatorUrl = buildVpsMaintenanceApprovalOperatorUrl({
     origin,
     approvalScope,
-    vpsProposalId
+    vpsProposalId,
+    dashboardThreadId: payload?.dashboardThreadId || payload?.dashboard_thread_id || payload?.threadId || payload?.thread_id,
+    executionId: payload?.executionId || payload?.execution_id
   });
   const ownerAction = {
     repository: proposal.repository,
@@ -61450,7 +61516,7 @@ function createVpsMaintenanceApprovalProposalRecord({ vpsProposalId, proposal, a
     createdAt: (/* @__PURE__ */ new Date()).toISOString()
   });
 }
-function buildVpsMaintenanceApprovalOperatorUrl({ origin, approvalScope, vpsProposalId }) {
+function buildVpsMaintenanceApprovalOperatorUrl({ origin, approvalScope, vpsProposalId, dashboardThreadId, executionId }) {
   const url = new URL("/v2/approval/passkey/operator", `${origin}/`);
   url.searchParams.set("mode", "vps");
   url.searchParams.set("vpsProposalId", vpsProposalId);
@@ -61459,6 +61525,14 @@ function buildVpsMaintenanceApprovalOperatorUrl({ origin, approvalScope, vpsProp
   url.searchParams.set("phase", approvalScope.phase || "execution");
   url.searchParams.set("actionType", approvalScope.actionType);
   url.searchParams.set("highRiskKind", approvalScope.highRiskKind);
+  const normalizedThreadId = normalizeDashboardThreadId(dashboardThreadId);
+  if (normalizedThreadId) {
+    url.searchParams.set("dashboardThreadId", normalizedThreadId);
+  }
+  const normalizedExecutionId = normalizeText32(executionId);
+  if (normalizedExecutionId) {
+    url.searchParams.set("executionId", normalizedExecutionId);
+  }
   return url.href;
 }
 function normalizeVpsMaintenanceProposalExpiresAt(value, now = /* @__PURE__ */ new Date()) {
@@ -63284,6 +63358,8 @@ async function handlePasskeyOperatorPageRequest(request, env) {
     vpsCapabilityId: vpsScope.vpsCapabilityId || vpsScope.display?.capabilityId || "",
     vpsImpactScope: vpsScope.vpsImpactScope || vpsScope.display?.impactScope || "",
     vpsExpiresAt: vpsScope.vpsExpiresAt || vpsScope.display?.expiresAt || "",
+    vpsDashboardThreadId: url.searchParams.get("dashboardThreadId") || url.searchParams.get("threadId"),
+    vpsExecutionId: url.searchParams.get("executionId"),
     githubActionsVariableProposalId: url.searchParams.get("variableProposalId"),
     githubActionsVariableProposalName: githubActionsVariableScope.variableName || githubActionsVariableProposal?.content?.variableName || "",
     returnUrl: normalizeOperatorReturnUrl(url.searchParams.get("returnUrl")),
@@ -66684,7 +66760,11 @@ async function buildDashboardVpsPrivilegedMaintenanceNaturalLanguageFlow({
       };
     }
     const proposal = await createVpsPrivilegedMaintenanceProposal({
-      payload: proposalPayload,
+      payload: {
+        ...proposalPayload,
+        dashboardThreadId: normalizeDashboardThreadId(payload?.threadId || payload?.thread_id),
+        executionId: normalizeText32(payload?.executionId || payload?.execution_id)
+      },
       provider,
       origin: origin || "https://example.com"
     });


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #637 のうち、Dashboard Butler の自然文 VPS maintenance intent から表示された passkey 認証を owner が押した後、approvalGrantId を手作業コピーさせずに同じ Dashboard Butler chat thread へ戻して helper queue へ自動継続する経路を接続します。

## Satisfied Success Criteria

- Dashboard Butler が自然文で VPS privileged maintenance intent を理解し、scoped approval URL を owner-facing に返す経路で `dashboardThreadId` と `executionId` を保持します。
- iPhone passkey approval で host / repository / action / capability / impact scope / expiry が表示された scoped approvalGrant を発行し、その承認イベントを Dashboard Butler chat へ返せるようにします。
- 実行結果の前段として、helper queue に渡す runtime truth へ `rootExecutionStarted=false` / `helperExecutionStarted=false` を維持したまま進めます。

## Unsatisfied Success Criteria

- Production deploy 後の Dashboard Butler live E2E は未実施です。
- root-owned helper の全 lifecycle、capability add/remove/rollback/review、未知 capability proposal の完全 E2E はこの PR では完了しません。
- PWA notification の失敗時 repair/re-auth 通知設計全体はこの PR では実装しません。

## Non-goal violations

None.

## 開発前作戦図

- 作戦図 evidence: docs/development-strategy/issue-637-vps-passkey-auto-continue.md
- 完了体験: Owner は Dashboard Butler の chat に出た passkey を押すだけで、Butler が同じ thread に戻って VPS helper queue へ継続する。
- VTDD 全体で進める部分: Issue #637 の Dashboard Butler passkey 承認イベント return と helper queue 自動継続の接続を進める。
- 設計: Dashboard Butler proposal URL に `dashboardThreadId` と `executionId` を固定し、passkey operator page が same-origin Dashboard chat API へ承認イベントを返す owner-facing 経路にする。
- 仮説: 原因は helper queue ではなく passkey 承認後の approvalGrantId が chat thread に戻らず owner copy/paste に落ちていることだという仮説。
- 検証計画: worker test と operator page test で URL scope、auto-continue JS、manual copy UI suppression を検証し、`npm run verify:worker` で generated worker と self parity を確認する。
- 改修見積もり: `src/worker/runtime.js` の proposal URL / passkey page request / Dashboard VPS flow、`src/core/passkey-operator-page.js` の auto-continue mode、`test/worker.test.js`、`worker.js`。
- 既に通っている経路: Dashboard Butler natural-language intent、proposal 作成、scoped passkey approval、helper request、execution envelope、GitHub queue comment、VPS runner pickup/result comment は既存経路として通っている。
- 未確認の境界: Production deploy 後の live Dashboard auth state、PWA notification receive ack、VPS runner pickup timing は PR 前ローカル検証だけでは未確認。
- 穴が出そうな箇所: `dashboardThreadId` なしの URL では従来 manual flow を壊さないこと、Dashboard auth 切れで auto-continue POST が止まること、operator page から root/helper を直接実行しないこと。
- PR 前に確認すること: Issue #637、AGENTS.md、execution queue contract、active queue、該当 source/test、worker generated file、`npm run verify:worker` を確認する。
- 実装候補と捨てた案: 採用は passkey operator page から same-origin Dashboard chat API へ戻す案。捨てた案は approvalGrantId copy/paste、通知だけで owner に次操作させる案、mac Codex が代理で拾う案。
- merge 後に通す E2E: Production deploy 後、Dashboard Butler で #637 VPS runner status 自然文 prompt、passkey 承認、同じ thread への return、helper queue comment、runner result を live E2E で検証する。
- 次の PR を増やさない理由: 新しい queue protocol を増やさず既存 `/v2/dashboard/chat/messages` と #637 natural-language flow を再利用するため、この slice から予測できる別 PR を増やさない。
- 停止条件: Dashboard chat API が approvalGrantId を受けても helper queue に進めない、approval scope が proposal と一致しない、Dashboard auth が切れる、または root/helper execution を operator page から直接始める必要が出た場合は停止する。

## Dry-run Impact Report

- Target Issue: Issue #637
- Implementing Success Criteria: Dashboard Butler natural-language VPS maintenance intent から scoped passkey approval を出し、owner passkey 後に same Dashboard thread 経由で helper queue へ自動継続する。
- Explicit Non-goals: root/sudo helper の新 capability 追加、credential mutation、production deploy、Issue closure、Custom GPT Action Schema 主経路化、通知 system 全体改修はしない。
- Expected touched files/routes/workflows: `src/worker/runtime.js` `/v2/approval/passkey/operator` `/v2/dashboard/chat/messages`、`src/core/passkey-operator-page.js`、`test/worker.test.js`、`worker.js`、`docs/development-strategy/issue-637-vps-passkey-auto-continue.md`。
- Affected Issues: Issue #637 directly; Issue #413 / Issue #450 / Issue #514 are affected only as downstream visibility and notification surfaces.
- Affected PRs: PR #701 / PR #702 / PR #706 の既存 #637 queue/result/delivery 経路に接続するが、それらの merged branch は変更しない。
- Affected workflows: reviewer / auto-merge / deploy-production は PR 後の通常 workflow のみ。workflow file は変更しない。
- Affected runtime/operator surfaces: Dashboard Butler chat、passkey operator `mode=vps`、Worker Dashboard chat API、VPS helper queue comment。
- What may break if we patch narrowly: passkey page が threadId を持たない case、dashboard auth required case、manual approvalGrantId fallback、proposal scope matching が壊れる可能性がある。
- Unknowns to investigate before coding: production Dashboard auth cookie が operator page から same-origin POST できるか、PWA notification receive ack が live で取れるかは merge/deploy 後に確認する。
- Validation needed: `git diff --check`、targeted worker tests、`npm run verify:worker`、merge/deploy 後の production Dashboard Butler live E2E。
- Stop condition: root/helper execution を browser から直接始める必要が出る、approval scope mismatch が解消できない、Issue #637 以外の broad notification redesign が必要になる場合は停止する。

## Execution Queue Delta

- Queue position before: `Now` は Issue #637。owner の指摘は #637 の passkey approval return が Mac/manual 操作へ落ちる blocker。
- Preemption decision: ROOT。これは Issue #637 の Butler Completion Gate を塞ぎ、Issue #413 / Issue #450 / Issue #514 の owner-facing recovery も塞ぐ root blocker の内側です。
- Queue delta: Issue #637 stays `Now`; この PR は passkey approval event return から helper queue 自動継続の slice を進めます。
- Why this PR is next: owner が passkey を押した後に Dashboard Butler がイベントを拾えず、approvalGrantId copy/paste になる状態は Butler-first completion ではないため最短で塞ぐ必要があります。
- Active Issues not downscoped: Active Issues は縮小しません。Issue #637 の残り Success Criteria と他 active Issue は未完了として残します。

## File / Line Hypotheses

- file: `src/worker/runtime.js`
  - hypothesis: `buildVpsMaintenanceApprovalOperatorUrl` と Dashboard VPS flow が thread context を operator URL へ渡していないため、承認後に同じ chat thread へ戻れない。
  - risk if changed narrowly: proposal scope matching と manual/direct proposal flow を壊す。
  - validation: worker tests で URL search params と helper queue flow を確認。
  - related Issue: #637
- file: `src/core/passkey-operator-page.js`
  - hypothesis: passkey approve success handler が approvalGrantId 表示で止まり、Dashboard chat API へ戻すイベントを持たない。
  - risk if changed narrowly: deploy one-tap / dashboard_access operator mode を巻き込む。
  - validation: operator page HTML assertions と targeted worker tests。
  - related Issue: #637
- file: `test/worker.test.js`
  - hypothesis: 現行 tests は scoped passkey URL と page display を見ているが、Dashboard thread return を固定していない。
  - risk if changed narrowly: regression が production live E2E まで見つからない。
  - validation: `dashboardThreadId` / `executionId` / auto-continue JS / copy UI suppression assertions。
  - related Issue: #637

## Hypothesis Retrospective

- expected: Dashboard Butler proposal URL に thread context を保持し、operator page 承認後に `/v2/dashboard/chat/messages` へ戻せば manual copy/paste が不要になる。
- actual: 実装後の tests で approval URL に `dashboardThreadId` / `executionId` が入り、operator page が VPS auto-continue JS を持ち、manual copy UI を隠すことを確認した。
- mismatch: production live E2E は merge/deploy 後でないと確認できない。
- lesson: passkey approval は ID 発行 UI ではなく、Butler chat の continuation event として扱う必要がある。
- should become RAG candidate: はい。#637 の passkey approval は owner copy/paste 禁止、Dashboard Butler thread continuation event として扱う。

## Verification Evidence

- Unit: `node --test test/worker.test.js --test-name-pattern 'VPS privileged maintenance|Dashboard Butler VPS runner status|passkey operator displays VPS|connects VPS privileged maintenance'` passed 240/240.
- Integration: `npm run verify:worker` passed: `npm test` 1105 tests, 1104 pass, 1 skipped; self parity checked 33 routes and 33 operationIds; generated worker check passed.
- E2E: Production Dashboard Butler live E2E は merge/deploy 後に実施します。
- Manual: `git diff --check` passed.
- Evidence path/link: docs/development-strategy/issue-637-vps-passkey-auto-continue.md

## Butler Completion Contract

- Primary owner surface: Dashboard Butler。
- Fallback surface: Custom GPT は fallback surface であり、この PR の主経路ではありません。
- Owner goal: owner は Dashboard Butler の chat で passkey 認証を押すだけで、approvalGrantId をコピーせずに VPS helper queue へ進められる。
- Butler entrypoint: Dashboard Butler の通常チャットで VPS runner status / VPS maintenance intent を自然文で送る。
- Dashboard Butler natural-language path: Dashboard Butler の自然文 chat entrypoint が proposal URL を返し、passkey 承認後も同じ chat thread に戻って helper queue へ接続します。
- Action Schema exposure: Custom GPT Action Schema は fallback であり、この PR では主経路として扱わず変更しません。
- Runtime path: `/v2/dashboard/chat/messages` -> `buildDashboardVpsPrivilegedMaintenanceNaturalLanguageFlow` -> `/v2/approval/passkey/operator?mode=vps&dashboardThreadId=...` -> passkey approve -> `/v2/dashboard/chat/messages` -> helper queue。
- Runner/runtime truth: PR 前は local Worker tests で runtime truth を確認。production runner pickup/result は merge/deploy 後の live E2E で確認します。
- Authority boundary: scoped same-origin passkey approvalGrant のみが high-risk continuation を許可します。operator page は root/helper execution を直接開始せず、queue handoff までです。
- E2E evidence: 未完了。merge/deploy 後に production Dashboard Butler live E2E が必要です。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 必要。worker runtime 変更のため merge 後に production deploy passkey が必要です。
- Custom GPT Action Schema update: 不要。Dashboard Butler 主経路の runtime 接続です。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 必要。owner passkey 後に same Dashboard thread へ戻り helper queue が作られることを確認します。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate
- AGENTS.md Butler-First Operating Principle
- AGENTS.md Drift Stop Protocol
- docs/butler/execution-queue-contract.md
- docs/mvp/active-issue-execution-queue.md

## Out-of-scope but NOT implemented

- broad notification subsystem redesign
- failure repair / re-auth notification policy
- capability add/remove/rollback lifecycle full E2E
- Issue #637 closure
- production deploy itself

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #637
- Execution ID: issue637-vps-passkey-auto-continue
- Goal: Dashboard Butler の passkey 認証イベントを同じ chat thread に戻して VPS helper queue へ自動継続する。
