### PR TITLE
Issue #637 Dashboard WSのapproval URL originを修正

### DIFF
--- a/docs/development-strategy/issue-637-dashboard-ws-origin.md
+++ b/docs/development-strategy/issue-637-dashboard-ws-origin.md
@@ -1,0 +1,59 @@
+# Issue #637 Dashboard WebSocket origin strategy
+
+## 完了体験
+
+Owner は Dashboard Butler の通常チャットで VPS runner status intent を送る。Butler が返す passkey approval URL は、常に owner が開いている production Dashboard と同じ origin になり、`dashboard-butler.local` のような内部 fallback URL は表示されない。
+
+## VTDD 全体で進める部分
+
+Issue #637 の Dashboard Butler live E2E で見つかった WebSocket owner turn の origin drift を塞ぐ。#707 の passkey auto-continue 自体は維持し、そこへ到達する approval URL を production same-origin に固定する。
+
+## 設計
+
+DashboardChatRoom が WebSocket 接続を受けた時点の request origin を socket attachment に保持する。owner message 処理では、その origin を VPS maintenance natural-language flow に渡す。明示 origin がある場合は `VTDD_RUNTIME_URL` / `VTDD_PASSKEY_ORIGIN` より優先し、最後の fallback としてのみ `dashboard-butler.local` を残す。
+
+## 仮説
+
+HTTP Dashboard chat route は request origin を使うが、WebSocket DashboardChatRoom は env fallback だけで approval URL を作るため、本番 env に `VTDD_RUNTIME_URL` が無いと `dashboard-butler.local` が漏れるという仮説。
+
+## 検証計画
+
+DashboardChatRoom の unit test で env に runtime URL が無い状態でも attachment origin から production approval URL が生成され、`dashboard-butler.local` が出ないことを確認する。worker build と `npm run verify:worker` を通す。merge/deploy 後に production Dashboard Butler live E2E で approval URL が production origin になることを確認する。
+
+## 改修見積もり
+
+- `src/worker/runtime.js`: `DashboardChatRoom.acceptSocket` attachment、`handleSocketMessage` から `acceptOwnerMessage` への origin 伝搬、`buildVpsMaintenanceIntentMessages` の origin 優先順。
+- `test/worker.test.js`: DashboardChatRoom WebSocket origin regression test。
+- `worker.js`: generated worker。
+
+## 既に通っている経路
+
+#707 で Dashboard Butler の passkey URL に `dashboardThreadId` を含め、operator page が承認後に same thread へ戻す JS は production route に載っている。
+
+## 未確認の境界
+
+Production deploy 後の実 Dashboard WebSocket での owner turn、passkey 承認、helper queue 自動継続は merge/deploy 後に再度 live E2E が必要。
+
+## 穴が出そうな箇所
+
+app-server bridge socket も attachment origin を持つが、今回の origin は Dashboard owner turn の approval URL 生成だけに使う。env fallback を完全に消すと内部テストや非標準 runtime が壊れるため、明示 origin がない場合の fallback は残す。
+
+## PR 前に確認すること
+
+Issue #637、#707 の live E2E failure、DashboardChatRoom source、worker tests、generated worker、PR body guardrail を確認する。
+
+## 実装候補と捨てた案
+
+採用案は WebSocket request origin を attachment に保存して owner turn に渡す。捨てた案は production env に `VTDD_RUNTIME_URL` を足すだけの運用修正、URL 文字列をあとから置換する案、owner に手で URL host を直させる案。
+
+## merge 後に通す E2E
+
+Production deploy 後、Dashboard Butler の新規 thread で VPS runner status intent を送る。approval URL が `https://vtdd-v2-mvp.polished-tree-da7c.workers.dev/...` で、`dashboardThreadId` を持ち、`dashboard-butler.local` を含まないことを確認する。その後 passkey 承認で helper queue へ自動継続する。
+
+## 次の PR を増やさない理由
+
+この slice は live E2E で見えた root cause の origin 伝搬だけを直す。#707 の auto-continue 設計を広げず、env 設定や通知 system に逃げないため、同じ穴からの後続 PR を増やさない。
+
+## 停止条件
+
+WebSocket request origin が取得できない、production URL が still local fallback になる、または approval URL を作るために owner-specific static URL を repo に埋める必要が出た場合は停止する。

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -155,7 +155,7 @@ export class DashboardChatRoom {
   async acceptSocket({ request, role, threadId }) {
     const pair = new WebSocketPair();
     const [client, server] = Object.values(pair);
-    const attachment = { role, threadId };
+    const attachment = { role, threadId, origin: url.origin };
     if (typeof this.ctx?.acceptWebSocket === "function") {
       server.serializeAttachment(attachment);
       this.ctx.acceptWebSocket(server);
@@ -218,7 +218,7 @@ export class DashboardChatRoom {
       payload = null;
     }
     if (payload?.type === "owner_message") {
-      await this.acceptOwnerMessage({ socket, threadId, payload });
+      await this.acceptOwnerMessage({ socket, threadId, payload, origin: socketAttachment.origin });
       return;
     }
     if (socketAttachment.role === "app_server_bridge") {
@@ -226,7 +226,7 @@ export class DashboardChatRoom {
     }
   }
 
-  async acceptOwnerMessage({ socket, threadId, payload }) {
+  async acceptOwnerMessage({ socket, threadId, payload, origin }) {
     const clientMessageId = sanitizeDashboardChatText(payload?.clientMessageId || payload?.client_message_id);
     const inputMediaReferences = payload?.mediaReferences || payload?.media_references || payload?.media;
     const mediaReferences = normalizeMediaReferences(inputMediaReferences);
@@ -301,7 +301,8 @@ export class DashboardChatRoom {
       repository,
       relatedIssue,
       text,
-      now
+      now,
+      origin
     });
     const bridgeSockets = this.connectedAppServerBridgeSockets(threadId);
     if (bridgeSockets.length === 0) {
@@ -402,7 +403,7 @@ export class DashboardChatRoom {
     return this.sendSocket(bridgeSocket, turnRequest);
   }
 
-  async buildVpsMaintenanceIntentMessages({ payload, threadId, repository, relatedIssue, text, now }) {
+  async buildVpsMaintenanceIntentMessages({ payload, threadId, repository, relatedIssue, text, now, origin }) {
     if (!detectDashboardVpsPrivilegedMaintenanceIntent({ text })) {
       return null;
     }
@@ -417,7 +418,7 @@ export class DashboardChatRoom {
       },
       repository,
       relatedIssue,
-      origin: normalizeText(this.env?.VTDD_RUNTIME_URL || this.env?.VTDD_PASSKEY_ORIGIN) || "https://dashboard-butler.local",
+      origin: normalizeText(origin) || normalizeText(this.env?.VTDD_RUNTIME_URL || this.env?.VTDD_PASSKEY_ORIGIN) || "https://dashboard-butler.local",
       env: this.env
     });
     return [

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -3269,6 +3269,52 @@ test("DashboardChatRoom routes VPS maintenance owner turns to Worker proposal be
   assert.equal(proposalRecord.content.proposal.capability.riskLevel, "low");
 });
 
+test("DashboardChatRoom uses WebSocket request origin for VPS approval URLs", async () => {
+  const provider = createInMemoryMemoryProvider();
+  const store = createInMemoryDashboardChatStore();
+  const dashboardSocket = createMockSocket("dashboard", "dashboard-e2e-637-origin");
+  const room = new DashboardChatRoom(
+    {
+      storage: createMockDurableObjectStorage(),
+      getWebSockets() {
+        return [dashboardSocket];
+      }
+    },
+    {
+      DASHBOARD_CHAT_STORE: store,
+      MEMORY_PROVIDER: provider,
+      VTDD_DASHBOARD_VPS_MAINTENANCE_HOST: "x85-131-245-163",
+      VTDD_DASHBOARD_VPS_MAINTENANCE_WORKDIR: "/home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p"
+    }
+  );
+
+  await room.handleSocketMessage(
+    dashboardSocket,
+    JSON.stringify({
+      type: "owner_message",
+      repository: "marushu/vtdd-v2-p",
+      issueNumber: 637,
+      text: "Dashboard Butler から VPS runner status を確認して。root 実行は passkey 境界で止める。"
+    }),
+    {
+      role: "dashboard",
+      threadId: "dashboard-e2e-637-origin",
+      origin: "https://vtdd-v2-mvp.polished-tree-da7c.workers.dev"
+    }
+  );
+
+  const finalBroadcast = dashboardSocket.sent
+    .map((message) => JSON.parse(message))
+    .findLast((message) => message.type === "thread");
+  const butlerMessage = finalBroadcast.messages.find((message) => message.role === "butler");
+  assert.match(
+    butlerMessage.text,
+    /https:\/\/vtdd-v2-mvp\.polished-tree-da7c\.workers\.dev\/v2\/approval\/passkey\/operator/
+  );
+  assert.doesNotMatch(butlerMessage.text, /dashboard-butler\.local/);
+  assert.match(butlerMessage.text, /dashboardThreadId=dashboard-e2e-637-origin/);
+});
+
 test("DashboardChatRoom routes VPS maintenance owner turns without an app-server bridge socket", async () => {
   const provider = createInMemoryMemoryProvider();
   const store = createInMemoryDashboardChatStore();

--- a/worker.js
+++ b/worker.js
@@ -22242,9 +22242,9 @@ var CRLDistributionPointsExtension = class extends Extension2 {
       super(args[0]);
     } else if (Array.isArray(args[0]) && typeof args[0][0] === "string") {
       const urls = args[0];
-      const dps = urls.map((url) => {
+      const dps = urls.map((url2) => {
         return new DistributionPoint({
-          distributionPoint: new DistributionPointName({ fullName: [new GeneralName({ uniformResourceIdentifier: url })] })
+          distributionPoint: new DistributionPointName({ fullName: [new GeneralName({ uniformResourceIdentifier: url2 })] })
         });
       });
       const value = new CRLDistributionPoints(dps);
@@ -22366,13 +22366,13 @@ function addAccessDescriptions(value, params, method, key) {
   const items = params[key];
   if (items) {
     const array2 = Array.isArray(items) ? items : [items];
-    array2.forEach((url) => {
-      if (typeof url === "string") {
-        url = new GeneralName3("url", url);
+    array2.forEach((url2) => {
+      if (typeof url2 === "string") {
+        url2 = new GeneralName3("url", url2);
       }
       value.push(new AccessDescription({
         accessMethod: method,
-        accessLocation: AsnConvert.parse(url.rawData, GeneralName)
+        accessLocation: AsnConvert.parse(url2.rawData, GeneralName)
       }));
     });
   }
@@ -23510,11 +23510,11 @@ AsnEcSignatureFormatter.namedCurveSize.set("P-384", 48);
 AsnEcSignatureFormatter.namedCurveSize.set("P-521", 66);
 
 // node_modules/@simplewebauthn/server/esm/helpers/fetch.js
-function fetch2(url) {
-  return _fetchInternals.stubThis(url);
+function fetch2(url2) {
+  return _fetchInternals.stubThis(url2);
 }
 var _fetchInternals = {
-  stubThis: (url) => globalThis.fetch(url)
+  stubThis: (url2) => globalThis.fetch(url2)
 };
 
 // node_modules/@simplewebauthn/server/esm/helpers/isCertRevoked.js
@@ -24703,17 +24703,17 @@ var BaseMetadataService = class {
     if (mdsServers?.length) {
       const currentCacheCount = Object.keys(this.statementCache).length;
       let numServers = mdsServers.length;
-      for (const url of mdsServers) {
+      for (const url2 of mdsServers) {
         try {
           const cachedMDS = {
-            url,
+            url: url2,
             no: 0,
             nextUpdate: /* @__PURE__ */ new Date(0)
           };
           const blob = await this.downloadBlob(cachedMDS);
           await this.verifyBlob(blob, cachedMDS);
         } catch (err) {
-          log(`Could not download BLOB from ${url}:`, err);
+          log(`Could not download BLOB from ${url2}:`, err);
           numServers -= 1;
         }
       }
@@ -24770,8 +24770,8 @@ var BaseMetadataService = class {
    * Download and process the latest BLOB from MDS
    */
   async downloadBlob(cachedMDS) {
-    const { url } = cachedMDS;
-    const resp = await fetch2(url);
+    const { url: url2 } = cachedMDS;
+    const resp = await fetch2(url2);
     const data = await resp.text();
     return data;
   }
@@ -24779,18 +24779,18 @@ var BaseMetadataService = class {
    * Verify and process the MDS metadata blob
    */
   async verifyBlob(blob, cachedMDS) {
-    const { url, no } = cachedMDS;
+    const { url: url2, no } = cachedMDS;
     const { payload, parsedNextUpdate } = await verifyMDSBlob(blob);
     if (payload.no <= no) {
       throw new Error(`Latest BLOB no. ${payload.no} is not greater than previous no. ${no}`);
     }
     for (const entry of payload.entries) {
       if (entry.aaguid) {
-        this.statementCache[entry.aaguid] = { entry, url };
+        this.statementCache[entry.aaguid] = { entry, url: url2 };
       }
     }
-    if (url) {
-      this.mdsCache[url] = {
+    if (url2) {
+      this.mdsCache[url2] = {
         ...cachedMDS,
         // Store the payload `no` to make sure we're getting the next BLOB in the sequence
         no: payload.no,
@@ -29143,8 +29143,8 @@ function buildHeadline({ pullRequest, reviewLoop }) {
     if (pullRequest.mergeability.status === "unverified") {
       return `${base} PR conflict runtime truth is unverified; Butler must re-read runtime truth before merge judgment.`;
     }
-    const url = reviewLoop.reviewerEvidence.url ? ` Approve evidence: ${reviewLoop.reviewerEvidence.url}` : "";
-    return `${base} Gemini reviewer action is approve.${url}`;
+    const url2 = reviewLoop.reviewerEvidence.url ? ` Approve evidence: ${reviewLoop.reviewerEvidence.url}` : "";
+    return `${base} Gemini reviewer action is approve.${url2}`;
   }
   if (reviewLoop.reviewCommentsCount > 0) {
     return `${base} Reviewer feedback exists and should be checked before human GO.`;
@@ -29206,14 +29206,14 @@ function buildHumanDecisionFocus({ pullRequest, reviewLoop, codexGoal, branchAtt
   }
   if (reviewLoop.reviewerEvidence?.recommendedAction) {
     const action = reviewLoop.reviewerEvidence.recommendedAction;
-    const url = reviewLoop.reviewerEvidence.url ? ` ${reviewLoop.reviewerEvidence.url}` : "";
-    focus.push(`Latest ${reviewLoop.reviewer} reviewer action is ${action}.${url}`);
+    const url2 = reviewLoop.reviewerEvidence.url ? ` ${reviewLoop.reviewerEvidence.url}` : "";
+    focus.push(`Latest ${reviewLoop.reviewer} reviewer action is ${action}.${url2}`);
   }
   const latestTimelineItem = reviewLoop.reviewTimeline.at(-1);
   if (latestTimelineItem) {
-    const url = latestTimelineItem.url ? ` ${latestTimelineItem.url}` : "";
+    const url2 = latestTimelineItem.url ? ` ${latestTimelineItem.url}` : "";
     focus.push(
-      `Latest review timeline item: ${latestTimelineItem.type}, status=${latestTimelineItem.status || "unknown"}${url}`
+      `Latest review timeline item: ${latestTimelineItem.type}, status=${latestTimelineItem.status || "unknown"}${url2}`
     );
   }
   for (const warning of reviewLoop.reviewerSignalTruth?.warnings ?? []) {
@@ -29732,10 +29732,10 @@ async function createGitHubAppJwt({ appId, privateKey, env, nowSeconds }) {
 async function fetchGitHubInstallationRepositories({ token, fetchImpl, apiBaseUrl }) {
   const repositories = [];
   for (let page = 1; page <= MAX_REPOSITORY_PAGES; page += 1) {
-    const url = `${apiBaseUrl}${INSTALLATION_REPOSITORIES_PATH}?per_page=${REPOSITORIES_PER_PAGE}&page=${page}`;
+    const url2 = `${apiBaseUrl}${INSTALLATION_REPOSITORIES_PATH}?per_page=${REPOSITORIES_PER_PAGE}&page=${page}`;
     let response;
     try {
-      response = await fetchImpl(url, {
+      response = await fetchImpl(url2, {
         method: "GET",
         headers: {
           authorization: `Bearer ${token}`,
@@ -39943,18 +39943,18 @@ function normalizeApiBaseUrl5(value) {
   return normalized ? normalized.replace(/\/+$/, "") : GITHUB_API_BASE_URL4;
 }
 function buildPasskeyOperatorUrl({ origin, repository, phase, actionType, highRiskKind, issueNumber, pullNumber }) {
-  const url = new URL("/v2/approval/passkey/operator", `${origin}/`);
-  url.searchParams.set("repositoryInput", repository);
-  url.searchParams.set("phase", phase || "execution");
-  url.searchParams.set("actionType", actionType);
-  url.searchParams.set("highRiskKind", highRiskKind);
+  const url2 = new URL("/v2/approval/passkey/operator", `${origin}/`);
+  url2.searchParams.set("repositoryInput", repository);
+  url2.searchParams.set("phase", phase || "execution");
+  url2.searchParams.set("actionType", actionType);
+  url2.searchParams.set("highRiskKind", highRiskKind);
   if (Number.isInteger(issueNumber) && issueNumber > 0) {
-    url.searchParams.set("issueNumber", String(issueNumber));
+    url2.searchParams.set("issueNumber", String(issueNumber));
   }
   if (Number.isInteger(pullNumber) && pullNumber > 0) {
-    url.searchParams.set("pullNumber", String(pullNumber));
+    url2.searchParams.set("pullNumber", String(pullNumber));
   }
-  return url.toString();
+  return url2.toString();
 }
 function classifyIssueCloseOperatorStatus({
   repository,
@@ -40323,12 +40323,12 @@ function buildGitHubReadRequest({
     };
   }
   if (resource === GitHubReadResource.WORKFLOW_RUNS) {
-    const url = new URL(`${apiBaseUrl}/repos/${encodedRepository}/actions/runs`);
-    url.searchParams.set("per_page", String(limit));
+    const url2 = new URL(`${apiBaseUrl}/repos/${encodedRepository}/actions/runs`);
+    url2.searchParams.set("per_page", String(limit));
     if (branch) {
-      url.searchParams.set("branch", branch);
+      url2.searchParams.set("branch", branch);
     }
-    return { url: url.toString() };
+    return { url: url2.toString() };
   }
   if (resource === GitHubReadResource.WORKFLOW_JOBS) {
     return {
@@ -40347,16 +40347,16 @@ function buildGitHubReadRequest({
   }
   if (resource === GitHubReadResource.CONTENTS) {
     const encodedPath = path.split("/").filter(Boolean).map((segment) => encodeURIComponent(segment)).join("/");
-    const url = new URL(`${apiBaseUrl}/repos/${encodedRepository}/contents/${encodedPath}`);
+    const url2 = new URL(`${apiBaseUrl}/repos/${encodedRepository}/contents/${encodedPath}`);
     if (ref) {
-      url.searchParams.set("ref", ref);
+      url2.searchParams.set("ref", ref);
     }
-    return { url: url.toString() };
+    return { url: url2.toString() };
   }
   if (resource === GitHubReadResource.TREE) {
-    const url = new URL(`${apiBaseUrl}/repos/${encodedRepository}/git/trees/${encodeURIComponent(ref)}`);
-    url.searchParams.set("recursive", "1");
-    return { url: url.toString() };
+    const url2 = new URL(`${apiBaseUrl}/repos/${encodedRepository}/git/trees/${encodeURIComponent(ref)}`);
+    url2.searchParams.set("recursive", "1");
+    return { url: url2.toString() };
   }
   return { url: `${apiBaseUrl}/repos/${encodedRepository}` };
 }
@@ -40964,11 +40964,11 @@ function resolveGitHubWriteFetch(env) {
   }
   return globalThis.fetch.bind(globalThis);
 }
-function buildGitHubWriteFetchExceptionDiagnostics({ operation, method, url, error: error2 }) {
+function buildGitHubWriteFetchExceptionDiagnostics({ operation, method, url: url2, error: error2 }) {
   return {
     operation,
     requestMethod: method,
-    requestUrl: sanitizeGitHubWriteDiagnosticText(url),
+    requestUrl: sanitizeGitHubWriteDiagnosticText(url2),
     exceptionName: sanitizeGitHubWriteDiagnosticText(error2?.name || "Error"),
     exceptionMessage: sanitizeGitHubWriteDiagnosticText(error2?.message || error2)
   };
@@ -47465,10 +47465,10 @@ var $ZodURL = /* @__PURE__ */ $constructor("$ZodURL", (inst, def) => {
           return;
         }
       }
-      const url = new URL(trimmed);
+      const url2 = new URL(trimmed);
       if (def.hostname) {
         def.hostname.lastIndex = 0;
-        if (!def.hostname.test(url.hostname)) {
+        if (!def.hostname.test(url2.hostname)) {
           payload.issues.push({
             code: "invalid_format",
             format: "url",
@@ -47482,7 +47482,7 @@ var $ZodURL = /* @__PURE__ */ $constructor("$ZodURL", (inst, def) => {
       }
       if (def.protocol) {
         def.protocol.lastIndex = 0;
-        if (!def.protocol.test(url.protocol.endsWith(":") ? url.protocol.slice(0, -1) : url.protocol)) {
+        if (!def.protocol.test(url2.protocol.endsWith(":") ? url2.protocol.slice(0, -1) : url2.protocol)) {
           payload.issues.push({
             code: "invalid_format",
             format: "url",
@@ -47495,7 +47495,7 @@ var $ZodURL = /* @__PURE__ */ $constructor("$ZodURL", (inst, def) => {
         }
       }
       if (def.normalize) {
-        payload.value = url.href;
+        payload.value = url2.href;
       } else {
         payload.value = trimmed;
       }
@@ -57512,8 +57512,8 @@ var DashboardChatRoom = class {
     this.sessions = /* @__PURE__ */ new Map();
   }
   async fetch(request) {
-    const url = new URL(request.url);
-    if (request.method === "POST" && url.pathname === "/broadcast") {
+    const url2 = new URL(request.url);
+    if (request.method === "POST" && url2.pathname === "/broadcast") {
       const payload = await readJson(request);
       const threadId2 = normalizeDashboardThreadId(payload.threadId || payload.thread_id);
       if (!threadId2) {
@@ -57543,8 +57543,8 @@ var DashboardChatRoom = class {
         reason: "WebSocketPair is not available in this runtime"
       });
     }
-    const appServerBridgeSocket = isDashboardAppServerBridgeSocketPath(url.pathname);
-    const threadId = appServerBridgeSocket ? normalizeDashboardThreadId(url.searchParams.get("threadId") || url.searchParams.get("thread_id")) : extractDashboardChatSocketThreadId(url.pathname);
+    const appServerBridgeSocket = isDashboardAppServerBridgeSocketPath(url2.pathname);
+    const threadId = appServerBridgeSocket ? normalizeDashboardThreadId(url2.searchParams.get("threadId") || url2.searchParams.get("thread_id")) : extractDashboardChatSocketThreadId(url2.pathname);
     if (appServerBridgeSocket) {
       return this.acceptSocket({ request, role: "app_server_bridge", threadId });
     }
@@ -57560,7 +57560,7 @@ var DashboardChatRoom = class {
   async acceptSocket({ request, role, threadId }) {
     const pair = new WebSocketPair();
     const [client, server] = Object.values(pair);
-    const attachment = { role, threadId };
+    const attachment = { role, threadId, origin: url.origin };
     if (typeof this.ctx?.acceptWebSocket === "function") {
       server.serializeAttachment(attachment);
       this.ctx.acceptWebSocket(server);
@@ -57615,14 +57615,14 @@ var DashboardChatRoom = class {
       payload = null;
     }
     if (payload?.type === "owner_message") {
-      await this.acceptOwnerMessage({ socket, threadId, payload });
+      await this.acceptOwnerMessage({ socket, threadId, payload, origin: socketAttachment.origin });
       return;
     }
     if (socketAttachment.role === "app_server_bridge") {
       await this.acceptAppServerBridgeMessage({ socket, attachment: socketAttachment, payload });
     }
   }
-  async acceptOwnerMessage({ socket, threadId, payload }) {
+  async acceptOwnerMessage({ socket, threadId, payload, origin }) {
     const clientMessageId = sanitizeDashboardChatText(payload?.clientMessageId || payload?.client_message_id);
     const inputMediaReferences = payload?.mediaReferences || payload?.media_references || payload?.media;
     const mediaReferences = normalizeMediaReferences(inputMediaReferences);
@@ -57694,7 +57694,8 @@ var DashboardChatRoom = class {
       repository,
       relatedIssue,
       text,
-      now
+      now,
+      origin
     });
     const bridgeSockets = this.connectedAppServerBridgeSockets(threadId);
     if (bridgeSockets.length === 0) {
@@ -57792,7 +57793,7 @@ var DashboardChatRoom = class {
     };
     return this.sendSocket(bridgeSocket, turnRequest);
   }
-  async buildVpsMaintenanceIntentMessages({ payload, threadId, repository, relatedIssue, text, now }) {
+  async buildVpsMaintenanceIntentMessages({ payload, threadId, repository, relatedIssue, text, now, origin }) {
     if (!detectDashboardVpsPrivilegedMaintenanceIntent({ text })) {
       return null;
     }
@@ -57807,7 +57808,7 @@ var DashboardChatRoom = class {
       },
       repository,
       relatedIssue,
-      origin: normalizeText32(this.env?.VTDD_RUNTIME_URL || this.env?.VTDD_PASSKEY_ORIGIN) || "https://dashboard-butler.local",
+      origin: normalizeText32(origin) || normalizeText32(this.env?.VTDD_RUNTIME_URL || this.env?.VTDD_PASSKEY_ORIGIN) || "https://dashboard-butler.local",
       env: this.env
     });
     return [
@@ -58119,8 +58120,8 @@ var MEDIA_UPLOAD_HARD_LIMIT_BYTES = 20 * 1024 * 1024;
 var MEDIA_REFERENCE_LIMIT = 12;
 var runtime_default = {
   async fetch(request, env) {
-    const url = new URL(request.url);
-    if (request.method === "GET" && url.pathname === "/health") {
+    const url2 = new URL(request.url);
+    if (request.method === "GET" && url2.pathname === "/health") {
       return json(200, {
         ok: true,
         service: "vtdd-v2-worker",
@@ -58128,162 +58129,162 @@ var runtime_default = {
         autonomyMode: resolveRuntimeAutonomyMode(env)
       });
     }
-    if (request.method === "GET" && url.pathname === "/status") {
+    if (request.method === "GET" && url2.pathname === "/status") {
       return html(
         200,
         renderV2StatusPage({
-          runtimeOrigin: url.origin,
+          runtimeOrigin: url2.origin,
           autonomyMode: resolveRuntimeAutonomyMode(env)
         })
       );
     }
-    if (request.method === "GET" && (url.pathname === "/setup" || url.pathname === "/setup/recovery" || url.pathname === "/setup/latest" || url.pathname === "/setup/known-good")) {
-      return handleCustomGptRecoveryPageRequest(url, env);
+    if (request.method === "GET" && (url2.pathname === "/setup" || url2.pathname === "/setup/recovery" || url2.pathname === "/setup/latest" || url2.pathname === "/setup/known-good")) {
+      return handleCustomGptRecoveryPageRequest(url2, env);
     }
-    if (request.method === "GET" && url.pathname === "/setup/diagnostics") {
-      return handleCustomGptSetupDiagnosticsPageRequest(url, env);
+    if (request.method === "GET" && url2.pathname === "/setup/diagnostics") {
+      return handleCustomGptSetupDiagnosticsPageRequest(url2, env);
     }
-    if (request.method === "GET" && (url.pathname === "/help" || url.pathname === "/guide")) {
+    if (request.method === "GET" && (url2.pathname === "/help" || url2.pathname === "/guide")) {
       return html(
         200,
         renderVtddHelpGuidePage({
-          runtimeOrigin: url.origin,
+          runtimeOrigin: url2.origin,
           mcpPath: MCP_PATH
         })
       );
     }
-    if (request.method === "GET" && url.pathname === "/dashboard.webmanifest") {
-      return json(200, buildDashboardWebManifest(url), {
+    if (request.method === "GET" && url2.pathname === "/dashboard.webmanifest") {
+      return json(200, buildDashboardWebManifest(url2), {
         "content-type": "application/manifest+json; charset=utf-8"
       });
     }
-    if (request.method === "GET" && url.pathname === "/dashboard-sw.js") {
+    if (request.method === "GET" && url2.pathname === "/dashboard-sw.js") {
       return javascript(200, renderDashboardServiceWorkerScript());
     }
-    if (request.method === "GET" && url.pathname === "/dashboard-icon.svg") {
+    if (request.method === "GET" && url2.pathname === "/dashboard-icon.svg") {
       return svg(200, renderDashboardIconSvg());
     }
-    if (request.method === "GET" && (url.pathname === "/dashboard-icon.png" || url.pathname === DASHBOARD_ICON_PNG_PATH || url.pathname === "/apple-touch-icon.png" || url.pathname === "/apple-touch-icon-precomposed.png")) {
+    if (request.method === "GET" && (url2.pathname === "/dashboard-icon.png" || url2.pathname === DASHBOARD_ICON_PNG_PATH || url2.pathname === "/apple-touch-icon.png" || url2.pathname === "/apple-touch-icon-precomposed.png")) {
       return png(200, dashboard_butler_icon_512_default);
     }
-    if (request.method === "GET" && isDashboardPagePath(url.pathname)) {
-      const auth = await authorizeDashboardRequest({ request, env, apiSuffix: url.pathname });
+    if (request.method === "GET" && isDashboardPagePath(url2.pathname)) {
+      const auth = await authorizeDashboardRequest({ request, env, apiSuffix: url2.pathname });
       if (!auth.ok) {
         return html(
           auth.status,
           renderDashboardAuthRequiredPage({
-            runtimeOrigin: url.origin,
-            returnPath: `${url.pathname}${url.search}`,
+            runtimeOrigin: url2.origin,
+            returnPath: `${url2.pathname}${url2.search}`,
             reason: auth.reason,
             passkeyFallbackReason: auth.passkeyFallbackReason
           })
         );
       }
     }
-    if (request.method === "GET" && (url.pathname === "/dashboard" || url.pathname === "/orchestrator")) {
+    if (request.method === "GET" && (url2.pathname === "/dashboard" || url2.pathname === "/orchestrator")) {
       return html(
         200,
         await renderV2DashboardPage({
-          runtimeOrigin: url.origin,
-          url,
+          runtimeOrigin: url2.origin,
+          url: url2,
           dashboardEventStore: resolveDashboardEventStore(env)
         })
       );
     }
-    if (request.method === "GET" && url.pathname === "/dashboard/github") {
-      return html(200, await renderDashboardGitHubTruthPage({ url, env }));
+    if (request.method === "GET" && url2.pathname === "/dashboard/github") {
+      return html(200, await renderDashboardGitHubTruthPage({ url: url2, env }));
     }
-    if (request.method === "GET" && url.pathname === "/dashboard/preflight") {
-      return html(200, await renderDashboardPreflightPage({ url, env }));
+    if (request.method === "GET" && url2.pathname === "/dashboard/preflight") {
+      return html(200, await renderDashboardPreflightPage({ url: url2, env }));
     }
-    if (request.method === "GET" && url.pathname === "/dashboard/progress") {
-      return html(200, await renderDashboardProgressPage({ url, env }));
+    if (request.method === "GET" && url2.pathname === "/dashboard/progress") {
+      return html(200, await renderDashboardProgressPage({ url: url2, env }));
     }
-    if (request.method === "GET" && url.pathname === "/dashboard/vps-runner") {
-      return html(200, await renderDashboardVpsRunnerPage({ url, env }));
+    if (request.method === "GET" && url2.pathname === "/dashboard/vps-runner") {
+      return html(200, await renderDashboardVpsRunnerPage({ url: url2, env }));
     }
-    if (request.method === "GET" && url.pathname === "/dashboard/memory") {
-      return html(200, await renderDashboardMemoryPage({ url, env }));
+    if (request.method === "GET" && url2.pathname === "/dashboard/memory") {
+      return html(200, await renderDashboardMemoryPage({ url: url2, env }));
     }
-    if (request.method === "GET" && url.pathname === "/dashboard/self-parity") {
-      return html(200, await renderDashboardSelfParityPage({ url, env }));
+    if (request.method === "GET" && url2.pathname === "/dashboard/self-parity") {
+      return html(200, await renderDashboardSelfParityPage({ url: url2, env }));
     }
-    if (request.method === "GET" && url.pathname === "/dashboard/news") {
-      return html(200, renderDashboardNewsPage({ runtimeOrigin: url.origin, env }));
+    if (request.method === "GET" && url2.pathname === "/dashboard/news") {
+      return html(200, renderDashboardNewsPage({ runtimeOrigin: url2.origin, env }));
     }
-    if (request.method === "GET" && url.pathname === "/dashboard/notifications") {
+    if (request.method === "GET" && url2.pathname === "/dashboard/notifications") {
       return html(
         200,
         await renderDashboardNotificationsPage({
-          runtimeOrigin: url.origin,
+          runtimeOrigin: url2.origin,
           dashboardEventStore: resolveDashboardEventStore(env),
           env
         })
       );
     }
-    if (request.method === "POST" && isApiPath(url.pathname, "/dashboard/chat/messages")) {
+    if (request.method === "POST" && isApiPath(url2.pathname, "/dashboard/chat/messages")) {
       return handleDashboardChatMessageRequest(request, env);
     }
-    if (request.method === "POST" && isApiPath(url.pathname, "/media/upload")) {
+    if (request.method === "POST" && isApiPath(url2.pathname, "/media/upload")) {
       return handleMediaUploadRequest(request, env);
     }
-    if (request.method === "GET" && isApiPath(url.pathname, "/media/search")) {
-      return handleMediaSearchRequest(request, url, env);
+    if (request.method === "GET" && isApiPath(url2.pathname, "/media/search")) {
+      return handleMediaSearchRequest(request, url2, env);
     }
-    const mediaRoute = matchMediaObjectRoute(url.pathname);
+    const mediaRoute = matchMediaObjectRoute(url2.pathname);
     if (mediaRoute && request.method === "GET") {
       return handleMediaObjectRequest(request, env, mediaRoute);
     }
     if (mediaRoute && request.method === "DELETE") {
       return handleMediaDeleteRequest(request, env, mediaRoute);
     }
-    if (request.method === "POST" && isApiPath(url.pathname, "/dashboard/push/subscription")) {
+    if (request.method === "POST" && isApiPath(url2.pathname, "/dashboard/push/subscription")) {
       return handleDashboardPushSubscriptionRequest(request, env);
     }
-    if (request.method === "POST" && isApiPath(url.pathname, "/dashboard/push/status")) {
+    if (request.method === "POST" && isApiPath(url2.pathname, "/dashboard/push/status")) {
       return handleDashboardPushStatusRequest(request, env);
     }
-    if (request.method === "POST" && isApiPath(url.pathname, "/dashboard/push/test")) {
+    if (request.method === "POST" && isApiPath(url2.pathname, "/dashboard/push/test")) {
       return handleDashboardPushTestRequest(request, env);
     }
-    if (request.method === "POST" && isApiPath(url.pathname, "/dashboard/push/ack")) {
+    if (request.method === "POST" && isApiPath(url2.pathname, "/dashboard/push/ack")) {
       return handleDashboardPushAckRequest(request, env);
     }
-    if (request.method === "GET" && isDashboardChatSocketApiPath(url.pathname)) {
-      return handleDashboardChatSocketRequest(request, url, env);
+    if (request.method === "GET" && isDashboardChatSocketApiPath(url2.pathname)) {
+      return handleDashboardChatSocketRequest(request, url2, env);
     }
-    if (request.method === "GET" && isDashboardAppServerBridgeSocketPath(url.pathname)) {
-      return handleDashboardAppServerBridgeSocketRequest(request, url, env);
+    if (request.method === "GET" && isDashboardAppServerBridgeSocketPath(url2.pathname)) {
+      return handleDashboardAppServerBridgeSocketRequest(request, url2, env);
     }
-    if (request.method === "GET" && isApiPath(url.pathname, "/dashboard/chat/search")) {
-      return handleDashboardChatSearchRequest(request, url, env);
+    if (request.method === "GET" && isApiPath(url2.pathname, "/dashboard/chat/search")) {
+      return handleDashboardChatSearchRequest(request, url2, env);
     }
-    if ((request.method === "GET" || request.method === "POST") && isDashboardChatSummaryApiPath(url.pathname)) {
-      return handleDashboardChatSummaryRequest(request, url, env);
+    if ((request.method === "GET" || request.method === "POST") && isDashboardChatSummaryApiPath(url2.pathname)) {
+      return handleDashboardChatSummaryRequest(request, url2, env);
     }
-    if (request.method === "GET" && isDashboardChatThreadApiPath(url.pathname)) {
-      return handleDashboardChatThreadRequest(request, url, env);
+    if (request.method === "GET" && isDashboardChatThreadApiPath(url2.pathname)) {
+      return handleDashboardChatThreadRequest(request, url2, env);
     }
-    if (request.method === "GET" && (url.pathname === MCP_PROTECTED_RESOURCE_METADATA_PATH || url.pathname === MCP_PROTECTED_RESOURCE_METADATA_MIRROR_PATH)) {
-      return json(200, buildMcpProtectedResourceMetadata(url));
+    if (request.method === "GET" && (url2.pathname === MCP_PROTECTED_RESOURCE_METADATA_PATH || url2.pathname === MCP_PROTECTED_RESOURCE_METADATA_MIRROR_PATH)) {
+      return json(200, buildMcpProtectedResourceMetadata(url2));
     }
-    if ((request.method === "POST" || request.method === "GET") && url.pathname === MCP_PATH) {
+    if ((request.method === "POST" || request.method === "GET") && url2.pathname === MCP_PATH) {
       const auth = authorizeGatewayRequest({ request, env, apiSuffix: MCP_PATH });
       if (!auth.ok) {
-        const headers = auth.status === 401 ? buildMcpUnauthorizedHeaders(url, auth.headers ?? {}) : auth.headers ?? {};
+        const headers = auth.status === 401 ? buildMcpUnauthorizedHeaders(url2, auth.headers ?? {}) : auth.headers ?? {};
         return json(auth.status, {
           ok: false,
           error: "unauthorized",
           reason: auth.reason
         }, headers);
       }
-      return handleMcpRequest({ request, env, url });
+      return handleMcpRequest({ request, env, url: url2 });
     }
-    if (request.method === "GET" && isApiPath(url.pathname, "/approval/passkey/operator")) {
+    if (request.method === "GET" && isApiPath(url2.pathname, "/approval/passkey/operator")) {
       await purgeExpiredPasskeyArtifacts(resolveMemoryProvider(env));
       return handlePasskeyOperatorPageRequest(request, env);
     }
-    if (request.method === "POST" && isApiPath(url.pathname, "/gateway")) {
+    if (request.method === "POST" && isApiPath(url2.pathname, "/gateway")) {
       const auth = authorizeGatewayRequest({ request, env, apiSuffix: "/gateway" });
       if (!auth.ok) {
         return json(auth.status, {
@@ -58307,7 +58308,7 @@ var runtime_default = {
       });
       return json(auditedGatewayOutcome.status, auditedGatewayOutcome.body);
     }
-    if (request.method === "POST" && isApiPath(url.pathname, "/action/execute")) {
+    if (request.method === "POST" && isApiPath(url2.pathname, "/action/execute")) {
       const auth = authorizeGatewayRequest({ request, env, apiSuffix: "/action/execute" });
       if (!auth.ok) {
         return json(auth.status, {
@@ -58362,7 +58363,7 @@ var runtime_default = {
         execution: dispatched.execution
       });
     }
-    if (request.method === "POST" && isApiPath(url.pathname, "/action/github")) {
+    if (request.method === "POST" && isApiPath(url2.pathname, "/action/github")) {
       const auth = authorizeGatewayRequest({ request, env, apiSuffix: "/action/github" });
       if (!auth.ok) {
         return json(auth.status, {
@@ -58373,7 +58374,7 @@ var runtime_default = {
       }
       return handleGitHubWritePlaneRequest(request, env);
     }
-    if (request.method === "POST" && isApiPath(url.pathname, "/action/memory-write")) {
+    if (request.method === "POST" && isApiPath(url2.pathname, "/action/memory-write")) {
       const auth = authorizeGatewayRequest({
         request,
         env,
@@ -58388,7 +58389,7 @@ var runtime_default = {
       }
       return handleMemoryWriteRequest(request, env);
     }
-    if (request.method === "POST" && isApiPath(url.pathname, "/action/github-authority")) {
+    if (request.method === "POST" && isApiPath(url2.pathname, "/action/github-authority")) {
       const auth = authorizePasskeyBrowserOrMachineRequest({
         request,
         env,
@@ -58403,7 +58404,7 @@ var runtime_default = {
       }
       return handleGitHubHighRiskPlaneRequest(request, env);
     }
-    if (request.method === "POST" && isApiPath(url.pathname, "/action/deploy")) {
+    if (request.method === "POST" && isApiPath(url2.pathname, "/action/deploy")) {
       const auth = authorizePasskeyBrowserOrMachineRequest({
         request,
         env,
@@ -58418,7 +58419,7 @@ var runtime_default = {
       }
       return handleDeployProductionRequest(request, env);
     }
-    if (request.method === "POST" && isApiPath(url.pathname, "/events/github-actions")) {
+    if (request.method === "POST" && isApiPath(url2.pathname, "/events/github-actions")) {
       const auth = authorizeGatewayRequest({
         request,
         env,
@@ -58433,7 +58434,7 @@ var runtime_default = {
       }
       return handleGitHubActionsEventRequest(request, env);
     }
-    if (request.method === "POST" && isApiPath(url.pathname, "/events/vps-runner")) {
+    if (request.method === "POST" && isApiPath(url2.pathname, "/events/vps-runner")) {
       const auth = authorizeGatewayRequest({
         request,
         env,
@@ -58448,7 +58449,7 @@ var runtime_default = {
       }
       return handleVpsRunnerEventRequest(request, env);
     }
-    if (request.method === "POST" && isApiPath(url.pathname, "/events/owner-action-required")) {
+    if (request.method === "POST" && isApiPath(url2.pathname, "/events/owner-action-required")) {
       const auth = authorizeGatewayRequest({
         request,
         env,
@@ -58463,7 +58464,7 @@ var runtime_default = {
       }
       return handleOwnerActionRequiredEventRequest(request, env);
     }
-    if (request.method === "POST" && isApiPath(url.pathname, "/vps/privileged-maintenance/proposals")) {
+    if (request.method === "POST" && isApiPath(url2.pathname, "/vps/privileged-maintenance/proposals")) {
       const auth = authorizeGatewayRequest({
         request,
         env,
@@ -58478,7 +58479,7 @@ var runtime_default = {
       }
       return handleVpsPrivilegedMaintenanceProposalRequest(request, env);
     }
-    if (request.method === "POST" && isApiPath(url.pathname, "/vps/privileged-maintenance/helper-requests")) {
+    if (request.method === "POST" && isApiPath(url2.pathname, "/vps/privileged-maintenance/helper-requests")) {
       const auth = authorizeGatewayRequest({
         request,
         env,
@@ -58493,7 +58494,7 @@ var runtime_default = {
       }
       return handleVpsPrivilegedMaintenanceHelperRequest(request, env);
     }
-    if (request.method === "POST" && isApiPath(url.pathname, "/vps/privileged-maintenance/helper-dry-runs")) {
+    if (request.method === "POST" && isApiPath(url2.pathname, "/vps/privileged-maintenance/helper-dry-runs")) {
       const auth = authorizeGatewayRequest({
         request,
         env,
@@ -58508,7 +58509,7 @@ var runtime_default = {
       }
       return handleVpsPrivilegedMaintenanceHelperDryRunRequest(request, env);
     }
-    if (request.method === "POST" && isApiPath(url.pathname, "/vps/privileged-maintenance/helper-executions")) {
+    if (request.method === "POST" && isApiPath(url2.pathname, "/vps/privileged-maintenance/helper-executions")) {
       const auth = authorizeGatewayRequest({
         request,
         env,
@@ -58523,7 +58524,7 @@ var runtime_default = {
       }
       return handleVpsPrivilegedMaintenanceHelperExecutionRequest(request, env);
     }
-    if (request.method === "POST" && isApiPath(url.pathname, "/vps/privileged-maintenance/helper-execution-queues")) {
+    if (request.method === "POST" && isApiPath(url2.pathname, "/vps/privileged-maintenance/helper-execution-queues")) {
       const auth = authorizeGatewayRequest({
         request,
         env,
@@ -58538,21 +58539,21 @@ var runtime_default = {
       }
       return handleVpsPrivilegedMaintenanceHelperExecutionQueueRequest(request, env);
     }
-    if (request.method === "GET" && isApiPath(url.pathname, "/retrieve/vps-maintenance-install-inventory")) {
+    if (request.method === "GET" && isApiPath(url2.pathname, "/retrieve/vps-maintenance-install-inventory")) {
       const auth = authorizeGatewayRequest({
         request,
         env,
         apiSuffix: "/retrieve/vps-maintenance-install-inventory"
       });
       if (!auth.ok) {
-        return retrieveErrorJson(url, auth.status, {
+        return retrieveErrorJson(url2, auth.status, {
           error: "unauthorized",
           reason: auth.reason
         });
       }
-      return handleRetrieveVpsMaintenanceInstallInventoryRequest(url);
+      return handleRetrieveVpsMaintenanceInstallInventoryRequest(url2);
     }
-    if (request.method === "POST" && isApiPath(url.pathname, "/action/github-actions-secret")) {
+    if (request.method === "POST" && isApiPath(url2.pathname, "/action/github-actions-secret")) {
       const auth = authorizePasskeyBrowserOrMachineRequest({
         request,
         env,
@@ -58567,7 +58568,7 @@ var runtime_default = {
       }
       return handleGitHubActionsSecretSyncRequest(request, env);
     }
-    if (request.method === "POST" && isApiPath(url.pathname, "/action/github-actions-variable")) {
+    if (request.method === "POST" && isApiPath(url2.pathname, "/action/github-actions-variable")) {
       const auth = authorizePasskeyBrowserOrMachineRequest({
         request,
         env,
@@ -58582,7 +58583,7 @@ var runtime_default = {
       }
       return handleGitHubActionsVariableSyncRequest(request, env);
     }
-    if (request.method === "POST" && isApiPath(url.pathname, "/action/github-actions-variable/proposals")) {
+    if (request.method === "POST" && isApiPath(url2.pathname, "/action/github-actions-variable/proposals")) {
       const auth = authorizeGatewayRequest({
         request,
         env,
@@ -58595,9 +58596,9 @@ var runtime_default = {
           reason: auth.reason
         });
       }
-      return handleGitHubActionsVariableSyncProposalRequest(request, url, env);
+      return handleGitHubActionsVariableSyncProposalRequest(request, url2, env);
     }
-    if (request.method === "POST" && isApiPath(url.pathname, "/action/repository-nickname")) {
+    if (request.method === "POST" && isApiPath(url2.pathname, "/action/repository-nickname")) {
       const auth = authorizeGatewayRequest({
         request,
         env,
@@ -58612,7 +58613,7 @@ var runtime_default = {
       }
       return handleRepositoryNicknameUpsertRequest(request, env);
     }
-    if (request.method === "POST" && isApiPath(url.pathname, "/action/repository-nickname/delete")) {
+    if (request.method === "POST" && isApiPath(url2.pathname, "/action/repository-nickname/delete")) {
       const auth = authorizeGatewayRequest({
         request,
         env,
@@ -58627,7 +58628,7 @@ var runtime_default = {
       }
       return handleRepositoryNicknameDeleteRequest(request, env);
     }
-    if (request.method === "GET" && isApiPath(url.pathname, "/action/progress")) {
+    if (request.method === "GET" && isApiPath(url2.pathname, "/action/progress")) {
       const auth = authorizeGatewayRequest({ request, env, apiSuffix: "/action/progress" });
       if (!auth.ok) {
         return json(auth.status, {
@@ -58637,11 +58638,11 @@ var runtime_default = {
         });
       }
       const progress = await retrieveRemoteCodexExecutionProgress({
-        executionId: url.searchParams.get("executionId"),
-        repository: url.searchParams.get("repository"),
-        issueNumber: url.searchParams.get("issueNumber"),
-        branch: url.searchParams.get("branch"),
-        executorTransport: url.searchParams.get("executorTransport"),
+        executionId: url2.searchParams.get("executionId"),
+        repository: url2.searchParams.get("repository"),
+        issueNumber: url2.searchParams.get("issueNumber"),
+        branch: url2.searchParams.get("branch"),
+        executorTransport: url2.searchParams.get("executorTransport"),
         env
       });
       if (!progress.ok) {
@@ -58656,7 +58657,7 @@ var runtime_default = {
         progress: progress.progress
       });
     }
-    if (request.method === "GET" && isApiPath(url.pathname, "/action/vps-runner-status")) {
+    if (request.method === "GET" && isApiPath(url2.pathname, "/action/vps-runner-status")) {
       const auth = authorizeGatewayRequest({
         request,
         env,
@@ -58670,10 +58671,10 @@ var runtime_default = {
         });
       }
       const status = await retrieveVpsRunnerHealthStatus({
-        executionId: url.searchParams.get("executionId"),
-        repository: url.searchParams.get("repository"),
-        issueNumber: url.searchParams.get("issueNumber"),
-        branch: url.searchParams.get("branch"),
+        executionId: url2.searchParams.get("executionId"),
+        repository: url2.searchParams.get("repository"),
+        issueNumber: url2.searchParams.get("issueNumber"),
+        branch: url2.searchParams.get("branch"),
         env
       });
       if (!status.ok) {
@@ -58689,7 +58690,7 @@ var runtime_default = {
         progress: status.progress
       });
     }
-    if (request.method === "POST" && isApiPath(url.pathname, "/action/vps-runner-cancel")) {
+    if (request.method === "POST" && isApiPath(url2.pathname, "/action/vps-runner-cancel")) {
       const auth = authorizeGatewayRequest({
         request,
         env,
@@ -58725,18 +58726,18 @@ var runtime_default = {
         cancellation: cancellation.cancellation
       });
     }
-    if (request.method === "GET" && isApiPath(url.pathname, "/retrieve/approval-grant")) {
+    if (request.method === "GET" && isApiPath(url2.pathname, "/retrieve/approval-grant")) {
       const auth = authorizeGatewayRequest({ request, env, apiSuffix: "/retrieve/approval-grant" });
       if (!auth.ok) {
-        return retrieveErrorJson(url, auth.status, {
+        return retrieveErrorJson(url2, auth.status, {
           ok: false,
           error: "unauthorized",
           reason: auth.reason
         });
       }
-      return handleRetrieveApprovalGrantRequest(url, env);
+      return handleRetrieveApprovalGrantRequest(url2, env);
     }
-    if (request.method === "POST" && isApiPath(url.pathname, "/approval/passkey/register/options")) {
+    if (request.method === "POST" && isApiPath(url2.pathname, "/approval/passkey/register/options")) {
       await purgeExpiredPasskeyArtifacts(resolveMemoryProvider(env));
       const auth = await authorizePasskeyRegistrationRequest({
         request,
@@ -58752,7 +58753,7 @@ var runtime_default = {
       }
       return handlePasskeyRegistrationOptionsRequest(request, env);
     }
-    if (request.method === "POST" && isApiPath(url.pathname, "/approval/passkey/register/verify")) {
+    if (request.method === "POST" && isApiPath(url2.pathname, "/approval/passkey/register/verify")) {
       await purgeExpiredPasskeyArtifacts(resolveMemoryProvider(env));
       const auth = await authorizePasskeyRegistrationRequest({
         request,
@@ -58768,7 +58769,7 @@ var runtime_default = {
       }
       return handlePasskeyRegistrationVerifyRequest(request, env);
     }
-    if (request.method === "POST" && isApiPath(url.pathname, "/approval/passkey/challenge")) {
+    if (request.method === "POST" && isApiPath(url2.pathname, "/approval/passkey/challenge")) {
       await purgeExpiredPasskeyArtifacts(resolveMemoryProvider(env));
       const auth = authorizePasskeyBrowserOrMachineRequest({
         request,
@@ -58784,7 +58785,7 @@ var runtime_default = {
       }
       return handlePasskeyApprovalOptionsRequest(request, env);
     }
-    if (request.method === "POST" && isApiPath(url.pathname, "/approval/passkey/verify")) {
+    if (request.method === "POST" && isApiPath(url2.pathname, "/approval/passkey/verify")) {
       await purgeExpiredPasskeyArtifacts(resolveMemoryProvider(env));
       const auth = authorizePasskeyBrowserOrMachineRequest({
         request,
@@ -58800,147 +58801,147 @@ var runtime_default = {
       }
       return handlePasskeyApprovalVerifyRequest(request, env);
     }
-    if (request.method === "GET" && isApiPath(url.pathname, "/retrieve/constitution")) {
+    if (request.method === "GET" && isApiPath(url2.pathname, "/retrieve/constitution")) {
       const auth = authorizeGatewayRequest({ request, env, apiSuffix: "/retrieve/constitution" });
       if (!auth.ok) {
-        return retrieveErrorJson(url, auth.status, {
+        return retrieveErrorJson(url2, auth.status, {
           ok: false,
           error: "unauthorized",
           reason: auth.reason
         });
       }
-      return handleRetrieveConstitutionRequest(url, env);
+      return handleRetrieveConstitutionRequest(url2, env);
     }
-    if (request.method === "GET" && isApiPath(url.pathname, "/retrieve/decisions")) {
+    if (request.method === "GET" && isApiPath(url2.pathname, "/retrieve/decisions")) {
       const auth = authorizeGatewayRequest({ request, env, apiSuffix: "/retrieve/decisions" });
       if (!auth.ok) {
-        return retrieveErrorJson(url, auth.status, {
+        return retrieveErrorJson(url2, auth.status, {
           ok: false,
           error: "unauthorized",
           reason: auth.reason
         });
       }
-      return handleRetrieveDecisionLogsRequest(url, env);
+      return handleRetrieveDecisionLogsRequest(url2, env);
     }
-    if (request.method === "GET" && isApiPath(url.pathname, "/retrieve/proposals")) {
+    if (request.method === "GET" && isApiPath(url2.pathname, "/retrieve/proposals")) {
       const auth = authorizeGatewayRequest({ request, env, apiSuffix: "/retrieve/proposals" });
       if (!auth.ok) {
-        return retrieveErrorJson(url, auth.status, {
+        return retrieveErrorJson(url2, auth.status, {
           ok: false,
           error: "unauthorized",
           reason: auth.reason
         });
       }
-      return handleRetrieveProposalLogsRequest(url, env);
+      return handleRetrieveProposalLogsRequest(url2, env);
     }
-    if (request.method === "GET" && isApiPath(url.pathname, "/retrieve/cross")) {
+    if (request.method === "GET" && isApiPath(url2.pathname, "/retrieve/cross")) {
       const auth = authorizeGatewayRequest({ request, env, apiSuffix: "/retrieve/cross" });
       if (!auth.ok) {
-        return retrieveErrorJson(url, auth.status, {
+        return retrieveErrorJson(url2, auth.status, {
           ok: false,
           error: "unauthorized",
           reason: auth.reason
         });
       }
-      return handleRetrieveCrossIssueRequest(url, env);
+      return handleRetrieveCrossIssueRequest(url2, env);
     }
-    if (request.method === "GET" && isApiPath(url.pathname, "/retrieve/operational-memory")) {
+    if (request.method === "GET" && isApiPath(url2.pathname, "/retrieve/operational-memory")) {
       const auth = authorizeGatewayRequest({
         request,
         env,
         apiSuffix: "/retrieve/operational-memory"
       });
       if (!auth.ok) {
-        return retrieveErrorJson(url, auth.status, {
+        return retrieveErrorJson(url2, auth.status, {
           ok: false,
           error: "unauthorized",
           reason: auth.reason
         });
       }
-      return handleRetrieveOperationalMemoryRequest(url, env);
+      return handleRetrieveOperationalMemoryRequest(url2, env);
     }
-    if (request.method === "GET" && isApiPath(url.pathname, "/retrieve/startup-preflight")) {
+    if (request.method === "GET" && isApiPath(url2.pathname, "/retrieve/startup-preflight")) {
       const auth = authorizeGatewayRequest({
         request,
         env,
         apiSuffix: "/retrieve/startup-preflight"
       });
       if (!auth.ok) {
-        return retrieveErrorJson(url, auth.status, {
+        return retrieveErrorJson(url2, auth.status, {
           ok: false,
           error: "unauthorized",
           reason: auth.reason
         });
       }
-      return handleRetrieveStartupPreflightRequest(url, env);
+      return handleRetrieveStartupPreflightRequest(url2, env);
     }
-    if (request.method === "GET" && isApiPath(url.pathname, "/retrieve/github")) {
+    if (request.method === "GET" && isApiPath(url2.pathname, "/retrieve/github")) {
       const auth = authorizeGatewayRequest({ request, env, apiSuffix: "/retrieve/github" });
       if (!auth.ok) {
-        return retrieveErrorJson(url, auth.status, {
+        return retrieveErrorJson(url2, auth.status, {
           ok: false,
           error: "unauthorized",
           reason: auth.reason
         });
       }
-      return handleRetrieveGitHubReadPlaneRequest(url, env);
+      return handleRetrieveGitHubReadPlaneRequest(url2, env);
     }
-    if (request.method === "GET" && isApiPath(url.pathname, "/retrieve/cloudflare-pages")) {
+    if (request.method === "GET" && isApiPath(url2.pathname, "/retrieve/cloudflare-pages")) {
       const auth = authorizeGatewayRequest({
         request,
         env,
         apiSuffix: "/retrieve/cloudflare-pages"
       });
       if (!auth.ok) {
-        return retrieveErrorJson(url, auth.status, {
+        return retrieveErrorJson(url2, auth.status, {
           ok: false,
           error: "unauthorized",
           reason: auth.reason
         });
       }
-      return handleRetrieveCloudflarePagesRequest(url);
+      return handleRetrieveCloudflarePagesRequest(url2);
     }
-    if (request.method === "GET" && isApiPath(url.pathname, "/retrieve/setup-artifact")) {
+    if (request.method === "GET" && isApiPath(url2.pathname, "/retrieve/setup-artifact")) {
       const auth = authorizeGatewayRequest({ request, env, apiSuffix: "/retrieve/setup-artifact" });
       if (!auth.ok) {
-        return retrieveErrorJson(url, auth.status, {
+        return retrieveErrorJson(url2, auth.status, {
           ok: false,
           error: "unauthorized",
           reason: auth.reason
         });
       }
-      return handleRetrieveCustomGptSetupArtifactRequest(url, env);
+      return handleRetrieveCustomGptSetupArtifactRequest(url2, env);
     }
-    if (request.method === "GET" && isApiPath(url.pathname, "/retrieve/self-parity")) {
+    if (request.method === "GET" && isApiPath(url2.pathname, "/retrieve/self-parity")) {
       const auth = authorizeGatewayRequest({ request, env, apiSuffix: "/retrieve/self-parity" });
       if (!auth.ok) {
-        return retrieveErrorJson(url, auth.status, {
+        return retrieveErrorJson(url2, auth.status, {
           ok: false,
           error: "unauthorized",
           reason: auth.reason
         });
       }
-      return handleRetrieveButlerSelfParityRequest(url, env);
+      return handleRetrieveButlerSelfParityRequest(url2, env);
     }
-    if (request.method === "GET" && isApiPath(url.pathname, "/retrieve/setup-diagnostics")) {
+    if (request.method === "GET" && isApiPath(url2.pathname, "/retrieve/setup-diagnostics")) {
       const auth = authorizeGatewayRequest({ request, env, apiSuffix: "/retrieve/setup-diagnostics" });
       if (!auth.ok) {
-        return retrieveErrorJson(url, auth.status, {
+        return retrieveErrorJson(url2, auth.status, {
           ok: false,
           error: "unauthorized",
           reason: auth.reason
         });
       }
-      return handleRetrieveCustomGptSetupDiagnosticsRequest(url, env);
+      return handleRetrieveCustomGptSetupDiagnosticsRequest(url2, env);
     }
-    if (request.method === "GET" && isApiPath(url.pathname, "/retrieve/repository-nicknames")) {
+    if (request.method === "GET" && isApiPath(url2.pathname, "/retrieve/repository-nicknames")) {
       const auth = authorizeGatewayRequest({
         request,
         env,
         apiSuffix: "/retrieve/repository-nicknames"
       });
       if (!auth.ok) {
-        return retrieveErrorJson(url, auth.status, {
+        return retrieveErrorJson(url2, auth.status, {
           ok: false,
           error: "unauthorized",
           reason: auth.reason
@@ -58954,17 +58955,17 @@ var runtime_default = {
     });
   }
 };
-async function handleRetrieveConstitutionRequest(url, env) {
+async function handleRetrieveConstitutionRequest(url2, env) {
   const provider = resolveMemoryProvider(env);
   const validation = validateMemoryProvider(provider);
   if (!validation.ok) {
-    return retrieveErrorJson(url, 503, {
+    return retrieveErrorJson(url2, 503, {
       ok: false,
       error: "memory_provider_unavailable",
       reason: "valid memory provider is required for constitution retrieval"
     });
   }
-  const limit = normalizeLimit7(url.searchParams.get("limit"), 5);
+  const limit = normalizeLimit7(url2.searchParams.get("limit"), 5);
   const records = await retrieveConstitution(provider, limit);
   return json(200, {
     ok: true,
@@ -58973,24 +58974,24 @@ async function handleRetrieveConstitutionRequest(url, env) {
     records
   });
 }
-async function handleRetrieveDecisionLogsRequest(url, env) {
+async function handleRetrieveDecisionLogsRequest(url2, env) {
   const provider = resolveMemoryProvider(env);
   const validation = validateMemoryProvider(provider);
   if (!validation.ok) {
-    return retrieveErrorJson(url, 503, {
+    return retrieveErrorJson(url2, 503, {
       ok: false,
       error: "memory_provider_unavailable",
       reason: "valid memory provider is required for decision log retrieval"
     });
   }
-  const limit = normalizeLimit7(url.searchParams.get("limit"), 5);
-  const relatedIssue = normalizeIssue6(url.searchParams.get("relatedIssue"));
+  const limit = normalizeLimit7(url2.searchParams.get("limit"), 5);
+  const relatedIssue = normalizeIssue6(url2.searchParams.get("relatedIssue"));
   const retrieved = await retrieveDecisionLogReferences(provider, {
     limit,
     relatedIssue
   });
   if (!retrieved.ok) {
-    return retrieveErrorJson(url, retrieved.status, {
+    return retrieveErrorJson(url2, retrieved.status, {
       ok: false,
       error: retrieved.error ?? "memory_read_failed",
       reason: retrieved.reason
@@ -59003,24 +59004,24 @@ async function handleRetrieveDecisionLogsRequest(url, env) {
     references: retrieved.references
   });
 }
-async function handleRetrieveProposalLogsRequest(url, env) {
+async function handleRetrieveProposalLogsRequest(url2, env) {
   const provider = resolveMemoryProvider(env);
   const validation = validateMemoryProvider(provider);
   if (!validation.ok) {
-    return retrieveErrorJson(url, 503, {
+    return retrieveErrorJson(url2, 503, {
       ok: false,
       error: "memory_provider_unavailable",
       reason: "valid memory provider is required for proposal log retrieval"
     });
   }
-  const limit = normalizeLimit7(url.searchParams.get("limit"), 5);
-  const relatedIssue = normalizeIssue6(url.searchParams.get("relatedIssue"));
+  const limit = normalizeLimit7(url2.searchParams.get("limit"), 5);
+  const relatedIssue = normalizeIssue6(url2.searchParams.get("relatedIssue"));
   const retrieved = await retrieveProposalLogReferences(provider, {
     limit,
     relatedIssue
   });
   if (!retrieved.ok) {
-    return retrieveErrorJson(url, retrieved.status, {
+    return retrieveErrorJson(url2, retrieved.status, {
       ok: false,
       error: retrieved.error ?? "memory_read_failed",
       reason: retrieved.reason
@@ -59033,16 +59034,16 @@ async function handleRetrieveProposalLogsRequest(url, env) {
     references: retrieved.references
   });
 }
-async function handleRetrieveCrossIssueRequest(url, env) {
+async function handleRetrieveCrossIssueRequest(url2, env) {
   const provider = resolveMemoryProvider(env);
-  const phase = normalize7(url.searchParams.get("phase")) || "execution";
-  const limit = normalizeLimit7(url.searchParams.get("limit"), 5);
-  const relatedIssue = normalizeIssue6(url.searchParams.get("relatedIssue"));
-  const issueNumber = normalizeIssue6(url.searchParams.get("issueNumber"));
-  const issueTitle = normalizeText32(url.searchParams.get("issueTitle"));
-  const issueUrl = normalizeText32(url.searchParams.get("issueUrl"));
-  const queryText = normalizeText32(url.searchParams.get("text")) || normalizeText32(url.searchParams.get("q"));
-  const semanticEnabled = parseBooleanQueryParam(url.searchParams.get("semantic"));
+  const phase = normalize7(url2.searchParams.get("phase")) || "execution";
+  const limit = normalizeLimit7(url2.searchParams.get("limit"), 5);
+  const relatedIssue = normalizeIssue6(url2.searchParams.get("relatedIssue"));
+  const issueNumber = normalizeIssue6(url2.searchParams.get("issueNumber"));
+  const issueTitle = normalizeText32(url2.searchParams.get("issueTitle"));
+  const issueUrl = normalizeText32(url2.searchParams.get("issueUrl"));
+  const queryText = normalizeText32(url2.searchParams.get("text")) || normalizeText32(url2.searchParams.get("q"));
+  const semanticEnabled = parseBooleanQueryParam(url2.searchParams.get("semantic"));
   const retrieved = await retrieveCrossIssueMemoryIndex(provider, {
     phase,
     limit,
@@ -59059,7 +59060,7 @@ async function handleRetrieveCrossIssueRequest(url, env) {
     } : null
   });
   if (!retrieved.ok) {
-    return retrieveErrorJson(url, retrieved.status ?? 503, {
+    return retrieveErrorJson(url2, retrieved.status ?? 503, {
       ok: false,
       error: retrieved.error ?? "memory_read_failed",
       reason: retrieved.reason
@@ -59076,13 +59077,13 @@ async function handleRetrieveCrossIssueRequest(url, env) {
     orderedReferences: retrieved.orderedReferences
   });
 }
-async function handleRetrieveOperationalMemoryRequest(url, env) {
+async function handleRetrieveOperationalMemoryRequest(url2, env) {
   const provider = resolveMemoryProvider(env);
-  const limit = normalizeLimit7(url.searchParams.get("limit"), 8);
-  const queryText = normalizeText32(url.searchParams.get("text")) || normalizeText32(url.searchParams.get("q"));
-  const recordId = normalizeText32(url.searchParams.get("recordId"));
-  const repository = normalizeText32(url.searchParams.get("repository"));
-  const runtimeTruth = buildRetrieveRuntimeTruth(url);
+  const limit = normalizeLimit7(url2.searchParams.get("limit"), 8);
+  const queryText = normalizeText32(url2.searchParams.get("text")) || normalizeText32(url2.searchParams.get("q"));
+  const recordId = normalizeText32(url2.searchParams.get("recordId"));
+  const repository = normalizeText32(url2.searchParams.get("repository"));
+  const runtimeTruth = buildRetrieveRuntimeTruth(url2);
   const retrieved = await retrieveOperationalMemory(provider, {
     text: queryText,
     recordId,
@@ -59091,7 +59092,7 @@ async function handleRetrieveOperationalMemoryRequest(url, env) {
     runtimeTruth
   });
   if (!retrieved.ok) {
-    return retrieveErrorJson(url, retrieved.status ?? 503, {
+    return retrieveErrorJson(url2, retrieved.status ?? 503, {
       ok: false,
       error: retrieved.error ?? "operational_memory_read_failed",
       reason: retrieved.reason
@@ -59110,21 +59111,21 @@ async function handleRetrieveOperationalMemoryRequest(url, env) {
     retrievalSignals: retrieved.retrievalSignals
   });
 }
-async function handleRetrieveStartupPreflightRequest(url, env) {
-  const repository = normalizeText32(url.searchParams.get("repository"));
+async function handleRetrieveStartupPreflightRequest(url2, env) {
+  const repository = normalizeText32(url2.searchParams.get("repository"));
   if (!repository) {
-    return retrieveErrorJson(url, 422, {
+    return retrieveErrorJson(url2, 422, {
       ok: false,
       error: "startup_preflight_request_invalid",
       reason: "repository is required",
       issues: ["repository is required"]
     });
   }
-  const ref = normalizeText32(url.searchParams.get("ref")) || "main";
-  const issueNumber = normalizeIssue6(url.searchParams.get("issueNumber"));
-  const phase = normalizeText32(url.searchParams.get("phase")) || "execution";
-  const currentSurface = normalizeText32(url.searchParams.get("currentSurface")) || "butler";
-  const queryText = normalizeText32(url.searchParams.get("text")) || [
+  const ref = normalizeText32(url2.searchParams.get("ref")) || "main";
+  const issueNumber = normalizeIssue6(url2.searchParams.get("issueNumber"));
+  const phase = normalizeText32(url2.searchParams.get("phase")) || "execution";
+  const currentSurface = normalizeText32(url2.searchParams.get("currentSurface")) || "butler";
+  const queryText = normalizeText32(url2.searchParams.get("text")) || [
     "VTDD startup preflight",
     "Butler-first",
     "iPhone iPad first",
@@ -59138,7 +59139,7 @@ async function handleRetrieveStartupPreflightRequest(url, env) {
     phase,
     currentSurface,
     queryText,
-    runtimeOrigin: url.origin,
+    runtimeOrigin: url2.origin,
     env
   });
   return json(200, {
@@ -59700,19 +59701,19 @@ function compactExcerpt(value, maxLength = 400) {
   }
   return `${text.slice(0, Math.max(0, maxLength - 3))}...`;
 }
-async function handleRetrieveApprovalGrantRequest(url, env) {
+async function handleRetrieveApprovalGrantRequest(url2, env) {
   const provider = resolveMemoryProvider(env);
   const validation = validateMemoryProvider(provider);
   if (!validation.ok) {
-    return retrieveErrorJson(url, 503, {
+    return retrieveErrorJson(url2, 503, {
       ok: false,
       error: "memory_provider_unavailable",
       reason: "valid memory provider is required for approval grant retrieval"
     });
   }
-  const approvalId = normalizeText32(url.searchParams.get("approvalId"));
+  const approvalId = normalizeText32(url2.searchParams.get("approvalId"));
   if (!approvalId) {
-    return retrieveErrorJson(url, 422, {
+    return retrieveErrorJson(url2, 422, {
       ok: false,
       error: "approval_id_required",
       reason: "approvalId query parameter is required"
@@ -59720,14 +59721,14 @@ async function handleRetrieveApprovalGrantRequest(url, env) {
   }
   const record2 = await findApprovalRecordById(provider, approvalId);
   if (!record2 || normalizeText32(record2?.content?.kind) !== "passkey_grant") {
-    return retrieveErrorJson(url, 404, {
+    return retrieveErrorJson(url2, 404, {
       ok: false,
       error: "approval_grant_not_found",
       reason: "matching passkey approval grant was not found"
     });
   }
   if (isExpiredPasskeyEphemeralRecord(record2)) {
-    return retrieveErrorJson(url, 410, {
+    return retrieveErrorJson(url2, 410, {
       ok: false,
       error: "approval_grant_expired",
       reason: "approval grant is expired. Worker origin \u3067\u518D\u627F\u8A8D\u3057\u3066\u3001\u65B0\u3057\u3044 approvalGrantId \u3092\u53D6\u5F97\u3057\u3066\u304F\u3060\u3055\u3044\u3002"
@@ -60125,22 +60126,22 @@ function normalizeRejectedReasons2(value) {
 function makeOperationalMemoryRecordId(record2) {
   return `mem_${crypto.randomUUID()}`;
 }
-async function handleRetrieveGitHubReadPlaneRequest(url, env) {
+async function handleRetrieveGitHubReadPlaneRequest(url2, env) {
   const retrieved = await retrieveGitHubReadPlane({
-    resource: url.searchParams.get("resource"),
-    repository: url.searchParams.get("repository"),
-    issueNumber: url.searchParams.get("issueNumber"),
-    pullNumber: url.searchParams.get("pullNumber"),
-    branch: url.searchParams.get("branch"),
-    ref: url.searchParams.get("ref"),
-    path: url.searchParams.get("path"),
-    runId: url.searchParams.get("runId"),
-    state: url.searchParams.get("state"),
-    limit: url.searchParams.get("limit"),
+    resource: url2.searchParams.get("resource"),
+    repository: url2.searchParams.get("repository"),
+    issueNumber: url2.searchParams.get("issueNumber"),
+    pullNumber: url2.searchParams.get("pullNumber"),
+    branch: url2.searchParams.get("branch"),
+    ref: url2.searchParams.get("ref"),
+    path: url2.searchParams.get("path"),
+    runId: url2.searchParams.get("runId"),
+    state: url2.searchParams.get("state"),
+    limit: url2.searchParams.get("limit"),
     env
   });
   if (!retrieved.ok) {
-    return retrieveErrorJson(url, retrieved.status ?? 503, {
+    return retrieveErrorJson(url2, retrieved.status ?? 503, {
       ok: false,
       error: retrieved.error ?? "github_read_failed",
       reason: retrieved.reason,
@@ -60152,15 +60153,15 @@ async function handleRetrieveGitHubReadPlaneRequest(url, env) {
     read: retrieved.read
   });
 }
-async function handleRetrieveCustomGptSetupArtifactRequest(url, env) {
+async function handleRetrieveCustomGptSetupArtifactRequest(url2, env) {
   const retrieved = await retrieveCustomGptSetupArtifact({
-    artifact: normalizeText32(url.searchParams.get("artifact")),
-    repository: normalizeText32(url.searchParams.get("repository")),
-    ref: normalizeText32(url.searchParams.get("ref")),
+    artifact: normalizeText32(url2.searchParams.get("artifact")),
+    repository: normalizeText32(url2.searchParams.get("repository")),
+    ref: normalizeText32(url2.searchParams.get("ref")),
     env
   });
   if (!retrieved.ok) {
-    return retrieveErrorJson(url, retrieved.status ?? 503, {
+    return retrieveErrorJson(url2, retrieved.status ?? 503, {
       ok: false,
       error: retrieved.error ?? "custom_gpt_setup_artifact_unavailable",
       reason: retrieved.reason,
@@ -60172,20 +60173,20 @@ async function handleRetrieveCustomGptSetupArtifactRequest(url, env) {
     artifact: retrieved.artifact
   });
 }
-function handleRetrieveCloudflarePagesRequest(url) {
-  return json(200, buildVtddCloudflarePageDirectory({ runtimeOrigin: url.origin }));
+function handleRetrieveCloudflarePagesRequest(url2) {
+  return json(200, buildVtddCloudflarePageDirectory({ runtimeOrigin: url2.origin }));
 }
-async function handleRetrieveButlerSelfParityRequest(url, env) {
+async function handleRetrieveButlerSelfParityRequest(url2, env) {
   const parity = await evaluateButlerSelfParity({
-    repository: normalizeText32(url.searchParams.get("repository")),
-    ref: normalizeText32(url.searchParams.get("ref")),
-    issueNumber: normalizeIssue6(url.searchParams.get("issueNumber")),
-    pullNumber: normalizeIssue6(url.searchParams.get("pullNumber")),
-    runtimeOrigin: url.origin,
+    repository: normalizeText32(url2.searchParams.get("repository")),
+    ref: normalizeText32(url2.searchParams.get("ref")),
+    issueNumber: normalizeIssue6(url2.searchParams.get("issueNumber")),
+    pullNumber: normalizeIssue6(url2.searchParams.get("pullNumber")),
+    runtimeOrigin: url2.origin,
     env
   });
   if (!parity.ok) {
-    return retrieveErrorJson(url, parity.status ?? 503, {
+    return retrieveErrorJson(url2, parity.status ?? 503, {
       ok: false,
       error: parity.error ?? "custom_gpt_self_parity_unavailable",
       reason: parity.reason
@@ -60196,17 +60197,17 @@ async function handleRetrieveButlerSelfParityRequest(url, env) {
     selfParity: parity.selfParity
   });
 }
-async function handleRetrieveCustomGptSetupDiagnosticsRequest(url, env) {
+async function handleRetrieveCustomGptSetupDiagnosticsRequest(url2, env) {
   const result = await evaluateCustomGptSetupDiagnostics({
-    repository: normalizeText32(url.searchParams.get("repository")),
-    ref: normalizeText32(url.searchParams.get("ref")),
-    issueNumber: normalizeIssue6(url.searchParams.get("issueNumber")),
-    runtimeOrigin: url.origin,
-    observedFailure: readObservedSetupFailureFromUrl(url),
+    repository: normalizeText32(url2.searchParams.get("repository")),
+    ref: normalizeText32(url2.searchParams.get("ref")),
+    issueNumber: normalizeIssue6(url2.searchParams.get("issueNumber")),
+    runtimeOrigin: url2.origin,
+    observedFailure: readObservedSetupFailureFromUrl(url2),
     env
   });
   if (!result.ok) {
-    return retrieveErrorJson(url, result.status ?? 503, {
+    return retrieveErrorJson(url2, result.status ?? 503, {
       ok: false,
       error: result.error ?? "custom_gpt_setup_diagnostics_unavailable",
       reason: result.reason
@@ -60217,16 +60218,16 @@ async function handleRetrieveCustomGptSetupDiagnosticsRequest(url, env) {
     diagnostics: result.diagnostics
   });
 }
-async function handleCustomGptSetupDiagnosticsPageRequest(url, env) {
-  const repository = normalizeText32(url.searchParams.get("repository")) || "marushu/vtdd-v2-p";
-  const ref = normalizeText32(url.searchParams.get("ref")) || "main";
-  const issueNumber = normalizeIssue6(url.searchParams.get("issueNumber"));
+async function handleCustomGptSetupDiagnosticsPageRequest(url2, env) {
+  const repository = normalizeText32(url2.searchParams.get("repository")) || "marushu/vtdd-v2-p";
+  const ref = normalizeText32(url2.searchParams.get("ref")) || "main";
+  const issueNumber = normalizeIssue6(url2.searchParams.get("issueNumber"));
   const result = await evaluateCustomGptSetupDiagnostics({
     repository,
     ref,
     issueNumber,
-    runtimeOrigin: url.origin,
-    observedFailure: readObservedSetupFailureFromUrl(url),
+    runtimeOrigin: url2.origin,
+    observedFailure: readObservedSetupFailureFromUrl(url2),
     env
   });
   return html(
@@ -60265,7 +60266,7 @@ async function handleRetrieveRepositoryNicknamesRequest(env) {
     aliasRegistry: retrieved.aliasRegistry
   });
 }
-async function handleMcpRequest({ request, env, url }) {
+async function handleMcpRequest({ request, env, url: url2 }) {
   if (request.method === "GET") {
     return json(
       405,
@@ -60274,7 +60275,7 @@ async function handleMcpRequest({ request, env, url }) {
         error: "mcp_post_required",
         reason: "VTDD MCP endpoint requires MCP JSON-RPC POST requests. This stateless read surface does not expose an SSE GET stream.",
         protectedResourceMetadataUrl: buildRuntimeUrl2(
-          url.origin,
+          url2.origin,
           MCP_PROTECTED_RESOURCE_METADATA_MIRROR_PATH
         )
       },
@@ -60284,7 +60285,7 @@ async function handleMcpRequest({ request, env, url }) {
       }
     );
   }
-  const server = createVtddMcpServer({ env, runtimeOrigin: url.origin });
+  const server = createVtddMcpServer({ env, runtimeOrigin: url2.origin });
   const transport = new WebStandardStreamableHTTPServerTransport({
     sessionIdGenerator: void 0,
     enableJsonResponse: true
@@ -60886,21 +60887,21 @@ async function responseToMcpToolResult(response) {
     value: body
   };
 }
-function buildMcpProtectedResourceMetadata(url) {
-  const resource = buildRuntimeUrl2(url.origin, MCP_PATH);
+function buildMcpProtectedResourceMetadata(url2) {
+  const resource = buildRuntimeUrl2(url2.origin, MCP_PATH);
   return {
     resource,
     resource_name: "VTDD MCP",
-    resource_documentation: buildRuntimeUrl2(url.origin, "/help#paths"),
+    resource_documentation: buildRuntimeUrl2(url2.origin, "/help#paths"),
     bearer_methods_supported: ["header"],
     scopes_supported: ["vtdd:mcp:read"]
   };
 }
-function buildMcpUnauthorizedHeaders(url, baseHeaders = {}) {
+function buildMcpUnauthorizedHeaders(url2, baseHeaders = {}) {
   return {
     ...baseHeaders,
     "www-authenticate": `Bearer realm="vtdd-mcp", resource_metadata="${buildRuntimeUrl2(
-      url.origin,
+      url2.origin,
       MCP_PROTECTED_RESOURCE_METADATA_MIRROR_PATH
     )}"`,
     "mcp-protocol-version": MCP_PROTOCOL_VERSION
@@ -60983,8 +60984,8 @@ function wantsActionVisibleGitHubWriteErrors(payload) {
   const responseMode = normalizeText32(payload?.responseMode);
   return responseMode === "action_visible";
 }
-function retrieveErrorJson(url, status, body = {}) {
-  if (!wantsActionVisibleRetrieveErrors(url)) {
+function retrieveErrorJson(url2, status, body = {}) {
+  if (!wantsActionVisibleRetrieveErrors(url2)) {
     return json(status, body);
   }
   return json(200, {
@@ -60994,14 +60995,14 @@ function retrieveErrorJson(url, status, body = {}) {
     reason: normalizeText32(body.reason) || null,
     issues: Array.isArray(body.issues) ? body.issues : [],
     diagnostics: {
-      route: normalizeText32(url?.pathname) || null,
+      route: normalizeText32(url2?.pathname) || null,
       responseMode: "action_visible",
       rootCause: "Custom GPT Action test screen can surface non-2xx retrieve responses as ClientResponseError; this envelope preserves error/reason/issues for debugging."
     }
   });
 }
-function wantsActionVisibleRetrieveErrors(url) {
-  const responseMode = normalizeText32(url?.searchParams?.get("responseMode"));
+function wantsActionVisibleRetrieveErrors(url2) {
+  const responseMode = normalizeText32(url2?.searchParams?.get("responseMode"));
   return responseMode === "action_visible";
 }
 function validateConsistentIssueScope({ payload, issueContext }) {
@@ -61342,12 +61343,12 @@ async function handleVpsPrivilegedMaintenanceProposalRequest(request, env) {
       reason: "valid memory provider is required for VPS maintenance approval proposals"
     });
   }
-  const url = new URL(request.url);
+  const url2 = new URL(request.url);
   const payload = await readJson(request);
   const result = await createVpsPrivilegedMaintenanceProposal({
     payload,
     provider,
-    origin: url.origin
+    origin: url2.origin
   });
   return json(result.status, result.body);
 }
@@ -61517,23 +61518,23 @@ function createVpsMaintenanceApprovalProposalRecord({ vpsProposalId, proposal, a
   });
 }
 function buildVpsMaintenanceApprovalOperatorUrl({ origin, approvalScope, vpsProposalId, dashboardThreadId, executionId }) {
-  const url = new URL("/v2/approval/passkey/operator", `${origin}/`);
-  url.searchParams.set("mode", "vps");
-  url.searchParams.set("vpsProposalId", vpsProposalId);
-  url.searchParams.set("repositoryInput", approvalScope.repositoryInput);
-  url.searchParams.set("issueNumber", approvalScope.relatedIssue);
-  url.searchParams.set("phase", approvalScope.phase || "execution");
-  url.searchParams.set("actionType", approvalScope.actionType);
-  url.searchParams.set("highRiskKind", approvalScope.highRiskKind);
+  const url2 = new URL("/v2/approval/passkey/operator", `${origin}/`);
+  url2.searchParams.set("mode", "vps");
+  url2.searchParams.set("vpsProposalId", vpsProposalId);
+  url2.searchParams.set("repositoryInput", approvalScope.repositoryInput);
+  url2.searchParams.set("issueNumber", approvalScope.relatedIssue);
+  url2.searchParams.set("phase", approvalScope.phase || "execution");
+  url2.searchParams.set("actionType", approvalScope.actionType);
+  url2.searchParams.set("highRiskKind", approvalScope.highRiskKind);
   const normalizedThreadId = normalizeDashboardThreadId(dashboardThreadId);
   if (normalizedThreadId) {
-    url.searchParams.set("dashboardThreadId", normalizedThreadId);
+    url2.searchParams.set("dashboardThreadId", normalizedThreadId);
   }
   const normalizedExecutionId = normalizeText32(executionId);
   if (normalizedExecutionId) {
-    url.searchParams.set("executionId", normalizedExecutionId);
+    url2.searchParams.set("executionId", normalizedExecutionId);
   }
-  return url.href;
+  return url2.href;
 }
 function normalizeVpsMaintenanceProposalExpiresAt(value, now = /* @__PURE__ */ new Date()) {
   const normalized = normalizeText32(value);
@@ -62040,25 +62041,25 @@ function normalizeGitHubLogin(value) {
   const login = normalizeText32(value);
   return /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/.test(login) ? login : "";
 }
-async function handleRetrieveVpsMaintenanceInstallInventoryRequest(url) {
+async function handleRetrieveVpsMaintenanceInstallInventoryRequest(url2) {
   const inventory = buildVpsPrivilegedMaintenanceInstallInventory({
-    host: url.searchParams.get("host"),
-    repository: url.searchParams.get("repository"),
-    helperPath: url.searchParams.get("helperPath"),
-    manifestPath: url.searchParams.get("manifestPath"),
-    sudoersPath: url.searchParams.get("sudoersPath"),
-    runnerUser: url.searchParams.get("runnerUser"),
-    helperInstalled: url.searchParams.get("helperInstalled"),
-    manifestInstalled: url.searchParams.get("manifestInstalled"),
-    sudoersInstalled: url.searchParams.get("sudoersInstalled"),
-    helperOwner: url.searchParams.get("helperOwner"),
-    manifestOwner: url.searchParams.get("manifestOwner"),
-    sudoersOwner: url.searchParams.get("sudoersOwner"),
-    sudoersAllowsAll: url.searchParams.get("sudoersAllowsAll"),
-    sudoersScopedHelperEntry: url.searchParams.get("sudoersScopedHelperEntry")
+    host: url2.searchParams.get("host"),
+    repository: url2.searchParams.get("repository"),
+    helperPath: url2.searchParams.get("helperPath"),
+    manifestPath: url2.searchParams.get("manifestPath"),
+    sudoersPath: url2.searchParams.get("sudoersPath"),
+    runnerUser: url2.searchParams.get("runnerUser"),
+    helperInstalled: url2.searchParams.get("helperInstalled"),
+    manifestInstalled: url2.searchParams.get("manifestInstalled"),
+    sudoersInstalled: url2.searchParams.get("sudoersInstalled"),
+    helperOwner: url2.searchParams.get("helperOwner"),
+    manifestOwner: url2.searchParams.get("manifestOwner"),
+    sudoersOwner: url2.searchParams.get("sudoersOwner"),
+    sudoersAllowsAll: url2.searchParams.get("sudoersAllowsAll"),
+    sudoersScopedHelperEntry: url2.searchParams.get("sudoersScopedHelperEntry")
   });
   if (!inventory.ok) {
-    return retrieveErrorJson(url, 422, {
+    return retrieveErrorJson(url2, 422, {
       error: "vps_maintenance_install_inventory_invalid",
       reason: "VPS maintenance install inventory query is invalid",
       issues: inventory.issues
@@ -62340,7 +62341,7 @@ async function handleMediaObjectRequest(request, env, mediaRoute) {
     }
   });
 }
-async function handleMediaSearchRequest(request, url, env) {
+async function handleMediaSearchRequest(request, url2, env) {
   const dashboardAuth = await authorizeDashboardRequest({
     request,
     env,
@@ -62361,7 +62362,7 @@ async function handleMediaSearchRequest(request, url, env) {
       reason: "D1 media metadata store is not configured"
     });
   }
-  const repository = normalizeCanonicalRepositoryInput(url.searchParams.get("repository"));
+  const repository = normalizeCanonicalRepositoryInput(url2.searchParams.get("repository"));
   if (!repository) {
     return json(422, {
       ok: false,
@@ -62371,9 +62372,9 @@ async function handleMediaSearchRequest(request, url, env) {
   }
   const records = await store.search({
     repository,
-    relatedIssue: url.searchParams.get("relatedIssue") || url.searchParams.get("issueNumber"),
-    relatedPr: url.searchParams.get("relatedPr") || url.searchParams.get("pullRequestNumber"),
-    limit: url.searchParams.get("limit")
+    relatedIssue: url2.searchParams.get("relatedIssue") || url2.searchParams.get("issueNumber"),
+    relatedPr: url2.searchParams.get("relatedPr") || url2.searchParams.get("pullRequestNumber"),
+    limit: url2.searchParams.get("limit")
   });
   return json(200, {
     ok: true,
@@ -62394,10 +62395,10 @@ async function handleMediaDeleteRequest(request, env, mediaRoute) {
       reason: dashboardAuth.reason
     });
   }
-  const url = new URL(request.url);
-  const cleanup = normalizeDashboardEventText(url.searchParams.get("cleanup"));
+  const url2 = new URL(request.url);
+  const cleanup = normalizeDashboardEventText(url2.searchParams.get("cleanup"));
   if (cleanup === "abandoned_send") {
-    return handleAbandonedMediaSendRollback({ env, mediaRoute, url });
+    return handleAbandonedMediaSendRollback({ env, mediaRoute, url: url2 });
   }
   return json(403, {
     ok: false,
@@ -62406,7 +62407,7 @@ async function handleMediaDeleteRequest(request, env, mediaRoute) {
     mediaId: mediaRoute.id
   });
 }
-async function handleAbandonedMediaSendRollback({ env, mediaRoute, url }) {
+async function handleAbandonedMediaSendRollback({ env, mediaRoute, url: url2 }) {
   const store = resolveMediaObjectStore(env);
   if (!store || typeof store.get !== "function" || typeof store.delete !== "function") {
     return json(503, {
@@ -62431,9 +62432,9 @@ async function handleAbandonedMediaSendRollback({ env, mediaRoute, url }) {
       reason: "media object was not found"
     });
   }
-  const repository = normalizeCanonicalRepositoryInput(url.searchParams.get("repository"));
-  const relatedIssue = normalizePositiveInteger10(url.searchParams.get("relatedIssue") || url.searchParams.get("issueNumber"));
-  const requestedSourceEventId = sanitizeDashboardChatText(url.searchParams.get("sourceEventId") || url.searchParams.get("source_event_id"));
+  const repository = normalizeCanonicalRepositoryInput(url2.searchParams.get("repository"));
+  const relatedIssue = normalizePositiveInteger10(url2.searchParams.get("relatedIssue") || url2.searchParams.get("issueNumber"));
+  const requestedSourceEventId = sanitizeDashboardChatText(url2.searchParams.get("sourceEventId") || url2.searchParams.get("source_event_id"));
   const sourceEventId = normalizeDashboardEventText(record2.sourceEventId);
   const repositoryScopeMatches = record2.repository ? Boolean(repository) && record2.repository === repository : !repository;
   const isRollbackScoped = record2.visibility === "private" && record2.sourceSurface === "dashboard_butler" && sourceEventId.startsWith("dashboard_owner_message:") && requestedSourceEventId === sourceEventId && repositoryScopeMatches && (!relatedIssue || record2.relatedIssue === relatedIssue);
@@ -62719,7 +62720,7 @@ function isSupportedDashboardPushAckSourceEventId(value) {
   const text = normalizeText32(value);
   return text.startsWith("github-actions:") || text.startsWith("vps-runner:") || text.startsWith("ai-news:") || text.startsWith("owner-action-required:") || text.startsWith("dashboard-push-test:");
 }
-async function handleDashboardChatSocketRequest(request, url, env) {
+async function handleDashboardChatSocketRequest(request, url2, env) {
   const auth = await authorizeDashboardRequest({
     request,
     env,
@@ -62732,7 +62733,7 @@ async function handleDashboardChatSocketRequest(request, url, env) {
       reason: auth.reason
     });
   }
-  const threadId = extractDashboardChatSocketThreadId(url.pathname);
+  const threadId = extractDashboardChatSocketThreadId(url2.pathname);
   if (!threadId) {
     return json(422, {
       ok: false,
@@ -62757,7 +62758,7 @@ async function handleDashboardChatSocketRequest(request, url, env) {
   }
   return room.fetch(request);
 }
-async function handleDashboardAppServerBridgeSocketRequest(request, url, env) {
+async function handleDashboardAppServerBridgeSocketRequest(request, url2, env) {
   const auth = authorizeDashboardAppServerBridgeRequest({
     request,
     env,
@@ -62770,7 +62771,7 @@ async function handleDashboardAppServerBridgeSocketRequest(request, url, env) {
       reason: auth.reason
     });
   }
-  const threadId = normalizeDashboardThreadId(url.searchParams.get("threadId") || url.searchParams.get("thread_id"));
+  const threadId = normalizeDashboardThreadId(url2.searchParams.get("threadId") || url2.searchParams.get("thread_id"));
   const room = resolveDashboardChatRoomStub(env, threadId || "dashboard-app-server-bridge");
   if (!room) {
     return json(503, {
@@ -62804,7 +62805,7 @@ function authorizeDashboardAppServerBridgeRequest({ request, env, apiSuffix }) {
   }
   return direct;
 }
-async function handleDashboardChatThreadRequest(request, url, env) {
+async function handleDashboardChatThreadRequest(request, url2, env) {
   const auth = await authorizeDashboardRequest({
     request,
     env,
@@ -62817,7 +62818,7 @@ async function handleDashboardChatThreadRequest(request, url, env) {
       reason: auth.reason
     });
   }
-  const threadId = extractDashboardChatThreadId(url.pathname);
+  const threadId = extractDashboardChatThreadId(url2.pathname);
   if (!threadId) {
     return json(422, {
       ok: false,
@@ -62834,7 +62835,7 @@ async function handleDashboardChatThreadRequest(request, url, env) {
     });
   }
   const messages = await store.listThread(threadId, {
-    limit: normalizeLimit7(url.searchParams.get("limit"), 80)
+    limit: normalizeLimit7(url2.searchParams.get("limit"), 80)
   });
   const summary = typeof store.getSummary === "function" ? await store.getSummary(threadId) : null;
   return json(200, {
@@ -62844,7 +62845,7 @@ async function handleDashboardChatThreadRequest(request, url, env) {
     summary
   });
 }
-async function handleDashboardChatSearchRequest(request, url, env) {
+async function handleDashboardChatSearchRequest(request, url2, env) {
   const auth = await authorizeDashboardRequest({
     request,
     env,
@@ -62866,17 +62867,17 @@ async function handleDashboardChatSearchRequest(request, url, env) {
     });
   }
   const results = await store.search({
-    text: url.searchParams.get("text") || url.searchParams.get("q"),
-    repository: url.searchParams.get("repository"),
-    relatedIssue: url.searchParams.get("relatedIssue") || url.searchParams.get("issueNumber"),
-    limit: normalizeLimit7(url.searchParams.get("limit"), 20)
+    text: url2.searchParams.get("text") || url2.searchParams.get("q"),
+    repository: url2.searchParams.get("repository"),
+    relatedIssue: url2.searchParams.get("relatedIssue") || url2.searchParams.get("issueNumber"),
+    limit: normalizeLimit7(url2.searchParams.get("limit"), 20)
   });
   return json(200, {
     ok: true,
     results
   });
 }
-async function handleDashboardChatSummaryRequest(request, url, env) {
+async function handleDashboardChatSummaryRequest(request, url2, env) {
   const auth = await authorizeDashboardRequest({
     request,
     env,
@@ -62889,7 +62890,7 @@ async function handleDashboardChatSummaryRequest(request, url, env) {
       reason: auth.reason
     });
   }
-  const threadId = extractDashboardChatSummaryThreadId(url.pathname);
+  const threadId = extractDashboardChatSummaryThreadId(url2.pathname);
   if (!threadId) {
     return json(422, {
       ok: false,
@@ -63075,7 +63076,7 @@ async function handleGitHubActionsVariableSyncRequest(request, env) {
     }
   });
 }
-async function handleGitHubActionsVariableSyncProposalRequest(request, url, env) {
+async function handleGitHubActionsVariableSyncProposalRequest(request, url2, env) {
   const provider = resolveMemoryProvider(env);
   const validation = validateMemoryProvider(provider);
   if (!validation.ok) {
@@ -63088,7 +63089,7 @@ async function handleGitHubActionsVariableSyncProposalRequest(request, url, env)
   const payload = await readJson(request);
   const proposal = buildGitHubActionsVariableSyncProposal({
     payload,
-    origin: url.origin
+    origin: url2.origin
   });
   if (!proposal.ok) {
     return json(422, {
@@ -63194,17 +63195,17 @@ function createGitHubActionsVariableSyncProposalRecord(proposal) {
   }).record;
 }
 function buildGitHubActionsVariableSyncApprovalOperatorUrl({ origin, approvalScope, variableProposalId }) {
-  const url = new URL("/v2/approval/passkey/operator", `${origin || "https://example.com"}/`);
-  url.searchParams.set("mode", "github_actions_variable_sync");
-  url.searchParams.set("variableProposalId", variableProposalId);
-  url.searchParams.set("repositoryInput", approvalScope.repositoryInput);
+  const url2 = new URL("/v2/approval/passkey/operator", `${origin || "https://example.com"}/`);
+  url2.searchParams.set("mode", "github_actions_variable_sync");
+  url2.searchParams.set("variableProposalId", variableProposalId);
+  url2.searchParams.set("repositoryInput", approvalScope.repositoryInput);
   if (approvalScope.relatedIssue) {
-    url.searchParams.set("issueNumber", approvalScope.relatedIssue);
+    url2.searchParams.set("issueNumber", approvalScope.relatedIssue);
   }
-  url.searchParams.set("phase", approvalScope.phase || "execution");
-  url.searchParams.set("actionType", approvalScope.actionType);
-  url.searchParams.set("highRiskKind", approvalScope.highRiskKind);
-  return url.href;
+  url2.searchParams.set("phase", approvalScope.phase || "execution");
+  url2.searchParams.set("actionType", approvalScope.actionType);
+  url2.searchParams.set("highRiskKind", approvalScope.highRiskKind);
+  return url2.href;
 }
 async function resolveGitHubActionsVariableSyncProposal({ provider, proposalId }) {
   const id = normalizeText32(proposalId);
@@ -63296,21 +63297,21 @@ async function recordGitHubActionsVariableSyncNotification({ ownerAction, env } 
     pwaNotificationDelivered: eventWithNotificationTruth.pwaNotificationDelivered
   };
 }
-async function handleCustomGptRecoveryPageRequest(url, env) {
-  const channel = url.pathname === "/setup/known-good" ? CustomGptSetupChannel.KNOWN_GOOD : CustomGptSetupChannel.LATEST;
-  const ref = normalizeText32(url.searchParams.get("ref")) || "main";
-  const issueNumber = normalizeIssue6(url.searchParams.get("issueNumber"));
+async function handleCustomGptRecoveryPageRequest(url2, env) {
+  const channel = url2.pathname === "/setup/known-good" ? CustomGptSetupChannel.KNOWN_GOOD : CustomGptSetupChannel.LATEST;
+  const ref = normalizeText32(url2.searchParams.get("ref")) || "main";
+  const issueNumber = normalizeIssue6(url2.searchParams.get("issueNumber"));
   const bundle = await buildCustomGptRecoveryBundle({
     channel,
     ref,
     issueNumber,
-    runtimeOrigin: url.origin,
+    runtimeOrigin: url2.origin,
     env
   });
   return html(
     200,
     renderCustomGptRecoveryPage({
-      runtimeOrigin: url.origin,
+      runtimeOrigin: url2.origin,
       channel,
       ref,
       issueNumber,
@@ -63324,49 +63325,49 @@ async function handleCustomGptRecoveryPageRequest(url, env) {
   );
 }
 async function handlePasskeyOperatorPageRequest(request, env) {
-  const url = new URL(request.url);
-  const syncApiBase = normalizeOptionalHttpUrl(url.searchParams.get("syncApiBase"));
+  const url2 = new URL(request.url);
+  const syncApiBase = normalizeOptionalHttpUrl(url2.searchParams.get("syncApiBase"));
   const syncEnabled = Boolean(syncApiBase);
-  const requestedActionType = url.searchParams.get("actionType");
-  const requestedHighRiskKind = url.searchParams.get("highRiskKind");
-  const requestedOperatorMode = url.searchParams.get("mode") || (requestedActionType || requestedHighRiskKind ? "" : "full");
+  const requestedActionType = url2.searchParams.get("actionType");
+  const requestedHighRiskKind = url2.searchParams.get("highRiskKind");
+  const requestedOperatorMode = url2.searchParams.get("mode") || (requestedActionType || requestedHighRiskKind ? "" : "full");
   const dashboardSessionMode = normalizeText32(requestedOperatorMode) === "dashboard";
   const vpsProposal = await retrieveVpsMaintenanceApprovalProposalForOperator({
     provider: resolveMemoryProvider(env),
-    proposalId: url.searchParams.get("vpsProposalId")
+    proposalId: url2.searchParams.get("vpsProposalId")
   });
   const githubActionsVariableProposal = await retrieveGitHubActionsVariableSyncProposalForOperator({
     provider: resolveMemoryProvider(env),
-    proposalId: url.searchParams.get("variableProposalId")
+    proposalId: url2.searchParams.get("variableProposalId")
   });
   const vpsScope = vpsProposal?.content?.approvalScope ?? {};
   const githubActionsVariableScope = githubActionsVariableProposal?.content?.approvalScope ?? {};
   const html2 = renderPasskeyOperatorPage({
-    origin: url.origin,
+    origin: url2.origin,
     syncApiBase,
     operatorMode: requestedOperatorMode,
-    repositoryInput: dashboardSessionMode ? "" : url.searchParams.get("repositoryInput"),
-    issueNumber: dashboardSessionMode ? "" : url.searchParams.get("issueNumber"),
-    pullNumber: dashboardSessionMode ? "" : url.searchParams.get("pullNumber"),
-    phase: url.searchParams.get("phase") || "execution",
+    repositoryInput: dashboardSessionMode ? "" : url2.searchParams.get("repositoryInput"),
+    issueNumber: dashboardSessionMode ? "" : url2.searchParams.get("issueNumber"),
+    pullNumber: dashboardSessionMode ? "" : url2.searchParams.get("pullNumber"),
+    phase: url2.searchParams.get("phase") || "execution",
     actionType: requestedActionType,
     highRiskKind: requestedHighRiskKind,
-    mergeMethod: url.searchParams.get("mergeMethod") || "squash",
-    vpsProposalId: url.searchParams.get("vpsProposalId"),
+    mergeMethod: url2.searchParams.get("mergeMethod") || "squash",
+    vpsProposalId: url2.searchParams.get("vpsProposalId"),
     vpsHost: vpsScope.vpsHost || vpsScope.display?.host || "",
     vpsOperation: vpsScope.vpsOperation || vpsScope.display?.operation || "",
     vpsCapabilityId: vpsScope.vpsCapabilityId || vpsScope.display?.capabilityId || "",
     vpsImpactScope: vpsScope.vpsImpactScope || vpsScope.display?.impactScope || "",
     vpsExpiresAt: vpsScope.vpsExpiresAt || vpsScope.display?.expiresAt || "",
-    vpsDashboardThreadId: url.searchParams.get("dashboardThreadId") || url.searchParams.get("threadId"),
-    vpsExecutionId: url.searchParams.get("executionId"),
-    githubActionsVariableProposalId: url.searchParams.get("variableProposalId"),
+    vpsDashboardThreadId: url2.searchParams.get("dashboardThreadId") || url2.searchParams.get("threadId"),
+    vpsExecutionId: url2.searchParams.get("executionId"),
+    githubActionsVariableProposalId: url2.searchParams.get("variableProposalId"),
     githubActionsVariableProposalName: githubActionsVariableScope.variableName || githubActionsVariableProposal?.content?.variableName || "",
-    returnUrl: normalizeOperatorReturnUrl(url.searchParams.get("returnUrl")),
-    dashboardReturnPath: sanitizeDashboardPreAuthReturnPath(url.searchParams.get("dashboardReturnPath")),
-    operatorId: url.searchParams.get("operatorId") || "vtdd-operator",
-    operatorLabel: url.searchParams.get("operatorLabel") || "VTDD Operator",
-    githubAppRole: url.searchParams.get("githubAppRole") || "legacy",
+    returnUrl: normalizeOperatorReturnUrl(url2.searchParams.get("returnUrl")),
+    dashboardReturnPath: sanitizeDashboardPreAuthReturnPath(url2.searchParams.get("dashboardReturnPath")),
+    operatorId: url2.searchParams.get("operatorId") || "vtdd-operator",
+    operatorLabel: url2.searchParams.get("operatorLabel") || "VTDD Operator",
+    githubAppRole: url2.searchParams.get("githubAppRole") || "legacy",
     syncEnabled,
     syncMessage: syncEnabled ? "approvalGrantId \u304C\u53D6\u5F97\u6E08\u307F\u306A\u3089\u5B9F\u884C\u3067\u304D\u307E\u3059\u3002desktop helper bridge \u306B\u63A5\u7D9A\u3057\u307E\u3059\u3002" : "desktop maintenance required: local secret sync bridge \u304C\u672A\u63A5\u7D9A\u3067\u3059\u3002"
   });
@@ -63399,11 +63400,11 @@ function normalizeOptionalHttpUrl(value) {
     return "";
   }
   try {
-    const url = new URL(text);
-    if (url.protocol !== "http:" && url.protocol !== "https:") {
+    const url2 = new URL(text);
+    if (url2.protocol !== "http:" && url2.protocol !== "https:") {
       return "";
     }
-    return url.href.replace(/\/$/, "");
+    return url2.href.replace(/\/$/, "");
   } catch {
     return "";
   }
@@ -63414,15 +63415,15 @@ function normalizeOperatorReturnUrl(value) {
     return "";
   }
   try {
-    const url = new URL(text);
-    if (url.protocol !== "https:") {
+    const url2 = new URL(text);
+    if (url2.protocol !== "https:") {
       return "";
     }
-    const hostname = url.hostname.toLowerCase();
+    const hostname = url2.hostname.toLowerCase();
     if (hostname !== "chatgpt.com" && hostname !== "chat.openai.com") {
       return "";
     }
-    return url.href;
+    return url2.href;
   } catch {
     return "";
   }
@@ -64759,10 +64760,10 @@ function parseBooleanQueryParam(value) {
   const normalized = normalize7(value);
   return normalized === "true" || normalized === "1" || normalized === "yes";
 }
-function buildRetrieveRuntimeTruth(url) {
-  const currentState = normalizeText32(url.searchParams.get("currentState"));
-  const source = normalizeText32(url.searchParams.get("runtimeTruthSource"));
-  const checkedAt = normalizeText32(url.searchParams.get("checkedAt"));
+function buildRetrieveRuntimeTruth(url2) {
+  const currentState = normalizeText32(url2.searchParams.get("currentState"));
+  const source = normalizeText32(url2.searchParams.get("runtimeTruthSource"));
+  const checkedAt = normalizeText32(url2.searchParams.get("checkedAt"));
   if (!currentState && !source && !checkedAt) {
     return null;
   }
@@ -68163,14 +68164,14 @@ function normalizeIssue6(value) {
   }
   return numeric;
 }
-function readObservedSetupFailureFromUrl(url) {
+function readObservedSetupFailureFromUrl(url2) {
   return {
-    actionName: normalizeText32(url.searchParams.get("actionName")),
-    httpStatus: normalizeIssue6(url.searchParams.get("httpStatus")),
-    error: normalizeText32(url.searchParams.get("error")),
-    reason: normalizeText32(url.searchParams.get("reason")),
-    visibleBodyFields: normalizeText32(url.searchParams.get("visibleBodyFields")),
-    missingBodyFields: normalizeText32(url.searchParams.get("missingBodyFields"))
+    actionName: normalizeText32(url2.searchParams.get("actionName")),
+    httpStatus: normalizeIssue6(url2.searchParams.get("httpStatus")),
+    error: normalizeText32(url2.searchParams.get("error")),
+    reason: normalizeText32(url2.searchParams.get("reason")),
+    visibleBodyFields: normalizeText32(url2.searchParams.get("visibleBodyFields")),
+    missingBodyFields: normalizeText32(url2.searchParams.get("missingBodyFields"))
   };
 }
 function normalizeObject12(value) {
@@ -68523,11 +68524,11 @@ function normalizeDashboardUrl(value) {
     return "";
   }
   try {
-    const url = new URL(text);
-    if (url.protocol !== "https:" && url.protocol !== "http:") {
+    const url2 = new URL(text);
+    if (url2.protocol !== "https:" && url2.protocol !== "http:") {
       return "";
     }
-    return url.toString();
+    return url2.toString();
   } catch {
     return "";
   }
@@ -68817,9 +68818,9 @@ function formatDashboardRelativeTime(value, now = /* @__PURE__ */ new Date()) {
   }
   return `${Math.floor(months / 12)}\u5E74\u524D`;
 }
-async function renderDashboardGitHubTruthPage({ url, env } = {}) {
-  const origin = normalize7(url?.origin);
-  const repository = normalizeCanonicalRepositoryInput(url?.searchParams?.get("repository")) || "marushu/vtdd-v2-p";
+async function renderDashboardGitHubTruthPage({ url: url2, env } = {}) {
+  const origin = normalize7(url2?.origin);
+  const repository = normalizeCanonicalRepositoryInput(url2?.searchParams?.get("repository")) || "marushu/vtdd-v2-p";
   const [issues, pulls, workflowRuns] = await Promise.all([
     retrieveGitHubReadPlane({
       resource: "issues",
@@ -68860,15 +68861,15 @@ async function renderDashboardGitHubTruthPage({ url, env } = {}) {
     `
   });
 }
-async function renderDashboardPreflightPage({ url, env } = {}) {
-  const origin = normalize7(url?.origin);
-  const repository = normalizeCanonicalRepositoryInput(url?.searchParams?.get("repository")) || "marushu/vtdd-v2-p";
-  const issueNumber = normalizeIssue6(url?.searchParams?.get("issueNumber"));
-  const phase = normalizeText32(url?.searchParams?.get("phase")) || "execution";
-  const currentSurface = normalizeText32(url?.searchParams?.get("currentSurface")) || "dashboard";
+async function renderDashboardPreflightPage({ url: url2, env } = {}) {
+  const origin = normalize7(url2?.origin);
+  const repository = normalizeCanonicalRepositoryInput(url2?.searchParams?.get("repository")) || "marushu/vtdd-v2-p";
+  const issueNumber = normalizeIssue6(url2?.searchParams?.get("issueNumber"));
+  const phase = normalizeText32(url2?.searchParams?.get("phase")) || "execution";
+  const currentSurface = normalizeText32(url2?.searchParams?.get("currentSurface")) || "dashboard";
   const startupPreflight = await buildStartupPreflight({
     repository,
-    ref: normalizeText32(url?.searchParams?.get("ref")) || "main",
+    ref: normalizeText32(url2?.searchParams?.get("ref")) || "main",
     issueNumber,
     phase,
     currentSurface,
@@ -68901,15 +68902,15 @@ async function renderDashboardPreflightPage({ url, env } = {}) {
     `
   });
 }
-async function renderDashboardProgressPage({ url, env } = {}) {
-  const origin = normalize7(url?.origin);
-  const repository = normalizeCanonicalRepositoryInput(url?.searchParams?.get("repository")) || "marushu/vtdd-v2-p";
+async function renderDashboardProgressPage({ url: url2, env } = {}) {
+  const origin = normalize7(url2?.origin);
+  const repository = normalizeCanonicalRepositoryInput(url2?.searchParams?.get("repository")) || "marushu/vtdd-v2-p";
   const progress = await retrieveRemoteCodexExecutionProgress({
-    executionId: url.searchParams.get("executionId"),
+    executionId: url2.searchParams.get("executionId"),
     repository,
-    issueNumber: url.searchParams.get("issueNumber"),
-    branch: url.searchParams.get("branch"),
-    executorTransport: url.searchParams.get("executorTransport"),
+    issueNumber: url2.searchParams.get("issueNumber"),
+    branch: url2.searchParams.get("branch"),
+    executorTransport: url2.searchParams.get("executorTransport"),
     env
   });
   return renderDashboardUtilityPage({
@@ -68924,14 +68925,14 @@ async function renderDashboardProgressPage({ url, env } = {}) {
     `
   });
 }
-async function renderDashboardVpsRunnerPage({ url, env } = {}) {
-  const origin = normalize7(url?.origin);
-  const repository = normalizeCanonicalRepositoryInput(url?.searchParams?.get("repository")) || "marushu/vtdd-v2-p";
+async function renderDashboardVpsRunnerPage({ url: url2, env } = {}) {
+  const origin = normalize7(url2?.origin);
+  const repository = normalizeCanonicalRepositoryInput(url2?.searchParams?.get("repository")) || "marushu/vtdd-v2-p";
   const status = await retrieveVpsRunnerHealthStatus({
-    executionId: url.searchParams.get("executionId"),
+    executionId: url2.searchParams.get("executionId"),
     repository,
-    issueNumber: url.searchParams.get("issueNumber"),
-    branch: url.searchParams.get("branch"),
+    issueNumber: url2.searchParams.get("issueNumber"),
+    branch: url2.searchParams.get("branch"),
     env
   });
   return renderDashboardUtilityPage({
@@ -68946,15 +68947,15 @@ async function renderDashboardVpsRunnerPage({ url, env } = {}) {
     `
   });
 }
-async function renderDashboardMemoryPage({ url, env } = {}) {
-  const origin = normalize7(url?.origin);
-  const repository = normalizeCanonicalRepositoryInput(url?.searchParams?.get("repository")) || "marushu/vtdd-v2-p";
+async function renderDashboardMemoryPage({ url: url2, env } = {}) {
+  const origin = normalize7(url2?.origin);
+  const repository = normalizeCanonicalRepositoryInput(url2?.searchParams?.get("repository")) || "marushu/vtdd-v2-p";
   const retrieved = await retrieveOperationalMemory(resolveMemoryProvider(env), {
-    text: normalizeText32(url.searchParams.get("text")) || normalizeText32(url.searchParams.get("q")),
-    recordId: normalizeText32(url.searchParams.get("recordId")),
+    text: normalizeText32(url2.searchParams.get("text")) || normalizeText32(url2.searchParams.get("q")),
+    recordId: normalizeText32(url2.searchParams.get("recordId")),
     repository,
-    limit: normalizeLimit7(url.searchParams.get("limit"), 8),
-    runtimeTruth: buildRetrieveRuntimeTruth(url)
+    limit: normalizeLimit7(url2.searchParams.get("limit"), 8),
+    runtimeTruth: buildRetrieveRuntimeTruth(url2)
   });
   return renderDashboardUtilityPage({
     title: "Operational RAG",
@@ -68968,14 +68969,14 @@ async function renderDashboardMemoryPage({ url, env } = {}) {
     `
   });
 }
-async function renderDashboardSelfParityPage({ url, env } = {}) {
-  const origin = normalize7(url?.origin);
-  const repository = normalizeCanonicalRepositoryInput(url?.searchParams?.get("repository")) || "marushu/vtdd-v2-p";
+async function renderDashboardSelfParityPage({ url: url2, env } = {}) {
+  const origin = normalize7(url2?.origin);
+  const repository = normalizeCanonicalRepositoryInput(url2?.searchParams?.get("repository")) || "marushu/vtdd-v2-p";
   const parity = await evaluateButlerSelfParity({
     repository,
-    ref: normalizeText32(url.searchParams.get("ref")),
-    issueNumber: normalizeIssue6(url.searchParams.get("issueNumber")),
-    pullNumber: normalizeIssue6(url.searchParams.get("pullNumber")),
+    ref: normalizeText32(url2.searchParams.get("ref")),
+    issueNumber: normalizeIssue6(url2.searchParams.get("issueNumber")),
+    pullNumber: normalizeIssue6(url2.searchParams.get("pullNumber")),
     runtimeOrigin: origin,
     env
   });
@@ -69275,8 +69276,8 @@ async function renderDashboardNotificationsPage({ runtimeOrigin, dashboardEventS
     `
   });
 }
-function buildDashboardWebManifest(url) {
-  const origin = normalize7(url?.origin);
+function buildDashboardWebManifest(url2) {
+  const origin = normalize7(url2?.origin);
   return {
     name: "VTDD Butler",
     short_name: "VTDD",
@@ -69771,8 +69772,8 @@ function normalizeDashboardExternalUrl(value) {
     return "";
   }
   try {
-    const url = new URL(text);
-    return url.protocol === "https:" ? url.toString() : "";
+    const url2 = new URL(text);
+    return url2.protocol === "https:" ? url2.toString() : "";
   } catch {
     return "";
   }
@@ -69790,13 +69791,13 @@ function uniqueTextList2(value) {
 function shouldSubmitDashboardComposerShortcut(event) {
   return event && event.key === "Enter" && event.shiftKey !== true && event.isComposing !== true && (event.metaKey === true || event.ctrlKey === true);
 }
-async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore } = {}) {
+async function renderV2DashboardPage({ runtimeOrigin, url: url2, dashboardEventStore } = {}) {
   const origin = normalize7(runtimeOrigin);
   const repositoryInput = normalizeDashboardRepositoryInput(
-    url?.searchParams?.get("repositoryInput") || url?.searchParams?.get("repository")
+    url2?.searchParams?.get("repositoryInput") || url2?.searchParams?.get("repository")
   );
-  const dashboardIssueNumber = normalizePositiveInteger10(url?.searchParams?.get("issueNumber"));
-  const requestedChatThreadId = normalizeDashboardThreadId(url?.searchParams?.get("threadId") || url?.searchParams?.get("thread_id"));
+  const dashboardIssueNumber = normalizePositiveInteger10(url2?.searchParams?.get("issueNumber"));
+  const requestedChatThreadId = normalizeDashboardThreadId(url2?.searchParams?.get("threadId") || url2?.searchParams?.get("thread_id"));
   const dashboardTargetLabel = repositoryInput ? `\u3053\u306E\u4F5C\u696D: ${repositoryInput}` : "\u4F5C\u696D\u5BFE\u8C61 repo \u672A\u6307\u5B9A";
   const targetStatusMarkup = repositoryInput ? `<p><strong>${escapeDashboardHtml(repositoryInput)}</strong></p>
           <p class="muted">\u56FA\u5B9A\u3067\u306F\u3042\u308A\u307E\u305B\u3093\u3002\u3053\u306E\u4F1A\u8A71\u3067 Issue / PR / deploy \u306A\u3069 repo \u304C\u5FC5\u8981\u306A\u4F5C\u696D\u3092\u3059\u308B\u9593\u3060\u3051\u5BFE\u8C61\u306B\u3057\u307E\u3059\u3002deploy \u5148\u3068\u627F\u8A8D\u5883\u754C\u306F repo \u3054\u3068\u306B\u78BA\u8A8D\u3057\u307E\u3059\u3002</p>` : `<p><strong>\u4F5C\u696D\u5BFE\u8C61 repo \u672A\u6307\u5B9A</strong></p>
@@ -69813,7 +69814,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
   const chatThreadId = requestedChatThreadId || `dashboard-main-${(repositoryInput || "unresolved").replace(/[^a-z0-9_.-]+/gi, "-")}`;
   const socketOrigin = origin.replace(/^http/i, "ws");
   const currentDashboardReturnPath = withDashboardReturnThreadId(
-    sanitizeDashboardPreAuthReturnPath(`${url?.pathname || "/dashboard"}${url?.search || ""}`),
+    sanitizeDashboardPreAuthReturnPath(`${url2?.pathname || "/dashboard"}${url2?.search || ""}`),
     chatThreadId
   );
   const dashboardSignInUrl = `${origin}/v2/approval/passkey/operator?mode=dashboard&phase=execution&actionType=read&highRiskKind=dashboard_access&dashboardReturnPath=${encodeURIComponent(currentDashboardReturnPath)}`;


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #637 の production Dashboard Butler live E2E で出た `dashboard-butler.local` approval URL drift を修正し、Dashboard WebSocket owner turn でも request origin から production same-origin passkey URL を生成します。

## Satisfied Success Criteria

- Dashboard Butler が自然文で VPS privileged maintenance intent を理解し、owner-facing approval URL を production same-origin で返します。
- passkey approval URL に `dashboardThreadId` を保持したまま、内部 fallback origin を owner に表示しないようにします。

## Unsatisfied Success Criteria

- merge/deploy 後の production Dashboard Butler live E2E は未実施です。
- helper lifecycle 全体、capability add/remove/rollback/review、Issue #637 closure はこの PR では完了しません。

## Non-goal violations

None.

## 開発前作戦図

- 作戦図 evidence: docs/development-strategy/issue-637-dashboard-ws-origin.md
- 完了体験: Owner が Dashboard Butler の chat で VPS runner status を頼むと、本番同一 origin の passkey URL が返り、`dashboard-butler.local` は表示されない。
- VTDD 全体で進める部分: Issue #637 の Dashboard Butler live E2E で見つかった WebSocket origin drift を塞ぎ、#707 の passkey auto-continue に到達できるようにする。
- 設計: DashboardChatRoom の WebSocket request origin を socket attachment に保存し、owner message から VPS maintenance flow へ渡す。
- 仮説: HTTP route は request origin を使うが WebSocket owner turn は env fallback だけで approval URL を作るため、本番 env に runtime URL が無いと `dashboard-butler.local` が漏れるという仮説。
- 検証計画: DashboardChatRoom unit test で env runtime URL なしでも attachment origin から production approval URL が生成されることを確認し、`npm run verify:worker` を通す。
- 改修見積もり: `src/worker/runtime.js` の `DashboardChatRoom.acceptSocket` / `handleSocketMessage` / `acceptOwnerMessage` / `buildVpsMaintenanceIntentMessages`、`test/worker.test.js`、`worker.js`。
- 既に通っている経路: #707 で `dashboardThreadId` と passkey auto-continue JS は本番 route に載っている。
- 未確認の境界: merge/deploy 後の production Dashboard WebSocket で approval URL が same-origin になること、passkey 承認後に helper queue へ自動継続すること。
- 穴が出そうな箇所: env fallback を消すと内部テストや非標準 runtime を壊すため、request origin がある時だけ優先し fallback は最後に残す。
- PR 前に確認すること: #707 live E2E failure、Issue #637、DashboardChatRoom source、targeted worker test、`npm run verify:worker`、generated worker を確認する。
- 実装候補と捨てた案: 採用は WebSocket request origin を attachment に保存する案。捨てた案は production env 設定だけで逃げる案、URL 文字列置換、owner に host を直させる案。
- merge 後に通す E2E: Production deploy 後の live E2E として、Dashboard Butler 新規 thread で VPS runner status intent を送り、approval URL が `https://vtdd-v2-mvp.polished-tree-da7c.workers.dev/...` かつ `dashboardThreadId` 付きであることを確認し、passkey 承認から helper queue へ進める。
- 次の PR を増やさない理由: live E2E で出た root cause の origin 伝搬だけを塞ぎ、#707 の auto-continue 設計や通知 system を広げず、同じ穴の後続 PR を増やさない。
- 停止条件: WebSocket request origin が取れない、production URL が still local fallback になる、owner-specific static URL を repo に埋める必要が出た場合は停止する。

## Dry-run Impact Report

- Target Issue: Issue #637
- Implementing Success Criteria: Dashboard Butler WebSocket owner turn の VPS maintenance approval URL を production same-origin にする。
- Explicit Non-goals: helper 実行、通知 system redesign、deploy workflow、Custom GPT Action Schema、credential mutation、Issue closure は触らない。
- Expected touched files/routes/workflows: `src/worker/runtime.js` DashboardChatRoom WebSocket path、`test/worker.test.js` regression test、`worker.js`、`docs/development-strategy/issue-637-dashboard-ws-origin.md`。
- Affected Issues: Issue #637 directly; Issue #413 / Issue #450 / Issue #514 は downstream visibility と recovery surface として影響する。
- Affected PRs: PR #707 の live E2E follow-up。merged branch は変更しない。
- Affected workflows: reviewer / guarded-policy / test / deploy-production の通常 workflow のみ。workflow file は変更しない。
- Affected runtime/operator surfaces: Dashboard Butler WebSocket chat、VPS passkey operator URL、helper queue handoff entry。
- What may break if we patch narrowly: app-server bridge socket attachment、manual env fallback、non-production test origin が壊れる可能性。
- Unknowns to investigate before coding: production env に `VTDD_RUNTIME_URL` が無い場合の WebSocket origin fallback、existing tests の socket attachment shape。
- Validation needed: `git diff --check`、targeted worker tests、`npm run verify:worker`、merge/deploy 後 production Dashboard Butler live E2E。
- Stop condition: origin を安全に伝搬できない、または hard-coded owner runtime URL が必要になる場合は停止する。

## Execution Queue Delta

- Queue position before: `Now` は Issue #637。PR #707 deploy 後の live E2E が `dashboard-butler.local` approval URL で止まった。
- Preemption decision: ROOT。これは Issue #637 の Butler Completion Gate を塞ぐ live E2E blocker です。
- Queue delta: Issue #637 stays `Now`; PR #707 の passkey auto-continue slice に必要な WebSocket origin blocker を解消します。
- Why this PR is next: owner が押せない approval URL は passkey-only continuation を成立させないため、helper queue E2E に進む前に必ず塞ぐ必要があります。
- Active Issues not downscoped: Active Issues は縮小しません。Issue #637 の残り Success Criteria と他 active Issue は未完了として残します。

## File / Line Hypotheses

- file: `src/worker/runtime.js`
  - hypothesis: `DashboardChatRoom.buildVpsMaintenanceIntentMessages` が request origin を受け取らず、env fallback から `dashboard-butler.local` を使う。
  - risk if changed narrowly: HTTP route や app-server bridge、manual fallback を壊す。
  - validation: DashboardChatRoom origin regression test と full worker verify。
  - related Issue: #637
- file: `test/worker.test.js`
  - hypothesis: WebSocket owner turn の origin regression test がなかったため production live E2E まで漏れた。
  - risk if changed narrowly: future PR で local fallback が再発する。
  - validation: env runtime URL なしで production origin URL を assert。
  - related Issue: #637

## Hypothesis Retrospective

- expected: WebSocket request origin を attachment 経由で渡せば approval URL は production same-origin になる。
- actual: targeted test で `dashboard-butler.local` が消え、production origin の approval URL を生成することを確認した。
- mismatch: production live E2E は merge/deploy 後に再実施する。
- lesson: Dashboard WebSocket path は HTTP path と同じ request origin discipline を持たせる必要がある。
- should become RAG candidate: はい。Dashboard Butler の owner-facing URL は request origin 優先で、local fallback を owner に出さない。

## Verification Evidence

- Unit: `npm run build:worker && node --test test/worker.test.js --test-name-pattern 'DashboardChatRoom routes VPS maintenance owner turns|DashboardChatRoom uses WebSocket request origin|worker connects VPS privileged maintenance intent'` passed 241/241.
- Integration: `npm run verify:worker` passed: `npm test` 1106 tests, 1105 pass, 1 skipped; self parity checked 33 routes and 33 operationIds; generated worker check passed.
- E2E: Production Dashboard Butler live E2E は merge/deploy 後に再実施します。
- Manual: #707 production live E2E で `dashboard-butler.local` approval URL drift を確認し、この PR の対象にしました。
- Evidence path/link: docs/development-strategy/issue-637-dashboard-ws-origin.md

## Butler Completion Contract

- Primary owner surface: Dashboard Butler。
- Fallback surface: Custom GPT は fallback surface であり、この PR の主経路ではありません。
- Owner goal: Dashboard Butler chat に出る passkey URL が本番同一 origin になり、owner がそのまま押して継続できる。
- Butler entrypoint: Dashboard Butler の通常チャットで VPS runner status / VPS maintenance intent を自然文で送る。
- Dashboard Butler natural-language path: Dashboard Butler の自然文 chat entrypoint が WebSocket 経由でも production same-origin approval URL を返します。
- Action Schema exposure: Custom GPT Action Schema は fallback であり、この PR では主経路として扱わず変更しません。
- Runtime path: Dashboard WebSocket owner_message -> DashboardChatRoom origin attachment -> buildDashboardVpsPrivilegedMaintenanceNaturalLanguageFlow -> passkey operator URL。
- Runner/runtime truth: local Worker tests で origin propagation を確認。production runner pickup/result は merge/deploy 後の live E2E で確認します。
- Authority boundary: scoped passkey approval が必要です。この PR は root/helper execution を開始せず、approval URL の owner-facing origin を修正します。
- E2E evidence: 未完了。merge/deploy 後に production Dashboard Butler live E2E が必要です。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 必要。worker runtime 変更のため merge 後に production deploy passkey が必要です。
- Custom GPT Action Schema update: 不要。Dashboard Butler 主経路の runtime 接続です。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 必要。approval URL origin と passkey 後 helper queue 自動継続を確認します。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate
- AGENTS.md Butler-First Operating Principle
- AGENTS.md Drift Stop Protocol
- docs/butler/execution-queue-contract.md
- docs/mvp/active-issue-execution-queue.md

## Out-of-scope but NOT implemented

- helper lifecycle full completion
- broad notification subsystem redesign
- production deploy itself
- Issue #637 closure

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #637
- Execution ID: issue637-dashboard-ws-origin
- Goal: Dashboard WebSocket owner turn の passkey approval URL を production same-origin にする。
