### PR TITLE
Issue #528 Dashboard WebSocket heartbeatを追加

### DIFF
--- a/docs/development-strategy/issue-528-passive-reconnect-status.md
+++ b/docs/development-strategy/issue-528-passive-reconnect-status.md
@@ -1,0 +1,63 @@
+# Issue #528 Dashboard WebSocket heartbeat strategy
+
+## 完了体験
+
+オーナーは Dashboard Butler の通常チャットを開いたまま、ブラウザ側 Dashboard WebSocket と VPS app-server bridge WebSocket が idle close されにくい状態で会話を続けられる。もし close/error が起きても、入力欄下の `接続が切れました。履歴を確認しながら復帰しています。` の点滅に邪魔されず、ログイン切れ、送信確認前切断、オフラインなどオーナー操作が必要な時だけ短い状態表示が出る。
+
+## VTDD 全体で進める部分
+
+Issue #528 の「Dashboard Butler を ChatGPT iOS 相当の通常チャット面にする」品質を進める。Issue #450 の live app-server bridge、Issue #579 の reconnect/auth recovery と関係する。この slice は #637 capability lifecycle を閉じず、Dashboard Butler 通常チャットの WebSocket heartbeat と passive recovery 表示制御だけを扱う。
+
+## 設計
+
+既存の Worker WebSocket 受信側は raw text `ping` に `pong` を返せるため、その契約を使う。Dashboard ブラウザ側は WebSocket open 中だけ recursive `setTimeout` で raw `ping` を送り、close/error で heartbeat を止める。VPS app-server bridge も同じく open 中だけ raw `ping` を送り、close/error で止める。
+
+あわせて `setConnectionRecoveryStatus()` を visible opt-in にする。passive recovery では `composer-status` に文字を出さず、`data-reconnect-attempt`、`data-websocket-state`、`data-recovery-message` に runtime truth を残す。owner action required の status は既存 `setStatus()` 経路を維持する。
+
+## 仮説
+
+Worker の `DashboardChatRoom.handleSocketMessage()` には ping/pong があるが、Dashboard ブラウザと app-server bridge が heartbeat を送っていないため、idle close が発生し、bridge reconnect と Dashboard reconnect が断続的に走っているという仮説。さらに #565 で temporary status と `:empty` は入ったが、`close` / `error` / `scheduleReconnect` / `visibilitychange` が短周期で `setConnectionRecoveryStatus()` を呼び、because `setConnectionRecoveryStatus()` が毎回 `setStatus()` へ渡しているため、2.4 秒で消えてもすぐ再点灯し、mac Chrome と iPhone ではチラつき・居座りに見える。
+
+## 検証計画
+
+worker HTML contract test で Dashboard ブラウザ側 heartbeat が raw `ping` を送ること、passive recovery が visible opt-in になっていること、`接続が切れました...` / `接続できませんでした...` の passive 呼び出しが `visible: true` を渡していないこと、data 属性に recovery truth が残ることを確認する。app-server bridge test で `VTDD_DASHBOARD_BRIDGE_HEARTBEAT_MS` と raw `ping` 送信を確認する。`npm run build:worker` と `npm run verify:worker` を通す。merge/deploy 後に production mac Chrome / iPhone PWA で composer 下の点滅が止まり、VPS bridge pickup が安定することを確認する。
+
+## 改修見積もり
+
+- `src/worker/runtime.js`: Dashboard chat WebSocket heartbeat、`setConnectionRecoveryStatus()` の visible opt-in 化、再ログイン復帰時の passive 表示化。
+- `scripts/run-dashboard-app-server-bridge.mjs`: VPS app-server bridge の WebSocket heartbeat と `--heartbeat-ms` / `VTDD_DASHBOARD_BRIDGE_HEARTBEAT_MS`。
+- `test/worker.test.js`: Dashboard chat shell contract に heartbeat、recovery data 属性、passive status 非表示条件を追加。
+- `test/dashboard-app-server-bridge.test.js`: bridge heartbeat config と raw `ping` 送信を追加。
+- `worker.js`: generated worker。
+
+## 既に通っている経路
+
+Dashboard chat は HTTP fallback / refreshThread / draft persistence で入力保持と履歴復帰ができる。Issue #565 で empty status の余白除去、Issue #579/#654 で reconnect/auth recovery と fallback resume の実装・証跡がある。
+
+## 未確認の境界
+
+この Codex セッションから VPS へ SSH read-only 確認はできなかったため、production service log の live truth は未確認。heartbeat で idle close 要因を潰すが、Cloudflare / PWA / app-server bridge / VPS service 側に別原因の close/error が残る可能性はある。
+
+## 穴が出そうな箇所
+
+passive status を消すことで本当の接続断が見えなくなるリスクがあるため、data 属性には残す。owner action required のログイン切れ、オフライン、送信確認前切断まで隠すと復旧不能になるため触らない。
+
+## PR 前に確認すること
+
+Issue #528 / #579 / #565 の scope、`src/worker/runtime.js` の composer status 経路、`test/worker.test.js` の Dashboard chat shell assertions、generated worker、PR body guardrail を確認する。
+
+## 実装候補と捨てた案
+
+採用案は既存 ping/pong 契約を使った Dashboard ブラウザ側・VPS app-server bridge 側 heartbeat と、passive recovery を visible opt-in にして通常 UI には出さず data 属性に残す案。捨てた案は文言だけ短くする案、temporary 秒数を短くする案、`setInterval` polling、debug drawer 新設まで広げる案。
+
+## merge 後に通す E2E
+
+Production deploy 後の live E2E として、mac Chrome と iPhone/PWA で Dashboard Butler 通常チャットを開き、WebSocket heartbeat が動いた状態で composer 下に `接続が切れました。履歴を確認しながら復帰しています。` が点滅しないことを確認する。あわせてログイン切れ・オフラインなど owner action required 表示は残ること、VPS app-server bridge が raw `ping` で維持されることを確認する。
+
+## 次の PR を増やさない理由
+
+この PR は WebSocket heartbeat と通常チャット面の表示ノイズ抑制を同時に行う。VPS helper lifecycle や #637 の completion claim には踏み込まず、Durable Object の再設計や queue/timer 方式変更まで広げないため、同じ PR の後始末を増やさない。
+
+## 停止条件
+
+owner action required の復旧表示まで消す必要が出る、heartbeat ではなく queue/runner/timer の実行方式変更に踏み込まないと成立しない、または Dashboard Butler 通常チャットではなく Custom GPT / Action Schema 側の修正に逸れる場合は停止する。

--- a/scripts/run-dashboard-app-server-bridge.mjs
+++ b/scripts/run-dashboard-app-server-bridge.mjs
@@ -909,7 +909,8 @@ export function parseBridgeArgs(argv = process.argv.slice(2), env = process.env)
     cwd: env.VTDD_DASHBOARD_CODEX_CWD || process.cwd(),
     sandboxMode: env.VTDD_DASHBOARD_APP_SERVER_SANDBOX || "",
     turnTimeoutMs: Number(env.VTDD_DASHBOARD_APP_SERVER_TURN_TIMEOUT_MS || 0),
-    reconnectDelayMs: Number(env.VTDD_DASHBOARD_BRIDGE_RECONNECT_DELAY_MS || 1000)
+    reconnectDelayMs: Number(env.VTDD_DASHBOARD_BRIDGE_RECONNECT_DELAY_MS || 1000),
+    heartbeatMs: Number(env.VTDD_DASHBOARD_BRIDGE_HEARTBEAT_MS || 25000)
   };
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
@@ -920,6 +921,7 @@ export function parseBridgeArgs(argv = process.argv.slice(2), env = process.env)
     if (arg === "--sandbox") options.sandboxMode = argv[++index] || "";
     if (arg === "--turn-timeout-ms") options.turnTimeoutMs = Number(argv[++index] || 0);
     if (arg === "--reconnect-delay-ms") options.reconnectDelayMs = Number(argv[++index] || 1000);
+    if (arg === "--heartbeat-ms") options.heartbeatMs = Number(argv[++index] || 25000);
   }
   return options;
 }
@@ -973,6 +975,7 @@ export async function connectDashboardAppServerBridgeOnce({
   cwd = process.cwd(),
   sandboxMode = "",
   turnTimeoutMs = 0,
+  heartbeatMs = 25000,
   runtimeUrl = "",
   fetchImpl = globalThis.fetch,
   mediaTmpRoot = os.tmpdir(),
@@ -982,6 +985,7 @@ export async function connectDashboardAppServerBridgeOnce({
   const socket = new WebSocketImpl(endpoint, ["vtdd-dashboard-bridge", bearerProtocol]);
   let turnQueue = Promise.resolve();
   let settled = false;
+  let heartbeatTimer = null;
 
   const safeSend = (payload) => {
     try {
@@ -991,15 +995,37 @@ export async function connectDashboardAppServerBridgeOnce({
     }
   };
 
+  const stopHeartbeat = () => {
+    if (!heartbeatTimer) return;
+    clearTimeout(heartbeatTimer);
+    heartbeatTimer = null;
+  };
+
+  const scheduleHeartbeat = () => {
+    stopHeartbeat();
+    const delayMs = Number(heartbeatMs);
+    if (!Number.isFinite(delayMs) || delayMs <= 0) return;
+    heartbeatTimer = setTimeout(() => {
+      heartbeatTimer = null;
+      try {
+        socket.send("ping");
+      } catch {}
+      scheduleHeartbeat();
+    }, delayMs);
+  };
+
   const disconnected = new Promise((resolve) => {
     const finish = () => {
       if (settled) return;
       settled = true;
+      stopHeartbeat();
       resolve();
     };
     socket.addEventListener("close", finish);
     socket.addEventListener("error", finish);
   });
+
+  socket.addEventListener("open", scheduleHeartbeat);
 
   socket.addEventListener("message", (event) => {
     let payload;

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -14392,6 +14392,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
       const initialMarkup = log.innerHTML;
       let chatSocket = null;
       let reconnectTimer = null;
+      let socketHeartbeatTimer = null;
       let reconnectAttempt = 0;
       let refreshingThread = false;
       let lastRefreshFailure = "";
@@ -14513,6 +14514,25 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         return Boolean(chatSocket && chatSocket.readyState === WebSocket.OPEN);
       }
 
+      function stopSocketHeartbeat() {
+        if (!socketHeartbeatTimer) return;
+        window.clearTimeout(socketHeartbeatTimer);
+        socketHeartbeatTimer = null;
+      }
+
+      function scheduleSocketHeartbeat() {
+        stopSocketHeartbeat();
+        if (dashboardSessionExpired || !isChatSocketOpen()) return;
+        socketHeartbeatTimer = window.setTimeout(() => {
+          socketHeartbeatTimer = null;
+          if (!isChatSocketOpen()) return;
+          try {
+            chatSocket.send("ping");
+          } catch {}
+          scheduleSocketHeartbeat();
+        }, 25000);
+      }
+
       function describeChatSocketState() {
         if (!chatSocket) return "未接続";
         if (chatSocket.readyState === WebSocket.CONNECTING) return "接続中";
@@ -14528,6 +14548,15 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         status.dataset.reconnectAttempt = String(attempt);
         status.dataset.websocketState = describeChatSocketState();
         status.dataset.lastRefreshFailure = lastRefreshFailure || "";
+        status.dataset.recoveryMessage = message || "";
+        if (options.visible !== true) {
+          if (status.textContent.trim() === message || status.dataset.passiveRecoveryVisible === "true") {
+            setStatus("");
+          }
+          status.dataset.passiveRecoveryVisible = "false";
+          return;
+        }
+        status.dataset.passiveRecoveryVisible = "true";
         setStatus(message, { temporary: options.temporary !== false });
       }
 
@@ -14577,7 +14606,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         }
         authReturnResumePromise = (async () => {
           dashboardSessionExpired = false;
-          setConnectionRecoveryStatus(reason || "再ログイン後の接続を復帰しています。入力は保持しています。", { temporary: false });
+          setConnectionRecoveryStatus(reason || "再ログイン後の接続を復帰しています。入力は保持しています。");
           dropStaleSocketIfNeeded();
           const refreshResult = await refreshThread();
           if (refreshResult && refreshResult.authExpired) {
@@ -15325,6 +15354,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
             reconnectTimer = null;
           }
           setStatus("Dashboard thread 接続済み。", { temporary: true });
+          scheduleSocketHeartbeat();
           refreshThread();
         });
         chatSocket.addEventListener("message", (event) => {
@@ -15369,6 +15399,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           }
         });
         chatSocket.addEventListener("close", () => {
+          stopSocketHeartbeat();
           if (pendingOwnerSend) {
             releasePendingOwnerSend(pendingOwnerSend.clientMessageId, { clearComposer: false, keepRollbackTimer: true });
             setStatus("送信確認前に WebSocket が切れました。入力は残しています。履歴再取得後にもう一度送信できます。");
@@ -15382,6 +15413,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           }
         });
         chatSocket.addEventListener("error", () => {
+          stopSocketHeartbeat();
           if (pendingOwnerSend) {
             releasePendingOwnerSend(pendingOwnerSend.clientMessageId, { clearComposer: false, keepRollbackTimer: true });
             setStatus("送信確認前に WebSocket 接続が失敗しました。入力は残しています。再接続後にもう一度送信できます。");

--- a/test/dashboard-app-server-bridge.test.js
+++ b/test/dashboard-app-server-bridge.test.js
@@ -1371,7 +1371,8 @@ test("dashboard app-server bridge args read runtime, token, and thread from envi
     VTDD_RUNTIME_URL: "https://runtime.example",
     VTDD_GATEWAY_BEARER_TOKEN: "secret-token",
     VTDD_DASHBOARD_CODEX_CWD: "/repo",
-    VTDD_DASHBOARD_APP_SERVER_TURN_TIMEOUT_MS: "0"
+    VTDD_DASHBOARD_APP_SERVER_TURN_TIMEOUT_MS: "0",
+    VTDD_DASHBOARD_BRIDGE_HEARTBEAT_MS: "30000"
   });
   assert.equal(parsed.runtimeUrl, "https://runtime.example");
   assert.equal(parsed.token, "secret-token");
@@ -1380,6 +1381,7 @@ test("dashboard app-server bridge args read runtime, token, and thread from envi
   assert.equal(parsed.sandboxMode, "");
   assert.equal(parsed.turnTimeoutMs, 1500);
   assert.equal(parsed.reconnectDelayMs, 1000);
+  assert.equal(parsed.heartbeatMs, 30000);
 });
 
 test("dashboard app-server bridge endpoint uses the dashboard app-server thread WebSocket", () => {
@@ -1508,6 +1510,60 @@ test("dashboard app-server bridge reconnects the dashboard WebSocket without rei
   assert.equal(initializeCount, 1);
   assert.equal(String(sockets[0].endpoint), "wss://runtime.example/v2/dashboard/app-server/ws?threadId=dashboard-main");
   assert.equal(String(sockets[1].endpoint), "wss://runtime.example/v2/dashboard/app-server/ws?threadId=dashboard-main");
+});
+
+test("dashboard app-server bridge sends heartbeat pings on an open socket", async () => {
+  const sockets = [];
+  class MockWebSocket {
+    constructor(endpoint, protocols) {
+      this.endpoint = endpoint;
+      this.protocols = protocols;
+      this.listeners = new Map();
+      this.sent = [];
+      sockets.push(this);
+    }
+
+    addEventListener(type, handler) {
+      if (!this.listeners.has(type)) {
+        this.listeners.set(type, new Set());
+      }
+      this.listeners.get(type).add(handler);
+    }
+
+    send(payload) {
+      this.sent.push(payload);
+    }
+
+    emit(type, event = {}) {
+      for (const handler of this.listeners.get(type) || []) {
+        handler(event);
+      }
+    }
+  }
+  const appServer = {
+    nextRequestId() {
+      return 1;
+    },
+    onNotification() {
+      return () => {};
+    },
+    async request() {
+      throw new Error("turn handling should not run in this heartbeat test");
+    }
+  };
+
+  const once = connectDashboardAppServerBridgeOnce({
+    endpoint: new URL("wss://runtime.example/v2/dashboard/app-server/ws?threadId=dashboard-main"),
+    token: "secret-token",
+    appServer,
+    WebSocketImpl: MockWebSocket,
+    heartbeatMs: 1
+  });
+  assert.equal(sockets.length, 1);
+  sockets[0].emit("open");
+  await waitFor(() => sockets[0].sent.includes("ping"));
+  sockets[0].emit("close");
+  await once;
 });
 
 async function waitFor(predicate, { timeoutMs = 1000 } = {}) {

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -1265,6 +1265,10 @@ test("worker serves v2 dashboard for allowed owner identity without exposing sec
   assert.equal(body.includes('data-codex-goal="dashboard_chat_triage"'), false);
   assert.equal(body.includes('executorTransport: dispatchToVpsRunner ? "vps_runner" : undefined'), false);
   assert.equal(body.includes("new WebSocket(socketEndpoint)"), true);
+  assert.equal(body.includes("let socketHeartbeatTimer = null"), true);
+  assert.equal(body.includes("function scheduleSocketHeartbeat()"), true);
+  assert.equal(body.includes('chatSocket.send("ping")'), true);
+  assert.equal(body.includes("stopSocketHeartbeat();"), true);
   assert.equal(body.includes("function refreshThread()"), true);
   assert.equal(body.includes("function scheduleReconnect()"), true);
   assert.equal(body.includes("function sendOwnerMessageByHttp("), true);
@@ -1308,9 +1312,16 @@ test("worker serves v2 dashboard for allowed owner identity without exposing sec
   assert.equal(body.includes("WebSocket: "), false);
   assert.equal(body.includes("status.dataset.reconnectAttempt"), true);
   assert.equal(body.includes("status.dataset.websocketState"), true);
+  assert.equal(body.includes("status.dataset.recoveryMessage"), true);
+  assert.equal(body.includes('if (options.visible !== true)'), true);
+  assert.equal(body.includes('status.dataset.passiveRecoveryVisible = "false"'), true);
   assert.equal(body.includes("接続を復帰しています。入力は保持しています。"), true);
   assert.equal(body.includes("setConnectionRecoveryStatus(message, options = {})"), true);
   assert.equal(body.includes("setStatus(message, { temporary: options.temporary !== false })"), true);
+  assert.equal(body.includes('setConnectionRecoveryStatus("接続が切れました。履歴を確認しながら復帰しています。");'), true);
+  assert.equal(body.includes('setConnectionRecoveryStatus("接続できませんでした。履歴を確認しながら復帰しています。");'), true);
+  assert.equal(body.includes('setConnectionRecoveryStatus("接続が切れました。履歴を確認しながら復帰しています。", { visible: true'), false);
+  assert.equal(body.includes('setConnectionRecoveryStatus("接続できませんでした。履歴を確認しながら復帰しています。", { visible: true'), false);
   assert.equal(body.includes('setStatus("Dashboard thread 接続済み。", { temporary: true })'), true);
   assert.equal(body.includes('setStatus("");'), true);
   assert.equal(body.includes('document.addEventListener("visibilitychange", async () => {'), true);

--- a/worker.js
+++ b/worker.js
@@ -70233,6 +70233,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url: url2, dashboardEventS
       const initialMarkup = log.innerHTML;
       let chatSocket = null;
       let reconnectTimer = null;
+      let socketHeartbeatTimer = null;
       let reconnectAttempt = 0;
       let refreshingThread = false;
       let lastRefreshFailure = "";
@@ -70354,6 +70355,25 @@ async function renderV2DashboardPage({ runtimeOrigin, url: url2, dashboardEventS
         return Boolean(chatSocket && chatSocket.readyState === WebSocket.OPEN);
       }
 
+      function stopSocketHeartbeat() {
+        if (!socketHeartbeatTimer) return;
+        window.clearTimeout(socketHeartbeatTimer);
+        socketHeartbeatTimer = null;
+      }
+
+      function scheduleSocketHeartbeat() {
+        stopSocketHeartbeat();
+        if (dashboardSessionExpired || !isChatSocketOpen()) return;
+        socketHeartbeatTimer = window.setTimeout(() => {
+          socketHeartbeatTimer = null;
+          if (!isChatSocketOpen()) return;
+          try {
+            chatSocket.send("ping");
+          } catch {}
+          scheduleSocketHeartbeat();
+        }, 25000);
+      }
+
       function describeChatSocketState() {
         if (!chatSocket) return "\u672A\u63A5\u7D9A";
         if (chatSocket.readyState === WebSocket.CONNECTING) return "\u63A5\u7D9A\u4E2D";
@@ -70369,6 +70389,15 @@ async function renderV2DashboardPage({ runtimeOrigin, url: url2, dashboardEventS
         status.dataset.reconnectAttempt = String(attempt);
         status.dataset.websocketState = describeChatSocketState();
         status.dataset.lastRefreshFailure = lastRefreshFailure || "";
+        status.dataset.recoveryMessage = message || "";
+        if (options.visible !== true) {
+          if (status.textContent.trim() === message || status.dataset.passiveRecoveryVisible === "true") {
+            setStatus("");
+          }
+          status.dataset.passiveRecoveryVisible = "false";
+          return;
+        }
+        status.dataset.passiveRecoveryVisible = "true";
         setStatus(message, { temporary: options.temporary !== false });
       }
 
@@ -70418,7 +70447,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url: url2, dashboardEventS
         }
         authReturnResumePromise = (async () => {
           dashboardSessionExpired = false;
-          setConnectionRecoveryStatus(reason || "\u518D\u30ED\u30B0\u30A4\u30F3\u5F8C\u306E\u63A5\u7D9A\u3092\u5FA9\u5E30\u3057\u3066\u3044\u307E\u3059\u3002\u5165\u529B\u306F\u4FDD\u6301\u3057\u3066\u3044\u307E\u3059\u3002", { temporary: false });
+          setConnectionRecoveryStatus(reason || "\u518D\u30ED\u30B0\u30A4\u30F3\u5F8C\u306E\u63A5\u7D9A\u3092\u5FA9\u5E30\u3057\u3066\u3044\u307E\u3059\u3002\u5165\u529B\u306F\u4FDD\u6301\u3057\u3066\u3044\u307E\u3059\u3002");
           dropStaleSocketIfNeeded();
           const refreshResult = await refreshThread();
           if (refreshResult && refreshResult.authExpired) {
@@ -71166,6 +71195,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url: url2, dashboardEventS
             reconnectTimer = null;
           }
           setStatus("Dashboard thread \u63A5\u7D9A\u6E08\u307F\u3002", { temporary: true });
+          scheduleSocketHeartbeat();
           refreshThread();
         });
         chatSocket.addEventListener("message", (event) => {
@@ -71210,6 +71240,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url: url2, dashboardEventS
           }
         });
         chatSocket.addEventListener("close", () => {
+          stopSocketHeartbeat();
           if (pendingOwnerSend) {
             releasePendingOwnerSend(pendingOwnerSend.clientMessageId, { clearComposer: false, keepRollbackTimer: true });
             setStatus("\u9001\u4FE1\u78BA\u8A8D\u524D\u306B WebSocket \u304C\u5207\u308C\u307E\u3057\u305F\u3002\u5165\u529B\u306F\u6B8B\u3057\u3066\u3044\u307E\u3059\u3002\u5C65\u6B74\u518D\u53D6\u5F97\u5F8C\u306B\u3082\u3046\u4E00\u5EA6\u9001\u4FE1\u3067\u304D\u307E\u3059\u3002");
@@ -71223,6 +71254,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url: url2, dashboardEventS
           }
         });
         chatSocket.addEventListener("error", () => {
+          stopSocketHeartbeat();
           if (pendingOwnerSend) {
             releasePendingOwnerSend(pendingOwnerSend.clientMessageId, { clearComposer: false, keepRollbackTimer: true });
             setStatus("\u9001\u4FE1\u78BA\u8A8D\u524D\u306B WebSocket \u63A5\u7D9A\u304C\u5931\u6557\u3057\u307E\u3057\u305F\u3002\u5165\u529B\u306F\u6B8B\u3057\u3066\u3044\u307E\u3059\u3002\u518D\u63A5\u7D9A\u5F8C\u306B\u3082\u3046\u4E00\u5EA6\u9001\u4FE1\u3067\u304D\u307E\u3059\u3002");


### PR DESCRIPTION
## This PR satisfies Intent

Issue #528 / Issue #450 / Issue #579 の部分進捗です。Dashboard Butler の通常チャットで、ブラウザ側 Dashboard WebSocket と VPS app-server bridge WebSocket が idle close されにくいよう heartbeat を追加します。あわせて、close/error が起きた時に `接続が切れました。履歴を確認しながら復帰しています。` が入力欄下で点滅し続け、会話体験を邪魔する問題を抑制します。

これは Issue #637 の VPS helper lifecycle completion を閉じる PR ではありません。Dashboard Butler の通常チャット面と live bridge の土台を直す ROOT 割り込みです。実運用で別原因の WebSocket close/error が残る場合は #450 / #579 の接続安定性として継続します。

## Satisfied Success Criteria

- [x] Dashboard ブラウザ側 WebSocket が open 中に raw `ping` heartbeat を送る。
- [x] VPS app-server bridge WebSocket が open 中に raw `ping` heartbeat を送る。
- [x] bridge heartbeat は `VTDD_DASHBOARD_BRIDGE_HEARTBEAT_MS` / `--heartbeat-ms` で調整できる。
- [x] heartbeat は `setInterval` polling ではなく recursive `setTimeout` で、close/error 時に停止する。
- [x] passive reconnect / close / error / visibility 復帰表示を通常 composer 下に出し続けない。
- [x] reconnect attempt / WebSocket state / recovery message は `data-*` に残し、デバッグ可能性を消さない。
- [x] Dashboard ログイン切れ、送信確認前の切断、オフライン、送信失敗など owner action が必要な status 表示は維持する。
- [x] generated `worker.js` を更新し、worker verification を通した。

## Unsatisfied Success Criteria

- production VPS service log はこの Codex セッションから read-only SSH できず未確認です。
- production iPhone/PWA と mac Chrome の live 再確認は deploy 後に必要です。
- Issue #637 の capability lifecycle completion はこの PR では進めません。
- queue/timer 実行方式そのものの見直しはこの PR では扱いません。

## Non-goal violations

None.

## 開発前作戦図

- 作戦図 evidence: docs/development-strategy/issue-528-passive-reconnect-status.md
- 完了体験: オーナーは Dashboard Butler の通常チャットを開いたまま、ブラウザ側 Dashboard WebSocket と VPS app-server bridge WebSocket が idle close されにくい状態で会話を続けられる。もし close/error が起きても入力欄下の接続断文言の点滅に邪魔されない。
- VTDD 全体で進める部分: Issue #528 の通常チャット面品質、Issue #450 の live app-server bridge、Issue #579 の reconnect/auth recovery を進める。Issue #637 capability lifecycle は閉じない。
- 設計: 既存 Worker WebSocket の raw `ping` / `pong` 契約を使い、Dashboard ブラウザ側と VPS app-server bridge 側で open 中だけ heartbeat を送る。passive recovery は composer status に出さず data 属性へ runtime truth を残す。owner action required status は既存経路を維持する。
- 仮説: 原因仮説は、Worker には ping/pong 受け口があったが Dashboard ブラウザと app-server bridge が heartbeat を送っていないため idle close が発生していること。さらに `setConnectionRecoveryStatus()` が close/error ごとに `setStatus()` しており、mac Chrome / iPhone で点滅・居座りに見えている。
- 検証計画: Dashboard chat shell test、app-server bridge heartbeat test、`npm run build:worker`、`npm run verify:worker` で heartbeat と passive recovery 非表示を検証する。
- 改修見積もり: `src/worker/runtime.js` の Dashboard WebSocket heartbeat と `setConnectionRecoveryStatus()`、`scripts/run-dashboard-app-server-bridge.mjs` の bridge heartbeat、`test/worker.test.js`、`test/dashboard-app-server-bridge.test.js`、generated `worker.js` を変更する。
- 既に通っている経路: Worker 側 `DashboardChatRoom.handleSocketMessage()` は raw `ping` に `pong` を返す。HTTP fallback / refreshThread / draft persistence / #565 empty status / #579 #654 reconnect evidence は既にある。
- 未確認の境界: production VPS service log は未確認。heartbeat で idle close 要因を潰すが、Cloudflare / PWA / app-server bridge / VPS service 側に別原因の close/error が残る可能性はある。
- 穴が出そうな箇所: heartbeat を JSON stringify すると Worker の raw `ping` 契約に合わないため raw `socket.send("ping")` に固定する。passive status を消すと実接続断が見えにくくなるため data 属性に残す。
- PR 前に確認すること: Issue #528 / #450 / #579、`src/worker/runtime.js`、`scripts/run-dashboard-app-server-bridge.mjs`、関連 tests、generated worker、PR body guardrail を確認する。
- 実装候補と捨てた案: 採用案は既存 ping/pong 契約を使った heartbeat と visible opt-in。捨てた案は文言短縮、temporary 秒数調整、`setInterval` polling、queue/timer 実行方式変更、debug drawer 新設案。
- merge 後に通す E2E: production deploy 後の live E2E として、mac Chrome と iPhone/PWA で Dashboard Butler 通常チャットを開き、composer 下の接続断文言が点滅しないこと、VPS app-server bridge が raw `ping` で維持されることを確認する。
- 次の PR を増やさない理由: この PR は WebSocket heartbeat と通常チャット面の表示ノイズ抑制を同時に行う。VPS helper lifecycle や #637 completion claim、Durable Object 再設計、queue/timer 方式変更へ広げない。
- 停止条件: owner action required 表示まで消す必要が出る、heartbeat ではなく queue/runner/timer の実行方式変更に踏み込まないと成立しない、または Dashboard Butler ではなく Custom GPT / Action Schema 側へ逸れる場合は停止する。

## Dry-run Impact Report

- Target Issue: Issue #528
- Implementing Success Criteria: Dashboard Butler 通常チャット面で WebSocket idle close を抑え、passive reconnect status が入力欄下に点滅・居座りしないようにする。
- Explicit Non-goals: Issue #637 close、queue/timer 実行方式変更、VPS helper lifecycle completion、deploy、credential / permission mutation、Issue close。
- Expected touched files/routes/workflows: `src/worker/runtime.js`、`scripts/run-dashboard-app-server-bridge.mjs`、`test/worker.test.js`、`test/dashboard-app-server-bridge.test.js`、`worker.js`。
- Affected Issues: Issue #528 / Issue #450 / Issue #579。Issue #565 は過去の narrow close evidence として参照のみ。Issue #637 は Now だが、この PR では completion claim しない。
- Affected PRs: 新規 PR のみ。
- Affected workflows: worker build / tests / self parity / generated worker check。
- Affected runtime/operator surfaces: Dashboard Butler `/dashboard` WebSocket、VPS app-server bridge WebSocket、composer status logic。
- What may break if we patch narrowly: heartbeat が raw `ping` でなければ Worker が pong を返せない。passive status を消すだけだと実接続断は見えにくくなるため、DOM data 属性に recovery truth を残す。
- Unknowns to investigate before coding: production VPS service log の live close/error truth はこの session から未確認。
- Validation needed: worker verification、deploy 後の live mac Chrome / iPhone PWA 確認。
- Stop condition: owner action required のログイン切れ、送信確認前切断、オフライン、fallback failure まで隠す実装になった場合は停止。

## Execution Queue Delta

- Queue position before: `Now` は Issue #637。
- Preemption decision: ROOT。
- Queue delta: Issue #528 moves this WebSocket heartbeat and passive reconnect display slice to a short ROOT interruption; Issue #637 の completion claim は進めず、Dashboard Butler 通常チャット面と live bridge の接続土台だけを修正する。Issue #450 / #579 の接続安定化にも影響する。
- Why this PR is next: 通常チャット面と VPS bridge の接続がチラつくと、Dashboard Butler が通常開発入口として成立せず、#637 E2E 継続も不安定になるため。
- Active Issues not downscoped: Active Issues は縮小しません。Issue #637 / #450 / #528 / #579 は未完了のまま残します。

## File / Line Hypotheses

- file: `src/worker/runtime.js`
  - hypothesis: Dashboard browser WebSocket が heartbeat を送らないため idle close される余地がある。さらに `setConnectionRecoveryStatus()` が close/error ごとに `setStatus()` し、composer 下の点滅・居座りを起こす。
  - risk if changed narrowly: status を完全に消すと、ログイン切れや送信確認前切断など owner action required まで隠す。
  - validation: dashboard chat shell HTML contract assertions、targeted worker test、full worker verify。
  - related Issue: Issue #528 / Issue #579

- file: `scripts/run-dashboard-app-server-bridge.mjs`
  - hypothesis: VPS app-server bridge が heartbeat を送らないため、Worker との WebSocket が idle close され、reconnect loop と Dashboard 側の接続不安定に見えている。
  - risk if changed narrowly: `safeSend("ping")` を使うと JSON string `"\"ping\""` になり Worker raw `ping` 契約と合わない。
  - validation: MockWebSocket test で open 後に raw `ping` が送られることを確認する。
  - related Issue: Issue #450 / Issue #528 / Issue #579

- file: `test/worker.test.js`
  - hypothesis: #565 では `temporary` と `:empty` を固定したが、passive recovery が通常 UI に visible で出ないこと、heartbeat が存在することまでは固定していなかった。
  - risk if changed narrowly: 今後の reconnect 周辺修正で同じ文言が再び composer 下に出る。
  - validation: `setConnectionRecoveryStatus` が `data-recovery-message` を残し、passive では `visible: true` を使わないことを固定する。
  - related Issue: Issue #528 / Issue #579

- file: `test/dashboard-app-server-bridge.test.js`
  - hypothesis: bridge 側 heartbeat config と raw send 契約を test で固定しないと、後続修正で JSON message 化や heartbeat 消失が再発する。
  - risk if changed narrowly: production だけで idle close が再発する。
  - validation: `dashboard app-server bridge sends heartbeat pings on an open socket`。
  - related Issue: Issue #450 / Issue #528

## Hypothesis Retrospective

- expected: browser Dashboard と VPS app-server bridge が raw `ping` heartbeat を送り、idle close 由来の接続チラつきを減らせる。passive recovery message は通常 UI に出さず、debug truth と owner action required status は残せる。
- actual: `src/worker/runtime.js` に WebSocket heartbeat を追加し、`setConnectionRecoveryStatus()` が `data-recovery-message` / `data-passive-recovery-visible` を更新し、`options.visible !== true` の場合は composer status を空に戻すようにした。`scripts/run-dashboard-app-server-bridge.mjs` に raw `socket.send("ping")` heartbeat を追加した。
- mismatch: production VPS service log は未確認。heartbeat で idle close 要因を潰すが、別原因の close/error が残る可能性はある。
- lesson: Worker 側に ping/pong があっても、client/bridge 側が送らなければ live connection の維持にはならない。Dashboard Butler の通常チャット面では passive transport recovery を composer 下に出さず、owner action required のみ前面化する。
- should become RAG candidate: はい。Dashboard Butler WebSocket はブラウザと app-server bridge の両方で raw `ping` heartbeat を持ち、passive recovery は通常 composer 下に出さない。

## Verification Evidence

- Unit/Integration: `npm run build:worker && node --test test/dashboard-app-server-bridge.test.js test/worker.test.js --test-name-pattern "heartbeat|reconnects|args read|dashboard chat-first|dashboard chat"` passed。276 pass。
- Integration: `npm run verify:worker` passed。1107 tests / 1106 pass / 1 skipped、self-parity 33 routes / 33 operationIds、generated worker check pass。
- Manual: owner screenshot / mac Chrome report で `接続が切れました。履歴を確認しながら復帰しています。` が composer 下に点滅する production symptom を確認。
- Read-only live limit: VPS read-only SSH は `x85-131-245-163` hostname resolution failure、`85.131.245.163` publickey permission denied で未確認。root / helper / deploy / credential mutation は未実行。
- Evidence path/link: owner provided screenshots in thread. Repo evidence is code/test verification in this PR.

## Butler Completion Contract

- Primary owner surface: Dashboard Butler `/dashboard` 通常チャット。
- Fallback surface: なし。この PR は Custom GPT fallback ではなく Dashboard Butler の通常面を対象にする。
- Owner goal: 接続復帰中の内部状態表示が通常会話と入力操作を邪魔せず、WebSocket idle close で bridge が不安定化しにくいこと。
- Butler entrypoint: Dashboard Butler chat composer。
- Dashboard Butler natural-language path: Dashboard Butler の通常チャット入口で owner が自然文を送る経路を対象にし、内部 route や raw JSON は不要。
- Action Schema exposure: 不要。この PR は Dashboard Butler UI runtime と VPS app-server bridge の接続維持であり、Custom GPT Action Schema 中心ではない。
- Runtime path: `renderV2DashboardPage()` が生成する Dashboard chat JS の WebSocket lifecycle / `setConnectionRecoveryStatus()`、および `scripts/run-dashboard-app-server-bridge.mjs`。
- Runner/runtime truth: data attributes に reconnect attempt / websocket state / recovery message を保持。bridge heartbeat は test で raw `ping` として固定。
- Authority boundary: read/UI/connection maintenance のみ。deploy、credential mutation、permission mutation、destructive operation は実行しない。
- E2E evidence: local tests passed。production live E2E は deploy 後に必要。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: merge 後に必要。deploy には scoped passkey approval が必要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: deploy 後に必要。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate
- AGENTS.md Butler-First Operating Principle
- AGENTS.md Chief Butler Operating Principle
- AGENTS.md Conversation UX Contract
- AGENTS.md Evidence Discipline
- docs/butler/execution-queue-contract.md

## Out-of-scope but NOT implemented

- queue/timer 実行方式の再設計。
- VPS service restart / root helper execution。
- Issue #637 capability lifecycle close-readiness。
- Issue #565 の再オープン / 再クローズ判断。

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #528
- Execution ID: issue528-dashboard-websocket-heartbeat
- Goal: Dashboard Butler 通常チャット面で WebSocket idle close を抑え、passive reconnect status が入力欄下に点滅しないようにする。
