### PR TITLE
Issue #528 Dashboard WS auth sessionを接続

### DIFF
--- a/docs/development-strategy/issue-528-dashboard-ws-auth-session.md
+++ b/docs/development-strategy/issue-528-dashboard-ws-auth-session.md
@@ -1,0 +1,59 @@
+# Issue #528 Dashboard WebSocket auth session strategy
+
+## 完了体験
+
+オーナーが Dashboard Butler を passkey / Cloudflare Access で開いたら、通常チャットの WebSocket も同じ owner session で接続できる。画面だけ開いて `接続準備中です。送信できる状態になったら知らせます。` が居座る状態にしない。
+
+## VTDD 全体で進める部分
+
+Issue #528 の Dashboard Butler 通常チャット面、Issue #579 の reconnect/auth recovery、Issue #450 の live bridge 土台を進める。Issue #637 の VPS helper completion はこの PR では閉じない。
+
+## 設計
+
+Dashboard HTML を Cloudflare Access owner identity で許可できた時、Worker が短命の `dashboard_read_session` を memory に作り、`vtdd_dashboard_session` HttpOnly cookie を同じ response に付ける。以後、Dashboard chat WebSocket は既存の `authorizeDashboardPasskeySession()` で同じ cookie を読める。passkey で既に read session cookie がある場合は既存経路をそのまま使う。
+
+## 仮説
+
+原因仮説は、Dashboard page request は Cloudflare Access headers で通る一方、WebSocket handshake では同じ Access identity headers が届かず、passkey/read-session cookie も無い場合に `/v2/dashboard/chat/:threadId/ws` が `dashboard_auth_required` になること。結果として HTML は開くが WebSocket は `未接続` のまま reconnect し続ける。
+
+## 検証計画
+
+worker test で Cloudflare Access authenticated Dashboard HTML response が `vtdd_dashboard_session` cookie をセットすること、その cookie で dashboard chat WebSocket route が auth を通過して `426 websocket_upgrade_required` まで進むことを確認する。`npm run build:worker` と `npm run verify:worker` を通す。deploy 後に production Dashboard Butler で composer status が接続済み/通常状態へ進むことを確認する。
+
+## 改修見積もり
+
+- `src/worker/runtime.js`: Dashboard HTML response に Access-backed read session cookie を付与する helper、`html()` の extra headers 対応。
+- `test/worker.test.js`: Access-auth Dashboard が read session cookie を出す test、read session cookie で chat WebSocket auth を通る test。
+- `worker.js`: generated worker。
+
+## 既に通っている経路
+
+passkey verify 後に `dashboard_read_session` を作り、`vtdd_dashboard_session` cookie をセットする経路は既にある。Dashboard chat WebSocket は同 cookie を `authorizeDashboardPasskeySession()` で読める。
+
+## 未確認の境界
+
+Cloudflare Access が production WebSocket handshake に identity headers を入れるかは未確認。今回の修正は Access headers に頼らず、HTML response 時点で same-origin read session cookie を作ることで回避する。
+
+## 穴が出そうな箇所
+
+cookie を作れない memory provider 状態では fallback できない。passkey session cookie を無制限に増やすと memory が増えるため、既存 cookie がある場合は新規作成しない。WebSocket で高リスク操作を許可するわけではなく read session のみに限定する。
+
+## PR 前に確認すること
+
+`authorizeDashboardRequest()`、`authorizeDashboardPasskeySession()`、`buildDashboardPasskeySessionCookie()`、Dashboard page route、Dashboard chat WebSocket route、既存 dashboard auth tests を確認する。
+
+## 実装候補と捨てた案
+
+採用案は Dashboard HTML response で Access-backed read session cookie を作る案。捨てた案は WebSocket URL に token を埋め込む案、Cloudflare Access cookie/JWT を直接読む案、WebSocket route を無認証にする案、heartbeat をさらに調整する案。
+
+## merge 後に通す E2E
+
+production deploy 後に Dashboard Butler を開き、composer 下が `接続準備中です...` のまま増殖しないこと、`data-websocket-state` が接続済みに進むこと、通常メッセージ送信が同じ thread に保存されることを確認する。
+
+## 次の PR を増やさない理由
+
+この PR は Dashboard page auth と chat WebSocket auth の断絶だけを直す。VPS helper lifecycle、queue/timer 即時性、Butler 作戦図自動生成には踏み込まず、接続不能の root blocker を狭く閉じる。
+
+## 停止条件
+
+WebSocket に bearer token を露出する必要が出る、read session を高リスク approval と混同する、または Dashboard Butler 通常チャットではなく Custom GPT / Action Schema 側へ逸れる場合は停止する。

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -851,13 +851,24 @@ export default {
     }
 
     if (request.method === "GET" && (url.pathname === "/dashboard" || url.pathname === "/orchestrator")) {
+      const dashboardAuth = await authorizeDashboardRequest({
+        request,
+        env,
+        apiSuffix: url.pathname
+      });
+      const dashboardSessionHeaders = await createDashboardReadSessionCookieHeadersFromAuth({
+        request,
+        env,
+        dashboardAuth
+      });
       return html(
         200,
         await renderV2DashboardPage({
           runtimeOrigin: url.origin,
           url,
           dashboardEventStore: resolveDashboardEventStore(env)
-        })
+        }),
+        dashboardSessionHeaders
       );
     }
 
@@ -11818,6 +11829,35 @@ function buildDashboardPasskeySessionCookie(sessionRecord = {}) {
   ].join("; ");
 }
 
+async function createDashboardReadSessionCookieHeadersFromAuth({ request, env, dashboardAuth } = {}) {
+  if (dashboardAuth?.authType !== "cloudflare_access") {
+    return {};
+  }
+  if (parseCookieHeader(request?.headers?.get("cookie"))[DASHBOARD_PASSKEY_SESSION_COOKIE]) {
+    return {};
+  }
+  const provider = resolveMemoryProvider(env);
+  const validation = validateMemoryProvider(provider);
+  if (!validation.ok) {
+    return {};
+  }
+  const dashboardSession = createDashboardReadSessionRecord({
+    approvalGrant: {},
+    credentialId: normalizeText(dashboardAuth.subject) || "cloudflare_access",
+    userAgent: request?.headers?.get("user-agent")
+  });
+  if (!dashboardSession.ok) {
+    return {};
+  }
+  const storedDashboardSession = await provider.store(dashboardSession.record);
+  if (!storedDashboardSession?.ok) {
+    return {};
+  }
+  return {
+    "set-cookie": buildDashboardPasskeySessionCookie(dashboardSession.record)
+  };
+}
+
 function parseCookieHeader(value) {
   const cookies = {};
   for (const part of normalizeText(value).split(";")) {
@@ -15873,13 +15913,14 @@ function json(status, body, extraHeaders = {}) {
   });
 }
 
-function html(status, body) {
+function html(status, body, extraHeaders = {}) {
   return new Response(body, {
     status,
     headers: {
       "content-type": "text/html; charset=utf-8",
       "cache-control": "no-store, no-cache, must-revalidate, max-age=0",
-      pragma: "no-cache"
+      pragma: "no-cache",
+      ...extraHeaders
     }
   });
 }

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -1517,6 +1517,54 @@ test("worker serves v2 dashboard for allowed owner identity without exposing sec
   assert.equal(aliasBody.includes("WebSocket"), true);
 });
 
+test("worker issues dashboard read session cookie for Access-authenticated dashboard HTML", async () => {
+  const provider = createInMemoryMemoryProvider();
+  const response = await worker.fetch(
+    new Request("https://example.com/dashboard", {
+      headers: dashboardAccessHeaders
+    }),
+    {
+      ...dashboardAccessEnv,
+      MEMORY_PROVIDER: provider
+    }
+  );
+
+  assert.equal(response.status, 200);
+  assert.match(response.headers.get("set-cookie"), /vtdd_dashboard_session=dashboard-session%3A/);
+  assert.match(response.headers.get("set-cookie"), /HttpOnly/);
+  assert.match(response.headers.get("set-cookie"), /Max-Age=28800/);
+});
+
+test("worker accepts Access-backed dashboard read session cookie for dashboard chat WebSocket auth", async () => {
+  const provider = createInMemoryMemoryProvider();
+  const dashboardResponse = await worker.fetch(
+    new Request("https://example.com/dashboard", {
+      headers: dashboardAccessHeaders
+    }),
+    {
+      ...dashboardAccessEnv,
+      MEMORY_PROVIDER: provider
+    }
+  );
+  const cookie = dashboardResponse.headers.get("set-cookie")?.match(/vtdd_dashboard_session=[^;]+/)?.[0] || "";
+  assert.notEqual(cookie, "");
+
+  const rooms = createMockDashboardChatRoomNamespace();
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/dashboard/chat/dashboard-main-marushu-vtdd-v2-p/ws", {
+      headers: { cookie }
+    }),
+    {
+      MEMORY_PROVIDER: provider,
+      DASHBOARD_CHAT_ROOMS: rooms.namespace
+    }
+  );
+
+  assert.equal(response.status, 426);
+  const body = await response.json();
+  assert.equal(body.error, "websocket_upgrade_required");
+});
+
 test("served dashboard inline chat renderer executes decode, link, wrap, and copy behavior", async () => {
   const response = await worker.fetch(
     new Request("https://example.com/dashboard", {

--- a/worker.js
+++ b/worker.js
@@ -58182,13 +58182,24 @@ var runtime_default = {
       }
     }
     if (request.method === "GET" && (url2.pathname === "/dashboard" || url2.pathname === "/orchestrator")) {
+      const dashboardAuth = await authorizeDashboardRequest({
+        request,
+        env,
+        apiSuffix: url2.pathname
+      });
+      const dashboardSessionHeaders = await createDashboardReadSessionCookieHeadersFromAuth({
+        request,
+        env,
+        dashboardAuth
+      });
       return html(
         200,
         await renderV2DashboardPage({
           runtimeOrigin: url2.origin,
           url: url2,
           dashboardEventStore: resolveDashboardEventStore(env)
-        })
+        }),
+        dashboardSessionHeaders
       );
     }
     if (request.method === "GET" && url2.pathname === "/dashboard/github") {
@@ -67844,6 +67855,34 @@ function buildDashboardPasskeySessionCookie(sessionRecord = {}) {
     "SameSite=Lax"
   ].join("; ");
 }
+async function createDashboardReadSessionCookieHeadersFromAuth({ request, env, dashboardAuth } = {}) {
+  if (dashboardAuth?.authType !== "cloudflare_access") {
+    return {};
+  }
+  if (parseCookieHeader(request?.headers?.get("cookie"))[DASHBOARD_PASSKEY_SESSION_COOKIE]) {
+    return {};
+  }
+  const provider = resolveMemoryProvider(env);
+  const validation = validateMemoryProvider(provider);
+  if (!validation.ok) {
+    return {};
+  }
+  const dashboardSession = createDashboardReadSessionRecord({
+    approvalGrant: {},
+    credentialId: normalizeText32(dashboardAuth.subject) || "cloudflare_access",
+    userAgent: request?.headers?.get("user-agent")
+  });
+  if (!dashboardSession.ok) {
+    return {};
+  }
+  const storedDashboardSession = await provider.store(dashboardSession.record);
+  if (!storedDashboardSession?.ok) {
+    return {};
+  }
+  return {
+    "set-cookie": buildDashboardPasskeySessionCookie(dashboardSession.record)
+  };
+}
 function parseCookieHeader(value) {
   const cookies = {};
   for (const part of normalizeText32(value).split(";")) {
@@ -71696,13 +71735,14 @@ function json(status, body, extraHeaders = {}) {
     }
   });
 }
-function html(status, body) {
+function html(status, body, extraHeaders = {}) {
   return new Response(body, {
     status,
     headers: {
       "content-type": "text/html; charset=utf-8",
       "cache-control": "no-store, no-cache, must-revalidate, max-age=0",
-      pragma: "no-cache"
+      pragma: "no-cache",
+      ...extraHeaders
     }
   });
 }


### PR DESCRIPTION
## This PR satisfies Intent

Issue #528 / Issue #579 / Issue #450 の ROOT 修正です。Dashboard Butler の HTML は開けるのに通常チャット WebSocket が `dashboard_auth_required` で落ち、composer 下に `接続準備中です。送信できる状態になったら知らせます。` が居座る問題を修正します。

原因は、Cloudflare Access で Dashboard HTML を許可できても、WebSocket handshake に同じ owner identity が届かない場合があり、Dashboard chat WebSocket が認証を通過できないことです。この PR では Dashboard HTML response 時点で 8時間の `dashboard_read_session` cookie を発行し、同じ owner session で WebSocket auth を通せるようにします。

## Satisfied Success Criteria

- [x] Access-authenticated Dashboard HTML response が `vtdd_dashboard_session` cookie を発行する。
- [x] cookie は既存 Dashboard read session と同じ `Max-Age=28800` で、2分 approval grant ではない。
- [x] Access-backed read session cookie で dashboard chat WebSocket auth が通り、unauth ではなく `websocket_upgrade_required` まで進む。
- [x] Dashboard read session は高リスク approval grant としては使えない既存境界を維持する。
- [x] generated `worker.js` を更新し、worker verification を通した。

## Unsatisfied Success Criteria

- production live E2E は deploy 後に必要です。
- Issue #637 の VPS helper lifecycle completion はこの PR では進めません。

## Non-goal violations

None.

## 開発前作戦図

- 作戦図 evidence: docs/development-strategy/issue-528-dashboard-ws-auth-session.md
- 完了体験: オーナーが Dashboard Butler を passkey / Cloudflare Access で開いたら、通常チャットの WebSocket も同じ owner session で接続できる。画面だけ開いて `接続準備中です。送信できる状態になったら知らせます。` が居座る状態にしない。
- VTDD 全体で進める部分: Issue #528 の Dashboard Butler 通常チャット面、Issue #579 の reconnect/auth recovery、Issue #450 の live bridge 土台を進める。Issue #637 の VPS helper completion はこの PR では閉じない。
- 設計: Dashboard HTML を Cloudflare Access owner identity で許可できた時、Worker が短命ではない 8時間の `dashboard_read_session` を memory に作り、`vtdd_dashboard_session` HttpOnly cookie を同じ response に付ける。以後、Dashboard chat WebSocket は既存の `authorizeDashboardPasskeySession()` で同じ cookie を読める。
- 仮説: 原因仮説は、Dashboard page request は Cloudflare Access headers で通る一方、WebSocket handshake では同じ Access identity headers が届かず、passkey/read-session cookie も無い場合に `/v2/dashboard/chat/:threadId/ws` が `dashboard_auth_required` になること。
- 検証計画: worker test で Cloudflare Access authenticated Dashboard HTML response が `vtdd_dashboard_session` cookie をセットすること、その cookie で dashboard chat WebSocket route が auth を通過して `426 websocket_upgrade_required` まで進むことを確認する。`npm run build:worker` と `npm run verify:worker` を通す。
- 改修見積もり: `src/worker/runtime.js` の Dashboard HTML response / `html()` headers / read session cookie helper、`test/worker.test.js` の dashboard auth tests、generated `worker.js` を変更する。
- 既に通っている経路: passkey verify 後に `dashboard_read_session` を作り、`vtdd_dashboard_session` cookie をセットする経路は既にある。Dashboard chat WebSocket は同 cookie を `authorizeDashboardPasskeySession()` で読める。
- 未確認の境界: Cloudflare Access が production WebSocket handshake に identity headers を入れるかは未確認。今回の修正は Access headers に頼らず、HTML response 時点で same-origin read session cookie を作ることで回避する。
- 穴が出そうな箇所: cookie を作れない memory provider 状態では fallback できない。passkey session cookie を無制限に増やすと memory が増えるため、既存 cookie がある場合は新規作成しない。WebSocket で高リスク操作を許可するわけではなく read session のみに限定する。
- PR 前に確認すること: `authorizeDashboardRequest()`、`authorizeDashboardPasskeySession()`、`buildDashboardPasskeySessionCookie()`、Dashboard page route、Dashboard chat WebSocket route、既存 dashboard auth tests を確認する。
- 実装候補と捨てた案: 採用案は Dashboard HTML response で Access-backed read session cookie を作る案。捨てた案は WebSocket URL に token を埋め込む案、Cloudflare Access cookie/JWT を直接読む案、WebSocket route を無認証にする案、heartbeat をさらに調整する案。
- merge 後に通す E2E: production deploy 後の live E2E として Dashboard Butler を開き、composer 下が `接続準備中です...` のまま増殖しないこと、`data-websocket-state` が接続済みに進むこと、通常メッセージ送信が同じ thread に保存されることを確認する。
- 次の PR を増やさない理由: この PR は Dashboard page auth と chat WebSocket auth の断絶だけを直す。VPS helper lifecycle、queue/timer 即時性、Butler 作戦図自動生成には踏み込まず、接続不能の root blocker を狭く閉じる。
- 停止条件: WebSocket に bearer token を露出する必要が出る、read session を高リスク approval と混同する、または Dashboard Butler 通常チャットではなく Custom GPT / Action Schema 側へ逸れる場合は停止する。

## Dry-run Impact Report

- Target Issue: Issue #528
- Implementing Success Criteria: Dashboard HTML を開けた owner が同じ read session で Dashboard chat WebSocket auth も通れるようにする。
- Explicit Non-goals: Issue #637 close、VPS helper lifecycle、queue/timer 方式変更、2分再ログイン、deploy、credential / permission mutation、Issue close。
- Expected touched files/routes/workflows: `src/worker/runtime.js`、`test/worker.test.js`、`worker.js`、`docs/development-strategy/issue-528-dashboard-ws-auth-session.md`。
- Affected Issues: Issue #528 / Issue #579 / Issue #450。Issue #637 は Now だが、この PR では completion claim しない。
- Affected PRs: 新規 PR のみ。
- Affected workflows: worker build / tests / self parity / generated worker check。
- Affected runtime/operator surfaces: Dashboard Butler `/dashboard` HTML auth response、`/v2/dashboard/chat/:threadId/ws` WebSocket auth。
- What may break if we patch narrowly: read session を高リスク approval と混同すると危険なので、既存 test `worker gateway does not accept dashboard read session as high-risk approval grant` を維持する。
- Unknowns to investigate before coding: production Cloudflare Access が WebSocket handshake に identity headers を入れるかは未確認。
- Validation needed: worker verification、deploy 後の production Dashboard Butler live E2E。
- Stop condition: 2分 approval grant を通常 Dashboard session として使う必要が出る、または WebSocket URL に bearer token を露出する実装になった場合は停止。

## Execution Queue Delta

- Queue position before: `Now` は Issue #637。
- Preemption decision: ROOT。
- Queue delta: Issue #528 moves this Dashboard WebSocket auth session slice to a ROOT interruption; Issue #637 の completion claim は進めず、Dashboard Butler 通常チャットが使えない root blocker を先に修正する。
- Why this PR is next: Dashboard Butler の通常チャット WebSocket が認証で落ちると、Butler で今後の開発を進める入口そのものが壊れるため。
- Active Issues not downscoped: Active Issues は縮小しません。Issue #637 / #450 / #528 / #579 は未完了のまま残します。

## File / Line Hypotheses

- file: `src/worker/runtime.js`
  - hypothesis: `/dashboard` は Cloudflare Access headers で認証できるが、`/v2/dashboard/chat/:threadId/ws` handshake には同じ headers が届かず `dashboard_auth_required` になる。
  - risk if changed narrowly: read session cookie を高リスク approval と混同すると authorization boundary が壊れる。
  - validation: Access HTML response cookie test、WebSocket auth cookie test、full worker verify。
  - related Issue: Issue #528 / Issue #579 / Issue #450

- file: `test/worker.test.js`
  - hypothesis: 既存 tests は Dashboard HTML passkey session と unauth reject を見ていたが、Access-auth HTML が WebSocket 用 read session cookie を出すことを固定していなかった。
  - risk if changed narrowly: 画面は開くが通常チャット WebSocket だけ 401 になる regression が再発する。
  - validation: `worker issues dashboard read session cookie for Access-authenticated dashboard HTML` と `worker accepts Access-backed dashboard read session cookie for dashboard chat WebSocket auth`。
  - related Issue: Issue #528 / Issue #579

## Hypothesis Retrospective

- expected: Dashboard HTML response 時点で 8時間 read session cookie を発行すれば、WebSocket auth が Access handshake headers に依存せず通る。
- actual: `createDashboardReadSessionCookieHeadersFromAuth()` を追加し、Access-authenticated Dashboard HTML response に `vtdd_dashboard_session` を付けた。read session cookie で chat WebSocket route が unauth ではなく upgrade required まで進むことを test で固定した。
- mismatch: production live E2E は deploy 後に必要。
- lesson: Dashboard HTML と WebSocket は同じ owner-facing surface でも transport が違うため、HTML を開けることだけでは Butler chat live 接続の証跡にならない。
- should become RAG candidate: はい。Dashboard owner session は HTML / fetch / WebSocket をまたいで使える same-origin read session cookie として扱う。2分 approval grant を通常 session に使わない。

## Verification Evidence

- Unit/Integration: `npm run build:worker && node --test test/worker.test.js --test-name-pattern "dashboard read session cookie|dashboard chat WebSocket auth|allowed owner identity"` passed。243 pass。
- Integration: `npm run verify:worker` passed。1109 tests / 1108 pass / 1 skipped、self-parity 33 routes / 33 operationIds、generated worker check pass。
- Manual: production Dashboard after PR #709 deploy showed `接続準備中です。送信できる状態になったら知らせます。` with `data-websocket-state=未接続`; direct WebSocket probe returned `401 dashboard_auth_required`.
- Evidence path/link: docs/development-strategy/issue-528-dashboard-ws-auth-session.md

## Butler Completion Contract

- Primary owner surface: Dashboard Butler `/dashboard` 通常チャット。
- Fallback surface: なし。この PR は Custom GPT fallback ではなく Dashboard Butler の通常面を対象にする。
- Owner goal: Dashboard を開いた owner が、そのまま通常チャット WebSocket に接続できること。
- Butler entrypoint: Dashboard Butler 通常チャット入口。
- Dashboard Butler natural-language path: Dashboard Butler の通常チャット入口で owner が自然文を送る経路を対象にし、内部 route や raw JSON は不要。
- Action Schema exposure: 不要。この PR は Dashboard Butler runtime auth 接続であり、Custom GPT Action Schema 主経路ではない。
- Runtime path: `/dashboard` HTML response、`/v2/dashboard/chat/:threadId/ws` WebSocket auth、`authorizeDashboardRequest()`。
- Runner/runtime truth: worker tests と production symptom の `dashboard_auth_required` / `data-websocket-state=未接続`。
- Authority boundary: read session のみ。deploy、credential mutation、permission mutation、destructive operation は実行しない。
- E2E evidence: local tests passed。production live E2E は deploy 後に必要。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: merge 後に必要。deploy には scoped passkey approval が必要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: deploy 後に必要。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate
- AGENTS.md Butler-First Operating Principle
- AGENTS.md Chief Butler Operating Principle
- AGENTS.md Conversation UX Contract
- AGENTS.md Evidence Discipline
- docs/butler/execution-queue-contract.md

## Out-of-scope but NOT implemented

- 2分 approval grant を Dashboard session として使うこと。
- WebSocket URL bearer token。
- VPS helper lifecycle。
- queue/timer 即時性。

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #528
- Execution ID: issue528-dashboard-ws-auth-session
- Goal: Dashboard HTML auth と Dashboard chat WebSocket auth を同じ owner read session で接続する。
