### PR TITLE
Issue #528 stale Dashboard cookieを更新

### DIFF
--- a/docs/development-strategy/issue-528-refresh-ws-read-session.md
+++ b/docs/development-strategy/issue-528-refresh-ws-read-session.md
@@ -1,0 +1,42 @@
+# Issue #528 Dashboard WS read-session refresh 作戦図
+
+## 目的
+
+Dashboard Butler の HTML は Cloudflare Access で開けるが、通常チャット WebSocket が `dashboard_auth_required` で未接続になる状態を止める。
+
+## 原因仮説
+
+PR #710 は Access 認証済み Dashboard HTML response で `vtdd_dashboard_session` を発行するようにした。しかし既存 request に `vtdd_dashboard_session` cookie が存在するだけで新規発行をスキップしていた。
+
+本番ブラウザに古い、壊れた、または memory 側に存在しない cookie が残ると、Dashboard HTML は Access headers で通る一方、WebSocket handshake は Access headers なしで古い cookie だけを送り、`dashboard_auth_required` になる。
+
+## 改修方針
+
+`authorizeDashboardRequest()` が `cloudflare_access` で成功した場合は、request に Dashboard cookie が存在していても新しい 8時間 read-session cookie を発行する。
+
+この cookie は通常 Dashboard read session であり、高リスク approval grant ではない。2分 approval grant は使わない。
+
+## 対象ファイル
+
+- `src/worker/runtime.js`
+- `test/worker.test.js`
+- `worker.js`
+
+## 非ゴール
+
+- VPS helper / Issue #637 の実行経路変更
+- deploy、credential mutation、permission mutation、root/helper 実行
+- WebSocket URL token 化
+- Dashboard read session を high-risk approval grant として扱うこと
+
+## 検証
+
+- stale `vtdd_dashboard_session` cookie があっても Cloudflare Access owner identity が valid なら Dashboard HTML response で新しい `dashboard-session:` cookie を返すこと。
+- cookie の `Max-Age` が `28800` で、2分 approval grant ではないこと。
+- 既存の Access-backed read-session cookie で Dashboard chat WebSocket auth が `websocket_upgrade_required` まで進むこと。
+- `npm run build:worker`
+- `npm run verify:worker`
+
+## 停止条件
+
+Dashboard read session が高リスク approval と混同される、または owner-facing Dashboard Butler ではなく Custom GPT / Action Schema 側へ逸れる場合は停止する。

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -11833,9 +11833,6 @@ async function createDashboardReadSessionCookieHeadersFromAuth({ request, env, d
   if (dashboardAuth?.authType !== "cloudflare_access") {
     return {};
   }
-  if (parseCookieHeader(request?.headers?.get("cookie"))[DASHBOARD_PASSKEY_SESSION_COOKIE]) {
-    return {};
-  }
   const provider = resolveMemoryProvider(env);
   const validation = validateMemoryProvider(provider);
   if (!validation.ok) {

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -1114,6 +1114,7 @@ test("worker does not expose dashboard notification details before Access auth",
 });
 
 test("worker ignores stale dashboard passkey cookie when Cloudflare Access owner identity is valid", async () => {
+  const provider = createInMemoryMemoryProvider();
   const response = await worker.fetch(
     new Request("https://example.com/dashboard", {
       headers: {
@@ -1123,11 +1124,13 @@ test("worker ignores stale dashboard passkey cookie when Cloudflare Access owner
     }),
     {
       ...dashboardAccessEnv,
-      MEMORY_PROVIDER: createInMemoryMemoryProvider()
+      MEMORY_PROVIDER: provider
     }
   );
 
   assert.equal(response.status, 200);
+  assert.match(response.headers.get("set-cookie"), /vtdd_dashboard_session=dashboard-session%3A/);
+  assert.match(response.headers.get("set-cookie"), /Max-Age=28800/);
   const body = await response.text();
   assert.equal(body.includes("VTDD v2 Dashboard"), true);
   assert.equal(body.includes("dashboard session was not found"), false);

--- a/worker.js
+++ b/worker.js
@@ -67859,9 +67859,6 @@ async function createDashboardReadSessionCookieHeadersFromAuth({ request, env, d
   if (dashboardAuth?.authType !== "cloudflare_access") {
     return {};
   }
-  if (parseCookieHeader(request?.headers?.get("cookie"))[DASHBOARD_PASSKEY_SESSION_COOKIE]) {
-    return {};
-  }
   const provider = resolveMemoryProvider(env);
   const validation = validateMemoryProvider(provider);
   if (!validation.ok) {


### PR DESCRIPTION
## This PR satisfies Intent

Issue #528 の Dashboard Butler 通常チャット WebSocket 接続回復です。

PR #710 は Cloudflare Access authenticated Dashboard HTML response で `dashboard_read_session` cookie を発行する経路を追加しましたが、request に既存 `vtdd_dashboard_session` cookie があるだけで新規発行をスキップしていました。そのため、本番ブラウザに古い、壊れた、または memory 側に存在しない cookie が残ると、Dashboard HTML は Access headers で開ける一方、WebSocket handshake は古い cookie だけで `dashboard_auth_required` になり続けます。

この PR は `cloudflare_access` で Dashboard HTML が許可された場合、既存 cookie の有無にかかわらず新しい 8時間 read-session cookie を発行します。2分 approval grant は使いません。

## Satisfied Success Criteria

- [x] 古い `vtdd_dashboard_session` cookie が残っていても、Cloudflare Access owner identity が valid なら Dashboard HTML response が新しい `dashboard-session:` cookie を返す。
- [x] 新しい cookie は `Max-Age=28800` で、2分 approval grant ではない。
- [x] Access-backed read session cookie で Dashboard chat WebSocket auth が `websocket_upgrade_required` まで進む既存テストを維持する。
- [x] Dashboard read session は high-risk approval grant として使えない既存境界を維持する。
- [x] generated `worker.js` を更新し、worker verification を通した。

## Unsatisfied Success Criteria

- production live E2E は deploy 後に必要です。
- Issue #637 の VPS helper lifecycle completion はこの PR では進めません。

## Non-goal violations

None.

## 開発前作戦図

- 作戦図 evidence: docs/development-strategy/issue-528-refresh-ws-read-session.md
- 完了体験: owner が Dashboard Butler を iPhone / Mac Chrome で開いた時、古い Dashboard cookie が残っていても HTML response で read-session が更新され、通常チャット WebSocket が未接続のままにならない。
- VTDD 全体で進める部分: Issue #528 の Dashboard Butler 通常チャット面、Issue #579 の reconnect/auth recovery、Issue #450 の live bridge 土台を進める。Issue #637 は Now だが、この PR では helper lifecycle completion を主張しない。
- 設計: Dashboard Butler の owner-facing surface である `/dashboard` が `cloudflare_access` で成功した場合は、request cookie の存在だけでは信頼せず、新しい 8時間 read-session cookie を発行する。
- 仮説: 本番では古い/壊れた `vtdd_dashboard_session` が残り、#710 の guard が read-session refresh を止めた。HTML は Access headers で通るが、WebSocket は Access headers なしで古い cookie を送り、`dashboard_auth_required` になる。
- 検証計画: stale cookie + Access owner identity の Dashboard HTML test で `dashboard-session:` cookie と `Max-Age=28800` を assert する。既存 Access-backed WebSocket auth test と high-risk approval boundary test も通す。`npm run build:worker` と `npm run verify:worker` を通す。
- 改修見積もり: `src/worker/runtime.js` の `createDashboardReadSessionCookieHeadersFromAuth()`、`test/worker.test.js` の stale cookie test、generated `worker.js` を変更する。
- 既に通っている経路: passkey verify 後の Dashboard read session 発行、Access-backed read session cookie による chat WebSocket auth、Dashboard read session が high-risk approval grant にならない境界。
- 未確認の境界: production live E2E で iPhone / Mac Chrome の Dashboard WebSocket が接続済みに進むことは deploy 後に確認する。
- 穴が出そうな箇所: Cloudflare Access request ごとに read-session を更新するため、memory write 回数は増える。ただし通常 Dashboard HTML navigation 時のみで、秘密値や high-risk grant は保存しない。
- PR 前に確認すること: #710 の PR body、`createDashboardReadSessionCookieHeadersFromAuth()`、stale cookie test、Dashboard chat WebSocket auth test、high-risk approval boundary test。
- 実装候補と捨てた案: 採用案は Access-auth Dashboard HTML response で read-session を常に更新する案。捨てた案は WebSocket URL token、無認証 WebSocket、2分 approval grant reuse、Custom GPT 側回避。
- merge 後に通す E2E: production live E2E として Dashboard Butler を開き、composer status が `接続準備中です...` から通常送信可能状態へ進むこと、通常メッセージが同じ thread に保存されることを確認する。
- 次の PR を増やさない理由: 次の PR を増やさないため、#710 の未考慮 guard だけを直し、VPS helper、timer/queue 即時性、通知設計、作戦図自動生成には触れない。
- 停止条件: read session を high-risk approval と混同する必要が出る、WebSocket URL token が必要になる、または Dashboard Butler ではなく Custom GPT 主経路に逸れる場合は停止する。

## Dry-run Impact Report

- Target Issue: Issue #528
- Implementing Success Criteria: Dashboard HTML が Access で許可された時、古い cookie があっても WebSocket 用 read-session を refresh する。
- Explicit Non-goals: Issue #637 close、VPS helper lifecycle、queue/timer 方式変更、2分再ログイン、deploy、credential / permission mutation、Issue close。
- Expected touched files/routes/workflows: `src/worker/runtime.js`、`test/worker.test.js`、`worker.js`、`docs/development-strategy/issue-528-refresh-ws-read-session.md`。
- Affected Issues: Issue #528 / Issue #579 / Issue #450。Issue #637 は Now だが、この PR では completion claim しない。
- Affected PRs: PR #710 の不足修正。新規 PR のみ。
- Affected workflows: worker build / tests / self parity / generated worker check。
- Affected runtime/operator surfaces: Dashboard Butler `/dashboard` HTML auth response、`/v2/dashboard/chat/:threadId/ws` WebSocket auth。
- What may break if we patch narrowly: Access Dashboard HTML navigation ごとに read-session store が増える。高リスク approval には使えない境界を test で固定する。
- Unknowns to investigate before coding: production browser に stale cookie が残る具体的な時系列。今回は stale cookie が残っても回復する経路を固定する。
- Validation needed: worker verification、deploy 後の production Dashboard Butler live E2E。
- Stop condition: 2分 approval grant を通常 Dashboard session として使う必要が出る、または WebSocket URL に bearer token を露出する実装になった場合。

## Execution Queue Delta

- Queue position before: `Now` は Issue #637。
- Preemption decision: ROOT。
- Queue delta: Issue #528 の Dashboard WebSocket auth refresh slice を ROOT interruption として扱う。Issue #637 は縮小せず、Dashboard Butler 通常チャットが使えない入口 blocker を先に修正する。
- Why this PR is next: Dashboard Butler の通常チャット WebSocket が接続不能だと、Butler で今後の開発を進める入口が壊れたままになるため。
- Active Issues not downscoped: Active Issues は縮小しません。Issue #637 / #450 / #528 / #579 は未完了のまま残します。

## File / Line Hypotheses

- file: `src/worker/runtime.js`
  - hypothesis: `createDashboardReadSessionCookieHeadersFromAuth()` が既存 cookie の存在だけで refresh をスキップしていたため、古い cookie が WebSocket auth を落としていた。
  - risk if changed narrowly: memory write が増えるが、read session は high-risk approval ではない。
  - validation: stale cookie + Access test、Access-backed WebSocket auth test、full worker verify。
  - related Issue: Issue #528 / Issue #579 / Issue #450

- file: `test/worker.test.js`
  - hypothesis: stale cookie + valid Access owner identity で新しい read session cookie を返す assertion が不足していた。
  - risk if changed narrowly: HTML が開くことだけを success と誤認し、WebSocket auth regression を再発させる。
  - validation: `worker ignores stale dashboard passkey cookie when Cloudflare Access owner identity is valid`。
  - related Issue: Issue #528 / Issue #579

## Hypothesis Retrospective

- expected: request に古い Dashboard cookie が残っていても、Access owner identity が valid なら新しい 8時間 read-session cookie を返し、次の Dashboard chat WebSocket auth が通れる。
- actual: `createDashboardReadSessionCookieHeadersFromAuth()` の cookie-exists skip を削除し、stale cookie test で `dashboard-session:` cookie と `Max-Age=28800` を固定した。
- mismatch: production live E2E は deploy 後に必要。
- lesson: Dashboard HTML が owner-authenticated でも、WebSocket は同じ transport ではない。request cookie の存在だけを信頼して refresh を止めると、古い cookie が回復経路を塞ぐ。
- should become RAG candidate: はい。Dashboard Access auth は stale cookie を refresh する owner read-session minting point として扱う。

## Verification Evidence

- Targeted: `npm run build:worker && node --test test/worker.test.js --test-name-pattern "stale dashboard passkey cookie|dashboard read session cookie|dashboard chat WebSocket auth|gateway does not accept dashboard read session"` passed。243 pass。
- Full: `npm run verify:worker` passed。1109 tests / 1108 pass / 1 skipped、self-parity 33 routes / 33 operationIds、generated worker check pass。
- Evidence path/link: docs/development-strategy/issue-528-refresh-ws-read-session.md

## Butler Completion Contract

- Primary owner surface: Dashboard Butler `/dashboard` 通常チャット。
- Fallback surface: なし。この PR は Dashboard Butler の通常面を対象にする。
- Owner goal: Dashboard を開いた owner が、古い cookie に邪魔されず通常チャット WebSocket に接続できること。
- Butler entrypoint: Dashboard Butler 通常チャット入口。
- Dashboard Butler natural-language path: Dashboard Butler の通常チャット入口で owner が自然文を送る経路を対象にし、内部 route や raw JSON は不要。
- Action Schema exposure: 不要。この PR は Custom GPT ではなく Dashboard Butler runtime auth 接続。
- Runtime path: `/dashboard` HTML response、`/v2/dashboard/chat/:threadId/ws` WebSocket auth、`authorizeDashboardRequest()`。
- Runner/runtime truth: stale cookie test、Access-backed WebSocket auth test、production symptom の `data-websocket-state=未接続`。
- Authority boundary: read session のみ。deploy、credential mutation、permission mutation、destructive operation は実行しない。
- E2E evidence: local tests passed。production live E2E は deploy 後に必要。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: merge 後に必要。deploy には scoped passkey approval が必要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: deploy 後に必要。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate
- AGENTS.md Butler-First Operating Principle
- AGENTS.md Chief Butler Operating Principle
- AGENTS.md Conversation UX Contract
- AGENTS.md Evidence Discipline
- docs/butler/execution-queue-contract.md

## Out-of-scope but NOT implemented

- 2分 approval grant を Dashboard session として使うこと。
- WebSocket URL bearer token。
- VPS helper lifecycle。
- queue/timer 即時性。

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #528
- Execution ID: issue528-refresh-ws-read-session
- Goal: stale Dashboard cookie が残っていても Access-auth Dashboard HTML response で WebSocket 用 read session を更新する。
