### PR TITLE
Issue #528 Dashboard fallback ready表示を追加

### DIFF
--- a/docs/development-strategy/issue-528-dashboard-fallback-ready-status.md
+++ b/docs/development-strategy/issue-528-dashboard-fallback-ready-status.md
@@ -1,0 +1,40 @@
+# Issue #528 Dashboard fallback ready status 作戦図
+
+## 目的
+
+Dashboard Butler で WebSocket が未接続のままでも、HTTP fallback で履歴取得と送信が可能な状態なら「使えない」表示にしない。
+
+## 予測
+
+本番 deploy 後も Mac Chrome で `websocketState=未接続` だった。一方で Dashboard の submit button は disabled ではなく、既存コードには `sendOwnerMessageByHttp()` がある。
+
+コードを読むと、`refreshThread()` は HTTP で履歴取得に成功しても composer status を更新していない。そのため初期表示の `接続準備中です。送信できる状態になったら知らせます。` が残り続け、HTTP fallback が使える場合でも owner には Butler が使えないように見える。
+
+## 改修方針
+
+`refreshThread()` が成功した時、WebSocket が開いていなければ Dashboard status を「WebSocket は未接続ですが、送信できます。再接続を続けています。」へ更新する。あわせて `status.dataset.httpFallbackReady` を `true` にして、live E2E で UI truth を読めるようにする。
+
+履歴取得が失敗した時は `httpFallbackReady=false` に戻す。
+
+## 対象ファイル
+
+- `src/worker/runtime.js`
+- `test/worker.test.js`
+- `worker.js`
+
+## 非ゴール
+
+- WebSocket handshake の根本原因を隠すこと
+- WebSocket auth / Cloudflare Access / cookie 境界の追加変更
+- VPS helper / Issue #637 の実行経路変更
+- deploy、credential mutation、permission mutation、root/helper 実行
+
+## 検証
+
+- Dashboard HTML contract test で `setHttpFallbackReadyStatus()`、`httpFallbackReady=true/false`、owner-facing fallback-ready 文言を固定する。
+- `npm run build:worker`
+- `npm run verify:worker`
+
+## merge 後 E2E
+
+production deploy 後、Dashboard Butler を開き、WebSocket が未接続でも HTTP fallback が成功した場合は composer status が「送信できます」に変わること、通常メッセージ送信が保存されることを確認する。

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -14551,6 +14551,14 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         return Boolean(chatSocket && chatSocket.readyState === WebSocket.OPEN);
       }
 
+      function setHttpFallbackReadyStatus() {
+        status.dataset.httpFallbackReady = "true";
+        status.dataset.websocketState = describeChatSocketState();
+        if (!isChatSocketOpen() && !pendingOwnerSend) {
+          setStatus("WebSocket は未接続ですが、送信できます。再接続を続けています。", { temporary: true });
+        }
+      }
+
       function stopSocketHeartbeat() {
         if (!socketHeartbeatTimer) return;
         window.clearTimeout(socketHeartbeatTimer);
@@ -15334,6 +15342,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           });
           const body = await response.json().catch(() => ({}));
           if (!response.ok) {
+            status.dataset.httpFallbackReady = "false";
             if (isAuthExpiredResponse(response, body)) {
               lastRefreshFailure = "再ログインが必要";
               setDashboardSessionExpiredStatus();
@@ -15348,9 +15357,11 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
             lastRefreshFailure = "";
             renderThread(body.messages || [], { replace: true });
             releasePendingOwnerSendFromThread(body.messages || []);
+            setHttpFallbackReadyStatus();
             return { ok: true };
           }
         } catch {
+          status.dataset.httpFallbackReady = "false";
           lastRefreshFailure = "ネットワーク";
           setConnectionRecoveryStatus("履歴の再取得に失敗しました。入力は保持しています。");
           return { ok: false, network: true };

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -1276,6 +1276,7 @@ test("worker serves v2 dashboard for allowed owner identity without exposing sec
   assert.equal(body.includes("function scheduleReconnect()"), true);
   assert.equal(body.includes("function sendOwnerMessageByHttp("), true);
   assert.equal(body.includes("function isChatSocketOpen()"), true);
+  assert.equal(body.includes("function setHttpFallbackReadyStatus()"), true);
   assert.equal(body.includes("function describeChatSocketState()"), true);
   assert.equal(body.includes("function setConnectionRecoveryStatus("), true);
   assert.equal(body.includes("function buildReconnectStatus("), true);
@@ -1307,6 +1308,10 @@ test("worker serves v2 dashboard for allowed owner identity without exposing sec
   assert.equal(body.includes("WebSocket 未接続のため HTTP fallback で保存しました。再接続を続けています。"), false);
   assert.equal(body.includes("接続が不安定です。入力は保持したまま保存します。"), true);
   assert.equal(body.includes("接続が不安定なため保存しました。再接続を続けています。"), true);
+  assert.equal(body.includes("WebSocket は未接続ですが、送信できます。再接続を続けています。"), true);
+  assert.equal(body.includes('status.dataset.httpFallbackReady = "true"'), true);
+  assert.equal(body.includes('status.dataset.httpFallbackReady = "false"'), true);
+  assert.equal(body.includes("setHttpFallbackReadyStatus();"), true);
   assert.equal(body.includes("sendOwnerMessageByHttp(ownerPayload, clientMessageId)"), true);
   assert.equal(body.includes("refreshThread().then"), false);
   assert.equal(body.includes("履歴の再取得に失敗しました。入力は保持しています。"), true);

--- a/worker.js
+++ b/worker.js
@@ -70391,6 +70391,14 @@ async function renderV2DashboardPage({ runtimeOrigin, url: url2, dashboardEventS
         return Boolean(chatSocket && chatSocket.readyState === WebSocket.OPEN);
       }
 
+      function setHttpFallbackReadyStatus() {
+        status.dataset.httpFallbackReady = "true";
+        status.dataset.websocketState = describeChatSocketState();
+        if (!isChatSocketOpen() && !pendingOwnerSend) {
+          setStatus("WebSocket \u306F\u672A\u63A5\u7D9A\u3067\u3059\u304C\u3001\u9001\u4FE1\u3067\u304D\u307E\u3059\u3002\u518D\u63A5\u7D9A\u3092\u7D9A\u3051\u3066\u3044\u307E\u3059\u3002", { temporary: true });
+        }
+      }
+
       function stopSocketHeartbeat() {
         if (!socketHeartbeatTimer) return;
         window.clearTimeout(socketHeartbeatTimer);
@@ -71174,6 +71182,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url: url2, dashboardEventS
           });
           const body = await response.json().catch(() => ({}));
           if (!response.ok) {
+            status.dataset.httpFallbackReady = "false";
             if (isAuthExpiredResponse(response, body)) {
               lastRefreshFailure = "\u518D\u30ED\u30B0\u30A4\u30F3\u304C\u5FC5\u8981";
               setDashboardSessionExpiredStatus();
@@ -71188,9 +71197,11 @@ async function renderV2DashboardPage({ runtimeOrigin, url: url2, dashboardEventS
             lastRefreshFailure = "";
             renderThread(body.messages || [], { replace: true });
             releasePendingOwnerSendFromThread(body.messages || []);
+            setHttpFallbackReadyStatus();
             return { ok: true };
           }
         } catch {
+          status.dataset.httpFallbackReady = "false";
           lastRefreshFailure = "\u30CD\u30C3\u30C8\u30EF\u30FC\u30AF";
           setConnectionRecoveryStatus("\u5C65\u6B74\u306E\u518D\u53D6\u5F97\u306B\u5931\u6557\u3057\u307E\u3057\u305F\u3002\u5165\u529B\u306F\u4FDD\u6301\u3057\u3066\u3044\u307E\u3059\u3002");
           return { ok: false, network: true };


### PR DESCRIPTION
## This PR satisfies Intent

Issue #528 の Dashboard Butler 通常チャット回復です。

本番 deploy 後も WebSocket が未接続のままになる一方、既存コードには HTTP fallback の送信・履歴取得経路があります。問題は、`refreshThread()` が HTTP で履歴取得に成功しても composer status を更新せず、初期文言 `接続準備中です。送信できる状態になったら知らせます。` が残ることです。

この PR は WebSocket 未接続でも HTTP fallback が使える状態を owner-facing に表示し、Dashboard Butler が「使えない」ように見える状態を避けます。

## Satisfied Success Criteria

- [x] `refreshThread()` 成功時に `status.dataset.httpFallbackReady = "true"` を記録する。
- [x] WebSocket 未接続かつ pending send がない場合、`WebSocket は未接続ですが、送信できます。再接続を続けています。` を表示する。
- [x] 履歴取得失敗時は `httpFallbackReady=false` に戻す。
- [x] WebSocket 接続済みの通常経路、HTTP fallback 保存経路、passkey 再ログイン境界は維持する。
- [x] generated `worker.js` を更新し、worker verification を通した。

## Unsatisfied Success Criteria

- production live E2E は deploy 後に必要です。
- WebSocket handshake 自体の根本原因調査は残ります。この PR は「HTTP fallback が使えるのに使えないように見える」穴を閉じます。

## Non-goal violations

None.

## 開発前作戦図

- 作戦図 evidence: docs/development-strategy/issue-528-dashboard-fallback-ready-status.md
- 完了体験: Dashboard Butler の owner-facing 通常チャットで、WebSocket が未接続でも HTTP fallback で送信できる場合は「送信できます」と分かる。
- VTDD 全体で進める部分: Issue #528 の Dashboard Butler 通常チャット面、Issue #579 の reconnect/auth recovery、Issue #450 の live bridge 土台を進める。Issue #637 は縮小しない。
- 設計: Dashboard Butler の owner-facing surface である composer status に、HTTP fallback success を接続 truth として反映する。WebSocket の未接続 truth は dataset に残し、HTTP fallback ready も dataset に残す。
- 仮説: 原因仮説は、`refreshThread()` が成功しても status を更新しないため、初期文言 `接続準備中です...` が残り、実際には HTTP fallback があるのに owner には使えないように見えること。
- 検証計画: Dashboard HTML contract test で fallback-ready 文言、`setHttpFallbackReadyStatus()`、`httpFallbackReady=true/false` を固定する。`npm run build:worker` と `npm run verify:worker` を通す。
- 改修見積もり: `src/worker/runtime.js` の `refreshThread()` と新規 `setHttpFallbackReadyStatus()`、`test/worker.test.js` の Dashboard shell assertions、generated `worker.js` を変更する。
- 既に通っている経路: HTTP fallback の `sendOwnerMessageByHttp()`、Dashboard chat thread GET、pending send rollback、passkey session expired handling は既存で通っている。
- 未確認の境界: production live E2E で iPhone / Mac Chrome の composer status が fallback ready へ進むことは deploy 後に確認する。
- 穴が出そうな箇所: WebSocket handshake 自体は未解決なので、`websocketState=未接続` は残る可能性がある。ただし owner-facing には送信可能状態を見せる。
- PR 前に確認すること: `refreshThread()`、`sendOwnerMessageByHttp()`、`setConnectionRecoveryStatus()`、Dashboard shell test、PR #711 の live symptom を確認した。
- 実装候補と捨てた案: 採用案は HTTP fallback ready を status と dataset に反映する案。捨てた案は WebSocket auth をさらに推測で修正する案、文言だけ消す案、Custom GPT 側へ逃がす案。
- merge 後に通す E2E: production live E2E として Dashboard Butler を開き、WebSocket が未接続でも HTTP fallback が成功した場合は composer status が「送信できます」に変わること、通常メッセージ送信が保存されることを確認する。
- 次の PR を増やさない理由: 次の PR を増やさないため、今回は「HTTP fallback が使えるのに使えないように見える」穴だけを閉じ、WebSocket handshake 根本原因調査は別の観測課題として残す。
- 停止条件: WebSocket 根本原因を推測で追加修正する必要が出る、または Dashboard Butler ではなく Custom GPT 主経路に逸れる場合は停止する。

## Dry-run Impact Report

- Target Issue: Issue #528
- Implementing Success Criteria: Dashboard Butler で HTTP fallback が使える場合、WebSocket 未接続でも送信可能状態を owner-facing に表示する。
- Explicit Non-goals: Issue #637 close、VPS helper lifecycle、WebSocket handshake 根本修正、deploy、credential / permission mutation、Issue close。
- Expected touched files/routes/workflows: `src/worker/runtime.js`、`test/worker.test.js`、`worker.js`、`docs/development-strategy/issue-528-dashboard-fallback-ready-status.md`。
- Affected Issues: Issue #528 / Issue #579 / Issue #450。Issue #637 は Now だが、この PR では completion claim しない。
- Affected PRs: PR #711 後の production symptom に対する次 slice。新規 PR のみ。
- Affected workflows: worker build / tests / self parity / generated worker check。
- Affected runtime/operator surfaces: Dashboard Butler `/dashboard` composer status、Dashboard chat HTTP fallback readiness。
- What may break if we patch narrowly: WebSocket 未接続自体は残る可能性がある。HTTP fallback ready の表示が長く残りすぎないよう temporary status と dataset truth に分ける。
- Unknowns to investigate before coding: production WebSocket handshake の close/error 理由。この PR では推測修正しない。
- Validation needed: worker verification、deploy 後の production Dashboard Butler live E2E。
- Stop condition: WebSocket auth / Cloudflare Access / cookie をさらに推測で書き換える必要が出た場合。

## Execution Queue Delta

- Queue position before: `Now` は Issue #637。
- Preemption decision: ROOT。
- Queue delta: Issue #528 の Dashboard fallback-ready status slice を Root Blockers の短期 interruption として扱う。Issue #637 は縮小しない。
- Why this PR is next: Dashboard Butler が「接続準備中」のまま使えないように見えると、Butler を primary surface として進める入口が壊れるため。
- Active Issues not downscoped: Active Issues は縮小しません。Issue #637 / #450 / #528 / #579 は未完了のまま残します。

## File / Line Hypotheses

- file: `src/worker/runtime.js`
  - hypothesis: `refreshThread()` 成功時に status を更新しないため、HTTP fallback が使える状態でも初期接続準備文言が残る。
  - risk if changed narrowly: WebSocket 根本原因は残るが、owner-facing には「送信可能」を正しく示せる。
  - validation: Dashboard shell test、full worker verify。
  - related Issue: Issue #528 / Issue #579 / Issue #450

- file: `test/worker.test.js`
  - hypothesis: Dashboard shell contract test に fallback-ready status の assertion がないため、同じ UX regression が再発する。
  - risk if changed narrowly: HTML string test だけでは live WS の根本原因は証明しない。
  - validation: `worker serves dashboard chat-first shell with debug and ops surfaces isolated`。
  - related Issue: Issue #528 / Issue #579

## Hypothesis Retrospective

- expected: `refreshThread()` 成功時に HTTP fallback ready を status と dataset に反映すれば、WebSocket が未接続でも Dashboard Butler が送信可能であることを owner が理解できる。
- actual: `setHttpFallbackReadyStatus()` を追加し、`refreshThread()` success で `httpFallbackReady=true` と fallback-ready 文言を出すようにした。失敗時は `httpFallbackReady=false` に戻す。
- mismatch: production live E2E は deploy 後に必要。WebSocket handshake 根本原因はまだ未解決。
- lesson: WS live 接続と Dashboard chat 使用可能性は同一ではない。HTTP fallback success を接続 truth として UI に出さないと、使える経路があっても owner-facing には壊れて見える。
- should become RAG candidate: はい。Dashboard Butler は WebSocket 未接続時も HTTP fallback readiness を owner-facing status と runtime truth に出す。

## Verification Evidence

- Targeted: `npm run build:worker && node --test test/worker.test.js --test-name-pattern "dashboard chat-first shell"` passed。243 pass。
- Full: `npm run verify:worker` passed。1109 tests / 1108 pass / 1 skipped、self-parity 33 routes / 33 operationIds、generated worker check pass。
- Evidence path/link: docs/development-strategy/issue-528-dashboard-fallback-ready-status.md

## Butler Completion Contract

- Primary owner surface: Dashboard Butler `/dashboard` 通常チャット。
- Fallback surface: なし。この PR は Dashboard Butler の通常面を対象にする。
- Owner goal: WebSocket が未接続でも、HTTP fallback が使える時は Dashboard Butler から送信できると分かること。
- Butler entrypoint: Dashboard Butler 通常チャット入口。
- Dashboard Butler natural-language path: Dashboard Butler の通常チャット入口で owner が自然文を送る経路を対象にし、内部 route や raw JSON は不要。
- Action Schema exposure: 不要。この PR は Custom GPT ではなく Dashboard Butler runtime UI 接続。
- Runtime path: `/dashboard` HTML、Dashboard chat thread GET、Dashboard chat messages HTTP fallback。
- Runner/runtime truth: `status.dataset.httpFallbackReady`、`status.dataset.websocketState`、Dashboard shell test。
- Authority boundary: read/send UI status のみ。deploy、credential mutation、permission mutation、destructive operation は実行しない。
- E2E evidence: local tests passed。production live E2E は deploy 後に必要。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: merge 後に必要。deploy には scoped passkey approval が必要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: deploy 後に必要。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate
- AGENTS.md Butler-First Operating Principle
- AGENTS.md Chief Butler Operating Principle
- AGENTS.md Conversation UX Contract
- AGENTS.md Evidence Discipline
- docs/butler/execution-queue-contract.md

## Out-of-scope but NOT implemented

- WebSocket handshake root cause fix。
- 2分 approval grant を Dashboard session として使うこと。
- WebSocket URL bearer token。
- VPS helper lifecycle。

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #528
- Execution ID: issue528-dashboard-fallback-ready-status
- Goal: HTTP fallback が使える Dashboard Butler を未接続表示のままにしない。
