### PR TITLE
Issue #450 WebSocket reconnect中も composer をロックしない

### DIFF
--- a/docs/development-strategy/issue-450-reconnect-does-not-block-composer.md
+++ b/docs/development-strategy/issue-450-reconnect-does-not-block-composer.md
@@ -1,0 +1,26 @@
+# Issue #450 reconnect does not block composer
+
+## Root
+
+PR #713 removed the misleading HTTP fallback path, but kept the composer lock
+from the old send flow when WebSocket was disconnected. That made the owner
+press send, enter pending state, and then lose the ability to keep operating
+while reconnect waited.
+
+## Strategy
+
+- Do not restore HTTP fallback as a normal conversation path.
+- If WebSocket is disconnected at submit time, keep the text in the composer,
+  keep the composer editable, and store one pending owner message for reconnect.
+- When the WebSocket opens, send the pending owner message with the latest
+  composer text and the existing `clientMessageId` dedupe boundary.
+- If attachments are selected while disconnected, do not upload or queue them
+  silently. Keep the composer editable and ask for a resend after reconnect.
+
+## Verification
+
+- Dashboard shell contract test must prove the old locked-message copy is gone.
+- Dashboard shell contract test must prove the reconnect pending state does not
+  depend on HTTP fallback.
+- Production E2E after merge/deploy must confirm iPhone Dashboard Butler can
+  send again.

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -14615,11 +14615,25 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
 
       function sendPendingOwnerMessage(reason) {
         if (!pendingOwnerSend || !isChatSocketOpen()) return false;
+        if (pendingOwnerSend.queuedWhileDisconnected) {
+          const latestText = textarea.value.trim();
+          if (latestText) {
+            pendingOwnerSend.text = latestText;
+          }
+        }
+        const submitButton = form.querySelector("button[type='submit']");
+        if (submitButton) {
+          submitButton.disabled = true;
+          pendingOwnerSend.submitButton = submitButton;
+        }
+        setComposerLocked(true);
         try {
           chatSocket.send(JSON.stringify(buildOwnerPayload(pendingOwnerSend)));
           setStatus(reason || "接続しました。未送信の入力を送信しています。", { thinking: true });
           return true;
         } catch (error) {
+          setComposerLocked(false);
+          if (submitButton) submitButton.disabled = false;
           setStatus((error && error.message) || "WebSocket 送信に失敗しました。入力は保持し、再接続後に再送します。");
           scheduleReconnect();
           return false;
@@ -15508,15 +15522,50 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         }
         const submitButton = form.querySelector("button[type='submit']");
         persistDashboardDraft();
-        if (submitButton) submitButton.disabled = true;
-        setComposerLocked(true);
         const socketWasOpenAtSubmit = isChatSocketOpen();
         if (!socketWasOpenAtSubmit) {
-          setStatus("WebSocket 再接続中です。入力は保持し、接続後に送信します。", { thinking: true });
+          if (pendingMediaItems.length > 0) {
+            setStatus("WebSocket 再接続中です。入力と添付は保持しています。接続後にもう一度送信してください。");
+            scheduleReconnect();
+            textarea.focus({ preventScroll: true });
+            return;
+          }
+          if (pendingOwnerSend?.timeoutId) {
+            window.clearTimeout(pendingOwnerSend.timeoutId);
+          }
+          if (pendingOwnerSend?.clientMessageId) {
+            pendingSendRollbacks.delete(pendingOwnerSend.clientMessageId);
+          }
+          const clientMessageId = createClientMessageId();
+          pendingSendRollbacks.set(clientMessageId, []);
+          pendingOwnerSend = {
+            clientMessageId,
+            text,
+            mediaReferences: [],
+            submitButton: null,
+            queuedWhileDisconnected: true,
+            timeoutId: window.setTimeout(() => {
+              if (!pendingSendRollbacks.has(clientMessageId)) return;
+              if (isChatSocketOpen()) {
+                sendPendingOwnerMessage("送信確認が返らないため、同じ内容を再送しています。");
+              } else {
+                setStatus("WebSocket 再接続中です。入力は保持しています。接続後に自動送信します。");
+                scheduleReconnect();
+              }
+            }, 30000)
+          };
+          retryClientMessageId = clientMessageId;
+          setComposerLocked(false);
+          if (submitButton) submitButton.disabled = false;
+          setStatus("WebSocket 再接続中です。入力は保持しています。接続後に自動送信します。", { thinking: true });
           scheduleReconnect();
-        } else {
-          setStatus(pendingMediaItems.length > 0 ? "添付を保存してから送信しています" : "送信中です", { thinking: true });
+          textarea.focus({ preventScroll: true });
+          updateComposerReserve();
+          return;
         }
+        if (submitButton) submitButton.disabled = true;
+        setComposerLocked(true);
+        setStatus(pendingMediaItems.length > 0 ? "添付を保存してから送信しています" : "送信中です", { thinking: true });
         let mediaReferences = [];
         const clientMessageId = retryClientMessageId || createClientMessageId();
         try {
@@ -15545,7 +15594,9 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           }, 30000)
         };
         if (!isChatSocketOpen()) {
-          setStatus("WebSocket 再接続中です。入力は保持し、接続後に送信します。", { thinking: true });
+          setComposerLocked(false);
+          if (submitButton) submitButton.disabled = false;
+          setStatus("WebSocket 再接続中です。入力は保持しています。接続後に自動送信します。", { thinking: true });
           scheduleReconnect();
           textarea.focus({ preventScroll: true });
           updateComposerReserve();

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -1314,7 +1314,10 @@ test("worker serves v2 dashboard for allowed owner identity without exposing sec
   assert.equal(body.includes('status.dataset.httpFallbackReady = "false"'), false);
   assert.equal(body.includes("setHttpFallbackReadyStatus();"), false);
   assert.equal(body.includes("sendOwnerMessageByHttp(ownerPayload, clientMessageId)"), false);
-  assert.equal(body.includes("WebSocket 再接続中です。入力は保持し、接続後に送信します。"), true);
+  assert.equal(body.includes("WebSocket 再接続中です。入力は保持し、接続後に送信します。"), false);
+  assert.equal(body.includes("WebSocket 再接続中です。入力は保持しています。接続後に自動送信します。"), true);
+  assert.equal(body.includes("queuedWhileDisconnected: true"), true);
+  assert.equal(body.includes("setComposerLocked(false);"), true);
   assert.equal(body.includes("接続しました。未送信の入力を送信しています。"), true);
   assert.equal(body.includes("sendPendingOwnerMessage(\"接続しました。未送信の入力を送信しています。\")"), true);
   assert.equal(body.includes("refreshThread().then"), true);

--- a/worker.js
+++ b/worker.js
@@ -70455,11 +70455,25 @@ async function renderV2DashboardPage({ runtimeOrigin, url: url2, dashboardEventS
 
       function sendPendingOwnerMessage(reason) {
         if (!pendingOwnerSend || !isChatSocketOpen()) return false;
+        if (pendingOwnerSend.queuedWhileDisconnected) {
+          const latestText = textarea.value.trim();
+          if (latestText) {
+            pendingOwnerSend.text = latestText;
+          }
+        }
+        const submitButton = form.querySelector("button[type='submit']");
+        if (submitButton) {
+          submitButton.disabled = true;
+          pendingOwnerSend.submitButton = submitButton;
+        }
+        setComposerLocked(true);
         try {
           chatSocket.send(JSON.stringify(buildOwnerPayload(pendingOwnerSend)));
           setStatus(reason || "\u63A5\u7D9A\u3057\u307E\u3057\u305F\u3002\u672A\u9001\u4FE1\u306E\u5165\u529B\u3092\u9001\u4FE1\u3057\u3066\u3044\u307E\u3059\u3002", { thinking: true });
           return true;
         } catch (error) {
+          setComposerLocked(false);
+          if (submitButton) submitButton.disabled = false;
           setStatus((error && error.message) || "WebSocket \u9001\u4FE1\u306B\u5931\u6557\u3057\u307E\u3057\u305F\u3002\u5165\u529B\u306F\u4FDD\u6301\u3057\u3001\u518D\u63A5\u7D9A\u5F8C\u306B\u518D\u9001\u3057\u307E\u3059\u3002");
           scheduleReconnect();
           return false;
@@ -71348,15 +71362,50 @@ async function renderV2DashboardPage({ runtimeOrigin, url: url2, dashboardEventS
         }
         const submitButton = form.querySelector("button[type='submit']");
         persistDashboardDraft();
-        if (submitButton) submitButton.disabled = true;
-        setComposerLocked(true);
         const socketWasOpenAtSubmit = isChatSocketOpen();
         if (!socketWasOpenAtSubmit) {
-          setStatus("WebSocket \u518D\u63A5\u7D9A\u4E2D\u3067\u3059\u3002\u5165\u529B\u306F\u4FDD\u6301\u3057\u3001\u63A5\u7D9A\u5F8C\u306B\u9001\u4FE1\u3057\u307E\u3059\u3002", { thinking: true });
+          if (pendingMediaItems.length > 0) {
+            setStatus("WebSocket \u518D\u63A5\u7D9A\u4E2D\u3067\u3059\u3002\u5165\u529B\u3068\u6DFB\u4ED8\u306F\u4FDD\u6301\u3057\u3066\u3044\u307E\u3059\u3002\u63A5\u7D9A\u5F8C\u306B\u3082\u3046\u4E00\u5EA6\u9001\u4FE1\u3057\u3066\u304F\u3060\u3055\u3044\u3002");
+            scheduleReconnect();
+            textarea.focus({ preventScroll: true });
+            return;
+          }
+          if (pendingOwnerSend?.timeoutId) {
+            window.clearTimeout(pendingOwnerSend.timeoutId);
+          }
+          if (pendingOwnerSend?.clientMessageId) {
+            pendingSendRollbacks.delete(pendingOwnerSend.clientMessageId);
+          }
+          const clientMessageId = createClientMessageId();
+          pendingSendRollbacks.set(clientMessageId, []);
+          pendingOwnerSend = {
+            clientMessageId,
+            text,
+            mediaReferences: [],
+            submitButton: null,
+            queuedWhileDisconnected: true,
+            timeoutId: window.setTimeout(() => {
+              if (!pendingSendRollbacks.has(clientMessageId)) return;
+              if (isChatSocketOpen()) {
+                sendPendingOwnerMessage("\u9001\u4FE1\u78BA\u8A8D\u304C\u8FD4\u3089\u306A\u3044\u305F\u3081\u3001\u540C\u3058\u5185\u5BB9\u3092\u518D\u9001\u3057\u3066\u3044\u307E\u3059\u3002");
+              } else {
+                setStatus("WebSocket \u518D\u63A5\u7D9A\u4E2D\u3067\u3059\u3002\u5165\u529B\u306F\u4FDD\u6301\u3057\u3066\u3044\u307E\u3059\u3002\u63A5\u7D9A\u5F8C\u306B\u81EA\u52D5\u9001\u4FE1\u3057\u307E\u3059\u3002");
+                scheduleReconnect();
+              }
+            }, 30000)
+          };
+          retryClientMessageId = clientMessageId;
+          setComposerLocked(false);
+          if (submitButton) submitButton.disabled = false;
+          setStatus("WebSocket \u518D\u63A5\u7D9A\u4E2D\u3067\u3059\u3002\u5165\u529B\u306F\u4FDD\u6301\u3057\u3066\u3044\u307E\u3059\u3002\u63A5\u7D9A\u5F8C\u306B\u81EA\u52D5\u9001\u4FE1\u3057\u307E\u3059\u3002", { thinking: true });
           scheduleReconnect();
-        } else {
-          setStatus(pendingMediaItems.length > 0 ? "\u6DFB\u4ED8\u3092\u4FDD\u5B58\u3057\u3066\u304B\u3089\u9001\u4FE1\u3057\u3066\u3044\u307E\u3059" : "\u9001\u4FE1\u4E2D\u3067\u3059", { thinking: true });
+          textarea.focus({ preventScroll: true });
+          updateComposerReserve();
+          return;
         }
+        if (submitButton) submitButton.disabled = true;
+        setComposerLocked(true);
+        setStatus(pendingMediaItems.length > 0 ? "\u6DFB\u4ED8\u3092\u4FDD\u5B58\u3057\u3066\u304B\u3089\u9001\u4FE1\u3057\u3066\u3044\u307E\u3059" : "\u9001\u4FE1\u4E2D\u3067\u3059", { thinking: true });
         let mediaReferences = [];
         const clientMessageId = retryClientMessageId || createClientMessageId();
         try {
@@ -71385,7 +71434,9 @@ async function renderV2DashboardPage({ runtimeOrigin, url: url2, dashboardEventS
           }, 30000)
         };
         if (!isChatSocketOpen()) {
-          setStatus("WebSocket \u518D\u63A5\u7D9A\u4E2D\u3067\u3059\u3002\u5165\u529B\u306F\u4FDD\u6301\u3057\u3001\u63A5\u7D9A\u5F8C\u306B\u9001\u4FE1\u3057\u307E\u3059\u3002", { thinking: true });
+          setComposerLocked(false);
+          if (submitButton) submitButton.disabled = false;
+          setStatus("WebSocket \u518D\u63A5\u7D9A\u4E2D\u3067\u3059\u3002\u5165\u529B\u306F\u4FDD\u6301\u3057\u3066\u3044\u307E\u3059\u3002\u63A5\u7D9A\u5F8C\u306B\u81EA\u52D5\u9001\u4FE1\u3057\u307E\u3059\u3002", { thinking: true });
           scheduleReconnect();
           textarea.focus({ preventScroll: true });
           updateComposerReserve();


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #450 / #528 / #654 の ROOT regression として、PR #713 後に WebSocket 未接続時の Dashboard Butler composer がロックされ、送信不能に見える問題を修正します。
- 通常会話の主経路は WebSocket のまま維持し、HTTP fallback は復活させません。

## Satisfied Success Criteria

- WebSocket 未接続時に submit しても `setComposerLocked(true)` に入らず、入力欄と送信ボタンを操作可能なまま保持します。
- 未接続時の text-only submit は `pendingOwnerSend` に保持し、WebSocket open 後に同じ `clientMessageId` で自動送信します。
- reconnect 待ち中に owner が入力を編集した場合、WebSocket open 時点の最新 composer text を送ります。
- 添付つき未接続 submit は upload せず、入力と添付を保持して再送を促します。

## Unsatisfied Success Criteria

- production iPhone Dashboard Butler live E2E は未実施です。merge / deploy 後に実機で送信できることを確認します。

## Non-goal violations

None.

## 開発前作戦図

- 作戦図 evidence: `docs/development-strategy/issue-450-reconnect-does-not-block-composer.md`
- 完了体験: Dashboard Butler で WebSocket が切れていても、owner は入力欄を失わず、送信ボタン操作後も編集を続けられます。接続復帰時に pending text が送られます。
- VTDD 全体で進める部分: Dashboard Butler normal chat の owner-facing 操作不能 regression を止める部分です。
- 設計: WebSocket 未接続 submit は upload / lock / HTTP fallback に入れず、text pending と draft persistence に寄せます。WebSocket open 後に `sendPendingOwnerMessage()` が最新 text を送ります。
- 仮説: 原因は PR #713 の「HTTP fallback を外す」修正で、旧 send flow の composer lock を未接続時にも残したことです。
- 検証計画: Dashboard shell contract test で旧文言が消え、新しい reconnect pending 文言と `queuedWhileDisconnected` があることを固定し、`npm run verify:worker` を通します。
- 改修見積もり: `src/worker/runtime.js` の `sendPendingOwnerMessage()` と form submit handler、生成物 `worker.js`、`test/worker.test.js`、作戦図 doc を変更します。
- 既に通っている経路: WebSocket open 後の `owner_message` と `clientMessageId` dedupe は PR #713 と既存 `DashboardChatRoom` tests で確認済みです。
- 未確認の境界: production iPhone PWA / Safari WebSocket close の実原因は未確認です。本PRは操作不能 regression の解除に限定します。
- 穴が出そうな箇所: 添付つき disconnected submit を勝手に upload / queue すると media と draft の整合が崩れるため、今回は保持して再送案内に留めます。
- PR 前に確認すること: `src/worker/runtime.js` submit handler、PR #713 の差分、targeted worker tests、full verify。
- 実装候補と捨てた案: HTTP fallback 復活は捨てます。VPS Codex CLI へ届かない persistence を通常会話送信に見せる regression を再発させるためです。
- merge 後に通す E2E: production iPhone Dashboard Butler live E2E テストで、未接続表示後も入力欄が操作でき、接続復帰後に通常メッセージを送れることを確認します。
- 次の PR を増やさない理由: このPRは PR #713 の直接副作用だけを戻します。WebSocket close root cause は別の調査対象で、ここに混ぜません。
- 停止条件: HTTP fallback を通常会話の送信経路に戻す必要が出た場合、または添付 outbox を設計する必要が出た場合は停止します。

## Dry-run Impact Report

- Target Issue: Issue #450 / #528 / #654
- Implementing Success Criteria: WebSocket 未接続時に Dashboard Butler composer をロックせず、text pending を reconnect 後に送れるようにする。
- Explicit Non-goals: HTTP fallback 復活、deploy、VPS helper、passkey、notification、Issue close。
- Expected touched files/routes/workflows: `src/worker/runtime.js`, `worker.js`, `test/worker.test.js`, `docs/development-strategy/issue-450-reconnect-does-not-block-composer.md`
- Affected Issues: Issue #450, Issue #528, Issue #654。
- Affected PRs: PR #713 の直接補正です。
- Affected workflows: GitHub Actions workflow は未変更です。worker build / test のみ対象です。
- Affected runtime/operator surfaces: Dashboard Butler normal chat composer。operator / deploy / Action Schema は未変更です。
- What may break if we patch narrowly: composer lock だけを外して pending を持たないと、reconnect 後の自動送信ができません。
- Unknowns to investigate before coding: 未接続 submit がどの順序で lock / pending / reconnect に入るか、添付あり submit を同じ扱いにしてよいか。
- Validation needed: targeted worker tests、`npm run verify:worker`、merge / deploy 後の iPhone live E2E。
- Stop condition: 通常会話の代替送信として HTTP persistence を復活させる判断が必要になった場合。

## Execution Queue Delta

- Queue position before: `Now` は Dashboard Butler normal chat が実機で送信不能になった ROOT blocker です。
- Preemption decision: ROOT。#637 などの他 E2E より先に、Butler の通常チャット操作不能を止めます。
- Queue delta: Issue #450 / Issue #654 の Queue を、PR #713 後の composer lock regression 修正へ移します。
- Why this PR is next: Butler が送信できなければ、Butler-first 開発の入口が成立しません。
- Active Issues not downscoped: Active Issues は縮小しません。本PRで扱わない WebSocket close root cause、通知、VPS helper、passkey は未完了として残します。

## File / Line Hypotheses

- file: `src/worker/runtime.js`
  - hypothesis: form submit handler が WebSocket 未接続時にも `setComposerLocked(true)` と submit disabled を実行し、reconnect 待ちの間 owner 操作を止めていました。
  - risk if changed narrowly: lock だけ外して pending を消すと、reconnect 後の resend が失われます。
  - validation: Dashboard shell contract test と `npm run verify:worker`。
  - related Issue: Issue #450 / #654

## Hypothesis Retrospective

- expected: 未接続 submit を lock せず text pending に変えれば、owner は送信不能画面に閉じ込められません。
- actual: 未接続 submit は composer を editable のまま保ち、pending を reconnect 後に送る実装にしました。
- mismatch: WebSocket close の根本原因はこのPRでは未解決です。
- lesson: 「fallback を外す」と「入力欄を殺さない」は別の成功条件として扱う必要があります。
- should become RAG candidate: はい。Dashboard Butler 通常チャットの未接続時 UX は HTTP fallback ではなく editable pending outbox として扱う。

## Verification Evidence

- Unit: `node --test test/worker.test.js --test-name-pattern "dashboard chat-first shell|DashboardChatRoom replays pending WebSocket owner messages|dedupes retried owner sends|maps app-server replies"`
- Integration: `npm run verify:worker`
- E2E: 未実施。merge / deploy 後に production iPhone Dashboard Butler live E2E が必要です。
- Manual: `rg` で HTTP fallback 送信文言が runtime/generated worker にないことを確認。
- Evidence path/link: `docs/development-strategy/issue-450-reconnect-does-not-block-composer.md`

## Butler Completion Contract

- Primary owner surface: Dashboard Butler。
- Fallback surface: Custom GPT は fallback surface として残しますが、このPRの主経路ではありません。
- Owner goal: Dashboard Butler 通常チャットで、WebSocket 未接続時も入力欄が操作不能にならないようにする。
- Butler entrypoint: Dashboard Butler 通常チャット入力欄。
- Dashboard Butler natural-language path: Dashboard Butler の自然文 / 通常チャット入口で owner message を受け、WebSocket 接続復帰後に同じ thread へ送信します。
- Action Schema exposure: Custom GPT fallback 用の露出は未変更です。このPRの主経路ではありません。
- Runtime path: `renderV2DashboardPage()` submit handler -> pending owner message -> WebSocket open -> `sendPendingOwnerMessage()` -> `DashboardChatRoom.acceptOwnerMessage()`。
- Runner/runtime truth: local worker tests と generated worker verification で UI contract を確認しました。production runtime truth は merge / deploy 後に確認します。
- Authority boundary: 新しい high-risk authority は追加しません。passkey / deploy / credential mutation は未実行です。
- E2E evidence: 未実施。production Dashboard Butler live E2E は merge / deploy 後の残作業です。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: merge 後に必要です。このPRでは未実行です。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: merge / deploy 後に必要です。

## Related Constitution Rules

- Butler-first: owner-facing 通常会話は Dashboard Butler で操作可能でなければならない。
- Drift Stop Protocol: runtime edit 前に Issue / Success Criteria / Non-goals / touched files / validation を固定しました。
- Evidence Discipline: production E2E 未実施のため completion claim はしません。

## Out-of-scope but NOT implemented

- WebSocket close の根本原因調査。
- 添付 outbox の完全設計。
- HTTP persistence fallback 復活。
- production iPhone live E2E。

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #450 / Issue #528 / Issue #654
- Execution ID: dashboard-butler-reconnect-does-not-block-composer
- Goal: Dashboard Butler composer remains usable while WebSocket reconnects
