### PR TITLE
vps: runner queue投稿後に即時wakeupする

### DIFF
--- a/docs/butler/remote-codex-cli-executor.md
+++ b/docs/butler/remote-codex-cli-executor.md
@@ -136,6 +136,10 @@ not require a public inbound VPS API:
   known, and a short redacted stderr summary
 - Butler reads the queue comment, runner state/event comments, target branch,
   and target PR as GitHub runtime truth
+- after posting a bounded `vps_runner` queue comment, Dashboard Butler may send
+  a best-effort wakeup request to the connected Dashboard app-server bridge so
+  the user-owned VPS can run `systemctl --user start vtdd-vps-runner.service`
+  immediately instead of waiting for the next timer tick
 - queued/requested is not implementation success; if no runner pickup or
   branch/PR evidence appears after the grace period, progress becomes blocked
   with `vps_runner_pickup_not_observed`
@@ -318,6 +322,27 @@ The script is suitable for a later systemd timer/service wrapper, but systemd
 installation, Codex login, token placement, and credential storage remain
 user-owned runtime setup. They must not be represented as shared VTDD
 infrastructure or embedded in this public/core repository.
+
+### Immediate Wakeup and Timer Fallback
+
+The systemd timer remains the recovery fallback. Operators should keep
+`vtdd-vps-runner.timer` enabled so a missed wakeup, disconnected bridge, or
+temporary Worker/DO delivery failure does not strand queued work.
+
+When Dashboard Butler has a live app-server bridge for the same dashboard
+thread, the Worker can send a bounded `runner_wakeup_requested` message after a
+`vps_runner` queue comment is successfully posted. The bridge is allowed to run
+only this fixed non-root command:
+
+```sh
+systemctl --user start vtdd-vps-runner.service
+```
+
+The wakeup request does not carry arbitrary shell, command arguments, sudo,
+root-owned helper input, deploy authority, merge authority, or credential
+mutation authority. It is a latency improvement only. If it fails, the response
+must keep the GitHub queue state as `queued` and report the fallback as
+`vtdd-vps-runner.timer`.
 
 ## Optional API-backed Runner
 

--- a/docs/development-strategy/issue-717-vps-runner-wakeup.md
+++ b/docs/development-strategy/issue-717-vps-runner-wakeup.md
@@ -1,0 +1,64 @@
+# Issue #717: VPS runner immediate wakeup
+
+## Owner-facing completion experience
+
+Dashboard Butler から `vps_runner` の開発実行を投げたあと、州平が次の
+1分 timer tick を待たなくても VPS runner が起動し始める。
+
+GitHub queue comment は従来通り runtime truth として残す。即時 wakeup は
+latency 改善だけを担当し、失敗しても `vtdd-vps-runner.timer` が fallback
+として回収する。
+
+## Scope
+
+- Worker の `/v2/action/execute` が `vps_runner` queue comment 投稿に成功した後、
+  `dashboardThreadId` がある場合だけ DashboardChatRoom に wakeup を依頼する。
+- DashboardChatRoom は同じ thread の app-server bridge socket にだけ
+  `runner_wakeup_requested` を送る。
+- Dashboard app-server bridge は固定の user systemd command だけを実行する。
+
+## Authority boundary
+
+Allowed fixed command:
+
+```sh
+systemctl --user start vtdd-vps-runner.service
+```
+
+This slice must not add:
+
+- arbitrary shell execution
+- payload-controlled command or arguments
+- root or sudo execution
+- VPS privileged maintenance helper execution
+- deploy authority
+- merge or issue-close authority
+- credential mutation
+
+## Hypothesis
+
+Upcoming VTDD work will repeatedly use the VPS runner. A maximum one minute
+polling delay is small once, but costly when repeated across many owner turns.
+Keeping the timer as fallback while adding immediate wakeup should reduce
+perceived waiting without weakening GitHub queue truth or authority boundaries.
+
+## Validation plan
+
+- Bridge command test proves the app-server bridge uses only the fixed user
+  systemd command with `shell:false`.
+- Worker dispatch test proves `vps_runner` queue dispatch reports wakeup status.
+- DashboardChatRoom test proves wakeup is sent only to app-server bridge sockets.
+- `npm run build:worker` regenerates `worker.js`.
+- `npm run check:generated-worker` proves generated worker parity.
+- Production E2E after merge/deploy should confirm queue-to-pickup lead time.
+
+## Stop conditions
+
+Stop if implementation requires:
+
+- public inbound VPS API
+- root/sudo authority
+- arbitrary command execution from Worker payload
+- skipping GitHub queue comment truth
+- claiming production lead-time improvement without live evidence
+

--- a/scripts/run-dashboard-app-server-bridge.mjs
+++ b/scripts/run-dashboard-app-server-bridge.mjs
@@ -196,6 +196,96 @@ export async function materializeDashboardMediaReferences({
   );
 }
 
+export function buildVpsRunnerWakeupCommand() {
+  return {
+    command: "systemctl",
+    args: ["--user", "start", "vtdd-vps-runner.service"],
+    shell: false
+  };
+}
+
+export async function executeVpsRunnerWakeup({
+  request = {},
+  spawnImpl = spawn,
+  now = () => new Date().toISOString()
+} = {}) {
+  const command = buildVpsRunnerWakeupCommand();
+  const startedAt = now();
+  return new Promise((resolve) => {
+    let stdout = "";
+    let stderr = "";
+    let child;
+    try {
+      child = spawnImpl(command.command, command.args, {
+        shell: false,
+        stdio: ["ignore", "pipe", "pipe"]
+      });
+    } catch (error) {
+      resolve({
+        type: "runner_wakeup_result",
+        schema: DEFAULT_SCHEMA,
+        threadId: normalizeBridgeText(request.threadId),
+        requestId: normalizeBridgeText(request.requestId),
+        executionId: normalizeBridgeText(request.executionId),
+        status: "failed",
+        attempted: true,
+        fallback: "vtdd-vps-runner.timer",
+        command,
+        startedAt,
+        completedAt: now(),
+        exitCode: null,
+        reason: normalizeBridgeText(error?.message || "failed to start vtdd-vps-runner.service").slice(0, 240)
+      });
+      return;
+    }
+    child.stdout?.on("data", (chunk) => {
+      stdout += String(chunk || "");
+    });
+    child.stderr?.on("data", (chunk) => {
+      stderr += String(chunk || "");
+    });
+    child.on("error", (error) => {
+      resolve({
+        type: "runner_wakeup_result",
+        schema: DEFAULT_SCHEMA,
+        threadId: normalizeBridgeText(request.threadId),
+        requestId: normalizeBridgeText(request.requestId),
+        executionId: normalizeBridgeText(request.executionId),
+        status: "failed",
+        attempted: true,
+        fallback: "vtdd-vps-runner.timer",
+        command,
+        startedAt,
+        completedAt: now(),
+        exitCode: null,
+        reason: normalizeBridgeText(error?.message || "failed to start vtdd-vps-runner.service").slice(0, 240)
+      });
+    });
+    child.on("close", (exitCode) => {
+      const normalizedExitCode = Number.isInteger(exitCode) ? exitCode : null;
+      const reason = normalizeBridgeText(stderr || stdout);
+      resolve({
+        type: "runner_wakeup_result",
+        schema: DEFAULT_SCHEMA,
+        threadId: normalizeBridgeText(request.threadId),
+        requestId: normalizeBridgeText(request.requestId),
+        executionId: normalizeBridgeText(request.executionId),
+        repository: normalizeBridgeText(request.repository),
+        issueNumber: Number(request.issueNumber || 0) || null,
+        queueCommentUrl: normalizeBridgeText(request.queueCommentUrl),
+        status: normalizedExitCode === 0 ? "started" : "failed",
+        attempted: true,
+        fallback: "vtdd-vps-runner.timer",
+        command,
+        startedAt,
+        completedAt: now(),
+        exitCode: normalizedExitCode,
+        reason: reason ? reason.slice(0, 240) : null
+      });
+    });
+  });
+}
+
 async function materializeDashboardMediaReference({ reference, runtimeUrl, token, fetchImpl, tmpRoot }) {
   const normalized = normalizeDashboardMediaReferenceForBridge(reference);
   if (!normalized.mediaId) {
@@ -1062,6 +1152,9 @@ export async function connectDashboardAppServerBridgeOnce({
             text: error?.message || DEFAULT_APP_SERVER_ERROR_TEXT
           });
         });
+    }
+    if (payload?.type === "runner_wakeup_requested") {
+      executeVpsRunnerWakeup({ request: payload }).then((result) => safeSend(result));
     }
   });
 

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -119,6 +119,51 @@ export class DashboardChatRoom {
       return json(202, { ok: true, threadId });
     }
 
+    if (request.method === "POST" && url.pathname === "/runner-wakeup") {
+      const payload = await readJson(request);
+      const threadId = normalizeDashboardThreadId(payload.threadId || payload.thread_id);
+      if (!threadId) {
+        return json(422, {
+          ok: false,
+          error: "thread_id_required",
+          reason: "threadId is required"
+        });
+      }
+      const bridgeSockets = this.connectedAppServerBridgeSockets(threadId);
+      if (bridgeSockets.length === 0) {
+        return json(202, {
+          ok: true,
+          wakeup: {
+            status: "unavailable",
+            attempted: false,
+            fallback: "vtdd-vps-runner.timer",
+            reason: "app-server bridge socket is not connected"
+          }
+        });
+      }
+      const message = {
+        type: "runner_wakeup_requested",
+        schema: "vtdd.dashboard.app_server_bridge.v1",
+        requestId: createDashboardRequestId("runner-wakeup"),
+        threadId,
+        executionId: normalizeDashboardEventText(payload.executionId || payload.execution_id),
+        repository: normalizeCanonicalRepositoryInput(payload.repository),
+        issueNumber: normalizePositiveInteger(payload.issueNumber || payload.issue_number),
+        queueCommentUrl: normalizeDashboardEventText(payload.queueCommentUrl || payload.queue_comment_url),
+        createdAt: new Date().toISOString()
+      };
+      const sent = this.sendSocket(bridgeSockets[0], message);
+      return json(202, {
+        ok: true,
+        wakeup: {
+          status: sent ? "requested" : "unavailable",
+          attempted: sent,
+          fallback: "vtdd-vps-runner.timer",
+          reason: sent ? "runner wakeup request sent to app-server bridge" : "failed to send runner wakeup request"
+        }
+      });
+    }
+
     if (request.headers.get("upgrade")?.toLowerCase() !== "websocket") {
       return json(426, {
         ok: false,
@@ -1077,6 +1122,14 @@ export default {
           blockedByRule: dispatched.blockedByRule ?? null,
           reason: dispatched.reason,
           issues: dispatched.issues ?? []
+        });
+      }
+
+      if (dispatched.execution?.transport === "vps_runner") {
+        dispatched.execution.wakeup = await requestDashboardVpsRunnerWakeup({
+          env,
+          request: requestValidation.request,
+          execution: dispatched.execution
         });
       }
 
@@ -8497,6 +8550,60 @@ function resolveDashboardChatRoomStub(env, threadId) {
   return null;
 }
 
+async function requestDashboardVpsRunnerWakeup({ env, request, execution } = {}) {
+  const threadId = normalizeDashboardThreadId(
+    request?.handoff?.dashboardThreadId ||
+      request?.dashboardThreadId ||
+      execution?.dashboardThreadId
+  );
+  if (!threadId) {
+    return {
+      status: "unavailable",
+      attempted: false,
+      fallback: "vtdd-vps-runner.timer",
+      reason: "dashboardThreadId is not available"
+    };
+  }
+  const room = resolveDashboardChatRoomStub(env, threadId);
+  if (!room || typeof room.fetch !== "function") {
+    return {
+      status: "unavailable",
+      attempted: false,
+      fallback: "vtdd-vps-runner.timer",
+      reason: "DASHBOARD_CHAT_ROOMS Durable Object binding is not configured"
+    };
+  }
+  try {
+    const response = await room.fetch(
+      new Request("https://dashboard-room.local/runner-wakeup", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          threadId,
+          executionId: execution?.executionId,
+          repository: execution?.targetRepository,
+          issueNumber: execution?.issueNumber,
+          queueCommentUrl: execution?.queueCommentUrl
+        })
+      })
+    );
+    const body = await readJsonResponseSafe(response);
+    return {
+      status: normalizeDashboardEventText(body?.wakeup?.status) || (response.ok ? "requested" : "failed"),
+      attempted: body?.wakeup?.attempted === true,
+      fallback: normalizeDashboardEventText(body?.wakeup?.fallback) || "vtdd-vps-runner.timer",
+      reason: normalizeDashboardEventText(body?.wakeup?.reason) || null
+    };
+  } catch (error) {
+    return {
+      status: "failed",
+      attempted: true,
+      fallback: "vtdd-vps-runner.timer",
+      reason: sanitizeDashboardChatText(error?.message || "runner wakeup request failed")
+    };
+  }
+}
+
 async function resolveDashboardChatRepository({ payload, env }) {
   const input = normalizeObject(payload);
   const text = input.text || input.message || input.body;
@@ -12196,6 +12303,14 @@ function isSameOriginBrowserRequest(request) {
 async function readJson(request) {
   try {
     return await request.json();
+  } catch {
+    return {};
+  }
+}
+
+async function readJsonResponseSafe(response) {
+  try {
+    return await response.json();
   } catch {
     return {};
   }

--- a/test/dashboard-app-server-bridge.test.js
+++ b/test/dashboard-app-server-bridge.test.js
@@ -9,11 +9,13 @@ import {
   buildOwnerActionRequiredPayloadForAppServerApproval,
   buildAppServerRequestApprovalResponse,
   buildAppServerSandboxOverrides,
+  buildVpsRunnerWakeupCommand,
   buildAppServerThreadResumeRequest,
   buildAppServerThreadStartRequest,
   buildAppServerTurnStartRequest,
   buildDashboardTurnInputText,
   connectDashboardAppServerBridgeOnce,
+  executeVpsRunnerWakeup,
   extractAppServerNotificationTurnId,
   formatDashboardMediaReferenceLines,
   handleDashboardTurnRequest,
@@ -67,6 +69,57 @@ test("dashboard app-server bridge builds initialize and thread requests from Cod
   assert.equal(turn.params.threadId, "codex-thread-1");
   assert.deepEqual(turn.params.input, [{ type: "text", text: "今日は何日？", text_elements: [] }]);
   assert.equal(turn.params.sandboxPolicy, undefined);
+});
+
+test("dashboard app-server bridge runner wakeup uses only fixed user systemd start command", async () => {
+  assert.deepEqual(buildVpsRunnerWakeupCommand(), {
+    command: "systemctl",
+    args: ["--user", "start", "vtdd-vps-runner.service"],
+    shell: false
+  });
+
+  const spawnCalls = [];
+  const result = await executeVpsRunnerWakeup({
+    request: {
+      threadId: "dashboard-main",
+      requestId: "runner-wakeup:test",
+      executionId: "remote-codex-issue717",
+      repository: "marushu/vtdd-v2-p",
+      issueNumber: 717,
+      queueCommentUrl: "https://github.com/marushu/vtdd-v2-p/issues/717#issuecomment-1"
+    },
+    now: (() => {
+      const values = ["2026-06-01T00:00:00.000Z", "2026-06-01T00:00:01.000Z"];
+      return () => values.shift() || "2026-06-01T00:00:01.000Z";
+    })(),
+    spawnImpl(command, args, options) {
+      spawnCalls.push({ command, args, options });
+      const listeners = new Map();
+      return {
+        stdout: { on() {} },
+        stderr: { on() {} },
+        on(type, handler) {
+          listeners.set(type, handler);
+          if (type === "close") {
+            queueMicrotask(() => handler(0));
+          }
+        }
+      };
+    }
+  });
+
+  assert.equal(spawnCalls.length, 1);
+  assert.deepEqual(spawnCalls[0], {
+    command: "systemctl",
+    args: ["--user", "start", "vtdd-vps-runner.service"],
+    options: { shell: false, stdio: ["ignore", "pipe", "pipe"] }
+  });
+  assert.equal(result.type, "runner_wakeup_result");
+  assert.equal(result.status, "started");
+  assert.equal(result.attempted, true);
+  assert.equal(result.fallback, "vtdd-vps-runner.timer");
+  assert.equal(result.threadId, "dashboard-main");
+  assert.equal(result.executionId, "remote-codex-issue717");
 });
 
 test("dashboard app-server bridge wraps repository traffic-control context into turn input", () => {

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -3510,6 +3510,49 @@ test("DashboardChatRoom routes VPS maintenance owner turns without an app-server
   assert.equal(proposalRecord.content.proposal.capability.id, "systemd.user.runner.status");
 });
 
+test("DashboardChatRoom sends runner wakeup requests only to connected app-server bridge", async () => {
+  const dashboardSocket = createMockSocket("dashboard", "dashboard-main-marushu-vtdd-v2-p");
+  const bridgeSocket = createMockSocket("app_server_bridge", "dashboard-main-marushu-vtdd-v2-p");
+  const room = new DashboardChatRoom(
+    {
+      storage: createMockDurableObjectStorage(),
+      getWebSockets() {
+        return [dashboardSocket, bridgeSocket];
+      }
+    },
+    { DASHBOARD_CHAT_STORE: createInMemoryDashboardChatStore() }
+  );
+
+  const response = await room.fetch(
+    new Request("https://dashboard-room.local/runner-wakeup", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        threadId: "dashboard-main-marushu-vtdd-v2-p",
+        executionId: "remote-codex-issue717",
+        repository: "marushu/vtdd-v2-p",
+        issueNumber: 717,
+        queueCommentUrl: "https://github.com/marushu/vtdd-v2-p/issues/717#issuecomment-1"
+      })
+    })
+  );
+
+  assert.equal(response.status, 202);
+  const body = await response.json();
+  assert.equal(body.wakeup.status, "requested");
+  assert.equal(body.wakeup.attempted, true);
+  assert.equal(body.wakeup.fallback, "vtdd-vps-runner.timer");
+  assert.equal(dashboardSocket.sent.length, 0);
+  assert.equal(bridgeSocket.sent.length, 1);
+  const wakeup = JSON.parse(bridgeSocket.sent[0]);
+  assert.equal(wakeup.type, "runner_wakeup_requested");
+  assert.equal(wakeup.threadId, "dashboard-main-marushu-vtdd-v2-p");
+  assert.equal(wakeup.executionId, "remote-codex-issue717");
+  assert.equal(wakeup.repository, "marushu/vtdd-v2-p");
+  assert.equal(wakeup.issueNumber, 717);
+  assert.equal(wakeup.queueCommentUrl, "https://github.com/marushu/vtdd-v2-p/issues/717#issuecomment-1");
+});
+
 test("DashboardChatRoom attaches execution queue preflight to repository app-server turns", async () => {
   const provider = createInMemoryMemoryProvider();
   const store = createInMemoryDashboardChatStore();
@@ -7711,6 +7754,7 @@ test("worker dispatches API-backed remote Codex execution when explicitly select
 
 test("worker dispatches VPS runner execution by posting a bounded queue comment", async () => {
   const calls = [];
+  const roomCalls = [];
   const response = await worker.fetch(
     new Request("https://example.com/v2/action/execute", {
       method: "POST",
@@ -7734,6 +7778,7 @@ test("worker dispatches VPS runner execution by posting a bounded queue comment"
             issueTraceable: true,
             approvalScopeMatched: true,
             relatedIssue: 157,
+            dashboardThreadId: "dashboard-main-marushu-vtdd-v2-p",
             summary: "Issue #157 bounded VPS runner handoff"
           }
         },
@@ -7765,6 +7810,27 @@ test("worker dispatches VPS runner execution by posting a bounded queue comment"
     }),
     {
       ...gatewayAuthEnv,
+      DASHBOARD_CHAT_ROOMS: {
+        getByName(name) {
+          return {
+            async fetch(input) {
+              roomCalls.push({ name, input });
+              return new Response(
+                JSON.stringify({
+                  ok: true,
+                  wakeup: {
+                    status: "requested",
+                    attempted: true,
+                    fallback: "vtdd-vps-runner.timer",
+                    reason: "runner wakeup request sent to app-server bridge"
+                  }
+                }),
+                { status: 202, headers: { "content-type": "application/json" } }
+              );
+            }
+          };
+        }
+      },
       GITHUB_APP_INSTALLATION_TOKEN: "ghs_dispatch_token",
       GITHUB_API_FETCH: async (url, init) => {
         calls.push({ url, init });
@@ -7806,7 +7872,21 @@ test("worker dispatches VPS runner execution by posting a bounded queue comment"
   assert.equal(body.execution.branch, "codex/issue-157-vps-worker-dispatch");
   assert.equal(body.execution.queueCommentId, 15701);
   assert.equal(body.execution.queueCommentUrl, "https://github.com/sample-org/vtdd-v2/issues/157#issuecomment-15701");
+  assert.deepEqual(body.execution.wakeup, {
+    status: "requested",
+    attempted: true,
+    fallback: "vtdd-vps-runner.timer",
+    reason: "runner wakeup request sent to app-server bridge"
+  });
   assert.equal(calls.length, 2);
+  assert.equal(roomCalls.length, 1);
+  assert.equal(roomCalls[0].name, "dashboard-main-marushu-vtdd-v2-p");
+  const wakeupPayload = await roomCalls[0].input.json();
+  assert.equal(wakeupPayload.threadId, "dashboard-main-marushu-vtdd-v2-p");
+  assert.equal(wakeupPayload.executionId, body.execution.executionId);
+  assert.equal(wakeupPayload.repository, "sample-org/vtdd-v2");
+  assert.equal(wakeupPayload.issueNumber, 157);
+  assert.equal(wakeupPayload.queueCommentUrl, "https://github.com/sample-org/vtdd-v2/issues/157#issuecomment-15701");
   const queueCall = calls.find((call) => String(call.url).includes("/issues/157/comments"));
   assert.equal(queueCall.init.method, "POST");
   const queueBody = JSON.parse(queueCall.init.body).body;

--- a/worker.js
+++ b/worker.js
@@ -57529,6 +57529,50 @@ var DashboardChatRoom = class {
       });
       return json(202, { ok: true, threadId: threadId2 });
     }
+    if (request.method === "POST" && url.pathname === "/runner-wakeup") {
+      const payload = await readJson(request);
+      const threadId2 = normalizeDashboardThreadId(payload.threadId || payload.thread_id);
+      if (!threadId2) {
+        return json(422, {
+          ok: false,
+          error: "thread_id_required",
+          reason: "threadId is required"
+        });
+      }
+      const bridgeSockets = this.connectedAppServerBridgeSockets(threadId2);
+      if (bridgeSockets.length === 0) {
+        return json(202, {
+          ok: true,
+          wakeup: {
+            status: "unavailable",
+            attempted: false,
+            fallback: "vtdd-vps-runner.timer",
+            reason: "app-server bridge socket is not connected"
+          }
+        });
+      }
+      const message = {
+        type: "runner_wakeup_requested",
+        schema: "vtdd.dashboard.app_server_bridge.v1",
+        requestId: createDashboardRequestId("runner-wakeup"),
+        threadId: threadId2,
+        executionId: normalizeDashboardEventText(payload.executionId || payload.execution_id),
+        repository: normalizeCanonicalRepositoryInput(payload.repository),
+        issueNumber: normalizePositiveInteger10(payload.issueNumber || payload.issue_number),
+        queueCommentUrl: normalizeDashboardEventText(payload.queueCommentUrl || payload.queue_comment_url),
+        createdAt: (/* @__PURE__ */ new Date()).toISOString()
+      };
+      const sent = this.sendSocket(bridgeSockets[0], message);
+      return json(202, {
+        ok: true,
+        wakeup: {
+          status: sent ? "requested" : "unavailable",
+          attempted: sent,
+          fallback: "vtdd-vps-runner.timer",
+          reason: sent ? "runner wakeup request sent to app-server bridge" : "failed to send runner wakeup request"
+        }
+      });
+    }
     if (request.headers.get("upgrade")?.toLowerCase() !== "websocket") {
       return json(426, {
         ok: false,
@@ -58366,6 +58410,13 @@ var runtime_default = {
           blockedByRule: dispatched.blockedByRule ?? null,
           reason: dispatched.reason,
           issues: dispatched.issues ?? []
+        });
+      }
+      if (dispatched.execution?.transport === "vps_runner") {
+        dispatched.execution.wakeup = await requestDashboardVpsRunnerWakeup({
+          env,
+          request: requestValidation.request,
+          execution: dispatched.execution
         });
       }
       return json(202, {
@@ -64903,6 +64954,57 @@ function resolveDashboardChatRoomStub(env, threadId) {
   }
   return null;
 }
+async function requestDashboardVpsRunnerWakeup({ env, request, execution } = {}) {
+  const threadId = normalizeDashboardThreadId(
+    request?.handoff?.dashboardThreadId || request?.dashboardThreadId || execution?.dashboardThreadId
+  );
+  if (!threadId) {
+    return {
+      status: "unavailable",
+      attempted: false,
+      fallback: "vtdd-vps-runner.timer",
+      reason: "dashboardThreadId is not available"
+    };
+  }
+  const room = resolveDashboardChatRoomStub(env, threadId);
+  if (!room || typeof room.fetch !== "function") {
+    return {
+      status: "unavailable",
+      attempted: false,
+      fallback: "vtdd-vps-runner.timer",
+      reason: "DASHBOARD_CHAT_ROOMS Durable Object binding is not configured"
+    };
+  }
+  try {
+    const response = await room.fetch(
+      new Request("https://dashboard-room.local/runner-wakeup", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          threadId,
+          executionId: execution?.executionId,
+          repository: execution?.targetRepository,
+          issueNumber: execution?.issueNumber,
+          queueCommentUrl: execution?.queueCommentUrl
+        })
+      })
+    );
+    const body = await readJsonResponseSafe(response);
+    return {
+      status: normalizeDashboardEventText(body?.wakeup?.status) || (response.ok ? "requested" : "failed"),
+      attempted: body?.wakeup?.attempted === true,
+      fallback: normalizeDashboardEventText(body?.wakeup?.fallback) || "vtdd-vps-runner.timer",
+      reason: normalizeDashboardEventText(body?.wakeup?.reason) || null
+    };
+  } catch (error2) {
+    return {
+      status: "failed",
+      attempted: true,
+      fallback: "vtdd-vps-runner.timer",
+      reason: sanitizeDashboardChatText(error2?.message || "runner wakeup request failed")
+    };
+  }
+}
 async function resolveDashboardChatRepository({ payload, env }) {
   const input = normalizeObject12(payload);
   const text = input.text || input.message || input.body;
@@ -68182,6 +68284,13 @@ function isSameOriginBrowserRequest(request) {
 async function readJson(request) {
   try {
     return await request.json();
+  } catch {
+    return {};
+  }
+}
+async function readJsonResponseSafe(response) {
+  try {
+    return await response.json();
   } catch {
     return {};
   }


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #717 の部分進捗です。`vps_runner` queue comment 投稿後に、同じ Dashboard thread の app-server bridge へ即時 wakeup を送れるようにします。
- owner-facing には「ただの1分待ち」を通常経路から外し、`vtdd-vps-runner.timer` は復旧 fallback として残します。

## Satisfied Success Criteria

- Worker が `vps_runner` dispatch 成功後、`dashboardThreadId` がある場合だけ DashboardChatRoom の `/runner-wakeup` に wakeup を依頼します。
- DashboardChatRoom は接続中の app-server bridge socket にだけ `runner_wakeup_requested` を送り、通常 dashboard socket には送らないことをテストで固定しました。
- app-server bridge は固定の非 root コマンド `systemctl --user start vtdd-vps-runner.service` だけを `shell:false` で実行することをテストで固定しました。
- wakeup 失敗または bridge 未接続でも queue 投稿自体は失敗扱いにせず、fallback として `vtdd-vps-runner.timer` を返します。
- remote Codex executor docs に即時 wakeup と timer fallback の権限境界を追加しました。

## Unsatisfied Success Criteria

- production Dashboard Butler で queue 投稿直後に runner pickup が早くなる live E2E は未実施です。
- 既存の `npm run verify:worker` は実機 vault/dashboard runtime 設定を拾う4件で失敗しており、このPR由来ではない可能性が高いものの未解消です。

## Non-goal violations

None.

## 開発前作戦図

- 作戦図 evidence: docs/development-strategy/issue-717-vps-runner-wakeup.md
- 完了体験: 州平が Dashboard Butler から開発実行を投げた直後、VPS runner が次の1分timerを待たずに起動し始める。bridge が切れている場合でも timer fallback で取りこぼさない。
- VTDD 全体で進める部分: Dashboard Butler から VPS Codex CLI execution へ渡る体感レイテンシを下げる。
- 設計: completion design は、queue comment を従来通りGitHub runtime truthとして残し、wakeup は同一threadのapp-server bridgeへ送るbest-effort通知に限定する。scope は latency 改善だけで、authority boundary は user systemd fixed command に限定する。
- 仮説: suspected cause は VPS runner timer の最大1分待ちで、prediction は queue後に user systemd service を即startすれば連続開発の体感が改善すること。
- 検証計画: bridge command固定テスト、Worker dispatch wakeupテスト、DashboardChatRoom socket routingテスト、worker生成物整合性確認。
- 改修見積もり: `src/worker/runtime.js`、`scripts/run-dashboard-app-server-bridge.mjs`、関連テスト、`worker.js`、executor docs。
- 既に通っている経路: `vps_runner` はGitHub queue comment経由で動いており、runner timerはfallbackとして残っている。
- 未確認の境界: productionでの実際の起動短縮、systemd user service startの実機戻り値、Dashboard bridge切断時の実運用表示。
- 穴が出そうな箇所: wakeup を任意コマンド化すると権限境界が壊れるため、bridge側で固定コマンドのみ許可する。
- PR 前に確認すること: `node --test test/dashboard-app-server-bridge.test.js`、`node --test test/worker.test.js --test-name-pattern "VPS runner execution|runner wakeup"`、`npm run build:worker`、`npm run check:self-parity`、`npm run check:generated-worker`、`npm run verify:worker` の結果を確認する。
- 実装候補と捨てた案: WorkerからVPSへ直接HTTP/APIを開ける案は公開入口と権限面が重いので採用しない。GitHub queueを消す案はruntime truthを失うので採用しない。
- merge 後に通す E2E: production Dashboard Butler same-thread `vps_runner` execution E2E を実行し、queue commentからrunner pickupまでのlead timeと `execution.wakeup` runtime truthを確認する。
- 次の PR を増やさない理由: このPRはwake latency sliceだけに閉じ、runner lane並行化や進行UIは別Issueに残す。
- 停止条件: root/sudo/任意shell/credential/deploy/merge authorityに広がるなら停止する。

## Dry-run Impact Report

- Target Issue: Issue #717
- Implementing Success Criteria: queue投稿後の即時wakeup、timer fallback維持、非root固定コマンド境界、runtime truth返却。
- Explicit Non-goals: root/sudo maintenance helper、deploy、merge、credential mutation、repo lane並行化、進行UI、production deploy。
- Expected touched files/routes/workflows: `src/worker/runtime.js`、DashboardChatRoom `/runner-wakeup`、app-server bridge WebSocket message handler、`worker.js`、関連テスト、`docs/butler/remote-codex-cli-executor.md`。
- Affected Issues: #717。関連して #637 / #590 / #450 の開発体験に効くが、このPRでは完了扱いにしない。
- Affected PRs: なし。
- Affected workflows: GitHub Actions workflow は変更なし。VPS runner timer/service runtime に影響する。
- Affected runtime/operator surfaces: Dashboard Butler、DashboardChatRoom Durable Object、Dashboard app-server bridge、VPS user systemd runner。
- What may break if we patch narrowly: `dashboardThreadId` が渡らない実行経路ではwakeupできない。bridge未接続時のowner-facing表示は今後の進行UI側で扱う必要がある。
- Unknowns to investigate before coding: production実機でのwake lead time、systemd startの失敗時表示、bridge再接続中のwake再送要否。
- Validation needed: unit/integration、worker build、generated worker check、production same-thread E2E。
- Stop condition: wakeupがGitHub queue truthを迂回して実行状態を不明にする、または任意コマンド実行へ広がる場合。

## Execution Queue Delta

- Queue position before: Issue #637 が Now だが、州平が「このあと開発が連続するので1分待ちを先に潰す」と明示したため、Issue #717 を先行のbounded latency sliceとして扱います。
- Preemption decision: EMERGENCY ではありません。owner明示の順序変更により、以後の開発全体へ効く NEXT slice として先に進めます。
- Queue delta: Issue #717 をこのPRで `NEXT latency slice` から `PR review / post-merge E2E待ち` に移動します。#637/#590/#450/#413/#528/#716 などのactive Issueは未完了のまま残します。
- Why this PR is next: VPS runner のpickup待ち最大1分は、今後の連続開発で毎回効くため、先に短縮する価値が高いです。
- Active Issues not downscoped: Active Issues は縮小しません。このPRで扱わないactive Issueは未完了として残します。

## File / Line Hypotheses

- file: `src/worker/runtime.js`
  - hypothesis: `/v2/action/execute` の `vps_runner` dispatch後にwakeupを付加すればqueue truthを壊さず latency だけ下げられる。
  - risk if changed narrowly: `dashboardThreadId` がない経路では未接続になるためfallback表示が必要。
  - validation: worker dispatch test と DashboardChatRoom wakeup routing test。
  - related Issue: #717
- file: `scripts/run-dashboard-app-server-bridge.mjs`
  - hypothesis: bridge側で固定systemd user commandだけを実行すれば、任意shell化せずに即時runner起動できる。
  - risk if changed narrowly: commandをpayload由来にすると権限境界が壊れる。
  - validation: fixed command test。
  - related Issue: #717

## Hypothesis Retrospective

- expected: queue投稿直後のwakeup要求はbridgeへ届き、bridgeは固定systemd user commandだけを実行する。
- actual: ローカルテストでは Worker dispatch / DashboardChatRoom routing / bridge command固定が通過。
- mismatch: production lead time E2E は未実施。
- lesson: 即時化はGitHub queueを消すのではなく、queue truthを残したままwakeupを追加するのが安全。
- should become RAG candidate: はい。VPS runner latency改善と権限境界の判断材料として残す価値があります。

## Verification Evidence

- Unit: `node --test test/dashboard-app-server-bridge.test.js` pass 36/36。
- Integration: `node --test test/remote-codex-executor.test.js --test-name-pattern "vps_runner dispatch"` pass 40/40。`node --test test/worker.test.js --test-name-pattern "VPS runner execution|runner wakeup"` pass 245/245。`node --test test/dashboard-app-server-bridge.test.js test/worker.test.js --test-name-pattern "runner wakeup|VPS runner execution"` pass 281/281。
- E2E: production Dashboard Butler live E2E は未実施。
- Manual: `npm run build:worker` pass。`npm run check:self-parity` pass。`npm run check:generated-worker` pass。
- Evidence path/link: PR checks と上記ローカルコマンド結果。

## Butler Completion Contract

- Primary owner surface: Dashboard Butler。
- Fallback surface: Custom GPT は明示されたfallback surfaceとして扱います。主経路ではありません。
- Owner goal: Dashboard Butlerから開発実行した時、VPS runnerが1分timerを待たずに動き始める。
- Butler entrypoint: `/v2/action/execute` の `vps_runner` dispatch後にwakeupを付加。
- Dashboard Butler natural-language path: 州平がDashboard Butler chatで開発実行を依頼し、既存の自然文/チャット入口が `/v2/action/execute` の `vps_runner` handoff に到達した後、このPRのwakeupが動く。このPRでは自然文分類そのものは変更しない。
- Action Schema exposure: 変更なし。
- Runtime path: Worker `/v2/action/execute` -> GitHub queue comment -> DashboardChatRoom `/runner-wakeup` -> app-server bridge `runner_wakeup_requested` -> `systemctl --user start vtdd-vps-runner.service`。
- Runner/runtime truth: responseの `execution.wakeup` に `status/attempted/fallback/reason` を返す。queue truthは従来通りGitHub commentを使う。
- Authority boundary: root/sudo/maintenance helper/deploy/merge/credential mutationは追加しない。bridgeは固定のuser systemd startのみ。
- E2E evidence: production same-thread E2E は未実施。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: このPR内では未実施。merge後にproduction反映が必要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: merge/deploy後に必要。

## Related Constitution Rules

- Butler Completion Gate
- Butler-First Operating Principle
- Authority Boundary
- Evidence Discipline
- Change Size and PR Discipline

## Out-of-scope but NOT implemented

- Repo別 execution lane / parallel queue traffic control (#716)
- 実行中フィードバック / progress UI (#413)
- app-server timeout/reconnect root blocker (#590/#654)
- root/sudo VPS maintenance helper execution (#637)
- production deploy

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #717
- Execution ID: dashboard-butler-issue-717-wakeup
- Goal: vps_runner queue投稿後に即時wakeupし、1分timer待ちをfallback化する
