### PR TITLE
Issue #450 app-server bridge turn timeoutを既定化

### DIFF
--- a/docs/development-strategy/issue-450-bridge-turn-timeout.md
+++ b/docs/development-strategy/issue-450-bridge-turn-timeout.md
@@ -1,0 +1,44 @@
+# Issue #450 / #590 app-server bridge turn timeout strategy
+
+## 完了体験
+
+Dashboard Butler の通常チャットで、Codex app-server の 1 turn が完了通知を返さない場合でも、owner は次の発言を送れる。画面には日本語の recoverable timeout が出て、同じ Dashboard thread に入力が保存されたまま、後続の普通の会話が `app-server bridge の返信を待っています` で永久停止しない。
+
+## 対象 Issue
+
+- Issue #450: Dashboard Butler live app-server path
+- Issue #590: app-server timeout / recovery
+
+## Success Criteria
+
+- VPS app-server bridge の実運用 default が timeout 無効 `0` にならない。
+- env に `VTDD_DASHBOARD_APP_SERVER_TURN_TIMEOUT_MS` が無い場合でも、一定時間で `app_server_turn_failed` timeout event を返す。
+- 明示的に `VTDD_DASHBOARD_APP_SERVER_TURN_TIMEOUT_MS=0` を設定した場合は、従来どおり timeout 無効化を残す。
+- timeout 後に turn queue が解放され、後続の owner message を処理できる。
+
+## Non-goals
+
+- #637 helper execution、root/sudo、credential、permission、deploy はこの PR で実行しない。
+- app-server bridge service restart はこの PR のコード変更では行わない。
+- Dashboard UI 全体の再設計や任意 thread bridge 多重化は扱わない。
+- Codex app-server の内部 protocol 変更や model timeout 調整は扱わない。
+
+## 原因仮説
+
+本番の `dashboard-main-unresolved` で #637 helper completion 後、普通の owner 発言が `app-server bridge の返信を待っています` のまま戻らない。VPS の bridge env には `VTDD_DASHBOARD_APP_SERVER_TURN_TIMEOUT_MS` が無く、`parseBridgeArgs()` の default は `0` で timeout 無効だった。`connectDashboardAppServerBridgeOnce()` は turn を `turnQueue` で直列化しているため、1 turn が完了通知を返さないと後続の通常会話が全て待たされる。
+
+## 改修見積もり
+
+- `scripts/run-dashboard-app-server-bridge.mjs`: 実運用 default timeout を 120 秒にする。明示 `0` は維持する。
+- `test/dashboard-app-server-bridge.test.js`: env 未指定時の default timeout と明示 `0` の保持を固定する。
+- `worker.js`: worker build が触る場合のみ生成物を更新する。
+
+## 検証計画
+
+- `node --test test/dashboard-app-server-bridge.test.js --test-name-pattern "turn timeout|bridge args"`
+- `npm run build:worker`
+- `npm run verify:worker`
+
+## 予測される残リスク
+
+この PR は queue 永久停止を防ぐ。既に本番で詰まっている 5/29 起動中の bridge process は、merge/deploy 後に service が再起動されるまで新しい script を読まない。production E2E では deploy 後に bridge process の script 反映状態と、同じ unresolved thread で普通の会話が timeout 後も継続できることを確認する。

--- a/scripts/run-dashboard-app-server-bridge.mjs
+++ b/scripts/run-dashboard-app-server-bridge.mjs
@@ -13,6 +13,7 @@ const DEFAULT_APP_SERVER_ERROR_TEXT =
 const APP_SERVER_TURN_TIMEOUT_TEXT =
   "codex app-server の応答生成が時間切れになりました。入力は Dashboard thread に保存済みです。同じ thread で続けるか、内容を短くしてもう一度送れます。";
 const DASHBOARD_MEDIA_TMP_DIR = "vtdd-dashboard-media";
+const DEFAULT_TURN_TIMEOUT_MS = 120 * 1000;
 
 export function buildAppServerInitializeRequest(id = 1) {
   return {
@@ -998,7 +999,7 @@ export function parseBridgeArgs(argv = process.argv.slice(2), env = process.env)
     threadId: env.VTDD_DASHBOARD_THREAD_ID || "",
     cwd: env.VTDD_DASHBOARD_CODEX_CWD || process.cwd(),
     sandboxMode: env.VTDD_DASHBOARD_APP_SERVER_SANDBOX || "",
-    turnTimeoutMs: Number(env.VTDD_DASHBOARD_APP_SERVER_TURN_TIMEOUT_MS || 0),
+    turnTimeoutMs: Number(env.VTDD_DASHBOARD_APP_SERVER_TURN_TIMEOUT_MS || DEFAULT_TURN_TIMEOUT_MS),
     reconnectDelayMs: Number(env.VTDD_DASHBOARD_BRIDGE_RECONNECT_DELAY_MS || 1000),
     heartbeatMs: Number(env.VTDD_DASHBOARD_BRIDGE_HEARTBEAT_MS || 25000)
   };
@@ -1009,7 +1010,7 @@ export function parseBridgeArgs(argv = process.argv.slice(2), env = process.env)
     if (arg === "--thread-id") options.threadId = argv[++index] || "";
     if (arg === "--cwd") options.cwd = argv[++index] || "";
     if (arg === "--sandbox") options.sandboxMode = argv[++index] || "";
-    if (arg === "--turn-timeout-ms") options.turnTimeoutMs = Number(argv[++index] || 0);
+    if (arg === "--turn-timeout-ms") options.turnTimeoutMs = Number(argv[++index] || DEFAULT_TURN_TIMEOUT_MS);
     if (arg === "--reconnect-delay-ms") options.reconnectDelayMs = Number(argv[++index] || 1000);
     if (arg === "--heartbeat-ms") options.heartbeatMs = Number(argv[++index] || 25000);
   }
@@ -1064,7 +1065,7 @@ export async function connectDashboardAppServerBridgeOnce({
   appServer,
   cwd = process.cwd(),
   sandboxMode = "",
-  turnTimeoutMs = 0,
+  turnTimeoutMs = DEFAULT_TURN_TIMEOUT_MS,
   heartbeatMs = 25000,
   runtimeUrl = "",
   fetchImpl = globalThis.fetch,

--- a/test/dashboard-app-server-bridge.test.js
+++ b/test/dashboard-app-server-bridge.test.js
@@ -1404,6 +1404,17 @@ test("dashboard app-server bridge args require a dashboard thread id for runtime
   });
   assert.equal(parsed.threadId, "");
   assert.equal(parsed.sandboxMode, "danger-full-access");
+  assert.equal(parsed.turnTimeoutMs, 120000);
+});
+
+test("dashboard app-server bridge args preserve explicit disabled turn timeout", () => {
+  const parsed = parseBridgeArgs([], {
+    VTDD_RUNTIME_URL: "https://runtime.example",
+    VTDD_GATEWAY_BEARER_TOKEN: "secret-token",
+    VTDD_DASHBOARD_THREAD_ID: "dashboard-main",
+    VTDD_DASHBOARD_APP_SERVER_TURN_TIMEOUT_MS: "0"
+  });
+  assert.equal(parsed.threadId, "dashboard-main");
   assert.equal(parsed.turnTimeoutMs, 0);
 });
 


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #450 / #590 の部分進捗です。Dashboard Butler の普通の会話が、Codex app-server bridge の 1 turn 未完了で永久に `app-server bridge の返信を待っています` のまま詰まる failure mode を潰します。
- owner-facing の主経路は Dashboard Butler 通常チャットです。Custom GPT / Action Schema は主経路にしません。

## Satisfied Success Criteria

- VPS app-server bridge の実運用 default が timeout 無効 `0` にならないようにしました。
- env に `VTDD_DASHBOARD_APP_SERVER_TURN_TIMEOUT_MS` が無い場合でも、120 秒で recoverable timeout event を返す default を固定しました。
- 明示的に `VTDD_DASHBOARD_APP_SERVER_TURN_TIMEOUT_MS=0` を設定した場合は、従来どおり timeout 無効を維持します。
- timeout 後に turn queue が解放され、後続 owner message を処理できる既存経路を default から使えるようにしました。

## Unsatisfied Success Criteria

- Production Dashboard Butler live E2E は merge / deploy / VPS bridge process 反映後に実施が必要です。
- 既に 2026-05-29 から起動中の本番 bridge process は、この PR の merge だけでは新しい script を読みません。service restart または process refresh の境界確認が残ります。

## Non-goal violations

None.

## 開発前作戦図

- 作戦図 evidence: `docs/development-strategy/issue-450-bridge-turn-timeout.md`
- 完了体験: Dashboard Butler の通常チャットで 1 turn が完了通知を返さなくても、日本語の recoverable timeout を出して後続発言を受け付け、同じ thread の会話が永久停止しない。
- VTDD 全体で進める部分: Dashboard Butler / VPS app-server bridge の通常チャット継続性。#637 helper 実行ではなく、普通の会話面の root blocker を扱う。
- 設計: owner-facing surface は Dashboard Butler 通常チャット、scope は bridge default timeout のみ、authority 境界は root/helper/deploy 不実行。`parseBridgeArgs()` と `connectDashboardAppServerBridgeOnce()` の実運用 default timeout を 120 秒にする。
- 仮説: 原因仮説は、本番 unresolved bridge env に timeout 設定が無く、default `0` のため `handleDashboardTurnRequest()` が completion を待ち続け、直列 `turnQueue` が後続メッセージを塞いだこと。
- 検証計画: bridge args test で default 120000 と明示 0 を固定し、既存 timeout / late completion tests と worker verification を通す。
- 改修見積もり: `scripts/run-dashboard-app-server-bridge.mjs` の default 値、`test/dashboard-app-server-bridge.test.js` の args test、作戦図 doc。
- 既に通っている経路: PR #715 / #718 後、canonical repository thread では Dashboard Butler と app-server bridge の入口接続は通った。#637 helper completion message も Dashboard thread に戻った。
- 未確認の境界: 本番 VPS service restart 後の live unresolved thread で、普通の会話が timeout 後に継続できるかは未確認。
- 穴が出そうな箇所: timeout を短くしすぎると長い応答が recoverable timeout になる。既存 late completion persistence の挙動は維持する必要がある。
- PR 前に確認すること: VPS bridge env に timeout 設定が無いこと、service が 5/29 から起動中で新 script を読んでいないこと、該当 source/test の既存 timeout path。
- 実装候補と捨てた案: HTTP fallback 接続や UI だけの文言修正は捨てた。WebSocket / app-server bridge の queue 永久停止を default timeout で止める。
- merge 後に通す E2E: deploy 後、VPS bridge process 反映状態を確認し、Dashboard Butler live E2E test として repo 未指定 main chat で普通の会話が返ることを検証する。
- 次の PR を増やさない理由: 後続 PR を増やさないため、この PR は既存の timeout / late completion / queue 解放実装を活かし、予測済みの穴である実運用 default 未接続だけを scope 内で閉じる。
- 停止条件: この default 変更で app-server protocol や owner authority boundary を変更する必要が出た場合は、この PR では止める。

## Dry-run Impact Report

- Target Issue: Issue #450 / Issue #590
- Implementing Success Criteria: Dashboard Butler 通常チャットで app-server turn が完了しない場合も、recoverable timeout により queue を解放し、後続 owner message を永久停止させない。
- Explicit Non-goals: #637 helper execution、root/sudo、credential、permission、deploy、VPS service restart、Dashboard UI redesign、arbitrary thread bridge 多重化は実行しない。
- Expected touched files/routes/workflows: `scripts/run-dashboard-app-server-bridge.mjs`, `test/dashboard-app-server-bridge.test.js`, `docs/development-strategy/issue-450-bridge-turn-timeout.md`
- Affected Issues: Issue #450, Issue #590, Issue #637 の live E2E 前提に影響。ただし #637 helper 実行そのものはこの PR では扱わない。
- Affected PRs: PR #715 / #718 後の app-server bridge live path に対する修正。既存 PR へは push せず新規 PR。
- Affected workflows: GitHub Actions test / reviewer / deploy-production。workflow definition は変更しない。
- Affected runtime/operator surfaces: Dashboard Butler 通常チャット、VPS app-server bridge process、Dashboard thread event。passkey/operator route は変更しない。
- What may break if we patch narrowly: timeout default だけでは、既に起動中の VPS bridge process は再起動まで直らない。長い turn は 120 秒で timeout 表示になる可能性がある。
- Unknowns to investigate before coding: 本番 env の timeout 設定有無、bridge process 起動時刻、既存 timeout event が queue を解放するか。
- Validation needed: targeted node test、`npm run build:worker`、`npm run verify:worker`、merge/deploy 後の Dashboard Butler live E2E。
- Stop condition: HTTP fallback や Action Schema 主経路へ scope が逸れる場合、または root/helper/deploy 実行が必要になる場合は止める。

## Execution Queue Delta

- Queue position before: Now は Dashboard Butler の普通の会話が app-server bridge 待ちで詰まる EMERGENCY / ROOT blocker。
- Preemption decision: ROOT blocker として #637 helper 進行より先に、Butler で会話できる基盤復旧を優先する。
- Queue delta: Issue #450 / Issue #590 の bridge timeout default slice を `Now` として進める。Issue #637 helper execution はこの修正の production E2E 後に戻す。
- Why this PR is next: owner が iPhone Dashboard Butler で普通の会話返信を受け取れず、Butler-first 開発の入口が止まっているため。
- Active Issues not downscoped: Active Issues は縮小しない。この PR は #450/#590 の root blocker slice であり、#637/#654/#579 など残件は未完了として残す。

## File / Line Hypotheses

- file: `scripts/run-dashboard-app-server-bridge.mjs`
  - hypothesis: `parseBridgeArgs()` と `connectDashboardAppServerBridgeOnce()` の default timeout が `0` のため、本番 env 未指定時に timeout が無効化される。
  - risk if changed narrowly: explicit `0` opt-out を壊すとテストや運用で意図的に timeout 無効化したいケースが壊れる。
  - validation: bridge args test で default 120000 と explicit 0 を両方固定する。
  - related Issue: #450 / #590
- file: `test/dashboard-app-server-bridge.test.js`
  - hypothesis: 既存 timeout event / late completion tests はあるが、runtime args default が 0 であることを検出していなかった。
  - risk if changed narrowly: default だけ変えて explicit opt-out test を追加しないと将来の回帰で 0 opt-out が消える。
  - validation: targeted node test と `npm run verify:worker`。
  - related Issue: #450 / #590

## Hypothesis Retrospective

- expected: env 未指定時の default timeout を 120 秒にすると、既存 timeout event と queue release が実運用で有効になる。
- actual: `parseBridgeArgs()` の env 未指定 test は 120000 を返し、explicit `VTDD_DASHBOARD_APP_SERVER_TURN_TIMEOUT_MS=0` は 0 のまま保持された。
- mismatch: 実装前仮説との大きな mismatch はなし。ただし live process restart 後 E2E は未実施。
- lesson: timeout handler 自体ではなく、実運用 default が無効だったことが根だった。
- should become RAG candidate: はい。Dashboard Butler bridge は default env 未指定でも queue 永久停止を避ける必要がある。

## Verification Evidence

- Unit: `node --test test/dashboard-app-server-bridge.test.js --test-name-pattern "timeout|bridge args"` passed.
- Integration: `npm run verify:worker` passed.
- E2E: 未実施。merge / deploy / VPS bridge process 反映後に Dashboard Butler live E2E を実施する。
- Manual: VPS bridge service / env / 起動時刻を read-only で確認。env に `VTDD_DASHBOARD_APP_SERVER_TURN_TIMEOUT_MS` は無く、service は 2026-05-29 から起動中。
- Evidence path/link: `docs/development-strategy/issue-450-bridge-turn-timeout.md`

## Butler Completion Contract

- Primary owner surface: Dashboard Butler。
- Fallback surface: Custom GPT は明示された fallback surface として扱います。主経路ではありません。
- Owner goal: Dashboard Butler の普通の会話が app-server bridge 待ちで永久停止せず、iPhone/iPad から会話を続けられる。
- Butler entrypoint: Dashboard Butler 通常チャット。
- Dashboard Butler natural-language path: Dashboard Butler の自然文 / 通常チャット入口から owner message を受け、app-server bridge が Codex app-server turn を開始し、timeout 時も同じ thread に recoverable failure を返す経路。
- Action Schema exposure: Custom GPT fallback 用の露出状態として扱います。この PR では主経路にも実装対象にもしていません。
- Runtime path: Dashboard Worker thread WebSocket -> VPS app-server bridge -> Codex app-server turn -> Dashboard thread event。
- Runner/runtime truth: local test で bridge timeout default と timeout event path を確認。本番 runtime truth は merge / deploy / VPS bridge process 反映後に確認する。
- Authority boundary: 変更なし。root/helper/deploy/credential/permission mutation はこの PR で実行しない。
- E2E evidence: 未実施。Production Dashboard Butler live E2E は merge / deploy / bridge process refresh 後に必要。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: merge 後に必要。Worker route 変更はないが、production evidence と notification のため deploy truth を追う。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: merge / deploy / bridge process refresh 後に必要。

## Related Constitution Rules

- Butler-first: owner-facing 主経路は Dashboard Butler。
- Drift Stop Protocol: Issue-backed bounded change contract と作戦図を先に作る。
- Evidence Discipline: live E2E 未実施のため completion status は incomplete。
- Authority Boundary: deploy / root / helper / credential mutation は実行しない。

## Out-of-scope but NOT implemented

- #637 VPS helper execution の再実行。
- passkey approval UX の修正。
- app-server bridge service restart の自動化。
- arbitrary `threadId` への bridge 多重接続。
- HTTP fallback による通常チャット主経路化。

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #450 / Issue #590
- Execution ID: dashboard-butler-bridge-turn-timeout
- Goal: Dashboard Butler 普通の会話の app-server bridge queue 永久停止を防ぐ
