### PR TITLE
dashboard: timeoutをstalled turn recoveryとして扱う

### DIFF
--- a/docs/development-strategy/issue-590-stalled-turn-recovery.md
+++ b/docs/development-strategy/issue-590-stalled-turn-recovery.md
@@ -1,0 +1,52 @@
+# Issue #590: stalled turn recovery
+
+## 完了体験
+
+Dashboard Butler の通常チャットで Codex app-server の返答が時間内に戻らなくても、owner は「壊れた」「返信が消えた」と感じずに復旧できる。
+
+timeout は会話の終点ではなく、`stalled` として扱う。元入力は保存済みで、owner は待つ、同じ内容でもう一度実行する、短くして再送する、キャンセルする、の選択肢を持つ。遅れて返信が届いた場合は、同じ thread に late completion として追加する。
+
+## 対象 Issue
+
+- Issue #590: app-server turn timeout recovery
+- Related: Issue #450, Issue #413, Issue #444
+
+## Success Criteria
+
+- timeout event は `failed` ではなく復旧可能な `stalled` state として Dashboard thread に残る。
+- timeout event は retryable recovery metadata を持つ。
+- owner-facing text は raw English timeout を出さず、保存済み、再実行、短縮再送、キャンセル、late completion を説明する。
+- timeout 後に late completion が来た場合、遅れて届いた返信として thread に追加する。
+- 既存の app-server bridge queue release は維持する。
+
+## Non-goals
+
+- Codex app-server 自体の性能改善は扱わない。
+- 自動再実行はしない。
+- deploy / credential / permission / root / sudo は扱わない。
+- iPhone lock/suspend reconnect 全体は Issue #579 側に残す。
+- full UI redesign は Issue #528 / #413 側に残す。
+
+## 原因仮説
+
+PR #719 で永久停止を防ぐ default timeout は入ったが、timeout が `failed` に寄りすぎると、owner は元依頼が失われたように感じる。VTDD の通常運用では、timeout 後も元入力を保持し、再実行や短縮再送に進めることが必要。
+
+## 改修見積もり
+
+- `scripts/run-dashboard-app-server-bridge.mjs`: timeout event に `recovery` metadata を追加し、late completion を明示する。
+- `src/worker/runtime.js`: timeout event を `stalled` chat message として保存する。
+- `test/dashboard-app-server-bridge.test.js`: recovery metadata と late completion text を固定する。
+- `test/worker.test.js`: stalled message と owner-facing text を固定する。
+- `worker.js`: worker build で生成物を更新する。
+
+## 検証計画
+
+- `node --test test/dashboard-app-server-bridge.test.js --test-name-pattern "timeout|late completion"`
+- `node --test test/worker.test.js --test-name-pattern "app-server timeout"`
+- `npm run build:worker`
+- `npm run check:generated-worker`
+
+## 残リスク
+
+この slice は recovery metadata と表示状態を固定する。実際の再実行ボタン、短縮再送UI、通知連携は次の #590/#413/#444 slice で扱う。
+

--- a/scripts/run-dashboard-app-server-bridge.mjs
+++ b/scripts/run-dashboard-app-server-bridge.mjs
@@ -11,7 +11,7 @@ const APP_SERVER_FAILURE_ALREADY_SENT = Symbol("appServerFailureAlreadySent");
 const DEFAULT_APP_SERVER_ERROR_TEXT =
   "codex app-server が応答生成中に失敗しました。画像を解析できなかった可能性があります。もう一度送るか、画像なしで内容を短く説明してください。";
 const APP_SERVER_TURN_TIMEOUT_TEXT =
-  "codex app-server の応答生成が時間切れになりました。入力は Dashboard thread に保存済みです。同じ thread で続けるか、内容を短くしてもう一度送れます。";
+  "codex app-server の応答が遅れています。この依頼は Dashboard thread に保存済みです。待つ、同じ内容でもう一度実行する、短くして再送する、キャンセルする、のいずれかで復旧できます。遅れて返信が届いた場合は、この thread に追加します。";
 const DASHBOARD_MEDIA_TMP_DIR = "vtdd-dashboard-media";
 const DEFAULT_TURN_TIMEOUT_MS = 120 * 1000;
 
@@ -611,7 +611,8 @@ function buildAppServerTurnTimeoutEvent({
   dashboardThreadId,
   codexThreadId,
   repository,
-  relatedIssue
+  relatedIssue,
+  ownerText
 } = {}) {
   return {
     type: "app_server_turn_failed",
@@ -621,7 +622,13 @@ function buildAppServerTurnTimeoutEvent({
     repository: repository || null,
     relatedIssue: relatedIssue || null,
     status: "timeout",
-    text: APP_SERVER_TURN_TIMEOUT_TEXT
+    text: APP_SERVER_TURN_TIMEOUT_TEXT,
+    recovery: {
+      status: "stalled",
+      retryable: true,
+      originalText: String(ownerText || ""),
+      actions: ["wait", "retry", "shorten_and_resend", "cancel"]
+    }
   };
 }
 
@@ -854,7 +861,8 @@ export async function handleDashboardTurnRequest({
         dashboardThreadId,
         codexThreadId,
         repository: request.repository,
-        relatedIssue: request.relatedIssue || request.issueNumber
+        relatedIssue: request.relatedIssue || request.issueNumber,
+        ownerText: text
       });
       void sendDashboardEvent(timeoutEvent);
       lateCompletionCleanupHandle = setTimeout(() => {
@@ -891,6 +899,10 @@ export async function handleDashboardTurnRequest({
     if (event.type === "app_server_status" && event.status === "replied") {
       event.type = "app_server_reply";
       event.text = accumulatedText || event.text;
+      if (timedOut) {
+        event.lateCompletion = true;
+        event.text = `遅れて返信が届きました。\n\n${event.text}`;
+      }
       void sendDashboardEvent(event);
       if (timedOut) {
         cleanupNotifications();

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -8825,6 +8825,11 @@ function normalizeDashboardAppServerBridgeEvent(payload, { fallbackThreadId = ""
     transientText = "Dashboard thread 接続済み。";
   } else if (eventType === "app_server_turn_failed" || status === "failed") {
     const failureText = buildDashboardAppServerFailureThreadText({ text, status });
+    const messageStatus =
+      normalizeDashboardEventText(input?.recovery?.status).toLowerCase() === "stalled" ||
+      status === "timeout"
+        ? "stalled"
+        : "failed";
     messages.push(
       normalizeDashboardChatMessage(
         {
@@ -8832,14 +8837,14 @@ function normalizeDashboardAppServerBridgeEvent(payload, { fallbackThreadId = ""
           role: "system",
           repository,
           relatedIssue,
-          status: "failed",
+          status: messageStatus,
           text: failureText,
           createdAt
         },
         { threadId }
       )
     );
-    transientStatus = "failed";
+    transientStatus = messageStatus;
     transientText = failureText;
   } else if (eventType === "app_server_status") {
     transientStatus = status === "replied" ? "replied" : "thinking";
@@ -8868,7 +8873,7 @@ function buildDashboardAppServerFailureThreadText({ text = "", status = "" } = {
     normalizedStatus === "timeout" ||
     /timed out before completion/i.test(normalizedText)
   ) {
-    return "codex app-server の応答生成が時間切れになりました。入力は Dashboard thread に保存済みです。同じ thread で続けるか、内容を短くしてもう一度送れます。";
+    return "codex app-server の応答が遅れています。この依頼は Dashboard thread に保存済みです。待つ、同じ内容でもう一度実行する、短くして再送する、キャンセルする、のいずれかで復旧できます。遅れて返信が届いた場合は、この thread に追加します。";
   }
   return normalizedText || "codex app-server が返信前に失敗しました。同じ thread で続けるか、内容を短くしてもう一度送れます。";
 }
@@ -11190,7 +11195,7 @@ function normalizeDashboardChatRole(value) {
 
 function normalizeDashboardChatStatus(value) {
   const status = normalizeDashboardEventText(value).toLowerCase();
-  return ["sent", "thinking", "replied", "blocked", "failed"].includes(status) ? status : "sent";
+  return ["sent", "thinking", "replied", "blocked", "failed", "stalled"].includes(status) ? status : "sent";
 }
 
 function normalizeDashboardThreadId(value) {

--- a/test/dashboard-app-server-bridge.test.js
+++ b/test/dashboard-app-server-bridge.test.js
@@ -1168,7 +1168,11 @@ test("dashboard app-server bridge sends Japanese recoverable timeout failure", a
   assert.equal(timeoutEvent.threadId, "dashboard-main");
   assert.equal(timeoutEvent.repository, "marushu/vtdd-v2-p");
   assert.equal(timeoutEvent.relatedIssue, 590);
-  assert.match(timeoutEvent.text, /入力は Dashboard thread に保存済み/);
+  assert.match(timeoutEvent.text, /この依頼は Dashboard thread に保存済み/);
+  assert.deepEqual(timeoutEvent.recovery.actions, ["wait", "retry", "shorten_and_resend", "cancel"]);
+  assert.equal(timeoutEvent.recovery.status, "stalled");
+  assert.equal(timeoutEvent.recovery.retryable, true);
+  assert.equal(timeoutEvent.recovery.originalText, "timeout を再現して");
   assert.doesNotMatch(timeoutEvent.text, /timed out before completion/);
   await new Promise((resolve) => setTimeout(resolve, 10));
   assert.equal(handlers.size, 0);
@@ -1238,7 +1242,8 @@ test("dashboard app-server bridge persists late completion after timeout instead
   assert.ok(finalReply);
   assert.equal(finalReply.threadId, "dashboard-main");
   assert.equal(finalReply.codexThreadId, "codex-thread-late");
-  assert.equal(finalReply.text, "PR #632 を Draft で作成済みです。");
+  assert.equal(finalReply.lateCompletion, true);
+  assert.equal(finalReply.text, "遅れて返信が届きました。\n\nPR #632 を Draft で作成済みです。");
   assert.equal(handlers.size, 0);
 });
 

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -3946,11 +3946,13 @@ test("DashboardChatRoom persists app-server timeout as recoverable Japanese thre
   const stored = await store.listThread("dashboard-main-unresolved");
   assert.equal(stored.length, 1);
   assert.equal(stored[0].role, "system");
-  assert.equal(stored[0].status, "failed");
+  assert.equal(stored[0].status, "stalled");
   assert.equal(stored[0].repository, "marushu/vtdd-v2-p");
   assert.equal(stored[0].relatedIssue, 590);
-  assert.match(stored[0].text, /応答生成が時間切れ/);
-  assert.match(stored[0].text, /同じ thread で続ける/);
+  assert.match(stored[0].text, /応答が遅れています/);
+  assert.match(stored[0].text, /同じ内容でもう一度実行する/);
+  assert.match(stored[0].text, /短くして再送/);
+  assert.match(stored[0].text, /遅れて返信が届いた場合/);
   assert.doesNotMatch(stored[0].text, /timed out before completion/);
 
   const broadcast = dashboardSocket.sent.map((message) => JSON.parse(message)).find((message) => message.type === "thread");
@@ -3959,7 +3961,7 @@ test("DashboardChatRoom persists app-server timeout as recoverable Japanese thre
 
   const failedStatus = dashboardSocket.sent.map((message) => JSON.parse(message)).find((message) => message.type === "transient_status");
   assert.ok(failedStatus);
-  assert.equal(failedStatus.status, "failed");
+  assert.equal(failedStatus.status, "stalled");
   assert.equal(failedStatus.text, stored[0].text);
 });
 

--- a/worker.js
+++ b/worker.js
@@ -65204,6 +65204,7 @@ function normalizeDashboardAppServerBridgeEvent(payload, { fallbackThreadId = ""
     transientText = "Dashboard thread \u63A5\u7D9A\u6E08\u307F\u3002";
   } else if (eventType === "app_server_turn_failed" || status === "failed") {
     const failureText = buildDashboardAppServerFailureThreadText({ text, status });
+    const messageStatus = normalizeDashboardEventText(input?.recovery?.status).toLowerCase() === "stalled" || status === "timeout" ? "stalled" : "failed";
     messages.push(
       normalizeDashboardChatMessage(
         {
@@ -65211,14 +65212,14 @@ function normalizeDashboardAppServerBridgeEvent(payload, { fallbackThreadId = ""
           role: "system",
           repository,
           relatedIssue,
-          status: "failed",
+          status: messageStatus,
           text: failureText,
           createdAt
         },
         { threadId }
       )
     );
-    transientStatus = "failed";
+    transientStatus = messageStatus;
     transientText = failureText;
   } else if (eventType === "app_server_status") {
     transientStatus = status === "replied" ? "replied" : "thinking";
@@ -65243,7 +65244,7 @@ function buildDashboardAppServerFailureThreadText({ text = "", status = "" } = {
   const normalizedText = sanitizeDashboardChatText(text);
   const normalizedStatus = normalizeDashboardEventText(status).toLowerCase();
   if (normalizedStatus === "timeout" || /timed out before completion/i.test(normalizedText)) {
-    return "codex app-server \u306E\u5FDC\u7B54\u751F\u6210\u304C\u6642\u9593\u5207\u308C\u306B\u306A\u308A\u307E\u3057\u305F\u3002\u5165\u529B\u306F Dashboard thread \u306B\u4FDD\u5B58\u6E08\u307F\u3067\u3059\u3002\u540C\u3058 thread \u3067\u7D9A\u3051\u308B\u304B\u3001\u5185\u5BB9\u3092\u77ED\u304F\u3057\u3066\u3082\u3046\u4E00\u5EA6\u9001\u308C\u307E\u3059\u3002";
+    return "codex app-server \u306E\u5FDC\u7B54\u304C\u9045\u308C\u3066\u3044\u307E\u3059\u3002\u3053\u306E\u4F9D\u983C\u306F Dashboard thread \u306B\u4FDD\u5B58\u6E08\u307F\u3067\u3059\u3002\u5F85\u3064\u3001\u540C\u3058\u5185\u5BB9\u3067\u3082\u3046\u4E00\u5EA6\u5B9F\u884C\u3059\u308B\u3001\u77ED\u304F\u3057\u3066\u518D\u9001\u3059\u308B\u3001\u30AD\u30E3\u30F3\u30BB\u30EB\u3059\u308B\u3001\u306E\u3044\u305A\u308C\u304B\u3067\u5FA9\u65E7\u3067\u304D\u307E\u3059\u3002\u9045\u308C\u3066\u8FD4\u4FE1\u304C\u5C4A\u3044\u305F\u5834\u5408\u306F\u3001\u3053\u306E thread \u306B\u8FFD\u52A0\u3057\u307E\u3059\u3002";
   }
   return normalizedText || "codex app-server \u304C\u8FD4\u4FE1\u524D\u306B\u5931\u6557\u3057\u307E\u3057\u305F\u3002\u540C\u3058 thread \u3067\u7D9A\u3051\u308B\u304B\u3001\u5185\u5BB9\u3092\u77ED\u304F\u3057\u3066\u3082\u3046\u4E00\u5EA6\u9001\u308C\u307E\u3059\u3002";
 }
@@ -67328,7 +67329,7 @@ function normalizeDashboardChatRole(value) {
 }
 function normalizeDashboardChatStatus(value) {
   const status = normalizeDashboardEventText(value).toLowerCase();
-  return ["sent", "thinking", "replied", "blocked", "failed"].includes(status) ? status : "sent";
+  return ["sent", "thinking", "replied", "blocked", "failed", "stalled"].includes(status) ? status : "sent";
 }
 function normalizeDashboardThreadId(value) {
   const text = normalizeDashboardEventText(value).toLowerCase().replace(/[^a-z0-9_.:/-]+/g, "-").replace(/-+/g, "-").replace(/^-|-$/g, "");


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #590 の部分進捗です。app-server turn timeout を会話の終点や単なる失敗ではなく、復旧可能な `stalled` state として Dashboard thread に残します。
- owner-facing には、元依頼が保存済みで、待つ・再実行・短くして再送・キャンセルで復旧できることを明示します。

## Satisfied Success Criteria

- timeout event に retryable recovery metadata を追加しました。
- Dashboard thread では timeout を `failed` ではなく `stalled` message として保存します。
- raw English timeout を出さず、保存済み・再実行・短縮再送・キャンセル・late completion を日本語で説明します。
- timeout 後に遅れて completion が来た場合、`遅れて返信が届きました。` として同じ thread に追加します。
- 既存の timeout 後 queue release / late completion handler は維持します。

## Unsatisfied Success Criteria

- 実際の再実行ボタン、短縮再送UI、キャンセルUIは次の slice です。
- production Dashboard Butler live E2E は未実施です。
- iPhone background notification 連携は #444 側に残します。

## Non-goal violations

None.

## 開発前作戦図

- 作戦図 evidence: docs/development-strategy/issue-590-stalled-turn-recovery.md
- 完了体験: timeout 後も owner は元依頼が保存済みであることと、復旧選択肢を理解でき、同じ thread で継続できる。
- VTDD 全体で進める部分: Dashboard Butler 通常チャットの会話継続性。mac Codex に戻らないための timeout recovery 基盤。
- 設計: Dashboard Butler owner-facing surface では timeout event を `app_server_turn_failed` のまま受け、`recovery.status=stalled` と `retryable=true` を付ける。Worker側は `stalled` chat status として保存する。
- 仮説: root原因は #719 の timeout default だけでは「元依頼が失われた」体験が残ること。stalled/retryable と late completion 明示で、timeout を復旧可能状態に変えられる。
- 検証計画: bridge timeout test、late completion test、worker timeout persistence test、worker build、generated worker check。
- 改修見積もり: `scripts/run-dashboard-app-server-bridge.mjs`、`src/worker/runtime.js`、関連テスト、`worker.js`、作戦図doc。
- 既に通っている経路: #719 で timeout default は 120 秒になった。既存 late completion handler は存在する。
- 未確認の境界: production live timeout、実際の再実行/短縮再送UI、通知連携。
- 穴が出そうな箇所: `failed` のままだと owner が会話破損と解釈する。late completion が通常返信と区別できないと混乱する。
- PR 前に確認すること: `node --test test/dashboard-app-server-bridge.test.js --test-name-pattern "timeout|late completion"`、`node --test test/worker.test.js --test-name-pattern "app-server timeout"`、`npm run build:worker`、`npm run check:generated-worker`。
- 実装候補と捨てた案: 自動再実行は副作用と重複実行の危険があるため捨てた。まず recovery state と late completion 明示だけを実装する。
- merge 後に通す E2E: production Dashboard Butler live E2E で timeout/stalled event と late completion を確認する。実際の再実行UIは後続sliceで確認する。
- 次の PR を増やさない理由: このPRは土台の状態表現に閉じ、UIボタンや通知まで広げない。
- 停止条件: 自動再実行、deploy、root/sudo、credential mutation に広がる場合は停止する。

## Dry-run Impact Report

- Target Issue: Issue #590
- Implementing Success Criteria: timeout を stalled/retryable として保存し、late completion を明示する。
- Explicit Non-goals: 自動再実行、短縮再送UI、キャンセルUI、deploy、credential mutation、root/sudo、iPhone background notification。
- Expected touched files/routes/workflows: `scripts/run-dashboard-app-server-bridge.mjs`, `src/worker/runtime.js`, `test/dashboard-app-server-bridge.test.js`, `test/worker.test.js`, `worker.js`, `docs/development-strategy/issue-590-stalled-turn-recovery.md`。
- Affected Issues: #590、関連 #450 / #413 / #444。#579 はPWA復帰全体として残す。
- Affected PRs: #719 の follow-up。既存PRへpushしない。
- Affected workflows: GitHub Actions test / guarded-policy / review。workflow定義は変更しない。
- Affected runtime/operator surfaces: Dashboard Butler chat、VPS app-server bridge、Dashboard thread event。
- What may break if we patch narrowly: UIボタンがまだ無いので、復旧選択肢は文言とmetadataに留まる。
- Unknowns to investigate before coding: production live timeout、late completion の見え方、再実行UIの最適導線。
- Validation needed: targeted tests、worker build、generated worker parity、production E2E。
- Stop condition: timeout復旧が自動再実行や高リスク操作へ広がる場合。

## Execution Queue Delta

- Queue position before: Issue #637 が durable queue の Now だが、Dashboard Butler の返信停止/timeout recovery は Butler-first 開発の入口を塞ぐ ROOT blocker として owner が明示的に先行指定した。
- Preemption decision: ROOT。
- Queue delta: Issue #590 を `Now` の stalled turn recovery slice として進める。#637 は停止せず、#590 の会話復旧後に戻す。
- Why this PR is next: Butler と会話できなければ VTDD が成立せず、mac Codex 離脱ができないため。
- Active Issues not downscoped: Active Issues は縮小しない。このPRで扱わない #637/#450/#413/#444/#579/#528 は未完了として残す。

## File / Line Hypotheses

- file: `scripts/run-dashboard-app-server-bridge.mjs`
  - hypothesis: timeout event に recovery metadata と late completion marker を付ければ、同じ thread で復旧可能な状態を表現できる。
  - risk if changed narrowly: 自動再実行まで入れると重複副作用の危険がある。
  - validation: timeout / late completion tests。
  - related Issue: #590
- file: `src/worker/runtime.js`
  - hypothesis: timeout を `stalled` status として保存すれば、owner-facing に失敗ではなく復旧待ちとして扱える。
  - risk if changed narrowly: UIボタンがないため、初回sliceでは文言とmetadata止まりになる。
  - validation: worker timeout persistence test。
  - related Issue: #590

## Hypothesis Retrospective

- expected: timeout は stalled として保存され、late completion は遅れて届いた返信として見える。
- actual: targeted tests で stalled保存、recovery metadata、late completion marker を確認。
- mismatch: 実際の再実行UIは未実装。
- lesson: timeout は失敗終了ではなく復旧可能な会話状態として扱う必要がある。
- should become RAG candidate: はい。Butler通常チャットの根本復旧パターンとして残す価値があります。

## Verification Evidence

- Unit: `node --test test/dashboard-app-server-bridge.test.js --test-name-pattern "timeout|late completion"` pass 37/37。
- Integration: `node --test test/worker.test.js --test-name-pattern "app-server timeout"` pass 245/245。`npm run build:worker` pass。`npm run check:generated-worker` pass。
- E2E: production Dashboard Butler live E2E は未実施。
- Manual: なし。
- Evidence path/link: `docs/development-strategy/issue-590-stalled-turn-recovery.md`

## Butler Completion Contract

- Primary owner surface: Dashboard Butler。
- Fallback surface: Custom GPT はfallbackであり主経路ではありません。
- Owner goal: app-server timeout後も、元依頼を失わず、同じthreadで復旧できる。
- Butler entrypoint: Dashboard Butler通常チャット。
- Dashboard Butler natural-language path: Dashboard Butler の自然文/通常チャット入口で owner が送信し、app-server bridge が timeout した場合に、同じ thread へ stalled recovery message を返す経路です。
- Action Schema exposure: 変更なし。
- Runtime path: Dashboard Worker thread WebSocket -> VPS app-server bridge -> Codex app-server turn -> timeout event -> Dashboard thread stalled message。
- Runner/runtime truth: timeout event に `recovery.status=stalled` / `retryable=true` / actions を含める。
- Authority boundary: 変更なし。deploy / root / sudo / credential / permission mutation は扱わない。
- E2E evidence: production live E2E は未実施。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: merge後に必要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: merge/deploy後に必要。

## Related Constitution Rules

- Butler Completion Gate
- Butler-First Operating Principle
- Conversation UX Contract
- Evidence Discipline
- Authority Boundary

## Out-of-scope but NOT implemented

- 再実行ボタン
- 短縮再送UI
- キャンセルUI
- background notification
- app-server性能改善
- PWA lock/suspend recovery全体

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #590
- Execution ID: dashboard-butler-issue-590-stalled-recovery
- Goal: app-server timeout を復旧可能な stalled turn として扱う
