### PR TITLE
Issue #723 Dashboard self refresh

### DIFF
--- a/docs/development-strategy/issue-723-dashboard-self-refresh.md
+++ b/docs/development-strategy/issue-723-dashboard-self-refresh.md
@@ -1,0 +1,110 @@
+# Issue #723 Dashboard Self Refresh Strategy
+
+## 完了体験
+
+Owner が Dashboard Butler で「古いままかもしれない」と感じた時、Mac Codex を開かずに同じ PWA から現在の client / service worker / runtime / bridge の手掛かりを確認できる。
+
+通常の `⌘ + R` で戻れる場合はそのまま案内し、古い service worker や Cache Storage を疑う場合は「強制キャッシュ削除リロード」を明示的に選べる。未送信 draft、thread id、repository context は reload 前に sessionStorage へ保存する。
+
+この PR は Issue #590 の activity watchdog を完成扱いにしない。PR #721 deploy 後にも古い 2分 timeout 文言が出た事実から、freshness drift を owner-facing に切り分けるための前提回復スライスとして扱う。
+
+## VTDD 全体で進める部分
+
+Issue #723 を Issue #590 の `ROOT` 補助スライスとして先に進める。Dashboard Butler が最新 client かどうかを owner が推測する状態では、Issue #590 の timeout recovery E2E が正しく読めない。
+
+Issue #637 の VPS privileged maintenance はこの PR では進めない。Issue #723 は iPhone/PWA recovery gap を狭めるが、deploy / root / credential / permission mutation は一切開始しない。
+
+## 設計
+
+Dashboard main chat の管理メニューに「最新状態」と「強制リロード」を追加する。通常チャット面を壊さず、debug/ops 面に隔離されている既存構造に合わせて、進行中 lane の中へ小さく置く。
+
+client script は build id、thread id、repository context、service worker registration state、WebSocket state を status area に出す。強制リロードは draft 保存後、service worker へ cache clear message を送り、registration update と Cache Storage 削除を best-effort で行い、最後は `location.reload()` に fallback する。
+
+service worker は `VTDD_DASHBOARD_CLEAR_CACHES` message を受け、Dashboard / VTDD 系 cache name だけ削除する。unregister や全 origin cache 削除は初期実装では避ける。
+
+## 仮説
+
+PR #721 は merge/deploy truth では成功していたが、owner PWA では旧 2分 timeout 文言が出た。`⌘ + R` で復帰したため、Worker 未deploy よりも stale client / service worker / WebSocket session の可能性が高い。
+
+現在の Dashboard service worker は push/notificationclick だけを扱い、client 側にも freshness 表示や force reload 導線がない。そのため deploy 成功通知を受けても、owner は古い PWA shell なのか app-server stall なのかを切り分けられない。
+
+狭く timeout 秒数だけ伸ばすと、実際の stale client 問題を隠して Issue #590 の E2E を誤読する。
+
+## 検証計画
+
+Unit / integration test では `/dashboard` HTML に freshness / force reload UI、draft preserving reload script、service worker update / cache delete path が含まれることを確認する。
+
+Service worker test では `/dashboard-sw.js` に `VTDD_DASHBOARD_CLEAR_CACHES` message handler、dashboard scoped cache deletion、`clients.claim()` が残ることを確認する。
+
+生成 worker を更新し、`npm run check:generated-worker` で source と generated worker の差分を検証する。
+
+Production E2E は merge/deploy 後に Dashboard Butler を開き、最新状態表示、強制リロード後の同一 thread/context 復帰、旧 timeout 文言が残る場合の切り分け文言を確認する。この PR 内では production deploy は実行しない。
+
+## 改修見積もり
+
+- `src/worker/runtime.js`: Dashboard main chat HTML / client script / service worker script。UI 追加と best-effort refresh function。通常送信や timeout watchdog へは触れない。
+- `test/worker.test.js`: Dashboard shell と PWA service worker の assertions を追加。既存の auth/header helper を使う。
+- `worker.js`: `npm run build:worker` で生成更新。
+- `docs/mvp/active-issue-execution-queue.md`: Issue #723 が Issue #590 の freshness validation をブロックする ROOT 補助スライスであることを記録する。
+
+## 既に通っている経路
+
+PR #721 は merged。deploy-production run 26753699460 は merge SHA `4aaf2580e55b01754b764b2b77a3aca97d8b73ec` で成功していた。
+
+Dashboard notification 経路は deploy 完了通知を owner に届けられる。`⌘ + R` による手動復帰は owner 観測として存在する。
+
+Dashboard chat は sessionStorage draft retention、WebSocket reconnect、thread refresh、service worker registration を既に持つ。
+
+## 未確認の境界
+
+iOS PWA で Cache Storage deletion と service worker update がどこまで即時反映されるかは端末依存で未確認。
+
+Cloudflare edge / browser HTTP cache / service worker update timing のどれが stale を生んだかは、この PR だけでは断定しない。
+
+app-server bridge の session freshness truth は別 Issue の範囲に残る。
+
+## 穴が出そうな箇所
+
+強制 reload が未送信添付を完全保持できない。添付 file object はブラウザ reload を跨げないため、draft text は復元し、添付は再選択が必要という文言を出す。
+
+cache deletion を広げすぎると同一 origin の無関係 cache を消す可能性がある。初期実装では dashboard / vtdd prefix を含む cache name に限定する。
+
+通常チャット面へ debug UI を出しすぎると Issue #528 の chat-first 方針に反する。管理メニュー内に留める。
+
+## PR 前に確認すること
+
+Issue #723 の Success Criteria と Non-goal に反して deploy / root / credential mutation を含めていないこと。
+
+Dashboard main chat の通常送信 UI、font-size、textarea focus 挙動に触れていないこと。
+
+PR body に Issue #723、Issue #590 への関係、E2E 未完了、Execution Queue Delta を明記すること。
+
+## 実装候補と捨てた案
+
+採用: owner が明示的に押せる `最新状態` と `強制キャッシュ削除リロード`。draft 保存と best-effort cache clear を行う。
+
+捨てた案: deploy 完了時に自動で即 reload する。owner の入力中 state を壊す可能性があるため初期実装では採用しない。
+
+捨てた案: service worker unregister と全 cache delete。復旧効果は強いが、初期実装として破壊的に寄りすぎる。
+
+## merge 後に通す E2E
+
+production deploy 後、Dashboard Butler PWA の同じ thread で「最新状態確認」を押し、build id / service worker / WebSocket state が表示されることを見る。
+
+強制キャッシュ削除リロードを押し、同じ thread id と repository context に戻り、draft text が保持または復元警告されることを見る。
+
+旧 2分 timeout 文言が再発した場合、Issue #590 の actual stall か Issue #723 の stale client かを分けて記録する。
+
+## 次の PR を増やさない理由
+
+Issue #723 の初期 owner-facing 導線、service worker message handler、test evidence は同じ runtime surface に閉じており、分けると stale client 対策が半端になる。
+
+ただし app-server bridge freshness truth、deploy event からの same-thread 自動投稿、stop/interrupt UI は別 scope として残す。
+
+## 停止条件
+
+Dashboard main chat の通常送信、draft retention、WebSocket reconnect に予期しない変更が必要になったら停止する。
+
+iOS PWA で実現不能な browser capability を前提にしないと success criteria を満たせないと分かったら停止する。
+
+Issue #723 以外の root/deploy/credential/permission 境界へ踏み込む必要が出たら停止する。

--- a/docs/mvp/active-issue-execution-queue.md
+++ b/docs/mvp/active-issue-execution-queue.md
@@ -101,18 +101,28 @@ Last rebuilt from GitHub runtime truth: 2026-05-31
   blocks Issue #637 and the broader Butler-first operating center. Issue #590
   moves to `Now` for the app-server activity watchdog slice; Issue #637 resumes
   after this recovery path no longer interrupts ordinary development.
+- 2026-06-01 owner live evidence classified Issue #723 as `ROOT` support for
+  Issue #590: after PR #721 merged and deploy-production succeeded, Dashboard
+  Butler still showed the old fixed 2-minute timeout until the owner manually
+  reloaded the PWA. This blocks Issue #590 validation because stale Dashboard
+  client / service worker / WebSocket session state can hide the actual runtime
+  behavior. Issue #723 temporarily becomes `Now` to add owner-facing freshness
+  check and force cache refresh; Issue #590 remains the parent root and resumes
+  immediately after stale-client recovery no longer masks the watchdog.
 
 ## Now
 
-- Issue #590: app-server turn timeout / silent wait recovery. This is the
-  current root because Dashboard Butler must not become unusable while Codex
-  app-server is still active. The immediate slice replaces fixed elapsed-time
-  timeout behavior with an app-server activity watchdog so progress / thinking /
-  command / diff / tool events keep the turn alive, quiet state remains
-  transient, and stalled recovery is reserved for true inactivity.
+- Issue #723: Dashboard Butler self-refresh and force cache reload for stale
+  PWA/client state. This is a temporary `ROOT` support slice for Issue #590
+  because PR #721 deploy truth cannot be trusted by the owner-facing PWA while
+  stale client/service-worker/session state can keep old timeout behavior alive.
 
 ## Next
 
+- Issue #590: app-server turn timeout / silent wait recovery resumes after
+  Issue #723 gives the owner a same-PWA freshness check and force refresh path,
+  so production E2E can distinguish stale client state from actual app-server
+  inactivity.
 - Issue #637: iPhone/PWA-complete VPS privileged maintenance capability
   lifecycle resumes after Issue #590 no longer blocks ordinary Dashboard Butler
   conversation continuity.

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -88,6 +88,7 @@ const MCP_SERVER_INFO = Object.freeze({
 const MCP_INSTRUCTIONS =
   "VTDD MCP は Butler と同じ runtime truth / review truth / operational memory を読むための read-first surface です。現在の truth は runtime truth を優先し、memory は補助として扱ってください。";
 const DASHBOARD_ICON_VERSION = "20260529-butler-v2";
+const DASHBOARD_CLIENT_VERSION = "20260601-issue-723-self-refresh";
 const DASHBOARD_ICON_PNG_PATH = `/dashboard-icon-${DASHBOARD_ICON_VERSION}.png`;
 const DASHBOARD_ICON_LINKS = `<link rel="icon" type="image/png" sizes="512x512" href="${DASHBOARD_ICON_PNG_PATH}">
   <link rel="shortcut icon" href="${DASHBOARD_ICON_PNG_PATH}">
@@ -13546,12 +13547,36 @@ function buildDashboardWebManifest(url) {
 
 function renderDashboardServiceWorkerScript() {
   return `
+const DASHBOARD_SERVICE_WORKER_VERSION = ${JSON.stringify(DASHBOARD_CLIENT_VERSION)};
+
+function isDashboardCacheName(name) {
+  const text = String(name || "").toLowerCase();
+  return text.includes("dashboard") || text.includes("vtdd");
+}
+
 self.addEventListener("install", () => {
   self.skipWaiting();
 });
 
 self.addEventListener("activate", (event) => {
   event.waitUntil(self.clients.claim());
+});
+
+self.addEventListener("message", (event) => {
+  const data = event.data || {};
+  if (data.type === "VTDD_DASHBOARD_CLEAR_CACHES") {
+    event.waitUntil((async () => {
+      if (typeof caches === "undefined") return;
+      const keys = await caches.keys();
+      await Promise.allSettled(keys.filter(isDashboardCacheName).map((key) => caches.delete(key)));
+    })());
+  }
+  if (data.type === "VTDD_DASHBOARD_VERSION") {
+    event.source?.postMessage?.({
+      type: "VTDD_DASHBOARD_VERSION",
+      serviceWorkerVersion: DASHBOARD_SERVICE_WORKER_VERSION
+    });
+  }
 });
 
 self.addEventListener("push", (event) => {
@@ -14388,6 +14413,10 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
     .pill.danger { border-color: #d69b9b; background: #fff0f0; color: #8a1f1f; }
     .deploy-event { border: 1px solid var(--border); border-radius: 12px; padding: 10px; margin: 10px 0; background: var(--soft); }
     .deploy-event p { margin-bottom: 6px; font-size: 13px; line-height: 1.45; }
+    .freshness-panel { border: 1px solid var(--border); border-radius: 12px; padding: 10px; margin: 10px 0; background: var(--soft); }
+    .freshness-panel p { margin-bottom: 6px; font-size: 13px; line-height: 1.45; }
+    .freshness-panel button { min-height: 36px; border: 1px solid var(--border); border-radius: 10px; padding: 7px 9px; color: var(--text); background: var(--button); font: inherit; font-size: 13px; font-weight: 750; }
+    .freshness-panel button:disabled { opacity: .55; }
     .quick-actions, .surface-list { display: grid; gap: 8px; }
     .quick-actions { grid-template-columns: repeat(2, minmax(0, 1fr)); }
     .quick-actions a, .surface-list a, .disabled-action { display: inline-flex; align-items: center; justify-content: center; min-height: 36px; border: 1px solid var(--border); border-radius: 10px; padding: 7px 9px; color: var(--text); text-decoration: none; background: var(--soft); font-weight: 750; font-size: 13px; text-align: center; }
@@ -14476,6 +14505,15 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
             <div class="lane-title"><h3>進行中</h3><span class="pill">状態</span></div>
             <p>直近の反映、失敗、進行中の作業があればここに出します。</p>
             ${renderDashboardDeployEvent(latestDeployEvent)}
+            <div class="freshness-panel" data-dashboard-freshness-panel data-client-version="${escapeDashboardHtml(DASHBOARD_CLIENT_VERSION)}">
+              <div class="lane-title"><h3>最新状態</h3><span class="pill" id="dashboard-freshness-pill">未確認</span></div>
+              <p id="dashboard-freshness-state">client build: ${escapeDashboardHtml(DASHBOARD_CLIENT_VERSION)}</p>
+              <p class="muted">2分 timeout など古い挙動が残る時は、PWA / service worker / WebSocket session が古い可能性をここで切り分けます。</p>
+              <div class="actions">
+                <button id="dashboard-refresh-check-button" type="button">最新状態を確認</button>
+                <button id="dashboard-force-refresh-button" type="button">強制キャッシュ削除リロード</button>
+              </div>
+            </div>
             <div class="quick-actions">
               ${renderDashboardActionList(cockpitActions)}
             </div>
@@ -14545,11 +14583,16 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
       const mediaButton = document.getElementById("butler-media-button");
       const mediaInput = document.getElementById("butler-media-input");
       const pendingMedia = document.getElementById("butler-pending-media");
+      const freshnessPill = document.getElementById("dashboard-freshness-pill");
+      const freshnessState = document.getElementById("dashboard-freshness-state");
+      const refreshCheckButton = document.getElementById("dashboard-refresh-check-button");
+      const forceRefreshButton = document.getElementById("dashboard-force-refresh-button");
       if (!form || !log || !textarea || !status) return;
 
       const socketEndpoint = form.dataset.socketEndpoint;
       const threadEndpoint = form.dataset.threadEndpoint;
       const mediaUploadEndpoint = "/v2/media/upload";
+      const dashboardClientVersion = ${JSON.stringify(DASHBOARD_CLIENT_VERSION)};
       const dashboardSignInUrl = ${JSON.stringify(dashboardSignInUrl)};
       const threadId = form.dataset.threadId;
       const repositoryInput = form.dataset.repositoryInput;
@@ -14570,6 +14613,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
       let authReturnResumePromise = null;
       const dashboardDraftKey = "vtdd.dashboard.draft:" + (threadId || "unknown");
       const dashboardDraftMetaKey = dashboardDraftKey + ":meta";
+      const dashboardForceRefreshKey = "vtdd.dashboard.forceRefresh:last";
 
       function getDashboardDraftStorage() {
         return window.sessionStorage;
@@ -14595,6 +14639,114 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           draftStorage.removeItem(dashboardDraftKey);
           draftStorage.removeItem(dashboardDraftMetaKey);
         } catch {}
+      }
+
+      function setFreshnessPill(text, ok) {
+        if (!freshnessPill) return;
+        freshnessPill.textContent = text;
+        freshnessPill.classList.toggle("success", ok === true);
+        freshnessPill.classList.toggle("danger", ok === false);
+      }
+
+      function setFreshnessState(text, options = {}) {
+        if (!freshnessState) return;
+        freshnessState.textContent = text;
+        setFreshnessPill(options.pill || "確認済み", options.ok);
+      }
+
+      async function getDashboardServiceWorkerRegistration() {
+        if (!("serviceWorker" in navigator)) return null;
+        try {
+          return await navigator.serviceWorker.getRegistration("/dashboard/");
+        } catch {
+          return null;
+        }
+      }
+
+      async function readDashboardFreshnessSnapshot() {
+        const registration = await getDashboardServiceWorkerRegistration();
+        const controllerState = navigator.serviceWorker?.controller ? "controllerあり" : "controllerなし";
+        const registrationState = registration
+          ? registration.waiting
+            ? "更新待ち"
+            : registration.installing
+              ? "installing"
+              : registration.active
+                ? "active"
+                : "registered"
+          : "未登録";
+        const socketState = describeChatSocketState();
+        return {
+          registration,
+          text: "client build: " + dashboardClientVersion + " / service worker: " + registrationState + " / " + controllerState + " / 接続状態: " + socketState
+        };
+      }
+
+      async function refreshDashboardFreshnessStatus(options = {}) {
+        try {
+          const snapshot = await readDashboardFreshnessSnapshot();
+          const lastForcedAt = getDashboardDraftStorage().getItem(dashboardForceRefreshKey) || "";
+          const suffix = lastForcedAt ? " / 前回の強制リロード: " + lastForcedAt : "";
+          setFreshnessState(snapshot.text + suffix, { ok: true, pill: options.pill || "確認済み" });
+          if (options.visibleStatus === true) {
+            setStatus("最新状態を確認しました。古い timeout 文言が続く場合は強制キャッシュ削除リロードを試せます。", { temporary: true });
+          }
+          return snapshot;
+        } catch {
+          setFreshnessState("最新状態を確認できませんでした。通常 reload か強制キャッシュ削除リロードを試してください。", { ok: false, pill: "要確認" });
+          return { registration: null, text: "" };
+        }
+      }
+
+      async function requestDashboardServiceWorkerCacheClear(registration) {
+        const target = registration?.active || registration?.waiting || registration?.installing || navigator.serviceWorker?.controller;
+        if (!target || typeof target.postMessage !== "function") return false;
+        try {
+          target.postMessage({
+            type: "VTDD_DASHBOARD_CLEAR_CACHES",
+            clientVersion: dashboardClientVersion,
+            threadId
+          });
+          return true;
+        } catch {
+          return false;
+        }
+      }
+
+      function isDashboardCacheName(name) {
+        const text = String(name || "").toLowerCase();
+        return text.includes("dashboard") || text.includes("vtdd");
+      }
+
+      async function clearDashboardCaches() {
+        if (!("caches" in window)) return 0;
+        const keys = await caches.keys();
+        const dashboardKeys = keys.filter(isDashboardCacheName);
+        await Promise.allSettled(dashboardKeys.map((key) => caches.delete(key)));
+        return dashboardKeys.length;
+      }
+
+      async function forceDashboardRefresh() {
+        persistDashboardDraft();
+        setFreshnessPill("更新中", null);
+        setStatus("強制キャッシュ削除リロードを準備しています。入力は保存します。添付は再選択が必要な場合があります。", { thinking: true });
+        if (forceRefreshButton) forceRefreshButton.disabled = true;
+        if (refreshCheckButton) refreshCheckButton.disabled = true;
+        try {
+          const snapshot = await readDashboardFreshnessSnapshot();
+          await requestDashboardServiceWorkerCacheClear(snapshot.registration);
+          await clearDashboardCaches();
+          if (snapshot.registration && typeof snapshot.registration.update === "function") {
+            await snapshot.registration.update().catch(() => null);
+          }
+          getDashboardDraftStorage().setItem(dashboardForceRefreshKey, new Date().toISOString());
+        } catch {
+          getDashboardDraftStorage().setItem(dashboardForceRefreshKey, new Date().toISOString() + " fallback");
+        } finally {
+          window.setTimeout(() => {
+            window.location.reload();
+          }, 120);
+        }
       }
 
       function restoreDashboardDraft() {
@@ -15790,6 +15942,12 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
 
       resizeComposerInput();
       restoreDashboardDraft();
+      refreshCheckButton?.addEventListener("click", () => {
+        refreshDashboardFreshnessStatus({ visibleStatus: true, pill: "確認済み" });
+      });
+      forceRefreshButton?.addEventListener("click", () => {
+        forceDashboardRefresh();
+      });
       textarea.addEventListener("input", () => {
         normalizeComposerInput();
         persistDashboardDraft();
@@ -15828,6 +15986,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
       window.addEventListener("pagehide", persistDashboardDraft);
       window.addEventListener("pageshow", async () => {
         if (await resumeDashboardSessionAfterAuthReturn("画面復帰後、再ログイン状態を確認しています。入力は保持しています。")) return;
+        refreshDashboardFreshnessStatus({ pill: "復帰確認" });
         dropStaleSocketIfNeeded();
         refreshThread();
         scheduleReconnect();
@@ -15838,6 +15997,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           return;
         }
         if (await resumeDashboardSessionAfterAuthReturn("画面復帰後、再ログイン状態を確認しています。入力は保持しています。")) return;
+        refreshDashboardFreshnessStatus({ pill: "表示中" });
         if (!chatSocket || chatSocket.readyState !== WebSocket.OPEN) {
           setConnectionRecoveryStatus("画面復帰を検知しました。接続を復帰しています。");
           dropStaleSocketIfNeeded();
@@ -15845,6 +16005,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           scheduleReconnect();
         }
       });
+      refreshDashboardFreshnessStatus({ pill: "初期確認" });
       connectThreadSocket();
     })();
   </script>

--- a/test/active-issue-execution-queue.test.js
+++ b/test/active-issue-execution-queue.test.js
@@ -84,7 +84,8 @@ test("active issue execution queue names current open PR hygiene", () => {
 });
 
 test("active issue execution queue names the next automatic implementation lane", () => {
-  assert.equal(sectionBody("Now").includes("Issue #590: app-server turn timeout / silent wait recovery"), true);
+  assert.equal(sectionBody("Now").includes("Issue #723: Dashboard Butler self-refresh and force cache reload"), true);
+  assert.equal(sectionBody("Next").includes("Issue #590: app-server turn timeout / silent wait recovery"), true);
   assert.equal(sectionBody("Next").includes("Issue #637: iPhone/PWA-complete VPS privileged maintenance"), true);
   assert.equal(sectionBody("Evidence Gaps").includes("Issue #606: PR #627 merged and production deployed"), true);
   assert.equal(

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -4369,6 +4369,16 @@ test("worker serves dashboard chat-first shell with debug and ops surfaces isola
   assert.equal(body.includes("<summary>開発/運用</summary>"), true);
   assert.equal(body.includes("<summary>Runtime surfaces</summary>"), false);
   assert.equal(body.includes("RAG を読む"), false);
+  assert.equal(body.includes("最新状態"), true);
+  assert.equal(body.includes("dashboard-refresh-check-button"), true);
+  assert.equal(body.includes("dashboard-force-refresh-button"), true);
+  assert.equal(body.includes("強制キャッシュ削除リロード"), true);
+  assert.equal(body.includes("20260601-issue-723-self-refresh"), true);
+  assert.equal(body.includes("VTDD_DASHBOARD_CLEAR_CACHES"), true);
+  assert.equal(body.includes("serviceWorker.getRegistration(\"/dashboard/\""), true);
+  assert.equal(body.includes("registration.update()"), true);
+  assert.equal(body.includes("window.location.reload()"), true);
+  assert.equal(body.includes("入力は保存します。添付は再選択が必要な場合があります。"), true);
 });
 
 test("worker uses explicit dashboard thread id for chat shell and passkey return", async () => {
@@ -4599,6 +4609,13 @@ test("worker serves dashboard PWA manifest and service worker notification handl
   assert.equal(serviceWorker.includes('pull\\/\\d+'), true);
   assert.equal(serviceWorker.includes("parsed.origin !== self.location.origin"), true);
   assert.equal(serviceWorker.includes('!parsed.pathname.startsWith("/dashboard/")'), true);
+  assert.equal(serviceWorker.includes("DASHBOARD_SERVICE_WORKER_VERSION"), true);
+  assert.equal(serviceWorker.includes("20260601-issue-723-self-refresh"), true);
+  assert.equal(serviceWorker.includes('self.addEventListener("message"'), true);
+  assert.equal(serviceWorker.includes("VTDD_DASHBOARD_CLEAR_CACHES"), true);
+  assert.equal(serviceWorker.includes("caches.keys()"), true);
+  assert.equal(serviceWorker.includes("isDashboardCacheName"), true);
+  assert.equal(serviceWorker.includes("Promise.allSettled"), true);
 
   const iconResponse = await worker.fetch(new Request("https://example.com/dashboard-icon.svg"));
   assert.equal(iconResponse.status, 200);

--- a/worker.js
+++ b/worker.js
@@ -57501,6 +57501,7 @@ var MCP_SERVER_INFO = Object.freeze({
 });
 var MCP_INSTRUCTIONS = "VTDD MCP \u306F Butler \u3068\u540C\u3058 runtime truth / review truth / operational memory \u3092\u8AAD\u3080\u305F\u3081\u306E read-first surface \u3067\u3059\u3002\u73FE\u5728\u306E truth \u306F runtime truth \u3092\u512A\u5148\u3057\u3001memory \u306F\u88DC\u52A9\u3068\u3057\u3066\u6271\u3063\u3066\u304F\u3060\u3055\u3044\u3002";
 var DASHBOARD_ICON_VERSION = "20260529-butler-v2";
+var DASHBOARD_CLIENT_VERSION = "20260601-issue-723-self-refresh";
 var DASHBOARD_ICON_PNG_PATH = `/dashboard-icon-${DASHBOARD_ICON_VERSION}.png`;
 var DASHBOARD_ICON_LINKS = `<link rel="icon" type="image/png" sizes="512x512" href="${DASHBOARD_ICON_PNG_PATH}">
   <link rel="shortcut icon" href="${DASHBOARD_ICON_PNG_PATH}">
@@ -69459,12 +69460,36 @@ function buildDashboardWebManifest(url) {
 }
 function renderDashboardServiceWorkerScript() {
   return `
+const DASHBOARD_SERVICE_WORKER_VERSION = ${JSON.stringify(DASHBOARD_CLIENT_VERSION)};
+
+function isDashboardCacheName(name) {
+  const text = String(name || "").toLowerCase();
+  return text.includes("dashboard") || text.includes("vtdd");
+}
+
 self.addEventListener("install", () => {
   self.skipWaiting();
 });
 
 self.addEventListener("activate", (event) => {
   event.waitUntil(self.clients.claim());
+});
+
+self.addEventListener("message", (event) => {
+  const data = event.data || {};
+  if (data.type === "VTDD_DASHBOARD_CLEAR_CACHES") {
+    event.waitUntil((async () => {
+      if (typeof caches === "undefined") return;
+      const keys = await caches.keys();
+      await Promise.allSettled(keys.filter(isDashboardCacheName).map((key) => caches.delete(key)));
+    })());
+  }
+  if (data.type === "VTDD_DASHBOARD_VERSION") {
+    event.source?.postMessage?.({
+      type: "VTDD_DASHBOARD_VERSION",
+      serviceWorkerVersion: DASHBOARD_SERVICE_WORKER_VERSION
+    });
+  }
 });
 
 self.addEventListener("push", (event) => {
@@ -70218,6 +70243,10 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
     .pill.danger { border-color: #d69b9b; background: #fff0f0; color: #8a1f1f; }
     .deploy-event { border: 1px solid var(--border); border-radius: 12px; padding: 10px; margin: 10px 0; background: var(--soft); }
     .deploy-event p { margin-bottom: 6px; font-size: 13px; line-height: 1.45; }
+    .freshness-panel { border: 1px solid var(--border); border-radius: 12px; padding: 10px; margin: 10px 0; background: var(--soft); }
+    .freshness-panel p { margin-bottom: 6px; font-size: 13px; line-height: 1.45; }
+    .freshness-panel button { min-height: 36px; border: 1px solid var(--border); border-radius: 10px; padding: 7px 9px; color: var(--text); background: var(--button); font: inherit; font-size: 13px; font-weight: 750; }
+    .freshness-panel button:disabled { opacity: .55; }
     .quick-actions, .surface-list { display: grid; gap: 8px; }
     .quick-actions { grid-template-columns: repeat(2, minmax(0, 1fr)); }
     .quick-actions a, .surface-list a, .disabled-action { display: inline-flex; align-items: center; justify-content: center; min-height: 36px; border: 1px solid var(--border); border-radius: 10px; padding: 7px 9px; color: var(--text); text-decoration: none; background: var(--soft); font-weight: 750; font-size: 13px; text-align: center; }
@@ -70306,6 +70335,15 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
             <div class="lane-title"><h3>\u9032\u884C\u4E2D</h3><span class="pill">\u72B6\u614B</span></div>
             <p>\u76F4\u8FD1\u306E\u53CD\u6620\u3001\u5931\u6557\u3001\u9032\u884C\u4E2D\u306E\u4F5C\u696D\u304C\u3042\u308C\u3070\u3053\u3053\u306B\u51FA\u3057\u307E\u3059\u3002</p>
             ${renderDashboardDeployEvent(latestDeployEvent)}
+            <div class="freshness-panel" data-dashboard-freshness-panel data-client-version="${escapeDashboardHtml(DASHBOARD_CLIENT_VERSION)}">
+              <div class="lane-title"><h3>\u6700\u65B0\u72B6\u614B</h3><span class="pill" id="dashboard-freshness-pill">\u672A\u78BA\u8A8D</span></div>
+              <p id="dashboard-freshness-state">client build: ${escapeDashboardHtml(DASHBOARD_CLIENT_VERSION)}</p>
+              <p class="muted">2\u5206 timeout \u306A\u3069\u53E4\u3044\u6319\u52D5\u304C\u6B8B\u308B\u6642\u306F\u3001PWA / service worker / WebSocket session \u304C\u53E4\u3044\u53EF\u80FD\u6027\u3092\u3053\u3053\u3067\u5207\u308A\u5206\u3051\u307E\u3059\u3002</p>
+              <div class="actions">
+                <button id="dashboard-refresh-check-button" type="button">\u6700\u65B0\u72B6\u614B\u3092\u78BA\u8A8D</button>
+                <button id="dashboard-force-refresh-button" type="button">\u5F37\u5236\u30AD\u30E3\u30C3\u30B7\u30E5\u524A\u9664\u30EA\u30ED\u30FC\u30C9</button>
+              </div>
+            </div>
             <div class="quick-actions">
               ${renderDashboardActionList(cockpitActions)}
             </div>
@@ -70375,11 +70413,16 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
       const mediaButton = document.getElementById("butler-media-button");
       const mediaInput = document.getElementById("butler-media-input");
       const pendingMedia = document.getElementById("butler-pending-media");
+      const freshnessPill = document.getElementById("dashboard-freshness-pill");
+      const freshnessState = document.getElementById("dashboard-freshness-state");
+      const refreshCheckButton = document.getElementById("dashboard-refresh-check-button");
+      const forceRefreshButton = document.getElementById("dashboard-force-refresh-button");
       if (!form || !log || !textarea || !status) return;
 
       const socketEndpoint = form.dataset.socketEndpoint;
       const threadEndpoint = form.dataset.threadEndpoint;
       const mediaUploadEndpoint = "/v2/media/upload";
+      const dashboardClientVersion = ${JSON.stringify(DASHBOARD_CLIENT_VERSION)};
       const dashboardSignInUrl = ${JSON.stringify(dashboardSignInUrl)};
       const threadId = form.dataset.threadId;
       const repositoryInput = form.dataset.repositoryInput;
@@ -70400,6 +70443,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
       let authReturnResumePromise = null;
       const dashboardDraftKey = "vtdd.dashboard.draft:" + (threadId || "unknown");
       const dashboardDraftMetaKey = dashboardDraftKey + ":meta";
+      const dashboardForceRefreshKey = "vtdd.dashboard.forceRefresh:last";
 
       function getDashboardDraftStorage() {
         return window.sessionStorage;
@@ -70425,6 +70469,114 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           draftStorage.removeItem(dashboardDraftKey);
           draftStorage.removeItem(dashboardDraftMetaKey);
         } catch {}
+      }
+
+      function setFreshnessPill(text, ok) {
+        if (!freshnessPill) return;
+        freshnessPill.textContent = text;
+        freshnessPill.classList.toggle("success", ok === true);
+        freshnessPill.classList.toggle("danger", ok === false);
+      }
+
+      function setFreshnessState(text, options = {}) {
+        if (!freshnessState) return;
+        freshnessState.textContent = text;
+        setFreshnessPill(options.pill || "\u78BA\u8A8D\u6E08\u307F", options.ok);
+      }
+
+      async function getDashboardServiceWorkerRegistration() {
+        if (!("serviceWorker" in navigator)) return null;
+        try {
+          return await navigator.serviceWorker.getRegistration("/dashboard/");
+        } catch {
+          return null;
+        }
+      }
+
+      async function readDashboardFreshnessSnapshot() {
+        const registration = await getDashboardServiceWorkerRegistration();
+        const controllerState = navigator.serviceWorker?.controller ? "controller\u3042\u308A" : "controller\u306A\u3057";
+        const registrationState = registration
+          ? registration.waiting
+            ? "\u66F4\u65B0\u5F85\u3061"
+            : registration.installing
+              ? "installing"
+              : registration.active
+                ? "active"
+                : "registered"
+          : "\u672A\u767B\u9332";
+        const socketState = describeChatSocketState();
+        return {
+          registration,
+          text: "client build: " + dashboardClientVersion + " / service worker: " + registrationState + " / " + controllerState + " / \u63A5\u7D9A\u72B6\u614B: " + socketState
+        };
+      }
+
+      async function refreshDashboardFreshnessStatus(options = {}) {
+        try {
+          const snapshot = await readDashboardFreshnessSnapshot();
+          const lastForcedAt = getDashboardDraftStorage().getItem(dashboardForceRefreshKey) || "";
+          const suffix = lastForcedAt ? " / \u524D\u56DE\u306E\u5F37\u5236\u30EA\u30ED\u30FC\u30C9: " + lastForcedAt : "";
+          setFreshnessState(snapshot.text + suffix, { ok: true, pill: options.pill || "\u78BA\u8A8D\u6E08\u307F" });
+          if (options.visibleStatus === true) {
+            setStatus("\u6700\u65B0\u72B6\u614B\u3092\u78BA\u8A8D\u3057\u307E\u3057\u305F\u3002\u53E4\u3044 timeout \u6587\u8A00\u304C\u7D9A\u304F\u5834\u5408\u306F\u5F37\u5236\u30AD\u30E3\u30C3\u30B7\u30E5\u524A\u9664\u30EA\u30ED\u30FC\u30C9\u3092\u8A66\u305B\u307E\u3059\u3002", { temporary: true });
+          }
+          return snapshot;
+        } catch {
+          setFreshnessState("\u6700\u65B0\u72B6\u614B\u3092\u78BA\u8A8D\u3067\u304D\u307E\u305B\u3093\u3067\u3057\u305F\u3002\u901A\u5E38 reload \u304B\u5F37\u5236\u30AD\u30E3\u30C3\u30B7\u30E5\u524A\u9664\u30EA\u30ED\u30FC\u30C9\u3092\u8A66\u3057\u3066\u304F\u3060\u3055\u3044\u3002", { ok: false, pill: "\u8981\u78BA\u8A8D" });
+          return { registration: null, text: "" };
+        }
+      }
+
+      async function requestDashboardServiceWorkerCacheClear(registration) {
+        const target = registration?.active || registration?.waiting || registration?.installing || navigator.serviceWorker?.controller;
+        if (!target || typeof target.postMessage !== "function") return false;
+        try {
+          target.postMessage({
+            type: "VTDD_DASHBOARD_CLEAR_CACHES",
+            clientVersion: dashboardClientVersion,
+            threadId
+          });
+          return true;
+        } catch {
+          return false;
+        }
+      }
+
+      function isDashboardCacheName(name) {
+        const text = String(name || "").toLowerCase();
+        return text.includes("dashboard") || text.includes("vtdd");
+      }
+
+      async function clearDashboardCaches() {
+        if (!("caches" in window)) return 0;
+        const keys = await caches.keys();
+        const dashboardKeys = keys.filter(isDashboardCacheName);
+        await Promise.allSettled(dashboardKeys.map((key) => caches.delete(key)));
+        return dashboardKeys.length;
+      }
+
+      async function forceDashboardRefresh() {
+        persistDashboardDraft();
+        setFreshnessPill("\u66F4\u65B0\u4E2D", null);
+        setStatus("\u5F37\u5236\u30AD\u30E3\u30C3\u30B7\u30E5\u524A\u9664\u30EA\u30ED\u30FC\u30C9\u3092\u6E96\u5099\u3057\u3066\u3044\u307E\u3059\u3002\u5165\u529B\u306F\u4FDD\u5B58\u3057\u307E\u3059\u3002\u6DFB\u4ED8\u306F\u518D\u9078\u629E\u304C\u5FC5\u8981\u306A\u5834\u5408\u304C\u3042\u308A\u307E\u3059\u3002", { thinking: true });
+        if (forceRefreshButton) forceRefreshButton.disabled = true;
+        if (refreshCheckButton) refreshCheckButton.disabled = true;
+        try {
+          const snapshot = await readDashboardFreshnessSnapshot();
+          await requestDashboardServiceWorkerCacheClear(snapshot.registration);
+          await clearDashboardCaches();
+          if (snapshot.registration && typeof snapshot.registration.update === "function") {
+            await snapshot.registration.update().catch(() => null);
+          }
+          getDashboardDraftStorage().setItem(dashboardForceRefreshKey, new Date().toISOString());
+        } catch {
+          getDashboardDraftStorage().setItem(dashboardForceRefreshKey, new Date().toISOString() + " fallback");
+        } finally {
+          window.setTimeout(() => {
+            window.location.reload();
+          }, 120);
+        }
       }
 
       function restoreDashboardDraft() {
@@ -71620,6 +71772,12 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
 
       resizeComposerInput();
       restoreDashboardDraft();
+      refreshCheckButton?.addEventListener("click", () => {
+        refreshDashboardFreshnessStatus({ visibleStatus: true, pill: "\u78BA\u8A8D\u6E08\u307F" });
+      });
+      forceRefreshButton?.addEventListener("click", () => {
+        forceDashboardRefresh();
+      });
       textarea.addEventListener("input", () => {
         normalizeComposerInput();
         persistDashboardDraft();
@@ -71658,6 +71816,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
       window.addEventListener("pagehide", persistDashboardDraft);
       window.addEventListener("pageshow", async () => {
         if (await resumeDashboardSessionAfterAuthReturn("\u753B\u9762\u5FA9\u5E30\u5F8C\u3001\u518D\u30ED\u30B0\u30A4\u30F3\u72B6\u614B\u3092\u78BA\u8A8D\u3057\u3066\u3044\u307E\u3059\u3002\u5165\u529B\u306F\u4FDD\u6301\u3057\u3066\u3044\u307E\u3059\u3002")) return;
+        refreshDashboardFreshnessStatus({ pill: "\u5FA9\u5E30\u78BA\u8A8D" });
         dropStaleSocketIfNeeded();
         refreshThread();
         scheduleReconnect();
@@ -71668,6 +71827,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           return;
         }
         if (await resumeDashboardSessionAfterAuthReturn("\u753B\u9762\u5FA9\u5E30\u5F8C\u3001\u518D\u30ED\u30B0\u30A4\u30F3\u72B6\u614B\u3092\u78BA\u8A8D\u3057\u3066\u3044\u307E\u3059\u3002\u5165\u529B\u306F\u4FDD\u6301\u3057\u3066\u3044\u307E\u3059\u3002")) return;
+        refreshDashboardFreshnessStatus({ pill: "\u8868\u793A\u4E2D" });
         if (!chatSocket || chatSocket.readyState !== WebSocket.OPEN) {
           setConnectionRecoveryStatus("\u753B\u9762\u5FA9\u5E30\u3092\u691C\u77E5\u3057\u307E\u3057\u305F\u3002\u63A5\u7D9A\u3092\u5FA9\u5E30\u3057\u3066\u3044\u307E\u3059\u3002");
           dropStaleSocketIfNeeded();
@@ -71675,6 +71835,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           scheduleReconnect();
         }
       });
+      refreshDashboardFreshnessStatus({ pill: "\u521D\u671F\u78BA\u8A8D" });
       connectThreadSocket();
     })();
   <\/script>


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #723 の部分進捗です。PR #721 deploy 後も古い 2分 timeout 文言が残った owner live evidence を受けて、Dashboard Butler に client / service worker / connection freshness を owner-facing に確認する入口を追加しました。
- Dashboard PWA の管理メニュー内に「最新状態を確認」と「強制キャッシュ削除リロード」を追加し、通常チャット入力欄や割り込み UI は増やしていません。
- 強制リロード前に draft / thread id / repository context を保持し、添付は reload を跨げないため再選択が必要な場合があることを明示します。
- Service Worker は `VTDD_DASHBOARD_CLEAR_CACHES` message を受け、dashboard / vtdd 系 cache だけを best-effort で削除します。

## Satisfied Success Criteria

- Dashboard Butler が client build / service worker registration / controller / connection state を owner-facing に表示する入口を持つ。
- owner が明示的に選べる「強制キャッシュ削除リロード」導線を持つ。
- 強制リロード前に draft を保存し、thread id / repository context を URL と sessionStorage 経由で保持する。
- refresh 操作は deploy / root / credential / permission mutation を開始しない。
- Issue #590 の production E2E を stale client と actual app-server stall に分けて読むため、active queue を Issue #723 temporary ROOT support として更新した。

## Unsatisfied Success Criteria

- production deploy event から同じ thread に refresh 推奨を自動投稿する経路は未接続です。
- 自然文「リフレッシュして」「最新か確認して」からこの UI を実行する Butler tool/action path は未接続です。
- app-server bridge session id / runtime freshness truth の canonical model は未接続です。
- production iPhone/PWA E2E は未実施です。merge/deploy 後に確認します。

## Non-goal violations

None.

## 開発前作戦図

- 作戦図 evidence: docs/development-strategy/issue-723-dashboard-self-refresh.md
- 完了体験: owner が Dashboard Butler PWA だけで stale client / service worker / session の可能性を確認し、強制キャッシュ削除リロードで復帰できる。
- VTDD 全体で進める部分: Issue #590 の watchdog E2E を正しく読むための freshness recovery 前提を作る。
- 設計: Dashboard Butler owner-facing surface の管理メニュー内に freshness panel を追加し、scope は `/dashboard` と `/dashboard-sw.js` に限定し、通常チャット面と high-risk authority 境界は崩さない。
- 仮説: PR #721 deploy truth は成功していたが、PWA が古い client / service worker / WebSocket session を掴み続けたことが原因で旧 timeout 文言が出た、という仮説で進める。
- 検証計画: Dashboard HTML、Service Worker script、generated worker、active queue の unit/integration checks で確認する。
- 改修見積もり: `src/worker/runtime.js`、`worker.js`、`test/worker.test.js`、`test/active-issue-execution-queue.test.js`、`docs/mvp/active-issue-execution-queue.md`、strategy doc。
- 既に通っている経路: PR #721 は merge/deploy 成功、owner は `⌘ + R` で復帰できた。
- 未確認の境界: iOS PWA の Cache Storage / service worker update 即時反映は production E2E まで未確認。
- 穴が出そうな箇所: 添付 file object は reload を跨げないため、draft text と context 保存に限定する。
- PR 前に確認すること: `git diff --check`、focused worker test、active queue test、`npm run build:worker`、`npm run check:generated-worker`、clean-env `npm test` を通し、deploy/root/credential mutation を含まないことと通常チャット入力欄を増やしていないことを確認する。
- 実装候補と捨てた案: 自動 reload と全 cache/unregister は捨て、owner 明示ボタンと dashboard/vtdd scoped cache clear を採用。
- merge 後に通す E2E: Issue #723 / Issue #590 の production Dashboard Butler same-thread E2E として、freshness 表示、強制リロード後の同一 thread/context 復帰、旧 timeout 再発時の stale client / actual app-server stall 切り分けを確認する。
- 次の PR を増やさない理由: UI、service worker message handler、queue/test evidence は同じ runtime surface に閉じるため、この PR でまとめる。
- 停止条件: 通常送信、draft retention、WebSocket reconnect、high-risk authority へ踏み込む必要が出た場合は停止する。

## Dry-run Impact Report

- Target Issue: Issue #723
- Implementing Success Criteria: owner-facing freshness status、強制キャッシュ削除リロード、draft/context 保持、service worker cache clear message。
- Explicit Non-goals: deploy 実行、root/sudo、credential/permission mutation、Issue #590 完了宣言、app-server bridge restart。
- Expected touched files/routes/workflows: `/dashboard` HTML/client script、`/dashboard-sw.js` script、active queue docs、worker tests、generated `worker.js`。
- Affected Issues: Issue #723、Issue #590、Issue #528、Issue #514。
- Affected PRs: PR #721 は既に merged/deployed。この PR は follow-up です。
- Affected workflows: GitHub Actions workflow は変更なし。deploy-production は merge 後の E2E 対象のみ。
- Affected runtime/operator surfaces: Dashboard Butler PWA、Dashboard Service Worker、Dashboard notification/recovery surface。
- What may break if we patch narrowly: timeout 秒数だけ伸ばすと stale PWA を actual app-server stall と誤読する。
- Unknowns to investigate before coding: iOS PWA の cache deletion / service worker update 即時性。
- Validation needed: worker focused tests、active queue test、build:worker、check:generated-worker、clean-env npm test、production PWA E2E。
- Stop condition: high-risk operation、通常チャット UX regressions、添付完全保持要求が出た場合。

## Execution Queue Delta

- Queue position before: Issue #590 が Now。PR #721 deploy 後の stale PWA evidence により Issue #590 の E2E 判定が曖昧になっていた。
- Preemption decision: ROOT。Issue #723 は Issue #590 の temporary ROOT support で、stale client が watchdog evidence を隠すため先行する。
- Queue delta: Issue #723 を Now に移し、Issue #590 を Next に戻した。Issue #637 はその後の Next として維持。
- Why this PR is next: owner-facing PWA が古いままだと、正しい app-server activity watchdog が deploy 済みでも owner は旧 2分 timeout を見続ける。
- Active Issues not downscoped: Active Issues are not downscoped. Active Issues は縮小していません。Issue #590、Issue #637、Issue #528、Issue #514 は未完了のまま残します。

## File / Line Hypotheses

- file: `src/worker/runtime.js`
  - hypothesis: Dashboard main shell と service worker に freshness / force refresh path がないため、deploy 後 stale client を owner が切り分けられない。
  - risk if changed narrowly: 通常チャット入力欄や WebSocket send path を触ると Issue #528 / Issue #590 の regressions を増やす。
  - validation: Dashboard shell test、PWA service worker test、focused worker test。
  - related Issue: Issue #723
- file: `docs/mvp/active-issue-execution-queue.md`
  - hypothesis: Issue #723 を queue に残さないと、Issue #590 evidence が stale client と actual stall を混同する。
  - risk if changed narrowly: Issue #590 を完了扱いに近づける drift が起きる。
  - validation: active issue execution queue test。
  - related Issue: Issue #723 / Issue #590

## Hypothesis Retrospective

- expected: Dashboard PWA に owner-facing freshness / force refresh path を追加できる。
- actual: 通常チャット欄を変えず、管理メニュー内の freshness panel と service worker cache clear message を追加した。
- mismatch: production PWA E2E は merge/deploy 後まで未実施。
- lesson: 2分 timeout 再発は app-server だけでなく stale PWA/client として切り分ける必要がある。
- should become RAG candidate: はい。PR #721 deploy 後に `⌘ + R` で復帰した stale PWA evidence は RAG candidate。

## Verification Evidence

- Unit: `node --test test/active-issue-execution-queue.test.js`
- Integration: `node --test test/worker.test.js --test-name-pattern "dashboard chat-first shell|dashboard PWA manifest|allowed owner identity"`
- E2E: 未実施。merge/deploy 後に production Dashboard Butler PWA で確認する。
- Manual: `npm run build:worker`; `npm run check:generated-worker`; `git diff --check`
- Evidence path/link: `env -u VTDD_GATEWAY_BEARER_TOKEN -u VTDD_RUNTIME_URL -u VTDD_DASHBOARD_APP_SERVER_ENV -u VTDD_DASHBOARD_THREAD_ID HOME=/tmp/vtdd-empty-home npm test` passed: 1116 pass, 0 fail, 1 skipped, plus self-parity and generated-worker checks passed.

## Butler Completion Contract

- Primary owner surface: Dashboard Butler PWA。
- Fallback surface: Custom GPT / mac Codex は fallback。主経路ではありません。
- Owner goal: stale Dashboard client / service worker / session を owner が PWA 上で確認し、必要なら強制リロードできる。
- Butler entrypoint: `/dashboard` の管理メニュー内 freshness panel。
- Dashboard Butler natural-language path: Dashboard Butler 通常チャットで「古いかも」「リフレッシュしたい」と相談できる前提を残し、この PR では管理メニュー内の owner-facing entrypoint へ到達する説明経路を追加します。自然文から直接実行する tool path は follow-up です。
- Action Schema exposure: 未変更。
- Runtime path: `/dashboard` HTML と `/dashboard-sw.js`。
- Runner/runtime truth: client build、service worker registration/controller、connection state を表示する。app-server bridge canonical truth は未接続。
- Authority boundary: deploy / root / credential / permission mutation は開始しない。高リスク操作は既存 GO/passkey 境界のまま。
- E2E evidence: production iPhone/PWA E2E は未実施。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 未実行。deploy は passkey 境界外なのでこの PR では行わない。
- Custom GPT Action Schema update: 不要。この PR は Dashboard PWA / service worker の runtime surface 更新です。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。merge/deploy 後に production Dashboard Butler PWA で確認する。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate
- AGENTS.md Butler-First Operating Principle
- AGENTS.md Drift Stop Protocol
- docs/butler/execution-queue-contract.md

## Out-of-scope but NOT implemented

- 自然文「リフレッシュして」からの tool/action 実行。
- deploy event から same-thread 自動 refresh 推奨投稿。
- app-server bridge canonical freshness truth。
- production deploy / merge / Issue close。

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #723
- Execution ID: dashboard-butler-local-issue-723
- Goal: Dashboard Butler self-refresh and force cache reload for stale PWA/client state
