### PR TITLE
Issue #590 allow follow-up input during stalled recovery

### DIFF
--- a/docs/development-strategy/issue-590-stalled-owner-input-recovery.md
+++ b/docs/development-strategy/issue-590-stalled-owner-input-recovery.md
@@ -1,0 +1,63 @@
+# Issue #590 stalled owner input recovery
+
+## 完了体験
+
+owner が Dashboard Butler PWA で `codex app-server から進行イベントがしばらく届いていません` を見ても、通常チャット入力欄から同じ thread に追加連絡できる。Butler は「待つしかない」状態ではなく、入力欄が使えることを明示し、保存済みの依頼に続けて補足・短縮・キャンセル指示を送れる。
+
+## VTDD 全体で進める部分
+
+Issue #590 の parent root である app-server timeout / silent wait recovery を進める。Issue #723 の stale client recovery は production evidence 済みなので、次は stalled recovery 中の owner input path を守る。
+
+## 設計
+
+Dashboard client が `transient_status: stalled` または thread 上の `status: failed/stalled` を受け取ったら、composer を明示的に解放し、submit button も復帰させる。表示文言は「入力は保存済み」「このまま追加メッセージを送れます」を含める。runtime route、deploy、bridge timeout 値、stop/interrupt UI は触らない。
+
+## 仮説
+
+owner が「連絡できない」と感じる原因は、VPS Codex CLI が裏で動いていても Dashboard 側に progress が来ない時、stalled recovery 表示が通常入力の継続可否を明示せず、composer lock が残り得ることにある。タイマー値を伸ばすより、stalled event 受信時に owner input path を復旧する方が drift が少ない。
+
+## 検証計画
+
+`test/worker.test.js` で Dashboard HTML が stalled transient status / thread failed status を受けた時に `releaseComposerForFollowUp` 相当を呼び、追加メッセージを送れる文言を持つことを確認する。`npm run build:worker` と `npm run check:generated-worker` で generated worker を同期する。
+
+## 改修見積もり
+
+- `src/worker/runtime.js`: Dashboard client script の WebSocket message handler。stalled / failed recovery status 受信時に composer を解放する helper と owner-facing 文言を追加する。リスクは通常送信中の未保存入力を誤って解放すること。
+- `test/worker.test.js`: Dashboard HTML string assertion を追加/更新し、stalled recovery が follow-up input を許すことを固定する。
+- `worker.js`: generated worker を build で同期する。
+
+## 既に通っている経路
+
+PR #721 は fixed timeout を activity watchdog 化した。PR #724 は stale client recovery を追加した。PR #725 は queue を Issue #590 に戻した。owner production evidence では stalled recovery 表示がまだ出ており、ここが現在の root symptom。
+
+## 未確認の境界
+
+app-server bridge が本当に CLI activity を受け取れていないのか、受け取っているが Dashboard thread に出していないのかは未確認。この PR では bridge heartbeat 根本修正までは扱わない。
+
+## 穴が出そうな箇所
+
+composer を解放しすぎると、保存確認前の送信を二重送信する恐れがある。`pendingOwnerSend` が残っている送信確認前は既存ロックを守り、stalled recovery 後の follow-up だけを解放対象にする。
+
+## PR 前に確認すること
+
+Issue #590、PR #725 merge truth、active queue の Now が Issue #590 であることを確認する。対象 source と tests を読んでから code edit する。
+
+## 実装候補と捨てた案
+
+採用: stalled / failed recovery 表示時に composer follow-up を明示的に解放し、文言で追加送信可能と伝える。
+
+捨てた案: timeout をさらに伸ばす。無制限待機に近づき、本当に返らない時の復旧を壊すため。
+
+捨てた案: stop/interrupt UI を同時に作る。公式アプリ調査が必要で、この owner input recovery slice から外れるため。
+
+## merge 後に通す E2E
+
+production Dashboard Butler で stalled recovery 表示が出た時、owner がそのまま同じ composer から「もしもし」などの追加メッセージを送れ、同じ thread に保存されることを確認する。
+
+## 次の PR を増やさない理由
+
+この PR は stalled 表示と composer follow-up の単一 owner-facing 穴を塞ぐ。bridge heartbeat / progress event の根本修正は別 scope として残るが、owner が連絡不能になる穴はこの PR で閉じる必要がある。
+
+## 停止条件
+
+実装中に bridge protocol 変更、deploy、passkey、root/VPS helper、stop/interrupt UI、または Issue #590 完了 claim が必要になったら停止する。

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -14827,6 +14827,32 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         if (mediaButton) mediaButton.disabled = locked === true;
       }
 
+      function withFollowUpInstruction(text) {
+        const base = String(text || "").trim();
+        const instruction = "このまま同じ thread に追加メッセージを送れます。";
+        if (!base) return instruction;
+        return base.includes("追加メッセージを送れます") ? base : base + " " + instruction;
+      }
+
+      function withPendingSendRecoveryInstruction(text) {
+        const base = String(text || "").trim() || "codex app-server から進行イベントがしばらく届いていません。";
+        const instruction = "送信保存を確認中のため入力欄は保持しています。確認後に同じ thread へ追加できます。";
+        return base.includes("送信保存を確認中") ? base : base + " " + instruction;
+      }
+
+      function releaseComposerForFollowUp(text) {
+        if (pendingOwnerSend) {
+          setStatus(withPendingSendRecoveryInstruction(text), { thinking: true });
+          return false;
+        }
+        const submitButton = form.querySelector("button[type='submit']");
+        setComposerLocked(false);
+        if (submitButton) submitButton.disabled = false;
+        setStatus(withFollowUpInstruction(text));
+        updateComposerReserve();
+        return true;
+      }
+
       function isChatSocketOpen() {
         return Boolean(chatSocket && chatSocket.readyState === WebSocket.OPEN);
       }
@@ -15728,17 +15754,21 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
               const lastMessage = Array.isArray(body.messages) ? body.messages[body.messages.length - 1] : null;
               if (lastMessage?.role === "butler" && lastMessage?.status === "replied") {
                 setStatus("返信を受信しました。", { temporary: true });
-              } else if (lastMessage?.status === "failed") {
-                setStatus(lastMessage.text || "応答生成が時間切れになりました。同じ thread で続けられます。");
+              } else if (lastMessage?.status === "failed" || lastMessage?.status === "stalled") {
+                releaseComposerForFollowUp(lastMessage.text || "応答生成が時間切れになりました。同じ thread で続けられます。");
               } else if (releasedFromThread) {
                 setStatus("送信を保存しました。app-server bridge の返信を待っています", { thinking: true });
               }
             } else if (body.type === "transient_status" && body.ok) {
               const isThinking = body.status === "thinking";
-              setStatus(body.text || (isThinking ? "codex app-server が応答を生成しています" : "codex app-server の応答が完了しました。"), {
-                thinking: isThinking,
-                temporary: !isThinking
-              });
+              if (body.status === "stalled") {
+                releaseComposerForFollowUp(body.text || "codex app-server から進行イベントがしばらく届いていません。");
+              } else {
+                setStatus(body.text || (isThinking ? "codex app-server が応答を生成しています" : "codex app-server の応答が完了しました。"), {
+                  thinking: isThinking,
+                  temporary: !isThinking
+                });
+              }
             } else if (body.type === "owner_message_accepted" && body.ok) {
               const clientMessageId = body.clientMessageId || body.client_message_id || "";
               if (clientMessageId) {

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -212,6 +212,32 @@ function loadDashboardInlineChatHelpers(html) {
   );
 }
 
+function loadDashboardComposerRecoveryHelpers(html) {
+  const names = [
+    "setComposerLocked",
+    "withFollowUpInstruction",
+    "withPendingSendRecoveryInstruction",
+    "releaseComposerForFollowUp"
+  ];
+  const sources = names.map((name) => extractDashboardInlineFunction(html, name)).join("\n");
+  return Function(
+    `${sources}
+    const statusLog = [];
+    const textarea = { readOnly: true };
+    const mediaButton = { disabled: true };
+    const submitButton = { disabled: true };
+    const form = { querySelector(selector) { return selector === "button[type='submit']" ? submitButton : null; } };
+    let pendingOwnerSend = null;
+    function setStatus(text, options = {}) { statusLog.push({ text, options }); }
+    function updateComposerReserve() { statusLog.push({ reserveUpdated: true }); }
+    return {
+      releaseComposerForFollowUp,
+      setPendingOwnerSend(value) { pendingOwnerSend = value; },
+      getState() { return { textarea, mediaButton, submitButton, statusLog }; }
+    };`
+  )();
+}
+
 test("dashboard chat message text safely decodes command-like percent encoded lines", () => {
   assert.equal(
     normalizeDashboardChatMessageText("go:%0Adeploy%20production%0Aissue%20%23524"),
@@ -1318,6 +1344,12 @@ test("worker serves v2 dashboard for allowed owner identity without exposing sec
   assert.equal(body.includes("WebSocket 再接続中です。入力は保持しています。接続後に自動送信します。"), true);
   assert.equal(body.includes("queuedWhileDisconnected: true"), true);
   assert.equal(body.includes("setComposerLocked(false);"), true);
+  assert.equal(body.includes("function releaseComposerForFollowUp("), true);
+  assert.equal(body.includes("このまま同じ thread に追加メッセージを送れます。"), true);
+  assert.equal(body.includes("function withPendingSendRecoveryInstruction("), true);
+  assert.equal(body.includes("送信保存を確認中のため入力欄は保持しています。確認後に同じ thread へ追加できます。"), true);
+  assert.equal(body.includes('body.status === "stalled"'), true);
+  assert.equal(body.includes('lastMessage?.status === "failed" || lastMessage?.status === "stalled"'), true);
   assert.equal(body.includes("接続しました。未送信の入力を送信しています。"), true);
   assert.equal(body.includes("sendPendingOwnerMessage(\"接続しました。未送信の入力を送信しています。\")"), true);
   assert.equal(body.includes("refreshThread().then"), true);
@@ -1818,6 +1850,42 @@ test("worker serves dashboard media add controls for iPhone-first upload", async
   assert.equal(body.includes("setComposerLocked(true)"), true);
   assert.equal(body.includes("releasePendingOwnerSend(clientMessageId, { clearComposer: true })"), true);
   assert.equal(body.includes("owner_message_accepted"), true);
+});
+
+test("dashboard stalled recovery unlocks follow-up composer after saved sends only", async () => {
+  const response = await worker.fetch(
+    new Request("https://example.com/dashboard", {
+      headers: dashboardAccessHeaders
+    }),
+    dashboardAccessEnv
+  );
+  assert.equal(response.status, 200);
+  const helpers = loadDashboardComposerRecoveryHelpers(await response.text());
+
+  assert.equal(helpers.releaseComposerForFollowUp("進行イベントがしばらく届いていません。"), true);
+  let state = helpers.getState();
+  assert.equal(state.textarea.readOnly, false);
+  assert.equal(state.mediaButton.disabled, false);
+  assert.equal(state.submitButton.disabled, false);
+  assert.equal(
+    state.statusLog.some((entry) => String(entry.text || "").includes("このまま同じ thread に追加メッセージを送れます。")),
+    true
+  );
+  assert.equal(state.statusLog.some((entry) => entry.reserveUpdated === true), true);
+
+  state.textarea.readOnly = true;
+  state.mediaButton.disabled = true;
+  state.submitButton.disabled = true;
+  helpers.setPendingOwnerSend({ clientMessageId: "pending-owner-send" });
+  assert.equal(helpers.releaseComposerForFollowUp("進行イベントがしばらく届いていません。"), false);
+  state = helpers.getState();
+  assert.equal(state.textarea.readOnly, true);
+  assert.equal(state.mediaButton.disabled, true);
+  assert.equal(state.submitButton.disabled, true);
+  const latestStatus = state.statusLog.at(-1);
+  assert.equal(String(latestStatus.text || "").includes("進行イベントがしばらく届いていません。"), true);
+  assert.equal(String(latestStatus.text || "").includes("送信保存を確認中のため入力欄は保持しています。"), true);
+  assert.equal(latestStatus.options.thinking, true);
 });
 
 test("worker uploads dashboard media to R2 and stores D1 metadata reference only", async () => {

--- a/worker.js
+++ b/worker.js
@@ -70657,6 +70657,32 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         if (mediaButton) mediaButton.disabled = locked === true;
       }
 
+      function withFollowUpInstruction(text) {
+        const base = String(text || "").trim();
+        const instruction = "\u3053\u306E\u307E\u307E\u540C\u3058 thread \u306B\u8FFD\u52A0\u30E1\u30C3\u30BB\u30FC\u30B8\u3092\u9001\u308C\u307E\u3059\u3002";
+        if (!base) return instruction;
+        return base.includes("\u8FFD\u52A0\u30E1\u30C3\u30BB\u30FC\u30B8\u3092\u9001\u308C\u307E\u3059") ? base : base + " " + instruction;
+      }
+
+      function withPendingSendRecoveryInstruction(text) {
+        const base = String(text || "").trim() || "codex app-server \u304B\u3089\u9032\u884C\u30A4\u30D9\u30F3\u30C8\u304C\u3057\u3070\u3089\u304F\u5C4A\u3044\u3066\u3044\u307E\u305B\u3093\u3002";
+        const instruction = "\u9001\u4FE1\u4FDD\u5B58\u3092\u78BA\u8A8D\u4E2D\u306E\u305F\u3081\u5165\u529B\u6B04\u306F\u4FDD\u6301\u3057\u3066\u3044\u307E\u3059\u3002\u78BA\u8A8D\u5F8C\u306B\u540C\u3058 thread \u3078\u8FFD\u52A0\u3067\u304D\u307E\u3059\u3002";
+        return base.includes("\u9001\u4FE1\u4FDD\u5B58\u3092\u78BA\u8A8D\u4E2D") ? base : base + " " + instruction;
+      }
+
+      function releaseComposerForFollowUp(text) {
+        if (pendingOwnerSend) {
+          setStatus(withPendingSendRecoveryInstruction(text), { thinking: true });
+          return false;
+        }
+        const submitButton = form.querySelector("button[type='submit']");
+        setComposerLocked(false);
+        if (submitButton) submitButton.disabled = false;
+        setStatus(withFollowUpInstruction(text));
+        updateComposerReserve();
+        return true;
+      }
+
       function isChatSocketOpen() {
         return Boolean(chatSocket && chatSocket.readyState === WebSocket.OPEN);
       }
@@ -71558,17 +71584,21 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
               const lastMessage = Array.isArray(body.messages) ? body.messages[body.messages.length - 1] : null;
               if (lastMessage?.role === "butler" && lastMessage?.status === "replied") {
                 setStatus("\u8FD4\u4FE1\u3092\u53D7\u4FE1\u3057\u307E\u3057\u305F\u3002", { temporary: true });
-              } else if (lastMessage?.status === "failed") {
-                setStatus(lastMessage.text || "\u5FDC\u7B54\u751F\u6210\u304C\u6642\u9593\u5207\u308C\u306B\u306A\u308A\u307E\u3057\u305F\u3002\u540C\u3058 thread \u3067\u7D9A\u3051\u3089\u308C\u307E\u3059\u3002");
+              } else if (lastMessage?.status === "failed" || lastMessage?.status === "stalled") {
+                releaseComposerForFollowUp(lastMessage.text || "\u5FDC\u7B54\u751F\u6210\u304C\u6642\u9593\u5207\u308C\u306B\u306A\u308A\u307E\u3057\u305F\u3002\u540C\u3058 thread \u3067\u7D9A\u3051\u3089\u308C\u307E\u3059\u3002");
               } else if (releasedFromThread) {
                 setStatus("\u9001\u4FE1\u3092\u4FDD\u5B58\u3057\u307E\u3057\u305F\u3002app-server bridge \u306E\u8FD4\u4FE1\u3092\u5F85\u3063\u3066\u3044\u307E\u3059", { thinking: true });
               }
             } else if (body.type === "transient_status" && body.ok) {
               const isThinking = body.status === "thinking";
-              setStatus(body.text || (isThinking ? "codex app-server \u304C\u5FDC\u7B54\u3092\u751F\u6210\u3057\u3066\u3044\u307E\u3059" : "codex app-server \u306E\u5FDC\u7B54\u304C\u5B8C\u4E86\u3057\u307E\u3057\u305F\u3002"), {
-                thinking: isThinking,
-                temporary: !isThinking
-              });
+              if (body.status === "stalled") {
+                releaseComposerForFollowUp(body.text || "codex app-server \u304B\u3089\u9032\u884C\u30A4\u30D9\u30F3\u30C8\u304C\u3057\u3070\u3089\u304F\u5C4A\u3044\u3066\u3044\u307E\u305B\u3093\u3002");
+              } else {
+                setStatus(body.text || (isThinking ? "codex app-server \u304C\u5FDC\u7B54\u3092\u751F\u6210\u3057\u3066\u3044\u307E\u3059" : "codex app-server \u306E\u5FDC\u7B54\u304C\u5B8C\u4E86\u3057\u307E\u3057\u305F\u3002"), {
+                  thinking: isThinking,
+                  temporary: !isThinking
+                });
+              }
             } else if (body.type === "owner_message_accepted" && body.ok) {
               const clientMessageId = body.clientMessageId || body.client_message_id || "";
               if (clientMessageId) {


### PR DESCRIPTION
## This PR satisfies Intent

Issue #590 の stalled recovery 表示中でも、owner が Dashboard Butler の通常チャットから同じ thread に追加連絡できるようにします。VPS Codex CLI が裏で動いていて bridge の進行イベントが途切れた場合でも、Butler 側が「待つしかない」状態に見えないことを狙います。

## Satisfied Success Criteria

- [x] stalled / failed recovery state を受けた Dashboard client が composer を follow-up 可能な状態へ戻す。
- [x] owner-facing 文言に「このまま同じ thread に追加メッセージを送れます」を含める。
- [x] 保存確認前の pending owner send が残っている場合は、既存ロックを維持して二重送信を避ける。

## Unsatisfied Success Criteria

- Issue #590 の app-server bridge heartbeat / progress event 根本修正は未完了です。
- Issue #590 の production long-running E2E と close-readiness は未完了です。

## Non-goal violations

None.

## 開発前作戦図

- 作戦図 evidence: `docs/development-strategy/issue-590-stalled-owner-input-recovery.md`
- 完了体験: owner が Dashboard Butler で stalled 表示を見ても、通常チャットから同じ thread に追加メッセージを送れる。
- VTDD 全体で進める部分: Issue #590 の silent wait recovery で、owner input path を先に守る。
- 設計: Dashboard Butler client の stalled / failed recovery 受信時だけ composer を解放し、runtime/bridge protocol 境界は触らない。
- 仮説: 仮説として、連絡不能感の主因は stalled recovery 表示後に入力可能であることが明示されず、composer lock が残り得ること。
- 検証計画: worker HTML test、dashboard app-server bridge timeout tests、worker build/generated check、diff check で検証する。
- 改修見積もり: `src/worker/runtime.js` の WebSocket message handler、`test/worker.test.js` の HTML guard、`worker.js` generated bundle。リスクは保存確認前送信の二重解放。
- 既に通っている経路: PR #721 activity watchdog、PR #724 self-refresh、PR #725 queue return after Issue #723 production evidence。
- 未確認の境界: bridge が CLI activity を受け取っていないのか、Dashboard thread に流していないのかは未確認。
- 穴が出そうな箇所: pending send 中にも解放すると二重送信になるため、pendingOwnerSend がある場合は解放しない。
- PR 前に確認すること: Issue #590 本文、PR #725 merge truth、stalled recovery source、Dashboard client composer lock source、関連 tests。
- 実装候補と捨てた案: 採用は stalled follow-up 解放。捨てた案は timeout 延長、stop/interrupt UI 同時実装、bridge protocol 変更。
- merge 後に通す E2E: production Dashboard Butler で stalled recovery 表示後、同じ composer から追加メッセージが送れることを確認する E2E。
- 次の PR を増やさない理由: owner が連絡不能になる穴は Issue #590 の現在の root symptom で、この small slice で閉じるべき。bridge heartbeat は後続 scope として残す。
- 停止条件: bridge protocol 変更、deploy、Issue close、stop/interrupt UI、high-risk action が必要になった場合。

## Dry-run Impact Report

- Target Issue: Issue #590
- Implementing Success Criteria: timeout / stalled 後も composer が永続ロックされず、owner が次のメッセージを送れる。
- Explicit Non-goals: deploy、Issue close、timeout 値変更、bridge heartbeat 根本修正、stop/interrupt UI。
- Expected touched files/routes/workflows: `src/worker/runtime.js`, `test/worker.test.js`, `worker.js`, `docs/development-strategy/issue-590-stalled-owner-input-recovery.md`。routes/workflows は未変更。
- Affected Issues: Issue #590, Issue #579, Issue #450。
- Affected PRs: PR #721, PR #724, PR #725。
- Affected workflows: guarded-autonomy-required-checks test path。
- Affected runtime/operator surfaces: Dashboard Butler PWA normal chat client only。
- What may break if we patch narrowly: bridge heartbeat は残るため stalled 表示自体は出る。ただし owner input path は守れる。
- Unknowns to investigate before coding: bridge activity loss の根本原因は未確認で、この PR では扱わない。
- Validation needed: worker/dashboard bridge tests、worker build、generated worker check、diff check。
- Stop condition: protocol or authority boundary changesが必要になった場合。

## Execution Queue Delta

- Queue position before: Issue #590 is `Now`; Issue #637 remains `Next` after PR #725.
- Preemption decision: ROOT continuation for Issue #590; no new preemption.
- Queue delta: Issue #590 stays `Now`; this PR advances the owner input recovery sub-slice.
- Why this PR is next: owner live evidence showed stalled recovery blocks practical contact from Dashboard Butler, which is the current Issue #590 root symptom.
- Active Issues not downscoped: Active Issues are not downscoped. Issue #590 remains open and incomplete after this slice.

## File / Line Hypotheses

- file: `src/worker/runtime.js:14827`
  - hypothesis: a helper can safely release composer only after pendingOwnerSend is gone.
  - risk if changed narrowly: releasing while pendingOwnerSend exists can cause double send.
  - validation: worker HTML guard test and manual code review.
  - related Issue: Issue #590
- file: `src/worker/runtime.js:15728`
  - hypothesis: transient `stalled` and thread `failed/stalled` are the right owner-facing recovery triggers.
  - risk if changed narrowly: thinking/progress statuses could lose their temporary behavior.
  - validation: worker test and dashboard bridge status tests.
  - related Issue: Issue #590

## Hypothesis Retrospective

- expected: stalled/failed recovery can unlock follow-up input without changing bridge protocol.
- actual: Dashboard client now unlocks follow-up only when no pending owner send remains, and appends explicit follow-up wording.
- mismatch: bridge heartbeat root cause remains separate.
- lesson: stalled recovery must preserve owner input first; progress fidelity can be improved after that.
- should become RAG candidate: yes, compactly: recovery UI must never block owner follow-up input.

## Verification Evidence

- Unit: `node --test test/worker.test.js --test-name-pattern "dashboard chat-first shell"` passed, 245 tests.
- Unit: `node --test test/dashboard-app-server-bridge.test.js --test-name-pattern "quiet status|stalled timeout"` passed, 41 tests.
- Integration: `npm run build:worker` passed.
- Integration: `npm run check:generated-worker` passed.
- Integration: `git diff --check` passed.
- E2E: not yet run in production after merge/deploy.
- Manual: owner live evidence reported stalled recovery display prevents practical contact.
- Evidence path/link: Issue #590 comments and this PR verification.

## Butler Completion Contract

- Primary owner surface: Dashboard Butler。
- Fallback surface: Custom GPT は明示された fallback surface として扱います。主経路ではありません。
- Owner goal: stalled recovery 表示後も Dashboard Butler 通常チャットから同じ thread に追加連絡できる。
- Butler entrypoint: Dashboard Butler の通常チャット composer。
- Dashboard Butler natural-language path: Dashboard Butler の通常チャット入口で owner が自然文の追加メッセージを送る経路を維持します。
- Action Schema exposure: Custom GPT fallback 用の露出状態として扱います。この PR では未変更です。
- Runtime path: Dashboard Butler PWA client script の WebSocket message handler。
- Runner/runtime truth: app-server bridge stalled / failed events を Dashboard client が受ける既存 path。
- Authority boundary: runtime client code only。deploy、credential、permission、destructive action は実行しません。
- E2E evidence: production E2E は未実施。merge/deploy 後に stalled recovery 表示から follow-up 送信を確認する必要があります。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: merge 後に必要。実行には passkey approval が必要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。merge/deploy 後に同じ thread で follow-up 送信を確認する。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate
- AGENTS.md Butler-First Operating Principle
- AGENTS.md Evidence Discipline
- docs/butler/execution-queue-contract.md

## Out-of-scope but NOT implemented

- bridge heartbeat / progress event root cause fix
- stop / interrupt UI
- Issue #590 close

## Extra changes (if any)

None.
