### PR TITLE
Issue #590 debug slow-turn E2E harness

### DIFF
--- a/docs/development-strategy/issue-590-debug-slow-turn-harness.md
+++ b/docs/development-strategy/issue-590-debug-slow-turn-harness.md
@@ -1,0 +1,80 @@
+# Issue #590 debug slow turn harness
+
+## 完了体験
+
+Dashboard Butler から `Issue #590 の slow turn を 3分で実行して` のように自然文で依頼すると、Codex 本体の処理時間に依存せず、同じ Dashboard thread に progress と completion が返る。owner は 2分固定 timeout の有無、quiet/progress 表示、same-thread continuation を production PWA で再現性を持って確認できる。
+
+## VTDD 全体で進める部分
+
+Issue #590 の E2E evidence gap を埋めるための低リスク診断ルートを追加する。これは通常開発機能ではなく、timeout / reconnect / late completion / silent wait の回帰確認に使う debug/E2E ハーネスである。
+
+## 設計
+
+- `scripts/run-dashboard-app-server-bridge.mjs` で Issue #590 slow-turn 文脈を検出する。
+- 検出条件は `Issue #590` と `slow turn` / `debug_slow_turn` / `timeout e2e` の明示に限定する。
+- `durationSeconds` は自然文の `N秒` / `N分` / `Ns` / `Nm` から読む。
+- 許可範囲は 10 秒から 10 分まで。範囲外は実行せず owner-facing failed event を返す。
+- 実行中は同じ `app_server_status` 経路で debug progress を流し、終了時は `app_server_reply` を返す。
+- Codex turn は起動しない。repo mutation、root、deploy、credential、permission mutation はしない。
+
+## 仮説
+
+Issue #590 の production E2E が難しい理由は、自然な Codex 作業時間が再現不能だからである。bridge 層で低リスク slow-turn を再現できれば、Dashboard PWA / WebSocket / transient status / same-thread completion の挙動を deterministic に観測できる。
+
+狭く timeout 値だけを変えると、owner が指摘した「5分無音で最後にまとめて返る」問題を見逃す。slow-turn ハーネスは progress event が PWA に実際に届くかを観測するための土台になる。
+
+## 検証計画
+
+- `node --test test/dashboard-app-server-bridge.test.js --test-name-pattern "debug slow turn|bridge args"`
+- `node --test test/dashboard-app-server-bridge.test.js`
+- `npm run build:worker`
+- `npm run check:generated-worker`
+- `git diff --check`
+
+production E2E では owner が Dashboard Butler から `Issue #590 の slow turn を 3分で実行して` を送り、旧 2分 SYSTEM 文言が出ないこと、progress が出ること、同じ thread に完了が戻ることを確認する。
+
+## 改修見積もり
+
+- `scripts/run-dashboard-app-server-bridge.mjs`: slow-turn 検出、duration parser、simulated progress/reply 追加。リスクは通常文の誤検出。
+- `test/dashboard-app-server-bridge.test.js`: duration parser、範囲外拒否、Codex を呼ばない slow-turn event sequence を固定。リスクは timer 依存の flaky 化なので test では delay を注入する。
+- `docs/development-strategy/issue-590-debug-slow-turn-harness.md`: この作戦図。実行挙動なし。
+
+## 既に通っている経路
+
+PR #727 で 2分固定 hard timeout は 10分 default に変更され、quiet status と late completion の既存テストはある。Issue #590 は open のままで、production 長時間 E2E evidence が不足している。
+
+## 未確認の境界
+
+production VPS app-server bridge service が merge 後にいつ最新 script を読むかは、この PR では変えない。deploy / service restart は passkey 境界であり、この PR では実行しない。
+
+## 穴が出そうな箇所
+
+自然文検出が広すぎると通常チャットを debug harness に吸い込む。必ず Issue #590 文脈と slow-turn/debug/e2e 語を要求する。
+
+## PR 前に確認すること
+
+- Issue #590 が `Now` の parent root であること。
+- slow-turn が high-risk 操作ではないこと。
+- generated `worker.js` が必要な場合は `npm run build:worker` で同期すること。
+
+## 実装候補と捨てた案
+
+採用: 1つの `debug_slow_turn(durationSeconds)` 相当の自然文ハーネス。
+
+捨てた案: `2分用` / `5分用` preset を複数作る。固定 preset が増えて保守性が悪く、owner が求める「引数で分数指定」に合わない。
+
+捨てた案: timeout を 0 にする。永久詰まりを検出できなくなる。
+
+## merge 後に通す E2E
+
+- 30秒 slow-turn で progress/reply が同じ thread に返ることを短時間確認する。
+- 3分 slow-turn で旧 2分 SYSTEM 文言が出ないことを確認する。
+- 必要な時だけ 5分超 slow-turn を走らせ、silent wait / reconnect 表示を観測する。
+
+## 次の PR を増やさない理由
+
+この PR は Issue #590 の E2E harness に閉じる。実際の Codex progress をもっと細かく owner-facing に流す改善、stop/interrupt UI、final answer formatting は別 Issue/PR で扱う。
+
+## 停止条件
+
+slow-turn が通常 owner message を誤検出する、duration 上限なしになる、repo mutation/root/deploy/credential に触れる、または production service restart が必要になる場合は停止する。

--- a/scripts/run-dashboard-app-server-bridge.mjs
+++ b/scripts/run-dashboard-app-server-bridge.mjs
@@ -17,6 +17,10 @@ const APP_SERVER_TURN_QUIET_TEXT =
 const DASHBOARD_MEDIA_TMP_DIR = "vtdd-dashboard-media";
 const DEFAULT_TURN_TIMEOUT_MS = 10 * 60 * 1000;
 const DEFAULT_ACTIVITY_QUIET_MS = 90 * 1000;
+const DEBUG_SLOW_TURN_DEFAULT_SECONDS = 150;
+const DEBUG_SLOW_TURN_MIN_SECONDS = 10;
+const DEBUG_SLOW_TURN_MAX_SECONDS = 10 * 60;
+const DEBUG_SLOW_TURN_PROGRESS_INTERVAL_MS = 30 * 1000;
 
 export function buildAppServerInitializeRequest(id = 1) {
   return {
@@ -787,6 +791,139 @@ function buildAppServerTurnTimeoutEvent({
   };
 }
 
+export function parseDashboardDebugSlowTurnRequest(request = {}) {
+  const text = normalizeBridgeText(request.text);
+  const relatedIssue = normalizePositiveInteger(request.relatedIssue || request.issueNumber);
+  const hasIssue590Context = relatedIssue === 590 || /(?:issue\s*)?#?590/i.test(text);
+  const hasSlowTurnIntent =
+    /debug[_ -]?slow[_ -]?turn/i.test(text) ||
+    /slow[_ -]?turn/i.test(text) ||
+    /timeout\s*e2e/i.test(text) ||
+    /slow\s*e2e/i.test(text) ||
+    /遅延.*(?:e2e|検証)/i.test(text) ||
+    /スローターン/i.test(text);
+
+  if (!hasIssue590Context || !hasSlowTurnIntent) {
+    return { enabled: false };
+  }
+
+  const durationSeconds = extractDebugSlowTurnDurationSeconds(text);
+  if (
+    !Number.isInteger(durationSeconds) ||
+    durationSeconds < DEBUG_SLOW_TURN_MIN_SECONDS ||
+    durationSeconds > DEBUG_SLOW_TURN_MAX_SECONDS
+  ) {
+    return {
+      enabled: true,
+      ok: false,
+      durationSeconds,
+      reason: `durationSeconds must be ${DEBUG_SLOW_TURN_MIN_SECONDS}-${DEBUG_SLOW_TURN_MAX_SECONDS}`
+    };
+  }
+
+  return {
+    enabled: true,
+    ok: true,
+    durationSeconds
+  };
+}
+
+function extractDebugSlowTurnDurationSeconds(text = "") {
+  const normalized = normalizeBridgeText(text);
+  const secondMatch = normalized.match(/(\d{1,4})\s*(?:秒|sec|secs|second|seconds|s)(?![a-z])/i);
+  if (secondMatch) {
+    return Number(secondMatch[1]);
+  }
+  const minuteMatch = normalized.match(/(\d{1,3})\s*(?:分|min|mins|minute|minutes|m)(?![a-z])/i);
+  if (minuteMatch) {
+    return Number(minuteMatch[1]) * 60;
+  }
+  return DEBUG_SLOW_TURN_DEFAULT_SECONDS;
+}
+
+export async function runDashboardDebugSlowTurn({
+  request = {},
+  sendDashboardEvent,
+  durationSeconds = DEBUG_SLOW_TURN_DEFAULT_SECONDS,
+  progressIntervalMs = DEBUG_SLOW_TURN_PROGRESS_INTERVAL_MS,
+  delayImpl = delay,
+  now = () => new Date().toISOString()
+} = {}) {
+  const dashboardThreadId = String(request.threadId || "");
+  const repository = request.repository || null;
+  const relatedIssue = request.relatedIssue || request.issueNumber || null;
+  const startedAt = now();
+  await sendDashboardEvent({
+    type: "app_server_status",
+    schema: DEFAULT_SCHEMA,
+    threadId: dashboardThreadId,
+    repository,
+    relatedIssue,
+    status: "thinking",
+    stage: "debug_slow_turn",
+    text: `Issue #590 slow turn E2E を開始しました。指定待機時間: ${durationSeconds}秒。`,
+    debugSlowTurn: {
+      startedAt,
+      durationSeconds,
+      lowRisk: true
+    }
+  });
+
+  let elapsedMs = 0;
+  const intervalMs = Math.max(1, Number(progressIntervalMs) || DEBUG_SLOW_TURN_PROGRESS_INTERVAL_MS);
+  const durationMs = durationSeconds * 1000;
+  while (elapsedMs < durationMs) {
+    const remainingMs = durationMs - elapsedMs;
+    const nextWaitMs = Math.min(intervalMs, remainingMs);
+    await delayImpl(nextWaitMs);
+    elapsedMs = Math.min(durationMs, elapsedMs + nextWaitMs);
+    if (elapsedMs >= durationMs) {
+      break;
+    }
+    await sendDashboardEvent({
+      type: "app_server_status",
+      schema: DEFAULT_SCHEMA,
+      threadId: dashboardThreadId,
+      repository,
+      relatedIssue,
+      status: "thinking",
+      stage: "debug_slow_turn",
+      text: `Issue #590 slow turn E2E 継続中です。経過: ${Math.floor(elapsedMs / 1000)}秒 / ${durationSeconds}秒。`,
+      debugSlowTurn: {
+        startedAt,
+        elapsedSeconds: Math.floor(elapsedMs / 1000),
+        durationSeconds,
+        lowRisk: true
+      }
+    });
+  }
+
+  const completedAt = now();
+  await sendDashboardEvent({
+    type: "app_server_reply",
+    schema: DEFAULT_SCHEMA,
+    threadId: dashboardThreadId,
+    repository,
+    relatedIssue,
+    status: "replied",
+    text: [
+      "Issue #590 slow turn E2E が完了しました。",
+      "",
+      `指定待機時間: ${durationSeconds}秒`,
+      `開始: ${startedAt}`,
+      `完了: ${completedAt}`,
+      "",
+      "この診断は sleep と progress event だけを使う低リスク検証です。root / sudo / deploy / credential / repository mutation は実行していません。"
+    ].join("\n"),
+    debugSlowTurn: {
+      startedAt,
+      completedAt,
+      durationSeconds,
+      lowRisk: true
+    }
+  });
+}
+
 function isAppServerFailureAlreadySent(error) {
   return Boolean(error && error[APP_SERVER_FAILURE_ALREADY_SENT]);
 }
@@ -1027,7 +1164,9 @@ export async function handleDashboardTurnRequest({
   runtimeUrl = "",
   token = "",
   fetchImpl = globalThis.fetch,
-  mediaTmpRoot = os.tmpdir()
+  mediaTmpRoot = os.tmpdir(),
+  debugSlowTurnDelayImpl = delay,
+  debugSlowTurnProgressIntervalMs = DEBUG_SLOW_TURN_PROGRESS_INTERVAL_MS
 }) {
   const dashboardThreadId = String(request.threadId || "");
   const text = String(request.text || "");
@@ -1037,6 +1176,30 @@ export async function handleDashboardTurnRequest({
       schema: DEFAULT_SCHEMA,
       threadId: dashboardThreadId,
       text: "dashboard threadId and text are required"
+    });
+    return;
+  }
+
+  const debugSlowTurn = parseDashboardDebugSlowTurnRequest(request);
+  if (debugSlowTurn.enabled) {
+    if (!debugSlowTurn.ok) {
+      await sendDashboardEvent({
+        type: "app_server_turn_failed",
+        schema: DEFAULT_SCHEMA,
+        threadId: dashboardThreadId,
+        repository: request.repository || null,
+        relatedIssue: request.relatedIssue || request.issueNumber || null,
+        status: "invalid_debug_slow_turn_duration",
+        text: `Issue #590 slow turn E2E の待機時間は ${DEBUG_SLOW_TURN_MIN_SECONDS}秒から ${DEBUG_SLOW_TURN_MAX_SECONDS}秒までにしてください。例: 「Issue #590 の slow turn を 3分で実行して」。`
+      });
+      return;
+    }
+    await runDashboardDebugSlowTurn({
+      request,
+      sendDashboardEvent,
+      durationSeconds: debugSlowTurn.durationSeconds,
+      progressIntervalMs: debugSlowTurnProgressIntervalMs,
+      delayImpl: debugSlowTurnDelayImpl
     });
     return;
   }

--- a/test/dashboard-app-server-bridge.test.js
+++ b/test/dashboard-app-server-bridge.test.js
@@ -25,8 +25,10 @@ import {
   matchesAppServerTurnNotification,
   materializeDashboardMediaReferences,
   parseBridgeArgs,
+  parseDashboardDebugSlowTurnRequest,
   postOwnerActionRequiredEvent,
-  runDashboardAppServerBridge
+  runDashboardAppServerBridge,
+  runDashboardDebugSlowTurn
 } from "../scripts/run-dashboard-app-server-bridge.mjs";
 
 test("dashboard app-server bridge builds initialize and thread requests from Codex app-server protocol", () => {
@@ -1232,6 +1234,126 @@ test("dashboard app-server bridge sends Japanese recoverable timeout failure", a
   assert.doesNotMatch(timeoutEvent.text, /timed out before completion/);
   await new Promise((resolve) => setTimeout(resolve, 10));
   assert.equal(handlers.size, 0);
+});
+
+test("dashboard app-server bridge parses Issue #590 debug slow turn duration from natural language", () => {
+  assert.deepEqual(
+    parseDashboardDebugSlowTurnRequest({
+      relatedIssue: 590,
+      text: "Issue #590 の slow turn を 3分で実行して"
+    }),
+    {
+      enabled: true,
+      ok: true,
+      durationSeconds: 180
+    }
+  );
+
+  assert.deepEqual(
+    parseDashboardDebugSlowTurnRequest({
+      text: "Issue #590 timeout E2E を 45秒で実行"
+    }),
+    {
+      enabled: true,
+      ok: true,
+      durationSeconds: 45
+    }
+  );
+
+  assert.equal(parseDashboardDebugSlowTurnRequest({ text: "普通に返信して" }).enabled, false);
+  assert.equal(parseDashboardDebugSlowTurnRequest({ relatedIssue: 498, text: "slow turn を 3分で実行" }).enabled, false);
+  assert.equal(parseDashboardDebugSlowTurnRequest({ relatedIssue: 590, text: "slow turn を 11分で実行" }).ok, false);
+});
+
+test("dashboard app-server bridge runs Issue #590 debug slow turn without starting Codex", async () => {
+  const events = [];
+  let requestCount = 0;
+  const appServer = {
+    nextRequestId() {
+      return 1;
+    },
+    onNotification() {
+      return () => {};
+    },
+    async request() {
+      requestCount += 1;
+      throw new Error("debug slow turn must not call codex app-server");
+    }
+  };
+
+  await handleDashboardTurnRequest({
+    request: {
+      threadId: "dashboard-main",
+      repository: "marushu/vtdd-v2-p",
+      relatedIssue: 590,
+      text: "Issue #590 の slow turn を 10秒で実行して"
+    },
+    appServer,
+    sendDashboardEvent: async (event) => events.push(event),
+    debugSlowTurnDelayImpl: async () => {},
+    debugSlowTurnProgressIntervalMs: 1000
+  });
+
+  assert.equal(requestCount, 0);
+  assert.equal(events[0].type, "app_server_status");
+  assert.equal(events[0].stage, "debug_slow_turn");
+  assert.match(events[0].text, /slow turn E2E を開始/);
+  assert.ok(events.some((event) => event.type === "app_server_status" && /継続中/.test(event.text)));
+  const reply = events.find((event) => event.type === "app_server_reply");
+  assert.ok(reply);
+  assert.equal(reply.threadId, "dashboard-main");
+  assert.equal(reply.repository, "marushu/vtdd-v2-p");
+  assert.equal(reply.relatedIssue, 590);
+  assert.match(reply.text, /low turn E2E が完了/);
+  assert.match(reply.text, /root \/ sudo \/ deploy \/ credential \/ repository mutation は実行していません/);
+});
+
+test("dashboard app-server bridge rejects out-of-range Issue #590 debug slow turn duration", async () => {
+  const events = [];
+  await handleDashboardTurnRequest({
+    request: {
+      threadId: "dashboard-main",
+      repository: "marushu/vtdd-v2-p",
+      relatedIssue: 590,
+      text: "Issue #590 の slow turn を 0秒で実行して"
+    },
+    appServer: {
+      nextRequestId() {
+        throw new Error("must not call codex app-server");
+      }
+    },
+    sendDashboardEvent: async (event) => events.push(event)
+  });
+
+  assert.equal(events.length, 1);
+  assert.equal(events[0].type, "app_server_turn_failed");
+  assert.equal(events[0].status, "invalid_debug_slow_turn_duration");
+  assert.match(events[0].text, /10秒から 600秒まで/);
+});
+
+test("dashboard app-server bridge can run debug slow turn with injected timing", async () => {
+  const events = [];
+  await runDashboardDebugSlowTurn({
+    request: {
+      threadId: "dashboard-main",
+      repository: "marushu/vtdd-v2-p",
+      relatedIssue: 590
+    },
+    sendDashboardEvent: async (event) => events.push(event),
+    durationSeconds: 10,
+    progressIntervalMs: 2500,
+    delayImpl: async () => {},
+    now: (() => {
+      const values = ["2026-06-02T00:00:00.000Z", "2026-06-02T00:00:10.000Z"];
+      return () => values.shift() || "2026-06-02T00:00:10.000Z";
+    })()
+  });
+
+  assert.equal(events[0].type, "app_server_status");
+  assert.equal(events[0].debugSlowTurn.lowRisk, true);
+  assert.ok(events.filter((event) => event.type === "app_server_status" && event.stage === "debug_slow_turn").length >= 2);
+  assert.equal(events.at(-1).type, "app_server_reply");
+  assert.match(events.at(-1).text, /指定待機時間: 10秒/);
 });
 
 test("dashboard app-server bridge repeats quiet status before hard stalled timeout without ending the turn", async () => {


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #590 の production E2E が自然な Codex 処理時間に依存して再現不能だったため、Dashboard app-server bridge に低リスクの `debug_slow_turn(durationSeconds)` 相当ハーネスを追加します。
- owner は Dashboard Butler から `Issue #590 の slow turn を 3分で実行して` のように自然文で指定し、2分固定 timeout / progress / same-thread completion を検証できます。

## Satisfied Success Criteria

- Issue #590 の E2E: app-server turn timeout / silent wait を任意秒数で模擬できる検証入口を追加。
- Issue #590 の安全境界: slow-turn は sleep と progress event のみで、root / sudo / deploy / credential / repository mutation を実行しない。
- Issue #590 の owner-facing path: `Issue #590` と `slow turn` / `timeout E2E` 文脈に限定した自然文起動に対応。
- Issue #590 のテスト: duration parser、範囲外拒否、Codex を起動しない event sequence を unit test で固定。

## Unsatisfied Success Criteria

- production Dashboard Butler での 3分 slow-turn E2E は merge/deploy 後に実施が必要。
- 実際の Codex app-server progress を細かく owner-facing に流す改善は未実装。
- stop / interrupt UI、owner input queue、final answer formatting は未実装。
- Issue #590 はこの PR だけでは close-ready ではありません。

## Non-goal violations

None.

## 開発前作戦図

- 作戦図 evidence: `docs/development-strategy/issue-590-debug-slow-turn-harness.md`
- 完了体験: Dashboard Butler から自然文で slow-turn 秒数を指定し、同じ thread に progress と completion が返る。
- VTDD 全体で進める部分: Issue #590 の production E2E 再現性を上げる低リスク診断ルート。
- 設計: Dashboard Butler owner-facing surface の通常チャットを入口にし、scope を Issue #590 slow-turn 文脈へ限定し、bridge が Codex 本体を起動せず debug progress/reply を送る境界設計。
- 仮説: 原因は長時間 E2E が自然な Codex 作業時間に依存して再現不能な点なので、bridge 層の deterministic slow-turn なら timeout/progress/same-thread の予測を観測できる。
- 検証計画: bridge unit test、full npm test、generated worker check。
- 改修見積もり: `scripts/run-dashboard-app-server-bridge.mjs` parser/simulator、`test/dashboard-app-server-bridge.test.js` tests、strategy doc。
- 既に通っている経路: PR #727 で 2分 hard timeout は緩和済みだが production 長時間 E2E が不足。
- 未確認の境界: merge 後に VPS app-server bridge service が最新 script を読むタイミング。
- 穴が出そうな箇所: 通常チャットの誤検出、duration 上限なし、debug 機能の通常 UI 露出。
- PR 前に確認すること: Issue #590 / active queue / PR #727 truth、high-risk 操作なし、テスト通過。
- 実装候補と捨てた案: 採用は単一 duration 引数ハーネス。固定 2分/5分 preset と timeout 無効化は捨てた。
- merge 後に通す E2E: production E2E として 30秒、3分、必要時 5分超の Dashboard Butler slow-turn 検証を通す。
- 次の PR を増やさない理由: この PR は E2E harness に限定し、実 Codex progress UI は別 slice に残す。
- 停止条件: 通常文誤検出、高リスク操作、service restart 必須、owner-specific runtime 埋め込みが出た場合。

## Dry-run Impact Report

- Target Issue: Issue #590
- Implementing Success Criteria: app-server turn timeout / silent wait E2E を任意秒数で再現できる低リスク検証入口。
- Explicit Non-goals: deploy、credential mutation、permission mutation、root/sudo、repository mutation、stop/interrupt UI、final formatting。
- Expected touched files/routes/workflows: `scripts/run-dashboard-app-server-bridge.mjs`、`test/dashboard-app-server-bridge.test.js`、`docs/development-strategy/issue-590-debug-slow-turn-harness.md`
- Affected Issues: Issue #590。Issue #528 / Issue #413 は関連するが、この PR では実装しない。
- Affected PRs: PR #727 の後続。PR #727 の merge commit を base にした新 PR。
- Affected workflows: GitHub Actions test/review のみ。deploy workflow はこの PR では起動しない。
- Affected runtime/operator surfaces: Dashboard app-server bridge の debug/E2E path。通常 Dashboard chat は誤検出防止条件で保護。
- What may break if we patch narrowly: slow-turn が通常文を吸い込むとチャット体験を壊すため、Issue #590 明示と slow-turn/debug/e2e 語を要求。
- Unknowns to investigate before coding: VPS app-server bridge service が merge/deploy 後に最新 script を読むタイミング。
- Validation needed: bridge unit test、full `npm test`、production slow-turn E2E。
- Stop condition: duration 上限なし、通常文誤検出、高リスク操作、owner-specific URL 埋め込み。

## Execution Queue Delta

- Queue position before: Issue #590 は active issue execution queue の Now。Dashboard Butler timeout / silent wait recovery が root blocker。
- Preemption decision: EVIDENCE。Now を差し替えず、Issue #590 の E2E evidence gap を埋める bounded slice。
- Queue delta: Issue #590 に debug slow-turn harness を追加し、production E2E を実施可能にする。Issue #590 自体は未完了のまま。
- Why this PR is next: owner が指摘した通り、意図的に2分/5分を超える自然な作業を作るのは再現性がないため、先に deterministic E2E harness が必要。
- Active Issues not downscoped: Active Issues は縮小しません。Issue #528 / Issue #413 / Issue #637 など関連 root blockers は未完了として残します。

## File / Line Hypotheses

- file: `scripts/run-dashboard-app-server-bridge.mjs`
  - hypothesis: bridge が Issue #590 slow-turn 文脈を検出して Codex 本体を起動しなければ、production PWA の timeout/progress/same-thread behavior を deterministic に検証できる。
  - risk if changed narrowly: 検出条件が広すぎると通常チャットを debug path に誤誘導する。
  - validation: natural-language parser、out-of-range reject、Codex request count 0 の tests。
  - related Issue: Issue #590
- file: `test/dashboard-app-server-bridge.test.js`
  - hypothesis: injected timing で slow-turn を高速に検証すれば、unit test が実時間に依存しない。
  - risk if changed narrowly: 実時間 sleep を入れると test が遅く flaky になる。
  - validation: debug slow-turn tests と full npm test。
  - related Issue: Issue #590

## Hypothesis Retrospective

- expected: bridge 層だけで low-risk slow-turn event sequence を作れる。
- actual: parser、invalid duration、Codex を起動しない progress/reply sequence を実装し、unit test で確認した。
- mismatch: production VPS app-server bridge service 反映タイミングは未確認で、merge/deploy 後 E2E が必要。
- lesson: Issue #590 の長時間 E2E は自然な遅さに頼らず deterministic harness を持つべき。
- should become RAG candidate: yes。timeout/reconnect 系 E2E は debug duration harness で再現する。

## Verification Evidence

- Unit: `node --test test/dashboard-app-server-bridge.test.js` pass。debug slow-turn / timeout / bridge tests 46 pass。
- Integration: `env -u VTDD_GATEWAY_BEARER_TOKEN -u VTDD_RUNTIME_URL -u VTDD_DASHBOARD_APP_SERVER_SANDBOX -u VTDD_DASHBOARD_APP_SERVER_ENV -u VTDD_DASHBOARD_THREAD_ID HOME=/tmp/vtdd-empty-home npm test` pass。1123 tests、1122 pass、1 skipped、0 fail。`check:self-parity` pass。`check:generated-worker` pass。
- E2E: 未実施。merge/deploy 後に Dashboard Butler production slow-turn で実施する。
- Manual: `git diff --check` pass。
- Evidence path/link: `docs/development-strategy/issue-590-debug-slow-turn-harness.md`

## Butler Completion Contract

- Primary owner surface: Dashboard Butler。
- Fallback surface: mac Codex は実装/検証補助。Issue #590 の owner-facing E2E は Dashboard Butler production で行う。
- Owner goal: 2分/5分を超える待機を再現性を持って検証し、timeout 文言や progress 表示を確認できるようにする。
- Butler entrypoint: Dashboard Butler の通常チャットから `Issue #590 の slow turn を N分/N秒で実行して`。
- Dashboard Butler natural-language path: Dashboard Butler の通常チャット入口で `Issue #590 の slow turn を N分/N秒で実行して` という自然文を受け、Issue #590 と slow-turn/debug/e2e 文脈だけを debug harness に接続する。
- Action Schema exposure: 未変更。Custom GPT fallback schema はこの PR では触らない。
- Runtime path: Dashboard WebSocket owner turn -> app-server bridge -> debug slow-turn event sequence -> Dashboard thread。
- Runner/runtime truth: bridge event sequence と tests。production runtime truth は merge/deploy 後 E2E で追加する。
- Authority boundary: low-risk debug/E2E。GO 範囲の実装のみ。deploy、credential、permission、root/sudo、repository mutation はなし。
- E2E evidence: 未実施。merge/deploy 後の production Dashboard Butler slow-turn が必要。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: この PR では実行しない。merge 後に passkey 境界で owner が判断。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: merge/deploy 後に必要。

## Related Constitution Rules

- Butler Completion Gate
- Butler-First Operating Principle
- Drift Stop Protocol
- 開発前作戦図 Gate
- Evidence Discipline
- Authority Boundary

## Out-of-scope but NOT implemented

- 実 Codex app-server の詳細 progress を owner-facing に逐次要約する UI。
- stop / interrupt / queued owner input UI。
- final answer formatting / paragraphing。
- Issue #590 close judgment。
- deploy、credential mutation、permission mutation、root/sudo。

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #590
- Execution ID: app-server-debug-slow-turn
- Goal: Issue #590 slow-turn E2E harness
