### PR TITLE
Issue #590 dedupe stalled recovery messages

### DIFF
--- a/docs/development-strategy/issue-590-stalled-recovery-dedupe.md
+++ b/docs/development-strategy/issue-590-stalled-recovery-dedupe.md
@@ -1,0 +1,80 @@
+# Issue #590: stalled recovery message dedupe
+
+## 完了体験
+
+Dashboard Butler が app-server / VPS Codex CLI の応答確認中になっても、同じ thread に同じ SYSTEM stalled 文言を何度も積み上げない。owner は「会話が壊れた」のではなく「同じ入力と文脈を保持したまま再接続確認中」と短く分かり、同じ thread で補足やキャンセル指示を続けられる。
+
+この PR の完了は Issue #590 の完了ではない。Issue #590 は、実 Codex progress の逐次表示、production slow-turn E2E、stop / interrupt / owner input queue の整理が残る。
+
+## VTDD 全体で進める部分
+
+Issue #590 の root blocker のうち、production PWA で確認された「stalled recovery 表示が owner-facing progress の代わりに重複 SYSTEM として残る」問題だけを直す。mac Codex へ戻らずに Butler thread で復旧・補足できる体験の土台を整える。
+
+## 設計
+
+初回の `app_server_turn_failed` / timeout は、これまで通り recovery evidence として SYSTEM message に保存する。これは「入力は保存済みで同じ thread で続けられる」ことを thread history に残すため。
+
+同じ thread の直近に同一 `role=system` / `status=stalled` / text の message がある場合、2回目以降は永続 message として保存しない。代わりに transient status だけを更新する。transient status は全文ではなく短い文言にし、下部 status area が長文で埋まらないようにする。
+
+## 仮説
+
+`DashboardChatRoom.acceptAppServerBridgeMessage()` は `normalizeDashboardAppServerBridgeEvent()` が返した `messages` を無条件に `appendMany()` している。そのため bridge 側が quiet / stalled retry を繰り返すと、同じ stalled SYSTEM message が thread に何度も保存される。
+
+`normalizeDashboardAppServerBridgeEvent()` は `app_server_turn_failed` の `transientText` に failure thread text 全文を入れているため、persistent bubble と bottom transient の両方に同じ長文が出る。スクショの「なんら改善されていない」感はこの二重化と重複保存で説明できる。
+
+## 検証計画
+
+- Worker unit test で同じ `app_server_turn_failed` timeout event を2回送る。
+- 1回目は SYSTEM stalled message として保存されることを確認する。
+- 2回目は thread message が増えないことを確認する。
+- 2回目でも transient status は送られ、短い再接続中文言になることを確認する。
+- 既存の「初回 timeout は recovery message として保存する」test は維持する。
+- `npm run build:worker` と `npm run check:generated-worker` で generated worker の同期を確認する。
+
+## 改修見積もり
+
+- `src/worker/runtime.js`
+  - `acceptAppServerBridgeMessage()` で app-server bridge 由来の messages を append 前に重複除外する。
+  - `normalizeDashboardAppServerBridgeEvent()` / helper で stalled transient text を短くする。
+  - risk: 初回 recovery message まで消すと owner が復旧状態を履歴で追えなくなる。
+- `test/worker.test.js`
+  - stalled event dedupe と short transient status の regression test を追加する。
+  - risk: 実時刻や messageId に依存すると flaky になるため、text/status/role で検証する。
+- `worker.js`
+  - runtime bundle 生成物。`npm run build:worker` で更新する。
+
+## 既に通っている経路
+
+PR #721 / PR #727 で固定 2分 timeout の扱いは緩和された。PR #728 で slow-turn E2E harness は入った。これらは「長時間 turn を観測できる土台」だが、今回のスクショに出ている重複 SYSTEM 表示はまだ残っている。
+
+## 未確認の境界
+
+本番の app-server bridge がどの間隔で stalled event を再送しているかは未確認。ただし重複保存を worker 側で止めれば、bridge 側再送間隔に依存せず thread 汚染は止められる。
+
+## 穴が出そうな箇所
+
+- 異なる failed text まで dedupe すると別原因の failure が見えなくなる。
+- first stalled message を transient-only にすると recovery evidence が消える。
+- bottom transient に全文を残すと、SYSTEM dedupe しても owner 体感は改善しない。
+
+## PR 前に確認すること
+
+Issue #590、PR #728 merged truth、active execution queue、既存 worker tests、generated worker 差分を確認する。deploy はこの PR では実行しない。
+
+## 実装候補と捨てた案
+
+- 採用: worker append 前の recent-message dedupe と short transient status。
+- 捨てた案: bridge 側だけで stalled event を止める。WebSocket reconnect や duplicate delivery に弱いため。
+- 捨てた案: stalled message を一切保存しない。owner が後から thread history で recovery state を確認できなくなるため。
+
+## merge 後に通す E2E
+
+production Dashboard Butler で slow-turn / stalled recovery を発火し、同じ SYSTEM stalled 文言が2個以上増えないこと、下部 status が短く、同じ thread で補足を送れることを確認する。
+
+## 次の PR を増やさない理由
+
+この PR は screenshot で確認できた具体的 UX regression に限定する。実 Codex progress の逐次表示、deploy status 自動投稿、stop / interrupt UI は別 Issue/PR slice に分けないと今回の root symptom がぼやける。
+
+## 停止条件
+
+first recovery message が保存されなくなる、通常 app-server reply が保存されなくなる、異なる failure が隠れる、owner-specific runtime URL を埋め込む、deploy / credential / permission / root 操作が必要になる場合は停止する。

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -521,9 +521,17 @@ export class DashboardChatRoom {
       return;
     }
     const store = resolveDashboardChatStore(this.env);
+    const messagesToAppend = await filterDashboardAppServerBridgeMessagesForAppend({
+      store,
+      threadId: normalized.threadId,
+      messages: normalized.messages
+    });
+    if (messagesToAppend.length === 0) {
+      return;
+    }
     const messages = store
-      ? await store.appendMany(normalized.threadId, normalized.messages)
-      : normalized.messages;
+      ? await store.appendMany(normalized.threadId, messagesToAppend)
+      : messagesToAppend;
     await this.broadcastThread({ threadId: normalized.threadId, messages });
   }
 
@@ -8846,7 +8854,7 @@ function normalizeDashboardAppServerBridgeEvent(payload, { fallbackThreadId = ""
       )
     );
     transientStatus = messageStatus;
-    transientText = failureText;
+    transientText = buildDashboardAppServerFailureTransientText({ messageStatus, failureText });
   } else if (eventType === "app_server_status") {
     transientStatus = status === "replied" ? "replied" : "thinking";
     transientText = buildDashboardOwnerFacingTransientStatusText(input, {
@@ -8877,6 +8885,41 @@ function buildDashboardAppServerFailureThreadText({ text = "", status = "" } = {
     return "codex app-server の応答確認が長引いています。入力と文脈は Dashboard thread に保存済みです。再接続と状態確認を続けています。同じ thread で補足やキャンセル指示を送れます。遅れて返信が届いた場合は、この thread に追加します。";
   }
   return normalizedText || "codex app-server が返信前に失敗しました。同じ thread で続けるか、内容を短くしてもう一度送れます。";
+}
+
+function buildDashboardAppServerFailureTransientText({ messageStatus = "", failureText = "" } = {}) {
+  if (normalizeDashboardChatStatus(messageStatus) === "stalled") {
+    return "再接続と状態確認を続けています。入力と文脈は保持しています。";
+  }
+  return sanitizeDashboardChatText(failureText) || "app-server bridge の返信を待っています";
+}
+
+async function filterDashboardAppServerBridgeMessagesForAppend({ store, threadId, messages = [] } = {}) {
+  const normalizedMessages = Array.isArray(messages) ? messages.filter(Boolean) : [];
+  if (normalizedMessages.length === 0 || !store || typeof store.listThread !== "function") {
+    return normalizedMessages;
+  }
+  let recentMessages = [];
+  try {
+    recentMessages = await store.listThread(threadId, { limit: 1 });
+  } catch {
+    return normalizedMessages;
+  }
+  const latest = Array.isArray(recentMessages) ? recentMessages.at(-1) : null;
+  return normalizedMessages.filter((message) => !isDuplicateLatestStalledRecoveryMessage(message, latest));
+}
+
+function isDuplicateLatestStalledRecoveryMessage(message, latest) {
+  if (!message || !latest) {
+    return false;
+  }
+  return (
+    normalizeDashboardEventText(message.role).toLowerCase() === "system" &&
+    normalizeDashboardChatStatus(message.status) === "stalled" &&
+    normalizeDashboardEventText(latest.role).toLowerCase() === "system" &&
+    normalizeDashboardChatStatus(latest.status) === "stalled" &&
+    sanitizeDashboardChatText(message.text) === sanitizeDashboardChatText(latest.text)
+  );
 }
 
 const DASHBOARD_APP_SERVER_STAGE_TEXT = {

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -4030,7 +4030,53 @@ test("DashboardChatRoom persists app-server timeout as recoverable Japanese thre
   const failedStatus = dashboardSocket.sent.map((message) => JSON.parse(message)).find((message) => message.type === "transient_status");
   assert.ok(failedStatus);
   assert.equal(failedStatus.status, "stalled");
-  assert.equal(failedStatus.text, stored[0].text);
+  assert.equal(failedStatus.text, "再接続と状態確認を続けています。入力と文脈は保持しています。");
+});
+
+test("DashboardChatRoom dedupes repeated app-server stalled recovery messages", async () => {
+  const store = createInMemoryDashboardChatStore();
+  const dashboardSocket = createMockSocket("dashboard", "dashboard-main-unresolved");
+  const bridgeSocket = createMockSocket("app_server_bridge", "dashboard-main-unresolved");
+  const room = new DashboardChatRoom(
+    {
+      storage: createMockDurableObjectStorage(),
+      getWebSockets() {
+        return [dashboardSocket, bridgeSocket];
+      }
+    },
+    { DASHBOARD_CHAT_STORE: store }
+  );
+  const stalledEvent = {
+    type: "app_server_turn_failed",
+    status: "timeout",
+    threadId: "dashboard-main-unresolved",
+    repository: "marushu/vtdd-v2-p",
+    relatedIssue: 590,
+    text: "codex app-server turn timed out before completion"
+  };
+
+  await room.webSocketMessage(bridgeSocket, JSON.stringify(stalledEvent));
+  await room.webSocketMessage(bridgeSocket, JSON.stringify(stalledEvent));
+
+  const stored = await store.listThread("dashboard-main-unresolved");
+  assert.equal(stored.length, 1);
+  assert.equal(stored[0].role, "system");
+  assert.equal(stored[0].status, "stalled");
+  assert.match(stored[0].text, /応答確認が長引いています/);
+
+  const sentPayloads = dashboardSocket.sent.map((message) => JSON.parse(message));
+  const threadBroadcasts = sentPayloads.filter((message) => message.type === "thread");
+  assert.equal(threadBroadcasts.length, 1);
+  assert.equal(threadBroadcasts[0].messages.length, 1);
+  const transientStatuses = sentPayloads.filter((message) => message.type === "transient_status");
+  assert.equal(transientStatuses.length, 2);
+  assert.deepEqual(
+    transientStatuses.map((message) => message.text),
+    [
+      "再接続と状態確認を続けています。入力と文脈は保持しています。",
+      "再接続と状態確認を続けています。入力と文脈は保持しています。"
+    ]
+  );
 });
 
 test("DashboardChatRoom sends app-server thinking status as transient UI state", async () => {

--- a/worker.js
+++ b/worker.js
@@ -57909,7 +57909,15 @@ var DashboardChatRoom = class {
       return;
     }
     const store = resolveDashboardChatStore(this.env);
-    const messages = store ? await store.appendMany(normalized.threadId, normalized.messages) : normalized.messages;
+    const messagesToAppend = await filterDashboardAppServerBridgeMessagesForAppend({
+      store,
+      threadId: normalized.threadId,
+      messages: normalized.messages
+    });
+    if (messagesToAppend.length === 0) {
+      return;
+    }
+    const messages = store ? await store.appendMany(normalized.threadId, messagesToAppend) : messagesToAppend;
     await this.broadcastThread({ threadId: normalized.threadId, messages });
   }
   async broadcastThread({ threadId, messages = null }) {
@@ -65221,7 +65229,7 @@ function normalizeDashboardAppServerBridgeEvent(payload, { fallbackThreadId = ""
       )
     );
     transientStatus = messageStatus;
-    transientText = failureText;
+    transientText = buildDashboardAppServerFailureTransientText({ messageStatus, failureText });
   } else if (eventType === "app_server_status") {
     transientStatus = status === "replied" ? "replied" : "thinking";
     transientText = buildDashboardOwnerFacingTransientStatusText(input, {
@@ -65248,6 +65256,32 @@ function buildDashboardAppServerFailureThreadText({ text = "", status = "" } = {
     return "codex app-server \u306E\u5FDC\u7B54\u78BA\u8A8D\u304C\u9577\u5F15\u3044\u3066\u3044\u307E\u3059\u3002\u5165\u529B\u3068\u6587\u8108\u306F Dashboard thread \u306B\u4FDD\u5B58\u6E08\u307F\u3067\u3059\u3002\u518D\u63A5\u7D9A\u3068\u72B6\u614B\u78BA\u8A8D\u3092\u7D9A\u3051\u3066\u3044\u307E\u3059\u3002\u540C\u3058 thread \u3067\u88DC\u8DB3\u3084\u30AD\u30E3\u30F3\u30BB\u30EB\u6307\u793A\u3092\u9001\u308C\u307E\u3059\u3002\u9045\u308C\u3066\u8FD4\u4FE1\u304C\u5C4A\u3044\u305F\u5834\u5408\u306F\u3001\u3053\u306E thread \u306B\u8FFD\u52A0\u3057\u307E\u3059\u3002";
   }
   return normalizedText || "codex app-server \u304C\u8FD4\u4FE1\u524D\u306B\u5931\u6557\u3057\u307E\u3057\u305F\u3002\u540C\u3058 thread \u3067\u7D9A\u3051\u308B\u304B\u3001\u5185\u5BB9\u3092\u77ED\u304F\u3057\u3066\u3082\u3046\u4E00\u5EA6\u9001\u308C\u307E\u3059\u3002";
+}
+function buildDashboardAppServerFailureTransientText({ messageStatus = "", failureText = "" } = {}) {
+  if (normalizeDashboardChatStatus(messageStatus) === "stalled") {
+    return "\u518D\u63A5\u7D9A\u3068\u72B6\u614B\u78BA\u8A8D\u3092\u7D9A\u3051\u3066\u3044\u307E\u3059\u3002\u5165\u529B\u3068\u6587\u8108\u306F\u4FDD\u6301\u3057\u3066\u3044\u307E\u3059\u3002";
+  }
+  return sanitizeDashboardChatText(failureText) || "app-server bridge \u306E\u8FD4\u4FE1\u3092\u5F85\u3063\u3066\u3044\u307E\u3059";
+}
+async function filterDashboardAppServerBridgeMessagesForAppend({ store, threadId, messages = [] } = {}) {
+  const normalizedMessages = Array.isArray(messages) ? messages.filter(Boolean) : [];
+  if (normalizedMessages.length === 0 || !store || typeof store.listThread !== "function") {
+    return normalizedMessages;
+  }
+  let recentMessages = [];
+  try {
+    recentMessages = await store.listThread(threadId, { limit: 1 });
+  } catch {
+    return normalizedMessages;
+  }
+  const latest = Array.isArray(recentMessages) ? recentMessages.at(-1) : null;
+  return normalizedMessages.filter((message) => !isDuplicateLatestStalledRecoveryMessage(message, latest));
+}
+function isDuplicateLatestStalledRecoveryMessage(message, latest) {
+  if (!message || !latest) {
+    return false;
+  }
+  return normalizeDashboardEventText(message.role).toLowerCase() === "system" && normalizeDashboardChatStatus(message.status) === "stalled" && normalizeDashboardEventText(latest.role).toLowerCase() === "system" && normalizeDashboardChatStatus(latest.status) === "stalled" && sanitizeDashboardChatText(message.text) === sanitizeDashboardChatText(latest.text);
 }
 var DASHBOARD_APP_SERVER_STAGE_TEXT = {
   read_context: "\u65E2\u5B58 Issue / PR / docs \u3092\u78BA\u8A8D\u3057\u3066\u3044\u307E\u3059\u3002",


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #590 の production PWA スクショで確認された「同じ stalled SYSTEM message が 2分間隔で増殖し、下部 status も長文で埋まる」問題を修正します。
- 初回 stalled recovery は thread history に残し、2回目以降の同一 stalled recovery は永続 message として保存しません。
- bottom transient status は全文ではなく短い「再接続と状態確認中」表示にします。

## Satisfied Success Criteria

- Issue #590: app-server turn が stalled / timeout recovery に入っても、同じ thread に同じ SYSTEM recovery 文言が繰り返し保存されない。
- Issue #590: 初回 stalled recovery は「入力と文脈は Dashboard thread に保存済み」という owner-facing evidence として残る。
- Issue #590: repeated stalled event は短い transient status で表示され、長文 SYSTEM と bottom 長文の二重表示を避ける。
- Issue #590: regression test で同じ timeout event を2回送り、stored SYSTEM message が1件のままになることを固定。

## Unsatisfied Success Criteria

- 実 Codex app-server の細かい progress / 独り言 event を owner-facing に逐次流す改善は未実装。
- production Dashboard Butler での slow-turn / stalled duplicate E2E は merge/deploy 後に必要。
- stop / interrupt UI、owner input queue、deploy status 自動 thread 投稿は未実装。
- Issue #590 はこの PR だけでは close-ready ではありません。

## Non-goal violations

None.

## 開発前作戦図

- 作戦図 evidence: `docs/development-strategy/issue-590-stalled-recovery-dedupe.md`
- 完了体験: Dashboard Butler が応答確認中になっても、同じ SYSTEM stalled 文言を thread に積み上げず、owner は短い再接続 status を見ながら同じ thread で補足やキャンセル指示を続けられる。
- VTDD 全体で進める部分: Issue #590 の root blocker のうち、stalled recovery 表示が owner-facing progress の代わりに重複 SYSTEM として残る問題を修正する。
- 設計: Dashboard Butler の owner-facing surface では初回 stalled を保存し、直近 message が同一 stalled recovery の場合だけ append 前に除外する。transient status は短文へ分離し、thread history と status area の境界を分ける。
- 仮説: `DashboardChatRoom.acceptAppServerBridgeMessage()` が app-server bridge messages を無条件 append していることが原因で、bridge の stalled retry が同一 SYSTEM message を増殖させている。
- 検証計画: worker unit test、generated worker check、full npm test。
- 改修見積もり: `src/worker/runtime.js` append前 dedupe / transient短文化、`test/worker.test.js` regression、`worker.js` generated bundle。
- 既に通っている経路: PR #721 / PR #727 で固定 timeout 緩和、PR #728 で slow-turn E2E harness が入ったが、今回の重複 SYSTEM 表示は未解決だった。
- 未確認の境界: production bridge が stalled event を再送する正確な間隔は未確認。ただし worker 側 dedupe で thread 汚染は止められる。
- 穴が出そうな箇所: 初回 recovery message まで消すこと、異なる failure まで隠すこと、bottom transient に全文を残すこと。
- PR 前に確認すること: Issue #590 / PR #728 merged truth、active queue、worker tests、generated worker。
- 実装候補と捨てた案: 採用は worker append 前 dedupe。bridge 側だけの抑止と stalled 全削除は捨てた。
- merge 後に通す E2E: production Dashboard Butler live E2E で slow-turn / stalled recovery を発火し、同じ SYSTEM stalled 文言が2個以上増えないことを検証する。
- 次の PR を増やさない理由: この PR はスクショで見えた具体的 UX regression に限定する。progress event 詳細表示や deploy status 自動投稿は別 slice。
- 停止条件: first recovery message が消える、通常 reply が保存されない、異なる failure が隠れる、deploy / credential / permission / root 操作が必要になる場合。

## Dry-run Impact Report

- Target Issue: Issue #590
- Implementing Success Criteria: repeated stalled recovery event の永続 message 重複防止と短い transient status 表示。
- Explicit Non-goals: deploy、credential mutation、permission mutation、root/sudo、実 Codex progress の逐次表示、stop/interrupt UI、owner input queue、Issue closure。
- Expected touched files/routes/workflows: `src/worker/runtime.js`、`test/worker.test.js`、`worker.js`、`docs/development-strategy/issue-590-stalled-recovery-dedupe.md`
- Affected Issues: Issue #590。Issue #528 / Issue #413 は関連するが、この PR では実装しない。
- Affected PRs: PR #728 の後続。PR #728 は merged のため fresh branch で作成。
- Affected workflows: GitHub Actions test/review のみ。deploy workflow はこの PR では起動しない。
- Affected runtime/operator surfaces: DashboardChatRoom WebSocket / app-server bridge event handling。
- What may break if we patch narrowly: 同じ stalled の duplicate 以外まで消すと別 failure が見えなくなるため、直近 message の role/status/text が同一の場合だけ除外する。
- Unknowns to investigate before coding: production bridge の retry interval。
- Validation needed: worker targeted test、full `npm test`、production Dashboard Butler E2E。
- Stop condition: first recovery evidence 消失、通常 reply 消失、異なる failure の抑止、high-risk 操作要求。

## Execution Queue Delta

- Queue position before: Issue #590 は active issue execution queue の Now。Dashboard Butler timeout / silent wait recovery が root blocker。
- Preemption decision: ROOT。owner の最新 screenshot は Issue #590 の parent root を直接阻害しており、通常の Butler 開発継続を壊しているため Now のまま処理する。
- Queue delta: Issue #590 の stalled recovery duplicate 表示を修正する。Issue #590 は未完了のまま、production E2E と progress/interrupt 設計を Evidence Gaps に残す。
- Why this PR is next: slow-turn harness が入っても、stalled 表示が SYSTEM message として増殖すると owner は同じ thread で安心して待てない。Issue #590 の先行 blocker として先に潰す必要がある。
- Active Issues not downscoped: Active Issues は縮小しません。Issue #528 / Issue #413 / Issue #637 など関連 root blockers は未完了として残します。

## File / Line Hypotheses

- file: `src/worker/runtime.js`
  - hypothesis: app-server bridge event messages を append 前に直近 stalled と比較すれば、同一 SYSTEM message の増殖を止められる。
  - risk if changed narrowly: 直近以外まで dedupe すると新しい turn の recovery evidence を隠す。
  - validation: repeated stalled recovery worker test、既存 timeout persistence test。
  - related Issue: Issue #590
- file: `test/worker.test.js`
  - hypothesis: 同じ timeout event を2回送る regression test が screenshot の症状を再現できる。
  - risk if changed narrowly: transient status だけを見て stored message の増殖を見逃す。
  - validation: stored length、thread broadcast count、transient status count。
  - related Issue: Issue #590

## Hypothesis Retrospective

- expected: repeated stalled retry は worker append 前 dedupe で止められる。
- actual: 初回 timeout recovery は保存し、2回目の同一 stalled event は保存せず短い transient status のみ送る実装になった。
- mismatch: production bridge retry interval は未確認で、merge/deploy 後 E2E が必要。
- lesson: stalled recovery は thread evidence と transient status を分離しないと、復旧表示が thread spam になる。
- should become RAG candidate: yes。Dashboard recovery 表示は first persistent / repeated transient-only を基本にする。

## Verification Evidence

- Targeted: `node --test test/worker.test.js --test-name-pattern "app-server timeout|stalled recovery|transient UI state|progress stages"` pass。247 pass、0 fail。
- Worker build: `npm run build:worker` pass。
- Generated worker: `npm run check:generated-worker` pass。
- Full: `env -u VTDD_GATEWAY_BEARER_TOKEN -u VTDD_RUNTIME_URL -u VTDD_DASHBOARD_APP_SERVER_SANDBOX -u VTDD_DASHBOARD_APP_SERVER_ENV -u VTDD_DASHBOARD_THREAD_ID HOME=/tmp/vtdd-empty-home npm test` pass。1124 tests、1123 pass、1 skipped、0 fail。`check:self-parity` pass。`check:generated-worker` pass。
- Manual: `git diff --check` pass。
- E2E: 未実施。merge/deploy 後に production Dashboard Butler で確認する。
- Evidence path/link: `docs/development-strategy/issue-590-stalled-recovery-dedupe.md`

## Butler Completion Contract

- Primary owner surface: Dashboard Butler。
- Fallback surface: mac Codex は実装/検証補助。Issue #590 の owner-facing E2E は Dashboard Butler production で行う。
- Owner goal: 2分おきの長文 SYSTEM stalled spam を止め、同じ thread で待機・補足・キャンセルを続けられるようにする。
- Butler entrypoint: Dashboard Butler の通常チャットと app-server bridge event path。
- Dashboard Butler natural-language path: Dashboard Butler の natural-language chat entrypoint で owner は通常チャットに補足やキャンセル指示を送れる。今回の変更は bridge event 表示の復旧 UX を改善する。
- Action Schema exposure: 未変更。Custom GPT Action Schema はこの PR では触らない。
- Runtime path: DashboardChatRoom WebSocket -> app-server bridge event normalization -> transient status broadcast -> append dedupe -> thread broadcast。
- Runner/runtime truth: worker unit test と generated worker sync。production runtime truth は merge/deploy 後に追加する。
- Authority boundary: low-risk runtime UI handling。GO 範囲の実装のみ。deploy、credential、permission、root/sudo、repository mutation はなし。
- E2E evidence: 未実施。merge/deploy 後の production Dashboard Butler stalled duplicate E2E が必要。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: この PR では実行しない。merge 後に passkey 境界で owner が判断。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: merge/deploy 後に必要。

## Related Constitution Rules

- Butler Completion Gate
- Butler-First Operating Principle
- Drift Stop Protocol
- 開発前作戦図 Gate
- Evidence Discipline
- Authority Boundary

## Out-of-scope but NOT implemented

- 実 Codex app-server progress / 独り言の逐次表示。
- deploy completion の thread 自動投稿。
- stop / interrupt / queued owner input UI。
- Issue #590 close judgment。
- deploy、credential mutation、permission mutation、root/sudo。

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #590
- Execution ID: app-server-stalled-dedupe
- Goal: Issue #590 stalled recovery duplicate message suppression
