### PR TITLE
Issue #590 persist progress checkpoints to Butler thread

### DIFF
--- a/docs/development-strategy/issue-590-progress-checkpoints-to-thread.md
+++ b/docs/development-strategy/issue-590-progress-checkpoints-to-thread.md
@@ -12,7 +12,9 @@ Issue #590 の silent wait recovery と Issue #413 の owner-facing execution pr
 
 ## 設計
 
-app-server bridge が既に受けている Codex app-server lifecycle event を、`app_server_status` の transient だけで終わらせず、`persistProgress` が付いた checkpoint event として DashboardChatRoom に渡す。Worker 側は `persistProgress` のある `app_server_status` だけを durable thread message に保存する。
+app-server bridge が既に受けている Codex app-server lifecycle event を、`app_server_status` の transient だけで終わらせず、`persistProgress` が付いた checkpoint event として DashboardChatRoom に渡す。Worker 側は `persistProgress` のある `app_server_status` を durable thread message に保存する。
+
+レビュアー指摘を受け、Worker 側は `persistProgress` がない場合でも、`planning` / `command` / `file_change` / `tool_call` / `test` など既知の安全な stage だけは checkpoint として保存する。これにより、VPS app-server bridge process が一部古く、まだ `persistProgress` を付けない場合でも、既存 stage event が出ている限り owner-facing progress は thread に残る。
 
 通常の `app_server_status` は今まで通り transient-only にする。これにより既存の軽い status 表示は壊さない。durable checkpoint は role `butler` / status `thinking` として短い owner-facing text だけを保存する。直近に同じ role/status/text がある場合は保存しない。
 
@@ -23,15 +25,16 @@ app-server bridge が既に受けている Codex app-server lifecycle event を�
 ## 検証計画
 
 - Worker test: `persistProgress: true` の `app_server_status` が transient と durable thread message の両方になること。
+- Worker test: `persistProgress` がない既知の安全な stage も durable checkpoint になること。
 - Worker test: 同じ progress checkpoint が連続しても durable message は増殖しないこと。
-- Worker test: `persistProgress` なしの `app_server_status` は従来どおり transient-only のままであること。
+- Worker test: safety list 外の `app_server_status` は従来どおり transient-only のままであること。
 - Bridge test: Codex plan / command / file change / tool / reasoning summary events が `persistProgress: true` を持つこと。
 - `npm run build:worker`、`npm run check:generated-worker`、full `npm test` を通す。
 
 ## 改修見積もり
 
 - `scripts/run-dashboard-app-server-bridge.mjs`: Codex lifecycle event のうち owner-facing checkpoint にしたい status event に `persistProgress: true` を付与する。raw delta / raw provider message は保存しない。
-- `src/worker/runtime.js`: `app_server_status` の `persistProgress` を読み、owner-facing stage text を durable message として保存する。重複 checkpoint を append 前に除外する。
+- `src/worker/runtime.js`: `app_server_status` の `persistProgress` と既知の安全な stage を読み、owner-facing stage text を durable message として保存する。重複 checkpoint を append 前に除外する。
 - `test/dashboard-app-server-bridge.test.js`: bridge event mapping regression。
 - `test/worker.test.js`: persistent progress / duplicate suppression / transient-only regression。
 - `worker.js`: generated worker bundle。
@@ -57,7 +60,7 @@ Issue #590 / Issue #413、active execution queue、PR #728 / PR #729 truth、Ope
 
 ## 実装候補と捨てた案
 
-採用案は `persistProgress` flag による opt-in durable checkpoint。捨てた案は全 `app_server_status` durable 化、raw output 保存、VPS Codex CLI commentary の全文保存、final summary replacement まで同時実装する案。
+採用案は `persistProgress` flag による opt-in durable checkpoint と、Worker 側の既知安全 stage fallback。捨てた案は全 `app_server_status` durable 化、raw output 保存、VPS Codex CLI commentary の全文保存、final summary replacement まで同時実装する案。
 
 ## merge 後に通す E2E
 

--- a/docs/development-strategy/issue-590-progress-checkpoints-to-thread.md
+++ b/docs/development-strategy/issue-590-progress-checkpoints-to-thread.md
@@ -1,0 +1,72 @@
+# Issue #590 / Issue #413: progress checkpoints to Butler thread
+
+## 完了体験
+
+Dashboard Butler で長めの開発を開始した owner が、開発終了まで無言で待たされない。Butler thread には、VPS Codex / app-server bridge が今どの段階にいるかが短い日本語の checkpoint として出る。owner は「何を読んでいるか」「どの仮説であたりをつけているか」「検証中か」「テスト中か」「reviewer 待ちか」を追える。
+
+この PR は生の chain-of-thought を出さない。owner-facing な作業 checkpoint だけを出す。
+
+## VTDD 全体で進める部分
+
+Issue #590 の silent wait recovery と Issue #413 の owner-facing execution progress をつなぐ。VTDD の root blocker は「VPS Codex が動いているか」ではなく「Butler から作業の筋道が見えないこと」なので、app-server bridge event を Dashboard thread へ流す実行可視化レイヤーを作る。
+
+## 設計
+
+app-server bridge が既に受けている Codex app-server lifecycle event を、`app_server_status` の transient だけで終わらせず、`persistProgress` が付いた checkpoint event として DashboardChatRoom に渡す。Worker 側は `persistProgress` のある `app_server_status` だけを durable thread message に保存する。
+
+通常の `app_server_status` は今まで通り transient-only にする。これにより既存の軽い status 表示は壊さない。durable checkpoint は role `butler` / status `thinking` として短い owner-facing text だけを保存する。直近に同じ role/status/text がある場合は保存しない。
+
+## 仮説
+
+現状の原因は、`scripts/run-dashboard-app-server-bridge.mjs` が Codex lifecycle event を `app_server_status` として Dashboard に送っているが、`src/worker/runtime.js` が `app_server_status` を transient-only として扱っていること。結果として、Codex 側で進行 event が出ても Butler thread には残らず、owner には「無言」に見える。
+
+## 検証計画
+
+- Worker test: `persistProgress: true` の `app_server_status` が transient と durable thread message の両方になること。
+- Worker test: 同じ progress checkpoint が連続しても durable message は増殖しないこと。
+- Worker test: `persistProgress` なしの `app_server_status` は従来どおり transient-only のままであること。
+- Bridge test: Codex plan / command / file change / tool / reasoning summary events が `persistProgress: true` を持つこと。
+- `npm run build:worker`、`npm run check:generated-worker`、full `npm test` を通す。
+
+## 改修見積もり
+
+- `scripts/run-dashboard-app-server-bridge.mjs`: Codex lifecycle event のうち owner-facing checkpoint にしたい status event に `persistProgress: true` を付与する。raw delta / raw provider message は保存しない。
+- `src/worker/runtime.js`: `app_server_status` の `persistProgress` を読み、owner-facing stage text を durable message として保存する。重複 checkpoint を append 前に除外する。
+- `test/dashboard-app-server-bridge.test.js`: bridge event mapping regression。
+- `test/worker.test.js`: persistent progress / duplicate suppression / transient-only regression。
+- `worker.js`: generated worker bundle。
+
+## 既に通っている経路
+
+PR #721 / PR #727 で activity watchdog と stalled 表示は改善された。PR #728 で slow-turn harness が入った。PR #729 で同一 stalled SYSTEM の増殖は止めた。しかし、owner-facing progress checkpoint はまだ Butler thread に出ていない。
+
+## 未確認の境界
+
+Codex app-server が提供する event の完全な種類は今後変わる可能性がある。今回の PR は既存実装で既に map している event だけを対象にする。VPS checkout 同期 / bridge restart は runtime 操作なのでこの PR では実行しない。
+
+## 穴が出そうな箇所
+
+- raw terminal output や raw reasoning を durable message に混ぜると UX と安全境界を壊す。
+- 全ての status を durable にすると thread spam になる。
+- transient-only の既存挙動を壊すと通常 chat が重くなる。
+- final summary で途中 checkpoint を置き換える機構は別 slice に残る。
+
+## PR 前に確認すること
+
+Issue #590 / Issue #413、active execution queue、PR #728 / PR #729 truth、OpenAI streaming/realtime docs の lifecycle event 方針、既存 app-server bridge mapping、Worker status handling を確認する。
+
+## 実装候補と捨てた案
+
+採用案は `persistProgress` flag による opt-in durable checkpoint。捨てた案は全 `app_server_status` durable 化、raw output 保存、VPS Codex CLI commentary の全文保存、final summary replacement まで同時実装する案。
+
+## merge 後に通す E2E
+
+Production Dashboard Butler live E2E として、最新 VPS checkout / bridge restart 後に `Issue #590 の slow turn を 3分で実行して` を送り、開始・継続・完了 checkpoint が Butler thread に見えること、同一文言が増殖しないことを検証する。
+
+## 次の PR を増やさない理由
+
+この PR は最初の owner-facing progress checkpoint 経路だけを作る。final summary replacement、deploy後 bridge parity 自動復旧、stop/interrupt UI は別 blocker なので、この PR に混ぜると検証境界が壊れる。
+
+## 停止条件
+
+raw chain-of-thought / raw terminal output が durable message に出る、通常 transient status が全て durable 化される、同一 progress が増殖する、deploy / credential / permission / root 操作が必要になる場合は停止する。

--- a/docs/mvp/e2e/e2e-518-dashboard-chat-transient-timestamps.md
+++ b/docs/mvp/e2e/e2e-518-dashboard-chat-transient-timestamps.md
@@ -11,7 +11,8 @@ Goal:
 - confirm Dashboard Butler chat messages show subtle timestamps
 - confirm owner / Butler / system timestamps fit in an iPhone-width layout
 - confirm app-server progress stages are mapped to owner-facing Japanese transient status
-- confirm transient progress is not persisted as chat history
+- confirm transient progress still updates composer status while selected safe
+  stages may also persist as short Butler progress checkpoints
 - confirm final app-server replies return transient status to the normal connected state
 
 Non-goals:
@@ -31,7 +32,8 @@ node --test test/worker.test.js
 Observed result on 2026-05-26:
 - passed
 - confirms Dashboard inline chat renderer contains `message-meta` timestamp rendering
-- confirms `transient_status` is handled as composer status, not appended as a message
+- confirms `transient_status` is handled as composer status, and selected safe
+  stages can also create short Butler progress checkpoints
 - confirms `app_server_reply` is persisted as a Butler message and also returns transient status to `Dashboard thread 接続済み。`
 - confirms app-server stages map to owner-facing Japanese transient labels:
   - `既存 Issue / PR / docs を確認しています。`
@@ -62,7 +64,8 @@ Observed result on 2026-05-26:
 - previous-day message shows a date plus time label: `5/25 23:21`
 - timestamp text is visually secondary to message body text
 - owner copy button, Butler copy button, message body, and composer controls are not horizontally clipped in the 390 px viewport
-- transient status is not represented as a chat message in this visual fixture
+- transient status is not represented as a chat message in this visual fixture;
+  production progress checkpoints are covered by the app-server bridge tests
 
 ## Evidence Files
 
@@ -78,6 +81,7 @@ Screenshot hash:
 ## Current Reading
 
 Issue `#518` now has code-level evidence for timestamp rendering, transient
-non-persistence, owner-facing stage mapping, and final connected-state reset.
+status rendering, selected safe progress checkpoint persistence,
+owner-facing stage mapping, and final connected-state reset.
 It also has mobile-width visual evidence for timestamp layout. This is not a
 production deploy claim and does not close the Issue by itself.

--- a/scripts/run-dashboard-app-server-bridge.mjs
+++ b/scripts/run-dashboard-app-server-bridge.mjs
@@ -583,6 +583,7 @@ export function mapAppServerNotificationToDashboardEvent(message, context = {}) 
       threadId: context.dashboardThreadId,
       codexThreadId: params.threadId || context.codexThreadId || null,
       status: "thinking",
+      persistProgress: true,
       text: "codex app-server が応答を生成しています。"
     };
   }
@@ -603,6 +604,7 @@ export function mapAppServerNotificationToDashboardEvent(message, context = {}) 
       codexThreadId: params.threadId || context.codexThreadId || null,
       status: "thinking",
       stage,
+      persistProgress: shouldPersistAppServerProgressStage(stage),
       text: "codex app-server の実行状態が更新されました。"
     };
   }
@@ -615,6 +617,7 @@ export function mapAppServerNotificationToDashboardEvent(message, context = {}) 
       turnId: params.turnId || null,
       status: "thinking",
       stage: "planning",
+      persistProgress: true,
       text: "方針を整理しています。"
     };
   }
@@ -627,6 +630,7 @@ export function mapAppServerNotificationToDashboardEvent(message, context = {}) 
       turnId: params.turnId || null,
       status: "thinking",
       stage: "file_change",
+      persistProgress: true,
       text: "ファイル変更を確認しています。"
     };
   }
@@ -639,6 +643,7 @@ export function mapAppServerNotificationToDashboardEvent(message, context = {}) 
       turnId: params.turnId || null,
       status: "thinking",
       stage: "command",
+      persistProgress: true,
       text: "コマンドを実行しています。"
     };
   }
@@ -651,6 +656,7 @@ export function mapAppServerNotificationToDashboardEvent(message, context = {}) 
       turnId: params.turnId || null,
       status: "thinking",
       stage: "tool_call",
+      persistProgress: true,
       text: "外部ツールの結果を待っています。"
     };
   }
@@ -663,6 +669,7 @@ export function mapAppServerNotificationToDashboardEvent(message, context = {}) 
       turnId: params.turnId || null,
       status: "thinking",
       stage: mapAppServerItemToProgressStage(params.item),
+      persistProgress: shouldPersistAppServerProgressStage(mapAppServerItemToProgressStage(params.item)),
       text: "codex app-server の処理が進行しています。"
     };
   }
@@ -675,6 +682,7 @@ export function mapAppServerNotificationToDashboardEvent(message, context = {}) 
       turnId: params.turnId || null,
       status: "thinking",
       stage: "thinking",
+      persistProgress: true,
       text: "考えています。"
     };
   }
@@ -709,6 +717,32 @@ export function mapAppServerNotificationToDashboardEvent(message, context = {}) 
     };
   }
   return null;
+}
+
+function shouldPersistAppServerProgressStage(stage = "") {
+  const normalized = String(stage || "").trim().toLowerCase().replaceAll("-", "_");
+  return [
+    "thinking",
+    "planning",
+    "hypothesis",
+    "target",
+    "verify",
+    "verification",
+    "command",
+    "file_change",
+    "tool_call",
+    "web_search",
+    "waiting_approval",
+    "waiting_user_input",
+    "implementation",
+    "test",
+    "tests",
+    "pr_body",
+    "pr_create",
+    "reviewer_wait",
+    "reviewer_revision",
+    "debug_slow_turn"
+  ].includes(normalized);
 }
 
 function mapAppServerItemToProgressStage(item = {}) {
@@ -861,6 +895,7 @@ export async function runDashboardDebugSlowTurn({
     relatedIssue,
     status: "thinking",
     stage: "debug_slow_turn",
+    persistProgress: true,
     text: `Issue #590 slow turn E2E を開始しました。指定待機時間: ${durationSeconds}秒。`,
     debugSlowTurn: {
       startedAt,
@@ -888,6 +923,7 @@ export async function runDashboardDebugSlowTurn({
       relatedIssue,
       status: "thinking",
       stage: "debug_slow_turn",
+      persistProgress: true,
       text: `Issue #590 slow turn E2E 継続中です。経過: ${Math.floor(elapsedMs / 1000)}秒 / ${durationSeconds}秒。`,
       debugSlowTurn: {
         startedAt,

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -8862,6 +8862,22 @@ function normalizeDashboardAppServerBridgeEvent(payload, { fallbackThreadId = ""
       text,
       transientStatus
     });
+    if (shouldPersistDashboardAppServerProgress(input, { transientStatus })) {
+      messages.push(
+        normalizeDashboardChatMessage(
+          {
+            threadId,
+            role: "butler",
+            repository,
+            relatedIssue,
+            status: transientStatus,
+            text: transientText,
+            createdAt
+          },
+          { threadId }
+        )
+      );
+    }
   }
   return {
     ok: true,
@@ -8906,20 +8922,36 @@ async function filterDashboardAppServerBridgeMessagesForAppend({ store, threadId
     return normalizedMessages;
   }
   const latest = Array.isArray(recentMessages) ? recentMessages.at(-1) : null;
-  return normalizedMessages.filter((message) => !isDuplicateLatestStalledRecoveryMessage(message, latest));
+  return normalizedMessages.filter((message) => !isDuplicateLatestBridgeProgressMessage(message, latest));
 }
 
-function isDuplicateLatestStalledRecoveryMessage(message, latest) {
+function isDuplicateLatestBridgeProgressMessage(message, latest) {
   if (!message || !latest) {
     return false;
   }
+  const messageStatus = normalizeDashboardChatStatus(message.status);
+  const latestStatus = normalizeDashboardChatStatus(latest.status);
+  const duplicateCandidateStatus =
+    (messageStatus === "stalled" && latestStatus === "stalled") ||
+    (messageStatus === "thinking" && latestStatus === "thinking");
   return (
-    normalizeDashboardEventText(message.role).toLowerCase() === "system" &&
-    normalizeDashboardChatStatus(message.status) === "stalled" &&
-    normalizeDashboardEventText(latest.role).toLowerCase() === "system" &&
-    normalizeDashboardChatStatus(latest.status) === "stalled" &&
+    duplicateCandidateStatus &&
+    normalizeDashboardEventText(message.role).toLowerCase() === normalizeDashboardEventText(latest.role).toLowerCase() &&
     sanitizeDashboardChatText(message.text) === sanitizeDashboardChatText(latest.text)
   );
+}
+
+function shouldPersistDashboardAppServerProgress(input, { transientStatus = "" } = {}) {
+  if (!normalizeDashboardBooleanFlag(input?.persistProgress ?? input?.persist_progress)) {
+    return false;
+  }
+  return normalizeDashboardChatStatus(transientStatus || input?.status) === "thinking";
+}
+
+function normalizeDashboardBooleanFlag(value) {
+  if (value === true) return true;
+  if (value === false || value === null || value === undefined) return false;
+  return ["1", "true", "yes", "on"].includes(normalizeDashboardEventText(value).toLowerCase());
 }
 
 const DASHBOARD_APP_SERVER_STAGE_TEXT = {
@@ -8934,6 +8966,10 @@ const DASHBOARD_APP_SERVER_STAGE_TEXT = {
   topic_branch: "topic branch を作成しています。",
   branch_create: "topic branch を作成しています。",
   planning: "方針を整理しています。",
+  hypothesis: "仮説を整理しています。",
+  target: "確認する箇所にあたりをつけています。",
+  verify: "検証方法を確認しています。",
+  verification: "検証方法を確認しています。",
   command: "コマンドを実行しています。",
   file_change: "ファイル変更を確認しています。",
   tool_call: "外部ツールの結果を待っています。",
@@ -8941,6 +8977,7 @@ const DASHBOARD_APP_SERVER_STAGE_TEXT = {
   waiting_approval: "承認待ちです。",
   waiting_user_input: "確認が必要です。",
   quiet: "接続と実行状態を確認中です。入力と文脈は保持しています。",
+  debug_slow_turn: "Issue #590 slow turn E2E を実行しています。",
   thinking: "考えています。",
   implementation: "実装に入っています。",
   implement: "実装に入っています。",

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -9015,6 +9015,8 @@ const DASHBOARD_DURABLE_APP_SERVER_PROGRESS_STAGES = new Set([
   "file_change",
   "tool_call",
   "web_search",
+  "waiting_approval",
+  "waiting_user_input",
   "implementation",
   "implement",
   "test",

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -8942,10 +8942,21 @@ function isDuplicateLatestBridgeProgressMessage(message, latest) {
 }
 
 function shouldPersistDashboardAppServerProgress(input, { transientStatus = "" } = {}) {
-  if (!normalizeDashboardBooleanFlag(input?.persistProgress ?? input?.persist_progress)) {
+  if (normalizeDashboardChatStatus(transientStatus || input?.status) !== "thinking") {
     return false;
   }
-  return normalizeDashboardChatStatus(transientStatus || input?.status) === "thinking";
+  if (normalizeDashboardBooleanFlag(input?.persistProgress ?? input?.persist_progress)) {
+    return true;
+  }
+  const stage = normalizeDashboardEventText(
+    input?.stage ||
+      input?.phase ||
+      input?.step ||
+      input?.activity ||
+      input?.progressStage ||
+      input?.progress_stage
+  ).toLowerCase().replaceAll("-", "_");
+  return DASHBOARD_DURABLE_APP_SERVER_PROGRESS_STAGES.has(stage);
 }
 
 function normalizeDashboardBooleanFlag(value) {
@@ -8992,6 +9003,32 @@ const DASHBOARD_APP_SERVER_STAGE_TEXT = {
   reviewer_revision: "reviewer 指摘を反映しています。",
   review_fix: "reviewer 指摘を反映しています。"
 };
+
+const DASHBOARD_DURABLE_APP_SERVER_PROGRESS_STAGES = new Set([
+  "thinking",
+  "planning",
+  "hypothesis",
+  "target",
+  "verify",
+  "verification",
+  "command",
+  "file_change",
+  "tool_call",
+  "web_search",
+  "implementation",
+  "implement",
+  "test",
+  "tests",
+  "pr_body",
+  "pull_request_body",
+  "pr_create",
+  "pull_request_create",
+  "reviewer_wait",
+  "ci_wait",
+  "reviewer_revision",
+  "review_fix",
+  "debug_slow_turn"
+]);
 
 function buildDashboardOwnerFacingTransientStatusText(input, { status = "", text = "", transientStatus = "" } = {}) {
   if (transientStatus === "replied" || status === "replied") {

--- a/test/dashboard-app-server-bridge.test.js
+++ b/test/dashboard-app-server-bridge.test.js
@@ -579,12 +579,21 @@ test("dashboard app-server bridge maps Codex app-server notifications to dashboa
   assert.equal(completed.status, "replied");
   assert.equal(completed.text, "最終返答");
 
+  const started = mapAppServerNotificationToDashboardEvent(
+    { method: "turn/started", params: { threadId: "codex-thread-1", turnId: "turn-1" } },
+    { dashboardThreadId: "dashboard-main", codexThreadId: "codex-thread-1" }
+  );
+  assert.equal(started.type, "app_server_status");
+  assert.equal(started.persistProgress, true);
+  assert.equal(started.text, "codex app-server が応答を生成しています。");
+
   const plan = mapAppServerNotificationToDashboardEvent(
     { method: "turn/plan/updated", params: { threadId: "codex-thread-1", turnId: "turn-1" } },
     { dashboardThreadId: "dashboard-main", codexThreadId: "codex-thread-1" }
   );
   assert.equal(plan.type, "app_server_status");
   assert.equal(plan.stage, "planning");
+  assert.equal(plan.persistProgress, true);
 
   const command = mapAppServerNotificationToDashboardEvent(
     { method: "item/commandExecution/outputDelta", params: { threadId: "codex-thread-1", turnId: "turn-1", delta: "npm test" } },
@@ -592,6 +601,7 @@ test("dashboard app-server bridge maps Codex app-server notifications to dashboa
   );
   assert.equal(command.type, "app_server_status");
   assert.equal(command.stage, "command");
+  assert.equal(command.persistProgress, true);
 
   const diff = mapAppServerNotificationToDashboardEvent(
     { method: "turn/diff/updated", params: { threadId: "codex-thread-1", turnId: "turn-1" } },
@@ -599,6 +609,7 @@ test("dashboard app-server bridge maps Codex app-server notifications to dashboa
   );
   assert.equal(diff.type, "app_server_status");
   assert.equal(diff.stage, "file_change");
+  assert.equal(diff.persistProgress, true);
 
   const toolProgress = mapAppServerNotificationToDashboardEvent(
     { method: "item/mcpToolCall/progress", params: { threadId: "codex-thread-1", turnId: "turn-1", message: "raw provider progress" } },
@@ -606,6 +617,7 @@ test("dashboard app-server bridge maps Codex app-server notifications to dashboa
   );
   assert.equal(toolProgress.type, "app_server_status");
   assert.equal(toolProgress.stage, "tool_call");
+  assert.equal(toolProgress.persistProgress, true);
   assert.equal(toolProgress.text, "外部ツールの結果を待っています。");
   assert.doesNotMatch(toolProgress.text, /raw provider progress/);
 
@@ -1297,8 +1309,11 @@ test("dashboard app-server bridge runs Issue #590 debug slow turn without starti
   assert.equal(requestCount, 0);
   assert.equal(events[0].type, "app_server_status");
   assert.equal(events[0].stage, "debug_slow_turn");
+  assert.equal(events[0].persistProgress, true);
   assert.match(events[0].text, /slow turn E2E を開始/);
-  assert.ok(events.some((event) => event.type === "app_server_status" && /継続中/.test(event.text)));
+  assert.ok(
+    events.some((event) => event.type === "app_server_status" && event.persistProgress === true && /継続中/.test(event.text))
+  );
   const reply = events.find((event) => event.type === "app_server_reply");
   assert.ok(reply);
   assert.equal(reply.threadId, "dashboard-main");
@@ -1350,8 +1365,11 @@ test("dashboard app-server bridge can run debug slow turn with injected timing",
   });
 
   assert.equal(events[0].type, "app_server_status");
+  assert.equal(events[0].persistProgress, true);
   assert.equal(events[0].debugSlowTurn.lowRisk, true);
-  assert.ok(events.filter((event) => event.type === "app_server_status" && event.stage === "debug_slow_turn").length >= 2);
+  assert.ok(
+    events.filter((event) => event.type === "app_server_status" && event.stage === "debug_slow_turn" && event.persistProgress === true).length >= 2
+  );
   assert.equal(events.at(-1).type, "app_server_reply");
   assert.match(events.at(-1).text, /指定待機時間: 10秒/);
 });

--- a/test/e2e-518-dashboard-chat-transient-timestamps.test.js
+++ b/test/e2e-518-dashboard-chat-transient-timestamps.test.js
@@ -88,6 +88,7 @@ test("E2E-518 evidence doc records Dashboard timestamp and transient status run"
   assert.equal(doc.includes(["", "Users", "shuhei"].join("/") + "/"), false);
   assert.equal(doc.includes(["", "opt", "homebrew"].join("/") + "/"), false);
   assert.equal(doc.includes("does not deploy to Cloudflare"), true);
+  assert.equal(doc.includes("selected safe progress checkpoint persistence"), true);
   assert.equal(doc.includes("does not close Issue `#518`"), true);
 });
 
@@ -117,7 +118,7 @@ test("E2E-518 dashboard route exposes timestamp renderer and transient status UI
   assert.equal(html.includes('data-thread-endpoint="https://example.com/v2/dashboard/chat/dashboard-main-sample-org-vtdd-v2-p"'), true);
 });
 
-test("E2E-518 app-server stages are transient, non-persistent, and final reply resets status", async () => {
+test("E2E-518 app-server stages update transient status, safe checkpoints persist, and final reply resets status", async () => {
   const store = createInMemoryDashboardChatStore();
   const dashboardSocket = createMockSocket("dashboard", "dashboard-main-unresolved");
   const bridgeSocket = createMockSocket("app_server_bridge", "dashboard-main-unresolved");
@@ -144,12 +145,19 @@ test("E2E-518 app-server stages are transient, non-persistent, and final reply r
     })
   );
 
-  assert.equal((await store.listThread("dashboard-main-unresolved")).length, 0);
-  assert.equal(dashboardSocket.sent.length, 1);
+  let stored = await store.listThread("dashboard-main-unresolved");
+  assert.equal(stored.length, 1);
+  assert.equal(stored[0].role, "butler");
+  assert.equal(stored[0].status, "thinking");
+  assert.equal(stored[0].text, "テストを実行しています。");
+  assert.equal(dashboardSocket.sent.length, 2);
   const transient = JSON.parse(dashboardSocket.sent[0]);
   assert.equal(transient.type, "transient_status");
   assert.equal(transient.status, "thinking");
   assert.equal(transient.text, "テストを実行しています。");
+  const checkpointThread = JSON.parse(dashboardSocket.sent[1]);
+  assert.equal(checkpointThread.type, "thread");
+  assert.equal(checkpointThread.messages[0].text, "テストを実行しています。");
 
   await room.webSocketMessage(
     bridgeSocket,
@@ -162,16 +170,16 @@ test("E2E-518 app-server stages are transient, non-persistent, and final reply r
     })
   );
 
-  const stored = await store.listThread("dashboard-main-unresolved");
-  assert.equal(stored.length, 1);
-  assert.equal(stored[0].role, "butler");
-  assert.equal(stored[0].status, "replied");
-  assert.equal(dashboardSocket.sent.length, 3);
-  const finalStatus = JSON.parse(dashboardSocket.sent[1]);
+  stored = await store.listThread("dashboard-main-unresolved");
+  assert.equal(stored.length, 2);
+  assert.equal(stored[1].role, "butler");
+  assert.equal(stored[1].status, "replied");
+  assert.equal(dashboardSocket.sent.length, 4);
+  const finalStatus = JSON.parse(dashboardSocket.sent[2]);
   assert.equal(finalStatus.type, "transient_status");
   assert.equal(finalStatus.status, "replied");
   assert.equal(finalStatus.text, "Dashboard thread 接続済み。");
-  const finalThread = JSON.parse(dashboardSocket.sent[2]);
+  const finalThread = JSON.parse(dashboardSocket.sent[3]);
   assert.equal(finalThread.type, "thread");
-  assert.equal(finalThread.messages[0].text, "PR #519 の残りを確認しました。");
+  assert.equal(finalThread.messages.at(-1).text, "PR #519 の残りを確認しました。");
 });

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -4262,6 +4262,8 @@ test("DashboardChatRoom maps app-server progress stages to owner-facing transien
     "file_change",
     "tool_call",
     "web_search",
+    "waiting_approval",
+    "waiting_user_input",
     "implementation",
     "test",
     "pr_body",

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -4157,6 +4157,43 @@ test("DashboardChatRoom persists opt-in app-server progress checkpoints", async 
   assert.equal(sentPayloads[1].messages[0].text, "方針を整理しています。");
 });
 
+test("DashboardChatRoom persists known safe app-server progress stages without bridge opt-in flag", async () => {
+  const store = createInMemoryDashboardChatStore();
+  const dashboardSocket = createMockSocket("dashboard", "dashboard-main-unresolved");
+  const bridgeSocket = createMockSocket("app_server_bridge", "dashboard-main-unresolved");
+  const room = new DashboardChatRoom(
+    {
+      storage: createMockDurableObjectStorage(),
+      getWebSockets() {
+        return [dashboardSocket, bridgeSocket];
+      }
+    },
+    { DASHBOARD_CHAT_STORE: store }
+  );
+
+  await room.webSocketMessage(
+    bridgeSocket,
+    JSON.stringify({
+      type: "app_server_status",
+      status: "thinking",
+      stage: "file_change",
+      threadId: "dashboard-main-unresolved",
+      codexThreadId: "codex-thread-450",
+      text: "raw diff detail that must not be persisted"
+    })
+  );
+
+  const stored = await store.listThread("dashboard-main-unresolved");
+  assert.equal(stored.length, 1);
+  assert.equal(stored[0].role, "butler");
+  assert.equal(stored[0].status, "thinking");
+  assert.equal(stored[0].text, "ファイル変更を確認しています。");
+  assert.doesNotMatch(stored[0].text, /raw diff detail/);
+  const sentPayloads = dashboardSocket.sent.map((message) => JSON.parse(message));
+  assert.equal(sentPayloads[0].type, "transient_status");
+  assert.equal(sentPayloads[1].type, "thread");
+});
+
 test("DashboardChatRoom dedupes repeated app-server progress checkpoints", async () => {
   const store = createInMemoryDashboardChatStore();
   const dashboardSocket = createMockSocket("dashboard", "dashboard-main-unresolved");
@@ -4216,6 +4253,22 @@ test("DashboardChatRoom maps app-server progress stages to owner-facing transien
     ["reviewer_wait", "CI / reviewer を待っています。"],
     ["reviewer_revision", "reviewer 指摘を反映しています。"]
   ];
+  const durableStages = new Set([
+    "planning",
+    "hypothesis",
+    "target",
+    "verify",
+    "command",
+    "file_change",
+    "tool_call",
+    "web_search",
+    "implementation",
+    "test",
+    "pr_body",
+    "pr_create",
+    "reviewer_wait",
+    "reviewer_revision"
+  ]);
   for (const [stage, expectedText] of stageCases) {
     const store = createInMemoryDashboardChatStore();
     const dashboardSocket = createMockSocket("dashboard", "dashboard-main-unresolved");
@@ -4243,8 +4296,12 @@ test("DashboardChatRoom maps app-server progress stages to owner-facing transien
       })
     );
 
-    assert.equal((await store.listThread("dashboard-main-unresolved")).length, 0);
-    assert.equal(dashboardSocket.sent.length, 1);
+    const stored = await store.listThread("dashboard-main-unresolved");
+    assert.equal(stored.length, durableStages.has(stage) ? 1 : 0);
+    if (durableStages.has(stage)) {
+      assert.equal(stored[0].text, expectedText);
+    }
+    assert.equal(dashboardSocket.sent.filter((message) => JSON.parse(message).type === "transient_status").length, 1);
     const status = JSON.parse(dashboardSocket.sent[0]);
     assert.equal(status.type, "transient_status");
     assert.equal(status.status, "thinking");

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -4114,6 +4114,83 @@ test("DashboardChatRoom sends app-server thinking status as transient UI state",
   assert.equal(status.text, "codex app-server が応答を生成しています。");
 });
 
+test("DashboardChatRoom persists opt-in app-server progress checkpoints", async () => {
+  const store = createInMemoryDashboardChatStore();
+  const dashboardSocket = createMockSocket("dashboard", "dashboard-main-unresolved");
+  const bridgeSocket = createMockSocket("app_server_bridge", "dashboard-main-unresolved");
+  const room = new DashboardChatRoom(
+    {
+      storage: createMockDurableObjectStorage(),
+      getWebSockets() {
+        return [dashboardSocket, bridgeSocket];
+      }
+    },
+    { DASHBOARD_CHAT_STORE: store }
+  );
+
+  await room.webSocketMessage(
+    bridgeSocket,
+    JSON.stringify({
+      type: "app_server_status",
+      status: "thinking",
+      stage: "planning",
+      persistProgress: true,
+      threadId: "dashboard-main-unresolved",
+      codexThreadId: "codex-thread-450",
+      repository: "marushu/vtdd-v2-p",
+      relatedIssue: 590,
+      text: "raw plan event"
+    })
+  );
+
+  const stored = await store.listThread("dashboard-main-unresolved");
+  assert.equal(stored.length, 1);
+  assert.equal(stored[0].role, "butler");
+  assert.equal(stored[0].status, "thinking");
+  assert.equal(stored[0].repository, "marushu/vtdd-v2-p");
+  assert.equal(stored[0].relatedIssue, 590);
+  assert.equal(stored[0].text, "方針を整理しています。");
+  const sentPayloads = dashboardSocket.sent.map((message) => JSON.parse(message));
+  assert.equal(sentPayloads[0].type, "transient_status");
+  assert.equal(sentPayloads[0].text, "方針を整理しています。");
+  assert.equal(sentPayloads[1].type, "thread");
+  assert.equal(sentPayloads[1].messages[0].text, "方針を整理しています。");
+});
+
+test("DashboardChatRoom dedupes repeated app-server progress checkpoints", async () => {
+  const store = createInMemoryDashboardChatStore();
+  const dashboardSocket = createMockSocket("dashboard", "dashboard-main-unresolved");
+  const bridgeSocket = createMockSocket("app_server_bridge", "dashboard-main-unresolved");
+  const room = new DashboardChatRoom(
+    {
+      storage: createMockDurableObjectStorage(),
+      getWebSockets() {
+        return [dashboardSocket, bridgeSocket];
+      }
+    },
+    { DASHBOARD_CHAT_STORE: store }
+  );
+  const progressEvent = {
+    type: "app_server_status",
+    status: "thinking",
+    stage: "command",
+    persistProgress: true,
+    threadId: "dashboard-main-unresolved",
+    codexThreadId: "codex-thread-450",
+    text: "raw command output"
+  };
+
+  await room.webSocketMessage(bridgeSocket, JSON.stringify(progressEvent));
+  await room.webSocketMessage(bridgeSocket, JSON.stringify(progressEvent));
+
+  const stored = await store.listThread("dashboard-main-unresolved");
+  assert.equal(stored.length, 1);
+  assert.equal(stored[0].text, "コマンドを実行しています。");
+  const sentPayloads = dashboardSocket.sent.map((message) => JSON.parse(message));
+  assert.equal(sentPayloads.filter((message) => message.type === "thread").length, 1);
+  assert.equal(sentPayloads.filter((message) => message.type === "transient_status").length, 2);
+});
+
 test("DashboardChatRoom maps app-server progress stages to owner-facing transient status", async () => {
   const stageCases = [
     ["read_context", "既存 Issue / PR / docs を確認しています。"],
@@ -4122,6 +4199,9 @@ test("DashboardChatRoom maps app-server progress stages to owner-facing transien
     ["bounded_change_contract", "bounded change contract を確認しています。"],
     ["topic_branch", "topic branch を作成しています。"],
     ["planning", "方針を整理しています。"],
+    ["hypothesis", "仮説を整理しています。"],
+    ["target", "確認する箇所にあたりをつけています。"],
+    ["verify", "検証方法を確認しています。"],
     ["command", "コマンドを実行しています。"],
     ["file_change", "ファイル変更を確認しています。"],
     ["tool_call", "外部ツールの結果を待っています。"],

--- a/worker.js
+++ b/worker.js
@@ -65237,6 +65237,22 @@ function normalizeDashboardAppServerBridgeEvent(payload, { fallbackThreadId = ""
       text,
       transientStatus
     });
+    if (shouldPersistDashboardAppServerProgress(input, { transientStatus })) {
+      messages.push(
+        normalizeDashboardChatMessage(
+          {
+            threadId,
+            role: "butler",
+            repository,
+            relatedIssue,
+            status: transientStatus,
+            text: transientText,
+            createdAt
+          },
+          { threadId }
+        )
+      );
+    }
   }
   return {
     ok: true,
@@ -65275,13 +65291,27 @@ async function filterDashboardAppServerBridgeMessagesForAppend({ store, threadId
     return normalizedMessages;
   }
   const latest = Array.isArray(recentMessages) ? recentMessages.at(-1) : null;
-  return normalizedMessages.filter((message) => !isDuplicateLatestStalledRecoveryMessage(message, latest));
+  return normalizedMessages.filter((message) => !isDuplicateLatestBridgeProgressMessage(message, latest));
 }
-function isDuplicateLatestStalledRecoveryMessage(message, latest) {
+function isDuplicateLatestBridgeProgressMessage(message, latest) {
   if (!message || !latest) {
     return false;
   }
-  return normalizeDashboardEventText(message.role).toLowerCase() === "system" && normalizeDashboardChatStatus(message.status) === "stalled" && normalizeDashboardEventText(latest.role).toLowerCase() === "system" && normalizeDashboardChatStatus(latest.status) === "stalled" && sanitizeDashboardChatText(message.text) === sanitizeDashboardChatText(latest.text);
+  const messageStatus = normalizeDashboardChatStatus(message.status);
+  const latestStatus = normalizeDashboardChatStatus(latest.status);
+  const duplicateCandidateStatus = messageStatus === "stalled" && latestStatus === "stalled" || messageStatus === "thinking" && latestStatus === "thinking";
+  return duplicateCandidateStatus && normalizeDashboardEventText(message.role).toLowerCase() === normalizeDashboardEventText(latest.role).toLowerCase() && sanitizeDashboardChatText(message.text) === sanitizeDashboardChatText(latest.text);
+}
+function shouldPersistDashboardAppServerProgress(input, { transientStatus = "" } = {}) {
+  if (!normalizeDashboardBooleanFlag(input?.persistProgress ?? input?.persist_progress)) {
+    return false;
+  }
+  return normalizeDashboardChatStatus(transientStatus || input?.status) === "thinking";
+}
+function normalizeDashboardBooleanFlag(value) {
+  if (value === true) return true;
+  if (value === false || value === null || value === void 0) return false;
+  return ["1", "true", "yes", "on"].includes(normalizeDashboardEventText(value).toLowerCase());
 }
 var DASHBOARD_APP_SERVER_STAGE_TEXT = {
   read_context: "\u65E2\u5B58 Issue / PR / docs \u3092\u78BA\u8A8D\u3057\u3066\u3044\u307E\u3059\u3002",
@@ -65295,6 +65325,10 @@ var DASHBOARD_APP_SERVER_STAGE_TEXT = {
   topic_branch: "topic branch \u3092\u4F5C\u6210\u3057\u3066\u3044\u307E\u3059\u3002",
   branch_create: "topic branch \u3092\u4F5C\u6210\u3057\u3066\u3044\u307E\u3059\u3002",
   planning: "\u65B9\u91DD\u3092\u6574\u7406\u3057\u3066\u3044\u307E\u3059\u3002",
+  hypothesis: "\u4EEE\u8AAC\u3092\u6574\u7406\u3057\u3066\u3044\u307E\u3059\u3002",
+  target: "\u78BA\u8A8D\u3059\u308B\u7B87\u6240\u306B\u3042\u305F\u308A\u3092\u3064\u3051\u3066\u3044\u307E\u3059\u3002",
+  verify: "\u691C\u8A3C\u65B9\u6CD5\u3092\u78BA\u8A8D\u3057\u3066\u3044\u307E\u3059\u3002",
+  verification: "\u691C\u8A3C\u65B9\u6CD5\u3092\u78BA\u8A8D\u3057\u3066\u3044\u307E\u3059\u3002",
   command: "\u30B3\u30DE\u30F3\u30C9\u3092\u5B9F\u884C\u3057\u3066\u3044\u307E\u3059\u3002",
   file_change: "\u30D5\u30A1\u30A4\u30EB\u5909\u66F4\u3092\u78BA\u8A8D\u3057\u3066\u3044\u307E\u3059\u3002",
   tool_call: "\u5916\u90E8\u30C4\u30FC\u30EB\u306E\u7D50\u679C\u3092\u5F85\u3063\u3066\u3044\u307E\u3059\u3002",
@@ -65302,6 +65336,7 @@ var DASHBOARD_APP_SERVER_STAGE_TEXT = {
   waiting_approval: "\u627F\u8A8D\u5F85\u3061\u3067\u3059\u3002",
   waiting_user_input: "\u78BA\u8A8D\u304C\u5FC5\u8981\u3067\u3059\u3002",
   quiet: "\u63A5\u7D9A\u3068\u5B9F\u884C\u72B6\u614B\u3092\u78BA\u8A8D\u4E2D\u3067\u3059\u3002\u5165\u529B\u3068\u6587\u8108\u306F\u4FDD\u6301\u3057\u3066\u3044\u307E\u3059\u3002",
+  debug_slow_turn: "Issue #590 slow turn E2E \u3092\u5B9F\u884C\u3057\u3066\u3044\u307E\u3059\u3002",
   thinking: "\u8003\u3048\u3066\u3044\u307E\u3059\u3002",
   implementation: "\u5B9F\u88C5\u306B\u5165\u3063\u3066\u3044\u307E\u3059\u3002",
   implement: "\u5B9F\u88C5\u306B\u5165\u3063\u3066\u3044\u307E\u3059\u3002",

--- a/worker.js
+++ b/worker.js
@@ -65303,10 +65303,16 @@ function isDuplicateLatestBridgeProgressMessage(message, latest) {
   return duplicateCandidateStatus && normalizeDashboardEventText(message.role).toLowerCase() === normalizeDashboardEventText(latest.role).toLowerCase() && sanitizeDashboardChatText(message.text) === sanitizeDashboardChatText(latest.text);
 }
 function shouldPersistDashboardAppServerProgress(input, { transientStatus = "" } = {}) {
-  if (!normalizeDashboardBooleanFlag(input?.persistProgress ?? input?.persist_progress)) {
+  if (normalizeDashboardChatStatus(transientStatus || input?.status) !== "thinking") {
     return false;
   }
-  return normalizeDashboardChatStatus(transientStatus || input?.status) === "thinking";
+  if (normalizeDashboardBooleanFlag(input?.persistProgress ?? input?.persist_progress)) {
+    return true;
+  }
+  const stage = normalizeDashboardEventText(
+    input?.stage || input?.phase || input?.step || input?.activity || input?.progressStage || input?.progress_stage
+  ).toLowerCase().replaceAll("-", "_");
+  return DASHBOARD_DURABLE_APP_SERVER_PROGRESS_STAGES.has(stage);
 }
 function normalizeDashboardBooleanFlag(value) {
   if (value === true) return true;
@@ -65351,6 +65357,31 @@ var DASHBOARD_APP_SERVER_STAGE_TEXT = {
   reviewer_revision: "reviewer \u6307\u6458\u3092\u53CD\u6620\u3057\u3066\u3044\u307E\u3059\u3002",
   review_fix: "reviewer \u6307\u6458\u3092\u53CD\u6620\u3057\u3066\u3044\u307E\u3059\u3002"
 };
+var DASHBOARD_DURABLE_APP_SERVER_PROGRESS_STAGES = /* @__PURE__ */ new Set([
+  "thinking",
+  "planning",
+  "hypothesis",
+  "target",
+  "verify",
+  "verification",
+  "command",
+  "file_change",
+  "tool_call",
+  "web_search",
+  "implementation",
+  "implement",
+  "test",
+  "tests",
+  "pr_body",
+  "pull_request_body",
+  "pr_create",
+  "pull_request_create",
+  "reviewer_wait",
+  "ci_wait",
+  "reviewer_revision",
+  "review_fix",
+  "debug_slow_turn"
+]);
 function buildDashboardOwnerFacingTransientStatusText(input, { status = "", text = "", transientStatus = "" } = {}) {
   if (transientStatus === "replied" || status === "replied") {
     return "Dashboard thread \u63A5\u7D9A\u6E08\u307F\u3002";

--- a/worker.js
+++ b/worker.js
@@ -65368,6 +65368,8 @@ var DASHBOARD_DURABLE_APP_SERVER_PROGRESS_STAGES = /* @__PURE__ */ new Set([
   "file_change",
   "tool_call",
   "web_search",
+  "waiting_approval",
+  "waiting_user_input",
   "implementation",
   "implement",
   "test",


### PR DESCRIPTION
## This PR satisfies Intent

Issue #590 の silent wait recovery と Issue #413 の owner-facing execution progress visibility をつなぎます。

Dashboard Butler で長めの開発を開始した owner が、開発終了まで無言で待たされないように、codex app-server bridge の lifecycle event を短い日本語 checkpoint として Dashboard thread に残します。

レビュアー指摘への追加対応として、Worker 側は `persistProgress` がない場合でも、`planning` / `command` / `file_change` / `tool_call` / `test` など既知の安全な stage を durable checkpoint として保存します。これにより、VPS app-server bridge process が一部古くても、既存 stage event が出ている限り無言になりにくくします。

この PR は raw chain-of-thought / raw terminal output / raw provider progress を保存しません。保存するのは `方針を整理しています。`、`コマンドを実行しています。`、`ファイル変更を確認しています。` のような owner-facing checkpoint だけです。

## Satisfied Success Criteria

- [x] `persistProgress: true` の app-server status event が transient UI state だけでなく Butler thread message として durable 保存される。
- [x] `persistProgress` がない既知の安全な app-server stage も、raw text を保存せず owner-facing checkpoint として durable 保存される。
- [x] plan / command / file change / tool / reasoning summary / Issue #590 slow-turn harness の checkpoint event が bridge 側で opt-in durable progress として識別される。
- [x] 同じ progress checkpoint が連続しても、直近同一 role/status/text の durable message は増殖しない。
- [x] safety list 外の通常 `app_server_status` は従来どおり transient-only として扱われる。

## Unsatisfied Success Criteria

- Production Dashboard Butler での Issue #590 slow-turn E2E は未実施です。
- merge/deploy 後に VPS checkout と app-server bridge process が最新 `origin/main` で動いていることの runtime truth 確認が必要です。
- final summary で途中 checkpoint を置き換える仕組みは未実装です。
- stop / interrupt UI の再設計は未実装です。

## Non-goal violations

None.

## 開発前作戦図

- 作戦図 evidence: `docs/development-strategy/issue-590-progress-checkpoints-to-thread.md`
- 完了体験: Dashboard Butler の同じ thread に長めの開発中の短い進行 checkpoint が出て、owner が待ち時間中に状況を追える。
- VTDD 全体で進める部分: Issue #590 の silent wait recovery と Issue #413 の execution progress visibility を接続する。
- 設計: Dashboard Butler の owner-facing surface を壊さず、app-server bridge が checkpoint にしたい event に `persistProgress` を付け、Worker がその opt-in event と既知の安全な stage だけを durable thread message に保存する。
- 仮説: 無言に見える原因は、既存 lifecycle event が transient-only で Dashboard thread に残らないこと。
- 検証計画: bridge mapping test、Worker durable progress fallback test、duplicate suppression test、E2E-518 update、generated worker check、full test。
- 改修見積もり: `scripts/run-dashboard-app-server-bridge.mjs`、`src/worker/runtime.js`、`test/dashboard-app-server-bridge.test.js`、`test/worker.test.js`、`test/e2e-518-dashboard-chat-transient-timestamps.test.js`、`docs/mvp/e2e/e2e-518-dashboard-chat-transient-timestamps.md`、`worker.js`。
- 既に通っている経路: PR #721 / PR #727 / PR #728 / PR #729 で watchdog、slow-turn harness、stalled message dedupe は入っている。
- 未確認の境界: production deploy 後の VPS checkout / app-server bridge process freshness は runtime 操作なので別確認が必要。
- 穴が出そうな箇所: raw reasoning や raw terminal output を保存すると UX と安全境界を壊す。全 status durable 化は thread spam になる。
- PR 前に確認すること: Issue #590 / Issue #413、active execution queue、PR #728 / PR #729 truth、既存 bridge event mapping、Worker status handling。
- 実装候補と捨てた案: 採用は `persistProgress` opt-in と Worker 側の既知安全 stage fallback。捨てた案は全 status durable 化、raw output 保存、final summary replacement 同時実装。
- merge 後に通す E2E: production Dashboard Butler E2E として `Issue #590 の slow turn を 3分で実行して` を送り、進行 checkpoint が thread に見えることを確認する。
- 次の PR を増やさない理由: この PR は最初の owner-facing progress checkpoint 経路だけを作る。deploy parity / final summary / stop UI は別 blocker なので混ぜない。
- 停止条件: raw chain-of-thought / raw terminal output が durable message に出る、通常 transient status が全て durable 化される、deploy / credential / permission / root 操作が必要になる。

## Dry-run Impact Report

- Target Issue: Issue #590、linked Issue #413。
- Implementing Success Criteria: 長時間 turn 中の owner-facing progress checkpoint を Dashboard thread に残す。
- Explicit Non-goals: deploy 実行、VPS process restart、credential/permission mutation、final summary replacement、stop/interrupt UI。
- Expected touched files/routes/workflows: `scripts/run-dashboard-app-server-bridge.mjs`、`src/worker/runtime.js`、`worker.js`、`docs/mvp/e2e/e2e-518-dashboard-chat-transient-timestamps.md`、bridge/worker/E2E tests。
- Affected Issues: Issue #590、Issue #413。Issue #450 / Issue #528 は関連 root blocker だがこの PR では完了扱いしない。
- Affected PRs: PR #728 の slow-turn harness と PR #729 の stalled dedupe の上に積む。
- Affected workflows: CI test workflow。deploy-production は post-merge approval boundary。
- Affected runtime/operator surfaces: Dashboard Butler chat thread、dashboard app-server bridge WebSocket event path。
- What may break if we patch narrowly: checkpoint が durable に残らなければ owner は依然として無言に見える。逆に広げすぎると thread spam や raw output leakage が起きる。
- Unknowns to investigate before coding: Codex app-server event の全種類は将来変わる可能性があるため、既存 mapping 対象に限定する。
- Validation needed: targeted bridge/worker tests、generated worker check、full `npm test`、post-merge production E2E。
- Stop condition: high-risk operationが必要になる、raw hidden reasoning/output の永続化が必要になる、production E2E without deploy/restart truth を completion と誤認しそうになる。

## Execution Queue Delta

- Queue position before: Issue #590 is `Now` as the parent ROOT blocker for Dashboard Butler silent wait / timeout recovery. Issue #413 is a linked root blocker for owner-facing execution progress visibility.
- Preemption decision: ROOT.
- Queue delta: Issue #590 remains `Now`; this PR advances the owner-facing progress checkpoint column for Issue #590 and Issue #413.
- Why this PR is next: without durable progress checkpoints, Butler can avoid the hard 2-minute failure but still leaves the owner blind for several minutes, which blocks iPhone/iPad-first development.
- Active Issues not downscoped: active issues are not downscoped, shrunk, deferred out of scope, or treated as complete by omission. Final summary replacement, deploy/VPS bridge parity, stop/interrupt UI, and production E2E remain explicit follow-up gaps.

## File / Line Hypotheses

- file: `scripts/run-dashboard-app-server-bridge.mjs`
  - hypothesis: bridge already sees app-server lifecycle events, but does not mark owner-facing progress as durable.
  - risk if changed narrowly: missing event classes still look silent; over-broad persistence may leak noisy/raw events.
  - validation: `test/dashboard-app-server-bridge.test.js` mapping assertions for plan / command / diff / tool / slow-turn events.
  - related Issue: Issue #590、Issue #413。
- file: `src/worker/runtime.js`
  - hypothesis: Worker treats `app_server_status` as transient-only, so progress never appears in the thread. It can safely persist known stage labels even when bridge lacks the new opt-in flag.
  - risk if changed narrowly: repeated status can spam the thread; raw event text can be persisted; stale bridge remains silent if stage fallback is not included.
  - validation: Worker tests for opt-in persistence, known safe stage fallback, duplicate suppression, and transient-only status preservation.
  - related Issue: Issue #590、Issue #413。
- file: `worker.js`
  - hypothesis: generated bundle must include runtime changes or production deploy will not contain the behavior.
  - risk if changed narrowly: source passes but deployed Worker remains stale.
  - validation: `npm run build:worker` and `npm run check:generated-worker`.
  - related Issue: Issue #590。

## Hypothesis Retrospective

- expected: lifecycle events can be converted to durable owner-facing checkpoints by adding an explicit opt-in flag and Worker handling.
- actual: targeted tests and full test passed; durable checkpoint path works locally, known safe stage fallback reduces stale-bridge dependency, and safety-list外 status remains transient-only.
- mismatch: production behavior still depends on deploying the Worker and ensuring the VPS app-server bridge checkout/process is fresh.
- lesson: the root UX defect has two layers: event persistence in Worker, and runtime process freshness on VPS.
- should become RAG candidate: Yes. `butler_gap_found`: progress events must be owner-facing checkpoints, and post-deploy VPS bridge freshness must be verified before slow-turn E2E is trusted.

## Verification Evidence

- Unit: `node --test test/worker.test.js --test-name-pattern "app-server thinking status|opt-in app-server progress|known safe app-server progress|repeated app-server progress|progress stages|stalled recovery"` passed.
- Integration: `node --test test/dashboard-app-server-bridge.test.js --test-name-pattern "maps Codex app-server notifications|debug slow turn"` passed.
- E2E: `node --test test/e2e-518-dashboard-chat-transient-timestamps.test.js` passed. Production Issue #590 E2E pending after merge/deploy/VPS bridge freshness verification.
- Manual: `git diff --check` passed; `npm run build:worker` passed; `npm run check:generated-worker` passed.
- Evidence path/link: full `npm test` passed with 1127 tests, 1126 pass, 1 skipped, 0 fail; `check:self-parity` and `check:generated-worker` passed.

## Butler Completion Contract

- Primary owner surface: Dashboard Butler。
- Fallback surface: mac Codex / Custom GPT are fallback surfaces, not completion evidence for this PR.
- Owner goal: 長めの開発中も Butler thread で進行状況を追えるようにする。
- Butler entrypoint: Dashboard Butler normal chat thread; bridge event path is updated.
- Dashboard Butler natural-language path: Dashboard Butler の通常チャット入口で owner が自然文の長めの turn を開始すると、app-server bridge progress event が thread checkpoint として保存される経路です。
- Action Schema exposure: 未変更。この PR は Custom GPT Action Schema を変更しない。
- Runtime path: `dashboard app-server bridge WebSocket -> app_server_status persistProgress or known safe stage -> DashboardChatRoom -> durable thread message`。
- Runner/runtime truth: local unit/integration/full test truth はあり。production runtime truth は post-merge E2E で確認が必要。
- Authority boundary: 新しい high-risk authority は追加しない。deploy / VPS bridge restart は別途 scoped passkey approval boundary。
- E2E evidence: production Dashboard Butler E2E は未実施。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: Required after merge with scoped deploy approval; not performed by this PR.
- Custom GPT Action Schema update: Not required.
- Custom GPT Instructions update: Not required.
- iPhone Butler live E2E: Pending.

## Related Constitution Rules

- Butler Completion Gate
- Butler-First Operating Principle
- Drift Stop Protocol
- 開発前作戦図 Gate
- Execution Queue Delta
- Evidence Discipline

## Out-of-scope but NOT implemented

- final summary replacement for interim checkpoint cleanup
- automatic VPS checkout sync / app-server bridge restart after deploy
- stop / interrupt UI redesign
- production slow-turn E2E and Issue close-readiness

## Extra changes (if any)

None.
