### PR TITLE
Issue #590: progressをtransient-onlyに戻す

### DIFF
--- a/docs/development-strategy/issue-590-progress-checkpoints-to-thread.md
+++ b/docs/development-strategy/issue-590-progress-checkpoints-to-thread.md
@@ -1,47 +1,47 @@
-# Issue #590 / Issue #413: progress checkpoints to Butler thread
+# Issue #590 / Issue #413: transient progress checkpoints without chat spam
 
 ## 完了体験
 
-Dashboard Butler で長めの開発を開始した owner が、開発終了まで無言で待たされない。Butler thread には、VPS Codex / app-server bridge が今どの段階にいるかが短い日本語の checkpoint として出る。owner は「何を読んでいるか」「どの仮説であたりをつけているか」「検証中か」「テスト中か」「reviewer 待ちか」を追える。
+Dashboard Butler で長めの開発を開始した owner が、開発終了まで無言で待たされない。ただし、`考えています` / `コマンドを実行しています` のような汎用 checkpoint が Butler thread の通常 message として積み上がり、チャット履歴を埋めない。owner は turn の進行を transient UI で見られ、履歴には最終回答、失敗、承認待ち、確認待ちなど後から読む意味のあるものだけが残る。
 
-この PR は生の chain-of-thought を出さない。owner-facing な作業 checkpoint だけを出す。
+この PR は生の chain-of-thought を出さない。汎用作業 checkpoint は transient 表示に閉じ、最終回答要約への置換までは次 slice とする。
 
 ## VTDD 全体で進める部分
 
-Issue #590 の silent wait recovery と Issue #413 の owner-facing execution progress をつなぐ。VTDD の root blocker は「VPS Codex が動いているか」ではなく「Butler から作業の筋道が見えないこと」なので、app-server bridge event を Dashboard thread へ流す実行可視化レイヤーを作る。
+Issue #590 の silent wait recovery と Issue #413 の owner-facing execution progress をつなぐ。VTDD の root blocker は「VPS Codex が動いているか」ではなく「Butler から作業の筋道が見えないこと」だが、進行可視化を通常 chat message として残すと owner-facing UX を壊す。app-server bridge event は Dashboard へ流し続け、Worker 側で transient 表示と durable 履歴を分離する。
 
 ## 設計
 
-app-server bridge が既に受けている Codex app-server lifecycle event を、`app_server_status` の transient だけで終わらせず、`persistProgress` が付いた checkpoint event として DashboardChatRoom に渡す。Worker 側は `persistProgress` のある `app_server_status` を durable thread message に保存する。
+app-server bridge が既に受けている Codex app-server lifecycle event は、引き続き `app_server_status` として DashboardChatRoom に渡す。Worker 側は `app_server_status` を基本的に transient UI state として扱い、`persistProgress` が付いていても、それだけでは durable thread message に保存しない。
 
-レビュアー指摘を受け、Worker 側は `persistProgress` がない場合でも、`planning` / `command` / `file_change` / `tool_call` / `test` など既知の安全な stage だけは checkpoint として保存する。これにより、VPS app-server bridge process が一部古く、まだ `persistProgress` を付けない場合でも、既存 stage event が出ている限り owner-facing progress は thread に残る。
+durable thread message に保存するのは、owner action が必要で履歴価値がある stage に絞る。現時点では `waiting_approval` と `waiting_user_input` を対象にする。`planning` / `thinking` / `command` / `file_change` / `tool_call` / `test` / `debug_slow_turn` は transient-only に戻す。
 
-通常の `app_server_status` は今まで通り transient-only にする。これにより既存の軽い status 表示は壊さない。durable checkpoint は role `butler` / status `thinking` として短い owner-facing text だけを保存する。直近に同じ role/status/text がある場合は保存しない。
+失敗や timeout recovery は既存どおり system message として残す。turn completion は最終回答として残る。durable checkpoint は role `butler` / status `thinking` として短い owner-facing text だけを保存し、直近に同じ role/status/text がある場合は保存しない。
 
 ## 仮説
 
-現状の原因は、`scripts/run-dashboard-app-server-bridge.mjs` が Codex lifecycle event を `app_server_status` として Dashboard に送っているが、`src/worker/runtime.js` が `app_server_status` を transient-only として扱っていること。結果として、Codex 側で進行 event が出ても Butler thread には残らず、owner には「無言」に見える。
+PR #730 後の原因は逆に、`src/worker/runtime.js` が `persistProgress` と既知 stage fallback を durable message 化したこと。結果として「無言」は軽減したが、`考えています` / `コマンドを実行しています` のような低情報 checkpoint が通常チャットを埋める。owner が求めているのは ChatGPT / Codex アプリ相当の進行表示であり、履歴汚染ではない。
 
 ## 検証計画
 
-- Worker test: `persistProgress: true` の `app_server_status` が transient と durable thread message の両方になること。
-- Worker test: `persistProgress` がない既知の安全な stage も durable checkpoint になること。
-- Worker test: 同じ progress checkpoint が連続しても durable message は増殖しないこと。
-- Worker test: safety list 外の `app_server_status` は従来どおり transient-only のままであること。
-- Bridge test: Codex plan / command / file change / tool / reasoning summary events が `persistProgress: true` を持つこと。
+- Worker test: `persistProgress: true` の汎用 `app_server_status` が durable thread message にならず、transient status にだけ出ること。
+- Worker test: `persistProgress` がない汎用 stage も durable checkpoint にならないこと。
+- Worker test: `waiting_approval` / `waiting_user_input` は owner action が必要な durable checkpoint として残ること。
+- Worker test: progress event が複数回来ても通常 chat message が増殖しないこと。
+- Bridge test: Codex plan / command / file change / tool / reasoning summary events は引き続き `persistProgress` / stage を出せること。Worker 側で永続化を抑制するため、bridge event visibility は失わない。
 - `npm run build:worker`、`npm run check:generated-worker`、full `npm test` を通す。
 
 ## 改修見積もり
 
-- `scripts/run-dashboard-app-server-bridge.mjs`: Codex lifecycle event のうち owner-facing checkpoint にしたい status event に `persistProgress: true` を付与する。raw delta / raw provider message は保存しない。
-- `src/worker/runtime.js`: `app_server_status` の `persistProgress` と既知の安全な stage を読み、owner-facing stage text を durable message として保存する。重複 checkpoint を append 前に除外する。
-- `test/dashboard-app-server-bridge.test.js`: bridge event mapping regression。
-- `test/worker.test.js`: persistent progress / duplicate suppression / transient-only regression。
+- `scripts/run-dashboard-app-server-bridge.mjs`: 通常は変更しない。event emission は残す。
+- `src/worker/runtime.js`: `app_server_status` の `persistProgress` を durable message 化の条件から外し、owner action stage だけを durable 化する。
+- `test/dashboard-app-server-bridge.test.js`: 必要なら bridge event mapping regression を維持する。
+- `test/worker.test.js`: transient-only regression、owner action durable regression、message spam regression。
 - `worker.js`: generated worker bundle。
 
 ## 既に通っている経路
 
-PR #721 / PR #727 で activity watchdog と stalled 表示は改善された。PR #728 で slow-turn harness が入った。PR #729 で同一 stalled SYSTEM の増殖は止めた。しかし、owner-facing progress checkpoint はまだ Butler thread に出ていない。
+PR #721 / PR #727 で activity watchdog と stalled 表示は改善された。PR #728 で slow-turn harness が入った。PR #729 で同一 stalled SYSTEM の増殖は止めた。PR #730 で progress checkpoint の durable message 化を入れたが、owner live feedback により chat spam として不適切だと判明した。
 
 ## 未確認の境界
 
@@ -50,7 +50,7 @@ Codex app-server が提供する event の完全な種類は今後変わる可�
 ## 穴が出そうな箇所
 
 - raw terminal output や raw reasoning を durable message に混ぜると UX と安全境界を壊す。
-- 全ての status を durable にすると thread spam になる。
+- 汎用 status を durable にすると thread spam になる。
 - transient-only の既存挙動を壊すと通常 chat が重くなる。
 - final summary で途中 checkpoint を置き換える機構は別 slice に残る。
 
@@ -60,15 +60,15 @@ Issue #590 / Issue #413、active execution queue、PR #728 / PR #729 truth、Ope
 
 ## 実装候補と捨てた案
 
-採用案は `persistProgress` flag による opt-in durable checkpoint と、Worker 側の既知安全 stage fallback。捨てた案は全 `app_server_status` durable 化、raw output 保存、VPS Codex CLI commentary の全文保存、final summary replacement まで同時実装する案。
+採用案は `persistProgress` を durable 保存の条件から外し、owner action stage だけを durable checkpoint にする案。捨てた案は全 `app_server_status` durable 化、raw output 保存、VPS Codex CLI commentary の全文保存、final summary replacement まで同時実装する案。
 
 ## merge 後に通す E2E
 
-Production Dashboard Butler live E2E として、最新 VPS checkout / bridge restart 後に `Issue #590 の slow turn を 3分で実行して` を送り、開始・継続・完了 checkpoint が Butler thread に見えること、同一文言が増殖しないことを検証する。
+Production Dashboard Butler live E2E として、最新 VPS checkout / bridge restart 後に `Issue #590 の slow turn を 3分で実行して` を送り、旧 2分 timeout SYSTEM が出ないこと、進行状態は transient UI で見えること、通常 chat message として `考えています` / `コマンドを実行しています` が増殖しないこと、完了応答が同じ thread に戻ることを検証する。
 
 ## 次の PR を増やさない理由
 
-この PR は最初の owner-facing progress checkpoint 経路だけを作る。final summary replacement、deploy後 bridge parity 自動復旧、stop/interrupt UI は別 blocker なので、この PR に混ぜると検証境界が壊れる。
+この PR は PR #730 の UX regression を戻しつつ、進行検知自体は残す。final summary replacement、deploy後 bridge parity 自動復旧、stop/interrupt UI は別 blocker なので、この PR に混ぜると検証境界が壊れる。
 
 ## 停止条件
 

--- a/docs/mvp/e2e/e2e-518-dashboard-chat-transient-timestamps.md
+++ b/docs/mvp/e2e/e2e-518-dashboard-chat-transient-timestamps.md
@@ -11,8 +11,8 @@ Goal:
 - confirm Dashboard Butler chat messages show subtle timestamps
 - confirm owner / Butler / system timestamps fit in an iPhone-width layout
 - confirm app-server progress stages are mapped to owner-facing Japanese transient status
-- confirm transient progress still updates composer status while selected safe
-  stages may also persist as short Butler progress checkpoints
+- confirm generic progress stays transient-only so chat history is not filled with
+  low-information progress checkpoints
 - confirm final app-server replies return transient status to the normal connected state
 
 Non-goals:
@@ -32,8 +32,8 @@ node --test test/worker.test.js
 Observed result on 2026-05-26:
 - passed
 - confirms Dashboard inline chat renderer contains `message-meta` timestamp rendering
-- confirms `transient_status` is handled as composer status, and selected safe
-  stages can also create short Butler progress checkpoints
+- confirms `transient_status` is handled as composer status, and generic progress
+  stages do not create durable Butler chat messages
 - confirms `app_server_reply` is persisted as a Butler message and also returns transient status to `Dashboard thread 接続済み。`
 - confirms app-server stages map to owner-facing Japanese transient labels:
   - `既存 Issue / PR / docs を確認しています。`
@@ -81,7 +81,7 @@ Screenshot hash:
 ## Current Reading
 
 Issue `#518` now has code-level evidence for timestamp rendering, transient
-status rendering, selected safe progress checkpoint persistence,
-owner-facing stage mapping, and final connected-state reset.
+status rendering, generic progress stays transient-only, owner-facing stage
+mapping, and final connected-state reset.
 It also has mobile-width visual evidence for timestamp layout. This is not a
 production deploy claim and does not close the Issue by itself.

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -8945,9 +8945,6 @@ function shouldPersistDashboardAppServerProgress(input, { transientStatus = "" }
   if (normalizeDashboardChatStatus(transientStatus || input?.status) !== "thinking") {
     return false;
   }
-  if (normalizeDashboardBooleanFlag(input?.persistProgress ?? input?.persist_progress)) {
-    return true;
-  }
   const stage = normalizeDashboardEventText(
     input?.stage ||
       input?.phase ||
@@ -9005,31 +9002,8 @@ const DASHBOARD_APP_SERVER_STAGE_TEXT = {
 };
 
 const DASHBOARD_DURABLE_APP_SERVER_PROGRESS_STAGES = new Set([
-  "thinking",
-  "planning",
-  "hypothesis",
-  "target",
-  "verify",
-  "verification",
-  "command",
-  "file_change",
-  "tool_call",
-  "web_search",
   "waiting_approval",
-  "waiting_user_input",
-  "implementation",
-  "implement",
-  "test",
-  "tests",
-  "pr_body",
-  "pull_request_body",
-  "pr_create",
-  "pull_request_create",
-  "reviewer_wait",
-  "ci_wait",
-  "reviewer_revision",
-  "review_fix",
-  "debug_slow_turn"
+  "waiting_user_input"
 ]);
 
 function buildDashboardOwnerFacingTransientStatusText(input, { status = "", text = "", transientStatus = "" } = {}) {

--- a/test/e2e-518-dashboard-chat-transient-timestamps.test.js
+++ b/test/e2e-518-dashboard-chat-transient-timestamps.test.js
@@ -88,7 +88,7 @@ test("E2E-518 evidence doc records Dashboard timestamp and transient status run"
   assert.equal(doc.includes(["", "Users", "shuhei"].join("/") + "/"), false);
   assert.equal(doc.includes(["", "opt", "homebrew"].join("/") + "/"), false);
   assert.equal(doc.includes("does not deploy to Cloudflare"), true);
-  assert.equal(doc.includes("selected safe progress checkpoint persistence"), true);
+  assert.equal(doc.includes("generic progress stays transient-only"), true);
   assert.equal(doc.includes("does not close Issue `#518`"), true);
 });
 
@@ -118,7 +118,7 @@ test("E2E-518 dashboard route exposes timestamp renderer and transient status UI
   assert.equal(html.includes('data-thread-endpoint="https://example.com/v2/dashboard/chat/dashboard-main-sample-org-vtdd-v2-p"'), true);
 });
 
-test("E2E-518 app-server stages update transient status, safe checkpoints persist, and final reply resets status", async () => {
+test("E2E-518 app-server stages update transient status without generic chat spam and final reply resets status", async () => {
   const store = createInMemoryDashboardChatStore();
   const dashboardSocket = createMockSocket("dashboard", "dashboard-main-unresolved");
   const bridgeSocket = createMockSocket("app_server_bridge", "dashboard-main-unresolved");
@@ -146,18 +146,12 @@ test("E2E-518 app-server stages update transient status, safe checkpoints persis
   );
 
   let stored = await store.listThread("dashboard-main-unresolved");
-  assert.equal(stored.length, 1);
-  assert.equal(stored[0].role, "butler");
-  assert.equal(stored[0].status, "thinking");
-  assert.equal(stored[0].text, "テストを実行しています。");
-  assert.equal(dashboardSocket.sent.length, 2);
+  assert.equal(stored.length, 0);
+  assert.equal(dashboardSocket.sent.length, 1);
   const transient = JSON.parse(dashboardSocket.sent[0]);
   assert.equal(transient.type, "transient_status");
   assert.equal(transient.status, "thinking");
   assert.equal(transient.text, "テストを実行しています。");
-  const checkpointThread = JSON.parse(dashboardSocket.sent[1]);
-  assert.equal(checkpointThread.type, "thread");
-  assert.equal(checkpointThread.messages[0].text, "テストを実行しています。");
 
   await room.webSocketMessage(
     bridgeSocket,
@@ -171,15 +165,15 @@ test("E2E-518 app-server stages update transient status, safe checkpoints persis
   );
 
   stored = await store.listThread("dashboard-main-unresolved");
-  assert.equal(stored.length, 2);
-  assert.equal(stored[1].role, "butler");
-  assert.equal(stored[1].status, "replied");
-  assert.equal(dashboardSocket.sent.length, 4);
-  const finalStatus = JSON.parse(dashboardSocket.sent[2]);
+  assert.equal(stored.length, 1);
+  assert.equal(stored[0].role, "butler");
+  assert.equal(stored[0].status, "replied");
+  assert.equal(dashboardSocket.sent.length, 3);
+  const finalStatus = JSON.parse(dashboardSocket.sent[1]);
   assert.equal(finalStatus.type, "transient_status");
   assert.equal(finalStatus.status, "replied");
   assert.equal(finalStatus.text, "Dashboard thread 接続済み。");
-  const finalThread = JSON.parse(dashboardSocket.sent[3]);
+  const finalThread = JSON.parse(dashboardSocket.sent[2]);
   assert.equal(finalThread.type, "thread");
   assert.equal(finalThread.messages.at(-1).text, "PR #519 の残りを確認しました。");
 });

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -4114,7 +4114,7 @@ test("DashboardChatRoom sends app-server thinking status as transient UI state",
   assert.equal(status.text, "codex app-server が応答を生成しています。");
 });
 
-test("DashboardChatRoom persists opt-in app-server progress checkpoints", async () => {
+test("DashboardChatRoom keeps generic opt-in app-server progress transient-only", async () => {
   const store = createInMemoryDashboardChatStore();
   const dashboardSocket = createMockSocket("dashboard", "dashboard-main-unresolved");
   const bridgeSocket = createMockSocket("app_server_bridge", "dashboard-main-unresolved");
@@ -4144,20 +4144,14 @@ test("DashboardChatRoom persists opt-in app-server progress checkpoints", async 
   );
 
   const stored = await store.listThread("dashboard-main-unresolved");
-  assert.equal(stored.length, 1);
-  assert.equal(stored[0].role, "butler");
-  assert.equal(stored[0].status, "thinking");
-  assert.equal(stored[0].repository, "marushu/vtdd-v2-p");
-  assert.equal(stored[0].relatedIssue, 590);
-  assert.equal(stored[0].text, "方針を整理しています。");
+  assert.equal(stored.length, 0);
   const sentPayloads = dashboardSocket.sent.map((message) => JSON.parse(message));
   assert.equal(sentPayloads[0].type, "transient_status");
   assert.equal(sentPayloads[0].text, "方針を整理しています。");
-  assert.equal(sentPayloads[1].type, "thread");
-  assert.equal(sentPayloads[1].messages[0].text, "方針を整理しています。");
+  assert.equal(sentPayloads.some((message) => message.type === "thread"), false);
 });
 
-test("DashboardChatRoom persists known safe app-server progress stages without bridge opt-in flag", async () => {
+test("DashboardChatRoom keeps generic app-server progress stages transient-only without bridge opt-in flag", async () => {
   const store = createInMemoryDashboardChatStore();
   const dashboardSocket = createMockSocket("dashboard", "dashboard-main-unresolved");
   const bridgeSocket = createMockSocket("app_server_bridge", "dashboard-main-unresolved");
@@ -4184,17 +4178,14 @@ test("DashboardChatRoom persists known safe app-server progress stages without b
   );
 
   const stored = await store.listThread("dashboard-main-unresolved");
-  assert.equal(stored.length, 1);
-  assert.equal(stored[0].role, "butler");
-  assert.equal(stored[0].status, "thinking");
-  assert.equal(stored[0].text, "ファイル変更を確認しています。");
-  assert.doesNotMatch(stored[0].text, /raw diff detail/);
+  assert.equal(stored.length, 0);
   const sentPayloads = dashboardSocket.sent.map((message) => JSON.parse(message));
   assert.equal(sentPayloads[0].type, "transient_status");
-  assert.equal(sentPayloads[1].type, "thread");
+  assert.equal(sentPayloads[0].text, "ファイル変更を確認しています。");
+  assert.equal(sentPayloads.some((message) => message.type === "thread"), false);
 });
 
-test("DashboardChatRoom dedupes repeated app-server progress checkpoints", async () => {
+test("DashboardChatRoom does not append repeated generic app-server progress checkpoints", async () => {
   const store = createInMemoryDashboardChatStore();
   const dashboardSocket = createMockSocket("dashboard", "dashboard-main-unresolved");
   const bridgeSocket = createMockSocket("app_server_bridge", "dashboard-main-unresolved");
@@ -4221,10 +4212,9 @@ test("DashboardChatRoom dedupes repeated app-server progress checkpoints", async
   await room.webSocketMessage(bridgeSocket, JSON.stringify(progressEvent));
 
   const stored = await store.listThread("dashboard-main-unresolved");
-  assert.equal(stored.length, 1);
-  assert.equal(stored[0].text, "コマンドを実行しています。");
+  assert.equal(stored.length, 0);
   const sentPayloads = dashboardSocket.sent.map((message) => JSON.parse(message));
-  assert.equal(sentPayloads.filter((message) => message.type === "thread").length, 1);
+  assert.equal(sentPayloads.filter((message) => message.type === "thread").length, 0);
   assert.equal(sentPayloads.filter((message) => message.type === "transient_status").length, 2);
 });
 
@@ -4253,24 +4243,7 @@ test("DashboardChatRoom maps app-server progress stages to owner-facing transien
     ["reviewer_wait", "CI / reviewer を待っています。"],
     ["reviewer_revision", "reviewer 指摘を反映しています。"]
   ];
-  const durableStages = new Set([
-    "planning",
-    "hypothesis",
-    "target",
-    "verify",
-    "command",
-    "file_change",
-    "tool_call",
-    "web_search",
-    "waiting_approval",
-    "waiting_user_input",
-    "implementation",
-    "test",
-    "pr_body",
-    "pr_create",
-    "reviewer_wait",
-    "reviewer_revision"
-  ]);
+  const durableStages = new Set(["waiting_approval", "waiting_user_input"]);
   for (const [stage, expectedText] of stageCases) {
     const store = createInMemoryDashboardChatStore();
     const dashboardSocket = createMockSocket("dashboard", "dashboard-main-unresolved");

--- a/worker.js
+++ b/worker.js
@@ -65306,18 +65306,10 @@ function shouldPersistDashboardAppServerProgress(input, { transientStatus = "" }
   if (normalizeDashboardChatStatus(transientStatus || input?.status) !== "thinking") {
     return false;
   }
-  if (normalizeDashboardBooleanFlag(input?.persistProgress ?? input?.persist_progress)) {
-    return true;
-  }
   const stage = normalizeDashboardEventText(
     input?.stage || input?.phase || input?.step || input?.activity || input?.progressStage || input?.progress_stage
   ).toLowerCase().replaceAll("-", "_");
   return DASHBOARD_DURABLE_APP_SERVER_PROGRESS_STAGES.has(stage);
-}
-function normalizeDashboardBooleanFlag(value) {
-  if (value === true) return true;
-  if (value === false || value === null || value === void 0) return false;
-  return ["1", "true", "yes", "on"].includes(normalizeDashboardEventText(value).toLowerCase());
 }
 var DASHBOARD_APP_SERVER_STAGE_TEXT = {
   read_context: "\u65E2\u5B58 Issue / PR / docs \u3092\u78BA\u8A8D\u3057\u3066\u3044\u307E\u3059\u3002",
@@ -65358,31 +65350,8 @@ var DASHBOARD_APP_SERVER_STAGE_TEXT = {
   review_fix: "reviewer \u6307\u6458\u3092\u53CD\u6620\u3057\u3066\u3044\u307E\u3059\u3002"
 };
 var DASHBOARD_DURABLE_APP_SERVER_PROGRESS_STAGES = /* @__PURE__ */ new Set([
-  "thinking",
-  "planning",
-  "hypothesis",
-  "target",
-  "verify",
-  "verification",
-  "command",
-  "file_change",
-  "tool_call",
-  "web_search",
   "waiting_approval",
-  "waiting_user_input",
-  "implementation",
-  "implement",
-  "test",
-  "tests",
-  "pr_body",
-  "pull_request_body",
-  "pr_create",
-  "pull_request_create",
-  "reviewer_wait",
-  "ci_wait",
-  "reviewer_revision",
-  "review_fix",
-  "debug_slow_turn"
+  "waiting_user_input"
 ]);
 function buildDashboardOwnerFacingTransientStatusText(input, { status = "", text = "", transientStatus = "" } = {}) {
   if (transientStatus === "replied" || status === "replied") {


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #590 の部分進捗。Dashboard Butler の app-server progress を transient UI に残しつつ、低情報な progress message が通常チャット履歴を埋める regression を止める。

## Satisfied Success Criteria

- 汎用 app_server_status は persistProgress があっても durable Butler message に保存しない。
planning / file_change / command / test / debug_slow_turn は transient_status のみに戻す。
waiting_approval / waiting_user_input は owner action が必要な履歴価値のある checkpoint として durable 保存を維持する。
E2E-518 の evidence doc と test を新仕様に更新した。

## Unsatisfied Success Criteria

- Issue #590 の production slow-turn E2E はこのPRのmerge/deploy後に未実施。
final answer summary replacement は未実装。
stop / interrupt UI と owner input queue は未実装。
app-server bridge deploy後自動 restart / freshness parity は未実装。

## Non-goal violations

Issue #590 全体の close はしない。deploy、credential mutation、permission mutation、destructive work はしない。bridge event emission は消さない。raw chain-of-thought や raw terminal output は出さない。final summary replacement はこのPRに混ぜない。

## 開発前作戦図

- 作戦図 evidence: docs/development-strategy/issue-590-progress-checkpoints-to-thread.md
- 完了体験: Dashboard Butler owner は長い開発中も transient UI で進行を見られるが、通常 chat 履歴は 考えています / コマンドを実行しています で埋まらない。
- VTDD 全体で進める部分: Issue #590 silent wait recovery と Issue #413 execution progress visibility の Dashboard Butler owner-facing UX 境界を進める。
- 設計: Dashboard Butler owner-facing surface の設計。scope は app_server_status の保存境界だけ。boundary は transient UI と durable chat message の分離。
- 仮説: 仮説: 原因は PR #730 で persistProgress と既知stage fallback を durable message 化したこと。これが generic progress chat spam を壊した。
- 検証計画: 検証計画: worker unit test、E2E-518 test、dashboard app-server bridge test、build:worker、check:generated-worker、空HOMEでの npm test で確認する。
- 改修見積もり: src/worker/runtime.js function shouldPersistDashboardAppServerProgress と DASHBOARD_DURABLE_APP_SERVER_PROGRESS_STAGES、test/worker.test.js、test/e2e-518-dashboard-chat-transient-timestamps.test.js、docs/mvp/e2e/e2e-518-dashboard-chat-transient-timestamps.md、worker.js を変更する。
- 既に通っている経路: PR #721 / PR #727 / PR #728 / PR #729 / PR #730 で timeout recovery、slow-turn harness、progress event persistence の経路は既にある。
- 未確認の境界: production PWA で transient UI がどの見え方になるかは merge/deploy後 E2E live 検証が必要。
- 穴が出そうな箇所: transient-only に戻しすぎると owner が進行を見失う。durable に残しすぎると chat spam が残る。
- PR 前に確認すること: Issue #590、active execution queue、PR #730 後 owner feedback、src/worker/runtime.js、test/worker.test.js を確認した。
- 実装候補と捨てた案: 全 progress durable 化、raw output 保存、VPS Codex CLI commentary 全文保存、final summary replacement の同時実装を捨てた。
- merge 後に通す E2E: E2E: deploy後に Issue #590 の slow turn を 3分で実行し、旧2分timeoutが出ないこと、generic progressが通常messageとして増殖しないこと、完了応答が同じthreadに戻ることを検証する。
- 次の PR を増やさない理由: このPRは PR #730 の chat spam regression を閉じる範囲。final summary replacement など残る不足は後続scopeとして残す。
- 停止条件: raw reasoning / raw terminal output が durable message に出る、deployやcredential mutationが必要になる、Issue #590 外のUI改修に広がる場合は停止する。

## Dry-run Impact Report

- Target Issue: Issue #590
- Implementing Success Criteria: timeout / silent wait recovery の owner-facing UX を壊す generic durable progress spam を止める。
- Explicit Non-goals: Issue #590 close、deploy、credential、permission、final summary replacement、stop/interrupt UI。
- Expected touched files/routes/workflows: docs/development-strategy/issue-590-progress-checkpoints-to-thread.md; docs/mvp/e2e/e2e-518-dashboard-chat-transient-timestamps.md; src/worker/runtime.js; test/e2e-518-dashboard-chat-transient-timestamps.test.js; test/worker.test.js; worker.js
- Affected Issues: Issue #590, Issue #413, Issue #518
- Affected PRs: PR #730 regression follow-up
- Affected workflows: GitHub Actions test / guarded-policy / review only。deploy workflow は未実行。
- Affected runtime/operator surfaces: Dashboard Butler chat WebSocket, Worker DashboardChatRoom, app-server bridge status events
- What may break if we patch narrowly: progressを全部消すと無言に戻る。durable保存を残すとchat spamが続く。
- Unknowns to investigate before coding: production PWA transient UI の実表示はmerge/deploy後のlive E2E待ち。
- Validation needed: unit test, integration test, E2E test, generated worker, full npm test。
- Stop condition: owner-facing progressが全く見えなくなる、または通常chat messageが再び増殖する場合。

## Execution Queue Delta

- Queue position before: Issue #590 は active issue execution queue の Now。PR #730 後の owner live feedback で chat spam regression が判明。
- Preemption decision: ROOT。Issue #590 の観測性UXが壊れると Dashboard Butler で開発を継続できない。
- Queue delta: Issue #590 の PR #730 regression をこのPRで修正。Issue #590 自体は production E2E 未完了のまま残す。
- Why this PR is next: 無言問題の次に、進行messageがchatを埋める問題を直さないと owner-facing workflow が実用にならないため。
- Active Issues not downscoped: Active Issues は縮小しない。Issue #590 / Issue #413 / Issue #518 の残E2Eや未接続項目は未完了として残す。

## File / Line Hypotheses

- file: src/worker/runtime.js
  - hypothesis: persistProgress の true を durable 保存条件にしているため、generic progress が通常chatに残る。
  - risk if changed narrowly: owner action required checkpoint まで消すと承認待ちが見えない。
  - validation: worker test と E2E-518。
  - related Issue: Issue #590

## Hypothesis Retrospective

- expected: persistProgress を durable 条件から外すと generic progress は transient-only になる。
- actual: worker test と E2E-518 で確認。
- mismatch: full npm test は実VPS env/vaultを拾うと unrelated missing-config tests が失敗したため、空HOMEと該当env unsetで再実行しpass。
- lesson: progress visibility と chat history persistence は別概念として扱う。
- should become RAG candidate: yes

## Verification Evidence

- Unit: node --test test/worker.test.js: pass。node --test test/dashboard-app-server-bridge.test.js: pass。
- Integration: npm run build:worker: pass。npm run check:generated-worker: pass。git diff --check: pass。空HOMEと該当env unsetで npm test: pass (1126 pass / 1 skipped / 0 fail)。
- E2E: node --test test/e2e-518-dashboard-chat-transient-timestamps.test.js: pass。production slow-turn E2E はmerge/deploy後。
- Manual: 通常 env の npm test は VPS 実 runtime/vault credential を拾い、missing-config 期待の unrelated tests が fail したため hermetic env で再実行した。
- Evidence path/link: docs/development-strategy/issue-590-progress-checkpoints-to-thread.md; docs/mvp/e2e/e2e-518-dashboard-chat-transient-timestamps.md

## Butler Completion Contract

- Primary owner surface: Dashboard Butler PWA
- Fallback surface: mac Codex は実装・検証補助。owner-facing completion ではない。
- Owner goal: 長い開発中に進行は見えるが、通常チャットが低情報progressで埋まらない。
- Butler entrypoint: Dashboard Butler normal chat / app-server bridge status events
- Dashboard Butler natural-language path: Dashboard Butler の通常チャット入口で owner の自然文を受け、app-server status event が transient UI 経路へ接続される。
- Action Schema exposure: 未変更。Action Schema は主経路ではない。
- Runtime path: DashboardChatRoom receives app_server_status from app-server bridge and updates transient status; durable messages are limited to action-required stages and final/failure paths。
- Runner/runtime truth: local unit/E2E/generated-worker evidence only。production deploy/runtime truth はmerge後。
- Authority boundary: 未変更。通常コード変更のみ。deploy / credential / permission / destructive work は未実行。
- E2E evidence: local E2E-518 は pass。Issue #590 production slow-turn E2E は未実施。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 未実行。merge後に passkey approval が必要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。merge/deploy後に Issue #590 slow turn 3分で確認する。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate
AGENTS.md Drift Stop Protocol
AGENTS.md 開発前作戦図 Gate
AGENTS.md Evidence Discipline
Issue #590 Success Criteria
docs/butler/execution-queue-contract.md

## Out-of-scope but NOT implemented

- final summary replacement
stop / interrupt UI
owner input queue
app-server bridge auto restart after deploy
Issue #590 close

## Extra changes (if any)

E2E-518 evidence wording was updated because it asserted the old selected safe progress checkpoint persistence behavior.

<!-- VTDD metadata -->
- Issue: Issue #590
- Execution ID: issue-590-transient-progress-only
- Goal: Remove generic durable progress chat spam while keeping transient progress visibility
