### PR TITLE
Issue #498 添付を7日保持し期限切れを扱う

### DIFF
--- a/docs/development-strategy/issue-498-media-seven-day-retention.md
+++ b/docs/development-strategy/issue-498-media-seven-day-retention.md
@@ -1,0 +1,109 @@
+# Issue #498 / #587 media seven-day retention strategy
+
+## 完了体験
+
+Owner が Dashboard Butler に画像や短い動画を添付すると、送信前プレビューが消えず、送信後も 7 日間は同じ thread から確認できる。添付本体は R2 に置き、D1 と chat history には metadata と media reference だけを残す。期限内であれば Butler / VPS Codex CLI は mediaId から同一 origin の download route を通じて取得できる。
+
+動画は first slice では保存・表示・取得を扱う。Codex 解析は、直接動画入力を前提にせず、将来の frame extraction / thumbnail sampling route へ拡張できる境界を残す。
+
+## VTDD 全体で進める部分
+
+- Issue #498: 添付が Butler / VPS analysis path に届くこと、raw binary を D1 / chat / RAG に入れないこと、TTL と見返し UX を owner-facing にする。
+- Issue #587: 短い動画添付を画像と同じ storage route で退行させず、UI でも動画として認識できることを保つ。
+- Issue #590 は進行表示の親 blocker だが、この PR では触らない。添付 UX が戻らないと screenshot feedback loop が成立しないため、Issue #498 は active root blocker の実用上の前提になる。
+
+## 設計
+
+- Default retention は 7 日。`createdAt + 7 days` を `expiresAt` として media metadata に保存する。
+- D1 schema に `expires_at` を追加する。既存 D1 に対しては `ALTER TABLE ... ADD COLUMN expires_at TEXT` を best-effort で走らせ、既存行は `created_at + 7 days` に normalize する。
+- R2 object の customMetadata に `expiresAt` を入れる。これは cleanup / debugging の補助で、canonical は D1 metadata。
+- `GET /v2/media/:id` と `/download` は期限切れを 410 で返す。raw JSON だけで終わらせず、日本語 `reason` と `ownerMessage` を入れる。
+- Search は期限切れ media を返さない。
+- `toMediaReference()` と chat media reference に `expiresAt` / `retentionLabel` を含め、UI で「7日後に削除」または「あとN日」を表示できるようにする。
+- 送信待ち preview は object URL を保持し、ファイル名は補助情報に抑える。動画は `video` preview を優先する。
+
+## 仮説
+
+添付が「消える」主因は storage TTL ではなく、pending media preview / media reference rendering の情報不足と、送信後 media reference の owner-facing 表示が弱いこと。既存 code には `URL.createObjectURL`、video/mp4 upload、R2/D1 metadata tests があるため、first slice は route/schema/metadata/UI 表示を細く補強すればよい。
+
+動画 picker が owner 画面で写真だけに見える理由は、deployed client / iOS picker UI / PWA stale state の可能性がある。source では `accept="image/*"` は既に消えており、`video/mp4` upload test もあるので、今回の PR は動画添付の許可を壊さず、表示と metadata を固める。
+
+## 検証計画
+
+- `node --test test/worker.test.js`
+- `npm run build:worker`
+- `npm run check:generated-worker`
+- `git diff --check`
+- 追加テスト:
+  - upload response / metadata / normalized reference に `expiresAt` が含まれる。
+  - R2 customMetadata に `expiresAt` が入る。
+  - expired media metadata/download は 410 と日本語 reason を返す。
+  - search は expired media を返さない。
+  - Dashboard HTML は retention 表示と video preview path を持つ。
+
+## 改修見積もり
+
+- `src/worker/runtime.js`
+  - media upload route: default 7-day `expiresAt` calculation and R2 metadata.
+  - media object route: expired media 410 handling.
+  - D1 media object store: `expires_at` column, schema migration, row mapping, search filtering.
+  - media reference normalization/rendering: `expiresAt` and retention label.
+  - Dashboard HTML JS: pending/stored media retention label display.
+- `worker.js`
+  - generated Worker bundle.
+- `test/worker.test.js`
+  - media upload/metadata/download/search/UI assertions.
+- `docs/media/cloudflare-r2-media-storage.md`
+  - first slice non-goalから automatic long-term retention を外し、7-day short-lived retention contract を明記する。
+
+## 既に通っている経路
+
+- `/v2/media/upload` は R2 に raw bytes、D1 に metadata のみを保存するテストがある。
+- `video/mp4` は保存・download route の test がある。
+- Dashboard HTML は `accept="image/*"` を使わず、video preview element を持つ。
+- app-server bridge は media references を localPath に materialize する経路を持つ。
+
+## 未確認の境界
+
+- production R2 lifecycle rule は未確認。今回の PR では Cloudflare bucket 設定を変更しない。
+- real iPhone Photos picker の動画選択挙動は production E2E が必要。
+- Codex の直接動画解析 capability は surface 依存。今回の PR では保存と取得だけを完成体験にする。
+
+## 穴が出そうな箇所
+
+- D1 `ALTER TABLE` が既存 schema に対して idempotent でない可能性。
+- 期限切れ判定を download だけに入れると metadata / search で stale reference が残る。
+- UI の retention label が長すぎると thumbnail を圧迫する。
+- rollback delete は期限切れと同じ delete 権限に混ぜない。
+
+## PR 前に確認すること
+
+- main worktree の未整理差分に触れていないこと。
+- raw binary が response / metadata / chat history に入っていないこと。
+- `Issue #498` と `Issue #587` の Non-goal を越えていないこと。
+- deploy / Cloudflare binding mutation をしていないこと。
+
+## 実装候補と捨てた案
+
+- 採用: D1 metadata に `expiresAt` を入れ、R2 metadata にも同じ値を補助的に入れる。
+- 採用: expired read は 410 Gone + Japanese owner message。
+- 捨てた案: R2 lifecycle rule だけで削除する。D1 metadata が残り、UI が stale reference を出すため不十分。
+- 捨てた案: 動画を直接 Codex に渡す。surface capability に依存し、Issue #587 の first slice を越える。
+
+## merge 後に通す E2E
+
+- production PWA で画像を添付し、送信前 preview が残る。
+- 送信後 thread に media reference が残り、7日保持が分かる。
+- mediaId から app-server bridge が localPath を取得できる。
+- 短い mp4 を添付し、pending / stored 表示で動画として認識できる。
+
+## 次の PR を増やさない理由
+
+7日保持、期限表示、期限切れエラーは同じ schema / route / UI reference の一体変更であり、分割すると production E2E が「保存されたがいつ消えるか分からない」状態になる。動画解析そのものは別 PR に分ける。
+
+## 停止条件
+
+- D1 migration が既存 production schema に安全に適用できない場合。
+- 添付 retention が Issue #498 の raw binary 非保存ルールを破る場合。
+- 動画解析のために新しい外部 model / credential / Cloudflare binding が必要になる場合。
+- production deploy / bucket lifecycle mutation が必要になった場合。

--- a/docs/media/cloudflare-r2-media-storage.md
+++ b/docs/media/cloudflare-r2-media-storage.md
@@ -73,7 +73,8 @@ CREATE TABLE IF NOT EXISTS vtdd_media_objects (
   ocr_text TEXT,
   created_by TEXT,
   created_at TEXT NOT NULL,
-  updated_at TEXT NOT NULL
+  updated_at TEXT NOT NULL,
+  expires_at TEXT
 );
 
 CREATE INDEX IF NOT EXISTS idx_vtdd_media_repo
@@ -90,6 +91,10 @@ CREATE INDEX IF NOT EXISTS idx_vtdd_media_source
 ```
 
 `sha256` is calculated before metadata insert. A failed R2 put or failed D1 insert must not be reported as a saved media object.
+
+Dashboard Butler の private media は default 7 日の短命 retention を持つ。`expires_at` は D1 metadata に保存し、R2 object の custom metadata にも同じ値を入れる。D1 には raw binary を保存しない。
+
+期限切れ media は metadata / download / validation の各経路で owner-facing に `410 Gone` とし、「保存期間が切れた」ことと再添付導線を日本語で返す。期限切れ object の物理削除は scheduled cleanup / R2 lifecycle / maintenance runner の後続自動化で扱うが、期限切れ後に Butler / VPS 解析へ渡してはいけない。
 
 ## Visibility
 
@@ -170,6 +175,7 @@ RAG may store:
   "contentType": "image/png",
   "summary": "Dashboard Butler の iPhone PWA 画面。返信待ち表示が残っている。",
   "ocrText": "VPS Codex CLI に送信しました...",
+  "expiresAt": "2026-06-09T00:00:00.000Z",
   "objectKey": "media/...",
   "visibility": "private"
 }
@@ -221,6 +227,7 @@ The first implementation slice is incomplete until all of these are connected an
 5. Dashboard Butler thread can display a media reference.
 6. RAG stores only media summary/reference, never raw media.
 7. E2E proves iPhone screenshot upload -> dashboard thread media reference -> R2/D1 confirmation.
+8. Dashboard private media exposes a default 7-day `expiresAt`, and expired media returns an owner-facing Japanese expiration message.
 
 ## Non-goals for First Slice
 
@@ -228,7 +235,7 @@ The first implementation slice is incomplete until all of these are connected an
 - thumbnail generation
 - image editing
 - automatic public promotion
-- automatic long-term retention policy
+- physical expired-object purge automation beyond the 7-day read/validation cutoff
 - bulk upload optimization
 - Cloudflare account setup automation
 - deploy or credential mutation without scoped passkey approval

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -817,6 +817,8 @@ const mediaObjectStoreCache = new WeakMap();
 const MEDIA_UPLOAD_SOFT_LIMIT_BYTES = 5 * 1024 * 1024;
 const MEDIA_UPLOAD_HARD_LIMIT_BYTES = 20 * 1024 * 1024;
 const MEDIA_REFERENCE_LIMIT = 12;
+const MEDIA_DEFAULT_RETENTION_DAYS = 7;
+const MEDIA_DEFAULT_RETENTION_MS = MEDIA_DEFAULT_RETENTION_DAYS * 24 * 60 * 60 * 1000;
 
 export default {
   async fetch(request, env) {
@@ -5478,6 +5480,7 @@ async function handleMediaUploadRequest(request, env) {
     });
   }
   const now = new Date().toISOString();
+  const expiresAt = buildMediaExpiresAt(now);
   const mediaId = `med_${crypto.randomUUID()}`;
   const objectKey = buildMediaObjectKey({ repository, createdAt: now, mediaId, filename });
   const arrayBuffer = await file.arrayBuffer();
@@ -5502,7 +5505,8 @@ async function handleMediaUploadRequest(request, env) {
       mediaId,
       repository: repository || "unscoped",
       visibility,
-      sha256
+      sha256,
+      expiresAt
     }
   });
 
@@ -5525,7 +5529,8 @@ async function handleMediaUploadRequest(request, env) {
       ocrText: "",
       createdBy: dashboardAuth.email || dashboardAuth.login || dashboardAuth.authType || "dashboard",
       createdAt: now,
-      updatedAt: now
+      updatedAt: now,
+      expiresAt
     });
   } catch (error) {
     await cleanupOrphanMediaObject(r2, objectKey);
@@ -5583,6 +5588,9 @@ async function handleMediaObjectRequest(request, env, mediaRoute) {
       error: "media_not_found",
       reason: "media object was not found"
     });
+  }
+  if (isExpiredMediaObjectRecord(record)) {
+    return buildExpiredMediaResponse(record);
   }
   if (!mediaRoute.download) {
     return json(200, {
@@ -5654,7 +5662,7 @@ async function handleMediaSearchRequest(request, url, env) {
   });
   return json(200, {
     ok: true,
-    media: records.map((record) => toMediaReference(record)).filter(Boolean),
+    media: records.filter((record) => !isExpiredMediaObjectRecord(record)).map((record) => toMediaReference(record)).filter(Boolean),
     rawBinaryReturned: false
   });
 }
@@ -9490,8 +9498,8 @@ function createD1MediaObjectStore(d1) {
           `INSERT OR REPLACE INTO vtdd_media_objects (
              id, repository, related_issue, related_pr, source_surface, source_event_id,
              object_key, filename, content_type, byte_size, sha256, visibility,
-             summary, ocr_text, created_by, created_at, updated_at
-           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+             summary, ocr_text, created_by, created_at, updated_at, expires_at
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
         )
         .bind(
           normalized.id,
@@ -9510,7 +9518,8 @@ function createD1MediaObjectStore(d1) {
           normalized.ocrText,
           normalized.createdBy,
           normalized.createdAt,
-          normalized.updatedAt
+          normalized.updatedAt,
+          normalized.expiresAt
         )
         .run();
       return normalized;
@@ -9577,7 +9586,10 @@ function createD1MediaObjectStore(d1) {
   function ensureSchema() {
     if (!schemaPromise) {
       schemaPromise = (async () => {
-        await d1.exec("CREATE TABLE IF NOT EXISTS vtdd_media_objects (id TEXT PRIMARY KEY, repository TEXT, related_issue INTEGER, related_pr INTEGER, source_surface TEXT NOT NULL, source_event_id TEXT, object_key TEXT NOT NULL, filename TEXT NOT NULL, content_type TEXT NOT NULL, byte_size INTEGER NOT NULL, sha256 TEXT NOT NULL, visibility TEXT NOT NULL, summary TEXT, ocr_text TEXT, created_by TEXT, created_at TEXT NOT NULL, updated_at TEXT NOT NULL);");
+        await d1.exec("CREATE TABLE IF NOT EXISTS vtdd_media_objects (id TEXT PRIMARY KEY, repository TEXT, related_issue INTEGER, related_pr INTEGER, source_surface TEXT NOT NULL, source_event_id TEXT, object_key TEXT NOT NULL, filename TEXT NOT NULL, content_type TEXT NOT NULL, byte_size INTEGER NOT NULL, sha256 TEXT NOT NULL, visibility TEXT NOT NULL, summary TEXT, ocr_text TEXT, created_by TEXT, created_at TEXT NOT NULL, updated_at TEXT NOT NULL, expires_at TEXT);");
+        try {
+          await d1.exec("ALTER TABLE vtdd_media_objects ADD COLUMN expires_at TEXT;");
+        } catch {}
         await d1.exec("CREATE INDEX IF NOT EXISTS idx_vtdd_media_repo ON vtdd_media_objects(repository, created_at DESC);");
         await d1.exec("CREATE INDEX IF NOT EXISTS idx_vtdd_media_issue ON vtdd_media_objects(repository, related_issue, created_at DESC);");
         await d1.exec("CREATE INDEX IF NOT EXISTS idx_vtdd_media_pr ON vtdd_media_objects(repository, related_pr, created_at DESC);");
@@ -10449,6 +10461,49 @@ function buildMediaObjectKey({ repository, createdAt, mediaId, filename }) {
   return `media/${owner}/${name}/${yyyy}/${mm}/${dd}/${mediaId}/${sanitizeMediaFilename(filename)}`;
 }
 
+function buildMediaExpiresAt(createdAt) {
+  const created = Date.parse(normalizeIsoTimestamp(createdAt) || "");
+  const base = Number.isFinite(created) ? created : Date.now();
+  return new Date(base + MEDIA_DEFAULT_RETENTION_MS).toISOString();
+}
+
+function isExpiredMediaObjectRecord(record, now = Date.now()) {
+  const normalized = normalizeMediaObjectRecord(record);
+  if (!normalized) {
+    return false;
+  }
+  const expiresAt = Date.parse(normalized.expiresAt || "");
+  return Number.isFinite(expiresAt) && expiresAt <= now;
+}
+
+function buildExpiredMediaResponse(record) {
+  const media = toMediaReference(record);
+  return json(410, {
+    ok: false,
+    error: "media_expired",
+    reason: "この添付は保存期間が切れました。必要であれば再添付してください。",
+    ownerMessage: "添付の保存期間が切れました。必要であれば再添付してください。",
+    media,
+    rawBinaryReturned: false
+  });
+}
+
+function buildMediaRetentionLabel(expiresAt, now = Date.now()) {
+  const expires = Date.parse(normalizeIsoTimestamp(expiresAt) || "");
+  if (!Number.isFinite(expires)) {
+    return "";
+  }
+  const remainingMs = expires - now;
+  if (remainingMs <= 0) {
+    return "保存期間切れ";
+  }
+  const remainingDays = Math.max(1, Math.ceil(remainingMs / (24 * 60 * 60 * 1000)));
+  if (remainingDays >= MEDIA_DEFAULT_RETENTION_DAYS) {
+    return `${MEDIA_DEFAULT_RETENTION_DAYS}日後に削除`;
+  }
+  return `あと${remainingDays}日`;
+}
+
 async function sha256ArrayBufferHex(arrayBuffer) {
   if (globalThis.crypto?.subtle) {
     const digest = await globalThis.crypto.subtle.digest("SHA-256", arrayBuffer);
@@ -10481,6 +10536,7 @@ function normalizeMediaObjectRecord(record) {
     return null;
   }
   const createdAt = normalizeIsoTimestamp(input.createdAt || input.created_at) || new Date().toISOString();
+  const expiresAt = normalizeIsoTimestamp(input.expiresAt || input.expires_at) || buildMediaExpiresAt(createdAt);
   return {
     id,
     repository: normalizeCanonicalRepositoryInput(input.repository) || null,
@@ -10498,7 +10554,8 @@ function normalizeMediaObjectRecord(record) {
     ocrText: sanitizeDashboardChatText(input.ocrText || input.ocr_text),
     createdBy: sanitizeDashboardChatText(input.createdBy || input.created_by),
     createdAt,
-    updatedAt: normalizeIsoTimestamp(input.updatedAt || input.updated_at) || createdAt
+    updatedAt: normalizeIsoTimestamp(input.updatedAt || input.updated_at) || createdAt,
+    expiresAt
   };
 }
 
@@ -10520,7 +10577,8 @@ function mediaObjectRecordFromRow(row) {
     ocrText: row?.ocr_text,
     createdBy: row?.created_by,
     createdAt: row?.created_at,
-    updatedAt: row?.updated_at
+    updatedAt: row?.updated_at,
+    expiresAt: row?.expires_at
   });
 }
 
@@ -10544,6 +10602,8 @@ function toMediaReference(record) {
     ocrText: normalized.ocrText || "",
     createdAt: normalized.createdAt,
     updatedAt: normalized.updatedAt,
+    expiresAt: normalized.expiresAt,
+    retentionLabel: buildMediaRetentionLabel(normalized.expiresAt),
     metadataUrl: `/v2/media/${normalized.id}`,
     downloadUrl: `/v2/media/${normalized.id}/download`
   };
@@ -10569,6 +10629,8 @@ function normalizeMediaReferences(value) {
         sha256: normalizeDashboardEventText(input.sha256).toLowerCase().slice(0, 64),
         visibility: normalizeMediaVisibility(input.visibility) || "private",
         summary: sanitizeDashboardChatText(input.summary),
+        expiresAt: normalizeIsoTimestamp(input.expiresAt || input.expires_at) || "",
+        retentionLabel: sanitizeDashboardChatText(input.retentionLabel || input.retention_label),
         metadataUrl: `/v2/media/${mediaId}`,
         downloadUrl: `/v2/media/${mediaId}/download`
       };
@@ -10600,6 +10662,13 @@ async function resolveDashboardChatMediaReferences({ env, mediaReferences, repos
         ok: false,
         error: "media_reference_not_found",
         reason: `media reference ${reference.mediaId} was not found`
+      };
+    }
+    if (isExpiredMediaObjectRecord(record)) {
+      return {
+        ok: false,
+        error: "media_reference_expired",
+        reason: `media reference ${reference.mediaId} は保存期間が切れました。必要であれば再添付してください。`
       };
     }
     const media = toMediaReference(record);
@@ -14501,7 +14570,10 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
     .composer-progress.thinking .progress-title::before { animation: pulseProgress 1.25s ease-in-out infinite; }
     .media-chip { display: inline-flex; align-items: center; max-width: 100%; min-width: 0; min-height: 34px; border: 1px solid var(--border); border-radius: 14px; padding: 5px 10px; gap: 8px; color: var(--text); background: var(--soft); font-size: 12px; text-decoration: none; overflow: hidden; }
     .media-chip span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: min(48vw, 320px); }
-    .media-thumb { width: 48px; height: 48px; flex: 0 0 auto; border-radius: 10px; object-fit: cover; background: var(--border); }
+    .media-chip .media-label { display: inline-flex; flex-direction: column; align-items: flex-start; gap: 1px; min-width: 0; }
+    .media-chip .media-kind { color: var(--text); font-weight: 700; max-width: min(26vw, 140px); }
+    .media-chip .media-retention { color: var(--muted); font-size: 11px; max-width: min(38vw, 220px); }
+    .media-thumb { width: 64px; height: 64px; flex: 0 0 auto; border-radius: 10px; object-fit: cover; background: var(--border); }
     .media-chip.pending-preview { padding: 5px 8px 5px 5px; }
     .media-remove { border: 0; background: transparent; color: var(--muted); font: inherit; font-weight: 900; padding: 0 2px; cursor: pointer; }
     .composer-status { min-height: 18px; padding-left: 16px; color: var(--muted); font-size: 12px; max-width: 100%; overflow-wrap: anywhere; }
@@ -15340,6 +15412,40 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         return "";
       }
 
+      function getMediaKindLabel(item) {
+        const kind = getMediaContentKind(item);
+        if (kind === "video") return "動画";
+        if (kind === "image") return "画像";
+        return "添付";
+      }
+
+      function formatMediaRetentionLabel(item) {
+        const explicit = String(item && item.retentionLabel || "").trim();
+        if (explicit) return explicit;
+        const expiresAt = String(item && item.expiresAt || "");
+        const expires = Date.parse(expiresAt);
+        if (!Number.isFinite(expires)) return "7日後に削除";
+        const remainingMs = expires - Date.now();
+        if (remainingMs <= 0) return "保存期間切れ";
+        const remainingDays = Math.max(1, Math.ceil(remainingMs / (24 * 60 * 60 * 1000)));
+        return remainingDays >= 7 ? "7日後に削除" : "あと" + remainingDays + "日";
+      }
+
+      function appendMediaLabel(chip, item) {
+        const label = document.createElement("span");
+        label.className = "media-label";
+        const kind = document.createElement("span");
+        kind.className = "media-kind";
+        kind.textContent = getMediaKindLabel(item);
+        const retention = document.createElement("span");
+        retention.className = "media-retention";
+        retention.textContent = formatMediaRetentionLabel(item);
+        label.title = item && item.filename ? item.filename : "";
+        label.appendChild(kind);
+        label.appendChild(retention);
+        chip.appendChild(label);
+      }
+
       function renderMediaReferences(references) {
         const list = Array.isArray(references) ? references : [];
         if (list.length === 0) return null;
@@ -15386,14 +15492,8 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
             icon.textContent = "添付";
             chip.appendChild(icon);
           }
-          const label = document.createElement(isVideo && downloadHref !== "#" ? "a" : "span");
-          label.textContent = reference.filename || reference.mediaId || "media";
-          if (label.tagName === "A") {
-            label.href = downloadHref;
-            label.target = "_blank";
-            label.rel = "noreferrer";
-          }
-          chip.appendChild(label);
+          chip.title = reference.filename || reference.mediaId || "media";
+          appendMediaLabel(chip, reference);
           wrapper.appendChild(chip);
         }
         return wrapper;
@@ -15445,8 +15545,11 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
               chip.appendChild(image);
             }
           }
-          const label = document.createElement("span");
-          label.textContent = item.filename || "attachment";
+          chip.title = item.filename || "attachment";
+          appendMediaLabel(chip, {
+            ...item,
+            retentionLabel: "送信後7日で削除"
+          });
           const remove = document.createElement("button");
           remove.className = "media-remove";
           remove.type = "button";

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -478,7 +478,8 @@ function createStrictMediaD1Binding() {
                   ocrText,
                   createdBy,
                   createdAt,
-                  updatedAt
+                  updatedAt,
+                  expiresAt
                 ] = params;
                 rows.set(id, {
                   id,
@@ -497,7 +498,8 @@ function createStrictMediaD1Binding() {
                   ocr_text: ocrText,
                   created_by: createdBy,
                   created_at: createdAt,
-                  updated_at: updatedAt
+                  updated_at: updatedAt,
+                  expires_at: expiresAt
                 });
               }
               return { success: true };
@@ -1834,6 +1836,9 @@ test("worker serves dashboard media add controls for iPhone-first upload", async
   assert.equal(body.includes("createImageBitmap"), true);
   assert.equal(body.includes("className = \"media-thumb\""), true);
   assert.equal(body.includes("function getMediaContentKind("), true);
+  assert.equal(body.includes("function formatMediaRetentionLabel("), true);
+  assert.equal(body.includes("retentionLabel: \"送信後7日で削除\""), true);
+  assert.equal(body.includes("className = \"media-retention\""), true);
   assert.equal(body.includes("function isPreviewableMediaFile("), true);
   assert.equal(body.includes("const mediaKind = getMediaContentKind(reference)"), true);
   assert.equal(body.includes("getMediaContentKind(item) === \"video\""), true);
@@ -1847,7 +1852,7 @@ test("worker serves dashboard media add controls for iPhone-first upload", async
   assert.equal(body.includes("const safeDownloadHref = referenceDownloadUrl.startsWith(\"/v2/media/\") ? referenceDownloadUrl : \"\""), true);
   assert.equal(body.includes("const downloadHref = mediaRouteHref || safeDownloadHref || \"#\""), true);
   assert.equal(body.includes("chip.href = downloadHref"), true);
-  assert.equal(body.includes("label.href = downloadHref"), true);
+  assert.equal(body.includes("appendMediaLabel(chip, reference)"), true);
   assert.equal(body.includes("const chip = document.createElement(isVideo && downloadHref !== \"#\" ? \"span\" : \"a\")"), true);
   assert.equal(body.includes("isImage && downloadHref !== \"#\""), true);
   assert.equal(body.includes("image.src = downloadHref"), true);
@@ -1937,9 +1942,14 @@ test("worker uploads dashboard media to R2 and stores D1 metadata reference only
   assert.equal(body.media.filename, "dashboard.png");
   assert.equal(body.media.contentType, "image/png");
   assert.equal(body.media.visibility, "private");
+  assert.equal(typeof body.media.expiresAt, "string");
+  assert.equal(body.media.retentionLabel, "7日後に削除");
+  assert.equal(Math.round((Date.parse(body.media.expiresAt) - Date.parse(body.media.createdAt)) / (24 * 60 * 60 * 1000)), 7);
   assert.equal(body.stored.rawBinaryReturned, false);
   assert.equal(JSON.stringify(body).includes("fake image bytes"), false);
   assert.equal(r2.objects.size, 1);
+  const storedObject = [...r2.objects.values()][0];
+  assert.equal(storedObject.options.customMetadata.expiresAt, body.media.expiresAt);
 
   const metadataResponse = await worker.fetch(
     new Request(`https://example.com${body.media.metadataUrl}`, {
@@ -1950,6 +1960,7 @@ test("worker uploads dashboard media to R2 and stores D1 metadata reference only
   assert.equal(metadataResponse.status, 200);
   const metadataBody = await metadataResponse.json();
   assert.equal(metadataBody.media.mediaId, body.media.mediaId);
+  assert.equal(metadataBody.media.expiresAt, body.media.expiresAt);
   assert.equal(metadataBody.media.objectKey, undefined);
   assert.equal(metadataBody.media.sourceEventId, undefined);
   assert.equal(JSON.stringify(metadataBody).includes("fake image bytes"), false);
@@ -1995,11 +2006,14 @@ test("worker uploads dashboard mp4 media to R2 and stores metadata reference onl
   assert.equal(body.media.filename, "broken-scroll.mp4");
   assert.equal(body.media.contentType, "video/mp4");
   assert.equal(body.media.visibility, "private");
+  assert.equal(typeof body.media.expiresAt, "string");
+  assert.equal(body.media.retentionLabel, "7日後に削除");
   assert.equal(body.stored.rawBinaryReturned, false);
   assert.equal(JSON.stringify(body).includes("ftypisom"), false);
   assert.equal(r2.objects.size, 1);
   const storedObject = [...r2.objects.values()][0];
   assert.equal(storedObject.options.httpMetadata.contentType, "video/mp4");
+  assert.equal(storedObject.options.customMetadata.expiresAt, body.media.expiresAt);
 
   const downloadResponse = await worker.fetch(
     new Request(`https://example.com${body.media.downloadUrl}`, {
@@ -2009,6 +2023,103 @@ test("worker uploads dashboard mp4 media to R2 and stores metadata reference onl
   );
   assert.equal(downloadResponse.status, 200);
   assert.equal(downloadResponse.headers.get("content-type"), "video/mp4");
+});
+
+test("worker returns owner-facing expiration for expired dashboard media", async () => {
+  const mediaStore = createInMemoryMediaObjectStore();
+  const r2 = createInMemoryR2Binding();
+  await mediaStore.put({
+    id: "med_expiredmedia",
+    repository: "marushu/vtdd-v2-p",
+    relatedIssue: 498,
+    sourceSurface: "dashboard_butler",
+    sourceEventId: "dashboard_owner_message:expired",
+    objectKey: "media/marushu/vtdd-v2-p/2026/05/23/med_expiredmedia/dashboard.png",
+    filename: "dashboard.png",
+    contentType: "image/png",
+    byteSize: 16,
+    sha256: "0123456789abcdef",
+    visibility: "private",
+    createdAt: "2026-05-23T00:00:00.000Z",
+    updatedAt: "2026-05-23T00:00:00.000Z",
+    expiresAt: "2026-05-30T00:00:00.000Z"
+  });
+  await r2.put("media/marushu/vtdd-v2-p/2026/05/23/med_expiredmedia/dashboard.png", new Uint8Array([1, 2, 3]));
+
+  const metadataResponse = await worker.fetch(
+    new Request("https://example.com/v2/media/med_expiredmedia", {
+      headers: dashboardAccessHeaders
+    }),
+    { ...dashboardAccessEnv, MEDIA_OBJECT_STORE: mediaStore, VTDD_MEDIA_R2: r2 }
+  );
+  assert.equal(metadataResponse.status, 410);
+  const metadataBody = await metadataResponse.json();
+  assert.equal(metadataBody.error, "media_expired");
+  assert.equal(metadataBody.rawBinaryReturned, false);
+  assert.match(metadataBody.ownerMessage, /保存期間が切れました/);
+
+  const downloadResponse = await worker.fetch(
+    new Request("https://example.com/v2/media/med_expiredmedia/download", {
+      headers: dashboardAccessHeaders
+    }),
+    { ...dashboardAccessEnv, MEDIA_OBJECT_STORE: mediaStore, VTDD_MEDIA_R2: r2 }
+  );
+  assert.equal(downloadResponse.status, 410);
+  const downloadBody = await downloadResponse.json();
+  assert.equal(downloadBody.error, "media_expired");
+  assert.equal(r2.objects.size, 1);
+});
+
+test("worker filters expired dashboard media from search and rejects expired chat references", async () => {
+  const mediaStore = createInMemoryMediaObjectStore();
+  const r2 = createInMemoryR2Binding();
+  await mediaStore.put({
+    id: "med_expiredref",
+    repository: "marushu/vtdd-v2-p",
+    relatedIssue: 498,
+    sourceSurface: "dashboard_butler",
+    sourceEventId: "dashboard_owner_message:expired-ref",
+    objectKey: "media/marushu/vtdd-v2-p/2026/05/23/med_expiredref/dashboard.png",
+    filename: "dashboard.png",
+    contentType: "image/png",
+    byteSize: 16,
+    sha256: "0123456789abcdef",
+    visibility: "private",
+    createdAt: "2026-05-23T00:00:00.000Z",
+    updatedAt: "2026-05-23T00:00:00.000Z",
+    expiresAt: "2026-05-30T00:00:00.000Z"
+  });
+
+  const searchResponse = await worker.fetch(
+    new Request("https://example.com/v2/media/search?repository=marushu%2Fvtdd-v2-p&relatedIssue=498", {
+      headers: dashboardAccessHeaders
+    }),
+    { ...dashboardAccessEnv, MEDIA_OBJECT_STORE: mediaStore, VTDD_MEDIA_R2: r2 }
+  );
+  assert.equal(searchResponse.status, 200);
+  const searchBody = await searchResponse.json();
+  assert.equal(searchBody.media.length, 0);
+
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/dashboard/chat/messages", {
+      method: "POST",
+      headers: {
+        ...dashboardAccessHeaders,
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({
+        repository: "marushu/vtdd-v2-p",
+        relatedIssue: 498,
+        text: "期限切れ添付を使う",
+        mediaReferences: [{ mediaId: "med_expiredref", filename: "dashboard.png", contentType: "image/png" }]
+      })
+    }),
+    { ...dashboardAccessEnv, MEDIA_OBJECT_STORE: mediaStore, VTDD_MEDIA_R2: r2 }
+  );
+  assert.equal(response.status, 422);
+  const body = await response.json();
+  assert.equal(body.error, "media_reference_expired");
+  assert.match(body.reason, /保存期間が切れました/);
 });
 
 test("worker rejects media upload without R2 binding before metadata drift", async () => {
@@ -2058,6 +2169,7 @@ test("worker uploads private dashboard media without repository for ordinary cha
   assert.equal(body.ok, true);
   assert.equal(body.media.repository, null);
   assert.equal(body.media.visibility, "private");
+  assert.equal(body.media.retentionLabel, "7日後に削除");
   assert.match(body.media.downloadUrl, /^\/v2\/media\/med_/);
   assert.equal(r2.objects.size, 1);
   const [objectKey, stored] = [...r2.objects.entries()][0];
@@ -2096,6 +2208,8 @@ test("worker creates media D1 schema without multiline exec truncation", async (
   );
   assert.ok(createTableStatement);
   assert.equal(createTableStatement.includes("\n"), false);
+  assert.equal(createTableStatement.includes("expires_at TEXT"), true);
+  assert.equal(d1.rows.values().next().value.expires_at, body.media.expiresAt);
 });
 
 test("worker rejects public or evidence media without resolved repository before R2 put", async () => {
@@ -2328,7 +2442,8 @@ test("worker rejects abandoned media rollback without exact source event scope",
     sha256: "0123456789abcdef",
     visibility: "private",
     createdAt: "2026-05-23T00:00:00.000Z",
-    updatedAt: "2026-05-23T00:00:00.000Z"
+    updatedAt: "2026-05-23T00:00:00.000Z",
+    expiresAt: "2999-01-01T00:00:00.000Z"
   });
   await r2.put("media/marushu/vtdd-v2-p/2026/05/23/med_rollbackscope/dashboard.png", new Uint8Array([1, 2, 3]));
 
@@ -2367,7 +2482,8 @@ test("worker allows rollback delete for private unscoped dashboard media from an
     sha256: "0123456789abcdef",
     visibility: "private",
     createdAt: "2026-05-23T00:00:00.000Z",
-    updatedAt: "2026-05-23T00:00:00.000Z"
+    updatedAt: "2026-05-23T00:00:00.000Z",
+    expiresAt: "2999-01-01T00:00:00.000Z"
   });
   await r2.put("media/_dashboard/unscoped/2026/05/23/med_unscopedrollback/dashboard.png", new Uint8Array([1, 2, 3]));
 
@@ -2424,7 +2540,8 @@ test("worker stores dashboard media references in chat without raw binary", asyn
     sha256: "0123456789abcdef",
     visibility: "private",
     createdAt: "2026-05-23T00:00:00.000Z",
-    updatedAt: "2026-05-23T00:00:00.000Z"
+    updatedAt: "2026-05-23T00:00:00.000Z",
+    expiresAt: "2999-01-01T00:00:00.000Z"
   });
   const response = await worker.fetch(
     new Request("https://example.com/v2/dashboard/chat/messages", {
@@ -2477,7 +2594,8 @@ test("worker rejects chat media references outside the repository or issue conte
     sha256: "0123456789abcdef",
     visibility: "private",
     createdAt: "2026-05-23T00:00:00.000Z",
-    updatedAt: "2026-05-23T00:00:00.000Z"
+    updatedAt: "2026-05-23T00:00:00.000Z",
+    expiresAt: "2999-01-01T00:00:00.000Z"
   });
 
   const response = await worker.fetch(

--- a/worker.js
+++ b/worker.js
@@ -40,9 +40,9 @@ var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__ge
   mod
 ));
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/pvtsutils/build/index.js
+// node_modules/pvtsutils/build/index.js
 var require_build = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/pvtsutils/build/index.js"(exports) {
+  "node_modules/pvtsutils/build/index.js"(exports) {
     "use strict";
     var ARRAY_BUFFER_NAME = "[object ArrayBuffer]";
     var BufferSourceConverter6 = class _BufferSourceConverter {
@@ -404,9 +404,9 @@ var require_build = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/reflect-metadata/Reflect.js
+// node_modules/reflect-metadata/Reflect.js
 var require_Reflect = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/reflect-metadata/Reflect.js"() {
+  "node_modules/reflect-metadata/Reflect.js"() {
     var Reflect2;
     (function(Reflect3) {
       (function(factory) {
@@ -1495,9 +1495,9 @@ var require_crypto = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tweetnacl/nacl-fast.js
+// node_modules/tweetnacl/nacl-fast.js
 var require_nacl_fast = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tweetnacl/nacl-fast.js"(exports, module) {
+  "node_modules/tweetnacl/nacl-fast.js"(exports, module) {
     (function(nacl5) {
       "use strict";
       var gf = function(init) {
@@ -3719,18 +3719,18 @@ var require_nacl_fast = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tweetnacl-sealedbox-js/src/consts.js
+// node_modules/tweetnacl-sealedbox-js/src/consts.js
 var import_tweetnacl, overheadLength;
 var init_consts = __esm({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tweetnacl-sealedbox-js/src/consts.js"() {
+  "node_modules/tweetnacl-sealedbox-js/src/consts.js"() {
     import_tweetnacl = __toESM(require_nacl_fast());
     overheadLength = import_tweetnacl.default.box.publicKeyLength + import_tweetnacl.default.box.overheadLength;
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/blakejs/util.js
+// node_modules/blakejs/util.js
 var require_util = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/blakejs/util.js"(exports, module) {
+  "node_modules/blakejs/util.js"(exports, module) {
     var ERROR_MSG_INPUT = "Input must be an string, Buffer or Uint8Array";
     function normalizeInput(input) {
       let ret;
@@ -3800,9 +3800,9 @@ var require_util = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/blakejs/blake2b.js
+// node_modules/blakejs/blake2b.js
 var require_blake2b = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/blakejs/blake2b.js"(exports, module) {
+  "node_modules/blakejs/blake2b.js"(exports, module) {
     var util2 = require_util();
     function ADD64AA(v2, a, b) {
       const o0 = v2[a] + v2[b];
@@ -4274,7 +4274,7 @@ var require_blake2b = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tweetnacl-sealedbox-js/src/nonce.js
+// node_modules/tweetnacl-sealedbox-js/src/nonce.js
 function nonce(pk1, pk2) {
   var state = import_blake2b.default.blake2bInit(import_tweetnacl2.default.box.nonceLength, null);
   import_blake2b.default.blake2bUpdate(state, pk1);
@@ -4283,24 +4283,24 @@ function nonce(pk1, pk2) {
 }
 var import_tweetnacl2, import_blake2b;
 var init_nonce = __esm({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tweetnacl-sealedbox-js/src/nonce.js"() {
+  "node_modules/tweetnacl-sealedbox-js/src/nonce.js"() {
     import_tweetnacl2 = __toESM(require_nacl_fast());
     import_blake2b = __toESM(require_blake2b());
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tweetnacl-sealedbox-js/src/utils.js
+// node_modules/tweetnacl-sealedbox-js/src/utils.js
 function zero(buf) {
   for (var i = 0; i < buf.length; i++) {
     buf[i] = 0;
   }
 }
 var init_utils = __esm({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tweetnacl-sealedbox-js/src/utils.js"() {
+  "node_modules/tweetnacl-sealedbox-js/src/utils.js"() {
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tweetnacl-sealedbox-js/src/seal.js
+// node_modules/tweetnacl-sealedbox-js/src/seal.js
 function seal(m, pk) {
   var c = new Uint8Array(overheadLength + m.length);
   var ek = import_tweetnacl3.default.box.keyPair();
@@ -4313,7 +4313,7 @@ function seal(m, pk) {
 }
 var import_tweetnacl3;
 var init_seal = __esm({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tweetnacl-sealedbox-js/src/seal.js"() {
+  "node_modules/tweetnacl-sealedbox-js/src/seal.js"() {
     import_tweetnacl3 = __toESM(require_nacl_fast());
     init_nonce();
     init_consts();
@@ -4321,7 +4321,7 @@ var init_seal = __esm({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tweetnacl-sealedbox-js/src/open.js
+// node_modules/tweetnacl-sealedbox-js/src/open.js
 function open(c, pk, sk) {
   var epk = c.subarray(0, import_tweetnacl4.default.box.publicKeyLength);
   var nonce2 = nonce(epk, pk);
@@ -4330,13 +4330,13 @@ function open(c, pk, sk) {
 }
 var import_tweetnacl4;
 var init_open = __esm({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tweetnacl-sealedbox-js/src/open.js"() {
+  "node_modules/tweetnacl-sealedbox-js/src/open.js"() {
     import_tweetnacl4 = __toESM(require_nacl_fast());
     init_nonce();
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tweetnacl-sealedbox-js/entrypoint.js
+// node_modules/tweetnacl-sealedbox-js/entrypoint.js
 var entrypoint_exports = {};
 __export(entrypoint_exports, {
   default: () => entrypoint_default,
@@ -4346,7 +4346,7 @@ __export(entrypoint_exports, {
 });
 var entrypoint_default;
 var init_entrypoint = __esm({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tweetnacl-sealedbox-js/entrypoint.js"() {
+  "node_modules/tweetnacl-sealedbox-js/entrypoint.js"() {
     init_consts();
     init_seal();
     init_open();
@@ -4354,9 +4354,9 @@ var init_entrypoint = __esm({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/codegen/code.js
+// node_modules/ajv/dist/compile/codegen/code.js
 var require_code = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/codegen/code.js"(exports) {
+  "node_modules/ajv/dist/compile/codegen/code.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.regexpCode = exports.getEsmExportName = exports.getProperty = exports.safeStringify = exports.stringify = exports.strConcat = exports.addCodeArg = exports.str = exports._ = exports.nil = exports._Code = exports.Name = exports.IDENTIFIER = exports._CodeOrName = void 0;
@@ -4508,9 +4508,9 @@ var require_code = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/codegen/scope.js
+// node_modules/ajv/dist/compile/codegen/scope.js
 var require_scope = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/codegen/scope.js"(exports) {
+  "node_modules/ajv/dist/compile/codegen/scope.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.ValueScope = exports.ValueScopeName = exports.Scope = exports.varKinds = exports.UsedValueState = void 0;
@@ -4653,9 +4653,9 @@ var require_scope = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/codegen/index.js
+// node_modules/ajv/dist/compile/codegen/index.js
 var require_codegen = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/codegen/index.js"(exports) {
+  "node_modules/ajv/dist/compile/codegen/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.or = exports.and = exports.not = exports.CodeGen = exports.operators = exports.varKinds = exports.ValueScopeName = exports.ValueScope = exports.Scope = exports.Name = exports.regexpCode = exports.stringify = exports.getProperty = exports.nil = exports.strConcat = exports.str = exports._ = void 0;
@@ -5373,9 +5373,9 @@ var require_codegen = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/util.js
+// node_modules/ajv/dist/compile/util.js
 var require_util2 = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/util.js"(exports) {
+  "node_modules/ajv/dist/compile/util.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.checkStrictMode = exports.getErrorPath = exports.Type = exports.useFunc = exports.setEvaluated = exports.evaluatedPropsToName = exports.mergeEvaluated = exports.eachItem = exports.unescapeJsonPointer = exports.escapeJsonPointer = exports.escapeFragment = exports.unescapeFragment = exports.schemaRefOrVal = exports.schemaHasRulesButRef = exports.schemaHasRules = exports.checkUnknownRules = exports.alwaysValidSchema = exports.toHash = void 0;
@@ -5540,9 +5540,9 @@ var require_util2 = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/names.js
+// node_modules/ajv/dist/compile/names.js
 var require_names = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/names.js"(exports) {
+  "node_modules/ajv/dist/compile/names.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -5579,9 +5579,9 @@ var require_names = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/errors.js
+// node_modules/ajv/dist/compile/errors.js
 var require_errors = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/errors.js"(exports) {
+  "node_modules/ajv/dist/compile/errors.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.extendErrors = exports.resetErrorsCount = exports.reportExtraError = exports.reportError = exports.keyword$DataError = exports.keywordError = void 0;
@@ -5701,9 +5701,9 @@ var require_errors = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/validate/boolSchema.js
+// node_modules/ajv/dist/compile/validate/boolSchema.js
 var require_boolSchema = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/validate/boolSchema.js"(exports) {
+  "node_modules/ajv/dist/compile/validate/boolSchema.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.boolOrEmptySchema = exports.topBoolOrEmptySchema = void 0;
@@ -5752,9 +5752,9 @@ var require_boolSchema = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/rules.js
+// node_modules/ajv/dist/compile/rules.js
 var require_rules = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/rules.js"(exports) {
+  "node_modules/ajv/dist/compile/rules.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.getRules = exports.isJSONType = void 0;
@@ -5783,9 +5783,9 @@ var require_rules = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/validate/applicability.js
+// node_modules/ajv/dist/compile/validate/applicability.js
 var require_applicability = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/validate/applicability.js"(exports) {
+  "node_modules/ajv/dist/compile/validate/applicability.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.shouldUseRule = exports.shouldUseGroup = exports.schemaHasRulesForType = void 0;
@@ -5806,9 +5806,9 @@ var require_applicability = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/validate/dataType.js
+// node_modules/ajv/dist/compile/validate/dataType.js
 var require_dataType = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/validate/dataType.js"(exports) {
+  "node_modules/ajv/dist/compile/validate/dataType.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.reportTypeError = exports.checkDataTypes = exports.checkDataType = exports.coerceAndCheckDataType = exports.getJSONTypes = exports.getSchemaTypes = exports.DataType = void 0;
@@ -5990,9 +5990,9 @@ var require_dataType = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/validate/defaults.js
+// node_modules/ajv/dist/compile/validate/defaults.js
 var require_defaults = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/validate/defaults.js"(exports) {
+  "node_modules/ajv/dist/compile/validate/defaults.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.assignDefaults = void 0;
@@ -6027,9 +6027,9 @@ var require_defaults = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/code.js
+// node_modules/ajv/dist/vocabularies/code.js
 var require_code2 = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/code.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/code.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.validateUnion = exports.validateArray = exports.usePattern = exports.callValidateCode = exports.schemaProperties = exports.allSchemaProperties = exports.noPropertyInData = exports.propertyInData = exports.isOwnProperty = exports.hasPropFunc = exports.reportMissingProp = exports.checkMissingProp = exports.checkReportMissingProp = void 0;
@@ -6160,9 +6160,9 @@ var require_code2 = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/validate/keyword.js
+// node_modules/ajv/dist/compile/validate/keyword.js
 var require_keyword = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/validate/keyword.js"(exports) {
+  "node_modules/ajv/dist/compile/validate/keyword.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.validateKeywordUsage = exports.validSchemaType = exports.funcKeywordCode = exports.macroKeywordCode = void 0;
@@ -6278,9 +6278,9 @@ var require_keyword = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/validate/subschema.js
+// node_modules/ajv/dist/compile/validate/subschema.js
 var require_subschema = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/validate/subschema.js"(exports) {
+  "node_modules/ajv/dist/compile/validate/subschema.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.extendSubschemaMode = exports.extendSubschemaData = exports.getSubschema = void 0;
@@ -6361,9 +6361,9 @@ var require_subschema = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/fast-deep-equal/index.js
+// node_modules/fast-deep-equal/index.js
 var require_fast_deep_equal = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/fast-deep-equal/index.js"(exports, module) {
+  "node_modules/fast-deep-equal/index.js"(exports, module) {
     "use strict";
     module.exports = function equal(a, b) {
       if (a === b) return true;
@@ -6396,9 +6396,9 @@ var require_fast_deep_equal = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/json-schema-traverse/index.js
+// node_modules/json-schema-traverse/index.js
 var require_json_schema_traverse = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/json-schema-traverse/index.js"(exports, module) {
+  "node_modules/json-schema-traverse/index.js"(exports, module) {
     "use strict";
     var traverse = module.exports = function(schema, opts, cb) {
       if (typeof opts == "function") {
@@ -6484,9 +6484,9 @@ var require_json_schema_traverse = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/resolve.js
+// node_modules/ajv/dist/compile/resolve.js
 var require_resolve = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/resolve.js"(exports) {
+  "node_modules/ajv/dist/compile/resolve.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.getSchemaRefs = exports.resolveUrl = exports.normalizeId = exports._getFullPath = exports.getFullPath = exports.inlineRef = void 0;
@@ -6640,9 +6640,9 @@ var require_resolve = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/validate/index.js
+// node_modules/ajv/dist/compile/validate/index.js
 var require_validate = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/validate/index.js"(exports) {
+  "node_modules/ajv/dist/compile/validate/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.getData = exports.KeywordCxt = exports.validateFunctionCode = void 0;
@@ -7148,9 +7148,9 @@ var require_validate = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/runtime/validation_error.js
+// node_modules/ajv/dist/runtime/validation_error.js
 var require_validation_error = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/runtime/validation_error.js"(exports) {
+  "node_modules/ajv/dist/runtime/validation_error.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var ValidationError = class extends Error {
@@ -7164,9 +7164,9 @@ var require_validation_error = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/ref_error.js
+// node_modules/ajv/dist/compile/ref_error.js
 var require_ref_error = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/ref_error.js"(exports) {
+  "node_modules/ajv/dist/compile/ref_error.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var resolve_1 = require_resolve();
@@ -7181,9 +7181,9 @@ var require_ref_error = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/index.js
+// node_modules/ajv/dist/compile/index.js
 var require_compile = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/index.js"(exports) {
+  "node_modules/ajv/dist/compile/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.resolveSchema = exports.getCompilingSchema = exports.resolveRef = exports.compileSchema = exports.SchemaEnv = void 0;
@@ -7405,9 +7405,9 @@ var require_compile = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/refs/data.json
+// node_modules/ajv/dist/refs/data.json
 var require_data = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/refs/data.json"(exports, module) {
+  "node_modules/ajv/dist/refs/data.json"(exports, module) {
     module.exports = {
       $id: "https://raw.githubusercontent.com/ajv-validator/ajv/master/lib/refs/data.json#",
       description: "Meta-schema for $data reference (JSON AnySchema extension proposal)",
@@ -7424,9 +7424,9 @@ var require_data = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/fast-uri/lib/utils.js
+// node_modules/fast-uri/lib/utils.js
 var require_utils = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/fast-uri/lib/utils.js"(exports, module) {
+  "node_modules/fast-uri/lib/utils.js"(exports, module) {
     "use strict";
     var isUUID = RegExp.prototype.test.bind(/^[\da-f]{8}-[\da-f]{4}-[\da-f]{4}-[\da-f]{4}-[\da-f]{12}$/iu);
     var isIPv4 = RegExp.prototype.test.bind(/^(?:(?:25[0-5]|2[0-4]\d|1\d{2}|[1-9]\d|\d)\.){3}(?:25[0-5]|2[0-4]\d|1\d{2}|[1-9]\d|\d)$/u);
@@ -7737,9 +7737,9 @@ var require_utils = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/fast-uri/lib/schemes.js
+// node_modules/fast-uri/lib/schemes.js
 var require_schemes = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/fast-uri/lib/schemes.js"(exports, module) {
+  "node_modules/fast-uri/lib/schemes.js"(exports, module) {
     "use strict";
     var { isUUID } = require_utils();
     var URN_REG = /([\da-z][\d\-a-z]{0,31}):((?:[\w!$'()*+,\-.:;=@]|%[\da-f]{2})+)/iu;
@@ -7947,9 +7947,9 @@ var require_schemes = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/fast-uri/index.js
+// node_modules/fast-uri/index.js
 var require_fast_uri = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/fast-uri/index.js"(exports, module) {
+  "node_modules/fast-uri/index.js"(exports, module) {
     "use strict";
     var { normalizeIPv6, removeDotSegments, recomposeAuthority, normalizePercentEncoding, normalizePathEncoding, escapePreservingEscapes, reescapeHostDelimiters, isIPv4, nonSimpleDomain } = require_utils();
     var { SCHEMES, getSchemeHandler } = require_schemes();
@@ -8233,9 +8233,9 @@ var require_fast_uri = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/runtime/uri.js
+// node_modules/ajv/dist/runtime/uri.js
 var require_uri = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/runtime/uri.js"(exports) {
+  "node_modules/ajv/dist/runtime/uri.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var uri = require_fast_uri();
@@ -8244,9 +8244,9 @@ var require_uri = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/core.js
+// node_modules/ajv/dist/core.js
 var require_core = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/core.js"(exports) {
+  "node_modules/ajv/dist/core.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.CodeGen = exports.Name = exports.nil = exports.stringify = exports.str = exports._ = exports.KeywordCxt = void 0;
@@ -8855,9 +8855,9 @@ var require_core = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/core/id.js
+// node_modules/ajv/dist/vocabularies/core/id.js
 var require_id = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/core/id.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/core/id.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var def = {
@@ -8870,9 +8870,9 @@ var require_id = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/core/ref.js
+// node_modules/ajv/dist/vocabularies/core/ref.js
 var require_ref = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/core/ref.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/core/ref.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.callRef = exports.getValidate = void 0;
@@ -8992,9 +8992,9 @@ var require_ref = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/core/index.js
+// node_modules/ajv/dist/vocabularies/core/index.js
 var require_core2 = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/core/index.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/core/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var id_1 = require_id();
@@ -9013,9 +9013,9 @@ var require_core2 = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/limitNumber.js
+// node_modules/ajv/dist/vocabularies/validation/limitNumber.js
 var require_limitNumber = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/limitNumber.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/validation/limitNumber.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -9045,9 +9045,9 @@ var require_limitNumber = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/multipleOf.js
+// node_modules/ajv/dist/vocabularies/validation/multipleOf.js
 var require_multipleOf = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/multipleOf.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/validation/multipleOf.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -9073,9 +9073,9 @@ var require_multipleOf = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/runtime/ucs2length.js
+// node_modules/ajv/dist/runtime/ucs2length.js
 var require_ucs2length = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/runtime/ucs2length.js"(exports) {
+  "node_modules/ajv/dist/runtime/ucs2length.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     function ucs2length(str) {
@@ -9099,9 +9099,9 @@ var require_ucs2length = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/limitLength.js
+// node_modules/ajv/dist/vocabularies/validation/limitLength.js
 var require_limitLength = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/limitLength.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/validation/limitLength.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -9131,9 +9131,9 @@ var require_limitLength = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/pattern.js
+// node_modules/ajv/dist/vocabularies/validation/pattern.js
 var require_pattern = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/pattern.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/validation/pattern.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var code_1 = require_code2();
@@ -9168,9 +9168,9 @@ var require_pattern = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/limitProperties.js
+// node_modules/ajv/dist/vocabularies/validation/limitProperties.js
 var require_limitProperties = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/limitProperties.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/validation/limitProperties.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -9197,9 +9197,9 @@ var require_limitProperties = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/required.js
+// node_modules/ajv/dist/vocabularies/validation/required.js
 var require_required = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/required.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/validation/required.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var code_1 = require_code2();
@@ -9279,9 +9279,9 @@ var require_required = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/limitItems.js
+// node_modules/ajv/dist/vocabularies/validation/limitItems.js
 var require_limitItems = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/limitItems.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/validation/limitItems.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -9308,9 +9308,9 @@ var require_limitItems = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/runtime/equal.js
+// node_modules/ajv/dist/runtime/equal.js
 var require_equal = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/runtime/equal.js"(exports) {
+  "node_modules/ajv/dist/runtime/equal.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var equal = require_fast_deep_equal();
@@ -9319,9 +9319,9 @@ var require_equal = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/uniqueItems.js
+// node_modules/ajv/dist/vocabularies/validation/uniqueItems.js
 var require_uniqueItems = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/uniqueItems.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/validation/uniqueItems.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var dataType_1 = require_dataType();
@@ -9386,9 +9386,9 @@ var require_uniqueItems = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/const.js
+// node_modules/ajv/dist/vocabularies/validation/const.js
 var require_const = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/const.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/validation/const.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -9415,9 +9415,9 @@ var require_const = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/enum.js
+// node_modules/ajv/dist/vocabularies/validation/enum.js
 var require_enum = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/enum.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/validation/enum.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -9464,9 +9464,9 @@ var require_enum = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/index.js
+// node_modules/ajv/dist/vocabularies/validation/index.js
 var require_validation = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/index.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/validation/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var limitNumber_1 = require_limitNumber();
@@ -9502,9 +9502,9 @@ var require_validation = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/additionalItems.js
+// node_modules/ajv/dist/vocabularies/applicator/additionalItems.js
 var require_additionalItems = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/additionalItems.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/applicator/additionalItems.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.validateAdditionalItems = void 0;
@@ -9555,9 +9555,9 @@ var require_additionalItems = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/items.js
+// node_modules/ajv/dist/vocabularies/applicator/items.js
 var require_items = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/items.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/applicator/items.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.validateTuple = void 0;
@@ -9612,9 +9612,9 @@ var require_items = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/prefixItems.js
+// node_modules/ajv/dist/vocabularies/applicator/prefixItems.js
 var require_prefixItems = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/prefixItems.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/applicator/prefixItems.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var items_1 = require_items();
@@ -9629,9 +9629,9 @@ var require_prefixItems = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/items2020.js
+// node_modules/ajv/dist/vocabularies/applicator/items2020.js
 var require_items2020 = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/items2020.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/applicator/items2020.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -9664,9 +9664,9 @@ var require_items2020 = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/contains.js
+// node_modules/ajv/dist/vocabularies/applicator/contains.js
 var require_contains = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/contains.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/applicator/contains.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -9758,9 +9758,9 @@ var require_contains = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/dependencies.js
+// node_modules/ajv/dist/vocabularies/applicator/dependencies.js
 var require_dependencies = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/dependencies.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/applicator/dependencies.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.validateSchemaDeps = exports.validatePropertyDeps = exports.error = void 0;
@@ -9852,9 +9852,9 @@ var require_dependencies = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/propertyNames.js
+// node_modules/ajv/dist/vocabularies/applicator/propertyNames.js
 var require_propertyNames = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/propertyNames.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/applicator/propertyNames.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -9895,9 +9895,9 @@ var require_propertyNames = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/additionalProperties.js
+// node_modules/ajv/dist/vocabularies/applicator/additionalProperties.js
 var require_additionalProperties = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/additionalProperties.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/applicator/additionalProperties.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var code_1 = require_code2();
@@ -10001,9 +10001,9 @@ var require_additionalProperties = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/properties.js
+// node_modules/ajv/dist/vocabularies/applicator/properties.js
 var require_properties = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/properties.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/applicator/properties.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var validate_1 = require_validate();
@@ -10059,9 +10059,9 @@ var require_properties = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/patternProperties.js
+// node_modules/ajv/dist/vocabularies/applicator/patternProperties.js
 var require_patternProperties = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/patternProperties.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/applicator/patternProperties.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var code_1 = require_code2();
@@ -10133,9 +10133,9 @@ var require_patternProperties = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/not.js
+// node_modules/ajv/dist/vocabularies/applicator/not.js
 var require_not = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/not.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/applicator/not.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var util_1 = require_util2();
@@ -10164,9 +10164,9 @@ var require_not = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/anyOf.js
+// node_modules/ajv/dist/vocabularies/applicator/anyOf.js
 var require_anyOf = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/anyOf.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/applicator/anyOf.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var code_1 = require_code2();
@@ -10181,9 +10181,9 @@ var require_anyOf = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/oneOf.js
+// node_modules/ajv/dist/vocabularies/applicator/oneOf.js
 var require_oneOf = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/oneOf.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/applicator/oneOf.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -10239,9 +10239,9 @@ var require_oneOf = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/allOf.js
+// node_modules/ajv/dist/vocabularies/applicator/allOf.js
 var require_allOf = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/allOf.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/applicator/allOf.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var util_1 = require_util2();
@@ -10266,9 +10266,9 @@ var require_allOf = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/if.js
+// node_modules/ajv/dist/vocabularies/applicator/if.js
 var require_if = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/if.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/applicator/if.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -10335,9 +10335,9 @@ var require_if = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/thenElse.js
+// node_modules/ajv/dist/vocabularies/applicator/thenElse.js
 var require_thenElse = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/thenElse.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/applicator/thenElse.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var util_1 = require_util2();
@@ -10353,9 +10353,9 @@ var require_thenElse = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/index.js
+// node_modules/ajv/dist/vocabularies/applicator/index.js
 var require_applicator = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/index.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/applicator/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var additionalItems_1 = require_additionalItems();
@@ -10401,9 +10401,9 @@ var require_applicator = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/format/format.js
+// node_modules/ajv/dist/vocabularies/format/format.js
 var require_format = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/format/format.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/format/format.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -10491,9 +10491,9 @@ var require_format = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/format/index.js
+// node_modules/ajv/dist/vocabularies/format/index.js
 var require_format2 = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/format/index.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/format/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var format_1 = require_format();
@@ -10502,9 +10502,9 @@ var require_format2 = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/metadata.js
+// node_modules/ajv/dist/vocabularies/metadata.js
 var require_metadata = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/metadata.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/metadata.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.contentVocabulary = exports.metadataVocabulary = void 0;
@@ -10525,9 +10525,9 @@ var require_metadata = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/draft7.js
+// node_modules/ajv/dist/vocabularies/draft7.js
 var require_draft7 = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/draft7.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/draft7.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var core_1 = require_core2();
@@ -10547,9 +10547,9 @@ var require_draft7 = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/discriminator/types.js
+// node_modules/ajv/dist/vocabularies/discriminator/types.js
 var require_types = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/discriminator/types.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/discriminator/types.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.DiscrError = void 0;
@@ -10561,9 +10561,9 @@ var require_types = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/discriminator/index.js
+// node_modules/ajv/dist/vocabularies/discriminator/index.js
 var require_discriminator = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/discriminator/index.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/discriminator/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -10666,9 +10666,9 @@ var require_discriminator = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/refs/json-schema-draft-07.json
+// node_modules/ajv/dist/refs/json-schema-draft-07.json
 var require_json_schema_draft_07 = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/refs/json-schema-draft-07.json"(exports, module) {
+  "node_modules/ajv/dist/refs/json-schema-draft-07.json"(exports, module) {
     module.exports = {
       $schema: "http://json-schema.org/draft-07/schema#",
       $id: "http://json-schema.org/draft-07/schema#",
@@ -10823,9 +10823,9 @@ var require_json_schema_draft_07 = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/ajv.js
+// node_modules/ajv/dist/ajv.js
 var require_ajv = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/ajv.js"(exports, module) {
+  "node_modules/ajv/dist/ajv.js"(exports, module) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.MissingRefError = exports.ValidationError = exports.CodeGen = exports.Name = exports.nil = exports.stringify = exports.str = exports._ = exports.KeywordCxt = exports.Ajv = void 0;
@@ -10893,9 +10893,9 @@ var require_ajv = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv-formats/dist/formats.js
+// node_modules/ajv-formats/dist/formats.js
 var require_formats = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv-formats/dist/formats.js"(exports) {
+  "node_modules/ajv-formats/dist/formats.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.formatNames = exports.fastFormats = exports.fullFormats = void 0;
@@ -11096,9 +11096,9 @@ var require_formats = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv-formats/dist/limit.js
+// node_modules/ajv-formats/dist/limit.js
 var require_limit = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv-formats/dist/limit.js"(exports) {
+  "node_modules/ajv-formats/dist/limit.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.formatLimitDefinition = void 0;
@@ -11168,9 +11168,9 @@ var require_limit = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv-formats/dist/index.js
+// node_modules/ajv-formats/dist/index.js
 var require_dist = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv-formats/dist/index.js"(exports, module) {
+  "node_modules/ajv-formats/dist/index.js"(exports, module) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var formats_1 = require_formats();
@@ -11392,7 +11392,7 @@ var ProtectionSignalStatus = Object.freeze({
   UNKNOWN: "unknown"
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/iso/isoBase64URL.js
+// node_modules/@simplewebauthn/server/esm/helpers/iso/isoBase64URL.js
 var isoBase64URL_exports = {};
 __export(isoBase64URL_exports, {
   fromBuffer: () => fromBuffer,
@@ -11405,7 +11405,7 @@ __export(isoBase64URL_exports, {
   trimPadding: () => trimPadding
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@hexagon/base64/src/base64.js
+// node_modules/@hexagon/base64/src/base64.js
 var chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 var charsUrl = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
 var genLookup = (target) => {
@@ -11479,7 +11479,7 @@ base64.validate = (encoded, urlMode) => {
 base64.base64 = base64;
 var base64_default = base64;
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/iso/isoBase64URL.js
+// node_modules/@simplewebauthn/server/esm/helpers/iso/isoBase64URL.js
 function toBuffer(base64urlString, from = "base64url") {
   const _buffer = base64_default.toArrayBuffer(base64urlString, from === "base64url");
   return new Uint8Array(_buffer);
@@ -11510,14 +11510,14 @@ function trimPadding(input) {
   return input.replace(/=/g, "");
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/iso/isoCBOR.js
+// node_modules/@simplewebauthn/server/esm/helpers/iso/isoCBOR.js
 var isoCBOR_exports = {};
 __export(isoCBOR_exports, {
   decodeFirst: () => decodeFirst,
   encode: () => encode
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@levischuck/tiny-cbor/esm/cbor/cbor_internal.js
+// node_modules/@levischuck/tiny-cbor/esm/cbor/cbor_internal.js
 function decodeLength(data, argument, index) {
   if (argument < 24) {
     return [argument, 1];
@@ -11616,7 +11616,7 @@ function encodeLength(major, argument) {
   }
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@levischuck/tiny-cbor/esm/cbor/cbor.js
+// node_modules/@levischuck/tiny-cbor/esm/cbor/cbor.js
 var CBORTag = class {
   /**
    * Wrap a value with a tag number.
@@ -11943,7 +11943,7 @@ function encodeCBOR(data) {
   return output;
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/iso/isoCBOR.js
+// node_modules/@simplewebauthn/server/esm/helpers/iso/isoCBOR.js
 function decodeFirst(input) {
   const _input = new Uint8Array(input);
   const decoded = decodePartialCBOR(_input, 0);
@@ -11954,7 +11954,7 @@ function encode(input) {
   return encodeCBOR(input);
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/index.js
+// node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/index.js
 var isoCrypto_exports = {};
 __export(isoCrypto_exports, {
   digest: () => digest,
@@ -11962,7 +11962,7 @@ __export(isoCrypto_exports, {
   verify: () => verify
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/cose.js
+// node_modules/@simplewebauthn/server/esm/helpers/cose.js
 function isCOSEPublicKeyOKP(cosePublicKey) {
   const kty = cosePublicKey.get(COSEKEYS.kty);
   return isCOSEKty(kty) && kty === COSEKTY.OKP;
@@ -12024,7 +12024,7 @@ function isCOSEAlg(alg) {
   return Object.values(COSEALG).indexOf(alg) >= 0;
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/mapCoseAlgToWebCryptoAlg.js
+// node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/mapCoseAlgToWebCryptoAlg.js
 function mapCoseAlgToWebCryptoAlg(alg) {
   if ([COSEALG.RS1].indexOf(alg) >= 0) {
     return "SHA-1";
@@ -12038,7 +12038,7 @@ function mapCoseAlgToWebCryptoAlg(alg) {
   throw new Error(`Could not map COSE alg value of ${alg} to a WebCrypto alg`);
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/getWebCrypto.js
+// node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/getWebCrypto.js
 var webCrypto = void 0;
 function getWebCrypto() {
   const toResolve = new Promise((resolve, reject) => {
@@ -12069,7 +12069,7 @@ var _getWebCryptoInternals = {
   }
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/digest.js
+// node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/digest.js
 async function digest(data, algorithm) {
   const WebCrypto = await getWebCrypto();
   const subtleAlgorithm = mapCoseAlgToWebCryptoAlg(algorithm);
@@ -12077,14 +12077,14 @@ async function digest(data, algorithm) {
   return new Uint8Array(hashed);
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/getRandomValues.js
+// node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/getRandomValues.js
 async function getRandomValues(array2) {
   const WebCrypto = await getWebCrypto();
   WebCrypto.getRandomValues(array2);
   return array2;
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/importKey.js
+// node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/importKey.js
 async function importKey(opts) {
   const WebCrypto = await getWebCrypto();
   const { keyData, algorithm } = opts;
@@ -12093,7 +12093,7 @@ async function importKey(opts) {
   ]);
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/verifyEC2.js
+// node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/verifyEC2.js
 async function verifyEC2(opts) {
   const { cosePublicKey, signature, data, shaHashOverride } = opts;
   const WebCrypto = await getWebCrypto();
@@ -12155,7 +12155,7 @@ async function verifyEC2(opts) {
   return WebCrypto.subtle.verify(verifyAlgorithm, key, signature, data);
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/mapCoseAlgToWebCryptoKeyAlgName.js
+// node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/mapCoseAlgToWebCryptoKeyAlgName.js
 function mapCoseAlgToWebCryptoKeyAlgName(alg) {
   if ([COSEALG.EdDSA].indexOf(alg) >= 0) {
     return "Ed25519";
@@ -12169,7 +12169,7 @@ function mapCoseAlgToWebCryptoKeyAlgName(alg) {
   throw new Error(`Could not map COSE alg value of ${alg} to a WebCrypto key alg name`);
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/verifyRSA.js
+// node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/verifyRSA.js
 async function verifyRSA(opts) {
   const { cosePublicKey, signature, data, shaHashOverride } = opts;
   const WebCrypto = await getWebCrypto();
@@ -12238,7 +12238,7 @@ async function verifyRSA(opts) {
   return WebCrypto.subtle.verify(verifyAlgorithm, key, signature, data);
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/convertAAGUIDToString.js
+// node_modules/@simplewebauthn/server/esm/helpers/convertAAGUIDToString.js
 function convertAAGUIDToString(aaguid) {
   const hex = isoUint8Array_exports.toHex(aaguid);
   const segments = [
@@ -12256,7 +12256,7 @@ function convertAAGUIDToString(aaguid) {
   return segments.join("-");
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/convertCertBufferToPEM.js
+// node_modules/@simplewebauthn/server/esm/helpers/convertCertBufferToPEM.js
 function convertCertBufferToPEM(certBuffer) {
   let b64cert;
   if (typeof certBuffer === "string") {
@@ -12282,7 +12282,7 @@ ${PEMKey}-----END CERTIFICATE-----
   return PEMKey;
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/convertCOSEtoPKCS.js
+// node_modules/@simplewebauthn/server/esm/helpers/convertCOSEtoPKCS.js
 function convertCOSEtoPKCS(cosePublicKey) {
   const struct = isoCBOR_exports.decodeFirst(cosePublicKey);
   const tag = Uint8Array.from([4]);
@@ -12297,7 +12297,7 @@ function convertCOSEtoPKCS(cosePublicKey) {
   return isoUint8Array_exports.concat([tag, x]);
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/decodeAttestationObject.js
+// node_modules/@simplewebauthn/server/esm/helpers/decodeAttestationObject.js
 function decodeAttestationObject(attestationObject) {
   return _decodeAttestationObjectInternals.stubThis(isoCBOR_exports.decodeFirst(attestationObject));
 }
@@ -12305,7 +12305,7 @@ var _decodeAttestationObjectInternals = {
   stubThis: (value) => value
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/decodeClientDataJSON.js
+// node_modules/@simplewebauthn/server/esm/helpers/decodeClientDataJSON.js
 function decodeClientDataJSON(data) {
   const toString = isoBase64URL_exports.toUTF8String(data);
   const clientData = JSON.parse(toString);
@@ -12315,7 +12315,7 @@ var _decodeClientDataJSONInternals = {
   stubThis: (value) => value
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/decodeCredentialPublicKey.js
+// node_modules/@simplewebauthn/server/esm/helpers/decodeCredentialPublicKey.js
 function decodeCredentialPublicKey(publicKey) {
   return _decodeCredentialPublicKeyInternals.stubThis(isoCBOR_exports.decodeFirst(publicKey));
 }
@@ -12323,7 +12323,7 @@ var _decodeCredentialPublicKeyInternals = {
   stubThis: (value) => value
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/generateUserID.js
+// node_modules/@simplewebauthn/server/esm/helpers/generateUserID.js
 async function generateUserID() {
   const newUserID = new Uint8Array(32);
   await isoCrypto_exports.getRandomValues(newUserID);
@@ -12333,7 +12333,7 @@ var _generateUserIDInternals = {
   stubThis: (value) => value
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/asn1js/build/index.es.js
+// node_modules/asn1js/build/index.es.js
 var index_es_exports = {};
 __export(index_es_exports, {
   Any: () => Any,
@@ -12386,7 +12386,7 @@ __export(index_es_exports, {
 });
 var pvtsutils = __toESM(require_build());
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/pvutils/build/utils.es.js
+// node_modules/pvutils/build/utils.es.js
 function utilFromBase(inputBuffer, inputBase) {
   let result = 0;
   if (inputBuffer.length === 1) {
@@ -12524,7 +12524,7 @@ function padNumber(inputNumber, fullLength) {
 }
 var log2 = Math.log(2);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/asn1js/build/index.es.js
+// node_modules/asn1js/build/index.es.js
 function assertBigInt() {
   if (typeof BigInt === "undefined") {
     throw new Error("BigInt is not defined. Your environment doesn't implement BigInt.");
@@ -15565,7 +15565,7 @@ function verifySchema(inputBuffer, inputSchema) {
   return compareSchema(asn1.result, asn1.result, inputSchema);
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-schema/build/es2015/enums.js
+// node_modules/@peculiar/asn1-schema/build/es2015/enums.js
 var AsnTypeTypes;
 (function(AsnTypeTypes2) {
   AsnTypeTypes2[AsnTypeTypes2["Sequence"] = 0] = "Sequence";
@@ -15603,7 +15603,7 @@ var AsnPropTypes;
   AsnPropTypes2[AsnPropTypes2["Null"] = 27] = "Null";
 })(AsnPropTypes || (AsnPropTypes = {}));
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-schema/build/es2015/types/bit_string.js
+// node_modules/@peculiar/asn1-schema/build/es2015/types/bit_string.js
 var import_pvtsutils = __toESM(require_build());
 var BitString2 = class {
   constructor(params, unusedBits = 0) {
@@ -15661,7 +15661,7 @@ var BitString2 = class {
   }
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-schema/build/es2015/types/octet_string.js
+// node_modules/@peculiar/asn1-schema/build/es2015/types/octet_string.js
 var import_pvtsutils2 = __toESM(require_build());
 var OctetString2 = class {
   get byteLength() {
@@ -15698,7 +15698,7 @@ var OctetString2 = class {
   }
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-schema/build/es2015/converters.js
+// node_modules/@peculiar/asn1-schema/build/es2015/converters.js
 var AsnAnyConverter = {
   fromASN: (value) => value instanceof Null ? null : value.valueBeforeDecodeView,
   toASN: (value) => {
@@ -15827,7 +15827,7 @@ function defaultConverter(type) {
   }
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-schema/build/es2015/helper.js
+// node_modules/@peculiar/asn1-schema/build/es2015/helper.js
 function isConvertible(target) {
   if (typeof target === "function" && target.prototype) {
     if (target.prototype.toASN && target.prototype.fromASN) {
@@ -15867,7 +15867,7 @@ function isArrayEqual(bytes1, bytes2) {
   return true;
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-schema/build/es2015/schema.js
+// node_modules/@peculiar/asn1-schema/build/es2015/schema.js
 var AsnSchemaStorage = class {
   constructor() {
     this.items = /* @__PURE__ */ new WeakMap();
@@ -15991,10 +15991,10 @@ var AsnSchemaStorage = class {
   }
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-schema/build/es2015/storage.js
+// node_modules/@peculiar/asn1-schema/build/es2015/storage.js
 var schemaStorage = new AsnSchemaStorage();
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-schema/build/es2015/decorators.js
+// node_modules/@peculiar/asn1-schema/build/es2015/decorators.js
 var AsnType = (options) => (target) => {
   let schema;
   if (!schemaStorage.has(target)) {
@@ -16025,7 +16025,7 @@ var AsnProp = (options) => (target, propertyKey) => {
   schema.items[propertyKey] = copyOptions;
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-schema/build/es2015/errors/schema_validation.js
+// node_modules/@peculiar/asn1-schema/build/es2015/errors/schema_validation.js
 var AsnSchemaValidationError = class extends Error {
   constructor() {
     super(...arguments);
@@ -16033,7 +16033,7 @@ var AsnSchemaValidationError = class extends Error {
   }
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-schema/build/es2015/parser.js
+// node_modules/@peculiar/asn1-schema/build/es2015/parser.js
 var AsnParser = class {
   static parse(data, target) {
     const asn1Parsed = fromBER(data);
@@ -16308,7 +16308,7 @@ var AsnParser = class {
   }
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-schema/build/es2015/serializer.js
+// node_modules/@peculiar/asn1-schema/build/es2015/serializer.js
 var AsnSerializer = class _AsnSerializer {
   static serialize(obj) {
     if (obj instanceof BaseBlock) {
@@ -16442,7 +16442,7 @@ var AsnSerializer = class _AsnSerializer {
   }
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-schema/build/es2015/objects.js
+// node_modules/@peculiar/asn1-schema/build/es2015/objects.js
 var AsnArray = class extends Array {
   constructor(items = []) {
     if (typeof items === "number") {
@@ -16456,7 +16456,7 @@ var AsnArray = class extends Array {
   }
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-schema/build/es2015/convert.js
+// node_modules/@peculiar/asn1-schema/build/es2015/convert.js
 var import_pvtsutils3 = __toESM(require_build());
 var AsnConvert = class _AsnConvert {
   static serialize(obj) {
@@ -16475,7 +16475,7 @@ var AsnConvert = class _AsnConvert {
   }
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tslib/tslib.es6.mjs
+// node_modules/tslib/tslib.es6.mjs
 function __decorate(decorators, target, key, desc) {
   var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
   if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
@@ -16494,7 +16494,7 @@ function __classPrivateFieldSet(receiver, state, value, kind, f) {
   return kind === "a" ? f.call(receiver, value) : f ? f.value = value : state.set(receiver, value), value;
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/ip_converter.js
+// node_modules/@peculiar/asn1-x509/build/es2015/ip_converter.js
 var import_pvtsutils4 = __toESM(require_build());
 var IpConverter = class {
   static isIPv4(ip) {
@@ -16662,7 +16662,7 @@ var IpConverter = class {
   }
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/name.js
+// node_modules/@peculiar/asn1-x509/build/es2015/name.js
 var import_pvtsutils5 = __toESM(require_build());
 var RelativeDistinguishedName_1;
 var RDNSequence_1;
@@ -16752,7 +16752,7 @@ Name = Name_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence })
 ], Name);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/general_name.js
+// node_modules/@peculiar/asn1-x509/build/es2015/general_name.js
 var AsnIpConverter = {
   fromASN: (value) => IpConverter.toString(AsnOctetStringConverter.fromASN(value)),
   toASN: (value) => AsnOctetStringConverter.toASN(IpConverter.fromString(value))
@@ -16823,7 +16823,7 @@ GeneralName = __decorate([
   AsnType({ type: AsnTypeTypes.Choice })
 ], GeneralName);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/object_identifiers.js
+// node_modules/@peculiar/asn1-x509/build/es2015/object_identifiers.js
 var id_pkix = "1.3.6.1.5.5.7";
 var id_pe = `${id_pkix}.1`;
 var id_qt = `${id_pkix}.2`;
@@ -16837,7 +16837,7 @@ var id_ad_timeStamping = `${id_ad}.3`;
 var id_ad_caRepository = `${id_ad}.5`;
 var id_ce = "2.5.29";
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/authority_information_access.js
+// node_modules/@peculiar/asn1-x509/build/es2015/extensions/authority_information_access.js
 var AuthorityInfoAccessSyntax_1;
 var id_pe_authorityInfoAccess = `${id_pe}.1`;
 var AccessDescription = class {
@@ -16863,7 +16863,7 @@ AuthorityInfoAccessSyntax = AuthorityInfoAccessSyntax_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence, itemType: AccessDescription })
 ], AuthorityInfoAccessSyntax);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/authority_key_identifier.js
+// node_modules/@peculiar/asn1-x509/build/es2015/extensions/authority_key_identifier.js
 var id_ce_authorityKeyIdentifier = `${id_ce}.35`;
 var KeyIdentifier = class extends OctetString2 {
 };
@@ -16890,7 +16890,7 @@ __decorate([
   })
 ], AuthorityKeyIdentifier.prototype, "authorityCertSerialNumber", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/basic_constraints.js
+// node_modules/@peculiar/asn1-x509/build/es2015/extensions/basic_constraints.js
 var id_ce_basicConstraints = `${id_ce}.19`;
 var BasicConstraints = class {
   constructor(params = {}) {
@@ -16905,7 +16905,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.Integer, optional: true })
 ], BasicConstraints.prototype, "pathLenConstraint", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/general_names.js
+// node_modules/@peculiar/asn1-x509/build/es2015/general_names.js
 var GeneralNames_1;
 var GeneralNames = GeneralNames_1 = class GeneralNames2 extends AsnArray {
   constructor(items) {
@@ -16917,7 +16917,7 @@ GeneralNames = GeneralNames_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence, itemType: GeneralName })
 ], GeneralNames);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/certificate_issuer.js
+// node_modules/@peculiar/asn1-x509/build/es2015/extensions/certificate_issuer.js
 var CertificateIssuer_1;
 var id_ce_certificateIssuer = `${id_ce}.29`;
 var CertificateIssuer = CertificateIssuer_1 = class CertificateIssuer2 extends GeneralNames {
@@ -16930,7 +16930,7 @@ CertificateIssuer = CertificateIssuer_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence })
 ], CertificateIssuer);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/certificate_policies.js
+// node_modules/@peculiar/asn1-x509/build/es2015/extensions/certificate_policies.js
 var CertificatePolicies_1;
 var id_ce_certificatePolicies = `${id_ce}.32`;
 var id_ce_certificatePolicies_anyPolicy = `${id_ce_certificatePolicies}.0`;
@@ -17030,7 +17030,7 @@ CertificatePolicies = CertificatePolicies_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence, itemType: PolicyInformation })
 ], CertificatePolicies);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/crl_number.js
+// node_modules/@peculiar/asn1-x509/build/es2015/extensions/crl_number.js
 var id_ce_cRLNumber = `${id_ce}.20`;
 var CRLNumber = class CRLNumber2 {
   constructor(value = 0) {
@@ -17044,7 +17044,7 @@ CRLNumber = __decorate([
   AsnType({ type: AsnTypeTypes.Choice })
 ], CRLNumber);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/crl_delta_indicator.js
+// node_modules/@peculiar/asn1-x509/build/es2015/extensions/crl_delta_indicator.js
 var id_ce_deltaCRLIndicator = `${id_ce}.27`;
 var BaseCRLNumber = class BaseCRLNumber2 extends CRLNumber {
 };
@@ -17052,7 +17052,7 @@ BaseCRLNumber = __decorate([
   AsnType({ type: AsnTypeTypes.Choice })
 ], BaseCRLNumber);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/crl_distribution_points.js
+// node_modules/@peculiar/asn1-x509/build/es2015/extensions/crl_distribution_points.js
 var CRLDistributionPoints_1;
 var id_ce_cRLDistributionPoints = `${id_ce}.31`;
 var ReasonFlags;
@@ -17142,7 +17142,7 @@ CRLDistributionPoints = CRLDistributionPoints_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence, itemType: DistributionPoint })
 ], CRLDistributionPoints);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/crl_freshest.js
+// node_modules/@peculiar/asn1-x509/build/es2015/extensions/crl_freshest.js
 var FreshestCRL_1;
 var id_ce_freshestCRL = `${id_ce}.46`;
 var FreshestCRL = FreshestCRL_1 = class FreshestCRL2 extends CRLDistributionPoints {
@@ -17155,7 +17155,7 @@ FreshestCRL = FreshestCRL_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence, itemType: DistributionPoint })
 ], FreshestCRL);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/crl_issuing_distribution_point.js
+// node_modules/@peculiar/asn1-x509/build/es2015/extensions/crl_issuing_distribution_point.js
 var id_ce_issuingDistributionPoint = `${id_ce}.28`;
 var IssuingDistributionPoint = class _IssuingDistributionPoint {
   constructor(params = {}) {
@@ -17206,7 +17206,7 @@ __decorate([
   })
 ], IssuingDistributionPoint.prototype, "onlyContainsAttributeCerts", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/crl_reason.js
+// node_modules/@peculiar/asn1-x509/build/es2015/extensions/crl_reason.js
 var id_ce_cRLReasons = `${id_ce}.21`;
 var CRLReasons;
 (function(CRLReasons2) {
@@ -17240,7 +17240,7 @@ CRLReason = __decorate([
   AsnType({ type: AsnTypeTypes.Choice })
 ], CRLReason);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/extended_key_usage.js
+// node_modules/@peculiar/asn1-x509/build/es2015/extensions/extended_key_usage.js
 var ExtendedKeyUsage_1;
 var id_ce_extKeyUsage = `${id_ce}.37`;
 var ExtendedKeyUsage = ExtendedKeyUsage_1 = class ExtendedKeyUsage2 extends AsnArray {
@@ -17260,7 +17260,7 @@ var id_kp_emailProtection = `${id_kp}.4`;
 var id_kp_timeStamping = `${id_kp}.8`;
 var id_kp_OCSPSigning = `${id_kp}.9`;
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/inhibit_any_policy.js
+// node_modules/@peculiar/asn1-x509/build/es2015/extensions/inhibit_any_policy.js
 var id_ce_inhibitAnyPolicy = `${id_ce}.54`;
 var InhibitAnyPolicy = class InhibitAnyPolicy2 {
   constructor(value = new ArrayBuffer(0)) {
@@ -17274,7 +17274,7 @@ InhibitAnyPolicy = __decorate([
   AsnType({ type: AsnTypeTypes.Choice })
 ], InhibitAnyPolicy);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/invalidity_date.js
+// node_modules/@peculiar/asn1-x509/build/es2015/extensions/invalidity_date.js
 var id_ce_invalidityDate = `${id_ce}.24`;
 var InvalidityDate = class InvalidityDate2 {
   constructor(value) {
@@ -17291,7 +17291,7 @@ InvalidityDate = __decorate([
   AsnType({ type: AsnTypeTypes.Choice })
 ], InvalidityDate);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/issuer_alternative_name.js
+// node_modules/@peculiar/asn1-x509/build/es2015/extensions/issuer_alternative_name.js
 var IssueAlternativeName_1;
 var id_ce_issuerAltName = `${id_ce}.18`;
 var IssueAlternativeName = IssueAlternativeName_1 = class IssueAlternativeName2 extends GeneralNames {
@@ -17304,7 +17304,7 @@ IssueAlternativeName = IssueAlternativeName_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence })
 ], IssueAlternativeName);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/key_usage.js
+// node_modules/@peculiar/asn1-x509/build/es2015/extensions/key_usage.js
 var id_ce_keyUsage = `${id_ce}.15`;
 var KeyUsageFlags;
 (function(KeyUsageFlags3) {
@@ -17356,7 +17356,7 @@ var KeyUsage = class extends BitString2 {
   }
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/name_constraints.js
+// node_modules/@peculiar/asn1-x509/build/es2015/extensions/name_constraints.js
 var GeneralSubtrees_1;
 var id_ce_nameConstraints = `${id_ce}.30`;
 var GeneralSubtree = class {
@@ -17396,7 +17396,7 @@ __decorate([
   AsnProp({ type: GeneralSubtrees, context: 1, optional: true, implicit: true })
 ], NameConstraints.prototype, "excludedSubtrees", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/policy_constraints.js
+// node_modules/@peculiar/asn1-x509/build/es2015/extensions/policy_constraints.js
 var id_ce_policyConstraints = `${id_ce}.36`;
 var PolicyConstraints = class {
   constructor(params = {}) {
@@ -17422,7 +17422,7 @@ __decorate([
   })
 ], PolicyConstraints.prototype, "inhibitPolicyMapping", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/policy_mappings.js
+// node_modules/@peculiar/asn1-x509/build/es2015/extensions/policy_mappings.js
 var PolicyMappings_1;
 var id_ce_policyMappings = `${id_ce}.33`;
 var PolicyMapping = class {
@@ -17448,7 +17448,7 @@ PolicyMappings = PolicyMappings_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence, itemType: PolicyMapping })
 ], PolicyMappings);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/subject_alternative_name.js
+// node_modules/@peculiar/asn1-x509/build/es2015/extensions/subject_alternative_name.js
 var SubjectAlternativeName_1;
 var id_ce_subjectAltName = `${id_ce}.17`;
 var SubjectAlternativeName = SubjectAlternativeName_1 = class SubjectAlternativeName2 extends GeneralNames {
@@ -17461,7 +17461,7 @@ SubjectAlternativeName = SubjectAlternativeName_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence })
 ], SubjectAlternativeName);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/attribute.js
+// node_modules/@peculiar/asn1-x509/build/es2015/attribute.js
 var Attribute = class {
   constructor(params = {}) {
     this.type = "";
@@ -17476,7 +17476,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.Any, repeated: "set" })
 ], Attribute.prototype, "values", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/subject_directory_attributes.js
+// node_modules/@peculiar/asn1-x509/build/es2015/extensions/subject_directory_attributes.js
 var SubjectDirectoryAttributes_1;
 var id_ce_subjectDirectoryAttributes = `${id_ce}.9`;
 var SubjectDirectoryAttributes = SubjectDirectoryAttributes_1 = class SubjectDirectoryAttributes2 extends AsnArray {
@@ -17489,12 +17489,12 @@ SubjectDirectoryAttributes = SubjectDirectoryAttributes_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence, itemType: Attribute })
 ], SubjectDirectoryAttributes);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/subject_key_identifier.js
+// node_modules/@peculiar/asn1-x509/build/es2015/extensions/subject_key_identifier.js
 var id_ce_subjectKeyIdentifier = `${id_ce}.14`;
 var SubjectKeyIdentifier = class extends KeyIdentifier {
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/private_key_usage_period.js
+// node_modules/@peculiar/asn1-x509/build/es2015/extensions/private_key_usage_period.js
 var id_ce_privateKeyUsagePeriod = `${id_ce}.16`;
 var PrivateKeyUsagePeriod = class {
   constructor(params = {}) {
@@ -17508,7 +17508,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.GeneralizedTime, context: 1, implicit: true, optional: true })
 ], PrivateKeyUsagePeriod.prototype, "notAfter", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/entrust_version_info.js
+// node_modules/@peculiar/asn1-x509/build/es2015/extensions/entrust_version_info.js
 var EntrustInfoFlags;
 (function(EntrustInfoFlags2) {
   EntrustInfoFlags2[EntrustInfoFlags2["keyUpdateAllowed"] = 1] = "keyUpdateAllowed";
@@ -17548,7 +17548,7 @@ __decorate([
   AsnProp({ type: EntrustInfo })
 ], EntrustVersionInfo.prototype, "entrustInfoFlags", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/subject_info_access.js
+// node_modules/@peculiar/asn1-x509/build/es2015/extensions/subject_info_access.js
 var SubjectInfoAccessSyntax_1;
 var id_pe_subjectInfoAccess = `${id_pe}.11`;
 var SubjectInfoAccessSyntax = SubjectInfoAccessSyntax_1 = class SubjectInfoAccessSyntax2 extends AsnArray {
@@ -17561,7 +17561,7 @@ SubjectInfoAccessSyntax = SubjectInfoAccessSyntax_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence, itemType: AccessDescription })
 ], SubjectInfoAccessSyntax);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/algorithm_identifier.js
+// node_modules/@peculiar/asn1-x509/build/es2015/algorithm_identifier.js
 var pvtsutils2 = __toESM(require_build());
 var AlgorithmIdentifier = class _AlgorithmIdentifier {
   constructor(params = {}) {
@@ -17584,7 +17584,7 @@ __decorate([
   })
 ], AlgorithmIdentifier.prototype, "parameters", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/subject_public_key_info.js
+// node_modules/@peculiar/asn1-x509/build/es2015/subject_public_key_info.js
 var SubjectPublicKeyInfo = class {
   constructor(params = {}) {
     this.algorithm = new AlgorithmIdentifier();
@@ -17599,7 +17599,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.BitString })
 ], SubjectPublicKeyInfo.prototype, "subjectPublicKey", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/time.js
+// node_modules/@peculiar/asn1-x509/build/es2015/time.js
 var Time = class Time2 {
   constructor(time3) {
     if (time3) {
@@ -17638,7 +17638,7 @@ Time = __decorate([
   AsnType({ type: AsnTypeTypes.Choice })
 ], Time);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/validity.js
+// node_modules/@peculiar/asn1-x509/build/es2015/validity.js
 var Validity = class {
   constructor(params) {
     this.notBefore = new Time(/* @__PURE__ */ new Date());
@@ -17656,7 +17656,7 @@ __decorate([
   AsnProp({ type: Time })
 ], Validity.prototype, "notAfter", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extension.js
+// node_modules/@peculiar/asn1-x509/build/es2015/extension.js
 var Extensions_1;
 var Extension = class _Extension {
   constructor(params = {}) {
@@ -17689,7 +17689,7 @@ Extensions = Extensions_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence, itemType: Extension })
 ], Extensions);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/types.js
+// node_modules/@peculiar/asn1-x509/build/es2015/types.js
 var Version;
 (function(Version4) {
   Version4[Version4["v1"] = 0] = "v1";
@@ -17697,7 +17697,7 @@ var Version;
   Version4[Version4["v3"] = 2] = "v3";
 })(Version || (Version = {}));
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/tbs_certificate.js
+// node_modules/@peculiar/asn1-x509/build/es2015/tbs_certificate.js
 var TBSCertificate = class {
   constructor(params = {}) {
     this.version = Version.v1;
@@ -17753,7 +17753,7 @@ __decorate([
   AsnProp({ type: Extensions, context: 3, optional: true })
 ], TBSCertificate.prototype, "extensions", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/certificate.js
+// node_modules/@peculiar/asn1-x509/build/es2015/certificate.js
 var Certificate = class {
   constructor(params = {}) {
     this.tbsCertificate = new TBSCertificate();
@@ -17772,7 +17772,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.BitString })
 ], Certificate.prototype, "signatureValue", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/tbs_cert_list.js
+// node_modules/@peculiar/asn1-x509/build/es2015/tbs_cert_list.js
 var RevokedCertificate = class {
   constructor(params = {}) {
     this.userCertificate = new ArrayBuffer(0);
@@ -17819,7 +17819,7 @@ __decorate([
   AsnProp({ type: Extension, optional: true, context: 0, repeated: "sequence" })
 ], TBSCertList.prototype, "crlExtensions", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/certificate_list.js
+// node_modules/@peculiar/asn1-x509/build/es2015/certificate_list.js
 var CertificateList = class {
   constructor(params = {}) {
     this.tbsCertList = new TBSCertList();
@@ -17838,7 +17838,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.BitString })
 ], CertificateList.prototype, "signature", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/getCertificateInfo.js
+// node_modules/@simplewebauthn/server/esm/helpers/getCertificateInfo.js
 var issuerSubjectIDKey = {
   "2.5.4.6": "C",
   "2.5.4.10": "O",
@@ -17900,11 +17900,11 @@ function issuerSubjectToString(input) {
   return parts.join(" : ");
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/x509/build/x509.es.js
+// node_modules/@peculiar/x509/build/x509.es.js
 var import_reflect_metadata = __toESM(require_Reflect());
 var import_pvtsutils6 = __toESM(require_build());
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/issuer_and_serial_number.js
+// node_modules/@peculiar/asn1-cms/build/es2015/issuer_and_serial_number.js
 var IssuerAndSerialNumber = class {
   constructor(params = {}) {
     this.issuer = new Name();
@@ -17919,7 +17919,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.Integer, converter: AsnIntegerArrayBufferConverter })
 ], IssuerAndSerialNumber.prototype, "serialNumber", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/signer_identifier.js
+// node_modules/@peculiar/asn1-cms/build/es2015/signer_identifier.js
 var SignerIdentifier = class SignerIdentifier2 {
   constructor(params = {}) {
     Object.assign(this, params);
@@ -17935,7 +17935,7 @@ SignerIdentifier = __decorate([
   AsnType({ type: AsnTypeTypes.Choice })
 ], SignerIdentifier);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/types.js
+// node_modules/@peculiar/asn1-cms/build/es2015/types.js
 var CMSVersion;
 (function(CMSVersion2) {
   CMSVersion2[CMSVersion2["v0"] = 0] = "v0";
@@ -17976,7 +17976,7 @@ KeyDerivationAlgorithmIdentifier = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence })
 ], KeyDerivationAlgorithmIdentifier);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/attribute.js
+// node_modules/@peculiar/asn1-cms/build/es2015/attribute.js
 var Attribute2 = class {
   constructor(params = {}) {
     this.attrType = "";
@@ -17991,7 +17991,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.Any, repeated: "set" })
 ], Attribute2.prototype, "attrValues", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/signer_info.js
+// node_modules/@peculiar/asn1-cms/build/es2015/signer_info.js
 var SignerInfos_1;
 var SignerInfo = class {
   constructor(params = {}) {
@@ -18041,21 +18041,21 @@ SignerInfos = SignerInfos_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Set, itemType: SignerInfo })
 ], SignerInfos);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/attributes/counter_signature.js
+// node_modules/@peculiar/asn1-cms/build/es2015/attributes/counter_signature.js
 var CounterSignature = class CounterSignature2 extends SignerInfo {
 };
 CounterSignature = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence })
 ], CounterSignature);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/attributes/signing_time.js
+// node_modules/@peculiar/asn1-cms/build/es2015/attributes/signing_time.js
 var SigningTime = class SigningTime2 extends Time {
 };
 SigningTime = __decorate([
   AsnType({ type: AsnTypeTypes.Choice })
 ], SigningTime);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509-attr/build/es2015/aa_clear_attrs.js
+// node_modules/@peculiar/asn1-x509-attr/build/es2015/aa_clear_attrs.js
 var ACClearAttrs = class {
   constructor(params = {}) {
     this.acIssuer = new GeneralName();
@@ -18074,7 +18074,7 @@ __decorate([
   AsnProp({ type: Attribute, repeated: "sequence" })
 ], ACClearAttrs.prototype, "attrs", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509-attr/build/es2015/attr_spec.js
+// node_modules/@peculiar/asn1-x509-attr/build/es2015/attr_spec.js
 var AttrSpec_1;
 var AttrSpec = AttrSpec_1 = class AttrSpec2 extends AsnArray {
   constructor(items) {
@@ -18086,7 +18086,7 @@ AttrSpec = AttrSpec_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence, itemType: AsnPropTypes.ObjectIdentifier })
 ], AttrSpec);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509-attr/build/es2015/aa_controls.js
+// node_modules/@peculiar/asn1-x509-attr/build/es2015/aa_controls.js
 var AAControls = class {
   constructor(params = {}) {
     this.permitUnSpecified = true;
@@ -18106,7 +18106,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.Boolean, defaultValue: true })
 ], AAControls.prototype, "permitUnSpecified", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509-attr/build/es2015/issuer_serial.js
+// node_modules/@peculiar/asn1-x509-attr/build/es2015/issuer_serial.js
 var IssuerSerial = class {
   constructor(params = {}) {
     this.issuer = new GeneralNames();
@@ -18125,7 +18125,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.BitString, optional: true })
 ], IssuerSerial.prototype, "issuerUID", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509-attr/build/es2015/object_digest_info.js
+// node_modules/@peculiar/asn1-x509-attr/build/es2015/object_digest_info.js
 var DigestedObjectType;
 (function(DigestedObjectType2) {
   DigestedObjectType2[DigestedObjectType2["publicKey"] = 0] = "publicKey";
@@ -18153,7 +18153,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.BitString })
 ], ObjectDigestInfo.prototype, "objectDigest", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509-attr/build/es2015/v2_form.js
+// node_modules/@peculiar/asn1-x509-attr/build/es2015/v2_form.js
 var V2Form = class {
   constructor(params = {}) {
     Object.assign(this, params);
@@ -18169,7 +18169,7 @@ __decorate([
   AsnProp({ type: ObjectDigestInfo, context: 1, implicit: true, optional: true })
 ], V2Form.prototype, "objectDigestInfo", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509-attr/build/es2015/attr_cert_issuer.js
+// node_modules/@peculiar/asn1-x509-attr/build/es2015/attr_cert_issuer.js
 var AttCertIssuer = class AttCertIssuer2 {
   constructor(params = {}) {
     Object.assign(this, params);
@@ -18185,7 +18185,7 @@ AttCertIssuer = __decorate([
   AsnType({ type: AsnTypeTypes.Choice })
 ], AttCertIssuer);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509-attr/build/es2015/attr_cert_validity_period.js
+// node_modules/@peculiar/asn1-x509-attr/build/es2015/attr_cert_validity_period.js
 var AttCertValidityPeriod = class {
   constructor(params = {}) {
     this.notBeforeTime = /* @__PURE__ */ new Date();
@@ -18200,7 +18200,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.GeneralizedTime })
 ], AttCertValidityPeriod.prototype, "notAfterTime", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509-attr/build/es2015/holder.js
+// node_modules/@peculiar/asn1-x509-attr/build/es2015/holder.js
 var Holder = class {
   constructor(params = {}) {
     Object.assign(this, params);
@@ -18216,7 +18216,7 @@ __decorate([
   AsnProp({ type: ObjectDigestInfo, implicit: true, context: 2, optional: true })
 ], Holder.prototype, "objectDigestInfo", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509-attr/build/es2015/attribute_certificate_info.js
+// node_modules/@peculiar/asn1-x509-attr/build/es2015/attribute_certificate_info.js
 var AttCertVersion;
 (function(AttCertVersion2) {
   AttCertVersion2[AttCertVersion2["v2"] = 1] = "v2";
@@ -18261,7 +18261,7 @@ __decorate([
   AsnProp({ type: Extensions, optional: true })
 ], AttributeCertificateInfo.prototype, "extensions", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509-attr/build/es2015/attribute_certificate.js
+// node_modules/@peculiar/asn1-x509-attr/build/es2015/attribute_certificate.js
 var AttributeCertificate = class {
   constructor(params = {}) {
     this.acinfo = new AttributeCertificateInfo();
@@ -18280,7 +18280,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.BitString })
 ], AttributeCertificate.prototype, "signatureValue", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509-attr/build/es2015/class_list.js
+// node_modules/@peculiar/asn1-x509-attr/build/es2015/class_list.js
 var ClassListFlags;
 (function(ClassListFlags2) {
   ClassListFlags2[ClassListFlags2["unmarked"] = 1] = "unmarked";
@@ -18293,7 +18293,7 @@ var ClassListFlags;
 var ClassList = class extends BitString2 {
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509-attr/build/es2015/security_category.js
+// node_modules/@peculiar/asn1-x509-attr/build/es2015/security_category.js
 var SecurityCategory = class {
   constructor(params = {}) {
     this.type = "";
@@ -18308,7 +18308,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.Any, implicit: true, context: 1 })
 ], SecurityCategory.prototype, "value", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509-attr/build/es2015/clearance.js
+// node_modules/@peculiar/asn1-x509-attr/build/es2015/clearance.js
 var Clearance = class {
   constructor(params = {}) {
     this.policyId = "";
@@ -18326,7 +18326,7 @@ __decorate([
   AsnProp({ type: SecurityCategory, repeated: "set" })
 ], Clearance.prototype, "securityCategories", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509-attr/build/es2015/ietf_attr_syntax.js
+// node_modules/@peculiar/asn1-x509-attr/build/es2015/ietf_attr_syntax.js
 var IetfAttrSyntaxValueChoices = class {
   constructor(params = {}) {
     Object.assign(this, params);
@@ -18354,7 +18354,7 @@ __decorate([
   AsnProp({ type: IetfAttrSyntaxValueChoices, repeated: "sequence" })
 ], IetfAttrSyntax.prototype, "values", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509-attr/build/es2015/object_identifiers.js
+// node_modules/@peculiar/asn1-x509-attr/build/es2015/object_identifiers.js
 var id_pe_ac_auditIdentity = `${id_pe}.4`;
 var id_pe_aaControls = `${id_pe}.6`;
 var id_pe_ac_proxying = `${id_pe}.10`;
@@ -18368,7 +18368,7 @@ var id_aca_encAttrs = `${id_aca}.6`;
 var id_at = "2.5.4";
 var id_at_role = `${id_at}.72`;
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509-attr/build/es2015/target.js
+// node_modules/@peculiar/asn1-x509-attr/build/es2015/target.js
 var Targets_1;
 var TargetCert = class {
   constructor(params = {}) {
@@ -18412,7 +18412,7 @@ Targets = Targets_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence, itemType: Target })
 ], Targets);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509-attr/build/es2015/proxy_info.js
+// node_modules/@peculiar/asn1-x509-attr/build/es2015/proxy_info.js
 var ProxyInfo_1;
 var ProxyInfo = ProxyInfo_1 = class ProxyInfo2 extends AsnArray {
   constructor(items) {
@@ -18424,7 +18424,7 @@ ProxyInfo = ProxyInfo_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence, itemType: Targets })
 ], ProxyInfo);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509-attr/build/es2015/role_syntax.js
+// node_modules/@peculiar/asn1-x509-attr/build/es2015/role_syntax.js
 var RoleSyntax = class {
   constructor(params = {}) {
     Object.assign(this, params);
@@ -18437,7 +18437,7 @@ __decorate([
   AsnProp({ type: GeneralName, implicit: true, context: 1 })
 ], RoleSyntax.prototype, "roleName", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509-attr/build/es2015/svce_auth_info.js
+// node_modules/@peculiar/asn1-x509-attr/build/es2015/svce_auth_info.js
 var SvceAuthInfo = class {
   constructor(params = {}) {
     this.service = new GeneralName();
@@ -18455,7 +18455,7 @@ __decorate([
   AsnProp({ type: OctetString2, optional: true })
 ], SvceAuthInfo.prototype, "authInfo", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/certificate_choices.js
+// node_modules/@peculiar/asn1-cms/build/es2015/certificate_choices.js
 var CertificateSet_1;
 var OtherCertificateFormat = class {
   constructor(params = {}) {
@@ -18497,7 +18497,7 @@ CertificateSet = CertificateSet_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Set, itemType: CertificateChoices })
 ], CertificateSet);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/content_info.js
+// node_modules/@peculiar/asn1-cms/build/es2015/content_info.js
 var ContentInfo = class {
   constructor(params = {}) {
     this.contentType = "";
@@ -18512,7 +18512,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.Any, context: 0 })
 ], ContentInfo.prototype, "content", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/encapsulated_content_info.js
+// node_modules/@peculiar/asn1-cms/build/es2015/encapsulated_content_info.js
 var EncapsulatedContent = class EncapsulatedContent2 {
   constructor(params = {}) {
     Object.assign(this, params);
@@ -18540,7 +18540,7 @@ __decorate([
   AsnProp({ type: EncapsulatedContent, context: 0, optional: true })
 ], EncapsulatedContentInfo.prototype, "eContent", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/encrypted_content_info.js
+// node_modules/@peculiar/asn1-cms/build/es2015/encrypted_content_info.js
 var EncryptedContent = class EncryptedContent2 {
   constructor(params = {}) {
     Object.assign(this, params);
@@ -18579,7 +18579,7 @@ __decorate([
   AsnProp({ type: EncryptedContent, optional: true })
 ], EncryptedContentInfo.prototype, "encryptedContent", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/other_key_attribute.js
+// node_modules/@peculiar/asn1-cms/build/es2015/other_key_attribute.js
 var OtherKeyAttribute = class {
   constructor(params = {}) {
     this.keyAttrId = "";
@@ -18593,7 +18593,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.Any, optional: true })
 ], OtherKeyAttribute.prototype, "keyAttr", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/key_agree_recipient_info.js
+// node_modules/@peculiar/asn1-cms/build/es2015/key_agree_recipient_info.js
 var RecipientEncryptedKeys_1;
 var RecipientKeyIdentifier = class {
   constructor(params = {}) {
@@ -18701,7 +18701,7 @@ __decorate([
   AsnProp({ type: RecipientEncryptedKeys })
 ], KeyAgreeRecipientInfo.prototype, "recipientEncryptedKeys", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/key_trans_recipient_info.js
+// node_modules/@peculiar/asn1-cms/build/es2015/key_trans_recipient_info.js
 var RecipientIdentifier = class RecipientIdentifier2 {
   constructor(params = {}) {
     Object.assign(this, params);
@@ -18738,7 +18738,7 @@ __decorate([
   AsnProp({ type: OctetString2 })
 ], KeyTransRecipientInfo.prototype, "encryptedKey", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/kek_recipient_info.js
+// node_modules/@peculiar/asn1-cms/build/es2015/kek_recipient_info.js
 var KEKIdentifier = class {
   constructor(params = {}) {
     this.keyIdentifier = new OctetString2();
@@ -18776,7 +18776,7 @@ __decorate([
   AsnProp({ type: OctetString2 })
 ], KEKRecipientInfo.prototype, "encryptedKey", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/password_recipient_info.js
+// node_modules/@peculiar/asn1-cms/build/es2015/password_recipient_info.js
 var PasswordRecipientInfo = class {
   constructor(params = {}) {
     this.version = CMSVersion.v0;
@@ -18798,7 +18798,7 @@ __decorate([
   AsnProp({ type: OctetString2 })
 ], PasswordRecipientInfo.prototype, "encryptedKey", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/recipient_info.js
+// node_modules/@peculiar/asn1-cms/build/es2015/recipient_info.js
 var OtherRecipientInfo = class {
   constructor(params = {}) {
     this.oriType = "";
@@ -18836,7 +18836,7 @@ RecipientInfo = __decorate([
   AsnType({ type: AsnTypeTypes.Choice })
 ], RecipientInfo);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/recipient_infos.js
+// node_modules/@peculiar/asn1-cms/build/es2015/recipient_infos.js
 var RecipientInfos_1;
 var RecipientInfos = RecipientInfos_1 = class RecipientInfos2 extends AsnArray {
   constructor(items) {
@@ -18848,7 +18848,7 @@ RecipientInfos = RecipientInfos_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Set, itemType: RecipientInfo })
 ], RecipientInfos);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/revocation_info_choice.js
+// node_modules/@peculiar/asn1-cms/build/es2015/revocation_info_choice.js
 var RevocationInfoChoices_1;
 var id_ri = `${id_pkix}.16`;
 var id_ri_ocsp_response = `${id_ri}.2`;
@@ -18888,7 +18888,7 @@ RevocationInfoChoices = RevocationInfoChoices_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Set, itemType: RevocationInfoChoice })
 ], RevocationInfoChoices);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/originator_info.js
+// node_modules/@peculiar/asn1-cms/build/es2015/originator_info.js
 var OriginatorInfo = class {
   constructor(params = {}) {
     Object.assign(this, params);
@@ -18901,7 +18901,7 @@ __decorate([
   AsnProp({ type: RevocationInfoChoices, context: 1, implicit: true, optional: true })
 ], OriginatorInfo.prototype, "crls", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/enveloped_data.js
+// node_modules/@peculiar/asn1-cms/build/es2015/enveloped_data.js
 var UnprotectedAttributes_1;
 var UnprotectedAttributes = UnprotectedAttributes_1 = class UnprotectedAttributes2 extends AsnArray {
   constructor(items) {
@@ -18936,10 +18936,10 @@ __decorate([
   AsnProp({ type: UnprotectedAttributes, context: 1, implicit: true, optional: true })
 ], EnvelopedData.prototype, "unprotectedAttrs", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/object_identifiers.js
+// node_modules/@peculiar/asn1-cms/build/es2015/object_identifiers.js
 var id_signedData = "1.2.840.113549.1.7.2";
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/signed_data.js
+// node_modules/@peculiar/asn1-cms/build/es2015/signed_data.js
 var DigestAlgorithmIdentifiers_1;
 var DigestAlgorithmIdentifiers = DigestAlgorithmIdentifiers_1 = class DigestAlgorithmIdentifiers2 extends AsnArray {
   constructor(items) {
@@ -18978,7 +18978,7 @@ __decorate([
   AsnProp({ type: SignerInfos })
 ], SignedData.prototype, "signerInfos", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-ecc/build/es2015/object_identifiers.js
+// node_modules/@peculiar/asn1-ecc/build/es2015/object_identifiers.js
 var id_ecPublicKey = "1.2.840.10045.2.1";
 var id_ecdsaWithSHA1 = "1.2.840.10045.4.1";
 var id_ecdsaWithSHA224 = "1.2.840.10045.4.3.1";
@@ -18989,7 +18989,7 @@ var id_secp256r1 = "1.2.840.10045.3.1.7";
 var id_secp384r1 = "1.3.132.0.34";
 var id_secp521r1 = "1.3.132.0.35";
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-ecc/build/es2015/algorithms.js
+// node_modules/@peculiar/asn1-ecc/build/es2015/algorithms.js
 function create(algorithm) {
   return new AlgorithmIdentifier({ algorithm });
 }
@@ -18999,7 +18999,7 @@ var ecdsaWithSHA256 = create(id_ecdsaWithSHA256);
 var ecdsaWithSHA384 = create(id_ecdsaWithSHA384);
 var ecdsaWithSHA512 = create(id_ecdsaWithSHA512);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-ecc/build/es2015/rfc3279.js
+// node_modules/@peculiar/asn1-ecc/build/es2015/rfc3279.js
 var FieldID = class FieldID2 {
   constructor(params = {}) {
     Object.assign(this, params);
@@ -19065,7 +19065,7 @@ SpecifiedECDomain = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence })
 ], SpecifiedECDomain);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-ecc/build/es2015/ec_parameters.js
+// node_modules/@peculiar/asn1-ecc/build/es2015/ec_parameters.js
 var ECParameters = class ECParameters2 {
   constructor(params = {}) {
     Object.assign(this, params);
@@ -19084,7 +19084,7 @@ ECParameters = __decorate([
   AsnType({ type: AsnTypeTypes.Choice })
 ], ECParameters);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-ecc/build/es2015/ec_private_key.js
+// node_modules/@peculiar/asn1-ecc/build/es2015/ec_private_key.js
 var ECPrivateKey = class {
   constructor(params = {}) {
     this.version = 1;
@@ -19105,7 +19105,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.BitString, context: 1, optional: true })
 ], ECPrivateKey.prototype, "publicKey", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-ecc/build/es2015/ec_signature_value.js
+// node_modules/@peculiar/asn1-ecc/build/es2015/ec_signature_value.js
 var ECDSASigValue = class {
   constructor(params = {}) {
     this.r = new ArrayBuffer(0);
@@ -19120,7 +19120,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.Integer, converter: AsnIntegerArrayBufferConverter })
 ], ECDSASigValue.prototype, "s", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-rsa/build/es2015/object_identifiers.js
+// node_modules/@peculiar/asn1-rsa/build/es2015/object_identifiers.js
 var id_pkcs_1 = "1.2.840.113549.1.1";
 var id_rsaEncryption = `${id_pkcs_1}.1`;
 var id_RSAES_OAEP = `${id_pkcs_1}.7`;
@@ -19146,7 +19146,7 @@ var id_md2 = "1.2.840.113549.2.2";
 var id_md5 = "1.2.840.113549.2.5";
 var id_mgf1 = `${id_pkcs_1}.8`;
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-rsa/build/es2015/algorithms.js
+// node_modules/@peculiar/asn1-rsa/build/es2015/algorithms.js
 function create2(algorithm) {
   return new AlgorithmIdentifier({ algorithm, parameters: null });
 }
@@ -19199,7 +19199,7 @@ var sha512WithRSAEncryption = create2(id_sha512WithRSAEncryption);
 var sha512_224WithRSAEncryption = create2(id_sha512_224WithRSAEncryption);
 var sha512_256WithRSAEncryption = create2(id_sha512_256WithRSAEncryption);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-rsa/build/es2015/parameters/rsaes_oaep.js
+// node_modules/@peculiar/asn1-rsa/build/es2015/parameters/rsaes_oaep.js
 var RsaEsOaepParams = class {
   constructor(params = {}) {
     this.hashAlgorithm = new AlgorithmIdentifier(sha1);
@@ -19225,7 +19225,7 @@ var RSAES_OAEP = new AlgorithmIdentifier({
   parameters: AsnConvert.serialize(new RsaEsOaepParams())
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-rsa/build/es2015/parameters/rsassa_pss.js
+// node_modules/@peculiar/asn1-rsa/build/es2015/parameters/rsassa_pss.js
 var RsaSaPssParams = class {
   constructor(params = {}) {
     this.hashAlgorithm = new AlgorithmIdentifier(sha1);
@@ -19255,7 +19255,7 @@ var RSASSA_PSS = new AlgorithmIdentifier({
   parameters: AsnConvert.serialize(new RsaSaPssParams())
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-rsa/build/es2015/parameters/rsassa_pkcs1_v1_5.js
+// node_modules/@peculiar/asn1-rsa/build/es2015/parameters/rsassa_pkcs1_v1_5.js
 var DigestInfo = class {
   constructor(params = {}) {
     this.digestAlgorithm = new AlgorithmIdentifier();
@@ -19270,7 +19270,7 @@ __decorate([
   AsnProp({ type: OctetString2 })
 ], DigestInfo.prototype, "digest", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-rsa/build/es2015/other_prime_info.js
+// node_modules/@peculiar/asn1-rsa/build/es2015/other_prime_info.js
 var OtherPrimeInfos_1;
 var OtherPrimeInfo = class {
   constructor(params = {}) {
@@ -19299,7 +19299,7 @@ OtherPrimeInfos = OtherPrimeInfos_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence, itemType: OtherPrimeInfo })
 ], OtherPrimeInfos);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-rsa/build/es2015/rsa_private_key.js
+// node_modules/@peculiar/asn1-rsa/build/es2015/rsa_private_key.js
 var RSAPrivateKey = class {
   constructor(params = {}) {
     this.version = 0;
@@ -19345,7 +19345,7 @@ __decorate([
   AsnProp({ type: OtherPrimeInfos, optional: true })
 ], RSAPrivateKey.prototype, "otherPrimeInfos", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-rsa/build/es2015/rsa_public_key.js
+// node_modules/@peculiar/asn1-rsa/build/es2015/rsa_public_key.js
 var RSAPublicKey = class {
   constructor(params = {}) {
     this.modulus = new ArrayBuffer(0);
@@ -19360,7 +19360,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.Integer, converter: AsnIntegerArrayBufferConverter })
 ], RSAPublicKey.prototype, "publicExponent", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tsyringe/dist/esm5/types/lifecycle.js
+// node_modules/tsyringe/dist/esm5/types/lifecycle.js
 var Lifecycle;
 (function(Lifecycle2) {
   Lifecycle2[Lifecycle2["Transient"] = 0] = "Transient";
@@ -19370,7 +19370,7 @@ var Lifecycle;
 })(Lifecycle || (Lifecycle = {}));
 var lifecycle_default = Lifecycle;
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tsyringe/node_modules/tslib/tslib.es6.js
+// node_modules/tsyringe/node_modules/tslib/tslib.es6.js
 var extendStatics = function(d, b) {
   extendStatics = Object.setPrototypeOf || { __proto__: [] } instanceof Array && function(d2, b2) {
     d2.__proto__ = b2;
@@ -19516,7 +19516,7 @@ function __spread() {
   return ar;
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tsyringe/dist/esm5/reflection-helpers.js
+// node_modules/tsyringe/dist/esm5/reflection-helpers.js
 var INJECTION_TOKEN_METADATA_KEY = "injectionTokens";
 function getParamInfo(target) {
   var params = Reflect.getMetadata("design:paramtypes", target) || [];
@@ -19527,17 +19527,17 @@ function getParamInfo(target) {
   return params;
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tsyringe/dist/esm5/providers/class-provider.js
+// node_modules/tsyringe/dist/esm5/providers/class-provider.js
 function isClassProvider(provider) {
   return !!provider.useClass;
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tsyringe/dist/esm5/providers/factory-provider.js
+// node_modules/tsyringe/dist/esm5/providers/factory-provider.js
 function isFactoryProvider(provider) {
   return !!provider.useFactory;
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tsyringe/dist/esm5/lazy-helpers.js
+// node_modules/tsyringe/dist/esm5/lazy-helpers.js
 var DelayedConstructor = (function() {
   function DelayedConstructor2(wrap) {
     this.wrap = wrap;
@@ -19588,7 +19588,7 @@ var DelayedConstructor = (function() {
   return DelayedConstructor2;
 })();
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tsyringe/dist/esm5/providers/injection-token.js
+// node_modules/tsyringe/dist/esm5/providers/injection-token.js
 function isNormalToken(token) {
   return typeof token === "string" || typeof token === "symbol";
 }
@@ -19602,22 +19602,22 @@ function isConstructorToken(token) {
   return typeof token === "function" || token instanceof DelayedConstructor;
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tsyringe/dist/esm5/providers/token-provider.js
+// node_modules/tsyringe/dist/esm5/providers/token-provider.js
 function isTokenProvider(provider) {
   return !!provider.useToken;
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tsyringe/dist/esm5/providers/value-provider.js
+// node_modules/tsyringe/dist/esm5/providers/value-provider.js
 function isValueProvider(provider) {
   return provider.useValue != void 0;
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tsyringe/dist/esm5/providers/provider.js
+// node_modules/tsyringe/dist/esm5/providers/provider.js
 function isProvider(provider) {
   return isClassProvider(provider) || isValueProvider(provider) || isTokenProvider(provider) || isFactoryProvider(provider);
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tsyringe/dist/esm5/registry-base.js
+// node_modules/tsyringe/dist/esm5/registry-base.js
 var RegistryBase = (function() {
   function RegistryBase2() {
     this._registryMap = /* @__PURE__ */ new Map();
@@ -19657,7 +19657,7 @@ var RegistryBase = (function() {
 })();
 var registry_base_default = RegistryBase;
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tsyringe/dist/esm5/registry.js
+// node_modules/tsyringe/dist/esm5/registry.js
 var Registry = (function(_super) {
   __extends(Registry2, _super);
   function Registry2() {
@@ -19667,7 +19667,7 @@ var Registry = (function(_super) {
 })(registry_base_default);
 var registry_default = Registry;
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tsyringe/dist/esm5/resolution-context.js
+// node_modules/tsyringe/dist/esm5/resolution-context.js
 var ResolutionContext = /* @__PURE__ */ (function() {
   function ResolutionContext2() {
     this.scopedResolutions = /* @__PURE__ */ new Map();
@@ -19676,7 +19676,7 @@ var ResolutionContext = /* @__PURE__ */ (function() {
 })();
 var resolution_context_default = ResolutionContext;
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tsyringe/dist/esm5/error-helpers.js
+// node_modules/tsyringe/dist/esm5/error-helpers.js
 function formatDependency(params, idx) {
   if (params === null) {
     return "at position #" + idx;
@@ -19698,7 +19698,7 @@ function formatErrorCtor(ctor, paramIdx, error2) {
   return composeErrorMessage("Cannot inject the dependency " + dep + ' of "' + ctor.name + '" constructor. Reason:', error2);
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tsyringe/dist/esm5/types/disposable.js
+// node_modules/tsyringe/dist/esm5/types/disposable.js
 function isDisposable(value) {
   if (typeof value.dispose !== "function")
     return false;
@@ -19709,7 +19709,7 @@ function isDisposable(value) {
   return true;
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tsyringe/dist/esm5/interceptors.js
+// node_modules/tsyringe/dist/esm5/interceptors.js
 var PreResolutionInterceptors = (function(_super) {
   __extends(PreResolutionInterceptors2, _super);
   function PreResolutionInterceptors2() {
@@ -19733,7 +19733,7 @@ var Interceptors = /* @__PURE__ */ (function() {
 })();
 var interceptors_default = Interceptors;
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tsyringe/dist/esm5/dependency-container.js
+// node_modules/tsyringe/dist/esm5/dependency-container.js
 var typeInfo = /* @__PURE__ */ new Map();
 var InternalDependencyContainer = (function() {
   function InternalDependencyContainer2(parent) {
@@ -20127,7 +20127,7 @@ var InternalDependencyContainer = (function() {
 })();
 var instance = new InternalDependencyContainer();
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tsyringe/dist/esm5/decorators/injectable.js
+// node_modules/tsyringe/dist/esm5/decorators/injectable.js
 function injectable(options) {
   return function(target) {
     typeInfo.set(target, getParamInfo(target));
@@ -20144,12 +20144,12 @@ function injectable(options) {
 }
 var injectable_default = injectable;
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tsyringe/dist/esm5/index.js
+// node_modules/tsyringe/dist/esm5/index.js
 if (typeof Reflect === "undefined" || !Reflect.getMetadata) {
   throw new Error(`tsyringe requires a reflect polyfill. Please add 'import "reflect-metadata"' to the top of your entry point.`);
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-pfx/build/es2015/attribute.js
+// node_modules/@peculiar/asn1-pfx/build/es2015/attribute.js
 var PKCS12AttrSet_1;
 var PKCS12Attribute = class {
   constructor(params = {}) {
@@ -20174,7 +20174,7 @@ PKCS12AttrSet = PKCS12AttrSet_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence, itemType: PKCS12Attribute })
 ], PKCS12AttrSet);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-pfx/build/es2015/authenticated_safe.js
+// node_modules/@peculiar/asn1-pfx/build/es2015/authenticated_safe.js
 var AuthenticatedSafe_1;
 var AuthenticatedSafe = AuthenticatedSafe_1 = class AuthenticatedSafe2 extends AsnArray {
   constructor(items) {
@@ -20186,7 +20186,7 @@ AuthenticatedSafe = AuthenticatedSafe_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence, itemType: ContentInfo })
 ], AuthenticatedSafe);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-pfx/build/es2015/object_identifiers.js
+// node_modules/@peculiar/asn1-pfx/build/es2015/object_identifiers.js
 var id_rsadsi = "1.2.840.113549";
 var id_pkcs = `${id_rsadsi}.1`;
 var id_pkcs_12 = `${id_pkcs}.12`;
@@ -20199,7 +20199,7 @@ var id_pbeWithSHAAnd128BitRC2_CBC = `${id_pkcs_12PbeIds}.5`;
 var id_pbewithSHAAnd40BitRC2_CBC = `${id_pkcs_12PbeIds}.6`;
 var id_bagtypes = `${id_pkcs_12}.10.1`;
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-pfx/build/es2015/bags/types.js
+// node_modules/@peculiar/asn1-pfx/build/es2015/bags/types.js
 var id_keyBag = `${id_bagtypes}.1`;
 var id_pkcs8ShroudedKeyBag = `${id_bagtypes}.2`;
 var id_certBag = `${id_bagtypes}.3`;
@@ -20208,7 +20208,7 @@ var id_SecretBag = `${id_bagtypes}.5`;
 var id_SafeContents = `${id_bagtypes}.6`;
 var id_pkcs_9 = "1.2.840.113549.1.9";
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-pfx/build/es2015/bags/cert_bag.js
+// node_modules/@peculiar/asn1-pfx/build/es2015/bags/cert_bag.js
 var CertBag = class {
   constructor(params = {}) {
     this.certId = "";
@@ -20226,7 +20226,7 @@ var id_certTypes = `${id_pkcs_9}.22`;
 var id_x509Certificate = `${id_certTypes}.1`;
 var id_sdsiCertificate = `${id_certTypes}.2`;
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-pfx/build/es2015/bags/crl_bag.js
+// node_modules/@peculiar/asn1-pfx/build/es2015/bags/crl_bag.js
 var CRLBag = class {
   constructor(params = {}) {
     this.crlId = "";
@@ -20243,7 +20243,7 @@ __decorate([
 var id_crlTypes = `${id_pkcs_9}.23`;
 var id_x509CRL = `${id_crlTypes}.1`;
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-pkcs8/build/es2015/encrypted_private_key_info.js
+// node_modules/@peculiar/asn1-pkcs8/build/es2015/encrypted_private_key_info.js
 var EncryptedData = class extends OctetString2 {
 };
 var EncryptedPrivateKeyInfo = class {
@@ -20260,7 +20260,7 @@ __decorate([
   AsnProp({ type: EncryptedData })
 ], EncryptedPrivateKeyInfo.prototype, "encryptedData", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-pkcs8/build/es2015/private_key_info.js
+// node_modules/@peculiar/asn1-pkcs8/build/es2015/private_key_info.js
 var Attributes_1;
 var Version2;
 (function(Version4) {
@@ -20298,21 +20298,21 @@ __decorate([
   AsnProp({ type: Attributes, implicit: true, context: 0, optional: true })
 ], PrivateKeyInfo.prototype, "attributes", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-pfx/build/es2015/bags/key_bag.js
+// node_modules/@peculiar/asn1-pfx/build/es2015/bags/key_bag.js
 var KeyBag = class KeyBag2 extends PrivateKeyInfo {
 };
 KeyBag = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence })
 ], KeyBag);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-pfx/build/es2015/bags/pkcs8_shrouded_key_bag.js
+// node_modules/@peculiar/asn1-pfx/build/es2015/bags/pkcs8_shrouded_key_bag.js
 var PKCS8ShroudedKeyBag = class PKCS8ShroudedKeyBag2 extends EncryptedPrivateKeyInfo {
 };
 PKCS8ShroudedKeyBag = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence })
 ], PKCS8ShroudedKeyBag);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-pfx/build/es2015/bags/secret_bag.js
+// node_modules/@peculiar/asn1-pfx/build/es2015/bags/secret_bag.js
 var SecretBag = class {
   constructor(params = {}) {
     this.secretTypeId = "";
@@ -20327,7 +20327,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.Any, context: 0 })
 ], SecretBag.prototype, "secretValue", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-pfx/build/es2015/mac_data.js
+// node_modules/@peculiar/asn1-pfx/build/es2015/mac_data.js
 var MacData = class {
   constructor(params = {}) {
     this.mac = new DigestInfo();
@@ -20346,7 +20346,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.Integer, defaultValue: 1 })
 ], MacData.prototype, "iterations", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-pfx/build/es2015/pfx.js
+// node_modules/@peculiar/asn1-pfx/build/es2015/pfx.js
 var PFX = class {
   constructor(params = {}) {
     this.version = 3;
@@ -20365,7 +20365,7 @@ __decorate([
   AsnProp({ type: MacData, optional: true })
 ], PFX.prototype, "macData", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-pfx/build/es2015/safe_bag.js
+// node_modules/@peculiar/asn1-pfx/build/es2015/safe_bag.js
 var SafeContents_1;
 var SafeBag = class {
   constructor(params = {}) {
@@ -20393,7 +20393,7 @@ SafeContents = SafeContents_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence, itemType: SafeBag })
 ], SafeContents);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-pkcs9/build/es2015/index.js
+// node_modules/@peculiar/asn1-pkcs9/build/es2015/index.js
 var ExtensionRequest_1;
 var ExtendedCertificateAttributes_1;
 var SMIMECapabilities_1;
@@ -20637,7 +20637,7 @@ SMIMECapabilities = SMIMECapabilities_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence, itemType: SMIMECapability })
 ], SMIMECapabilities);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-csr/build/es2015/attributes.js
+// node_modules/@peculiar/asn1-csr/build/es2015/attributes.js
 var Attributes_12;
 var Attributes3 = Attributes_12 = class Attributes4 extends AsnArray {
   constructor(items) {
@@ -20649,7 +20649,7 @@ Attributes3 = Attributes_12 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence, itemType: Attribute })
 ], Attributes3);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-csr/build/es2015/certification_request_info.js
+// node_modules/@peculiar/asn1-csr/build/es2015/certification_request_info.js
 var CertificationRequestInfo = class {
   constructor(params = {}) {
     this.version = 0;
@@ -20672,7 +20672,7 @@ __decorate([
   AsnProp({ type: Attributes3, implicit: true, context: 0, optional: true })
 ], CertificationRequestInfo.prototype, "attributes", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-csr/build/es2015/certification_request.js
+// node_modules/@peculiar/asn1-csr/build/es2015/certification_request.js
 var CertificationRequest = class {
   constructor(params = {}) {
     this.certificationRequestInfo = new CertificationRequestInfo();
@@ -20691,7 +20691,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.BitString })
 ], CertificationRequest.prototype, "signature", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/x509/build/x509.es.js
+// node_modules/@peculiar/x509/build/x509.es.js
 var diAlgorithm = "crypto.algorithm";
 var AlgorithmProvider = class {
   getAlgorithms() {
@@ -23509,7 +23509,7 @@ AsnEcSignatureFormatter.namedCurveSize.set("K-256", 32);
 AsnEcSignatureFormatter.namedCurveSize.set("P-384", 48);
 AsnEcSignatureFormatter.namedCurveSize.set("P-521", 66);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/fetch.js
+// node_modules/@simplewebauthn/server/esm/helpers/fetch.js
 function fetch2(url) {
   return _fetchInternals.stubThis(url);
 }
@@ -23517,7 +23517,7 @@ var _fetchInternals = {
   stubThis: (url) => globalThis.fetch(url)
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/isCertRevoked.js
+// node_modules/@simplewebauthn/server/esm/helpers/isCertRevoked.js
 var cacheRevokedCerts = {};
 async function isCertRevoked(cert) {
   const { extensions } = cert;
@@ -23589,7 +23589,7 @@ async function isCertRevoked(cert) {
   return false;
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/decodeAuthenticatorExtensions.js
+// node_modules/@simplewebauthn/server/esm/helpers/decodeAuthenticatorExtensions.js
 function decodeAuthenticatorExtensions(extensionData) {
   let toCBOR;
   try {
@@ -23612,7 +23612,7 @@ function convertMapToObjectDeep(input) {
   return mapped;
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/parseAuthenticatorData.js
+// node_modules/@simplewebauthn/server/esm/helpers/parseAuthenticatorData.js
 function parseAuthenticatorData(authData) {
   if (authData.byteLength < 37) {
     throw new Error(`Authenticator data was ${authData.byteLength} bytes, expected at least 37 bytes`);
@@ -23701,7 +23701,7 @@ var _parseAuthenticatorDataInternals = {
   stubThis: (value) => value
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/toHash.js
+// node_modules/@simplewebauthn/server/esm/helpers/toHash.js
 function toHash(data, algorithm = -7) {
   if (typeof data === "string") {
     data = isoUint8Array_exports.fromUTF8String(data);
@@ -23710,7 +23710,7 @@ function toHash(data, algorithm = -7) {
   return digest2;
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/validateCertificatePath.js
+// node_modules/@simplewebauthn/server/esm/helpers/validateCertificatePath.js
 async function validateCertificatePath(x5cCertsPEM, trustAnchorsPEM = []) {
   if (trustAnchorsPEM.length === 0) {
     return true;
@@ -23817,7 +23817,7 @@ var InvalidSubjectAndIssuer = class extends Error {
   }
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/mapX509SignatureAlgToCOSEAlg.js
+// node_modules/@simplewebauthn/server/esm/helpers/mapX509SignatureAlgToCOSEAlg.js
 function mapX509SignatureAlgToCOSEAlg(signatureAlgorithm) {
   let alg;
   if (signatureAlgorithm === "1.2.840.10045.4.3.2") {
@@ -23840,7 +23840,7 @@ function mapX509SignatureAlgToCOSEAlg(signatureAlgorithm) {
   return alg;
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/convertX509PublicKeyToCOSE.js
+// node_modules/@simplewebauthn/server/esm/helpers/convertX509PublicKeyToCOSE.js
 function convertX509PublicKeyToCOSE(x509Certificate) {
   let cosePublicKey = /* @__PURE__ */ new Map();
   const x509 = AsnParser.parse(x509Certificate, Certificate);
@@ -23894,7 +23894,7 @@ function convertX509PublicKeyToCOSE(x509Certificate) {
   return cosePublicKey;
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/verifySignature.js
+// node_modules/@simplewebauthn/server/esm/helpers/verifySignature.js
 function verifySignature(opts) {
   const { signature, data, credentialPublicKey, x509Certificate, hashAlgorithm } = opts;
   if (!x509Certificate && !credentialPublicKey) {
@@ -23920,7 +23920,7 @@ var _verifySignatureInternals = {
   stubThis: (value) => value
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/metadata/parseJWT.js
+// node_modules/@simplewebauthn/server/esm/metadata/parseJWT.js
 function parseJWT(jwt) {
   const parts = jwt.split(".");
   return [
@@ -23930,7 +23930,7 @@ function parseJWT(jwt) {
   ];
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/metadata/verifyJWT.js
+// node_modules/@simplewebauthn/server/esm/metadata/verifyJWT.js
 function verifyJWT(jwt, leafCert) {
   const [header, payload, signature] = jwt.split(".");
   const certCOSE = convertX509PublicKeyToCOSE(leafCert);
@@ -23954,13 +23954,13 @@ function verifyJWT(jwt, leafCert) {
   throw new Error(`JWT verification with public key of kty ${kty} is not supported by this method`);
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/convertPEMToBytes.js
+// node_modules/@simplewebauthn/server/esm/helpers/convertPEMToBytes.js
 function convertPEMToBytes(pem) {
   const certBase64 = pem.replace("-----BEGIN CERTIFICATE-----", "").replace("-----END CERTIFICATE-----", "").replace(/[\n ]/g, "");
   return isoBase64URL_exports.toBuffer(certBase64, "base64");
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/services/defaultRootCerts/android-safetynet.js
+// node_modules/@simplewebauthn/server/esm/services/defaultRootCerts/android-safetynet.js
 var GlobalSign_Root_CA = `-----BEGIN CERTIFICATE-----
 MIIDdTCCAl2gAwIBAgILBAAAAAABFUtaw5QwDQYJKoZIhvcNAQEFBQAwVzELMAkG
 A1UEBhMCQkUxGTAXBgNVBAoTEEdsb2JhbFNpZ24gbnYtc2ExEDAOBgNVBAsTB1Jv
@@ -23984,7 +23984,7 @@ HMUfpIBvFSDJ3gyICh3WZlXi/EjJKSZp4A==
 -----END CERTIFICATE-----
 `;
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/services/defaultRootCerts/android-key.js
+// node_modules/@simplewebauthn/server/esm/services/defaultRootCerts/android-key.js
 var Google_Hardware_Attestation_Root_1 = `-----BEGIN CERTIFICATE-----
 MIIFYDCCA0igAwIBAgIJAOj6GWMU0voYMA0GCSqGSIb3DQEBCwUAMBsxGTAXBgNV
 BAUTEGY5MjAwOWU4NTNiNmIwNDUwHhcNMTYwNTI2MTYyODUyWhcNMjYwNTI0MTYy
@@ -24113,7 +24113,7 @@ w1IdYIg2Wxg7yHcQZemFQg==
 -----END CERTIFICATE-----
 `;
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/services/defaultRootCerts/apple.js
+// node_modules/@simplewebauthn/server/esm/services/defaultRootCerts/apple.js
 var Apple_WebAuthn_Root_CA = `-----BEGIN CERTIFICATE-----
 MIICEjCCAZmgAwIBAgIQaB0BbHo84wIlpQGUKEdXcTAKBggqhkjOPQQDAzBLMR8w
 HQYDVQQDDBZBcHBsZSBXZWJBdXRobiBSb290IENBMRMwEQYDVQQKDApBcHBsZSBJ
@@ -24130,7 +24130,7 @@ jAGGiQIwHFj+dJZYUJR786osByBelJYsVZd2GbHQu209b5RCmGQ21gpSAk9QZW4B
 -----END CERTIFICATE-----
 `;
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/services/defaultRootCerts/mds.js
+// node_modules/@simplewebauthn/server/esm/services/defaultRootCerts/mds.js
 var GlobalSign_Root_CA_R3 = `-----BEGIN CERTIFICATE-----
 MIIDXzCCAkegAwIBAgILBAAAAAABIVhTCKIwDQYJKoZIhvcNAQELBQAwTDEgMB4G
 A1UECxMXR2xvYmFsU2lnbiBSb290IENBIC0gUjMxEzARBgNVBAoTCkdsb2JhbFNp
@@ -24154,7 +24154,7 @@ WD9f
 -----END CERTIFICATE-----
  `;
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/services/settingsService.js
+// node_modules/@simplewebauthn/server/esm/services/settingsService.js
 var BaseSettingsService = class {
   constructor() {
     Object.defineProperty(this, "pemCertificates", {
@@ -24205,7 +24205,7 @@ SettingsService.setRootCertificates({
   certificates: [GlobalSign_Root_CA_R3]
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/metadata/verifyMDSBlob.js
+// node_modules/@simplewebauthn/server/esm/metadata/verifyMDSBlob.js
 async function verifyMDSBlob(blob) {
   const parsedJWT = parseJWT(blob);
   const header = parsedJWT[0];
@@ -24245,7 +24245,7 @@ async function verifyMDSBlob(blob) {
   };
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/verifyOKP.js
+// node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/verifyOKP.js
 async function verifyOKP(opts) {
   const { cosePublicKey, signature, data } = opts;
   const WebCrypto = await getWebCrypto();
@@ -24291,7 +24291,7 @@ async function verifyOKP(opts) {
   return WebCrypto.subtle.verify(verifyAlgorithm, key, signature, data);
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/unwrapEC2Signature.js
+// node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/unwrapEC2Signature.js
 function unwrapEC2Signature(signature, crv) {
   const parsedSignature = AsnParser.parse(signature, ECDSASigValue);
   const rBytes = new Uint8Array(parsedSignature.r);
@@ -24332,7 +24332,7 @@ function toNormalizedBytes(bytes, componentLength) {
   return normalizedBytes;
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/verify.js
+// node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/verify.js
 function verify(opts) {
   const { cosePublicKey, signature, data, shaHashOverride } = opts;
   if (isCOSEPublicKeyEC2(cosePublicKey)) {
@@ -24356,7 +24356,7 @@ function verify(opts) {
   throw new Error(`Signature verification with public key of kty ${kty} is not supported by this method`);
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/iso/isoUint8Array.js
+// node_modules/@simplewebauthn/server/esm/helpers/iso/isoUint8Array.js
 var isoUint8Array_exports = {};
 __export(isoUint8Array_exports, {
   areEqual: () => areEqual,
@@ -24414,7 +24414,7 @@ function toDataView(array2) {
   return new DataView(array2.buffer, array2.byteOffset, array2.length);
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/generateChallenge.js
+// node_modules/@simplewebauthn/server/esm/helpers/generateChallenge.js
 async function generateChallenge() {
   const challenge = new Uint8Array(32);
   await isoCrypto_exports.getRandomValues(challenge);
@@ -24424,7 +24424,7 @@ var _generateChallengeInternals = {
   stubThis: (value) => value
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/registration/generateRegistrationOptions.js
+// node_modules/@simplewebauthn/server/esm/registration/generateRegistrationOptions.js
 var supportedCOSEAlgorithmIdentifiers = [
   // EdDSA (In first position to encourage authenticators to use this over ES256)
   -8,
@@ -24523,7 +24523,7 @@ async function generateRegistrationOptions(options) {
   };
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/parseBackupFlags.js
+// node_modules/@simplewebauthn/server/esm/helpers/parseBackupFlags.js
 function parseBackupFlags({ be, bs }) {
   const credentialBackedUp = bs;
   let credentialDeviceType = "singleDevice";
@@ -24542,7 +24542,7 @@ var InvalidBackupFlags = class extends Error {
   }
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/matchExpectedRPID.js
+// node_modules/@simplewebauthn/server/esm/helpers/matchExpectedRPID.js
 async function matchExpectedRPID(rpIDHash, expectedRPIDs) {
   try {
     const matchedRPID = await Promise.any(expectedRPIDs.map((expected) => {
@@ -24573,7 +24573,7 @@ var UnexpectedRPIDHash = class extends Error {
   }
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/registration/verifications/verifyAttestationFIDOU2F.js
+// node_modules/@simplewebauthn/server/esm/registration/verifications/verifyAttestationFIDOU2F.js
 async function verifyAttestationFIDOU2F(options) {
   const { attStmt, clientDataHash, rpIdHash, credentialID, credentialPublicKey, aaguid, rootCertificates } = options;
   const reservedByte = Uint8Array.from([0]);
@@ -24611,7 +24611,7 @@ async function verifyAttestationFIDOU2F(options) {
   });
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/validateExtFIDOGenCEAAGUID.js
+// node_modules/@simplewebauthn/server/esm/helpers/validateExtFIDOGenCEAAGUID.js
 var id_fido_gen_ce_aaguid = "1.3.6.1.4.1.45724.1.1.4";
 function validateExtFIDOGenCEAAGUID(certExtensions, aaguid) {
   if (!certExtensions) {
@@ -24632,13 +24632,13 @@ function validateExtFIDOGenCEAAGUID(certExtensions, aaguid) {
   return true;
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/logging.js
+// node_modules/@simplewebauthn/server/esm/helpers/logging.js
 function getLogger(_name) {
   return (_message, ..._rest) => {
   };
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/services/metadataService.js
+// node_modules/@simplewebauthn/server/esm/services/metadataService.js
 var NonRefreshingMDS = {
   url: "",
   no: 0,
@@ -24845,7 +24845,7 @@ var BaseMetadataService = class {
 };
 var MetadataService = new BaseMetadataService();
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/metadata/verifyAttestationWithMetadata.js
+// node_modules/@simplewebauthn/server/esm/metadata/verifyAttestationWithMetadata.js
 async function verifyAttestationWithMetadata({ statement, credentialPublicKey, x5c, attestationStatementAlg }) {
   const { authenticationAlgorithms, authenticatorGetInfo, attestationRootCertificates } = statement;
   const keypairCOSEAlgs = /* @__PURE__ */ new Set();
@@ -24941,7 +24941,7 @@ function stringifyCOSEInfo(info) {
   return toReturn;
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/registration/verifications/verifyAttestationPacked.js
+// node_modules/@simplewebauthn/server/esm/registration/verifications/verifyAttestationPacked.js
 async function verifyAttestationPacked(options) {
   const { attStmt, clientDataHash, authData, credentialPublicKey, aaguid, rootCertificates } = options;
   const sig = attStmt.get("sig");
@@ -25033,7 +25033,7 @@ async function verifyAttestationPacked(options) {
   return verified;
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/registration/verifications/verifyAttestationAndroidSafetyNet.js
+// node_modules/@simplewebauthn/server/esm/registration/verifications/verifyAttestationAndroidSafetyNet.js
 async function verifyAttestationAndroidSafetyNet(options) {
   const { attStmt, clientDataHash, authData, aaguid, rootCertificates, verifyTimestampMS = true, credentialPublicKey, attestationSafetyNetEnforceCTSCheck } = options;
   const alg = attStmt.get("alg");
@@ -25108,7 +25108,7 @@ async function verifyAttestationAndroidSafetyNet(options) {
   return verified;
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/registration/verifications/tpm/constants.js
+// node_modules/@simplewebauthn/server/esm/registration/verifications/tpm/constants.js
 var TPM_ST = {
   196: "TPM_ST_RSP_COMMAND",
   32768: "TPM_ST_NULL",
@@ -25226,7 +25226,7 @@ var TPM_ECC_CURVE_COSE_CRV_MAP = {
   // p256
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/registration/verifications/tpm/parseCertInfo.js
+// node_modules/@simplewebauthn/server/esm/registration/verifications/tpm/parseCertInfo.js
 function parseCertInfo(certInfo) {
   let pointer = 0;
   const dataView = isoUint8Array_exports.toDataView(certInfo);
@@ -25273,7 +25273,7 @@ function parseCertInfo(certInfo) {
   };
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/registration/verifications/tpm/parsePubArea.js
+// node_modules/@simplewebauthn/server/esm/registration/verifications/tpm/parsePubArea.js
 function parsePubArea(pubArea) {
   let pointer = 0;
   const dataView = isoUint8Array_exports.toDataView(pubArea);
@@ -25344,7 +25344,7 @@ function parsePubArea(pubArea) {
   };
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/registration/verifications/tpm/verifyAttestationTPM.js
+// node_modules/@simplewebauthn/server/esm/registration/verifications/tpm/verifyAttestationTPM.js
 async function verifyAttestationTPM(options) {
   const { aaguid, attStmt, authData, credentialPublicKey, clientDataHash, rootCertificates } = options;
   const ver = attStmt.get("ver");
@@ -25575,7 +25575,7 @@ function attestedNameAlgToCOSEAlg(alg) {
   throw new Error(`Unexpected TPM attested name alg ${alg}`);
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-android/build/es2015/key_description.js
+// node_modules/@peculiar/asn1-android/build/es2015/key_description.js
 var IntegerSet_1;
 var id_ce_keyDescription = "1.3.6.1.4.1.11129.2.1.17";
 var VerifiedBootState;
@@ -25864,7 +25864,7 @@ __decorate([
   AsnProp({ type: AuthorizationList })
 ], KeyMintKeyDescription.prototype, "hardwareEnforced", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-android/build/es2015/nonstandard.js
+// node_modules/@peculiar/asn1-android/build/es2015/nonstandard.js
 var NonStandardAuthorizationList_1;
 var NonStandardAuthorization = class NonStandardAuthorization2 extends AuthorizationList {
 };
@@ -25960,7 +25960,7 @@ NonStandardKeyMintKeyDescription = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence })
 ], NonStandardKeyMintKeyDescription);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-android/build/es2015/attestation.js
+// node_modules/@peculiar/asn1-android/build/es2015/attestation.js
 var AttestationPackageInfo = class {
   constructor(params = {}) {
     Object.assign(this, params);
@@ -25984,7 +25984,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.OctetString, repeated: "set" })
 ], AttestationApplicationId.prototype, "signatureDigests", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/registration/verifications/verifyAttestationAndroidKey.js
+// node_modules/@simplewebauthn/server/esm/registration/verifications/verifyAttestationAndroidKey.js
 async function verifyAttestationAndroidKey(options) {
   const { authData, clientDataHash, attStmt, credentialPublicKey, aaguid, rootCertificates } = options;
   const x5c = attStmt.get("x5c");
@@ -26058,7 +26058,7 @@ async function verifyAttestationAndroidKey(options) {
   });
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/registration/verifications/verifyAttestationApple.js
+// node_modules/@simplewebauthn/server/esm/registration/verifications/verifyAttestationApple.js
 async function verifyAttestationApple(options) {
   const { attStmt, authData, clientDataHash, credentialPublicKey, rootCertificates } = options;
   const x5c = attStmt.get("x5c");
@@ -26094,7 +26094,7 @@ async function verifyAttestationApple(options) {
   return true;
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/registration/verifyRegistrationResponse.js
+// node_modules/@simplewebauthn/server/esm/registration/verifyRegistrationResponse.js
 async function verifyRegistrationResponse(options) {
   const { response, expectedChallenge, expectedOrigin, expectedRPID, expectedType, requireUserPresence = true, requireUserVerification = true, supportedAlgorithmIDs = supportedCOSEAlgorithmIdentifiers, attestationSafetyNetEnforceCTSCheck = true } = options;
   const { id, rawId, type: credentialType, response: attestationResponse } = response;
@@ -26249,7 +26249,7 @@ async function verifyRegistrationResponse(options) {
   };
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/authentication/generateAuthenticationOptions.js
+// node_modules/@simplewebauthn/server/esm/authentication/generateAuthenticationOptions.js
 async function generateAuthenticationOptions(options) {
   const { allowCredentials, challenge = await generateChallenge(), timeout = 6e4, userVerification = "preferred", extensions, rpID } = options;
   let _challenge = challenge;
@@ -26275,7 +26275,7 @@ async function generateAuthenticationOptions(options) {
   };
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/authentication/verifyAuthenticationResponse.js
+// node_modules/@simplewebauthn/server/esm/authentication/verifyAuthenticationResponse.js
 async function verifyAuthenticationResponse(options) {
   const { response, expectedChallenge, expectedOrigin, expectedRPID, expectedType, credential, requireUserVerification = true, advancedFIDOConfig } = options;
   const { id, rawId, type: credentialType, response: assertionResponse } = response;
@@ -41996,7 +41996,7 @@ function errorMessage(error2) {
   return normalizeText31(error2) || "unknown error";
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v3/helpers/util.js
+// node_modules/zod/v3/helpers/util.js
 var util;
 (function(util2) {
   util2.assertEqual = (_) => {
@@ -42130,7 +42130,7 @@ var getParsedType = (data) => {
   }
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v3/ZodError.js
+// node_modules/zod/v3/ZodError.js
 var ZodIssueCode = util.arrayToEnum([
   "invalid_type",
   "invalid_literal",
@@ -42244,7 +42244,7 @@ ZodError.create = (issues) => {
   return error2;
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v3/locales/en.js
+// node_modules/zod/v3/locales/en.js
 var errorMap = (issue2, _ctx) => {
   let message;
   switch (issue2.code) {
@@ -42347,13 +42347,13 @@ var errorMap = (issue2, _ctx) => {
 };
 var en_default = errorMap;
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v3/errors.js
+// node_modules/zod/v3/errors.js
 var overrideErrorMap = en_default;
 function getErrorMap() {
   return overrideErrorMap;
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v3/helpers/parseUtil.js
+// node_modules/zod/v3/helpers/parseUtil.js
 var makeIssue = (params) => {
   const { data, path, errorMaps, issueData } = params;
   const fullPath = [...path, ...issueData.path || []];
@@ -42462,14 +42462,14 @@ var isDirty = (x) => x.status === "dirty";
 var isValid = (x) => x.status === "valid";
 var isAsync = (x) => typeof Promise !== "undefined" && x instanceof Promise;
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v3/helpers/errorUtil.js
+// node_modules/zod/v3/helpers/errorUtil.js
 var errorUtil;
 (function(errorUtil2) {
   errorUtil2.errToObj = (message) => typeof message === "string" ? { message } : message || {};
   errorUtil2.toString = (message) => typeof message === "string" ? message : message?.message;
 })(errorUtil || (errorUtil = {}));
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v3/types.js
+// node_modules/zod/v3/types.js
 var ParseInputLazyPath = class {
   constructor(parent, value, path, key) {
     this._cachedPath = [];
@@ -45873,7 +45873,7 @@ var nullableType = ZodNullable.create;
 var preprocessType = ZodEffects.createWithPreprocess;
 var pipelineType = ZodPipeline.create;
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v4/core/core.js
+// node_modules/zod/v4/core/core.js
 var _a3;
 // @__NO_SIDE_EFFECTS__
 function $constructor(name, initializer3, params) {
@@ -45947,7 +45947,7 @@ function config(newConfig) {
   return globalConfig;
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v4/core/util.js
+// node_modules/zod/v4/core/util.js
 var util_exports = {};
 __export(util_exports, {
   BIGINT_FORMAT_RANGES: () => BIGINT_FORMAT_RANGES,
@@ -46643,7 +46643,7 @@ var Class = class {
   }
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v4/core/errors.js
+// node_modules/zod/v4/core/errors.js
 var initializer = (inst, def) => {
   inst.name = "$ZodError";
   Object.defineProperty(inst, "_zod", {
@@ -46712,7 +46712,7 @@ function formatError(error2, mapper = (issue2) => issue2.message) {
   return fieldErrors;
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v4/core/parse.js
+// node_modules/zod/v4/core/parse.js
 var _parse = (_Err) => (schema, value, _ctx, _params) => {
   const ctx = _ctx ? { ..._ctx, async: false } : { async: false };
   const result = schema._zod.run({ value, issues: [] }, ctx);
@@ -46792,7 +46792,7 @@ var _safeDecodeAsync = (_Err) => async (schema, value, _ctx) => {
   return _safeParseAsync(_Err)(schema, value, _ctx);
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v4/core/regexes.js
+// node_modules/zod/v4/core/regexes.js
 var cuid = /^[cC][0-9a-z]{6,}$/;
 var cuid2 = /^[0-9a-z]+$/;
 var ulid = /^[0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{26}$/;
@@ -46850,7 +46850,7 @@ var _null = /^null$/i;
 var lowercase = /^[^A-Z]*$/;
 var uppercase = /^[^a-z]*$/;
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v4/core/checks.js
+// node_modules/zod/v4/core/checks.js
 var $ZodCheck = /* @__PURE__ */ $constructor("$ZodCheck", (inst, def) => {
   var _a5;
   inst._zod ?? (inst._zod = {});
@@ -47240,7 +47240,7 @@ var $ZodCheckOverwrite = /* @__PURE__ */ $constructor("$ZodCheckOverwrite", (ins
   };
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v4/core/doc.js
+// node_modules/zod/v4/core/doc.js
 var Doc = class {
   constructor(args = []) {
     this.content = [];
@@ -47276,14 +47276,14 @@ var Doc = class {
   }
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v4/core/versions.js
+// node_modules/zod/v4/core/versions.js
 var version = {
   major: 4,
   minor: 4,
   patch: 3
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v4/core/schemas.js
+// node_modules/zod/v4/core/schemas.js
 var $ZodType = /* @__PURE__ */ $constructor("$ZodType", (inst, def) => {
   var _a5;
   inst ?? (inst = {});
@@ -48763,7 +48763,7 @@ function handleRefineResult(result, payload, input, inst) {
   }
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v4/locales/en.js
+// node_modules/zod/v4/locales/en.js
 var error = () => {
   const Sizable = {
     string: { unit: "characters", verb: "to have" },
@@ -48876,7 +48876,7 @@ function en_default2() {
   };
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v4/core/registries.js
+// node_modules/zod/v4/core/registries.js
 var _a4;
 var $output = Symbol("ZodOutput");
 var $input = Symbol("ZodInput");
@@ -48926,7 +48926,7 @@ function registry() {
 (_a4 = globalThis).__zod_globalRegistry ?? (_a4.__zod_globalRegistry = registry());
 var globalRegistry = globalThis.__zod_globalRegistry;
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v4/core/api.js
+// node_modules/zod/v4/core/api.js
 // @__NO_SIDE_EFFECTS__
 function _string(Class2, params) {
   return new Class2({
@@ -49454,7 +49454,7 @@ function _check(fn, params) {
   return ch;
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v4/core/to-json-schema.js
+// node_modules/zod/v4/core/to-json-schema.js
 function initializeContext(params) {
   let target = params?.target ?? "draft-2020-12";
   if (target === "draft-4")
@@ -49813,7 +49813,7 @@ var createStandardJSONSchemaMethod = (schema, io, processors = {}) => (params) =
   return finalize(ctx, schema);
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v4/core/json-schema-processors.js
+// node_modules/zod/v4/core/json-schema-processors.js
 var formatMap = {
   guid: "uuid",
   url: "uri",
@@ -50357,7 +50357,7 @@ function toJSONSchema(input, params) {
   return finalize(ctx, input);
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v4/mini/schemas.js
+// node_modules/zod/v4/mini/schemas.js
 var ZodMiniType = /* @__PURE__ */ $constructor("ZodMiniType", (inst, def) => {
   if (!inst._zod)
     throw new Error("Uninitialized schema in ZodMiniType.");
@@ -50403,7 +50403,7 @@ function object(shape, params) {
   return new ZodMiniObject(def);
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@modelcontextprotocol/sdk/dist/esm/server/zod-compat.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/server/zod-compat.js
 function isZ4Schema(s) {
   const schema = s;
   return !!schema._zod;
@@ -50547,7 +50547,7 @@ function getLiteralValue(schema) {
   return void 0;
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v4/classic/iso.js
+// node_modules/zod/v4/classic/iso.js
 var iso_exports2 = {};
 __export(iso_exports2, {
   ZodISODate: () => ZodISODate,
@@ -50588,7 +50588,7 @@ function duration2(params) {
   return _isoDuration(ZodISODuration, params);
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v4/classic/errors.js
+// node_modules/zod/v4/classic/errors.js
 var initializer2 = (inst, issues) => {
   $ZodError.init(inst, issues);
   inst.name = "ZodError";
@@ -50627,7 +50627,7 @@ var ZodRealError = /* @__PURE__ */ $constructor("ZodError", initializer2, {
   Parent: Error
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v4/classic/parse.js
+// node_modules/zod/v4/classic/parse.js
 var parse2 = /* @__PURE__ */ _parse(ZodRealError);
 var parseAsync2 = /* @__PURE__ */ _parseAsync(ZodRealError);
 var safeParse4 = /* @__PURE__ */ _safeParse(ZodRealError);
@@ -50641,7 +50641,7 @@ var safeDecode2 = /* @__PURE__ */ _safeDecode(ZodRealError);
 var safeEncodeAsync2 = /* @__PURE__ */ _safeEncodeAsync(ZodRealError);
 var safeDecodeAsync2 = /* @__PURE__ */ _safeDecodeAsync(ZodRealError);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v4/classic/schemas.js
+// node_modules/zod/v4/classic/schemas.js
 var _installedGroups = /* @__PURE__ */ new WeakMap();
 function _installLazyMethods(inst, group, methods) {
   const proto = Object.getPrototypeOf(inst);
@@ -51483,10 +51483,10 @@ function preprocess(fn, schema) {
   });
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v4/classic/external.js
+// node_modules/zod/v4/classic/external.js
 config(en_default2());
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@modelcontextprotocol/sdk/dist/esm/types.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/types.js
 var LATEST_PROTOCOL_VERSION = "2025-11-25";
 var DEFAULT_NEGOTIATED_PROTOCOL_VERSION = "2025-03-26";
 var SUPPORTED_PROTOCOL_VERSIONS = [LATEST_PROTOCOL_VERSION, "2025-06-18", "2025-03-26", "2024-11-05", "2024-10-07"];
@@ -53019,12 +53019,12 @@ var UrlElicitationRequiredError = class extends McpError {
   }
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@modelcontextprotocol/sdk/dist/esm/experimental/tasks/interfaces.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/experimental/tasks/interfaces.js
 function isTerminal(status) {
   return status === "completed" || status === "failed" || status === "cancelled";
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/Options.js
+// node_modules/zod-to-json-schema/dist/esm/Options.js
 var ignoreOverride = Symbol("Let zodToJsonSchema decide on which parser to use");
 var defaultOptions = {
   name: void 0,
@@ -53058,7 +53058,7 @@ var getDefaultOptions = (options) => typeof options === "string" ? {
   ...options
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/Refs.js
+// node_modules/zod-to-json-schema/dist/esm/Refs.js
 var getRefs = (options) => {
   const _options = getDefaultOptions(options);
   const currentPath = _options.name !== void 0 ? [..._options.basePath, _options.definitionPath, _options.name] : _options.basePath;
@@ -53079,7 +53079,7 @@ var getRefs = (options) => {
   };
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/errorMessages.js
+// node_modules/zod-to-json-schema/dist/esm/errorMessages.js
 function addErrorMessage(res, key, errorMessage2, refs) {
   if (!refs?.errorMessages)
     return;
@@ -53095,7 +53095,7 @@ function setResponseValueAndErrors(res, key, value, errorMessage2, refs) {
   addErrorMessage(res, key, errorMessage2, refs);
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/getRelativePath.js
+// node_modules/zod-to-json-schema/dist/esm/getRelativePath.js
 var getRelativePath = (pathA, pathB) => {
   let i = 0;
   for (; i < pathA.length && i < pathB.length; i++) {
@@ -53105,7 +53105,7 @@ var getRelativePath = (pathA, pathB) => {
   return [(pathA.length - i).toString(), ...pathB.slice(i)].join("/");
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/any.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/any.js
 function parseAnyDef(refs) {
   if (refs.target !== "openAi") {
     return {};
@@ -53121,7 +53121,7 @@ function parseAnyDef(refs) {
   };
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/array.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/array.js
 function parseArrayDef(def, refs) {
   const res = {
     type: "array"
@@ -53145,7 +53145,7 @@ function parseArrayDef(def, refs) {
   return res;
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/bigint.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/bigint.js
 function parseBigintDef(def, refs) {
   const res = {
     type: "integer",
@@ -53191,24 +53191,24 @@ function parseBigintDef(def, refs) {
   return res;
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/boolean.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/boolean.js
 function parseBooleanDef() {
   return {
     type: "boolean"
   };
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/branded.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/branded.js
 function parseBrandedDef(_def, refs) {
   return parseDef(_def.type._def, refs);
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/catch.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/catch.js
 var parseCatchDef = (def, refs) => {
   return parseDef(def.innerType._def, refs);
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/date.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/date.js
 function parseDateDef(def, refs, overrideDateStrategy) {
   const strategy = overrideDateStrategy ?? refs.dateStrategy;
   if (Array.isArray(strategy)) {
@@ -53267,7 +53267,7 @@ var integerDateParser = (def, refs) => {
   return res;
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/default.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/default.js
 function parseDefaultDef(_def, refs) {
   return {
     ...parseDef(_def.innerType._def, refs),
@@ -53275,12 +53275,12 @@ function parseDefaultDef(_def, refs) {
   };
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/effects.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/effects.js
 function parseEffectsDef(_def, refs) {
   return refs.effectStrategy === "input" ? parseDef(_def.schema._def, refs) : parseAnyDef(refs);
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/enum.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/enum.js
 function parseEnumDef(def) {
   return {
     type: "string",
@@ -53288,7 +53288,7 @@ function parseEnumDef(def) {
   };
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/intersection.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/intersection.js
 var isJsonSchema7AllOfType = (type) => {
   if ("type" in type && type.type === "string")
     return false;
@@ -53330,7 +53330,7 @@ function parseIntersectionDef(def, refs) {
   } : void 0;
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/literal.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/literal.js
 function parseLiteralDef(def, refs) {
   const parsedType2 = typeof def.value;
   if (parsedType2 !== "bigint" && parsedType2 !== "number" && parsedType2 !== "boolean" && parsedType2 !== "string") {
@@ -53350,7 +53350,7 @@ function parseLiteralDef(def, refs) {
   };
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/string.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/string.js
 var emojiRegex2 = void 0;
 var zodPatterns = {
   /**
@@ -53675,7 +53675,7 @@ function stringifyRegExpWithFlags(regex, refs) {
   return pattern;
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/record.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/record.js
 function parseRecordDef(def, refs) {
   if (refs.target === "openAi") {
     console.warn("Warning: OpenAI may not support records in schemas! Try an array of key-value pairs instead.");
@@ -53727,7 +53727,7 @@ function parseRecordDef(def, refs) {
   return schema;
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/map.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/map.js
 function parseMapDef(def, refs) {
   if (refs.mapStrategy === "record") {
     return parseRecordDef(def, refs);
@@ -53752,7 +53752,7 @@ function parseMapDef(def, refs) {
   };
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/nativeEnum.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/nativeEnum.js
 function parseNativeEnumDef(def) {
   const object3 = def.values;
   const actualKeys = Object.keys(def.values).filter((key) => {
@@ -53766,7 +53766,7 @@ function parseNativeEnumDef(def) {
   };
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/never.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/never.js
 function parseNeverDef(refs) {
   return refs.target === "openAi" ? void 0 : {
     not: parseAnyDef({
@@ -53776,7 +53776,7 @@ function parseNeverDef(refs) {
   };
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/null.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/null.js
 function parseNullDef(refs) {
   return refs.target === "openApi3" ? {
     enum: ["null"],
@@ -53786,7 +53786,7 @@ function parseNullDef(refs) {
   };
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/union.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/union.js
 var primitiveMappings = {
   ZodString: "string",
   ZodNumber: "number",
@@ -53854,7 +53854,7 @@ var asAnyOf = (def, refs) => {
   return anyOf.length ? { anyOf } : void 0;
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/nullable.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/nullable.js
 function parseNullableDef(def, refs) {
   if (["ZodString", "ZodNumber", "ZodBigInt", "ZodBoolean", "ZodNull"].includes(def.innerType._def.typeName) && (!def.innerType._def.checks || !def.innerType._def.checks.length)) {
     if (refs.target === "openApi3") {
@@ -53886,7 +53886,7 @@ function parseNullableDef(def, refs) {
   return base && { anyOf: [base, { type: "null" }] };
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/number.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/number.js
 function parseNumberDef(def, refs) {
   const res = {
     type: "number"
@@ -53935,7 +53935,7 @@ function parseNumberDef(def, refs) {
   return res;
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/object.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/object.js
 function parseObjectDef(def, refs) {
   const forceOptionalIntoNullable = refs.target === "openAi";
   const result = {
@@ -54005,7 +54005,7 @@ function safeIsOptional(schema) {
   }
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/optional.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/optional.js
 var parseOptionalDef = (def, refs) => {
   if (refs.currentPath.toString() === refs.propertyPath?.toString()) {
     return parseDef(def.innerType._def, refs);
@@ -54024,7 +54024,7 @@ var parseOptionalDef = (def, refs) => {
   } : parseAnyDef(refs);
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/pipeline.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/pipeline.js
 var parsePipelineDef = (def, refs) => {
   if (refs.pipeStrategy === "input") {
     return parseDef(def.in._def, refs);
@@ -54044,12 +54044,12 @@ var parsePipelineDef = (def, refs) => {
   };
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/promise.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/promise.js
 function parsePromiseDef(def, refs) {
   return parseDef(def.type._def, refs);
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/set.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/set.js
 function parseSetDef(def, refs) {
   const items = parseDef(def.valueType._def, {
     ...refs,
@@ -54069,7 +54069,7 @@ function parseSetDef(def, refs) {
   return schema;
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/tuple.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/tuple.js
 function parseTupleDef(def, refs) {
   if (def.rest) {
     return {
@@ -54097,24 +54097,24 @@ function parseTupleDef(def, refs) {
   }
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/undefined.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/undefined.js
 function parseUndefinedDef(refs) {
   return {
     not: parseAnyDef(refs)
   };
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/unknown.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/unknown.js
 function parseUnknownDef(refs) {
   return parseAnyDef(refs);
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/readonly.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/readonly.js
 var parseReadonlyDef = (def, refs) => {
   return parseDef(def.innerType._def, refs);
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/selectParser.js
+// node_modules/zod-to-json-schema/dist/esm/selectParser.js
 var selectParser = (def, typeName, refs) => {
   switch (typeName) {
     case ZodFirstPartyTypeKind.ZodString:
@@ -54190,7 +54190,7 @@ var selectParser = (def, typeName, refs) => {
   }
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parseDef.js
+// node_modules/zod-to-json-schema/dist/esm/parseDef.js
 function parseDef(def, refs, forceResolution = false) {
   const seenItem = refs.seen.get(def);
   if (refs.override) {
@@ -54246,7 +54246,7 @@ var addMeta = (def, refs, jsonSchema) => {
   return jsonSchema;
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/zodToJsonSchema.js
+// node_modules/zod-to-json-schema/dist/esm/zodToJsonSchema.js
 var zodToJsonSchema = (schema, options) => {
   const refs = getRefs(options);
   let definitions = typeof options === "object" && options.definitions ? Object.entries(options.definitions).reduce((acc, [name2, schema2]) => ({
@@ -54308,7 +54308,7 @@ var zodToJsonSchema = (schema, options) => {
   return combined;
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@modelcontextprotocol/sdk/dist/esm/server/zod-json-schema-compat.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/server/zod-json-schema-compat.js
 function mapMiniTarget(t) {
   if (!t)
     return "draft-7";
@@ -54350,7 +54350,7 @@ function parseWithCompat(schema, data) {
   return result.data;
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@modelcontextprotocol/sdk/dist/esm/shared/protocol.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/shared/protocol.js
 var DEFAULT_REQUEST_TIMEOUT_MSEC = 6e4;
 var Protocol = class {
   constructor(_options) {
@@ -55304,7 +55304,7 @@ function mergeCapabilities(base, additional) {
   return result;
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@modelcontextprotocol/sdk/dist/esm/validation/ajv-provider.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/validation/ajv-provider.js
 var import_ajv = __toESM(require_ajv(), 1);
 var import_ajv_formats = __toESM(require_dist(), 1);
 function createDefaultAjvInstance() {
@@ -55372,7 +55372,7 @@ var AjvJsonSchemaValidator = class {
   }
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@modelcontextprotocol/sdk/dist/esm/experimental/tasks/server.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/experimental/tasks/server.js
 var ExperimentalServerTasks = class {
   constructor(_server) {
     this._server = _server;
@@ -55585,7 +55585,7 @@ var ExperimentalServerTasks = class {
   }
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@modelcontextprotocol/sdk/dist/esm/experimental/tasks/helpers.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/experimental/tasks/helpers.js
 function assertToolsCallTaskCapability(requests, method, entityName) {
   if (!requests) {
     throw new Error(`${entityName} does not support task creation (required for ${method})`);
@@ -55620,7 +55620,7 @@ function assertClientRequestTaskCapability(requests, method, entityName) {
   }
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@modelcontextprotocol/sdk/dist/esm/server/index.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/server/index.js
 var Server = class extends Protocol {
   /**
    * Initializes this server with the given name and version information.
@@ -56000,7 +56000,7 @@ var Server = class extends Protocol {
   }
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@modelcontextprotocol/sdk/dist/esm/server/completable.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/server/completable.js
 var COMPLETABLE_SYMBOL = Symbol.for("mcp.completable");
 function isCompletable(schema) {
   return !!schema && typeof schema === "object" && COMPLETABLE_SYMBOL in schema;
@@ -56014,7 +56014,7 @@ var McpZodTypeKind;
   McpZodTypeKind2["Completable"] = "McpCompletable";
 })(McpZodTypeKind || (McpZodTypeKind = {}));
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@modelcontextprotocol/sdk/dist/esm/shared/toolNameValidation.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/shared/toolNameValidation.js
 var TOOL_NAME_REGEX = /^[A-Za-z0-9._-]{1,128}$/;
 function validateToolName(name) {
   const warnings = [];
@@ -56072,7 +56072,7 @@ function validateAndWarnToolName(name) {
   return result.isValid;
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@modelcontextprotocol/sdk/dist/esm/experimental/tasks/mcp-server.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/experimental/tasks/mcp-server.js
 var ExperimentalMcpServerTasks = class {
   constructor(_mcpServer) {
     this._mcpServer = _mcpServer;
@@ -56087,7 +56087,7 @@ var ExperimentalMcpServerTasks = class {
   }
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@modelcontextprotocol/sdk/dist/esm/server/mcp.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/server/mcp.js
 var McpServer = class {
   constructor(serverInfo, options) {
     this._registeredResources = {};
@@ -56879,7 +56879,7 @@ var EMPTY_COMPLETION_RESULT = {
   }
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@modelcontextprotocol/sdk/dist/esm/server/webStandardStreamableHttp.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/server/webStandardStreamableHttp.js
 var WebStandardStreamableHTTPServerTransport = class {
   constructor(options = {}) {
     this._started = false;

--- a/worker.js
+++ b/worker.js
@@ -40,9 +40,9 @@ var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__ge
   mod
 ));
 
-// node_modules/pvtsutils/build/index.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/pvtsutils/build/index.js
 var require_build = __commonJS({
-  "node_modules/pvtsutils/build/index.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/pvtsutils/build/index.js"(exports) {
     "use strict";
     var ARRAY_BUFFER_NAME = "[object ArrayBuffer]";
     var BufferSourceConverter6 = class _BufferSourceConverter {
@@ -404,9 +404,9 @@ var require_build = __commonJS({
   }
 });
 
-// node_modules/reflect-metadata/Reflect.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/reflect-metadata/Reflect.js
 var require_Reflect = __commonJS({
-  "node_modules/reflect-metadata/Reflect.js"() {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/reflect-metadata/Reflect.js"() {
     var Reflect2;
     (function(Reflect3) {
       (function(factory) {
@@ -1495,9 +1495,9 @@ var require_crypto = __commonJS({
   }
 });
 
-// node_modules/tweetnacl/nacl-fast.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tweetnacl/nacl-fast.js
 var require_nacl_fast = __commonJS({
-  "node_modules/tweetnacl/nacl-fast.js"(exports, module) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tweetnacl/nacl-fast.js"(exports, module) {
     (function(nacl5) {
       "use strict";
       var gf = function(init) {
@@ -3719,18 +3719,18 @@ var require_nacl_fast = __commonJS({
   }
 });
 
-// node_modules/tweetnacl-sealedbox-js/src/consts.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tweetnacl-sealedbox-js/src/consts.js
 var import_tweetnacl, overheadLength;
 var init_consts = __esm({
-  "node_modules/tweetnacl-sealedbox-js/src/consts.js"() {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tweetnacl-sealedbox-js/src/consts.js"() {
     import_tweetnacl = __toESM(require_nacl_fast());
     overheadLength = import_tweetnacl.default.box.publicKeyLength + import_tweetnacl.default.box.overheadLength;
   }
 });
 
-// node_modules/blakejs/util.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/blakejs/util.js
 var require_util = __commonJS({
-  "node_modules/blakejs/util.js"(exports, module) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/blakejs/util.js"(exports, module) {
     var ERROR_MSG_INPUT = "Input must be an string, Buffer or Uint8Array";
     function normalizeInput(input) {
       let ret;
@@ -3800,9 +3800,9 @@ var require_util = __commonJS({
   }
 });
 
-// node_modules/blakejs/blake2b.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/blakejs/blake2b.js
 var require_blake2b = __commonJS({
-  "node_modules/blakejs/blake2b.js"(exports, module) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/blakejs/blake2b.js"(exports, module) {
     var util2 = require_util();
     function ADD64AA(v2, a, b) {
       const o0 = v2[a] + v2[b];
@@ -4274,7 +4274,7 @@ var require_blake2b = __commonJS({
   }
 });
 
-// node_modules/tweetnacl-sealedbox-js/src/nonce.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tweetnacl-sealedbox-js/src/nonce.js
 function nonce(pk1, pk2) {
   var state = import_blake2b.default.blake2bInit(import_tweetnacl2.default.box.nonceLength, null);
   import_blake2b.default.blake2bUpdate(state, pk1);
@@ -4283,24 +4283,24 @@ function nonce(pk1, pk2) {
 }
 var import_tweetnacl2, import_blake2b;
 var init_nonce = __esm({
-  "node_modules/tweetnacl-sealedbox-js/src/nonce.js"() {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tweetnacl-sealedbox-js/src/nonce.js"() {
     import_tweetnacl2 = __toESM(require_nacl_fast());
     import_blake2b = __toESM(require_blake2b());
   }
 });
 
-// node_modules/tweetnacl-sealedbox-js/src/utils.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tweetnacl-sealedbox-js/src/utils.js
 function zero(buf) {
   for (var i = 0; i < buf.length; i++) {
     buf[i] = 0;
   }
 }
 var init_utils = __esm({
-  "node_modules/tweetnacl-sealedbox-js/src/utils.js"() {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tweetnacl-sealedbox-js/src/utils.js"() {
   }
 });
 
-// node_modules/tweetnacl-sealedbox-js/src/seal.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tweetnacl-sealedbox-js/src/seal.js
 function seal(m, pk) {
   var c = new Uint8Array(overheadLength + m.length);
   var ek = import_tweetnacl3.default.box.keyPair();
@@ -4313,7 +4313,7 @@ function seal(m, pk) {
 }
 var import_tweetnacl3;
 var init_seal = __esm({
-  "node_modules/tweetnacl-sealedbox-js/src/seal.js"() {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tweetnacl-sealedbox-js/src/seal.js"() {
     import_tweetnacl3 = __toESM(require_nacl_fast());
     init_nonce();
     init_consts();
@@ -4321,7 +4321,7 @@ var init_seal = __esm({
   }
 });
 
-// node_modules/tweetnacl-sealedbox-js/src/open.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tweetnacl-sealedbox-js/src/open.js
 function open(c, pk, sk) {
   var epk = c.subarray(0, import_tweetnacl4.default.box.publicKeyLength);
   var nonce2 = nonce(epk, pk);
@@ -4330,13 +4330,13 @@ function open(c, pk, sk) {
 }
 var import_tweetnacl4;
 var init_open = __esm({
-  "node_modules/tweetnacl-sealedbox-js/src/open.js"() {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tweetnacl-sealedbox-js/src/open.js"() {
     import_tweetnacl4 = __toESM(require_nacl_fast());
     init_nonce();
   }
 });
 
-// node_modules/tweetnacl-sealedbox-js/entrypoint.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tweetnacl-sealedbox-js/entrypoint.js
 var entrypoint_exports = {};
 __export(entrypoint_exports, {
   default: () => entrypoint_default,
@@ -4346,7 +4346,7 @@ __export(entrypoint_exports, {
 });
 var entrypoint_default;
 var init_entrypoint = __esm({
-  "node_modules/tweetnacl-sealedbox-js/entrypoint.js"() {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tweetnacl-sealedbox-js/entrypoint.js"() {
     init_consts();
     init_seal();
     init_open();
@@ -4354,9 +4354,9 @@ var init_entrypoint = __esm({
   }
 });
 
-// node_modules/ajv/dist/compile/codegen/code.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/codegen/code.js
 var require_code = __commonJS({
-  "node_modules/ajv/dist/compile/codegen/code.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/codegen/code.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.regexpCode = exports.getEsmExportName = exports.getProperty = exports.safeStringify = exports.stringify = exports.strConcat = exports.addCodeArg = exports.str = exports._ = exports.nil = exports._Code = exports.Name = exports.IDENTIFIER = exports._CodeOrName = void 0;
@@ -4508,9 +4508,9 @@ var require_code = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/compile/codegen/scope.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/codegen/scope.js
 var require_scope = __commonJS({
-  "node_modules/ajv/dist/compile/codegen/scope.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/codegen/scope.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.ValueScope = exports.ValueScopeName = exports.Scope = exports.varKinds = exports.UsedValueState = void 0;
@@ -4653,9 +4653,9 @@ var require_scope = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/compile/codegen/index.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/codegen/index.js
 var require_codegen = __commonJS({
-  "node_modules/ajv/dist/compile/codegen/index.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/codegen/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.or = exports.and = exports.not = exports.CodeGen = exports.operators = exports.varKinds = exports.ValueScopeName = exports.ValueScope = exports.Scope = exports.Name = exports.regexpCode = exports.stringify = exports.getProperty = exports.nil = exports.strConcat = exports.str = exports._ = void 0;
@@ -5373,9 +5373,9 @@ var require_codegen = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/compile/util.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/util.js
 var require_util2 = __commonJS({
-  "node_modules/ajv/dist/compile/util.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/util.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.checkStrictMode = exports.getErrorPath = exports.Type = exports.useFunc = exports.setEvaluated = exports.evaluatedPropsToName = exports.mergeEvaluated = exports.eachItem = exports.unescapeJsonPointer = exports.escapeJsonPointer = exports.escapeFragment = exports.unescapeFragment = exports.schemaRefOrVal = exports.schemaHasRulesButRef = exports.schemaHasRules = exports.checkUnknownRules = exports.alwaysValidSchema = exports.toHash = void 0;
@@ -5540,9 +5540,9 @@ var require_util2 = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/compile/names.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/names.js
 var require_names = __commonJS({
-  "node_modules/ajv/dist/compile/names.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/names.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -5579,9 +5579,9 @@ var require_names = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/compile/errors.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/errors.js
 var require_errors = __commonJS({
-  "node_modules/ajv/dist/compile/errors.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/errors.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.extendErrors = exports.resetErrorsCount = exports.reportExtraError = exports.reportError = exports.keyword$DataError = exports.keywordError = void 0;
@@ -5701,9 +5701,9 @@ var require_errors = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/compile/validate/boolSchema.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/validate/boolSchema.js
 var require_boolSchema = __commonJS({
-  "node_modules/ajv/dist/compile/validate/boolSchema.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/validate/boolSchema.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.boolOrEmptySchema = exports.topBoolOrEmptySchema = void 0;
@@ -5752,9 +5752,9 @@ var require_boolSchema = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/compile/rules.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/rules.js
 var require_rules = __commonJS({
-  "node_modules/ajv/dist/compile/rules.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/rules.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.getRules = exports.isJSONType = void 0;
@@ -5783,9 +5783,9 @@ var require_rules = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/compile/validate/applicability.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/validate/applicability.js
 var require_applicability = __commonJS({
-  "node_modules/ajv/dist/compile/validate/applicability.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/validate/applicability.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.shouldUseRule = exports.shouldUseGroup = exports.schemaHasRulesForType = void 0;
@@ -5806,9 +5806,9 @@ var require_applicability = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/compile/validate/dataType.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/validate/dataType.js
 var require_dataType = __commonJS({
-  "node_modules/ajv/dist/compile/validate/dataType.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/validate/dataType.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.reportTypeError = exports.checkDataTypes = exports.checkDataType = exports.coerceAndCheckDataType = exports.getJSONTypes = exports.getSchemaTypes = exports.DataType = void 0;
@@ -5990,9 +5990,9 @@ var require_dataType = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/compile/validate/defaults.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/validate/defaults.js
 var require_defaults = __commonJS({
-  "node_modules/ajv/dist/compile/validate/defaults.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/validate/defaults.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.assignDefaults = void 0;
@@ -6027,9 +6027,9 @@ var require_defaults = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/vocabularies/code.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/code.js
 var require_code2 = __commonJS({
-  "node_modules/ajv/dist/vocabularies/code.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/code.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.validateUnion = exports.validateArray = exports.usePattern = exports.callValidateCode = exports.schemaProperties = exports.allSchemaProperties = exports.noPropertyInData = exports.propertyInData = exports.isOwnProperty = exports.hasPropFunc = exports.reportMissingProp = exports.checkMissingProp = exports.checkReportMissingProp = void 0;
@@ -6160,9 +6160,9 @@ var require_code2 = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/compile/validate/keyword.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/validate/keyword.js
 var require_keyword = __commonJS({
-  "node_modules/ajv/dist/compile/validate/keyword.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/validate/keyword.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.validateKeywordUsage = exports.validSchemaType = exports.funcKeywordCode = exports.macroKeywordCode = void 0;
@@ -6278,9 +6278,9 @@ var require_keyword = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/compile/validate/subschema.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/validate/subschema.js
 var require_subschema = __commonJS({
-  "node_modules/ajv/dist/compile/validate/subschema.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/validate/subschema.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.extendSubschemaMode = exports.extendSubschemaData = exports.getSubschema = void 0;
@@ -6361,9 +6361,9 @@ var require_subschema = __commonJS({
   }
 });
 
-// node_modules/fast-deep-equal/index.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/fast-deep-equal/index.js
 var require_fast_deep_equal = __commonJS({
-  "node_modules/fast-deep-equal/index.js"(exports, module) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/fast-deep-equal/index.js"(exports, module) {
     "use strict";
     module.exports = function equal(a, b) {
       if (a === b) return true;
@@ -6396,9 +6396,9 @@ var require_fast_deep_equal = __commonJS({
   }
 });
 
-// node_modules/json-schema-traverse/index.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/json-schema-traverse/index.js
 var require_json_schema_traverse = __commonJS({
-  "node_modules/json-schema-traverse/index.js"(exports, module) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/json-schema-traverse/index.js"(exports, module) {
     "use strict";
     var traverse = module.exports = function(schema, opts, cb) {
       if (typeof opts == "function") {
@@ -6484,9 +6484,9 @@ var require_json_schema_traverse = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/compile/resolve.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/resolve.js
 var require_resolve = __commonJS({
-  "node_modules/ajv/dist/compile/resolve.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/resolve.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.getSchemaRefs = exports.resolveUrl = exports.normalizeId = exports._getFullPath = exports.getFullPath = exports.inlineRef = void 0;
@@ -6640,9 +6640,9 @@ var require_resolve = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/compile/validate/index.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/validate/index.js
 var require_validate = __commonJS({
-  "node_modules/ajv/dist/compile/validate/index.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/validate/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.getData = exports.KeywordCxt = exports.validateFunctionCode = void 0;
@@ -7148,9 +7148,9 @@ var require_validate = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/runtime/validation_error.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/runtime/validation_error.js
 var require_validation_error = __commonJS({
-  "node_modules/ajv/dist/runtime/validation_error.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/runtime/validation_error.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var ValidationError = class extends Error {
@@ -7164,9 +7164,9 @@ var require_validation_error = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/compile/ref_error.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/ref_error.js
 var require_ref_error = __commonJS({
-  "node_modules/ajv/dist/compile/ref_error.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/ref_error.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var resolve_1 = require_resolve();
@@ -7181,9 +7181,9 @@ var require_ref_error = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/compile/index.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/index.js
 var require_compile = __commonJS({
-  "node_modules/ajv/dist/compile/index.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.resolveSchema = exports.getCompilingSchema = exports.resolveRef = exports.compileSchema = exports.SchemaEnv = void 0;
@@ -7405,9 +7405,9 @@ var require_compile = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/refs/data.json
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/refs/data.json
 var require_data = __commonJS({
-  "node_modules/ajv/dist/refs/data.json"(exports, module) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/refs/data.json"(exports, module) {
     module.exports = {
       $id: "https://raw.githubusercontent.com/ajv-validator/ajv/master/lib/refs/data.json#",
       description: "Meta-schema for $data reference (JSON AnySchema extension proposal)",
@@ -7424,9 +7424,9 @@ var require_data = __commonJS({
   }
 });
 
-// node_modules/fast-uri/lib/utils.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/fast-uri/lib/utils.js
 var require_utils = __commonJS({
-  "node_modules/fast-uri/lib/utils.js"(exports, module) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/fast-uri/lib/utils.js"(exports, module) {
     "use strict";
     var isUUID = RegExp.prototype.test.bind(/^[\da-f]{8}-[\da-f]{4}-[\da-f]{4}-[\da-f]{4}-[\da-f]{12}$/iu);
     var isIPv4 = RegExp.prototype.test.bind(/^(?:(?:25[0-5]|2[0-4]\d|1\d{2}|[1-9]\d|\d)\.){3}(?:25[0-5]|2[0-4]\d|1\d{2}|[1-9]\d|\d)$/u);
@@ -7737,9 +7737,9 @@ var require_utils = __commonJS({
   }
 });
 
-// node_modules/fast-uri/lib/schemes.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/fast-uri/lib/schemes.js
 var require_schemes = __commonJS({
-  "node_modules/fast-uri/lib/schemes.js"(exports, module) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/fast-uri/lib/schemes.js"(exports, module) {
     "use strict";
     var { isUUID } = require_utils();
     var URN_REG = /([\da-z][\d\-a-z]{0,31}):((?:[\w!$'()*+,\-.:;=@]|%[\da-f]{2})+)/iu;
@@ -7947,9 +7947,9 @@ var require_schemes = __commonJS({
   }
 });
 
-// node_modules/fast-uri/index.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/fast-uri/index.js
 var require_fast_uri = __commonJS({
-  "node_modules/fast-uri/index.js"(exports, module) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/fast-uri/index.js"(exports, module) {
     "use strict";
     var { normalizeIPv6, removeDotSegments, recomposeAuthority, normalizePercentEncoding, normalizePathEncoding, escapePreservingEscapes, reescapeHostDelimiters, isIPv4, nonSimpleDomain } = require_utils();
     var { SCHEMES, getSchemeHandler } = require_schemes();
@@ -8233,9 +8233,9 @@ var require_fast_uri = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/runtime/uri.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/runtime/uri.js
 var require_uri = __commonJS({
-  "node_modules/ajv/dist/runtime/uri.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/runtime/uri.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var uri = require_fast_uri();
@@ -8244,9 +8244,9 @@ var require_uri = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/core.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/core.js
 var require_core = __commonJS({
-  "node_modules/ajv/dist/core.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/core.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.CodeGen = exports.Name = exports.nil = exports.stringify = exports.str = exports._ = exports.KeywordCxt = void 0;
@@ -8855,9 +8855,9 @@ var require_core = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/vocabularies/core/id.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/core/id.js
 var require_id = __commonJS({
-  "node_modules/ajv/dist/vocabularies/core/id.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/core/id.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var def = {
@@ -8870,9 +8870,9 @@ var require_id = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/vocabularies/core/ref.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/core/ref.js
 var require_ref = __commonJS({
-  "node_modules/ajv/dist/vocabularies/core/ref.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/core/ref.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.callRef = exports.getValidate = void 0;
@@ -8992,9 +8992,9 @@ var require_ref = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/vocabularies/core/index.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/core/index.js
 var require_core2 = __commonJS({
-  "node_modules/ajv/dist/vocabularies/core/index.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/core/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var id_1 = require_id();
@@ -9013,9 +9013,9 @@ var require_core2 = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/vocabularies/validation/limitNumber.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/limitNumber.js
 var require_limitNumber = __commonJS({
-  "node_modules/ajv/dist/vocabularies/validation/limitNumber.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/limitNumber.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -9045,9 +9045,9 @@ var require_limitNumber = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/vocabularies/validation/multipleOf.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/multipleOf.js
 var require_multipleOf = __commonJS({
-  "node_modules/ajv/dist/vocabularies/validation/multipleOf.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/multipleOf.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -9073,9 +9073,9 @@ var require_multipleOf = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/runtime/ucs2length.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/runtime/ucs2length.js
 var require_ucs2length = __commonJS({
-  "node_modules/ajv/dist/runtime/ucs2length.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/runtime/ucs2length.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     function ucs2length(str) {
@@ -9099,9 +9099,9 @@ var require_ucs2length = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/vocabularies/validation/limitLength.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/limitLength.js
 var require_limitLength = __commonJS({
-  "node_modules/ajv/dist/vocabularies/validation/limitLength.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/limitLength.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -9131,9 +9131,9 @@ var require_limitLength = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/vocabularies/validation/pattern.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/pattern.js
 var require_pattern = __commonJS({
-  "node_modules/ajv/dist/vocabularies/validation/pattern.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/pattern.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var code_1 = require_code2();
@@ -9168,9 +9168,9 @@ var require_pattern = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/vocabularies/validation/limitProperties.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/limitProperties.js
 var require_limitProperties = __commonJS({
-  "node_modules/ajv/dist/vocabularies/validation/limitProperties.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/limitProperties.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -9197,9 +9197,9 @@ var require_limitProperties = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/vocabularies/validation/required.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/required.js
 var require_required = __commonJS({
-  "node_modules/ajv/dist/vocabularies/validation/required.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/required.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var code_1 = require_code2();
@@ -9279,9 +9279,9 @@ var require_required = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/vocabularies/validation/limitItems.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/limitItems.js
 var require_limitItems = __commonJS({
-  "node_modules/ajv/dist/vocabularies/validation/limitItems.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/limitItems.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -9308,9 +9308,9 @@ var require_limitItems = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/runtime/equal.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/runtime/equal.js
 var require_equal = __commonJS({
-  "node_modules/ajv/dist/runtime/equal.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/runtime/equal.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var equal = require_fast_deep_equal();
@@ -9319,9 +9319,9 @@ var require_equal = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/vocabularies/validation/uniqueItems.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/uniqueItems.js
 var require_uniqueItems = __commonJS({
-  "node_modules/ajv/dist/vocabularies/validation/uniqueItems.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/uniqueItems.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var dataType_1 = require_dataType();
@@ -9386,9 +9386,9 @@ var require_uniqueItems = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/vocabularies/validation/const.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/const.js
 var require_const = __commonJS({
-  "node_modules/ajv/dist/vocabularies/validation/const.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/const.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -9415,9 +9415,9 @@ var require_const = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/vocabularies/validation/enum.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/enum.js
 var require_enum = __commonJS({
-  "node_modules/ajv/dist/vocabularies/validation/enum.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/enum.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -9464,9 +9464,9 @@ var require_enum = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/vocabularies/validation/index.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/index.js
 var require_validation = __commonJS({
-  "node_modules/ajv/dist/vocabularies/validation/index.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var limitNumber_1 = require_limitNumber();
@@ -9502,9 +9502,9 @@ var require_validation = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/vocabularies/applicator/additionalItems.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/additionalItems.js
 var require_additionalItems = __commonJS({
-  "node_modules/ajv/dist/vocabularies/applicator/additionalItems.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/additionalItems.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.validateAdditionalItems = void 0;
@@ -9555,9 +9555,9 @@ var require_additionalItems = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/vocabularies/applicator/items.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/items.js
 var require_items = __commonJS({
-  "node_modules/ajv/dist/vocabularies/applicator/items.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/items.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.validateTuple = void 0;
@@ -9612,9 +9612,9 @@ var require_items = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/vocabularies/applicator/prefixItems.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/prefixItems.js
 var require_prefixItems = __commonJS({
-  "node_modules/ajv/dist/vocabularies/applicator/prefixItems.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/prefixItems.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var items_1 = require_items();
@@ -9629,9 +9629,9 @@ var require_prefixItems = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/vocabularies/applicator/items2020.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/items2020.js
 var require_items2020 = __commonJS({
-  "node_modules/ajv/dist/vocabularies/applicator/items2020.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/items2020.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -9664,9 +9664,9 @@ var require_items2020 = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/vocabularies/applicator/contains.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/contains.js
 var require_contains = __commonJS({
-  "node_modules/ajv/dist/vocabularies/applicator/contains.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/contains.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -9758,9 +9758,9 @@ var require_contains = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/vocabularies/applicator/dependencies.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/dependencies.js
 var require_dependencies = __commonJS({
-  "node_modules/ajv/dist/vocabularies/applicator/dependencies.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/dependencies.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.validateSchemaDeps = exports.validatePropertyDeps = exports.error = void 0;
@@ -9852,9 +9852,9 @@ var require_dependencies = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/vocabularies/applicator/propertyNames.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/propertyNames.js
 var require_propertyNames = __commonJS({
-  "node_modules/ajv/dist/vocabularies/applicator/propertyNames.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/propertyNames.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -9895,9 +9895,9 @@ var require_propertyNames = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/vocabularies/applicator/additionalProperties.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/additionalProperties.js
 var require_additionalProperties = __commonJS({
-  "node_modules/ajv/dist/vocabularies/applicator/additionalProperties.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/additionalProperties.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var code_1 = require_code2();
@@ -10001,9 +10001,9 @@ var require_additionalProperties = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/vocabularies/applicator/properties.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/properties.js
 var require_properties = __commonJS({
-  "node_modules/ajv/dist/vocabularies/applicator/properties.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/properties.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var validate_1 = require_validate();
@@ -10059,9 +10059,9 @@ var require_properties = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/vocabularies/applicator/patternProperties.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/patternProperties.js
 var require_patternProperties = __commonJS({
-  "node_modules/ajv/dist/vocabularies/applicator/patternProperties.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/patternProperties.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var code_1 = require_code2();
@@ -10133,9 +10133,9 @@ var require_patternProperties = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/vocabularies/applicator/not.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/not.js
 var require_not = __commonJS({
-  "node_modules/ajv/dist/vocabularies/applicator/not.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/not.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var util_1 = require_util2();
@@ -10164,9 +10164,9 @@ var require_not = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/vocabularies/applicator/anyOf.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/anyOf.js
 var require_anyOf = __commonJS({
-  "node_modules/ajv/dist/vocabularies/applicator/anyOf.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/anyOf.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var code_1 = require_code2();
@@ -10181,9 +10181,9 @@ var require_anyOf = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/vocabularies/applicator/oneOf.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/oneOf.js
 var require_oneOf = __commonJS({
-  "node_modules/ajv/dist/vocabularies/applicator/oneOf.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/oneOf.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -10239,9 +10239,9 @@ var require_oneOf = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/vocabularies/applicator/allOf.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/allOf.js
 var require_allOf = __commonJS({
-  "node_modules/ajv/dist/vocabularies/applicator/allOf.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/allOf.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var util_1 = require_util2();
@@ -10266,9 +10266,9 @@ var require_allOf = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/vocabularies/applicator/if.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/if.js
 var require_if = __commonJS({
-  "node_modules/ajv/dist/vocabularies/applicator/if.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/if.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -10335,9 +10335,9 @@ var require_if = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/vocabularies/applicator/thenElse.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/thenElse.js
 var require_thenElse = __commonJS({
-  "node_modules/ajv/dist/vocabularies/applicator/thenElse.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/thenElse.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var util_1 = require_util2();
@@ -10353,9 +10353,9 @@ var require_thenElse = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/vocabularies/applicator/index.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/index.js
 var require_applicator = __commonJS({
-  "node_modules/ajv/dist/vocabularies/applicator/index.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var additionalItems_1 = require_additionalItems();
@@ -10401,9 +10401,9 @@ var require_applicator = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/vocabularies/format/format.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/format/format.js
 var require_format = __commonJS({
-  "node_modules/ajv/dist/vocabularies/format/format.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/format/format.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -10491,9 +10491,9 @@ var require_format = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/vocabularies/format/index.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/format/index.js
 var require_format2 = __commonJS({
-  "node_modules/ajv/dist/vocabularies/format/index.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/format/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var format_1 = require_format();
@@ -10502,9 +10502,9 @@ var require_format2 = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/vocabularies/metadata.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/metadata.js
 var require_metadata = __commonJS({
-  "node_modules/ajv/dist/vocabularies/metadata.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/metadata.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.contentVocabulary = exports.metadataVocabulary = void 0;
@@ -10525,9 +10525,9 @@ var require_metadata = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/vocabularies/draft7.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/draft7.js
 var require_draft7 = __commonJS({
-  "node_modules/ajv/dist/vocabularies/draft7.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/draft7.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var core_1 = require_core2();
@@ -10547,9 +10547,9 @@ var require_draft7 = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/vocabularies/discriminator/types.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/discriminator/types.js
 var require_types = __commonJS({
-  "node_modules/ajv/dist/vocabularies/discriminator/types.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/discriminator/types.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.DiscrError = void 0;
@@ -10561,9 +10561,9 @@ var require_types = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/vocabularies/discriminator/index.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/discriminator/index.js
 var require_discriminator = __commonJS({
-  "node_modules/ajv/dist/vocabularies/discriminator/index.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/discriminator/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -10666,9 +10666,9 @@ var require_discriminator = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/refs/json-schema-draft-07.json
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/refs/json-schema-draft-07.json
 var require_json_schema_draft_07 = __commonJS({
-  "node_modules/ajv/dist/refs/json-schema-draft-07.json"(exports, module) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/refs/json-schema-draft-07.json"(exports, module) {
     module.exports = {
       $schema: "http://json-schema.org/draft-07/schema#",
       $id: "http://json-schema.org/draft-07/schema#",
@@ -10823,9 +10823,9 @@ var require_json_schema_draft_07 = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/ajv.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/ajv.js
 var require_ajv = __commonJS({
-  "node_modules/ajv/dist/ajv.js"(exports, module) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/ajv.js"(exports, module) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.MissingRefError = exports.ValidationError = exports.CodeGen = exports.Name = exports.nil = exports.stringify = exports.str = exports._ = exports.KeywordCxt = exports.Ajv = void 0;
@@ -10893,9 +10893,9 @@ var require_ajv = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/dist/formats.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv-formats/dist/formats.js
 var require_formats = __commonJS({
-  "node_modules/ajv-formats/dist/formats.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv-formats/dist/formats.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.formatNames = exports.fastFormats = exports.fullFormats = void 0;
@@ -11096,9 +11096,9 @@ var require_formats = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/dist/limit.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv-formats/dist/limit.js
 var require_limit = __commonJS({
-  "node_modules/ajv-formats/dist/limit.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv-formats/dist/limit.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.formatLimitDefinition = void 0;
@@ -11168,9 +11168,9 @@ var require_limit = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/dist/index.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv-formats/dist/index.js
 var require_dist = __commonJS({
-  "node_modules/ajv-formats/dist/index.js"(exports, module) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv-formats/dist/index.js"(exports, module) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var formats_1 = require_formats();
@@ -11392,7 +11392,7 @@ var ProtectionSignalStatus = Object.freeze({
   UNKNOWN: "unknown"
 });
 
-// node_modules/@simplewebauthn/server/esm/helpers/iso/isoBase64URL.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/iso/isoBase64URL.js
 var isoBase64URL_exports = {};
 __export(isoBase64URL_exports, {
   fromBuffer: () => fromBuffer,
@@ -11405,7 +11405,7 @@ __export(isoBase64URL_exports, {
   trimPadding: () => trimPadding
 });
 
-// node_modules/@hexagon/base64/src/base64.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@hexagon/base64/src/base64.js
 var chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 var charsUrl = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
 var genLookup = (target) => {
@@ -11479,7 +11479,7 @@ base64.validate = (encoded, urlMode) => {
 base64.base64 = base64;
 var base64_default = base64;
 
-// node_modules/@simplewebauthn/server/esm/helpers/iso/isoBase64URL.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/iso/isoBase64URL.js
 function toBuffer(base64urlString, from = "base64url") {
   const _buffer = base64_default.toArrayBuffer(base64urlString, from === "base64url");
   return new Uint8Array(_buffer);
@@ -11510,14 +11510,14 @@ function trimPadding(input) {
   return input.replace(/=/g, "");
 }
 
-// node_modules/@simplewebauthn/server/esm/helpers/iso/isoCBOR.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/iso/isoCBOR.js
 var isoCBOR_exports = {};
 __export(isoCBOR_exports, {
   decodeFirst: () => decodeFirst,
   encode: () => encode
 });
 
-// node_modules/@levischuck/tiny-cbor/esm/cbor/cbor_internal.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@levischuck/tiny-cbor/esm/cbor/cbor_internal.js
 function decodeLength(data, argument, index) {
   if (argument < 24) {
     return [argument, 1];
@@ -11616,7 +11616,7 @@ function encodeLength(major, argument) {
   }
 }
 
-// node_modules/@levischuck/tiny-cbor/esm/cbor/cbor.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@levischuck/tiny-cbor/esm/cbor/cbor.js
 var CBORTag = class {
   /**
    * Wrap a value with a tag number.
@@ -11943,7 +11943,7 @@ function encodeCBOR(data) {
   return output;
 }
 
-// node_modules/@simplewebauthn/server/esm/helpers/iso/isoCBOR.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/iso/isoCBOR.js
 function decodeFirst(input) {
   const _input = new Uint8Array(input);
   const decoded = decodePartialCBOR(_input, 0);
@@ -11954,7 +11954,7 @@ function encode(input) {
   return encodeCBOR(input);
 }
 
-// node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/index.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/index.js
 var isoCrypto_exports = {};
 __export(isoCrypto_exports, {
   digest: () => digest,
@@ -11962,7 +11962,7 @@ __export(isoCrypto_exports, {
   verify: () => verify
 });
 
-// node_modules/@simplewebauthn/server/esm/helpers/cose.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/cose.js
 function isCOSEPublicKeyOKP(cosePublicKey) {
   const kty = cosePublicKey.get(COSEKEYS.kty);
   return isCOSEKty(kty) && kty === COSEKTY.OKP;
@@ -12024,7 +12024,7 @@ function isCOSEAlg(alg) {
   return Object.values(COSEALG).indexOf(alg) >= 0;
 }
 
-// node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/mapCoseAlgToWebCryptoAlg.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/mapCoseAlgToWebCryptoAlg.js
 function mapCoseAlgToWebCryptoAlg(alg) {
   if ([COSEALG.RS1].indexOf(alg) >= 0) {
     return "SHA-1";
@@ -12038,7 +12038,7 @@ function mapCoseAlgToWebCryptoAlg(alg) {
   throw new Error(`Could not map COSE alg value of ${alg} to a WebCrypto alg`);
 }
 
-// node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/getWebCrypto.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/getWebCrypto.js
 var webCrypto = void 0;
 function getWebCrypto() {
   const toResolve = new Promise((resolve, reject) => {
@@ -12069,7 +12069,7 @@ var _getWebCryptoInternals = {
   }
 };
 
-// node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/digest.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/digest.js
 async function digest(data, algorithm) {
   const WebCrypto = await getWebCrypto();
   const subtleAlgorithm = mapCoseAlgToWebCryptoAlg(algorithm);
@@ -12077,14 +12077,14 @@ async function digest(data, algorithm) {
   return new Uint8Array(hashed);
 }
 
-// node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/getRandomValues.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/getRandomValues.js
 async function getRandomValues(array2) {
   const WebCrypto = await getWebCrypto();
   WebCrypto.getRandomValues(array2);
   return array2;
 }
 
-// node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/importKey.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/importKey.js
 async function importKey(opts) {
   const WebCrypto = await getWebCrypto();
   const { keyData, algorithm } = opts;
@@ -12093,7 +12093,7 @@ async function importKey(opts) {
   ]);
 }
 
-// node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/verifyEC2.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/verifyEC2.js
 async function verifyEC2(opts) {
   const { cosePublicKey, signature, data, shaHashOverride } = opts;
   const WebCrypto = await getWebCrypto();
@@ -12155,7 +12155,7 @@ async function verifyEC2(opts) {
   return WebCrypto.subtle.verify(verifyAlgorithm, key, signature, data);
 }
 
-// node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/mapCoseAlgToWebCryptoKeyAlgName.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/mapCoseAlgToWebCryptoKeyAlgName.js
 function mapCoseAlgToWebCryptoKeyAlgName(alg) {
   if ([COSEALG.EdDSA].indexOf(alg) >= 0) {
     return "Ed25519";
@@ -12169,7 +12169,7 @@ function mapCoseAlgToWebCryptoKeyAlgName(alg) {
   throw new Error(`Could not map COSE alg value of ${alg} to a WebCrypto key alg name`);
 }
 
-// node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/verifyRSA.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/verifyRSA.js
 async function verifyRSA(opts) {
   const { cosePublicKey, signature, data, shaHashOverride } = opts;
   const WebCrypto = await getWebCrypto();
@@ -12238,7 +12238,7 @@ async function verifyRSA(opts) {
   return WebCrypto.subtle.verify(verifyAlgorithm, key, signature, data);
 }
 
-// node_modules/@simplewebauthn/server/esm/helpers/convertAAGUIDToString.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/convertAAGUIDToString.js
 function convertAAGUIDToString(aaguid) {
   const hex = isoUint8Array_exports.toHex(aaguid);
   const segments = [
@@ -12256,7 +12256,7 @@ function convertAAGUIDToString(aaguid) {
   return segments.join("-");
 }
 
-// node_modules/@simplewebauthn/server/esm/helpers/convertCertBufferToPEM.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/convertCertBufferToPEM.js
 function convertCertBufferToPEM(certBuffer) {
   let b64cert;
   if (typeof certBuffer === "string") {
@@ -12282,7 +12282,7 @@ ${PEMKey}-----END CERTIFICATE-----
   return PEMKey;
 }
 
-// node_modules/@simplewebauthn/server/esm/helpers/convertCOSEtoPKCS.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/convertCOSEtoPKCS.js
 function convertCOSEtoPKCS(cosePublicKey) {
   const struct = isoCBOR_exports.decodeFirst(cosePublicKey);
   const tag = Uint8Array.from([4]);
@@ -12297,7 +12297,7 @@ function convertCOSEtoPKCS(cosePublicKey) {
   return isoUint8Array_exports.concat([tag, x]);
 }
 
-// node_modules/@simplewebauthn/server/esm/helpers/decodeAttestationObject.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/decodeAttestationObject.js
 function decodeAttestationObject(attestationObject) {
   return _decodeAttestationObjectInternals.stubThis(isoCBOR_exports.decodeFirst(attestationObject));
 }
@@ -12305,7 +12305,7 @@ var _decodeAttestationObjectInternals = {
   stubThis: (value) => value
 };
 
-// node_modules/@simplewebauthn/server/esm/helpers/decodeClientDataJSON.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/decodeClientDataJSON.js
 function decodeClientDataJSON(data) {
   const toString = isoBase64URL_exports.toUTF8String(data);
   const clientData = JSON.parse(toString);
@@ -12315,7 +12315,7 @@ var _decodeClientDataJSONInternals = {
   stubThis: (value) => value
 };
 
-// node_modules/@simplewebauthn/server/esm/helpers/decodeCredentialPublicKey.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/decodeCredentialPublicKey.js
 function decodeCredentialPublicKey(publicKey) {
   return _decodeCredentialPublicKeyInternals.stubThis(isoCBOR_exports.decodeFirst(publicKey));
 }
@@ -12323,7 +12323,7 @@ var _decodeCredentialPublicKeyInternals = {
   stubThis: (value) => value
 };
 
-// node_modules/@simplewebauthn/server/esm/helpers/generateUserID.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/generateUserID.js
 async function generateUserID() {
   const newUserID = new Uint8Array(32);
   await isoCrypto_exports.getRandomValues(newUserID);
@@ -12333,7 +12333,7 @@ var _generateUserIDInternals = {
   stubThis: (value) => value
 };
 
-// node_modules/asn1js/build/index.es.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/asn1js/build/index.es.js
 var index_es_exports = {};
 __export(index_es_exports, {
   Any: () => Any,
@@ -12386,7 +12386,7 @@ __export(index_es_exports, {
 });
 var pvtsutils = __toESM(require_build());
 
-// node_modules/pvutils/build/utils.es.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/pvutils/build/utils.es.js
 function utilFromBase(inputBuffer, inputBase) {
   let result = 0;
   if (inputBuffer.length === 1) {
@@ -12524,7 +12524,7 @@ function padNumber(inputNumber, fullLength) {
 }
 var log2 = Math.log(2);
 
-// node_modules/asn1js/build/index.es.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/asn1js/build/index.es.js
 function assertBigInt() {
   if (typeof BigInt === "undefined") {
     throw new Error("BigInt is not defined. Your environment doesn't implement BigInt.");
@@ -15565,7 +15565,7 @@ function verifySchema(inputBuffer, inputSchema) {
   return compareSchema(asn1.result, asn1.result, inputSchema);
 }
 
-// node_modules/@peculiar/asn1-schema/build/es2015/enums.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-schema/build/es2015/enums.js
 var AsnTypeTypes;
 (function(AsnTypeTypes2) {
   AsnTypeTypes2[AsnTypeTypes2["Sequence"] = 0] = "Sequence";
@@ -15603,7 +15603,7 @@ var AsnPropTypes;
   AsnPropTypes2[AsnPropTypes2["Null"] = 27] = "Null";
 })(AsnPropTypes || (AsnPropTypes = {}));
 
-// node_modules/@peculiar/asn1-schema/build/es2015/types/bit_string.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-schema/build/es2015/types/bit_string.js
 var import_pvtsutils = __toESM(require_build());
 var BitString2 = class {
   constructor(params, unusedBits = 0) {
@@ -15661,7 +15661,7 @@ var BitString2 = class {
   }
 };
 
-// node_modules/@peculiar/asn1-schema/build/es2015/types/octet_string.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-schema/build/es2015/types/octet_string.js
 var import_pvtsutils2 = __toESM(require_build());
 var OctetString2 = class {
   get byteLength() {
@@ -15698,7 +15698,7 @@ var OctetString2 = class {
   }
 };
 
-// node_modules/@peculiar/asn1-schema/build/es2015/converters.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-schema/build/es2015/converters.js
 var AsnAnyConverter = {
   fromASN: (value) => value instanceof Null ? null : value.valueBeforeDecodeView,
   toASN: (value) => {
@@ -15827,7 +15827,7 @@ function defaultConverter(type) {
   }
 }
 
-// node_modules/@peculiar/asn1-schema/build/es2015/helper.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-schema/build/es2015/helper.js
 function isConvertible(target) {
   if (typeof target === "function" && target.prototype) {
     if (target.prototype.toASN && target.prototype.fromASN) {
@@ -15867,7 +15867,7 @@ function isArrayEqual(bytes1, bytes2) {
   return true;
 }
 
-// node_modules/@peculiar/asn1-schema/build/es2015/schema.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-schema/build/es2015/schema.js
 var AsnSchemaStorage = class {
   constructor() {
     this.items = /* @__PURE__ */ new WeakMap();
@@ -15991,10 +15991,10 @@ var AsnSchemaStorage = class {
   }
 };
 
-// node_modules/@peculiar/asn1-schema/build/es2015/storage.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-schema/build/es2015/storage.js
 var schemaStorage = new AsnSchemaStorage();
 
-// node_modules/@peculiar/asn1-schema/build/es2015/decorators.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-schema/build/es2015/decorators.js
 var AsnType = (options) => (target) => {
   let schema;
   if (!schemaStorage.has(target)) {
@@ -16025,7 +16025,7 @@ var AsnProp = (options) => (target, propertyKey) => {
   schema.items[propertyKey] = copyOptions;
 };
 
-// node_modules/@peculiar/asn1-schema/build/es2015/errors/schema_validation.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-schema/build/es2015/errors/schema_validation.js
 var AsnSchemaValidationError = class extends Error {
   constructor() {
     super(...arguments);
@@ -16033,7 +16033,7 @@ var AsnSchemaValidationError = class extends Error {
   }
 };
 
-// node_modules/@peculiar/asn1-schema/build/es2015/parser.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-schema/build/es2015/parser.js
 var AsnParser = class {
   static parse(data, target) {
     const asn1Parsed = fromBER(data);
@@ -16308,7 +16308,7 @@ var AsnParser = class {
   }
 };
 
-// node_modules/@peculiar/asn1-schema/build/es2015/serializer.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-schema/build/es2015/serializer.js
 var AsnSerializer = class _AsnSerializer {
   static serialize(obj) {
     if (obj instanceof BaseBlock) {
@@ -16442,7 +16442,7 @@ var AsnSerializer = class _AsnSerializer {
   }
 };
 
-// node_modules/@peculiar/asn1-schema/build/es2015/objects.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-schema/build/es2015/objects.js
 var AsnArray = class extends Array {
   constructor(items = []) {
     if (typeof items === "number") {
@@ -16456,7 +16456,7 @@ var AsnArray = class extends Array {
   }
 };
 
-// node_modules/@peculiar/asn1-schema/build/es2015/convert.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-schema/build/es2015/convert.js
 var import_pvtsutils3 = __toESM(require_build());
 var AsnConvert = class _AsnConvert {
   static serialize(obj) {
@@ -16475,7 +16475,7 @@ var AsnConvert = class _AsnConvert {
   }
 };
 
-// node_modules/tslib/tslib.es6.mjs
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tslib/tslib.es6.mjs
 function __decorate(decorators, target, key, desc) {
   var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
   if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
@@ -16494,7 +16494,7 @@ function __classPrivateFieldSet(receiver, state, value, kind, f) {
   return kind === "a" ? f.call(receiver, value) : f ? f.value = value : state.set(receiver, value), value;
 }
 
-// node_modules/@peculiar/asn1-x509/build/es2015/ip_converter.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/ip_converter.js
 var import_pvtsutils4 = __toESM(require_build());
 var IpConverter = class {
   static isIPv4(ip) {
@@ -16662,7 +16662,7 @@ var IpConverter = class {
   }
 };
 
-// node_modules/@peculiar/asn1-x509/build/es2015/name.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/name.js
 var import_pvtsutils5 = __toESM(require_build());
 var RelativeDistinguishedName_1;
 var RDNSequence_1;
@@ -16752,7 +16752,7 @@ Name = Name_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence })
 ], Name);
 
-// node_modules/@peculiar/asn1-x509/build/es2015/general_name.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/general_name.js
 var AsnIpConverter = {
   fromASN: (value) => IpConverter.toString(AsnOctetStringConverter.fromASN(value)),
   toASN: (value) => AsnOctetStringConverter.toASN(IpConverter.fromString(value))
@@ -16823,7 +16823,7 @@ GeneralName = __decorate([
   AsnType({ type: AsnTypeTypes.Choice })
 ], GeneralName);
 
-// node_modules/@peculiar/asn1-x509/build/es2015/object_identifiers.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/object_identifiers.js
 var id_pkix = "1.3.6.1.5.5.7";
 var id_pe = `${id_pkix}.1`;
 var id_qt = `${id_pkix}.2`;
@@ -16837,7 +16837,7 @@ var id_ad_timeStamping = `${id_ad}.3`;
 var id_ad_caRepository = `${id_ad}.5`;
 var id_ce = "2.5.29";
 
-// node_modules/@peculiar/asn1-x509/build/es2015/extensions/authority_information_access.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/authority_information_access.js
 var AuthorityInfoAccessSyntax_1;
 var id_pe_authorityInfoAccess = `${id_pe}.1`;
 var AccessDescription = class {
@@ -16863,7 +16863,7 @@ AuthorityInfoAccessSyntax = AuthorityInfoAccessSyntax_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence, itemType: AccessDescription })
 ], AuthorityInfoAccessSyntax);
 
-// node_modules/@peculiar/asn1-x509/build/es2015/extensions/authority_key_identifier.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/authority_key_identifier.js
 var id_ce_authorityKeyIdentifier = `${id_ce}.35`;
 var KeyIdentifier = class extends OctetString2 {
 };
@@ -16890,7 +16890,7 @@ __decorate([
   })
 ], AuthorityKeyIdentifier.prototype, "authorityCertSerialNumber", void 0);
 
-// node_modules/@peculiar/asn1-x509/build/es2015/extensions/basic_constraints.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/basic_constraints.js
 var id_ce_basicConstraints = `${id_ce}.19`;
 var BasicConstraints = class {
   constructor(params = {}) {
@@ -16905,7 +16905,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.Integer, optional: true })
 ], BasicConstraints.prototype, "pathLenConstraint", void 0);
 
-// node_modules/@peculiar/asn1-x509/build/es2015/general_names.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/general_names.js
 var GeneralNames_1;
 var GeneralNames = GeneralNames_1 = class GeneralNames2 extends AsnArray {
   constructor(items) {
@@ -16917,7 +16917,7 @@ GeneralNames = GeneralNames_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence, itemType: GeneralName })
 ], GeneralNames);
 
-// node_modules/@peculiar/asn1-x509/build/es2015/extensions/certificate_issuer.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/certificate_issuer.js
 var CertificateIssuer_1;
 var id_ce_certificateIssuer = `${id_ce}.29`;
 var CertificateIssuer = CertificateIssuer_1 = class CertificateIssuer2 extends GeneralNames {
@@ -16930,7 +16930,7 @@ CertificateIssuer = CertificateIssuer_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence })
 ], CertificateIssuer);
 
-// node_modules/@peculiar/asn1-x509/build/es2015/extensions/certificate_policies.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/certificate_policies.js
 var CertificatePolicies_1;
 var id_ce_certificatePolicies = `${id_ce}.32`;
 var id_ce_certificatePolicies_anyPolicy = `${id_ce_certificatePolicies}.0`;
@@ -17030,7 +17030,7 @@ CertificatePolicies = CertificatePolicies_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence, itemType: PolicyInformation })
 ], CertificatePolicies);
 
-// node_modules/@peculiar/asn1-x509/build/es2015/extensions/crl_number.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/crl_number.js
 var id_ce_cRLNumber = `${id_ce}.20`;
 var CRLNumber = class CRLNumber2 {
   constructor(value = 0) {
@@ -17044,7 +17044,7 @@ CRLNumber = __decorate([
   AsnType({ type: AsnTypeTypes.Choice })
 ], CRLNumber);
 
-// node_modules/@peculiar/asn1-x509/build/es2015/extensions/crl_delta_indicator.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/crl_delta_indicator.js
 var id_ce_deltaCRLIndicator = `${id_ce}.27`;
 var BaseCRLNumber = class BaseCRLNumber2 extends CRLNumber {
 };
@@ -17052,7 +17052,7 @@ BaseCRLNumber = __decorate([
   AsnType({ type: AsnTypeTypes.Choice })
 ], BaseCRLNumber);
 
-// node_modules/@peculiar/asn1-x509/build/es2015/extensions/crl_distribution_points.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/crl_distribution_points.js
 var CRLDistributionPoints_1;
 var id_ce_cRLDistributionPoints = `${id_ce}.31`;
 var ReasonFlags;
@@ -17142,7 +17142,7 @@ CRLDistributionPoints = CRLDistributionPoints_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence, itemType: DistributionPoint })
 ], CRLDistributionPoints);
 
-// node_modules/@peculiar/asn1-x509/build/es2015/extensions/crl_freshest.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/crl_freshest.js
 var FreshestCRL_1;
 var id_ce_freshestCRL = `${id_ce}.46`;
 var FreshestCRL = FreshestCRL_1 = class FreshestCRL2 extends CRLDistributionPoints {
@@ -17155,7 +17155,7 @@ FreshestCRL = FreshestCRL_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence, itemType: DistributionPoint })
 ], FreshestCRL);
 
-// node_modules/@peculiar/asn1-x509/build/es2015/extensions/crl_issuing_distribution_point.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/crl_issuing_distribution_point.js
 var id_ce_issuingDistributionPoint = `${id_ce}.28`;
 var IssuingDistributionPoint = class _IssuingDistributionPoint {
   constructor(params = {}) {
@@ -17206,7 +17206,7 @@ __decorate([
   })
 ], IssuingDistributionPoint.prototype, "onlyContainsAttributeCerts", void 0);
 
-// node_modules/@peculiar/asn1-x509/build/es2015/extensions/crl_reason.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/crl_reason.js
 var id_ce_cRLReasons = `${id_ce}.21`;
 var CRLReasons;
 (function(CRLReasons2) {
@@ -17240,7 +17240,7 @@ CRLReason = __decorate([
   AsnType({ type: AsnTypeTypes.Choice })
 ], CRLReason);
 
-// node_modules/@peculiar/asn1-x509/build/es2015/extensions/extended_key_usage.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/extended_key_usage.js
 var ExtendedKeyUsage_1;
 var id_ce_extKeyUsage = `${id_ce}.37`;
 var ExtendedKeyUsage = ExtendedKeyUsage_1 = class ExtendedKeyUsage2 extends AsnArray {
@@ -17260,7 +17260,7 @@ var id_kp_emailProtection = `${id_kp}.4`;
 var id_kp_timeStamping = `${id_kp}.8`;
 var id_kp_OCSPSigning = `${id_kp}.9`;
 
-// node_modules/@peculiar/asn1-x509/build/es2015/extensions/inhibit_any_policy.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/inhibit_any_policy.js
 var id_ce_inhibitAnyPolicy = `${id_ce}.54`;
 var InhibitAnyPolicy = class InhibitAnyPolicy2 {
   constructor(value = new ArrayBuffer(0)) {
@@ -17274,7 +17274,7 @@ InhibitAnyPolicy = __decorate([
   AsnType({ type: AsnTypeTypes.Choice })
 ], InhibitAnyPolicy);
 
-// node_modules/@peculiar/asn1-x509/build/es2015/extensions/invalidity_date.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/invalidity_date.js
 var id_ce_invalidityDate = `${id_ce}.24`;
 var InvalidityDate = class InvalidityDate2 {
   constructor(value) {
@@ -17291,7 +17291,7 @@ InvalidityDate = __decorate([
   AsnType({ type: AsnTypeTypes.Choice })
 ], InvalidityDate);
 
-// node_modules/@peculiar/asn1-x509/build/es2015/extensions/issuer_alternative_name.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/issuer_alternative_name.js
 var IssueAlternativeName_1;
 var id_ce_issuerAltName = `${id_ce}.18`;
 var IssueAlternativeName = IssueAlternativeName_1 = class IssueAlternativeName2 extends GeneralNames {
@@ -17304,7 +17304,7 @@ IssueAlternativeName = IssueAlternativeName_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence })
 ], IssueAlternativeName);
 
-// node_modules/@peculiar/asn1-x509/build/es2015/extensions/key_usage.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/key_usage.js
 var id_ce_keyUsage = `${id_ce}.15`;
 var KeyUsageFlags;
 (function(KeyUsageFlags3) {
@@ -17356,7 +17356,7 @@ var KeyUsage = class extends BitString2 {
   }
 };
 
-// node_modules/@peculiar/asn1-x509/build/es2015/extensions/name_constraints.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/name_constraints.js
 var GeneralSubtrees_1;
 var id_ce_nameConstraints = `${id_ce}.30`;
 var GeneralSubtree = class {
@@ -17396,7 +17396,7 @@ __decorate([
   AsnProp({ type: GeneralSubtrees, context: 1, optional: true, implicit: true })
 ], NameConstraints.prototype, "excludedSubtrees", void 0);
 
-// node_modules/@peculiar/asn1-x509/build/es2015/extensions/policy_constraints.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/policy_constraints.js
 var id_ce_policyConstraints = `${id_ce}.36`;
 var PolicyConstraints = class {
   constructor(params = {}) {
@@ -17422,7 +17422,7 @@ __decorate([
   })
 ], PolicyConstraints.prototype, "inhibitPolicyMapping", void 0);
 
-// node_modules/@peculiar/asn1-x509/build/es2015/extensions/policy_mappings.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/policy_mappings.js
 var PolicyMappings_1;
 var id_ce_policyMappings = `${id_ce}.33`;
 var PolicyMapping = class {
@@ -17448,7 +17448,7 @@ PolicyMappings = PolicyMappings_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence, itemType: PolicyMapping })
 ], PolicyMappings);
 
-// node_modules/@peculiar/asn1-x509/build/es2015/extensions/subject_alternative_name.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/subject_alternative_name.js
 var SubjectAlternativeName_1;
 var id_ce_subjectAltName = `${id_ce}.17`;
 var SubjectAlternativeName = SubjectAlternativeName_1 = class SubjectAlternativeName2 extends GeneralNames {
@@ -17461,7 +17461,7 @@ SubjectAlternativeName = SubjectAlternativeName_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence })
 ], SubjectAlternativeName);
 
-// node_modules/@peculiar/asn1-x509/build/es2015/attribute.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/attribute.js
 var Attribute = class {
   constructor(params = {}) {
     this.type = "";
@@ -17476,7 +17476,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.Any, repeated: "set" })
 ], Attribute.prototype, "values", void 0);
 
-// node_modules/@peculiar/asn1-x509/build/es2015/extensions/subject_directory_attributes.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/subject_directory_attributes.js
 var SubjectDirectoryAttributes_1;
 var id_ce_subjectDirectoryAttributes = `${id_ce}.9`;
 var SubjectDirectoryAttributes = SubjectDirectoryAttributes_1 = class SubjectDirectoryAttributes2 extends AsnArray {
@@ -17489,12 +17489,12 @@ SubjectDirectoryAttributes = SubjectDirectoryAttributes_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence, itemType: Attribute })
 ], SubjectDirectoryAttributes);
 
-// node_modules/@peculiar/asn1-x509/build/es2015/extensions/subject_key_identifier.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/subject_key_identifier.js
 var id_ce_subjectKeyIdentifier = `${id_ce}.14`;
 var SubjectKeyIdentifier = class extends KeyIdentifier {
 };
 
-// node_modules/@peculiar/asn1-x509/build/es2015/extensions/private_key_usage_period.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/private_key_usage_period.js
 var id_ce_privateKeyUsagePeriod = `${id_ce}.16`;
 var PrivateKeyUsagePeriod = class {
   constructor(params = {}) {
@@ -17508,7 +17508,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.GeneralizedTime, context: 1, implicit: true, optional: true })
 ], PrivateKeyUsagePeriod.prototype, "notAfter", void 0);
 
-// node_modules/@peculiar/asn1-x509/build/es2015/extensions/entrust_version_info.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/entrust_version_info.js
 var EntrustInfoFlags;
 (function(EntrustInfoFlags2) {
   EntrustInfoFlags2[EntrustInfoFlags2["keyUpdateAllowed"] = 1] = "keyUpdateAllowed";
@@ -17548,7 +17548,7 @@ __decorate([
   AsnProp({ type: EntrustInfo })
 ], EntrustVersionInfo.prototype, "entrustInfoFlags", void 0);
 
-// node_modules/@peculiar/asn1-x509/build/es2015/extensions/subject_info_access.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/subject_info_access.js
 var SubjectInfoAccessSyntax_1;
 var id_pe_subjectInfoAccess = `${id_pe}.11`;
 var SubjectInfoAccessSyntax = SubjectInfoAccessSyntax_1 = class SubjectInfoAccessSyntax2 extends AsnArray {
@@ -17561,7 +17561,7 @@ SubjectInfoAccessSyntax = SubjectInfoAccessSyntax_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence, itemType: AccessDescription })
 ], SubjectInfoAccessSyntax);
 
-// node_modules/@peculiar/asn1-x509/build/es2015/algorithm_identifier.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/algorithm_identifier.js
 var pvtsutils2 = __toESM(require_build());
 var AlgorithmIdentifier = class _AlgorithmIdentifier {
   constructor(params = {}) {
@@ -17584,7 +17584,7 @@ __decorate([
   })
 ], AlgorithmIdentifier.prototype, "parameters", void 0);
 
-// node_modules/@peculiar/asn1-x509/build/es2015/subject_public_key_info.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/subject_public_key_info.js
 var SubjectPublicKeyInfo = class {
   constructor(params = {}) {
     this.algorithm = new AlgorithmIdentifier();
@@ -17599,7 +17599,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.BitString })
 ], SubjectPublicKeyInfo.prototype, "subjectPublicKey", void 0);
 
-// node_modules/@peculiar/asn1-x509/build/es2015/time.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/time.js
 var Time = class Time2 {
   constructor(time3) {
     if (time3) {
@@ -17638,7 +17638,7 @@ Time = __decorate([
   AsnType({ type: AsnTypeTypes.Choice })
 ], Time);
 
-// node_modules/@peculiar/asn1-x509/build/es2015/validity.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/validity.js
 var Validity = class {
   constructor(params) {
     this.notBefore = new Time(/* @__PURE__ */ new Date());
@@ -17656,7 +17656,7 @@ __decorate([
   AsnProp({ type: Time })
 ], Validity.prototype, "notAfter", void 0);
 
-// node_modules/@peculiar/asn1-x509/build/es2015/extension.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extension.js
 var Extensions_1;
 var Extension = class _Extension {
   constructor(params = {}) {
@@ -17689,7 +17689,7 @@ Extensions = Extensions_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence, itemType: Extension })
 ], Extensions);
 
-// node_modules/@peculiar/asn1-x509/build/es2015/types.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/types.js
 var Version;
 (function(Version4) {
   Version4[Version4["v1"] = 0] = "v1";
@@ -17697,7 +17697,7 @@ var Version;
   Version4[Version4["v3"] = 2] = "v3";
 })(Version || (Version = {}));
 
-// node_modules/@peculiar/asn1-x509/build/es2015/tbs_certificate.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/tbs_certificate.js
 var TBSCertificate = class {
   constructor(params = {}) {
     this.version = Version.v1;
@@ -17753,7 +17753,7 @@ __decorate([
   AsnProp({ type: Extensions, context: 3, optional: true })
 ], TBSCertificate.prototype, "extensions", void 0);
 
-// node_modules/@peculiar/asn1-x509/build/es2015/certificate.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/certificate.js
 var Certificate = class {
   constructor(params = {}) {
     this.tbsCertificate = new TBSCertificate();
@@ -17772,7 +17772,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.BitString })
 ], Certificate.prototype, "signatureValue", void 0);
 
-// node_modules/@peculiar/asn1-x509/build/es2015/tbs_cert_list.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/tbs_cert_list.js
 var RevokedCertificate = class {
   constructor(params = {}) {
     this.userCertificate = new ArrayBuffer(0);
@@ -17819,7 +17819,7 @@ __decorate([
   AsnProp({ type: Extension, optional: true, context: 0, repeated: "sequence" })
 ], TBSCertList.prototype, "crlExtensions", void 0);
 
-// node_modules/@peculiar/asn1-x509/build/es2015/certificate_list.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/certificate_list.js
 var CertificateList = class {
   constructor(params = {}) {
     this.tbsCertList = new TBSCertList();
@@ -17838,7 +17838,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.BitString })
 ], CertificateList.prototype, "signature", void 0);
 
-// node_modules/@simplewebauthn/server/esm/helpers/getCertificateInfo.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/getCertificateInfo.js
 var issuerSubjectIDKey = {
   "2.5.4.6": "C",
   "2.5.4.10": "O",
@@ -17900,11 +17900,11 @@ function issuerSubjectToString(input) {
   return parts.join(" : ");
 }
 
-// node_modules/@peculiar/x509/build/x509.es.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/x509/build/x509.es.js
 var import_reflect_metadata = __toESM(require_Reflect());
 var import_pvtsutils6 = __toESM(require_build());
 
-// node_modules/@peculiar/asn1-cms/build/es2015/issuer_and_serial_number.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/issuer_and_serial_number.js
 var IssuerAndSerialNumber = class {
   constructor(params = {}) {
     this.issuer = new Name();
@@ -17919,7 +17919,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.Integer, converter: AsnIntegerArrayBufferConverter })
 ], IssuerAndSerialNumber.prototype, "serialNumber", void 0);
 
-// node_modules/@peculiar/asn1-cms/build/es2015/signer_identifier.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/signer_identifier.js
 var SignerIdentifier = class SignerIdentifier2 {
   constructor(params = {}) {
     Object.assign(this, params);
@@ -17935,7 +17935,7 @@ SignerIdentifier = __decorate([
   AsnType({ type: AsnTypeTypes.Choice })
 ], SignerIdentifier);
 
-// node_modules/@peculiar/asn1-cms/build/es2015/types.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/types.js
 var CMSVersion;
 (function(CMSVersion2) {
   CMSVersion2[CMSVersion2["v0"] = 0] = "v0";
@@ -17976,7 +17976,7 @@ KeyDerivationAlgorithmIdentifier = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence })
 ], KeyDerivationAlgorithmIdentifier);
 
-// node_modules/@peculiar/asn1-cms/build/es2015/attribute.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/attribute.js
 var Attribute2 = class {
   constructor(params = {}) {
     this.attrType = "";
@@ -17991,7 +17991,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.Any, repeated: "set" })
 ], Attribute2.prototype, "attrValues", void 0);
 
-// node_modules/@peculiar/asn1-cms/build/es2015/signer_info.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/signer_info.js
 var SignerInfos_1;
 var SignerInfo = class {
   constructor(params = {}) {
@@ -18041,21 +18041,21 @@ SignerInfos = SignerInfos_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Set, itemType: SignerInfo })
 ], SignerInfos);
 
-// node_modules/@peculiar/asn1-cms/build/es2015/attributes/counter_signature.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/attributes/counter_signature.js
 var CounterSignature = class CounterSignature2 extends SignerInfo {
 };
 CounterSignature = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence })
 ], CounterSignature);
 
-// node_modules/@peculiar/asn1-cms/build/es2015/attributes/signing_time.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/attributes/signing_time.js
 var SigningTime = class SigningTime2 extends Time {
 };
 SigningTime = __decorate([
   AsnType({ type: AsnTypeTypes.Choice })
 ], SigningTime);
 
-// node_modules/@peculiar/asn1-x509-attr/build/es2015/aa_clear_attrs.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509-attr/build/es2015/aa_clear_attrs.js
 var ACClearAttrs = class {
   constructor(params = {}) {
     this.acIssuer = new GeneralName();
@@ -18074,7 +18074,7 @@ __decorate([
   AsnProp({ type: Attribute, repeated: "sequence" })
 ], ACClearAttrs.prototype, "attrs", void 0);
 
-// node_modules/@peculiar/asn1-x509-attr/build/es2015/attr_spec.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509-attr/build/es2015/attr_spec.js
 var AttrSpec_1;
 var AttrSpec = AttrSpec_1 = class AttrSpec2 extends AsnArray {
   constructor(items) {
@@ -18086,7 +18086,7 @@ AttrSpec = AttrSpec_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence, itemType: AsnPropTypes.ObjectIdentifier })
 ], AttrSpec);
 
-// node_modules/@peculiar/asn1-x509-attr/build/es2015/aa_controls.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509-attr/build/es2015/aa_controls.js
 var AAControls = class {
   constructor(params = {}) {
     this.permitUnSpecified = true;
@@ -18106,7 +18106,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.Boolean, defaultValue: true })
 ], AAControls.prototype, "permitUnSpecified", void 0);
 
-// node_modules/@peculiar/asn1-x509-attr/build/es2015/issuer_serial.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509-attr/build/es2015/issuer_serial.js
 var IssuerSerial = class {
   constructor(params = {}) {
     this.issuer = new GeneralNames();
@@ -18125,7 +18125,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.BitString, optional: true })
 ], IssuerSerial.prototype, "issuerUID", void 0);
 
-// node_modules/@peculiar/asn1-x509-attr/build/es2015/object_digest_info.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509-attr/build/es2015/object_digest_info.js
 var DigestedObjectType;
 (function(DigestedObjectType2) {
   DigestedObjectType2[DigestedObjectType2["publicKey"] = 0] = "publicKey";
@@ -18153,7 +18153,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.BitString })
 ], ObjectDigestInfo.prototype, "objectDigest", void 0);
 
-// node_modules/@peculiar/asn1-x509-attr/build/es2015/v2_form.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509-attr/build/es2015/v2_form.js
 var V2Form = class {
   constructor(params = {}) {
     Object.assign(this, params);
@@ -18169,7 +18169,7 @@ __decorate([
   AsnProp({ type: ObjectDigestInfo, context: 1, implicit: true, optional: true })
 ], V2Form.prototype, "objectDigestInfo", void 0);
 
-// node_modules/@peculiar/asn1-x509-attr/build/es2015/attr_cert_issuer.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509-attr/build/es2015/attr_cert_issuer.js
 var AttCertIssuer = class AttCertIssuer2 {
   constructor(params = {}) {
     Object.assign(this, params);
@@ -18185,7 +18185,7 @@ AttCertIssuer = __decorate([
   AsnType({ type: AsnTypeTypes.Choice })
 ], AttCertIssuer);
 
-// node_modules/@peculiar/asn1-x509-attr/build/es2015/attr_cert_validity_period.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509-attr/build/es2015/attr_cert_validity_period.js
 var AttCertValidityPeriod = class {
   constructor(params = {}) {
     this.notBeforeTime = /* @__PURE__ */ new Date();
@@ -18200,7 +18200,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.GeneralizedTime })
 ], AttCertValidityPeriod.prototype, "notAfterTime", void 0);
 
-// node_modules/@peculiar/asn1-x509-attr/build/es2015/holder.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509-attr/build/es2015/holder.js
 var Holder = class {
   constructor(params = {}) {
     Object.assign(this, params);
@@ -18216,7 +18216,7 @@ __decorate([
   AsnProp({ type: ObjectDigestInfo, implicit: true, context: 2, optional: true })
 ], Holder.prototype, "objectDigestInfo", void 0);
 
-// node_modules/@peculiar/asn1-x509-attr/build/es2015/attribute_certificate_info.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509-attr/build/es2015/attribute_certificate_info.js
 var AttCertVersion;
 (function(AttCertVersion2) {
   AttCertVersion2[AttCertVersion2["v2"] = 1] = "v2";
@@ -18261,7 +18261,7 @@ __decorate([
   AsnProp({ type: Extensions, optional: true })
 ], AttributeCertificateInfo.prototype, "extensions", void 0);
 
-// node_modules/@peculiar/asn1-x509-attr/build/es2015/attribute_certificate.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509-attr/build/es2015/attribute_certificate.js
 var AttributeCertificate = class {
   constructor(params = {}) {
     this.acinfo = new AttributeCertificateInfo();
@@ -18280,7 +18280,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.BitString })
 ], AttributeCertificate.prototype, "signatureValue", void 0);
 
-// node_modules/@peculiar/asn1-x509-attr/build/es2015/class_list.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509-attr/build/es2015/class_list.js
 var ClassListFlags;
 (function(ClassListFlags2) {
   ClassListFlags2[ClassListFlags2["unmarked"] = 1] = "unmarked";
@@ -18293,7 +18293,7 @@ var ClassListFlags;
 var ClassList = class extends BitString2 {
 };
 
-// node_modules/@peculiar/asn1-x509-attr/build/es2015/security_category.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509-attr/build/es2015/security_category.js
 var SecurityCategory = class {
   constructor(params = {}) {
     this.type = "";
@@ -18308,7 +18308,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.Any, implicit: true, context: 1 })
 ], SecurityCategory.prototype, "value", void 0);
 
-// node_modules/@peculiar/asn1-x509-attr/build/es2015/clearance.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509-attr/build/es2015/clearance.js
 var Clearance = class {
   constructor(params = {}) {
     this.policyId = "";
@@ -18326,7 +18326,7 @@ __decorate([
   AsnProp({ type: SecurityCategory, repeated: "set" })
 ], Clearance.prototype, "securityCategories", void 0);
 
-// node_modules/@peculiar/asn1-x509-attr/build/es2015/ietf_attr_syntax.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509-attr/build/es2015/ietf_attr_syntax.js
 var IetfAttrSyntaxValueChoices = class {
   constructor(params = {}) {
     Object.assign(this, params);
@@ -18354,7 +18354,7 @@ __decorate([
   AsnProp({ type: IetfAttrSyntaxValueChoices, repeated: "sequence" })
 ], IetfAttrSyntax.prototype, "values", void 0);
 
-// node_modules/@peculiar/asn1-x509-attr/build/es2015/object_identifiers.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509-attr/build/es2015/object_identifiers.js
 var id_pe_ac_auditIdentity = `${id_pe}.4`;
 var id_pe_aaControls = `${id_pe}.6`;
 var id_pe_ac_proxying = `${id_pe}.10`;
@@ -18368,7 +18368,7 @@ var id_aca_encAttrs = `${id_aca}.6`;
 var id_at = "2.5.4";
 var id_at_role = `${id_at}.72`;
 
-// node_modules/@peculiar/asn1-x509-attr/build/es2015/target.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509-attr/build/es2015/target.js
 var Targets_1;
 var TargetCert = class {
   constructor(params = {}) {
@@ -18412,7 +18412,7 @@ Targets = Targets_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence, itemType: Target })
 ], Targets);
 
-// node_modules/@peculiar/asn1-x509-attr/build/es2015/proxy_info.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509-attr/build/es2015/proxy_info.js
 var ProxyInfo_1;
 var ProxyInfo = ProxyInfo_1 = class ProxyInfo2 extends AsnArray {
   constructor(items) {
@@ -18424,7 +18424,7 @@ ProxyInfo = ProxyInfo_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence, itemType: Targets })
 ], ProxyInfo);
 
-// node_modules/@peculiar/asn1-x509-attr/build/es2015/role_syntax.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509-attr/build/es2015/role_syntax.js
 var RoleSyntax = class {
   constructor(params = {}) {
     Object.assign(this, params);
@@ -18437,7 +18437,7 @@ __decorate([
   AsnProp({ type: GeneralName, implicit: true, context: 1 })
 ], RoleSyntax.prototype, "roleName", void 0);
 
-// node_modules/@peculiar/asn1-x509-attr/build/es2015/svce_auth_info.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509-attr/build/es2015/svce_auth_info.js
 var SvceAuthInfo = class {
   constructor(params = {}) {
     this.service = new GeneralName();
@@ -18455,7 +18455,7 @@ __decorate([
   AsnProp({ type: OctetString2, optional: true })
 ], SvceAuthInfo.prototype, "authInfo", void 0);
 
-// node_modules/@peculiar/asn1-cms/build/es2015/certificate_choices.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/certificate_choices.js
 var CertificateSet_1;
 var OtherCertificateFormat = class {
   constructor(params = {}) {
@@ -18497,7 +18497,7 @@ CertificateSet = CertificateSet_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Set, itemType: CertificateChoices })
 ], CertificateSet);
 
-// node_modules/@peculiar/asn1-cms/build/es2015/content_info.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/content_info.js
 var ContentInfo = class {
   constructor(params = {}) {
     this.contentType = "";
@@ -18512,7 +18512,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.Any, context: 0 })
 ], ContentInfo.prototype, "content", void 0);
 
-// node_modules/@peculiar/asn1-cms/build/es2015/encapsulated_content_info.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/encapsulated_content_info.js
 var EncapsulatedContent = class EncapsulatedContent2 {
   constructor(params = {}) {
     Object.assign(this, params);
@@ -18540,7 +18540,7 @@ __decorate([
   AsnProp({ type: EncapsulatedContent, context: 0, optional: true })
 ], EncapsulatedContentInfo.prototype, "eContent", void 0);
 
-// node_modules/@peculiar/asn1-cms/build/es2015/encrypted_content_info.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/encrypted_content_info.js
 var EncryptedContent = class EncryptedContent2 {
   constructor(params = {}) {
     Object.assign(this, params);
@@ -18579,7 +18579,7 @@ __decorate([
   AsnProp({ type: EncryptedContent, optional: true })
 ], EncryptedContentInfo.prototype, "encryptedContent", void 0);
 
-// node_modules/@peculiar/asn1-cms/build/es2015/other_key_attribute.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/other_key_attribute.js
 var OtherKeyAttribute = class {
   constructor(params = {}) {
     this.keyAttrId = "";
@@ -18593,7 +18593,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.Any, optional: true })
 ], OtherKeyAttribute.prototype, "keyAttr", void 0);
 
-// node_modules/@peculiar/asn1-cms/build/es2015/key_agree_recipient_info.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/key_agree_recipient_info.js
 var RecipientEncryptedKeys_1;
 var RecipientKeyIdentifier = class {
   constructor(params = {}) {
@@ -18701,7 +18701,7 @@ __decorate([
   AsnProp({ type: RecipientEncryptedKeys })
 ], KeyAgreeRecipientInfo.prototype, "recipientEncryptedKeys", void 0);
 
-// node_modules/@peculiar/asn1-cms/build/es2015/key_trans_recipient_info.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/key_trans_recipient_info.js
 var RecipientIdentifier = class RecipientIdentifier2 {
   constructor(params = {}) {
     Object.assign(this, params);
@@ -18738,7 +18738,7 @@ __decorate([
   AsnProp({ type: OctetString2 })
 ], KeyTransRecipientInfo.prototype, "encryptedKey", void 0);
 
-// node_modules/@peculiar/asn1-cms/build/es2015/kek_recipient_info.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/kek_recipient_info.js
 var KEKIdentifier = class {
   constructor(params = {}) {
     this.keyIdentifier = new OctetString2();
@@ -18776,7 +18776,7 @@ __decorate([
   AsnProp({ type: OctetString2 })
 ], KEKRecipientInfo.prototype, "encryptedKey", void 0);
 
-// node_modules/@peculiar/asn1-cms/build/es2015/password_recipient_info.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/password_recipient_info.js
 var PasswordRecipientInfo = class {
   constructor(params = {}) {
     this.version = CMSVersion.v0;
@@ -18798,7 +18798,7 @@ __decorate([
   AsnProp({ type: OctetString2 })
 ], PasswordRecipientInfo.prototype, "encryptedKey", void 0);
 
-// node_modules/@peculiar/asn1-cms/build/es2015/recipient_info.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/recipient_info.js
 var OtherRecipientInfo = class {
   constructor(params = {}) {
     this.oriType = "";
@@ -18836,7 +18836,7 @@ RecipientInfo = __decorate([
   AsnType({ type: AsnTypeTypes.Choice })
 ], RecipientInfo);
 
-// node_modules/@peculiar/asn1-cms/build/es2015/recipient_infos.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/recipient_infos.js
 var RecipientInfos_1;
 var RecipientInfos = RecipientInfos_1 = class RecipientInfos2 extends AsnArray {
   constructor(items) {
@@ -18848,7 +18848,7 @@ RecipientInfos = RecipientInfos_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Set, itemType: RecipientInfo })
 ], RecipientInfos);
 
-// node_modules/@peculiar/asn1-cms/build/es2015/revocation_info_choice.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/revocation_info_choice.js
 var RevocationInfoChoices_1;
 var id_ri = `${id_pkix}.16`;
 var id_ri_ocsp_response = `${id_ri}.2`;
@@ -18888,7 +18888,7 @@ RevocationInfoChoices = RevocationInfoChoices_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Set, itemType: RevocationInfoChoice })
 ], RevocationInfoChoices);
 
-// node_modules/@peculiar/asn1-cms/build/es2015/originator_info.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/originator_info.js
 var OriginatorInfo = class {
   constructor(params = {}) {
     Object.assign(this, params);
@@ -18901,7 +18901,7 @@ __decorate([
   AsnProp({ type: RevocationInfoChoices, context: 1, implicit: true, optional: true })
 ], OriginatorInfo.prototype, "crls", void 0);
 
-// node_modules/@peculiar/asn1-cms/build/es2015/enveloped_data.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/enveloped_data.js
 var UnprotectedAttributes_1;
 var UnprotectedAttributes = UnprotectedAttributes_1 = class UnprotectedAttributes2 extends AsnArray {
   constructor(items) {
@@ -18936,10 +18936,10 @@ __decorate([
   AsnProp({ type: UnprotectedAttributes, context: 1, implicit: true, optional: true })
 ], EnvelopedData.prototype, "unprotectedAttrs", void 0);
 
-// node_modules/@peculiar/asn1-cms/build/es2015/object_identifiers.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/object_identifiers.js
 var id_signedData = "1.2.840.113549.1.7.2";
 
-// node_modules/@peculiar/asn1-cms/build/es2015/signed_data.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/signed_data.js
 var DigestAlgorithmIdentifiers_1;
 var DigestAlgorithmIdentifiers = DigestAlgorithmIdentifiers_1 = class DigestAlgorithmIdentifiers2 extends AsnArray {
   constructor(items) {
@@ -18978,7 +18978,7 @@ __decorate([
   AsnProp({ type: SignerInfos })
 ], SignedData.prototype, "signerInfos", void 0);
 
-// node_modules/@peculiar/asn1-ecc/build/es2015/object_identifiers.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-ecc/build/es2015/object_identifiers.js
 var id_ecPublicKey = "1.2.840.10045.2.1";
 var id_ecdsaWithSHA1 = "1.2.840.10045.4.1";
 var id_ecdsaWithSHA224 = "1.2.840.10045.4.3.1";
@@ -18989,7 +18989,7 @@ var id_secp256r1 = "1.2.840.10045.3.1.7";
 var id_secp384r1 = "1.3.132.0.34";
 var id_secp521r1 = "1.3.132.0.35";
 
-// node_modules/@peculiar/asn1-ecc/build/es2015/algorithms.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-ecc/build/es2015/algorithms.js
 function create(algorithm) {
   return new AlgorithmIdentifier({ algorithm });
 }
@@ -18999,7 +18999,7 @@ var ecdsaWithSHA256 = create(id_ecdsaWithSHA256);
 var ecdsaWithSHA384 = create(id_ecdsaWithSHA384);
 var ecdsaWithSHA512 = create(id_ecdsaWithSHA512);
 
-// node_modules/@peculiar/asn1-ecc/build/es2015/rfc3279.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-ecc/build/es2015/rfc3279.js
 var FieldID = class FieldID2 {
   constructor(params = {}) {
     Object.assign(this, params);
@@ -19065,7 +19065,7 @@ SpecifiedECDomain = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence })
 ], SpecifiedECDomain);
 
-// node_modules/@peculiar/asn1-ecc/build/es2015/ec_parameters.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-ecc/build/es2015/ec_parameters.js
 var ECParameters = class ECParameters2 {
   constructor(params = {}) {
     Object.assign(this, params);
@@ -19084,7 +19084,7 @@ ECParameters = __decorate([
   AsnType({ type: AsnTypeTypes.Choice })
 ], ECParameters);
 
-// node_modules/@peculiar/asn1-ecc/build/es2015/ec_private_key.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-ecc/build/es2015/ec_private_key.js
 var ECPrivateKey = class {
   constructor(params = {}) {
     this.version = 1;
@@ -19105,7 +19105,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.BitString, context: 1, optional: true })
 ], ECPrivateKey.prototype, "publicKey", void 0);
 
-// node_modules/@peculiar/asn1-ecc/build/es2015/ec_signature_value.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-ecc/build/es2015/ec_signature_value.js
 var ECDSASigValue = class {
   constructor(params = {}) {
     this.r = new ArrayBuffer(0);
@@ -19120,7 +19120,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.Integer, converter: AsnIntegerArrayBufferConverter })
 ], ECDSASigValue.prototype, "s", void 0);
 
-// node_modules/@peculiar/asn1-rsa/build/es2015/object_identifiers.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-rsa/build/es2015/object_identifiers.js
 var id_pkcs_1 = "1.2.840.113549.1.1";
 var id_rsaEncryption = `${id_pkcs_1}.1`;
 var id_RSAES_OAEP = `${id_pkcs_1}.7`;
@@ -19146,7 +19146,7 @@ var id_md2 = "1.2.840.113549.2.2";
 var id_md5 = "1.2.840.113549.2.5";
 var id_mgf1 = `${id_pkcs_1}.8`;
 
-// node_modules/@peculiar/asn1-rsa/build/es2015/algorithms.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-rsa/build/es2015/algorithms.js
 function create2(algorithm) {
   return new AlgorithmIdentifier({ algorithm, parameters: null });
 }
@@ -19199,7 +19199,7 @@ var sha512WithRSAEncryption = create2(id_sha512WithRSAEncryption);
 var sha512_224WithRSAEncryption = create2(id_sha512_224WithRSAEncryption);
 var sha512_256WithRSAEncryption = create2(id_sha512_256WithRSAEncryption);
 
-// node_modules/@peculiar/asn1-rsa/build/es2015/parameters/rsaes_oaep.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-rsa/build/es2015/parameters/rsaes_oaep.js
 var RsaEsOaepParams = class {
   constructor(params = {}) {
     this.hashAlgorithm = new AlgorithmIdentifier(sha1);
@@ -19225,7 +19225,7 @@ var RSAES_OAEP = new AlgorithmIdentifier({
   parameters: AsnConvert.serialize(new RsaEsOaepParams())
 });
 
-// node_modules/@peculiar/asn1-rsa/build/es2015/parameters/rsassa_pss.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-rsa/build/es2015/parameters/rsassa_pss.js
 var RsaSaPssParams = class {
   constructor(params = {}) {
     this.hashAlgorithm = new AlgorithmIdentifier(sha1);
@@ -19255,7 +19255,7 @@ var RSASSA_PSS = new AlgorithmIdentifier({
   parameters: AsnConvert.serialize(new RsaSaPssParams())
 });
 
-// node_modules/@peculiar/asn1-rsa/build/es2015/parameters/rsassa_pkcs1_v1_5.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-rsa/build/es2015/parameters/rsassa_pkcs1_v1_5.js
 var DigestInfo = class {
   constructor(params = {}) {
     this.digestAlgorithm = new AlgorithmIdentifier();
@@ -19270,7 +19270,7 @@ __decorate([
   AsnProp({ type: OctetString2 })
 ], DigestInfo.prototype, "digest", void 0);
 
-// node_modules/@peculiar/asn1-rsa/build/es2015/other_prime_info.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-rsa/build/es2015/other_prime_info.js
 var OtherPrimeInfos_1;
 var OtherPrimeInfo = class {
   constructor(params = {}) {
@@ -19299,7 +19299,7 @@ OtherPrimeInfos = OtherPrimeInfos_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence, itemType: OtherPrimeInfo })
 ], OtherPrimeInfos);
 
-// node_modules/@peculiar/asn1-rsa/build/es2015/rsa_private_key.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-rsa/build/es2015/rsa_private_key.js
 var RSAPrivateKey = class {
   constructor(params = {}) {
     this.version = 0;
@@ -19345,7 +19345,7 @@ __decorate([
   AsnProp({ type: OtherPrimeInfos, optional: true })
 ], RSAPrivateKey.prototype, "otherPrimeInfos", void 0);
 
-// node_modules/@peculiar/asn1-rsa/build/es2015/rsa_public_key.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-rsa/build/es2015/rsa_public_key.js
 var RSAPublicKey = class {
   constructor(params = {}) {
     this.modulus = new ArrayBuffer(0);
@@ -19360,7 +19360,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.Integer, converter: AsnIntegerArrayBufferConverter })
 ], RSAPublicKey.prototype, "publicExponent", void 0);
 
-// node_modules/tsyringe/dist/esm5/types/lifecycle.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tsyringe/dist/esm5/types/lifecycle.js
 var Lifecycle;
 (function(Lifecycle2) {
   Lifecycle2[Lifecycle2["Transient"] = 0] = "Transient";
@@ -19370,7 +19370,7 @@ var Lifecycle;
 })(Lifecycle || (Lifecycle = {}));
 var lifecycle_default = Lifecycle;
 
-// node_modules/tsyringe/node_modules/tslib/tslib.es6.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tsyringe/node_modules/tslib/tslib.es6.js
 var extendStatics = function(d, b) {
   extendStatics = Object.setPrototypeOf || { __proto__: [] } instanceof Array && function(d2, b2) {
     d2.__proto__ = b2;
@@ -19516,7 +19516,7 @@ function __spread() {
   return ar;
 }
 
-// node_modules/tsyringe/dist/esm5/reflection-helpers.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tsyringe/dist/esm5/reflection-helpers.js
 var INJECTION_TOKEN_METADATA_KEY = "injectionTokens";
 function getParamInfo(target) {
   var params = Reflect.getMetadata("design:paramtypes", target) || [];
@@ -19527,17 +19527,17 @@ function getParamInfo(target) {
   return params;
 }
 
-// node_modules/tsyringe/dist/esm5/providers/class-provider.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tsyringe/dist/esm5/providers/class-provider.js
 function isClassProvider(provider) {
   return !!provider.useClass;
 }
 
-// node_modules/tsyringe/dist/esm5/providers/factory-provider.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tsyringe/dist/esm5/providers/factory-provider.js
 function isFactoryProvider(provider) {
   return !!provider.useFactory;
 }
 
-// node_modules/tsyringe/dist/esm5/lazy-helpers.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tsyringe/dist/esm5/lazy-helpers.js
 var DelayedConstructor = (function() {
   function DelayedConstructor2(wrap) {
     this.wrap = wrap;
@@ -19588,7 +19588,7 @@ var DelayedConstructor = (function() {
   return DelayedConstructor2;
 })();
 
-// node_modules/tsyringe/dist/esm5/providers/injection-token.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tsyringe/dist/esm5/providers/injection-token.js
 function isNormalToken(token) {
   return typeof token === "string" || typeof token === "symbol";
 }
@@ -19602,22 +19602,22 @@ function isConstructorToken(token) {
   return typeof token === "function" || token instanceof DelayedConstructor;
 }
 
-// node_modules/tsyringe/dist/esm5/providers/token-provider.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tsyringe/dist/esm5/providers/token-provider.js
 function isTokenProvider(provider) {
   return !!provider.useToken;
 }
 
-// node_modules/tsyringe/dist/esm5/providers/value-provider.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tsyringe/dist/esm5/providers/value-provider.js
 function isValueProvider(provider) {
   return provider.useValue != void 0;
 }
 
-// node_modules/tsyringe/dist/esm5/providers/provider.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tsyringe/dist/esm5/providers/provider.js
 function isProvider(provider) {
   return isClassProvider(provider) || isValueProvider(provider) || isTokenProvider(provider) || isFactoryProvider(provider);
 }
 
-// node_modules/tsyringe/dist/esm5/registry-base.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tsyringe/dist/esm5/registry-base.js
 var RegistryBase = (function() {
   function RegistryBase2() {
     this._registryMap = /* @__PURE__ */ new Map();
@@ -19657,7 +19657,7 @@ var RegistryBase = (function() {
 })();
 var registry_base_default = RegistryBase;
 
-// node_modules/tsyringe/dist/esm5/registry.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tsyringe/dist/esm5/registry.js
 var Registry = (function(_super) {
   __extends(Registry2, _super);
   function Registry2() {
@@ -19667,7 +19667,7 @@ var Registry = (function(_super) {
 })(registry_base_default);
 var registry_default = Registry;
 
-// node_modules/tsyringe/dist/esm5/resolution-context.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tsyringe/dist/esm5/resolution-context.js
 var ResolutionContext = /* @__PURE__ */ (function() {
   function ResolutionContext2() {
     this.scopedResolutions = /* @__PURE__ */ new Map();
@@ -19676,7 +19676,7 @@ var ResolutionContext = /* @__PURE__ */ (function() {
 })();
 var resolution_context_default = ResolutionContext;
 
-// node_modules/tsyringe/dist/esm5/error-helpers.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tsyringe/dist/esm5/error-helpers.js
 function formatDependency(params, idx) {
   if (params === null) {
     return "at position #" + idx;
@@ -19698,7 +19698,7 @@ function formatErrorCtor(ctor, paramIdx, error2) {
   return composeErrorMessage("Cannot inject the dependency " + dep + ' of "' + ctor.name + '" constructor. Reason:', error2);
 }
 
-// node_modules/tsyringe/dist/esm5/types/disposable.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tsyringe/dist/esm5/types/disposable.js
 function isDisposable(value) {
   if (typeof value.dispose !== "function")
     return false;
@@ -19709,7 +19709,7 @@ function isDisposable(value) {
   return true;
 }
 
-// node_modules/tsyringe/dist/esm5/interceptors.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tsyringe/dist/esm5/interceptors.js
 var PreResolutionInterceptors = (function(_super) {
   __extends(PreResolutionInterceptors2, _super);
   function PreResolutionInterceptors2() {
@@ -19733,7 +19733,7 @@ var Interceptors = /* @__PURE__ */ (function() {
 })();
 var interceptors_default = Interceptors;
 
-// node_modules/tsyringe/dist/esm5/dependency-container.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tsyringe/dist/esm5/dependency-container.js
 var typeInfo = /* @__PURE__ */ new Map();
 var InternalDependencyContainer = (function() {
   function InternalDependencyContainer2(parent) {
@@ -20127,7 +20127,7 @@ var InternalDependencyContainer = (function() {
 })();
 var instance = new InternalDependencyContainer();
 
-// node_modules/tsyringe/dist/esm5/decorators/injectable.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tsyringe/dist/esm5/decorators/injectable.js
 function injectable(options) {
   return function(target) {
     typeInfo.set(target, getParamInfo(target));
@@ -20144,12 +20144,12 @@ function injectable(options) {
 }
 var injectable_default = injectable;
 
-// node_modules/tsyringe/dist/esm5/index.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tsyringe/dist/esm5/index.js
 if (typeof Reflect === "undefined" || !Reflect.getMetadata) {
   throw new Error(`tsyringe requires a reflect polyfill. Please add 'import "reflect-metadata"' to the top of your entry point.`);
 }
 
-// node_modules/@peculiar/asn1-pfx/build/es2015/attribute.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-pfx/build/es2015/attribute.js
 var PKCS12AttrSet_1;
 var PKCS12Attribute = class {
   constructor(params = {}) {
@@ -20174,7 +20174,7 @@ PKCS12AttrSet = PKCS12AttrSet_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence, itemType: PKCS12Attribute })
 ], PKCS12AttrSet);
 
-// node_modules/@peculiar/asn1-pfx/build/es2015/authenticated_safe.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-pfx/build/es2015/authenticated_safe.js
 var AuthenticatedSafe_1;
 var AuthenticatedSafe = AuthenticatedSafe_1 = class AuthenticatedSafe2 extends AsnArray {
   constructor(items) {
@@ -20186,7 +20186,7 @@ AuthenticatedSafe = AuthenticatedSafe_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence, itemType: ContentInfo })
 ], AuthenticatedSafe);
 
-// node_modules/@peculiar/asn1-pfx/build/es2015/object_identifiers.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-pfx/build/es2015/object_identifiers.js
 var id_rsadsi = "1.2.840.113549";
 var id_pkcs = `${id_rsadsi}.1`;
 var id_pkcs_12 = `${id_pkcs}.12`;
@@ -20199,7 +20199,7 @@ var id_pbeWithSHAAnd128BitRC2_CBC = `${id_pkcs_12PbeIds}.5`;
 var id_pbewithSHAAnd40BitRC2_CBC = `${id_pkcs_12PbeIds}.6`;
 var id_bagtypes = `${id_pkcs_12}.10.1`;
 
-// node_modules/@peculiar/asn1-pfx/build/es2015/bags/types.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-pfx/build/es2015/bags/types.js
 var id_keyBag = `${id_bagtypes}.1`;
 var id_pkcs8ShroudedKeyBag = `${id_bagtypes}.2`;
 var id_certBag = `${id_bagtypes}.3`;
@@ -20208,7 +20208,7 @@ var id_SecretBag = `${id_bagtypes}.5`;
 var id_SafeContents = `${id_bagtypes}.6`;
 var id_pkcs_9 = "1.2.840.113549.1.9";
 
-// node_modules/@peculiar/asn1-pfx/build/es2015/bags/cert_bag.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-pfx/build/es2015/bags/cert_bag.js
 var CertBag = class {
   constructor(params = {}) {
     this.certId = "";
@@ -20226,7 +20226,7 @@ var id_certTypes = `${id_pkcs_9}.22`;
 var id_x509Certificate = `${id_certTypes}.1`;
 var id_sdsiCertificate = `${id_certTypes}.2`;
 
-// node_modules/@peculiar/asn1-pfx/build/es2015/bags/crl_bag.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-pfx/build/es2015/bags/crl_bag.js
 var CRLBag = class {
   constructor(params = {}) {
     this.crlId = "";
@@ -20243,7 +20243,7 @@ __decorate([
 var id_crlTypes = `${id_pkcs_9}.23`;
 var id_x509CRL = `${id_crlTypes}.1`;
 
-// node_modules/@peculiar/asn1-pkcs8/build/es2015/encrypted_private_key_info.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-pkcs8/build/es2015/encrypted_private_key_info.js
 var EncryptedData = class extends OctetString2 {
 };
 var EncryptedPrivateKeyInfo = class {
@@ -20260,7 +20260,7 @@ __decorate([
   AsnProp({ type: EncryptedData })
 ], EncryptedPrivateKeyInfo.prototype, "encryptedData", void 0);
 
-// node_modules/@peculiar/asn1-pkcs8/build/es2015/private_key_info.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-pkcs8/build/es2015/private_key_info.js
 var Attributes_1;
 var Version2;
 (function(Version4) {
@@ -20298,21 +20298,21 @@ __decorate([
   AsnProp({ type: Attributes, implicit: true, context: 0, optional: true })
 ], PrivateKeyInfo.prototype, "attributes", void 0);
 
-// node_modules/@peculiar/asn1-pfx/build/es2015/bags/key_bag.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-pfx/build/es2015/bags/key_bag.js
 var KeyBag = class KeyBag2 extends PrivateKeyInfo {
 };
 KeyBag = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence })
 ], KeyBag);
 
-// node_modules/@peculiar/asn1-pfx/build/es2015/bags/pkcs8_shrouded_key_bag.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-pfx/build/es2015/bags/pkcs8_shrouded_key_bag.js
 var PKCS8ShroudedKeyBag = class PKCS8ShroudedKeyBag2 extends EncryptedPrivateKeyInfo {
 };
 PKCS8ShroudedKeyBag = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence })
 ], PKCS8ShroudedKeyBag);
 
-// node_modules/@peculiar/asn1-pfx/build/es2015/bags/secret_bag.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-pfx/build/es2015/bags/secret_bag.js
 var SecretBag = class {
   constructor(params = {}) {
     this.secretTypeId = "";
@@ -20327,7 +20327,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.Any, context: 0 })
 ], SecretBag.prototype, "secretValue", void 0);
 
-// node_modules/@peculiar/asn1-pfx/build/es2015/mac_data.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-pfx/build/es2015/mac_data.js
 var MacData = class {
   constructor(params = {}) {
     this.mac = new DigestInfo();
@@ -20346,7 +20346,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.Integer, defaultValue: 1 })
 ], MacData.prototype, "iterations", void 0);
 
-// node_modules/@peculiar/asn1-pfx/build/es2015/pfx.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-pfx/build/es2015/pfx.js
 var PFX = class {
   constructor(params = {}) {
     this.version = 3;
@@ -20365,7 +20365,7 @@ __decorate([
   AsnProp({ type: MacData, optional: true })
 ], PFX.prototype, "macData", void 0);
 
-// node_modules/@peculiar/asn1-pfx/build/es2015/safe_bag.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-pfx/build/es2015/safe_bag.js
 var SafeContents_1;
 var SafeBag = class {
   constructor(params = {}) {
@@ -20393,7 +20393,7 @@ SafeContents = SafeContents_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence, itemType: SafeBag })
 ], SafeContents);
 
-// node_modules/@peculiar/asn1-pkcs9/build/es2015/index.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-pkcs9/build/es2015/index.js
 var ExtensionRequest_1;
 var ExtendedCertificateAttributes_1;
 var SMIMECapabilities_1;
@@ -20637,7 +20637,7 @@ SMIMECapabilities = SMIMECapabilities_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence, itemType: SMIMECapability })
 ], SMIMECapabilities);
 
-// node_modules/@peculiar/asn1-csr/build/es2015/attributes.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-csr/build/es2015/attributes.js
 var Attributes_12;
 var Attributes3 = Attributes_12 = class Attributes4 extends AsnArray {
   constructor(items) {
@@ -20649,7 +20649,7 @@ Attributes3 = Attributes_12 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence, itemType: Attribute })
 ], Attributes3);
 
-// node_modules/@peculiar/asn1-csr/build/es2015/certification_request_info.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-csr/build/es2015/certification_request_info.js
 var CertificationRequestInfo = class {
   constructor(params = {}) {
     this.version = 0;
@@ -20672,7 +20672,7 @@ __decorate([
   AsnProp({ type: Attributes3, implicit: true, context: 0, optional: true })
 ], CertificationRequestInfo.prototype, "attributes", void 0);
 
-// node_modules/@peculiar/asn1-csr/build/es2015/certification_request.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-csr/build/es2015/certification_request.js
 var CertificationRequest = class {
   constructor(params = {}) {
     this.certificationRequestInfo = new CertificationRequestInfo();
@@ -20691,7 +20691,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.BitString })
 ], CertificationRequest.prototype, "signature", void 0);
 
-// node_modules/@peculiar/x509/build/x509.es.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/x509/build/x509.es.js
 var diAlgorithm = "crypto.algorithm";
 var AlgorithmProvider = class {
   getAlgorithms() {
@@ -23509,7 +23509,7 @@ AsnEcSignatureFormatter.namedCurveSize.set("K-256", 32);
 AsnEcSignatureFormatter.namedCurveSize.set("P-384", 48);
 AsnEcSignatureFormatter.namedCurveSize.set("P-521", 66);
 
-// node_modules/@simplewebauthn/server/esm/helpers/fetch.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/fetch.js
 function fetch2(url) {
   return _fetchInternals.stubThis(url);
 }
@@ -23517,7 +23517,7 @@ var _fetchInternals = {
   stubThis: (url) => globalThis.fetch(url)
 };
 
-// node_modules/@simplewebauthn/server/esm/helpers/isCertRevoked.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/isCertRevoked.js
 var cacheRevokedCerts = {};
 async function isCertRevoked(cert) {
   const { extensions } = cert;
@@ -23589,7 +23589,7 @@ async function isCertRevoked(cert) {
   return false;
 }
 
-// node_modules/@simplewebauthn/server/esm/helpers/decodeAuthenticatorExtensions.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/decodeAuthenticatorExtensions.js
 function decodeAuthenticatorExtensions(extensionData) {
   let toCBOR;
   try {
@@ -23612,7 +23612,7 @@ function convertMapToObjectDeep(input) {
   return mapped;
 }
 
-// node_modules/@simplewebauthn/server/esm/helpers/parseAuthenticatorData.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/parseAuthenticatorData.js
 function parseAuthenticatorData(authData) {
   if (authData.byteLength < 37) {
     throw new Error(`Authenticator data was ${authData.byteLength} bytes, expected at least 37 bytes`);
@@ -23701,7 +23701,7 @@ var _parseAuthenticatorDataInternals = {
   stubThis: (value) => value
 };
 
-// node_modules/@simplewebauthn/server/esm/helpers/toHash.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/toHash.js
 function toHash(data, algorithm = -7) {
   if (typeof data === "string") {
     data = isoUint8Array_exports.fromUTF8String(data);
@@ -23710,7 +23710,7 @@ function toHash(data, algorithm = -7) {
   return digest2;
 }
 
-// node_modules/@simplewebauthn/server/esm/helpers/validateCertificatePath.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/validateCertificatePath.js
 async function validateCertificatePath(x5cCertsPEM, trustAnchorsPEM = []) {
   if (trustAnchorsPEM.length === 0) {
     return true;
@@ -23817,7 +23817,7 @@ var InvalidSubjectAndIssuer = class extends Error {
   }
 };
 
-// node_modules/@simplewebauthn/server/esm/helpers/mapX509SignatureAlgToCOSEAlg.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/mapX509SignatureAlgToCOSEAlg.js
 function mapX509SignatureAlgToCOSEAlg(signatureAlgorithm) {
   let alg;
   if (signatureAlgorithm === "1.2.840.10045.4.3.2") {
@@ -23840,7 +23840,7 @@ function mapX509SignatureAlgToCOSEAlg(signatureAlgorithm) {
   return alg;
 }
 
-// node_modules/@simplewebauthn/server/esm/helpers/convertX509PublicKeyToCOSE.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/convertX509PublicKeyToCOSE.js
 function convertX509PublicKeyToCOSE(x509Certificate) {
   let cosePublicKey = /* @__PURE__ */ new Map();
   const x509 = AsnParser.parse(x509Certificate, Certificate);
@@ -23894,7 +23894,7 @@ function convertX509PublicKeyToCOSE(x509Certificate) {
   return cosePublicKey;
 }
 
-// node_modules/@simplewebauthn/server/esm/helpers/verifySignature.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/verifySignature.js
 function verifySignature(opts) {
   const { signature, data, credentialPublicKey, x509Certificate, hashAlgorithm } = opts;
   if (!x509Certificate && !credentialPublicKey) {
@@ -23920,7 +23920,7 @@ var _verifySignatureInternals = {
   stubThis: (value) => value
 };
 
-// node_modules/@simplewebauthn/server/esm/metadata/parseJWT.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/metadata/parseJWT.js
 function parseJWT(jwt) {
   const parts = jwt.split(".");
   return [
@@ -23930,7 +23930,7 @@ function parseJWT(jwt) {
   ];
 }
 
-// node_modules/@simplewebauthn/server/esm/metadata/verifyJWT.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/metadata/verifyJWT.js
 function verifyJWT(jwt, leafCert) {
   const [header, payload, signature] = jwt.split(".");
   const certCOSE = convertX509PublicKeyToCOSE(leafCert);
@@ -23954,13 +23954,13 @@ function verifyJWT(jwt, leafCert) {
   throw new Error(`JWT verification with public key of kty ${kty} is not supported by this method`);
 }
 
-// node_modules/@simplewebauthn/server/esm/helpers/convertPEMToBytes.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/convertPEMToBytes.js
 function convertPEMToBytes(pem) {
   const certBase64 = pem.replace("-----BEGIN CERTIFICATE-----", "").replace("-----END CERTIFICATE-----", "").replace(/[\n ]/g, "");
   return isoBase64URL_exports.toBuffer(certBase64, "base64");
 }
 
-// node_modules/@simplewebauthn/server/esm/services/defaultRootCerts/android-safetynet.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/services/defaultRootCerts/android-safetynet.js
 var GlobalSign_Root_CA = `-----BEGIN CERTIFICATE-----
 MIIDdTCCAl2gAwIBAgILBAAAAAABFUtaw5QwDQYJKoZIhvcNAQEFBQAwVzELMAkG
 A1UEBhMCQkUxGTAXBgNVBAoTEEdsb2JhbFNpZ24gbnYtc2ExEDAOBgNVBAsTB1Jv
@@ -23984,7 +23984,7 @@ HMUfpIBvFSDJ3gyICh3WZlXi/EjJKSZp4A==
 -----END CERTIFICATE-----
 `;
 
-// node_modules/@simplewebauthn/server/esm/services/defaultRootCerts/android-key.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/services/defaultRootCerts/android-key.js
 var Google_Hardware_Attestation_Root_1 = `-----BEGIN CERTIFICATE-----
 MIIFYDCCA0igAwIBAgIJAOj6GWMU0voYMA0GCSqGSIb3DQEBCwUAMBsxGTAXBgNV
 BAUTEGY5MjAwOWU4NTNiNmIwNDUwHhcNMTYwNTI2MTYyODUyWhcNMjYwNTI0MTYy
@@ -24113,7 +24113,7 @@ w1IdYIg2Wxg7yHcQZemFQg==
 -----END CERTIFICATE-----
 `;
 
-// node_modules/@simplewebauthn/server/esm/services/defaultRootCerts/apple.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/services/defaultRootCerts/apple.js
 var Apple_WebAuthn_Root_CA = `-----BEGIN CERTIFICATE-----
 MIICEjCCAZmgAwIBAgIQaB0BbHo84wIlpQGUKEdXcTAKBggqhkjOPQQDAzBLMR8w
 HQYDVQQDDBZBcHBsZSBXZWJBdXRobiBSb290IENBMRMwEQYDVQQKDApBcHBsZSBJ
@@ -24130,7 +24130,7 @@ jAGGiQIwHFj+dJZYUJR786osByBelJYsVZd2GbHQu209b5RCmGQ21gpSAk9QZW4B
 -----END CERTIFICATE-----
 `;
 
-// node_modules/@simplewebauthn/server/esm/services/defaultRootCerts/mds.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/services/defaultRootCerts/mds.js
 var GlobalSign_Root_CA_R3 = `-----BEGIN CERTIFICATE-----
 MIIDXzCCAkegAwIBAgILBAAAAAABIVhTCKIwDQYJKoZIhvcNAQELBQAwTDEgMB4G
 A1UECxMXR2xvYmFsU2lnbiBSb290IENBIC0gUjMxEzARBgNVBAoTCkdsb2JhbFNp
@@ -24154,7 +24154,7 @@ WD9f
 -----END CERTIFICATE-----
  `;
 
-// node_modules/@simplewebauthn/server/esm/services/settingsService.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/services/settingsService.js
 var BaseSettingsService = class {
   constructor() {
     Object.defineProperty(this, "pemCertificates", {
@@ -24205,7 +24205,7 @@ SettingsService.setRootCertificates({
   certificates: [GlobalSign_Root_CA_R3]
 });
 
-// node_modules/@simplewebauthn/server/esm/metadata/verifyMDSBlob.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/metadata/verifyMDSBlob.js
 async function verifyMDSBlob(blob) {
   const parsedJWT = parseJWT(blob);
   const header = parsedJWT[0];
@@ -24245,7 +24245,7 @@ async function verifyMDSBlob(blob) {
   };
 }
 
-// node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/verifyOKP.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/verifyOKP.js
 async function verifyOKP(opts) {
   const { cosePublicKey, signature, data } = opts;
   const WebCrypto = await getWebCrypto();
@@ -24291,7 +24291,7 @@ async function verifyOKP(opts) {
   return WebCrypto.subtle.verify(verifyAlgorithm, key, signature, data);
 }
 
-// node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/unwrapEC2Signature.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/unwrapEC2Signature.js
 function unwrapEC2Signature(signature, crv) {
   const parsedSignature = AsnParser.parse(signature, ECDSASigValue);
   const rBytes = new Uint8Array(parsedSignature.r);
@@ -24332,7 +24332,7 @@ function toNormalizedBytes(bytes, componentLength) {
   return normalizedBytes;
 }
 
-// node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/verify.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/verify.js
 function verify(opts) {
   const { cosePublicKey, signature, data, shaHashOverride } = opts;
   if (isCOSEPublicKeyEC2(cosePublicKey)) {
@@ -24356,7 +24356,7 @@ function verify(opts) {
   throw new Error(`Signature verification with public key of kty ${kty} is not supported by this method`);
 }
 
-// node_modules/@simplewebauthn/server/esm/helpers/iso/isoUint8Array.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/iso/isoUint8Array.js
 var isoUint8Array_exports = {};
 __export(isoUint8Array_exports, {
   areEqual: () => areEqual,
@@ -24414,7 +24414,7 @@ function toDataView(array2) {
   return new DataView(array2.buffer, array2.byteOffset, array2.length);
 }
 
-// node_modules/@simplewebauthn/server/esm/helpers/generateChallenge.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/generateChallenge.js
 async function generateChallenge() {
   const challenge = new Uint8Array(32);
   await isoCrypto_exports.getRandomValues(challenge);
@@ -24424,7 +24424,7 @@ var _generateChallengeInternals = {
   stubThis: (value) => value
 };
 
-// node_modules/@simplewebauthn/server/esm/registration/generateRegistrationOptions.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/registration/generateRegistrationOptions.js
 var supportedCOSEAlgorithmIdentifiers = [
   // EdDSA (In first position to encourage authenticators to use this over ES256)
   -8,
@@ -24523,7 +24523,7 @@ async function generateRegistrationOptions(options) {
   };
 }
 
-// node_modules/@simplewebauthn/server/esm/helpers/parseBackupFlags.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/parseBackupFlags.js
 function parseBackupFlags({ be, bs }) {
   const credentialBackedUp = bs;
   let credentialDeviceType = "singleDevice";
@@ -24542,7 +24542,7 @@ var InvalidBackupFlags = class extends Error {
   }
 };
 
-// node_modules/@simplewebauthn/server/esm/helpers/matchExpectedRPID.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/matchExpectedRPID.js
 async function matchExpectedRPID(rpIDHash, expectedRPIDs) {
   try {
     const matchedRPID = await Promise.any(expectedRPIDs.map((expected) => {
@@ -24573,7 +24573,7 @@ var UnexpectedRPIDHash = class extends Error {
   }
 };
 
-// node_modules/@simplewebauthn/server/esm/registration/verifications/verifyAttestationFIDOU2F.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/registration/verifications/verifyAttestationFIDOU2F.js
 async function verifyAttestationFIDOU2F(options) {
   const { attStmt, clientDataHash, rpIdHash, credentialID, credentialPublicKey, aaguid, rootCertificates } = options;
   const reservedByte = Uint8Array.from([0]);
@@ -24611,7 +24611,7 @@ async function verifyAttestationFIDOU2F(options) {
   });
 }
 
-// node_modules/@simplewebauthn/server/esm/helpers/validateExtFIDOGenCEAAGUID.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/validateExtFIDOGenCEAAGUID.js
 var id_fido_gen_ce_aaguid = "1.3.6.1.4.1.45724.1.1.4";
 function validateExtFIDOGenCEAAGUID(certExtensions, aaguid) {
   if (!certExtensions) {
@@ -24632,13 +24632,13 @@ function validateExtFIDOGenCEAAGUID(certExtensions, aaguid) {
   return true;
 }
 
-// node_modules/@simplewebauthn/server/esm/helpers/logging.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/logging.js
 function getLogger(_name) {
   return (_message, ..._rest) => {
   };
 }
 
-// node_modules/@simplewebauthn/server/esm/services/metadataService.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/services/metadataService.js
 var NonRefreshingMDS = {
   url: "",
   no: 0,
@@ -24845,7 +24845,7 @@ var BaseMetadataService = class {
 };
 var MetadataService = new BaseMetadataService();
 
-// node_modules/@simplewebauthn/server/esm/metadata/verifyAttestationWithMetadata.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/metadata/verifyAttestationWithMetadata.js
 async function verifyAttestationWithMetadata({ statement, credentialPublicKey, x5c, attestationStatementAlg }) {
   const { authenticationAlgorithms, authenticatorGetInfo, attestationRootCertificates } = statement;
   const keypairCOSEAlgs = /* @__PURE__ */ new Set();
@@ -24941,7 +24941,7 @@ function stringifyCOSEInfo(info) {
   return toReturn;
 }
 
-// node_modules/@simplewebauthn/server/esm/registration/verifications/verifyAttestationPacked.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/registration/verifications/verifyAttestationPacked.js
 async function verifyAttestationPacked(options) {
   const { attStmt, clientDataHash, authData, credentialPublicKey, aaguid, rootCertificates } = options;
   const sig = attStmt.get("sig");
@@ -25033,7 +25033,7 @@ async function verifyAttestationPacked(options) {
   return verified;
 }
 
-// node_modules/@simplewebauthn/server/esm/registration/verifications/verifyAttestationAndroidSafetyNet.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/registration/verifications/verifyAttestationAndroidSafetyNet.js
 async function verifyAttestationAndroidSafetyNet(options) {
   const { attStmt, clientDataHash, authData, aaguid, rootCertificates, verifyTimestampMS = true, credentialPublicKey, attestationSafetyNetEnforceCTSCheck } = options;
   const alg = attStmt.get("alg");
@@ -25108,7 +25108,7 @@ async function verifyAttestationAndroidSafetyNet(options) {
   return verified;
 }
 
-// node_modules/@simplewebauthn/server/esm/registration/verifications/tpm/constants.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/registration/verifications/tpm/constants.js
 var TPM_ST = {
   196: "TPM_ST_RSP_COMMAND",
   32768: "TPM_ST_NULL",
@@ -25226,7 +25226,7 @@ var TPM_ECC_CURVE_COSE_CRV_MAP = {
   // p256
 };
 
-// node_modules/@simplewebauthn/server/esm/registration/verifications/tpm/parseCertInfo.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/registration/verifications/tpm/parseCertInfo.js
 function parseCertInfo(certInfo) {
   let pointer = 0;
   const dataView = isoUint8Array_exports.toDataView(certInfo);
@@ -25273,7 +25273,7 @@ function parseCertInfo(certInfo) {
   };
 }
 
-// node_modules/@simplewebauthn/server/esm/registration/verifications/tpm/parsePubArea.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/registration/verifications/tpm/parsePubArea.js
 function parsePubArea(pubArea) {
   let pointer = 0;
   const dataView = isoUint8Array_exports.toDataView(pubArea);
@@ -25344,7 +25344,7 @@ function parsePubArea(pubArea) {
   };
 }
 
-// node_modules/@simplewebauthn/server/esm/registration/verifications/tpm/verifyAttestationTPM.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/registration/verifications/tpm/verifyAttestationTPM.js
 async function verifyAttestationTPM(options) {
   const { aaguid, attStmt, authData, credentialPublicKey, clientDataHash, rootCertificates } = options;
   const ver = attStmt.get("ver");
@@ -25575,7 +25575,7 @@ function attestedNameAlgToCOSEAlg(alg) {
   throw new Error(`Unexpected TPM attested name alg ${alg}`);
 }
 
-// node_modules/@peculiar/asn1-android/build/es2015/key_description.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-android/build/es2015/key_description.js
 var IntegerSet_1;
 var id_ce_keyDescription = "1.3.6.1.4.1.11129.2.1.17";
 var VerifiedBootState;
@@ -25864,7 +25864,7 @@ __decorate([
   AsnProp({ type: AuthorizationList })
 ], KeyMintKeyDescription.prototype, "hardwareEnforced", void 0);
 
-// node_modules/@peculiar/asn1-android/build/es2015/nonstandard.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-android/build/es2015/nonstandard.js
 var NonStandardAuthorizationList_1;
 var NonStandardAuthorization = class NonStandardAuthorization2 extends AuthorizationList {
 };
@@ -25960,7 +25960,7 @@ NonStandardKeyMintKeyDescription = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence })
 ], NonStandardKeyMintKeyDescription);
 
-// node_modules/@peculiar/asn1-android/build/es2015/attestation.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-android/build/es2015/attestation.js
 var AttestationPackageInfo = class {
   constructor(params = {}) {
     Object.assign(this, params);
@@ -25984,7 +25984,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.OctetString, repeated: "set" })
 ], AttestationApplicationId.prototype, "signatureDigests", void 0);
 
-// node_modules/@simplewebauthn/server/esm/registration/verifications/verifyAttestationAndroidKey.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/registration/verifications/verifyAttestationAndroidKey.js
 async function verifyAttestationAndroidKey(options) {
   const { authData, clientDataHash, attStmt, credentialPublicKey, aaguid, rootCertificates } = options;
   const x5c = attStmt.get("x5c");
@@ -26058,7 +26058,7 @@ async function verifyAttestationAndroidKey(options) {
   });
 }
 
-// node_modules/@simplewebauthn/server/esm/registration/verifications/verifyAttestationApple.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/registration/verifications/verifyAttestationApple.js
 async function verifyAttestationApple(options) {
   const { attStmt, authData, clientDataHash, credentialPublicKey, rootCertificates } = options;
   const x5c = attStmt.get("x5c");
@@ -26094,7 +26094,7 @@ async function verifyAttestationApple(options) {
   return true;
 }
 
-// node_modules/@simplewebauthn/server/esm/registration/verifyRegistrationResponse.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/registration/verifyRegistrationResponse.js
 async function verifyRegistrationResponse(options) {
   const { response, expectedChallenge, expectedOrigin, expectedRPID, expectedType, requireUserPresence = true, requireUserVerification = true, supportedAlgorithmIDs = supportedCOSEAlgorithmIdentifiers, attestationSafetyNetEnforceCTSCheck = true } = options;
   const { id, rawId, type: credentialType, response: attestationResponse } = response;
@@ -26249,7 +26249,7 @@ async function verifyRegistrationResponse(options) {
   };
 }
 
-// node_modules/@simplewebauthn/server/esm/authentication/generateAuthenticationOptions.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/authentication/generateAuthenticationOptions.js
 async function generateAuthenticationOptions(options) {
   const { allowCredentials, challenge = await generateChallenge(), timeout = 6e4, userVerification = "preferred", extensions, rpID } = options;
   let _challenge = challenge;
@@ -26275,7 +26275,7 @@ async function generateAuthenticationOptions(options) {
   };
 }
 
-// node_modules/@simplewebauthn/server/esm/authentication/verifyAuthenticationResponse.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/authentication/verifyAuthenticationResponse.js
 async function verifyAuthenticationResponse(options) {
   const { response, expectedChallenge, expectedOrigin, expectedRPID, expectedType, credential, requireUserVerification = true, advancedFIDOConfig } = options;
   const { id, rawId, type: credentialType, response: assertionResponse } = response;
@@ -41996,7 +41996,7 @@ function errorMessage(error2) {
   return normalizeText31(error2) || "unknown error";
 }
 
-// node_modules/zod/v3/helpers/util.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v3/helpers/util.js
 var util;
 (function(util2) {
   util2.assertEqual = (_) => {
@@ -42130,7 +42130,7 @@ var getParsedType = (data) => {
   }
 };
 
-// node_modules/zod/v3/ZodError.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v3/ZodError.js
 var ZodIssueCode = util.arrayToEnum([
   "invalid_type",
   "invalid_literal",
@@ -42244,7 +42244,7 @@ ZodError.create = (issues) => {
   return error2;
 };
 
-// node_modules/zod/v3/locales/en.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v3/locales/en.js
 var errorMap = (issue2, _ctx) => {
   let message;
   switch (issue2.code) {
@@ -42347,13 +42347,13 @@ var errorMap = (issue2, _ctx) => {
 };
 var en_default = errorMap;
 
-// node_modules/zod/v3/errors.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v3/errors.js
 var overrideErrorMap = en_default;
 function getErrorMap() {
   return overrideErrorMap;
 }
 
-// node_modules/zod/v3/helpers/parseUtil.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v3/helpers/parseUtil.js
 var makeIssue = (params) => {
   const { data, path, errorMaps, issueData } = params;
   const fullPath = [...path, ...issueData.path || []];
@@ -42462,14 +42462,14 @@ var isDirty = (x) => x.status === "dirty";
 var isValid = (x) => x.status === "valid";
 var isAsync = (x) => typeof Promise !== "undefined" && x instanceof Promise;
 
-// node_modules/zod/v3/helpers/errorUtil.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v3/helpers/errorUtil.js
 var errorUtil;
 (function(errorUtil2) {
   errorUtil2.errToObj = (message) => typeof message === "string" ? { message } : message || {};
   errorUtil2.toString = (message) => typeof message === "string" ? message : message?.message;
 })(errorUtil || (errorUtil = {}));
 
-// node_modules/zod/v3/types.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v3/types.js
 var ParseInputLazyPath = class {
   constructor(parent, value, path, key) {
     this._cachedPath = [];
@@ -45873,7 +45873,7 @@ var nullableType = ZodNullable.create;
 var preprocessType = ZodEffects.createWithPreprocess;
 var pipelineType = ZodPipeline.create;
 
-// node_modules/zod/v4/core/core.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v4/core/core.js
 var _a3;
 // @__NO_SIDE_EFFECTS__
 function $constructor(name, initializer3, params) {
@@ -45947,7 +45947,7 @@ function config(newConfig) {
   return globalConfig;
 }
 
-// node_modules/zod/v4/core/util.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v4/core/util.js
 var util_exports = {};
 __export(util_exports, {
   BIGINT_FORMAT_RANGES: () => BIGINT_FORMAT_RANGES,
@@ -46643,7 +46643,7 @@ var Class = class {
   }
 };
 
-// node_modules/zod/v4/core/errors.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v4/core/errors.js
 var initializer = (inst, def) => {
   inst.name = "$ZodError";
   Object.defineProperty(inst, "_zod", {
@@ -46712,7 +46712,7 @@ function formatError(error2, mapper = (issue2) => issue2.message) {
   return fieldErrors;
 }
 
-// node_modules/zod/v4/core/parse.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v4/core/parse.js
 var _parse = (_Err) => (schema, value, _ctx, _params) => {
   const ctx = _ctx ? { ..._ctx, async: false } : { async: false };
   const result = schema._zod.run({ value, issues: [] }, ctx);
@@ -46792,7 +46792,7 @@ var _safeDecodeAsync = (_Err) => async (schema, value, _ctx) => {
   return _safeParseAsync(_Err)(schema, value, _ctx);
 };
 
-// node_modules/zod/v4/core/regexes.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v4/core/regexes.js
 var cuid = /^[cC][0-9a-z]{6,}$/;
 var cuid2 = /^[0-9a-z]+$/;
 var ulid = /^[0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{26}$/;
@@ -46850,7 +46850,7 @@ var _null = /^null$/i;
 var lowercase = /^[^A-Z]*$/;
 var uppercase = /^[^a-z]*$/;
 
-// node_modules/zod/v4/core/checks.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v4/core/checks.js
 var $ZodCheck = /* @__PURE__ */ $constructor("$ZodCheck", (inst, def) => {
   var _a5;
   inst._zod ?? (inst._zod = {});
@@ -47240,7 +47240,7 @@ var $ZodCheckOverwrite = /* @__PURE__ */ $constructor("$ZodCheckOverwrite", (ins
   };
 });
 
-// node_modules/zod/v4/core/doc.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v4/core/doc.js
 var Doc = class {
   constructor(args = []) {
     this.content = [];
@@ -47276,14 +47276,14 @@ var Doc = class {
   }
 };
 
-// node_modules/zod/v4/core/versions.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v4/core/versions.js
 var version = {
   major: 4,
   minor: 4,
   patch: 3
 };
 
-// node_modules/zod/v4/core/schemas.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v4/core/schemas.js
 var $ZodType = /* @__PURE__ */ $constructor("$ZodType", (inst, def) => {
   var _a5;
   inst ?? (inst = {});
@@ -48763,7 +48763,7 @@ function handleRefineResult(result, payload, input, inst) {
   }
 }
 
-// node_modules/zod/v4/locales/en.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v4/locales/en.js
 var error = () => {
   const Sizable = {
     string: { unit: "characters", verb: "to have" },
@@ -48876,7 +48876,7 @@ function en_default2() {
   };
 }
 
-// node_modules/zod/v4/core/registries.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v4/core/registries.js
 var _a4;
 var $output = Symbol("ZodOutput");
 var $input = Symbol("ZodInput");
@@ -48926,7 +48926,7 @@ function registry() {
 (_a4 = globalThis).__zod_globalRegistry ?? (_a4.__zod_globalRegistry = registry());
 var globalRegistry = globalThis.__zod_globalRegistry;
 
-// node_modules/zod/v4/core/api.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v4/core/api.js
 // @__NO_SIDE_EFFECTS__
 function _string(Class2, params) {
   return new Class2({
@@ -49454,7 +49454,7 @@ function _check(fn, params) {
   return ch;
 }
 
-// node_modules/zod/v4/core/to-json-schema.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v4/core/to-json-schema.js
 function initializeContext(params) {
   let target = params?.target ?? "draft-2020-12";
   if (target === "draft-4")
@@ -49813,7 +49813,7 @@ var createStandardJSONSchemaMethod = (schema, io, processors = {}) => (params) =
   return finalize(ctx, schema);
 };
 
-// node_modules/zod/v4/core/json-schema-processors.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v4/core/json-schema-processors.js
 var formatMap = {
   guid: "uuid",
   url: "uri",
@@ -50357,7 +50357,7 @@ function toJSONSchema(input, params) {
   return finalize(ctx, input);
 }
 
-// node_modules/zod/v4/mini/schemas.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v4/mini/schemas.js
 var ZodMiniType = /* @__PURE__ */ $constructor("ZodMiniType", (inst, def) => {
   if (!inst._zod)
     throw new Error("Uninitialized schema in ZodMiniType.");
@@ -50403,7 +50403,7 @@ function object(shape, params) {
   return new ZodMiniObject(def);
 }
 
-// node_modules/@modelcontextprotocol/sdk/dist/esm/server/zod-compat.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@modelcontextprotocol/sdk/dist/esm/server/zod-compat.js
 function isZ4Schema(s) {
   const schema = s;
   return !!schema._zod;
@@ -50547,7 +50547,7 @@ function getLiteralValue(schema) {
   return void 0;
 }
 
-// node_modules/zod/v4/classic/iso.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v4/classic/iso.js
 var iso_exports2 = {};
 __export(iso_exports2, {
   ZodISODate: () => ZodISODate,
@@ -50588,7 +50588,7 @@ function duration2(params) {
   return _isoDuration(ZodISODuration, params);
 }
 
-// node_modules/zod/v4/classic/errors.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v4/classic/errors.js
 var initializer2 = (inst, issues) => {
   $ZodError.init(inst, issues);
   inst.name = "ZodError";
@@ -50627,7 +50627,7 @@ var ZodRealError = /* @__PURE__ */ $constructor("ZodError", initializer2, {
   Parent: Error
 });
 
-// node_modules/zod/v4/classic/parse.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v4/classic/parse.js
 var parse2 = /* @__PURE__ */ _parse(ZodRealError);
 var parseAsync2 = /* @__PURE__ */ _parseAsync(ZodRealError);
 var safeParse4 = /* @__PURE__ */ _safeParse(ZodRealError);
@@ -50641,7 +50641,7 @@ var safeDecode2 = /* @__PURE__ */ _safeDecode(ZodRealError);
 var safeEncodeAsync2 = /* @__PURE__ */ _safeEncodeAsync(ZodRealError);
 var safeDecodeAsync2 = /* @__PURE__ */ _safeDecodeAsync(ZodRealError);
 
-// node_modules/zod/v4/classic/schemas.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v4/classic/schemas.js
 var _installedGroups = /* @__PURE__ */ new WeakMap();
 function _installLazyMethods(inst, group, methods) {
   const proto = Object.getPrototypeOf(inst);
@@ -51483,10 +51483,10 @@ function preprocess(fn, schema) {
   });
 }
 
-// node_modules/zod/v4/classic/external.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v4/classic/external.js
 config(en_default2());
 
-// node_modules/@modelcontextprotocol/sdk/dist/esm/types.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@modelcontextprotocol/sdk/dist/esm/types.js
 var LATEST_PROTOCOL_VERSION = "2025-11-25";
 var DEFAULT_NEGOTIATED_PROTOCOL_VERSION = "2025-03-26";
 var SUPPORTED_PROTOCOL_VERSIONS = [LATEST_PROTOCOL_VERSION, "2025-06-18", "2025-03-26", "2024-11-05", "2024-10-07"];
@@ -53019,12 +53019,12 @@ var UrlElicitationRequiredError = class extends McpError {
   }
 };
 
-// node_modules/@modelcontextprotocol/sdk/dist/esm/experimental/tasks/interfaces.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@modelcontextprotocol/sdk/dist/esm/experimental/tasks/interfaces.js
 function isTerminal(status) {
   return status === "completed" || status === "failed" || status === "cancelled";
 }
 
-// node_modules/zod-to-json-schema/dist/esm/Options.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/Options.js
 var ignoreOverride = Symbol("Let zodToJsonSchema decide on which parser to use");
 var defaultOptions = {
   name: void 0,
@@ -53058,7 +53058,7 @@ var getDefaultOptions = (options) => typeof options === "string" ? {
   ...options
 };
 
-// node_modules/zod-to-json-schema/dist/esm/Refs.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/Refs.js
 var getRefs = (options) => {
   const _options = getDefaultOptions(options);
   const currentPath = _options.name !== void 0 ? [..._options.basePath, _options.definitionPath, _options.name] : _options.basePath;
@@ -53079,7 +53079,7 @@ var getRefs = (options) => {
   };
 };
 
-// node_modules/zod-to-json-schema/dist/esm/errorMessages.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/errorMessages.js
 function addErrorMessage(res, key, errorMessage2, refs) {
   if (!refs?.errorMessages)
     return;
@@ -53095,7 +53095,7 @@ function setResponseValueAndErrors(res, key, value, errorMessage2, refs) {
   addErrorMessage(res, key, errorMessage2, refs);
 }
 
-// node_modules/zod-to-json-schema/dist/esm/getRelativePath.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/getRelativePath.js
 var getRelativePath = (pathA, pathB) => {
   let i = 0;
   for (; i < pathA.length && i < pathB.length; i++) {
@@ -53105,7 +53105,7 @@ var getRelativePath = (pathA, pathB) => {
   return [(pathA.length - i).toString(), ...pathB.slice(i)].join("/");
 };
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/any.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/any.js
 function parseAnyDef(refs) {
   if (refs.target !== "openAi") {
     return {};
@@ -53121,7 +53121,7 @@ function parseAnyDef(refs) {
   };
 }
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/array.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/array.js
 function parseArrayDef(def, refs) {
   const res = {
     type: "array"
@@ -53145,7 +53145,7 @@ function parseArrayDef(def, refs) {
   return res;
 }
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/bigint.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/bigint.js
 function parseBigintDef(def, refs) {
   const res = {
     type: "integer",
@@ -53191,24 +53191,24 @@ function parseBigintDef(def, refs) {
   return res;
 }
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/boolean.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/boolean.js
 function parseBooleanDef() {
   return {
     type: "boolean"
   };
 }
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/branded.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/branded.js
 function parseBrandedDef(_def, refs) {
   return parseDef(_def.type._def, refs);
 }
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/catch.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/catch.js
 var parseCatchDef = (def, refs) => {
   return parseDef(def.innerType._def, refs);
 };
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/date.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/date.js
 function parseDateDef(def, refs, overrideDateStrategy) {
   const strategy = overrideDateStrategy ?? refs.dateStrategy;
   if (Array.isArray(strategy)) {
@@ -53267,7 +53267,7 @@ var integerDateParser = (def, refs) => {
   return res;
 };
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/default.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/default.js
 function parseDefaultDef(_def, refs) {
   return {
     ...parseDef(_def.innerType._def, refs),
@@ -53275,12 +53275,12 @@ function parseDefaultDef(_def, refs) {
   };
 }
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/effects.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/effects.js
 function parseEffectsDef(_def, refs) {
   return refs.effectStrategy === "input" ? parseDef(_def.schema._def, refs) : parseAnyDef(refs);
 }
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/enum.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/enum.js
 function parseEnumDef(def) {
   return {
     type: "string",
@@ -53288,7 +53288,7 @@ function parseEnumDef(def) {
   };
 }
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/intersection.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/intersection.js
 var isJsonSchema7AllOfType = (type) => {
   if ("type" in type && type.type === "string")
     return false;
@@ -53330,7 +53330,7 @@ function parseIntersectionDef(def, refs) {
   } : void 0;
 }
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/literal.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/literal.js
 function parseLiteralDef(def, refs) {
   const parsedType2 = typeof def.value;
   if (parsedType2 !== "bigint" && parsedType2 !== "number" && parsedType2 !== "boolean" && parsedType2 !== "string") {
@@ -53350,7 +53350,7 @@ function parseLiteralDef(def, refs) {
   };
 }
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/string.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/string.js
 var emojiRegex2 = void 0;
 var zodPatterns = {
   /**
@@ -53675,7 +53675,7 @@ function stringifyRegExpWithFlags(regex, refs) {
   return pattern;
 }
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/record.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/record.js
 function parseRecordDef(def, refs) {
   if (refs.target === "openAi") {
     console.warn("Warning: OpenAI may not support records in schemas! Try an array of key-value pairs instead.");
@@ -53727,7 +53727,7 @@ function parseRecordDef(def, refs) {
   return schema;
 }
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/map.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/map.js
 function parseMapDef(def, refs) {
   if (refs.mapStrategy === "record") {
     return parseRecordDef(def, refs);
@@ -53752,7 +53752,7 @@ function parseMapDef(def, refs) {
   };
 }
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/nativeEnum.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/nativeEnum.js
 function parseNativeEnumDef(def) {
   const object3 = def.values;
   const actualKeys = Object.keys(def.values).filter((key) => {
@@ -53766,7 +53766,7 @@ function parseNativeEnumDef(def) {
   };
 }
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/never.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/never.js
 function parseNeverDef(refs) {
   return refs.target === "openAi" ? void 0 : {
     not: parseAnyDef({
@@ -53776,7 +53776,7 @@ function parseNeverDef(refs) {
   };
 }
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/null.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/null.js
 function parseNullDef(refs) {
   return refs.target === "openApi3" ? {
     enum: ["null"],
@@ -53786,7 +53786,7 @@ function parseNullDef(refs) {
   };
 }
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/union.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/union.js
 var primitiveMappings = {
   ZodString: "string",
   ZodNumber: "number",
@@ -53854,7 +53854,7 @@ var asAnyOf = (def, refs) => {
   return anyOf.length ? { anyOf } : void 0;
 };
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/nullable.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/nullable.js
 function parseNullableDef(def, refs) {
   if (["ZodString", "ZodNumber", "ZodBigInt", "ZodBoolean", "ZodNull"].includes(def.innerType._def.typeName) && (!def.innerType._def.checks || !def.innerType._def.checks.length)) {
     if (refs.target === "openApi3") {
@@ -53886,7 +53886,7 @@ function parseNullableDef(def, refs) {
   return base && { anyOf: [base, { type: "null" }] };
 }
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/number.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/number.js
 function parseNumberDef(def, refs) {
   const res = {
     type: "number"
@@ -53935,7 +53935,7 @@ function parseNumberDef(def, refs) {
   return res;
 }
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/object.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/object.js
 function parseObjectDef(def, refs) {
   const forceOptionalIntoNullable = refs.target === "openAi";
   const result = {
@@ -54005,7 +54005,7 @@ function safeIsOptional(schema) {
   }
 }
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/optional.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/optional.js
 var parseOptionalDef = (def, refs) => {
   if (refs.currentPath.toString() === refs.propertyPath?.toString()) {
     return parseDef(def.innerType._def, refs);
@@ -54024,7 +54024,7 @@ var parseOptionalDef = (def, refs) => {
   } : parseAnyDef(refs);
 };
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/pipeline.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/pipeline.js
 var parsePipelineDef = (def, refs) => {
   if (refs.pipeStrategy === "input") {
     return parseDef(def.in._def, refs);
@@ -54044,12 +54044,12 @@ var parsePipelineDef = (def, refs) => {
   };
 };
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/promise.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/promise.js
 function parsePromiseDef(def, refs) {
   return parseDef(def.type._def, refs);
 }
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/set.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/set.js
 function parseSetDef(def, refs) {
   const items = parseDef(def.valueType._def, {
     ...refs,
@@ -54069,7 +54069,7 @@ function parseSetDef(def, refs) {
   return schema;
 }
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/tuple.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/tuple.js
 function parseTupleDef(def, refs) {
   if (def.rest) {
     return {
@@ -54097,24 +54097,24 @@ function parseTupleDef(def, refs) {
   }
 }
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/undefined.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/undefined.js
 function parseUndefinedDef(refs) {
   return {
     not: parseAnyDef(refs)
   };
 }
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/unknown.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/unknown.js
 function parseUnknownDef(refs) {
   return parseAnyDef(refs);
 }
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/readonly.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/readonly.js
 var parseReadonlyDef = (def, refs) => {
   return parseDef(def.innerType._def, refs);
 };
 
-// node_modules/zod-to-json-schema/dist/esm/selectParser.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/selectParser.js
 var selectParser = (def, typeName, refs) => {
   switch (typeName) {
     case ZodFirstPartyTypeKind.ZodString:
@@ -54190,7 +54190,7 @@ var selectParser = (def, typeName, refs) => {
   }
 };
 
-// node_modules/zod-to-json-schema/dist/esm/parseDef.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parseDef.js
 function parseDef(def, refs, forceResolution = false) {
   const seenItem = refs.seen.get(def);
   if (refs.override) {
@@ -54246,7 +54246,7 @@ var addMeta = (def, refs, jsonSchema) => {
   return jsonSchema;
 };
 
-// node_modules/zod-to-json-schema/dist/esm/zodToJsonSchema.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/zodToJsonSchema.js
 var zodToJsonSchema = (schema, options) => {
   const refs = getRefs(options);
   let definitions = typeof options === "object" && options.definitions ? Object.entries(options.definitions).reduce((acc, [name2, schema2]) => ({
@@ -54308,7 +54308,7 @@ var zodToJsonSchema = (schema, options) => {
   return combined;
 };
 
-// node_modules/@modelcontextprotocol/sdk/dist/esm/server/zod-json-schema-compat.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@modelcontextprotocol/sdk/dist/esm/server/zod-json-schema-compat.js
 function mapMiniTarget(t) {
   if (!t)
     return "draft-7";
@@ -54350,7 +54350,7 @@ function parseWithCompat(schema, data) {
   return result.data;
 }
 
-// node_modules/@modelcontextprotocol/sdk/dist/esm/shared/protocol.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@modelcontextprotocol/sdk/dist/esm/shared/protocol.js
 var DEFAULT_REQUEST_TIMEOUT_MSEC = 6e4;
 var Protocol = class {
   constructor(_options) {
@@ -55304,7 +55304,7 @@ function mergeCapabilities(base, additional) {
   return result;
 }
 
-// node_modules/@modelcontextprotocol/sdk/dist/esm/validation/ajv-provider.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@modelcontextprotocol/sdk/dist/esm/validation/ajv-provider.js
 var import_ajv = __toESM(require_ajv(), 1);
 var import_ajv_formats = __toESM(require_dist(), 1);
 function createDefaultAjvInstance() {
@@ -55372,7 +55372,7 @@ var AjvJsonSchemaValidator = class {
   }
 };
 
-// node_modules/@modelcontextprotocol/sdk/dist/esm/experimental/tasks/server.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@modelcontextprotocol/sdk/dist/esm/experimental/tasks/server.js
 var ExperimentalServerTasks = class {
   constructor(_server) {
     this._server = _server;
@@ -55585,7 +55585,7 @@ var ExperimentalServerTasks = class {
   }
 };
 
-// node_modules/@modelcontextprotocol/sdk/dist/esm/experimental/tasks/helpers.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@modelcontextprotocol/sdk/dist/esm/experimental/tasks/helpers.js
 function assertToolsCallTaskCapability(requests, method, entityName) {
   if (!requests) {
     throw new Error(`${entityName} does not support task creation (required for ${method})`);
@@ -55620,7 +55620,7 @@ function assertClientRequestTaskCapability(requests, method, entityName) {
   }
 }
 
-// node_modules/@modelcontextprotocol/sdk/dist/esm/server/index.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@modelcontextprotocol/sdk/dist/esm/server/index.js
 var Server = class extends Protocol {
   /**
    * Initializes this server with the given name and version information.
@@ -56000,7 +56000,7 @@ var Server = class extends Protocol {
   }
 };
 
-// node_modules/@modelcontextprotocol/sdk/dist/esm/server/completable.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@modelcontextprotocol/sdk/dist/esm/server/completable.js
 var COMPLETABLE_SYMBOL = Symbol.for("mcp.completable");
 function isCompletable(schema) {
   return !!schema && typeof schema === "object" && COMPLETABLE_SYMBOL in schema;
@@ -56014,7 +56014,7 @@ var McpZodTypeKind;
   McpZodTypeKind2["Completable"] = "McpCompletable";
 })(McpZodTypeKind || (McpZodTypeKind = {}));
 
-// node_modules/@modelcontextprotocol/sdk/dist/esm/shared/toolNameValidation.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@modelcontextprotocol/sdk/dist/esm/shared/toolNameValidation.js
 var TOOL_NAME_REGEX = /^[A-Za-z0-9._-]{1,128}$/;
 function validateToolName(name) {
   const warnings = [];
@@ -56072,7 +56072,7 @@ function validateAndWarnToolName(name) {
   return result.isValid;
 }
 
-// node_modules/@modelcontextprotocol/sdk/dist/esm/experimental/tasks/mcp-server.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@modelcontextprotocol/sdk/dist/esm/experimental/tasks/mcp-server.js
 var ExperimentalMcpServerTasks = class {
   constructor(_mcpServer) {
     this._mcpServer = _mcpServer;
@@ -56087,7 +56087,7 @@ var ExperimentalMcpServerTasks = class {
   }
 };
 
-// node_modules/@modelcontextprotocol/sdk/dist/esm/server/mcp.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@modelcontextprotocol/sdk/dist/esm/server/mcp.js
 var McpServer = class {
   constructor(serverInfo, options) {
     this._registeredResources = {};
@@ -56879,7 +56879,7 @@ var EMPTY_COMPLETION_RESULT = {
   }
 };
 
-// node_modules/@modelcontextprotocol/sdk/dist/esm/server/webStandardStreamableHttp.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@modelcontextprotocol/sdk/dist/esm/server/webStandardStreamableHttp.js
 var WebStandardStreamableHTTPServerTransport = class {
   constructor(options = {}) {
     this._started = false;
@@ -58171,6 +58171,8 @@ var mediaObjectStoreCache = /* @__PURE__ */ new WeakMap();
 var MEDIA_UPLOAD_SOFT_LIMIT_BYTES = 5 * 1024 * 1024;
 var MEDIA_UPLOAD_HARD_LIMIT_BYTES = 20 * 1024 * 1024;
 var MEDIA_REFERENCE_LIMIT = 12;
+var MEDIA_DEFAULT_RETENTION_DAYS = 7;
+var MEDIA_DEFAULT_RETENTION_MS = MEDIA_DEFAULT_RETENTION_DAYS * 24 * 60 * 60 * 1e3;
 var runtime_default = {
   async fetch(request, env) {
     const url = new URL(request.url);
@@ -62278,6 +62280,7 @@ async function handleMediaUploadRequest(request, env) {
     });
   }
   const now = (/* @__PURE__ */ new Date()).toISOString();
+  const expiresAt = buildMediaExpiresAt(now);
   const mediaId = `med_${crypto.randomUUID()}`;
   const objectKey = buildMediaObjectKey({ repository, createdAt: now, mediaId, filename });
   const arrayBuffer = await file.arrayBuffer();
@@ -62301,7 +62304,8 @@ async function handleMediaUploadRequest(request, env) {
       mediaId,
       repository: repository || "unscoped",
       visibility,
-      sha256: sha2562
+      sha256: sha2562,
+      expiresAt
     }
   });
   let record2 = null;
@@ -62323,7 +62327,8 @@ async function handleMediaUploadRequest(request, env) {
       ocrText: "",
       createdBy: dashboardAuth.email || dashboardAuth.login || dashboardAuth.authType || "dashboard",
       createdAt: now,
-      updatedAt: now
+      updatedAt: now,
+      expiresAt
     });
   } catch (error2) {
     await cleanupOrphanMediaObject(r2, objectKey);
@@ -62379,6 +62384,9 @@ async function handleMediaObjectRequest(request, env, mediaRoute) {
       error: "media_not_found",
       reason: "media object was not found"
     });
+  }
+  if (isExpiredMediaObjectRecord(record2)) {
+    return buildExpiredMediaResponse(record2);
   }
   if (!mediaRoute.download) {
     return json(200, {
@@ -62449,7 +62457,7 @@ async function handleMediaSearchRequest(request, url, env) {
   });
   return json(200, {
     ok: true,
-    media: records.map((record2) => toMediaReference(record2)).filter(Boolean),
+    media: records.filter((record2) => !isExpiredMediaObjectRecord(record2)).map((record2) => toMediaReference(record2)).filter(Boolean),
     rawBinaryReturned: false
   });
 }
@@ -65771,8 +65779,8 @@ function createD1MediaObjectStore(d1) {
         `INSERT OR REPLACE INTO vtdd_media_objects (
              id, repository, related_issue, related_pr, source_surface, source_event_id,
              object_key, filename, content_type, byte_size, sha256, visibility,
-             summary, ocr_text, created_by, created_at, updated_at
-           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+             summary, ocr_text, created_by, created_at, updated_at, expires_at
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
       ).bind(
         normalized.id,
         normalized.repository,
@@ -65790,7 +65798,8 @@ function createD1MediaObjectStore(d1) {
         normalized.ocrText,
         normalized.createdBy,
         normalized.createdAt,
-        normalized.updatedAt
+        normalized.updatedAt,
+        normalized.expiresAt
       ).run();
       return normalized;
     },
@@ -65846,7 +65855,11 @@ function createD1MediaObjectStore(d1) {
   function ensureSchema() {
     if (!schemaPromise) {
       schemaPromise = (async () => {
-        await d1.exec("CREATE TABLE IF NOT EXISTS vtdd_media_objects (id TEXT PRIMARY KEY, repository TEXT, related_issue INTEGER, related_pr INTEGER, source_surface TEXT NOT NULL, source_event_id TEXT, object_key TEXT NOT NULL, filename TEXT NOT NULL, content_type TEXT NOT NULL, byte_size INTEGER NOT NULL, sha256 TEXT NOT NULL, visibility TEXT NOT NULL, summary TEXT, ocr_text TEXT, created_by TEXT, created_at TEXT NOT NULL, updated_at TEXT NOT NULL);");
+        await d1.exec("CREATE TABLE IF NOT EXISTS vtdd_media_objects (id TEXT PRIMARY KEY, repository TEXT, related_issue INTEGER, related_pr INTEGER, source_surface TEXT NOT NULL, source_event_id TEXT, object_key TEXT NOT NULL, filename TEXT NOT NULL, content_type TEXT NOT NULL, byte_size INTEGER NOT NULL, sha256 TEXT NOT NULL, visibility TEXT NOT NULL, summary TEXT, ocr_text TEXT, created_by TEXT, created_at TEXT NOT NULL, updated_at TEXT NOT NULL, expires_at TEXT);");
+        try {
+          await d1.exec("ALTER TABLE vtdd_media_objects ADD COLUMN expires_at TEXT;");
+        } catch {
+        }
         await d1.exec("CREATE INDEX IF NOT EXISTS idx_vtdd_media_repo ON vtdd_media_objects(repository, created_at DESC);");
         await d1.exec("CREATE INDEX IF NOT EXISTS idx_vtdd_media_issue ON vtdd_media_objects(repository, related_issue, created_at DESC);");
         await d1.exec("CREATE INDEX IF NOT EXISTS idx_vtdd_media_pr ON vtdd_media_objects(repository, related_pr, created_at DESC);");
@@ -66645,6 +66658,45 @@ function buildMediaObjectKey({ repository, createdAt, mediaId, filename }) {
   const dd = String(date3.getUTCDate()).padStart(2, "0");
   return `media/${owner}/${name}/${yyyy}/${mm}/${dd}/${mediaId}/${sanitizeMediaFilename(filename)}`;
 }
+function buildMediaExpiresAt(createdAt) {
+  const created = Date.parse(normalizeIsoTimestamp(createdAt) || "");
+  const base = Number.isFinite(created) ? created : Date.now();
+  return new Date(base + MEDIA_DEFAULT_RETENTION_MS).toISOString();
+}
+function isExpiredMediaObjectRecord(record2, now = Date.now()) {
+  const normalized = normalizeMediaObjectRecord(record2);
+  if (!normalized) {
+    return false;
+  }
+  const expiresAt = Date.parse(normalized.expiresAt || "");
+  return Number.isFinite(expiresAt) && expiresAt <= now;
+}
+function buildExpiredMediaResponse(record2) {
+  const media = toMediaReference(record2);
+  return json(410, {
+    ok: false,
+    error: "media_expired",
+    reason: "\u3053\u306E\u6DFB\u4ED8\u306F\u4FDD\u5B58\u671F\u9593\u304C\u5207\u308C\u307E\u3057\u305F\u3002\u5FC5\u8981\u3067\u3042\u308C\u3070\u518D\u6DFB\u4ED8\u3057\u3066\u304F\u3060\u3055\u3044\u3002",
+    ownerMessage: "\u6DFB\u4ED8\u306E\u4FDD\u5B58\u671F\u9593\u304C\u5207\u308C\u307E\u3057\u305F\u3002\u5FC5\u8981\u3067\u3042\u308C\u3070\u518D\u6DFB\u4ED8\u3057\u3066\u304F\u3060\u3055\u3044\u3002",
+    media,
+    rawBinaryReturned: false
+  });
+}
+function buildMediaRetentionLabel(expiresAt, now = Date.now()) {
+  const expires = Date.parse(normalizeIsoTimestamp(expiresAt) || "");
+  if (!Number.isFinite(expires)) {
+    return "";
+  }
+  const remainingMs = expires - now;
+  if (remainingMs <= 0) {
+    return "\u4FDD\u5B58\u671F\u9593\u5207\u308C";
+  }
+  const remainingDays = Math.max(1, Math.ceil(remainingMs / (24 * 60 * 60 * 1e3)));
+  if (remainingDays >= MEDIA_DEFAULT_RETENTION_DAYS) {
+    return `${MEDIA_DEFAULT_RETENTION_DAYS}\u65E5\u5F8C\u306B\u524A\u9664`;
+  }
+  return `\u3042\u3068${remainingDays}\u65E5`;
+}
 async function sha256ArrayBufferHex(arrayBuffer) {
   if (globalThis.crypto?.subtle) {
     const digest2 = await globalThis.crypto.subtle.digest("SHA-256", arrayBuffer);
@@ -66675,6 +66727,7 @@ function normalizeMediaObjectRecord(record2) {
     return null;
   }
   const createdAt = normalizeIsoTimestamp(input.createdAt || input.created_at) || (/* @__PURE__ */ new Date()).toISOString();
+  const expiresAt = normalizeIsoTimestamp(input.expiresAt || input.expires_at) || buildMediaExpiresAt(createdAt);
   return {
     id,
     repository: normalizeCanonicalRepositoryInput(input.repository) || null,
@@ -66692,7 +66745,8 @@ function normalizeMediaObjectRecord(record2) {
     ocrText: sanitizeDashboardChatText(input.ocrText || input.ocr_text),
     createdBy: sanitizeDashboardChatText(input.createdBy || input.created_by),
     createdAt,
-    updatedAt: normalizeIsoTimestamp(input.updatedAt || input.updated_at) || createdAt
+    updatedAt: normalizeIsoTimestamp(input.updatedAt || input.updated_at) || createdAt,
+    expiresAt
   };
 }
 function mediaObjectRecordFromRow(row) {
@@ -66713,7 +66767,8 @@ function mediaObjectRecordFromRow(row) {
     ocrText: row?.ocr_text,
     createdBy: row?.created_by,
     createdAt: row?.created_at,
-    updatedAt: row?.updated_at
+    updatedAt: row?.updated_at,
+    expiresAt: row?.expires_at
   });
 }
 function toMediaReference(record2) {
@@ -66736,6 +66791,8 @@ function toMediaReference(record2) {
     ocrText: normalized.ocrText || "",
     createdAt: normalized.createdAt,
     updatedAt: normalized.updatedAt,
+    expiresAt: normalized.expiresAt,
+    retentionLabel: buildMediaRetentionLabel(normalized.expiresAt),
     metadataUrl: `/v2/media/${normalized.id}`,
     downloadUrl: `/v2/media/${normalized.id}/download`
   };
@@ -66759,6 +66816,8 @@ function normalizeMediaReferences(value) {
       sha256: normalizeDashboardEventText(input.sha256).toLowerCase().slice(0, 64),
       visibility: normalizeMediaVisibility(input.visibility) || "private",
       summary: sanitizeDashboardChatText(input.summary),
+      expiresAt: normalizeIsoTimestamp(input.expiresAt || input.expires_at) || "",
+      retentionLabel: sanitizeDashboardChatText(input.retentionLabel || input.retention_label),
       metadataUrl: `/v2/media/${mediaId}`,
       downloadUrl: `/v2/media/${mediaId}/download`
     };
@@ -66787,6 +66846,13 @@ async function resolveDashboardChatMediaReferences({ env, mediaReferences, repos
         ok: false,
         error: "media_reference_not_found",
         reason: `media reference ${reference.mediaId} was not found`
+      };
+    }
+    if (isExpiredMediaObjectRecord(record2)) {
+      return {
+        ok: false,
+        error: "media_reference_expired",
+        reason: `media reference ${reference.mediaId} \u306F\u4FDD\u5B58\u671F\u9593\u304C\u5207\u308C\u307E\u3057\u305F\u3002\u5FC5\u8981\u3067\u3042\u308C\u3070\u518D\u6DFB\u4ED8\u3057\u3066\u304F\u3060\u3055\u3044\u3002`
       };
     }
     const media = toMediaReference(record2);
@@ -70309,7 +70375,10 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
     .composer-progress.thinking .progress-title::before { animation: pulseProgress 1.25s ease-in-out infinite; }
     .media-chip { display: inline-flex; align-items: center; max-width: 100%; min-width: 0; min-height: 34px; border: 1px solid var(--border); border-radius: 14px; padding: 5px 10px; gap: 8px; color: var(--text); background: var(--soft); font-size: 12px; text-decoration: none; overflow: hidden; }
     .media-chip span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: min(48vw, 320px); }
-    .media-thumb { width: 48px; height: 48px; flex: 0 0 auto; border-radius: 10px; object-fit: cover; background: var(--border); }
+    .media-chip .media-label { display: inline-flex; flex-direction: column; align-items: flex-start; gap: 1px; min-width: 0; }
+    .media-chip .media-kind { color: var(--text); font-weight: 700; max-width: min(26vw, 140px); }
+    .media-chip .media-retention { color: var(--muted); font-size: 11px; max-width: min(38vw, 220px); }
+    .media-thumb { width: 64px; height: 64px; flex: 0 0 auto; border-radius: 10px; object-fit: cover; background: var(--border); }
     .media-chip.pending-preview { padding: 5px 8px 5px 5px; }
     .media-remove { border: 0; background: transparent; color: var(--muted); font: inherit; font-weight: 900; padding: 0 2px; cursor: pointer; }
     .composer-status { min-height: 18px; padding-left: 16px; color: var(--muted); font-size: 12px; max-width: 100%; overflow-wrap: anywhere; }
@@ -71148,6 +71217,40 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         return "";
       }
 
+      function getMediaKindLabel(item) {
+        const kind = getMediaContentKind(item);
+        if (kind === "video") return "\u52D5\u753B";
+        if (kind === "image") return "\u753B\u50CF";
+        return "\u6DFB\u4ED8";
+      }
+
+      function formatMediaRetentionLabel(item) {
+        const explicit = String(item && item.retentionLabel || "").trim();
+        if (explicit) return explicit;
+        const expiresAt = String(item && item.expiresAt || "");
+        const expires = Date.parse(expiresAt);
+        if (!Number.isFinite(expires)) return "7\u65E5\u5F8C\u306B\u524A\u9664";
+        const remainingMs = expires - Date.now();
+        if (remainingMs <= 0) return "\u4FDD\u5B58\u671F\u9593\u5207\u308C";
+        const remainingDays = Math.max(1, Math.ceil(remainingMs / (24 * 60 * 60 * 1000)));
+        return remainingDays >= 7 ? "7\u65E5\u5F8C\u306B\u524A\u9664" : "\u3042\u3068" + remainingDays + "\u65E5";
+      }
+
+      function appendMediaLabel(chip, item) {
+        const label = document.createElement("span");
+        label.className = "media-label";
+        const kind = document.createElement("span");
+        kind.className = "media-kind";
+        kind.textContent = getMediaKindLabel(item);
+        const retention = document.createElement("span");
+        retention.className = "media-retention";
+        retention.textContent = formatMediaRetentionLabel(item);
+        label.title = item && item.filename ? item.filename : "";
+        label.appendChild(kind);
+        label.appendChild(retention);
+        chip.appendChild(label);
+      }
+
       function renderMediaReferences(references) {
         const list = Array.isArray(references) ? references : [];
         if (list.length === 0) return null;
@@ -71194,14 +71297,8 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
             icon.textContent = "\u6DFB\u4ED8";
             chip.appendChild(icon);
           }
-          const label = document.createElement(isVideo && downloadHref !== "#" ? "a" : "span");
-          label.textContent = reference.filename || reference.mediaId || "media";
-          if (label.tagName === "A") {
-            label.href = downloadHref;
-            label.target = "_blank";
-            label.rel = "noreferrer";
-          }
-          chip.appendChild(label);
+          chip.title = reference.filename || reference.mediaId || "media";
+          appendMediaLabel(chip, reference);
           wrapper.appendChild(chip);
         }
         return wrapper;
@@ -71253,8 +71350,11 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
               chip.appendChild(image);
             }
           }
-          const label = document.createElement("span");
-          label.textContent = item.filename || "attachment";
+          chip.title = item.filename || "attachment";
+          appendMediaLabel(chip, {
+            ...item,
+            retentionLabel: "\u9001\u4FE1\u5F8C7\u65E5\u3067\u524A\u9664"
+          });
           const remove = document.createElement("button");
           remove.className = "media-remove";
           remove.type = "button";


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #498 の部分進捗として、Dashboard Butler 添付を default 7 日保持にし、期限切れ media を owner-facing に扱います。
- 添付本体は R2 に置き、D1 / dashboard chat history / response には metadata と media reference だけを残す境界を維持します。
- Issue #587 の動画添付は、既存の `video/mp4` 保存・表示・download 経路を退行させない範囲で扱います。

## Satisfied Success Criteria

- Dashboard private media に `expiresAt` と `retentionLabel` を付け、owner-facing に「7日後に削除 / あとN日」を表示できるようにしました。
- D1 metadata は `expires_at` を持ち、R2 object custom metadata にも同じ期限を入れます。
- 期限切れ media の metadata / download / chat reference validation は `410 media_expired` または `media_reference_expired` と日本語 reason を返します。
- Search は期限切れ media を返しません。
- 画像 / 短い動画の upload response と stored media reference は raw binary を返しません。

## Unsatisfied Success Criteria

- production iPhone/PWA での実画像添付、送信後のタップ拡大、期限表示、期限切れ表示の E2E は未実施です。
- Codex / VPS 側の動画解析はこの PR では接続していません。動画解析は frame extraction または video-capable model 経路の後続 slice です。
- 物理削除の scheduled cleanup / R2 lifecycle automation はこの PR では実装していません。

## Non-goal violations

None.

## 開発前作戦図

- 作戦図 evidence: docs/development-strategy/issue-498-media-seven-day-retention.md
- 完了体験: Owner が Dashboard Butler に画像や短い動画を添付すると、送信前 preview が消えず、送信後も 7 日間は同じ thread から確認できる。
- VTDD 全体で進める部分: Issue #498 の media attachment analysis path と Issue #587 の短い動画添付退行防止を進める。
- 設計: default retention は createdAt + 7 日。D1 metadata と R2 customMetadata に expiresAt を置き、期限切れ read / validation は owner-facing 410 にする。
- 仮説: 添付が消える体験の原因候補は storage TTL だけではなく、metadata / reference / preview 表示の保持情報不足にある。既存 video upload 経路はあるため、first slice は route/schema/UI metadata を細く固めればよい。
- 検証計画: worker test、build worker、generated worker check、diff check で schema / route / UI smoke / raw binary 非保存 / expired handling を確認する。
- 改修見積もり: src/worker/runtime.js の media upload/object/search/reference/UI、test/worker.test.js の media tests、docs/media/cloudflare-r2-media-storage.md、worker.js を変更する。
- 既に通っている経路: R2 への raw bytes 保存、D1 metadata-only 保存、video/mp4 upload/download、Dashboard HTML の video preview path は既に存在する。
- 未確認の境界: production iPhone Photos picker の実挙動、production R2 lifecycle rule、Codex 直接動画解析 capability は未確認。
- 穴が出そうな箇所: 既存 D1 schema migration、期限切れ media の search / validation 漏れ、rollback cleanup と期限切れ判定の混同、ファイル名表示による thumbnail 圧迫。
- PR 前に確認すること: Issue #498/#587、AGENTS.md、media storage spec、runtime media route、worker tests、generated worker を確認する。
- 実装候補と捨てた案: D1/R2 metadata に expiresAt を置く案を採用し、R2 lifecycle だけで済ませる案と動画直接解析案は捨てた。
- merge 後に通す E2E: production PWA E2E test として画像と短い動画を添付し、送信前 preview、送信後 7 日表示、mediaId 取得、期限切れ表示を検証する。
- 次の PR を増やさない理由: 7日保持、期限表示、期限切れ read/validation は同じ schema / reference contract の一体変更で、分割すると owner-facing E2E の穴が残り、後続 PR を無駄に増やす。
- 停止条件: D1 migration が安全に適用できない、raw binary 非保存を破る、動画解析に新 credential/model/binding が必要になる、deploy/bucket mutation が必要になる場合は停止する。

## Dry-run Impact Report

- Target Issue: Issue #498
- Implementing Success Criteria: default 最大 7 日程度の短命 TTL、owner-facing 保存期限表示、期限切れ attachment の日本語表示、raw binary 非保存、Butler/VPS が media reference を取得できる metadata path。
- Explicit Non-goals: 動画解析 AI 接続、長尺動画、サムネイル生成、画像編集、physical expired-object purge automation、deploy、credential mutation、Cloudflare bucket mutation。
- Expected touched files/routes/workflows: `src/worker/runtime.js` の `/v2/media/upload`、`/v2/media/:id`、`/v2/media/:id/download`、`/v2/media/search`、chat media reference validation、Dashboard media rendering。`test/worker.test.js`、`docs/media/cloudflare-r2-media-storage.md`、`worker.js`。
- Affected Issues: Issue #498, Issue #587, Issue #528, Issue #579, Issue #590。
- Affected PRs: 影響する既存 PR はありません。
- Affected workflows: deploy workflow itself is not changed; generated worker validation is affected.
- Affected runtime/operator surfaces: Dashboard Butler Worker media upload/read/download/search, Dashboard chat media preview/reference rendering, app-server bridge media materialization through existing download route.
- What may break if we patch narrowly: expired media might still appear in search or chat validation; rollback cleanup could be blocked by expiry; old D1 rows without expires_at could be misclassified.
- Unknowns to investigate before coding: production iPhone picker behavior, production R2 lifecycle physical cleanup, direct video analysis support.
- Validation needed: `node --test test/worker.test.js`, `npm run build:worker`, `npm run check:generated-worker`, `git diff --check`, production PWA E2E after deploy.
- Stop condition: deploy, Cloudflare binding mutation, credential mutation, or direct video-analysis model integration becomes necessary.

## Execution Queue Delta

- Queue position before: Issue #590 remains Now, but Issue #498 is an active root blocker for screenshot/video feedback and owner-facing Butler UX.
- Preemption decision: ROOT support slice. Issue #498 blocks Issue #587 and the owner-facing screenshot/video feedback loop needed to continue Dashboard Butler UX repair.
- Queue delta: Issue #498 moves within Root Blockers as a bounded implementation slice for 7-day retention and expired-media handling; Issue #590 remains open and not complete.
- Why this PR is next: Owner cannot reliably explain UI problems with attachments disappearing, so progress-display polish is less useful until screenshots/videos can survive long enough for Butler/Codex inspection.
- Active Issues not downscoped: Active Issues are not shrunk, deferred out of scope, or treated as complete by omission. Issue #587 video analysis, Issue #590 progress UX, and production E2E remain open.

## File / Line Hypotheses

- file: `src/worker/runtime.js`
  - hypothesis: media upload/read/search/reference functions lack retention metadata and expired handling.
  - risk if changed narrowly: expired attachments can still enter chat context or app-server analysis.
  - validation: worker media upload/read/search/chat-reference tests.
  - related Issue: Issue #498
- file: `src/worker/runtime.js`
  - hypothesis: Dashboard media rendering needs a compact retention label and should not let filenames dominate thumbnails.
  - risk if changed narrowly: chat layout remains visually noisy even after storage retention works.
  - validation: Dashboard HTML smoke assertions.
  - related Issue: Issue #498 / Issue #587
- file: `test/worker.test.js`
  - hypothesis: existing media tests only prove storage, not retention or expired behavior.
  - risk if changed narrowly: retention regresses silently.
  - validation: new expiration and metadata assertions.
  - related Issue: Issue #498

## Hypothesis Retrospective

- expected: Adding expiresAt at upload/schema/reference boundaries is enough to make 7-day retention observable without storing raw binary in D1/chat.
- actual: Local worker tests confirmed upload response, metadata read, download, search filtering, expired reference rejection, and video upload all pass.
- mismatch: rollback cleanup initially became blocked by expiry; this was corrected so abandoned-send cleanup can still delete expired private media.
- lesson: expiry is a read/analysis boundary, not a rollback cleanup boundary.
- should become RAG candidate: yes, if production E2E confirms the UX direction.

## Verification Evidence

- Unit: `node --test test/worker.test.js` passed.
- Integration: `npm run build:worker` passed; `npm run check:generated-worker` passed; `git diff --check` passed.
- E2E: Not run. Production PWA image/video attachment E2E remains required after deploy.
- Manual: Not run.
- Evidence path/link: docs/development-strategy/issue-498-media-seven-day-retention.md

## Butler Completion Contract

- Primary owner surface: Dashboard Butler PWA
- Fallback surface: mac Codex / GitHub PR for development-time inspection only
- Owner goal: 添付画像/動画が送信前後に消えず、7日間は Butler/Codex が参照できる。
- Butler entrypoint: Dashboard chat composer `+` attachment flow and `/v2/media/*` routes.
- Dashboard Butler natural-language path: Dashboard Butler chat で Owner が「画像を添付する」「動画を添付する」と自然に依頼し、Dashboard chat composer `+` から media reference を同じ thread に渡す入口です。
- Action Schema exposure: Custom GPT Action Schema はこの PR では変更しません。この添付 slice は Dashboard PWA の通常チャット runtime route だけを更新します。
- Runtime path: `/v2/media/upload`, `/v2/media/:id`, `/v2/media/:id/download`, `/v2/media/search`, Dashboard chat media reference validation.
- Runner/runtime truth: app-server bridge can continue to materialize media references through the existing download route; local Worker tests prove route behavior and production runtime truth remains after deploy.
- Authority boundary: upload/read are owner-authenticated ordinary routes; deploy / Cloudflare bucket lifecycle / credential mutation are not authorized in this PR.
- Runtime truth: local Worker tests prove route behavior; production runtime truth remains after deploy.
- E2E evidence: missing production PWA E2E.
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 必要だが、この PR では実行しない。deploy は passkey approval 境界。
- Custom GPT Action Schema update: 不要。Dashboard PWA runtime route の変更です。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 必要。merge/deploy 後に画像と短い動画の production PWA E2E を実施する。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate
- AGENTS.md Evidence Discipline
- AGENTS.md RAG Memory Capture and Cost Boundary
- AGENTS.md Authority Boundary
- AGENTS.md Change Size and PR Discipline

## Out-of-scope but NOT implemented

- 動画の AI 解析、frame extraction、文字起こし、長尺動画、Cloudflare bucket lifecycle mutation、deploy、Issue close。

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #498
- Execution ID: dashboard-butler-issue-498-media-seven-day-retention
- Goal: Dashboard Butler 添付を 7 日保持し、画像/短い動画を raw binary 非保存のまま Butler/Codex が参照できるようにする。
