### PR TITLE
Issue #498 media lightbox の表示サイズを実機向けに直す

### DIFF
--- a/docs/development-strategy/issue-498-lightbox-visible-media.md
+++ b/docs/development-strategy/issue-498-lightbox-visible-media.md
@@ -1,0 +1,73 @@
+# Issue #498: make media lightbox render visible image content
+
+## 完了体験
+
+Dashboard Butler PWA で送信済み画像サムネイルをタップすると、黒い overlay にファイル名だけが出るのではなく、画像本体が画面内に収まって表示される。閉じるボタンだけでなく、画像本体・余白・retention label などの lightbox 面をタップしてもチャットに戻れる。owner は添付したスクリーンショットを後から確認できる。
+
+## VTDD 全体で進める部分
+
+Issue #498 の添付 preview / 拡大表示 completion を進める。PR #735 で 7日保持、PR #736 で lightbox DOM は production に入ったが、owner 実機観測では modal 内の画像本体が表示されていないため、production bug 修正として扱う。
+
+## 設計
+
+download path はサムネイル表示に使えているため、まず path ではなく lightbox 内の CSS sizing を疑う。iPad/Safari の CSS grid 内で replaced element の `max-height: 100%` が期待通り解決されない可能性を避けるため、lightbox body に明示的な `height` / `width` を持たせ、画像と動画を `width: 100%; height: 100%; object-fit: contain;` で表示する。
+
+画像読込失敗時の owner-facing 日本語 error は PR #736 の handler を維持する。lightbox の dismissal は画像 preview では広く閉じる一方、動画 preview では controls 操作を潰さないため `video` 上の tap は閉じない。今回は URL routing や storage schema には触れない。
+
+## 仮説
+
+サムネイルは表示されているので `/v2/media/:id/download` の path は成立している。lightbox では filename と retention label は出るが画像本体が出ていないため、`img` は作られているが modal body 内で見えないサイズになっている可能性が高い。
+
+狭く path を変えると、既に動いているサムネイル / download route を壊す危険がある。まず visible layout を修正し、test で lightbox media element が `object-fit: contain` と full body sizing を持つことを固定する。
+
+## 検証計画
+
+- Unit: Dashboard HTML に lightbox body full-size layout と `object-fit: contain` が含まれることを `test/worker.test.js` で確認する。
+- Unit: lightbox surface click で閉じる handler と、video controls を閉じない guard が含まれることを確認する。
+- Unit: 既存 media lightbox / thumbnail assertion が保持されることを確認する。
+- Build: `npm run build:worker` で `worker.js` を更新する。
+- Generated check: `npm run check:generated-worker` を通す。
+- Targeted test: `node --test test/worker.test.js` を通す。
+- Diff: `git diff --check` を通す。
+
+## 改修見積もり
+
+- `src/worker/runtime.js`: `.media-lightbox-body` と `.media-lightbox-body img/video` の CSS、lightbox click dismissal を修正する。risk は video preview の表示サイズが変わることと、video controls tap を誤って close と扱うこと。
+- `worker.js`: generated worker。source と同じ変更を build で反映する。
+- `test/worker.test.js`: HTML smoke assertion に iOS/Safari 向け lightbox sizing の証跡を追加する。
+
+## 既に通っている経路
+
+Issue #498 の upload / R2 metadata / D1 metadata / 7日保持は PR #735 で production deploy 済み。PR #736 で lightbox DOM、閉じるボタン、filename 表示、thumbnail click handler は入っている。owner screenshot では overlay、filename、close button、retention label は出ている。
+
+## 未確認の境界
+
+production PWA の DOM inspector はこの場では直接使えていない。画像 load event が成功しているか、CSS のみで不可視になっているかは owner screenshot と source からの推定である。修正後は owner 実機 E2E が必要。
+
+## 穴が出そうな箇所
+
+CSS grid の `minmax(0, 1fr)` と `max-height: 100%` は Safari で replaced element のサイズ解決が不安定になり得る。lightbox body と media element の双方に明示的な width/height を与える必要がある。
+
+## PR 前に確認すること
+
+Issue #498 の Success Criteria、PR #736 の merged source、owner screenshot、download path reuse、targeted worker test、generated worker check を確認する。
+
+## 実装候補と捨てた案
+
+採用: lightbox body と img/video の CSS sizing を full-size contain にする。
+
+捨てた案: `downloadHref` を別 route に変える。サムネイルが同じ route で表示されているため、path 変更は現時点の root cause ではない。
+
+捨てた案: ファイル名や retention label を消す。owner の不具合は画像本体が出ないことで、metadata 表示は Issue #498 の成功条件に含まれる。
+
+## merge 後に通す E2E
+
+production Dashboard Butler PWA で送信済み画像サムネイルをタップし、lightbox に画像本体が画面内に表示され、filename と 7日 retention label が見え、閉じるボタン・画像本体・余白・retention label tap でチャットへ戻れることを owner 実機で確認する。動画 preview は controls 操作で意図せず閉じないことも確認する。
+
+## 次の PR を増やさない理由
+
+この PR は PR #736 の production bug を最小修正する。attachment upload、7日保持、動画解析、progress UI、LINE-style reply preview へ広げると検証境界が壊れる。
+
+## 停止条件
+
+修正後も画像本体が出ない場合、CSS ではなく image load / auth / cache / service worker 経路の問題として停止し、download route と PWA cache を別 slice で調べる。

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -14579,9 +14579,9 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
     .media-lightbox-top { display: flex; align-items: center; justify-content: space-between; gap: 12px; min-width: 0; }
     .media-lightbox-title { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: #fff; font-size: 14px; font-weight: 800; }
     .media-lightbox-close { width: 42px; height: 42px; flex: 0 0 auto; border: 1px solid rgba(255, 255, 255, .32); border-radius: 999px; background: rgba(255, 255, 255, .12); color: #fff; font: inherit; font-size: 24px; line-height: 1; cursor: pointer; }
-    .media-lightbox-body { min-height: 0; display: grid; place-items: center; overflow: auto; overscroll-behavior: contain; }
-    .media-lightbox-body img, .media-lightbox-body video { display: block; max-width: 100%; max-height: 100%; border-radius: 8px; background: #111; }
-    .media-lightbox-body video { width: min(100%, 960px); }
+    .media-lightbox-body { min-width: 0; min-height: 0; width: 100%; height: 100%; display: grid; place-items: center; overflow: auto; overscroll-behavior: contain; }
+    .media-lightbox-body img, .media-lightbox-body video { display: block; width: 100%; height: 100%; max-width: 100%; max-height: 100%; object-fit: contain; border-radius: 8px; background: #111; }
+    .media-lightbox-body video { max-width: min(100%, 960px); }
     .media-lightbox-meta { min-height: 20px; color: rgba(255, 255, 255, .74); font-size: 12px; text-align: center; overflow-wrap: anywhere; }
     .composer-status { min-height: 18px; padding-left: 16px; color: var(--muted); font-size: 12px; max-width: 100%; overflow-wrap: anywhere; }
     .composer-status:empty { min-height: 0; padding-left: 0; }
@@ -15502,7 +15502,11 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
       }
       if (mediaLightbox) {
         mediaLightbox.addEventListener("click", (event) => {
-          if (event.target === mediaLightbox) closeMediaLightbox();
+          const target = event.target;
+          if (!(target instanceof Element)) return;
+          if (target.closest("button")) return;
+          if (target.closest("video")) return;
+          closeMediaLightbox();
         });
       }
       document.addEventListener("keydown", (event) => {

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -1839,8 +1839,14 @@ test("worker serves dashboard media add controls for iPhone-first upload", async
   assert.equal(body.includes("function formatMediaRetentionLabel("), true);
   assert.equal(body.includes("id=\"butler-media-lightbox\""), true);
   assert.equal(body.includes("id=\"butler-media-lightbox-close\""), true);
+  assert.equal(body.includes(".media-lightbox-body { min-width: 0; min-height: 0; width: 100%; height: 100%;"), true);
+  assert.equal(body.includes(".media-lightbox-body img, .media-lightbox-body video { display: block; width: 100%; height: 100%;"), true);
+  assert.equal(body.includes("object-fit: contain;"), true);
   assert.equal(body.includes("function openMediaLightbox("), true);
   assert.equal(body.includes("function closeMediaLightbox("), true);
+  assert.equal(body.includes("if (target.closest(\"button\")) return;"), true);
+  assert.equal(body.includes("if (target.closest(\"video\")) return;"), true);
+  assert.equal(body.includes("closeMediaLightbox();"), true);
   assert.equal(body.includes("mediaLightboxTitle.textContent = item && item.filename ? item.filename : getMediaKindLabel(item)"), true);
   assert.equal(body.includes("mediaLightboxMeta.textContent = formatMediaRetentionLabel(item)"), true);
   assert.equal(body.includes("保存期間が切れたか、取得できません。必要なら再添付してください。"), true);

--- a/worker.js
+++ b/worker.js
@@ -70384,9 +70384,9 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
     .media-lightbox-top { display: flex; align-items: center; justify-content: space-between; gap: 12px; min-width: 0; }
     .media-lightbox-title { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: #fff; font-size: 14px; font-weight: 800; }
     .media-lightbox-close { width: 42px; height: 42px; flex: 0 0 auto; border: 1px solid rgba(255, 255, 255, .32); border-radius: 999px; background: rgba(255, 255, 255, .12); color: #fff; font: inherit; font-size: 24px; line-height: 1; cursor: pointer; }
-    .media-lightbox-body { min-height: 0; display: grid; place-items: center; overflow: auto; overscroll-behavior: contain; }
-    .media-lightbox-body img, .media-lightbox-body video { display: block; max-width: 100%; max-height: 100%; border-radius: 8px; background: #111; }
-    .media-lightbox-body video { width: min(100%, 960px); }
+    .media-lightbox-body { min-width: 0; min-height: 0; width: 100%; height: 100%; display: grid; place-items: center; overflow: auto; overscroll-behavior: contain; }
+    .media-lightbox-body img, .media-lightbox-body video { display: block; width: 100%; height: 100%; max-width: 100%; max-height: 100%; object-fit: contain; border-radius: 8px; background: #111; }
+    .media-lightbox-body video { max-width: min(100%, 960px); }
     .media-lightbox-meta { min-height: 20px; color: rgba(255, 255, 255, .74); font-size: 12px; text-align: center; overflow-wrap: anywhere; }
     .composer-status { min-height: 18px; padding-left: 16px; color: var(--muted); font-size: 12px; max-width: 100%; overflow-wrap: anywhere; }
     .composer-status:empty { min-height: 0; padding-left: 0; }
@@ -71307,7 +71307,11 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
       }
       if (mediaLightbox) {
         mediaLightbox.addEventListener("click", (event) => {
-          if (event.target === mediaLightbox) closeMediaLightbox();
+          const target = event.target;
+          if (!(target instanceof Element)) return;
+          if (target.closest("button")) return;
+          if (target.closest("video")) return;
+          closeMediaLightbox();
         });
       }
       document.addEventListener("keydown", (event) => {


### PR DESCRIPTION
Issue #498 の添付 lightbox production bug 修正です。PR #736 で modal は開くようになりましたが、owner 実機 screenshot では黒い overlay と filename / retention label だけが出て、画像本体が表示されませんでした。サムネイルは同じ media download route で表示されているため、path 変更ではなく lightbox 内の media sizing を直します。

- Issue: Issue #498
- PR 種別: production bug fix / runtime UI slice
- Closes: なし

## This PR satisfies Intent

Dashboard Butler の送信済み画像をタップしたとき、lightbox 内で画像本体が画面内に収まって表示されるようにします。添付画像を owner が後から見返せる体験を Issue #498 の成功条件に近づけます。

## Satisfied Success Criteria

- lightbox body に明示的な `width: 100%` / `height: 100%` を付けます。
- lightbox 内の `img` / `video` に `width: 100%` / `height: 100%` / `object-fit: contain` を付け、iPad/Safari でも画像本体が見える sizing にします。
- 既存の filename、retention label、close button、download route、期限切れ error handler は維持します。
- regression guard として `test/worker.test.js` に lightbox sizing assertion を追加します。

## Unsatisfied Success Criteria

- production Owner PWA での実機再確認は未実施です。
- 画像 load / auth / service worker cache 側に追加原因がある場合は、この PR だけでは解決しません。
- Issue #498 全体の completion はまだ未完了です。

## 開発前作戦図

- 作戦図 evidence: docs/development-strategy/issue-498-lightbox-visible-media.md
- 完了体験: Dashboard Butler PWA で送信済み画像サムネイルをタップすると、黒 overlay 内に画像本体が表示され、閉じるボタンで戻れます。
- VTDD 全体で進める部分: Issue #498 の添付 preview / 拡大表示 completion を production bug fix として進めます。
- 設計: owner-facing surface は Dashboard Butler PWA の lightbox です。path は変えず、lightbox body と img/video の CSS sizing を full-size contain にします。
- 仮説: サムネイルが表示されているため download path は成立しており、modal 内で画像が見えない root cause は CSS sizing です。
- 検証計画: `node --test test/worker.test.js`、`npm run build:worker`、`npm run check:generated-worker`、`git diff --check` を通します。
- 改修見積もり: `src/worker/runtime.js` の `.media-lightbox-body` と `img/video` CSS、generated `worker.js`、`test/worker.test.js`、strategy doc を変更します。
- 既に通っている経路: PR #735 の 7日保持、PR #736 の lightbox DOM / filename / close button / thumbnail click handler は deploy 済みです。
- 未確認の境界: 実機 DOM inspector は見ていないため、画像 load event か CSS 不可視かは screenshot と source からの推定です。
- 穴が出そうな箇所: CSS grid 内の `max-height: 100%` は Safari で replaced element が見えないサイズになる可能性があります。
- PR 前に確認すること: Issue #498、PR #736 source、owner screenshot、download path reuse、targeted tests、generated worker check を確認します。
- 実装候補と捨てた案: 採用は CSS sizing fix。捨てた案は media path 変更で、サムネイルが同 path で動いているため対象外にしました。
- merge 後に通す E2E: production PWA E2E で送信済み画像をタップし、画像本体が表示されること、filename / 7日 label / close が機能することを確認します。
- 次の PR を増やさない理由: この PR は PR #736 の表示 bug に限定します。upload、7日保持、動画解析、progress UI には広げません。
- 停止条件: 修正後も画像本体が出ない場合、CSS ではなく image load / auth / cache / service worker 経路として別 slice に切り替えます。

## Dry-run Impact Report

- Target Issue: Issue #498
- Implementing Success Criteria: 送信済み画像を TTL 内にタップして拡大表示し、iPhone/PWA で破綻しないこと。
- Explicit Non-goals: Issue close、deploy、merge後 E2E claim、media storage schema 変更、download route 変更、動画解析、service worker cache 修正は対象外です。
- Expected touched files/routes/workflows: `src/worker/runtime.js`、`worker.js`、`test/worker.test.js`、`docs/development-strategy/issue-498-lightbox-visible-media.md`。
- Affected Issues: Issue #498 が直接対象。Issue #587 の動画添付は video sizing の副作用確認だけで、解析は対象外です。
- Affected PRs: PR #736 の production bug follow-up。既存 merged PR は変更しません。
- Affected workflows: 通常 test / guarded-policy / reviewer workflow。新規 workflow は追加しません。
- Affected runtime/operator surfaces: Dashboard Butler PWA の media lightbox 表示のみ。operator / approval / deploy surface は触りません。
- What may break if we patch narrowly: 画像が出ない原因が auth/cache なら CSS だけでは直りません。ただし path を先に変えると動いている thumbnail を壊す恐れがあります。
- Unknowns to investigate before coding: iPad/Safari の実際の computed size と image load event 状態。
- Validation needed: targeted worker test、worker build、generated worker check、diff check、production PWA owner E2E。
- Stop condition: CSS fix 後も owner 実機で画像が表示されなければ、download/auth/cache/service-worker 調査へ切り替えます。

## Execution Queue Delta

- Queue position before: Issue #498 は Evidence Gaps / active media UX の対象で、PR #736 deploy 後の production bug が発見されました。
- Preemption decision: ROOT。添付画像を確認できないと、owner が screenshot で UI 不具合を説明できず、Dashboard Butler の通常開発体験を阻害します。
- Queue delta: Issue #498 に PR #736 後続の production bug fix PR を追加します。`Now` / `Next` の active Issues は縮小しません。
- Why this PR is next: owner が実機 screenshot で modal 内に画像が表示されないことを示し、Issue #498 の success criteria に直接反するためです。
- Active Issues not downscoped: Active Issues are not downscoped。Issue #498、Issue #528、Issue #590、Issue #637、Issue #450 は縮小しません。

## File / Line Hypotheses

- `src/worker/runtime.js`: `.media-lightbox-body` に full-size sizing を追加します。
- `src/worker/runtime.js`: `.media-lightbox-body img, video` を `object-fit: contain` で画面内表示にします。
- `test/worker.test.js`: lightbox CSS が regression しないよう HTML assertion を追加します。
- `worker.js`: generated worker として source 差分を反映します。

## Hypothesis Retrospective

owner screenshot では filename と close button と retention label が表示されており、modal open path は動いていました。チャット内サムネイルも表示されているため、download route よりも lightbox body 内の sizing 問題を優先する判断は妥当です。

ただし production 実機での再確認までは completion ではありません。表示されない場合は auth/cache/load event 側へ切り替える必要があります。

## Verification Evidence

- `node --test test/worker.test.js`: pass, 252 tests
- `npm run build:worker`: pass
- `npm run check:generated-worker`: pass
- `git diff --check`: pass

## Butler Completion Contract

- Primary owner surface: Dashboard Butler PWA
- Fallback surface: mac Codex は開発・緊急確認のフォールバックで、主経路ではありません。
- Owner goal: 添付済み画像をタップしたとき、modal 内で画像本体を確認できること。
- Butler entrypoint: Dashboard Butler の通常チャット上の添付サムネイル。
- Dashboard Butler natural-language path: Dashboard Butler の通常チャットで画像を添付し、送信済みサムネイルをタップして拡大表示へ到達する経路です。
- Action Schema exposure: Custom GPT Action Schema は対象外です。この PR は Dashboard PWA runtime UI だけの改善です。
- Runtime path: `renderV2DashboardPage()` の inline Dashboard ChatRoom CSS。
- Runner/runtime truth: Worker の dashboard route HTML と generated `worker.js` に full-size contain lightbox CSS が含まれます。
- Authority boundary: merge / deploy / Issue close は未実行で、必要なら owner の明示 GO または passkey approval が必要です。
- E2E evidence: production Owner PWA E2E は未実施。local test evidence は Verification Evidence に記録済みです。
- Completion status: incomplete

## Surface Update Checklist

- Dashboard Butler PWA: 更新あり。media lightbox の画像表示 sizing を修正します。
- Custom GPT Action Schema: 更新なし。
- VPS Codex CLI / app-server bridge: 更新なし。
- GitHub Issue / PR / reviewer: この PR 作成後に reviewer / checks を確認します。
- Deploy / operator surface: 更新なし。deploy はこの PR では実行しません。
