### PR TITLE
Issue #613 repo-less main chat formalization

### DIFF
--- a/docs/development-strategy/issue-613-repoless-main-chat.md
+++ b/docs/development-strategy/issue-613-repoless-main-chat.md
@@ -1,0 +1,100 @@
+# Issue #613 repo-less main chat formalization
+
+## 完了体験
+
+Dashboard Butler の通常チャットを開いた時、repo 未指定はエラーや未解決の残骸ではなく、repo-less main chat として扱われる。
+
+owner はまずこのメインチャットで雑談、状況確認、複数 repo をまたぐ相談を始められる。Issue / PR / deploy / passkey / GitHub Actions など repo 境界が必要な作業に入る時だけ、Butler が会話の中で対象 repo を内部解決し、曖昧なら短く確認する。
+
+## VTDD 全体で進める部分
+
+この PR は Issue #613 の本筋のうち、通常チャット first viewport と drawer 表示を repo-less main chat に寄せる最小 slice である。
+
+既存の `dashboard-main-unresolved` WebSocket / app-server bridge thread は維持する。名前の `unresolved` は内部 thread id として残るが、owner-facing UI では未解決扱いにしない。
+
+## 設計
+
+- repo が URL に指定されていない Dashboard では、header subtitle を repo-less main chat として表示する。
+- drawer の repo lane は「repo-less main chat」として説明し、常設 repo 入力フォームを出さない。
+- repo が指定されている Dashboard では、従来どおりその turn の対象 repo として表示する。
+- GitHub / deploy / progress など repo 必須 surface は disabled のまま残し、repo 境界を弱めない。
+- composer の `data-repository-input` は空のまま維持し、送信経路は `dashboard-main-unresolved` を使う。
+
+## 仮説
+
+現在の owner-facing 問題は、実行経路そのものではなく UI 文言と常設 repo 入力の扱いである。
+
+`src/worker/runtime.js` には repo 未指定時の `dashboard-main-unresolved` thread と WebSocket endpoint が既に存在する。一方で header と drawer が `作業対象 repo 未指定`、`この作業の対象 repo`、`owner/repo` 入力フォームを常時表示するため、repo-less main chat が未解決状態や残骸に見える。
+
+ここを repo-less main chat として表示すれば、unresolved bridge を止めるのではなく正式運用する方向へ寄せられる。
+
+## 検証計画
+
+- `test/worker.test.js` で default dashboard が `repo-less main chat` を表示することを確認する。
+- 同じテストで `作業対象 repo 未指定` と `dashboard-repository-input` が通常 dashboard に出ないことを確認する。
+- `dashboard-main-unresolved` の thread endpoint / WebSocket endpoint が維持されることを確認する。
+- `npm run build:worker` で generated `worker.js` を更新する。
+- `npm run check:generated-worker` で generated worker の差分を確認する。
+- `node --test test/worker.test.js` と `git diff --check` を実行する。
+
+## 改修見積もり
+
+- `src/worker/runtime.js`
+  - `renderV2DashboardPage` の repo 未指定 label / drawer lane / initial assistant text を変更する。
+  - repo 必須 surface の disabled 表示は維持する。
+  - internal thread id は変更しない。
+- `worker.js`
+  - `npm run build:worker` による生成物更新。
+- `test/worker.test.js`
+  - Dashboard HTML smoke assertion を repo-less main chat 仕様へ更新する。
+
+## 既に通っている経路
+
+- repo 未指定時の thread id は `dashboard-main-unresolved`。
+- WebSocket endpoint は `/v2/dashboard/chat/dashboard-main-unresolved/ws`。
+- app-server bridge tests は unresolved thread を既に扱っている。
+- media upload status も repo 未指定通常会話の private media として扱う文言を持つ。
+
+## 未確認の境界
+
+- `unresolved` という内部名を将来 owner-facing / logs / service 名で完全に置換するかは、この PR では決めない。
+- repo-less main chat から repo-required action へ入る自然言語 repo resolver は、この PR では実装しない。
+- bridge lifecycle guard は Issue #741 の別 slice とする。
+
+## 穴が出そうな箇所
+
+- repo 入力フォームを完全に消すと、手動で repo 固定したい開発者の逃げ道が減る。今回は URL query の `repository` は維持し、通常画面にフォームを出さない方針にする。
+- disabled surface の `repo 設定後に開けます` はまだ repo 選択前提に見える。今回の slice では repo 必須 operation の境界として残し、通常チャットの主導線からは下げる。
+- `dashboard-main-unresolved` という内部名はテストや bridge に残る。owner-facing の未解決印象だけを先に消す。
+
+## PR 前に確認すること
+
+- default dashboard が repo 入力フォームを出さない。
+- repo 指定 URL は従来どおり対象 repo を表示する。
+- generated worker が source と一致する。
+- `main` の既存 dirty 差分を触っていない。
+
+## 実装候補と捨てた案
+
+- 採用: UI 表示を repo-less main chat に変え、既存 unresolved thread を維持する。
+- 捨てた案: unresolved bridge を stop/disable する。owner が repo-less main chat として必要だと明示したため不採用。
+- 捨てた案: repo resolver まで同時実装する。Issue #613 の大きな本筋だが、この PR では first viewport の誤認を先に除く。
+- 捨てた案: drawer から repo 関連 surface を全削除する。repo 必須操作の boundary が曖昧になるため不採用。
+
+## merge 後に通す E2E
+
+- production PWA を強制リロードする。
+- repo 未指定で Dashboard Butler を開き、header と drawer が repo-less main chat として見えることを確認する。
+- チャット送信が `dashboard-main-unresolved` で通常に流れることを確認する。
+- repo 必須操作に入る時だけ対象 repo 確認が出ることを後続 slice で確認する。
+
+## 次の PR を増やさない理由
+
+この PR は Issue #613 の大きな redesign 全体ではなく、owner が明示した unresolved bridge の解釈修正に閉じる。これを先に入れることで、Issue #741 の bridge lifecycle guard と Issue #528 の通常チャット UX 改修が同じ前提で進められる。
+
+## 停止条件
+
+- repo 未指定時の送信経路が `dashboard-main-unresolved` から変わる場合。
+- repo 必須 operation が repo 確認なしで実行可能になる場合。
+- URL query による repo 指定が壊れる場合。
+- 作戦図にない bridge service / deploy / credential / passkey 変更が必要になった場合。

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -14298,20 +14298,12 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
   );
   const dashboardIssueNumber = normalizePositiveInteger(url?.searchParams?.get("issueNumber"));
   const requestedChatThreadId = normalizeDashboardThreadId(url?.searchParams?.get("threadId") || url?.searchParams?.get("thread_id"));
-  const dashboardTargetLabel = repositoryInput ? `この作業: ${repositoryInput}` : "作業対象 repo 未指定";
+  const dashboardTargetLabel = repositoryInput ? `この作業: ${repositoryInput}` : "repo-less main chat";
   const targetStatusMarkup = repositoryInput
     ? `<p><strong>${escapeDashboardHtml(repositoryInput)}</strong></p>
           <p class="muted">固定ではありません。この会話で Issue / PR / deploy など repo が必要な作業をする間だけ対象にします。deploy 先と承認境界は repo ごとに確認します。</p>`
-    : `<p><strong>作業対象 repo 未指定</strong></p>
-          <p class="muted">通常会話は続けられます。Issue / PR / deploy など repo が必要な作業を始める時だけ、この作業の対象 repo を指定します。VTDD と TOMIO では deploy 先も承認境界も別物として扱います。</p>
-          <form class="target-form" method="get" action="${escapeDashboardHtml(origin)}/dashboard">
-            <label for="dashboard-repository-input">この作業の対象 repo</label>
-            <div class="target-form-row">
-              <input id="dashboard-repository-input" name="repository" placeholder="owner/repo" autocomplete="off" autocapitalize="off" spellcheck="false">
-              ${dashboardIssueNumber ? `<input type="hidden" name="issueNumber" value="${dashboardIssueNumber}">` : ""}
-              <button type="submit">設定</button>
-            </div>
-          </form>`;
+    : `<p><strong>repo-less main chat</strong></p>
+          <p class="muted">ここが通常のメインチャットです。repo は常設設定ではなく、Issue / PR / deploy など repo 境界が必要になった時だけ Butler が会話の中で確認します。VTDD と TOMIO では deploy 先も承認境界も別物として扱います。</p>`;
   const encodedRepository = encodeURIComponent(repositoryInput);
   const chatThreadId = requestedChatThreadId || `dashboard-main-${(repositoryInput || "unresolved").replace(/[^a-z0-9_.-]+/gi, "-")}`;
   const socketOrigin = origin.replace(/^http/i, "ws");
@@ -14435,6 +14427,11 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           : `<span class="disabled-action" aria-disabled="true"><strong>${escapeDashboardHtml(surface.title)}</strong><small>${escapeDashboardHtml(surface.disabledReason || "利用できません")}</small></span>`
       )
       .join("");
+  const initialDashboardIntroMarkup = repositoryInput
+    ? `<p>はい。ここではまず普通に会話できます。通知、進捗、この作業の対象 repo の確認は必要な時だけ開けます。</p>
+          <p>作業を進める時は、対象 repo、Issue、deploy 先を会話の中で確認してから進めます。</p>`
+    : `<p>はい。ここは repo-less main chat です。repo を固定しなくても、まず普通に会話できます。</p>
+          <p>Issue / PR / deploy など repo 境界が必要な作業に入る時だけ、対象 repo、Issue、deploy 先を会話の中で確認してから進めます。</p>`;
 
   return `<!doctype html>
 <html lang="ja">
@@ -14674,9 +14671,9 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           <label class="round-button menu-open" for="mobile-menu-toggle" aria-label="管理メニューを閉じる">×</label>
         </div>
         <div class="mobile-drawer-content">
-          <p class="menu-callout">通知、進捗、この作業の対象 repo の確認はここから開きます。開発/運用の詳細は下に隔離しています。</p>
+          <p class="menu-callout">通知、進捗、repo が必要な開発/運用確認はここから開きます。通常チャットは repo 未指定のまま始められます。</p>
           <div class="lane">
-            <div class="lane-title"><h3>この作業の対象 repo</h3><span class="pill">${repositoryInput ? "active" : "未指定"}</span></div>
+            <div class="lane-title"><h3>${repositoryInput ? "この作業の対象 repo" : "repo-less main chat"}</h3><span class="pill">${repositoryInput ? "active" : "main"}</span></div>
             ${targetStatusMarkup}
           </div>
           <div class="lane">
@@ -14726,8 +14723,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         </article>
         <article class="bubble">
           <strong>Butler</strong>
-          <p>はい。ここではまず普通に会話できます。通知、進捗、この作業の対象 repo の確認は必要な時だけ開けます。</p>
-          <p>作業を進める時は、対象 repo、Issue、deploy 先を会話の中で確認してから進めます。</p>
+          ${initialDashboardIntroMarkup}
           <ul>
             <li>対象: <code>${escapeDashboardHtml(dashboardTargetLabel)}</code></li>
             <li>通知と進捗はこの画面から戻って確認できます。</li>

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -1263,10 +1263,12 @@ test("worker serves v2 dashboard for allowed owner identity without exposing sec
   assert.equal(body.includes("接続準備中です。送信できる状態になったら知らせます。"), true);
   assert.equal(body.includes("接続準備中です。WebSocket 接続後に送信できます。"), false);
   assert.equal(body.includes("repo/nickname 未指定"), false);
-  assert.equal(body.includes("作業対象 repo 未指定"), true);
-  assert.equal(body.includes("この作業の対象 repo"), true);
+  assert.equal(body.includes("作業対象 repo 未指定"), false);
+  assert.equal(body.includes("repo-less main chat"), true);
+  assert.equal(body.includes("通常チャットは repo 未指定のまま始められます"), true);
+  assert.equal(body.includes("この作業の対象 repo"), false);
   assert.equal(body.includes("固定ではありません"), false);
-  assert.equal(body.includes("VTDD と TOMIO では deploy 先も承認境界も別物"), true);
+  assert.equal(body.includes("repo 境界が必要になった時だけ Butler が会話の中で確認します"), true);
   assert.equal(body.includes("?repository=owner/repo"), false);
   assert.equal(body.includes("旧 VPS runner 直送経路は使いません"), false);
   assert.equal(body.includes("codex app-server"), true);
@@ -1293,8 +1295,8 @@ test("worker serves v2 dashboard for allowed owner identity without exposing sec
   assert.equal(body.includes('aria-label="Passkey">◇</a>'), false);
   assert.equal(body.includes('<label class="tool-button menu-open" for="mobile-menu-toggle">管理</label>'), false);
   assert.equal(body.includes('class="tool-button top-action"'), false);
-  assert.equal(body.includes('id="dashboard-repository-input"'), true);
-  assert.equal(body.includes('placeholder="owner/repo"'), true);
+  assert.equal(body.includes('id="dashboard-repository-input"'), false);
+  assert.equal(body.includes('placeholder="owner/repo"'), false);
   assert.equal(body.includes('aria-disabled="true"'), true);
   assert.equal(body.includes("repo 設定後に開けます"), true);
   assert.equal(body.includes('id="butler-chat-form"'), true);

--- a/worker.js
+++ b/worker.js
@@ -70118,18 +70118,10 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
   );
   const dashboardIssueNumber = normalizePositiveInteger10(url?.searchParams?.get("issueNumber"));
   const requestedChatThreadId = normalizeDashboardThreadId(url?.searchParams?.get("threadId") || url?.searchParams?.get("thread_id"));
-  const dashboardTargetLabel = repositoryInput ? `\u3053\u306E\u4F5C\u696D: ${repositoryInput}` : "\u4F5C\u696D\u5BFE\u8C61 repo \u672A\u6307\u5B9A";
+  const dashboardTargetLabel = repositoryInput ? `\u3053\u306E\u4F5C\u696D: ${repositoryInput}` : "repo-less main chat";
   const targetStatusMarkup = repositoryInput ? `<p><strong>${escapeDashboardHtml(repositoryInput)}</strong></p>
-          <p class="muted">\u56FA\u5B9A\u3067\u306F\u3042\u308A\u307E\u305B\u3093\u3002\u3053\u306E\u4F1A\u8A71\u3067 Issue / PR / deploy \u306A\u3069 repo \u304C\u5FC5\u8981\u306A\u4F5C\u696D\u3092\u3059\u308B\u9593\u3060\u3051\u5BFE\u8C61\u306B\u3057\u307E\u3059\u3002deploy \u5148\u3068\u627F\u8A8D\u5883\u754C\u306F repo \u3054\u3068\u306B\u78BA\u8A8D\u3057\u307E\u3059\u3002</p>` : `<p><strong>\u4F5C\u696D\u5BFE\u8C61 repo \u672A\u6307\u5B9A</strong></p>
-          <p class="muted">\u901A\u5E38\u4F1A\u8A71\u306F\u7D9A\u3051\u3089\u308C\u307E\u3059\u3002Issue / PR / deploy \u306A\u3069 repo \u304C\u5FC5\u8981\u306A\u4F5C\u696D\u3092\u59CB\u3081\u308B\u6642\u3060\u3051\u3001\u3053\u306E\u4F5C\u696D\u306E\u5BFE\u8C61 repo \u3092\u6307\u5B9A\u3057\u307E\u3059\u3002VTDD \u3068 TOMIO \u3067\u306F deploy \u5148\u3082\u627F\u8A8D\u5883\u754C\u3082\u5225\u7269\u3068\u3057\u3066\u6271\u3044\u307E\u3059\u3002</p>
-          <form class="target-form" method="get" action="${escapeDashboardHtml(origin)}/dashboard">
-            <label for="dashboard-repository-input">\u3053\u306E\u4F5C\u696D\u306E\u5BFE\u8C61 repo</label>
-            <div class="target-form-row">
-              <input id="dashboard-repository-input" name="repository" placeholder="owner/repo" autocomplete="off" autocapitalize="off" spellcheck="false">
-              ${dashboardIssueNumber ? `<input type="hidden" name="issueNumber" value="${dashboardIssueNumber}">` : ""}
-              <button type="submit">\u8A2D\u5B9A</button>
-            </div>
-          </form>`;
+          <p class="muted">\u56FA\u5B9A\u3067\u306F\u3042\u308A\u307E\u305B\u3093\u3002\u3053\u306E\u4F1A\u8A71\u3067 Issue / PR / deploy \u306A\u3069 repo \u304C\u5FC5\u8981\u306A\u4F5C\u696D\u3092\u3059\u308B\u9593\u3060\u3051\u5BFE\u8C61\u306B\u3057\u307E\u3059\u3002deploy \u5148\u3068\u627F\u8A8D\u5883\u754C\u306F repo \u3054\u3068\u306B\u78BA\u8A8D\u3057\u307E\u3059\u3002</p>` : `<p><strong>repo-less main chat</strong></p>
+          <p class="muted">\u3053\u3053\u304C\u901A\u5E38\u306E\u30E1\u30A4\u30F3\u30C1\u30E3\u30C3\u30C8\u3067\u3059\u3002repo \u306F\u5E38\u8A2D\u8A2D\u5B9A\u3067\u306F\u306A\u304F\u3001Issue / PR / deploy \u306A\u3069 repo \u5883\u754C\u304C\u5FC5\u8981\u306B\u306A\u3063\u305F\u6642\u3060\u3051 Butler \u304C\u4F1A\u8A71\u306E\u4E2D\u3067\u78BA\u8A8D\u3057\u307E\u3059\u3002VTDD \u3068 TOMIO \u3067\u306F deploy \u5148\u3082\u627F\u8A8D\u5883\u754C\u3082\u5225\u7269\u3068\u3057\u3066\u6271\u3044\u307E\u3059\u3002</p>`;
   const encodedRepository = encodeURIComponent(repositoryInput);
   const chatThreadId = requestedChatThreadId || `dashboard-main-${(repositoryInput || "unresolved").replace(/[^a-z0-9_.-]+/gi, "-")}`;
   const socketOrigin = origin.replace(/^http/i, "ws");
@@ -70241,6 +70233,9 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
   const renderDashboardSurfaceList = (items) => items.map(
     (surface) => surface.href ? `<a href="${escapeDashboardHtml(surface.href)}">${escapeDashboardHtml(surface.title)}</a>` : `<span class="disabled-action" aria-disabled="true"><strong>${escapeDashboardHtml(surface.title)}</strong><small>${escapeDashboardHtml(surface.disabledReason || "\u5229\u7528\u3067\u304D\u307E\u305B\u3093")}</small></span>`
   ).join("");
+  const initialDashboardIntroMarkup = repositoryInput ? `<p>\u306F\u3044\u3002\u3053\u3053\u3067\u306F\u307E\u305A\u666E\u901A\u306B\u4F1A\u8A71\u3067\u304D\u307E\u3059\u3002\u901A\u77E5\u3001\u9032\u6357\u3001\u3053\u306E\u4F5C\u696D\u306E\u5BFE\u8C61 repo \u306E\u78BA\u8A8D\u306F\u5FC5\u8981\u306A\u6642\u3060\u3051\u958B\u3051\u307E\u3059\u3002</p>
+          <p>\u4F5C\u696D\u3092\u9032\u3081\u308B\u6642\u306F\u3001\u5BFE\u8C61 repo\u3001Issue\u3001deploy \u5148\u3092\u4F1A\u8A71\u306E\u4E2D\u3067\u78BA\u8A8D\u3057\u3066\u304B\u3089\u9032\u3081\u307E\u3059\u3002</p>` : `<p>\u306F\u3044\u3002\u3053\u3053\u306F repo-less main chat \u3067\u3059\u3002repo \u3092\u56FA\u5B9A\u3057\u306A\u304F\u3066\u3082\u3001\u307E\u305A\u666E\u901A\u306B\u4F1A\u8A71\u3067\u304D\u307E\u3059\u3002</p>
+          <p>Issue / PR / deploy \u306A\u3069 repo \u5883\u754C\u304C\u5FC5\u8981\u306A\u4F5C\u696D\u306B\u5165\u308B\u6642\u3060\u3051\u3001\u5BFE\u8C61 repo\u3001Issue\u3001deploy \u5148\u3092\u4F1A\u8A71\u306E\u4E2D\u3067\u78BA\u8A8D\u3057\u3066\u304B\u3089\u9032\u3081\u307E\u3059\u3002</p>`;
   return `<!doctype html>
 <html lang="ja">
 <head>
@@ -70479,9 +70474,9 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           <label class="round-button menu-open" for="mobile-menu-toggle" aria-label="\u7BA1\u7406\u30E1\u30CB\u30E5\u30FC\u3092\u9589\u3058\u308B">\xD7</label>
         </div>
         <div class="mobile-drawer-content">
-          <p class="menu-callout">\u901A\u77E5\u3001\u9032\u6357\u3001\u3053\u306E\u4F5C\u696D\u306E\u5BFE\u8C61 repo \u306E\u78BA\u8A8D\u306F\u3053\u3053\u304B\u3089\u958B\u304D\u307E\u3059\u3002\u958B\u767A/\u904B\u7528\u306E\u8A73\u7D30\u306F\u4E0B\u306B\u9694\u96E2\u3057\u3066\u3044\u307E\u3059\u3002</p>
+          <p class="menu-callout">\u901A\u77E5\u3001\u9032\u6357\u3001repo \u304C\u5FC5\u8981\u306A\u958B\u767A/\u904B\u7528\u78BA\u8A8D\u306F\u3053\u3053\u304B\u3089\u958B\u304D\u307E\u3059\u3002\u901A\u5E38\u30C1\u30E3\u30C3\u30C8\u306F repo \u672A\u6307\u5B9A\u306E\u307E\u307E\u59CB\u3081\u3089\u308C\u307E\u3059\u3002</p>
           <div class="lane">
-            <div class="lane-title"><h3>\u3053\u306E\u4F5C\u696D\u306E\u5BFE\u8C61 repo</h3><span class="pill">${repositoryInput ? "active" : "\u672A\u6307\u5B9A"}</span></div>
+            <div class="lane-title"><h3>${repositoryInput ? "\u3053\u306E\u4F5C\u696D\u306E\u5BFE\u8C61 repo" : "repo-less main chat"}</h3><span class="pill">${repositoryInput ? "active" : "main"}</span></div>
             ${targetStatusMarkup}
           </div>
           <div class="lane">
@@ -70531,8 +70526,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         </article>
         <article class="bubble">
           <strong>Butler</strong>
-          <p>\u306F\u3044\u3002\u3053\u3053\u3067\u306F\u307E\u305A\u666E\u901A\u306B\u4F1A\u8A71\u3067\u304D\u307E\u3059\u3002\u901A\u77E5\u3001\u9032\u6357\u3001\u3053\u306E\u4F5C\u696D\u306E\u5BFE\u8C61 repo \u306E\u78BA\u8A8D\u306F\u5FC5\u8981\u306A\u6642\u3060\u3051\u958B\u3051\u307E\u3059\u3002</p>
-          <p>\u4F5C\u696D\u3092\u9032\u3081\u308B\u6642\u306F\u3001\u5BFE\u8C61 repo\u3001Issue\u3001deploy \u5148\u3092\u4F1A\u8A71\u306E\u4E2D\u3067\u78BA\u8A8D\u3057\u3066\u304B\u3089\u9032\u3081\u307E\u3059\u3002</p>
+          ${initialDashboardIntroMarkup}
           <ul>
             <li>\u5BFE\u8C61: <code>${escapeDashboardHtml(dashboardTargetLabel)}</code></li>
             <li>\u901A\u77E5\u3068\u9032\u6357\u306F\u3053\u306E\u753B\u9762\u304B\u3089\u623B\u3063\u3066\u78BA\u8A8D\u3067\u304D\u307E\u3059\u3002</li>


### PR DESCRIPTION
Issue #613 の repo-less main chat 正式化 slice です。owner が `unresolved bridge` を未解決の残骸ではなく repo 未指定のメインチャットとして扱うべきだと明示したため、通常 Dashboard の first viewport / drawer 表示から未解決扱いと常設 repo 入力フォームを外します。

- Issue: Issue #613
- PR 種別: runtime UI / Dashboard chat shell slice
- Closes: なし

## This PR satisfies Intent

Dashboard Butler を「repo を選んでから使う管理画面」ではなく、repo 未指定でも始められる repo-less main chat として表示します。

既存の `dashboard-main-unresolved` thread / WebSocket / app-server bridge 経路は維持し、owner-facing UI だけを「未解決」から「通常のメインチャット」へ寄せます。

## Satisfied Success Criteria

- Dashboard 通常チャットで `作業対象 repo 未指定` を表示しません。
- repo 未指定時の header / drawer / 初期 Butler message を `repo-less main chat` として表示します。
- 通常 Dashboard に常設 `owner/repo` 入力フォームを出しません。
- repo 指定 URL では従来どおり `この作業: owner/repo` として対象 repo を表示します。
- repo 必須の progress / GitHub / deploy / RAG surface は disabled のまま残し、repo 境界と authority boundary を弱めません。
- repo 未指定時の `dashboard-main-unresolved` thread endpoint / WebSocket endpoint は維持します。

## Unsatisfied Success Criteria

- 自然文から repo 候補を内部解決し、曖昧な時だけ確認する repo resolver は未実装です。
- inline voice / operation lane / cross-repo activity history は未実装です。
- Issue #613 全体の completion ではありません。
- production PWA E2E は未実施です。

## 開発前作戦図

- 作戦図 evidence: docs/development-strategy/issue-613-repoless-main-chat.md
- 完了体験: repo 未指定 Dashboard を開いた時、未解決ではなく repo-less main chat として自然に会話を始められます。
- VTDD 全体で進める部分: Issue #613 の通常チャット first viewport と drawer 表示を repo-less main chat 前提へ寄せます。
- 設計: internal `dashboard-main-unresolved` は維持し、owner-facing label と常設 repo 入力だけを変更します。
- 仮説: root cause は経路不足ではなく、未解決に見える UI 文言と常設 repo 入力です。
- 検証計画: `node --test test/worker.test.js`、`npm run build:worker`、`npm run check:generated-worker`、`git diff --check` を通します。
- 改修見積もり: `src/worker/runtime.js`、`worker.js`、`test/worker.test.js`、strategy doc を変更します。
- 既に通っている経路: `dashboard-main-unresolved` thread / WebSocket / app-server bridge tests は既存で通っています。
- 未確認の境界: 内部名 `unresolved` の service/log 名変更、repo resolver、bridge lifecycle guard は別 slice です。
- 穴が出そうな箇所: repo 入力フォームを通常面から外すことで手動固定導線が減るため、URL query repo 指定は維持します。
- PR 前に確認すること: default dashboard の form 非表示、repo 指定 URL の従来表示、generated worker 一致を確認します。
- 実装候補と捨てた案: 採用は UI 表示変更。unresolved bridge stop/disable は owner 方針と逆なので捨てました。
- merge 後に通す E2E: production PWA E2E で repo 未指定 Dashboard を開き、repo-less main chat として見えること、送信が通常 thread で流れることを確認します。
- 次の PR を増やさない理由: 後続 PR を増やす前に、Issue #741 と #528 の前提をそろえるため、未解決扱いだけをこの scope で狭く直します。
- 停止条件: repo 未指定送信経路が変わる、repo 必須 operation が確認なしで実行可能になる、URL query repo 指定が壊れる場合は停止します。

## Dry-run Impact Report

- Target Issue: Issue #613
- Implementing Success Criteria: 通常チャット first viewport に常設 repo 入力 UI を出さず、repo 未指定を repo-less main chat として扱うこと。
- Explicit Non-goals: merge、deploy、Issue close、bridge systemd lifecycle、progress folding、LINE 風返信、Markdown renderer、repo resolver は対象外です。
- Expected touched files/routes/workflows: `src/worker/runtime.js`、`worker.js`、`test/worker.test.js`、`docs/development-strategy/issue-613-repoless-main-chat.md`。
- Affected Issues: Issue #613 が直接対象。Issue #528、Issue #590、Issue #741 の前提整理に影響します。
- Affected PRs: 既存 open PR は変更しません。
- Affected workflows: 通常 test / guarded-policy / reviewer workflow。新規 workflow は追加しません。
- Affected runtime/operator surfaces: Dashboard Butler PWA の通常 chat shell 表示のみ。operator / approval / deploy surface は触りません。
- What may break if we patch narrowly: repo resolver が未実装のため、repo 必須 operation へ入る時の自然な確認はまだ後続 slice です。
- Unknowns to investigate before coding: repo 入力フォームが他の E2E で明示的に必要かどうか。
- Validation needed: worker test、worker build、generated worker check、diff check、production PWA E2E。
- Stop condition: repo boundary / passkey / deploy scope が弱まる場合。

## Execution Queue Delta

- Queue position before: Durable queue の `Now` は Issue #590。Issue #613 は Root Blockers にあり、Dashboard Butler を repo-selected admin panel ではなく single-thread cross-repo work-control surface にする blocker です。
- Preemption decision: ROOT。owner が unresolved bridge を repo-less main chat として正式化すべきと明示し、これを未解決扱いのままにすると Issue #528、Issue #590、Issue #741 の owner-facing 判定が濁ります。
- Queue delta: Issue #613 moves into a narrow repo-less main chat implementation slice. Issue #590 は active のままで、Issue #613 全体も完了扱いにしません。
- Why this PR is next: unresolved bridge は止める対象ではなく main chat だと判明したため、bridge lifecycle guard や通常チャット UX の前提を先に正します。
- Active Issues not downscoped: Active Issues are not downscoped。Issue #613、Issue #528、Issue #590、Issue #741、Issue #450、Issue #637 は縮小・完了扱いにしません。

## File / Line Hypotheses

- `src/worker/runtime.js`: `renderV2DashboardPage()` の repo 未指定 label / drawer lane / initial Butler message を変更します。
- `test/worker.test.js`: default dashboard が repo-less main chat を表示し、repo input を出さず、unresolved endpoint を維持する assertion に更新します。
- `worker.js`: generated worker として source 差分を反映します。
- `docs/development-strategy/issue-613-repoless-main-chat.md`: 実装前作戦図を追加します。

## Hypothesis Retrospective

`dashboard-main-unresolved` WebSocket / app-server bridge 経路は既に存在し、テストも多数あります。今回の root cause はその thread を未解決状態のように見せる UI と、通常チャットに常設 repo 入力フォームを置いていることでした。

repo 必須 operation の disabled 表示は残したため、repo 境界や passkey / deploy authority は弱めていません。

## Verification Evidence

- `node --test test/worker.test.js`: pass, 252 tests
- `npm run build:worker`: pass
- `npm run check:generated-worker`: pass
- `git diff --check`: pass

## Butler Completion Contract

- Primary owner surface: Dashboard Butler PWA
- Fallback surface: mac Codex は開発・緊急確認のフォールバックで、主経路ではありません。
- Owner goal: repo 未指定チャットを未解決の残骸ではなく正式なメインチャットとして使えること。
- Butler entrypoint: `/dashboard` の通常チャット。
- Dashboard Butler natural-language path: Dashboard Butler の通常チャット入口で repo 未指定のまま自然文の通常会話を始め、repo 必須作業に入る時だけ会話内で対象 repo を確認する経路です。
- Action Schema exposure: Custom GPT Action Schema は対象外です。この PR は Dashboard PWA runtime UI の first slice です。
- Runtime path: `renderV2DashboardPage()` の Dashboard chat shell。
- Runner/runtime truth: Worker の dashboard route HTML と generated `worker.js` に repo-less main chat 表示が含まれます。
- Authority boundary: merge / deploy / Issue close は未実行で、必要なら owner の明示 GO または passkey approval が必要です。
- E2E evidence: production Owner PWA E2E は未実施。local test evidence は Verification Evidence に記録済みです。
- Completion status: incomplete

## Surface Update Checklist

- Dashboard Butler PWA: 更新あり。repo 未指定 Dashboard を repo-less main chat として表示します。
- Custom GPT Action Schema: 更新なし。
- VPS Codex CLI / app-server bridge: 経路変更なし。`dashboard-main-unresolved` は維持します。
- GitHub Issue / PR / reviewer: この PR 作成後に reviewer / checks を確認します。
- Deploy / operator surface: 更新なし。deploy はこの PR では実行しません。
