### PR TITLE
Issue #741 app-server bridge の復帰状態を Dashboard に返す

### DIFF
--- a/docs/development-strategy/issue-741-bridge-resume-state.md
+++ b/docs/development-strategy/issue-741-bridge-resume-state.md
@@ -1,0 +1,91 @@
+# Issue #741 bridge resume state
+
+## 完了体験
+
+deploy 後または app-server bridge restart 後、owner は同じ Dashboard chat で「bridge が再接続した」「既存 Codex thread を resume した」「turn id が確定した」「進行中または完了した」を確認できる。
+
+owner は前の文脈を再入力せず、repo-less main chat の同じ thread で続きから会話できる。
+
+## VTDD 全体で進める部分
+
+この PR は Issue #741 の最初の runtime state slice である。systemd restart policy や deploy 後 checkout sync そのものではなく、restart / reconnect 後に Dashboard が復帰状態を観測できる event contract を先に作る。
+
+## 設計
+
+- bridge WebSocket open 時に `app_server_status` を送信し、thread id と lifecycle status を Dashboard に出す。
+- request に `codexThreadId` がある場合、`thread/resume` 成功後に `resumed_existing_thread` status を送信する。
+- request に `codexThreadId` がない場合は従来どおり `thread/start` status を送信する。
+- `turn/start` 成功後に turn id / message id / resume state を含む `turn_started` status を送信する。
+- status は transient owner-facing runtime truth として扱い、chat history に durable spam を増やさない。
+
+## 仮説
+
+Worker 側には `app_server_thread:<dashboardThreadId>` mapping と pending owner message drain が既にある。bridge 側も `codexThreadId` を受け取ると `thread/resume` できる。
+
+不足しているのは、deploy 後 restart や bridge reconnect 時に「何が復元されたか」を owner が見える runtime truth として出すこと。これがないため、裏では復帰していても Butler では止まったように見える。
+
+## 検証計画
+
+- `test/dashboard-app-server-bridge.test.js` に bridge open status、resume status、turn started status の assertion を追加する。
+- existing fresh turn test で `thread/start` は維持されることを確認する。
+- existing resume request test で `thread/resume` が使われることを確認する。
+- `node --test test/dashboard-app-server-bridge.test.js` を通す。
+- `git diff --check` を通す。
+
+## 改修見積もり
+
+- `scripts/run-dashboard-app-server-bridge.mjs`
+  - bridge connected status helper を追加する。
+  - `handleDashboardTurnRequest()` の resume/start/turn-start status を拡張する。
+  - `connectDashboardAppServerBridgeOnce()` の WebSocket open 時に lifecycle status を送る。
+- `test/dashboard-app-server-bridge.test.js`
+  - open/reconnect status、resume status、turn started status のテストを追加または更新する。
+
+## 既に通っている経路
+
+- Worker Durable Object は `app_server_thread:<dashboardThreadId>` に Codex thread id を保存している。
+- Worker は app-server bridge reconnect 時に pending owner messages を drain できる。
+- bridge は `codexThreadId` がある request で `thread/resume` を呼ぶ。
+- bridge は `turn/started` / progress / reply / timeout を Dashboard event に変換できる。
+
+## 未確認の境界
+
+- systemd unit の `RuntimeMaxSec=` / watchdog 設定は未確認。
+- deploy 後 checkout sync + restart helper は未実装。
+- production VPS での before/after CPU/memory evidence は未取得。
+- Codex app-server が restart 中 turn をどこまで resume できるかは provider behavior に依存する。
+
+## 穴が出そうな箇所
+
+- bridge が restart した瞬間に進行中 Codex turn の notification stream を完全に再購読できるとは限らない。
+- pending owner message は Worker 側で保持できるが、turn 中の partial progress は Dashboard event と chat state にどこまで保持するか後続設計が必要。
+- transient status だけでは sleep 復帰後の過去 state を見返せないため、後続で runtime state store が必要になる可能性がある。
+
+## PR 前に確認すること
+
+- Issue #741 の Success Criteria と Non-goal。
+- `scripts/run-dashboard-app-server-bridge.mjs` の resume/start/turn handling。
+- `src/worker/runtime.js` の app_server_thread mapping と pending message drain。
+- targeted bridge tests。
+
+## 実装候補と捨てた案
+
+- 採用: bridge event contract を先に作り、restart 復帰状態を owner-facing に出す。
+- 捨てた案: systemd unit を先に変える。runtime truth がないまま restart だけ増えると、owner は余計に不安になる。
+- 捨てた案: deploy 後 restart を自動実行する。deploy / host operation authority が絡むため、この PR の権限境界を超える。
+
+## merge 後に通す E2E
+
+- production PWA E2E で unresolved main chat を開く。
+- app-server bridge restart 後に同じ Dashboard thread で bridge connected / resumed_existing_thread / turn_started status が見えることを確認する。
+- repo-less ordinary chat の送信が復帰後も同じ thread で続くことを確認する。
+
+## 次の PR を増やさない理由
+
+この PR は後続 PR を増やさないためではなく、後続の systemd restart policy / deploy restart helper / runtime state store の前提をそろえるための最初の scope である。Issue #741 全体はまだ完了しない。
+
+## 停止条件
+
+- chat history や owner message persistence が失われる変更が必要になった場合。
+- deploy / credential / permission / destructive host operation が必要になった場合。
+- Codex app-server の非公開内部挙動を completion 前提にする必要が出た場合。

--- a/scripts/run-dashboard-app-server-bridge.mjs
+++ b/scripts/run-dashboard-app-server-bridge.mjs
@@ -1367,8 +1367,16 @@ export async function handleDashboardTurnRequest({
   }
 
   let codexThreadId = request.codexThreadId || null;
+  const resumedExistingThread = Boolean(codexThreadId);
   if (codexThreadId) {
     await appServer.request(buildAppServerThreadResumeRequest({ id: appServer.nextRequestId(), codexThreadId, cwd, sandboxMode }));
+    await sendDashboardEvent(
+      buildDashboardBridgeResumeStatusEvent({
+        dashboardThreadId,
+        codexThreadId,
+        messageId: request.messageId
+      })
+    );
   } else {
     const started = await appServer.request(buildAppServerThreadStartRequest({ id: appServer.nextRequestId(), cwd, sandboxMode }));
     codexThreadId = started?.thread?.id || null;
@@ -1555,6 +1563,15 @@ export async function handleDashboardTurnRequest({
     if (!activeTurnId && startedTurnId) {
       activeTurnId = startedTurnId;
     }
+    await sendDashboardEvent(
+      buildDashboardBridgeTurnStartedStatusEvent({
+        dashboardThreadId,
+        codexThreadId,
+        turnId: activeTurnId || startedTurnId,
+        messageId: request.messageId,
+        resumedExistingThread
+      })
+    );
     markAppServerActivity();
     await turnCompletion;
   } finally {
@@ -1637,6 +1654,86 @@ export function buildDashboardAppServerBridgeEndpoint(options = {}) {
   return endpoint;
 }
 
+export function buildDashboardBridgeConnectedEvent({ endpoint, threadId = "", cwd = process.cwd(), resumedAt = new Date().toISOString() } = {}) {
+  const dashboardThreadId =
+    normalizeBridgeText(threadId) ||
+    (() => {
+      try {
+        return normalizeBridgeText(new URL(String(endpoint || "")).searchParams.get("threadId"));
+      } catch {
+        return "";
+      }
+    })();
+  return {
+    type: "app_server_status",
+    schema: DEFAULT_SCHEMA,
+    threadId: dashboardThreadId,
+    status: "bridge_connected",
+    stage: "bridge_connected",
+    text: "app-server bridge が接続しました。保存済み文脈と未送信 owner message を同じ Dashboard thread で復帰できます。",
+    bridgeLifecycle: {
+      status: "connected",
+      threadId: dashboardThreadId || null,
+      cwd: normalizeBridgeText(cwd) || null,
+      connectedAt: normalizeBridgeText(resumedAt) || new Date().toISOString()
+    }
+  };
+}
+
+export function buildDashboardBridgeResumeStatusEvent({
+  dashboardThreadId = "",
+  codexThreadId = "",
+  messageId = "",
+  resumedAt = new Date().toISOString()
+} = {}) {
+  return {
+    type: "app_server_status",
+    schema: DEFAULT_SCHEMA,
+    threadId: dashboardThreadId,
+    codexThreadId: codexThreadId || null,
+    status: "resumed_existing_thread",
+    stage: "thread_resume",
+    text: "既存 Codex thread を resume しました。deploy 後 restart でも前の文脈から続けられます。",
+    bridgeLifecycle: {
+      status: "resumed_existing_thread",
+      dashboardThreadId: dashboardThreadId || null,
+      codexThreadId: codexThreadId || null,
+      messageId: messageId || null,
+      resumedAt: normalizeBridgeText(resumedAt) || new Date().toISOString()
+    }
+  };
+}
+
+export function buildDashboardBridgeTurnStartedStatusEvent({
+  dashboardThreadId = "",
+  codexThreadId = "",
+  turnId = "",
+  messageId = "",
+  resumedExistingThread = false,
+  startedAt = new Date().toISOString()
+} = {}) {
+  return {
+    type: "app_server_status",
+    schema: DEFAULT_SCHEMA,
+    threadId: dashboardThreadId,
+    codexThreadId: codexThreadId || null,
+    status: "turn_started",
+    stage: "turn_started",
+    text: resumedExistingThread
+      ? "復帰した Codex thread で turn を開始しました。進行中状態を同じ Dashboard thread に返します。"
+      : "Codex thread で turn を開始しました。進行中状態を同じ Dashboard thread に返します。",
+    bridgeLifecycle: {
+      status: "turn_started",
+      dashboardThreadId: dashboardThreadId || null,
+      codexThreadId: codexThreadId || null,
+      turnId: turnId || null,
+      messageId: messageId || null,
+      resumedExistingThread: Boolean(resumedExistingThread),
+      startedAt: normalizeBridgeText(startedAt) || new Date().toISOString()
+    }
+  };
+}
+
 export async function connectDashboardAppServerBridgeOnce({
   endpoint,
   token,
@@ -1695,7 +1792,10 @@ export async function connectDashboardAppServerBridgeOnce({
     socket.addEventListener("error", finish);
   });
 
-  socket.addEventListener("open", scheduleHeartbeat);
+  socket.addEventListener("open", () => {
+    scheduleHeartbeat();
+    safeSend(buildDashboardBridgeConnectedEvent({ endpoint, cwd }));
+  });
 
   socket.addEventListener("message", (event) => {
     let payload;

--- a/test/dashboard-app-server-bridge.test.js
+++ b/test/dashboard-app-server-bridge.test.js
@@ -13,6 +13,9 @@ import {
   buildAppServerThreadResumeRequest,
   buildAppServerThreadStartRequest,
   buildAppServerTurnStartRequest,
+  buildDashboardBridgeConnectedEvent,
+  buildDashboardBridgeResumeStatusEvent,
+  buildDashboardBridgeTurnStartedStatusEvent,
   buildDashboardTurnInputText,
   connectDashboardAppServerBridgeOnce,
   executeVpsRunnerWakeup,
@@ -76,6 +79,46 @@ test("dashboard app-server bridge builds initialize and thread requests from Cod
   assert.equal(turn.params.threadId, "codex-thread-1");
   assert.deepEqual(turn.params.input, [{ type: "text", text: "今日は何日？", text_elements: [] }]);
   assert.equal(turn.params.sandboxPolicy, undefined);
+});
+
+test("dashboard app-server bridge formats lifecycle resume status events", () => {
+  const connected = buildDashboardBridgeConnectedEvent({
+    endpoint: "wss://runtime.example/v2/dashboard/app-server/ws?threadId=dashboard-main-unresolved",
+    cwd: "/repo",
+    resumedAt: "2026-06-02T00:00:00.000Z"
+  });
+  assert.equal(connected.type, "app_server_status");
+  assert.equal(connected.threadId, "dashboard-main-unresolved");
+  assert.equal(connected.status, "bridge_connected");
+  assert.equal(connected.stage, "bridge_connected");
+  assert.match(connected.text, /保存済み文脈/);
+  assert.equal(connected.bridgeLifecycle.cwd, "/repo");
+
+  const resumed = buildDashboardBridgeResumeStatusEvent({
+    dashboardThreadId: "dashboard-main-unresolved",
+    codexThreadId: "codex-thread-741",
+    messageId: "owner-message-1",
+    resumedAt: "2026-06-02T00:00:01.000Z"
+  });
+  assert.equal(resumed.status, "resumed_existing_thread");
+  assert.equal(resumed.stage, "thread_resume");
+  assert.equal(resumed.codexThreadId, "codex-thread-741");
+  assert.equal(resumed.bridgeLifecycle.messageId, "owner-message-1");
+  assert.match(resumed.text, /前の文脈から続けられます/);
+
+  const turnStarted = buildDashboardBridgeTurnStartedStatusEvent({
+    dashboardThreadId: "dashboard-main-unresolved",
+    codexThreadId: "codex-thread-741",
+    turnId: "turn-741",
+    messageId: "owner-message-1",
+    resumedExistingThread: true,
+    startedAt: "2026-06-02T00:00:02.000Z"
+  });
+  assert.equal(turnStarted.status, "turn_started");
+  assert.equal(turnStarted.stage, "turn_started");
+  assert.equal(turnStarted.bridgeLifecycle.turnId, "turn-741");
+  assert.equal(turnStarted.bridgeLifecycle.resumedExistingThread, true);
+  assert.match(turnStarted.text, /復帰した Codex thread/);
 });
 
 test("dashboard app-server bridge runner wakeup uses only fixed user systemd start command", async () => {
@@ -826,9 +869,90 @@ test("dashboard app-server bridge handles a fresh dashboard turn through thread/
   assert.equal(requests[1].params.threadId, "codex-thread-1");
   assert.equal(events[0].type, "app_server_status");
   assert.equal(events[0].codexThreadId, "codex-thread-1");
-  assert.equal(events[1].type, "app_server_reply_delta");
-  assert.equal(events[2].type, "app_server_reply");
-  assert.equal(events[2].text, "今日は2026年5月22日です。");
+  const turnStarted = events.find((event) => event.status === "turn_started");
+  assert.ok(turnStarted);
+  assert.equal(turnStarted.codexThreadId, "codex-thread-1");
+  assert.equal(turnStarted.bridgeLifecycle.turnId, "turn-1");
+  assert.equal(turnStarted.bridgeLifecycle.resumedExistingThread, false);
+  const delta = events.find((event) => event.type === "app_server_reply_delta");
+  const reply = events.find((event) => event.type === "app_server_reply");
+  assert.ok(delta);
+  assert.ok(reply);
+  assert.equal(reply.text, "今日は2026年5月22日です。");
+});
+
+test("dashboard app-server bridge resumes an existing Codex thread and reports resume state", async () => {
+  const requests = [];
+  const events = [];
+  const handlers = new Set();
+  let nextId = 1;
+  const appServer = {
+    nextRequestId() {
+      const id = nextId;
+      nextId += 1;
+      return id;
+    },
+    onNotification(handler) {
+      handlers.add(handler);
+      return () => handlers.delete(handler);
+    },
+    async request(message) {
+      requests.push(message);
+      if (message.method === "thread/resume") {
+        return { thread: { id: "codex-thread-existing" } };
+      }
+      if (message.method === "turn/start") {
+        for (const handler of handlers) {
+          handler({
+            method: "item/agentMessage/delta",
+            params: {
+              threadId: "codex-thread-existing",
+              turnId: "turn-resumed",
+              delta: "続きから確認しています。"
+            }
+          });
+          handler({
+            method: "turn/completed",
+            params: {
+              threadId: "codex-thread-existing",
+              turn: { id: "turn-resumed", status: "completed" }
+            }
+          });
+        }
+        return { turn: { id: "turn-resumed" } };
+      }
+      throw new Error(`unexpected method ${message.method}`);
+    }
+  };
+
+  await handleDashboardTurnRequest({
+    request: {
+      threadId: "dashboard-main-unresolved",
+      codexThreadId: "codex-thread-existing",
+      messageId: "owner-message-resume",
+      text: "続きは？"
+    },
+    appServer,
+    sendDashboardEvent: async (event) => events.push(event),
+    cwd: "/repo"
+  });
+
+  assert.deepEqual(
+    requests.map((request) => request.method),
+    ["thread/resume", "turn/start"]
+  );
+  const resumed = events.find((event) => event.status === "resumed_existing_thread");
+  assert.ok(resumed);
+  assert.equal(resumed.threadId, "dashboard-main-unresolved");
+  assert.equal(resumed.codexThreadId, "codex-thread-existing");
+  assert.equal(resumed.bridgeLifecycle.messageId, "owner-message-resume");
+  const turnStarted = events.find((event) => event.status === "turn_started");
+  assert.ok(turnStarted);
+  assert.equal(turnStarted.bridgeLifecycle.turnId, "turn-resumed");
+  assert.equal(turnStarted.bridgeLifecycle.resumedExistingThread, true);
+  const reply = events.find((event) => event.type === "app_server_reply");
+  assert.ok(reply);
+  assert.equal(reply.text, "続きから確認しています。");
 });
 
 test("dashboard app-server bridge posts owner-action-required when app-server requests approval during a turn", async () => {
@@ -907,7 +1031,7 @@ test("dashboard app-server bridge posts owner-action-required when app-server re
   assert.equal(body.actionId, "app-server-approval:dashboard-main:codex-thread-approval:item-commandExecution-requestApproval:7");
   assert.equal(body.issueNumber, 637);
   assert.equal(body.url, "/dashboard/notifications?focus=owner-action");
-  assert.equal(events.at(-1).type, "app_server_reply");
+  assert.ok(events.find((event) => event.type === "app_server_reply"));
 });
 
 test("dashboard app-server bridge records owner-action notification failure in dashboard thread", async () => {
@@ -1055,7 +1179,7 @@ test("dashboard app-server bridge drains real client approval notification tasks
     JSON.parse(runtimeCalls[0].init.body).actionId,
     "app-server-approval:dashboard-main:codex-thread-drain:item-commandExecution-requestApproval:99"
   );
-  assert.equal(events.at(-1).type, "app_server_reply");
+  assert.ok(events.find((event) => event.type === "app_server_reply"));
 });
 
 test("dashboard app-server bridge passes traffic-control context to codex app-server turns", async () => {
@@ -1143,7 +1267,7 @@ test("dashboard app-server bridge passes traffic-control context to codex app-se
   assert.match(inputText, /"currentNow":"Issue #590: app-server turn timeout must become recoverable\."/);
   assert.match(inputText, /mechanicalBoundary/);
   assert.match(inputText, /Owner message:\nDashboard Butler が交通整理できるか確認して/);
-  assert.equal(events.at(-1).type, "app_server_reply");
+  assert.ok(events.find((event) => event.type === "app_server_reply"));
 });
 
 test("dashboard app-server bridge passes materialized media paths to codex app-server turns", async () => {
@@ -1214,7 +1338,7 @@ test("dashboard app-server bridge passes materialized media paths to codex app-s
   assert.match(inputText, /mediaReferences: 1/);
   assert.match(inputText, /fetchStatus: fetched/);
   assert.match(inputText, /localPath: .*med_turn_image-dashboard\.png/);
-  assert.equal(events.at(-1).type, "app_server_reply");
+  assert.ok(events.find((event) => event.type === "app_server_reply"));
 });
 
 test("dashboard app-server bridge keeps listening for async turn notifications after turn/start response", async () => {


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #741 の部分進捗です。deploy 後や app-server bridge restart 後でも、Dashboard Butler が同じ thread で復帰状態を owner に見せるための bridge lifecycle truth を追加します。
- この PR は UI 見た目ではなく土台を優先し、repo-less main chat を使う owner が「裏では続いているのか / 新規 thread になったのか」を判定できる状態イベントを bridge から返します。

## Satisfied Success Criteria

- app-server bridge 接続時に `bridge_connected` の `app_server_status` を送信し、保存済み文脈と未送信 owner message を同じ Dashboard thread で復帰できることを runtime truth として出します。
- 既存 Codex thread を `thread/resume` した時に `resumed_existing_thread` を送信し、dashboard thread id / codex thread id / owner message id を `bridgeLifecycle` に残します。
- `turn/start` 後に `turn_started` を送信し、turn id と `resumedExistingThread` を Dashboard 側へ返します。
- targeted bridge test で fresh thread と existing Codex thread resume の両方を検証しました。

## Unsatisfied Success Criteria

- production deploy 後に app-server bridge を実際に restart し、同じ Dashboard chat で復帰状態が owner-facing に見える E2E は未実施です。
- sleep/resume、pending owner message の完全な再送、systemd lifecycle guard、deploy watcher、Web Push 通知はこの PR では未実装です。
- Issue #741 は close-ready ではありません。

## Non-goal violations

None.

## 開発前作戦図

- 作戦図 evidence: `docs/development-strategy/issue-741-bridge-resume-state.md`
- 完了体験: deploy 後または app-server bridge restart 後、owner が repo-less main chat で同じ文脈に復帰し、bridge connected / existing Codex thread resumed / turn started の状態を短い progress truth として確認できます。
- VTDD 全体で進める部分: Dashboard Butler と VPS Codex CLI の間にある app-server bridge lifecycle truth を補強し、Mac Codex を開かずに復帰状態を判断できる土台を進めます。
- 設計: bridge が WebSocket open、thread/resume、turn/start の境界で `app_server_status` を送信し、Dashboard thread id、Codex thread id、turn id、message id を `bridgeLifecycle` に入れます。
- 仮説: 現在の owner-facing 破綻は UI 表示だけでなく、bridge restart 後に「接続した / resume した / turn を開始した」の runtime truth が Dashboard に返らないことが root blocker です。
- 検証計画: `test/dashboard-app-server-bridge.test.js` に lifecycle event formatter、fresh turn、existing Codex thread resume の検証を追加し、`git diff --check` で差分整合性を確認します。
- 改修見積もり: `scripts/run-dashboard-app-server-bridge.mjs` の bridge event builder と `handleDashboardTurnRequest`、`test/dashboard-app-server-bridge.test.js` の bridge lifecycle tests、作戦図 docs を変更します。
- 既に通っている経路: Dashboard turn request、thread/start、thread/resume、turn/start、app-server notification mapping、owner-action-required notification は既存 test coverage があります。
- 未確認の境界: production app-server restart 後の同一 Dashboard chat E2E、systemd guard、deploy watcher、sleep/resume、pending owner message replay は未確認です。
- 穴が出そうな箇所: lifecycle status を通常 reply と誤認する test ordering、status が durable 履歴に残りすぎる可能性、複数 bridge thread の owner-facing 判定が弱い可能性があります。
- PR 前に確認すること: Issue #741 本文、active queue、既存 bridge tests、open PR への衝突、targeted bridge test、diff check を確認します。
- 実装候補と捨てた案: systemd restart guard まで一気に入れる案は scope が大きく deploy/host approval に近づくため捨て、まず bridge lifecycle truth の runtime slice に絞りました。
- merge 後に通す E2E: E2E-741 bridge restart resume。production deploy 後、repo-less main chat で app-server bridge restart を挟み、同じ Dashboard thread に bridge_connected / resumed_existing_thread / turn_started / final reply が見えるか確認します。
- 次の PR を増やさない理由: この PR は foundation の最小 runtime truth slice であり、systemd guard や deploy watcher は別 Issue-backed slice に分ける方が authority boundary と E2E が明確です。
- 停止条件: lifecycle event が durable chat spam になる、既存 approval notification を壊す、production restart E2E に進むための権限境界が不明になる場合は停止します。

## Dry-run Impact Report

- Target Issue: Issue #741
- Implementing Success Criteria: deploy / app-server bridge restart 後の復帰判定に必要な bridge connected、existing Codex thread resume、turn started の runtime truth を追加します。
- Explicit Non-goals: merge、deploy、credential / permission mutation、systemd unit 変更、実サーバ restart、Web Push、UI polish、Issue close はしません。
- Expected touched files/routes/workflows: `scripts/run-dashboard-app-server-bridge.mjs`、`test/dashboard-app-server-bridge.test.js`、`docs/development-strategy/issue-741-bridge-resume-state.md`
- Affected Issues: Issue #741 を直接進めます。Issue #590、Issue #613、Issue #528 は復帰観測性の土台として影響しますが、この PR では完了扱いにしません。
- Affected PRs: 既存 open PR #740 / #739 / #737 には触りません。PR #742 merge 後の `origin/main` から fresh branch で作業しています。
- Affected workflows: GitHub Actions reviewer / deploy workflow は未変更です。local targeted bridge test のみ実行しました。
- Affected runtime/operator surfaces: Dashboard app-server bridge、Dashboard thread WebSocket、Codex app-server thread/turn lifecycle status。
- What may break if we patch narrowly: lifecycle status を追加したことで、最後の event が reply だと仮定しているテストや UI がずれる可能性があります。該当 test は reply を type で探す形に直しました。
- Unknowns to investigate before coding: production app-server restart 後の WebSocket reconnect と Codex thread id 保持の実機挙動は、この PR 後の E2E で確認します。
- Validation needed: `node --test test/dashboard-app-server-bridge.test.js`、`git diff --check`、merge/deploy 後の production Dashboard Butler E2E。
- Stop condition: deploy/host restart、credential mutation、permission mutation、destructive cleanup が必要になった場合は passkey approval なしに進めません。

## Execution Queue Delta

- Queue position before: active queue の Now は Issue #590 ですが、Issue #741 は deploy 後 restart / sleep/resume / bridge lifecycle が owner-facing continuity を壊す ROOT blocker として扱います。
- Preemption decision: ROOT preemption。UI 見た目ではなく土台を優先する owner 指示に従い、Issue #741 の最小 bridge resume truth slice を先に進めます。
- Queue delta: Issue #741 / PR #743 を app-server bridge lifecycle truth の実装 slice として進めます。Issue #590 / Issue #613 / Issue #528 は完了扱いにせず、production E2E gap を残します。
- Why this PR is next: PR #742 で repo-less main chat が production に入った後、owner は unresolved main chat を主経路として使っています。そのため bridge restart 後に同じ thread へ復帰できる runtime truth が次の土台です。
- Active Issues not downscoped: Active Issues は縮小しません。この PR は Issue #741 の部分進捗であり、他の active Issue は未完了として残します。

## File / Line Hypotheses

- file: `scripts/run-dashboard-app-server-bridge.mjs`
  - hypothesis: WebSocket open、thread/resume、turn/start の境界に lifecycle status がないため、deploy/restart 後に owner が継続状態を判断できません。
  - risk if changed narrowly: status event が reply ordering を壊す可能性があります。
  - validation: fresh turn / existing thread resume / approval notification / traffic-control / media turn tests を targeted bridge test 内で通します。
  - related Issue: Issue #741
- file: `test/dashboard-app-server-bridge.test.js`
  - hypothesis: existing Codex thread resume の owner-facing status が未検証のため、restart 復帰の土台が regression に弱いです。
  - risk if changed narrowly: tests が final reply の順序だけを見て、lifecycle truth の追加を検知できません。
  - validation: lifecycle event formatter と resume turn path の assertions を追加します。
  - related Issue: Issue #741

## Hypothesis Retrospective

- expected: lifecycle status 追加により、bridge connected / resumed_existing_thread / turn_started が Dashboard thread へ送信されます。
- actual: targeted bridge test で fresh thread と existing Codex thread resume の両方が lifecycle status を返すことを確認しました。
- mismatch: 既存 test の一部が `events.at(-1)` を reply と仮定していたため、status 追加後は reply を type で探す assertion に修正しました。
- lesson: bridge lifecycle truth を追加する場合、event ordering ではなく event type / status を検証対象にする必要があります。
- should become RAG candidate: はい。deploy/restart recovery は Dashboard Butler 土台 work の優先判断として残す価値があります。

## Verification Evidence

- Unit: `node --test test/dashboard-app-server-bridge.test.js` passed, 48 tests.
- Integration: `git diff --check` passed.
- E2E: 未実施。production deploy 後の app-server bridge restart E2E が必要です。
- Manual: 未実施。
- Evidence path/link: `test/dashboard-app-server-bridge.test.js`

## Butler Completion Contract

- Primary owner surface: Dashboard Butler。
- Fallback surface: Custom GPT は fallback surface として扱います。主経路ではありません。
- Owner goal: deploy 後や app-server bridge restart 後も、repo-less main chat で同じ文脈に復帰できるかを owner が判断できること。
- Butler entrypoint: Dashboard Butler の通常チャット / repo-less main chat 入口。
- Dashboard Butler natural-language path: Dashboard Butler の自然文 / 通常チャット入口で owner が「続き」「状況確認」「deploy 後に復帰したか」を聞いた時に、bridge lifecycle truth へ到達する土台です。
- Action Schema exposure: Custom GPT fallback 用 Action Schema は未変更です。この PR の主経路ではありません。
- Runtime path: Dashboard app-server bridge WebSocket、Codex app-server `thread/resume`、`turn/start`、Dashboard `app_server_status` event。
- Runner/runtime truth: `bridgeLifecycle` に dashboard thread id、Codex thread id、turn id、message id、resume / start status を返します。
- Authority boundary: 未変更。この PR は high-risk authority を追加せず、merge/deploy/restart/credential/permission 操作は行いません。
- E2E evidence: 未実施。production deploy 後に app-server bridge restart E2E が必要です。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: この PR では未実施。merge 後に deploy が必要です。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。merge/deploy 後に repo-less main chat で確認します。

## Related Constitution Rules

- Butler Completion Gate: runtime truth と E2E evidence が揃うまで完了扱いにしません。
- Drift Stop Protocol: Issue #741 の bounded change contract と作戦図を先に作りました。
- Authority Boundary: deploy / restart / credential / permission / destructive work は passkey approval なしに実行しません。
- Change Size and PR Discipline: fresh branch from `origin/main`、one bounded Issue slice、open PR #740 / #739 / #737 には触りません。

## Out-of-scope but NOT implemented

- app-server bridge systemd lifecycle guard
- deploy watcher の chat 統合
- sleep/resume の full E2E
- pending owner message replay
- UI 見た目 polish
- Issue #741 close

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #741
- Execution ID: issue-741-bridge-resume-state
- Goal: Dashboard app-server bridge restart/resume state truth
