### PR TITLE
Issue #748: app-server bridge の mapping write burst を止める

### DIFF
--- a/docs/development-strategy/issue-748-cost-aware-bridge.md
+++ b/docs/development-strategy/issue-748-cost-aware-bridge.md
@@ -1,0 +1,85 @@
+# Issue #748 cost-aware Butler bridge strategy
+
+## 完了体験
+
+Owner が iPhone/iPad で Dashboard Butler を再開しても、app-server bridge の delta / status / progress burst が Cloudflare Durable Objects rows_written を増やし続けない。Butler は短い presence update を速く返すが、復旧に必要な owner message、final reply、failure、timeout、approval、thread mapping だけを durable に残す。bridge restart は、local regression test と runtime metrics guard を通した後だけ許可する。
+
+## VTDD 全体で進める部分
+
+Issue #748 を emergency root として、DashboardChatRoom の app-server bridge persistence boundary を修正する。Issue #455 の Codex usage 削減と Issue #745 の reviewer fallback retry 抑止は本 PR では audit / evidence に留め、既に main に入っている fallback model guard を再確認する。Issue #613 の voice-ready work は、この cost-aware boundary が先に成立するまで実装しない。
+
+## 設計
+
+`presence != persistence` を runtime 実装に落とす。`codexThreadId` mapping は thread resume に必要なので保存するが、同じ `threadId -> codexThreadId` を transient event ごとに再保存しない。Dashboard UI へは WebSocket transient status を流す。chat store / Durable Object storage へは final / failure / timeout / selected durable checkpoint だけを送る。
+
+## 仮説
+
+RowsWritten 急増の直接原因は `DashboardChatRoom.acceptAppServerBridgeMessage()` が `normalized.codexThreadId` を含むすべての bridge event で `writeAppServerThreadMapping()` を呼び、`writeAppServerThreadMapping()` が同一値でも `ctx.storage.put()` していたこと。bridge は delta / status / progress の多くに `codexThreadId` を付けるため、同じ mapping でも高頻度 write が発生した。
+
+狭く `codexThreadId` を bridge 側から消すだけだと、resume / timeout / final reply の復旧情報を壊す可能性がある。Worker 側で同値 no-op を保証し、必要なら bridge 側で送信頻度を後続で減らす方が安全。
+
+## 検証計画
+
+- Unit: 同一 `codexThreadId` の delta / status burst が `ctx.storage.put()` を初回以外発生させない。
+- Unit: 新しい `codexThreadId` に変わった場合だけ mapping を更新する。
+- Unit: final reply / timeout / failure は引き続き復旧可能な thread message を残す。
+- Local targeted: `node --test test/worker.test.js test/dashboard-app-server-bridge.test.js test/codex-review-fallback.test.js`
+- Worker build/verify: `npm run build:worker` と `npm run verify:worker`
+- Runtime: deploy/restart 後に Cloudflare metrics で `DashboardChatRoom` rowsWritten が burst しないことを確認する。Deploy / restart は owner approval boundary を満たした後だけ行う。
+
+## 改修見積もり
+
+- `src/worker/runtime.js`: `writeAppServerThreadMapping()` に existing mapping read と同値 no-op を追加する。risk: storage get が増えるが put を抑制し、DO write quota を守る。
+- `test/worker.test.js`: mock storage に put count を追加し、delta/status burst regression を追加する。risk: 既存テストの mapping expectation を更新する必要がある。
+- `scripts/run-dashboard-app-server-bridge.mjs`: 今回は基本変更しない。risk: bridge 側の `codexThreadId` 送信は残るが worker no-op が主防御になる。
+- `worker.js`: build output。runtime source 変更後に `npm run build:worker` で更新する。
+
+## 既に通っている経路
+
+- Owner message は DashboardChatRoom で保存され、app-server bridge へ turn request を送れる。
+- App-server final reply は chat store に `butler` message として保存される。
+- Reply delta / generic progress は chat message としては永続化しない既存テストがある。
+- Codex fallback reviewer は main で `gpt-5.4-mini` default と `--model` 明示に変わっている。
+
+## 未確認の境界
+
+- Cloudflare GraphQL metrics の post-fix live rowsWritten は deploy/restart 後にしか確認できない。
+- VPS bridge restart は service 操作であり、未修正 production に対して行うと再発し得る。
+- Deploy / permission / credential mutation はこの PR の local implementation だけでは実施しない。
+
+## 穴が出そうな箇所
+
+- `app_server_status` の durable progress opt-in が将来増えると chat store 側の write が増える可能性。
+- Owner-action notification / push dispatch が approval request burst と結びつくと別 quota を消費する可能性。
+- VPS runner の reviewer fallback retry loop は Cloudflare ではなく Codex usage を消費するため、#455/#745 側で継続 audit が必要。
+
+## PR 前に確認すること
+
+- `git status --short --branch`
+- local targeted tests
+- `npm run build:worker`
+- `npm run verify:worker`
+- PR body に Execution Queue Delta と #748 emergency preemption を記録する。
+
+## 実装候補と捨てた案
+
+- 採用: Worker mapping write を同値 no-op にする。
+- 採用: regression test で `ctx.storage.put()` 回数を数える。
+- 捨てた案: bridge から transient event の `codexThreadId` を完全に外す。理由は resume/final/timeout recovery の境界を壊すリスクがあるため。
+- 捨てた案: Cloudflare paid plan で回避する。理由は root cause を残すため。
+
+## merge 後に通す E2E
+
+- Production deploy 後、VPS bridge を再有効化する前に Cloudflare metrics baseline を読む。
+- bridge restart 後、短い Dashboard Butler turn を1回流し、rowsWritten が burst しないことを確認する。
+- Dashboard thread に final reply が残り、delta/status が transient UI として見えることを確認する。
+
+## 次の PR を増やさない理由
+
+本 PR は root cause の最小修正と regression test に絞る。Codex usage routing / reviewer fallback dedupe / voice UX は関連するが、別 quota / 別 authority / 別 completion gate なので、この PR では audit と関連 Issue 参照に留める。
+
+## 停止条件
+
+- Mapping no-op test が書けない、または同値 mapping でも storage put が必要な仕様衝突が出る。
+- `npm run build:worker` または `npm run verify:worker` が unrelated failure ではなく本修正に起因して失敗する。
+- Deploy / bridge restart / Cloudflare metrics read に credential or passkey boundary が必要になり、owner approval が未取得。

--- a/docs/ops/vtdd-cost-audit-2026-06-03.md
+++ b/docs/ops/vtdd-cost-audit-2026-06-03.md
@@ -1,0 +1,59 @@
+# VTDD cost audit 2026-06-03
+
+Related Issues: #748, #455, #745, #613
+
+## Purpose
+
+Capture the cost and quota lessons from the 2026-06-02 Dashboard Butler incident before app-server bridge work resumes. This is an audit note, not completion evidence.
+
+## Immediate Root Cause
+
+`DashboardChatRoom` accepted high-frequency app-server bridge events and rewrote the same Durable Object storage mapping every time `codexThreadId` appeared. App-server delta, status, progress, plan, diff, command, tool, and reasoning notifications can all carry the same `codexThreadId`, so `ctx.storage.put()` was coupled to transient presence.
+
+The fix in this slice makes the `app_server_thread:<threadId>` mapping write idempotent: if the stored `codexThreadId` already matches the incoming one, the Worker does not write again.
+
+## Cost-Aware Runtime Rules
+
+- Presence is ephemeral by default.
+- Durable writes are for recovery facts: owner messages, final Butler replies, failures, timeouts, approvals, evidence, and changed thread mappings.
+- Delta/status/progress bursts must not write Durable Object storage, D1, R2, GitHub comments, or Push notifications by default.
+- A repeated runtime fact with the same key and value must be a no-op unless a version, status, or recovery boundary changed.
+- Any path that starts Codex CLI, Gemini, a reviewer, deploy, push, or notification delivery must have an owner-facing reason and a non-retryable failure marker.
+
+## Audit Findings
+
+| Area | Risk | Current evidence | Follow-up |
+| --- | --- | --- | --- |
+| DashboardChatRoom app-server mapping | High Cloudflare DO `rows_written` if same mapping is rewritten on every transient event | Fixed in this slice with a storage `put` count regression test | Keep as #748 completion evidence |
+| App-server bridge `persistProgress: true` event mapping | Medium future D1/chat-store risk if generic progress is persisted broadly | Existing Worker tests keep generic progress transient-only; durable stages are narrow | Keep future progress persistence behind explicit stage allowlist |
+| App-server bridge delta/status WebSocket flow | Medium latency/noise risk, low durable write risk after this fix | Deltas are not chat messages; now unchanged mapping is not rewritten | Consider client-side throttling/coalescing under #450/#613 |
+| VPS Codex reviewer fallback | High Codex usage risk if unsupported model or auth failure repeats | Main already has `gpt-5.4-mini` default, `--model`, and blocked marker tests for unsupported model | #745 should verify live VPS config and actor identity so blocked comments can be posted once per head SHA |
+| VPS runner timer | Medium GitHub/API and possible Codex usage risk if pending fallback requests never become terminal | Timer is active; bridge is inactive; prior logs showed repeated fallback completions / actor identity incidents | #455 should add queue throttle / non-retryable failure visibility |
+| GitHub issue/PR comments as progress | Medium GitHub noise and runner reprocessing risk | Remote executor docs say progress-poll comments should be milestone-limited | Keep progress comments milestone-only: picked up, branch pushed, PR created/updated, blocked, completed |
+| D1 chat/media/RAG stores | Medium cost/noise risk if full transcripts or raw media are stored | Repo rules already prohibit full transcript RAG by default; media docs use R2 for binary and D1 metadata | #415/#498 should keep pre-write filtering and metadata-only persistence |
+| Push notifications | Medium notification fatigue and delivery cost/noise risk | Worker tests require owner-action and push auth boundaries | #514/#670 should rate-limit non-critical push and expose send-result truth |
+
+## Bridge Restart Gate
+
+Do not restart `vtdd-dashboard-app-server-bridge-unresolved.service` until all are true:
+
+1. This fix is merged and deployed to the Worker that owns `DashboardChatRoom`.
+2. Local tests include a passing storage write-count regression.
+3. Cloudflare metrics baseline is captured before restart.
+4. Bridge is restarted once, not enabled as `Restart=always` before the first smoke check.
+5. One short Dashboard Butler turn is run and Cloudflare rowsWritten is checked again.
+6. If rowsWritten bursts, stop and disable the bridge immediately.
+
+## Verification Captured In This Slice
+
+- `node --test test/worker.test.js`
+- `node --test test/dashboard-app-server-bridge.test.js test/codex-review-fallback.test.js`
+- `npm run build:worker`
+- `npm run verify:worker`
+
+## Non-Goals
+
+- Do not remove Gemini or Codex fallback reviewer.
+- Do not make Cloudflare paid plan the root fix.
+- Do not start voice implementation before the presence/persistence boundary is proven.
+- Do not restart or enable the production bridge before deploy and metrics evidence.

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -664,7 +664,18 @@ export class DashboardChatRoom {
     if (!codexThreadId) {
       return false;
     }
-    await this.ctx.storage.put(`app_server_thread:${normalizedThreadId}`, {
+    const key = `app_server_thread:${normalizedThreadId}`;
+    if (typeof this.ctx?.storage?.get === "function") {
+      try {
+        const existing = normalizeObject(await this.ctx.storage.get(key));
+        if (normalizeDashboardEventText(existing.codexThreadId || existing.codex_thread_id) === codexThreadId) {
+          return false;
+        }
+      } catch {
+        // If the existing mapping cannot be read, keep the recoverable write path.
+      }
+    }
+    await this.ctx.storage.put(key, {
       codexThreadId,
       updatedAt: normalizeIsoTimestamp(mapping?.updatedAt) || new Date().toISOString()
     });

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -694,12 +694,15 @@ function createMockDashboardChatRoomNamespace() {
 
 function createMockDurableObjectStorage() {
   const values = new Map();
+  const putCalls = [];
   return {
     values,
+    putCalls,
     async get(key) {
       return values.get(key);
     },
     async put(key, value) {
+      putCalls.push({ key, value });
       values.set(key, value);
     }
   };
@@ -4161,6 +4164,75 @@ test("DashboardChatRoom does not persist app-server reply deltas as chat message
   assert.equal(stored[0].role, "butler");
   assert.equal(stored[0].status, "replied");
   assert.equal(stored[0].text, "日本時間では、今日は 05月22日 20時09分です。");
+});
+
+test("DashboardChatRoom does not rewrite unchanged app-server thread mapping during transient bursts", async () => {
+  const store = createInMemoryDashboardChatStore();
+  const dashboardSocket = createMockSocket("dashboard", "dashboard-main-unresolved");
+  const bridgeSocket = createMockSocket("app_server_bridge", "dashboard-main-unresolved");
+  const storage = createMockDurableObjectStorage();
+  const room = new DashboardChatRoom(
+    {
+      storage,
+      getWebSockets() {
+        return [dashboardSocket, bridgeSocket];
+      }
+    },
+    { DASHBOARD_CHAT_STORE: store }
+  );
+  const transientEvents = [
+    {
+      type: "app_server_reply_delta",
+      threadId: "dashboard-main-unresolved",
+      codexThreadId: "codex-thread-450",
+      delta: "調"
+    },
+    {
+      type: "app_server_status",
+      status: "thinking",
+      stage: "planning",
+      threadId: "dashboard-main-unresolved",
+      codexThreadId: "codex-thread-450",
+      text: "方針を整理しています。"
+    },
+    {
+      type: "app_server_reply_delta",
+      threadId: "dashboard-main-unresolved",
+      codexThreadId: "codex-thread-450",
+      delta: "査"
+    },
+    {
+      type: "app_server_status",
+      status: "thinking",
+      stage: "command",
+      threadId: "dashboard-main-unresolved",
+      codexThreadId: "codex-thread-450",
+      text: "コマンドを実行しています。"
+    }
+  ];
+
+  for (const event of transientEvents) {
+    await room.webSocketMessage(bridgeSocket, JSON.stringify(event));
+  }
+
+  assert.equal(storage.values.get("app_server_thread:dashboard-main-unresolved").codexThreadId, "codex-thread-450");
+  assert.equal(storage.putCalls.filter((call) => call.key === "app_server_thread:dashboard-main-unresolved").length, 1);
+  assert.equal((await store.listThread("dashboard-main-unresolved")).length, 0);
+  assert.equal(dashboardSocket.sent.map((message) => JSON.parse(message)).filter((message) => message.type === "transient_status").length, 4);
+
+  await room.webSocketMessage(
+    bridgeSocket,
+    JSON.stringify({
+      type: "app_server_status",
+      status: "thinking",
+      threadId: "dashboard-main-unresolved",
+      codexThreadId: "codex-thread-451",
+      text: "新しい Codex thread で再開しています。"
+    })
+  );
+
+  assert.equal(storage.values.get("app_server_thread:dashboard-main-unresolved").codexThreadId, "codex-thread-451");
+  assert.equal(storage.putCalls.filter((call) => call.key === "app_server_thread:dashboard-main-unresolved").length, 2);
 });
 
 test("DashboardChatRoom persists app-server timeout as recoverable Japanese thread message", async () => {

--- a/worker.js
+++ b/worker.js
@@ -58026,7 +58026,17 @@ var DashboardChatRoom = class {
     if (!codexThreadId) {
       return false;
     }
-    await this.ctx.storage.put(`app_server_thread:${normalizedThreadId}`, {
+    const key = `app_server_thread:${normalizedThreadId}`;
+    if (typeof this.ctx?.storage?.get === "function") {
+      try {
+        const existing = normalizeObject12(await this.ctx.storage.get(key));
+        if (normalizeDashboardEventText(existing.codexThreadId || existing.codex_thread_id) === codexThreadId) {
+          return false;
+        }
+      } catch {
+      }
+    }
+    await this.ctx.storage.put(key, {
       codexThreadId,
       updatedAt: normalizeIsoTimestamp(mapping?.updatedAt) || (/* @__PURE__ */ new Date()).toISOString()
     });


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #748 の emergency root 対応として、Dashboard Butler app-server bridge の transient event burst が同じ Durable Object thread mapping を何度も書き直す経路を止めます。
- Owner を待たせない delta / status / progress は WebSocket transient として残し、復旧に必要な mapping だけを durable に保存する `presence != persistence` 境界を runtime 実装と regression test に落とします。
- 今日の Cloudflare / Codex usage 教訓を `docs/ops/vtdd-cost-audit-2026-06-03.md` に残し、VTDD の機能を殺さずに冗長な write / retry / notification 経路を洗い出します。

## Satisfied Success Criteria

- `DashboardChatRoom.writeAppServerThreadMapping()` が既存 `codexThreadId` と同一値の場合は `ctx.storage.put()` を実行しないようになりました。
- 同じ `codexThreadId` を含む delta / status burst では mapping write が初回1回だけになり、新しい `codexThreadId` に変わった場合だけ更新される regression test を追加しました。
- `npm run verify:worker` で worker build、全 Node tests、runtime self-parity、generated worker check が通っています。
- Cloudflare rows_written / Codex usage / reviewer fallback / progress comment / push / RAG の cost-aware audit を repo-backed docs として追加しました。

## Unsatisfied Success Criteria

- Production Worker への deploy は、このPRでは実施していません。
- app-server bridge の production restart / enable は、このPRでは実施していません。
- Cloudflare live metrics で restart 後の rowsWritten 非 burst は、このPRでは未検証です。
- Issue #748 の close-ready 判断には、merge、deploy、bridge restart、Cloudflare metrics before/after、Dashboard Butler live smoke が残っています。

## Non-goal violations

None.

## 開発前作戦図

- 作戦図 evidence: `docs/development-strategy/issue-748-cost-aware-bridge.md`
- 完了体験: Owner が iPhone/iPad で Dashboard Butler を再開しても、app-server bridge の delta / status / progress burst が Cloudflare Durable Objects rows_written を増やし続けない。bridge restart は local regression test と runtime metrics guard を通した後だけ許可する。
- VTDD 全体で進める部分: Issue #748 を emergency root として、DashboardChatRoom の app-server bridge persistence boundary を修正する。Issue #455/#745 は audit と関連確認に留め、Issue #613 の voice-ready work は cost-aware boundary が先に成立するまで実装しない。
- 設計: `presence != persistence` を runtime 実装に落とす。WebSocket transient status は速く返し、owner message / final reply / failure / timeout / approval / changed mapping だけを durable に残す。
- 仮説: `acceptAppServerBridgeMessage()` が `codexThreadId` を含む全 bridge event で mapping write を呼び、同一値でも `ctx.storage.put()` していたことが rowsWritten 急増の直接原因。
- 検証計画: 同一 mapping burst の put count test、新 mapping 更新 test、既存 final/timeout/failure persistence test、targeted tests、`npm run build:worker`、`npm run verify:worker`、merge/deploy 後の Cloudflare metrics before/after。
- 改修見積もり: `src/worker/runtime.js` の `writeAppServerThreadMapping()`、`test/worker.test.js` の Durable Object storage mock と regression test、`worker.js` の generated output、strategy/audit docs。
- 既に通っている経路: Owner message 保存、app-server bridge turn dispatch、final reply の chat store 保存、delta/progress transient-only 既存テスト、Codex fallback reviewer の `gpt-5.4-mini` default guard。
- 未確認の境界: Production deploy 後の Cloudflare GraphQL metrics、VPS bridge restart 後の live rowsWritten、deployment / service operation の approval boundary。
- 穴が出そうな箇所: 将来の `persistProgress: true` 拡張、approval push burst、VPS runner fallback retry loop、GitHub progress comment の過剰投稿、D1/R2/RAG full transcript 化。
- PR 前に確認すること: `git status --short --branch`、targeted tests、`npm run build:worker`、`npm run verify:worker`、PR body の Execution Queue Delta と incomplete status。
- 実装候補と捨てた案: 採用は Worker mapping write の同値 no-op と put count regression。捨てた案は bridge から `codexThreadId` を完全削除する案と Cloudflare paid plan だけで回避する案。
- merge 後に通す E2E: Production deploy 後に metrics baseline を読み、bridge を一度だけ restart し、短い Dashboard Butler live E2E turn を1回流し、rowsWritten が burst しないことと final reply persistence を確認する。
- 次の PR を増やさない理由: 本PRは root cause の最小修正と audit に絞る。Codex usage routing / reviewer fallback dedupe / voice UX は関連するが別 quota / 別 authority / 別 completion gate のため、ここでは未実装として残す。
- 停止条件: Mapping no-op test が成立しない、同値 mapping write が仕様上必要と判明する、verify が本修正起因で失敗する、deploy / bridge restart / metrics read に必要な approval が未取得。

## Dry-run Impact Report

- Target Issue: Issue #748
- Implementing Success Criteria: Durable Object mapping write burst を止め、同一 mapping の再書き込みを regression test で検出可能にし、cost-aware audit を repo-backed evidence に残します。
- Explicit Non-goals: Production deploy、Cloudflare plan 変更、credential / permission mutation、app-server bridge restart / enable、voice UX 実装、Issue close。
- Expected touched files/routes/workflows: `src/worker/runtime.js`, `test/worker.test.js`, `worker.js`, `docs/development-strategy/issue-748-cost-aware-bridge.md`, `docs/ops/vtdd-cost-audit-2026-06-03.md`
- Affected Issues: #748 primary。#455/#745/#613 are referenced as related cost / fallback / voice-boundary follow-up, not implemented.
- Affected PRs: 新規PRのみ。既存PRへの push や close はしません。
- Affected workflows: local `npm run build:worker`, `npm run verify:worker`, future production deploy workflow after approval.
- Affected runtime/operator surfaces: Dashboard Butler Worker Durable Object, app-server bridge WebSocket transient flow, future VPS bridge service restart gate.
- What may break if we patch narrowly: Mapping persistence を消すと resume / timeout / final reply recovery が壊れるため、完全削除ではなく同値 no-op にしています。
- Unknowns to investigate before coding: Live Cloudflare metrics は deploy/restart 後でないと確認できないため、このPRでは local proof と restart gate までに留めます。
- Validation needed: Unit / integration / generated worker verification plus post-merge deploy, metrics baseline, bridge smoke, metrics after check.
- Stop condition: Production deploy または bridge restart に進むには approval boundary と metrics gate が必要です。

## Execution Queue Delta

- Queue position before: Issue #748 は 2026-06-03 の Cloudflare rows_written incident による EMERGENCY / ROOT item です。
- Preemption decision: EMERGENCY preemption。音声/voice UX、通常の active issue 実装、app-server bridge 常時稼働より先に cost-aware persistence boundary を直します。
- Queue delta: Issue #748 を local fix + regression + audit PR まで進めます。deploy/restart/live metrics は未完了 blocker として残します。
- Why this PR is next: app-server bridge を未修正のまま戻すと、owner が Butler を使うほど Cloudflare free tier を再消費するためです。
- Active Issues not downscoped: Active Issues は縮小しません。#455/#745/#613 など関連 Issue は未完了または別 follow-up として残します。

## File / Line Hypotheses

- file: `src/worker/runtime.js`
  - hypothesis: `DashboardChatRoom.writeAppServerThreadMapping()` が同一 `threadId -> codexThreadId` mapping でも毎回 `ctx.storage.put()` している。
  - risk if changed narrowly: mapping persistence を消すと app-server thread resume / timeout / final reply recovery が壊れる。
  - validation: 同一 mapping burst の put count regression と既存 dashboard bridge tests。
  - related Issue: #748
- file: `test/worker.test.js`
  - hypothesis: Durable Object storage mock が put 回数を数えられないため、rows_written regression が見えない。
  - risk if changed narrowly: mock が過剰に実装依存になると既存 storage tests を壊す。
  - validation: `node --test test/worker.test.js` と `npm run verify:worker`。
  - related Issue: #748
- file: `scripts/run-dashboard-app-server-bridge.mjs`
  - hypothesis: bridge event は `codexThreadId` を高頻度に含めるが、Worker 側同値 no-op で primary cost は抑えられる。
  - risk if changed narrowly: bridge 側で `codexThreadId` を落とすと recovery truth を壊す可能性がある。
  - validation: このPRでは未変更。audit follow-up として client-side coalescing を検討する。
  - related Issue: #748/#613

## Hypothesis Retrospective

- expected: 同じ `codexThreadId` の delta / status burst では mapping write が1回だけになり、新しい thread mapping の場合だけ write される。
- actual: 追加テスト `DashboardChatRoom does not rewrite unchanged app-server thread mapping during transient bursts` で、4件の transient event が mapping put 1回、thread change 後に put 2回目であることを確認しました。
- mismatch: Bridge 側の event payload は温存しています。root cause は Worker persistence boundary で止める方が recovery を壊さないと判断しました。
- lesson: 待たせない UI と durable persistence は別設計にする。presence を保存で実現すると Cloudflare quota と latency の両方を傷つける。
- should become RAG candidate: 既存の incident RAG checkpoint に加え、このPR merge 後に #748 evidence として再保存候補です。

## Verification Evidence

- Unit: `node --test test/worker.test.js` passed。追加 regression test を含む。
- Integration: `node --test test/dashboard-app-server-bridge.test.js test/codex-review-fallback.test.js` passed。
- E2E: Production deploy / bridge restart / Cloudflare metrics after check は未実施。このPRでは local worker verification まで。
- Manual: VPS status read では `vtdd-dashboard-app-server-bridge-unresolved.service` は disabled/inactive、`vtdd-vps-runner.timer` は active。bridge restart は実施していません。
- Evidence path/link: `docs/development-strategy/issue-748-cost-aware-bridge.md`, `docs/ops/vtdd-cost-audit-2026-06-03.md`, `test/worker.test.js`, `src/worker/runtime.js`

## Butler Completion Contract

- Primary owner surface: Dashboard Butler。
- Fallback surface: Custom GPT は fallback surface としてのみ扱います。主経路ではありません。
- Owner goal: Dashboard Butler を iPhone/iPad から使っても、返答 delta / status / turn event によって Cloudflare Durable Objects rows_written を無駄に消費し続けないこと。
- Butler entrypoint: Dashboard Butler 通常チャット。owner が内部 API path や raw JSON を入力する前提は追加していません。
- Dashboard Butler natural-language path: Dashboard Butler の自然文 / 通常チャットで app-server bridge 経由の turn を動かす既存経路を前提に、transient presence は表示しつつ同一 mapping write を抑制します。
- Action Schema exposure: Custom GPT Action Schema はこのPRでは未変更です。primary owner path ではなく fallback / setup surface として扱います。
- Runtime path: `DashboardChatRoom.acceptAppServerBridgeMessage()` -> `writeAppServerThreadMapping()` -> Durable Object storage mapping。production deploy 後に Worker runtime path へ反映されます。
- Runner/runtime truth: Local tests and generated worker verification passed。Production Worker deploy and bridge restart truth are not yet captured.
- Authority boundary: Production deploy、Cloudflare metric operation、VPS bridge restart/enable はこのPRでは実施しません。必要な approval / passkey boundary を満たしてから行います。
- E2E evidence: このPRでは未接続。merge/deploy 後に Dashboard Butler live smoke と Cloudflare rowsWritten before/after evidence が必要です。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 必要。ただしこのPRでは未実施。merge 後に approval boundary と metrics gate を満たしてから実施。
- Custom GPT Action Schema update: 不要。このPRは Worker persistence boundary の修正です。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 必要。ただし production deploy / bridge restart 後に実施。

## Related Constitution Rules

- Butler Completion Gate: Butler-facing workflow は production deploy / live metrics / E2E が残るため complete と主張しない。
- Butler-First Operating Principle: mac Codex local fix は bootstrap/debug であり、Dashboard Butler の iPhone/iPad path completion には deploy/restart evidence が必要。
- RAG Memory Capture and Cost Boundary: full transcript や transient burst を保存せず、future judgment に必要な structured lesson だけ残す。
- Authority Boundary: deploy / service restart / credential or permission mutation は scoped approval boundary を越えて実行しない。
- Evidence Discipline: local tests と runtime truth を分け、未実施の live evidence を未実施と書く。

## Out-of-scope but NOT implemented

- Cloudflare paid plan upgrade。
- app-server bridge production restart / enable。
- Gemini / Codex fallback reviewer の routing 変更。
- Voice UX / 常時ON Butler / microphone pipeline。
- Issue close / merge / post-merge cleanup。

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #748
- Execution ID: 2026-06-03-cost-aware-bridge
- Goal: Dashboard Butler app-server bridge の Durable Object write burst を止め、cost-aware audit を残す。
