### PR TITLE
Issue #455 Codex fallback usage guard

### DIFF
--- a/docs/development-strategy/issue-455-codex-usage-guard.md
+++ b/docs/development-strategy/issue-455-codex-usage-guard.md
@@ -1,0 +1,63 @@
+# Issue #455 Codex usage guard strategy
+
+## 完了体験
+
+Butler / VPS runner が reviewer fallback を扱う時、同じ PR head に対する完了済みまたは blocked 済みの Codex fallback を再実行しない。owner は PR/runner status から、Codex CLI を起動する予定か、起動しない理由か、重複抑止 key を確認できる。
+
+## VTDD 全体で進める部分
+
+Issue #455 の Codex 使用量削減と Issue #745 の unsupported model fallback 抑止を、VPS runner の reviewer fallback pickup 前 guard として進める。Issue #717 の wakeup primary は今回実装しないが、wakeup が入っても無駄な `codex exec` を速く繰り返さない前提を作る。
+
+## 設計
+
+VPS runner は Codex fallback requested marker を拾う前に、同じ PR / same head の reviewer terminal state を読む。`completed` と `blocked` は request consumption として terminal に扱い、`approve` だけを merge-ready approval として扱う。pending fallback には `dedupeKey`, `codexWillStart`, `codexUsageImpact` を付け、将来の Butler runtime truth で使えるようにする。
+
+## 仮説
+
+既存の `isReviewerTerminalResolved()` は blocked/completed を terminal として扱えるが、`selectPendingVpsReviewerFallbacks()` が `comment.headSha` に依存しているため、GitHub issue comment body には `- Head SHA:` があるのに API 補完 headSha がない場合に head matching が弱くなる。requested marker 自身の parsed headSha を使えば、unsupported model / auth failure / blocked marker 後の重複 Codex 起動をより確実に止められる。
+
+## 検証計画
+
+- Unit: requested/comment/completed/blocked が `comment.headSha` を持たず、body の `- Head SHA:` だけを持つ場合でも再処理しない。
+- Unit: new head SHA の requested は、old head の completed/blocked に妨げられない。
+- Unit: pending fallback に `dedupeKey`, `codexWillStart=true`, `codexUsageImpact=high` が出る。
+- Local: `node --test test/vps-runner-script.test.js test/codex-review-fallback.test.js` を実行する。
+
+## 改修見積もり
+
+- `scripts/run-vps-runner.mjs`: `selectPendingVpsReviewerFallbacks()` で parsed headSha を使う。pending runtime truth に usage fields を追加する。risk は fallback reviewer pickup の選択条件に触れるため、テストで同一 head / new head を固定する。
+- `test/vps-runner-script.test.js`: body headSha only の regression test と usage field assertion を追加する。
+
+## 既に通っている経路
+
+`scripts/run-codex-pr-review-fallback.mjs` は `--model gpt-5.4-mini` を明示し、unsupported model を blocked marker に分類できる。`isReviewerTerminalResolved()` は Codex fallback `completed` / `blocked` を resolved として扱う。
+
+## 未確認の境界
+
+Codex Analytics の実使用量 API はこの PR では読まない。VPS 本番での live retry loop 消失は post-merge / deploy / runner sync 後の実証が必要。
+
+## 穴が出そうな箇所
+
+trusted reviewer 判定外の actor が blocked marker を投稿した場合は terminal として扱わない。これは安全側だが、actor identity failure 時は dedicated incident marker で止める。
+
+## PR 前に確認すること
+
+対象 branch が latest `origin/main` から切られていること、PR #749 の #748 hotfix と混ぜないこと、fallback reviewer tests が通ること。
+
+## 実装候補と捨てた案
+
+採用: runner pickup 前に same-head terminal/blocked を body headSha fallback で検出する。
+
+捨てた案: OpenAI API runner に切り替える。これは owner 方針と Issue #455 Non-goal に反する。捨てた案: Gemini reviewer を止める。これは reviewer gate を弱める。
+
+## merge 後に通す E2E
+
+VPS を `origin/main` に同期後、同一 PR head に requested + blocked fallback marker がある状態で runner を起動し、`codex exec` が起動せず pending fallback count が 0 になることを確認する。
+
+## 次の PR を増やさない理由
+
+この PR は runner pickup guard と usage truth の最小 slice に絞る。wakeup primary、bridge restart、inline stop UI は別 Issue の実装単位であり混ぜない。
+
+## 停止条件
+
+runner selection が必要な fallback まで落とす、trusted reviewer 判定を弱める、credential / deploy / permission mutation が必要になる、または PR #749 の Cloudflare hotfix と混ざり始めた場合は停止する。

--- a/scripts/run-vps-runner.mjs
+++ b/scripts/run-vps-runner.mjs
@@ -751,7 +751,10 @@ async function collectVpsRunnerPendingSnapshot({ githubFetch, repositoryPolicies
     pendingReviewerFallbacks: reviewerFallbacks.map((item) => ({
       repository: item.repository,
       pullRequestNumber: item.pullRequestNumber,
-      fallbackCommentId: item.commentId
+      fallbackCommentId: item.commentId,
+      dedupeKey: item.dedupeKey,
+      codexWillStart: item.codexWillStart === true,
+      codexUsageImpact: item.codexUsageImpact || "unknown"
     }))
   };
 }
@@ -912,6 +915,7 @@ function selectPendingVpsReviewerFallbacks({ comments, allowedRepositories, repo
       if (!policies.some((policy) => policy.repository === repository)) {
         return null;
       }
+      const headSha = normalizeText(parsed.headSha || comment.headSha);
       const samePullRequestComments = comments.filter(
         (candidate) =>
           normalizeRepository(candidate.repository) === repository &&
@@ -921,7 +925,7 @@ function selectPendingVpsReviewerFallbacks({ comments, allowedRepositories, repo
         isReviewerTerminalResolved({
           comments: samePullRequestComments,
           after: comment.created_at,
-          headSha: normalizeText(comment.headSha)
+          headSha
         })
       ) {
         return null;
@@ -930,11 +934,17 @@ function selectPendingVpsReviewerFallbacks({ comments, allowedRepositories, repo
         hasVpsReviewerFallbackActorIdentityIncident({
           comments: samePullRequestComments,
           after: comment.created_at,
-          headSha: normalizeText(comment.headSha)
+          headSha
         })
       ) {
         return null;
       }
+      const dedupeKey = [
+        "codex-fallback",
+        repository,
+        `pr-${pullRequestNumber}`,
+        headSha || "head-unknown"
+      ].join(":");
       return {
         repository,
         pullRequestNumber,
@@ -943,7 +953,10 @@ function selectPendingVpsReviewerFallbacks({ comments, allowedRepositories, repo
         createdAt: comment.created_at,
         commentId: comment.id,
         commentUrl: comment.html_url,
-        headSha: normalizeText(comment.headSha)
+        headSha,
+        dedupeKey,
+        codexWillStart: true,
+        codexUsageImpact: "high"
       };
     })
     .filter(Boolean);

--- a/test/vps-runner-script.test.js
+++ b/test/vps-runner-script.test.js
@@ -1381,6 +1381,9 @@ test("VPS runner selects pending Codex reviewer fallback comments after developm
   assert.equal(selected[0].repository, "sample-org/vtdd-v2");
   assert.equal(selected[0].pullRequestNumber, 22);
   assert.equal(selected[0].trigger, "pull_request_target:synchronize");
+  assert.equal(selected[0].dedupeKey, "codex-fallback:sample-org/vtdd-v2:pr-22:head-unknown");
+  assert.equal(selected[0].codexWillStart, true);
+  assert.equal(selected[0].codexUsageImpact, "high");
 });
 
 test("VPS runner does not reprocess Codex fallback requested comments after reviewer approve", () => {
@@ -1525,6 +1528,54 @@ test("VPS runner does not reprocess Codex fallback requested comments after revi
           "- Delivery mode: `vps_codex_cli`",
           "- Head SHA: `abc123`",
           "- Blocker: `actor_identity_failure`"
+        ].join("\n")
+      }
+    ]
+  });
+
+  assert.equal(selected.length, 0);
+});
+
+test("VPS runner uses fallback reviewer body head SHA when API headSha is missing", () => {
+  const selected = selectPendingVpsReviewerFallbacks({
+    repositoryPolicies: normalizeRepositoryPolicies({
+      allowedRepositories: ["sample-org/vtdd-v2"]
+    }),
+    comments: [
+      {
+        id: 1,
+        html_url: "https://github.com/sample-org/vtdd-v2/pull/22#issuecomment-1",
+        created_at: "2026-06-03T01:00:00Z",
+        repository: "sample-org/vtdd-v2",
+        pullRequestNumber: 22,
+        body: [
+          "<!-- vtdd:reviewer=codex-fallback -->",
+          "## VTDD Codex fallback レビュー",
+          "",
+          "- Status: `requested`",
+          "- Trigger: `pull_request_target:synchronize`",
+          "- Reason: `gemini_temporarily_unavailable`",
+          "- Delivery mode: `vps_codex_cli`",
+          "- Head SHA: `same-head-455`"
+        ].join("\n")
+      },
+      {
+        id: 2,
+        html_url: "https://github.com/sample-org/vtdd-v2/pull/22#issuecomment-2",
+        created_at: "2026-06-03T01:01:00Z",
+        user: { login: "vtdd-codex-fallback-reviewer[bot]" },
+        repository: "sample-org/vtdd-v2",
+        pullRequestNumber: 22,
+        body: [
+          "<!-- vtdd:reviewer=codex-fallback -->",
+          "## VTDD Codex fallback レビュー",
+          "",
+          "- Status: `blocked`",
+          "- Trigger: `pull_request_target:synchronize`",
+          "- Reason: `gemini_temporarily_unavailable`",
+          "- Delivery mode: `vps_codex_cli`",
+          "- Head SHA: `same-head-455`",
+          "- Blocker: `openai_codex_chatgpt_account_model_unsupported`"
         ].join("\n")
       }
     ]


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #455 の Codex 使用量削減として、VPS runner が同一 PR head の Codex fallback requested marker を重複 pickup し、無駄に `codex exec` を起動する余地を狭めます。
- Issue #745 の unsupported model 事故に対し、blocked fallback marker が同じ head に残っている場合は runner selection 段階で再実行しないようにします。

## Satisfied Success Criteria

- 同じ PR head に `completed` または `blocked` Codex fallback marker がある場合、requested marker を pending fallback として再選択しません。
- API 補完の `comment.headSha` がない GitHub comment 形でも、comment body の `- Head SHA:` を使って same-head 判定します。
- pending fallback runtime truth に `dedupeKey`, `codexWillStart`, `codexUsageImpact` を追加し、重い Codex 起動予定を見える化します。

## Unsatisfied Success Criteria

- Codex Analytics の実使用量集計は未実装です。
- status/read/preflight すべての fast path 可視化は未完了です。
- wakeup primary / timer fallback / SHA sync gate は Issue #717 側に残ります。
- app-server bridge restart / lifecycle は Issue #741 側に残ります。

## Non-goal violations

None.

## 開発前作戦図

- 作戦図 evidence: docs/development-strategy/issue-455-codex-usage-guard.md
- 完了体験: Butler / VPS runner が reviewer fallback を扱う時、同じ PR head の完了済みまたは blocked 済み fallback を再実行せず、owner が usage impact と skip 理由を理解できる状態に近づけます。
- VTDD 全体で進める部分: Issue #455 の Codex 使用量削減と Issue #745 の unsupported model fallback 抑止を、VPS runner の reviewer fallback pickup 前 guard として進めます。
- 設計: Butler-facing owner runtime truth のため、scope を VPS runner fallback pickup 前 guard に限定します。`selectPendingVpsReviewerFallbacks()` が requested marker の parsed `Head SHA` を使い、same-head terminal/blocked reviewer truth を検出します。pending fallback には usage fields を付けます。
- 仮説: 原因は GitHub API が `comment.headSha` を補完しない comment 形でも body には `- Head SHA:` があるのに、runner selection がそれを使い切っていないことです。それを使えば unsupported model blocked marker 後の重複 Codex 起動を防げると予測します。
- 検証計画: `node --test test/vps-runner-script.test.js test/codex-review-fallback.test.js` で same-head blocked/completed と fallback script guard を検証します。
- 改修見積もり: `scripts/run-vps-runner.mjs` の reviewer fallback selection と pending snapshot、`test/vps-runner-script.test.js` の regression、作戦図 doc を変更します。
- 既に通っている経路: fallback script は `--model gpt-5.4-mini` を明示し、unsupported model error を blocked marker に分類できます。
- 未確認の境界: 本番 VPS で live retry loop が止まることは、merge 後に VPS sync して runner dry-run / status で確認が必要です。
- 穴が出そうな箇所: trusted reviewer 判定外の actor の blocked marker は terminal として扱いません。actor identity failure は dedicated incident marker で止めます。
- PR 前に確認すること: PR #749 の Cloudflare rows hotfix と混ぜないこと、targeted tests が通ること、worker runtime を変更していないこと。
- 実装候補と捨てた案: 採用は runner pickup 前 guard。OpenAI API runner への切替、Gemini reviewer 省略、credential 変更は捨てました。
- merge 後に通す E2E: 同一 PR head に requested + blocked fallback marker がある状態で VPS runner が `codex exec` を起動しないことを live E2E / runner status / logs / test evidence で確認します。
- 次の PR を増やさない理由: この PR は usage guard の最小 slice です。wakeup、bridge restart、inline UI は既存 Issue に残し、ここへ混ぜません。
- 停止条件: runner selection が必要な fallback まで落とす、trusted reviewer 判定を弱める、credential / deploy / permission mutation が必要になる場合は停止します。

## Dry-run Impact Report

- Target Issue: Issue #455 / Issue #745
- Implementing Success Criteria: 同一 PR head の重複 fallback reviewer 実行抑止、unsupported model blocked marker 後の non-retryable pickup 抑止、pending fallback usage truth の追加。
- Explicit Non-goals: deploy、credential mutation、permission mutation、app-server bridge restart、wakeup primary 実装、reviewer quality redesign。
- Expected touched files/routes/workflows: `scripts/run-vps-runner.mjs`, `test/vps-runner-script.test.js`, `docs/development-strategy/issue-455-codex-usage-guard.md`。
- Affected Issues: Issue #455, Issue #745, Issue #717。
- Affected PRs: PR #749 は別 hotfix として未変更。
- Affected workflows: VPS runner fallback reviewer pickup。GitHub Actions workflow は未変更。
- Affected runtime/operator surfaces: VPS runner status / pending reviewer fallback truth。
- What may break if we patch narrowly: head SHA のない古い requested marker は `head-unknown` として pending になり得ます。ただし同一 head が分かる marker は再実行を止めます。
- Unknowns to investigate before coding: live VPS logs 上での残 pending fallback 数と Codex Analytics 実測は未確認。
- Validation needed: targeted Node tests、merge 後 VPS sync / runner status。
- Stop condition: fallback reviewer gate を弱める、必要 reviewer を省略する、外部 credential を触る場合。

## Execution Queue Delta

- Queue position before: Issue #748 の Cloudflare rows_written hotfix が先行し、Issue #455/#745 は Codex usage 側の次の止血 slice です。
- Preemption decision: ROOT。Cloudflare quota 事故とは別枠ですが、Butler -> VPS Codex CLI の無駄な Codex 起動は VTDD 継続運用を妨げる root cost blocker です。
- Queue delta: Issue #455 と Issue #745 の reviewer fallback retry guard をこの PR で進めます。Issue #717、Issue #637、Issue #741 は未完了のまま残します。
- Why this PR is next: wakeup primary を入れる前に、無駄な pending fallback を速く再実行する危険を止める必要があります。
- Active Issues not downscoped: Active Issues は縮小しません。この PR で扱わない wakeup、bridge lifecycle、recovery plane、mac Codex parity は未完了として残します。

## File / Line Hypotheses

- file: `scripts/run-vps-runner.mjs`
  - hypothesis: `selectPendingVpsReviewerFallbacks()` が parsed fallback body head SHA を使えば、API補完 headSha がない comment 形でも same-head blocked/completed を検出できる。
  - risk if changed narrowly: pending fallback が不足選択されると reviewer evidence が作られない。既存 new-head test で別 head は再処理可能なまま確認する。
  - validation: `test/vps-runner-script.test.js` の same-head blocked/completed/new-head tests。
  - related Issue: Issue #455 / Issue #745
- file: `test/vps-runner-script.test.js`
  - hypothesis: body `- Head SHA:` only の regression test が今回の failure mode を固定する。
  - risk if changed narrowly: test fixture が実 GitHub comment shape とずれる。repository / PR number / user login を実 shape に寄せる。
  - validation: targeted Node test。
  - related Issue: Issue #455 / Issue #745

## Hypothesis Retrospective

- expected: body headSha fallback により same-head blocked marker 後の pending fallback selection が 0 になる。
- actual: targeted test で `selected.length === 0` を確認しました。
- mismatch: なし。
- lesson: runner pickup guard は API 補完値だけでなく marker body の machine field を authority として使う必要があります。
- should become RAG candidate: はい。Codex usage guard / fallback reviewer duplicate suppression として候補です。

## Verification Evidence

- Unit: `node --test test/vps-runner-script.test.js test/codex-review-fallback.test.js` -> 86 pass, 0 fail。
- Integration: 未実施。VPS live runner sync 後に確認します。
- E2E: 未実施。VPS live fallback retry suppression は merge 後確認です。
- Manual: `git diff --cached --stat` で 3 files の scoped diff を確認しました。
- Evidence path/link: docs/development-strategy/issue-455-codex-usage-guard.md

## Butler Completion Contract

- Primary owner surface: Dashboard Butler。
- Fallback surface: mac Codex は今回の緊急実装 surface。通常運用の completion surface ではありません。
- Owner goal: Butler -> VPS Codex CLI の無駄な Codex クレジット消費を減らす。
- Butler entrypoint: この PR では未変更。runtime truth の材料を runner 側に追加します。
- Dashboard Butler natural-language path: Dashboard Butler の自然文チャット入口は未変更です。将来、Butler が runner status を読む時にこの PR の usage truth を説明材料として使います。
- Action Schema exposure: 未変更。
- Runtime path: VPS runner の `selectPendingVpsReviewerFallbacks()` と pending snapshot。
- Runner/runtime truth: pending fallback に dedupeKey / codexWillStart / codexUsageImpact を追加。
- Authority boundary: deploy、credential、permission、repository administration は扱いません。
- E2E evidence: 未実施。live VPS runner evidence は merge/sync 後に必要です。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 不要。Worker runtime は変更していません。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。

## Related Constitution Rules

- AGENTS.md Drift Stop Protocol
- AGENTS.md 開発前作戦図 Gate
- AGENTS.md Reviewer as Stop Role
- AGENTS.md Evidence Discipline
- docs/butler/execution-queue-contract.md

## Out-of-scope but NOT implemented

- Issue #717 wakeup primary / timer fallback / SHA sync gate。
- Issue #637 recovery plane / helper recovery。
- Issue #741 app-server bridge lifecycle / restart。
- Issue #413 mac Codex parity / stop button / realtime commentary。
- OpenAI API runner への切替。

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #455 / Issue #745
- Execution ID: mac-codex-issue-455-codex-usage-guard
- Goal: codex_usage_guard
