### PR TITLE
Issue #717: VPS runner repo sync gate

### DIFF
--- a/docs/development-strategy/issue-717-vps-sha-sync-gate.md
+++ b/docs/development-strategy/issue-717-vps-sha-sync-gate.md
@@ -1,0 +1,101 @@
+# Issue #717 VPS SHA sync gate 作戦図
+
+## 完了体験
+
+オーナーが Butler から開発を投げても、VPS Codex CLI は GitHub `main` と違う
+VTDD ソースコードで queue を拾わない。VPS の runner repo が `origin/main` と同じ
+SHA なら通常どおり実行し、clean かつ behind-only なら `git pull --ff-only` で同期して
+から実行する。dirty、ahead、diverged、別ブランチ、未知の未追跡ファイルがある場合は
+queue 選択前に停止し、開発作業を開始しない。
+
+## VTDD 全体で進める部分
+
+Issue #717 の runner wakeup / timer fallback 構成の前提として、wakeup でも timer でも
+同じ preflight を通す。今回の PR は VPS runner のローカル canonical repo drift を防ぐ
+最小実装であり、Butler UI の recovery button、passkey action、bridge restart UI は別 Issue
+に残す。
+
+## 設計
+
+VPS runner は GitHub queue や reviewer fallback を読む前に `scripts/run-vps-runner.mjs`
+内で canonical repo preflight を実行する。preflight は `git fetch origin <baseRef>`、
+現在 branch、`HEAD`、`origin/<baseRef>`、ahead/behind、tracked dirty、unknown untracked
+を取得する。安全に同期できるのは current branch が baseRef、tracked dirty なし、ahead
+なし、diverged なし、behind のみのときだけで、その場合だけ `git pull --ff-only origin
+<baseRef>` を実行して再確認する。
+
+## 仮説
+
+今回の根本原因は、VPS 上の runner repo が GitHub `main` とズレても runner が queue を
+拾えてしまうことにある。runner 起動 wrapper が `git pull --ff-only || true` のように失敗を
+握り潰すと、古い `scripts/run-vps-runner.mjs` がそのまま reviewer fallback や execution
+queue を処理し、Codex usage guard や新しい安全境界が効かない。queue 選択前の repo 内
+preflight であれば、wrapper の失敗を握り潰しても runner 自身が停止できる。
+
+## 検証計画
+
+`test/vps-runner-script.test.js` に preflight 単体テストを追加し、次を検証する。
+
+- clean かつ in-sync は pull せず allow
+- clean かつ behind-only は `git pull --ff-only` 後に allow
+- tracked dirty は block
+- ahead または diverged は block
+- `.tmp/` と `test-results/` のみの untracked artifact は block しない
+- unknown untracked は block
+- `runVpsRunnerOnce` は preflight block 時に GitHub queue 読み取りへ進まない
+
+## 改修見積もり
+
+- `scripts/run-vps-runner.mjs`: `runVpsRunnerOnce` の先頭に canonical repo sync gate を追加する。risk は runner が誤って止まることなので、既知 artifact を明示分類し、dry-run も同じ truth を返す。
+- `test/vps-runner-script.test.js`: preflight helper と `runVpsRunnerOnce` の回帰テストを追加する。risk は mock git 応答が実 git と乖離することなので、`git status --porcelain=v1` と `git rev-list --left-right --count` の標準出力に寄せる。
+- `docs/development-strategy/issue-717-vps-sha-sync-gate.md`: 作戦図 evidence。risk は仕様だけ先行することなので、PR body で実装とテストを対応させる。
+
+## 既に通っている経路
+
+VPS runner は GitHub Issue comment queue、privileged maintenance queue、PR reviewer
+fallback を読む前に `runVpsRunnerOnce` を通る。post-merge verification には
+`collectVpsMainSyncStatus` があり、merge 後の `origin/main` 同期確認は既に存在する。
+今回の不足は「通常実行を拾う前」の stop gate。
+
+## 未確認の境界
+
+VPS の systemd wrapper 側がどのコマンドで runner を起動しているかは環境依存だが、
+runner script 内 gate にすることで wrapper 差分に依存しない。Butler から safe sync を押す
+inline action は Issue #528 / #637 に残り、今回の PR では UI を変更しない。
+
+## 穴が出そうな箇所
+
+unknown untracked をすべて許すと main 直接修正の兆候を見落とす。逆に `.tmp/` や
+`test-results/` を block すると現 VPS の検証成果物だけで runner が止まり続ける。今回の
+分類は known artifact を owner-facing truth として返し、未知だけを block する。
+
+## PR 前に確認すること
+
+`node --test test/vps-runner-script.test.js` を実行し、既存 runner queue / reviewer fallback
+テストを壊していないことを確認する。`git diff --check` で whitespace を確認する。
+
+## 実装候補と捨てた案
+
+採用案は runner script 内 preflight + safe behind-only `--ff-only` sync。捨てた案は
+systemd wrapper の `git pull` だけに依存する案、GitHub main を毎回直接読む案、dirty
+状態でも checkout/reset で強制復旧する案。強制復旧は owner の未承認変更を破壊しうるため
+今回の通常経路では扱わない。
+
+## merge 後に通す E2E
+
+VPS で `main` が merge commit と `origin/main` に同期していること、runner timer が active
+であること、pending queue がないことを post-merge verification で確認する。VPS に unknown
+untracked や ahead commit がある場合は Butler/recovery plane で safe sync または emergency
+recovery へ誘導する。
+
+## 次の PR を増やさない理由
+
+drift を止める gate と、その gate のテストは同じ安全境界であり、分けるとテストなしの
+停止条件または停止条件なしのテストが生まれる。UI recovery action や wakeup primary 化は
+別 Issue criteria なのでこの PR には混ぜない。
+
+## 停止条件
+
+preflight が dirty/ahead/diverged/unknown untracked を検出しても runner が queue を拾える
+場合は停止する。clean behind-only 以外で自動同期する必要が出た場合も、権限境界が変わる
+ため実装を止めて owner decision を求める。

--- a/scripts/run-vps-runner.mjs
+++ b/scripts/run-vps-runner.mjs
@@ -31,6 +31,8 @@ const DEFAULT_API_BASE_URL = "https://api.github.com";
 const DEFAULT_HEARTBEAT_SECONDS = 120;
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const REPOSITORY_ROOT = path.dirname(SCRIPT_DIR);
+const DEFAULT_REPO_SYNC_BASE_REF = "main";
+const KNOWN_RUNNER_UNTRACKED_ARTIFACT_PREFIXES = [".tmp/", "test-results/"];
 const VTDD_INCIDENT_ACTOR_IDENTITY_FAILURE_MARKER = "<!-- vtdd:incident=actor_identity_failure -->";
 const ROLE_GITHUB_APP_ENV = {
   codex_fallback_reviewer: {
@@ -108,8 +110,29 @@ async function runVpsRunnerOnce({
   allowedRepositories,
   repositoryPolicies,
   workRoot,
-  dryRun = false
+  dryRun = false,
+  repoSyncPreflight = process.env.VTDD_VPS_RUNNER_REPO_SYNC_PREFLIGHT !== "0",
+  repoRoot = normalizeText(process.env.VTDD_VPS_RUNNER_REPO_ROOT) || REPOSITORY_ROOT,
+  repoSyncBaseRef = normalizeText(process.env.VTDD_VPS_RUNNER_REPO_SYNC_BASE_REF) || DEFAULT_REPO_SYNC_BASE_REF,
+  env = process.env,
+  run = runCommand
 }) {
+  if (repoSyncPreflight) {
+    const repoSync = await ensureVpsRunnerCanonicalRepoSynced({
+      repoRoot,
+      baseRef: repoSyncBaseRef,
+      env,
+      run
+    });
+    if (!repoSync.developmentAllowed) {
+      return {
+        ok: true,
+        message: `VPS runner repository sync preflight blocked queue pickup: ${repoSync.reason}`,
+        repoSync
+      };
+    }
+  }
+
   const policies = normalizeRepositoryPolicies({ allowedRepositories, repositoryPolicies });
   const issueCommentsByRepository = new Map();
   for (const repository of policies.map((policy) => policy.repository)) {
@@ -666,6 +689,196 @@ function buildPostMergePullTruth({ pull, target }) {
     headSha: normalizeText(normalizedPull.head?.sha || target.headSha) || null,
     baseRef: normalizeText(normalizedPull.base?.ref || target.baseRef) || null
   };
+}
+
+async function ensureVpsRunnerCanonicalRepoSynced({
+  repoRoot = REPOSITORY_ROOT,
+  baseRef = DEFAULT_REPO_SYNC_BASE_REF,
+  env = process.env,
+  run = runCommand
+} = {}) {
+  const first = await collectVpsRunnerCanonicalRepoSyncStatus({ repoRoot, baseRef, env, run });
+  if (!first.ok || first.developmentAllowed || first.behindCount <= 0) {
+    return first;
+  }
+  if (!first.safeToFastForward) {
+    return first;
+  }
+
+  try {
+    await run("git", ["pull", "--ff-only", "origin", baseRef], { cwd: repoRoot, env });
+  } catch (error) {
+    return {
+      ...first,
+      developmentAllowed: false,
+      safeToFastForward: false,
+      syncAction: "pull_ff_only_failed",
+      reason: `VPS runner repo is behind origin/${baseRef}, but git pull --ff-only failed: ${
+        summarizeDiagnosticText(error?.stderr || error?.message) || "unknown failure"
+      }`,
+      error: summarizeDiagnosticText(error?.stderr || error?.message)
+    };
+  }
+
+  const second = await collectVpsRunnerCanonicalRepoSyncStatus({
+    repoRoot,
+    baseRef,
+    env,
+    run,
+    skipFetch: true
+  });
+  return {
+    ...second,
+    syncAction: second.developmentAllowed ? "fast_forwarded" : "fast_forwarded_but_still_blocked"
+  };
+}
+
+async function collectVpsRunnerCanonicalRepoSyncStatus({
+  repoRoot = REPOSITORY_ROOT,
+  baseRef = DEFAULT_REPO_SYNC_BASE_REF,
+  env = process.env,
+  run = runCommand,
+  skipFetch = false
+} = {}) {
+  const result = {
+    ok: false,
+    developmentAllowed: false,
+    safeToFastForward: false,
+    syncAction: "none",
+    reason: null,
+    repoRoot,
+    baseRef,
+    currentBranch: null,
+    headSha: null,
+    originHeadSha: null,
+    aheadCount: 0,
+    behindCount: 0,
+    inSyncWithOrigin: false,
+    trackedDirtyPaths: [],
+    unknownUntrackedPaths: [],
+    knownUntrackedArtifacts: [],
+    blockedBy: [],
+    error: null
+  };
+
+  try {
+    if (!skipFetch) {
+      await run("git", ["fetch", "origin", baseRef], { cwd: repoRoot, env });
+    }
+    const [branch, head, originHead, revList, status] = await Promise.all([
+      run("git", ["symbolic-ref", "--short", "HEAD"], { cwd: repoRoot, env }),
+      run("git", ["rev-parse", "HEAD"], { cwd: repoRoot, env }),
+      run("git", ["rev-parse", `origin/${baseRef}`], { cwd: repoRoot, env }),
+      run("git", ["rev-list", "--left-right", "--count", `HEAD...origin/${baseRef}`], { cwd: repoRoot, env }),
+      run("git", ["status", "--porcelain=v1"], { cwd: repoRoot, env })
+    ]);
+    const parsedStatus = parseVpsRunnerRepoPorcelainStatus(status.stdout);
+    const [aheadText, behindText] = normalizeText(revList.stdout).split(/\s+/);
+    result.currentBranch = normalizeText(branch.stdout) || null;
+    result.headSha = normalizeText(head.stdout) || null;
+    result.originHeadSha = normalizeText(originHead.stdout) || null;
+    result.aheadCount = Number.parseInt(aheadText || "0", 10) || 0;
+    result.behindCount = Number.parseInt(behindText || "0", 10) || 0;
+    result.inSyncWithOrigin = Boolean(result.headSha && result.headSha === result.originHeadSha);
+    result.trackedDirtyPaths = parsedStatus.trackedDirtyPaths;
+    result.unknownUntrackedPaths = parsedStatus.unknownUntrackedPaths;
+    result.knownUntrackedArtifacts = parsedStatus.knownUntrackedArtifacts;
+    result.ok = true;
+
+    if (result.currentBranch !== baseRef) {
+      result.blockedBy.push("not_on_base_branch");
+    }
+    if (result.trackedDirtyPaths.length > 0) {
+      result.blockedBy.push("tracked_dirty");
+    }
+    if (result.unknownUntrackedPaths.length > 0) {
+      result.blockedBy.push("unknown_untracked");
+    }
+    if (result.aheadCount > 0 && result.behindCount > 0) {
+      result.blockedBy.push("diverged_from_origin");
+    } else if (result.aheadCount > 0) {
+      result.blockedBy.push("ahead_of_origin");
+    }
+
+    result.safeToFastForward =
+      result.blockedBy.length === 0 &&
+      result.behindCount > 0 &&
+      result.currentBranch === baseRef;
+    result.developmentAllowed =
+      result.blockedBy.length === 0 &&
+      result.behindCount === 0 &&
+      result.inSyncWithOrigin;
+    result.reason = buildVpsRunnerRepoSyncReason(result);
+  } catch (error) {
+    result.error = summarizeDiagnosticText(error?.stderr || error?.message);
+    result.reason = `VPS runner repo sync preflight failed: ${result.error || "unknown failure"}`;
+  }
+
+  return result;
+}
+
+function parseVpsRunnerRepoPorcelainStatus(stdout) {
+  const trackedDirtyPaths = [];
+  const unknownUntrackedPaths = [];
+  const knownUntrackedArtifacts = [];
+  for (const line of String(stdout || "").split("\n")) {
+    if (!line.trim()) {
+      continue;
+    }
+    if (line.startsWith("?? ")) {
+      const filePath = normalizeText(line.slice(3));
+      if (isKnownRunnerUntrackedArtifact(filePath)) {
+        knownUntrackedArtifacts.push(filePath);
+      } else {
+        unknownUntrackedPaths.push(filePath);
+      }
+      continue;
+    }
+    trackedDirtyPaths.push(normalizeText(line.slice(3)) || normalizeText(line));
+  }
+  return {
+    trackedDirtyPaths,
+    unknownUntrackedPaths,
+    knownUntrackedArtifacts
+  };
+}
+
+function isKnownRunnerUntrackedArtifact(filePath) {
+  const normalized = normalizeText(filePath);
+  return KNOWN_RUNNER_UNTRACKED_ARTIFACT_PREFIXES.some((prefix) => normalized.startsWith(prefix));
+}
+
+function buildVpsRunnerRepoSyncReason(result) {
+  if (!result.ok) {
+    return result.reason;
+  }
+  if (result.developmentAllowed) {
+    return `VPS runner repo is synced with origin/${result.baseRef}.`;
+  }
+  if (result.safeToFastForward) {
+    return `VPS runner repo is behind origin/${result.baseRef} and can be fast-forwarded.`;
+  }
+  const reasons = [];
+  if (result.blockedBy.includes("not_on_base_branch")) {
+    reasons.push(`current branch is ${result.currentBranch || "unknown"}, expected ${result.baseRef}`);
+  }
+  if (result.blockedBy.includes("tracked_dirty")) {
+    reasons.push(`tracked dirty paths: ${result.trackedDirtyPaths.join(", ")}`);
+  }
+  if (result.blockedBy.includes("unknown_untracked")) {
+    reasons.push(`unknown untracked paths: ${result.unknownUntrackedPaths.join(", ")}`);
+  }
+  if (result.blockedBy.includes("diverged_from_origin")) {
+    reasons.push(`HEAD diverged from origin/${result.baseRef} (${result.aheadCount} ahead, ${result.behindCount} behind)`);
+  } else if (result.blockedBy.includes("ahead_of_origin")) {
+    reasons.push(`HEAD is ${result.aheadCount} commit(s) ahead of origin/${result.baseRef}`);
+  }
+  if (result.behindCount > 0 && result.blockedBy.length > 0) {
+    reasons.push(`also ${result.behindCount} commit(s) behind origin/${result.baseRef}`);
+  }
+  return reasons.length > 0
+    ? `VPS runner repo is not safe to use before recovery: ${reasons.join("; ")}.`
+    : `VPS runner repo is not synced with origin/${result.baseRef}.`;
 }
 
 async function collectVpsMainSyncStatus({ repoRoot, baseRef, mergeCommitSha, env }) {
@@ -3009,6 +3222,8 @@ export {
   buildVpsRunnerPullRequestContext,
   checkoutVpsRunnerBranch,
   classifyVpsRunnerFailure,
+  collectVpsRunnerCanonicalRepoSyncStatus,
+  ensureVpsRunnerCanonicalRepoSynced,
   formatPullRequestContext,
   isNonFastForwardPushFailure,
   loadVpsRunnerRepositoryPolicies,

--- a/test/vps-runner-script.test.js
+++ b/test/vps-runner-script.test.js
@@ -20,6 +20,8 @@ import {
   buildVpsRunnerPullRequestContext,
   checkoutVpsRunnerBranch,
   classifyVpsRunnerFailure,
+  collectVpsRunnerCanonicalRepoSyncStatus,
+  ensureVpsRunnerCanonicalRepoSynced,
   formatPullRequestContext,
   isNonFastForwardPushFailure,
   loadVpsRunnerRepositoryPolicies,
@@ -1227,6 +1229,124 @@ test("VPS runner PR body describes ready PR handoff without draft blocking seman
   assert.equal(body.includes("reviewer approve、required checks、head SHA一致、mergeability、approve_auto_merge policy"), true);
 });
 
+test("VPS runner repo sync preflight allows clean in-sync main with known artifacts", async () => {
+  const status = await collectVpsRunnerCanonicalRepoSyncStatus({
+    repoRoot: "/tmp/vtdd-runner/repos/vtdd-v2-p",
+    baseRef: "main",
+    run: mockRepoSyncRun({
+      branch: "main",
+      headSha: "abc123",
+      originHeadSha: "abc123",
+      ahead: 0,
+      behind: 0,
+      status: "?? .tmp/runtime.json\n?? test-results/runner/output.log\n"
+    })
+  });
+
+  assert.equal(status.ok, true);
+  assert.equal(status.developmentAllowed, true);
+  assert.equal(status.inSyncWithOrigin, true);
+  assert.deepEqual(status.knownUntrackedArtifacts, [".tmp/runtime.json", "test-results/runner/output.log"]);
+  assert.deepEqual(status.unknownUntrackedPaths, []);
+});
+
+test("VPS runner repo sync preflight fast-forwards clean behind-only main", async () => {
+  const calls = [];
+  let pulled = false;
+  const status = await ensureVpsRunnerCanonicalRepoSynced({
+    repoRoot: "/tmp/vtdd-runner/repos/vtdd-v2-p",
+    baseRef: "main",
+    run: async (command, args, options) => {
+      calls.push(args.join(" "));
+      if (args[0] === "pull") {
+        pulled = true;
+        return { stdout: "", stderr: "" };
+      }
+      return mockRepoSyncRun({
+        branch: "main",
+        headSha: pulled ? "def456" : "abc123",
+        originHeadSha: "def456",
+        ahead: 0,
+        behind: pulled ? 0 : 1,
+        status: ""
+      })(command, args, options);
+    }
+  });
+
+  assert.equal(status.developmentAllowed, true);
+  assert.equal(status.syncAction, "fast_forwarded");
+  assert.equal(status.headSha, "def456");
+  assert.equal(calls.includes("pull --ff-only origin main"), true);
+});
+
+test("VPS runner repo sync preflight blocks tracked dirty, ahead, and unknown untracked drift", async () => {
+  const dirty = await collectVpsRunnerCanonicalRepoSyncStatus({
+    run: mockRepoSyncRun({
+      branch: "main",
+      headSha: "abc123",
+      originHeadSha: "abc123",
+      ahead: 0,
+      behind: 0,
+      status: " M scripts/run-vps-runner.mjs\n"
+    })
+  });
+  const ahead = await collectVpsRunnerCanonicalRepoSyncStatus({
+    run: mockRepoSyncRun({
+      branch: "main",
+      headSha: "abc123",
+      originHeadSha: "def456",
+      ahead: 1,
+      behind: 0,
+      status: ""
+    })
+  });
+  const unknownUntracked = await collectVpsRunnerCanonicalRepoSyncStatus({
+    run: mockRepoSyncRun({
+      branch: "main",
+      headSha: "abc123",
+      originHeadSha: "abc123",
+      ahead: 0,
+      behind: 0,
+      status: "?? scripts/local-hotfix.mjs\n"
+    })
+  });
+
+  assert.equal(dirty.developmentAllowed, false);
+  assert.deepEqual(dirty.blockedBy, ["tracked_dirty"]);
+  assert.equal(ahead.developmentAllowed, false);
+  assert.deepEqual(ahead.blockedBy, ["ahead_of_origin"]);
+  assert.equal(unknownUntracked.developmentAllowed, false);
+  assert.deepEqual(unknownUntracked.blockedBy, ["unknown_untracked"]);
+});
+
+test("VPS runner repo sync preflight blocks queue pickup before GitHub reads", async () => {
+  let githubRead = false;
+  const result = await runVpsRunnerOnce({
+    token: "ghs_test",
+    allowedRepositories: ["sample-org/vtdd-v2"],
+    workRoot: "/tmp/vtdd-runner-test",
+    dryRun: true,
+    githubFetch: async () => {
+      githubRead = true;
+      return [];
+    },
+    repoSyncPreflight: true,
+    run: mockRepoSyncRun({
+      branch: "main",
+      headSha: "abc123",
+      originHeadSha: "abc123",
+      ahead: 0,
+      behind: 0,
+      status: "?? scripts/local-hotfix.mjs\n"
+    })
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.message.includes("preflight blocked queue pickup"), true);
+  assert.equal(result.repoSync.developmentAllowed, false);
+  assert.equal(githubRead, false);
+});
+
 test("VPS runner dry run reports selected execution without side effects", async () => {
   const calls = [];
   const result = await runVpsRunnerOnce({
@@ -1234,6 +1354,7 @@ test("VPS runner dry run reports selected execution without side effects", async
     allowedRepositories: ["sample-org/vtdd-v2"],
     workRoot: "/tmp/vtdd-runner-test",
     dryRun: true,
+    repoSyncPreflight: false,
     githubFetch: async (url) => {
       calls.push(url);
       if (url.includes("/issues?")) {
@@ -2345,6 +2466,38 @@ function queueComment({
   }
 }
 \`\`\``;
+}
+
+function mockRepoSyncRun({
+  branch = "main",
+  headSha = "abc123",
+  originHeadSha = "abc123",
+  ahead = 0,
+  behind = 0,
+  status = ""
+} = {}) {
+  return async (_command, args) => {
+    const signature = args.join(" ");
+    if (signature.startsWith("fetch origin ")) {
+      return { stdout: "", stderr: "" };
+    }
+    if (signature === "symbolic-ref --short HEAD") {
+      return { stdout: `${branch}\n`, stderr: "" };
+    }
+    if (signature === "rev-parse HEAD") {
+      return { stdout: `${headSha}\n`, stderr: "" };
+    }
+    if (signature.startsWith("rev-parse origin/")) {
+      return { stdout: `${originHeadSha}\n`, stderr: "" };
+    }
+    if (signature.startsWith("rev-list --left-right --count HEAD...origin/")) {
+      return { stdout: `${ahead}\t${behind}\n`, stderr: "" };
+    }
+    if (signature === "status --porcelain=v1") {
+      return { stdout: status, stderr: "" };
+    }
+    throw new Error(`Unexpected git command in mock: ${signature}`);
+  };
 }
 
 function privilegedMaintenanceQueueComment({


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #717 の一部として、VPS runner が GitHub queue / reviewer fallback を読む前に、自分が動いている VTDD repo の `HEAD == origin/main` を確認する gate を追加します。
- clean かつ behind-only の場合だけ `git pull --ff-only origin main` で安全同期し、dirty / ahead / diverged / 別ブランチ / unknown untracked の場合は queue pickup 前に停止します。
- systemd wrapper や外側の `git pull` が失敗を握り潰しても、runner script 自身が古いソースコードで開発を拾わないようにします。

## Satisfied Success Criteria

- `runVpsRunnerOnce()` の入口で repo sync preflight を実行し、block 時は GitHub queue 読み取りへ進みません。
- `HEAD`、`origin/main`、current branch、ahead/behind、tracked dirty、unknown untracked、known artifact を runtime truth として返します。
- clean behind-only のときだけ `git pull --ff-only` で同期し、同期後に再確認します。
- `.tmp/` と `test-results/` は VPS 上に残りうる検証 artifact として分類し、それだけでは block しません。
- unknown untracked、tracked dirty、ahead、diverged、base branch 以外は developmentAllowed=false になります。

## Unsatisfied Success Criteria

- wakeup primary / timer fallback の直接 wakeup 経路は未実装です。
- Butler chat 内の `safe sync` / `bridge restart` / `emergency recovery` action button は未実装です。
- VPS helper recovery plane からこの block 状態を復旧する UI / route は未実装です。
- merge 後の live VPS post-merge verification は、この PR merge 後に別途必要です。

## Non-goal violations

None.

## 開発前作戦図

- 作戦図 evidence: docs/development-strategy/issue-717-vps-sha-sync-gate.md
- 完了体験: Butler から開発を投げても、VPS runner は GitHub `main` と違う VTDD ソースコードでは queue を拾わない。clean behind-only なら安全同期してから実行し、dirty/ahead/diverged/unknown untracked なら開発を始めず復旧待ちにする。
- VTDD 全体で進める部分: Issue #717 の wakeup / timer fallback の前提として、wakeup でも timer でも同じ repo sync preflight を通す。
- 設計: owner-facing safety boundary として、`scripts/run-vps-runner.mjs` の `runVpsRunnerOnce()` 先頭で `ensureVpsRunnerCanonicalRepoSynced()` を呼び、GitHub API queue read より前に canonical repo drift を検出する。
- 仮説: 原因仮説は、VPS と GitHub main のズレが外側 wrapper の `git pull --ff-only` だけに依存すると握り潰されること。runner script 内 gate にすれば、古い runner が queue を処理する事故を止められる。
- 検証計画: clean in-sync、behind-only fast-forward、dirty/ahead/unknown untracked block、queue read 前 block を `test/vps-runner-script.test.js` で固定する。
- 改修見積もり: `scripts/run-vps-runner.mjs` に sync preflight helper と入口 gate、`test/vps-runner-script.test.js` に regression、作戦図 doc を追加する。
- 既に通っている経路: VPS runner は queue / privileged maintenance / reviewer fallback すべて `runVpsRunnerOnce()` を通る。post-merge verification には既に `collectVpsMainSyncStatus()` がある。
- 未確認の境界: Butler UI recovery action と VPS helper 復旧 route は別 Issue で、今回の PR では UI を変更しない。
- 穴が出そうな箇所: unknown untracked を許すと main 直接修正の兆候を見落とす。`.tmp/` と `test-results/` を block すると現実の検証 artifact で runner が止まり続ける。
- PR 前に確認すること: runner tests、Codex fallback guard tests、diff check、PR body に Issue 完了宣言を書かないこと。
- 実装候補と捨てた案: 採用は runner script 内 preflight + clean behind-only `--ff-only` sync。捨てた案は wrapper 依存、GitHub main 毎回直接読み、dirty 状態の reset/checkout 強制復旧。
- merge 後に通す E2E: VPS live E2E/test として、`main` と `origin/main` が同じ SHA になり、runner timer が active で、pending queue がないことを post-merge verification で確認する。
- 次の PR を増やさない理由: drift stop gate と regression test は同じ safety boundary なので同一 PR にまとめる。UI recovery と wakeup primary は混ぜない。
- 停止条件: clean behind-only 以外で自動同期が必要になる、または owner の未承認変更を破壊する復旧が必要になる場合は停止する。

## Dry-run Impact Report

- Target Issue: Issue #717
- Implementing Success Criteria: VPS runner queue pickup 前の canonical repo SHA sync gate、safe fast-forward、dirty/ahead/diverged/unknown untracked block。
- Explicit Non-goals: deploy、credential mutation、permission mutation、bridge restart、wakeup primary 実装、Butler inline recovery UI。
- Expected touched files/routes/workflows: `scripts/run-vps-runner.mjs`, `test/vps-runner-script.test.js`, `docs/development-strategy/issue-717-vps-sha-sync-gate.md`。
- Affected Issues: Issue #717、Issue #455 の fallback guard 継続安全性、Issue #637 の recovery plane 未完了領域。
- Affected PRs: PR #750 の Codex usage guard を前提に、その guard が古い VPS runner で無効化される事故を防ぐ。
- Affected workflows: VPS runner queue pickup、privileged maintenance pickup、Codex reviewer fallback pickup。
- Affected runtime/operator surfaces: VPS runner stdout/message と future Butler runtime truth。
- What may break if we patch narrowly: VPS runner repo に unknown untracked が残っている環境では queue pickup が止まる。ただしこれは意図した drift stop で、復旧 action は別 Issue の残タスクです。
- Unknowns to investigate before coding: VPS live repo に `.tmp/` / `test-results/` 以外の unknown untracked があるかは merge 後確認が必要です。
- Validation needed: targeted Node tests、merge 後 VPS sync / post-merge verification。
- Stop condition: force reset、permission mutation、deploy、credential mutation、owner-specific path の恒久化が必要になる場合。

## Execution Queue Delta

- Queue position before: PR #750 で Codex fallback usage guard を先に止血済み。次はその guard が VPS/GitHub drift で無効化されないようにする #717 safety slice。
- Preemption decision: ROOT。ズレた VPS runner が古いコードで動くと、Cloudflare/codex usage 対策を入れても再発するため、他の開発より先に仕組み化します。
- Queue delta: Issue #717 の SHA sync gate をこの PR で進めます。wakeup primary、safe sync UI、recovery plane は未完了として残します。
- Why this PR is next: VPS と GitHub が常に同じ SHA で動く保証がないと、Butler 経由の開発再開時に再びズレた状態で作業が進む可能性があります。
- Active Issues not downscoped: Active Issues は縮小しません。この PR は Issue #717 の一部実装で、#528/#637/#741/#413 の残作業は完了扱いにしません。

## File / Line Hypotheses

- file: `scripts/run-vps-runner.mjs`
  - hypothesis: `runVpsRunnerOnce()` の先頭で repo sync preflight を実行すれば、queue / privileged maintenance / reviewer fallback の全 pickup 経路を一箇所で止められる。
  - risk if changed narrowly: preflight が厳しすぎると runner が止まり続ける。`.tmp/` と `test-results/` を known artifact として分類して現 VPS の現実に合わせる。
  - validation: `test/vps-runner-script.test.js` の preflight tests。
  - related Issue: Issue #717
- file: `test/vps-runner-script.test.js`
  - hypothesis: clean/in-sync、behind-only、dirty/ahead/unknown untracked、queue read 前 block を mock git で固定すれば regression を検出できる。
  - risk if changed narrowly: mock が実 git とずれる。`git status --porcelain=v1` と `git rev-list --left-right --count` の標準出力形式に寄せる。
  - validation: targeted Node test。
  - related Issue: Issue #717
- file: `docs/development-strategy/issue-717-vps-sha-sync-gate.md`
  - hypothesis: drift stop の判断基準を PR 前に固定することで、復旧 UI や wakeup primary と混ざる scope drift を防げる。
  - risk if changed narrowly: docs-only に見える。runner code と tests を同じ PR に含める。
  - validation: PR body references strategy evidence。
  - related Issue: Issue #717

## Hypothesis Retrospective

- expected: dirty/ahead/unknown untracked の時は GitHub queue read へ進まない。
- actual: `VPS runner repo sync preflight blocks queue pickup before GitHub reads` で `githubRead === false` を確認しました。
- mismatch: なし。
- lesson: VPS runner の安全境界は systemd wrapper に置くだけでなく、runner script 内にも置く必要があります。
- should become RAG candidate: はい。VPS/GitHub SHA sync gate として future handoff に残す価値があります。

## Verification Evidence

- Unit: `node --test test/vps-runner-script.test.js` -> 77 pass, 0 fail。
- Regression: `node --test test/vps-runner-script.test.js test/codex-review-fallback.test.js` -> 90 pass, 0 fail。
- Static: `git diff --check -- docs/development-strategy/issue-717-vps-sha-sync-gate.md scripts/run-vps-runner.mjs test/vps-runner-script.test.js` -> no output。
- Integration: 未実施。merge 後に VPS live repo / timer / pending snapshot を確認します。
- E2E: 未実施。Butler inline recovery action は未実装です。
- Evidence path/link: docs/development-strategy/issue-717-vps-sha-sync-gate.md

## Butler Completion Contract

- Primary owner surface: Dashboard Butler。
- Fallback surface: mac Codex は今回の緊急 bootstrap surface。通常運用の completion surface ではありません。
- Owner goal: Butler -> VPS Codex CLI の開発を、GitHub main とズレた runner で始めない。
- Butler entrypoint: この PR では未変更。
- Dashboard Butler natural-language path: Dashboard Butler の自然文 / 通常チャット入口から runner status を尋ねた時に、将来 `repoSync` truth を説明材料として使える状態にします。この PR では入口そのものは未変更です。
- Action Schema exposure: 未変更。
- Runtime path: VPS runner `runVpsRunnerOnce()` の queue pickup 前 preflight。
- Runner/runtime truth: block 時に `repoSync` object と reason を返します。
- Authority boundary: clean behind-only の `git pull --ff-only` のみ通常同期として許可。dirty/ahead/diverged/unknown untracked の破壊的復旧は実行しません。
- E2E evidence: 未実施。merge 後の VPS live verification が必要です。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 不要。Worker runtime は変更していません。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。
- app-server bridge restart: 不要。この PR は runner script 側のみです。

## Related Constitution Rules

- AGENTS.md Drift Stop Protocol
- AGENTS.md 開発前作戦図 Gate
- AGENTS.md Change Size and PR Discipline
- AGENTS.md Evidence Discipline
- docs/butler/execution-queue-contract.md

## Out-of-scope but NOT implemented

- Issue #717 wakeup primary / timer fallback direct wakeup。
- Issue #528 chat inline safe sync / passkey action button。
- Issue #637 recovery plane / helper recovery。
- Issue #741 app-server bridge lifecycle / restart。
- Issue #413 mac Codex parity / stop button / realtime commentary。

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #717
- Execution ID: mac-codex-issue-717-vps-sha-sync-gate
- Goal: vps_sha_sync_gate
