### PR TITLE
Issue #741: app-server bridge startup repo sync gate

### DIFF
--- a/docs/development-strategy/issue-741-bridge-safe-sync.md
+++ b/docs/development-strategy/issue-741-bridge-safe-sync.md
@@ -1,0 +1,98 @@
+# Issue #741 bridge safe sync 作戦図
+
+## 完了体験
+
+app-server bridge を起動または restart した時、owner は古い VPS checkout の bridge script /
+Codex app-server runtime で会話を再開しない。bridge は Codex app-server を初期化する前に
+VPS canonical repo が `origin/main` と一致するか確認し、clean + behind-only なら
+`git pull --ff-only` で同期してから接続する。dirty / ahead / diverged / unknown untracked
+なら bridge は起動を止め、owner-facing な理由をログに残す。
+
+## VTDD 全体で進める部分
+
+Issue #741 の app-server bridge lifecycle guard のうち、deploy 後 / restart 前の checkout
+sync guard を進める。Cloudflare deploy、metrics read、systemd restart、bridge smoke test は
+passkey / deploy approval 境界のため、この PR では実行しない。
+
+## 設計
+
+`scripts/run-dashboard-app-server-bridge.mjs` に `ensureDashboardBridgeRepoSynced()` を追加し、
+`runDashboardAppServerBridge()` が appServer initialize より前に呼ぶ。preflight は
+`git fetch origin main`、current branch、HEAD、origin/main、ahead/behind、tracked dirty、
+unknown untracked、known artifact を確認する。safe auto-sync は current branch が main、
+tracked dirty なし、unknown untracked なし、ahead なし、behind-only の時だけ
+`git pull --ff-only origin main` を実行する。
+
+## 仮説
+
+原因仮説は、PR merge / Worker deploy / bridge restart の境界で VPS canonical checkout が
+behind のまま残ると、最新の cost boundary や bridge resume logic が入っていない古い
+`scripts/run-dashboard-app-server-bridge.mjs` が動き続けること。runner 側 #717 の sync gate
+だけでは bridge process 自体の起動前 sync は保証しないため、bridge script 内にも gate が必要。
+
+## 検証計画
+
+- `test/dashboard-app-server-bridge.test.js` で clean in-sync は appServer initialize へ進むことを確認する。
+- clean behind-only は `git pull --ff-only origin main` 後に initialize へ進むことを確認する。
+- tracked dirty / ahead / unknown untracked は initialize せず reject することを確認する。
+- `.tmp/` と `test-results/` は known artifact として block しないことを確認する。
+- `node --test test/dashboard-app-server-bridge.test.js` と関連 runner tests を通す。
+
+## 改修見積もり
+
+- `scripts/run-dashboard-app-server-bridge.mjs`: repo sync preflight helper、parse args、run entrypoint guard を追加する。
+- `test/dashboard-app-server-bridge.test.js`: preflight 単体と `runDashboardAppServerBridge()` の initialize 前 block tests を追加する。
+- `docs/development-strategy/issue-741-bridge-safe-sync.md`: この strategy evidence。
+
+## 既に通っている経路
+
+- `runDashboardAppServerBridge()` は appServer initialize 後に Dashboard WebSocket へ接続する。
+- `buildDashboardBridgeConnectedEvent()` は bridge lifecycle を owner-facing transient status として送る。
+- Issue #717 の VPS runner sync gate は runner queue pickup 前の drift を止める。
+- Issue #748 の Worker fix は同一 app-server thread mapping の Durable Object rewrite burst を止める。
+
+## 未確認の境界
+
+- production Cloudflare Worker への deploy は未実施。
+- Cloudflare rowsWritten metrics baseline は未取得。
+- systemd unit の restart policy / helper route は未変更。
+- bridge restart 実行は、この PR では行わない。
+
+## 穴が出そうな箇所
+
+unknown untracked をすべて許すと、VPS 上の emergency patch や直接 main 変更の兆候を見落とす。
+逆に `.tmp/` と `test-results/` を block すると、現 VPS の検証 artifact だけで bridge が
+止まり続ける。known artifact は runtime truth に残し、未知だけを block する。
+
+## PR 前に確認すること
+
+- Issue #741 の Success Criteria と #748 cost audit。
+- `scripts/run-dashboard-app-server-bridge.mjs` の parse / run / reconnect boundary。
+- `test/dashboard-app-server-bridge.test.js` の bridge initialize / reconnect tests。
+- `git diff --check`、targeted tests、必要なら `npm run verify:worker`。
+
+## 実装候補と捨てた案
+
+- 採用: bridge script 内で appServer initialize 前に safe sync preflight。
+- 捨てた案: systemd wrapper の `git pull` のみに依存する。wrapper が握り潰すと古い bridge が動くため。
+- 捨てた案: dirty/ahead を自動 reset する。owner の未承認変更を破壊しうるため。
+- 捨てた案: GitHub main を毎回直接読む。bridge はローカル Node script と app-server cwd を必要とするため。
+
+## merge 後に通す E2E
+
+- deploy 前に VPS `HEAD == origin/main` を確認する。
+- Cloudflare deploy 後、metrics baseline を取得する。
+- bridge restart 前に safe sync preflight が clean/in-sync を返すことを確認する。
+- bridge restart 後、短い Dashboard Butler turn を1回だけ流し、rowsWritten が burst しないことを確認する。
+
+## 次の PR を増やさない理由
+
+bridge safe sync とその regression test は同じ lifecycle boundary なので同じ PR にまとめる。
+deploy / metrics / restart smoke は external authority と runtime evidence の領域なので、この
+PR には混ぜない。
+
+## 停止条件
+
+- dirty/ahead/diverged を自動破壊しないと進められない場合。
+- deploy / credential / permission / systemd restart が必要になった場合。
+- bridge 起動前 sync が appServer initialize 後でないと実装できないことが分かった場合。

--- a/scripts/run-dashboard-app-server-bridge.mjs
+++ b/scripts/run-dashboard-app-server-bridge.mjs
@@ -21,6 +21,8 @@ const DEBUG_SLOW_TURN_DEFAULT_SECONDS = 150;
 const DEBUG_SLOW_TURN_MIN_SECONDS = 10;
 const DEBUG_SLOW_TURN_MAX_SECONDS = 10 * 60;
 const DEBUG_SLOW_TURN_PROGRESS_INTERVAL_MS = 30 * 1000;
+const DEFAULT_REPO_SYNC_BASE_REF = "main";
+const KNOWN_BRIDGE_UNTRACKED_ARTIFACT_PREFIXES = [".tmp/", "test-results/"];
 
 export function buildAppServerInitializeRequest(id = 1) {
   return {
@@ -1591,6 +1593,8 @@ export function parseBridgeArgs(argv = process.argv.slice(2), env = process.env)
     token: env.VTDD_GATEWAY_BEARER_TOKEN || env.MVP_GATEWAY_BEARER_TOKEN || "",
     threadId: env.VTDD_DASHBOARD_THREAD_ID || "",
     cwd: env.VTDD_DASHBOARD_CODEX_CWD || process.cwd(),
+    repoSyncPreflight: env.VTDD_DASHBOARD_BRIDGE_REPO_SYNC_PREFLIGHT !== "0",
+    repoSyncBaseRef: env.VTDD_DASHBOARD_BRIDGE_REPO_SYNC_BASE_REF || DEFAULT_REPO_SYNC_BASE_REF,
     sandboxMode: env.VTDD_DASHBOARD_APP_SERVER_SANDBOX || "",
     turnTimeoutMs: Number(env.VTDD_DASHBOARD_APP_SERVER_TURN_TIMEOUT_MS || DEFAULT_TURN_TIMEOUT_MS),
     activityQuietMs: Number(env.VTDD_DASHBOARD_APP_SERVER_ACTIVITY_QUIET_MS || DEFAULT_ACTIVITY_QUIET_MS),
@@ -1603,6 +1607,8 @@ export function parseBridgeArgs(argv = process.argv.slice(2), env = process.env)
     if (arg === "--token") options.token = argv[++index] || "";
     if (arg === "--thread-id") options.threadId = argv[++index] || "";
     if (arg === "--cwd") options.cwd = argv[++index] || "";
+    if (arg === "--repo-sync-base-ref") options.repoSyncBaseRef = argv[++index] || DEFAULT_REPO_SYNC_BASE_REF;
+    if (arg === "--skip-repo-sync-preflight") options.repoSyncPreflight = false;
     if (arg === "--sandbox") options.sandboxMode = argv[++index] || "";
     if (arg === "--turn-timeout-ms") options.turnTimeoutMs = Number(argv[++index] || DEFAULT_TURN_TIMEOUT_MS);
     if (arg === "--activity-quiet-ms") options.activityQuietMs = Number(argv[++index] || DEFAULT_ACTIVITY_QUIET_MS);
@@ -1624,6 +1630,17 @@ export async function runDashboardAppServerBridge(options = parseBridgeArgs()) {
   }
   if (typeof WebSocket !== "function") {
     throw new Error("global WebSocket is required. Run with Node.js that provides WebSocket.");
+  }
+  if (options.repoSyncPreflight !== false) {
+    const repoSync = await ensureDashboardBridgeRepoSynced({
+      repoRoot: options.cwd,
+      baseRef: options.repoSyncBaseRef || DEFAULT_REPO_SYNC_BASE_REF,
+      env: options.env || process.env,
+      run: options.run || runBridgeCommand
+    });
+    if (!repoSync.developmentAllowed) {
+      throw new Error(`Dashboard app-server bridge repo sync preflight blocked startup: ${repoSync.reason}`);
+    }
   }
   const endpoint = buildDashboardAppServerBridgeEndpoint(options);
   const appServer = options.appServer || new JsonLineAppServerClient({ cwd: options.cwd });
@@ -1652,6 +1669,225 @@ export function buildDashboardAppServerBridgeEndpoint(options = {}) {
   endpoint.searchParams.set("threadId", options.threadId);
   endpoint.protocol = endpoint.protocol === "https:" ? "wss:" : "ws:";
   return endpoint;
+}
+
+export async function ensureDashboardBridgeRepoSynced({
+  repoRoot = process.cwd(),
+  baseRef = DEFAULT_REPO_SYNC_BASE_REF,
+  env = process.env,
+  run = runBridgeCommand
+} = {}) {
+  const first = await collectDashboardBridgeRepoSyncStatus({ repoRoot, baseRef, env, run });
+  if (!first.ok || first.developmentAllowed || first.behindCount <= 0 || !first.safeToFastForward) {
+    return first;
+  }
+  try {
+    await run("git", ["pull", "--ff-only", "origin", baseRef], { cwd: repoRoot, env });
+  } catch (error) {
+    return {
+      ...first,
+      developmentAllowed: false,
+      safeToFastForward: false,
+      syncAction: "pull_ff_only_failed",
+      reason: `bridge repo is behind origin/${baseRef}, but git pull --ff-only failed: ${
+        summarizeBridgeDiagnostic(error?.stderr || error?.message) || "unknown failure"
+      }`,
+      error: summarizeBridgeDiagnostic(error?.stderr || error?.message)
+    };
+  }
+  const second = await collectDashboardBridgeRepoSyncStatus({
+    repoRoot,
+    baseRef,
+    env,
+    run,
+    skipFetch: true
+  });
+  return {
+    ...second,
+    syncAction: second.developmentAllowed ? "fast_forwarded" : "fast_forwarded_but_still_blocked"
+  };
+}
+
+export async function collectDashboardBridgeRepoSyncStatus({
+  repoRoot = process.cwd(),
+  baseRef = DEFAULT_REPO_SYNC_BASE_REF,
+  env = process.env,
+  run = runBridgeCommand,
+  skipFetch = false
+} = {}) {
+  const result = {
+    ok: false,
+    developmentAllowed: false,
+    safeToFastForward: false,
+    syncAction: "none",
+    reason: null,
+    repoRoot,
+    baseRef,
+    currentBranch: null,
+    headSha: null,
+    originHeadSha: null,
+    aheadCount: 0,
+    behindCount: 0,
+    inSyncWithOrigin: false,
+    trackedDirtyPaths: [],
+    unknownUntrackedPaths: [],
+    knownUntrackedArtifacts: [],
+    blockedBy: [],
+    error: null
+  };
+  try {
+    if (!skipFetch) {
+      await run("git", ["fetch", "origin", baseRef], { cwd: repoRoot, env });
+    }
+    const [branch, head, originHead, revList, status] = await Promise.all([
+      run("git", ["symbolic-ref", "--short", "HEAD"], { cwd: repoRoot, env }),
+      run("git", ["rev-parse", "HEAD"], { cwd: repoRoot, env }),
+      run("git", ["rev-parse", `origin/${baseRef}`], { cwd: repoRoot, env }),
+      run("git", ["rev-list", "--left-right", "--count", `HEAD...origin/${baseRef}`], { cwd: repoRoot, env }),
+      run("git", ["status", "--porcelain=v1"], { cwd: repoRoot, env })
+    ]);
+    const parsedStatus = parseDashboardBridgeRepoPorcelainStatus(status.stdout);
+    const [aheadText, behindText] = normalizeBridgeText(revList.stdout).split(/\s+/);
+    result.currentBranch = normalizeBridgeText(branch.stdout) || null;
+    result.headSha = normalizeBridgeText(head.stdout) || null;
+    result.originHeadSha = normalizeBridgeText(originHead.stdout) || null;
+    result.aheadCount = Number.parseInt(aheadText || "0", 10) || 0;
+    result.behindCount = Number.parseInt(behindText || "0", 10) || 0;
+    result.inSyncWithOrigin = Boolean(result.headSha && result.headSha === result.originHeadSha);
+    result.trackedDirtyPaths = parsedStatus.trackedDirtyPaths;
+    result.unknownUntrackedPaths = parsedStatus.unknownUntrackedPaths;
+    result.knownUntrackedArtifacts = parsedStatus.knownUntrackedArtifacts;
+    result.ok = true;
+    if (result.currentBranch !== baseRef) {
+      result.blockedBy.push("not_on_base_branch");
+    }
+    if (result.trackedDirtyPaths.length > 0) {
+      result.blockedBy.push("tracked_dirty");
+    }
+    if (result.unknownUntrackedPaths.length > 0) {
+      result.blockedBy.push("unknown_untracked");
+    }
+    if (result.aheadCount > 0 && result.behindCount > 0) {
+      result.blockedBy.push("diverged_from_origin");
+    } else if (result.aheadCount > 0) {
+      result.blockedBy.push("ahead_of_origin");
+    }
+    result.safeToFastForward =
+      result.blockedBy.length === 0 &&
+      result.behindCount > 0 &&
+      result.currentBranch === baseRef;
+    result.developmentAllowed =
+      result.blockedBy.length === 0 &&
+      result.behindCount === 0 &&
+      result.inSyncWithOrigin;
+    result.reason = buildDashboardBridgeRepoSyncReason(result);
+  } catch (error) {
+    result.error = summarizeBridgeDiagnostic(error?.stderr || error?.message);
+    result.reason = `bridge repo sync preflight failed: ${result.error || "unknown failure"}`;
+  }
+  return result;
+}
+
+function parseDashboardBridgeRepoPorcelainStatus(stdout) {
+  const trackedDirtyPaths = [];
+  const unknownUntrackedPaths = [];
+  const knownUntrackedArtifacts = [];
+  for (const line of String(stdout || "").split("\n")) {
+    if (!line.trim()) {
+      continue;
+    }
+    if (line.startsWith("?? ")) {
+      const filePath = normalizeBridgeText(line.slice(3));
+      if (isKnownBridgeUntrackedArtifact(filePath)) {
+        knownUntrackedArtifacts.push(filePath);
+      } else {
+        unknownUntrackedPaths.push(filePath);
+      }
+      continue;
+    }
+    trackedDirtyPaths.push(normalizeBridgeText(line.slice(3)) || normalizeBridgeText(line));
+  }
+  return {
+    trackedDirtyPaths,
+    unknownUntrackedPaths,
+    knownUntrackedArtifacts
+  };
+}
+
+function isKnownBridgeUntrackedArtifact(filePath) {
+  const normalized = normalizeBridgeText(filePath);
+  return KNOWN_BRIDGE_UNTRACKED_ARTIFACT_PREFIXES.some((prefix) => normalized.startsWith(prefix));
+}
+
+function buildDashboardBridgeRepoSyncReason(result) {
+  if (!result.ok) {
+    return result.reason;
+  }
+  if (result.developmentAllowed) {
+    return `bridge repo is synced with origin/${result.baseRef}.`;
+  }
+  if (result.safeToFastForward) {
+    return `bridge repo is behind origin/${result.baseRef} and can be fast-forwarded.`;
+  }
+  const reasons = [];
+  if (result.blockedBy.includes("not_on_base_branch")) {
+    reasons.push(`current branch is ${result.currentBranch || "unknown"}, expected ${result.baseRef}`);
+  }
+  if (result.blockedBy.includes("tracked_dirty")) {
+    reasons.push(`tracked dirty paths: ${result.trackedDirtyPaths.join(", ")}`);
+  }
+  if (result.blockedBy.includes("unknown_untracked")) {
+    reasons.push(`unknown untracked paths: ${result.unknownUntrackedPaths.join(", ")}`);
+  }
+  if (result.blockedBy.includes("diverged_from_origin")) {
+    reasons.push(`HEAD diverged from origin/${result.baseRef} (${result.aheadCount} ahead, ${result.behindCount} behind)`);
+  } else if (result.blockedBy.includes("ahead_of_origin")) {
+    reasons.push(`HEAD is ${result.aheadCount} commit(s) ahead of origin/${result.baseRef}`);
+  }
+  if (result.behindCount > 0 && result.blockedBy.length > 0) {
+    reasons.push(`also ${result.behindCount} commit(s) behind origin/${result.baseRef}`);
+  }
+  return reasons.length > 0
+    ? `bridge repo is not safe to use before recovery: ${reasons.join("; ")}.`
+    : `bridge repo is not synced with origin/${result.baseRef}.`;
+}
+
+function summarizeBridgeDiagnostic(value, maxLength = 500) {
+  const text = normalizeBridgeText(value).replace(/\s+/g, " ");
+  return text.length <= maxLength ? text : `${text.slice(0, maxLength)} [truncated]`;
+}
+
+function runBridgeCommand(command, args, options = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd: options.cwd,
+      env: options.env || process.env,
+      stdio: ["pipe", "pipe", "pipe"]
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code === 0) {
+        resolve({ stdout, stderr });
+        return;
+      }
+      const error = new Error(`${command} ${args.join(" ")} failed with exit code ${code}: ${stderr || stdout}`);
+      error.exitCode = code;
+      error.stdout = stdout;
+      error.stderr = stderr;
+      reject(error);
+    });
+    child.stdin.end();
+  });
 }
 
 export function buildDashboardBridgeConnectedEvent({ endpoint, threadId = "", cwd = process.cwd(), resumedAt = new Date().toISOString() } = {}) {

--- a/test/dashboard-app-server-bridge.test.js
+++ b/test/dashboard-app-server-bridge.test.js
@@ -17,7 +17,9 @@ import {
   buildDashboardBridgeResumeStatusEvent,
   buildDashboardBridgeTurnStartedStatusEvent,
   buildDashboardTurnInputText,
+  collectDashboardBridgeRepoSyncStatus,
   connectDashboardAppServerBridgeOnce,
+  ensureDashboardBridgeRepoSynced,
   executeVpsRunnerWakeup,
   extractAppServerNotificationTurnId,
   formatDashboardMediaReferenceLines,
@@ -2210,6 +2212,126 @@ test("dashboard app-server bridge args read runtime, token, and thread from envi
   assert.equal(parsed.heartbeatMs, 30000);
 });
 
+test("dashboard app-server bridge repo sync preflight allows clean in-sync main with known artifacts", async () => {
+  const status = await collectDashboardBridgeRepoSyncStatus({
+    repoRoot: "/srv/vtdd-runner/repos/vtdd-v2-p",
+    baseRef: "main",
+    run: mockBridgeRepoSyncRun({
+      branch: "main",
+      headSha: "abc123",
+      originHeadSha: "abc123",
+      ahead: 0,
+      behind: 0,
+      status: "?? .tmp/runtime.json\n?? test-results/bridge/output.log\n"
+    })
+  });
+
+  assert.equal(status.ok, true);
+  assert.equal(status.developmentAllowed, true);
+  assert.equal(status.inSyncWithOrigin, true);
+  assert.deepEqual(status.knownUntrackedArtifacts, [".tmp/runtime.json", "test-results/bridge/output.log"]);
+  assert.deepEqual(status.unknownUntrackedPaths, []);
+});
+
+test("dashboard app-server bridge repo sync preflight fast-forwards clean behind-only main", async () => {
+  const calls = [];
+  let pulled = false;
+  const status = await ensureDashboardBridgeRepoSynced({
+    repoRoot: "/srv/vtdd-runner/repos/vtdd-v2-p",
+    baseRef: "main",
+    run: async (command, args, options) => {
+      calls.push(args.join(" "));
+      if (args[0] === "pull") {
+        pulled = true;
+        return { stdout: "", stderr: "" };
+      }
+      return mockBridgeRepoSyncRun({
+        branch: "main",
+        headSha: pulled ? "def456" : "abc123",
+        originHeadSha: "def456",
+        ahead: 0,
+        behind: pulled ? 0 : 1,
+        status: ""
+      })(command, args, options);
+    }
+  });
+
+  assert.equal(status.developmentAllowed, true);
+  assert.equal(status.syncAction, "fast_forwarded");
+  assert.equal(status.headSha, "def456");
+  assert.equal(calls.includes("pull --ff-only origin main"), true);
+});
+
+test("dashboard app-server bridge repo sync preflight blocks tracked dirty, ahead, and unknown untracked drift", async () => {
+  const dirty = await collectDashboardBridgeRepoSyncStatus({
+    run: mockBridgeRepoSyncRun({
+      branch: "main",
+      headSha: "abc123",
+      originHeadSha: "abc123",
+      ahead: 0,
+      behind: 0,
+      status: " M scripts/run-dashboard-app-server-bridge.mjs\n"
+    })
+  });
+  const ahead = await collectDashboardBridgeRepoSyncStatus({
+    run: mockBridgeRepoSyncRun({
+      branch: "main",
+      headSha: "abc123",
+      originHeadSha: "def456",
+      ahead: 1,
+      behind: 0,
+      status: ""
+    })
+  });
+  const unknownUntracked = await collectDashboardBridgeRepoSyncStatus({
+    run: mockBridgeRepoSyncRun({
+      branch: "main",
+      headSha: "abc123",
+      originHeadSha: "abc123",
+      ahead: 0,
+      behind: 0,
+      status: "?? scripts/local-hotfix.mjs\n"
+    })
+  });
+
+  assert.equal(dirty.developmentAllowed, false);
+  assert.deepEqual(dirty.blockedBy, ["tracked_dirty"]);
+  assert.equal(ahead.developmentAllowed, false);
+  assert.deepEqual(ahead.blockedBy, ["ahead_of_origin"]);
+  assert.equal(unknownUntracked.developmentAllowed, false);
+  assert.deepEqual(unknownUntracked.blockedBy, ["unknown_untracked"]);
+});
+
+test("dashboard app-server bridge repo sync preflight blocks app-server initialization before connect", async () => {
+  let initializeCount = 0;
+  const appServer = {
+    async initialize() {
+      initializeCount += 1;
+    }
+  };
+
+  await assert.rejects(
+    runDashboardAppServerBridge({
+      runtimeUrl: "https://runtime.example",
+      token: "secret-token",
+      threadId: "dashboard-main",
+      cwd: "/repo",
+      appServer,
+      run: mockBridgeRepoSyncRun({
+        branch: "main",
+        headSha: "abc123",
+        originHeadSha: "abc123",
+        ahead: 0,
+        behind: 0,
+        status: "?? scripts/local-hotfix.mjs\n"
+      }),
+      WebSocketImpl: class MockWebSocket {}
+    }),
+    /repo sync preflight blocked startup/
+  );
+  assert.equal(initializeCount, 0);
+});
+
 test("dashboard app-server bridge endpoint uses the dashboard app-server thread WebSocket", () => {
   const endpoint = buildDashboardAppServerBridgeEndpoint({
     runtimeUrl: "https://runtime.example",
@@ -2322,6 +2444,7 @@ test("dashboard app-server bridge reconnects the dashboard WebSocket without rei
     token: "secret-token",
     threadId: "dashboard-main",
     cwd: "/repo",
+    repoSyncPreflight: false,
     appServer,
     WebSocketImpl: MockWebSocket,
     reconnectDelayMs: 0,
@@ -2391,6 +2514,38 @@ test("dashboard app-server bridge sends heartbeat pings on an open socket", asyn
   sockets[0].emit("close");
   await once;
 });
+
+function mockBridgeRepoSyncRun({
+  branch = "main",
+  headSha = "abc123",
+  originHeadSha = "abc123",
+  ahead = 0,
+  behind = 0,
+  status = ""
+} = {}) {
+  return async (_command, args) => {
+    const signature = args.join(" ");
+    if (signature.startsWith("fetch origin ")) {
+      return { stdout: "", stderr: "" };
+    }
+    if (signature === "symbolic-ref --short HEAD") {
+      return { stdout: `${branch}\n`, stderr: "" };
+    }
+    if (signature === "rev-parse HEAD") {
+      return { stdout: `${headSha}\n`, stderr: "" };
+    }
+    if (signature.startsWith("rev-parse origin/")) {
+      return { stdout: `${originHeadSha}\n`, stderr: "" };
+    }
+    if (signature.startsWith("rev-list --left-right --count HEAD...origin/")) {
+      return { stdout: `${ahead}\t${behind}\n`, stderr: "" };
+    }
+    if (signature === "status --porcelain=v1") {
+      return { stdout: status, stderr: "" };
+    }
+    throw new Error(`Unexpected git command in mock: ${signature}`);
+  };
+}
 
 async function waitFor(predicate, { timeoutMs = 1000 } = {}) {
   const start = Date.now();


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #741 の一部として、app-server bridge が Codex app-server を初期化する前に VPS canonical repo の sync preflight を実行します。
- clean + behind-only の場合だけ `git pull --ff-only origin main` で安全同期し、dirty / ahead / diverged / 別ブランチ / unknown untracked の場合は bridge startup を止めます。
- PR merge / deploy / bridge restart 境界で、古い `scripts/run-dashboard-app-server-bridge.mjs` が動き続ける事故を減らします。

## Satisfied Success Criteria

- bridge 起動時に `HEAD`、`origin/main`、current branch、ahead/behind、tracked dirty、unknown untracked、known artifact を確認します。
- `.tmp/` と `test-results/` は known artifact として分類し、それだけでは block しません。
- clean behind-only の時だけ `git pull --ff-only` で同期し、同期後に再確認します。
- block 時は appServer initialize / Dashboard WebSocket connect 前に停止します。
- `VTDD_DASHBOARD_BRIDGE_REPO_SYNC_PREFLIGHT=0` または `--skip-repo-sync-preflight` で emergency escape hatch を残します。

## Unsatisfied Success Criteria

- Cloudflare deploy は未実施です。
- Cloudflare rowsWritten metrics baseline は未取得です。
- app-server bridge restart / 起動は未実施です。
- bridge restart 後の Dashboard Butler smoke test は未実施です。
- Issue #741 全体の periodic restart / health-based restart / CPU memory guard は未完了です。

## Non-goal violations

None.

## 開発前作戦図

- 作戦図 evidence: docs/development-strategy/issue-741-bridge-safe-sync.md
- 完了体験: app-server bridge を起動または restart した時、owner は古い VPS checkout の bridge script / Codex app-server runtime で会話を再開しない。bridge は Codex app-server を初期化する前に VPS canonical repo が `origin/main` と一致するか確認する。
- VTDD 全体で進める部分: Issue #741 の app-server bridge lifecycle guard のうち、deploy 後 / restart 前の checkout sync guard を進める。
- 設計: owner-facing safety boundary として、`scripts/run-dashboard-app-server-bridge.mjs` の `runDashboardAppServerBridge()` が appServer initialize より前に `ensureDashboardBridgeRepoSynced()` を呼ぶ。
- 仮説: 原因仮説は、PR merge / Worker deploy / bridge restart の境界で VPS canonical checkout が behind のまま残ると、最新の cost boundary や bridge resume logic が入っていない古い bridge script が動き続けること。
- 検証計画: `test/dashboard-app-server-bridge.test.js` で clean in-sync、behind-only fast-forward、dirty/ahead/unknown untracked block、initialize 前 block を確認する。
- 改修見積もり: `scripts/run-dashboard-app-server-bridge.mjs` に repo sync preflight helper / parse args / run entrypoint guard を追加し、`test/dashboard-app-server-bridge.test.js` に regression tests を追加する。
- 既に通っている経路: `runDashboardAppServerBridge()` は appServer initialize 後に Dashboard WebSocket へ接続する。Issue #717 は runner queue pickup 前 drift を止め、Issue #748 は Worker mapping rewrite burst を止める。
- 未確認の境界: production Cloudflare Worker への deploy、Cloudflare rowsWritten metrics baseline、systemd unit restart policy、bridge restart 実行はこの PR では未実施。
- 穴が出そうな箇所: unknown untracked を許すと emergency patch や直接 main 変更の兆候を見落とす。一方 `.tmp/` と `test-results/` を block すると現 VPS の検証 artifact だけで bridge が止まり続ける。
- PR 前に確認すること: Issue #741 / #748 cost audit、bridge parse/run/reconnect boundary、targeted tests、`git diff --check`。
- 実装候補と捨てた案: 採用は bridge script 内で appServer initialize 前に safe sync preflight。捨てた案は systemd wrapper 依存、dirty/ahead の自動 reset、GitHub main 直接読み。
- merge 後に通す E2E: live E2E/test として、deploy 前に VPS `HEAD == origin/main` を確認し、Cloudflare deploy 後に metrics baseline を取得し、bridge restart 後に短い Dashboard Butler turn を1回だけ流して rowsWritten が burst しないことを確認する。
- 次の PR を増やさない理由: bridge safe sync と regression test は同じ lifecycle boundary なので同じ PR にまとめる。deploy / metrics / restart smoke は external authority と runtime evidence の領域なので、この PR には混ぜない。
- 停止条件: dirty/ahead/diverged を自動破壊しないと進められない場合、deploy / credential / permission / systemd restart が必要になった場合。

## Dry-run Impact Report

- Target Issue: Issue #741
- Implementing Success Criteria: app-server bridge startup 前の canonical repo SHA sync gate、safe fast-forward、dirty/ahead/diverged/unknown untracked block。
- Explicit Non-goals: deploy、credential mutation、permission mutation、systemd restart、bridge smoke test、Issue #741 close。
- Expected touched files/routes/workflows: `scripts/run-dashboard-app-server-bridge.mjs`, `test/dashboard-app-server-bridge.test.js`, `docs/development-strategy/issue-741-bridge-safe-sync.md`。
- Affected Issues: Issue #741、Issue #748、Issue #717。
- Affected PRs: PR #749 / PR #751 の安全策を bridge 起動前にも効かせる後続 slice。
- Affected workflows: app-server bridge process startup / reconnect loop の初期化前 boundary。
- Affected runtime/operator surfaces: VPS app-server bridge stdout/stderr、future Dashboard Butler recovery explanation。
- What may break if we patch narrowly: VPS bridge cwd に unknown untracked が残っている環境では bridge startup が止まる。ただしこれは drift stop であり、破壊的復旧は別 approval lane に残す。
- Unknowns to investigate before coding: production deploy と bridge restart 後の rowsWritten metrics はこの PR では未確認。
- Validation needed: targeted Node tests、merge 後 VPS source sync、deploy 前 metrics baseline。
- Stop condition: reset / checkout / systemd restart / deploy / credential mutation が必要になる場合。

## Execution Queue Delta

- Queue position before: PR #749 で Worker の rows_written root fix が merge 済み、PR #751 で runner repo sync gate が merge 済み。次は Issue #741 の bridge 起動前 sync gate。
- Preemption decision: ROOT。bridge を古い checkout で起動すると、#748 / #717 の安全策を入れても再発する可能性があるため、bridge 起動前に仕組み化します。
- Queue delta: Issue #741 の bridge safe sync slice を進めます。Issue #741 の restart policy / metrics / smoke E2E は未完了として残します。
- Why this PR is next: app-server bridge 起動前に VPS canonical repo が main と同期している保証がないと、Cloudflare rows_written 修正の反映前に古い bridge で再接続する危険があります。
- Active Issues not downscoped: Active Issues は縮小しません。この PR で扱わない #528/#637/#717/#741/#748 の runtime E2E / recovery work は未完了として残します。

## File / Line Hypotheses

- file: `scripts/run-dashboard-app-server-bridge.mjs`
  - hypothesis: `runDashboardAppServerBridge()` が appServer initialize 前に repo sync preflight を通せば、古い bridge script で Codex app-server を初期化する事故を止められる。
  - risk if changed narrowly: strict すぎると bridge が止まり続けるため、`.tmp/` と `test-results/` は known artifact として分類する。
  - validation: `test/dashboard-app-server-bridge.test.js` の preflight tests。
  - related Issue: Issue #741
- file: `test/dashboard-app-server-bridge.test.js`
  - hypothesis: clean/in-sync、behind-only、dirty/ahead/unknown untracked、initialize 前 block を mock git で固定すれば regression を検出できる。
  - risk if changed narrowly: mock が実 git とずれる。`git status --porcelain=v1` と `git rev-list --left-right --count` の標準出力形式に寄せる。
  - validation: targeted Node tests。
  - related Issue: Issue #741

## Hypothesis Retrospective

- expected: dirty/ahead/unknown untracked の時は appServer initialize に進まない。
- actual: `dashboard app-server bridge repo sync preflight blocks app-server initialization before connect` で `initializeCount === 0` を確認しました。
- mismatch: なし。
- lesson: bridge lifecycle guard は systemd wrapper だけでなく Node bridge script 内にも必要です。
- should become RAG candidate: はい。bridge startup safe sync として future handoff に残す価値があります。

## Verification Evidence

- Unit: `node --test test/dashboard-app-server-bridge.test.js` -> 52 pass, 0 fail。
- Regression: `node --test test/dashboard-app-server-bridge.test.js test/vps-runner-script.test.js` -> 129 pass, 0 fail。
- Static: `git diff --check -- docs/development-strategy/issue-741-bridge-safe-sync.md scripts/run-dashboard-app-server-bridge.mjs test/dashboard-app-server-bridge.test.js` -> no output。
- Integration: 未実施。merge 後に VPS live source sync を確認します。
- E2E: 未実施。deploy / metrics / bridge restart / smoke turn は未実施です。
- Manual: local diff は 3 files に限定しました。
- Evidence path/link: docs/development-strategy/issue-741-bridge-safe-sync.md

## Butler Completion Contract

- Primary owner surface: Dashboard Butler。
- Fallback surface: mac Codex は今回の緊急 bootstrap surface。通常運用の completion surface ではありません。
- Owner goal: Butler の app-server bridge を、GitHub main とズレた VPS checkout で起動しない。
- Butler entrypoint: この PR では未変更。
- Dashboard Butler natural-language path: Dashboard Butler の自然文 / 通常チャット入口から bridge restart や status を尋ねた時、将来この repoSync truth を説明材料として使える状態にします。この PR では入口そのものは未変更です。
- Action Schema exposure: 未変更。
- Runtime path: VPS app-server bridge `runDashboardAppServerBridge()` の appServer initialize 前 preflight。
- Runner/runtime truth: block 時は process startup error として repo sync reason を出します。Dashboard runtime event への配送は未実装です。
- Authority boundary: clean behind-only の `git pull --ff-only` のみ通常同期として許可。dirty/ahead/diverged/unknown untracked の破壊的復旧は実行しません。
- E2E evidence: 未実施。deploy / metrics / bridge restart 後の live evidence が必要です。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 不要。この PR 自体は Worker runtime を変更していません。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。
- app-server bridge restart: 未実施。この PR は restart 前 guard のみです。

## Related Constitution Rules

- AGENTS.md Drift Stop Protocol
- AGENTS.md 開発前作戦図 Gate
- AGENTS.md Change Size and PR Discipline
- AGENTS.md Evidence Discipline
- Issue #741 app-server bridge lifecycle guard
- Issue #748 cost audit bridge restart gate

## Out-of-scope but NOT implemented

- Cloudflare deploy。
- Cloudflare Durable Objects metrics baseline。
- app-server bridge restart / enable。
- Dashboard Butler inline safe sync button。
- VPS privileged recovery lane。
- Issue #741 close judgment。

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #741
- Execution ID: mac-codex-issue-741-bridge-safe-sync
- Goal: bridge_safe_sync
