### PR TITLE
Issue #744 URL折り返しをVRTで固定する

### DIFF
--- a/docs/development-strategy/issue-744-owner-bubble-fit-content.md
+++ b/docs/development-strategy/issue-744-owner-bubble-fit-content.md
@@ -21,6 +21,7 @@ owner message entry は `justify-items: end` のまま維持する。owner bubbl
 - Unit: Worker HTML に owner bubble の `width: fit-content` と `max-width` が含まれ、旧 `width: min(720px, 100%)` が残らないことを確認する。
 - VRT: iPhone / iPad portrait / iPad landscape / iPad real landscape で、owner 短文 bubble が owner entry 全幅より十分小さいことを確認する。
 - VRT: owner 長文・スペースなし日本語・長い URL が viewport 外へ見切れず、右寄せのまま表示されることを確認する。
+- VRT: 長い URL のリンク要素が owner bubble / message body の幅を超えず、複数行へ折り返されることを bounding box で確認する。
 - Local: `node --test test/worker.test.js`
 - Local: `npm run e2e:issue744-chat-layout:chromium`
 - Local: `npm run check:generated-worker`

--- a/docs/mvp/e2e/assets/issue-744/local/issue744-dashboard-chat-layout-chromium-ipad-landscape-1180x820-state.json
+++ b/docs/mvp/e2e/assets/issue-744/local/issue744-dashboard-chat-layout-chromium-ipad-landscape-1180x820-state.json
@@ -28,6 +28,12 @@
         "width": 688,
         "height": 196.328125
       },
+      "link": {
+        "left": 391,
+        "right": 1075.03125,
+        "width": 684.03125,
+        "height": 131.1875
+      },
       "styles": {
         "bubbleBackgroundColor": "rgb(23, 23, 23)",
         "bodyColor": "rgb(247, 247, 244)",
@@ -53,6 +59,7 @@
         "width": 272,
         "height": 28.046875
       },
+      "link": null,
       "styles": {
         "bubbleBackgroundColor": "rgb(23, 23, 23)",
         "bodyColor": "rgb(247, 247, 244)",
@@ -78,6 +85,7 @@
         "width": 403.28125,
         "height": 28.046875
       },
+      "link": null,
       "styles": {
         "bubbleBackgroundColor": "rgb(23, 23, 23)",
         "bodyColor": "rgb(247, 247, 244)",
@@ -103,6 +111,7 @@
         "width": 1010,
         "height": 222.453125
       },
+      "link": null,
       "styles": {
         "bubbleBackgroundColor": "rgba(0, 0, 0, 0)",
         "bodyColor": "rgb(21, 21, 21)",

--- a/docs/mvp/e2e/assets/issue-744/local/issue744-dashboard-chat-layout-chromium-ipad-portrait-820x1180-state.json
+++ b/docs/mvp/e2e/assets/issue-744/local/issue744-dashboard-chat-layout-chromium-ipad-portrait-820x1180-state.json
@@ -28,6 +28,12 @@
         "width": 533.796875,
         "height": 184.734375
       },
+      "link": {
+        "left": 205.203125,
+        "right": 738.765625,
+        "width": 533.5625,
+        "height": 122.5625
+      },
       "styles": {
         "bubbleBackgroundColor": "rgb(23, 23, 23)",
         "bodyColor": "rgb(247, 247, 244)",
@@ -53,6 +59,7 @@
         "width": 256,
         "height": 26.390625
       },
+      "link": null,
       "styles": {
         "bubbleBackgroundColor": "rgb(23, 23, 23)",
         "bodyColor": "rgb(247, 247, 244)",
@@ -78,6 +85,7 @@
         "width": 379.5625,
         "height": 26.390625
       },
+      "link": null,
       "styles": {
         "bubbleBackgroundColor": "rgb(23, 23, 23)",
         "bodyColor": "rgb(247, 247, 244)",
@@ -103,6 +111,7 @@
         "width": 690,
         "height": 211.953125
       },
+      "link": null,
       "styles": {
         "bubbleBackgroundColor": "rgba(0, 0, 0, 0)",
         "bodyColor": "rgb(21, 21, 21)",

--- a/docs/mvp/e2e/assets/issue-744/local/issue744-dashboard-chat-layout-chromium-ipad-real-landscape-1194x834-state.json
+++ b/docs/mvp/e2e/assets/issue-744/local/issue744-dashboard-chat-layout-chromium-ipad-real-landscape-1194x834-state.json
@@ -28,6 +28,12 @@
         "width": 688,
         "height": 196.328125
       },
+      "link": {
+        "left": 404.3125,
+        "right": 1088.34375,
+        "width": 684.03125,
+        "height": 131.1875
+      },
       "styles": {
         "bubbleBackgroundColor": "rgb(23, 23, 23)",
         "bodyColor": "rgb(247, 247, 244)",
@@ -53,6 +59,7 @@
         "width": 272,
         "height": 28.046875
       },
+      "link": null,
       "styles": {
         "bubbleBackgroundColor": "rgb(23, 23, 23)",
         "bodyColor": "rgb(247, 247, 244)",
@@ -78,6 +85,7 @@
         "width": 403.28125,
         "height": 28.046875
       },
+      "link": null,
       "styles": {
         "bubbleBackgroundColor": "rgb(23, 23, 23)",
         "bodyColor": "rgb(247, 247, 244)",
@@ -103,6 +111,7 @@
         "width": 1022.625,
         "height": 222.453125
       },
+      "link": null,
       "styles": {
         "bubbleBackgroundColor": "rgba(0, 0, 0, 0)",
         "bodyColor": "rgb(21, 21, 21)",

--- a/docs/mvp/e2e/assets/issue-744/local/issue744-dashboard-chat-layout-chromium-iphone-390x844-state.json
+++ b/docs/mvp/e2e/assets/issue-744/local/issue744-dashboard-chat-layout-chromium-iphone-390x844-state.json
@@ -28,6 +28,12 @@
         "width": 223.015625,
         "height": 395.859375
       },
+      "link": {
+        "left": 111.484375,
+        "right": 334.171875,
+        "width": 222.6875,
+        "height": 254.515625
+      },
       "styles": {
         "bubbleBackgroundColor": "rgb(23, 23, 23)",
         "bodyColor": "rgb(247, 247, 244)",
@@ -53,6 +59,7 @@
         "width": 223.015625,
         "height": 52.78125
       },
+      "link": null,
       "styles": {
         "bubbleBackgroundColor": "rgb(23, 23, 23)",
         "bodyColor": "rgb(247, 247, 244)",
@@ -78,6 +85,7 @@
         "width": 223.015625,
         "height": 52.78125
       },
+      "link": null,
       "styles": {
         "bubbleBackgroundColor": "rgb(23, 23, 23)",
         "bodyColor": "rgb(247, 247, 244)",
@@ -103,6 +111,7 @@
         "width": 311,
         "height": 327.125
       },
+      "link": null,
       "styles": {
         "bubbleBackgroundColor": "rgba(0, 0, 0, 0)",
         "bodyColor": "rgb(21, 21, 21)",

--- a/scripts/e2e-issue744-dashboard-chat-layout.spec.mjs
+++ b/scripts/e2e-issue744-dashboard-chat-layout.spec.mjs
@@ -182,12 +182,17 @@ for (const viewport of viewports) {
         const body = element.querySelector(".message-body") || bubble;
         const bubbleRect = bubble.getBoundingClientRect();
         const bodyRect = body.getBoundingClientRect();
+        const link = element.querySelector(".chat-link, a[href]");
+        const linkRect = link?.getBoundingClientRect();
         const bubbleStyle = getComputedStyle(bubble);
         const bodyStyle = getComputedStyle(body);
         return {
           entry: { left: rect.left, right: rect.right, width: rect.width },
           bubble: { left: bubbleRect.left, right: bubbleRect.right, width: bubbleRect.width },
           body: { left: bodyRect.left, right: bodyRect.right, width: bodyRect.width, height: bodyRect.height },
+          link: linkRect
+            ? { left: linkRect.left, right: linkRect.right, width: linkRect.width, height: linkRect.height }
+            : null,
           styles: {
             bubbleBackgroundColor: bubbleStyle.backgroundColor,
             bodyColor: bodyStyle.color,
@@ -273,6 +278,18 @@ function assertLayout(state) {
   }
   if (state.ownerNoSpace.bubble.width < Math.min(420, state.ownerNoSpace.entry.width * 0.45)) {
     throw new Error(`no-space Japanese owner bubble collapsed too narrow: ${JSON.stringify(state.ownerNoSpace.bubble)}`);
+  }
+  if (!state.owner.link) {
+    throw new Error("owner long URL link is not rendered as a measurable link");
+  }
+  if (state.owner.link.right > state.owner.bubble.right || state.owner.link.left < state.owner.bubble.left) {
+    throw new Error(`owner long URL link overflows bubble: ${JSON.stringify({ link: state.owner.link, bubble: state.owner.bubble })}`);
+  }
+  if (state.owner.link.width > state.owner.body.width + 1) {
+    throw new Error(`owner long URL link is wider than message body: ${JSON.stringify({ link: state.owner.link, body: state.owner.body })}`);
+  }
+  if (state.owner.link.height < 32) {
+    throw new Error(`owner long URL link did not wrap across lines: ${JSON.stringify(state.owner.link)}`);
   }
   if (state.ownerShort.bubble.width > state.ownerShort.entry.width * 0.9) {
     throw new Error(


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #744 の follow-up として、長い URL が owner 発言 bubble 内で確実に折り返されることを VRT で固定します。
- PR #753 は merge 済みなので、merged branch へ追記せず latest `main` から小さな追撃 PR として分離します。
- CSS の追加変更ではなく、既存の `overflow-wrap` / `word-break` が iPhone / iPad viewport で効いていることを bounding box で証明します。

## Satisfied Success Criteria

- 長い URL の link 要素が owner bubble の外へはみ出さないことを E2E assertion にしました。
- 長い URL の link 要素が message body 幅を超えないことを E2E assertion にしました。
- 長い URL が複数行へ折り返されることを link height で E2E assertion にしました。
- iPhone / iPad portrait / iPad landscape / iPad real landscape の VRT state に link bounding box evidence を保存しました。

## Unsatisfied Success Criteria

- Issue #744 全体の Markdown renderer、進行ログ折りたたみ、reply preview、長文 final answer の全体 UX はこの PR では完了しません。
- production deploy 後の実機 iPad owner E2E は merge 後に必要です。

## Non-goal violations

None.

## 開発前作戦図

- 作戦図 evidence: docs/development-strategy/issue-744-owner-bubble-fit-content.md
- 完了体験: iPad / iPhone の Dashboard Butler で owner 発言内の長い URL が bubble 内に収まり、読める形で複数行に折り返される。
- VTDD 全体で進める部分: Issue #744 の chat layout follow-up。#753 の owner bubble 内容幅修正を保ったまま、URL 折り返しの証跡を追加する。
- 設計: owner-facing Dashboard Butler chat の表示範囲を壊さず、UI CSS は追加変更せず、VRT が `.chat-link` / `a[href]` の bounding box を測って URL はみ出しを検出する。
- 仮説: 原因は CSS 欠落ではなく VRT assertion の穴であり、CSS には既に URL 折り返し設定があるが、VRT assertion がないため将来の layout 変更で退行しても検出できない。
- 検証計画: iPhone / iPad portrait / iPad landscape / iPad real landscape の VRT、worker test、generated-worker check、diff check で固定する。
- 改修見積もり: `scripts/e2e-issue744-dashboard-chat-layout.spec.mjs` は link rect 取得と assertion 追加。`docs/mvp/e2e/assets/issue-744/local/*-state.json` は VRT evidence 更新。作戦図は検証項目追記。
- 既に通っている経路: PR #747 / PR #753 は merge/deploy 済みで、owner 発言が見える状態と短文内容幅化までは改善済み。
- 未確認の境界: deploy 後の実機 iPad / iPhone での最終表示は owner E2E が必要。
- 穴が出そうな箇所: CSS を見ただけでは URL link の実測幅が bubble を超えないか判断できない。VRT の link rect で固定する。
- PR 前に確認すること: PR #753 が merge 済みであること、latest `main` から新規 branch を切っていること、URL 折り返し E2E が通ること。
- 実装候補と捨てた案: 採用は E2E assertion 追加。CSS をさらに足す案は、既存 CSS が効いている限り不要なので捨てた。
- merge 後に通す E2E: production deploy 後、iPad 実機 E2E 検証で長い URL が bubble 内で折り返され、owner コメントが見切れないことを確認する。
- 次の PR を増やさない理由: この PR は #753 後に残った URL 折り返し evidence gap だけを塞ぐ。新しい UI 仕様は増やさない。
- 停止条件: VRT で URL link が bubble / body を超える、複数行に折り返されない、または deploy / credential / permission mutation が必要になる場合。

## Dry-run Impact Report

- Target Issue: Issue #744
- Implementing Success Criteria: chat layout が iPad / iPhone で本文を見切らせず、長い URL も bubble 内に折り返すことを VRT で固定する。
- Explicit Non-goals: CSS の追加再設計、進行ログ折りたたみ、reply preview、Markdown renderer 全体、deploy、Issue close、credential / permission mutation。
- Expected touched files/routes/workflows: `scripts/e2e-issue744-dashboard-chat-layout.spec.mjs`, `docs/mvp/e2e/assets/issue-744/local/*-state.json`, `docs/development-strategy/issue-744-owner-bubble-fit-content.md`
- Affected Issues: Issue #744。Issue #590 / #579 / #654 / #613 は未変更。
- Affected PRs: PR #753 の follow-up。既存 merged PR は変更しない。
- Affected workflows: GitHub Actions workflow file は変更しない。PR checks と reviewer が対象。
- Affected runtime/operator surfaces: Dashboard Butler chat UI の E2E/VRT evidence。runtime CSS / operator / deploy / passkey surface は未変更。
- What may break if we patch narrowly: VRT が URL の複数行折り返しを固定しないと、将来の layout 変更で URL が横にはみ出しても検出できない。
- Unknowns to investigate before coding: 実機 iPad PWA の最終描画差分。
- Validation needed: VRT、worker test、generated-worker、diff check、merge/deploy 後の iPad 実機 E2E。
- Stop condition: VRT で URL link が bubble 外へはみ出す、または test evidence が作れない場合。

## Execution Queue Delta

- Queue position before: Issue #744 は #753 merge 後の owner-facing layout follow-up として扱います。
- Preemption decision: EMERGENCY ではありませんが、owner が URL 折り返しを明示したため、#744 の同一 layout slice として bounded follow-up にします。
- Queue delta: Issue #744 の URL 折り返し evidence gap をこの PR で進めます。Issue #744 全体は未完了のままです。
- Why this PR is next: owner コメントの見切れ対応後、長い URL が同じ layout 退行源になるため、VRT で先に固定する必要があります。
- Active Issues not downscoped: Active Issues は縮小しません。この PR で扱わない #590 / #579 / #654 / #613 / #455 などは未完了として残します。

## File / Line Hypotheses

- file: `scripts/e2e-issue744-dashboard-chat-layout.spec.mjs`
  - hypothesis: owner 発言内 link の bounding box を測れば、URL が bubble / body からはみ出す退行を検出できる。
  - risk if changed narrowly: link height assertion が viewport や font 差で false positive になる可能性。
  - validation: iPhone / iPad portrait / iPad landscape / iPad real landscape の VRT。
  - related Issue: Issue #744
- file: `docs/mvp/e2e/assets/issue-744/local/*-state.json`
  - hypothesis: link rect evidence を state に残すことで、後から URL 折り返しの実測値を確認できる。
  - risk if changed narrowly: screenshot だけでは link のはみ出し境界が読みづらい。
  - validation: generated state JSON の link rect。
  - related Issue: Issue #744

## Hypothesis Retrospective

- expected: 既存 CSS により長い URL は owner bubble 内で複数行に折り返される。
- actual: iPad real landscape では link width `684.03125` / body width `688` / link height `131.1875` となり、body 幅内で複数行に折り返されている。
- mismatch: CSS 変更は不要だった。必要だったのは URL link を測る VRT assertion の追加だった。
- lesson: layout 修正後は、本文・短文・無空白日本語だけでなく URL link そのものの rect を証跡化する。
- should become RAG candidate: いいえ。#744 の PR evidence として十分。

## Verification Evidence

- Unit: `node --test test/worker.test.js` pass, 253 tests.
- Integration: `npm run check:generated-worker` pass.
- E2E: `npm run e2e:issue744-chat-layout:chromium` pass, 4 tests.
- Static: `git diff --check` pass.
- Manual: 未実施。merge/deploy 後に iPad 実機確認が必要。
- Evidence path/link: `docs/mvp/e2e/assets/issue-744/local/`

## Butler Completion Contract

- Primary owner surface: Dashboard Butler。
- Fallback surface: Custom GPT / mac Codex は fallback / debug surface。主経路ではありません。
- Owner goal: owner 発言内の長い URL が iPad / iPhone で横にはみ出さず、bubble 内で読める形に折り返される。
- Butler entrypoint: Dashboard Butler chat UI。自然文入口自体は未変更。
- Dashboard Butler natural-language path: Dashboard Butler chat の自然文入力入口は維持します。この PR は入口ではなく URL 折り返し evidence の follow-up です。
- Action Schema exposure: 不要。UI layout E2E / VRT の follow-up。
- Runtime path: Worker-hosted Dashboard HTML / generated `worker.js`。この PR では runtime CSS は変更しません。
- Runner/runtime truth: local worker test / VRT / generated-worker check。
- Authority boundary: merge には owner の GO が必要。deploy には passkey approval が必要。この PR では deploy しない。
- E2E evidence: local Playwright VRT evidence はあり。production iPad E2E は merge/deploy 後に必要。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: PR #753 は deploy 済み。この PR は E2E/VRT evidence 追加のみだが、main へ入れるなら通常の deploy 判定に従う。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: merge/deploy 後に iPad / iPhone 実機 E2E を確認。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate
- AGENTS.md Chief Butler Operating Principle
- AGENTS.md Drift Stop Protocol
- AGENTS.md 開発前作戦図 Gate
- AGENTS.md Evidence Discipline
- AGENTS.md Conversation UX Contract

## Out-of-scope but NOT implemented

- 進行ログ折りたたみ
- iPad sleep / resume 復帰
- LINE 風 reply preview
- Codex usage guard
- Issue close
- production deploy

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #744
- Execution ID: issue-744-url-wrap-vrt
- Goal: open_pr
