### PR TITLE
Issue #741 復帰時にthread状態を再取得する

### DIFF
--- a/docs/development-strategy/issue-741-resume-thread-state-refetch.md
+++ b/docs/development-strategy/issue-741-resume-thread-state-refetch.md
@@ -1,0 +1,74 @@
+# Issue #741 resume thread state refetch 作戦図
+
+## 完了体験
+
+iPad / iPhone で Dashboard Butler を開いたまま sleep、他アプリ移動、PWA background を挟んでも、復帰後に同じ chat で最新 thread が再取得される。最終回答が既に保存されていれば表示され、まだ owner message で止まっている場合は「送信済み、返信待ち」と分かる進行表示が復元される。
+
+## VTDD 全体で進める部分
+
+Issue #741 の sleep / resume 復帰時 owner-facing continuity を進める。Issue #748 の `presence != persistence` 境界を守り、transient progress を Durable Object に高頻度保存しない。既に durable な owner message / final reply / failure / stalled を読み直して、UI 上の復帰状態を再構成する。
+
+## 設計
+
+Dashboard browser client の `refreshThread()` 後に最新 durable messages を評価する。最後の durable message が Butler final / failed / stalled なら transient progress を消す。最後が owner message のままなら、server-side thread に送信済みで app-server bridge の返信待ちであることを transient progress と status に表示する。`visibilitychange` 復帰時は socket が open に見えても `refreshThread()` を実行し、iPad の background 復帰で消えた UI state を再構成する。
+
+## 仮説
+
+iPad で「考えています…」が消える原因は、sleep / app switch 後に browser-local transient state が失われても、socket が open 扱いのままだと `visibilitychange` 復帰で `refreshThread()` が走らず、UI state を再構成できないこと。final reply は durable chat store に保存されるため、履歴再取得で戻せる。turn 中の細かい progress を保存するのではなく、owner message が最後なら waiting state を復元すれば、無言待ちを避けつつ #748 の cost boundary を守れる。
+
+## 検証計画
+
+- Unit: Dashboard HTML に `restoreThreadRecoveryState()` が入り、`refreshThread()` 後に呼ばれることを確認する。
+- Unit: `visibilitychange` の visible 復帰で socket open 状態でも `refreshThread()` が走ることを確認する。
+- Unit: owner message が最後の時に「送信済みです。app-server bridge の返信を待っています。」を表示する contract を確認する。
+- Build: `npm run build:worker` と `npm run check:generated-worker` を通す。
+- Worker test: `node --test test/worker.test.js` を通す。
+
+## 改修見積もり
+
+- `src/worker/runtime.js`: Dashboard HTML script に `restoreThreadRecoveryState()` を追加し、`refreshThread()` と `visibilitychange` 復帰処理を更新する。
+- `worker.js`: Worker source build output。
+- `test/worker.test.js`: HTML smoke assertion を追加する。
+
+## 既に通っている経路
+
+- `refreshThread()` は `/v2/dashboard/chat/:threadId` から durable messages を再取得できる。
+- `pageshow` は既に `refreshThread()` を呼ぶ。
+- `visibilitychange` は visible 復帰を検出できる。
+- final reply / failed / stalled は durable chat message として保存される。
+- Issue #748 により app-server transient burst は同一 mapping の DO put を増やさない。
+
+## 未確認の境界
+
+- 実機 iPad の PWA background 復帰で socket readyState がどう見えるかは browser behavior 依存。
+- app-server が turn 中に完全停止した場合、細かい progress は復元しない。復元するのは durable owner message に基づく waiting state。
+- production live E2E は merge/deploy 後に必要。
+
+## 穴が出そうな箇所
+
+- `refreshThread()` ごとに scrollToLatest すると owner が過去ログを読んでいる時に下へ戻される可能性がある。今回は既存挙動を変えず、sleep/resume の無言回避を優先する。
+- waiting state を出し続けると、実際は bridge が落ちている場合に「進行中」と誤認させる可能性がある。文面は「返信を待っています。復帰中なら再接続します」に寄せ、完了主張にしない。
+- Durable progress 保存を足すと #748 に反するため、この PR では追加しない。
+
+## PR 前に確認すること
+
+Issue #741、Issue #748、PR #743、PR #749、PR #752 の truth、現 client の `pageshow` / `visibilitychange` / `refreshThread()`、worker HTML smoke tests を確認する。
+
+## 実装候補と捨てた案
+
+- 採用: durable messages から waiting / complete / failure state を再構成する。
+- 採用: visible 復帰時は socket open でも `refreshThread()` を実行する。
+- 捨てた案: transient progress を DO storage に保存する。#748 の cost boundary に反する。
+- 捨てた案: Web Push で毎 progress を通知する。通知頻度とコスト境界が未整理。
+
+## merge 後に通す E2E
+
+production deploy 後、iPad 実機で長めの Dashboard Butler turn を開始し、他アプリ移動または sleep 後に復帰する。同じ chat で final reply が戻ること、まだ完了していなければ送信済み/返信待ちの復帰表示が出ること、低頻度 durable write 以外を増やしていないことを確認する。
+
+## 次の PR を増やさない理由
+
+この PR は sleep/resume 復帰時の無言回避に限定する。systemd restart、periodic restart、metrics monitor、progress folding、Web Push は authority / cost / UX の境界が異なるため混ぜない。
+
+## 停止条件
+
+復帰状態を出すために high-frequency durable progress 保存が必要になる、deploy / bridge restart / credential / permission mutation が必要になる、または final reply persistence を壊す変更が必要になる場合は停止する。

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -15347,6 +15347,33 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         return releasePendingOwnerSend(pendingClientMessageId, { clearComposer: true });
       }
 
+      function restoreThreadRecoveryState(messages) {
+        if (!Array.isArray(messages) || messages.length === 0 || pendingOwnerSend) return;
+        const latestConversationMessage = [...messages]
+          .reverse()
+          .find((message) => message && (message.role === "owner" || message.role === "butler"));
+        if (!latestConversationMessage) return;
+        if (latestConversationMessage.role === "butler") {
+          if (latestConversationMessage.status === "replied") {
+            clearTransientProgress();
+            return;
+          }
+          if (latestConversationMessage.status === "failed" || latestConversationMessage.status === "stalled") {
+            clearTransientProgress();
+            releaseComposerForFollowUp(latestConversationMessage.text || "応答生成が止まっています。同じ thread で続けられます。");
+            return;
+          }
+        }
+        if (latestConversationMessage.role === "owner") {
+          updateTransientProgress("送信済みです。app-server bridge の返信を待っています。復帰中なら同じ thread で再接続します。", {
+            status: "pending_app_server_bridge",
+            thinking: true,
+            title: "返信待ち"
+          });
+          setStatus("送信済みです。app-server bridge の返信を待っています。", { thinking: true });
+        }
+      }
+
       function normalizeMessageId(value) {
         const id = String(value || "").trim();
         return id || "";
@@ -16203,6 +16230,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
             lastRefreshFailure = "";
             renderThread(body.messages || [], { replace: true });
             releasePendingOwnerSendFromThread(body.messages || []);
+            restoreThreadRecoveryState(body.messages || []);
             status.dataset.websocketState = describeChatSocketState();
             return { ok: true };
           }
@@ -16554,10 +16582,10 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         }
         if (await resumeDashboardSessionAfterAuthReturn("画面復帰後、再ログイン状態を確認しています。入力は保持しています。")) return;
         refreshDashboardFreshnessStatus({ pill: "表示中" });
+        refreshThread();
         if (!chatSocket || chatSocket.readyState !== WebSocket.OPEN) {
           setConnectionRecoveryStatus("画面復帰を検知しました。接続を復帰しています。");
           dropStaleSocketIfNeeded();
-          refreshThread();
           scheduleReconnect();
         }
       });

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -1367,6 +1367,11 @@ test("worker serves v2 dashboard for allowed owner identity without exposing sec
   assert.equal(body.includes("setComposerLocked(false);"), true);
   assert.equal(body.includes("function releaseComposerForFollowUp("), true);
   assert.equal(body.includes("このまま同じ thread に追加メッセージを送れます。"), true);
+  assert.equal(body.includes("function restoreThreadRecoveryState(messages)"), true);
+  assert.equal(body.includes("送信済みです。app-server bridge の返信を待っています。復帰中なら同じ thread で再接続します。"), true);
+  assert.equal(body.includes('status: "pending_app_server_bridge"'), true);
+  assert.equal(body.includes('title: "返信待ち"'), true);
+  assert.equal(body.includes("restoreThreadRecoveryState(body.messages || []);"), true);
   assert.equal(body.includes("function withPendingSendRecoveryInstruction("), true);
   assert.equal(body.includes("送信保存を確認中のため入力欄は保持しています。確認後に同じ thread へ追加できます。"), true);
   assert.equal(body.includes('body.status === "stalled"'), true);
@@ -1393,6 +1398,7 @@ test("worker serves v2 dashboard for allowed owner identity without exposing sec
   assert.equal(body.includes('setStatus("Dashboard thread 接続済み。", { temporary: true })'), true);
   assert.equal(body.includes('setStatus("");'), true);
   assert.equal(body.includes('document.addEventListener("visibilitychange", async () => {'), true);
+  assert.equal(body.includes('refreshDashboardFreshnessStatus({ pill: "表示中" });\n        refreshThread();\n        if (!chatSocket || chatSocket.readyState !== WebSocket.OPEN)'), true);
   assert.equal(body.includes('window.addEventListener("online", async () => {'), true);
   assert.equal(body.includes("window.addEventListener(\"offline\""), true);
   assert.equal(body.includes("window.addEventListener(\"pagehide\", persistDashboardDraft)"), true);

--- a/worker.js
+++ b/worker.js
@@ -71149,6 +71149,33 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         return releasePendingOwnerSend(pendingClientMessageId, { clearComposer: true });
       }
 
+      function restoreThreadRecoveryState(messages) {
+        if (!Array.isArray(messages) || messages.length === 0 || pendingOwnerSend) return;
+        const latestConversationMessage = [...messages]
+          .reverse()
+          .find((message) => message && (message.role === "owner" || message.role === "butler"));
+        if (!latestConversationMessage) return;
+        if (latestConversationMessage.role === "butler") {
+          if (latestConversationMessage.status === "replied") {
+            clearTransientProgress();
+            return;
+          }
+          if (latestConversationMessage.status === "failed" || latestConversationMessage.status === "stalled") {
+            clearTransientProgress();
+            releaseComposerForFollowUp(latestConversationMessage.text || "\u5FDC\u7B54\u751F\u6210\u304C\u6B62\u307E\u3063\u3066\u3044\u307E\u3059\u3002\u540C\u3058 thread \u3067\u7D9A\u3051\u3089\u308C\u307E\u3059\u3002");
+            return;
+          }
+        }
+        if (latestConversationMessage.role === "owner") {
+          updateTransientProgress("\u9001\u4FE1\u6E08\u307F\u3067\u3059\u3002app-server bridge \u306E\u8FD4\u4FE1\u3092\u5F85\u3063\u3066\u3044\u307E\u3059\u3002\u5FA9\u5E30\u4E2D\u306A\u3089\u540C\u3058 thread \u3067\u518D\u63A5\u7D9A\u3057\u307E\u3059\u3002", {
+            status: "pending_app_server_bridge",
+            thinking: true,
+            title: "\u8FD4\u4FE1\u5F85\u3061"
+          });
+          setStatus("\u9001\u4FE1\u6E08\u307F\u3067\u3059\u3002app-server bridge \u306E\u8FD4\u4FE1\u3092\u5F85\u3063\u3066\u3044\u307E\u3059\u3002", { thinking: true });
+        }
+      }
+
       function normalizeMessageId(value) {
         const id = String(value || "").trim();
         return id || "";
@@ -72005,6 +72032,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
             lastRefreshFailure = "";
             renderThread(body.messages || [], { replace: true });
             releasePendingOwnerSendFromThread(body.messages || []);
+            restoreThreadRecoveryState(body.messages || []);
             status.dataset.websocketState = describeChatSocketState();
             return { ok: true };
           }
@@ -72356,10 +72384,10 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         }
         if (await resumeDashboardSessionAfterAuthReturn("\u753B\u9762\u5FA9\u5E30\u5F8C\u3001\u518D\u30ED\u30B0\u30A4\u30F3\u72B6\u614B\u3092\u78BA\u8A8D\u3057\u3066\u3044\u307E\u3059\u3002\u5165\u529B\u306F\u4FDD\u6301\u3057\u3066\u3044\u307E\u3059\u3002")) return;
         refreshDashboardFreshnessStatus({ pill: "\u8868\u793A\u4E2D" });
+        refreshThread();
         if (!chatSocket || chatSocket.readyState !== WebSocket.OPEN) {
           setConnectionRecoveryStatus("\u753B\u9762\u5FA9\u5E30\u3092\u691C\u77E5\u3057\u307E\u3057\u305F\u3002\u63A5\u7D9A\u3092\u5FA9\u5E30\u3057\u3066\u3044\u307E\u3059\u3002");
           dropStaleSocketIfNeeded();
-          refreshThread();
           scheduleReconnect();
         }
       });


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #741 の follow-up として、iPad / iPhone が sleep、他アプリ移動、PWA background から戻った時に、Dashboard Butler が同じ chat の durable thread state を再取得して無言待ちを避けるようにします。
- Issue #748 の `presence != persistence` 境界を守り、transient progress を Durable Object に高頻度保存しません。
- 既に保存済みの owner message / final reply / failed / stalled だけから、復帰時の owner-facing 状態を再構成します。

## Satisfied Success Criteria

- `refreshThread()` 後に `restoreThreadRecoveryState()` を呼び、保存済み thread の末尾から復帰状態を再構成します。
- 最後の durable message が owner message の場合、`返信待ち` の transient progress を表示します。
- 最後の durable message が Butler final reply の場合、transient progress を消します。
- 最後の durable message が failed / stalled の場合、同じ thread に follow-up できる状態へ戻します。
- `visibilitychange` の visible 復帰時は socket が open に見えても `refreshThread()` を実行します。

## Unsatisfied Success Criteria

- production deploy 後の iPad / iPhone sleep / app switch 実機 E2E は未実施です。
- app-server bridge restart / enable、systemd lifecycle guard、Cloudflare metrics before/after はこの PR では実施しません。
- Issue #741 全体の periodic restart / health-based restart / CPU memory guard は未完了です。

## Non-goal violations

None.

## 開発前作戦図

- 作戦図 evidence: docs/development-strategy/issue-741-resume-thread-state-refetch.md
- 完了体験: iPad / iPhone で Dashboard Butler を sleep / 他アプリ移動から復帰しても、同じ chat で最終回答または返信待ち状態を確認できます。
- VTDD 全体で進める部分: Issue #741 の sleep/resume continuity を、Issue #748 の cost boundary を守りながら進めます。
- 設計: Dashboard browser client が `refreshThread()` 後に durable messages を評価し、owner message / final reply / failed / stalled から owner-facing recovery state を再構成します。
- 仮説: 原因は iPad 復帰時に browser-local transient state が失われても、socket が open 扱いだと `visibilitychange` で `refreshThread()` が走らず、UI state を再構成できないことです。
- 検証計画: HTML smoke で `restoreThreadRecoveryState()`、`pending_app_server_bridge`、visible 復帰時の `refreshThread()` を確認し、worker test / generated worker check / diff check を通します。
- 改修見積もり: `src/worker/runtime.js`、`worker.js`、`test/worker.test.js`、`docs/development-strategy/issue-741-resume-thread-state-refetch.md`。
- 既に通っている経路: `/v2/dashboard/chat/:threadId` の durable message 再取得、`pageshow` refresh、final reply / failed / stalled の durable persistence、Issue #748 の mapping write burst guard。
- 未確認の境界: 実機 iPad PWA background 復帰時の socket readyState、production live E2E、Cloudflare metrics after deploy。
- 穴が出そうな箇所: `refreshThread()` の既存 scroll behavior、bridge が落ちている時の返信待ち表示の誤認、durable progress 保存を足したくなる誘惑。
- PR 前に確認すること: Issue #741 / #748、PR #743 / #749 / #752、現 client の `pageshow` / `visibilitychange` / `refreshThread()`、worker tests。
- 実装候補と捨てた案: 採用は durable messages からの waiting / complete / failure state 再構成。捨てた案は transient progress の DO 保存と progress ごとの Web Push。
- merge 後に通す E2E: production deploy 後、iPad 実機 E2E で長めの Dashboard Butler turn 中に sleep または他アプリ移動を行い、復帰後に最終回答または返信待ち状態が同じ chat に出ることを確認します。
- 次の PR を増やさない理由: この PR は sleep/resume 復帰時の無言回避に限定します。systemd restart、periodic restart、metrics monitor、progress folding は別 authority / cost / UX 境界です。
- 停止条件: high-frequency durable progress 保存、deploy / bridge restart / credential / permission mutation、final reply persistence を壊す変更が必要になる場合。

## Dry-run Impact Report

- Target Issue: Issue #741
- Implementing Success Criteria: sleep / app switch / PWA background 復帰後に latest thread と recovery state を再取得し、最終回答または返信待ち状態を owner-facing に戻す。
- Explicit Non-goals: deploy、bridge restart / enable、credential mutation、permission mutation、systemd lifecycle guard、Cloudflare metrics operation、progress log folding、Issue close。
- Expected touched files/routes/workflows: `src/worker/runtime.js`, `worker.js`, `test/worker.test.js`, `docs/development-strategy/issue-741-resume-thread-state-refetch.md`
- Affected Issues: Issue #741 primary。Issue #748 は cost boundary として守ります。Issue #590 / #654 / #579 は関連 recovery work ですが未完了のままです。
- Affected PRs: PR #743 / PR #749 / PR #752 の後続 slice。既存 merged PR は変更しません。
- Affected workflows: local `npm run build:worker`, `node --test test/worker.test.js`, `npm run check:generated-worker`。
- Affected runtime/operator surfaces: Dashboard Butler chat browser client、Worker-hosted Dashboard HTML。operator / deploy / passkey surface は未変更。
- What may break if we patch narrowly: visible 復帰時の `refreshThread()` が scrollToLatest を呼ぶ既存挙動により、過去ログ閲覧中でも最新へ戻る可能性があります。
- Unknowns to investigate before coding: iPad PWA の background 復帰時に socket readyState が open のまま残るかどうか。
- Validation needed: worker test、generated worker check、diff check、merge/deploy 後の iPad live E2E。
- Stop condition: progress 復元に durable high-frequency write が必要になる場合は停止します。

## Execution Queue Delta

- Queue position before: Issue #741 は PR #743 / PR #752 が merge 済みで、復帰状態 truth と bridge sync gate は部分進捗済みです。
- Preemption decision: ROOT。owner が「返信は sleep / 他アプリ移動後も chat に出るべき」と確認したため、Issue #741 の sleep/resume recovery state slice を次に進めます。
- Queue delta: Issue #741 を resume thread state refetch slice として進めます。Issue #741 全体の lifecycle guard / metrics / restart E2E は未完了として残します。
- Why this PR is next: UI polish より、Butler が無言で止まったように見える根本 UX を先に減らす必要があります。
- Active Issues not downscoped: Active Issues は縮小しません。#590 / #579 / #654 / #748 / #613 など関連 Issue は未完了として残します。

## File / Line Hypotheses

- file: `src/worker/runtime.js`
  - hypothesis: `visibilitychange` 復帰時に socket が open 扱いだと `refreshThread()` が走らず、失われた transient UI state を再構成できません。
  - risk if changed narrowly: `refreshThread()` は既存で scrollToLatest するため、復帰時に最新へ移動します。
  - validation: HTML smoke、worker test、production iPad E2E。
  - related Issue: Issue #741
- file: `test/worker.test.js`
  - hypothesis: Dashboard HTML smoke で recovery state helper と visible refresh contract を固定できます。
  - risk if changed narrowly: 文字列 smoke は構造変更に弱いが、現 repo pattern に合わせた最小 regression とします。
  - validation: `node --test test/worker.test.js`。
  - related Issue: Issue #741

## Hypothesis Retrospective

- expected: visible 復帰時に `refreshThread()` が走り、durable thread の最後が owner message なら `返信待ち` が復元されます。
- actual: local HTML smoke で `restoreThreadRecoveryState()`、`pending_app_server_bridge`、visible 復帰時の `refreshThread()` を確認しました。
- mismatch: 初回 test では改行表現を `\\n` としてしまい、実 HTML の改行と一致せず失敗しました。assertion を実際の改行に合わせて修正しました。
- lesson: sleep/resume 復帰は high-frequency progress 保存ではなく、durable thread の確定事実から UI state を再構成する方が #748 の cost boundary に合います。
- should become RAG candidate: はい。#741 / #748 の future recovery 設計として残す価値があります。

## Verification Evidence

- Unit: `node --test test/worker.test.js` pass, 253 tests。
- Build: `npm run build:worker` pass。
- Integration: `npm run check:generated-worker` pass。
- Static: `git diff --check` pass。
- E2E: 未実施。production deploy 後に iPad / iPhone sleep / app switch live E2E が必要です。
- Evidence path/link: `docs/development-strategy/issue-741-resume-thread-state-refetch.md`, `test/worker.test.js`, `src/worker/runtime.js`

## Butler Completion Contract

- Primary owner surface: Dashboard Butler。
- Fallback surface: Custom GPT / mac Codex は fallback / debug surface。主経路ではありません。
- Owner goal: sleep / 他アプリ移動 / PWA background 後も、Butler 返信または返信待ち状態が同じ chat に戻ること。
- Butler entrypoint: Dashboard Butler 通常チャット / repo-less main chat。
- Dashboard Butler natural-language path: owner は通常通り Dashboard Butler natural-language chat 入口に入力します。この PR は復帰時の表示再構成で、内部 API 入力は要求しません。
- Action Schema exposure: 不要。この PR は Worker-hosted Dashboard client の復帰挙動です。
- Runtime path: `/v2/dashboard/chat/:threadId` の durable thread fetch、Dashboard browser `refreshThread()`、`restoreThreadRecoveryState()`。
- Runner/runtime truth: local worker test / generated worker check は通過。production runtime truth は deploy 後に必要です。
- Authority boundary: merge には owner GO が必要。deploy / bridge restart / Cloudflare metrics / credential / permission mutation はこの PR では実施しません。
- E2E evidence: local HTML smoke はあり。production iPad / iPhone E2E は未実施です。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 必要。`src/worker/runtime.js` / `worker.js` を変更しています。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: merge/deploy 後に iPad / iPhone sleep / app switch で確認。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate
- AGENTS.md Butler-First Operating Principle
- AGENTS.md Chief Butler Operating Principle
- AGENTS.md RAG Memory Capture and Cost Boundary
- AGENTS.md Evidence Discipline
- AGENTS.md Conversation UX Contract

## Out-of-scope but NOT implemented

- app-server bridge restart / enable
- systemd periodic restart / watchdog
- Cloudflare metrics read/write
- progress log folding
- Web Push progress notification
- Issue close

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #741
- Execution ID: issue-741-resume-thread-state-refetch
- Goal: open_pr
