### PR TITLE
Issue #455 Dashboard の軽量 cost 相談で Codex を起動しない

### DIFF
--- a/docs/development-strategy/issue-455-dashboard-cost-aware-fast-path.md
+++ b/docs/development-strategy/issue-455-dashboard-cost-aware-fast-path.md
@@ -1,0 +1,66 @@
+# Issue #455 Dashboard cost-aware fast path strategy
+
+## 完了体験
+
+owner が Dashboard Butler で「今の状況」「次は？」「PR/Issue の状態を見たい」のような read/status 系の軽い依頼を投げた時、Butler はまず Codex app-server turn を起動せず、チャット上に「この応答は軽量 read/status fast path で、Codex usage を消費していない」ことを返す。実装・修正・merge・deploy・reviewer などの重い作業は従来通り app-server / runner / reviewer 経路へ進み、品質 gate は削らない。
+
+## VTDD 全体で進める部分
+
+Issue #455 のうち、今回の slice は Dashboard の通常 chat entrypoint での usage-aware routing に限定する。PR #750 で入った reviewer fallback 重複抑止は前提として扱い、同じ PR head の fallback retry 抑止は再実装しない。Cloudflare rowsWritten の presence/persistence 修正や bridge lifecycle guard も今回は触らない。
+
+## 設計
+
+DashboardChatRoom の `owner_message` 処理で、owner message を durable thread に保存し ack した後、app-server bridge dispatch 前に軽量 intent 分類を挟む。分類が read/status/cost explanation の範囲に収まる場合は Butler message を同じ thread に保存して broadcast し、`dispatchOwnerMessageToAppServerBridge()` を呼ばない。返答には `cost_boundary: lightweight_worker_reply / codexWillStart=false` を明記する。
+
+分類が実装、調査、ファイル編集、PR 作成、merge、deploy、reviewer、画像解析、repo truth 深掘りなどを含む場合は fast path にせず、既存 app-server bridge 経路へ渡す。その場合は transient status に「Codex app-server を使うため usage を消費し得る」ことを短く出す。これは処理を止める承認 gate ではなく、owner-facing cost visibility である。
+
+## 仮説
+
+現在の `DashboardChatRoom` は VPS maintenance intent 以外の owner turn を、bridge 接続時に即 `app_server_turn_requested` として送る。そのため「今の状況は？」「クレジット消費が多い？」のような軽い相談でも app-server Codex thread が動き、Mac から離れたことで通常会話の Codex usage が増えた体感につながっている。Worker 側で lightweight reply を返せば、実行機能を落とさずに、少なくとも明白な read/status/cost guard 依頼の Codex 起動を抑えられる。
+
+## 検証計画
+
+- Unit: DashboardChatRoom が cost/status 系の軽い owner turn を保存し、Butler の軽量応答を保存して、connected app-server bridge へ送らない。
+- Unit: 実装修正系の owner turn は fast path されず、既存通り app-server bridge へ送られる。
+- Unit: fast path 応答に `cost_boundary` と `codexWillStart=false` が含まれる。
+- Local: `npm run build:worker`、`node --test test/worker.test.js`、`npm run check:generated-worker`、`git diff --check` を実行する。
+
+## 改修見積もり
+
+- `src/worker/runtime.js`: DashboardChatRoom の owner message dispatch 前に `buildDashboardCostAwareFastPathReply()` を呼ぶ。軽量判定 helper と日本語応答 builder を追加する。risk は通常会話を誤って短絡し、owner が期待する Codex 会話を止めること。
+- `test/worker.test.js`: bridge 接続時の fast path と heavy path の分岐を追加する。risk は既存の ordinary owner turn test と期待が衝突すること。
+- `worker.js`: generated worker 更新。risk は source と generated の不一致。
+
+## 既に通っている経路
+
+PR #750 は reviewer fallback の same-head 重複起動を抑止している。`docs/butler/intent-mode-contract.md` は Read mode が heavy tool を起動しないこと、Status Packet に `cost_boundary` を含めることを定義している。Dashboard app-server live path は ordinary conversation を app-server に渡せるが、軽量 read/status を Worker で返す fast path はまだ弱い。
+
+## 未確認の境界
+
+実際の Codex Analytics 使用量 API は読まない。今回の PR だけでは、全ての status/read を GitHub App-backed runtime truth で完全回答するところまでは行かない。軽量応答は「Codex を起動しないための入口整理」であり、PR 詳細や CI 詳細の深い読みに必要な tooling は次 slice で分ける。
+
+## 穴が出そうな箇所
+
+「状況を調べて」は軽く見えるが、repo/PR/CI の deep read を要求する場合がある。今回の fast path は owner に次の安全な進め方を返すだけで、実際の repo truth 深掘りは app-server または将来の GitHub App read route に委ねる。メディア添付がある場合は画像解析期待があるため fast path しない。
+
+## PR 前に確認すること
+
+branch が latest `origin/main` から切られていること、PR #755 の worker changes が取り込まれていること、未追跡 `.tmp/` と `test-results/` を混ぜないこと、PR body が日本語-first で #455 criteria と incomplete boundary を明示すること。
+
+## 実装候補と捨てた案
+
+採用: Worker 側で明白な cost/status/read 依頼だけを軽量応答し、重い操作は既存 app-server 経路へ渡す。
+
+捨てた案: app-server bridge の system prompt だけで節約する。app-server を起動した時点で Codex usage を消費し得るため、Issue #455 の fast path にはならない。捨てた案: reviewer や E2E を止める。VTDD の品質 gate を落とすため Non-goal。
+
+## merge 後に通す E2E
+
+Dashboard から「Codex クレジット消費を削れる？」のような軽量相談を送り、bridge 側に `app_server_turn_requested` が出ないこと、チャットには cost boundary が表示されることを確認する。別途、実装依頼では app-server turn が動くことを確認する。
+
+## 次の PR を増やさない理由
+
+この PR は Worker entrypoint の最小 routing に限定する。GitHub App read route で PR/Issue/Actions を完全に軽量回答する slice は別 PR の方が安全で、今回混ぜると runtime truth 読みと UI/UX と cost guard が膨らむ。
+
+## 停止条件
+
+軽量 fast path が実装修正や high-risk action を誤って飲み込む、repo truth を読んだふりになる、reviewer/CI/E2E gate を削る必要が出る、または deploy/credential/permission mutation が必要になる場合は停止する。

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -350,12 +350,33 @@ export class DashboardChatRoom {
       now,
       origin
     });
+    const costAwareFastPathMessages = vpsMaintenanceMessages
+      ? null
+      : buildDashboardCostAwareFastPathMessages({
+          threadId,
+          repository,
+          relatedIssue,
+          text,
+          mediaReferences: mediaValidation.mediaReferences,
+          now
+        });
     const bridgeSockets = this.connectedAppServerBridgeSockets(threadId);
     if (bridgeSockets.length === 0) {
       const messages = store ? await store.appendMany(threadId, [ownerMessage]) : [ownerMessage].filter(Boolean);
       await this.writeAcceptedOwnerMessage({ threadId, clientMessageId, messageId: ownerMessage.messageId, acceptedAt: now });
       if (vpsMaintenanceMessages) {
         const butlerMessages = store ? await store.appendMany(threadId, vpsMaintenanceMessages) : vpsMaintenanceMessages;
+        await this.broadcastThread({ threadId, messages: [...messages, ...butlerMessages] });
+        this.sendSocket(socket, {
+          type: "owner_message_accepted",
+          ok: true,
+          clientMessageId,
+          messageId: ownerMessage.messageId
+        });
+        return;
+      }
+      if (costAwareFastPathMessages) {
+        const butlerMessages = store ? await store.appendMany(threadId, costAwareFastPathMessages) : costAwareFastPathMessages;
         await this.broadcastThread({ threadId, messages: [...messages, ...butlerMessages] });
         this.sendSocket(socket, {
           type: "owner_message_accepted",
@@ -399,10 +420,15 @@ export class DashboardChatRoom {
       await this.broadcastThread({ threadId, messages: [...messages, ...butlerMessages] });
       return;
     }
+    if (costAwareFastPathMessages) {
+      const butlerMessages = store ? await store.appendMany(threadId, costAwareFastPathMessages) : costAwareFastPathMessages;
+      await this.broadcastThread({ threadId, messages: [...messages, ...butlerMessages] });
+      return;
+    }
     await this.broadcastTransientStatus({
       threadId,
       status: "thinking",
-      text: "app-server bridge の返信を待っています"
+      text: buildDashboardAppServerUsageTransientText({ text, repository, relatedIssue })
     });
     await this.dispatchOwnerMessageToAppServerBridge({
       threadId,
@@ -8930,6 +8956,102 @@ function buildDashboardAppServerFailureTransientText({ messageStatus = "", failu
     return "再接続と状態確認を続けています。入力と文脈は保持しています。";
   }
   return sanitizeDashboardChatText(failureText) || "app-server bridge の返信を待っています";
+}
+
+function buildDashboardAppServerUsageTransientText({ text = "", repository = "", relatedIssue = "" } = {}) {
+  const scope = [
+    repository ? `repo=${repository}` : "repo=未指定",
+    relatedIssue ? `Issue #${relatedIssue}` : "Issue=未指定"
+  ].join(" / ");
+  if (isDashboardCostAwareLightweightIntent({ text })) {
+    return `軽量相談として扱えない文脈が含まれるため、Codex app-server に渡します。Codex usage を消費し得ます。${scope}`;
+  }
+  return `Codex app-server に渡しています。Codex usage を消費し得ます。${scope}`;
+}
+
+function buildDashboardCostAwareFastPathMessages({
+  threadId,
+  repository = "",
+  relatedIssue = "",
+  text = "",
+  mediaReferences = [],
+  now = ""
+} = {}) {
+  if (!isDashboardCostAwareLightweightIntent({ text, mediaReferences })) {
+    return null;
+  }
+  const createdAt = normalizeIsoTimestamp(now) || new Date().toISOString();
+  const message = normalizeDashboardChatMessage(
+    {
+      threadId,
+      role: "butler",
+      repository,
+      relatedIssue,
+      status: "replied",
+      messageId: `dashboard_butler_cost_fast_path:${crypto.randomUUID()}`,
+      createdAt,
+      text: buildDashboardCostAwareFastPathReplyText({ repository, relatedIssue })
+    },
+    { threadId }
+  );
+  return message ? [message] : null;
+}
+
+function isDashboardCostAwareLightweightIntent({ text = "", mediaReferences = [] } = {}) {
+  if (Array.isArray(mediaReferences) && mediaReferences.length > 0) {
+    return false;
+  }
+  const normalized = sanitizeDashboardChatText(text);
+  if (!normalized) {
+    return false;
+  }
+  const lower = normalized.toLowerCase();
+  const hasCostTerm =
+    lower.includes("codex usage") ||
+    lower.includes("usage") ||
+    lower.includes("quota") ||
+    lower.includes("credit") ||
+    lower.includes("cost") ||
+    lower.includes("fast path") ||
+    normalized.includes("クレジット") ||
+    normalized.includes("使用量") ||
+    normalized.includes("消費") ||
+    normalized.includes("節約") ||
+    normalized.includes("削る") ||
+    normalized.includes("軽量") ||
+    normalized.includes("コスト");
+  if (!hasCostTerm) {
+    return false;
+  }
+  const heavyPatterns = [
+    /\bGO\b/,
+    /\bmerge\b/i,
+    /\bdeploy\b/i,
+    /\breviewer\b/i,
+    /\bci\b/i,
+    /\bpr\s*#?\d+/i,
+    /#\d+\b/,
+    /実装|修正|直して|作って|追加|削除|マージ|デプロイ|レビュー|レビュアー|テスト|CI|PR|Issue|ファイル|画像|動画|添付|調査して|探して/
+  ];
+  return !heavyPatterns.some((pattern) => pattern.test(normalized));
+}
+
+function buildDashboardCostAwareFastPathReplyText({ repository = "", relatedIssue = "" } = {}) {
+  const scope = [
+    repository ? `対象 repo: ${repository}` : "対象 repo: 未指定",
+    relatedIssue ? `関連 Issue: #${relatedIssue}` : "関連 Issue: 未指定"
+  ].join("\n");
+  return [
+    "この返答は Dashboard Worker の軽量 fast path で返しています。Codex app-server / VPS Codex CLI は起動していません。",
+    "",
+    scope,
+    "cost_boundary: lightweight_worker_reply",
+    "codexWillStart: false",
+    "",
+    "削る対象は、通常会話や cost/status の入口で毎回 Codex turn を起動する部分です。Issue / PR / reviewer / CI / E2E / merge / deploy の gate は削りません。",
+    "",
+    "次に重い実装や深い repo truth 読みが必要になった時だけ、Butler は Codex app-server に渡し、その時点で Codex usage を消費し得ることを表示します。"
+  ].join("\n");
 }
 
 async function filterDashboardAppServerBridgeMessagesForAppend({ store, threadId, messages = [] } = {}) {

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -3624,7 +3624,52 @@ test("DashboardChatRoom sends ordinary owner turns to connected app-server bridg
   const status = JSON.parse(dashboardSocket.sent[2]);
   assert.equal(status.type, "transient_status");
   assert.equal(status.status, "thinking");
-  assert.equal(status.text, "app-server bridge の返信を待っています");
+  assert.match(status.text, /Codex app-server に渡しています/);
+  assert.match(status.text, /Codex usage を消費し得ます/);
+});
+
+test("DashboardChatRoom answers cost-aware lightweight owner turns without starting app-server Codex", async () => {
+  const provider = createInMemoryMemoryProvider();
+  const store = createInMemoryDashboardChatStore();
+  const dashboardSocket = createMockSocket("dashboard", "dashboard-main-unresolved");
+  const bridgeSocket = createMockSocket("app_server_bridge", "dashboard-main-unresolved");
+  const room = new DashboardChatRoom(
+    {
+      storage: createMockDurableObjectStorage(),
+      getWebSockets() {
+        return [dashboardSocket, bridgeSocket];
+      }
+    },
+    { DASHBOARD_CHAT_STORE: store, MEMORY_PROVIDER: provider }
+  );
+
+  await room.webSocketMessage(
+    dashboardSocket,
+    JSON.stringify({
+      type: "owner_message",
+      threadId: "dashboard-main-unresolved",
+      text: "Codex クレジット消費を削るとVTDD自体が思ったものにならなくなるんじゃない？"
+    })
+  );
+
+  assert.equal(bridgeSocket.sent.length, 0);
+  assert.equal(dashboardSocket.sent.length, 3);
+  const ownerBroadcast = JSON.parse(dashboardSocket.sent[0]);
+  assert.equal(ownerBroadcast.messages.length, 1);
+  assert.equal(ownerBroadcast.messages[0].role, "owner");
+  const ack = JSON.parse(dashboardSocket.sent[1]);
+  assert.equal(ack.type, "owner_message_accepted");
+  assert.equal(ack.ok, true);
+  const fastPathBroadcast = JSON.parse(dashboardSocket.sent[2]);
+  assert.equal(fastPathBroadcast.type, "thread");
+  assert.equal(fastPathBroadcast.messages.length, 2);
+  const reply = fastPathBroadcast.messages[1];
+  assert.equal(reply.role, "butler");
+  assert.equal(reply.status, "replied");
+  assert.match(reply.text, /軽量 fast path/);
+  assert.match(reply.text, /Codex app-server \/ VPS Codex CLI は起動していません/);
+  assert.match(reply.text, /cost_boundary: lightweight_worker_reply/);
+  assert.match(reply.text, /codexWillStart: false/);
 });
 
 test("DashboardChatRoom routes VPS maintenance owner turns to Worker proposal before app-server bridge", async () => {

--- a/worker.js
+++ b/worker.js
@@ -57742,12 +57742,31 @@ var DashboardChatRoom = class {
       now,
       origin
     });
+    const costAwareFastPathMessages = vpsMaintenanceMessages ? null : buildDashboardCostAwareFastPathMessages({
+      threadId,
+      repository,
+      relatedIssue,
+      text,
+      mediaReferences: mediaValidation.mediaReferences,
+      now
+    });
     const bridgeSockets = this.connectedAppServerBridgeSockets(threadId);
     if (bridgeSockets.length === 0) {
       const messages2 = store ? await store.appendMany(threadId, [ownerMessage]) : [ownerMessage].filter(Boolean);
       await this.writeAcceptedOwnerMessage({ threadId, clientMessageId, messageId: ownerMessage.messageId, acceptedAt: now });
       if (vpsMaintenanceMessages) {
         const butlerMessages = store ? await store.appendMany(threadId, vpsMaintenanceMessages) : vpsMaintenanceMessages;
+        await this.broadcastThread({ threadId, messages: [...messages2, ...butlerMessages] });
+        this.sendSocket(socket, {
+          type: "owner_message_accepted",
+          ok: true,
+          clientMessageId,
+          messageId: ownerMessage.messageId
+        });
+        return;
+      }
+      if (costAwareFastPathMessages) {
+        const butlerMessages = store ? await store.appendMany(threadId, costAwareFastPathMessages) : costAwareFastPathMessages;
         await this.broadcastThread({ threadId, messages: [...messages2, ...butlerMessages] });
         this.sendSocket(socket, {
           type: "owner_message_accepted",
@@ -57790,10 +57809,15 @@ var DashboardChatRoom = class {
       await this.broadcastThread({ threadId, messages: [...messages, ...butlerMessages] });
       return;
     }
+    if (costAwareFastPathMessages) {
+      const butlerMessages = store ? await store.appendMany(threadId, costAwareFastPathMessages) : costAwareFastPathMessages;
+      await this.broadcastThread({ threadId, messages: [...messages, ...butlerMessages] });
+      return;
+    }
     await this.broadcastTransientStatus({
       threadId,
       status: "thinking",
-      text: "app-server bridge \u306E\u8FD4\u4FE1\u3092\u5F85\u3063\u3066\u3044\u307E\u3059"
+      text: buildDashboardAppServerUsageTransientText({ text, repository, relatedIssue })
     });
     await this.dispatchOwnerMessageToAppServerBridge({
       threadId,
@@ -65299,6 +65323,85 @@ function buildDashboardAppServerFailureTransientText({ messageStatus = "", failu
     return "\u518D\u63A5\u7D9A\u3068\u72B6\u614B\u78BA\u8A8D\u3092\u7D9A\u3051\u3066\u3044\u307E\u3059\u3002\u5165\u529B\u3068\u6587\u8108\u306F\u4FDD\u6301\u3057\u3066\u3044\u307E\u3059\u3002";
   }
   return sanitizeDashboardChatText(failureText) || "app-server bridge \u306E\u8FD4\u4FE1\u3092\u5F85\u3063\u3066\u3044\u307E\u3059";
+}
+function buildDashboardAppServerUsageTransientText({ text = "", repository = "", relatedIssue = "" } = {}) {
+  const scope = [
+    repository ? `repo=${repository}` : "repo=\u672A\u6307\u5B9A",
+    relatedIssue ? `Issue #${relatedIssue}` : "Issue=\u672A\u6307\u5B9A"
+  ].join(" / ");
+  if (isDashboardCostAwareLightweightIntent({ text })) {
+    return `\u8EFD\u91CF\u76F8\u8AC7\u3068\u3057\u3066\u6271\u3048\u306A\u3044\u6587\u8108\u304C\u542B\u307E\u308C\u308B\u305F\u3081\u3001Codex app-server \u306B\u6E21\u3057\u307E\u3059\u3002Codex usage \u3092\u6D88\u8CBB\u3057\u5F97\u307E\u3059\u3002${scope}`;
+  }
+  return `Codex app-server \u306B\u6E21\u3057\u3066\u3044\u307E\u3059\u3002Codex usage \u3092\u6D88\u8CBB\u3057\u5F97\u307E\u3059\u3002${scope}`;
+}
+function buildDashboardCostAwareFastPathMessages({
+  threadId,
+  repository = "",
+  relatedIssue = "",
+  text = "",
+  mediaReferences = [],
+  now = ""
+} = {}) {
+  if (!isDashboardCostAwareLightweightIntent({ text, mediaReferences })) {
+    return null;
+  }
+  const createdAt = normalizeIsoTimestamp(now) || (/* @__PURE__ */ new Date()).toISOString();
+  const message = normalizeDashboardChatMessage(
+    {
+      threadId,
+      role: "butler",
+      repository,
+      relatedIssue,
+      status: "replied",
+      messageId: `dashboard_butler_cost_fast_path:${crypto.randomUUID()}`,
+      createdAt,
+      text: buildDashboardCostAwareFastPathReplyText({ repository, relatedIssue })
+    },
+    { threadId }
+  );
+  return message ? [message] : null;
+}
+function isDashboardCostAwareLightweightIntent({ text = "", mediaReferences = [] } = {}) {
+  if (Array.isArray(mediaReferences) && mediaReferences.length > 0) {
+    return false;
+  }
+  const normalized = sanitizeDashboardChatText(text);
+  if (!normalized) {
+    return false;
+  }
+  const lower = normalized.toLowerCase();
+  const hasCostTerm = lower.includes("codex usage") || lower.includes("usage") || lower.includes("quota") || lower.includes("credit") || lower.includes("cost") || lower.includes("fast path") || normalized.includes("\u30AF\u30EC\u30B8\u30C3\u30C8") || normalized.includes("\u4F7F\u7528\u91CF") || normalized.includes("\u6D88\u8CBB") || normalized.includes("\u7BC0\u7D04") || normalized.includes("\u524A\u308B") || normalized.includes("\u8EFD\u91CF") || normalized.includes("\u30B3\u30B9\u30C8");
+  if (!hasCostTerm) {
+    return false;
+  }
+  const heavyPatterns = [
+    /\bGO\b/,
+    /\bmerge\b/i,
+    /\bdeploy\b/i,
+    /\breviewer\b/i,
+    /\bci\b/i,
+    /\bpr\s*#?\d+/i,
+    /#\d+\b/,
+    /実装|修正|直して|作って|追加|削除|マージ|デプロイ|レビュー|レビュアー|テスト|CI|PR|Issue|ファイル|画像|動画|添付|調査して|探して/
+  ];
+  return !heavyPatterns.some((pattern) => pattern.test(normalized));
+}
+function buildDashboardCostAwareFastPathReplyText({ repository = "", relatedIssue = "" } = {}) {
+  const scope = [
+    repository ? `\u5BFE\u8C61 repo: ${repository}` : "\u5BFE\u8C61 repo: \u672A\u6307\u5B9A",
+    relatedIssue ? `\u95A2\u9023 Issue: #${relatedIssue}` : "\u95A2\u9023 Issue: \u672A\u6307\u5B9A"
+  ].join("\n");
+  return [
+    "\u3053\u306E\u8FD4\u7B54\u306F Dashboard Worker \u306E\u8EFD\u91CF fast path \u3067\u8FD4\u3057\u3066\u3044\u307E\u3059\u3002Codex app-server / VPS Codex CLI \u306F\u8D77\u52D5\u3057\u3066\u3044\u307E\u305B\u3093\u3002",
+    "",
+    scope,
+    "cost_boundary: lightweight_worker_reply",
+    "codexWillStart: false",
+    "",
+    "\u524A\u308B\u5BFE\u8C61\u306F\u3001\u901A\u5E38\u4F1A\u8A71\u3084 cost/status \u306E\u5165\u53E3\u3067\u6BCE\u56DE Codex turn \u3092\u8D77\u52D5\u3059\u308B\u90E8\u5206\u3067\u3059\u3002Issue / PR / reviewer / CI / E2E / merge / deploy \u306E gate \u306F\u524A\u308A\u307E\u305B\u3093\u3002",
+    "",
+    "\u6B21\u306B\u91CD\u3044\u5B9F\u88C5\u3084\u6DF1\u3044 repo truth \u8AAD\u307F\u304C\u5FC5\u8981\u306B\u306A\u3063\u305F\u6642\u3060\u3051\u3001Butler \u306F Codex app-server \u306B\u6E21\u3057\u3001\u305D\u306E\u6642\u70B9\u3067 Codex usage \u3092\u6D88\u8CBB\u3057\u5F97\u308B\u3053\u3068\u3092\u8868\u793A\u3057\u307E\u3059\u3002"
+  ].join("\n");
 }
 async function filterDashboardAppServerBridgeMessagesForAppend({ store, threadId, messages = [] } = {}) {
   const normalizedMessages = Array.isArray(messages) ? messages.filter(Boolean) : [];


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #455 の部分進捗です。Dashboard Butler の通常チャット入口で、Codex usage / クレジット消費に関する軽い相談を Worker fast path で返し、Codex app-server / VPS Codex CLI を起動しない経路を追加します。
- 重い実装・調査・reviewer・CI・merge・deploy は削らず、app-server へ渡る時は Codex usage を消費し得ることを transient status に表示します。

## Satisfied Success Criteria

- 軽量 read / status / dashboard 表示では Codex CLI を起動しない fast path の一部として、cost-aware lightweight owner turn を Dashboard Worker だけで返信する経路を実装しました。
- 重い処理を実行する前に、Dashboard が「Codex app-server に渡しています。Codex usage を消費し得ます」と owner-facing に表示するようにしました。

## Unsatisfied Success Criteria

- Codex usage が増える箇所の dispatch / review / 修正 / re-review / merge 判断別の完全可視化は未実装です。
- Issue / PR / Actions の深い read/status を GitHub App read route だけで完結させる fast path は未実装です。
- 複数リポジトリ開発時の queue / throttle / defer 方針の実装は未実装です。
- RAG への使用量削減結果の構造化保存は未実装です。
- Codex Analytics 実使用量の集計は未実装です。

## Non-goal violations

None.

## 開発前作戦図

- 作戦図 evidence: `docs/development-strategy/issue-455-dashboard-cost-aware-fast-path.md`
- 完了体験: owner が Dashboard Butler で Codex usage / クレジット消費の軽い相談をした時、Codex app-server を起動せず、チャット内で `cost_boundary: lightweight_worker_reply` と `codexWillStart=false` を確認できます。
- VTDD 全体で進める部分: Issue #455 の Dashboard 通常 chat entrypoint に限定した usage-aware routing です。PR #750 の reviewer fallback 重複抑止は前提として扱います。
- 設計: DashboardChatRoom の owner_message 保存・ack 後、app-server bridge dispatch 前に cost-aware lightweight intent を分類し、該当時は Butler message を thread に保存して app-server dispatch を止めます。
- 仮説: 原因は、現状の DashboardChatRoom が maintenance intent 以外を即 app-server turn へ流すことです。そのため軽い cost 相談でも Codex usage が増える。Worker fast path で明白な cost 相談を止めると、VTDD gate を落とさず通常会話の使用量を下げられます。
- 検証計画: cost-aware lightweight owner turn は bridge に送られず Butler reply が保存されること、ordinary/heavy turn は既存通り bridge に送られることを worker test で固定します。
- 改修見積もり: `src/worker/runtime.js` の DashboardChatRoom dispatch 前分類、`test/worker.test.js` の分岐テスト、generated `worker.js` を変更します。
- 既に通っている経路: PR #750 は reviewer fallback の same-head 重複起動を抑止済みです。`docs/butler/intent-mode-contract.md` は Read mode と `cost_boundary` を定義済みです。
- 未確認の境界: 実際の Codex Analytics usage API はこの PR では読みません。GitHub App read route での完全 status answer は次 slice です。
- 穴が出そうな箇所: cost 相談に Issue/PR/実装/画像解析などの重い文脈が混ざると fast path せず app-server へ渡します。軽量応答が repo truth を読んだふりをしないようにしています。
- PR 前に確認すること: latest `origin/main` から topic branch を切ること、未追跡 `.tmp/` / `test-results/` を混ぜないこと、worker generated check を通すこと。
- 実装候補と捨てた案: 採用は Worker entrypoint の小さい fast path。捨てた案は app-server prompt だけで節約する案と reviewer/E2E gate を止める案です。
- merge 後に通す E2E: Dashboard live E2E として、Dashboard から Codex usage / クレジット消費の軽い相談を送り、bridge へ `app_server_turn_requested` が出ないことを本番 runtime で検証します。
- 次の PR を増やさない理由: この PR は入口 routing に限定し、GitHub App read route の完全 status 対応は別 PR に分けます。
- 停止条件: fast path が実装・merge・deploy・reviewer・画像解析を飲み込む、repo truth を読んだふりになる、または authority boundary を弱める場合は停止します。

## Dry-run Impact Report

- Target Issue: Issue #455
- Implementing Success Criteria: 軽量 read/status/dashboard 表示では Codex CLI を起動しない fast path の一部と、重い処理前の Codex usage 表示。
- Explicit Non-goals: reviewer gate 削除、CI/E2E 削減、merge/deploy/credential 操作、Codex Analytics 集計、OpenAI API runner 化。
- Expected touched files/routes/workflows: `src/worker/runtime.js`, `worker.js`, `test/worker.test.js`, `docs/development-strategy/issue-455-dashboard-cost-aware-fast-path.md`
- Affected Issues: #455
- Affected PRs: PR #750 の reviewer fallback guard を前提にするのみ。変更はしません。
- Affected workflows: GitHub Actions / reviewer / deploy workflow は未変更です。
- Affected runtime/operator surfaces: Dashboard Butler WebSocket chat room / app-server bridge dispatch 前の Worker path。
- What may break if we patch narrowly: 軽量相談の判定が広すぎると、本来 app-server に渡すべき実装・調査・画像解析を止める可能性があります。
- Unknowns to investigate before coding: GitHub App read route だけで完全 status answer を返す次 slice の範囲、Codex Analytics の実使用量 API。
- Validation needed: worker build、worker test、generated-worker check、diff check。post-merge で本番 Dashboard E2E。
- Stop condition: authority boundary を弱める、heavy path を誤って止める、または repo truth を読んだふりになる場合。

## Execution Queue Delta

- Queue position before: Issue #455 は cost-aware Butler repair の ROOT/NEXT slice として扱います。
- Preemption decision: EMERGENCY ではありません。ただし owner が mac を離れても Codex usage が増え続ける blocker に対する scoped progress です。
- Queue delta: Issue #455 の Dashboard entrypoint fast path を `Now` slice として進めます。Issue #455 全体は未完了として残します。
- Why this PR is next: PR #750 で reviewer fallback 重複起動は抑止済みですが、Dashboard の軽い cost 相談が app-server Codex turn に落ちる入口が残っているためです。
- Active Issues not downscoped: Active Issues は縮小しません。この PR で扱わない #455 criteria と他 active Issues は未完了です。

## File / Line Hypotheses

- file: `src/worker/runtime.js`
  - hypothesis: DashboardChatRoom の owner_message dispatch 前に軽量分類を入れない限り、bridge 接続時は軽い cost 相談でも app-server Codex turn が始まる。
  - risk if changed narrowly: heavy intent を fast path に誤分類すると VTDD 実行が止まる。
  - validation: cost-aware lightweight turn は bridge に送られず、ordinary turn は bridge に送られる worker test。
  - related Issue: #455
- file: `test/worker.test.js`
  - hypothesis: WebSocket レベルで bridge sent count を見ると、Codex 起動有無の regression を固定できる。
  - risk if changed narrowly: UI 表示だけ見て bridge dispatch を見落とす。
  - validation: `bridgeSocket.sent.length` assertions。
  - related Issue: #455

## Hypothesis Retrospective

- expected: cost-aware lightweight owner turn は Worker reply で止まり、bridge に送られない。
- actual: `DashboardChatRoom answers cost-aware lightweight owner turns without starting app-server Codex` が追加され、`bridgeSocket.sent.length === 0` を確認しました。
- mismatch: GitHub App read route の完全 status answer は今回実装していません。
- lesson: app-server prompt だけでは起動後の節約にしかならないため、Worker entrypoint で分類する必要があります。
- should become RAG candidate: yes。Dashboard の軽量 cost/status 相談は app-server 起動前に分類する。

## Verification Evidence

- Unit: `node --test test/worker.test.js` pass, 254 tests.
- Integration: DashboardChatRoom WebSocket test で cost-aware fast path と ordinary app-server dispatch の分岐を確認しました。
- E2E: 未実施。merge/deploy 後に本番 Dashboard から bridge dispatch が出ないことを確認します。
- Manual: `npm run build:worker`, `npm run check:generated-worker`, `git diff --check` pass.
- Evidence path/link: `test/worker.test.js`, `docs/development-strategy/issue-455-dashboard-cost-aware-fast-path.md`

## Butler Completion Contract

- Primary owner surface: Dashboard Butler。
- Fallback surface: Custom GPT は明示された fallback surface として扱います。主経路ではありません。
- Owner goal: mac から離れても、軽い cost 相談だけで VPS Codex CLI / app-server usage が増えない入口を作る。
- Butler entrypoint: Dashboard Butler WebSocket owner_message。
- Dashboard Butler natural-language path: Dashboard Butler の通常チャット入口で、Codex usage / クレジット消費に関する軽量相談を自然文で受け、Dashboard Worker が同じ thread に返信する経路です。
- Action Schema exposure: Custom GPT fallback 用 Action Schema は未変更です。
- Runtime path: `DashboardChatRoom.webSocketMessage` -> owner message 保存 -> cost-aware fast path reply -> app-server dispatch なし。
- Runner/runtime truth: fast path reply に `cost_boundary: lightweight_worker_reply` と `codexWillStart=false` を表示します。heavy path は transient status に usage impact を表示します。
- Authority boundary: 未変更。merge/deploy/credential/permission/destructive work はこの PR では扱いません。
- E2E evidence: 未実施。Butler Completion Gate 上は incomplete です。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: worker runtime が変わるため merge 後に deploy が必要です。実行は passkey approval 後です。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: merge/deploy 後に必要です。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate
- AGENTS.md RAG Memory Capture and Cost Boundary
- AGENTS.md Change Size and PR Discipline
- docs/butler/intent-mode-contract.md Read mode / cost_boundary

## Out-of-scope but NOT implemented

- Issue / PR / Actions の完全な GitHub App lightweight status answer。
- Codex Analytics の実使用量集計。
- reviewer fallback 以外の重複 runner 抑止。
- queue / throttle / defer policy 実装。

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #455
- Execution ID: dashboard-cost-aware-fast-path
- Goal: Dashboard cost-aware lightweight owner turns do not start app-server Codex.
