### PR TITLE
Issue #455 Dashboard の PR/Issue 状況確認を軽量 read に逃がす

### DIFF
--- a/docs/development-strategy/issue-455-dashboard-github-read-fast-path.md
+++ b/docs/development-strategy/issue-455-dashboard-github-read-fast-path.md
@@ -1,0 +1,66 @@
+# Issue #455 Dashboard GitHub read fast path strategy
+
+## 完了体験
+
+owner が Dashboard Butler で `PR #756 の状況`、`Issue #455 の状態`、`#590 は open?` のような明白な read/status intent を投げた時、Dashboard Worker が GitHub App-backed read plane で必要な Issue / PR truth を読み、同じ thread に短い日本語 status packet を返す。Codex app-server / VPS Codex CLI は起動せず、返信には `cost_boundary: github_read_plane_lightweight` と `codexWillStart=false` が表示される。
+
+## VTDD 全体で進める部分
+
+Issue #455 の「軽量 read / status / dashboard 表示では Codex CLI を起動しない fast path」を、既存 `retrieveGitHubReadPlane()` に接続して進める。PR #756 の cost-only fast path を前提にし、次の大口削減として PR/Issue status read を app-server から外す。
+
+## 設計
+
+DashboardChatRoom の owner message 保存・ack 後、app-server bridge dispatch 前に `buildDashboardGitHubReadFastPathMessages()` を挟む。明白な read/status intent かつ repository が解決済みで、対象が Issue または PR なら `retrieveGitHubReadPlane()` を呼ぶ。成功時は Butler message を durable thread に保存して broadcast し、app-server へ送らない。失敗時も GitHub read plane failure として短く返し、Codex 起動に逃げない。
+
+対象分類は狭くする。`PR #123 状況`、`Issue #123 状態`、`#123 状況` のような read/status 語を含む場合だけ扱う。`直して`、`実装`、`レビュー`、`merge`、`deploy`、`GO`、添付ありは fast path しない。
+
+## 仮説
+
+原因は、Dashboard chat の status/read 系 owner turn が bridge 接続時に app-server turn へ流れていること。GitHub read plane は既に Worker から利用可能なので、明白な PR/Issue status read を Worker で処理すれば、VTDD gate を落とさず週間 Codex usage を削れる。狭く分類すれば通常会話や実装依頼を誤って止めるリスクを抑えられる。
+
+## 検証計画
+
+- Unit: DashboardChatRoom が `PR #756 の状況` を GitHub read plane で返し、bridge に `app_server_turn_requested` を送らない。
+- Unit: GitHub read failure 時も Codex に fallback せず、owner-facing failure message を返す。
+- Unit: 実装修正系 owner turn は fast path されず、既存通り app-server bridge へ送る。
+- Local: `npm run build:worker`、`node --test test/worker.test.js`、`npm run check:generated-worker`、`git diff --check` を実行する。
+
+## 改修見積もり
+
+- `src/worker/runtime.js`: DashboardChatRoom owner message flow に GitHub read fast path を追加する。helper で intent 抽出、read plane 呼び出し、status packet 生成を行う。risk は PR/Issue 番号の意味を誤ること。
+- `test/worker.test.js`: WebSocket DashboardChatRoom に mock `GITHUB_API_FETCH` を入れ、bridge sent count と reply text を検証する。
+- `worker.js`: generated worker 更新。
+
+## 既に通っている経路
+
+`retrieveGitHubReadPlane()` は repositories / issues / pulls / reviews / checks / workflow_runs / branches / contents などを GitHub App-backed で読む。Custom GPT instructions では status intent の lightweight ladder として `vtddRetrieveGitHub` が既に定義されている。PR #756 では cost-only lightweight fast path が実装済み。
+
+## 未確認の境界
+
+複数 repository を跨ぐ曖昧な chat で repo 未指定のまま status read する経路は今回扱わない。repo-less main chat で repo が無い場合は app-server に流すか、次 slice で repo 確認 UI を作る。Actions / checks / deploy run の詳細 ladder は今回の Issue/PR first slice の外。
+
+## 穴が出そうな箇所
+
+`#756` だけでは Issue か PR か曖昧。今回の初期実装では `PR` 語があれば pulls、`Issue` 語があれば issues、どちらも無い場合は issue read に寄せる。merge readiness や close readiness は deep judgment なので fast path せず app-server に残す。
+
+## PR 前に確認すること
+
+latest `origin/main` から topic branch を切ること、PR #756 merge/deploy の fast path と衝突しないこと、GitHub read plane route の既存 tests を壊さないこと、未追跡 `.tmp/` / `test-results/` を混ぜないこと。
+
+## 実装候補と捨てた案
+
+採用: DashboardChatRoom の app-server dispatch 前に narrow GitHub read fast path を挟む。
+
+捨てた案: app-server prompt で `vtddRetrieveGitHub` を優先させる。app-server 起動後では Codex usage 削減にならない。捨てた案: 全ての status/read を Worker で解釈する。誤分類と仕様膨張が大きい。
+
+## merge 後に通す E2E
+
+Dashboard live E2E として、`PR #756 の状況` のような PR status read を送り、GitHub read plane の短い status packet が返り、bridge へ `app_server_turn_requested` が出ないことを検証する。
+
+## 次の PR を増やさない理由
+
+この PR は PR/Issue first read に限定する。checks / workflow_runs / deploy / branch の ladder は後続として必要だが、ここに混ぜると status packet と merge readiness judgment が肥大化するため分ける。
+
+## 停止条件
+
+repo truth を読んだふりになる、GitHub read failure を隠す、実装/merge/deploy/reviewer を誤って fast path する、または authority boundary を弱める場合は停止する。

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -350,6 +350,17 @@ export class DashboardChatRoom {
       now,
       origin
     });
+    const githubReadFastPathMessages = vpsMaintenanceMessages
+      ? null
+      : await buildDashboardGitHubReadFastPathMessages({
+          env: this.env,
+          threadId,
+          repository,
+          relatedIssue,
+          text,
+          mediaReferences: mediaValidation.mediaReferences,
+          now
+        });
     const costAwareFastPathMessages = vpsMaintenanceMessages
       ? null
       : buildDashboardCostAwareFastPathMessages({
@@ -366,6 +377,17 @@ export class DashboardChatRoom {
       await this.writeAcceptedOwnerMessage({ threadId, clientMessageId, messageId: ownerMessage.messageId, acceptedAt: now });
       if (vpsMaintenanceMessages) {
         const butlerMessages = store ? await store.appendMany(threadId, vpsMaintenanceMessages) : vpsMaintenanceMessages;
+        await this.broadcastThread({ threadId, messages: [...messages, ...butlerMessages] });
+        this.sendSocket(socket, {
+          type: "owner_message_accepted",
+          ok: true,
+          clientMessageId,
+          messageId: ownerMessage.messageId
+        });
+        return;
+      }
+      if (githubReadFastPathMessages) {
+        const butlerMessages = store ? await store.appendMany(threadId, githubReadFastPathMessages) : githubReadFastPathMessages;
         await this.broadcastThread({ threadId, messages: [...messages, ...butlerMessages] });
         this.sendSocket(socket, {
           type: "owner_message_accepted",
@@ -417,6 +439,11 @@ export class DashboardChatRoom {
     });
     if (vpsMaintenanceMessages) {
       const butlerMessages = store ? await store.appendMany(threadId, vpsMaintenanceMessages) : vpsMaintenanceMessages;
+      await this.broadcastThread({ threadId, messages: [...messages, ...butlerMessages] });
+      return;
+    }
+    if (githubReadFastPathMessages) {
+      const butlerMessages = store ? await store.appendMany(threadId, githubReadFastPathMessages) : githubReadFastPathMessages;
       await this.broadcastThread({ threadId, messages: [...messages, ...butlerMessages] });
       return;
     }
@@ -8967,6 +8994,213 @@ function buildDashboardAppServerUsageTransientText({ text = "", repository = "",
     return `軽量相談として扱えない文脈が含まれるため、Codex app-server に渡します。Codex usage を消費し得ます。${scope}`;
   }
   return `Codex app-server に渡しています。Codex usage を消費し得ます。${scope}`;
+}
+
+async function buildDashboardGitHubReadFastPathMessages({
+  env,
+  threadId,
+  repository = "",
+  relatedIssue = "",
+  text = "",
+  mediaReferences = [],
+  now = ""
+} = {}) {
+  const intent = parseDashboardGitHubReadFastPathIntent({ text, repository, relatedIssue, mediaReferences });
+  if (!intent.ok) {
+    return null;
+  }
+  let result;
+  if (intent.blocked) {
+    result = { ok: true, read: { records: [] } };
+  } else {
+    try {
+      result = await retrieveGitHubReadPlane({
+        resource: intent.resource,
+        repository: intent.repository,
+        issueNumber: intent.issueNumber,
+        pullNumber: intent.pullNumber,
+        limit: 1,
+        env
+      });
+    } catch (error) {
+      result = {
+        ok: false,
+        error: "github_read_exception",
+        reason: normalizeText(error?.message) || "GitHub read threw"
+      };
+    }
+  }
+  const createdAt = normalizeIsoTimestamp(now) || new Date().toISOString();
+  const message = normalizeDashboardChatMessage(
+    {
+      threadId,
+      role: "butler",
+      repository: intent.repository,
+      relatedIssue: intent.issueNumber || relatedIssue,
+      status: result?.ok ? "replied" : "failed",
+      messageId: `dashboard_butler_github_read_fast_path:${crypto.randomUUID()}`,
+      createdAt,
+      text: buildDashboardGitHubReadFastPathReplyText({ intent, result })
+    },
+    { threadId }
+  );
+  return message ? [message] : null;
+}
+
+function parseDashboardGitHubReadFastPathIntent({ text = "", repository = "", relatedIssue = "", mediaReferences = [] } = {}) {
+  if (Array.isArray(mediaReferences) && mediaReferences.length > 0) {
+    return { ok: false, reason: "media references require app-server context" };
+  }
+  const normalized = sanitizeDashboardChatText(text);
+  const resolvedRepository = normalizeCanonicalRepositoryInput(repository);
+  if (!normalized) {
+    return { ok: false, reason: "message text is required" };
+  }
+  if (!isDashboardNarrowStatusReadIntent(normalized)) {
+    return { ok: false, reason: "not a narrow status read intent" };
+  }
+  const number = extractIssueNumberFromDashboardChatText(normalized) || normalizePositiveInteger(relatedIssue);
+  if (!number) {
+    return { ok: false, reason: "issue or pull number is required" };
+  }
+  const lower = normalized.toLowerCase();
+  const isPull = /\b(pr|pull request|pull)\b/i.test(normalized) || normalized.includes("プルリク") || normalized.includes("PR");
+  const isIssue = /\bissue\b/i.test(normalized) || normalized.includes("Issue") || normalized.includes("イシュー");
+  if (!resolvedRepository) {
+    return {
+      ok: true,
+      blocked: true,
+      repository: "",
+      resource: isPull ? "pulls" : "issues",
+      pullNumber: isPull ? number : null,
+      issueNumber: isPull ? null : number,
+      source: "dashboard_github_read_fast_path",
+      reason: "repository is required for GitHub read fast path"
+    };
+  }
+  if (isPull) {
+    return {
+      ok: true,
+      repository: resolvedRepository,
+      resource: "pulls",
+      pullNumber: number,
+      issueNumber: null,
+      source: "dashboard_github_read_fast_path"
+    };
+  }
+  if (isIssue || !lower.includes("pr")) {
+    return {
+      ok: true,
+      repository: resolvedRepository,
+      resource: "issues",
+      issueNumber: number,
+      pullNumber: null,
+      source: "dashboard_github_read_fast_path"
+    };
+  }
+  return { ok: false, reason: "ambiguous GitHub read intent" };
+}
+
+function isDashboardNarrowStatusReadIntent(value) {
+  const text = sanitizeDashboardChatText(value);
+  if (!text) {
+    return false;
+  }
+  const lower = text.toLowerCase();
+  if (/\bGO\b/.test(text)) {
+    return false;
+  }
+  if (/(実装|修正|直して|作って|追加|削除|デプロイして|レビューして|レビュアー起動|テストして|調査して|探して|開発して)/.test(text)) {
+    return false;
+  }
+  if (/(merge\s+it|mergeして|マージして|deploy\s+it|deployして)/i.test(text)) {
+    return false;
+  }
+  const hasNumber = /#([1-9][0-9]*)/.test(text);
+  if (!hasNumber) {
+    return false;
+  }
+  return (
+    /\b(status|state|open|closed|merged|mergeable|checks?)\b/i.test(text) ||
+    /(状況|状態|どう|開いて|閉じて|マージ済み|マージされた|自動マージ|チェック|確認だけ|見るだけ|読んで|見て)/.test(text)
+  );
+}
+
+function buildDashboardGitHubReadFastPathReplyText({ intent, result } = {}) {
+  const resourceLabel = intent?.resource === "pulls" ? `PR #${intent.pullNumber}` : `Issue #${intent?.issueNumber || ""}`;
+  const scope = [
+    `対象 repo: ${intent?.repository || "未指定"}`,
+    `対象: ${resourceLabel}`,
+    "cost_boundary: github_read_plane_lightweight",
+    "codexWillStart: false"
+  ].join("\n");
+  if (!result?.ok) {
+    return [
+      "GitHub read plane の軽量 fast path で読み取りを試みましたが、取得できませんでした。Codex app-server / VPS Codex CLI は起動していません。",
+      "",
+      scope,
+      `status: failed`,
+      `reason: ${sanitizeDashboardChatText(result?.reason || result?.error || "GitHub read failed")}`,
+      "",
+      "次に進めるなら、repository / Issue / PR 番号を確認するか、明示的に調査を依頼してください。その場合は Codex usage を消費し得ます。"
+    ].join("\n");
+  }
+  if (intent?.blocked) {
+    return [
+      "GitHub read plane の軽量 fast path で止めました。Codex app-server / VPS Codex CLI は起動していません。",
+      "",
+      scope,
+      "status: blocked",
+      `reason: ${sanitizeDashboardChatText(intent.reason || "repository is required")}`,
+      "",
+      "repo 未指定の main chat では、対象 repository を推測しません。owner/repo を付けてもう一度送ると、GitHub read plane だけで確認できます。"
+    ].join("\n");
+  }
+  const record = Array.isArray(result.read?.records) ? result.read.records[0] : null;
+  if (!record) {
+    return [
+      "GitHub read plane の軽量 fast path で読みましたが、対象 record が見つかりませんでした。Codex app-server / VPS Codex CLI は起動していません。",
+      "",
+      scope,
+      "status: not_found"
+    ].join("\n");
+  }
+  if (intent.resource === "pulls") {
+    return buildDashboardPullReadFastPathReplyText({ scope, record });
+  }
+  return buildDashboardIssueReadFastPathReplyText({ scope, record });
+}
+
+function buildDashboardPullReadFastPathReplyText({ scope, record } = {}) {
+  const lines = [
+    "GitHub read plane の軽量 fast path で PR 状態を読みました。Codex app-server / VPS Codex CLI は起動していません。",
+    "",
+    scope,
+    `title: ${record.title || "未取得"}`,
+    `state: ${record.state || "unknown"}`,
+    `draft: ${record.draft === true ? "true" : "false"}`,
+    `merged: ${record.merged === true ? "true" : "false"}`,
+    record.mergedAt ? `mergedAt: ${record.mergedAt}` : "",
+    record.mergeCommitSha ? `mergeCommitSha: ${record.mergeCommitSha}` : "",
+    `head: ${record.headRef || "unknown"} ${record.headSha || ""}`.trim(),
+    `base: ${record.baseRef || "unknown"}`,
+    record.mergeableState ? `mergeableState: ${record.mergeableState}` : "",
+    record.mergeBlockedReason ? `mergeBlockedReason: ${record.mergeBlockedReason}` : "",
+    record.htmlUrl ? `source: ${record.htmlUrl}` : ""
+  ].filter(Boolean);
+  return lines.join("\n");
+}
+
+function buildDashboardIssueReadFastPathReplyText({ scope, record } = {}) {
+  return [
+    "GitHub read plane の軽量 fast path で Issue 状態を読みました。Codex app-server / VPS Codex CLI は起動していません。",
+    "",
+    scope,
+    `title: ${record.title || "未取得"}`,
+    `state: ${record.state || "unknown"}`,
+    record.author ? `author: ${record.author}` : "",
+    record.htmlUrl ? `source: ${record.htmlUrl}` : ""
+  ].filter(Boolean).join("\n");
 }
 
 function buildDashboardCostAwareFastPathMessages({

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -3672,6 +3672,106 @@ test("DashboardChatRoom answers cost-aware lightweight owner turns without start
   assert.match(reply.text, /codexWillStart: false/);
 });
 
+test("DashboardChatRoom answers PR status through GitHub read plane without starting app-server Codex", async () => {
+  const provider = createInMemoryMemoryProvider();
+  const store = createInMemoryDashboardChatStore();
+  const dashboardSocket = createMockSocket("dashboard", "dashboard-main-marushu-vtdd-v2-p");
+  const bridgeSocket = createMockSocket("app_server_bridge", "dashboard-main-marushu-vtdd-v2-p");
+  const fetchedUrls = [];
+  const room = new DashboardChatRoom(
+    {
+      storage: createMockDurableObjectStorage(),
+      getWebSockets() {
+        return [dashboardSocket, bridgeSocket];
+      }
+    },
+    {
+      DASHBOARD_CHAT_STORE: store,
+      MEMORY_PROVIDER: provider,
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_read",
+      GITHUB_API_FETCH: async (url) => {
+        fetchedUrls.push(String(url));
+        return new Response(
+          JSON.stringify({
+            number: 756,
+            title: "Issue #455 Dashboard の軽量 cost 相談で Codex を起動しない",
+            state: "closed",
+            draft: false,
+            merged: true,
+            merged_at: "2026-06-03T10:36:02Z",
+            merge_commit_sha: "ea831654cd00d06b2041a3f7c51ffb8dcaacf9fa",
+            head: {
+              ref: "issue-455-dashboard-cost-aware-fast-path",
+              sha: "f23938ed83b9ca79576bcdc020b7c0577a029d2a",
+              repo: { owner: { login: "marushu" } }
+            },
+            base: { ref: "main", sha: "base-sha" },
+            html_url: "https://github.com/marushu/vtdd-v2-p/pull/756"
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        );
+      }
+    }
+  );
+
+  await room.webSocketMessage(
+    dashboardSocket,
+    JSON.stringify({
+      type: "owner_message",
+      threadId: "dashboard-main-marushu-vtdd-v2-p",
+      repositoryInput: "marushu/vtdd-v2-p",
+      text: "PR #756 の状況を確認だけして"
+    })
+  );
+
+  assert.equal(bridgeSocket.sent.length, 0);
+  assert.equal(fetchedUrls.length, 1);
+  assert.match(fetchedUrls[0], /\/repos\/marushu\/vtdd-v2-p\/pulls\/756/);
+  const sentPayloads = dashboardSocket.sent.map((message) => JSON.parse(message));
+  const reply = sentPayloads.at(-1).messages.at(-1);
+  assert.equal(reply.role, "butler");
+  assert.equal(reply.status, "replied");
+  assert.match(reply.text, /GitHub read plane の軽量 fast path で PR 状態を読みました/);
+  assert.match(reply.text, /cost_boundary: github_read_plane_lightweight/);
+  assert.match(reply.text, /codexWillStart: false/);
+  assert.match(reply.text, /merged: true/);
+  assert.match(reply.text, /source: https:\/\/github.com\/marushu\/vtdd-v2-p\/pull\/756/);
+});
+
+test("DashboardChatRoom blocks repo-less PR status fast path without starting app-server Codex", async () => {
+  const provider = createInMemoryMemoryProvider();
+  const store = createInMemoryDashboardChatStore();
+  const dashboardSocket = createMockSocket("dashboard", "dashboard-main-unresolved");
+  const bridgeSocket = createMockSocket("app_server_bridge", "dashboard-main-unresolved");
+  const room = new DashboardChatRoom(
+    {
+      storage: createMockDurableObjectStorage(),
+      getWebSockets() {
+        return [dashboardSocket, bridgeSocket];
+      }
+    },
+    { DASHBOARD_CHAT_STORE: store, MEMORY_PROVIDER: provider }
+  );
+
+  await room.webSocketMessage(
+    dashboardSocket,
+    JSON.stringify({
+      type: "owner_message",
+      threadId: "dashboard-main-unresolved",
+      text: "PR #756 の状況を確認だけして"
+    })
+  );
+
+  assert.equal(bridgeSocket.sent.length, 0);
+  const sentPayloads = dashboardSocket.sent.map((message) => JSON.parse(message));
+  const reply = sentPayloads.at(-1).messages.at(-1);
+  assert.equal(reply.role, "butler");
+  assert.equal(reply.status, "replied");
+  assert.match(reply.text, /GitHub read plane の軽量 fast path で止めました/);
+  assert.match(reply.text, /reason: repository is required/);
+  assert.match(reply.text, /codexWillStart: false/);
+});
+
 test("DashboardChatRoom routes VPS maintenance owner turns to Worker proposal before app-server bridge", async () => {
   const provider = createInMemoryMemoryProvider();
   const store = createInMemoryDashboardChatStore();

--- a/worker.js
+++ b/worker.js
@@ -57742,6 +57742,15 @@ var DashboardChatRoom = class {
       now,
       origin
     });
+    const githubReadFastPathMessages = vpsMaintenanceMessages ? null : await buildDashboardGitHubReadFastPathMessages({
+      env: this.env,
+      threadId,
+      repository,
+      relatedIssue,
+      text,
+      mediaReferences: mediaValidation.mediaReferences,
+      now
+    });
     const costAwareFastPathMessages = vpsMaintenanceMessages ? null : buildDashboardCostAwareFastPathMessages({
       threadId,
       repository,
@@ -57756,6 +57765,17 @@ var DashboardChatRoom = class {
       await this.writeAcceptedOwnerMessage({ threadId, clientMessageId, messageId: ownerMessage.messageId, acceptedAt: now });
       if (vpsMaintenanceMessages) {
         const butlerMessages = store ? await store.appendMany(threadId, vpsMaintenanceMessages) : vpsMaintenanceMessages;
+        await this.broadcastThread({ threadId, messages: [...messages2, ...butlerMessages] });
+        this.sendSocket(socket, {
+          type: "owner_message_accepted",
+          ok: true,
+          clientMessageId,
+          messageId: ownerMessage.messageId
+        });
+        return;
+      }
+      if (githubReadFastPathMessages) {
+        const butlerMessages = store ? await store.appendMany(threadId, githubReadFastPathMessages) : githubReadFastPathMessages;
         await this.broadcastThread({ threadId, messages: [...messages2, ...butlerMessages] });
         this.sendSocket(socket, {
           type: "owner_message_accepted",
@@ -57806,6 +57826,11 @@ var DashboardChatRoom = class {
     });
     if (vpsMaintenanceMessages) {
       const butlerMessages = store ? await store.appendMany(threadId, vpsMaintenanceMessages) : vpsMaintenanceMessages;
+      await this.broadcastThread({ threadId, messages: [...messages, ...butlerMessages] });
+      return;
+    }
+    if (githubReadFastPathMessages) {
+      const butlerMessages = store ? await store.appendMany(threadId, githubReadFastPathMessages) : githubReadFastPathMessages;
       await this.broadcastThread({ threadId, messages: [...messages, ...butlerMessages] });
       return;
     }
@@ -65333,6 +65358,204 @@ function buildDashboardAppServerUsageTransientText({ text = "", repository = "",
     return `\u8EFD\u91CF\u76F8\u8AC7\u3068\u3057\u3066\u6271\u3048\u306A\u3044\u6587\u8108\u304C\u542B\u307E\u308C\u308B\u305F\u3081\u3001Codex app-server \u306B\u6E21\u3057\u307E\u3059\u3002Codex usage \u3092\u6D88\u8CBB\u3057\u5F97\u307E\u3059\u3002${scope}`;
   }
   return `Codex app-server \u306B\u6E21\u3057\u3066\u3044\u307E\u3059\u3002Codex usage \u3092\u6D88\u8CBB\u3057\u5F97\u307E\u3059\u3002${scope}`;
+}
+async function buildDashboardGitHubReadFastPathMessages({
+  env,
+  threadId,
+  repository = "",
+  relatedIssue = "",
+  text = "",
+  mediaReferences = [],
+  now = ""
+} = {}) {
+  const intent = parseDashboardGitHubReadFastPathIntent({ text, repository, relatedIssue, mediaReferences });
+  if (!intent.ok) {
+    return null;
+  }
+  let result;
+  if (intent.blocked) {
+    result = { ok: true, read: { records: [] } };
+  } else {
+    try {
+      result = await retrieveGitHubReadPlane({
+        resource: intent.resource,
+        repository: intent.repository,
+        issueNumber: intent.issueNumber,
+        pullNumber: intent.pullNumber,
+        limit: 1,
+        env
+      });
+    } catch (error2) {
+      result = {
+        ok: false,
+        error: "github_read_exception",
+        reason: normalizeText32(error2?.message) || "GitHub read threw"
+      };
+    }
+  }
+  const createdAt = normalizeIsoTimestamp(now) || (/* @__PURE__ */ new Date()).toISOString();
+  const message = normalizeDashboardChatMessage(
+    {
+      threadId,
+      role: "butler",
+      repository: intent.repository,
+      relatedIssue: intent.issueNumber || relatedIssue,
+      status: result?.ok ? "replied" : "failed",
+      messageId: `dashboard_butler_github_read_fast_path:${crypto.randomUUID()}`,
+      createdAt,
+      text: buildDashboardGitHubReadFastPathReplyText({ intent, result })
+    },
+    { threadId }
+  );
+  return message ? [message] : null;
+}
+function parseDashboardGitHubReadFastPathIntent({ text = "", repository = "", relatedIssue = "", mediaReferences = [] } = {}) {
+  if (Array.isArray(mediaReferences) && mediaReferences.length > 0) {
+    return { ok: false, reason: "media references require app-server context" };
+  }
+  const normalized = sanitizeDashboardChatText(text);
+  const resolvedRepository = normalizeCanonicalRepositoryInput(repository);
+  if (!normalized) {
+    return { ok: false, reason: "message text is required" };
+  }
+  if (!isDashboardNarrowStatusReadIntent(normalized)) {
+    return { ok: false, reason: "not a narrow status read intent" };
+  }
+  const number3 = extractIssueNumberFromDashboardChatText(normalized) || normalizePositiveInteger10(relatedIssue);
+  if (!number3) {
+    return { ok: false, reason: "issue or pull number is required" };
+  }
+  const lower = normalized.toLowerCase();
+  const isPull = /\b(pr|pull request|pull)\b/i.test(normalized) || normalized.includes("\u30D7\u30EB\u30EA\u30AF") || normalized.includes("PR");
+  const isIssue = /\bissue\b/i.test(normalized) || normalized.includes("Issue") || normalized.includes("\u30A4\u30B7\u30E5\u30FC");
+  if (!resolvedRepository) {
+    return {
+      ok: true,
+      blocked: true,
+      repository: "",
+      resource: isPull ? "pulls" : "issues",
+      pullNumber: isPull ? number3 : null,
+      issueNumber: isPull ? null : number3,
+      source: "dashboard_github_read_fast_path",
+      reason: "repository is required for GitHub read fast path"
+    };
+  }
+  if (isPull) {
+    return {
+      ok: true,
+      repository: resolvedRepository,
+      resource: "pulls",
+      pullNumber: number3,
+      issueNumber: null,
+      source: "dashboard_github_read_fast_path"
+    };
+  }
+  if (isIssue || !lower.includes("pr")) {
+    return {
+      ok: true,
+      repository: resolvedRepository,
+      resource: "issues",
+      issueNumber: number3,
+      pullNumber: null,
+      source: "dashboard_github_read_fast_path"
+    };
+  }
+  return { ok: false, reason: "ambiguous GitHub read intent" };
+}
+function isDashboardNarrowStatusReadIntent(value) {
+  const text = sanitizeDashboardChatText(value);
+  if (!text) {
+    return false;
+  }
+  const lower = text.toLowerCase();
+  if (/\bGO\b/.test(text)) {
+    return false;
+  }
+  if (/(実装|修正|直して|作って|追加|削除|デプロイして|レビューして|レビュアー起動|テストして|調査して|探して|開発して)/.test(text)) {
+    return false;
+  }
+  if (/(merge\s+it|mergeして|マージして|deploy\s+it|deployして)/i.test(text)) {
+    return false;
+  }
+  const hasNumber = /#([1-9][0-9]*)/.test(text);
+  if (!hasNumber) {
+    return false;
+  }
+  return /\b(status|state|open|closed|merged|mergeable|checks?)\b/i.test(text) || /(状況|状態|どう|開いて|閉じて|マージ済み|マージされた|自動マージ|チェック|確認だけ|見るだけ|読んで|見て)/.test(text);
+}
+function buildDashboardGitHubReadFastPathReplyText({ intent, result } = {}) {
+  const resourceLabel = intent?.resource === "pulls" ? `PR #${intent.pullNumber}` : `Issue #${intent?.issueNumber || ""}`;
+  const scope = [
+    `\u5BFE\u8C61 repo: ${intent?.repository || "\u672A\u6307\u5B9A"}`,
+    `\u5BFE\u8C61: ${resourceLabel}`,
+    "cost_boundary: github_read_plane_lightweight",
+    "codexWillStart: false"
+  ].join("\n");
+  if (!result?.ok) {
+    return [
+      "GitHub read plane \u306E\u8EFD\u91CF fast path \u3067\u8AAD\u307F\u53D6\u308A\u3092\u8A66\u307F\u307E\u3057\u305F\u304C\u3001\u53D6\u5F97\u3067\u304D\u307E\u305B\u3093\u3067\u3057\u305F\u3002Codex app-server / VPS Codex CLI \u306F\u8D77\u52D5\u3057\u3066\u3044\u307E\u305B\u3093\u3002",
+      "",
+      scope,
+      `status: failed`,
+      `reason: ${sanitizeDashboardChatText(result?.reason || result?.error || "GitHub read failed")}`,
+      "",
+      "\u6B21\u306B\u9032\u3081\u308B\u306A\u3089\u3001repository / Issue / PR \u756A\u53F7\u3092\u78BA\u8A8D\u3059\u308B\u304B\u3001\u660E\u793A\u7684\u306B\u8ABF\u67FB\u3092\u4F9D\u983C\u3057\u3066\u304F\u3060\u3055\u3044\u3002\u305D\u306E\u5834\u5408\u306F Codex usage \u3092\u6D88\u8CBB\u3057\u5F97\u307E\u3059\u3002"
+    ].join("\n");
+  }
+  if (intent?.blocked) {
+    return [
+      "GitHub read plane \u306E\u8EFD\u91CF fast path \u3067\u6B62\u3081\u307E\u3057\u305F\u3002Codex app-server / VPS Codex CLI \u306F\u8D77\u52D5\u3057\u3066\u3044\u307E\u305B\u3093\u3002",
+      "",
+      scope,
+      "status: blocked",
+      `reason: ${sanitizeDashboardChatText(intent.reason || "repository is required")}`,
+      "",
+      "repo \u672A\u6307\u5B9A\u306E main chat \u3067\u306F\u3001\u5BFE\u8C61 repository \u3092\u63A8\u6E2C\u3057\u307E\u305B\u3093\u3002owner/repo \u3092\u4ED8\u3051\u3066\u3082\u3046\u4E00\u5EA6\u9001\u308B\u3068\u3001GitHub read plane \u3060\u3051\u3067\u78BA\u8A8D\u3067\u304D\u307E\u3059\u3002"
+    ].join("\n");
+  }
+  const record2 = Array.isArray(result.read?.records) ? result.read.records[0] : null;
+  if (!record2) {
+    return [
+      "GitHub read plane \u306E\u8EFD\u91CF fast path \u3067\u8AAD\u307F\u307E\u3057\u305F\u304C\u3001\u5BFE\u8C61 record \u304C\u898B\u3064\u304B\u308A\u307E\u305B\u3093\u3067\u3057\u305F\u3002Codex app-server / VPS Codex CLI \u306F\u8D77\u52D5\u3057\u3066\u3044\u307E\u305B\u3093\u3002",
+      "",
+      scope,
+      "status: not_found"
+    ].join("\n");
+  }
+  if (intent.resource === "pulls") {
+    return buildDashboardPullReadFastPathReplyText({ scope, record: record2 });
+  }
+  return buildDashboardIssueReadFastPathReplyText({ scope, record: record2 });
+}
+function buildDashboardPullReadFastPathReplyText({ scope, record: record2 } = {}) {
+  const lines = [
+    "GitHub read plane \u306E\u8EFD\u91CF fast path \u3067 PR \u72B6\u614B\u3092\u8AAD\u307F\u307E\u3057\u305F\u3002Codex app-server / VPS Codex CLI \u306F\u8D77\u52D5\u3057\u3066\u3044\u307E\u305B\u3093\u3002",
+    "",
+    scope,
+    `title: ${record2.title || "\u672A\u53D6\u5F97"}`,
+    `state: ${record2.state || "unknown"}`,
+    `draft: ${record2.draft === true ? "true" : "false"}`,
+    `merged: ${record2.merged === true ? "true" : "false"}`,
+    record2.mergedAt ? `mergedAt: ${record2.mergedAt}` : "",
+    record2.mergeCommitSha ? `mergeCommitSha: ${record2.mergeCommitSha}` : "",
+    `head: ${record2.headRef || "unknown"} ${record2.headSha || ""}`.trim(),
+    `base: ${record2.baseRef || "unknown"}`,
+    record2.mergeableState ? `mergeableState: ${record2.mergeableState}` : "",
+    record2.mergeBlockedReason ? `mergeBlockedReason: ${record2.mergeBlockedReason}` : "",
+    record2.htmlUrl ? `source: ${record2.htmlUrl}` : ""
+  ].filter(Boolean);
+  return lines.join("\n");
+}
+function buildDashboardIssueReadFastPathReplyText({ scope, record: record2 } = {}) {
+  return [
+    "GitHub read plane \u306E\u8EFD\u91CF fast path \u3067 Issue \u72B6\u614B\u3092\u8AAD\u307F\u307E\u3057\u305F\u3002Codex app-server / VPS Codex CLI \u306F\u8D77\u52D5\u3057\u3066\u3044\u307E\u305B\u3093\u3002",
+    "",
+    scope,
+    `title: ${record2.title || "\u672A\u53D6\u5F97"}`,
+    `state: ${record2.state || "unknown"}`,
+    record2.author ? `author: ${record2.author}` : "",
+    record2.htmlUrl ? `source: ${record2.htmlUrl}` : ""
+  ].filter(Boolean).join("\n");
 }
 function buildDashboardCostAwareFastPathMessages({
   threadId,


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #455 の部分進捗です。Dashboard Butler の `PR #... 状況` / `Issue #... 状態` のような明白な status read を GitHub App-backed read plane で返し、Codex app-server / VPS Codex CLI を起動しない fast path を追加します。
- repo 未指定の main chat では repository を推測せず、Codex に逃がさず、`repository is required` を軽量返信として返します。

## Satisfied Success Criteria

- 軽量 read / status / dashboard 表示では Codex CLI を起動しない fast path の一部として、PR/Issue status read を GitHub read plane に接続しました。
- 重い処理前の cost visibility を維持しつつ、GitHub read fast path では `cost_boundary: github_read_plane_lightweight` と `codexWillStart=false` を owner-facing に返します。

## Unsatisfied Success Criteria

- dispatch / review / 修正 / re-review / merge 判断別の Codex 使用量可視化は未実装です。
- checks / workflow_runs / deploy / branch まで含む status read ladder は未実装です。
- 複数リポジトリ開発時の queue / throttle / defer 方針は未実装です。
- RAG への使用量削減結果の構造化保存は未実装です。
- Codex Analytics 実使用量の集計は未実装です。

## Non-goal violations

None.

## 開発前作戦図

- 作戦図 evidence: `docs/development-strategy/issue-455-dashboard-github-read-fast-path.md`
- 完了体験: Dashboard Butler で owner が PR/Issue 状況を自然文で確認した時、GitHub read plane の軽量返信が同じ chat に返り、Codex app-server は起動しません。
- VTDD 全体で進める部分: Issue #455 の status/read fast path を、既存 `retrieveGitHubReadPlane()` に接続する PR/Issue first slice です。
- 設計: DashboardChatRoom の owner_message 保存・ack 後、app-server dispatch 前に narrow GitHub read fast path を挟み、該当時は Butler message を保存して bridge dispatch を止めます。
- 仮説: 原因は、Dashboard chat の status/read 系 owner turn が bridge 接続時に app-server turn へ流れていることです。GitHub read plane は既に Worker から使えるため、明白な PR/Issue status read を Worker で処理すれば週間 Codex usage を削れます。
- 検証計画: PR status read は bridge へ送られず GitHub read plane だけで返ること、repo 未指定でも Codex に逃がさず blocked reply になること、ordinary/heavy turn は従来通り bridge に送られることを worker test で固定します。
- 改修見積もり: `src/worker/runtime.js` の DashboardChatRoom dispatch 前分類、`test/worker.test.js` の WebSocket/read-plane tests、generated `worker.js` を変更します。
- 既に通っている経路: `retrieveGitHubReadPlane()` は GitHub App-backed read plane として既存です。PR #756 では cost-only lightweight fast path が merge/deploy 済みです。
- 未確認の境界: checks / workflow_runs / deploy / branch の ladder と、repo-less main chat での自然な repository 解決 UI はこの PR では未実装です。
- 穴が出そうな箇所: `#123` だけでは Issue/PR が曖昧です。この PR は `PR` 語がある場合だけ pulls にし、それ以外は Issue read に寄せます。merge readiness judgment は扱いません。
- PR 前に確認すること: latest `origin/main` から topic branch を切ること、PR #756 の fast path と衝突しないこと、GitHub read plane route tests を壊さないこと。
- 実装候補と捨てた案: 採用は Worker entrypoint の narrow GitHub read fast path。捨てた案は app-server prompt だけで read plane 優先にする案です。app-server 起動後では Codex usage 削減になりません。
- merge 後に通す E2E: Dashboard live E2E として、`PR #756 の状況` を送り、GitHub read plane の短い status packet が返り、bridge へ `app_server_turn_requested` が出ないことを検証します。
- 次の PR を増やさない理由: この PR は PR/Issue first read に限定します。checks / deploy / branch ladder は後続 scope として残しますが、この PR に混ぜると merge readiness judgment まで膨らみます。
- 停止条件: repo truth を読んだふりになる、GitHub read failure を隠す、実装/merge/deploy/reviewer を誤って fast path する、または authority boundary を弱める場合は停止します。

## Dry-run Impact Report

- Target Issue: Issue #455
- Implementing Success Criteria: 軽量 read / status / dashboard 表示では Codex CLI を起動しない fast path の PR/Issue status read slice。
- Explicit Non-goals: 実装/修正/レビュー/merge/deploy の軽量化、Codex Analytics 集計、checks/deploy ladder、credential/permission mutation。
- Expected touched files/routes/workflows: `src/worker/runtime.js`, `worker.js`, `test/worker.test.js`, `docs/development-strategy/issue-455-dashboard-github-read-fast-path.md`
- Affected Issues: #455
- Affected PRs: PR #756 の cost fast path を前提にするのみ。変更はしません。
- Affected workflows: GitHub Actions / reviewer / deploy workflow は未変更です。
- Affected runtime/operator surfaces: Dashboard Butler WebSocket chat room / GitHub App-backed read plane。
- What may break if we patch narrowly: status read 判定が広すぎると、本来 app-server に渡すべき実装・調査・レビュー依頼を止める可能性があります。
- Unknowns to investigate before coding: checks / workflow_runs / deploy / branch ladder の次 slice、repo-less main chat の repository 確認 UI。
- Validation needed: worker build、worker test、generated-worker check、diff check。post-merge で本番 Dashboard E2E。
- Stop condition: heavy intent を誤って fast path する、GitHub read failure を隠す、または authority boundary を弱める場合。

## Execution Queue Delta

- Queue position before: Issue #455 は cost-aware Butler repair の `Now` / ROOT-class slice として扱います。
- Preemption decision: ROOT。週間 Codex usage を抑える土台の続きであり、UI 見た目より先に進める cost boundary です。
- Queue delta: Issue #455 の Dashboard GitHub read fast path を `Now` slice として進めます。Issue #455 全体は未完了として残します。
- Why this PR is next: PR #756 で cost 相談だけは止まりましたが、PR/Issue status read が app-server に落ちる大口が残っているためです。
- Active Issues not downscoped: Active Issues は縮小しません。この PR で扱わない #455 criteria と他 active Issues は未完了です。

## File / Line Hypotheses

- file: `src/worker/runtime.js`
  - hypothesis: DashboardChatRoom の app-server dispatch 前に GitHub read fast path を入れない限り、PR/Issue status read が Codex app-server turn へ流れる。
  - risk if changed narrowly: heavy intent を fast path に誤分類すると VTDD 実行が止まる。
  - validation: PR status read は `bridgeSocket.sent.length === 0`、ordinary/heavy turn は既存通り bridge dispatch。
  - related Issue: #455
- file: `test/worker.test.js`
  - hypothesis: WebSocket mock と `GITHUB_API_FETCH` mock で Codex 起動有無と GitHub read path を固定できる。
  - risk if changed narrowly: reply text だけ見て bridge dispatch を見落とす。
  - validation: fetched URL と bridge sent count の assertion。
  - related Issue: #455

## Hypothesis Retrospective

- expected: `PR #756 の状況` は GitHub read plane だけで返り、bridge に送られない。
- actual: `DashboardChatRoom answers PR status through GitHub read plane without starting app-server Codex` が追加され、GitHub pulls URL と `bridgeSocket.sent.length === 0` を確認しました。
- mismatch: repo-less main chat で対象 repo を推測する UI は未実装です。代わりに軽量 blocked reply を返します。
- lesson: GitHub read plane がある場合は app-server 起動前に narrow status read を止めるのが cost-effective です。
- should become RAG candidate: yes。PR/Issue status read は GitHub read plane fast path を優先し、Codex 起動前に止める。

## Verification Evidence

- Unit: `node --test test/worker.test.js` pass, 256 tests.
- Integration: DashboardChatRoom WebSocket test で PR status read / repo-less blocked read / ordinary app-server dispatch の分岐を確認しました。
- E2E: 未実施。merge/deploy 後に本番 Dashboard で bridge dispatch が出ないことを確認します。
- Manual: `npm run build:worker`, `npm run check:generated-worker`, `git diff --check` pass.
- Evidence path/link: `test/worker.test.js`, `docs/development-strategy/issue-455-dashboard-github-read-fast-path.md`

## Butler Completion Contract

- Primary owner surface: Dashboard Butler。
- Fallback surface: Custom GPT は明示された fallback surface として扱います。主経路ではありません。
- Owner goal: PR/Issue 状況確認だけで VPS Codex CLI / app-server usage が増えない入口を作る。
- Butler entrypoint: Dashboard Butler WebSocket owner_message。
- Dashboard Butler natural-language path: Dashboard Butler の通常チャット入口で、PR/Issue status read を自然文で受け、GitHub read plane 結果を同じ thread に返す経路です。
- Action Schema exposure: Custom GPT fallback 用 Action Schema は未変更です。
- Runtime path: `DashboardChatRoom.webSocketMessage` -> owner message 保存 -> GitHub read fast path -> app-server dispatch なし。
- Runner/runtime truth: fast path reply に `cost_boundary: github_read_plane_lightweight` と `codexWillStart=false` を表示します。
- Authority boundary: 未変更。merge/deploy/credential/permission/destructive work はこの PR では扱いません。
- E2E evidence: 未実施。Butler Completion Gate 上は incomplete です。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: worker runtime が変わるため merge 後に deploy が必要です。実行は passkey approval 後です。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: merge/deploy 後に必要です。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate
- AGENTS.md RAG Memory Capture and Cost Boundary
- AGENTS.md Change Size and PR Discipline
- docs/butler/intent-mode-contract.md Read mode / cost_boundary

## Out-of-scope but NOT implemented

- checks / workflow_runs / deploy / branch の lightweight ladder。
- repo-less main chat の自然な repository 確認 UI。
- Codex Analytics の実使用量集計。
- reviewer fallback 以外の重複 runner 抑止。

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #455
- Execution ID: dashboard-github-read-fast-path
- Goal: Dashboard PR/Issue status reads use GitHub read plane without starting app-server Codex.
