### PR TITLE
Issue #413 復帰可能な進行状態snapshotを追加

### DIFF
--- a/docs/development-strategy/issue-413-transient-progress-snapshot.md
+++ b/docs/development-strategy/issue-413-transient-progress-snapshot.md
@@ -1,0 +1,99 @@
+# Issue #413 / #590: transient progress snapshot
+
+## 完了体験
+
+owner が Dashboard Butler で長い app-server turn を待っている間に iPad をスリープしたり、別アプリへ移動したりしても、復帰後に「何も分からない」状態へ戻らない。
+
+Dashboard thread は通常チャット履歴を汚さず、最後に確認できた進行状態を 1 件だけ復元して表示する。完了返信、失敗、timeout recovery が来たら snapshot は消え、古い `考えています` が残り続けない。
+
+## VTDD 全体で進める部分
+
+- Issue #590: silent wait / timeout recovery の残りである owner-facing observability を進める。
+- Issue #413: owner-facing progress を chat history に積み上げず表示する。
+- Issue #748: `presence != persistence` の境界を守り、高頻度 durable write を避ける。
+
+## 設計
+
+`app_server_reply_delta` は引き続き durable chat message にしない。app-server bridge の status event、owner message dispatch、bridge reconnect のような owner-facing milestone だけを対象に、DashboardChatRoom Durable Object storage に thread ごとの compact snapshot を 1 件だけ保存する。
+
+snapshot は chat store / D1 / GitHub comment / RAG ではなく Durable Object storage の single key に限定する。保存対象は `threadId`, `status`, `text`, `updatedAt`, `source` のみ。raw delta、terminal log、chain-of-thought、full transcript は保存しない。
+
+## 仮説
+
+現状の復帰時に progress が消える原因は、`broadcastTransientStatus` が WebSocket へだけ送信し、`sendThread` と HTTP thread fetch が保存済み messages だけを返すため。
+
+`sendThread` と HTTP thread fetch に last snapshot を含め、UI が `transientProgressSnapshot` を読み込めば、iPad sleep / app switch 復帰時に generic な「返信待ち」ではなく最後に観測した進行状態を出せる。
+
+狭く `restoreThreadRecoveryState` だけを直すと、実際にどの stage だったかを失い、また「考えています」だけに戻る。逆に全 progress を durable message にすると #748 の cost incident を再発させる。
+
+## 検証計画
+
+- Unit: app-server status snapshot が thread WebSocket 初期 payload に含まれる。
+- Unit: app-server reply delta は snapshot に保存されない。
+- Unit: app-server final reply / failed / stalled で snapshot が消える。
+- Unit: 同じ snapshot の連続 status は storage put を増やさない。
+- UI static: HTTP refresh result の `transientProgressSnapshot` を `updateTransientProgress` へ渡す処理が存在する。
+- Verification: `npm run build:worker`、`node --test test/worker.test.js`、`npm run check:generated-worker`、`git diff --check`。
+
+## 改修見積もり
+
+- `src/worker/runtime.js`
+  - `DashboardChatRoom`: snapshot read/write/clear helper を追加する。risk は DO storage write count の増加。
+  - `broadcastTransientStatus`: opt-in snapshot 書き込みを追加する。risk は delta を誤って保存すること。
+  - `sendThread` / `broadcastThread`: payload に snapshot を追加する。risk は UI 互換。
+  - `handleDashboardChatThreadRequest`: HTTP refresh 用に snapshot を返す。risk は DO fetch 経由の追加 read。
+  - inline UI script: `refreshThread` と WebSocket `thread` handler が snapshot を復元する。risk は stale progress 表示。
+- `worker.js`: generated worker 更新。
+- `test/worker.test.js`: snapshot と UI static test を追加する。
+
+## 既に通っている経路
+
+- `app_server_reply_delta` は chat history へ保存されない。
+- 低情報 progress は durable chat history を汚染しない。
+- timeout / failed は owner-facing Japanese recovery message として thread に残る。
+- refreshThread は HTTP で thread messages を再取得できる。
+
+## 未確認の境界
+
+- production iPad の sleep / app switch で WebSocket が必ず切れるか、HTTP refresh だけになるかは端末依存。
+- Dashboard DO storage の single-key snapshot write が Cloudflare rowsWritten 上でどの程度増えるかは production metrics で確認が必要。
+- stop / interrupt / cancel の runtime signal はこの PR では未接続。
+
+## 穴が出そうな箇所
+
+- snapshot を reply delta から作ると raw partial answer が保存され、cost / privacy / readability が悪化する。
+- final reply 後に snapshot を消さないと stale spinner が残る。
+- HTTP refresh が snapshot を返さないと、visibilitychange 復帰で generic recovery に戻る。
+- unchanged snapshot の連続保存を許すと #748 の rowsWritten incident に近づく。
+
+## PR 前に確認すること
+
+- snapshot の保存は opt-in で、delta では呼ばれない。
+- final reply / failed / stalled で snapshot が clear される。
+- `thread` payload は後方互換の JSON field 追加のみ。
+- owner-facing prose は日本語。
+
+## 実装候補と捨てた案
+
+- 採用: single-key compact snapshot。復帰可能性と cost 境界のバランスが良い。
+- 捨てた案: progress を chat message として保存する。履歴汚染と rowsWritten 増加が大きい。
+- 捨てた案: client sessionStorage だけで保持する。iPad sleep / reload / WebSocket reconnect の復帰根拠にならない。
+- 捨てた案: app-server reply delta を snapshot にする。partial response と chain-of-thought 誤認の risk がある。
+
+## merge 後に通す E2E
+
+- production Dashboard Butler で長めの app-server turn を開始する。
+- app-server status が出た状態で iPad / Safari PWA を別アプリへ切り替える。
+- 復帰後、最後に確認できた進行状態が chat 近辺に復元されることを確認する。
+- final reply 後に stale progress が残らないことを確認する。
+
+## 次の PR を増やさない理由
+
+この PR は #590/#413 の owner-facing observability の最小単位で、#748 の cost 境界を壊さないために scope を snapshot 復帰に限定する。stop/interrupt、runner phase、deploy/reviewer 通知を同時に入れると、cost 境界と UX 設計が混ざる。
+
+## 停止条件
+
+- snapshot 保存が高頻度 delta から呼ばれることが判明した場合。
+- DO storage の unchanged put を避けられない場合。
+- HTTP refresh に snapshot を戻す経路が安全に作れない場合。
+- Issue #748 の `presence != persistence` 境界に反する変更が必要になった場合。

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -120,6 +120,22 @@ export class DashboardChatRoom {
       return json(202, { ok: true, threadId });
     }
 
+    if (request.method === "GET" && url.pathname === "/thread-state") {
+      const threadId = normalizeDashboardThreadId(url.searchParams.get("threadId") || url.searchParams.get("thread_id"));
+      if (!threadId) {
+        return json(422, {
+          ok: false,
+          error: "thread_id_required",
+          reason: "threadId is required"
+        });
+      }
+      return json(200, {
+        ok: true,
+        threadId,
+        transientProgressSnapshot: await this.readTransientProgressSnapshot(threadId)
+      });
+    }
+
     if (request.method === "POST" && url.pathname === "/runner-wakeup") {
       const payload = await readJson(request);
       const threadId = normalizeDashboardThreadId(payload.threadId || payload.thread_id);
@@ -423,7 +439,9 @@ export class DashboardChatRoom {
       await this.broadcastTransientStatus({
         threadId,
         text: "送信は保存済みです。app-server bridge の再接続後に同じ thread で続けられます。",
-        status: "pending_app_server_bridge"
+        status: "pending_app_server_bridge",
+        snapshot: true,
+        snapshotSource: "pending_app_server_bridge"
       });
       return;
     }
@@ -455,7 +473,9 @@ export class DashboardChatRoom {
     await this.broadcastTransientStatus({
       threadId,
       status: "thinking",
-      text: buildDashboardAppServerUsageTransientText({ text, repository, relatedIssue })
+      text: buildDashboardAppServerUsageTransientText({ text, repository, relatedIssue }),
+      snapshot: true,
+      snapshotSource: "owner_message_dispatch"
     });
     await this.dispatchOwnerMessageToAppServerBridge({
       threadId,
@@ -563,11 +583,16 @@ export class DashboardChatRoom {
         updatedAt: normalized.createdAt
       });
     }
+    if (normalized.transientStatus === "replied") {
+      await this.clearTransientProgressSnapshot(normalized.threadId);
+    }
     if (normalized.transientStatus) {
       await this.broadcastTransientStatus({
         threadId: normalized.threadId,
         status: normalized.transientStatus,
-        text: normalized.transientText || normalized.text
+        text: normalized.transientText || normalized.text,
+        snapshot: normalized.snapshotTransientStatus === true,
+        snapshotSource: normalized.snapshotSource
       });
     }
     if (normalized.messages.length === 0) {
@@ -585,16 +610,21 @@ export class DashboardChatRoom {
     const messages = store
       ? await store.appendMany(normalized.threadId, messagesToAppend)
       : messagesToAppend;
+    if (messagesToAppend.some((message) => shouldClearDashboardTransientProgressSnapshot(message))) {
+      await this.clearTransientProgressSnapshot(normalized.threadId);
+    }
     await this.broadcastThread({ threadId: normalized.threadId, messages });
   }
 
   async broadcastThread({ threadId, messages = null }) {
     const resolvedMessages = Array.isArray(messages) ? messages : await this.listThreadMessages(threadId);
+    const transientProgressSnapshot = await this.readTransientProgressSnapshot(threadId);
     const payload = JSON.stringify({
       type: "thread",
       ok: true,
       threadId,
-      messages: resolvedMessages
+      messages: resolvedMessages,
+      transientProgressSnapshot
     });
     for (const socket of this.connectedSockets()) {
       const attachment = this.getSocketAttachment(socket);
@@ -609,7 +639,15 @@ export class DashboardChatRoom {
     }
   }
 
-  async broadcastTransientStatus({ threadId, status, text }) {
+  async broadcastTransientStatus({ threadId, status, text, snapshot = false, snapshotSource = "" }) {
+    if (snapshot === true) {
+      await this.writeTransientProgressSnapshot({
+        threadId,
+        status,
+        text,
+        source: snapshotSource
+      });
+    }
     const payload = JSON.stringify({
       type: "transient_status",
       ok: true,
@@ -633,12 +671,14 @@ export class DashboardChatRoom {
   async sendThread(socket, threadId) {
     if (!isSocketOpen(socket)) return;
     try {
+      const transientProgressSnapshot = await this.readTransientProgressSnapshot(threadId);
       socket.send(
         JSON.stringify({
           type: "thread",
           ok: true,
           threadId,
-          messages: await this.listThreadMessages(threadId)
+          messages: await this.listThreadMessages(threadId),
+          transientProgressSnapshot
         })
       );
     } catch (error) {
@@ -660,6 +700,61 @@ export class DashboardChatRoom {
       return [];
     }
     return store.listThread(threadId, { limit: 80 });
+  }
+
+  transientProgressSnapshotKey(threadId) {
+    const normalizedThreadId = normalizeDashboardThreadId(threadId);
+    return normalizedThreadId ? `transient_progress_snapshot:${normalizedThreadId}` : "";
+  }
+
+  async readTransientProgressSnapshot(threadId) {
+    const key = this.transientProgressSnapshotKey(threadId);
+    if (!key || typeof this.ctx?.storage?.get !== "function") {
+      return null;
+    }
+    const snapshot = await this.ctx.storage.get(key);
+    return normalizeDashboardTransientProgressSnapshot(snapshot);
+  }
+
+  async writeTransientProgressSnapshot({ threadId, status = "", text = "", source = "" } = {}) {
+    const key = this.transientProgressSnapshotKey(threadId);
+    const normalized = normalizeDashboardTransientProgressSnapshot({
+      threadId,
+      status,
+      text,
+      source,
+      updatedAt: new Date().toISOString()
+    });
+    if (!key || !normalized || typeof this.ctx?.storage?.put !== "function") {
+      return false;
+    }
+    const previous = await this.readTransientProgressSnapshot(threadId);
+    if (
+      previous &&
+      previous.status === normalized.status &&
+      previous.text === normalized.text &&
+      previous.source === normalized.source
+    ) {
+      return false;
+    }
+    await this.ctx.storage.put(key, normalized);
+    return true;
+  }
+
+  async clearTransientProgressSnapshot(threadId) {
+    const key = this.transientProgressSnapshotKey(threadId);
+    if (!key || !this.ctx?.storage) {
+      return false;
+    }
+    if (typeof this.ctx.storage.delete === "function") {
+      await this.ctx.storage.delete(key);
+      return true;
+    }
+    if (typeof this.ctx.storage.put === "function") {
+      await this.ctx.storage.put(key, null);
+      return true;
+    }
+    return false;
   }
 
   connectedSockets() {
@@ -850,7 +945,9 @@ export class DashboardChatRoom {
       await this.broadcastTransientStatus({
         threadId: normalizedThreadId,
         status: "thinking",
-        text: "接続しました。保存済みの送信を app-server bridge に渡しました。"
+        text: "接続しました。保存済みの送信を app-server bridge に渡しました。",
+        snapshot: true,
+        snapshotSource: "pending_app_server_bridge_drained"
       });
     }
     return { ok: true, drained, remaining: remaining.length };
@@ -6232,12 +6329,39 @@ async function handleDashboardChatThreadRequest(request, url, env) {
   });
   const summary =
     typeof store.getSummary === "function" ? await store.getSummary(threadId) : null;
+  const transientProgressSnapshot = await readDashboardChatRoomTransientProgressSnapshot({
+    env,
+    threadId,
+    origin: url.origin
+  });
   return json(200, {
     ok: true,
     threadId,
     messages,
-    summary
+    summary,
+    transientProgressSnapshot
   });
+}
+
+async function readDashboardChatRoomTransientProgressSnapshot({ env, threadId, origin = "" } = {}) {
+  const normalizedThreadId = normalizeDashboardThreadId(threadId);
+  if (!normalizedThreadId) {
+    return null;
+  }
+  const room = resolveDashboardChatRoomStub(env, normalizedThreadId);
+  if (!room || typeof room.fetch !== "function") {
+    return null;
+  }
+  try {
+    const baseOrigin = normalizeText(origin) || normalizeText(env?.VTDD_RUNTIME_URL) || "https://dashboard-butler.local";
+    const url = new URL("/thread-state", baseOrigin);
+    url.searchParams.set("threadId", normalizedThreadId);
+    const response = await room.fetch(new Request(url.toString(), { method: "GET" }));
+    const body = await response.json().catch(() => ({}));
+    return body?.ok ? normalizeDashboardTransientProgressSnapshot(body.transientProgressSnapshot) : null;
+  } catch {
+    return null;
+  }
 }
 
 async function handleDashboardChatSearchRequest(request, url, env) {
@@ -8884,6 +9008,8 @@ function normalizeDashboardAppServerBridgeEvent(payload, { fallbackThreadId = ""
   const createdAt = normalizeIsoTimestamp(input.createdAt) || new Date().toISOString();
   const messages = [];
   let transientStatus = "";
+  let snapshotTransientStatus = false;
+  let snapshotSource = "";
   if (eventType === "app_server_reply_delta") {
     // Streaming deltas are transient progress, not durable chat messages.
     transientStatus = "thinking";
@@ -8937,6 +9063,8 @@ function normalizeDashboardAppServerBridgeEvent(payload, { fallbackThreadId = ""
       text,
       transientStatus
     });
+    snapshotTransientStatus = transientStatus === "thinking";
+    snapshotSource = "app_server_status";
     if (shouldPersistDashboardAppServerProgress(input, { transientStatus })) {
       messages.push(
         normalizeDashboardChatMessage(
@@ -8962,8 +9090,46 @@ function normalizeDashboardAppServerBridgeEvent(payload, { fallbackThreadId = ""
     text,
     transientText,
     transientStatus,
+    snapshotTransientStatus,
+    snapshotSource,
     messages: messages.filter(Boolean)
   };
+}
+
+function normalizeDashboardTransientProgressSnapshot(value) {
+  const input = normalizeObject(value);
+  const threadId = normalizeDashboardThreadId(input.threadId || input.thread_id);
+  const status = normalizeDashboardChatStatus(input.status);
+  const text = sanitizeDashboardChatText(input.text);
+  if (!threadId || !text || !isDashboardSnapshotTransientStatus(status)) {
+    return null;
+  }
+  return {
+    threadId,
+    status,
+    text,
+    source: sanitizeDashboardChatText(input.source || ""),
+    updatedAt: normalizeIsoTimestamp(input.updatedAt || input.updated_at) || new Date().toISOString()
+  };
+}
+
+function isDashboardSnapshotTransientStatus(status) {
+  return [
+    "thinking",
+    "pending_app_server_bridge",
+    "waiting_approval",
+    "waiting_user_input"
+  ].includes(normalizeDashboardChatStatus(status));
+}
+
+function shouldClearDashboardTransientProgressSnapshot(message) {
+  const role = normalizeDashboardEventText(message?.role).toLowerCase();
+  const status = normalizeDashboardChatStatus(message?.status);
+  return (
+    (role === "butler" && status === "replied") ||
+    status === "failed" ||
+    status === "stalled"
+  );
 }
 
 function buildDashboardAppServerFailureThreadText({ text = "", status = "" } = {}) {
@@ -15730,6 +15896,20 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         }
       }
 
+      function restoreTransientProgressSnapshot(snapshot) {
+        if (!snapshot || typeof snapshot !== "object") return false;
+        const text = String(snapshot.text || "").trim();
+        const statusValue = String(snapshot.status || "").trim();
+        if (!text || !isLongRunningTransientStatus(statusValue)) return false;
+        updateTransientProgress(text, {
+          status: statusValue,
+          thinking: statusValue === "thinking" || statusValue === "pending_app_server_bridge",
+          title: statusValue === "pending_app_server_bridge" ? "返信待ち" : "進行中"
+        });
+        setStatus(text, { thinking: true });
+        return true;
+      }
+
       function normalizeMessageId(value) {
         const id = String(value || "").trim();
         return id || "";
@@ -16586,7 +16766,9 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
             lastRefreshFailure = "";
             renderThread(body.messages || [], { replace: true });
             releasePendingOwnerSendFromThread(body.messages || []);
-            restoreThreadRecoveryState(body.messages || []);
+            if (!restoreTransientProgressSnapshot(body.transientProgressSnapshot)) {
+              restoreThreadRecoveryState(body.messages || []);
+            }
             status.dataset.websocketState = describeChatSocketState();
             return { ok: true };
           }
@@ -16643,6 +16825,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
             const body = JSON.parse(event.data || "{}");
             if (body.type === "thread" && body.ok) {
               renderThread(body.messages || [], { replace: false });
+              restoreTransientProgressSnapshot(body.transientProgressSnapshot);
               const releasedFromThread = releasePendingOwnerSendFromThread(body.messages || []);
               const lastMessage = Array.isArray(body.messages) ? body.messages[body.messages.length - 1] : null;
               if (lastMessage?.role === "butler" && lastMessage?.status === "replied") {

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -695,15 +695,21 @@ function createMockDashboardChatRoomNamespace() {
 function createMockDurableObjectStorage() {
   const values = new Map();
   const putCalls = [];
+  const deleteCalls = [];
   return {
     values,
     putCalls,
+    deleteCalls,
     async get(key) {
       return values.get(key);
     },
     async put(key, value) {
       putCalls.push({ key, value });
       values.set(key, value);
+    },
+    async delete(key) {
+      deleteCalls.push({ key });
+      values.delete(key);
     }
   };
 }
@@ -1368,10 +1374,13 @@ test("worker serves v2 dashboard for allowed owner identity without exposing sec
   assert.equal(body.includes("function releaseComposerForFollowUp("), true);
   assert.equal(body.includes("このまま同じ thread に追加メッセージを送れます。"), true);
   assert.equal(body.includes("function restoreThreadRecoveryState(messages)"), true);
+  assert.equal(body.includes("function restoreTransientProgressSnapshot(snapshot)"), true);
   assert.equal(body.includes("送信済みです。app-server bridge の返信を待っています。復帰中なら同じ thread で再接続します。"), true);
   assert.equal(body.includes('status: "pending_app_server_bridge"'), true);
   assert.equal(body.includes('title: "返信待ち"'), true);
+  assert.equal(body.includes("if (!restoreTransientProgressSnapshot(body.transientProgressSnapshot))"), true);
   assert.equal(body.includes("restoreThreadRecoveryState(body.messages || []);"), true);
+  assert.equal(body.includes("restoreTransientProgressSnapshot(body.transientProgressSnapshot);"), true);
   assert.equal(body.includes("function withPendingSendRecoveryInstruction("), true);
   assert.equal(body.includes("送信保存を確認中のため入力欄は保持しています。確認後に同じ thread へ追加できます。"), true);
   assert.equal(body.includes('body.status === "stalled"'), true);
@@ -3370,6 +3379,67 @@ test("worker requires WebSocket upgrade for dashboard chat live updates", async 
   assert.equal(rooms.calls.length, 0);
 });
 
+test("worker includes DashboardChatRoom transient progress snapshot in chat thread refresh", async () => {
+  const store = createInMemoryDashboardChatStore();
+  await store.appendMany("dashboard-main-unresolved", [
+    {
+      threadId: "dashboard-main-unresolved",
+      role: "owner",
+      repository: "",
+      relatedIssue: null,
+      status: "sent",
+      text: "長めの作業を進めて",
+      createdAt: "2026-06-03T00:00:00.000Z"
+    }
+  ]);
+  const calls = [];
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/dashboard/chat/dashboard-main-unresolved", {
+      headers: dashboardAccessHeaders
+    }),
+    {
+      ...dashboardAccessEnv,
+      DASHBOARD_CHAT_STORE: store,
+      DASHBOARD_CHAT_ROOMS: {
+        getByName(name) {
+          return {
+            async fetch(input) {
+              calls.push({ name, input });
+              return new Response(JSON.stringify({
+                ok: true,
+                threadId: "dashboard-main-unresolved",
+                transientProgressSnapshot: {
+                  threadId: "dashboard-main-unresolved",
+                  status: "thinking",
+                  text: "テストを実行しています。",
+                  source: "app_server_status",
+                  updatedAt: "2026-06-03T00:00:02.000Z"
+                }
+              }), {
+                headers: { "content-type": "application/json" }
+              });
+            }
+          };
+        }
+      }
+    }
+  );
+
+  assert.equal(response.status, 200);
+  const body = await response.json();
+  assert.equal(body.ok, true);
+  assert.equal(body.messages.length, 1);
+  assert.deepEqual(body.transientProgressSnapshot, {
+    threadId: "dashboard-main-unresolved",
+    status: "thinking",
+    text: "テストを実行しています。",
+    source: "app_server_status",
+    updatedAt: "2026-06-03T00:00:02.000Z"
+  });
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].name, "dashboard-main-unresolved");
+});
+
 test("DashboardChatRoom accepts dashboard WebSocket upgrade with request origin attachment", async () => {
   const originalWebSocketPair = globalThis.WebSocketPair;
   const OriginalResponse = globalThis.Response;
@@ -4525,6 +4595,155 @@ test("DashboardChatRoom sends app-server thinking status as transient UI state",
   assert.equal(status.type, "transient_status");
   assert.equal(status.status, "thinking");
   assert.equal(status.text, "codex app-server が応答を生成しています。");
+});
+
+test("DashboardChatRoom exposes last app-server status snapshot on thread reconnect", async () => {
+  const store = createInMemoryDashboardChatStore();
+  const dashboardSocket = createMockSocket("dashboard", "dashboard-main-unresolved");
+  const reconnectSocket = createMockSocket("dashboard", "dashboard-main-unresolved");
+  const bridgeSocket = createMockSocket("app_server_bridge", "dashboard-main-unresolved");
+  const storage = createMockDurableObjectStorage();
+  const room = new DashboardChatRoom(
+    {
+      storage,
+      getWebSockets() {
+        return [dashboardSocket, bridgeSocket];
+      }
+    },
+    { DASHBOARD_CHAT_STORE: store }
+  );
+
+  await room.webSocketMessage(
+    bridgeSocket,
+    JSON.stringify({
+      type: "app_server_status",
+      status: "thinking",
+      stage: "planning",
+      threadId: "dashboard-main-unresolved",
+      codexThreadId: "codex-thread-450",
+      text: "raw plan detail"
+    })
+  );
+
+  const snapshot = storage.values.get("transient_progress_snapshot:dashboard-main-unresolved");
+  assert.equal(snapshot.status, "thinking");
+  assert.equal(snapshot.text, "方針を整理しています。");
+  assert.equal(snapshot.source, "app_server_status");
+  assert.equal((await store.listThread("dashboard-main-unresolved")).length, 0);
+
+  await room.sendThread(reconnectSocket, "dashboard-main-unresolved");
+
+  const payload = JSON.parse(reconnectSocket.sent[0]);
+  assert.equal(payload.type, "thread");
+  assert.equal(payload.messages.length, 0);
+  assert.deepEqual(payload.transientProgressSnapshot, snapshot);
+});
+
+test("DashboardChatRoom keeps app-server reply deltas out of progress snapshots", async () => {
+  const store = createInMemoryDashboardChatStore();
+  const dashboardSocket = createMockSocket("dashboard", "dashboard-main-unresolved");
+  const bridgeSocket = createMockSocket("app_server_bridge", "dashboard-main-unresolved");
+  const storage = createMockDurableObjectStorage();
+  const room = new DashboardChatRoom(
+    {
+      storage,
+      getWebSockets() {
+        return [dashboardSocket, bridgeSocket];
+      }
+    },
+    { DASHBOARD_CHAT_STORE: store }
+  );
+
+  await room.webSocketMessage(
+    bridgeSocket,
+    JSON.stringify({
+      type: "app_server_reply_delta",
+      threadId: "dashboard-main-unresolved",
+      codexThreadId: "codex-thread-450",
+      delta: "途中の返答断片"
+    })
+  );
+
+  assert.equal(storage.values.has("transient_progress_snapshot:dashboard-main-unresolved"), false);
+  assert.equal(storage.putCalls.some((call) => call.key === "transient_progress_snapshot:dashboard-main-unresolved"), false);
+  assert.equal((await store.listThread("dashboard-main-unresolved")).length, 0);
+});
+
+test("DashboardChatRoom dedupes unchanged transient progress snapshot writes", async () => {
+  const store = createInMemoryDashboardChatStore();
+  const dashboardSocket = createMockSocket("dashboard", "dashboard-main-unresolved");
+  const bridgeSocket = createMockSocket("app_server_bridge", "dashboard-main-unresolved");
+  const storage = createMockDurableObjectStorage();
+  const room = new DashboardChatRoom(
+    {
+      storage,
+      getWebSockets() {
+        return [dashboardSocket, bridgeSocket];
+      }
+    },
+    { DASHBOARD_CHAT_STORE: store }
+  );
+  const event = {
+    type: "app_server_status",
+    status: "thinking",
+    stage: "command",
+    threadId: "dashboard-main-unresolved",
+    codexThreadId: "codex-thread-450",
+    text: "raw command detail"
+  };
+
+  await room.webSocketMessage(bridgeSocket, JSON.stringify(event));
+  await room.webSocketMessage(bridgeSocket, JSON.stringify(event));
+
+  const snapshotPuts = storage.putCalls.filter((call) => call.key === "transient_progress_snapshot:dashboard-main-unresolved");
+  assert.equal(snapshotPuts.length, 1);
+  assert.equal(snapshotPuts[0].value.text, "コマンドを実行しています。");
+  assert.equal(dashboardSocket.sent.map((message) => JSON.parse(message)).filter((message) => message.type === "transient_status").length, 2);
+});
+
+test("DashboardChatRoom clears transient progress snapshot after final reply", async () => {
+  const store = createInMemoryDashboardChatStore();
+  const dashboardSocket = createMockSocket("dashboard", "dashboard-main-unresolved");
+  const bridgeSocket = createMockSocket("app_server_bridge", "dashboard-main-unresolved");
+  const storage = createMockDurableObjectStorage();
+  const room = new DashboardChatRoom(
+    {
+      storage,
+      getWebSockets() {
+        return [dashboardSocket, bridgeSocket];
+      }
+    },
+    { DASHBOARD_CHAT_STORE: store }
+  );
+
+  await room.webSocketMessage(
+    bridgeSocket,
+    JSON.stringify({
+      type: "app_server_status",
+      status: "thinking",
+      stage: "test",
+      threadId: "dashboard-main-unresolved",
+      codexThreadId: "codex-thread-450",
+      text: "raw test detail"
+    })
+  );
+  assert.equal(storage.values.get("transient_progress_snapshot:dashboard-main-unresolved").text, "テストを実行しています。");
+
+  await room.webSocketMessage(
+    bridgeSocket,
+    JSON.stringify({
+      type: "app_server_reply",
+      threadId: "dashboard-main-unresolved",
+      codexThreadId: "codex-thread-450",
+      text: "検証が終わりました。"
+    })
+  );
+
+  assert.equal(storage.values.has("transient_progress_snapshot:dashboard-main-unresolved"), false);
+  assert.equal(storage.deleteCalls.filter((call) => call.key === "transient_progress_snapshot:dashboard-main-unresolved").length >= 1, true);
+  const threadPayloads = dashboardSocket.sent.map((message) => JSON.parse(message)).filter((message) => message.type === "thread");
+  assert.equal(threadPayloads.at(-1).transientProgressSnapshot, null);
+  assert.equal((await store.listThread("dashboard-main-unresolved")).at(-1).text, "検証が終わりました。");
 });
 
 test("DashboardChatRoom keeps generic opt-in app-server progress transient-only", async () => {

--- a/worker.js
+++ b/worker.js
@@ -57530,6 +57530,21 @@ var DashboardChatRoom = class {
       });
       return json(202, { ok: true, threadId: threadId2 });
     }
+    if (request.method === "GET" && url.pathname === "/thread-state") {
+      const threadId2 = normalizeDashboardThreadId(url.searchParams.get("threadId") || url.searchParams.get("thread_id"));
+      if (!threadId2) {
+        return json(422, {
+          ok: false,
+          error: "thread_id_required",
+          reason: "threadId is required"
+        });
+      }
+      return json(200, {
+        ok: true,
+        threadId: threadId2,
+        transientProgressSnapshot: await this.readTransientProgressSnapshot(threadId2)
+      });
+    }
     if (request.method === "POST" && url.pathname === "/runner-wakeup") {
       const payload = await readJson(request);
       const threadId2 = normalizeDashboardThreadId(payload.threadId || payload.thread_id);
@@ -57811,7 +57826,9 @@ var DashboardChatRoom = class {
       await this.broadcastTransientStatus({
         threadId,
         text: "\u9001\u4FE1\u306F\u4FDD\u5B58\u6E08\u307F\u3067\u3059\u3002app-server bridge \u306E\u518D\u63A5\u7D9A\u5F8C\u306B\u540C\u3058 thread \u3067\u7D9A\u3051\u3089\u308C\u307E\u3059\u3002",
-        status: "pending_app_server_bridge"
+        status: "pending_app_server_bridge",
+        snapshot: true,
+        snapshotSource: "pending_app_server_bridge"
       });
       return;
     }
@@ -57842,7 +57859,9 @@ var DashboardChatRoom = class {
     await this.broadcastTransientStatus({
       threadId,
       status: "thinking",
-      text: buildDashboardAppServerUsageTransientText({ text, repository, relatedIssue })
+      text: buildDashboardAppServerUsageTransientText({ text, repository, relatedIssue }),
+      snapshot: true,
+      snapshotSource: "owner_message_dispatch"
     });
     await this.dispatchOwnerMessageToAppServerBridge({
       threadId,
@@ -57947,11 +57966,16 @@ var DashboardChatRoom = class {
         updatedAt: normalized.createdAt
       });
     }
+    if (normalized.transientStatus === "replied") {
+      await this.clearTransientProgressSnapshot(normalized.threadId);
+    }
     if (normalized.transientStatus) {
       await this.broadcastTransientStatus({
         threadId: normalized.threadId,
         status: normalized.transientStatus,
-        text: normalized.transientText || normalized.text
+        text: normalized.transientText || normalized.text,
+        snapshot: normalized.snapshotTransientStatus === true,
+        snapshotSource: normalized.snapshotSource
       });
     }
     if (normalized.messages.length === 0) {
@@ -57967,15 +57991,20 @@ var DashboardChatRoom = class {
       return;
     }
     const messages = store ? await store.appendMany(normalized.threadId, messagesToAppend) : messagesToAppend;
+    if (messagesToAppend.some((message) => shouldClearDashboardTransientProgressSnapshot(message))) {
+      await this.clearTransientProgressSnapshot(normalized.threadId);
+    }
     await this.broadcastThread({ threadId: normalized.threadId, messages });
   }
   async broadcastThread({ threadId, messages = null }) {
     const resolvedMessages = Array.isArray(messages) ? messages : await this.listThreadMessages(threadId);
+    const transientProgressSnapshot = await this.readTransientProgressSnapshot(threadId);
     const payload = JSON.stringify({
       type: "thread",
       ok: true,
       threadId,
-      messages: resolvedMessages
+      messages: resolvedMessages,
+      transientProgressSnapshot
     });
     for (const socket of this.connectedSockets()) {
       const attachment = this.getSocketAttachment(socket);
@@ -57984,7 +58013,15 @@ var DashboardChatRoom = class {
       }
     }
   }
-  async broadcastTransientStatus({ threadId, status, text }) {
+  async broadcastTransientStatus({ threadId, status, text, snapshot = false, snapshotSource = "" }) {
+    if (snapshot === true) {
+      await this.writeTransientProgressSnapshot({
+        threadId,
+        status,
+        text,
+        source: snapshotSource
+      });
+    }
     const payload = JSON.stringify({
       type: "transient_status",
       ok: true,
@@ -58002,12 +58039,14 @@ var DashboardChatRoom = class {
   async sendThread(socket, threadId) {
     if (!isSocketOpen(socket)) return;
     try {
+      const transientProgressSnapshot = await this.readTransientProgressSnapshot(threadId);
       socket.send(
         JSON.stringify({
           type: "thread",
           ok: true,
           threadId,
-          messages: await this.listThreadMessages(threadId)
+          messages: await this.listThreadMessages(threadId),
+          transientProgressSnapshot
         })
       );
     } catch (error2) {
@@ -58028,6 +58067,52 @@ var DashboardChatRoom = class {
       return [];
     }
     return store.listThread(threadId, { limit: 80 });
+  }
+  transientProgressSnapshotKey(threadId) {
+    const normalizedThreadId = normalizeDashboardThreadId(threadId);
+    return normalizedThreadId ? `transient_progress_snapshot:${normalizedThreadId}` : "";
+  }
+  async readTransientProgressSnapshot(threadId) {
+    const key = this.transientProgressSnapshotKey(threadId);
+    if (!key || typeof this.ctx?.storage?.get !== "function") {
+      return null;
+    }
+    const snapshot = await this.ctx.storage.get(key);
+    return normalizeDashboardTransientProgressSnapshot(snapshot);
+  }
+  async writeTransientProgressSnapshot({ threadId, status = "", text = "", source = "" } = {}) {
+    const key = this.transientProgressSnapshotKey(threadId);
+    const normalized = normalizeDashboardTransientProgressSnapshot({
+      threadId,
+      status,
+      text,
+      source,
+      updatedAt: (/* @__PURE__ */ new Date()).toISOString()
+    });
+    if (!key || !normalized || typeof this.ctx?.storage?.put !== "function") {
+      return false;
+    }
+    const previous = await this.readTransientProgressSnapshot(threadId);
+    if (previous && previous.status === normalized.status && previous.text === normalized.text && previous.source === normalized.source) {
+      return false;
+    }
+    await this.ctx.storage.put(key, normalized);
+    return true;
+  }
+  async clearTransientProgressSnapshot(threadId) {
+    const key = this.transientProgressSnapshotKey(threadId);
+    if (!key || !this.ctx?.storage) {
+      return false;
+    }
+    if (typeof this.ctx.storage.delete === "function") {
+      await this.ctx.storage.delete(key);
+      return true;
+    }
+    if (typeof this.ctx.storage.put === "function") {
+      await this.ctx.storage.put(key, null);
+      return true;
+    }
+    return false;
   }
   connectedSockets() {
     if (typeof this.ctx?.getWebSockets === "function") {
@@ -58199,7 +58284,9 @@ var DashboardChatRoom = class {
       await this.broadcastTransientStatus({
         threadId: normalizedThreadId,
         status: "thinking",
-        text: "\u63A5\u7D9A\u3057\u307E\u3057\u305F\u3002\u4FDD\u5B58\u6E08\u307F\u306E\u9001\u4FE1\u3092 app-server bridge \u306B\u6E21\u3057\u307E\u3057\u305F\u3002"
+        text: "\u63A5\u7D9A\u3057\u307E\u3057\u305F\u3002\u4FDD\u5B58\u6E08\u307F\u306E\u9001\u4FE1\u3092 app-server bridge \u306B\u6E21\u3057\u307E\u3057\u305F\u3002",
+        snapshot: true,
+        snapshotSource: "pending_app_server_bridge_drained"
       });
     }
     return { ok: true, drained, remaining: remaining.length };
@@ -62976,12 +63063,38 @@ async function handleDashboardChatThreadRequest(request, url, env) {
     limit: normalizeLimit7(url.searchParams.get("limit"), 80)
   });
   const summary = typeof store.getSummary === "function" ? await store.getSummary(threadId) : null;
+  const transientProgressSnapshot = await readDashboardChatRoomTransientProgressSnapshot({
+    env,
+    threadId,
+    origin: url.origin
+  });
   return json(200, {
     ok: true,
     threadId,
     messages,
-    summary
+    summary,
+    transientProgressSnapshot
   });
+}
+async function readDashboardChatRoomTransientProgressSnapshot({ env, threadId, origin = "" } = {}) {
+  const normalizedThreadId = normalizeDashboardThreadId(threadId);
+  if (!normalizedThreadId) {
+    return null;
+  }
+  const room = resolveDashboardChatRoomStub(env, normalizedThreadId);
+  if (!room || typeof room.fetch !== "function") {
+    return null;
+  }
+  try {
+    const baseOrigin = normalizeText32(origin) || normalizeText32(env?.VTDD_RUNTIME_URL) || "https://dashboard-butler.local";
+    const url = new URL("/thread-state", baseOrigin);
+    url.searchParams.set("threadId", normalizedThreadId);
+    const response = await room.fetch(new Request(url.toString(), { method: "GET" }));
+    const body = await response.json().catch(() => ({}));
+    return body?.ok ? normalizeDashboardTransientProgressSnapshot(body.transientProgressSnapshot) : null;
+  } catch {
+    return null;
+  }
 }
 async function handleDashboardChatSearchRequest(request, url, env) {
   const auth = await authorizeDashboardRequest({
@@ -65259,6 +65372,8 @@ function normalizeDashboardAppServerBridgeEvent(payload, { fallbackThreadId = ""
   const createdAt = normalizeIsoTimestamp(input.createdAt) || (/* @__PURE__ */ new Date()).toISOString();
   const messages = [];
   let transientStatus = "";
+  let snapshotTransientStatus = false;
+  let snapshotSource = "";
   if (eventType === "app_server_reply_delta") {
     transientStatus = "thinking";
     transientText = progressText || text;
@@ -65307,6 +65422,8 @@ function normalizeDashboardAppServerBridgeEvent(payload, { fallbackThreadId = ""
       text,
       transientStatus
     });
+    snapshotTransientStatus = transientStatus === "thinking";
+    snapshotSource = "app_server_status";
     if (shouldPersistDashboardAppServerProgress(input, { transientStatus })) {
       messages.push(
         normalizeDashboardChatMessage(
@@ -65332,8 +65449,39 @@ function normalizeDashboardAppServerBridgeEvent(payload, { fallbackThreadId = ""
     text,
     transientText,
     transientStatus,
+    snapshotTransientStatus,
+    snapshotSource,
     messages: messages.filter(Boolean)
   };
+}
+function normalizeDashboardTransientProgressSnapshot(value) {
+  const input = normalizeObject12(value);
+  const threadId = normalizeDashboardThreadId(input.threadId || input.thread_id);
+  const status = normalizeDashboardChatStatus(input.status);
+  const text = sanitizeDashboardChatText(input.text);
+  if (!threadId || !text || !isDashboardSnapshotTransientStatus(status)) {
+    return null;
+  }
+  return {
+    threadId,
+    status,
+    text,
+    source: sanitizeDashboardChatText(input.source || ""),
+    updatedAt: normalizeIsoTimestamp(input.updatedAt || input.updated_at) || (/* @__PURE__ */ new Date()).toISOString()
+  };
+}
+function isDashboardSnapshotTransientStatus(status) {
+  return [
+    "thinking",
+    "pending_app_server_bridge",
+    "waiting_approval",
+    "waiting_user_input"
+  ].includes(normalizeDashboardChatStatus(status));
+}
+function shouldClearDashboardTransientProgressSnapshot(message) {
+  const role = normalizeDashboardEventText(message?.role).toLowerCase();
+  const status = normalizeDashboardChatStatus(message?.status);
+  return role === "butler" && status === "replied" || status === "failed" || status === "stalled";
 }
 function buildDashboardAppServerFailureThreadText({ text = "", status = "" } = {}) {
   const normalizedText = sanitizeDashboardChatText(text);
@@ -71502,6 +71650,20 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         }
       }
 
+      function restoreTransientProgressSnapshot(snapshot) {
+        if (!snapshot || typeof snapshot !== "object") return false;
+        const text = String(snapshot.text || "").trim();
+        const statusValue = String(snapshot.status || "").trim();
+        if (!text || !isLongRunningTransientStatus(statusValue)) return false;
+        updateTransientProgress(text, {
+          status: statusValue,
+          thinking: statusValue === "thinking" || statusValue === "pending_app_server_bridge",
+          title: statusValue === "pending_app_server_bridge" ? "\u8FD4\u4FE1\u5F85\u3061" : "\u9032\u884C\u4E2D"
+        });
+        setStatus(text, { thinking: true });
+        return true;
+      }
+
       function normalizeMessageId(value) {
         const id = String(value || "").trim();
         return id || "";
@@ -72358,7 +72520,9 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
             lastRefreshFailure = "";
             renderThread(body.messages || [], { replace: true });
             releasePendingOwnerSendFromThread(body.messages || []);
-            restoreThreadRecoveryState(body.messages || []);
+            if (!restoreTransientProgressSnapshot(body.transientProgressSnapshot)) {
+              restoreThreadRecoveryState(body.messages || []);
+            }
             status.dataset.websocketState = describeChatSocketState();
             return { ok: true };
           }
@@ -72415,6 +72579,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
             const body = JSON.parse(event.data || "{}");
             if (body.type === "thread" && body.ok) {
               renderThread(body.messages || [], { replace: false });
+              restoreTransientProgressSnapshot(body.transientProgressSnapshot);
               const releasedFromThread = releasePendingOwnerSendFromThread(body.messages || []);
               const lastMessage = Array.isArray(body.messages) ? body.messages[body.messages.length - 1] : null;
               if (lastMessage?.role === "butler" && lastMessage?.status === "replied") {


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #590 の残りである silent wait / long turn observability を部分的に進めます。
- Issue #413 の owner-facing progress を、通常チャット履歴に積み上げず復帰可能にします。
- Issue #748 の `presence != persistence` 境界に従い、app-server delta や高頻度 progress を durable chat message / D1 / GitHub comment にしません。

## Satisfied Success Criteria

- `app_server_status` の最後の owner-facing 進行状態を thread ごとに 1 件の compact snapshot として保持します。
- WebSocket reconnect の `thread` payload と HTTP refresh の response に `transientProgressSnapshot` を含めます。
- Dashboard UI は snapshot があれば復帰時に progress card を復元し、無ければ既存の thread recovery に落ちます。
- `app_server_reply_delta` は snapshot に保存せず、引き続き transient-only にします。
- final reply / failed / stalled message の到着時に snapshot を clear し、古い進行表示を残しません。
- 同じ snapshot の連続 status は storage put を増やさないよう dedupe します。

## Unsatisfied Success Criteria

- Issue #590 全体の close-ready ではありません。長時間 production E2E、stop / interrupt、owner input queue、final condensation は未完了です。
- Issue #413 全体の close-ready ではありません。runner phase / deploy / reviewer / environment panel / stop affordance は未接続です。
- Issue #748 全体の close-ready ではありません。Cloudflare production metrics evidence と broader audit は未完了です。

## Non-goal violations

None.

## 開発前作戦図

- 作戦図 evidence: `docs/development-strategy/issue-413-transient-progress-snapshot.md`
- 完了体験: owner が Dashboard Butler で iPad sleep / app switch 復帰後も、最後に観測した進行状態が thread 上で復元され、最終返信や失敗後には古い progress が残らない。
- VTDD 全体で進める部分: Issue #590 の silent wait recovery、Issue #413 の owner-facing progress、Issue #748 の cost-aware presence boundary。
- 設計: `app_server_reply_delta` は保存せず、owner-facing status milestone だけを thread ごとの single snapshot として Durable Object storage に保持する。
- 仮説: 原因は、現状の transient status が WebSocket にしか流れず、`sendThread` / HTTP refresh が messages だけを返すため、復帰時に progress が消える。
- 検証計画: snapshot restore / delta exclusion / unchanged dedupe / final clear / HTTP refresh 合流を worker test と UI static test で確認する。
- 改修見積もり: `src/worker/runtime.js` の DashboardChatRoom、HTTP thread handler、inline UI script、`test/worker.test.js`、generated `worker.js` を変更する。
- 既に通っている経路: app-server reply delta は chat history に保存されず、timeout recovery は日本語 durable message として残る。
- 未確認の境界: production iPad sleep / app switch 実機挙動と Cloudflare rowsWritten metrics は merge/deploy 後に確認が必要。
- 穴が出そうな箇所: delta を snapshot に混ぜること、final reply 後に stale snapshot が残ること、同一 progress の repeated put が増えること。
- PR 前に確認すること: Issue #590 / #413 / #748、execution queue、runtime code、worker tests、generated worker discipline。
- 実装候補と捨てた案: single snapshot を採用。chat message 化、client sessionStorage のみ、reply delta snapshot 化は捨てた。
- merge 後に通す E2E: production Dashboard Butler E2E で長い app-server turn 中に iPad を別アプリへ切り替え、復帰後の progress 復元と final clear を確認する。
- 次の PR を増やさない理由: この PR は snapshot 復帰だけの最小 slice に限定し、stop/interrupt や runner/deploy progress とは混ぜない。
- 停止条件: high-frequency delta 保存、unchanged put 増加、HTTP refresh snapshot 合流不能、Issue #748 境界違反が見えた場合は停止する。

## Dry-run Impact Report

- Target Issue: Issue #413
- Implementing Success Criteria: transient progress を通常チャット履歴に積まず、復帰時に最後の進行状態を表示できるようにする。
- Explicit Non-goals: stop / interrupt、runner phase 全体、deploy / reviewer notification、bridge restart、deploy、credential / permission mutation。
- Expected touched files/routes/workflows: `src/worker/runtime.js`、`worker.js`、`test/worker.test.js`、`docs/development-strategy/issue-413-transient-progress-snapshot.md`
- Affected Issues: Issue #590、Issue #413、Issue #748
- Affected PRs: なし。新規 PR として扱う。
- Affected workflows: worker build / generated-worker check / worker test
- Affected runtime/operator surfaces: Dashboard Butler chat Worker、DashboardChatRoom Durable Object、Dashboard PWA inline chat script
- What may break if we patch narrowly: snapshot を返さない refresh 経路が残ると iPad 復帰時に generic recovery だけになる。逆に保存を広げると #748 の cost incident を再発させる。
- Unknowns to investigate before coding: production iPad の sleep / app switch が WebSocket reconnect と HTTP refresh のどちらへ寄るか。
- Validation needed: worker unit、generated worker check、diff check、merge/deploy 後の production iPad E2E。
- Stop condition: snapshot が high-frequency durable write へ変わる、または stale progress が final reply 後に残る場合。

## Execution Queue Delta

- Queue position before: Issue #590 は active execution queue の Now。Issue #413 は root blocker、Issue #748 は cost boundary blocker。
- Preemption decision: ROOT。#590 の無言待ちを解消する bounded progress であり、#748 境界を破らないため scope を snapshot に限定した。
- Queue delta: Issue #590 の owner-facing observability を 1 slice 進める。Issue #413 / #748 は完了扱いにしない。
- Why this PR is next: owner が「無言のまま待つ」問題を継続して報告しており、UI 見た目より土台の復帰可能 progress が先に必要。
- Active Issues not downscoped: Active Issues は縮小しません。この PR で扱わない stop / interrupt / deploy / reviewer / E2E は未完了として残します。

## File / Line Hypotheses

- file: `src/worker/runtime.js`
  - hypothesis: `broadcastTransientStatus` は WebSocket-only なので、復帰時に progress が消える。
  - risk if changed narrowly: messages だけを直すと chat history 汚染か stale spinner のどちらかになる。
  - validation: snapshot restore / clear / dedupe tests。
  - related Issue: #590 / #413 / #748
- file: `test/worker.test.js`
  - hypothesis: storage write count と delta exclusion を test で固定しないと #748 regress が再発する。
  - risk if changed narrowly: UI 表示だけ通って cost boundary が壊れる。
  - validation: worker test。
  - related Issue: #748

## Hypothesis Retrospective

- expected: thread fetch / reconnect payload に last snapshot を足すと、復帰時に progress を復元できる。
- actual: worker test で WebSocket reconnect payload と HTTP refresh payload の snapshot 合流を確認した。
- mismatch: production iPad E2E は未実施。merge/deploy 後に確認が必要。
- lesson: progress は durable chat history ではなく、低頻度 single snapshot と final/failed clear の組み合わせが現時点の最小土台。
- should become RAG candidate: production E2E と Cloudflare metrics を確認後に判断する。

## Verification Evidence

- Unit: `node --test test/worker.test.js` pass。261 tests。
- Integration: `npm run build:worker` pass。`npm run check:generated-worker` pass。
- E2E: 未実施。merge/deploy 後に production iPad sleep / app switch evidence が必要。
- Manual: 未実施。
- Evidence path/link: `docs/development-strategy/issue-413-transient-progress-snapshot.md`

## Butler Completion Contract

- Primary owner surface: Dashboard Butler。
- Fallback surface: mac Codex は実装・検証用 fallback。主経路ではありません。
- Owner goal: iPad / iPhone で Butler の長い作業を待つ時、復帰後も「今どこまで進んでいるか」を失わない。
- Butler entrypoint: Dashboard Butler 通常チャットの app-server bridge turn。
- Dashboard Butler natural-language path: Dashboard Butler の自然文通常チャット入口で owner が長い作業を依頼した時、progress snapshot は runtime が自動的に扱う。
- Action Schema exposure: 変更なし。Custom GPT Action Schema はこの PR では触りません。
- Runtime path: `DashboardChatRoom` の `broadcastTransientStatus`、`sendThread`、HTTP thread refresh、inline UI refresh path。
- Runner/runtime truth: app-server status event の最後の snapshot を thread payload / refresh payload に含める。
- Authority boundary: 変更なし。deploy / credential / permission / destructive operation は扱っていません。
- E2E evidence: 未実施。production iPad sleep / app switch E2E が必要。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 未実施。merge 後に passkey approval / owner approval が必要な deploy path で行う。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。merge/deploy 後に iPad / iPhone production evidence が必要。

## Related Constitution Rules

- Butler Completion Gate は未完了なら complete と言わない。
- Issue-backed scope なしに runtime behavior を変更しない。
- progress / presence を high-frequency durable write にしない。
- owner-facing Issue / PR / review / comment は日本語をデフォルトにする。

## Out-of-scope but NOT implemented

- stop / interrupt / cancel signal。
- runner phase / deploy / reviewer progress 全体。
- final condensation / transient replacement metadata。
- Cloudflare production metrics guard。
- bridge service restart / deploy。

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #590 / Issue #413 / Issue #748
- Execution ID: dashboard-butler-issue-413-transient-progress-snapshot
- Goal: Dashboard Butler の復帰可能 transient progress snapshot
