### PR TITLE
Issue #722 deploy完了をButler threadへ残す

### DIFF
--- a/docs/development-strategy/issue-722-completion-event-thread-state.md
+++ b/docs/development-strategy/issue-722-completion-event-thread-state.md
@@ -16,7 +16,7 @@ Butler thread には「何が完了したか」「次に何を確認するか」
 
 `handleGitHubActionsEventRequest` は machine auth 済みの GitHub Actions event を受け、`recordDashboardNotificationEvent` で dashboard event store と Web Push へ保存している。
 
-ここに Dashboard chat store への append を追加する。ただし Web Push は一度送ると rollback できないので、順序は chat append 成功を先にする。chat append が成功した場合だけ Web Push を dispatch し、chat store 未設定または append 失敗時は event truth に失敗理由を保存して Web Push を送らない。
+ここに Dashboard chat store への append を追加する。ただし Web Push は一度送ると rollback できないので、順序は event truth 受理保存、chat append、Web Push dispatch の順にする。chat append が成功した場合だけ Web Push を dispatch し、既に `sent` 済みの duplicate event は Web Push を再送しない。chat store 未設定または append 失敗時は event truth に失敗理由を保存して Web Push を送らない。
 
 thread は payload の `threadId` があればそれを使う。なければ repository から `dashboard-main-<owner-repo>` を導出する。これは repo-less main chat の将来対応とは分ける。
 
@@ -34,6 +34,8 @@ thread は payload の `threadId` があればそれを使う。なければ rep
 - Unit: owner-facing message が `PR #...` / `Issue #...` と種別付きで表示され、bare `#...` を主表現にしない。
 - Unit: 同じ deploy event が再送されても同じ messageId で置換され、thread に重複追加されない。
 - Integration: chat append 成功後だけ Web Push が送られる。
+- Integration: duplicate event では thread message は idempotent に置換されるが、Web Push は再送されない。
+- Integration: event truth の初回受理保存に失敗した場合は chat append も Web Push も実行しない。
 - Integration: chat append 失敗時または `DASHBOARD_CHAT_STORE` 未設定時は 202 で event truth を残し、Web Push は送らず、`pwaNotificationStatus` に失敗理由を残す。
 - Integration: production D1 chat message は `(thread_id, message_id)` 主キーと `INSERT OR REPLACE` で idempotent に保存される。
 - Build: `npm run build:worker`
@@ -44,7 +46,7 @@ thread は payload の `threadId` があればそれを使う。なければ rep
 
 | path | 境界 | 変更 | risk |
 | --- | --- | --- | --- |
-| `src/worker/runtime.js` | `handleGitHubActionsEventRequest` | deploy completion event の chat append と chat 成功後 Web Push dispatch を追加 | Web Push を先に送ると rollback 不能になり通知だけ残る |
+| `src/worker/runtime.js` | `handleGitHubActionsEventRequest` | event truth 受理保存、chat append、chat 成功後 Web Push dispatch、duplicate push skip を追加 | 順序を誤ると thread-only / push-only / duplicate push が起きる |
 | `src/worker/runtime.js` | formatter helper | owner-facing deploy completion message を生成 | 長文・bare `#...`・secret 混入の risk |
 | `test/worker.test.js` | deploy completion tests | thread append / dedupe / rollback を追加 | 既存通知テストとの fixture ずれ |
 | `worker.js` | generated worker | source 変更を反映 | generated mismatch |
@@ -66,6 +68,7 @@ thread は payload の `threadId` があればそれを使う。なければ rep
 
 - `DASHBOARD_CHAT_STORE` が未設定の environment で deploy event を受けた時は、event truth を残して Web Push を送らない fallback にする。
 - duplicate webhook / workflow retry で同じ event が複数回届く場合。
+- event store 受理保存が失敗した場合に、chat thread だけが先に更新されないこと。
 - `threadId` 未指定時に owner が見ている thread と導出 thread がズレる場合。
 
 ## PR 前に確認すること

--- a/docs/development-strategy/issue-722-completion-event-thread-state.md
+++ b/docs/development-strategy/issue-722-completion-event-thread-state.md
@@ -16,7 +16,7 @@ Butler thread には「何が完了したか」「次に何を確認するか」
 
 `handleGitHubActionsEventRequest` は machine auth 済みの GitHub Actions event を受け、`recordDashboardNotificationEvent` で dashboard event store と Web Push へ保存している。
 
-ここに Dashboard chat store への append を追加する。ただし通知保存と chat append のどちらか片方だけが成功した状態を放置しないよう、VPS runner event と同じく chat append 失敗時は dashboard event を rollback する。
+ここに Dashboard chat store への append を追加する。ただし Web Push は一度送ると rollback できないので、順序は chat append 成功を先にする。chat append が成功した場合だけ Web Push を dispatch し、chat store 未設定または append 失敗時は event truth に失敗理由を保存して Web Push を送らない。
 
 thread は payload の `threadId` があればそれを使う。なければ repository から `dashboard-main-<owner-repo>` を導出する。これは repo-less main chat の将来対応とは分ける。
 
@@ -33,7 +33,9 @@ thread は payload の `threadId` があればそれを使う。なければ rep
 - Unit: GitHub Actions deploy completion event が dashboard event store に保存され、同時に Dashboard Butler thread へ system message として append される。
 - Unit: owner-facing message が `PR #...` / `Issue #...` と種別付きで表示され、bare `#...` を主表現にしない。
 - Unit: 同じ deploy event が再送されても同じ messageId で置換され、thread に重複追加されない。
-- Integration: chat append 失敗時は dashboard event を rollback し、通知だけが残る状態を防ぐ。
+- Integration: chat append 成功後だけ Web Push が送られる。
+- Integration: chat append 失敗時または `DASHBOARD_CHAT_STORE` 未設定時は 202 で event truth を残し、Web Push は送らず、`pwaNotificationStatus` に失敗理由を残す。
+- Integration: production D1 chat message は `(thread_id, message_id)` 主キーと `INSERT OR REPLACE` で idempotent に保存される。
 - Build: `npm run build:worker`
 - Generated check: `npm run check:generated-worker`
 - Worker test: `node --test test/worker.test.js`
@@ -42,7 +44,7 @@ thread は payload の `threadId` があればそれを使う。なければ rep
 
 | path | 境界 | 変更 | risk |
 | --- | --- | --- | --- |
-| `src/worker/runtime.js` | `handleGitHubActionsEventRequest` | deploy completion event の chat append と broadcast を追加 | event store / chat store 片側成功の扱いを誤ると runtime truth が割れる |
+| `src/worker/runtime.js` | `handleGitHubActionsEventRequest` | deploy completion event の chat append と chat 成功後 Web Push dispatch を追加 | Web Push を先に送ると rollback 不能になり通知だけ残る |
 | `src/worker/runtime.js` | formatter helper | owner-facing deploy completion message を生成 | 長文・bare `#...`・secret 混入の risk |
 | `test/worker.test.js` | deploy completion tests | thread append / dedupe / rollback を追加 | 既存通知テストとの fixture ずれ |
 | `worker.js` | generated worker | source 変更を反映 | generated mismatch |
@@ -62,7 +64,7 @@ thread は payload の `threadId` があればそれを使う。なければ rep
 
 ## 穴が出そうな箇所
 
-- `DASHBOARD_CHAT_STORE` が未設定の environment で deploy event を受けた時の挙動。
+- `DASHBOARD_CHAT_STORE` が未設定の environment で deploy event を受けた時は、event truth を残して Web Push を送らない fallback にする。
 - duplicate webhook / workflow retry で同じ event が複数回届く場合。
 - `threadId` 未指定時に owner が見ている thread と導出 thread がズレる場合。
 
@@ -93,6 +95,6 @@ owner が別アプリへ移動して戻っても、同じ thread で直近 deplo
 ## 停止条件
 
 - deploy completion event の chat append に必要な store が production で未設定と分かった場合。
-- rollback なしで通知だけ残る状態しか作れない場合。
+- chat append 成功前に Web Push を送る必要が出た場合。
 - threadId 導出が repository owner の通常 thread と矛盾すると分かった場合。
 - 実装中に deploy / merge / credential / permission mutation が必要になった場合。

--- a/docs/development-strategy/issue-722-completion-event-thread-state.md
+++ b/docs/development-strategy/issue-722-completion-event-thread-state.md
@@ -1,0 +1,98 @@
+# Issue #722 completion event thread state 作戦図
+
+## 完了体験
+
+owner が「マージされた」「デプロイ完了」と手で補足しなくても、GitHub Actions から届いた deploy completion event が Dashboard Butler の同じ thread に残る。
+
+Butler thread には「何が完了したか」「次に何を確認するか」「高リスク操作は自動実行していないこと」が短い system message として表示される。iPad / iPhone で別アプリへ移動して戻っても、通知センターだけでなく chat thread の履歴から状態を追える。
+
+## VTDD 全体で進める部分
+
+今回は Issue #722 のうち、deploy completion event を thread truth へ接続する最初の実装 slice にする。
+
+進行中 narration、reviewer approve、auto-merge の全種類を同時に広げると、event source と authority boundary が混ざる。まず既存 production workflow がすでに送っている `/v2/events/github-actions` を起点に、通知だけで終わる gap を潰す。
+
+## 設計
+
+`handleGitHubActionsEventRequest` は machine auth 済みの GitHub Actions event を受け、`recordDashboardNotificationEvent` で dashboard event store と Web Push へ保存している。
+
+ここに Dashboard chat store への append を追加する。ただし通知保存と chat append のどちらか片方だけが成功した状態を放置しないよう、VPS runner event と同じく chat append 失敗時は dashboard event を rollback する。
+
+thread は payload の `threadId` があればそれを使う。なければ repository から `dashboard-main-<owner-repo>` を導出する。これは repo-less main chat の将来対応とは分ける。
+
+## 仮説
+
+今の owner 体験が「通知は来るが thread に残らない」になっている理由は、deploy completion route が `DASHBOARD_EVENT_STORE` と Web Push のみを使い、`DASHBOARD_CHAT_STORE` に書いていないため。
+
+既存の VPS runner event は `DASHBOARD_CHAT_STORE` と `DASHBOARD_CHAT_ROOMS` に接続済みなので、そのパターンを GitHub Actions deploy completion に限って再利用すれば、iPad sleep / app switch 復帰後の「何が起きたか分からない」体験を下げられる。
+
+狭く「通知センターの文言だけ」を直すと、owner が求めている「この chat 上に自動で残る」が解決しない。
+
+## 検証計画
+
+- Unit: GitHub Actions deploy completion event が dashboard event store に保存され、同時に Dashboard Butler thread へ system message として append される。
+- Unit: owner-facing message が `PR #...` / `Issue #...` と種別付きで表示され、bare `#...` を主表現にしない。
+- Unit: 同じ deploy event が再送されても同じ messageId で置換され、thread に重複追加されない。
+- Integration: chat append 失敗時は dashboard event を rollback し、通知だけが残る状態を防ぐ。
+- Build: `npm run build:worker`
+- Generated check: `npm run check:generated-worker`
+- Worker test: `node --test test/worker.test.js`
+
+## 改修見積もり
+
+| path | 境界 | 変更 | risk |
+| --- | --- | --- | --- |
+| `src/worker/runtime.js` | `handleGitHubActionsEventRequest` | deploy completion event の chat append と broadcast を追加 | event store / chat store 片側成功の扱いを誤ると runtime truth が割れる |
+| `src/worker/runtime.js` | formatter helper | owner-facing deploy completion message を生成 | 長文・bare `#...`・secret 混入の risk |
+| `test/worker.test.js` | deploy completion tests | thread append / dedupe / rollback を追加 | 既存通知テストとの fixture ずれ |
+| `worker.js` | generated worker | source 変更を反映 | generated mismatch |
+
+## 既に通っている経路
+
+- `/v2/events/github-actions` は machine auth 付き event を受けられる。
+- dashboard event store は deploy event を保存できる。
+- Web Push は deploy completion の owner-facing copy を作れる。
+- VPS runner event は通知と Butler chat thread の両方へ書ける。
+
+## 未確認の境界
+
+- reviewer approve / auto-merge event の production event source は今回まだ実装しない。
+- repo-less main chat と repository thread の最終統合は Issue #613 側の設計が必要。
+- deploy 後 E2E を自動起動するかは authority boundary と runner queue の別 Issue。
+
+## 穴が出そうな箇所
+
+- `DASHBOARD_CHAT_STORE` が未設定の environment で deploy event を受けた時の挙動。
+- duplicate webhook / workflow retry で同じ event が複数回届く場合。
+- `threadId` 未指定時に owner が見ている thread と導出 thread がズレる場合。
+
+## PR 前に確認すること
+
+- topic branch が `origin/main` から切られていること。
+- `.tmp/` と `test-results/` は成果物に含めないこと。
+- PR body は日本語 first で、Issue #722 の criteria と未完部分を明示すること。
+
+## 実装候補と捨てた案
+
+採用案: deploy completion route に chat append を追加し、既存 event store / Web Push / chat room broadcast を接続する。
+
+捨てた案: 通知センター UI だけに「次 action」を出す。chat thread に残らず、#722 の owner-facing completion event にならない。
+
+捨てた案: reviewer / auto-merge / deploy を一括で作る。event source が異なり、authority boundary と検証が膨らむため、今回の PR が大きくなりすぎる。
+
+## merge 後に通す E2E
+
+production deploy completion event を発生させ、Dashboard Butler thread に system message が残ることを確認する。
+
+owner が別アプリへ移動して戻っても、同じ thread で直近 deploy 完了と次 action を読めることを確認する。
+
+## 次の PR を増やさない理由
+
+この PR は Issue #722 の全完了ではなく、deploy completion の既存 event source を thread state へ接続する最小 slice である。reviewer approve / auto-merge / long-running progress は event source と UI persistence が別なので、同じ PR に混ぜない。
+
+## 停止条件
+
+- deploy completion event の chat append に必要な store が production で未設定と分かった場合。
+- rollback なしで通知だけ残る状態しか作れない場合。
+- threadId 導出が repository owner の通常 thread と矛盾すると分かった場合。
+- 実装中に deploy / merge / credential / permission mutation が必要になった場合。

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -4541,9 +4541,22 @@ async function handleGitHubActionsEventRequest(request, env) {
     });
   }
 
-  const threadId = event.threadId || buildDashboardEventDefaultThreadId(event.event);
+  const baseEvent = normalizeDashboardEventRecord(event.event);
+  const existingEvent = await readDashboardEventById(store, baseEvent.id);
+  const acceptedEvent = normalizeDashboardEventRecord({
+    ...baseEvent,
+    pwaNotificationStatus: existingEvent?.pwaNotificationStatus === "sent" ? "sent" : "dashboard_event_received",
+    pwaNotificationError: existingEvent?.pwaNotificationError || null,
+    pwaNotificationReason: existingEvent?.pwaNotificationReason || null,
+    pwaNotificationAttempted: existingEvent?.pwaNotificationAttempted || 0,
+    pwaNotificationDelivered: existingEvent?.pwaNotificationDelivered || 0,
+    pwaNotificationCleaned: existingEvent?.pwaNotificationCleaned || 0
+  });
+  await store.put(acceptedEvent);
+
+  const threadId = event.threadId || buildDashboardEventDefaultThreadId(baseEvent);
   const chatMessage = buildGitHubActionsDashboardChatMessage({
-    event: event.event,
+    event: baseEvent,
     threadId
   });
   const chatStore = resolveDashboardChatStore(env);
@@ -4567,21 +4580,32 @@ async function handleGitHubActionsEventRequest(request, env) {
     }
   }
 
-  const shouldDispatchNotification = chatAppendStatus === "appended";
+  const duplicateNotificationAlreadySent =
+    existingEvent?.pwaNotificationStatus === "sent" && Number(existingEvent?.pwaNotificationDelivered || 0) > 0;
+  const shouldDispatchNotification = chatAppendStatus === "appended" && !duplicateNotificationAlreadySent;
   const recorded = await recordDashboardNotificationEvent({
     env,
     eventStore: store,
-    event: event.event,
+    event: baseEvent,
     overrides: shouldDispatchNotification
       ? {}
-      : {
-          pwaNotificationStatus: chatAppendError || "dashboard_chat_append_skipped",
-          pwaNotificationError: chatAppendError || null,
-          pwaNotificationReason: chatAppendReason || "dashboard Butler chat append did not complete",
-          pwaNotificationAttempted: 0,
-          pwaNotificationDelivered: 0,
-          pwaNotificationCleaned: 0
-        },
+      : duplicateNotificationAlreadySent
+        ? {
+            pwaNotificationStatus: "sent",
+            pwaNotificationError: null,
+            pwaNotificationReason: "duplicate event ignored after prior Web Push delivery",
+            pwaNotificationAttempted: existingEvent.pwaNotificationAttempted || 0,
+            pwaNotificationDelivered: existingEvent.pwaNotificationDelivered || 0,
+            pwaNotificationCleaned: existingEvent.pwaNotificationCleaned || 0
+          }
+        : {
+            pwaNotificationStatus: chatAppendError || "dashboard_chat_append_skipped",
+            pwaNotificationError: chatAppendError || null,
+            pwaNotificationReason: chatAppendReason || "dashboard Butler chat append did not complete",
+            pwaNotificationAttempted: 0,
+            pwaNotificationDelivered: 0,
+            pwaNotificationCleaned: 0
+          },
     dispatch: shouldDispatchNotification
   });
   const webSocketBroadcast =
@@ -4598,6 +4622,18 @@ async function handleGitHubActionsEventRequest(request, env) {
     webSocketBroadcast,
     webPush: recorded.webPush
   });
+}
+
+async function readDashboardEventById(eventStore, eventId) {
+  const id = normalizeDashboardEventText(eventId);
+  if (!id || !eventStore || typeof eventStore.get !== "function") {
+    return null;
+  }
+  try {
+    return await eventStore.get(id);
+  } catch {
+    return null;
+  }
 }
 
 async function recordDashboardNotificationEvent({ env, eventStore, event, overrides = {}, dispatch = true } = {}) {
@@ -9757,6 +9793,24 @@ function createD1DashboardEventStore(d1) {
       await ensureSchema();
       await d1.prepare("DELETE FROM vtdd_dashboard_events WHERE id = ?").bind(id).run();
       return true;
+    },
+
+    async get(eventId) {
+      const id = normalizeDashboardEventText(eventId);
+      if (!id) {
+        return null;
+      }
+      await ensureSchema();
+      const result = await d1.prepare("SELECT payload_json FROM vtdd_dashboard_events WHERE id = ? LIMIT 1").bind(id).all();
+      const row = Array.isArray(result?.results) ? result.results[0] : null;
+      if (!row?.payload_json) {
+        return null;
+      }
+      try {
+        return normalizeDashboardEventRecord(JSON.parse(row.payload_json));
+      } catch {
+        return null;
+      }
     },
 
     async latest(filter = {}) {

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -4541,43 +4541,49 @@ async function handleGitHubActionsEventRequest(request, env) {
     });
   }
 
+  const threadId = event.threadId || buildDashboardEventDefaultThreadId(event.event);
+  const chatMessage = buildGitHubActionsDashboardChatMessage({
+    event: event.event,
+    threadId
+  });
   const chatStore = resolveDashboardChatStore(env);
-  if (!chatStore) {
-    return json(503, {
-      ok: false,
-      error: "dashboard_chat_store_unavailable",
-      reason: "dashboard Butler chat store is not configured"
-    });
+  let messages = [];
+  let chatAppendStatus = "unavailable";
+  let chatAppendError = null;
+  let chatAppendReason = null;
+  if (chatMessage) {
+    if (chatStore) {
+      try {
+        messages = await chatStore.appendMany(threadId, [chatMessage]);
+        chatAppendStatus = messages.length > 0 ? "appended" : "skipped";
+      } catch (error) {
+        chatAppendStatus = "failed";
+        chatAppendError = "dashboard_event_chat_append_failed";
+        chatAppendReason = error instanceof Error ? error.message : "Dashboard Butler chat append failed";
+      }
+    } else {
+      chatAppendError = "dashboard_chat_store_unavailable";
+      chatAppendReason = "dashboard Butler chat store is not configured";
+    }
   }
 
+  const shouldDispatchNotification = chatAppendStatus === "appended";
   const recorded = await recordDashboardNotificationEvent({
     env,
     eventStore: store,
-    event: event.event
+    event: event.event,
+    overrides: shouldDispatchNotification
+      ? {}
+      : {
+          pwaNotificationStatus: chatAppendError || "dashboard_chat_append_skipped",
+          pwaNotificationError: chatAppendError || null,
+          pwaNotificationReason: chatAppendReason || "dashboard Butler chat append did not complete",
+          pwaNotificationAttempted: 0,
+          pwaNotificationDelivered: 0,
+          pwaNotificationCleaned: 0
+        },
+    dispatch: shouldDispatchNotification
   });
-
-  const threadId = event.threadId || buildDashboardEventDefaultThreadId(event.event);
-  const chatMessage = buildGitHubActionsDashboardChatMessage({
-    event: recorded.event,
-    threadId
-  });
-  let messages = [];
-  if (chatMessage) {
-    try {
-      messages = await chatStore.appendMany(threadId, [chatMessage]);
-    } catch (error) {
-      await store.delete(recorded.event.id);
-      return json(502, {
-        ok: false,
-        error: "dashboard_event_chat_append_failed",
-        reason: "GitHub Actions event was not saved because Butler chat append failed",
-        rollback: {
-          eventId: recorded.event.id,
-          notificationDeleted: true
-        }
-      });
-    }
-  }
   const webSocketBroadcast =
     messages.length > 0 ? await notifyDashboardChatRoom({ env, threadId, messages }) : false;
 
@@ -4585,6 +4591,9 @@ async function handleGitHubActionsEventRequest(request, env) {
     ok: true,
     event: recorded.event,
     threadId,
+    chatAppendStatus,
+    chatAppendError,
+    chatAppendReason,
     messages,
     webSocketBroadcast,
     webPush: recorded.webPush

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -4541,14 +4541,52 @@ async function handleGitHubActionsEventRequest(request, env) {
     });
   }
 
+  const chatStore = resolveDashboardChatStore(env);
+  if (!chatStore) {
+    return json(503, {
+      ok: false,
+      error: "dashboard_chat_store_unavailable",
+      reason: "dashboard Butler chat store is not configured"
+    });
+  }
+
   const recorded = await recordDashboardNotificationEvent({
     env,
     eventStore: store,
     event: event.event
   });
+
+  const threadId = event.threadId || buildDashboardEventDefaultThreadId(event.event);
+  const chatMessage = buildGitHubActionsDashboardChatMessage({
+    event: recorded.event,
+    threadId
+  });
+  let messages = [];
+  if (chatMessage) {
+    try {
+      messages = await chatStore.appendMany(threadId, [chatMessage]);
+    } catch (error) {
+      await store.delete(recorded.event.id);
+      return json(502, {
+        ok: false,
+        error: "dashboard_event_chat_append_failed",
+        reason: "GitHub Actions event was not saved because Butler chat append failed",
+        rollback: {
+          eventId: recorded.event.id,
+          notificationDeleted: true
+        }
+      });
+    }
+  }
+  const webSocketBroadcast =
+    messages.length > 0 ? await notifyDashboardChatRoom({ env, threadId, messages }) : false;
+
   return json(202, {
     ok: true,
     event: recorded.event,
+    threadId,
+    messages,
+    webSocketBroadcast,
     webPush: recorded.webPush
   });
 }
@@ -13106,6 +13144,7 @@ function normalizeGitHubActionsEvent(payload) {
     normalizeIssue(input.pullNumber || input.pull_number || input.prNumber || input.pr_number) ||
     inferPullNumberFromText(`${title} ${changeSummary}`);
   const issueNumber = normalizeIssue(input.issueNumber || input.issue_number);
+  const threadId = normalizeDashboardThreadId(input.threadId || input.thread_id);
 
   if (!repository) {
     return {
@@ -13164,8 +13203,84 @@ function normalizeGitHubActionsEvent(payload) {
 
   return {
     ok: true,
-    event
+    event,
+    threadId
   };
+}
+
+function buildDashboardEventDefaultThreadId(event) {
+  const record = normalizeDashboardEventRecord(event);
+  const repository = normalizeCanonicalRepositoryInput(record.repository);
+  if (repository) {
+    return normalizeDashboardThreadId(`dashboard-main-${repository.replace("/", "-")}`);
+  }
+  return "dashboard-main-unresolved";
+}
+
+function buildGitHubActionsDashboardChatMessage({ event, threadId } = {}) {
+  const record = normalizeDashboardEventRecord(event);
+  const resolvedThreadId = normalizeDashboardThreadId(threadId) || buildDashboardEventDefaultThreadId(record);
+  if (!resolvedThreadId || record.kind !== "github_actions_workflow_run") {
+    return null;
+  }
+  const messageId = `dashboard-event:${record.id}`;
+  return normalizeDashboardChatMessage(
+    {
+      threadId: resolvedThreadId,
+      messageId,
+      role: "system",
+      repository: record.repository,
+      relatedIssue: record.issueNumber,
+      status: record.conclusion === "failure" || record.conclusion === "cancelled" ? "blocked" : "replied",
+      text: buildGitHubActionsDashboardChatMessageText(record),
+      createdAt: record.updatedAt || record.createdAt
+    },
+    { threadId: resolvedThreadId }
+  );
+}
+
+function buildGitHubActionsDashboardChatMessageText(event) {
+  const record = normalizeDashboardEventRecord(event);
+  const conclusion = normalizeDashboardEventText(record.conclusion || record.status) || "unknown";
+  const isDeploy = normalize(record.workflowName).includes("deploy");
+  const title = buildDashboardEventDisplayTitle(record, {
+    workflowName: record.workflowName,
+    conclusion
+  });
+  const lines = [
+    isDeploy ? "デプロイ完了イベントを受信しました。" : "GitHub Actions の完了イベントを受信しました。",
+    "",
+    "状態:",
+    `- repo: ${record.repository || "未確認"}`,
+    `- workflow: ${record.workflowName || "未確認"}`,
+    `- status: ${record.status || "未確認"}`,
+    `- conclusion: ${conclusion}`
+  ];
+  if (record.pullNumber) {
+    lines.push(`- PR: PR #${record.pullNumber}`);
+  }
+  if (record.issueNumber) {
+    lines.push(`- Issue: Issue #${record.issueNumber}`);
+  }
+  if (record.headSha) {
+    lines.push(`- sha: ${record.headSha.slice(0, 12)}`);
+  }
+  if (title) {
+    lines.push("", "内容:", title);
+  }
+  lines.push("", "次:");
+  if (isDeploy && conclusion === "success") {
+    lines.push("- production E2E / runtime truth を確認します。");
+  } else if (conclusion === "failure" || conclusion === "cancelled" || conclusion === "timed_out") {
+    lines.push("- deploy / Actions の失敗原因を確認し、blocker と次 action を出します。");
+  } else {
+    lines.push("- 最新 event と残る blocker を確認します。");
+  }
+  lines.push("- merge / deploy / credential / permission は、この event だけでは自動実行しません。");
+  if (record.runUrl) {
+    lines.push("", `Actions: ${record.runUrl}`);
+  }
+  return lines.join("\n");
 }
 
 function normalizeVpsRunnerDashboardEvent(payload) {

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -289,6 +289,9 @@ function createInMemoryDashboardEventStore() {
     async delete(eventId) {
       return events.delete(eventId);
     },
+    async get(eventId) {
+      return events.get(eventId) ?? null;
+    },
     async latest(filter = {}) {
       const matches = [...events.values()].filter((event) => {
         if (filter.kind && event.kind !== filter.kind) {
@@ -6247,6 +6250,11 @@ test("worker ingests GitHub Actions deploy completion event and shows it on dash
     }
   );
   assert.equal(duplicateResponse.status, 202);
+  const duplicateBody = await duplicateResponse.json();
+  assert.equal(duplicateBody.event.pwaNotificationStatus, "sent");
+  assert.equal(duplicateBody.webPush.status, 204);
+  assert.equal(duplicateBody.webPush.delivered, 0);
+  assert.equal(pushCalls.length, 1);
   const duplicateChat = await worker.fetch(
     new Request("https://example.com/v2/dashboard/chat/dashboard-main-marushu-vtdd-v2-p", {
       headers: dashboardAccessHeaders
@@ -6558,6 +6566,53 @@ test("worker accepts GitHub Actions event without Web Push when dashboard chat s
   assert.equal(latest.pwaNotificationStatus, "dashboard_chat_store_unavailable");
   assert.equal(latest.pwaNotificationAttempted, 0);
   assert.equal(latest.pwaNotificationDelivered, 0);
+});
+
+test("worker does not append GitHub Actions chat before event truth is accepted", async () => {
+  let chatAppendCalls = 0;
+  const pushCalls = [];
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/events/github-actions", {
+      method: "POST",
+      headers: gatewayAuthHeaders,
+      body: JSON.stringify({
+        repository: "marushu/vtdd-v2-p",
+        workflowName: "deploy-production",
+        runId: "26133049999",
+        status: "completed",
+        conclusion: "success",
+        pullNumber: 749,
+        updatedAt: "2026-05-20T00:14:01Z"
+      })
+    }),
+    {
+      ...gatewayAuthEnv,
+      ...(await createTestVapidEnv({
+        DASHBOARD_WEB_PUSH_FETCH: async (input, init) => {
+          pushCalls.push({ input, init });
+          return new Response(null, { status: 201 });
+        }
+      })),
+      DASHBOARD_EVENT_STORE: {
+        async put() {
+          throw new Error("event store failed before chat");
+        },
+        async get() {
+          return null;
+        }
+      },
+      DASHBOARD_CHAT_STORE: {
+        async appendMany() {
+          chatAppendCalls += 1;
+          return [];
+        }
+      }
+    }
+  );
+
+  assert.equal(response.status, 503);
+  assert.equal(chatAppendCalls, 0);
+  assert.equal(pushCalls.length, 0);
 });
 
 test("worker does not infer PR number from issue-style parenthetical summary", async () => {

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -343,7 +343,14 @@ function createInMemoryDashboardChatStore() {
         ...message,
         threadId
       }));
-      list.push(...normalizedMessages);
+      for (const message of normalizedMessages) {
+        const existingIndex = list.findIndex((item) => item.messageId === message.messageId);
+        if (existingIndex >= 0) {
+          list[existingIndex] = message;
+        } else {
+          list.push(message);
+        }
+      }
       messagesByThread.set(threadId, list);
       return normalizedMessages;
     },
@@ -6091,6 +6098,8 @@ test("worker redacts dashboard push subscription raw material from D1 payload_js
 
 test("worker ingests GitHub Actions deploy completion event and shows it on dashboard", async () => {
   const store = createInMemoryDashboardEventStore();
+  const chatStore = createInMemoryDashboardChatStore();
+  const rooms = createMockDashboardChatRoomNamespace();
   const pushStore = createInMemoryDashboardPushSubscriptionStore();
   const pushKeys = await createTestPushSubscription({
     endpointHash: "deploy-push-endpoint",
@@ -6129,6 +6138,8 @@ test("worker ingests GitHub Actions deploy completion event and shows it on dash
       ...gatewayAuthEnv,
       ...vapidEnv,
       DASHBOARD_EVENT_STORE: store,
+      DASHBOARD_CHAT_STORE: chatStore,
+      DASHBOARD_CHAT_ROOMS: rooms.namespace,
       DASHBOARD_PUSH_SUBSCRIPTION_STORE: pushStore
     }
   );
@@ -6143,6 +6154,22 @@ test("worker ingests GitHub Actions deploy completion event and shows it on dash
   assert.equal(eventBody.event.pwaNotificationStatus, "sent");
   assert.equal(eventBody.event.pwaNotificationAttempted, 1);
   assert.equal(eventBody.event.pwaNotificationDelivered, 1);
+  assert.equal(eventBody.threadId, "dashboard-main-marushu-vtdd-v2-p");
+  assert.equal(eventBody.messages.length, 1);
+  assert.equal(eventBody.messages[0].messageId, "dashboard-event:github-actions:marushu/vtdd-v2-p:deploy-production:26133044458");
+  assert.equal(eventBody.messages[0].role, "system");
+  assert.equal(eventBody.messages[0].repository, "marushu/vtdd-v2-p");
+  assert.equal(eventBody.messages[0].relatedIssue, null);
+  assert.equal(eventBody.messages[0].status, "replied");
+  assert.equal(eventBody.messages[0].text.includes("デプロイ完了イベントを受信しました。"), true);
+  assert.equal(eventBody.messages[0].text.includes("- PR: PR #552"), true);
+  assert.equal(eventBody.messages[0].text.includes("- production E2E / runtime truth を確認します。"), true);
+  assert.equal(eventBody.messages[0].text.includes("merge / deploy / credential / permission"), true);
+  assert.equal(JSON.stringify(eventBody.messages).includes("approval:must-not-persist"), false);
+  assert.equal(JSON.stringify(eventBody.messages).includes("secret-must-not-persist"), false);
+  assert.equal(eventBody.webSocketBroadcast, true);
+  assert.equal(rooms.calls.length, 1);
+  assert.equal(rooms.calls[0].name, "dashboard-main-marushu-vtdd-v2-p");
   assert.equal(pushCalls.length, 1);
   assert.equal(pushCalls[0].input, "https://push.example/send/deploy");
   assert.match(pushCalls[0].init.headers.authorization, /^vapid t=.+, k=.+/);
@@ -6171,6 +6198,59 @@ test("worker ingests GitHub Actions deploy completion event and shows it on dash
   assert.equal(storedDeployEvent.pwaNotificationStatus, "sent");
   assert.equal(storedDeployEvent.pwaNotificationAttempted, 1);
   assert.equal(storedDeployEvent.pwaNotificationDelivered, 1);
+
+  const chatResponse = await worker.fetch(
+    new Request("https://example.com/v2/dashboard/chat/dashboard-main-marushu-vtdd-v2-p", {
+      headers: dashboardAccessHeaders
+    }),
+    { ...dashboardAccessEnv, DASHBOARD_CHAT_STORE: chatStore }
+  );
+  assert.equal(chatResponse.status, 200);
+  const chatBody = await chatResponse.json();
+  assert.equal(chatBody.messages.length, 1);
+  assert.equal(chatBody.messages[0].role, "system");
+  assert.equal(chatBody.messages[0].text.includes("デプロイ完了イベントを受信しました。"), true);
+  assert.equal(chatBody.messages[0].text.includes("- PR: PR #552"), true);
+  assert.equal(chatBody.messages[0].text.includes("bare #552"), false);
+
+  const duplicateResponse = await worker.fetch(
+    new Request("https://example.com/v2/events/github-actions", {
+      method: "POST",
+      headers: gatewayAuthHeaders,
+      body: JSON.stringify({
+        repository: "marushu/vtdd-v2-p",
+        workflowName: "deploy-production",
+        runId: "26133044458",
+        runUrl: "https://github.com/marushu/vtdd-v2-p/actions/runs/26133044458",
+        status: "completed",
+        conclusion: "success",
+        headSha: "ef55709c4f52b54f436417acc239ec03a0c999fd",
+        headBranch: "main",
+        displayTitle: "dashboard: 通知カードにPR概要を出す (#534)",
+        changeSummary: "dashboard: 通知カードにPR概要を出す (#534)",
+        pullNumber: 552,
+        updatedAt: "2026-05-20T00:10:02Z"
+      })
+    }),
+    {
+      ...gatewayAuthEnv,
+      ...vapidEnv,
+      DASHBOARD_EVENT_STORE: store,
+      DASHBOARD_CHAT_STORE: chatStore,
+      DASHBOARD_CHAT_ROOMS: rooms.namespace,
+      DASHBOARD_PUSH_SUBSCRIPTION_STORE: pushStore
+    }
+  );
+  assert.equal(duplicateResponse.status, 202);
+  const duplicateChat = await worker.fetch(
+    new Request("https://example.com/v2/dashboard/chat/dashboard-main-marushu-vtdd-v2-p", {
+      headers: dashboardAccessHeaders
+    }),
+    { ...dashboardAccessEnv, DASHBOARD_CHAT_STORE: chatStore }
+  );
+  const duplicateChatBody = await duplicateChat.json();
+  assert.equal(duplicateChatBody.messages.length, 1);
+  assert.equal(duplicateChatBody.messages[0].messageId, "dashboard-event:github-actions:marushu/vtdd-v2-p:deploy-production:26133044458");
 
   const dashboardResponse = await worker.fetch(
     new Request("https://example.com/dashboard", {
@@ -6366,6 +6446,52 @@ test("worker rejects GitHub Actions deploy completion event without machine auth
   assert.equal(response.status, 401);
 });
 
+test("worker rolls back GitHub Actions notification when Butler chat append fails", async () => {
+  const eventStore = createInMemoryDashboardEventStore();
+  const chatStore = {
+    async appendMany() {
+      throw new Error("chat append failed");
+    },
+    async listThread() {
+      return [];
+    }
+  };
+
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/events/github-actions", {
+      method: "POST",
+      headers: gatewayAuthHeaders,
+      body: JSON.stringify({
+        repository: "marushu/vtdd-v2-p",
+        workflowName: "deploy-production",
+        runId: "26133047777",
+        status: "completed",
+        conclusion: "success",
+        pullNumber: 747,
+        updatedAt: "2026-05-20T00:12:01Z"
+      })
+    }),
+    {
+      ...gatewayAuthEnv,
+      DASHBOARD_EVENT_STORE: eventStore,
+      DASHBOARD_CHAT_STORE: chatStore
+    }
+  );
+
+  assert.equal(response.status, 502);
+  const body = await response.json();
+  assert.equal(body.ok, false);
+  assert.equal(body.error, "dashboard_event_chat_append_failed");
+  assert.equal(body.rollback.notificationDeleted, true);
+
+  const latest = await eventStore.latest({
+    kind: "github_actions_workflow_run",
+    repository: "marushu/vtdd-v2-p",
+    workflowName: "deploy-production"
+  });
+  assert.equal(latest, null);
+});
+
 test("worker does not infer PR number from issue-style parenthetical summary", async () => {
   const response = await worker.fetch(
     new Request("https://example.com/v2/events/github-actions", {
@@ -6384,7 +6510,8 @@ test("worker does not infer PR number from issue-style parenthetical summary", a
     }),
     {
       ...gatewayAuthEnv,
-      DASHBOARD_EVENT_STORE: createInMemoryDashboardEventStore()
+      DASHBOARD_EVENT_STORE: createInMemoryDashboardEventStore(),
+      DASHBOARD_CHAT_STORE: createInMemoryDashboardChatStore()
     }
   );
 

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -1,5 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import path from "node:path";
 import worker from "../src/worker.js";
 import { DashboardChatRoom } from "../src/worker.js";
 import {
@@ -6155,6 +6157,9 @@ test("worker ingests GitHub Actions deploy completion event and shows it on dash
   assert.equal(eventBody.event.pwaNotificationAttempted, 1);
   assert.equal(eventBody.event.pwaNotificationDelivered, 1);
   assert.equal(eventBody.threadId, "dashboard-main-marushu-vtdd-v2-p");
+  assert.equal(eventBody.chatAppendStatus, "appended");
+  assert.equal(eventBody.chatAppendError, null);
+  assert.equal(eventBody.chatAppendReason, null);
   assert.equal(eventBody.messages.length, 1);
   assert.equal(eventBody.messages[0].messageId, "dashboard-event:github-actions:marushu/vtdd-v2-p:deploy-production:26133044458");
   assert.equal(eventBody.messages[0].role, "system");
@@ -6251,6 +6256,9 @@ test("worker ingests GitHub Actions deploy completion event and shows it on dash
   const duplicateChatBody = await duplicateChat.json();
   assert.equal(duplicateChatBody.messages.length, 1);
   assert.equal(duplicateChatBody.messages[0].messageId, "dashboard-event:github-actions:marushu/vtdd-v2-p:deploy-production:26133044458");
+  const runtimeSource = await fs.readFile(path.join(process.cwd(), "src", "worker", "runtime.js"), "utf8");
+  assert.equal(runtimeSource.includes("PRIMARY KEY (thread_id, message_id)"), true);
+  assert.equal(runtimeSource.includes("INSERT OR REPLACE INTO vtdd_dashboard_chat_messages"), true);
 
   const dashboardResponse = await worker.fetch(
     new Request("https://example.com/dashboard", {
@@ -6446,8 +6454,9 @@ test("worker rejects GitHub Actions deploy completion event without machine auth
   assert.equal(response.status, 401);
 });
 
-test("worker rolls back GitHub Actions notification when Butler chat append fails", async () => {
+test("worker records GitHub Actions event without Web Push when Butler chat append fails", async () => {
   const eventStore = createInMemoryDashboardEventStore();
+  const pushCalls = [];
   const chatStore = {
     async appendMany() {
       throw new Error("chat append failed");
@@ -6473,23 +6482,82 @@ test("worker rolls back GitHub Actions notification when Butler chat append fail
     }),
     {
       ...gatewayAuthEnv,
+      ...(await createTestVapidEnv({
+        DASHBOARD_WEB_PUSH_FETCH: async (input, init) => {
+          pushCalls.push({ input, init });
+          return new Response(null, { status: 201 });
+        }
+      })),
       DASHBOARD_EVENT_STORE: eventStore,
       DASHBOARD_CHAT_STORE: chatStore
     }
   );
 
-  assert.equal(response.status, 502);
+  assert.equal(response.status, 202);
   const body = await response.json();
-  assert.equal(body.ok, false);
-  assert.equal(body.error, "dashboard_event_chat_append_failed");
-  assert.equal(body.rollback.notificationDeleted, true);
+  assert.equal(body.ok, true);
+  assert.equal(body.chatAppendStatus, "failed");
+  assert.equal(body.chatAppendError, "dashboard_event_chat_append_failed");
+  assert.equal(body.webPush.status, 204);
+  assert.equal(body.webPush.delivered, 0);
+  assert.equal(pushCalls.length, 0);
 
   const latest = await eventStore.latest({
     kind: "github_actions_workflow_run",
     repository: "marushu/vtdd-v2-p",
     workflowName: "deploy-production"
   });
-  assert.equal(latest, null);
+  assert.equal(latest.pwaNotificationStatus, "dashboard_event_chat_append_failed");
+  assert.equal(latest.pwaNotificationAttempted, 0);
+  assert.equal(latest.pwaNotificationDelivered, 0);
+});
+
+test("worker accepts GitHub Actions event without Web Push when dashboard chat store is unavailable", async () => {
+  const eventStore = createInMemoryDashboardEventStore();
+  const pushCalls = [];
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/events/github-actions", {
+      method: "POST",
+      headers: gatewayAuthHeaders,
+      body: JSON.stringify({
+        repository: "marushu/vtdd-v2-p",
+        workflowName: "deploy-production",
+        runId: "26133048888",
+        status: "completed",
+        conclusion: "success",
+        pullNumber: 748,
+        updatedAt: "2026-05-20T00:13:01Z"
+      })
+    }),
+    {
+      ...gatewayAuthEnv,
+      ...(await createTestVapidEnv({
+        DASHBOARD_WEB_PUSH_FETCH: async (input, init) => {
+          pushCalls.push({ input, init });
+          return new Response(null, { status: 201 });
+        }
+      })),
+      DASHBOARD_EVENT_STORE: eventStore
+    }
+  );
+
+  assert.equal(response.status, 202);
+  const body = await response.json();
+  assert.equal(body.ok, true);
+  assert.equal(body.chatAppendStatus, "unavailable");
+  assert.equal(body.chatAppendError, "dashboard_chat_store_unavailable");
+  assert.equal(body.messages.length, 0);
+  assert.equal(body.webPush.status, 204);
+  assert.equal(pushCalls.length, 0);
+
+  const latest = await eventStore.latest({
+    kind: "github_actions_workflow_run",
+    repository: "marushu/vtdd-v2-p",
+    workflowName: "deploy-production"
+  });
+  assert.equal(latest.pwaNotificationStatus, "dashboard_chat_store_unavailable");
+  assert.equal(latest.pwaNotificationAttempted, 0);
+  assert.equal(latest.pwaNotificationDelivered, 0);
 });
 
 test("worker does not infer PR number from issue-style parenthetical summary", async () => {

--- a/worker.js
+++ b/worker.js
@@ -61394,9 +61394,21 @@ async function handleGitHubActionsEventRequest(request, env) {
       reason: "dashboard event store is not configured"
     });
   }
-  const threadId = event.threadId || buildDashboardEventDefaultThreadId(event.event);
+  const baseEvent = normalizeDashboardEventRecord(event.event);
+  const existingEvent = await readDashboardEventById(store, baseEvent.id);
+  const acceptedEvent = normalizeDashboardEventRecord({
+    ...baseEvent,
+    pwaNotificationStatus: existingEvent?.pwaNotificationStatus === "sent" ? "sent" : "dashboard_event_received",
+    pwaNotificationError: existingEvent?.pwaNotificationError || null,
+    pwaNotificationReason: existingEvent?.pwaNotificationReason || null,
+    pwaNotificationAttempted: existingEvent?.pwaNotificationAttempted || 0,
+    pwaNotificationDelivered: existingEvent?.pwaNotificationDelivered || 0,
+    pwaNotificationCleaned: existingEvent?.pwaNotificationCleaned || 0
+  });
+  await store.put(acceptedEvent);
+  const threadId = event.threadId || buildDashboardEventDefaultThreadId(baseEvent);
   const chatMessage = buildGitHubActionsDashboardChatMessage({
-    event: event.event,
+    event: baseEvent,
     threadId
   });
   const chatStore = resolveDashboardChatStore(env);
@@ -61419,12 +61431,20 @@ async function handleGitHubActionsEventRequest(request, env) {
       chatAppendReason = "dashboard Butler chat store is not configured";
     }
   }
-  const shouldDispatchNotification = chatAppendStatus === "appended";
+  const duplicateNotificationAlreadySent = existingEvent?.pwaNotificationStatus === "sent" && Number(existingEvent?.pwaNotificationDelivered || 0) > 0;
+  const shouldDispatchNotification = chatAppendStatus === "appended" && !duplicateNotificationAlreadySent;
   const recorded = await recordDashboardNotificationEvent({
     env,
     eventStore: store,
-    event: event.event,
-    overrides: shouldDispatchNotification ? {} : {
+    event: baseEvent,
+    overrides: shouldDispatchNotification ? {} : duplicateNotificationAlreadySent ? {
+      pwaNotificationStatus: "sent",
+      pwaNotificationError: null,
+      pwaNotificationReason: "duplicate event ignored after prior Web Push delivery",
+      pwaNotificationAttempted: existingEvent.pwaNotificationAttempted || 0,
+      pwaNotificationDelivered: existingEvent.pwaNotificationDelivered || 0,
+      pwaNotificationCleaned: existingEvent.pwaNotificationCleaned || 0
+    } : {
       pwaNotificationStatus: chatAppendError || "dashboard_chat_append_skipped",
       pwaNotificationError: chatAppendError || null,
       pwaNotificationReason: chatAppendReason || "dashboard Butler chat append did not complete",
@@ -61446,6 +61466,17 @@ async function handleGitHubActionsEventRequest(request, env) {
     webSocketBroadcast,
     webPush: recorded.webPush
   });
+}
+async function readDashboardEventById(eventStore, eventId) {
+  const id = normalizeDashboardEventText(eventId);
+  if (!id || !eventStore || typeof eventStore.get !== "function") {
+    return null;
+  }
+  try {
+    return await eventStore.get(id);
+  } catch {
+    return null;
+  }
 }
 async function recordDashboardNotificationEvent({ env, eventStore, event, overrides = {}, dispatch = true } = {}) {
   const baseEvent = normalizeDashboardEventRecord({
@@ -66032,6 +66063,23 @@ function createD1DashboardEventStore(d1) {
       await ensureSchema();
       await d1.prepare("DELETE FROM vtdd_dashboard_events WHERE id = ?").bind(id).run();
       return true;
+    },
+    async get(eventId) {
+      const id = normalizeDashboardEventText(eventId);
+      if (!id) {
+        return null;
+      }
+      await ensureSchema();
+      const result = await d1.prepare("SELECT payload_json FROM vtdd_dashboard_events WHERE id = ? LIMIT 1").bind(id).all();
+      const row = Array.isArray(result?.results) ? result.results[0] : null;
+      if (!row?.payload_json) {
+        return null;
+      }
+      try {
+        return normalizeDashboardEventRecord(JSON.parse(row.payload_json));
+      } catch {
+        return null;
+      }
     },
     async latest(filter = {}) {
       await ensureSchema();

--- a/worker.js
+++ b/worker.js
@@ -40,9 +40,9 @@ var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__ge
   mod
 ));
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/pvtsutils/build/index.js
+// node_modules/pvtsutils/build/index.js
 var require_build = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/pvtsutils/build/index.js"(exports) {
+  "node_modules/pvtsutils/build/index.js"(exports) {
     "use strict";
     var ARRAY_BUFFER_NAME = "[object ArrayBuffer]";
     var BufferSourceConverter6 = class _BufferSourceConverter {
@@ -404,9 +404,9 @@ var require_build = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/reflect-metadata/Reflect.js
+// node_modules/reflect-metadata/Reflect.js
 var require_Reflect = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/reflect-metadata/Reflect.js"() {
+  "node_modules/reflect-metadata/Reflect.js"() {
     var Reflect2;
     (function(Reflect3) {
       (function(factory) {
@@ -1495,9 +1495,9 @@ var require_crypto = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tweetnacl/nacl-fast.js
+// node_modules/tweetnacl/nacl-fast.js
 var require_nacl_fast = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tweetnacl/nacl-fast.js"(exports, module) {
+  "node_modules/tweetnacl/nacl-fast.js"(exports, module) {
     (function(nacl5) {
       "use strict";
       var gf = function(init) {
@@ -3719,18 +3719,18 @@ var require_nacl_fast = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tweetnacl-sealedbox-js/src/consts.js
+// node_modules/tweetnacl-sealedbox-js/src/consts.js
 var import_tweetnacl, overheadLength;
 var init_consts = __esm({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tweetnacl-sealedbox-js/src/consts.js"() {
+  "node_modules/tweetnacl-sealedbox-js/src/consts.js"() {
     import_tweetnacl = __toESM(require_nacl_fast());
     overheadLength = import_tweetnacl.default.box.publicKeyLength + import_tweetnacl.default.box.overheadLength;
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/blakejs/util.js
+// node_modules/blakejs/util.js
 var require_util = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/blakejs/util.js"(exports, module) {
+  "node_modules/blakejs/util.js"(exports, module) {
     var ERROR_MSG_INPUT = "Input must be an string, Buffer or Uint8Array";
     function normalizeInput(input) {
       let ret;
@@ -3800,9 +3800,9 @@ var require_util = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/blakejs/blake2b.js
+// node_modules/blakejs/blake2b.js
 var require_blake2b = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/blakejs/blake2b.js"(exports, module) {
+  "node_modules/blakejs/blake2b.js"(exports, module) {
     var util2 = require_util();
     function ADD64AA(v2, a, b) {
       const o0 = v2[a] + v2[b];
@@ -4274,7 +4274,7 @@ var require_blake2b = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tweetnacl-sealedbox-js/src/nonce.js
+// node_modules/tweetnacl-sealedbox-js/src/nonce.js
 function nonce(pk1, pk2) {
   var state = import_blake2b.default.blake2bInit(import_tweetnacl2.default.box.nonceLength, null);
   import_blake2b.default.blake2bUpdate(state, pk1);
@@ -4283,24 +4283,24 @@ function nonce(pk1, pk2) {
 }
 var import_tweetnacl2, import_blake2b;
 var init_nonce = __esm({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tweetnacl-sealedbox-js/src/nonce.js"() {
+  "node_modules/tweetnacl-sealedbox-js/src/nonce.js"() {
     import_tweetnacl2 = __toESM(require_nacl_fast());
     import_blake2b = __toESM(require_blake2b());
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tweetnacl-sealedbox-js/src/utils.js
+// node_modules/tweetnacl-sealedbox-js/src/utils.js
 function zero(buf) {
   for (var i = 0; i < buf.length; i++) {
     buf[i] = 0;
   }
 }
 var init_utils = __esm({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tweetnacl-sealedbox-js/src/utils.js"() {
+  "node_modules/tweetnacl-sealedbox-js/src/utils.js"() {
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tweetnacl-sealedbox-js/src/seal.js
+// node_modules/tweetnacl-sealedbox-js/src/seal.js
 function seal(m, pk) {
   var c = new Uint8Array(overheadLength + m.length);
   var ek = import_tweetnacl3.default.box.keyPair();
@@ -4313,7 +4313,7 @@ function seal(m, pk) {
 }
 var import_tweetnacl3;
 var init_seal = __esm({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tweetnacl-sealedbox-js/src/seal.js"() {
+  "node_modules/tweetnacl-sealedbox-js/src/seal.js"() {
     import_tweetnacl3 = __toESM(require_nacl_fast());
     init_nonce();
     init_consts();
@@ -4321,7 +4321,7 @@ var init_seal = __esm({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tweetnacl-sealedbox-js/src/open.js
+// node_modules/tweetnacl-sealedbox-js/src/open.js
 function open(c, pk, sk) {
   var epk = c.subarray(0, import_tweetnacl4.default.box.publicKeyLength);
   var nonce2 = nonce(epk, pk);
@@ -4330,13 +4330,13 @@ function open(c, pk, sk) {
 }
 var import_tweetnacl4;
 var init_open = __esm({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tweetnacl-sealedbox-js/src/open.js"() {
+  "node_modules/tweetnacl-sealedbox-js/src/open.js"() {
     import_tweetnacl4 = __toESM(require_nacl_fast());
     init_nonce();
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tweetnacl-sealedbox-js/entrypoint.js
+// node_modules/tweetnacl-sealedbox-js/entrypoint.js
 var entrypoint_exports = {};
 __export(entrypoint_exports, {
   default: () => entrypoint_default,
@@ -4346,7 +4346,7 @@ __export(entrypoint_exports, {
 });
 var entrypoint_default;
 var init_entrypoint = __esm({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tweetnacl-sealedbox-js/entrypoint.js"() {
+  "node_modules/tweetnacl-sealedbox-js/entrypoint.js"() {
     init_consts();
     init_seal();
     init_open();
@@ -4354,9 +4354,9 @@ var init_entrypoint = __esm({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/codegen/code.js
+// node_modules/ajv/dist/compile/codegen/code.js
 var require_code = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/codegen/code.js"(exports) {
+  "node_modules/ajv/dist/compile/codegen/code.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.regexpCode = exports.getEsmExportName = exports.getProperty = exports.safeStringify = exports.stringify = exports.strConcat = exports.addCodeArg = exports.str = exports._ = exports.nil = exports._Code = exports.Name = exports.IDENTIFIER = exports._CodeOrName = void 0;
@@ -4508,9 +4508,9 @@ var require_code = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/codegen/scope.js
+// node_modules/ajv/dist/compile/codegen/scope.js
 var require_scope = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/codegen/scope.js"(exports) {
+  "node_modules/ajv/dist/compile/codegen/scope.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.ValueScope = exports.ValueScopeName = exports.Scope = exports.varKinds = exports.UsedValueState = void 0;
@@ -4653,9 +4653,9 @@ var require_scope = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/codegen/index.js
+// node_modules/ajv/dist/compile/codegen/index.js
 var require_codegen = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/codegen/index.js"(exports) {
+  "node_modules/ajv/dist/compile/codegen/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.or = exports.and = exports.not = exports.CodeGen = exports.operators = exports.varKinds = exports.ValueScopeName = exports.ValueScope = exports.Scope = exports.Name = exports.regexpCode = exports.stringify = exports.getProperty = exports.nil = exports.strConcat = exports.str = exports._ = void 0;
@@ -5373,9 +5373,9 @@ var require_codegen = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/util.js
+// node_modules/ajv/dist/compile/util.js
 var require_util2 = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/util.js"(exports) {
+  "node_modules/ajv/dist/compile/util.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.checkStrictMode = exports.getErrorPath = exports.Type = exports.useFunc = exports.setEvaluated = exports.evaluatedPropsToName = exports.mergeEvaluated = exports.eachItem = exports.unescapeJsonPointer = exports.escapeJsonPointer = exports.escapeFragment = exports.unescapeFragment = exports.schemaRefOrVal = exports.schemaHasRulesButRef = exports.schemaHasRules = exports.checkUnknownRules = exports.alwaysValidSchema = exports.toHash = void 0;
@@ -5540,9 +5540,9 @@ var require_util2 = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/names.js
+// node_modules/ajv/dist/compile/names.js
 var require_names = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/names.js"(exports) {
+  "node_modules/ajv/dist/compile/names.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -5579,9 +5579,9 @@ var require_names = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/errors.js
+// node_modules/ajv/dist/compile/errors.js
 var require_errors = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/errors.js"(exports) {
+  "node_modules/ajv/dist/compile/errors.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.extendErrors = exports.resetErrorsCount = exports.reportExtraError = exports.reportError = exports.keyword$DataError = exports.keywordError = void 0;
@@ -5701,9 +5701,9 @@ var require_errors = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/validate/boolSchema.js
+// node_modules/ajv/dist/compile/validate/boolSchema.js
 var require_boolSchema = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/validate/boolSchema.js"(exports) {
+  "node_modules/ajv/dist/compile/validate/boolSchema.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.boolOrEmptySchema = exports.topBoolOrEmptySchema = void 0;
@@ -5752,9 +5752,9 @@ var require_boolSchema = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/rules.js
+// node_modules/ajv/dist/compile/rules.js
 var require_rules = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/rules.js"(exports) {
+  "node_modules/ajv/dist/compile/rules.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.getRules = exports.isJSONType = void 0;
@@ -5783,9 +5783,9 @@ var require_rules = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/validate/applicability.js
+// node_modules/ajv/dist/compile/validate/applicability.js
 var require_applicability = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/validate/applicability.js"(exports) {
+  "node_modules/ajv/dist/compile/validate/applicability.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.shouldUseRule = exports.shouldUseGroup = exports.schemaHasRulesForType = void 0;
@@ -5806,9 +5806,9 @@ var require_applicability = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/validate/dataType.js
+// node_modules/ajv/dist/compile/validate/dataType.js
 var require_dataType = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/validate/dataType.js"(exports) {
+  "node_modules/ajv/dist/compile/validate/dataType.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.reportTypeError = exports.checkDataTypes = exports.checkDataType = exports.coerceAndCheckDataType = exports.getJSONTypes = exports.getSchemaTypes = exports.DataType = void 0;
@@ -5990,9 +5990,9 @@ var require_dataType = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/validate/defaults.js
+// node_modules/ajv/dist/compile/validate/defaults.js
 var require_defaults = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/validate/defaults.js"(exports) {
+  "node_modules/ajv/dist/compile/validate/defaults.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.assignDefaults = void 0;
@@ -6027,9 +6027,9 @@ var require_defaults = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/code.js
+// node_modules/ajv/dist/vocabularies/code.js
 var require_code2 = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/code.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/code.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.validateUnion = exports.validateArray = exports.usePattern = exports.callValidateCode = exports.schemaProperties = exports.allSchemaProperties = exports.noPropertyInData = exports.propertyInData = exports.isOwnProperty = exports.hasPropFunc = exports.reportMissingProp = exports.checkMissingProp = exports.checkReportMissingProp = void 0;
@@ -6160,9 +6160,9 @@ var require_code2 = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/validate/keyword.js
+// node_modules/ajv/dist/compile/validate/keyword.js
 var require_keyword = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/validate/keyword.js"(exports) {
+  "node_modules/ajv/dist/compile/validate/keyword.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.validateKeywordUsage = exports.validSchemaType = exports.funcKeywordCode = exports.macroKeywordCode = void 0;
@@ -6278,9 +6278,9 @@ var require_keyword = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/validate/subschema.js
+// node_modules/ajv/dist/compile/validate/subschema.js
 var require_subschema = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/validate/subschema.js"(exports) {
+  "node_modules/ajv/dist/compile/validate/subschema.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.extendSubschemaMode = exports.extendSubschemaData = exports.getSubschema = void 0;
@@ -6361,9 +6361,9 @@ var require_subschema = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/fast-deep-equal/index.js
+// node_modules/fast-deep-equal/index.js
 var require_fast_deep_equal = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/fast-deep-equal/index.js"(exports, module) {
+  "node_modules/fast-deep-equal/index.js"(exports, module) {
     "use strict";
     module.exports = function equal(a, b) {
       if (a === b) return true;
@@ -6396,9 +6396,9 @@ var require_fast_deep_equal = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/json-schema-traverse/index.js
+// node_modules/json-schema-traverse/index.js
 var require_json_schema_traverse = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/json-schema-traverse/index.js"(exports, module) {
+  "node_modules/json-schema-traverse/index.js"(exports, module) {
     "use strict";
     var traverse = module.exports = function(schema, opts, cb) {
       if (typeof opts == "function") {
@@ -6484,9 +6484,9 @@ var require_json_schema_traverse = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/resolve.js
+// node_modules/ajv/dist/compile/resolve.js
 var require_resolve = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/resolve.js"(exports) {
+  "node_modules/ajv/dist/compile/resolve.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.getSchemaRefs = exports.resolveUrl = exports.normalizeId = exports._getFullPath = exports.getFullPath = exports.inlineRef = void 0;
@@ -6640,9 +6640,9 @@ var require_resolve = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/validate/index.js
+// node_modules/ajv/dist/compile/validate/index.js
 var require_validate = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/validate/index.js"(exports) {
+  "node_modules/ajv/dist/compile/validate/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.getData = exports.KeywordCxt = exports.validateFunctionCode = void 0;
@@ -7148,9 +7148,9 @@ var require_validate = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/runtime/validation_error.js
+// node_modules/ajv/dist/runtime/validation_error.js
 var require_validation_error = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/runtime/validation_error.js"(exports) {
+  "node_modules/ajv/dist/runtime/validation_error.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var ValidationError = class extends Error {
@@ -7164,9 +7164,9 @@ var require_validation_error = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/ref_error.js
+// node_modules/ajv/dist/compile/ref_error.js
 var require_ref_error = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/ref_error.js"(exports) {
+  "node_modules/ajv/dist/compile/ref_error.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var resolve_1 = require_resolve();
@@ -7181,9 +7181,9 @@ var require_ref_error = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/index.js
+// node_modules/ajv/dist/compile/index.js
 var require_compile = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/index.js"(exports) {
+  "node_modules/ajv/dist/compile/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.resolveSchema = exports.getCompilingSchema = exports.resolveRef = exports.compileSchema = exports.SchemaEnv = void 0;
@@ -7405,9 +7405,9 @@ var require_compile = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/refs/data.json
+// node_modules/ajv/dist/refs/data.json
 var require_data = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/refs/data.json"(exports, module) {
+  "node_modules/ajv/dist/refs/data.json"(exports, module) {
     module.exports = {
       $id: "https://raw.githubusercontent.com/ajv-validator/ajv/master/lib/refs/data.json#",
       description: "Meta-schema for $data reference (JSON AnySchema extension proposal)",
@@ -7424,9 +7424,9 @@ var require_data = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/fast-uri/lib/utils.js
+// node_modules/fast-uri/lib/utils.js
 var require_utils = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/fast-uri/lib/utils.js"(exports, module) {
+  "node_modules/fast-uri/lib/utils.js"(exports, module) {
     "use strict";
     var isUUID = RegExp.prototype.test.bind(/^[\da-f]{8}-[\da-f]{4}-[\da-f]{4}-[\da-f]{4}-[\da-f]{12}$/iu);
     var isIPv4 = RegExp.prototype.test.bind(/^(?:(?:25[0-5]|2[0-4]\d|1\d{2}|[1-9]\d|\d)\.){3}(?:25[0-5]|2[0-4]\d|1\d{2}|[1-9]\d|\d)$/u);
@@ -7737,9 +7737,9 @@ var require_utils = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/fast-uri/lib/schemes.js
+// node_modules/fast-uri/lib/schemes.js
 var require_schemes = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/fast-uri/lib/schemes.js"(exports, module) {
+  "node_modules/fast-uri/lib/schemes.js"(exports, module) {
     "use strict";
     var { isUUID } = require_utils();
     var URN_REG = /([\da-z][\d\-a-z]{0,31}):((?:[\w!$'()*+,\-.:;=@]|%[\da-f]{2})+)/iu;
@@ -7947,9 +7947,9 @@ var require_schemes = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/fast-uri/index.js
+// node_modules/fast-uri/index.js
 var require_fast_uri = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/fast-uri/index.js"(exports, module) {
+  "node_modules/fast-uri/index.js"(exports, module) {
     "use strict";
     var { normalizeIPv6, removeDotSegments, recomposeAuthority, normalizePercentEncoding, normalizePathEncoding, escapePreservingEscapes, reescapeHostDelimiters, isIPv4, nonSimpleDomain } = require_utils();
     var { SCHEMES, getSchemeHandler } = require_schemes();
@@ -8233,9 +8233,9 @@ var require_fast_uri = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/runtime/uri.js
+// node_modules/ajv/dist/runtime/uri.js
 var require_uri = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/runtime/uri.js"(exports) {
+  "node_modules/ajv/dist/runtime/uri.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var uri = require_fast_uri();
@@ -8244,9 +8244,9 @@ var require_uri = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/core.js
+// node_modules/ajv/dist/core.js
 var require_core = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/core.js"(exports) {
+  "node_modules/ajv/dist/core.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.CodeGen = exports.Name = exports.nil = exports.stringify = exports.str = exports._ = exports.KeywordCxt = void 0;
@@ -8855,9 +8855,9 @@ var require_core = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/core/id.js
+// node_modules/ajv/dist/vocabularies/core/id.js
 var require_id = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/core/id.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/core/id.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var def = {
@@ -8870,9 +8870,9 @@ var require_id = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/core/ref.js
+// node_modules/ajv/dist/vocabularies/core/ref.js
 var require_ref = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/core/ref.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/core/ref.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.callRef = exports.getValidate = void 0;
@@ -8992,9 +8992,9 @@ var require_ref = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/core/index.js
+// node_modules/ajv/dist/vocabularies/core/index.js
 var require_core2 = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/core/index.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/core/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var id_1 = require_id();
@@ -9013,9 +9013,9 @@ var require_core2 = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/limitNumber.js
+// node_modules/ajv/dist/vocabularies/validation/limitNumber.js
 var require_limitNumber = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/limitNumber.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/validation/limitNumber.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -9045,9 +9045,9 @@ var require_limitNumber = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/multipleOf.js
+// node_modules/ajv/dist/vocabularies/validation/multipleOf.js
 var require_multipleOf = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/multipleOf.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/validation/multipleOf.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -9073,9 +9073,9 @@ var require_multipleOf = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/runtime/ucs2length.js
+// node_modules/ajv/dist/runtime/ucs2length.js
 var require_ucs2length = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/runtime/ucs2length.js"(exports) {
+  "node_modules/ajv/dist/runtime/ucs2length.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     function ucs2length(str) {
@@ -9099,9 +9099,9 @@ var require_ucs2length = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/limitLength.js
+// node_modules/ajv/dist/vocabularies/validation/limitLength.js
 var require_limitLength = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/limitLength.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/validation/limitLength.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -9131,9 +9131,9 @@ var require_limitLength = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/pattern.js
+// node_modules/ajv/dist/vocabularies/validation/pattern.js
 var require_pattern = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/pattern.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/validation/pattern.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var code_1 = require_code2();
@@ -9168,9 +9168,9 @@ var require_pattern = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/limitProperties.js
+// node_modules/ajv/dist/vocabularies/validation/limitProperties.js
 var require_limitProperties = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/limitProperties.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/validation/limitProperties.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -9197,9 +9197,9 @@ var require_limitProperties = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/required.js
+// node_modules/ajv/dist/vocabularies/validation/required.js
 var require_required = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/required.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/validation/required.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var code_1 = require_code2();
@@ -9279,9 +9279,9 @@ var require_required = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/limitItems.js
+// node_modules/ajv/dist/vocabularies/validation/limitItems.js
 var require_limitItems = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/limitItems.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/validation/limitItems.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -9308,9 +9308,9 @@ var require_limitItems = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/runtime/equal.js
+// node_modules/ajv/dist/runtime/equal.js
 var require_equal = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/runtime/equal.js"(exports) {
+  "node_modules/ajv/dist/runtime/equal.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var equal = require_fast_deep_equal();
@@ -9319,9 +9319,9 @@ var require_equal = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/uniqueItems.js
+// node_modules/ajv/dist/vocabularies/validation/uniqueItems.js
 var require_uniqueItems = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/uniqueItems.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/validation/uniqueItems.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var dataType_1 = require_dataType();
@@ -9386,9 +9386,9 @@ var require_uniqueItems = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/const.js
+// node_modules/ajv/dist/vocabularies/validation/const.js
 var require_const = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/const.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/validation/const.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -9415,9 +9415,9 @@ var require_const = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/enum.js
+// node_modules/ajv/dist/vocabularies/validation/enum.js
 var require_enum = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/enum.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/validation/enum.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -9464,9 +9464,9 @@ var require_enum = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/index.js
+// node_modules/ajv/dist/vocabularies/validation/index.js
 var require_validation = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/index.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/validation/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var limitNumber_1 = require_limitNumber();
@@ -9502,9 +9502,9 @@ var require_validation = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/additionalItems.js
+// node_modules/ajv/dist/vocabularies/applicator/additionalItems.js
 var require_additionalItems = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/additionalItems.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/applicator/additionalItems.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.validateAdditionalItems = void 0;
@@ -9555,9 +9555,9 @@ var require_additionalItems = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/items.js
+// node_modules/ajv/dist/vocabularies/applicator/items.js
 var require_items = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/items.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/applicator/items.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.validateTuple = void 0;
@@ -9612,9 +9612,9 @@ var require_items = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/prefixItems.js
+// node_modules/ajv/dist/vocabularies/applicator/prefixItems.js
 var require_prefixItems = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/prefixItems.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/applicator/prefixItems.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var items_1 = require_items();
@@ -9629,9 +9629,9 @@ var require_prefixItems = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/items2020.js
+// node_modules/ajv/dist/vocabularies/applicator/items2020.js
 var require_items2020 = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/items2020.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/applicator/items2020.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -9664,9 +9664,9 @@ var require_items2020 = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/contains.js
+// node_modules/ajv/dist/vocabularies/applicator/contains.js
 var require_contains = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/contains.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/applicator/contains.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -9758,9 +9758,9 @@ var require_contains = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/dependencies.js
+// node_modules/ajv/dist/vocabularies/applicator/dependencies.js
 var require_dependencies = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/dependencies.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/applicator/dependencies.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.validateSchemaDeps = exports.validatePropertyDeps = exports.error = void 0;
@@ -9852,9 +9852,9 @@ var require_dependencies = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/propertyNames.js
+// node_modules/ajv/dist/vocabularies/applicator/propertyNames.js
 var require_propertyNames = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/propertyNames.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/applicator/propertyNames.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -9895,9 +9895,9 @@ var require_propertyNames = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/additionalProperties.js
+// node_modules/ajv/dist/vocabularies/applicator/additionalProperties.js
 var require_additionalProperties = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/additionalProperties.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/applicator/additionalProperties.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var code_1 = require_code2();
@@ -10001,9 +10001,9 @@ var require_additionalProperties = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/properties.js
+// node_modules/ajv/dist/vocabularies/applicator/properties.js
 var require_properties = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/properties.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/applicator/properties.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var validate_1 = require_validate();
@@ -10059,9 +10059,9 @@ var require_properties = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/patternProperties.js
+// node_modules/ajv/dist/vocabularies/applicator/patternProperties.js
 var require_patternProperties = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/patternProperties.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/applicator/patternProperties.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var code_1 = require_code2();
@@ -10133,9 +10133,9 @@ var require_patternProperties = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/not.js
+// node_modules/ajv/dist/vocabularies/applicator/not.js
 var require_not = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/not.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/applicator/not.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var util_1 = require_util2();
@@ -10164,9 +10164,9 @@ var require_not = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/anyOf.js
+// node_modules/ajv/dist/vocabularies/applicator/anyOf.js
 var require_anyOf = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/anyOf.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/applicator/anyOf.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var code_1 = require_code2();
@@ -10181,9 +10181,9 @@ var require_anyOf = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/oneOf.js
+// node_modules/ajv/dist/vocabularies/applicator/oneOf.js
 var require_oneOf = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/oneOf.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/applicator/oneOf.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -10239,9 +10239,9 @@ var require_oneOf = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/allOf.js
+// node_modules/ajv/dist/vocabularies/applicator/allOf.js
 var require_allOf = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/allOf.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/applicator/allOf.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var util_1 = require_util2();
@@ -10266,9 +10266,9 @@ var require_allOf = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/if.js
+// node_modules/ajv/dist/vocabularies/applicator/if.js
 var require_if = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/if.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/applicator/if.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -10335,9 +10335,9 @@ var require_if = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/thenElse.js
+// node_modules/ajv/dist/vocabularies/applicator/thenElse.js
 var require_thenElse = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/thenElse.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/applicator/thenElse.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var util_1 = require_util2();
@@ -10353,9 +10353,9 @@ var require_thenElse = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/index.js
+// node_modules/ajv/dist/vocabularies/applicator/index.js
 var require_applicator = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/index.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/applicator/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var additionalItems_1 = require_additionalItems();
@@ -10401,9 +10401,9 @@ var require_applicator = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/format/format.js
+// node_modules/ajv/dist/vocabularies/format/format.js
 var require_format = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/format/format.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/format/format.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -10491,9 +10491,9 @@ var require_format = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/format/index.js
+// node_modules/ajv/dist/vocabularies/format/index.js
 var require_format2 = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/format/index.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/format/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var format_1 = require_format();
@@ -10502,9 +10502,9 @@ var require_format2 = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/metadata.js
+// node_modules/ajv/dist/vocabularies/metadata.js
 var require_metadata = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/metadata.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/metadata.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.contentVocabulary = exports.metadataVocabulary = void 0;
@@ -10525,9 +10525,9 @@ var require_metadata = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/draft7.js
+// node_modules/ajv/dist/vocabularies/draft7.js
 var require_draft7 = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/draft7.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/draft7.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var core_1 = require_core2();
@@ -10547,9 +10547,9 @@ var require_draft7 = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/discriminator/types.js
+// node_modules/ajv/dist/vocabularies/discriminator/types.js
 var require_types = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/discriminator/types.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/discriminator/types.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.DiscrError = void 0;
@@ -10561,9 +10561,9 @@ var require_types = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/discriminator/index.js
+// node_modules/ajv/dist/vocabularies/discriminator/index.js
 var require_discriminator = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/discriminator/index.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/discriminator/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -10666,9 +10666,9 @@ var require_discriminator = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/refs/json-schema-draft-07.json
+// node_modules/ajv/dist/refs/json-schema-draft-07.json
 var require_json_schema_draft_07 = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/refs/json-schema-draft-07.json"(exports, module) {
+  "node_modules/ajv/dist/refs/json-schema-draft-07.json"(exports, module) {
     module.exports = {
       $schema: "http://json-schema.org/draft-07/schema#",
       $id: "http://json-schema.org/draft-07/schema#",
@@ -10823,9 +10823,9 @@ var require_json_schema_draft_07 = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/ajv.js
+// node_modules/ajv/dist/ajv.js
 var require_ajv = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/ajv.js"(exports, module) {
+  "node_modules/ajv/dist/ajv.js"(exports, module) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.MissingRefError = exports.ValidationError = exports.CodeGen = exports.Name = exports.nil = exports.stringify = exports.str = exports._ = exports.KeywordCxt = exports.Ajv = void 0;
@@ -10893,9 +10893,9 @@ var require_ajv = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv-formats/dist/formats.js
+// node_modules/ajv-formats/dist/formats.js
 var require_formats = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv-formats/dist/formats.js"(exports) {
+  "node_modules/ajv-formats/dist/formats.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.formatNames = exports.fastFormats = exports.fullFormats = void 0;
@@ -11096,9 +11096,9 @@ var require_formats = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv-formats/dist/limit.js
+// node_modules/ajv-formats/dist/limit.js
 var require_limit = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv-formats/dist/limit.js"(exports) {
+  "node_modules/ajv-formats/dist/limit.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.formatLimitDefinition = void 0;
@@ -11168,9 +11168,9 @@ var require_limit = __commonJS({
   }
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv-formats/dist/index.js
+// node_modules/ajv-formats/dist/index.js
 var require_dist = __commonJS({
-  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv-formats/dist/index.js"(exports, module) {
+  "node_modules/ajv-formats/dist/index.js"(exports, module) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var formats_1 = require_formats();
@@ -11392,7 +11392,7 @@ var ProtectionSignalStatus = Object.freeze({
   UNKNOWN: "unknown"
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/iso/isoBase64URL.js
+// node_modules/@simplewebauthn/server/esm/helpers/iso/isoBase64URL.js
 var isoBase64URL_exports = {};
 __export(isoBase64URL_exports, {
   fromBuffer: () => fromBuffer,
@@ -11405,7 +11405,7 @@ __export(isoBase64URL_exports, {
   trimPadding: () => trimPadding
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@hexagon/base64/src/base64.js
+// node_modules/@hexagon/base64/src/base64.js
 var chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 var charsUrl = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
 var genLookup = (target) => {
@@ -11479,7 +11479,7 @@ base64.validate = (encoded, urlMode) => {
 base64.base64 = base64;
 var base64_default = base64;
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/iso/isoBase64URL.js
+// node_modules/@simplewebauthn/server/esm/helpers/iso/isoBase64URL.js
 function toBuffer(base64urlString, from = "base64url") {
   const _buffer = base64_default.toArrayBuffer(base64urlString, from === "base64url");
   return new Uint8Array(_buffer);
@@ -11510,14 +11510,14 @@ function trimPadding(input) {
   return input.replace(/=/g, "");
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/iso/isoCBOR.js
+// node_modules/@simplewebauthn/server/esm/helpers/iso/isoCBOR.js
 var isoCBOR_exports = {};
 __export(isoCBOR_exports, {
   decodeFirst: () => decodeFirst,
   encode: () => encode
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@levischuck/tiny-cbor/esm/cbor/cbor_internal.js
+// node_modules/@levischuck/tiny-cbor/esm/cbor/cbor_internal.js
 function decodeLength(data, argument, index) {
   if (argument < 24) {
     return [argument, 1];
@@ -11616,7 +11616,7 @@ function encodeLength(major, argument) {
   }
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@levischuck/tiny-cbor/esm/cbor/cbor.js
+// node_modules/@levischuck/tiny-cbor/esm/cbor/cbor.js
 var CBORTag = class {
   /**
    * Wrap a value with a tag number.
@@ -11943,7 +11943,7 @@ function encodeCBOR(data) {
   return output;
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/iso/isoCBOR.js
+// node_modules/@simplewebauthn/server/esm/helpers/iso/isoCBOR.js
 function decodeFirst(input) {
   const _input = new Uint8Array(input);
   const decoded = decodePartialCBOR(_input, 0);
@@ -11954,7 +11954,7 @@ function encode(input) {
   return encodeCBOR(input);
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/index.js
+// node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/index.js
 var isoCrypto_exports = {};
 __export(isoCrypto_exports, {
   digest: () => digest,
@@ -11962,7 +11962,7 @@ __export(isoCrypto_exports, {
   verify: () => verify
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/cose.js
+// node_modules/@simplewebauthn/server/esm/helpers/cose.js
 function isCOSEPublicKeyOKP(cosePublicKey) {
   const kty = cosePublicKey.get(COSEKEYS.kty);
   return isCOSEKty(kty) && kty === COSEKTY.OKP;
@@ -12024,7 +12024,7 @@ function isCOSEAlg(alg) {
   return Object.values(COSEALG).indexOf(alg) >= 0;
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/mapCoseAlgToWebCryptoAlg.js
+// node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/mapCoseAlgToWebCryptoAlg.js
 function mapCoseAlgToWebCryptoAlg(alg) {
   if ([COSEALG.RS1].indexOf(alg) >= 0) {
     return "SHA-1";
@@ -12038,7 +12038,7 @@ function mapCoseAlgToWebCryptoAlg(alg) {
   throw new Error(`Could not map COSE alg value of ${alg} to a WebCrypto alg`);
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/getWebCrypto.js
+// node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/getWebCrypto.js
 var webCrypto = void 0;
 function getWebCrypto() {
   const toResolve = new Promise((resolve, reject) => {
@@ -12069,7 +12069,7 @@ var _getWebCryptoInternals = {
   }
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/digest.js
+// node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/digest.js
 async function digest(data, algorithm) {
   const WebCrypto = await getWebCrypto();
   const subtleAlgorithm = mapCoseAlgToWebCryptoAlg(algorithm);
@@ -12077,14 +12077,14 @@ async function digest(data, algorithm) {
   return new Uint8Array(hashed);
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/getRandomValues.js
+// node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/getRandomValues.js
 async function getRandomValues(array2) {
   const WebCrypto = await getWebCrypto();
   WebCrypto.getRandomValues(array2);
   return array2;
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/importKey.js
+// node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/importKey.js
 async function importKey(opts) {
   const WebCrypto = await getWebCrypto();
   const { keyData, algorithm } = opts;
@@ -12093,7 +12093,7 @@ async function importKey(opts) {
   ]);
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/verifyEC2.js
+// node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/verifyEC2.js
 async function verifyEC2(opts) {
   const { cosePublicKey, signature, data, shaHashOverride } = opts;
   const WebCrypto = await getWebCrypto();
@@ -12155,7 +12155,7 @@ async function verifyEC2(opts) {
   return WebCrypto.subtle.verify(verifyAlgorithm, key, signature, data);
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/mapCoseAlgToWebCryptoKeyAlgName.js
+// node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/mapCoseAlgToWebCryptoKeyAlgName.js
 function mapCoseAlgToWebCryptoKeyAlgName(alg) {
   if ([COSEALG.EdDSA].indexOf(alg) >= 0) {
     return "Ed25519";
@@ -12169,7 +12169,7 @@ function mapCoseAlgToWebCryptoKeyAlgName(alg) {
   throw new Error(`Could not map COSE alg value of ${alg} to a WebCrypto key alg name`);
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/verifyRSA.js
+// node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/verifyRSA.js
 async function verifyRSA(opts) {
   const { cosePublicKey, signature, data, shaHashOverride } = opts;
   const WebCrypto = await getWebCrypto();
@@ -12238,7 +12238,7 @@ async function verifyRSA(opts) {
   return WebCrypto.subtle.verify(verifyAlgorithm, key, signature, data);
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/convertAAGUIDToString.js
+// node_modules/@simplewebauthn/server/esm/helpers/convertAAGUIDToString.js
 function convertAAGUIDToString(aaguid) {
   const hex = isoUint8Array_exports.toHex(aaguid);
   const segments = [
@@ -12256,7 +12256,7 @@ function convertAAGUIDToString(aaguid) {
   return segments.join("-");
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/convertCertBufferToPEM.js
+// node_modules/@simplewebauthn/server/esm/helpers/convertCertBufferToPEM.js
 function convertCertBufferToPEM(certBuffer) {
   let b64cert;
   if (typeof certBuffer === "string") {
@@ -12282,7 +12282,7 @@ ${PEMKey}-----END CERTIFICATE-----
   return PEMKey;
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/convertCOSEtoPKCS.js
+// node_modules/@simplewebauthn/server/esm/helpers/convertCOSEtoPKCS.js
 function convertCOSEtoPKCS(cosePublicKey) {
   const struct = isoCBOR_exports.decodeFirst(cosePublicKey);
   const tag = Uint8Array.from([4]);
@@ -12297,7 +12297,7 @@ function convertCOSEtoPKCS(cosePublicKey) {
   return isoUint8Array_exports.concat([tag, x]);
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/decodeAttestationObject.js
+// node_modules/@simplewebauthn/server/esm/helpers/decodeAttestationObject.js
 function decodeAttestationObject(attestationObject) {
   return _decodeAttestationObjectInternals.stubThis(isoCBOR_exports.decodeFirst(attestationObject));
 }
@@ -12305,7 +12305,7 @@ var _decodeAttestationObjectInternals = {
   stubThis: (value) => value
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/decodeClientDataJSON.js
+// node_modules/@simplewebauthn/server/esm/helpers/decodeClientDataJSON.js
 function decodeClientDataJSON(data) {
   const toString = isoBase64URL_exports.toUTF8String(data);
   const clientData = JSON.parse(toString);
@@ -12315,7 +12315,7 @@ var _decodeClientDataJSONInternals = {
   stubThis: (value) => value
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/decodeCredentialPublicKey.js
+// node_modules/@simplewebauthn/server/esm/helpers/decodeCredentialPublicKey.js
 function decodeCredentialPublicKey(publicKey) {
   return _decodeCredentialPublicKeyInternals.stubThis(isoCBOR_exports.decodeFirst(publicKey));
 }
@@ -12323,7 +12323,7 @@ var _decodeCredentialPublicKeyInternals = {
   stubThis: (value) => value
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/generateUserID.js
+// node_modules/@simplewebauthn/server/esm/helpers/generateUserID.js
 async function generateUserID() {
   const newUserID = new Uint8Array(32);
   await isoCrypto_exports.getRandomValues(newUserID);
@@ -12333,7 +12333,7 @@ var _generateUserIDInternals = {
   stubThis: (value) => value
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/asn1js/build/index.es.js
+// node_modules/asn1js/build/index.es.js
 var index_es_exports = {};
 __export(index_es_exports, {
   Any: () => Any,
@@ -12386,7 +12386,7 @@ __export(index_es_exports, {
 });
 var pvtsutils = __toESM(require_build());
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/pvutils/build/utils.es.js
+// node_modules/pvutils/build/utils.es.js
 function utilFromBase(inputBuffer, inputBase) {
   let result = 0;
   if (inputBuffer.length === 1) {
@@ -12524,7 +12524,7 @@ function padNumber(inputNumber, fullLength) {
 }
 var log2 = Math.log(2);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/asn1js/build/index.es.js
+// node_modules/asn1js/build/index.es.js
 function assertBigInt() {
   if (typeof BigInt === "undefined") {
     throw new Error("BigInt is not defined. Your environment doesn't implement BigInt.");
@@ -15565,7 +15565,7 @@ function verifySchema(inputBuffer, inputSchema) {
   return compareSchema(asn1.result, asn1.result, inputSchema);
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-schema/build/es2015/enums.js
+// node_modules/@peculiar/asn1-schema/build/es2015/enums.js
 var AsnTypeTypes;
 (function(AsnTypeTypes2) {
   AsnTypeTypes2[AsnTypeTypes2["Sequence"] = 0] = "Sequence";
@@ -15603,7 +15603,7 @@ var AsnPropTypes;
   AsnPropTypes2[AsnPropTypes2["Null"] = 27] = "Null";
 })(AsnPropTypes || (AsnPropTypes = {}));
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-schema/build/es2015/types/bit_string.js
+// node_modules/@peculiar/asn1-schema/build/es2015/types/bit_string.js
 var import_pvtsutils = __toESM(require_build());
 var BitString2 = class {
   constructor(params, unusedBits = 0) {
@@ -15661,7 +15661,7 @@ var BitString2 = class {
   }
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-schema/build/es2015/types/octet_string.js
+// node_modules/@peculiar/asn1-schema/build/es2015/types/octet_string.js
 var import_pvtsutils2 = __toESM(require_build());
 var OctetString2 = class {
   get byteLength() {
@@ -15698,7 +15698,7 @@ var OctetString2 = class {
   }
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-schema/build/es2015/converters.js
+// node_modules/@peculiar/asn1-schema/build/es2015/converters.js
 var AsnAnyConverter = {
   fromASN: (value) => value instanceof Null ? null : value.valueBeforeDecodeView,
   toASN: (value) => {
@@ -15827,7 +15827,7 @@ function defaultConverter(type) {
   }
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-schema/build/es2015/helper.js
+// node_modules/@peculiar/asn1-schema/build/es2015/helper.js
 function isConvertible(target) {
   if (typeof target === "function" && target.prototype) {
     if (target.prototype.toASN && target.prototype.fromASN) {
@@ -15867,7 +15867,7 @@ function isArrayEqual(bytes1, bytes2) {
   return true;
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-schema/build/es2015/schema.js
+// node_modules/@peculiar/asn1-schema/build/es2015/schema.js
 var AsnSchemaStorage = class {
   constructor() {
     this.items = /* @__PURE__ */ new WeakMap();
@@ -15991,10 +15991,10 @@ var AsnSchemaStorage = class {
   }
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-schema/build/es2015/storage.js
+// node_modules/@peculiar/asn1-schema/build/es2015/storage.js
 var schemaStorage = new AsnSchemaStorage();
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-schema/build/es2015/decorators.js
+// node_modules/@peculiar/asn1-schema/build/es2015/decorators.js
 var AsnType = (options) => (target) => {
   let schema;
   if (!schemaStorage.has(target)) {
@@ -16025,7 +16025,7 @@ var AsnProp = (options) => (target, propertyKey) => {
   schema.items[propertyKey] = copyOptions;
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-schema/build/es2015/errors/schema_validation.js
+// node_modules/@peculiar/asn1-schema/build/es2015/errors/schema_validation.js
 var AsnSchemaValidationError = class extends Error {
   constructor() {
     super(...arguments);
@@ -16033,7 +16033,7 @@ var AsnSchemaValidationError = class extends Error {
   }
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-schema/build/es2015/parser.js
+// node_modules/@peculiar/asn1-schema/build/es2015/parser.js
 var AsnParser = class {
   static parse(data, target) {
     const asn1Parsed = fromBER(data);
@@ -16308,7 +16308,7 @@ var AsnParser = class {
   }
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-schema/build/es2015/serializer.js
+// node_modules/@peculiar/asn1-schema/build/es2015/serializer.js
 var AsnSerializer = class _AsnSerializer {
   static serialize(obj) {
     if (obj instanceof BaseBlock) {
@@ -16442,7 +16442,7 @@ var AsnSerializer = class _AsnSerializer {
   }
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-schema/build/es2015/objects.js
+// node_modules/@peculiar/asn1-schema/build/es2015/objects.js
 var AsnArray = class extends Array {
   constructor(items = []) {
     if (typeof items === "number") {
@@ -16456,7 +16456,7 @@ var AsnArray = class extends Array {
   }
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-schema/build/es2015/convert.js
+// node_modules/@peculiar/asn1-schema/build/es2015/convert.js
 var import_pvtsutils3 = __toESM(require_build());
 var AsnConvert = class _AsnConvert {
   static serialize(obj) {
@@ -16475,7 +16475,7 @@ var AsnConvert = class _AsnConvert {
   }
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tslib/tslib.es6.mjs
+// node_modules/tslib/tslib.es6.mjs
 function __decorate(decorators, target, key, desc) {
   var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
   if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
@@ -16494,7 +16494,7 @@ function __classPrivateFieldSet(receiver, state, value, kind, f) {
   return kind === "a" ? f.call(receiver, value) : f ? f.value = value : state.set(receiver, value), value;
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/ip_converter.js
+// node_modules/@peculiar/asn1-x509/build/es2015/ip_converter.js
 var import_pvtsutils4 = __toESM(require_build());
 var IpConverter = class {
   static isIPv4(ip) {
@@ -16662,7 +16662,7 @@ var IpConverter = class {
   }
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/name.js
+// node_modules/@peculiar/asn1-x509/build/es2015/name.js
 var import_pvtsutils5 = __toESM(require_build());
 var RelativeDistinguishedName_1;
 var RDNSequence_1;
@@ -16752,7 +16752,7 @@ Name = Name_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence })
 ], Name);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/general_name.js
+// node_modules/@peculiar/asn1-x509/build/es2015/general_name.js
 var AsnIpConverter = {
   fromASN: (value) => IpConverter.toString(AsnOctetStringConverter.fromASN(value)),
   toASN: (value) => AsnOctetStringConverter.toASN(IpConverter.fromString(value))
@@ -16823,7 +16823,7 @@ GeneralName = __decorate([
   AsnType({ type: AsnTypeTypes.Choice })
 ], GeneralName);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/object_identifiers.js
+// node_modules/@peculiar/asn1-x509/build/es2015/object_identifiers.js
 var id_pkix = "1.3.6.1.5.5.7";
 var id_pe = `${id_pkix}.1`;
 var id_qt = `${id_pkix}.2`;
@@ -16837,7 +16837,7 @@ var id_ad_timeStamping = `${id_ad}.3`;
 var id_ad_caRepository = `${id_ad}.5`;
 var id_ce = "2.5.29";
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/authority_information_access.js
+// node_modules/@peculiar/asn1-x509/build/es2015/extensions/authority_information_access.js
 var AuthorityInfoAccessSyntax_1;
 var id_pe_authorityInfoAccess = `${id_pe}.1`;
 var AccessDescription = class {
@@ -16863,7 +16863,7 @@ AuthorityInfoAccessSyntax = AuthorityInfoAccessSyntax_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence, itemType: AccessDescription })
 ], AuthorityInfoAccessSyntax);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/authority_key_identifier.js
+// node_modules/@peculiar/asn1-x509/build/es2015/extensions/authority_key_identifier.js
 var id_ce_authorityKeyIdentifier = `${id_ce}.35`;
 var KeyIdentifier = class extends OctetString2 {
 };
@@ -16890,7 +16890,7 @@ __decorate([
   })
 ], AuthorityKeyIdentifier.prototype, "authorityCertSerialNumber", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/basic_constraints.js
+// node_modules/@peculiar/asn1-x509/build/es2015/extensions/basic_constraints.js
 var id_ce_basicConstraints = `${id_ce}.19`;
 var BasicConstraints = class {
   constructor(params = {}) {
@@ -16905,7 +16905,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.Integer, optional: true })
 ], BasicConstraints.prototype, "pathLenConstraint", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/general_names.js
+// node_modules/@peculiar/asn1-x509/build/es2015/general_names.js
 var GeneralNames_1;
 var GeneralNames = GeneralNames_1 = class GeneralNames2 extends AsnArray {
   constructor(items) {
@@ -16917,7 +16917,7 @@ GeneralNames = GeneralNames_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence, itemType: GeneralName })
 ], GeneralNames);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/certificate_issuer.js
+// node_modules/@peculiar/asn1-x509/build/es2015/extensions/certificate_issuer.js
 var CertificateIssuer_1;
 var id_ce_certificateIssuer = `${id_ce}.29`;
 var CertificateIssuer = CertificateIssuer_1 = class CertificateIssuer2 extends GeneralNames {
@@ -16930,7 +16930,7 @@ CertificateIssuer = CertificateIssuer_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence })
 ], CertificateIssuer);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/certificate_policies.js
+// node_modules/@peculiar/asn1-x509/build/es2015/extensions/certificate_policies.js
 var CertificatePolicies_1;
 var id_ce_certificatePolicies = `${id_ce}.32`;
 var id_ce_certificatePolicies_anyPolicy = `${id_ce_certificatePolicies}.0`;
@@ -17030,7 +17030,7 @@ CertificatePolicies = CertificatePolicies_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence, itemType: PolicyInformation })
 ], CertificatePolicies);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/crl_number.js
+// node_modules/@peculiar/asn1-x509/build/es2015/extensions/crl_number.js
 var id_ce_cRLNumber = `${id_ce}.20`;
 var CRLNumber = class CRLNumber2 {
   constructor(value = 0) {
@@ -17044,7 +17044,7 @@ CRLNumber = __decorate([
   AsnType({ type: AsnTypeTypes.Choice })
 ], CRLNumber);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/crl_delta_indicator.js
+// node_modules/@peculiar/asn1-x509/build/es2015/extensions/crl_delta_indicator.js
 var id_ce_deltaCRLIndicator = `${id_ce}.27`;
 var BaseCRLNumber = class BaseCRLNumber2 extends CRLNumber {
 };
@@ -17052,7 +17052,7 @@ BaseCRLNumber = __decorate([
   AsnType({ type: AsnTypeTypes.Choice })
 ], BaseCRLNumber);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/crl_distribution_points.js
+// node_modules/@peculiar/asn1-x509/build/es2015/extensions/crl_distribution_points.js
 var CRLDistributionPoints_1;
 var id_ce_cRLDistributionPoints = `${id_ce}.31`;
 var ReasonFlags;
@@ -17142,7 +17142,7 @@ CRLDistributionPoints = CRLDistributionPoints_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence, itemType: DistributionPoint })
 ], CRLDistributionPoints);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/crl_freshest.js
+// node_modules/@peculiar/asn1-x509/build/es2015/extensions/crl_freshest.js
 var FreshestCRL_1;
 var id_ce_freshestCRL = `${id_ce}.46`;
 var FreshestCRL = FreshestCRL_1 = class FreshestCRL2 extends CRLDistributionPoints {
@@ -17155,7 +17155,7 @@ FreshestCRL = FreshestCRL_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence, itemType: DistributionPoint })
 ], FreshestCRL);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/crl_issuing_distribution_point.js
+// node_modules/@peculiar/asn1-x509/build/es2015/extensions/crl_issuing_distribution_point.js
 var id_ce_issuingDistributionPoint = `${id_ce}.28`;
 var IssuingDistributionPoint = class _IssuingDistributionPoint {
   constructor(params = {}) {
@@ -17206,7 +17206,7 @@ __decorate([
   })
 ], IssuingDistributionPoint.prototype, "onlyContainsAttributeCerts", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/crl_reason.js
+// node_modules/@peculiar/asn1-x509/build/es2015/extensions/crl_reason.js
 var id_ce_cRLReasons = `${id_ce}.21`;
 var CRLReasons;
 (function(CRLReasons2) {
@@ -17240,7 +17240,7 @@ CRLReason = __decorate([
   AsnType({ type: AsnTypeTypes.Choice })
 ], CRLReason);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/extended_key_usage.js
+// node_modules/@peculiar/asn1-x509/build/es2015/extensions/extended_key_usage.js
 var ExtendedKeyUsage_1;
 var id_ce_extKeyUsage = `${id_ce}.37`;
 var ExtendedKeyUsage = ExtendedKeyUsage_1 = class ExtendedKeyUsage2 extends AsnArray {
@@ -17260,7 +17260,7 @@ var id_kp_emailProtection = `${id_kp}.4`;
 var id_kp_timeStamping = `${id_kp}.8`;
 var id_kp_OCSPSigning = `${id_kp}.9`;
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/inhibit_any_policy.js
+// node_modules/@peculiar/asn1-x509/build/es2015/extensions/inhibit_any_policy.js
 var id_ce_inhibitAnyPolicy = `${id_ce}.54`;
 var InhibitAnyPolicy = class InhibitAnyPolicy2 {
   constructor(value = new ArrayBuffer(0)) {
@@ -17274,7 +17274,7 @@ InhibitAnyPolicy = __decorate([
   AsnType({ type: AsnTypeTypes.Choice })
 ], InhibitAnyPolicy);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/invalidity_date.js
+// node_modules/@peculiar/asn1-x509/build/es2015/extensions/invalidity_date.js
 var id_ce_invalidityDate = `${id_ce}.24`;
 var InvalidityDate = class InvalidityDate2 {
   constructor(value) {
@@ -17291,7 +17291,7 @@ InvalidityDate = __decorate([
   AsnType({ type: AsnTypeTypes.Choice })
 ], InvalidityDate);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/issuer_alternative_name.js
+// node_modules/@peculiar/asn1-x509/build/es2015/extensions/issuer_alternative_name.js
 var IssueAlternativeName_1;
 var id_ce_issuerAltName = `${id_ce}.18`;
 var IssueAlternativeName = IssueAlternativeName_1 = class IssueAlternativeName2 extends GeneralNames {
@@ -17304,7 +17304,7 @@ IssueAlternativeName = IssueAlternativeName_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence })
 ], IssueAlternativeName);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/key_usage.js
+// node_modules/@peculiar/asn1-x509/build/es2015/extensions/key_usage.js
 var id_ce_keyUsage = `${id_ce}.15`;
 var KeyUsageFlags;
 (function(KeyUsageFlags3) {
@@ -17356,7 +17356,7 @@ var KeyUsage = class extends BitString2 {
   }
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/name_constraints.js
+// node_modules/@peculiar/asn1-x509/build/es2015/extensions/name_constraints.js
 var GeneralSubtrees_1;
 var id_ce_nameConstraints = `${id_ce}.30`;
 var GeneralSubtree = class {
@@ -17396,7 +17396,7 @@ __decorate([
   AsnProp({ type: GeneralSubtrees, context: 1, optional: true, implicit: true })
 ], NameConstraints.prototype, "excludedSubtrees", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/policy_constraints.js
+// node_modules/@peculiar/asn1-x509/build/es2015/extensions/policy_constraints.js
 var id_ce_policyConstraints = `${id_ce}.36`;
 var PolicyConstraints = class {
   constructor(params = {}) {
@@ -17422,7 +17422,7 @@ __decorate([
   })
 ], PolicyConstraints.prototype, "inhibitPolicyMapping", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/policy_mappings.js
+// node_modules/@peculiar/asn1-x509/build/es2015/extensions/policy_mappings.js
 var PolicyMappings_1;
 var id_ce_policyMappings = `${id_ce}.33`;
 var PolicyMapping = class {
@@ -17448,7 +17448,7 @@ PolicyMappings = PolicyMappings_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence, itemType: PolicyMapping })
 ], PolicyMappings);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/subject_alternative_name.js
+// node_modules/@peculiar/asn1-x509/build/es2015/extensions/subject_alternative_name.js
 var SubjectAlternativeName_1;
 var id_ce_subjectAltName = `${id_ce}.17`;
 var SubjectAlternativeName = SubjectAlternativeName_1 = class SubjectAlternativeName2 extends GeneralNames {
@@ -17461,7 +17461,7 @@ SubjectAlternativeName = SubjectAlternativeName_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence })
 ], SubjectAlternativeName);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/attribute.js
+// node_modules/@peculiar/asn1-x509/build/es2015/attribute.js
 var Attribute = class {
   constructor(params = {}) {
     this.type = "";
@@ -17476,7 +17476,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.Any, repeated: "set" })
 ], Attribute.prototype, "values", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/subject_directory_attributes.js
+// node_modules/@peculiar/asn1-x509/build/es2015/extensions/subject_directory_attributes.js
 var SubjectDirectoryAttributes_1;
 var id_ce_subjectDirectoryAttributes = `${id_ce}.9`;
 var SubjectDirectoryAttributes = SubjectDirectoryAttributes_1 = class SubjectDirectoryAttributes2 extends AsnArray {
@@ -17489,12 +17489,12 @@ SubjectDirectoryAttributes = SubjectDirectoryAttributes_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence, itemType: Attribute })
 ], SubjectDirectoryAttributes);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/subject_key_identifier.js
+// node_modules/@peculiar/asn1-x509/build/es2015/extensions/subject_key_identifier.js
 var id_ce_subjectKeyIdentifier = `${id_ce}.14`;
 var SubjectKeyIdentifier = class extends KeyIdentifier {
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/private_key_usage_period.js
+// node_modules/@peculiar/asn1-x509/build/es2015/extensions/private_key_usage_period.js
 var id_ce_privateKeyUsagePeriod = `${id_ce}.16`;
 var PrivateKeyUsagePeriod = class {
   constructor(params = {}) {
@@ -17508,7 +17508,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.GeneralizedTime, context: 1, implicit: true, optional: true })
 ], PrivateKeyUsagePeriod.prototype, "notAfter", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/entrust_version_info.js
+// node_modules/@peculiar/asn1-x509/build/es2015/extensions/entrust_version_info.js
 var EntrustInfoFlags;
 (function(EntrustInfoFlags2) {
   EntrustInfoFlags2[EntrustInfoFlags2["keyUpdateAllowed"] = 1] = "keyUpdateAllowed";
@@ -17548,7 +17548,7 @@ __decorate([
   AsnProp({ type: EntrustInfo })
 ], EntrustVersionInfo.prototype, "entrustInfoFlags", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/subject_info_access.js
+// node_modules/@peculiar/asn1-x509/build/es2015/extensions/subject_info_access.js
 var SubjectInfoAccessSyntax_1;
 var id_pe_subjectInfoAccess = `${id_pe}.11`;
 var SubjectInfoAccessSyntax = SubjectInfoAccessSyntax_1 = class SubjectInfoAccessSyntax2 extends AsnArray {
@@ -17561,7 +17561,7 @@ SubjectInfoAccessSyntax = SubjectInfoAccessSyntax_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence, itemType: AccessDescription })
 ], SubjectInfoAccessSyntax);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/algorithm_identifier.js
+// node_modules/@peculiar/asn1-x509/build/es2015/algorithm_identifier.js
 var pvtsutils2 = __toESM(require_build());
 var AlgorithmIdentifier = class _AlgorithmIdentifier {
   constructor(params = {}) {
@@ -17584,7 +17584,7 @@ __decorate([
   })
 ], AlgorithmIdentifier.prototype, "parameters", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/subject_public_key_info.js
+// node_modules/@peculiar/asn1-x509/build/es2015/subject_public_key_info.js
 var SubjectPublicKeyInfo = class {
   constructor(params = {}) {
     this.algorithm = new AlgorithmIdentifier();
@@ -17599,7 +17599,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.BitString })
 ], SubjectPublicKeyInfo.prototype, "subjectPublicKey", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/time.js
+// node_modules/@peculiar/asn1-x509/build/es2015/time.js
 var Time = class Time2 {
   constructor(time3) {
     if (time3) {
@@ -17638,7 +17638,7 @@ Time = __decorate([
   AsnType({ type: AsnTypeTypes.Choice })
 ], Time);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/validity.js
+// node_modules/@peculiar/asn1-x509/build/es2015/validity.js
 var Validity = class {
   constructor(params) {
     this.notBefore = new Time(/* @__PURE__ */ new Date());
@@ -17656,7 +17656,7 @@ __decorate([
   AsnProp({ type: Time })
 ], Validity.prototype, "notAfter", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extension.js
+// node_modules/@peculiar/asn1-x509/build/es2015/extension.js
 var Extensions_1;
 var Extension = class _Extension {
   constructor(params = {}) {
@@ -17689,7 +17689,7 @@ Extensions = Extensions_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence, itemType: Extension })
 ], Extensions);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/types.js
+// node_modules/@peculiar/asn1-x509/build/es2015/types.js
 var Version;
 (function(Version4) {
   Version4[Version4["v1"] = 0] = "v1";
@@ -17697,7 +17697,7 @@ var Version;
   Version4[Version4["v3"] = 2] = "v3";
 })(Version || (Version = {}));
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/tbs_certificate.js
+// node_modules/@peculiar/asn1-x509/build/es2015/tbs_certificate.js
 var TBSCertificate = class {
   constructor(params = {}) {
     this.version = Version.v1;
@@ -17753,7 +17753,7 @@ __decorate([
   AsnProp({ type: Extensions, context: 3, optional: true })
 ], TBSCertificate.prototype, "extensions", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/certificate.js
+// node_modules/@peculiar/asn1-x509/build/es2015/certificate.js
 var Certificate = class {
   constructor(params = {}) {
     this.tbsCertificate = new TBSCertificate();
@@ -17772,7 +17772,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.BitString })
 ], Certificate.prototype, "signatureValue", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/tbs_cert_list.js
+// node_modules/@peculiar/asn1-x509/build/es2015/tbs_cert_list.js
 var RevokedCertificate = class {
   constructor(params = {}) {
     this.userCertificate = new ArrayBuffer(0);
@@ -17819,7 +17819,7 @@ __decorate([
   AsnProp({ type: Extension, optional: true, context: 0, repeated: "sequence" })
 ], TBSCertList.prototype, "crlExtensions", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/certificate_list.js
+// node_modules/@peculiar/asn1-x509/build/es2015/certificate_list.js
 var CertificateList = class {
   constructor(params = {}) {
     this.tbsCertList = new TBSCertList();
@@ -17838,7 +17838,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.BitString })
 ], CertificateList.prototype, "signature", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/getCertificateInfo.js
+// node_modules/@simplewebauthn/server/esm/helpers/getCertificateInfo.js
 var issuerSubjectIDKey = {
   "2.5.4.6": "C",
   "2.5.4.10": "O",
@@ -17900,11 +17900,11 @@ function issuerSubjectToString(input) {
   return parts.join(" : ");
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/x509/build/x509.es.js
+// node_modules/@peculiar/x509/build/x509.es.js
 var import_reflect_metadata = __toESM(require_Reflect());
 var import_pvtsutils6 = __toESM(require_build());
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/issuer_and_serial_number.js
+// node_modules/@peculiar/asn1-cms/build/es2015/issuer_and_serial_number.js
 var IssuerAndSerialNumber = class {
   constructor(params = {}) {
     this.issuer = new Name();
@@ -17919,7 +17919,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.Integer, converter: AsnIntegerArrayBufferConverter })
 ], IssuerAndSerialNumber.prototype, "serialNumber", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/signer_identifier.js
+// node_modules/@peculiar/asn1-cms/build/es2015/signer_identifier.js
 var SignerIdentifier = class SignerIdentifier2 {
   constructor(params = {}) {
     Object.assign(this, params);
@@ -17935,7 +17935,7 @@ SignerIdentifier = __decorate([
   AsnType({ type: AsnTypeTypes.Choice })
 ], SignerIdentifier);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/types.js
+// node_modules/@peculiar/asn1-cms/build/es2015/types.js
 var CMSVersion;
 (function(CMSVersion2) {
   CMSVersion2[CMSVersion2["v0"] = 0] = "v0";
@@ -17976,7 +17976,7 @@ KeyDerivationAlgorithmIdentifier = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence })
 ], KeyDerivationAlgorithmIdentifier);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/attribute.js
+// node_modules/@peculiar/asn1-cms/build/es2015/attribute.js
 var Attribute2 = class {
   constructor(params = {}) {
     this.attrType = "";
@@ -17991,7 +17991,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.Any, repeated: "set" })
 ], Attribute2.prototype, "attrValues", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/signer_info.js
+// node_modules/@peculiar/asn1-cms/build/es2015/signer_info.js
 var SignerInfos_1;
 var SignerInfo = class {
   constructor(params = {}) {
@@ -18041,21 +18041,21 @@ SignerInfos = SignerInfos_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Set, itemType: SignerInfo })
 ], SignerInfos);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/attributes/counter_signature.js
+// node_modules/@peculiar/asn1-cms/build/es2015/attributes/counter_signature.js
 var CounterSignature = class CounterSignature2 extends SignerInfo {
 };
 CounterSignature = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence })
 ], CounterSignature);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/attributes/signing_time.js
+// node_modules/@peculiar/asn1-cms/build/es2015/attributes/signing_time.js
 var SigningTime = class SigningTime2 extends Time {
 };
 SigningTime = __decorate([
   AsnType({ type: AsnTypeTypes.Choice })
 ], SigningTime);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509-attr/build/es2015/aa_clear_attrs.js
+// node_modules/@peculiar/asn1-x509-attr/build/es2015/aa_clear_attrs.js
 var ACClearAttrs = class {
   constructor(params = {}) {
     this.acIssuer = new GeneralName();
@@ -18074,7 +18074,7 @@ __decorate([
   AsnProp({ type: Attribute, repeated: "sequence" })
 ], ACClearAttrs.prototype, "attrs", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509-attr/build/es2015/attr_spec.js
+// node_modules/@peculiar/asn1-x509-attr/build/es2015/attr_spec.js
 var AttrSpec_1;
 var AttrSpec = AttrSpec_1 = class AttrSpec2 extends AsnArray {
   constructor(items) {
@@ -18086,7 +18086,7 @@ AttrSpec = AttrSpec_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence, itemType: AsnPropTypes.ObjectIdentifier })
 ], AttrSpec);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509-attr/build/es2015/aa_controls.js
+// node_modules/@peculiar/asn1-x509-attr/build/es2015/aa_controls.js
 var AAControls = class {
   constructor(params = {}) {
     this.permitUnSpecified = true;
@@ -18106,7 +18106,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.Boolean, defaultValue: true })
 ], AAControls.prototype, "permitUnSpecified", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509-attr/build/es2015/issuer_serial.js
+// node_modules/@peculiar/asn1-x509-attr/build/es2015/issuer_serial.js
 var IssuerSerial = class {
   constructor(params = {}) {
     this.issuer = new GeneralNames();
@@ -18125,7 +18125,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.BitString, optional: true })
 ], IssuerSerial.prototype, "issuerUID", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509-attr/build/es2015/object_digest_info.js
+// node_modules/@peculiar/asn1-x509-attr/build/es2015/object_digest_info.js
 var DigestedObjectType;
 (function(DigestedObjectType2) {
   DigestedObjectType2[DigestedObjectType2["publicKey"] = 0] = "publicKey";
@@ -18153,7 +18153,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.BitString })
 ], ObjectDigestInfo.prototype, "objectDigest", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509-attr/build/es2015/v2_form.js
+// node_modules/@peculiar/asn1-x509-attr/build/es2015/v2_form.js
 var V2Form = class {
   constructor(params = {}) {
     Object.assign(this, params);
@@ -18169,7 +18169,7 @@ __decorate([
   AsnProp({ type: ObjectDigestInfo, context: 1, implicit: true, optional: true })
 ], V2Form.prototype, "objectDigestInfo", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509-attr/build/es2015/attr_cert_issuer.js
+// node_modules/@peculiar/asn1-x509-attr/build/es2015/attr_cert_issuer.js
 var AttCertIssuer = class AttCertIssuer2 {
   constructor(params = {}) {
     Object.assign(this, params);
@@ -18185,7 +18185,7 @@ AttCertIssuer = __decorate([
   AsnType({ type: AsnTypeTypes.Choice })
 ], AttCertIssuer);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509-attr/build/es2015/attr_cert_validity_period.js
+// node_modules/@peculiar/asn1-x509-attr/build/es2015/attr_cert_validity_period.js
 var AttCertValidityPeriod = class {
   constructor(params = {}) {
     this.notBeforeTime = /* @__PURE__ */ new Date();
@@ -18200,7 +18200,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.GeneralizedTime })
 ], AttCertValidityPeriod.prototype, "notAfterTime", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509-attr/build/es2015/holder.js
+// node_modules/@peculiar/asn1-x509-attr/build/es2015/holder.js
 var Holder = class {
   constructor(params = {}) {
     Object.assign(this, params);
@@ -18216,7 +18216,7 @@ __decorate([
   AsnProp({ type: ObjectDigestInfo, implicit: true, context: 2, optional: true })
 ], Holder.prototype, "objectDigestInfo", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509-attr/build/es2015/attribute_certificate_info.js
+// node_modules/@peculiar/asn1-x509-attr/build/es2015/attribute_certificate_info.js
 var AttCertVersion;
 (function(AttCertVersion2) {
   AttCertVersion2[AttCertVersion2["v2"] = 1] = "v2";
@@ -18261,7 +18261,7 @@ __decorate([
   AsnProp({ type: Extensions, optional: true })
 ], AttributeCertificateInfo.prototype, "extensions", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509-attr/build/es2015/attribute_certificate.js
+// node_modules/@peculiar/asn1-x509-attr/build/es2015/attribute_certificate.js
 var AttributeCertificate = class {
   constructor(params = {}) {
     this.acinfo = new AttributeCertificateInfo();
@@ -18280,7 +18280,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.BitString })
 ], AttributeCertificate.prototype, "signatureValue", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509-attr/build/es2015/class_list.js
+// node_modules/@peculiar/asn1-x509-attr/build/es2015/class_list.js
 var ClassListFlags;
 (function(ClassListFlags2) {
   ClassListFlags2[ClassListFlags2["unmarked"] = 1] = "unmarked";
@@ -18293,7 +18293,7 @@ var ClassListFlags;
 var ClassList = class extends BitString2 {
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509-attr/build/es2015/security_category.js
+// node_modules/@peculiar/asn1-x509-attr/build/es2015/security_category.js
 var SecurityCategory = class {
   constructor(params = {}) {
     this.type = "";
@@ -18308,7 +18308,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.Any, implicit: true, context: 1 })
 ], SecurityCategory.prototype, "value", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509-attr/build/es2015/clearance.js
+// node_modules/@peculiar/asn1-x509-attr/build/es2015/clearance.js
 var Clearance = class {
   constructor(params = {}) {
     this.policyId = "";
@@ -18326,7 +18326,7 @@ __decorate([
   AsnProp({ type: SecurityCategory, repeated: "set" })
 ], Clearance.prototype, "securityCategories", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509-attr/build/es2015/ietf_attr_syntax.js
+// node_modules/@peculiar/asn1-x509-attr/build/es2015/ietf_attr_syntax.js
 var IetfAttrSyntaxValueChoices = class {
   constructor(params = {}) {
     Object.assign(this, params);
@@ -18354,7 +18354,7 @@ __decorate([
   AsnProp({ type: IetfAttrSyntaxValueChoices, repeated: "sequence" })
 ], IetfAttrSyntax.prototype, "values", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509-attr/build/es2015/object_identifiers.js
+// node_modules/@peculiar/asn1-x509-attr/build/es2015/object_identifiers.js
 var id_pe_ac_auditIdentity = `${id_pe}.4`;
 var id_pe_aaControls = `${id_pe}.6`;
 var id_pe_ac_proxying = `${id_pe}.10`;
@@ -18368,7 +18368,7 @@ var id_aca_encAttrs = `${id_aca}.6`;
 var id_at = "2.5.4";
 var id_at_role = `${id_at}.72`;
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509-attr/build/es2015/target.js
+// node_modules/@peculiar/asn1-x509-attr/build/es2015/target.js
 var Targets_1;
 var TargetCert = class {
   constructor(params = {}) {
@@ -18412,7 +18412,7 @@ Targets = Targets_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence, itemType: Target })
 ], Targets);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509-attr/build/es2015/proxy_info.js
+// node_modules/@peculiar/asn1-x509-attr/build/es2015/proxy_info.js
 var ProxyInfo_1;
 var ProxyInfo = ProxyInfo_1 = class ProxyInfo2 extends AsnArray {
   constructor(items) {
@@ -18424,7 +18424,7 @@ ProxyInfo = ProxyInfo_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence, itemType: Targets })
 ], ProxyInfo);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509-attr/build/es2015/role_syntax.js
+// node_modules/@peculiar/asn1-x509-attr/build/es2015/role_syntax.js
 var RoleSyntax = class {
   constructor(params = {}) {
     Object.assign(this, params);
@@ -18437,7 +18437,7 @@ __decorate([
   AsnProp({ type: GeneralName, implicit: true, context: 1 })
 ], RoleSyntax.prototype, "roleName", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509-attr/build/es2015/svce_auth_info.js
+// node_modules/@peculiar/asn1-x509-attr/build/es2015/svce_auth_info.js
 var SvceAuthInfo = class {
   constructor(params = {}) {
     this.service = new GeneralName();
@@ -18455,7 +18455,7 @@ __decorate([
   AsnProp({ type: OctetString2, optional: true })
 ], SvceAuthInfo.prototype, "authInfo", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/certificate_choices.js
+// node_modules/@peculiar/asn1-cms/build/es2015/certificate_choices.js
 var CertificateSet_1;
 var OtherCertificateFormat = class {
   constructor(params = {}) {
@@ -18497,7 +18497,7 @@ CertificateSet = CertificateSet_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Set, itemType: CertificateChoices })
 ], CertificateSet);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/content_info.js
+// node_modules/@peculiar/asn1-cms/build/es2015/content_info.js
 var ContentInfo = class {
   constructor(params = {}) {
     this.contentType = "";
@@ -18512,7 +18512,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.Any, context: 0 })
 ], ContentInfo.prototype, "content", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/encapsulated_content_info.js
+// node_modules/@peculiar/asn1-cms/build/es2015/encapsulated_content_info.js
 var EncapsulatedContent = class EncapsulatedContent2 {
   constructor(params = {}) {
     Object.assign(this, params);
@@ -18540,7 +18540,7 @@ __decorate([
   AsnProp({ type: EncapsulatedContent, context: 0, optional: true })
 ], EncapsulatedContentInfo.prototype, "eContent", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/encrypted_content_info.js
+// node_modules/@peculiar/asn1-cms/build/es2015/encrypted_content_info.js
 var EncryptedContent = class EncryptedContent2 {
   constructor(params = {}) {
     Object.assign(this, params);
@@ -18579,7 +18579,7 @@ __decorate([
   AsnProp({ type: EncryptedContent, optional: true })
 ], EncryptedContentInfo.prototype, "encryptedContent", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/other_key_attribute.js
+// node_modules/@peculiar/asn1-cms/build/es2015/other_key_attribute.js
 var OtherKeyAttribute = class {
   constructor(params = {}) {
     this.keyAttrId = "";
@@ -18593,7 +18593,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.Any, optional: true })
 ], OtherKeyAttribute.prototype, "keyAttr", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/key_agree_recipient_info.js
+// node_modules/@peculiar/asn1-cms/build/es2015/key_agree_recipient_info.js
 var RecipientEncryptedKeys_1;
 var RecipientKeyIdentifier = class {
   constructor(params = {}) {
@@ -18701,7 +18701,7 @@ __decorate([
   AsnProp({ type: RecipientEncryptedKeys })
 ], KeyAgreeRecipientInfo.prototype, "recipientEncryptedKeys", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/key_trans_recipient_info.js
+// node_modules/@peculiar/asn1-cms/build/es2015/key_trans_recipient_info.js
 var RecipientIdentifier = class RecipientIdentifier2 {
   constructor(params = {}) {
     Object.assign(this, params);
@@ -18738,7 +18738,7 @@ __decorate([
   AsnProp({ type: OctetString2 })
 ], KeyTransRecipientInfo.prototype, "encryptedKey", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/kek_recipient_info.js
+// node_modules/@peculiar/asn1-cms/build/es2015/kek_recipient_info.js
 var KEKIdentifier = class {
   constructor(params = {}) {
     this.keyIdentifier = new OctetString2();
@@ -18776,7 +18776,7 @@ __decorate([
   AsnProp({ type: OctetString2 })
 ], KEKRecipientInfo.prototype, "encryptedKey", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/password_recipient_info.js
+// node_modules/@peculiar/asn1-cms/build/es2015/password_recipient_info.js
 var PasswordRecipientInfo = class {
   constructor(params = {}) {
     this.version = CMSVersion.v0;
@@ -18798,7 +18798,7 @@ __decorate([
   AsnProp({ type: OctetString2 })
 ], PasswordRecipientInfo.prototype, "encryptedKey", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/recipient_info.js
+// node_modules/@peculiar/asn1-cms/build/es2015/recipient_info.js
 var OtherRecipientInfo = class {
   constructor(params = {}) {
     this.oriType = "";
@@ -18836,7 +18836,7 @@ RecipientInfo = __decorate([
   AsnType({ type: AsnTypeTypes.Choice })
 ], RecipientInfo);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/recipient_infos.js
+// node_modules/@peculiar/asn1-cms/build/es2015/recipient_infos.js
 var RecipientInfos_1;
 var RecipientInfos = RecipientInfos_1 = class RecipientInfos2 extends AsnArray {
   constructor(items) {
@@ -18848,7 +18848,7 @@ RecipientInfos = RecipientInfos_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Set, itemType: RecipientInfo })
 ], RecipientInfos);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/revocation_info_choice.js
+// node_modules/@peculiar/asn1-cms/build/es2015/revocation_info_choice.js
 var RevocationInfoChoices_1;
 var id_ri = `${id_pkix}.16`;
 var id_ri_ocsp_response = `${id_ri}.2`;
@@ -18888,7 +18888,7 @@ RevocationInfoChoices = RevocationInfoChoices_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Set, itemType: RevocationInfoChoice })
 ], RevocationInfoChoices);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/originator_info.js
+// node_modules/@peculiar/asn1-cms/build/es2015/originator_info.js
 var OriginatorInfo = class {
   constructor(params = {}) {
     Object.assign(this, params);
@@ -18901,7 +18901,7 @@ __decorate([
   AsnProp({ type: RevocationInfoChoices, context: 1, implicit: true, optional: true })
 ], OriginatorInfo.prototype, "crls", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/enveloped_data.js
+// node_modules/@peculiar/asn1-cms/build/es2015/enveloped_data.js
 var UnprotectedAttributes_1;
 var UnprotectedAttributes = UnprotectedAttributes_1 = class UnprotectedAttributes2 extends AsnArray {
   constructor(items) {
@@ -18936,10 +18936,10 @@ __decorate([
   AsnProp({ type: UnprotectedAttributes, context: 1, implicit: true, optional: true })
 ], EnvelopedData.prototype, "unprotectedAttrs", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/object_identifiers.js
+// node_modules/@peculiar/asn1-cms/build/es2015/object_identifiers.js
 var id_signedData = "1.2.840.113549.1.7.2";
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/signed_data.js
+// node_modules/@peculiar/asn1-cms/build/es2015/signed_data.js
 var DigestAlgorithmIdentifiers_1;
 var DigestAlgorithmIdentifiers = DigestAlgorithmIdentifiers_1 = class DigestAlgorithmIdentifiers2 extends AsnArray {
   constructor(items) {
@@ -18978,7 +18978,7 @@ __decorate([
   AsnProp({ type: SignerInfos })
 ], SignedData.prototype, "signerInfos", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-ecc/build/es2015/object_identifiers.js
+// node_modules/@peculiar/asn1-ecc/build/es2015/object_identifiers.js
 var id_ecPublicKey = "1.2.840.10045.2.1";
 var id_ecdsaWithSHA1 = "1.2.840.10045.4.1";
 var id_ecdsaWithSHA224 = "1.2.840.10045.4.3.1";
@@ -18989,7 +18989,7 @@ var id_secp256r1 = "1.2.840.10045.3.1.7";
 var id_secp384r1 = "1.3.132.0.34";
 var id_secp521r1 = "1.3.132.0.35";
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-ecc/build/es2015/algorithms.js
+// node_modules/@peculiar/asn1-ecc/build/es2015/algorithms.js
 function create(algorithm) {
   return new AlgorithmIdentifier({ algorithm });
 }
@@ -18999,7 +18999,7 @@ var ecdsaWithSHA256 = create(id_ecdsaWithSHA256);
 var ecdsaWithSHA384 = create(id_ecdsaWithSHA384);
 var ecdsaWithSHA512 = create(id_ecdsaWithSHA512);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-ecc/build/es2015/rfc3279.js
+// node_modules/@peculiar/asn1-ecc/build/es2015/rfc3279.js
 var FieldID = class FieldID2 {
   constructor(params = {}) {
     Object.assign(this, params);
@@ -19065,7 +19065,7 @@ SpecifiedECDomain = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence })
 ], SpecifiedECDomain);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-ecc/build/es2015/ec_parameters.js
+// node_modules/@peculiar/asn1-ecc/build/es2015/ec_parameters.js
 var ECParameters = class ECParameters2 {
   constructor(params = {}) {
     Object.assign(this, params);
@@ -19084,7 +19084,7 @@ ECParameters = __decorate([
   AsnType({ type: AsnTypeTypes.Choice })
 ], ECParameters);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-ecc/build/es2015/ec_private_key.js
+// node_modules/@peculiar/asn1-ecc/build/es2015/ec_private_key.js
 var ECPrivateKey = class {
   constructor(params = {}) {
     this.version = 1;
@@ -19105,7 +19105,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.BitString, context: 1, optional: true })
 ], ECPrivateKey.prototype, "publicKey", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-ecc/build/es2015/ec_signature_value.js
+// node_modules/@peculiar/asn1-ecc/build/es2015/ec_signature_value.js
 var ECDSASigValue = class {
   constructor(params = {}) {
     this.r = new ArrayBuffer(0);
@@ -19120,7 +19120,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.Integer, converter: AsnIntegerArrayBufferConverter })
 ], ECDSASigValue.prototype, "s", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-rsa/build/es2015/object_identifiers.js
+// node_modules/@peculiar/asn1-rsa/build/es2015/object_identifiers.js
 var id_pkcs_1 = "1.2.840.113549.1.1";
 var id_rsaEncryption = `${id_pkcs_1}.1`;
 var id_RSAES_OAEP = `${id_pkcs_1}.7`;
@@ -19146,7 +19146,7 @@ var id_md2 = "1.2.840.113549.2.2";
 var id_md5 = "1.2.840.113549.2.5";
 var id_mgf1 = `${id_pkcs_1}.8`;
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-rsa/build/es2015/algorithms.js
+// node_modules/@peculiar/asn1-rsa/build/es2015/algorithms.js
 function create2(algorithm) {
   return new AlgorithmIdentifier({ algorithm, parameters: null });
 }
@@ -19199,7 +19199,7 @@ var sha512WithRSAEncryption = create2(id_sha512WithRSAEncryption);
 var sha512_224WithRSAEncryption = create2(id_sha512_224WithRSAEncryption);
 var sha512_256WithRSAEncryption = create2(id_sha512_256WithRSAEncryption);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-rsa/build/es2015/parameters/rsaes_oaep.js
+// node_modules/@peculiar/asn1-rsa/build/es2015/parameters/rsaes_oaep.js
 var RsaEsOaepParams = class {
   constructor(params = {}) {
     this.hashAlgorithm = new AlgorithmIdentifier(sha1);
@@ -19225,7 +19225,7 @@ var RSAES_OAEP = new AlgorithmIdentifier({
   parameters: AsnConvert.serialize(new RsaEsOaepParams())
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-rsa/build/es2015/parameters/rsassa_pss.js
+// node_modules/@peculiar/asn1-rsa/build/es2015/parameters/rsassa_pss.js
 var RsaSaPssParams = class {
   constructor(params = {}) {
     this.hashAlgorithm = new AlgorithmIdentifier(sha1);
@@ -19255,7 +19255,7 @@ var RSASSA_PSS = new AlgorithmIdentifier({
   parameters: AsnConvert.serialize(new RsaSaPssParams())
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-rsa/build/es2015/parameters/rsassa_pkcs1_v1_5.js
+// node_modules/@peculiar/asn1-rsa/build/es2015/parameters/rsassa_pkcs1_v1_5.js
 var DigestInfo = class {
   constructor(params = {}) {
     this.digestAlgorithm = new AlgorithmIdentifier();
@@ -19270,7 +19270,7 @@ __decorate([
   AsnProp({ type: OctetString2 })
 ], DigestInfo.prototype, "digest", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-rsa/build/es2015/other_prime_info.js
+// node_modules/@peculiar/asn1-rsa/build/es2015/other_prime_info.js
 var OtherPrimeInfos_1;
 var OtherPrimeInfo = class {
   constructor(params = {}) {
@@ -19299,7 +19299,7 @@ OtherPrimeInfos = OtherPrimeInfos_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence, itemType: OtherPrimeInfo })
 ], OtherPrimeInfos);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-rsa/build/es2015/rsa_private_key.js
+// node_modules/@peculiar/asn1-rsa/build/es2015/rsa_private_key.js
 var RSAPrivateKey = class {
   constructor(params = {}) {
     this.version = 0;
@@ -19345,7 +19345,7 @@ __decorate([
   AsnProp({ type: OtherPrimeInfos, optional: true })
 ], RSAPrivateKey.prototype, "otherPrimeInfos", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-rsa/build/es2015/rsa_public_key.js
+// node_modules/@peculiar/asn1-rsa/build/es2015/rsa_public_key.js
 var RSAPublicKey = class {
   constructor(params = {}) {
     this.modulus = new ArrayBuffer(0);
@@ -19360,7 +19360,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.Integer, converter: AsnIntegerArrayBufferConverter })
 ], RSAPublicKey.prototype, "publicExponent", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tsyringe/dist/esm5/types/lifecycle.js
+// node_modules/tsyringe/dist/esm5/types/lifecycle.js
 var Lifecycle;
 (function(Lifecycle2) {
   Lifecycle2[Lifecycle2["Transient"] = 0] = "Transient";
@@ -19370,7 +19370,7 @@ var Lifecycle;
 })(Lifecycle || (Lifecycle = {}));
 var lifecycle_default = Lifecycle;
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tsyringe/node_modules/tslib/tslib.es6.js
+// node_modules/tsyringe/node_modules/tslib/tslib.es6.js
 var extendStatics = function(d, b) {
   extendStatics = Object.setPrototypeOf || { __proto__: [] } instanceof Array && function(d2, b2) {
     d2.__proto__ = b2;
@@ -19516,7 +19516,7 @@ function __spread() {
   return ar;
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tsyringe/dist/esm5/reflection-helpers.js
+// node_modules/tsyringe/dist/esm5/reflection-helpers.js
 var INJECTION_TOKEN_METADATA_KEY = "injectionTokens";
 function getParamInfo(target) {
   var params = Reflect.getMetadata("design:paramtypes", target) || [];
@@ -19527,17 +19527,17 @@ function getParamInfo(target) {
   return params;
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tsyringe/dist/esm5/providers/class-provider.js
+// node_modules/tsyringe/dist/esm5/providers/class-provider.js
 function isClassProvider(provider) {
   return !!provider.useClass;
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tsyringe/dist/esm5/providers/factory-provider.js
+// node_modules/tsyringe/dist/esm5/providers/factory-provider.js
 function isFactoryProvider(provider) {
   return !!provider.useFactory;
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tsyringe/dist/esm5/lazy-helpers.js
+// node_modules/tsyringe/dist/esm5/lazy-helpers.js
 var DelayedConstructor = (function() {
   function DelayedConstructor2(wrap) {
     this.wrap = wrap;
@@ -19588,7 +19588,7 @@ var DelayedConstructor = (function() {
   return DelayedConstructor2;
 })();
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tsyringe/dist/esm5/providers/injection-token.js
+// node_modules/tsyringe/dist/esm5/providers/injection-token.js
 function isNormalToken(token) {
   return typeof token === "string" || typeof token === "symbol";
 }
@@ -19602,22 +19602,22 @@ function isConstructorToken(token) {
   return typeof token === "function" || token instanceof DelayedConstructor;
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tsyringe/dist/esm5/providers/token-provider.js
+// node_modules/tsyringe/dist/esm5/providers/token-provider.js
 function isTokenProvider(provider) {
   return !!provider.useToken;
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tsyringe/dist/esm5/providers/value-provider.js
+// node_modules/tsyringe/dist/esm5/providers/value-provider.js
 function isValueProvider(provider) {
   return provider.useValue != void 0;
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tsyringe/dist/esm5/providers/provider.js
+// node_modules/tsyringe/dist/esm5/providers/provider.js
 function isProvider(provider) {
   return isClassProvider(provider) || isValueProvider(provider) || isTokenProvider(provider) || isFactoryProvider(provider);
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tsyringe/dist/esm5/registry-base.js
+// node_modules/tsyringe/dist/esm5/registry-base.js
 var RegistryBase = (function() {
   function RegistryBase2() {
     this._registryMap = /* @__PURE__ */ new Map();
@@ -19657,7 +19657,7 @@ var RegistryBase = (function() {
 })();
 var registry_base_default = RegistryBase;
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tsyringe/dist/esm5/registry.js
+// node_modules/tsyringe/dist/esm5/registry.js
 var Registry = (function(_super) {
   __extends(Registry2, _super);
   function Registry2() {
@@ -19667,7 +19667,7 @@ var Registry = (function(_super) {
 })(registry_base_default);
 var registry_default = Registry;
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tsyringe/dist/esm5/resolution-context.js
+// node_modules/tsyringe/dist/esm5/resolution-context.js
 var ResolutionContext = /* @__PURE__ */ (function() {
   function ResolutionContext2() {
     this.scopedResolutions = /* @__PURE__ */ new Map();
@@ -19676,7 +19676,7 @@ var ResolutionContext = /* @__PURE__ */ (function() {
 })();
 var resolution_context_default = ResolutionContext;
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tsyringe/dist/esm5/error-helpers.js
+// node_modules/tsyringe/dist/esm5/error-helpers.js
 function formatDependency(params, idx) {
   if (params === null) {
     return "at position #" + idx;
@@ -19698,7 +19698,7 @@ function formatErrorCtor(ctor, paramIdx, error2) {
   return composeErrorMessage("Cannot inject the dependency " + dep + ' of "' + ctor.name + '" constructor. Reason:', error2);
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tsyringe/dist/esm5/types/disposable.js
+// node_modules/tsyringe/dist/esm5/types/disposable.js
 function isDisposable(value) {
   if (typeof value.dispose !== "function")
     return false;
@@ -19709,7 +19709,7 @@ function isDisposable(value) {
   return true;
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tsyringe/dist/esm5/interceptors.js
+// node_modules/tsyringe/dist/esm5/interceptors.js
 var PreResolutionInterceptors = (function(_super) {
   __extends(PreResolutionInterceptors2, _super);
   function PreResolutionInterceptors2() {
@@ -19733,7 +19733,7 @@ var Interceptors = /* @__PURE__ */ (function() {
 })();
 var interceptors_default = Interceptors;
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tsyringe/dist/esm5/dependency-container.js
+// node_modules/tsyringe/dist/esm5/dependency-container.js
 var typeInfo = /* @__PURE__ */ new Map();
 var InternalDependencyContainer = (function() {
   function InternalDependencyContainer2(parent) {
@@ -20127,7 +20127,7 @@ var InternalDependencyContainer = (function() {
 })();
 var instance = new InternalDependencyContainer();
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tsyringe/dist/esm5/decorators/injectable.js
+// node_modules/tsyringe/dist/esm5/decorators/injectable.js
 function injectable(options) {
   return function(target) {
     typeInfo.set(target, getParamInfo(target));
@@ -20144,12 +20144,12 @@ function injectable(options) {
 }
 var injectable_default = injectable;
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tsyringe/dist/esm5/index.js
+// node_modules/tsyringe/dist/esm5/index.js
 if (typeof Reflect === "undefined" || !Reflect.getMetadata) {
   throw new Error(`tsyringe requires a reflect polyfill. Please add 'import "reflect-metadata"' to the top of your entry point.`);
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-pfx/build/es2015/attribute.js
+// node_modules/@peculiar/asn1-pfx/build/es2015/attribute.js
 var PKCS12AttrSet_1;
 var PKCS12Attribute = class {
   constructor(params = {}) {
@@ -20174,7 +20174,7 @@ PKCS12AttrSet = PKCS12AttrSet_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence, itemType: PKCS12Attribute })
 ], PKCS12AttrSet);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-pfx/build/es2015/authenticated_safe.js
+// node_modules/@peculiar/asn1-pfx/build/es2015/authenticated_safe.js
 var AuthenticatedSafe_1;
 var AuthenticatedSafe = AuthenticatedSafe_1 = class AuthenticatedSafe2 extends AsnArray {
   constructor(items) {
@@ -20186,7 +20186,7 @@ AuthenticatedSafe = AuthenticatedSafe_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence, itemType: ContentInfo })
 ], AuthenticatedSafe);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-pfx/build/es2015/object_identifiers.js
+// node_modules/@peculiar/asn1-pfx/build/es2015/object_identifiers.js
 var id_rsadsi = "1.2.840.113549";
 var id_pkcs = `${id_rsadsi}.1`;
 var id_pkcs_12 = `${id_pkcs}.12`;
@@ -20199,7 +20199,7 @@ var id_pbeWithSHAAnd128BitRC2_CBC = `${id_pkcs_12PbeIds}.5`;
 var id_pbewithSHAAnd40BitRC2_CBC = `${id_pkcs_12PbeIds}.6`;
 var id_bagtypes = `${id_pkcs_12}.10.1`;
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-pfx/build/es2015/bags/types.js
+// node_modules/@peculiar/asn1-pfx/build/es2015/bags/types.js
 var id_keyBag = `${id_bagtypes}.1`;
 var id_pkcs8ShroudedKeyBag = `${id_bagtypes}.2`;
 var id_certBag = `${id_bagtypes}.3`;
@@ -20208,7 +20208,7 @@ var id_SecretBag = `${id_bagtypes}.5`;
 var id_SafeContents = `${id_bagtypes}.6`;
 var id_pkcs_9 = "1.2.840.113549.1.9";
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-pfx/build/es2015/bags/cert_bag.js
+// node_modules/@peculiar/asn1-pfx/build/es2015/bags/cert_bag.js
 var CertBag = class {
   constructor(params = {}) {
     this.certId = "";
@@ -20226,7 +20226,7 @@ var id_certTypes = `${id_pkcs_9}.22`;
 var id_x509Certificate = `${id_certTypes}.1`;
 var id_sdsiCertificate = `${id_certTypes}.2`;
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-pfx/build/es2015/bags/crl_bag.js
+// node_modules/@peculiar/asn1-pfx/build/es2015/bags/crl_bag.js
 var CRLBag = class {
   constructor(params = {}) {
     this.crlId = "";
@@ -20243,7 +20243,7 @@ __decorate([
 var id_crlTypes = `${id_pkcs_9}.23`;
 var id_x509CRL = `${id_crlTypes}.1`;
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-pkcs8/build/es2015/encrypted_private_key_info.js
+// node_modules/@peculiar/asn1-pkcs8/build/es2015/encrypted_private_key_info.js
 var EncryptedData = class extends OctetString2 {
 };
 var EncryptedPrivateKeyInfo = class {
@@ -20260,7 +20260,7 @@ __decorate([
   AsnProp({ type: EncryptedData })
 ], EncryptedPrivateKeyInfo.prototype, "encryptedData", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-pkcs8/build/es2015/private_key_info.js
+// node_modules/@peculiar/asn1-pkcs8/build/es2015/private_key_info.js
 var Attributes_1;
 var Version2;
 (function(Version4) {
@@ -20298,21 +20298,21 @@ __decorate([
   AsnProp({ type: Attributes, implicit: true, context: 0, optional: true })
 ], PrivateKeyInfo.prototype, "attributes", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-pfx/build/es2015/bags/key_bag.js
+// node_modules/@peculiar/asn1-pfx/build/es2015/bags/key_bag.js
 var KeyBag = class KeyBag2 extends PrivateKeyInfo {
 };
 KeyBag = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence })
 ], KeyBag);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-pfx/build/es2015/bags/pkcs8_shrouded_key_bag.js
+// node_modules/@peculiar/asn1-pfx/build/es2015/bags/pkcs8_shrouded_key_bag.js
 var PKCS8ShroudedKeyBag = class PKCS8ShroudedKeyBag2 extends EncryptedPrivateKeyInfo {
 };
 PKCS8ShroudedKeyBag = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence })
 ], PKCS8ShroudedKeyBag);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-pfx/build/es2015/bags/secret_bag.js
+// node_modules/@peculiar/asn1-pfx/build/es2015/bags/secret_bag.js
 var SecretBag = class {
   constructor(params = {}) {
     this.secretTypeId = "";
@@ -20327,7 +20327,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.Any, context: 0 })
 ], SecretBag.prototype, "secretValue", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-pfx/build/es2015/mac_data.js
+// node_modules/@peculiar/asn1-pfx/build/es2015/mac_data.js
 var MacData = class {
   constructor(params = {}) {
     this.mac = new DigestInfo();
@@ -20346,7 +20346,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.Integer, defaultValue: 1 })
 ], MacData.prototype, "iterations", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-pfx/build/es2015/pfx.js
+// node_modules/@peculiar/asn1-pfx/build/es2015/pfx.js
 var PFX = class {
   constructor(params = {}) {
     this.version = 3;
@@ -20365,7 +20365,7 @@ __decorate([
   AsnProp({ type: MacData, optional: true })
 ], PFX.prototype, "macData", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-pfx/build/es2015/safe_bag.js
+// node_modules/@peculiar/asn1-pfx/build/es2015/safe_bag.js
 var SafeContents_1;
 var SafeBag = class {
   constructor(params = {}) {
@@ -20393,7 +20393,7 @@ SafeContents = SafeContents_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence, itemType: SafeBag })
 ], SafeContents);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-pkcs9/build/es2015/index.js
+// node_modules/@peculiar/asn1-pkcs9/build/es2015/index.js
 var ExtensionRequest_1;
 var ExtendedCertificateAttributes_1;
 var SMIMECapabilities_1;
@@ -20637,7 +20637,7 @@ SMIMECapabilities = SMIMECapabilities_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence, itemType: SMIMECapability })
 ], SMIMECapabilities);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-csr/build/es2015/attributes.js
+// node_modules/@peculiar/asn1-csr/build/es2015/attributes.js
 var Attributes_12;
 var Attributes3 = Attributes_12 = class Attributes4 extends AsnArray {
   constructor(items) {
@@ -20649,7 +20649,7 @@ Attributes3 = Attributes_12 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence, itemType: Attribute })
 ], Attributes3);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-csr/build/es2015/certification_request_info.js
+// node_modules/@peculiar/asn1-csr/build/es2015/certification_request_info.js
 var CertificationRequestInfo = class {
   constructor(params = {}) {
     this.version = 0;
@@ -20672,7 +20672,7 @@ __decorate([
   AsnProp({ type: Attributes3, implicit: true, context: 0, optional: true })
 ], CertificationRequestInfo.prototype, "attributes", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-csr/build/es2015/certification_request.js
+// node_modules/@peculiar/asn1-csr/build/es2015/certification_request.js
 var CertificationRequest = class {
   constructor(params = {}) {
     this.certificationRequestInfo = new CertificationRequestInfo();
@@ -20691,7 +20691,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.BitString })
 ], CertificationRequest.prototype, "signature", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/x509/build/x509.es.js
+// node_modules/@peculiar/x509/build/x509.es.js
 var diAlgorithm = "crypto.algorithm";
 var AlgorithmProvider = class {
   getAlgorithms() {
@@ -23509,7 +23509,7 @@ AsnEcSignatureFormatter.namedCurveSize.set("K-256", 32);
 AsnEcSignatureFormatter.namedCurveSize.set("P-384", 48);
 AsnEcSignatureFormatter.namedCurveSize.set("P-521", 66);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/fetch.js
+// node_modules/@simplewebauthn/server/esm/helpers/fetch.js
 function fetch2(url) {
   return _fetchInternals.stubThis(url);
 }
@@ -23517,7 +23517,7 @@ var _fetchInternals = {
   stubThis: (url) => globalThis.fetch(url)
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/isCertRevoked.js
+// node_modules/@simplewebauthn/server/esm/helpers/isCertRevoked.js
 var cacheRevokedCerts = {};
 async function isCertRevoked(cert) {
   const { extensions } = cert;
@@ -23589,7 +23589,7 @@ async function isCertRevoked(cert) {
   return false;
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/decodeAuthenticatorExtensions.js
+// node_modules/@simplewebauthn/server/esm/helpers/decodeAuthenticatorExtensions.js
 function decodeAuthenticatorExtensions(extensionData) {
   let toCBOR;
   try {
@@ -23612,7 +23612,7 @@ function convertMapToObjectDeep(input) {
   return mapped;
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/parseAuthenticatorData.js
+// node_modules/@simplewebauthn/server/esm/helpers/parseAuthenticatorData.js
 function parseAuthenticatorData(authData) {
   if (authData.byteLength < 37) {
     throw new Error(`Authenticator data was ${authData.byteLength} bytes, expected at least 37 bytes`);
@@ -23701,7 +23701,7 @@ var _parseAuthenticatorDataInternals = {
   stubThis: (value) => value
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/toHash.js
+// node_modules/@simplewebauthn/server/esm/helpers/toHash.js
 function toHash(data, algorithm = -7) {
   if (typeof data === "string") {
     data = isoUint8Array_exports.fromUTF8String(data);
@@ -23710,7 +23710,7 @@ function toHash(data, algorithm = -7) {
   return digest2;
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/validateCertificatePath.js
+// node_modules/@simplewebauthn/server/esm/helpers/validateCertificatePath.js
 async function validateCertificatePath(x5cCertsPEM, trustAnchorsPEM = []) {
   if (trustAnchorsPEM.length === 0) {
     return true;
@@ -23817,7 +23817,7 @@ var InvalidSubjectAndIssuer = class extends Error {
   }
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/mapX509SignatureAlgToCOSEAlg.js
+// node_modules/@simplewebauthn/server/esm/helpers/mapX509SignatureAlgToCOSEAlg.js
 function mapX509SignatureAlgToCOSEAlg(signatureAlgorithm) {
   let alg;
   if (signatureAlgorithm === "1.2.840.10045.4.3.2") {
@@ -23840,7 +23840,7 @@ function mapX509SignatureAlgToCOSEAlg(signatureAlgorithm) {
   return alg;
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/convertX509PublicKeyToCOSE.js
+// node_modules/@simplewebauthn/server/esm/helpers/convertX509PublicKeyToCOSE.js
 function convertX509PublicKeyToCOSE(x509Certificate) {
   let cosePublicKey = /* @__PURE__ */ new Map();
   const x509 = AsnParser.parse(x509Certificate, Certificate);
@@ -23894,7 +23894,7 @@ function convertX509PublicKeyToCOSE(x509Certificate) {
   return cosePublicKey;
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/verifySignature.js
+// node_modules/@simplewebauthn/server/esm/helpers/verifySignature.js
 function verifySignature(opts) {
   const { signature, data, credentialPublicKey, x509Certificate, hashAlgorithm } = opts;
   if (!x509Certificate && !credentialPublicKey) {
@@ -23920,7 +23920,7 @@ var _verifySignatureInternals = {
   stubThis: (value) => value
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/metadata/parseJWT.js
+// node_modules/@simplewebauthn/server/esm/metadata/parseJWT.js
 function parseJWT(jwt) {
   const parts = jwt.split(".");
   return [
@@ -23930,7 +23930,7 @@ function parseJWT(jwt) {
   ];
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/metadata/verifyJWT.js
+// node_modules/@simplewebauthn/server/esm/metadata/verifyJWT.js
 function verifyJWT(jwt, leafCert) {
   const [header, payload, signature] = jwt.split(".");
   const certCOSE = convertX509PublicKeyToCOSE(leafCert);
@@ -23954,13 +23954,13 @@ function verifyJWT(jwt, leafCert) {
   throw new Error(`JWT verification with public key of kty ${kty} is not supported by this method`);
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/convertPEMToBytes.js
+// node_modules/@simplewebauthn/server/esm/helpers/convertPEMToBytes.js
 function convertPEMToBytes(pem) {
   const certBase64 = pem.replace("-----BEGIN CERTIFICATE-----", "").replace("-----END CERTIFICATE-----", "").replace(/[\n ]/g, "");
   return isoBase64URL_exports.toBuffer(certBase64, "base64");
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/services/defaultRootCerts/android-safetynet.js
+// node_modules/@simplewebauthn/server/esm/services/defaultRootCerts/android-safetynet.js
 var GlobalSign_Root_CA = `-----BEGIN CERTIFICATE-----
 MIIDdTCCAl2gAwIBAgILBAAAAAABFUtaw5QwDQYJKoZIhvcNAQEFBQAwVzELMAkG
 A1UEBhMCQkUxGTAXBgNVBAoTEEdsb2JhbFNpZ24gbnYtc2ExEDAOBgNVBAsTB1Jv
@@ -23984,7 +23984,7 @@ HMUfpIBvFSDJ3gyICh3WZlXi/EjJKSZp4A==
 -----END CERTIFICATE-----
 `;
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/services/defaultRootCerts/android-key.js
+// node_modules/@simplewebauthn/server/esm/services/defaultRootCerts/android-key.js
 var Google_Hardware_Attestation_Root_1 = `-----BEGIN CERTIFICATE-----
 MIIFYDCCA0igAwIBAgIJAOj6GWMU0voYMA0GCSqGSIb3DQEBCwUAMBsxGTAXBgNV
 BAUTEGY5MjAwOWU4NTNiNmIwNDUwHhcNMTYwNTI2MTYyODUyWhcNMjYwNTI0MTYy
@@ -24113,7 +24113,7 @@ w1IdYIg2Wxg7yHcQZemFQg==
 -----END CERTIFICATE-----
 `;
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/services/defaultRootCerts/apple.js
+// node_modules/@simplewebauthn/server/esm/services/defaultRootCerts/apple.js
 var Apple_WebAuthn_Root_CA = `-----BEGIN CERTIFICATE-----
 MIICEjCCAZmgAwIBAgIQaB0BbHo84wIlpQGUKEdXcTAKBggqhkjOPQQDAzBLMR8w
 HQYDVQQDDBZBcHBsZSBXZWJBdXRobiBSb290IENBMRMwEQYDVQQKDApBcHBsZSBJ
@@ -24130,7 +24130,7 @@ jAGGiQIwHFj+dJZYUJR786osByBelJYsVZd2GbHQu209b5RCmGQ21gpSAk9QZW4B
 -----END CERTIFICATE-----
 `;
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/services/defaultRootCerts/mds.js
+// node_modules/@simplewebauthn/server/esm/services/defaultRootCerts/mds.js
 var GlobalSign_Root_CA_R3 = `-----BEGIN CERTIFICATE-----
 MIIDXzCCAkegAwIBAgILBAAAAAABIVhTCKIwDQYJKoZIhvcNAQELBQAwTDEgMB4G
 A1UECxMXR2xvYmFsU2lnbiBSb290IENBIC0gUjMxEzARBgNVBAoTCkdsb2JhbFNp
@@ -24154,7 +24154,7 @@ WD9f
 -----END CERTIFICATE-----
  `;
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/services/settingsService.js
+// node_modules/@simplewebauthn/server/esm/services/settingsService.js
 var BaseSettingsService = class {
   constructor() {
     Object.defineProperty(this, "pemCertificates", {
@@ -24205,7 +24205,7 @@ SettingsService.setRootCertificates({
   certificates: [GlobalSign_Root_CA_R3]
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/metadata/verifyMDSBlob.js
+// node_modules/@simplewebauthn/server/esm/metadata/verifyMDSBlob.js
 async function verifyMDSBlob(blob) {
   const parsedJWT = parseJWT(blob);
   const header = parsedJWT[0];
@@ -24245,7 +24245,7 @@ async function verifyMDSBlob(blob) {
   };
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/verifyOKP.js
+// node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/verifyOKP.js
 async function verifyOKP(opts) {
   const { cosePublicKey, signature, data } = opts;
   const WebCrypto = await getWebCrypto();
@@ -24291,7 +24291,7 @@ async function verifyOKP(opts) {
   return WebCrypto.subtle.verify(verifyAlgorithm, key, signature, data);
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/unwrapEC2Signature.js
+// node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/unwrapEC2Signature.js
 function unwrapEC2Signature(signature, crv) {
   const parsedSignature = AsnParser.parse(signature, ECDSASigValue);
   const rBytes = new Uint8Array(parsedSignature.r);
@@ -24332,7 +24332,7 @@ function toNormalizedBytes(bytes, componentLength) {
   return normalizedBytes;
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/verify.js
+// node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/verify.js
 function verify(opts) {
   const { cosePublicKey, signature, data, shaHashOverride } = opts;
   if (isCOSEPublicKeyEC2(cosePublicKey)) {
@@ -24356,7 +24356,7 @@ function verify(opts) {
   throw new Error(`Signature verification with public key of kty ${kty} is not supported by this method`);
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/iso/isoUint8Array.js
+// node_modules/@simplewebauthn/server/esm/helpers/iso/isoUint8Array.js
 var isoUint8Array_exports = {};
 __export(isoUint8Array_exports, {
   areEqual: () => areEqual,
@@ -24414,7 +24414,7 @@ function toDataView(array2) {
   return new DataView(array2.buffer, array2.byteOffset, array2.length);
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/generateChallenge.js
+// node_modules/@simplewebauthn/server/esm/helpers/generateChallenge.js
 async function generateChallenge() {
   const challenge = new Uint8Array(32);
   await isoCrypto_exports.getRandomValues(challenge);
@@ -24424,7 +24424,7 @@ var _generateChallengeInternals = {
   stubThis: (value) => value
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/registration/generateRegistrationOptions.js
+// node_modules/@simplewebauthn/server/esm/registration/generateRegistrationOptions.js
 var supportedCOSEAlgorithmIdentifiers = [
   // EdDSA (In first position to encourage authenticators to use this over ES256)
   -8,
@@ -24523,7 +24523,7 @@ async function generateRegistrationOptions(options) {
   };
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/parseBackupFlags.js
+// node_modules/@simplewebauthn/server/esm/helpers/parseBackupFlags.js
 function parseBackupFlags({ be, bs }) {
   const credentialBackedUp = bs;
   let credentialDeviceType = "singleDevice";
@@ -24542,7 +24542,7 @@ var InvalidBackupFlags = class extends Error {
   }
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/matchExpectedRPID.js
+// node_modules/@simplewebauthn/server/esm/helpers/matchExpectedRPID.js
 async function matchExpectedRPID(rpIDHash, expectedRPIDs) {
   try {
     const matchedRPID = await Promise.any(expectedRPIDs.map((expected) => {
@@ -24573,7 +24573,7 @@ var UnexpectedRPIDHash = class extends Error {
   }
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/registration/verifications/verifyAttestationFIDOU2F.js
+// node_modules/@simplewebauthn/server/esm/registration/verifications/verifyAttestationFIDOU2F.js
 async function verifyAttestationFIDOU2F(options) {
   const { attStmt, clientDataHash, rpIdHash, credentialID, credentialPublicKey, aaguid, rootCertificates } = options;
   const reservedByte = Uint8Array.from([0]);
@@ -24611,7 +24611,7 @@ async function verifyAttestationFIDOU2F(options) {
   });
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/validateExtFIDOGenCEAAGUID.js
+// node_modules/@simplewebauthn/server/esm/helpers/validateExtFIDOGenCEAAGUID.js
 var id_fido_gen_ce_aaguid = "1.3.6.1.4.1.45724.1.1.4";
 function validateExtFIDOGenCEAAGUID(certExtensions, aaguid) {
   if (!certExtensions) {
@@ -24632,13 +24632,13 @@ function validateExtFIDOGenCEAAGUID(certExtensions, aaguid) {
   return true;
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/logging.js
+// node_modules/@simplewebauthn/server/esm/helpers/logging.js
 function getLogger(_name) {
   return (_message, ..._rest) => {
   };
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/services/metadataService.js
+// node_modules/@simplewebauthn/server/esm/services/metadataService.js
 var NonRefreshingMDS = {
   url: "",
   no: 0,
@@ -24845,7 +24845,7 @@ var BaseMetadataService = class {
 };
 var MetadataService = new BaseMetadataService();
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/metadata/verifyAttestationWithMetadata.js
+// node_modules/@simplewebauthn/server/esm/metadata/verifyAttestationWithMetadata.js
 async function verifyAttestationWithMetadata({ statement, credentialPublicKey, x5c, attestationStatementAlg }) {
   const { authenticationAlgorithms, authenticatorGetInfo, attestationRootCertificates } = statement;
   const keypairCOSEAlgs = /* @__PURE__ */ new Set();
@@ -24941,7 +24941,7 @@ function stringifyCOSEInfo(info) {
   return toReturn;
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/registration/verifications/verifyAttestationPacked.js
+// node_modules/@simplewebauthn/server/esm/registration/verifications/verifyAttestationPacked.js
 async function verifyAttestationPacked(options) {
   const { attStmt, clientDataHash, authData, credentialPublicKey, aaguid, rootCertificates } = options;
   const sig = attStmt.get("sig");
@@ -25033,7 +25033,7 @@ async function verifyAttestationPacked(options) {
   return verified;
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/registration/verifications/verifyAttestationAndroidSafetyNet.js
+// node_modules/@simplewebauthn/server/esm/registration/verifications/verifyAttestationAndroidSafetyNet.js
 async function verifyAttestationAndroidSafetyNet(options) {
   const { attStmt, clientDataHash, authData, aaguid, rootCertificates, verifyTimestampMS = true, credentialPublicKey, attestationSafetyNetEnforceCTSCheck } = options;
   const alg = attStmt.get("alg");
@@ -25108,7 +25108,7 @@ async function verifyAttestationAndroidSafetyNet(options) {
   return verified;
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/registration/verifications/tpm/constants.js
+// node_modules/@simplewebauthn/server/esm/registration/verifications/tpm/constants.js
 var TPM_ST = {
   196: "TPM_ST_RSP_COMMAND",
   32768: "TPM_ST_NULL",
@@ -25226,7 +25226,7 @@ var TPM_ECC_CURVE_COSE_CRV_MAP = {
   // p256
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/registration/verifications/tpm/parseCertInfo.js
+// node_modules/@simplewebauthn/server/esm/registration/verifications/tpm/parseCertInfo.js
 function parseCertInfo(certInfo) {
   let pointer = 0;
   const dataView = isoUint8Array_exports.toDataView(certInfo);
@@ -25273,7 +25273,7 @@ function parseCertInfo(certInfo) {
   };
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/registration/verifications/tpm/parsePubArea.js
+// node_modules/@simplewebauthn/server/esm/registration/verifications/tpm/parsePubArea.js
 function parsePubArea(pubArea) {
   let pointer = 0;
   const dataView = isoUint8Array_exports.toDataView(pubArea);
@@ -25344,7 +25344,7 @@ function parsePubArea(pubArea) {
   };
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/registration/verifications/tpm/verifyAttestationTPM.js
+// node_modules/@simplewebauthn/server/esm/registration/verifications/tpm/verifyAttestationTPM.js
 async function verifyAttestationTPM(options) {
   const { aaguid, attStmt, authData, credentialPublicKey, clientDataHash, rootCertificates } = options;
   const ver = attStmt.get("ver");
@@ -25575,7 +25575,7 @@ function attestedNameAlgToCOSEAlg(alg) {
   throw new Error(`Unexpected TPM attested name alg ${alg}`);
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-android/build/es2015/key_description.js
+// node_modules/@peculiar/asn1-android/build/es2015/key_description.js
 var IntegerSet_1;
 var id_ce_keyDescription = "1.3.6.1.4.1.11129.2.1.17";
 var VerifiedBootState;
@@ -25864,7 +25864,7 @@ __decorate([
   AsnProp({ type: AuthorizationList })
 ], KeyMintKeyDescription.prototype, "hardwareEnforced", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-android/build/es2015/nonstandard.js
+// node_modules/@peculiar/asn1-android/build/es2015/nonstandard.js
 var NonStandardAuthorizationList_1;
 var NonStandardAuthorization = class NonStandardAuthorization2 extends AuthorizationList {
 };
@@ -25960,7 +25960,7 @@ NonStandardKeyMintKeyDescription = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence })
 ], NonStandardKeyMintKeyDescription);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-android/build/es2015/attestation.js
+// node_modules/@peculiar/asn1-android/build/es2015/attestation.js
 var AttestationPackageInfo = class {
   constructor(params = {}) {
     Object.assign(this, params);
@@ -25984,7 +25984,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.OctetString, repeated: "set" })
 ], AttestationApplicationId.prototype, "signatureDigests", void 0);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/registration/verifications/verifyAttestationAndroidKey.js
+// node_modules/@simplewebauthn/server/esm/registration/verifications/verifyAttestationAndroidKey.js
 async function verifyAttestationAndroidKey(options) {
   const { authData, clientDataHash, attStmt, credentialPublicKey, aaguid, rootCertificates } = options;
   const x5c = attStmt.get("x5c");
@@ -26058,7 +26058,7 @@ async function verifyAttestationAndroidKey(options) {
   });
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/registration/verifications/verifyAttestationApple.js
+// node_modules/@simplewebauthn/server/esm/registration/verifications/verifyAttestationApple.js
 async function verifyAttestationApple(options) {
   const { attStmt, authData, clientDataHash, credentialPublicKey, rootCertificates } = options;
   const x5c = attStmt.get("x5c");
@@ -26094,7 +26094,7 @@ async function verifyAttestationApple(options) {
   return true;
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/registration/verifyRegistrationResponse.js
+// node_modules/@simplewebauthn/server/esm/registration/verifyRegistrationResponse.js
 async function verifyRegistrationResponse(options) {
   const { response, expectedChallenge, expectedOrigin, expectedRPID, expectedType, requireUserPresence = true, requireUserVerification = true, supportedAlgorithmIDs = supportedCOSEAlgorithmIdentifiers, attestationSafetyNetEnforceCTSCheck = true } = options;
   const { id, rawId, type: credentialType, response: attestationResponse } = response;
@@ -26249,7 +26249,7 @@ async function verifyRegistrationResponse(options) {
   };
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/authentication/generateAuthenticationOptions.js
+// node_modules/@simplewebauthn/server/esm/authentication/generateAuthenticationOptions.js
 async function generateAuthenticationOptions(options) {
   const { allowCredentials, challenge = await generateChallenge(), timeout = 6e4, userVerification = "preferred", extensions, rpID } = options;
   let _challenge = challenge;
@@ -26275,7 +26275,7 @@ async function generateAuthenticationOptions(options) {
   };
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/authentication/verifyAuthenticationResponse.js
+// node_modules/@simplewebauthn/server/esm/authentication/verifyAuthenticationResponse.js
 async function verifyAuthenticationResponse(options) {
   const { response, expectedChallenge, expectedOrigin, expectedRPID, expectedType, credential, requireUserVerification = true, advancedFIDOConfig } = options;
   const { id, rawId, type: credentialType, response: assertionResponse } = response;
@@ -41996,7 +41996,7 @@ function errorMessage(error2) {
   return normalizeText31(error2) || "unknown error";
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v3/helpers/util.js
+// node_modules/zod/v3/helpers/util.js
 var util;
 (function(util2) {
   util2.assertEqual = (_) => {
@@ -42130,7 +42130,7 @@ var getParsedType = (data) => {
   }
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v3/ZodError.js
+// node_modules/zod/v3/ZodError.js
 var ZodIssueCode = util.arrayToEnum([
   "invalid_type",
   "invalid_literal",
@@ -42244,7 +42244,7 @@ ZodError.create = (issues) => {
   return error2;
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v3/locales/en.js
+// node_modules/zod/v3/locales/en.js
 var errorMap = (issue2, _ctx) => {
   let message;
   switch (issue2.code) {
@@ -42347,13 +42347,13 @@ var errorMap = (issue2, _ctx) => {
 };
 var en_default = errorMap;
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v3/errors.js
+// node_modules/zod/v3/errors.js
 var overrideErrorMap = en_default;
 function getErrorMap() {
   return overrideErrorMap;
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v3/helpers/parseUtil.js
+// node_modules/zod/v3/helpers/parseUtil.js
 var makeIssue = (params) => {
   const { data, path, errorMaps, issueData } = params;
   const fullPath = [...path, ...issueData.path || []];
@@ -42462,14 +42462,14 @@ var isDirty = (x) => x.status === "dirty";
 var isValid = (x) => x.status === "valid";
 var isAsync = (x) => typeof Promise !== "undefined" && x instanceof Promise;
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v3/helpers/errorUtil.js
+// node_modules/zod/v3/helpers/errorUtil.js
 var errorUtil;
 (function(errorUtil2) {
   errorUtil2.errToObj = (message) => typeof message === "string" ? { message } : message || {};
   errorUtil2.toString = (message) => typeof message === "string" ? message : message?.message;
 })(errorUtil || (errorUtil = {}));
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v3/types.js
+// node_modules/zod/v3/types.js
 var ParseInputLazyPath = class {
   constructor(parent, value, path, key) {
     this._cachedPath = [];
@@ -45873,7 +45873,7 @@ var nullableType = ZodNullable.create;
 var preprocessType = ZodEffects.createWithPreprocess;
 var pipelineType = ZodPipeline.create;
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v4/core/core.js
+// node_modules/zod/v4/core/core.js
 var _a3;
 // @__NO_SIDE_EFFECTS__
 function $constructor(name, initializer3, params) {
@@ -45947,7 +45947,7 @@ function config(newConfig) {
   return globalConfig;
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v4/core/util.js
+// node_modules/zod/v4/core/util.js
 var util_exports = {};
 __export(util_exports, {
   BIGINT_FORMAT_RANGES: () => BIGINT_FORMAT_RANGES,
@@ -46643,7 +46643,7 @@ var Class = class {
   }
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v4/core/errors.js
+// node_modules/zod/v4/core/errors.js
 var initializer = (inst, def) => {
   inst.name = "$ZodError";
   Object.defineProperty(inst, "_zod", {
@@ -46712,7 +46712,7 @@ function formatError(error2, mapper = (issue2) => issue2.message) {
   return fieldErrors;
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v4/core/parse.js
+// node_modules/zod/v4/core/parse.js
 var _parse = (_Err) => (schema, value, _ctx, _params) => {
   const ctx = _ctx ? { ..._ctx, async: false } : { async: false };
   const result = schema._zod.run({ value, issues: [] }, ctx);
@@ -46792,7 +46792,7 @@ var _safeDecodeAsync = (_Err) => async (schema, value, _ctx) => {
   return _safeParseAsync(_Err)(schema, value, _ctx);
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v4/core/regexes.js
+// node_modules/zod/v4/core/regexes.js
 var cuid = /^[cC][0-9a-z]{6,}$/;
 var cuid2 = /^[0-9a-z]+$/;
 var ulid = /^[0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{26}$/;
@@ -46850,7 +46850,7 @@ var _null = /^null$/i;
 var lowercase = /^[^A-Z]*$/;
 var uppercase = /^[^a-z]*$/;
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v4/core/checks.js
+// node_modules/zod/v4/core/checks.js
 var $ZodCheck = /* @__PURE__ */ $constructor("$ZodCheck", (inst, def) => {
   var _a5;
   inst._zod ?? (inst._zod = {});
@@ -47240,7 +47240,7 @@ var $ZodCheckOverwrite = /* @__PURE__ */ $constructor("$ZodCheckOverwrite", (ins
   };
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v4/core/doc.js
+// node_modules/zod/v4/core/doc.js
 var Doc = class {
   constructor(args = []) {
     this.content = [];
@@ -47276,14 +47276,14 @@ var Doc = class {
   }
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v4/core/versions.js
+// node_modules/zod/v4/core/versions.js
 var version = {
   major: 4,
   minor: 4,
   patch: 3
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v4/core/schemas.js
+// node_modules/zod/v4/core/schemas.js
 var $ZodType = /* @__PURE__ */ $constructor("$ZodType", (inst, def) => {
   var _a5;
   inst ?? (inst = {});
@@ -48763,7 +48763,7 @@ function handleRefineResult(result, payload, input, inst) {
   }
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v4/locales/en.js
+// node_modules/zod/v4/locales/en.js
 var error = () => {
   const Sizable = {
     string: { unit: "characters", verb: "to have" },
@@ -48876,7 +48876,7 @@ function en_default2() {
   };
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v4/core/registries.js
+// node_modules/zod/v4/core/registries.js
 var _a4;
 var $output = Symbol("ZodOutput");
 var $input = Symbol("ZodInput");
@@ -48926,7 +48926,7 @@ function registry() {
 (_a4 = globalThis).__zod_globalRegistry ?? (_a4.__zod_globalRegistry = registry());
 var globalRegistry = globalThis.__zod_globalRegistry;
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v4/core/api.js
+// node_modules/zod/v4/core/api.js
 // @__NO_SIDE_EFFECTS__
 function _string(Class2, params) {
   return new Class2({
@@ -49454,7 +49454,7 @@ function _check(fn, params) {
   return ch;
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v4/core/to-json-schema.js
+// node_modules/zod/v4/core/to-json-schema.js
 function initializeContext(params) {
   let target = params?.target ?? "draft-2020-12";
   if (target === "draft-4")
@@ -49813,7 +49813,7 @@ var createStandardJSONSchemaMethod = (schema, io, processors = {}) => (params) =
   return finalize(ctx, schema);
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v4/core/json-schema-processors.js
+// node_modules/zod/v4/core/json-schema-processors.js
 var formatMap = {
   guid: "uuid",
   url: "uri",
@@ -50357,7 +50357,7 @@ function toJSONSchema(input, params) {
   return finalize(ctx, input);
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v4/mini/schemas.js
+// node_modules/zod/v4/mini/schemas.js
 var ZodMiniType = /* @__PURE__ */ $constructor("ZodMiniType", (inst, def) => {
   if (!inst._zod)
     throw new Error("Uninitialized schema in ZodMiniType.");
@@ -50403,7 +50403,7 @@ function object(shape, params) {
   return new ZodMiniObject(def);
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@modelcontextprotocol/sdk/dist/esm/server/zod-compat.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/server/zod-compat.js
 function isZ4Schema(s) {
   const schema = s;
   return !!schema._zod;
@@ -50547,7 +50547,7 @@ function getLiteralValue(schema) {
   return void 0;
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v4/classic/iso.js
+// node_modules/zod/v4/classic/iso.js
 var iso_exports2 = {};
 __export(iso_exports2, {
   ZodISODate: () => ZodISODate,
@@ -50588,7 +50588,7 @@ function duration2(params) {
   return _isoDuration(ZodISODuration, params);
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v4/classic/errors.js
+// node_modules/zod/v4/classic/errors.js
 var initializer2 = (inst, issues) => {
   $ZodError.init(inst, issues);
   inst.name = "ZodError";
@@ -50627,7 +50627,7 @@ var ZodRealError = /* @__PURE__ */ $constructor("ZodError", initializer2, {
   Parent: Error
 });
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v4/classic/parse.js
+// node_modules/zod/v4/classic/parse.js
 var parse2 = /* @__PURE__ */ _parse(ZodRealError);
 var parseAsync2 = /* @__PURE__ */ _parseAsync(ZodRealError);
 var safeParse4 = /* @__PURE__ */ _safeParse(ZodRealError);
@@ -50641,7 +50641,7 @@ var safeDecode2 = /* @__PURE__ */ _safeDecode(ZodRealError);
 var safeEncodeAsync2 = /* @__PURE__ */ _safeEncodeAsync(ZodRealError);
 var safeDecodeAsync2 = /* @__PURE__ */ _safeDecodeAsync(ZodRealError);
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v4/classic/schemas.js
+// node_modules/zod/v4/classic/schemas.js
 var _installedGroups = /* @__PURE__ */ new WeakMap();
 function _installLazyMethods(inst, group, methods) {
   const proto = Object.getPrototypeOf(inst);
@@ -51483,10 +51483,10 @@ function preprocess(fn, schema) {
   });
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v4/classic/external.js
+// node_modules/zod/v4/classic/external.js
 config(en_default2());
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@modelcontextprotocol/sdk/dist/esm/types.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/types.js
 var LATEST_PROTOCOL_VERSION = "2025-11-25";
 var DEFAULT_NEGOTIATED_PROTOCOL_VERSION = "2025-03-26";
 var SUPPORTED_PROTOCOL_VERSIONS = [LATEST_PROTOCOL_VERSION, "2025-06-18", "2025-03-26", "2024-11-05", "2024-10-07"];
@@ -53019,12 +53019,12 @@ var UrlElicitationRequiredError = class extends McpError {
   }
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@modelcontextprotocol/sdk/dist/esm/experimental/tasks/interfaces.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/experimental/tasks/interfaces.js
 function isTerminal(status) {
   return status === "completed" || status === "failed" || status === "cancelled";
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/Options.js
+// node_modules/zod-to-json-schema/dist/esm/Options.js
 var ignoreOverride = Symbol("Let zodToJsonSchema decide on which parser to use");
 var defaultOptions = {
   name: void 0,
@@ -53058,7 +53058,7 @@ var getDefaultOptions = (options) => typeof options === "string" ? {
   ...options
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/Refs.js
+// node_modules/zod-to-json-schema/dist/esm/Refs.js
 var getRefs = (options) => {
   const _options = getDefaultOptions(options);
   const currentPath = _options.name !== void 0 ? [..._options.basePath, _options.definitionPath, _options.name] : _options.basePath;
@@ -53079,7 +53079,7 @@ var getRefs = (options) => {
   };
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/errorMessages.js
+// node_modules/zod-to-json-schema/dist/esm/errorMessages.js
 function addErrorMessage(res, key, errorMessage2, refs) {
   if (!refs?.errorMessages)
     return;
@@ -53095,7 +53095,7 @@ function setResponseValueAndErrors(res, key, value, errorMessage2, refs) {
   addErrorMessage(res, key, errorMessage2, refs);
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/getRelativePath.js
+// node_modules/zod-to-json-schema/dist/esm/getRelativePath.js
 var getRelativePath = (pathA, pathB) => {
   let i = 0;
   for (; i < pathA.length && i < pathB.length; i++) {
@@ -53105,7 +53105,7 @@ var getRelativePath = (pathA, pathB) => {
   return [(pathA.length - i).toString(), ...pathB.slice(i)].join("/");
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/any.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/any.js
 function parseAnyDef(refs) {
   if (refs.target !== "openAi") {
     return {};
@@ -53121,7 +53121,7 @@ function parseAnyDef(refs) {
   };
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/array.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/array.js
 function parseArrayDef(def, refs) {
   const res = {
     type: "array"
@@ -53145,7 +53145,7 @@ function parseArrayDef(def, refs) {
   return res;
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/bigint.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/bigint.js
 function parseBigintDef(def, refs) {
   const res = {
     type: "integer",
@@ -53191,24 +53191,24 @@ function parseBigintDef(def, refs) {
   return res;
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/boolean.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/boolean.js
 function parseBooleanDef() {
   return {
     type: "boolean"
   };
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/branded.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/branded.js
 function parseBrandedDef(_def, refs) {
   return parseDef(_def.type._def, refs);
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/catch.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/catch.js
 var parseCatchDef = (def, refs) => {
   return parseDef(def.innerType._def, refs);
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/date.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/date.js
 function parseDateDef(def, refs, overrideDateStrategy) {
   const strategy = overrideDateStrategy ?? refs.dateStrategy;
   if (Array.isArray(strategy)) {
@@ -53267,7 +53267,7 @@ var integerDateParser = (def, refs) => {
   return res;
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/default.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/default.js
 function parseDefaultDef(_def, refs) {
   return {
     ...parseDef(_def.innerType._def, refs),
@@ -53275,12 +53275,12 @@ function parseDefaultDef(_def, refs) {
   };
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/effects.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/effects.js
 function parseEffectsDef(_def, refs) {
   return refs.effectStrategy === "input" ? parseDef(_def.schema._def, refs) : parseAnyDef(refs);
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/enum.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/enum.js
 function parseEnumDef(def) {
   return {
     type: "string",
@@ -53288,7 +53288,7 @@ function parseEnumDef(def) {
   };
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/intersection.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/intersection.js
 var isJsonSchema7AllOfType = (type) => {
   if ("type" in type && type.type === "string")
     return false;
@@ -53330,7 +53330,7 @@ function parseIntersectionDef(def, refs) {
   } : void 0;
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/literal.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/literal.js
 function parseLiteralDef(def, refs) {
   const parsedType2 = typeof def.value;
   if (parsedType2 !== "bigint" && parsedType2 !== "number" && parsedType2 !== "boolean" && parsedType2 !== "string") {
@@ -53350,7 +53350,7 @@ function parseLiteralDef(def, refs) {
   };
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/string.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/string.js
 var emojiRegex2 = void 0;
 var zodPatterns = {
   /**
@@ -53675,7 +53675,7 @@ function stringifyRegExpWithFlags(regex, refs) {
   return pattern;
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/record.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/record.js
 function parseRecordDef(def, refs) {
   if (refs.target === "openAi") {
     console.warn("Warning: OpenAI may not support records in schemas! Try an array of key-value pairs instead.");
@@ -53727,7 +53727,7 @@ function parseRecordDef(def, refs) {
   return schema;
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/map.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/map.js
 function parseMapDef(def, refs) {
   if (refs.mapStrategy === "record") {
     return parseRecordDef(def, refs);
@@ -53752,7 +53752,7 @@ function parseMapDef(def, refs) {
   };
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/nativeEnum.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/nativeEnum.js
 function parseNativeEnumDef(def) {
   const object3 = def.values;
   const actualKeys = Object.keys(def.values).filter((key) => {
@@ -53766,7 +53766,7 @@ function parseNativeEnumDef(def) {
   };
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/never.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/never.js
 function parseNeverDef(refs) {
   return refs.target === "openAi" ? void 0 : {
     not: parseAnyDef({
@@ -53776,7 +53776,7 @@ function parseNeverDef(refs) {
   };
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/null.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/null.js
 function parseNullDef(refs) {
   return refs.target === "openApi3" ? {
     enum: ["null"],
@@ -53786,7 +53786,7 @@ function parseNullDef(refs) {
   };
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/union.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/union.js
 var primitiveMappings = {
   ZodString: "string",
   ZodNumber: "number",
@@ -53854,7 +53854,7 @@ var asAnyOf = (def, refs) => {
   return anyOf.length ? { anyOf } : void 0;
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/nullable.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/nullable.js
 function parseNullableDef(def, refs) {
   if (["ZodString", "ZodNumber", "ZodBigInt", "ZodBoolean", "ZodNull"].includes(def.innerType._def.typeName) && (!def.innerType._def.checks || !def.innerType._def.checks.length)) {
     if (refs.target === "openApi3") {
@@ -53886,7 +53886,7 @@ function parseNullableDef(def, refs) {
   return base && { anyOf: [base, { type: "null" }] };
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/number.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/number.js
 function parseNumberDef(def, refs) {
   const res = {
     type: "number"
@@ -53935,7 +53935,7 @@ function parseNumberDef(def, refs) {
   return res;
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/object.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/object.js
 function parseObjectDef(def, refs) {
   const forceOptionalIntoNullable = refs.target === "openAi";
   const result = {
@@ -54005,7 +54005,7 @@ function safeIsOptional(schema) {
   }
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/optional.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/optional.js
 var parseOptionalDef = (def, refs) => {
   if (refs.currentPath.toString() === refs.propertyPath?.toString()) {
     return parseDef(def.innerType._def, refs);
@@ -54024,7 +54024,7 @@ var parseOptionalDef = (def, refs) => {
   } : parseAnyDef(refs);
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/pipeline.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/pipeline.js
 var parsePipelineDef = (def, refs) => {
   if (refs.pipeStrategy === "input") {
     return parseDef(def.in._def, refs);
@@ -54044,12 +54044,12 @@ var parsePipelineDef = (def, refs) => {
   };
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/promise.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/promise.js
 function parsePromiseDef(def, refs) {
   return parseDef(def.type._def, refs);
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/set.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/set.js
 function parseSetDef(def, refs) {
   const items = parseDef(def.valueType._def, {
     ...refs,
@@ -54069,7 +54069,7 @@ function parseSetDef(def, refs) {
   return schema;
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/tuple.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/tuple.js
 function parseTupleDef(def, refs) {
   if (def.rest) {
     return {
@@ -54097,24 +54097,24 @@ function parseTupleDef(def, refs) {
   }
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/undefined.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/undefined.js
 function parseUndefinedDef(refs) {
   return {
     not: parseAnyDef(refs)
   };
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/unknown.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/unknown.js
 function parseUnknownDef(refs) {
   return parseAnyDef(refs);
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/readonly.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/readonly.js
 var parseReadonlyDef = (def, refs) => {
   return parseDef(def.innerType._def, refs);
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/selectParser.js
+// node_modules/zod-to-json-schema/dist/esm/selectParser.js
 var selectParser = (def, typeName, refs) => {
   switch (typeName) {
     case ZodFirstPartyTypeKind.ZodString:
@@ -54190,7 +54190,7 @@ var selectParser = (def, typeName, refs) => {
   }
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parseDef.js
+// node_modules/zod-to-json-schema/dist/esm/parseDef.js
 function parseDef(def, refs, forceResolution = false) {
   const seenItem = refs.seen.get(def);
   if (refs.override) {
@@ -54246,7 +54246,7 @@ var addMeta = (def, refs, jsonSchema) => {
   return jsonSchema;
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/zodToJsonSchema.js
+// node_modules/zod-to-json-schema/dist/esm/zodToJsonSchema.js
 var zodToJsonSchema = (schema, options) => {
   const refs = getRefs(options);
   let definitions = typeof options === "object" && options.definitions ? Object.entries(options.definitions).reduce((acc, [name2, schema2]) => ({
@@ -54308,7 +54308,7 @@ var zodToJsonSchema = (schema, options) => {
   return combined;
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@modelcontextprotocol/sdk/dist/esm/server/zod-json-schema-compat.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/server/zod-json-schema-compat.js
 function mapMiniTarget(t) {
   if (!t)
     return "draft-7";
@@ -54350,7 +54350,7 @@ function parseWithCompat(schema, data) {
   return result.data;
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@modelcontextprotocol/sdk/dist/esm/shared/protocol.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/shared/protocol.js
 var DEFAULT_REQUEST_TIMEOUT_MSEC = 6e4;
 var Protocol = class {
   constructor(_options) {
@@ -55304,7 +55304,7 @@ function mergeCapabilities(base, additional) {
   return result;
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@modelcontextprotocol/sdk/dist/esm/validation/ajv-provider.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/validation/ajv-provider.js
 var import_ajv = __toESM(require_ajv(), 1);
 var import_ajv_formats = __toESM(require_dist(), 1);
 function createDefaultAjvInstance() {
@@ -55372,7 +55372,7 @@ var AjvJsonSchemaValidator = class {
   }
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@modelcontextprotocol/sdk/dist/esm/experimental/tasks/server.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/experimental/tasks/server.js
 var ExperimentalServerTasks = class {
   constructor(_server) {
     this._server = _server;
@@ -55585,7 +55585,7 @@ var ExperimentalServerTasks = class {
   }
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@modelcontextprotocol/sdk/dist/esm/experimental/tasks/helpers.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/experimental/tasks/helpers.js
 function assertToolsCallTaskCapability(requests, method, entityName) {
   if (!requests) {
     throw new Error(`${entityName} does not support task creation (required for ${method})`);
@@ -55620,7 +55620,7 @@ function assertClientRequestTaskCapability(requests, method, entityName) {
   }
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@modelcontextprotocol/sdk/dist/esm/server/index.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/server/index.js
 var Server = class extends Protocol {
   /**
    * Initializes this server with the given name and version information.
@@ -56000,7 +56000,7 @@ var Server = class extends Protocol {
   }
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@modelcontextprotocol/sdk/dist/esm/server/completable.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/server/completable.js
 var COMPLETABLE_SYMBOL = Symbol.for("mcp.completable");
 function isCompletable(schema) {
   return !!schema && typeof schema === "object" && COMPLETABLE_SYMBOL in schema;
@@ -56014,7 +56014,7 @@ var McpZodTypeKind;
   McpZodTypeKind2["Completable"] = "McpCompletable";
 })(McpZodTypeKind || (McpZodTypeKind = {}));
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@modelcontextprotocol/sdk/dist/esm/shared/toolNameValidation.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/shared/toolNameValidation.js
 var TOOL_NAME_REGEX = /^[A-Za-z0-9._-]{1,128}$/;
 function validateToolName(name) {
   const warnings = [];
@@ -56072,7 +56072,7 @@ function validateAndWarnToolName(name) {
   return result.isValid;
 }
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@modelcontextprotocol/sdk/dist/esm/experimental/tasks/mcp-server.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/experimental/tasks/mcp-server.js
 var ExperimentalMcpServerTasks = class {
   constructor(_mcpServer) {
     this._mcpServer = _mcpServer;
@@ -56087,7 +56087,7 @@ var ExperimentalMcpServerTasks = class {
   }
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@modelcontextprotocol/sdk/dist/esm/server/mcp.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/server/mcp.js
 var McpServer = class {
   constructor(serverInfo, options) {
     this._registeredResources = {};
@@ -56879,7 +56879,7 @@ var EMPTY_COMPLETION_RESULT = {
   }
 };
 
-// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@modelcontextprotocol/sdk/dist/esm/server/webStandardStreamableHttp.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/server/webStandardStreamableHttp.js
 var WebStandardStreamableHTTPServerTransport = class {
   constructor(options = {}) {
     this._started = false;

--- a/worker.js
+++ b/worker.js
@@ -40,9 +40,9 @@ var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__ge
   mod
 ));
 
-// node_modules/pvtsutils/build/index.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/pvtsutils/build/index.js
 var require_build = __commonJS({
-  "node_modules/pvtsutils/build/index.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/pvtsutils/build/index.js"(exports) {
     "use strict";
     var ARRAY_BUFFER_NAME = "[object ArrayBuffer]";
     var BufferSourceConverter6 = class _BufferSourceConverter {
@@ -404,9 +404,9 @@ var require_build = __commonJS({
   }
 });
 
-// node_modules/reflect-metadata/Reflect.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/reflect-metadata/Reflect.js
 var require_Reflect = __commonJS({
-  "node_modules/reflect-metadata/Reflect.js"() {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/reflect-metadata/Reflect.js"() {
     var Reflect2;
     (function(Reflect3) {
       (function(factory) {
@@ -1495,9 +1495,9 @@ var require_crypto = __commonJS({
   }
 });
 
-// node_modules/tweetnacl/nacl-fast.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tweetnacl/nacl-fast.js
 var require_nacl_fast = __commonJS({
-  "node_modules/tweetnacl/nacl-fast.js"(exports, module) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tweetnacl/nacl-fast.js"(exports, module) {
     (function(nacl5) {
       "use strict";
       var gf = function(init) {
@@ -3719,18 +3719,18 @@ var require_nacl_fast = __commonJS({
   }
 });
 
-// node_modules/tweetnacl-sealedbox-js/src/consts.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tweetnacl-sealedbox-js/src/consts.js
 var import_tweetnacl, overheadLength;
 var init_consts = __esm({
-  "node_modules/tweetnacl-sealedbox-js/src/consts.js"() {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tweetnacl-sealedbox-js/src/consts.js"() {
     import_tweetnacl = __toESM(require_nacl_fast());
     overheadLength = import_tweetnacl.default.box.publicKeyLength + import_tweetnacl.default.box.overheadLength;
   }
 });
 
-// node_modules/blakejs/util.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/blakejs/util.js
 var require_util = __commonJS({
-  "node_modules/blakejs/util.js"(exports, module) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/blakejs/util.js"(exports, module) {
     var ERROR_MSG_INPUT = "Input must be an string, Buffer or Uint8Array";
     function normalizeInput(input) {
       let ret;
@@ -3800,9 +3800,9 @@ var require_util = __commonJS({
   }
 });
 
-// node_modules/blakejs/blake2b.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/blakejs/blake2b.js
 var require_blake2b = __commonJS({
-  "node_modules/blakejs/blake2b.js"(exports, module) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/blakejs/blake2b.js"(exports, module) {
     var util2 = require_util();
     function ADD64AA(v2, a, b) {
       const o0 = v2[a] + v2[b];
@@ -4274,7 +4274,7 @@ var require_blake2b = __commonJS({
   }
 });
 
-// node_modules/tweetnacl-sealedbox-js/src/nonce.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tweetnacl-sealedbox-js/src/nonce.js
 function nonce(pk1, pk2) {
   var state = import_blake2b.default.blake2bInit(import_tweetnacl2.default.box.nonceLength, null);
   import_blake2b.default.blake2bUpdate(state, pk1);
@@ -4283,24 +4283,24 @@ function nonce(pk1, pk2) {
 }
 var import_tweetnacl2, import_blake2b;
 var init_nonce = __esm({
-  "node_modules/tweetnacl-sealedbox-js/src/nonce.js"() {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tweetnacl-sealedbox-js/src/nonce.js"() {
     import_tweetnacl2 = __toESM(require_nacl_fast());
     import_blake2b = __toESM(require_blake2b());
   }
 });
 
-// node_modules/tweetnacl-sealedbox-js/src/utils.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tweetnacl-sealedbox-js/src/utils.js
 function zero(buf) {
   for (var i = 0; i < buf.length; i++) {
     buf[i] = 0;
   }
 }
 var init_utils = __esm({
-  "node_modules/tweetnacl-sealedbox-js/src/utils.js"() {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tweetnacl-sealedbox-js/src/utils.js"() {
   }
 });
 
-// node_modules/tweetnacl-sealedbox-js/src/seal.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tweetnacl-sealedbox-js/src/seal.js
 function seal(m, pk) {
   var c = new Uint8Array(overheadLength + m.length);
   var ek = import_tweetnacl3.default.box.keyPair();
@@ -4313,7 +4313,7 @@ function seal(m, pk) {
 }
 var import_tweetnacl3;
 var init_seal = __esm({
-  "node_modules/tweetnacl-sealedbox-js/src/seal.js"() {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tweetnacl-sealedbox-js/src/seal.js"() {
     import_tweetnacl3 = __toESM(require_nacl_fast());
     init_nonce();
     init_consts();
@@ -4321,7 +4321,7 @@ var init_seal = __esm({
   }
 });
 
-// node_modules/tweetnacl-sealedbox-js/src/open.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tweetnacl-sealedbox-js/src/open.js
 function open(c, pk, sk) {
   var epk = c.subarray(0, import_tweetnacl4.default.box.publicKeyLength);
   var nonce2 = nonce(epk, pk);
@@ -4330,13 +4330,13 @@ function open(c, pk, sk) {
 }
 var import_tweetnacl4;
 var init_open = __esm({
-  "node_modules/tweetnacl-sealedbox-js/src/open.js"() {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tweetnacl-sealedbox-js/src/open.js"() {
     import_tweetnacl4 = __toESM(require_nacl_fast());
     init_nonce();
   }
 });
 
-// node_modules/tweetnacl-sealedbox-js/entrypoint.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tweetnacl-sealedbox-js/entrypoint.js
 var entrypoint_exports = {};
 __export(entrypoint_exports, {
   default: () => entrypoint_default,
@@ -4346,7 +4346,7 @@ __export(entrypoint_exports, {
 });
 var entrypoint_default;
 var init_entrypoint = __esm({
-  "node_modules/tweetnacl-sealedbox-js/entrypoint.js"() {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tweetnacl-sealedbox-js/entrypoint.js"() {
     init_consts();
     init_seal();
     init_open();
@@ -4354,9 +4354,9 @@ var init_entrypoint = __esm({
   }
 });
 
-// node_modules/ajv/dist/compile/codegen/code.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/codegen/code.js
 var require_code = __commonJS({
-  "node_modules/ajv/dist/compile/codegen/code.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/codegen/code.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.regexpCode = exports.getEsmExportName = exports.getProperty = exports.safeStringify = exports.stringify = exports.strConcat = exports.addCodeArg = exports.str = exports._ = exports.nil = exports._Code = exports.Name = exports.IDENTIFIER = exports._CodeOrName = void 0;
@@ -4508,9 +4508,9 @@ var require_code = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/compile/codegen/scope.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/codegen/scope.js
 var require_scope = __commonJS({
-  "node_modules/ajv/dist/compile/codegen/scope.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/codegen/scope.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.ValueScope = exports.ValueScopeName = exports.Scope = exports.varKinds = exports.UsedValueState = void 0;
@@ -4653,9 +4653,9 @@ var require_scope = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/compile/codegen/index.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/codegen/index.js
 var require_codegen = __commonJS({
-  "node_modules/ajv/dist/compile/codegen/index.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/codegen/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.or = exports.and = exports.not = exports.CodeGen = exports.operators = exports.varKinds = exports.ValueScopeName = exports.ValueScope = exports.Scope = exports.Name = exports.regexpCode = exports.stringify = exports.getProperty = exports.nil = exports.strConcat = exports.str = exports._ = void 0;
@@ -5373,9 +5373,9 @@ var require_codegen = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/compile/util.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/util.js
 var require_util2 = __commonJS({
-  "node_modules/ajv/dist/compile/util.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/util.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.checkStrictMode = exports.getErrorPath = exports.Type = exports.useFunc = exports.setEvaluated = exports.evaluatedPropsToName = exports.mergeEvaluated = exports.eachItem = exports.unescapeJsonPointer = exports.escapeJsonPointer = exports.escapeFragment = exports.unescapeFragment = exports.schemaRefOrVal = exports.schemaHasRulesButRef = exports.schemaHasRules = exports.checkUnknownRules = exports.alwaysValidSchema = exports.toHash = void 0;
@@ -5540,9 +5540,9 @@ var require_util2 = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/compile/names.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/names.js
 var require_names = __commonJS({
-  "node_modules/ajv/dist/compile/names.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/names.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -5579,9 +5579,9 @@ var require_names = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/compile/errors.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/errors.js
 var require_errors = __commonJS({
-  "node_modules/ajv/dist/compile/errors.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/errors.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.extendErrors = exports.resetErrorsCount = exports.reportExtraError = exports.reportError = exports.keyword$DataError = exports.keywordError = void 0;
@@ -5701,9 +5701,9 @@ var require_errors = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/compile/validate/boolSchema.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/validate/boolSchema.js
 var require_boolSchema = __commonJS({
-  "node_modules/ajv/dist/compile/validate/boolSchema.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/validate/boolSchema.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.boolOrEmptySchema = exports.topBoolOrEmptySchema = void 0;
@@ -5752,9 +5752,9 @@ var require_boolSchema = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/compile/rules.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/rules.js
 var require_rules = __commonJS({
-  "node_modules/ajv/dist/compile/rules.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/rules.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.getRules = exports.isJSONType = void 0;
@@ -5783,9 +5783,9 @@ var require_rules = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/compile/validate/applicability.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/validate/applicability.js
 var require_applicability = __commonJS({
-  "node_modules/ajv/dist/compile/validate/applicability.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/validate/applicability.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.shouldUseRule = exports.shouldUseGroup = exports.schemaHasRulesForType = void 0;
@@ -5806,9 +5806,9 @@ var require_applicability = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/compile/validate/dataType.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/validate/dataType.js
 var require_dataType = __commonJS({
-  "node_modules/ajv/dist/compile/validate/dataType.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/validate/dataType.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.reportTypeError = exports.checkDataTypes = exports.checkDataType = exports.coerceAndCheckDataType = exports.getJSONTypes = exports.getSchemaTypes = exports.DataType = void 0;
@@ -5990,9 +5990,9 @@ var require_dataType = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/compile/validate/defaults.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/validate/defaults.js
 var require_defaults = __commonJS({
-  "node_modules/ajv/dist/compile/validate/defaults.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/validate/defaults.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.assignDefaults = void 0;
@@ -6027,9 +6027,9 @@ var require_defaults = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/vocabularies/code.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/code.js
 var require_code2 = __commonJS({
-  "node_modules/ajv/dist/vocabularies/code.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/code.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.validateUnion = exports.validateArray = exports.usePattern = exports.callValidateCode = exports.schemaProperties = exports.allSchemaProperties = exports.noPropertyInData = exports.propertyInData = exports.isOwnProperty = exports.hasPropFunc = exports.reportMissingProp = exports.checkMissingProp = exports.checkReportMissingProp = void 0;
@@ -6160,9 +6160,9 @@ var require_code2 = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/compile/validate/keyword.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/validate/keyword.js
 var require_keyword = __commonJS({
-  "node_modules/ajv/dist/compile/validate/keyword.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/validate/keyword.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.validateKeywordUsage = exports.validSchemaType = exports.funcKeywordCode = exports.macroKeywordCode = void 0;
@@ -6278,9 +6278,9 @@ var require_keyword = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/compile/validate/subschema.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/validate/subschema.js
 var require_subschema = __commonJS({
-  "node_modules/ajv/dist/compile/validate/subschema.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/validate/subschema.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.extendSubschemaMode = exports.extendSubschemaData = exports.getSubschema = void 0;
@@ -6361,9 +6361,9 @@ var require_subschema = __commonJS({
   }
 });
 
-// node_modules/fast-deep-equal/index.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/fast-deep-equal/index.js
 var require_fast_deep_equal = __commonJS({
-  "node_modules/fast-deep-equal/index.js"(exports, module) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/fast-deep-equal/index.js"(exports, module) {
     "use strict";
     module.exports = function equal(a, b) {
       if (a === b) return true;
@@ -6396,9 +6396,9 @@ var require_fast_deep_equal = __commonJS({
   }
 });
 
-// node_modules/json-schema-traverse/index.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/json-schema-traverse/index.js
 var require_json_schema_traverse = __commonJS({
-  "node_modules/json-schema-traverse/index.js"(exports, module) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/json-schema-traverse/index.js"(exports, module) {
     "use strict";
     var traverse = module.exports = function(schema, opts, cb) {
       if (typeof opts == "function") {
@@ -6484,9 +6484,9 @@ var require_json_schema_traverse = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/compile/resolve.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/resolve.js
 var require_resolve = __commonJS({
-  "node_modules/ajv/dist/compile/resolve.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/resolve.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.getSchemaRefs = exports.resolveUrl = exports.normalizeId = exports._getFullPath = exports.getFullPath = exports.inlineRef = void 0;
@@ -6640,9 +6640,9 @@ var require_resolve = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/compile/validate/index.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/validate/index.js
 var require_validate = __commonJS({
-  "node_modules/ajv/dist/compile/validate/index.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/validate/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.getData = exports.KeywordCxt = exports.validateFunctionCode = void 0;
@@ -7148,9 +7148,9 @@ var require_validate = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/runtime/validation_error.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/runtime/validation_error.js
 var require_validation_error = __commonJS({
-  "node_modules/ajv/dist/runtime/validation_error.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/runtime/validation_error.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var ValidationError = class extends Error {
@@ -7164,9 +7164,9 @@ var require_validation_error = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/compile/ref_error.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/ref_error.js
 var require_ref_error = __commonJS({
-  "node_modules/ajv/dist/compile/ref_error.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/ref_error.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var resolve_1 = require_resolve();
@@ -7181,9 +7181,9 @@ var require_ref_error = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/compile/index.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/index.js
 var require_compile = __commonJS({
-  "node_modules/ajv/dist/compile/index.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/compile/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.resolveSchema = exports.getCompilingSchema = exports.resolveRef = exports.compileSchema = exports.SchemaEnv = void 0;
@@ -7405,9 +7405,9 @@ var require_compile = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/refs/data.json
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/refs/data.json
 var require_data = __commonJS({
-  "node_modules/ajv/dist/refs/data.json"(exports, module) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/refs/data.json"(exports, module) {
     module.exports = {
       $id: "https://raw.githubusercontent.com/ajv-validator/ajv/master/lib/refs/data.json#",
       description: "Meta-schema for $data reference (JSON AnySchema extension proposal)",
@@ -7424,9 +7424,9 @@ var require_data = __commonJS({
   }
 });
 
-// node_modules/fast-uri/lib/utils.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/fast-uri/lib/utils.js
 var require_utils = __commonJS({
-  "node_modules/fast-uri/lib/utils.js"(exports, module) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/fast-uri/lib/utils.js"(exports, module) {
     "use strict";
     var isUUID = RegExp.prototype.test.bind(/^[\da-f]{8}-[\da-f]{4}-[\da-f]{4}-[\da-f]{4}-[\da-f]{12}$/iu);
     var isIPv4 = RegExp.prototype.test.bind(/^(?:(?:25[0-5]|2[0-4]\d|1\d{2}|[1-9]\d|\d)\.){3}(?:25[0-5]|2[0-4]\d|1\d{2}|[1-9]\d|\d)$/u);
@@ -7737,9 +7737,9 @@ var require_utils = __commonJS({
   }
 });
 
-// node_modules/fast-uri/lib/schemes.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/fast-uri/lib/schemes.js
 var require_schemes = __commonJS({
-  "node_modules/fast-uri/lib/schemes.js"(exports, module) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/fast-uri/lib/schemes.js"(exports, module) {
     "use strict";
     var { isUUID } = require_utils();
     var URN_REG = /([\da-z][\d\-a-z]{0,31}):((?:[\w!$'()*+,\-.:;=@]|%[\da-f]{2})+)/iu;
@@ -7947,9 +7947,9 @@ var require_schemes = __commonJS({
   }
 });
 
-// node_modules/fast-uri/index.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/fast-uri/index.js
 var require_fast_uri = __commonJS({
-  "node_modules/fast-uri/index.js"(exports, module) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/fast-uri/index.js"(exports, module) {
     "use strict";
     var { normalizeIPv6, removeDotSegments, recomposeAuthority, normalizePercentEncoding, normalizePathEncoding, escapePreservingEscapes, reescapeHostDelimiters, isIPv4, nonSimpleDomain } = require_utils();
     var { SCHEMES, getSchemeHandler } = require_schemes();
@@ -8233,9 +8233,9 @@ var require_fast_uri = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/runtime/uri.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/runtime/uri.js
 var require_uri = __commonJS({
-  "node_modules/ajv/dist/runtime/uri.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/runtime/uri.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var uri = require_fast_uri();
@@ -8244,9 +8244,9 @@ var require_uri = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/core.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/core.js
 var require_core = __commonJS({
-  "node_modules/ajv/dist/core.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/core.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.CodeGen = exports.Name = exports.nil = exports.stringify = exports.str = exports._ = exports.KeywordCxt = void 0;
@@ -8855,9 +8855,9 @@ var require_core = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/vocabularies/core/id.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/core/id.js
 var require_id = __commonJS({
-  "node_modules/ajv/dist/vocabularies/core/id.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/core/id.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var def = {
@@ -8870,9 +8870,9 @@ var require_id = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/vocabularies/core/ref.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/core/ref.js
 var require_ref = __commonJS({
-  "node_modules/ajv/dist/vocabularies/core/ref.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/core/ref.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.callRef = exports.getValidate = void 0;
@@ -8992,9 +8992,9 @@ var require_ref = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/vocabularies/core/index.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/core/index.js
 var require_core2 = __commonJS({
-  "node_modules/ajv/dist/vocabularies/core/index.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/core/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var id_1 = require_id();
@@ -9013,9 +9013,9 @@ var require_core2 = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/vocabularies/validation/limitNumber.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/limitNumber.js
 var require_limitNumber = __commonJS({
-  "node_modules/ajv/dist/vocabularies/validation/limitNumber.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/limitNumber.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -9045,9 +9045,9 @@ var require_limitNumber = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/vocabularies/validation/multipleOf.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/multipleOf.js
 var require_multipleOf = __commonJS({
-  "node_modules/ajv/dist/vocabularies/validation/multipleOf.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/multipleOf.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -9073,9 +9073,9 @@ var require_multipleOf = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/runtime/ucs2length.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/runtime/ucs2length.js
 var require_ucs2length = __commonJS({
-  "node_modules/ajv/dist/runtime/ucs2length.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/runtime/ucs2length.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     function ucs2length(str) {
@@ -9099,9 +9099,9 @@ var require_ucs2length = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/vocabularies/validation/limitLength.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/limitLength.js
 var require_limitLength = __commonJS({
-  "node_modules/ajv/dist/vocabularies/validation/limitLength.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/limitLength.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -9131,9 +9131,9 @@ var require_limitLength = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/vocabularies/validation/pattern.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/pattern.js
 var require_pattern = __commonJS({
-  "node_modules/ajv/dist/vocabularies/validation/pattern.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/pattern.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var code_1 = require_code2();
@@ -9168,9 +9168,9 @@ var require_pattern = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/vocabularies/validation/limitProperties.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/limitProperties.js
 var require_limitProperties = __commonJS({
-  "node_modules/ajv/dist/vocabularies/validation/limitProperties.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/limitProperties.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -9197,9 +9197,9 @@ var require_limitProperties = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/vocabularies/validation/required.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/required.js
 var require_required = __commonJS({
-  "node_modules/ajv/dist/vocabularies/validation/required.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/required.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var code_1 = require_code2();
@@ -9279,9 +9279,9 @@ var require_required = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/vocabularies/validation/limitItems.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/limitItems.js
 var require_limitItems = __commonJS({
-  "node_modules/ajv/dist/vocabularies/validation/limitItems.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/limitItems.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -9308,9 +9308,9 @@ var require_limitItems = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/runtime/equal.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/runtime/equal.js
 var require_equal = __commonJS({
-  "node_modules/ajv/dist/runtime/equal.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/runtime/equal.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var equal = require_fast_deep_equal();
@@ -9319,9 +9319,9 @@ var require_equal = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/vocabularies/validation/uniqueItems.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/uniqueItems.js
 var require_uniqueItems = __commonJS({
-  "node_modules/ajv/dist/vocabularies/validation/uniqueItems.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/uniqueItems.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var dataType_1 = require_dataType();
@@ -9386,9 +9386,9 @@ var require_uniqueItems = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/vocabularies/validation/const.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/const.js
 var require_const = __commonJS({
-  "node_modules/ajv/dist/vocabularies/validation/const.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/const.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -9415,9 +9415,9 @@ var require_const = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/vocabularies/validation/enum.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/enum.js
 var require_enum = __commonJS({
-  "node_modules/ajv/dist/vocabularies/validation/enum.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/enum.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -9464,9 +9464,9 @@ var require_enum = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/vocabularies/validation/index.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/index.js
 var require_validation = __commonJS({
-  "node_modules/ajv/dist/vocabularies/validation/index.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/validation/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var limitNumber_1 = require_limitNumber();
@@ -9502,9 +9502,9 @@ var require_validation = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/vocabularies/applicator/additionalItems.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/additionalItems.js
 var require_additionalItems = __commonJS({
-  "node_modules/ajv/dist/vocabularies/applicator/additionalItems.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/additionalItems.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.validateAdditionalItems = void 0;
@@ -9555,9 +9555,9 @@ var require_additionalItems = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/vocabularies/applicator/items.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/items.js
 var require_items = __commonJS({
-  "node_modules/ajv/dist/vocabularies/applicator/items.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/items.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.validateTuple = void 0;
@@ -9612,9 +9612,9 @@ var require_items = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/vocabularies/applicator/prefixItems.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/prefixItems.js
 var require_prefixItems = __commonJS({
-  "node_modules/ajv/dist/vocabularies/applicator/prefixItems.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/prefixItems.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var items_1 = require_items();
@@ -9629,9 +9629,9 @@ var require_prefixItems = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/vocabularies/applicator/items2020.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/items2020.js
 var require_items2020 = __commonJS({
-  "node_modules/ajv/dist/vocabularies/applicator/items2020.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/items2020.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -9664,9 +9664,9 @@ var require_items2020 = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/vocabularies/applicator/contains.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/contains.js
 var require_contains = __commonJS({
-  "node_modules/ajv/dist/vocabularies/applicator/contains.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/contains.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -9758,9 +9758,9 @@ var require_contains = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/vocabularies/applicator/dependencies.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/dependencies.js
 var require_dependencies = __commonJS({
-  "node_modules/ajv/dist/vocabularies/applicator/dependencies.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/dependencies.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.validateSchemaDeps = exports.validatePropertyDeps = exports.error = void 0;
@@ -9852,9 +9852,9 @@ var require_dependencies = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/vocabularies/applicator/propertyNames.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/propertyNames.js
 var require_propertyNames = __commonJS({
-  "node_modules/ajv/dist/vocabularies/applicator/propertyNames.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/propertyNames.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -9895,9 +9895,9 @@ var require_propertyNames = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/vocabularies/applicator/additionalProperties.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/additionalProperties.js
 var require_additionalProperties = __commonJS({
-  "node_modules/ajv/dist/vocabularies/applicator/additionalProperties.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/additionalProperties.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var code_1 = require_code2();
@@ -10001,9 +10001,9 @@ var require_additionalProperties = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/vocabularies/applicator/properties.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/properties.js
 var require_properties = __commonJS({
-  "node_modules/ajv/dist/vocabularies/applicator/properties.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/properties.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var validate_1 = require_validate();
@@ -10059,9 +10059,9 @@ var require_properties = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/vocabularies/applicator/patternProperties.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/patternProperties.js
 var require_patternProperties = __commonJS({
-  "node_modules/ajv/dist/vocabularies/applicator/patternProperties.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/patternProperties.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var code_1 = require_code2();
@@ -10133,9 +10133,9 @@ var require_patternProperties = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/vocabularies/applicator/not.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/not.js
 var require_not = __commonJS({
-  "node_modules/ajv/dist/vocabularies/applicator/not.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/not.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var util_1 = require_util2();
@@ -10164,9 +10164,9 @@ var require_not = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/vocabularies/applicator/anyOf.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/anyOf.js
 var require_anyOf = __commonJS({
-  "node_modules/ajv/dist/vocabularies/applicator/anyOf.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/anyOf.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var code_1 = require_code2();
@@ -10181,9 +10181,9 @@ var require_anyOf = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/vocabularies/applicator/oneOf.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/oneOf.js
 var require_oneOf = __commonJS({
-  "node_modules/ajv/dist/vocabularies/applicator/oneOf.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/oneOf.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -10239,9 +10239,9 @@ var require_oneOf = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/vocabularies/applicator/allOf.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/allOf.js
 var require_allOf = __commonJS({
-  "node_modules/ajv/dist/vocabularies/applicator/allOf.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/allOf.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var util_1 = require_util2();
@@ -10266,9 +10266,9 @@ var require_allOf = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/vocabularies/applicator/if.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/if.js
 var require_if = __commonJS({
-  "node_modules/ajv/dist/vocabularies/applicator/if.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/if.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -10335,9 +10335,9 @@ var require_if = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/vocabularies/applicator/thenElse.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/thenElse.js
 var require_thenElse = __commonJS({
-  "node_modules/ajv/dist/vocabularies/applicator/thenElse.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/thenElse.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var util_1 = require_util2();
@@ -10353,9 +10353,9 @@ var require_thenElse = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/vocabularies/applicator/index.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/index.js
 var require_applicator = __commonJS({
-  "node_modules/ajv/dist/vocabularies/applicator/index.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/applicator/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var additionalItems_1 = require_additionalItems();
@@ -10401,9 +10401,9 @@ var require_applicator = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/vocabularies/format/format.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/format/format.js
 var require_format = __commonJS({
-  "node_modules/ajv/dist/vocabularies/format/format.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/format/format.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -10491,9 +10491,9 @@ var require_format = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/vocabularies/format/index.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/format/index.js
 var require_format2 = __commonJS({
-  "node_modules/ajv/dist/vocabularies/format/index.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/format/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var format_1 = require_format();
@@ -10502,9 +10502,9 @@ var require_format2 = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/vocabularies/metadata.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/metadata.js
 var require_metadata = __commonJS({
-  "node_modules/ajv/dist/vocabularies/metadata.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/metadata.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.contentVocabulary = exports.metadataVocabulary = void 0;
@@ -10525,9 +10525,9 @@ var require_metadata = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/vocabularies/draft7.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/draft7.js
 var require_draft7 = __commonJS({
-  "node_modules/ajv/dist/vocabularies/draft7.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/draft7.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var core_1 = require_core2();
@@ -10547,9 +10547,9 @@ var require_draft7 = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/vocabularies/discriminator/types.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/discriminator/types.js
 var require_types = __commonJS({
-  "node_modules/ajv/dist/vocabularies/discriminator/types.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/discriminator/types.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.DiscrError = void 0;
@@ -10561,9 +10561,9 @@ var require_types = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/vocabularies/discriminator/index.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/discriminator/index.js
 var require_discriminator = __commonJS({
-  "node_modules/ajv/dist/vocabularies/discriminator/index.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/vocabularies/discriminator/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -10666,9 +10666,9 @@ var require_discriminator = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/refs/json-schema-draft-07.json
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/refs/json-schema-draft-07.json
 var require_json_schema_draft_07 = __commonJS({
-  "node_modules/ajv/dist/refs/json-schema-draft-07.json"(exports, module) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/refs/json-schema-draft-07.json"(exports, module) {
     module.exports = {
       $schema: "http://json-schema.org/draft-07/schema#",
       $id: "http://json-schema.org/draft-07/schema#",
@@ -10823,9 +10823,9 @@ var require_json_schema_draft_07 = __commonJS({
   }
 });
 
-// node_modules/ajv/dist/ajv.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/ajv.js
 var require_ajv = __commonJS({
-  "node_modules/ajv/dist/ajv.js"(exports, module) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv/dist/ajv.js"(exports, module) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.MissingRefError = exports.ValidationError = exports.CodeGen = exports.Name = exports.nil = exports.stringify = exports.str = exports._ = exports.KeywordCxt = exports.Ajv = void 0;
@@ -10893,9 +10893,9 @@ var require_ajv = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/dist/formats.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv-formats/dist/formats.js
 var require_formats = __commonJS({
-  "node_modules/ajv-formats/dist/formats.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv-formats/dist/formats.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.formatNames = exports.fastFormats = exports.fullFormats = void 0;
@@ -11096,9 +11096,9 @@ var require_formats = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/dist/limit.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv-formats/dist/limit.js
 var require_limit = __commonJS({
-  "node_modules/ajv-formats/dist/limit.js"(exports) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv-formats/dist/limit.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.formatLimitDefinition = void 0;
@@ -11168,9 +11168,9 @@ var require_limit = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/dist/index.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv-formats/dist/index.js
 var require_dist = __commonJS({
-  "node_modules/ajv-formats/dist/index.js"(exports, module) {
+  "../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/ajv-formats/dist/index.js"(exports, module) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var formats_1 = require_formats();
@@ -11392,7 +11392,7 @@ var ProtectionSignalStatus = Object.freeze({
   UNKNOWN: "unknown"
 });
 
-// node_modules/@simplewebauthn/server/esm/helpers/iso/isoBase64URL.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/iso/isoBase64URL.js
 var isoBase64URL_exports = {};
 __export(isoBase64URL_exports, {
   fromBuffer: () => fromBuffer,
@@ -11405,7 +11405,7 @@ __export(isoBase64URL_exports, {
   trimPadding: () => trimPadding
 });
 
-// node_modules/@hexagon/base64/src/base64.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@hexagon/base64/src/base64.js
 var chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 var charsUrl = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
 var genLookup = (target) => {
@@ -11479,7 +11479,7 @@ base64.validate = (encoded, urlMode) => {
 base64.base64 = base64;
 var base64_default = base64;
 
-// node_modules/@simplewebauthn/server/esm/helpers/iso/isoBase64URL.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/iso/isoBase64URL.js
 function toBuffer(base64urlString, from = "base64url") {
   const _buffer = base64_default.toArrayBuffer(base64urlString, from === "base64url");
   return new Uint8Array(_buffer);
@@ -11510,14 +11510,14 @@ function trimPadding(input) {
   return input.replace(/=/g, "");
 }
 
-// node_modules/@simplewebauthn/server/esm/helpers/iso/isoCBOR.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/iso/isoCBOR.js
 var isoCBOR_exports = {};
 __export(isoCBOR_exports, {
   decodeFirst: () => decodeFirst,
   encode: () => encode
 });
 
-// node_modules/@levischuck/tiny-cbor/esm/cbor/cbor_internal.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@levischuck/tiny-cbor/esm/cbor/cbor_internal.js
 function decodeLength(data, argument, index) {
   if (argument < 24) {
     return [argument, 1];
@@ -11616,7 +11616,7 @@ function encodeLength(major, argument) {
   }
 }
 
-// node_modules/@levischuck/tiny-cbor/esm/cbor/cbor.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@levischuck/tiny-cbor/esm/cbor/cbor.js
 var CBORTag = class {
   /**
    * Wrap a value with a tag number.
@@ -11943,7 +11943,7 @@ function encodeCBOR(data) {
   return output;
 }
 
-// node_modules/@simplewebauthn/server/esm/helpers/iso/isoCBOR.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/iso/isoCBOR.js
 function decodeFirst(input) {
   const _input = new Uint8Array(input);
   const decoded = decodePartialCBOR(_input, 0);
@@ -11954,7 +11954,7 @@ function encode(input) {
   return encodeCBOR(input);
 }
 
-// node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/index.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/index.js
 var isoCrypto_exports = {};
 __export(isoCrypto_exports, {
   digest: () => digest,
@@ -11962,7 +11962,7 @@ __export(isoCrypto_exports, {
   verify: () => verify
 });
 
-// node_modules/@simplewebauthn/server/esm/helpers/cose.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/cose.js
 function isCOSEPublicKeyOKP(cosePublicKey) {
   const kty = cosePublicKey.get(COSEKEYS.kty);
   return isCOSEKty(kty) && kty === COSEKTY.OKP;
@@ -12024,7 +12024,7 @@ function isCOSEAlg(alg) {
   return Object.values(COSEALG).indexOf(alg) >= 0;
 }
 
-// node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/mapCoseAlgToWebCryptoAlg.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/mapCoseAlgToWebCryptoAlg.js
 function mapCoseAlgToWebCryptoAlg(alg) {
   if ([COSEALG.RS1].indexOf(alg) >= 0) {
     return "SHA-1";
@@ -12038,7 +12038,7 @@ function mapCoseAlgToWebCryptoAlg(alg) {
   throw new Error(`Could not map COSE alg value of ${alg} to a WebCrypto alg`);
 }
 
-// node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/getWebCrypto.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/getWebCrypto.js
 var webCrypto = void 0;
 function getWebCrypto() {
   const toResolve = new Promise((resolve, reject) => {
@@ -12069,7 +12069,7 @@ var _getWebCryptoInternals = {
   }
 };
 
-// node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/digest.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/digest.js
 async function digest(data, algorithm) {
   const WebCrypto = await getWebCrypto();
   const subtleAlgorithm = mapCoseAlgToWebCryptoAlg(algorithm);
@@ -12077,14 +12077,14 @@ async function digest(data, algorithm) {
   return new Uint8Array(hashed);
 }
 
-// node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/getRandomValues.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/getRandomValues.js
 async function getRandomValues(array2) {
   const WebCrypto = await getWebCrypto();
   WebCrypto.getRandomValues(array2);
   return array2;
 }
 
-// node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/importKey.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/importKey.js
 async function importKey(opts) {
   const WebCrypto = await getWebCrypto();
   const { keyData, algorithm } = opts;
@@ -12093,7 +12093,7 @@ async function importKey(opts) {
   ]);
 }
 
-// node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/verifyEC2.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/verifyEC2.js
 async function verifyEC2(opts) {
   const { cosePublicKey, signature, data, shaHashOverride } = opts;
   const WebCrypto = await getWebCrypto();
@@ -12155,7 +12155,7 @@ async function verifyEC2(opts) {
   return WebCrypto.subtle.verify(verifyAlgorithm, key, signature, data);
 }
 
-// node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/mapCoseAlgToWebCryptoKeyAlgName.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/mapCoseAlgToWebCryptoKeyAlgName.js
 function mapCoseAlgToWebCryptoKeyAlgName(alg) {
   if ([COSEALG.EdDSA].indexOf(alg) >= 0) {
     return "Ed25519";
@@ -12169,7 +12169,7 @@ function mapCoseAlgToWebCryptoKeyAlgName(alg) {
   throw new Error(`Could not map COSE alg value of ${alg} to a WebCrypto key alg name`);
 }
 
-// node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/verifyRSA.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/verifyRSA.js
 async function verifyRSA(opts) {
   const { cosePublicKey, signature, data, shaHashOverride } = opts;
   const WebCrypto = await getWebCrypto();
@@ -12238,7 +12238,7 @@ async function verifyRSA(opts) {
   return WebCrypto.subtle.verify(verifyAlgorithm, key, signature, data);
 }
 
-// node_modules/@simplewebauthn/server/esm/helpers/convertAAGUIDToString.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/convertAAGUIDToString.js
 function convertAAGUIDToString(aaguid) {
   const hex = isoUint8Array_exports.toHex(aaguid);
   const segments = [
@@ -12256,7 +12256,7 @@ function convertAAGUIDToString(aaguid) {
   return segments.join("-");
 }
 
-// node_modules/@simplewebauthn/server/esm/helpers/convertCertBufferToPEM.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/convertCertBufferToPEM.js
 function convertCertBufferToPEM(certBuffer) {
   let b64cert;
   if (typeof certBuffer === "string") {
@@ -12282,7 +12282,7 @@ ${PEMKey}-----END CERTIFICATE-----
   return PEMKey;
 }
 
-// node_modules/@simplewebauthn/server/esm/helpers/convertCOSEtoPKCS.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/convertCOSEtoPKCS.js
 function convertCOSEtoPKCS(cosePublicKey) {
   const struct = isoCBOR_exports.decodeFirst(cosePublicKey);
   const tag = Uint8Array.from([4]);
@@ -12297,7 +12297,7 @@ function convertCOSEtoPKCS(cosePublicKey) {
   return isoUint8Array_exports.concat([tag, x]);
 }
 
-// node_modules/@simplewebauthn/server/esm/helpers/decodeAttestationObject.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/decodeAttestationObject.js
 function decodeAttestationObject(attestationObject) {
   return _decodeAttestationObjectInternals.stubThis(isoCBOR_exports.decodeFirst(attestationObject));
 }
@@ -12305,7 +12305,7 @@ var _decodeAttestationObjectInternals = {
   stubThis: (value) => value
 };
 
-// node_modules/@simplewebauthn/server/esm/helpers/decodeClientDataJSON.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/decodeClientDataJSON.js
 function decodeClientDataJSON(data) {
   const toString = isoBase64URL_exports.toUTF8String(data);
   const clientData = JSON.parse(toString);
@@ -12315,7 +12315,7 @@ var _decodeClientDataJSONInternals = {
   stubThis: (value) => value
 };
 
-// node_modules/@simplewebauthn/server/esm/helpers/decodeCredentialPublicKey.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/decodeCredentialPublicKey.js
 function decodeCredentialPublicKey(publicKey) {
   return _decodeCredentialPublicKeyInternals.stubThis(isoCBOR_exports.decodeFirst(publicKey));
 }
@@ -12323,7 +12323,7 @@ var _decodeCredentialPublicKeyInternals = {
   stubThis: (value) => value
 };
 
-// node_modules/@simplewebauthn/server/esm/helpers/generateUserID.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/generateUserID.js
 async function generateUserID() {
   const newUserID = new Uint8Array(32);
   await isoCrypto_exports.getRandomValues(newUserID);
@@ -12333,7 +12333,7 @@ var _generateUserIDInternals = {
   stubThis: (value) => value
 };
 
-// node_modules/asn1js/build/index.es.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/asn1js/build/index.es.js
 var index_es_exports = {};
 __export(index_es_exports, {
   Any: () => Any,
@@ -12386,7 +12386,7 @@ __export(index_es_exports, {
 });
 var pvtsutils = __toESM(require_build());
 
-// node_modules/pvutils/build/utils.es.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/pvutils/build/utils.es.js
 function utilFromBase(inputBuffer, inputBase) {
   let result = 0;
   if (inputBuffer.length === 1) {
@@ -12524,7 +12524,7 @@ function padNumber(inputNumber, fullLength) {
 }
 var log2 = Math.log(2);
 
-// node_modules/asn1js/build/index.es.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/asn1js/build/index.es.js
 function assertBigInt() {
   if (typeof BigInt === "undefined") {
     throw new Error("BigInt is not defined. Your environment doesn't implement BigInt.");
@@ -15565,7 +15565,7 @@ function verifySchema(inputBuffer, inputSchema) {
   return compareSchema(asn1.result, asn1.result, inputSchema);
 }
 
-// node_modules/@peculiar/asn1-schema/build/es2015/enums.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-schema/build/es2015/enums.js
 var AsnTypeTypes;
 (function(AsnTypeTypes2) {
   AsnTypeTypes2[AsnTypeTypes2["Sequence"] = 0] = "Sequence";
@@ -15603,7 +15603,7 @@ var AsnPropTypes;
   AsnPropTypes2[AsnPropTypes2["Null"] = 27] = "Null";
 })(AsnPropTypes || (AsnPropTypes = {}));
 
-// node_modules/@peculiar/asn1-schema/build/es2015/types/bit_string.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-schema/build/es2015/types/bit_string.js
 var import_pvtsutils = __toESM(require_build());
 var BitString2 = class {
   constructor(params, unusedBits = 0) {
@@ -15661,7 +15661,7 @@ var BitString2 = class {
   }
 };
 
-// node_modules/@peculiar/asn1-schema/build/es2015/types/octet_string.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-schema/build/es2015/types/octet_string.js
 var import_pvtsutils2 = __toESM(require_build());
 var OctetString2 = class {
   get byteLength() {
@@ -15698,7 +15698,7 @@ var OctetString2 = class {
   }
 };
 
-// node_modules/@peculiar/asn1-schema/build/es2015/converters.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-schema/build/es2015/converters.js
 var AsnAnyConverter = {
   fromASN: (value) => value instanceof Null ? null : value.valueBeforeDecodeView,
   toASN: (value) => {
@@ -15827,7 +15827,7 @@ function defaultConverter(type) {
   }
 }
 
-// node_modules/@peculiar/asn1-schema/build/es2015/helper.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-schema/build/es2015/helper.js
 function isConvertible(target) {
   if (typeof target === "function" && target.prototype) {
     if (target.prototype.toASN && target.prototype.fromASN) {
@@ -15867,7 +15867,7 @@ function isArrayEqual(bytes1, bytes2) {
   return true;
 }
 
-// node_modules/@peculiar/asn1-schema/build/es2015/schema.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-schema/build/es2015/schema.js
 var AsnSchemaStorage = class {
   constructor() {
     this.items = /* @__PURE__ */ new WeakMap();
@@ -15991,10 +15991,10 @@ var AsnSchemaStorage = class {
   }
 };
 
-// node_modules/@peculiar/asn1-schema/build/es2015/storage.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-schema/build/es2015/storage.js
 var schemaStorage = new AsnSchemaStorage();
 
-// node_modules/@peculiar/asn1-schema/build/es2015/decorators.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-schema/build/es2015/decorators.js
 var AsnType = (options) => (target) => {
   let schema;
   if (!schemaStorage.has(target)) {
@@ -16025,7 +16025,7 @@ var AsnProp = (options) => (target, propertyKey) => {
   schema.items[propertyKey] = copyOptions;
 };
 
-// node_modules/@peculiar/asn1-schema/build/es2015/errors/schema_validation.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-schema/build/es2015/errors/schema_validation.js
 var AsnSchemaValidationError = class extends Error {
   constructor() {
     super(...arguments);
@@ -16033,7 +16033,7 @@ var AsnSchemaValidationError = class extends Error {
   }
 };
 
-// node_modules/@peculiar/asn1-schema/build/es2015/parser.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-schema/build/es2015/parser.js
 var AsnParser = class {
   static parse(data, target) {
     const asn1Parsed = fromBER(data);
@@ -16308,7 +16308,7 @@ var AsnParser = class {
   }
 };
 
-// node_modules/@peculiar/asn1-schema/build/es2015/serializer.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-schema/build/es2015/serializer.js
 var AsnSerializer = class _AsnSerializer {
   static serialize(obj) {
     if (obj instanceof BaseBlock) {
@@ -16442,7 +16442,7 @@ var AsnSerializer = class _AsnSerializer {
   }
 };
 
-// node_modules/@peculiar/asn1-schema/build/es2015/objects.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-schema/build/es2015/objects.js
 var AsnArray = class extends Array {
   constructor(items = []) {
     if (typeof items === "number") {
@@ -16456,7 +16456,7 @@ var AsnArray = class extends Array {
   }
 };
 
-// node_modules/@peculiar/asn1-schema/build/es2015/convert.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-schema/build/es2015/convert.js
 var import_pvtsutils3 = __toESM(require_build());
 var AsnConvert = class _AsnConvert {
   static serialize(obj) {
@@ -16475,7 +16475,7 @@ var AsnConvert = class _AsnConvert {
   }
 };
 
-// node_modules/tslib/tslib.es6.mjs
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tslib/tslib.es6.mjs
 function __decorate(decorators, target, key, desc) {
   var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
   if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
@@ -16494,7 +16494,7 @@ function __classPrivateFieldSet(receiver, state, value, kind, f) {
   return kind === "a" ? f.call(receiver, value) : f ? f.value = value : state.set(receiver, value), value;
 }
 
-// node_modules/@peculiar/asn1-x509/build/es2015/ip_converter.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/ip_converter.js
 var import_pvtsutils4 = __toESM(require_build());
 var IpConverter = class {
   static isIPv4(ip) {
@@ -16662,7 +16662,7 @@ var IpConverter = class {
   }
 };
 
-// node_modules/@peculiar/asn1-x509/build/es2015/name.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/name.js
 var import_pvtsutils5 = __toESM(require_build());
 var RelativeDistinguishedName_1;
 var RDNSequence_1;
@@ -16752,7 +16752,7 @@ Name = Name_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence })
 ], Name);
 
-// node_modules/@peculiar/asn1-x509/build/es2015/general_name.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/general_name.js
 var AsnIpConverter = {
   fromASN: (value) => IpConverter.toString(AsnOctetStringConverter.fromASN(value)),
   toASN: (value) => AsnOctetStringConverter.toASN(IpConverter.fromString(value))
@@ -16823,7 +16823,7 @@ GeneralName = __decorate([
   AsnType({ type: AsnTypeTypes.Choice })
 ], GeneralName);
 
-// node_modules/@peculiar/asn1-x509/build/es2015/object_identifiers.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/object_identifiers.js
 var id_pkix = "1.3.6.1.5.5.7";
 var id_pe = `${id_pkix}.1`;
 var id_qt = `${id_pkix}.2`;
@@ -16837,7 +16837,7 @@ var id_ad_timeStamping = `${id_ad}.3`;
 var id_ad_caRepository = `${id_ad}.5`;
 var id_ce = "2.5.29";
 
-// node_modules/@peculiar/asn1-x509/build/es2015/extensions/authority_information_access.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/authority_information_access.js
 var AuthorityInfoAccessSyntax_1;
 var id_pe_authorityInfoAccess = `${id_pe}.1`;
 var AccessDescription = class {
@@ -16863,7 +16863,7 @@ AuthorityInfoAccessSyntax = AuthorityInfoAccessSyntax_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence, itemType: AccessDescription })
 ], AuthorityInfoAccessSyntax);
 
-// node_modules/@peculiar/asn1-x509/build/es2015/extensions/authority_key_identifier.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/authority_key_identifier.js
 var id_ce_authorityKeyIdentifier = `${id_ce}.35`;
 var KeyIdentifier = class extends OctetString2 {
 };
@@ -16890,7 +16890,7 @@ __decorate([
   })
 ], AuthorityKeyIdentifier.prototype, "authorityCertSerialNumber", void 0);
 
-// node_modules/@peculiar/asn1-x509/build/es2015/extensions/basic_constraints.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/basic_constraints.js
 var id_ce_basicConstraints = `${id_ce}.19`;
 var BasicConstraints = class {
   constructor(params = {}) {
@@ -16905,7 +16905,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.Integer, optional: true })
 ], BasicConstraints.prototype, "pathLenConstraint", void 0);
 
-// node_modules/@peculiar/asn1-x509/build/es2015/general_names.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/general_names.js
 var GeneralNames_1;
 var GeneralNames = GeneralNames_1 = class GeneralNames2 extends AsnArray {
   constructor(items) {
@@ -16917,7 +16917,7 @@ GeneralNames = GeneralNames_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence, itemType: GeneralName })
 ], GeneralNames);
 
-// node_modules/@peculiar/asn1-x509/build/es2015/extensions/certificate_issuer.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/certificate_issuer.js
 var CertificateIssuer_1;
 var id_ce_certificateIssuer = `${id_ce}.29`;
 var CertificateIssuer = CertificateIssuer_1 = class CertificateIssuer2 extends GeneralNames {
@@ -16930,7 +16930,7 @@ CertificateIssuer = CertificateIssuer_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence })
 ], CertificateIssuer);
 
-// node_modules/@peculiar/asn1-x509/build/es2015/extensions/certificate_policies.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/certificate_policies.js
 var CertificatePolicies_1;
 var id_ce_certificatePolicies = `${id_ce}.32`;
 var id_ce_certificatePolicies_anyPolicy = `${id_ce_certificatePolicies}.0`;
@@ -17030,7 +17030,7 @@ CertificatePolicies = CertificatePolicies_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence, itemType: PolicyInformation })
 ], CertificatePolicies);
 
-// node_modules/@peculiar/asn1-x509/build/es2015/extensions/crl_number.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/crl_number.js
 var id_ce_cRLNumber = `${id_ce}.20`;
 var CRLNumber = class CRLNumber2 {
   constructor(value = 0) {
@@ -17044,7 +17044,7 @@ CRLNumber = __decorate([
   AsnType({ type: AsnTypeTypes.Choice })
 ], CRLNumber);
 
-// node_modules/@peculiar/asn1-x509/build/es2015/extensions/crl_delta_indicator.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/crl_delta_indicator.js
 var id_ce_deltaCRLIndicator = `${id_ce}.27`;
 var BaseCRLNumber = class BaseCRLNumber2 extends CRLNumber {
 };
@@ -17052,7 +17052,7 @@ BaseCRLNumber = __decorate([
   AsnType({ type: AsnTypeTypes.Choice })
 ], BaseCRLNumber);
 
-// node_modules/@peculiar/asn1-x509/build/es2015/extensions/crl_distribution_points.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/crl_distribution_points.js
 var CRLDistributionPoints_1;
 var id_ce_cRLDistributionPoints = `${id_ce}.31`;
 var ReasonFlags;
@@ -17142,7 +17142,7 @@ CRLDistributionPoints = CRLDistributionPoints_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence, itemType: DistributionPoint })
 ], CRLDistributionPoints);
 
-// node_modules/@peculiar/asn1-x509/build/es2015/extensions/crl_freshest.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/crl_freshest.js
 var FreshestCRL_1;
 var id_ce_freshestCRL = `${id_ce}.46`;
 var FreshestCRL = FreshestCRL_1 = class FreshestCRL2 extends CRLDistributionPoints {
@@ -17155,7 +17155,7 @@ FreshestCRL = FreshestCRL_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence, itemType: DistributionPoint })
 ], FreshestCRL);
 
-// node_modules/@peculiar/asn1-x509/build/es2015/extensions/crl_issuing_distribution_point.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/crl_issuing_distribution_point.js
 var id_ce_issuingDistributionPoint = `${id_ce}.28`;
 var IssuingDistributionPoint = class _IssuingDistributionPoint {
   constructor(params = {}) {
@@ -17206,7 +17206,7 @@ __decorate([
   })
 ], IssuingDistributionPoint.prototype, "onlyContainsAttributeCerts", void 0);
 
-// node_modules/@peculiar/asn1-x509/build/es2015/extensions/crl_reason.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/crl_reason.js
 var id_ce_cRLReasons = `${id_ce}.21`;
 var CRLReasons;
 (function(CRLReasons2) {
@@ -17240,7 +17240,7 @@ CRLReason = __decorate([
   AsnType({ type: AsnTypeTypes.Choice })
 ], CRLReason);
 
-// node_modules/@peculiar/asn1-x509/build/es2015/extensions/extended_key_usage.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/extended_key_usage.js
 var ExtendedKeyUsage_1;
 var id_ce_extKeyUsage = `${id_ce}.37`;
 var ExtendedKeyUsage = ExtendedKeyUsage_1 = class ExtendedKeyUsage2 extends AsnArray {
@@ -17260,7 +17260,7 @@ var id_kp_emailProtection = `${id_kp}.4`;
 var id_kp_timeStamping = `${id_kp}.8`;
 var id_kp_OCSPSigning = `${id_kp}.9`;
 
-// node_modules/@peculiar/asn1-x509/build/es2015/extensions/inhibit_any_policy.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/inhibit_any_policy.js
 var id_ce_inhibitAnyPolicy = `${id_ce}.54`;
 var InhibitAnyPolicy = class InhibitAnyPolicy2 {
   constructor(value = new ArrayBuffer(0)) {
@@ -17274,7 +17274,7 @@ InhibitAnyPolicy = __decorate([
   AsnType({ type: AsnTypeTypes.Choice })
 ], InhibitAnyPolicy);
 
-// node_modules/@peculiar/asn1-x509/build/es2015/extensions/invalidity_date.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/invalidity_date.js
 var id_ce_invalidityDate = `${id_ce}.24`;
 var InvalidityDate = class InvalidityDate2 {
   constructor(value) {
@@ -17291,7 +17291,7 @@ InvalidityDate = __decorate([
   AsnType({ type: AsnTypeTypes.Choice })
 ], InvalidityDate);
 
-// node_modules/@peculiar/asn1-x509/build/es2015/extensions/issuer_alternative_name.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/issuer_alternative_name.js
 var IssueAlternativeName_1;
 var id_ce_issuerAltName = `${id_ce}.18`;
 var IssueAlternativeName = IssueAlternativeName_1 = class IssueAlternativeName2 extends GeneralNames {
@@ -17304,7 +17304,7 @@ IssueAlternativeName = IssueAlternativeName_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence })
 ], IssueAlternativeName);
 
-// node_modules/@peculiar/asn1-x509/build/es2015/extensions/key_usage.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/key_usage.js
 var id_ce_keyUsage = `${id_ce}.15`;
 var KeyUsageFlags;
 (function(KeyUsageFlags3) {
@@ -17356,7 +17356,7 @@ var KeyUsage = class extends BitString2 {
   }
 };
 
-// node_modules/@peculiar/asn1-x509/build/es2015/extensions/name_constraints.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/name_constraints.js
 var GeneralSubtrees_1;
 var id_ce_nameConstraints = `${id_ce}.30`;
 var GeneralSubtree = class {
@@ -17396,7 +17396,7 @@ __decorate([
   AsnProp({ type: GeneralSubtrees, context: 1, optional: true, implicit: true })
 ], NameConstraints.prototype, "excludedSubtrees", void 0);
 
-// node_modules/@peculiar/asn1-x509/build/es2015/extensions/policy_constraints.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/policy_constraints.js
 var id_ce_policyConstraints = `${id_ce}.36`;
 var PolicyConstraints = class {
   constructor(params = {}) {
@@ -17422,7 +17422,7 @@ __decorate([
   })
 ], PolicyConstraints.prototype, "inhibitPolicyMapping", void 0);
 
-// node_modules/@peculiar/asn1-x509/build/es2015/extensions/policy_mappings.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/policy_mappings.js
 var PolicyMappings_1;
 var id_ce_policyMappings = `${id_ce}.33`;
 var PolicyMapping = class {
@@ -17448,7 +17448,7 @@ PolicyMappings = PolicyMappings_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence, itemType: PolicyMapping })
 ], PolicyMappings);
 
-// node_modules/@peculiar/asn1-x509/build/es2015/extensions/subject_alternative_name.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/subject_alternative_name.js
 var SubjectAlternativeName_1;
 var id_ce_subjectAltName = `${id_ce}.17`;
 var SubjectAlternativeName = SubjectAlternativeName_1 = class SubjectAlternativeName2 extends GeneralNames {
@@ -17461,7 +17461,7 @@ SubjectAlternativeName = SubjectAlternativeName_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence })
 ], SubjectAlternativeName);
 
-// node_modules/@peculiar/asn1-x509/build/es2015/attribute.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/attribute.js
 var Attribute = class {
   constructor(params = {}) {
     this.type = "";
@@ -17476,7 +17476,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.Any, repeated: "set" })
 ], Attribute.prototype, "values", void 0);
 
-// node_modules/@peculiar/asn1-x509/build/es2015/extensions/subject_directory_attributes.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/subject_directory_attributes.js
 var SubjectDirectoryAttributes_1;
 var id_ce_subjectDirectoryAttributes = `${id_ce}.9`;
 var SubjectDirectoryAttributes = SubjectDirectoryAttributes_1 = class SubjectDirectoryAttributes2 extends AsnArray {
@@ -17489,12 +17489,12 @@ SubjectDirectoryAttributes = SubjectDirectoryAttributes_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence, itemType: Attribute })
 ], SubjectDirectoryAttributes);
 
-// node_modules/@peculiar/asn1-x509/build/es2015/extensions/subject_key_identifier.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/subject_key_identifier.js
 var id_ce_subjectKeyIdentifier = `${id_ce}.14`;
 var SubjectKeyIdentifier = class extends KeyIdentifier {
 };
 
-// node_modules/@peculiar/asn1-x509/build/es2015/extensions/private_key_usage_period.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/private_key_usage_period.js
 var id_ce_privateKeyUsagePeriod = `${id_ce}.16`;
 var PrivateKeyUsagePeriod = class {
   constructor(params = {}) {
@@ -17508,7 +17508,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.GeneralizedTime, context: 1, implicit: true, optional: true })
 ], PrivateKeyUsagePeriod.prototype, "notAfter", void 0);
 
-// node_modules/@peculiar/asn1-x509/build/es2015/extensions/entrust_version_info.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/entrust_version_info.js
 var EntrustInfoFlags;
 (function(EntrustInfoFlags2) {
   EntrustInfoFlags2[EntrustInfoFlags2["keyUpdateAllowed"] = 1] = "keyUpdateAllowed";
@@ -17548,7 +17548,7 @@ __decorate([
   AsnProp({ type: EntrustInfo })
 ], EntrustVersionInfo.prototype, "entrustInfoFlags", void 0);
 
-// node_modules/@peculiar/asn1-x509/build/es2015/extensions/subject_info_access.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extensions/subject_info_access.js
 var SubjectInfoAccessSyntax_1;
 var id_pe_subjectInfoAccess = `${id_pe}.11`;
 var SubjectInfoAccessSyntax = SubjectInfoAccessSyntax_1 = class SubjectInfoAccessSyntax2 extends AsnArray {
@@ -17561,7 +17561,7 @@ SubjectInfoAccessSyntax = SubjectInfoAccessSyntax_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence, itemType: AccessDescription })
 ], SubjectInfoAccessSyntax);
 
-// node_modules/@peculiar/asn1-x509/build/es2015/algorithm_identifier.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/algorithm_identifier.js
 var pvtsutils2 = __toESM(require_build());
 var AlgorithmIdentifier = class _AlgorithmIdentifier {
   constructor(params = {}) {
@@ -17584,7 +17584,7 @@ __decorate([
   })
 ], AlgorithmIdentifier.prototype, "parameters", void 0);
 
-// node_modules/@peculiar/asn1-x509/build/es2015/subject_public_key_info.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/subject_public_key_info.js
 var SubjectPublicKeyInfo = class {
   constructor(params = {}) {
     this.algorithm = new AlgorithmIdentifier();
@@ -17599,7 +17599,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.BitString })
 ], SubjectPublicKeyInfo.prototype, "subjectPublicKey", void 0);
 
-// node_modules/@peculiar/asn1-x509/build/es2015/time.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/time.js
 var Time = class Time2 {
   constructor(time3) {
     if (time3) {
@@ -17638,7 +17638,7 @@ Time = __decorate([
   AsnType({ type: AsnTypeTypes.Choice })
 ], Time);
 
-// node_modules/@peculiar/asn1-x509/build/es2015/validity.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/validity.js
 var Validity = class {
   constructor(params) {
     this.notBefore = new Time(/* @__PURE__ */ new Date());
@@ -17656,7 +17656,7 @@ __decorate([
   AsnProp({ type: Time })
 ], Validity.prototype, "notAfter", void 0);
 
-// node_modules/@peculiar/asn1-x509/build/es2015/extension.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/extension.js
 var Extensions_1;
 var Extension = class _Extension {
   constructor(params = {}) {
@@ -17689,7 +17689,7 @@ Extensions = Extensions_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence, itemType: Extension })
 ], Extensions);
 
-// node_modules/@peculiar/asn1-x509/build/es2015/types.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/types.js
 var Version;
 (function(Version4) {
   Version4[Version4["v1"] = 0] = "v1";
@@ -17697,7 +17697,7 @@ var Version;
   Version4[Version4["v3"] = 2] = "v3";
 })(Version || (Version = {}));
 
-// node_modules/@peculiar/asn1-x509/build/es2015/tbs_certificate.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/tbs_certificate.js
 var TBSCertificate = class {
   constructor(params = {}) {
     this.version = Version.v1;
@@ -17753,7 +17753,7 @@ __decorate([
   AsnProp({ type: Extensions, context: 3, optional: true })
 ], TBSCertificate.prototype, "extensions", void 0);
 
-// node_modules/@peculiar/asn1-x509/build/es2015/certificate.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/certificate.js
 var Certificate = class {
   constructor(params = {}) {
     this.tbsCertificate = new TBSCertificate();
@@ -17772,7 +17772,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.BitString })
 ], Certificate.prototype, "signatureValue", void 0);
 
-// node_modules/@peculiar/asn1-x509/build/es2015/tbs_cert_list.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/tbs_cert_list.js
 var RevokedCertificate = class {
   constructor(params = {}) {
     this.userCertificate = new ArrayBuffer(0);
@@ -17819,7 +17819,7 @@ __decorate([
   AsnProp({ type: Extension, optional: true, context: 0, repeated: "sequence" })
 ], TBSCertList.prototype, "crlExtensions", void 0);
 
-// node_modules/@peculiar/asn1-x509/build/es2015/certificate_list.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509/build/es2015/certificate_list.js
 var CertificateList = class {
   constructor(params = {}) {
     this.tbsCertList = new TBSCertList();
@@ -17838,7 +17838,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.BitString })
 ], CertificateList.prototype, "signature", void 0);
 
-// node_modules/@simplewebauthn/server/esm/helpers/getCertificateInfo.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/getCertificateInfo.js
 var issuerSubjectIDKey = {
   "2.5.4.6": "C",
   "2.5.4.10": "O",
@@ -17900,11 +17900,11 @@ function issuerSubjectToString(input) {
   return parts.join(" : ");
 }
 
-// node_modules/@peculiar/x509/build/x509.es.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/x509/build/x509.es.js
 var import_reflect_metadata = __toESM(require_Reflect());
 var import_pvtsutils6 = __toESM(require_build());
 
-// node_modules/@peculiar/asn1-cms/build/es2015/issuer_and_serial_number.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/issuer_and_serial_number.js
 var IssuerAndSerialNumber = class {
   constructor(params = {}) {
     this.issuer = new Name();
@@ -17919,7 +17919,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.Integer, converter: AsnIntegerArrayBufferConverter })
 ], IssuerAndSerialNumber.prototype, "serialNumber", void 0);
 
-// node_modules/@peculiar/asn1-cms/build/es2015/signer_identifier.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/signer_identifier.js
 var SignerIdentifier = class SignerIdentifier2 {
   constructor(params = {}) {
     Object.assign(this, params);
@@ -17935,7 +17935,7 @@ SignerIdentifier = __decorate([
   AsnType({ type: AsnTypeTypes.Choice })
 ], SignerIdentifier);
 
-// node_modules/@peculiar/asn1-cms/build/es2015/types.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/types.js
 var CMSVersion;
 (function(CMSVersion2) {
   CMSVersion2[CMSVersion2["v0"] = 0] = "v0";
@@ -17976,7 +17976,7 @@ KeyDerivationAlgorithmIdentifier = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence })
 ], KeyDerivationAlgorithmIdentifier);
 
-// node_modules/@peculiar/asn1-cms/build/es2015/attribute.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/attribute.js
 var Attribute2 = class {
   constructor(params = {}) {
     this.attrType = "";
@@ -17991,7 +17991,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.Any, repeated: "set" })
 ], Attribute2.prototype, "attrValues", void 0);
 
-// node_modules/@peculiar/asn1-cms/build/es2015/signer_info.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/signer_info.js
 var SignerInfos_1;
 var SignerInfo = class {
   constructor(params = {}) {
@@ -18041,21 +18041,21 @@ SignerInfos = SignerInfos_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Set, itemType: SignerInfo })
 ], SignerInfos);
 
-// node_modules/@peculiar/asn1-cms/build/es2015/attributes/counter_signature.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/attributes/counter_signature.js
 var CounterSignature = class CounterSignature2 extends SignerInfo {
 };
 CounterSignature = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence })
 ], CounterSignature);
 
-// node_modules/@peculiar/asn1-cms/build/es2015/attributes/signing_time.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/attributes/signing_time.js
 var SigningTime = class SigningTime2 extends Time {
 };
 SigningTime = __decorate([
   AsnType({ type: AsnTypeTypes.Choice })
 ], SigningTime);
 
-// node_modules/@peculiar/asn1-x509-attr/build/es2015/aa_clear_attrs.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509-attr/build/es2015/aa_clear_attrs.js
 var ACClearAttrs = class {
   constructor(params = {}) {
     this.acIssuer = new GeneralName();
@@ -18074,7 +18074,7 @@ __decorate([
   AsnProp({ type: Attribute, repeated: "sequence" })
 ], ACClearAttrs.prototype, "attrs", void 0);
 
-// node_modules/@peculiar/asn1-x509-attr/build/es2015/attr_spec.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509-attr/build/es2015/attr_spec.js
 var AttrSpec_1;
 var AttrSpec = AttrSpec_1 = class AttrSpec2 extends AsnArray {
   constructor(items) {
@@ -18086,7 +18086,7 @@ AttrSpec = AttrSpec_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence, itemType: AsnPropTypes.ObjectIdentifier })
 ], AttrSpec);
 
-// node_modules/@peculiar/asn1-x509-attr/build/es2015/aa_controls.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509-attr/build/es2015/aa_controls.js
 var AAControls = class {
   constructor(params = {}) {
     this.permitUnSpecified = true;
@@ -18106,7 +18106,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.Boolean, defaultValue: true })
 ], AAControls.prototype, "permitUnSpecified", void 0);
 
-// node_modules/@peculiar/asn1-x509-attr/build/es2015/issuer_serial.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509-attr/build/es2015/issuer_serial.js
 var IssuerSerial = class {
   constructor(params = {}) {
     this.issuer = new GeneralNames();
@@ -18125,7 +18125,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.BitString, optional: true })
 ], IssuerSerial.prototype, "issuerUID", void 0);
 
-// node_modules/@peculiar/asn1-x509-attr/build/es2015/object_digest_info.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509-attr/build/es2015/object_digest_info.js
 var DigestedObjectType;
 (function(DigestedObjectType2) {
   DigestedObjectType2[DigestedObjectType2["publicKey"] = 0] = "publicKey";
@@ -18153,7 +18153,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.BitString })
 ], ObjectDigestInfo.prototype, "objectDigest", void 0);
 
-// node_modules/@peculiar/asn1-x509-attr/build/es2015/v2_form.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509-attr/build/es2015/v2_form.js
 var V2Form = class {
   constructor(params = {}) {
     Object.assign(this, params);
@@ -18169,7 +18169,7 @@ __decorate([
   AsnProp({ type: ObjectDigestInfo, context: 1, implicit: true, optional: true })
 ], V2Form.prototype, "objectDigestInfo", void 0);
 
-// node_modules/@peculiar/asn1-x509-attr/build/es2015/attr_cert_issuer.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509-attr/build/es2015/attr_cert_issuer.js
 var AttCertIssuer = class AttCertIssuer2 {
   constructor(params = {}) {
     Object.assign(this, params);
@@ -18185,7 +18185,7 @@ AttCertIssuer = __decorate([
   AsnType({ type: AsnTypeTypes.Choice })
 ], AttCertIssuer);
 
-// node_modules/@peculiar/asn1-x509-attr/build/es2015/attr_cert_validity_period.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509-attr/build/es2015/attr_cert_validity_period.js
 var AttCertValidityPeriod = class {
   constructor(params = {}) {
     this.notBeforeTime = /* @__PURE__ */ new Date();
@@ -18200,7 +18200,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.GeneralizedTime })
 ], AttCertValidityPeriod.prototype, "notAfterTime", void 0);
 
-// node_modules/@peculiar/asn1-x509-attr/build/es2015/holder.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509-attr/build/es2015/holder.js
 var Holder = class {
   constructor(params = {}) {
     Object.assign(this, params);
@@ -18216,7 +18216,7 @@ __decorate([
   AsnProp({ type: ObjectDigestInfo, implicit: true, context: 2, optional: true })
 ], Holder.prototype, "objectDigestInfo", void 0);
 
-// node_modules/@peculiar/asn1-x509-attr/build/es2015/attribute_certificate_info.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509-attr/build/es2015/attribute_certificate_info.js
 var AttCertVersion;
 (function(AttCertVersion2) {
   AttCertVersion2[AttCertVersion2["v2"] = 1] = "v2";
@@ -18261,7 +18261,7 @@ __decorate([
   AsnProp({ type: Extensions, optional: true })
 ], AttributeCertificateInfo.prototype, "extensions", void 0);
 
-// node_modules/@peculiar/asn1-x509-attr/build/es2015/attribute_certificate.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509-attr/build/es2015/attribute_certificate.js
 var AttributeCertificate = class {
   constructor(params = {}) {
     this.acinfo = new AttributeCertificateInfo();
@@ -18280,7 +18280,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.BitString })
 ], AttributeCertificate.prototype, "signatureValue", void 0);
 
-// node_modules/@peculiar/asn1-x509-attr/build/es2015/class_list.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509-attr/build/es2015/class_list.js
 var ClassListFlags;
 (function(ClassListFlags2) {
   ClassListFlags2[ClassListFlags2["unmarked"] = 1] = "unmarked";
@@ -18293,7 +18293,7 @@ var ClassListFlags;
 var ClassList = class extends BitString2 {
 };
 
-// node_modules/@peculiar/asn1-x509-attr/build/es2015/security_category.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509-attr/build/es2015/security_category.js
 var SecurityCategory = class {
   constructor(params = {}) {
     this.type = "";
@@ -18308,7 +18308,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.Any, implicit: true, context: 1 })
 ], SecurityCategory.prototype, "value", void 0);
 
-// node_modules/@peculiar/asn1-x509-attr/build/es2015/clearance.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509-attr/build/es2015/clearance.js
 var Clearance = class {
   constructor(params = {}) {
     this.policyId = "";
@@ -18326,7 +18326,7 @@ __decorate([
   AsnProp({ type: SecurityCategory, repeated: "set" })
 ], Clearance.prototype, "securityCategories", void 0);
 
-// node_modules/@peculiar/asn1-x509-attr/build/es2015/ietf_attr_syntax.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509-attr/build/es2015/ietf_attr_syntax.js
 var IetfAttrSyntaxValueChoices = class {
   constructor(params = {}) {
     Object.assign(this, params);
@@ -18354,7 +18354,7 @@ __decorate([
   AsnProp({ type: IetfAttrSyntaxValueChoices, repeated: "sequence" })
 ], IetfAttrSyntax.prototype, "values", void 0);
 
-// node_modules/@peculiar/asn1-x509-attr/build/es2015/object_identifiers.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509-attr/build/es2015/object_identifiers.js
 var id_pe_ac_auditIdentity = `${id_pe}.4`;
 var id_pe_aaControls = `${id_pe}.6`;
 var id_pe_ac_proxying = `${id_pe}.10`;
@@ -18368,7 +18368,7 @@ var id_aca_encAttrs = `${id_aca}.6`;
 var id_at = "2.5.4";
 var id_at_role = `${id_at}.72`;
 
-// node_modules/@peculiar/asn1-x509-attr/build/es2015/target.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509-attr/build/es2015/target.js
 var Targets_1;
 var TargetCert = class {
   constructor(params = {}) {
@@ -18412,7 +18412,7 @@ Targets = Targets_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence, itemType: Target })
 ], Targets);
 
-// node_modules/@peculiar/asn1-x509-attr/build/es2015/proxy_info.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509-attr/build/es2015/proxy_info.js
 var ProxyInfo_1;
 var ProxyInfo = ProxyInfo_1 = class ProxyInfo2 extends AsnArray {
   constructor(items) {
@@ -18424,7 +18424,7 @@ ProxyInfo = ProxyInfo_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence, itemType: Targets })
 ], ProxyInfo);
 
-// node_modules/@peculiar/asn1-x509-attr/build/es2015/role_syntax.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509-attr/build/es2015/role_syntax.js
 var RoleSyntax = class {
   constructor(params = {}) {
     Object.assign(this, params);
@@ -18437,7 +18437,7 @@ __decorate([
   AsnProp({ type: GeneralName, implicit: true, context: 1 })
 ], RoleSyntax.prototype, "roleName", void 0);
 
-// node_modules/@peculiar/asn1-x509-attr/build/es2015/svce_auth_info.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-x509-attr/build/es2015/svce_auth_info.js
 var SvceAuthInfo = class {
   constructor(params = {}) {
     this.service = new GeneralName();
@@ -18455,7 +18455,7 @@ __decorate([
   AsnProp({ type: OctetString2, optional: true })
 ], SvceAuthInfo.prototype, "authInfo", void 0);
 
-// node_modules/@peculiar/asn1-cms/build/es2015/certificate_choices.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/certificate_choices.js
 var CertificateSet_1;
 var OtherCertificateFormat = class {
   constructor(params = {}) {
@@ -18497,7 +18497,7 @@ CertificateSet = CertificateSet_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Set, itemType: CertificateChoices })
 ], CertificateSet);
 
-// node_modules/@peculiar/asn1-cms/build/es2015/content_info.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/content_info.js
 var ContentInfo = class {
   constructor(params = {}) {
     this.contentType = "";
@@ -18512,7 +18512,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.Any, context: 0 })
 ], ContentInfo.prototype, "content", void 0);
 
-// node_modules/@peculiar/asn1-cms/build/es2015/encapsulated_content_info.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/encapsulated_content_info.js
 var EncapsulatedContent = class EncapsulatedContent2 {
   constructor(params = {}) {
     Object.assign(this, params);
@@ -18540,7 +18540,7 @@ __decorate([
   AsnProp({ type: EncapsulatedContent, context: 0, optional: true })
 ], EncapsulatedContentInfo.prototype, "eContent", void 0);
 
-// node_modules/@peculiar/asn1-cms/build/es2015/encrypted_content_info.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/encrypted_content_info.js
 var EncryptedContent = class EncryptedContent2 {
   constructor(params = {}) {
     Object.assign(this, params);
@@ -18579,7 +18579,7 @@ __decorate([
   AsnProp({ type: EncryptedContent, optional: true })
 ], EncryptedContentInfo.prototype, "encryptedContent", void 0);
 
-// node_modules/@peculiar/asn1-cms/build/es2015/other_key_attribute.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/other_key_attribute.js
 var OtherKeyAttribute = class {
   constructor(params = {}) {
     this.keyAttrId = "";
@@ -18593,7 +18593,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.Any, optional: true })
 ], OtherKeyAttribute.prototype, "keyAttr", void 0);
 
-// node_modules/@peculiar/asn1-cms/build/es2015/key_agree_recipient_info.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/key_agree_recipient_info.js
 var RecipientEncryptedKeys_1;
 var RecipientKeyIdentifier = class {
   constructor(params = {}) {
@@ -18701,7 +18701,7 @@ __decorate([
   AsnProp({ type: RecipientEncryptedKeys })
 ], KeyAgreeRecipientInfo.prototype, "recipientEncryptedKeys", void 0);
 
-// node_modules/@peculiar/asn1-cms/build/es2015/key_trans_recipient_info.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/key_trans_recipient_info.js
 var RecipientIdentifier = class RecipientIdentifier2 {
   constructor(params = {}) {
     Object.assign(this, params);
@@ -18738,7 +18738,7 @@ __decorate([
   AsnProp({ type: OctetString2 })
 ], KeyTransRecipientInfo.prototype, "encryptedKey", void 0);
 
-// node_modules/@peculiar/asn1-cms/build/es2015/kek_recipient_info.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/kek_recipient_info.js
 var KEKIdentifier = class {
   constructor(params = {}) {
     this.keyIdentifier = new OctetString2();
@@ -18776,7 +18776,7 @@ __decorate([
   AsnProp({ type: OctetString2 })
 ], KEKRecipientInfo.prototype, "encryptedKey", void 0);
 
-// node_modules/@peculiar/asn1-cms/build/es2015/password_recipient_info.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/password_recipient_info.js
 var PasswordRecipientInfo = class {
   constructor(params = {}) {
     this.version = CMSVersion.v0;
@@ -18798,7 +18798,7 @@ __decorate([
   AsnProp({ type: OctetString2 })
 ], PasswordRecipientInfo.prototype, "encryptedKey", void 0);
 
-// node_modules/@peculiar/asn1-cms/build/es2015/recipient_info.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/recipient_info.js
 var OtherRecipientInfo = class {
   constructor(params = {}) {
     this.oriType = "";
@@ -18836,7 +18836,7 @@ RecipientInfo = __decorate([
   AsnType({ type: AsnTypeTypes.Choice })
 ], RecipientInfo);
 
-// node_modules/@peculiar/asn1-cms/build/es2015/recipient_infos.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/recipient_infos.js
 var RecipientInfos_1;
 var RecipientInfos = RecipientInfos_1 = class RecipientInfos2 extends AsnArray {
   constructor(items) {
@@ -18848,7 +18848,7 @@ RecipientInfos = RecipientInfos_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Set, itemType: RecipientInfo })
 ], RecipientInfos);
 
-// node_modules/@peculiar/asn1-cms/build/es2015/revocation_info_choice.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/revocation_info_choice.js
 var RevocationInfoChoices_1;
 var id_ri = `${id_pkix}.16`;
 var id_ri_ocsp_response = `${id_ri}.2`;
@@ -18888,7 +18888,7 @@ RevocationInfoChoices = RevocationInfoChoices_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Set, itemType: RevocationInfoChoice })
 ], RevocationInfoChoices);
 
-// node_modules/@peculiar/asn1-cms/build/es2015/originator_info.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/originator_info.js
 var OriginatorInfo = class {
   constructor(params = {}) {
     Object.assign(this, params);
@@ -18901,7 +18901,7 @@ __decorate([
   AsnProp({ type: RevocationInfoChoices, context: 1, implicit: true, optional: true })
 ], OriginatorInfo.prototype, "crls", void 0);
 
-// node_modules/@peculiar/asn1-cms/build/es2015/enveloped_data.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/enveloped_data.js
 var UnprotectedAttributes_1;
 var UnprotectedAttributes = UnprotectedAttributes_1 = class UnprotectedAttributes2 extends AsnArray {
   constructor(items) {
@@ -18936,10 +18936,10 @@ __decorate([
   AsnProp({ type: UnprotectedAttributes, context: 1, implicit: true, optional: true })
 ], EnvelopedData.prototype, "unprotectedAttrs", void 0);
 
-// node_modules/@peculiar/asn1-cms/build/es2015/object_identifiers.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/object_identifiers.js
 var id_signedData = "1.2.840.113549.1.7.2";
 
-// node_modules/@peculiar/asn1-cms/build/es2015/signed_data.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-cms/build/es2015/signed_data.js
 var DigestAlgorithmIdentifiers_1;
 var DigestAlgorithmIdentifiers = DigestAlgorithmIdentifiers_1 = class DigestAlgorithmIdentifiers2 extends AsnArray {
   constructor(items) {
@@ -18978,7 +18978,7 @@ __decorate([
   AsnProp({ type: SignerInfos })
 ], SignedData.prototype, "signerInfos", void 0);
 
-// node_modules/@peculiar/asn1-ecc/build/es2015/object_identifiers.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-ecc/build/es2015/object_identifiers.js
 var id_ecPublicKey = "1.2.840.10045.2.1";
 var id_ecdsaWithSHA1 = "1.2.840.10045.4.1";
 var id_ecdsaWithSHA224 = "1.2.840.10045.4.3.1";
@@ -18989,7 +18989,7 @@ var id_secp256r1 = "1.2.840.10045.3.1.7";
 var id_secp384r1 = "1.3.132.0.34";
 var id_secp521r1 = "1.3.132.0.35";
 
-// node_modules/@peculiar/asn1-ecc/build/es2015/algorithms.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-ecc/build/es2015/algorithms.js
 function create(algorithm) {
   return new AlgorithmIdentifier({ algorithm });
 }
@@ -18999,7 +18999,7 @@ var ecdsaWithSHA256 = create(id_ecdsaWithSHA256);
 var ecdsaWithSHA384 = create(id_ecdsaWithSHA384);
 var ecdsaWithSHA512 = create(id_ecdsaWithSHA512);
 
-// node_modules/@peculiar/asn1-ecc/build/es2015/rfc3279.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-ecc/build/es2015/rfc3279.js
 var FieldID = class FieldID2 {
   constructor(params = {}) {
     Object.assign(this, params);
@@ -19065,7 +19065,7 @@ SpecifiedECDomain = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence })
 ], SpecifiedECDomain);
 
-// node_modules/@peculiar/asn1-ecc/build/es2015/ec_parameters.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-ecc/build/es2015/ec_parameters.js
 var ECParameters = class ECParameters2 {
   constructor(params = {}) {
     Object.assign(this, params);
@@ -19084,7 +19084,7 @@ ECParameters = __decorate([
   AsnType({ type: AsnTypeTypes.Choice })
 ], ECParameters);
 
-// node_modules/@peculiar/asn1-ecc/build/es2015/ec_private_key.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-ecc/build/es2015/ec_private_key.js
 var ECPrivateKey = class {
   constructor(params = {}) {
     this.version = 1;
@@ -19105,7 +19105,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.BitString, context: 1, optional: true })
 ], ECPrivateKey.prototype, "publicKey", void 0);
 
-// node_modules/@peculiar/asn1-ecc/build/es2015/ec_signature_value.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-ecc/build/es2015/ec_signature_value.js
 var ECDSASigValue = class {
   constructor(params = {}) {
     this.r = new ArrayBuffer(0);
@@ -19120,7 +19120,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.Integer, converter: AsnIntegerArrayBufferConverter })
 ], ECDSASigValue.prototype, "s", void 0);
 
-// node_modules/@peculiar/asn1-rsa/build/es2015/object_identifiers.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-rsa/build/es2015/object_identifiers.js
 var id_pkcs_1 = "1.2.840.113549.1.1";
 var id_rsaEncryption = `${id_pkcs_1}.1`;
 var id_RSAES_OAEP = `${id_pkcs_1}.7`;
@@ -19146,7 +19146,7 @@ var id_md2 = "1.2.840.113549.2.2";
 var id_md5 = "1.2.840.113549.2.5";
 var id_mgf1 = `${id_pkcs_1}.8`;
 
-// node_modules/@peculiar/asn1-rsa/build/es2015/algorithms.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-rsa/build/es2015/algorithms.js
 function create2(algorithm) {
   return new AlgorithmIdentifier({ algorithm, parameters: null });
 }
@@ -19199,7 +19199,7 @@ var sha512WithRSAEncryption = create2(id_sha512WithRSAEncryption);
 var sha512_224WithRSAEncryption = create2(id_sha512_224WithRSAEncryption);
 var sha512_256WithRSAEncryption = create2(id_sha512_256WithRSAEncryption);
 
-// node_modules/@peculiar/asn1-rsa/build/es2015/parameters/rsaes_oaep.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-rsa/build/es2015/parameters/rsaes_oaep.js
 var RsaEsOaepParams = class {
   constructor(params = {}) {
     this.hashAlgorithm = new AlgorithmIdentifier(sha1);
@@ -19225,7 +19225,7 @@ var RSAES_OAEP = new AlgorithmIdentifier({
   parameters: AsnConvert.serialize(new RsaEsOaepParams())
 });
 
-// node_modules/@peculiar/asn1-rsa/build/es2015/parameters/rsassa_pss.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-rsa/build/es2015/parameters/rsassa_pss.js
 var RsaSaPssParams = class {
   constructor(params = {}) {
     this.hashAlgorithm = new AlgorithmIdentifier(sha1);
@@ -19255,7 +19255,7 @@ var RSASSA_PSS = new AlgorithmIdentifier({
   parameters: AsnConvert.serialize(new RsaSaPssParams())
 });
 
-// node_modules/@peculiar/asn1-rsa/build/es2015/parameters/rsassa_pkcs1_v1_5.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-rsa/build/es2015/parameters/rsassa_pkcs1_v1_5.js
 var DigestInfo = class {
   constructor(params = {}) {
     this.digestAlgorithm = new AlgorithmIdentifier();
@@ -19270,7 +19270,7 @@ __decorate([
   AsnProp({ type: OctetString2 })
 ], DigestInfo.prototype, "digest", void 0);
 
-// node_modules/@peculiar/asn1-rsa/build/es2015/other_prime_info.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-rsa/build/es2015/other_prime_info.js
 var OtherPrimeInfos_1;
 var OtherPrimeInfo = class {
   constructor(params = {}) {
@@ -19299,7 +19299,7 @@ OtherPrimeInfos = OtherPrimeInfos_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence, itemType: OtherPrimeInfo })
 ], OtherPrimeInfos);
 
-// node_modules/@peculiar/asn1-rsa/build/es2015/rsa_private_key.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-rsa/build/es2015/rsa_private_key.js
 var RSAPrivateKey = class {
   constructor(params = {}) {
     this.version = 0;
@@ -19345,7 +19345,7 @@ __decorate([
   AsnProp({ type: OtherPrimeInfos, optional: true })
 ], RSAPrivateKey.prototype, "otherPrimeInfos", void 0);
 
-// node_modules/@peculiar/asn1-rsa/build/es2015/rsa_public_key.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-rsa/build/es2015/rsa_public_key.js
 var RSAPublicKey = class {
   constructor(params = {}) {
     this.modulus = new ArrayBuffer(0);
@@ -19360,7 +19360,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.Integer, converter: AsnIntegerArrayBufferConverter })
 ], RSAPublicKey.prototype, "publicExponent", void 0);
 
-// node_modules/tsyringe/dist/esm5/types/lifecycle.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tsyringe/dist/esm5/types/lifecycle.js
 var Lifecycle;
 (function(Lifecycle2) {
   Lifecycle2[Lifecycle2["Transient"] = 0] = "Transient";
@@ -19370,7 +19370,7 @@ var Lifecycle;
 })(Lifecycle || (Lifecycle = {}));
 var lifecycle_default = Lifecycle;
 
-// node_modules/tsyringe/node_modules/tslib/tslib.es6.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tsyringe/node_modules/tslib/tslib.es6.js
 var extendStatics = function(d, b) {
   extendStatics = Object.setPrototypeOf || { __proto__: [] } instanceof Array && function(d2, b2) {
     d2.__proto__ = b2;
@@ -19516,7 +19516,7 @@ function __spread() {
   return ar;
 }
 
-// node_modules/tsyringe/dist/esm5/reflection-helpers.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tsyringe/dist/esm5/reflection-helpers.js
 var INJECTION_TOKEN_METADATA_KEY = "injectionTokens";
 function getParamInfo(target) {
   var params = Reflect.getMetadata("design:paramtypes", target) || [];
@@ -19527,17 +19527,17 @@ function getParamInfo(target) {
   return params;
 }
 
-// node_modules/tsyringe/dist/esm5/providers/class-provider.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tsyringe/dist/esm5/providers/class-provider.js
 function isClassProvider(provider) {
   return !!provider.useClass;
 }
 
-// node_modules/tsyringe/dist/esm5/providers/factory-provider.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tsyringe/dist/esm5/providers/factory-provider.js
 function isFactoryProvider(provider) {
   return !!provider.useFactory;
 }
 
-// node_modules/tsyringe/dist/esm5/lazy-helpers.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tsyringe/dist/esm5/lazy-helpers.js
 var DelayedConstructor = (function() {
   function DelayedConstructor2(wrap) {
     this.wrap = wrap;
@@ -19588,7 +19588,7 @@ var DelayedConstructor = (function() {
   return DelayedConstructor2;
 })();
 
-// node_modules/tsyringe/dist/esm5/providers/injection-token.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tsyringe/dist/esm5/providers/injection-token.js
 function isNormalToken(token) {
   return typeof token === "string" || typeof token === "symbol";
 }
@@ -19602,22 +19602,22 @@ function isConstructorToken(token) {
   return typeof token === "function" || token instanceof DelayedConstructor;
 }
 
-// node_modules/tsyringe/dist/esm5/providers/token-provider.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tsyringe/dist/esm5/providers/token-provider.js
 function isTokenProvider(provider) {
   return !!provider.useToken;
 }
 
-// node_modules/tsyringe/dist/esm5/providers/value-provider.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tsyringe/dist/esm5/providers/value-provider.js
 function isValueProvider(provider) {
   return provider.useValue != void 0;
 }
 
-// node_modules/tsyringe/dist/esm5/providers/provider.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tsyringe/dist/esm5/providers/provider.js
 function isProvider(provider) {
   return isClassProvider(provider) || isValueProvider(provider) || isTokenProvider(provider) || isFactoryProvider(provider);
 }
 
-// node_modules/tsyringe/dist/esm5/registry-base.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tsyringe/dist/esm5/registry-base.js
 var RegistryBase = (function() {
   function RegistryBase2() {
     this._registryMap = /* @__PURE__ */ new Map();
@@ -19657,7 +19657,7 @@ var RegistryBase = (function() {
 })();
 var registry_base_default = RegistryBase;
 
-// node_modules/tsyringe/dist/esm5/registry.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tsyringe/dist/esm5/registry.js
 var Registry = (function(_super) {
   __extends(Registry2, _super);
   function Registry2() {
@@ -19667,7 +19667,7 @@ var Registry = (function(_super) {
 })(registry_base_default);
 var registry_default = Registry;
 
-// node_modules/tsyringe/dist/esm5/resolution-context.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tsyringe/dist/esm5/resolution-context.js
 var ResolutionContext = /* @__PURE__ */ (function() {
   function ResolutionContext2() {
     this.scopedResolutions = /* @__PURE__ */ new Map();
@@ -19676,7 +19676,7 @@ var ResolutionContext = /* @__PURE__ */ (function() {
 })();
 var resolution_context_default = ResolutionContext;
 
-// node_modules/tsyringe/dist/esm5/error-helpers.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tsyringe/dist/esm5/error-helpers.js
 function formatDependency(params, idx) {
   if (params === null) {
     return "at position #" + idx;
@@ -19698,7 +19698,7 @@ function formatErrorCtor(ctor, paramIdx, error2) {
   return composeErrorMessage("Cannot inject the dependency " + dep + ' of "' + ctor.name + '" constructor. Reason:', error2);
 }
 
-// node_modules/tsyringe/dist/esm5/types/disposable.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tsyringe/dist/esm5/types/disposable.js
 function isDisposable(value) {
   if (typeof value.dispose !== "function")
     return false;
@@ -19709,7 +19709,7 @@ function isDisposable(value) {
   return true;
 }
 
-// node_modules/tsyringe/dist/esm5/interceptors.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tsyringe/dist/esm5/interceptors.js
 var PreResolutionInterceptors = (function(_super) {
   __extends(PreResolutionInterceptors2, _super);
   function PreResolutionInterceptors2() {
@@ -19733,7 +19733,7 @@ var Interceptors = /* @__PURE__ */ (function() {
 })();
 var interceptors_default = Interceptors;
 
-// node_modules/tsyringe/dist/esm5/dependency-container.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tsyringe/dist/esm5/dependency-container.js
 var typeInfo = /* @__PURE__ */ new Map();
 var InternalDependencyContainer = (function() {
   function InternalDependencyContainer2(parent) {
@@ -20127,7 +20127,7 @@ var InternalDependencyContainer = (function() {
 })();
 var instance = new InternalDependencyContainer();
 
-// node_modules/tsyringe/dist/esm5/decorators/injectable.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tsyringe/dist/esm5/decorators/injectable.js
 function injectable(options) {
   return function(target) {
     typeInfo.set(target, getParamInfo(target));
@@ -20144,12 +20144,12 @@ function injectable(options) {
 }
 var injectable_default = injectable;
 
-// node_modules/tsyringe/dist/esm5/index.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/tsyringe/dist/esm5/index.js
 if (typeof Reflect === "undefined" || !Reflect.getMetadata) {
   throw new Error(`tsyringe requires a reflect polyfill. Please add 'import "reflect-metadata"' to the top of your entry point.`);
 }
 
-// node_modules/@peculiar/asn1-pfx/build/es2015/attribute.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-pfx/build/es2015/attribute.js
 var PKCS12AttrSet_1;
 var PKCS12Attribute = class {
   constructor(params = {}) {
@@ -20174,7 +20174,7 @@ PKCS12AttrSet = PKCS12AttrSet_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence, itemType: PKCS12Attribute })
 ], PKCS12AttrSet);
 
-// node_modules/@peculiar/asn1-pfx/build/es2015/authenticated_safe.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-pfx/build/es2015/authenticated_safe.js
 var AuthenticatedSafe_1;
 var AuthenticatedSafe = AuthenticatedSafe_1 = class AuthenticatedSafe2 extends AsnArray {
   constructor(items) {
@@ -20186,7 +20186,7 @@ AuthenticatedSafe = AuthenticatedSafe_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence, itemType: ContentInfo })
 ], AuthenticatedSafe);
 
-// node_modules/@peculiar/asn1-pfx/build/es2015/object_identifiers.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-pfx/build/es2015/object_identifiers.js
 var id_rsadsi = "1.2.840.113549";
 var id_pkcs = `${id_rsadsi}.1`;
 var id_pkcs_12 = `${id_pkcs}.12`;
@@ -20199,7 +20199,7 @@ var id_pbeWithSHAAnd128BitRC2_CBC = `${id_pkcs_12PbeIds}.5`;
 var id_pbewithSHAAnd40BitRC2_CBC = `${id_pkcs_12PbeIds}.6`;
 var id_bagtypes = `${id_pkcs_12}.10.1`;
 
-// node_modules/@peculiar/asn1-pfx/build/es2015/bags/types.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-pfx/build/es2015/bags/types.js
 var id_keyBag = `${id_bagtypes}.1`;
 var id_pkcs8ShroudedKeyBag = `${id_bagtypes}.2`;
 var id_certBag = `${id_bagtypes}.3`;
@@ -20208,7 +20208,7 @@ var id_SecretBag = `${id_bagtypes}.5`;
 var id_SafeContents = `${id_bagtypes}.6`;
 var id_pkcs_9 = "1.2.840.113549.1.9";
 
-// node_modules/@peculiar/asn1-pfx/build/es2015/bags/cert_bag.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-pfx/build/es2015/bags/cert_bag.js
 var CertBag = class {
   constructor(params = {}) {
     this.certId = "";
@@ -20226,7 +20226,7 @@ var id_certTypes = `${id_pkcs_9}.22`;
 var id_x509Certificate = `${id_certTypes}.1`;
 var id_sdsiCertificate = `${id_certTypes}.2`;
 
-// node_modules/@peculiar/asn1-pfx/build/es2015/bags/crl_bag.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-pfx/build/es2015/bags/crl_bag.js
 var CRLBag = class {
   constructor(params = {}) {
     this.crlId = "";
@@ -20243,7 +20243,7 @@ __decorate([
 var id_crlTypes = `${id_pkcs_9}.23`;
 var id_x509CRL = `${id_crlTypes}.1`;
 
-// node_modules/@peculiar/asn1-pkcs8/build/es2015/encrypted_private_key_info.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-pkcs8/build/es2015/encrypted_private_key_info.js
 var EncryptedData = class extends OctetString2 {
 };
 var EncryptedPrivateKeyInfo = class {
@@ -20260,7 +20260,7 @@ __decorate([
   AsnProp({ type: EncryptedData })
 ], EncryptedPrivateKeyInfo.prototype, "encryptedData", void 0);
 
-// node_modules/@peculiar/asn1-pkcs8/build/es2015/private_key_info.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-pkcs8/build/es2015/private_key_info.js
 var Attributes_1;
 var Version2;
 (function(Version4) {
@@ -20298,21 +20298,21 @@ __decorate([
   AsnProp({ type: Attributes, implicit: true, context: 0, optional: true })
 ], PrivateKeyInfo.prototype, "attributes", void 0);
 
-// node_modules/@peculiar/asn1-pfx/build/es2015/bags/key_bag.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-pfx/build/es2015/bags/key_bag.js
 var KeyBag = class KeyBag2 extends PrivateKeyInfo {
 };
 KeyBag = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence })
 ], KeyBag);
 
-// node_modules/@peculiar/asn1-pfx/build/es2015/bags/pkcs8_shrouded_key_bag.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-pfx/build/es2015/bags/pkcs8_shrouded_key_bag.js
 var PKCS8ShroudedKeyBag = class PKCS8ShroudedKeyBag2 extends EncryptedPrivateKeyInfo {
 };
 PKCS8ShroudedKeyBag = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence })
 ], PKCS8ShroudedKeyBag);
 
-// node_modules/@peculiar/asn1-pfx/build/es2015/bags/secret_bag.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-pfx/build/es2015/bags/secret_bag.js
 var SecretBag = class {
   constructor(params = {}) {
     this.secretTypeId = "";
@@ -20327,7 +20327,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.Any, context: 0 })
 ], SecretBag.prototype, "secretValue", void 0);
 
-// node_modules/@peculiar/asn1-pfx/build/es2015/mac_data.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-pfx/build/es2015/mac_data.js
 var MacData = class {
   constructor(params = {}) {
     this.mac = new DigestInfo();
@@ -20346,7 +20346,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.Integer, defaultValue: 1 })
 ], MacData.prototype, "iterations", void 0);
 
-// node_modules/@peculiar/asn1-pfx/build/es2015/pfx.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-pfx/build/es2015/pfx.js
 var PFX = class {
   constructor(params = {}) {
     this.version = 3;
@@ -20365,7 +20365,7 @@ __decorate([
   AsnProp({ type: MacData, optional: true })
 ], PFX.prototype, "macData", void 0);
 
-// node_modules/@peculiar/asn1-pfx/build/es2015/safe_bag.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-pfx/build/es2015/safe_bag.js
 var SafeContents_1;
 var SafeBag = class {
   constructor(params = {}) {
@@ -20393,7 +20393,7 @@ SafeContents = SafeContents_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence, itemType: SafeBag })
 ], SafeContents);
 
-// node_modules/@peculiar/asn1-pkcs9/build/es2015/index.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-pkcs9/build/es2015/index.js
 var ExtensionRequest_1;
 var ExtendedCertificateAttributes_1;
 var SMIMECapabilities_1;
@@ -20637,7 +20637,7 @@ SMIMECapabilities = SMIMECapabilities_1 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence, itemType: SMIMECapability })
 ], SMIMECapabilities);
 
-// node_modules/@peculiar/asn1-csr/build/es2015/attributes.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-csr/build/es2015/attributes.js
 var Attributes_12;
 var Attributes3 = Attributes_12 = class Attributes4 extends AsnArray {
   constructor(items) {
@@ -20649,7 +20649,7 @@ Attributes3 = Attributes_12 = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence, itemType: Attribute })
 ], Attributes3);
 
-// node_modules/@peculiar/asn1-csr/build/es2015/certification_request_info.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-csr/build/es2015/certification_request_info.js
 var CertificationRequestInfo = class {
   constructor(params = {}) {
     this.version = 0;
@@ -20672,7 +20672,7 @@ __decorate([
   AsnProp({ type: Attributes3, implicit: true, context: 0, optional: true })
 ], CertificationRequestInfo.prototype, "attributes", void 0);
 
-// node_modules/@peculiar/asn1-csr/build/es2015/certification_request.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-csr/build/es2015/certification_request.js
 var CertificationRequest = class {
   constructor(params = {}) {
     this.certificationRequestInfo = new CertificationRequestInfo();
@@ -20691,7 +20691,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.BitString })
 ], CertificationRequest.prototype, "signature", void 0);
 
-// node_modules/@peculiar/x509/build/x509.es.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/x509/build/x509.es.js
 var diAlgorithm = "crypto.algorithm";
 var AlgorithmProvider = class {
   getAlgorithms() {
@@ -23509,7 +23509,7 @@ AsnEcSignatureFormatter.namedCurveSize.set("K-256", 32);
 AsnEcSignatureFormatter.namedCurveSize.set("P-384", 48);
 AsnEcSignatureFormatter.namedCurveSize.set("P-521", 66);
 
-// node_modules/@simplewebauthn/server/esm/helpers/fetch.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/fetch.js
 function fetch2(url) {
   return _fetchInternals.stubThis(url);
 }
@@ -23517,7 +23517,7 @@ var _fetchInternals = {
   stubThis: (url) => globalThis.fetch(url)
 };
 
-// node_modules/@simplewebauthn/server/esm/helpers/isCertRevoked.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/isCertRevoked.js
 var cacheRevokedCerts = {};
 async function isCertRevoked(cert) {
   const { extensions } = cert;
@@ -23589,7 +23589,7 @@ async function isCertRevoked(cert) {
   return false;
 }
 
-// node_modules/@simplewebauthn/server/esm/helpers/decodeAuthenticatorExtensions.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/decodeAuthenticatorExtensions.js
 function decodeAuthenticatorExtensions(extensionData) {
   let toCBOR;
   try {
@@ -23612,7 +23612,7 @@ function convertMapToObjectDeep(input) {
   return mapped;
 }
 
-// node_modules/@simplewebauthn/server/esm/helpers/parseAuthenticatorData.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/parseAuthenticatorData.js
 function parseAuthenticatorData(authData) {
   if (authData.byteLength < 37) {
     throw new Error(`Authenticator data was ${authData.byteLength} bytes, expected at least 37 bytes`);
@@ -23701,7 +23701,7 @@ var _parseAuthenticatorDataInternals = {
   stubThis: (value) => value
 };
 
-// node_modules/@simplewebauthn/server/esm/helpers/toHash.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/toHash.js
 function toHash(data, algorithm = -7) {
   if (typeof data === "string") {
     data = isoUint8Array_exports.fromUTF8String(data);
@@ -23710,7 +23710,7 @@ function toHash(data, algorithm = -7) {
   return digest2;
 }
 
-// node_modules/@simplewebauthn/server/esm/helpers/validateCertificatePath.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/validateCertificatePath.js
 async function validateCertificatePath(x5cCertsPEM, trustAnchorsPEM = []) {
   if (trustAnchorsPEM.length === 0) {
     return true;
@@ -23817,7 +23817,7 @@ var InvalidSubjectAndIssuer = class extends Error {
   }
 };
 
-// node_modules/@simplewebauthn/server/esm/helpers/mapX509SignatureAlgToCOSEAlg.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/mapX509SignatureAlgToCOSEAlg.js
 function mapX509SignatureAlgToCOSEAlg(signatureAlgorithm) {
   let alg;
   if (signatureAlgorithm === "1.2.840.10045.4.3.2") {
@@ -23840,7 +23840,7 @@ function mapX509SignatureAlgToCOSEAlg(signatureAlgorithm) {
   return alg;
 }
 
-// node_modules/@simplewebauthn/server/esm/helpers/convertX509PublicKeyToCOSE.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/convertX509PublicKeyToCOSE.js
 function convertX509PublicKeyToCOSE(x509Certificate) {
   let cosePublicKey = /* @__PURE__ */ new Map();
   const x509 = AsnParser.parse(x509Certificate, Certificate);
@@ -23894,7 +23894,7 @@ function convertX509PublicKeyToCOSE(x509Certificate) {
   return cosePublicKey;
 }
 
-// node_modules/@simplewebauthn/server/esm/helpers/verifySignature.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/verifySignature.js
 function verifySignature(opts) {
   const { signature, data, credentialPublicKey, x509Certificate, hashAlgorithm } = opts;
   if (!x509Certificate && !credentialPublicKey) {
@@ -23920,7 +23920,7 @@ var _verifySignatureInternals = {
   stubThis: (value) => value
 };
 
-// node_modules/@simplewebauthn/server/esm/metadata/parseJWT.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/metadata/parseJWT.js
 function parseJWT(jwt) {
   const parts = jwt.split(".");
   return [
@@ -23930,7 +23930,7 @@ function parseJWT(jwt) {
   ];
 }
 
-// node_modules/@simplewebauthn/server/esm/metadata/verifyJWT.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/metadata/verifyJWT.js
 function verifyJWT(jwt, leafCert) {
   const [header, payload, signature] = jwt.split(".");
   const certCOSE = convertX509PublicKeyToCOSE(leafCert);
@@ -23954,13 +23954,13 @@ function verifyJWT(jwt, leafCert) {
   throw new Error(`JWT verification with public key of kty ${kty} is not supported by this method`);
 }
 
-// node_modules/@simplewebauthn/server/esm/helpers/convertPEMToBytes.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/convertPEMToBytes.js
 function convertPEMToBytes(pem) {
   const certBase64 = pem.replace("-----BEGIN CERTIFICATE-----", "").replace("-----END CERTIFICATE-----", "").replace(/[\n ]/g, "");
   return isoBase64URL_exports.toBuffer(certBase64, "base64");
 }
 
-// node_modules/@simplewebauthn/server/esm/services/defaultRootCerts/android-safetynet.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/services/defaultRootCerts/android-safetynet.js
 var GlobalSign_Root_CA = `-----BEGIN CERTIFICATE-----
 MIIDdTCCAl2gAwIBAgILBAAAAAABFUtaw5QwDQYJKoZIhvcNAQEFBQAwVzELMAkG
 A1UEBhMCQkUxGTAXBgNVBAoTEEdsb2JhbFNpZ24gbnYtc2ExEDAOBgNVBAsTB1Jv
@@ -23984,7 +23984,7 @@ HMUfpIBvFSDJ3gyICh3WZlXi/EjJKSZp4A==
 -----END CERTIFICATE-----
 `;
 
-// node_modules/@simplewebauthn/server/esm/services/defaultRootCerts/android-key.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/services/defaultRootCerts/android-key.js
 var Google_Hardware_Attestation_Root_1 = `-----BEGIN CERTIFICATE-----
 MIIFYDCCA0igAwIBAgIJAOj6GWMU0voYMA0GCSqGSIb3DQEBCwUAMBsxGTAXBgNV
 BAUTEGY5MjAwOWU4NTNiNmIwNDUwHhcNMTYwNTI2MTYyODUyWhcNMjYwNTI0MTYy
@@ -24113,7 +24113,7 @@ w1IdYIg2Wxg7yHcQZemFQg==
 -----END CERTIFICATE-----
 `;
 
-// node_modules/@simplewebauthn/server/esm/services/defaultRootCerts/apple.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/services/defaultRootCerts/apple.js
 var Apple_WebAuthn_Root_CA = `-----BEGIN CERTIFICATE-----
 MIICEjCCAZmgAwIBAgIQaB0BbHo84wIlpQGUKEdXcTAKBggqhkjOPQQDAzBLMR8w
 HQYDVQQDDBZBcHBsZSBXZWJBdXRobiBSb290IENBMRMwEQYDVQQKDApBcHBsZSBJ
@@ -24130,7 +24130,7 @@ jAGGiQIwHFj+dJZYUJR786osByBelJYsVZd2GbHQu209b5RCmGQ21gpSAk9QZW4B
 -----END CERTIFICATE-----
 `;
 
-// node_modules/@simplewebauthn/server/esm/services/defaultRootCerts/mds.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/services/defaultRootCerts/mds.js
 var GlobalSign_Root_CA_R3 = `-----BEGIN CERTIFICATE-----
 MIIDXzCCAkegAwIBAgILBAAAAAABIVhTCKIwDQYJKoZIhvcNAQELBQAwTDEgMB4G
 A1UECxMXR2xvYmFsU2lnbiBSb290IENBIC0gUjMxEzARBgNVBAoTCkdsb2JhbFNp
@@ -24154,7 +24154,7 @@ WD9f
 -----END CERTIFICATE-----
  `;
 
-// node_modules/@simplewebauthn/server/esm/services/settingsService.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/services/settingsService.js
 var BaseSettingsService = class {
   constructor() {
     Object.defineProperty(this, "pemCertificates", {
@@ -24205,7 +24205,7 @@ SettingsService.setRootCertificates({
   certificates: [GlobalSign_Root_CA_R3]
 });
 
-// node_modules/@simplewebauthn/server/esm/metadata/verifyMDSBlob.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/metadata/verifyMDSBlob.js
 async function verifyMDSBlob(blob) {
   const parsedJWT = parseJWT(blob);
   const header = parsedJWT[0];
@@ -24245,7 +24245,7 @@ async function verifyMDSBlob(blob) {
   };
 }
 
-// node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/verifyOKP.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/verifyOKP.js
 async function verifyOKP(opts) {
   const { cosePublicKey, signature, data } = opts;
   const WebCrypto = await getWebCrypto();
@@ -24291,7 +24291,7 @@ async function verifyOKP(opts) {
   return WebCrypto.subtle.verify(verifyAlgorithm, key, signature, data);
 }
 
-// node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/unwrapEC2Signature.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/unwrapEC2Signature.js
 function unwrapEC2Signature(signature, crv) {
   const parsedSignature = AsnParser.parse(signature, ECDSASigValue);
   const rBytes = new Uint8Array(parsedSignature.r);
@@ -24332,7 +24332,7 @@ function toNormalizedBytes(bytes, componentLength) {
   return normalizedBytes;
 }
 
-// node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/verify.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/iso/isoCrypto/verify.js
 function verify(opts) {
   const { cosePublicKey, signature, data, shaHashOverride } = opts;
   if (isCOSEPublicKeyEC2(cosePublicKey)) {
@@ -24356,7 +24356,7 @@ function verify(opts) {
   throw new Error(`Signature verification with public key of kty ${kty} is not supported by this method`);
 }
 
-// node_modules/@simplewebauthn/server/esm/helpers/iso/isoUint8Array.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/iso/isoUint8Array.js
 var isoUint8Array_exports = {};
 __export(isoUint8Array_exports, {
   areEqual: () => areEqual,
@@ -24414,7 +24414,7 @@ function toDataView(array2) {
   return new DataView(array2.buffer, array2.byteOffset, array2.length);
 }
 
-// node_modules/@simplewebauthn/server/esm/helpers/generateChallenge.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/generateChallenge.js
 async function generateChallenge() {
   const challenge = new Uint8Array(32);
   await isoCrypto_exports.getRandomValues(challenge);
@@ -24424,7 +24424,7 @@ var _generateChallengeInternals = {
   stubThis: (value) => value
 };
 
-// node_modules/@simplewebauthn/server/esm/registration/generateRegistrationOptions.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/registration/generateRegistrationOptions.js
 var supportedCOSEAlgorithmIdentifiers = [
   // EdDSA (In first position to encourage authenticators to use this over ES256)
   -8,
@@ -24523,7 +24523,7 @@ async function generateRegistrationOptions(options) {
   };
 }
 
-// node_modules/@simplewebauthn/server/esm/helpers/parseBackupFlags.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/parseBackupFlags.js
 function parseBackupFlags({ be, bs }) {
   const credentialBackedUp = bs;
   let credentialDeviceType = "singleDevice";
@@ -24542,7 +24542,7 @@ var InvalidBackupFlags = class extends Error {
   }
 };
 
-// node_modules/@simplewebauthn/server/esm/helpers/matchExpectedRPID.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/matchExpectedRPID.js
 async function matchExpectedRPID(rpIDHash, expectedRPIDs) {
   try {
     const matchedRPID = await Promise.any(expectedRPIDs.map((expected) => {
@@ -24573,7 +24573,7 @@ var UnexpectedRPIDHash = class extends Error {
   }
 };
 
-// node_modules/@simplewebauthn/server/esm/registration/verifications/verifyAttestationFIDOU2F.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/registration/verifications/verifyAttestationFIDOU2F.js
 async function verifyAttestationFIDOU2F(options) {
   const { attStmt, clientDataHash, rpIdHash, credentialID, credentialPublicKey, aaguid, rootCertificates } = options;
   const reservedByte = Uint8Array.from([0]);
@@ -24611,7 +24611,7 @@ async function verifyAttestationFIDOU2F(options) {
   });
 }
 
-// node_modules/@simplewebauthn/server/esm/helpers/validateExtFIDOGenCEAAGUID.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/validateExtFIDOGenCEAAGUID.js
 var id_fido_gen_ce_aaguid = "1.3.6.1.4.1.45724.1.1.4";
 function validateExtFIDOGenCEAAGUID(certExtensions, aaguid) {
   if (!certExtensions) {
@@ -24632,13 +24632,13 @@ function validateExtFIDOGenCEAAGUID(certExtensions, aaguid) {
   return true;
 }
 
-// node_modules/@simplewebauthn/server/esm/helpers/logging.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/helpers/logging.js
 function getLogger(_name) {
   return (_message, ..._rest) => {
   };
 }
 
-// node_modules/@simplewebauthn/server/esm/services/metadataService.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/services/metadataService.js
 var NonRefreshingMDS = {
   url: "",
   no: 0,
@@ -24845,7 +24845,7 @@ var BaseMetadataService = class {
 };
 var MetadataService = new BaseMetadataService();
 
-// node_modules/@simplewebauthn/server/esm/metadata/verifyAttestationWithMetadata.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/metadata/verifyAttestationWithMetadata.js
 async function verifyAttestationWithMetadata({ statement, credentialPublicKey, x5c, attestationStatementAlg }) {
   const { authenticationAlgorithms, authenticatorGetInfo, attestationRootCertificates } = statement;
   const keypairCOSEAlgs = /* @__PURE__ */ new Set();
@@ -24941,7 +24941,7 @@ function stringifyCOSEInfo(info) {
   return toReturn;
 }
 
-// node_modules/@simplewebauthn/server/esm/registration/verifications/verifyAttestationPacked.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/registration/verifications/verifyAttestationPacked.js
 async function verifyAttestationPacked(options) {
   const { attStmt, clientDataHash, authData, credentialPublicKey, aaguid, rootCertificates } = options;
   const sig = attStmt.get("sig");
@@ -25033,7 +25033,7 @@ async function verifyAttestationPacked(options) {
   return verified;
 }
 
-// node_modules/@simplewebauthn/server/esm/registration/verifications/verifyAttestationAndroidSafetyNet.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/registration/verifications/verifyAttestationAndroidSafetyNet.js
 async function verifyAttestationAndroidSafetyNet(options) {
   const { attStmt, clientDataHash, authData, aaguid, rootCertificates, verifyTimestampMS = true, credentialPublicKey, attestationSafetyNetEnforceCTSCheck } = options;
   const alg = attStmt.get("alg");
@@ -25108,7 +25108,7 @@ async function verifyAttestationAndroidSafetyNet(options) {
   return verified;
 }
 
-// node_modules/@simplewebauthn/server/esm/registration/verifications/tpm/constants.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/registration/verifications/tpm/constants.js
 var TPM_ST = {
   196: "TPM_ST_RSP_COMMAND",
   32768: "TPM_ST_NULL",
@@ -25226,7 +25226,7 @@ var TPM_ECC_CURVE_COSE_CRV_MAP = {
   // p256
 };
 
-// node_modules/@simplewebauthn/server/esm/registration/verifications/tpm/parseCertInfo.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/registration/verifications/tpm/parseCertInfo.js
 function parseCertInfo(certInfo) {
   let pointer = 0;
   const dataView = isoUint8Array_exports.toDataView(certInfo);
@@ -25273,7 +25273,7 @@ function parseCertInfo(certInfo) {
   };
 }
 
-// node_modules/@simplewebauthn/server/esm/registration/verifications/tpm/parsePubArea.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/registration/verifications/tpm/parsePubArea.js
 function parsePubArea(pubArea) {
   let pointer = 0;
   const dataView = isoUint8Array_exports.toDataView(pubArea);
@@ -25344,7 +25344,7 @@ function parsePubArea(pubArea) {
   };
 }
 
-// node_modules/@simplewebauthn/server/esm/registration/verifications/tpm/verifyAttestationTPM.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/registration/verifications/tpm/verifyAttestationTPM.js
 async function verifyAttestationTPM(options) {
   const { aaguid, attStmt, authData, credentialPublicKey, clientDataHash, rootCertificates } = options;
   const ver = attStmt.get("ver");
@@ -25575,7 +25575,7 @@ function attestedNameAlgToCOSEAlg(alg) {
   throw new Error(`Unexpected TPM attested name alg ${alg}`);
 }
 
-// node_modules/@peculiar/asn1-android/build/es2015/key_description.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-android/build/es2015/key_description.js
 var IntegerSet_1;
 var id_ce_keyDescription = "1.3.6.1.4.1.11129.2.1.17";
 var VerifiedBootState;
@@ -25864,7 +25864,7 @@ __decorate([
   AsnProp({ type: AuthorizationList })
 ], KeyMintKeyDescription.prototype, "hardwareEnforced", void 0);
 
-// node_modules/@peculiar/asn1-android/build/es2015/nonstandard.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-android/build/es2015/nonstandard.js
 var NonStandardAuthorizationList_1;
 var NonStandardAuthorization = class NonStandardAuthorization2 extends AuthorizationList {
 };
@@ -25960,7 +25960,7 @@ NonStandardKeyMintKeyDescription = __decorate([
   AsnType({ type: AsnTypeTypes.Sequence })
 ], NonStandardKeyMintKeyDescription);
 
-// node_modules/@peculiar/asn1-android/build/es2015/attestation.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@peculiar/asn1-android/build/es2015/attestation.js
 var AttestationPackageInfo = class {
   constructor(params = {}) {
     Object.assign(this, params);
@@ -25984,7 +25984,7 @@ __decorate([
   AsnProp({ type: AsnPropTypes.OctetString, repeated: "set" })
 ], AttestationApplicationId.prototype, "signatureDigests", void 0);
 
-// node_modules/@simplewebauthn/server/esm/registration/verifications/verifyAttestationAndroidKey.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/registration/verifications/verifyAttestationAndroidKey.js
 async function verifyAttestationAndroidKey(options) {
   const { authData, clientDataHash, attStmt, credentialPublicKey, aaguid, rootCertificates } = options;
   const x5c = attStmt.get("x5c");
@@ -26058,7 +26058,7 @@ async function verifyAttestationAndroidKey(options) {
   });
 }
 
-// node_modules/@simplewebauthn/server/esm/registration/verifications/verifyAttestationApple.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/registration/verifications/verifyAttestationApple.js
 async function verifyAttestationApple(options) {
   const { attStmt, authData, clientDataHash, credentialPublicKey, rootCertificates } = options;
   const x5c = attStmt.get("x5c");
@@ -26094,7 +26094,7 @@ async function verifyAttestationApple(options) {
   return true;
 }
 
-// node_modules/@simplewebauthn/server/esm/registration/verifyRegistrationResponse.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/registration/verifyRegistrationResponse.js
 async function verifyRegistrationResponse(options) {
   const { response, expectedChallenge, expectedOrigin, expectedRPID, expectedType, requireUserPresence = true, requireUserVerification = true, supportedAlgorithmIDs = supportedCOSEAlgorithmIdentifiers, attestationSafetyNetEnforceCTSCheck = true } = options;
   const { id, rawId, type: credentialType, response: attestationResponse } = response;
@@ -26249,7 +26249,7 @@ async function verifyRegistrationResponse(options) {
   };
 }
 
-// node_modules/@simplewebauthn/server/esm/authentication/generateAuthenticationOptions.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/authentication/generateAuthenticationOptions.js
 async function generateAuthenticationOptions(options) {
   const { allowCredentials, challenge = await generateChallenge(), timeout = 6e4, userVerification = "preferred", extensions, rpID } = options;
   let _challenge = challenge;
@@ -26275,7 +26275,7 @@ async function generateAuthenticationOptions(options) {
   };
 }
 
-// node_modules/@simplewebauthn/server/esm/authentication/verifyAuthenticationResponse.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@simplewebauthn/server/esm/authentication/verifyAuthenticationResponse.js
 async function verifyAuthenticationResponse(options) {
   const { response, expectedChallenge, expectedOrigin, expectedRPID, expectedType, credential, requireUserVerification = true, advancedFIDOConfig } = options;
   const { id, rawId, type: credentialType, response: assertionResponse } = response;
@@ -41996,7 +41996,7 @@ function errorMessage(error2) {
   return normalizeText31(error2) || "unknown error";
 }
 
-// node_modules/zod/v3/helpers/util.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v3/helpers/util.js
 var util;
 (function(util2) {
   util2.assertEqual = (_) => {
@@ -42130,7 +42130,7 @@ var getParsedType = (data) => {
   }
 };
 
-// node_modules/zod/v3/ZodError.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v3/ZodError.js
 var ZodIssueCode = util.arrayToEnum([
   "invalid_type",
   "invalid_literal",
@@ -42244,7 +42244,7 @@ ZodError.create = (issues) => {
   return error2;
 };
 
-// node_modules/zod/v3/locales/en.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v3/locales/en.js
 var errorMap = (issue2, _ctx) => {
   let message;
   switch (issue2.code) {
@@ -42347,13 +42347,13 @@ var errorMap = (issue2, _ctx) => {
 };
 var en_default = errorMap;
 
-// node_modules/zod/v3/errors.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v3/errors.js
 var overrideErrorMap = en_default;
 function getErrorMap() {
   return overrideErrorMap;
 }
 
-// node_modules/zod/v3/helpers/parseUtil.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v3/helpers/parseUtil.js
 var makeIssue = (params) => {
   const { data, path, errorMaps, issueData } = params;
   const fullPath = [...path, ...issueData.path || []];
@@ -42462,14 +42462,14 @@ var isDirty = (x) => x.status === "dirty";
 var isValid = (x) => x.status === "valid";
 var isAsync = (x) => typeof Promise !== "undefined" && x instanceof Promise;
 
-// node_modules/zod/v3/helpers/errorUtil.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v3/helpers/errorUtil.js
 var errorUtil;
 (function(errorUtil2) {
   errorUtil2.errToObj = (message) => typeof message === "string" ? { message } : message || {};
   errorUtil2.toString = (message) => typeof message === "string" ? message : message?.message;
 })(errorUtil || (errorUtil = {}));
 
-// node_modules/zod/v3/types.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v3/types.js
 var ParseInputLazyPath = class {
   constructor(parent, value, path, key) {
     this._cachedPath = [];
@@ -45873,7 +45873,7 @@ var nullableType = ZodNullable.create;
 var preprocessType = ZodEffects.createWithPreprocess;
 var pipelineType = ZodPipeline.create;
 
-// node_modules/zod/v4/core/core.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v4/core/core.js
 var _a3;
 // @__NO_SIDE_EFFECTS__
 function $constructor(name, initializer3, params) {
@@ -45947,7 +45947,7 @@ function config(newConfig) {
   return globalConfig;
 }
 
-// node_modules/zod/v4/core/util.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v4/core/util.js
 var util_exports = {};
 __export(util_exports, {
   BIGINT_FORMAT_RANGES: () => BIGINT_FORMAT_RANGES,
@@ -46643,7 +46643,7 @@ var Class = class {
   }
 };
 
-// node_modules/zod/v4/core/errors.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v4/core/errors.js
 var initializer = (inst, def) => {
   inst.name = "$ZodError";
   Object.defineProperty(inst, "_zod", {
@@ -46712,7 +46712,7 @@ function formatError(error2, mapper = (issue2) => issue2.message) {
   return fieldErrors;
 }
 
-// node_modules/zod/v4/core/parse.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v4/core/parse.js
 var _parse = (_Err) => (schema, value, _ctx, _params) => {
   const ctx = _ctx ? { ..._ctx, async: false } : { async: false };
   const result = schema._zod.run({ value, issues: [] }, ctx);
@@ -46792,7 +46792,7 @@ var _safeDecodeAsync = (_Err) => async (schema, value, _ctx) => {
   return _safeParseAsync(_Err)(schema, value, _ctx);
 };
 
-// node_modules/zod/v4/core/regexes.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v4/core/regexes.js
 var cuid = /^[cC][0-9a-z]{6,}$/;
 var cuid2 = /^[0-9a-z]+$/;
 var ulid = /^[0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{26}$/;
@@ -46850,7 +46850,7 @@ var _null = /^null$/i;
 var lowercase = /^[^A-Z]*$/;
 var uppercase = /^[^a-z]*$/;
 
-// node_modules/zod/v4/core/checks.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v4/core/checks.js
 var $ZodCheck = /* @__PURE__ */ $constructor("$ZodCheck", (inst, def) => {
   var _a5;
   inst._zod ?? (inst._zod = {});
@@ -47240,7 +47240,7 @@ var $ZodCheckOverwrite = /* @__PURE__ */ $constructor("$ZodCheckOverwrite", (ins
   };
 });
 
-// node_modules/zod/v4/core/doc.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v4/core/doc.js
 var Doc = class {
   constructor(args = []) {
     this.content = [];
@@ -47276,14 +47276,14 @@ var Doc = class {
   }
 };
 
-// node_modules/zod/v4/core/versions.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v4/core/versions.js
 var version = {
   major: 4,
   minor: 4,
   patch: 3
 };
 
-// node_modules/zod/v4/core/schemas.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v4/core/schemas.js
 var $ZodType = /* @__PURE__ */ $constructor("$ZodType", (inst, def) => {
   var _a5;
   inst ?? (inst = {});
@@ -48763,7 +48763,7 @@ function handleRefineResult(result, payload, input, inst) {
   }
 }
 
-// node_modules/zod/v4/locales/en.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v4/locales/en.js
 var error = () => {
   const Sizable = {
     string: { unit: "characters", verb: "to have" },
@@ -48876,7 +48876,7 @@ function en_default2() {
   };
 }
 
-// node_modules/zod/v4/core/registries.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v4/core/registries.js
 var _a4;
 var $output = Symbol("ZodOutput");
 var $input = Symbol("ZodInput");
@@ -48926,7 +48926,7 @@ function registry() {
 (_a4 = globalThis).__zod_globalRegistry ?? (_a4.__zod_globalRegistry = registry());
 var globalRegistry = globalThis.__zod_globalRegistry;
 
-// node_modules/zod/v4/core/api.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v4/core/api.js
 // @__NO_SIDE_EFFECTS__
 function _string(Class2, params) {
   return new Class2({
@@ -49454,7 +49454,7 @@ function _check(fn, params) {
   return ch;
 }
 
-// node_modules/zod/v4/core/to-json-schema.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v4/core/to-json-schema.js
 function initializeContext(params) {
   let target = params?.target ?? "draft-2020-12";
   if (target === "draft-4")
@@ -49813,7 +49813,7 @@ var createStandardJSONSchemaMethod = (schema, io, processors = {}) => (params) =
   return finalize(ctx, schema);
 };
 
-// node_modules/zod/v4/core/json-schema-processors.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v4/core/json-schema-processors.js
 var formatMap = {
   guid: "uuid",
   url: "uri",
@@ -50357,7 +50357,7 @@ function toJSONSchema(input, params) {
   return finalize(ctx, input);
 }
 
-// node_modules/zod/v4/mini/schemas.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v4/mini/schemas.js
 var ZodMiniType = /* @__PURE__ */ $constructor("ZodMiniType", (inst, def) => {
   if (!inst._zod)
     throw new Error("Uninitialized schema in ZodMiniType.");
@@ -50403,7 +50403,7 @@ function object(shape, params) {
   return new ZodMiniObject(def);
 }
 
-// node_modules/@modelcontextprotocol/sdk/dist/esm/server/zod-compat.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@modelcontextprotocol/sdk/dist/esm/server/zod-compat.js
 function isZ4Schema(s) {
   const schema = s;
   return !!schema._zod;
@@ -50547,7 +50547,7 @@ function getLiteralValue(schema) {
   return void 0;
 }
 
-// node_modules/zod/v4/classic/iso.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v4/classic/iso.js
 var iso_exports2 = {};
 __export(iso_exports2, {
   ZodISODate: () => ZodISODate,
@@ -50588,7 +50588,7 @@ function duration2(params) {
   return _isoDuration(ZodISODuration, params);
 }
 
-// node_modules/zod/v4/classic/errors.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v4/classic/errors.js
 var initializer2 = (inst, issues) => {
   $ZodError.init(inst, issues);
   inst.name = "ZodError";
@@ -50627,7 +50627,7 @@ var ZodRealError = /* @__PURE__ */ $constructor("ZodError", initializer2, {
   Parent: Error
 });
 
-// node_modules/zod/v4/classic/parse.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v4/classic/parse.js
 var parse2 = /* @__PURE__ */ _parse(ZodRealError);
 var parseAsync2 = /* @__PURE__ */ _parseAsync(ZodRealError);
 var safeParse4 = /* @__PURE__ */ _safeParse(ZodRealError);
@@ -50641,7 +50641,7 @@ var safeDecode2 = /* @__PURE__ */ _safeDecode(ZodRealError);
 var safeEncodeAsync2 = /* @__PURE__ */ _safeEncodeAsync(ZodRealError);
 var safeDecodeAsync2 = /* @__PURE__ */ _safeDecodeAsync(ZodRealError);
 
-// node_modules/zod/v4/classic/schemas.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v4/classic/schemas.js
 var _installedGroups = /* @__PURE__ */ new WeakMap();
 function _installLazyMethods(inst, group, methods) {
   const proto = Object.getPrototypeOf(inst);
@@ -51483,10 +51483,10 @@ function preprocess(fn, schema) {
   });
 }
 
-// node_modules/zod/v4/classic/external.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod/v4/classic/external.js
 config(en_default2());
 
-// node_modules/@modelcontextprotocol/sdk/dist/esm/types.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@modelcontextprotocol/sdk/dist/esm/types.js
 var LATEST_PROTOCOL_VERSION = "2025-11-25";
 var DEFAULT_NEGOTIATED_PROTOCOL_VERSION = "2025-03-26";
 var SUPPORTED_PROTOCOL_VERSIONS = [LATEST_PROTOCOL_VERSION, "2025-06-18", "2025-03-26", "2024-11-05", "2024-10-07"];
@@ -53019,12 +53019,12 @@ var UrlElicitationRequiredError = class extends McpError {
   }
 };
 
-// node_modules/@modelcontextprotocol/sdk/dist/esm/experimental/tasks/interfaces.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@modelcontextprotocol/sdk/dist/esm/experimental/tasks/interfaces.js
 function isTerminal(status) {
   return status === "completed" || status === "failed" || status === "cancelled";
 }
 
-// node_modules/zod-to-json-schema/dist/esm/Options.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/Options.js
 var ignoreOverride = Symbol("Let zodToJsonSchema decide on which parser to use");
 var defaultOptions = {
   name: void 0,
@@ -53058,7 +53058,7 @@ var getDefaultOptions = (options) => typeof options === "string" ? {
   ...options
 };
 
-// node_modules/zod-to-json-schema/dist/esm/Refs.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/Refs.js
 var getRefs = (options) => {
   const _options = getDefaultOptions(options);
   const currentPath = _options.name !== void 0 ? [..._options.basePath, _options.definitionPath, _options.name] : _options.basePath;
@@ -53079,7 +53079,7 @@ var getRefs = (options) => {
   };
 };
 
-// node_modules/zod-to-json-schema/dist/esm/errorMessages.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/errorMessages.js
 function addErrorMessage(res, key, errorMessage2, refs) {
   if (!refs?.errorMessages)
     return;
@@ -53095,7 +53095,7 @@ function setResponseValueAndErrors(res, key, value, errorMessage2, refs) {
   addErrorMessage(res, key, errorMessage2, refs);
 }
 
-// node_modules/zod-to-json-schema/dist/esm/getRelativePath.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/getRelativePath.js
 var getRelativePath = (pathA, pathB) => {
   let i = 0;
   for (; i < pathA.length && i < pathB.length; i++) {
@@ -53105,7 +53105,7 @@ var getRelativePath = (pathA, pathB) => {
   return [(pathA.length - i).toString(), ...pathB.slice(i)].join("/");
 };
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/any.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/any.js
 function parseAnyDef(refs) {
   if (refs.target !== "openAi") {
     return {};
@@ -53121,7 +53121,7 @@ function parseAnyDef(refs) {
   };
 }
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/array.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/array.js
 function parseArrayDef(def, refs) {
   const res = {
     type: "array"
@@ -53145,7 +53145,7 @@ function parseArrayDef(def, refs) {
   return res;
 }
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/bigint.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/bigint.js
 function parseBigintDef(def, refs) {
   const res = {
     type: "integer",
@@ -53191,24 +53191,24 @@ function parseBigintDef(def, refs) {
   return res;
 }
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/boolean.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/boolean.js
 function parseBooleanDef() {
   return {
     type: "boolean"
   };
 }
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/branded.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/branded.js
 function parseBrandedDef(_def, refs) {
   return parseDef(_def.type._def, refs);
 }
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/catch.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/catch.js
 var parseCatchDef = (def, refs) => {
   return parseDef(def.innerType._def, refs);
 };
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/date.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/date.js
 function parseDateDef(def, refs, overrideDateStrategy) {
   const strategy = overrideDateStrategy ?? refs.dateStrategy;
   if (Array.isArray(strategy)) {
@@ -53267,7 +53267,7 @@ var integerDateParser = (def, refs) => {
   return res;
 };
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/default.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/default.js
 function parseDefaultDef(_def, refs) {
   return {
     ...parseDef(_def.innerType._def, refs),
@@ -53275,12 +53275,12 @@ function parseDefaultDef(_def, refs) {
   };
 }
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/effects.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/effects.js
 function parseEffectsDef(_def, refs) {
   return refs.effectStrategy === "input" ? parseDef(_def.schema._def, refs) : parseAnyDef(refs);
 }
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/enum.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/enum.js
 function parseEnumDef(def) {
   return {
     type: "string",
@@ -53288,7 +53288,7 @@ function parseEnumDef(def) {
   };
 }
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/intersection.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/intersection.js
 var isJsonSchema7AllOfType = (type) => {
   if ("type" in type && type.type === "string")
     return false;
@@ -53330,7 +53330,7 @@ function parseIntersectionDef(def, refs) {
   } : void 0;
 }
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/literal.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/literal.js
 function parseLiteralDef(def, refs) {
   const parsedType2 = typeof def.value;
   if (parsedType2 !== "bigint" && parsedType2 !== "number" && parsedType2 !== "boolean" && parsedType2 !== "string") {
@@ -53350,7 +53350,7 @@ function parseLiteralDef(def, refs) {
   };
 }
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/string.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/string.js
 var emojiRegex2 = void 0;
 var zodPatterns = {
   /**
@@ -53675,7 +53675,7 @@ function stringifyRegExpWithFlags(regex, refs) {
   return pattern;
 }
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/record.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/record.js
 function parseRecordDef(def, refs) {
   if (refs.target === "openAi") {
     console.warn("Warning: OpenAI may not support records in schemas! Try an array of key-value pairs instead.");
@@ -53727,7 +53727,7 @@ function parseRecordDef(def, refs) {
   return schema;
 }
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/map.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/map.js
 function parseMapDef(def, refs) {
   if (refs.mapStrategy === "record") {
     return parseRecordDef(def, refs);
@@ -53752,7 +53752,7 @@ function parseMapDef(def, refs) {
   };
 }
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/nativeEnum.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/nativeEnum.js
 function parseNativeEnumDef(def) {
   const object3 = def.values;
   const actualKeys = Object.keys(def.values).filter((key) => {
@@ -53766,7 +53766,7 @@ function parseNativeEnumDef(def) {
   };
 }
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/never.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/never.js
 function parseNeverDef(refs) {
   return refs.target === "openAi" ? void 0 : {
     not: parseAnyDef({
@@ -53776,7 +53776,7 @@ function parseNeverDef(refs) {
   };
 }
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/null.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/null.js
 function parseNullDef(refs) {
   return refs.target === "openApi3" ? {
     enum: ["null"],
@@ -53786,7 +53786,7 @@ function parseNullDef(refs) {
   };
 }
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/union.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/union.js
 var primitiveMappings = {
   ZodString: "string",
   ZodNumber: "number",
@@ -53854,7 +53854,7 @@ var asAnyOf = (def, refs) => {
   return anyOf.length ? { anyOf } : void 0;
 };
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/nullable.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/nullable.js
 function parseNullableDef(def, refs) {
   if (["ZodString", "ZodNumber", "ZodBigInt", "ZodBoolean", "ZodNull"].includes(def.innerType._def.typeName) && (!def.innerType._def.checks || !def.innerType._def.checks.length)) {
     if (refs.target === "openApi3") {
@@ -53886,7 +53886,7 @@ function parseNullableDef(def, refs) {
   return base && { anyOf: [base, { type: "null" }] };
 }
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/number.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/number.js
 function parseNumberDef(def, refs) {
   const res = {
     type: "number"
@@ -53935,7 +53935,7 @@ function parseNumberDef(def, refs) {
   return res;
 }
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/object.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/object.js
 function parseObjectDef(def, refs) {
   const forceOptionalIntoNullable = refs.target === "openAi";
   const result = {
@@ -54005,7 +54005,7 @@ function safeIsOptional(schema) {
   }
 }
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/optional.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/optional.js
 var parseOptionalDef = (def, refs) => {
   if (refs.currentPath.toString() === refs.propertyPath?.toString()) {
     return parseDef(def.innerType._def, refs);
@@ -54024,7 +54024,7 @@ var parseOptionalDef = (def, refs) => {
   } : parseAnyDef(refs);
 };
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/pipeline.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/pipeline.js
 var parsePipelineDef = (def, refs) => {
   if (refs.pipeStrategy === "input") {
     return parseDef(def.in._def, refs);
@@ -54044,12 +54044,12 @@ var parsePipelineDef = (def, refs) => {
   };
 };
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/promise.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/promise.js
 function parsePromiseDef(def, refs) {
   return parseDef(def.type._def, refs);
 }
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/set.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/set.js
 function parseSetDef(def, refs) {
   const items = parseDef(def.valueType._def, {
     ...refs,
@@ -54069,7 +54069,7 @@ function parseSetDef(def, refs) {
   return schema;
 }
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/tuple.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/tuple.js
 function parseTupleDef(def, refs) {
   if (def.rest) {
     return {
@@ -54097,24 +54097,24 @@ function parseTupleDef(def, refs) {
   }
 }
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/undefined.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/undefined.js
 function parseUndefinedDef(refs) {
   return {
     not: parseAnyDef(refs)
   };
 }
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/unknown.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/unknown.js
 function parseUnknownDef(refs) {
   return parseAnyDef(refs);
 }
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/readonly.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parsers/readonly.js
 var parseReadonlyDef = (def, refs) => {
   return parseDef(def.innerType._def, refs);
 };
 
-// node_modules/zod-to-json-schema/dist/esm/selectParser.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/selectParser.js
 var selectParser = (def, typeName, refs) => {
   switch (typeName) {
     case ZodFirstPartyTypeKind.ZodString:
@@ -54190,7 +54190,7 @@ var selectParser = (def, typeName, refs) => {
   }
 };
 
-// node_modules/zod-to-json-schema/dist/esm/parseDef.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/parseDef.js
 function parseDef(def, refs, forceResolution = false) {
   const seenItem = refs.seen.get(def);
   if (refs.override) {
@@ -54246,7 +54246,7 @@ var addMeta = (def, refs, jsonSchema) => {
   return jsonSchema;
 };
 
-// node_modules/zod-to-json-schema/dist/esm/zodToJsonSchema.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/zod-to-json-schema/dist/esm/zodToJsonSchema.js
 var zodToJsonSchema = (schema, options) => {
   const refs = getRefs(options);
   let definitions = typeof options === "object" && options.definitions ? Object.entries(options.definitions).reduce((acc, [name2, schema2]) => ({
@@ -54308,7 +54308,7 @@ var zodToJsonSchema = (schema, options) => {
   return combined;
 };
 
-// node_modules/@modelcontextprotocol/sdk/dist/esm/server/zod-json-schema-compat.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@modelcontextprotocol/sdk/dist/esm/server/zod-json-schema-compat.js
 function mapMiniTarget(t) {
   if (!t)
     return "draft-7";
@@ -54350,7 +54350,7 @@ function parseWithCompat(schema, data) {
   return result.data;
 }
 
-// node_modules/@modelcontextprotocol/sdk/dist/esm/shared/protocol.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@modelcontextprotocol/sdk/dist/esm/shared/protocol.js
 var DEFAULT_REQUEST_TIMEOUT_MSEC = 6e4;
 var Protocol = class {
   constructor(_options) {
@@ -55304,7 +55304,7 @@ function mergeCapabilities(base, additional) {
   return result;
 }
 
-// node_modules/@modelcontextprotocol/sdk/dist/esm/validation/ajv-provider.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@modelcontextprotocol/sdk/dist/esm/validation/ajv-provider.js
 var import_ajv = __toESM(require_ajv(), 1);
 var import_ajv_formats = __toESM(require_dist(), 1);
 function createDefaultAjvInstance() {
@@ -55372,7 +55372,7 @@ var AjvJsonSchemaValidator = class {
   }
 };
 
-// node_modules/@modelcontextprotocol/sdk/dist/esm/experimental/tasks/server.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@modelcontextprotocol/sdk/dist/esm/experimental/tasks/server.js
 var ExperimentalServerTasks = class {
   constructor(_server) {
     this._server = _server;
@@ -55585,7 +55585,7 @@ var ExperimentalServerTasks = class {
   }
 };
 
-// node_modules/@modelcontextprotocol/sdk/dist/esm/experimental/tasks/helpers.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@modelcontextprotocol/sdk/dist/esm/experimental/tasks/helpers.js
 function assertToolsCallTaskCapability(requests, method, entityName) {
   if (!requests) {
     throw new Error(`${entityName} does not support task creation (required for ${method})`);
@@ -55620,7 +55620,7 @@ function assertClientRequestTaskCapability(requests, method, entityName) {
   }
 }
 
-// node_modules/@modelcontextprotocol/sdk/dist/esm/server/index.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@modelcontextprotocol/sdk/dist/esm/server/index.js
 var Server = class extends Protocol {
   /**
    * Initializes this server with the given name and version information.
@@ -56000,7 +56000,7 @@ var Server = class extends Protocol {
   }
 };
 
-// node_modules/@modelcontextprotocol/sdk/dist/esm/server/completable.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@modelcontextprotocol/sdk/dist/esm/server/completable.js
 var COMPLETABLE_SYMBOL = Symbol.for("mcp.completable");
 function isCompletable(schema) {
   return !!schema && typeof schema === "object" && COMPLETABLE_SYMBOL in schema;
@@ -56014,7 +56014,7 @@ var McpZodTypeKind;
   McpZodTypeKind2["Completable"] = "McpCompletable";
 })(McpZodTypeKind || (McpZodTypeKind = {}));
 
-// node_modules/@modelcontextprotocol/sdk/dist/esm/shared/toolNameValidation.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@modelcontextprotocol/sdk/dist/esm/shared/toolNameValidation.js
 var TOOL_NAME_REGEX = /^[A-Za-z0-9._-]{1,128}$/;
 function validateToolName(name) {
   const warnings = [];
@@ -56072,7 +56072,7 @@ function validateAndWarnToolName(name) {
   return result.isValid;
 }
 
-// node_modules/@modelcontextprotocol/sdk/dist/esm/experimental/tasks/mcp-server.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@modelcontextprotocol/sdk/dist/esm/experimental/tasks/mcp-server.js
 var ExperimentalMcpServerTasks = class {
   constructor(_mcpServer) {
     this._mcpServer = _mcpServer;
@@ -56087,7 +56087,7 @@ var ExperimentalMcpServerTasks = class {
   }
 };
 
-// node_modules/@modelcontextprotocol/sdk/dist/esm/server/mcp.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@modelcontextprotocol/sdk/dist/esm/server/mcp.js
 var McpServer = class {
   constructor(serverInfo, options) {
     this._registeredResources = {};
@@ -56879,7 +56879,7 @@ var EMPTY_COMPLETION_RESULT = {
   }
 };
 
-// node_modules/@modelcontextprotocol/sdk/dist/esm/server/webStandardStreamableHttp.js
+// ../../home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/node_modules/@modelcontextprotocol/sdk/dist/esm/server/webStandardStreamableHttp.js
 var WebStandardStreamableHTTPServerTransport = class {
   constructor(options = {}) {
     this._started = false;
@@ -61394,46 +61394,54 @@ async function handleGitHubActionsEventRequest(request, env) {
       reason: "dashboard event store is not configured"
     });
   }
+  const threadId = event.threadId || buildDashboardEventDefaultThreadId(event.event);
+  const chatMessage = buildGitHubActionsDashboardChatMessage({
+    event: event.event,
+    threadId
+  });
   const chatStore = resolveDashboardChatStore(env);
-  if (!chatStore) {
-    return json(503, {
-      ok: false,
-      error: "dashboard_chat_store_unavailable",
-      reason: "dashboard Butler chat store is not configured"
-    });
+  let messages = [];
+  let chatAppendStatus = "unavailable";
+  let chatAppendError = null;
+  let chatAppendReason = null;
+  if (chatMessage) {
+    if (chatStore) {
+      try {
+        messages = await chatStore.appendMany(threadId, [chatMessage]);
+        chatAppendStatus = messages.length > 0 ? "appended" : "skipped";
+      } catch (error2) {
+        chatAppendStatus = "failed";
+        chatAppendError = "dashboard_event_chat_append_failed";
+        chatAppendReason = error2 instanceof Error ? error2.message : "Dashboard Butler chat append failed";
+      }
+    } else {
+      chatAppendError = "dashboard_chat_store_unavailable";
+      chatAppendReason = "dashboard Butler chat store is not configured";
+    }
   }
+  const shouldDispatchNotification = chatAppendStatus === "appended";
   const recorded = await recordDashboardNotificationEvent({
     env,
     eventStore: store,
-    event: event.event
+    event: event.event,
+    overrides: shouldDispatchNotification ? {} : {
+      pwaNotificationStatus: chatAppendError || "dashboard_chat_append_skipped",
+      pwaNotificationError: chatAppendError || null,
+      pwaNotificationReason: chatAppendReason || "dashboard Butler chat append did not complete",
+      pwaNotificationAttempted: 0,
+      pwaNotificationDelivered: 0,
+      pwaNotificationCleaned: 0
+    },
+    dispatch: shouldDispatchNotification
   });
-  const threadId = event.threadId || buildDashboardEventDefaultThreadId(event.event);
-  const chatMessage = buildGitHubActionsDashboardChatMessage({
-    event: recorded.event,
-    threadId
-  });
-  let messages = [];
-  if (chatMessage) {
-    try {
-      messages = await chatStore.appendMany(threadId, [chatMessage]);
-    } catch (error2) {
-      await store.delete(recorded.event.id);
-      return json(502, {
-        ok: false,
-        error: "dashboard_event_chat_append_failed",
-        reason: "GitHub Actions event was not saved because Butler chat append failed",
-        rollback: {
-          eventId: recorded.event.id,
-          notificationDeleted: true
-        }
-      });
-    }
-  }
   const webSocketBroadcast = messages.length > 0 ? await notifyDashboardChatRoom({ env, threadId, messages }) : false;
   return json(202, {
     ok: true,
     event: recorded.event,
     threadId,
+    chatAppendStatus,
+    chatAppendError,
+    chatAppendReason,
     messages,
     webSocketBroadcast,
     webPush: recorded.webPush

--- a/worker.js
+++ b/worker.js
@@ -61394,14 +61394,48 @@ async function handleGitHubActionsEventRequest(request, env) {
       reason: "dashboard event store is not configured"
     });
   }
+  const chatStore = resolveDashboardChatStore(env);
+  if (!chatStore) {
+    return json(503, {
+      ok: false,
+      error: "dashboard_chat_store_unavailable",
+      reason: "dashboard Butler chat store is not configured"
+    });
+  }
   const recorded = await recordDashboardNotificationEvent({
     env,
     eventStore: store,
     event: event.event
   });
+  const threadId = event.threadId || buildDashboardEventDefaultThreadId(event.event);
+  const chatMessage = buildGitHubActionsDashboardChatMessage({
+    event: recorded.event,
+    threadId
+  });
+  let messages = [];
+  if (chatMessage) {
+    try {
+      messages = await chatStore.appendMany(threadId, [chatMessage]);
+    } catch (error2) {
+      await store.delete(recorded.event.id);
+      return json(502, {
+        ok: false,
+        error: "dashboard_event_chat_append_failed",
+        reason: "GitHub Actions event was not saved because Butler chat append failed",
+        rollback: {
+          eventId: recorded.event.id,
+          notificationDeleted: true
+        }
+      });
+    }
+  }
+  const webSocketBroadcast = messages.length > 0 ? await notifyDashboardChatRoom({ env, threadId, messages }) : false;
   return json(202, {
     ok: true,
     event: recorded.event,
+    threadId,
+    messages,
+    webSocketBroadcast,
     webPush: recorded.webPush
   });
 }
@@ -68992,6 +69026,7 @@ function normalizeGitHubActionsEvent(payload) {
   );
   const pullNumber = normalizeIssue6(input.pullNumber || input.pull_number || input.prNumber || input.pr_number) || inferPullNumberFromText(`${title} ${changeSummary}`);
   const issueNumber = normalizeIssue6(input.issueNumber || input.issue_number);
+  const threadId = normalizeDashboardThreadId(input.threadId || input.thread_id);
   if (!repository) {
     return {
       ok: false,
@@ -69047,8 +69082,81 @@ function normalizeGitHubActionsEvent(payload) {
   };
   return {
     ok: true,
-    event
+    event,
+    threadId
   };
+}
+function buildDashboardEventDefaultThreadId(event) {
+  const record2 = normalizeDashboardEventRecord(event);
+  const repository = normalizeCanonicalRepositoryInput(record2.repository);
+  if (repository) {
+    return normalizeDashboardThreadId(`dashboard-main-${repository.replace("/", "-")}`);
+  }
+  return "dashboard-main-unresolved";
+}
+function buildGitHubActionsDashboardChatMessage({ event, threadId } = {}) {
+  const record2 = normalizeDashboardEventRecord(event);
+  const resolvedThreadId = normalizeDashboardThreadId(threadId) || buildDashboardEventDefaultThreadId(record2);
+  if (!resolvedThreadId || record2.kind !== "github_actions_workflow_run") {
+    return null;
+  }
+  const messageId = `dashboard-event:${record2.id}`;
+  return normalizeDashboardChatMessage(
+    {
+      threadId: resolvedThreadId,
+      messageId,
+      role: "system",
+      repository: record2.repository,
+      relatedIssue: record2.issueNumber,
+      status: record2.conclusion === "failure" || record2.conclusion === "cancelled" ? "blocked" : "replied",
+      text: buildGitHubActionsDashboardChatMessageText(record2),
+      createdAt: record2.updatedAt || record2.createdAt
+    },
+    { threadId: resolvedThreadId }
+  );
+}
+function buildGitHubActionsDashboardChatMessageText(event) {
+  const record2 = normalizeDashboardEventRecord(event);
+  const conclusion = normalizeDashboardEventText(record2.conclusion || record2.status) || "unknown";
+  const isDeploy = normalize7(record2.workflowName).includes("deploy");
+  const title = buildDashboardEventDisplayTitle(record2, {
+    workflowName: record2.workflowName,
+    conclusion
+  });
+  const lines = [
+    isDeploy ? "\u30C7\u30D7\u30ED\u30A4\u5B8C\u4E86\u30A4\u30D9\u30F3\u30C8\u3092\u53D7\u4FE1\u3057\u307E\u3057\u305F\u3002" : "GitHub Actions \u306E\u5B8C\u4E86\u30A4\u30D9\u30F3\u30C8\u3092\u53D7\u4FE1\u3057\u307E\u3057\u305F\u3002",
+    "",
+    "\u72B6\u614B:",
+    `- repo: ${record2.repository || "\u672A\u78BA\u8A8D"}`,
+    `- workflow: ${record2.workflowName || "\u672A\u78BA\u8A8D"}`,
+    `- status: ${record2.status || "\u672A\u78BA\u8A8D"}`,
+    `- conclusion: ${conclusion}`
+  ];
+  if (record2.pullNumber) {
+    lines.push(`- PR: PR #${record2.pullNumber}`);
+  }
+  if (record2.issueNumber) {
+    lines.push(`- Issue: Issue #${record2.issueNumber}`);
+  }
+  if (record2.headSha) {
+    lines.push(`- sha: ${record2.headSha.slice(0, 12)}`);
+  }
+  if (title) {
+    lines.push("", "\u5185\u5BB9:", title);
+  }
+  lines.push("", "\u6B21:");
+  if (isDeploy && conclusion === "success") {
+    lines.push("- production E2E / runtime truth \u3092\u78BA\u8A8D\u3057\u307E\u3059\u3002");
+  } else if (conclusion === "failure" || conclusion === "cancelled" || conclusion === "timed_out") {
+    lines.push("- deploy / Actions \u306E\u5931\u6557\u539F\u56E0\u3092\u78BA\u8A8D\u3057\u3001blocker \u3068\u6B21 action \u3092\u51FA\u3057\u307E\u3059\u3002");
+  } else {
+    lines.push("- \u6700\u65B0 event \u3068\u6B8B\u308B blocker \u3092\u78BA\u8A8D\u3057\u307E\u3059\u3002");
+  }
+  lines.push("- merge / deploy / credential / permission \u306F\u3001\u3053\u306E event \u3060\u3051\u3067\u306F\u81EA\u52D5\u5B9F\u884C\u3057\u307E\u305B\u3093\u3002");
+  if (record2.runUrl) {
+    lines.push("", `Actions: ${record2.runUrl}`);
+  }
+  return lines.join("\n");
 }
 function normalizeVpsRunnerDashboardEvent(payload) {
   const input = normalizeObject12(payload);


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #722 の部分進捗として、GitHub Actions の deploy completion event を通知センターだけで終わらせず、Dashboard Butler thread に owner-facing system message として残します。
- reviewer 指摘を受け、処理順序を event truth 受理保存 -> chat append -> Web Push dispatch に修正しました。Web Push は送信後に rollback できないため、chat store 未設定または chat append 失敗時は event truth に失敗理由を残し、Web Push は送らない設計にします。

## Satisfied Success Criteria

- deploy 完了イベントを受信したら、対象 Dashboard Butler thread に owner-facing system message として自動追記されます。
- chat append が成功した場合だけ Web Push を送ります。
- duplicate event は thread message を idempotent に置換しますが、既に Web Push `sent` 済みなら Web Push は再送しません。
- event truth の初回受理保存が失敗した場合は、chat append も Web Push も実行しません。
- chat append 失敗時は 202 で event truth を保存し、`pwaNotificationStatus=dashboard_event_chat_append_failed`、attempted/delivered 0 として通知未送信を明示します。
- `DASHBOARD_CHAT_STORE` 未設定時も 503 で ingest を止めず、202 で event truth を保存し、`pwaNotificationStatus=dashboard_chat_store_unavailable`、attempted/delivered 0 として通知未送信を明示します。
- duplicate event は同じ `messageId` で置換されます。production D1 の `PRIMARY KEY (thread_id, message_id)` と `INSERT OR REPLACE` を test evidence に含めました。
- owner-facing な PR / Issue 参照は `PR #...` / `Issue #...` の種別付きで表示します。
- deploy / merge / credential / permission などの authority boundary は維持し、event だけで高リスク操作を自動実行しません。

## Unsatisfied Success Criteria

- auto-merge / reviewer approve event の thread 追記は、この PR では未実装です。
- Butler が thread 再開時に「直近イベント」「残る blocker」「次 action」を自然文で統合説明する full path は未完了です。
- owner GO 直後の受理、長時間作業中の progress message、完了時の progress 要約は未完了です。
- iPhone / iPad production E2E は merge / deploy 後に確認が必要です。

## Non-goal violations

None.

## 開発前作戦図

- 作戦図 evidence: `docs/development-strategy/issue-722-completion-event-thread-state.md`
- 完了体験: deploy completion event が Dashboard Butler thread に残り、owner が通知だけでなく会話履歴から次 action を追えます。
- VTDD 全体で進める部分: Issue #722 のうち、既存 GitHub Actions deploy event source を thread state に接続する first slice です。
- 設計: Dashboard Butler の owner-facing surface に deploy 完了を残す設計です。scope は `/v2/events/github-actions` で event truth を先に受理保存し、Dashboard chat store へ system message を append し、chat append 成功後だけ Web Push を dispatch する経路に限定します。
- 仮説: root 原因は、deploy completion が無言に見える failure mode として GitHub Actions event route が chat store に書いていないことです。
- 検証計画: worker test で event ingest、thread append、broadcast、dedupe、duplicate Web Push skip、event truth accepted before chat、chat append failure fallback、chat store missing fallback を確認します。
- 改修見積もり: `src/worker/runtime.js`、`worker.js`、`test/worker.test.js`、作戦図を変更します。
- 既に通っている経路: GitHub Actions event ingest、dashboard event store、Web Push、VPS runner event の thread append は既存です。
- 未確認の境界: reviewer approve / auto-merge event source、repo-less main chat 統合、production iPad E2E は未確認です。
- 穴が出そうな箇所: chat store 未設定、duplicate webhook、threadId 未指定時の thread 導出です。
- PR 前に確認すること: topic branch、generated worker、worker test、generated check、PR body validation を確認します。
- 実装候補と捨てた案: 通知センターだけの文言変更は捨て、thread append を採用しました。全 event 一括実装は scope 過多として捨てました。
- merge 後に通す E2E: production live E2E として deploy completion event 後、Dashboard Butler thread に system message が残ることを検証します。
- 次の PR を増やさない理由: この PR は deploy completion だけに絞るため、reviewer / auto-merge / progress narration は次 slice に分離します。
- 停止条件: chat append 成功前に Web Push を送る必要が出た場合、または high-risk operation 実行が必要になった場合は停止します。

## Dry-run Impact Report

- Target Issue: Issue #722
- Implementing Success Criteria: deploy completion event の thread 自動追記、event truth 受理保存後の chat append、chat 成功後 Web Push dispatch、duplicate Web Push skip、chat append failure / chat store missing の event truth fallback、owner-facing PR / Issue 種別表示、authority boundary 維持。
- Explicit Non-goals: auto-merge / reviewer approve event、long-running progress narration、deploy / merge / credential / permission の自動実行、通知 UI redesign。
- Expected touched files/routes/workflows: `src/worker/runtime.js` の `/v2/events/github-actions` route、`worker.js`、`test/worker.test.js`、`docs/development-strategy/issue-722-completion-event-thread-state.md`。
- Affected Issues: Issue #722、関連して Issue #590 / Issue #413 / Issue #455。
- Affected PRs: なし。
- Affected workflows: `deploy-production` workflow から届く GitHub Actions completion event。
- Affected runtime/operator surfaces: Dashboard Butler chat thread、dashboard event store、Web Push notification、DashboardChatRoom broadcast。
- What may break if we patch narrowly: Web Push を先に送ると rollback 不能で「通知だけ残る」状態になり、chat append を event truth より先に行うと「thread だけ残る」状態になります。event truth 受理保存 -> chat append -> Web Push dispatch の順序に固定します。
- Unknowns to investigate before coding: reviewer approve / auto-merge の event source はこの PR では未確認のまま残します。
- Validation needed: worker test、build worker、generated worker check、merge 後 production E2E。
- Stop condition: 通知だけ残る partial truth、または high-risk operation 実行が必要になった場合。

## Execution Queue Delta

- Queue position before: docs 上の Now は Issue #590 ですが、Issue #722 は Issue #590 / Issue #413 の「待たせない・節目を thread に残す」root gap を塞ぐ bounded slice として扱います。
- Preemption decision: ROOT。owner の「マージ/デプロイ完了を人間が手でパスするのはおかしい」という指摘は、Issue #590 の silent wait と Issue #413 の runtime truth visibility を妨げるため、この bounded slice を先に直します。
- Queue delta: Issue #722 の deploy completion event thread append を進めます。auto-merge / reviewer / progress narration は未完了として残します。
- Why this PR is next: owner が「人間が merge/deploy 完了を手でパスするのはおかしい」と指摘し、Butler が event を自動で thread truth に残す必要が明確になったためです。
- Active Issues not downscoped: Active Issues は縮小しません。この PR で扱わない Issue #590 / Issue #413 / Issue #455 / Issue #613 などは未完了または別 slice として残します。

## File / Line Hypotheses

- file: `src/worker/runtime.js`
  - hypothesis: `handleGitHubActionsEventRequest` が dashboard event store / Web Push だけに保存し、Dashboard chat store へ append していない。
  - risk if changed narrowly: Web Push を先に送ると通知だけ残る partial truth が発生する。
  - validation: deploy completion event test で thread append / duplicate Web Push skip / event truth accepted before chat / chat append failure fallback / chat store missing fallback を確認する。
  - related Issue: Issue #722
- file: `test/worker.test.js`
  - hypothesis: 既存 deploy completion test は notification center だけを見ており、thread persistence と production idempotency を拾えていない。
  - risk if changed narrowly: production で「通知は来たが chat が無言」の regression をテストが見逃す。
  - validation: chat store / room broadcast / duplicate event / Web Push 未送信 assertion を追加する。
  - related Issue: Issue #722

## Hypothesis Retrospective

- expected: GitHub Actions deploy completion route に chat append を足せば、thread に deploy completion system message が残る。
- actual: `node --test test/worker.test.js` で deploy completion event が thread に system message を append し、duplicate event が同じ messageId で置換され、Web Push が重複送信されず、event truth の初回受理保存が失敗した場合は chat append / Web Push が走らず、chat append 失敗時と chat store 未設定時に Web Push を送らず event truth を残すことを確認しました。
- mismatch: `npm run verify:worker` は別領域の環境変数依存テスト 4 件で失敗しました。今回の worker runtime 差分に関係する `test/worker.test.js` と generated worker check は通過しています。
- lesson: deploy event は notification-only にせず、event truth 受理保存、thread append、Web Push dispatch の順序と duplicate skip を runtime invariant にする必要があります。
- should become RAG candidate: `proposal_log` 候補。completion event は notification-only にせず thread truth へ接続する。

## Verification Evidence

- Unit: `node --test test/worker.test.js` pass, 264 tests.
- Integration: `node --test test/worker.test.js` 内で `/v2/events/github-actions` -> event store / chat store / DashboardChatRoom broadcast / dashboard chat retrieve を確認。
- Boundary: duplicate Web Push skip、event truth accepted before chat、chat append failure、chat store missing は 202/503 + Web Push 未送信 + runtime truth を確認。
- Generated: `npm run build:worker` pass、`npm run check:generated-worker` pass。
- Full verification: `npm run verify:worker` failed in unrelated existing env-dependent tests (`gateway-bearer-vault-bootstrap.test.js` 2件、`vps-runner-script.test.js` 2件)。今回変更対象の worker route tests は pass。
- E2E: 未実施。merge / deploy 後に production Dashboard Butler thread で確認が必要です。
- Evidence path/link: `test/worker.test.js` の GitHub Actions deploy completion / failure fallback tests、`docs/development-strategy/issue-722-completion-event-thread-state.md`。

## Butler Completion Contract

- Primary owner surface: Dashboard Butler。
- Fallback surface: Custom GPT は fallback surface であり、この PR では変更しません。
- Owner goal: deploy completion を owner が手で補足しなくても、Butler thread に残して次 action を追えるようにする。
- Butler entrypoint: GitHub Actions deploy workflow から `/v2/events/github-actions` に届く machine event。
- Dashboard Butler natural-language path: Dashboard Butler の通常チャット入口で owner が戻った時に読める経路へ、completion event の thread 表示を接続します。この PR では自然文 intent の解釈自体は変更しません。
- Action Schema exposure: 不要。この PR は runtime event ingest の変更です。
- Runtime path: `/v2/events/github-actions` -> dashboard event store 受理保存 -> Dashboard chat store -> Web Push -> DashboardChatRoom broadcast。
- Runner/runtime truth: API response に `event`、`threadId`、`chatAppendStatus`、`chatAppendError`、`chatAppendReason`、`messages`、`webSocketBroadcast`、`webPush` を返します。
- Authority boundary: 未変更。event 追記だけで merge / deploy / credential / permission は自動実行しません。
- E2E evidence: この PR スライスでは未実施。production deploy event で thread 表示確認が必要です。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: merge 後に別途 passkey approval が必要です。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: merge / deploy 後に必要です。

## Related Constitution Rules

- Butler Completion Gate
- Butler-First Operating Principle
- Conversation UX Contract
- Authority Boundary
- Drift Stop Protocol

## Out-of-scope but NOT implemented

- reviewer approve event の thread append。
- auto-merge event の thread append。
- long-running progress narration の durable thread 化。
- repo-less main chat と repository thread の統合。
- deploy / merge / credential / permission の自動実行。

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #722
- Execution ID: local-issue-722-completion-event-thread-state
- Goal: deploy completion event を Dashboard Butler thread truth へ接続する
