### PR TITLE
Issue #455 fast pathを会話本文優先に直す

### DIFF
--- a/docs/development-strategy/issue-455-dashboard-cost-aware-fast-path.md
+++ b/docs/development-strategy/issue-455-dashboard-cost-aware-fast-path.md
@@ -4,6 +4,8 @@
 
 owner が Dashboard Butler で「今の状況」「次は？」「PR/Issue の状態を見たい」のような read/status 系の軽い依頼を投げた時、Butler はまず Codex app-server turn を起動せず、チャット上に「この応答は軽量 read/status fast path で、Codex usage を消費していない」ことを返す。実装・修正・merge・deploy・reviewer などの重い作業は従来通り app-server / runner / reviewer 経路へ進み、品質 gate は削らない。
 
+2026-06-03 follow-up: fast path は owner-facing 返答の主役にしてはいけない。`cost_boundary` や `codexWillStart=false` は補足情報であり、先頭本文は owner の質問に答える必要がある。軽量化の目的は会話を潰すことではなく、会話品質を保ったまま不要な Codex 起動を避けることである。
+
 ## VTDD 全体で進める部分
 
 Issue #455 のうち、今回の slice は Dashboard の通常 chat entrypoint での usage-aware routing に限定する。PR #750 で入った reviewer fallback 重複抑止は前提として扱い、同じ PR head の fallback retry 抑止は再実装しない。Cloudflare rowsWritten の presence/persistence 修正や bridge lifecycle guard も今回は触らない。
@@ -11,6 +13,8 @@ Issue #455 のうち、今回の slice は Dashboard の通常 chat entrypoint �
 ## 設計
 
 DashboardChatRoom の `owner_message` 処理で、owner message を durable thread に保存し ack した後、app-server bridge dispatch 前に軽量 intent 分類を挟む。分類が read/status/cost explanation の範囲に収まる場合は Butler message を同じ thread に保存して broadcast し、`dispatchOwnerMessageToAppServerBridge()` を呼ばない。返答には `cost_boundary: lightweight_worker_reply / codexWillStart=false` を明記する。
+
+ただし返答本文は status packet ではなく、owner の発言に対する自然な回答を先に出す。`cost_boundary` は「補足」へ下げ、対象 repo / Issue などの internal context も必要最小限にする。
 
 分類が実装、調査、ファイル編集、PR 作成、merge、deploy、reviewer、画像解析、repo truth 深掘りなどを含む場合は fast path にせず、既存 app-server bridge 経路へ渡す。その場合は transient status に「Codex app-server を使うため usage を消費し得る」ことを短く出す。これは処理を止める承認 gate ではなく、owner-facing cost visibility である。
 
@@ -22,7 +26,7 @@ DashboardChatRoom の `owner_message` 処理で、owner message を durable thre
 
 - Unit: DashboardChatRoom が cost/status 系の軽い owner turn を保存し、Butler の軽量応答を保存して、connected app-server bridge へ送らない。
 - Unit: 実装修正系の owner turn は fast path されず、既存通り app-server bridge へ送られる。
-- Unit: fast path 応答に `cost_boundary` と `codexWillStart=false` が含まれる。
+- Unit: fast path 応答は owner の質問への回答を先頭に置き、`cost_boundary` と `codexWillStart=false` は補足として含める。
 - Local: `npm run build:worker`、`node --test test/worker.test.js`、`npm run check:generated-worker`、`git diff --check` を実行する。
 
 ## 改修見積もり

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -9390,7 +9390,7 @@ function buildDashboardCostAwareFastPathMessages({
       status: "replied",
       messageId: `dashboard_butler_cost_fast_path:${crypto.randomUUID()}`,
       createdAt,
-      text: buildDashboardCostAwareFastPathReplyText({ repository, relatedIssue })
+      text: buildDashboardCostAwareFastPathReplyText({ repository, relatedIssue, text })
     },
     { threadId }
   );
@@ -9436,21 +9436,39 @@ function isDashboardCostAwareLightweightIntent({ text = "", mediaReferences = []
   return !heavyPatterns.some((pattern) => pattern.test(normalized));
 }
 
-function buildDashboardCostAwareFastPathReplyText({ repository = "", relatedIssue = "" } = {}) {
+function buildDashboardCostAwareFastPathReplyText({ repository = "", relatedIssue = "", text = "" } = {}) {
   const scope = [
     repository ? `対象 repo: ${repository}` : "対象 repo: 未指定",
-    relatedIssue ? `関連 Issue: #${relatedIssue}` : "関連 Issue: 未指定"
+    relatedIssue ? `関連 Issue: Issue #${relatedIssue}` : "関連 Issue: 未指定"
   ].join("\n");
+  const ownerText = sanitizeDashboardChatText(text);
+  const isQualityConcern =
+    /VTDD|品質|機能|落と|足りない|思ったもの|壊|劣化|改悪/.test(ownerText) ||
+    /quality|feature|capability|regress/i.test(ownerText);
+  const answer = isQualityConcern
+    ? [
+        "結論から言うと、削る場所を間違えると VTDD 自体が足りないものになります。",
+        "",
+        "削ってよいのは、毎回 Codex app-server / VPS Codex CLI を起動しなくても答えられる入口だけです。たとえば cost 方針の説明、既に Worker が持っている軽い状態説明、明白な read/status の受け付けです。",
+        "",
+        "削ってはいけないのは、Issue / PR / reviewer / CI / E2E / merge / deploy の gate です。ここを軽量化で飛ばすと、VTDD の目的そのものが壊れます。",
+        "",
+        "なので方針は「機能を薄くする」ではなく、「Codex を起動しなくてよい定型入口だけ Worker で返し、判断や実装が必要になったら Codex に渡す」です。"
+      ]
+    : [
+        "Codex usage を削る対象は、通常会話や cost/status の入口で毎回 Codex turn を起動する部分です。",
+        "",
+        "Issue / PR / reviewer / CI / E2E / merge / deploy の gate は削りません。ここを削ると VTDD の品質と安全境界が落ちます。",
+        "",
+        "重い実装、深い repo truth 読み、判断が必要な相談になった時だけ、Butler は Codex app-server に渡します。"
+      ];
   return [
-    "この返答は Dashboard Worker の軽量 fast path で返しています。Codex app-server / VPS Codex CLI は起動していません。",
+    ...answer,
     "",
+    "補足:",
     scope,
     "cost_boundary: lightweight_worker_reply",
-    "codexWillStart: false",
-    "",
-    "削る対象は、通常会話や cost/status の入口で毎回 Codex turn を起動する部分です。Issue / PR / reviewer / CI / E2E / merge / deploy の gate は削りません。",
-    "",
-    "次に重い実装や深い repo truth 読みが必要になった時だけ、Butler は Codex app-server に渡し、その時点で Codex usage を消費し得ることを表示します。"
+    "codexWillStart: false"
   ].join("\n");
 }
 

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -3736,10 +3736,13 @@ test("DashboardChatRoom answers cost-aware lightweight owner turns without start
   const reply = fastPathBroadcast.messages[1];
   assert.equal(reply.role, "butler");
   assert.equal(reply.status, "replied");
-  assert.match(reply.text, /軽量 fast path/);
-  assert.match(reply.text, /Codex app-server \/ VPS Codex CLI は起動していません/);
+  assert.match(reply.text, /削る場所を間違えると VTDD 自体が足りないものになります/);
+  assert.match(reply.text, /削ってはいけないのは、Issue \/ PR \/ reviewer \/ CI \/ E2E \/ merge \/ deploy の gate/);
+  assert.match(reply.text, /方針は「機能を薄くする」ではなく/);
+  assert.match(reply.text, /補足:/);
   assert.match(reply.text, /cost_boundary: lightweight_worker_reply/);
   assert.match(reply.text, /codexWillStart: false/);
+  assert.equal(reply.text.startsWith("この返答は Dashboard Worker"), false);
 });
 
 test("DashboardChatRoom answers PR status through GitHub read plane without starting app-server Codex", async () => {

--- a/worker.js
+++ b/worker.js
@@ -65726,7 +65726,7 @@ function buildDashboardCostAwareFastPathMessages({
       status: "replied",
       messageId: `dashboard_butler_cost_fast_path:${crypto.randomUUID()}`,
       createdAt,
-      text: buildDashboardCostAwareFastPathReplyText({ repository, relatedIssue })
+      text: buildDashboardCostAwareFastPathReplyText({ repository, relatedIssue, text })
     },
     { threadId }
   );
@@ -65757,21 +65757,35 @@ function isDashboardCostAwareLightweightIntent({ text = "", mediaReferences = []
   ];
   return !heavyPatterns.some((pattern) => pattern.test(normalized));
 }
-function buildDashboardCostAwareFastPathReplyText({ repository = "", relatedIssue = "" } = {}) {
+function buildDashboardCostAwareFastPathReplyText({ repository = "", relatedIssue = "", text = "" } = {}) {
   const scope = [
     repository ? `\u5BFE\u8C61 repo: ${repository}` : "\u5BFE\u8C61 repo: \u672A\u6307\u5B9A",
-    relatedIssue ? `\u95A2\u9023 Issue: #${relatedIssue}` : "\u95A2\u9023 Issue: \u672A\u6307\u5B9A"
+    relatedIssue ? `\u95A2\u9023 Issue: Issue #${relatedIssue}` : "\u95A2\u9023 Issue: \u672A\u6307\u5B9A"
   ].join("\n");
-  return [
-    "\u3053\u306E\u8FD4\u7B54\u306F Dashboard Worker \u306E\u8EFD\u91CF fast path \u3067\u8FD4\u3057\u3066\u3044\u307E\u3059\u3002Codex app-server / VPS Codex CLI \u306F\u8D77\u52D5\u3057\u3066\u3044\u307E\u305B\u3093\u3002",
+  const ownerText = sanitizeDashboardChatText(text);
+  const isQualityConcern = /VTDD|品質|機能|落と|足りない|思ったもの|壊|劣化|改悪/.test(ownerText) || /quality|feature|capability|regress/i.test(ownerText);
+  const answer = isQualityConcern ? [
+    "\u7D50\u8AD6\u304B\u3089\u8A00\u3046\u3068\u3001\u524A\u308B\u5834\u6240\u3092\u9593\u9055\u3048\u308B\u3068 VTDD \u81EA\u4F53\u304C\u8DB3\u308A\u306A\u3044\u3082\u306E\u306B\u306A\u308A\u307E\u3059\u3002",
     "",
+    "\u524A\u3063\u3066\u3088\u3044\u306E\u306F\u3001\u6BCE\u56DE Codex app-server / VPS Codex CLI \u3092\u8D77\u52D5\u3057\u306A\u304F\u3066\u3082\u7B54\u3048\u3089\u308C\u308B\u5165\u53E3\u3060\u3051\u3067\u3059\u3002\u305F\u3068\u3048\u3070 cost \u65B9\u91DD\u306E\u8AAC\u660E\u3001\u65E2\u306B Worker \u304C\u6301\u3063\u3066\u3044\u308B\u8EFD\u3044\u72B6\u614B\u8AAC\u660E\u3001\u660E\u767D\u306A read/status \u306E\u53D7\u3051\u4ED8\u3051\u3067\u3059\u3002",
+    "",
+    "\u524A\u3063\u3066\u306F\u3044\u3051\u306A\u3044\u306E\u306F\u3001Issue / PR / reviewer / CI / E2E / merge / deploy \u306E gate \u3067\u3059\u3002\u3053\u3053\u3092\u8EFD\u91CF\u5316\u3067\u98DB\u3070\u3059\u3068\u3001VTDD \u306E\u76EE\u7684\u305D\u306E\u3082\u306E\u304C\u58CA\u308C\u307E\u3059\u3002",
+    "",
+    "\u306A\u306E\u3067\u65B9\u91DD\u306F\u300C\u6A5F\u80FD\u3092\u8584\u304F\u3059\u308B\u300D\u3067\u306F\u306A\u304F\u3001\u300CCodex \u3092\u8D77\u52D5\u3057\u306A\u304F\u3066\u3088\u3044\u5B9A\u578B\u5165\u53E3\u3060\u3051 Worker \u3067\u8FD4\u3057\u3001\u5224\u65AD\u3084\u5B9F\u88C5\u304C\u5FC5\u8981\u306B\u306A\u3063\u305F\u3089 Codex \u306B\u6E21\u3059\u300D\u3067\u3059\u3002"
+  ] : [
+    "Codex usage \u3092\u524A\u308B\u5BFE\u8C61\u306F\u3001\u901A\u5E38\u4F1A\u8A71\u3084 cost/status \u306E\u5165\u53E3\u3067\u6BCE\u56DE Codex turn \u3092\u8D77\u52D5\u3059\u308B\u90E8\u5206\u3067\u3059\u3002",
+    "",
+    "Issue / PR / reviewer / CI / E2E / merge / deploy \u306E gate \u306F\u524A\u308A\u307E\u305B\u3093\u3002\u3053\u3053\u3092\u524A\u308B\u3068 VTDD \u306E\u54C1\u8CEA\u3068\u5B89\u5168\u5883\u754C\u304C\u843D\u3061\u307E\u3059\u3002",
+    "",
+    "\u91CD\u3044\u5B9F\u88C5\u3001\u6DF1\u3044 repo truth \u8AAD\u307F\u3001\u5224\u65AD\u304C\u5FC5\u8981\u306A\u76F8\u8AC7\u306B\u306A\u3063\u305F\u6642\u3060\u3051\u3001Butler \u306F Codex app-server \u306B\u6E21\u3057\u307E\u3059\u3002"
+  ];
+  return [
+    ...answer,
+    "",
+    "\u88DC\u8DB3:",
     scope,
     "cost_boundary: lightweight_worker_reply",
-    "codexWillStart: false",
-    "",
-    "\u524A\u308B\u5BFE\u8C61\u306F\u3001\u901A\u5E38\u4F1A\u8A71\u3084 cost/status \u306E\u5165\u53E3\u3067\u6BCE\u56DE Codex turn \u3092\u8D77\u52D5\u3059\u308B\u90E8\u5206\u3067\u3059\u3002Issue / PR / reviewer / CI / E2E / merge / deploy \u306E gate \u306F\u524A\u308A\u307E\u305B\u3093\u3002",
-    "",
-    "\u6B21\u306B\u91CD\u3044\u5B9F\u88C5\u3084\u6DF1\u3044 repo truth \u8AAD\u307F\u304C\u5FC5\u8981\u306B\u306A\u3063\u305F\u6642\u3060\u3051\u3001Butler \u306F Codex app-server \u306B\u6E21\u3057\u3001\u305D\u306E\u6642\u70B9\u3067 Codex usage \u3092\u6D88\u8CBB\u3057\u5F97\u308B\u3053\u3068\u3092\u8868\u793A\u3057\u307E\u3059\u3002"
+    "codexWillStart: false"
   ].join("\n");
 }
 async function filterDashboardAppServerBridgeMessagesForAppend({ store, threadId, messages = [] } = {}) {


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #455 の follow-up として、Dashboard Worker の cost-aware fast path が owner の相談を拾わず、内部メタ情報だけを返してしまう regression を修正します。
- fast path は Codex usage を削るための裏側の最適化に留め、owner-facing 本文はまず質問への回答として返します。

## Satisfied Success Criteria

- cost/status 系の軽い owner turn は引き続き Codex app-server / VPS Codex CLI を起動しません。
- fast path 返信は `cost_boundary` より前に owner の質問への自然な回答を出します。
- `cost_boundary: lightweight_worker_reply` と `codexWillStart: false` は補足として残します。
- Issue / PR / reviewer / CI / E2E / merge / deploy の gate は削らないことを明示します。

## Unsatisfied Success Criteria

- GitHub read fast path や PR/Issue 状態確認の完全自動化は、この PR では扱いません。
- Codex Analytics 使用量 API の読み取りや週次 quota 最適化 dashboard は未実装です。
- production Dashboard Butler での live E2E は merge / deploy 後に確認が必要です。

## Non-goal violations

None.

## 開発前作戦図

- 作戦図 evidence: `docs/development-strategy/issue-455-dashboard-cost-aware-fast-path.md`
- 完了体験: Dashboard Butler の owner-facing 通常チャットで、fast path でも会話として質問に答え、内部都合は補足に下げます。
- VTDD 全体で進める部分: Issue #455 の cost-aware routing のうち、通常会話を潰す fast path 文面 regression を直す follow-up slice です。
- 設計: DashboardChatRoom の cost-aware fast path は維持し、`buildDashboardCostAwareFastPathReplyText` で owner の質問への回答を先頭に出します。scope は文面と補足情報の整理に限定し、authority boundary は未変更です。
- 仮説: root 原因は、fast path が `cost_boundary` / `codexWillStart` などの内部メタ情報を主文として返し、owner の相談内容への回答を欠いたことです。
- 検証計画: worker test で fast path が app-server を起動しないこと、かつ本文先頭が owner の質問に答えることを確認します。
- 改修見積もり: `src/worker/runtime.js` の fast path formatter、`test/worker.test.js` の期待値、`worker.js` generated、#455 作戦図を変更します。
- 既に通っている経路: Issue #455 の fast path route は既に app-server を起動しない。今回それを会話品質側へ補正します。
- 未確認の境界: production iPad / iPhone live E2E は merge / deploy 後に確認します。
- 穴が出そうな箇所: fast path を広げすぎると実装・調査・reviewer・deploy を誤って飲み込むため、分類条件は広げません。
- PR 前に確認すること: `node --test test/worker.test.js`、`npm run build:worker`、`npm run check:generated-worker`、PR body validation を確認します。
- 実装候補と捨てた案: fast path を全部止める案は cost 削減効果を失うため捨てました。採用案は会話本文を改善し、cost metadata を補足に下げることです。
- merge 後に通す E2E: production live E2E として Dashboard Butler で cost 相談を投げ、会話として回答しつつ Codex app-server が起動しないことを検証します。
- 次の PR を増やさない理由: この PR は regression 修正です。GitHub read / quota dashboard / automation は別 issue slice として残します。
- 停止条件: fast path が実装・調査・high-risk operation を飲み込む必要が出た場合、または gate を削る必要が出た場合は停止します。

## Dry-run Impact Report

- Target Issue: Issue #455
- Implementing Success Criteria: cost-aware fast path の conversation quality 修正、Codex 非起動維持、quality gate 非削減。
- Explicit Non-goals: GitHub read fast path 再設計、merge/deploy/reviewer gate 変更、quota API 読み取り、production deploy。
- Expected touched files/routes/workflows: `src/worker/runtime.js`、`worker.js`、`test/worker.test.js`、`docs/development-strategy/issue-455-dashboard-cost-aware-fast-path.md`。
- Affected Issues: Issue #455。
- Affected PRs: PR #759 は別 branch の open PR で、この PR では触りません。
- Affected workflows: なし。
- Affected runtime/operator surfaces: Dashboard Butler chat fast path。
- What may break if we patch narrowly: metadata を消しすぎると cost_boundary が見えなくなる。逆に metadata を前面に出すと会話品質が落ちる。
- Unknowns to investigate before coding: production live で owner が期待する文量と表示位置。
- Validation needed: worker test、build worker、generated worker check、production live E2E。
- Stop condition: fast path が owner の実装依頼を short-circuit する必要が出た場合。

## Execution Queue Delta

- Queue position before: Issue #455 の cost-aware routing follow-up として扱います。
- Preemption decision: ROOT ではなく NEXT の regression repair です。owner が「改悪」と明示したため、UI 見た目ではなく土台の cost-aware routing 品質を補正します。
- Queue delta: Issue #455 の fast path 文面 regression を進めます。
- Why this PR is next: Codex usage 削減を進めるには、fast path が owner の会話を拾う必要があります。ここを放置すると cost 削減が Butler 体験の劣化になります。
- Active Issues not downscoped: Active Issues は縮小しません。この PR で扱わない Issue #722 / Issue #590 / Issue #413 などは未完了または別 slice として残します。

## File / Line Hypotheses

- file: `src/worker/runtime.js`
  - hypothesis: `buildDashboardCostAwareFastPathReplyText` が internal metadata を主文にしているため、owner の相談に答えていない。
  - risk if changed narrowly: `cost_boundary` を消すと Issue #455 の evidence が弱くなる。
  - validation: fast path test で自然回答と metadata 補足の両方を確認する。
  - related Issue: Issue #455

## Hypothesis Retrospective

- expected: formatter の順序を直せば、Codex 非起動を維持しながら owner の質問に答えられる。
- actual: `node --test test/worker.test.js` で app-server 非起動と自然回答を確認しました。
- mismatch: なし。
- lesson: fast path は owner-facing 会話の代替ではなく、不要な Codex 起動を避ける transport boundary として扱う。
- should become RAG candidate: `decision_log` 候補。cost fast path は会話本文を先に、metadata は補足へ下げる。

## Verification Evidence

- Unit: `node --test test/worker.test.js --test-name-pattern "cost-aware lightweight owner turns|ordinary owner turns"` pass。
- Integration: 同 test で DashboardChatRoom が app-server bridge に送らず、Dashboard thread に Butler reply を保存することを確認。
- E2E: 未実施。merge / deploy 後に production Dashboard Butler で確認が必要です。
- Manual: `npm run build:worker` pass、`npm run check:generated-worker` pass。
- Evidence path/link: `test/worker.test.js` の cost-aware lightweight owner turns test。

## Butler Completion Contract

- Primary owner surface: Dashboard Butler。
- Fallback surface: Custom GPT は fallback surface であり、この PR では変更しません。
- Owner goal: cost-aware fast path でも owner の話を拾い、会話品質を落とさず Codex usage を抑える。
- Butler entrypoint: Dashboard Butler の通常チャット `owner_message`。
- Dashboard Butler natural-language path: Dashboard Butler の通常チャット入口で owner の cost / usage 相談を受け、Codex を起動せず自然文で回答する経路です。
- Action Schema exposure: 不要。この PR は Dashboard Worker runtime の chat path 修正です。
- Runtime path: DashboardChatRoom `owner_message` -> cost-aware fast path -> Dashboard chat store / broadcast。
- Runner/runtime truth: app-server bridge に送られないことを test で確認。
- Authority boundary: 未変更。merge / deploy / credential / permission は自動実行しません。
- E2E evidence: この PR スライスでは未実施。production live E2E が必要です。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: merge 後に別途 passkey approval が必要です。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: merge / deploy 後に必要です。

## Related Constitution Rules

- Butler-First Operating Principle
- Conversation UX Contract
- Evidence Discipline
- Authority Boundary
- Drift Stop Protocol

## Out-of-scope but NOT implemented

- GitHub read fast path の追加。
- reviewer / CI / E2E gate の削減。
- quota dashboard。
- deploy / merge の自動実行。

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #455
- Execution ID: local-issue-455-fast-path-human-reply
- Goal: cost-aware fast path を会話として成立させる
