### PR TITLE
Issue #637 recovery intent 検出を広げる

### DIFF
--- a/docs/development-strategy/issue-637-recovery-intent-detection.md
+++ b/docs/development-strategy/issue-637-recovery-intent-detection.md
@@ -1,0 +1,93 @@
+# Issue #637 Butler-first recovery intent detection strategy
+
+## 完了体験
+
+Dashboard Butler の main chat で owner が「app-server bridge が落ちてないか確認して」「runner のログを見て」「bridge を安全に再起動して」のように普通の日本語で相談した時、Butler は `VPS` / `root` / `sudo` / `helper` という内部語がなくても Issue #637 の VPS recovery plane として認識する。
+
+この slice の完了体験は、自然文が Worker の Dashboard chat path で VPS privileged maintenance proposal に入り、passkey approval が必要な authority boundary と `rootExecutionStarted=false` を日本語で返すこと。実 root execution は行わない。
+
+## VTDD 全体で進める部分
+
+Issue #637 は iPhone/PWA から VPS 側の runner / app-server bridge / host capability を復旧する backbone である。これまで helper、manifest、sudoers、queue handoff の足場はできたが、入口の自然文検出が内部語に寄ると owner はまた「何を言えば動くか」を覚える必要がある。
+
+今回は Issue #637 の入口だけを狭く改善し、root helper 実行や service restart の実行権限は既存 passkey/helper queue 境界に残す。
+
+## 設計
+
+`detectDashboardVpsPrivilegedMaintenanceIntent` を、`VPS` / `root` / `sudo` / `helper` だけでなく、runner / app-server bridge と復旧系 intent の組み合わせで検出できるようにする。
+
+検出対象:
+
+- app-server bridge / bridge / ブリッジ
+- runner / ランナー / 実行器
+- 状態確認 / 生存確認 / 落ちている / 止まっている / ログ / 再起動 / 復旧
+
+検出後の capability 選択は既存 `resolveDashboardVpsMaintenanceNaturalLanguagePreset` に任せる。これにより、status/logs は low risk、restart は medium risk の既存 registry boundary を再利用する。
+
+## 仮説
+
+現在の実装は、自然文検出で `lower.includes("vps")` または root/sudo/helper 系を要求している。したがって「bridge が落ちてないか確認して」「runner のログを見て」は、preset resolver 自体は対応していても、その前段で VPS maintenance flow に入らない。
+
+この仮説が正しければ、検出関数だけを改善すれば既存 proposal / approval URL / helper queue path は流用できる。
+
+狭く直さず proposal builder や helper registry まで触ると、authority boundary を変えたり Issue #637 の root execution 側まで広げたりするリスクがある。
+
+## 検証計画
+
+- `test/worker.test.js` に、`VPS` / `root` / `sudo` / `helper` を含まない app-server bridge status 自然文が proposal に入ることを追加する。
+- 既存の runner status test が壊れないことを確認する。
+- `node --test test/worker.test.js` で Worker runtime の Dashboard chat path を検証する。
+- `npm run build:worker` と `npm run check:generated-worker` で generated Worker の同期を確認する。
+- `git diff --check` で whitespace を確認する。
+
+## 改修見積もり
+
+- `src/worker/runtime.js`: `detectDashboardVpsPrivilegedMaintenanceIntent` の条件を拡張する。リスクは通常チャットの誤検出。runner/bridge と復旧語の組み合わせに限定して抑える。
+- `test/worker.test.js`: app-server bridge status の自然文テストを追加する。リスクは既存 fixture の肥大化。
+- `worker.js`: `npm run build:worker` による生成物更新。手編集しない。
+- `docs/development-strategy/issue-637-recovery-intent-detection.md`: この作戦図。
+
+## 既に通っている経路
+
+- Issue #637 の Dashboard chat -> proposal -> passkey approval URL -> helper queue path は `test/worker.test.js` に既存テストがある。
+- runner status の low-risk preset mapping は既存テストで確認されている。
+- helper queue handoff は production evidence と GitHub-visible runtime truth が Issue #637 に残っている。
+
+## 未確認の境界
+
+- production PWA で owner が内部語なしの日本語を投げた時の実機表示。
+- app-server bridge restart の実 execution は今回行わない。
+- helper queue pickup 後の live service restart / logs evidence は今回の PR では増やさない。
+
+## 穴が出そうな箇所
+
+- `bridge` という単語が通常会話にも出るため、復旧語なしでは検出しない。
+- `確認` は広い語なので、runner/bridge と組み合わせた時だけ検出する。
+- repository / relatedIssue がない場合は既存 preflight が blocked にする。今回の slice は repo-less main chat の最終仕様ではなく、自然文入口の改善に限定する。
+
+## PR 前に確認すること
+
+- branch が `origin/main` から切られていること。
+- open PR がないこと。
+- untracked `.tmp/` / `test-results/` を commit に混ぜないこと。
+- PR body に Execution Queue Delta を日本語で入れること。
+
+## 実装候補と捨てた案
+
+採用: detection 条件を拡張し、既存 preset resolver と proposal path を再利用する。
+
+捨てた案: app-server bridge 専用 route を新設する。理由は Issue #637 の helper lifecycle と重複し、authority boundary が分裂するため。
+
+捨てた案: repo-less main chat の default repository を入れる。理由は Safety Invariant の「No default repository」に反するため。
+
+## merge 後に通す E2E
+
+production deploy 後、Dashboard Butler main chat で「app-server bridge が落ちてないか確認して。Issue #637」と送る。期待値は approval_required または必要 context/config の owner-facing 日本語表示で、英語 raw error や無言待機にならないこと。
+
+## 次の PR を増やさない理由
+
+この PR は入口検出だけの狭い土台で、helper execution や restart 実行を含まない。root/helper 実行 evidence は別 PR に分ける方が authority boundary と検証が明確になる。
+
+## 停止条件
+
+検出改善だけでは proposal path に入らない、または proposal path が repository / issue / approval boundary を弱める必要があると判明した場合は停止する。deploy、root execution、credential/permission mutation が必要になった場合も停止する。

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -11726,6 +11726,31 @@ function detectDashboardVpsPrivilegedMaintenanceIntent({ text } = {}) {
   const normalized = normalizeText(text);
   if (!normalized) return false;
   const lower = normalized.toLowerCase();
+  const mentionsRecoveryTarget =
+    lower.includes("runner") ||
+    lower.includes("app-server") ||
+    lower.includes("app server") ||
+    lower.includes("bridge") ||
+    normalized.includes("ランナー") ||
+    normalized.includes("実行器") ||
+    normalized.includes("ブリッジ");
+  const mentionsRecoveryAction =
+    lower.includes("status") ||
+    lower.includes("health") ||
+    lower.includes("state") ||
+    lower.includes("logs") ||
+    lower.includes("log") ||
+    lower.includes("restart") ||
+    lower.includes("reconnect") ||
+    normalized.includes("状態") ||
+    normalized.includes("確認") ||
+    normalized.includes("生存") ||
+    normalized.includes("稼働") ||
+    normalized.includes("ログ") ||
+    normalized.includes("再起動") ||
+    normalized.includes("復旧") ||
+    normalized.includes("落ち") ||
+    normalized.includes("止ま");
   const hasVpsMaintenance =
     lower.includes("vps") &&
     (lower.includes("privileged") ||
@@ -11737,7 +11762,7 @@ function detectDashboardVpsPrivilegedMaintenanceIntent({ text } = {}) {
   const hasJapaneseMaintenance =
     (lower.includes("root") || lower.includes("sudo") || lower.includes("helper")) &&
     (normalized.includes("保守") || normalized.includes("復旧") || normalized.includes("承認"));
-  return hasVpsMaintenance || hasJapaneseMaintenance;
+  return hasVpsMaintenance || hasJapaneseMaintenance || (mentionsRecoveryTarget && mentionsRecoveryAction);
 }
 
 function buildDashboardVpsMaintenanceProposalPayload({ payload, repository, relatedIssue, env } = {}) {

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -3037,6 +3037,49 @@ test("worker maps Dashboard Butler VPS runner status text to the low-risk preset
   ]);
 });
 
+test("worker detects app-server bridge recovery intent without internal VPS helper words", async () => {
+  const store = createInMemoryDashboardChatStore();
+  const provider = createInMemoryMemoryProvider();
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/dashboard/chat/messages", {
+      method: "POST",
+      headers: gatewayAuthHeaders,
+      body: JSON.stringify({
+        threadId: "dashboard-main-unresolved",
+        repository: "marushu/vtdd-v2-p",
+        issueNumber: 637,
+        text: "app-server bridge が落ちてないか状態を確認して。"
+      })
+    }),
+    {
+      ...gatewayAuthEnv,
+      DASHBOARD_CHAT_STORE: store,
+      MEMORY_PROVIDER: provider,
+      VTDD_DASHBOARD_VPS_MAINTENANCE_HOST: "x85-131-245-163",
+      VTDD_DASHBOARD_VPS_MAINTENANCE_WORKDIR: "/home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p"
+    }
+  );
+
+  assert.equal(response.status, 202);
+  const body = await response.json();
+  assert.equal(body.ok, true);
+  assert.equal(body.execution.status, "approval_required");
+  assert.equal(body.execution.approvalScope.vpsCapabilityId, "systemd.user.app.server.bridge.status");
+  assert.equal(body.execution.approvalScope.vpsOperation, "review");
+  assert.equal(body.execution.runtimeTruth.capabilityId, "systemd.user.app.server.bridge.status");
+  assert.equal(body.execution.runtimeTruth.rootExecutionStarted, false);
+  assert.match(body.messages[1].text, /自然文 intent/);
+  assert.match(body.messages[1].text, /passkey approval が必要/);
+
+  const records = await provider.retrieve({ ids: [body.execution.vpsProposalId] });
+  const proposalRecord = records[0];
+  assert.equal(proposalRecord.content.proposal.capability.commandClass, "systemd_user_app_server_bridge_status");
+  assert.equal(proposalRecord.content.proposal.capability.riskLevel, "low");
+  assert.deepEqual(proposalRecord.content.proposal.capability.allowedArgs, [
+    "systemctl --user is-active vtdd-dashboard-app-server-bridge.service"
+  ]);
+});
+
 test("worker reports Dashboard VPS maintenance config blockers before creating a proposal", async () => {
   const store = createInMemoryDashboardChatStore();
   const provider = createInMemoryMemoryProvider();

--- a/worker.js
+++ b/worker.js
@@ -67813,9 +67813,11 @@ function detectDashboardVpsPrivilegedMaintenanceIntent({ text } = {}) {
   const normalized = normalizeText32(text);
   if (!normalized) return false;
   const lower = normalized.toLowerCase();
+  const mentionsRecoveryTarget = lower.includes("runner") || lower.includes("app-server") || lower.includes("app server") || lower.includes("bridge") || normalized.includes("\u30E9\u30F3\u30CA\u30FC") || normalized.includes("\u5B9F\u884C\u5668") || normalized.includes("\u30D6\u30EA\u30C3\u30B8");
+  const mentionsRecoveryAction = lower.includes("status") || lower.includes("health") || lower.includes("state") || lower.includes("logs") || lower.includes("log") || lower.includes("restart") || lower.includes("reconnect") || normalized.includes("\u72B6\u614B") || normalized.includes("\u78BA\u8A8D") || normalized.includes("\u751F\u5B58") || normalized.includes("\u7A3C\u50CD") || normalized.includes("\u30ED\u30B0") || normalized.includes("\u518D\u8D77\u52D5") || normalized.includes("\u5FA9\u65E7") || normalized.includes("\u843D\u3061") || normalized.includes("\u6B62\u307E");
   const hasVpsMaintenance = lower.includes("vps") && (lower.includes("privileged") || lower.includes("maintenance") || lower.includes("root") || lower.includes("sudo") || lower.includes("helper") || lower.includes("passkey"));
   const hasJapaneseMaintenance = (lower.includes("root") || lower.includes("sudo") || lower.includes("helper")) && (normalized.includes("\u4FDD\u5B88") || normalized.includes("\u5FA9\u65E7") || normalized.includes("\u627F\u8A8D"));
-  return hasVpsMaintenance || hasJapaneseMaintenance;
+  return hasVpsMaintenance || hasJapaneseMaintenance || mentionsRecoveryTarget && mentionsRecoveryAction;
 }
 function buildDashboardVpsMaintenanceProposalPayload({ payload, repository, relatedIssue, env } = {}) {
   const workingDirectory = normalizeText32(env?.VTDD_DASHBOARD_VPS_MAINTENANCE_WORKDIR);


### PR DESCRIPTION
## This PR satisfies Intent

Issue #637 の Butler-first recovery plane で、owner が `VPS` / `root` / `sudo` / `helper` という内部語を使わなくても、Dashboard Butler が app-server bridge / runner の状態確認・ログ・再起動 intent を VPS privileged maintenance path として拾えるようにします。

今回の PR は入口検出の改善です。root 実行、helper manifest 変更、sudoers 変更、deploy、credential / permission mutation は行いません。

## Satisfied Success Criteria

- Dashboard Butler の通常チャット自然文で、app-server bridge の recovery/status intent が Issue #637 の proposal path に到達する。
- low-risk status preset は既存 helper command registry に沿って `systemd_user_app_server_bridge_status` を使う。
- proposal / approval URL / runtime truth は既存 passkey boundary を維持し、`rootExecutionStarted=false` を返す。

## Unsatisfied Success Criteria

- Issue #637 全体の root-owned helper lifecycle、real execution、disable/remove/rollback、iPhone実機E2Eは未完了です。
- production deploy 後の owner-facing live E2E はこの PR では未実施です。
- repo-less main chat の repository 解決設計は Issue #613 側の本筋として残します。

## 開発前作戦図

- 作戦図 evidence: docs/development-strategy/issue-637-recovery-intent-detection.md
- 完了体験: Dashboard Butler main chat で owner が「app-server bridge が落ちてないか確認して」と言うだけで、VPS helper proposal と passkey boundary が日本語で返る。
- VTDD 全体で進める部分: Issue #637 の Butler-first recovery plane の入口を内部語依存から owner 自然文へ寄せる。
- 設計: Dashboard Butler owner-facing surface の通常チャットから、runner / app-server bridge と復旧・状態確認語の組み合わせを Issue #637 scope の recovery intent として検出し、既存 passkey boundary を保った proposal path に渡す。
- 仮説: 仮説として、preset resolver は既に app-server bridge status/log/restart を解決できるが、前段検出が `VPS` / `root` / `sudo` / `helper` に寄っているため通常の復旧相談を取り逃がしている。
- 検証計画: `node --test test/worker.test.js`、`npm run build:worker`、`npm run check:generated-worker`、`git diff --check` で自然文 path と generated worker 同期を確認する。
- 改修見積もり: `src/worker/runtime.js` の intent 検出関数、`test/worker.test.js` の Dashboard chat test、`worker.js` の generated bundle、`docs/development-strategy/issue-637-recovery-intent-detection.md`。
- 既に通っている経路: Dashboard chat -> proposal -> passkey approval URL -> helper queue は既存 #637 tests と production evidence がある。
- 未確認の境界: production PWA 実機での内部語なし prompt、helper queue pickup 後の live service status/restart/logs evidence。
- 穴が出そうな箇所: `bridge` と `確認` は広い語なので、target と action の両方を要求して誤検出を抑える。
- PR 前に確認すること: branch と origin/main、open PR、Issue #637、queue、worker test、generated worker、diff check を確認する。
- 実装候補と捨てた案: 専用 route 新設と default repository 追加は捨て、既存 #637 proposal path の検出改善を採用した。
- merge 後に通す E2E: mapped E2E として production live test で Dashboard Butler に「app-server bridge が落ちてないか確認して。Issue #637」と送り、approval_required または明示 blocker が返ることを検証する。
- 次の PR を増やさない理由: この PR は入口検出だけに scope を限定し、root/helper execution evidence は後続 PR に残すことで予測可能な権限境界の穴を同じ PR に増やさない。
- 停止条件: 検出改善だけでは proposal path に入らない、または repository / issue / approval boundary を弱める必要がある場合は停止する。

## Dry-run Impact Report

- Target Issue: Issue #637
- Implementing Success Criteria: Dashboard Butler が自然文で VPS privileged maintenance intent を理解し、root/sudo が必要な操作を owner-facing に説明できる入口部分。
- Explicit Non-goals: root/sudo 実行、helper manifest 変更、sudoers 変更、deploy、credential mutation、permission mutation、Issue #637 close。
- Expected touched files/routes/workflows: `src/worker/runtime.js`、`test/worker.test.js`、`worker.js`、`docs/development-strategy/issue-637-recovery-intent-detection.md`。
- Affected Issues: Issue #637 を進める。Issue #613 の repo-less main chat 設計は閉じない。
- Affected PRs: 新規 PR のみ。既存 open PR はありません。
- Affected workflows: `guarded-autonomy-required-checks` と `gemini-pr-review` が対象。workflow 定義は変更しない。
- Affected runtime/operator surfaces: Dashboard Butler chat の自然文検出と VPS maintenance proposal path。operator page と helper execution は変更しない。
- What may break if we patch narrowly: recovery intent を拾いすぎると通常会話が approval_required になる可能性がある。target/action の組み合わせに限定して抑える。
- Unknowns to investigate before coding: production PWA 実機での prompt 表示、repo-less main chat の repository 解決は別 Issue 境界として残る。
- Validation needed: Worker unit test、generated Worker check、diff check、merge/deploy 後の production owner-facing E2E。
- Stop condition: approval boundary を弱める必要が出る、または root/helper 実行を同じ PR に入れたくなる場合は停止する。

## Execution Queue Delta

- Queue position before: Issue #590 の低情報 progress 汚染と deploy完了 thread evidence が進み、Issue #637 が Next として再開対象。
- Preemption decision: NEXT
- Queue delta: Issue #637 moves from `Next` toward `Now` for the Butler-first recovery plane natural-language entry slice.
- Why this PR is next: owner が VPS / app-server bridge / runner の復旧と可観測性を iPhone/PWA から扱いたいという本筋に戻るため。
- Active Issues not downscoped: active Issues are not downscoped; Issue #590、Issue #613、Issue #741、Issue #455 などの関連 active Issues は縮小しません。

## File / Line Hypotheses

`src/worker/runtime.js` の `detectDashboardVpsPrivilegedMaintenanceIntent` が内部語依存の入口で、`resolveDashboardVpsMaintenanceNaturalLanguagePreset` は既に app-server bridge / runner の low/medium risk preset を選べる。したがって入口検出を広げるだけで proposal path に乗るはずです。

## Hypothesis Retrospective

仮説は正しかった。`app-server bridge が落ちてないか状態を確認して。` は新規 Worker test で `systemd_user_app_server_bridge_status` proposal に入り、approval_required と `rootExecutionStarted=false` を返した。preset resolver や helper registry の変更は不要でした。

## Verification Evidence

- `node --test test/worker.test.js`: pass、265 tests
- `npm run build:worker`: pass
- `npm run check:generated-worker`: pass
- `git diff --check`: pass

## Butler Completion Contract

- Primary owner surface: Dashboard Butler
- Fallback surface: mac Codex は実装・検証補助の fallback surface。通常入口ではありません。
- Owner goal: iPhone/iPad の Dashboard Butler から runner / app-server bridge の復旧相談を自然文で始められること。
- Butler entrypoint: Dashboard Butler 通常チャット `/v2/dashboard/chat/messages`
- Dashboard Butler natural-language path: Dashboard Butler の自然文 chat entrypoint が app-server bridge / runner の復旧 intent を受け、Issue #637 proposal path に到達します。
- Action Schema exposure: 変更なし。Action Schema はこの PR の primary entrypoint ではないため、Dashboard Butler chat path の補助 surface として扱います。
- Runtime path: `buildDashboardChatTurn` -> `detectDashboardVpsPrivilegedMaintenanceIntent` -> `buildDashboardVpsPrivilegedMaintenanceNaturalLanguageFlow`
- Runner/runtime truth: proposal path は `approval_required` と `rootExecutionStarted=false` / `helperExecutionStarted=false` を返します。
- Authority boundary: passkey approval なしに root / sudo / helper execution は開始しません。
- E2E evidence: local Worker test で Dashboard chat path を確認。production PWA live E2E は merge/deploy 後に必要です。
- Completion status: incomplete

## Surface Update Checklist

- Dashboard Butler chat: 更新あり。自然文検出を改善。
- Custom GPT Action Schema: 更新なし。
- VPS runner/helper: 更新なし。
- GitHub workflow: 更新なし。
- Production deploy: この PR では未実行。
