### PR TITLE
Issue #637/#455: Butler chat intent boundary を戻す

### DIFF
--- a/docs/development-strategy/issue-637-restore-butler-chat-intent-boundary.md
+++ b/docs/development-strategy/issue-637-restore-butler-chat-intent-boundary.md
@@ -1,0 +1,97 @@
+# Issue #637 / #455 Butler chat intent boundary restore strategy
+
+## 完了体験
+
+Dashboard Butler の通常チャットで owner が VTDD の状況確認、次タスク相談、コスト相談、または一般的な開発相談をした時、Butler は会話本文を優先し、`VPS helper queue` の途中停止文言へ吸い込まない。
+
+一方で owner が明示的に `runner` / `app-server bridge` の status / logs / restart / recovery を頼んだ時だけ、Issue #637 の VPS privileged maintenance proposal path に入る。root / sudo 実行は引き続き passkey approval と helper queue boundary の内側に残す。
+
+## VTDD 全体で進める部分
+
+Issue #455 の cost-aware fast path は、軽量な status / PR / Issue /相談では Codex CLI を起動しないための土台である。これを壊して mac Codex や VPS Codex CLI に戻すのではなく、Dashboard Butler の通常会話が helper queue の blocked reply で止まる副作用だけを戻す。
+
+Issue #637 の recovery plane は必要だが、通常チャット体験を壊すと Issue #528 / #613 の Butler-first single chat が後退する。今回の slice は「自然文 maintenance intent の境界を狭くする」ことで、コスト抑制と会話品質を両立する。
+
+## 設計
+
+`detectDashboardVpsPrivilegedMaintenanceIntent` を二段階に分けて扱う。
+
+- 明示的な privileged maintenance 語: `VPS` と `privileged` / `maintenance` / `root` / `sudo` / `helper` / `passkey` の組み合わせ、または root/sudo/helper と日本語の保守/復旧/承認。
+- recovery plane 語: `runner` / `app-server bridge` / `ブリッジ` / `ランナー` があり、かつ logs / restart / reconnect / 落ちている / 止まっている / 復旧などの実運用 action がある場合。
+
+`状態` / `確認` / `稼働` だけでは広すぎるため、内部対象語と組み合わせても blocked helper reply には入れない。低リスク status 確認を実行したい場合は `status` / `health` / `is-active` / `ログ` / `再起動` / `復旧` など明示語に寄せる。
+
+blocked reply の先頭文言は、owner-facing chat で「途中で止まりました」と見えるものをやめる。代わりに、VPS maintenance request として扱ったが実行開始していないこと、足りない情報、次に必要な owner action を短く出す。
+
+## 仮説
+
+PR #761 は `bridge` / `runner` と `状態` / `確認` の組み合わせを recovery intent として拾うようにした。これにより、本来は会話本文で扱うべき「状況を確認して」「次に進めるべきタスク」系の発話が、repository / issue / config の不足で helper queue blocked reply へ進む可能性が高くなった。
+
+この仮説が正しければ、検出語を実運用 action に狭め、blocked reply の文言を通常チャットに出ても破壊的でない表現へ戻せば、cost guard と #637 recovery plane を同時に残せる。
+
+狭めずに app-server bridge や helper queue route を削除すると、iPhone/PWA-only recovery の Issue #637 そのものを壊す。逆に blocked reply だけを書き換えて検出を広いまま残すと、通常会話の誤ルーティングは残る。
+
+## 検証計画
+
+- `test/worker.test.js` に通常の「VTDD 状況 / 次タスク」相談が VPS helper execution を作らない regression test を追加する。
+- 既存の明示 `VPS helper queue` / `runner status` / `app-server bridge recovery` test が壊れないことを確認する。
+- broad な `app-server bridge が落ちてないか状態を確認して` が approval path へ入る既存 test は、明示的な `status` / `復旧` などの action 語を含む期待に更新する。
+- `node --test test/worker.test.js --test-name-pattern "VPS privileged maintenance|recovery intent|cost-aware|helper queue"` を実行する。
+- `npm run build:worker` と `npm run check:generated-worker` を実行する。
+- `git diff --check` を実行する。
+
+## 改修見積もり
+
+- `src/worker/runtime.js`: intent detection と blocked reply 文言を調整する。リスクは #637 recovery plane の入口を狭めすぎること。
+- `test/worker.test.js`: regression と既存 expectation を更新する。リスクは test 名と実際の owner-facing completion のズレ。
+- `worker.js`: `npm run build:worker` の生成物。手編集しない。
+- `docs/development-strategy/issue-637-restore-butler-chat-intent-boundary.md`: この作戦図。
+
+## 既に通っている経路
+
+- PR #749 / Issue #748 で Durable Objects mapping write burst は止まっている。
+- PR #756 / #757 / #760 は cost-aware fast path を追加し、軽量 read で Codex CLI を起動しない方向へ進めている。
+- PR #761 は internal word なしの recovery intent を広げたが、今回の owner feedback で誤検出境界を再調整する必要がある。
+
+## 未確認の境界
+
+- production PWA で owner が実際に送った文面全文。
+- Butler app-server bridge 側が、Worker の `execution=null` を受けた時に通常の app-server conversation へ進めるか。
+- Custom GPT Action Schema 側の自然文分類が同じ表現を別 path に送るか。
+
+## 穴が出そうな箇所
+
+- `確認` は日本語で非常に広い。これを recovery action に残すと、通常会話の誤検出が再発する。
+- `status` は英語では明示 action だが、日本語の `状況` と混ぜると雑談にも出るため、単独ではなく runner/bridge など対象語と組み合わせる。
+- memory provider / runtime config の不足を通常チャットに出すと owner 体験が壊れる。blocked reply は explicit maintenance path だけに出す。
+
+## PR 前に確認すること
+
+- `git status --short --branch` で topic branch であること。
+- PR #761 以後の `origin/main` から分岐していること。
+- untracked `.tmp-*` / `test-results/` を混ぜないこと。
+- PR body に `Execution Queue Delta` を入れること。
+
+## 実装候補と捨てた案
+
+採用: detection を narrow に戻し、blocked reply の user-facing 破壊表現をなくす。
+
+捨てた案: PR #761 を丸ごと revert する。理由は Issue #637 の自然文 recovery 入口まで失われるため。
+
+捨てた案: #455 cost fast path を revert する。理由は Codex 使用量削減の本丸を壊し、今回の DO rows_written 教訓にも反するため。
+
+捨てた案: default repository / default issue を補完して helper queue に進める。理由は Safety Invariant の No default repository / unresolved target blocks execution に反するため。
+
+## merge 後に通す E2E
+
+production deploy 後、Dashboard Butler で「今VTDDの状況は？次に進めるべきタスクも示して。」を送る。期待値は通常の status / next task reply であり、`VPS helper queue` の blocked reply ではない。
+
+別途「app-server bridge の status を確認して。Issue #637」は passkey approval boundary へ進むことを確認する。
+
+## 次の PR を増やさない理由
+
+この PR は user-facing regression の修正であり、#637 helper lifecycle 実行や #455 usage metering の新機能を増やさない。誤検出を止めるだけなので、同じ PR にまとめる方が owner-facing 復旧として最小である。
+
+## 停止条件
+
+通常チャットへの復帰に app-server bridge / Custom GPT schema / VPS runner 側の変更が必要だと判明した場合は停止する。deploy、root execution、credential / permission mutation が必要になった場合も停止する。

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -11443,7 +11443,7 @@ async function buildDashboardVpsPrivilegedMaintenanceNaturalLanguageFlow({
     return {
       messageStatus: "blocked",
       reply: [
-        "Dashboard Butler の自然文から VPS helper queue へ進めようとしましたが、memory provider が未接続です。",
+        "VPS maintenance request として受け取りましたが、このチャットでは実行を開始していません。",
         "",
         `- 対象 repo: ${repository || "未指定"}`,
         `- 関連 Issue: ${relatedIssue ? `#${relatedIssue}` : "未指定"}`,
@@ -11737,15 +11737,12 @@ function detectDashboardVpsPrivilegedMaintenanceIntent({ text } = {}) {
   const mentionsRecoveryAction =
     lower.includes("status") ||
     lower.includes("health") ||
-    lower.includes("state") ||
+    lower.includes("is-active") ||
     lower.includes("logs") ||
     lower.includes("log") ||
     lower.includes("restart") ||
     lower.includes("reconnect") ||
-    normalized.includes("状態") ||
-    normalized.includes("確認") ||
     normalized.includes("生存") ||
-    normalized.includes("稼働") ||
     normalized.includes("ログ") ||
     normalized.includes("再起動") ||
     normalized.includes("復旧") ||
@@ -11906,7 +11903,7 @@ function buildDashboardVpsPrivilegedMaintenanceQueuedReply({ repository, related
 function buildDashboardVpsPrivilegedMaintenanceBlockedReply({ repository, relatedIssue, error, reason, issues, nextAction } = {}) {
   const issueText = Array.isArray(issues) && issues.length > 0 ? issues.join("; ") : reason || "blocked";
   const lines = [
-    "Dashboard Butler の自然文 intent から VPS helper queue へ進めようとしましたが、途中で止まりました。",
+    "VPS maintenance request として受け取りましたが、このチャットでは実行を開始していません。",
     "",
     `- 対象 repo: ${repository || "未指定"}`,
     `- 関連 Issue: ${relatedIssue ? `#${relatedIssue}` : "未指定"}`,

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -2990,6 +2990,38 @@ test("worker connects VPS privileged maintenance intent from Dashboard Butler ch
   assert.equal(queueCommentBody.includes('"handoff"'), true);
 });
 
+test("worker keeps ordinary Dashboard Butler planning chat out of VPS helper queue", async () => {
+  const store = createInMemoryDashboardChatStore();
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/dashboard/chat/messages", {
+      method: "POST",
+      headers: gatewayAuthHeaders,
+      body: JSON.stringify({
+        threadId: "dashboard-main-unresolved",
+        repository: "marushu/vtdd-v2-p",
+        issueNumber: 455,
+        text: "今VTDDの状況は？次に進めるべきタスクも示して。app-server bridge の設定も確認しながら、Butlerで進められるか教えて。"
+      })
+    }),
+    {
+      ...gatewayAuthEnv,
+      DASHBOARD_CHAT_STORE: store,
+      MEMORY_PROVIDER: createInMemoryMemoryProvider(),
+      VTDD_DASHBOARD_VPS_MAINTENANCE_HOST: "x85-131-245-163",
+      VTDD_DASHBOARD_VPS_MAINTENANCE_WORKDIR: "/home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p"
+    }
+  );
+
+  assert.equal(response.status, 202);
+  const body = await response.json();
+  assert.equal(body.ok, true);
+  assert.equal(body.execution, null);
+  assert.equal(body.messages.length, 1);
+  assert.equal(body.messages[0].role, "owner");
+  assert.doesNotMatch(JSON.stringify(body.messages), /VPS helper queue/);
+  assert.doesNotMatch(JSON.stringify(body.messages), /途中で止まりました/);
+});
+
 test("worker maps Dashboard Butler VPS runner status text to the low-risk preset", async () => {
   const store = createInMemoryDashboardChatStore();
   const provider = createInMemoryMemoryProvider();

--- a/worker.js
+++ b/worker.js
@@ -67550,7 +67550,7 @@ async function buildDashboardVpsPrivilegedMaintenanceNaturalLanguageFlow({
     return {
       messageStatus: "blocked",
       reply: [
-        "Dashboard Butler \u306E\u81EA\u7136\u6587\u304B\u3089 VPS helper queue \u3078\u9032\u3081\u3088\u3046\u3068\u3057\u307E\u3057\u305F\u304C\u3001memory provider \u304C\u672A\u63A5\u7D9A\u3067\u3059\u3002",
+        "VPS maintenance request \u3068\u3057\u3066\u53D7\u3051\u53D6\u308A\u307E\u3057\u305F\u304C\u3001\u3053\u306E\u30C1\u30E3\u30C3\u30C8\u3067\u306F\u5B9F\u884C\u3092\u958B\u59CB\u3057\u3066\u3044\u307E\u305B\u3093\u3002",
         "",
         `- \u5BFE\u8C61 repo: ${repository || "\u672A\u6307\u5B9A"}`,
         `- \u95A2\u9023 Issue: ${relatedIssue ? `#${relatedIssue}` : "\u672A\u6307\u5B9A"}`,
@@ -67814,7 +67814,7 @@ function detectDashboardVpsPrivilegedMaintenanceIntent({ text } = {}) {
   if (!normalized) return false;
   const lower = normalized.toLowerCase();
   const mentionsRecoveryTarget = lower.includes("runner") || lower.includes("app-server") || lower.includes("app server") || lower.includes("bridge") || normalized.includes("\u30E9\u30F3\u30CA\u30FC") || normalized.includes("\u5B9F\u884C\u5668") || normalized.includes("\u30D6\u30EA\u30C3\u30B8");
-  const mentionsRecoveryAction = lower.includes("status") || lower.includes("health") || lower.includes("state") || lower.includes("logs") || lower.includes("log") || lower.includes("restart") || lower.includes("reconnect") || normalized.includes("\u72B6\u614B") || normalized.includes("\u78BA\u8A8D") || normalized.includes("\u751F\u5B58") || normalized.includes("\u7A3C\u50CD") || normalized.includes("\u30ED\u30B0") || normalized.includes("\u518D\u8D77\u52D5") || normalized.includes("\u5FA9\u65E7") || normalized.includes("\u843D\u3061") || normalized.includes("\u6B62\u307E");
+  const mentionsRecoveryAction = lower.includes("status") || lower.includes("health") || lower.includes("is-active") || lower.includes("logs") || lower.includes("log") || lower.includes("restart") || lower.includes("reconnect") || normalized.includes("\u751F\u5B58") || normalized.includes("\u30ED\u30B0") || normalized.includes("\u518D\u8D77\u52D5") || normalized.includes("\u5FA9\u65E7") || normalized.includes("\u843D\u3061") || normalized.includes("\u6B62\u307E");
   const hasVpsMaintenance = lower.includes("vps") && (lower.includes("privileged") || lower.includes("maintenance") || lower.includes("root") || lower.includes("sudo") || lower.includes("helper") || lower.includes("passkey"));
   const hasJapaneseMaintenance = (lower.includes("root") || lower.includes("sudo") || lower.includes("helper")) && (normalized.includes("\u4FDD\u5B88") || normalized.includes("\u5FA9\u65E7") || normalized.includes("\u627F\u8A8D"));
   return hasVpsMaintenance || hasJapaneseMaintenance || mentionsRecoveryTarget && mentionsRecoveryAction;
@@ -67941,7 +67941,7 @@ function buildDashboardVpsPrivilegedMaintenanceQueuedReply({ repository, related
 function buildDashboardVpsPrivilegedMaintenanceBlockedReply({ repository, relatedIssue, error: error2, reason, issues, nextAction } = {}) {
   const issueText = Array.isArray(issues) && issues.length > 0 ? issues.join("; ") : reason || "blocked";
   const lines = [
-    "Dashboard Butler \u306E\u81EA\u7136\u6587 intent \u304B\u3089 VPS helper queue \u3078\u9032\u3081\u3088\u3046\u3068\u3057\u307E\u3057\u305F\u304C\u3001\u9014\u4E2D\u3067\u6B62\u307E\u308A\u307E\u3057\u305F\u3002",
+    "VPS maintenance request \u3068\u3057\u3066\u53D7\u3051\u53D6\u308A\u307E\u3057\u305F\u304C\u3001\u3053\u306E\u30C1\u30E3\u30C3\u30C8\u3067\u306F\u5B9F\u884C\u3092\u958B\u59CB\u3057\u3066\u3044\u307E\u305B\u3093\u3002",
     "",
     `- \u5BFE\u8C61 repo: ${repository || "\u672A\u6307\u5B9A"}`,
     `- \u95A2\u9023 Issue: ${relatedIssue ? `#${relatedIssue}` : "\u672A\u6307\u5B9A"}`,


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #637 の自然文 recovery intent を残しつつ、通常の Dashboard Butler planning chat が VPS helper queue の blocked reply へ誤ルーティングされないように境界を戻します。
- Issue #455 の cost-aware fast path は残し、軽量相談で Codex / helper 実行を起動しない方針を守ります。

## Satisfied Success Criteria

- Dashboard Butler の通常チャットで、VTDD 状況 / 次タスク相談が `execution=null` の軽量 chat turn として保存され、VPS helper queue に進まない regression test を追加しました。
- `runner` / `app-server bridge` の明示的な status / logs / restart / recovery intent は、既存 Issue #637 proposal / passkey boundary path に残しました。
- helper blocked reply の owner-facing 先頭文言から、問題の `途中で止まりました` 表現を削除しました。
- Worker source と generated `worker.js` を同期しました。

## Unsatisfied Success Criteria

- Issue #637 全体の helper lifecycle / live root execution / VPS runner pickup E2E は、このPRでは未完了です。
- Issue #455 全体の Codex 使用量可視化 / throttle / duplicate reviewer 抑止は、このPRでは未完了です。
- production deploy 後の live Butler E2E は未実施です。

## Non-goal violations

None.

## 開発前作戦図

- 作戦図 evidence: `docs/development-strategy/issue-637-restore-butler-chat-intent-boundary.md`
- 完了体験: 通常の Butler 状況相談は helper queue blocked reply に吸い込まれず、明示的な VPS recovery request だけが #637 path に入る。
- VTDD 全体で進める部分: #455 の cost-aware fast path と #637 の recovery plane を両立させる user-facing boundary restore。
- 設計: Dashboard Butler の通常チャット入口と VPS maintenance 境界を分け、`確認` / `状態` だけでは VPS maintenance intent にせず、`status` / `health` / `logs` / `restart` / `復旧` / `落ち` / `止ま` など実運用 action 語に狭める。
- 仮説: PR #761 の intent 拡張が原因で、通常会話を helper blocked reply へ吸い込む副作用を生んだと疑った。
- 検証計画: worker chat path の regression test、既存 #637 helper path test、generated worker check を通す。
- 改修見積もり: `src/worker/runtime.js`, `test/worker.test.js`, `worker.js`, 作戦図。
- 既に通っている経路: PR #749 の DO write burst fix、PR #756/#757/#760 の cost-aware fast path、PR #761 の recovery intent entrance。
- 未確認の境界: production PWA live E2E、Custom GPT Action Schema 側分類、app-server bridge が `execution=null` を通常会話へ進める live behavior。
- 穴が出そうな箇所: 日本語の `確認` は広すぎるため、復旧 intent に残すと再発する。
- PR 前に確認すること: topic branch と origin/main 最新を確認し、Issue #637 / Issue #455 / PR #761 の source を読み、worker test / generated worker check / git diff --check を検証し、untracked を混ぜないことを確認する。
- 実装候補と捨てた案: PR #761 丸ごと revert は捨て、検出境界と文言だけ戻す。
- merge 後に通す E2E: production live E2E として「今VTDDの状況は？次に進めるべきタスクも示して。」が helper queue blocked reply にならないことを Dashboard Butler で検証する。
- 次の PR を増やさない理由: user-facing regression の最小復旧であり、新しい helper capability や usage metering を増やさない。
- 停止条件: deploy、root execution、credential / permission mutation が必要になったら停止する。

## Dry-run Impact Report

- Target Issue: Issue #637 / Issue #455
- Implementing Success Criteria: #637 の自然文 intent 境界を維持しつつ誤検出を止める。#455 の軽量相談 fast path を壊さない。
- Explicit Non-goals: deploy、root/sudo 実行、helper queue pickup、credential/permission mutation、DO rows_written fix の変更。
- Expected touched files/routes/workflows: `src/worker/runtime.js`, `test/worker.test.js`, `worker.js`, `docs/development-strategy/issue-637-restore-butler-chat-intent-boundary.md`
- Affected Issues: #637, #455, #528, #613
- Affected PRs: PR #761 の後続 regression fix。PR #749 / #756 / #757 / #760 は方針として保持。
- Affected workflows: GitHub Actions tests / generated worker check。deploy workflow はこのPRでは起動しない。
- Affected runtime/operator surfaces: Dashboard Butler chat Worker path、VPS privileged maintenance proposal path。
- What may break if we patch narrowly: recovery intent を狭めすぎると、本当に bridge / runner を見たい自然文が helper path に入らない。
- Unknowns to investigate before coding: production PWA で owner が送った文面全文、Custom GPT Action Schema 分類。
- Validation needed: Worker unit/integration test、generated worker check、merge/deploy 後の production Butler live E2E。
- Stop condition: app-server bridge / schema / VPS runner 側変更が必要になった場合はこのPRで広げない。

## Execution Queue Delta

- Queue position before: Issue #590 が durable queue 上の Now だが、Dashboard Butler の通常会話が止まる regression は #637/#455 の ROOT-class recovery として割り込み扱い。
- Preemption decision: ROOT
- Queue delta: Issue #637 / Issue #455 にまたがる user-facing regression を bounded slice として先に直す。Issue #590 は downscope せず `Now` に戻る。
- Why this PR is next: Butler から次作業へ進める入口が helper blocked reply で壊れると、VTDD の iPhone/iPad-first 操作中心そのものが止まるため。
- Active Issues not downscoped: Active Issues は縮小しない。このPRで扱わない #590 / #528 / #613 / #637 残件は未完了として残す。

## File / Line Hypotheses

- file: `src/worker/runtime.js`
  - hypothesis: `detectDashboardVpsPrivilegedMaintenanceIntent` が `確認` / `状態` を広く拾りすぎ、通常チャットを #637 helper path へ送っている。
  - risk if changed narrowly: 明示的な bridge / runner recovery が拾えなくなる。
  - validation: ordinary planning chat は `execution=null`、明示 helper/status/recovery tests は pass。
  - related Issue: #637 / #455
- file: `test/worker.test.js`
  - hypothesis: regression test がないため、通常チャットの誤ルーティングが再発した。
  - risk if changed narrowly: test が synthetic すぎると production 文面を守れない。
  - validation: owner 報告に近い VTDD 状況 / 次タスク相談を含める。
  - related Issue: #637 / #455

## Hypothesis Retrospective

- expected: `確認` / `状態` を外すと、通常 chat は helper queue に入らず、明示 status/log/restart/recovery は維持される。
- actual: `node --test test/worker.test.js --test-name-pattern "VPS privileged maintenance|recovery intent|helper queue|ordinary Dashboard Butler planning chat|Dashboard VPS maintenance config"` で 266 tests pass。
- mismatch: Node test pattern は広く一致し、worker 全体が実行された。
- lesson: cost-aware path は通常会話を helper blocked reply へ逃がさない regression test とセットで進める必要がある。
- should become RAG candidate: yes。通常チャットの軽量化は helper/runner path への誤ルーティングを避ける境界と同時に記録する。

## Verification Evidence

- Unit: `node --test test/worker.test.js --test-name-pattern "VPS privileged maintenance|recovery intent|helper queue|ordinary Dashboard Butler planning chat|Dashboard VPS maintenance config"` -> pass 266 / fail 0
- Integration: `npm run check:generated-worker` -> pass
- E2E: 未実施。production deploy 後に Dashboard Butler live E2E が必要。
- Manual: `git diff --check` -> pass
- Evidence path/link: `docs/development-strategy/issue-637-restore-butler-chat-intent-boundary.md`

## Butler Completion Contract

- Primary owner surface: Dashboard Butler。
- Fallback surface: mac Codex は今回の bootstrap/debug surface。主経路ではありません。
- Owner goal: Butler が通常相談で helper queue blocked reply に止まらず、必要な時だけ #637 recovery path に入る。
- Butler entrypoint: `/v2/dashboard/chat/messages`
- Dashboard Butler natural-language path: Dashboard Butler の自然文 / 通常チャット入口では通常 planning chat を `execution=null` として受け、明示 VPS recovery intent だけ既存 proposal / approval path に到達させる。
- Action Schema exposure: 変更なし。
- Runtime path: Worker Dashboard chat path の intent detection。
- Runner/runtime truth: regression test で `execution=null`、既存 helper path test で `approval_required` / `queued_for_vps_helper_execution`。
- Authority boundary: 変更なし。root/sudo 実行は passkey approval なしに開始しない。
- E2E evidence: 未実施。deploy 後に production Butler で確認する。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: このPRだけでは未実施。merge 後に passkey approval が必要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: merge/deploy 後に必要。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate
- AGENTS.md Butler-First Operating Principle
- AGENTS.md Drift Stop Protocol
- AGENTS.md 開発前作戦図 Gate
- docs/butler/execution-queue-contract.md
- docs/butler/intent-mode-contract.md

## Out-of-scope but NOT implemented

- Issue #637 の helper lifecycle 全体完了
- Issue #455 の Codex 使用量可視化全体
- production deploy
- Issue closure

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #637 / Issue #455
- Execution ID: issue637-455-restore-butler-chat-intent-boundary
- Goal: Restore Dashboard Butler chat intent boundary after cost-aware / recovery-intent regression.
