### PR TITLE
Issue #637 復旧提案の表示を読みやすくする

### DIFF
--- a/docs/development-strategy/issue-637-owner-facing-recovery-proposal.md
+++ b/docs/development-strategy/issue-637-owner-facing-recovery-proposal.md
@@ -1,0 +1,80 @@
+# Issue #637 owner-facing recovery proposal strategy
+
+## 完了体験
+
+Dashboard Butler で owner が明示的に `runner status` や `app-server bridge status` を頼んだ時、返答は `VPS privileged maintenance proposal` / `helper queue` という内部語中心ではなく、何を確認しようとしているか、risk は何か、承認なしでは実行していないこと、次に owner が開く承認 URL が何かを日本語で読める。
+
+通常の状況相談は PR #762 の境界通り、VPS maintenance path に吸い込まない。
+
+## VTDD 全体で進める部分
+
+Issue #637 は iPhone/PWA から VPS runner / app-server bridge / helper recovery を扱う土台である。入口の自然文検出だけでなく、owner-facing 表示が内部構造を押し付けると、実際の運用で「何が起きるのか」が分からないまま passkey を求める体験になる。
+
+今回は実行能力を増やさず、明示的 recovery intent に対する説明を owner-facing にする。
+
+## 設計
+
+`buildDashboardVpsPrivilegedMaintenanceApprovalRequiredReply` で proposal の capability / approvalScope / runtimeTruth から以下を表示する。
+
+- 対象 repo / Issue
+- 確認対象 capability title
+- operation / risk
+- approval URL
+- `rootExecutionStarted=false` / `helperExecutionStarted=false`
+- 承認後も queue 化までであり、VPS runner の完了 truth まで live 実行完了とは扱わないこと
+
+queued reply も `helper execution queue` を前面に出すのではなく、「VPS runner へ復旧依頼を渡した」と説明する。
+
+## 仮説
+
+現在の実装は機能上は proposal に到達しているが、返信が内部語中心で owner には分かりにくい。表示文言だけを直せば、authority boundary と runtime path を変えずに UX を改善できる。
+
+## 検証計画
+
+- `test/worker.test.js` の Issue #637 関連 test で approval_required reply が owner-facing 文言、operation、risk、実行未開始を含むことを確認する。
+- queue reply が owner-facing 文言で、runtime truth はこれまで通り `rootExecutionStarted=false` / `helperExecutionStarted=false` を含むことを確認する。
+- `node --test test/worker.test.js --test-name-pattern "VPS privileged maintenance|VPS runner status|recovery intent|helper queue"` を実行する。
+- `npm run build:worker`、`npm run check:generated-worker`、`git diff --check` を実行する。
+
+## 改修見積もり
+
+- `src/worker/runtime.js`: approval_required / queued reply builder の文言を変更する。risk は tests の既存期待とのズレ。
+- `test/worker.test.js`: owner-facing 文言の期待値を追加する。risk は文言を固定しすぎること。
+- `worker.js`: `npm run build:worker` の生成物。
+- `docs/development-strategy/issue-637-owner-facing-recovery-proposal.md`: この作戦図。
+
+## 既に通っている経路
+
+PR #762 で通常チャットを VPS helper path に吸い込まない regression test がある。Issue #637 の proposal / approval URL / queue handoff test も既にある。
+
+## 未確認の境界
+
+production PWA での実際の表示確認、passkey 承認後の live runner pickup、status/logs の実 command output 表示は未確認。
+
+## 穴が出そうな箇所
+
+文言を owner-facing にしすぎて authority boundary が弱く見えると危険。必ず「承認なしに実行していない」「承認後も完了 truth ではない」を残す。
+
+## PR 前に確認すること
+
+latest `origin/main` から branch を切ること、PR #762 の regression を壊さないこと、untracked `.tmp/` / `test-results/` を混ぜないこと、PR body は日本語-first にすること。
+
+## 実装候補と捨てた案
+
+採用: reply builder の owner-facing 表示だけを改善する。
+
+捨てた案: low-risk status を passkey なしで即実行する。Issue #637 の authority boundary を変えるため、この PR では扱わない。
+
+捨てた案: #455 fast path を再導入/削除する。通常会話と recovery proposal の文言改善とは別問題。
+
+## merge 後に通す E2E
+
+production deploy 後、Dashboard Butler で `app-server bridge status を確認して。Issue #637` を送り、返答が owner-facing proposal になり、通常の状況相談は VPS maintenance path に吸い込まれないことを確認する。
+
+## 次の PR を増やさない理由
+
+この PR は表示の最小改善で、execution / passkey / helper queue の仕様変更を含まない。次の PR で status/logs 実行 truth を扱う場合も、今回の文言改善が前提になる。
+
+## 停止条件
+
+文言改善だけで authority boundary が弱くなる、または low-risk 実行 semantics を変える必要が出た場合は停止する。deploy、root execution、credential / permission mutation が必要になった場合も停止する。

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -11870,30 +11870,38 @@ function buildDashboardVpsMaintenanceManifest({ helperRequest, now } = {}) {
 }
 
 function buildDashboardVpsPrivilegedMaintenanceApprovalRequiredReply({ repository, relatedIssue, proposal } = {}) {
+  const capability = proposal?.proposal?.capability || {};
+  const scope = proposal?.approvalScope || {};
+  const title = normalizeText(capability.title) || normalizeText(scope.vpsCapabilityId) || "VPS maintenance capability";
+  const operation = normalizeText(scope.vpsOperation || proposal?.proposal?.operation) || "review";
+  const riskLevel = normalizeText(capability.riskLevel) || "unknown";
   return [
-    "Dashboard Butler の自然文 intent から VPS privileged maintenance proposal まで到達しました。",
+    "VPS 復旧・保守の確認リクエストとして受け取りました。",
     "",
     `- 対象 repo: ${repository || "未指定"}`,
     `- 関連 Issue: ${relatedIssue ? `#${relatedIssue}` : "未指定"}`,
+    `- 確認対象: ${title}`,
+    `- 操作: ${operation}`,
+    `- risk: ${riskLevel}`,
     `- vpsProposalId: ${proposal?.vpsProposalId || "未作成"}`,
-    "- authority: passkey approval が必要です。承認なしに root / sudo 実行は開始しません。",
-    "- runtime truth: status=approval_required, rootExecutionStarted=false",
+    "- authority: scoped passkey approval が必要です。承認なしに root / sudo / helper 実行は開始しません。",
+    "- runtime truth: status=approval_required, rootExecutionStarted=false, helperExecutionStarted=false",
     proposal?.approvalOperatorUrl ? `- approval URL: ${proposal.approvalOperatorUrl}` : "- approval URL: 未生成",
     "",
-    "承認後、Dashboard Butler はこの同じ自然文フローから helper request / execution handoff / VPS runner queue へ進めます。"
+    "承認後は VPS runner へ復旧依頼を渡します。VPS runner の完了 truth が戻るまで、live 実行完了とは扱いません。"
   ].join("\n");
 }
 
 function buildDashboardVpsPrivilegedMaintenanceQueuedReply({ repository, relatedIssue, queue } = {}) {
   const execution = queue?.execution || {};
   return [
-    "Dashboard Butler の自然文 intent から VPS helper execution queue まで到達しました。",
+    "VPS runner へ復旧依頼を渡しました。",
     "",
     `- 対象 repo: ${repository || execution.repository || "未指定"}`,
     `- 関連 Issue: ${relatedIssue ? `#${relatedIssue}` : execution.issueNumber ? `#${execution.issueNumber}` : "未指定"}`,
     `- executionId: ${execution.executionId || "未生成"}`,
     `- queueCommentUrl: ${execution.queueCommentUrl || "未取得"}`,
-    "- authority: passkey approval 済みの helper handoff だけを queue 化しました。",
+    "- authority: passkey approval 済みの bounded handoff だけを queue 化しました。",
     "- runtime truth: status=queued_for_vps_helper_execution, rootExecutionStarted=false, helperExecutionStarted=false",
     "",
     "VPS runner pickup の完了 truth が戻るまで、live root 実行完了とは扱いません。"

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -2907,9 +2907,12 @@ test("worker connects VPS privileged maintenance intent from Dashboard Butler ch
   assert.equal(body.execution.runtimeTruth.helperQueueReached, false);
   assert.equal(body.messages[1].role, "butler");
   assert.equal(body.messages[1].status, "blocked");
-  assert.match(body.messages[1].text, /自然文 intent/);
+  assert.match(body.messages[1].text, /VPS 復旧・保守の確認リクエスト/);
+  assert.match(body.messages[1].text, /確認対象: Playwright Chromium dependency install/);
+  assert.match(body.messages[1].text, /操作: add/);
+  assert.match(body.messages[1].text, /risk: high/);
   assert.match(body.messages[1].text, /approval_required/);
-  assert.match(body.messages[1].text, /rootExecutionStarted=false/);
+  assert.match(body.messages[1].text, /rootExecutionStarted=false, helperExecutionStarted=false/);
   assert.match(body.messages[1].text, /approval URL/);
   const approvalUrl = new URL(body.execution.approvalOperatorUrl);
   assert.equal(approvalUrl.searchParams.get("dashboardThreadId"), "dashboard-main-marushu-vtdd-v2-p");
@@ -2979,8 +2982,8 @@ test("worker connects VPS privileged maintenance intent from Dashboard Butler ch
   assert.equal(approvedBody.execution.runtimeTruth.helperExecutionStarted, false);
   assert.equal(approvedBody.messages[1].role, "butler");
   assert.equal(approvedBody.messages[1].status, "sent");
-  assert.match(approvedBody.messages[1].text, /自然文 intent/);
-  assert.match(approvedBody.messages[1].text, /helper execution queue/);
+  assert.match(approvedBody.messages[1].text, /VPS runner へ復旧依頼を渡しました/);
+  assert.match(approvedBody.messages[1].text, /bounded handoff/);
   assert.match(approvedBody.messages[1].text, /rootExecutionStarted=false/);
   assert.equal(githubCalls.length, 1);
   const queueCommentBody = JSON.parse(githubCalls[0].init.body).body;
@@ -3059,6 +3062,10 @@ test("worker maps Dashboard Butler VPS runner status text to the low-risk preset
   assert.equal(body.execution.approvalScope.vpsOperation, "review");
   assert.equal(body.execution.runtimeTruth.capabilityId, "systemd.user.runner.status");
   assert.equal(body.execution.runtimeTruth.rootExecutionStarted, false);
+  assert.match(body.messages[1].text, /確認対象: Check VTDD runner user service status/);
+  assert.match(body.messages[1].text, /操作: review/);
+  assert.match(body.messages[1].text, /risk: low/);
+  assert.match(body.messages[1].text, /承認なしに root \/ sudo \/ helper 実行は開始しません/);
 
   const records = await provider.retrieve({ ids: [body.execution.vpsProposalId] });
   const proposalRecord = records[0];
@@ -3100,8 +3107,11 @@ test("worker detects app-server bridge recovery intent without internal VPS help
   assert.equal(body.execution.approvalScope.vpsOperation, "review");
   assert.equal(body.execution.runtimeTruth.capabilityId, "systemd.user.app.server.bridge.status");
   assert.equal(body.execution.runtimeTruth.rootExecutionStarted, false);
-  assert.match(body.messages[1].text, /自然文 intent/);
-  assert.match(body.messages[1].text, /passkey approval が必要/);
+  assert.match(body.messages[1].text, /VPS 復旧・保守の確認リクエスト/);
+  assert.match(body.messages[1].text, /確認対象: Check Dashboard app-server bridge status/);
+  assert.match(body.messages[1].text, /操作: review/);
+  assert.match(body.messages[1].text, /risk: low/);
+  assert.match(body.messages[1].text, /scoped passkey approval が必要/);
 
   const records = await provider.retrieve({ ids: [body.execution.vpsProposalId] });
   const proposalRecord = records[0];

--- a/worker.js
+++ b/worker.js
@@ -67910,29 +67910,37 @@ function buildDashboardVpsMaintenanceManifest({ helperRequest, now } = {}) {
   };
 }
 function buildDashboardVpsPrivilegedMaintenanceApprovalRequiredReply({ repository, relatedIssue, proposal } = {}) {
+  const capability = proposal?.proposal?.capability || {};
+  const scope = proposal?.approvalScope || {};
+  const title = normalizeText32(capability.title) || normalizeText32(scope.vpsCapabilityId) || "VPS maintenance capability";
+  const operation = normalizeText32(scope.vpsOperation || proposal?.proposal?.operation) || "review";
+  const riskLevel = normalizeText32(capability.riskLevel) || "unknown";
   return [
-    "Dashboard Butler \u306E\u81EA\u7136\u6587 intent \u304B\u3089 VPS privileged maintenance proposal \u307E\u3067\u5230\u9054\u3057\u307E\u3057\u305F\u3002",
+    "VPS \u5FA9\u65E7\u30FB\u4FDD\u5B88\u306E\u78BA\u8A8D\u30EA\u30AF\u30A8\u30B9\u30C8\u3068\u3057\u3066\u53D7\u3051\u53D6\u308A\u307E\u3057\u305F\u3002",
     "",
     `- \u5BFE\u8C61 repo: ${repository || "\u672A\u6307\u5B9A"}`,
     `- \u95A2\u9023 Issue: ${relatedIssue ? `#${relatedIssue}` : "\u672A\u6307\u5B9A"}`,
+    `- \u78BA\u8A8D\u5BFE\u8C61: ${title}`,
+    `- \u64CD\u4F5C: ${operation}`,
+    `- risk: ${riskLevel}`,
     `- vpsProposalId: ${proposal?.vpsProposalId || "\u672A\u4F5C\u6210"}`,
-    "- authority: passkey approval \u304C\u5FC5\u8981\u3067\u3059\u3002\u627F\u8A8D\u306A\u3057\u306B root / sudo \u5B9F\u884C\u306F\u958B\u59CB\u3057\u307E\u305B\u3093\u3002",
-    "- runtime truth: status=approval_required, rootExecutionStarted=false",
+    "- authority: scoped passkey approval \u304C\u5FC5\u8981\u3067\u3059\u3002\u627F\u8A8D\u306A\u3057\u306B root / sudo / helper \u5B9F\u884C\u306F\u958B\u59CB\u3057\u307E\u305B\u3093\u3002",
+    "- runtime truth: status=approval_required, rootExecutionStarted=false, helperExecutionStarted=false",
     proposal?.approvalOperatorUrl ? `- approval URL: ${proposal.approvalOperatorUrl}` : "- approval URL: \u672A\u751F\u6210",
     "",
-    "\u627F\u8A8D\u5F8C\u3001Dashboard Butler \u306F\u3053\u306E\u540C\u3058\u81EA\u7136\u6587\u30D5\u30ED\u30FC\u304B\u3089 helper request / execution handoff / VPS runner queue \u3078\u9032\u3081\u307E\u3059\u3002"
+    "\u627F\u8A8D\u5F8C\u306F VPS runner \u3078\u5FA9\u65E7\u4F9D\u983C\u3092\u6E21\u3057\u307E\u3059\u3002VPS runner \u306E\u5B8C\u4E86 truth \u304C\u623B\u308B\u307E\u3067\u3001live \u5B9F\u884C\u5B8C\u4E86\u3068\u306F\u6271\u3044\u307E\u305B\u3093\u3002"
   ].join("\n");
 }
 function buildDashboardVpsPrivilegedMaintenanceQueuedReply({ repository, relatedIssue, queue } = {}) {
   const execution = queue?.execution || {};
   return [
-    "Dashboard Butler \u306E\u81EA\u7136\u6587 intent \u304B\u3089 VPS helper execution queue \u307E\u3067\u5230\u9054\u3057\u307E\u3057\u305F\u3002",
+    "VPS runner \u3078\u5FA9\u65E7\u4F9D\u983C\u3092\u6E21\u3057\u307E\u3057\u305F\u3002",
     "",
     `- \u5BFE\u8C61 repo: ${repository || execution.repository || "\u672A\u6307\u5B9A"}`,
     `- \u95A2\u9023 Issue: ${relatedIssue ? `#${relatedIssue}` : execution.issueNumber ? `#${execution.issueNumber}` : "\u672A\u6307\u5B9A"}`,
     `- executionId: ${execution.executionId || "\u672A\u751F\u6210"}`,
     `- queueCommentUrl: ${execution.queueCommentUrl || "\u672A\u53D6\u5F97"}`,
-    "- authority: passkey approval \u6E08\u307F\u306E helper handoff \u3060\u3051\u3092 queue \u5316\u3057\u307E\u3057\u305F\u3002",
+    "- authority: passkey approval \u6E08\u307F\u306E bounded handoff \u3060\u3051\u3092 queue \u5316\u3057\u307E\u3057\u305F\u3002",
     "- runtime truth: status=queued_for_vps_helper_execution, rootExecutionStarted=false, helperExecutionStarted=false",
     "",
     "VPS runner pickup \u306E\u5B8C\u4E86 truth \u304C\u623B\u308B\u307E\u3067\u3001live root \u5B9F\u884C\u5B8C\u4E86\u3068\u306F\u6271\u3044\u307E\u305B\u3093\u3002"


### PR DESCRIPTION
## This PR satisfies Intent

Issue #637 の Dashboard Butler recovery proposal 表示を、内部語中心から owner-facing な日本語に直します。

明示的に `runner status` / `app-server bridge status` などを頼んだ時、Butler は「何を確認するのか」「operation / risk は何か」「承認なしには実行していないこと」「承認後も VPS runner の完了 truth までは完了扱いしないこと」をチャットで読める形にします。

## Satisfied Success Criteria

- Dashboard Butler が自然文で VPS privileged maintenance intent を理解した後、owner-facing に対象・operation・risk・承認境界を説明する。
- approval_required reply は `rootExecutionStarted=false` / `helperExecutionStarted=false` を明示する。
- queued reply は「VPS runner へ復旧依頼を渡した」と説明し、live 実行完了とは扱わない。

## Unsatisfied Success Criteria

- Issue #637 全体の root-owned helper lifecycle、real execution、disable/remove/rollback、iPhone実機E2Eは未完了です。
- low-risk status/logs を passkey なしで即実行する仕様変更は未実装です。
- production PWA live E2E は merge/deploy 後に必要です。

## 開発前作戦図

- 作戦図 evidence: docs/development-strategy/issue-637-owner-facing-recovery-proposal.md
- 完了体験: Dashboard Butler で owner が明示的 recovery intent を送ると、対象・operation・risk・承認境界・実行未開始が日本語で読める。
- VTDD 全体で進める部分: Issue #637 の iPhone/PWA recovery plane を、owner が判断できる表示に寄せる。
- 設計: Dashboard Butler owner-facing surface の reply builder で proposal capability と approvalScope を読み、対象、operation、risk、approval URL、runtime truth を表示する設計。
- 仮説: 仮説として、現状の機能は proposal に到達しているが、返信が `VPS privileged maintenance proposal` / `helper queue` 中心で owner には分かりにくい。
- 検証計画: `node --test test/worker.test.js`、関連 test name pattern、`npm run build:worker`、`npm run check:generated-worker`、`git diff --check` で確認する。
- 改修見積もり: `src/worker/runtime.js` の approval_required / queued reply builder、`test/worker.test.js` の期待値、`worker.js` の generated bundle、`docs/development-strategy/issue-637-owner-facing-recovery-proposal.md`。
- 既に通っている経路: PR #762 で通常チャットを VPS helper path に吸い込まない regression test があり、#637 の proposal / approval URL / queue handoff test もある。
- 未確認の境界: production PWA 表示、passkey 承認後の live runner pickup、status/logs の実 command output 表示は未確認。
- 穴が出そうな箇所: owner-facing に寄せすぎて authority boundary が弱く見えると危険なので、承認なしには実行していないことを必ず残す。
- PR 前に確認すること: latest `origin/main`、PR #762 regression、worker test、generated worker、diff check、未追跡 `.tmp/` / `test-results/` の除外を確認する。
- 実装候補と捨てた案: reply builder の owner-facing 表示だけを改善する案を採用し、low-risk status の即実行は authority semantics が変わるため捨てた。
- merge 後に通す E2E: production live test で `app-server bridge status を確認して。Issue #637` を送り、owner-facing proposal と通常相談の誤吸い込みなしを検証する。
- 次の PR を増やさない理由: この PR は表示改善だけに scope を限定し、execution / passkey / helper semantics を増やさないため、予測可能な後続実行 PR と分けられる。
- 停止条件: 文言改善だけで authority boundary が弱くなる、または low-risk 実行 semantics を変える必要が出た場合は停止する。

## Dry-run Impact Report

- Target Issue: Issue #637
- Implementing Success Criteria: Dashboard Butler が自然文で VPS privileged maintenance intent を理解し、owner-facing に説明できる表示部分。
- Explicit Non-goals: root/sudo 実行、helper queue 実行、approval 境界変更、#455 fast path 再設計、deploy、credential mutation、permission mutation。
- Expected touched files/routes/workflows: `src/worker/runtime.js`、`test/worker.test.js`、`worker.js`、`docs/development-strategy/issue-637-owner-facing-recovery-proposal.md`。
- Affected Issues: Issue #637 を進める。Issue #455 と Issue #613 は完了扱いしない。
- Affected PRs: 新規 PR のみ。PR #762 の通常チャット regression 境界を維持する。
- Affected workflows: `guarded-autonomy-required-checks` と `gemini-pr-review`。workflow 定義は変更しない。
- Affected runtime/operator surfaces: Dashboard Butler chat の #637 approval_required / queued reply。operator page と helper execution は変更しない。
- What may break if we patch narrowly: 文言期待テストと実際の owner-facing 表示がズレる可能性がある。authority boundary は維持する。
- Unknowns to investigate before coding: production PWA 実機表示と passkey 後の live runner pickup は別途確認が必要。
- Validation needed: Worker unit test、generated Worker check、diff check、merge/deploy 後の production owner-facing E2E。
- Stop condition: low-risk 実行 semantics、deploy、root/helper execution、credential/permission mutation が必要になった場合は停止する。

## Execution Queue Delta

- Queue position before: Issue #637 が Butler-first VPS recovery plane の Next/Now 候補で、PR #762 が通常チャット誤吸い込みを戻した直後。
- Preemption decision: NEXT
- Queue delta: Issue #637 stays in `Now` for the owner-facing recovery proposal display slice.
- Why this PR is next: #637 の入口は戻ったが、approval_required 表示が内部語中心のままだと owner が判断できないため。
- Active Issues not downscoped: active Issues are not downscoped; Issue #590、Issue #455、Issue #613、Issue #741 は縮小しません。

## File / Line Hypotheses

`src/worker/runtime.js` の `buildDashboardVpsPrivilegedMaintenanceApprovalRequiredReply` と `buildDashboardVpsPrivilegedMaintenanceQueuedReply` が owner-facing 表示の主因です。ここだけを変えれば proposal / approval / queue path を変えずに UX を改善できるはずです。

## Hypothesis Retrospective

仮説は正しかった。reply builder の変更だけで、Worker test は proposal capability title、operation、risk、実行未開始 truth を含むようになり、通常チャットを helper path に吸い込まない PR #762 regression も維持できました。

## Verification Evidence

- `node --test test/worker.test.js --test-name-pattern "VPS privileged maintenance|VPS runner status|recovery intent|helper queue"`: pass、266 tests
- `node --test test/worker.test.js`: pass、266 tests
- `npm run build:worker`: pass
- `npm run check:generated-worker`: pass
- `git diff --check`: pass

## Butler Completion Contract

- Primary owner surface: Dashboard Butler
- Fallback surface: mac Codex は実装・検証補助の fallback surface。通常入口ではありません。
- Owner goal: iPhone/iPad の Dashboard Butler で VPS recovery proposal を判断できる日本語表示にすること。
- Butler entrypoint: Dashboard Butler 通常チャット `/v2/dashboard/chat/messages`
- Dashboard Butler natural-language path: Dashboard Butler の自然文 chat entrypoint が明示的 recovery intent を受け、Issue #637 proposal path に到達し、owner-facing に説明します。
- Action Schema exposure: 変更なし。Action Schema はこの PR の primary entrypoint ではありません。
- Runtime path: `buildDashboardChatTurn` -> `buildDashboardVpsPrivilegedMaintenanceNaturalLanguageFlow` -> reply builder
- Runner/runtime truth: approval_required / queued reply が `rootExecutionStarted=false` / `helperExecutionStarted=false` を表示します。
- Authority boundary: passkey approval なしに root / sudo / helper execution は開始しません。
- E2E evidence: local Worker test で Dashboard chat path を確認。production PWA live E2E は merge/deploy 後に必要です。
- Completion status: incomplete

## Surface Update Checklist

- Dashboard Butler chat: 更新あり。#637 proposal / queue 表示を owner-facing に変更。
- Custom GPT Action Schema: 更新なし。
- VPS runner/helper: 更新なし。
- GitHub workflow: 更新なし。
- Production deploy: この PR では未実行。
