### PR TITLE
Issue #455 Dashboard app-server usage profile を追加

### DIFF
--- a/docs/butler/dashboard-butler-app-server-live-path.md
+++ b/docs/butler/dashboard-butler-app-server-live-path.md
@@ -16,6 +16,19 @@ VPS Dashboard Bridge / `codex app-server` path when the bridge is connected.
 Worker-side deterministic replies must not pretend to answer as Butler or stop
 the turn only to save Codex usage.
 
+Codex usage tuning belongs on the VPS Dashboard Bridge / `codex app-server`
+side, not in Worker-side pseudo-answers. The bridge may start app-server with
+operator-provided usage profile overrides:
+
+- `VTDD_DASHBOARD_APP_SERVER_PROFILE`
+- `VTDD_DASHBOARD_APP_SERVER_MODEL`
+- `VTDD_DASHBOARD_APP_SERVER_REASONING_EFFORT`
+
+When configured, these values are passed as `codex app-server -c ...` argv
+overrides and surfaced as bridge runtime truth. They do not grant command,
+file-change, patch, merge, deploy, credential, permission, or approval authority.
+If unset, the bridge uses the normal Codex config for that VPS account.
+
 The Dashboard Butler implementation target is:
 
 ```text

--- a/docs/development-strategy/issue-455-dashboard-app-server-usage-tuning.md
+++ b/docs/development-strategy/issue-455-dashboard-app-server-usage-tuning.md
@@ -1,0 +1,97 @@
+# Issue #455 Dashboard app-server usage tuning 作戦図
+
+## 完了体験
+
+Dashboard Butler は Worker 内で AI 風に答えず、通常会話も VPS Dashboard Bridge / `codex app-server` へ中継する。そのうえで、VPS 側の `codex app-server` は operator が明示した軽量 model / reasoning effort で起動でき、Dashboard runtime truth に「この bridge はどの cost profile で動いているか」が出る。
+
+owner は iPhone/iPad から Butler を使い続ける時、Mac Codex より減り方が遅い通常会話に近い設定を VPS 側でも試せる。設定が未指定なら既存の Codex config を使い、勝手に model を決めない。
+
+## VTDD 全体で進める部分
+
+Issue #455 の「重い処理を実行する前に消費境界を示す」「VTDD 自身で使用枠を食い潰さない」部分を、Dashboard app-server bridge の起動設定に狭く接続する。
+
+PR #764 で Worker の lightweight AI 風回答は止めた。今回の slice はその方針を戻さず、VPS Codex CLI 側の起動コスト profile を制御可能にする。
+
+## 設計
+
+`scripts/run-dashboard-app-server-bridge.mjs` に app-server command args builder を追加する。既定は現在と同じ `codex app-server --listen stdio://`。環境変数で次を指定できるようにする。
+
+- `VTDD_DASHBOARD_APP_SERVER_MODEL`: `-c model="<value>"` として app-server に渡す。
+- `VTDD_DASHBOARD_APP_SERVER_REASONING_EFFORT`: `-c model_reasoning_effort="<value>"` として app-server に渡す。
+- `VTDD_DASHBOARD_APP_SERVER_PROFILE`: runtime truth の表示用 profile 名。未指定なら `default`.
+
+bridge connected event の `bridgeLifecycle.costBoundary` に profile / model configured / reasoning effort configured / Codex will start を出す。値自体は secret ではないが、runtime truth では「設定済みか」と実値を短く出すだけにし、token や grant は含めない。
+
+## 仮説
+
+いまの VPS service は `node scripts/run-dashboard-app-server-bridge.mjs` が `JsonLineAppServerClient` を既定 args で作るため、app-server は VPS の `~/.codex/config.toml` 既定 model / reasoning effort で起動する。Dashboard Butler の通常会話がすべてこの app-server に流れる設計に戻したため、VPS 側の既定が重い場合、通常会話まで高消費になる。
+
+狭く patch するなら、app-server 起動 args の明示 override だけでよい。Worker に分類回答を戻すと PR #764 の核心条件を壊すため採用しない。
+
+## 検証計画
+
+- Unit: app-server args builder が未指定時に既存 args を返す。
+- Unit: model / reasoning effort env が `-c model=...` / `-c model_reasoning_effort=...` を追加する。
+- Unit: parse args と connected event が cost profile truth を含む。
+- Integration: bridge initialization は repo sync preflight 後に configured args で app-server client を作る。
+- Local: `node --test test/dashboard-app-server-bridge.test.js`
+- Worker generated file は触らない想定。触った場合のみ `npm run build:worker` と `npm run verify:worker` を追加する。
+
+## 改修見積もり
+
+- `scripts/run-dashboard-app-server-bridge.mjs`: app-server args builder、parseBridgeArgs、runDashboardAppServerBridge、connected event に cost profile を追加。リスクは app-server CLI args のクォート不備。
+- `test/dashboard-app-server-bridge.test.js`: protocol request、args parse、client creation tests を追加・更新。リスクは既存 test fixture の期待値追加漏れ。
+- `docs/development-strategy/issue-455-dashboard-app-server-usage-tuning.md`: この作戦図。リスクなし。
+
+## 既に通っている経路
+
+- PR #764 で Dashboard Worker は cost/read の AI 風 fast path を止め、bridge 接続時は app-server に送る。
+- `codex app-server --help` で `-c key=value` config override が利用可能。
+- VPS repo は `main` / `origin/main` / `HEAD` が `d52a8f2` で一致し、bridge service は restart 後に最新 script で起動済み。
+- deploy-production run `26930927693` は `d52a8f2` で成功済み。
+
+## 未確認の境界
+
+OpenAI / ChatGPT / Codex の実際のクレジット計算は公式・runtime analytics でしか確定できない。この PR では「消費量が必ず下がる」とは言わず、operator が軽量設定を適用・観測できる足場に限定する。
+
+`model_reasoning_effort` の受理可否は Codex CLI version / account に依存し得る。app-server 起動が失敗した場合は systemd/runtime truth に明示される。既定では override しないため既存運用は壊さない。
+
+## 穴が出そうな箇所
+
+- env 値を shell 文字列ではなく argv 配列に入れないとクォート問題が出る。
+- model 名を repo に固定すると operator account 差異で壊れる。
+- connected event に full config や token を出すと情報露出になる。
+- Worker fast path を戻すと「Butler は中継機」という今回の最重要条件を壊す。
+
+## PR 前に確認すること
+
+- local branch が latest `origin/main` から切られている。
+- PR #764 deploy run が成功済み。
+- VPS service restart 後に最新 source が process に反映済み。
+- test が pass している。
+- PR body の Execution Queue Delta で Issue #455 が owner 指示によりこの slice の Now になったことを明示する。
+
+## 実装候補と捨てた案
+
+採用: app-server 起動 args を env override 可能にし、runtime truth に cost profile を出す。
+
+捨てた案: Worker で cost/read/status を回答する。Butler が AI 風に振る舞うため不採用。
+
+捨てた案: app-server に送る前に通常会話だけ別 AI API へ流す。API 課金 runner への切替であり Issue #455 の Non-goal に反する。
+
+捨てた案: model を repo 固定で軽量 model にする。operator account / plan 差異で壊れるため env 明示にする。
+
+## merge 後に通す E2E
+
+production deploy 後、VPS service env に軽量 profile を設定して bridge restart し、Dashboard Butler から短い通常会話を送る。期待値は Worker が AI 風に答えず app-server に届くこと、bridge connected runtime truth に configured profile が出ること、Codex Analytics の減り方は観測値として別途記録すること。
+
+## 次の PR を増やさない理由
+
+PR #764 で「Worker は中継機」に戻した直後の同じ Issue #455 follow-up であり、今回の変更は app-server 起動設定と tests に限定される。reviewer duplicate suppression / fallback retry throttle / queue policy は別 surface なので、この PR には混ぜない。
+
+## 停止条件
+
+- Codex app-server CLI が `-c model` / `-c model_reasoning_effort` を受けないことが確認された場合。
+- app-server bridge 以外の reviewer / runner / Worker routing へ修正が広がり始めた場合。
+- Worker AI 風 fast path の復活が必要になった場合。
+- model / billing / account semantics を公式・runtime truth なしに断定しそうになった場合。

--- a/scripts/run-dashboard-app-server-bridge.mjs
+++ b/scripts/run-dashboard-app-server-bridge.mjs
@@ -107,6 +107,42 @@ export function buildAppServerTurnStartRequest({ id, codexThreadId, text, cwd = 
   };
 }
 
+export function buildDashboardAppServerCostBoundary({
+  profile = "",
+  model = "",
+  reasoningEffort = ""
+} = {}) {
+  const normalizedProfile = normalizeBridgeText(profile) || "default";
+  const normalizedModel = normalizeBridgeText(model);
+  const normalizedReasoningEffort = normalizeBridgeText(reasoningEffort);
+  return {
+    profile: normalizedProfile,
+    codexWillStart: true,
+    appServerBridgeRequired: true,
+    modelConfigured: Boolean(normalizedModel),
+    reasoningEffortConfigured: Boolean(normalizedReasoningEffort),
+    ...(normalizedModel ? { model: normalizedModel } : {}),
+    ...(normalizedReasoningEffort ? { reasoningEffort: normalizedReasoningEffort } : {})
+  };
+}
+
+export function buildDashboardAppServerCommandArgs({
+  listen = "stdio://",
+  model = "",
+  reasoningEffort = ""
+} = {}) {
+  const args = ["app-server", "--listen", normalizeBridgeText(listen) || "stdio://"];
+  const normalizedModel = normalizeBridgeText(model);
+  const normalizedReasoningEffort = normalizeBridgeText(reasoningEffort);
+  if (normalizedModel) {
+    args.push("-c", `model=${JSON.stringify(normalizedModel)}`);
+  }
+  if (normalizedReasoningEffort) {
+    args.push("-c", `model_reasoning_effort=${JSON.stringify(normalizedReasoningEffort)}`);
+  }
+  return args;
+}
+
 export function buildDashboardTurnInputText(request = {}) {
   const ownerText = String(request.text || "").trim();
   const repository = String(request.repository || "").trim();
@@ -1596,6 +1632,9 @@ export function parseBridgeArgs(argv = process.argv.slice(2), env = process.env)
     repoSyncPreflight: env.VTDD_DASHBOARD_BRIDGE_REPO_SYNC_PREFLIGHT !== "0",
     repoSyncBaseRef: env.VTDD_DASHBOARD_BRIDGE_REPO_SYNC_BASE_REF || DEFAULT_REPO_SYNC_BASE_REF,
     sandboxMode: env.VTDD_DASHBOARD_APP_SERVER_SANDBOX || "",
+    appServerCostProfile: env.VTDD_DASHBOARD_APP_SERVER_PROFILE || "",
+    appServerModel: env.VTDD_DASHBOARD_APP_SERVER_MODEL || "",
+    appServerReasoningEffort: env.VTDD_DASHBOARD_APP_SERVER_REASONING_EFFORT || "",
     turnTimeoutMs: Number(env.VTDD_DASHBOARD_APP_SERVER_TURN_TIMEOUT_MS || DEFAULT_TURN_TIMEOUT_MS),
     activityQuietMs: Number(env.VTDD_DASHBOARD_APP_SERVER_ACTIVITY_QUIET_MS || DEFAULT_ACTIVITY_QUIET_MS),
     reconnectDelayMs: Number(env.VTDD_DASHBOARD_BRIDGE_RECONNECT_DELAY_MS || 1000),
@@ -1610,6 +1649,9 @@ export function parseBridgeArgs(argv = process.argv.slice(2), env = process.env)
     if (arg === "--repo-sync-base-ref") options.repoSyncBaseRef = argv[++index] || DEFAULT_REPO_SYNC_BASE_REF;
     if (arg === "--skip-repo-sync-preflight") options.repoSyncPreflight = false;
     if (arg === "--sandbox") options.sandboxMode = argv[++index] || "";
+    if (arg === "--app-server-cost-profile") options.appServerCostProfile = argv[++index] || "";
+    if (arg === "--app-server-model") options.appServerModel = argv[++index] || "";
+    if (arg === "--app-server-reasoning-effort") options.appServerReasoningEffort = argv[++index] || "";
     if (arg === "--turn-timeout-ms") options.turnTimeoutMs = Number(argv[++index] || DEFAULT_TURN_TIMEOUT_MS);
     if (arg === "--activity-quiet-ms") options.activityQuietMs = Number(argv[++index] || DEFAULT_ACTIVITY_QUIET_MS);
     if (arg === "--reconnect-delay-ms") options.reconnectDelayMs = Number(argv[++index] || 1000);
@@ -1643,7 +1685,27 @@ export async function runDashboardAppServerBridge(options = parseBridgeArgs()) {
     }
   }
   const endpoint = buildDashboardAppServerBridgeEndpoint(options);
-  const appServer = options.appServer || new JsonLineAppServerClient({ cwd: options.cwd });
+  const costBoundary =
+    options.costBoundary ||
+    buildDashboardAppServerCostBoundary({
+      profile: options.appServerCostProfile,
+      model: options.appServerModel,
+      reasoningEffort: options.appServerReasoningEffort
+    });
+  const appServerArgs = buildDashboardAppServerCommandArgs({
+    model: options.appServerModel,
+    reasoningEffort: options.appServerReasoningEffort
+  });
+  const appServerFactory =
+    typeof options.appServerFactory === "function"
+      ? options.appServerFactory
+      : (clientOptions) => new JsonLineAppServerClient(clientOptions);
+  const appServer =
+    options.appServer ||
+    appServerFactory({
+      cwd: options.cwd,
+      args: appServerArgs
+    });
   await appServer.initialize();
   let reconnects = 0;
   for (;;) {
@@ -1651,6 +1713,7 @@ export async function runDashboardAppServerBridge(options = parseBridgeArgs()) {
       ...options,
       endpoint,
       appServer,
+      costBoundary,
       WebSocketImpl: options.WebSocketImpl || WebSocket
     });
     if (options.reconnect === false) {
@@ -1890,7 +1953,13 @@ function runBridgeCommand(command, args, options = {}) {
   });
 }
 
-export function buildDashboardBridgeConnectedEvent({ endpoint, threadId = "", cwd = process.cwd(), resumedAt = new Date().toISOString() } = {}) {
+export function buildDashboardBridgeConnectedEvent({
+  endpoint,
+  threadId = "",
+  cwd = process.cwd(),
+  resumedAt = new Date().toISOString(),
+  costBoundary = null
+} = {}) {
   const dashboardThreadId =
     normalizeBridgeText(threadId) ||
     (() => {
@@ -1911,7 +1980,8 @@ export function buildDashboardBridgeConnectedEvent({ endpoint, threadId = "", cw
       status: "connected",
       threadId: dashboardThreadId || null,
       cwd: normalizeBridgeText(cwd) || null,
-      connectedAt: normalizeBridgeText(resumedAt) || new Date().toISOString()
+      connectedAt: normalizeBridgeText(resumedAt) || new Date().toISOString(),
+      costBoundary: costBoundary && typeof costBoundary === "object" ? costBoundary : buildDashboardAppServerCostBoundary()
     }
   };
 }
@@ -1982,6 +2052,7 @@ export async function connectDashboardAppServerBridgeOnce({
   runtimeUrl = "",
   fetchImpl = globalThis.fetch,
   mediaTmpRoot = os.tmpdir(),
+  costBoundary = null,
   WebSocketImpl = WebSocket
 } = {}) {
   const bearerProtocol = `vtdd-bearer.${Buffer.from(token, "utf8").toString("base64url")}`;
@@ -2030,7 +2101,7 @@ export async function connectDashboardAppServerBridgeOnce({
 
   socket.addEventListener("open", () => {
     scheduleHeartbeat();
-    safeSend(buildDashboardBridgeConnectedEvent({ endpoint, cwd }));
+    safeSend(buildDashboardBridgeConnectedEvent({ endpoint, cwd, costBoundary }));
   });
 
   socket.addEventListener("message", (event) => {

--- a/test/dashboard-app-server-bridge.test.js
+++ b/test/dashboard-app-server-bridge.test.js
@@ -5,6 +5,8 @@ import path from "node:path";
 import test from "node:test";
 import {
   buildDashboardAppServerBridgeEndpoint,
+  buildDashboardAppServerCommandArgs,
+  buildDashboardAppServerCostBoundary,
   buildAppServerInitializeRequest,
   buildOwnerActionRequiredPayloadForAppServerApproval,
   buildAppServerRequestApprovalResponse,
@@ -95,6 +97,31 @@ test("dashboard app-server bridge formats lifecycle resume status events", () =>
   assert.equal(connected.stage, "bridge_connected");
   assert.match(connected.text, /保存済み文脈/);
   assert.equal(connected.bridgeLifecycle.cwd, "/repo");
+  assert.deepEqual(connected.bridgeLifecycle.costBoundary, {
+    profile: "default",
+    codexWillStart: true,
+    appServerBridgeRequired: true,
+    modelConfigured: false,
+    reasoningEffortConfigured: false
+  });
+  const connectedWithCostProfile = buildDashboardBridgeConnectedEvent({
+    endpoint: "wss://runtime.example/v2/dashboard/app-server/ws?threadId=dashboard-main-unresolved",
+    cwd: "/repo",
+    costBoundary: buildDashboardAppServerCostBoundary({
+      profile: "dashboard-light-chat",
+      model: "gpt-5.3-codex-spark",
+      reasoningEffort: "low"
+    })
+  });
+  assert.deepEqual(connectedWithCostProfile.bridgeLifecycle.costBoundary, {
+    profile: "dashboard-light-chat",
+    codexWillStart: true,
+    appServerBridgeRequired: true,
+    modelConfigured: true,
+    reasoningEffortConfigured: true,
+    model: "gpt-5.3-codex-spark",
+    reasoningEffort: "low"
+  });
 
   const resumed = buildDashboardBridgeResumeStatusEvent({
     dashboardThreadId: "dashboard-main-unresolved",
@@ -121,6 +148,41 @@ test("dashboard app-server bridge formats lifecycle resume status events", () =>
   assert.equal(turnStarted.bridgeLifecycle.turnId, "turn-741");
   assert.equal(turnStarted.bridgeLifecycle.resumedExistingThread, true);
   assert.match(turnStarted.text, /復帰した Codex thread/);
+});
+
+test("dashboard app-server bridge builds optional app-server usage tuning args", () => {
+  assert.deepEqual(buildDashboardAppServerCommandArgs(), ["app-server", "--listen", "stdio://"]);
+  assert.deepEqual(
+    buildDashboardAppServerCommandArgs({
+      model: "gpt-5.3-codex-spark",
+      reasoningEffort: "low"
+    }),
+    [
+      "app-server",
+      "--listen",
+      "stdio://",
+      "-c",
+      'model="gpt-5.3-codex-spark"',
+      "-c",
+      'model_reasoning_effort="low"'
+    ]
+  );
+  assert.deepEqual(
+    buildDashboardAppServerCostBoundary({
+      profile: "dashboard-light-chat",
+      model: "gpt-5.3-codex-spark",
+      reasoningEffort: "low"
+    }),
+    {
+      profile: "dashboard-light-chat",
+      codexWillStart: true,
+      appServerBridgeRequired: true,
+      modelConfigured: true,
+      reasoningEffortConfigured: true,
+      model: "gpt-5.3-codex-spark",
+      reasoningEffort: "low"
+    }
+  );
 });
 
 test("dashboard app-server bridge runner wakeup uses only fixed user systemd start command", async () => {
@@ -2210,6 +2272,91 @@ test("dashboard app-server bridge args read runtime, token, and thread from envi
   assert.equal(parsed.activityQuietMs, 700);
   assert.equal(parsed.reconnectDelayMs, 1000);
   assert.equal(parsed.heartbeatMs, 30000);
+});
+
+test("dashboard app-server bridge args read app-server usage tuning from env and cli", () => {
+  const parsedFromEnv = parseBridgeArgs([], {
+    VTDD_RUNTIME_URL: "https://runtime.example",
+    VTDD_GATEWAY_BEARER_TOKEN: "secret-token",
+    VTDD_DASHBOARD_THREAD_ID: "dashboard-main",
+    VTDD_DASHBOARD_APP_SERVER_PROFILE: "dashboard-light-chat",
+    VTDD_DASHBOARD_APP_SERVER_MODEL: "gpt-5.3-codex-spark",
+    VTDD_DASHBOARD_APP_SERVER_REASONING_EFFORT: "low"
+  });
+  assert.equal(parsedFromEnv.appServerCostProfile, "dashboard-light-chat");
+  assert.equal(parsedFromEnv.appServerModel, "gpt-5.3-codex-spark");
+  assert.equal(parsedFromEnv.appServerReasoningEffort, "low");
+
+  const parsedFromCli = parseBridgeArgs(
+    [
+      "--app-server-cost-profile",
+      "dashboard-balanced",
+      "--app-server-model",
+      "gpt-5.5",
+      "--app-server-reasoning-effort",
+      "medium"
+    ],
+    {
+      VTDD_RUNTIME_URL: "https://runtime.example",
+      VTDD_GATEWAY_BEARER_TOKEN: "secret-token",
+      VTDD_DASHBOARD_THREAD_ID: "dashboard-main"
+    }
+  );
+  assert.equal(parsedFromCli.appServerCostProfile, "dashboard-balanced");
+  assert.equal(parsedFromCli.appServerModel, "gpt-5.5");
+  assert.equal(parsedFromCli.appServerReasoningEffort, "medium");
+});
+
+test("dashboard app-server bridge creates app-server client with usage tuning args", async () => {
+  const created = [];
+  await runDashboardAppServerBridge({
+    runtimeUrl: "https://runtime.example",
+    token: "secret-token",
+    threadId: "dashboard-main",
+    cwd: "/repo",
+    repoSyncPreflight: false,
+    reconnect: false,
+    reconnectLimit: 0,
+    appServerCostProfile: "dashboard-light-chat",
+    appServerModel: "gpt-5.3-codex-spark",
+    appServerReasoningEffort: "low",
+    appServerFactory(options) {
+      created.push(options);
+      return {
+        async initialize() {},
+        drainApprovalRequests() {
+          return Promise.resolve();
+        }
+      };
+    },
+    WebSocketImpl: class MockWebSocket {
+      constructor() {
+        this.listeners = new Map();
+        queueMicrotask(() => {
+          this.listeners.get("open")?.({});
+          this.listeners.get("close")?.({});
+        });
+      }
+      addEventListener(type, handler) {
+        this.listeners.set(type, handler);
+      }
+      send() {}
+    }
+  });
+
+  assert.equal(created.length, 1);
+  assert.deepEqual(created[0], {
+    cwd: "/repo",
+    args: [
+      "app-server",
+      "--listen",
+      "stdio://",
+      "-c",
+      'model="gpt-5.3-codex-spark"',
+      "-c",
+      'model_reasoning_effort="low"'
+    ]
+  });
 });
 
 test("dashboard app-server bridge repo sync preflight allows clean in-sync main with known artifacts", async () => {


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #455 の部分進捗。Dashboard Butler は Worker 内で AI 風に答えず、VPS Dashboard Bridge / codex app-server へ中継する。その前提を守ったまま、VPS app-server の model / reasoning effort を operator が軽量 profile として明示できるようにする。

## Satisfied Success Criteria

- Dashboard app-server bridge に `VTDD_DASHBOARD_APP_SERVER_PROFILE` / `VTDD_DASHBOARD_APP_SERVER_MODEL` / `VTDD_DASHBOARD_APP_SERVER_REASONING_EFFORT` を追加し、`codex app-server -c ...` argv override として渡せるようにした。
- `bridge_connected` runtime truth に `costBoundary` を追加し、`codexWillStart=true` / `appServerBridgeRequired=true` / `modelConfigured` / `reasoningEffortConfigured` を見えるようにした。
- PR #764 の条件どおり、Worker 側の cost/read/status AI 風 fast path は復活させていない。

## Unsatisfied Success Criteria

- Issue #455 全体は未完了。重複 reviewer 抑止、fallback retry throttle、queue / defer 方針、Codex Analytics 実測比較、mapped live E2E は後続。
- この PR は消費量が必ず下がると断定しない。operator が軽量設定を適用して観測できる足場まで。

## Non-goal violations

Worker-side pseudo-answer は復活させない。reviewer gate / passkey gate / safety gate は削らない。OpenAI 料金体系や ChatGPT/Codex credit 算出を推測で断定しない。API key runner へ切り替えない。deploy / credential / permission mutation はしない。

## 開発前作戦図

- 作戦図 evidence: docs/development-strategy/issue-455-dashboard-app-server-usage-tuning.md
- 完了体験: Dashboard Butler の通常会話は VPS app-server に届き、operator が明示した軽量 profile / model / reasoning effort で app-server を起動できる。runtime truth にはその cost profile が出る。
- VTDD 全体で進める部分: Issue #455 の Codex usage 境界を Dashboard app-server bridge 起動設定へ接続する。Worker は中継機のままにする。
- 設計: Dashboard Butler の owner-facing 経路は変えず、app-server args builder を追加する。未指定時は既存の `codex app-server --listen stdio://` を維持し、env/CLI 指定時だけ `-c model=...` / `-c model_reasoning_effort=...` を追加する。connected event に `costBoundary` を含める。
- 仮説: 仮説: VPS bridge が重い既定 Codex config のまま通常会話を処理することが消費増の原因になり得る。起動 args を operator override 可能にすれば、Worker AI 風回答を戻さずに消費 profile を調整できる。
- 検証計画: `node --test test/dashboard-app-server-bridge.test.js` と `npm test`。merge 後は VPS service env に profile/model/reasoning effort を設定して restart し、Dashboard Butler から短い通常会話を送る。
- 改修見積もり: `scripts/run-dashboard-app-server-bridge.mjs`: args builder / parse / run / connected event。`test/dashboard-app-server-bridge.test.js`: regression tests。`docs/butler/dashboard-butler-app-server-live-path.md`: durable operator guidance。
- 既に通っている経路: PR #764 は merge/deploy 済み。deploy-production run 26930927693 は `d52a8f2` で success。VPS repo と bridge process は `d52a8f2` 反映済み。`codex app-server --help` で `-c key=value` override を確認済み。
- 未確認の境界: 実際の credit 消費計算は Codex Analytics / 公式 runtime truth でしか確定できない。`model_reasoning_effort` の account/version 依存は live bridge 起動時に確認する。
- 穴が出そうな箇所: env 値のクォート、model 名の account 差異、runtime truth への過剰露出、Worker fast path 復活による中継機条件の破壊。
- PR 前に確認すること: latest `origin/main` から topic branch 作成。PR #764 deploy success と VPS source反映を確認。targeted test と `npm test` を実行。
- 実装候補と捨てた案: 採用: app-server 起動 args の env override。捨てた案: Worker で軽量 AI 風回答、API key runner、repo 固定 model。
- merge 後に通す E2E: E2E: production deploy 後、VPS service env に軽量 profile を設定し、bridge restart 後の Dashboard Butler 通常会話と runtime truth を確認する。Codex Analytics は観測値として別記録。
- 次の PR を増やさない理由: このPRは PR #764 の直後に必要な同一 Issue #455 follow-up であり、変更は bridge 起動設定と docs/tests の範囲に限定される。reviewer / runner throttle は別 surface として混ぜない。
- 停止条件: app-server CLI が `-c` override を受けない、reviewer/runner/Worker routing に広がる、Worker pseudo-answer 復活が必要になる、billing を推測で断定しそうになる場合は停止。

## Dry-run Impact Report

- Target Issue: Issue #455
- Implementing Success Criteria: 重い処理を実行する前に Codex 使用量境界を示すための bridge runtime truth と、VPS app-server の消費 profile override。
- Explicit Non-goals: Worker AI 風回答、reviewer gate 削除、deploy、credential/permission mutation、API課金 runner。
- Expected touched files/routes/workflows: `scripts/run-dashboard-app-server-bridge.mjs`; `test/dashboard-app-server-bridge.test.js`; `docs/butler/dashboard-butler-app-server-live-path.md`; `docs/development-strategy/issue-455-dashboard-app-server-usage-tuning.md`
- Affected Issues: Issue #455。Issue #450 の app-server live path docs に境界追記。
- Affected PRs: PR #764 の方針を前提にするが、PR #764 の branch には push しない。
- Affected workflows: GitHub Actions workflow は変更なし。deploy-production はこの PR では実行しない。
- Affected runtime/operator surfaces: VPS Dashboard Bridge / codex app-server 起動 args、Dashboard bridge connected runtime truth。Worker routing は変更なし。
- What may break if we patch narrowly: Worker で回答を戻すと Dashboard Butler が AI 風に振る舞う。model を固定すると operator account 差異で起動失敗する。
- Unknowns to investigate before coding: 実際の credit 減少量、各 model の account availability、production env 設定値。
- Validation needed: `node --test test/dashboard-app-server-bridge.test.js`; `npm test`; merge/deploy 後の VPS service env/restart/live Dashboard smoke。
- Stop condition: CLI override が動かない、scope が reviewer/runner へ広がる、billing 断定が必要になる。

## Execution Queue Delta

- Queue position before: Owner が PR #764 deploy 完了後に Issue #455 の消費量調整を依頼。active queue の Now は Issue #590 だが、この入力は Butler 使用継続の cost ROOT として bounded Issue #455 slice を実施。
- Preemption decision: ROOT: Dashboard Butler が必ず VPS Codex CLI に渡る方針に戻した直後、通常会話の app-server cost profile が未制御だと owner が Butler を使い続けにくい。Issue #590 全体は downscope しない。
- Queue delta: Issue #455 の Dashboard app-server usage profile slice を進める。Issue #590 / #637 / #450 は未完了のまま Queue に残す。
- Why this PR is next: PR #764 で Worker pseudo-answer を止めたため、次にやるべき消費量削減は Worker fast path 復活ではなく VPS app-server 側の軽量設定である。
- Active Issues not downscoped: Active Issues は縮小しない。この PR で扱わない reviewer suppression / queue throttle / E2E は未完了として残す。

## File / Line Hypotheses

- file: `scripts/run-dashboard-app-server-bridge.mjs`
  - hypothesis: `JsonLineAppServerClient` の既定 args が VPS Codex config の重さをそのまま使っている。
  - risk if changed narrowly: argv のクォートを誤ると app-server 起動失敗。
  - validation: args builder / parse / run tests。
  - related Issue: #455
- file: `docs/butler/dashboard-butler-app-server-live-path.md`
  - hypothesis: cost tuning は Worker pseudo-answer ではなく bridge/app-server 側に明記する必要がある。
  - risk if changed narrowly: future agent が PR #756/#757 型の fast path を復活させる。
  - validation: docs と tests の境界確認。
  - related Issue: #455

## Hypothesis Retrospective

- expected: env override なしでは既存 args が変わらず、env override ありで `app-server -c model` / `model_reasoning_effort` が追加される。
- actual: targeted test で期待通り。`npm test` も pass。
- mismatch: なし。
- lesson: Dashboard Butler の cost 削減は Worker 回答ではなく bridge/runtime profile として扱う。
- should become RAG candidate: yes, PR merge後に compact decisionとして候補化する。

## Verification Evidence

- Unit: `node --test test/dashboard-app-server-bridge.test.js`: pass, 55 tests。
- Integration: `npm test`: pass, 1156 pass / 1 skipped。`check:self-parity` と `check:generated-worker` も pass。
- E2E: 未実施。この PR は runtime設定足場。merge/deploy後に VPS env 設定と Dashboard smoke を行う。
- Manual: PR #764 deploy-production run 26930927693 success。VPS repo HEAD/origin/main `d52a8f2` 一致。bridge service restart 後に最新 source process 起動確認。
- Evidence path/link: `docs/development-strategy/issue-455-dashboard-app-server-usage-tuning.md`; GitHub Actions run 26930927693; local test output

## Butler Completion Contract

- Primary owner surface: Dashboard Butler。
- Fallback surface: Custom GPT は fallback surface。主経路ではない。
- Owner goal: Dashboard Butler を Worker pseudo-answer ではなく VPS Codex CLI 中継として使いながら、VPS app-server の消費 profile を調整できるようにする。
- Butler entrypoint: Dashboard Butler 通常チャット。入口は変更しない。
- Dashboard Butler natural-language path: Dashboard Butler の自然文/通常チャット経路は Worker を通って VPS Dashboard Bridge / codex app-server に到達する。
- Action Schema exposure: Custom GPT fallback schema は未変更。主経路ではない。
- Runtime path: `scripts/run-dashboard-app-server-bridge.mjs` が `codex app-server` を profile/model/reasoning effort override 付きで起動可能にする。
- Runner/runtime truth: `bridge_connected` event の `bridgeLifecycle.costBoundary` に profile / codexWillStart / appServerBridgeRequired / modelConfigured / reasoningEffortConfigured を出す。
- Authority boundary: 新しい high-risk authority は追加しない。起動 profile は command/file/merge/deploy/credential/permission 承認を与えない。
- E2E evidence: 未実施。この PR は incomplete。merge/deploy後の production Dashboard smoke が必要。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: このPRでは未実行。merge後に passkey approval 付き deploy が必要。
- Custom GPT Action Schema update: 不要。Dashboard bridge script / docs の変更で、Custom GPT Action Schema は未変更。
- Custom GPT Instructions update: 不要。Dashboard app-server live path docs を更新。
- iPhone Butler live E2E: 未実施。merge/deploy後に実施。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate。AGENTS.md Drift Stop Protocol。docs/butler/intent-mode-contract.md。docs/butler/execution-queue-contract.md。Issue #455 Non-goal。

## Out-of-scope but NOT implemented

- reviewer duplicate suppression。fallback reviewer retry throttle。VPS runner queue/defer policy。Codex Analytics 実測比較。Issue close。deploy。

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #455
- Execution ID: mac-codex-issue455-dashboard-app-server-usage-profile
- Goal: issue455_dashboard_app_server_usage_profile
