### PR TITLE
Issue #741 deploy後のrepo-less bridge restart導線を追加

### DIFF
--- a/docs/development-strategy/issue-741-deploy-bridge-restart-automation.md
+++ b/docs/development-strategy/issue-741-deploy-bridge-restart-automation.md
@@ -1,0 +1,128 @@
+# Issue #741 deploy 後 bridge restart automation 作戦図
+
+## 完了体験
+
+owner が Dashboard Butler で「デプロイしたい」と言うと、Butler は GitHub Actions の workflow 画面ではなく、同一 origin の deploy passkey operator URL を短い Markdown link で返す。owner は passkey 認証だけを行う。
+
+認証後、operator / runtime は `deploy-production` workflow dispatch を行い、operator page に居座らず Dashboard Butler の chat thread へ戻る。deploy run の追跡、完了/失敗通知、bridge follow-up は chat / notification center / runtime truth で扱う。deploy 成功後は VPS checkout sync と Dashboard app-server bridge restart を標準 follow-up として扱い、repo 設定済み bridge と repo 未設定 `unresolved` bridge のどちらを対象にしたか、before/after の SHA、service active state、process argv を owner-facing runtime truth として返す。
+
+## VTDD 全体で進める部分
+
+Issue #741 の deploy 後 checkout sync + bridge restart 標準運用と、Issue #637 の app-server bridge status/restart/logs capability preset を接続する。
+
+この slice は「人間は認証だけ」という owner 指摘を受けたもの。mac Codex が URL を組み、GitHub Actions を開かせ、SSH で restart する現状は `butler_gap_found` / `vps_handoff_gap_found` であり、VTDD completion ではない。
+
+## 設計
+
+順番は固定する。
+
+1. Butler / self-parity が same-origin deploy operator URL を提示する。
+2. owner は passkey 認証だけ行う。
+3. runtime が deploy workflow を dispatch し、run URL / run status を返す。
+4. deploy 成功後、VPS helper capability で checkout sync と bridge restart を実行または提案する。
+5. Butler が production SHA / VPS SHA / bridge process truth を返す。
+
+Cloudflare passkey operator page は approvalGrant を作るだけでは足りない。deploy mode では承認成功後に same-origin `/v2/action/deploy` へ approvalGrantId を POST し、Worker が deploy dispatch を検知できる必要がある。VPS maintenance mode でも同じく、承認成功後に `/v2/dashboard/chat/messages` へ approvalGrantId / vpsProposalId を戻し、Dashboard Butler が helper queue へ自動継続できる必要がある。owner に approvalGrantId をコピーさせる flow は fallback であり、通常導線ではない。
+
+deploy operator page は認証と dispatch の場であって、追跡UIではない。dispatch 後は `returnUrl` で Dashboard Butler の chat surface に戻す。chat 上の詳細な deploy tracking state と deploy success 後の bridge restart auto-proposal は後続 runtime path で接続するが、operator page に owner を残して GitHub Actions run link を眺めさせる設計にはしない。
+
+今回の実装最小単位は、VPS privileged maintenance capability registry と Dashboard natural-language preset が repo 設定済み bridge だけでなく `vtdd-dashboard-app-server-bridge-unresolved.service` も扱えるようにすること。実運用で動いている unresolved bridge が preset から抜けていると、Butler が「bridge restart」と理解しても正しい service を restart できない。
+
+deploy operator URL は既に `selfParity.deployOperatorMarkdownLink` と passkey operator page に存在するため、今回はそれを GitHub Actions URL と混同しない guidance / tests を補強する。URL 自動提示は `vtddRetrieveSelfParity` を優先し、fallback でも same-origin `/v2/approval/passkey/operator?...actionType=deploy_production&highRiskKind=deploy_production` を返す。
+
+## 仮説
+
+現在の blocker は deploy plane そのものではない。`/v2/action/deploy` は approvalGrant から workflow dispatch まで進める。足りないのは、owner-facing 会話で deploy operator URL を自動提示し、deploy 後に VPS bridge lifecycle follow-up をつなぐこと。
+
+さらに #637 preset は `vtdd-dashboard-app-server-bridge.service` だけを指している。repo-less main chat の正式経路で実際に動いている `vtdd-dashboard-app-server-bridge-unresolved.service` が抜けているため、今日の手動 restart と同じ場面で Butler から正しい capability proposal を作れない。
+
+## 検証計画
+
+- Unit: VPS privileged maintenance command registry が repo 設定済み bridge と unresolved bridge の status / restart / logs preset を持つ。
+- Unit: natural-language preset が `unresolved` / `repo 未設定` / `main chat` を含む bridge restart 依頼を unresolved service capability に解決する。
+- Unit: generic bridge restart は既存 bridge service capability を保つ。
+- Unit: deploy operator guidance が GitHub Actions workflow URL ではなく same-origin passkey operator URL を要求する。
+- Unit: deploy operator page は passkey 承認後に `/v2/action/deploy` へ自動 dispatch する導線を維持する。
+- Unit: deploy operator page は dispatch 後に `returnUrl` で Dashboard Butler chat へ戻る導線を持つ。
+- Unit: VPS operator page は `dashboardThreadId` がある時に `/v2/dashboard/chat/messages` へ承認イベントを戻す導線を維持する。
+- Local: `node --test test/vps-privileged-maintenance.test.js test/worker.test.js --test-name-pattern "VPS privileged maintenance|deploy operator|app-server bridge"`
+- Worker source を触る場合は `npm run build:worker` と `npm run verify:worker` を実行する。
+
+## 改修見積もり
+
+- `src/core/vps-privileged-maintenance.js`: unresolved bridge status / restart / logs command registry entriesを追加する。risk は既存 main bridge capability と混同すること。
+- `src/worker/runtime.js`: Dashboard natural-language preset が unresolved bridge を選べるようにする。risk は通常 chat を helper proposal に誤分類すること。
+- `src/core/passkey-operator-page.js`: 今回は既存 auto-dispatch 導線の回帰確認を基本とし、必要時だけ文言を補強する。risk は owner に approvalGrantId copy を要求する flow へ戻ること。
+- `test/vps-privileged-maintenance.test.js`: registry coverage を追加する。
+- `test/worker.test.js` / `test/passkey-operator-page.test.js`: unresolved bridge natural-language proposal、deploy operator URL guidance、passkey 承認後 auto-dispatch / auto-continue の回帰を追加する。
+- `worker.js`: generated worker。Worker source を変更した場合のみ更新する。
+
+## 既に通っている経路
+
+- `/v2/approval/passkey/operator` は deploy mode を表示できる。
+- deploy mode の operator page は passkey 承認後に `/v2/action/deploy` を自動 dispatch し、`returnUrl` があれば Dashboard Butler chat へ戻れる。
+- `/v2/action/deploy` は real passkey approval grant から `deploy-production.yml` を dispatch できる。
+- `evaluateButlerSelfParity()` は `deployOperatorUrl` / `deployOperatorMarkdownLink` / `deployRecovery` を返せる。
+- `ensureDashboardBridgeRepoSynced()` は bridge startup 前に clean behind-only checkout を `origin/main` へ fast-forward できる。
+- Issue #637 の VPS operator page は `dashboardThreadId` がある時、承認後に Dashboard chat API へ戻って helper queue へ自動継続できる。
+- Issue #637 の VPS helper queue は approvalGrant を受けて helper execution envelope を作れる。
+
+## 未確認の境界
+
+deploy workflow 完了を Worker が長時間 polling して bridge restart まで自動連鎖する runtime path はまだ未確認。GitHub Actions の protected environment approval と passkey approval は別 gate であり、どちらも bypass しない。dispatch 後に chat へ戻る導線は入れるが、chat 上で running/success/failure/bridge follow-up を細かく追跡する state machine は後続接続が必要。
+
+VPS helper が現在の production host で unresolved bridge capability manifest を持っているかは deploy 後 live evidence が必要。repo に registry が入るだけでは root-owned manifest の現物更新完了ではない。
+
+bridge restart の頻度による副作用は未測定。予測されるリスクは、進行中 turn の切断、Codex thread resume 失敗、transient progress 消失、Dashboard 再接続スパム、`codex app-server` 再初期化による追加 latency / usage である。restart automation は before/after truth と進行中 turn 判定を持つまで、無条件の高頻度 restart にしてはいけない。
+
+## 穴が出そうな箇所
+
+- GitHub Actions workflow URL を deploy URL として返すと、owner は認証だけで済まない。
+- deploy approval scope に bridge restart まで含めるかは未決定。今回の slice は deploy 後 follow-up capability を作るが、勝手に destructive / maintenance execution を始めない。
+- unresolved bridge を残骸扱いで stop/disable すると repo-less main chat を壊す。
+- broad `bridge restart` intent で全 bridge を同時 restart すると進行中 turn を落とす可能性がある。
+- health check なしの周期 restart は、長時間開発 turn と衝突して owner-facing UX を悪化させる可能性がある。
+
+## PR 前に確認すること
+
+- Issue #741 / #637 の Success Criteria と Non-goal。
+- `src/core/vps-privileged-maintenance.js` の registry が public/core branch に owner 固有 service 名以外の秘密値を入れないこと。
+- `src/worker/runtime.js` の natural-language preset が通常会話を helper proposal に誤分類しないこと。
+- generated worker が source と一致すること。
+- PR body の Execution Queue Delta で、owner 指摘により #741/#637 deploy follow-up slice が `ROOT` 寄りの `NEXT` として入ったこと、active Issues を downscope していないことを明記する。
+
+## 実装候補と捨てた案
+
+採用: unresolved bridge service 用の status / restart / logs capability を registry に追加し、natural-language preset が unresolved を選べるようにする。
+
+採用: deploy operator URL は self-parity same-origin link を正とし、GitHub Actions workflow URL は run 追跡用としてのみ扱う。
+
+採用: passkey operator page が承認イベントを same-origin action / Dashboard chat API へ戻す auto-dispatch / auto-continue を通常導線とする。
+
+捨てた案: mac Codex が SSH で restart する運用を標準とする。Butler completion ではないため不採用。
+
+捨てた案: deploy workflow 内で無条件に VPS SSH restart する。deploy approval と VPS maintenance approval の scope 混在が未整理のため不採用。
+
+捨てた案: 短間隔の periodic restart。進行中 turn とコスト観測に悪影響を出す可能性があるため、health-based または deploy-follow-up に限定して検証する。
+
+捨てた案: repo-less `unresolved` bridge を止める。Issue #741 の Non-goal に反する。
+
+## merge 後に通す E2E
+
+1. Dashboard Butler で「デプロイしたい」と送る。期待値は same-origin deploy operator URL が返り、GitHub Actions workflow URL だけでは止まらない。
+2. owner が passkey 認証する。runtime が deploy workflow を dispatch し run URL を返す。
+3. deploy success 後、Dashboard Butler で「repo 未設定 main chat の app-server bridge を再起動して」と送る。期待値は unresolved bridge restart proposal / approval URL が出る。
+4. owner が passkey 認証する。VPS helper queue が unresolved bridge restart を実行し、before/after active state と repo SHA を返す。
+
+## 次の PR を増やさない理由
+
+deploy operator URL 自動提示と bridge restart は owner から見て同じ deploy follow-up workflow であり、今日の手動作業で一続きに露呈した gap である。少なくとも unresolved bridge capability を同じ slice で入れないと、deploy 後 restart automation が実運用対象を外す。
+
+ただし long-running deploy polling から automatic VPS helper execution までを完全接続するには authority scope の確認が必要なので、この PR では capability / natural-language / URL guidance の最小接続に留める。
+
+## 停止条件
+
+- deploy approval grant だけで VPS maintenance execution まで自動開始しないと成立しない場合。
+- GitHub environment approval、credential、permission、repository settings mutation を変える必要が出た場合。
+- unresolved bridge restart が通常 chat を壊すことが分かった場合。
+- owner 固有の runtime URL / host secret / credential を public repo に固定しそうになった場合。

--- a/src/core/passkey-operator-page.js
+++ b/src/core/passkey-operator-page.js
@@ -623,12 +623,19 @@ export function renderPasskeyOperatorPage(input = {}) {
           return "deploy を開始しました。Dashboard Butler のチャットに戻って追跡します。";
         }
         if (deploy.status === "dispatch_accepted_unverified") {
-          return "deploy request は受理されました。GitHub Actions の run 確認は未確定です。Dashboard Butler のチャットに戻って追跡します。";
+          return "deploy request は受理されました。GitHub Actions の run 確認は未確定です。この画面で詳細を確認してください。";
         }
-        return "deploy request を受け付けました。Dashboard Butler のチャットに戻って追跡します。";
+        return "deploy request を受け付けました。この画面で詳細を確認してください。";
       }
 
-      function returnToButlerAfterDeployDispatch() {
+      function shouldReturnToButlerAfterDeployDispatch(body) {
+        return body?.deploy?.status === "dispatched";
+      }
+
+      function returnToButlerAfterDeployDispatch(body) {
+        if (!shouldReturnToButlerAfterDeployDispatch(body)) {
+          return;
+        }
         if (operatorMode !== "deploy" || !returnToButlerLink || !returnToButlerLink.href) {
           return;
         }
@@ -835,7 +842,7 @@ export function renderPasskeyOperatorPage(input = {}) {
         if (deployDebugOutput) {
           deployDebugOutput.textContent = JSON.stringify(deployBody, null, 2);
         }
-        returnToButlerAfterDeployDispatch();
+        returnToButlerAfterDeployDispatch(deployBody);
       }
 
       async function continueVpsMaintenanceFromApproval() {

--- a/src/core/passkey-operator-page.js
+++ b/src/core/passkey-operator-page.js
@@ -70,7 +70,7 @@ export function renderPasskeyOperatorPage(input = {}) {
   const heroDescription = dashboardMode
     ? "このページは Dashboard Butler を開くための読み取り専用パスキー確認です。Cloudflare Access が使えない時だけ、同一 origin の passkey で dashboard session を更新します。"
     : deployOneTapMode
-      ? "このページは production deploy を承認して、そのまま反映を開始するためのパスキー確認です。内部の承認IDや workflow 入力は通常操作では扱いません。"
+      ? "このページは production deploy を承認して、そのまま反映を開始するためのパスキー確認です。反映開始後は Dashboard Butler のチャットへ戻り、内部の承認IDや workflow 入力は通常操作では扱いません。"
       : "このページは real WebAuthn/passkey approval 用の operator helper です。登録と high-risk approval の両方を same-origin で実行し、最終的に <code>approvalGrantId</code> を取得できます。";
   const approvalHeading = deployOneTapMode
     ? "本番反映の承認"
@@ -620,12 +620,21 @@ export function renderPasskeyOperatorPage(input = {}) {
       function buildDeployResultText(body) {
         const deploy = body?.deploy || {};
         if (deploy.status === "dispatched") {
-          return "deploy を開始しました。完了通知を待ってください。";
+          return "deploy を開始しました。Dashboard Butler のチャットに戻って追跡します。";
         }
         if (deploy.status === "dispatch_accepted_unverified") {
-          return "deploy request は受理されました。GitHub Actions の run 確認は未確定です。";
+          return "deploy request は受理されました。GitHub Actions の run 確認は未確定です。Dashboard Butler のチャットに戻って追跡します。";
         }
-        return "deploy request を受け付けました。";
+        return "deploy request を受け付けました。Dashboard Butler のチャットに戻って追跡します。";
+      }
+
+      function returnToButlerAfterDeployDispatch() {
+        if (operatorMode !== "deploy" || !returnToButlerLink || !returnToButlerLink.href) {
+          return;
+        }
+        window.setTimeout(() => {
+          window.location.assign(returnToButlerLink.href);
+        }, 900);
       }
 
       function extractMergePullRequestUrl(body) {
@@ -826,6 +835,7 @@ export function renderPasskeyOperatorPage(input = {}) {
         if (deployDebugOutput) {
           deployDebugOutput.textContent = JSON.stringify(deployBody, null, 2);
         }
+        returnToButlerAfterDeployDispatch();
       }
 
       async function continueVpsMaintenanceFromApproval() {

--- a/src/core/vps-privileged-maintenance.js
+++ b/src/core/vps-privileged-maintenance.js
@@ -117,6 +117,43 @@ const HELPER_COMMAND_REGISTRY = defineHelperCommandRegistry([
     initialPreset: true
   },
   {
+    commandClass: "systemd_user_app_server_bridge_unresolved_status",
+    title: "Check repo-less Dashboard app-server bridge status",
+    allowedArgs: ["systemctl --user is-active vtdd-dashboard-app-server-bridge-unresolved.service"],
+    argv: ["systemctl", "--user", "is-active", "vtdd-dashboard-app-server-bridge-unresolved.service"],
+    requiredRiskLevel: "low",
+    requiresRoot: false,
+    initialPreset: true
+  },
+  {
+    commandClass: "systemd_user_app_server_bridge_unresolved_restart",
+    title: "Restart repo-less Dashboard app-server bridge",
+    allowedArgs: ["systemctl --user restart vtdd-dashboard-app-server-bridge-unresolved.service"],
+    argv: ["systemctl", "--user", "restart", "vtdd-dashboard-app-server-bridge-unresolved.service"],
+    requiredRiskLevel: "medium",
+    requiresRoot: false,
+    initialPreset: true
+  },
+  {
+    commandClass: "systemd_user_app_server_bridge_unresolved_logs",
+    title: "Read redacted repo-less Dashboard app-server bridge journal summary",
+    allowedArgs: [
+      "journalctl --user -u vtdd-dashboard-app-server-bridge-unresolved.service --no-pager -n 200"
+    ],
+    argv: [
+      "journalctl",
+      "--user",
+      "-u",
+      "vtdd-dashboard-app-server-bridge-unresolved.service",
+      "--no-pager",
+      "-n",
+      "200"
+    ],
+    requiredRiskLevel: "low",
+    requiresRoot: false,
+    initialPreset: true
+  },
+  {
     commandClass: "vps_runner_status_dry_run",
     title: "Check VPS runner queue status without executing work",
     allowedArgs: ["node scripts/run-vps-runner.mjs --dry-run"],

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -11486,6 +11486,7 @@ function resolveDashboardVpsMaintenanceNaturalLanguagePreset({ payload, workingD
 
   const registryEntry = listVpsPrivilegedMaintenanceCommandRegistry().find((entry) => entry.commandClass === commandClass);
   if (!registryEntry) return null;
+  const affectedSystemdUnits = (registryEntry.argv || []).filter((arg) => /\.(service|timer)$/.test(String(arg || "")));
   return {
     id: commandClass.replaceAll("_", "."),
     title: registryEntry.title,
@@ -11496,7 +11497,7 @@ function resolveDashboardVpsMaintenanceNaturalLanguagePreset({ payload, workingD
       workingDirectory,
       "/home/vtdd-runner/.config/systemd/user",
       "/run/user",
-      ...registryEntry.allowedArgs
+      ...affectedSystemdUnits
     ].filter(Boolean),
     operation: wantsRestart ? "enable" : "review"
   };

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -11460,11 +11460,23 @@ function resolveDashboardVpsMaintenanceNaturalLanguagePreset({ payload, workingD
     lower.includes("app server") ||
     lower.includes("bridge") ||
     text.includes("ブリッジ");
+  const mentionsRepoLessBridge =
+    mentionsBridge &&
+    (lower.includes("unresolved") ||
+      lower.includes("repo-less") ||
+      lower.includes("repoless") ||
+      text.includes("repo 未設定") ||
+      text.includes("リポジトリ未設定") ||
+      text.includes("未設定 main chat") ||
+      text.includes("メインチャット"));
   const mentionsRunner = lower.includes("runner") || text.includes("ランナー") || text.includes("実行器");
   if (!mentionsBridge && !mentionsRunner) return null;
 
   let commandClass = "";
-  if (mentionsBridge && wantsLogs) commandClass = "systemd_user_app_server_bridge_logs";
+  if (mentionsRepoLessBridge && wantsLogs) commandClass = "systemd_user_app_server_bridge_unresolved_logs";
+  else if (mentionsRepoLessBridge && wantsRestart) commandClass = "systemd_user_app_server_bridge_unresolved_restart";
+  else if (mentionsRepoLessBridge && wantsStatus) commandClass = "systemd_user_app_server_bridge_unresolved_status";
+  else if (mentionsBridge && wantsLogs) commandClass = "systemd_user_app_server_bridge_logs";
   else if (mentionsBridge && wantsRestart) commandClass = "systemd_user_app_server_bridge_restart";
   else if (mentionsBridge && wantsStatus) commandClass = "systemd_user_app_server_bridge_status";
   else if (mentionsRunner && wantsLogs) commandClass = "systemd_user_runner_logs";
@@ -11480,7 +11492,12 @@ function resolveDashboardVpsMaintenanceNaturalLanguagePreset({ payload, workingD
     commandClass: registryEntry.commandClass,
     riskLevel: registryEntry.requiredRiskLevel,
     allowedArgs: registryEntry.allowedArgs,
-    affectedPaths: [workingDirectory, "/home/vtdd-runner/.config/systemd/user", "/run/user"].filter(Boolean),
+    affectedPaths: [
+      workingDirectory,
+      "/home/vtdd-runner/.config/systemd/user",
+      "/run/user",
+      ...registryEntry.allowedArgs
+    ].filter(Boolean),
     operation: wantsRestart ? "enable" : "review"
   };
 }

--- a/test/passkey-operator-page.test.js
+++ b/test/passkey-operator-page.test.js
@@ -142,6 +142,7 @@ test("passkey operator page focuses deploy mode on deploy approval and dispatch 
     ),
     true
   );
+  assert.equal(html.includes("反映開始後は Dashboard Butler のチャットへ戻り"), true);
   assert.equal(html.includes("内部の承認IDや workflow 入力は通常操作では扱いません。"), true);
   assert.equal(html.includes("最終的に <code>approvalGrantId</code> を取得できます。"), false);
   assert.equal(html.includes('id="approve-button">パスキー</button>'), true);
@@ -154,7 +155,10 @@ test("passkey operator page focuses deploy mode on deploy approval and dispatch 
   assert.equal(html.includes("Auto-copy approvalGrantId after approval"), false);
   assert.equal(html.includes('id="deploy-button" hidden>Dispatch production deploy</button>'), true);
   assert.equal(html.includes("Dashboard 通知センターと保存済み Web Push 購読へ届きます"), true);
-  assert.equal(html.includes("deploy を開始しました。完了通知を待ってください。"), true);
+  assert.equal(html.includes("deploy を開始しました。Dashboard Butler のチャットに戻って追跡します。"), true);
+  assert.equal(html.includes("function returnToButlerAfterDeployDispatch()"), true);
+  assert.equal(html.includes("window.location.assign(returnToButlerLink.href)"), true);
+  assert.equal(html.includes("returnToButlerAfterDeployDispatch();"), true);
   assert.equal(html.includes("deploy-debug-output"), true);
   assert.equal(html.includes("<summary>詳細</summary>"), true);
   assert.equal(html.includes("Return to Butler"), true);

--- a/test/passkey-operator-page.test.js
+++ b/test/passkey-operator-page.test.js
@@ -156,9 +156,15 @@ test("passkey operator page focuses deploy mode on deploy approval and dispatch 
   assert.equal(html.includes('id="deploy-button" hidden>Dispatch production deploy</button>'), true);
   assert.equal(html.includes("Dashboard 通知センターと保存済み Web Push 購読へ届きます"), true);
   assert.equal(html.includes("deploy を開始しました。Dashboard Butler のチャットに戻って追跡します。"), true);
-  assert.equal(html.includes("function returnToButlerAfterDeployDispatch()"), true);
+  assert.equal(
+    html.includes("deploy request は受理されました。GitHub Actions の run 確認は未確定です。この画面で詳細を確認してください。"),
+    true
+  );
+  assert.equal(html.includes("function shouldReturnToButlerAfterDeployDispatch(body)"), true);
+  assert.equal(html.includes('body?.deploy?.status === "dispatched"'), true);
+  assert.equal(html.includes("function returnToButlerAfterDeployDispatch(body)"), true);
   assert.equal(html.includes("window.location.assign(returnToButlerLink.href)"), true);
-  assert.equal(html.includes("returnToButlerAfterDeployDispatch();"), true);
+  assert.equal(html.includes("returnToButlerAfterDeployDispatch(deployBody);"), true);
   assert.equal(html.includes("deploy-debug-output"), true);
   assert.equal(html.includes("<summary>詳細</summary>"), true);
   assert.equal(html.includes("Return to Butler"), true);

--- a/test/vps-privileged-maintenance.test.js
+++ b/test/vps-privileged-maintenance.test.js
@@ -148,6 +148,9 @@ test("VPS privileged maintenance helper command registry exposes initial presets
   assert.equal(commandClasses.includes("systemd_user_app_server_bridge_status"), true);
   assert.equal(commandClasses.includes("systemd_user_app_server_bridge_restart"), true);
   assert.equal(commandClasses.includes("systemd_user_app_server_bridge_logs"), true);
+  assert.equal(commandClasses.includes("systemd_user_app_server_bridge_unresolved_status"), true);
+  assert.equal(commandClasses.includes("systemd_user_app_server_bridge_unresolved_restart"), true);
+  assert.equal(commandClasses.includes("systemd_user_app_server_bridge_unresolved_logs"), true);
   assert.equal(commandClasses.includes("vps_runner_status_dry_run"), true);
   assert.equal(commandClasses.includes("vps_maintenance_install_inventory_collect"), true);
   assert.equal(
@@ -159,6 +162,44 @@ test("VPS privileged maintenance helper command registry exposes initial presets
     true
   );
   assert.equal(registry.every((entry) => entry.initialPreset === true), true);
+});
+
+test("VPS privileged maintenance registry separates repo-less Dashboard bridge service", () => {
+  const registry = listVpsPrivilegedMaintenanceCommandRegistry();
+  const unresolvedRestart = registry.find(
+    (entry) => entry.commandClass === "systemd_user_app_server_bridge_unresolved_restart"
+  );
+  const unresolvedStatus = registry.find(
+    (entry) => entry.commandClass === "systemd_user_app_server_bridge_unresolved_status"
+  );
+  const unresolvedLogs = registry.find(
+    (entry) => entry.commandClass === "systemd_user_app_server_bridge_unresolved_logs"
+  );
+
+  assert.deepEqual(unresolvedRestart.argv, [
+    "systemctl",
+    "--user",
+    "restart",
+    "vtdd-dashboard-app-server-bridge-unresolved.service"
+  ]);
+  assert.deepEqual(unresolvedStatus.argv, [
+    "systemctl",
+    "--user",
+    "is-active",
+    "vtdd-dashboard-app-server-bridge-unresolved.service"
+  ]);
+  assert.deepEqual(unresolvedLogs.argv, [
+    "journalctl",
+    "--user",
+    "-u",
+    "vtdd-dashboard-app-server-bridge-unresolved.service",
+    "--no-pager",
+    "-n",
+    "200"
+  ]);
+  assert.equal(unresolvedRestart.requiredRiskLevel, "medium");
+  assert.equal(unresolvedStatus.requiredRiskLevel, "low");
+  assert.equal(unresolvedLogs.requiredRiskLevel, "low");
 });
 
 test("VPS privileged maintenance helper command registry does not expose mutable internal arrays", () => {

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -3058,6 +3058,7 @@ test("worker maps repo-less Dashboard bridge restart intent to unresolved bridge
     body.execution.approvalScope.vpsImpactScope.includes("vtdd-dashboard-app-server-bridge-unresolved.service"),
     true
   );
+  assert.equal(body.execution.approvalScope.vpsImpactScope.includes("systemctl --user restart"), false);
   assert.match(body.messages[1].text, /Restart repo-less Dashboard app-server bridge/);
   assert.match(body.messages[1].text, /approval_required/);
   assert.match(body.messages[1].text, /rootExecutionStarted=false, helperExecutionStarted=false/);

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -3025,6 +3025,48 @@ test("worker keeps ordinary Dashboard Butler planning chat out of VPS helper que
   assert.doesNotMatch(JSON.stringify(body.messages), /途中で止まりました/);
 });
 
+test("worker maps repo-less Dashboard bridge restart intent to unresolved bridge capability", async () => {
+  const store = createInMemoryDashboardChatStore();
+  const provider = createInMemoryMemoryProvider();
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/dashboard/chat/messages", {
+      method: "POST",
+      headers: gatewayAuthHeaders,
+      body: JSON.stringify({
+        threadId: "dashboard-main-unresolved",
+        repository: "marushu/vtdd-v2-p",
+        issueNumber: 741,
+        text: "repo 未設定 main chat の app-server bridge を再起動して。deploy 後の反映確認です。"
+      })
+    }),
+    {
+      ...gatewayAuthEnv,
+      DASHBOARD_CHAT_STORE: store,
+      MEMORY_PROVIDER: provider,
+      VTDD_DASHBOARD_VPS_MAINTENANCE_HOST: "x85-131-245-163",
+      VTDD_DASHBOARD_VPS_MAINTENANCE_WORKDIR: "/home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p"
+    }
+  );
+
+  assert.equal(response.status, 202);
+  const body = await response.json();
+  assert.equal(body.ok, true);
+  assert.equal(body.execution.status, "approval_required");
+  assert.equal(body.execution.approvalScope.vpsCapabilityId, "systemd.user.app.server.bridge.unresolved.restart");
+  assert.equal(body.execution.approvalScope.vpsOperation, "enable");
+  assert.equal(
+    body.execution.approvalScope.vpsImpactScope.includes("vtdd-dashboard-app-server-bridge-unresolved.service"),
+    true
+  );
+  assert.match(body.messages[1].text, /Restart repo-less Dashboard app-server bridge/);
+  assert.match(body.messages[1].text, /approval_required/);
+  assert.match(body.messages[1].text, /rootExecutionStarted=false, helperExecutionStarted=false/);
+  const approvalUrl = new URL(body.execution.approvalOperatorUrl);
+  assert.equal(approvalUrl.searchParams.get("mode"), "vps");
+  assert.equal(approvalUrl.searchParams.get("dashboardThreadId"), "dashboard-main-unresolved");
+  assert.equal(approvalUrl.searchParams.get("vpsProposalId"), body.execution.vpsProposalId);
+});
+
 test("worker maps Dashboard Butler VPS runner status text to the low-risk preset", async () => {
   const store = createInMemoryDashboardChatStore();
   const provider = createInMemoryMemoryProvider();

--- a/worker.js
+++ b/worker.js
@@ -27845,12 +27845,19 @@ function renderPasskeyOperatorPage(input = {}) {
           return "deploy \u3092\u958B\u59CB\u3057\u307E\u3057\u305F\u3002Dashboard Butler \u306E\u30C1\u30E3\u30C3\u30C8\u306B\u623B\u3063\u3066\u8FFD\u8DE1\u3057\u307E\u3059\u3002";
         }
         if (deploy.status === "dispatch_accepted_unverified") {
-          return "deploy request \u306F\u53D7\u7406\u3055\u308C\u307E\u3057\u305F\u3002GitHub Actions \u306E run \u78BA\u8A8D\u306F\u672A\u78BA\u5B9A\u3067\u3059\u3002Dashboard Butler \u306E\u30C1\u30E3\u30C3\u30C8\u306B\u623B\u3063\u3066\u8FFD\u8DE1\u3057\u307E\u3059\u3002";
+          return "deploy request \u306F\u53D7\u7406\u3055\u308C\u307E\u3057\u305F\u3002GitHub Actions \u306E run \u78BA\u8A8D\u306F\u672A\u78BA\u5B9A\u3067\u3059\u3002\u3053\u306E\u753B\u9762\u3067\u8A73\u7D30\u3092\u78BA\u8A8D\u3057\u3066\u304F\u3060\u3055\u3044\u3002";
         }
-        return "deploy request \u3092\u53D7\u3051\u4ED8\u3051\u307E\u3057\u305F\u3002Dashboard Butler \u306E\u30C1\u30E3\u30C3\u30C8\u306B\u623B\u3063\u3066\u8FFD\u8DE1\u3057\u307E\u3059\u3002";
+        return "deploy request \u3092\u53D7\u3051\u4ED8\u3051\u307E\u3057\u305F\u3002\u3053\u306E\u753B\u9762\u3067\u8A73\u7D30\u3092\u78BA\u8A8D\u3057\u3066\u304F\u3060\u3055\u3044\u3002";
       }
 
-      function returnToButlerAfterDeployDispatch() {
+      function shouldReturnToButlerAfterDeployDispatch(body) {
+        return body?.deploy?.status === "dispatched";
+      }
+
+      function returnToButlerAfterDeployDispatch(body) {
+        if (!shouldReturnToButlerAfterDeployDispatch(body)) {
+          return;
+        }
         if (operatorMode !== "deploy" || !returnToButlerLink || !returnToButlerLink.href) {
           return;
         }
@@ -28057,7 +28064,7 @@ function renderPasskeyOperatorPage(input = {}) {
         if (deployDebugOutput) {
           deployDebugOutput.textContent = JSON.stringify(deployBody, null, 2);
         }
-        returnToButlerAfterDeployDispatch();
+        returnToButlerAfterDeployDispatch(deployBody);
       }
 
       async function continueVpsMaintenanceFromApproval() {
@@ -67600,6 +67607,7 @@ function resolveDashboardVpsMaintenanceNaturalLanguagePreset({ payload, workingD
   if (!commandClass) return null;
   const registryEntry = listVpsPrivilegedMaintenanceCommandRegistry().find((entry) => entry.commandClass === commandClass);
   if (!registryEntry) return null;
+  const affectedSystemdUnits = (registryEntry.argv || []).filter((arg) => /\.(service|timer)$/.test(String(arg || "")));
   return {
     id: commandClass.replaceAll("_", "."),
     title: registryEntry.title,
@@ -67610,7 +67618,7 @@ function resolveDashboardVpsMaintenanceNaturalLanguagePreset({ payload, workingD
       workingDirectory,
       "/home/vtdd-runner/.config/systemd/user",
       "/run/user",
-      ...registryEntry.allowedArgs
+      ...affectedSystemdUnits
     ].filter(Boolean),
     operation: wantsRestart ? "enable" : "review"
   };

--- a/worker.js
+++ b/worker.js
@@ -27310,7 +27310,7 @@ function renderPasskeyOperatorPage(input = {}) {
   const approvalSectionAttributes = deployOneTapMode ? ' data-owner-flow="one-tap-deploy"' : "";
   const approveButtonLabel = deployOneTapMode ? "\u30D1\u30B9\u30AD\u30FC" : dashboardMode ? "\u30D1\u30B9\u30AD\u30FC\u3067\u958B\u304F" : "Approve high-risk action";
   const heroTitle = dashboardMode ? "Dashboard Passkey" : "VTDD Passkey Operator";
-  const heroDescription = dashboardMode ? "\u3053\u306E\u30DA\u30FC\u30B8\u306F Dashboard Butler \u3092\u958B\u304F\u305F\u3081\u306E\u8AAD\u307F\u53D6\u308A\u5C02\u7528\u30D1\u30B9\u30AD\u30FC\u78BA\u8A8D\u3067\u3059\u3002Cloudflare Access \u304C\u4F7F\u3048\u306A\u3044\u6642\u3060\u3051\u3001\u540C\u4E00 origin \u306E passkey \u3067 dashboard session \u3092\u66F4\u65B0\u3057\u307E\u3059\u3002" : deployOneTapMode ? "\u3053\u306E\u30DA\u30FC\u30B8\u306F production deploy \u3092\u627F\u8A8D\u3057\u3066\u3001\u305D\u306E\u307E\u307E\u53CD\u6620\u3092\u958B\u59CB\u3059\u308B\u305F\u3081\u306E\u30D1\u30B9\u30AD\u30FC\u78BA\u8A8D\u3067\u3059\u3002\u5185\u90E8\u306E\u627F\u8A8DID\u3084 workflow \u5165\u529B\u306F\u901A\u5E38\u64CD\u4F5C\u3067\u306F\u6271\u3044\u307E\u305B\u3093\u3002" : "\u3053\u306E\u30DA\u30FC\u30B8\u306F real WebAuthn/passkey approval \u7528\u306E operator helper \u3067\u3059\u3002\u767B\u9332\u3068 high-risk approval \u306E\u4E21\u65B9\u3092 same-origin \u3067\u5B9F\u884C\u3057\u3001\u6700\u7D42\u7684\u306B <code>approvalGrantId</code> \u3092\u53D6\u5F97\u3067\u304D\u307E\u3059\u3002";
+  const heroDescription = dashboardMode ? "\u3053\u306E\u30DA\u30FC\u30B8\u306F Dashboard Butler \u3092\u958B\u304F\u305F\u3081\u306E\u8AAD\u307F\u53D6\u308A\u5C02\u7528\u30D1\u30B9\u30AD\u30FC\u78BA\u8A8D\u3067\u3059\u3002Cloudflare Access \u304C\u4F7F\u3048\u306A\u3044\u6642\u3060\u3051\u3001\u540C\u4E00 origin \u306E passkey \u3067 dashboard session \u3092\u66F4\u65B0\u3057\u307E\u3059\u3002" : deployOneTapMode ? "\u3053\u306E\u30DA\u30FC\u30B8\u306F production deploy \u3092\u627F\u8A8D\u3057\u3066\u3001\u305D\u306E\u307E\u307E\u53CD\u6620\u3092\u958B\u59CB\u3059\u308B\u305F\u3081\u306E\u30D1\u30B9\u30AD\u30FC\u78BA\u8A8D\u3067\u3059\u3002\u53CD\u6620\u958B\u59CB\u5F8C\u306F Dashboard Butler \u306E\u30C1\u30E3\u30C3\u30C8\u3078\u623B\u308A\u3001\u5185\u90E8\u306E\u627F\u8A8DID\u3084 workflow \u5165\u529B\u306F\u901A\u5E38\u64CD\u4F5C\u3067\u306F\u6271\u3044\u307E\u305B\u3093\u3002" : "\u3053\u306E\u30DA\u30FC\u30B8\u306F real WebAuthn/passkey approval \u7528\u306E operator helper \u3067\u3059\u3002\u767B\u9332\u3068 high-risk approval \u306E\u4E21\u65B9\u3092 same-origin \u3067\u5B9F\u884C\u3057\u3001\u6700\u7D42\u7684\u306B <code>approvalGrantId</code> \u3092\u53D6\u5F97\u3067\u304D\u307E\u3059\u3002";
   const approvalHeading = deployOneTapMode ? "\u672C\u756A\u53CD\u6620\u306E\u627F\u8A8D" : dashboardMode ? "Dashboard \u3092\u958B\u304F" : "2. High-risk Approval";
   const deployScopeSummary = renderDeployScopeSummary({
     repositoryInput: repoDefault,
@@ -27842,12 +27842,21 @@ function renderPasskeyOperatorPage(input = {}) {
       function buildDeployResultText(body) {
         const deploy = body?.deploy || {};
         if (deploy.status === "dispatched") {
-          return "deploy \u3092\u958B\u59CB\u3057\u307E\u3057\u305F\u3002\u5B8C\u4E86\u901A\u77E5\u3092\u5F85\u3063\u3066\u304F\u3060\u3055\u3044\u3002";
+          return "deploy \u3092\u958B\u59CB\u3057\u307E\u3057\u305F\u3002Dashboard Butler \u306E\u30C1\u30E3\u30C3\u30C8\u306B\u623B\u3063\u3066\u8FFD\u8DE1\u3057\u307E\u3059\u3002";
         }
         if (deploy.status === "dispatch_accepted_unverified") {
-          return "deploy request \u306F\u53D7\u7406\u3055\u308C\u307E\u3057\u305F\u3002GitHub Actions \u306E run \u78BA\u8A8D\u306F\u672A\u78BA\u5B9A\u3067\u3059\u3002";
+          return "deploy request \u306F\u53D7\u7406\u3055\u308C\u307E\u3057\u305F\u3002GitHub Actions \u306E run \u78BA\u8A8D\u306F\u672A\u78BA\u5B9A\u3067\u3059\u3002Dashboard Butler \u306E\u30C1\u30E3\u30C3\u30C8\u306B\u623B\u3063\u3066\u8FFD\u8DE1\u3057\u307E\u3059\u3002";
         }
-        return "deploy request \u3092\u53D7\u3051\u4ED8\u3051\u307E\u3057\u305F\u3002";
+        return "deploy request \u3092\u53D7\u3051\u4ED8\u3051\u307E\u3057\u305F\u3002Dashboard Butler \u306E\u30C1\u30E3\u30C3\u30C8\u306B\u623B\u3063\u3066\u8FFD\u8DE1\u3057\u307E\u3059\u3002";
+      }
+
+      function returnToButlerAfterDeployDispatch() {
+        if (operatorMode !== "deploy" || !returnToButlerLink || !returnToButlerLink.href) {
+          return;
+        }
+        window.setTimeout(() => {
+          window.location.assign(returnToButlerLink.href);
+        }, 900);
       }
 
       function extractMergePullRequestUrl(body) {
@@ -28048,6 +28057,7 @@ function renderPasskeyOperatorPage(input = {}) {
         if (deployDebugOutput) {
           deployDebugOutput.textContent = JSON.stringify(deployBody, null, 2);
         }
+        returnToButlerAfterDeployDispatch();
       }
 
       async function continueVpsMaintenanceFromApproval() {
@@ -37832,6 +37842,43 @@ var HELPER_COMMAND_REGISTRY = defineHelperCommandRegistry([
       "--user",
       "-u",
       "vtdd-dashboard-app-server-bridge.service",
+      "--no-pager",
+      "-n",
+      "200"
+    ],
+    requiredRiskLevel: "low",
+    requiresRoot: false,
+    initialPreset: true
+  },
+  {
+    commandClass: "systemd_user_app_server_bridge_unresolved_status",
+    title: "Check repo-less Dashboard app-server bridge status",
+    allowedArgs: ["systemctl --user is-active vtdd-dashboard-app-server-bridge-unresolved.service"],
+    argv: ["systemctl", "--user", "is-active", "vtdd-dashboard-app-server-bridge-unresolved.service"],
+    requiredRiskLevel: "low",
+    requiresRoot: false,
+    initialPreset: true
+  },
+  {
+    commandClass: "systemd_user_app_server_bridge_unresolved_restart",
+    title: "Restart repo-less Dashboard app-server bridge",
+    allowedArgs: ["systemctl --user restart vtdd-dashboard-app-server-bridge-unresolved.service"],
+    argv: ["systemctl", "--user", "restart", "vtdd-dashboard-app-server-bridge-unresolved.service"],
+    requiredRiskLevel: "medium",
+    requiresRoot: false,
+    initialPreset: true
+  },
+  {
+    commandClass: "systemd_user_app_server_bridge_unresolved_logs",
+    title: "Read redacted repo-less Dashboard app-server bridge journal summary",
+    allowedArgs: [
+      "journalctl --user -u vtdd-dashboard-app-server-bridge-unresolved.service --no-pager -n 200"
+    ],
+    argv: [
+      "journalctl",
+      "--user",
+      "-u",
+      "vtdd-dashboard-app-server-bridge-unresolved.service",
       "--no-pager",
       "-n",
       "200"
@@ -67537,10 +67584,14 @@ function resolveDashboardVpsMaintenanceNaturalLanguagePreset({ payload, workingD
   const wantsRestart = lower.includes("restart") || lower.includes("\u518D\u8D77\u52D5") || text.includes("\u518D\u8D77\u52D5");
   const wantsStatus = lower.includes("status") || lower.includes("health") || lower.includes("state") || text.includes("\u72B6\u614B") || text.includes("\u78BA\u8A8D") || text.includes("\u751F\u5B58") || text.includes("\u7A3C\u50CD");
   const mentionsBridge = lower.includes("app-server") || lower.includes("app server") || lower.includes("bridge") || text.includes("\u30D6\u30EA\u30C3\u30B8");
+  const mentionsRepoLessBridge = mentionsBridge && (lower.includes("unresolved") || lower.includes("repo-less") || lower.includes("repoless") || text.includes("repo \u672A\u8A2D\u5B9A") || text.includes("\u30EA\u30DD\u30B8\u30C8\u30EA\u672A\u8A2D\u5B9A") || text.includes("\u672A\u8A2D\u5B9A main chat") || text.includes("\u30E1\u30A4\u30F3\u30C1\u30E3\u30C3\u30C8"));
   const mentionsRunner = lower.includes("runner") || text.includes("\u30E9\u30F3\u30CA\u30FC") || text.includes("\u5B9F\u884C\u5668");
   if (!mentionsBridge && !mentionsRunner) return null;
   let commandClass = "";
-  if (mentionsBridge && wantsLogs) commandClass = "systemd_user_app_server_bridge_logs";
+  if (mentionsRepoLessBridge && wantsLogs) commandClass = "systemd_user_app_server_bridge_unresolved_logs";
+  else if (mentionsRepoLessBridge && wantsRestart) commandClass = "systemd_user_app_server_bridge_unresolved_restart";
+  else if (mentionsRepoLessBridge && wantsStatus) commandClass = "systemd_user_app_server_bridge_unresolved_status";
+  else if (mentionsBridge && wantsLogs) commandClass = "systemd_user_app_server_bridge_logs";
   else if (mentionsBridge && wantsRestart) commandClass = "systemd_user_app_server_bridge_restart";
   else if (mentionsBridge && wantsStatus) commandClass = "systemd_user_app_server_bridge_status";
   else if (mentionsRunner && wantsLogs) commandClass = "systemd_user_runner_logs";
@@ -67555,7 +67606,12 @@ function resolveDashboardVpsMaintenanceNaturalLanguagePreset({ payload, workingD
     commandClass: registryEntry.commandClass,
     riskLevel: registryEntry.requiredRiskLevel,
     allowedArgs: registryEntry.allowedArgs,
-    affectedPaths: [workingDirectory, "/home/vtdd-runner/.config/systemd/user", "/run/user"].filter(Boolean),
+    affectedPaths: [
+      workingDirectory,
+      "/home/vtdd-runner/.config/systemd/user",
+      "/run/user",
+      ...registryEntry.allowedArgs
+    ].filter(Boolean),
     operation: wantsRestart ? "enable" : "review"
   };
 }


### PR DESCRIPTION
## This PR satisfies Intent

Issue #741 のうち、deploy 後に repo-less Dashboard app-server bridge を扱えるようにするための最小 runtime slice です。`unresolved` bridge を正式経路として扱い、Dashboard Butler の自然文から repo 未設定 main chat の bridge status / restart / logs を VPS helper proposal に到達させます。

あわせて、deploy 用 passkey operator page は認証と workflow dispatch だけを担当し、dispatch 後は Dashboard Butler のチャットへ戻る文言と導線を追加しました。operator page を GitHub Actions 追跡 UI として使わず、deploy 追跡は chat / notification / runtime truth 側で扱う前提を PR に明記します。

## Satisfied Success Criteria

- Issue #741: `unresolved` bridge を repo 未設定 main chat の正式経路として扱い、不要な残骸として stop/disable しない。
- Issue #741: repo 設定済み bridge と repo 未設定 bridge の区別を VPS helper command registry と natural-language preset で表現する。
- Issue #741: deploy 後の app-server bridge restart 標準運用に向けて、repo-less bridge の status / restart / logs を approval-bound helper proposal へ接続する。
- Issue #741: restart / lifecycle guard は deploy、credential mutation、permission mutation、destructive cleanup を自動実行しない。
- Owner 指摘: Cloudflare passkey operator page で認証した後、operator page に留まらず Dashboard Butler chat へ戻って追跡する導線を追加する。

## Unsatisfied Success Criteria

- deploy workflow の running / success / failure を chat 上で長時間 polling し、deploy 成功後に bridge sync/restart を自動提案する state machine はまだ未接続です。
- production VPS の root-owned helper manifest 更新、systemd before/after truth、CPU / memory growth threshold restart はこの PR では未検証です。
- iPhone / iPad sleep、lock、PWA background 後の deploy tracking / bridge restart 復帰 E2E は未実施です。
- bridge restart 前後の Codex thread id、turn id、pending owner message、last progress event 復元 E2E は未実施です。

## 開発前作戦図

- 作戦図 evidence: docs/development-strategy/issue-741-deploy-bridge-restart-automation.md
- 完了体験: オーナーは Dashboard Butler chat で「デプロイして」と言い、Butler から同一 origin の passkey operator URL を受け取る。認証後は operator page が deploy を dispatch して chat へ戻り、以後の追跡と bridge follow-up は Dashboard Butler が owner-facing runtime truth として返す。
- VTDD 全体で進める部分: Dashboard Butler を主 surface、VPS Codex CLI / VPS helper を実行 surface として、repo-less ordinary chat でも bridge restart intent が Mac SSH なしに approval-bound helper proposal へ届く経路を増やす。
- 設計: operator page は approval / dispatch surface に限定し、tracking UI にはしない。repo-less bridge は `vtdd-dashboard-app-server-bridge-unresolved.service` として registry に明示し、自然文 preset が unresolved service を選ぶ。
- 仮説: 原因仮説として、これまで deploy URL と GitHub Actions URL が混同され、さらに unresolved bridge が registry / preset から抜けていたため、オーナーは chat から deploy 後 bridge recovery に戻れず Mac Codex / SSH に落ちていた。
- 検証計画: passkey operator page unit、VPS privileged maintenance registry unit、Dashboard Butler natural-language worker unit、`npm run build:worker`、`npm run verify:worker` で route / generated worker 整合を確認する。
- 改修見積もり: src/core/passkey-operator-page.js の deploy dispatch 後 return path、src/core/vps-privileged-maintenance.js の helper command registry、src/worker/runtime.js の natural-language preset、test/passkey-operator-page.test.js / test/vps-privileged-maintenance.test.js / test/worker.test.js、generated worker.js。
- 既に通っている経路: `/v2/approval/passkey/operator` の deploy mode、`/v2/action/deploy` の approval-bound workflow dispatch、VPS maintenance proposal と passkey operator URL、Dashboard chat から VPS helper proposal を作る Worker path。
- 未確認の境界: GitHub Actions deploy completion を chat で追跡し、deploy 成功後に bridge sync/restart proposal まで自動連鎖する runtime state machine は未接続。Cloudflare deploy approval と GitHub protected environment approval は別 gate として残す。
- 穴が出そうな箇所: operator page だけで完了扱いすると owner が Cloudflare page / GitHub Actions に取り残される。頻繁な bridge restart は進行中 turn の切断、Codex thread resume failure、transient progress loss、reconnect spam、app-server initialization latency を起こし得る。
- PR 前に確認すること: Issue #741、実装済み operator page behavior、VPS helper registry、worker runtime preset、generated worker 整合、targeted tests、full worker verify を確認する。
- 実装候補と捨てた案: GitHub Actions page へ直接誘導する案は捨てた。operator page で長時間 tracking する案も捨て、chat / notification / runtime truth に戻す導線だけをこの slice に入れた。
- merge 後に通す E2E: production deploy 後、Dashboard Butler chat から deploy operator URL を出し、passkey 認証後に chat へ戻ること、repo-less bridge restart proposal が unresolved service を指すこと、VPS service before/after truth を取得する live E2E を実施する。
- 次の PR を増やさない理由: この PR は予測できる穴を隠さず、deploy tracking state machine と production VPS helper manifest 更新を未接続として残す。ここまでを 1 PR に閉じることで、次 PR は chat tracking / deploy success follow-up の明確な残 scope だけを扱える。
- 停止条件: deploy 自動実行、credential mutation、permission mutation、destructive cleanup、または full chat tracking 完了宣言が必要になったら、この PR では停止する。

## Dry-run Impact Report

- Target Issue: Issue #741
- Implementing Success Criteria: repo-less `unresolved` bridge を正式な helper capability として扱う。Dashboard Butler の自然文から unresolved bridge restart intent を approval-bound VPS helper proposal へ接続する。deploy passkey operator は dispatch 後に Dashboard Butler chat へ戻す。
- Explicit Non-goals: deploy 実行、credential mutation、permission mutation、destructive cleanup、Issue close、merge、production VPS helper manifest 更新、full chat deploy tracking state machine。
- Expected touched files/routes/workflows: `src/core/passkey-operator-page.js`, `src/core/vps-privileged-maintenance.js`, `src/worker/runtime.js`, `worker.js`, `test/passkey-operator-page.test.js`, `test/vps-privileged-maintenance.test.js`, `test/worker.test.js`, `docs/development-strategy/issue-741-deploy-bridge-restart-automation.md`。
- Affected Issues: Issue #741 が直接対象。Issue #637 の VPS privileged maintenance lifecycle と Issue #590 / Issue #450 の Dashboard chat continuity に影響するが、これらを完了扱いしない。
- Affected PRs: 新規 PR のみ。PR #765 は merged / deployed 済みの前提で、この branch は origin/main から作成した。
- Affected workflows: deploy-production workflow の URL ではなく passkey operator URL を owner-facing entry とする。workflow dispatch 自体は既存 `/v2/action/deploy` route を使う。
- Affected runtime/operator surfaces: Dashboard Butler chat、same-origin passkey operator page、VPS privileged maintenance helper proposal、repo-less app-server bridge service。
- What may break if we patch narrowly: operator page に戻し導線だけを入れて chat tracking を未接続のまま過大主張すると、owner は完了/失敗/bridge follow-up を chat 上で追えない。頻繁な restart を無条件化すると進行中 turn が切れる。
- Unknowns to investigate before coding: production VPS helper manifest が deploy 後に registry を取り込むタイミング、deploy completion event から bridge follow-up を queue する安全な authority boundary、restart 頻度の CPU / memory 閾値。
- Validation needed: targeted node test、`npm run build:worker`、`npm run verify:worker`、PR 後の GitHub checks、merge/deploy 後の production E2E。
- Stop condition: deploy / credential / permission mutation や production service restart の実行が必要になったら passkey approval が必要なので停止する。

## Execution Queue Delta

- Queue position before: `Now` は Issue #590 の owner-facing observability。Issue #741 は deploy 後 bridge lifecycle の ROOT-adjacent recovery gap として、Issue #637 / #450 / #590 を支える NEXT slice。
- Preemption decision: NEXT
- Queue delta: Issue #741 moves into this PR as a bounded NEXT slice for deploy後 repo-less bridge restart導線。Issue #590 remains `Now`; Issue #637 remains `Next` / Root Blockers until broader privileged maintenance lifecycle is complete.
- Why this PR is next: owner が production deploy 後に bridge restart と operator URL 自動提示を明示し、現状は Mac Codex / SSH に戻らないと repo-less bridge recovery を完結できないため、今の deploy後 recovery path を先に塞ぐ必要がある。
- Active Issues not downscoped: Active Issues は縮小しない。Issue #590、Issue #637、Issue #450、Issue #741 の未接続 criteria は完了扱いせず、未満たし項目として残す。

## File / Line Hypotheses

- `src/core/vps-privileged-maintenance.js`: helper command registry に unresolved bridge service がないため、repo-less main chat の restart intent が正しい systemd user unit に落ちない。
- `src/worker/runtime.js`: natural-language preset が `repo 未設定 main chat` / `unresolved` を区別できないため、Dashboard Butler の自然文から wrong bridge または generic bridge restart に寄る。
- `src/core/passkey-operator-page.js`: deploy mode が dispatch 後に chat へ戻る動きを持たないと、operator page が tracking UI のように振る舞い、owner がチャットに受動復帰する必要が残る。
- `test/*`: 上記の route / registry / rendered page behavior を固定しないと、次の cost / deploy UI 変更でまた GitHub Actions URL や Mac Codex path に戻る。

## Hypothesis Retrospective

仮説は概ね当たりでした。existing deploy operator は `/v2/action/deploy` dispatch までは接続済みでしたが、dispatch 後に Dashboard Butler chat へ戻ることを page behavior と test で固定していませんでした。VPS helper registry も repo 設定済み bridge だけで、repo-less `unresolved` bridge の status / restart / logs がなかったため、自然文 recovery が正しい service を選べませんでした。

この PR で repo-less bridge capability と natural-language preset は接続しました。ただし deploy completion tracking と deploy success 後の bridge sync/restart proposal は未接続のままで、Completion status は incomplete です。

## Verification Evidence

- `node --test test/passkey-operator-page.test.js test/vps-privileged-maintenance.test.js test/worker.test.js --test-name-pattern "deploy mode|deploy run link|VPS privileged maintenance|repo-less Dashboard bridge|deploy operator|app-server bridge"`: 310 pass / 0 fail。
- `npm run build:worker && npm run verify:worker`: 1158 pass / 1 skipped / 0 fail、`check:self-parity` passed、`check:generated-worker` passed。
- `git diff --check`: passed。
- Evidence path/link: docs/development-strategy/issue-741-deploy-bridge-restart-automation.md とこの PR の test output。

## Butler Completion Contract

- Primary owner surface: Dashboard Butler only.
- Fallback surface: mac Codex は bootstrap / emergency fallback のみ。Custom GPT は fallback として扱い、主経路ではない。
- Owner goal: iPhone/iPad の Dashboard Butler chat から deploy operator URL を受け取り、passkey 認証後に chat へ戻って deploy / bridge follow-up を追えること。
- Butler entrypoint: Dashboard Butler の通常チャットで「デプロイして」「deploy 後 bridge restart」「repo 未設定 main chat の bridge を再起動して」と自然文で依頼する入口。
- Dashboard Butler natural-language path: Dashboard Butler chat が deploy / VPS maintenance intent を受け、repo-less bridge restart intent は Worker の natural-language preset から unresolved bridge helper proposal に到達する。
- Action Schema exposure: Custom GPT Action Schema は主経路ではない。この PR は Dashboard Butler / Worker runtime path を優先し、Action Schema だけで完了扱いしない。
- Runtime path: passkey operator page -> `/v2/action/deploy` dispatch -> returnUrl で Dashboard Butler chat。repo-less bridge restart は Dashboard chat -> Worker VPS maintenance proposal -> passkey operator -> helper queue。
- Runner/runtime truth: helper proposal は commandClass / argv / affectedPaths に unresolved systemd user unit を含める。production VPS before/after truth は merge/deploy 後 E2E で取得する必要がある。
- Authority boundary: deploy、credential mutation、permission mutation、destructive cleanup、privileged host maintenance は scoped passkey approval が必要。この PR は deploy/restart を実行しない。
- E2E evidence: 未実施。local unit / integration tests only。production iPhone/PWA と VPS service before/after truth は merge/deploy 後に必要。
- Completion status: incomplete

## Surface Update Checklist

- Dashboard Butler natural-language intent: repo-less bridge restart intent を unresolved bridge helper proposal に接続。
- Custom GPT Action Schema: 変更なし。主経路として扱わない。
- Runtime route / runner path: deploy operator return-to-chat と VPS maintenance proposal path を更新。
- Authority boundary: deploy / VPS restart は passkey approval-bound のまま。自動実行しない。
- Runtime truth: helper proposal の affectedPaths / command class を明示。production before/after truth は未取得。
- E2E evidence: 未実施。merge/deploy 後に必要。
