### PR TITLE
Issue #741 deploy後bridge sync/restartをqueue接続

### DIFF
--- a/docs/development-strategy/issue-741-deploy-bridge-restart-automation.md
+++ b/docs/development-strategy/issue-741-deploy-bridge-restart-automation.md
@@ -24,9 +24,9 @@ Issue #741 の deploy 後 checkout sync + bridge restart 標準運用と、Issue
 
 Cloudflare passkey operator page は approvalGrant を作るだけでは足りない。deploy mode では承認成功後に same-origin `/v2/action/deploy` へ approvalGrantId を POST し、Worker が deploy dispatch を検知できる必要がある。VPS maintenance mode でも同じく、承認成功後に `/v2/dashboard/chat/messages` へ approvalGrantId / vpsProposalId を戻し、Dashboard Butler が helper queue へ自動継続できる必要がある。owner に approvalGrantId をコピーさせる flow は fallback であり、通常導線ではない。
 
-deploy operator page は認証と dispatch の場であって、追跡UIではない。dispatch 後は `returnUrl` で Dashboard Butler の chat surface に戻す。chat 上の詳細な deploy tracking state と deploy success 後の bridge restart auto-proposal は後続 runtime path で接続するが、operator page に owner を残して GitHub Actions run link を眺めさせる設計にはしない。
+deploy operator page は認証と dispatch の場であって、追跡UIではない。dispatch 後は `returnUrl` で Dashboard Butler の chat surface に戻す。GitHub Actions deploy success event を Worker が受けたら、同じ chat thread に deploy 完了 truth と VPS checkout sync + repo-less bridge restart の approval_required proposal を出す。operator page に owner を残して GitHub Actions run link を眺めさせる設計にはしない。
 
-今回の実装最小単位は、VPS privileged maintenance capability registry と Dashboard natural-language preset が repo 設定済み bridge だけでなく `vtdd-dashboard-app-server-bridge-unresolved.service` も扱えるようにすること。実運用で動いている unresolved bridge が preset から抜けていると、Butler が「bridge restart」と理解しても正しい service を restart できない。
+今回の実装単位は、deploy success event から VPS privileged maintenance proposal を作り、same-origin VPS passkey operator URL を chat に出し、承認後の Dashboard chat auto-continue が既存 helper queue に固定 command envelope を渡すところまでを一塊で接続すること。実運用で動いている unresolved bridge が deploy 後 follow-up から抜けていると、Butler が「人間は認証だけ」という運用を満たせない。
 
 deploy operator URL は既に `selfParity.deployOperatorMarkdownLink` と passkey operator page に存在するため、今回はそれを GitHub Actions URL と混同しない guidance / tests を補強する。URL 自動提示は `vtddRetrieveSelfParity` を優先し、fallback でも same-origin `/v2/approval/passkey/operator?...actionType=deploy_production&highRiskKind=deploy_production` を返す。
 
@@ -34,7 +34,7 @@ deploy operator URL は既に `selfParity.deployOperatorMarkdownLink` と passke
 
 現在の blocker は deploy plane そのものではない。`/v2/action/deploy` は approvalGrant から workflow dispatch まで進める。足りないのは、owner-facing 会話で deploy operator URL を自動提示し、deploy 後に VPS bridge lifecycle follow-up をつなぐこと。
 
-さらに #637 preset は `vtdd-dashboard-app-server-bridge.service` だけを指している。repo-less main chat の正式経路で実際に動いている `vtdd-dashboard-app-server-bridge-unresolved.service` が抜けているため、今日の手動 restart と同じ場面で Butler から正しい capability proposal を作れない。
+さらに #637 preset は repo-less bridge restart まで扱えるようになったが、deploy success event からその proposal を自動生成する runtime path がまだない。今日の手動 restart と同じ場面で Butler から正しい capability proposal と operator URL を出せても、deploy 完了 chat に自動で出なければ owner はまた mac Codex / GitHub Actions / SSH に戻される。
 
 ## 検証計画
 
@@ -45,13 +45,18 @@ deploy operator URL は既に `selfParity.deployOperatorMarkdownLink` と passke
 - Unit: deploy operator page は passkey 承認後に `/v2/action/deploy` へ自動 dispatch する導線を維持する。
 - Unit: deploy operator page は dispatch 後に `returnUrl` で Dashboard Butler chat へ戻る導線を持つ。
 - Unit: VPS operator page は `dashboardThreadId` がある時に `/v2/dashboard/chat/messages` へ承認イベントを戻す導線を維持する。
-- Local: `node --test test/vps-privileged-maintenance.test.js test/worker.test.js --test-name-pattern "VPS privileged maintenance|deploy operator|app-server bridge"`
+- Unit: GitHub Actions deploy success event は同じ Dashboard chat に bridge sync/restart approval URL を追記する。
+- Unit: 同じ deploy event の重複受信は proposal / chat message / Web Push を二重化しない。
+- Unit: bridge follow-up approval grant が戻ると既存 helper queue に fixed script command envelope を渡す。
+- Unit: fixed helper script は tracked dirty checkout を restart 前に止め、before/after SHA と service truth を JSON で返す。
+- Local: `node --test test/sync-dashboard-app-server-bridge-after-deploy.test.js test/vps-privileged-maintenance.test.js test/worker.test.js --test-name-pattern "deploy|VPS privileged maintenance|app-server bridge|sync"`
 - Worker source を触る場合は `npm run build:worker` と `npm run verify:worker` を実行する。
 
 ## 改修見積もり
 
-- `src/core/vps-privileged-maintenance.js`: unresolved bridge status / restart / logs command registry entriesを追加する。risk は既存 main bridge capability と混同すること。
-- `src/worker/runtime.js`: Dashboard natural-language preset が unresolved bridge を選べるようにする。risk は通常 chat を helper proposal に誤分類すること。
+- `src/core/vps-privileged-maintenance.js`: deploy follow-up 用 fixed helper command registry entry を追加する。risk は arbitrary command 化することなので argv / allowedArgs は固定する。
+- `src/worker/runtime.js`: GitHub Actions deploy success event から unresolved bridge sync/restart approval proposal を作り、承認後の既存 helper queue へつなぐ。risk は deploy approval と VPS maintenance approval を混ぜること。
+- `scripts/sync-dashboard-app-server-bridge-after-deploy.mjs`: VPS checkout fast-forward と unresolved bridge restart を固定処理にする。risk は dirty checkout / service 名誤り / stdout に秘密を出すこと。
 - `src/core/passkey-operator-page.js`: 今回は既存 auto-dispatch 導線の回帰確認を基本とし、必要時だけ文言を補強する。risk は owner に approvalGrantId copy を要求する flow へ戻ること。
 - `test/vps-privileged-maintenance.test.js`: registry coverage を追加する。
 - `test/worker.test.js` / `test/passkey-operator-page.test.js`: unresolved bridge natural-language proposal、deploy operator URL guidance、passkey 承認後 auto-dispatch / auto-continue の回帰を追加する。
@@ -69,7 +74,7 @@ deploy operator URL は既に `selfParity.deployOperatorMarkdownLink` と passke
 
 ## 未確認の境界
 
-deploy workflow 完了を Worker が長時間 polling して bridge restart まで自動連鎖する runtime path はまだ未確認。GitHub Actions の protected environment approval と passkey approval は別 gate であり、どちらも bypass しない。dispatch 後に chat へ戻る導線は入れるが、chat 上で running/success/failure/bridge follow-up を細かく追跡する state machine は後続接続が必要。
+deploy workflow の長時間 polling 自体はまだ作らない。今回の runtime entrypoint は GitHub Actions deploy success event webhook / repository_dispatch 相当の受信であり、受信後に bridge follow-up proposal を chat に出す。GitHub Actions の protected environment approval と passkey approval は別 gate であり、どちらも bypass しない。deploy approval grant だけでは VPS maintenance execution を開始しない。
 
 VPS helper が現在の production host で unresolved bridge capability manifest を持っているかは deploy 後 live evidence が必要。repo に registry が入るだけでは root-owned manifest の現物更新完了ではない。
 
@@ -78,7 +83,7 @@ bridge restart の頻度による副作用は未測定。予測されるリス�
 ## 穴が出そうな箇所
 
 - GitHub Actions workflow URL を deploy URL として返すと、owner は認証だけで済まない。
-- deploy approval scope に bridge restart まで含めるかは未決定。今回の slice は deploy 後 follow-up capability を作るが、勝手に destructive / maintenance execution を始めない。
+- deploy approval scope に bridge restart までは含めない。今回の slice は deploy 後 follow-up approval URL を作るが、勝手に destructive / maintenance execution を始めない。
 - unresolved bridge を残骸扱いで stop/disable すると repo-less main chat を壊す。
 - broad `bridge restart` intent で全 bridge を同時 restart すると進行中 turn を落とす可能性がある。
 - health check なしの周期 restart は、長時間開発 turn と衝突して owner-facing UX を悪化させる可能性がある。
@@ -93,7 +98,9 @@ bridge restart の頻度による副作用は未測定。予測されるリス�
 
 ## 実装候補と捨てた案
 
-採用: unresolved bridge service 用の status / restart / logs capability を registry に追加し、natural-language preset が unresolved を選べるようにする。
+採用: deploy success event から unresolved bridge checkout sync + restart fixed command の approval proposal を自動生成し、同じ chat thread に operator URL を提示する。
+
+採用: fixed helper script で `git fetch` / `git pull --ff-only` / `systemctl --user restart vtdd-dashboard-app-server-bridge-unresolved.service` を実行し、before/after truth を JSON にまとめる。
 
 採用: deploy operator URL は self-parity same-origin link を正とし、GitHub Actions workflow URL は run 追跡用としてのみ扱う。
 
@@ -118,7 +125,7 @@ bridge restart の頻度による副作用は未測定。予測されるリス�
 
 deploy operator URL 自動提示と bridge restart は owner から見て同じ deploy follow-up workflow であり、今日の手動作業で一続きに露呈した gap である。少なくとも unresolved bridge capability を同じ slice で入れないと、deploy 後 restart automation が実運用対象を外す。
 
-ただし long-running deploy polling から automatic VPS helper execution までを完全接続するには authority scope の確認が必要なので、この PR では capability / natural-language / URL guidance の最小接続に留める。
+ただし deploy approval と VPS maintenance approval は分ける。自動化するのは proposal / operator URL / helper queue handoff までで、owner の scoped passkey approval なしに restart は始めない。
 
 ## 停止条件
 

--- a/scripts/sync-dashboard-app-server-bridge-after-deploy.mjs
+++ b/scripts/sync-dashboard-app-server-bridge-after-deploy.mjs
@@ -1,0 +1,206 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import process from "node:process";
+
+const DEFAULT_SERVICE = "vtdd-dashboard-app-server-bridge-unresolved.service";
+const DEFAULT_REF = "origin/main";
+
+function parseArgs(argv = process.argv.slice(2)) {
+  const options = {
+    service: DEFAULT_SERVICE,
+    ref: DEFAULT_REF,
+    cwd: process.cwd()
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const value = argv[index];
+    if (value === "--service") options.service = argv[++index] || "";
+    else if (value === "--ref") options.ref = argv[++index] || "";
+    else if (value === "--cwd") options.cwd = argv[++index] || "";
+    else if (value === "--help") options.help = true;
+    else throw new Error(`unsupported argument: ${value}`);
+  }
+  return options;
+}
+
+function assertSafeService(service) {
+  if (service !== DEFAULT_SERVICE) {
+    throw new Error(`service must be ${DEFAULT_SERVICE}`);
+  }
+}
+
+function assertSafeRef(ref) {
+  if (!["origin/main", "main"].includes(ref)) {
+    throw new Error("ref must be origin/main or main");
+  }
+}
+
+function runCommand({ command, args = [], cwd, allowFailure = false, runner = spawnSync }) {
+  const result = runner(command, args, {
+    cwd,
+    encoding: "utf8",
+    shell: false,
+    maxBuffer: 1024 * 1024
+  });
+  const exitCode = typeof result.status === "number" ? result.status : result.error ? 1 : 0;
+  const record = {
+    command,
+    args,
+    exitCode,
+    stdout: String(result.stdout || "").trim(),
+    stderr: String(result.stderr || "").trim()
+  };
+  if (!allowFailure && exitCode !== 0) {
+    const error = new Error(`${command} ${args.join(" ")} failed with exit code ${exitCode}`);
+    error.commandResult = record;
+    throw error;
+  }
+  return record;
+}
+
+function readGitState({ cwd, runner }) {
+  const head = runCommand({ command: "git", args: ["rev-parse", "HEAD"], cwd, runner }).stdout;
+  const branch = runCommand({ command: "git", args: ["status", "--short", "--branch"], cwd, runner }).stdout;
+  const diff = runCommand({ command: "git", args: ["diff", "--quiet"], cwd, runner, allowFailure: true });
+  const staged = runCommand({ command: "git", args: ["diff", "--cached", "--quiet"], cwd, runner, allowFailure: true });
+  return {
+    head,
+    branch,
+    trackedDirty: diff.exitCode !== 0 || staged.exitCode !== 0
+  };
+}
+
+function readServiceState({ cwd, service, runner }) {
+  const active = runCommand({
+    command: "systemctl",
+    args: ["--user", "is-active", service],
+    cwd,
+    runner,
+    allowFailure: true
+  }).stdout;
+  const show = runCommand({
+    command: "systemctl",
+    args: ["--user", "show", service, "--property=ActiveState,SubState,MainPID,ExecMainPID,ExecMainStatus,ActiveEnterTimestamp"],
+    cwd,
+    runner,
+    allowFailure: true
+  }).stdout;
+  const properties = Object.fromEntries(
+    show
+      .split("\n")
+      .map((line) => line.split("="))
+      .filter((parts) => parts.length === 2)
+  );
+  return {
+    active,
+    activeState: properties.ActiveState || "",
+    subState: properties.SubState || "",
+    mainPid: properties.MainPID || properties.ExecMainPID || "",
+    execMainStatus: properties.ExecMainStatus || "",
+    activeEnterTimestamp: properties.ActiveEnterTimestamp || ""
+  };
+}
+
+export async function runDeployBridgeSyncRestart({
+  cwd = process.cwd(),
+  service = DEFAULT_SERVICE,
+  ref = DEFAULT_REF,
+  runner = spawnSync,
+  now = () => new Date().toISOString()
+} = {}) {
+  assertSafeService(service);
+  assertSafeRef(ref);
+  const beforeGit = readGitState({ cwd, runner });
+  const beforeService = readServiceState({ cwd, service, runner });
+  if (beforeGit.trackedDirty) {
+    return {
+      ok: false,
+      status: "blocked_tracked_dirty_checkout",
+      cwd,
+      service,
+      ref,
+      before: {
+        git: beforeGit,
+        service: beforeService
+      },
+      after: null,
+      runtimeTruth: {
+        kind: "dashboard_bridge_deploy_sync_restart",
+        status: "blocked_tracked_dirty_checkout",
+        rootExecutionStarted: false,
+        helperExecutionStarted: true,
+        serviceRestarted: false,
+        checkedAt: now()
+      }
+    };
+  }
+
+  const fetch = runCommand({ command: "git", args: ["fetch", "origin", "main"], cwd, runner });
+  const pull = runCommand({ command: "git", args: ["pull", "--ff-only", "origin", "main"], cwd, runner });
+  const restart = runCommand({ command: "systemctl", args: ["--user", "restart", service], cwd, runner });
+  const afterGit = readGitState({ cwd, runner });
+  const afterService = readServiceState({ cwd, service, runner });
+  return {
+    ok: true,
+    status: "synced_and_restarted",
+    cwd,
+    service,
+    ref,
+    before: {
+      git: beforeGit,
+      service: beforeService
+    },
+    commands: {
+      fetch,
+      pull,
+      restart
+    },
+    after: {
+      git: afterGit,
+      service: afterService
+    },
+    runtimeTruth: {
+      kind: "dashboard_bridge_deploy_sync_restart",
+      status: "synced_and_restarted",
+      rootExecutionStarted: false,
+      helperExecutionStarted: true,
+      serviceRestarted: true,
+      beforeSha: beforeGit.head,
+      afterSha: afterGit.head,
+      beforeServiceActiveState: beforeService.activeState || beforeService.active,
+      afterServiceActiveState: afterService.activeState || afterService.active,
+      afterServiceMainPid: afterService.mainPid,
+      checkedAt: now()
+    }
+  };
+}
+
+async function main() {
+  const options = parseArgs();
+  if (options.help) {
+    process.stdout.write(`Usage: node scripts/sync-dashboard-app-server-bridge-after-deploy.mjs --service ${DEFAULT_SERVICE} --ref origin/main\n`);
+    return;
+  }
+  const result = await runDeployBridgeSyncRestart(options);
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+  process.exitCode = result.ok ? 0 : 2;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((error) => {
+    const result = {
+      ok: false,
+      status: "failed",
+      error: error.message,
+      commandResult: error.commandResult || null,
+      runtimeTruth: {
+        kind: "dashboard_bridge_deploy_sync_restart",
+        status: "failed",
+        rootExecutionStarted: false,
+        helperExecutionStarted: true,
+        serviceRestarted: false
+      }
+    };
+    process.stderr.write(`${JSON.stringify(result, null, 2)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/src/core/vps-privileged-maintenance.js
+++ b/src/core/vps-privileged-maintenance.js
@@ -154,6 +154,24 @@ const HELPER_COMMAND_REGISTRY = defineHelperCommandRegistry([
     initialPreset: true
   },
   {
+    commandClass: "dashboard_bridge_unresolved_deploy_sync_restart",
+    title: "Sync checkout and restart repo-less Dashboard app-server bridge after deploy",
+    allowedArgs: [
+      "node scripts/sync-dashboard-app-server-bridge-after-deploy.mjs --service vtdd-dashboard-app-server-bridge-unresolved.service --ref origin/main"
+    ],
+    argv: [
+      "node",
+      "scripts/sync-dashboard-app-server-bridge-after-deploy.mjs",
+      "--service",
+      "vtdd-dashboard-app-server-bridge-unresolved.service",
+      "--ref",
+      "origin/main"
+    ],
+    requiredRiskLevel: "medium",
+    requiresRoot: false,
+    initialPreset: true
+  },
+  {
     commandClass: "vps_runner_status_dry_run",
     title: "Check VPS runner queue status without executing work",
     allowedArgs: ["node scripts/run-vps-runner.mjs --dry-run"],

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -4506,15 +4506,29 @@ async function handleGitHubActionsEventRequest(request, env) {
     event: baseEvent,
     threadId
   });
+  const deployBridgeFollowup =
+    existingEvent || !isSuccessfulDeployWorkflowEvent(baseEvent)
+      ? {
+          status: existingEvent ? "duplicate_event_skipped" : "not_required",
+          proposalCreated: false,
+          message: null
+        }
+      : await buildDeployBridgeFollowupChatMessage({
+          event: baseEvent,
+          threadId,
+          env,
+          origin: new URL(request.url).origin
+        });
+  const chatMessages = [chatMessage, deployBridgeFollowup.message].filter(Boolean);
   const chatStore = resolveDashboardChatStore(env);
   let messages = [];
   let chatAppendStatus = "unavailable";
   let chatAppendError = null;
   let chatAppendReason = null;
-  if (chatMessage) {
+  if (chatMessages.length > 0) {
     if (chatStore) {
       try {
-        messages = await chatStore.appendMany(threadId, [chatMessage]);
+        messages = await chatStore.appendMany(threadId, chatMessages);
         chatAppendStatus = messages.length > 0 ? "appended" : "skipped";
       } catch (error) {
         chatAppendStatus = "failed";
@@ -4566,9 +4580,193 @@ async function handleGitHubActionsEventRequest(request, env) {
     chatAppendError,
     chatAppendReason,
     messages,
+    deployBridgeFollowup: {
+      ...deployBridgeFollowup,
+      message: deployBridgeFollowup.message
+        ? {
+            messageId: deployBridgeFollowup.message.messageId,
+            status: deployBridgeFollowup.message.status
+          }
+        : null
+    },
     webSocketBroadcast,
     webPush: recorded.webPush
   });
+}
+
+function isSuccessfulDeployWorkflowEvent(event) {
+  const record = normalizeDashboardEventRecord(event);
+  return (
+    record.kind === "github_actions_workflow_run" &&
+    normalize(record.workflowName).includes("deploy") &&
+    normalizeDashboardEventText(record.status).toLowerCase() === "completed" &&
+    normalizeDashboardEventText(record.conclusion).toLowerCase() === "success"
+  );
+}
+
+async function buildDeployBridgeFollowupChatMessage({ event, threadId, env, origin } = {}) {
+  const record = normalizeDashboardEventRecord(event);
+  const repository = normalizeCanonicalRepositoryInput(record.repository);
+  const relatedIssue =
+    normalizePositiveInteger(record.issueNumber) ||
+    normalizePositiveInteger(env?.VTDD_DASHBOARD_DEPLOY_BRIDGE_FOLLOWUP_ISSUE) ||
+    741;
+  const messageId = `dashboard-event:${record.id}:deploy-bridge-followup`;
+  const workingDirectory = normalizeText(env?.VTDD_DASHBOARD_VPS_MAINTENANCE_WORKDIR);
+  const host = normalizeDashboardVpsMaintenanceHost({ env });
+  const provider = resolveMemoryProvider(env);
+  const memoryValidation = validateMemoryProvider(provider);
+  if (!memoryValidation.ok || !repository || !host || !workingDirectory) {
+    const issues = [
+      !memoryValidation.ok ? "memory_provider_unavailable" : "",
+      !repository ? "repository_required" : "",
+      !host ? "VTDD_DASHBOARD_VPS_MAINTENANCE_HOST required" : "",
+      !workingDirectory ? "VTDD_DASHBOARD_VPS_MAINTENANCE_WORKDIR required" : ""
+    ].filter(Boolean);
+    return {
+      status: "blocked",
+      proposalCreated: false,
+      error: "deploy_bridge_followup_configuration_required",
+      issues,
+      message: normalizeDashboardChatMessage(
+        {
+          threadId,
+          messageId,
+          role: "system",
+          repository,
+          relatedIssue,
+          status: "blocked",
+          text: buildDeployBridgeFollowupBlockedMessage({ record, repository, relatedIssue, issues }),
+          createdAt: record.updatedAt || record.createdAt
+        },
+        { threadId }
+      )
+    };
+  }
+
+  const executionId = `deploy-bridge-followup-${safeIdentifier(record.runId) || createDashboardRequestId("deploy")}`;
+  const allowedArg =
+    "node scripts/sync-dashboard-app-server-bridge-after-deploy.mjs --service vtdd-dashboard-app-server-bridge-unresolved.service --ref origin/main";
+  const proposal = await createVpsPrivilegedMaintenanceProposal({
+    payload: {
+      host,
+      repository,
+      relatedIssue,
+      operation: "enable",
+      id: "dashboard.bridge.unresolved.deploy.sync.restart",
+      title: "Deploy後 repo-less Dashboard bridge sync/restart",
+      commandClass: "dashboard_bridge_unresolved_deploy_sync_restart",
+      riskLevel: "medium",
+      workingDirectories: [workingDirectory],
+      allowedArgs: [allowedArg],
+      affectedPaths: [
+        workingDirectory,
+        "/home/vtdd-runner/.config/systemd/user",
+        "/run/user",
+        "vtdd-dashboard-app-server-bridge-unresolved.service"
+      ],
+      redactionRules: ["no secrets", "summarize stdout/stderr", "redact tokens and credentials"],
+      rollbackPlan: "stop auto follow-up proposal and restart the previous bridge service state manually if needed",
+      expectedRuntimeTruth: [
+        "before git HEAD",
+        "after git HEAD",
+        "before service active state",
+        "after service active state",
+        "after service main PID",
+        "exit code"
+      ],
+      reason: `Issue #741 deploy run ${record.runId} success at ${record.headSha || "unknown sha"} requires VPS checkout sync and repo-less bridge restart follow-up`,
+      impactScope: `${workingDirectory}, vtdd-dashboard-app-server-bridge-unresolved.service`,
+      dashboardThreadId: threadId,
+      executionId
+    },
+    provider,
+    origin: origin || "https://example.com"
+  });
+  if (!proposal.ok) {
+    return {
+      status: "blocked",
+      proposalCreated: false,
+      error: proposal.error,
+      issues: proposal.issues || [],
+      message: normalizeDashboardChatMessage(
+        {
+          threadId,
+          messageId,
+          role: "system",
+          repository,
+          relatedIssue,
+          status: "blocked",
+          text: buildDeployBridgeFollowupBlockedMessage({
+            record,
+            repository,
+            relatedIssue,
+            issues: proposal.issues || [proposal.error || "proposal_failed"]
+          }),
+          createdAt: record.updatedAt || record.createdAt
+        },
+        { threadId }
+      )
+    };
+  }
+
+  return {
+    status: "approval_required",
+    proposalCreated: true,
+    vpsProposalId: proposal.body.vpsProposalId,
+    approvalScope: proposal.body.approvalScope,
+    approvalOperatorUrl: proposal.body.approvalOperatorUrl,
+    message: normalizeDashboardChatMessage(
+      {
+        threadId,
+        messageId,
+        role: "system",
+        repository,
+        relatedIssue,
+        status: "blocked",
+        text: buildDeployBridgeFollowupApprovalRequiredMessage({
+          record,
+          repository,
+          relatedIssue,
+          proposal: proposal.body
+        }),
+        createdAt: record.updatedAt || record.createdAt
+      },
+      { threadId }
+    )
+  };
+}
+
+function buildDeployBridgeFollowupApprovalRequiredMessage({ record, repository, relatedIssue, proposal } = {}) {
+  return [
+    "deploy 後 bridge sync/restart の承認が必要です。",
+    "",
+    `- repo: ${repository || "未確認"}`,
+    `- related Issue: #${relatedIssue || 741}`,
+    `- deploy run: ${record.runId || "未確認"}`,
+    `- deploy sha: ${record.headSha ? record.headSha.slice(0, 12) : "未確認"}`,
+    "- 対象: repo-less Dashboard app-server bridge",
+    "- service: vtdd-dashboard-app-server-bridge-unresolved.service",
+    `- vpsProposalId: ${proposal?.vpsProposalId || "未作成"}`,
+    "- authority: deploy approval とは別の scoped passkey approval が必要です。",
+    "- runtime truth: status=approval_required, rootExecutionStarted=false, helperExecutionStarted=false",
+    proposal?.approvalOperatorUrl ? `- approval URL: ${proposal.approvalOperatorUrl}` : "- approval URL: 未生成",
+    "",
+    "承認後は Dashboard chat が VPS helper queue へ fixed sync/restart command を渡します。VPS runner の before/after truth が戻るまで live restart 完了とは扱いません。"
+  ].join("\n");
+}
+
+function buildDeployBridgeFollowupBlockedMessage({ record, repository, relatedIssue, issues } = {}) {
+  return [
+    "deploy 後 bridge sync/restart follow-up を作れませんでした。",
+    "",
+    `- repo: ${repository || "未確認"}`,
+    `- related Issue: #${relatedIssue || 741}`,
+    `- deploy run: ${record?.runId || "未確認"}`,
+    `- reason: ${(issues || []).join("; ") || "configuration required"}`,
+    "- runtime truth: status=blocked, rootExecutionStarted=false, helperExecutionStarted=false",
+    "- next action: runtime config と memory provider を確認してから、同じ chat で VPS maintenance approval URL を再提示します。"
+  ].join("\n");
 }
 
 async function readDashboardEventById(eventStore, eventId) {
@@ -13015,6 +13213,7 @@ function buildGitHubActionsDashboardChatMessageText(event) {
   }
   lines.push("", "次:");
   if (isDeploy && conclusion === "success") {
+    lines.push("- deploy 後 bridge sync/restart approval URL を同じ chat に出します。");
     lines.push("- production E2E / runtime truth を確認します。");
   } else if (conclusion === "failure" || conclusion === "cancelled" || conclusion === "timed_out") {
     lines.push("- deploy / Actions の失敗原因を確認し、blocker と次 action を出します。");

--- a/test/sync-dashboard-app-server-bridge-after-deploy.test.js
+++ b/test/sync-dashboard-app-server-bridge-after-deploy.test.js
@@ -1,0 +1,85 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { runDeployBridgeSyncRestart } from "../scripts/sync-dashboard-app-server-bridge-after-deploy.mjs";
+
+function createFakeRunner({ dirty = false } = {}) {
+  const calls = [];
+  let head = "before-sha";
+  const runner = (command, args) => {
+    calls.push([command, ...args]);
+    const joined = [command, ...args].join(" ");
+    if (joined === "git rev-parse HEAD") {
+      return { status: 0, stdout: `${head}\n`, stderr: "" };
+    }
+    if (joined === "git status --short --branch") {
+      return { status: 0, stdout: "## main...origin/main\n?? .tmp/\n", stderr: "" };
+    }
+    if (joined === "git diff --quiet") {
+      return { status: dirty ? 1 : 0, stdout: "", stderr: "" };
+    }
+    if (joined === "git diff --cached --quiet") {
+      return { status: 0, stdout: "", stderr: "" };
+    }
+    if (joined === "systemctl --user is-active vtdd-dashboard-app-server-bridge-unresolved.service") {
+      return { status: 0, stdout: "active\n", stderr: "" };
+    }
+    if (
+      joined ===
+      "systemctl --user show vtdd-dashboard-app-server-bridge-unresolved.service --property=ActiveState,SubState,MainPID,ExecMainPID,ExecMainStatus,ActiveEnterTimestamp"
+    ) {
+      return {
+        status: 0,
+        stdout: "ActiveState=active\nSubState=running\nMainPID=1234\nExecMainStatus=0\nActiveEnterTimestamp=Thu 2026-06-04 15:00:46 JST\n",
+        stderr: ""
+      };
+    }
+    if (joined === "git fetch origin main") {
+      return { status: 0, stdout: "", stderr: "" };
+    }
+    if (joined === "git pull --ff-only origin main") {
+      head = "after-sha";
+      return { status: 0, stdout: "Fast-forward\n", stderr: "" };
+    }
+    if (joined === "systemctl --user restart vtdd-dashboard-app-server-bridge-unresolved.service") {
+      return { status: 0, stdout: "", stderr: "" };
+    }
+    return { status: 127, stdout: "", stderr: `unexpected command: ${joined}` };
+  };
+  return { runner, calls };
+}
+
+test("deploy bridge sync/restart helper fast-forwards checkout and restarts unresolved bridge", async () => {
+  const fake = createFakeRunner();
+  const result = await runDeployBridgeSyncRestart({
+    cwd: "/repo",
+    service: "vtdd-dashboard-app-server-bridge-unresolved.service",
+    ref: "origin/main",
+    runner: fake.runner,
+    now: () => "2026-06-04T06:00:00.000Z"
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.status, "synced_and_restarted");
+  assert.equal(result.runtimeTruth.beforeSha, "before-sha");
+  assert.equal(result.runtimeTruth.afterSha, "after-sha");
+  assert.equal(result.runtimeTruth.afterServiceMainPid, "1234");
+  assert.deepEqual(fake.calls.filter((call) => call[0] === "systemctl" && call.includes("restart")), [
+    ["systemctl", "--user", "restart", "vtdd-dashboard-app-server-bridge-unresolved.service"]
+  ]);
+});
+
+test("deploy bridge sync/restart helper blocks tracked dirty checkout before restart", async () => {
+  const fake = createFakeRunner({ dirty: true });
+  const result = await runDeployBridgeSyncRestart({
+    cwd: "/repo",
+    service: "vtdd-dashboard-app-server-bridge-unresolved.service",
+    ref: "origin/main",
+    runner: fake.runner,
+    now: () => "2026-06-04T06:00:00.000Z"
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.status, "blocked_tracked_dirty_checkout");
+  assert.equal(result.runtimeTruth.serviceRestarted, false);
+  assert.equal(fake.calls.some((call) => call.join(" ") === "systemctl --user restart vtdd-dashboard-app-server-bridge-unresolved.service"), false);
+});

--- a/test/vps-privileged-maintenance.test.js
+++ b/test/vps-privileged-maintenance.test.js
@@ -151,6 +151,7 @@ test("VPS privileged maintenance helper command registry exposes initial presets
   assert.equal(commandClasses.includes("systemd_user_app_server_bridge_unresolved_status"), true);
   assert.equal(commandClasses.includes("systemd_user_app_server_bridge_unresolved_restart"), true);
   assert.equal(commandClasses.includes("systemd_user_app_server_bridge_unresolved_logs"), true);
+  assert.equal(commandClasses.includes("dashboard_bridge_unresolved_deploy_sync_restart"), true);
   assert.equal(commandClasses.includes("vps_runner_status_dry_run"), true);
   assert.equal(commandClasses.includes("vps_maintenance_install_inventory_collect"), true);
   assert.equal(
@@ -162,6 +163,28 @@ test("VPS privileged maintenance helper command registry exposes initial presets
     true
   );
   assert.equal(registry.every((entry) => entry.initialPreset === true), true);
+});
+
+test("VPS privileged maintenance registry includes fixed deploy bridge sync/restart helper", () => {
+  const registry = listVpsPrivilegedMaintenanceCommandRegistry();
+  const entry = registry.find((item) => item.commandClass === "dashboard_bridge_unresolved_deploy_sync_restart");
+
+  assert.ok(entry);
+  assert.equal(entry.title, "Sync checkout and restart repo-less Dashboard app-server bridge after deploy");
+  assert.deepEqual(entry.argv, [
+    "node",
+    "scripts/sync-dashboard-app-server-bridge-after-deploy.mjs",
+    "--service",
+    "vtdd-dashboard-app-server-bridge-unresolved.service",
+    "--ref",
+    "origin/main"
+  ]);
+  assert.deepEqual(entry.allowedArgs, [
+    "node scripts/sync-dashboard-app-server-bridge-after-deploy.mjs --service vtdd-dashboard-app-server-bridge-unresolved.service --ref origin/main"
+  ]);
+  assert.equal(entry.requiredRiskLevel, "medium");
+  assert.equal(entry.requiresRoot, false);
+  assert.equal(entry.initialPreset, true);
 });
 
 test("VPS privileged maintenance registry separates repo-less Dashboard bridge service", () => {

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -6225,6 +6225,7 @@ test("worker redacts dashboard push subscription raw material from D1 payload_js
 test("worker ingests GitHub Actions deploy completion event and shows it on dashboard", async () => {
   const store = createInMemoryDashboardEventStore();
   const chatStore = createInMemoryDashboardChatStore();
+  const provider = createInMemoryMemoryProvider();
   const rooms = createMockDashboardChatRoomNamespace();
   const pushStore = createInMemoryDashboardPushSubscriptionStore();
   const pushKeys = await createTestPushSubscription({
@@ -6266,7 +6267,10 @@ test("worker ingests GitHub Actions deploy completion event and shows it on dash
       DASHBOARD_EVENT_STORE: store,
       DASHBOARD_CHAT_STORE: chatStore,
       DASHBOARD_CHAT_ROOMS: rooms.namespace,
-      DASHBOARD_PUSH_SUBSCRIPTION_STORE: pushStore
+      DASHBOARD_PUSH_SUBSCRIPTION_STORE: pushStore,
+      MEMORY_PROVIDER: provider,
+      VTDD_DASHBOARD_VPS_MAINTENANCE_HOST: "x85-131-245-163",
+      VTDD_DASHBOARD_VPS_MAINTENANCE_WORKDIR: "/home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p"
     }
   );
 
@@ -6284,7 +6288,7 @@ test("worker ingests GitHub Actions deploy completion event and shows it on dash
   assert.equal(eventBody.chatAppendStatus, "appended");
   assert.equal(eventBody.chatAppendError, null);
   assert.equal(eventBody.chatAppendReason, null);
-  assert.equal(eventBody.messages.length, 1);
+  assert.equal(eventBody.messages.length, 2);
   assert.equal(eventBody.messages[0].messageId, "dashboard-event:github-actions:marushu/vtdd-v2-p:deploy-production:26133044458");
   assert.equal(eventBody.messages[0].role, "system");
   assert.equal(eventBody.messages[0].repository, "marushu/vtdd-v2-p");
@@ -6292,8 +6296,29 @@ test("worker ingests GitHub Actions deploy completion event and shows it on dash
   assert.equal(eventBody.messages[0].status, "replied");
   assert.equal(eventBody.messages[0].text.includes("デプロイ完了イベントを受信しました。"), true);
   assert.equal(eventBody.messages[0].text.includes("- PR: PR #552"), true);
+  assert.equal(eventBody.messages[0].text.includes("deploy 後 bridge sync/restart approval URL を同じ chat に出します。"), true);
   assert.equal(eventBody.messages[0].text.includes("- production E2E / runtime truth を確認します。"), true);
   assert.equal(eventBody.messages[0].text.includes("merge / deploy / credential / permission"), true);
+  assert.equal(eventBody.messages[1].messageId, "dashboard-event:github-actions:marushu/vtdd-v2-p:deploy-production:26133044458:deploy-bridge-followup");
+  assert.equal(eventBody.messages[1].role, "system");
+  assert.equal(eventBody.messages[1].status, "blocked");
+  assert.equal(eventBody.messages[1].relatedIssue, 741);
+  assert.equal(eventBody.messages[1].text.includes("deploy 後 bridge sync/restart の承認が必要です。"), true);
+  assert.equal(eventBody.messages[1].text.includes("vtdd-dashboard-app-server-bridge-unresolved.service"), true);
+  assert.equal(eventBody.messages[1].text.includes("status=approval_required, rootExecutionStarted=false, helperExecutionStarted=false"), true);
+  assert.equal(eventBody.deployBridgeFollowup.status, "approval_required");
+  assert.equal(eventBody.deployBridgeFollowup.proposalCreated, true);
+  assert.equal(eventBody.deployBridgeFollowup.approvalScope.vpsCapabilityId, "dashboard.bridge.unresolved.deploy.sync.restart");
+  const followupApprovalUrl = new URL(eventBody.deployBridgeFollowup.approvalOperatorUrl);
+  assert.equal(followupApprovalUrl.searchParams.get("mode"), "vps");
+  assert.equal(followupApprovalUrl.searchParams.get("dashboardThreadId"), "dashboard-main-marushu-vtdd-v2-p");
+  assert.equal(followupApprovalUrl.searchParams.get("vpsProposalId"), eventBody.deployBridgeFollowup.vpsProposalId);
+  const approvalRecords = await provider.retrieve({ type: MemoryRecordType.APPROVAL_LOG, limit: 10 });
+  const followupProposalRecord = approvalRecords.find((record) => record.id === eventBody.deployBridgeFollowup.vpsProposalId);
+  assert.equal(followupProposalRecord.content.proposal.capability.commandClass, "dashboard_bridge_unresolved_deploy_sync_restart");
+  assert.deepEqual(followupProposalRecord.content.proposal.capability.allowedArgs, [
+    "node scripts/sync-dashboard-app-server-bridge-after-deploy.mjs --service vtdd-dashboard-app-server-bridge-unresolved.service --ref origin/main"
+  ]);
   assert.equal(JSON.stringify(eventBody.messages).includes("approval:must-not-persist"), false);
   assert.equal(JSON.stringify(eventBody.messages).includes("secret-must-not-persist"), false);
   assert.equal(eventBody.webSocketBroadcast, true);
@@ -6336,11 +6361,75 @@ test("worker ingests GitHub Actions deploy completion event and shows it on dash
   );
   assert.equal(chatResponse.status, 200);
   const chatBody = await chatResponse.json();
-  assert.equal(chatBody.messages.length, 1);
+  assert.equal(chatBody.messages.length, 2);
   assert.equal(chatBody.messages[0].role, "system");
   assert.equal(chatBody.messages[0].text.includes("デプロイ完了イベントを受信しました。"), true);
   assert.equal(chatBody.messages[0].text.includes("- PR: PR #552"), true);
   assert.equal(chatBody.messages[0].text.includes("bare #552"), false);
+  assert.equal(chatBody.messages[1].text.includes("approval URL:"), true);
+
+  await provider.store({
+    id: "approval:deploy-bridge-followup",
+    type: MemoryRecordType.APPROVAL_LOG,
+    content: {
+      kind: "passkey_grant",
+      status: "verified",
+      approvalId: "approval:deploy-bridge-followup",
+      credentialId: "AQIDBA",
+      verifiedAt: "2026-05-20T00:11:00.000Z",
+      expiresAt: "2999-01-01T00:00:00.000Z",
+      scope: eventBody.deployBridgeFollowup.approvalScope
+    },
+    metadata: { source: "deploy-bridge-followup-test" },
+    priority: 96,
+    tags: ["passkey_grant", "passkey_approval", "verified"],
+    createdAt: "2026-05-20T00:11:00.000Z"
+  });
+  const queueCalls = [];
+  const approvedResponse = await worker.fetch(
+    new Request("https://example.com/v2/dashboard/chat/messages", {
+      method: "POST",
+      headers: gatewayAuthHeaders,
+      body: JSON.stringify({
+        threadId: "dashboard-main-marushu-vtdd-v2-p",
+        repository: "marushu/vtdd-v2-p",
+        issueNumber: 741,
+        text: "deploy 後 bridge sync/restart を承認済みなので進めて。",
+        vpsProposalId: eventBody.deployBridgeFollowup.vpsProposalId,
+        approvalGrantId: "approval:deploy-bridge-followup",
+        executionId: "deploy-bridge-followup-26133044458"
+      })
+    }),
+    {
+      ...gatewayAuthEnv,
+      DASHBOARD_CHAT_STORE: chatStore,
+      MEMORY_PROVIDER: provider,
+      VTDD_DASHBOARD_VPS_MAINTENANCE_HOST: "x85-131-245-163",
+      VTDD_DASHBOARD_VPS_MAINTENANCE_WORKDIR: "/home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p",
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_deploy_bridge_followup",
+      GITHUB_API_FETCH: async (url, init) => {
+        queueCalls.push({ url, init });
+        return new Response(
+          JSON.stringify({
+            id: 74101,
+            html_url: "https://github.com/marushu/vtdd-v2-p/issues/741#issuecomment-74101"
+          }),
+          { status: 201, headers: { "content-type": "application/json" } }
+        );
+      }
+    }
+  );
+  assert.equal(approvedResponse.status, 202);
+  const approvedBody = await approvedResponse.json();
+  assert.equal(approvedBody.execution.status, "queued_for_vps_helper_execution");
+  assert.equal(approvedBody.execution.runtimeTruth.helperQueueReached, true);
+  assert.equal(approvedBody.execution.runtimeTruth.rootExecutionStarted, false);
+  assert.equal(approvedBody.execution.runtimeTruth.helperExecutionStarted, false);
+  assert.equal(queueCalls.length, 1);
+  const queueCommentBody = JSON.parse(queueCalls[0].init.body).body;
+  assert.equal(queueCommentBody.includes("vtdd:vps-privileged-maintenance-execution:deploy-bridge-followup-26133044458"), true);
+  assert.equal(queueCommentBody.includes('"commandClass": "dashboard_bridge_unresolved_deploy_sync_restart"'), true);
+  assert.equal(queueCommentBody.includes("sync-dashboard-app-server-bridge-after-deploy.mjs"), true);
 
   const duplicateResponse = await worker.fetch(
     new Request("https://example.com/v2/events/github-actions", {
@@ -6367,7 +6456,10 @@ test("worker ingests GitHub Actions deploy completion event and shows it on dash
       DASHBOARD_EVENT_STORE: store,
       DASHBOARD_CHAT_STORE: chatStore,
       DASHBOARD_CHAT_ROOMS: rooms.namespace,
-      DASHBOARD_PUSH_SUBSCRIPTION_STORE: pushStore
+      DASHBOARD_PUSH_SUBSCRIPTION_STORE: pushStore,
+      MEMORY_PROVIDER: provider,
+      VTDD_DASHBOARD_VPS_MAINTENANCE_HOST: "x85-131-245-163",
+      VTDD_DASHBOARD_VPS_MAINTENANCE_WORKDIR: "/home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p"
     }
   );
   assert.equal(duplicateResponse.status, 202);
@@ -6383,8 +6475,14 @@ test("worker ingests GitHub Actions deploy completion event and shows it on dash
     { ...dashboardAccessEnv, DASHBOARD_CHAT_STORE: chatStore }
   );
   const duplicateChatBody = await duplicateChat.json();
-  assert.equal(duplicateChatBody.messages.length, 1);
+  assert.equal(duplicateChatBody.messages.length, 4);
   assert.equal(duplicateChatBody.messages[0].messageId, "dashboard-event:github-actions:marushu/vtdd-v2-p:deploy-production:26133044458");
+  assert.equal(duplicateBody.deployBridgeFollowup.status, "duplicate_event_skipped");
+  const approvalRecordsAfterDuplicate = await provider.retrieve({ type: MemoryRecordType.APPROVAL_LOG, limit: 20 });
+  const duplicateFollowupProposals = approvalRecordsAfterDuplicate.filter(
+    (record) => record.content?.proposal?.capability?.commandClass === "dashboard_bridge_unresolved_deploy_sync_restart"
+  );
+  assert.equal(duplicateFollowupProposals.length, 1);
   const runtimeSource = await fs.readFile(path.join(process.cwd(), "src", "worker", "runtime.js"), "utf8");
   assert.equal(runtimeSource.includes("PRIMARY KEY (thread_id, message_id)"), true);
   assert.equal(runtimeSource.includes("INSERT OR REPLACE INTO vtdd_dashboard_chat_messages"), true);

--- a/worker.js
+++ b/worker.js
@@ -37895,6 +37895,24 @@ var HELPER_COMMAND_REGISTRY = defineHelperCommandRegistry([
     initialPreset: true
   },
   {
+    commandClass: "dashboard_bridge_unresolved_deploy_sync_restart",
+    title: "Sync checkout and restart repo-less Dashboard app-server bridge after deploy",
+    allowedArgs: [
+      "node scripts/sync-dashboard-app-server-bridge-after-deploy.mjs --service vtdd-dashboard-app-server-bridge-unresolved.service --ref origin/main"
+    ],
+    argv: [
+      "node",
+      "scripts/sync-dashboard-app-server-bridge-after-deploy.mjs",
+      "--service",
+      "vtdd-dashboard-app-server-bridge-unresolved.service",
+      "--ref",
+      "origin/main"
+    ],
+    requiredRiskLevel: "medium",
+    requiresRoot: false,
+    initialPreset: true
+  },
+  {
     commandClass: "vps_runner_status_dry_run",
     title: "Check VPS runner queue status without executing work",
     allowedArgs: ["node scripts/run-vps-runner.mjs --dry-run"],
@@ -61416,15 +61434,26 @@ async function handleGitHubActionsEventRequest(request, env) {
     event: baseEvent,
     threadId
   });
+  const deployBridgeFollowup = existingEvent || !isSuccessfulDeployWorkflowEvent(baseEvent) ? {
+    status: existingEvent ? "duplicate_event_skipped" : "not_required",
+    proposalCreated: false,
+    message: null
+  } : await buildDeployBridgeFollowupChatMessage({
+    event: baseEvent,
+    threadId,
+    env,
+    origin: new URL(request.url).origin
+  });
+  const chatMessages = [chatMessage, deployBridgeFollowup.message].filter(Boolean);
   const chatStore = resolveDashboardChatStore(env);
   let messages = [];
   let chatAppendStatus = "unavailable";
   let chatAppendError = null;
   let chatAppendReason = null;
-  if (chatMessage) {
+  if (chatMessages.length > 0) {
     if (chatStore) {
       try {
-        messages = await chatStore.appendMany(threadId, [chatMessage]);
+        messages = await chatStore.appendMany(threadId, chatMessages);
         chatAppendStatus = messages.length > 0 ? "appended" : "skipped";
       } catch (error2) {
         chatAppendStatus = "failed";
@@ -61468,9 +61497,176 @@ async function handleGitHubActionsEventRequest(request, env) {
     chatAppendError,
     chatAppendReason,
     messages,
+    deployBridgeFollowup: {
+      ...deployBridgeFollowup,
+      message: deployBridgeFollowup.message ? {
+        messageId: deployBridgeFollowup.message.messageId,
+        status: deployBridgeFollowup.message.status
+      } : null
+    },
     webSocketBroadcast,
     webPush: recorded.webPush
   });
+}
+function isSuccessfulDeployWorkflowEvent(event) {
+  const record2 = normalizeDashboardEventRecord(event);
+  return record2.kind === "github_actions_workflow_run" && normalize7(record2.workflowName).includes("deploy") && normalizeDashboardEventText(record2.status).toLowerCase() === "completed" && normalizeDashboardEventText(record2.conclusion).toLowerCase() === "success";
+}
+async function buildDeployBridgeFollowupChatMessage({ event, threadId, env, origin } = {}) {
+  const record2 = normalizeDashboardEventRecord(event);
+  const repository = normalizeCanonicalRepositoryInput(record2.repository);
+  const relatedIssue = normalizePositiveInteger10(record2.issueNumber) || normalizePositiveInteger10(env?.VTDD_DASHBOARD_DEPLOY_BRIDGE_FOLLOWUP_ISSUE) || 741;
+  const messageId = `dashboard-event:${record2.id}:deploy-bridge-followup`;
+  const workingDirectory = normalizeText32(env?.VTDD_DASHBOARD_VPS_MAINTENANCE_WORKDIR);
+  const host = normalizeDashboardVpsMaintenanceHost({ env });
+  const provider = resolveMemoryProvider(env);
+  const memoryValidation = validateMemoryProvider(provider);
+  if (!memoryValidation.ok || !repository || !host || !workingDirectory) {
+    const issues = [
+      !memoryValidation.ok ? "memory_provider_unavailable" : "",
+      !repository ? "repository_required" : "",
+      !host ? "VTDD_DASHBOARD_VPS_MAINTENANCE_HOST required" : "",
+      !workingDirectory ? "VTDD_DASHBOARD_VPS_MAINTENANCE_WORKDIR required" : ""
+    ].filter(Boolean);
+    return {
+      status: "blocked",
+      proposalCreated: false,
+      error: "deploy_bridge_followup_configuration_required",
+      issues,
+      message: normalizeDashboardChatMessage(
+        {
+          threadId,
+          messageId,
+          role: "system",
+          repository,
+          relatedIssue,
+          status: "blocked",
+          text: buildDeployBridgeFollowupBlockedMessage({ record: record2, repository, relatedIssue, issues }),
+          createdAt: record2.updatedAt || record2.createdAt
+        },
+        { threadId }
+      )
+    };
+  }
+  const executionId = `deploy-bridge-followup-${safeIdentifier(record2.runId) || createDashboardRequestId("deploy")}`;
+  const allowedArg = "node scripts/sync-dashboard-app-server-bridge-after-deploy.mjs --service vtdd-dashboard-app-server-bridge-unresolved.service --ref origin/main";
+  const proposal = await createVpsPrivilegedMaintenanceProposal({
+    payload: {
+      host,
+      repository,
+      relatedIssue,
+      operation: "enable",
+      id: "dashboard.bridge.unresolved.deploy.sync.restart",
+      title: "Deploy\u5F8C repo-less Dashboard bridge sync/restart",
+      commandClass: "dashboard_bridge_unresolved_deploy_sync_restart",
+      riskLevel: "medium",
+      workingDirectories: [workingDirectory],
+      allowedArgs: [allowedArg],
+      affectedPaths: [
+        workingDirectory,
+        "/home/vtdd-runner/.config/systemd/user",
+        "/run/user",
+        "vtdd-dashboard-app-server-bridge-unresolved.service"
+      ],
+      redactionRules: ["no secrets", "summarize stdout/stderr", "redact tokens and credentials"],
+      rollbackPlan: "stop auto follow-up proposal and restart the previous bridge service state manually if needed",
+      expectedRuntimeTruth: [
+        "before git HEAD",
+        "after git HEAD",
+        "before service active state",
+        "after service active state",
+        "after service main PID",
+        "exit code"
+      ],
+      reason: `Issue #741 deploy run ${record2.runId} success at ${record2.headSha || "unknown sha"} requires VPS checkout sync and repo-less bridge restart follow-up`,
+      impactScope: `${workingDirectory}, vtdd-dashboard-app-server-bridge-unresolved.service`,
+      dashboardThreadId: threadId,
+      executionId
+    },
+    provider,
+    origin: origin || "https://example.com"
+  });
+  if (!proposal.ok) {
+    return {
+      status: "blocked",
+      proposalCreated: false,
+      error: proposal.error,
+      issues: proposal.issues || [],
+      message: normalizeDashboardChatMessage(
+        {
+          threadId,
+          messageId,
+          role: "system",
+          repository,
+          relatedIssue,
+          status: "blocked",
+          text: buildDeployBridgeFollowupBlockedMessage({
+            record: record2,
+            repository,
+            relatedIssue,
+            issues: proposal.issues || [proposal.error || "proposal_failed"]
+          }),
+          createdAt: record2.updatedAt || record2.createdAt
+        },
+        { threadId }
+      )
+    };
+  }
+  return {
+    status: "approval_required",
+    proposalCreated: true,
+    vpsProposalId: proposal.body.vpsProposalId,
+    approvalScope: proposal.body.approvalScope,
+    approvalOperatorUrl: proposal.body.approvalOperatorUrl,
+    message: normalizeDashboardChatMessage(
+      {
+        threadId,
+        messageId,
+        role: "system",
+        repository,
+        relatedIssue,
+        status: "blocked",
+        text: buildDeployBridgeFollowupApprovalRequiredMessage({
+          record: record2,
+          repository,
+          relatedIssue,
+          proposal: proposal.body
+        }),
+        createdAt: record2.updatedAt || record2.createdAt
+      },
+      { threadId }
+    )
+  };
+}
+function buildDeployBridgeFollowupApprovalRequiredMessage({ record: record2, repository, relatedIssue, proposal } = {}) {
+  return [
+    "deploy \u5F8C bridge sync/restart \u306E\u627F\u8A8D\u304C\u5FC5\u8981\u3067\u3059\u3002",
+    "",
+    `- repo: ${repository || "\u672A\u78BA\u8A8D"}`,
+    `- related Issue: #${relatedIssue || 741}`,
+    `- deploy run: ${record2.runId || "\u672A\u78BA\u8A8D"}`,
+    `- deploy sha: ${record2.headSha ? record2.headSha.slice(0, 12) : "\u672A\u78BA\u8A8D"}`,
+    "- \u5BFE\u8C61: repo-less Dashboard app-server bridge",
+    "- service: vtdd-dashboard-app-server-bridge-unresolved.service",
+    `- vpsProposalId: ${proposal?.vpsProposalId || "\u672A\u4F5C\u6210"}`,
+    "- authority: deploy approval \u3068\u306F\u5225\u306E scoped passkey approval \u304C\u5FC5\u8981\u3067\u3059\u3002",
+    "- runtime truth: status=approval_required, rootExecutionStarted=false, helperExecutionStarted=false",
+    proposal?.approvalOperatorUrl ? `- approval URL: ${proposal.approvalOperatorUrl}` : "- approval URL: \u672A\u751F\u6210",
+    "",
+    "\u627F\u8A8D\u5F8C\u306F Dashboard chat \u304C VPS helper queue \u3078 fixed sync/restart command \u3092\u6E21\u3057\u307E\u3059\u3002VPS runner \u306E before/after truth \u304C\u623B\u308B\u307E\u3067 live restart \u5B8C\u4E86\u3068\u306F\u6271\u3044\u307E\u305B\u3093\u3002"
+  ].join("\n");
+}
+function buildDeployBridgeFollowupBlockedMessage({ record: record2, repository, relatedIssue, issues } = {}) {
+  return [
+    "deploy \u5F8C bridge sync/restart follow-up \u3092\u4F5C\u308C\u307E\u305B\u3093\u3067\u3057\u305F\u3002",
+    "",
+    `- repo: ${repository || "\u672A\u78BA\u8A8D"}`,
+    `- related Issue: #${relatedIssue || 741}`,
+    `- deploy run: ${record2?.runId || "\u672A\u78BA\u8A8D"}`,
+    `- reason: ${(issues || []).join("; ") || "configuration required"}`,
+    "- runtime truth: status=blocked, rootExecutionStarted=false, helperExecutionStarted=false",
+    "- next action: runtime config \u3068 memory provider \u3092\u78BA\u8A8D\u3057\u3066\u304B\u3089\u3001\u540C\u3058 chat \u3067 VPS maintenance approval URL \u3092\u518D\u63D0\u793A\u3057\u307E\u3059\u3002"
+  ].join("\n");
 }
 async function readDashboardEventById(eventStore, eventId) {
   const id = normalizeDashboardEventText(eventId);
@@ -68943,6 +69139,7 @@ function buildGitHubActionsDashboardChatMessageText(event) {
   }
   lines.push("", "\u6B21:");
   if (isDeploy && conclusion === "success") {
+    lines.push("- deploy \u5F8C bridge sync/restart approval URL \u3092\u540C\u3058 chat \u306B\u51FA\u3057\u307E\u3059\u3002");
     lines.push("- production E2E / runtime truth \u3092\u78BA\u8A8D\u3057\u307E\u3059\u3002");
   } else if (conclusion === "failure" || conclusion === "cancelled" || conclusion === "timed_out") {
     lines.push("- deploy / Actions \u306E\u5931\u6557\u539F\u56E0\u3092\u78BA\u8A8D\u3057\u3001blocker \u3068\u6B21 action \u3092\u51FA\u3057\u307E\u3059\u3002");


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #741 の deploy 後 checkout sync + repo-less Dashboard app-server bridge restart 標準運用を、Dashboard Butler chat の deploy success event から scoped passkey approval と VPS helper queue handoff まで接続する。

## Satisfied Success Criteria

- deploy 後に VPS checkout を origin/main へ同期し、app-server bridge を restart する標準運用が runtime path に反映される。\nbridge restart 前後の before/after state を Dashboard Butler が owner-facing に報告できるための fixed helper JSON truth を追加。\nrestart / lifecycle guard は deploy approval だけで credential mutation / permission mutation / destructive cleanup を自動実行しない。

## Unsatisfied Success Criteria

- Issue #741 全体の periodic restart / health-based restart は未完了。\nunresolved bridge の CPU time / memory growth 閾値検知は未完了。\nrestart 復帰後の実機 iPhone/iPad E2E と production VPS before/after evidence は未実施。\n進行中 turn id / pending owner message / last progress event の deploy restart 復元 E2E は未実施。

## Non-goal violations

None.

## 開発前作戦図

- 作戦図 evidence: docs/development-strategy/issue-741-deploy-bridge-restart-automation.md
- 完了体験: deploy success event 後、同じ Dashboard Butler chat に bridge sync/restart approval URL が出て、owner は passkey 認証だけ行い、承認後は helper queue に fixed command が渡る。
- VTDD 全体で進める部分: Dashboard Butler event ingest、VPS privileged maintenance proposal、helper queue handoff、repo-less bridge runtime truth。
- 設計: Butler owner-facing surface の設計として、deploy approval と VPS maintenance approval の境界を分離し、deploy success event は proposal/URL 生成まで、restart は別 passkey approval 後に helper queue へ渡す。
- 仮説: 仮説: PR #766 では unresolved bridge restart preset は入ったが、deploy completion event から proposal を作る runtime path がないことが原因で、owner が GitHub Actions / mac SSH に戻される。
- 検証計画: deploy event ingest、duplicate suppression、VPS approval URL、approval grant auto-continue、fixed helper script dirty checkout guard を unit/integration test で確認する。
- 改修見積もり: src/worker/runtime.js: deploy success follow-up message/proposal。src/core/vps-privileged-maintenance.js: fixed command registry。scripts/sync-dashboard-app-server-bridge-after-deploy.mjs: VPS helper script。test/worker.test.js ほか。
- 既に通っている経路: deploy operator dispatch、GitHub Actions event ingest、VPS maintenance proposal、VPS operator auto-continue、helper queue は既存経路。
- 未確認の境界: production VPS manifest pickup と actual systemd restart evidence は merge/deploy 後の live E2E が必要。long-running deploy polling は未実装。
- 穴が出そうな箇所: approval scope 混在、duplicate deploy event で proposal 二重化、dirty checkout で restart してしまうこと、unresolved service を残骸扱いすること。
- PR 前に確認すること: Issue #741 本文、PR #766 merged baseline、worker generated parity、full verify を確認する。
- 実装候補と捨てた案: deploy approval だけで restart まで自動実行する案は authority scope 混在のため不採用。mac SSH restart を標準運用にする案は Butler completion でないため不採用。
- merge 後に通す E2E: E2E: production deploy success event -> Dashboard chat approval URL -> passkey approval -> VPS helper queue -> runner before/after truth を live 検証する。
- 次の PR を増やさない理由: owner-facing deploy follow-up は URL提示だけでは不足なので、helper queue handoff まで同じ PR scope に含め、予見できる不足を残さない。
- 停止条件: credential/permission mutation、repository settings mutation、deploy approval だけで VPS restart 実行が必要になる場合は停止。

## Dry-run Impact Report

- Target Issue: Issue #741
- Implementing Success Criteria: deploy 後 checkout sync + bridge restart 標準運用、before/after truth、authority boundary。
- Explicit Non-goals: periodic restart、CPU/memory watchdog、live deploy、credential/permission mutation、Issue close。
- Expected touched files/routes/workflows: docs/development-strategy/issue-741-deploy-bridge-restart-automation.md; src/core/vps-privileged-maintenance.js; src/worker/runtime.js; worker.js; scripts/sync-dashboard-app-server-bridge-after-deploy.mjs; tests。
- Affected Issues: Issue #741, Issue #637.
- Affected PRs: PR #766 の follow-up。
- Affected workflows: deploy-production event ingest; VPS privileged maintenance helper queue comment.
- Affected runtime/operator surfaces: Dashboard Butler chat, GitHub Actions event route, passkey operator URL, VPS helper queue.
- What may break if we patch narrowly: URL提示だけで止めると owner が再び mac SSH へ戻される。deploy approval と restart approval を混ぜると authority drift になる。
- Unknowns to investigate before coding: production VPS root-owned manifest が新 registry を取り込むタイミングと live runner pickup evidence。
- Validation needed: unit/integration/full worker verification と merge/deploy後 live E2E。
- Stop condition: deploy approval grant だけで VPS maintenance execution を始める必要が出た場合。

## Execution Queue Delta

- Queue position before: Issue #741 の deploy follow-up slice。PR #766 merged 後の recovery_gap_found を解消する NEXT。
- Preemption decision: NEXT: owner 指摘により細切れ不足が blocker 化したため、同じ Issue #741 内で helper queue handoff まで拡張。Active Issues は縮小しない。
- Queue delta: Issue #741 の Queue item を、PR #766 の unresolved restart capability から deploy event -> approval URL -> helper queue まで前進。
- Why this PR is next: deploy 後 bridge restart が mac Codex-only だと Butler-first deploy が成立しないため。
- Active Issues not downscoped: Active Issues are not downscoped / 縮小しません。Issue #741 全体は incomplete として残す。

## File / Line Hypotheses

- file: src/worker/runtime.js\n  - hypothesis: deploy success event ingest に follow-up proposal を差し込めば chat 上で operator URL を自動提示できる。\n  - risk if changed narrowly: duplicate event で proposal が増殖する。\n  - validation: duplicate event test。\n  - related Issue: #741\n- file: scripts/sync-dashboard-app-server-bridge-after-deploy.mjs\n  - hypothesis: fixed script にすれば helper command を arbitrary shell にせず sync/restart できる。\n  - risk if changed narrowly: dirty checkout を上書きする。\n  - validation: dirty checkout blocks before restart test。\n  - related Issue: #741

## Hypothesis Retrospective

- expected: deploy success event から approval_required follow-up が同じ chat に出て、approval grant 後に helper queue comment が作られる。\n- actual: targeted test と npm run verify:worker で確認。\n- mismatch: live production E2E は未実施。\n- lesson: URL提示だけでは不足で、helper queue handoff まで同一 slice が必要。\n- should become RAG candidate: yes, recovery_gap_found として候補。

## Verification Evidence

- Unit: node --test test/sync-dashboard-app-server-bridge-after-deploy.test.js test/vps-privileged-maintenance.test.js test/worker.test.js --test-name-pattern 'deploy|VPS privileged maintenance|app-server bridge|sync' passed.
- Integration: npm run verify:worker passed. Includes build:worker, node --test, check:self-parity, check:generated-worker.
- E2E: 未実施。merge/deploy後に production deploy success event -> approval -> VPS helper pickup -> before/after truth を通す。
- Manual: mac_codex_only_probe: PR #766 deploy 後に VPS checkout 65b29d1 と unresolved bridge restart active/running PID 3570244 を確認済み。ただし本PR完了 evidence ではない。
- Evidence path/link: docs/development-strategy/issue-741-deploy-bridge-restart-automation.md; test/worker.test.js deploy event test; test/sync-dashboard-app-server-bridge-after-deploy.test.js

## Butler Completion Contract

- Primary owner surface: Dashboard Butler chat。
- Fallback surface: Custom GPT は明示された fallback surface として扱います。主経路ではありません。
- Owner goal: このPRが扱う owner-facing goal は Intent / Success Criteria に記載しています。
- Butler entrypoint: GitHub Actions deploy success event route が Dashboard Butler chat に follow-up message を追加する。
- Dashboard Butler natural-language path: Dashboard Butler の通常チャット入口から、VPS operator 承認後の /v2/dashboard/chat/messages が helper queue へ接続する natural-language/chat 経路。
- Action Schema exposure: 未変更。Custom GPT Action Schema は fallback であり主経路ではない。
- Runtime path: POST /v2/events/github-actions -> deployBridgeFollowup proposal -> same-origin /v2/approval/passkey/operator?mode=vps -> /v2/dashboard/chat/messages -> VPS helper execution queue comment。
- Runner/runtime truth: approval_required と queued_for_vps_helper_execution で rootExecutionStarted=false/helperExecutionStarted=false を返す。fixed helper は before/after git/service JSON truth を出す。
- Authority boundary: deploy approval と VPS maintenance approval を分離。deploy event だけでは restart しない。VPS restart は scoped passkey approval 後に helper queue handoff。
- E2E evidence: 未実施。production deploy後の live Butler-facing E2E が必要。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 必要。merge後に production deploy と event/follow-up live check が必要。
- Custom GPT Action Schema update: 不要。既存 machine event / dashboard chat routes の runtime path。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。merge/deploy後に実施。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate\nAGENTS.md Authority Boundary\nAGENTS.md Evidence Discipline\nAGENTS.md Drift Stop Protocol

## Out-of-scope but NOT implemented

- periodic restart / health watchdog\nCPU/memory threshold restart\ncredential or permission mutation\nIssue #741 close\nproduction deploy/merge in this PR creation step

## Extra changes (if any)

Generated worker.js updated by npm run build:worker.

<!-- VTDD metadata -->
- Issue: Issue #741
- Execution ID: Not provided.
- Goal: Not provided.
