### PR TITLE
Issue #741 VPS承認継続のDashboard認証を修正

### DIFF
--- a/docs/development-strategy/issue-741-deploy-bridge-restart-automation.md
+++ b/docs/development-strategy/issue-741-deploy-bridge-restart-automation.md
@@ -24,6 +24,8 @@ Issue #741 の deploy 後 checkout sync + bridge restart 標準運用と、Issue
 
 Cloudflare passkey operator page は approvalGrant を作るだけでは足りない。deploy mode では承認成功後に same-origin `/v2/action/deploy` へ approvalGrantId を POST し、Worker が deploy dispatch を検知できる必要がある。VPS maintenance mode でも同じく、承認成功後に `/v2/dashboard/chat/messages` へ approvalGrantId / vpsProposalId を戻し、Dashboard Butler が helper queue へ自動継続できる必要がある。owner に approvalGrantId をコピーさせる flow は fallback であり、通常導線ではない。
 
+2026-06-04 live deploy 後、VPS operator の passkey 承認自体は成功したが、auto-continue POST が `Cloudflare Access authenticated owner identity is required for dashboard surface /dashboard/chat/messages` で止まった。Dashboard chat write 全体を緩めてはいけないが、stored VPS proposal と matching passkey approval grant が検証できる continuation request は、same-origin passkey operator の通常導線として Dashboard chat auth とは別に許可する必要がある。
+
 deploy operator page は認証と dispatch の場であって、追跡UIではない。dispatch 後は `returnUrl` で Dashboard Butler の chat surface に戻す。GitHub Actions deploy success event を Worker が受けたら、同じ chat thread に deploy 完了 truth と VPS checkout sync + repo-less bridge restart の approval_required proposal を出す。operator page に owner を残して GitHub Actions run link を眺めさせる設計にはしない。
 
 今回の実装単位は、deploy success event から VPS privileged maintenance proposal を作り、same-origin VPS passkey operator URL を chat に出し、承認後の Dashboard chat auto-continue が既存 helper queue に固定 command envelope を渡すところまでを一塊で接続すること。実運用で動いている unresolved bridge が deploy 後 follow-up から抜けていると、Butler が「人間は認証だけ」という運用を満たせない。
@@ -48,6 +50,8 @@ deploy operator URL は既に `selfParity.deployOperatorMarkdownLink` と passke
 - Unit: GitHub Actions deploy success event は同じ Dashboard chat に bridge sync/restart approval URL を追記する。
 - Unit: 同じ deploy event の重複受信は proposal / chat message / Web Push を二重化しない。
 - Unit: bridge follow-up approval grant が戻ると既存 helper queue に fixed script command envelope を渡す。
+- Unit: Cloudflare Access session を持たない passkey operator からの VPS approval continuation は、stored proposal / matching grant がある場合だけ helper queue に到達する。
+- Unit: approvalGrantId / vpsProposalId がない ordinary chat write は引き続き Cloudflare Access / dashboard passkey session なしでは拒否される。
 - Unit: fixed helper script は tracked dirty checkout を restart 前に止め、before/after SHA と service truth を JSON で返す。
 - Local: `node --test test/sync-dashboard-app-server-bridge-after-deploy.test.js test/vps-privileged-maintenance.test.js test/worker.test.js --test-name-pattern "deploy|VPS privileged maintenance|app-server bridge|sync"`
 - Worker source を触る場合は `npm run build:worker` と `npm run verify:worker` を実行する。

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -5720,20 +5720,24 @@ async function handleRetrieveVpsMaintenanceInstallInventoryRequest(url) {
 }
 
 async function handleDashboardChatMessageRequest(request, env) {
+  const payload = await readJson(request);
   const dashboardAuth = await authorizeDashboardRequest({
     request,
     env,
     apiSuffix: "/dashboard/chat/messages"
   });
   if (!dashboardAuth.ok) {
-    return json(dashboardAuth.status, {
-      ok: false,
-      error: "dashboard_auth_required",
-      reason: dashboardAuth.reason
-    });
+    const continuationAuth = await authorizeDashboardVpsApprovalContinuation({ payload, env });
+    if (!continuationAuth.ok) {
+      return json(dashboardAuth.status, {
+        ok: false,
+        error: "dashboard_auth_required",
+        reason: dashboardAuth.reason,
+        continuationReason: continuationAuth.reason || undefined
+      });
+    }
   }
 
-  const payload = await readJson(request);
   const repositoryResolution = await resolveDashboardChatRepository({ payload, env });
   // HTTP chat writes are the non-live persistence fallback. Live Codex delivery
   // happens through DashboardChatRoom WebSocket owner_message events.
@@ -5773,6 +5777,41 @@ async function handleDashboardChatMessageRequest(request, env) {
     messages,
     execution: prepared.execution || null
   });
+}
+
+async function authorizeDashboardVpsApprovalContinuation({ payload, env } = {}) {
+  const input = normalizeObject(payload);
+  const vpsProposalId = normalizeText(input.vpsProposalId || input.vps_proposal_id);
+  const approvalGrantId = normalizeText(input.approvalGrantId || input.approval_grant_id);
+  const threadId = normalizeDashboardThreadId(input.threadId || input.thread_id);
+  if (!vpsProposalId || !approvalGrantId || !threadId) {
+    return {
+      ok: false,
+      reason: "vps approval continuation requires vpsProposalId, approvalGrantId, and threadId"
+    };
+  }
+  const provider = resolveMemoryProvider(env);
+  const memoryValidation = validateMemoryProvider(provider);
+  if (!memoryValidation.ok) {
+    return {
+      ok: false,
+      reason: "valid memory provider is required for VPS approval continuation"
+    };
+  }
+  const helper = await createVpsPrivilegedMaintenanceHelperRequest({
+    payload: { vpsProposalId, approvalGrantId },
+    provider
+  });
+  if (!helper.ok) {
+    return {
+      ok: false,
+      reason: helper.reason || helper.error || "VPS approval continuation scope did not validate"
+    };
+  }
+  return {
+    ok: true,
+    authType: "vps_approval_continuation"
+  };
 }
 
 async function handleMediaUploadRequest(request, env) {

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -2993,6 +2993,107 @@ test("worker connects VPS privileged maintenance intent from Dashboard Butler ch
   assert.equal(queueCommentBody.includes('"handoff"'), true);
 });
 
+test("worker allows VPS passkey operator continuation without Cloudflare Access dashboard session", async () => {
+  const store = createInMemoryDashboardChatStore();
+  const provider = createInMemoryMemoryProvider();
+  const proposalResponse = await worker.fetch(
+    new Request("https://example.com/v2/vps/privileged-maintenance/proposals", {
+      method: "POST",
+      headers: gatewayAuthHeaders,
+      body: JSON.stringify({
+        host: "x85-131-245-163",
+        repository: "marushu/vtdd-v2-p",
+        relatedIssue: 741,
+        operation: "enable",
+        id: "dashboard.bridge.unresolved.deploy.sync.restart",
+        title: "Deploy後 repo-less Dashboard bridge sync/restart",
+        commandClass: "dashboard_bridge_unresolved_deploy_sync_restart",
+        riskLevel: "medium",
+        workingDirectories: ["/home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p"],
+        allowedArgs: [
+          "node scripts/sync-dashboard-app-server-bridge-after-deploy.mjs --service vtdd-dashboard-app-server-bridge-unresolved.service --ref origin/main"
+        ],
+        affectedPaths: [
+          "/home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p",
+          "vtdd-dashboard-app-server-bridge-unresolved.service"
+        ],
+        redactionRules: ["no secrets"],
+        rollbackPlan: "stop auto follow-up proposal",
+        expectedRuntimeTruth: ["before git HEAD", "after git HEAD", "after service active state"],
+        reason: "Issue #741 deploy follow-up",
+        impactScope: "/home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p, vtdd-dashboard-app-server-bridge-unresolved.service",
+        dashboardThreadId: "dashboard-main-marushu-vtdd-v2-p",
+        executionId: "deploy-bridge-followup-auth-regression"
+      })
+    }),
+    { ...gatewayAuthEnv, MEMORY_PROVIDER: provider }
+  );
+  assert.equal(proposalResponse.status, 200);
+  const proposalBody = await proposalResponse.json();
+  await provider.store({
+    id: "approval:vps-operator-auto-continue",
+    type: MemoryRecordType.APPROVAL_LOG,
+    content: {
+      kind: "passkey_grant",
+      status: "verified",
+      approvalId: "approval:vps-operator-auto-continue",
+      credentialId: "AQIDBA",
+      verifiedAt: "2026-06-04T07:00:00.000Z",
+      expiresAt: "2999-01-01T00:00:00.000Z",
+      scope: proposalBody.approvalScope
+    },
+    metadata: { source: "vps-operator-auto-continue-test" },
+    priority: 96,
+    tags: ["passkey_grant", "passkey_approval", "verified"],
+    createdAt: "2026-06-04T07:00:00.000Z"
+  });
+
+  const githubCalls = [];
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/dashboard/chat/messages", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        threadId: "dashboard-main-marushu-vtdd-v2-p",
+        repository: "marushu/vtdd-v2-p",
+        issueNumber: 741,
+        text: "passkey 承認済みです。Dashboard Butler から VPS helper queue へ進めて。",
+        vpsProposalId: proposalBody.vpsProposalId,
+        approvalGrantId: "approval:vps-operator-auto-continue",
+        executionId: "deploy-bridge-followup-auth-regression"
+      })
+    }),
+    {
+      DASHBOARD_CHAT_STORE: store,
+      MEMORY_PROVIDER: provider,
+      VTDD_DASHBOARD_VPS_MAINTENANCE_HOST: "x85-131-245-163",
+      VTDD_DASHBOARD_VPS_MAINTENANCE_WORKDIR: "/home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p",
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_dashboard_vps",
+      GITHUB_API_FETCH: async (url, init) => {
+        githubCalls.push({ url, init });
+        return new Response(
+          JSON.stringify({
+            id: 74102,
+            html_url: "https://github.com/marushu/vtdd-v2-p/issues/741#issuecomment-74102"
+          }),
+          { status: 201, headers: { "content-type": "application/json" } }
+        );
+      }
+    }
+  );
+
+  assert.equal(response.status, 202);
+  const body = await response.json();
+  assert.equal(body.ok, true);
+  assert.equal(body.execution.status, "queued_for_vps_helper_execution");
+  assert.equal(body.execution.runtimeTruth.helperQueueReached, true);
+  assert.equal(body.execution.runtimeTruth.rootExecutionStarted, false);
+  assert.equal(body.execution.runtimeTruth.helperExecutionStarted, false);
+  assert.equal(githubCalls.length, 1);
+  const queueCommentBody = JSON.parse(githubCalls[0].init.body).body;
+  assert.equal(queueCommentBody.includes("dashboard_bridge_unresolved_deploy_sync_restart"), true);
+});
+
 test("worker keeps ordinary Dashboard Butler planning chat out of VPS helper queue", async () => {
   const store = createInMemoryDashboardChatStore();
   const response = await worker.fetch(

--- a/worker.js
+++ b/worker.js
@@ -62565,19 +62565,23 @@ async function handleRetrieveVpsMaintenanceInstallInventoryRequest(url) {
   });
 }
 async function handleDashboardChatMessageRequest(request, env) {
+  const payload = await readJson(request);
   const dashboardAuth = await authorizeDashboardRequest({
     request,
     env,
     apiSuffix: "/dashboard/chat/messages"
   });
   if (!dashboardAuth.ok) {
-    return json(dashboardAuth.status, {
-      ok: false,
-      error: "dashboard_auth_required",
-      reason: dashboardAuth.reason
-    });
+    const continuationAuth = await authorizeDashboardVpsApprovalContinuation({ payload, env });
+    if (!continuationAuth.ok) {
+      return json(dashboardAuth.status, {
+        ok: false,
+        error: "dashboard_auth_required",
+        reason: dashboardAuth.reason,
+        continuationReason: continuationAuth.reason || void 0
+      });
+    }
   }
-  const payload = await readJson(request);
   const repositoryResolution = await resolveDashboardChatRepository({ payload, env });
   const repository = repositoryResolution.ok ? repositoryResolution.repository : "";
   const prepared = await buildDashboardChatTurn(
@@ -62610,6 +62614,40 @@ async function handleDashboardChatMessageRequest(request, env) {
     messages,
     execution: prepared.execution || null
   });
+}
+async function authorizeDashboardVpsApprovalContinuation({ payload, env } = {}) {
+  const input = normalizeObject12(payload);
+  const vpsProposalId = normalizeText32(input.vpsProposalId || input.vps_proposal_id);
+  const approvalGrantId = normalizeText32(input.approvalGrantId || input.approval_grant_id);
+  const threadId = normalizeDashboardThreadId(input.threadId || input.thread_id);
+  if (!vpsProposalId || !approvalGrantId || !threadId) {
+    return {
+      ok: false,
+      reason: "vps approval continuation requires vpsProposalId, approvalGrantId, and threadId"
+    };
+  }
+  const provider = resolveMemoryProvider(env);
+  const memoryValidation = validateMemoryProvider(provider);
+  if (!memoryValidation.ok) {
+    return {
+      ok: false,
+      reason: "valid memory provider is required for VPS approval continuation"
+    };
+  }
+  const helper = await createVpsPrivilegedMaintenanceHelperRequest({
+    payload: { vpsProposalId, approvalGrantId },
+    provider
+  });
+  if (!helper.ok) {
+    return {
+      ok: false,
+      reason: helper.reason || helper.error || "VPS approval continuation scope did not validate"
+    };
+  }
+  return {
+    ok: true,
+    authType: "vps_approval_continuation"
+  };
 }
 async function handleMediaUploadRequest(request, env) {
   const dashboardAuth = await authorizeDashboardRequest({


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #741 の deploy後 VPS bridge sync/restart で、passkey 承認後の operator auto-continue が Cloudflare Access dashboard auth で止まる回帰を修正する。

## Satisfied Success Criteria

- VPS operator からの approvalGrantId/vpsProposalId 付き continuation が、stored proposal と matching grant 検証後に helper queue へ到達する。\nordinary dashboard chat write は引き続き Cloudflare Access / dashboard passkey session なしでは拒否される。\nproduction live failure の原因を strategy に記録した。

## Unsatisfied Success Criteria

- Issue #741 全体の periodic restart / health-based restart は未完了。\nCPU/memory threshold restart は未完了。\n修正後 production deploy と live retry は未実施。

## Non-goal violations

None.

## 開発前作戦図

- 作戦図 evidence: docs/development-strategy/issue-741-deploy-bridge-restart-automation.md
- 完了体験: Dashboard Butler chat の bridge restart approval URL を owner が passkey 承認すると、operator page が Cloudflare Access session なしでも stored proposal / matching grant 検証により helper queue へ自動継続する。
- VTDD 全体で進める部分: Dashboard Butler chat write auth、VPS passkey operator continuation、VPS helper queue handoff。
- 設計: Butler owner-facing surface の設計として、dashboard chat write 全体は緩めず、vpsProposalId/approvalGrantId/threadId を持つ continuation だけを stored proposal と passkey grant の境界で許可する。
- 仮説: 仮説: PR #767 は operator page の POST 先を正しくしたが、/v2/dashboard/chat/messages の Cloudflare Access auth が先に走り、passkey-approved continuation を Dashboard chat auth として誤って拒否したことが原因。
- 検証計画: Cloudflare Access session なしの VPS operator continuation が queued_for_vps_helper_execution になること、ordinary unauthenticated chat write が拒否されることを unit/integration test で確認する。
- 改修見積もり: src/worker/runtime.js: handleDashboardChatMessageRequest auth preflight。test/worker.test.js: operator continuation regression。worker.js: generated。docs/development-strategy/issue-741-deploy-bridge-restart-automation.md: live failure記録。
- 既に通っている経路: VPS proposal作成、passkey grant保存、helper request scope validation、helper queue comment は既存経路。
- 未確認の境界: production deploy後に同じ vpsProposalId で再承認または新proposal作成が必要かは live runtime state で確認する。
- 穴が出そうな箇所: dashboard chat write auth を広く緩めると普通の未認証chat writeを許してしまう。proposal/grant検証前に通すと approvalGrantId だけの横流しになる。
- PR 前に確認すること: Issue #741, PR #767 merged baseline, live error text, targeted test, npm run verify:worker を確認する。
- 実装候補と捨てた案: Dashboard chat route 全体を public にする案は不採用。operator page に Cloudflare Access cookie を要求する案は iPhone passkey導線を壊すため不採用。
- merge 後に通す E2E: E2E: production deploy後、bridge sync/restart operator を開き passkey承認し、/v2/dashboard/chat/messages auto-continue が helper queue comment を作ることを live 検証する。
- 次の PR を増やさない理由: この回帰は PR #767 の同一 deploy follow-up workflow を止める穴なので、別機能にせず auth continuation を同じ Issue #741 scope で閉じる。
- 停止条件: ordinary unauthenticated chat write を許す必要が出る、または approval scope validation を省く必要が出る場合は停止。

## Dry-run Impact Report

- Target Issue: Issue #741
- Implementing Success Criteria: deploy後 bridge restart approval continuation と helper queue handoff。
- Explicit Non-goals: Dashboard chat全体のauth緩和、periodic restart、credential/permission mutation、Issue close。
- Expected touched files/routes/workflows: docs/development-strategy/issue-741-deploy-bridge-restart-automation.md; src/worker/runtime.js; worker.js; test/worker.test.js。
- Affected Issues: Issue #741, Issue #637.
- Affected PRs: PR #767 follow-up.
- Affected workflows: deploy-production後の VPS operator continuation; VPS helper queue comment.
- Affected runtime/operator surfaces: Dashboard Butler chat, passkey operator, /v2/dashboard/chat/messages, VPS helper queue.
- What may break if we patch narrowly: Access authだけを外すと未認証chat writeになる。operator側だけ直すとCloudflare Access sessionなしのiPhone導線が残り続ける。
- Unknowns to investigate before coding: live proposalの再利用可否と production deploy後の retry evidence。
- Validation needed: targeted unit/integration, npm run verify:worker, merge/deploy後 live retry。
- Stop condition: proposal/grant検証なしで continuation を許可する必要が出た場合。

## Execution Queue Delta

- Queue position before: Issue #741 deploy follow-up slice の production regression。
- Preemption decision: NEXT: PR #767 deploy後の owner-facing blocker なので同一 Issue #741 の回帰修正として割り込む。Active Issues は縮小しない。
- Queue delta: Issue #741 Queue item を PR #767 follow-up regression fix として進める。
- Why this PR is next: passkey承認済みなのに helper queue に進めないと『人間は認証だけ』が成立しないため。
- Active Issues not downscoped: Active Issues are not downscoped / 縮小しません。Issue #741 全体は incomplete。

## File / Line Hypotheses

- file: src/worker/runtime.js\n  - hypothesis: handleDashboardChatMessageRequest の dashboard auth が vps approval continuation より先に拒否している。\n  - risk if changed narrowly: ordinary unauthenticated chat write を許す。\n  - validation: continuation without Access passes; ordinary unauthenticated write rejects。\n  - related Issue: #741

## Hypothesis Retrospective

- expected: stored proposal / matching grant がある continuation だけ Cloudflare Access session なしで helper queue に到達する。\n- actual: targeted test と npm run verify:worker で確認。\n- mismatch: production live retry は未実施。\n- lesson: passkey operator continuation は Dashboard page auth ではなく approval scope auth として扱う必要がある。\n- should become RAG candidate: yes, recovery_gap_found。

## Verification Evidence

- Unit: node --test test/worker.test.js --test-name-pattern 'VPS passkey operator continuation|VPS privileged maintenance|unauthenticated dashboard chat writes|deploy completion event' passed.
- Integration: npm run verify:worker passed. Includes build:worker, node --test, check:self-parity, check:generated-worker.
- E2E: 未実施。merge/deploy後に production operator auto-continue retry が必要。
- Manual: Live failure: passkey承認後の /v2/dashboard/chat/messages が Cloudflare Access authenticated owner identity required で失敗。
- Evidence path/link: docs/development-strategy/issue-741-deploy-bridge-restart-automation.md; test/worker.test.js

## Butler Completion Contract

- Primary owner surface: Dashboard Butler chat。
- Fallback surface: Custom GPT は明示された fallback surface として扱います。主経路ではありません。
- Owner goal: このPRが扱う owner-facing goal は Intent / Success Criteria に記載しています。
- Butler entrypoint: Dashboard Butler chat に出た VPS operator URL から passkey承認し、operator auto-continue が chat message route に戻る。
- Dashboard Butler natural-language path: Dashboard Butler の通常チャット/approval thread 経路に戻り、承認済み continuation が helper queue に到達する chat path。
- Action Schema exposure: 未変更。Custom GPT Action Schema は fallback であり主経路ではない。
- Runtime path: VPS passkey operator -> /v2/dashboard/chat/messages with vpsProposalId/approvalGrantId -> proposal/grant validation -> buildDashboardChatTurn -> VPS helper queue comment。
- Runner/runtime truth: queued_for_vps_helper_execution, rootExecutionStarted=false, helperExecutionStarted=false を返す。
- Authority boundary: Dashboard chat auth は維持。VPS continuation は stored proposal と matching passkey approval grant がある場合だけ許可。
- E2E evidence: 未実施。production deploy後の live retry が必要。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 必要。merge後に production deploy と operator continuation live retry が必要。
- Custom GPT Action Schema update: 不要。runtime route修正のみ。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。merge/deploy後に実施。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate\nAGENTS.md Authority Boundary\nAGENTS.md Evidence Discipline\nAGENTS.md Drift Stop Protocol

## Out-of-scope but NOT implemented

- Dashboard chat全体のpublic化\nperiodic restart / watchdog\ncredential or permission mutation\nIssue #741 close

## Extra changes (if any)

Generated worker.js updated by npm run build:worker.

<!-- VTDD metadata -->
- Issue: Issue #741
- Execution ID: Not provided.
- Goal: Not provided.
