### PR TITLE
Issue #741 passkey operator の復帰リンク回帰を修正

### DIFF
--- a/docs/development-strategy/issue-741-deploy-bridge-restart-automation.md
+++ b/docs/development-strategy/issue-741-deploy-bridge-restart-automation.md
@@ -28,6 +28,8 @@ Cloudflare passkey operator page は approvalGrant を作るだけでは足り�
 
 deploy operator page は認証と dispatch の場であって、追跡UIではない。dispatch 後は `returnUrl` で Dashboard Butler の chat surface に戻す。GitHub Actions deploy success event を Worker が受けたら、同じ chat thread に deploy 完了 truth と VPS checkout sync + repo-less bridge restart の approval_required proposal を出す。operator page に owner を残して GitHub Actions run link を眺めさせる設計にはしない。
 
+2026-06-04 の live operator では `ReferenceError: Can't find variable: returnToButlerLink` が出た。これは deploy operator page が `returnUrl` を持つ Butler 起点だけを暗黙前提にし、mac Codex から passkey operator URL を開く break-glass / bootstrap 経路を壊した回帰である。正しい境界は、Butler から開いた時は承認後に chat へ戻る、mac Codex から開いた時は `returnUrl` が無くても deploy dispatch と結果表示が成立する、である。`returnToButlerLink` は必須 runtime authority ではなく任意の復帰リンクとして扱う。
+
 今回の実装単位は、deploy success event から VPS privileged maintenance proposal を作り、same-origin VPS passkey operator URL を chat に出し、承認後の Dashboard chat auto-continue が既存 helper queue に固定 command envelope を渡すところまでを一塊で接続すること。実運用で動いている unresolved bridge が deploy 後 follow-up から抜けていると、Butler が「人間は認証だけ」という運用を満たせない。
 
 deploy operator URL は既に `selfParity.deployOperatorMarkdownLink` と passkey operator page に存在するため、今回はそれを GitHub Actions URL と混同しない guidance / tests を補強する。URL 自動提示は `vtddRetrieveSelfParity` を優先し、fallback でも same-origin `/v2/approval/passkey/operator?...actionType=deploy_production&highRiskKind=deploy_production` を返す。
@@ -46,6 +48,8 @@ deploy operator URL は既に `selfParity.deployOperatorMarkdownLink` と passke
 - Unit: deploy operator guidance が GitHub Actions workflow URL ではなく same-origin passkey operator URL を要求する。
 - Unit: deploy operator page は passkey 承認後に `/v2/action/deploy` へ自動 dispatch する導線を維持する。
 - Unit: deploy operator page は dispatch 後に `returnUrl` で Dashboard Butler chat へ戻る導線を持つ。
+- Unit: deploy operator page は `returnUrl` が無い mac Codex 起点でも `returnToButlerLink` ReferenceError を起こさず、dispatch 結果をページ内に表示できる。
+- Unit: deploy operator page は `returnUrl` がある Butler 起点だけ、dispatch 後にその復帰先へ遷移する。
 - Unit: VPS operator page は `dashboardThreadId` がある時に `/v2/dashboard/chat/messages` へ承認イベントを戻す導線を維持する。
 - Unit: GitHub Actions deploy success event は同じ Dashboard chat に bridge sync/restart approval URL を追記する。
 - Unit: 同じ deploy event の重複受信は proposal / chat message / Web Push を二重化しない。
@@ -61,7 +65,7 @@ deploy operator URL は既に `selfParity.deployOperatorMarkdownLink` と passke
 - `src/core/vps-privileged-maintenance.js`: deploy follow-up 用 fixed helper command registry entry を追加する。risk は arbitrary command 化することなので argv / allowedArgs は固定する。
 - `src/worker/runtime.js`: GitHub Actions deploy success event から unresolved bridge sync/restart approval proposal を作り、承認後の既存 helper queue へつなぐ。risk は deploy approval と VPS maintenance approval を混ぜること。
 - `scripts/sync-dashboard-app-server-bridge-after-deploy.mjs`: VPS checkout fast-forward と unresolved bridge restart を固定処理にする。risk は dirty checkout / service 名誤り / stdout に秘密を出すこと。
-- `src/core/passkey-operator-page.js`: 今回は既存 auto-dispatch 導線の回帰確認を基本とし、必要時だけ文言を補強する。risk は owner に approvalGrantId copy を要求する flow へ戻ること。
+- `src/core/passkey-operator-page.js`: deploy auto-dispatch 後の任意 return link を DOM 参照として明示し、mac Codex 起点では未指定でも落ちないようにする。risk は Butler 起点の chat 復帰を失うこと、または mac Codex 起点で不要な redirect を起こすこと。
 - `test/vps-privileged-maintenance.test.js`: registry coverage を追加する。
 - `test/worker.test.js` / `test/passkey-operator-page.test.js`: unresolved bridge natural-language proposal、deploy operator URL guidance、passkey 承認後 auto-dispatch / auto-continue の回帰を追加する。
 - `worker.js`: generated worker。Worker source を変更した場合のみ更新する。
@@ -72,6 +76,7 @@ deploy operator URL は既に `selfParity.deployOperatorMarkdownLink` と passke
 - deploy mode の operator page は passkey 承認後に `/v2/action/deploy` を自動 dispatch し、`returnUrl` があれば Dashboard Butler chat へ戻れる。
 - `/v2/action/deploy` は real passkey approval grant から `deploy-production.yml` を dispatch できる。
 - `evaluateButlerSelfParity()` は `deployOperatorUrl` / `deployOperatorMarkdownLink` / `deployRecovery` を返せる。
+- deploy operator page は `returnUrl` を任意の復帰リンクとして描画できる。Butler 起点では chat 復帰に使い、mac Codex 起点ではリンク非表示で動作する必要がある。
 - `ensureDashboardBridgeRepoSynced()` は bridge startup 前に clean behind-only checkout を `origin/main` へ fast-forward できる。
 - Issue #637 の VPS operator page は `dashboardThreadId` がある時、承認後に Dashboard chat API へ戻って helper queue へ自動継続できる。
 - Issue #637 の VPS helper queue は approvalGrant を受けて helper execution envelope を作れる。
@@ -88,6 +93,7 @@ bridge restart の頻度による副作用は未測定。予測されるリス�
 
 - GitHub Actions workflow URL を deploy URL として返すと、owner は認証だけで済まない。
 - deploy approval scope に bridge restart までは含めない。今回の slice は deploy 後 follow-up approval URL を作るが、勝手に destructive / maintenance execution を始めない。
+- deploy operator page の `returnUrl` を必須扱いにすると、mac Codex から passkey approval を開く bootstrap / break-glass 経路が ReferenceError で止まる。
 - unresolved bridge を残骸扱いで stop/disable すると repo-less main chat を壊す。
 - broad `bridge restart` intent で全 bridge を同時 restart すると進行中 turn を落とす可能性がある。
 - health check なしの周期 restart は、長時間開発 turn と衝突して owner-facing UX を悪化させる可能性がある。

--- a/src/core/passkey-operator-page.js
+++ b/src/core/passkey-operator-page.js
@@ -447,6 +447,7 @@ export function renderPasskeyOperatorPage(input = {}) {
       const autoCopyApprovalGrantInput = document.getElementById("auto-copy-approval-grant-input");
       const deployRunLink = document.getElementById("deploy-run-link");
       const deployDebugOutput = document.getElementById("deploy-debug-output");
+      const returnToButlerLink = document.getElementById("return-to-butler-link");
       const mergePrLink = document.getElementById("merge-pr-link");
       const issueCloseLink = document.getElementById("issue-close-link");
       const operatorMode = "${escapeHtml(operatorMode)}";

--- a/test/passkey-operator-page.test.js
+++ b/test/passkey-operator-page.test.js
@@ -163,6 +163,7 @@ test("passkey operator page focuses deploy mode on deploy approval and dispatch 
   assert.equal(html.includes("function shouldReturnToButlerAfterDeployDispatch(body)"), true);
   assert.equal(html.includes('body?.deploy?.status === "dispatched"'), true);
   assert.equal(html.includes("function returnToButlerAfterDeployDispatch(body)"), true);
+  assert.equal(html.includes('const returnToButlerLink = document.getElementById("return-to-butler-link");'), true);
   assert.equal(html.includes("window.location.assign(returnToButlerLink.href)"), true);
   assert.equal(html.includes("returnToButlerAfterDeployDispatch(deployBody);"), true);
   assert.equal(html.includes("deploy-debug-output"), true);
@@ -762,6 +763,99 @@ test("passkey operator page rejects unsafe or missing deploy run links", () => {
   assert.equal(deployRunLink.hidden, true);
 });
 
+test("passkey operator deploy return is optional for mac Codex-origin approval", () => {
+  const helpers = loadOperatorPageHelpers(
+    {
+      document: {
+        getElementById(id) {
+          if (id === "return-to-butler-link") {
+            return {
+              href: "",
+              hidden: true,
+              addEventListener() {}
+            };
+          }
+          return {
+            value: "",
+            textContent: "",
+            addEventListener() {}
+          };
+        }
+      },
+      window: {
+        setTimeout(callback) {
+          callback();
+        },
+        location: {
+          assign() {
+            assert.fail("mac Codex-origin deploy approval without returnUrl must not redirect");
+          }
+        }
+      }
+    },
+    {
+      operatorMode: "deploy",
+      repositoryInput: "marushu/vtdd-v2-p"
+    }
+  );
+
+  assert.doesNotThrow(() => {
+    helpers.returnToButlerAfterDeployDispatch({
+      deploy: {
+        status: "dispatched"
+      }
+    });
+  });
+});
+
+test("passkey operator deploy returns to Butler only when return link is present", () => {
+  let assignedUrl = "";
+  const helpers = loadOperatorPageHelpers(
+    {
+      document: {
+        getElementById(id) {
+          if (id === "return-to-butler-link") {
+            return {
+              href: "https://chatgpt.com/g/example-butler",
+              hidden: false,
+              addEventListener() {}
+            };
+          }
+          return {
+            value: "",
+            textContent: "",
+            addEventListener() {}
+          };
+        }
+      },
+      window: {
+        setTimeout(callback, delay) {
+          assert.equal(delay, 900);
+          callback();
+        },
+        location: {
+          assign(url) {
+            assignedUrl = url;
+          }
+        }
+      }
+    },
+    {
+      operatorMode: "deploy",
+      repositoryInput: "marushu/vtdd-v2-p",
+      returnUrl: "https://chatgpt.com/g/example-butler"
+    }
+  );
+
+  helpers.returnToButlerAfterDeployDispatch({
+    deploy: {
+      status: "dispatched"
+    }
+  });
+
+  assert.equal(assignedUrl, "https://chatgpt.com/g/example-butler");
+});
+
 test("passkey operator page exposes safe PR link from merge response", () => {
   const mergePrLink = {
     href: "#",
@@ -850,8 +944,8 @@ test("passkey operator page exposes safe issue link from issue close response", 
   assert.equal(issueCloseLink.hidden, true);
 });
 
-function loadOperatorPageHelpers(overrides = {}) {
-  const html = renderPasskeyOperatorPage();
+function loadOperatorPageHelpers(overrides = {}, pageInput = {}) {
+  const html = renderPasskeyOperatorPage(pageInput);
   const script = html.match(/<script>([\s\S]*)<\/script>/)?.[1];
   assert.ok(script);
 

--- a/worker.js
+++ b/worker.js
@@ -27669,6 +27669,7 @@ function renderPasskeyOperatorPage(input = {}) {
       const autoCopyApprovalGrantInput = document.getElementById("auto-copy-approval-grant-input");
       const deployRunLink = document.getElementById("deploy-run-link");
       const deployDebugOutput = document.getElementById("deploy-debug-output");
+      const returnToButlerLink = document.getElementById("return-to-butler-link");
       const mergePrLink = document.getElementById("merge-pr-link");
       const issueCloseLink = document.getElementById("issue-close-link");
       const operatorMode = "${escapeHtml(operatorMode)}";


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #741 の deploy passkey operator 回帰修正です。mac Codex から operator URL を開く bootstrap / break-glass 経路では `returnUrl` が無くても ReferenceError で落ちず、Butler から開いた場合だけ dispatch 後に chat 復帰リンクへ戻る状態にします。

## Satisfied Success Criteria

- deploy 後 workflow の入口である passkey operator page が、`returnToButlerLink` 未定義で停止しないよう DOM 参照を明示しました。
- `returnUrl` が無い mac Codex 起点では redirect せず、`returnUrl` がある Butler 起点では dispatch 後にその復帰先へ遷移することを unit test で固定しました。
- Worker source 変更として `worker.js` を再生成し、generated worker parity を確認しました。

## Unsatisfied Success Criteria

- Issue #741 全体の bridge lifecycle guard、deploy 後 VPS checkout sync、app-server bridge restart 実行、before/after runtime truth、mapped production E2E はこのPRでは未完了です。
- Cost boundary コメントで止まっている `unresolved` bridge の自動 restart / periodic restart / durable progress 復元は、このPRでは再開しません。
- Butler からの自然文 deploy URL 提示、deploy 完了追跡、VPS helper queue 実行までの end-to-end evidence は merge / deploy 後に別途確認が必要です。

## Non-goal violations

なし。deploy、bridge restart、credential mutation、permission mutation、通常 Dashboard chat 認証緩和は実行していません。

## 開発前作戦図

- 作戦図 evidence: docs/development-strategy/issue-741-deploy-bridge-restart-automation.md
- 完了体験: owner が mac Codex から passkey operator を開く場合は認証と deploy dispatch が同じページ内で完了し、Dashboard Butler から開く場合は認証後に chat へ戻れる。
- VTDD 全体で進める部分: Issue #741 の deploy operator / passkey approval 境界を安定させ、後続の deploy 後 bridge sync/restart follow-up が認証ページの JS 例外で止まらないようにする。
- 設計: `returnToButlerLink` は authority ではなく任意の復帰リンクとして扱う。DOM 参照を明示し、operatorMode が deploy かつ href がある場合だけ `window.location.assign()` する。
- 仮説: live error の原因は `returnToButlerAfterDeployDispatch()` が未定義の `returnToButlerLink` を参照していたこと。`returnUrl` なしの mac Codex 起点でも dispatched response 後に関数が呼ばれ、ReferenceError で止まったと判断した。
- 検証計画: generated operator script を VM で読み、`returnUrl` なしの deploy dispatch で例外にならないこと、`returnUrl` ありでは 900ms 後に復帰 URL へ assign することを test する。Worker bundle を build し `verify:worker` を通す。
- 改修見積もり: `src/core/passkey-operator-page.js` の script DOM const 追加、`test/passkey-operator-page.test.js` の deploy return 境界テスト追加、`worker.js` generated bundle 更新、作戦図への live regression 境界追記。
- 既に通っている経路: `/v2/approval/passkey/operator` は deploy mode を表示でき、`/v2/action/deploy` への auto-dispatch 導線と `returnUrl` link 描画は既存実装に存在する。
- 未確認の境界: production へこの修正を deploy した後、実機 passkey operator で mac Codex 起点と Butler 起点の両方を live 確認する必要がある。
- 穴が出そうな箇所: `returnUrl` を必須扱いにすると mac Codex 起点が壊れ、逆に復帰処理を消すと Butler 起点でチャットに戻れなくなる。
- PR 前に確認すること: Issue #741、PR #768 merge truth、該当 source/test、generated worker diff、`npm run verify:worker` の結果を確認する。
- 実装候補と捨てた案: 採用は DOM 参照を明示して href がある場合だけ戻る案。捨てた案は return 処理削除、常に Dashboard URL へ redirect、mac Codex 起点にも returnUrl を強制する案。
- merge 後に通す E2E: production deploy 後、mac Codex 起点の deploy operator URL で ReferenceError が消えることを live 確認し、Butler 起点では認証後に chat へ戻ることを確認する。
- 次の PR を増やさない理由: 今回は既に露呈した operator page JS 回帰の止血であり、bridge restart 本体や deploy tracking の残作業は Issue #741 の既存未完了項目として残す。
- 停止条件: 修正に deploy 実行、bridge restart 実行、Cloudflare Access / Dashboard chat 認証緩和、owner 固有 URL の repo 固定が必要になる場合は停止する。

## Dry-run Impact Report

- Target Issue: Issue #741
- Implementing Success Criteria: deploy passkey operator が `returnToButlerLink` ReferenceError を起こさず、mac Codex 起点では復帰リンク任意、Butler 起点では chat 復帰可能という owner-facing 境界を満たす。
- Explicit Non-goals: deploy 実行、VPS checkout sync、bridge restart、credential mutation、permission mutation、通常 Dashboard chat 認証の変更、Issue close は行わない。
- Expected touched files/routes/workflows: `src/core/passkey-operator-page.js`、`test/passkey-operator-page.test.js`、`worker.js`、`docs/development-strategy/issue-741-deploy-bridge-restart-automation.md`。route/workflow 定義は変更しない。
- Affected Issues: Issue #741。関連して Issue #637 / #450 の後続 handoff に影響するが、このPRでは scope を広げない。
- Affected PRs: PR #768 の deploy 後に露呈した回帰の follow-up。既存 merged PR へ push せず新規 PR とする。
- Affected workflows: `deploy-production.yml` の operator entrance を壊さないための UI/runtime bundle 修正。workflow file 自体は変更しない。
- Affected runtime/operator surfaces: Cloudflare Worker の passkey operator page、Dashboard Butler からの deploy returnUrl、mac Codex から開く operator page。
- What may break if we patch narrowly: 復帰リンクを任意扱いにしないと mac Codex 起点が壊れ続ける。逆に deploy 後 return 処理を消すと Butler 起点で owner がチャットへ戻れない。
- Unknowns to investigate before coding: live production Safari / iOS での redirect timing と deploy dispatch 後の UX は merge/deploy 後に runtime truth として確認する。
- Validation needed: `node --test test/passkey-operator-page.test.js --test-name-pattern "deploy return|deploy mode|deploy run|response parser"`、`npm run build:worker`、`npm run verify:worker`。
- Stop condition: deploy approval grant だけで bridge restart を始める必要が出た場合、または Dashboard chat write 認証を広く緩める必要が出た場合は停止する。

## Execution Queue Delta

- Queue position before: Issue #741 は deploy 後 bridge lifecycle follow-up の bounded slice として進行中だが、Cost boundary により bridge 自動 restart 本体は制限中。
- Preemption decision: ROOT。passkey operator が ReferenceError で落ちると deploy / bridge follow-up の承認入口が止まり、Issue #741 / #637 / Dashboard Butler recovery の検証が進まないため先に止血する。
- Queue delta: Issue #741 の operator page regression をこのPRで進める。bridge restart 本体は Blocked / Evidence Gaps に残る。
- Why this PR is next: owner の live error が passkey approval 入口そのものを止めており、後続の deploy 追跡や bridge sync/restart 自動化へ進む前に解消が必要。
- Active Issues not downscoped: Active Issues は縮小しません。このPRで扱わない Issue #741 の success criteria と関連 active Issues は未完了として残します。

## File / Line Hypotheses

- file: `src/core/passkey-operator-page.js`
  - hypothesis: generated script 内で `returnToButlerLink` の DOM const が未定義のまま `returnToButlerAfterDeployDispatch()` から参照されている。
  - risk if changed narrowly: DOM const だけを追加しても、`returnUrl` なしの mac Codex 起点と `returnUrl` ありの Butler 起点をテストしないと再発する。
  - validation: VM で generated script helper を読み、両起点の dispatch 後挙動を unit test する。
  - related Issue: Issue #741
- file: `test/passkey-operator-page.test.js`
  - hypothesis: 既存テストは文字列確認が中心で、未定義変数を実行時に捕まえられていない。
  - risk if changed narrowly: 文字列 assert だけを増やすと ReferenceError 再発を検知できない。
  - validation: `returnToButlerAfterDeployDispatch()` を実行するテストを追加する。
  - related Issue: Issue #741

## Hypothesis Retrospective

- expected: `returnToButlerLink` DOM const を追加すれば、`returnUrl` なしの deploy dispatch で例外にならない。
- actual: 追加テストで mac Codex 起点は redirect せず例外なし、Butler 起点は `https://chatgpt.com/g/example-butler` へ assign することを確認した。
- mismatch: なし。原因は未定義 DOM 参照で説明できた。
- lesson: deploy operator page の return link は必須入力ではなく surface 起点に依存する optional recovery affordance としてテストする必要がある。
- should become RAG candidate: 候補。`returnUrl` は Butler 起点のチャット復帰用であり、mac Codex 起点では必須にしない。

## Verification Evidence

- `node --test test/passkey-operator-page.test.js --test-name-pattern "deploy return|deploy mode|deploy run|response parser"`: pass 30 / fail 0
- `npm run build:worker`: pass
- `npm run verify:worker`: pass。`node --test` pass 1164 / skipped 1、`check:self-parity` pass、`check:generated-worker` pass。
- Evidence path/link: `test/passkey-operator-page.test.js` の `passkey operator deploy return is optional for mac Codex-origin approval` と `passkey operator deploy returns to Butler only when return link is present`。

## Butler Completion Contract

- Primary owner surface: Dashboard Butler。
- Fallback surface: mac Codex は bootstrap / break-glass fallback surface。Custom GPT はこのPRでは主経路ではなく fallback 扱い。
- Owner goal: passkey operator 認証後に ReferenceError で止まらず、mac Codex 起点と Butler 起点のどちらでも次の操作へ進める。
- Butler entrypoint: Dashboard Butler の deploy 自然文入口から same-origin passkey operator URL を開く経路を前提に、operator page の復帰リンク境界を修正する。
- Dashboard Butler natural-language path: Dashboard Butler の自然文 / 通常チャットで deploy を依頼し、提示された operator URL から認証後に chat へ戻る経路を壊さない。
- Action Schema exposure: Custom GPT Action Schema / operationId はこのPRでは変更しない。主経路とは扱わない。
- Runtime path: Worker の `/v2/approval/passkey/operator` が生成する deploy operator page script。
- Runner/runtime truth: generated `worker.js` を更新し、`check:generated-worker` と `verify:worker` で source/bundle parity を確認。
- Authority boundary: passkey approval boundary は未変更。deploy dispatch や bridge restart はこのPRでは実行しない。
- E2E evidence: merge/deploy 前のため production Butler-facing E2E は未実施。unit と worker verification まで。
- Completion status: incomplete

## Surface Update Checklist

- Dashboard Butler normal chat: deploy 起点の returnUrl 挙動を維持するが、chat UI 自体は未変更。
- Passkey operator page: `returnToButlerLink` DOM 参照を明示し、復帰リンクを任意化。
- Worker bundle: `worker.js` regenerated.
- Custom GPT Action Schema: 未変更。
- VPS helper / bridge: 未変更。
- Docs / strategy: Issue #741 作戦図に live regression と mac Codex / Butler 起点境界を追記。
