### PR TITLE
Issue #455 Codex Analytics observer core を追加

### DIFF
--- a/docs/development-strategy/issue-455-codex-analytics-page-observer.md
+++ b/docs/development-strategy/issue-455-codex-analytics-page-observer.md
@@ -1,0 +1,136 @@
+# Issue #455 Codex Analytics page observer 作戦図
+
+## 完了体験
+
+owner は Dashboard Butler から「Codex 使用量を確認して」「この turn の前後でどれだけ減ったか見たい」と自然文で依頼できる。Butler は AI 風に代替回答せず、接続済みの観測 runner から最新 snapshot または before/after delta を読み、使用量ページ由来の構造化値だけを返す。
+
+コストチェッカーは常時ONではない。owner または operator が明示的に有効化した時だけ取得し、不要な時は完全に停止できる。既定は `disabled` とし、短時間の検証では `manual` または single-shot capture を使う。
+
+## VTDD 全体で進める部分
+
+Issue #455 の「Codex 使用量がどこで増えるかを可視化する」「RAG には full transcript ではなく、使用量増加の原因・判断・削減結果だけを構造化して残す」部分を進める。
+
+PR #764 / PR #765 の方針を維持する。Dashboard Worker は cost/read 相談に AI 風返信しない。通常 chat は bridge / `codex app-server` へ届き、コスト観測は別の observer truth として扱う。
+
+## 設計
+
+`codex_analytics_page_observer` という観測 surface を定義する。これは実行・判断・返信生成の主経路ではなく、使用量ページの表示値を読む read-only collector である。
+
+設定は次の3状態にする。
+
+- `disabled`: 既定。ChatGPT / Codex usage page を開かず、snapshot も取得しない。Dashboard には `costChecker.enabled=false` と `reason=disabled_by_default` を返す。
+- `manual`: owner が明示した single-shot の時だけ取得する。通常の before/after 証跡はこの mode から始める。
+- `enabled`: owner / operator が明示した期間だけ before/after capture を許可する。TTL または session scope を必須にし、無期限の常時監視にしない。
+
+observer の出力は、ページ全文・cookie・token・生HTMLではなく、次の最小 snapshot に限定する。
+
+```json
+{
+  "kind": "codex_analytics_usage_snapshot",
+  "captureMode": "manual",
+  "enabled": true,
+  "capturedAt": "2026-06-04T00:00:00.000Z",
+  "source": "chatgpt_codex_analytics_page",
+  "captureMethod": "authenticated_browser_dom_or_ocr",
+  "limits": [
+    {
+      "label": "5時間の使用制限",
+      "remainingPercent": 93,
+      "resetAtText": "15:16"
+    }
+  ],
+  "redacted": true
+}
+```
+
+Dashboard / Butler へ返す runtime truth は `costChecker.enabled`, `mode`, `lastCapturedAt`, `lastSnapshotAvailable`, `lastDeltaAvailable`, `blockedReason` に絞る。
+
+## 仮説
+
+公式の個人向け usage page は owner の logged-in browser session で表示されるため、Cloudflare Worker や VPS から無条件に読めるものではない。認証情報を repo / RAG / runtime storage に置く実装は安全境界を壊す。
+
+したがって最初の実装は、operator-owned browser context で page DOM または screenshot OCR を読む local / VPS-side observer と、Dashboard がその redacted snapshot を読む ingest path に分けるのが安全である。
+
+toggle を持たない collector から始めると、通常会話や長時間作業のたびに usage page を開く設計に流れ、owner が望むコスト削減と逆方向になる。先に on/off と TTL を仕様に固定する。
+
+## 検証計画
+
+- Unit: config parser が未指定を `disabled` にする。
+- Unit: `manual` は single-shot capture だけ許可し、定期 capture を拒否する。
+- Unit: `enabled` は TTL / session scope なしでは invalid とする。
+- Unit: snapshot sanitizer が cookie、token、生HTML、full transcript を保持しない。
+- Unit: before/after delta は rounded percent / reset text を扱い、厳密な per-message billing として断定しない。
+- Integration: Dashboard runtime truth が `costChecker.enabled=false` の時に capture を起動しない。
+- E2E: owner が manual capture を要求した時、接続済み observer があれば snapshot を返し、なければ `observer_unavailable` と次の owner action を返す。
+
+## 改修見積もり
+
+- `docs/development-strategy/issue-455-codex-analytics-page-observer.md`: この作戦図。risk は実装前提を曖昧にすると常時監視へ drift すること。
+- `scripts/capture-codex-analytics-usage.mjs`: optional follow-up。logged-in browser DOM または screenshot OCR から redacted snapshot を作る。risk は ChatGPT UI 変更と認証境界。
+- `src/core/codex-analytics-usage.js`: optional follow-up。mode parser / sanitizer / delta builder。risk は percent 表示を精密課金に見せてしまうこと。
+- `test/codex-analytics-usage.test.js`: optional follow-up。fixture HTML / OCR text / config mode を検証する。live ChatGPT page は CI で叩かない。
+- `src/worker/runtime.js`: optional later。Dashboard runtime truth / ingest route を接続する場合のみ触る。risk は Worker が ChatGPT 認証情報を扱う方向へ広がること。
+
+## 既に通っている経路
+
+- PR #764 で Dashboard Worker の AI 風 fast path を止め、通常 chat を app-server bridge へ届ける方針に戻した。
+- PR #765 で Dashboard app-server bridge の cost profile / model / reasoning effort truth を出せる足場を追加した。
+- `docs/butler/dashboard-butler-app-server-live-path.md` は、cost questions も bridge / `codex app-server` へ届けること、usage tuning は Worker pseudo-answer ではなく bridge 側で扱うことを定義している。
+- Issue #455 は Codex Analytics スクリーンショット由来の owner 報告を evidence path として認めている。
+
+## 未確認の境界
+
+個人向け `https://chatgpt.com/codex/cloud/settings/analytics#usage` の DOM から安定して値を読めるかは未確認。DOM が読めない場合は screenshot OCR fallback が必要になる。
+
+Business / Enterprise / Edu では Codex Analytics / Compliance API が存在する可能性があるが、この public/core branch は owner 個人アカウント前提の秘密値や API key を repo に固定しない。
+
+usage page の percent は丸め表示や反映遅延があり得る。before/after delta は傾向証跡であり、正確な per-turn 課金証明ではない。
+
+## 穴が出そうな箇所
+
+- toggle なしで collector を実装すると、常時監視になり使用量・認証・プライバシー負荷が増える。
+- ChatGPT cookie / session token を RAG や repo に保存すると重大な credential leak になる。
+- full screenshot をそのまま保存すると workspace 名、account 情報、他の UI 断片を含む可能性がある。
+- Worker に ChatGPT 認証を持たせると、Dashboard Butler の中継機境界を壊す。
+- usage delta を「この会話は何クレジット」と断定すると、公式 billing truth ではない値を過信させる。
+
+## PR 前に確認すること
+
+- branch が latest `origin/main` から切られている。
+- PR #765 の deploy / VPS bridge restart 状況を PR body に正直に書く。未デプロイなら未デプロイと書く。
+- 実装を入れる場合は先に `manual` / `disabled` の tests を書く。
+- ChatGPT logged-in browser を読む live probe は owner の明示許可なしに実行しない。
+- PR body の Execution Queue Delta で、Issue #455 の observer slice が owner 指示による `NEXT` / `QUEUE` 更新であり、active Issues を downscope していないことを明記する。
+
+## 実装候補と捨てた案
+
+採用: 既定 `disabled`、single-shot `manual`、TTL 必須の `enabled` を持つ observer config。
+
+採用: snapshot は redacted structured metrics のみ。full transcript / full page dump / raw cookie は保持しない。
+
+捨てた案: usage page を Dashboard Worker から直接 scrape する。ChatGPT 認証情報を Worker に持ち込むため不採用。
+
+捨てた案: 常時ONの定期監視。owner の「クレジット節約」目的と矛盾し、不要な認証ページアクセスを増やすため不採用。
+
+捨てた案: usage delta を精密課金として扱う。表示値の丸め・遅延があるため不採用。
+
+## merge 後に通す E2E
+
+1. `disabled` の状態で Dashboard Butler から「使用量を確認して」と送る。期待値は capture を起動せず、`costChecker.enabled=false` と observer 未接続 / disabled reason を返す。
+2. `manual` の状態で owner が single-shot capture を明示する。接続済み observer がある場合だけ redacted snapshot を返す。
+3. `enabled` の状態で Dashboard app-server turn の前後に snapshot を取り、delta を `bridgeProfile` / `modelConfigured` / `reasoningEffortConfigured` と一緒に表示する。
+4. TTL 期限後は自動で `disabled` 相当に戻り、capture が止まる。
+
+## 次の PR を増やさない理由
+
+この作戦図は、PR #765 の「軽量 profile を試せる足場」に対して、実際に減り方を観測するための次 slice を定義する。toggle を同じ slice に含めることで、observer 実装後に常時監視を止める別 PR を増やさない。
+
+ただし DOM/OCR collector、Dashboard ingest、VPS deployment は authority と検証境界が違うため、実装 PR では最小の parser / config / sanitizer から始め、live browser probe は明示許可後に分ける。
+
+## 停止条件
+
+- ChatGPT 認証情報を repo / RAG / Worker storage に置く必要が出た場合。
+- owner の明示許可なしに logged-in browser を開く必要が出た場合。
+- Worker が使用量ページを直接読む設計に広がった場合。
+- cost checker が既定ONまたは無期限ONでないと成立しない場合。
+- usage page の表示値を正確な課金 API として扱いそうになった場合。

--- a/src/core/codex-analytics-usage.js
+++ b/src/core/codex-analytics-usage.js
@@ -1,0 +1,294 @@
+const MODE_DISABLED = "disabled";
+const MODE_MANUAL = "manual";
+const MODE_ENABLED = "enabled";
+
+const VALID_MODES = new Set([MODE_DISABLED, MODE_MANUAL, MODE_ENABLED]);
+const DEFAULT_SOURCE = "chatgpt_codex_analytics_page";
+const DEFAULT_CAPTURE_METHOD = "authenticated_browser_dom_or_ocr";
+
+function normalizeText(value) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function normalizeMode(value) {
+  const mode = normalizeText(value).toLowerCase();
+  return VALID_MODES.has(mode) ? mode : MODE_DISABLED;
+}
+
+function normalizeDate(value, now = new Date()) {
+  if (value instanceof Date && Number.isFinite(value.getTime())) {
+    return value;
+  }
+  const text = normalizeText(value);
+  if (!text) {
+    return null;
+  }
+  const date = new Date(text);
+  if (!Number.isFinite(date.getTime())) {
+    return null;
+  }
+  return date;
+}
+
+function normalizePositiveNumber(value) {
+  const number = Number(value);
+  return Number.isFinite(number) && number > 0 ? number : 0;
+}
+
+function isoDate(value) {
+  const date = normalizeDate(value);
+  return date ? date.toISOString() : null;
+}
+
+function sanitizeShortText(value, { maxLength = 120 } = {}) {
+  return normalizeText(value)
+    .replace(/<[^>]*>/g, " ")
+    .replace(/\b(sk-[A-Za-z0-9_-]+|gh[psuor]_[A-Za-z0-9_]+|approval:[A-Za-z0-9-]+)\b/g, "[REDACTED]")
+    .replace(/\b(cookie|authorization|token|secret|session)\s*[:=]\s*[^\s]+/gi, "$1=[REDACTED]")
+    .replace(/\s+/g, " ")
+    .slice(0, maxLength)
+    .trim();
+}
+
+function normalizePercent(value) {
+  if (typeof value === "string") {
+    const match = value.match(/-?\d+(?:\.\d+)?/);
+    if (!match) {
+      return null;
+    }
+    value = match[0];
+  }
+  const number = Number(value);
+  if (!Number.isFinite(number)) {
+    return null;
+  }
+  const clamped = Math.min(100, Math.max(0, number));
+  return Math.round(clamped * 10) / 10;
+}
+
+function normalizeLimit(input = {}) {
+  const label = sanitizeShortText(input.label || input.name || input.title, { maxLength: 80 });
+  const remainingPercent = normalizePercent(
+    input.remainingPercent ?? input.remaining_percent ?? input.percentRemaining ?? input.percent
+  );
+  if (!label || remainingPercent === null) {
+    return null;
+  }
+  const resetAtText = sanitizeShortText(input.resetAtText || input.reset_at_text || input.reset || "", {
+    maxLength: 80
+  });
+  return {
+    label,
+    remainingPercent,
+    ...(resetAtText ? { resetAtText } : {})
+  };
+}
+
+function normalizeCaptureMode(value, fallbackMode = MODE_DISABLED) {
+  const mode = normalizeMode(value || fallbackMode);
+  return mode === MODE_ENABLED ? MODE_ENABLED : mode === MODE_MANUAL ? MODE_MANUAL : MODE_DISABLED;
+}
+
+function normalizeCostCheckerConfig(input = {}, options = {}) {
+  const now = normalizeDate(options.now) || new Date();
+  const mode = normalizeMode(input.mode ?? input.captureMode ?? input.enabledMode);
+  const issues = [];
+  const ttlMs =
+    normalizePositiveNumber(input.ttlMs ?? input.ttl_ms) ||
+    normalizePositiveNumber(input.ttlSeconds ?? input.ttl_seconds) * 1000;
+  const requestedExpiresAt = normalizeDate(input.expiresAt ?? input.expires_at, now);
+  const expiresAt = requestedExpiresAt || (ttlMs ? new Date(now.getTime() + ttlMs) : null);
+  const sessionId = sanitizeShortText(input.sessionId || input.session_id || "", { maxLength: 80 });
+
+  if (mode === MODE_DISABLED) {
+    return {
+      mode,
+      enabled: false,
+      valid: true,
+      captureAllowed: false,
+      scheduledCaptureAllowed: false,
+      singleShot: false,
+      reason: "disabled_by_default",
+      issues
+    };
+  }
+
+  if (mode === MODE_MANUAL) {
+    return {
+      mode,
+      enabled: true,
+      valid: true,
+      captureAllowed: true,
+      scheduledCaptureAllowed: false,
+      singleShot: true,
+      reason: "manual_single_shot_only",
+      ...(expiresAt ? { expiresAt: expiresAt.toISOString() } : {}),
+      ...(sessionId ? { sessionId } : {}),
+      issues
+    };
+  }
+
+  if (!expiresAt && !sessionId) {
+    issues.push("enabled mode requires ttl/expiresAt or session scope");
+  }
+  if (expiresAt && expiresAt.getTime() <= now.getTime()) {
+    issues.push("enabled mode expiry is already elapsed");
+  }
+  const valid = issues.length === 0;
+  return {
+    mode,
+    enabled: valid,
+    valid,
+    captureAllowed: valid,
+    scheduledCaptureAllowed: valid,
+    singleShot: false,
+    reason: valid ? "enabled_with_bounded_scope" : "enabled_requires_bounded_scope",
+    ...(expiresAt ? { expiresAt: expiresAt.toISOString() } : {}),
+    ...(sessionId ? { sessionId } : {}),
+    issues
+  };
+}
+
+function sanitizeCodexAnalyticsUsageSnapshot(input = {}, options = {}) {
+  const captureMode = normalizeCaptureMode(input.captureMode || input.mode, options.captureMode || MODE_MANUAL);
+  const capturedAt = isoDate(input.capturedAt || input.captured_at || options.now || new Date()) || new Date().toISOString();
+  const rawLimits = Array.isArray(input.limits) ? input.limits : [];
+  const limits = rawLimits.map((limit) => normalizeLimit(limit)).filter(Boolean);
+  return {
+    kind: "codex_analytics_usage_snapshot",
+    captureMode,
+    enabled: captureMode !== MODE_DISABLED,
+    capturedAt,
+    source: sanitizeShortText(input.source || DEFAULT_SOURCE, { maxLength: 80 }) || DEFAULT_SOURCE,
+    captureMethod:
+      sanitizeShortText(input.captureMethod || input.capture_method || DEFAULT_CAPTURE_METHOD, { maxLength: 80 }) ||
+      DEFAULT_CAPTURE_METHOD,
+    limits,
+    redacted: true
+  };
+}
+
+function parseCodexAnalyticsUsageText(text, options = {}) {
+  const sourceText = normalizeText(text);
+  const limits = [];
+  if (!sourceText) {
+    return sanitizeCodexAnalyticsUsageSnapshot({ limits: [], captureMode: options.captureMode }, options);
+  }
+  const lines = sourceText
+    .split(/\r?\n/)
+    .map((line) => sanitizeShortText(line, { maxLength: 140 }))
+    .filter(Boolean);
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    const percentMatch = line.match(/(\d+(?:\.\d+)?)\s*%\s*(?:残り|remaining)?/i);
+    if (!percentMatch) {
+      continue;
+    }
+    const remainingPercent = normalizePercent(percentMatch[1]);
+    const labelCandidates = [lines[index - 1], line.replace(percentMatch[0], ""), lines[index - 2]].filter(Boolean);
+    const label =
+      labelCandidates.find((candidate) => /制限|上限|limit|usage|spark|codex/i.test(candidate)) ||
+      `Codex usage limit ${limits.length + 1}`;
+    const nextLine = lines[index + 1] || "";
+    const resetAtText = /リセット|reset/i.test(nextLine) ? nextLine : "";
+    const normalized = normalizeLimit({ label, remainingPercent, resetAtText });
+    if (normalized) {
+      limits.push(normalized);
+    }
+  }
+
+  return sanitizeCodexAnalyticsUsageSnapshot(
+    {
+      captureMode: options.captureMode || MODE_MANUAL,
+      capturedAt: options.now,
+      captureMethod: options.captureMethod || "authenticated_browser_text_or_ocr",
+      limits
+    },
+    options
+  );
+}
+
+function buildCodexAnalyticsUsageDelta(beforeSnapshot, afterSnapshot) {
+  const before = sanitizeCodexAnalyticsUsageSnapshot(beforeSnapshot || {}, { captureMode: MODE_MANUAL });
+  const after = sanitizeCodexAnalyticsUsageSnapshot(afterSnapshot || {}, { captureMode: MODE_MANUAL });
+  const afterByLabel = new Map(after.limits.map((limit) => [limit.label, limit]));
+  const limits = before.limits.map((beforeLimit) => {
+    const afterLimit = afterByLabel.get(beforeLimit.label);
+    if (!afterLimit) {
+      return {
+        label: beforeLimit.label,
+        status: "missing_after",
+        beforeRemainingPercent: beforeLimit.remainingPercent,
+        afterRemainingPercent: null,
+        consumedDisplayPercent: null
+      };
+    }
+    const consumed = Math.round((beforeLimit.remainingPercent - afterLimit.remainingPercent) * 10) / 10;
+    return {
+      label: beforeLimit.label,
+      status: "compared",
+      beforeRemainingPercent: beforeLimit.remainingPercent,
+      afterRemainingPercent: afterLimit.remainingPercent,
+      consumedDisplayPercent: consumed,
+      resetChanged: (beforeLimit.resetAtText || "") !== (afterLimit.resetAtText || "")
+    };
+  });
+  for (const afterLimit of after.limits) {
+    if (!before.limits.some((beforeLimit) => beforeLimit.label === afterLimit.label)) {
+      limits.push({
+        label: afterLimit.label,
+        status: "missing_before",
+        beforeRemainingPercent: null,
+        afterRemainingPercent: afterLimit.remainingPercent,
+        consumedDisplayPercent: null
+      });
+    }
+  }
+  return {
+    kind: "codex_analytics_usage_delta",
+    beforeCapturedAt: before.capturedAt,
+    afterCapturedAt: after.capturedAt,
+    limits,
+    precision: "display_percent_delta_not_billing_truth",
+    billingTruth: false,
+    redacted: true
+  };
+}
+
+function buildCostCheckerRuntimeTruth(configInput = {}, state = {}) {
+  const config = normalizeCostCheckerConfig(configInput, { now: state.now });
+  const lastSnapshot = state.lastSnapshot
+    ? sanitizeCodexAnalyticsUsageSnapshot(state.lastSnapshot, { captureMode: config.mode, now: state.now })
+    : null;
+  const lastDelta = state.lastDelta || null;
+  const observerAvailable = state.observerAvailable === true;
+  return {
+    costChecker: {
+      enabled: config.enabled,
+      mode: config.mode,
+      valid: config.valid,
+      reason: config.reason,
+      blockedReason: config.valid ? null : config.issues.join("; "),
+      observerAvailable,
+      captureAllowed: config.captureAllowed,
+      scheduledCaptureAllowed: config.scheduledCaptureAllowed,
+      lastCapturedAt: lastSnapshot?.capturedAt || null,
+      lastSnapshotAvailable: Boolean(lastSnapshot && lastSnapshot.limits.length > 0),
+      lastDeltaAvailable: Boolean(lastDelta),
+      billingTruth: false,
+      source: DEFAULT_SOURCE
+    }
+  };
+}
+
+export {
+  MODE_DISABLED as COST_CHECKER_MODE_DISABLED,
+  MODE_ENABLED as COST_CHECKER_MODE_ENABLED,
+  MODE_MANUAL as COST_CHECKER_MODE_MANUAL,
+  buildCodexAnalyticsUsageDelta,
+  buildCostCheckerRuntimeTruth,
+  normalizeCostCheckerConfig,
+  parseCodexAnalyticsUsageText,
+  sanitizeCodexAnalyticsUsageSnapshot
+};

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -42,6 +42,16 @@ export {
   verifyPasskeyRegistration
 } from "./passkey-approval.js";
 export { renderPasskeyOperatorPage } from "./passkey-operator-page.js";
+export {
+  COST_CHECKER_MODE_DISABLED,
+  COST_CHECKER_MODE_ENABLED,
+  COST_CHECKER_MODE_MANUAL,
+  buildCodexAnalyticsUsageDelta,
+  buildCostCheckerRuntimeTruth,
+  normalizeCostCheckerConfig,
+  parseCodexAnalyticsUsageText,
+  sanitizeCodexAnalyticsUsageSnapshot
+} from "./codex-analytics-usage.js";
 export { buildVtddCloudflarePageDirectory, renderVtddHelpGuidePage } from "./help-guide-page.js";
 export { buildButlerReviewSynthesis } from "./butler-review-synthesis.js";
 export { validateDeployApprovalGrant } from "./deploy-approval-grant.js";

--- a/test/codex-analytics-usage.test.js
+++ b/test/codex-analytics-usage.test.js
@@ -1,0 +1,259 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  COST_CHECKER_MODE_DISABLED,
+  COST_CHECKER_MODE_ENABLED,
+  COST_CHECKER_MODE_MANUAL,
+  buildCodexAnalyticsUsageDelta,
+  buildCostCheckerRuntimeTruth,
+  normalizeCostCheckerConfig,
+  parseCodexAnalyticsUsageText,
+  sanitizeCodexAnalyticsUsageSnapshot
+} from "../src/core/index.js";
+
+const NOW = "2026-06-04T07:30:00.000Z";
+
+test("codex analytics cost checker defaults to disabled and does not capture", () => {
+  const config = normalizeCostCheckerConfig({}, { now: NOW });
+
+  assert.equal(config.mode, COST_CHECKER_MODE_DISABLED);
+  assert.equal(config.enabled, false);
+  assert.equal(config.valid, true);
+  assert.equal(config.captureAllowed, false);
+  assert.equal(config.scheduledCaptureAllowed, false);
+  assert.equal(config.reason, "disabled_by_default");
+
+  const truth = buildCostCheckerRuntimeTruth({}, { now: NOW });
+  assert.deepEqual(truth.costChecker, {
+    enabled: false,
+    mode: "disabled",
+    valid: true,
+    reason: "disabled_by_default",
+    blockedReason: null,
+    observerAvailable: false,
+    captureAllowed: false,
+    scheduledCaptureAllowed: false,
+    lastCapturedAt: null,
+    lastSnapshotAvailable: false,
+    lastDeltaAvailable: false,
+    billingTruth: false,
+    source: "chatgpt_codex_analytics_page"
+  });
+});
+
+test("codex analytics manual mode allows only single-shot capture", () => {
+  const config = normalizeCostCheckerConfig(
+    {
+      mode: COST_CHECKER_MODE_MANUAL,
+      ttlSeconds: 300
+    },
+    { now: NOW }
+  );
+
+  assert.equal(config.mode, COST_CHECKER_MODE_MANUAL);
+  assert.equal(config.enabled, true);
+  assert.equal(config.captureAllowed, true);
+  assert.equal(config.scheduledCaptureAllowed, false);
+  assert.equal(config.singleShot, true);
+  assert.equal(config.reason, "manual_single_shot_only");
+  assert.equal(config.expiresAt, "2026-06-04T07:35:00.000Z");
+});
+
+test("codex analytics enabled mode requires bounded TTL or session scope", () => {
+  const unbounded = normalizeCostCheckerConfig({ mode: COST_CHECKER_MODE_ENABLED }, { now: NOW });
+  assert.equal(unbounded.enabled, false);
+  assert.equal(unbounded.valid, false);
+  assert.equal(unbounded.captureAllowed, false);
+  assert.equal(unbounded.reason, "enabled_requires_bounded_scope");
+  assert.deepEqual(unbounded.issues, ["enabled mode requires ttl/expiresAt or session scope"]);
+
+  const expired = normalizeCostCheckerConfig(
+    {
+      mode: COST_CHECKER_MODE_ENABLED,
+      expiresAt: "2026-06-04T07:29:59.000Z"
+    },
+    { now: NOW }
+  );
+  assert.equal(expired.enabled, false);
+  assert.deepEqual(expired.issues, ["enabled mode expiry is already elapsed"]);
+
+  const bounded = normalizeCostCheckerConfig(
+    {
+      mode: COST_CHECKER_MODE_ENABLED,
+      ttlMs: 120000
+    },
+    { now: NOW }
+  );
+  assert.equal(bounded.enabled, true);
+  assert.equal(bounded.scheduledCaptureAllowed, true);
+  assert.equal(bounded.singleShot, false);
+  assert.equal(bounded.reason, "enabled_with_bounded_scope");
+  assert.equal(bounded.expiresAt, "2026-06-04T07:32:00.000Z");
+
+  const sessionScoped = normalizeCostCheckerConfig(
+    {
+      mode: COST_CHECKER_MODE_ENABLED,
+      sessionId: "codex-usage-check-1"
+    },
+    { now: NOW }
+  );
+  assert.equal(sessionScoped.enabled, true);
+  assert.equal(sessionScoped.sessionId, "codex-usage-check-1");
+});
+
+test("codex analytics snapshot sanitizer keeps only redacted structured limits", () => {
+  const snapshot = sanitizeCodexAnalyticsUsageSnapshot({
+    captureMode: COST_CHECKER_MODE_MANUAL,
+    capturedAt: NOW,
+    source: "chatgpt_codex_analytics_page cookie=private",
+    captureMethod: "dom token=secret",
+    rawHtml: "<html>should not persist</html>",
+    cookie: "session=private",
+    limits: [
+      {
+        label: "<b>5時間の使用制限</b> sk-secret",
+        remainingPercent: "93% 残り",
+        resetAtText: "リセット: 15:16 authorization: bearer-secret"
+      },
+      {
+        label: "bad without percent"
+      },
+      {
+        label: "週間利用上限",
+        remainingPercent: 101.234
+      }
+    ]
+  });
+
+  assert.equal(snapshot.kind, "codex_analytics_usage_snapshot");
+  assert.equal(snapshot.enabled, true);
+  assert.equal(snapshot.redacted, true);
+  assert.equal(snapshot.rawHtml, undefined);
+  assert.equal(snapshot.cookie, undefined);
+  assert.equal(snapshot.limits.length, 2);
+  assert.deepEqual(snapshot.limits[0], {
+    label: "5時間の使用制限 [REDACTED]",
+    remainingPercent: 93,
+    resetAtText: "リセット: 15:16 authorization=[REDACTED]"
+  });
+  assert.deepEqual(snapshot.limits[1], {
+    label: "週間利用上限",
+    remainingPercent: 100
+  });
+});
+
+test("codex analytics text parser extracts visible usage percentages without raw page storage", () => {
+  const snapshot = parseCodexAnalyticsUsageText(
+    [
+      "Codex アナリティクス",
+      "5時間の使用制限",
+      "93% 残り",
+      "リセット: 15:16",
+      "週間利用上限",
+      "99% 残り",
+      "リセット: 2026/06/11 10:16",
+      "cookie=session-secret"
+    ].join("\n"),
+    { now: NOW }
+  );
+
+  assert.equal(snapshot.captureMethod, "authenticated_browser_text_or_ocr");
+  assert.equal(snapshot.limits.length, 2);
+  assert.deepEqual(snapshot.limits[0], {
+    label: "5時間の使用制限",
+    remainingPercent: 93,
+    resetAtText: "リセット: 15:16"
+  });
+  assert.deepEqual(snapshot.limits[1], {
+    label: "週間利用上限",
+    remainingPercent: 99,
+    resetAtText: "リセット: 2026/06/11 10:16"
+  });
+  assert.equal(JSON.stringify(snapshot).includes("session-secret"), false);
+});
+
+test("codex analytics usage delta is display-percent evidence, not billing truth", () => {
+  const before = sanitizeCodexAnalyticsUsageSnapshot({
+    captureMode: COST_CHECKER_MODE_MANUAL,
+    capturedAt: "2026-06-04T07:30:00.000Z",
+    limits: [
+      { label: "5時間の使用制限", remainingPercent: 93, resetAtText: "15:16" },
+      { label: "週間利用上限", remainingPercent: 99 }
+    ]
+  });
+  const after = sanitizeCodexAnalyticsUsageSnapshot({
+    captureMode: COST_CHECKER_MODE_MANUAL,
+    capturedAt: "2026-06-04T07:45:00.000Z",
+    limits: [
+      { label: "5時間の使用制限", remainingPercent: 90.4, resetAtText: "15:16" },
+      { label: "GPT-5.3-Codex-Spark 5時間の使用制限", remainingPercent: 100 }
+    ]
+  });
+
+  const delta = buildCodexAnalyticsUsageDelta(before, after);
+
+  assert.equal(delta.kind, "codex_analytics_usage_delta");
+  assert.equal(delta.precision, "display_percent_delta_not_billing_truth");
+  assert.equal(delta.billingTruth, false);
+  assert.deepEqual(delta.limits, [
+    {
+      label: "5時間の使用制限",
+      status: "compared",
+      beforeRemainingPercent: 93,
+      afterRemainingPercent: 90.4,
+      consumedDisplayPercent: 2.6,
+      resetChanged: false
+    },
+    {
+      label: "週間利用上限",
+      status: "missing_after",
+      beforeRemainingPercent: 99,
+      afterRemainingPercent: null,
+      consumedDisplayPercent: null
+    },
+    {
+      label: "GPT-5.3-Codex-Spark 5時間の使用制限",
+      status: "missing_before",
+      beforeRemainingPercent: null,
+      afterRemainingPercent: 100,
+      consumedDisplayPercent: null
+    }
+  ]);
+});
+
+test("codex analytics runtime truth reports snapshot and delta availability without launching observer", () => {
+  const snapshot = sanitizeCodexAnalyticsUsageSnapshot({
+    captureMode: COST_CHECKER_MODE_MANUAL,
+    capturedAt: NOW,
+    limits: [{ label: "5時間の使用制限", remainingPercent: 93 }]
+  });
+  const delta = buildCodexAnalyticsUsageDelta(snapshot, {
+    captureMode: COST_CHECKER_MODE_MANUAL,
+    capturedAt: "2026-06-04T07:40:00.000Z",
+    limits: [{ label: "5時間の使用制限", remainingPercent: 92 }]
+  });
+
+  const truth = buildCostCheckerRuntimeTruth(
+    {
+      mode: COST_CHECKER_MODE_ENABLED,
+      ttlSeconds: 600
+    },
+    {
+      now: NOW,
+      observerAvailable: true,
+      lastSnapshot: snapshot,
+      lastDelta: delta
+    }
+  );
+
+  assert.equal(truth.costChecker.enabled, true);
+  assert.equal(truth.costChecker.mode, COST_CHECKER_MODE_ENABLED);
+  assert.equal(truth.costChecker.observerAvailable, true);
+  assert.equal(truth.costChecker.captureAllowed, true);
+  assert.equal(truth.costChecker.scheduledCaptureAllowed, true);
+  assert.equal(truth.costChecker.lastCapturedAt, NOW);
+  assert.equal(truth.costChecker.lastSnapshotAvailable, true);
+  assert.equal(truth.costChecker.lastDeltaAvailable, true);
+  assert.equal(truth.costChecker.billingTruth, false);
+});


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #455 の部分進捗。Codex Analytics usage page の値を将来安全に読むため、コストチェッカーの `disabled` / `manual` / `enabled` 境界、snapshot sanitizer、before/after delta、Dashboard/Butler 向け runtime truth の core helper を追加する。
- Dashboard Worker が AI 風に代替回答する fast path は復活させず、使用量観測は read-only observer truth として分離する。

## Satisfied Success Criteria

- コストチェッカーは未指定で `disabled` になり、capture を起動しない。
- `manual` は single-shot capture のみ許可し、scheduled capture を拒否する。
- `enabled` は TTL / expiresAt / session scope のいずれかがないと invalid になり、無期限常時監視を防ぐ。
- snapshot sanitizer は cookie / token / raw HTML / full page dump を保持せず、redacted structured limits だけを返す。
- before/after delta は `display_percent_delta_not_billing_truth` として、正確な課金 API ではないことを machine-readable に残す。

## Unsatisfied Success Criteria

- ChatGPT logged-in usage page の live DOM / OCR capture runner は未実装。
- Dashboard / Butler から natural-language で manual capture を起動する route / runner / UI は未接続。
- observer snapshot の ingest / storage / retrieval は未接続。
- Butler から開発実行した前後の production E2E と Codex Analytics 実測比較は未実施。
- Issue #455 全体の reviewer duplicate suppression、fallback retry throttle、queue/defer 方針は未完了。

## Non-goal violations

なし。ChatGPT cookie / session token 保存、Worker による ChatGPT page scrape、deploy、bridge restart、credential/permission mutation、課金額の断定は行っていません。

## 開発前作戦図

- 作戦図 evidence: docs/development-strategy/issue-455-codex-analytics-page-observer.md
- 完了体験: owner が Dashboard Butler から「使用量を確認して」「この turn の前後差分を見たい」と依頼し、接続済み observer から redacted snapshot / delta だけを受け取れる。
- VTDD 全体で進める部分: Issue #455 の usage visibility と RAG cost boundary を、AI 風回答ではなく read-only observer truth として進める。
- 設計: owner-facing boundary と scope は、既定 disabled、manual single-shot、enabled は TTL/session 必須に固定する設計。snapshot は structured limits のみ、delta は表示 percent 差分として扱う。
- 仮説: 仮説として、toggle と sanitizer を先に固定しないと、ChatGPT usage page 監視が常時ONや credential 保存へ drift する原因になる。
- 検証計画: config parser、sanitizer、OCR/text parser、delta、runtime truth を unit test で固定し、live ChatGPT page は CI / このPRでは開かない。
- 改修見積もり: `src/core/codex-analytics-usage.js` に pure helper、`test/codex-analytics-usage.test.js` に unit test、`src/core/index.js` に export、作戦図を tracked 化。
- 既に通っている経路: PR #764 で Worker pseudo-answer を止め、PR #765 で app-server usage profile runtime truth を追加済み。
- 未確認の境界: ChatGPT Analytics page の DOM 安定性、OCR fallback、Dashboard ingest、operator-owned browser context は未確認。
- 穴が出そうな箇所: 常時監視、cookie保存、full screenshot保存、Worker scrape、usage delta の課金断定。
- PR 前に確認すること: latest `origin/main`、Issue #455、PR #765、作戦図、targeted test、`npm test`。
- 実装候補と捨てた案: 採用は pure helper から入る案。捨てた案は Worker direct scrape、常時ON observer、精密課金扱い。
- merge 後に通す E2E: E2E / test evidence として、disabled で capture しないこと、manual で接続済み observer があれば snapshot を返すこと、enabled が TTL 期限後に止まることを Dashboard/Butler 経由で確認する。
- 次の PR を増やさない理由: このPRは observer 実装前に必須の toggle/sanitizer/delta 土台を一つにまとめ、常時監視を止める後追いPRを作らないための core slice。
- 停止条件: ChatGPT 認証情報を repo/RAG/Worker storage に置く必要が出る、owner 明示許可なしに logged-in page を開く、正確な課金 API として扱う場合は停止する。

## Dry-run Impact Report

- Target Issue: Issue #455
- Implementing Success Criteria: Codex 使用量の可視化に必要な observer config / sanitizer / delta / runtime truth の core 境界を実装する。
- Explicit Non-goals: live ChatGPT page capture、Dashboard route、VPS/browser runner、deploy、bridge restart、credential/permission mutation、billing truth 断定。
- Expected touched files/routes/workflows: `docs/development-strategy/issue-455-codex-analytics-page-observer.md`; `src/core/codex-analytics-usage.js`; `src/core/index.js`; `test/codex-analytics-usage.test.js`。routes/workflows は変更しない。
- Affected Issues: Issue #455。関連して Issue #450 / #613 の Butler-first measurement に影響するが、このPRでは scope を広げない。
- Affected PRs: PR #764 / #765 の方針を前提にするが、既存 merged branch には push しない。
- Affected workflows: GitHub Actions workflow は変更なし。deploy-production はこのPRでは実行しない。
- Affected runtime/operator surfaces: まだ runtime route には未接続。将来の Dashboard Butler cost checker / observer runner が使う core helper を追加する。
- What may break if we patch narrowly: toggle なしの collector へ進むと常時監視になり、cookie保存や使用量増加を招く。sanitizer なしだと raw page / session leakage の危険がある。
- Unknowns to investigate before coding: live DOM / OCR の安定性、owner browser session 境界、Dashboard ingest 先、TTL UX。
- Validation needed: `node --test test/codex-analytics-usage.test.js`; `npm run build:worker`; `npm test`。
- Stop condition: ChatGPT session token を保存しないと成立しない、Worker が usage page を直接読む、usage delta を精密課金値として見せる必要が出た場合。

## Execution Queue Delta

- Queue position before: Issue #455 は cost ROOT / NEXT slice。PR #764/#765 後、owner が Butler 開発前に credit 消費を測りたいと指示。
- Preemption decision: ROOT。Butler で開発を再開する前に、消費量観測の on/off と sanitizer 境界がないと、測定自体がコスト/認証リスクになる。
- Queue delta: Issue #455 の Codex Analytics observer core をこのPRで進める。Dashboard ingest / live capture / Butler E2E は Evidence Gaps / Queue に残る。
- Why this PR is next: Butler から開発して消費量を比較するには、まず observer の disabled/manual/enabled と redacted delta の土台が必要。
- Active Issues not downscoped: Active Issues は縮小しません。このPRで扱わない Issue #455 の残 criteria と関連 active Issues は未完了として残します。

## File / Line Hypotheses

- file: `src/core/codex-analytics-usage.js`
  - hypothesis: observer core を pure helper として分離すれば、Worker scrape や credential 保存をせずに config/sanitizer/delta を先に固定できる。
  - risk if changed narrowly: runtime route がないため Butler-facing completion ではない。PR body に incomplete と明記する必要がある。
  - validation: unit test と `npm test`。
  - related Issue: Issue #455
- file: `test/codex-analytics-usage.test.js`
  - hypothesis: disabled/manual/enabled+TTL、sanitizer、text parser、delta を unit test で固定すれば、後続 collector が常時ONや raw page保存へ drift しにくい。
  - risk if changed narrowly: live ChatGPT DOM 変更はまだ検出できない。
  - validation: targeted test。
  - related Issue: Issue #455

## Hypothesis Retrospective

- expected: pure helper で cost checker mode、snapshot redaction、display percent delta を CI 上で検証できる。
- actual: targeted test 7件 pass。`npm test` も pass。`worker.js` は変化なし。
- mismatch: runtime route / live collector は未接続のままなので Butler Completion Gate は incomplete。
- lesson: Codex Analytics の観測は、最初に on/off と redaction を固定してから browser runner / Dashboard ingest へ進めるべき。
- should become RAG candidate: yes。usage page observer は default disabled、manual single-shot、enabled bounded scope、billing truth ではない。

## Verification Evidence

- `node --test test/codex-analytics-usage.test.js`: pass 7 / fail 0
- `npm run build:worker`: pass。generated worker diff なし。
- `npm test`: pass。`node --test` pass 1171 / skipped 1、`check:self-parity` pass、`check:generated-worker` pass。
- Evidence path/link: `test/codex-analytics-usage.test.js`; `docs/development-strategy/issue-455-codex-analytics-page-observer.md`

## Butler Completion Contract

- Primary owner surface: Dashboard Butler。
- Fallback surface: mac Codex は implementation/debug fallback。Custom GPT は fallback surface で主経路ではない。
- Owner goal: Butler 開発前後で Codex usage page の表示値を安全に比較できるようにする。
- Butler entrypoint: Dashboard Butler の自然文 cost checker 依頼に将来接続する core helper。現時点では route 未接続。
- Dashboard Butler natural-language path: Dashboard Butler の自然文 / 通常チャット入口から「使用量を確認して」に到達する設計だが、このPRでは runtime path 未接続。
- Action Schema exposure: Custom GPT Action Schema / operationId は未変更。主経路とは扱わない。
- Runtime path: core helper のみ。Worker route / VPS observer runner / Dashboard ingest は未接続。
- Runner/runtime truth: `buildCostCheckerRuntimeTruth()` で `costChecker.enabled/mode/lastSnapshotAvailable/lastDeltaAvailable` を生成できるが、本番 route にはまだ出していない。
- Authority boundary: logged-in ChatGPT page への live access は owner 明示許可が必要。このPRでは実行しない。
- E2E evidence: Butler-facing E2E は未実施。unit と repo verification まで。
- Completion status: incomplete

## Surface Update Checklist

- Dashboard Butler normal chat: 未変更。
- Cost checker core: 追加。
- ChatGPT Analytics live capture: 未実装。
- Dashboard ingest / route: 未実装。
- VPS helper / observer runner: 未実装。
- Worker bundle: `npm run build:worker` 実行、diff なし。
- Custom GPT Action Schema: 未変更。
- Docs / strategy: Issue #455 作戦図を tracked 化。
