### PR TITLE
Issue #455 content-aware app-server usage profile

### DIFF
--- a/docs/development-strategy/issue-455-content-aware-app-server-usage-profile.md
+++ b/docs/development-strategy/issue-455-content-aware-app-server-usage-profile.md
@@ -1,0 +1,105 @@
+# Issue #455 content-aware app-server usage profile 作戦図
+
+## 完了体験
+
+Dashboard Butler は owner の発話を Worker 内で AI 風に処理せず、通常会話も開発依頼も Dashboard app-server bridge へ届ける。そのうえで、Dashboard は発話内容を `conversation` / `status_read` / `development` / `long_development` の usage profile に分類し、VPS bridge はその profile に対応した `codex app-server` 起動設定を使う。
+
+owner は iPhone/iPad の Butler から「会話だけ」「状況確認」「開発」「長時間開発」を試し、Dashboard runtime truth と Codex Analytics 観測で、どの profile で bridge に渡ったかを後から確認できる。
+
+## VTDD 全体で進める部分
+
+Issue #455 の「重い処理を実行する前に Codex usage 消費境界を示す」「VTDD 自身で使用枠を食い潰さない queue / throttle / defer 方針を持つ」うち、Dashboard app-server bridge に入る owner turn の content-aware usage profile 化を実装する。
+
+この slice は PR #765 の固定 app-server profile ノブと PR #770/#771 の Codex Analytics 観測を、owner-facing workflow と bridge 実行設定へ接続する。古い Worker fast path 作戦図のように Worker が軽量回答して Codex を起動しない設計は、owner の「Butler は中継機であり AI はいない」という判断に反するため採用しない。
+
+## 設計
+
+`src/core/dashboard-app-server-usage-profile.js` に pure classifier を置く。Worker は owner message を保存・ack 後、bridge dispatch payload に `usageProfile` と `costBoundary` を付け、transient status に profile と reasoning effort を表示する。
+
+`scripts/run-dashboard-app-server-bridge.mjs` は request の `usageProfile` を読み、profile ごとの app-server command args を組み立てる。model は repo で固定しない。既定の調整対象は `model_reasoning_effort` のみとし、profile default は次にする。
+
+- `conversation`: `low`
+- `status_read`: `low`
+- `development`: `medium`
+- `long_development`: `high`
+
+operator が明示した `VTDD_DASHBOARD_APP_SERVER_MODEL` / `VTDD_DASHBOARD_APP_SERVER_REASONING_EFFORT` / CLI args は既存互換の default override として残す。request profile に reasoning effort がある場合はその turn の profile を優先する。bridge は profile/args key ごとに app-server client を lazy cache し、同じ profile の連続 turn では同じ client を再利用する。
+
+## 仮説
+
+現在の本番 bridge は `codex app-server --listen stdio://` の固定起動であり、Dashboard の会話内容に応じて model / reasoning effort が変わらない。PR #765 は operator が固定値を渡せるだけなので、「普通の会話と開発で消費が違う」という owner の観測を Dashboard Butler -> VPS Codex CLI 経路に移植できていない。
+
+Worker が分類だけを行い、回答は app-server に渡すなら、「Butler は AI 風に振る舞わない」という制約を守れる。bridge が profile ごとに app-server args を分ければ、単なる表示ではなく実行設定として内容別調整になる。
+
+## 検証計画
+
+- Unit: classifier が普通会話を `conversation/low`、PR/Issue 確認を `status_read/low`、実装依頼を `development/medium`、長時間・最後まで系を `long_development/high` に分類する。
+- Worker integration: ordinary / cost-aware / PR status owner turn は全て app-server bridge に送られ、payload と transient status に usage profile が出る。
+- Bridge integration: request usage profile から app-server command args が作られ、profile 別 client が作成・再利用される。
+- Local: `node --test test/dashboard-app-server-bridge.test.js`
+- Local: `node --test test/worker.test.js`
+- Local: `npm run build:worker`
+- Local: `npm run verify:worker`
+- Local: `git diff --check`
+
+## 改修見積もり
+
+- `src/core/dashboard-app-server-usage-profile.js`: profile constants、classifier、cost boundary builder。risk は分類語彙の過不足。
+- `src/core/index.js`: core helper export。risk は export 漏れ。
+- `src/worker/runtime.js`: bridge request payload と transient status に usage profile/cost boundary を追加。risk は Worker が回答生成に戻ったように見える文言。
+- `scripts/run-dashboard-app-server-bridge.mjs`: profile-aware command args と app-server client selector を追加。risk は thread continuity と複数 app-server process の運用負荷。
+- `test/worker.test.js`: Dashboard owner turn payload/status expectations。risk は既存 fast path 期待との衝突。
+- `test/dashboard-app-server-bridge.test.js`: helper/selector/turn input tests。risk は app-server factory mock の不足。
+- `worker.js`: generated bundle 更新。risk は source と bundle の不一致。
+
+## 既に通っている経路
+
+- PR #764 で Worker の cost/read AI 風 fast path は止め、bridge 接続時は app-server に渡す方向へ戻した。
+- PR #765 で app-server fixed profile args と connected runtime truth が入った。
+- PR #770/#771 で Codex Analytics 使用量 snapshot の manual capture / Worker ingest / retrieve / Dashboard evidence route が入った。
+- Issue #455 は open で、Codex usage 削減と可視化を active scope として残している。
+
+## 未確認の境界
+
+Codex CLI / account が `model_reasoning_effort` を常に受理するかは runtime で確認が必要。失敗した場合は app-server startup failure として surface されるべきで、この PR では公式 usage 削減量を断定しない。
+
+複数 app-server client が同一 Codex thread を別 profile で resume した場合の完全な内部挙動は未確認。実装は profile ごとに client を lazy reuse するが、runtime E2E で同一 Dashboard thread の会話継続を確認する。
+
+## 穴が出そうな箇所
+
+- 「確認して」だけでも repo truth 深掘りや実装を含む場合があるため、開発語彙が含まれる時は `development` を優先する。
+- cost 関連会話は owner の相談であって Worker 回答対象ではない。`conversation` か `status_read` に分類しても app-server bridge へ送る。
+- model 名を hard-code すると operator account 差異で壊れる。
+- transient status が長すぎると chat UX を汚す。profile truth は短く出す。
+
+## PR 前に確認すること
+
+- branch が latest `origin/main` から切られている。
+- unrelated untracked E2E assets を commit に混ぜない。
+- PR body は Japanese-first で Issue #455 とこの作戦図を参照する。
+- Execution Queue Delta は owner complaint を `ROOT` follow-up として扱い、active Issues を downscope していないことを明示する。
+
+## 実装候補と捨てた案
+
+採用: Worker は分類 metadata だけを付け、bridge が profile に応じた app-server args/client を選ぶ。
+
+捨てた案: Worker が lightweight reply を返して app-server を起動しない。Butler が AI 風に振る舞うため不採用。
+
+捨てた案: 全 turn を固定 `low` にする。開発・長時間開発で品質劣化し、content-aware ではないため不採用。
+
+捨てた案: model を repo 固定で軽量 model にする。operator account / Codex plan 差異で壊れるため不採用。
+
+## merge 後に通す E2E
+
+production deploy 後、bridge restart を行い、Dashboard Butler から「会話だけ」「PR 状況確認」「軽い実装」「長時間開発」の短い probe を送る。期待値は全 turn が app-server bridge に届き、runtime truth に profile/reasoning effort が出ること。Codex Analytics の減り方は #771 の snapshot route で別途記録する。
+
+## 次の PR を増やさない理由
+
+PR #765 は固定ノブ、PR #770/#771 は観測で止まり、owner-facing の「内容別に実際の bridge 使用設定が変わる」が未完だった。今回の slice はその抜けを同じ Issue #455 の機能単位として閉じるため、Worker/bridge/test を一塊で実装する。
+
+## 停止条件
+
+- app-server CLI が profile 別 args で起動不能になる。
+- Worker が再び AI 風 fast path 回答を持つ必要が出る。
+- deploy / credential / permission mutation が必要になる。
+- Issue #455 の範囲を超えて reviewer / merge / deploy policy の広範修正へ膨らむ。

--- a/scripts/run-dashboard-app-server-bridge.mjs
+++ b/scripts/run-dashboard-app-server-bridge.mjs
@@ -4,6 +4,10 @@ import os from "node:os";
 import path from "node:path";
 import { spawn } from "node:child_process";
 import process from "node:process";
+import {
+  buildDashboardAppServerUsageCostBoundary,
+  normalizeDashboardAppServerUsageProfile
+} from "../src/core/dashboard-app-server-usage-profile.js";
 
 const DEFAULT_SCHEMA = "vtdd.dashboard.app_server_bridge.v1";
 const DANGER_FULL_ACCESS_SANDBOX = "danger-full-access";
@@ -126,6 +130,36 @@ export function buildDashboardAppServerCostBoundary({
   };
 }
 
+export function buildDashboardAppServerUsageProfileCommandConfig({
+  usageProfile = null,
+  defaultProfile = "",
+  defaultModel = "",
+  defaultReasoningEffort = ""
+} = {}) {
+  const normalizedUsageProfile = normalizeDashboardAppServerUsageProfile(usageProfile || defaultProfile || "conversation");
+  const model = normalizeBridgeText(normalizedUsageProfile.model || defaultModel);
+  const reasoningEffort = normalizeBridgeText(normalizedUsageProfile.reasoningEffort || defaultReasoningEffort);
+  const profile = normalizeBridgeText(normalizedUsageProfile.profile || defaultProfile) || "conversation";
+  return {
+    usageProfile: {
+      ...normalizedUsageProfile,
+      profile,
+      ...(model ? { model } : {}),
+      ...(reasoningEffort ? { reasoningEffort } : {})
+    },
+    costBoundary: buildDashboardAppServerUsageCostBoundary({
+      ...normalizedUsageProfile,
+      profile,
+      ...(model ? { model } : {}),
+      ...(reasoningEffort ? { reasoningEffort } : {})
+    }),
+    args: buildDashboardAppServerCommandArgs({
+      model,
+      reasoningEffort
+    })
+  };
+}
+
 export function buildDashboardAppServerCommandArgs({
   listen = "stdio://",
   model = "",
@@ -152,12 +186,19 @@ export function buildDashboardTurnInputText(request = {}) {
     request.trafficControl && typeof request.trafficControl === "object"
       ? request.trafficControl
       : null;
+  const usageProfile =
+    request.usageProfile && typeof request.usageProfile === "object"
+      ? normalizeDashboardAppServerUsageProfile(request.usageProfile)
+      : null;
+  const costBoundary = request.costBoundary && typeof request.costBoundary === "object" ? request.costBoundary : null;
   const mediaReferences = Array.isArray(request.mediaReferences) ? request.mediaReferences : [];
   const hasDashboardContext = Boolean(
     repository ||
       relatedIssue ||
       authority ||
       trafficControl ||
+      usageProfile ||
+      costBoundary ||
       mediaReferences.length > 0
   );
   if (!hasDashboardContext) {
@@ -169,6 +210,12 @@ export function buildDashboardTurnInputText(request = {}) {
     `- repository: ${repository || "未指定"}`,
     `- relatedIssue: ${relatedIssue ? `#${relatedIssue}` : "未指定"}`,
     `- mediaReferences: ${mediaReferences.length}`,
+    usageProfile
+      ? `- usageProfile: ${JSON.stringify(usageProfile)}`
+      : "- usageProfile: 未指定",
+    costBoundary
+      ? `- costBoundary: ${JSON.stringify(costBoundary)}`
+      : "- costBoundary: 未指定",
     "- surface: Dashboard Butler PWA via VPS Dashboard Bridge / codex app-server",
     "- trafficControlRule: repo-backed vtdd-chief-butler / Issue/PR/docs/runtime truth を先に読み、blocker / next action / authority boundary / evidence gap を分けて報告する。",
     "- completionRule: Butler Completion Gate と E2E evidence が揃うまで Dashboard Butler 完了とは言わない。",
@@ -1365,11 +1412,18 @@ export async function handleDashboardTurnRequest({
   token = "",
   fetchImpl = globalThis.fetch,
   mediaTmpRoot = os.tmpdir(),
+  usageProfile = null,
+  costBoundary = null,
   debugSlowTurnDelayImpl = delay,
   debugSlowTurnProgressIntervalMs = DEBUG_SLOW_TURN_PROGRESS_INTERVAL_MS
 }) {
   const dashboardThreadId = String(request.threadId || "");
   const text = String(request.text || "");
+  const turnUsageProfile = normalizeDashboardAppServerUsageProfile(usageProfile || request.usageProfile || "conversation");
+  const turnCostBoundary =
+    costBoundary && typeof costBoundary === "object"
+      ? costBoundary
+      : buildDashboardAppServerUsageCostBoundary(turnUsageProfile);
   if (!dashboardThreadId || !text) {
     await sendDashboardEvent({
       type: "app_server_turn_failed",
@@ -1583,6 +1637,8 @@ export async function handleDashboardTurnRequest({
       relatedIssue: request.relatedIssue || request.issueNumber,
       authority: request.authority,
       trafficControl: request.trafficControl,
+      usageProfile: turnUsageProfile,
+      costBoundary: turnCostBoundary,
       mediaReferences: materializedMediaReferences
     });
     const startedTurn = await appServer.request(
@@ -1607,7 +1663,9 @@ export async function handleDashboardTurnRequest({
         codexThreadId,
         turnId: activeTurnId || startedTurnId,
         messageId: request.messageId,
-        resumedExistingThread
+        resumedExistingThread,
+        usageProfile: turnUsageProfile,
+        costBoundary: turnCostBoundary
       })
     );
     markAppServerActivity();
@@ -1707,12 +1765,22 @@ export async function runDashboardAppServerBridge(options = parseBridgeArgs()) {
       args: appServerArgs
     });
   await appServer.initialize();
+  const selectAppServerForRequest = createDashboardAppServerClientSelector({
+    defaultAppServer: appServer,
+    staticAppServer: Boolean(options.appServer),
+    appServerFactory,
+    cwd: options.cwd,
+    defaultProfile: options.appServerCostProfile,
+    defaultModel: options.appServerModel,
+    defaultReasoningEffort: options.appServerReasoningEffort
+  });
   let reconnects = 0;
   for (;;) {
     await connectDashboardAppServerBridgeOnce({
       ...options,
       endpoint,
       appServer,
+      selectAppServerForRequest,
       costBoundary,
       WebSocketImpl: options.WebSocketImpl || WebSocket
     });
@@ -1725,6 +1793,45 @@ export async function runDashboardAppServerBridge(options = parseBridgeArgs()) {
     reconnects += 1;
     await delay(normalizeReconnectDelayMs(options.reconnectDelayMs));
   }
+}
+
+export function createDashboardAppServerClientSelector({
+  defaultAppServer = null,
+  staticAppServer = false,
+  appServerFactory,
+  cwd = process.cwd(),
+  defaultProfile = "",
+  defaultModel = "",
+  defaultReasoningEffort = ""
+} = {}) {
+  const clients = new Map();
+  return async function selectAppServerForRequest(request = {}) {
+    const config = buildDashboardAppServerUsageProfileCommandConfig({
+      usageProfile: request.usageProfile,
+      defaultProfile,
+      defaultModel,
+      defaultReasoningEffort
+    });
+    if (staticAppServer || !request.usageProfile) {
+      return {
+        appServer: defaultAppServer,
+        ...config
+      };
+    }
+    const key = JSON.stringify(config.args);
+    if (!clients.has(key)) {
+      const client = appServerFactory({
+        cwd,
+        args: config.args
+      });
+      await client.initialize();
+      clients.set(key, client);
+    }
+    return {
+      appServer: clients.get(key),
+      ...config
+    };
+  };
 }
 
 export function buildDashboardAppServerBridgeEndpoint(options = {}) {
@@ -2016,8 +2123,11 @@ export function buildDashboardBridgeTurnStartedStatusEvent({
   turnId = "",
   messageId = "",
   resumedExistingThread = false,
+  usageProfile = null,
+  costBoundary = null,
   startedAt = new Date().toISOString()
 } = {}) {
+  const normalizedUsageProfile = usageProfile ? normalizeDashboardAppServerUsageProfile(usageProfile) : null;
   return {
     type: "app_server_status",
     schema: DEFAULT_SCHEMA,
@@ -2035,6 +2145,8 @@ export function buildDashboardBridgeTurnStartedStatusEvent({
       turnId: turnId || null,
       messageId: messageId || null,
       resumedExistingThread: Boolean(resumedExistingThread),
+      usageProfile: normalizedUsageProfile,
+      costBoundary: costBoundary && typeof costBoundary === "object" ? costBoundary : null,
       startedAt: normalizeBridgeText(startedAt) || new Date().toISOString()
     }
   };
@@ -2044,6 +2156,7 @@ export async function connectDashboardAppServerBridgeOnce({
   endpoint,
   token,
   appServer,
+  selectAppServerForRequest = null,
   cwd = process.cwd(),
   sandboxMode = "",
   turnTimeoutMs = DEFAULT_TURN_TIMEOUT_MS,
@@ -2114,10 +2227,16 @@ export async function connectDashboardAppServerBridgeOnce({
     if (payload?.type === "app_server_turn_requested") {
       turnQueue = turnQueue
         .catch(() => {})
-        .then(() =>
-          handleDashboardTurnRequest({
+        .then(async () => {
+          const selected =
+            typeof selectAppServerForRequest === "function"
+              ? await selectAppServerForRequest(payload)
+              : { appServer, usageProfile: payload.usageProfile || null, costBoundary: payload.costBoundary || null };
+          return handleDashboardTurnRequest({
             request: payload,
-            appServer,
+            appServer: selected.appServer || appServer,
+            usageProfile: selected.usageProfile || payload.usageProfile || null,
+            costBoundary: selected.costBoundary || payload.costBoundary || null,
             sendDashboardEvent: async (dashboardEvent) => safeSend(dashboardEvent),
             cwd,
             sandboxMode,
@@ -2127,8 +2246,8 @@ export async function connectDashboardAppServerBridgeOnce({
             token,
             fetchImpl,
             mediaTmpRoot
-          })
-        )
+          });
+        })
         .catch((error) => {
           if (isAppServerFailureAlreadySent(error)) {
             return;

--- a/src/core/dashboard-app-server-usage-profile.js
+++ b/src/core/dashboard-app-server-usage-profile.js
@@ -1,0 +1,172 @@
+export const DASHBOARD_APP_SERVER_USAGE_PROFILES = Object.freeze({
+  conversation: Object.freeze({
+    profile: "conversation",
+    reasoningEffort: "low",
+    reason: "ordinary_conversation"
+  }),
+  status_read: Object.freeze({
+    profile: "status_read",
+    reasoningEffort: "low",
+    reason: "status_or_read_request"
+  }),
+  development: Object.freeze({
+    profile: "development",
+    reasoningEffort: "medium",
+    reason: "implementation_or_repository_work"
+  }),
+  long_development: Object.freeze({
+    profile: "long_development",
+    reasoningEffort: "high",
+    reason: "long_running_development_or_e2e"
+  })
+});
+
+const PROFILE_ORDER = ["conversation", "status_read", "development", "long_development"];
+
+const LONG_DEVELOPMENT_PATTERNS = [
+  /長時間/,
+  /最後まで/,
+  /一塊/,
+  /まとめて/,
+  /全部/,
+  /全て/,
+  /すべて/,
+  /一度に/,
+  /刻みすぎ/,
+  /E2E/i,
+  /end[- ]?to[- ]?end/i,
+  /deploy.*追/i,
+  /デプロイ.*追/,
+  /production deploy/i,
+  /リスタートまで/,
+  /restart.*deploy/i,
+  /完了まで/,
+  /close.*Issue/i
+];
+
+const DEVELOPMENT_PATTERNS = [
+  /実装/,
+  /修正/,
+  /改修/,
+  /開発/,
+  /作成/,
+  /作って/,
+  /開いて/,
+  /テスト/,
+  /\btest\b/i,
+  /pull request/i,
+  /ブランチ/,
+  /branch/i,
+  /commit/i,
+  /コミット/,
+  /merge/i,
+  /マージ/,
+  /deploy/i,
+  /デプロイ/,
+  /レビュー/,
+  /review/i,
+  /runner/i,
+  /bridge/i,
+  /VPS/i,
+  /Codex CLI/i,
+  /worker/i,
+  /schema/i,
+  /Action Schema/i,
+  /コード/,
+  /ファイル/,
+  /ビルド/,
+  /build/i,
+  /verify/i
+];
+
+const STATUS_READ_PATTERNS = [
+  /確認/,
+  /見て/,
+  /読んで/,
+  /状況/,
+  /状態/,
+  /最新/,
+  /マージ済み/,
+  /デプロイ完了/,
+  /どのブランチ/,
+  /戻せる/,
+  /ログ/,
+  /truth/i,
+  /status/i,
+  /\bPR\s*#?\d+\b/i,
+  /\bIssue\s*#?\d+\b/i
+];
+
+function normalizeUsageText(value = "") {
+  return String(value || "").replace(/\s+/g, " ").trim();
+}
+
+function matchesAny(text, patterns) {
+  return patterns.some((pattern) => pattern.test(text));
+}
+
+export function normalizeDashboardAppServerUsageProfile(profileLike = null, fallbackProfile = "conversation") {
+  const input = profileLike && typeof profileLike === "object" ? profileLike : { profile: profileLike };
+  const requestedProfile = normalizeUsageText(input.profile || input.name || fallbackProfile);
+  const profile = PROFILE_ORDER.includes(requestedProfile) ? requestedProfile : fallbackProfile;
+  const defaults = DASHBOARD_APP_SERVER_USAGE_PROFILES[profile] || DASHBOARD_APP_SERVER_USAGE_PROFILES.conversation;
+  const reasoningEffort = normalizeUsageText(input.reasoningEffort || input.reasoning_effort || defaults.reasoningEffort);
+  const model = normalizeUsageText(input.model || "");
+  return {
+    profile,
+    reasoningEffort,
+    selectedBy: normalizeUsageText(input.selectedBy || input.selected_by || "content"),
+    reason: normalizeUsageText(input.reason || defaults.reason),
+    ...(model ? { model } : {})
+  };
+}
+
+export function classifyDashboardAppServerUsageProfile({
+  text = "",
+  repository = "",
+  relatedIssue = "",
+  mediaReferences = []
+} = {}) {
+  const normalizedText = normalizeUsageText(text);
+  const hasRepositoryContext = Boolean(normalizeUsageText(repository));
+  const hasIssueContext = Boolean(normalizeUsageText(relatedIssue));
+  const hasMedia = Array.isArray(mediaReferences) && mediaReferences.length > 0;
+  if (hasMedia || matchesAny(normalizedText, LONG_DEVELOPMENT_PATTERNS)) {
+    return normalizeDashboardAppServerUsageProfile({
+      profile: "long_development",
+      reason: hasMedia ? "media_or_attachment_requires_full_context" : "long_running_development_or_e2e"
+    });
+  }
+  if (matchesAny(normalizedText, DEVELOPMENT_PATTERNS)) {
+    return normalizeDashboardAppServerUsageProfile({
+      profile: "development",
+      reason: "implementation_or_repository_work"
+    });
+  }
+  if (hasRepositoryContext || hasIssueContext || matchesAny(normalizedText, STATUS_READ_PATTERNS)) {
+    return normalizeDashboardAppServerUsageProfile({
+      profile: "status_read",
+      reason: "status_or_read_request"
+    });
+  }
+  return normalizeDashboardAppServerUsageProfile({
+    profile: "conversation",
+    reason: "ordinary_conversation"
+  });
+}
+
+export function buildDashboardAppServerUsageCostBoundary(profileLike = null) {
+  const usageProfile = normalizeDashboardAppServerUsageProfile(profileLike);
+  return {
+    profile: usageProfile.profile,
+    codexWillStart: true,
+    appServerBridgeRequired: true,
+    contentAwareProfile: true,
+    selectedBy: usageProfile.selectedBy,
+    reason: usageProfile.reason,
+    modelConfigured: Boolean(usageProfile.model),
+    reasoningEffortConfigured: Boolean(usageProfile.reasoningEffort),
+    ...(usageProfile.model ? { model: usageProfile.model } : {}),
+    ...(usageProfile.reasoningEffort ? { reasoningEffort: usageProfile.reasoningEffort } : {})
+  };
+}

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -52,6 +52,12 @@ export {
   parseCodexAnalyticsUsageText,
   sanitizeCodexAnalyticsUsageSnapshot
 } from "./codex-analytics-usage.js";
+export {
+  DASHBOARD_APP_SERVER_USAGE_PROFILES,
+  buildDashboardAppServerUsageCostBoundary,
+  classifyDashboardAppServerUsageProfile,
+  normalizeDashboardAppServerUsageProfile
+} from "./dashboard-app-server-usage-profile.js";
 export { buildVtddCloudflarePageDirectory, renderVtddHelpGuidePage } from "./help-guide-page.js";
 export { buildButlerReviewSynthesis } from "./butler-review-synthesis.js";
 export { validateDeployApprovalGrant } from "./deploy-approval-grant.js";

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -7,6 +7,7 @@ import {
   appendDecisionLogFromGateway,
   appendProposalLogFromGateway,
   buildCodexAnalyticsUsageDelta,
+  buildDashboardAppServerUsageCostBoundary,
   buildVpsCapabilityProposal,
   buildCostCheckerRuntimeTruth,
   buildVpsPrivilegedMaintenanceInstallInventory,
@@ -28,6 +29,7 @@ import {
   evaluateButlerSelfParity,
   evaluateCustomGptSetupDiagnostics,
   evaluateExecutionContinuity,
+  classifyDashboardAppServerUsageProfile,
   evaluateMemorySafety,
   executeGitHubHighRiskPlane,
   inferRelatedIssueFromGatewayInput,
@@ -61,6 +63,7 @@ import {
   mergeAliasRegistries,
   retrieveStoredAliasRegistry,
   retrieveGitHubReadPlane,
+  normalizeDashboardAppServerUsageProfile,
   TaskMode,
   bindNaturalGitHubWriteApproval,
   cancelVpsRunnerQueue,
@@ -425,7 +428,12 @@ export class DashboardChatRoom {
     await this.broadcastTransientStatus({
       threadId,
       status: "thinking",
-      text: buildDashboardAppServerUsageTransientText({ text, repository, relatedIssue }),
+      text: buildDashboardAppServerUsageTransientText({
+        text,
+        repository,
+        relatedIssue,
+        mediaReferences: ownerMessage.mediaReferences || ownerMessage.media_references || []
+      }),
       snapshot: true,
       snapshotSource: "owner_message_dispatch"
     });
@@ -445,6 +453,13 @@ export class DashboardChatRoom {
     const repository = normalizeCanonicalRepositoryInput(message.repository);
     const relatedIssue = normalizePositiveInteger(message.relatedIssue || message.issueNumber);
     const mediaReferences = normalizeMediaReferences(message.mediaReferences || message.media_references || []);
+    const usageProfile = classifyDashboardAppServerUsageProfile({
+      text,
+      repository,
+      relatedIssue,
+      mediaReferences
+    });
+    const costBoundary = buildDashboardAppServerUsageCostBoundary(usageProfile);
     const trafficControl = await buildDashboardChatTrafficControlContext({
       env: this.env,
       repository,
@@ -469,6 +484,8 @@ export class DashboardChatRoom {
         turnMethod: "turn/start"
       },
       authority: buildDashboardAppServerAuthorityHint({ repository, relatedIssue, text }),
+      usageProfile,
+      costBoundary,
       trafficControl
     };
     return this.sendSocket(bridgeSocket, turnRequest);
@@ -9833,10 +9850,25 @@ function buildDashboardAppServerFailureTransientText({ messageStatus = "", failu
   return sanitizeDashboardChatText(failureText) || "app-server bridge の返信を待っています";
 }
 
-function buildDashboardAppServerUsageTransientText({ repository = "", relatedIssue = "" } = {}) {
+function buildDashboardAppServerUsageTransientText({
+  text = "",
+  repository = "",
+  relatedIssue = "",
+  mediaReferences = []
+} = {}) {
+  const usageProfile = normalizeDashboardAppServerUsageProfile(
+    classifyDashboardAppServerUsageProfile({
+      text,
+      repository,
+      relatedIssue,
+      mediaReferences
+    })
+  );
   const scope = [
     repository ? `repo=${repository}` : "repo=未指定",
-    relatedIssue ? `Issue #${relatedIssue}` : "Issue=未指定"
+    relatedIssue ? `Issue #${relatedIssue}` : "Issue=未指定",
+    `usage_profile=${usageProfile.profile}`,
+    `reasoning_effort=${usageProfile.reasoningEffort}`
   ].join(" / ");
   return `Codex app-server に渡しています。Codex usage を消費し得ます。${scope}`;
 }

--- a/test/dashboard-app-server-bridge.test.js
+++ b/test/dashboard-app-server-bridge.test.js
@@ -4,9 +4,13 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import {
+  classifyDashboardAppServerUsageProfile
+} from "../src/core/dashboard-app-server-usage-profile.js";
+import {
   buildDashboardAppServerBridgeEndpoint,
   buildDashboardAppServerCommandArgs,
   buildDashboardAppServerCostBoundary,
+  buildDashboardAppServerUsageProfileCommandConfig,
   buildAppServerInitializeRequest,
   buildOwnerActionRequiredPayloadForAppServerApproval,
   buildAppServerRequestApprovalResponse,
@@ -21,6 +25,7 @@ import {
   buildDashboardTurnInputText,
   collectDashboardBridgeRepoSyncStatus,
   connectDashboardAppServerBridgeOnce,
+  createDashboardAppServerClientSelector,
   ensureDashboardBridgeRepoSynced,
   executeVpsRunnerWakeup,
   extractAppServerNotificationTurnId,
@@ -183,6 +188,80 @@ test("dashboard app-server bridge builds optional app-server usage tuning args",
       reasoningEffort: "low"
     }
   );
+});
+
+test("dashboard app-server usage profile classifier separates conversation, read, development, and long development", () => {
+  assert.deepEqual(
+    classifyDashboardAppServerUsageProfile({ text: "今日は何月何日？日本時間を答えて" }),
+    {
+      profile: "conversation",
+      reasoningEffort: "low",
+      selectedBy: "content",
+      reason: "ordinary_conversation"
+    }
+  );
+  assert.deepEqual(
+    classifyDashboardAppServerUsageProfile({ text: "PR #756 の状況を確認だけして" }),
+    {
+      profile: "status_read",
+      reasoningEffort: "low",
+      selectedBy: "content",
+      reason: "status_or_read_request"
+    }
+  );
+  assert.deepEqual(
+    classifyDashboardAppServerUsageProfile({ text: "Issue #455 の修正を実装してテストも通して" }),
+    {
+      profile: "development",
+      reasoningEffort: "medium",
+      selectedBy: "content",
+      reason: "implementation_or_repository_work"
+    }
+  );
+  assert.deepEqual(
+    classifyDashboardAppServerUsageProfile({ text: "長時間開発で最後まで一塊でやって。E2E と deploy 追跡も必要" }),
+    {
+      profile: "long_development",
+      reasoningEffort: "high",
+      selectedBy: "content",
+      reason: "long_running_development_or_e2e"
+    }
+  );
+});
+
+test("dashboard app-server bridge builds command args from content-aware usage profile", () => {
+  const conversation = buildDashboardAppServerUsageProfileCommandConfig({
+    usageProfile: {
+      profile: "conversation",
+      reasoningEffort: "low",
+      reason: "ordinary_conversation"
+    }
+  });
+  assert.deepEqual(conversation.args, ["app-server", "--listen", "stdio://", "-c", 'model_reasoning_effort="low"']);
+  assert.equal(conversation.usageProfile.profile, "conversation");
+  assert.equal(conversation.costBoundary.contentAwareProfile, true);
+  assert.equal(conversation.costBoundary.reasoningEffort, "low");
+
+  const longDevelopment = buildDashboardAppServerUsageProfileCommandConfig({
+    usageProfile: {
+      profile: "long_development",
+      reasoningEffort: "high",
+      reason: "long_running_development_or_e2e"
+    },
+    defaultModel: "gpt-5.3-codex-spark"
+  });
+  assert.deepEqual(longDevelopment.args, [
+    "app-server",
+    "--listen",
+    "stdio://",
+    "-c",
+    'model="gpt-5.3-codex-spark"',
+    "-c",
+    'model_reasoning_effort="high"'
+  ]);
+  assert.equal(longDevelopment.usageProfile.profile, "long_development");
+  assert.equal(longDevelopment.costBoundary.modelConfigured, true);
+  assert.equal(longDevelopment.costBoundary.reasoningEffort, "high");
 });
 
 test("dashboard app-server bridge runner wakeup uses only fixed user systemd start command", async () => {
@@ -2357,6 +2436,52 @@ test("dashboard app-server bridge creates app-server client with usage tuning ar
       'model_reasoning_effort="low"'
     ]
   });
+});
+
+test("dashboard app-server bridge selects app-server client by content-aware usage profile", async () => {
+  const created = [];
+  const selector = createDashboardAppServerClientSelector({
+    defaultAppServer: { id: "default" },
+    appServerFactory(options) {
+      const client = {
+        id: `client-${created.length + 1}`,
+        async initialize() {}
+      };
+      created.push({ ...options, client });
+      return client;
+    },
+    cwd: "/repo"
+  });
+
+  const conversation = await selector({
+    usageProfile: {
+      profile: "conversation",
+      reasoningEffort: "low",
+      reason: "ordinary_conversation"
+    }
+  });
+  const conversationAgain = await selector({
+    usageProfile: {
+      profile: "conversation",
+      reasoningEffort: "low",
+      reason: "ordinary_conversation"
+    }
+  });
+  const development = await selector({
+    usageProfile: {
+      profile: "development",
+      reasoningEffort: "medium",
+      reason: "implementation_or_repository_work"
+    }
+  });
+
+  assert.equal(created.length, 2);
+  assert.equal(conversation.appServer, conversationAgain.appServer);
+  assert.notEqual(conversation.appServer, development.appServer);
+  assert.deepEqual(created[0].args, ["app-server", "--listen", "stdio://", "-c", 'model_reasoning_effort="low"']);
+  assert.deepEqual(created[1].args, ["app-server", "--listen", "stdio://", "-c", 'model_reasoning_effort="medium"']);
+  assert.equal(conversation.costBoundary.profile, "conversation");
+  assert.equal(development.costBoundary.profile, "development");
 });
 
 test("dashboard app-server bridge repo sync preflight allows clean in-sync main with known artifacts", async () => {

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -3920,6 +3920,10 @@ test("DashboardChatRoom sends ordinary owner turns to connected app-server bridg
   assert.equal(turnRequest.appServer.startThreadMethod, "thread/start");
   assert.equal(turnRequest.appServer.turnMethod, "turn/start");
   assert.equal(turnRequest.authority.ordinaryConversationAllowed, true);
+  assert.equal(turnRequest.usageProfile.profile, "conversation");
+  assert.equal(turnRequest.usageProfile.reasoningEffort, "low");
+  assert.equal(turnRequest.costBoundary.profile, "conversation");
+  assert.equal(turnRequest.costBoundary.contentAwareProfile, true);
   assert.equal(turnRequest.trafficControl.status, "未確認");
   assert.equal(turnRequest.trafficControl.currentSurface, "dashboard_butler");
   assert.match(turnRequest.trafficControl.reason, /repository is required/);
@@ -3937,6 +3941,8 @@ test("DashboardChatRoom sends ordinary owner turns to connected app-server bridg
   assert.equal(status.status, "thinking");
   assert.match(status.text, /Codex app-server に渡しています/);
   assert.match(status.text, /Codex usage を消費し得ます/);
+  assert.match(status.text, /usage_profile=conversation/);
+  assert.match(status.text, /reasoning_effort=low/);
 });
 
 test("DashboardChatRoom forwards cost-aware owner turns to app-server bridge", async () => {
@@ -3969,6 +3975,9 @@ test("DashboardChatRoom forwards cost-aware owner turns to app-server bridge", a
   assert.equal(turnRequest.threadId, "dashboard-main-unresolved");
   assert.equal(turnRequest.repository, null);
   assert.equal(turnRequest.authority.ordinaryConversationAllowed, true);
+  assert.equal(turnRequest.usageProfile.profile, "conversation");
+  assert.equal(turnRequest.usageProfile.reasoningEffort, "low");
+  assert.equal(turnRequest.costBoundary.profile, "conversation");
   assert.equal(dashboardSocket.sent.length, 3);
   const ownerBroadcast = JSON.parse(dashboardSocket.sent[0]);
   assert.equal(ownerBroadcast.messages.length, 1);
@@ -3980,6 +3989,7 @@ test("DashboardChatRoom forwards cost-aware owner turns to app-server bridge", a
   assert.equal(status.type, "transient_status");
   assert.equal(status.status, "thinking");
   assert.match(status.text, /Codex app-server に渡しています/);
+  assert.match(status.text, /usage_profile=conversation/);
 });
 
 test("DashboardChatRoom forwards PR status owner turns to app-server bridge", async () => {
@@ -4040,9 +4050,13 @@ test("DashboardChatRoom forwards PR status owner turns to app-server bridge", as
   assert.equal(turnRequest.type, "app_server_turn_requested");
   assert.equal(turnRequest.threadId, "dashboard-main-marushu-vtdd-v2-p");
   assert.equal(turnRequest.repository, "marushu/vtdd-v2-p");
+  assert.equal(turnRequest.usageProfile.profile, "status_read");
+  assert.equal(turnRequest.usageProfile.reasoningEffort, "low");
+  assert.equal(turnRequest.costBoundary.profile, "status_read");
   const sentPayloads = dashboardSocket.sent.map((message) => JSON.parse(message));
   assert.equal(sentPayloads.at(-1).type, "transient_status");
   assert.match(sentPayloads.at(-1).text, /Codex app-server に渡しています/);
+  assert.match(sentPayloads.at(-1).text, /usage_profile=status_read/);
 });
 
 test("DashboardChatRoom forwards repo-less PR status owner turns to app-server bridge", async () => {

--- a/worker.js
+++ b/worker.js
@@ -29054,6 +29054,171 @@ function buildCostCheckerRuntimeTruth(configInput = {}, state = {}) {
   };
 }
 
+// src/core/dashboard-app-server-usage-profile.js
+var DASHBOARD_APP_SERVER_USAGE_PROFILES = Object.freeze({
+  conversation: Object.freeze({
+    profile: "conversation",
+    reasoningEffort: "low",
+    reason: "ordinary_conversation"
+  }),
+  status_read: Object.freeze({
+    profile: "status_read",
+    reasoningEffort: "low",
+    reason: "status_or_read_request"
+  }),
+  development: Object.freeze({
+    profile: "development",
+    reasoningEffort: "medium",
+    reason: "implementation_or_repository_work"
+  }),
+  long_development: Object.freeze({
+    profile: "long_development",
+    reasoningEffort: "high",
+    reason: "long_running_development_or_e2e"
+  })
+});
+var PROFILE_ORDER = ["conversation", "status_read", "development", "long_development"];
+var LONG_DEVELOPMENT_PATTERNS = [
+  /長時間/,
+  /最後まで/,
+  /一塊/,
+  /まとめて/,
+  /全部/,
+  /全て/,
+  /すべて/,
+  /一度に/,
+  /刻みすぎ/,
+  /E2E/i,
+  /end[- ]?to[- ]?end/i,
+  /deploy.*追/i,
+  /デプロイ.*追/,
+  /production deploy/i,
+  /リスタートまで/,
+  /restart.*deploy/i,
+  /完了まで/,
+  /close.*Issue/i
+];
+var DEVELOPMENT_PATTERNS = [
+  /実装/,
+  /修正/,
+  /改修/,
+  /開発/,
+  /作成/,
+  /作って/,
+  /開いて/,
+  /テスト/,
+  /\btest\b/i,
+  /pull request/i,
+  /ブランチ/,
+  /branch/i,
+  /commit/i,
+  /コミット/,
+  /merge/i,
+  /マージ/,
+  /deploy/i,
+  /デプロイ/,
+  /レビュー/,
+  /review/i,
+  /runner/i,
+  /bridge/i,
+  /VPS/i,
+  /Codex CLI/i,
+  /worker/i,
+  /schema/i,
+  /Action Schema/i,
+  /コード/,
+  /ファイル/,
+  /ビルド/,
+  /build/i,
+  /verify/i
+];
+var STATUS_READ_PATTERNS = [
+  /確認/,
+  /見て/,
+  /読んで/,
+  /状況/,
+  /状態/,
+  /最新/,
+  /マージ済み/,
+  /デプロイ完了/,
+  /どのブランチ/,
+  /戻せる/,
+  /ログ/,
+  /truth/i,
+  /status/i,
+  /\bPR\s*#?\d+\b/i,
+  /\bIssue\s*#?\d+\b/i
+];
+function normalizeUsageText(value = "") {
+  return String(value || "").replace(/\s+/g, " ").trim();
+}
+function matchesAny(text, patterns) {
+  return patterns.some((pattern) => pattern.test(text));
+}
+function normalizeDashboardAppServerUsageProfile(profileLike = null, fallbackProfile = "conversation") {
+  const input = profileLike && typeof profileLike === "object" ? profileLike : { profile: profileLike };
+  const requestedProfile = normalizeUsageText(input.profile || input.name || fallbackProfile);
+  const profile = PROFILE_ORDER.includes(requestedProfile) ? requestedProfile : fallbackProfile;
+  const defaults = DASHBOARD_APP_SERVER_USAGE_PROFILES[profile] || DASHBOARD_APP_SERVER_USAGE_PROFILES.conversation;
+  const reasoningEffort = normalizeUsageText(input.reasoningEffort || input.reasoning_effort || defaults.reasoningEffort);
+  const model = normalizeUsageText(input.model || "");
+  return {
+    profile,
+    reasoningEffort,
+    selectedBy: normalizeUsageText(input.selectedBy || input.selected_by || "content"),
+    reason: normalizeUsageText(input.reason || defaults.reason),
+    ...model ? { model } : {}
+  };
+}
+function classifyDashboardAppServerUsageProfile({
+  text = "",
+  repository = "",
+  relatedIssue = "",
+  mediaReferences = []
+} = {}) {
+  const normalizedText = normalizeUsageText(text);
+  const hasRepositoryContext = Boolean(normalizeUsageText(repository));
+  const hasIssueContext = Boolean(normalizeUsageText(relatedIssue));
+  const hasMedia = Array.isArray(mediaReferences) && mediaReferences.length > 0;
+  if (hasMedia || matchesAny(normalizedText, LONG_DEVELOPMENT_PATTERNS)) {
+    return normalizeDashboardAppServerUsageProfile({
+      profile: "long_development",
+      reason: hasMedia ? "media_or_attachment_requires_full_context" : "long_running_development_or_e2e"
+    });
+  }
+  if (matchesAny(normalizedText, DEVELOPMENT_PATTERNS)) {
+    return normalizeDashboardAppServerUsageProfile({
+      profile: "development",
+      reason: "implementation_or_repository_work"
+    });
+  }
+  if (hasRepositoryContext || hasIssueContext || matchesAny(normalizedText, STATUS_READ_PATTERNS)) {
+    return normalizeDashboardAppServerUsageProfile({
+      profile: "status_read",
+      reason: "status_or_read_request"
+    });
+  }
+  return normalizeDashboardAppServerUsageProfile({
+    profile: "conversation",
+    reason: "ordinary_conversation"
+  });
+}
+function buildDashboardAppServerUsageCostBoundary(profileLike = null) {
+  const usageProfile = normalizeDashboardAppServerUsageProfile(profileLike);
+  return {
+    profile: usageProfile.profile,
+    codexWillStart: true,
+    appServerBridgeRequired: true,
+    contentAwareProfile: true,
+    selectedBy: usageProfile.selectedBy,
+    reason: usageProfile.reason,
+    modelConfigured: Boolean(usageProfile.model),
+    reasoningEffortConfigured: Boolean(usageProfile.reasoningEffort),
+    ...usageProfile.model ? { model: usageProfile.model } : {},
+    ...usageProfile.reasoningEffort ? { reasoningEffort: usageProfile.reasoningEffort } : {}
+  };
+}
+
 // src/core/help-guide-page.js
 function renderVtddHelpGuidePage(input = {}) {
   const runtimeOrigin = normalizeOrigin(input.runtimeOrigin);
@@ -58137,7 +58302,12 @@ var DashboardChatRoom = class {
     await this.broadcastTransientStatus({
       threadId,
       status: "thinking",
-      text: buildDashboardAppServerUsageTransientText({ text, repository, relatedIssue }),
+      text: buildDashboardAppServerUsageTransientText({
+        text,
+        repository,
+        relatedIssue,
+        mediaReferences: ownerMessage.mediaReferences || ownerMessage.media_references || []
+      }),
       snapshot: true,
       snapshotSource: "owner_message_dispatch"
     });
@@ -58156,6 +58326,13 @@ var DashboardChatRoom = class {
     const repository = normalizeCanonicalRepositoryInput(message.repository);
     const relatedIssue = normalizePositiveInteger10(message.relatedIssue || message.issueNumber);
     const mediaReferences = normalizeMediaReferences(message.mediaReferences || message.media_references || []);
+    const usageProfile = classifyDashboardAppServerUsageProfile({
+      text,
+      repository,
+      relatedIssue,
+      mediaReferences
+    });
+    const costBoundary = buildDashboardAppServerUsageCostBoundary(usageProfile);
     const trafficControl = await buildDashboardChatTrafficControlContext({
       env: this.env,
       repository,
@@ -58180,6 +58357,8 @@ var DashboardChatRoom = class {
         turnMethod: "turn/start"
       },
       authority: buildDashboardAppServerAuthorityHint({ repository, relatedIssue, text }),
+      usageProfile,
+      costBoundary,
       trafficControl
     };
     return this.sendSocket(bridgeSocket, turnRequest);
@@ -66436,10 +66615,25 @@ function buildDashboardAppServerFailureTransientText({ messageStatus = "", failu
   }
   return sanitizeDashboardChatText(failureText) || "app-server bridge \u306E\u8FD4\u4FE1\u3092\u5F85\u3063\u3066\u3044\u307E\u3059";
 }
-function buildDashboardAppServerUsageTransientText({ repository = "", relatedIssue = "" } = {}) {
+function buildDashboardAppServerUsageTransientText({
+  text = "",
+  repository = "",
+  relatedIssue = "",
+  mediaReferences = []
+} = {}) {
+  const usageProfile = normalizeDashboardAppServerUsageProfile(
+    classifyDashboardAppServerUsageProfile({
+      text,
+      repository,
+      relatedIssue,
+      mediaReferences
+    })
+  );
   const scope = [
     repository ? `repo=${repository}` : "repo=\u672A\u6307\u5B9A",
-    relatedIssue ? `Issue #${relatedIssue}` : "Issue=\u672A\u6307\u5B9A"
+    relatedIssue ? `Issue #${relatedIssue}` : "Issue=\u672A\u6307\u5B9A",
+    `usage_profile=${usageProfile.profile}`,
+    `reasoning_effort=${usageProfile.reasoningEffort}`
   ].join(" / ");
   return `Codex app-server \u306B\u6E21\u3057\u3066\u3044\u307E\u3059\u3002Codex usage \u3092\u6D88\u8CBB\u3057\u5F97\u307E\u3059\u3002${scope}`;
 }


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #455 の Dashboard Butler -> app-server bridge 経路で、Worker が AI 風に回答せず全 turn を bridge へ渡したまま、owner 発話内容に応じた usage profile を分類し、VPS codex app-server の reasoning effort 起動設定へ反映できるようにします。

## Satisfied Success Criteria

- Dashboard owner turn に conversation/status_read/development/long_development の usageProfile と costBoundary を付与しました。 bridge runner が usageProfile から model_reasoning_effort args を組み、profile/args ごとに app-server client を lazy reuse するようにしました。 turn input と turn_started runtime truth に usageProfile/costBoundary を出すようにしました。 分類 helper と Worker/bridge integration tests を追加しました。

## Unsatisfied Success Criteria

- production deploy 後の live Dashboard Butler E2E と Codex Analytics snapshot 突合せは未実施です。 Codex CLI/account が model_reasoning_effort を本番で受理することは deploy 後 runtime truth で確認が必要です。

## Non-goal violations

Worker が軽量 AI 風回答を返す fast path は復活させていません。モデル名の repo 固定、deploy 実行、credential/permission mutation、Issue #455 全体の close はしません。

## 開発前作戦図

- 作戦図 evidence: docs/development-strategy/issue-455-content-aware-app-server-usage-profile.md
- 完了体験: Dashboard Butler は全入力を bridge/VPS Codex CLI に届け、会話・状況確認・開発・長時間開発ごとの usage profile と reasoning effort が runtime truth で見えます。
- VTDD 全体で進める部分: Issue #455 の Dashboard app-server bridge entrypoint で content-aware usage profile を実行設定へ接続します。
- 設計: owner-facing surface は Dashboard Butler 通常チャットです。scope は Worker の分類 metadata と VPS bridge の app-server client selection に限定し、authority 境界として deploy/restart/credential mutation は含めません。
- 仮説: 仮説: PR #765 は固定 profile ノブだけで、発話内容ごとの実行設定切替がなかったことが原因で、本番 bridge は常に同じ codex app-server 起動設定でした。
- 検証計画: classifier unit、Worker dispatch integration、bridge command/client selection tests、build:worker、verify:worker、diff check を通して検証します。
- 改修見積もり: src/core/dashboard-app-server-usage-profile.js: profile classifier; src/worker/runtime.js: payload/status; scripts/run-dashboard-app-server-bridge.mjs: profile-aware args/client/runtime truth; test/*.js; worker.js。
- 既に通っている経路: PR #764 で Worker AI 風 fast path は停止済み。PR #765 で fixed app-server profile args、PR #770/#771 で analytics observer path が入っています。
- 未確認の境界: Codex CLI/account の model_reasoning_effort 受理と実際のクレジット削減量は production runtime と Codex Analytics で確認します。
- 穴が出そうな箇所: 分類語彙の過不足、複数 app-server client の thread resume 挙動、long-running turn 中の bridge restart 観測が残ります。
- PR 前に確認すること: latest origin/main branch、unrelated untracked assets 除外、source tests、worker build、verify:worker、diff check を確認します。
- 実装候補と捨てた案: Worker が軽量回答して Codex を起動しない案、全 turn 固定 low 案、model 名 hard-code 案は捨てました。
- merge 後に通す E2E: merge 後に production live E2E 検証として bridge restart 後の会話/status/development/long_development probe と Codex Analytics snapshot delta test を行います。
- 次の PR を増やさない理由: 固定ノブと観測だけで終わっていた #455 の不足を、今回の PR scope で Worker/bridge/tests まで一塊で閉じるためです。
- 停止条件: app-server CLI が profile args を受けない、Worker AI 風 fast path が必要になる、deploy/credential/permission mutation が必要になる場合は停止します。

## Dry-run Impact Report

- Target Issue: Issue #455
- Implementing Success Criteria: 軽量 read/status/通常会話と開発 turn の Codex usage 境界を owner-facing runtime truth と app-server 起動設定へ接続します。
- Explicit Non-goals: deploy、credential/permission mutation、Worker AI answer fast path、model hard-code、Issue close は範囲外です。
- Expected touched files/routes/workflows: docs/development-strategy/issue-455-content-aware-app-server-usage-profile.md; src/core/dashboard-app-server-usage-profile.js; src/core/index.js; src/worker/runtime.js; scripts/run-dashboard-app-server-bridge.mjs; test/dashboard-app-server-bridge.test.js; test/worker.test.js; worker.js。
- Affected Issues: Issue #455。Issue #450/#590 の app-server bridge runtime truth に隣接しますが、このPRでは downscope しません。
- Affected PRs: PR #765/#770/#771 の続きです。
- Affected workflows: GitHub Actions workflow は変更しません。deploy-production は merge 後に別途 passkey approval 境界です。
- Affected runtime/operator surfaces: Dashboard Butler WebSocket chat、Dashboard app-server bridge runner、VPS codex app-server process selection。
- What may break if we patch narrowly: Worker payload だけだと表示だけで消費設定が変わらないため、bridge client args まで接続しました。
- Unknowns to investigate before coding: 本番 Codex CLI の model_reasoning_effort 受理、profile 別 client と同一 thread resume の live 挙動、Analytics delta。
- Validation needed: node --test test/dashboard-app-server-bridge.test.js; node --test test/worker.test.js; npm run build:worker; npm run verify:worker; git diff --check。
- Stop condition: profile args が runtime で起動不能、または Worker AI fast path 復活が必要になる場合。

## Execution Queue Delta

- Queue position before: Issue #455 は owner complaint により content-aware cost adjustment の ROOT follow-up として現在の実装 slice になります。
- Preemption decision: ROOT: 固定ノブだけでは Butler からの通常会話/開発の消費調整が実装済みと言えず、Butler-first 開発継続の根を塞ぎます。
- Queue delta: Issue #455 の Dashboard app-server usage profile slice を進めます。production live E2E と Analytics 突合せは evidence gap として残します。
- Why this PR is next: owner が Butler で開発を再開する前に、会話/開発/長時間開発の消費差を測る経路が必要なためです。
- Active Issues not downscoped: Active Issues は縮小しません。#455 以外の root blockers は未完了のまま残します。

## File / Line Hypotheses

- file: src/worker/runtime.js; hypothesis: Dashboard owner turn に usageProfile/costBoundary が無いため bridge が内容別に調整できない; risk if changed narrowly: Worker が回答 fast path を復活させると Butler 中継機条件を壊す; validation: worker tests; related Issue: #455. - file: scripts/run-dashboard-app-server-bridge.mjs; hypothesis: fixed appServerArgs だけでは content-aware 切替にならない; risk if changed narrowly: runtime truth だけ出て実際の args が変わらない; validation: command config and client selector tests; related Issue: #455.

## Hypothesis Retrospective

- expected: 発話分類 metadata と bridge client args の両方が入り、表示だけでなく実行設定が変わる。 - actual: classifier、Worker payload/status、bridge profile command config/client selector、turn runtime truth を実装した。 - mismatch: production runtime と Codex Analytics delta は未確認。 - lesson: #455 は固定ノブや観測だけでなく owner-facing機能単位で閉じる必要がある。 - should become RAG candidate: yes, owner frustration identified the repeated slice-too-small failure mode.

## Verification Evidence

- Unit: node --test test/dashboard-app-server-bridge.test.js: pass 58/58; classifier and bridge command/client selection included.
- Integration: node --test test/worker.test.js: pass 271/271; DashboardChatRoom ordinary/cost/status turns still forward to app-server bridge with usageProfile/costBoundary.
- E2E: npm run verify:worker: pass 1179/1180, skipped 1; includes build:worker, npm test, self-parity, generated-worker check. Production iPhone E2E is not run in this PR.
- Manual: git diff --check: pass. Unrelated untracked E2E assets were not touched.
- Evidence path/link: docs/development-strategy/issue-455-content-aware-app-server-usage-profile.md; test/dashboard-app-server-bridge.test.js; test/worker.test.js

## Butler Completion Contract

- Primary owner surface: Dashboard Butler
- Fallback surface: Custom GPT は fallback surface です。このPRの主経路ではありません。
- Owner goal: Butler からの会話/状況確認/開発/長時間開発で、VPS codex app-server の usage profile が変わることを確認できる。
- Butler entrypoint: DashboardChatRoom owner_message WebSocket entrypoint。
- Dashboard Butler natural-language path: Dashboard Butler の自然文 通常チャット入口で owner turn を受け、app-server bridge 経路へ接続します。
- Action Schema exposure: Custom GPT Action Schema は未変更。このPRは Dashboard live bridge 経路の実装です。
- Runtime path: DashboardChatRoom -> app_server_turn_requested -> run-dashboard-app-server-bridge -> codex app-server client selector。
- Runner/runtime truth: transient status, app_server_turn_requested payload, Dashboard turn_started bridgeLifecycle に usageProfile/costBoundary を出します。
- Authority boundary: 新しい high-risk authority はありません。deploy/restart は merge 後に passkey approval 境界です。
- E2E evidence: Local integration only。production iPhone/PWA E2E と Codex Analytics delta は merge/deploy 後に実施します。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 必要。merge 後に scoped passkey approval で deploy-production と bridge restart が必要です。
- Custom GPT Action Schema update: 不要。Dashboard live bridge internal payload の変更です。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 必要。merge/deploy/restart 後に会話/status/development/long_development probe を行います。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate; Butler-First Operating Principle; Drift Stop Protocol; 開発前作戦図 Gate; Evidence Discipline; Change Size and PR Discipline。

## Out-of-scope but NOT implemented

- Codex Analytics ページの自動ログイン/自動スクレイピング本体。reviewer duplicate suppression。deploy/bridge restart 実行。Issue #455 close。

## Extra changes (if any)

Generated worker.js updated by npm run build:worker.

<!-- VTDD metadata -->
- Issue: Issue #455
- Execution ID: mac-codex-issue-455-content-aware-usage-profile-2026-06-04
- Goal: Dashboard Butler content-aware app-server usage profile implementation
