### PR TITLE
Issue #741 deploy後 bridge sync/restart を標準後処理にする

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -286,6 +286,7 @@ jobs:
           DEPLOY_SHA: ${{ github.sha }}
           DEPLOY_BRANCH: ${{ github.ref_name }}
           RUNTIME_URL: ${{ github.event.inputs.runtime_url }}
+          APPROVAL_GRANT_ID: ${{ github.event.inputs.approval_grant_id }}
           GITHUB_TOKEN: ${{ github.token }}
         shell: bash
         run: |
@@ -372,6 +373,7 @@ jobs:
               displayTitle: changeSummary || "deploy-production",
               changeSummary: changeSummary || null,
               pullNumber: pullNumber || null,
+              approvalGrantId: process.env.APPROVAL_GRANT_ID || null,
               updatedAt: new Date().toISOString()
             };
             process.stdout.write(JSON.stringify(payload));

--- a/docs/development-strategy/issue-741-deploy-bridge-restart-automation.md
+++ b/docs/development-strategy/issue-741-deploy-bridge-restart-automation.md
@@ -19,18 +19,20 @@ Issue #741 の deploy 後 checkout sync + bridge restart 標準運用と、Issue
 1. Butler / self-parity が same-origin deploy operator URL を提示する。
 2. owner は passkey 認証だけ行う。
 3. runtime が deploy workflow を dispatch し、run URL / run status を返す。
-4. deploy 成功後、VPS helper capability で checkout sync と bridge restart を実行または提案する。
+4. deploy 成功後、既存 deploy approval の標準後処理として VPS helper queue に checkout sync と bridge restart を必ず積む。
 5. Butler が production SHA / VPS SHA / bridge process truth を返す。
 
 Cloudflare passkey operator page は approvalGrant を作るだけでは足りない。deploy mode では承認成功後に same-origin `/v2/action/deploy` へ approvalGrantId を POST し、Worker が deploy dispatch を検知できる必要がある。VPS maintenance mode でも同じく、承認成功後に `/v2/dashboard/chat/messages` へ approvalGrantId / vpsProposalId を戻し、Dashboard Butler が helper queue へ自動継続できる必要がある。owner に approvalGrantId をコピーさせる flow は fallback であり、通常導線ではない。
 
 2026-06-04 live deploy 後、VPS operator の passkey 承認自体は成功したが、auto-continue POST が `Cloudflare Access authenticated owner identity is required for dashboard surface /dashboard/chat/messages` で止まった。Dashboard chat write 全体を緩めてはいけないが、stored VPS proposal と matching passkey approval grant が検証できる continuation request は、same-origin passkey operator の通常導線として Dashboard chat auth とは別に許可する必要がある。
 
-deploy operator page は認証と dispatch の場であって、追跡UIではない。dispatch 後は `returnUrl` で Dashboard Butler の chat surface に戻す。GitHub Actions deploy success event を Worker が受けたら、同じ chat thread に deploy 完了 truth と VPS checkout sync + repo-less bridge restart の approval_required proposal を出す。operator page に owner を残して GitHub Actions run link を眺めさせる設計にはしない。
+deploy operator page は認証と dispatch の場であって、追跡UIではない。dispatch 後は `returnUrl` で Dashboard Butler の chat surface に戻す。GitHub Actions deploy success event を Worker が受けたら、同じ chat thread に deploy 完了 truth と VPS checkout sync + repo-less bridge restart の helper queue handoff を出す。operator page に owner を残して GitHub Actions run link を眺めさせる設計にはしない。
 
 2026-06-04 の live operator では `ReferenceError: Can't find variable: returnToButlerLink` が出た。これは deploy operator page が `returnUrl` を持つ Butler 起点だけを暗黙前提にし、mac Codex から passkey operator URL を開く break-glass / bootstrap 経路を壊した回帰である。正しい境界は、Butler から開いた時は承認後に chat へ戻る、mac Codex から開いた時は `returnUrl` が無くても deploy dispatch と結果表示が成立する、である。`returnToButlerLink` は必須 runtime authority ではなく任意の復帰リンクとして扱う。
 
-今回の実装単位は、deploy success event から VPS privileged maintenance proposal を作り、same-origin VPS passkey operator URL を chat に出し、承認後の Dashboard chat auto-continue が既存 helper queue に固定 command envelope を渡すところまでを一塊で接続すること。実運用で動いている unresolved bridge が deploy 後 follow-up から抜けていると、Butler が「人間は認証だけ」という運用を満たせない。
+今回の実装単位は、deploy success event から既存 deploy approval grant を検証し、そのまま VPS helper queue に固定 command envelope を渡すところまでを一塊で接続すること。実運用で動いている unresolved bridge が deploy 後 follow-up から抜けていると、Butler が「人間は認証だけ」という運用を満たせない。
+
+2026-06-04 owner 指摘により境界を修正する。production deploy は Dashboard app-server bridge が最新 source に追従して初めて owner-facing deploy 完了である。したがって deploy 後 bridge sync/restart は opt-in パラメータや二回目の passkey approval にしてはいけない。`deploy-production.yml` が runtime に送る deploy success event へ `approvalGrantId` を machine-only payload として含め、Worker は stored passkey grant を読み直して `deploy_production` scope / repository / expiry を検証し、固定 `dashboard_bridge_unresolved_deploy_sync_restart` helper execution envelope を queue comment として発行する。`approvalGrantId` は event record / chat message / Web Push / owner-facing response に残さない。
 
 deploy operator URL は既に `selfParity.deployOperatorMarkdownLink` と passkey operator page に存在するため、今回はそれを GitHub Actions URL と混同しない guidance / tests を補強する。URL 自動提示は `vtddRetrieveSelfParity` を優先し、fallback でも same-origin `/v2/approval/passkey/operator?...actionType=deploy_production&highRiskKind=deploy_production` を返す。
 
@@ -38,7 +40,7 @@ deploy operator URL は既に `selfParity.deployOperatorMarkdownLink` と passke
 
 現在の blocker は deploy plane そのものではない。`/v2/action/deploy` は approvalGrant から workflow dispatch まで進める。足りないのは、owner-facing 会話で deploy operator URL を自動提示し、deploy 後に VPS bridge lifecycle follow-up をつなぐこと。
 
-さらに #637 preset は repo-less bridge restart まで扱えるようになったが、deploy success event からその proposal を自動生成する runtime path がまだない。今日の手動 restart と同じ場面で Butler から正しい capability proposal と operator URL を出せても、deploy 完了 chat に自動で出なければ owner はまた mac Codex / GitHub Actions / SSH に戻される。
+さらに #637 preset は repo-less bridge restart まで扱えるようになったが、deploy success event から helper queue へ自動で積む runtime path がまだない。今日の手動 restart と同じ場面で Butler が再承認要求や repo/Issue 欠落 blocker を返すと、owner はまた mac Codex / GitHub Actions / SSH に戻される。
 
 ## 検証計画
 
@@ -51,9 +53,10 @@ deploy operator URL は既に `selfParity.deployOperatorMarkdownLink` と passke
 - Unit: deploy operator page は `returnUrl` が無い mac Codex 起点でも `returnToButlerLink` ReferenceError を起こさず、dispatch 結果をページ内に表示できる。
 - Unit: deploy operator page は `returnUrl` がある Butler 起点だけ、dispatch 後にその復帰先へ遷移する。
 - Unit: VPS operator page は `dashboardThreadId` がある時に `/v2/dashboard/chat/messages` へ承認イベントを戻す導線を維持する。
-- Unit: GitHub Actions deploy success event は同じ Dashboard chat に bridge sync/restart approval URL を追記する。
+- Unit: GitHub Actions deploy success event は同じ Dashboard chat に bridge sync/restart helper queue handoff を追記する。
+- Unit: deploy success event の `approvalGrantId` は stored passkey grant 検証にだけ使い、event record / chat / Web Push / owner-facing response には出さない。
 - Unit: 同じ deploy event の重複受信は proposal / chat message / Web Push を二重化しない。
-- Unit: bridge follow-up approval grant が戻ると既存 helper queue に fixed script command envelope を渡す。
+- Unit: deploy success event が既存 deploy approval grant で固定 script command envelope を helper queue に渡す。
 - Unit: Cloudflare Access session を持たない passkey operator からの VPS approval continuation は、stored proposal / matching grant がある場合だけ helper queue に到達する。
 - Unit: approvalGrantId / vpsProposalId がない ordinary chat write は引き続き Cloudflare Access / dashboard passkey session なしでは拒否される。
 - Unit: fixed helper script は tracked dirty checkout を restart 前に止め、before/after SHA と service truth を JSON で返す。
@@ -63,7 +66,7 @@ deploy operator URL は既に `selfParity.deployOperatorMarkdownLink` と passke
 ## 改修見積もり
 
 - `src/core/vps-privileged-maintenance.js`: deploy follow-up 用 fixed helper command registry entry を追加する。risk は arbitrary command 化することなので argv / allowedArgs は固定する。
-- `src/worker/runtime.js`: GitHub Actions deploy success event から unresolved bridge sync/restart approval proposal を作り、承認後の既存 helper queue へつなぐ。risk は deploy approval と VPS maintenance approval を混ぜること。
+- `src/worker/runtime.js`: GitHub Actions deploy success event から unresolved bridge sync/restart helper execution envelope を作り、既存 deploy approval grant 検証後に helper queue へつなぐ。risk は approvalGrantId を owner-facing payload に漏らすこと、または任意 command 化すること。
 - `scripts/sync-dashboard-app-server-bridge-after-deploy.mjs`: VPS checkout fast-forward と unresolved bridge restart を固定処理にする。risk は dirty checkout / service 名誤り / stdout に秘密を出すこと。
 - `src/core/passkey-operator-page.js`: deploy auto-dispatch 後の任意 return link を DOM 参照として明示し、mac Codex 起点では未指定でも落ちないようにする。risk は Butler 起点の chat 復帰を失うこと、または mac Codex 起点で不要な redirect を起こすこと。
 - `test/vps-privileged-maintenance.test.js`: registry coverage を追加する。
@@ -83,7 +86,7 @@ deploy operator URL は既に `selfParity.deployOperatorMarkdownLink` と passke
 
 ## 未確認の境界
 
-deploy workflow の長時間 polling 自体はまだ作らない。今回の runtime entrypoint は GitHub Actions deploy success event webhook / repository_dispatch 相当の受信であり、受信後に bridge follow-up proposal を chat に出す。GitHub Actions の protected environment approval と passkey approval は別 gate であり、どちらも bypass しない。deploy approval grant だけでは VPS maintenance execution を開始しない。
+deploy workflow の長時間 polling 自体はまだ作らない。今回の runtime entrypoint は GitHub Actions deploy success event webhook / repository_dispatch 相当の受信であり、受信後に bridge follow-up helper queue を同じ chat に出す。GitHub Actions の protected environment approval と passkey approval は別 gate であり、どちらも bypass しない。deploy approval grant は production deploy とその標準後処理である bridge sync/restart helper queue handoff までを含む。ただし Worker は root 実行も helper 実行も開始せず、VPS runner pickup path へ固定 envelope を渡すだけに留める。
 
 VPS helper が現在の production host で unresolved bridge capability manifest を持っているかは deploy 後 live evidence が必要。repo に registry が入るだけでは root-owned manifest の現物更新完了ではない。
 
@@ -92,7 +95,7 @@ bridge restart の頻度による副作用は未測定。予測されるリス�
 ## 穴が出そうな箇所
 
 - GitHub Actions workflow URL を deploy URL として返すと、owner は認証だけで済まない。
-- deploy approval scope に bridge restart までは含めない。今回の slice は deploy 後 follow-up approval URL を作るが、勝手に destructive / maintenance execution を始めない。
+- deploy 後 bridge restart を追加 passkey にしない。今回の slice は deploy approval grant を再検証して helper queue へ fixed command envelope を積むが、Worker 自身は root/helper execution を開始しない。
 - deploy operator page の `returnUrl` を必須扱いにすると、mac Codex から passkey approval を開く bootstrap / break-glass 経路が ReferenceError で止まる。
 - unresolved bridge を残骸扱いで stop/disable すると repo-less main chat を壊す。
 - broad `bridge restart` intent で全 bridge を同時 restart すると進行中 turn を落とす可能性がある。
@@ -108,7 +111,7 @@ bridge restart の頻度による副作用は未測定。予測されるリス�
 
 ## 実装候補と捨てた案
 
-採用: deploy success event から unresolved bridge checkout sync + restart fixed command の approval proposal を自動生成し、同じ chat thread に operator URL を提示する。
+採用: deploy success event から unresolved bridge checkout sync + restart fixed command の helper execution envelope を自動生成し、同じ chat thread に queue truth を提示する。
 
 採用: fixed helper script で `git fetch` / `git pull --ff-only` / `systemctl --user restart vtdd-dashboard-app-server-bridge-unresolved.service` を実行し、before/after truth を JSON にまとめる。
 
@@ -118,7 +121,9 @@ bridge restart の頻度による副作用は未測定。予測されるリス�
 
 捨てた案: mac Codex が SSH で restart する運用を標準とする。Butler completion ではないため不採用。
 
-捨てた案: deploy workflow 内で無条件に VPS SSH restart する。deploy approval と VPS maintenance approval の scope 混在が未整理のため不採用。
+捨てた案: deploy 後に二回目の VPS passkey approval URL を出す。production deploy 完了の標準後処理を owner に再承認させる設計であり、パスキー地獄を温存するため不採用。
+
+捨てた案: deploy workflow 内で無条件に VPS SSH restart する。GitHub Actions に VPS root credential を広げるため不採用。既存 VTDD の runner pickup / helper queue 境界を使う。
 
 捨てた案: 短間隔の periodic restart。進行中 turn とコスト観測に悪影響を出す可能性があるため、health-based または deploy-follow-up に限定して検証する。
 
@@ -128,18 +133,18 @@ bridge restart の頻度による副作用は未測定。予測されるリス�
 
 1. Dashboard Butler で「デプロイしたい」と送る。期待値は same-origin deploy operator URL が返り、GitHub Actions workflow URL だけでは止まらない。
 2. owner が passkey 認証する。runtime が deploy workflow を dispatch し run URL を返す。
-3. deploy success 後、Dashboard Butler で「repo 未設定 main chat の app-server bridge を再起動して」と送る。期待値は unresolved bridge restart proposal / approval URL が出る。
-4. owner が passkey 認証する。VPS helper queue が unresolved bridge restart を実行し、before/after active state と repo SHA を返す。
+3. deploy success 後、Dashboard Butler chat に unresolved bridge restart helper queue handoff が自動追記される。期待値は追加 passkey なし、queueCommentUrl / executionId / rootExecutionStarted=false / helperExecutionStarted=false が出る。
+4. VPS helper runner が queue を拾う。before/after active state と repo SHA を返す。
 
 ## 次の PR を増やさない理由
 
 deploy operator URL 自動提示と bridge restart は owner から見て同じ deploy follow-up workflow であり、今日の手動作業で一続きに露呈した gap である。少なくとも unresolved bridge capability を同じ slice で入れないと、deploy 後 restart automation が実運用対象を外す。
 
-ただし deploy approval と VPS maintenance approval は分ける。自動化するのは proposal / operator URL / helper queue handoff までで、owner の scoped passkey approval なしに restart は始めない。
+ただし Worker は root/helper execution を直接始めない。自動化するのは fixed helper queue handoff までで、VPS runner / helper の実行境界と before/after truth は維持する。
 
 ## 停止条件
 
-- deploy approval grant だけで VPS maintenance execution まで自動開始しないと成立しない場合。
+- deploy approval grant を owner-facing event/chat/push に漏らさないと実装できない場合。
 - GitHub environment approval、credential、permission、repository settings mutation を変える必要が出た場合。
 - unresolved bridge restart が通常 chat を壊すことが分かった場合。
 - owner 固有の runtime URL / host secret / credential を public repo に固定しそうになった場合。

--- a/scripts/run-dashboard-app-server-bridge.mjs
+++ b/scripts/run-dashboard-app-server-bridge.mjs
@@ -186,6 +186,10 @@ export function buildDashboardTurnInputText(request = {}) {
     request.trafficControl && typeof request.trafficControl === "object"
       ? request.trafficControl
       : null;
+  const vpsMaintenancePassThrough =
+    request.vpsMaintenancePassThrough && typeof request.vpsMaintenancePassThrough === "object"
+      ? request.vpsMaintenancePassThrough
+      : null;
   const usageProfile =
     request.usageProfile && typeof request.usageProfile === "object"
       ? normalizeDashboardAppServerUsageProfile(request.usageProfile)
@@ -197,6 +201,7 @@ export function buildDashboardTurnInputText(request = {}) {
       relatedIssue ||
       authority ||
       trafficControl ||
+      vpsMaintenancePassThrough ||
       usageProfile ||
       costBoundary ||
       mediaReferences.length > 0
@@ -234,6 +239,11 @@ export function buildDashboardTurnInputText(request = {}) {
 
   if (trafficControl) {
     lines.push(`- trafficControl: ${JSON.stringify(trafficControl)}`);
+  }
+
+  if (vpsMaintenancePassThrough) {
+    lines.push(`- vpsMaintenancePassThrough: ${JSON.stringify(vpsMaintenancePassThrough)}`);
+    lines.push("- vpsMaintenancePassThroughRule: 不足 context/config がある VPS/root/helper/restart intent は実行を開始せず、不足情報を日本語で短く確認する。");
   }
 
   if (authority) {
@@ -1637,6 +1647,7 @@ export async function handleDashboardTurnRequest({
       relatedIssue: request.relatedIssue || request.issueNumber,
       authority: request.authority,
       trafficControl: request.trafficControl,
+      vpsMaintenancePassThrough: request.vpsMaintenancePassThrough,
       usageProfile: turnUsageProfile,
       costBoundary: turnCostBoundary,
       mediaReferences: materializedMediaReferences

--- a/scripts/sync-dashboard-app-server-bridge-after-deploy.mjs
+++ b/scripts/sync-dashboard-app-server-bridge-after-deploy.mjs
@@ -59,11 +59,13 @@ function runCommand({ command, args = [], cwd, allowFailure = false, runner = sp
 
 function readGitState({ cwd, runner }) {
   const head = runCommand({ command: "git", args: ["rev-parse", "HEAD"], cwd, runner }).stdout;
+  const originMain = runCommand({ command: "git", args: ["rev-parse", "origin/main"], cwd, runner, allowFailure: true }).stdout;
   const branch = runCommand({ command: "git", args: ["status", "--short", "--branch"], cwd, runner }).stdout;
   const diff = runCommand({ command: "git", args: ["diff", "--quiet"], cwd, runner, allowFailure: true });
   const staged = runCommand({ command: "git", args: ["diff", "--cached", "--quiet"], cwd, runner, allowFailure: true });
   return {
     head,
+    originMain,
     branch,
     trackedDirty: diff.exitCode !== 0 || staged.exitCode !== 0
   };
@@ -139,6 +141,7 @@ export async function runDeployBridgeSyncRestart({
   const restart = runCommand({ command: "systemctl", args: ["--user", "restart", service], cwd, runner });
   const afterGit = readGitState({ cwd, runner });
   const afterService = readServiceState({ cwd, service, runner });
+  const afterMatchesTargetRef = Boolean(afterGit.head && afterGit.originMain && afterGit.head === afterGit.originMain);
   return {
     ok: true,
     status: "synced_and_restarted",
@@ -164,6 +167,10 @@ export async function runDeployBridgeSyncRestart({
       rootExecutionStarted: false,
       helperExecutionStarted: true,
       serviceRestarted: true,
+      targetRef: ref,
+      targetRefSha: afterGit.originMain,
+      syncVerified: afterMatchesTargetRef,
+      afterMatchesTargetRef,
       beforeSha: beforeGit.head,
       afterSha: afterGit.head,
       beforeServiceActiveState: beforeService.activeState || beforeService.active,

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -467,6 +467,12 @@ export class DashboardChatRoom {
       relatedIssue,
       text
     });
+    const vpsMaintenancePassThrough = buildDashboardVpsMaintenancePassThroughContext({
+      text,
+      repository,
+      relatedIssue,
+      env: this.env
+    });
     const mapping = await this.readAppServerThreadMapping(threadId);
     const turnRequest = {
       type: "app_server_turn_requested",
@@ -487,7 +493,8 @@ export class DashboardChatRoom {
       authority: buildDashboardAppServerAuthorityHint({ repository, relatedIssue, text }),
       usageProfile,
       costBoundary,
-      trafficControl
+      trafficControl,
+      vpsMaintenancePassThrough
     };
     return this.sendSocket(bridgeSocket, turnRequest);
   }
@@ -12181,6 +12188,42 @@ function buildDashboardVpsMaintenanceProposalPreflight({ proposalPayload, reposi
     missingContext,
     missingConfiguration,
     nextAction
+  };
+}
+
+function buildDashboardVpsMaintenancePassThroughContext({ text, repository, relatedIssue, env } = {}) {
+  if (!detectDashboardVpsPrivilegedMaintenanceIntent({ text })) {
+    return null;
+  }
+  const proposalPayload = buildDashboardVpsMaintenanceProposalPayload({
+    payload: { text },
+    repository,
+    relatedIssue,
+    env
+  });
+  const preflight = buildDashboardVpsMaintenanceProposalPreflight({
+    proposalPayload,
+    repository,
+    relatedIssue
+  });
+  if (preflight.ok) {
+    return null;
+  }
+  return {
+    kind: "dashboard_vps_maintenance_pass_through",
+    status: "passed_to_app_server_bridge",
+    reason: preflight.reason,
+    missingContext: preflight.missingContext || [],
+    missingConfiguration: preflight.missingConfiguration || [],
+    rootExecutionStarted: false,
+    helperExecutionStarted: false,
+    workerProposalCreated: false,
+    guidance: [
+      "Dashboard Butler はこの VPS maintenance intent を Worker blocker で止めず app-server bridge へ渡しました。",
+      "VPS / root / helper / restart / deploy recovery の実行を開始しないでください。",
+      "不足している repository、related Issue、または runtime config を日本語で短く確認してください。",
+      "owner が deploy 後 bridge sync/restart を求めている場合は、deploy standard post-step / helper queue truth を確認してから案内してください。"
+    ]
   };
 }
 

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -72,6 +72,7 @@ import {
   upsertRepositoryNickname,
   validateMemoryProvider,
   verifyPasskeyApproval,
+  validateDeployApprovalGrant,
   verifyPasskeyRegistration
 } from "../core/index.js";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -509,6 +510,9 @@ export class DashboardChatRoom {
       origin: normalizeText(origin) || normalizeText(this.env?.VTDD_RUNTIME_URL || this.env?.VTDD_PASSKEY_ORIGIN) || "https://dashboard-butler.local",
       env: this.env
     });
+    if (!shouldDashboardVpsMaintenanceFlowStayInWorker(flow)) {
+      return null;
+    }
     return [
       normalizeDashboardChatMessage(
         {
@@ -4945,11 +4949,12 @@ async function handleGitHubActionsEventRequest(request, env) {
           proposalCreated: false,
           message: null
         }
-      : await buildDeployBridgeFollowupChatMessage({
+        : await buildDeployBridgeFollowupChatMessage({
           event: baseEvent,
           threadId,
           env,
-          origin: new URL(request.url).origin
+          origin: new URL(request.url).origin,
+          approvalGrantId: normalizeText(payload?.approvalGrantId || payload?.approval_grant_id)
         });
   const chatMessages = [chatMessage, deployBridgeFollowup.message].filter(Boolean);
   const chatStore = resolveDashboardChatStore(env);
@@ -5036,7 +5041,7 @@ function isSuccessfulDeployWorkflowEvent(event) {
   );
 }
 
-async function buildDeployBridgeFollowupChatMessage({ event, threadId, env, origin } = {}) {
+async function buildDeployBridgeFollowupChatMessage({ event, threadId, env, origin, approvalGrantId } = {}) {
   const record = normalizeDashboardEventRecord(event);
   const repository = normalizeCanonicalRepositoryInput(record.repository);
   const relatedIssue =
@@ -5076,15 +5081,178 @@ async function buildDeployBridgeFollowupChatMessage({ event, threadId, env, orig
     };
   }
 
+  const deployApproval = await resolveApprovalGrant({
+    payload: {},
+    policyInput: { approvalGrantId },
+    env
+  });
+  const approvalValidation = validateDeployApprovalGrant({
+    approvalGrant: deployApproval.approvalGrant,
+    repositoryInput: repository
+  });
+  if (!approvalValidation.ok) {
+    return {
+      status: "blocked",
+      proposalCreated: false,
+      queueCreated: false,
+      error: "deploy_bridge_followup_approval_required",
+      issues: approvalValidation.issues || [deployApproval.warning || "deploy approval grant required"],
+      message: normalizeDashboardChatMessage(
+        {
+          threadId,
+          messageId,
+          role: "system",
+          repository,
+          relatedIssue,
+          status: "blocked",
+          text: buildDeployBridgeFollowupBlockedMessage({
+            record,
+            repository,
+            relatedIssue,
+            issues: approvalValidation.issues || [deployApproval.warning || "deploy approval grant required"]
+          }),
+          createdAt: record.updatedAt || record.createdAt
+        },
+        { threadId }
+      )
+    };
+  }
+
   const executionId = `deploy-bridge-followup-${safeIdentifier(record.runId) || createDashboardRequestId("deploy")}`;
+  const helperRequest = buildDeployBridgeFollowupHelperRequest({
+    record,
+    repository,
+    relatedIssue,
+    host,
+    workingDirectory,
+    threadId,
+    deployApproval: deployApproval.approvalGrant
+  });
+  const manifest = buildDashboardVpsMaintenanceManifest({
+    helperRequest,
+    now: record.updatedAt || record.createdAt
+  });
+  const execution = createVpsPrivilegedMaintenanceHelperExecution({
+    payload: {
+      manifest,
+      helperRequest,
+      now: record.updatedAt || record.createdAt
+    }
+  });
+  if (!execution.ok) {
+    return {
+      status: "blocked",
+      proposalCreated: false,
+      queueCreated: false,
+      error: execution.error,
+      issues: execution.issues || [],
+      message: normalizeDashboardChatMessage(
+        {
+          threadId,
+          messageId,
+          role: "system",
+          repository,
+          relatedIssue,
+          status: "blocked",
+          text: buildDeployBridgeFollowupBlockedMessage({
+            record,
+            repository,
+            relatedIssue,
+            issues: execution.issues || [execution.error || "execution_handoff_failed"]
+          }),
+          createdAt: record.updatedAt || record.createdAt
+        },
+        { threadId }
+      )
+    };
+  }
+  const queue = await createVpsPrivilegedMaintenanceHelperExecutionQueue({
+    payload: {
+      repository,
+      issueNumber: relatedIssue,
+      executionId,
+      dashboardThreadId: threadId,
+      approvalActor: "Dashboard deploy approval",
+      executionEnvelope: execution.body.executionEnvelope
+    },
+    env
+  });
+  if (!queue.ok) {
+    return {
+      status: "blocked",
+      proposalCreated: false,
+      queueCreated: false,
+      error: queue.error,
+      reason: queue.reason,
+      issues: queue.issues || [],
+      message: normalizeDashboardChatMessage(
+        {
+          threadId,
+          messageId,
+          role: "system",
+          repository,
+          relatedIssue,
+          status: "blocked",
+          text: buildDeployBridgeFollowupBlockedMessage({
+            record,
+            repository,
+            relatedIssue,
+            issues: queue.issues || [queue.reason || queue.error || "queue_handoff_failed"]
+          }),
+          createdAt: record.updatedAt || record.createdAt
+        },
+        { threadId }
+      )
+    };
+  }
+  return {
+    status: "queued_for_vps_helper_execution",
+    proposalCreated: false,
+    queueCreated: true,
+    execution: queue.body.execution,
+    runtimeTruth: {
+      ...(queue.body.runtimeTruth || {}),
+      deployApprovalValidated: true,
+      deployStandardPostStep: "dashboard_bridge_unresolved_deploy_sync_restart",
+      helperQueueReached: true,
+      rootExecutionStarted: false,
+      helperExecutionStarted: false
+    },
+    message: normalizeDashboardChatMessage(
+      {
+        threadId,
+        messageId,
+        role: "system",
+        repository,
+        relatedIssue,
+        status: "sent",
+        text: buildDeployBridgeFollowupQueuedMessage({
+          record,
+          repository,
+          relatedIssue,
+          queue: queue.body
+        }),
+        createdAt: record.updatedAt || record.createdAt
+      },
+      { threadId }
+    )
+  };
+}
+
+function buildDeployBridgeFollowupHelperRequest({ record, repository, relatedIssue, host, workingDirectory, threadId, deployApproval } = {}) {
   const allowedArg =
     "node scripts/sync-dashboard-app-server-bridge-after-deploy.mjs --service vtdd-dashboard-app-server-bridge-unresolved.service --ref origin/main";
-  const proposal = await createVpsPrivilegedMaintenanceProposal({
-    payload: {
-      host,
-      repository,
-      relatedIssue,
-      operation: "enable",
+  return {
+    kind: "vps_privileged_maintenance_helper_request",
+    status: "ready_for_vps_helper",
+    requestId: createDashboardRequestId("deploy-bridge-helper-request"),
+    vpsProposalId: `deploy-standard-post-step:${safeIdentifier(record.runId) || createDashboardRequestId("deploy")}`,
+    approvalGrantId: "deploy-approval-verified-redacted",
+    host,
+    repository,
+    relatedIssue,
+    operation: "enable",
+    capability: {
       id: "dashboard.bridge.unresolved.deploy.sync.restart",
       title: "Deploy後 repo-less Dashboard bridge sync/restart",
       commandClass: "dashboard_bridge_unresolved_deploy_sync_restart",
@@ -5098,80 +5266,49 @@ async function buildDeployBridgeFollowupChatMessage({ event, threadId, env, orig
         "vtdd-dashboard-app-server-bridge-unresolved.service"
       ],
       redactionRules: ["no secrets", "summarize stdout/stderr", "redact tokens and credentials"],
-      rollbackPlan: "stop auto follow-up proposal and restart the previous bridge service state manually if needed",
+      rollbackPlan: "stop deploy standard post-step queueing and restart the previous bridge service state manually if needed",
       expectedRuntimeTruth: [
         "before git HEAD",
+        "target ref",
+        "target ref SHA",
+        "sync verified after git HEAD matches origin/main",
         "after git HEAD",
         "before service active state",
         "after service active state",
         "after service main PID",
+        "pending owner messages replay source",
         "exit code"
-      ],
-      reason: `Issue #741 deploy run ${record.runId} success at ${record.headSha || "unknown sha"} requires VPS checkout sync and repo-less bridge restart follow-up`,
-      impactScope: `${workingDirectory}, vtdd-dashboard-app-server-bridge-unresolved.service`,
-      dashboardThreadId: threadId,
-      executionId
+      ]
     },
-    provider,
-    origin: origin || "https://example.com"
-  });
-  if (!proposal.ok) {
-    return {
-      status: "blocked",
-      proposalCreated: false,
-      error: proposal.error,
-      issues: proposal.issues || [],
-      message: normalizeDashboardChatMessage(
-        {
-          threadId,
-          messageId,
-          role: "system",
-          repository,
-          relatedIssue,
-          status: "blocked",
-          text: buildDeployBridgeFollowupBlockedMessage({
-            record,
-            repository,
-            relatedIssue,
-            issues: proposal.issues || [proposal.error || "proposal_failed"]
-          }),
-          createdAt: record.updatedAt || record.createdAt
-        },
-        { threadId }
-      )
-    };
-  }
-
-  return {
-    status: "approval_required",
-    proposalCreated: true,
-    vpsProposalId: proposal.body.vpsProposalId,
-    approvalScope: proposal.body.approvalScope,
-    approvalOperatorUrl: proposal.body.approvalOperatorUrl,
-    message: normalizeDashboardChatMessage(
-      {
-        threadId,
-        messageId,
-        role: "system",
-        repository,
-        relatedIssue,
-        status: "blocked",
-        text: buildDeployBridgeFollowupApprovalRequiredMessage({
-          record,
-          repository,
-          relatedIssue,
-          proposal: proposal.body
-        }),
-        createdAt: record.updatedAt || record.createdAt
-      },
-      { threadId }
-    )
+    approvalScope: {
+      actionType: "deploy_production",
+      highRiskKind: "deploy_production",
+      repositoryInput: repository,
+      phase: "deploy_standard_post_step",
+      display: {
+        operation: "deploy_production",
+        postStep: "dashboard_bridge_unresolved_deploy_sync_restart",
+        deployApprovalId: deployApproval?.approvalId ? "redacted" : ""
+      }
+    },
+    handoff: {
+      dashboardThreadId: threadId,
+      restartStrategy: {
+        pendingOwnerMessagesPersistedBy: "DashboardChatRoom pending_app_server_owner_messages",
+        bridgeReconnectPath: "app-server bridge reconnect resumes dashboard thread mapping and drains pending owner messages",
+        activeTurnHandling: "restart is queued after deploy completion; Worker does not drop stored dashboard owner messages; live app-server stream resume remains VPS runner truth"
+      }
+    },
+    rootExecutionStarted: false,
+    helperExecutionStarted: false,
+    redacted: true
   };
 }
 
-function buildDeployBridgeFollowupApprovalRequiredMessage({ record, repository, relatedIssue, proposal } = {}) {
+function buildDeployBridgeFollowupQueuedMessage({ record, repository, relatedIssue, queue } = {}) {
+  const execution = queue?.execution || {};
   return [
-    "deploy 後 bridge sync/restart の承認が必要です。",
+    "deploy 後 bridge sync/restart を VPS helper queue へ渡しました。",
     "",
     `- repo: ${repository || "未確認"}`,
     `- related Issue: #${relatedIssue || 741}`,
@@ -5179,12 +5316,13 @@ function buildDeployBridgeFollowupApprovalRequiredMessage({ record, repository, 
     `- deploy sha: ${record.headSha ? record.headSha.slice(0, 12) : "未確認"}`,
     "- 対象: repo-less Dashboard app-server bridge",
     "- service: vtdd-dashboard-app-server-bridge-unresolved.service",
-    `- vpsProposalId: ${proposal?.vpsProposalId || "未作成"}`,
-    "- authority: deploy approval とは別の scoped passkey approval が必要です。",
-    "- runtime truth: status=approval_required, rootExecutionStarted=false, helperExecutionStarted=false",
-    proposal?.approvalOperatorUrl ? `- approval URL: ${proposal.approvalOperatorUrl}` : "- approval URL: 未生成",
+    `- executionId: ${execution.executionId || "未生成"}`,
+    `- queueCommentUrl: ${execution.queueCommentUrl || "未取得"}`,
+    "- authority: deploy approval に含まれる標準後処理です。追加 passkey は不要です。",
+    "- restart guard: Dashboard の pending owner messages は保存済み queue から bridge reconnect 後に再送します。",
+    "- runtime truth: status=queued_for_vps_helper_execution, rootExecutionStarted=false, helperExecutionStarted=false",
     "",
-    "承認後は Dashboard chat が VPS helper queue へ fixed sync/restart command を渡します。VPS runner の before/after truth が戻るまで live restart 完了とは扱いません。"
+    "VPS runner pickup の before/after truth が戻るまで、live restart 完了とは扱いません。"
   ].join("\n");
 }
 
@@ -11723,7 +11861,8 @@ async function buildDashboardChatTurn(payload, options = {}) {
         env: options.env
       })
     : null;
-  const butlerMessage = hasVpsPrivilegedMaintenanceIntent
+  const keepVpsMaintenanceInWorker = shouldDashboardVpsMaintenanceFlowStayInWorker(vpsMaintenanceFlow);
+  const butlerMessage = keepVpsMaintenanceInWorker
     ? normalizeDashboardChatMessage(
         {
           threadId,
@@ -11744,8 +11883,13 @@ async function buildDashboardChatTurn(payload, options = {}) {
     relatedIssue,
     threadId,
     messages: [ownerMessage, butlerMessage].filter(Boolean),
-    execution: vpsMaintenanceFlow?.execution || null
+    execution: keepVpsMaintenanceInWorker ? vpsMaintenanceFlow?.execution || null : null
   };
+}
+
+function shouldDashboardVpsMaintenanceFlowStayInWorker(flow = null) {
+  const status = normalizeText(flow?.execution?.status || flow?.messageStatus);
+  return ["approval_required", "queued_for_vps_helper_execution", "sent"].includes(status);
 }
 
 async function buildDashboardVpsPrivilegedMaintenanceNaturalLanguageFlow({
@@ -13699,7 +13843,7 @@ function buildGitHubActionsDashboardChatMessageText(event) {
   }
   lines.push("", "次:");
   if (isDeploy && conclusion === "success") {
-    lines.push("- deploy 後 bridge sync/restart approval URL を同じ chat に出します。");
+    lines.push("- deploy 後 bridge sync/restart helper queue handoff を同じ chat に出します。");
     lines.push("- production E2E / runtime truth を確認します。");
   } else if (conclusion === "failure" || conclusion === "cancelled" || conclusion === "timed_out") {
     lines.push("- deploy / Actions の失敗原因を確認し、blocker と次 action を出します。");

--- a/test/dashboard-app-server-bridge.test.js
+++ b/test/dashboard-app-server-bridge.test.js
@@ -348,6 +348,33 @@ test("dashboard app-server bridge wraps repository traffic-control context into 
   assert.match(text, /Owner message:\nDashboard Butler が交通整理できるようにして/);
 });
 
+test("dashboard app-server bridge wraps VPS maintenance pass-through context into turn input", () => {
+  const text = buildDashboardTurnInputText({
+    text: "app-server bridge を再起動したい。",
+    vpsMaintenancePassThrough: {
+      kind: "dashboard_vps_maintenance_pass_through",
+      status: "passed_to_app_server_bridge",
+      missingContext: ["repository", "relatedIssue"],
+      missingConfiguration: ["host", "workingDirectories"],
+      rootExecutionStarted: false,
+      helperExecutionStarted: false,
+      workerProposalCreated: false,
+      guidance: [
+        "VPS / root / helper / restart / deploy recovery の実行を開始しないでください。",
+        "不足している repository、related Issue、または runtime config を日本語で短く確認してください。"
+      ]
+    }
+  });
+
+  assert.match(text, /Dashboard Butler turn context/);
+  assert.match(text, /vpsMaintenancePassThrough/);
+  assert.match(text, /"missingContext":\["repository","relatedIssue"\]/);
+  assert.match(text, /"missingConfiguration":\["host","workingDirectories"\]/);
+  assert.match(text, /"rootExecutionStarted":false/);
+  assert.match(text, /実行を開始しない/);
+  assert.match(text, /不足情報を日本語で短く確認/);
+});
+
 test("dashboard app-server bridge includes attachment delivery truth in turn input", () => {
   const text = buildDashboardTurnInputText({
     repository: "marushu/vtdd-v2-p",

--- a/test/production-deploy-path.test.js
+++ b/test/production-deploy-path.test.js
@@ -103,6 +103,7 @@ test("deploy-production workflow enforces the MVP production deploy boundary", (
     true
   );
   assert.equal(workflow.includes("Validate real passkey approval grant"), true);
+  assert.equal(workflow.includes("approval_grant_id is required for production deploy."), true);
   assert.equal(
     workflow.indexOf("Preflight Cloudflare Workers deploy entitlement") <
       workflow.indexOf("Validate real passkey approval grant"),
@@ -231,6 +232,11 @@ test("deploy-production workflow enforces the MVP production deploy boundary", (
   assert.equal(workflow.includes("authorization: Bearer ${VTDD_GATEWAY_BEARER_TOKEN}"), true);
   assert.equal(workflow.includes('APPROVAL_GRANT_ID: ${{ github.event.inputs.approval_grant_id }}'), true);
   assert.equal(workflow.includes('approvalGrantId: process.env.APPROVAL_GRANT_ID || null'), true);
+  assert.equal(
+    workflow.indexOf('APPROVAL_GRANT_ID: ${{ github.event.inputs.approval_grant_id }}') <
+      workflow.indexOf('approvalGrantId: process.env.APPROVAL_GRANT_ID || null'),
+    true
+  );
   assert.equal(workflow.includes("if: always()"), true);
   assert.equal(
     workflow.includes("DEPLOY_NOTIFICATION_ISSUE_NUMBER: ${{ vars.VTDD_DEPLOY_NOTIFICATION_ISSUE_NUMBER }}"),

--- a/test/production-deploy-path.test.js
+++ b/test/production-deploy-path.test.js
@@ -229,7 +229,8 @@ test("deploy-production workflow enforces the MVP production deploy boundary", (
   assert.equal(workflow.includes("          NODE\n              rm -f \"$response_file\""), true);
   assert.equal(workflow.includes("deploy remains successful, but dashboard may be stale until the next event"), true);
   assert.equal(workflow.includes("authorization: Bearer ${VTDD_GATEWAY_BEARER_TOKEN}"), true);
-  assert.equal(workflow.includes('approvalGrantId'), false);
+  assert.equal(workflow.includes('APPROVAL_GRANT_ID: ${{ github.event.inputs.approval_grant_id }}'), true);
+  assert.equal(workflow.includes('approvalGrantId: process.env.APPROVAL_GRANT_ID || null'), true);
   assert.equal(workflow.includes("if: always()"), true);
   assert.equal(
     workflow.includes("DEPLOY_NOTIFICATION_ISSUE_NUMBER: ${{ vars.VTDD_DEPLOY_NOTIFICATION_ISSUE_NUMBER }}"),

--- a/test/sync-dashboard-app-server-bridge-after-deploy.test.js
+++ b/test/sync-dashboard-app-server-bridge-after-deploy.test.js
@@ -11,6 +11,9 @@ function createFakeRunner({ dirty = false } = {}) {
     if (joined === "git rev-parse HEAD") {
       return { status: 0, stdout: `${head}\n`, stderr: "" };
     }
+    if (joined === "git rev-parse origin/main") {
+      return { status: 0, stdout: `${head === "after-sha" ? "after-sha" : "remote-before-sha"}\n`, stderr: "" };
+    }
     if (joined === "git status --short --branch") {
       return { status: 0, stdout: "## main...origin/main\n?? .tmp/\n", stderr: "" };
     }
@@ -62,6 +65,10 @@ test("deploy bridge sync/restart helper fast-forwards checkout and restarts unre
   assert.equal(result.status, "synced_and_restarted");
   assert.equal(result.runtimeTruth.beforeSha, "before-sha");
   assert.equal(result.runtimeTruth.afterSha, "after-sha");
+  assert.equal(result.runtimeTruth.targetRef, "origin/main");
+  assert.equal(result.runtimeTruth.targetRefSha, "after-sha");
+  assert.equal(result.runtimeTruth.syncVerified, true);
+  assert.equal(result.runtimeTruth.afterMatchesTargetRef, true);
   assert.equal(result.runtimeTruth.afterServiceMainPid, "1234");
   assert.deepEqual(fake.calls.filter((call) => call[0] === "systemctl" && call.includes("restart")), [
     ["systemctl", "--user", "restart", "vtdd-dashboard-app-server-bridge-unresolved.service"]

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -3367,6 +3367,14 @@ test("DashboardChatRoom passes VPS maintenance intent to app-server bridge when 
   const turnRequest = JSON.parse(bridgeSocket.sent[0]);
   assert.equal(turnRequest.type, "app_server_turn_requested");
   assert.equal(turnRequest.text, "Dashboard Butler から VPS runner status を確認して。root 実行は passkey 境界で止める。");
+  assert.equal(turnRequest.vpsMaintenancePassThrough.status, "passed_to_app_server_bridge");
+  assert.deepEqual(turnRequest.vpsMaintenancePassThrough.missingContext, ["repository", "relatedIssue"]);
+  assert.deepEqual(turnRequest.vpsMaintenancePassThrough.missingConfiguration, ["host", "workingDirectories"]);
+  assert.equal(turnRequest.vpsMaintenancePassThrough.rootExecutionStarted, false);
+  assert.equal(turnRequest.vpsMaintenancePassThrough.helperExecutionStarted, false);
+  assert.equal(turnRequest.vpsMaintenancePassThrough.workerProposalCreated, false);
+  assert.match(turnRequest.vpsMaintenancePassThrough.guidance.join("\n"), /実行を開始しない/);
+  assert.match(turnRequest.vpsMaintenancePassThrough.guidance.join("\n"), /不足している repository/);
   const finalBroadcast = dashboardSocket.sent.map((message) => JSON.parse(message)).find((message) => message.type === "thread");
   assert.equal(finalBroadcast.type, "thread");
   assert.equal(finalBroadcast.messages.length, 1);

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -3289,16 +3289,9 @@ test("worker reports Dashboard VPS maintenance config blockers before creating a
   assert.equal(response.status, 202);
   const body = await response.json();
   assert.equal(body.ok, true);
-  assert.equal(body.execution.status, "blocked");
-  assert.equal(body.execution.runtimeTruth.status, "vps_privileged_maintenance_context_required");
-  assert.equal(body.execution.runtimeTruth.dashboardNaturalLanguagePathReached, true);
-  assert.equal(body.execution.runtimeTruth.proposalCreated, false);
-  assert.deepEqual(body.execution.runtimeTruth.missingContext, ["relatedIssue"]);
-  assert.deepEqual(body.execution.runtimeTruth.missingConfiguration, ["host", "workingDirectories"]);
-  assert.match(body.messages[1].text, /関連 Issue: 未指定/);
-  assert.match(body.messages[1].text, /relatedIssue or issueNumber is required/);
-  assert.match(body.messages[1].text, /VTDD_DASHBOARD_VPS_MAINTENANCE_HOST/);
-  assert.match(body.messages[1].text, /rootExecutionStarted=false/);
+  assert.equal(body.execution, null);
+  assert.equal(body.messages.length, 1);
+  assert.equal(body.messages[0].role, "owner");
 
   const records = await provider.retrieve({ type: MemoryRecordType.APPROVAL_LOG, limit: 10 });
   assert.equal(records.length, 0);
@@ -3333,20 +3326,16 @@ test("worker uses only Dashboard maintenance runtime config for privileged maint
 
   assert.equal(response.status, 202);
   const body = await response.json();
-  assert.equal(body.execution.status, "blocked");
-  assert.equal(body.execution.runtimeTruth.status, "vps_privileged_maintenance_configuration_required");
-  assert.deepEqual(body.execution.runtimeTruth.missingConfiguration, ["host", "workingDirectories"]);
-  assert.match(body.messages[1].text, /VTDD_DASHBOARD_VPS_MAINTENANCE_HOST/);
-  assert.doesNotMatch(
-    body.messages[1].text,
-    /VTDD_VPS_RUNNER_HOST|VTDD_VPS_RUNNER_WORKDIR|VTDD_VPS_MAINTENANCE_HOST|VTDD_VPS_MAINTENANCE_WORKDIR|owner-chat-host|owner-chat-workdir/
-  );
+  assert.equal(body.execution, null);
+  assert.equal(body.messages.length, 1);
+  assert.equal(body.messages[0].role, "owner");
+  assert.doesNotMatch(JSON.stringify(body), /owner-chat-host|owner-chat-workdir/);
 
   const records = await provider.retrieve({ type: MemoryRecordType.APPROVAL_LOG, limit: 10 });
   assert.equal(records.length, 0);
 });
 
-test("DashboardChatRoom keeps VPS maintenance intent in Worker path when repo and config are missing", async () => {
+test("DashboardChatRoom passes VPS maintenance intent to app-server bridge when repo and config are missing", async () => {
   const provider = createInMemoryMemoryProvider();
   const store = createInMemoryDashboardChatStore();
   const dashboardSocket = createMockSocket("dashboard", "dashboard-main-unresolved");
@@ -3374,17 +3363,14 @@ test("DashboardChatRoom keeps VPS maintenance intent in Worker path when repo an
     })
   );
 
-  assert.equal(bridgeSocket.sent.length, 0);
-  const finalBroadcast = JSON.parse(dashboardSocket.sent.at(-1));
+  assert.equal(bridgeSocket.sent.length, 1);
+  const turnRequest = JSON.parse(bridgeSocket.sent[0]);
+  assert.equal(turnRequest.type, "app_server_turn_requested");
+  assert.equal(turnRequest.text, "Dashboard Butler から VPS runner status を確認して。root 実行は passkey 境界で止める。");
+  const finalBroadcast = dashboardSocket.sent.map((message) => JSON.parse(message)).find((message) => message.type === "thread");
   assert.equal(finalBroadcast.type, "thread");
-  assert.equal(finalBroadcast.messages.length, 2);
-  assert.equal(finalBroadcast.messages[1].role, "butler");
-  assert.equal(finalBroadcast.messages[1].status, "blocked");
-  assert.match(finalBroadcast.messages[1].text, /対象 repo: 未指定/);
-  assert.match(finalBroadcast.messages[1].text, /関連 Issue: 未指定/);
-  assert.match(finalBroadcast.messages[1].text, /proposal repository is required/);
-  assert.match(finalBroadcast.messages[1].text, /relatedIssue or issueNumber is required/);
-  assert.match(finalBroadcast.messages[1].text, /VTDD_DASHBOARD_VPS_MAINTENANCE_WORKDIR/);
+  assert.equal(finalBroadcast.messages.length, 1);
+  assert.equal(finalBroadcast.messages[0].role, "owner");
 
   const records = await provider.retrieve({ type: MemoryRecordType.APPROVAL_LOG, limit: 10 });
   assert.equal(records.length, 0);
@@ -6349,6 +6335,28 @@ test("worker ingests GitHub Actions deploy completion event and shows it on dash
   });
   await pushStore.put(pushKeys.subscription);
   const pushCalls = [];
+  const queueCalls = [];
+  await provider.store({
+    id: "approval:must-not-persist",
+    type: MemoryRecordType.APPROVAL_LOG,
+    content: {
+      kind: "passkey_grant",
+      status: "verified",
+      approvalId: "approval:must-not-persist",
+      credentialId: "AQIDBA",
+      verifiedAt: "2026-05-20T00:09:00.000Z",
+      expiresAt: "2999-01-01T00:00:00.000Z",
+      scope: {
+        actionType: "deploy_production",
+        highRiskKind: "deploy_production",
+        repositoryInput: "marushu/vtdd-v2-p"
+      }
+    },
+    metadata: { source: "deploy-event-test" },
+    priority: 96,
+    tags: ["passkey_grant", "passkey_approval", "verified"],
+    createdAt: "2026-05-20T00:09:00.000Z"
+  });
   const vapidEnv = await createTestVapidEnv({
     DASHBOARD_WEB_PUSH_FETCH: async (input, init) => {
       pushCalls.push({ input, init });
@@ -6385,7 +6393,18 @@ test("worker ingests GitHub Actions deploy completion event and shows it on dash
       DASHBOARD_PUSH_SUBSCRIPTION_STORE: pushStore,
       MEMORY_PROVIDER: provider,
       VTDD_DASHBOARD_VPS_MAINTENANCE_HOST: "x85-131-245-163",
-      VTDD_DASHBOARD_VPS_MAINTENANCE_WORKDIR: "/home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p"
+      VTDD_DASHBOARD_VPS_MAINTENANCE_WORKDIR: "/home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p",
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_deploy_bridge_followup",
+      GITHUB_API_FETCH: async (url, init) => {
+        queueCalls.push({ url, init });
+        return new Response(
+          JSON.stringify({
+            id: 74101,
+            html_url: "https://github.com/marushu/vtdd-v2-p/issues/741#issuecomment-74101"
+          }),
+          { status: 201, headers: { "content-type": "application/json" } }
+        );
+      }
     }
   );
 
@@ -6411,30 +6430,32 @@ test("worker ingests GitHub Actions deploy completion event and shows it on dash
   assert.equal(eventBody.messages[0].status, "replied");
   assert.equal(eventBody.messages[0].text.includes("デプロイ完了イベントを受信しました。"), true);
   assert.equal(eventBody.messages[0].text.includes("- PR: PR #552"), true);
-  assert.equal(eventBody.messages[0].text.includes("deploy 後 bridge sync/restart approval URL を同じ chat に出します。"), true);
+  assert.equal(eventBody.messages[0].text.includes("deploy 後 bridge sync/restart helper queue handoff を同じ chat に出します。"), true);
   assert.equal(eventBody.messages[0].text.includes("- production E2E / runtime truth を確認します。"), true);
   assert.equal(eventBody.messages[0].text.includes("merge / deploy / credential / permission"), true);
   assert.equal(eventBody.messages[1].messageId, "dashboard-event:github-actions:marushu/vtdd-v2-p:deploy-production:26133044458:deploy-bridge-followup");
   assert.equal(eventBody.messages[1].role, "system");
-  assert.equal(eventBody.messages[1].status, "blocked");
+  assert.equal(eventBody.messages[1].status, "sent");
   assert.equal(eventBody.messages[1].relatedIssue, 741);
-  assert.equal(eventBody.messages[1].text.includes("deploy 後 bridge sync/restart の承認が必要です。"), true);
+  assert.equal(eventBody.messages[1].text.includes("deploy 後 bridge sync/restart を VPS helper queue へ渡しました。"), true);
   assert.equal(eventBody.messages[1].text.includes("vtdd-dashboard-app-server-bridge-unresolved.service"), true);
-  assert.equal(eventBody.messages[1].text.includes("status=approval_required, rootExecutionStarted=false, helperExecutionStarted=false"), true);
-  assert.equal(eventBody.deployBridgeFollowup.status, "approval_required");
-  assert.equal(eventBody.deployBridgeFollowup.proposalCreated, true);
-  assert.equal(eventBody.deployBridgeFollowup.approvalScope.vpsCapabilityId, "dashboard.bridge.unresolved.deploy.sync.restart");
-  const followupApprovalUrl = new URL(eventBody.deployBridgeFollowup.approvalOperatorUrl);
-  assert.equal(followupApprovalUrl.searchParams.get("mode"), "vps");
-  assert.equal(followupApprovalUrl.searchParams.get("dashboardThreadId"), "dashboard-main-marushu-vtdd-v2-p");
-  assert.equal(followupApprovalUrl.searchParams.get("vpsProposalId"), eventBody.deployBridgeFollowup.vpsProposalId);
-  const approvalRecords = await provider.retrieve({ type: MemoryRecordType.APPROVAL_LOG, limit: 10 });
-  const followupProposalRecord = approvalRecords.find((record) => record.id === eventBody.deployBridgeFollowup.vpsProposalId);
-  assert.equal(followupProposalRecord.content.proposal.capability.commandClass, "dashboard_bridge_unresolved_deploy_sync_restart");
-  assert.deepEqual(followupProposalRecord.content.proposal.capability.allowedArgs, [
-    "node scripts/sync-dashboard-app-server-bridge-after-deploy.mjs --service vtdd-dashboard-app-server-bridge-unresolved.service --ref origin/main"
-  ]);
+  assert.equal(eventBody.messages[1].text.includes("追加 passkey は不要です。"), true);
+  assert.equal(eventBody.messages[1].text.includes("status=queued_for_vps_helper_execution, rootExecutionStarted=false, helperExecutionStarted=false"), true);
+  assert.equal(eventBody.deployBridgeFollowup.status, "queued_for_vps_helper_execution");
+  assert.equal(eventBody.deployBridgeFollowup.proposalCreated, false);
+  assert.equal(eventBody.deployBridgeFollowup.queueCreated, true);
+  assert.equal(eventBody.deployBridgeFollowup.runtimeTruth.helperQueueReached, true);
+  assert.equal(eventBody.deployBridgeFollowup.runtimeTruth.rootExecutionStarted, false);
+  assert.equal(eventBody.deployBridgeFollowup.runtimeTruth.helperExecutionStarted, false);
+  assert.equal(queueCalls.length, 1);
+  const queueCommentBody = JSON.parse(queueCalls[0].init.body).body;
+  assert.equal(queueCommentBody.includes("vtdd:vps-privileged-maintenance-execution:deploy-bridge-followup-26133044458"), true);
+  assert.equal(queueCommentBody.includes('"commandClass": "dashboard_bridge_unresolved_deploy_sync_restart"'), true);
+  assert.equal(queueCommentBody.includes("sync-dashboard-app-server-bridge-after-deploy.mjs"), true);
+  assert.equal(queueCommentBody.includes("deploy-approval-verified-redacted"), true);
+  assert.equal(queueCommentBody.includes("approval:must-not-persist"), false);
   assert.equal(JSON.stringify(eventBody.messages).includes("approval:must-not-persist"), false);
+  assert.equal(JSON.stringify(eventBody.deployBridgeFollowup).includes("approval:must-not-persist"), false);
   assert.equal(JSON.stringify(eventBody.messages).includes("secret-must-not-persist"), false);
   assert.equal(eventBody.webSocketBroadcast, true);
   assert.equal(rooms.calls.length, 1);
@@ -6481,70 +6502,8 @@ test("worker ingests GitHub Actions deploy completion event and shows it on dash
   assert.equal(chatBody.messages[0].text.includes("デプロイ完了イベントを受信しました。"), true);
   assert.equal(chatBody.messages[0].text.includes("- PR: PR #552"), true);
   assert.equal(chatBody.messages[0].text.includes("bare #552"), false);
-  assert.equal(chatBody.messages[1].text.includes("approval URL:"), true);
-
-  await provider.store({
-    id: "approval:deploy-bridge-followup",
-    type: MemoryRecordType.APPROVAL_LOG,
-    content: {
-      kind: "passkey_grant",
-      status: "verified",
-      approvalId: "approval:deploy-bridge-followup",
-      credentialId: "AQIDBA",
-      verifiedAt: "2026-05-20T00:11:00.000Z",
-      expiresAt: "2999-01-01T00:00:00.000Z",
-      scope: eventBody.deployBridgeFollowup.approvalScope
-    },
-    metadata: { source: "deploy-bridge-followup-test" },
-    priority: 96,
-    tags: ["passkey_grant", "passkey_approval", "verified"],
-    createdAt: "2026-05-20T00:11:00.000Z"
-  });
-  const queueCalls = [];
-  const approvedResponse = await worker.fetch(
-    new Request("https://example.com/v2/dashboard/chat/messages", {
-      method: "POST",
-      headers: gatewayAuthHeaders,
-      body: JSON.stringify({
-        threadId: "dashboard-main-marushu-vtdd-v2-p",
-        repository: "marushu/vtdd-v2-p",
-        issueNumber: 741,
-        text: "deploy 後 bridge sync/restart を承認済みなので進めて。",
-        vpsProposalId: eventBody.deployBridgeFollowup.vpsProposalId,
-        approvalGrantId: "approval:deploy-bridge-followup",
-        executionId: "deploy-bridge-followup-26133044458"
-      })
-    }),
-    {
-      ...gatewayAuthEnv,
-      DASHBOARD_CHAT_STORE: chatStore,
-      MEMORY_PROVIDER: provider,
-      VTDD_DASHBOARD_VPS_MAINTENANCE_HOST: "x85-131-245-163",
-      VTDD_DASHBOARD_VPS_MAINTENANCE_WORKDIR: "/home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p",
-      GITHUB_APP_INSTALLATION_TOKEN: "ghs_deploy_bridge_followup",
-      GITHUB_API_FETCH: async (url, init) => {
-        queueCalls.push({ url, init });
-        return new Response(
-          JSON.stringify({
-            id: 74101,
-            html_url: "https://github.com/marushu/vtdd-v2-p/issues/741#issuecomment-74101"
-          }),
-          { status: 201, headers: { "content-type": "application/json" } }
-        );
-      }
-    }
-  );
-  assert.equal(approvedResponse.status, 202);
-  const approvedBody = await approvedResponse.json();
-  assert.equal(approvedBody.execution.status, "queued_for_vps_helper_execution");
-  assert.equal(approvedBody.execution.runtimeTruth.helperQueueReached, true);
-  assert.equal(approvedBody.execution.runtimeTruth.rootExecutionStarted, false);
-  assert.equal(approvedBody.execution.runtimeTruth.helperExecutionStarted, false);
-  assert.equal(queueCalls.length, 1);
-  const queueCommentBody = JSON.parse(queueCalls[0].init.body).body;
-  assert.equal(queueCommentBody.includes("vtdd:vps-privileged-maintenance-execution:deploy-bridge-followup-26133044458"), true);
-  assert.equal(queueCommentBody.includes('"commandClass": "dashboard_bridge_unresolved_deploy_sync_restart"'), true);
-  assert.equal(queueCommentBody.includes("sync-dashboard-app-server-bridge-after-deploy.mjs"), true);
+  assert.equal(chatBody.messages[1].text.includes("approval URL:"), false);
+  assert.equal(chatBody.messages[1].text.includes("追加 passkey は不要です。"), true);
 
   const duplicateResponse = await worker.fetch(
     new Request("https://example.com/v2/events/github-actions", {
@@ -6590,14 +6549,14 @@ test("worker ingests GitHub Actions deploy completion event and shows it on dash
     { ...dashboardAccessEnv, DASHBOARD_CHAT_STORE: chatStore }
   );
   const duplicateChatBody = await duplicateChat.json();
-  assert.equal(duplicateChatBody.messages.length, 4);
+  assert.equal(duplicateChatBody.messages.length, 2);
   assert.equal(duplicateChatBody.messages[0].messageId, "dashboard-event:github-actions:marushu/vtdd-v2-p:deploy-production:26133044458");
   assert.equal(duplicateBody.deployBridgeFollowup.status, "duplicate_event_skipped");
   const approvalRecordsAfterDuplicate = await provider.retrieve({ type: MemoryRecordType.APPROVAL_LOG, limit: 20 });
   const duplicateFollowupProposals = approvalRecordsAfterDuplicate.filter(
     (record) => record.content?.proposal?.capability?.commandClass === "dashboard_bridge_unresolved_deploy_sync_restart"
   );
-  assert.equal(duplicateFollowupProposals.length, 1);
+  assert.equal(duplicateFollowupProposals.length, 0);
   const runtimeSource = await fs.readFile(path.join(process.cwd(), "src", "worker", "runtime.js"), "utf8");
   assert.equal(runtimeSource.includes("PRIMARY KEY (thread_id, message_id)"), true);
   assert.equal(runtimeSource.includes("INSERT OR REPLACE INTO vtdd_dashboard_chat_messages"), true);

--- a/worker.js
+++ b/worker.js
@@ -58339,6 +58339,12 @@ var DashboardChatRoom = class {
       relatedIssue,
       text
     });
+    const vpsMaintenancePassThrough = buildDashboardVpsMaintenancePassThroughContext({
+      text,
+      repository,
+      relatedIssue,
+      env: this.env
+    });
     const mapping = await this.readAppServerThreadMapping(threadId);
     const turnRequest = {
       type: "app_server_turn_requested",
@@ -58359,7 +58365,8 @@ var DashboardChatRoom = class {
       authority: buildDashboardAppServerAuthorityHint({ repository, relatedIssue, text }),
       usageProfile,
       costBoundary,
-      trafficControl
+      trafficControl,
+      vpsMaintenancePassThrough
     };
     return this.sendSocket(bridgeSocket, turnRequest);
   }
@@ -68724,6 +68731,41 @@ function buildDashboardVpsMaintenanceProposalPreflight({ proposalPayload, reposi
     missingContext,
     missingConfiguration,
     nextAction
+  };
+}
+function buildDashboardVpsMaintenancePassThroughContext({ text, repository, relatedIssue, env } = {}) {
+  if (!detectDashboardVpsPrivilegedMaintenanceIntent({ text })) {
+    return null;
+  }
+  const proposalPayload = buildDashboardVpsMaintenanceProposalPayload({
+    payload: { text },
+    repository,
+    relatedIssue,
+    env
+  });
+  const preflight = buildDashboardVpsMaintenanceProposalPreflight({
+    proposalPayload,
+    repository,
+    relatedIssue
+  });
+  if (preflight.ok) {
+    return null;
+  }
+  return {
+    kind: "dashboard_vps_maintenance_pass_through",
+    status: "passed_to_app_server_bridge",
+    reason: preflight.reason,
+    missingContext: preflight.missingContext || [],
+    missingConfiguration: preflight.missingConfiguration || [],
+    rootExecutionStarted: false,
+    helperExecutionStarted: false,
+    workerProposalCreated: false,
+    guidance: [
+      "Dashboard Butler \u306F\u3053\u306E VPS maintenance intent \u3092 Worker blocker \u3067\u6B62\u3081\u305A app-server bridge \u3078\u6E21\u3057\u307E\u3057\u305F\u3002",
+      "VPS / root / helper / restart / deploy recovery \u306E\u5B9F\u884C\u3092\u958B\u59CB\u3057\u306A\u3044\u3067\u304F\u3060\u3055\u3044\u3002",
+      "\u4E0D\u8DB3\u3057\u3066\u3044\u308B repository\u3001related Issue\u3001\u307E\u305F\u306F runtime config \u3092\u65E5\u672C\u8A9E\u3067\u77ED\u304F\u78BA\u8A8D\u3057\u3066\u304F\u3060\u3055\u3044\u3002",
+      "owner \u304C deploy \u5F8C bridge sync/restart \u3092\u6C42\u3081\u3066\u3044\u308B\u5834\u5408\u306F\u3001deploy standard post-step / helper queue truth \u3092\u78BA\u8A8D\u3057\u3066\u304B\u3089\u6848\u5185\u3057\u3066\u304F\u3060\u3055\u3044\u3002"
+    ]
   };
 }
 function detectDashboardVpsPrivilegedMaintenanceIntent({ text } = {}) {

--- a/worker.js
+++ b/worker.js
@@ -58381,6 +58381,9 @@ var DashboardChatRoom = class {
       origin: normalizeText33(origin) || normalizeText33(this.env?.VTDD_RUNTIME_URL || this.env?.VTDD_PASSKEY_ORIGIN) || "https://dashboard-butler.local",
       env: this.env
     });
+    if (!shouldDashboardVpsMaintenanceFlowStayInWorker(flow)) {
+      return null;
+    }
     return [
       normalizeDashboardChatMessage(
         {
@@ -62248,7 +62251,8 @@ async function handleGitHubActionsEventRequest(request, env) {
     event: baseEvent,
     threadId,
     env,
-    origin: new URL(request.url).origin
+    origin: new URL(request.url).origin,
+    approvalGrantId: normalizeText33(payload?.approvalGrantId || payload?.approval_grant_id)
   });
   const chatMessages = [chatMessage, deployBridgeFollowup.message].filter(Boolean);
   const chatStore = resolveDashboardChatStore(env);
@@ -62318,7 +62322,7 @@ function isSuccessfulDeployWorkflowEvent(event) {
   const record2 = normalizeDashboardEventRecord(event);
   return record2.kind === "github_actions_workflow_run" && normalize7(record2.workflowName).includes("deploy") && normalizeDashboardEventText(record2.status).toLowerCase() === "completed" && normalizeDashboardEventText(record2.conclusion).toLowerCase() === "success";
 }
-async function buildDeployBridgeFollowupChatMessage({ event, threadId, env, origin } = {}) {
+async function buildDeployBridgeFollowupChatMessage({ event, threadId, env, origin, approvalGrantId } = {}) {
   const record2 = normalizeDashboardEventRecord(event);
   const repository = normalizeCanonicalRepositoryInput(record2.repository);
   const relatedIssue = normalizePositiveInteger10(record2.issueNumber) || normalizePositiveInteger10(env?.VTDD_DASHBOARD_DEPLOY_BRIDGE_FOLLOWUP_ISSUE) || 741;
@@ -62354,14 +62358,175 @@ async function buildDeployBridgeFollowupChatMessage({ event, threadId, env, orig
       )
     };
   }
+  const deployApproval = await resolveApprovalGrant({
+    payload: {},
+    policyInput: { approvalGrantId },
+    env
+  });
+  const approvalValidation = validateDeployApprovalGrant({
+    approvalGrant: deployApproval.approvalGrant,
+    repositoryInput: repository
+  });
+  if (!approvalValidation.ok) {
+    return {
+      status: "blocked",
+      proposalCreated: false,
+      queueCreated: false,
+      error: "deploy_bridge_followup_approval_required",
+      issues: approvalValidation.issues || [deployApproval.warning || "deploy approval grant required"],
+      message: normalizeDashboardChatMessage(
+        {
+          threadId,
+          messageId,
+          role: "system",
+          repository,
+          relatedIssue,
+          status: "blocked",
+          text: buildDeployBridgeFollowupBlockedMessage({
+            record: record2,
+            repository,
+            relatedIssue,
+            issues: approvalValidation.issues || [deployApproval.warning || "deploy approval grant required"]
+          }),
+          createdAt: record2.updatedAt || record2.createdAt
+        },
+        { threadId }
+      )
+    };
+  }
   const executionId = `deploy-bridge-followup-${safeIdentifier(record2.runId) || createDashboardRequestId("deploy")}`;
-  const allowedArg = "node scripts/sync-dashboard-app-server-bridge-after-deploy.mjs --service vtdd-dashboard-app-server-bridge-unresolved.service --ref origin/main";
-  const proposal = await createVpsPrivilegedMaintenanceProposal({
+  const helperRequest = buildDeployBridgeFollowupHelperRequest({
+    record: record2,
+    repository,
+    relatedIssue,
+    host,
+    workingDirectory,
+    threadId,
+    deployApproval: deployApproval.approvalGrant
+  });
+  const manifest = buildDashboardVpsMaintenanceManifest({
+    helperRequest,
+    now: record2.updatedAt || record2.createdAt
+  });
+  const execution = createVpsPrivilegedMaintenanceHelperExecution({
     payload: {
-      host,
+      manifest,
+      helperRequest,
+      now: record2.updatedAt || record2.createdAt
+    }
+  });
+  if (!execution.ok) {
+    return {
+      status: "blocked",
+      proposalCreated: false,
+      queueCreated: false,
+      error: execution.error,
+      issues: execution.issues || [],
+      message: normalizeDashboardChatMessage(
+        {
+          threadId,
+          messageId,
+          role: "system",
+          repository,
+          relatedIssue,
+          status: "blocked",
+          text: buildDeployBridgeFollowupBlockedMessage({
+            record: record2,
+            repository,
+            relatedIssue,
+            issues: execution.issues || [execution.error || "execution_handoff_failed"]
+          }),
+          createdAt: record2.updatedAt || record2.createdAt
+        },
+        { threadId }
+      )
+    };
+  }
+  const queue = await createVpsPrivilegedMaintenanceHelperExecutionQueue({
+    payload: {
       repository,
-      relatedIssue,
-      operation: "enable",
+      issueNumber: relatedIssue,
+      executionId,
+      dashboardThreadId: threadId,
+      approvalActor: "Dashboard deploy approval",
+      executionEnvelope: execution.body.executionEnvelope
+    },
+    env
+  });
+  if (!queue.ok) {
+    return {
+      status: "blocked",
+      proposalCreated: false,
+      queueCreated: false,
+      error: queue.error,
+      reason: queue.reason,
+      issues: queue.issues || [],
+      message: normalizeDashboardChatMessage(
+        {
+          threadId,
+          messageId,
+          role: "system",
+          repository,
+          relatedIssue,
+          status: "blocked",
+          text: buildDeployBridgeFollowupBlockedMessage({
+            record: record2,
+            repository,
+            relatedIssue,
+            issues: queue.issues || [queue.reason || queue.error || "queue_handoff_failed"]
+          }),
+          createdAt: record2.updatedAt || record2.createdAt
+        },
+        { threadId }
+      )
+    };
+  }
+  return {
+    status: "queued_for_vps_helper_execution",
+    proposalCreated: false,
+    queueCreated: true,
+    execution: queue.body.execution,
+    runtimeTruth: {
+      ...queue.body.runtimeTruth || {},
+      deployApprovalValidated: true,
+      deployStandardPostStep: "dashboard_bridge_unresolved_deploy_sync_restart",
+      helperQueueReached: true,
+      rootExecutionStarted: false,
+      helperExecutionStarted: false
+    },
+    message: normalizeDashboardChatMessage(
+      {
+        threadId,
+        messageId,
+        role: "system",
+        repository,
+        relatedIssue,
+        status: "sent",
+        text: buildDeployBridgeFollowupQueuedMessage({
+          record: record2,
+          repository,
+          relatedIssue,
+          queue: queue.body
+        }),
+        createdAt: record2.updatedAt || record2.createdAt
+      },
+      { threadId }
+    )
+  };
+}
+function buildDeployBridgeFollowupHelperRequest({ record: record2, repository, relatedIssue, host, workingDirectory, threadId, deployApproval } = {}) {
+  const allowedArg = "node scripts/sync-dashboard-app-server-bridge-after-deploy.mjs --service vtdd-dashboard-app-server-bridge-unresolved.service --ref origin/main";
+  return {
+    kind: "vps_privileged_maintenance_helper_request",
+    status: "ready_for_vps_helper",
+    requestId: createDashboardRequestId("deploy-bridge-helper-request"),
+    vpsProposalId: `deploy-standard-post-step:${safeIdentifier(record2.runId) || createDashboardRequestId("deploy")}`,
+    approvalGrantId: "deploy-approval-verified-redacted",
+    host,
+    repository,
+    relatedIssue,
+    operation: "enable",
+    capability: {
       id: "dashboard.bridge.unresolved.deploy.sync.restart",
       title: "Deploy\u5F8C repo-less Dashboard bridge sync/restart",
       commandClass: "dashboard_bridge_unresolved_deploy_sync_restart",
@@ -62375,78 +62540,48 @@ async function buildDeployBridgeFollowupChatMessage({ event, threadId, env, orig
         "vtdd-dashboard-app-server-bridge-unresolved.service"
       ],
       redactionRules: ["no secrets", "summarize stdout/stderr", "redact tokens and credentials"],
-      rollbackPlan: "stop auto follow-up proposal and restart the previous bridge service state manually if needed",
+      rollbackPlan: "stop deploy standard post-step queueing and restart the previous bridge service state manually if needed",
       expectedRuntimeTruth: [
         "before git HEAD",
+        "target ref",
+        "target ref SHA",
+        "sync verified after git HEAD matches origin/main",
         "after git HEAD",
         "before service active state",
         "after service active state",
         "after service main PID",
+        "pending owner messages replay source",
         "exit code"
-      ],
-      reason: `Issue #741 deploy run ${record2.runId} success at ${record2.headSha || "unknown sha"} requires VPS checkout sync and repo-less bridge restart follow-up`,
-      impactScope: `${workingDirectory}, vtdd-dashboard-app-server-bridge-unresolved.service`,
-      dashboardThreadId: threadId,
-      executionId
+      ]
     },
-    provider,
-    origin: origin || "https://example.com"
-  });
-  if (!proposal.ok) {
-    return {
-      status: "blocked",
-      proposalCreated: false,
-      error: proposal.error,
-      issues: proposal.issues || [],
-      message: normalizeDashboardChatMessage(
-        {
-          threadId,
-          messageId,
-          role: "system",
-          repository,
-          relatedIssue,
-          status: "blocked",
-          text: buildDeployBridgeFollowupBlockedMessage({
-            record: record2,
-            repository,
-            relatedIssue,
-            issues: proposal.issues || [proposal.error || "proposal_failed"]
-          }),
-          createdAt: record2.updatedAt || record2.createdAt
-        },
-        { threadId }
-      )
-    };
-  }
-  return {
-    status: "approval_required",
-    proposalCreated: true,
-    vpsProposalId: proposal.body.vpsProposalId,
-    approvalScope: proposal.body.approvalScope,
-    approvalOperatorUrl: proposal.body.approvalOperatorUrl,
-    message: normalizeDashboardChatMessage(
-      {
-        threadId,
-        messageId,
-        role: "system",
-        repository,
-        relatedIssue,
-        status: "blocked",
-        text: buildDeployBridgeFollowupApprovalRequiredMessage({
-          record: record2,
-          repository,
-          relatedIssue,
-          proposal: proposal.body
-        }),
-        createdAt: record2.updatedAt || record2.createdAt
-      },
-      { threadId }
-    )
+    approvalScope: {
+      actionType: "deploy_production",
+      highRiskKind: "deploy_production",
+      repositoryInput: repository,
+      phase: "deploy_standard_post_step",
+      display: {
+        operation: "deploy_production",
+        postStep: "dashboard_bridge_unresolved_deploy_sync_restart",
+        deployApprovalId: deployApproval?.approvalId ? "redacted" : ""
+      }
+    },
+    handoff: {
+      dashboardThreadId: threadId,
+      restartStrategy: {
+        pendingOwnerMessagesPersistedBy: "DashboardChatRoom pending_app_server_owner_messages",
+        bridgeReconnectPath: "app-server bridge reconnect resumes dashboard thread mapping and drains pending owner messages",
+        activeTurnHandling: "restart is queued after deploy completion; Worker does not drop stored dashboard owner messages; live app-server stream resume remains VPS runner truth"
+      }
+    },
+    rootExecutionStarted: false,
+    helperExecutionStarted: false,
+    redacted: true
   };
 }
-function buildDeployBridgeFollowupApprovalRequiredMessage({ record: record2, repository, relatedIssue, proposal } = {}) {
+function buildDeployBridgeFollowupQueuedMessage({ record: record2, repository, relatedIssue, queue } = {}) {
+  const execution = queue?.execution || {};
   return [
-    "deploy \u5F8C bridge sync/restart \u306E\u627F\u8A8D\u304C\u5FC5\u8981\u3067\u3059\u3002",
+    "deploy \u5F8C bridge sync/restart \u3092 VPS helper queue \u3078\u6E21\u3057\u307E\u3057\u305F\u3002",
     "",
     `- repo: ${repository || "\u672A\u78BA\u8A8D"}`,
     `- related Issue: #${relatedIssue || 741}`,
@@ -62454,12 +62589,13 @@ function buildDeployBridgeFollowupApprovalRequiredMessage({ record: record2, rep
     `- deploy sha: ${record2.headSha ? record2.headSha.slice(0, 12) : "\u672A\u78BA\u8A8D"}`,
     "- \u5BFE\u8C61: repo-less Dashboard app-server bridge",
     "- service: vtdd-dashboard-app-server-bridge-unresolved.service",
-    `- vpsProposalId: ${proposal?.vpsProposalId || "\u672A\u4F5C\u6210"}`,
-    "- authority: deploy approval \u3068\u306F\u5225\u306E scoped passkey approval \u304C\u5FC5\u8981\u3067\u3059\u3002",
-    "- runtime truth: status=approval_required, rootExecutionStarted=false, helperExecutionStarted=false",
-    proposal?.approvalOperatorUrl ? `- approval URL: ${proposal.approvalOperatorUrl}` : "- approval URL: \u672A\u751F\u6210",
+    `- executionId: ${execution.executionId || "\u672A\u751F\u6210"}`,
+    `- queueCommentUrl: ${execution.queueCommentUrl || "\u672A\u53D6\u5F97"}`,
+    "- authority: deploy approval \u306B\u542B\u307E\u308C\u308B\u6A19\u6E96\u5F8C\u51E6\u7406\u3067\u3059\u3002\u8FFD\u52A0 passkey \u306F\u4E0D\u8981\u3067\u3059\u3002",
+    "- restart guard: Dashboard \u306E pending owner messages \u306F\u4FDD\u5B58\u6E08\u307F queue \u304B\u3089 bridge reconnect \u5F8C\u306B\u518D\u9001\u3057\u307E\u3059\u3002",
+    "- runtime truth: status=queued_for_vps_helper_execution, rootExecutionStarted=false, helperExecutionStarted=false",
     "",
-    "\u627F\u8A8D\u5F8C\u306F Dashboard chat \u304C VPS helper queue \u3078 fixed sync/restart command \u3092\u6E21\u3057\u307E\u3059\u3002VPS runner \u306E before/after truth \u304C\u623B\u308B\u307E\u3067 live restart \u5B8C\u4E86\u3068\u306F\u6271\u3044\u307E\u305B\u3093\u3002"
+    "VPS runner pickup \u306E before/after truth \u304C\u623B\u308B\u307E\u3067\u3001live restart \u5B8C\u4E86\u3068\u306F\u6271\u3044\u307E\u305B\u3093\u3002"
   ].join("\n");
 }
 function buildDeployBridgeFollowupBlockedMessage({ record: record2, repository, relatedIssue, issues } = {}) {
@@ -68292,7 +68428,8 @@ async function buildDashboardChatTurn(payload, options = {}) {
     origin: options.origin,
     env: options.env
   }) : null;
-  const butlerMessage = hasVpsPrivilegedMaintenanceIntent ? normalizeDashboardChatMessage(
+  const keepVpsMaintenanceInWorker = shouldDashboardVpsMaintenanceFlowStayInWorker(vpsMaintenanceFlow);
+  const butlerMessage = keepVpsMaintenanceInWorker ? normalizeDashboardChatMessage(
     {
       threadId,
       role: "butler",
@@ -68310,8 +68447,12 @@ async function buildDashboardChatTurn(payload, options = {}) {
     relatedIssue,
     threadId,
     messages: [ownerMessage, butlerMessage].filter(Boolean),
-    execution: vpsMaintenanceFlow?.execution || null
+    execution: keepVpsMaintenanceInWorker ? vpsMaintenanceFlow?.execution || null : null
   };
+}
+function shouldDashboardVpsMaintenanceFlowStayInWorker(flow = null) {
+  const status = normalizeText33(flow?.execution?.status || flow?.messageStatus);
+  return ["approval_required", "queued_for_vps_helper_execution", "sent"].includes(status);
 }
 async function buildDashboardVpsPrivilegedMaintenanceNaturalLanguageFlow({
   payload,
@@ -69998,7 +70139,7 @@ function buildGitHubActionsDashboardChatMessageText(event) {
   }
   lines.push("", "\u6B21:");
   if (isDeploy && conclusion === "success") {
-    lines.push("- deploy \u5F8C bridge sync/restart approval URL \u3092\u540C\u3058 chat \u306B\u51FA\u3057\u307E\u3059\u3002");
+    lines.push("- deploy \u5F8C bridge sync/restart helper queue handoff \u3092\u540C\u3058 chat \u306B\u51FA\u3057\u307E\u3059\u3002");
     lines.push("- production E2E / runtime truth \u3092\u78BA\u8A8D\u3057\u307E\u3059\u3002");
   } else if (conclusion === "failure" || conclusion === "cancelled" || conclusion === "timed_out") {
     lines.push("- deploy / Actions \u306E\u5931\u6557\u539F\u56E0\u3092\u78BA\u8A8D\u3057\u3001blocker \u3068\u6B21 action \u3092\u51FA\u3057\u307E\u3059\u3002");


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #741 の deploy 後 bridge sync/restart 標準後処理を、追加 passkey なしで既存 deploy flow に接続します。
- Issue #637 の VPS helper queue handoff を deploy success event から使い、repo-less Dashboard app-server bridge を最新 main に合わせて restart する固定 command envelope を発行します。
- Issue #455 の使用量調整検証前提として、deploy 後に unresolved bridge が最新 source / latest main へ追従することを runtime truth で確認できるようにします。
- Dashboard Butler が repo/Issue/config 欠落 blocker を自前で返して止めるのではなく、app-server bridge に自然文を届ける経路へ戻します。

## Satisfied Success Criteria

- deploy-production workflow の deploy completion event が machine-only `approvalGrantId` を Worker に渡します。
- Worker は stored deploy passkey grant を再検証し、owner-facing event / chat / Web Push / response に approvalGrantId を残さず、固定 `dashboard_bridge_unresolved_deploy_sync_restart` helper queue comment を作ります。
- deploy 後 bridge sync/restart は追加 passkey URL を出さず、deploy approval に含まれる標準後処理として扱います。
- helper script は `git fetch origin main` / `git pull --ff-only origin main` 後に unresolved bridge service を restart し、before/after SHA、target ref SHA、`syncVerified`、service active state を runtime truth へ返します。
- Dashboard Butler Durable Object は Worker で blocker を作れない VPS maintenance intent を app-server bridge へ流します。
- `worker.js` generated bundle を source と同期しました。

## Unsatisfied Success Criteria

- live production deploy 後に VPS runner が実際に queue comment を拾い、before/after runtime truth を返す E2E は merge/deploy 後に実施します。
- app-server stream 中の active turn の完全再実行保証は未完了です。このPRでは Dashboard の pending owner messages replay source と bridge reconnect 前提を queue truth に含め、live resume 完了は VPS runner truth で確認します。

## Non-goal violations

None.

## 開発前作戦図

- 作戦図 evidence: docs/development-strategy/issue-741-deploy-bridge-restart-automation.md
- 完了体験: owner は Dashboard Butler で deploy passkey を一度承認するだけでよい。deploy 成功後、Dashboard Butler chat に bridge sync/restart helper queue handoff が自動追記され、追加 passkey は要求されない。
- VTDD 全体で進める部分: Dashboard Butler -> Worker deploy event -> VPS helper queue -> unresolved app-server bridge sync/restart の owner-facing deploy 後運用を一塊で接続します。
- 設計: owner-facing deploy 完了の設計として、`deploy-production.yml` が deploy event に approvalGrantId を machine-only で添付し、Worker が stored grant を `deploy_production` scope / repository / expiry で検証して固定 helper envelope を queue comment 化します。Worker は root/helper execution を開始しません。
- 仮説: 仮説は、失敗の原因が deploy 後 restart を別 approval proposal に切ったことと、repo-less chat の maintenance intent を Worker blocker で止めたことにある、というものです。既存 deploy approval と app-server relay に戻せば passkey 地獄と blocker が消えます。
- 検証計画: deploy event ingestion、approvalGrantId redaction、helper queue comment、duplicate event skip、VPS maintenance pass-through、sync script SHA/ref/service truth、worker generated parity を unit/integration test で検証します。
- 改修見積もり: .github/workflows/deploy-production.yml は event payload、src/worker/runtime.js は deploy follow-up / pass-through、scripts/sync-dashboard-app-server-bridge-after-deploy.mjs は git sync verification、test/worker.test.js と worker.js を更新します。
- 既に通っている経路: deploy approval -> /v2/action/deploy -> workflow dispatch、GitHub Actions deploy event ingestion、VPS helper queue comment、unresolved bridge fixed command registry、DashboardChatRoom pending message replay は既存です。
- 未確認の境界: live VPS runner pickup と active app-server turn の完全 replay は production E2E で確認します。Worker は root/helper execution を直接開始しません。
- 穴が出そうな箇所: approvalGrantId の owner-facing leak、duplicate deploy event の二重 queue、任意 command 化、GitHub Actions に VPS root credential を広げること、repo-less chat を Worker blocker で止めること。
- PR 前に確認すること: strategy doc、deploy workflow、runtime follow-up、sync script、worker tests、generated worker parity、diff check を確認します。
- 実装候補と捨てた案: 採用は既存 deploy approval を標準後処理に使う fixed helper queue。捨てた案は二回目の VPS passkey、deploy workflow から SSH restart、opt-in parameter、mac Codex manual restart。
- merge 後に通す E2E: production deploy E2E を実行し、deploy event が queue comment を作り、VPS runner が checkout を origin/main に合わせ、unresolved bridge restart 後の before/after SHA と service state を返すことを検証します。
- 次の PR を増やさない理由: deploy 後 source sync、bridge restart、Butler pass-through は owner から見て一つの deploy 完了体験であり、ここを分けると次PRに同じ穴と不足が残ります。
- 停止条件: deploy approval grant を owner-facing payload に漏らさないと成立しない場合、GitHub Actions に VPS root credential を追加しないと成立しない場合、任意 command 化が必要な場合、public repo に owner 固有 secret を固定しそうな場合。

## Dry-run Impact Report

- Target Issue: Issue #741
- Implementing Success Criteria: deploy 後 bridge sync/restart を既存 deploy flow に追加し、VPS checkout が最新 main と一致した確認 truth を返し、Butler blocker pass-through を直します。
- Explicit Non-goals: 新しい passkey 境界、任意 command 実行、GitHub Actions からの VPS SSH/root 実行、Issue close、deploy 実行そのものは行いません。
- Expected touched files/routes/workflows: .github/workflows/deploy-production.yml, src/worker/runtime.js, scripts/sync-dashboard-app-server-bridge-after-deploy.mjs, worker.js, related tests, strategy doc.
- Affected Issues: Issue #741, Issue #637, Issue #455。
- Affected PRs: 直近の PR #772 の usage profile を live bridge に反映する前提に影響します。このPR自体は新規 PR です。
- Affected workflows: deploy-production.yml の dashboard deploy event payload。
- Affected runtime/operator surfaces: Dashboard Butler chat, GitHub Actions deploy event route, VPS helper queue, repo-less app-server bridge restart helper script。
- What may break if we patch narrowly: restart だけ自動化して Git sync verification が抜ける、approval URL だけ消して queue が積まれない、Worker blocker が残り Butler が bridge に届かない、短命 grant が表示漏れする。
- Unknowns to investigate before coding: 既存 sync script が origin/main との一致を返しているか、deploy event が approvalGrantId を持てるか、queue payload に grant 実値が残るか。
- Validation needed: targeted worker tests、sync script tests、production deploy workflow tests、npm run build:worker、npm run verify:worker、git diff --check。
- Stop condition: fixed helper queue ではなく broad/root execution が必要になった場合、approvalGrantId leak を避けられない場合、live runner pickup contract を壊す場合。

## Execution Queue Delta

- Queue position before: Issue #741 deploy 後 bridge sync/restart と Issue #455 usage profile live verification の間にある blocker です。
- Preemption decision: ROOT/NEXT として扱います。deploy 済み source が bridge に反映されないため、以降の Butler 開発とコスト検証を進める前に必要です。
- Queue delta: Issue #741 の queue item を進めます。deploy 後標準処理として bridge sync/restart helper queue handoff を追加し、Butler blocker pass-through を修正します。live deploy/runner pickup は merge 後 evidence として残ります。
- Why this PR is next: owner が明示した「デプロイ後は app-server bridge も最新 main に合わせる」「追加 passkey は不要」「Butler は止めず VPS Codex CLI に届ける」を一つの機能単位で満たすためです。
- Active Issues not downscoped: Active Issues は縮小しません。このPRで扱わないコストチェッカー live 実測、active turn 完全 replay、他 bridge 種別のrestart policy は未完了として残します。

## File / Line Hypotheses

- file: `.github/workflows/deploy-production.yml`
  - hypothesis: deploy event が approvalGrantId を送っていないため Worker が既存 deploy approval を後処理に使えない。
  - risk if changed narrowly: event record/chat に grant を漏らす。
  - validation: workflow test と worker deploy event redaction assertions。
  - related Issue: #741
- file: `src/worker/runtime.js`
  - hypothesis: deploy follow-up が二回目の VPS approval proposal を作り、repo-less maintenance intent が Worker blocker で止まる。
  - risk if changed narrowly: queue が積まれない、duplicate event が二重 queue になる、ordinary chat auth を緩める。
  - validation: worker deploy event / duplicate / VPS maintenance pass-through tests。
  - related Issue: #741 / #637
- file: `scripts/sync-dashboard-app-server-bridge-after-deploy.mjs`
  - hypothesis: Git sync はあるが origin/main 一致確認が runtime truth として不足している。
  - risk if changed narrowly: restart だけ成功して VPS checkout が stale でも完了に見える。
  - validation: sync script test for `targetRefSha`, `syncVerified`, `afterMatchesTargetRef`。
  - related Issue: #741 / #455

## Hypothesis Retrospective

- expected: deploy event approvalGrantId を machine-only で渡せば、Worker が deploy approval を検証して追加 passkey なしに fixed helper queue を作れる。
- actual: targeted worker test で `queued_for_vps_helper_execution`、queue comment、redaction、duplicate skip を確認しました。
- mismatch: active app-server turn の完全 replay は今回の code path だけでは live 実行完了を証明できないため、pending owner messages replay source と runner truth に限定しました。
- lesson: deploy 完了体験は deploy workflow、runtime event、VPS helper、Dashboard chat の一塊で扱わないと passkey/bridge 取りこぼしが残ります。
- should become RAG candidate: はい。deploy 後 bridge sync/restart は既存 deploy approval の標準後処理であり、追加 passkey にしないという決定は RAG candidate です。

## Verification Evidence

- Unit: `node --test test/worker.test.js --test-name-pattern "deploy completion event|VPS maintenance|app-server bridge"` passed.
- Integration: `node --test test/sync-dashboard-app-server-bridge-after-deploy.test.js test/production-deploy-path.test.js` passed.
- E2E: `npm run verify:worker` passed; live production deploy / VPS runner pickup E2E は merge/deploy 後に実施します。
- Manual: `git diff --check` passed. `npm run build:worker` passed and `worker.js` was regenerated.
- Evidence path/link: docs/development-strategy/issue-741-deploy-bridge-restart-automation.md; test output in this PR run.

## Butler Completion Contract

- Primary owner surface: Dashboard Butler。
- Fallback surface: Custom GPT は fallback surface としてのみ残ります。主経路ではありません。
- Owner goal: deploy passkey 一回で production deploy 後に VPS checkout / unresolved app-server bridge が最新 main へ追従し、追加 passkey なしで helper queue に積まれること。
- Butler entrypoint: Dashboard Butler の deploy completion event chat と通常チャット自然文。repo/Issue/config が足りない VPS maintenance text は Butler が止めず app-server bridge に届けます。
- Dashboard Butler natural-language path: Dashboard Butler 通常チャットは VPS maintenance intent を受け、Worker で実行可能な proposal/queue の時だけ処理し、足りない場合は app-server bridge へ接続します。
- Action Schema exposure: Action Schema は変更なし。このPRは Dashboard runtime path の更新です。
- Runtime path: /v2/events/github-actions -> buildDeployBridgeFollowupChatMessage -> createVpsPrivilegedMaintenanceHelperExecutionQueue -> VPS runner queue comment。DashboardChatRoom は blocker flow を bridge relay に戻します。
- Runner/runtime truth: deploy follow-up returns `queued_for_vps_helper_execution`, `helperQueueReached=true`, `rootExecutionStarted=false`, `helperExecutionStarted=false`; script returns before/after SHA, `targetRefSha`, `syncVerified`, service state。
- Authority boundary: production deploy approval grant を再検証します。追加 passkey は不要です。Worker は root/helper execution を開始せず、fixed helper queue handoff のみ行います。
- E2E evidence: `npm run verify:worker` passed. Live deploy/VPS runner pickup evidence は merge/deploy 後に追跡します。
- Completion status: incomplete

## Surface Update Checklist

- [x] Dashboard Butler chat deploy completion message updated from approval URL guidance to helper queue handoff guidance.
- [x] GitHub Actions deploy event includes machine-only approvalGrantId for Worker-side verification.
- [x] VPS helper script reports latest main sync verification truth.
- [x] Generated `worker.js` updated.
- [ ] Live production deploy and VPS runner pickup evidence collected after merge/deploy.
