### PR TITLE
Issue #590 最終返信に進行ログ要約を残す

### DIFF
--- a/docs/development-strategy/issue-590-progress-summary-after-final.md
+++ b/docs/development-strategy/issue-590-progress-summary-after-final.md
@@ -1,0 +1,72 @@
+# Issue #590: 最終返信に進行要約を折りたたんで残す
+
+## 完了体験
+
+Dashboard Butler で長い作業を待つ owner が、作業中は transient progress で現在位置を見られる。作業完了後は progress pane が消えるだけでなく、最終 Butler 返信の下に「進行ログ」として折りたたみ要約が残る。通常チャット履歴には `考えています。` や `コマンドを実行しています。` が個別 message として積み上がらない。
+
+## VTDD 全体で進める部分
+
+Issue #590 の残 blocker である silent wait / long-turn observability を進める。Issue #413 の実行中 progress runtime truth とも接続するが、この PR は Dashboard chat message の owner-facing 表示に限定する。
+
+## 設計
+
+`app_server_status` の transient snapshot に、直近 turn の owner-facing progress text を `progressSummary.entries` として蓄積する。final `app_server_reply` が来た時、snapshot を消す前に progress summary を final Butler message の payload に添付する。
+
+UI は Butler message の本文下に `<details>` を追加し、summary label は `進行ログ` とする。message 本文や copy text には混ぜない。raw chain-of-thought / raw terminal output は保存せず、既存の stage mapping を通った owner-facing 短文だけを残す。
+
+## 仮説
+
+現在は sleep / reconnect 用の transient snapshot があるが、final reply 後に消えるため、owner は作業中に何が起きていたかを後で追えない。progress を durable message として保存すると履歴汚染が戻るため、final reply の補助 payload に集約するのが最小の改善になる。
+
+## 検証計画
+
+- Worker test: 複数の `app_server_status` 後に `app_server_reply` が来ると、最終 Butler message に `progressSummary.entries` が付く。
+- Worker test: progress summary 付き final reply 後、transient snapshot は消える。
+- Worker test: generic progress は従来通り単独 durable message にならない。
+- HTML test: Butler message が `progressSummary.entries` を `<details>` として描画できる。
+- `npm run build:worker`
+- `npm run check:generated-worker`
+- `git diff --check`
+
+## 改修見積もり
+
+- `src/worker/runtime.js`: snapshot schema、final reply への progress summary 添付、Dashboard UI renderer を変更する。リスクは snapshot rowsWritten 増加と final message payload 肥大化。
+- `test/worker.test.js`: progress summary regression と UI route assertion を追加する。
+- `worker.js`: generated Worker bundle。
+
+## 既に通っている経路
+
+PR #731 で generic progress の durable message 汚染は止まっている。PR #733/#734 系で composer progress pane と reply delta transient 表示の土台が入っている。PR #741/#773 で deploy 後 bridge 復帰導線も進んでいる。
+
+## 未確認の境界
+
+Codex app-server protocol が final answer と progress を完全分離しているわけではない可能性がある。この PR は protocol 解釈を広げず、Worker が受け取った既存 `app_server_status` の owner-facing text だけを扱う。
+
+## 穴が出そうな箇所
+
+- progress を message 本文へ混ぜると、読みづらい長文が再発する。
+- raw terminal output を保存すると安全境界が崩れる。
+- 件数制限で途中ログを雑に切ると owner が後で追えない。保存は件数ではなく payload safety の文字量で抑える。
+- final reply がない stalled / failed は既存 recovery message を優先する。
+
+## PR 前に確認すること
+
+open PR がないこと、`main` が `origin/main` と一致すること、Issue #590 が open であること、active queue の Now が #590 であること、通常 chat progress spam regression が戻らないこと。
+
+## 実装候補と捨てた案
+
+採用: transient snapshot に progress entries を蓄積し、final Butler message に折りたたみ payload として添付する。
+
+捨てた案: progress を全て durable Butler message に戻す。履歴汚染と storage cost が戻る。捨てた案: final message 本文へ progress を連結する。owner が読みにくい。捨てた案: raw delta / raw command output を保存する。安全境界と UX を壊す。
+
+## merge 後に通す E2E
+
+production Dashboard Butler で長めの依頼を送り、途中 progress が composer pane に出ること、完了後に pane が消えること、最終 Butler message 下の `進行ログ` を開くと進行要約を見返せること、通常履歴に progress message が増殖しないことを確認する。
+
+## 次の PR を増やさない理由
+
+この PR は #590 の残 UX のうち「完了後に progress を見返せる」一点に限定する。stop/interrupt、owner input queue、Web Push、#637 privileged helper は別 authority / runtime 境界なので混ぜない。
+
+## 停止条件
+
+raw chain-of-thought / raw terminal output の保存が必要になる、progress が通常 message として増殖する、deploy / credential / permission / destructive work が必要になる、または app-server protocol の final/progress 境界が現在の仮説と矛盾する場合は停止する。

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -563,6 +563,10 @@ export class DashboardChatRoom {
         updatedAt: normalized.createdAt
       });
     }
+    const finalProgressSnapshot =
+      normalized.transientStatus === "replied"
+        ? await this.readTransientProgressSnapshot(normalized.threadId)
+        : null;
     if (normalized.transientStatus === "replied") {
       await this.clearTransientProgressSnapshot(normalized.threadId);
     }
@@ -578,11 +582,15 @@ export class DashboardChatRoom {
     if (normalized.messages.length === 0) {
       return;
     }
+    const bridgeMessages = attachDashboardProgressSummaryToFinalMessages(
+      normalized.messages,
+      finalProgressSnapshot
+    );
     const store = resolveDashboardChatStore(this.env);
     const messagesToAppend = await filterDashboardAppServerBridgeMessagesForAppend({
       store,
       threadId: normalized.threadId,
-      messages: normalized.messages
+      messages: bridgeMessages
     });
     if (messagesToAppend.length === 0) {
       return;
@@ -698,22 +706,25 @@ export class DashboardChatRoom {
 
   async writeTransientProgressSnapshot({ threadId, status = "", text = "", source = "" } = {}) {
     const key = this.transientProgressSnapshotKey(threadId);
+    const previous = await this.readTransientProgressSnapshot(threadId);
     const normalized = normalizeDashboardTransientProgressSnapshot({
       threadId,
       status,
       text,
       source,
+      progressSummary: buildDashboardProgressSummarySnapshot(previous, { text }),
       updatedAt: new Date().toISOString()
     });
     if (!key || !normalized || typeof this.ctx?.storage?.put !== "function") {
       return false;
     }
-    const previous = await this.readTransientProgressSnapshot(threadId);
     if (
       previous &&
       previous.status === normalized.status &&
       previous.text === normalized.text &&
-      previous.source === normalized.source
+      previous.source === normalized.source &&
+      dashboardProgressSummaryEntriesKey(previous.progressSummary) ===
+        dashboardProgressSummaryEntriesKey(normalized.progressSummary)
     ) {
       return false;
     }
@@ -9948,13 +9959,80 @@ function normalizeDashboardTransientProgressSnapshot(value) {
   if (!threadId || !text || !isDashboardSnapshotTransientStatus(status)) {
     return null;
   }
+  const progressSummary = normalizeDashboardProgressSummary(input.progressSummary || input.progress_summary);
   return {
     threadId,
     status,
     text,
     source: sanitizeDashboardChatText(input.source || ""),
+    ...(progressSummary.entries.length ? { progressSummary } : {}),
     updatedAt: normalizeIsoTimestamp(input.updatedAt || input.updated_at) || new Date().toISOString()
   };
+}
+
+function normalizeDashboardProgressSummary(value) {
+  const input = normalizeObject(value);
+  const rawEntries = Array.isArray(input.entries) ? input.entries : [];
+  const entries = [];
+  let totalLength = 0;
+  for (const rawEntry of rawEntries) {
+    const text = sanitizeDashboardChatText(rawEntry?.text || rawEntry);
+    if (!text) continue;
+    const entry = {
+      text,
+      at: normalizeIsoTimestamp(rawEntry?.at || rawEntry?.createdAt || rawEntry?.created_at) || ""
+    };
+    const entryLength = entry.text.length + entry.at.length;
+    if (totalLength + entryLength > 3200) break;
+    entries.push(entry);
+    totalLength += entryLength;
+  }
+  return {
+    entries,
+    updatedAt: normalizeIsoTimestamp(input.updatedAt || input.updated_at) || new Date().toISOString()
+  };
+}
+
+function buildDashboardProgressSummarySnapshot(previous, { text = "" } = {}) {
+  const previousSummary = normalizeDashboardProgressSummary(previous?.progressSummary);
+  const entries = [...previousSummary.entries];
+  const normalizedText = sanitizeDashboardChatText(text);
+  if (normalizedText) {
+    const latest = entries.at(-1);
+    if (!latest || latest.text !== normalizedText) {
+      entries.push({
+        text: normalizedText,
+        at: new Date().toISOString()
+      });
+    }
+  }
+  return normalizeDashboardProgressSummary({
+    entries,
+    updatedAt: new Date().toISOString()
+  });
+}
+
+function dashboardProgressSummaryEntriesKey(progressSummary) {
+  const normalized = normalizeDashboardProgressSummary(progressSummary);
+  return JSON.stringify(normalized.entries.map((entry) => entry.text));
+}
+
+function attachDashboardProgressSummaryToFinalMessages(messages = [], snapshot = null) {
+  const progressSummary = normalizeDashboardProgressSummary(snapshot?.progressSummary);
+  if (!progressSummary.entries.length) {
+    return messages;
+  }
+  return (Array.isArray(messages) ? messages : []).map((message) => {
+    const role = normalizeDashboardEventText(message?.role).toLowerCase();
+    const status = normalizeDashboardChatStatus(message?.status);
+    if (role !== "butler" || status !== "replied") {
+      return message;
+    }
+    return {
+      ...message,
+      progressSummary
+    };
+  });
 }
 
 function isDashboardSnapshotTransientStatus(status) {
@@ -12474,6 +12552,7 @@ function normalizeDashboardChatMessage(message, defaults = {}) {
   }
   const role = normalizeDashboardChatRole(input.role);
   const createdAt = normalizeIsoTimestamp(input.createdAt || input.created_at) || new Date().toISOString();
+  const progressSummary = normalizeDashboardProgressSummary(input.progressSummary || input.progress_summary);
   return {
     threadId,
     messageId: normalizeDashboardEventText(input.messageId || input.message_id) || crypto.randomUUID(),
@@ -12482,6 +12561,7 @@ function normalizeDashboardChatMessage(message, defaults = {}) {
     relatedIssue: normalizePositiveInteger(input.relatedIssue || input.issueNumber || input.related_issue),
     status: normalizeDashboardChatStatus(input.status),
     text: sanitizeDashboardChatText(input.text || input.message || input.body) || "（空のメッセージ）",
+    ...(progressSummary.entries.length ? { progressSummary } : {}),
     mediaReferences: normalizeMediaReferences(input.mediaReferences || input.media_references || input.media),
     createdAt
   };
@@ -15811,6 +15891,10 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
     .bubble .message-body pre code { display: block; max-width: 100%; white-space: pre-wrap; overflow-wrap: anywhere; word-break: break-word; font-size: 14px; line-height: 1.55; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace; }
     .bubble .message-body pre.wrap-code code { white-space: pre-wrap; overflow-wrap: anywhere; word-break: break-word; }
     .bubble .message-body strong { display: inline; color: inherit; font-size: inherit; letter-spacing: 0; text-transform: none; margin: 0; font-weight: 800; }
+    .progress-summary { margin-top: 12px; border: 1px solid var(--border); border-radius: 10px; padding: 10px 12px; background: rgba(247, 248, 244, .8); color: var(--muted); }
+    .progress-summary summary { cursor: pointer; font-weight: 800; color: var(--text); }
+    .progress-summary ol { margin: 10px 0 0; padding-left: 22px; }
+    .progress-summary li { margin-top: 6px; overflow-wrap: anywhere; word-break: break-word; }
     .reply-context { display: grid; grid-template-columns: minmax(0, 1fr); gap: 2px; width: min(100%, 680px); margin: 0 0 10px; padding: 8px 10px; border: 0; border-left: 3px solid var(--border); border-radius: 0 8px 8px 0; background: var(--soft); color: var(--muted); font: inherit; font-size: 12px; line-height: 1.45; text-align: left; cursor: pointer; }
     .reply-context:hover, .reply-context:focus-visible { color: var(--text); background: var(--panel-strong); outline: none; }
     .reply-context:focus-visible { box-shadow: 0 0 0 2px var(--link); }
@@ -16793,6 +16877,10 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         if (media) {
           article.appendChild(media);
         }
+        const progressSummary = renderProgressSummaryDetails(message.progressSummary || message.progress_summary);
+        if (progressSummary) {
+          article.appendChild(progressSummary);
+        }
         entry.appendChild(article);
         const actions = document.createElement("div");
         actions.className = "message-actions";
@@ -16819,6 +16907,27 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         if (target === log && options.scroll !== false) {
           scrollToLatest();
         }
+      }
+
+      function renderProgressSummaryDetails(progressSummary) {
+        const entries = Array.isArray(progressSummary && progressSummary.entries) ? progressSummary.entries : [];
+        const normalizedEntries = entries
+          .map((entry) => String(entry && entry.text || entry || "").trim())
+          .filter(Boolean);
+        if (!normalizedEntries.length) return null;
+        const details = document.createElement("details");
+        details.className = "progress-summary";
+        const summary = document.createElement("summary");
+        summary.textContent = "進行ログ";
+        details.appendChild(summary);
+        const list = document.createElement("ol");
+        for (const text of normalizedEntries) {
+          const item = document.createElement("li");
+          item.textContent = text;
+          list.appendChild(item);
+        }
+        details.appendChild(list);
+        return details;
       }
 
       function formatMessageTimestamp(value) {

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -1270,6 +1270,9 @@ test("worker serves v2 dashboard for allowed owner identity without exposing sec
   assert.equal(body.includes("function updateTransientProgress(text, options = {})"), true);
   assert.equal(body.includes("function clearTransientProgress()"), true);
   assert.equal(body.includes("function renderTransientProgress()"), true);
+  assert.equal(body.includes("function renderProgressSummaryDetails(progressSummary)"), true);
+  assert.equal(body.includes("進行ログ"), true);
+  assert.equal(body.includes(".progress-summary"), true);
   const renderTransientProgressSource = body.match(/function renderTransientProgress\(\) \{[\s\S]*?\n      \}/)?.[0] || "";
   assert.equal(renderTransientProgressSource.includes("scrollToLatest()"), false);
   assert.equal(renderTransientProgressSource.includes("updateComposerReserve()"), true);
@@ -4966,6 +4969,17 @@ test("DashboardChatRoom clears transient progress snapshot after final reply", a
     JSON.stringify({
       type: "app_server_status",
       status: "thinking",
+      stage: "planning",
+      threadId: "dashboard-main-unresolved",
+      codexThreadId: "codex-thread-450",
+      text: "raw plan detail"
+    })
+  );
+  await room.webSocketMessage(
+    bridgeSocket,
+    JSON.stringify({
+      type: "app_server_status",
+      status: "thinking",
       stage: "test",
       threadId: "dashboard-main-unresolved",
       codexThreadId: "codex-thread-450",
@@ -4973,6 +4987,10 @@ test("DashboardChatRoom clears transient progress snapshot after final reply", a
     })
   );
   assert.equal(storage.values.get("transient_progress_snapshot:dashboard-main-unresolved").text, "テストを実行しています。");
+  assert.deepEqual(
+    storage.values.get("transient_progress_snapshot:dashboard-main-unresolved").progressSummary.entries.map((entry) => entry.text),
+    ["方針を整理しています。", "テストを実行しています。"]
+  );
 
   await room.webSocketMessage(
     bridgeSocket,
@@ -4988,7 +5006,16 @@ test("DashboardChatRoom clears transient progress snapshot after final reply", a
   assert.equal(storage.deleteCalls.filter((call) => call.key === "transient_progress_snapshot:dashboard-main-unresolved").length >= 1, true);
   const threadPayloads = dashboardSocket.sent.map((message) => JSON.parse(message)).filter((message) => message.type === "thread");
   assert.equal(threadPayloads.at(-1).transientProgressSnapshot, null);
-  assert.equal((await store.listThread("dashboard-main-unresolved")).at(-1).text, "検証が終わりました。");
+  const finalMessage = (await store.listThread("dashboard-main-unresolved")).at(-1);
+  assert.equal(finalMessage.text, "検証が終わりました。");
+  assert.deepEqual(
+    finalMessage.progressSummary.entries.map((entry) => entry.text),
+    ["方針を整理しています。", "テストを実行しています。"]
+  );
+  assert.deepEqual(
+    threadPayloads.at(-1).messages.at(-1).progressSummary.entries.map((entry) => entry.text),
+    ["方針を整理しています。", "テストを実行しています。"]
+  );
 });
 
 test("DashboardChatRoom keeps generic opt-in app-server progress transient-only", async () => {

--- a/worker.js
+++ b/worker.js
@@ -58433,6 +58433,7 @@ var DashboardChatRoom = class {
         updatedAt: normalized.createdAt
       });
     }
+    const finalProgressSnapshot = normalized.transientStatus === "replied" ? await this.readTransientProgressSnapshot(normalized.threadId) : null;
     if (normalized.transientStatus === "replied") {
       await this.clearTransientProgressSnapshot(normalized.threadId);
     }
@@ -58448,11 +58449,15 @@ var DashboardChatRoom = class {
     if (normalized.messages.length === 0) {
       return;
     }
+    const bridgeMessages = attachDashboardProgressSummaryToFinalMessages(
+      normalized.messages,
+      finalProgressSnapshot
+    );
     const store = resolveDashboardChatStore(this.env);
     const messagesToAppend = await filterDashboardAppServerBridgeMessagesForAppend({
       store,
       threadId: normalized.threadId,
-      messages: normalized.messages
+      messages: bridgeMessages
     });
     if (messagesToAppend.length === 0) {
       return;
@@ -58549,18 +58554,19 @@ var DashboardChatRoom = class {
   }
   async writeTransientProgressSnapshot({ threadId, status = "", text = "", source = "" } = {}) {
     const key = this.transientProgressSnapshotKey(threadId);
+    const previous = await this.readTransientProgressSnapshot(threadId);
     const normalized = normalizeDashboardTransientProgressSnapshot({
       threadId,
       status,
       text,
       source,
+      progressSummary: buildDashboardProgressSummarySnapshot(previous, { text }),
       updatedAt: (/* @__PURE__ */ new Date()).toISOString()
     });
     if (!key || !normalized || typeof this.ctx?.storage?.put !== "function") {
       return false;
     }
-    const previous = await this.readTransientProgressSnapshot(threadId);
-    if (previous && previous.status === normalized.status && previous.text === normalized.text && previous.source === normalized.source) {
+    if (previous && previous.status === normalized.status && previous.text === normalized.text && previous.source === normalized.source && dashboardProgressSummaryEntriesKey(previous.progressSummary) === dashboardProgressSummaryEntriesKey(normalized.progressSummary)) {
       return false;
     }
     await this.ctx.storage.put(key, normalized);
@@ -66723,13 +66729,76 @@ function normalizeDashboardTransientProgressSnapshot(value) {
   if (!threadId || !text || !isDashboardSnapshotTransientStatus(status)) {
     return null;
   }
+  const progressSummary = normalizeDashboardProgressSummary(input.progressSummary || input.progress_summary);
   return {
     threadId,
     status,
     text,
     source: sanitizeDashboardChatText(input.source || ""),
+    ...progressSummary.entries.length ? { progressSummary } : {},
     updatedAt: normalizeIsoTimestamp(input.updatedAt || input.updated_at) || (/* @__PURE__ */ new Date()).toISOString()
   };
+}
+function normalizeDashboardProgressSummary(value) {
+  const input = normalizeObject12(value);
+  const rawEntries = Array.isArray(input.entries) ? input.entries : [];
+  const entries = [];
+  let totalLength = 0;
+  for (const rawEntry of rawEntries) {
+    const text = sanitizeDashboardChatText(rawEntry?.text || rawEntry);
+    if (!text) continue;
+    const entry = {
+      text,
+      at: normalizeIsoTimestamp(rawEntry?.at || rawEntry?.createdAt || rawEntry?.created_at) || ""
+    };
+    const entryLength = entry.text.length + entry.at.length;
+    if (totalLength + entryLength > 3200) break;
+    entries.push(entry);
+    totalLength += entryLength;
+  }
+  return {
+    entries,
+    updatedAt: normalizeIsoTimestamp(input.updatedAt || input.updated_at) || (/* @__PURE__ */ new Date()).toISOString()
+  };
+}
+function buildDashboardProgressSummarySnapshot(previous, { text = "" } = {}) {
+  const previousSummary = normalizeDashboardProgressSummary(previous?.progressSummary);
+  const entries = [...previousSummary.entries];
+  const normalizedText = sanitizeDashboardChatText(text);
+  if (normalizedText) {
+    const latest = entries.at(-1);
+    if (!latest || latest.text !== normalizedText) {
+      entries.push({
+        text: normalizedText,
+        at: (/* @__PURE__ */ new Date()).toISOString()
+      });
+    }
+  }
+  return normalizeDashboardProgressSummary({
+    entries,
+    updatedAt: (/* @__PURE__ */ new Date()).toISOString()
+  });
+}
+function dashboardProgressSummaryEntriesKey(progressSummary) {
+  const normalized = normalizeDashboardProgressSummary(progressSummary);
+  return JSON.stringify(normalized.entries.map((entry) => entry.text));
+}
+function attachDashboardProgressSummaryToFinalMessages(messages = [], snapshot = null) {
+  const progressSummary = normalizeDashboardProgressSummary(snapshot?.progressSummary);
+  if (!progressSummary.entries.length) {
+    return messages;
+  }
+  return (Array.isArray(messages) ? messages : []).map((message) => {
+    const role = normalizeDashboardEventText(message?.role).toLowerCase();
+    const status = normalizeDashboardChatStatus(message?.status);
+    if (role !== "butler" || status !== "replied") {
+      return message;
+    }
+    return {
+      ...message,
+      progressSummary
+    };
+  });
 }
 function isDashboardSnapshotTransientStatus(status) {
   return [
@@ -68956,6 +69025,7 @@ function normalizeDashboardChatMessage(message, defaults = {}) {
   }
   const role = normalizeDashboardChatRole(input.role);
   const createdAt = normalizeIsoTimestamp(input.createdAt || input.created_at) || (/* @__PURE__ */ new Date()).toISOString();
+  const progressSummary = normalizeDashboardProgressSummary(input.progressSummary || input.progress_summary);
   return {
     threadId,
     messageId: normalizeDashboardEventText(input.messageId || input.message_id) || crypto.randomUUID(),
@@ -68964,6 +69034,7 @@ function normalizeDashboardChatMessage(message, defaults = {}) {
     relatedIssue: normalizePositiveInteger10(input.relatedIssue || input.issueNumber || input.related_issue),
     status: normalizeDashboardChatStatus(input.status),
     text: sanitizeDashboardChatText(input.text || input.message || input.body) || "\uFF08\u7A7A\u306E\u30E1\u30C3\u30BB\u30FC\u30B8\uFF09",
+    ...progressSummary.entries.length ? { progressSummary } : {},
     mediaReferences: normalizeMediaReferences(input.mediaReferences || input.media_references || input.media),
     createdAt
   };
@@ -71973,6 +72044,10 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
     .bubble .message-body pre code { display: block; max-width: 100%; white-space: pre-wrap; overflow-wrap: anywhere; word-break: break-word; font-size: 14px; line-height: 1.55; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace; }
     .bubble .message-body pre.wrap-code code { white-space: pre-wrap; overflow-wrap: anywhere; word-break: break-word; }
     .bubble .message-body strong { display: inline; color: inherit; font-size: inherit; letter-spacing: 0; text-transform: none; margin: 0; font-weight: 800; }
+    .progress-summary { margin-top: 12px; border: 1px solid var(--border); border-radius: 10px; padding: 10px 12px; background: rgba(247, 248, 244, .8); color: var(--muted); }
+    .progress-summary summary { cursor: pointer; font-weight: 800; color: var(--text); }
+    .progress-summary ol { margin: 10px 0 0; padding-left: 22px; }
+    .progress-summary li { margin-top: 6px; overflow-wrap: anywhere; word-break: break-word; }
     .reply-context { display: grid; grid-template-columns: minmax(0, 1fr); gap: 2px; width: min(100%, 680px); margin: 0 0 10px; padding: 8px 10px; border: 0; border-left: 3px solid var(--border); border-radius: 0 8px 8px 0; background: var(--soft); color: var(--muted); font: inherit; font-size: 12px; line-height: 1.45; text-align: left; cursor: pointer; }
     .reply-context:hover, .reply-context:focus-visible { color: var(--text); background: var(--panel-strong); outline: none; }
     .reply-context:focus-visible { box-shadow: 0 0 0 2px var(--link); }
@@ -72955,6 +73030,10 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         if (media) {
           article.appendChild(media);
         }
+        const progressSummary = renderProgressSummaryDetails(message.progressSummary || message.progress_summary);
+        if (progressSummary) {
+          article.appendChild(progressSummary);
+        }
         entry.appendChild(article);
         const actions = document.createElement("div");
         actions.className = "message-actions";
@@ -72981,6 +73060,27 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         if (target === log && options.scroll !== false) {
           scrollToLatest();
         }
+      }
+
+      function renderProgressSummaryDetails(progressSummary) {
+        const entries = Array.isArray(progressSummary && progressSummary.entries) ? progressSummary.entries : [];
+        const normalizedEntries = entries
+          .map((entry) => String(entry && entry.text || entry || "").trim())
+          .filter(Boolean);
+        if (!normalizedEntries.length) return null;
+        const details = document.createElement("details");
+        details.className = "progress-summary";
+        const summary = document.createElement("summary");
+        summary.textContent = "\u9032\u884C\u30ED\u30B0";
+        details.appendChild(summary);
+        const list = document.createElement("ol");
+        for (const text of normalizedEntries) {
+          const item = document.createElement("li");
+          item.textContent = text;
+          list.appendChild(item);
+        }
+        details.appendChild(list);
+        return details;
       }
 
       function formatMessageTimestamp(value) {


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #590 の部分進捗です。長い app-server turn 中に表示されていた transient progress を、完了後に最終 Butler 返信の折りたたみ「進行ログ」として見返せるようにします。低情報 progress を通常 chat message として積み上げない方針は維持します。

## Satisfied Success Criteria

- app-server progress は通常履歴に個別 message として増殖しません。final app_server_reply の直前に残っている transient progress snapshot を、最終 Butler message の progressSummary.entries に移します。Dashboard UI は Butler 最終返信の本文下に「進行ログ」details を描画できます。final reply 後は transient progress snapshot を消し、stale progress pane を残しません。

## Unsatisfied Success Criteria

- Issue #590 全体は close-ready ではありません。production iPad/iPhone PWA の live E2E、長時間 turn の実機観測、stop / interrupt / owner input queue は未完了です。raw Codex protocol の final/progress 完全分離はこの PR では扱っていません。

## Non-goal violations

None.

## 開発前作戦図

- 作戦図 evidence: docs/development-strategy/issue-590-progress-summary-after-final.md
- 完了体験: 作業中は transient progress、完了後は最終 Butler 返信下の「進行ログ」で進行要約を見返せます。
- VTDD 全体で進める部分: Issue #590 の silent wait / long-turn observability を進めます。Issue #413 に関係しますが runner 側は変更しません。
- 設計: transient snapshot に owner-facing progress entries を蓄積し、final reply へ補助 payload として添付します。
- 仮説: 原因仮説: final reply 前に transient snapshot を消しているため、作業中に見えた progress が完了後に追えません。予測: final message payload に集約すれば履歴汚染なしに後から読めます。
- 検証計画: worker test、Dashboard HTML assertion、build worker、generated worker check、diff check。
- 改修見積もり: src/worker/runtime.js: snapshot schema、final reply への progress summary 添付、Dashboard UI renderer。test/worker.test.js: regression。worker.js: generated bundle。
- 既に通っている経路: PR #731 で durable progress spam は止まっています。composer progress pane と transient snapshot は既存経路を使います。
- 未確認の境界: production PWA 実機での長時間 turn 視認性は merge/deploy 後 evidence が必要です。
- 穴が出そうな箇所: raw terminal output / raw reasoning を保存すると安全境界が崩れます。通常 message 化すると履歴汚染が戻ります。
- PR 前に確認すること: open PR なし、main と origin/main 一致、Issue #590 open、active queue Now が #590。
- 実装候補と捨てた案: 採用は final message payload 添付。捨てた案は durable progress message 化、本文連結、raw output 保存。
- merge 後に通す E2E: production Dashboard Butler PWA E2E: 長い依頼を送り、途中 progress、完了後「進行ログ」、通常履歴に progress spam がないことを確認します。
- 次の PR を増やさない理由: この PR は完了後に progress を見返す一点に限定し、stop/interrupt や #637 helper を混ぜません。
- 停止条件: raw chain-of-thought / raw terminal output 保存、通常 message 増殖、deploy/credential/permission/destructive work が必要になる場合。

## Dry-run Impact Report

- Target Issue: Issue #590
- Implementing Success Criteria: 長い turn の owner-facing progress observability と、完了後の progress summary visibility。
- Explicit Non-goals: deploy、credential mutation、permission mutation、root/helper 実行、stop/interrupt UI、Web Push、Issue close。
- Expected touched files/routes/workflows: src/worker/runtime.js、test/worker.test.js、worker.js、docs/development-strategy/issue-590-progress-summary-after-final.md。
- Affected Issues: Issue #590、関連して Issue #413。ほかの active Issue は未完了のまま残します。
- Affected PRs: なし。open PR は 0 件でした。
- Affected workflows: GitHub Actions test / guarded-policy / reviewer。workflow 定義は変更しません。
- Affected runtime/operator surfaces: Dashboard Butler PWA chat、DashboardChatRoom Durable Object、D1 chat payload。operator / passkey は未変更。
- What may break if we patch narrowly: snapshot payload が増えすぎる、stale progress が final 後に残る、通常 chat message spam が戻る可能性。
- Unknowns to investigate before coding: production PWA 実機での見え方、長時間 turn の実際の progress event 密度。
- Validation needed: worker test、build worker、generated worker check、diff check、merge/deploy 後の production PWA E2E。
- Stop condition: raw reasoning/output 保存や high-risk operation が必要になる場合は停止。

## Execution Queue Delta

- Queue position before: Issue #590 は active execution queue の Now です。残 blocker は owner-facing long-turn observability です。
- Preemption decision: ROOT。Issue #590 の root blocker を進める scoped progress であり、EMERGENCY ではありません。
- Queue delta: Issue #590 の owner-facing progress summary bucket をこの PR で前進させます。Issue #590 全体は incomplete のままです。
- Why this PR is next: owner が Butler の無言待ちと、完了後に作業過程が読めないことを継続 blocker として示しているためです。
- Active Issues not downscoped: Active Issues は縮小しません。Issue #413/#450/#637/#654 などは未完了として残します。

## File / Line Hypotheses

- file: src/worker/runtime.js
  - hypothesis: DashboardChatRoom.acceptAppServerBridgeMessage が final reply 前に transient snapshot を消すため、進行が後から読めない。
  - risk if changed narrowly: progress が final 本文へ混ざる、または通常 message として増殖する。
  - validation: app-server status -> final reply の worker test。
  - related Issue: Issue #590
- file: src/worker/runtime.js
  - hypothesis: Dashboard UI は progressSummary payload を描画できない。
  - risk if changed narrowly: payload は保存されても owner から見えない。
  - validation: dashboard HTML assertion。
  - related Issue: Issue #590

## Hypothesis Retrospective

- expected: transient snapshot に progress entries を貯め、final reply にだけ添付できる。
- actual: progressSummary.entries として final Butler message に添付し、UI details で描画する実装になった。
- mismatch: なし。ただし full npm test は VPS 実環境/credential 影響の既存2件が残った。
- lesson: progress は durable message ではなく final payload に集約する方が履歴汚染を避けられる。
- should become RAG candidate: はい。Issue #590 の progress summary 設計判断として候補。

## Verification Evidence

- Unit: node --test test/worker.test.js --test-name-pattern "DashboardChatRoom|dashboard HTML" pass。Node は test/worker.test.js 271件を実行し、271 pass。
- Integration: npm run build:worker pass / npm run check:generated-worker pass / git diff --check pass。
- E2E: 未実施。production PWA E2E は merge/deploy 後に実施します。
- Manual: npm test は clean env で 1178 pass / 2 fail。fail は test/vps-runner-script.test.js の VPS runner live delivery / role credential 環境依存で、この PR の変更範囲外です。
- Evidence path/link: docs/development-strategy/issue-590-progress-summary-after-final.md

## Butler Completion Contract

- Primary owner surface: Dashboard Butler PWA。
- Fallback surface: mac Codex は実装補助。owner-facing 完了経路ではありません。
- Owner goal: 長い turn の作業過程を無言で待たず、完了後も「進行ログ」として見返せること。
- Butler entrypoint: Dashboard normal chat / app-server bridge event path。
- Dashboard Butler natural-language path: Dashboard Butler の通常チャット入口から自然文を受け、app-server bridge の progress event 経路へ接続し、final reply の進行ログ表示へ到達します。
- Action Schema exposure: 未変更。
- Runtime path: app_server_status -> transient snapshot -> final app_server_reply message payload -> Dashboard UI details。
- Runner/runtime truth: worker test で snapshot 蓄積、final payload 添付、snapshot clear を確認。
- Authority boundary: 新しい high-risk action はありません。merge は GO 必須、deploy は passkey approval 必須。
- E2E evidence: この PR では未実施。production PWA E2E は merge/deploy 後に必要です。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: merge 後に必要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: merge/deploy 後に必要。

## Related Constitution Rules

- Butler Completion Gate
- Butler-First Operating Principle
- Drift Stop Protocol
- 開発前作戦図 Gate
- Evidence Discipline
- Conversation UX Contract

## Out-of-scope but NOT implemented

- stop / interrupt UI
- owner input queue
- Web Push
- Issue #637 privileged helper execution
- Issue #590 close
- deploy

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #590
- Execution ID: issue-590-progress-summary
- Goal: Dashboard Butler の最終返信に進行ログ要約を残す
