### PR TITLE
Issue #637 低リスクreadを承認なしでqueue化

### DIFF
--- a/docs/butler/vps-privileged-maintenance-capability-lifecycle.md
+++ b/docs/butler/vps-privileged-maintenance-capability-lifecycle.md
@@ -34,6 +34,15 @@ message alone is not enough for work that is blocked on owner attention.
 - PWA notification is sent for `approval_needed`, `execution_completed`, and
   `blocked_owner_action_required`.
 
+Low-risk read/status operations are the narrow exception to the approval step.
+When Dashboard Butler maps natural language to a reviewed registry capability
+with `operation=review`, `riskLevel=low`, and `requiresRoot=false`, the Worker
+may enqueue the bounded helper handoff without a passkey grant. The queue and
+runtime truth must mark `approvalBypassReason=low_risk_read`. This exception
+must not apply to restart, enable, add, disable, remove, rollback, root-required
+capabilities, credential mutation, permission mutation, destructive cleanup, or
+any capability whose registry entry is not explicitly low-risk and non-root.
+
 ## Capability Lifecycle
 
 Capabilities must be manageable from iPhone after approval:

--- a/docs/development-strategy/issue-637-low-risk-read-no-passkey.md
+++ b/docs/development-strategy/issue-637-low-risk-read-no-passkey.md
@@ -1,0 +1,77 @@
+# Issue #637: low-risk recovery read を passkey なしで helper queue に渡す
+
+## 完了体験
+
+Dashboard Butler で owner が「VPS runner の状態を見て」「app-server bridge が落ちてないか確認して」と聞いた時、低リスクの status / logs / read は passkey 承認待ちで止まらず、bounded helper queue として VPS runner へ渡る。owner は「承認してください」ではなく「確認依頼を渡した。完了 truth を待つ」と読める。
+
+restart、enable、add、root-required capability、credential / permission / destructive work は引き続き scoped passkey approval で止まる。
+
+## VTDD 全体で進める部分
+
+Issue #637 の Butler-first recovery plane を進める。最新 Issue コメントで定義された Lane B では、低リスク status/read は approval なしで読める必要がある。これにより、VPS / bridge / runner が怪しい時の最初の診断で owner が毎回 passkey を開く負担を減らす。
+
+## 設計
+
+Dashboard 自然文 VPS maintenance flow で proposal を作った後、capability が `riskLevel=low` かつ `operation=review` かつ registry 上 `requiresRoot=false` なら、passkey approval を要求せず内部 read grant として helper request を生成し、既存の helper execution queue path へ流す。
+
+内部 read grant は passkey grant ではないため、ID と runtime truth に `approvalBypassReason=low_risk_read` を明示する。root/helper 実行は queue handoff 時点では開始しない。
+
+## 仮説
+
+現 runtime は `systemd_user_runner_status` や `systemd_user_app_server_bridge_status` のような低リスク read でも `approval_required` にしている。Issue #637 の最新方針とはズレており、VPS が怪しい時の初動診断を重くしている。
+
+low-risk review に限って既存 queue path へ直接進めれば、権限境界を崩さずに recovery plane の使い勝手を改善できる。
+
+## 検証計画
+
+- Unit: Dashboard chat の `VPS runner status` が `queued_for_vps_helper_execution` になり、approval URL を出さない。
+- Unit: DashboardChatRoom WebSocket 経由でも低リスク status が app-server bridge へ流れず Worker helper queue に入る。
+- Unit: repo-less bridge restart は `approval_required` のまま残る。
+- Unit: high risk Playwright add は `approval_required` のまま残る。
+- `npm run build:worker`
+- `npm run check:generated-worker`
+- focused worker tests
+
+## 改修見積もり
+
+- `src/worker/runtime.js`: Dashboard VPS maintenance natural-language flow に low-risk read bypass 判定と helper request 生成を追加する。
+- `test/worker.test.js`: 既存 #637 tests の期待値を更新し、restart/high-risk approval 境界の regression を追加する。
+- `worker.js`: generated Worker bundle。
+
+## 既に通っている経路
+
+proposal 作成、approval proposal 保存、passkey approval 後 helper request 作成、helper execution envelope、GitHub Issue queue comment、VPS runner pickup は既に存在する。
+
+## 未確認の境界
+
+production VPS runner が low-risk read queue を拾って実行完了 truth を Dashboard に返す live evidence は merge/deploy 後に必要。
+
+## 穴が出そうな箇所
+
+- low-risk 判定が甘いと restart / add / root-required まで approval なしになる。
+- passkey grant と内部 read grant を同じものとして扱うと監査が曖昧になる。
+- helper request validator が approvalGrantId を必須としているため、read grant の ID 形状を明示しないと後続が壊れる。
+
+## PR 前に確認すること
+
+open PR がないこと、Issue #637 が open であること、#590 evidence を兼ねるため長めの turn で進行ログが残ること。
+
+## 実装候補と捨てた案
+
+採用: low-risk review + non-root registry capability のみ internal read grant で queue 化する。
+
+捨てた案: low-risk status を Worker 内で直接実行する。Worker は VPS host command を実行できず、Butler-first runtime truth を失う。
+
+捨てた案: すべて passkey のままにする。Issue #637 の latest recovery plane 方針とズレ、初動診断が重い。
+
+## merge 後に通す E2E
+
+production Dashboard Butler で「VPS runner の状態を確認して。Issue #637」を送り、passkey なしで helper queue に渡ること、VPS runner completed event が Dashboard thread に戻ること、#590 の `進行ログ` が最終返信に残ることを確認する。
+
+## 次の PR を増やさない理由
+
+この PR は low-risk read の authority boundary だけを変える。restart / sync / root-required / capability lifecycle mutation を混ぜると passkey 境界が広がるため別 PR にする。
+
+## 停止条件
+
+restart / enable / add / high risk / root-required capability が approval なしで進む、または helper queue が passkey grant と read grant を区別できない場合は停止する。

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -12083,6 +12083,15 @@ async function buildDashboardVpsPrivilegedMaintenanceNaturalLanguageFlow({
         }
       };
     }
+    if (isDashboardVpsMaintenanceLowRiskReadProposal(proposal.body)) {
+      return await queueDashboardVpsMaintenanceLowRiskRead({
+        payload,
+        repository,
+        relatedIssue,
+        proposalBody: proposal.body,
+        env
+      });
+    }
     return {
       messageStatus: "blocked",
       reply: buildDashboardVpsPrivilegedMaintenanceApprovalRequiredReply({
@@ -12209,6 +12218,145 @@ async function buildDashboardVpsPrivilegedMaintenanceNaturalLanguageFlow({
         ...(queue.body?.runtimeTruth || {}),
         dashboardNaturalLanguagePathReached: true,
         helperQueueReached: queue.ok === true,
+        rootExecutionStarted: false,
+        helperExecutionStarted: false
+      }
+    }
+  };
+}
+
+function isDashboardVpsMaintenanceLowRiskReadProposal(proposalBody = {}) {
+  const proposal = proposalBody?.proposal || {};
+  const capability = proposal?.capability || {};
+  const operation = normalizeText(proposalBody?.approvalScope?.vpsOperation || proposal?.operation);
+  if (operation !== "review") return false;
+  if (normalizeText(capability.riskLevel) !== "low") return false;
+  const registryEntry = listVpsPrivilegedMaintenanceCommandRegistry().find(
+    (entry) => entry.commandClass === capability.commandClass
+  );
+  return Boolean(registryEntry && registryEntry.requiredRiskLevel === "low" && registryEntry.requiresRoot === false);
+}
+
+async function queueDashboardVpsMaintenanceLowRiskRead({
+  payload,
+  repository,
+  relatedIssue,
+  proposalBody,
+  env
+} = {}) {
+  const proposal = proposalBody?.proposal || {};
+  const capability = proposal.capability || {};
+  const approvalScope = normalizeScopeSnapshot(proposalBody?.approvalScope || {});
+  const helperRequest = {
+    kind: "vps_privileged_maintenance_helper_request",
+    status: "ready_for_vps_helper",
+    requestId: createDashboardRequestId("vps-maintenance-helper-request"),
+    vpsProposalId: proposalBody?.vpsProposalId,
+    approvalGrantId: `low-risk-read:${safeIdentifier(proposalBody?.vpsProposalId || capability.id || Date.now())}`,
+    host: proposal.host,
+    repository: proposal.repository,
+    relatedIssue,
+    operation: "review",
+    capability: {
+      id: capability.id,
+      title: capability.title,
+      commandClass: capability.commandClass,
+      riskLevel: capability.riskLevel,
+      workingDirectories: capability.workingDirectories ?? [],
+      allowedArgs: capability.allowedArgs ?? [],
+      affectedPaths: capability.affectedPaths ?? [],
+      redactionRules: capability.redactionRules ?? [],
+      rollbackPlan: capability.rollbackPlan,
+      expectedRuntimeTruth: capability.expectedRuntimeTruth ?? []
+    },
+    approvalScope: {
+      ...approvalScope,
+      approvalBypassReason: "low_risk_read"
+    },
+    approvalBypassReason: "low_risk_read",
+    rootExecutionStarted: false,
+    helperExecutionStarted: false,
+    redacted: true
+  };
+  const manifest = buildDashboardVpsMaintenanceManifest({
+    helperRequest,
+    now: payload?.now
+  });
+  const execution = createVpsPrivilegedMaintenanceHelperExecution({
+    payload: {
+      manifest,
+      helperRequest,
+      now: payload?.now
+    }
+  });
+  if (!execution.ok) {
+    return {
+      messageStatus: "blocked",
+      reply: buildDashboardVpsPrivilegedMaintenanceBlockedReply({
+        repository,
+        relatedIssue,
+        error: execution.error,
+        issues: execution.issues
+      }),
+      execution: {
+        kind: "dashboard_vps_privileged_maintenance_natural_language",
+        status: "blocked",
+        vpsProposalId: proposalBody?.vpsProposalId,
+        runtimeTruth: execution.body?.runtimeTruth || {
+          kind: "vps_privileged_maintenance_dashboard_natural_language",
+          status: "execution_handoff_blocked",
+          rootExecutionStarted: false,
+          helperExecutionStarted: false
+        }
+      }
+    };
+  }
+
+  const queue = await createVpsPrivilegedMaintenanceHelperExecutionQueue({
+    payload: {
+      repository,
+      issueNumber: relatedIssue,
+      executionId:
+        normalizeText(payload?.executionId || payload?.execution_id) ||
+        `dashboard-butler-issue${relatedIssue || "unknown"}-${safeIdentifier(helperRequest.requestId)}`,
+      dashboardThreadId: normalizeText(payload?.threadId || payload?.thread_id),
+      approvalActor: "Dashboard Butler low-risk read",
+      executionEnvelope: execution.body.executionEnvelope
+    },
+    env
+  });
+  const reply = queue.ok
+    ? buildDashboardVpsPrivilegedMaintenanceQueuedReply({
+        repository,
+        relatedIssue,
+        queue,
+        lowRiskRead: true
+      })
+    : buildDashboardVpsPrivilegedMaintenanceBlockedReply({
+        repository,
+        relatedIssue,
+        error: queue.error,
+        reason: queue.reason,
+        issues: queue.issues
+      });
+
+  return {
+    messageStatus: queue.ok ? "sent" : "blocked",
+    reply,
+    execution: {
+      kind: "dashboard_vps_privileged_maintenance_natural_language",
+      status: queue.ok ? "queued_for_vps_helper_execution" : "blocked",
+      vpsProposalId: proposalBody?.vpsProposalId,
+      approvalScope: proposalBody?.approvalScope,
+      helperRequest,
+      executionEnvelope: execution.body.executionEnvelope,
+      queue: queue.body?.execution || null,
+      runtimeTruth: {
+        ...(queue.body?.runtimeTruth || {}),
+        dashboardNaturalLanguagePathReached: true,
+        helperQueueReached: queue.ok === true,
+        approvalRequired: false,
+        approvalBypassReason: "low_risk_read",
         rootExecutionStarted: false,
         helperExecutionStarted: false
       }
@@ -12493,8 +12641,8 @@ function buildDashboardVpsPrivilegedMaintenanceApprovalRequiredReply({ repositor
   ].join("\n");
 }
 
-function buildDashboardVpsPrivilegedMaintenanceQueuedReply({ repository, relatedIssue, queue } = {}) {
-  const execution = queue?.execution || {};
+function buildDashboardVpsPrivilegedMaintenanceQueuedReply({ repository, relatedIssue, queue, lowRiskRead = false } = {}) {
+  const execution = (queue?.body?.execution || queue?.execution) ?? {};
   return [
     "VPS runner へ復旧依頼を渡しました。",
     "",
@@ -12502,7 +12650,9 @@ function buildDashboardVpsPrivilegedMaintenanceQueuedReply({ repository, related
     `- 関連 Issue: ${relatedIssue ? `#${relatedIssue}` : execution.issueNumber ? `#${execution.issueNumber}` : "未指定"}`,
     `- executionId: ${execution.executionId || "未生成"}`,
     `- queueCommentUrl: ${execution.queueCommentUrl || "未取得"}`,
-    "- authority: passkey approval 済みの bounded handoff だけを queue 化しました。",
+    lowRiskRead
+      ? "- authority: low-risk read のため passkey approval なしで bounded handoff しました。restart / mutation / root-required capability は対象外です。"
+      : "- authority: passkey approval 済みの bounded handoff だけを queue 化しました。",
     "- runtime truth: status=queued_for_vps_helper_execution, rootExecutionStarted=false, helperExecutionStarted=false",
     "",
     "VPS runner pickup の完了 truth が戻るまで、live root 実行完了とは扱いません。"

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -3175,6 +3175,7 @@ test("worker maps repo-less Dashboard bridge restart intent to unresolved bridge
 test("worker maps Dashboard Butler VPS runner status text to the low-risk preset", async () => {
   const store = createInMemoryDashboardChatStore();
   const provider = createInMemoryMemoryProvider();
+  const githubCalls = [];
   const response = await worker.fetch(
     new Request("https://example.com/v2/dashboard/chat/messages", {
       method: "POST",
@@ -3197,22 +3198,40 @@ test("worker maps Dashboard Butler VPS runner status text to the low-risk preset
       DASHBOARD_CHAT_STORE: store,
       MEMORY_PROVIDER: provider,
       VTDD_DASHBOARD_VPS_MAINTENANCE_HOST: "x85-131-245-163",
-      VTDD_DASHBOARD_VPS_MAINTENANCE_WORKDIR: "/home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p"
+      VTDD_DASHBOARD_VPS_MAINTENANCE_WORKDIR: "/home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p",
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_dashboard_vps",
+      GITHUB_API_FETCH: async (url, init) => {
+        githubCalls.push({ url, init });
+        return new Response(
+          JSON.stringify({
+            id: 63703,
+            html_url: "https://github.com/marushu/vtdd-v2-p/issues/637#issuecomment-63703"
+          }),
+          { status: 201, headers: { "content-type": "application/json" } }
+        );
+      }
     }
   );
 
   assert.equal(response.status, 202);
   const body = await response.json();
   assert.equal(body.ok, true);
-  assert.equal(body.execution.status, "approval_required");
+  assert.equal(body.execution.status, "queued_for_vps_helper_execution");
   assert.equal(body.execution.approvalScope.vpsCapabilityId, "systemd.user.runner.status");
   assert.equal(body.execution.approvalScope.vpsOperation, "review");
-  assert.equal(body.execution.runtimeTruth.capabilityId, "systemd.user.runner.status");
+  assert.equal(body.execution.runtimeTruth.approvalRequired, false);
+  assert.equal(body.execution.runtimeTruth.approvalBypassReason, "low_risk_read");
+  assert.equal(body.execution.runtimeTruth.helperQueueReached, true);
   assert.equal(body.execution.runtimeTruth.rootExecutionStarted, false);
-  assert.match(body.messages[1].text, /確認対象: Check VTDD runner user service status/);
-  assert.match(body.messages[1].text, /操作: review/);
-  assert.match(body.messages[1].text, /risk: low/);
-  assert.match(body.messages[1].text, /承認なしに root \/ sudo \/ helper 実行は開始しません/);
+  assert.equal(body.messages[1].status, "sent");
+  assert.match(body.messages[1].text, /VPS runner へ復旧依頼を渡しました/);
+  assert.match(body.messages[1].text, /low-risk read/);
+  assert.doesNotMatch(body.messages[1].text, /approval URL/);
+  assert.equal(githubCalls.length, 1);
+  const queueCommentBody = JSON.parse(githubCalls[0].init.body).body;
+  assert.equal(queueCommentBody.includes("vtdd:vps-privileged-maintenance-execution:"), true);
+  assert.equal(queueCommentBody.includes('"transport": "vps_privileged_maintenance_helper"'), true);
+  assert.equal(queueCommentBody.includes('"approvalBypassReason": "low_risk_read"'), true);
 
   const records = await provider.retrieve({ ids: [body.execution.vpsProposalId] });
   const proposalRecord = records[0];
@@ -3226,6 +3245,7 @@ test("worker maps Dashboard Butler VPS runner status text to the low-risk preset
 test("worker detects app-server bridge recovery intent without internal VPS helper words", async () => {
   const store = createInMemoryDashboardChatStore();
   const provider = createInMemoryMemoryProvider();
+  const githubCalls = [];
   const response = await worker.fetch(
     new Request("https://example.com/v2/dashboard/chat/messages", {
       method: "POST",
@@ -3242,23 +3262,38 @@ test("worker detects app-server bridge recovery intent without internal VPS help
       DASHBOARD_CHAT_STORE: store,
       MEMORY_PROVIDER: provider,
       VTDD_DASHBOARD_VPS_MAINTENANCE_HOST: "x85-131-245-163",
-      VTDD_DASHBOARD_VPS_MAINTENANCE_WORKDIR: "/home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p"
+      VTDD_DASHBOARD_VPS_MAINTENANCE_WORKDIR: "/home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p",
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_dashboard_vps",
+      GITHUB_API_FETCH: async (url, init) => {
+        githubCalls.push({ url, init });
+        return new Response(
+          JSON.stringify({
+            id: 63704,
+            html_url: "https://github.com/marushu/vtdd-v2-p/issues/637#issuecomment-63704"
+          }),
+          { status: 201, headers: { "content-type": "application/json" } }
+        );
+      }
     }
   );
 
   assert.equal(response.status, 202);
   const body = await response.json();
   assert.equal(body.ok, true);
-  assert.equal(body.execution.status, "approval_required");
+  assert.equal(body.execution.status, "queued_for_vps_helper_execution");
   assert.equal(body.execution.approvalScope.vpsCapabilityId, "systemd.user.app.server.bridge.status");
   assert.equal(body.execution.approvalScope.vpsOperation, "review");
-  assert.equal(body.execution.runtimeTruth.capabilityId, "systemd.user.app.server.bridge.status");
+  assert.equal(body.execution.runtimeTruth.approvalRequired, false);
+  assert.equal(body.execution.runtimeTruth.approvalBypassReason, "low_risk_read");
+  assert.equal(body.execution.runtimeTruth.helperQueueReached, true);
   assert.equal(body.execution.runtimeTruth.rootExecutionStarted, false);
-  assert.match(body.messages[1].text, /VPS 復旧・保守の確認リクエスト/);
-  assert.match(body.messages[1].text, /確認対象: Check Dashboard app-server bridge status/);
-  assert.match(body.messages[1].text, /操作: review/);
-  assert.match(body.messages[1].text, /risk: low/);
-  assert.match(body.messages[1].text, /scoped passkey approval が必要/);
+  assert.equal(body.messages[1].status, "sent");
+  assert.match(body.messages[1].text, /VPS runner へ復旧依頼を渡しました/);
+  assert.match(body.messages[1].text, /low-risk read/);
+  assert.doesNotMatch(body.messages[1].text, /approval URL/);
+  assert.equal(githubCalls.length, 1);
+  const queueCommentBody = JSON.parse(githubCalls[0].init.body).body;
+  assert.equal(queueCommentBody.includes('"approvalBypassReason": "low_risk_read"'), true);
 
   const records = await provider.retrieve({ ids: [body.execution.vpsProposalId] });
   const proposalRecord = records[0];
@@ -4093,6 +4128,7 @@ test("DashboardChatRoom forwards repo-less PR status owner turns to app-server b
 test("DashboardChatRoom routes VPS maintenance owner turns to Worker proposal before app-server bridge", async () => {
   const provider = createInMemoryMemoryProvider();
   const store = createInMemoryDashboardChatStore();
+  const githubCalls = [];
   const dashboardSocket = createMockSocket("dashboard", "dashboard-main-marushu-vtdd-v2-p");
   const bridgeSocket = createMockSocket("app_server_bridge", "dashboard-main-marushu-vtdd-v2-p");
   const room = new DashboardChatRoom(
@@ -4107,7 +4143,18 @@ test("DashboardChatRoom routes VPS maintenance owner turns to Worker proposal be
       MEMORY_PROVIDER: provider,
       VTDD_RUNTIME_URL: "https://example.com",
       VTDD_DASHBOARD_VPS_MAINTENANCE_HOST: "x85-131-245-163",
-      VTDD_DASHBOARD_VPS_MAINTENANCE_WORKDIR: "/home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p"
+      VTDD_DASHBOARD_VPS_MAINTENANCE_WORKDIR: "/home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p",
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_dashboard_vps",
+      GITHUB_API_FETCH: async (url, init) => {
+        githubCalls.push({ url, init });
+        return new Response(
+          JSON.stringify({
+            id: 63705,
+            html_url: "https://github.com/marushu/vtdd-v2-p/issues/637#issuecomment-63705"
+          }),
+          { status: 201, headers: { "content-type": "application/json" } }
+        );
+      }
     }
   );
 
@@ -4131,9 +4178,11 @@ test("DashboardChatRoom routes VPS maintenance owner turns to Worker proposal be
   assert.equal(finalBroadcast.messages.length, 2);
   assert.equal(finalBroadcast.messages[0].role, "owner");
   assert.equal(finalBroadcast.messages[1].role, "butler");
-  assert.equal(finalBroadcast.messages[1].status, "blocked");
-  assert.match(finalBroadcast.messages[1].text, /approval_required/);
-  assert.match(finalBroadcast.messages[1].text, /systemd\.user\.runner\.status|approval URL/);
+  assert.equal(finalBroadcast.messages[1].status, "sent");
+  assert.match(finalBroadcast.messages[1].text, /VPS runner へ復旧依頼を渡しました/);
+  assert.match(finalBroadcast.messages[1].text, /low-risk read/);
+  assert.doesNotMatch(finalBroadcast.messages[1].text, /approval URL/);
+  assert.equal(githubCalls.length, 1);
 
   const records = await provider.retrieve({ type: MemoryRecordType.APPROVAL_LOG, limit: 10 });
   const proposalRecord = records.find((record) => record.content?.kind === "vps_privileged_maintenance_approval_proposal");
@@ -4141,7 +4190,7 @@ test("DashboardChatRoom routes VPS maintenance owner turns to Worker proposal be
   assert.equal(proposalRecord.content.proposal.capability.riskLevel, "low");
 });
 
-test("DashboardChatRoom uses WebSocket request origin for VPS approval URLs", async () => {
+test("DashboardChatRoom still uses WebSocket request origin for VPS restart approval URLs", async () => {
   const provider = createInMemoryMemoryProvider();
   const store = createInMemoryDashboardChatStore();
   const dashboardSocket = createMockSocket("dashboard", "dashboard-e2e-637-origin");
@@ -4166,7 +4215,7 @@ test("DashboardChatRoom uses WebSocket request origin for VPS approval URLs", as
       type: "owner_message",
       repository: "marushu/vtdd-v2-p",
       issueNumber: 637,
-      text: "Dashboard Butler から VPS runner status を確認して。root 実行は passkey 境界で止める。"
+      text: "Dashboard Butler から VPS runner を再起動して。root 実行は passkey 境界で止める。"
     }),
     {
       role: "dashboard",
@@ -4190,6 +4239,7 @@ test("DashboardChatRoom uses WebSocket request origin for VPS approval URLs", as
 test("DashboardChatRoom routes VPS maintenance owner turns without an app-server bridge socket", async () => {
   const provider = createInMemoryMemoryProvider();
   const store = createInMemoryDashboardChatStore();
+  const githubCalls = [];
   const storage = createMockDurableObjectStorage();
   const dashboardSocket = createMockSocket("dashboard", "dashboard-e2e-637-post697");
   const room = new DashboardChatRoom(
@@ -4204,7 +4254,18 @@ test("DashboardChatRoom routes VPS maintenance owner turns without an app-server
       MEMORY_PROVIDER: provider,
       VTDD_RUNTIME_URL: "https://example.com",
       VTDD_DASHBOARD_VPS_MAINTENANCE_HOST: "x85-131-245-163",
-      VTDD_DASHBOARD_VPS_MAINTENANCE_WORKDIR: "/home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p"
+      VTDD_DASHBOARD_VPS_MAINTENANCE_WORKDIR: "/home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p",
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_dashboard_vps",
+      GITHUB_API_FETCH: async (url, init) => {
+        githubCalls.push({ url, init });
+        return new Response(
+          JSON.stringify({
+            id: 63706,
+            html_url: "https://github.com/marushu/vtdd-v2-p/issues/637#issuecomment-63706"
+          }),
+          { status: 201, headers: { "content-type": "application/json" } }
+        );
+      }
     }
   );
 
@@ -4227,9 +4288,11 @@ test("DashboardChatRoom routes VPS maintenance owner turns without an app-server
   assert.equal(finalBroadcast.messages.length, 2);
   assert.equal(finalBroadcast.messages[0].role, "owner");
   assert.equal(finalBroadcast.messages[1].role, "butler");
-  assert.equal(finalBroadcast.messages[1].status, "blocked");
-  assert.match(finalBroadcast.messages[1].text, /approval_required/);
-  assert.match(finalBroadcast.messages[1].text, /systemd\.user\.runner\.status|approval URL/);
+  assert.equal(finalBroadcast.messages[1].status, "sent");
+  assert.match(finalBroadcast.messages[1].text, /VPS runner へ復旧依頼を渡しました/);
+  assert.match(finalBroadcast.messages[1].text, /low-risk read/);
+  assert.doesNotMatch(finalBroadcast.messages[1].text, /approval URL/);
+  assert.equal(githubCalls.length, 1);
 
   const records = await provider.retrieve({ type: MemoryRecordType.APPROVAL_LOG, limit: 10 });
   const proposalRecord = records.find((record) => record.content?.kind === "vps_privileged_maintenance_approval_proposal");

--- a/worker.js
+++ b/worker.js
@@ -68635,6 +68635,15 @@ async function buildDashboardVpsPrivilegedMaintenanceNaturalLanguageFlow({
         }
       };
     }
+    if (isDashboardVpsMaintenanceLowRiskReadProposal(proposal.body)) {
+      return await queueDashboardVpsMaintenanceLowRiskRead({
+        payload,
+        repository,
+        relatedIssue,
+        proposalBody: proposal.body,
+        env
+      });
+    }
     return {
       messageStatus: "blocked",
       reply: buildDashboardVpsPrivilegedMaintenanceApprovalRequiredReply({
@@ -68753,6 +68762,137 @@ async function buildDashboardVpsPrivilegedMaintenanceNaturalLanguageFlow({
         ...queue.body?.runtimeTruth || {},
         dashboardNaturalLanguagePathReached: true,
         helperQueueReached: queue.ok === true,
+        rootExecutionStarted: false,
+        helperExecutionStarted: false
+      }
+    }
+  };
+}
+function isDashboardVpsMaintenanceLowRiskReadProposal(proposalBody = {}) {
+  const proposal = proposalBody?.proposal || {};
+  const capability = proposal?.capability || {};
+  const operation = normalizeText33(proposalBody?.approvalScope?.vpsOperation || proposal?.operation);
+  if (operation !== "review") return false;
+  if (normalizeText33(capability.riskLevel) !== "low") return false;
+  const registryEntry = listVpsPrivilegedMaintenanceCommandRegistry().find(
+    (entry) => entry.commandClass === capability.commandClass
+  );
+  return Boolean(registryEntry && registryEntry.requiredRiskLevel === "low" && registryEntry.requiresRoot === false);
+}
+async function queueDashboardVpsMaintenanceLowRiskRead({
+  payload,
+  repository,
+  relatedIssue,
+  proposalBody,
+  env
+} = {}) {
+  const proposal = proposalBody?.proposal || {};
+  const capability = proposal.capability || {};
+  const approvalScope = normalizeScopeSnapshot(proposalBody?.approvalScope || {});
+  const helperRequest = {
+    kind: "vps_privileged_maintenance_helper_request",
+    status: "ready_for_vps_helper",
+    requestId: createDashboardRequestId("vps-maintenance-helper-request"),
+    vpsProposalId: proposalBody?.vpsProposalId,
+    approvalGrantId: `low-risk-read:${safeIdentifier(proposalBody?.vpsProposalId || capability.id || Date.now())}`,
+    host: proposal.host,
+    repository: proposal.repository,
+    relatedIssue,
+    operation: "review",
+    capability: {
+      id: capability.id,
+      title: capability.title,
+      commandClass: capability.commandClass,
+      riskLevel: capability.riskLevel,
+      workingDirectories: capability.workingDirectories ?? [],
+      allowedArgs: capability.allowedArgs ?? [],
+      affectedPaths: capability.affectedPaths ?? [],
+      redactionRules: capability.redactionRules ?? [],
+      rollbackPlan: capability.rollbackPlan,
+      expectedRuntimeTruth: capability.expectedRuntimeTruth ?? []
+    },
+    approvalScope: {
+      ...approvalScope,
+      approvalBypassReason: "low_risk_read"
+    },
+    approvalBypassReason: "low_risk_read",
+    rootExecutionStarted: false,
+    helperExecutionStarted: false,
+    redacted: true
+  };
+  const manifest = buildDashboardVpsMaintenanceManifest({
+    helperRequest,
+    now: payload?.now
+  });
+  const execution = createVpsPrivilegedMaintenanceHelperExecution({
+    payload: {
+      manifest,
+      helperRequest,
+      now: payload?.now
+    }
+  });
+  if (!execution.ok) {
+    return {
+      messageStatus: "blocked",
+      reply: buildDashboardVpsPrivilegedMaintenanceBlockedReply({
+        repository,
+        relatedIssue,
+        error: execution.error,
+        issues: execution.issues
+      }),
+      execution: {
+        kind: "dashboard_vps_privileged_maintenance_natural_language",
+        status: "blocked",
+        vpsProposalId: proposalBody?.vpsProposalId,
+        runtimeTruth: execution.body?.runtimeTruth || {
+          kind: "vps_privileged_maintenance_dashboard_natural_language",
+          status: "execution_handoff_blocked",
+          rootExecutionStarted: false,
+          helperExecutionStarted: false
+        }
+      }
+    };
+  }
+  const queue = await createVpsPrivilegedMaintenanceHelperExecutionQueue({
+    payload: {
+      repository,
+      issueNumber: relatedIssue,
+      executionId: normalizeText33(payload?.executionId || payload?.execution_id) || `dashboard-butler-issue${relatedIssue || "unknown"}-${safeIdentifier(helperRequest.requestId)}`,
+      dashboardThreadId: normalizeText33(payload?.threadId || payload?.thread_id),
+      approvalActor: "Dashboard Butler low-risk read",
+      executionEnvelope: execution.body.executionEnvelope
+    },
+    env
+  });
+  const reply = queue.ok ? buildDashboardVpsPrivilegedMaintenanceQueuedReply({
+    repository,
+    relatedIssue,
+    queue,
+    lowRiskRead: true
+  }) : buildDashboardVpsPrivilegedMaintenanceBlockedReply({
+    repository,
+    relatedIssue,
+    error: queue.error,
+    reason: queue.reason,
+    issues: queue.issues
+  });
+  return {
+    messageStatus: queue.ok ? "sent" : "blocked",
+    reply,
+    execution: {
+      kind: "dashboard_vps_privileged_maintenance_natural_language",
+      status: queue.ok ? "queued_for_vps_helper_execution" : "blocked",
+      vpsProposalId: proposalBody?.vpsProposalId,
+      approvalScope: proposalBody?.approvalScope,
+      helperRequest,
+      executionEnvelope: execution.body.executionEnvelope,
+      queue: queue.body?.execution || null,
+      runtimeTruth: {
+        ...queue.body?.runtimeTruth || {},
+        dashboardNaturalLanguagePathReached: true,
+        helperQueueReached: queue.ok === true,
+        approvalRequired: false,
+        approvalBypassReason: "low_risk_read",
         rootExecutionStarted: false,
         helperExecutionStarted: false
       }
@@ -68969,8 +69109,8 @@ function buildDashboardVpsPrivilegedMaintenanceApprovalRequiredReply({ repositor
     "\u627F\u8A8D\u5F8C\u306F VPS runner \u3078\u5FA9\u65E7\u4F9D\u983C\u3092\u6E21\u3057\u307E\u3059\u3002VPS runner \u306E\u5B8C\u4E86 truth \u304C\u623B\u308B\u307E\u3067\u3001live \u5B9F\u884C\u5B8C\u4E86\u3068\u306F\u6271\u3044\u307E\u305B\u3093\u3002"
   ].join("\n");
 }
-function buildDashboardVpsPrivilegedMaintenanceQueuedReply({ repository, relatedIssue, queue } = {}) {
-  const execution = queue?.execution || {};
+function buildDashboardVpsPrivilegedMaintenanceQueuedReply({ repository, relatedIssue, queue, lowRiskRead = false } = {}) {
+  const execution = (queue?.body?.execution || queue?.execution) ?? {};
   return [
     "VPS runner \u3078\u5FA9\u65E7\u4F9D\u983C\u3092\u6E21\u3057\u307E\u3057\u305F\u3002",
     "",
@@ -68978,7 +69118,7 @@ function buildDashboardVpsPrivilegedMaintenanceQueuedReply({ repository, related
     `- \u95A2\u9023 Issue: ${relatedIssue ? `#${relatedIssue}` : execution.issueNumber ? `#${execution.issueNumber}` : "\u672A\u6307\u5B9A"}`,
     `- executionId: ${execution.executionId || "\u672A\u751F\u6210"}`,
     `- queueCommentUrl: ${execution.queueCommentUrl || "\u672A\u53D6\u5F97"}`,
-    "- authority: passkey approval \u6E08\u307F\u306E bounded handoff \u3060\u3051\u3092 queue \u5316\u3057\u307E\u3057\u305F\u3002",
+    lowRiskRead ? "- authority: low-risk read \u306E\u305F\u3081 passkey approval \u306A\u3057\u3067 bounded handoff \u3057\u307E\u3057\u305F\u3002restart / mutation / root-required capability \u306F\u5BFE\u8C61\u5916\u3067\u3059\u3002" : "- authority: passkey approval \u6E08\u307F\u306E bounded handoff \u3060\u3051\u3092 queue \u5316\u3057\u307E\u3057\u305F\u3002",
     "- runtime truth: status=queued_for_vps_helper_execution, rootExecutionStarted=false, helperExecutionStarted=false",
     "",
     "VPS runner pickup \u306E\u5B8C\u4E86 truth \u304C\u623B\u308B\u307E\u3067\u3001live root \u5B9F\u884C\u5B8C\u4E86\u3068\u306F\u6271\u3044\u307E\u305B\u3093\u3002"


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #637 の部分進捗です。Dashboard Butler の自然文から VPS runner / app-server bridge の低リスク status/read を、passkey approval なしで bounded helper queue に渡せるようにします。restart / mutation / root-required capability は引き続き approval_required のままです。

## Satisfied Success Criteria

- Dashboard Butler の runner status 自然文が low-risk read として helper queue に到達します。Dashboard Butler の app-server bridge status 自然文が low-risk read として helper queue に到達します。queue/runtime truth に approvalRequired=false と approvalBypassReason=low_risk_read が残ります。repo-less bridge restart は approval_required のままです。high-risk Playwright add は approval_required のままです。

## Unsatisfied Success Criteria

- Issue #637 全体は未完了です。production VPS runner pickup / completed event の live evidence、restart/sync/root-required capability の実行 E2E、disable/remove/rollback lifecycle、iPhone/PWA passkey 実機 evidence は残っています。

## Non-goal violations

restart の無承認化、root/sudo 実行、credential mutation、permission mutation、disable/remove/rollback lifecycle、Issue #637 close、deploy。

## 開発前作戦図

- 作戦図 evidence: docs/development-strategy/issue-637-low-risk-read-no-passkey.md
- 完了体験: owner は VPS runner / app-server bridge の状態確認で毎回 passkey を開かず、Butler から bounded helper queue に診断依頼を渡せます。
- VTDD 全体で進める部分: Issue #637 の Butler-first recovery plane の初動診断を軽くします。
- 設計: 設計: Dashboard Butler 通常チャットの owner-facing 自然文 status/read を、low-risk review かつ non-root registry capability の時だけ passkey なし helper queue に接続する scope です。restart/high-risk/root-required は approval_required の boundary を維持します。
- 仮説: 原因仮説: 現 runtime は low-risk status/read でも approval_required にしているため、Issue #637 の recovery plane 初動診断が重い。予測: low-risk review だけ queue 化すれば権限境界を崩さず改善できます。
- 検証計画: focused worker tests、VPS privileged maintenance core/helper tests、build worker、generated worker check、diff check。
- 改修見積もり: src/worker/runtime.js: low-risk read 判定と queue 化。test/worker.test.js: HTTP/WebSocket regression。docs/butler/vps-privileged-maintenance-capability-lifecycle.md: authority boundary 追記。worker.js: generated bundle。
- 既に通っている経路: proposal、helper execution envelope、GitHub Issue queue、VPS runner pickup path は既存実装済みです。
- 未確認の境界: production VPS runner が low-risk read queue を拾って Dashboard に completed event を返す live evidence は未確認です。
- 穴が出そうな箇所: low-risk 判定を広げすぎると restart / root-required capability が approval なしになるリスクがあります。
- PR 前に確認すること: open PR なし、Issue #637 open、#590 evidence を兼ねる長めの turn として進行ログを観測。
- 実装候補と捨てた案: 捨てた案は Worker が VPS status を直接読む案、全て passkey のままにする案です。
- merge 後に通す E2E: production Dashboard Butler PWA E2E: VPS runner status を自然文で送り、passkey なし queue、VPS runner completed event、#590 進行ログを確認します。
- 次の PR を増やさない理由: この PR は low-risk read authority boundary だけに限定し、restart / root-required / lifecycle mutation は混ぜません。
- 停止条件: restart / enable / add / high risk / root-required capability が approval なしで進む場合は停止します。

## Dry-run Impact Report

- Target Issue: Issue #637
- Implementing Success Criteria: Dashboard Butler が自然文で VPS privileged maintenance intent を理解し、低リスク status/read を owner-facing に進められる。authority boundary を runtime truth に明示する。
- Explicit Non-goals: restart の無承認化、root/sudo 実行、credential mutation、permission mutation、deploy、Issue close。
- Expected touched files/routes/workflows: src/worker/runtime.js、test/worker.test.js、worker.js、docs/butler/vps-privileged-maintenance-capability-lifecycle.md、docs/development-strategy/issue-637-low-risk-read-no-passkey.md。
- Affected Issues: Issue #637。Issue #590 の deploy 後 E2E evidence を兼ねますが #590 完了とは扱いません。
- Affected PRs: なし。open PR は 0 件でした。
- Affected workflows: guarded-policy、test、review。workflow 定義は変更しません。
- Affected runtime/operator surfaces: Dashboard Butler PWA chat、DashboardChatRoom Durable Object、VPS maintenance helper queue、GitHub Issue comment queue。
- What may break if we patch narrowly: approval bypass が広がると restart/root-required operation まで承認なしになるリスクがあります。
- Unknowns to investigate before coding: production VPS runner pickup と completed event の実機反映。
- Validation needed: focused worker tests、core/helper tests、build worker、generated-worker check、CI、merge/deploy 後 production E2E。
- Stop condition: low-risk review 以外が approval なしで進む場合。

## Execution Queue Delta

- Queue position before: Issue #590 evidence を兼ねながら、Next の Issue #637 を開始します。
- Preemption decision: NEXT。Issue #590 の実機 evidence を兼ねて、次の root blocker Issue #637 を進めます。
- Queue delta: Issue #637 の low-risk read/status recovery lane を前進させます。Issue #637 全体は incomplete のままです。
- Why this PR is next: #590 の長時間 turn evidence を取りつつ、次の土台 root blocker #637 の初動診断を軽くするためです。
- Active Issues not downscoped: Active Issues は縮小しません。#637 以外の active Issue は未完了として残します。

## File / Line Hypotheses

- file: src/worker/runtime.js
  - hypothesis: buildDashboardVpsPrivilegedMaintenanceNaturalLanguageFlow が low-risk status でも approval_required にしている。
  - risk if changed narrowly: restart / high risk まで bypass される。
  - validation: runner status は queued、bridge restart は approval_required の worker test。
  - related Issue: Issue #637
- file: test/worker.test.js
  - hypothesis: HTTP/WebSocket の両経路で同じ authority boundary を検証する必要がある。
  - risk if changed narrowly: UI 経路だけ未接続になる。
  - validation: DashboardChatRoom tests。
  - related Issue: Issue #637

## Hypothesis Retrospective

- expected: low-risk review + non-root registry entry だけ queue 化できる。
- actual: approvalBypassReason=low_risk_read を helper request / queue runtime truth に残し、restart/high-risk は approval_required のまま維持した。
- mismatch: なし。
- lesson: Issue #637 の recovery plane は low-risk read と mutation/root-required を明確に分けるべき。
- should become RAG candidate: はい。#637 authority boundary の判断として候補。

## Verification Evidence

- Unit: node --test test/worker.test.js --test-name-pattern "VPS privileged maintenance|VPS runner status|app-server bridge recovery|repo-less Dashboard bridge restart|DashboardChatRoom routes VPS maintenance|WebSocket request origin" pass。Node は test/worker.test.js 271件を実行し、271 pass。
- Integration: node --test test/vps-privileged-maintenance.test.js test/vps-privileged-maintenance-helper-script.test.js --test-name-pattern "VPS privileged maintenance|helper|registry|low-risk" pass: 22 pass。npm run build:worker pass。npm run check:generated-worker pass。git diff --check pass。
- E2E: 未実施。production Dashboard Butler / VPS runner pickup は merge/deploy 後に実施します。
- Manual: この VPS local の full npm test は既存 env/vault credential 影響があるため、この PR では focused tests と CI clean runner で確認します。
- Evidence path/link: docs/development-strategy/issue-637-low-risk-read-no-passkey.md

## Butler Completion Contract

- Primary owner surface: Dashboard Butler PWA。
- Fallback surface: mac Codex は実装補助。owner-facing 完了経路ではありません。
- Owner goal: VPS runner / app-server bridge の状態確認を iPhone/iPad の Butler から軽く開始できること。
- Butler entrypoint: Dashboard Butler normal chat。
- Dashboard Butler natural-language path: Dashboard Butler の通常チャット入口から自然文を受け、VPS runner / app-server bridge status intent を low-risk read helper queue 経路へ接続します。
- Action Schema exposure: 既存 VPS maintenance route を利用。Action Schema はこの PR では変更しません。
- Runtime path: DashboardChatRoom owner_message -> buildDashboardVpsPrivilegedMaintenanceNaturalLanguageFlow -> low-risk read helper execution queue -> GitHub Issue queue comment。
- Runner/runtime truth: approvalRequired=false、approvalBypassReason=low_risk_read、rootExecutionStarted=false、helperExecutionStarted=false、helperQueueReached=true。
- Authority boundary: low-risk review + non-root registry capability のみ passkey 不要。restart / mutation / root-required / high-risk は passkey approval 必須。
- E2E evidence: 未実施。merge/deploy 後 production PWA で確認します。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: merge 後に必要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: merge/deploy 後に必要。

## Related Constitution Rules

- Butler Completion Gate
- Butler-First Operating Principle
- Drift Stop Protocol
- 開発前作戦図 Gate
- Authority Boundary
- Evidence Discipline
- Conversation UX Contract

## Out-of-scope but NOT implemented

- restart の無承認化
- root/sudo 実行
- credential mutation
- permission mutation
- disable/remove/rollback lifecycle
- Issue #637 close
- deploy

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #637
- Execution ID: issue-637-low-risk-read-no-passkey
- Goal: Dashboard Butler の低リスク VPS status/read を passkey なしで helper queue に渡す
