### PR TITLE
Issue #637 repo-less低リスクreadのrepository抽出を修正

### DIFF
--- a/docs/development-strategy/issue-637-repoless-low-risk-read-repo-extract.md
+++ b/docs/development-strategy/issue-637-repoless-low-risk-read-repo-extract.md
@@ -1,0 +1,78 @@
+# Issue #637 repo-less 低リスク read/status repository 解決
+
+## 完了体験
+
+Owner が Dashboard Butler の repo-less main chat で「Issue #637 E2E: VPS runner の status を確認して。repository は marushu/vtdd-v2-p。低リスク read/status として、passkey なしで helper queue に渡るか確認して。」と自然文で送る。Dashboard Worker は本文中の `owner/repo` を repository context として解決し、`systemd_user_runner_status` を `operation=review` / `riskLevel=low` / `requiresRoot=false` として判定し、passkey approval なしで bounded helper queue comment を作る。runtime truth は `approvalRequired=false` / `approvalBypassReason=low_risk_read` / `helperQueueReached=true` / `rootExecutionStarted=false` / `helperExecutionStarted=false` を返す。
+
+## VTDD 全体で進める部分
+
+Issue #637 の privileged maintenance lifecycle のうち、低リスク read/status の repo-less main chat 接続だけを進める。root helper 実行、restart、sync、credential、permission、deploy、Issue close は今回の対象外。
+
+## 設計
+
+現在の HTTP route は body の `repository` がある場合に queue 化できる。一方、repo-less PWA WebSocket では `repository` context が未指定のまま `resolveDashboardChatRepository` に入り、本文中の `repository は marushu/vtdd-v2-p` を拾えず `missingContext:["repository"]` の pass-through になる。
+
+修正は repository 解決の抽出器に限定する。文頭 `owner/repo` だけではなく、`repository は owner/repo`、`repo: owner/repo`、本文中の単独 `owner/repo` を canonical repository token として拾う。alias 推測や default repository は追加しない。
+
+## 仮説
+
+失敗原因は `extractRepositoryTokenFromDashboardChatText` が文頭 canonical token しか拾わないこと。今回の production E2E 文面では canonical token が本文中にあるため、repo-less thread の Worker preflight が repository 未解決として app-server bridge へ pass-through した。
+
+この仮説が正しければ、抽出器を本文中 canonical token 対応にすると、DashboardChatRoom WebSocket path でも `buildVpsMaintenanceIntentMessages` が Worker 内で queue 化し、app-server bridge へ送られない。
+
+## 検証計画
+
+- Unit: `extractRepositoryTokenFromDashboardChatText` を経由する WebSocket owner message で、本文中 `repository は marushu/vtdd-v2-p` が queue 化されることを `test/worker.test.js` で確認する。
+- Authority: queue comment body に `approvalBypassReason=low_risk_read` が含まれ、approval URL が出ないことを確認する。
+- Safety: root/helper 実行開始は Worker では起きず、`rootExecutionStarted=false` / `helperExecutionStarted=false` を確認する。
+- Worker bundle: `npm run verify:worker` を実行し、generated `worker.js` を更新する。
+- Production E2E: merge/deploy 後、同じ #637 prompt で 30秒以内に helper queue comment が作られ、runner pickup が passkey なしで進むことを確認する。
+
+## 改修見積もり
+
+- `src/worker/runtime.js`: `extractRepositoryTokenFromDashboardChatText`。本文中 canonical repository token の抽出を追加する。リスクは通常会話中の URL やコード断片を repository と誤認すること。`normalizeCanonicalRepositoryInput` の owner/repo 形式に限定して抑える。
+- `test/worker.test.js`: repo-less WebSocket + #637 low-risk read/status の回帰テストを追加する。リスクは既存 pass-through テストとの期待値衝突。既存 missing-context テストは repository が本文にないケースとして維持する。
+- `worker.js`: worker bundle 生成物。`src/worker/runtime.js` 変更に伴い更新する。
+
+## 既に通っている経路
+
+- HTTP `/v2/dashboard/chat/messages` に `repository` body がある場合、低リスク runner status は helper queue に到達する。
+- `docs/butler/vps-privileged-maintenance-capability-lifecycle.md` は低リスク read/status の passkey bypass 条件を定義済み。
+- VPS runner は `vtdd:vps-privileged-maintenance-execution` queue comment を pickup して helper へ渡せる。
+
+## 未確認の境界
+
+- production PWA の form dataset が repo-less main chat で空であることは turn context から推定しているが、今回の修正は dataset に依存しない。
+- owner text に複数 `owner/repo` が含まれる場合の優先順位は最初の canonical token とする。複数候補確認 UI は今回追加しない。
+
+## 穴が出そうな箇所
+
+- GitHub URL `https://github.com/owner/repo/...` 内の `owner/repo` を拾う可能性がある。これは repository 指定として実用上許容できるが、PR URL 等から repo が拾われるため、意図しない repo 切替には注意する。
+- `repository は` の日本語表現以外も拾うため、自然文中のコード例に owner/repo がある場合は repository context になる。デフォルト repo よりは安全だが、複数候補処理は未実装。
+
+## PR 前に確認すること
+
+- `git status --short --branch`
+- `npm run verify:worker`
+- 追加テストが既存 pass-through behavior を壊していないこと
+- PR body に #637 E2E 失敗コメントとこの strategy file を参照すること
+
+## 実装候補と捨てた案
+
+採用: repository token 抽出器を狭く拡張する。
+
+捨てた案: repo-less main chat に default repository を持たせる。Issue #613 の repo-less cross-repo 方針と衝突するため不採用。
+
+捨てた案: app-server bridge に判断させて helper queue comment を書かせる。Butler は中継機であり、低リスク read/status の authority 判定と queue handoff は Worker runtime truth として扱うべきなので不採用。
+
+## merge 後に通す E2E
+
+production deploy 後、Dashboard Butler repo-less main chat から同じ #637 prompt を送る。期待値は app-server bridge へ流れず Worker が butler message を返し、#637 に helper queue comment が作られ、VPS runner event が passkey なしで completed になること。#590 evidence として、進行中表示がリアルタイムに出るかは別途観察する。
+
+## 次の PR を増やさない理由
+
+この slice は #637 の production E2E failure の直接原因である repository 解決だけを修正する。root helper lifecycle や realtime progress は別 Issue / 別 slice であり、混ぜると authority と evidence が曖昧になる。
+
+## 停止条件
+
+repository token 抽出だけで queue 化できない場合、原因は repository 解決ではなく WebSocket path の Worker flow / memory provider / GitHub queue 作成にあるため、追加実装へ広げず停止して再設計する。高リスク操作が passkey なしで queue 化される兆候が出た場合も停止する。

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -10279,6 +10279,16 @@ function extractRepositoryTokenFromDashboardChatText(value) {
   if (canonicalMatch) {
     return canonicalMatch[1];
   }
+  const labeledCanonicalMatch = text.match(
+    /(?:repository|repo|リポジトリ|対象\s*repo)\s*(?:は|:|：|=)?\s*([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)/iu
+  );
+  if (labeledCanonicalMatch) {
+    return labeledCanonicalMatch[1];
+  }
+  const inlineCanonicalMatch = text.match(/(^|[^\w.-])([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)(?=$|[^\w.-])/u);
+  if (inlineCanonicalMatch) {
+    return inlineCanonicalMatch[2];
+  }
   const nicknameMatch = text.match(/^[\s　]*([^\s　#「『【\\/:]+?)(?:\s+|[　]*の|[　]*を|[　]*で|[　]*に)/u);
   return normalizeDashboardEventText(nicknameMatch?.[1]);
 }

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -3304,6 +3304,75 @@ test("worker detects app-server bridge recovery intent without internal VPS help
   ]);
 });
 
+test("DashboardChatRoom queues repo-less low-risk VPS runner status when repository is named in owner text", async () => {
+  const provider = createInMemoryMemoryProvider();
+  const store = createInMemoryDashboardChatStore();
+  const githubCalls = [];
+  const dashboardSocket = createMockSocket("dashboard", "dashboard-main-unresolved");
+  const bridgeSocket = createMockSocket("app_server_bridge", "dashboard-main-unresolved");
+  const room = new DashboardChatRoom(
+    {
+      storage: createMockDurableObjectStorage(),
+      getWebSockets() {
+        return [dashboardSocket, bridgeSocket];
+      }
+    },
+    {
+      ...gatewayAuthEnv,
+      DASHBOARD_CHAT_STORE: store,
+      MEMORY_PROVIDER: provider,
+      VTDD_RUNTIME_URL: "https://example.com",
+      VTDD_DASHBOARD_VPS_MAINTENANCE_HOST: "x85-131-245-163",
+      VTDD_DASHBOARD_VPS_MAINTENANCE_WORKDIR: "/home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p",
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_dashboard_vps",
+      GITHUB_API_FETCH: async (url, init) => {
+        githubCalls.push({ url, init });
+        return new Response(
+          JSON.stringify({
+            id: 63705,
+            html_url: "https://github.com/marushu/vtdd-v2-p/issues/637#issuecomment-63705"
+          }),
+          { status: 201, headers: { "content-type": "application/json" } }
+        );
+      }
+    }
+  );
+
+  await room.webSocketMessage(
+    dashboardSocket,
+    JSON.stringify({
+      type: "owner_message",
+      threadId: "dashboard-main-unresolved",
+      text: [
+        "Issue #637 E2E: VPS runner の status を確認して。",
+        "repository は marushu/vtdd-v2-p。",
+        "低リスク read/status として、passkey なしで helper queue に渡るか確認して。"
+      ].join("\n")
+    })
+  );
+
+  assert.equal(bridgeSocket.sent.length, 0);
+  assert.equal(githubCalls.length, 1);
+  const queueCommentBody = JSON.parse(githubCalls[0].init.body).body;
+  assert.equal(queueCommentBody.includes("vtdd:vps-privileged-maintenance-execution:"), true);
+  assert.equal(queueCommentBody.includes('"repository": "marushu/vtdd-v2-p"'), true);
+  assert.equal(queueCommentBody.includes('"issueNumber": 637'), true);
+  assert.equal(queueCommentBody.includes('"transport": "vps_privileged_maintenance_helper"'), true);
+  assert.equal(queueCommentBody.includes('"approvalBypassReason": "low_risk_read"'), true);
+
+  const finalBroadcast = dashboardSocket.sent.map((message) => JSON.parse(message)).findLast((message) => message.type === "thread");
+  assert.equal(finalBroadcast.type, "thread");
+  assert.equal(finalBroadcast.messages.length, 2);
+  assert.equal(finalBroadcast.messages[0].role, "owner");
+  assert.equal(finalBroadcast.messages[0].repository, "marushu/vtdd-v2-p");
+  assert.equal(finalBroadcast.messages[0].relatedIssue, 637);
+  assert.equal(finalBroadcast.messages[1].role, "butler");
+  assert.equal(finalBroadcast.messages[1].status, "sent");
+  assert.match(finalBroadcast.messages[1].text, /VPS runner へ復旧依頼を渡しました/);
+  assert.match(finalBroadcast.messages[1].text, /low-risk read/);
+  assert.doesNotMatch(finalBroadcast.messages[1].text, /approval URL/);
+});
+
 test("worker reports Dashboard VPS maintenance config blockers before creating a proposal", async () => {
   const store = createInMemoryDashboardChatStore();
   const provider = createInMemoryMemoryProvider();

--- a/worker.js
+++ b/worker.js
@@ -67003,6 +67003,16 @@ function extractRepositoryTokenFromDashboardChatText(value) {
   if (canonicalMatch) {
     return canonicalMatch[1];
   }
+  const labeledCanonicalMatch = text.match(
+    /(?:repository|repo|リポジトリ|対象\s*repo)\s*(?:は|:|：|=)?\s*([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)/iu
+  );
+  if (labeledCanonicalMatch) {
+    return labeledCanonicalMatch[1];
+  }
+  const inlineCanonicalMatch = text.match(/(^|[^\w.-])([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)(?=$|[^\w.-])/u);
+  if (inlineCanonicalMatch) {
+    return inlineCanonicalMatch[2];
+  }
   const nicknameMatch = text.match(/^[\s　]*([^\s　#「『【\\/:]+?)(?:\s+|[　]*の|[　]*を|[　]*で|[　]*に)/u);
   return normalizeDashboardEventText(nicknameMatch?.[1]);
 }


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #637 の部分進捗です。repo-less Dashboard Butler main chat で owner が本文中に `repository は marushu/vtdd-v2-p` と書いた場合でも、低リスク VPS runner status/read を passkey なしで helper queue に渡せるようにします。
- 2026-06-04 の production E2E 失敗 `#637 低リスク read/status が helper queue に到達しない` の直接原因に対応します。

## Satisfied Success Criteria

- Dashboard Butler が自然文の VPS runner status intent を Worker 内で解決し、helper queue に bounded handoff できる。
- 低リスク read/status は `approvalRequired=false` / `approvalBypassReason=low_risk_read` として queue comment に残る。
- Worker は root / helper execution を直接開始せず、`rootExecutionStarted=false` / `helperExecutionStarted=false` の境界を維持する。

## Unsatisfied Success Criteria

- Issue #637 全体の root-owned helper lifecycle、capability add/disable/remove/rollback、production iPhone/PWA mapped E2E は未完了です。
- merge/deploy 後の production Dashboard Butler live E2E は未実施です。

## Non-goal violations

None.

## 開発前作戦図

- 作戦図 evidence: `docs/development-strategy/issue-637-repoless-low-risk-read-repo-extract.md`
- 完了体験: Owner が Dashboard Butler の repo-less main chat で `Issue #637 E2E: VPS runner の status を確認して。repository は marushu/vtdd-v2-p。低リスク read/status として、passkey なしで helper queue に渡るか確認して。` を送ると、Worker が repository / Issue / low-risk status intent を解決して helper queue comment を作る。
- VTDD 全体で進める部分: Issue #637 の low-risk read/status recovery lane を、repo-less Dashboard Butler 入口から VPS runner queue へ接続する。
- 設計: `extractRepositoryTokenFromDashboardChatText` を canonical `owner/repo` 抽出に限定して拡張し、本文中 repository 指定を既存 Worker flow に渡す。
- 仮説: production 失敗の原因は repository token が文頭以外にあると repo-less WebSocket path で解決されず、missingContext に repository が残ること。
- 検証計画: WebSocket `DashboardChatRoom` テストで repo-less thread、本文中 repository 指定、Issue #637、VPS runner status、passkey なし queue comment を確認する。
- 改修見積もり: `src/worker/runtime.js` の repository token 抽出、`test/worker.test.js` の回帰テスト、`worker.js` generated bundle。
- 既に通っている経路: HTTP body に repository がある場合の low-risk runner status queue handoff は既存テストで通っていた。
- 未確認の境界: production PWA の live E2E は merge/deploy 後に再確認する。複数 repository token が本文にある場合の確認 UI は今回未実装。
- 穴が出そうな箇所: GitHub URL など本文中の `owner/repo` も repository として拾う可能性がある。default repo より安全だが、複数候補処理は将来の課題。
- PR 前に確認すること: `npm run check:generated-worker`、`npm run check:self-parity`、追加 Worker テストを実行して確認し、`verify:worker` の失敗理由を分離する。
- 実装候補と捨てた案: default repository 導入は Issue #613 の repo-less 方針と衝突するため不採用。app-server bridge 側で helper queue を書く案は authority truth が分散するため不採用。
- merge 後に通す E2E: production Dashboard Butler repo-less main chat から同じ #637 prompt を送り、30秒以内に helper queue comment と runner pickup を確認する E2E を通す。
- 次の PR を増やさない理由: この PR は production E2E failure の直接原因である repository 解決だけを直す。#590 realtime progress や #637 root lifecycle は混ぜない。
- 停止条件: 高リスク restart/root/credential/permission が passkey なしで queue 化される兆候が出た場合、または repository 抽出だけで queue 化できない場合は停止する。

## Dry-run Impact Report

- Target Issue: Issue #637
- Implementing Success Criteria: 低リスク read/status intent を Dashboard Butler repo-less main chat から passkey なしで helper queue に渡す。
- Explicit Non-goals: restart、root-required capability、credential mutation、permission mutation、deploy、Issue close、#590 realtime progress 実装。
- Expected touched files/routes/workflows: `src/worker/runtime.js`、`test/worker.test.js`、`worker.js`、`docs/development-strategy/issue-637-repoless-low-risk-read-repo-extract.md`
- Affected Issues: Issue #637。Issue #590 は production E2E 観察対象だがこの PR の実装対象ではありません。
- Affected PRs: なし。
- Affected workflows: `npm run verify:worker` / generated-worker check。GitHub Actions の deploy workflow 自体は未変更。
- Affected runtime/operator surfaces: Dashboard Butler WebSocket chat、Worker repository resolution、VPS helper queue handoff。
- What may break if we patch narrowly: 本文中の GitHub URL から repository が拾われる可能性がある。複数 repository 候補の曖昧性は今回未処理。
- Unknowns to investigate before coding: production PWA live で form dataset が空でも本文抽出で queue 化できるか。
- Validation needed: unit/integration Worker test、generated-worker check、self-parity、merge/deploy 後 production E2E。
- Stop condition: high-risk operation が approval bypass される、または queue comment が repository/issue を誤って作る。

## Execution Queue Delta

- Queue position before: Issue #637 は #590 後の Next だが、#637 production E2E failure が確認されたため、この bounded repair を現在の Issue #637 evidence gap 修正として進める。
- Preemption decision: EVIDENCE。実装済み slice の production E2E が未達で、helper queue 到達 evidence を作れないため修正する。
- Queue delta: Issue #637 の Evidence Gaps `repo-less main chat の自然文 repository 指定が low-risk helper queue に届かない` をこの PR で解消する。Issue #590 realtime progress は未完了のまま残す。
- Why this PR is next: この修正がないと owner が iPad/iPhone の repo-less main chat から VPS runner status を確認できず、Butler-first recovery plane の E2E が進まない。
- Active Issues not downscoped: Active Issues は縮小しません。この PR は #637 の低リスク read/status repository 解決だけを扱い、他 Issue は未完了として残します。

## File / Line Hypotheses

- file: `src/worker/runtime.js` / `extractRepositoryTokenFromDashboardChatText`
  - hypothesis: 文頭以外の canonical repository token を拾えず、repo-less WebSocket path が missingContext repository で pass-through していた。
  - risk if changed narrowly: 複数 repository 候補の曖昧性 UI は未解決。
  - validation: repo-less WebSocket owner message が bridge へ行かず helper queue comment を作るテスト。
  - related Issue: #637
- file: `test/worker.test.js`
  - hypothesis: production 失敗文面を単体テストに固定すれば回帰を防げる。
  - risk if changed narrowly: production Cloudflare / GitHub 実環境は別途 E2E が必要。
  - validation: `node --test test/worker.test.js --test-name-pattern "repo-less low-risk VPS runner status"`
  - related Issue: #637

## Hypothesis Retrospective

- expected: 本文中 `repository は marushu/vtdd-v2-p` を抽出すれば、repo-less WebSocket path が low-risk runner status queue を作る。
- actual: 追加テストで `bridgeSocket.sent.length=0`、GitHub queue comment 生成、`approvalBypassReason=low_risk_read` を確認した。
- mismatch: memory record 内部形式の追加検査は過剰だったため削除し、owner-facing / GitHub queue truth に寄せた。
- lesson: #637 の E2E は HTTP body repository だけでなく repo-less WebSocket の自然文 repository 指定で固定する必要がある。
- should become RAG candidate: はい。repo-less main chat の自然文 repository 指定は、default repo ではなく本文中 canonical token 抽出で扱う。

## Verification Evidence

- Unit: `node --test test/worker.test.js --test-name-pattern "repo-less low-risk VPS runner status"` pass。`node --test test/worker.test.js --test-name-pattern "repo-less low-risk VPS runner status"` では 272 tests / 272 pass。
- Integration: `npm run check:generated-worker` pass。`npm run check:self-parity` pass、35 routes / 35 operationIds。
- E2E: 未実施。merge/deploy 後に production Dashboard Butler repo-less main chat で #637 prompt を再実行する。
- Manual: `npm run verify:worker` は build と worker 関連テストを通過したが、全体 `npm test` で今回変更と別面の環境依存失敗が4件残った。
- Evidence path/link: `docs/development-strategy/issue-637-repoless-low-risk-read-repo-extract.md`

## Butler Completion Contract

- Primary owner surface: Dashboard Butler。
- Fallback surface: mac Codex は debug fallback として残るが、主経路ではありません。
- Owner goal: repo-less Dashboard Butler main chat から VPS runner status を自然文で確認し、低リスク read/status は passkey なしで helper queue に渡る。
- Butler entrypoint: Dashboard Butler 通常チャット。
- Dashboard Butler natural-language path: Dashboard Butler の自然文 / 通常チャット入口で、本文中 repository 指定を解決して VPS maintenance low-risk queue handoff に到達する。
- Action Schema exposure: Custom GPT fallback 用の Action Schema surface はこの PR では未変更。
- Runtime path: `DashboardChatRoom.acceptOwnerMessage` → `resolveDashboardChatRepository` → `buildVpsMaintenanceIntentMessages` → `queueDashboardVpsMaintenanceLowRiskRead`。
- Runner/runtime truth: queue comment に `transport=vps_privileged_maintenance_helper`、`approvalBypassReason=low_risk_read`、`rootExecutionStarted=false`、`helperExecutionStarted=false` が残る。
- Authority boundary: low-risk review/status のみ approval bypass。restart/root/credential/permission/deploy/destructive は passkey / GO 境界を維持。
- E2E evidence: production E2E は未実施。merge/deploy 後に #637 prompt で helper queue 到達と runner pickup を確認する。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: merge 後に必要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 必要。production deploy 後に #637 prompt を再実行する。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate
- AGENTS.md 開発前作戦図 Gate
- AGENTS.md Authority Boundary
- docs/butler/vps-privileged-maintenance-capability-lifecycle.md
- docs/butler/execution-queue-contract.md

## Out-of-scope but NOT implemented

- #590 realtime progress checkpoint stream
- #637 root-owned helper lifecycle completion
- restart/root/credential/permission/deploy の approval bypass
- Issue #637 close

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #637
- Execution ID: issue-637-repoless-low-risk-read-repo-extract
- Goal: repo-less Dashboard Butler main chat の自然文 repository 指定を低リスク VPS runner status queue に接続する
