### PR TITLE
Issue #590 realtime progress checkpoint stream

### DIFF
--- a/docs/development-strategy/issue-590-realtime-progress-checkpoints.md
+++ b/docs/development-strategy/issue-590-realtime-progress-checkpoints.md
@@ -1,0 +1,107 @@
+# Issue #590 realtime progress checkpoint stream 作戦図
+
+## 完了体験
+
+Dashboard Butler で長時間の VPS Codex CLI / app-server bridge 作業を投げたとき、owner は無言で待たされない。低情報の状態、たとえば「考えています」「コマンドを実行しています」は composer 下の一時状態として表示し続ける。一方で owner-facing な進行 checkpoint は通常チャット欄の末尾に表示され、アプリ切替、スリープ、WebSocket 再接続後も最新 checkpoint 1件から復帰できる。
+
+完了時は checkpoint 表示を消し、最終 Butler 返信に折りたたみの `進行ログ` として集約する。通常チャット履歴に raw event や高頻度 progress message は残さない。
+
+## VTDD 全体で進める部分
+
+この slice は #590 の realtime progress checkpoint stream の最小実装に限定する。#637 の production E2E で確認した「低リスク read/status が passkey なしで helper queue に渡る」経路を、#590 の進行表示 E2E の観測対象として使えるようにする。
+
+## 設計
+
+既存実装には `transient_progress_snapshot:<threadId>` があり、Durable Object に最新 snapshot 1件だけ保存される。これを新しい永続 chat message にせず、Dashboard UI が chat log 内に ephemeral checkpoint card として描画する。
+
+分類は二層にする。
+
+- composer 下: transport/transient 状態。`thinking` / `command` / `quiet` など低情報の状態も表示する。
+- chat 内 checkpoint: owner-facing progress。`planning` / `implementation` / `test` / `PR作成` / `CI待ち` など、作業段階が分かるものだけを表示する。
+
+完了時は現在の `attachDashboardProgressSummaryToFinalMessages` を使い、snapshot の `progressSummary` を最終返信に付ける。snapshot は最終返信後に clear されるため、chat 内 checkpoint card も消える。
+
+## 仮説
+
+現在の不満の根は、bridge が進行 event を受けて transient snapshot へ保存しているのに、UI がそれを composer 下の「進行中」枠としてしか描画していないことにある。iPad でアプリ切替やスリープが入ると composer 下の一時表示は見失いやすく、owner の体感は「最後にまとめて出る」になる。
+
+狭く durable chat message を増やすと、通常履歴が progress で汚れ、Cloudflare write も増える。逆に既存 snapshot を chat log 内に描画するだけなら、write volume は増えず、復帰可能性も保てる。
+
+## 検証計画
+
+- `DashboardChatRoom` が bridge status を受けたとき、低情報 progress は snapshot text としては保持するが `progressSummary.entries` には入れない。
+- owner-facing progress は `progressSummary.entries` に入り、final reply の `進行ログ` に集約される。
+- reply delta は従来通り snapshot / durable chat message にしない。
+- Dashboard HTML に chat 内 checkpoint card の描画経路があり、snapshot restore / WebSocket transient update / final reply clear で動く。
+- worker bundle を再生成し、generated worker 差分を一致させる。
+
+## 改修見積もり
+
+- `src/worker/runtime.js`
+  - `buildDashboardProgressSummarySnapshot`: 低情報 progress を summary から除外する。既存 snapshot write は維持する。
+  - Dashboard client script: `transientProgressSnapshot.progressSummary` から最新 checkpoint を chat log 内に ephemeral card として描画し、clear 時に消す。
+  - Dashboard CSS: checkpoint card と progress summary の dark mode 対応を最小限整える。
+- `test/worker.test.js`
+  - 低情報 progress が summary に入らないこと。
+  - owner-facing progress が summary と final reply に残ること。
+  - thread reconnect payload は既存通り latest snapshot 1件を返すこと。
+- `worker.js`
+  - `npm run build:worker` で生成更新する。
+
+## 既に通っている経路
+
+- `scripts/run-dashboard-app-server-bridge.mjs` は `app_server_status` / `app_server_reply_delta` / `app_server_reply` を worker へ送る。
+- `DashboardChatRoom.acceptAppServerBridgeMessage` は bridge event を正規化し、`transient_status` と final reply を配信する。
+- `writeTransientProgressSnapshot` は DO に最新 snapshot 1件を保存する。
+- `sendThread` / `broadcastThread` は `transientProgressSnapshot` を Dashboard UI に返す。
+- final reply には `attachDashboardProgressSummaryToFinalMessages` で `進行ログ` を付けられる。
+
+## 未確認の境界
+
+- app-server bridge が 30秒以内に必ず owner-facing stage を送るかは、この slice だけでは保証しない。
+- WebSocket が iPad PWA のバックグラウンドで停止する挙動自体は、この slice では直さない。復帰時に snapshot から見えることを優先する。
+- raw assistant delta をそのまま checkpoint にするかは未採用。思考や未整理文を流すリスクがあるため、この slice では stage-based checkpoint に限定する。
+
+## 穴が出そうな箇所
+
+- 低情報判定を強くしすぎると、final `進行ログ` が薄くなる。
+- chat 内 checkpoint card を通常 message と同じ DOM に入れると、copy/reply/scroll の既存挙動を壊す可能性がある。
+- completion 後の clear が漏れると、古い checkpoint が final reply の下に残る。
+- dark mode の progress summary 背景が light 固定だと #744 の見えづらさを悪化させる。
+
+## PR 前に確認すること
+
+- `git status --short --branch`
+- targeted worker tests
+- `npm run build:worker`
+- `npm run check:generated-worker`
+- `npm run check:self-parity`
+- 可能なら `npm run verify:worker`。既知の環境依存失敗が残る場合は、失敗箇所を PR に明記する。
+
+## 実装候補と捨てた案
+
+採用候補は、既存 DO snapshot 1件を chat log 内の ephemeral checkpoint card として表示する案。
+
+捨てた案:
+
+- raw event を durable chat message として append する案。履歴汚染と DO/D1 write 増加が大きい。
+- `app_server_reply_delta` をそのまま表示する案。owner-facing に未整理で、内部思考や断片表示のリスクがある。
+- Cloudflare Queue / D1 に progress event stream を保存する案。#590 の目的に対して重く、コスト境界に反する。
+
+## merge 後に通す E2E
+
+- production PWA から #637 相当の低リスク read/status を投げ、30秒以内に composer 下の transient と chat 内 checkpoint のどちらかが見えること。
+- app 切替またはリロード後、最新 checkpoint が chat log 内に復帰すること。
+- completion 後、checkpoint card が消え、最終 Butler 返信に `進行ログ` が残ること。
+- low-risk read/status は passkey なし、deploy / bridge restart は従来通り passkey 境界を維持すること。
+
+## 次の PR を増やさない理由
+
+この slice は #590 の根本 blocker に直結し、既存 snapshot 経路を再利用するため、UI と worker runtime を分けると E2E が成立しない。#741 の通知チャット化と #744 の表示崩れ本体は別 Issue として残し、この PR には混ぜない。
+
+## 停止条件
+
+- app-server bridge が owner-facing stage を送っていないことが判明した場合。
+- snapshot 1件では復帰体験を満たせず、追加 durable event stream が必要だと判明した場合。
+- chat message と checkpoint card の区別が UI/テストで曖昧になり、通常履歴を汚す恐れが出た場合。
+- Issue #590 の要件と矛盾する既存 contract が見つかった場合。

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -636,12 +636,14 @@ export class DashboardChatRoom {
         source: snapshotSource
       });
     }
+    const transientProgressSnapshot = snapshot === true ? await this.readTransientProgressSnapshot(threadId) : null;
     const payload = JSON.stringify({
       type: "transient_status",
       ok: true,
       threadId,
       status,
-      text
+      text,
+      transientProgressSnapshot
     });
     for (const socket of this.connectedSockets()) {
       const attachment = this.getSocketAttachment(socket);
@@ -9997,7 +9999,7 @@ function buildDashboardProgressSummarySnapshot(previous, { text = "" } = {}) {
   const previousSummary = normalizeDashboardProgressSummary(previous?.progressSummary);
   const entries = [...previousSummary.entries];
   const normalizedText = sanitizeDashboardChatText(text);
-  if (normalizedText) {
+  if (normalizedText && shouldIncludeDashboardProgressSummaryEntry(normalizedText)) {
     const latest = entries.at(-1);
     if (!latest || latest.text !== normalizedText) {
       entries.push({
@@ -10010,6 +10012,14 @@ function buildDashboardProgressSummarySnapshot(previous, { text = "" } = {}) {
     entries,
     updatedAt: new Date().toISOString()
   });
+}
+
+function shouldIncludeDashboardProgressSummaryEntry(text) {
+  const normalizedText = sanitizeDashboardChatText(text);
+  if (!normalizedText) {
+    return false;
+  }
+  return !DASHBOARD_LOW_INFORMATION_PROGRESS_TEXT.has(normalizedText);
 }
 
 function dashboardProgressSummaryEntriesKey(progressSummary) {
@@ -10190,6 +10200,13 @@ const DASHBOARD_APP_SERVER_STAGE_TEXT = {
 const DASHBOARD_DURABLE_APP_SERVER_PROGRESS_STAGES = new Set([
   "waiting_approval",
   "waiting_user_input"
+]);
+
+const DASHBOARD_LOW_INFORMATION_PROGRESS_TEXT = new Set([
+  "考えています。",
+  "コマンドを実行しています。",
+  "外部ツールの結果を待っています。",
+  "接続と実行状態を確認中です。入力と文脈は保持しています。"
 ]);
 
 function buildDashboardOwnerFacingTransientStatusText(input, { status = "", text = "", transientStatus = "" } = {}) {
@@ -16055,6 +16072,10 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
     .progress-summary summary { cursor: pointer; font-weight: 800; color: var(--text); }
     .progress-summary ol { margin: 10px 0 0; padding-left: 22px; }
     .progress-summary li { margin-top: 6px; overflow-wrap: anywhere; word-break: break-word; }
+    .progress-checkpoint-entry { opacity: .92; }
+    .progress-checkpoint-bubble { color: var(--muted); }
+    .progress-checkpoint-bubble .bubble-header strong { color: var(--muted); }
+    .progress-checkpoint-bubble .message-body p { color: var(--text); }
     .reply-context { display: grid; grid-template-columns: minmax(0, 1fr); gap: 2px; width: min(100%, 680px); margin: 0 0 10px; padding: 8px 10px; border: 0; border-left: 3px solid var(--border); border-radius: 0 8px 8px 0; background: var(--soft); color: var(--muted); font: inherit; font-size: 12px; line-height: 1.45; text-align: left; cursor: pointer; }
     .reply-context:hover, .reply-context:focus-visible { color: var(--text); background: var(--panel-strong); outline: none; }
     .reply-context:focus-visible { box-shadow: 0 0 0 2px var(--link); }
@@ -16339,6 +16360,8 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
       const renderedMessagesById = new Map();
       let transientProgressCard = null;
       let transientProgressState = null;
+      let threadProgressCheckpointCard = null;
+      let transientProgressSnapshotState = null;
       let latestOwnerReplySource = null;
       let lastMediaLightboxTrigger = null;
       let pendingOwnerSend = null;
@@ -16614,13 +16637,16 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           title: options.title || "進行中",
           text: normalized,
           status: String(options.status || ""),
-          thinking: options.thinking === true
+          thinking: options.thinking === true,
+          snapshot: options.snapshot || null
         };
         renderTransientProgress();
+        renderThreadProgressCheckpoint(options.snapshot || null);
       }
 
       function clearTransientProgress() {
         transientProgressState = null;
+        transientProgressSnapshotState = null;
         if (transientProgressCard) {
           if (transientProgressCard === progressPane) {
             transientProgressCard.hidden = true;
@@ -16631,6 +16657,68 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
             transientProgressCard.remove();
           }
           transientProgressCard = null;
+        }
+        clearThreadProgressCheckpoint();
+      }
+
+      function latestProgressCheckpointText(snapshot) {
+        const entries = Array.isArray(snapshot && snapshot.progressSummary && snapshot.progressSummary.entries)
+          ? snapshot.progressSummary.entries
+          : [];
+        return [...entries]
+          .reverse()
+          .map((entry) => String(entry && entry.text || entry || "").trim())
+          .find(Boolean) || "";
+      }
+
+      function ensureThreadProgressCheckpointCard() {
+        if (threadProgressCheckpointCard && threadProgressCheckpointCard.isConnected) {
+          return threadProgressCheckpointCard;
+        }
+        const entry = document.createElement("div");
+        entry.className = "message-entry butler progress-checkpoint-entry";
+        entry.setAttribute("data-thread-progress-checkpoint", "true");
+        const article = document.createElement("article");
+        article.className = "bubble progress-checkpoint-bubble";
+        const header = document.createElement("div");
+        header.className = "bubble-header";
+        const strong = document.createElement("strong");
+        strong.textContent = "Butler";
+        header.appendChild(strong);
+        const body = document.createElement("div");
+        body.className = "message-body";
+        const paragraph = document.createElement("p");
+        body.appendChild(paragraph);
+        article.appendChild(header);
+        article.appendChild(body);
+        entry.appendChild(article);
+        threadProgressCheckpointCard = entry;
+        log.appendChild(entry);
+        return entry;
+      }
+
+      function renderThreadProgressCheckpoint(snapshot) {
+        if (snapshot && typeof snapshot === "object") {
+          transientProgressSnapshotState = snapshot;
+        }
+        const text = latestProgressCheckpointText(transientProgressSnapshotState);
+        if (!text) {
+          clearThreadProgressCheckpoint();
+          return false;
+        }
+        const card = ensureThreadProgressCheckpointCard();
+        const paragraph = card.querySelector(".message-body p");
+        if (paragraph) {
+          paragraph.textContent = text;
+        }
+        scrollToLatest();
+        return true;
+      }
+
+      function clearThreadProgressCheckpoint() {
+        if (threadProgressCheckpointCard) {
+          threadProgressCheckpointCard.remove();
+          threadProgressCheckpointCard = null;
         }
       }
 
@@ -16898,7 +16986,8 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         updateTransientProgress(text, {
           status: statusValue,
           thinking: statusValue === "thinking" || statusValue === "pending_app_server_bridge",
-          title: statusValue === "pending_app_server_bridge" ? "返信待ち" : "進行中"
+          title: statusValue === "pending_app_server_bridge" ? "返信待ち" : "進行中",
+          snapshot
         });
         setStatus(text, { thinking: true });
         return true;
@@ -17724,23 +17813,16 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
 
       function renderThread(messages, options = {}) {
         const replace = options.replace === true;
-        const hadTransientProgress = Boolean(transientProgressState);
-        const existingTransientProgressCard = hadTransientProgress && transientProgressCard
-          ? transientProgressCard
-          : null;
+        const snapshotForCheckpoint = transientProgressSnapshotState;
         if (replace) {
           messagesById.clear();
         }
         resetRenderedReplyContext();
         if (!Array.isArray(messages) || messages.length === 0) {
           if (replace || messagesById.size === 0) {
-            if (existingTransientProgressCard) {
-              log.replaceChildren(existingTransientProgressCard);
-              renderTransientProgress();
-            } else {
-              log.innerHTML = initialMarkup;
-            }
+            log.innerHTML = initialMarkup;
           }
+          renderThreadProgressCheckpoint(snapshotForCheckpoint);
           scrollToLatest();
           return;
         }
@@ -17751,13 +17833,8 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         for (const message of messagesById.values()) {
           appendMessage(message, fragment, { scroll: false });
         }
-        if (existingTransientProgressCard) {
-          fragment.appendChild(existingTransientProgressCard);
-        }
         log.replaceChildren(fragment);
-        if (hadTransientProgress) {
-          renderTransientProgress();
-        }
+        renderThreadProgressCheckpoint(snapshotForCheckpoint);
         scrollToLatest();
       }
 
@@ -17871,7 +17948,8 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
                   updateTransientProgress(transientText, {
                     status: body.status,
                     thinking: true,
-                    title: "進行中"
+                    title: "進行中",
+                    snapshot: body.transientProgressSnapshot || null
                   });
                 } else {
                   clearTransientProgress();

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -16068,7 +16068,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
     .bubble .message-body pre code { display: block; max-width: 100%; white-space: pre-wrap; overflow-wrap: anywhere; word-break: break-word; font-size: 14px; line-height: 1.55; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace; }
     .bubble .message-body pre.wrap-code code { white-space: pre-wrap; overflow-wrap: anywhere; word-break: break-word; }
     .bubble .message-body strong { display: inline; color: inherit; font-size: inherit; letter-spacing: 0; text-transform: none; margin: 0; font-weight: 800; }
-    .progress-summary { margin-top: 12px; border: 1px solid var(--border); border-radius: 10px; padding: 10px 12px; background: rgba(247, 248, 244, .8); color: var(--muted); }
+    .progress-summary { margin-top: 12px; border: 1px solid var(--border); border-radius: 10px; padding: 10px 12px; background: var(--panel-strong); color: var(--muted); }
     .progress-summary summary { cursor: pointer; font-weight: 800; color: var(--text); }
     .progress-summary ol { margin: 10px 0 0; padding-left: 22px; }
     .progress-summary li { margin-top: 6px; overflow-wrap: anywhere; word-break: break-word; }

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -1273,6 +1273,12 @@ test("worker serves v2 dashboard for allowed owner identity without exposing sec
   assert.equal(body.includes("function renderProgressSummaryDetails(progressSummary)"), true);
   assert.equal(body.includes("進行ログ"), true);
   assert.equal(body.includes(".progress-summary"), true);
+  assert.equal(body.includes("background: var(--panel-strong); color: var(--muted);"), true);
+  assert.equal(body.includes("data-thread-progress-checkpoint"), true);
+  assert.equal(body.includes("function renderThreadProgressCheckpoint(snapshot)"), true);
+  assert.equal(body.includes("function clearThreadProgressCheckpoint()"), true);
+  assert.equal(body.includes("latestProgressCheckpointText(transientProgressSnapshotState)"), true);
+  assert.equal(body.includes("snapshot: body.transientProgressSnapshot || null"), true);
   const renderTransientProgressSource = body.match(/function renderTransientProgress\(\) \{[\s\S]*?\n      \}/)?.[0] || "";
   assert.equal(renderTransientProgressSource.includes("scrollToLatest()"), false);
   assert.equal(renderTransientProgressSource.includes("updateComposerReserve()"), true);

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -5078,7 +5078,62 @@ test("DashboardChatRoom dedupes unchanged transient progress snapshot writes", a
   const snapshotPuts = storage.putCalls.filter((call) => call.key === "transient_progress_snapshot:dashboard-main-unresolved");
   assert.equal(snapshotPuts.length, 1);
   assert.equal(snapshotPuts[0].value.text, "コマンドを実行しています。");
+  assert.equal(snapshotPuts[0].value.progressSummary, undefined);
   assert.equal(dashboardSocket.sent.map((message) => JSON.parse(message)).filter((message) => message.type === "transient_status").length, 2);
+});
+
+test("DashboardChatRoom separates low-information transient progress from owner-facing progress checkpoints", async () => {
+  const store = createInMemoryDashboardChatStore();
+  const dashboardSocket = createMockSocket("dashboard", "dashboard-main-unresolved");
+  const bridgeSocket = createMockSocket("app_server_bridge", "dashboard-main-unresolved");
+  const storage = createMockDurableObjectStorage();
+  const room = new DashboardChatRoom(
+    {
+      storage,
+      getWebSockets() {
+        return [dashboardSocket, bridgeSocket];
+      }
+    },
+    { DASHBOARD_CHAT_STORE: store }
+  );
+
+  await room.webSocketMessage(
+    bridgeSocket,
+    JSON.stringify({
+      type: "app_server_status",
+      status: "thinking",
+      stage: "command",
+      threadId: "dashboard-main-unresolved",
+      codexThreadId: "codex-thread-590",
+      text: "raw command detail"
+    })
+  );
+  await room.webSocketMessage(
+    bridgeSocket,
+    JSON.stringify({
+      type: "app_server_status",
+      status: "thinking",
+      stage: "implementation",
+      threadId: "dashboard-main-unresolved",
+      codexThreadId: "codex-thread-590",
+      text: "raw implementation detail"
+    })
+  );
+
+  const snapshot = storage.values.get("transient_progress_snapshot:dashboard-main-unresolved");
+  assert.equal(snapshot.text, "実装に入っています。");
+  assert.deepEqual(
+    snapshot.progressSummary.entries.map((entry) => entry.text),
+    ["実装に入っています。"]
+  );
+  const transientPayloads = dashboardSocket.sent.map((message) => JSON.parse(message)).filter((message) => message.type === "transient_status");
+  assert.equal(transientPayloads.length, 2);
+  assert.equal(transientPayloads[0].transientProgressSnapshot.progressSummary, undefined);
+  assert.deepEqual(
+    transientPayloads[1].transientProgressSnapshot.progressSummary.entries.map((entry) => entry.text),
+    ["実装に入っています。"]
+  );
+  assert.equal((await store.listThread("dashboard-main-unresolved")).length, 0);
 });
 
 test("DashboardChatRoom clears transient progress snapshot after final reply", async () => {

--- a/worker.js
+++ b/worker.js
@@ -58494,12 +58494,14 @@ var DashboardChatRoom = class {
         source: snapshotSource
       });
     }
+    const transientProgressSnapshot = snapshot === true ? await this.readTransientProgressSnapshot(threadId) : null;
     const payload = JSON.stringify({
       type: "transient_status",
       ok: true,
       threadId,
       status,
-      text
+      text,
+      transientProgressSnapshot
     });
     for (const socket of this.connectedSockets()) {
       const attachment = this.getSocketAttachment(socket);
@@ -66765,7 +66767,7 @@ function buildDashboardProgressSummarySnapshot(previous, { text = "" } = {}) {
   const previousSummary = normalizeDashboardProgressSummary(previous?.progressSummary);
   const entries = [...previousSummary.entries];
   const normalizedText = sanitizeDashboardChatText(text);
-  if (normalizedText) {
+  if (normalizedText && shouldIncludeDashboardProgressSummaryEntry(normalizedText)) {
     const latest = entries.at(-1);
     if (!latest || latest.text !== normalizedText) {
       entries.push({
@@ -66778,6 +66780,13 @@ function buildDashboardProgressSummarySnapshot(previous, { text = "" } = {}) {
     entries,
     updatedAt: (/* @__PURE__ */ new Date()).toISOString()
   });
+}
+function shouldIncludeDashboardProgressSummaryEntry(text) {
+  const normalizedText = sanitizeDashboardChatText(text);
+  if (!normalizedText) {
+    return false;
+  }
+  return !DASHBOARD_LOW_INFORMATION_PROGRESS_TEXT.has(normalizedText);
 }
 function dashboardProgressSummaryEntriesKey(progressSummary) {
   const normalized = normalizeDashboardProgressSummary(progressSummary);
@@ -66922,6 +66931,12 @@ var DASHBOARD_APP_SERVER_STAGE_TEXT = {
 var DASHBOARD_DURABLE_APP_SERVER_PROGRESS_STAGES = /* @__PURE__ */ new Set([
   "waiting_approval",
   "waiting_user_input"
+]);
+var DASHBOARD_LOW_INFORMATION_PROGRESS_TEXT = /* @__PURE__ */ new Set([
+  "\u8003\u3048\u3066\u3044\u307E\u3059\u3002",
+  "\u30B3\u30DE\u30F3\u30C9\u3092\u5B9F\u884C\u3057\u3066\u3044\u307E\u3059\u3002",
+  "\u5916\u90E8\u30C4\u30FC\u30EB\u306E\u7D50\u679C\u3092\u5F85\u3063\u3066\u3044\u307E\u3059\u3002",
+  "\u63A5\u7D9A\u3068\u5B9F\u884C\u72B6\u614B\u3092\u78BA\u8A8D\u4E2D\u3067\u3059\u3002\u5165\u529B\u3068\u6587\u8108\u306F\u4FDD\u6301\u3057\u3066\u3044\u307E\u3059\u3002"
 ]);
 function buildDashboardOwnerFacingTransientStatusText(input, { status = "", text = "", transientStatus = "" } = {}) {
   if (transientStatus === "replied" || status === "replied") {
@@ -72198,6 +72213,10 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
     .progress-summary summary { cursor: pointer; font-weight: 800; color: var(--text); }
     .progress-summary ol { margin: 10px 0 0; padding-left: 22px; }
     .progress-summary li { margin-top: 6px; overflow-wrap: anywhere; word-break: break-word; }
+    .progress-checkpoint-entry { opacity: .92; }
+    .progress-checkpoint-bubble { color: var(--muted); }
+    .progress-checkpoint-bubble .bubble-header strong { color: var(--muted); }
+    .progress-checkpoint-bubble .message-body p { color: var(--text); }
     .reply-context { display: grid; grid-template-columns: minmax(0, 1fr); gap: 2px; width: min(100%, 680px); margin: 0 0 10px; padding: 8px 10px; border: 0; border-left: 3px solid var(--border); border-radius: 0 8px 8px 0; background: var(--soft); color: var(--muted); font: inherit; font-size: 12px; line-height: 1.45; text-align: left; cursor: pointer; }
     .reply-context:hover, .reply-context:focus-visible { color: var(--text); background: var(--panel-strong); outline: none; }
     .reply-context:focus-visible { box-shadow: 0 0 0 2px var(--link); }
@@ -72482,6 +72501,8 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
       const renderedMessagesById = new Map();
       let transientProgressCard = null;
       let transientProgressState = null;
+      let threadProgressCheckpointCard = null;
+      let transientProgressSnapshotState = null;
       let latestOwnerReplySource = null;
       let lastMediaLightboxTrigger = null;
       let pendingOwnerSend = null;
@@ -72757,13 +72778,16 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           title: options.title || "\u9032\u884C\u4E2D",
           text: normalized,
           status: String(options.status || ""),
-          thinking: options.thinking === true
+          thinking: options.thinking === true,
+          snapshot: options.snapshot || null
         };
         renderTransientProgress();
+        renderThreadProgressCheckpoint(options.snapshot || null);
       }
 
       function clearTransientProgress() {
         transientProgressState = null;
+        transientProgressSnapshotState = null;
         if (transientProgressCard) {
           if (transientProgressCard === progressPane) {
             transientProgressCard.hidden = true;
@@ -72774,6 +72798,68 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
             transientProgressCard.remove();
           }
           transientProgressCard = null;
+        }
+        clearThreadProgressCheckpoint();
+      }
+
+      function latestProgressCheckpointText(snapshot) {
+        const entries = Array.isArray(snapshot && snapshot.progressSummary && snapshot.progressSummary.entries)
+          ? snapshot.progressSummary.entries
+          : [];
+        return [...entries]
+          .reverse()
+          .map((entry) => String(entry && entry.text || entry || "").trim())
+          .find(Boolean) || "";
+      }
+
+      function ensureThreadProgressCheckpointCard() {
+        if (threadProgressCheckpointCard && threadProgressCheckpointCard.isConnected) {
+          return threadProgressCheckpointCard;
+        }
+        const entry = document.createElement("div");
+        entry.className = "message-entry butler progress-checkpoint-entry";
+        entry.setAttribute("data-thread-progress-checkpoint", "true");
+        const article = document.createElement("article");
+        article.className = "bubble progress-checkpoint-bubble";
+        const header = document.createElement("div");
+        header.className = "bubble-header";
+        const strong = document.createElement("strong");
+        strong.textContent = "Butler";
+        header.appendChild(strong);
+        const body = document.createElement("div");
+        body.className = "message-body";
+        const paragraph = document.createElement("p");
+        body.appendChild(paragraph);
+        article.appendChild(header);
+        article.appendChild(body);
+        entry.appendChild(article);
+        threadProgressCheckpointCard = entry;
+        log.appendChild(entry);
+        return entry;
+      }
+
+      function renderThreadProgressCheckpoint(snapshot) {
+        if (snapshot && typeof snapshot === "object") {
+          transientProgressSnapshotState = snapshot;
+        }
+        const text = latestProgressCheckpointText(transientProgressSnapshotState);
+        if (!text) {
+          clearThreadProgressCheckpoint();
+          return false;
+        }
+        const card = ensureThreadProgressCheckpointCard();
+        const paragraph = card.querySelector(".message-body p");
+        if (paragraph) {
+          paragraph.textContent = text;
+        }
+        scrollToLatest();
+        return true;
+      }
+
+      function clearThreadProgressCheckpoint() {
+        if (threadProgressCheckpointCard) {
+          threadProgressCheckpointCard.remove();
+          threadProgressCheckpointCard = null;
         }
       }
 
@@ -73041,7 +73127,8 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         updateTransientProgress(text, {
           status: statusValue,
           thinking: statusValue === "thinking" || statusValue === "pending_app_server_bridge",
-          title: statusValue === "pending_app_server_bridge" ? "\u8FD4\u4FE1\u5F85\u3061" : "\u9032\u884C\u4E2D"
+          title: statusValue === "pending_app_server_bridge" ? "\u8FD4\u4FE1\u5F85\u3061" : "\u9032\u884C\u4E2D",
+          snapshot
         });
         setStatus(text, { thinking: true });
         return true;
@@ -73867,23 +73954,16 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
 
       function renderThread(messages, options = {}) {
         const replace = options.replace === true;
-        const hadTransientProgress = Boolean(transientProgressState);
-        const existingTransientProgressCard = hadTransientProgress && transientProgressCard
-          ? transientProgressCard
-          : null;
+        const snapshotForCheckpoint = transientProgressSnapshotState;
         if (replace) {
           messagesById.clear();
         }
         resetRenderedReplyContext();
         if (!Array.isArray(messages) || messages.length === 0) {
           if (replace || messagesById.size === 0) {
-            if (existingTransientProgressCard) {
-              log.replaceChildren(existingTransientProgressCard);
-              renderTransientProgress();
-            } else {
-              log.innerHTML = initialMarkup;
-            }
+            log.innerHTML = initialMarkup;
           }
+          renderThreadProgressCheckpoint(snapshotForCheckpoint);
           scrollToLatest();
           return;
         }
@@ -73894,13 +73974,8 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         for (const message of messagesById.values()) {
           appendMessage(message, fragment, { scroll: false });
         }
-        if (existingTransientProgressCard) {
-          fragment.appendChild(existingTransientProgressCard);
-        }
         log.replaceChildren(fragment);
-        if (hadTransientProgress) {
-          renderTransientProgress();
-        }
+        renderThreadProgressCheckpoint(snapshotForCheckpoint);
         scrollToLatest();
       }
 
@@ -74014,7 +74089,8 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
                   updateTransientProgress(transientText, {
                     status: body.status,
                     thinking: true,
-                    title: "\u9032\u884C\u4E2D"
+                    title: "\u9032\u884C\u4E2D",
+                    snapshot: body.transientProgressSnapshot || null
                   });
                 } else {
                   clearTransientProgress();

--- a/worker.js
+++ b/worker.js
@@ -72209,7 +72209,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
     .bubble .message-body pre code { display: block; max-width: 100%; white-space: pre-wrap; overflow-wrap: anywhere; word-break: break-word; font-size: 14px; line-height: 1.55; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace; }
     .bubble .message-body pre.wrap-code code { white-space: pre-wrap; overflow-wrap: anywhere; word-break: break-word; }
     .bubble .message-body strong { display: inline; color: inherit; font-size: inherit; letter-spacing: 0; text-transform: none; margin: 0; font-weight: 800; }
-    .progress-summary { margin-top: 12px; border: 1px solid var(--border); border-radius: 10px; padding: 10px 12px; background: rgba(247, 248, 244, .8); color: var(--muted); }
+    .progress-summary { margin-top: 12px; border: 1px solid var(--border); border-radius: 10px; padding: 10px 12px; background: var(--panel-strong); color: var(--muted); }
     .progress-summary summary { cursor: pointer; font-weight: 800; color: var(--text); }
     .progress-summary ol { margin: 10px 0 0; padding-left: 22px; }
     .progress-summary li { margin-top: 6px; overflow-wrap: anywhere; word-break: break-word; }


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #590 の intent である「Dashboard Butler が長時間作業中に無言に見えず、進行状況を owner-facing に見せる」ため、既存の latest transient snapshot を chat 内 checkpoint として表示する最小 slice を実装します。
- raw event / reply delta / 高頻度 progress を通常チャット履歴に保存せず、Cloudflare Durable Object write を増やさない設計にしています。

## Satisfied Success Criteria

- 低情報の transport 状態は composer 下の transient 表示に留め、`progressSummary` へ混ぜない。
- owner-facing progress checkpoint は `transientProgressSnapshot.progressSummary` から chat log 内の ephemeral card に表示できる。
- final reply 受信時に transient checkpoint は消え、既存の `進行ログ` 集約へ寄せられる。
- latest snapshot 1件を WebSocket payload / thread refresh payload で復帰できる既存経路を維持する。

## Unsatisfied Success Criteria

- production PWA で「30秒以内の初回 checkpoint」「app 切替/スリープ復帰後の checkpoint 表示」「完了時の `進行ログ` 集約」をまだ確認していません。
- app-server bridge が全 turn で 30秒以内に owner-facing stage を送る保証は、この PR では未完了です。
- #741 の deploy / bridge restart 通知チャット化、#744 の表示崩れ全体修正は別 Issue として残します。

## Non-goal violations

None.

## 開発前作戦図

- 作戦図 evidence: docs/development-strategy/issue-590-realtime-progress-checkpoints.md
- 完了体験: 長時間 turn で owner-facing checkpoint が chat log 内に見え、復帰後も latest snapshot 1件から表示され、完了時は final reply の `進行ログ` に集約される。
- VTDD 全体で進める部分: Dashboard Butler が VPS Codex CLI / app-server bridge の進行を owner-facing に見せる #590 root blocker を進める。
- 設計: Dashboard Butler の owner-facing surface で、DO の latest transient progress snapshot を再利用し、scope は composer transient と chat checkpoint の UI 分離に限定する。
- 仮説: 現在の「無言に見える」原因は、進行 event が transient snapshot に届いていても composer 下にしか表示されず、chat log 上で復帰可能な checkpoint になっていないこと。
- 検証計画: worker unit/integration で low-information progress の除外、owner-facing checkpoint の summary 化、final reply への集約を検証し、merge/deploy 後に production PWA E2E を行う。
- 改修見積もり: `src/worker/runtime.js` の snapshot payload / summary filter / Dashboard client script、`test/worker.test.js`、generated `worker.js`。
- 既に通っている経路: app-server bridge -> `DashboardChatRoom` -> `transient_status` / `transientProgressSnapshot` / final reply `progressSummary`。
- 未確認の境界: app-server bridge が 30秒以内に owner-facing stage を必ず送るか、iPad PWA background 中の WebSocket 停止をどこまで吸収できるか。
- 穴が出そうな箇所: 古い checkpoint card の消し忘れ、低情報判定の強すぎ/弱すぎ、composer progress DOM と chat log DOM の混線。
- PR 前に確認すること: strategy file、worker tests、generated worker、self-parity、`verify:worker` の結果。
- 実装候補と捨てた案: 採用は latest snapshot 1件の ephemeral card 表示。捨てた案は raw event durable append、reply delta 表示、Cloudflare event stream 保存。
- merge 後に通す E2E: production PWA E2E として #637 相当の low-risk read/status を投げ、30秒以内 checkpoint、復帰後 checkpoint、完了時の進行ログを検証する。
- 次の PR を増やさない理由: #590 の root blocker は runtime payload と Dashboard UI の両方が揃わないと E2E 不能で、ここを分けると次の PR が predictable follow-up として増えるため、この scope で一体化する。
- 停止条件: raw event 保存が必要になる、snapshot 1件で復帰体験を満たせない、Issue #590 と矛盾する contract が見つかる、通常履歴を汚す恐れが出る。

## Dry-run Impact Report

- Target Issue: Issue #590
- Implementing Success Criteria: realtime progress checkpoint stream の最小 slice。低情報 transient と owner-facing checkpoint の分離、latest snapshot の WebSocket payload 同梱、chat log 内 ephemeral checkpoint 表示。
- Explicit Non-goals: #741 通知チャット化、#744 表示崩れ全体修正、raw reply delta 表示、Durable Object / D1 への progress stream 高頻度保存、deploy / credential / permission / destructive work。
- Expected touched files/routes/workflows: `src/worker/runtime.js`, `test/worker.test.js`, `worker.js`, `docs/development-strategy/issue-590-realtime-progress-checkpoints.md`。
- Affected Issues: #590, #637, #741, #744
- Affected PRs: なし
- Affected workflows: worker build / worker test / self-parity / generated-worker check。GitHub Actions deploy workflow 自体は未変更。
- Affected runtime/operator surfaces: Dashboard Butler chat, DashboardChatRoom WebSocket, app-server bridge progress event display。passkey/operator route は未変更。
- What may break if we patch narrowly: progress card が通常 message と混ざる、古い checkpoint が残る、低情報 event が final summary を汚す、復帰時に composer 下だけ表示され続ける。
- Unknowns to investigate before coding: app-server status event の stage 粒度、既存 transient snapshot の restore 経路、final reply への `progressSummary` attach 経路。
- Validation needed: worker unit/integration、generated worker、self-parity、merge/deploy 後 production PWA E2E。
- Stop condition: Cloudflare write 増加なしで実現できない、通常チャット履歴を progress で汚す、#590 の Issue 意図と違う表示になる。

## Execution Queue Delta

- Queue position before: #590 は active issue execution queue の `Now` / root blocker。
- Preemption decision: EMERGENCY ではありません。#637 production E2E 後の次作業として、現在の `Now` item を継続。
- Queue delta: Issue #590 の `Now` queue item で realtime progress checkpoint stream を進める。merge/deploy 後の production E2E が残る。
- Why this PR is next: owner が「無言のまま待つ」状態を blocker として報告しており、#637 など長時間作業の前提 UX になっているため。
- Active Issues not downscoped: Active Issues は縮小しません。#741 / #744 / #637 の残作業は未完了として残します。

## File / Line Hypotheses

- file: `src/worker/runtime.js`
  - hypothesis: `broadcastTransientStatus` が latest snapshot を payload に含めていないため、WebSocket transient update だけでは chat 内 checkpoint を即時更新できない。
  - risk if changed narrowly: payload が増えても UI が使わなければ見えない。snapshot read を増やすが DO write は増やさない必要がある。
  - validation: DashboardChatRoom progress tests と generated worker check。
  - related Issue: #590
- file: `src/worker/runtime.js`
  - hypothesis: `buildDashboardProgressSummarySnapshot` が低情報 text も summary に入れると、final `進行ログ` がノイズ化する。
  - risk if changed narrowly: 低情報判定を強くしすぎると checkpoint が薄くなる。
  - validation: low-information transient progress separation test。
  - related Issue: #590
- file: `src/worker/runtime.js`
  - hypothesis: Dashboard client の `renderThread` が transient progress DOM と chat log DOM を混在させると、復帰時/再描画時に checkpoint 表示が不安定になる。
  - risk if changed narrowly: composer 下の transient 表示が消える、または old checkpoint が残る。
  - validation: inline chat renderer test、thread snapshot tests、production PWA E2E。
  - related Issue: #590

## Hypothesis Retrospective

- expected: latest snapshot 1件を再利用すれば、Cloudflare write を増やさず chat 内 checkpoint 表示と復帰が可能。
- actual: 実装では snapshot payload を `transient_status` に同梱し、Dashboard client が `progressSummary` の最新 entry を ephemeral card として表示する形にできた。
- mismatch: 30秒以内 checkpoint は app-server bridge が owner-facing stage を出す頻度に依存するため、merge/deploy 後 production E2E が必要。
- lesson: `考えています` / `コマンドを実行しています` は chat checkpoint ではなく composer transient に残すのが owner-facing には適切。
- should become RAG candidate: yes。#590 の progress stream 設計判断として、raw event durable append を避け、latest snapshot 1件 + ephemeral chat checkpoint を採用。

## Verification Evidence

- Unit: `node --test test/worker.test.js --test-name-pattern "transient progress|progress checkpoint|progress stages"` pass。
- Integration: `node --test test/worker.test.js --test-name-pattern "served dashboard inline chat renderer|DashboardChatRoom exposes last app-server status snapshot|DashboardChatRoom separates low-information|DashboardChatRoom clears transient progress snapshot"` pass。
- E2E: 未実施。merge/deploy 後に production PWA で実行する。
- Manual: `npm run build:worker` pass、`npm run check:generated-worker` pass、`npm run check:self-parity` pass。
- Evidence path/link: `docs/development-strategy/issue-590-realtime-progress-checkpoints.md`。
- `npm run verify:worker`: fail。今回差分外の既知環境依存 4 件で失敗し、progress / DashboardChatRoom 周辺は pass。

## Butler Completion Contract

- Primary owner surface: Dashboard Butler PWA。
- Fallback surface: mac Codex / Custom GPT は fallback。主経路ではありません。
- Owner goal: 長時間作業中に無言に見えず、進行 checkpoint が chat 上で見えること。
- Butler entrypoint: 既存 Dashboard Butler chat。
- Dashboard Butler natural-language path: Dashboard Butler の通常チャット入口で owner の自然文を受け、app-server bridge に渡る経路。
- Action Schema exposure: この PR では未変更。
- Runtime path: `app-server bridge -> DashboardChatRoom app_server_status -> transient_status + transientProgressSnapshot -> Dashboard chat UI`。
- Runner/runtime truth: local tests では DashboardChatRoom 経路を確認済み。production runtime truth は merge/deploy 後 E2E で確認する。
- Authority boundary: read/status/progress 表示のみ。GO/passkey/credential/deploy/permission/destructive work は含まない。
- E2E evidence: 未実施。merge/deploy 後に #590 evidence として追加する。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: merge 後に必要。実行には owner/passkey 境界が必要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: merge/deploy 後に必要。

## Related Constitution Rules

- Butler Completion Gate
- Butler-First Operating Principle
- Drift Stop Protocol
- 開発前作戦図 Gate
- Evidence Discipline
- Change Size and PR Discipline

## Out-of-scope but NOT implemented

- #741 deploy / bridge restart 通知を chat 欄に durable event として表示する実装。
- #744 final summary clipping / progress summary dark mode 全体修正。
- raw app-server event / reply delta の durable 保存。
- 30秒以内 checkpoint を app-server bridge 側で強制する heartbeat / watchdog。

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: #590
- Execution ID: Not provided.
- Goal: realtime progress checkpoint stream
