### PR TITLE
Issue #590 restore composer progress status

### DIFF
--- a/docs/development-strategy/issue-590-realtime-progress-checkpoints.md
+++ b/docs/development-strategy/issue-590-realtime-progress-checkpoints.md
@@ -4,9 +4,9 @@
 
 Dashboard Butler で長時間の VPS Codex CLI / app-server bridge 作業を投げたとき、owner は無言で待たされない。低情報の状態、たとえば「考えています」「コマンドを実行しています」は composer 下の一時状態として表示し続ける。一方で owner-facing な進行 checkpoint は通常チャット欄の末尾に表示され、アプリ切替、スリープ、WebSocket 再接続後も最新 checkpoint 1件から復帰できる。
 
-完了時は、その live progress message を最終 Butler 返信と折りたたみの `進行ログ` に一気に置き換える。通常チャット履歴に raw event や高頻度 progress message は残さない。
+完了時は checkpoint 表示を消し、最終 Butler 返信に折りたたみの `進行ログ` として集約する。通常チャット履歴に raw event や高頻度 progress message は残さない。
 
-2026-06-04 の production E2E で、composer 下の `進行中` とチャット本文内の checkpoint が二重表示になり、さらに `codex app-server が応答を生成しています。` のような低情報 status が本文側に混ざることを確認した。以後の設計は「composer 下の進行中カードを主表示にしない」「1 turn / 1 execution に対してチャット本文内の live progress message 1件だけを更新する」「完了時だけ final summary へ置換する」に修正する。
+2026-06-04 の PR #778 production E2E では、composer 下の `進行中` を主表示から外した結果、低情報の `codex app-server が応答を生成しています。` が chat 本文側に出続け、さらに checkpoint 更新で scroll が下へ戻る体験が発生した。これは #590 の意図に反するため、次 slice では PR #778 の UI 改変を rollback し、低情報 status を元の composer 下表示へ戻す。owner-facing checkpoint 生成不足は別 slice として bridge/app-server event 分類を調査する。
 
 ## VTDD 全体で進める部分
 
@@ -14,20 +14,18 @@ Dashboard Butler で長時間の VPS Codex CLI / app-server bridge 作業を投�
 
 ## 設計
 
-既存実装には `transient_progress_snapshot:<threadId>` があり、Durable Object に最新 snapshot 1件だけ保存される。これを新しい永続 chat message にせず、Dashboard UI が chat log 内に `live_progress_message_id` 相当の ephemeral checkpoint card として描画する。
-
-`live_progress_message_id` は checkpoint 1件ごとの ID ではない。1 owner turn / 1 app-server turn / 1 runner execution に対して、チャット本文内に表示する一時 progress message 1個の UI identity として扱う。checkpoint が増えても message row は増やさず、その 1個の中身だけを更新する。
+既存実装には `transient_progress_snapshot:<threadId>` があり、Durable Object に最新 snapshot 1件だけ保存される。これを新しい永続 chat message にせず、Dashboard UI が chat log 内に ephemeral checkpoint card として描画する。
 
 分類は二層にする。
 
-- composer 下: 低情報 status の主表示場所にはしない。この slice では composer 下の progress card を非表示化し、最下部の短い status line だけに限定する。
-- chat 内 live progress message: owner-facing progress。`planning` / `implementation` / `test` / `PR作成` / `CI待ち` など、作業段階が分かるものだけを 1件の一時 message として更新表示する。
+- composer 下: transport/transient 状態。`thinking` / `command` / `quiet` など低情報の状態も表示する。
+- chat 内 checkpoint: owner-facing progress。`planning` / `implementation` / `test` / `PR作成` / `CI待ち` など、作業段階が分かるものだけを表示する。
 
-完了時は現在の `attachDashboardProgressSummaryToFinalMessages` を使い、snapshot の `progressSummary` を最終返信に付ける。snapshot は最終返信後に clear されるため、chat 内 live progress message は消え、最終返信の `進行ログ` に集約される。
+完了時は現在の `attachDashboardProgressSummaryToFinalMessages` を使い、snapshot の `progressSummary` を最終返信に付ける。snapshot は最終返信後に clear されるため、chat 内 checkpoint card も消える。
 
 ## 仮説
 
-現在の不満の根は、bridge が進行 event を受けて transient snapshot へ保存しているのに、UI が「composer 下の進行中」「チャット本文内 checkpoint」「最下部 status line」を混在させていることにある。iPad でアプリ切替やスリープが入ると composer 下の一時表示は見失いやすく、owner の体感は「最後にまとめて出る」または「変な場所に出る」になる。
+現在の不満の根は、bridge が進行 event を受けて transient snapshot へ保存しているのに、UI がそれを composer 下の「進行中」枠としてしか描画していないことにある。iPad でアプリ切替やスリープが入ると composer 下の一時表示は見失いやすく、owner の体感は「最後にまとめて出る」になる。
 
 狭く durable chat message を増やすと、通常履歴が progress で汚れ、Cloudflare write も増える。逆に既存 snapshot を chat log 内に描画するだけなら、write volume は増えず、復帰可能性も保てる。
 
@@ -43,7 +41,7 @@ Dashboard Butler で長時間の VPS Codex CLI / app-server bridge 作業を投�
 
 - `src/worker/runtime.js`
   - `buildDashboardProgressSummarySnapshot`: 低情報 progress を summary から除外する。既存 snapshot write は維持する。
-- Dashboard client script: `transientProgressSnapshot.progressSummary` から最新 checkpoint を chat log 内の live progress message 1件として描画し、clear 時に消す。composer progress card は主表示として使わない。
+  - Dashboard client script: `transientProgressSnapshot.progressSummary` から最新 checkpoint を chat log 内に ephemeral card として描画し、clear 時に消す。
   - Dashboard CSS: checkpoint card と progress summary の dark mode 対応を最小限整える。
 - `test/worker.test.js`
   - 低情報 progress が summary に入らないこと。
@@ -72,7 +70,6 @@ Dashboard Butler で長時間の VPS Codex CLI / app-server bridge 作業を投�
 - chat 内 checkpoint card を通常 message と同じ DOM に入れると、copy/reply/scroll の既存挙動を壊す可能性がある。
 - completion 後の clear が漏れると、古い checkpoint が final reply の下に残る。
 - dark mode の progress summary 背景が light 固定だと #744 の見えづらさを悪化させる。
-- media attach / pending media preview の再描画で chat log 内の live progress message が消えると、owner には「チャットに出ていたテキストが消えた」と見える。#498 本体ではないが、この slice の E2E 観測対象に入れる。
 
 ## PR 前に確認すること
 
@@ -95,9 +92,9 @@ Dashboard Butler で長時間の VPS Codex CLI / app-server bridge 作業を投�
 
 ## merge 後に通す E2E
 
-- production PWA から #637 相当の低リスク read/status を投げ、30秒以内に chat 内 live progress message が1件だけ見えること。
-- app 切替、リロード、または画像添付プレビュー追加後、最新 checkpoint が chat log 内に復帰または維持されること。
-- completion 後、live progress message が消え、最終 Butler 返信に `進行ログ` が残ること。
+- production PWA から #637 相当の低リスク read/status を投げ、30秒以内に composer 下の transient と chat 内 checkpoint のどちらかが見えること。
+- app 切替またはリロード後、最新 checkpoint が chat log 内に復帰すること。
+- completion 後、checkpoint card が消え、最終 Butler 返信に `進行ログ` が残ること。
 - low-risk read/status は passkey なし、deploy / bridge restart は従来通り passkey 境界を維持すること。
 
 ## 次の PR を増やさない理由

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -16590,16 +16590,31 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
       }
 
       function ensureTransientProgressCard() {
-        return null;
+        if (transientProgressCard && transientProgressCard.isConnected) return transientProgressCard;
+        if (progressPane) {
+          progressPane.setAttribute("data-transient-progress", "true");
+          transientProgressCard = progressPane;
+          return progressPane;
+        }
+        const article = document.createElement("div");
+        article.className = "composer-progress";
+        article.setAttribute("aria-live", "polite");
+        article.setAttribute("data-transient-progress", "true");
+        const title = document.createElement("div");
+        title.className = "progress-title";
+        title.textContent = "進行中";
+        const text = document.createElement("p");
+        text.className = "progress-text";
+        article.appendChild(title);
+        article.appendChild(text);
+        transientProgressCard = article;
+        form.insertBefore(article, form.querySelector(".composer-box") || status);
+        return article;
       }
 
       function renderTransientProgress() {
         if (!transientProgressState) return;
         const card = ensureTransientProgressCard();
-        if (!card) {
-          updateComposerReserve();
-          return;
-        }
         card.hidden = false;
         card.classList.toggle("thinking", transientProgressState.thinking === true);
         const title = card.querySelector(".progress-title");
@@ -16643,12 +16658,6 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           }
           transientProgressCard = null;
         }
-        if (progressPane) {
-          progressPane.hidden = true;
-          progressPane.classList.remove("thinking");
-          const text = progressPane.querySelector(".progress-text");
-          if (text) text.textContent = "";
-        }
         clearThreadProgressCheckpoint();
       }
 
@@ -16682,14 +16691,6 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         body.appendChild(paragraph);
         article.appendChild(header);
         article.appendChild(body);
-        const summary = document.createElement("details");
-        summary.className = "progress-summary live-progress-summary";
-        const summaryTitle = document.createElement("summary");
-        summaryTitle.textContent = "進行ログ";
-        const list = document.createElement("ol");
-        summary.appendChild(summaryTitle);
-        summary.appendChild(list);
-        article.appendChild(summary);
         entry.appendChild(article);
         threadProgressCheckpointCard = entry;
         log.appendChild(entry);
@@ -16709,22 +16710,6 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         const paragraph = card.querySelector(".message-body p");
         if (paragraph) {
           paragraph.textContent = text;
-        }
-        const entries = Array.isArray(transientProgressSnapshotState && transientProgressSnapshotState.progressSummary && transientProgressSnapshotState.progressSummary.entries)
-          ? transientProgressSnapshotState.progressSummary.entries
-          : [];
-        const details = card.querySelector(".live-progress-summary");
-        const list = details ? details.querySelector("ol") : null;
-        if (details && list) {
-          list.replaceChildren();
-          for (const entry of entries) {
-            const entryText = String(entry && entry.text || entry || "").trim();
-            if (!entryText) continue;
-            const item = document.createElement("li");
-            item.textContent = entryText;
-            list.appendChild(item);
-          }
-          details.hidden = entries.length <= 1;
         }
         scrollToLatest();
         return true;

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -1266,17 +1266,15 @@ test("worker serves v2 dashboard for allowed owner identity without exposing sec
   assert.equal(body.includes(".transient-progress-card"), false);
   assert.equal(body.includes(".composer-progress"), true);
   assert.equal(body.includes('id="butler-transient-progress"'), true);
-  assert.equal(body.includes("data-transient-progress"), false);
+  assert.equal(body.includes("data-transient-progress"), true);
   assert.equal(body.includes("function updateTransientProgress(text, options = {})"), true);
   assert.equal(body.includes("function clearTransientProgress()"), true);
   assert.equal(body.includes("function renderTransientProgress()"), true);
-  assert.equal(body.includes("return null;"), true);
   assert.equal(body.includes("function renderProgressSummaryDetails(progressSummary)"), true);
   assert.equal(body.includes("進行ログ"), true);
   assert.equal(body.includes(".progress-summary"), true);
   assert.equal(body.includes("background: var(--panel-strong); color: var(--muted);"), true);
   assert.equal(body.includes("data-thread-progress-checkpoint"), true);
-  assert.equal(body.includes("live-progress-summary"), true);
   assert.equal(body.includes("function renderThreadProgressCheckpoint(snapshot)"), true);
   assert.equal(body.includes("function clearThreadProgressCheckpoint()"), true);
   assert.equal(body.includes("latestProgressCheckpointText(transientProgressSnapshotState)"), true);
@@ -1284,7 +1282,6 @@ test("worker serves v2 dashboard for allowed owner identity without exposing sec
   const renderTransientProgressSource = body.match(/function renderTransientProgress\(\) \{[\s\S]*?\n      \}/)?.[0] || "";
   assert.equal(renderTransientProgressSource.includes("scrollToLatest()"), false);
   assert.equal(renderTransientProgressSource.includes("updateComposerReserve()"), true);
-  assert.equal(renderTransientProgressSource.includes("renderThreadProgressCheckpoint"), false);
   assert.equal(body.includes("isLongRunningTransientStatus(options.status)"), true);
   assert.equal(body.includes("function appendMessage(message, target = log, options = {})"), true);
   assert.equal(body.includes("const fragment = document.createDocumentFragment()"), true);

--- a/worker.js
+++ b/worker.js
@@ -72731,16 +72731,31 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
       }
 
       function ensureTransientProgressCard() {
-        return null;
+        if (transientProgressCard && transientProgressCard.isConnected) return transientProgressCard;
+        if (progressPane) {
+          progressPane.setAttribute("data-transient-progress", "true");
+          transientProgressCard = progressPane;
+          return progressPane;
+        }
+        const article = document.createElement("div");
+        article.className = "composer-progress";
+        article.setAttribute("aria-live", "polite");
+        article.setAttribute("data-transient-progress", "true");
+        const title = document.createElement("div");
+        title.className = "progress-title";
+        title.textContent = "\u9032\u884C\u4E2D";
+        const text = document.createElement("p");
+        text.className = "progress-text";
+        article.appendChild(title);
+        article.appendChild(text);
+        transientProgressCard = article;
+        form.insertBefore(article, form.querySelector(".composer-box") || status);
+        return article;
       }
 
       function renderTransientProgress() {
         if (!transientProgressState) return;
         const card = ensureTransientProgressCard();
-        if (!card) {
-          updateComposerReserve();
-          return;
-        }
         card.hidden = false;
         card.classList.toggle("thinking", transientProgressState.thinking === true);
         const title = card.querySelector(".progress-title");
@@ -72784,12 +72799,6 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           }
           transientProgressCard = null;
         }
-        if (progressPane) {
-          progressPane.hidden = true;
-          progressPane.classList.remove("thinking");
-          const text = progressPane.querySelector(".progress-text");
-          if (text) text.textContent = "";
-        }
         clearThreadProgressCheckpoint();
       }
 
@@ -72823,14 +72832,6 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         body.appendChild(paragraph);
         article.appendChild(header);
         article.appendChild(body);
-        const summary = document.createElement("details");
-        summary.className = "progress-summary live-progress-summary";
-        const summaryTitle = document.createElement("summary");
-        summaryTitle.textContent = "\u9032\u884C\u30ED\u30B0";
-        const list = document.createElement("ol");
-        summary.appendChild(summaryTitle);
-        summary.appendChild(list);
-        article.appendChild(summary);
         entry.appendChild(article);
         threadProgressCheckpointCard = entry;
         log.appendChild(entry);
@@ -72850,22 +72851,6 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         const paragraph = card.querySelector(".message-body p");
         if (paragraph) {
           paragraph.textContent = text;
-        }
-        const entries = Array.isArray(transientProgressSnapshotState && transientProgressSnapshotState.progressSummary && transientProgressSnapshotState.progressSummary.entries)
-          ? transientProgressSnapshotState.progressSummary.entries
-          : [];
-        const details = card.querySelector(".live-progress-summary");
-        const list = details ? details.querySelector("ol") : null;
-        if (details && list) {
-          list.replaceChildren();
-          for (const entry of entries) {
-            const entryText = String(entry && entry.text || entry || "").trim();
-            if (!entryText) continue;
-            const item = document.createElement("li");
-            item.textContent = entryText;
-            list.appendChild(item);
-          }
-          details.hidden = entries.length <= 1;
         }
         scrollToLatest();
         return true;


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #590 / PR #778 の production E2E 失敗を受け、PR #778 で導入した composer progress 無効化と chat live progress details 追加を rollback します。
- `codex app-server が応答を生成しています。` のような低情報 status を、以前どおりチャット入力欄下の composer progress に戻します。
- chat 側 checkpoint 更新でスクロールが勝手に下へ戻る regression を避けるため、PR #778 で増やした live progress message 経路を外します。

## Satisfied Success Criteria

- composer 下の `data-transient-progress` 表示経路を復元した。
- `ensureTransientProgressCard()` が再び composer progress card を返すように戻した。
- PR #778 で追加した `live-progress-summary` と chat-side details 更新を撤回した。
- 対象 worker tests / generated worker / self-parity を確認した。

## Unsatisfied Success Criteria

- #590 の owner-facing realtime checkpoint 根本解決は未完了です。
- bridge/app-server から owner-facing checkpoint が実行中に届くかの確認は次 slice に残します。
- production PWA での再 E2E は merge/deploy 後に必要です。

## Non-goal violations

None.

## 開発前作戦図

- 作戦図 evidence: `docs/development-strategy/issue-590-realtime-progress-checkpoints.md`
- 完了体験: Dashboard Butler は低情報 status をチャット本文に出さず、以前どおり入力欄下に出す。owner は勝手な下スクロールで読んでいる位置を失わない。
- VTDD 全体で進める部分: #590 の failed E2E から、まず regression を戻して通常チャット体験を悪化前へ戻す。
- 設計: PR #778 の chat live progress message 方式を rollback し、composer progress と final progress summary の既存境界に戻す。根本 checkpoint 生成は次 slice で bridge/app-server event 分類から調べ直す。
- 仮説: スクロール regression の原因は、PR #778 が composer progress を無効化し、chat 側 live progress card 更新で `scrollToLatest()` 経路を増やしたこと。
- 検証計画: targeted worker tests、worker bundle generation、generated-worker check、self-parity、post-merge production PWA E2E。
- 改修見積もり: `src/worker/runtime.js` の Dashboard client script、`test/worker.test.js` の HTML expectation、`worker.js` generated bundle、strategy note。
- 既に通っている経路: PR #778 前の composer progress path は低情報 status を入力欄下に表示し、chat history 汚染を避ける test が通っていた。
- 未確認の境界: production PWA deploy 後にスクロール挙動が元に戻るかは live E2E で確認する。
- 穴が出そうな箇所: rollback 後も owner-facing checkpoint が途中で出ない根本問題は残る。
- PR 前に確認すること: git status、PR #778 diff、targeted worker tests、`npm run build:worker`、`npm run check:generated-worker`、`npm run check:self-parity`、`git diff --check`。
- 実装候補と捨てた案: 採用は PR #778 の no-commit revert + rollback strategy note。新しい checkpoint fallback 実装は上書き修正になるため今回は捨てる。
- merge 後に通す E2E: production PWA E2E で `codex app-server が応答を生成しています。` が入力欄下に戻ること、読んでいる位置が勝手に下へ戻らないこと、#590 はまだ incomplete のまま扱うことを検証する。
- 次の PR を増やさない理由: この PR は regression rollback に限定する。checkpoint 生成不足の調査は別 slice として残し、rollback と混ぜて挙動を不透明にしない。
- 停止条件: rollback だけで別の表示 regressions が出る、または composer progress path が現在の runtime と矛盾する場合。

## Dry-run Impact Report

- Target Issue: Issue #590
- Implementing Success Criteria: PR #778 による display-lane regression の rollback。
- Explicit Non-goals: owner-facing checkpoint fallback 実装、#498 media attach state preservation、deploy/credential/permission mutation。
- Expected touched files/routes/workflows: `docs/development-strategy/issue-590-realtime-progress-checkpoints.md`, `src/worker/runtime.js`, `test/worker.test.js`, `worker.js`。
- Affected Issues: #590, evidence overlap with #498 and #744.
- Affected PRs: PR #778 follow-up rollback.
- Affected workflows: worker build / worker tests only.
- Affected runtime/operator surfaces: Dashboard Butler PWA chat UI.
- What may break if we patch narrowly: root realtime checkpoint problem remains unresolved and must not be claimed complete.
- Unknowns to investigate before coding: none for rollback; next checkpoint generation slice still requires bridge event inspection.
- Validation needed: targeted worker tests, generated worker check, self-parity, production PWA E2E after deploy.
- Stop condition: rollback changes become broader than PR #778 reversal.

## Execution Queue Delta

- Queue position before: Issue #590 remains Now after PR #778 production E2E failed.
- Preemption decision: ROOT. This is rollback of a regression inside the current #590 root blocker.
- Queue delta: Issue #590 remains Now; PR #778 rollback advances the failed E2E recovery but does not close #590.
- Why this PR is next: Owner observed that PR #778 made status placement and scroll behavior worse; restoring prior behavior reduces damage before deeper bridge work.
- Active Issues not downscoped: Active Issues are not downscoped. #498, #637, #744 and other active Issues remain active and incomplete unless separately verified.

## File / Line Hypotheses

- file: `src/worker/runtime.js`
  - hypothesis: PR #778's `ensureTransientProgressCard() { return null; }` moved low-information status away from composer progress and exposed chat-side display/scroll regression.
  - risk if changed narrowly: owner-facing checkpoint generation still remains missing.
  - validation: targeted DashboardChatRoom and dashboard HTML tests.
  - related Issue: #590
- file: `test/worker.test.js`
  - hypothesis: HTML expectations should return to `data-transient-progress` composer path and remove `live-progress-summary`.
  - risk if changed narrowly: tests prove rollback, not realtime checkpoint completion.
  - validation: targeted node test and production PWA observation.
  - related Issue: #590

## Hypothesis Retrospective

- expected: Restoring composer progress path brings `codex app-server が応答を生成しています。` back under the input area and removes PR #778's extra chat-side details path.
- actual: targeted tests, generated worker check, self-parity, and diff check pass locally.
- mismatch: #590 realtime checkpoint generation remains unsolved.
- lesson: UI-lane rollback must land before adding fallback checkpoint logic.
- should become RAG candidate: Yes, if production E2E confirms the rollback fixes status placement/scroll.

## Verification Evidence

- Unit: `node --test test/worker.test.js --test-name-pattern "worker serves v2 dashboard for allowed owner identity without exposing secrets|DashboardChatRoom sends app-server thinking status|DashboardChatRoom separates low-information transient progress|DashboardChatRoom clears transient progress snapshot|DashboardChatRoom keeps generic opt-in app-server progress transient-only|DashboardChatRoom does not append repeated generic app-server progress checkpoints"` passed.
- Integration: `npm run build:worker` passed; `npm run check:generated-worker` passed; `npm run check:self-parity` passed; `git diff --check` passed.
- E2E: Not run before merge. Production PWA E2E required after deploy.
- Manual: PR #778 production failure evidence is recorded in #590 comment.
- Evidence path/link: `docs/development-strategy/issue-590-realtime-progress-checkpoints.md`

## Butler Completion Contract

- Primary owner surface: Dashboard Butler PWA.
- Fallback surface: mac Codex is debug/bootstrap only, not completion evidence.
- Owner goal: Return low-information app-server status to the input-area progress display and avoid forced down-scroll regression.
- Butler entrypoint: Existing Dashboard Butler natural-language chat turn.
- Dashboard Butler natural-language path: Dashboard Butler の通常チャット入口で owner が自然文を送ると、低情報 app-server status はチャット本文ではなく入力欄下の progress area に到達する。
- Action Schema exposure: Not changed.
- Runtime path: DashboardChatRoom WebSocket transient status rendering.
- Runner/runtime truth: No runner/deploy/credential path changed.
- Authority boundary: No high-risk operation added. No deploy/credential/permission/destructive work in this PR.
- E2E evidence: Missing until production PWA merge/deploy verification.
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: Required after merge by existing deploy flow; not performed by this PR.
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: merge/deploy 後に必要。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate
- AGENTS.md 開発前作戦図 Gate
- AGENTS.md Evidence Discipline
- AGENTS.md Change Size and PR Discipline
- AGENTS.md Conversation UX Contract

## Out-of-scope but NOT implemented

- bridge/app-server owner-facing checkpoint fallback generation.
- #498 media attach draft/checkpoint preservation full fix.
- #637 VPS privileged maintenance lifecycle.

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #590
- Execution ID: issue-590-restore-composer-progress-status
- Goal: Restore composer progress status after PR #778 regression
