### PR TITLE
Issue #590 guard live progress scrolling

### DIFF
--- a/docs/development-strategy/issue-590-realtime-progress-checkpoints.md
+++ b/docs/development-strategy/issue-590-realtime-progress-checkpoints.md
@@ -8,6 +8,8 @@ Dashboard Butler で長時間の VPS Codex CLI / app-server bridge 作業を投�
 
 2026-06-04 の PR #778 production E2E では、composer 下の `進行中` を主表示から外した結果、低情報の `codex app-server が応答を生成しています。` が chat 本文側に出続け、さらに checkpoint 更新で scroll が下へ戻る体験が発生した。これは #590 の意図に反するため、次 slice では PR #778 の UI 改変を rollback し、低情報 status を元の composer 下表示へ戻す。owner-facing checkpoint 生成不足は別 slice として bridge/app-server event 分類を調査する。
 
+2026-06-04 の追加 production 観測で、開発中に画面が下へチラチラ引っ張られる挙動が出た。原因候補は live progress checkpoint / thread refresh のたびに `scrollToLatest()` が無条件実行されること。owner が途中の進行を読んでいる場合は、最新 checkpoint が来ても scroll position を保持し、最下部付近にいる場合だけ追従する必要がある。
+
 ## VTDD 全体で進める部分
 
 この slice は #590 の realtime progress checkpoint stream の最小実装に限定する。#637 の production E2E で確認した「低リスク read/status が passkey なしで helper queue に渡る」経路を、#590 の進行表示 E2E の観測対象として使えるようにする。
@@ -35,6 +37,7 @@ Dashboard Butler で長時間の VPS Codex CLI / app-server bridge 作業を投�
 - owner-facing progress は `progressSummary.entries` に入り、final reply の `進行ログ` に集約される。
 - reply delta は従来通り snapshot / durable chat message にしない。
 - Dashboard HTML に chat 内 checkpoint card の描画経路があり、snapshot restore / WebSocket transient update / final reply clear で動く。
+- live progress checkpoint と thread refresh は、更新前に最下部付近だった場合だけ自動追従する。owner が途中を読んでいる場合は scroll position を壊さない。
 - worker bundle を再生成し、generated worker 差分を一致させる。
 
 ## 改修見積もり
@@ -42,6 +45,7 @@ Dashboard Butler で長時間の VPS Codex CLI / app-server bridge 作業を投�
 - `src/worker/runtime.js`
   - `buildDashboardProgressSummarySnapshot`: 低情報 progress を summary から除外する。既存 snapshot write は維持する。
   - Dashboard client script: `transientProgressSnapshot.progressSummary` から最新 checkpoint を chat log 内に ephemeral card として描画し、clear 時に消す。
+  - Dashboard client script: `isNearLatest()` / conditional scroll helper を追加し、progress update / thread refresh の無条件 scroll を止める。
   - Dashboard CSS: checkpoint card と progress summary の dark mode 対応を最小限整える。
 - `test/worker.test.js`
   - 低情報 progress が summary に入らないこと。
@@ -70,6 +74,7 @@ Dashboard Butler で長時間の VPS Codex CLI / app-server bridge 作業を投�
 - chat 内 checkpoint card を通常 message と同じ DOM に入れると、copy/reply/scroll の既存挙動を壊す可能性がある。
 - completion 後の clear が漏れると、古い checkpoint が final reply の下に残る。
 - dark mode の progress summary 背景が light 固定だと #744 の見えづらさを悪化させる。
+- scroll guard を広げすぎると、新規返信を受け取ったのに owner が気づきにくくなる。今回は live progress / refresh の追従だけを条件付きにし、通常 append の挙動は維持する。
 
 ## PR 前に確認すること
 
@@ -94,6 +99,7 @@ Dashboard Butler で長時間の VPS Codex CLI / app-server bridge 作業を投�
 
 - production PWA から #637 相当の低リスク read/status を投げ、30秒以内に composer 下の transient と chat 内 checkpoint のどちらかが見えること。
 - app 切替またはリロード後、最新 checkpoint が chat log 内に復帰すること。
+- owner が途中を読んでいる状態で checkpoint が更新されても、画面が下に引っ張られないこと。
 - completion 後、checkpoint card が消え、最終 Butler 返信に `進行ログ` が残ること。
 - low-risk read/status は passkey なし、deploy / bridge restart は従来通り passkey 境界を維持すること。
 

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -16558,6 +16558,18 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         });
       }
 
+      function isNearLatest() {
+        const distance = log.scrollHeight - log.scrollTop - log.clientHeight;
+        return distance < 96;
+      }
+
+      function scrollToLatestIfFollowing(shouldFollow) {
+        updateComposerReserve();
+        if (shouldFollow) {
+          scrollToLatest();
+        }
+      }
+
       function setStatus(text, options = {}) {
         status.replaceChildren(document.createTextNode(text));
         if (options.actionHref && options.actionLabel) {
@@ -16697,7 +16709,8 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         return entry;
       }
 
-      function renderThreadProgressCheckpoint(snapshot) {
+      function renderThreadProgressCheckpoint(snapshot, options = {}) {
+        const shouldFollow = options.follow === true || (options.follow !== false && isNearLatest());
         if (snapshot && typeof snapshot === "object") {
           transientProgressSnapshotState = snapshot;
         }
@@ -16711,15 +16724,17 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         if (paragraph) {
           paragraph.textContent = text;
         }
-        scrollToLatest();
+        scrollToLatestIfFollowing(shouldFollow);
         return true;
       }
 
       function clearThreadProgressCheckpoint() {
+        const shouldFollow = isNearLatest();
         if (threadProgressCheckpointCard) {
           threadProgressCheckpointCard.remove();
           threadProgressCheckpointCard = null;
         }
+        scrollToLatestIfFollowing(shouldFollow);
       }
 
       function setComposerLocked(locked) {
@@ -17814,6 +17829,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
       function renderThread(messages, options = {}) {
         const replace = options.replace === true;
         const snapshotForCheckpoint = transientProgressSnapshotState;
+        const shouldFollow = isNearLatest();
         if (replace) {
           messagesById.clear();
         }
@@ -17822,8 +17838,8 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           if (replace || messagesById.size === 0) {
             log.innerHTML = initialMarkup;
           }
-          renderThreadProgressCheckpoint(snapshotForCheckpoint);
-          scrollToLatest();
+          renderThreadProgressCheckpoint(snapshotForCheckpoint, { follow: shouldFollow });
+          scrollToLatestIfFollowing(shouldFollow);
           return;
         }
         for (const message of messages) {
@@ -17834,8 +17850,8 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           appendMessage(message, fragment, { scroll: false });
         }
         log.replaceChildren(fragment);
-        renderThreadProgressCheckpoint(snapshotForCheckpoint);
-        scrollToLatest();
+        renderThreadProgressCheckpoint(snapshotForCheckpoint, { follow: shouldFollow });
+        scrollToLatestIfFollowing(shouldFollow);
       }
 
       async function refreshThread() {

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -1275,10 +1275,13 @@ test("worker serves v2 dashboard for allowed owner identity without exposing sec
   assert.equal(body.includes(".progress-summary"), true);
   assert.equal(body.includes("background: var(--panel-strong); color: var(--muted);"), true);
   assert.equal(body.includes("data-thread-progress-checkpoint"), true);
-  assert.equal(body.includes("function renderThreadProgressCheckpoint(snapshot)"), true);
+  assert.equal(body.includes("function renderThreadProgressCheckpoint(snapshot, options = {})"), true);
   assert.equal(body.includes("function clearThreadProgressCheckpoint()"), true);
   assert.equal(body.includes("latestProgressCheckpointText(transientProgressSnapshotState)"), true);
   assert.equal(body.includes("snapshot: body.transientProgressSnapshot || null"), true);
+  assert.equal(body.includes("function isNearLatest()"), true);
+  assert.equal(body.includes("function scrollToLatestIfFollowing(shouldFollow)"), true);
+  assert.equal(body.includes("renderThreadProgressCheckpoint(snapshotForCheckpoint, { follow: shouldFollow })"), true);
   const renderTransientProgressSource = body.match(/function renderTransientProgress\(\) \{[\s\S]*?\n      \}/)?.[0] || "";
   assert.equal(renderTransientProgressSource.includes("scrollToLatest()"), false);
   assert.equal(renderTransientProgressSource.includes("updateComposerReserve()"), true);
@@ -1455,6 +1458,7 @@ test("worker serves v2 dashboard for allowed owner identity without exposing sec
   assert.equal(body.includes("form.requestSubmit();"), true);
   assert.equal(body.includes('form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }))'), true);
   assert.equal(body.includes("function scrollToLatest()"), true);
+  assert.equal(body.includes("function isNearLatest()"), true);
   assert.equal(body.includes("function showThinking()"), false);
   assert.equal(body.includes("function removeThinking("), false);
   assert.equal(body.includes('id="butler-interrupt-panel"'), false);

--- a/worker.js
+++ b/worker.js
@@ -72699,6 +72699,18 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         });
       }
 
+      function isNearLatest() {
+        const distance = log.scrollHeight - log.scrollTop - log.clientHeight;
+        return distance < 96;
+      }
+
+      function scrollToLatestIfFollowing(shouldFollow) {
+        updateComposerReserve();
+        if (shouldFollow) {
+          scrollToLatest();
+        }
+      }
+
       function setStatus(text, options = {}) {
         status.replaceChildren(document.createTextNode(text));
         if (options.actionHref && options.actionLabel) {
@@ -72838,7 +72850,8 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         return entry;
       }
 
-      function renderThreadProgressCheckpoint(snapshot) {
+      function renderThreadProgressCheckpoint(snapshot, options = {}) {
+        const shouldFollow = options.follow === true || (options.follow !== false && isNearLatest());
         if (snapshot && typeof snapshot === "object") {
           transientProgressSnapshotState = snapshot;
         }
@@ -72852,15 +72865,17 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         if (paragraph) {
           paragraph.textContent = text;
         }
-        scrollToLatest();
+        scrollToLatestIfFollowing(shouldFollow);
         return true;
       }
 
       function clearThreadProgressCheckpoint() {
+        const shouldFollow = isNearLatest();
         if (threadProgressCheckpointCard) {
           threadProgressCheckpointCard.remove();
           threadProgressCheckpointCard = null;
         }
+        scrollToLatestIfFollowing(shouldFollow);
       }
 
       function setComposerLocked(locked) {
@@ -73955,6 +73970,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
       function renderThread(messages, options = {}) {
         const replace = options.replace === true;
         const snapshotForCheckpoint = transientProgressSnapshotState;
+        const shouldFollow = isNearLatest();
         if (replace) {
           messagesById.clear();
         }
@@ -73963,8 +73979,8 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           if (replace || messagesById.size === 0) {
             log.innerHTML = initialMarkup;
           }
-          renderThreadProgressCheckpoint(snapshotForCheckpoint);
-          scrollToLatest();
+          renderThreadProgressCheckpoint(snapshotForCheckpoint, { follow: shouldFollow });
+          scrollToLatestIfFollowing(shouldFollow);
           return;
         }
         for (const message of messages) {
@@ -73975,8 +73991,8 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           appendMessage(message, fragment, { scroll: false });
         }
         log.replaceChildren(fragment);
-        renderThreadProgressCheckpoint(snapshotForCheckpoint);
-        scrollToLatest();
+        renderThreadProgressCheckpoint(snapshotForCheckpoint, { follow: shouldFollow });
+        scrollToLatestIfFollowing(shouldFollow);
       }
 
       async function refreshThread() {


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #590 の live progress checkpoint 更新で、owner が途中を読んでいる画面を最下部へ強制スクロールしないようにします。
- checkpoint / thread refresh は、更新前に最下部付近にいる場合だけ自動追従します。
- 通常の新規メッセージ append と composer progress 表示は #779 後の挙動を維持します。

## Satisfied Success Criteria

- `isNearLatest()` と `scrollToLatestIfFollowing()` を Dashboard chat client に追加した。
- `renderThreadProgressCheckpoint()` は更新前に bottom 近傍か確認し、読んでいる位置を壊さない。
- `renderThread()` の refresh/replace 後 scroll も、更新前に bottom 近傍だった場合だけ追従する。
- Dashboard HTML test で scroll guard 関数と conditional checkpoint render を確認する。

## Unsatisfied Success Criteria

- production iPad/PWA で、長い開発中に画面が下へチラつかないことは merge/deploy 後 E2E が必要です。
- #590 全体の realtime progress completion は、この PR だけでは完了しません。

## Non-goal violations

None.

## 開発前作戦図

- 作戦図 evidence: `docs/development-strategy/issue-590-realtime-progress-checkpoints.md`
- 完了体験: Dashboard Butler で owner が途中の progress を読んでいる時、live checkpoint 更新で画面が下へ引っ張られず、最下部で待っている時だけ自然に追従する。
- VTDD 全体で進める部分: Issue #590 の owner-facing observability を、無言待ち解消だけでなく読める進行表示へ近づける。
- 設計: Dashboard Butler chat surface で、live progress / thread refresh は更新前の scroll position を見て条件付き追従にする。通常 message append の挙動は維持する。
- 仮説: チラつきの原因は progress checkpoint / refresh のたびに `scrollToLatest()` が無条件実行されること。
- 検証計画: targeted worker HTML/progress tests、worker bundle generation、generated-worker check、self-parity、post-merge production PWA E2E。
- 改修見積もり: `src/worker/runtime.js` の `scrollToLatest`, `renderThreadProgressCheckpoint`, `renderThread` 近傍、`test/worker.test.js` HTML checks、`worker.js` generated bundle。
- 既に通っている経路: app-server status → transient snapshot → Dashboard WebSocket/thread refresh → progress checkpoint render。
- 未確認の境界: production iPad/PWA の実際の scroll inertia / keyboard / app switch 挙動。
- 穴が出そうな箇所: guard を広げすぎると新規返信に気づきにくくなるため、この PR では progress/refresh 追従だけを条件付きにする。
- PR 前に確認すること: `git status --short --branch`, targeted worker tests, `npm run build:worker`, `npm run check:generated-worker`, `npm run check:self-parity`, `git diff --check`。
- 実装候補と捨てた案: 採用は bottom 近傍のみ追従。全 auto-scroll 削除は新規返信の見落としリスクがあるため不採用。
- merge 後に通す E2E: production PWA E2E として、長い read/status を投げ、途中を読んでいる状態で checkpoint が来ても下へ引っ張られないことを検証する。
- 次の PR を増やさない理由: この PR は #590 の scroll regression を狭く直す scope で、既存 live progress 実装を広げずに予見できるチラつき原因だけを閉じる。
- 停止条件: production E2E で通常返信が見えなくなる、または scroll position 保持により owner-facing progress が見失われる場合。

## Dry-run Impact Report

- Target Issue: Issue #590
- Implementing Success Criteria: live progress update の scroll guard。
- Explicit Non-goals: #498 画像アップロード軽量化、#637 VPS helper、deploy / credential / permission mutation。
- Expected touched files/routes/workflows: `docs/development-strategy/issue-590-realtime-progress-checkpoints.md`, `src/worker/runtime.js`, `test/worker.test.js`, `worker.js`。
- Affected Issues: #590, evidence overlap with #528 and #744.
- Affected PRs: PR #778 and PR #779 aftereffects are narrowed by this follow-up PR.
- Affected workflows: worker build / worker tests only.
- Affected runtime/operator surfaces: Dashboard Butler PWA chat scroll behavior.
- What may break if we patch narrowly: owner at non-bottom may not auto-see a new checkpoint until scrolling down.
- Unknowns to investigate before coding: iPad production PWA scroll physics and keyboard behavior remain live-only.
- Validation needed: targeted worker tests, generated worker check, self-parity, production PWA E2E.
- Stop condition: scroll guard causes missed final replies or stale progress visibility.

## Execution Queue Delta

- Queue position before: Issue #590 remains Now as the Dashboard Butler silent wait / progress root blocker.
- Preemption decision: ROOT. This continues the current Issue #590 root blocker and does not replace the queue.
- Queue delta: Issue #590 stays in `Now`; this PR reduces live progress scroll jitter and leaves Issue #590 open for production E2E.
- Why this PR is next: Owner observed the screen being pulled downward during live development, which blocks readable progress.
- Active Issues not downscoped: Active Issues are not downscoped. #498, #637, #744, and other active Issues remain open unless separately verified.

## File / Line Hypotheses

- file: `src/worker/runtime.js`
  - hypothesis: `renderThreadProgressCheckpoint()` and `renderThread()` call `scrollToLatest()` unconditionally.
  - risk if changed narrowly: ordinary new messages could stop auto-scrolling if the guard is applied too broadly.
  - validation: targeted worker HTML/progress tests and production PWA E2E.
  - related Issue: #590

## Hypothesis Retrospective

- expected: Conditional scroll keeps owner reading position stable during progress updates.
- actual: Targeted tests pass; production PWA evidence remains required.
- mismatch: Not known until live E2E.
- lesson: #590 progress UX must treat scroll position as part of completion evidence.
- should become RAG candidate: Yes if production E2E confirms the scroll guard.

## Verification Evidence

- Unit: `node --test test/worker.test.js --test-name-pattern "worker serves v2 dashboard for allowed owner identity without exposing secrets|served dashboard inline chat renderer executes decode, link, wrap, and copy behavior|DashboardChatRoom separates low-information transient progress|DashboardChatRoom clears transient progress snapshot|DashboardChatRoom maps app-server progress stages"` passed.
- Integration: `npm run build:worker` passed; `npm run check:generated-worker` passed; `npm run check:self-parity` passed; `git diff --check` passed.
- E2E: Not run before merge. Production PWA E2E required after deploy.
- Manual: Owner observation recorded in Issue #590 comment.
- Evidence path/link: `docs/development-strategy/issue-590-realtime-progress-checkpoints.md`

## Butler Completion Contract

- Primary owner surface: Dashboard Butler PWA.
- Fallback surface: mac Codex is debug/bootstrap only and not completion evidence.
- Owner goal: Dashboard Butler live progress remains readable and does not yank the screen while owner reads.
- Butler entrypoint: Existing Dashboard Butler natural-language chat.
- Dashboard Butler natural-language path: Dashboard Butler の通常チャット入口で owner が自然文の開発依頼を送ると、同じ chat thread の progress checkpoint が条件付き scroll で表示される。
- Action Schema exposure: Not changed.
- Runtime path: DashboardChatRoom WebSocket/thread refresh payload with `transientProgressSnapshot` rendered by Dashboard client script.
- Runner/runtime truth: Latest transient snapshot 1件 is used; raw progress stream is not persisted.
- Authority boundary: No high-risk operation added.
- E2E evidence: Missing until production PWA merge/deploy verification.
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: Required after merge by existing deploy flow; not performed by this PR.
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: merge/deploy 後に必要。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate
- AGENTS.md 開発前作戦図 Gate
- AGENTS.md Evidence Discipline
- AGENTS.md Change Size and PR Discipline
- AGENTS.md Conversation UX Contract

## Out-of-scope but NOT implemented

- #498 image upload resize/compress.
- #637 VPS privileged maintenance lifecycle.
- #744 full long-response visual polish.

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #590
- Execution ID: issue-590-live-progress-scroll-guard
- Goal: Dashboard Butler live progress scroll guard
