### PR TITLE
Issue #590 keep live fallback after low-info progress

### DIFF
--- a/docs/development-strategy/issue-590-realtime-progress-checkpoints.md
+++ b/docs/development-strategy/issue-590-realtime-progress-checkpoints.md
@@ -12,6 +12,8 @@ Dashboard Butler で長時間の VPS Codex CLI / app-server bridge 作業を投�
 
 2026-06-04 の PR #780 deploy 後、composer 下の transient status は戻ったが、chat-visible live progress は相変わらず出ないことを owner が確認した。bridge が `planning` / `command` / `file_change` のような具体 event を受けられない turn でも、30秒以内に owner-facing fallback checkpoint を生成しなければ、#590 の無言待ち解消にはならない。
 
+2026-06-04 の追加調査で、bridge は `command` / `file_change` / `tool_call` など低情報 event を `ownerFacingProgressSeen=true` と扱って fallback timer を止めていた。一方 Worker は「コマンドを実行しています」「ファイル変更を確認しています」系を progress summary から除外する。結果として、低情報 event が fallback を潰し、chat-visible checkpoint が出ない。次 slice は、fallback 停止条件を summary に残る owner-facing stage のみに狭める。
+
 ## VTDD 全体で進める部分
 
 この slice は #590 の realtime progress checkpoint stream の最小実装に限定する。#637 の production E2E で確認した「低リスク read/status が passkey なしで helper queue に渡る」経路を、#590 の進行表示 E2E の観測対象として使えるようにする。
@@ -52,6 +54,7 @@ Dashboard Butler で長時間の VPS Codex CLI / app-server bridge 作業を投�
   - Dashboard CSS: checkpoint card と progress summary の dark mode 対応を最小限整える。
 - `scripts/run-dashboard-app-server-bridge.mjs`
   - turn 開始後、owner-facing progress event が一定時間届かない場合に `long_turn_checkpoint` を送る。
+  - `command` / `file_change` / `tool_call` のような低情報 event では fallback を止めず、`planning` / `implementation` / `test` / `pr_create` など owner-facing stage でのみ fallback を止める。
   - checkpoint は raw delta ではなく、turn lifecycle 由来の低頻度 owner-facing 文に限定する。
 - `test/worker.test.js`
   - 低情報 progress が summary に入らないこと。
@@ -73,6 +76,7 @@ Dashboard Butler で長時間の VPS Codex CLI / app-server bridge 作業を投�
 - app-server bridge が 30秒以内に owner-facing stage を送ることは、この slice で fallback として保証する。ただし WebSocket が iPad バックグラウンドで停止している間の即時表示は保証しない。
 - WebSocket が iPad PWA のバックグラウンドで停止する挙動自体は、この slice では直さない。復帰時に snapshot から見えることを優先する。
 - raw assistant delta をそのまま checkpoint にするかは未採用。思考や未整理文を流すリスクがあるため、この slice では stage-based checkpoint に限定する。
+- `long_turn_checkpoint` が production PWA で 30秒以内に見えるかは merge/deploy 後 E2E で確認する。local test は fallback event と snapshot 化までの証拠に留める。
 
 ## 穴が出そうな箇所
 
@@ -104,6 +108,7 @@ Dashboard Butler で長時間の VPS Codex CLI / app-server bridge 作業を投�
 ## merge 後に通す E2E
 
 - production PWA から #637 相当の低リスク read/status を投げ、30秒以内に chat-visible owner-facing checkpoint が見えること。
+- `command` / `file_change` の低情報 event が先に来ても、fallback checkpoint が潰れないこと。
 - app 切替またはリロード後、最新 checkpoint が chat log 内に復帰すること。
 - owner が途中を読んでいる状態で checkpoint が更新されても、画面が下に引っ張られないこと。
 - completion 後、checkpoint card が消え、最終 Butler 返信に `進行ログ` が残ること。

--- a/scripts/run-dashboard-app-server-bridge.mjs
+++ b/scripts/run-dashboard-app-server-bridge.mjs
@@ -974,7 +974,24 @@ function isDashboardBridgeOwnerFacingProgressEvent(event = {}) {
     return false;
   }
   const stage = String(event.stage || "").trim().toLowerCase().replaceAll("-", "_");
-  return shouldPersistAppServerProgressStage(stage) && stage !== "thinking";
+  return [
+    "planning",
+    "hypothesis",
+    "target",
+    "verify",
+    "verification",
+    "waiting_approval",
+    "waiting_user_input",
+    "implementation",
+    "test",
+    "tests",
+    "pr_body",
+    "pr_create",
+    "reviewer_wait",
+    "reviewer_revision",
+    "debug_slow_turn",
+    "long_turn_checkpoint"
+  ].includes(stage);
 }
 
 export function buildDashboardBridgeLiveProgressFallbackEvent({

--- a/test/dashboard-app-server-bridge.test.js
+++ b/test/dashboard-app-server-bridge.test.js
@@ -1783,6 +1783,69 @@ test("dashboard app-server bridge emits fallback live progress before a quiet lo
   assert.ok(events.find((event) => event.type === "app_server_reply"));
 });
 
+test("dashboard app-server bridge does not suppress live fallback after low-information progress", async () => {
+  const events = [];
+  let notificationHandler = () => {};
+  let nextId = 1;
+  const appServer = {
+    nextRequestId() {
+      const id = nextId;
+      nextId += 1;
+      return id;
+    },
+    onNotification(handler) {
+      notificationHandler = handler;
+      return () => {};
+    },
+    async request(message) {
+      if (message.method === "thread/start") {
+        return { thread: { id: "codex-thread-590" } };
+      }
+      if (message.method === "turn/start") {
+        setTimeout(() => {
+          notificationHandler({
+            method: "item/started",
+            params: {
+              threadId: "codex-thread-590",
+              turnId: "turn-590",
+              item: { type: "command_execution" }
+            }
+          });
+        }, 1);
+        setTimeout(() => {
+          notificationHandler({
+            method: "turn/completed",
+            params: {
+              threadId: "codex-thread-590",
+              turnId: "turn-590",
+              status: "completed"
+            }
+          });
+        }, 12);
+        return { turn: { id: "turn-590" } };
+      }
+      return {};
+    }
+  };
+
+  await handleDashboardTurnRequest({
+    request: {
+      threadId: "dashboard-main",
+      text: "Issue #590 の低情報 progress 後 fallback を確認して"
+    },
+    appServer,
+    sendDashboardEvent: async (event) => events.push(event),
+    liveProgressInitialDelayMs: 5,
+    liveProgressIntervalMs: 1000
+  });
+
+  assert.ok(events.find((event) => event.type === "app_server_status" && event.stage === "command"));
+  const fallback = events.find((event) => event.type === "app_server_status" && event.stage === "long_turn_checkpoint");
+  assert.ok(fallback);
+  assert.equal(fallback.persistProgress, true);
+  assert.match(fallback.text, /作業を継続しています/);
+});
+
 test("dashboard app-server bridge rejects out-of-range Issue #590 debug slow turn duration", async () => {
   const events = [];
   await handleDashboardTurnRequest({

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -5146,6 +5146,48 @@ test("DashboardChatRoom separates low-information transient progress from owner-
   assert.equal((await store.listThread("dashboard-main-unresolved")).length, 0);
 });
 
+test("DashboardChatRoom keeps long-turn fallback as owner-facing progress checkpoint", async () => {
+  const store = createInMemoryDashboardChatStore();
+  const dashboardSocket = createMockSocket("dashboard", "dashboard-main-unresolved");
+  const bridgeSocket = createMockSocket("app_server_bridge", "dashboard-main-unresolved");
+  const storage = createMockDurableObjectStorage();
+  const room = new DashboardChatRoom(
+    {
+      storage,
+      getWebSockets() {
+        return [dashboardSocket, bridgeSocket];
+      }
+    },
+    { DASHBOARD_CHAT_STORE: store }
+  );
+
+  await room.webSocketMessage(
+    bridgeSocket,
+    JSON.stringify({
+      type: "app_server_status",
+      status: "thinking",
+      stage: "long_turn_checkpoint",
+      persistProgress: true,
+      threadId: "dashboard-main-unresolved",
+      codexThreadId: "codex-thread-590",
+      text: "作業を継続しています。まだ最終回答は生成中です。"
+    })
+  );
+
+  const snapshot = storage.values.get("transient_progress_snapshot:dashboard-main-unresolved");
+  assert.equal(snapshot.text, "作業を継続しています。まだ最終回答は生成中です。");
+  assert.deepEqual(
+    snapshot.progressSummary.entries.map((entry) => entry.text),
+    ["作業を継続しています。まだ最終回答は生成中です。"]
+  );
+  const transientPayload = dashboardSocket.sent.map((message) => JSON.parse(message)).find((message) => message.type === "transient_status");
+  assert.deepEqual(
+    transientPayload.transientProgressSnapshot.progressSummary.entries.map((entry) => entry.text),
+    ["作業を継続しています。まだ最終回答は生成中です。"]
+  );
+  assert.equal((await store.listThread("dashboard-main-unresolved")).length, 0);
+});
+
 test("DashboardChatRoom clears transient progress snapshot after final reply", async () => {
   const store = createInMemoryDashboardChatStore();
   const dashboardSocket = createMockSocket("dashboard", "dashboard-main-unresolved");


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #590 の chat-visible live progress が出ない根本原因の一つを修正します。
- bridge が `command` / `file_change` / `tool_call` のような低情報 progress を見ただけで `ownerFacingProgressSeen=true` と扱い、30秒 fallback checkpoint を止めていた状態を直します。
- fallback 停止条件を、summary に残すべき owner-facing stage のみに狭めます。

## Satisfied Success Criteria

- `scripts/run-dashboard-app-server-bridge.mjs` の owner-facing progress 判定を、`planning` / `implementation` / `test` / `pr_create` / `long_turn_checkpoint` などに限定した。
- 低情報な `command` event が先に来ても、`long_turn_checkpoint` fallback が発火する bridge test を追加した。
- Worker 側で `long_turn_checkpoint` が transient snapshot の `progressSummary.entries` に入り、Dashboard chat-visible checkpoint の元データになることを test で固定した。
- raw reply delta / full transcript / high-frequency durable event stream は増やしていない。

## Unsatisfied Success Criteria

- production PWA で 30秒以内に chat-visible checkpoint が見えることは merge/deploy 後 E2E が必要です。
- Issue #590 全体はまだ close-ready ではありません。

## Non-goal violations

None.

## 開発前作戦図

- 作戦図 evidence: `docs/development-strategy/issue-590-realtime-progress-checkpoints.md`
- 完了体験: Dashboard Butler の長い turn 中に、低情報 event が先に来ても 30秒 fallback checkpoint が潰れず、owner が chat 本文側で作業継続を確認できる。
- VTDD 全体で進める部分: Issue #590 の silent wait blocker を、bridge fallback と Worker snapshot evidence の接続で狭く前進させる。
- 設計: bridge は低情報 transport progress と owner-facing checkpoint を分け、owner-facing stage が来た時だけ fallback timer を止める。Worker は `long_turn_checkpoint` を progress summary として snapshot に保持する。
- 仮説: suspected cause は `command` / `file_change` / `tool_call` が `ownerFacingProgressSeen` を立てて fallback を止めること。そのため Worker が summary に入れる checkpoint が来ない。
- 検証計画: bridge unit test で低情報 event 後 fallback を確認し、Worker test で `long_turn_checkpoint` snapshot summary を確認する。
- 改修見積もり: `scripts/run-dashboard-app-server-bridge.mjs` の owner-facing判定、`test/dashboard-app-server-bridge.test.js` の fallback test、`test/worker.test.js` の snapshot test、strategy file。
- 既に通っている経路: app-server bridge status -> DashboardChatRoom transient snapshot -> Dashboard UI checkpoint render。
- 未確認の境界: production PWA で WebSocket/App sleep/reconnect を含めて 30秒以内に見えるかは live E2E が必要。
- 穴が出そうな箇所: owner-facing 判定を狭めすぎると具体 progress があっても fallback が繰り返される可能性がある。
- PR 前に確認すること: targeted bridge tests, targeted worker tests, generated worker check, self-parity, diff check, PR checks。
- 実装候補と捨てた案: 採用は fallback 停止条件の修正。捨てた案は `command` / `file_change` を summary に入れる案。owner が低情報として除外希望のため不採用。
- merge 後に通す E2E: production PWA E2E で長い read/status を投げ、低情報 progress が先に来ても30秒以内に chat-visible `long_turn_checkpoint` が見えることを確認する。
- 次の PR を増やさない理由: この PR は #590 の「fallback が発火しない」根本条件だけを直す狭い slice で、media mismatch や reply preview は混ぜない。
- 停止条件: production E2E で fallback が出ない、または低情報 status が再び chat 本文を汚す場合。

## Dry-run Impact Report

- Target Issue: Issue #590
- Implementing Success Criteria: 低情報 event 後も owner-facing fallback checkpoint が潰れないこと。
- Explicit Non-goals: media reference repo mismatch、reply target preview、deploy、credential、permission mutation、#637 helper lifecycle。
- Expected touched files/routes/workflows: `scripts/run-dashboard-app-server-bridge.mjs`, `test/dashboard-app-server-bridge.test.js`, `test/worker.test.js`, `docs/development-strategy/issue-590-realtime-progress-checkpoints.md`。
- Affected Issues: #590.
- Affected PRs: PR #777 / #778 / #779 / #780 の follow-up evidence。
- Affected workflows: app-server bridge runtime and tests.
- Affected runtime/operator surfaces: Dashboard Butler PWA live progress via app-server bridge.
- What may break if we patch narrowly: fallback が owner-facing stage 後も過剰に出る可能性。
- Unknowns to investigate before coding: production app-server がどの低情報 event を何秒間隔で送るか。
- Validation needed: bridge test, worker test, generated worker check, self-parity, production PWA E2E.
- Stop condition: low-information event handling と fallback generation の boundary が実 production event と合わない場合。

## Execution Queue Delta

- Queue position before: Issue #590 remains `Now`.
- Preemption decision: ROOT. Owner explicitly corrected that #590 live progress is not finished.
- Queue delta: Issue #590 stays in `Now`; this PR fixes the fallback suppression path and leaves production PWA E2E as remaining evidence.
- Why this PR is next: #590 live progress checkpoint が途中表示されず、低情報 event が fallback を止める root cause が見つかったため。
- Active Issues not downscoped: Active Issues are not downscoped. #498 media mismatch / #528 reply preview / #637 helper lifecycle are not closed or downscoped by this PR.

## File / Line Hypotheses

- file: `scripts/run-dashboard-app-server-bridge.mjs`
  - hypothesis: `isDashboardBridgeOwnerFacingProgressEvent` treats low-information stages as owner-facing, so fallback timer stops too early.
  - risk if changed narrowly: fallback repeats after genuine progress if owner-facing stage list misses a real stage.
  - validation: bridge test for low-information command event followed by fallback.
  - related Issue: #590

- file: `test/worker.test.js`
  - hypothesis: Worker already accepts `long_turn_checkpoint` as summary-worthy text, but this was not explicitly locked by test.
  - risk if changed narrowly: future low-information filters could accidentally exclude fallback checkpoint.
  - validation: Worker snapshot test.
  - related Issue: #590

## Hypothesis Retrospective

- expected: Low-information `command` event no longer suppresses fallback, and Worker snapshot contains `long_turn_checkpoint`.
- actual: Targeted bridge and worker tests passed locally.
- mismatch: Production PWA E2E still required.
- lesson: bridge-side `ownerFacingProgressSeen` must match Worker-side summary inclusion, otherwise fallback can be silently lost.
- should become RAG candidate: Yes, if production E2E confirms the root cause.

## Verification Evidence

- Unit: `node --test test/dashboard-app-server-bridge.test.js --test-name-pattern "dashboard app-server bridge formats live progress fallback checkpoints|dashboard app-server bridge emits fallback live progress before a quiet long turn completes|dashboard app-server bridge does not suppress live fallback after low-information progress"` passed.
- Unit: `node --test test/worker.test.js --test-name-pattern "DashboardChatRoom separates low-information transient progress from owner-facing progress checkpoints|DashboardChatRoom keeps long-turn fallback as owner-facing progress checkpoint|DashboardChatRoom clears transient progress snapshot after final reply|DashboardChatRoom maps app-server progress stages"` passed.
- Integration: `npm run check:generated-worker` passed; `npm run check:self-parity` passed; `git diff --check` passed.
- E2E: Not run before merge. Production PWA E2E required after deploy.
- Manual: Issue #590 production evidence recorded in prior comments.
- Evidence path/link: `docs/development-strategy/issue-590-realtime-progress-checkpoints.md`

## Butler Completion Contract

- Primary owner surface: Dashboard Butler PWA.
- Fallback surface: mac Codex is debug/bootstrap only and not completion evidence.
- Owner goal: 長い turn 中に owner が無言で待たされず、chat-visible checkpoint を読める。
- Butler entrypoint: Existing Dashboard Butler natural-language chat.
- Dashboard Butler natural-language path: Dashboard Butler natural-language/chat entrypoint で owner が通常チャットに長めの read/status/development を自然文で投げると、bridge fallback が 30秒以内に checkpoint を送る。
- Action Schema exposure: Not changed.
- Runtime path: `scripts/run-dashboard-app-server-bridge.mjs` -> `app_server_status stage=long_turn_checkpoint` -> `DashboardChatRoom` transient snapshot -> Dashboard UI checkpoint.
- Runner/runtime truth: Latest transient snapshot only; raw event stream is not persisted.
- Authority boundary: No high-risk operation added.
- E2E evidence: Missing until production PWA deploy verification.
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: Required after merge by existing deploy flow; not performed by this PR.
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: merge/deploy 後に必要。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate
- AGENTS.md 開発前作戦図 Gate
- AGENTS.md Evidence Discipline
- AGENTS.md Conversation UX Contract
- AGENTS.md Change Size and PR Discipline

## Out-of-scope but NOT implemented

- media reference repo mismatch.
- reply target preview filtering.
- #637 production E2E.
- Issue closure.

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #590
- Execution ID: issue-590-live-progress-fallback-after-low-info
- Goal: Keep long-turn fallback alive after low-information app-server progress
