### PR TITLE
Issue #590 show reply delta progress in chat

### DIFF
--- a/docs/development-strategy/issue-590-realtime-progress-checkpoints.md
+++ b/docs/development-strategy/issue-590-realtime-progress-checkpoints.md
@@ -12,6 +12,8 @@ Dashboard Butler で長時間の VPS Codex CLI / app-server bridge 作業を投�
 
 2026-06-04 の PR #780 deploy 後、composer 下の transient status は戻ったが、chat-visible live progress は相変わらず出ないことを owner が確認した。bridge が `planning` / `command` / `file_change` のような具体 event を受けられない turn でも、30秒以内に owner-facing fallback checkpoint を生成しなければ、#590 の無言待ち解消にはならない。
 
+2026-06-04 の添付 evidence で、入力欄下の `進行中` には「その通りです。今の時点で #590 は終わっていません...」のような readable progress が既に出ていることを確認した。これは `app_server_reply_delta` の `progressText` として届いているため、chat-visible checkpoint に昇格できる。raw delta を durable message 化するのではなく、transient snapshot の latest assistant delta checkpoint として表示し、final summary には最新1件だけ残す。
+
 2026-06-04 の追加調査で、bridge は `command` / `file_change` / `tool_call` など低情報 event を `ownerFacingProgressSeen=true` と扱って fallback timer を止めていた。一方 Worker は「コマンドを実行しています」「ファイル変更を確認しています」系を progress summary から除外する。結果として、低情報 event が fallback を潰し、chat-visible checkpoint が出ない。次 slice は、fallback 停止条件を summary に残る owner-facing stage のみに狭める。
 
 ## VTDD 全体で進める部分
@@ -43,6 +45,7 @@ Dashboard Butler で長時間の VPS Codex CLI / app-server bridge 作業を投�
 - Dashboard HTML に chat 内 checkpoint card の描画経路があり、snapshot restore / WebSocket transient update / final reply clear で動く。
 - live progress checkpoint と thread refresh は、更新前に最下部付近だった場合だけ自動追従する。owner が途中を読んでいる場合は scroll position を壊さない。
 - app-server bridge は、具体 progress event が届かない turn でも 30秒以内に owner-facing fallback checkpoint を送る。
+- app-server reply delta の readable `progressText` は、入力欄下だけでなく chat-visible checkpoint としても出す。ただし raw delta を通常 chat history に永続化しない。
 - worker bundle を再生成し、generated worker 差分を一致させる。
 
 ## 改修見積もり
@@ -52,6 +55,7 @@ Dashboard Butler で長時間の VPS Codex CLI / app-server bridge 作業を投�
   - Dashboard client script: `transientProgressSnapshot.progressSummary` から最新 checkpoint を chat log 内に ephemeral card として描画し、clear 時に消す。
   - Dashboard client script: `isNearLatest()` / conditional scroll helper を追加し、progress update / thread refresh の無条件 scroll を止める。
   - Dashboard CSS: checkpoint card と progress summary の dark mode 対応を最小限整える。
+  - `app_server_reply_delta` の snapshot 化では、latest delta entry を差し替えることで final `進行ログ` の重複増殖を防ぐ。
 - `scripts/run-dashboard-app-server-bridge.mjs`
   - turn 開始後、owner-facing progress event が一定時間届かない場合に `long_turn_checkpoint` を送る。
   - `command` / `file_change` / `tool_call` のような低情報 event では fallback を止めず、`planning` / `implementation` / `test` / `pr_create` など owner-facing stage でのみ fallback を止める。
@@ -108,6 +112,7 @@ Dashboard Butler で長時間の VPS Codex CLI / app-server bridge 作業を投�
 ## merge 後に通す E2E
 
 - production PWA から #637 相当の低リスク read/status を投げ、30秒以内に chat-visible owner-facing checkpoint が見えること。
+- 入力欄下に readable progress が出た場合、同じ内容または要約された最新内容が chat 欄の checkpoint にも見えること。
 - `command` / `file_change` の低情報 event が先に来ても、fallback checkpoint が潰れないこと。
 - app 切替またはリロード後、最新 checkpoint が chat log 内に復帰すること。
 - owner が途中を読んでいる状態で checkpoint が更新されても、画面が下に引っ張られないこと。

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -714,7 +714,7 @@ export class DashboardChatRoom {
       status,
       text,
       source,
-      progressSummary: buildDashboardProgressSummarySnapshot(previous, { text }),
+      progressSummary: buildDashboardProgressSummarySnapshot(previous, { text, source }),
       updatedAt: new Date().toISOString()
     });
     if (!key || !normalized || typeof this.ctx?.storage?.put !== "function") {
@@ -9871,6 +9871,8 @@ function normalizeDashboardAppServerBridgeEvent(payload, { fallbackThreadId = ""
     // Streaming deltas are transient progress, not durable chat messages.
     transientStatus = "thinking";
     transientText = progressText || text;
+    snapshotTransientStatus = true;
+    snapshotSource = "app_server_reply_delta";
   } else if (eventType === "app_server_reply") {
     if (text) {
       messages.push(
@@ -9982,9 +9984,10 @@ function normalizeDashboardProgressSummary(value) {
     if (!text) continue;
     const entry = {
       text,
-      at: normalizeIsoTimestamp(rawEntry?.at || rawEntry?.createdAt || rawEntry?.created_at) || ""
+      at: normalizeIsoTimestamp(rawEntry?.at || rawEntry?.createdAt || rawEntry?.created_at) || "",
+      source: sanitizeDashboardChatText(rawEntry?.source || "")
     };
-    const entryLength = entry.text.length + entry.at.length;
+    const entryLength = entry.text.length + entry.at.length + entry.source.length;
     if (totalLength + entryLength > 3200) break;
     entries.push(entry);
     totalLength += entryLength;
@@ -9995,16 +9998,21 @@ function normalizeDashboardProgressSummary(value) {
   };
 }
 
-function buildDashboardProgressSummarySnapshot(previous, { text = "" } = {}) {
+function buildDashboardProgressSummarySnapshot(previous, { text = "", source = "" } = {}) {
   const previousSummary = normalizeDashboardProgressSummary(previous?.progressSummary);
-  const entries = [...previousSummary.entries];
+  const normalizedSource = sanitizeDashboardChatText(source);
+  const entries =
+    normalizedSource === "app_server_reply_delta"
+      ? previousSummary.entries.filter((entry) => entry.source !== "app_server_reply_delta")
+      : [...previousSummary.entries];
   const normalizedText = sanitizeDashboardChatText(text);
   if (normalizedText && shouldIncludeDashboardProgressSummaryEntry(normalizedText)) {
     const latest = entries.at(-1);
     if (!latest || latest.text !== normalizedText) {
       entries.push({
         text: normalizedText,
-        at: new Date().toISOString()
+        at: new Date().toISOString(),
+        source: normalizedSource
       });
     }
   }
@@ -10024,7 +10032,7 @@ function shouldIncludeDashboardProgressSummaryEntry(text) {
 
 function dashboardProgressSummaryEntriesKey(progressSummary) {
   const normalized = normalizeDashboardProgressSummary(progressSummary);
-  return JSON.stringify(normalized.entries.map((entry) => entry.text));
+  return JSON.stringify(normalized.entries.map((entry) => [entry.text, entry.source]));
 }
 
 function attachDashboardProgressSummaryToFinalMessages(messages = [], snapshot = null) {

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -4771,6 +4771,14 @@ test("DashboardChatRoom does not persist app-server reply deltas as chat message
   assert.equal(transientDelta.type, "transient_status");
   assert.equal(transientDelta.status, "thinking");
   assert.equal(transientDelta.text, "日本");
+  assert.deepEqual(
+    transientDelta.transientProgressSnapshot.progressSummary.entries.map((entry) => [entry.text, entry.source]),
+    [["日本", "app_server_reply_delta"]]
+  );
+  assert.deepEqual(
+    storage.values.get("transient_progress_snapshot:dashboard-main-unresolved").progressSummary.entries.map((entry) => [entry.text, entry.source]),
+    [["日本", "app_server_reply_delta"]]
+  );
 
   await room.webSocketMessage(
     bridgeSocket,
@@ -4787,6 +4795,10 @@ test("DashboardChatRoom does not persist app-server reply deltas as chat message
   assert.equal(stored[0].role, "butler");
   assert.equal(stored[0].status, "replied");
   assert.equal(stored[0].text, "日本時間では、今日は 05月22日 20時09分です。");
+  assert.deepEqual(
+    stored[0].progressSummary.entries.map((entry) => [entry.text, entry.source]),
+    [["日本", "app_server_reply_delta"]]
+  );
 });
 
 test("DashboardChatRoom does not rewrite unchanged app-server thread mapping during transient bursts", async () => {
@@ -4856,6 +4868,62 @@ test("DashboardChatRoom does not rewrite unchanged app-server thread mapping dur
 
   assert.equal(storage.values.get("app_server_thread:dashboard-main-unresolved").codexThreadId, "codex-thread-451");
   assert.equal(storage.putCalls.filter((call) => call.key === "app_server_thread:dashboard-main-unresolved").length, 2);
+});
+
+test("DashboardChatRoom keeps only the latest assistant reply delta checkpoint", async () => {
+  const store = createInMemoryDashboardChatStore();
+  const dashboardSocket = createMockSocket("dashboard", "dashboard-main-unresolved");
+  const bridgeSocket = createMockSocket("app_server_bridge", "dashboard-main-unresolved");
+  const storage = createMockDurableObjectStorage();
+  const room = new DashboardChatRoom(
+    {
+      storage,
+      getWebSockets() {
+        return [dashboardSocket, bridgeSocket];
+      }
+    },
+    { DASHBOARD_CHAT_STORE: store }
+  );
+
+  await room.webSocketMessage(
+    bridgeSocket,
+    JSON.stringify({
+      type: "app_server_status",
+      status: "thinking",
+      stage: "planning",
+      threadId: "dashboard-main-unresolved",
+      codexThreadId: "codex-thread-590",
+      text: "方針を整理しています。"
+    })
+  );
+  await room.webSocketMessage(
+    bridgeSocket,
+    JSON.stringify({
+      type: "app_server_reply_delta",
+      threadId: "dashboard-main-unresolved",
+      codexThreadId: "codex-thread-590",
+      progressText: "その通りです。"
+    })
+  );
+  await room.webSocketMessage(
+    bridgeSocket,
+    JSON.stringify({
+      type: "app_server_reply_delta",
+      threadId: "dashboard-main-unresolved",
+      codexThreadId: "codex-thread-590",
+      progressText: "その通りです。\n\n今の時点で #590 は終わっていません。"
+    })
+  );
+
+  const snapshot = storage.values.get("transient_progress_snapshot:dashboard-main-unresolved");
+  assert.deepEqual(
+    snapshot.progressSummary.entries.map((entry) => [entry.text, entry.source]),
+    [
+      ["方針を整理しています。", "app_server_status"],
+      ["その通りです。\n\n今の時点で #590 は終わっていません。", "app_server_reply_delta"]
+    ]
+  );
+  assert.equal((await store.listThread("dashboard-main-unresolved")).length, 0);
 });
 
 test("DashboardChatRoom persists app-server timeout as recoverable Japanese thread message", async () => {
@@ -5029,7 +5097,7 @@ test("DashboardChatRoom exposes last app-server status snapshot on thread reconn
   assert.deepEqual(payload.transientProgressSnapshot, snapshot);
 });
 
-test("DashboardChatRoom keeps app-server reply deltas out of progress snapshots", async () => {
+test("DashboardChatRoom keeps app-server reply deltas out of durable chat while exposing live checkpoints", async () => {
   const store = createInMemoryDashboardChatStore();
   const dashboardSocket = createMockSocket("dashboard", "dashboard-main-unresolved");
   const bridgeSocket = createMockSocket("app_server_bridge", "dashboard-main-unresolved");
@@ -5054,8 +5122,13 @@ test("DashboardChatRoom keeps app-server reply deltas out of progress snapshots"
     })
   );
 
-  assert.equal(storage.values.has("transient_progress_snapshot:dashboard-main-unresolved"), false);
-  assert.equal(storage.putCalls.some((call) => call.key === "transient_progress_snapshot:dashboard-main-unresolved"), false);
+  const snapshot = storage.values.get("transient_progress_snapshot:dashboard-main-unresolved");
+  assert.equal(snapshot.text, "途中の返答断片");
+  assert.deepEqual(
+    snapshot.progressSummary.entries.map((entry) => [entry.text, entry.source]),
+    [["途中の返答断片", "app_server_reply_delta"]]
+  );
+  assert.equal(storage.putCalls.some((call) => call.key === "transient_progress_snapshot:dashboard-main-unresolved"), true);
   assert.equal((await store.listThread("dashboard-main-unresolved")).length, 0);
 });
 

--- a/worker.js
+++ b/worker.js
@@ -58562,7 +58562,7 @@ var DashboardChatRoom = class {
       status,
       text,
       source,
-      progressSummary: buildDashboardProgressSummarySnapshot(previous, { text }),
+      progressSummary: buildDashboardProgressSummarySnapshot(previous, { text, source }),
       updatedAt: (/* @__PURE__ */ new Date()).toISOString()
     });
     if (!key || !normalized || typeof this.ctx?.storage?.put !== "function") {
@@ -66646,6 +66646,8 @@ function normalizeDashboardAppServerBridgeEvent(payload, { fallbackThreadId = ""
   if (eventType === "app_server_reply_delta") {
     transientStatus = "thinking";
     transientText = progressText || text;
+    snapshotTransientStatus = true;
+    snapshotSource = "app_server_reply_delta";
   } else if (eventType === "app_server_reply") {
     if (text) {
       messages.push(
@@ -66751,9 +66753,10 @@ function normalizeDashboardProgressSummary(value) {
     if (!text) continue;
     const entry = {
       text,
-      at: normalizeIsoTimestamp(rawEntry?.at || rawEntry?.createdAt || rawEntry?.created_at) || ""
+      at: normalizeIsoTimestamp(rawEntry?.at || rawEntry?.createdAt || rawEntry?.created_at) || "",
+      source: sanitizeDashboardChatText(rawEntry?.source || "")
     };
-    const entryLength = entry.text.length + entry.at.length;
+    const entryLength = entry.text.length + entry.at.length + entry.source.length;
     if (totalLength + entryLength > 3200) break;
     entries.push(entry);
     totalLength += entryLength;
@@ -66763,16 +66766,18 @@ function normalizeDashboardProgressSummary(value) {
     updatedAt: normalizeIsoTimestamp(input.updatedAt || input.updated_at) || (/* @__PURE__ */ new Date()).toISOString()
   };
 }
-function buildDashboardProgressSummarySnapshot(previous, { text = "" } = {}) {
+function buildDashboardProgressSummarySnapshot(previous, { text = "", source = "" } = {}) {
   const previousSummary = normalizeDashboardProgressSummary(previous?.progressSummary);
-  const entries = [...previousSummary.entries];
+  const normalizedSource = sanitizeDashboardChatText(source);
+  const entries = normalizedSource === "app_server_reply_delta" ? previousSummary.entries.filter((entry) => entry.source !== "app_server_reply_delta") : [...previousSummary.entries];
   const normalizedText = sanitizeDashboardChatText(text);
   if (normalizedText && shouldIncludeDashboardProgressSummaryEntry(normalizedText)) {
     const latest = entries.at(-1);
     if (!latest || latest.text !== normalizedText) {
       entries.push({
         text: normalizedText,
-        at: (/* @__PURE__ */ new Date()).toISOString()
+        at: (/* @__PURE__ */ new Date()).toISOString(),
+        source: normalizedSource
       });
     }
   }
@@ -66790,7 +66795,7 @@ function shouldIncludeDashboardProgressSummaryEntry(text) {
 }
 function dashboardProgressSummaryEntriesKey(progressSummary) {
   const normalized = normalizeDashboardProgressSummary(progressSummary);
-  return JSON.stringify(normalized.entries.map((entry) => entry.text));
+  return JSON.stringify(normalized.entries.map((entry) => [entry.text, entry.source]));
 }
 function attachDashboardProgressSummaryToFinalMessages(messages = [], snapshot = null) {
   const progressSummary = normalizeDashboardProgressSummary(snapshot?.progressSummary);


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #590 の production evidence で確認した「入力欄下の進行中には readable progress が出ているのに、チャット欄には出ない」問題を修正します。
- `app_server_reply_delta` の `progressText` を durable chat message にはせず、transient snapshot の owner-facing checkpoint として chat 欄に表示できるようにします。
- final `進行ログ` が reply delta の細切れで肥大化しないよう、reply delta 由来 entry は最新1件へ差し替えます。

## Satisfied Success Criteria

- `app_server_reply_delta` を `transientProgressSnapshot.progressSummary` に入れる。
- reply delta は durable chat history に保存しない。
- reply delta checkpoint は `source=app_server_reply_delta` として識別する。
- reply delta が複数届いた場合、最新1件だけを保持する。
- final Butler reply には最新 reply delta checkpoint が `進行ログ` として付く。

## Unsatisfied Success Criteria

- production PWA で、画像添付 evidence と同じ赤丸部分が chat checkpoint に出ることは merge/deploy 後 E2E が必要です。
- media reference repo mismatch と reply target preview filtering は未実装です。

## Non-goal violations

None.

## 開発前作戦図

- 作戦図 evidence: `docs/development-strategy/issue-590-realtime-progress-checkpoints.md`
- 完了体験: Dashboard Butler の入力欄下に出ている readable progress が、同じ turn の chat-visible checkpoint としても見える。
- VTDD 全体で進める部分: #590 の無言待ち解消を、fallback checkpoint だけでなく実際に届いている assistant progress text の表示へ接続する。
- 設計: owner-facing surface は Dashboard Butler PWA の通常チャット欄です。`app_server_reply_delta` は通常 chat message に永続化しない。代わりに transient snapshot の progress summary へ最新1件として入れ、Dashboard UI の既存 checkpoint card に表示する。
- 仮説: 原因は、`app_server_reply_delta` の `progressText` が入力欄下 transient status には届いているが、snapshot/progressSummary に入っていないこと。
- 検証計画: Worker tests で reply delta が durable chat には入らず snapshot/checkpoint/final progress summary に入ること、複数 delta が最新1件へ差し替わることを確認する。
- 改修見積もり: `src/worker/runtime.js` の app-server bridge event normalization と progress summary normalization、`test/worker.test.js`、generated `worker.js`。
- 既に通っている経路: bridge `app_server_reply_delta` → DashboardChatRoom `transient_status` → composer 下 `進行中`。
- 未確認の境界: production PWA の実表示で checkpoint card が意図通り出るか。
- 穴が出そうな箇所: reply delta を全件 append すると final `進行ログ` が巨大化するため、最新1件差し替えに限定する。
- PR 前に確認すること: targeted worker tests, `npm run build:worker`, `npm run check:generated-worker`, `npm run check:self-parity`, `git diff --check`。
- 実装候補と捨てた案: 採用は transient snapshot 最新1件。捨てた案は reply delta 全件 durable message 化、full transcript 保存、media/reply preview との同時修正。
- merge 後に通す E2E: production PWA E2E として、入力欄下に出る readable progress が chat checkpoint にも見えることを確認する。
- 次の PR を増やさない理由: #590 の live progress が出ない根本は、既に届いている progressText を chat checkpoint へ接続していない点なので、この接続は同じ slice で閉じる。
- 停止条件: reply delta が通常 chat history に増殖する、final progress summary が巨大化する、または低情報 status が chat 本文へ戻る場合。

## Dry-run Impact Report

- Target Issue: Issue #590
- Implementing Success Criteria: readable `app_server_reply_delta.progressText` を chat-visible checkpoint に出す。
- Explicit Non-goals: media reference repository mismatch、reply target preview filtering、#637 helper lifecycle、deploy / credential / permission mutation。
- Expected touched files/routes/workflows: `src/worker/runtime.js`, `test/worker.test.js`, `worker.js`, `docs/development-strategy/issue-590-realtime-progress-checkpoints.md`。
- Affected Issues: #590 primarily; #528 / #498 visible UX gaps remain separate.
- Affected PRs: follow-up after #781 fallback checkpoint.
- Affected workflows: worker build / worker tests.
- Affected runtime/operator surfaces: Dashboard Butler PWA live chat progress.
- What may break if we patch narrowly: final `進行ログ` may include a latest partial assistant progress text.
- Unknowns to investigate before coding: production PWA rendering timing.
- Validation needed: targeted tests, build, generated-worker check, self-parity, production PWA E2E.
- Stop condition: reply delta becomes durable chat spam.

## Execution Queue Delta

- Queue position before: Issue #590 is active `Now` after reopen.
- Preemption decision: ROOT. This continues Issue #590 and does not replace the queue.
- Queue delta: Issue #590 stays in `Now`; PR #782 candidate connects existing readable reply delta progress to chat-visible checkpoint. #637 remains next.
- Why this PR is next: Owner attached evidence showing the desired progress text already exists in the input-area progress pane.
- Active Issues not downscoped: active Issues are not downscoped; #637, #528, #498, #741, #744, and other active Issues remain open.

## File / Line Hypotheses

- file: `src/worker/runtime.js`
  - hypothesis: `app_server_reply_delta` sets transient text but does not write a transient progress snapshot.
  - risk if changed narrowly: reply deltas could pollute final progress summary if not deduped/replaced.
  - validation: worker tests for snapshot/source/latest-only behavior.
  - related Issue: #590

## Hypothesis Retrospective

- expected: reply delta progress appears as snapshot checkpoint and remains out of durable chat history.
- actual: local tests confirm snapshot and final progress summary behavior; production evidence pending.
- mismatch: production may still need UI rendering tweaks if checkpoint card display is insufficient.
- lesson: #590 must treat already-visible composer progress as a candidate owner-facing checkpoint source.
- should become RAG candidate: Yes after production E2E.

## Verification Evidence

- Unit: `node --test test/worker.test.js --test-name-pattern "app-server reply deltas|latest assistant reply delta checkpoint|transient bursts|DashboardChatRoom clears transient progress snapshot|worker serves v2 dashboard for allowed owner identity without exposing secrets"` passed.
- Integration: `npm run build:worker` passed; `npm run check:generated-worker` passed; `npm run check:self-parity` passed; `git diff --check` passed.
- E2E: Not run before merge. Production PWA E2E required after deploy.
- Manual: Owner screenshot evidence showed readable progress in input-area `進行中`.
- Evidence path/link: `docs/development-strategy/issue-590-realtime-progress-checkpoints.md`

## Butler Completion Contract

- Primary owner surface: Dashboard Butler PWA.
- Fallback surface: mac Codex is debug/bootstrap only and not completion evidence.
- Owner goal: Dashboard Butler shows the same readable live progress in chat that is already visible under the composer.
- Butler entrypoint: existing Dashboard Butler natural-language chat.
- Dashboard Butler natural-language path: owner uses the Dashboard Butler natural-language chat entrypoint and sends a long request; app-server reply delta progress appears as chat-visible checkpoint while final answer is still generating.
- Action Schema exposure: Not changed.
- Runtime path: DashboardChatRoom WebSocket `transient_status` with `transientProgressSnapshot.progressSummary`.
- Runner/runtime truth: reply delta snapshot source is `app_server_reply_delta`; durable chat message count remains unchanged until final reply.
- Authority boundary: no high-risk operation added.
- E2E evidence: missing until production PWA validation.
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: Required after merge by existing deploy flow; not performed by this PR.
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: merge/deploy 後に必要。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate
- AGENTS.md 開発前作戦図 Gate
- AGENTS.md Evidence Discipline
- AGENTS.md Change Size and PR Discipline
- AGENTS.md Conversation UX Contract

## Out-of-scope but NOT implemented

- media reference repo mismatch
- reply target preview filtering for system/error/progress messages
- #637 root-required helper lifecycle

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #590
- Execution ID: issue-590-reply-delta-chat-progress
- Goal: Dashboard Butler reply delta progress as chat-visible checkpoint
