### PR TITLE
Issue #590 app-server failure recovery を media-aware にする

### DIFF
--- a/docs/development-strategy/issue-590-app-server-failure-recovery.md
+++ b/docs/development-strategy/issue-590-app-server-failure-recovery.md
@@ -1,0 +1,132 @@
+# Issue #590 app-server failure recovery / media-aware error strategy
+
+## 完了体験
+
+Dashboard Butler で VPS Codex CLI / codex app-server が turn 中に失敗しても、owner は「返事が来ない」状態に見えない。同じ Dashboard thread に、入力は保存済みで同じ thread から再試行・補足できること、画像/添付が関係する場合は画像なし再送または短い説明が有効であること、画像が関係しない場合は画像解析失敗と決めつけないことが日本語で残る。
+
+## VTDD 全体で進める部分
+
+この slice は Issue #590 の failure recovery column を進める。Issue #498 には添付失敗時の owner-facing 説明として関係するが、画像解析パイプライン全体の完成は扱わない。Dashboard Butler / Worker / bridge の「失敗を見える状態にする」経路を先に固め、VPS Codex CLI が返答できない時でも owner が Mac Codex に戻らず次の行動を取れる状態を作る。
+
+## 設計
+
+- codex app-server の raw failure を bridge で `app_server_turn_failed` に正規化する。
+- 失敗文言は固定の「画像を解析できなかった可能性」ではなく、media reference の有無と取得状態に応じて生成する。
+- media がない turn では一般 failure とし、画像原因を断定しない。
+- media がある turn では、添付の取得/解析に失敗した可能性を補足し、画像なし再送または短い説明を案内する。
+- Worker は同一 messageId / text / status の app-server failure を短時間に二重 append しない。
+- thread に残る system failure は recovery action を含むが、raw stack trace、secret、full image binary、raw JSON は残さない。
+
+## 仮説
+
+スクリーンショットの system message は `scripts/run-dashboard-app-server-bridge.mjs` の `DEFAULT_APP_SERVER_ERROR_TEXT` に一致する。これは `turn/completed` failed や app-server error が原因でも同じ文言になるため、実原因が画像でない場合も owner に画像失敗として見える。また DashboardChatRoom 側は app-server failure を system message として append するため、同じ failure event が複数回来るか、client reconnect / duplicate send と重なると同じ文言が二重表示される。
+
+狭く文言だけ変えると、再試行導線や重複抑止が残り、同じ「返事がこない」体験が再発する。したがって bridge failure text と Worker append filter を同じ slice で扱う。
+
+## 検証計画
+
+- `node --test test/dashboard-app-server-bridge.test.js`
+- `node --test test/worker.test.js`
+- `npm run build:worker`
+- `npm run check:generated-worker`
+- `git diff --check`
+
+テストでは、media なし app-server failed は画像文言を出さないこと、media あり failed は画像/添付再送導線を含むこと、同一 failure の二重 append が抑止されることを確認する。
+
+## 改修見積もり
+
+- `scripts/run-dashboard-app-server-bridge.mjs`
+  - boundary: app-server failure text generation and failed turn mapping
+  - expected change: request media truth を context に持ち、failed / error notification で media-aware recovery text を返す
+  - risk: app-server protocol event shape の未知フィールドに依存しすぎると壊れるため、既存の `turn/completed failed` / `error` と fallback のみに限定する
+- `src/worker/runtime.js`
+  - boundary: `acceptAppServerBridgeMessage` append filter / normalized failure message
+  - expected change:同一 thread の直近同一 failure を再 append しない
+  - risk: 別 turn の別 failure を消すと evidence が失われるため、短時間・同一 text/status/thread に限定する
+- `test/dashboard-app-server-bridge.test.js`
+  - boundary: bridge failure mapping
+  - expected change: media なし/あり failure text tests
+  - risk:既存 long-turn tests と競合しないよう targeted assertions にする
+- `test/worker.test.js`
+  - boundary: DashboardChatRoom bridge message append filter
+  - expected change: duplicate app-server failure is ignored while first failure remains thread-visible
+  - risk: existing message append tests must keep non-duplicate failures appendable
+
+## 既に通っている経路
+
+- Dashboard app-server bridge は `app_server_turn_failed` を Worker へ送れる。
+- Worker は failure を Dashboard thread の system message として保存できる。
+- composer unlock / same-thread recovery は #590 の既存 timeout recovery evidence がある。
+- media reference metadata / short-lived download path は #498 の一部として存在する。
+
+## 未確認の境界
+
+- production VPS journal の生ログは、この Mac の SSH alias では直接確認できない。
+- codex app-server が画像 localPath をどの程度 native に解析できるかは、この slice では保証しない。
+- Cloudflare Access 認証付き production thread の raw runtime state はこの local probe だけでは読めない。
+
+## 穴が出そうな箇所
+
+- `turn/completed failed` に詳細 reason がない場合、原因推定はできない。
+- attachment fetch が `metadata_only` のままでも app-server は文章だけで返せるべきだが、prompt が画像解析前提だと失敗に見える。
+- 重複抑止を強くしすぎると、連続する別 failure の evidence を消す。
+- 失敗 messageId が毎回 random だと UI 側の key だけでは重複を防げない。
+
+## VTDD 全体の error surface 棚卸し
+
+2026-06-04 の owner 指摘「このエラーに限らず、起こりうるエラーに関して訳のわからないことになっていないか」を受け、`rg` で runtime / bridge / runner / deploy / docs / tests の failure surface を横断確認した。
+
+現時点の分類:
+
+- Dashboard chat / app-server bridge
+  - owner-facing failure は `app_server_turn_failed` として thread に残せる。
+  - 問題: 画像以外の失敗でも画像解析失敗に見える固定文言があった。
+  - 今回の対応: media-aware failure text と duplicate failed-message suppression。
+- Media / attachment
+  - R2/D1 metadata、download、TTL、repo/issue scope の失敗経路がある。
+  - 問題: media reference mismatch や fetch failure が owner には「VPS が返事しない」に見えやすい。
+  - 今回の対応: app-server failure に添付取得状態を短く含める。media pipeline completion は #498 に残す。
+- VPS runner / privileged helper
+  - queue payload invalid、allowlist miss、helper failed、runner auth unavailable、runtime event post failed などがある。
+  - 現状: Issue comment / runtime event には structured reason がある。
+  - 残課題: Dashboard Butler の通常 chat に戻す時、raw reason と owner-facing next action の対応表が必要。
+- Deploy / GitHub Actions
+  - passkey grant missing、approval validation failed、workflow failure、deploy completion event failure がある。
+  - 現状: workflow run と deploy event comment で追える。
+  - 残課題: Dashboard 側の owner-facing failure summary が deploy run URL / next approval / retry boundary を常に出す保証は別 slice。
+- Memory / approval / auth
+  - unauthorized、memory provider unavailable、approval grant expired/not found、cost checker not allowed などがある。
+  - 現状: API JSON と一部日本語 reason はある。
+  - 残課題: 通常 chat で raw API error だけを出さず、認証だけ人間がやる導線へ戻す taxonomy が必要。
+
+この棚卸しから、今回の直接事故は Dashboard chat / app-server bridge と Media / attachment の境界にあると判断する。VPS runner / deploy / approval / auth まで同じ PR で改修すると authority boundary と E2E が膨らむため、この PR では分類と現在事故の修正に止める。
+
+## PR 前に確認すること
+
+- open PR がないこと。
+- branch が latest `origin/main` から切られていること。
+- generated `worker.js` が source と一致していること。
+- PR body に #590 と #498 の境界、E2E 未完了、deploy 未実施を明記すること。
+
+## 実装候補と捨てた案
+
+- 採用: bridge で media-aware failure text を生成し、Worker で短時間同一 failure を抑止する。
+- 捨てた案: app-server を即 restart する。失敗原因が画像/turn protocol の可能性があり、再起動だけでは owner-facing recovery が改善しない。
+- 捨てた案: raw app-server error をそのまま表示する。owner-facing ではなく secret / implementation detail の露出リスクがある。
+- 捨てた案: 全 failure を「画像なしで再送」にする。media がない turn の失敗を誤誘導する。
+
+## merge 後に通す E2E
+
+- production Dashboard Butler で media なし read/status turn が失敗した場合に、画像文言なしの recovery message が残る。
+- production Dashboard Butler で画像添付あり turn が失敗した場合に、画像/添付を含む recovery message が残り、同じ文言が二重に出ない。
+- 同じ thread で owner が画像なし補足を送れる。
+
+## 次の PR を増やさない理由
+
+bridge failure text と Worker duplicate suppression は同じ owner-facing事故に対する入口と保存側であり、片方だけではスクリーンショットの再発を止められない。画像解析そのもの、live progress、scroll 挙動は別 Issue/slice に残す。
+
+## 停止条件
+
+- app-server failure の root cause が credential / permission / deploy / destructive operation に広がる場合は、この PR では進めない。
+- raw production logs が必要で、VPS privileged maintenance や Cloudflare credential boundary が必要になる場合は、passkey/operator flow に切り替える。
+- #590 / #498 の Issue text と矛盾する挙動が見つかった場合は、実装を止めて owner decision を求める。

--- a/scripts/run-dashboard-app-server-bridge.mjs
+++ b/scripts/run-dashboard-app-server-bridge.mjs
@@ -13,7 +13,9 @@ const DEFAULT_SCHEMA = "vtdd.dashboard.app_server_bridge.v1";
 const DANGER_FULL_ACCESS_SANDBOX = "danger-full-access";
 const APP_SERVER_FAILURE_ALREADY_SENT = Symbol("appServerFailureAlreadySent");
 const DEFAULT_APP_SERVER_ERROR_TEXT =
-  "codex app-server が応答生成中に失敗しました。画像を解析できなかった可能性があります。もう一度送るか、画像なしで内容を短く説明してください。";
+  "codex app-server が応答生成中に失敗しました。入力は Dashboard thread に保存済みです。同じ thread で補足するか、内容を短くしてもう一度送れます。";
+const MEDIA_APP_SERVER_ERROR_TEXT =
+  "codex app-server が応答生成中に失敗しました。入力と添付情報は Dashboard thread に保存済みです。添付画像の取得または解析で失敗した可能性があります。画像なしで要点を短く説明して再送するか、画像を添付し直してください。";
 const APP_SERVER_TURN_TIMEOUT_TEXT =
   "codex app-server の応答確認が長引いています。入力と文脈は Dashboard thread に保存済みです。再接続と状態確認を続けています。同じ thread で補足やキャンセル指示を送れます。遅れて返信が届いた場合は、この thread に追加します。";
 const APP_SERVER_TURN_QUIET_TEXT =
@@ -514,6 +516,10 @@ function sanitizeBridgeError(error) {
   return normalizeBridgeText(error?.message || error || "media fetch failed").slice(0, 240);
 }
 
+function sanitizeOptionalBridgeError(error) {
+  return normalizeBridgeText(error?.message || error || "").slice(0, 240);
+}
+
 export function buildAppServerSandboxOverrides(sandboxMode = "") {
   const normalized = String(sandboxMode || "").trim().toLowerCase();
   if (!normalized) {
@@ -818,7 +824,14 @@ export function mapAppServerNotificationToDashboardEvent(message, context = {}) 
         threadId: context.dashboardThreadId,
         codexThreadId: params.threadId || context.codexThreadId || null,
         status: turnStatus,
-        text: turnStatus === "interrupted" ? "生成を停止しました。" : DEFAULT_APP_SERVER_ERROR_TEXT
+        text:
+          turnStatus === "interrupted"
+            ? "生成を停止しました。"
+            : buildDashboardAppServerFailureText({
+                text: params.message || params.reason || params.error,
+                status: turnStatus,
+                mediaReferences: context.mediaReferences
+              })
       };
     }
     return {
@@ -836,10 +849,40 @@ export function mapAppServerNotificationToDashboardEvent(message, context = {}) 
       schema: DEFAULT_SCHEMA,
       threadId: context.dashboardThreadId,
       codexThreadId: context.codexThreadId || null,
-      text: params.message || params.reason || DEFAULT_APP_SERVER_ERROR_TEXT
+      text: buildDashboardAppServerFailureText({
+        text: params.message || params.reason || params.error,
+        status: "failed",
+        mediaReferences: context.mediaReferences
+      })
     };
   }
   return null;
+}
+
+export function buildDashboardAppServerFailureText({ text = "", status = "", mediaReferences = [] } = {}) {
+  const normalizedStatus = normalizeBridgeText(status).toLowerCase();
+  if (normalizedStatus === "interrupted") {
+    return "生成を停止しました。";
+  }
+  const references = Array.isArray(mediaReferences) ? mediaReferences.filter(Boolean) : [];
+  const baseText = references.length > 0 ? MEDIA_APP_SERVER_ERROR_TEXT : DEFAULT_APP_SERVER_ERROR_TEXT;
+  const detail = sanitizeOptionalBridgeError(text);
+  const mediaDetail = buildDashboardAppServerMediaFailureDetail(references);
+  return [baseText, detail ? `詳細: ${detail}` : "", mediaDetail].filter(Boolean).join("\n");
+}
+
+function buildDashboardAppServerMediaFailureDetail(mediaReferences = []) {
+  const references = Array.isArray(mediaReferences) ? mediaReferences.filter(Boolean) : [];
+  if (references.length === 0) {
+    return "";
+  }
+  const statuses = references.map((reference) => {
+    const mediaId = normalizeBridgeText(reference?.mediaId || reference?.id) || "unknown";
+    const fetchStatus = normalizeBridgeText(reference?.fetchStatus || reference?.fetch_status) || "metadata_only";
+    const fetchError = sanitizeOptionalBridgeError(reference?.fetchError || reference?.fetch_error);
+    return fetchError ? `${mediaId}: ${fetchStatus} (${fetchError})` : `${mediaId}: ${fetchStatus}`;
+  });
+  return `添付取得状態: ${statuses.slice(0, 3).join(" / ")}${statuses.length > 3 ? ` / 他${statuses.length - 3}件` : ""}`;
 }
 
 export function buildAppServerReplyDeltaProgressText({ accumulatedText = "", delta = "", maxLength = 1200 } = {}) {
@@ -1564,6 +1607,7 @@ export async function handleDashboardTurnRequest({
   let liveProgressFallbackHandle = null;
   let liveProgressFallbackCount = 0;
   let ownerFacingProgressSeen = false;
+  let materializedMediaReferences = [];
   let cleanupNotifications = () => {};
   let resolveTurn = () => {};
   let rejectTurn = () => {};
@@ -1656,7 +1700,8 @@ export async function handleDashboardTurnRequest({
     const event = mapAppServerNotificationToDashboardEvent(message, {
       dashboardThreadId,
       codexThreadId,
-      accumulatedText
+      accumulatedText,
+      mediaReferences: materializedMediaReferences
     });
     if (!event) return;
     if (event.type === "app_server_reply_delta") {
@@ -1733,7 +1778,7 @@ export async function handleDashboardTurnRequest({
     restoreApprovalRequestHandler();
   };
   try {
-    const materializedMediaReferences = await materializeDashboardMediaReferences({
+    materializedMediaReferences = await materializeDashboardMediaReferences({
       mediaReferences: request.mediaReferences,
       runtimeUrl,
       token,
@@ -2368,7 +2413,11 @@ export async function connectDashboardAppServerBridgeOnce({
             type: "app_server_turn_failed",
             schema: DEFAULT_SCHEMA,
             threadId: payload.threadId,
-            text: error?.message || DEFAULT_APP_SERVER_ERROR_TEXT
+            text: buildDashboardAppServerFailureText({
+              text: error?.message,
+              status: "failed",
+              mediaReferences: payload.mediaReferences
+            })
           });
         });
     }

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -10136,6 +10136,7 @@ function isDuplicateLatestBridgeProgressMessage(message, latest) {
   const messageStatus = normalizeDashboardChatStatus(message.status);
   const latestStatus = normalizeDashboardChatStatus(latest.status);
   const duplicateCandidateStatus =
+    (messageStatus === "failed" && latestStatus === "failed") ||
     (messageStatus === "stalled" && latestStatus === "stalled") ||
     (messageStatus === "thinking" && latestStatus === "thinking");
   return (

--- a/test/dashboard-app-server-bridge.test.js
+++ b/test/dashboard-app-server-bridge.test.js
@@ -10,6 +10,7 @@ import {
   buildDashboardAppServerBridgeEndpoint,
   buildDashboardAppServerCommandArgs,
   buildDashboardAppServerCostBoundary,
+  buildDashboardAppServerFailureText,
   buildDashboardAppServerUsageProfileCommandConfig,
   buildAppServerInitializeRequest,
   buildOwnerActionRequiredPayloadForAppServerApproval,
@@ -440,6 +441,49 @@ test("dashboard app-server bridge formats failed media delivery without raw bina
   assert.match(lines[0], /fetchStatus: fetch_failed/);
   assert.match(lines[0], /fetchError: media download failed with HTTP 404/);
   assert.equal(lines[0].includes("fake image bytes"), false);
+});
+
+test("dashboard app-server bridge does not blame images for non-media app-server failures", () => {
+  const text = buildDashboardAppServerFailureText({
+    status: "failed",
+    text: "model turn failed"
+  });
+
+  assert.match(text, /応答生成中に失敗しました/);
+  assert.match(text, /入力は Dashboard thread に保存済み/);
+  assert.match(text, /同じ thread で補足/);
+  assert.match(text, /詳細: model turn failed/);
+  assert.doesNotMatch(text, /画像/);
+  assert.doesNotMatch(text, /添付/);
+});
+
+test("dashboard app-server bridge omits fabricated detail when app-server failure has no reason", () => {
+  const text = buildDashboardAppServerFailureText({ status: "failed" });
+
+  assert.match(text, /応答生成中に失敗しました/);
+  assert.doesNotMatch(text, /詳細:/);
+  assert.doesNotMatch(text, /media fetch failed/);
+  assert.doesNotMatch(text, /画像/);
+});
+
+test("dashboard app-server bridge adds media recovery guidance only when media is present", () => {
+  const text = buildDashboardAppServerFailureText({
+    status: "failed",
+    text: "turn failed",
+    mediaReferences: [
+      {
+        mediaId: "med_screen",
+        fetchStatus: "fetch_failed",
+        fetchError: "media download failed with HTTP 403"
+      }
+    ]
+  });
+
+  assert.match(text, /入力と添付情報は Dashboard thread に保存済み/);
+  assert.match(text, /添付画像の取得または解析/);
+  assert.match(text, /画像なしで要点を短く説明/);
+  assert.match(text, /添付取得状態: med_screen: fetch_failed/);
+  assert.match(text, /HTTP 403/);
 });
 
 test("dashboard app-server bridge materializes dashboard media with bearer auth", async () => {

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -5020,6 +5020,45 @@ test("DashboardChatRoom dedupes repeated app-server stalled recovery messages", 
   );
 });
 
+test("DashboardChatRoom dedupes repeated app-server failed recovery messages", async () => {
+  const store = createInMemoryDashboardChatStore();
+  const dashboardSocket = createMockSocket("dashboard", "dashboard-main-unresolved");
+  const bridgeSocket = createMockSocket("app_server_bridge", "dashboard-main-unresolved");
+  const room = new DashboardChatRoom(
+    {
+      storage: createMockDurableObjectStorage(),
+      getWebSockets() {
+        return [dashboardSocket, bridgeSocket];
+      }
+    },
+    { DASHBOARD_CHAT_STORE: store }
+  );
+  const failedEvent = {
+    type: "app_server_turn_failed",
+    status: "failed",
+    threadId: "dashboard-main-unresolved",
+    repository: "marushu/vtdd-v2-p",
+    relatedIssue: 590,
+    text: "codex app-server が応答生成中に失敗しました。入力は Dashboard thread に保存済みです。同じ thread で補足するか、内容を短くしてもう一度送れます。"
+  };
+
+  await room.webSocketMessage(bridgeSocket, JSON.stringify(failedEvent));
+  await room.webSocketMessage(bridgeSocket, JSON.stringify(failedEvent));
+
+  const stored = await store.listThread("dashboard-main-unresolved");
+  assert.equal(stored.length, 1);
+  assert.equal(stored[0].role, "system");
+  assert.equal(stored[0].status, "failed");
+  assert.match(stored[0].text, /応答生成中に失敗しました/);
+  assert.doesNotMatch(stored[0].text, /画像を解析できなかった/);
+
+  const threadBroadcasts = dashboardSocket.sent
+    .map((message) => JSON.parse(message))
+    .filter((message) => message.type === "thread");
+  assert.equal(threadBroadcasts.length, 1);
+  assert.equal(threadBroadcasts[0].messages.length, 1);
+});
+
 test("DashboardChatRoom sends app-server thinking status as transient UI state", async () => {
   const store = createInMemoryDashboardChatStore();
   const dashboardSocket = createMockSocket("dashboard", "dashboard-main-unresolved");

--- a/worker.js
+++ b/worker.js
@@ -66883,7 +66883,7 @@ function isDuplicateLatestBridgeProgressMessage(message, latest) {
   }
   const messageStatus = normalizeDashboardChatStatus(message.status);
   const latestStatus = normalizeDashboardChatStatus(latest.status);
-  const duplicateCandidateStatus = messageStatus === "stalled" && latestStatus === "stalled" || messageStatus === "thinking" && latestStatus === "thinking";
+  const duplicateCandidateStatus = messageStatus === "failed" && latestStatus === "failed" || messageStatus === "stalled" && latestStatus === "stalled" || messageStatus === "thinking" && latestStatus === "thinking";
   return duplicateCandidateStatus && normalizeDashboardEventText(message.role).toLowerCase() === normalizeDashboardEventText(latest.role).toLowerCase() && sanitizeDashboardChatText(message.text) === sanitizeDashboardChatText(latest.text);
 }
 function shouldPersistDashboardAppServerProgress(input, { transientStatus = "" } = {}) {


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #590 の部分進捗です。codex app-server failure が Dashboard Butler で『返事がこない』『画像失敗か不明』に見える状態を改善します。Issue #498 の添付あり failure では添付取得/解析の可能性と再送導線を出し、添付なし failure では画像原因を断定しません。

## Satisfied Success Criteria

- Issue #590: app-server failure は入力保存済み・同じ thread で補足/再送可能な日本語 recovery message になります。
Issue #590: 添付なし failure では画像を解析できなかった可能性という誤誘導を出しません。
Issue #498: 添付あり failure では添付取得状態を短く出し、画像なし説明または再添付の導線を出します。
Issue #590: 同一 failed recovery message の二重 durable append を抑止します。
Issue #590 / Issue #528: VTDD 全体の error surface を strategy に棚卸しし、runner/deploy/auth/media の残課題を明示しました。

## Unsatisfied Success Criteria

- Issue #590 の live progress / silent gap / completion summary replacement / iPhone production E2E は未完了です。
Issue #498 の画像解析 pipeline、repo mismatch、client-side resize、TTL/拡大表示 E2E は未完了です。
VPS runner / deploy / auth / memory error taxonomy の owner-facing 統一表示は後続 slice です。
本 PR は Issue #590 または Issue #498 を close-ready にしません。

## Non-goal violations

None.

## 開発前作戦図

- 作戦図 evidence: docs/development-strategy/issue-590-app-server-failure-recovery.md
- 完了体験: Dashboard Butler の owner-facing chat surface で app-server failure が起きても、入力保存済み・同じ thread で再試行可能・添付有無に応じた原因候補が日本語で残る。
- VTDD 全体で進める部分: Dashboard chat / app-server bridge / media boundary の failure recovery。VPS runner/deploy/auth は棚卸しのみ。
- 設計: Dashboard Butler owner-facing surface では、bridge が media-aware failure text を生成し、Worker が同一 failed system message を重複 append しない。authority boundary は変えない。
- 仮説: 固定 fallback 文言が画像以外の failure も画像失敗に見せ、同一 failure の複数 append が『返事がこない』感を悪化させている。
- 検証計画: bridge unit、worker unit、build:worker、check:generated-worker、verify:worker、diff check。
- 改修見積もり: scripts/run-dashboard-app-server-bridge.mjs failure text mapping / src/worker/runtime.js duplicate filter / worker.js generated bundle / targeted tests / strategy file。
- 既に通っている経路: app_server_turn_failed は Worker に届き、system message として Dashboard thread に保存できる。media reference metadata は turn input に渡っている。
- 未確認の境界: production VPS journal と codex app-server の画像 native 解析能力は未確認。Cloudflare Access 下の raw production thread state はこの PR では直接読まない。
- 穴が出そうな箇所: reason なし failed event、media fetch metadata_only、別 turn failure の誤 dedupe、runner/deploy/auth の raw reason 表示。
- PR 前に確認すること: open PR 0、fresh origin/main branch、targeted tests、verify:worker、generated worker check、untracked E2E assets を staging しないこと。
- 実装候補と捨てた案: app-server restart だけで済ませる案、raw error をそのまま表示する案、全 failure を画像なし再送に寄せる案は捨てました。
- merge 後に通す E2E: Issue #590 / Issue #498 mapped E2E: production Dashboard Butler で添付なし failure と添付あり failure の recovery 表示、二重表示なし、同じ thread で補足可能を確認する。
- 次の PR を増やさない理由: bridge text と Worker duplicate suppression は同じ owner-facing accident の入口と保存側で、分けると再発を止めきれないため。
- 停止条件: credential / deploy / root helper / permission mutation に広がる場合は passkey/operator flow に切り替え、この PR では扱わない。

## Dry-run Impact Report

- Target Issue: Issue #590。関連 Issue #498。
- Implementing Success Criteria: Issue #590 app-server failure を復帰可能な日本語 thread message にする。画像原因の誤誘導をやめる。Issue #498 media あり failure だけ添付 recovery を出す。同一 failure の二重 append を抑止する。
- Explicit Non-goals: 画像解析 pipeline 完成、media repo mismatch 根本修正、VPS runner/deploy/auth taxonomy 統一、deploy、credential mutation、Issue close。
- Expected touched files/routes/workflows: scripts/run-dashboard-app-server-bridge.mjs, src/worker/runtime.js, worker.js, test/dashboard-app-server-bridge.test.js, test/worker.test.js, docs/development-strategy/issue-590-app-server-failure-recovery.md
- Affected Issues: Issue #590, Issue #498, Issue #528, Issue #450
- Affected PRs: なし。open PR 0 件から fresh branch で作成。
- Affected workflows: test / guarded-policy / review。deploy-production はこの PR では実行しない。
- Affected runtime/operator surfaces: Dashboard Butler chat, app-server bridge, Worker DashboardChatRoom, generated worker bundle。
- What may break if we patch narrowly: 文言だけ直すと duplicate failure と media/non-media 区別が残る。duplicate だけ直すと誤誘導文言が残る。
- Unknowns to investigate before coding: production VPS raw log、app-server native image handling、Cloudflare Access authenticated runtime read state。
- Validation needed: node --test test/dashboard-app-server-bridge.test.js; node --test test/worker.test.js; npm run build:worker; npm run check:generated-worker; npm run verify:worker; git diff --check
- Stop condition: high-risk authority、deploy、credential、permission、root helper が必要になった場合。

## Execution Queue Delta

- Queue position before: Issue #590 は active queue の Now。Issue #498 は関連 Root Blocker / Queue item。
- Preemption decision: ROOT。Dashboard Butler が返答不能に見える failure recovery は Issue #590 の継続 blocker で、Issue #637 など Butler 開発継続を妨げる。
- Queue delta: Issue #590 の failure recovery column を進める。Issue #498 は添付 recovery 表示のみ関連し、画像解析 completion は未完了のまま残す。
- Why this PR is next: owner が production PWA で app-server failure を確認し、Butler から開発を続ける前提が崩れているため。
- Active Issues not downscoped: Active Issues は縮小しません。Issue #590 / Issue #498 / Issue #528 / Issue #450 / Issue #637 の未完了項目は PR 本文で未満足として残します。

## File / Line Hypotheses

- file: `scripts/run-dashboard-app-server-bridge.mjs`
  - hypothesis: DEFAULT_APP_SERVER_ERROR_TEXT が media なし failure でも画像失敗に見せている。
  - risk if changed narrowly: media あり failure の再送導線が消える。
  - validation: bridge tests for media/non-media failure text。
  - related Issue: Issue #590 / Issue #498
- file: `src/worker/runtime.js`
  - hypothesis: duplicate filter が stalled/thinking だけで failed system message を二重 append し得る。
  - risk if changed narrowly: 別 failure evidence を消す。
  - validation: same text/status failed dedupe test。
  - related Issue: Issue #590

## Hypothesis Retrospective

- expected: failure text が media-aware になり、duplicate failed append が止まる。
- actual: targeted tests と verify:worker で期待通り。
- mismatch: production raw root cause は未確認。
- lesson: app-server failure は原因推定と owner recovery を分ける必要がある。
- should become RAG candidate: はい。Dashboard Butler の error taxonomy と media/non-media failure 境界。

## Verification Evidence

- Unit: node --test test/dashboard-app-server-bridge.test.js; node --test test/worker.test.js
- Integration: npm run build:worker; npm run check:generated-worker; npm run verify:worker; git diff --check
- E2E: 未実施。production deploy 後に Dashboard Butler 添付あり/なし failure recovery を確認する必要があります。
- Manual: VTDD 全体の error surface を rg で横断し、Dashboard/app-server, media, VPS runner/helper, deploy/GitHub Actions, memory/approval/auth に分類。
- Evidence path/link: docs/development-strategy/issue-590-app-server-failure-recovery.md

## Butler Completion Contract

- Primary owner surface: Dashboard Butler。
- Fallback surface: Custom GPT は明示された fallback surface として扱います。主経路ではありません。
- Owner goal: このPRが扱う owner-facing goal は Intent / Success Criteria に記載しています。
- Butler entrypoint: Dashboard Butler の通常 Dashboard chat。app-server turn failure の表示経路を改善。
- Dashboard Butler natural-language path: Dashboard Butler の自然文 / 通常チャット入口から owner が送るだけで、失敗時は同じ thread に recovery message が残る。
- Action Schema exposure: Custom GPT fallback 用の露出状態として扱います。このPRスライスでは未変更です。
- Runtime path: DashboardChatRoom WebSocket -> app-server bridge -> codex app-server -> app_server_turn_failed -> DashboardChatRoom append/dedupe。
- Runner/runtime truth: local unit/integration verified。production runtime truth は deploy 後 E2E が必要。
- Authority boundary: 未変更。新しい high-risk authority は追加しません。deploy は別途 passkey required。
- E2E evidence: 未実施。merge/deploy 後 production PWA で要確認。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 未実施。merge 後に必要なら passkey 承認で deploy-production。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。production deploy 後に確認。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate
AGENTS.md Drift Stop Protocol
AGENTS.md 開発前作戦図 Gate
AGENTS.md Evidence Discipline
docs/butler/execution-queue-contract.md

## Out-of-scope but NOT implemented

- Issue #498 画像解析 pipeline completion
Issue #590 live progress / silent gap completion
VPS runner/deploy/auth 全 error taxonomy 実装
Issue close / deploy / credential mutation

## Extra changes (if any)

Generated worker bundle `worker.js` を source change と同じ commit に含めます。

<!-- VTDD metadata -->
- Issue: Issue #590
- Execution ID: mac-codex-issue-590-app-server-failure-recovery
- Goal: Dashboard Butler app-server failure recovery を media-aware にし、同一 failed system message の二重表示を抑止する。
