### PR TITLE
Issue #590 Dashboard app-server turn context を軽量化する

### DIFF
--- a/docs/development-strategy/issue-590-context-lean-live-progress.md
+++ b/docs/development-strategy/issue-590-context-lean-live-progress.md
@@ -1,0 +1,83 @@
+# Issue #590: context lean live progress
+
+## 完了体験
+
+Dashboard Butler で短い会話を送った時、VPS Codex CLI / codex app-server には owner の短い入力だけが届く。`usageProfile`、`costBoundary`、未解決 repository preflight、一般 authority rule は prompt 本文に混ざらない。
+
+開発や調査など repo / Issue / ops 文脈が必要な時だけ、必要最小限の Dashboard context を付ける。作業中の live progress は owner が待ちを理解するために画面上へ流れるが、完了後は最終回答側の要約に任せ、通常 chat message の永続 `progressSummary` として残さない。
+
+## VTDD 全体で進める部分
+
+Issue #590 の owner-facing observability を、context window exceeded とコスト/性能劣化を増やさない形へ戻す。Issue #455 の「Butler は app-server bridge へ届ける」は維持するが、Worker が毎 turn に重い制御文を prompt 化する状態は止める。
+
+## 設計
+
+- `usageProfile` / `costBoundary` は routing / runtime metadata として保持し、`buildDashboardTurnInputText()` の prompt 本文には入れない。
+- 普通の会話では `Dashboard Butler turn context:` を付けず、owner text だけを送る。
+- repository / relatedIssue / real trafficControl / vpsMaintenancePassThrough / media の時だけ context wrapper を付ける。
+- `authority` は context wrapper が必要な時だけ補助情報として入れる。authority だけで wrapper を発生させない。
+- `app_server_reply_delta` / `long_turn_checkpoint` は transient snapshot と chat-visible live UI の材料に留め、final durable Butler message に `progressSummary` を添付しない。
+
+## 仮説
+
+最近の failure は live progress 表示そのものではなく、同時期に入った usage/cost routing と VPS maintenance pass-through により、短い turn でも巨大な `Dashboard Butler turn context` が毎回 app-server thread に積まれることが主因。
+
+`もしもし` 相当の短文に約 1.8KB の制御文が付くと、同じ `codexThreadId` を resume し続ける仕様と組み合わさり、5時間枠、応答速度、context window に悪影響が出る。
+
+## 検証計画
+
+- `buildDashboardTurnInputText()` が ordinary conversation では入力本文だけを返す unit test。
+- usage/cost metadata だけでは prompt context が発生しない unit test。
+- repository / trafficControl / VPS maintenance / media の wrapper は維持される unit test。
+- `app_server_reply_delta` は durable chat message にならず、final reply に `progressSummary` を残さない Worker test。
+- `npm run build:worker`、`npm run check:generated-worker`、`npm run verify:worker`。
+
+## 改修見積もり
+
+- `scripts/run-dashboard-app-server-bridge.mjs`: `buildDashboardTurnInputText()` の context 発生条件と prompt lines を整理する。risk: repo/ops turn で必要な guardrail が抜ける。
+- `src/worker/runtime.js`: ordinary conversation では unresolved trafficControl を作らず、app-server turn request payload から不要な heavy context を除く。final reply への progress summary 添付を止める。risk: progress summary replacement evidence が変わる。
+- `test/dashboard-app-server-bridge.test.js`: ordinary/cost/profile context size regression を追加する。
+- `test/worker.test.js`: final durable message に progressSummary が残らないこと、ordinary request payload が lean であることを追加する。
+- `worker.js`: generated bundle update。
+
+## 既に通っている経路
+
+- Dashboard owner message -> `app_server_turn_requested` -> bridge `turn/start` は動いている。
+- `usageProfile` / `costBoundary` classifier と app-server command args は存在する。
+- `app_server_reply_delta` は durable chat message にはしない test がある。
+- transient progress snapshot は WebSocket reconnect で読める。
+
+## 未確認の境界
+
+production `codex app-server` の context window exceeded が、既存 backend thread の蓄積だけで再現するか、今回の prompt 肥大化がどの程度寄与したかは production runtime でまだ未確認。
+
+## 穴が出そうな箇所
+
+- authority rule を prompt から外しすぎると、repo/ops turn の安全境界が弱くなる。
+- live progress を final `progressSummary` へ残さないことで、完了後の進行ログ evidence は薄くなる。ただし owner 方針では完了後に残さなくてよい。
+- backend thread 自体がすでに詰まっている場合、今回の修正だけでは既存 thread の context exceeded が即時には消えない。
+
+## PR 前に確認すること
+
+- open PR 0。
+- branch は latest `origin/main` から作成。
+- unrelated untracked E2E assets を stage しない。
+- generated `worker.js` を source と同じ commit に含める。
+
+## 実装候補と捨てた案
+
+採用: ordinary conversation の prompt を lean にし、usage/cost は metadata に留める。live progress の final durable attachment を止める。
+
+捨てた案: context window exceeded 時に即 backend thread を無限生成する案。原因の prompt 肥大化を隠し、thread 増殖リスクがあるため今回の主対応にしない。
+
+## merge 後に通す E2E
+
+production Dashboard Butler で `もしもし` のような短文が app-server から返ること、context window exceeded が再発しないこと、通常会話で巨大制御文が visible response に混ざらないことを確認する。長時間開発 live progress は別途 #590 の次 slice で確認する。
+
+## 次の PR を増やさない理由
+
+prompt 肥大化と live progress durable attachment は同じ owner observed regression の原因候補であり、片方だけ直すと context window exceeded / 最終ログ混入が残る。
+
+## 停止条件
+
+repo / Issue / VPS maintenance の authority boundary を保てないことが判明した場合、実装を止めて scope を再確認する。deploy、credential、permission、root helper mutation が必要になった場合はこの PR では扱わない。

--- a/scripts/run-dashboard-app-server-bridge.mjs
+++ b/scripts/run-dashboard-app-server-bridge.mjs
@@ -203,11 +203,8 @@ export function buildDashboardTurnInputText(request = {}) {
   const hasDashboardContext = Boolean(
     repository ||
       relatedIssue ||
-      authority ||
       trafficControl ||
       vpsMaintenancePassThrough ||
-      usageProfile ||
-      costBoundary ||
       mediaReferences.length > 0
   );
   if (!hasDashboardContext) {
@@ -219,12 +216,6 @@ export function buildDashboardTurnInputText(request = {}) {
     `- repository: ${repository || "未指定"}`,
     `- relatedIssue: ${relatedIssue ? `#${relatedIssue}` : "未指定"}`,
     `- mediaReferences: ${mediaReferences.length}`,
-    usageProfile
-      ? `- usageProfile: ${JSON.stringify(usageProfile)}`
-      : "- usageProfile: 未指定",
-    costBoundary
-      ? `- costBoundary: ${JSON.stringify(costBoundary)}`
-      : "- costBoundary: 未指定",
     "- surface: Dashboard Butler PWA via VPS Dashboard Bridge / codex app-server",
     "- trafficControlRule: repo-backed vtdd-chief-butler / Issue/PR/docs/runtime truth を先に読み、blocker / next action / authority boundary / evidence gap を分けて報告する。",
     "- completionRule: Butler Completion Gate と E2E evidence が揃うまで Dashboard Butler 完了とは言わない。",
@@ -252,6 +243,10 @@ export function buildDashboardTurnInputText(request = {}) {
 
   if (authority) {
     lines.push(`- authority: ${JSON.stringify(authority)}`);
+  }
+
+  if (usageProfile || costBoundary) {
+    lines.push("- runtimeMetadata: usageProfile / costBoundary は bridge routing metadata です。owner prompt 本文として判断材料にしないでください。");
   }
 
   lines.push("", "Owner message:", ownerText);

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -461,12 +461,15 @@ export class DashboardChatRoom {
       mediaReferences
     });
     const costBoundary = buildDashboardAppServerUsageCostBoundary(usageProfile);
-    const trafficControl = await buildDashboardChatTrafficControlContext({
-      env: this.env,
-      repository,
-      relatedIssue,
-      text
-    });
+    const needsRepositoryContext = Boolean(repository || relatedIssue || shouldUseDashboardThreadRepositoryContext(text));
+    const trafficControl = repository
+      ? await buildDashboardChatTrafficControlContext({
+          env: this.env,
+          repository,
+          relatedIssue,
+          text
+        })
+      : null;
     const vpsMaintenancePassThrough = buildDashboardVpsMaintenancePassThroughContext({
       text,
       repository,
@@ -490,7 +493,9 @@ export class DashboardChatRoom {
         startThreadMethod: mapping.codexThreadId ? "thread/resume" : "thread/start",
         turnMethod: "turn/start"
       },
-      authority: buildDashboardAppServerAuthorityHint({ repository, relatedIssue, text }),
+      authority: needsRepositoryContext || vpsMaintenancePassThrough
+        ? buildDashboardAppServerAuthorityHint({ repository, relatedIssue, text })
+        : null,
       usageProfile,
       costBoundary,
       trafficControl,
@@ -9764,7 +9769,7 @@ function shouldUseDashboardThreadRepositoryContext(value) {
   if (/#\d+\b/.test(text)) {
     return true;
   }
-  return /(\bissue\b|\bissues\b|\bpr\b|\bpull request\b|\bactions?\b|\bci\b|\brag\b|\bvps\b|\bcodex\b|\brunner\b|Issue|PR|残り|タスク|進捗|状況|確認|見て|調べて|レビュー|指摘|マージ|merge|デプロイ|deploy|実装|修正|直して|壊れ|バグ|エラー|失敗|ブロッカー|close|クローズ|返信|保存|検索|thread|スレッド)/i.test(
+  return /(\bissue\b|\bissues\b|\bpr\b|\bpull request\b|\bactions?\b|\bci\b|\brag\b|\bvps\b|\brunner\b|Issue|PR|残り|タスク|進捗|状況|確認|見て|調べて|レビュー|指摘|マージ|merge|デプロイ|deploy|実装|修正|直して|壊れ|バグ|エラー|失敗|ブロッカー|close|クローズ|返信|保存|検索|thread|スレッド)/i.test(
     text
   );
 }
@@ -10036,21 +10041,7 @@ function dashboardProgressSummaryEntriesKey(progressSummary) {
 }
 
 function attachDashboardProgressSummaryToFinalMessages(messages = [], snapshot = null) {
-  const progressSummary = normalizeDashboardProgressSummary(snapshot?.progressSummary);
-  if (!progressSummary.entries.length) {
-    return messages;
-  }
-  return (Array.isArray(messages) ? messages : []).map((message) => {
-    const role = normalizeDashboardEventText(message?.role).toLowerCase();
-    const status = normalizeDashboardChatStatus(message?.status);
-    if (role !== "butler" || status !== "replied") {
-      return message;
-    }
-    return {
-      ...message,
-      progressSummary
-    };
-  });
+  return Array.isArray(messages) ? messages : [];
 }
 
 function isDashboardSnapshotTransientStatus(status) {

--- a/test/dashboard-app-server-bridge.test.js
+++ b/test/dashboard-app-server-bridge.test.js
@@ -368,6 +368,31 @@ test("dashboard app-server bridge wraps repository traffic-control context into 
   assert.match(text, /Owner message:\nDashboard Butler が交通整理できるようにして/);
 });
 
+test("dashboard app-server bridge keeps ordinary usage metadata out of turn prompt", () => {
+  const text = buildDashboardTurnInputText({
+    text: "もしもし",
+    authority: {
+      ordinaryConversationAllowed: true,
+      highRiskActionsRequire: ["GO", "passkey_approval"]
+    },
+    usageProfile: {
+      profile: "conversation",
+      reasoningEffort: "low",
+      reason: "ordinary_conversation"
+    },
+    costBoundary: {
+      contentAwareProfile: true,
+      profile: "conversation",
+      reasoningEffort: "low"
+    }
+  });
+
+  assert.equal(text, "もしもし");
+  assert.equal(text.includes("Dashboard Butler turn context"), false);
+  assert.equal(text.includes("usageProfile"), false);
+  assert.equal(text.includes("costBoundary"), false);
+});
+
 test("dashboard app-server bridge wraps VPS maintenance pass-through context into turn input", () => {
   const text = buildDashboardTurnInputText({
     text: "app-server bridge を再起動したい。",

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -4030,14 +4030,13 @@ test("DashboardChatRoom sends ordinary owner turns to connected app-server bridg
   assert.equal(turnRequest.codexThreadId, null);
   assert.equal(turnRequest.appServer.startThreadMethod, "thread/start");
   assert.equal(turnRequest.appServer.turnMethod, "turn/start");
-  assert.equal(turnRequest.authority.ordinaryConversationAllowed, true);
+  assert.equal(turnRequest.authority, null);
   assert.equal(turnRequest.usageProfile.profile, "conversation");
   assert.equal(turnRequest.usageProfile.reasoningEffort, "low");
   assert.equal(turnRequest.costBoundary.profile, "conversation");
   assert.equal(turnRequest.costBoundary.contentAwareProfile, true);
-  assert.equal(turnRequest.trafficControl.status, "未確認");
-  assert.equal(turnRequest.trafficControl.currentSurface, "dashboard_butler");
-  assert.match(turnRequest.trafficControl.reason, /repository is required/);
+  assert.equal(turnRequest.trafficControl, null);
+  assert.equal(turnRequest.vpsMaintenancePassThrough, null);
 
   assert.equal(dashboardSocket.sent.length, 3);
   const broadcast = JSON.parse(dashboardSocket.sent[0]);
@@ -4085,10 +4084,12 @@ test("DashboardChatRoom forwards cost-aware owner turns to app-server bridge", a
   assert.equal(turnRequest.type, "app_server_turn_requested");
   assert.equal(turnRequest.threadId, "dashboard-main-unresolved");
   assert.equal(turnRequest.repository, null);
-  assert.equal(turnRequest.authority.ordinaryConversationAllowed, true);
+  assert.equal(turnRequest.authority, null);
   assert.equal(turnRequest.usageProfile.profile, "conversation");
   assert.equal(turnRequest.usageProfile.reasoningEffort, "low");
   assert.equal(turnRequest.costBoundary.profile, "conversation");
+  assert.equal(turnRequest.trafficControl, null);
+  assert.equal(turnRequest.vpsMaintenancePassThrough, null);
   assert.equal(dashboardSocket.sent.length, 3);
   const ownerBroadcast = JSON.parse(dashboardSocket.sent[0]);
   assert.equal(ownerBroadcast.messages.length, 1);
@@ -4795,10 +4796,7 @@ test("DashboardChatRoom does not persist app-server reply deltas as chat message
   assert.equal(stored[0].role, "butler");
   assert.equal(stored[0].status, "replied");
   assert.equal(stored[0].text, "日本時間では、今日は 05月22日 20時09分です。");
-  assert.deepEqual(
-    stored[0].progressSummary.entries.map((entry) => [entry.text, entry.source]),
-    [["日本", "app_server_reply_delta"]]
-  );
+  assert.equal(stored[0].progressSummary, undefined);
 });
 
 test("DashboardChatRoom does not rewrite unchanged app-server thread mapping during transient bursts", async () => {
@@ -5359,14 +5357,8 @@ test("DashboardChatRoom clears transient progress snapshot after final reply", a
   assert.equal(threadPayloads.at(-1).transientProgressSnapshot, null);
   const finalMessage = (await store.listThread("dashboard-main-unresolved")).at(-1);
   assert.equal(finalMessage.text, "検証が終わりました。");
-  assert.deepEqual(
-    finalMessage.progressSummary.entries.map((entry) => entry.text),
-    ["方針を整理しています。", "テストを実行しています。"]
-  );
-  assert.deepEqual(
-    threadPayloads.at(-1).messages.at(-1).progressSummary.entries.map((entry) => entry.text),
-    ["方針を整理しています。", "テストを実行しています。"]
-  );
+  assert.equal(finalMessage.progressSummary, undefined);
+  assert.equal(threadPayloads.at(-1).messages.at(-1).progressSummary, undefined);
 });
 
 test("DashboardChatRoom keeps generic opt-in app-server progress transient-only", async () => {
@@ -5643,7 +5635,8 @@ test("DashboardChatRoom sends nickname requests to connected app-server bridge",
   assert.equal(turnRequest.type, "app_server_turn_requested");
   assert.equal(turnRequest.text, "登録済みのニックネーム出して");
   assert.equal(turnRequest.repository, null);
-  assert.equal(turnRequest.authority.ordinaryConversationAllowed, true);
+  assert.equal(turnRequest.authority, null);
+  assert.equal(turnRequest.trafficControl, null);
 
   const broadcast = JSON.parse(dashboardSocket.sent[0]);
   assert.equal(broadcast.messages.length, 1);

--- a/worker.js
+++ b/worker.js
@@ -58333,12 +58333,13 @@ var DashboardChatRoom = class {
       mediaReferences
     });
     const costBoundary = buildDashboardAppServerUsageCostBoundary(usageProfile);
-    const trafficControl = await buildDashboardChatTrafficControlContext({
+    const needsRepositoryContext = Boolean(repository || relatedIssue || shouldUseDashboardThreadRepositoryContext(text));
+    const trafficControl = repository ? await buildDashboardChatTrafficControlContext({
       env: this.env,
       repository,
       relatedIssue,
       text
-    });
+    }) : null;
     const vpsMaintenancePassThrough = buildDashboardVpsMaintenancePassThroughContext({
       text,
       repository,
@@ -58362,7 +58363,7 @@ var DashboardChatRoom = class {
         startThreadMethod: mapping.codexThreadId ? "thread/resume" : "thread/start",
         turnMethod: "turn/start"
       },
-      authority: buildDashboardAppServerAuthorityHint({ repository, relatedIssue, text }),
+      authority: needsRepositoryContext || vpsMaintenancePassThrough ? buildDashboardAppServerAuthorityHint({ repository, relatedIssue, text }) : null,
       usageProfile,
       costBoundary,
       trafficControl,
@@ -66549,7 +66550,7 @@ function shouldUseDashboardThreadRepositoryContext(value) {
   if (/#\d+\b/.test(text)) {
     return true;
   }
-  return /(\bissue\b|\bissues\b|\bpr\b|\bpull request\b|\bactions?\b|\bci\b|\brag\b|\bvps\b|\bcodex\b|\brunner\b|Issue|PR|残り|タスク|進捗|状況|確認|見て|調べて|レビュー|指摘|マージ|merge|デプロイ|deploy|実装|修正|直して|壊れ|バグ|エラー|失敗|ブロッカー|close|クローズ|返信|保存|検索|thread|スレッド)/i.test(
+  return /(\bissue\b|\bissues\b|\bpr\b|\bpull request\b|\bactions?\b|\bci\b|\brag\b|\bvps\b|\brunner\b|Issue|PR|残り|タスク|進捗|状況|確認|見て|調べて|レビュー|指摘|マージ|merge|デプロイ|deploy|実装|修正|直して|壊れ|バグ|エラー|失敗|ブロッカー|close|クローズ|返信|保存|検索|thread|スレッド)/i.test(
     text
   );
 }
@@ -66798,21 +66799,7 @@ function dashboardProgressSummaryEntriesKey(progressSummary) {
   return JSON.stringify(normalized.entries.map((entry) => [entry.text, entry.source]));
 }
 function attachDashboardProgressSummaryToFinalMessages(messages = [], snapshot = null) {
-  const progressSummary = normalizeDashboardProgressSummary(snapshot?.progressSummary);
-  if (!progressSummary.entries.length) {
-    return messages;
-  }
-  return (Array.isArray(messages) ? messages : []).map((message) => {
-    const role = normalizeDashboardEventText(message?.role).toLowerCase();
-    const status = normalizeDashboardChatStatus(message?.status);
-    if (role !== "butler" || status !== "replied") {
-      return message;
-    }
-    return {
-      ...message,
-      progressSummary
-    };
-  });
+  return Array.isArray(messages) ? messages : [];
 }
 function isDashboardSnapshotTransientStatus(status) {
   return [


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #590 の部分進捗です。Dashboard Butler の短い ordinary conversation に `Dashboard Butler turn context`、unresolved trafficControl、authority rule、usage/cost JSON を毎回 prompt として混ぜる regression を止めます。
- `usageProfile` / `costBoundary` は app-server routing metadata として残し、owner prompt 本文には入れません。
- live progress は作業中の transient / UI state として扱い、完了後の durable Butler message に `progressSummary` を残しません。

## Satisfied Success Criteria

- ordinary conversation の `turnInputText` は owner text だけになる。
- usage/cost metadata だけでは `Dashboard Butler turn context` を発生させない。
- ordinary conversation / cost 相談 / nickname request の app-server turn request は `trafficControl=null`、`authority=null` になる。
- repository が解決されている PR/status/read turn では既存の trafficControl preflight を維持する。
- VPS maintenance pass-through と media delivery context は必要時だけ prompt wrapper に残す。
- app-server reply delta / progress checkpoint は final durable Butler message の `progressSummary` として残さない。
- generated `worker.js` を source change と同じ変更に含めた。

## Unsatisfied Success Criteria

- Issue #590 全体は close-ready ではありません。
- production PWA で `もしもし` 相当の短文が context window exceeded なしで返る E2E は merge/deploy 後に必要です。
- backend `codexThreadId` が既に context window exceeded 状態まで膨らんでいる場合の backend thread reset / epoch 管理はこの PR では未実装です。
- Codex 風の chat-visible live progress stream と完了時の要約置換は、今回の PR では完成させません。

## Non-goal violations

None.

## 開発前作戦図

- 作戦図 evidence: `docs/development-strategy/issue-590-context-lean-live-progress.md`
- 完了体験: Dashboard Butler の短い会話は owner text だけを app-server に届け、必要な repo / Issue / ops turn だけ最小 context を付ける。live progress は作業中 UI state であり、完了後に durable `progressSummary` として残さない。
- VTDD 全体で進める部分: Issue #590 の silent wait / context window exceeded / progress 混線を、まず prompt 肥大化と final summary 混入の除去で前進させる。
- 設計: owner-facing surface は Dashboard Butler の通常チャットです。scope は ordinary/cost/nickname turn の prompt lean 化と final progressSummary 非永続化です。Worker は ordinary conversation で unresolved trafficControl を作らず、bridge は usage/cost/authority だけで context wrapper を発生させない。final reply は progressSummary を添付せず通常回答だけを保存する。
- 仮説: suspected cause は、最近の context window exceeded が live progress 表示そのものではなく、usage/cost routing と VPS maintenance pass-through 周辺で短文にも重い制御文が毎 turn 載るようになったことです。
- 検証計画: ordinary/cost/nickname/repo-status turn request tests、bridge prompt wrapper tests、reply delta/final progressSummary tests、worker bundle generation、full worker verification。
- 改修見積もり: `scripts/run-dashboard-app-server-bridge.mjs` の `buildDashboardTurnInputText`、`src/worker/runtime.js` の `dispatchOwnerMessageToAppServerBridge` と final progress attachment、関連 unit tests、generated `worker.js`。
- 既に通っている経路: Dashboard owner message -> app_server_turn_requested -> bridge turn/start、usage profile classifier、reply delta transient snapshot、repository trafficControl preflight。
- 未確認の境界: production の既存 backend codex thread が既に context exceeded している場合、この PR だけで直近 thread が復旧するかは未確認。
- 穴が出そうな箇所: authority rule を軽くしすぎると repo/ops turn の安全境界が弱くなる。今回は context wrapper が必要な turn では authority を維持する。
- PR 前に確認すること: open PR 0、latest origin/main branch、untracked E2E assets を stage しない、targeted tests、`npm run verify:worker`。
- 実装候補と捨てた案: 採用は prompt lean 化と final progressSummary 非永続化。捨てた案は context exceeded 時に即 backend thread を無制限作成する案。
- merge 後に通す E2E: mapped E2E として production Dashboard Butler で短文 ordinary conversation、cost 相談、repo/Issue status read を試し、短文が巨大 context 化しないことと repo turn の必要 context が残ることを確認する。
- 次の PR を増やさない理由: prompt 肥大化と final progressSummary 混入は同じ #590 regression の root-cause slice で、片方だけ直すと context window exceeded または progress 混線が残る。
- 停止条件: repo / Issue / VPS maintenance の authority boundary が保てない場合、または deploy / credential / permission / root helper mutation が必要になった場合は停止する。

## Dry-run Impact Report

- Target Issue: Issue #590
- Implementing Success Criteria: ordinary conversation の prompt 肥大化を止め、live progress を final durable message へ残さない。
- Explicit Non-goals: production deploy、credential mutation、permission mutation、root helper mutation、Issue close、backend thread epoch/GC の完成、chat-visible live progress stream 完成。
- Expected touched files/routes/workflows: `scripts/run-dashboard-app-server-bridge.mjs`, `src/worker/runtime.js`, `worker.js`, `test/dashboard-app-server-bridge.test.js`, `test/worker.test.js`, `docs/development-strategy/issue-590-context-lean-live-progress.md`。
- Affected Issues: Issue #590 primarily。Issue #455 cost/profile app-server routing、Issue #637 VPS maintenance pass-through、Issue #528 chat UX と関連。
- Affected PRs: follow-up after PR #781, PR #782, PR #783, PR #784。
- Affected workflows: local worker build/test、GitHub guarded-policy/test/review。deploy-production はこの PR では実行しない。
- Affected runtime/operator surfaces: Dashboard Butler PWA, Worker DashboardChatRoom, VPS Dashboard app-server bridge。
- What may break if we patch narrowly: ordinary conversation は速くなるが、repo-less repository intent の authority hint が薄くなる可能性がある。repository resolved turn は trafficControl を維持して補う。
- Unknowns to investigate before coding: production app-server の既存 backend thread がすでに context window exceeded している場合の即時復旧可否。
- Validation needed: targeted bridge/worker tests、`npm run build:worker`、`npm run check:generated-worker`、`git diff --check`、`npm run verify:worker`、merge/deploy 後 production PWA E2E。
- Stop condition: authority boundary を保持できない、または deploy / credential / permission / root helper mutation が必要になる。

## Execution Queue Delta

- Queue position before: Issue #590 は active queue の `Now` root blocker。Dashboard Butler の普通の会話が context window exceeded で落ち、Butler-first 開発継続を妨げている。
- Preemption decision: ROOT。Issue #590 の root blocker 継続であり、Issue #637 など次の開発へ進む前に Butler 通常会話を復旧する必要がある。
- Queue delta: Issue #590 の context lean / progress storage slice を進める。Issue #637 は Next のまま、Issue #455 / #528 / #498 の未完了項目は未完了として残す。
- Why this PR is next: owner の production evidence で `context window` failure が出ており、短文 turn に巨大制御文が乗る実装上の root cause が見つかったため。
- Active Issues not downscoped: Active Issues は縮小しません。この PR で扱わない Issue #637、Issue #455、Issue #528、Issue #498、その他 active Issues は未完了として残します。

## File / Line Hypotheses

- file: `scripts/run-dashboard-app-server-bridge.mjs`
  - hypothesis: `usageProfile` / `costBoundary` / `authority` だけで `Dashboard Butler turn context` が発生し、短文 owner input が数百倍に膨らむ。
  - risk if changed narrowly: repository / ops turn の必要 context まで落とすと安全境界が弱くなる。
  - validation: ordinary usage metadata は prompt に入らず、repo trafficControl / VPS maintenance / media context は残る test。
  - related Issue: Issue #590
- file: `src/worker/runtime.js`
  - hypothesis: ordinary conversation でも unresolved trafficControl と authority hint を turn request に載せており、bridge 側 prompt wrapper を誘発している。
  - risk if changed narrowly: repo-less PR/status intent の分類が薄くなる可能性。
  - validation: ordinary/cost/nickname は `trafficControl=null`、repo resolved status read は trafficControl を維持する worker tests。
  - related Issue: Issue #590
- file: `src/worker/runtime.js`
  - hypothesis: transient progress snapshot を final message の `progressSummary` に添付すると、完了後にも progress が durable message として残り、owner 方針と違う。
  - risk if changed narrowly: 完了後進行ログ evidence は薄くなるが、owner 方針では残さなくてよい。
  - validation: reply delta / progress checkpoint 後の final message に `progressSummary` がない worker tests。
  - related Issue: Issue #590

## Hypothesis Retrospective

- expected: ordinary short turn prompt is owner text only, usage/cost stays metadata, final durable Butler message does not carry progressSummary.
- actual: local tests confirm ordinary/cost/nickname lean request behavior, repo trafficControl preservation, and final progressSummary omission.
- mismatch: production existing backend thread recovery remains unverified until deploy/E2E.
- lesson: cost/profile routing must not become prompt text for ordinary conversation.
- should become RAG candidate: Yes, after production E2E confirms context window recovery.

## Verification Evidence

- Unit: `node --test test/dashboard-app-server-bridge.test.js`; `node --test test/worker.test.js`; targeted tests for ordinary/cost/nickname/progressSummary passed.
- Integration: `npm run build:worker`; `npm run check:generated-worker`; `git diff --check`; `npm run verify:worker` passed.
- E2E: Not run before merge. Production Dashboard Butler E2E is required after deploy.
- Manual: Checked Issue #590 comments, active execution queue, recent PR #781-#784 diff, and measured `もしもし` context inflation before implementation.
- Evidence path/link: `docs/development-strategy/issue-590-context-lean-live-progress.md`

## Butler Completion Contract

- Primary owner surface: Dashboard Butler。
- Fallback surface: mac Codex は debug/bootstrap fallback です。Custom GPT は fallback surface であり主経路ではありません。
- Owner goal: Dashboard Butler の短い会話と軽い相談が巨大 context を背負わず、context window exceeded を起こしにくくする。
- Butler entrypoint: Dashboard Butler の通常自然文チャット。
- Dashboard Butler natural-language path: owner が Dashboard Butler natural-language/chat entrypoint の通常チャットに短文、cost 相談、nickname request、repo status request を送ると、必要な場合だけ app-server bridge へ最小 context 付きで渡る。
- Action Schema exposure: Custom GPT Action Schema は未変更。この PR は Dashboard Butler runtime path の修正です。
- Runtime path: DashboardChatRoom WebSocket owner message -> app_server_turn_requested -> VPS Dashboard app-server bridge -> codex app-server turn/start。
- Runner/runtime truth: local unit/integration/full worker verification passed。production runtime truth は deploy 後 E2E が必要です。
- Authority boundary: 未変更。deploy、credential、permission、destructive/root helper mutation は実行しません。
- E2E evidence: 未実施。production deploy 後の Dashboard Butler E2E が必要です。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 未実施。merge 後に必要なら scoped passkey approval で deploy-production。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。production deploy 後に必要。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate
- AGENTS.md Drift Stop Protocol
- AGENTS.md 開発前作戦図 Gate
- AGENTS.md Evidence Discipline
- docs/butler/execution-queue-contract.md

## Out-of-scope but NOT implemented

- backend app-server thread epoch / reset / GC
- Codex 風 chat-visible live progress stream の完成
- media reference repo mismatch
- reply target preview filtering
- Issue #590 close

## Extra changes (if any)

- `worker.js` generated bundle を更新。

<!-- VTDD metadata -->
- Issue: Issue #590
- Execution ID: issue-590-context-lean-live-progress
- Goal: Dashboard Butler ordinary turn context を軽量化し、live progress を final durable message に残さない。
