### PR TITLE
Issue #590 context exceeded backend reset

### DIFF
--- a/docs/development-strategy/issue-590-context-window-reset.md
+++ b/docs/development-strategy/issue-590-context-window-reset.md
@@ -1,0 +1,71 @@
+# Issue #590: context window reset and retry
+
+## 完了体験
+
+Dashboard Butler で既存 backend `codexThreadId` が context window exceeded になっても、owner は同じ Dashboard thread のまま続けられる。runtime は失敗理由を `context_window_exceeded` として扱い、古い backend mapping を破棄し、同じ owner 入力を新しい app-server backend thread へ一度だけ自動再送する。
+
+## VTDD 全体で進める部分
+
+Issue #590 の app-server failure recovery。PR #785 は新規 prompt の肥大化を止めたが、既に膨らんだ backend thread には効かない。今回は既存 backend thread が詰まった状態からの復旧を実装する。
+
+## 設計
+
+bridge は context window exceeded の失敗を media/generic failure と分け、`recovery.status=context_window_exceeded`、`originalText`、`originalMessageId`、`resetBackendThread=true` を Worker へ送る。
+
+Worker は該当 failure を受けたら `app_server_thread:<dashboardThreadId>` mapping を削除する。接続中の app-server bridge socket があり、同じ owner message の auto retry がまだ実行されていなければ、同じ owner text を `codexThreadId=null` で再 dispatch する。
+
+自動 retry は一度だけにする。再 retry 失敗時は owner-facing recovery message を残し、無限再送しない。
+
+## 仮説
+
+suspected cause は、PR #785 deploy 後も Dashboard PWA が同じ `codexThreadId` を resume し、すでに context window exceeded になった app-server backend thread に再投入していること。prompt を軽くしても既存 backend thread の履歴は消えないため、mapping reset が必要。
+
+## 検証計画
+
+- bridge unit: context window exceeded failure に recovery metadata が付く。
+- Worker unit: context window exceeded failure で app-server thread mapping を clear する。
+- Worker unit: context window exceeded failure 後、同じ owner input を fresh backend thread として一度だけ auto redispatch する。
+- Worker unit: auto retry 済み failure では再 dispatch しない。
+- `npm run build:worker`、`npm run check:generated-worker`、`npm run verify:worker`。
+
+## 改修見積もり
+
+- `scripts/run-dashboard-app-server-bridge.mjs`: failure text builder と failure event に context window recovery metadata を追加する。
+- `src/worker/runtime.js`: mapping clear helper、normalized recovery metadata、auto retry logic を追加する。
+- `test/dashboard-app-server-bridge.test.js`: context window exceeded recovery metadata test。
+- `test/worker.test.js`: mapping clear / redispatch tests。
+- `worker.js`: generated bundle update。
+
+## 既に通っている経路
+
+DashboardChatRoom は `codexThreadId` mapping を保存し、次 owner turn で `thread/resume` する。PR #785 で ordinary prompt は lean になった。
+
+## 未確認の境界
+
+production app-server が context window exceeded を `turn/completed failed` notification として出すか、request error として出すかは完全には未確認。両方の text に対して recovery classification を行う。
+
+## 穴が出そうな箇所
+
+auto retry が無限ループになること。別 owner message を誤って再送すること。bridge socket が既に閉じている場合に再送できないこと。
+
+## PR 前に確認すること
+
+latest `origin/main` branch、open PR 0、targeted tests、full `verify:worker`、untracked E2E assets を stage しないこと。
+
+## 実装候補と捨てた案
+
+採用: context window exceeded の時だけ mapping clear + same input one-shot retry。
+
+捨てた案: 全 failure で backend thread reset。原因が transient / media / approval の場合に文脈喪失が大きすぎる。
+
+## merge 後に通す E2E
+
+mapped E2E として production Dashboard Butler の同じ thread で `もしもし` を送り、context window exceeded が出ずに fresh backend thread へ復旧することを確認する。再発時は recovery message が無限増殖しないことを見る。
+
+## 次の PR を増やさない理由
+
+PR #785 の prompt lean 化だけでは既存詰まり thread を復旧できない。context exceeded の分類、mapping reset、one-shot retry は同じ owner-facing recovery の一塊。
+
+## 停止条件
+
+retry に high-risk authority、deploy、credential、permission、root helper mutation が必要になる場合は停止する。context exceeded 以外の failure に reset を広げる必要が出た場合も scope を再確認する。

--- a/scripts/run-dashboard-app-server-bridge.mjs
+++ b/scripts/run-dashboard-app-server-bridge.mjs
@@ -826,7 +826,14 @@ export function mapAppServerNotificationToDashboardEvent(message, context = {}) 
                 text: params.message || params.reason || params.error,
                 status: turnStatus,
                 mediaReferences: context.mediaReferences
-              })
+              }),
+        recovery: buildDashboardAppServerFailureRecovery({
+          text: params.message || params.reason || params.error,
+          status: turnStatus,
+          ownerText: context.ownerText,
+          ownerMessageId: context.ownerMessageId,
+          resumedExistingThread: context.resumedExistingThread
+        })
       };
     }
     return {
@@ -848,7 +855,45 @@ export function mapAppServerNotificationToDashboardEvent(message, context = {}) 
         text: params.message || params.reason || params.error,
         status: "failed",
         mediaReferences: context.mediaReferences
+      }),
+      recovery: buildDashboardAppServerFailureRecovery({
+        text: params.message || params.reason || params.error,
+        status: "failed",
+        ownerText: context.ownerText,
+        ownerMessageId: context.ownerMessageId,
+        resumedExistingThread: context.resumedExistingThread
       })
+    };
+  }
+  return null;
+}
+
+export function isDashboardAppServerContextWindowExceededText(text = "") {
+  return /ran out of room in the model'?s context window|context window|clear earlier history/i.test(
+    normalizeBridgeText(text)
+  );
+}
+
+export function buildDashboardAppServerFailureRecovery({
+  text = "",
+  status = "",
+  ownerText = "",
+  ownerMessageId = "",
+  resumedExistingThread = false
+} = {}) {
+  const detail = sanitizeOptionalBridgeError(text);
+  if (
+    normalizeBridgeText(status).toLowerCase() !== "interrupted" &&
+    resumedExistingThread === true &&
+    isDashboardAppServerContextWindowExceededText(detail)
+  ) {
+    return {
+      status: "context_window_exceeded",
+      retryable: true,
+      resetBackendThread: true,
+      autoRetry: true,
+      originalText: normalizeBridgeText(ownerText),
+      originalMessageId: normalizeBridgeText(ownerMessageId)
     };
   }
   return null;
@@ -1696,7 +1741,10 @@ export async function handleDashboardTurnRequest({
       dashboardThreadId,
       codexThreadId,
       accumulatedText,
-      mediaReferences: materializedMediaReferences
+      mediaReferences: materializedMediaReferences,
+      ownerText: text,
+      ownerMessageId: request.messageId,
+      resumedExistingThread
     });
     if (!event) return;
     if (event.type === "app_server_reply_delta") {
@@ -2412,6 +2460,13 @@ export async function connectDashboardAppServerBridgeOnce({
               text: error?.message,
               status: "failed",
               mediaReferences: payload.mediaReferences
+            }),
+            recovery: buildDashboardAppServerFailureRecovery({
+              text: error?.message,
+              status: "failed",
+              ownerText: payload.text,
+              ownerMessageId: payload.messageId,
+              resumedExistingThread: Boolean(payload.codexThreadId)
             })
           });
         });

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -568,6 +568,22 @@ export class DashboardChatRoom {
         updatedAt: normalized.createdAt
       });
     }
+    if (shouldResetDashboardAppServerBackendThread(normalized.recovery)) {
+      await this.clearAppServerThreadMapping(normalized.threadId);
+      const retried = await this.retryDashboardAppServerTurnAfterContextReset({
+        socket,
+        normalized
+      });
+      if (retried) {
+        await this.broadcastTransientStatus({
+          threadId: normalized.threadId,
+          status: "thinking",
+          text: "codex app-server の古い backend thread を切り替えて、同じ入力を再送しています。",
+          snapshot: false
+        });
+        return;
+      }
+    }
     const finalProgressSnapshot =
       normalized.transientStatus === "replied"
         ? await this.readTransientProgressSnapshot(normalized.threadId)
@@ -826,6 +842,60 @@ export class DashboardChatRoom {
       updatedAt: normalizeIsoTimestamp(mapping?.updatedAt) || new Date().toISOString()
     });
     return true;
+  }
+
+  async clearAppServerThreadMapping(threadId) {
+    const normalizedThreadId = normalizeDashboardThreadId(threadId);
+    const key = normalizedThreadId ? `app_server_thread:${normalizedThreadId}` : "";
+    if (!key || !this.ctx?.storage) {
+      return false;
+    }
+    if (typeof this.ctx.storage.delete === "function") {
+      await this.ctx.storage.delete(key);
+      return true;
+    }
+    if (typeof this.ctx.storage.put === "function") {
+      await this.ctx.storage.put(key, null);
+      return true;
+    }
+    return false;
+  }
+
+  async retryDashboardAppServerTurnAfterContextReset({ socket, normalized } = {}) {
+    if (!isSocketOpen(socket) || !shouldResetDashboardAppServerBackendThread(normalized?.recovery)) {
+      return false;
+    }
+    const originalText = sanitizeDashboardChatText(normalized.recovery.originalText);
+    const originalMessageId = normalizeDashboardEventText(normalized.recovery.originalMessageId);
+    if (!normalized.threadId || !originalText || !originalMessageId) {
+      return false;
+    }
+    const retryKey = `app_server_context_retry:${normalized.threadId}:${originalMessageId}`;
+    if (typeof this.ctx?.storage?.get === "function") {
+      const previous = await this.ctx.storage.get(retryKey);
+      if (previous) {
+        return false;
+      }
+    }
+    if (typeof this.ctx?.storage?.put === "function") {
+      await this.ctx.storage.put(retryKey, {
+        at: new Date().toISOString(),
+        reason: "context_window_exceeded"
+      });
+    }
+    return this.dispatchOwnerMessageToAppServerBridge({
+      threadId: normalized.threadId,
+      bridgeSocket: socket,
+      ownerMessage: {
+        threadId: normalized.threadId,
+        messageId: originalMessageId,
+        role: "owner",
+        repository: normalized.repository || null,
+        relatedIssue: normalized.relatedIssue || null,
+        text: originalText,
+        createdAt: new Date().toISOString()
+      }
+    });
   }
 
   async hasAcceptedOwnerMessage({ threadId, clientMessageId, store }) {
@@ -9868,6 +9938,7 @@ function normalizeDashboardAppServerBridgeEvent(payload, { fallbackThreadId = ""
   const repository = normalizeCanonicalRepositoryInput(input.repository);
   const relatedIssue = normalizePositiveInteger(input.relatedIssue || input.issueNumber);
   const createdAt = normalizeIsoTimestamp(input.createdAt) || new Date().toISOString();
+  const recovery = normalizeDashboardAppServerRecovery(input.recovery);
   const messages = [];
   let transientStatus = "";
   let snapshotTransientStatus = false;
@@ -9900,8 +9971,7 @@ function normalizeDashboardAppServerBridgeEvent(payload, { fallbackThreadId = ""
   } else if (eventType === "app_server_turn_failed" || status === "failed") {
     const failureText = buildDashboardAppServerFailureThreadText({ text, status });
     const messageStatus =
-      normalizeDashboardEventText(input?.recovery?.status).toLowerCase() === "stalled" ||
-      status === "timeout"
+      normalizeDashboardEventText(recovery?.status).toLowerCase() === "stalled" || status === "timeout"
         ? "stalled"
         : "failed";
     messages.push(
@@ -9950,14 +10020,47 @@ function normalizeDashboardAppServerBridgeEvent(payload, { fallbackThreadId = ""
     ok: true,
     threadId,
     codexThreadId,
+    repository,
+    relatedIssue,
     createdAt,
     text,
+    recovery,
     transientText,
     transientStatus,
     snapshotTransientStatus,
     snapshotSource,
     messages: messages.filter(Boolean)
   };
+}
+
+function normalizeDashboardAppServerRecovery(value) {
+  const input = normalizeObject(value);
+  const status = normalizeDashboardEventText(input.status).toLowerCase();
+  const originalText = sanitizeDashboardChatText(input.originalText || input.original_text);
+  const originalMessageId = normalizeDashboardEventText(input.originalMessageId || input.original_message_id);
+  const resetBackendThread = input.resetBackendThread === true || input.reset_backend_thread === true;
+  const retryable = input.retryable === true || status === "context_window_exceeded";
+  const autoRetry = input.autoRetry === true || input.auto_retry === true;
+  if (!status && !originalText && !originalMessageId && !resetBackendThread && !retryable && !autoRetry) {
+    return null;
+  }
+  return {
+    status,
+    retryable,
+    resetBackendThread,
+    autoRetry,
+    originalText,
+    originalMessageId
+  };
+}
+
+function shouldResetDashboardAppServerBackendThread(recovery) {
+  const normalized = normalizeDashboardAppServerRecovery(recovery);
+  return (
+    normalized?.status === "context_window_exceeded" &&
+    normalized.retryable === true &&
+    normalized.resetBackendThread === true
+  );
 }
 
 function normalizeDashboardTransientProgressSnapshot(value) {

--- a/test/dashboard-app-server-bridge.test.js
+++ b/test/dashboard-app-server-bridge.test.js
@@ -920,6 +920,51 @@ test("dashboard app-server bridge maps Codex app-server notifications to dashboa
   assert.equal(completed.status, "replied");
   assert.equal(completed.text, "最終返答");
 
+  const contextExceededFailure = mapAppServerNotificationToDashboardEvent(
+    {
+      method: "turn/completed",
+      params: {
+        threadId: "codex-thread-1",
+        status: "failed",
+        message:
+          "Codex ran out of room in the model's context window. Start a new thread or clear earlier history before retrying."
+      }
+    },
+    {
+      dashboardThreadId: "dashboard-main",
+      codexThreadId: "codex-thread-1",
+      ownerText: "もしもし。",
+      ownerMessageId: "dashboard_owner_message:context-reset-1",
+      resumedExistingThread: true
+    }
+  );
+  assert.equal(contextExceededFailure.type, "app_server_turn_failed");
+  assert.equal(contextExceededFailure.recovery.status, "context_window_exceeded");
+  assert.equal(contextExceededFailure.recovery.resetBackendThread, true);
+  assert.equal(contextExceededFailure.recovery.autoRetry, true);
+  assert.equal(contextExceededFailure.recovery.originalText, "もしもし。");
+  assert.equal(contextExceededFailure.recovery.originalMessageId, "dashboard_owner_message:context-reset-1");
+
+  const freshContextExceededFailure = mapAppServerNotificationToDashboardEvent(
+    {
+      method: "turn/completed",
+      params: {
+        threadId: "codex-thread-2",
+        status: "failed",
+        message:
+          "Codex ran out of room in the model's context window. Start a new thread or clear earlier history before retrying."
+      }
+    },
+    {
+      dashboardThreadId: "dashboard-main",
+      codexThreadId: "codex-thread-2",
+      ownerText: "もしもし。",
+      ownerMessageId: "dashboard_owner_message:context-reset-2",
+      resumedExistingThread: false
+    }
+  );
+  assert.equal(freshContextExceededFailure.recovery, null);
+
   const started = mapAppServerNotificationToDashboardEvent(
     { method: "turn/started", params: { threadId: "codex-thread-1", turnId: "turn-1" } },
     { dashboardThreadId: "dashboard-main", codexThreadId: "codex-thread-1" }

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -4972,6 +4972,128 @@ test("DashboardChatRoom persists app-server timeout as recoverable Japanese thre
   assert.equal(failedStatus.text, "再接続と状態確認を続けています。入力と文脈は保持しています。");
 });
 
+test("DashboardChatRoom resets overfull app-server backend thread and retries once", async () => {
+  const store = createInMemoryDashboardChatStore();
+  const dashboardSocket = createMockSocket("dashboard", "dashboard-main-unresolved");
+  const bridgeSocket = createMockSocket("app_server_bridge", "dashboard-main-unresolved");
+  const storage = createMockDurableObjectStorage();
+  storage.values.set("app_server_thread:dashboard-main-unresolved", {
+    codexThreadId: "codex-thread-overfull",
+    updatedAt: "2026-06-05T00:00:00.000Z"
+  });
+  const room = new DashboardChatRoom(
+    {
+      storage,
+      getWebSockets() {
+        return [dashboardSocket, bridgeSocket];
+      }
+    },
+    { DASHBOARD_CHAT_STORE: store }
+  );
+
+  await room.webSocketMessage(
+    bridgeSocket,
+    JSON.stringify({
+      type: "app_server_turn_failed",
+      status: "failed",
+      threadId: "dashboard-main-unresolved",
+      codexThreadId: "codex-thread-overfull",
+      repository: "marushu/vtdd-v2-p",
+      relatedIssue: 590,
+      text:
+        "codex app-server が応答生成中に失敗しました。詳細: Codex ran out of room in the model's context window. Start a new thread or clear earlier history before retrying.",
+      recovery: {
+        status: "context_window_exceeded",
+        retryable: true,
+        resetBackendThread: true,
+        autoRetry: true,
+        originalText: "もしもし。",
+        originalMessageId: "dashboard_owner_message:context-reset-1"
+      }
+    })
+  );
+
+  assert.equal(storage.values.get("app_server_thread:dashboard-main-unresolved"), undefined);
+  assert.ok(storage.deleteCalls.some((call) => call.key === "app_server_thread:dashboard-main-unresolved"));
+  assert.ok(storage.values.get("app_server_context_retry:dashboard-main-unresolved:dashboard_owner_message:context-reset-1"));
+
+  const turnRequest = bridgeSocket.sent.map((message) => JSON.parse(message)).find((message) => message.type === "app_server_turn_requested");
+  assert.ok(turnRequest);
+  assert.equal(turnRequest.threadId, "dashboard-main-unresolved");
+  assert.equal(turnRequest.codexThreadId, null);
+  assert.equal(turnRequest.appServer.startThreadMethod, "thread/start");
+  assert.equal(turnRequest.text, "もしもし。");
+  assert.equal(turnRequest.messageId, "dashboard_owner_message:context-reset-1");
+  assert.equal(turnRequest.repository, "marushu/vtdd-v2-p");
+  assert.equal(turnRequest.relatedIssue, 590);
+
+  const stored = await store.listThread("dashboard-main-unresolved");
+  assert.equal(stored.length, 0);
+  const transient = dashboardSocket.sent.map((message) => JSON.parse(message)).find((message) => message.type === "transient_status");
+  assert.ok(transient);
+  assert.equal(transient.status, "thinking");
+  assert.match(transient.text, /backend thread を切り替えて/);
+});
+
+test("DashboardChatRoom does not loop over app-server context reset retries", async () => {
+  const store = createInMemoryDashboardChatStore();
+  const dashboardSocket = createMockSocket("dashboard", "dashboard-main-unresolved");
+  const bridgeSocket = createMockSocket("app_server_bridge", "dashboard-main-unresolved");
+  const storage = createMockDurableObjectStorage();
+  storage.values.set("app_server_thread:dashboard-main-unresolved", {
+    codexThreadId: "codex-thread-overfull",
+    updatedAt: "2026-06-05T00:00:00.000Z"
+  });
+  storage.values.set("app_server_context_retry:dashboard-main-unresolved:dashboard_owner_message:context-reset-1", {
+    at: "2026-06-05T00:01:00.000Z",
+    reason: "context_window_exceeded"
+  });
+  const room = new DashboardChatRoom(
+    {
+      storage,
+      getWebSockets() {
+        return [dashboardSocket, bridgeSocket];
+      }
+    },
+    { DASHBOARD_CHAT_STORE: store }
+  );
+
+  await room.webSocketMessage(
+    bridgeSocket,
+    JSON.stringify({
+      type: "app_server_turn_failed",
+      status: "failed",
+      threadId: "dashboard-main-unresolved",
+      codexThreadId: "codex-thread-overfull",
+      repository: "marushu/vtdd-v2-p",
+      relatedIssue: 590,
+      text:
+        "codex app-server が応答生成中に失敗しました。詳細: Codex ran out of room in the model's context window. Start a new thread or clear earlier history before retrying.",
+      recovery: {
+        status: "context_window_exceeded",
+        retryable: true,
+        resetBackendThread: true,
+        autoRetry: true,
+        originalText: "もしもし。",
+        originalMessageId: "dashboard_owner_message:context-reset-1"
+      }
+    })
+  );
+
+  assert.equal(storage.values.get("app_server_thread:dashboard-main-unresolved"), undefined);
+  const retryRequests = bridgeSocket.sent
+    .map((message) => JSON.parse(message))
+    .filter((message) => message.type === "app_server_turn_requested");
+  assert.equal(retryRequests.length, 0);
+
+  const stored = await store.listThread("dashboard-main-unresolved");
+  assert.equal(stored.length, 1);
+  assert.equal(stored[0].role, "system");
+  assert.equal(stored[0].status, "failed");
+  assert.match(stored[0].text, /応答生成中に失敗しました/);
+  assert.match(stored[0].text, /context window/);
+});
+
 test("DashboardChatRoom dedupes repeated app-server stalled recovery messages", async () => {
   const store = createInMemoryDashboardChatStore();
   const dashboardSocket = createMockSocket("dashboard", "dashboard-main-unresolved");

--- a/worker.js
+++ b/worker.js
@@ -58434,6 +58434,22 @@ var DashboardChatRoom = class {
         updatedAt: normalized.createdAt
       });
     }
+    if (shouldResetDashboardAppServerBackendThread(normalized.recovery)) {
+      await this.clearAppServerThreadMapping(normalized.threadId);
+      const retried = await this.retryDashboardAppServerTurnAfterContextReset({
+        socket,
+        normalized
+      });
+      if (retried) {
+        await this.broadcastTransientStatus({
+          threadId: normalized.threadId,
+          status: "thinking",
+          text: "codex app-server \u306E\u53E4\u3044 backend thread \u3092\u5207\u308A\u66FF\u3048\u3066\u3001\u540C\u3058\u5165\u529B\u3092\u518D\u9001\u3057\u3066\u3044\u307E\u3059\u3002",
+          snapshot: false
+        });
+        return;
+      }
+    }
     const finalProgressSnapshot = normalized.transientStatus === "replied" ? await this.readTransientProgressSnapshot(normalized.threadId) : null;
     if (normalized.transientStatus === "replied") {
       await this.clearTransientProgressSnapshot(normalized.threadId);
@@ -58651,6 +58667,58 @@ var DashboardChatRoom = class {
       updatedAt: normalizeIsoTimestamp(mapping?.updatedAt) || (/* @__PURE__ */ new Date()).toISOString()
     });
     return true;
+  }
+  async clearAppServerThreadMapping(threadId) {
+    const normalizedThreadId = normalizeDashboardThreadId(threadId);
+    const key = normalizedThreadId ? `app_server_thread:${normalizedThreadId}` : "";
+    if (!key || !this.ctx?.storage) {
+      return false;
+    }
+    if (typeof this.ctx.storage.delete === "function") {
+      await this.ctx.storage.delete(key);
+      return true;
+    }
+    if (typeof this.ctx.storage.put === "function") {
+      await this.ctx.storage.put(key, null);
+      return true;
+    }
+    return false;
+  }
+  async retryDashboardAppServerTurnAfterContextReset({ socket, normalized } = {}) {
+    if (!isSocketOpen(socket) || !shouldResetDashboardAppServerBackendThread(normalized?.recovery)) {
+      return false;
+    }
+    const originalText = sanitizeDashboardChatText(normalized.recovery.originalText);
+    const originalMessageId = normalizeDashboardEventText(normalized.recovery.originalMessageId);
+    if (!normalized.threadId || !originalText || !originalMessageId) {
+      return false;
+    }
+    const retryKey = `app_server_context_retry:${normalized.threadId}:${originalMessageId}`;
+    if (typeof this.ctx?.storage?.get === "function") {
+      const previous = await this.ctx.storage.get(retryKey);
+      if (previous) {
+        return false;
+      }
+    }
+    if (typeof this.ctx?.storage?.put === "function") {
+      await this.ctx.storage.put(retryKey, {
+        at: (/* @__PURE__ */ new Date()).toISOString(),
+        reason: "context_window_exceeded"
+      });
+    }
+    return this.dispatchOwnerMessageToAppServerBridge({
+      threadId: normalized.threadId,
+      bridgeSocket: socket,
+      ownerMessage: {
+        threadId: normalized.threadId,
+        messageId: originalMessageId,
+        role: "owner",
+        repository: normalized.repository || null,
+        relatedIssue: normalized.relatedIssue || null,
+        text: originalText,
+        createdAt: (/* @__PURE__ */ new Date()).toISOString()
+      }
+    });
   }
   async hasAcceptedOwnerMessage({ threadId, clientMessageId, store }) {
     const normalizedThreadId = normalizeDashboardThreadId(threadId);
@@ -66640,6 +66708,7 @@ function normalizeDashboardAppServerBridgeEvent(payload, { fallbackThreadId = ""
   const repository = normalizeCanonicalRepositoryInput(input.repository);
   const relatedIssue = normalizePositiveInteger10(input.relatedIssue || input.issueNumber);
   const createdAt = normalizeIsoTimestamp(input.createdAt) || (/* @__PURE__ */ new Date()).toISOString();
+  const recovery = normalizeDashboardAppServerRecovery(input.recovery);
   const messages = [];
   let transientStatus = "";
   let snapshotTransientStatus = false;
@@ -66670,7 +66739,7 @@ function normalizeDashboardAppServerBridgeEvent(payload, { fallbackThreadId = ""
     transientText = "Dashboard thread \u63A5\u7D9A\u6E08\u307F\u3002";
   } else if (eventType === "app_server_turn_failed" || status === "failed") {
     const failureText = buildDashboardAppServerFailureThreadText({ text, status });
-    const messageStatus = normalizeDashboardEventText(input?.recovery?.status).toLowerCase() === "stalled" || status === "timeout" ? "stalled" : "failed";
+    const messageStatus = normalizeDashboardEventText(recovery?.status).toLowerCase() === "stalled" || status === "timeout" ? "stalled" : "failed";
     messages.push(
       normalizeDashboardChatMessage(
         {
@@ -66717,14 +66786,41 @@ function normalizeDashboardAppServerBridgeEvent(payload, { fallbackThreadId = ""
     ok: true,
     threadId,
     codexThreadId,
+    repository,
+    relatedIssue,
     createdAt,
     text,
+    recovery,
     transientText,
     transientStatus,
     snapshotTransientStatus,
     snapshotSource,
     messages: messages.filter(Boolean)
   };
+}
+function normalizeDashboardAppServerRecovery(value) {
+  const input = normalizeObject12(value);
+  const status = normalizeDashboardEventText(input.status).toLowerCase();
+  const originalText = sanitizeDashboardChatText(input.originalText || input.original_text);
+  const originalMessageId = normalizeDashboardEventText(input.originalMessageId || input.original_message_id);
+  const resetBackendThread = input.resetBackendThread === true || input.reset_backend_thread === true;
+  const retryable = input.retryable === true || status === "context_window_exceeded";
+  const autoRetry = input.autoRetry === true || input.auto_retry === true;
+  if (!status && !originalText && !originalMessageId && !resetBackendThread && !retryable && !autoRetry) {
+    return null;
+  }
+  return {
+    status,
+    retryable,
+    resetBackendThread,
+    autoRetry,
+    originalText,
+    originalMessageId
+  };
+}
+function shouldResetDashboardAppServerBackendThread(recovery) {
+  const normalized = normalizeDashboardAppServerRecovery(recovery);
+  return normalized?.status === "context_window_exceeded" && normalized.retryable === true && normalized.resetBackendThread === true;
 }
 function normalizeDashboardTransientProgressSnapshot(value) {
   const input = normalizeObject12(value);


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #590 の Dashboard Butler app-server recovery slice です。
- PR #785 で新規 prompt の肥大化は止めましたが、既に context window exceeded になった backend `codexThreadId` を同じ Dashboard thread が resume し続ける問題が残っていました。
- この PR は context window exceeded を明示 recovery として分類し、Worker が古い backend mapping を破棄して同じ owner 入力を fresh backend thread に一度だけ再送します。

## Satisfied Success Criteria

- bridge が既存 backend thread resume 中の context window exceeded failure に `recovery.status=context_window_exceeded` を付けます。
- Worker が `app_server_thread:<dashboardThreadId>` mapping を clear して、次の dispatch を `thread/start` に戻します。
- Worker が同じ owner text/messageId を一度だけ自動再送し、成功時は failure system message を増やしません。
- retry 済みの同じ owner message では再送せず、通常の recoverable failure message に落とします。
- generated `worker.js` を更新し、worker verification を通しました。

## Unsatisfied Success Criteria

- production deploy 後の iPad Dashboard Butler 実機 E2E は未実施です。
- Issue #590 全体の live progress / lane separation / long-running UX 全体完了はこの PR だけでは宣言しません。

## Non-goal violations

None.

## 開発前作戦図

- 作戦図 evidence: `docs/development-strategy/issue-590-context-window-reset.md`
- 完了体験: Dashboard Butler で既存 backend `codexThreadId` が context window exceeded になっても、owner は同じ Dashboard thread のまま続けられる。古い backend mapping を破棄し、同じ入力を新しい app-server backend thread へ一度だけ自動再送する。
- VTDD 全体で進める部分: Issue #590 の app-server failure recovery。PR #785 の prompt lean 化だけでは既存の詰まり thread を復旧できないため、runtime recovery を追加する。
- 設計: owner-facing surface は Dashboard Butler 通常チャット。bridge は context window exceeded を `recovery.status=context_window_exceeded` として Worker へ送り、Worker は該当 event で mapping clear、one-shot retry、retry 済み failure の通常保存を行う。
- 仮説: deploy 後も Dashboard PWA が同じ `codexThreadId` を resume し、すでに context window exceeded になった app-server backend thread に再投入していることが失敗継続の原因。
- 検証計画: bridge unit、Worker unit、generated worker check、`verify:worker` で分類、mapping clear、fresh dispatch、no-loop を確認する。
- 改修見積もり: `scripts/run-dashboard-app-server-bridge.mjs` の failure event metadata、`src/worker/runtime.js` の mapping/retry、`test/dashboard-app-server-bridge.test.js` と `test/worker.test.js`、生成物 `worker.js`。
- 既に通っている経路: DashboardChatRoom は app-server bridge と WebSocket でつながり、`codexThreadId` mapping により `thread/resume` できる。PR #785 で ordinary prompt は lean になっている。
- 未確認の境界: production app-server が context exceeded を `turn/completed failed` として出すか request error として出すかは runtime 依存のため、両方で分類する。
- 穴が出そうな箇所: 無限 retry、別 owner message の誤送、bridge socket close 時の retry 失敗、context exceeded 以外の failure を誤 reset すること。
- PR 前に確認すること: open PR 0、latest origin/main branch、targeted tests、`npm run verify:worker`、未追跡 E2E assets を stage しないこと。
- 実装候補と捨てた案: 採用は context exceeded の時だけ mapping clear + same input one-shot retry。捨てた案は全 failure で backend thread reset。transient/media/approval failure の文脈喪失が大きすぎる。
- merge 後に通す E2E: production Dashboard Butler E2E test として同じ thread で `もしもし` を送り、context window exceeded が再発せず fresh backend thread へ復旧すること。再発時に failure が無限増殖しないこと。
- 次の PR を増やさない理由: context exceeded の分類、mapping reset、one-shot retry は同じ owner-facing recovery の一塊であり、分けるとまた「修正したのに使えない」状態が残る。
- 停止条件: retry に high-risk authority、deploy、credential、permission、root helper mutation が必要になる場合。context exceeded 以外へ reset を広げる必要が出た場合。

## Dry-run Impact Report

- Target Issue: Issue #590
- Implementing Success Criteria: Dashboard Butler app-server context window exceeded recovery。古い backend mapping を clear して fresh backend に one-shot retry する。
- Explicit Non-goals: context exceeded 以外の failure reset、deploy automation 変更、passkey/operator 変更、VPS root helper 変更、Issue #590 全体完了宣言。
- Expected touched files/routes/workflows: `scripts/run-dashboard-app-server-bridge.mjs`, `src/worker/runtime.js`, `test/dashboard-app-server-bridge.test.js`, `test/worker.test.js`, `worker.js`, `docs/development-strategy/issue-590-context-window-reset.md`。
- Affected Issues: Issue #590。Issue #765 系の deploy/bridge restart automation は触りません。
- Affected PRs: PR #785 の follow-up。open PR は 0 件。
- Affected workflows: GitHub Actions test/build/reviewer/auto-merge workflow。workflow 定義自体は未変更です。
- Affected runtime/operator surfaces: Dashboard Butler chat runtime、DashboardChatRoom Durable Object storage、app-server bridge WebSocket event。operator/passkey surface は未変更です。
- What may break if we patch narrowly: bridge だけ分類して Worker が mapping clear しないと同じ failure が続く。Worker だけ retry して bridge が originalText/messageId を送らないと誤送や retry 不可になる。
- Unknowns to investigate before coding: production app-server の context exceeded event 形状。request error と turn/completed failure の両方を扱うことで吸収します。
- Validation needed: targeted bridge/Worker tests、generated worker check、full worker verification、merge/deploy 後の production Dashboard Butler E2E。
- Stop condition: context exceeded 以外の failure に reset を広げる必要がある、または high-risk authority が必要になる場合は停止します。

## Execution Queue Delta

- Queue position before: Issue #590 の live progress / app-server recovery 中、PR #785 merge/deploy 後に production thread が context window exceeded を継続した blocker。
- Preemption decision: EMERGENCY ではないが、Dashboard Butler が通常会話すら返せない owner-facing blocker のため、同じ Issue #590 内の即時 follow-up として扱います。
- Queue delta: Issue #590 に context window reset recovery を追加します。active Issues は縮小しません。
- Why this PR is next: prompt lean 化だけでは既存 backend thread の過去 context は消えないため、Dashboard Butler を使える状態へ戻すには mapping reset が先に必要です。
- Active Issues not downscoped: Active Issues は縮小しません。この PR で扱わない Issue #590 の残り UX/進捗設計と他 active Issues は未完了として残します。

## File / Line Hypotheses

- file: `scripts/run-dashboard-app-server-bridge.mjs`
  - hypothesis: context exceeded failure text は bridge が最初に観測するため、ここで recovery metadata を付ける必要がある。
  - risk if changed narrowly: generic/media failure と混ざると画像誤誘導や retry 不可になる。
  - validation: `node --test test/dashboard-app-server-bridge.test.js`
  - related Issue: #590
- file: `src/worker/runtime.js`
  - hypothesis: Durable Object storage の `app_server_thread:<threadId>` mapping が古い backend thread を resume し続ける root cause。
  - risk if changed narrowly: clear だけで retry しないと owner が手動再送を強いられる。retry guard がないと無限 retry になる。
  - validation: `node --test test/worker.test.js`
  - related Issue: #590

## Hypothesis Retrospective

- expected: PR #785 後も古い backend mapping が残る thread では context window exceeded が続く。
- actual: screenshot と production test で `Codex ran out of room in the model's context window` が継続した。
- mismatch: prompt lean 化だけでは既存 backend app-server thread の履歴を消せない点が不足していた。
- lesson: Dashboard thread storage と backend app-server thread storage は別物として recovery 設計する必要がある。
- should become RAG candidate: はい。`context window exceeded` は owner に手動 thread 切替を要求せず、backend mapping reset + one-shot retry で復旧する判断を記録する価値があります。

## Verification Evidence

- Unit: `node --test test/dashboard-app-server-bridge.test.js` pass、`node --test test/worker.test.js` pass。
- Integration: `npm run build:worker` pass、`npm run check:generated-worker` pass、`git diff --check` pass、`npm run verify:worker` pass。
- E2E: production deploy 後の Dashboard Butler 実機 E2E は未実施です。
- Manual: local runtime unit/integration verification のみ。production runtime truth は merge/deploy 後に確認します。
- Evidence path/link: `docs/development-strategy/issue-590-context-window-reset.md`

## Butler Completion Contract

- Primary owner surface: Dashboard Butler。
- Fallback surface: Custom GPT は fallback surface として扱います。主経路ではありません。
- Owner goal: Dashboard Butler が既存 backend app-server thread の context window exceeded で止まり続けず、同じ Dashboard thread のまま fresh backend に復旧する。
- Butler entrypoint: Dashboard Butler 通常チャット。owner は `もしもし` など通常の自然文を送るだけです。
- Dashboard Butler natural-language path: Dashboard Butler の通常チャット入口から自然文入力を受け、app-server bridge 経路に接続し、failure recovery event により Worker が自動復旧します。
- Action Schema exposure: Custom GPT Action Schema は未変更です。この PR は Dashboard runtime path の修正です。
- Runtime path: DashboardChatRoom WebSocket owner turn -> app-server bridge -> context exceeded failure event -> Worker mapping clear -> `app_server_turn_requested` with `codexThreadId=null`。
- Runner/runtime truth: unit tests で bridge metadata、Worker mapping clear、fresh `thread/start` dispatch、no-loop を確認しました。production runtime truth は deploy 後に確認します。
- Authority boundary: 新しい high-risk authority は追加しません。deploy は従来通り scoped passkey approval が必要です。
- E2E evidence: production deploy 後の iPad Dashboard Butler 実機 E2E は未実施です。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: merge 後に production deploy が必要です。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 必要。deploy 後に同じ Dashboard thread で `もしもし` を確認します。

## Related Constitution Rules

- Butler-first completion gate。
- Drift Stop Protocol。
- 開発前作戦図 Gate。
- Evidence Discipline。
- Current Reality Guard。

## Out-of-scope but NOT implemented

- Issue #590 全体の完了宣言。
- live progress の lane separation。
- deploy 後 bridge restart automation。
- passkey/operator URL 自動提示の追加変更。

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #590
- Execution ID: issue-590-context-window-reset
- Goal: Dashboard Butler app-server context window exceeded recovery
