### PR TITLE
Issue #455 fallback unsupported app-server model

### DIFF
--- a/docs/development-strategy/issue-455-app-server-unsupported-model-fallback.md
+++ b/docs/development-strategy/issue-455-app-server-unsupported-model-fallback.md
@@ -1,0 +1,74 @@
+# Issue #455 app-server unsupported model fallback 作戦図
+
+## 完了体験
+
+Dashboard Butler は VPS app-server bridge が `gpt-5.3-codex` など ChatGPT account 非対応 model を指定して 400 を受けても、owner に「内容を短くして再送」とだけ返して止まらない。bridge は unsupported model を runtime failure として分類し、同じ owner turn を model override なしの `codex app-server` client に一度だけ fallback して届ける。
+
+owner は iPhone/iPad の Dashboard Butler 通常チャットから同じ入力を送り直す必要がなく、repo 固定 model 名や VPS env の誤設定が通常会話を完全停止させない。
+
+## VTDD 全体で進める部分
+
+Issue #455 の content-aware cost / model tuning の安全境界を進める。既存作戦図は「model 名を repo 固定すると operator account 差異で壊れる」と明記しているが、runtime では unsupported model failure が owner-facing dead end になっていた。今回は model override の足場を残しつつ、ChatGPT account 非対応 model の場合だけ default Codex config へ退避する。
+
+## 設計
+
+`scripts/run-dashboard-app-server-bridge.mjs` に unsupported model classifier を追加する。`connectDashboardAppServerBridgeOnce` が `handleDashboardTurnRequest` で例外を受け、選択された client/costBoundary に model が設定されており、error が ChatGPT account unsupported model なら、selector の `withoutModel()` で model override なしの app-server client を取得し、同じ payload を一度だけ再実行する。
+
+fallback 時は `app_server_status` を transient に出し、`costBoundary` には `unsupportedModelFallback` と rejected model を入れる。fallback も失敗した場合は既存 failure path に落とす。`APP_SERVER_FAILURE_ALREADY_SENT` の場合は二重送信しない。
+
+## 仮説
+
+production の失敗原因は、VPS bridge または request profile が `-c model="gpt-5.3-codex"` を渡し、Codex app-server が ChatGPT account では非対応として 400 を返していること。reasoning effort だけなら account model 非対応 error は起きないはずなので、model override を外して default app-server に退避すれば通常会話は復旧する。
+
+## 検証計画
+
+- Unit: unsupported ChatGPT account model error classifier が JSON 文字列 / Error message を検出する。
+- Unit: selector の model-less fallback が defaultModel を無視し、reasoning effort は維持する。
+- Integration: `connectDashboardAppServerBridgeOnce` が unsupported model failure 後に model-less client で同じ turn を一度だけ retry する。
+- Local: `node --test test/dashboard-app-server-bridge.test.js`
+- Local: `git diff --check`
+
+## 改修見積もり
+
+- `scripts/run-dashboard-app-server-bridge.mjs`: unsupported model classifier、selector `withoutModel`、connect retry flow。risk は retry の二重実行と defaultModel の再混入。
+- `test/dashboard-app-server-bridge.test.js`: classifier / selector / retry integration tests。risk は mock app-server の error shape 不足。
+- `docs/development-strategy/issue-455-app-server-unsupported-model-fallback.md`: この作戦図。risk なし。
+
+## 既に通っている経路
+
+DashboardChatRoom は全 owner turn を app-server bridge に送る。Issue #455 の classifier は model を既定では固定せず、reasoning effort を content-aware にする。bridge selector は profile ごとに app-server client を lazy cache できる。
+
+## 未確認の境界
+
+OpenAI / Codex の account 別 supported model 一覧は runtime error を truth とする。repo は「どの model が使えるか」を断定しない。production env に実際にどの値が入っているかは VPS runtime truth で別途確認する。
+
+## 穴が出そうな箇所
+
+- fallback request が defaultModel を再適用して同じ unsupported model を呼ぶこと。
+- unsupported model 以外の auth/quota/network failure まで fallback して原因を隠すこと。
+- fallback 失敗時に failure message が二重に出ること。
+- selector cache key が model 有無を区別できず unsupported client を再利用すること。
+
+## PR 前に確認すること
+
+latest `origin/main` から branch を切る。open PR 0 を確認する。targeted tests と `git diff --check` を通す。未追跡 E2E assets を stage しない。
+
+## 実装候補と捨てた案
+
+採用: unsupported model の時だけ model override なし client に one-shot fallback する。
+
+捨てた案: repo で `gpt-5.3-codex-spark` など別 model 名へ固定する。account / plan 差異で同じ問題が再発するため不採用。
+
+捨てた案: production env だけを消す。即時回避にはなるが、次の誤設定でまた Butler が止まるため repo 側 guard が必要。
+
+## merge 後に通す E2E
+
+production deploy と bridge restart 後、Dashboard Butler で短い通常会話を送る。期待値は unsupported model 400 が出ず、model-less fallback または default app-server で返答が返ること。runtime truth に fallback status が出る場合は rejected model が短く示され、token/secret は出ないこと。
+
+## 次の PR を増やさない理由
+
+model unsupported の分類、model-less selector、turn retry は同じ復旧機能の一塊。分類だけ、または selector だけで分けると owner-facing failure が残る。
+
+## 停止条件
+
+fallback に credential / permission / deploy / root helper mutation が必要になる場合。unsupported model 以外の課金・quota・auth policy へ広がる場合。対応 model 名を repo で断定しそうになる場合。

--- a/scripts/run-dashboard-app-server-bridge.mjs
+++ b/scripts/run-dashboard-app-server-bridge.mjs
@@ -138,10 +138,11 @@ export function buildDashboardAppServerUsageProfileCommandConfig({
   usageProfile = null,
   defaultProfile = "",
   defaultModel = "",
-  defaultReasoningEffort = ""
+  defaultReasoningEffort = "",
+  ignoreDefaultModel = false
 } = {}) {
   const normalizedUsageProfile = normalizeDashboardAppServerUsageProfile(usageProfile || defaultProfile || "conversation");
-  const model = normalizeBridgeText(normalizedUsageProfile.model || defaultModel);
+  const model = normalizeBridgeText(normalizedUsageProfile.model || (ignoreDefaultModel ? "" : defaultModel));
   const reasoningEffort = normalizeBridgeText(normalizedUsageProfile.reasoningEffort || defaultReasoningEffort);
   const profile = normalizeBridgeText(normalizedUsageProfile.profile || defaultProfile) || "conversation";
   return {
@@ -179,6 +180,21 @@ export function buildDashboardAppServerCommandArgs({
     args.push("-c", `model_reasoning_effort=${JSON.stringify(normalizedReasoningEffort)}`);
   }
   return args;
+}
+
+export function isDashboardAppServerUnsupportedChatGptAccountModelError(errorLike = null) {
+  const text = normalizeBridgeText(
+    typeof errorLike === "string"
+      ? errorLike
+      : errorLike?.message || errorLike?.error?.message || JSON.stringify(errorLike || "")
+  );
+  return /model is not supported when using Codex with a ChatGPT account/i.test(text);
+}
+
+export function stripDashboardAppServerModelFromUsageProfile(usageProfile = null) {
+  const normalized = normalizeDashboardAppServerUsageProfile(usageProfile || "conversation");
+  const { model: _model, ...withoutModel } = normalized;
+  return withoutModel;
 }
 
 export function buildDashboardTurnInputText(request = {}) {
@@ -2005,13 +2021,24 @@ export function createDashboardAppServerClientSelector({
   defaultReasoningEffort = ""
 } = {}) {
   const clients = new Map();
-  return async function selectAppServerForRequest(request = {}) {
+  async function selectAppServerForRequestWithOptions(request = {}, { ignoreDefaultModel = false, rejectedModel = "" } = {}) {
+    const usageProfile = ignoreDefaultModel
+      ? stripDashboardAppServerModelFromUsageProfile(request.usageProfile || defaultProfile || "conversation")
+      : request.usageProfile;
     const config = buildDashboardAppServerUsageProfileCommandConfig({
-      usageProfile: request.usageProfile,
+      usageProfile,
       defaultProfile,
       defaultModel,
-      defaultReasoningEffort
+      defaultReasoningEffort,
+      ignoreDefaultModel
     });
+    if (ignoreDefaultModel && normalizeBridgeText(rejectedModel)) {
+      config.costBoundary = {
+        ...config.costBoundary,
+        unsupportedModelFallback: true,
+        rejectedModel: normalizeBridgeText(rejectedModel)
+      };
+    }
     if (staticAppServer || !request.usageProfile) {
       return {
         appServer: defaultAppServer,
@@ -2031,7 +2058,14 @@ export function createDashboardAppServerClientSelector({
       appServer: clients.get(key),
       ...config
     };
-  };
+  }
+  const selector = (request = {}) => selectAppServerForRequestWithOptions(request);
+  selector.withoutModel = (request = {}, options = {}) =>
+    selectAppServerForRequestWithOptions(request, {
+      ...options,
+      ignoreDefaultModel: true
+    });
+  return selector;
 }
 
 export function buildDashboardAppServerBridgeEndpoint(options = {}) {
@@ -2432,21 +2466,50 @@ export async function connectDashboardAppServerBridgeOnce({
             typeof selectAppServerForRequest === "function"
               ? await selectAppServerForRequest(payload)
               : { appServer, usageProfile: payload.usageProfile || null, costBoundary: payload.costBoundary || null };
-          return handleDashboardTurnRequest({
-            request: payload,
-            appServer: selected.appServer || appServer,
-            usageProfile: selected.usageProfile || payload.usageProfile || null,
-            costBoundary: selected.costBoundary || payload.costBoundary || null,
-            sendDashboardEvent: async (dashboardEvent) => safeSend(dashboardEvent),
-            cwd,
-            sandboxMode,
-            turnTimeoutMs,
-            activityQuietMs,
-            runtimeUrl,
-            token,
-            fetchImpl,
-            mediaTmpRoot
-          });
+          const runSelectedTurn = (turnSelection) =>
+            handleDashboardTurnRequest({
+              request: payload,
+              appServer: turnSelection.appServer || appServer,
+              usageProfile: turnSelection.usageProfile || payload.usageProfile || null,
+              costBoundary: turnSelection.costBoundary || payload.costBoundary || null,
+              sendDashboardEvent: async (dashboardEvent) => safeSend(dashboardEvent),
+              cwd,
+              sandboxMode,
+              turnTimeoutMs,
+              activityQuietMs,
+              runtimeUrl,
+              token,
+              fetchImpl,
+              mediaTmpRoot
+            });
+          try {
+            return await runSelectedTurn(selected);
+          } catch (error) {
+            if (
+              !isAppServerFailureAlreadySent(error) &&
+              isDashboardAppServerUnsupportedChatGptAccountModelError(error) &&
+              selected?.costBoundary?.modelConfigured === true &&
+              typeof selectAppServerForRequest?.withoutModel === "function"
+            ) {
+              const fallbackSelected = await selectAppServerForRequest.withoutModel(payload, {
+                rejectedModel: selected.usageProfile?.model || selected.costBoundary?.model || payload.usageProfile?.model || ""
+              });
+              safeSend({
+                type: "app_server_status",
+                schema: DEFAULT_SCHEMA,
+                threadId: payload.threadId,
+                codexThreadId: payload.codexThreadId || null,
+                status: "unsupported_model_fallback",
+                stage: "runtime_recovery",
+                text: "指定 model が ChatGPT account で非対応のため、model override なしで app-server に再送しています。",
+                persistProgress: true,
+                usageProfile: fallbackSelected.usageProfile || null,
+                costBoundary: fallbackSelected.costBoundary || null
+              });
+              return await runSelectedTurn(fallbackSelected);
+            }
+            throw error;
+          }
         })
         .catch((error) => {
           if (isAppServerFailureAlreadySent(error)) {

--- a/test/dashboard-app-server-bridge.test.js
+++ b/test/dashboard-app-server-bridge.test.js
@@ -34,6 +34,7 @@ import {
   formatDashboardMediaReferenceLines,
   handleDashboardTurnRequest,
   isAppServerActivityNotification,
+  isDashboardAppServerUnsupportedChatGptAccountModelError,
   JsonLineAppServerClient,
   mapAppServerNotificationToDashboardEvent,
   matchesAppServerTurnNotification,
@@ -42,7 +43,8 @@ import {
   parseDashboardDebugSlowTurnRequest,
   postOwnerActionRequiredEvent,
   runDashboardAppServerBridge,
-  runDashboardDebugSlowTurn
+  runDashboardDebugSlowTurn,
+  stripDashboardAppServerModelFromUsageProfile
 } from "../scripts/run-dashboard-app-server-bridge.mjs";
 
 test("dashboard app-server bridge builds initialize and thread requests from Codex app-server protocol", () => {
@@ -208,6 +210,46 @@ test("dashboard app-server bridge builds optional app-server usage tuning args",
       reasoningEffort: "low"
     }
   );
+});
+
+test("dashboard app-server bridge detects ChatGPT account unsupported model errors", () => {
+  assert.equal(
+    isDashboardAppServerUnsupportedChatGptAccountModelError(
+      `{"type":"error","status":400,"error":{"type":"invalid_request_error","message":"The 'gpt-5.3-codex' model is not supported when using Codex with a ChatGPT account."}}`
+    ),
+    true
+  );
+  assert.equal(
+    isDashboardAppServerUnsupportedChatGptAccountModelError(
+      new Error("The 'gpt-5.3-codex' model is not supported when using Codex with a ChatGPT account.")
+    ),
+    true
+  );
+  assert.equal(isDashboardAppServerUnsupportedChatGptAccountModelError(new Error("network timeout")), false);
+});
+
+test("dashboard app-server bridge can strip model override while preserving usage profile", () => {
+  const stripped = stripDashboardAppServerModelFromUsageProfile({
+    profile: "development",
+    reasoningEffort: "medium",
+    model: "gpt-5.3-codex",
+    reason: "implementation_or_repository_work"
+  });
+  assert.deepEqual(stripped, {
+    profile: "development",
+    reasoningEffort: "medium",
+    selectedBy: "content",
+    reason: "implementation_or_repository_work"
+  });
+
+  const config = buildDashboardAppServerUsageProfileCommandConfig({
+    usageProfile: stripped,
+    defaultModel: "gpt-5.3-codex",
+    ignoreDefaultModel: true
+  });
+  assert.deepEqual(config.args, ["app-server", "--listen", "stdio://", "-c", 'model_reasoning_effort="medium"']);
+  assert.equal(config.costBoundary.modelConfigured, false);
+  assert.equal(config.costBoundary.reasoningEffortConfigured, true);
 });
 
 test("dashboard app-server usage profile classifier separates conversation, read, development, and long development", () => {
@@ -2572,6 +2614,151 @@ test("dashboard app-server bridge sends one Japanese failure for app-server erro
   await once;
 });
 
+test("dashboard app-server bridge retries unsupported ChatGPT account model without model override", async () => {
+  const sockets = [];
+  const created = [];
+  class MockWebSocket {
+    constructor(endpoint, protocols) {
+      this.endpoint = endpoint;
+      this.protocols = protocols;
+      this.listeners = new Map();
+      this.sent = [];
+      sockets.push(this);
+    }
+
+    addEventListener(type, handler) {
+      if (!this.listeners.has(type)) {
+        this.listeners.set(type, new Set());
+      }
+      this.listeners.get(type).add(handler);
+    }
+
+    send(payload) {
+      this.sent.push(payload);
+    }
+
+    emit(type, event = {}) {
+      for (const handler of this.listeners.get(type) || []) {
+        handler(event);
+      }
+    }
+  }
+  const appServerFactory = (options) => {
+    const handlers = new Set();
+    const clientIndex = created.length;
+    const client = {
+      args: options.args,
+      nextId: 1,
+      async initialize() {},
+      nextRequestId() {
+        return this.nextId++;
+      },
+      onNotification(handler) {
+        handlers.add(handler);
+        return () => handlers.delete(handler);
+      },
+      drainApprovalRequests() {
+        return Promise.resolve();
+      },
+      async request(message) {
+        if (message.method === "thread/start") {
+          return { thread: { id: `codex-thread-fallback-${clientIndex}` } };
+        }
+        if (message.method === "turn/start" && options.args.includes('model="gpt-5.3-codex"')) {
+          throw new Error(
+            `{"type":"error","status":400,"error":{"type":"invalid_request_error","message":"The 'gpt-5.3-codex' model is not supported when using Codex with a ChatGPT account."}}`
+          );
+        }
+        if (message.method === "turn/start") {
+          setTimeout(() => {
+            for (const handler of handlers) {
+              handler({
+                method: "item/agentMessage/delta",
+                params: {
+                  threadId: `codex-thread-fallback-${clientIndex}`,
+                  turnId: "turn-fallback",
+                  delta: "復旧しました。"
+                }
+              });
+              handler({
+                method: "turn/completed",
+                params: {
+                  threadId: `codex-thread-fallback-${clientIndex}`,
+                  turn: { id: "turn-fallback", status: "completed" }
+                }
+              });
+            }
+          }, 0);
+          return { turn: { id: "turn-fallback" } };
+        }
+        throw new Error(`unexpected method ${message.method}`);
+      }
+    };
+    created.push(client);
+    return client;
+  };
+  const defaultAppServer = {
+    async initialize() {},
+    nextRequestId() {
+      return 1;
+    },
+    onNotification() {
+      return () => {};
+    },
+    drainApprovalRequests() {
+      return Promise.resolve();
+    }
+  };
+  const selector = createDashboardAppServerClientSelector({
+    defaultAppServer,
+    appServerFactory,
+    cwd: "/repo",
+    defaultModel: "gpt-5.3-codex"
+  });
+
+  const once = connectDashboardAppServerBridgeOnce({
+    endpoint: new URL("wss://runtime.example/v2/dashboard/app-server/ws?threadId=dashboard-main"),
+    token: "secret-token",
+    appServer: defaultAppServer,
+    selectAppServerForRequest: selector,
+    WebSocketImpl: MockWebSocket,
+    turnTimeoutMs: 1000,
+    liveProgressInitialDelayMs: 1000
+  });
+  const socket = sockets[0];
+  socket.emit("message", {
+    data: JSON.stringify({
+      type: "app_server_turn_requested",
+      threadId: "dashboard-main",
+      text: "もしもし。",
+      usageProfile: {
+        profile: "conversation",
+        reasoningEffort: "low",
+        model: "gpt-5.3-codex",
+        reason: "ordinary_conversation"
+      }
+    })
+  });
+
+  await waitFor(() => socket.sent.map((payload) => JSON.parse(payload)).some((payload) => payload.type === "app_server_reply"));
+  const parsed = socket.sent.map((payload) => JSON.parse(payload));
+  const fallbackStatus = parsed.find((payload) => payload.status === "unsupported_model_fallback");
+  assert.ok(fallbackStatus);
+  assert.equal(fallbackStatus.costBoundary.modelConfigured, false);
+  assert.equal(fallbackStatus.costBoundary.unsupportedModelFallback, true);
+  assert.equal(fallbackStatus.costBoundary.rejectedModel, "gpt-5.3-codex");
+  const failures = parsed.filter((payload) => payload.type === "app_server_turn_failed");
+  assert.equal(failures.length, 0);
+  const reply = parsed.find((payload) => payload.type === "app_server_reply");
+  assert.equal(reply.text, "復旧しました。");
+  assert.deepEqual(created.map((client) => client.args), [
+    ["app-server", "--listen", "stdio://", "-c", 'model="gpt-5.3-codex"', "-c", 'model_reasoning_effort="low"'],
+    ["app-server", "--listen", "stdio://", "-c", 'model_reasoning_effort="low"']
+  ]);
+  socket.emit("close");
+  await once;
+});
+
 test("dashboard app-server bridge args require a dashboard thread id for runtime connection", () => {
   const parsed = parseBridgeArgs([], {
     VTDD_RUNTIME_URL: "https://runtime.example",
@@ -2758,6 +2945,53 @@ test("dashboard app-server bridge selects app-server client by content-aware usa
   assert.deepEqual(created[1].args, ["app-server", "--listen", "stdio://", "-c", 'model_reasoning_effort="medium"']);
   assert.equal(conversation.costBoundary.profile, "conversation");
   assert.equal(development.costBoundary.profile, "development");
+});
+
+test("dashboard app-server bridge selector creates model-less fallback client", async () => {
+  const created = [];
+  const selector = createDashboardAppServerClientSelector({
+    defaultAppServer: { id: "default" },
+    defaultModel: "gpt-5.3-codex",
+    appServerFactory(options) {
+      const client = {
+        id: `client-${created.length + 1}`,
+        async initialize() {}
+      };
+      created.push({ ...options, client });
+      return client;
+    },
+    cwd: "/repo"
+  });
+
+  const selected = await selector({
+    usageProfile: {
+      profile: "conversation",
+      reasoningEffort: "low",
+      model: "gpt-5.3-codex",
+      reason: "ordinary_conversation"
+    }
+  });
+  const fallback = await selector.withoutModel(
+    {
+      usageProfile: selected.usageProfile
+    },
+    { rejectedModel: selected.usageProfile.model }
+  );
+
+  assert.equal(created.length, 2);
+  assert.deepEqual(created[0].args, [
+    "app-server",
+    "--listen",
+    "stdio://",
+    "-c",
+    'model="gpt-5.3-codex"',
+    "-c",
+    'model_reasoning_effort="low"'
+  ]);
+  assert.deepEqual(created[1].args, ["app-server", "--listen", "stdio://", "-c", 'model_reasoning_effort="low"']);
+  assert.equal(fallback.costBoundary.modelConfigured, false);
+  assert.equal(fallback.costBoundary.unsupportedModelFallback, true);
+  assert.equal(fallback.costBoundary.rejectedModel, "gpt-5.3-codex");
 });
 
 test("dashboard app-server bridge repo sync preflight allows clean in-sync main with known artifacts", async () => {


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #455 の app-server usage/model tuning safety follow-up です。
- Dashboard app-server bridge が ChatGPT account 非対応 model `gpt-5.3-codex` を指定して 400 を受けた時、owner-facing chat を generic failure で止めず、model override なしの app-server client へ一度だけ fallback します。
- repo は対応 model 名を断定せず、runtime error で非対応と判明した override だけを外します。

## Satisfied Success Criteria

- unsupported ChatGPT account model error を bridge が分類できます。
- selector が `withoutModel()` fallback client を作り、env/default model を再混入させません。
- fallback では reasoning effort/profile は維持し、model override だけを外します。
- WebSocket turn integration で、最初の model client が 400 を返しても同じ turn が model-less client で成功します。
- fallback 状態は `app_server_status` と `costBoundary.unsupportedModelFallback` に出ます。

## Unsatisfied Success Criteria

- production deploy 後の Dashboard Butler 実機 E2E は未実施です。
- Issue #455 全体の Codex Analytics 実測比較と usage 削減量の断定はこの PR では行いません。

## Non-goal violations

None.

## 開発前作戦図

- 作戦図 evidence: docs/development-strategy/issue-455-app-server-unsupported-model-fallback.md
- 完了体験: Dashboard Butler は VPS app-server bridge が ChatGPT account 非対応 model を指定して 400 を受けても、owner に再送を強いず、model override なしの app-server client へ同じ turn を一度だけ届ける。
- VTDD 全体で進める部分: Issue #455 の content-aware cost / model tuning safety boundary。model 名を repo 固定すると account 差異で壊れるという既存設計を runtime recovery として実装する。
- 設計: owner-facing surface は Dashboard Butler 通常チャット。bridge は unsupported model error を分類し、selector の `withoutModel()` で defaultModel を無視した app-server client を作り、同じ payload を一度だけ retry する。
- 仮説: production の失敗原因は `-c model="gpt-5.3-codex"` が ChatGPT account で非対応なこと。model override を外して default Codex config に退避すれば通常会話は復旧する。
- 検証計画: unsupported classifier unit、model stripping unit、selector fallback unit、WebSocket turn integration、`npm test`、`git diff --check`。
- 改修見積もり: scripts/run-dashboard-app-server-bridge.mjs の classifier/selector/retry、test/dashboard-app-server-bridge.test.js の unit/integration tests、作戦図 docs。
- 既に通っている経路: DashboardChatRoom は owner turn を app-server bridge に送る。Issue #455 classifier は reasoning effort を content-aware にし、model は既定では固定しない。
- 未確認の境界: OpenAI / Codex の account 別 supported model 一覧は runtime error を truth とする。repo は対応 model を断定しない。
- 穴が出そうな箇所: fallback が defaultModel を再適用すること、unsupported model 以外を隠すこと、failure message が二重に出ること、selector cache が unsupported client を再利用すること。
- PR 前に確認すること: latest origin/main branch、open PR 0、targeted test、full npm test、git diff --check、未追跡 E2E assets を stage しないこと。
- 実装候補と捨てた案: 採用は unsupported model の時だけ model override なし one-shot fallback。捨てた案は別 model 名への repo 固定と production env だけの手動削除。
- merge 後に通す E2E: production Dashboard Butler E2E test として短い通常会話を送り、unsupported model 400 が出ず、fallback または default app-server で返答が返ることを確認する。
- 次の PR を増やさない理由: unsupported 分類、model-less selector、turn retry は同じ復旧機能の一塊であり、分けると owner-facing failure が残る。
- 停止条件: fallback に credential / permission / deploy / root helper mutation が必要になる、unsupported model 以外の課金・quota・auth policy へ広がる、対応 model 名を repo で断定しそうになる場合。

## Dry-run Impact Report

- Target Issue: Issue #455
- Implementing Success Criteria: ChatGPT account unsupported model 400 を model-less fallback で復旧し、Dashboard Butler 通常チャットを止めない。
- Explicit Non-goals: supported model 名の断定、production env/secret mutation、Worker AI fast path 復活、deploy automation 変更、Issue #455 全体完了宣言。
- Expected touched files/routes/workflows: scripts/run-dashboard-app-server-bridge.mjs、test/dashboard-app-server-bridge.test.js、docs/development-strategy/issue-455-app-server-unsupported-model-fallback.md。
- Affected Issues: Issue #455。Issue #590 の context reset は前 PR で処理済みで、この PR では触りません。
- Affected PRs: PR #786 の deploy 後に surfaced した runtime error への follow-up。open PR は 0 件。
- Affected workflows: test / review / guarded-policy / auto-merge workflow。workflow 定義は未変更です。
- Affected runtime/operator surfaces: Dashboard app-server bridge process、Dashboard Butler transient status。Worker routes、passkey operator、Custom GPT Action Schema は未変更です。
- What may break if we patch narrowly: env を消すだけだと次の unsupported model 設定で再発する。別 model に固定すると account 差異でまた壊れる。
- Unknowns to investigate before coding: actual production supported model list は未確認。runtime error が source of truth なので repo は model 名を断定しません。
- Validation needed: bridge unit/integration tests、full npm test、git diff --check、merge/deploy 後の production Dashboard Butler E2E。
- Stop condition: unsupported model 以外の auth/quota/billing failure へ広げる必要が出た場合は停止します。

## Execution Queue Delta

- Queue position before: Issue #455 の content-aware app-server usage tuning follow-up。Dashboard Butler が unsupported model 400 で止まる ROOT blocker。
- Preemption decision: ROOT。Dashboard Butler の通常会話が止まっているため、Issue #455 の safety boundary として先に塞ぎます。
- Queue delta: Issue #455 の app-server model unsupported recovery を進めます。Active Issues は縮小しません。
- Why this PR is next: #786 で context window recovery を入れた後、次の実 failure は unsupported model 400 だったため、Butler を使える状態に戻すには model fallback が必要です。
- Active Issues not downscoped: Active Issues は縮小しません。この PR で扱わない Issue #455 の usage analytics 実測や他 active Issues は未完了として残します。

## File / Line Hypotheses

- file: scripts/run-dashboard-app-server-bridge.mjs
  - hypothesis: unsupported model 400 は bridge turn handling の例外として generic failure に落ちている。
  - risk if changed narrowly: selector が env defaultModel を再適用すると同じ 400 を繰り返す。
  - validation: node --test test/dashboard-app-server-bridge.test.js
  - related Issue: #455
- file: test/dashboard-app-server-bridge.test.js
  - hypothesis: selector / connect integration の両方を固定しないと、unit だけ通って runtime retry が抜ける。
  - risk if changed narrowly: unsupported model classifier だけで owner-facing recovery が残らない。
  - validation: node --test test/dashboard-app-server-bridge.test.js、npm test
  - related Issue: #455

## Hypothesis Retrospective

- expected: `gpt-5.3-codex` は ChatGPT account の Codex app-server では unsupported になり得る。
- actual: owner-facing error に `The 'gpt-5.3-codex' model is not supported when using Codex with a ChatGPT account.` が出た。
- mismatch: 既存設計は model 固定リスクを認識していたが、runtime fallback がなく generic failure になっていた。
- lesson: usage tuning は model 名の正解を決める機能ではなく、unsupported と判明した override を退避できる安全境界が必要。
- should become RAG candidate: はい。Dashboard app-server bridge は ChatGPT account unsupported model 400 を受けたら model override なしで one-shot fallback する、という判断を記録する価値があります。

## Verification Evidence

- Unit: node --test test/dashboard-app-server-bridge.test.js pass。
- Integration: npm test pass。check:self-parity pass。check:generated-worker pass。
- E2E: production deploy 後の Dashboard Butler 実機 E2E は未実施です。
- Manual: git diff --check pass。
- Evidence path/link: docs/development-strategy/issue-455-app-server-unsupported-model-fallback.md

## Butler Completion Contract

- Primary owner surface: Dashboard Butler。
- Fallback surface: Custom GPT は fallback surface として扱います。主経路ではありません。
- Owner goal: Dashboard Butler が unsupported model 400 で止まらず、model override なしで app-server に同じ turn を届け直す。
- Butler entrypoint: Dashboard Butler 通常チャット。
- Dashboard Butler natural-language path: Dashboard Butler の通常チャット入口から自然文入力を受け、app-server bridge 経路に接続し、unsupported model failure の時だけ model-less fallback に到達します。
- Action Schema exposure: Custom GPT Action Schema は未変更です。この PR は Dashboard app-server bridge runtime path の修正です。
- Runtime path: DashboardChatRoom owner turn -> app-server bridge selected model client -> unsupported model error -> selector.withoutModel -> same turn retry -> app-server reply。
- Runner/runtime truth: local bridge tests と npm test で retry path を確認済み。production runtime truth は deploy 後に確認します。
- Authority boundary: 新しい high-risk authority は追加しません。production deploy は従来通り scoped passkey approval が必要です。
- E2E evidence: production deploy 後の Dashboard Butler 実機 E2E は未実施です。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: merge 後に production deploy が必要です。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 必要。deploy 後に通常チャットで unsupported model 400 が消えることを確認します。

## Related Constitution Rules

- Butler Completion Gate。
- Drift Stop Protocol。
- 開発前作戦図 Gate。
- Evidence Discipline。
- Current Reality Guard。

## Out-of-scope but NOT implemented

- supported model 名の repo 固定。
- production secret / variable mutation。
- Worker AI fast path。
- Issue #455 全体の usage analytics 実測比較完了。

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #455
- Execution ID: issue-455-app-server-unsupported-model-fallback
- Goal: Dashboard app-server unsupported model fallback
