### PR TITLE
Issue #455 unsupported app-server model fallback を完了させる

### DIFF
--- a/docs/development-strategy/issue-455-unsupported-model-fallback-complete.md
+++ b/docs/development-strategy/issue-455-unsupported-model-fallback-complete.md
@@ -1,0 +1,76 @@
+# Issue #455 unsupported model fallback completion 作戦図
+
+## 完了体験
+
+Dashboard Butler が短い通常会話で `gpt-5.3-codex` unsupported 400 を受けても、owner には同じ失敗を返し続けない。VPS app-server bridge は error が thrown exception でも app-server `error` notification でも unsupported model として扱い、usageProfile が無い turn でも model override なしの新しい app-server client に一度だけ退避する。
+
+## VTDD 全体で進める部分
+
+Issue #455 の app-server usage/model tuning safety を完成させる。PR #787 は unsupported model fallback の第一実装だったが、`request.usageProfile` が無い経路と notification failure 経路で fallback が抜けていた。今回は owner-facing recovery として穴を塞ぐ。
+
+## 設計
+
+`createDashboardAppServerClientSelector().withoutModel()` は、`request.usageProfile` が無い場合でも default appServer を返さず、model-less config の client を factory から作る。static appServer が明示された test/embedding 経路だけは既存 appServer を返す。
+
+`handleDashboardTurnRequest` は `app_server_turn_failed` event が unsupported model で、turn costBoundary に modelConfigured がある場合、failure message を送信せずに retry 用 error を reject する。outer `connectDashboardAppServerBridgeOnce` が既存 fallback path で model-less retry を行う。fallback は `modelConfigured=false` なので、fallback 自体が失敗した時は二度目の retry をせず既存 generic failure を送る。
+
+unsupported model 判定は raw stringify 全体ではなく、JSON error payload の `message` / `error.message` / `cause` を優先して抽出する。判定範囲は ChatGPT account での Codex model unsupported に限定し、network / quota / auth failure を retry しない。
+
+## 仮説
+
+production で同じ unsupported model error が続く原因は、PR #787 の fallback が usageProfile 無し/default appServer 経路で同じ model-configured client を再利用しているか、unsupported model が notification event として先に failure sent になり fallback まで届いていないこと。
+
+## 検証計画
+
+- Unit: selector.withoutModel は usageProfile 無しでも model-less client を作る。
+- Integration: thrown unsupported model error を model-less fallback で復旧する。
+- Integration: app-server error notification の unsupported model を failure として送らず、model-less fallback で復旧する。
+- Integration: model-less fallback も失敗した場合、二度目の fallback に入らず generic failure 1件で終わる。
+- Local: `node --test test/dashboard-app-server-bridge.test.js`
+- Local: `git diff --check`
+- Local: `npm test`
+
+## 改修見積もり
+
+- `scripts/run-dashboard-app-server-bridge.mjs`: selector fallback の static/default 分岐、notification failure の retry handoff、構造化 error message 抽出。risk は通常 failure を隠すこと。
+- `test/dashboard-app-server-bridge.test.js`: usageProfile 無し fallback と notification fallback tests。risk は mock が実 app-server event とズレること。
+- `docs/development-strategy/issue-455-unsupported-model-fallback-complete.md`: この作戦図。risk なし。
+
+## 既に通っている経路
+
+PR #787 で unsupported classifier、model stripping、thrown error fallback の基本形は入っている。production deploy と bridge sync/restart は `b761910c` で完了済みだが、owner-facing error は変わっていない。
+
+## 未確認の境界
+
+production app-server が unsupported model を throw と notification のどちらで出すかは状況依存。両方を扱う。supported model 名は未確認であり、repo では断定しない。
+
+## 穴が出そうな箇所
+
+- fallback が default appServer を返して同じ model override を使い続ける。
+- notification failure が `APP_SERVER_FAILURE_ALREADY_SENT` になり outer fallback を止める。
+- unsupported model 以外の failure まで retry して root cause を隠す。
+- fallback が無限ループする。
+
+## PR 前に確認すること
+
+latest origin/main branch、open PR 0、targeted tests、npm test、git diff --check、未追跡 E2E assets を stage しないこと。
+
+## 実装候補と捨てた案
+
+採用: selector fallback と notification fallback handoff を同じ PR で直す。
+
+捨てた案: VPS env だけ消す。repo 側に同じ穴が残るため不採用。
+
+捨てた案: supported model を repo 固定する。account 差異で再発するため不採用。
+
+## merge 後に通す E2E
+
+production deploy と bridge restart 後、Dashboard Butler で「君は誰？」または「もしもし」を送り、unsupported model 400 が返らず reply が返ること。bridge status に unsupported_model_fallback が出てもよいが、generic failure のみで止まってはいけない。
+
+## 次の PR を増やさない理由
+
+PR #787 の抜けは selector と notification path の組み合わせであり、どちらかだけでは production failure が残る。owner-facing recovery を完成させるには同じ PR で塞ぐ必要がある。
+
+## 停止条件
+
+credential / permission / deploy / root helper mutation が必要になる場合。unsupported model 以外の auth/quota/network policy へ広がる場合。

--- a/scripts/run-dashboard-app-server-bridge.mjs
+++ b/scripts/run-dashboard-app-server-bridge.mjs
@@ -182,13 +182,55 @@ export function buildDashboardAppServerCommandArgs({
   return args;
 }
 
+function parseDashboardAppServerErrorPayload(value) {
+  if (!value || typeof value !== "string") {
+    return value;
+  }
+  const text = normalizeBridgeText(value);
+  if (!text || !/^[{[]/.test(text)) {
+    return value;
+  }
+  try {
+    return JSON.parse(text);
+  } catch {
+    return value;
+  }
+}
+
+function collectDashboardAppServerErrorMessages(value, seen = new Set()) {
+  const parsed = parseDashboardAppServerErrorPayload(value);
+  if (!parsed || seen.has(parsed)) {
+    return [];
+  }
+  if (typeof parsed === "object") {
+    seen.add(parsed);
+  }
+  if (typeof parsed === "string") {
+    return [parsed];
+  }
+  if (parsed instanceof Error) {
+    return [parsed.message, ...collectDashboardAppServerErrorMessages(parsed.cause, seen)];
+  }
+  if (typeof parsed !== "object") {
+    return [];
+  }
+  const messages = [];
+  for (const key of ["message", "reason", "detail", "text"]) {
+    if (typeof parsed[key] === "string") {
+      messages.push(parsed[key]);
+    }
+  }
+  for (const key of ["error", "cause"]) {
+    messages.push(...collectDashboardAppServerErrorMessages(parsed[key], seen));
+  }
+  return messages;
+}
+
 export function isDashboardAppServerUnsupportedChatGptAccountModelError(errorLike = null) {
-  const text = normalizeBridgeText(
-    typeof errorLike === "string"
-      ? errorLike
-      : errorLike?.message || errorLike?.error?.message || JSON.stringify(errorLike || "")
+  const messages = collectDashboardAppServerErrorMessages(errorLike);
+  return messages.some((message) =>
+    /\bmodel\b.*\bnot supported\b.*\bCodex\b.*\bChatGPT account\b/i.test(normalizeBridgeText(message))
   );
-  return /model is not supported when using Codex with a ChatGPT account/i.test(text);
 }
 
 export function stripDashboardAppServerModelFromUsageProfile(usageProfile = null) {
@@ -1788,6 +1830,17 @@ export async function handleDashboardTurnRequest({
       return;
     }
     if (event.type === "app_server_turn_failed") {
+      if (
+        turnCostBoundary?.modelConfigured === true &&
+        isDashboardAppServerUnsupportedChatGptAccountModelError(event.text)
+      ) {
+        if (timedOut) {
+          cleanupNotifications();
+          return;
+        }
+        finishTurn(() => rejectTurn(new Error(event.text)));
+        return;
+      }
       void sendDashboardEvent(event);
       if (timedOut) {
         cleanupNotifications();
@@ -2039,7 +2092,7 @@ export function createDashboardAppServerClientSelector({
         rejectedModel: normalizeBridgeText(rejectedModel)
       };
     }
-    if (staticAppServer || !request.usageProfile) {
+    if (staticAppServer || (!request.usageProfile && !ignoreDefaultModel)) {
       return {
         appServer: defaultAppServer,
         ...config

--- a/test/dashboard-app-server-bridge.test.js
+++ b/test/dashboard-app-server-bridge.test.js
@@ -225,6 +225,17 @@ test("dashboard app-server bridge detects ChatGPT account unsupported model erro
     ),
     true
   );
+  assert.equal(
+    isDashboardAppServerUnsupportedChatGptAccountModelError({
+      type: "error",
+      status: 400,
+      error: {
+        type: "invalid_request_error",
+        message: "The configured model is not supported when using Codex with a ChatGPT account."
+      }
+    }),
+    true
+  );
   assert.equal(isDashboardAppServerUnsupportedChatGptAccountModelError(new Error("network timeout")), false);
 });
 
@@ -2759,6 +2770,421 @@ test("dashboard app-server bridge retries unsupported ChatGPT account model with
   await once;
 });
 
+test("dashboard app-server bridge retries unsupported default model when request has no usage profile", async () => {
+  const sockets = [];
+  const created = [];
+  class MockWebSocket {
+    constructor(endpoint, protocols) {
+      this.endpoint = endpoint;
+      this.protocols = protocols;
+      this.listeners = new Map();
+      this.sent = [];
+      sockets.push(this);
+    }
+
+    addEventListener(type, handler) {
+      if (!this.listeners.has(type)) {
+        this.listeners.set(type, new Set());
+      }
+      this.listeners.get(type).add(handler);
+    }
+
+    send(payload) {
+      this.sent.push(payload);
+    }
+
+    emit(type, event = {}) {
+      for (const handler of this.listeners.get(type) || []) {
+        handler(event);
+      }
+    }
+  }
+  const appServerFactory = (options) => {
+    const handlers = new Set();
+    const clientIndex = created.length;
+    const client = {
+      args: options.args,
+      nextId: 1,
+      async initialize() {},
+      nextRequestId() {
+        return this.nextId++;
+      },
+      onNotification(handler) {
+        handlers.add(handler);
+        return () => handlers.delete(handler);
+      },
+      drainApprovalRequests() {
+        return Promise.resolve();
+      },
+      async request(message) {
+        if (message.method === "thread/start") {
+          return { thread: { id: `codex-thread-default-fallback-${clientIndex}` } };
+        }
+        if (message.method === "turn/start") {
+          setTimeout(() => {
+            for (const handler of handlers) {
+              handler({
+                method: "item/agentMessage/delta",
+                params: {
+                  threadId: `codex-thread-default-fallback-${clientIndex}`,
+                  turnId: "turn-default-fallback",
+                  delta: "usageProfile なしでも復旧しました。"
+                }
+              });
+              handler({
+                method: "turn/completed",
+                params: {
+                  threadId: `codex-thread-default-fallback-${clientIndex}`,
+                  turn: { id: "turn-default-fallback", status: "completed" }
+                }
+              });
+            }
+          }, 0);
+          return { turn: { id: "turn-default-fallback" } };
+        }
+        throw new Error(`unexpected method ${message.method}`);
+      }
+    };
+    created.push(client);
+    return client;
+  };
+  const defaultAppServer = {
+    nextId: 1,
+    async initialize() {},
+    nextRequestId() {
+      return this.nextId++;
+    },
+    onNotification() {
+      return () => {};
+    },
+    drainApprovalRequests() {
+      return Promise.resolve();
+    },
+    async request(message) {
+      if (message.method === "thread/start") {
+        return { thread: { id: "codex-thread-default-model" } };
+      }
+      if (message.method === "turn/start") {
+        throw new Error(
+          `{"type":"error","status":400,"error":{"type":"invalid_request_error","message":"The 'gpt-5.3-codex' model is not supported when using Codex with a ChatGPT account."}}`
+        );
+      }
+      throw new Error(`unexpected method ${message.method}`);
+    }
+  };
+  const selector = createDashboardAppServerClientSelector({
+    defaultAppServer,
+    appServerFactory,
+    cwd: "/repo",
+    defaultModel: "gpt-5.3-codex"
+  });
+
+  const once = connectDashboardAppServerBridgeOnce({
+    endpoint: new URL("wss://runtime.example/v2/dashboard/app-server/ws?threadId=dashboard-main"),
+    token: "secret-token",
+    appServer: defaultAppServer,
+    selectAppServerForRequest: selector,
+    WebSocketImpl: MockWebSocket,
+    turnTimeoutMs: 1000,
+    liveProgressInitialDelayMs: 1000
+  });
+  const socket = sockets[0];
+  socket.emit("message", {
+    data: JSON.stringify({
+      type: "app_server_turn_requested",
+      threadId: "dashboard-main",
+      text: "君は誰？"
+    })
+  });
+
+  await waitFor(() => socket.sent.map((payload) => JSON.parse(payload)).some((payload) => payload.type === "app_server_reply"));
+  const parsed = socket.sent.map((payload) => JSON.parse(payload));
+  const fallbackStatus = parsed.find((payload) => payload.status === "unsupported_model_fallback");
+  assert.ok(fallbackStatus);
+  assert.equal(fallbackStatus.costBoundary.modelConfigured, false);
+  assert.equal(fallbackStatus.costBoundary.unsupportedModelFallback, true);
+  assert.equal(fallbackStatus.costBoundary.rejectedModel, "gpt-5.3-codex");
+  assert.equal(parsed.some((payload) => payload.type === "app_server_turn_failed"), false);
+  assert.equal(parsed.find((payload) => payload.type === "app_server_reply").text, "usageProfile なしでも復旧しました。");
+  assert.deepEqual(created.map((client) => client.args), [["app-server", "--listen", "stdio://", "-c", 'model_reasoning_effort="low"']]);
+  socket.emit("close");
+  await once;
+});
+
+test("dashboard app-server bridge retries unsupported model reported as app-server error notification", async () => {
+  const sockets = [];
+  const created = [];
+  class MockWebSocket {
+    constructor(endpoint, protocols) {
+      this.endpoint = endpoint;
+      this.protocols = protocols;
+      this.listeners = new Map();
+      this.sent = [];
+      sockets.push(this);
+    }
+
+    addEventListener(type, handler) {
+      if (!this.listeners.has(type)) {
+        this.listeners.set(type, new Set());
+      }
+      this.listeners.get(type).add(handler);
+    }
+
+    send(payload) {
+      this.sent.push(payload);
+    }
+
+    emit(type, event = {}) {
+      for (const handler of this.listeners.get(type) || []) {
+        handler(event);
+      }
+    }
+  }
+  const appServerFactory = (options) => {
+    const handlers = new Set();
+    const clientIndex = created.length;
+    const client = {
+      args: options.args,
+      nextId: 1,
+      async initialize() {},
+      nextRequestId() {
+        return this.nextId++;
+      },
+      onNotification(handler) {
+        handlers.add(handler);
+        return () => handlers.delete(handler);
+      },
+      drainApprovalRequests() {
+        return Promise.resolve();
+      },
+      async request(message) {
+        if (message.method === "thread/start") {
+          return { thread: { id: `codex-thread-notification-fallback-${clientIndex}` } };
+        }
+        if (message.method === "turn/start" && options.args.includes('model="gpt-5.3-codex"')) {
+          setTimeout(() => {
+            for (const handler of handlers) {
+              handler({
+                method: "error",
+                params: {
+                  threadId: `codex-thread-notification-fallback-${clientIndex}`,
+                  turnId: "turn-notification-fallback",
+                  message:
+                    `{"type":"error","status":400,"error":{"type":"invalid_request_error","message":"The 'gpt-5.3-codex' model is not supported when using Codex with a ChatGPT account."}}`
+                }
+              });
+            }
+          }, 0);
+          return { turn: { id: "turn-notification-fallback" } };
+        }
+        if (message.method === "turn/start") {
+          setTimeout(() => {
+            for (const handler of handlers) {
+              handler({
+                method: "item/agentMessage/delta",
+                params: {
+                  threadId: `codex-thread-notification-fallback-${clientIndex}`,
+                  turnId: "turn-notification-fallback",
+                  delta: "通知経由でも復旧しました。"
+                }
+              });
+              handler({
+                method: "turn/completed",
+                params: {
+                  threadId: `codex-thread-notification-fallback-${clientIndex}`,
+                  turn: { id: "turn-notification-fallback", status: "completed" }
+                }
+              });
+            }
+          }, 0);
+          return { turn: { id: "turn-notification-fallback" } };
+        }
+        throw new Error(`unexpected method ${message.method}`);
+      }
+    };
+    created.push(client);
+    return client;
+  };
+  const defaultAppServer = {
+    async initialize() {},
+    nextRequestId() {
+      return 1;
+    },
+    onNotification() {
+      return () => {};
+    },
+    drainApprovalRequests() {
+      return Promise.resolve();
+    }
+  };
+  const selector = createDashboardAppServerClientSelector({
+    defaultAppServer,
+    appServerFactory,
+    cwd: "/repo",
+    defaultModel: "gpt-5.3-codex"
+  });
+
+  const once = connectDashboardAppServerBridgeOnce({
+    endpoint: new URL("wss://runtime.example/v2/dashboard/app-server/ws?threadId=dashboard-main"),
+    token: "secret-token",
+    appServer: defaultAppServer,
+    selectAppServerForRequest: selector,
+    WebSocketImpl: MockWebSocket,
+    turnTimeoutMs: 1000,
+    liveProgressInitialDelayMs: 1000
+  });
+  const socket = sockets[0];
+  socket.emit("message", {
+    data: JSON.stringify({
+      type: "app_server_turn_requested",
+      threadId: "dashboard-main",
+      text: "もしもし。",
+      usageProfile: {
+        profile: "conversation",
+        reasoningEffort: "low",
+        model: "gpt-5.3-codex",
+        reason: "ordinary_conversation"
+      }
+    })
+  });
+
+  await waitFor(() => socket.sent.map((payload) => JSON.parse(payload)).some((payload) => payload.type === "app_server_reply"));
+  const parsed = socket.sent.map((payload) => JSON.parse(payload));
+  const fallbackStatus = parsed.find((payload) => payload.status === "unsupported_model_fallback");
+  assert.ok(fallbackStatus);
+  assert.equal(fallbackStatus.costBoundary.modelConfigured, false);
+  assert.equal(fallbackStatus.costBoundary.unsupportedModelFallback, true);
+  assert.equal(fallbackStatus.costBoundary.rejectedModel, "gpt-5.3-codex");
+  assert.equal(parsed.some((payload) => payload.type === "app_server_turn_failed"), false);
+  assert.equal(parsed.find((payload) => payload.type === "app_server_reply").text, "通知経由でも復旧しました。");
+  assert.deepEqual(created.map((client) => client.args), [
+    ["app-server", "--listen", "stdio://", "-c", 'model="gpt-5.3-codex"', "-c", 'model_reasoning_effort="low"'],
+    ["app-server", "--listen", "stdio://", "-c", 'model_reasoning_effort="low"']
+  ]);
+  socket.emit("close");
+  await once;
+});
+
+test("dashboard app-server bridge does not loop when model-less fallback also fails", async () => {
+  const sockets = [];
+  const created = [];
+  class MockWebSocket {
+    constructor(endpoint, protocols) {
+      this.endpoint = endpoint;
+      this.protocols = protocols;
+      this.listeners = new Map();
+      this.sent = [];
+      sockets.push(this);
+    }
+
+    addEventListener(type, handler) {
+      if (!this.listeners.has(type)) {
+        this.listeners.set(type, new Set());
+      }
+      this.listeners.get(type).add(handler);
+    }
+
+    send(payload) {
+      this.sent.push(payload);
+    }
+
+    emit(type, event = {}) {
+      for (const handler of this.listeners.get(type) || []) {
+        handler(event);
+      }
+    }
+  }
+  const appServerFactory = (options) => {
+    const client = {
+      args: options.args,
+      nextId: 1,
+      async initialize() {},
+      nextRequestId() {
+        return this.nextId++;
+      },
+      onNotification() {
+        return () => {};
+      },
+      drainApprovalRequests() {
+        return Promise.resolve();
+      },
+      async request(message) {
+        if (message.method === "thread/start") {
+          return { thread: { id: `codex-thread-loop-guard-${created.length}` } };
+        }
+        if (message.method === "turn/start" && options.args.includes('model="gpt-5.3-codex"')) {
+          throw new Error(
+            `{"type":"error","status":400,"error":{"type":"invalid_request_error","message":"The 'gpt-5.3-codex' model is not supported when using Codex with a ChatGPT account."}}`
+          );
+        }
+        if (message.method === "turn/start") {
+          throw new Error("model-less fallback still failed");
+        }
+        throw new Error(`unexpected method ${message.method}`);
+      }
+    };
+    created.push(client);
+    return client;
+  };
+  const defaultAppServer = {
+    async initialize() {},
+    nextRequestId() {
+      return 1;
+    },
+    onNotification() {
+      return () => {};
+    },
+    drainApprovalRequests() {
+      return Promise.resolve();
+    }
+  };
+  const selector = createDashboardAppServerClientSelector({
+    defaultAppServer,
+    appServerFactory,
+    cwd: "/repo",
+    defaultModel: "gpt-5.3-codex"
+  });
+
+  const once = connectDashboardAppServerBridgeOnce({
+    endpoint: new URL("wss://runtime.example/v2/dashboard/app-server/ws?threadId=dashboard-main"),
+    token: "secret-token",
+    appServer: defaultAppServer,
+    selectAppServerForRequest: selector,
+    WebSocketImpl: MockWebSocket,
+    turnTimeoutMs: 1000,
+    liveProgressInitialDelayMs: 1000
+  });
+  const socket = sockets[0];
+  socket.emit("message", {
+    data: JSON.stringify({
+      type: "app_server_turn_requested",
+      threadId: "dashboard-main",
+      text: "もしもし。",
+      usageProfile: {
+        profile: "conversation",
+        reasoningEffort: "low",
+        model: "gpt-5.3-codex",
+        reason: "ordinary_conversation"
+      }
+    })
+  });
+
+  await waitFor(() => socket.sent.map((payload) => JSON.parse(payload)).some((payload) => payload.type === "app_server_turn_failed"));
+  const parsed = socket.sent.map((payload) => JSON.parse(payload));
+  const fallbackStatuses = parsed.filter((payload) => payload.status === "unsupported_model_fallback");
+  const failures = parsed.filter((payload) => payload.type === "app_server_turn_failed");
+  assert.equal(fallbackStatuses.length, 1);
+  assert.equal(failures.length, 1);
+  assert.match(failures[0].text, /model-less fallback still failed/);
+  assert.equal(created.length, 2);
+  assert.deepEqual(created.map((client) => client.args), [
+    ["app-server", "--listen", "stdio://", "-c", 'model="gpt-5.3-codex"', "-c", 'model_reasoning_effort="low"'],
+    ["app-server", "--listen", "stdio://", "-c", 'model_reasoning_effort="low"']
+  ]);
+  socket.emit("close");
+  await once;
+});
+
 test("dashboard app-server bridge args require a dashboard thread id for runtime connection", () => {
   const parsed = parseBridgeArgs([], {
     VTDD_RUNTIME_URL: "https://runtime.example",
@@ -2989,6 +3415,35 @@ test("dashboard app-server bridge selector creates model-less fallback client", 
     'model_reasoning_effort="low"'
   ]);
   assert.deepEqual(created[1].args, ["app-server", "--listen", "stdio://", "-c", 'model_reasoning_effort="low"']);
+  assert.equal(fallback.costBoundary.modelConfigured, false);
+  assert.equal(fallback.costBoundary.unsupportedModelFallback, true);
+  assert.equal(fallback.costBoundary.rejectedModel, "gpt-5.3-codex");
+});
+
+test("dashboard app-server bridge selector creates model-less fallback client without usage profile", async () => {
+  const defaultAppServer = { id: "default" };
+  const created = [];
+  const selector = createDashboardAppServerClientSelector({
+    defaultAppServer,
+    defaultModel: "gpt-5.3-codex",
+    appServerFactory(options) {
+      const client = {
+        id: `client-${created.length + 1}`,
+        async initialize() {}
+      };
+      created.push({ ...options, client });
+      return client;
+    },
+    cwd: "/repo"
+  });
+
+  const selected = await selector({});
+  const fallback = await selector.withoutModel({}, { rejectedModel: selected.costBoundary.model });
+
+  assert.equal(selected.appServer, defaultAppServer);
+  assert.notEqual(fallback.appServer, defaultAppServer);
+  assert.equal(created.length, 1);
+  assert.deepEqual(created[0].args, ["app-server", "--listen", "stdio://", "-c", 'model_reasoning_effort="low"']);
   assert.equal(fallback.costBoundary.modelConfigured, false);
   assert.equal(fallback.costBoundary.unsupportedModelFallback, true);
   assert.equal(fallback.costBoundary.rejectedModel, "gpt-5.3-codex");


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #455: ChatGPT account で非対応の app-server model override が出ても、Dashboard Butler が同じ 400 failure を返し続けず、model-less fallback に一度退避する。

## Satisfied Success Criteria

- usageProfile が無い通常 Butler turn でも selector.withoutModel が default appServer を再利用せず model-less client を作る。\napp-server error notification の unsupported model failure を先に Dashboard へ送らず、outer fallback へ渡す。\nJSON error payload は message / error.message / cause を抽出して判定し、raw stringify 全体への依存を減らす。\nmodel-less fallback も失敗した場合は二度目の fallback に入らず、generic failure 1件で終わる。

## Unsatisfied Success Criteria

- merge 後の production deploy と bridge restart 後に、Dashboard Butler 実機 E2E で『君は誰？』が unsupported model 400 で止まらないことを確認する作業が未実施。

## Non-goal violations

新しい model 名の固定、credential / permission / deploy workflow の変更、Worker route / Action Schema の変更はしない。

## 開発前作戦図

- 作戦図 evidence: docs/development-strategy/issue-455-unsupported-model-fallback-complete.md
- 完了体験: Dashboard Butler の短い通常会話が gpt-5.3-codex unsupported 400 で止まらず、model override なしで一度だけ再送される。
- VTDD 全体で進める部分: Dashboard app-server bridge の VPS Codex CLI 接続復旧。
- 設計: selector fallback と notification failure handoff を同じ PR で修正し、owner-facing failure 送信前に model-less retry へ渡す。fallback 自体が失敗した場合は retry せず generic failure に戻す。
- 仮説: 原因の仮説: PR #787 は thrown error だけを中心に直し、usageProfile 無し/default client と app-server error notification 経路を取りこぼした。
- 検証計画: selector unit、WebSocket bridge integration、notification fallback integration、fallback failure loop guard integration、node --test、npm test、git diff --check。
- 改修見積もり: scripts/run-dashboard-app-server-bridge.mjs の selector、app_server_turn_failed handling、構造化 error message 抽出、test/dashboard-app-server-bridge.test.js の fallback tests、作戦図 doc。
- 既に通っている経路: PR #787 で unsupported classifier と thrown error fallback の基本経路は実装済み。
- 未確認の境界: production app-server が unsupported model を throw と notification のどちらで返すかは環境依存。両方を扱う。
- 穴が出そうな箇所: default appServer の再利用、APP_SERVER_FAILURE_ALREADY_SENT による fallback 停止、unsupported 以外の failure 誤 retry、fallback 後失敗時の loop。
- PR 前に確認すること: latest origin/main、open PR 0、対象テスト、npm test、未追跡 E2E assets を stage しないこと。
- 実装候補と捨てた案: VPS env だけを消す案と supported model を repo 固定する案は、account 差異と再発リスクが残るため捨てた。
- merge 後に通す E2E: production deploy と bridge restart 後、Dashboard Butler 実機 E2E test で『君は誰？』を送り unsupported model 400 で止まらないことを確認する。
- 次の PR を増やさない理由: production failure は selector と notification path と fallback failure handling の組み合わせなので、分けると次 PR に残る穴として再発する。
- 停止条件: credential / permission / deploy mutation、または unsupported model 以外の auth/quota/network policy へ広がる場合。

## Dry-run Impact Report

- Target Issue: Issue #455
- Implementing Success Criteria: unsupported model fallback の残穴を塞ぎ、Dashboard Butler が同じ 400 error を返し続けない。
- Explicit Non-goals: model 名固定、Worker route 変更、Action Schema 変更、deploy automation 変更は対象外。
- Expected touched files/routes/workflows: scripts/run-dashboard-app-server-bridge.mjs、test/dashboard-app-server-bridge.test.js、docs/development-strategy/issue-455-unsupported-model-fallback-complete.md。
- Affected Issues: Issue #455、production E2E は Issue #590 系の Dashboard Butler recovery と関連。
- Affected PRs: PR #787 の追加修正。
- Affected workflows: GitHub Actions test のみ。deploy-production は merge 後に別途 passkey approval が必要。
- Affected runtime/operator surfaces: Dashboard Butler、VPS app-server bridge、Codex app-server client selector。
- What may break if we patch narrowly: throw 経路だけ直すと notification 経路で同じ owner-facing failure が残る。selector だけ直すと APP_SERVER_FAILURE_ALREADY_SENT が fallback を止める。loop guard がないと fallback 後失敗を再 retry する恐れがある。
- Unknowns to investigate before coding: production app-server の error 形式は断定しない。テストでは throw と notification の両方を固定する。
- Validation needed: node --test test/dashboard-app-server-bridge.test.js、git diff --check、npm test、merge 後 production E2E。
- Stop condition: unsupported model 以外の runtime failure をこの PR で吸収し始める場合。

## Execution Queue Delta

- Queue position before: Issue #455 の unsupported model recovery は、Butler が通常会話すら返せない現行 blocker の follow-up。
- Preemption decision: EMERGENCY: owner-facing regression 対応。ただし scope は Issue #455 の app-server model fallback に限定。
- Queue delta: Issue #455 の fallback 実装を production 再発に合わせて補完する。Active Issues は縮小しない。
- Why this PR is next: Dashboard Butler が『君は誰？』で 400 を返し続けており、Butler-first 開発再開の前提が壊れているため。
- Active Issues not downscoped: Active Issues は縮小しない。この PR は Issue #455 の app-server fallback gap のみを進める。

## File / Line Hypotheses

- file: scripts/run-dashboard-app-server-bridge.mjs\n  - hypothesis: app_server_turn_failed notification を failure sent にすると fallback へ届かない。\n  - risk if changed narrowly: unsupported 以外まで retry すると root cause を隠す。\n  - validation: notification unsupported model integration test。\n  - related Issue: #455\n- file: scripts/run-dashboard-app-server-bridge.mjs\n  - hypothesis: selector.withoutModel が usageProfile 無しで default appServer を返し、同じ model override を使い続ける。\n  - risk if changed narrowly: static appServer test embedding を壊す。\n  - validation: usageProfile 無し selector unit と WebSocket integration test。\n  - related Issue: #455\n- file: scripts/run-dashboard-app-server-bridge.mjs\n  - hypothesis: fallback 失敗時も modelConfigured=false のため二度目の fallback には入らない。\n  - risk if changed narrowly: loop guard をテストせず production で失敗時に不安定化する。\n  - validation: model-less fallback failure integration test。\n  - related Issue: #455

## Hypothesis Retrospective

- expected: usageProfile 無し、notification 経路、fallback 後失敗を追加すれば production 再発形と loop guard を repo test で再現できる。\n- actual: すべてのテストが追加され、node --test と npm test が通った。\n- mismatch: production E2E は merge/deploy 後に残る。\n- lesson: app-server failure は throw だけでなく notification path と fallback failure path も owner-facing recovery contract に含める。\n- should become RAG candidate: はい。PR #787/#788 の再発防止として記録候補。

## Verification Evidence

- Unit: node --test test/dashboard-app-server-bridge.test.js: pass (74 tests)
- Integration: npm test: pass (1202 pass, 1 skipped); check:self-parity pass; check:generated-worker pass
- E2E: 未実施。merge 後 production deploy と bridge restart 後に Dashboard Butler 実機 E2E で確認する。
- Manual: git diff --check: pass
- Evidence path/link: docs/development-strategy/issue-455-unsupported-model-fallback-complete.md

## Butler Completion Contract

- Primary owner surface: Dashboard Butler。
- Fallback surface: Custom GPT は fallback surface として扱う。この PR の主経路ではない。
- Owner goal: Dashboard Butler の通常チャットが unsupported model 400 で止まらず、VPS app-server bridge が model-less fallback へ退避する。
- Butler entrypoint: Dashboard Butler 通常チャット。
- Dashboard Butler natural-language path: Dashboard Butler の自然文/通常チャット入口から app-server bridge に到達する既存経路を維持する。
- Action Schema exposure: Custom GPT fallback schema は未変更。operationId 追加なし。
- Runtime path: connectDashboardAppServerBridgeOnce -> handleDashboardTurnRequest -> createDashboardAppServerClientSelector.withoutModel。
- Runner/runtime truth: local integration tests で WebSocket event、app-server notification、fallback failure を検証。production runtime truth は deploy 後に確認。
- Authority boundary: 新しい high-risk authority は追加しない。deploy と bridge restart は merge 後に scoped passkey approval が必要。
- E2E evidence: 未実施。merge/deploy 後に Dashboard Butler 実機 E2E で『君は誰？』を確認する。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: merge 後に必要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: merge/deploy/bridge restart 後に必要。

## Related Constitution Rules

- Butler Completion Gate、Drift Stop Protocol、開発前作戦図 Gate、Evidence Discipline。

## Out-of-scope but NOT implemented

- Codex Analytics cost checker、live progress 表示設計、deploy automation、thread compaction policy はこの PR では触らない。

## Extra changes (if any)

Gemini review の loop guard 指摘に対応し、fallback 後失敗 test を追加。

<!-- VTDD metadata -->
- Issue: Issue #455
- Execution ID: mac-codex-issue-455-fallback-complete-20260605
- Goal: production で再発した gpt-5.3-codex unsupported 400 を、Butler 通常チャットで model-less fallback に退避させる。
