### PR TITLE
Fix unsupported model backend thread recovery

### DIFF
--- a/docs/development-strategy/issue-455-reset-unsupported-model-thread.md
+++ b/docs/development-strategy/issue-455-reset-unsupported-model-thread.md
@@ -1,0 +1,82 @@
+# Issue #455 unsupported model backend thread reset 作戦図
+
+## 完了体験
+
+Dashboard Butler が `gpt-5.3-codex` unsupported を受けても、同じ古い Codex backend thread を resume し続けない。Worker は backend thread mapping を破棄し、bridge は `codexThreadId` なしで新規 app-server thread を開始する。owner は「短くして再送」ではなく、同じ入力が自動で新規 backend thread に再送される復旧を見る。
+
+## VTDD 全体で進める部分
+
+Issue #455 の cost/model routing regression を復旧する。PR #788 は model override 由来の unsupported fallback を直したが、実機では Codex CLI default / 既存 backend thread が `gpt-5.3-codex` を保持していた。今回は Dashboard thread mapping と bridge fallback の境界を直す。
+
+## 設計
+
+`buildDashboardAppServerFailureRecovery` は unsupported ChatGPT account model error を `unsupported_model` recovery として返し、`resetBackendThread=true`、`autoRetry=true`、original owner text / message id を含める。
+
+Worker の `shouldResetDashboardAppServerBackendThread` は `context_window_exceeded` だけでなく `unsupported_model` も backend thread reset 対象にする。
+
+bridge 側の unsupported fallback は、同じ payload の `codexThreadId` を引き継がない。fallback payload は `codexThreadId=null` とし、既存 backend thread を resume せず `thread/start` する。
+
+恒久設計として repo は特定 model を固定しない。今回の VPS `gpt-5.5` 指定は `gpt-5.3-codex` default 障害を避けるための運用復旧手段であり、正常化後に env 指定を外して model-less へ戻せる必要がある。そのため fallback はエラー本文から実際に拒否された model を抽出し、拒否された model が現在の defaultModel と同じ場合だけ model override を外す。拒否された model が古い backend thread 由来で現在の defaultModel と違う場合は、現在の defaultModel を維持して新規 thread を開始する。
+
+## 仮説
+
+原因の仮説: deploy/restart 後も実プロセスは `gpt-5.5` になったが、Dashboard thread に保存された古い `codexThreadId` を resume したため、backend thread 側が `gpt-5.3-codex` を保持し続けた。PR #788 の fallback も `codexThreadId` を消さないため、同じ古い backend thread に戻っていた。
+
+## 検証計画
+
+- Unit / integration: unsupported model failure の recovery が `unsupported_model` + `resetBackendThread=true` になる。
+- Worker integration: unsupported model recovery で app_server_thread mapping を削除し、`codexThreadId=null` の retry request を送る。
+- Bridge integration: unsupported model fallback retry は `codexThreadId` を渡さず新規 thread を開始する。拒否された model が古い thread 由来の場合、現在の defaultModel は維持する。
+- Local: `node --test test/dashboard-app-server-bridge.test.js test/worker.test.js`
+- Local: `git diff --check`
+- Local: `npm test`
+
+## 改修見積もり
+
+- `scripts/run-dashboard-app-server-bridge.mjs`: unsupported model recovery builder と fallback payload の `codexThreadId` reset。
+- `src/worker/runtime.js`: backend thread reset 対象 status に `unsupported_model` を追加。
+- `test/dashboard-app-server-bridge.test.js`: recovery payload と fallback retry の `thread/start` 検証。
+- `test/worker.test.js`: unsupported model recovery で mapping を削除して再送する検証。
+- `worker.js`: worker bundle rebuild。
+
+## 既に通っている経路
+
+context window exceeded では Worker が `app_server_thread:*` mapping を削除し、同じ owner text を `codexThreadId=null` で再送できている。PR #788 で unsupported model classifier と fallback status は入っている。
+
+## 未確認の境界
+
+`gpt-5.5` が新規 backend thread で実際に返答成功するかは production E2E で確認する。Codex CLI default model selection の内部仕様は repo からは制御できない。
+
+## 穴が出そうな箇所
+
+- fallback retry が `codexThreadId` を引き継ぐ。
+- Worker が unsupported model を generic failure として保存し、mapping を残す。
+- reset retry が同じ owner message id で無限 loop する。
+- model-less fallback が default `gpt-5.3-codex` に戻る。
+- 復旧用の `gpt-5.5` env 指定が repo 固定 model と誤解される。
+
+## PR 前に確認すること
+
+VPS runtime truth、PR #788、Issue #734/#745 の Codex default model lessons、対象 tests、worker bundle rebuild、未追跡 E2E assets を stage しないこと。
+
+## 実装候補と捨てた案
+
+採用: unsupported model を backend thread reset 対象にし、retry では `codexThreadId` を破棄する。
+
+捨てた案: Codex CLI update だけで直す。0.137.0 に更新しても同じ error が出たため不採用。
+
+捨てた案: model-less fallback のままにする。default が unsupported に流れるため不採用。
+
+採用: まず `gpt-5.5` 明示で新規 backend thread の正常化を確認し、その後 VPS env から model 指定を外して model-less が正常動作するかを実測する。repo には `gpt-5.5` を固定しない。
+
+## merge 後に通す E2E
+
+production deploy と bridge restart 後、Dashboard Butler で「君は誰？」を送り、`gpt-5.3-codex` unsupported で止まらず返信が返ること。必要なら一度だけ backend thread reset の transient status が出てもよい。
+
+## 次の PR を増やさない理由
+
+unsupported recovery、Worker mapping reset、bridge retry payload は同じ owner-facing failure の一塊。どれか一つだけでは同じ古い backend thread に戻って再発する。
+
+## 停止条件
+
+OpenAI credential / account / billing 変更、GitHub secret / variable mutation、deploy / root helper mutationが必要になった場合。unsupported model 以外の quota / auth policy へ広がる場合。

--- a/scripts/run-dashboard-app-server-bridge.mjs
+++ b/scripts/run-dashboard-app-server-bridge.mjs
@@ -233,6 +233,22 @@ export function isDashboardAppServerUnsupportedChatGptAccountModelError(errorLik
   );
 }
 
+export function extractDashboardAppServerUnsupportedModel(errorLike = null) {
+  const messages = collectDashboardAppServerErrorMessages(errorLike);
+  for (const message of messages) {
+    const normalized = normalizeBridgeText(message);
+    const quoted = normalized.match(/['"`]([a-z0-9][a-z0-9._-]*codex[a-z0-9._-]*)['"`]\s+model\s+is\s+not\s+supported/i);
+    if (quoted?.[1]) {
+      return quoted[1];
+    }
+    const generic = normalized.match(/\b([a-z0-9][a-z0-9._-]*codex[a-z0-9._-]*)\b.*\bnot supported\b/i);
+    if (generic?.[1]) {
+      return generic[1];
+    }
+  }
+  return "";
+}
+
 export function stripDashboardAppServerModelFromUsageProfile(usageProfile = null) {
   const normalized = normalizeDashboardAppServerUsageProfile(usageProfile || "conversation");
   const { model: _model, ...withoutModel } = normalized;
@@ -940,6 +956,19 @@ export function buildDashboardAppServerFailureRecovery({
   resumedExistingThread = false
 } = {}) {
   const detail = sanitizeOptionalBridgeError(text);
+  if (
+    normalizeBridgeText(status).toLowerCase() !== "interrupted" &&
+    isDashboardAppServerUnsupportedChatGptAccountModelError(detail)
+  ) {
+    return {
+      status: "unsupported_model",
+      retryable: true,
+      resetBackendThread: true,
+      autoRetry: true,
+      originalText: normalizeBridgeText(ownerText),
+      originalMessageId: normalizeBridgeText(ownerMessageId)
+    };
+  }
   if (
     normalizeBridgeText(status).toLowerCase() !== "interrupted" &&
     resumedExistingThread === true &&
@@ -2085,7 +2114,7 @@ export function createDashboardAppServerClientSelector({
       defaultReasoningEffort,
       ignoreDefaultModel
     });
-    if (ignoreDefaultModel && normalizeBridgeText(rejectedModel)) {
+    if (normalizeBridgeText(rejectedModel)) {
       config.costBoundary = {
         ...config.costBoundary,
         unsupportedModelFallback: true,
@@ -2118,6 +2147,22 @@ export function createDashboardAppServerClientSelector({
       ...options,
       ignoreDefaultModel: true
     });
+  selector.fallbackForUnsupportedModel = (request = {}, options = {}) => {
+    const rejectedModel = normalizeBridgeText(options?.rejectedModel);
+    const ignoreDefaultModel =
+      Boolean(rejectedModel) && Boolean(normalizeBridgeText(defaultModel)) && rejectedModel === normalizeBridgeText(defaultModel);
+    return selectAppServerForRequestWithOptions(
+      {
+        ...request,
+        codexThreadId: null,
+        usageProfile: stripDashboardAppServerModelFromUsageProfile(request.usageProfile || defaultProfile || "conversation")
+      },
+      {
+        ...options,
+        ignoreDefaultModel
+      }
+    );
+  };
   return selector;
 }
 
@@ -2519,12 +2564,12 @@ export async function connectDashboardAppServerBridgeOnce({
             typeof selectAppServerForRequest === "function"
               ? await selectAppServerForRequest(payload)
               : { appServer, usageProfile: payload.usageProfile || null, costBoundary: payload.costBoundary || null };
-          const runSelectedTurn = (turnSelection) =>
+          const runSelectedTurn = (turnSelection, turnPayload = payload) =>
             handleDashboardTurnRequest({
-              request: payload,
+              request: turnPayload,
               appServer: turnSelection.appServer || appServer,
-              usageProfile: turnSelection.usageProfile || payload.usageProfile || null,
-              costBoundary: turnSelection.costBoundary || payload.costBoundary || null,
+              usageProfile: turnSelection.usageProfile || turnPayload.usageProfile || null,
+              costBoundary: turnSelection.costBoundary || turnPayload.costBoundary || null,
               sendDashboardEvent: async (dashboardEvent) => safeSend(dashboardEvent),
               cwd,
               sandboxMode,
@@ -2542,24 +2587,43 @@ export async function connectDashboardAppServerBridgeOnce({
               !isAppServerFailureAlreadySent(error) &&
               isDashboardAppServerUnsupportedChatGptAccountModelError(error) &&
               selected?.costBoundary?.modelConfigured === true &&
-              typeof selectAppServerForRequest?.withoutModel === "function"
+              (typeof selectAppServerForRequest?.fallbackForUnsupportedModel === "function" ||
+                typeof selectAppServerForRequest?.withoutModel === "function")
             ) {
-              const fallbackSelected = await selectAppServerForRequest.withoutModel(payload, {
-                rejectedModel: selected.usageProfile?.model || selected.costBoundary?.model || payload.usageProfile?.model || ""
+              const fallbackPayload = {
+                ...payload,
+                codexThreadId: null,
+                appServer: {
+                  ...(payload.appServer && typeof payload.appServer === "object" ? payload.appServer : {}),
+                  startThreadMethod: "thread/start"
+                }
+              };
+              const fallbackSelector =
+                typeof selectAppServerForRequest.fallbackForUnsupportedModel === "function"
+                  ? selectAppServerForRequest.fallbackForUnsupportedModel
+                  : selectAppServerForRequest.withoutModel;
+              const rejectedModel =
+                extractDashboardAppServerUnsupportedModel(error) ||
+                selected.usageProfile?.model ||
+                selected.costBoundary?.model ||
+                payload.usageProfile?.model ||
+                "";
+              const fallbackSelected = await fallbackSelector(fallbackPayload, {
+                rejectedModel
               });
               safeSend({
                 type: "app_server_status",
                 schema: DEFAULT_SCHEMA,
                 threadId: payload.threadId,
-                codexThreadId: payload.codexThreadId || null,
+                codexThreadId: null,
                 status: "unsupported_model_fallback",
                 stage: "runtime_recovery",
-                text: "指定 model が ChatGPT account で非対応のため、model override なしで app-server に再送しています。",
+                text: "指定 model または古い backend thread が ChatGPT account で非対応のため、新しい app-server thread で再送しています。",
                 persistProgress: true,
                 usageProfile: fallbackSelected.usageProfile || null,
                 costBoundary: fallbackSelected.costBoundary || null
               });
-              return await runSelectedTurn(fallbackSelected);
+              return await runSelectedTurn(fallbackSelected, fallbackPayload);
             }
             throw error;
           }

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -10039,7 +10039,7 @@ function normalizeDashboardAppServerRecovery(value) {
   const originalText = sanitizeDashboardChatText(input.originalText || input.original_text);
   const originalMessageId = normalizeDashboardEventText(input.originalMessageId || input.original_message_id);
   const resetBackendThread = input.resetBackendThread === true || input.reset_backend_thread === true;
-  const retryable = input.retryable === true || status === "context_window_exceeded";
+  const retryable = input.retryable === true || status === "context_window_exceeded" || status === "unsupported_model";
   const autoRetry = input.autoRetry === true || input.auto_retry === true;
   if (!status && !originalText && !originalMessageId && !resetBackendThread && !retryable && !autoRetry) {
     return null;
@@ -10056,8 +10056,9 @@ function normalizeDashboardAppServerRecovery(value) {
 
 function shouldResetDashboardAppServerBackendThread(recovery) {
   const normalized = normalizeDashboardAppServerRecovery(recovery);
+  const resettableStatus = normalized?.status === "context_window_exceeded" || normalized?.status === "unsupported_model";
   return (
-    normalized?.status === "context_window_exceeded" &&
+    resettableStatus &&
     normalized.retryable === true &&
     normalized.resetBackendThread === true
   );

--- a/test/dashboard-app-server-bridge.test.js
+++ b/test/dashboard-app-server-bridge.test.js
@@ -30,6 +30,7 @@ import {
   createDashboardAppServerClientSelector,
   ensureDashboardBridgeRepoSynced,
   executeVpsRunnerWakeup,
+  extractDashboardAppServerUnsupportedModel,
   extractAppServerNotificationTurnId,
   formatDashboardMediaReferenceLines,
   handleDashboardTurnRequest,
@@ -237,6 +238,12 @@ test("dashboard app-server bridge detects ChatGPT account unsupported model erro
     true
   );
   assert.equal(isDashboardAppServerUnsupportedChatGptAccountModelError(new Error("network timeout")), false);
+  assert.equal(
+    extractDashboardAppServerUnsupportedModel(
+      `{"type":"error","status":400,"error":{"type":"invalid_request_error","message":"The 'gpt-5.3-codex' model is not supported when using Codex with a ChatGPT account."}}`
+    ),
+    "gpt-5.3-codex"
+  );
 });
 
 test("dashboard app-server bridge can strip model override while preserving usage profile", () => {
@@ -2765,6 +2772,161 @@ test("dashboard app-server bridge retries unsupported ChatGPT account model with
   assert.deepEqual(created.map((client) => client.args), [
     ["app-server", "--listen", "stdio://", "-c", 'model="gpt-5.3-codex"', "-c", 'model_reasoning_effort="low"'],
     ["app-server", "--listen", "stdio://", "-c", 'model_reasoning_effort="low"']
+  ]);
+  socket.emit("close");
+  await once;
+});
+
+test("dashboard app-server bridge drops stale backend thread when unsupported model comes from resumed thread", async () => {
+  const sockets = [];
+  const created = [];
+  const defaultRequests = [];
+  const fallbackRequests = [];
+  class MockWebSocket {
+    constructor(endpoint, protocols) {
+      this.endpoint = endpoint;
+      this.protocols = protocols;
+      this.listeners = new Map();
+      this.sent = [];
+      sockets.push(this);
+    }
+
+    addEventListener(type, handler) {
+      if (!this.listeners.has(type)) {
+        this.listeners.set(type, new Set());
+      }
+      this.listeners.get(type).add(handler);
+    }
+
+    send(payload) {
+      this.sent.push(payload);
+    }
+
+    emit(type, event = {}) {
+      for (const handler of this.listeners.get(type) || []) {
+        handler(event);
+      }
+    }
+  }
+  const appServerFactory = (options) => {
+    const handlers = new Set();
+    const clientIndex = created.length;
+    const client = {
+      args: options.args,
+      nextId: 1,
+      async initialize() {},
+      nextRequestId() {
+        return this.nextId++;
+      },
+      onNotification(handler) {
+        handlers.add(handler);
+        return () => handlers.delete(handler);
+      },
+      drainApprovalRequests() {
+        return Promise.resolve();
+      },
+      async request(message) {
+        fallbackRequests.push(message.method);
+        if (message.method === "thread/start") {
+          return { thread: { id: `codex-thread-fresh-${clientIndex}` } };
+        }
+        if (message.method === "thread/resume") {
+          throw new Error("fallback must not resume a stale backend thread");
+        }
+        if (message.method === "turn/start") {
+          setTimeout(() => {
+            for (const handler of handlers) {
+              handler({
+                method: "item/agentMessage/delta",
+                params: {
+                  threadId: `codex-thread-fresh-${clientIndex}`,
+                  turnId: "turn-fresh",
+                  delta: "fresh thread で復旧しました。"
+                }
+              });
+              handler({
+                method: "turn/completed",
+                params: {
+                  threadId: `codex-thread-fresh-${clientIndex}`,
+                  turn: { id: "turn-fresh", status: "completed" }
+                }
+              });
+            }
+          }, 0);
+          return { turn: { id: "turn-fresh" } };
+        }
+        throw new Error(`unexpected method ${message.method}`);
+      }
+    };
+    created.push(client);
+    return client;
+  };
+  const defaultAppServer = {
+    nextId: 1,
+    async initialize() {},
+    nextRequestId() {
+      return this.nextId++;
+    },
+    onNotification() {
+      return () => {};
+    },
+    drainApprovalRequests() {
+      return Promise.resolve();
+    },
+    async request(message) {
+      defaultRequests.push(message.method);
+      if (message.method === "thread/resume") {
+        return { thread: { id: message.params.threadId } };
+      }
+      if (message.method === "turn/start") {
+        throw new Error(
+          `{"type":"error","status":400,"error":{"type":"invalid_request_error","message":"The 'gpt-5.3-codex' model is not supported when using Codex with a ChatGPT account."}}`
+        );
+      }
+      throw new Error(`unexpected method ${message.method}`);
+    }
+  };
+  const selector = createDashboardAppServerClientSelector({
+    defaultAppServer,
+    appServerFactory,
+    cwd: "/repo",
+    defaultModel: "gpt-5.5"
+  });
+
+  const once = connectDashboardAppServerBridgeOnce({
+    endpoint: new URL("wss://runtime.example/v2/dashboard/app-server/ws?threadId=dashboard-main"),
+    token: "secret-token",
+    appServer: defaultAppServer,
+    selectAppServerForRequest: selector,
+    WebSocketImpl: MockWebSocket,
+    turnTimeoutMs: 1000,
+    liveProgressInitialDelayMs: 1000
+  });
+  const socket = sockets[0];
+  socket.emit("message", {
+    data: JSON.stringify({
+      type: "app_server_turn_requested",
+      threadId: "dashboard-main",
+      codexThreadId: "codex-thread-stale-5-3",
+      text: "君は誰？"
+    })
+  });
+
+  await waitFor(() => socket.sent.map((payload) => JSON.parse(payload)).some((payload) => payload.type === "app_server_reply"));
+  const parsed = socket.sent.map((payload) => JSON.parse(payload));
+  const fallbackStatus = parsed.find((payload) => payload.status === "unsupported_model_fallback");
+  assert.ok(fallbackStatus);
+  assert.equal(fallbackStatus.codexThreadId, null);
+  assert.equal(fallbackStatus.costBoundary.modelConfigured, true);
+  assert.equal(fallbackStatus.costBoundary.model, "gpt-5.5");
+  assert.equal(fallbackStatus.costBoundary.unsupportedModelFallback, true);
+  assert.equal(fallbackStatus.costBoundary.rejectedModel, "gpt-5.3-codex");
+  assert.equal(parsed.some((payload) => payload.type === "app_server_turn_failed"), false);
+  assert.equal(parsed.find((payload) => payload.type === "app_server_reply").text, "fresh thread で復旧しました。");
+  assert.deepEqual(defaultRequests, ["thread/resume", "turn/start"]);
+  assert.deepEqual(fallbackRequests, ["thread/start", "turn/start"]);
+  assert.deepEqual(created.map((client) => client.args), [
+    ["app-server", "--listen", "stdio://", "-c", 'model="gpt-5.5"', "-c", 'model_reasoning_effort="low"']
   ]);
   socket.emit("close");
   await once;

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -5035,6 +5035,69 @@ test("DashboardChatRoom resets overfull app-server backend thread and retries on
   assert.match(transient.text, /backend thread を切り替えて/);
 });
 
+test("DashboardChatRoom resets unsupported-model app-server backend thread and retries once", async () => {
+  const store = createInMemoryDashboardChatStore();
+  const dashboardSocket = createMockSocket("dashboard", "dashboard-main-unresolved");
+  const bridgeSocket = createMockSocket("app_server_bridge", "dashboard-main-unresolved");
+  const storage = createMockDurableObjectStorage();
+  storage.values.set("app_server_thread:dashboard-main-unresolved", {
+    codexThreadId: "codex-thread-stale-5-3",
+    updatedAt: "2026-06-05T00:00:00.000Z"
+  });
+  const room = new DashboardChatRoom(
+    {
+      storage,
+      getWebSockets() {
+        return [dashboardSocket, bridgeSocket];
+      }
+    },
+    { DASHBOARD_CHAT_STORE: store }
+  );
+
+  await room.webSocketMessage(
+    bridgeSocket,
+    JSON.stringify({
+      type: "app_server_turn_failed",
+      status: "failed",
+      threadId: "dashboard-main-unresolved",
+      codexThreadId: "codex-thread-stale-5-3",
+      repository: "marushu/vtdd-v2-p",
+      relatedIssue: 455,
+      text:
+        "codex app-server が応答生成中に失敗しました。詳細: The 'gpt-5.3-codex' model is not supported when using Codex with a ChatGPT account.",
+      recovery: {
+        status: "unsupported_model",
+        retryable: true,
+        resetBackendThread: true,
+        autoRetry: true,
+        originalText: "君は誰？",
+        originalMessageId: "dashboard_owner_message:unsupported-model-1"
+      }
+    })
+  );
+
+  assert.equal(storage.values.get("app_server_thread:dashboard-main-unresolved"), undefined);
+  assert.ok(storage.deleteCalls.some((call) => call.key === "app_server_thread:dashboard-main-unresolved"));
+  assert.ok(storage.values.get("app_server_context_retry:dashboard-main-unresolved:dashboard_owner_message:unsupported-model-1"));
+
+  const turnRequest = bridgeSocket.sent.map((message) => JSON.parse(message)).find((message) => message.type === "app_server_turn_requested");
+  assert.ok(turnRequest);
+  assert.equal(turnRequest.threadId, "dashboard-main-unresolved");
+  assert.equal(turnRequest.codexThreadId, null);
+  assert.equal(turnRequest.appServer.startThreadMethod, "thread/start");
+  assert.equal(turnRequest.text, "君は誰？");
+  assert.equal(turnRequest.messageId, "dashboard_owner_message:unsupported-model-1");
+  assert.equal(turnRequest.repository, "marushu/vtdd-v2-p");
+  assert.equal(turnRequest.relatedIssue, 455);
+
+  const stored = await store.listThread("dashboard-main-unresolved");
+  assert.equal(stored.length, 0);
+  const transient = dashboardSocket.sent.map((message) => JSON.parse(message)).find((message) => message.type === "transient_status");
+  assert.ok(transient);
+  assert.equal(transient.status, "thinking");
+  assert.match(transient.text, /backend thread を切り替えて/);
+});
+
 test("DashboardChatRoom does not loop over app-server context reset retries", async () => {
   const store = createInMemoryDashboardChatStore();
   const dashboardSocket = createMockSocket("dashboard", "dashboard-main-unresolved");

--- a/worker.js
+++ b/worker.js
@@ -66804,7 +66804,7 @@ function normalizeDashboardAppServerRecovery(value) {
   const originalText = sanitizeDashboardChatText(input.originalText || input.original_text);
   const originalMessageId = normalizeDashboardEventText(input.originalMessageId || input.original_message_id);
   const resetBackendThread = input.resetBackendThread === true || input.reset_backend_thread === true;
-  const retryable = input.retryable === true || status === "context_window_exceeded";
+  const retryable = input.retryable === true || status === "context_window_exceeded" || status === "unsupported_model";
   const autoRetry = input.autoRetry === true || input.auto_retry === true;
   if (!status && !originalText && !originalMessageId && !resetBackendThread && !retryable && !autoRetry) {
     return null;
@@ -66820,7 +66820,8 @@ function normalizeDashboardAppServerRecovery(value) {
 }
 function shouldResetDashboardAppServerBackendThread(recovery) {
   const normalized = normalizeDashboardAppServerRecovery(recovery);
-  return normalized?.status === "context_window_exceeded" && normalized.retryable === true && normalized.resetBackendThread === true;
+  const resettableStatus = normalized?.status === "context_window_exceeded" || normalized?.status === "unsupported_model";
+  return resettableStatus && normalized.retryable === true && normalized.resetBackendThread === true;
 }
 function normalizeDashboardTransientProgressSnapshot(value) {
   const input = normalizeObject12(value);


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #455 の部分進捗として、cost/model routing の軽量化コードが Dashboard Butler の app-server bridge を unsupported model ループに落とす回帰を復旧します。
VPS Codex CLI / codex app-server が古い backend thread 由来の 'gpt-5.3-codex' unsupported を返した場合、同じ thread を resume し続けず新規 backend thread に切り替えます。

## Satisfied Success Criteria

- unsupported ChatGPT account model error を recovery.status=unsupported_model として扱い、Worker が backend thread mapping を削除して retry できるようにしました。
bridge fallback が元 payload の codexThreadId を持ったまま再送しないようにし、新規 thread/start で再送します。
エラー本文から実際に拒否された model を抽出し、現行 defaultModel と違う場合は現行 defaultModel を維持します。repo に gpt-5.5 は固定していません。

## Unsatisfied Success Criteria

- Issue #455 全体の usage 可視化、duplicate reviewer 抑止、queue/throttle/defer 方針、Codex Analytics による消費量比較はこのPRでは未完了です。
production deploy 後の Dashboard Butler live E2E と、復旧後に VPS env の model 指定を外した model-less 実測は merge 後作業です。

## Non-goal violations

ChatGPT / Codex の料金体系や model default 仕様を断定しない。
repo に特定 model 名を恒久固定しない。
安全 gate、reviewer gate、passkey gate は変更しない。
deploy、credential、VPS privileged maintenance はこのPRでは実行しない。

## 開発前作戦図

- 作戦図 evidence: docs/development-strategy/issue-455-reset-unsupported-model-thread.md
- 完了体験: Dashboard Butler が 'gpt-5.3-codex' unsupported を受けても、同じ古い Codex backend thread を resume し続けず、同じ owner 入力を新規 backend thread に再送する。
- VTDD 全体で進める部分: Dashboard Butler -> Worker DashboardChatRoom -> VPS app-server bridge -> Codex app-server の復旧経路。
- 設計: Butler owner-facing surface の完了設計として、unsupported_model recovery を Worker の backend thread reset 対象に追加し、bridge fallback は codexThreadId=null で thread/start する。scope は Dashboard Butler chat と VPS app-server bridge 境界に限定し、repo に model 名は固定しない。
- 仮説: 原因仮説: 本番では Codex CLI 0.137.0 と gpt-5.5 明示後も、Dashboard thread に保存された古い codexThreadId が gpt-5.3-codex を保持しており、PR #788 の fallback も同じ codexThreadId を引き継いだため壊れた thread に戻った。
- 検証計画: 検証計画: bridge integration test、Worker integration test、worker bundle rebuild、npm test で仮説を検証する。merge 後は Dashboard Butler live E2E と model-less 再実測で runtime truth を確認する。
- 改修見積もり: scripts/run-dashboard-app-server-bridge.mjs: unsupported model extraction/recovery/fallback payload。src/worker/runtime.js: resettable recovery status。test/dashboard-app-server-bridge.test.js / test/worker.test.js: regression tests。worker.js: generated bundle。
- 既に通っている経路: context_window_exceeded は既に mapping clear + codexThreadId=null retry が通っていた。PR #788 で unsupported model classifier と fallback status は入っていた。
- 未確認の境界: Codex CLI の model-less default が今後どの model を選ぶかは repo から断定できない。production E2E と model-less 再実測が必要。
- 穴が出そうな箇所: fallback が codexThreadId を引き継ぐ、Worker が unsupported_model を generic failure として保存する、model-less fallback が壊れた default に戻る、運用の gpt-5.5 指定が repo 固定と誤解される。
- PR 前に確認すること: Issue #455、PR #788、VPS runtime truth、targeted tests、worker bundle、未追跡 E2E assets の非stage確認。
- 実装候補と捨てた案: Codex CLI update だけで直す案は 0.137.0 でも再発したため不採用。model-less fallback のみは default が unsupported に流れるため不採用。
- merge 後に通す E2E: merge 後 E2E: production deploy と bridge restart 後、Dashboard Butler live E2E で '君は誰？' を送り unsupported model で止まらず返信が返ることを検証する。その後、VPS env の model 指定を外して model-less 新規 thread が動くか検証する。
- 次の PR を増やさない理由: この次の PR を増やさない理由: unsupported recovery、Worker mapping reset、bridge retry payload は同じ範囲の穴であり、分けると同じ古い backend thread に戻る。残る #455 作業は別 scope として残す。
- 停止条件: credential / billing / account / deploy / root helper mutation が必要になった場合、または unsupported model 以外の quota/auth policy へ広がる場合。

## Dry-run Impact Report

- Target Issue: Issue #455
- Implementing Success Criteria: 軽量 read/status/dashboard 表示の fast path と cost/model routing の一部として、unsupported model で app-server bridge が使用不能になる回帰を止める。
- Explicit Non-goals: Issue #455 全体完了、料金推測、model 固定、deploy/credential mutation。
- Expected touched files/routes/workflows: scripts/run-dashboard-app-server-bridge.mjs, src/worker/runtime.js, worker.js, test/dashboard-app-server-bridge.test.js, test/worker.test.js, docs/development-strategy/issue-455-reset-unsupported-model-thread.md
- Affected Issues: #455
- Affected PRs: #788 の fallback 実装に対する追加修正。
- Affected workflows: GitHub Actions tests only. deploy-production はこのPRでは未実行。
- Affected runtime/operator surfaces: Dashboard Butler chat, Worker DashboardChatRoom, VPS app-server bridge, Codex app-server backend thread mapping.
- What may break if we patch narrowly: bridge だけ直すと Worker mapping が残る。Worker だけ直すと bridge fallback が古い codexThreadId を再利用する。model-less だけに逃がすと壊れた default に戻る。
- Unknowns to investigate before coding: model-less default の今後の選択仕様、production E2E での gpt-5.5 新規 thread 成功、復旧後 model-less へ戻した時の挙動。
- Validation needed: node --test test/dashboard-app-server-bridge.test.js test/worker.test.js; npm run build:worker; git diff --check; npm test; post-merge production E2E.
- Stop condition: deploy, credential mutation, root privileged maintenance, unsupported model 以外の quota/auth 改修へ広がる場合。

## Execution Queue Delta

- Queue position before: Issue #455 の runtime blocker 復旧 slice。Dashboard Butler が app-server bridge を使えない状態を先に戻す。
- Preemption decision: NEXT: OWNER-REPORTED runtime regression として #455 の現在 blocker に集中。active Issues は縮小しない。
- Queue delta: Issue #455 の cost/model routing regression を部分的に前進。全体の usage 可視化と throttle 方針は未完了。
- Why this PR is next: Butler で開発と消費量実測を続ける前提として、Dashboard Butler -> VPS Codex CLI の通常応答が復旧している必要があるため。
- Active Issues not downscoped: Active Issues は縮小しません。このPRで扱わない #455 criteria と他 active Issues は未完了として残す。

## File / Line Hypotheses

- file: scripts/run-dashboard-app-server-bridge.mjs
  - hypothesis: unsupported model fallback が元 payload の codexThreadId を持つため古い backend thread を resume して再発する。
  - risk if changed narrowly: model-less default が壊れている環境で再発する。
  - validation: stale thread integration test。
  - related Issue: #455
- file: src/worker/runtime.js
  - hypothesis: unsupported_model が reset 対象でないため app_server_thread mapping が残る。
  - risk if changed narrowly: generic failure として保存され owner が短く再送するしかなくなる。
  - validation: Worker retry test。
  - related Issue: #455

## Hypothesis Retrospective

- expected: unsupported model が古い thread 由来なら新規 backend thread で retry する。
- actual: targeted tests と npm test で確認。production live E2E は merge/deploy 後。
- mismatch: なし。
- lesson: cost-saving fallback は model 指定だけでなく backend thread mapping を同時に扱わないと危険。
- should become RAG candidate: 既に本障害の root cause を working_memory に保存済み。

## Verification Evidence

- Unit: node --test test/dashboard-app-server-bridge.test.js test/worker.test.js: pass (354 tests).
- Integration: npm test: pass (1204 pass, 1 skipped). npm run build:worker: pass. git diff --check: pass.
- E2E: 未実施。production deploy + bridge restart 後に Dashboard Butler live E2E が必要。
- Manual: VPS read-only investigationで codex-cli 0.137.0、model-less default/old backend thread が gpt-5.3-codex unsupported を返す事実を確認済み。
- Evidence path/link: docs/development-strategy/issue-455-reset-unsupported-model-thread.md

## Butler Completion Contract

- Primary owner surface: Dashboard Butler
- Fallback surface: mac Codex は緊急修正面。通常運用は Dashboard Butler -> VPS Codex CLI。
- Owner goal: Dashboard Butler が AI風に止めず VPS Codex CLI へ届き、unsupported model で同じ thread を再利用し続けないこと。
- Butler entrypoint: Dashboard Butler 通常チャット入口。
- Dashboard Butler natural-language path: Dashboard Butler の自然文/通常チャット入口から owner 入力を受け、Worker を経由して VPS app-server bridge へ到達する経路。
- Action Schema exposure: Custom GPT Action Schema は未変更。primary path ではない。
- Runtime path: DashboardChatRoom acceptAppServerBridgeMessage -> clearAppServerThreadMapping -> retryDashboardAppServerTurnAfterContextReset -> app-server bridge fallback thread/start.
- Runner/runtime truth: PR内では local tests。production runtime truth は merge/deploy/restart 後に確認する。
- Authority boundary: コード変更のみ。deploy/bridge restart/model env rollback は passkey/operation boundary の後続作業。
- E2E evidence: 未実施。merge/deploy後に Dashboard Butler live E2E が必要。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: このPRでは未実行。merge後に production deploy が必要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: merge/deploy後に必要。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate
AGENTS.md Drift Stop Protocol
AGENTS.md 開発前作戦図 Gate
AGENTS.md RAG Memory Capture and Cost Boundary
Issue #455 Non-goal: 料金体系を推測で断定しない

## Out-of-scope but NOT implemented

- Issue #455 全 criteria の完了。
Codex Analytics 自動観測の追加。
処理レーン分離。
VPS env から model 指定を外す運用作業。
production deploy / bridge restart。

## Extra changes (if any)

未追跡の docs/mvp/e2e/assets/* は今回のPRに含めない。

<!-- VTDD metadata -->
- Issue: Issue #455
- Execution ID: mac-codex-issue-455-unsupported-model-reset-20260605
- Goal: Dashboard Butler app-server bridge unsupported model recovery
