### PR TITLE
Fix app-server thread source protocol drift

### DIFF
--- a/docs/development-strategy/issue-455-app-server-thread-source-user.md
+++ b/docs/development-strategy/issue-455-app-server-thread-source-user.md
@@ -1,0 +1,70 @@
+# Issue #455 app-server threadSource protocol drift 作戦図
+
+## 完了体験
+
+Dashboard Butler から通常入力を送った時、Codex app-server が `Invalid request: unknown variant app_server` で即失敗しない。owner は同じ Dashboard Butler chat で VPS Codex CLI からの返答を受け取れる。
+
+## VTDD 全体で進める部分
+
+Dashboard Butler -> Worker DashboardChatRoom -> VPS app-server bridge -> Codex app-server の `thread/start` protocol drift を修正する。PR #789 で backend thread reset は直したが、Codex CLI 0.137.0 は `threadSource: "app_server"` を受け付けず、`user | subagent | memory_consolidation` の enum を要求している。
+
+## 設計
+
+`buildAppServerThreadStartRequest` の `threadSource` を Codex CLI 0.137.0 が受け付ける owner-facing 通常 thread 種別に合わせて `"user"` に変更する。これは Dashboard Butler が AI として振る舞うためではなく、owner の通常会話 turn を app-server に開始させる protocol value である。scope は app-server bridge の thread start request とその test に限定する。
+
+## 仮説
+
+原因仮説: deploy 後の VPS Codex CLI 0.137.0 で `thread/start.params.threadSource` の enum が変わり、既存コードの `"app_server"` が invalid variant として拒否された。`expected one of user, subagent, memory_consolidation` という実エラー文と、コード上の `threadSource: "app_server"` が一致している。
+
+## 検証計画
+
+- Unit: thread/start request が `threadSource: "user"` を送ることを確認する。
+- Integration: dashboard app-server bridge の既存 integration tests が通ることを確認する。
+- Local: `node --test test/dashboard-app-server-bridge.test.js`
+- Local: `npm run build:worker` は不要。Worker source は触らない。
+- Local: `git diff --check`
+- Local: `npm test`
+
+## 改修見積もり
+
+- `scripts/run-dashboard-app-server-bridge.mjs`: `buildAppServerThreadStartRequest` の `threadSource` literal を変更。
+- `test/dashboard-app-server-bridge.test.js`: thread start request の expected value を追加または更新。
+
+## 既に通っている経路
+
+bridge は `thread/start` と `turn/start` を組み立てて Codex app-server に送っている。VPS runtime は最新 main `37021db` で bridge restart 済みだが、実 turn は `unknown variant app_server` で失敗した。
+
+## 未確認の境界
+
+`threadSource: "user"` が production app-server で通常会話 turn として成功することは、merge/deploy/bridge restart 後の live E2E で確認する。
+
+## 穴が出そうな箇所
+
+- `threadSource` を削除するだけだと Codex CLI 側 default が不明になる。
+- `"subagent"` は owner-facing Dashboard Butler thread ではなく、意味が違う。
+- `"memory_consolidation"` は通常会話ではない。
+- model / backend thread reset の問題と混ぜると原因を誤る。
+
+## PR 前に確認すること
+
+Issue #455、PR #789、VPS runtime error、`buildAppServerThreadStartRequest`、該当 test、未追跡 E2E assets を stage しないこと。
+
+## 実装候補と捨てた案
+
+採用: `threadSource` を `"user"` にする。owner の通常入力を Codex app-server に渡す thread として enum 意味が合う。
+
+捨てた案: `threadSource` を削除する。Codex CLI default が未確認で、また protocol drift を隠すため不採用。
+
+捨てた案: `"subagent"` にする。Dashboard Butler は subagent thread ではないため不採用。
+
+## merge 後に通す E2E
+
+production deploy と bridge restart 後、Dashboard Butler で短い通常入力を送り、`unknown variant app_server` で失敗せず reply が返ることを live E2E として確認する。
+
+## 次の PR を増やさない理由
+
+今回の failure は `thread/start` の単一 protocol enum drift で、bridge request builder と test を同時に直せば owner-facing blocker を閉じられる。model-less rollback や cost analytics は別 scope として残す。
+
+## 停止条件
+
+Codex CLI が `"user"` でも拒否する、または `thread/start` の request schema 全体が変わっていて追加の protocol discovery が必要になった場合。deploy、credential、billing、permission mutation が必要になった場合。

--- a/scripts/run-dashboard-app-server-bridge.mjs
+++ b/scripts/run-dashboard-app-server-bridge.mjs
@@ -70,7 +70,7 @@ export function buildAppServerThreadStartRequest({ id, cwd = process.cwd(), deve
           "High-risk work requires explicit GO or passkey approval through VTDD runtime boundaries.",
           "Reply in Japanese by default."
         ].join("\n"),
-      threadSource: "app_server",
+      threadSource: "user",
       ...(sandbox.threadSandbox ? { sandbox: sandbox.threadSandbox } : {}),
       experimentalRawEvents: false,
       persistExtendedHistory: false

--- a/test/dashboard-app-server-bridge.test.js
+++ b/test/dashboard-app-server-bridge.test.js
@@ -69,6 +69,7 @@ test("dashboard app-server bridge builds initialize and thread requests from Cod
   assert.equal(start.method, "thread/start");
   assert.equal(start.params.cwd, "/repo");
   assert.equal(start.params.approvalPolicy, "on-request");
+  assert.equal(start.params.threadSource, "user");
   assert.equal(start.params.sandbox, undefined);
   assert.equal(start.params.experimentalRawEvents, false);
   assert.equal(start.params.persistExtendedHistory, false);


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #455 の部分進捗として、Codex CLI 0.137.0 の app-server protocol drift により Dashboard Butler が unknown variant app_server で止まる回帰を修正します。
Dashboard Butler の通常入力を VPS Codex CLI に届ける thread/start request を、現行 CLI が受け付ける threadSource=user に合わせます。

## Satisfied Success Criteria

- thread/start.params.threadSource を app_server から user に変更しました。
app-server bridge unit test で threadSource=user を明示検証しました。
repo に model 固定や権限変更は追加していません。

## Unsatisfied Success Criteria

- Issue #455 全体の usage 可視化、duplicate reviewer 抑止、queue/throttle/defer 方針、Codex Analytics による消費量比較はこのPRでは未完了です。
production deploy 後の Dashboard Butler live E2E は merge 後作業です。

## Non-goal violations

ChatGPT / Codex の料金体系や model default 仕様を断定しない。
model 指定、credential、permission、deploy workflow は変更しない。
Worker source は変更しない。

## 開発前作戦図

- 作戦図 evidence: docs/development-strategy/issue-455-app-server-thread-source-user.md
- 完了体験: Dashboard Butler から通常入力を送った時、Codex app-server が Invalid request unknown variant app_server で即失敗せず、VPS Codex CLI の返答を受け取れる。
- VTDD 全体で進める部分: Dashboard Butler -> Worker DashboardChatRoom -> VPS app-server bridge -> Codex app-server の thread/start protocol。
- 設計: Butler owner-facing surface の通常チャットを Codex app-server に渡す scope に限定し、threadSource を現行 CLI enum の user に合わせる。subagent や memory_consolidation は owner-facing 通常 thread ではないため使わない。
- 仮説: 原因仮説: Codex CLI 0.137.0 で thread/start.params.threadSource の enum が user/subagent/memory_consolidation に変わり、既存の app_server literal が invalid variant として拒否された。実エラー文とコード上の literal が一致している。
- 検証計画: 検証計画: thread/start request unit test、dashboard app-server bridge integration tests、git diff --check、npm test で確認する。merge 後に Dashboard Butler live E2E を行う。
- 改修見積もり: scripts/run-dashboard-app-server-bridge.mjs: buildAppServerThreadStartRequest の threadSource literal。test/dashboard-app-server-bridge.test.js: expected value。docs/development-strategy/issue-455-app-server-thread-source-user.md: 作戦図。
- 既に通っている経路: VPS は PR #789 の merge SHA 37021db で deploy/restart 済みだが、実 turn は unknown variant app_server で失敗した。
- 未確認の境界: threadSource=user が production app-server で通常会話 turn として成功することは merge/deploy/restart 後の live E2E で確認する。
- 穴が出そうな箇所: threadSource を削除すると default が不明になる。subagent は意味が違う。model/backend thread 問題と混ぜると原因を誤る。
- PR 前に確認すること: Issue #455、PR #789、VPS runtime error、buildAppServerThreadStartRequest、該当 test、未追跡 E2E assets の非stage確認。
- 実装候補と捨てた案: threadSource 削除案は default 未確認のため不採用。subagent/memory_consolidation は通常 owner chat thread ではないため不採用。
- merge 後に通す E2E: merge 後 E2E: production deploy と bridge restart 後、Dashboard Butler live E2E で短い通常入力を送り unknown variant app_server で失敗せず返信が返ることを検証する。
- 次の PR を増やさない理由: この次の PR を増やさない理由: failure は thread/start の単一 protocol enum drift で、request builder と test を同時に直せばこの owner-facing blocker は閉じられる。残る #455 作業は別 scope として残す。
- 停止条件: Codex CLI が user でも拒否する、thread/start schema 全体が変わっている、deploy/credential/billing/permission mutation が必要になる場合。

## Dry-run Impact Report

- Target Issue: Issue #455
- Implementing Success Criteria: 軽量/cost routing の復旧前提として、Dashboard Butler の通常入力が app-server protocol drift で即失敗しないこと。
- Explicit Non-goals: Issue #455 全体完了、model 固定、deploy/credential mutation、Worker source 変更。
- Expected touched files/routes/workflows: scripts/run-dashboard-app-server-bridge.mjs, test/dashboard-app-server-bridge.test.js, docs/development-strategy/issue-455-app-server-thread-source-user.md
- Affected Issues: #455
- Affected PRs: #789 の deploy 後に露呈した protocol drift への追加修正。
- Affected workflows: GitHub Actions tests only. deploy-production はこのPRでは未実行。
- Affected runtime/operator surfaces: Dashboard Butler chat, VPS app-server bridge, Codex app-server thread/start.
- What may break if we patch narrowly: model/backend thread reset 側だけを見ると今回の enum drift を見落とす。threadSource を削除すると Codex CLI default に依存する。
- Unknowns to investigate before coding: production app-server で threadSource=user が通常会話 turn として成功するか。
- Validation needed: node --test test/dashboard-app-server-bridge.test.js; git diff --check; npm test; post-merge production E2E.
- Stop condition: thread/start schema 全体の変更、deploy、credential、permission、quota/auth 改修へ広がる場合。

## Execution Queue Delta

- Queue position before: Issue #455 の runtime blocker 復旧 slice。Dashboard Butler が app-server bridge を使えない状態を戻す。
- Preemption decision: NEXT: OWNER-REPORTED runtime regression として Issue #455 の現在 blocker に集中。active Issues は縮小しない。
- Queue delta: Issue #455 の app-server protocol drift blocker を部分的に前進。全体の usage 可視化と throttle 方針は未完了。
- Why this PR is next: Butler で開発と消費量実測を続ける前提として、Dashboard Butler -> VPS Codex CLI の通常応答が復旧している必要があるため。
- Active Issues not downscoped: Active Issues は縮小しません。このPRで扱わない #455 criteria と他 active Issues は未完了として残す。

## File / Line Hypotheses

- file: scripts/run-dashboard-app-server-bridge.mjs
  - hypothesis: threadSource app_server が Codex CLI 0.137.0 enum から外れたため Invalid request になっている。
  - risk if changed narrowly: user 以外の enum を選ぶと通常 owner chat の意味が壊れる。
  - validation: thread start request unit test。
  - related Issue: #455

## Hypothesis Retrospective

- expected: threadSource=user にすると unknown variant app_server は出なくなる。
- actual: local tests で request shape を確認。production live E2E は merge/deploy 後。
- mismatch: なし。
- lesson: Codex CLI update 後は model だけでなく app-server protocol enum drift も疑う必要がある。
- should become RAG candidate: yes.

## Verification Evidence

- Unit: node --test test/dashboard-app-server-bridge.test.js: pass (75 tests).
- Integration: npm test: pass (1204 pass, 1 skipped). git diff --check: pass.
- E2E: 未実施。production deploy + bridge restart 後に Dashboard Butler live E2E が必要。
- Manual: VPS runtime error: Invalid request: unknown variant app_server, expected one of user, subagent, memory_consolidation。
- Evidence path/link: docs/development-strategy/issue-455-app-server-thread-source-user.md

## Butler Completion Contract

- Primary owner surface: Dashboard Butler
- Fallback surface: mac Codex は緊急修正面。通常運用は Dashboard Butler -> VPS Codex CLI。
- Owner goal: Dashboard Butler が app-server protocol drift で止まらず VPS Codex CLI へ届くこと。
- Butler entrypoint: Dashboard Butler 通常チャット入口。
- Dashboard Butler natural-language path: Dashboard Butler の自然文/通常チャット入口から owner 入力を受け、Worker を経由して VPS app-server bridge へ到達する経路。
- Action Schema exposure: Custom GPT Action Schema は未変更。primary path ではない。
- Runtime path: DashboardChatRoom app_server_turn_requested -> run-dashboard-app-server-bridge buildAppServerThreadStartRequest -> Codex app-server thread/start。
- Runner/runtime truth: PR内では local tests。production runtime truth は merge/deploy/restart 後に確認する。
- Authority boundary: コード変更のみ。deploy/bridge restart は passkey/operation boundary の後続作業。
- E2E evidence: 未実施。merge/deploy後に Dashboard Butler live E2E が必要。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: このPRでは未実行。merge後に production deploy が必要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: merge/deploy後に必要。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate
AGENTS.md Drift Stop Protocol
AGENTS.md 開発前作戦図 Gate
Issue #455 Non-goal: 料金体系を推測で断定しない

## Out-of-scope but NOT implemented

- Issue #455 全 criteria の完了。
Codex Analytics 自動観測の追加。
VPS env から model 指定を外す運用作業。
production deploy / bridge restart。

## Extra changes (if any)

Worker source は触っていないため worker.js は変更しない。未追跡の docs/mvp/e2e/assets/* は今回のPRに含めない。

<!-- VTDD metadata -->
- Issue: Issue #455
- Execution ID: mac-codex-issue-455-thread-source-user-20260605
- Goal: Dashboard Butler app-server threadSource protocol recovery
