### PR TITLE
Issue #590 app-server stall recovery timeout

### DIFF
--- a/docs/development-strategy/issue-590-app-server-stall-recovery.md
+++ b/docs/development-strategy/issue-590-app-server-stall-recovery.md
@@ -1,0 +1,73 @@
+# Issue #590 app-server stall recovery strategy
+
+## 完了体験
+
+Owner が Dashboard Butler repo-less main chat で通常メッセージを送った後、codex app-server が応答を返さない場合でも、Dashboard thread には日本語の復帰可能メッセージが残る。composer は次の入力へ戻り、owner は同じ thread で補足または再送できる。12:25 JST の `君は誰？` のように「Codex app-server に渡しています」で止まったままにはしない。
+
+## VTDD 全体で進める部分
+
+この slice は Issue #590 の timeout / stall recovery に限定する。VPS env の `VTDD_DASHBOARD_APP_SERVER_MODEL=gpt-5.5` 解除、systemd restart、deploy、credential mutation は別の approval-bound recovery として扱う。mac Codex の SSH read は `mac_codex_only_probe` の証跡であり、Butler 完了ではない。
+
+## 設計
+
+`handleDashboardTurnRequest()` は `thread/start` / `thread/resume` と `turn/start` の複数 await を持つ。現状の watchdog は主に turn notification 後の activity を見ており、app-server request 自体が返らない場合や fallback client 初期化後に completion が来ない場合、Dashboard thread に final failure が残らない可能性がある。
+
+この PR では turn 全体を包む deadline を追加し、`thread/start`、media materialize、`turn/start`、`turnCompletion` のどこで止まっても `app_server_turn_failed` timeout event を一度だけ送る。既存の late completion handling は維持し、後から reply が来た場合は既存の late reply path に任せる。
+
+## 仮説
+
+12:25 JST の production truth では、owner message は `dashboard-main-unresolved` に保存され、transient progress は `Codex app-server に渡しています ... usage_profile=conversation / reasoning_effort=low` まで更新された。その後、thread に failed/replied message が追加されていない。VPS service は active で、bridge process 配下に複数の app-server child が残っていた。したがって Worker/D1/runner delivery ではなく、bridge 内の app-server turn completion 停止を owner-facing event へ変換できていないことが root blocker。
+
+## 検証計画
+
+Unit: `node --test test/dashboard-app-server-bridge.test.js` で `thread/start` が返らない場合に timeout event が送信されることを確認する。
+
+Unit: `node --test test/dashboard-app-server-bridge.test.js` で `turn/start` 後に completion notification が来ない場合も timeout event が送信されることを確認する。
+
+Integration: `npm run build:worker` と `npm run check:generated-worker` を実行し、bundled worker に構文破綻がないことを確認する。
+
+E2E: merge/deploy 後、Dashboard repo-less main chat で短文を送り、unsupported/stall の場合でも thread に復帰可能な failed message が残ることを確認する。deploy と VPS restart は passkey 境界なので、この PR 作成時点では E2E は未実施として扱う。
+
+## 改修見積もり
+
+- `scripts/run-dashboard-app-server-bridge.mjs`: `handleDashboardTurnRequest()` に one-shot turn deadline helper を追加する。risk は既存 late completion / unsupported model fallback と二重 failure event を出すこと。
+- `test/dashboard-app-server-bridge.test.js`: hanging fake app-server で timeout event を検証する。risk は test runtime が長くなることなので short timeout を使う。
+- `worker.js`: worker bundle discipline に従い、source が bundle される場合は生成物を更新する。
+
+## 既に通っている経路
+
+PR #790 は `threadSource: "user"` に変更済みで、production deploy SHA `7d5dee2c32b50788aa8045c189efb615203c4a65` が VPS checkout に反映されている。Dashboard HTTP chat API、GitHub issue queue、VPS runner low-risk read、Dashboard event delivery は #741 の status/logs queue で通過した。
+
+## 未確認の境界
+
+`gpt-5.5` が ChatGPT account の codex app-server で正式に supported かはこの PR では断定しない。VPS env 変更と restart は scoped passkey approval が必要な runtime mutation として残す。
+
+## 穴が出そうな箇所
+
+unsupported model fallback が reject path に入り、outer deadline と inner failure が二重に送られる可能性がある。`timeoutSent` / `turnSettled` で一度だけ送る。
+
+`thread/start` が詰まると `codexThreadId` がない timeout event になる。これは許容し、owner-facing には「入力は保存済み」と出す。
+
+## PR 前に確認すること
+
+Git branch が `issue-590-app-server-stall-recovery` で、未追跡 E2E asset を PR に混ぜない。PR body には #590 criteria と 12:25 JST production probe を partial evidence として書く。
+
+## 実装候補と捨てた案
+
+採用: bridge 内 deadline を追加し、app-server request が返らなくても Dashboard event を送る。
+
+捨てた案: Worker fast path で `君は誰？` に直接答える。過去に「Dashboard Butler は AI ではなく app-server bridge へ届ける中継機」という方針へ戻しており、今回の #590 root blocker は timeout recovery である。
+
+捨てた案: mac Codex から VPS env を直接編集して restart する。短期復旧には有効だが passkey 境界であり、code PR の completion evidence にはならない。
+
+## merge 後に通す E2E
+
+Production deploy 後、repo-less main chat で `君は誰？` または `もしもし` を送る。reply が返る場合は成功、app-server が詰まる場合でも #590 の日本語 recovery message が thread に残り composer が戻ることを確認する。
+
+## 次の PR を増やさない理由
+
+この PR は既存 #590 の最小 slice で、runtime env model 問題や lifecycle restart policy は #455/#741 に残す。timeout recovery を先に入れることで、次の env/restart 作業が失敗しても owner-facing に詰まりを残さない。
+
+## 停止条件
+
+timeout event を送るために deploy、credential mutation、permission mutation、VPS env mutation が必要になる場合は停止する。app-server reply と timeout failure が同じ turn で二重に thread append される設計になる場合も停止する。

--- a/scripts/run-dashboard-app-server-bridge.mjs
+++ b/scripts/run-dashboard-app-server-bridge.mjs
@@ -1703,9 +1703,48 @@ export async function handleDashboardTurnRequest({
   }
 
   let codexThreadId = request.codexThreadId || null;
+  let timedOut = false;
+  let timeoutFailureSent = false;
+  const sendTimeoutFailureOnce = async () => {
+    if (timeoutFailureSent) return;
+    timeoutFailureSent = true;
+    timedOut = true;
+    await sendDashboardEvent(
+      buildAppServerTurnTimeoutEvent({
+        dashboardThreadId,
+        codexThreadId,
+        repository: request.repository,
+        relatedIssue: request.relatedIssue || request.issueNumber,
+        ownerText: text
+      })
+    );
+  };
+  const awaitAppServerRequestWithTimeout = async (promise) => {
+    const timeoutMs = Number(turnTimeoutMs);
+    if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+      return await promise;
+    }
+    let timeoutHandle = null;
+    try {
+      return await Promise.race([
+        promise,
+        new Promise((_, reject) => {
+          timeoutHandle = setTimeout(() => {
+            sendTimeoutFailureOnce()
+              .catch(() => {})
+              .finally(() => reject(createAppServerFailureAlreadySentError(APP_SERVER_TURN_TIMEOUT_TEXT)));
+          }, timeoutMs);
+        })
+      ]);
+    } finally {
+      clearTimeout(timeoutHandle);
+    }
+  };
   const resumedExistingThread = Boolean(codexThreadId);
   if (codexThreadId) {
-    await appServer.request(buildAppServerThreadResumeRequest({ id: appServer.nextRequestId(), codexThreadId, cwd, sandboxMode }));
+    await awaitAppServerRequestWithTimeout(
+      appServer.request(buildAppServerThreadResumeRequest({ id: appServer.nextRequestId(), codexThreadId, cwd, sandboxMode }))
+    );
     await sendDashboardEvent(
       buildDashboardBridgeResumeStatusEvent({
         dashboardThreadId,
@@ -1714,7 +1753,9 @@ export async function handleDashboardTurnRequest({
       })
     );
   } else {
-    const started = await appServer.request(buildAppServerThreadStartRequest({ id: appServer.nextRequestId(), cwd, sandboxMode }));
+    const started = await awaitAppServerRequestWithTimeout(
+      appServer.request(buildAppServerThreadStartRequest({ id: appServer.nextRequestId(), cwd, sandboxMode }))
+    );
     codexThreadId = started?.thread?.id || null;
     await sendDashboardEvent({
       type: "app_server_status",
@@ -1729,7 +1770,6 @@ export async function handleDashboardTurnRequest({
   let accumulatedText = "";
   let activeTurnId = "";
   let turnSettled = false;
-  let timedOut = false;
   let lateCompletionCleanupHandle = null;
   let liveProgressFallbackHandle = null;
   let liveProgressFallbackCount = 0;
@@ -1752,15 +1792,7 @@ export async function handleDashboardTurnRequest({
         text: APP_SERVER_TURN_QUIET_TEXT
       }),
     onStalled: () => {
-      timedOut = true;
-      const timeoutEvent = buildAppServerTurnTimeoutEvent({
-        dashboardThreadId,
-        codexThreadId,
-        repository: request.repository,
-        relatedIssue: request.relatedIssue || request.issueNumber,
-        ownerText: text
-      });
-      void sendDashboardEvent(timeoutEvent);
+      void sendTimeoutFailureOnce();
       lateCompletionCleanupHandle = setTimeout(() => {
         cleanupNotifications();
       }, lateCompletionTimeoutMs);
@@ -1937,14 +1969,16 @@ export async function handleDashboardTurnRequest({
       costBoundary: turnCostBoundary,
       mediaReferences: materializedMediaReferences
     });
-    const startedTurn = await appServer.request(
-      buildAppServerTurnStartRequest({
-        id: appServer.nextRequestId(),
-        codexThreadId,
-        text: turnInputText,
-        cwd,
-        sandboxMode
-      })
+    const startedTurn = await awaitAppServerRequestWithTimeout(
+      appServer.request(
+        buildAppServerTurnStartRequest({
+          id: appServer.nextRequestId(),
+          codexThreadId,
+          text: turnInputText,
+          cwd,
+          sandboxMode
+        })
+      )
     );
     const startedTurnId = String(startedTurn?.turn?.id || "");
     if (activeTurnId && startedTurnId && activeTurnId !== startedTurnId) {

--- a/test/dashboard-app-server-bridge.test.js
+++ b/test/dashboard-app-server-bridge.test.js
@@ -1830,6 +1830,119 @@ test("dashboard app-server bridge sends Japanese recoverable timeout failure", a
   assert.equal(handlers.size, 0);
 });
 
+test("dashboard app-server bridge sends recoverable timeout when thread start stalls", async () => {
+  const events = [];
+  const appServer = {
+    nextRequestId() {
+      return 1;
+    },
+    request(message) {
+      assert.equal(message.method, "thread/start");
+      return new Promise((resolve) => {
+        setTimeout(() => resolve({ thread: { id: "codex-thread-after-timeout" } }), 60);
+      });
+    },
+    onNotification() {
+      return () => {};
+    },
+    drainApprovalRequests() {
+      return Promise.resolve();
+    }
+  };
+
+  await assert.rejects(
+    handleDashboardTurnRequest({
+      request: {
+        threadId: "dashboard-main-unresolved",
+        repository: null,
+        relatedIssue: null,
+        text: "君は誰？"
+      },
+      appServer,
+      sendDashboardEvent: async (event) => events.push(event),
+      cwd: "/repo",
+      turnTimeoutMs: 20,
+      activityQuietMs: 1000,
+      lateCompletionTimeoutMs: 1,
+      liveProgressInitialDelayMs: 1000
+    }),
+    /応答確認が長引いています/
+  );
+  await new Promise((resolve) => setTimeout(resolve, 80));
+
+  const timeoutEvent = events.find((event) => event.type === "app_server_turn_failed");
+  assert.ok(timeoutEvent);
+  assert.equal(timeoutEvent.status, "timeout");
+  assert.equal(timeoutEvent.threadId, "dashboard-main-unresolved");
+  assert.equal(timeoutEvent.codexThreadId, null);
+  assert.equal(timeoutEvent.repository, null);
+  assert.equal(timeoutEvent.relatedIssue, null);
+  assert.match(timeoutEvent.text, /応答確認が長引いています/);
+  assert.match(timeoutEvent.text, /入力と文脈は Dashboard thread に保存済み/);
+  assert.equal(timeoutEvent.recovery.retryable, true);
+  assert.equal(timeoutEvent.recovery.originalText, "君は誰？");
+});
+
+test("dashboard app-server bridge sends recoverable timeout when turn start stalls", async () => {
+  const events = [];
+  const requests = [];
+  const appServer = {
+    nextId: 1,
+    nextRequestId() {
+      const id = this.nextId;
+      this.nextId += 1;
+      return id;
+    },
+    request(message) {
+      requests.push(message.method);
+      if (message.method === "thread/start") {
+        return Promise.resolve({ thread: { id: "codex-thread-stalled-turn-start" } });
+      }
+      if (message.method === "turn/start") {
+        return new Promise((resolve) => {
+          setTimeout(() => resolve({ turn: { id: "turn-after-timeout" } }), 60);
+        });
+      }
+      throw new Error(`unexpected method ${message.method}`);
+    },
+    onNotification() {
+      return () => {};
+    },
+    drainApprovalRequests() {
+      return Promise.resolve();
+    }
+  };
+
+  await assert.rejects(
+    handleDashboardTurnRequest({
+      request: {
+        threadId: "dashboard-main-unresolved",
+        repository: null,
+        relatedIssue: null,
+        text: "もしもし"
+      },
+      appServer,
+      sendDashboardEvent: async (event) => events.push(event),
+      cwd: "/repo",
+      turnTimeoutMs: 20,
+      activityQuietMs: 1000,
+      lateCompletionTimeoutMs: 1,
+      liveProgressInitialDelayMs: 1000
+    }),
+    /応答確認が長引いています/
+  );
+  await new Promise((resolve) => setTimeout(resolve, 80));
+
+  assert.deepEqual(requests, ["thread/start", "turn/start"]);
+  const timeoutEvent = events.find((event) => event.type === "app_server_turn_failed");
+  assert.ok(timeoutEvent);
+  assert.equal(timeoutEvent.status, "timeout");
+  assert.equal(timeoutEvent.threadId, "dashboard-main-unresolved");
+  assert.equal(timeoutEvent.codexThreadId, "codex-thread-stalled-turn-start");
+  assert.equal(timeoutEvent.recovery.retryable, true);
+  assert.equal(timeoutEvent.recovery.originalText, "もしもし");
+});
+
 test("dashboard app-server bridge parses Issue #590 debug slow turn duration from natural language", () => {
   assert.deepEqual(
     parseDashboardDebugSlowTurnRequest({


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #590 の「app-server turn timeout をチャット復帰可能な状態として扱う」Intent に対する部分進捗です。
- 12:25 JST の production probe で確認した `dashboard-main-unresolved` の「君は誰？」が `Codex app-server に渡しています` の後に final/failed event を残さなかった failure mode を対象にします。
- `thread/start` / `thread/resume` / `turn/start` の app-server request 自体が返らない場合でも、Dashboard thread に日本語の復帰可能 timeout message を一度だけ残します。

## Satisfied Success Criteria

- [x] app-server turn が timeout した場合、Dashboard thread に owner-facing 日本語で「応答生成が時間切れ」「入力は保存済み」「同じ thread で続けられる/再試行できる」を表示する。
- [x] app-server bridge は timeout を `app_server_turn_failed` として Dashboard に送る。
- [x] Dashboard は timeout event を thread に残る recovery state として扱える既存経路に、request stall も接続する。
- [x] `codex app-server turn timed out before completion` の英語生エラーをそのまま owner に出さない。

## Unsatisfied Success Criteria

- このPRは timeout/recovery event の bridge 側補強です。production deploy と iPhone Dashboard E2E は未実施です。
- `gpt-5.5` 固定 env の解除、VPS restart、model policy の整理は Issue #455/Issue #741 側に残ります。
- 後から届いた completion の production 上の扱いは既存 late completion path を維持しますが、本PR単独の live E2E では未検証です。

## Non-goal violations

None.

## 開発前作戦図

- 作戦図 evidence: `docs/development-strategy/issue-590-app-server-stall-recovery.md`
- 完了体験: app-server request が詰まっても Dashboard thread に復帰可能な日本語 failure が残り、owner は同じ thread で続けられる。
- VTDD 全体で進める部分: Dashboard Butler repo-less main chat の app-server bridge recovery。mac Codex SSH probe は `mac_codex_only_probe` で、Butler completion ではない。
- 設計: owner-facing Dashboard Butler 経路の完了設計として、`handleDashboardTurnRequest()` の app-server request await を bounded timeout で包み、既存 `app_server_turn_failed` timeout event を一度だけ送る。
- 仮説: root cause 仮説は、12:25 JST の `君は誰？` が Worker/D1/runner ではなく bridge 内 app-server request/turn completion 停止 failure で final event が出なかったこと。
- 検証計画: request stall unit、既存 turn timeout unit、全体 `npm test`。
- 改修見積もり: `scripts/run-dashboard-app-server-bridge.mjs` の request await 境界、`test/dashboard-app-server-bridge.test.js` の request stall tests。
- 既に通っている経路: PR #790 deploy SHA は VPS checkout に反映済み。Dashboard HTTP chat API、Issue #741 low-risk queue、VPS runner、Dashboard event delivery は通過。
- 未確認の境界: `gpt-5.5` 固定 env が supported かは未断定。env mutation/restart は passkey 境界。
- 穴が出そうな箇所: watchdog timeout と request timeout の二重 failure。`timeoutFailureSent` で一度だけ送る。
- PR 前に確認すること: 未追跡 E2E asset を混ぜない。Issue #590 criteria と production probe を PR body に残す。
- 実装候補と捨てた案: 採用は bridge request deadline。捨てた案は Worker が `君は誰？` に直接答える fast path、passkey なしの VPS env 直接編集。
- merge 後に通す E2E: production deploy 後の live E2E test として、repo-less main chat で短文を送り、reply または recovery message が thread に残ることを確認する。
- 次の PR を増やさない理由: timeout recovery を先に入れることで、次の env/restart 修復が失敗しても owner-facing に詰まりを残さない。
- 停止条件: deploy、credential、permission、VPS env mutation が必要になった場合はこのPRでは停止。

## Dry-run Impact Report

- Target Issue: Issue #590
- Implementing Success Criteria: app-server request/turn stall を `app_server_turn_failed` timeout event として Dashboard thread に残す。
- Explicit Non-goals: deploy、VPS env mutation、systemd restart、credential/permission mutation、Worker direct AI fast path。
- Expected touched files/routes/workflows: `scripts/run-dashboard-app-server-bridge.mjs`、`test/dashboard-app-server-bridge.test.js`、strategy doc。
- Affected Issues: Issue #590, Issue #455, Issue #741
- Affected PRs: PR #790 の production probe を根拠として参照。直接変更なし。
- Affected workflows: tests only。deploy workflow は未実行。
- Affected runtime/operator surfaces: Dashboard app-server bridge、Dashboard thread recovery message。
- What may break if we patch narrowly: unsupported model fallback と timeout が二重 failure になること。
- Unknowns to investigate before coding: `thread/start` / `turn/start` request stall が既存 watchdog の外側にあるか。
- Validation needed: `node --test test/dashboard-app-server-bridge.test.js`、`npm test`。
- Stop condition: request timeout を送るために runtime mutation が必要になった場合。

## Execution Queue Delta

- Queue position before: Issue #590 は active issue の timeout/recovery lane。12:25 JST の owner-visible stall により現在の root blocker として扱った。
- Preemption decision: `EMERGENCY` 相当の user-visible recovery gap だが、scope は Issue #590 の bounded implementation に限定。
- Queue delta: Issue #590 の request stall recovery を `Now` として進めた。Issue #455 model/cost、Issue #741 lifecycle/env restart は未完了として残す。
- Why this PR is next: 返信が返らないだけでなく failure も残らないため、owner が iPhone Dashboard で復帰判断できない。
- Active Issues not downscoped: Active Issues は縮小しません。このPR外の active Issue は未完了。

## File / Line Hypotheses

- file: `scripts/run-dashboard-app-server-bridge.mjs:1703`
  - hypothesis: `thread/start` / `turn/start` request await が返らない場合、既存 watchdog が owner-facing failed message を確実に残せない。
  - risk if changed narrowly: unsupported model fallback と request timeout が二重に failure を送る。
  - validation: request stall tests と既存 fallback tests。
  - related Issue: Issue #590

## Hypothesis Retrospective

- expected: app-server request stall でも timeout event が送られる。
- actual: `thread/start` stall と `turn/start` stall の unit test で `app_server_turn_failed` が送られた。
- mismatch: test runner では late completion timer が残り得たため、test 側で `lateCompletionTimeoutMs` を短縮した。
- lesson: request stall と turn notification stall は別の failure mode として test する必要がある。
- should become RAG candidate: はい。`dashboard-main-unresolved` の 12:25 JST stall は Issue #590/Issue #455/Issue #741 の境界事例。

## Verification Evidence

- Unit: `node --test test/dashboard-app-server-bridge.test.js` passed, 77 tests.
- Integration: `npm test` passed, 1206 passed / 1 skipped, self-parity passed, generated-worker check passed.
- E2E: 未実施。production deploy / VPS restart は passkey 境界。
- Manual: production read-only probe で `dashboard-main-unresolved` の 2026-06-05 03:25:02Z owner message と missing final/failed event、VPS service active、`gpt-5.5` env 固定を確認。
- Evidence path/link: strategy file and this PR.

## Butler Completion Contract

- Primary owner surface: Dashboard Butler。
- Fallback surface: Custom GPT は明示された fallback surface として扱います。主経路ではありません。
- Owner goal: app-server が詰まっても Dashboard thread から復帰できる状態を残す。
- Butler entrypoint: Dashboard repo-less main chat。
- Dashboard Butler natural-language path: Dashboard Butler chat entrypoint / repo-less main chat の自然文 owner message path から app-server bridge recovery に到達する経路を補強。
- Action Schema exposure: 未変更。
- Runtime path: `DashboardChatRoom -> app_server_turn_requested -> run-dashboard-app-server-bridge -> app_server_turn_failed timeout`。
- Runner/runtime truth: production probe は read-only。新 runtime は merge/deploy 後に確認が必要。
- Authority boundary: 新しい high-risk authority は追加していない。deploy / VPS env mutation / restart は passkey 境界。
- E2E evidence: 未実施。merge/deploy 後に iPhone Dashboard E2E が必要。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 未実施。passkey approval が必要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。merge/deploy 後に実施。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate
- AGENTS.md Butler-First Operating Principle
- AGENTS.md Drift Stop Protocol
- AGENTS.md Evidence Discipline

## Out-of-scope but NOT implemented

- VPS env の `VTDD_DASHBOARD_APP_SERVER_MODEL=gpt-5.5` 解除
- `vtdd-dashboard-app-server-bridge-unresolved.service` restart
- production deploy
- Worker direct fast path for `君は誰？`

## Extra changes (if any)

None.
