### PR TITLE
Issue #613 single main Dashboard chat thread

### DIFF
--- a/docs/development-strategy/issue-613-single-main-thread-runtime.md
+++ b/docs/development-strategy/issue-613-single-main-thread-runtime.md
@@ -1,0 +1,82 @@
+# Issue #613 single main chat runtime consolidation
+
+## 完了体験
+
+Dashboard Butler は repo を URL や runtime event で受け取っても、通常チャット thread を `dashboard-main-unresolved` の single main chat に集約する。owner は repo 別 thread を意識せず、repo / Issue / PR / deploy は同じ chat 内の work context として扱う。
+
+## VTDD 全体で進める部分
+
+Issue #613 の single main chat 方針を runtime に反映する。Issue #741 の bridge restart handoff も同じ main chat に戻し、repo 固定 `dashboard-main-<owner>-<repo>` thread を再生成しない。
+
+## 設計
+
+- repo 未指定・repo 指定の Dashboard shell はどちらも `dashboard-main-unresolved` を既定 thread にする。
+- HTTP chat turn の既定 thread も repo 派生にしない。
+- GitHub Actions / deploy follow-up / VPS runner event の既定 Dashboard thread を `dashboard-main-unresolved` にする。
+- 既存の repo 固定 thread id が明示入力された場合も、`dashboard-main-<owner>-<repo>` 形式なら single main chat に正規化する。
+
+## 仮説
+
+repo 固定 thread が残っていた原因は bridge service ではなく、Worker が repository から `dashboard-main-marushu-vtdd-v2-p` を既定生成する複数経路である。ここを止めると app-server bridge restart 後も repo-less bridge だけが owner-facing main chat として使われる。
+
+## 検証計画
+
+- Unit: repository 指定 Dashboard shell が `dashboard-main-unresolved` を使う。
+- Unit: repository 指定 HTTP chat turn が `dashboard-main-unresolved` に保存される。
+- Unit: deploy event / VPS runner event が `dashboard-main-unresolved` に append / broadcast される。
+- Build: `npm run build:worker` と `npm run check:generated-worker`。
+- Regression: focused `node --test test/worker.test.js` の関連 tests。
+
+## 改修見積もり
+
+- `src/worker/runtime.js`: main chat thread id helper、Dashboard shell、HTTP chat turn、GitHub Actions event、VPS runner event の thread normalization。
+- `test/worker.test.js`: repo 指定時と runtime event 時の expected thread を single main chat に更新。
+- `worker.js`: generated worker 更新。
+
+## 既に通っている経路
+
+- VPS production では `vtdd-dashboard-app-server-bridge-unresolved.service` だけが active。
+- repo 固定 `vtdd-dashboard-app-server-bridge.service` は inactive / disabled。
+- Issue #613 には single main chat / cross-repo work context 方針が記録済み。
+
+## 未確認の境界
+
+- Durable Object に残る過去の `dashboard-main-marushu-vtdd-v2-p` 履歴はこの PR では削除しない。
+- VPS env file `~/.config/vtdd/dashboard-ws.env` の削除や変更は passkey 境界であり、この PR では実施しない。
+- Custom GPT Action Schema の thread id 入力互換は、明示 thread id の正規化で吸収する。
+
+## 穴が出そうな箇所
+
+- 実行 event が explicit old thread id を持つ場合、古い thread に戻る可能性がある。repo 派生 main thread id は single main chat に正規化する。
+- repo 必須操作の authority boundary を弱めると VTDD の no default repository invariant を壊す。thread は single でも repository metadata は保持する。
+- 古い E2E fixtures が repo 固定 thread を前提にしている可能性がある。
+
+## PR 前に確認すること
+
+- Issue #613 の single main chat 方針と矛盾しない。
+- Issue #741 の repo-less bridge restart handoff が `dashboard-main-unresolved` に戻る。
+- repo metadata は messages / events / approval scopes に残る。
+- 未追跡 E2E asset を混ぜない。
+
+## 実装候補と捨てた案
+
+- 採用: Worker の thread id 既定値と repo 派生 main thread 正規化を修正する。
+- 捨てた案: VPS 全体 reboot。server 健康値は正常で、今回の問題は thread routing / bridge lifecycle であるため。
+- 捨てた案: Durable Object 履歴の削除。過去証跡を壊し、今回の「今後起動しない」要求を超える。
+- 捨てた案: repo metadata を消す。authority boundary と runtime truth が壊れる。
+
+## merge 後に通す E2E
+
+- production deploy 後、repo 指定あり Dashboard URL でも `data-thread-id="dashboard-main-unresolved"` になることを確認する。
+- repo-less main chat で短文を送り、app-server reply が同じ thread に返ることを確認する。
+- deploy success / VPS runner event が `dashboard-main-unresolved` に届き、repo 固定 thread に新規 append しないことを確認する。
+
+## 次の PR を増やさない理由
+
+この PR は repo 固定 thread 再生成を止める runtime 入口をまとめて塞ぐ。VPS env file の削除は passkey 境界なので別操作だが、通常 runtime が repo 固定 thread を再生成する穴はこの slice で閉じられる。
+
+## 停止条件
+
+- repository metadata を消さないと実装できない場合。
+- VPS env / systemd / credential / permission mutation が必要になった場合。
+- deploy や Durable Object 履歴削除が必要になった場合。

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -5032,7 +5032,7 @@ async function handleGitHubActionsEventRequest(request, env) {
   });
   await store.put(acceptedEvent);
 
-  const threadId = event.threadId || buildDashboardEventDefaultThreadId(baseEvent);
+  const threadId = normalizeDashboardSingleMainChatThreadId(event.threadId);
   const chatMessage = buildGitHubActionsDashboardChatMessage({
     event: baseEvent,
     threadId
@@ -6448,7 +6448,7 @@ async function authorizeDashboardVpsApprovalContinuation({ payload, env } = {}) 
   const input = normalizeObject(payload);
   const vpsProposalId = normalizeText(input.vpsProposalId || input.vps_proposal_id);
   const approvalGrantId = normalizeText(input.approvalGrantId || input.approval_grant_id);
-  const threadId = normalizeDashboardThreadId(input.threadId || input.thread_id);
+  const threadId = normalizeDashboardSingleMainChatThreadId(input.threadId || input.thread_id);
   if (!vpsProposalId || !approvalGrantId || !threadId) {
     return {
       ok: false,
@@ -12039,9 +12039,7 @@ async function buildDashboardChatTurn(payload, options = {}) {
     };
   }
 
-  const threadId =
-    normalizeDashboardThreadId(input.threadId || input.thread_id) ||
-    (repository ? `dashboard-main-${repository.replace("/", "-")}` : "dashboard-main-unresolved");
+  const threadId = normalizeDashboardSingleMainChatThreadId(input.threadId || input.thread_id);
   const relatedIssue =
     normalizePositiveInteger(input.relatedIssue || input.issueNumber) || extractIssueNumberFromDashboardChatText(text);
   const mediaValidation = await resolveDashboardChatMediaReferences({
@@ -12188,7 +12186,7 @@ async function buildDashboardVpsPrivilegedMaintenanceNaturalLanguageFlow({
     const proposal = await createVpsPrivilegedMaintenanceProposal({
       payload: {
         ...proposalPayload,
-        dashboardThreadId: normalizeDashboardThreadId(payload?.threadId || payload?.thread_id),
+        dashboardThreadId: normalizeDashboardSingleMainChatThreadId(payload?.threadId || payload?.thread_id),
         executionId: normalizeText(payload?.executionId || payload?.execution_id)
       },
       provider,
@@ -12316,7 +12314,7 @@ async function buildDashboardVpsPrivilegedMaintenanceNaturalLanguageFlow({
       executionId:
         normalizeText(payload?.executionId || payload?.execution_id) ||
         `dashboard-butler-issue${relatedIssue || "unknown"}-${safeIdentifier(helper.body.helperRequest.requestId)}`,
-      dashboardThreadId: normalizeText(payload?.threadId || payload?.thread_id),
+      dashboardThreadId: normalizeDashboardSingleMainChatThreadId(payload?.threadId || payload?.thread_id),
       approvalActor: "Dashboard Butler",
       executionEnvelope: execution.body.executionEnvelope
     },
@@ -12451,7 +12449,7 @@ async function queueDashboardVpsMaintenanceLowRiskRead({
       executionId:
         normalizeText(payload?.executionId || payload?.execution_id) ||
         `dashboard-butler-issue${relatedIssue || "unknown"}-${safeIdentifier(helperRequest.requestId)}`,
-      dashboardThreadId: normalizeText(payload?.threadId || payload?.thread_id),
+      dashboardThreadId: normalizeDashboardSingleMainChatThreadId(payload?.threadId || payload?.thread_id),
       approvalActor: "Dashboard Butler low-risk read",
       executionEnvelope: execution.body.executionEnvelope
     },
@@ -14186,18 +14184,28 @@ function normalizeGitHubActionsEvent(payload) {
   };
 }
 
-function buildDashboardEventDefaultThreadId(event) {
-  const record = normalizeDashboardEventRecord(event);
-  const repository = normalizeCanonicalRepositoryInput(record.repository);
-  if (repository) {
-    return normalizeDashboardThreadId(`dashboard-main-${repository.replace("/", "-")}`);
+const DASHBOARD_SINGLE_MAIN_CHAT_THREAD_ID = "dashboard-main-unresolved";
+
+function normalizeDashboardSingleMainChatThreadId(value = "") {
+  const normalized = normalizeDashboardThreadId(value);
+  if (!normalized || isRepositoryDerivedDashboardMainThreadId(normalized)) {
+    return DASHBOARD_SINGLE_MAIN_CHAT_THREAD_ID;
   }
-  return "dashboard-main-unresolved";
+  return normalized;
+}
+
+function isRepositoryDerivedDashboardMainThreadId(value = "") {
+  const normalized = normalizeDashboardThreadId(value);
+  return /^dashboard-main-(?!unresolved$)[a-z0-9_.-]+-[a-z0-9_.-]+$/i.test(normalized);
+}
+
+function buildDashboardEventDefaultThreadId() {
+  return DASHBOARD_SINGLE_MAIN_CHAT_THREAD_ID;
 }
 
 function buildGitHubActionsDashboardChatMessage({ event, threadId } = {}) {
   const record = normalizeDashboardEventRecord(event);
-  const resolvedThreadId = normalizeDashboardThreadId(threadId) || buildDashboardEventDefaultThreadId(record);
+  const resolvedThreadId = normalizeDashboardSingleMainChatThreadId(threadId);
   if (!resolvedThreadId || record.kind !== "github_actions_workflow_run") {
     return null;
   }
@@ -14279,9 +14287,7 @@ function normalizeVpsRunnerDashboardEvent(payload) {
   const issueNumber = normalizePositiveInteger(input.issueNumber || input.issue_number || input.relatedIssue);
   const branch = sanitizeDashboardChatText(input.branch || input.headBranch || input.head_branch);
   const progressUrl = normalizeDashboardUrl(input.progressUrl || input.progress_url || input.runUrl || input.run_url || input.url);
-  const threadId =
-    normalizeDashboardThreadId(input.threadId || input.thread_id) ||
-    normalizeDashboardThreadId(`execution-${executionId}`);
+  const threadId = normalizeDashboardSingleMainChatThreadId(input.threadId || input.thread_id);
   const title = buildVpsRunnerDashboardTitle({ status, currentStep, lastEvent, message });
 
   if (!repository) {
@@ -15942,7 +15948,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
     url?.searchParams?.get("repositoryInput") || url?.searchParams?.get("repository")
   );
   const dashboardIssueNumber = normalizePositiveInteger(url?.searchParams?.get("issueNumber"));
-  const requestedChatThreadId = normalizeDashboardThreadId(url?.searchParams?.get("threadId") || url?.searchParams?.get("thread_id"));
+  const requestedChatThreadId = normalizeDashboardSingleMainChatThreadId(url?.searchParams?.get("threadId") || url?.searchParams?.get("thread_id"));
   const dashboardTargetLabel = repositoryInput ? `この作業: ${repositoryInput}` : "repo-less main chat";
   const targetStatusMarkup = repositoryInput
     ? `<p><strong>${escapeDashboardHtml(repositoryInput)}</strong></p>
@@ -15950,7 +15956,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
     : `<p><strong>repo-less main chat</strong></p>
           <p class="muted">ここが通常のメインチャットです。repo は常設設定ではなく、Issue / PR / deploy など repo 境界が必要になった時だけ Butler が会話の中で確認します。VTDD と TOMIO では deploy 先も承認境界も別物として扱います。</p>`;
   const encodedRepository = encodeURIComponent(repositoryInput);
-  const chatThreadId = requestedChatThreadId || `dashboard-main-${(repositoryInput || "unresolved").replace(/[^a-z0-9_.-]+/gi, "-")}`;
+  const chatThreadId = requestedChatThreadId;
   const socketOrigin = origin.replace(/^http/i, "ws");
   const currentDashboardReturnPath = withDashboardReturnThreadId(
     sanitizeDashboardPreAuthReturnPath(`${url?.pathname || "/dashboard"}${url?.search || ""}`),

--- a/test/e2e-518-dashboard-chat-transient-timestamps.test.js
+++ b/test/e2e-518-dashboard-chat-transient-timestamps.test.js
@@ -126,7 +126,7 @@ test("E2E-518 dashboard route exposes timestamp renderer and transient status UI
   assert.equal(html.includes("function renderReplyContext("), true);
   assert.equal(html.includes("function appendMessage(message, target = log, options = {})"), true);
   assert.equal(html.includes("appendMessage(message, fragment, { scroll: false })"), true);
-  assert.equal(html.includes('data-thread-endpoint="https://example.com/v2/dashboard/chat/dashboard-main-sample-org-vtdd-v2-p"'), true);
+  assert.equal(html.includes('data-thread-endpoint="https://example.com/v2/dashboard/chat/dashboard-main-unresolved"'), true);
 });
 
 test("E2E-518 app-server stages update transient status without generic chat spam and final reply resets status", async () => {

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -1874,7 +1874,7 @@ test("worker appends dashboard Butler chat turn and retrieves the same thread", 
   assert.equal(response.status, 202);
   const body = await response.json();
   assert.equal(body.ok, true);
-  assert.equal(body.threadId, "dashboard-main-marushu-vtdd-v2-p");
+  assert.equal(body.threadId, "dashboard-main-unresolved");
   assert.equal(body.messages.length, 1);
   assert.equal(body.messages[0].role, "owner");
   assert.equal(body.messages[0].messageId, "dashboard_owner_message:http-fallback-1");
@@ -1882,7 +1882,7 @@ test("worker appends dashboard Butler chat turn and retrieves the same thread", 
   assert.equal(JSON.stringify(body.messages).includes("Custom GPT Butler"), false);
 
   const retrieveResponse = await worker.fetch(
-    new Request("https://example.com/v2/dashboard/chat/dashboard-main-marushu-vtdd-v2-p", {
+    new Request("https://example.com/v2/dashboard/chat/dashboard-main-unresolved", {
       headers: dashboardAccessHeaders
     }),
     { ...dashboardAccessEnv, DASHBOARD_CHAT_STORE: store }
@@ -2712,7 +2712,7 @@ test("worker rejects chat media references outside the repository or issue conte
 
 test("worker stores dashboard Butler thread summaries and searches archived context", async () => {
   const store = createInMemoryDashboardChatStore();
-  await store.appendMany("dashboard-main-marushu-vtdd-v2-p", [
+  await store.appendMany("dashboard-main-unresolved", [
     {
       role: "owner",
       repository: "marushu/vtdd-v2-p",
@@ -2734,7 +2734,7 @@ test("worker stores dashboard Butler thread summaries and searches archived cont
   ]);
 
   const summaryResponse = await worker.fetch(
-    new Request("https://example.com/v2/dashboard/chat/dashboard-main-marushu-vtdd-v2-p/summary", {
+    new Request("https://example.com/v2/dashboard/chat/dashboard-main-unresolved/summary", {
       method: "POST",
       headers: { ...dashboardAccessHeaders, "content-type": "application/json" },
       body: JSON.stringify({
@@ -2753,7 +2753,7 @@ test("worker stores dashboard Butler thread summaries and searches archived cont
   assert.equal(summaryBody.summary.relatedIssue, 450);
 
   const threadResponse = await worker.fetch(
-    new Request("https://example.com/v2/dashboard/chat/dashboard-main-marushu-vtdd-v2-p", {
+    new Request("https://example.com/v2/dashboard/chat/dashboard-main-unresolved", {
       headers: dashboardAccessHeaders
     }),
     { ...dashboardAccessEnv, DASHBOARD_CHAT_STORE: store }
@@ -2773,7 +2773,7 @@ test("worker stores dashboard Butler thread summaries and searches archived cont
   const searchBody = await searchResponse.json();
   assert.equal(searchBody.ok, true);
   assert.equal(searchBody.results.some((result) => result.kind === "summary"), true);
-  assert.equal(searchBody.results.every((result) => result.threadId === "dashboard-main-marushu-vtdd-v2-p"), true);
+  assert.equal(searchBody.results.every((result) => result.threadId === "dashboard-main-unresolved"), true);
 });
 
 test("worker appends dashboard Butler chat turn with dashboard passkey session cookie", async () => {
@@ -2877,7 +2877,7 @@ test("worker does not dispatch dashboard chat to the VPS runner queue", async ()
   assert.equal(calls.length, 0);
 
   const retrieveResponse = await worker.fetch(
-    new Request("https://example.com/v2/dashboard/chat/dashboard-main-marushu-vtdd-v2-p", {
+    new Request("https://example.com/v2/dashboard/chat/dashboard-main-unresolved", {
       headers: dashboardAccessHeaders
     }),
     { ...dashboardAccessEnv, DASHBOARD_CHAT_STORE: store }
@@ -2928,7 +2928,7 @@ test("worker connects VPS privileged maintenance intent from Dashboard Butler ch
   assert.match(body.messages[1].text, /rootExecutionStarted=false, helperExecutionStarted=false/);
   assert.match(body.messages[1].text, /approval URL/);
   const approvalUrl = new URL(body.execution.approvalOperatorUrl);
-  assert.equal(approvalUrl.searchParams.get("dashboardThreadId"), "dashboard-main-marushu-vtdd-v2-p");
+  assert.equal(approvalUrl.searchParams.get("dashboardThreadId"), "dashboard-main-unresolved");
   assert.equal(approvalUrl.searchParams.get("vpsProposalId"), body.execution.vpsProposalId);
   assert.doesNotMatch(body.messages[1].text, /app-server 接続 PR/);
 
@@ -2988,7 +2988,7 @@ test("worker connects VPS privileged maintenance intent from Dashboard Butler ch
   const approvedBody = await approvedResponse.json();
   assert.equal(approvedBody.ok, true);
   assert.equal(approvedBody.execution.status, "queued_for_vps_helper_execution");
-  assert.equal(approvedBody.execution.queue.dashboardThreadId, "dashboard-main-marushu-vtdd-v2-p");
+  assert.equal(approvedBody.execution.queue.dashboardThreadId, "dashboard-main-unresolved");
   assert.equal(approvedBody.execution.runtimeTruth.helperQueueReached, true);
   assert.equal(approvedBody.execution.runtimeTruth.dashboardThreadIdIncluded, true);
   assert.equal(approvedBody.execution.runtimeTruth.rootExecutionStarted, false);
@@ -3002,7 +3002,7 @@ test("worker connects VPS privileged maintenance intent from Dashboard Butler ch
   const queueCommentBody = JSON.parse(githubCalls[0].init.body).body;
   assert.equal(queueCommentBody.includes("vtdd:vps-privileged-maintenance-execution:issue637-dashboard-natural-chat"), true);
   assert.equal(queueCommentBody.includes('"transport": "vps_privileged_maintenance_helper"'), true);
-  assert.equal(queueCommentBody.includes('"dashboardThreadId": "dashboard-main-marushu-vtdd-v2-p"'), true);
+  assert.equal(queueCommentBody.includes('"dashboardThreadId": "dashboard-main-unresolved"'), true);
   assert.equal(queueCommentBody.includes('"handoff"'), true);
 });
 
@@ -5858,7 +5858,7 @@ test("worker redacts dashboard Butler chat sensitive material before returning a
   assert.equal(body.messages[0].text.includes("Bearer [redacted]"), true);
 
   const retrieveResponse = await worker.fetch(
-    new Request("https://example.com/v2/dashboard/chat/dashboard-main-marushu-vtdd-v2-p", {
+    new Request("https://example.com/v2/dashboard/chat/dashboard-main-unresolved", {
       headers: dashboardAccessHeaders
     }),
     { ...dashboardAccessEnv, DASHBOARD_CHAT_STORE: store }
@@ -6983,7 +6983,7 @@ test("worker ingests GitHub Actions deploy completion event and shows it on dash
   assert.equal(eventBody.event.pwaNotificationStatus, "sent");
   assert.equal(eventBody.event.pwaNotificationAttempted, 1);
   assert.equal(eventBody.event.pwaNotificationDelivered, 1);
-  assert.equal(eventBody.threadId, "dashboard-main-marushu-vtdd-v2-p");
+  assert.equal(eventBody.threadId, "dashboard-main-unresolved");
   assert.equal(eventBody.chatAppendStatus, "appended");
   assert.equal(eventBody.chatAppendError, null);
   assert.equal(eventBody.chatAppendReason, null);
@@ -7024,7 +7024,7 @@ test("worker ingests GitHub Actions deploy completion event and shows it on dash
   assert.equal(JSON.stringify(eventBody.messages).includes("secret-must-not-persist"), false);
   assert.equal(eventBody.webSocketBroadcast, true);
   assert.equal(rooms.calls.length, 1);
-  assert.equal(rooms.calls[0].name, "dashboard-main-marushu-vtdd-v2-p");
+  assert.equal(rooms.calls[0].name, "dashboard-main-unresolved");
   assert.equal(pushCalls.length, 1);
   assert.equal(pushCalls[0].input, "https://push.example/send/deploy");
   assert.match(pushCalls[0].init.headers.authorization, /^vapid t=.+, k=.+/);
@@ -7055,7 +7055,7 @@ test("worker ingests GitHub Actions deploy completion event and shows it on dash
   assert.equal(storedDeployEvent.pwaNotificationDelivered, 1);
 
   const chatResponse = await worker.fetch(
-    new Request("https://example.com/v2/dashboard/chat/dashboard-main-marushu-vtdd-v2-p", {
+    new Request("https://example.com/v2/dashboard/chat/dashboard-main-unresolved", {
       headers: dashboardAccessHeaders
     }),
     { ...dashboardAccessEnv, DASHBOARD_CHAT_STORE: chatStore }
@@ -7108,7 +7108,7 @@ test("worker ingests GitHub Actions deploy completion event and shows it on dash
   assert.equal(duplicateBody.webPush.delivered, 0);
   assert.equal(pushCalls.length, 1);
   const duplicateChat = await worker.fetch(
-    new Request("https://example.com/v2/dashboard/chat/dashboard-main-marushu-vtdd-v2-p", {
+    new Request("https://example.com/v2/dashboard/chat/dashboard-main-unresolved", {
       headers: dashboardAccessHeaders
     }),
     { ...dashboardAccessEnv, DASHBOARD_CHAT_STORE: chatStore }
@@ -7548,7 +7548,7 @@ test("worker ingests VPS runner event into notifications and Butler chat thread"
   assert.equal(eventBody.event.runUrl.includes("secret-must-not-persist"), false);
   assert.equal(JSON.stringify(eventBody).includes("approval:15b6f20d"), false);
   assert.equal(JSON.stringify(eventBody).includes("secret-must-not-persist"), false);
-  assert.equal(eventBody.threadId, "dashboard-main-marushu-vtdd-v2-p");
+  assert.equal(eventBody.threadId, "dashboard-main-unresolved");
   assert.equal(eventBody.webSocketBroadcast, true);
   assert.equal(eventBody.webPush.ok, false);
   assert.equal(eventBody.webPush.error, "dashboard_push_subscription_store_unavailable");
@@ -7567,14 +7567,14 @@ test("worker ingests VPS runner event into notifications and Butler chat thread"
   assert.equal(eventBody.messages[0].text.includes("\n本文:\nVPS Codex CLI が作業を開始しました。"), true);
   assert.equal(eventBody.messages[0].text.includes("codex_subprocess"), true);
   assert.equal(rooms.calls.length, 1);
-  assert.equal(rooms.calls[0].name, "dashboard-main-marushu-vtdd-v2-p");
+  assert.equal(rooms.calls[0].name, "dashboard-main-unresolved");
   assert.equal(String(rooms.calls[0].input), "https://dashboard-chat-room.internal/broadcast");
   const broadcastBody = JSON.parse(rooms.calls[0].init.body);
-  assert.equal(broadcastBody.threadId, "dashboard-main-marushu-vtdd-v2-p");
+  assert.equal(broadcastBody.threadId, "dashboard-main-unresolved");
   assert.equal(broadcastBody.messages[0].role, "runner");
 
   const chatResponse = await worker.fetch(
-    new Request("https://example.com/v2/dashboard/chat/dashboard-main-marushu-vtdd-v2-p", {
+    new Request("https://example.com/v2/dashboard/chat/dashboard-main-unresolved", {
       headers: dashboardAccessHeaders
     }),
     { ...dashboardAccessEnv, DASHBOARD_CHAT_STORE: chatStore }

--- a/worker.js
+++ b/worker.js
@@ -62322,7 +62322,7 @@ async function handleGitHubActionsEventRequest(request, env) {
     pwaNotificationCleaned: existingEvent?.pwaNotificationCleaned || 0
   });
   await store.put(acceptedEvent);
-  const threadId = event.threadId || buildDashboardEventDefaultThreadId(baseEvent);
+  const threadId = normalizeDashboardSingleMainChatThreadId(event.threadId);
   const chatMessage = buildGitHubActionsDashboardChatMessage({
     event: baseEvent,
     threadId
@@ -63645,7 +63645,7 @@ async function authorizeDashboardVpsApprovalContinuation({ payload, env } = {}) 
   const input = normalizeObject12(payload);
   const vpsProposalId = normalizeText33(input.vpsProposalId || input.vps_proposal_id);
   const approvalGrantId = normalizeText33(input.approvalGrantId || input.approval_grant_id);
-  const threadId = normalizeDashboardThreadId(input.threadId || input.thread_id);
+  const threadId = normalizeDashboardSingleMainChatThreadId(input.threadId || input.thread_id);
   if (!vpsProposalId || !approvalGrantId || !threadId) {
     return {
       ok: false,
@@ -68585,7 +68585,7 @@ async function buildDashboardChatTurn(payload, options = {}) {
       reason: "message text is required"
     };
   }
-  const threadId = normalizeDashboardThreadId(input.threadId || input.thread_id) || (repository ? `dashboard-main-${repository.replace("/", "-")}` : "dashboard-main-unresolved");
+  const threadId = normalizeDashboardSingleMainChatThreadId(input.threadId || input.thread_id);
   const relatedIssue = normalizePositiveInteger10(input.relatedIssue || input.issueNumber) || extractIssueNumberFromDashboardChatText(text);
   const mediaValidation = await resolveDashboardChatMediaReferences({
     env: options.env,
@@ -68723,7 +68723,7 @@ async function buildDashboardVpsPrivilegedMaintenanceNaturalLanguageFlow({
     const proposal = await createVpsPrivilegedMaintenanceProposal({
       payload: {
         ...proposalPayload,
-        dashboardThreadId: normalizeDashboardThreadId(payload?.threadId || payload?.thread_id),
+        dashboardThreadId: normalizeDashboardSingleMainChatThreadId(payload?.threadId || payload?.thread_id),
         executionId: normalizeText33(payload?.executionId || payload?.execution_id)
       },
       provider,
@@ -68846,7 +68846,7 @@ async function buildDashboardVpsPrivilegedMaintenanceNaturalLanguageFlow({
       repository,
       issueNumber: relatedIssue,
       executionId: normalizeText33(payload?.executionId || payload?.execution_id) || `dashboard-butler-issue${relatedIssue || "unknown"}-${safeIdentifier(helper.body.helperRequest.requestId)}`,
-      dashboardThreadId: normalizeText33(payload?.threadId || payload?.thread_id),
+      dashboardThreadId: normalizeDashboardSingleMainChatThreadId(payload?.threadId || payload?.thread_id),
       approvalActor: "Dashboard Butler",
       executionEnvelope: execution.body.executionEnvelope
     },
@@ -68973,7 +68973,7 @@ async function queueDashboardVpsMaintenanceLowRiskRead({
       repository,
       issueNumber: relatedIssue,
       executionId: normalizeText33(payload?.executionId || payload?.execution_id) || `dashboard-butler-issue${relatedIssue || "unknown"}-${safeIdentifier(helperRequest.requestId)}`,
-      dashboardThreadId: normalizeText33(payload?.threadId || payload?.thread_id),
+      dashboardThreadId: normalizeDashboardSingleMainChatThreadId(payload?.threadId || payload?.thread_id),
       approvalActor: "Dashboard Butler low-risk read",
       executionEnvelope: execution.body.executionEnvelope
     },
@@ -70447,17 +70447,21 @@ function normalizeGitHubActionsEvent(payload) {
     threadId
   };
 }
-function buildDashboardEventDefaultThreadId(event) {
-  const record2 = normalizeDashboardEventRecord(event);
-  const repository = normalizeCanonicalRepositoryInput(record2.repository);
-  if (repository) {
-    return normalizeDashboardThreadId(`dashboard-main-${repository.replace("/", "-")}`);
+var DASHBOARD_SINGLE_MAIN_CHAT_THREAD_ID = "dashboard-main-unresolved";
+function normalizeDashboardSingleMainChatThreadId(value = "") {
+  const normalized = normalizeDashboardThreadId(value);
+  if (!normalized || isRepositoryDerivedDashboardMainThreadId(normalized)) {
+    return DASHBOARD_SINGLE_MAIN_CHAT_THREAD_ID;
   }
-  return "dashboard-main-unresolved";
+  return normalized;
+}
+function isRepositoryDerivedDashboardMainThreadId(value = "") {
+  const normalized = normalizeDashboardThreadId(value);
+  return /^dashboard-main-(?!unresolved$)[a-z0-9_.-]+-[a-z0-9_.-]+$/i.test(normalized);
 }
 function buildGitHubActionsDashboardChatMessage({ event, threadId } = {}) {
   const record2 = normalizeDashboardEventRecord(event);
-  const resolvedThreadId = normalizeDashboardThreadId(threadId) || buildDashboardEventDefaultThreadId(record2);
+  const resolvedThreadId = normalizeDashboardSingleMainChatThreadId(threadId);
   if (!resolvedThreadId || record2.kind !== "github_actions_workflow_run") {
     return null;
   }
@@ -70537,7 +70541,7 @@ function normalizeVpsRunnerDashboardEvent(payload) {
   const issueNumber = normalizePositiveInteger10(input.issueNumber || input.issue_number || input.relatedIssue);
   const branch = sanitizeDashboardChatText(input.branch || input.headBranch || input.head_branch);
   const progressUrl = normalizeDashboardUrl(input.progressUrl || input.progress_url || input.runUrl || input.run_url || input.url);
-  const threadId = normalizeDashboardThreadId(input.threadId || input.thread_id) || normalizeDashboardThreadId(`execution-${executionId}`);
+  const threadId = normalizeDashboardSingleMainChatThreadId(input.threadId || input.thread_id);
   const title = buildVpsRunnerDashboardTitle({ status, currentStep, lastEvent, message });
   if (!repository) {
     return {
@@ -72085,13 +72089,13 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
     url?.searchParams?.get("repositoryInput") || url?.searchParams?.get("repository")
   );
   const dashboardIssueNumber = normalizePositiveInteger10(url?.searchParams?.get("issueNumber"));
-  const requestedChatThreadId = normalizeDashboardThreadId(url?.searchParams?.get("threadId") || url?.searchParams?.get("thread_id"));
+  const requestedChatThreadId = normalizeDashboardSingleMainChatThreadId(url?.searchParams?.get("threadId") || url?.searchParams?.get("thread_id"));
   const dashboardTargetLabel = repositoryInput ? `\u3053\u306E\u4F5C\u696D: ${repositoryInput}` : "repo-less main chat";
   const targetStatusMarkup = repositoryInput ? `<p><strong>${escapeDashboardHtml(repositoryInput)}</strong></p>
           <p class="muted">\u56FA\u5B9A\u3067\u306F\u3042\u308A\u307E\u305B\u3093\u3002\u3053\u306E\u4F1A\u8A71\u3067 Issue / PR / deploy \u306A\u3069 repo \u304C\u5FC5\u8981\u306A\u4F5C\u696D\u3092\u3059\u308B\u9593\u3060\u3051\u5BFE\u8C61\u306B\u3057\u307E\u3059\u3002deploy \u5148\u3068\u627F\u8A8D\u5883\u754C\u306F repo \u3054\u3068\u306B\u78BA\u8A8D\u3057\u307E\u3059\u3002</p>` : `<p><strong>repo-less main chat</strong></p>
           <p class="muted">\u3053\u3053\u304C\u901A\u5E38\u306E\u30E1\u30A4\u30F3\u30C1\u30E3\u30C3\u30C8\u3067\u3059\u3002repo \u306F\u5E38\u8A2D\u8A2D\u5B9A\u3067\u306F\u306A\u304F\u3001Issue / PR / deploy \u306A\u3069 repo \u5883\u754C\u304C\u5FC5\u8981\u306B\u306A\u3063\u305F\u6642\u3060\u3051 Butler \u304C\u4F1A\u8A71\u306E\u4E2D\u3067\u78BA\u8A8D\u3057\u307E\u3059\u3002VTDD \u3068 TOMIO \u3067\u306F deploy \u5148\u3082\u627F\u8A8D\u5883\u754C\u3082\u5225\u7269\u3068\u3057\u3066\u6271\u3044\u307E\u3059\u3002</p>`;
   const encodedRepository = encodeURIComponent(repositoryInput);
-  const chatThreadId = requestedChatThreadId || `dashboard-main-${(repositoryInput || "unresolved").replace(/[^a-z0-9_.-]+/gi, "-")}`;
+  const chatThreadId = requestedChatThreadId;
   const socketOrigin = origin.replace(/^http/i, "ws");
   const currentDashboardReturnPath = withDashboardReturnThreadId(
     sanitizeDashboardPreAuthReturnPath(`${url?.pathname || "/dashboard"}${url?.search || ""}`),


### PR DESCRIPTION
## This PR satisfies Intent

Issue #613 の「通常チャットは 1 本で、repo は会話内の work context として解決する」方針に合わせ、Dashboard runtime が `dashboard-main-marushu-vtdd-v2-p` のような repo 固定 main thread を新規生成・再利用しないようにします。

この PR は runtime 入口の修正です。production deploy、VPS env file 削除、systemd service 変更、Durable Object 履歴削除は実施していません。

## Satisfied Success Criteria

- Dashboard shell は repo query があっても通常 chat endpoint を `dashboard-main-unresolved` にします。
- HTTP dashboard chat turn は repository 入力があっても repo 派生 thread を既定生成しません。
- GitHub Actions / deploy event / VPS runner event は Dashboard Butler 通知を `dashboard-main-unresolved` に append / broadcast します。
- 古い repo 派生 `dashboard-main-<owner>-<repo>` thread id が明示入力されても single main chat に正規化します。
- VPS privileged maintenance の approval continuation / helper queue も single main chat id を渡します。

## Unsatisfied Success Criteria

- production deploy 後の iPhone/iPad PWA E2E は未実施です。
- VPS 側の古い `dashboard-ws.env` 削除や service cleanup は passkey 境界のため未実施です。
- 既存 Durable Object / chat store に残る過去の repo 固定 thread 履歴は削除していません。
- Issue #613 全体完了ではなく、runtime thread 再生成防止の部分進捗です。

## 開発前作戦図

- 作戦図 evidence: `docs/development-strategy/issue-613-single-main-thread-runtime.md`
- 完了体験: Dashboard Butler の通常会話は `dashboard-main-unresolved` に集約され、repo は同じ chat 内の context として扱われます。
- VTDD 全体で進める部分: Issue #613 の single main chat 方針を Worker runtime、event ingest、VPS maintenance handoff に反映します。
- 設計: Dashboard Butler の owner-facing surface は 1 本に保ち、repo query / repository metadata は保持しつつ、chat thread id だけを single main chat に正規化します。
- 仮説: 不要 thread の再発原因は VPS service の active 状態ではなく Worker が repository から repo 固定 thread id を生成する複数経路です。
- 検証計画: Dashboard shell、HTTP chat turn、deploy event、VPS runner event、VPS maintenance queue を tests で確認し、generated worker parity も確認します。
- 改修見積もり: `src/worker/runtime.js`、`worker.js`、`test/worker.test.js`、`test/e2e-518-dashboard-chat-transient-timestamps.test.js`、作戦図 file。
- 既に通っている経路: production VPS では repo-less unresolved bridge が active で、repo 固定 bridge service は inactive / disabled です。
- 未確認の境界: production deploy 後の PWA 実機確認、VPS env cleanup、過去 thread 履歴の扱い。
- 穴が出そうな箇所: old explicit thread id、deploy event thread id、VPS helper queue dashboardThreadId、repo metadata と authority boundary の混同。
- PR 前に確認すること: repo metadata を消していないこと、Issue #741 の repo-less bridge handoff と矛盾しないこと、未追跡 asset を混ぜないこと。
- 実装候補と捨てた案: Worker 正規化を採用。VPS reboot、Durable Object 履歴削除、repo metadata 削除は捨てました。
- merge 後に通す E2E: production deploy 後の live E2E で、repo query 付き Dashboard URL が `dashboard-main-unresolved` になり、通常 chat reply と event append が同じ thread に戻ることを検証します。
- 次の PR を増やさない理由: runtime が repo 固定 thread を再生成する既知の穴をこの PR 範囲でまとめて塞げるためです。VPS cleanup は passkey 境界なのでこの PR には残しません。
- 停止条件: VPS env / systemd / deploy / credential / permission mutation が必要になった場合、または repo metadata を消す必要が出た場合。

## Dry-run Impact Report

- Target Issue: Issue #613
- Implementing Success Criteria: single main chat / cross-repo work context の runtime thread routing 部分。
- Explicit Non-goals: deploy、VPS reboot、VPS env 削除、systemd mutation、credential / permission mutation、Durable Object 履歴削除、Issue close。
- Expected touched files/routes/workflows: `/dashboard` shell、`/v2/dashboard/chat/:threadId`、GitHub Actions event ingest、VPS runner event ingest、VPS maintenance approval continuation / helper queue。
- Affected Issues: #613 が主対象、#741 は repo-less bridge handoff の関連。
- Affected PRs: 新規 PR のみ。既存 merged PR には push していません。
- Affected workflows: local `npm test`、generated worker check。GitHub Actions は PR 作成後に確認します。
- Affected runtime/operator surfaces: Dashboard Butler main chat、Dashboard event notification、VPS maintenance passkey return thread。
- What may break if we patch narrowly: event path だけ直すと HTTP chat や passkey return が古い repo thread に戻るため、共通 normalizer で塞ぎます。
- Unknowns to investigate before coding: production chat store に残る過去 thread の移行要否、VPS env cleanup の実施タイミング。
- Validation needed: `npm run build:worker`、`npm run check:generated-worker`、`node --test test/worker.test.js`、`node --test test/e2e-518-dashboard-chat-transient-timestamps.test.js`、`npm test`。
- Stop condition: passkey が必要な VPS / deploy / credential / permission mutation が必要になった場合。

## Execution Queue Delta

- Queue position before: Issue #613 の owner-facing single main chat 修正として現在の ROOT/NEXT 修復 lane。
- Preemption decision: ROOT preemption。repo 固定 thread が通常会話と recovery の UX を分断しており、Butler completion gate に直接影響します。
- Queue delta: Issue #613 の runtime thread routing slice を `Now` に追加。Issue #741 は関連観測として扱い、scope は拡張していません。
- Why this PR is next: app-server bridge restart 後に repo 固定 thread を再生成しないことが、ユーザーの最新要求と Issue #613 の成功条件に直結するためです。
- Active Issues not downscoped: active Issues は縮小しません。この PR は #613 の部分進捗で、未完了項目を明記しています。

## File / Line Hypotheses

- `src/worker/runtime.js`: `buildDashboardChatTurn` と `renderV2DashboardPage` が repository から repo 固定 main thread を生成していました。
- `src/worker/runtime.js`: GitHub Actions / VPS runner event ingest が event thread id や repository から repo 固定 thread に戻る余地を持っていました。
- `src/worker/runtime.js`: VPS privileged maintenance の approval continuation / helper queue が古い dashboardThreadId をそのまま渡す余地を持っていました。
- `test/worker.test.js` と E2E test: 旧 repo 固定 thread を期待していた箇所があり、single main chat 期待値に更新しました。

## Hypothesis Retrospective

仮説は概ね正しかったです。repo 固定 service は VPS 上で inactive / disabled でしたが、Worker runtime には repo から `dashboard-main-<owner>-<repo>` を作る入口が複数残っていました。共通 normalizer を追加し、未指定 thread と repo 派生 main thread を `dashboard-main-unresolved` に畳むことで、restart 後の通常 runtime が repo 固定 thread に戻る経路を塞ぎました。

## Verification Evidence

- `npm run build:worker`: pass
- `npm run check:generated-worker`: pass
- `node --test test/e2e-518-dashboard-chat-transient-timestamps.test.js`: pass, 4 tests
- `node --test test/worker.test.js`: pass, 279 tests
- `git diff --check`: pass
- `npm test`: pass, 1206 pass / 0 fail / 1 skipped, plus self-parity and generated-worker checks pass

## Butler Completion Contract

- Primary owner surface: Dashboard Butler
- Fallback surface: mac Codex は debug / bootstrap fallback です。Custom GPT は fallback としてのみ扱います。
- Owner goal: 不要な repo 専用 chat thread を止め、app-server bridge restart 後も通常 chat を 1 本に保つこと。
- Butler entrypoint: Dashboard Butler の通常チャット `/dashboard`。
- Dashboard Butler natural-language path: Dashboard Butler が自然文の通常チャットを受け、repo は必要時に会話内 context として扱い、chat thread は `dashboard-main-unresolved` に接続します。
- Action Schema exposure: Action Schema は変更しません。古い repo 派生 thread id 入力は Dashboard runtime 正規化で吸収します。
- Runtime path: `/dashboard`、`/v2/dashboard/chat/:threadId`、GitHub Actions event ingest、VPS runner event ingest、VPS maintenance approval continuation / helper queue。
- Runner/runtime truth: local Worker tests と generated worker parity で確認済み。production deploy 後 runtime truth は未確認です。
- Authority boundary: code/test/PR 作成は通常実装範囲。deploy、VPS env / systemd mutation、credential / permission mutation は passkey 境界で未実施です。
- E2E evidence: local E2E-518 route test は pass。iPhone/iPad production PWA E2E は未実施です。
- Completion status: incomplete

## Surface Update Checklist

- Dashboard Butler normal chat: updated
- Custom GPT Action Schema: not changed, runtime thread normalization absorbs old repo-derived thread id inputs
- VPS Codex CLI / systemd: not changed; passkey boundary
- GitHub Issue / PR traceability: Issue #613 and related #741 are documented here
- Runtime truth / E2E: local tests pass; production PWA E2E remains after deploy
