### PR TITLE
Issue #595 active queue refresh 2026-06-05

### DIFF
--- a/docs/development-strategy/issue-595-active-queue-refresh-2026-06-05.md
+++ b/docs/development-strategy/issue-595-active-queue-refresh-2026-06-05.md
@@ -1,0 +1,64 @@
+# Issue #595: active queue refresh 2026-06-05
+
+## 完了体験
+
+Dashboard Butler が「VTDD の続きを順番に進めて」と言われた時、古い 2026-06-02 queue ではなく、PR #792 merge 後と Issue #793 作成後の durable queue を読んで次の一手を判断できる。
+
+## VTDD 全体で進める部分
+
+Issue #595 の execution queue contract を、直近の runtime truth に追従させる。これは実装機能ではなく交通整理の durable snapshot 更新であり、Issue #590 / Issue #637 / Issue #613 / Issue #793 の完了を主張しない。
+
+## 設計
+
+`docs/mvp/active-issue-execution-queue.md` に 2026-06-05 の GitHub truth を反映する。open PR が 0 件であること、latest main が PR #792 merge commit であること、Issue #590 が引き続き close-ready でないこと、Issue #637 が Next として残ること、Issue #793 は deploy notification driven stale-client refresh の Queue item であり #723 follow-up であることを記録する。
+
+## 仮説
+
+現 queue は 2026-06-02 rebuilt のままで、PR #774 以降の #590 live progress / #455 app-server復旧 / #613 single main thread / #793 新規 Issue を反映していない。ここを更新せずに次の実装へ進むと、owner の「順番に」という指示を古い `Now` / `Next` で解釈し、#793 を誤って preempt したり、PR #792 の production E2E gap を見落とす。
+
+## 検証計画
+
+- Unit: `node --test test/active-issue-execution-queue.test.js`
+- Guard: `git diff --check`
+- Read evidence: `gh pr list` で open PR 0、`gh pr view 792`、`gh issue view 590`、`gh issue view 637`、`gh issue view 793` を確認済みとして PR body に記録する。
+
+## 改修見積もり
+
+- `docs/development-strategy/issue-595-active-queue-refresh-2026-06-05.md`: この作戦図。リスクは chat-only 判断を durable 化しすぎること。
+- `docs/mvp/active-issue-execution-queue.md`: runtime truth snapshot、Now/Next/Queue/Evidence Gaps を更新する。リスクは active Issue を縮小したように読ませること。
+
+## 既に通っている経路
+
+Issue #595 の contract、PR body guardrail、active queue document は既に repo-backed である。PR #792 は merged、open PR は 0 件、main は `origin/main` と一致している。
+
+## 未確認の境界
+
+Production deploy / PWA live E2E / bridge restart truth はこの queue refresh では実行しない。Issue #793 の実装順序は #590/#637/#613 の残 blocker と照合して後続で決める。
+
+## 穴が出そうな箇所
+
+Issue #793 は owner の直近合意だが、EMERGENCY ではない。Queue に入れ、#590 / #637 / #613 の root blocker を勝手に下げない。PR #792 は merged だが production PWA E2E が未実施なので #613 completion ではない。
+
+## PR 前に確認すること
+
+open PR 0、branch が topic branch、`docs/mvp/active-issue-execution-queue.md` の tests が更新後も通ること、未追跡 `.tmp/` / `test-results/` を stage しないこと。
+
+## 実装候補と捨てた案
+
+採用: queue snapshot の狭い更新。
+
+捨てた案: すぐ #793 の runtime 実装に入る。理由は current Now / Next が未更新で、#793 は follow-up Queue item であり preemption 根拠がないため。
+
+捨てた案: Issue #590 を完了扱いにして #637 へ移る。理由は production E2E failure / request stall recovery deploy evidence / live progress UX がまだ incomplete のため。
+
+## merge 後に通す E2E
+
+この PR 自体は docs/traffic-control refresh なので production E2E は対象外。merge 後は queue に従い、Issue #590 の post-PR #791 production recovery evidence または Issue #637 の next low-risk / restart capability slice へ進む。
+
+## 次の PR を増やさない理由
+
+owner の「順番に進めて」に対する最初の必要作業は queue truth の更新であり、ここを単独 PR にすることで後続実装 PR が古い queue を根拠にしない。
+
+## 停止条件
+
+active Issue の scope conflict、open PR の発見、production deploy / credential / permission / root helper mutation が必要になる場合は停止する。

--- a/docs/mvp/active-issue-execution-queue.md
+++ b/docs/mvp/active-issue-execution-queue.md
@@ -9,7 +9,7 @@ This file is not a scope reducer. Active Issues remain in scope unless the owner
 explicitly narrows the implementation window. This file records execution order,
 preemption decisions, blockers, and evidence gaps.
 
-Last rebuilt from GitHub runtime truth: 2026-06-02
+Last rebuilt from GitHub runtime truth: 2026-06-05
 
 ## Queue Policy
 
@@ -33,13 +33,17 @@ Last rebuilt from GitHub runtime truth: 2026-06-02
   Issue #582, Issue #585, Issue #587, Issue #589, Issue #590, Issue #594,
   Issue #595, Issue #599, Issue #604, Issue #605, Issue #606, Issue #613,
   Issue #620, Issue #634, Issue #637, Issue #651, Issue #654, Issue #657,
-  Issue #667, Issue #670, Issue #689.
+  Issue #667, Issue #670, Issue #689, Issue #698, Issue #703, Issue #716,
+  Issue #717, Issue #722, Issue #723, Issue #741, Issue #744, Issue #745,
+  Issue #748, Issue #793.
 - Recently closed as completed with evidence and owner approval: Issue #573,
   Issue #565, Issue #577, Issue #580, Issue #601, Issue #609.
 - Open PRs read before this queue refresh PR was opened: none.
 - Recent queue-changing merged PRs read: PR #591, PR #597, PR #598, PR #600,
   PR #602, PR #603, PR #607, PR #608, PR #610, PR #611, PR #612, PR #685,
-  PR #686, PR #688, PR #690.
+  PR #686, PR #688, PR #690, PR #774, PR #775, PR #776, PR #777, PR #778,
+  PR #779, PR #780, PR #781, PR #782, PR #783, PR #784, PR #785, PR #786,
+  PR #787, PR #788, PR #789, PR #790, PR #791, PR #792.
 - Current queue rebuild scope: classify all open Issues without closing,
   downscoping, or treating any unverified Issue as done.
 - 2026-05-29 owner input classified Issue #606 as `ROOT`: the 2-minute
@@ -123,14 +127,40 @@ Last rebuilt from GitHub runtime truth: 2026-06-02
   because the owner-facing long-turn experience is still incomplete: transient
   progress must be visible without chat-history spam, and completion should
   leave a readable final summary instead of a trail of low-value progress.
+- 2026-06-04 production evidence showed Issue #590 remained incomplete after
+  multiple live-progress slices: owner-facing progress appeared late,
+  low-value transport status leaked into the wrong lane, scroll position could
+  be stolen, and final summaries lacked important queue / PR / runtime links.
+  Follow-up PRs #774 through #783 improved final progress summary, realtime
+  checkpoint stream, scroll guard, fallback checkpoint, reply-delta progress,
+  media-aware recovery, context-window reset, and related bridge behavior, but
+  mapped production completion evidence is still missing.
+- 2026-06-05 PR #789 and PR #790 repaired Issue #455 app-server regressions
+  exposed while continuing Issue #590: unsupported-model backend thread recovery
+  and Codex CLI threadSource protocol drift. These are partial runtime recovery
+  slices, not Issue #455 completion.
+- 2026-06-05 PR #791 merged Issue #590 app-server request stall recovery. It
+  prevents a `thread/start` / `turn/start` request stall from leaving no
+  final/failed Dashboard event, but production deploy and iPhone/PWA live E2E
+  remain required before Issue #590 can advance out of `Now`.
+- 2026-06-05 PR #792 merged Issue #613 single main Dashboard chat thread
+  runtime routing. It stops Worker runtime paths from generating repo-derived
+  main chat threads, but production deploy, PWA E2E, VPS env cleanup, and
+  historical thread migration remain incomplete.
+- 2026-06-05 Issue #793 was created from owner agreement on deploy notification
+  driven stale-client refresh. It is a follow-up to Issue #723 and related to
+  Issue #590 / Issue #654 / Issue #514, but it is classified as `QUEUE` and
+  does not preempt the current root blocker.
 
 ## Now
 
 - Issue #590: app-server turn timeout / silent wait recovery. Fixed 2-minute
   conversation death and durable low-information progress spam are mitigated in
-  production, but the remaining root blocker is owner-facing observability:
-  longer Dashboard Butler work must show transient progress without polluting
-  chat history, then leave a concise final summary.
+  production. PR #791 adds request-stall recovery, but the current root blocker
+  remains owner-facing observability and recovery evidence: longer Dashboard
+  Butler work must show readable live progress, avoid low-value transport spam,
+  keep scroll/draft/thread state stable, preserve important evidence links in
+  final summaries, and prove the recovery path in production PWA after deploy.
 
 ## Next
 
@@ -166,7 +196,12 @@ Root blockers hold multiple active Issues open. They should shape `Now` and
   single-thread cross-repo work-control surface, not a repo-selected admin
   panel. It gates the product direction for Issue #528, Issue #450, Issue #413,
   Issue #415, Issue #498, Issue #514, Issue #590, Issue #594, Issue #604,
-  Issue #605, and Issue #606.
+  Issue #605, and Issue #606. PR #792 merged the first runtime thread-routing
+  slice, but production PWA E2E and VPS cleanup are still incomplete.
+- Issue #748: presence / voice / progress must be cost-aware before broader
+  voice-ready or high-frequency progress work. It gates Issue #613 voice work,
+  Issue #590 progress lane design, and Issue #455 cost discipline by requiring
+  presence to stay distinct from persistence.
 - Issue #606: ordinary Dashboard read sessions must not reuse the same
   short-lived approval grant used for high-risk operations. It gates practical
   iPhone/PWA recovery for Issue #579, timeout recovery acceptance for Issue
@@ -236,6 +271,17 @@ Root blockers hold multiple active Issues open. They should shape `Now` and
 - Issue #565, Issue #577, and Issue #580 were closed on 2026-05-31 with
   evidence comments after merged PRs and current production setup truth were
   re-read.
+- PR #774 through PR #783 / Issue #590 merged live-progress, final-summary,
+  scroll, fallback, media-aware recovery, and context-reset slices. These PRs are
+  progress evidence only; owner production evidence still reports incomplete
+  realtime progress and lane separation.
+- PR #785 through PR #791 repaired Issue #590 / Issue #455 app-server context,
+  unsupported-model, protocol drift, and request-stall failure modes. They keep
+  Dashboard Butler usable but do not close Issue #590 or Issue #455 without
+  production deploy/live E2E evidence.
+- PR #792 / Issue #613 merged single main Dashboard chat runtime normalization.
+  It is partial #613 progress and does not perform production deploy, VPS env
+  cleanup, or historical thread migration.
 
 ## Evidence Gaps
 
@@ -256,7 +302,9 @@ Evidence gaps are active. They are not deferred out of scope.
   progress no longer pollutes durable chat history. Closure still needs mapped
   production owner-facing evidence for the remaining long-turn UX: transient
   progress visibility, final summary replacement, same-thread follow-up /
-  cancel / interrupt handling, and clear late-completion behavior.
+  cancel / interrupt handling, clear late-completion behavior, request-stall
+  recovery after PR #791, evidence-link preservation, and scroll-safe live
+  progress lane behavior.
 - Issue #651: PR #652 merged a same-head conflicting reviewer evidence gate, but
   live/mapped E2E close-readiness evidence is still missing, so the Issue remains
   open.
@@ -298,6 +346,15 @@ Evidence gaps are active. They are not deferred out of scope.
 - Issue #657: chief-butler interpretation confirmation is a process / traffic
   control gap and remains open until the protocol is repo/runtime-backed with
   mapped evidence.
+- Issue #613: PR #792 merged runtime thread normalization for single main chat,
+  but production PWA evidence, repo context ambiguity handling, voice-ready
+  operation lane, and VPS/env cleanup remain incomplete.
+- Issue #723: manual freshness / force cache reload controls exist, but close
+  readiness still needs evidence posting and stale-client recovery judgment. The
+  automatic deploy-notification-driven refresh follow-up is Issue #793.
+- Issue #741: deploy後 bridge checkout sync / restart lifecycle has
+  implementation slices, but production evidence and authority-bound cleanup
+  remain incomplete.
 
 ## Blocked
 
@@ -311,6 +368,9 @@ Evidence gaps are active. They are not deferred out of scope.
   truth; do not rely on chat alone as the intended VTDD product path.
 - Production iPhone/PWA live evidence remains blocked unless the relevant PR
   scope explicitly authorizes live verification.
+- Production deploy and app-server bridge restart after PR #791 / PR #792 remain
+  blocked on scoped passkey approval. Do not claim those merged PRs are
+  production-complete from local tests or GitHub merge truth alone.
 - Issue #354: VPS maintenance apply/reboot paths are blocked on explicit GO and
   careful authority design even if status/check paths can be designed first.
 - Issue #355 / Issue #412: live secret sync verification is blocked on safe
@@ -353,6 +413,31 @@ These Issues remain active and required, but they do not preempt the current
 - Issue #689: LINE-like reply target preview / tap-to-scroll context for
   fast multi-message Dashboard Butler chat. This is required owner-facing UX, but
   it remains `QUEUE` and must not preempt the current Now item.
+- Issue #698: notification policy and delayed notification settings should move
+  onto the shared notification system.
+- Issue #703: pre-development strategy guard. The 開発前作戦図 gate is active as a
+  process guardrail; remaining automation/guard enforcement stays queued unless
+  it becomes a root blocker.
+- Issue #716: Butler thought buffer and repo-specific execution lanes for
+  capturing ideas without replacing the current `Now`.
+- Issue #717: immediate VPS runner wakeup after queue comment, with the one
+  minute timer as fallback.
+- Issue #722: Dashboard Butler completion events should append thread state and
+  drive next action.
+- Issue #723: stale PWA/client self-refresh and manual force reload remains an
+  evidence gap / support slice for Issue #590.
+- Issue #741: app-server bridge lifecycle guard for main and repo-less chat.
+- Issue #744: Dashboard chat long replies must remain readable and avoid tail
+  clipping.
+- Issue #745: reviewer fallback must not keep calling a ChatGPT-account
+  unsupported model.
+- Issue #748: cost-aware presence / voice / progress redesign. Treat as a root
+  design constraint for Issue #590 / Issue #613 work, but do not let it become a
+  broad implementation detour without a bounded slice.
+- Issue #793: deploy notification driven stale-client refresh. This is the
+  agreed follow-up to Issue #723: deploy notifications should trigger stale
+  client detection and conditional auto/one-tap refresh without writing chat
+  spam or losing draft/thread/pending turn state.
 
 ## Questions
 
@@ -365,8 +450,8 @@ These Issues remain active and required, but they do not preempt the current
 
 ## Discovered
 
-- None recorded in this rebuild. New owner inputs and implementation discoveries
-  should be classified here before they become new Issues or preempt current work.
+- Issue #793 was discovered from owner discussion and authored on 2026-06-05. It
+  is now classified as `QUEUE`, not as an untracked discovery.
 
 ## Required PR Delta
 

--- a/test/active-issue-execution-queue.test.js
+++ b/test/active-issue-execution-queue.test.js
@@ -4,10 +4,11 @@ import fs from "node:fs";
 
 const doc = fs.readFileSync("docs/mvp/active-issue-execution-queue.md", "utf8");
 
-const OPEN_ISSUES_ON_2026_05_31 = [
+const OPEN_ISSUES_ON_2026_06_05 = [
   354, 355, 356, 358, 412, 413, 415, 417, 421, 444, 448, 450, 455, 491, 492,
   495, 497, 498, 501, 514, 528, 574, 579, 582, 585, 587, 589, 590, 594, 595,
-  599, 604, 605, 606, 613, 620, 634, 637, 651, 654, 657, 667, 670, 689
+  599, 604, 605, 606, 613, 620, 634, 637, 651, 654, 657, 667, 670, 689, 698,
+  703, 716, 717, 722, 723, 741, 744, 745, 748, 793
 ];
 
 const CLASSIFICATION_SECTIONS = [
@@ -35,7 +36,7 @@ function sectionBody(sectionName) {
 const classifiedIssueText = CLASSIFICATION_SECTIONS.map(sectionBody).join("\n");
 
 test("active issue execution queue records every open issue from the rebuild snapshot", () => {
-  for (const issueNumber of OPEN_ISSUES_ON_2026_05_31) {
+  for (const issueNumber of OPEN_ISSUES_ON_2026_06_05) {
     assert.equal(
       doc.includes(`Issue #${issueNumber}`),
       true,
@@ -45,7 +46,7 @@ test("active issue execution queue records every open issue from the rebuild sna
 });
 
 test("active issue execution queue classifies every open issue outside the runtime snapshot", () => {
-  for (const issueNumber of OPEN_ISSUES_ON_2026_05_31) {
+  for (const issueNumber of OPEN_ISSUES_ON_2026_06_05) {
     assert.equal(
       new RegExp(`^- Issue #${issueNumber}:`, "m").test(classifiedIssueText),
       true,


### PR DESCRIPTION
## This PR satisfies Intent

Issue #595 の execution queue contract に沿って、2026-06-05 時点の GitHub runtime truth を `docs/mvp/active-issue-execution-queue.md` に反映します。

owner の「VTDD の続きを順番に進めて」という入力を、古い 2026-06-02 queue ではなく、PR #792 merge 後・Issue #793 作成後の durable queue で判断できる状態にします。

## Satisfied Success Criteria

- `docs/mvp/active-issue-execution-queue.md` の rebuild date を 2026-06-05 に更新しました。
- current open Issue snapshot に Issue #698 / #703 / #716 / #717 / #722 / #723 / #741 / #744 / #745 / #748 / #793 を追加しました。
- Recent merged PR truth に PR #774 から PR #792 までを追加しました。
- Issue #590 は引き続き `Now` とし、PR #791 後も production deploy / PWA E2E / live progress evidence が未完了であることを明記しました。
- Issue #637 は `Next` のまま維持しました。
- Issue #793 は Issue #723 follow-up の `QUEUE` として分類し、現在の root blocker を preempt しないことを明記しました。
- queue test の open Issue snapshot を 2026-06-05 に更新しました。

## Unsatisfied Success Criteria

- この PR は queue snapshot refresh であり、Issue #590 / Issue #637 / Issue #613 / Issue #793 の runtime 実装や close-ready evidence は作りません。
- Butler / VPS Codex CLI の runtime auto-classification path は未接続のままです。

## Non-goal violations

None.

## 開発前作戦図

- 作戦図 evidence: `docs/development-strategy/issue-595-active-queue-refresh-2026-06-05.md`
- 完了体験: Dashboard Butler が「順番に進めて」と言われた時に、最新 queue を読んで #590 / #637 / #793 の順序を誤らない。
- VTDD 全体で進める部分: Issue #595 の traffic-control durable snapshot 更新。
- 設計: open Issue / merged PR / current Now / Next / Queue を docs に反映し、実装完了 claim は避ける。
- 仮説: suspected cause は 2026-06-02 queue のまま runtime truth が止まっていること。これにより Issue #793 が untracked になり、PR #792 の production E2E gap や PR #791 の deploy/E2E gap を見落とす。
- 検証計画: queue doc test と `git diff --check`。
- 改修見積もり: queue doc、queue test、作戦図 file。
- 既に通っている経路: Issue #595 contract と PR body guardrail は repo-backed。
- 未確認の境界: production deploy / PWA live E2E / bridge restart はこの PR では実行しない。
- 穴が出そうな箇所: Issue #793 を直近 owner 合意だけで `Now` にしてしまうこと。今回は `QUEUE` に留めた。
- PR 前に確認すること: open PR 0、main/upstream、targeted test、未追跡 `.tmp/` / `test-results/` を stage しないこと。
- 実装候補と捨てた案: queue refresh 単独を採用。#793 runtime 実装や #590 close-ready claim は捨てた。
- merge 後に通す E2E: docs refresh のため production E2E は対象外。後続は queue に従って #590 evidence / #637 next slice へ進む。
- 次の PR を増やさない理由: 古い queue のまま実装へ進む drift を止める最小 PR。
- 停止条件: deploy / credential / permission / root helper mutation が必要になった場合。

## Dry-run Impact Report

- Target Issue: Issue #595
- Implementing Success Criteria: active issue queue を repo-backed traffic-control truth として更新する。
- Explicit Non-goals: runtime code change、deploy、credential / permission mutation、Issue close、merge後 branch cleanup。
- Expected touched files/routes/workflows: `docs/mvp/active-issue-execution-queue.md`、`test/active-issue-execution-queue.test.js`、`docs/development-strategy/issue-595-active-queue-refresh-2026-06-05.md`
- Affected Issues: Issue #595, Issue #590, Issue #637, Issue #613, Issue #723, Issue #793
- Affected PRs: PR #774 through PR #792 are referenced as runtime truth only.
- Affected workflows: local Node test only.
- Affected runtime/operator surfaces: Dashboard Butler traffic-control documentation and queue-reading behavior only; no runtime route or operator action is changed.
- What may break if we patch narrowly: future agents may still rely on stale runtime truth outside the doc; runtime auto-classification remains a follow-up gap.
- Unknowns to investigate before coding: none for this docs-only refresh.
- Validation needed: `node --test test/active-issue-execution-queue.test.js`, `git diff --check`.
- Stop condition: queue update discovers open PR or authority-bound operation that changes the current order.

## Execution Queue Delta

- Queue position before: Issue #590 remained `Now`, Issue #637 remained `Next`, but durable queue truth was stale at 2026-06-02.
- Preemption decision: `QUEUE`. This PR refreshes the queue itself and does not replace Issue #590 as `Now`.
- Queue delta: Issue #793 is added to `QUEUE`; PR #791 / PR #792 are recorded as merged partial progress with production deploy/E2E still blocked; Issue #590 stays `Now`; Issue #637 stays `Next`.
- Why this PR is next: owner asked to continue VTDD in order, and continuing implementation from a stale queue would create drift.
- Active Issues not downscoped: Active Issues are not shrunk, deferred out of scope, or treated as complete by omission.

## File / Line Hypotheses

- file: `docs/mvp/active-issue-execution-queue.md`
  - hypothesis: queue truth is stale after PR #792 and Issue #793.
  - risk if changed narrowly: new Issues remain unclassified and next implementation order drifts.
  - validation: queue snapshot test.
  - related Issue: Issue #595
- file: `test/active-issue-execution-queue.test.js`
  - hypothesis: test should enforce the 2026-06-05 open Issue snapshot, not only the old 2026-05-31 list.
  - risk if changed narrowly: future open Issue additions can be missed.
  - validation: targeted Node test.
  - related Issue: Issue #595

## Hypothesis Retrospective

- expected: queue doc could be refreshed without changing runtime code.
- actual: queue doc and queue test updated; targeted test passed.
- mismatch: none.
- lesson: issue creation such as Issue #793 should be classified in the durable queue before being allowed to influence `Now`.
- should become RAG candidate: no, this is already repo-backed queue truth.

## Verification Evidence

- Unit: `node --test test/active-issue-execution-queue.test.js` passed, 5 tests.
- Guard: `git diff --check` passed.
- E2E: not applicable; this is docs/test traffic-control refresh, not runtime behavior.
- Manual: `gh pr list --state open` returned no open PRs before this PR was created; `gh issue list --state open` was used for the 2026-06-05 open Issue snapshot.

## Butler Completion Contract

- Primary owner surface: Dashboard Butler
- Fallback surface: mac Codex is only the implementation/debug fallback for this docs refresh.
- Owner goal: continue VTDD in durable queue order.
- Butler entrypoint: Dashboard Butler natural-language continuation request.
- Dashboard Butler natural-language path: Dashboard Butler natural-language/chat entrypoint で owner が「VTDD の続きを順番に進めて」と送ると、Butler が queue truth を読み `Now` / `Next` を維持する。
- Action Schema exposure: unchanged.
- Runtime path: unchanged.
- Runner/runtime truth: GitHub Issue / PR truth read; no runner launched.
- Authority boundary: no deploy, credential, permission, destructive, merge, Issue close, or branch cleanup.
- E2E evidence: not applicable for this docs-only queue refresh.
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: not run.
- Custom GPT Action Schema update: not changed.
- Custom GPT Instructions update: not changed.
- iPhone Butler live E2E: not run.

## Related Constitution Rules

- AGENTS.md Butler Completion Gate
- AGENTS.md Active-Issue Coverage Policy
- AGENTS.md MVP Definition
- AGENTS.md Drift Stop Protocol
- AGENTS.md 開発前作戦図 Gate
- docs/butler/execution-queue-contract.md

## Out-of-scope but NOT implemented

- Issue #590 runtime implementation or closure
- Issue #637 privileged maintenance implementation
- Issue #793 deploy notification refresh implementation
- production deploy / bridge restart

## Extra changes (if any)

None.
