### PR TITLE
Issue #590 progress lane stability

### DIFF
--- a/docs/development-strategy/issue-590-progress-lane-stability.md
+++ b/docs/development-strategy/issue-590-progress-lane-stability.md
@@ -1,0 +1,68 @@
+# Issue #590 progress lane stability 作戦図
+
+## 完了体験
+
+Dashboard Butler の長い turn 中、owner は入力欄下で `考えています。` / `ファイル変更を確認しています。` のような低情報 status を一時的に見られる。一方で、チャット本文側に出ている owner-facing checkpoint は、低情報 status、添付プレビュー、thread refresh、WebSocket transient event の再描画で空白化しない。最終回答が来た時だけ checkpoint は消え、必要な進行ログは最終回答側に集約される。
+
+## VTDD 全体で進める部分
+
+Issue #590 の owner-facing observability のうち、今回は表示レーン混線と checkpoint 空白化を直す。Issue #637 の VPS privileged maintenance、Issue #793 の deploy notification driven stale-client refresh、Issue #654 の reconnect-resend 全体は次以降に残す。
+
+## 設計
+
+低情報 transport status と owner-facing checkpoint は同じ transient snapshot 経路を通るが、UI での扱いを分ける。composer 下の transient progress は every status update を受けてよい。chat 内 checkpoint は `progressSummary.entries` がある snapshot だけで更新する。`progressSummary` の無い低情報 status は既存 checkpoint を消さず、final reply / failed / stalled / explicit clear の時だけ checkpoint を消す。
+
+## 仮説
+
+`src/worker/runtime.js` の `updateTransientProgress()` は、低情報 status でも `renderThreadProgressCheckpoint(options.snapshot || null)` を呼ぶ。`renderThreadProgressCheckpoint()` は snapshot を受けると `transientProgressSnapshotState` を置き換え、`latestProgressCheckpointText()` が空なら `clearThreadProgressCheckpoint()` を呼ぶ。これにより、直前に readable reply delta / long_turn_checkpoint で出ていた chat checkpoint が、`file_change` や `command` の status update で消える。
+
+この narrow patch だけなら bridge event 生成や Durable Object schema を変えずに、UI lane の安定性を改善できる。ここで fallback timer、owner input queue、stop/interrupt へ広げると #590 の残 scope が混線する。
+
+## 検証計画
+
+- Worker HTML regression: readable checkpoint snapshot の後に progressSummary の無い low-information transient status が来ても、chat checkpoint を消す呼び出しにならないことを source assertion で確認する。
+- Worker runtime regression: `app_server_reply_delta` の checkpoint 後に `file_change` status が来ても snapshot の `progressSummary` は latest readable checkpoint を保持することを確認する。
+- Existing targeted tests: `node --test test/worker.test.js --test-name-pattern 'DashboardChatRoom'`
+- Generated worker: `npm run build:worker`
+- Generated worker check: `npm run check:generated-worker`
+- Diff hygiene: `git diff --check`
+
+## 改修見積もり
+
+- `src/worker/runtime.js`: UI helper に `hasProgressCheckpointSnapshot()` を追加し、`updateTransientProgress()` が low-information snapshot で chat checkpoint を消さないようにする。risk は final / failure 時の clear が効かなくなることだが、そこは `clearTransientProgress()` の explicit clear 経路を維持する。
+- `test/worker.test.js`: app-server reply delta checkpoint 後の low-information status regression を追加する。risk は mock storage の期待値が Durable Object 実装とズレること。
+- `worker.js`: generated worker を `npm run build:worker` で同期する。
+
+## 既に通っている経路
+
+PR #731 で低情報 progress の durable chat history 汚染は止まっている。PR #774 以降で transient snapshot、final progress summary、live checkpoint card、scroll guard の土台が入っている。PR #779 / #780 後、`codex app-server が応答を生成しています。` は composer 下へ戻ったが、chat-visible checkpoint と低情報 status の混線は owner production evidence で残っている。
+
+## 未確認の境界
+
+production PWA の添付プレビュー再描画と WebSocket transient update の正確な順序は未確認。ただし、低情報 snapshot で checkpoint を clear する UI 経路は source 上で確認できるため、この slice で先に潰す価値がある。
+
+## 穴が出そうな箇所
+
+`restoreThreadRecoveryState()` が owner latest message から pending status を復元する場合も low-information snapshot と同様に chat checkpoint を消す可能性がある。今回の patch は `updateTransientProgress()` の入力を一元的に扱うため、ここも同時に保護される。
+
+## PR 前に確認すること
+
+`main` が `origin/main` と一致すること、Issue #590 が open で Now であること、open PR が競合していないこと、untracked `.tmp/` / `test-results/` を巻き込まないことを確認する。
+
+## 実装候補と捨てた案
+
+採用: chat checkpoint は owner-facing summary entries がある snapshot だけで更新し、低情報 snapshot は composer 下だけ更新する。
+
+捨てた案: low-information status を bridge 側で送らない。composer 下の現状維持という owner 方針に反する。捨てた案: progressSummary の無い snapshot でも dummy checkpoint を作る。チャット本文に低情報 status を戻す regression になる。捨てた案: thread refresh 全体を止める。添付/再接続/履歴復元の別機能を壊す。
+
+## merge 後に通す E2E
+
+production deploy 後、Dashboard Butler PWA で readable checkpoint が出た状態から画像添付または `file_change` / `command` status を含む長め turn を観測し、チャット本文 checkpoint が空白化せず、入力欄下 status だけが更新されることを確認する。最終回答後は checkpoint が消えることも確認する。
+
+## 次の PR を増やさない理由
+
+今回の変更は #590 の同一 root blockerである lane stability の最小修正で、source と test の触点が小さい。bridge fallback や scroll indicator まで同じ PR に入れると検証境界が広がるため入れない。
+
+## 停止条件
+
+checkpoint の clear が final reply / failed / stalled で効かなくなる、progressSummary の無い status が durable message に戻る、worker generated check が一致しない、または deploy / credential / permission / destructive work が必要になった場合は停止して owner に報告する。

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -10309,7 +10309,9 @@ const DASHBOARD_DURABLE_APP_SERVER_PROGRESS_STAGES = new Set([
 
 const DASHBOARD_LOW_INFORMATION_PROGRESS_TEXT = new Set([
   "考えています。",
+  "codex app-server が応答を生成しています。",
   "コマンドを実行しています。",
+  "ファイル変更を確認しています。",
   "外部ツールの結果を待っています。",
   "接続と実行状態を確認中です。入力と文脈は保持しています。"
 ]);
@@ -16764,7 +16766,9 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           snapshot: options.snapshot || null
         };
         renderTransientProgress();
-        renderThreadProgressCheckpoint(options.snapshot || null);
+        if (hasProgressCheckpointSnapshot(options.snapshot)) {
+          renderThreadProgressCheckpoint(options.snapshot);
+        }
       }
 
       function clearTransientProgress() {
@@ -16792,6 +16796,10 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           .reverse()
           .map((entry) => String(entry && entry.text || entry || "").trim())
           .find(Boolean) || "";
+      }
+
+      function hasProgressCheckpointSnapshot(snapshot) {
+        return Boolean(latestProgressCheckpointText(snapshot));
       }
 
       function ensureThreadProgressCheckpointCard() {
@@ -16822,7 +16830,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
 
       function renderThreadProgressCheckpoint(snapshot, options = {}) {
         const shouldFollow = options.follow === true || (options.follow !== false && isNearLatest());
-        if (snapshot && typeof snapshot === "object") {
+        if (hasProgressCheckpointSnapshot(snapshot)) {
           transientProgressSnapshotState = snapshot;
         }
         const text = latestProgressCheckpointText(transientProgressSnapshotState);

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -5354,6 +5354,57 @@ test("DashboardChatRoom keeps app-server reply deltas out of durable chat while 
   assert.equal((await store.listThread("dashboard-main-unresolved")).length, 0);
 });
 
+test("DashboardChatRoom preserves readable checkpoint when low-information file status follows reply delta", async () => {
+  const store = createInMemoryDashboardChatStore();
+  const dashboardSocket = createMockSocket("dashboard", "dashboard-main-unresolved");
+  const bridgeSocket = createMockSocket("app_server_bridge", "dashboard-main-unresolved");
+  const storage = createMockDurableObjectStorage();
+  const room = new DashboardChatRoom(
+    {
+      storage,
+      getWebSockets() {
+        return [dashboardSocket, bridgeSocket];
+      }
+    },
+    { DASHBOARD_CHAT_STORE: store }
+  );
+
+  await room.webSocketMessage(
+    bridgeSocket,
+    JSON.stringify({
+      type: "app_server_reply_delta",
+      threadId: "dashboard-main-unresolved",
+      codexThreadId: "codex-thread-590",
+      delta: "Issue #590 の表示レーンを確認しています。"
+    })
+  );
+  await room.webSocketMessage(
+    bridgeSocket,
+    JSON.stringify({
+      type: "app_server_status",
+      status: "thinking",
+      stage: "file_change",
+      threadId: "dashboard-main-unresolved",
+      codexThreadId: "codex-thread-590",
+      text: "raw diff detail"
+    })
+  );
+
+  const snapshot = storage.values.get("transient_progress_snapshot:dashboard-main-unresolved");
+  assert.equal(snapshot.text, "ファイル変更を確認しています。");
+  assert.deepEqual(
+    snapshot.progressSummary.entries.map((entry) => [entry.text, entry.source]),
+    [["Issue #590 の表示レーンを確認しています。", "app_server_reply_delta"]]
+  );
+  const transientPayloads = dashboardSocket.sent.map((message) => JSON.parse(message)).filter((message) => message.type === "transient_status");
+  assert.equal(transientPayloads.at(-1).text, "ファイル変更を確認しています。");
+  assert.deepEqual(
+    transientPayloads.at(-1).transientProgressSnapshot.progressSummary.entries.map((entry) => entry.text),
+    ["Issue #590 の表示レーンを確認しています。"]
+  );
+  assert.equal((await store.listThread("dashboard-main-unresolved")).length, 0);
+});
+
 test("DashboardChatRoom dedupes unchanged transient progress snapshot writes", async () => {
   const store = createInMemoryDashboardChatStore();
   const dashboardSocket = createMockSocket("dashboard", "dashboard-main-unresolved");

--- a/worker.js
+++ b/worker.js
@@ -67024,7 +67024,9 @@ var DASHBOARD_DURABLE_APP_SERVER_PROGRESS_STAGES = /* @__PURE__ */ new Set([
 ]);
 var DASHBOARD_LOW_INFORMATION_PROGRESS_TEXT = /* @__PURE__ */ new Set([
   "\u8003\u3048\u3066\u3044\u307E\u3059\u3002",
+  "codex app-server \u304C\u5FDC\u7B54\u3092\u751F\u6210\u3057\u3066\u3044\u307E\u3059\u3002",
   "\u30B3\u30DE\u30F3\u30C9\u3092\u5B9F\u884C\u3057\u3066\u3044\u307E\u3059\u3002",
+  "\u30D5\u30A1\u30A4\u30EB\u5909\u66F4\u3092\u78BA\u8A8D\u3057\u3066\u3044\u307E\u3059\u3002",
   "\u5916\u90E8\u30C4\u30FC\u30EB\u306E\u7D50\u679C\u3092\u5F85\u3063\u3066\u3044\u307E\u3059\u3002",
   "\u63A5\u7D9A\u3068\u5B9F\u884C\u72B6\u614B\u3092\u78BA\u8A8D\u4E2D\u3067\u3059\u3002\u5165\u529B\u3068\u6587\u8108\u306F\u4FDD\u6301\u3057\u3066\u3044\u307E\u3059\u3002"
 ]);
@@ -72888,7 +72890,9 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           snapshot: options.snapshot || null
         };
         renderTransientProgress();
-        renderThreadProgressCheckpoint(options.snapshot || null);
+        if (hasProgressCheckpointSnapshot(options.snapshot)) {
+          renderThreadProgressCheckpoint(options.snapshot);
+        }
       }
 
       function clearTransientProgress() {
@@ -72916,6 +72920,10 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           .reverse()
           .map((entry) => String(entry && entry.text || entry || "").trim())
           .find(Boolean) || "";
+      }
+
+      function hasProgressCheckpointSnapshot(snapshot) {
+        return Boolean(latestProgressCheckpointText(snapshot));
       }
 
       function ensureThreadProgressCheckpointCard() {
@@ -72946,7 +72954,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
 
       function renderThreadProgressCheckpoint(snapshot, options = {}) {
         const shouldFollow = options.follow === true || (options.follow !== false && isNearLatest());
-        if (snapshot && typeof snapshot === "object") {
+        if (hasProgressCheckpointSnapshot(snapshot)) {
           transientProgressSnapshotState = snapshot;
         }
         const text = latestProgressCheckpointText(transientProgressSnapshotState);


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #590 の progress 表示レーン混線を最小修正します。
- readable checkpoint が chat 本文側に出た後、`ファイル変更を確認しています。` / `codex app-server が応答を生成しています。` のような低情報 status が届いても、chat checkpoint を空白化しないようにします。
- 低情報 status は composer 下の transient status として維持し、chat 内 checkpoint は `progressSummary.entries` を持つ owner-facing snapshot が来た時だけ更新します。

## Satisfied Success Criteria

- `ファイル変更を確認しています。` と `codex app-server が応答を生成しています。` を low-information progress として summary 除外対象に追加した。
- `updateTransientProgress()` が progressSummary の無い snapshot で chat checkpoint を clear しないようにした。
- `renderThreadProgressCheckpoint()` が owner-facing checkpoint を持つ snapshot だけを state に採用するようにした。
- readable reply delta checkpoint 後に low-information `file_change` status が来ても、snapshot の readable checkpoint が保持され、durable chat message が増えない regression test を追加した。

## Unsatisfied Success Criteria

- production PWA で、添付プレビュー / low-information status / thread refresh 後も checkpoint が空白化しないことは merge/deploy 後 E2E が必要です。
- Issue #590 全体はまだ close-ready ではありません。

## Non-goal violations

None.

## 開発前作戦図

- 作戦図 evidence: docs/development-strategy/issue-590-progress-lane-stability.md
- 完了体験: Dashboard Butler の長い turn 中、低情報 status は入力欄下に出続け、chat 本文の readable checkpoint は低情報 status や再描画で消えない。final / failed / stalled 時だけ explicit clear される。
- VTDD 全体で進める部分: Issue #590 の owner-facing observability のうち、表示レーン混線と checkpoint 空白化を狭く修正する。
- 設計: composer 下 transient progress は every status update を受ける。chat 内 checkpoint は `progressSummary.entries` を持つ owner-facing snapshot だけで更新する。
- 仮説: suspected cause は、`updateTransientProgress()` が低情報 snapshot でも `renderThreadProgressCheckpoint()` を呼び、progressSummary の無い snapshot で既存 checkpoint を消していたこと。
- 検証計画: Worker regression test、DashboardChatRoom targeted tests、bridge tests、generated worker check、diff check。
- 改修見積もり: `src/worker/runtime.js` の低情報分類と UI helper、`test/worker.test.js` の regression、`worker.js` generated sync。
- 既に通っている経路: PR #731 で durable chat history 汚染は止まり、PR #774 以降で transient snapshot / final progress summary / live checkpoint card / scroll guard の土台がある。
- 未確認の境界: production PWA の添付プレビュー再描画と WebSocket transient update の正確な順序は merge/deploy 後に確認が必要。
- 穴が出そうな箇所: final reply / failed / stalled 時の clear が効かなくなる可能性。今回の patch は explicit clear 経路を維持している。
- PR 前に確認すること: main/origin truth、Issue #590 open/Now、open PR 無し、untracked `.tmp/` / `test-results/` を巻き込まないこと、targeted tests。
- 実装候補と捨てた案: 採用は owner-facing entries のある snapshot だけ chat checkpoint に反映する案。捨てた案は low-information status を送らない案、dummy checkpoint を作る案、thread refresh 全体を止める案。
- merge 後に通す E2E: production PWA E2E 検証として、readable checkpoint 表示後に画像添付または `file_change` / `command` status を含む長め turn を観測し、chat checkpoint が空白化しないことを確認する。
- 次の PR を増やさない理由: これは #590 の同一 root blocker の lane stability 最小修正であり、この範囲で閉じる。bridge fallback や scroll indicator は既に別の残 scope として残っており、今回の PR で増やす follow-up PR ではない。
- 停止条件: low-information status が durable message に戻る、final / failed / stalled clear が効かない、generated worker check が一致しない、deploy / credential / permission / destructive work が必要になる場合。

## Dry-run Impact Report

- Target Issue: Issue #590
- Implementing Success Criteria: low-information transport status と owner-facing checkpoint の表示先を分け、低情報 status で readable checkpoint を消さない。
- Explicit Non-goals: Issue #637 VPS privileged maintenance、Issue #793 deploy notification refresh、Issue #654 reconnect-resend、stop / interrupt / owner input queue、production deploy、Issue close。
- Expected touched files/routes/workflows: `src/worker/runtime.js`, `test/worker.test.js`, `worker.js`, `docs/development-strategy/issue-590-progress-lane-stability.md`。
- Affected Issues: #590.
- Affected PRs: PR #774 through #783 の follow-up evidence。PR #794 queue refresh truth。
- Affected workflows: Worker generated build only。GitHub Actions workflow definition は変更しない。
- Affected runtime/operator surfaces: Dashboard Butler PWA chat, composer transient progress, app-server bridge transient status display.
- What may break if we patch narrowly: progressSummary の無い snapshot では chat checkpoint が更新されないため、bridge 側が readable checkpoint を entries に入れ損ねると chat-visible progress は増えない。
- Unknowns to investigate before coding: production PWA の attach / refresh / transient update の順序。
- Validation needed: targeted Worker tests, bridge tests, generated worker check, production PWA E2E after deploy.
- Stop condition: checkpoint clear semantics と low-information status boundary が既存 tests と矛盾した場合。

## Execution Queue Delta

- Queue position before: Issue #590 remains `Now`.
- Preemption decision: EVIDENCE. Owner の直近指摘は #590 の production evidence / blocker 更新であり、#637 / #793 を preempt しない。
- Queue delta: Issue #590 stays in `Now`; this PR narrows the display-lane stability blocker and leaves production PWA E2E as remaining evidence.
- Why this PR is next: 低情報 status と chat checkpoint のレーン混線、添付/再描画時の checkpoint 空白化が Dashboard Butler の通常会話継続を直接ブロックしているため。
- Active Issues not downscoped: Active Issues are not downscoped. #637, #654, #793 remain active and are not closed or reduced by this PR.

## File / Line Hypotheses

- file: `src/worker/runtime.js`
  - hypothesis: `updateTransientProgress()` が低情報 snapshot でも checkpoint render を呼び、progressSummary の無い snapshot で既存 checkpoint を clear している。
  - risk if changed narrowly: final / failed / stalled の clear が効かなくなる可能性。
  - validation: DashboardChatRoom regression test and generated worker check.
  - related Issue: #590

- file: `test/worker.test.js`
  - hypothesis: reply delta checkpoint 後に file_change が来るケースを固定すれば、owner が見た「返信が消える」系 regression を局所的に防げる。
  - risk if changed narrowly: production attach/reconnect order までは unit test だけでは証明できない。
  - validation: new regression plus existing DashboardChatRoom tests.
  - related Issue: #590

## Hypothesis Retrospective

- expected: low-information file status keeps composer status updated without clearing readable checkpoint.
- actual: targeted DashboardChatRoom tests passed; new regression shows snapshot text becomes `ファイル変更を確認しています。` while progressSummary keeps the previous readable checkpoint.
- mismatch: full `npm run verify:worker` has unrelated local environment failures outside this slice.
- lesson: Worker-side summary inclusion and UI-side checkpoint state must share the same low-information boundary.
- should become RAG candidate: Yes, after production PWA E2E confirms this was the observed blanking cause.

## Verification Evidence

- Unit: `node --test test/worker.test.js --test-name-pattern 'DashboardChatRoom'` passed.
- Unit: `node --test test/dashboard-app-server-bridge.test.js` passed.
- Integration: `npm run build:worker` passed.
- Integration: `npm run check:generated-worker` passed.
- Hygiene: `git diff --check` passed.
- Full worker verification: `npm run verify:worker` partial/fail due unrelated local env expectations:
  - `gateway bearer vault bootstrap preserves existing manifest sections`
  - `gateway bearer vault bootstrap requires an explicit token source`
  - `VPS runner event records missing runtime dashboard delivery configuration`
  - `VPS runner role App token resolution fails closed when role credentials are missing`
- E2E: Not run before merge. Production PWA E2E required after deploy.
- Evidence path/link: `docs/development-strategy/issue-590-progress-lane-stability.md`

## Butler Completion Contract

- Primary owner surface: Dashboard Butler PWA.
- Fallback surface: mac Codex is debug/bootstrap only and not completion evidence.
- Owner goal: 長い turn 中に low-information status と readable checkpoint が混線せず、chat checkpoint が一瞬消えない。
- Butler entrypoint: Existing Dashboard Butler natural-language chat.
- Dashboard Butler natural-language path: Dashboard Butler の自然文/通常チャット入口で owner が長めの依頼を送り、app-server bridge transient status と readable progress checkpoint が同じ thread に表示される経路。
- Action Schema exposure: Not changed; existing Dashboard chat runtime path.
- Runtime path: DashboardChatRoom WebSocket -> transient_status / transientProgressSnapshot -> Dashboard PWA inline renderer.
- Runner/runtime truth: local Worker tests and generated worker check; production runtime truth pending.
- Authority boundary: No deploy, credential, permission, destructive work. Merge requires GO/automation gate; deploy requires scoped passkey approval.
- E2E evidence: Missing until production PWA deploy verification.
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: Required after merge by existing deploy flow; not performed by this PR.
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: merge/deploy 後に必要。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate
- AGENTS.md 開発前作戦図 Gate
- AGENTS.md Evidence Discipline
- AGENTS.md Conversation UX Contract
- AGENTS.md Change Size and PR Discipline

## Out-of-scope but NOT implemented

- #637 VPS privileged maintenance.
- #793 deploy notification driven stale-client refresh.
- #654 reconnect-resend correction.
- media reference repo mismatch.
- reply target preview filtering.
- Issue closure.

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #590
- Execution ID: issue-590-progress-lane-stability
- Goal: Keep Dashboard chat checkpoint stable when low-information transient status updates composer progress
