### PR TITLE
Issue #590 composer progress containment

### DIFF
--- a/docs/development-strategy/issue-590-composer-progress-containment.md
+++ b/docs/development-strategy/issue-590-composer-progress-containment.md
@@ -1,0 +1,66 @@
+# Issue #590 composer progress containment 作戦図
+
+## 完了体験
+
+iPhone の Dashboard Butler PWA で、入力欄下の `進行中` は短い status として見える。`app_server_reply_delta` 由来の readable progress が長文でも、composer 下は最大 2 行程度に収まり、画面の大半を占有しない。長い readable progress は chat checkpoint 側で読めるため、owner は待ち状態を把握しつつ入力欄を失わない。
+
+## VTDD 全体で進める部分
+
+Issue #590 の owner-facing observability のうち、PR #795 deploy 後に残った iPhone composer-progress visual containment を直す。Issue #637、Issue #654、Issue #793、stop / interrupt / owner input queue はこの slice では扱わない。
+
+## 設計
+
+composer 下の transient status は残す。ただし transient text は compact display text に変換し、DOM へ入る `progress-text` は長文をそのまま表示しない。CSS でも 2 行 clamp をかけ、iPhone viewport で高さが膨らまないようにする。raw snapshot / progressSummary は保持し、chat checkpoint 側は readable text を維持する。
+
+## 仮説
+
+suspected cause は、`.composer-progress .progress-text` が `max-height: min(9lh, 24dvh)` かつ `overflow: auto` で、`updateTransientProgress()` が `app_server_reply_delta` の readable long text をそのまま `transientProgressState.text` に入れること。短い stage text の時は良いが、reply delta の長文時だけ iPhone 画面を占有する。
+
+## 検証計画
+
+- HTML/source regression: composer progress text が 2 行 clamp される CSS を含むこと。
+- JS/source regression: `compactComposerProgressText()` が存在し、`updateTransientProgress()` が composer 表示用 text に使うこと。
+- Runtime regression: reply delta snapshot/progressSummary は保持される既存 tests を壊さないこと。
+- Local: `node --test test/worker.test.js --test-name-pattern 'dashboard|DashboardChatRoom|composer'`
+- Generated: `npm run build:worker`, `npm run check:generated-worker`
+- Hygiene: `git diff --check`
+
+## 改修見積もり
+
+- `src/worker/runtime.js`: `.composer-progress .progress-text` CSS を 2 行 clamp に変更し、`compactComposerProgressText()` を追加して composer 表示だけを短縮する。risk は status が短すぎて情報量が落ちること。
+- `test/worker.test.js`: served dashboard source assertion を追加する。risk は source assertion が過度に brittle になること。
+- `worker.js`: generated worker を同期する。
+
+## 既に通っている経路
+
+PR #795 で low-information status が readable checkpoint を消さないようになった。Dashboard UI には composer 下 transient progress と chat-visible checkpoint の両方がある。短い `考えています。` / `コマンドを実行しています。` の時は owner screenshot で良い見た目が確認されている。
+
+## 未確認の境界
+
+production PWA で long readable delta と media attach / app switch / reconnect が同時に起きる時の高さは merge/deploy 後に owner E2E が必要。CSS clamp は主要ブラウザで有効だが、iOS Safari/PWA の実表示は live evidence が必要。
+
+## 穴が出そうな箇所
+
+composer 下の text を短縮しすぎると、owner が現在状態を読めない。chat checkpoint 側に readable progress が出ない turn では情報量が落ちる可能性があるため、fallback checkpoint の E2E は別途残る。
+
+## PR 前に確認すること
+
+Issue #590 が open / Now であること、PR #795 deploy が success であること、open PR が無いこと、main が origin/main と一致すること、untracked `.tmp/` / `test-results/` を巻き込まないこと。
+
+## 実装候補と捨てた案
+
+採用: composer 表示だけを compact 化し、snapshot/checkpoint はそのまま維持する。
+
+捨てた案: composer 下の `進行中` を廃止する。owner 方針では現状維持が原則。捨てた案: reply delta を composer へ一切出さない。短い readable progress も消えてしまう。捨てた案: scroll container を大きくして逃がす。iPhone で画面占有が残る。
+
+## merge 後に通す E2E
+
+production PWA E2E として、長い readable progress が出る turn で入力欄下の `進行中` が 2 行程度に収まり、chat checkpoint 側の readable progress が維持されることを iPhone/PWA screenshot で確認する。短い `考えています。` / `コマンドを実行しています。` の見た目が悪化しないことも確認する。
+
+## 次の PR を増やさない理由
+
+この PR は #590 の composer visual containment だけを閉じる。chat checkpoint 生成不足、owner input queue、stop/interrupt、deploy notification refresh は既に別の残 scope として残っており、この変更が新しい follow-up PR を作るものではない。
+
+## 停止条件
+
+composer 表示の短縮が chat checkpoint / progressSummary を壊す、低情報 status が durable chat に戻る、generated worker check が一致しない、または deploy / credential / permission / destructive work が必要になった場合は停止する。

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -16234,7 +16234,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
     .composer-progress[hidden] { display: none; }
     .composer-progress .progress-title { display: inline-flex; align-items: center; gap: 7px; color: var(--muted); font-size: 12px; font-weight: 850; }
     .composer-progress .progress-title::before { content: ""; width: 7px; height: 7px; border-radius: 999px; background: var(--link); box-shadow: 0 0 0 4px rgba(11, 107, 101, .12); }
-    .composer-progress .progress-text { margin: 0; max-height: min(9lh, 24dvh); overflow: auto; color: var(--muted); white-space: pre-wrap; overflow-wrap: anywhere; word-break: break-word; }
+    .composer-progress .progress-text { display: -webkit-box; margin: 0; max-height: 3lh; overflow: hidden; -webkit-box-orient: vertical; -webkit-line-clamp: 2; color: var(--muted); white-space: normal; overflow-wrap: anywhere; word-break: break-word; }
     .composer-progress.thinking .progress-title::before { animation: pulseProgress 1.25s ease-in-out infinite; }
     .media-chip { position: relative; display: inline-flex; align-items: center; justify-content: center; width: 76px; height: 76px; min-width: 76px; border: 1px solid var(--border); border-radius: 8px; padding: 0; color: var(--text); background: var(--soft); font: inherit; font-size: 12px; text-decoration: none; overflow: hidden; cursor: pointer; }
     .media-chip:focus-visible { outline: 2px solid var(--text); outline-offset: 2px; }
@@ -16753,6 +16753,12 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         updateComposerReserve();
       }
 
+      function compactComposerProgressText(text) {
+        const normalized = String(text || "").replace(new RegExp("\\\\s+", "g"), " ").trim();
+        if (normalized.length <= 96) return normalized;
+        return normalized.slice(0, 93).trimEnd() + "...";
+      }
+
       function updateTransientProgress(text, options = {}) {
         const normalized = String(text || "").trim();
         if (!normalized || !isLongRunningTransientStatus(options.status)) {
@@ -16760,7 +16766,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         }
         transientProgressState = {
           title: options.title || "進行中",
-          text: normalized,
+          text: compactComposerProgressText(normalized),
           status: String(options.status || ""),
           thinking: options.thinking === true,
           snapshot: options.snapshot || null

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -1265,8 +1265,14 @@ test("worker serves v2 dashboard for allowed owner identity without exposing sec
   assert.equal(body.includes(".composer-status:empty"), true);
   assert.equal(body.includes(".transient-progress-card"), false);
   assert.equal(body.includes(".composer-progress"), true);
+  assert.equal(body.includes(".composer-progress .progress-text { display: -webkit-box;"), true);
+  assert.equal(body.includes("-webkit-line-clamp: 2"), true);
+  assert.equal(body.includes("max-height: 3lh"), true);
   assert.equal(body.includes('id="butler-transient-progress"'), true);
   assert.equal(body.includes("data-transient-progress"), true);
+  assert.equal(body.includes("function compactComposerProgressText(text)"), true);
+  assert.equal(body.includes('new RegExp("\\\\s+", "g")'), true);
+  assert.equal(body.includes("compactComposerProgressText(normalized)"), true);
   assert.equal(body.includes("function updateTransientProgress(text, options = {})"), true);
   assert.equal(body.includes("function clearTransientProgress()"), true);
   assert.equal(body.includes("function renderTransientProgress()"), true);

--- a/worker.js
+++ b/worker.js
@@ -72358,7 +72358,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
     .composer-progress[hidden] { display: none; }
     .composer-progress .progress-title { display: inline-flex; align-items: center; gap: 7px; color: var(--muted); font-size: 12px; font-weight: 850; }
     .composer-progress .progress-title::before { content: ""; width: 7px; height: 7px; border-radius: 999px; background: var(--link); box-shadow: 0 0 0 4px rgba(11, 107, 101, .12); }
-    .composer-progress .progress-text { margin: 0; max-height: min(9lh, 24dvh); overflow: auto; color: var(--muted); white-space: pre-wrap; overflow-wrap: anywhere; word-break: break-word; }
+    .composer-progress .progress-text { display: -webkit-box; margin: 0; max-height: 3lh; overflow: hidden; -webkit-box-orient: vertical; -webkit-line-clamp: 2; color: var(--muted); white-space: normal; overflow-wrap: anywhere; word-break: break-word; }
     .composer-progress.thinking .progress-title::before { animation: pulseProgress 1.25s ease-in-out infinite; }
     .media-chip { position: relative; display: inline-flex; align-items: center; justify-content: center; width: 76px; height: 76px; min-width: 76px; border: 1px solid var(--border); border-radius: 8px; padding: 0; color: var(--text); background: var(--soft); font: inherit; font-size: 12px; text-decoration: none; overflow: hidden; cursor: pointer; }
     .media-chip:focus-visible { outline: 2px solid var(--text); outline-offset: 2px; }
@@ -72877,6 +72877,12 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         updateComposerReserve();
       }
 
+      function compactComposerProgressText(text) {
+        const normalized = String(text || "").replace(new RegExp("\\\\s+", "g"), " ").trim();
+        if (normalized.length <= 96) return normalized;
+        return normalized.slice(0, 93).trimEnd() + "...";
+      }
+
       function updateTransientProgress(text, options = {}) {
         const normalized = String(text || "").trim();
         if (!normalized || !isLongRunningTransientStatus(options.status)) {
@@ -72884,7 +72890,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         }
         transientProgressState = {
           title: options.title || "\u9032\u884C\u4E2D",
-          text: normalized,
+          text: compactComposerProgressText(normalized),
           status: String(options.status || ""),
           thinking: options.thinking === true,
           snapshot: options.snapshot || null


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #590 の iPhone PWA evidence で確認した、入力欄下の `進行中` が長文で画面を占有する問題を最小修正します。
- composer 下の transient progress は残しつつ、表示 text を compact 化し、CSS でも 2 行 clamp します。
- snapshot / progressSummary / chat-visible checkpoint は維持し、長い readable progress は chat checkpoint 側で読める状態を保ちます。

## Satisfied Success Criteria

- `.composer-progress .progress-text` を 2 行 clamp / hidden overflow に変更した。
- `compactComposerProgressText()` を追加し、composer 下表示だけ 96 文字以内へ短縮した。
- `updateTransientProgress()` は snapshot/checkpoint の元データを壊さず、composer 表示 text だけを compact 化する。
- Dashboard HTML/source assertion に composer progress containment の確認を追加した。

## Unsatisfied Success Criteria

- production PWA で iPhone 実機表示が 2 行程度に収まることは merge/deploy 後 E2E が必要です。
- Issue #590 全体はまだ close-ready ではありません。

## Non-goal violations

None.

## 開発前作戦図

- 作戦図 evidence: docs/development-strategy/issue-590-composer-progress-containment.md
- 完了体験: Dashboard Butler PWA の iPhone 通常チャットで、入力欄下の `進行中` は短い status として見え、長文 readable progress で画面の大半を占有しない。
- VTDD 全体で進める部分: Issue #590 の owner-facing observability のうち、composer-progress visual containment だけを進める。
- 設計: owner-facing surface は Dashboard Butler PWA の通常チャットで、scope は composer 下 transient progress の表示 containment に限定する。composer 表示だけ compact 化し、chat checkpoint / snapshot / progressSummary は維持する。
- 仮説: suspected cause は、`.composer-progress .progress-text` が `max-height: min(9lh, 24dvh)` で、`updateTransientProgress()` が reply delta の長文をそのまま DOM へ入れていたこと。
- 検証計画: Worker HTML/source regression、DashboardChatRoom targeted tests、generated worker check、diff check で検証する。
- 改修見積もり: `src/worker/runtime.js` の CSS と `compactComposerProgressText()`、`test/worker.test.js` の source assertion、generated `worker.js`。
- 既に通っている経路: PR #795 で low-information status が readable checkpoint を消さないようになり、短い status の見た目は owner screenshot で良好だった。
- 未確認の境界: iOS Safari/PWA の live viewport で clamp と composer reserve が期待通りになるかは production E2E が必要。
- 穴が出そうな箇所: composer text を短縮しすぎると状態が読みにくい。chat checkpoint が出ない turn では情報量が落ちる可能性が残る。
- PR 前に確認すること: Issue #590 open/Now、PR #795 deploy success、open PR 無し、main/origin truth、targeted tests、generated worker check、diff check。
- 実装候補と捨てた案: 採用は composer 表示だけ compact 化する案。捨てた案は `進行中` 廃止、reply delta を composer へ一切出さない案、scroll container を大きくする案。
- merge 後に通す E2E: production PWA E2E として、長い readable progress が出る turn で入力欄下の `進行中` が 2 行程度に収まり、chat checkpoint 側の readable progress が維持されることを確認する。
- 次の PR を増やさない理由: この PR は #590 の composer visual containment だけを閉じる。chat checkpoint 生成不足、owner input queue、stop/interrupt は既存の残 scope であり、この PR が新しい follow-up PR を作るものではない。
- 停止条件: composer 表示の短縮が checkpoint / progressSummary を壊す、低情報 status が durable chat に戻る、generated worker check が一致しない、または deploy / credential / permission / destructive work が必要になる場合。

## Dry-run Impact Report

- Target Issue: Issue #590
- Implementing Success Criteria: iPhone で入力欄下の `進行中` が長文 progress により画面を占有しない。
- Explicit Non-goals: Issue #637 VPS privileged maintenance、Issue #654 reconnect-resend、Issue #793 deploy notification refresh、stop / interrupt / owner input queue、production deploy、Issue close。
- Expected touched files/routes/workflows: `src/worker/runtime.js`, `test/worker.test.js`, `worker.js`, `docs/development-strategy/issue-590-composer-progress-containment.md`。
- Affected Issues: #590.
- Affected PRs: follow-up after PR #795.
- Affected workflows: Worker generated build only。GitHub Actions workflow definition は変更しない。
- Affected runtime/operator surfaces: Dashboard Butler PWA chat composer transient progress.
- What may break if we patch narrowly: composer 下の progress text が短くなりすぎ、chat checkpoint が出ない turn では状態説明が薄く見える可能性。
- Unknowns to investigate before coding: iOS PWA live viewport で line clamp と composer reserve が実際にどう見えるか。
- Validation needed: targeted Worker tests, generated worker check, production PWA E2E after deploy.
- Stop condition: snapshot/checkpoint を壊す、または deploy/credential/permission/destructive work が必要になる場合。

## Execution Queue Delta

- Queue position before: Issue #590 remains `Now`.
- Preemption decision: EVIDENCE. Owner screenshot evidence is a #590 production UI blocker update and does not preempt to #637 or #793.
- Queue delta: Issue #590 stays in `Now`; this PR narrows composer-progress visual containment and leaves production PWA E2E as remaining evidence.
- Why this PR is next: PR #795 deploy 後の確認前に、owner screenshot で `進行中` の iPhone 画面占有差分が明確になり、通常チャット継続を邪魔するため。
- Active Issues not downscoped: Active Issues are not downscoped. #637, #654, #793 remain active and are not closed or reduced by this PR.

## File / Line Hypotheses

- file: `src/worker/runtime.js`
  - hypothesis: `.composer-progress .progress-text` allows up to 9 lines / 24dvh, and `updateTransientProgress()` sends long reply delta text directly to composer display.
  - risk if changed narrowly: composer status may become too compact if chat checkpoint is missing.
  - validation: source assertion and existing DashboardChatRoom tests.
  - related Issue: #590

- file: `test/worker.test.js`
  - hypothesis: source assertions can guard the iPhone containment contract without needing browser E2E before PR.
  - risk if changed narrowly: source assertion cannot prove iOS live rendering.
  - validation: production PWA E2E after deploy.
  - related Issue: #590

## Hypothesis Retrospective

- expected: composer progress becomes compact while snapshot/checkpoint behavior remains intact.
- actual: targeted Worker tests passed; generated worker check passed.
- mismatch: production PWA E2E is still required for iPhone rendering.
- lesson: composer transient status and chat checkpoint must not share the same visual weight or text length budget.
- should become RAG candidate: Yes, if production E2E confirms the containment fix.

## Verification Evidence

- Unit: `node --test test/worker.test.js --test-name-pattern 'dashboard|DashboardChatRoom|composer'` passed.
- Integration: `npm run build:worker` passed.
- Integration: `npm run check:generated-worker` passed.
- Hygiene: `git diff --check` passed.
- E2E: Not run before merge. Production PWA E2E required after deploy.
- Evidence path/link: docs/development-strategy/issue-590-composer-progress-containment.md

## Butler Completion Contract

- Primary owner surface: Dashboard Butler PWA.
- Fallback surface: mac Codex is debug/bootstrap only and not completion evidence.
- Owner goal: iPhone で `進行中` が入力欄周辺を大きく占有せず、通常チャットを続けられる。
- Butler entrypoint: Existing Dashboard Butler natural-language chat.
- Dashboard Butler natural-language path: Dashboard Butler の自然文/通常チャット入口で owner が長めの依頼を送り、composer 下 transient status と chat checkpoint が同じ thread に表示される経路。
- Action Schema exposure: Not changed; existing Dashboard chat runtime path.
- Runtime path: DashboardChatRoom WebSocket -> transient_status / transientProgressSnapshot -> Dashboard PWA inline renderer.
- Runner/runtime truth: local Worker tests and generated worker check; production runtime truth pending.
- Authority boundary: No deploy, credential, permission, destructive work. Merge requires GO/automation gate; deploy requires scoped passkey approval.
- E2E evidence: Missing until production PWA deploy verification.
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: Required after merge by existing deploy flow; not performed by this PR.
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: merge/deploy 後に必要。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate
- AGENTS.md 開発前作戦図 Gate
- AGENTS.md Evidence Discipline
- AGENTS.md Conversation UX Contract
- AGENTS.md Change Size and PR Discipline

## Out-of-scope but NOT implemented

- #637 VPS privileged maintenance.
- #654 reconnect-resend correction.
- #793 deploy notification driven stale-client refresh.
- stop / interrupt / owner input queue.
- Issue closure.

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #590
- Execution ID: issue-590-composer-progress-containment
- Goal: Keep Dashboard composer progress compact on iPhone while preserving chat-visible progress checkpoint
