### PR TITLE
Issue #590 pace live progress rendering

### DIFF
--- a/docs/development-strategy/issue-590-paced-progress-rendering.md
+++ b/docs/development-strategy/issue-590-paced-progress-rendering.md
@@ -1,0 +1,63 @@
+# Issue #590 paced progress rendering 作戦図
+
+## 完了体験
+
+Dashboard Butler PWA で live progress checkpoint が出る時、文字が一瞬で入れ替わらず、ChatGPT / Codex アプリや話し言葉に近い速度で読める。内部処理は速いまま受け取り、owner に見せる文字だけを paced rendering にする。
+
+## VTDD 全体で進める部分
+
+Issue #590 の owner-facing observability のうち、live progress が「出るようになったが速すぎて読めない」UX blocker を小さく直す。Issue #637 の privileged maintenance 実行はこの slice では扱わない。
+
+## 設計
+
+chat-visible progress checkpoint の paragraph へ直接 `textContent` を即時置換しない。最新 text を pending として保持し、短い間隔で文字を追加する。新しい checkpoint が来ても、直前 checkpoint の最低表示時間を満たすまで次の text へ切り替えない。処理本体や WebSocket 受信、snapshot 保存は遅らせない。
+
+## 仮説
+
+原因は `renderThreadProgressCheckpoint()` が `paragraph.textContent = text` で checkpoint を即時置換しており、app-server delta が短時間に複数来ると owner の目が追いつかないこと。checkpoint 表示だけに pacing queue を入れれば、内部実行速度を落とさず読みやすさを改善できる。
+
+## 検証計画
+
+- Source/unit: Dashboard HTML に paced checkpoint rendering の timer、minimum display interval、reduced motion bypass が含まれること。
+- Regression: 既存 dashboard / progress / composer tests を壊さないこと。
+- Local: `node --test test/worker.test.js --test-name-pattern 'dashboard|DashboardChatRoom|progress|composer'`
+- Generated: `npm run build:worker`, `npm run check:generated-worker`
+- Hygiene: `git diff --check`
+
+## 改修見積もり
+
+- `src/worker/runtime.js`: `schedulePacedProgressCheckpointText()` 系を追加し、`renderThreadProgressCheckpoint()` が即時 `textContent` 置換をしないようにする。risk は E2E が text 即時反映を期待している場合の不安定化。
+- `test/worker.test.js`: served dashboard source assertion を追加する。risk は source assertion が brittle になること。
+- `worker.js`: generated worker を同期する。
+
+## 既に通っている経路
+
+PR #795/#796/#797 で low-information status の checkpoint 消失、composer progress の画面占有、local E2E evidence が改善した。owner は強制キャッシュリロード済みで、次の UX blocker として「出るが速すぎる」を報告した。
+
+## 未確認の境界
+
+iOS Safari / production PWA の実速度は merge/deploy 後に owner evidence が必要。今回の slice は text pacing の初期実装であり、将来の TTS 同期や voice cadence は未実装。
+
+## 穴が出そうな箇所
+
+最終回答本文の token streaming と progress checkpoint は別物。今回 progress checkpoint だけを paced にしても、最終回答の表示速度が別経路なら追加 slice が必要になる可能性がある。
+
+## PR 前に確認すること
+
+Issue #590 が open、main が `origin/main` と一致、untracked `.tmp/` / `test-results/` を含めない、worker generated file を同期する。
+
+## 実装候補と捨てた案
+
+採用: progress checkpoint の表示だけを paced queue にする。捨てた案: app-server の出力自体を遅らせる。処理完了や runtime truth を遅くするため不採用。捨てた案: CSS animation だけで隠す。実際の読める速度を制御できない。
+
+## merge 後に通す E2E
+
+production PWA で長め turn を観測し、progress checkpoint が一瞬で入れ替わらず、owner が読める速度で出ることを確認する。音声運用に向けて、話速と表示速度の差も owner feedback として残す。
+
+## 次の PR を増やさない理由
+
+この PR は checkpoint pacing の最小実装で閉じる。TTS、voice cadence 設定、最終回答全文の streaming pacing は別 UX surface なので混ぜない。
+
+## 停止条件
+
+checkpoint が表示されなくなる、final summary replacement が壊れる、scroll guard が壊れる、または app-server 実処理を遅らせる必要が出た場合は停止する。

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -16475,6 +16475,13 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
       let transientProgressState = null;
       let threadProgressCheckpointCard = null;
       let transientProgressSnapshotState = null;
+      let pacedProgressCheckpointTimer = null;
+      let pacedProgressCheckpointState = {
+        activeText: "",
+        pendingText: "",
+        renderedLength: 0,
+        activeSince: 0
+      };
       let latestOwnerReplySource = null;
       let lastMediaLightboxTrigger = null;
       let pendingOwnerSend = null;
@@ -16808,6 +16815,86 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         return Boolean(latestProgressCheckpointText(snapshot));
       }
 
+      function shouldBypassPacedProgressRendering() {
+        try {
+          return window.matchMedia && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+        } catch {
+          return false;
+        }
+      }
+
+      function progressCheckpointStepSize(text) {
+        const length = String(text || "").length;
+        if (length <= 24) return 3;
+        if (length <= 80) return 4;
+        return 6;
+      }
+
+      function progressCheckpointFrameDelay(text) {
+        const length = String(text || "").length;
+        if (length <= 24) return 95;
+        if (length <= 80) return 70;
+        return 55;
+      }
+
+      function schedulePacedProgressCheckpointText(paragraph, nextText) {
+        const normalized = String(nextText || "").trim();
+        if (!paragraph || !normalized) return;
+        if (shouldBypassPacedProgressRendering()) {
+          if (pacedProgressCheckpointTimer) {
+            window.clearTimeout(pacedProgressCheckpointTimer);
+            pacedProgressCheckpointTimer = null;
+          }
+          pacedProgressCheckpointState = {
+            activeText: normalized,
+            pendingText: "",
+            renderedLength: normalized.length,
+            activeSince: Date.now()
+          };
+          paragraph.textContent = normalized;
+          return;
+        }
+        if (normalized === pacedProgressCheckpointState.activeText && pacedProgressCheckpointState.renderedLength >= normalized.length) {
+          return;
+        }
+        pacedProgressCheckpointState.pendingText = normalized;
+        if (!pacedProgressCheckpointTimer) {
+          pacedProgressCheckpointTimer = window.setTimeout(() => stepPacedProgressCheckpointText(paragraph), 0);
+        }
+      }
+
+      function stepPacedProgressCheckpointText(paragraph) {
+        pacedProgressCheckpointTimer = null;
+        if (!paragraph || !paragraph.isConnected) return;
+        const now = Date.now();
+        const minimumDisplayMs = 1800;
+        const pendingText = pacedProgressCheckpointState.pendingText;
+        const activeText = pacedProgressCheckpointState.activeText;
+        const activeComplete = activeText && pacedProgressCheckpointState.renderedLength >= activeText.length;
+        if (pendingText && pendingText !== activeText && (!activeComplete || now - pacedProgressCheckpointState.activeSince >= minimumDisplayMs)) {
+          pacedProgressCheckpointState = {
+            activeText: pendingText,
+            pendingText: "",
+            renderedLength: 0,
+            activeSince: now
+          };
+        }
+        const text = pacedProgressCheckpointState.activeText || pendingText;
+        if (!text) return;
+        const nextLength = Math.min(text.length, pacedProgressCheckpointState.renderedLength + progressCheckpointStepSize(text));
+        pacedProgressCheckpointState.renderedLength = nextLength;
+        paragraph.textContent = text.slice(0, nextLength);
+        if (
+          pacedProgressCheckpointState.renderedLength < text.length ||
+          (pacedProgressCheckpointState.pendingText && pacedProgressCheckpointState.pendingText !== text)
+        ) {
+          pacedProgressCheckpointTimer = window.setTimeout(
+            () => stepPacedProgressCheckpointText(paragraph),
+            progressCheckpointFrameDelay(text)
+          );
+        }
+      }
+
       function ensureThreadProgressCheckpointCard() {
         if (threadProgressCheckpointCard && threadProgressCheckpointCard.isConnected) {
           return threadProgressCheckpointCard;
@@ -16847,7 +16934,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         const card = ensureThreadProgressCheckpointCard();
         const paragraph = card.querySelector(".message-body p");
         if (paragraph) {
-          paragraph.textContent = text;
+          schedulePacedProgressCheckpointText(paragraph, text);
         }
         scrollToLatestIfFollowing(shouldFollow);
         return true;
@@ -16859,6 +16946,16 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           threadProgressCheckpointCard.remove();
           threadProgressCheckpointCard = null;
         }
+        if (pacedProgressCheckpointTimer) {
+          window.clearTimeout(pacedProgressCheckpointTimer);
+          pacedProgressCheckpointTimer = null;
+        }
+        pacedProgressCheckpointState = {
+          activeText: "",
+          pendingText: "",
+          renderedLength: 0,
+          activeSince: 0
+        };
         scrollToLatestIfFollowing(shouldFollow);
       }
 

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -1283,6 +1283,14 @@ test("worker serves v2 dashboard for allowed owner identity without exposing sec
   assert.equal(body.includes("data-thread-progress-checkpoint"), true);
   assert.equal(body.includes("function renderThreadProgressCheckpoint(snapshot, options = {})"), true);
   assert.equal(body.includes("function clearThreadProgressCheckpoint()"), true);
+  assert.equal(body.includes("let pacedProgressCheckpointTimer = null"), true);
+  assert.equal(body.includes("function schedulePacedProgressCheckpointText(paragraph, nextText)"), true);
+  assert.equal(body.includes("function stepPacedProgressCheckpointText(paragraph)"), true);
+  assert.equal(body.includes("const minimumDisplayMs = 1800"), true);
+  assert.equal(body.includes("progressCheckpointFrameDelay(text)"), true);
+  assert.equal(body.includes('window.matchMedia("(prefers-reduced-motion: reduce)")'), true);
+  assert.equal(body.includes("schedulePacedProgressCheckpointText(paragraph, text)"), true);
+  assert.equal(body.includes("paragraph.textContent = text;"), false);
   assert.equal(body.includes("latestProgressCheckpointText(transientProgressSnapshotState)"), true);
   assert.equal(body.includes("snapshot: body.transientProgressSnapshot || null"), true);
   assert.equal(body.includes("function isNearLatest()"), true);

--- a/worker.js
+++ b/worker.js
@@ -72599,6 +72599,13 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
       let transientProgressState = null;
       let threadProgressCheckpointCard = null;
       let transientProgressSnapshotState = null;
+      let pacedProgressCheckpointTimer = null;
+      let pacedProgressCheckpointState = {
+        activeText: "",
+        pendingText: "",
+        renderedLength: 0,
+        activeSince: 0
+      };
       let latestOwnerReplySource = null;
       let lastMediaLightboxTrigger = null;
       let pendingOwnerSend = null;
@@ -72932,6 +72939,86 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         return Boolean(latestProgressCheckpointText(snapshot));
       }
 
+      function shouldBypassPacedProgressRendering() {
+        try {
+          return window.matchMedia && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+        } catch {
+          return false;
+        }
+      }
+
+      function progressCheckpointStepSize(text) {
+        const length = String(text || "").length;
+        if (length <= 24) return 3;
+        if (length <= 80) return 4;
+        return 6;
+      }
+
+      function progressCheckpointFrameDelay(text) {
+        const length = String(text || "").length;
+        if (length <= 24) return 95;
+        if (length <= 80) return 70;
+        return 55;
+      }
+
+      function schedulePacedProgressCheckpointText(paragraph, nextText) {
+        const normalized = String(nextText || "").trim();
+        if (!paragraph || !normalized) return;
+        if (shouldBypassPacedProgressRendering()) {
+          if (pacedProgressCheckpointTimer) {
+            window.clearTimeout(pacedProgressCheckpointTimer);
+            pacedProgressCheckpointTimer = null;
+          }
+          pacedProgressCheckpointState = {
+            activeText: normalized,
+            pendingText: "",
+            renderedLength: normalized.length,
+            activeSince: Date.now()
+          };
+          paragraph.textContent = normalized;
+          return;
+        }
+        if (normalized === pacedProgressCheckpointState.activeText && pacedProgressCheckpointState.renderedLength >= normalized.length) {
+          return;
+        }
+        pacedProgressCheckpointState.pendingText = normalized;
+        if (!pacedProgressCheckpointTimer) {
+          pacedProgressCheckpointTimer = window.setTimeout(() => stepPacedProgressCheckpointText(paragraph), 0);
+        }
+      }
+
+      function stepPacedProgressCheckpointText(paragraph) {
+        pacedProgressCheckpointTimer = null;
+        if (!paragraph || !paragraph.isConnected) return;
+        const now = Date.now();
+        const minimumDisplayMs = 1800;
+        const pendingText = pacedProgressCheckpointState.pendingText;
+        const activeText = pacedProgressCheckpointState.activeText;
+        const activeComplete = activeText && pacedProgressCheckpointState.renderedLength >= activeText.length;
+        if (pendingText && pendingText !== activeText && (!activeComplete || now - pacedProgressCheckpointState.activeSince >= minimumDisplayMs)) {
+          pacedProgressCheckpointState = {
+            activeText: pendingText,
+            pendingText: "",
+            renderedLength: 0,
+            activeSince: now
+          };
+        }
+        const text = pacedProgressCheckpointState.activeText || pendingText;
+        if (!text) return;
+        const nextLength = Math.min(text.length, pacedProgressCheckpointState.renderedLength + progressCheckpointStepSize(text));
+        pacedProgressCheckpointState.renderedLength = nextLength;
+        paragraph.textContent = text.slice(0, nextLength);
+        if (
+          pacedProgressCheckpointState.renderedLength < text.length ||
+          (pacedProgressCheckpointState.pendingText && pacedProgressCheckpointState.pendingText !== text)
+        ) {
+          pacedProgressCheckpointTimer = window.setTimeout(
+            () => stepPacedProgressCheckpointText(paragraph),
+            progressCheckpointFrameDelay(text)
+          );
+        }
+      }
+
       function ensureThreadProgressCheckpointCard() {
         if (threadProgressCheckpointCard && threadProgressCheckpointCard.isConnected) {
           return threadProgressCheckpointCard;
@@ -72971,7 +73058,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         const card = ensureThreadProgressCheckpointCard();
         const paragraph = card.querySelector(".message-body p");
         if (paragraph) {
-          paragraph.textContent = text;
+          schedulePacedProgressCheckpointText(paragraph, text);
         }
         scrollToLatestIfFollowing(shouldFollow);
         return true;
@@ -72983,6 +73070,16 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           threadProgressCheckpointCard.remove();
           threadProgressCheckpointCard = null;
         }
+        if (pacedProgressCheckpointTimer) {
+          window.clearTimeout(pacedProgressCheckpointTimer);
+          pacedProgressCheckpointTimer = null;
+        }
+        pacedProgressCheckpointState = {
+          activeText: "",
+          pendingText: "",
+          renderedLength: 0,
+          activeSince: 0
+        };
         scrollToLatestIfFollowing(shouldFollow);
       }
 


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #590 の partial progress として、Dashboard Butler の chat-visible live progress checkpoint を即時置換せず、話し言葉に近い pace で段階表示する表示層を追加します。

## Satisfied Success Criteria

- live progress checkpoint paragraph は `paragraph.textContent = text` で即時置換せず、`schedulePacedProgressCheckpointText()` 経由で段階表示します。
- 新しい checkpoint が来ても、直前 checkpoint の最低表示時間 `1800ms` を満たすまで切り替えません。
- `prefers-reduced-motion: reduce` の owner には pacing を bypass して即時表示します。
- clear 時に pacing timer と state を破棄し、古い checkpoint timer が残らないようにします。

## Unsatisfied Success Criteria

- production PWA / iOS Safari 実機での読みやすい速度 evidence は merge/deploy 後に未実施です。
- TTS / voice cadence 同期、最終回答本文の streaming pacing、owner 設定 UI はこの PR では未実装です。
- Issue #590 全体の Butler Completion Gate は未完了です。

## Non-goal violations

None.

## 開発前作戦図

- 作戦図 evidence: docs/development-strategy/issue-590-paced-progress-rendering.md
- 完了体験: Dashboard Butler PWA で live progress checkpoint が一瞬で入れ替わらず、ChatGPT / Codex アプリや話し言葉に近い速度で読めます。
- VTDD 全体で進める部分: Issue #590 の owner-facing observability のうち、live progress が速すぎて読めない UX blocker を小さく直します。
- 設計: Dashboard Butler owner-facing surface の chat-visible progress checkpoint について、paragraph へ直接 `textContent` を即時置換せず、pending text と timer state で段階表示し、minimum display interval を持たせます。
- 仮説: 仮説は、`renderThreadProgressCheckpoint()` が `paragraph.textContent = text` で即時置換しており、app-server delta が短時間に複数来ると owner の目が追いつかない、というものです。
- 検証計画: focused worker tests、generated worker sync、Issue #590 Playwright E2E、`git diff --check` で検証します。
- 改修見積もり: `src/worker/runtime.js` の checkpoint rendering、`test/worker.test.js` の source assertion、`worker.js` generated bundle、作戦図を更新します。
- 既に通っている経路: PR #795/#796/#797 で low-information status の checkpoint 消失、composer progress の画面占有、local E2E evidence が改善済みです。
- 未確認の境界: production PWA / iOS Safari の実速度、TTS 同期、voice cadence 設定、最終回答本文の streaming pacing は未確認です。
- 穴が出そうな箇所: progress checkpoint と final answer streaming は別経路の可能性があり、最終回答が速すぎる場合は追加 slice が必要です。
- PR 前に確認すること: Issue #590 が open、main/origin/main 一致、untracked `.tmp/` / `test-results/` を含めない、worker generated file を同期します。
- 実装候補と捨てた案: 採用は progress checkpoint 表示だけを paced queue にする案。app-server 出力自体を遅らせる案と CSS animation だけの案は捨てました。
- merge 後に通す E2E: production PWA E2E / live test として長め turn を観測し、progress checkpoint が一瞬で入れ替わらず、owner が読める速度で出ることを確認します。
- 次の PR を増やさない理由: この PR は checkpoint pacing の最小実装で閉じます。TTS、voice cadence 設定、最終回答全文の streaming pacing は別 UX surface なので混ぜません。
- 停止条件: checkpoint が表示されなくなる、final summary replacement が壊れる、scroll guard が壊れる、または app-server 実処理を遅らせる必要が出た場合は停止します。

## Dry-run Impact Report

- Target Issue: Issue #590
- Implementing Success Criteria: Dashboard Butler live progress checkpoint の表示速度を owner が読める pace に近づけます。
- Explicit Non-goals: app-server 実処理の遅延、TTS、voice input/output、deploy 実行、Issue close は対象外です。
- Expected touched files/routes/workflows: `src/worker/runtime.js`; `test/worker.test.js`; `worker.js`; `docs/development-strategy/issue-590-paced-progress-rendering.md`
- Affected Issues: Issue #590。Issue #637 は再開待ち、Issue #450/#654/#793 は未変更です。
- Affected PRs: PR #795/#796/#797 の progress lane work に続く slice です。既存 PR は変更しません。
- Affected workflows: Worker bundle generated file を更新します。GitHub Actions workflow は未変更です。
- Affected runtime/operator surfaces: Dashboard Butler PWA `/dashboard` の live progress checkpoint rendering。operator / passkey / deploy surface は未変更です。
- What may break if we patch narrowly: final answer streaming が別経路なら、progress checkpoint だけ paced になり、最終回答の速度課題は残ります。
- Unknowns to investigate before coding: production PWA / iOS Safari での体感速度と reduced motion 挙動。
- Validation needed: focused worker tests、Issue #590 Playwright E2E、build/check generated worker、`git diff --check`。
- Stop condition: runtime truth 受信や app-server 実行を遅延させる必要が出たら停止します。

## Execution Queue Delta

- Queue position before: Issue #590 は current `Now` の owner-facing observability blocker です。
- Preemption decision: ROOT。owner input は #590 の completion UX blocker であり、Issue #637 の前に小さく処理します。
- Queue delta: Issue #590 の readable live progress UX を進めます。Issue #637 は `Next` として残し、active queue は縮小しません。
- Why this PR is next: owner が「出るようになったが入れ替わりが速すぎて目が追いつかない」と報告し、音声運用にも表示速度を合わせたいと明示したためです。
- Active Issues not downscoped: Active Issues は縮小しません。Issue #637、Issue #450/#654、Issue #793 などは未完了として残します。

## File / Line Hypotheses

- file: `src/worker/runtime.js`
  - hypothesis: `renderThreadProgressCheckpoint()` の即時 `textContent` 置換が、速すぎる progress 表示の主因です。
  - risk if changed narrowly: final answer streaming の速度課題は残る可能性があります。
  - validation: source assertion、focused worker tests、Issue #590 Playwright E2E。
  - related Issue: Issue #590

## Hypothesis Retrospective

- expected: checkpoint paragraph が schedule/timer 経由になり、minimum display interval と reduced motion bypass を持つ。
- actual: source assertion pass、focused worker tests pass、generated worker check pass、Issue #590 Playwright E2E pass。
- mismatch: production PWA 体感速度は未確認です。
- lesson: #590 の live progress は「出す」だけでなく、読める cadence が completion UX に必要です。
- should become RAG candidate: はい。Dashboard Butler progress cadence / voice-ready 表示速度判断として候補。

## Verification Evidence

- Unit: PASS: `node --test test/worker.test.js --test-name-pattern 'dashboard|DashboardChatRoom|progress|composer'`
- Integration: PASS: `npm run build:worker`; PASS: `npm run check:generated-worker`; PASS: `git diff --check`
- E2E: PASS: `npx playwright test scripts/e2e-issue590-dashboard-timeout-recovery.spec.mjs --browser=chromium --reporter=line`
- Manual: None.
- Evidence path/link: `docs/development-strategy/issue-590-paced-progress-rendering.md`

## Butler Completion Contract

- Primary owner surface: Dashboard Butler PWA。
- Fallback surface: mac Codex local tests は evidence generation surface であり fallback debug surface です。主経路ではありません。
- Owner goal: live progress を話し言葉に近い速度で読み、音声運用でも目が追いつく状態にする。
- Butler entrypoint: Dashboard Butler 通常チャット `/dashboard`。
- Dashboard Butler natural-language path: Dashboard Butler の通常チャット入口で owner が自然文を送り、runtime が live progress checkpoint を chat-visible に表示する経路です。
- Action Schema exposure: 未変更。Custom GPT Action Schema は fallback 表面であり、この PR の primary owner path ではありません。
- Runtime path: Worker `/dashboard` HTML/JS rendering path を変更し、generated `worker.js` を同期しました。
- Runner/runtime truth: tests と generated worker check により source/runtime bundle の pacing implementation を確認しました。
- Authority boundary: code/test/evidence only。deploy は merge 後に scoped passkey approval が必要です。
- E2E evidence: local Chromium E2E は実施済み。production PWA / iOS Safari E2E は未実施。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: merge 後に必要。deploy 実行は scoped passkey approval が必要です。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。deploy 後に owner-facing production PWA evidence が必要です。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate
- AGENTS.md 開発前作戦図 Gate
- AGENTS.md Evidence Discipline
- AGENTS.md Change Size and PR Discipline

## Out-of-scope but NOT implemented

- production deploy
- TTS / voice input/output
- final answer streaming pacing
- owner setting UI for speed
- Issue #590 close

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #590
- Execution ID: issue-590-paced-progress-rendering
- Goal: Dashboard Butler paced live progress rendering
