### PR TITLE
Issue #590 最終要約を読みやすく整形する

### DIFF
--- a/docs/development-strategy/issue-590-final-summary-formatting.md
+++ b/docs/development-strategy/issue-590-final-summary-formatting.md
@@ -1,0 +1,71 @@
+# Issue #590 最終要約整形 作戦図
+
+## 完了体験
+
+Owner が Dashboard Butler PWA / iPhone で長めの作業完了後に最終回答を見る時、本文が長文ベタ出しにならず、結論、変更契約、検証、境界、次の行動をすぐ識別できる。進行ログは補助情報として控えめに残り、最終まとめ本文より強く見えない。
+
+## VTDD 全体で進める部分
+
+Issue #590 の Now を継続する。今回の slice は production evidence で確認された completion summary replacement の可読性不足に限定し、#637 の VPS privileged maintenance 実装には戻らない。PR #799 の deploy / bridge restart 後に見えた UI blocker を、次の小さな #590 UI slice として扱う。
+
+## 設計
+
+Dashboard message renderer は通常の最終回答本文を `renderMessageText()` で段落化している。現状は Markdown 見出しでない短い節見出しや `対象:` / `検証:` のような契約行が通常段落に混ざるため、iPhone ではどこからが要約でどこからが契約か分かりにくい。
+
+今回は最終回答の HTML 生成時に、短い日本語/英語の節見出しとコロン区切りの契約行を軽量に検出し、`summary-section-title` / `summary-key-value` として表示する。Markdown パーサや LLM 出力内容は変えず、既存のリンク・コード・箇条書きレンダリング境界を壊さない。
+
+進行ログの visual weight は既存 Issue コメントに従い、強い panel 感を下げる。背景と border を弱め、本文より補助情報として見えるようにする。
+
+## 仮説
+
+対象ファイルは `src/worker/runtime.js` の Dashboard CSS と `renderMessageText()` 周辺、生成済み `worker.js`、および `test/worker.test.js`。最終要約が読みにくい主因は、message body 内で短い節見出しを段落と同じ扱いにしていることと、進行ログ block の装飾が強いことにある。
+
+狭く CSS だけを触ると、画像で見えている `変更契約` のような区切りが本文中に埋もれる問題は残る。逆に LLM 出力形式を強制すると Butler / app-server 側の自然会話を壊す。したがって renderer 側で既存テキストをセマンティックに少し整形するのが最小変更になる。
+
+## 検証計画
+
+- Unit: `node --test test/worker.test.js --test-name-pattern 'dashboard|DashboardChatRoom|progress|composer|summary'`
+- Build: `npm run build:worker`
+- Generated worker: `npm run check:generated-worker`
+- Diff hygiene: `git diff --check`
+- E2E: `npx playwright test scripts/e2e-issue590-dashboard-timeout-recovery.spec.mjs --browser=chromium --reporter=line`
+
+## 改修見積もり
+
+- `src/worker/runtime.js`: message body CSS に final summary section / key-value の表示ルールを追加する。リスクは通常チャット本文の過剰整形。
+- `src/worker/runtime.js`: `renderMessageText()` の行処理に短い節見出しと `key: value` 行の検出を追加する。リスクは URL や長文コロンを誤検出すること。
+- `src/worker/runtime.js`: `.progress-summary` の visual weight を下げる。リスクは進行ログが薄すぎて読めなくなること。
+- `worker.js`: worker bundle 更新。リスクは生成差分の取り込み漏れ。
+- `test/worker.test.js`: Dashboard shell と renderer 断片のテストを更新する。リスクは文字列検査が実装に寄りすぎること。
+
+## 既に通っている経路
+
+PR #799 で paced progress checkpoint rendering は merge / deploy 済み。Deploy workflow `27004369098` は merge SHA `27466105f5964cf733bbde7c6b79c275bf26f40a` で success。Owner は deploy と bridge restart 完了を報告済み。
+
+## 未確認の境界
+
+production PWA の最終回答が常に同じ文体とは限らない。今回の検出は短い節見出しと明確なコロン区切りに限定し、曖昧な本文を無理に再構造化しない。
+
+## 穴が出そうな箇所
+
+日本語本文中の自然なコロン、URL、Windows path、コード行を key-value と誤認すると読みにくくなる。検出は短い key と空白を含まない記号列に寄せ、既存 Markdown リンクや inline code の処理を優先する。
+
+## PR 前に確認すること
+
+branch が latest `origin/main` から作られていること。`.tmp/` と `test-results/` を commit しないこと。Issue #590 への evidence コメントは実装 PR とは別に事実として残すこと。
+
+## 実装候補と捨てた案
+
+採用候補は renderer 側の軽量 section / key-value 整形。捨てた案は、app-server 側 prompt で final answer の Markdown 化を強制する案と、進行ログだけ CSS で薄くする案。前者は出力生成に寄りすぎ、後者は `変更契約` が埋もれる本題を解決しない。
+
+## merge 後に通す E2E
+
+production deploy 後、owner が iPhone PWA で最終要約を確認し、結論・変更契約・検証・次の行動が視覚的に分かれることを確認する。進行ログは補助情報として強すぎないことも確認する。
+
+## 次の PR を増やさない理由
+
+今回の変更は同じ owner-facing completion summary replacement surface に閉じており、CSS と renderer の小さな協調が必要。docs-only と runtime を分けると evidence と実装の対応がかえって追いにくい。
+
+## 停止条件
+
+renderer 変更が通常チャット本文やコードブロックを壊す兆候が出た場合は停止する。Issue #590 以外の進行制御、deploy automation、#637 実行に踏み込む必要が出た場合も停止する。

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -16172,6 +16172,14 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
     .bubble p { color: var(--text); margin-bottom: 12px; }
     .bubble .message-body { display: grid; gap: 12px; min-width: 0; max-width: 100%; overflow: visible; }
     .bubble .message-body p { margin: 0; white-space: pre-wrap; overflow-wrap: anywhere; word-break: break-word; }
+    .bubble .message-body .summary-section-title { margin-top: 4px; color: var(--text); font-size: .9em; font-weight: 850; line-height: 1.45; }
+    .bubble .message-body .summary-key-value { display: grid; grid-template-columns: minmax(4.5em, max-content) minmax(0, 1fr); column-gap: 10px; row-gap: 2px; align-items: start; margin: 0; padding: 2px 0; line-height: 1.58; }
+    .bubble .message-body .summary-key { color: var(--muted); font-size: .88em; font-weight: 800; line-height: inherit; }
+    .bubble .message-body .summary-value { min-width: 0; color: var(--text); overflow-wrap: anywhere; word-break: break-word; }
+    @media (max-width: 520px) {
+      .bubble .message-body .summary-key-value { grid-template-columns: minmax(0, 1fr); row-gap: 0; }
+      .bubble .message-body .summary-key { font-size: .82em; }
+    }
     .bubble .message-body ul { margin: 0; }
     .bubble .message-body li + li { margin-top: 4px; }
     .bubble .message-body a, .bubble .message-body code { overflow-wrap: anywhere; word-break: break-word; }
@@ -16181,10 +16189,10 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
     .bubble .message-body pre code { display: block; max-width: 100%; white-space: pre-wrap; overflow-wrap: anywhere; word-break: break-word; font-size: 14px; line-height: 1.55; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace; }
     .bubble .message-body pre.wrap-code code { white-space: pre-wrap; overflow-wrap: anywhere; word-break: break-word; }
     .bubble .message-body strong { display: inline; color: inherit; font-size: inherit; letter-spacing: 0; text-transform: none; margin: 0; font-weight: 800; }
-    .progress-summary { margin-top: 12px; border: 1px solid var(--border); border-radius: 10px; padding: 10px 12px; background: var(--panel-strong); color: var(--muted); }
-    .progress-summary summary { cursor: pointer; font-weight: 800; color: var(--text); }
-    .progress-summary ol { margin: 10px 0 0; padding-left: 22px; }
-    .progress-summary li { margin-top: 6px; overflow-wrap: anywhere; word-break: break-word; }
+    .progress-summary { margin-top: 8px; border-top: 1px solid var(--border); padding-top: 8px; color: var(--muted); font-size: .88em; }
+    .progress-summary summary { cursor: pointer; font-weight: 700; color: var(--muted); }
+    .progress-summary ol { margin: 8px 0 0; padding-left: 20px; }
+    .progress-summary li { margin-top: 5px; overflow-wrap: anywhere; word-break: break-word; }
     .progress-checkpoint-entry { opacity: .92; }
     .progress-checkpoint-bubble { color: var(--muted); }
     .progress-checkpoint-bubble .bubble-header strong { color: var(--muted); }
@@ -17711,6 +17719,27 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         return source.length > 80 && !/\\s/.test(source);
       }
 
+      function isSummarySectionTitle(line) {
+        const source = String(line || "").trim();
+        if (!source || source.length > 28) return false;
+        if (/[。.!?！？:：]$/.test(source)) return false;
+        if (/^#{1,6}\\s+/.test(source)) return true;
+        return /^(変更契約|対象|成功条件|非ゴール|変更予定|検証|検証計画|境界|次|次の一手|状態|関連Issue\\/PR|未解決blocker|Evidence|Issue\\/PR|現状|Blocker|Next|Validation|Non-goals?)$/i.test(source);
+      }
+
+      function parseSummaryKeyValueLine(line) {
+        const source = String(line || "").trim();
+        if (!source || source.length > 220) return null;
+        if (/^https?:\\/\\//i.test(source) || /^go:/i.test(source)) return null;
+        const match = source.match(/^([A-Za-z0-9_#\\/\\-一-龠ぁ-んァ-ヶー・ ]{1,24})[:：]\\s+(.{1,180})$/);
+        if (!match) return null;
+        const key = match[1].trim();
+        const value = match[2].trim();
+        if (!key || !value || /^https?$/i.test(key)) return null;
+        if (/^https?:\\/\\//i.test(value)) return null;
+        return { key, value };
+      }
+
       function renderMessageText(container, text) {
         const source = String(text || "");
         const lines = source.replace(/\\r\\n/g, "\\n").split("\\n");
@@ -17765,13 +17794,39 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
             container.appendChild(list);
             continue;
           }
+          if (isSummarySectionTitle(lines[index])) {
+            const heading = document.createElement("p");
+            heading.className = "summary-section-title";
+            renderInlineMarkdown(heading, lines[index].replace(/^#{1,6}\\s+/, "").trim());
+            container.appendChild(heading);
+            index += 1;
+            continue;
+          }
+          const keyValue = parseSummaryKeyValueLine(lines[index]);
+          if (keyValue) {
+            const row = document.createElement("p");
+            row.className = "summary-key-value";
+            const key = document.createElement("span");
+            key.className = "summary-key";
+            key.textContent = keyValue.key;
+            const value = document.createElement("span");
+            value.className = "summary-value";
+            renderInlineMarkdown(value, keyValue.value);
+            row.appendChild(key);
+            row.appendChild(value);
+            container.appendChild(row);
+            index += 1;
+            continue;
+          }
           const paragraph = document.createElement("p");
           const paragraphLines = [];
           while (
             index < lines.length &&
             lines[index].trim() &&
             !lines[index].trim().startsWith(fence) &&
-            !/^\\s*-\\s+/.test(lines[index])
+            !/^\\s*-\\s+/.test(lines[index]) &&
+            !isSummarySectionTitle(lines[index]) &&
+            !parseSummaryKeyValueLine(lines[index])
           ) {
             paragraphLines.push(lines[index]);
             index += 1;

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -162,9 +162,15 @@ function createMinimalDashboardDocument() {
 
     querySelectorAll(tagName) {
       const matches = [];
-      const expected = String(tagName || "").toUpperCase();
+      const selector = String(tagName || "");
+      const expected = selector.toUpperCase();
+      const expectedClass = selector.startsWith(".") ? selector.slice(1) : "";
       const visit = (node) => {
-        if (node.nodeType === 1 && node.tagName === expected) {
+        const classNames = String(node.className || "").split(/\s+/).filter(Boolean);
+        if (
+          node.nodeType === 1 &&
+          ((expectedClass && classNames.includes(expectedClass)) || (!expectedClass && node.tagName === expected))
+        ) {
           matches.push(node);
         }
         for (const child of node.children || []) {
@@ -173,6 +179,10 @@ function createMinimalDashboardDocument() {
       };
       visit(this);
       return matches;
+    }
+
+    querySelector(selector) {
+      return this.querySelectorAll(selector)[0] || null;
     }
   }
 
@@ -195,6 +205,8 @@ function loadDashboardInlineChatHelpers(html) {
     "normalizeComposerInputText",
     "decodeSafeChatCommandText",
     "shouldWrapCodeBlock",
+    "isSummarySectionTitle",
+    "parseSummaryKeyValueLine",
     "renderMessageText",
     "renderInlineMarkdown",
     "splitTrailingLinkPunctuation",
@@ -1279,7 +1291,8 @@ test("worker serves v2 dashboard for allowed owner identity without exposing sec
   assert.equal(body.includes("function renderProgressSummaryDetails(progressSummary)"), true);
   assert.equal(body.includes("進行ログ"), true);
   assert.equal(body.includes(".progress-summary"), true);
-  assert.equal(body.includes("background: var(--panel-strong); color: var(--muted);"), true);
+  assert.equal(body.includes(".progress-summary { margin-top: 8px; border-top: 1px solid var(--border);"), true);
+  assert.equal(body.includes(".progress-summary summary { cursor: pointer; font-weight: 700; color: var(--muted); }"), true);
   assert.equal(body.includes("data-thread-progress-checkpoint"), true);
   assert.equal(body.includes("function renderThreadProgressCheckpoint(snapshot, options = {})"), true);
   assert.equal(body.includes("function clearThreadProgressCheckpoint()"), true);
@@ -1535,6 +1548,12 @@ test("worker serves v2 dashboard for allowed owner identity without exposing sec
   assert.equal(body.includes("decodeURIComponent(line)"), true);
   assert.equal(body.includes('if (/^https?:/i.test(line))'), true);
   assert.equal(body.includes("function shouldWrapCodeBlock("), true);
+  assert.equal(body.includes("function isSummarySectionTitle("), true);
+  assert.equal(body.includes("function parseSummaryKeyValueLine("), true);
+  assert.equal(body.includes(".summary-section-title"), true);
+  assert.equal(body.includes(".summary-key-value"), true);
+  assert.equal(body.includes(".summary-key"), true);
+  assert.equal(body.includes(".summary-value"), true);
   assert.equal(body.includes('if (/^https?:\\/\\//i.test(source)) return true;'), true);
   assert.equal(body.includes('if (/^go:%[0-9a-f]{2}/i.test(source)) return true;'), true);
   assert.equal(body.includes("return source.length > 80 && !/\\s/.test(source);"), true);
@@ -1859,6 +1878,20 @@ test("served dashboard inline chat renderer executes decode, link, wrap, and cop
   assert.equal(mixedParagraphs[0].textContent, "黒潰れ確認。");
   assert.equal(mixedCodeBlocks.length, 1);
   assert.equal(mixedCodeBlocks[0].className, "wrap-code");
+
+  const summaryContainer = document.createElement("div");
+  helpers.renderMessageText(
+    summaryContainer,
+    "では進めます。\n\n変更契約\n対象: Issue #590。\n非ゴール: deploy、#637 実行。\n検証: `npm run build:worker` と E2E。"
+  );
+  const sectionTitles = summaryContainer.querySelectorAll(".summary-section-title");
+  assert.equal(sectionTitles.length, 1);
+  assert.equal(sectionTitles[0].textContent, "変更契約");
+  const keyValues = summaryContainer.querySelectorAll(".summary-key-value");
+  assert.equal(keyValues.length, 3);
+  assert.equal(keyValues[0].querySelector(".summary-key").textContent, "対象");
+  assert.equal(keyValues[0].querySelector(".summary-value").textContent, "Issue #590。");
+  assert.equal(keyValues[2].querySelector("code").textContent, "npm run build:worker");
 
   const messageCopyButton = document.createElement("button");
   await helpers.copyMessageText(

--- a/worker.js
+++ b/worker.js
@@ -72296,6 +72296,14 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
     .bubble p { color: var(--text); margin-bottom: 12px; }
     .bubble .message-body { display: grid; gap: 12px; min-width: 0; max-width: 100%; overflow: visible; }
     .bubble .message-body p { margin: 0; white-space: pre-wrap; overflow-wrap: anywhere; word-break: break-word; }
+    .bubble .message-body .summary-section-title { margin-top: 4px; color: var(--text); font-size: .9em; font-weight: 850; line-height: 1.45; }
+    .bubble .message-body .summary-key-value { display: grid; grid-template-columns: minmax(4.5em, max-content) minmax(0, 1fr); column-gap: 10px; row-gap: 2px; align-items: start; margin: 0; padding: 2px 0; line-height: 1.58; }
+    .bubble .message-body .summary-key { color: var(--muted); font-size: .88em; font-weight: 800; line-height: inherit; }
+    .bubble .message-body .summary-value { min-width: 0; color: var(--text); overflow-wrap: anywhere; word-break: break-word; }
+    @media (max-width: 520px) {
+      .bubble .message-body .summary-key-value { grid-template-columns: minmax(0, 1fr); row-gap: 0; }
+      .bubble .message-body .summary-key { font-size: .82em; }
+    }
     .bubble .message-body ul { margin: 0; }
     .bubble .message-body li + li { margin-top: 4px; }
     .bubble .message-body a, .bubble .message-body code { overflow-wrap: anywhere; word-break: break-word; }
@@ -72305,10 +72313,10 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
     .bubble .message-body pre code { display: block; max-width: 100%; white-space: pre-wrap; overflow-wrap: anywhere; word-break: break-word; font-size: 14px; line-height: 1.55; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace; }
     .bubble .message-body pre.wrap-code code { white-space: pre-wrap; overflow-wrap: anywhere; word-break: break-word; }
     .bubble .message-body strong { display: inline; color: inherit; font-size: inherit; letter-spacing: 0; text-transform: none; margin: 0; font-weight: 800; }
-    .progress-summary { margin-top: 12px; border: 1px solid var(--border); border-radius: 10px; padding: 10px 12px; background: var(--panel-strong); color: var(--muted); }
-    .progress-summary summary { cursor: pointer; font-weight: 800; color: var(--text); }
-    .progress-summary ol { margin: 10px 0 0; padding-left: 22px; }
-    .progress-summary li { margin-top: 6px; overflow-wrap: anywhere; word-break: break-word; }
+    .progress-summary { margin-top: 8px; border-top: 1px solid var(--border); padding-top: 8px; color: var(--muted); font-size: .88em; }
+    .progress-summary summary { cursor: pointer; font-weight: 700; color: var(--muted); }
+    .progress-summary ol { margin: 8px 0 0; padding-left: 20px; }
+    .progress-summary li { margin-top: 5px; overflow-wrap: anywhere; word-break: break-word; }
     .progress-checkpoint-entry { opacity: .92; }
     .progress-checkpoint-bubble { color: var(--muted); }
     .progress-checkpoint-bubble .bubble-header strong { color: var(--muted); }
@@ -73835,6 +73843,27 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         return source.length > 80 && !/\\s/.test(source);
       }
 
+      function isSummarySectionTitle(line) {
+        const source = String(line || "").trim();
+        if (!source || source.length > 28) return false;
+        if (/[\u3002.!?\uFF01\uFF1F:\uFF1A]$/.test(source)) return false;
+        if (/^#{1,6}\\s+/.test(source)) return true;
+        return /^(\u5909\u66F4\u5951\u7D04|\u5BFE\u8C61|\u6210\u529F\u6761\u4EF6|\u975E\u30B4\u30FC\u30EB|\u5909\u66F4\u4E88\u5B9A|\u691C\u8A3C|\u691C\u8A3C\u8A08\u753B|\u5883\u754C|\u6B21|\u6B21\u306E\u4E00\u624B|\u72B6\u614B|\u95A2\u9023Issue\\/PR|\u672A\u89E3\u6C7Ablocker|Evidence|Issue\\/PR|\u73FE\u72B6|Blocker|Next|Validation|Non-goals?)$/i.test(source);
+      }
+
+      function parseSummaryKeyValueLine(line) {
+        const source = String(line || "").trim();
+        if (!source || source.length > 220) return null;
+        if (/^https?:\\/\\//i.test(source) || /^go:/i.test(source)) return null;
+        const match = source.match(/^([A-Za-z0-9_#\\/\\-\u4E00-\u9FA0\u3041-\u3093\u30A1-\u30F6\u30FC\u30FB ]{1,24})[:\uFF1A]\\s+(.{1,180})$/);
+        if (!match) return null;
+        const key = match[1].trim();
+        const value = match[2].trim();
+        if (!key || !value || /^https?$/i.test(key)) return null;
+        if (/^https?:\\/\\//i.test(value)) return null;
+        return { key, value };
+      }
+
       function renderMessageText(container, text) {
         const source = String(text || "");
         const lines = source.replace(/\\r\\n/g, "\\n").split("\\n");
@@ -73889,13 +73918,39 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
             container.appendChild(list);
             continue;
           }
+          if (isSummarySectionTitle(lines[index])) {
+            const heading = document.createElement("p");
+            heading.className = "summary-section-title";
+            renderInlineMarkdown(heading, lines[index].replace(/^#{1,6}\\s+/, "").trim());
+            container.appendChild(heading);
+            index += 1;
+            continue;
+          }
+          const keyValue = parseSummaryKeyValueLine(lines[index]);
+          if (keyValue) {
+            const row = document.createElement("p");
+            row.className = "summary-key-value";
+            const key = document.createElement("span");
+            key.className = "summary-key";
+            key.textContent = keyValue.key;
+            const value = document.createElement("span");
+            value.className = "summary-value";
+            renderInlineMarkdown(value, keyValue.value);
+            row.appendChild(key);
+            row.appendChild(value);
+            container.appendChild(row);
+            index += 1;
+            continue;
+          }
           const paragraph = document.createElement("p");
           const paragraphLines = [];
           while (
             index < lines.length &&
             lines[index].trim() &&
             !lines[index].trim().startsWith(fence) &&
-            !/^\\s*-\\s+/.test(lines[index])
+            !/^\\s*-\\s+/.test(lines[index]) &&
+            !isSummarySectionTitle(lines[index]) &&
+            !parseSummaryKeyValueLine(lines[index])
           ) {
             paragraphLines.push(lines[index]);
             index += 1;


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #590 の部分進捗です。PR #799 deploy 後の production PWA evidence で見えた「最後に出る要約部分が長文ベタ出しで読みづらい」問題に対し、Dashboard Butler の最終回答 renderer を iPhone で読める節構造に寄せます。
- 最終回答の内容そのものを LLM 側で強制せず、既存の通常本文を `変更契約` / `対象:` / `検証:` などの短い節見出し・key/value として表示できるようにします。
- 進行ログの visual weight を下げ、最終まとめ本文より目立たない補助情報として表示します。

## Satisfied Success Criteria

- 最終回答本文で `変更契約` などの短い節見出しを `.summary-section-title` として視覚的に区切ります。
- `対象: Issue #590。` / `検証: ...` のような短い契約行を `.summary-key-value` として key と value に分けます。
- URL から始まる値は key/value 化せず、既存リンク処理を維持します。
- `progress-summary` の強い panel / card 表現をやめ、薄い border-top と muted text に寄せました。

## Unsatisfied Success Criteria

- Issue #590 全体は未完了です。live progress stack が途中で消える問題、先頭欠け、production iPhone/PWA completion summary replacement の再確認は残ります。
- この PR は最終要約の可読性 slice であり、Butler Completion Gate 全体を満たしません。

## Non-goal violations

None.

## 開発前作戦図

- 作戦図 evidence: `docs/development-strategy/issue-590-final-summary-formatting.md`
- 完了体験: Owner が Dashboard Butler PWA / iPhone で長めの作業完了後に最終回答を見る時、結論、変更契約、検証、境界、次の行動を識別できる。
- VTDD 全体で進める部分: Issue #590 の Now を継続し、completion summary replacement の可読性不足だけを扱う。
- 設計: Dashboard Butler owner-facing surface の完了要約を、message renderer 側で短い節見出しとコロン区切りの契約行として軽量に検出し、既存のリンク・コード・箇条書き処理を壊さず整形する。
- 仮説: 読みにくさの主原因は `renderMessageText()` が短い節見出しと契約行を通常段落として扱い、進行ログの panel 感が強いことだと疑っている。
- 検証計画: focused worker test、worker build、generated worker check、diff hygiene、#590 Playwright E2E。
- 改修見積もり: `src/worker/runtime.js` CSS / renderer、`worker.js` generated bundle、`test/worker.test.js` renderer test。
- 既に通っている経路: PR #799 merge/deploy success、owner が deploy と bridge restart 完了を報告済み。
- 未確認の境界: production の最終回答文体は常に同じではないため、曖昧な本文は無理に再構造化しない。
- 穴が出そうな箇所: URL、コード、自然文中のコロンを key/value と誤検出すると通常チャットを壊す。
- PR 前に確認すること: latest `origin/main` から topic branch を作ること、`.tmp/` / `test-results/` を commit しないこと。
- 実装候補と捨てた案: renderer 側の軽量整形を採用。LLM prompt 強制と CSS だけの薄化は捨てた。
- merge 後に通す E2E: production deploy 後、iPhone PWA live E2E で最終要約と進行ログの見た目を検証する。
- 次の PR を増やさない理由: この PR 範囲は同じ completion summary surface の CSS と renderer に閉じ、予測できる不足を後続 PR に分離すると同じ画面の小変更 PR が増えるため。
- 停止条件: 通常チャット本文、コードブロック、リンク表示を壊す兆候が出たら停止する。

## Dry-run Impact Report

- Target Issue: Issue #590
- Implementing Success Criteria: completion summary replacement の最終要約が iPhone で読めるように、短い節見出し / key-value / 進行ログの表示を整える。
- Explicit Non-goals: app-server 実処理の遅延、TTS、音声入出力、deploy 実行、#637 実行、Issue #590 close。
- Expected touched files/routes/workflows: `src/worker/runtime.js`, `worker.js`, `test/worker.test.js`, `docs/development-strategy/issue-590-final-summary-formatting.md`
- Affected Issues: Issue #590。Issue #637 は Next のまま。
- Affected PRs: PR #799 の production evidence を受けた follow-up。既存 PR は更新しない。
- Affected workflows: local worker build / generated worker check / Playwright E2E。Deploy workflow はこの PR では実行しない。
- Affected runtime/operator surfaces: Dashboard Butler PWA の通常チャット message renderer。passkey operator surface は未変更。
- What may break if we patch narrowly: コロンを含む通常文や URL を誤って key/value 化すると読みにくくなる。
- Unknowns to investigate before coding: production final answer の全パターンは未確認。検出を短い明確な行に限定する。
- Validation needed: focused worker tests, build, generated-worker check, diff check, #590 Playwright E2E。
- Stop condition: 通常チャット本文や code/link rendering の回帰が出た場合。

## Execution Queue Delta

- Queue position before: Issue #590 が Now。PR #799 deploy 後も completion summary replacement の可読性が残 blocker。
- Preemption decision: ROOT。Issue #590 の owner-facing UX blocker 継続であり、#637 へ戻る前に小さく塞ぐ。
- Queue delta: Issue #590 の final summary formatting slice を進める。Issue #590 全体は incomplete のまま。
- Why this PR is next: owner が production PWA で deploy/bridge restart 後に確認した最新 blocker が、最終要約の整形不足だったため。
- Active Issues not downscoped: Active Issues は縮小しません。#637 / #450 / #654 / その他 active Issue は未完了として残します。

## File / Line Hypotheses

- file: `src/worker/runtime.js`
  - hypothesis: `renderMessageText()` が短い節見出しと契約行を通常段落にまとめているため、iPhone で最終要約が読みにくい。
  - risk if changed narrowly: URL や通常文中のコロンを誤検出すると通常チャットを壊す。
  - validation: inline renderer helper test で URL は通常リンクのまま、`変更契約` / `対象:` は構造化されることを確認する。
  - related Issue: Issue #590
- file: `src/worker/runtime.js`
  - hypothesis: `.progress-summary` の background / border / font weight が強く、最終本文より進行ログが目立つ。
  - risk if changed narrowly: 薄くしすぎると補助情報が読めない。
  - validation: HTML presence test と #590 E2E で表示 surface が壊れないことを確認する。
  - related Issue: Issue #590

## Hypothesis Retrospective

- expected: renderer 側の短い節見出し / key-value 検出で最終要約の区切りが読みやすくなり、URL とコード処理は維持される。
- actual: focused worker test で `次: https://...` が一度 key/value 誤検出され、URL value を key/value 対象外に狭めて解消した。
- mismatch: 初期仮説より URL 誤検出リスクが具体的だった。
- lesson: final summary auto-format は value 側 URL を明示的に除外する必要がある。
- should become RAG candidate: yes。Dashboard summary renderer の自動整形は URL / code / normal prose を優先して壊さない。

## Verification Evidence

- Unit: `node --test test/worker.test.js --test-name-pattern 'dashboard|DashboardChatRoom|progress|composer|summary'` -> 280 passed
- Integration: `npm run build:worker` -> pass; `npm run check:generated-worker` -> pass; `git diff --check` -> pass
- E2E: `npx playwright test scripts/e2e-issue590-dashboard-timeout-recovery.spec.mjs --browser=chromium --reporter=line` -> 2 passed
- Manual: 添付 `IMG_3258.jpeg` を production PWA evidence として確認し、Issue #590 にコメント済み。
- Evidence path/link: https://github.com/marushu/vtdd-v2-p/issues/590#issuecomment-4629652034

## Butler Completion Contract

- Primary owner surface: Dashboard Butler PWA。
- Fallback surface: mac Codex は今回の実装補助 surface。VTDD completion ではない。
- Owner goal: 最終要約が iPhone で読めるように整形されること。
- Butler entrypoint: Dashboard Butler 通常チャットの最終回答表示。
- Dashboard Butler natural-language path: Dashboard Butler 通常チャット入口で owner の自然文作業依頼を受け、完了後に同じ chat 経路で最終要約を表示する。新しい内部 API 入力は不要。
- Action Schema exposure: 変更なし。
- Runtime path: Worker-served Dashboard HTML / inline renderer。
- Runner/runtime truth: local tests / build / E2E evidence を参照。Production deploy は未実施。
- Authority boundary: deploy は passkey approval が必要。この PR では deploy しない。
- E2E evidence: local #590 Playwright E2E は pass。production iPhone/PWA E2E は merge/deploy 後に必要。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: merge 後に必要。passkey approval が必要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: merge/deploy 後に必要。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate
- AGENTS.md Chief Butler Operating Principle
- AGENTS.md Drift Stop Protocol
- AGENTS.md 開発前作戦図 Gate
- AGENTS.md Evidence Discipline
- docs/butler/execution-queue-contract.md

## Out-of-scope but NOT implemented

- live progress stack が一瞬消える問題の根本修正。
- live progress / reply delta の先頭欠け修正。
- TTS / 音声入力 / voice cadence 実装。
- #637 VPS privileged maintenance 実装。
- deploy / bridge restart 実行。

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #590
- Execution ID: dashboard-butler-issue-590-final-summary-formatting-2026-06-05
- Goal: Dashboard Butler PWA の最終要約を iPhone で読める形に整形する。
