### PR TITLE
Issue #637 VPS operator URL context を完備する

### DIFF
--- a/docs/development-strategy/issue-637-vps-operator-url-complete.md
+++ b/docs/development-strategy/issue-637-vps-operator-url-complete.md
@@ -1,0 +1,64 @@
+# Issue #637 VPS operator URL completeness strategy
+
+## 完了体験
+
+Owner が Dashboard Butler に「bridge を再起動して」「VPS runner を確認して」のように自然文で依頼した時、Butler は proposal 生成済みの passkey operator URL を返す。Owner は URL を開いて passkey 承認だけを行う。承認後は operator page が同じ Dashboard chat thread に戻り、`approvalGrantId` を owner にコピーさせず、VPS helper queue へ自動継続する。
+
+## VTDD 全体で進める部分
+
+Issue #637 の owner-facing approval path を進める。低リスク read/status は既に passkey なしで queue 通過 evidence がある。今回は restart など passkey が必要な flow で、operator URL が自動継続に必要な context を必ず持つことに絞る。
+
+## 設計
+
+Dashboard Butler natural-language flow は proposal 作成時に `dashboardThreadId` を渡しているが、owner 入力に `executionId` が無い場合は operator URL に `executionId` が入らない可能性がある。`executionId` は承認後の helper queue comment / runner event / Dashboard delivery を同じ作業として追跡するために必要なので、Dashboard natural-language flow 側で必ず生成する。
+
+approval-required reply では、owner action を「この URL で passkey 承認だけ」と明示し、`vpsProposalId` や `approvalGrantId` を owner に手入力させない境界を見える化する。
+
+## 仮説
+
+原因は `buildDashboardVpsPrivilegedMaintenanceNaturalLanguageFlow()` が `payload.executionId` をそのまま proposal 作成へ渡していること。自然文 chat では通常 `executionId` が無いため、URL completeness が caller 依存になる。ここを runtime 側で生成すれば、Butler は常に proposal-backed URL を出せる。
+
+## 検証計画
+
+- Unit: #637 Dashboard restart intent の test で operator URL に `mode=vps`、`vpsProposalId`、`dashboardThreadId`、`executionId` が揃うことを確認する。
+- Unit: approval-required reply が owner に passkey 承認だけを求め、manual copy を求めないことを確認する。
+- Integration: `npm run build:worker` と `npm run check:generated-worker`。
+- Hygiene: `git diff --check`。
+
+## 改修見積もり
+
+- `src/worker/runtime.js`: Dashboard VPS natural-language proposal path で fallback `executionId` を生成し、approval-required reply に owner action を追加する。
+- `test/worker.test.js`: #637 restart intent test の URL completeness / owner action assertion を追加する。
+- `worker.js`: generated worker bundle 更新。
+
+## 既に通っている経路
+
+Issue #637 は repo-less low-risk read/status helper queue の production E2E が通過済み。`vpsProposalId` と `dashboardThreadId` を持つ operator URL と auto-continue route の基本テストも存在する。
+
+## 未確認の境界
+
+production Dashboard chat で passkey 承認後に restart helper queue が実際に pickup / completion することは、この PR では実行しない。passkey approval と restart execution は merge/deploy 後の owner approval 境界で確認する。
+
+## 穴が出そうな箇所
+
+executionId を毎回不安定にすると retry / duplicate queue の追跡が難しくなる。既存 helper request と同じ `createDashboardRequestId()` を使い、operator URL と execution body に同じ値を通す。
+
+## PR 前に確認すること
+
+Issue #637、passkey auto-continue strategy、operator page source、Dashboard natural-language flow、既存 #637 tests、current `origin/main` を確認する。
+
+## 実装候補と捨てた案
+
+採用案は Dashboard natural-language flow 内で executionId を必ず生成する。捨てた案は owner に URL パラメータを追加入力させること、汎用 passkey URL を出すこと、operator page 側で proposal なしに補完すること。いずれも owner が passkey 承認だけで済む完成形に反する。
+
+## merge 後に通す E2E
+
+production Dashboard Butler で restart 系 intent を送り、proposal-backed operator URL を開いて passkey 承認する。期待値は同じ Dashboard thread への auto-continue、helper queue comment 作成、runner pickup / completion truth の返却。
+
+## 次の PR を増やさない理由
+
+この PR は URL completeness と owner action 文言の同一 approval surface に閉じる。restart 実行 evidence は authority boundary 上 merge/deploy 後にしか得られないため、この PR で予測できる実装不足を残さない。
+
+## 停止条件
+
+URL に proposal context が揃わない、approvalGrantId copy/manual flow が必要になる、または Worker から root/helper execution を直接始める必要が出た場合は停止する。

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -12185,11 +12185,15 @@ async function buildDashboardVpsPrivilegedMaintenanceNaturalLanguageFlow({
         }
       };
     }
+    const dashboardThreadId = normalizeDashboardSingleMainChatThreadId(payload?.threadId || payload?.thread_id);
+    const executionId =
+      normalizeText(payload?.executionId || payload?.execution_id) ||
+      createDashboardRequestId(`dashboard-butler-issue${relatedIssue || "unknown"}-vps-maintenance`);
     const proposal = await createVpsPrivilegedMaintenanceProposal({
       payload: {
         ...proposalPayload,
-        dashboardThreadId: normalizeDashboardSingleMainChatThreadId(payload?.threadId || payload?.thread_id),
-        executionId: normalizeText(payload?.executionId || payload?.execution_id)
+        dashboardThreadId,
+        executionId
       },
       provider,
       origin: origin || "https://example.com"
@@ -12235,10 +12239,14 @@ async function buildDashboardVpsPrivilegedMaintenanceNaturalLanguageFlow({
         kind: "dashboard_vps_privileged_maintenance_natural_language",
         status: "approval_required",
         vpsProposalId: proposal.body.vpsProposalId,
+        executionId,
         approvalScope: proposal.body.approvalScope,
         approvalOperatorUrl: proposal.body.approvalOperatorUrl,
         runtimeTruth: {
           ...proposal.body.runtimeTruth,
+          executionId,
+          dashboardThreadIdIncluded: Boolean(dashboardThreadId),
+          approvalOperatorUrlComplete: Boolean(proposal.body.vpsProposalId && dashboardThreadId && executionId),
           dashboardNaturalLanguagePathReached: true,
           helperQueueReached: false
         }
@@ -12765,6 +12773,7 @@ function buildDashboardVpsPrivilegedMaintenanceApprovalRequiredReply({ repositor
     `- 操作: ${operation}`,
     `- risk: ${riskLevel}`,
     `- vpsProposalId: ${proposal?.vpsProposalId || "未作成"}`,
+    "- owner action: この approval URL を開いて passkey 承認だけ行ってください。vpsProposalId や approvalGrantId のコピーは不要です。",
     "- authority: scoped passkey approval が必要です。承認なしに root / sudo / helper 実行は開始しません。",
     "- runtime truth: status=approval_required, rootExecutionStarted=false, helperExecutionStarted=false",
     proposal?.approvalOperatorUrl ? `- approval URL: ${proposal.approvalOperatorUrl}` : "- approval URL: 未生成",

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -3219,6 +3219,10 @@ test("worker maps repo-less Dashboard bridge restart intent to unresolved bridge
   const body = await response.json();
   assert.equal(body.ok, true);
   assert.equal(body.execution.status, "approval_required");
+  assert.match(body.execution.executionId, /^dashboard-butler-issue741-vps-maintenance:/);
+  assert.equal(body.execution.runtimeTruth.executionId, body.execution.executionId);
+  assert.equal(body.execution.runtimeTruth.dashboardThreadIdIncluded, true);
+  assert.equal(body.execution.runtimeTruth.approvalOperatorUrlComplete, true);
   assert.equal(body.execution.approvalScope.vpsCapabilityId, "systemd.user.app.server.bridge.unresolved.restart");
   assert.equal(body.execution.approvalScope.vpsOperation, "enable");
   assert.equal(
@@ -3228,11 +3232,14 @@ test("worker maps repo-less Dashboard bridge restart intent to unresolved bridge
   assert.equal(body.execution.approvalScope.vpsImpactScope.includes("systemctl --user restart"), false);
   assert.match(body.messages[1].text, /Restart repo-less Dashboard app-server bridge/);
   assert.match(body.messages[1].text, /approval_required/);
+  assert.match(body.messages[1].text, /passkey 承認だけ/);
+  assert.match(body.messages[1].text, /コピーは不要/);
   assert.match(body.messages[1].text, /rootExecutionStarted=false, helperExecutionStarted=false/);
   const approvalUrl = new URL(body.execution.approvalOperatorUrl);
   assert.equal(approvalUrl.searchParams.get("mode"), "vps");
   assert.equal(approvalUrl.searchParams.get("dashboardThreadId"), "dashboard-main-unresolved");
   assert.equal(approvalUrl.searchParams.get("vpsProposalId"), body.execution.vpsProposalId);
+  assert.equal(approvalUrl.searchParams.get("executionId"), body.execution.executionId);
 });
 
 test("worker maps Dashboard Butler VPS runner status text to the low-risk preset", async () => {

--- a/worker.js
+++ b/worker.js
@@ -68722,11 +68722,13 @@ async function buildDashboardVpsPrivilegedMaintenanceNaturalLanguageFlow({
         }
       };
     }
+    const dashboardThreadId = normalizeDashboardSingleMainChatThreadId(payload?.threadId || payload?.thread_id);
+    const executionId = normalizeText33(payload?.executionId || payload?.execution_id) || createDashboardRequestId(`dashboard-butler-issue${relatedIssue || "unknown"}-vps-maintenance`);
     const proposal = await createVpsPrivilegedMaintenanceProposal({
       payload: {
         ...proposalPayload,
-        dashboardThreadId: normalizeDashboardSingleMainChatThreadId(payload?.threadId || payload?.thread_id),
-        executionId: normalizeText33(payload?.executionId || payload?.execution_id)
+        dashboardThreadId,
+        executionId
       },
       provider,
       origin: origin || "https://example.com"
@@ -68772,10 +68774,14 @@ async function buildDashboardVpsPrivilegedMaintenanceNaturalLanguageFlow({
         kind: "dashboard_vps_privileged_maintenance_natural_language",
         status: "approval_required",
         vpsProposalId: proposal.body.vpsProposalId,
+        executionId,
         approvalScope: proposal.body.approvalScope,
         approvalOperatorUrl: proposal.body.approvalOperatorUrl,
         runtimeTruth: {
           ...proposal.body.runtimeTruth,
+          executionId,
+          dashboardThreadIdIncluded: Boolean(dashboardThreadId),
+          approvalOperatorUrlComplete: Boolean(proposal.body.vpsProposalId && dashboardThreadId && executionId),
           dashboardNaturalLanguagePathReached: true,
           helperQueueReached: false
         }
@@ -69219,6 +69225,7 @@ function buildDashboardVpsPrivilegedMaintenanceApprovalRequiredReply({ repositor
     `- \u64CD\u4F5C: ${operation}`,
     `- risk: ${riskLevel}`,
     `- vpsProposalId: ${proposal?.vpsProposalId || "\u672A\u4F5C\u6210"}`,
+    "- owner action: \u3053\u306E approval URL \u3092\u958B\u3044\u3066 passkey \u627F\u8A8D\u3060\u3051\u884C\u3063\u3066\u304F\u3060\u3055\u3044\u3002vpsProposalId \u3084 approvalGrantId \u306E\u30B3\u30D4\u30FC\u306F\u4E0D\u8981\u3067\u3059\u3002",
     "- authority: scoped passkey approval \u304C\u5FC5\u8981\u3067\u3059\u3002\u627F\u8A8D\u306A\u3057\u306B root / sudo / helper \u5B9F\u884C\u306F\u958B\u59CB\u3057\u307E\u305B\u3093\u3002",
     "- runtime truth: status=approval_required, rootExecutionStarted=false, helperExecutionStarted=false",
     proposal?.approvalOperatorUrl ? `- approval URL: ${proposal.approvalOperatorUrl}` : "- approval URL: \u672A\u751F\u6210",


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #637 の部分進捗です。VPS restart など passkey が必要な Dashboard Butler 自然文 flow で、owner がやる操作を passkey 承認だけに固定します。
- Dashboard natural-language proposal が `executionId` を持たない場合でも runtime 側で生成し、proposal-backed operator URL に `vpsProposalId` / `dashboardThreadId` / `executionId` が揃うようにします。
- approval-required reply に「passkey 承認だけ」「vpsProposalId / approvalGrantId のコピー不要」を明記します。

## Satisfied Success Criteria

- `buildDashboardVpsPrivilegedMaintenanceNaturalLanguageFlow()` が passkey-required proposal 用の fallback `executionId` を生成します。
- `execution.runtimeTruth` に `executionId`、`dashboardThreadIdIncluded`、`approvalOperatorUrlComplete` を返します。
- repo-less Dashboard bridge restart intent の test で operator URL の `mode=vps`、`vpsProposalId`、`dashboardThreadId`、`executionId` を確認します。
- owner-facing reply が manual copy ではなく passkey 承認だけを求めることを確認します。

## Unsatisfied Success Criteria

- Issue #637 全体は未完了です。実 production passkey 承認、helper queue pickup、restart completion truth、add-disable-remove-rollback、root-required capability E2E は残ります。
- この PR は URL completeness と owner action 明示の slice であり、helper/root 実行は行いません。

## Non-goal violations

None.

## 開発前作戦図

- 作戦図 evidence: docs/development-strategy/issue-637-vps-operator-url-complete.md
- 完了体験: Dashboard Butler が proposal 生成済み passkey operator URL を返し、Owner は URL を開いて passkey 承認だけを行う。
- VTDD 全体で進める部分: Issue #637 の passkey-required approval path を進める。低リスク read/status ではなく restart 系の proposal URL completeness に限定する。
- 設計: Dashboard Butler owner-facing natural-language surface で proposal 作成時に `executionId` を必ず生成し、同じ Dashboard chat thread への auto-continue に必要な context を operator URL に揃える。
- 仮説: 原因は `payload.executionId` 依存で、自然文 chat では通常 `executionId` が無いため URL completeness が caller 依存になることだと疑っている。
- 検証計画: #637 focused worker test、worker build、generated worker check、diff hygiene。
- 改修見積もり: `src/worker/runtime.js` の Dashboard VPS natural-language proposal path、`test/worker.test.js` の #637 restart intent test、`worker.js` generated bundle。
- 既に通っている経路: #637 repo-less low-risk read/status helper queue は production E2E 通過済み。VPS operator auto-continue の基本テストも存在する。
- 未確認の境界: production restart helper queue の passkey 承認後 pickup / completion はこの PR では実行しない。
- 穴が出そうな箇所: executionId が URL と runtime body でズレると queue / runner event の追跡が難しくなる。
- PR 前に確認すること: Issue #637、operator page source、Dashboard natural-language flow、既存 #637 tests、latest origin/main。
- 実装候補と捨てた案: runtime 側 executionId 生成を採用。owner 手入力、汎用 passkey URL、operator page 側 proposal なし補完は捨てた。
- merge 後に通す E2E: production Dashboard Butler で restart 系 intent を送り、operator URL を開いて passkey 承認し、同じ Dashboard thread への auto-continue、helper queue comment、runner pickup / completion truth を検証する。
- 次の PR を増やさない理由: この PR は同じ approval URL completeness surface に閉じる。restart 実行 evidence は authority boundary 上 merge/deploy 後にしか取得できないため。
- 停止条件: URL に proposal context が揃わない、approvalGrantId copy/manual flow が必要になる、または Worker から root/helper execution を直接始める必要が出た場合。

## Dry-run Impact Report

- Target Issue: Issue #637
- Implementing Success Criteria: Dashboard Butler natural-language restart proposal の operator URL に auto-continue 必須 context を揃え、owner action を passkey 承認だけにする。
- Explicit Non-goals: restart 実行、root/helper 実行、deploy 実行、credential/permission mutation、Issue close、#590 追加修正。
- Expected touched files/routes/workflows: `src/worker/runtime.js`, `worker.js`, `test/worker.test.js`, `docs/development-strategy/issue-637-vps-operator-url-complete.md`
- Affected Issues: Issue #637。Issue #590 は production observation 待ちで downscope しない。
- Affected PRs: なし。新規 PR として作成する。
- Affected workflows: local worker test / build / generated worker check。Deploy workflow は merge 後に passkey approval が必要。
- Affected runtime/operator surfaces: Dashboard Butler PWA normal chat、VPS passkey operator URL、VPS helper queue auto-continue path。
- What may break if we patch narrowly: executionId が URL と execution body で不一致になると runner event traceability が壊れる。
- Unknowns to investigate before coding: production passkey 承認後の pickup / completion は merge/deploy 後の E2E で確認する。
- Validation needed: focused worker test, build, generated worker check, diff check。
- Stop condition: manual copy flow や root/helper direct execution が必要になる場合。

## Execution Queue Delta

- Queue position before: Issue #637 は Issue #590 の owner-facing progress UX blocker 後の Next / Root Blocker。#590 PR #800/#801 後、#637 に戻る。
- Preemption decision: NEXT。現在の active queue に従い、#637 passkey-required approval URL completeness を進める。
- Queue delta: Issue #637 の passkey-required operator URL completeness slice を進める。Issue #637 は incomplete のまま。
- Why this PR is next: owner が「パスキーを承認するだけ」が正しい完成形だと確認し、汎用 operator URL / 不足パラメータ問題を指摘したため。
- Active Issues not downscoped: Active Issues は縮小しません。#590 / #450 / #654 / その他 active Issue は未完了として残します。

## File / Line Hypotheses

- file: `src/worker/runtime.js`
  - hypothesis: Dashboard VPS natural-language flow が `payload.executionId` に依存しているため、owner 自然文から作った operator URL が auto-continue context 不足になり得る。
  - risk if changed narrowly: executionId が URL と response body でズレる。
  - validation: restart intent test で URL と runtimeTruth の executionId 一致を確認する。
  - related Issue: Issue #637
- file: `test/worker.test.js`
  - hypothesis: 既存 restart intent test は `vpsProposalId` / `dashboardThreadId` だけを見ており、executionId completeness と owner action wording を捕捉していない。
  - risk if changed narrowly: 汎用 URL regression を再発見できない。
  - validation: assertion を追加する。
  - related Issue: Issue #637

## Hypothesis Retrospective

- expected: executionId fallback を追加すると passkey-required restart proposal URL が complete になり、owner-facing reply も passkey 承認だけを示せる。
- actual: focused test で `executionId` は `dashboard-butler-issue741-vps-maintenance:<uuid>` 形式で生成され、URL / runtimeTruth と一致した。
- mismatch: 期待した delimiter は `_` ではなく既存 helper の `:` 形式だったため、test expectation を既存 ID 形式に合わせた。
- lesson: ID 形式は既存 `createDashboardRequestId()` に合わせ、test 側で勝手に別 delimiter を仮定しない。
- should become RAG candidate: yes。VPS passkey operator URL は proposal-backed context complete が必須で、owner に ID copy を求めない。

## Verification Evidence

- Unit: `node --test test/worker.test.js --test-name-pattern 'VPS|vps|privileged|operator|Dashboard Butler VPS|repo-less Dashboard bridge restart'` -> 280 passed
- Integration: `npm run build:worker` -> pass; `npm run check:generated-worker` -> pass; `git diff --check` -> pass
- E2E: Not run in this PR. Production passkey approval / helper queue pickup E2E is required after merge/deploy.
- Manual: Source and Issue #637 evidence were read before implementation.
- Evidence path/link: docs/development-strategy/issue-637-vps-operator-url-complete.md

## Butler Completion Contract

- Primary owner surface: Dashboard Butler PWA。
- Fallback surface: mac Codex は implementation helper surface。主経路ではない。
- Owner goal: Owner が VPS restart approval で passkey 承認だけを行い、ID copy や JSON 手入力をしなくて済む。
- Butler entrypoint: Dashboard Butler 通常チャットの自然文 VPS maintenance intent。
- Dashboard Butler natural-language path: Dashboard Butler 通常チャット入口で owner の自然文 restart / recovery intent を受け、proposal-backed passkey operator URL に到達する。
- Action Schema exposure: 既存 `vtddCreateVpsMaintenanceProposal` / helper request schema は変更なし。
- Runtime path: Worker Dashboard chat natural-language flow -> VPS maintenance proposal -> passkey operator URL。
- Runner/runtime truth: local worker tests と generated worker check。Production runner pickup truth は未実施。
- Authority boundary: passkey approval required。承認なしに root / sudo / helper execution は開始しない。
- E2E evidence: local unit/integration evidence only。production iPhone/PWA passkey approval E2E は merge/deploy 後に必要。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: merge 後に必要。passkey approval が必要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: merge/deploy 後に必要。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate
- AGENTS.md Butler-First Operating Principle
- AGENTS.md Authority Boundary
- AGENTS.md 開発前作戦図 Gate
- docs/butler/execution-queue-contract.md
- docs/butler/vps-privileged-maintenance-capability-lifecycle.md

## Out-of-scope but NOT implemented

- restart helper execution
- root-required capability execution
- add / disable / remove / rollback lifecycle E2E
- deploy execution
- Issue #637 close

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #637
- Execution ID: dashboard-butler-issue-637-vps-operator-url-complete-2026-06-05
- Goal: VPS passkey operator URL を proposal-backed context complete にし、owner 操作を passkey 承認だけにする。
