### PR TITLE
Issue #590 bridge lifecycle progress を控えめにする

### DIFF
--- a/docs/development-strategy/issue-590-muted-bridge-lifecycle-progress.md
+++ b/docs/development-strategy/issue-590-muted-bridge-lifecycle-progress.md
@@ -1,0 +1,64 @@
+# Issue #590 bridge lifecycle progress を控えめにする作戦図
+
+## 完了体験
+
+Owner が Dashboard Butler PWA で bridge restart 後の通常チャットを見た時、`thread resume` や `turn start` の technical lifecycle truth は確認できるが、通常回答や重要 checkpoint より目立たない。画面を大きく占有せず、必要なら流し読みできる。
+
+## VTDD 全体で進める部分
+
+Issue #590 の owner-facing progress lane を改善する。Issue #741 の bridge lifecycle truth は関連するが、今回の slice は restart 実行や lifecycle guard の拡張ではなく、既に届く lifecycle event の表示分類だけを扱う。
+
+## 設計
+
+`app_server_status` の `stage=thread_resume` / `turn_started` / `bridge_connected` は復帰 truth として有用だが、owner-facing progress checkpoint と同じ `Butler` bubble で出すには technical すぎる。Worker 側で snapshot source を lifecycle 専用にし、Dashboard renderer 側で `bridge-lifecycle-checkpoint` class を付け、文言も短くする。
+
+## 仮説
+
+表示がうるさい原因は、bridge lifecycle event が `app_server_status` として一般 progress summary に入り、`progress-checkpoint-bubble` の通常 Butler bubble と同じ header / text size / color で表示されることだと疑っている。source と stage を分類すれば、runtime truth は残しつつ visual weight を下げられる。
+
+## 検証計画
+
+- Unit: `node --test test/worker.test.js --test-name-pattern 'dashboard|DashboardChatRoom|progress|composer|lifecycle'`
+- Unit: `node --test test/dashboard-app-server-bridge.test.js`
+- Build: `npm run build:worker`
+- Generated worker: `npm run check:generated-worker`
+- Hygiene: `git diff --check`
+- E2E: `npx playwright test scripts/e2e-issue590-dashboard-timeout-recovery.spec.mjs --browser=chromium --reporter=line`
+
+## 改修見積もり
+
+- `src/worker/runtime.js`: bridge lifecycle stage 判定、snapshot source 分類、短い lifecycle text、muted note CSS / DOM class を追加する。
+- `test/worker.test.js`: lifecycle status が generic owner-facing checkpoint ではなく muted lifecycle checkpoint として扱われることを確認する。
+- `worker.js`: generated Worker bundle を更新する。
+
+## 既に通っている経路
+
+PR #801 / #802 で live checkpoint stack と VPS operator URL context は merge 済み。bridge restart post-step は #741 runtime truth として issue comments に残る。ただし owner は production PWA で lifecycle checkpoint が強すぎることを観測した。
+
+## 未確認の境界
+
+production PWA で実際にどの lifecycle event が何件出るかは bridge restart timing に依存する。今回の変更は stage/source で絞り、通常 implementation/test/reviewer checkpoint には適用しない。
+
+## 穴が出そうな箇所
+
+lifecycle event を完全に消すと、restart 後に文脈が復帰した証拠が owner-facing に消える。逆に通常 progress と同じ見た目のままだと chat がうるさくなる。短い muted note でバランスを取る。
+
+## PR 前に確認すること
+
+`origin/main` から topic branch を作ること。local `main` の未同期 commit や `.tmp/` / `test-results/` を巻き込まないこと。#590 / #741 の既存 comments と queue truth を読むこと。
+
+## 実装候補と捨てた案
+
+採用候補は lifecycle stage を snapshot source と CSS class で分ける案。捨てた案は lifecycle event を完全に非表示にする案と、bridge script の event 自体を止める案。前者は復帰 truth を失い、後者は #741 の lifecycle evidence を弱める。
+
+## merge 後に通す E2E
+
+production deploy / cache reload 後、Dashboard Butler PWA で bridge restart 復帰時の lifecycle note が通常 Butler bubble より控えめに見えることを iPhone/PWA live E2E で確認する。
+
+## 次の PR を増やさない理由
+
+この slice は同じ #590 progress lane の表示分類内で完結する。bridge restart 実行、通知未達、#741 lifecycle guard の拡張は別 Issue の残作業として残し、ここで混ぜない。
+
+## 停止条件
+
+通常の owner-facing checkpoint が薄くなる、bridge lifecycle truth が完全に見えなくなる、または Durable Object write が増える実装になりそうな場合は停止する。

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -9998,7 +9998,7 @@ function normalizeDashboardAppServerBridgeEvent(payload, { fallbackThreadId = ""
       transientStatus
     });
     snapshotTransientStatus = transientStatus === "thinking";
-    snapshotSource = "app_server_status";
+    snapshotSource = isDashboardBridgeLifecycleStatus(input) ? "app_server_bridge_lifecycle" : "app_server_status";
     if (shouldPersistDashboardAppServerProgress(input, { transientStatus })) {
       messages.push(
         normalizeDashboardChatMessage(
@@ -10256,6 +10256,28 @@ function shouldPersistDashboardAppServerProgress(input, { transientStatus = "" }
   return DASHBOARD_DURABLE_APP_SERVER_PROGRESS_STAGES.has(stage);
 }
 
+const DASHBOARD_BRIDGE_LIFECYCLE_STAGES = new Set([
+  "bridge_connected",
+  "thread_resume",
+  "turn_started"
+]);
+
+function isDashboardBridgeLifecycleStatus(input) {
+  const stage = normalizeDashboardEventText(
+    input?.stage ||
+      input?.phase ||
+      input?.step ||
+      input?.activity ||
+      input?.progressStage ||
+      input?.progress_stage
+  ).toLowerCase().replaceAll("-", "_");
+  const lifecycleStatus = normalizeDashboardEventText(
+    input?.bridgeLifecycle?.status ||
+      input?.bridge_lifecycle?.status
+  ).toLowerCase().replaceAll("-", "_");
+  return DASHBOARD_BRIDGE_LIFECYCLE_STAGES.has(stage) || DASHBOARD_BRIDGE_LIFECYCLE_STAGES.has(lifecycleStatus);
+}
+
 function normalizeDashboardBooleanFlag(value) {
   if (value === true) return true;
   if (value === false || value === null || value === undefined) return false;
@@ -10284,6 +10306,9 @@ const DASHBOARD_APP_SERVER_STAGE_TEXT = {
   web_search: "必要な情報を確認しています。",
   waiting_approval: "承認待ちです。",
   waiting_user_input: "確認が必要です。",
+  bridge_connected: "bridge 接続済み。",
+  thread_resume: "既存 thread 復帰。",
+  turn_started: "turn 開始。",
   quiet: "接続と実行状態を確認中です。入力と文脈は保持しています。",
   debug_slow_turn: "Issue #590 slow turn E2E を実行しています。",
   long_turn_checkpoint: "作業を継続しています。まだ最終回答は生成中です。",
@@ -16206,6 +16231,11 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
     .progress-checkpoint-bubble { color: var(--muted); }
     .progress-checkpoint-bubble .bubble-header strong { color: var(--muted); }
     .progress-checkpoint-bubble .message-body p { color: var(--text); }
+    .bridge-lifecycle-checkpoint { opacity: .72; }
+    .bridge-lifecycle-checkpoint .bubble-header { margin-bottom: 3px; }
+    .bridge-lifecycle-checkpoint .bubble-header strong { color: var(--muted); font-size: 10px; letter-spacing: .04em; text-transform: none; }
+    .bridge-lifecycle-checkpoint .message-body { gap: 0; }
+    .bridge-lifecycle-checkpoint .message-body p { color: var(--muted); font-size: 13px; line-height: 1.45; }
     .reply-context { display: grid; grid-template-columns: minmax(0, 1fr); gap: 2px; width: min(100%, 680px); margin: 0 0 10px; padding: 8px 10px; border: 0; border-left: 3px solid var(--border); border-radius: 0 8px 8px 0; background: var(--soft); color: var(--muted); font: inherit; font-size: 12px; line-height: 1.45; text-align: left; cursor: pointer; }
     .reply-context:hover, .reply-context:focus-visible { color: var(--text); background: var(--panel-strong); outline: none; }
     .reply-context:focus-visible { box-shadow: 0 0 0 2px var(--link); }
@@ -16840,6 +16870,10 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         return (source || "checkpoint") + ":" + text;
       }
 
+      function isBridgeLifecycleCheckpointEntry(entry) {
+        return String(entry && entry.source || "").trim() === "app_server_bridge_lifecycle";
+      }
+
       function hasProgressCheckpointSnapshot(snapshot) {
         return Boolean(latestProgressCheckpointText(snapshot));
       }
@@ -16942,21 +16976,22 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         }
       }
 
-      function ensureThreadProgressCheckpointCard(entryKey) {
+      function ensureThreadProgressCheckpointCard(entryKey, checkpoint = {}) {
         const existing = threadProgressCheckpointCards.get(entryKey);
         if (existing && existing.isConnected) {
           return existing;
         }
+        const bridgeLifecycle = isBridgeLifecycleCheckpointEntry(checkpoint);
         const entry = document.createElement("div");
-        entry.className = "message-entry butler progress-checkpoint-entry";
+        entry.className = "message-entry butler progress-checkpoint-entry" + (bridgeLifecycle ? " bridge-lifecycle-checkpoint" : "");
         entry.setAttribute("data-thread-progress-checkpoint", "true");
         entry.dataset.progressCheckpointKey = entryKey;
         const article = document.createElement("article");
-        article.className = "bubble progress-checkpoint-bubble";
+        article.className = "bubble progress-checkpoint-bubble" + (bridgeLifecycle ? " bridge-lifecycle-bubble" : "");
         const header = document.createElement("div");
         header.className = "bubble-header";
         const strong = document.createElement("strong");
-        strong.textContent = "Butler";
+        strong.textContent = bridgeLifecycle ? "status" : "Butler";
         header.appendChild(strong);
         const body = document.createElement("div");
         body.className = "message-body";
@@ -16981,7 +17016,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           return false;
         }
         for (const entry of entries) {
-          const card = ensureThreadProgressCheckpointCard(progressCheckpointEntryKey(entry));
+          const card = ensureThreadProgressCheckpointCard(progressCheckpointEntryKey(entry), entry);
           const paragraph = card.querySelector(".message-body p");
           if (paragraph) {
             schedulePacedProgressCheckpointText(paragraph, entry.text);

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -1301,6 +1301,9 @@ test("worker serves v2 dashboard for allowed owner identity without exposing sec
   assert.equal(body.includes("const pacedProgressCheckpointStates = new Map()"), true);
   assert.equal(body.includes("function progressCheckpointEntries(snapshot)"), true);
   assert.equal(body.includes("function progressCheckpointEntryKey(entry)"), true);
+  assert.equal(body.includes("function isBridgeLifecycleCheckpointEntry(entry)"), true);
+  assert.equal(body.includes("bridge-lifecycle-checkpoint"), true);
+  assert.equal(body.includes("app_server_bridge_lifecycle"), true);
   assert.equal(body.includes("function schedulePacedProgressCheckpointText(paragraph, nextText)"), true);
   assert.equal(body.includes("function stepPacedProgressCheckpointText(paragraph)"), true);
   assert.equal(body.includes("const minimumDisplayMs = 1800"), true);
@@ -1309,8 +1312,6 @@ test("worker serves v2 dashboard for allowed owner identity without exposing sec
   assert.equal(body.includes("schedulePacedProgressCheckpointText(paragraph, entry.text)"), true);
   assert.equal(body.includes("paragraph.textContent = text;"), false);
   assert.equal(body.includes("const entries = progressCheckpointEntries(transientProgressSnapshotState);"), true);
-  assert.equal(body.includes("threadProgressCheckpointCards.set(entryKey, entry);"), true);
-  assert.equal(body.includes("threadProgressCheckpointCards.clear();"), true);
   assert.equal(body.includes("snapshot: body.transientProgressSnapshot || null"), true);
   assert.equal(body.includes("function isNearLatest()"), true);
   assert.equal(body.includes("function scrollToLatestIfFollowing(shouldFollow)"), true);
@@ -5377,6 +5378,53 @@ test("DashboardChatRoom exposes last app-server status snapshot on thread reconn
   assert.equal(payload.type, "thread");
   assert.equal(payload.messages.length, 0);
   assert.deepEqual(payload.transientProgressSnapshot, snapshot);
+});
+
+test("DashboardChatRoom marks bridge lifecycle status as muted progress checkpoint truth", async () => {
+  const store = createInMemoryDashboardChatStore();
+  const dashboardSocket = createMockSocket("dashboard", "dashboard-main-unresolved");
+  const bridgeSocket = createMockSocket("app_server_bridge", "dashboard-main-unresolved");
+  const storage = createMockDurableObjectStorage();
+  const room = new DashboardChatRoom(
+    {
+      storage,
+      getWebSockets() {
+        return [dashboardSocket, bridgeSocket];
+      }
+    },
+    { DASHBOARD_CHAT_STORE: store }
+  );
+
+  await room.webSocketMessage(
+    bridgeSocket,
+    JSON.stringify({
+      type: "app_server_status",
+      status: "thinking",
+      stage: "thread_resume",
+      threadId: "dashboard-main-unresolved",
+      codexThreadId: "codex-thread-450",
+      text: "既存 Codex thread を resume しました。deploy 後 restart でも前の文脈から続けられます。"
+    })
+  );
+
+  const snapshot = storage.values.get("transient_progress_snapshot:dashboard-main-unresolved");
+  assert.equal(snapshot.status, "thinking");
+  assert.equal(snapshot.text, "既存 thread 復帰。");
+  assert.equal(snapshot.source, "app_server_bridge_lifecycle");
+  assert.deepEqual(
+    snapshot.progressSummary.entries.map((entry) => [entry.text, entry.source]),
+    [["既存 thread 復帰。", "app_server_bridge_lifecycle"]]
+  );
+  assert.equal((await store.listThread("dashboard-main-unresolved")).length, 0);
+
+  const statusPayload = JSON.parse(dashboardSocket.sent[0]);
+  assert.equal(statusPayload.type, "transient_status");
+  assert.equal(statusPayload.text, "既存 thread 復帰。");
+  assert.equal(statusPayload.transientProgressSnapshot.source, "app_server_bridge_lifecycle");
+  assert.deepEqual(
+    statusPayload.transientProgressSnapshot.progressSummary.entries.map((entry) => [entry.text, entry.source]),
+    [["既存 thread 復帰。", "app_server_bridge_lifecycle"]]
+  );
 });
 
 test("DashboardChatRoom keeps app-server reply deltas out of durable chat while exposing live checkpoints", async () => {

--- a/worker.js
+++ b/worker.js
@@ -66764,7 +66764,7 @@ function normalizeDashboardAppServerBridgeEvent(payload, { fallbackThreadId = ""
       transientStatus
     });
     snapshotTransientStatus = transientStatus === "thinking";
-    snapshotSource = "app_server_status";
+    snapshotSource = isDashboardBridgeLifecycleStatus(input) ? "app_server_bridge_lifecycle" : "app_server_status";
     if (shouldPersistDashboardAppServerProgress(input, { transientStatus })) {
       messages.push(
         normalizeDashboardChatMessage(
@@ -66979,6 +66979,20 @@ function shouldPersistDashboardAppServerProgress(input, { transientStatus = "" }
   ).toLowerCase().replaceAll("-", "_");
   return DASHBOARD_DURABLE_APP_SERVER_PROGRESS_STAGES.has(stage);
 }
+var DASHBOARD_BRIDGE_LIFECYCLE_STAGES = /* @__PURE__ */ new Set([
+  "bridge_connected",
+  "thread_resume",
+  "turn_started"
+]);
+function isDashboardBridgeLifecycleStatus(input) {
+  const stage = normalizeDashboardEventText(
+    input?.stage || input?.phase || input?.step || input?.activity || input?.progressStage || input?.progress_stage
+  ).toLowerCase().replaceAll("-", "_");
+  const lifecycleStatus = normalizeDashboardEventText(
+    input?.bridgeLifecycle?.status || input?.bridge_lifecycle?.status
+  ).toLowerCase().replaceAll("-", "_");
+  return DASHBOARD_BRIDGE_LIFECYCLE_STAGES.has(stage) || DASHBOARD_BRIDGE_LIFECYCLE_STAGES.has(lifecycleStatus);
+}
 var DASHBOARD_APP_SERVER_STAGE_TEXT = {
   read_context: "\u65E2\u5B58 Issue / PR / docs \u3092\u78BA\u8A8D\u3057\u3066\u3044\u307E\u3059\u3002",
   inspect_context: "\u65E2\u5B58 Issue / PR / docs \u3092\u78BA\u8A8D\u3057\u3066\u3044\u307E\u3059\u3002",
@@ -67001,6 +67015,9 @@ var DASHBOARD_APP_SERVER_STAGE_TEXT = {
   web_search: "\u5FC5\u8981\u306A\u60C5\u5831\u3092\u78BA\u8A8D\u3057\u3066\u3044\u307E\u3059\u3002",
   waiting_approval: "\u627F\u8A8D\u5F85\u3061\u3067\u3059\u3002",
   waiting_user_input: "\u78BA\u8A8D\u304C\u5FC5\u8981\u3067\u3059\u3002",
+  bridge_connected: "bridge \u63A5\u7D9A\u6E08\u307F\u3002",
+  thread_resume: "\u65E2\u5B58 thread \u5FA9\u5E30\u3002",
+  turn_started: "turn \u958B\u59CB\u3002",
   quiet: "\u63A5\u7D9A\u3068\u5B9F\u884C\u72B6\u614B\u3092\u78BA\u8A8D\u4E2D\u3067\u3059\u3002\u5165\u529B\u3068\u6587\u8108\u306F\u4FDD\u6301\u3057\u3066\u3044\u307E\u3059\u3002",
   debug_slow_turn: "Issue #590 slow turn E2E \u3092\u5B9F\u884C\u3057\u3066\u3044\u307E\u3059\u3002",
   long_turn_checkpoint: "\u4F5C\u696D\u3092\u7D99\u7D9A\u3057\u3066\u3044\u307E\u3059\u3002\u307E\u3060\u6700\u7D42\u56DE\u7B54\u306F\u751F\u6210\u4E2D\u3067\u3059\u3002",
@@ -72328,6 +72345,11 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
     .progress-checkpoint-bubble { color: var(--muted); }
     .progress-checkpoint-bubble .bubble-header strong { color: var(--muted); }
     .progress-checkpoint-bubble .message-body p { color: var(--text); }
+    .bridge-lifecycle-checkpoint { opacity: .72; }
+    .bridge-lifecycle-checkpoint .bubble-header { margin-bottom: 3px; }
+    .bridge-lifecycle-checkpoint .bubble-header strong { color: var(--muted); font-size: 10px; letter-spacing: .04em; text-transform: none; }
+    .bridge-lifecycle-checkpoint .message-body { gap: 0; }
+    .bridge-lifecycle-checkpoint .message-body p { color: var(--muted); font-size: 13px; line-height: 1.45; }
     .reply-context { display: grid; grid-template-columns: minmax(0, 1fr); gap: 2px; width: min(100%, 680px); margin: 0 0 10px; padding: 8px 10px; border: 0; border-left: 3px solid var(--border); border-radius: 0 8px 8px 0; background: var(--soft); color: var(--muted); font: inherit; font-size: 12px; line-height: 1.45; text-align: left; cursor: pointer; }
     .reply-context:hover, .reply-context:focus-visible { color: var(--text); background: var(--panel-strong); outline: none; }
     .reply-context:focus-visible { box-shadow: 0 0 0 2px var(--link); }
@@ -72962,6 +72984,10 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         return (source || "checkpoint") + ":" + text;
       }
 
+      function isBridgeLifecycleCheckpointEntry(entry) {
+        return String(entry && entry.source || "").trim() === "app_server_bridge_lifecycle";
+      }
+
       function hasProgressCheckpointSnapshot(snapshot) {
         return Boolean(latestProgressCheckpointText(snapshot));
       }
@@ -73064,21 +73090,22 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
         }
       }
 
-      function ensureThreadProgressCheckpointCard(entryKey) {
+      function ensureThreadProgressCheckpointCard(entryKey, checkpoint = {}) {
         const existing = threadProgressCheckpointCards.get(entryKey);
         if (existing && existing.isConnected) {
           return existing;
         }
+        const bridgeLifecycle = isBridgeLifecycleCheckpointEntry(checkpoint);
         const entry = document.createElement("div");
-        entry.className = "message-entry butler progress-checkpoint-entry";
+        entry.className = "message-entry butler progress-checkpoint-entry" + (bridgeLifecycle ? " bridge-lifecycle-checkpoint" : "");
         entry.setAttribute("data-thread-progress-checkpoint", "true");
         entry.dataset.progressCheckpointKey = entryKey;
         const article = document.createElement("article");
-        article.className = "bubble progress-checkpoint-bubble";
+        article.className = "bubble progress-checkpoint-bubble" + (bridgeLifecycle ? " bridge-lifecycle-bubble" : "");
         const header = document.createElement("div");
         header.className = "bubble-header";
         const strong = document.createElement("strong");
-        strong.textContent = "Butler";
+        strong.textContent = bridgeLifecycle ? "status" : "Butler";
         header.appendChild(strong);
         const body = document.createElement("div");
         body.className = "message-body";
@@ -73103,7 +73130,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           return false;
         }
         for (const entry of entries) {
-          const card = ensureThreadProgressCheckpointCard(progressCheckpointEntryKey(entry));
+          const card = ensureThreadProgressCheckpointCard(progressCheckpointEntryKey(entry), entry);
           const paragraph = card.querySelector(".message-body p");
           if (paragraph) {
             schedulePacedProgressCheckpointText(paragraph, entry.text);


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #590 の部分進捗です。deploy / bridge restart 後に Dashboard Butler PWA へ出る `既存 Codex thread を resume...` / `復帰した Codex thread...` の lifecycle message が通常チャットのように目立ちすぎる問題を、progress lane の表示分類として小さく直します。
- bridge lifecycle truth は消さず、`app_server_bridge_lifecycle` source と短い文言で残します。
- Dashboard の checkpoint renderer では lifecycle entry だけ `status` header と muted CSS にして、通常の Butler 進行 checkpoint より視覚階層を下げます。

## Satisfied Success Criteria

- `stage=bridge_connected` / `thread_resume` / `turn_started` を短い owner-facing 文言へ変換します。
- lifecycle status の transient snapshot source を `app_server_bridge_lifecycle` に分離します。
- lifecycle checkpoint は `bridge-lifecycle-checkpoint` class と `status` header で通常 Butler checkpoint より控えめに表示します。
- lifecycle status は durable chat message に保存せず、progress truth としてのみ残します。

## Unsatisfied Success Criteria

- Issue #590 全体は未完了です。production PWA での merge/deploy 後 live evidence、silent wait recovery 全体、Butler Completion Gate 全体は残ります。
- #741 の bridge lifecycle guard / restart 実行 / notification 未達の根本対応はこの PR では扱いません。

## Non-goal violations

None.

## 開発前作戦図

- 作戦図 evidence: docs/development-strategy/issue-590-muted-bridge-lifecycle-progress.md
- 完了体験: Owner が Dashboard Butler PWA で bridge restart 後の通常チャットを見る時、thread resume / turn start の technical lifecycle truth は確認できるが、通常回答や重要 checkpoint より目立たない。
- VTDD 全体で進める部分: Issue #590 の owner-facing progress lane を改善する。Issue #741 は関連するが、今回の slice は restart 実行ではなく表示分類だけを扱う。
- 設計: Dashboard Butler の owner-facing chat surface で `app_server_status` の lifecycle stage を source と CSS class で分け、文言を短くして muted note にする。
- 仮説: うるささの主原因は lifecycle event が generic `app_server_status` として通常 Butler bubble と同じ header / text size / color で出ていること。
- 検証計画: focused worker test、bridge test、worker build、generated worker check、diff hygiene、#590 Playwright E2E。
- 改修見積もり: `src/worker/runtime.js` の bridge status 正規化 / Dashboard CSS / renderer、`test/worker.test.js`、generated `worker.js`。
- 既に通っている経路: PR #801 / #802 後、live checkpoint stack と VPS operator URL context は main に入っている。owner は production PWA で lifecycle checkpoint が強すぎることを観測した。
- 未確認の境界: production PWA で実際にどの lifecycle event が何件出るかは bridge restart timing に依存する。
- 穴が出そうな箇所: lifecycle event を完全に消すと復帰 truth が owner-facing に消える。逆に通常 progress と同じ見た目のままだと chat がうるさい。
- PR 前に確認すること: `origin/main` から topic branch を作ること、local `main` の未同期 commit や `.tmp/` / `test-results/` を巻き込まないこと。
- 実装候補と捨てた案: lifecycle stage を snapshot source と CSS class で分ける案を採用。完全非表示案と bridge script の event 自体を止める案は捨てた。
- merge 後に通す E2E: production deploy / cache reload 後、Dashboard Butler PWA で bridge restart 復帰時の lifecycle note が通常 Butler bubble より控えめに見えることを iPhone/PWA live E2E で確認する。
- 次の PR を増やさない理由: 同じ #590 progress lane の表示分類内で完結するため。bridge restart 実行、通知未達、#741 lifecycle guard 拡張は別 Issue の残作業として残す。
- 停止条件: 通常 owner-facing checkpoint が薄くなる、bridge lifecycle truth が完全に見えなくなる、または Durable Object write が増える実装になりそうな場合。

## Dry-run Impact Report

- Target Issue: Issue #590
- Implementing Success Criteria: Dashboard Butler の bridge lifecycle status を通常 Butler checkpoint より控えめな live progress note として表示し、truth は維持する。
- Explicit Non-goals: deploy、bridge restart、credential / permission mutation、#741 restart guard、notification 未達修正、Issue #590 close。
- Expected touched files/routes/workflows: `src/worker/runtime.js`, `worker.js`, `test/worker.test.js`, `docs/development-strategy/issue-590-muted-bridge-lifecycle-progress.md`
- Affected Issues: Issue #590。Issue #741 は関連するが今回の実装対象外。#637 / #450 / #654 は queue 上残る。
- Affected PRs: PR #801 / #802 後の production observation follow-up。既存 PR は更新しない。
- Affected workflows: local worker tests / app-server bridge tests / worker build / generated worker check / Playwright E2E。Deploy workflow はこの PR では実行しない。
- Affected runtime/operator surfaces: Dashboard Butler PWA の live progress checkpoint renderer。passkey operator surface は未変更。
- What may break if we patch narrowly: lifecycle 判定が広すぎると通常の app-server status まで薄くなる。狭すぎると restart/resume message が通常 bubble のまま残る。
- Unknowns to investigate before coding: production bridge restart timing で lifecycle event 件数が変動する。source/stage 判定を固定 stage に限定する。
- Validation needed: focused worker tests, bridge tests, build, generated-worker check, diff check, #590 Playwright E2E。
- Stop condition: 通常 progress checkpoint の視認性低下、lifecycle truth の消失、durable chat 保存増加が出た場合。

## Execution Queue Delta

- Queue position before: Issue #590 が Now。owner-facing observability / recovery evidence が root blocker。
- Preemption decision: ROOT。owner の最新 production 観測は Issue #590 の owner-facing progress lane blocker 継続であり、Next の #637 / #450/#654 を置き換えない。
- Queue delta: `Now` の Issue #590 muted bridge lifecycle progress slice を進める。Issue #590 全体は incomplete のまま。
- Why this PR is next: bridge restart 後の lifecycle message が iPhone/PWA 画面で目立ちすぎ、silent wait recovery の通常チャット体験を阻害しているため。
- Active Issues not downscoped: Active Issues は縮小しません。#637、#450/#654、#741、その他 active queue は未完了として残します。

## File / Line Hypotheses

- file: `src/worker/runtime.js`
  - hypothesis: `normalizeDashboardAppServerBridgeEvent()` が lifecycle status を generic `app_server_status` source として扱うため、renderer 側で区別できない。
  - risk if changed narrowly: source を変えすぎると通常 status の progress summary が崩れる。
  - validation: `DashboardChatRoom marks bridge lifecycle status as muted progress checkpoint truth` で `thread_resume` が `app_server_bridge_lifecycle` になることを確認する。
  - related Issue: Issue #590
- file: `src/worker/runtime.js`
  - hypothesis: `ensureThreadProgressCheckpointCard()` が全 checkpoint を同じ Butler bubble として作るため、technical lifecycle が強すぎる。
  - risk if changed narrowly: generic checkpoint まで muted になると長時間作業の重要 progress が見えにくくなる。
  - validation: Dashboard HTML assertion で lifecycle 専用 class / renderer helper だけが追加されることを確認する。
  - related Issue: Issue #590

## Hypothesis Retrospective

- expected: lifecycle stage を source 分離し、renderer が lifecycle entry だけ muted class にすれば、truth を残しつつ visual weight を下げられる。
- actual: Durable Object test で `thread_resume` が短文 `既存 thread 復帰。` と `app_server_bridge_lifecycle` source になり、durable chat に保存されないことを確認できた。
- mismatch: なし。HTML source assertion では server-side stage text が直接 HTML に出ないため、DOM renderer helper / class の確認へ絞った。
- lesson: server-side 正規化と client-side 表示 class は別テストで見る必要がある。
- should become RAG candidate: yes。Bridge lifecycle truth は消さず、通常 chat より低い視覚階層へ分類する。

## Verification Evidence

- Unit: `node --test test/worker.test.js --test-name-pattern 'dashboard|DashboardChatRoom|progress|composer|lifecycle'` -> 281 passed
- Unit: `node --test test/dashboard-app-server-bridge.test.js` -> 77 passed
- Build: `npm run build:worker` -> pass
- Generated worker: `npm run check:generated-worker` -> pass
- Hygiene: `git diff --check` -> pass
- E2E: `npx playwright test scripts/e2e-issue590-dashboard-timeout-recovery.spec.mjs --browser=chromium --reporter=line` -> 2 passed

## Butler Completion Contract

- Primary owner surface: Dashboard Butler PWA。
- Fallback surface: mac Codex は今回の実装補助 surface。VTDD completion ではない。
- Owner goal: bridge restart / resume lifecycle message が通常チャットより控えめに表示され、画面を取りすぎないこと。
- Butler entrypoint: Dashboard Butler 通常チャットの live progress lane。
- Dashboard Butler natural-language path: Owner が Dashboard Butler の通常チャット自然文入口で conversation / deploy 後 recovery を続けると、bridge lifecycle truth が同じ chat thread の progress lane に短く表示される。新しい内部 API 入力は不要。
- Action Schema exposure: 変更なし。
- Runtime path: Worker-served Dashboard HTML / DashboardChatRoom transient snapshot / inline progress checkpoint renderer。
- Runner/runtime truth: local focused tests / app-server bridge tests / #590 Playwright E2E evidence を参照。Production deploy は未実施。
- Authority boundary: deploy / bridge restart は passkey approval が必要。この PR では実行しない。
- E2E evidence: local #590 Playwright E2E は pass。production iPhone/PWA E2E は merge/deploy 後に必要。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: merge 後に必要。passkey approval が必要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: merge/deploy 後に必要。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate
- AGENTS.md Chief Butler Operating Principle
- AGENTS.md Drift Stop Protocol
- AGENTS.md 開発前作戦図 Gate
- AGENTS.md Evidence Discipline
- docs/butler/execution-queue-contract.md

## Out-of-scope but NOT implemented

- bridge restart 実行
- deploy 実行
- PWA notification 未達の修正
- #741 lifecycle guard / restart recovery の根本対応
- Issue #590 全体の close-readiness

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #590
- Execution ID: dashboard-butler-issue-590-muted-bridge-lifecycle-2026-06-05
- Goal: Dashboard Butler PWA の bridge lifecycle progress を通常 Butler checkpoint より控えめに表示する。
