### PR TITLE
Issue #613 repo-less media scope regression

### DIFF
--- a/docs/development-strategy/issue-613-repoless-media-scope.md
+++ b/docs/development-strategy/issue-613-repoless-media-scope.md
@@ -1,0 +1,64 @@
+# Issue #613 repo-less media scope regression strategy
+
+## 完了体験
+
+Owner が Dashboard Butler の repo-less main chat で画像を添付して送ると、画像は private unscoped media として保存され、同じ Dashboard thread の owner message に media reference として残る。URL や画面表示に `github.com/marushu` のような不完全な GitHub path が残っていても、それを `github.com/marushu` repository として扱わず、repo mismatch error を出さない。
+
+## VTDD 全体で進める部分
+
+この PR は #613 の single main chat 方針を壊さず、#498/#587 の media attachment path の repo-less private conversation case を復旧する。Butler の自然文から repo が必要になった時に repo を解決する設計は維持し、通常チャットの常設 repo 固定は復活させない。
+
+## 設計
+
+Dashboard の表示用 `repositoryInput` と、media upload / owner message validation に使う canonical repository scope を分離する。`github.com/marushu` は GitHub host path だが repository 名ではないため canonical repo として拒否する。一方、`https://github.com/marushu/vtdd-v2-p` や `github.com/marushu/vtdd-v2-p` のように owner/repo まである入力は `marushu/vtdd-v2-p` に正規化して扱えるようにする。
+
+## 仮説
+
+現在の `normalizeCanonicalRepositoryInput()` は `github.com/marushu` を `owner/repo` 形式として通してしまう。画像 upload は private unscoped として保存されるか、あるいは Dashboard form から raw `repositoryInput` が送信される。送信時 `resolveDashboardChatMediaReferences()` は message repository scope を `github.com/marushu` と見なし、media record の repository `null` と mismatch して `media reference ... does not belong to github.com/marushu` を返す。
+
+## 検証計画
+
+`/v2/dashboard/chat/messages` に `repository: "github.com/marushu"` と unscoped private media reference を送っても 202 で保存される regression test を追加する。Dashboard HTML に `repository=github.com/marushu` があっても composer の `data-repository-input` は空で、表示ラベルだけが `この作業: github.com/marushu` のまま残ることを確認する。worker build 後に generated worker check と worker test を通す。
+
+## 改修見積もり
+
+- `src/worker/runtime.js`: `normalizeCanonicalRepositoryInput()`。GitHub URL / host path を owner/repo に変換し、不完全な `github.com/owner` と host-like owner を拒否する。リスクは既存の owner segment 許容範囲が変わること。
+- `src/worker/runtime.js`: `renderV2DashboardPage()`。表示用 input と canonical scope を分け、form / repo-bound links / latest deploy lookup は canonical scope を使う。リスクは非 canonical 表示文字列で operations link が無効化されることだが、repo-less main chat 方針では望ましい。
+- `test/worker.test.js`: repo-less private media と incomplete GitHub path の regression test、Dashboard form scope test を追加する。リスクは fixture の Dashboard HTML 断片に依存しすぎること。
+- `worker.js`: generated worker を build で更新する。リスクは生成物差分が大きく見えること。
+
+## 既に通っている経路
+
+Private unscoped media upload は `repositoryInput: "未指定"` で許可されている。Canonical repo media reference は `marushu/vtdd-v2-p` で chat message に保存できる。Issue mismatch は既存 test で拒否される。
+
+## 未確認の境界
+
+実 production の該当 media record が `repository: null` だったか、upload 自体が 422/413 で落ちたかは runtime store を直接読んでいない。スクリーンショット上の error text は送信時 media validation の repository mismatch と一致する。
+
+## 穴が出そうな箇所
+
+Dashboard URL に古い `repositoryInput` が残る場合、表示上は「この作業: github.com/marushu」と見える可能性がある。実行 scope は空にするが、owner-facing 表示の紛らわしさは残り得る。これは別 slice で「不完全 repo 表示を repo-less label に戻す」UI 判断として扱える。
+
+## PR 前に確認すること
+
+`git status --short --branch` で latest main 由来の topic branch であることを確認する。PR body は #613 follow-up として、#498/#587 related と明記し、`Closes` は書かない。deploy / app-server bridge restart は owner approval boundary の外なので、この PR 作成時点では実行しない。
+
+## 実装候補と捨てた案
+
+採用: canonical normalization を GitHub URL aware にし、Dashboard composer の実行 scope には canonical repo だけを入れる。
+
+捨てた案: `resolveDashboardChatMediaReferences()` で private unscoped media の repository mismatch を常に許可する。これは repo-bound private media の漏れを防ぐ境界を弱めるため不採用。
+
+捨てた案: media upload の repository を raw `github.com/marushu` で保存する。GitHub repository として無効な値を永続化するため不採用。
+
+## merge 後に通す E2E
+
+本番 deploy 後、Dashboard Butler repo-less main chat で画像を添付して送信し、送信前の添付表示、owner message 保存、Butler/app-server 応答、media reference download が同じ thread で確認できることを iPad/iPhone で見る。
+
+## 次の PR を増やさない理由
+
+`github.com/marushu` 誤認と form の raw scope 送信は同じ root cause であり、どちらか一方だけだと再発する。media validation 緩和や UI redesign は含めないため、PR はこの regression slice に収まる。
+
+## 停止条件
+
+Canonical repository normalization の変更が approval / deploy / GitHub App route の既存 tests を広範囲に壊す場合は停止し、repo parser の共有契約を別 Issue/PR に切り出す。Public/evidence media の repository boundary を緩める必要が出た場合も停止する。

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -8559,10 +8559,32 @@ async function handleRepositoryNicknameDeleteRequest(request, env) {
 
 function normalizeCanonicalRepositoryInput(value) {
   const text = normalizeText(value).toLowerCase();
-  if (!/^[a-z0-9_.-]+\/[a-z0-9_.-]+$/.test(text)) {
+  if (!text) {
     return "";
   }
-  return text;
+  const githubPathMatch = text.match(/^(?:https?:\/\/)?github\.com\/([^/\s?#]+)\/([^/\s?#]+)/);
+  if (githubPathMatch) {
+    return normalizeCanonicalRepositoryInput(`${githubPathMatch[1]}/${githubPathMatch[2]}`);
+  }
+  if (/^(?:https?:\/\/)?github\.com\/[^/\s?#]+\/?$/.test(text)) {
+    return "";
+  }
+  if (!/^[a-z0-9-]+\/[a-z0-9_.-]+$/.test(text)) {
+    return "";
+  }
+  const [owner, repository] = text.split("/");
+  if (
+    owner === "github.com" ||
+    owner.startsWith("github.") ||
+    owner.startsWith("-") ||
+    owner.endsWith("-") ||
+    owner.length > 39 ||
+    repository === "." ||
+    repository === ".."
+  ) {
+    return "";
+  }
+  return `${owner}/${repository}`;
 }
 
 async function handlePasskeyRegistrationOptionsRequest(request, env) {
@@ -15985,13 +16007,14 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
   );
   const dashboardIssueNumber = normalizePositiveInteger(url?.searchParams?.get("issueNumber"));
   const requestedChatThreadId = normalizeDashboardSingleMainChatThreadId(url?.searchParams?.get("threadId") || url?.searchParams?.get("thread_id"));
+  const canonicalRepositoryInput = normalizeCanonicalRepositoryInput(repositoryInput);
   const dashboardTargetLabel = repositoryInput ? `この作業: ${repositoryInput}` : "repo-less main chat";
   const targetStatusMarkup = repositoryInput
     ? `<p><strong>${escapeDashboardHtml(repositoryInput)}</strong></p>
           <p class="muted">固定ではありません。この会話で Issue / PR / deploy など repo が必要な作業をする間だけ対象にします。deploy 先と承認境界は repo ごとに確認します。</p>`
     : `<p><strong>repo-less main chat</strong></p>
           <p class="muted">ここが通常のメインチャットです。repo は常設設定ではなく、Issue / PR / deploy など repo 境界が必要になった時だけ Butler が会話の中で確認します。VTDD と TOMIO では deploy 先も承認境界も別物として扱います。</p>`;
-  const encodedRepository = encodeURIComponent(repositoryInput);
+  const encodedRepository = encodeURIComponent(canonicalRepositoryInput);
   const chatThreadId = requestedChatThreadId;
   const socketOrigin = origin.replace(/^http/i, "ws");
   const currentDashboardReturnPath = withDashboardReturnThreadId(
@@ -16002,7 +16025,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
   const latestDeployEvent = await retrieveLatestDashboardEvent({
     store: dashboardEventStore,
     kind: "github_actions_workflow_run",
-    repository: normalizeCanonicalRepositoryInput(repositoryInput),
+    repository: canonicalRepositoryInput,
     workflowName: "deploy-production"
   });
   const surfaces = [
@@ -16014,25 +16037,25 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
     {
       title: "Startup preflight",
       body: "AGENTS.md、thread-independent startup、runtime truth、RAG、self parity を最初に読む入口。",
-      href: repositoryInput ? `${origin}/dashboard/preflight?repository=${encodedRepository}` : "",
+      href: canonicalRepositoryInput ? `${origin}/dashboard/preflight?repository=${encodedRepository}` : "",
       disabledReason: "repo 設定後に開けます"
     },
     {
       title: "Execution progress",
       body: "VPS Codex CLI / remote Codex execution の進捗確認。",
-      href: repositoryInput ? `${origin}/dashboard/progress?repository=${encodedRepository}` : "",
+      href: canonicalRepositoryInput ? `${origin}/dashboard/progress?repository=${encodedRepository}` : "",
       disabledReason: "repo 設定後に開けます"
     },
     {
       title: "VPS runner status",
       body: "runner health、queue、対象 execution の状態確認。",
-      href: repositoryInput ? `${origin}/dashboard/vps-runner?repository=${encodedRepository}` : "",
+      href: canonicalRepositoryInput ? `${origin}/dashboard/vps-runner?repository=${encodedRepository}` : "",
       disabledReason: "repo 設定後に開けます"
     },
     {
       title: "GitHub runtime truth",
       body: "Issues、PRs、checks、workflow runs、reviewer comments を読む入口。",
-      href: repositoryInput ? `${origin}/dashboard/github?repository=${encodedRepository}` : "",
+      href: canonicalRepositoryInput ? `${origin}/dashboard/github?repository=${encodedRepository}` : "",
       disabledReason: "repo 設定後に開けます"
     },
     {
@@ -16048,25 +16071,25 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
     {
       title: "Operational RAG",
       body: "decision / proposal / working memory の compact retrieval。runtime truth の代替ではない。",
-      href: repositoryInput ? `${origin}/dashboard/memory?repository=${encodedRepository}` : "",
+      href: canonicalRepositoryInput ? `${origin}/dashboard/memory?repository=${encodedRepository}` : "",
       disabledReason: "repo 設定後に開けます"
     },
     {
       title: "Self parity",
       body: "Action Schema、Instructions、Cloudflare deploy freshness、operator URL を確認。",
-      href: repositoryInput ? `${origin}/dashboard/self-parity?repository=${encodedRepository}` : "",
+      href: canonicalRepositoryInput ? `${origin}/dashboard/self-parity?repository=${encodedRepository}` : "",
       disabledReason: "repo 設定後に開けます"
     },
     {
       title: "Setup diagnostics",
       body: "Butler / Custom GPT / deploy drift の診断ページ。",
-      href: repositoryInput ? `${origin}/setup/diagnostics?repository=${encodedRepository}` : "",
+      href: canonicalRepositoryInput ? `${origin}/setup/diagnostics?repository=${encodedRepository}` : "",
       disabledReason: "repo 設定後に開けます"
     },
     {
       title: "本番反映 / Passkey 承認",
       body: "production deploy はこの作業の対象 repo と deploy 先を確認してから、scope 明示済み passkey approval の後ろで開きます。",
-      href: repositoryInput
+      href: canonicalRepositoryInput
         ? `${origin}/v2/approval/passkey/operator?repositoryInput=${encodedRepository}&phase=execution&actionType=deploy_production&highRiskKind=deploy_production`
         : "",
       disabledReason: "repo 設定後に開けます"
@@ -16089,12 +16112,12 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
     },
     {
       label: "進捗を見る",
-      href: repositoryInput ? `${origin}/dashboard/progress?repository=${encodedRepository}` : "",
+      href: canonicalRepositoryInput ? `${origin}/dashboard/progress?repository=${encodedRepository}` : "",
       disabledReason: "repo 設定後"
     },
     {
       label: "GitHub状況",
-      href: repositoryInput ? `${origin}/dashboard/github?repository=${encodedRepository}` : "",
+      href: canonicalRepositoryInput ? `${origin}/dashboard/github?repository=${encodedRepository}` : "",
       disabledReason: "repo 設定後"
     }
   ];
@@ -16454,7 +16477,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
 
       </div>
 
-      <form class="composer" id="butler-chat-form" aria-label="Butler composer" autocomplete="off" data-socket-endpoint="${escapeDashboardHtml(socketOrigin)}/v2/dashboard/chat/${escapeDashboardHtml(chatThreadId)}/ws" data-thread-endpoint="${escapeDashboardHtml(origin)}/v2/dashboard/chat/${escapeDashboardHtml(chatThreadId)}" data-thread-id="${escapeDashboardHtml(chatThreadId)}" data-repository-input="${escapeDashboardHtml(repositoryInput)}" data-issue-number="${dashboardIssueNumber || ""}">
+      <form class="composer" id="butler-chat-form" aria-label="Butler composer" autocomplete="off" data-socket-endpoint="${escapeDashboardHtml(socketOrigin)}/v2/dashboard/chat/${escapeDashboardHtml(chatThreadId)}/ws" data-thread-endpoint="${escapeDashboardHtml(origin)}/v2/dashboard/chat/${escapeDashboardHtml(chatThreadId)}" data-thread-id="${escapeDashboardHtml(chatThreadId)}" data-repository-input="${escapeDashboardHtml(canonicalRepositoryInput)}" data-issue-number="${dashboardIssueNumber || ""}">
         <div class="pending-media" id="butler-pending-media" aria-live="polite"></div>
         <div class="composer-progress" id="butler-transient-progress" aria-live="polite" hidden>
           <span class="progress-title">進行中</span>

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -930,6 +930,22 @@ test("worker preserves dashboard repository context across auth fallback links",
   assert.equal(body.includes("repositoryInput="), false);
 });
 
+test("worker does not use incomplete github.com owner path as dashboard composer repository scope", async () => {
+  const response = await worker.fetch(
+    new Request("https://example.com/dashboard?repository=github.com%2Fmarushu", {
+      headers: dashboardAccessHeaders
+    }),
+    dashboardAccessEnv
+  );
+
+  assert.equal(response.status, 200);
+  const body = await response.text();
+  assert.equal(body.includes("この作業: github.com/marushu"), true);
+  assert.equal(body.includes('data-repository-input="github.com/marushu"'), false);
+  assert.equal(body.includes('data-repository-input=""'), true);
+  assert.equal(body.includes("/dashboard/progress?repository=github.com%2Fmarushu"), false);
+});
+
 test("worker preserves dashboard thread context across auth fallback links", async () => {
   const response = await worker.fetch(
     new Request("https://example.com/dashboard?threadId=dashboard-main-unresolved&runId=private-run")
@@ -2730,6 +2746,47 @@ test("worker stores dashboard media references in chat without raw binary", asyn
   assert.equal(body.messages[0].mediaReferences[0].contentType, "image/png");
   assert.equal(body.messages[0].mediaReferences[0].downloadUrl, "/v2/media/med_testmedia1234/download");
   assert.equal(JSON.stringify(body).includes("fake image bytes"), false);
+});
+
+test("worker accepts repo-less private chat media when dashboard url carried incomplete github owner path", async () => {
+  const store = createInMemoryDashboardChatStore();
+  const mediaStore = createInMemoryMediaObjectStore();
+  await mediaStore.put({
+    id: "med_repolessgithubpath",
+    repository: null,
+    relatedIssue: null,
+    sourceSurface: "dashboard_butler",
+    objectKey: "media/_dashboard/unscoped/2026/06/05/med_repolessgithubpath/dashboard.png",
+    filename: "dashboard.png",
+    contentType: "image/png",
+    byteSize: 16,
+    sha256: "0123456789abcdef",
+    visibility: "private",
+    createdAt: "2026-06-05T00:00:00.000Z",
+    updatedAt: "2026-06-05T00:00:00.000Z",
+    expiresAt: "2999-01-01T00:00:00.000Z"
+  });
+
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/dashboard/chat/messages", {
+      method: "POST",
+      headers: { ...dashboardAccessHeaders, "content-type": "application/json" },
+      body: JSON.stringify({
+        threadId: "dashboard-main-unresolved",
+        repository: "github.com/marushu",
+        text: "画像添付で確認",
+        mediaReferences: [{ mediaId: "med_repolessgithubpath" }]
+      })
+    }),
+    { ...dashboardAccessEnv, DASHBOARD_CHAT_STORE: store, MEDIA_OBJECT_STORE: mediaStore }
+  );
+
+  assert.equal(response.status, 202);
+  const body = await response.json();
+  assert.equal(body.messages[0].repository || "", "");
+  assert.equal(body.messages[0].mediaReferences.length, 1);
+  assert.equal(body.messages[0].mediaReferences[0].mediaId, "med_repolessgithubpath");
+  assert.equal(JSON.stringify(body).includes("does not belong to github.com/marushu"), false);
 });
 
 test("worker rejects chat media references outside the repository or issue context", async () => {

--- a/worker.js
+++ b/worker.js
@@ -65512,10 +65512,24 @@ async function handleRepositoryNicknameDeleteRequest(request, env) {
 }
 function normalizeCanonicalRepositoryInput(value) {
   const text = normalizeText33(value).toLowerCase();
-  if (!/^[a-z0-9_.-]+\/[a-z0-9_.-]+$/.test(text)) {
+  if (!text) {
     return "";
   }
-  return text;
+  const githubPathMatch = text.match(/^(?:https?:\/\/)?github\.com\/([^/\s?#]+)\/([^/\s?#]+)/);
+  if (githubPathMatch) {
+    return normalizeCanonicalRepositoryInput(`${githubPathMatch[1]}/${githubPathMatch[2]}`);
+  }
+  if (/^(?:https?:\/\/)?github\.com\/[^/\s?#]+\/?$/.test(text)) {
+    return "";
+  }
+  if (!/^[a-z0-9-]+\/[a-z0-9_.-]+$/.test(text)) {
+    return "";
+  }
+  const [owner, repository] = text.split("/");
+  if (owner === "github.com" || owner.startsWith("github.") || owner.startsWith("-") || owner.endsWith("-") || owner.length > 39 || repository === "." || repository === "..") {
+    return "";
+  }
+  return `${owner}/${repository}`;
 }
 async function handlePasskeyRegistrationOptionsRequest(request, env) {
   const provider = resolveMemoryProvider(env);
@@ -72116,11 +72130,12 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
   );
   const dashboardIssueNumber = normalizePositiveInteger10(url?.searchParams?.get("issueNumber"));
   const requestedChatThreadId = normalizeDashboardSingleMainChatThreadId(url?.searchParams?.get("threadId") || url?.searchParams?.get("thread_id"));
+  const canonicalRepositoryInput = normalizeCanonicalRepositoryInput(repositoryInput);
   const dashboardTargetLabel = repositoryInput ? `\u3053\u306E\u4F5C\u696D: ${repositoryInput}` : "repo-less main chat";
   const targetStatusMarkup = repositoryInput ? `<p><strong>${escapeDashboardHtml(repositoryInput)}</strong></p>
           <p class="muted">\u56FA\u5B9A\u3067\u306F\u3042\u308A\u307E\u305B\u3093\u3002\u3053\u306E\u4F1A\u8A71\u3067 Issue / PR / deploy \u306A\u3069 repo \u304C\u5FC5\u8981\u306A\u4F5C\u696D\u3092\u3059\u308B\u9593\u3060\u3051\u5BFE\u8C61\u306B\u3057\u307E\u3059\u3002deploy \u5148\u3068\u627F\u8A8D\u5883\u754C\u306F repo \u3054\u3068\u306B\u78BA\u8A8D\u3057\u307E\u3059\u3002</p>` : `<p><strong>repo-less main chat</strong></p>
           <p class="muted">\u3053\u3053\u304C\u901A\u5E38\u306E\u30E1\u30A4\u30F3\u30C1\u30E3\u30C3\u30C8\u3067\u3059\u3002repo \u306F\u5E38\u8A2D\u8A2D\u5B9A\u3067\u306F\u306A\u304F\u3001Issue / PR / deploy \u306A\u3069 repo \u5883\u754C\u304C\u5FC5\u8981\u306B\u306A\u3063\u305F\u6642\u3060\u3051 Butler \u304C\u4F1A\u8A71\u306E\u4E2D\u3067\u78BA\u8A8D\u3057\u307E\u3059\u3002VTDD \u3068 TOMIO \u3067\u306F deploy \u5148\u3082\u627F\u8A8D\u5883\u754C\u3082\u5225\u7269\u3068\u3057\u3066\u6271\u3044\u307E\u3059\u3002</p>`;
-  const encodedRepository = encodeURIComponent(repositoryInput);
+  const encodedRepository = encodeURIComponent(canonicalRepositoryInput);
   const chatThreadId = requestedChatThreadId;
   const socketOrigin = origin.replace(/^http/i, "ws");
   const currentDashboardReturnPath = withDashboardReturnThreadId(
@@ -72131,7 +72146,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
   const latestDeployEvent = await retrieveLatestDashboardEvent({
     store: dashboardEventStore,
     kind: "github_actions_workflow_run",
-    repository: normalizeCanonicalRepositoryInput(repositoryInput),
+    repository: canonicalRepositoryInput,
     workflowName: "deploy-production"
   });
   const surfaces = [
@@ -72143,25 +72158,25 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
     {
       title: "Startup preflight",
       body: "AGENTS.md\u3001thread-independent startup\u3001runtime truth\u3001RAG\u3001self parity \u3092\u6700\u521D\u306B\u8AAD\u3080\u5165\u53E3\u3002",
-      href: repositoryInput ? `${origin}/dashboard/preflight?repository=${encodedRepository}` : "",
+      href: canonicalRepositoryInput ? `${origin}/dashboard/preflight?repository=${encodedRepository}` : "",
       disabledReason: "repo \u8A2D\u5B9A\u5F8C\u306B\u958B\u3051\u307E\u3059"
     },
     {
       title: "Execution progress",
       body: "VPS Codex CLI / remote Codex execution \u306E\u9032\u6357\u78BA\u8A8D\u3002",
-      href: repositoryInput ? `${origin}/dashboard/progress?repository=${encodedRepository}` : "",
+      href: canonicalRepositoryInput ? `${origin}/dashboard/progress?repository=${encodedRepository}` : "",
       disabledReason: "repo \u8A2D\u5B9A\u5F8C\u306B\u958B\u3051\u307E\u3059"
     },
     {
       title: "VPS runner status",
       body: "runner health\u3001queue\u3001\u5BFE\u8C61 execution \u306E\u72B6\u614B\u78BA\u8A8D\u3002",
-      href: repositoryInput ? `${origin}/dashboard/vps-runner?repository=${encodedRepository}` : "",
+      href: canonicalRepositoryInput ? `${origin}/dashboard/vps-runner?repository=${encodedRepository}` : "",
       disabledReason: "repo \u8A2D\u5B9A\u5F8C\u306B\u958B\u3051\u307E\u3059"
     },
     {
       title: "GitHub runtime truth",
       body: "Issues\u3001PRs\u3001checks\u3001workflow runs\u3001reviewer comments \u3092\u8AAD\u3080\u5165\u53E3\u3002",
-      href: repositoryInput ? `${origin}/dashboard/github?repository=${encodedRepository}` : "",
+      href: canonicalRepositoryInput ? `${origin}/dashboard/github?repository=${encodedRepository}` : "",
       disabledReason: "repo \u8A2D\u5B9A\u5F8C\u306B\u958B\u3051\u307E\u3059"
     },
     {
@@ -72177,25 +72192,25 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
     {
       title: "Operational RAG",
       body: "decision / proposal / working memory \u306E compact retrieval\u3002runtime truth \u306E\u4EE3\u66FF\u3067\u306F\u306A\u3044\u3002",
-      href: repositoryInput ? `${origin}/dashboard/memory?repository=${encodedRepository}` : "",
+      href: canonicalRepositoryInput ? `${origin}/dashboard/memory?repository=${encodedRepository}` : "",
       disabledReason: "repo \u8A2D\u5B9A\u5F8C\u306B\u958B\u3051\u307E\u3059"
     },
     {
       title: "Self parity",
       body: "Action Schema\u3001Instructions\u3001Cloudflare deploy freshness\u3001operator URL \u3092\u78BA\u8A8D\u3002",
-      href: repositoryInput ? `${origin}/dashboard/self-parity?repository=${encodedRepository}` : "",
+      href: canonicalRepositoryInput ? `${origin}/dashboard/self-parity?repository=${encodedRepository}` : "",
       disabledReason: "repo \u8A2D\u5B9A\u5F8C\u306B\u958B\u3051\u307E\u3059"
     },
     {
       title: "Setup diagnostics",
       body: "Butler / Custom GPT / deploy drift \u306E\u8A3A\u65AD\u30DA\u30FC\u30B8\u3002",
-      href: repositoryInput ? `${origin}/setup/diagnostics?repository=${encodedRepository}` : "",
+      href: canonicalRepositoryInput ? `${origin}/setup/diagnostics?repository=${encodedRepository}` : "",
       disabledReason: "repo \u8A2D\u5B9A\u5F8C\u306B\u958B\u3051\u307E\u3059"
     },
     {
       title: "\u672C\u756A\u53CD\u6620 / Passkey \u627F\u8A8D",
       body: "production deploy \u306F\u3053\u306E\u4F5C\u696D\u306E\u5BFE\u8C61 repo \u3068 deploy \u5148\u3092\u78BA\u8A8D\u3057\u3066\u304B\u3089\u3001scope \u660E\u793A\u6E08\u307F passkey approval \u306E\u5F8C\u308D\u3067\u958B\u304D\u307E\u3059\u3002",
-      href: repositoryInput ? `${origin}/v2/approval/passkey/operator?repositoryInput=${encodedRepository}&phase=execution&actionType=deploy_production&highRiskKind=deploy_production` : "",
+      href: canonicalRepositoryInput ? `${origin}/v2/approval/passkey/operator?repositoryInput=${encodedRepository}&phase=execution&actionType=deploy_production&highRiskKind=deploy_production` : "",
       disabledReason: "repo \u8A2D\u5B9A\u5F8C\u306B\u958B\u3051\u307E\u3059"
     }
   ];
@@ -72216,12 +72231,12 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
     },
     {
       label: "\u9032\u6357\u3092\u898B\u308B",
-      href: repositoryInput ? `${origin}/dashboard/progress?repository=${encodedRepository}` : "",
+      href: canonicalRepositoryInput ? `${origin}/dashboard/progress?repository=${encodedRepository}` : "",
       disabledReason: "repo \u8A2D\u5B9A\u5F8C"
     },
     {
       label: "GitHub\u72B6\u6CC1",
-      href: repositoryInput ? `${origin}/dashboard/github?repository=${encodedRepository}` : "",
+      href: canonicalRepositoryInput ? `${origin}/dashboard/github?repository=${encodedRepository}` : "",
       disabledReason: "repo \u8A2D\u5B9A\u5F8C"
     }
   ];
@@ -72568,7 +72583,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
 
       </div>
 
-      <form class="composer" id="butler-chat-form" aria-label="Butler composer" autocomplete="off" data-socket-endpoint="${escapeDashboardHtml(socketOrigin)}/v2/dashboard/chat/${escapeDashboardHtml(chatThreadId)}/ws" data-thread-endpoint="${escapeDashboardHtml(origin)}/v2/dashboard/chat/${escapeDashboardHtml(chatThreadId)}" data-thread-id="${escapeDashboardHtml(chatThreadId)}" data-repository-input="${escapeDashboardHtml(repositoryInput)}" data-issue-number="${dashboardIssueNumber || ""}">
+      <form class="composer" id="butler-chat-form" aria-label="Butler composer" autocomplete="off" data-socket-endpoint="${escapeDashboardHtml(socketOrigin)}/v2/dashboard/chat/${escapeDashboardHtml(chatThreadId)}/ws" data-thread-endpoint="${escapeDashboardHtml(origin)}/v2/dashboard/chat/${escapeDashboardHtml(chatThreadId)}" data-thread-id="${escapeDashboardHtml(chatThreadId)}" data-repository-input="${escapeDashboardHtml(canonicalRepositoryInput)}" data-issue-number="${dashboardIssueNumber || ""}">
         <div class="pending-media" id="butler-pending-media" aria-live="polite"></div>
         <div class="composer-progress" id="butler-transient-progress" aria-live="polite" hidden>
           <span class="progress-title">\u9032\u884C\u4E2D</span>


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #613 の repo-less main chat 方針を維持しながら、画像添付時に `github.com/marushu` のような不完全な GitHub path が repository scope として誤採用される回帰を修正します。
- 関連 Issue #498 / #587 の media attachment path について、repo-less private conversation media が通常チャットに添付できることを local runtime test で固定します。

## Satisfied Success Criteria

- Dashboard composer は表示用 `repositoryInput` と送信/運用に使う canonical repository scope を分離します。
- `github.com/marushu` は canonical repository として扱わず、repo-less private media reference を `does not belong to github.com/marushu` で拒否しません。
- `github.com/marushu/vtdd-v2-p` や `https://github.com/marushu/vtdd-v2-p` は canonical `marushu/vtdd-v2-p` として扱えるようにします。
- `src/worker/runtime.js` 変更後に generated `worker.js` を更新しました。

## Unsatisfied Success Criteria

- Production deploy 後の iPhone/iPad Dashboard Butler live E2E はこのPR作成時点では未実施です。
- 既に production D1/R2 に残った過去の失敗 media record の個別復旧はこのPRでは扱っていません。

## Non-goal violations

None.

## 開発前作戦図

- 作戦図 evidence: `docs/development-strategy/issue-613-repoless-media-scope.md`
- 完了体験: Owner が repo-less main chat で画像を添付して送ると、private unscoped media として保存され、同じ Dashboard thread の owner message に media reference として残る。
- VTDD 全体で進める部分: #613 の single main chat 方針を維持しつつ、#498/#587 の画像添付経路を repo-less private conversation case で復旧する。
- 設計: Dashboard の表示用 repository text と canonical execution scope を分離し、不完全な GitHub host path を repository として扱わない。
- 仮説: 原因は `normalizeCanonicalRepositoryInput()` が `github.com/marushu` を owner/repo として受け入れ、media validation が repo-less private media を repository mismatch で拒否していたことだと疑った。
- 検証計画: Dashboard HTML の form scope test と `/v2/dashboard/chat/messages` の media reference regression test を追加し、worker build / generated check / full test を通す。
- 改修見積もり: `src/worker/runtime.js` の repository normalization と Dashboard form data scope、`test/worker.test.js` の regression tests、generated `worker.js`。
- 既に通っている経路: Private unscoped media upload、canonical repo media reference、issue mismatch reject は既存 tests で通っている。
- 未確認の境界: production の該当 media record が upload 失敗か send validation 失敗かは runtime store 直読み未実施。スクリーンショットの error は send validation mismatch と一致する。
- 穴が出そうな箇所: 表示ラベルに不完全 repo text が残ると owner には紛らわしい可能性がある。実行 scope は空にして事故を止める。
- PR 前に確認すること: latest `origin/main` 由来の topic branch、#613 follow-up として PR 作成、deploy/restart はこのPRでは実行しない。
- 実装候補と捨てた案: 採用は canonical parser と form scope 分離。private unscoped media の mismatch を全面許可する案は境界を弱めるため不採用。
- merge 後に通す E2E: production deploy 後に Dashboard Butler repo-less main chat で画像添付、送信、media reference download、Butler/app-server 応答を iPhone/iPad live E2E test として検証する。
- 次の PR を増やさない理由: `github.com/marushu` 誤認と form raw scope 送信は同じ root cause で、片方だけでは再発する。
- 停止条件: repository normalization 変更が approval / deploy / GitHub App route の広範囲 test を壊す場合、または public/evidence media の repository boundary 緩和が必要になる場合。

## Dry-run Impact Report

- Target Issue: Issue #613 follow-up。関連 Issue #498 / #587。
- Implementing Success Criteria: repo-less main chat の画像添付で、不完全 GitHub path を repository scope として扱わず private unscoped media reference を保存できる。
- Explicit Non-goals: public/evidence media の repo 必須条件緩和、既存 media record mutation、deploy / app-server bridge restart、Custom GPT Action Schema 更新。
- Expected touched files/routes/workflows: `docs/development-strategy/issue-613-repoless-media-scope.md`, `src/worker/runtime.js`, `test/worker.test.js`, generated `worker.js`。Routes は `/dashboard` と `/v2/dashboard/chat/messages`。
- Affected Issues: #613, #498, #587。Active Issues はこのPRで縮小しません。
- Affected PRs: PR #792 の single main chat 後続回帰修正です。既存 merged PR には追加 push していません。
- Affected workflows: GitHub Actions workflow 自体は未変更。`deploy-production` は merge 後の自動 deploy 対象です。
- Affected runtime/operator surfaces: Dashboard Butler chat shell、Dashboard media upload/send validation、repo-bound dashboard operation links。
- What may break if we patch narrowly: parser だけ直すと Dashboard form が raw scope を送り続ける可能性が残り、form だけ直すと API 直送や WebSocket payload で再発します。
- Unknowns to investigate before coding: production store の該当 media record 実体は未確認。修正は screenshot error と local reproduction に基づく。
- Validation needed: focused regression、worker build、generated-worker check、worker test、full `npm test`。
- Stop condition: high-risk approval boundary や public media repository boundary を変更しないと通せない場合は停止。

## Execution Queue Delta

- Queue position before: Issue #613 の single main chat は PR #792 で merged 済みだが、owner が画像添付で runtime regression を報告したため follow-up ROOT slice として扱います。
- Preemption decision: ROOT。通常の次タスクより、Dashboard Butler の iPhone/iPad 証跡共有が塞がる添付回帰を優先します。
- Queue delta: Issue #613 follow-up として repo-less media scope regression を修正します。Production live E2E は merge/deploy 後に残ります。
- Why this PR is next: 画像添付が失敗すると Butler Completion Gate の evidence sharing が成立せず、owner が Mac Codex 側に戻されます。
- Active Issues not downscoped: Active Issues は縮小しません。このPRで扱わない active Issue は未完了のまま残します。

## File / Line Hypotheses

- file: `src/worker/runtime.js`
  - hypothesis: `normalizeCanonicalRepositoryInput()` が `github.com/marushu` を canonical owner/repo と誤認している。
  - risk if changed narrowly: parser だけでは Dashboard form が raw repository text を送り続ける。
  - validation: incomplete GitHub path の media reference API test と Dashboard HTML form scope test。
  - related Issue: #613, #498, #587。
- file: `test/worker.test.js`
  - hypothesis: repo-less private media と incomplete GitHub owner path の組み合わせを固定する regression test がなかった。
  - risk if changed narrowly: 将来の single main chat / media UI 変更で同じ mismatch が再発する。
  - validation: focused test と full `npm test`。
  - related Issue: #613, #498, #587。

## Hypothesis Retrospective

- expected: `github.com/marushu` を canonical repo として拒否し、Dashboard composer の `data-repository-input` を空にすれば repo-less private media が通る。
- actual: focused regression と full `npm test` が通り、`does not belong to github.com/marushu` を再発させない local evidence を得た。
- mismatch: production live E2E は未実施。表示ラベルには不完全 repo text が残るため、必要なら別 UI slice で repo-less label に寄せる。
- lesson: 表示用 repository text と execution/media validation scope は同じフィールドに置かない。
- should become RAG candidate: はい。single main chat の repo-less media scope 回帰として working_memory 候補。

## Verification Evidence

- Unit: `node --test --test-name-pattern 'incomplete github|repo-less private chat media|dashboard media references|outside the repository' test/worker.test.js` passed。
- Integration: `node --test test/worker.test.js` passed。`npm run build:worker` passed。`npm run check:generated-worker` passed。
- E2E: Production iPhone/iPad live E2E は未実施。
- Manual: スクリーンショットの `media reference ... does not belong to github.com/marushu` と一致する local regression path を test 化。
- Evidence path/link: `docs/development-strategy/issue-613-repoless-media-scope.md`, `test/worker.test.js`

## Butler Completion Contract

- Primary owner surface: Dashboard Butler。
- Fallback surface: Custom GPT は fallback surface です。主経路ではありません。
- Owner goal: Dashboard Butler repo-less main chat で画像添付を通常会話として送れる状態に戻す。
- Butler entrypoint: `/dashboard` の通常 chat shell。
- Dashboard Butler natural-language path: Dashboard Butler の通常チャット入口経路で、Owner は自然文と画像添付を送る。repo は常設設定せず、必要時だけ会話内で解決する。
- Action Schema exposure: 未変更。Custom GPT Action Schema は fallback であり主経路ではない。
- Runtime path: `/dashboard` form scope -> `/v2/media/upload` private unscoped media -> DashboardChatRoom / `/v2/dashboard/chat/messages` media validation。
- Runner/runtime truth: Local Worker test と generated worker check は通過。Production runtime truth は merge/deploy 後に確認が必要。
- Authority boundary: 未変更。deploy / credential / permission mutation はこのPRでは実行していません。
- E2E evidence: Production iPhone/iPad live E2E は未実施のため incomplete。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: merge 後に通常の deploy-production 対象。PR 作成時点では未実行。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 必要。merge/deploy 後に repo-less main chat で画像添付を確認する。

## Related Constitution Rules

- Butler は context-first。
- No default repository。
- Unresolved target blocks execution。
- High-risk actions require scoped passkey approval。
- Public/evidence media の repository boundary を緩めない。

## Out-of-scope but NOT implemented

- 既存 production media record の補修。
- 不完全 repo 表示ラベルを repo-less 表示へ戻す UI polish。
- deploy / app-server bridge restart の手動実行。

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #613
- Execution ID: local-codex-issue-613-repoless-media-scope-20260605
- Goal: Dashboard Butler repo-less main chat の画像添付 media scope regression を修正する。
