### PR TITLE
Issue #806 VPS Codex CLI の制御用 checkout を main 固定にする

### DIFF
--- a/.vtdd/pr-body-issue-806-control-plane-dev-worktree-candidate.md
+++ b/.vtdd/pr-body-issue-806-control-plane-dev-worktree-candidate.md
@@ -1,0 +1,145 @@
+## This PR satisfies Intent
+
+- Issue #806 の「VPS Codex CLI の制御用 checkout は常に main に置き、開発作業は隔離された作業台で行う」方針を repo-backed contract と runner guard にします。
+- 既存 VPS runner は `VTDD_VPS_RUNNER_WORKDIR` 配下へ execution clone を作る設計なので、その経路を正式な dev workspace として扱い、control-plane checkout と重なる設定を runtime で block します。
+- 2026-06-05 の Issue #741 復旧で見えた「VPS 上の制御用 repo が作業 branch / dirty 状態に寄って Butler 復旧が不安定になる」事故の再発防止を狙います。
+
+## Satisfied Success Criteria
+
+- control-plane checkout status に `checkoutRole=control_plane` と main 固定 invariant を出します。
+- VPS runner execution workspace が control-plane repo 自身または配下にある場合、execution 開始前に `workspace_isolation_blocked` として止めます。
+- 通常の dev workspace は `workRoot/<repository>/<executionId>` として control-plane 外に作られることを unit / integration test で固定します。
+- Owner-facing の運用契約を `docs/butler/vps-control-plane-dev-worktree.md` に日本語で保存しました。
+
+## Unsatisfied Success Criteria
+
+- production VPS wrapper `/home/vtdd-runner/bin/vtdd-vps-runner-once` の実体確認・更新はこの PR では行っていません。
+- merge 後の live VPS 適用、app-server bridge restart、VPS runtime truth 取得はこの PR では未実施です。
+- workspace cleanup / janitor、複数並行 worktree の retention policy、外部サーバ deploy / backup / rollback は別 Issue 範囲です。
+
+## Non-goal violations
+
+None.
+
+## 開発前作戦図
+
+- 作戦図 evidence: docs/development-strategy/issue-806-vps-control-plane-dev-worktree.md
+- 完了体験: Owner は Dashboard Butler / VPS Codex CLI の runner / bridge / recovery / deploy helper が読む制御用 checkout は `origin/main` に固定され、開発 branch の dirty 状態で queue pickup が止まらないと確認できる。
+- VTDD 全体で進める部分: Issue #741 復旧で見つかった control-plane 汚染を Issue #806 の root slice として止める。SunabaEye 前段や外部サーバ deploy は後続。
+- 設計: Butler の復旧 surface を守るため、既存の `VTDD_VPS_RUNNER_WORKDIR` clone 経路を dev workspace として明示し、control-plane repo root と dev workspace が重なる設定を block する。
+- 仮説: 仮説として、既存 runner は execution clone を分離しているが、workRoot 誤設定や wrapper 側の checkout 運用で control-plane repo 汚染が起こりうる。
+- 検証計画: repo sync role、workspace isolation resolver、runVpsRunnerOnce の blocked event を unit / integration test で検証する。
+- 改修見積もり: `scripts/run-vps-runner.mjs` の workspace guard、`test/vps-runner-script.test.js` の focused tests、`docs/butler/vps-control-plane-dev-worktree.md` の契約文書。
+- 既に通っている経路: runner execution は workRoot 配下へ clone し、branch checkout / Codex / commit / push / PR 作成を行う。
+- 未確認の境界: VPS production wrapper は repo 外なので、この PR では passkey が必要な live mutation をしない。
+- 穴が出そうな箇所: `VTDD_VPS_RUNNER_WORKDIR` が control-plane 配下なら clone/test artifact が repo untracked として残る。
+- PR 前に確認すること: Issue #806 を読み、runner tests、full `npm test`、worker generated file 不要を確認する。
+- 実装候補と捨てた案: 採用は既存 workRoot clone の guard。永続 full clone pool と recovery helper 先行は scope が広がるため不採用。
+- merge 後に通す E2E: live VPS で control-plane checkout が main clean、workRoot が control-plane 外、queue pickup が通常通り進むことを runtime truth と E2E 検証に残す。
+- 次の PR を増やさない理由: この PR の範囲は runner guard / tests / docs で閉じ、予測できる不足は janitor と外部 deploy の後続 Issue として残すため、同じ scope の次 PR は増やさない。
+- 停止条件: production wrapper 更新、VPS file mutation、deploy、credential/SSH 設定変更が必要な場合は passkey 境界に分ける。
+
+## Dry-run Impact Report
+
+- Target Issue: Issue #806。
+- Implementing Success Criteria: VPS runner の control-plane checkout main 固定を runtime truth と workspace isolation guard で支える。
+- Explicit Non-goals: VPS live mutation、deploy、app-server bridge restart、workspace janitor、外部サーバ deploy / backup / rollback、SSH credential 設定。
+- Expected touched files/routes/workflows: `scripts/run-vps-runner.mjs`, `test/vps-runner-script.test.js`, `docs/butler/vps-control-plane-dev-worktree.md`, `docs/development-strategy/issue-806-vps-control-plane-dev-worktree.md`。
+- Affected Issues: Issue #806。関連文脈は Issue #741 / Issue #590 / Issue #637 だが、この PR はそれらを close しません。
+- Affected PRs: 新規 PR。既存 merged PR には push していません。
+- Affected workflows: GitHub Actions workflow 定義は未変更。
+- Affected runtime/operator surfaces: VPS runner queue pickup、runner progress event、Butler が読む VPS control-plane contract。
+- What may break if we patch narrowly: docs だけでは VPS 誤設定を防げず、guard だけでは owner/Butler が main 固定方針を再利用できない。
+- Unknowns to investigate before coding: production wrapper の `VTDD_VPS_RUNNER_WORKDIR` 実値と repo 外 script 内容は未確認。
+- Validation needed: focused runner tests、full runner script test、full `npm test`、`git diff --check`。
+- Stop condition: live VPS mutation や credential/permission 変更が必要になったら、この PR では停止。
+
+## Execution Queue Delta
+
+- Queue position before: docs queue の `Now` は Issue #590 系だったが、owner の「VPS Codex CLI は常に main であるべき」という指摘は Issue #741 復旧と Issue #590 / Issue #637 の Butler 復旧経路を塞ぐ ROOT blocker と判断しました。
+- Preemption decision: ROOT。control-plane checkout が作業 branch / dirty に寄ると、Butler だけで復旧する前提が崩れるため、通常 queue より先に最小 slice として Issue #806 を作成しました。
+- Queue delta: Issue #806 をこの PR の `Now` に移します。Issue #590 / Issue #637 / Issue #741 は縮小しません。control-plane 汚染防止後に継続します。
+- Why this PR is next: 制御用 repo が main clean でないと、bridge restart / recovery / runner pickup の信頼性が落ち、owner が Mac Codex に戻されます。
+- Active Issues not downscoped: Active Issues は縮小しません。この PR で扱わない active Issue は未完了のまま残します。
+
+## File / Line Hypotheses
+
+- file: `scripts/run-vps-runner.mjs`
+  - hypothesis: execution clone は分離済みだが、workRoot が control-plane repo と重なる設定を runtime が明示 block していない。
+  - risk if changed narrowly: preflight が止まった時に「制御面の汚染」か「開発作業失敗」か Butler が区別できない。
+  - validation: workspace resolver unit test と `runVpsRunnerOnce` blocked event integration test。
+  - related Issue: #806。
+- file: `test/vps-runner-script.test.js`
+  - hypothesis: control-plane role と workspace isolation の regression test がなかった。
+  - risk if changed narrowly: 将来の runner 変更で control-plane 配下 workRoot を許しても検出できない。
+  - validation: focused runner tests と full runner script test。
+  - related Issue: #806。
+- file: `docs/butler/vps-control-plane-dev-worktree.md`
+  - hypothesis: 会話で決まった main 固定方針を repo-backed にしないと、次の thread / Butler / VPS handoff で消える。
+  - risk if changed narrowly: 実装だけ残って運用判断が再び Mac Codex 依存になる。
+  - validation: PR body から strategy / contract を参照。
+  - related Issue: #806。
+
+## Hypothesis Retrospective
+
+- expected: 既存 runner は workRoot clone を使っており、最小修正は workspace isolation guard と docs/tests で足りる。
+- actual: `resolveVpsRunnerExecutionWorkspace()` を追加し、control-plane 配下 workRoot を execution 前に block できた。
+- mismatch: production wrapper の live 実値は未確認。merge 後の passkey 境界で確認が必要。
+- lesson: Butler / VPS の制御面は、開発対象 repo と同じ checkout を作業台にしてはいけない。
+- should become RAG candidate: はい。#806 の main 固定 / dev workspace 分離契約として working_memory 候補。
+
+## Verification Evidence
+
+- Unit: `node --test --test-name-pattern 'repo sync preflight|execution workspace|workRoot is inside|dry run reports selected' test/vps-runner-script.test.js` passed。
+- Integration: `node --test test/vps-runner-script.test.js` passed。
+- Full: `npm test` passed。
+- Static: `git diff --check` passed。
+- E2E: live VPS E2E は未実施。merge/deploy/passkey 境界の後続です。
+- Evidence path/link: `docs/development-strategy/issue-806-vps-control-plane-dev-worktree.md`, `docs/butler/vps-control-plane-dev-worktree.md`, `test/vps-runner-script.test.js`
+
+## Butler Completion Contract
+
+- Primary owner surface: Dashboard Butler。
+- Fallback surface: mac Codex は emergency / debug surface であり、通常運用の前提にはしない。
+- Owner goal: Butler / VPS Codex CLI の制御用 checkout を常に main clean に保ち、開発作業の branch / dirty 状態から切り離す。
+- Butler entrypoint: Dashboard Butler の通常チャット入口から VPS runner / recovery / bridge restart の runtime truth を読む経路。
+- Dashboard Butler natural-language path: Owner が Dashboard Butler の通常チャット入口で「VPS が詰まっている」「bridge を復旧して」などの自然文を送ると、Butler は control-plane status と workspace isolation truth へ到達して判断できる。
+- Action Schema exposure: この PR では未変更。
+- Runtime path: VPS runner script の queue pickup 前後、workspace resolution、progress event。
+- Runner/runtime truth: `checkoutRole=control_plane` と `workspace_isolation_blocked` を runner truth として出す。
+- Authority boundary: live VPS mutation / deploy / restart / credential / permission は未実行。後続は scoped passkey approval が必要。
+- E2E evidence: local runner tests は通過。live VPS E2E は未実施のため Butler 完了は incomplete。
+- Completion status: incomplete
+
+## Surface Update Checklist
+
+- Cloudflare deploy: 不要。この PR では worker/runtime を変更していません。
+- Custom GPT Action Schema update: 不要。
+- Custom GPT Instructions update: 不要。
+- iPhone Butler live E2E: merge 後に VPS runtime truth と通知で確認が必要。
+
+## Related Constitution Rules
+
+- Butler Completion Gate。
+- Butler-First Operating Principle。
+- Thread-Independent Startup Contract。
+- Drift Stop Protocol。
+- High-risk actions require scoped passkey approval。
+
+## Out-of-scope but NOT implemented
+
+- production VPS wrapper の直接編集。
+- app-server bridge restart。
+- workspace janitor / cleanup scheduler。
+- GitHub branch cleanup policy。
+- SunabaEye の外部サーバ deploy / backup / rollback。
+- `~/.ssh/config` や deploy credential の設計・投入。
+
+## Extra changes (if any)
+
+None.
+
+<!-- VTDD metadata -->
+- Issue: Issue #806
+- Execution ID: local-codex-issue-806-control-plane-dev-worktree-20260605
+- Goal: VPS Codex CLI の制御用 checkout を main 固定にし、開発作業台を分離する。

--- a/.vtdd/pr-body-issue-806-control-plane-dev-worktree.md
+++ b/.vtdd/pr-body-issue-806-control-plane-dev-worktree.md
@@ -1,0 +1,145 @@
+## This PR satisfies Intent
+
+- Issue #806 の「VPS Codex CLI の制御用 checkout は常に main に置き、開発作業は隔離された作業台で行う」方針を repo-backed contract と runner guard にします。
+- 既存 VPS runner は `VTDD_VPS_RUNNER_WORKDIR` 配下へ execution clone を作る設計なので、その経路を正式な dev workspace として扱い、control-plane checkout と重なる設定を runtime で block します。
+- 2026-06-05 の Issue #741 復旧で見えた「VPS 上の制御用 repo が作業 branch / dirty 状態に寄って Butler 復旧が不安定になる」事故の再発防止を狙います。
+
+## Satisfied Success Criteria
+
+- control-plane checkout status に `checkoutRole=control_plane` と main 固定 invariant を出します。
+- VPS runner execution workspace が control-plane repo 自身または配下にある場合、execution 開始前に `workspace_isolation_blocked` として止めます。
+- 通常の dev workspace は `workRoot/<repository>/<executionId>` として control-plane 外に作られることを unit / integration test で固定します。
+- Owner-facing の運用契約を `docs/butler/vps-control-plane-dev-worktree.md` に日本語で保存しました。
+
+## Unsatisfied Success Criteria
+
+- production VPS wrapper `/home/vtdd-runner/bin/vtdd-vps-runner-once` の実体確認・更新はこの PR では行っていません。
+- merge 後の live VPS 適用、app-server bridge restart、VPS runtime truth 取得はこの PR では未実施です。
+- workspace cleanup / janitor、複数並行 worktree の retention policy、外部サーバ deploy / backup / rollback は別 Issue 範囲です。
+
+## Non-goal violations
+
+None.
+
+## 開発前作戦図
+
+- 作戦図 evidence: docs/development-strategy/issue-806-vps-control-plane-dev-worktree.md
+- 完了体験: Owner は Dashboard Butler / VPS Codex CLI の runner / bridge / recovery / deploy helper が読む制御用 checkout は `origin/main` に固定され、開発 branch の dirty 状態で queue pickup が止まらないと確認できる。
+- VTDD 全体で進める部分: Issue #741 復旧で見つかった control-plane 汚染を Issue #806 の root slice として止める。SunabaEye 前段や外部サーバ deploy は後続。
+- 設計: Butler の復旧 surface を守るため、既存の `VTDD_VPS_RUNNER_WORKDIR` clone 経路を dev workspace として明示し、control-plane repo root と dev workspace が重なる設定を block する。
+- 仮説: 仮説として、既存 runner は execution clone を分離しているが、workRoot 誤設定や wrapper 側の checkout 運用で control-plane repo 汚染が起こりうる。
+- 検証計画: repo sync role、workspace isolation resolver、runVpsRunnerOnce の blocked event を unit / integration test で検証する。
+- 改修見積もり: `scripts/run-vps-runner.mjs` の workspace guard、`test/vps-runner-script.test.js` の focused tests、`docs/butler/vps-control-plane-dev-worktree.md` の契約文書。
+- 既に通っている経路: runner execution は workRoot 配下へ clone し、branch checkout / Codex / commit / push / PR 作成を行う。
+- 未確認の境界: VPS production wrapper は repo 外なので、この PR では passkey が必要な live mutation をしない。
+- 穴が出そうな箇所: `VTDD_VPS_RUNNER_WORKDIR` が control-plane 配下なら clone/test artifact が repo untracked として残る。
+- PR 前に確認すること: Issue #806 を読み、runner tests、full `npm test`、worker generated file 不要を確認する。
+- 実装候補と捨てた案: 採用は既存 workRoot clone の guard。永続 full clone pool と recovery helper 先行は scope が広がるため不採用。
+- merge 後に通す E2E: live VPS で control-plane checkout が main clean、workRoot が control-plane 外、queue pickup が通常通り進むことを runtime truth と E2E 検証に残す。
+- 次の PR を増やさない理由: この PR の範囲は runner guard / tests / docs で閉じ、予測できる不足は janitor と外部 deploy の後続 Issue として残すため、同じ scope の次 PR は増やさない。
+- 停止条件: production wrapper 更新、VPS file mutation、deploy、credential/SSH 設定変更が必要な場合は passkey 境界に分ける。
+
+## Dry-run Impact Report
+
+- Target Issue: Issue #806。
+- Implementing Success Criteria: VPS runner の control-plane checkout main 固定を runtime truth と workspace isolation guard で支える。
+- Explicit Non-goals: VPS live mutation、deploy、app-server bridge restart、workspace janitor、外部サーバ deploy / backup / rollback、SSH credential 設定。
+- Expected touched files/routes/workflows: `scripts/run-vps-runner.mjs`, `test/vps-runner-script.test.js`, `docs/butler/vps-control-plane-dev-worktree.md`, `docs/development-strategy/issue-806-vps-control-plane-dev-worktree.md`。
+- Affected Issues: Issue #806。関連文脈は Issue #741 / Issue #590 / Issue #637 だが、この PR はそれらを close しません。
+- Affected PRs: 新規 PR。既存 merged PR には push していません。
+- Affected workflows: GitHub Actions workflow 定義は未変更。
+- Affected runtime/operator surfaces: VPS runner queue pickup、runner progress event、Butler が読む VPS control-plane contract。
+- What may break if we patch narrowly: docs だけでは VPS 誤設定を防げず、guard だけでは owner/Butler が main 固定方針を再利用できない。
+- Unknowns to investigate before coding: production wrapper の `VTDD_VPS_RUNNER_WORKDIR` 実値と repo 外 script 内容は未確認。
+- Validation needed: focused runner tests、full runner script test、full `npm test`、`git diff --check`。
+- Stop condition: live VPS mutation や credential/permission 変更が必要になったら、この PR では停止。
+
+## Execution Queue Delta
+
+- Queue position before: docs queue の `Now` は Issue #590 系だったが、owner の「VPS Codex CLI は常に main であるべき」という指摘は Issue #741 復旧と Issue #590 / Issue #637 の Butler 復旧経路を塞ぐ ROOT blocker と判断しました。
+- Preemption decision: ROOT。control-plane checkout が作業 branch / dirty に寄ると、Butler だけで復旧する前提が崩れるため、通常 queue より先に最小 slice として Issue #806 を作成しました。
+- Queue delta: Issue #806 をこの PR の `Now` に移します。Issue #590 / Issue #637 / Issue #741 は縮小しません。control-plane 汚染防止後に継続します。
+- Why this PR is next: 制御用 repo が main clean でないと、bridge restart / recovery / runner pickup の信頼性が落ち、owner が Mac Codex に戻されます。
+- Active Issues not downscoped: Active Issues は縮小しません。この PR で扱わない active Issue は未完了のまま残します。
+
+## File / Line Hypotheses
+
+- file: `scripts/run-vps-runner.mjs`
+  - hypothesis: execution clone は分離済みだが、workRoot が control-plane repo と重なる設定を runtime が明示 block していない。
+  - risk if changed narrowly: preflight が止まった時に「制御面の汚染」か「開発作業失敗」か Butler が区別できない。
+  - validation: workspace resolver unit test と `runVpsRunnerOnce` blocked event integration test。
+  - related Issue: #806。
+- file: `test/vps-runner-script.test.js`
+  - hypothesis: control-plane role と workspace isolation の regression test がなかった。
+  - risk if changed narrowly: 将来の runner 変更で control-plane 配下 workRoot を許しても検出できない。
+  - validation: focused runner tests と full runner script test。
+  - related Issue: #806。
+- file: `docs/butler/vps-control-plane-dev-worktree.md`
+  - hypothesis: 会話で決まった main 固定方針を repo-backed にしないと、次の thread / Butler / VPS handoff で消える。
+  - risk if changed narrowly: 実装だけ残って運用判断が再び Mac Codex 依存になる。
+  - validation: PR body から strategy / contract を参照。
+  - related Issue: #806。
+
+## Hypothesis Retrospective
+
+- expected: 既存 runner は workRoot clone を使っており、最小修正は workspace isolation guard と docs/tests で足りる。
+- actual: `resolveVpsRunnerExecutionWorkspace()` を追加し、control-plane 配下 workRoot を execution 前に block できた。
+- mismatch: production wrapper の live 実値は未確認。merge 後の passkey 境界で確認が必要。
+- lesson: Butler / VPS の制御面は、開発対象 repo と同じ checkout を作業台にしてはいけない。
+- should become RAG candidate: はい。#806 の main 固定 / dev workspace 分離契約として working_memory 候補。
+
+## Verification Evidence
+
+- Unit: `node --test --test-name-pattern 'repo sync preflight|execution workspace|workRoot is inside|dry run reports selected' test/vps-runner-script.test.js` passed。
+- Integration: `node --test test/vps-runner-script.test.js` passed。
+- Full: `npm test` passed。
+- Static: `git diff --check` passed。
+- E2E: live VPS E2E は未実施。merge/deploy/passkey 境界の後続です。
+- Evidence path/link: `docs/development-strategy/issue-806-vps-control-plane-dev-worktree.md`, `docs/butler/vps-control-plane-dev-worktree.md`, `test/vps-runner-script.test.js`
+
+## Butler Completion Contract
+
+- Primary owner surface: Dashboard Butler。
+- Fallback surface: mac Codex は emergency / debug surface であり、通常運用の前提にはしない。
+- Owner goal: Butler / VPS Codex CLI の制御用 checkout を常に main clean に保ち、開発作業の branch / dirty 状態から切り離す。
+- Butler entrypoint: Dashboard Butler の通常チャット入口から VPS runner / recovery / bridge restart の runtime truth を読む経路。
+- Dashboard Butler natural-language path: Owner が Dashboard Butler の通常チャット入口で「VPS が詰まっている」「bridge を復旧して」などの自然文を送ると、Butler は control-plane status と workspace isolation truth へ到達して判断できる。
+- Action Schema exposure: この PR では未変更。
+- Runtime path: VPS runner script の queue pickup 前後、workspace resolution、progress event。
+- Runner/runtime truth: `checkoutRole=control_plane` と `workspace_isolation_blocked` を runner truth として出す。
+- Authority boundary: live VPS mutation / deploy / restart / credential / permission は未実行。後続は scoped passkey approval が必要。
+- E2E evidence: local runner tests は通過。live VPS E2E は未実施のため Butler 完了は incomplete。
+- Completion status: incomplete
+
+## Surface Update Checklist
+
+- Cloudflare deploy: 不要。この PR では worker/runtime を変更していません。
+- Custom GPT Action Schema update: 不要。
+- Custom GPT Instructions update: 不要。
+- iPhone Butler live E2E: merge 後に VPS runtime truth と通知で確認が必要。
+
+## Related Constitution Rules
+
+- Butler Completion Gate。
+- Butler-First Operating Principle。
+- Thread-Independent Startup Contract。
+- Drift Stop Protocol。
+- High-risk actions require scoped passkey approval。
+
+## Out-of-scope but NOT implemented
+
+- production VPS wrapper の直接編集。
+- app-server bridge restart。
+- workspace janitor / cleanup scheduler。
+- GitHub branch cleanup policy。
+- SunabaEye の外部サーバ deploy / backup / rollback。
+- `~/.ssh/config` や deploy credential の設計・投入。
+
+## Extra changes (if any)
+
+None.
+
+<!-- VTDD metadata -->
+- Issue: Issue #806
+- Execution ID: local-codex-issue-806-control-plane-dev-worktree-20260605
+- Goal: VPS Codex CLI の制御用 checkout を main 固定にし、開発作業台を分離する。

--- a/docs/butler/vps-control-plane-dev-worktree.md
+++ b/docs/butler/vps-control-plane-dev-worktree.md
@@ -1,0 +1,60 @@
+# VPS Codex CLI control-plane / development workspace contract
+
+Issue: #806
+
+## 目的
+
+VPS Codex CLI / runner / app-server bridge / recovery / deploy helper を動かす
+制御用 checkout は、常に `origin/main` に固定する。開発 branch の dirty
+状態、E2E asset、test result、未 push commit は、制御面に混ぜない。
+
+2026-06-05 の Issue #741 復旧では、制御用 checkout が
+`issue-590-muted-bridge-lifecycle` の dirty/diverged 状態に残ったため、
+`vtdd-vps-runner.timer` が active のままでも queue pickup が止まった。この
+契約は、その再発を防ぐ。
+
+## ディレクトリ役割
+
+```text
+/home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p
+  control-plane checkout
+  runner / bridge / recovery / deploy helper の実行面
+  常に origin/main
+
+/home/vtdd-runner/vtdd-runner/workspaces/<owner_repo>/<execution-id>
+  development workspace
+  Codex CLI が branch checkout / 編集 / test / push / PR 作成を行う作業台
+  dirty になってよいが、control-plane を止めてはいけない
+```
+
+## 守るルール
+
+- control-plane checkout では feature branch を checkout しない。
+- control-plane checkout で test / E2E / artifact 生成をしない。
+- control-plane checkout が non-main、tracked dirty、unknown untracked、
+  ahead/diverged の時は queue pickup を止め、owner-facing blocker として出す。
+- development workspace は control-plane checkout 自身またはその配下に作らない。
+- development workspace が dirty / unpushed / branch mismatch でも、
+  runner / bridge / recovery / deploy helper の制御面は止めない。
+- default は単一または execution ごとの isolated workspace とし、並行実行を増やす
+  場合は容量上限、TTL、cleanup 方針を別 Issue で明示する。
+
+## 復旧時の読み方
+
+Butler が bridge restart 通知停止や queue pickup 停止を見た場合、まず
+`runner stopped` と決めつけない。以下を順番に確認する。
+
+1. `vtdd-vps-runner.timer` / `vtdd-vps-runner.service` の systemd 状態。
+2. runner log の `repo sync preflight blocked`。
+3. control-plane checkout の branch、HEAD、origin/main、dirty/untracked。
+4. development workspace の dirty 状態が control-plane に漏れていないか。
+5. Issue comment に `picked_up` / `completed` が戻ったか。
+
+自己修復や emergency reset を行う場合も、control-plane と development
+workspace の境界を崩してはいけない。
+
+## Butler Completion 境界
+
+この contract が repository にあるだけでは完了ではない。VPS runner が runtime
+truth で control-plane / development workspace の分離を示し、Issue #806 の
+テストと mapped evidence が揃うまで incomplete とする。

--- a/docs/development-strategy/issue-806-vps-control-plane-dev-worktree.md
+++ b/docs/development-strategy/issue-806-vps-control-plane-dev-worktree.md
@@ -1,0 +1,72 @@
+# Issue #806 VPS control-plane main 固定と開発作業台分離 作戦図
+
+## 完了体験
+
+Owner は Butler / VPS Codex CLI を使う時、runner / bridge / recovery / deploy helper の制御用 checkout が常に `origin/main` に固定され、開発 branch の dirty 状態で queue pickup が止まらないことを期待できる。VPS Codex CLI が編集・テスト・push する場所は control-plane checkout ではなく、隔離された dev workspace であると runtime truth / docs / tests で確認できる。
+
+## VTDD 全体で進める部分
+
+Issue #806 は、2026-06-05 の Issue #741 復旧で見つかった control-plane 汚染の再発防止を担当する。外部サイト deploy / backup / rollback と SunabaEye 固有運用は、この基盤が入った後の別 Issue にする。
+
+## 設計
+
+`scripts/run-vps-runner.mjs` はすでに通常 execution を `VTDD_VPS_RUNNER_WORKDIR` 配下へ `gh repo clone` している。したがって新しい巨大な workspace pool を作るのではなく、既存 workRoot を dev workspace として明示し、control-plane repo root と dev workspace が重ならないことを guard する。
+
+control-plane safety preflight は、`repoRoot` が `baseRef` 以外の branch、tracked dirty、unknown untracked、ahead/diverged の時に queue pickup を止める。今回の変更では、この status を `checkoutRole=control_plane` として明示し、原因が「開発作業の失敗」ではなく「制御面の安全停止」であることを runtime truth に出す。
+
+## 仮説
+
+主な変更点は `scripts/run-vps-runner.mjs` と `test/vps-runner-script.test.js` で足りる。既存の workspace clone 実装は残し、`workRoot` が `repoRoot` 自身またはその配下にある時だけ execution を block する。これにより、誤って control-plane checkout 内に clone / test artifact を作り、次回 preflight が止まる事故を防げる。
+
+狭すぎる patch で docs だけにすると、VPS 側の誤設定を防げない。逆に最初から multi-workspace janitor まで作ると scope が広がり、Issue #806 の目的である control-plane 汚染防止から逸れる。
+
+## 検証計画
+
+Unit では、control-plane repo sync status に `checkoutRole=control_plane` が入ること、dev workspace が control-plane 配下なら blocker になること、control-plane とは別の workRoot なら既存 execution clone へ進めることを検証する。
+
+Integration は既存 `runVpsRunnerOnce` fixture を使い、GitHub reads / queue selection / workspace guard の順序を確認する。
+
+E2E はこの PR では local script test を evidence とし、live VPS 変更や deploy は行わない。merge 後の live 適用は別途 passkey approval / deploy 境界に従う。
+
+## 改修見積もり
+
+- `scripts/run-vps-runner.mjs`: control-plane sync status の role 明示、workspace isolation guard、blocked event / failure classification の追加。リスクは既存 runner execution の誤 block。
+- `test/vps-runner-script.test.js`: repo sync role と workspace isolation guard の unit/integration test。リスクは fixture が実運用 env とずれること。
+- `docs/butler/vps-control-plane-dev-worktree.md`: owner-facing 契約を日本語で明文化。リスクは docs-only completion に見えることなので PR body で code/test evidence と分ける。
+- `docs/development-strategy/issue-806-vps-control-plane-dev-worktree.md`: この作戦図。実装の根拠として PR body から参照する。
+
+## 既に通っている経路
+
+通常 VPS runner execution は `workRoot/<repo>/<executionId>` に clone し、そこで branch checkout / Codex / commit / push / PR 作成を行う。control-plane repo sync preflight はすでに non-main / dirty / unknown untracked / ahead/diverged を検出して queue pickup を止める。
+
+## 未確認の境界
+
+VPS production wrapper `/home/vtdd-runner/bin/vtdd-vps-runner-once` は repo 内ファイルではないため、この PR だけでは wrapper の `git checkout main || true` 事故を完全には直せない。PR では runner script 側の guard と docs を入れ、live wrapper 更新は別の passkey/VPS maintenance 境界で扱う。
+
+## 穴が出そうな箇所
+
+`VTDD_VPS_RUNNER_WORKDIR` が control-plane 配下に設定されると、clone や test artifact が repo untracked として残る。既存の known artifact allowlist が広すぎると本当の汚染を見逃す。post-merge verification の `collectVpsMainSyncStatus` は checkout/pull を実行するため、dirty 状態では失敗しうる。
+
+## PR 前に確認すること
+
+Issue #806 body、既存 runner tests、`npm test` または focused `node --test test/vps-runner-script.test.js`、変更が `src/worker` / generated `worker.js` を触らないことを確認する。
+
+## 実装候補と捨てた案
+
+採用: 既存 workRoot clone を dev workspace として扱い、control-plane と重ならない guard を追加する。
+
+捨てた案: Issue ごとに永続 full clone を作る。ディスク圧迫と cleanup failure のリスクが高い。
+
+捨てた案: recovery helper を先に作る。今回の根本は control-plane 汚染防止なので順序が逆。
+
+## merge 後に通す E2E
+
+VPS に deploy された後、runner の control-plane checkout が `main@origin/main` で、`VTDD_VPS_RUNNER_WORKDIR` が control-plane 外であること、queue pickup が通常通り進むことを Issue #806 evidence に残す。
+
+## 次の PR を増やさない理由
+
+Issue #806 の最小 slice は runner script guard、tests、docs で一つの契約として成立する。外部 deploy / rollback と workspace janitor は別目的なのでこの PR に混ぜない。
+
+## 停止条件
+
+既存 runner が already isolated であり code change が不要と判明した場合は docs/test-only に縮小する。production wrapper 更新、VPS file mutation、deploy、credential/SSH 設定変更が必要になった場合はこの PR では止め、passkey approval が必要な別手順に分ける。

--- a/scripts/run-vps-runner.mjs
+++ b/scripts/run-vps-runner.mjs
@@ -186,6 +186,7 @@ async function runVpsRunnerOnce({
       githubFetch,
       token,
       workRoot,
+      repoRoot,
       execution,
       repositoryPolicies: policies
     });
@@ -296,6 +297,7 @@ async function executeVpsRunnerExecution({
   githubFetch,
   token,
   workRoot,
+  repoRoot = REPOSITORY_ROOT,
   execution,
   repositoryPolicies
 }) {
@@ -335,7 +337,30 @@ async function executeVpsRunnerExecution({
     }
 
     await assertVpsRunnerNotCanceled({ githubFetch, payload, checkpoint: "before_clone", notification });
-    const workspace = path.join(workRoot, safePathSegment(payload.repository), payload.executionId);
+    const workspaceResolution = resolveVpsRunnerExecutionWorkspace({
+      workRoot,
+      repoRoot,
+      repository: payload.repository,
+      executionId: payload.executionId
+    });
+    if (!workspaceResolution.ok) {
+      await postVpsRunnerEvent({
+        githubFetch,
+        payload,
+        notification,
+        event: {
+          status: "blocked",
+          lastEvent: "workspace_isolation_blocked",
+          currentStep: "workspace_isolation",
+          workspaceIsolation: workspaceResolution
+        }
+      });
+      return {
+        ok: false,
+        reason: workspaceResolution.reason
+      };
+    }
+    const workspace = workspaceResolution.workspace;
     await fs.mkdir(path.dirname(workspace), { recursive: true });
     await runCommand("rm", ["-rf", workspace], { env });
     await assertVpsRunnerNotCanceled({ githubFetch, payload, checkpoint: "before_clone_command", notification });
@@ -396,7 +421,8 @@ async function executeVpsRunnerExecution({
         currentStep: "branch_created",
         branch: payload.branch,
         originalBranch: branchCheckout.originalBranch,
-        branchRecovery: branchCheckout.recovered ? branchCheckout : undefined
+        branchRecovery: branchCheckout.recovered ? branchCheckout : undefined,
+        workspaceIsolation: workspaceResolution
       }
     });
 
@@ -745,6 +771,8 @@ async function collectVpsRunnerCanonicalRepoSyncStatus({
     developmentAllowed: false,
     safeToFastForward: false,
     syncAction: "none",
+    checkoutRole: "control_plane",
+    invariant: "control-plane checkout must stay on origin/main; development work must use an isolated execution workspace",
     reason: null,
     repoRoot,
     baseRef,
@@ -879,6 +907,79 @@ function buildVpsRunnerRepoSyncReason(result) {
   return reasons.length > 0
     ? `VPS runner repo is not safe to use before recovery: ${reasons.join("; ")}.`
     : `VPS runner repo is not synced with origin/${result.baseRef}.`;
+}
+
+function resolveVpsRunnerExecutionWorkspace({
+  workRoot,
+  repoRoot = REPOSITORY_ROOT,
+  repository,
+  executionId
+} = {}) {
+  const normalizedWorkRoot = normalizeText(workRoot);
+  const normalizedRepoRoot = normalizeText(repoRoot);
+  const safeRepository = safePathSegment(repository);
+  const safeExecutionId = safePathSegment(executionId);
+  const issues = [];
+  if (!normalizedWorkRoot) {
+    issues.push("workRoot is required");
+  }
+  if (!normalizedRepoRoot) {
+    issues.push("repoRoot is required");
+  }
+  if (!safeRepository) {
+    issues.push("repository is required");
+  }
+  if (!safeExecutionId) {
+    issues.push("executionId is required");
+  }
+
+  const workspace =
+    normalizedWorkRoot && safeRepository && safeExecutionId
+      ? path.resolve(normalizedWorkRoot, safeRepository, safeExecutionId)
+      : "";
+  const controlPlaneRepoRoot = normalizedRepoRoot ? path.resolve(normalizedRepoRoot) : "";
+  const workRootResolved = normalizedWorkRoot ? path.resolve(normalizedWorkRoot) : "";
+  const workRootInsideControlPlane =
+    Boolean(workRootResolved && controlPlaneRepoRoot) &&
+    isSamePathOrInside({ childPath: workRootResolved, parentPath: controlPlaneRepoRoot });
+  const workspaceInsideControlPlane =
+    Boolean(workspace && controlPlaneRepoRoot) &&
+    isSamePathOrInside({ childPath: workspace, parentPath: controlPlaneRepoRoot });
+  if (workRootInsideControlPlane || workspaceInsideControlPlane) {
+    issues.push("execution workspace must be outside the control-plane checkout");
+  }
+
+  const ok = issues.length === 0;
+  return {
+    ok,
+    workspace: workspace || null,
+    workRoot: workRootResolved || null,
+    controlPlaneRepoRoot: controlPlaneRepoRoot || null,
+    checkoutRole: "development_workspace",
+    controlPlaneCheckoutRole: "control_plane",
+    isolation: "execution workspace must not be the control-plane checkout or a child of it",
+    repository: normalizeRepository(repository) || normalizeText(repository) || null,
+    executionId: normalizeText(executionId) || null,
+    workRootInsideControlPlane,
+    workspaceInsideControlPlane,
+    issues,
+    reason: ok
+      ? "VPS runner execution workspace is isolated from the control-plane checkout."
+      : `VPS runner workspace isolation blocked execution: ${issues.join("; ")}.`
+  };
+}
+
+function isSamePathOrInside({ childPath, parentPath } = {}) {
+  const child = path.resolve(String(childPath || ""));
+  const parent = path.resolve(String(parentPath || ""));
+  if (!child || !parent) {
+    return false;
+  }
+  if (child === parent) {
+    return true;
+  }
+  const relative = path.relative(parent, child);
+  return Boolean(relative) && !relative.startsWith("..") && !path.isAbsolute(relative);
 }
 
 async function collectVpsMainSyncStatus({ repoRoot, baseRef, mergeCommitSha, env }) {
@@ -3233,6 +3334,7 @@ export {
   parseVpsPrivilegedMaintenanceQueueComment,
   parseVpsRunnerQueueComment,
   postVpsRunnerEvent,
+  resolveVpsRunnerExecutionWorkspace,
   runVpsRunnerOnce,
   resolveRoleGitHubAppInstallationToken,
   summarizeDiagnosticText,

--- a/test/vps-runner-script.test.js
+++ b/test/vps-runner-script.test.js
@@ -31,6 +31,7 @@ import {
   parseVpsPrivilegedMaintenanceQueueComment,
   parseVpsRunnerQueueComment,
   postVpsRunnerEvent,
+  resolveVpsRunnerExecutionWorkspace,
   runVpsRunnerOnce,
   resolveRoleGitHubAppInstallationToken,
   summarizeDiagnosticText,
@@ -1244,10 +1245,43 @@ test("VPS runner repo sync preflight allows clean in-sync main with known artifa
   });
 
   assert.equal(status.ok, true);
+  assert.equal(status.checkoutRole, "control_plane");
+  assert.match(status.invariant, /control-plane checkout must stay on origin\/main/);
   assert.equal(status.developmentAllowed, true);
   assert.equal(status.inSyncWithOrigin, true);
   assert.deepEqual(status.knownUntrackedArtifacts, [".tmp/runtime.json", "test-results/runner/output.log"]);
   assert.deepEqual(status.unknownUntrackedPaths, []);
+});
+
+test("VPS runner execution workspace must stay outside the control-plane checkout", () => {
+  const allowed = resolveVpsRunnerExecutionWorkspace({
+    repoRoot: "/home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p",
+    workRoot: "/home/vtdd-runner/vtdd-runner/workspaces",
+    repository: "marushu/vtdd-v2-p",
+    executionId: "issue806-exec"
+  });
+  const blockedInside = resolveVpsRunnerExecutionWorkspace({
+    repoRoot: "/home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p",
+    workRoot: "/home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p/workspaces",
+    repository: "marushu/vtdd-v2-p",
+    executionId: "issue806-exec"
+  });
+  const blockedSame = resolveVpsRunnerExecutionWorkspace({
+    repoRoot: "/home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p",
+    workRoot: "/home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p",
+    repository: "marushu/vtdd-v2-p",
+    executionId: "issue806-exec"
+  });
+
+  assert.equal(allowed.ok, true);
+  assert.equal(allowed.checkoutRole, "development_workspace");
+  assert.equal(allowed.controlPlaneCheckoutRole, "control_plane");
+  assert.equal(allowed.workspace, "/home/vtdd-runner/vtdd-runner/workspaces/marushu_vtdd-v2-p/issue806-exec");
+  assert.equal(blockedInside.ok, false);
+  assert.equal(blockedInside.workspaceInsideControlPlane, true);
+  assert.match(blockedInside.reason, /workspace isolation blocked/);
+  assert.equal(blockedSame.ok, false);
+  assert.equal(blockedSame.workRootInsideControlPlane, true);
 });
 
 test("VPS runner repo sync preflight fast-forwards clean behind-only main", async () => {
@@ -1345,6 +1379,58 @@ test("VPS runner repo sync preflight blocks queue pickup before GitHub reads", a
   assert.equal(result.message.includes("preflight blocked queue pickup"), true);
   assert.equal(result.repoSync.developmentAllowed, false);
   assert.equal(githubRead, false);
+});
+
+test("VPS runner blocks execution when workRoot is inside the control-plane checkout", async () => {
+  const posted = [];
+  const result = await runVpsRunnerOnce({
+    token: "ghs_test",
+    allowedRepositories: ["sample-org/vtdd-v2"],
+    workRoot: "/tmp/vtdd-control-plane/workspaces",
+    repoRoot: "/tmp/vtdd-control-plane",
+    dryRun: false,
+    repoSyncPreflight: true,
+    run: mockRepoSyncRun({
+      branch: "main",
+      headSha: "abc123",
+      originHeadSha: "abc123",
+      ahead: 0,
+      behind: 0,
+      status: ""
+    }),
+    githubFetch: async (url, init = {}) => {
+      if (init.method === "POST") {
+        const body = typeof init.body === "string" ? JSON.parse(init.body) : init.body;
+        posted.push({ url, body });
+        return { id: posted.length, html_url: `https://github.com/sample-org/vtdd-v2/issues/157#posted-${posted.length}` };
+      }
+      if (url.includes("/issues?")) {
+        return [{ number: 157 }];
+      }
+      if (url.includes("/issues/157/comments")) {
+        return [
+          {
+            id: 1,
+            html_url: "https://github.com/sample-org/vtdd-v2/issues/157#issuecomment-1",
+            created_at: "2026-05-07T10:00:00Z",
+            user: { login: "alice" },
+            body: queueComment({ executionId: "exec-workspace-inside", repository: "sample-org/vtdd-v2" })
+          }
+        ];
+      }
+      if (url.endsWith("/issues/157")) {
+        return { number: 157, user: { login: "alice" }, body: "Issue body" };
+      }
+      return [];
+    }
+  });
+
+  assert.equal(result.ok, false);
+  assert.match(result.reason, /workspace isolation blocked/);
+  assert.equal(posted.length, 2);
+  assert.equal(posted[0].body.body.includes('"lastEvent": "picked_up"'), true);
+  assert.equal(posted[1].body.body.includes('"lastEvent": "workspace_isolation_blocked"'), true);
+  assert.equal(posted[1].body.body.includes('"workRootInsideControlPlane": true'), true);
 });
 
 test("VPS runner dry run reports selected execution without side effects", async () => {


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #806 の「VPS Codex CLI の制御用 checkout は常に main に置き、開発作業は隔離された作業台で行う」方針を repo-backed contract と runner guard にします。
- 既存 VPS runner は `VTDD_VPS_RUNNER_WORKDIR` 配下へ execution clone を作る設計なので、その経路を正式な dev workspace として扱い、control-plane checkout と重なる設定を runtime で block します。
- 2026-06-05 の Issue #741 復旧で見えた「VPS 上の制御用 repo が作業 branch / dirty 状態に寄って Butler 復旧が不安定になる」事故の再発防止を狙います。

## Satisfied Success Criteria

- control-plane checkout status に `checkoutRole=control_plane` と main 固定 invariant を出します。
- VPS runner execution workspace が control-plane repo 自身または配下にある場合、execution 開始前に `workspace_isolation_blocked` として止めます。
- 通常の dev workspace は `workRoot/<repository>/<executionId>` として control-plane 外に作られることを unit / integration test で固定します。
- Owner-facing の運用契約を `docs/butler/vps-control-plane-dev-worktree.md` に日本語で保存しました。

## Unsatisfied Success Criteria

- production VPS wrapper `/home/vtdd-runner/bin/vtdd-vps-runner-once` の実体確認・更新はこの PR では行っていません。
- merge 後の live VPS 適用、app-server bridge restart、VPS runtime truth 取得はこの PR では未実施です。
- workspace cleanup / janitor、複数並行 worktree の retention policy、外部サーバ deploy / backup / rollback は別 Issue 範囲です。

## Non-goal violations

None.

## 開発前作戦図

- 作戦図 evidence: docs/development-strategy/issue-806-vps-control-plane-dev-worktree.md
- 完了体験: Owner は Dashboard Butler / VPS Codex CLI の runner / bridge / recovery / deploy helper が読む制御用 checkout は `origin/main` に固定され、開発 branch の dirty 状態で queue pickup が止まらないと確認できる。
- VTDD 全体で進める部分: Issue #741 復旧で見つかった control-plane 汚染を Issue #806 の root slice として止める。SunabaEye 前段や外部サーバ deploy は後続。
- 設計: Butler の復旧 surface を守るため、既存の `VTDD_VPS_RUNNER_WORKDIR` clone 経路を dev workspace として明示し、control-plane repo root と dev workspace が重なる設定を block する。
- 仮説: 仮説として、既存 runner は execution clone を分離しているが、workRoot 誤設定や wrapper 側の checkout 運用で control-plane repo 汚染が起こりうる。
- 検証計画: repo sync role、workspace isolation resolver、runVpsRunnerOnce の blocked event を unit / integration test で検証する。
- 改修見積もり: `scripts/run-vps-runner.mjs` の workspace guard、`test/vps-runner-script.test.js` の focused tests、`docs/butler/vps-control-plane-dev-worktree.md` の契約文書。
- 既に通っている経路: runner execution は workRoot 配下へ clone し、branch checkout / Codex / commit / push / PR 作成を行う。
- 未確認の境界: VPS production wrapper は repo 外なので、この PR では passkey が必要な live mutation をしない。
- 穴が出そうな箇所: `VTDD_VPS_RUNNER_WORKDIR` が control-plane 配下なら clone/test artifact が repo untracked として残る。
- PR 前に確認すること: Issue #806 を読み、runner tests、full `npm test`、worker generated file 不要を確認する。
- 実装候補と捨てた案: 採用は既存 workRoot clone の guard。永続 full clone pool と recovery helper 先行は scope が広がるため不採用。
- merge 後に通す E2E: live VPS で control-plane checkout が main clean、workRoot が control-plane 外、queue pickup が通常通り進むことを runtime truth と E2E 検証に残す。
- 次の PR を増やさない理由: この PR の範囲は runner guard / tests / docs で閉じ、予測できる不足は janitor と外部 deploy の後続 Issue として残すため、同じ scope の次 PR は増やさない。
- 停止条件: production wrapper 更新、VPS file mutation、deploy、credential/SSH 設定変更が必要な場合は passkey 境界に分ける。

## Dry-run Impact Report

- Target Issue: Issue #806。
- Implementing Success Criteria: VPS runner の control-plane checkout main 固定を runtime truth と workspace isolation guard で支える。
- Explicit Non-goals: VPS live mutation、deploy、app-server bridge restart、workspace janitor、外部サーバ deploy / backup / rollback、SSH credential 設定。
- Expected touched files/routes/workflows: `scripts/run-vps-runner.mjs`, `test/vps-runner-script.test.js`, `docs/butler/vps-control-plane-dev-worktree.md`, `docs/development-strategy/issue-806-vps-control-plane-dev-worktree.md`。
- Affected Issues: Issue #806。関連文脈は Issue #741 / Issue #590 / Issue #637 だが、この PR はそれらを close しません。
- Affected PRs: 新規 PR。既存 merged PR には push していません。
- Affected workflows: GitHub Actions workflow 定義は未変更。
- Affected runtime/operator surfaces: VPS runner queue pickup、runner progress event、Butler が読む VPS control-plane contract。
- What may break if we patch narrowly: docs だけでは VPS 誤設定を防げず、guard だけでは owner/Butler が main 固定方針を再利用できない。
- Unknowns to investigate before coding: production wrapper の `VTDD_VPS_RUNNER_WORKDIR` 実値と repo 外 script 内容は未確認。
- Validation needed: focused runner tests、full runner script test、full `npm test`、`git diff --check`。
- Stop condition: live VPS mutation や credential/permission 変更が必要になったら、この PR では停止。

## Execution Queue Delta

- Queue position before: docs queue の `Now` は Issue #590 系だったが、owner の「VPS Codex CLI は常に main であるべき」という指摘は Issue #741 復旧と Issue #590 / Issue #637 の Butler 復旧経路を塞ぐ ROOT blocker と判断しました。
- Preemption decision: ROOT。control-plane checkout が作業 branch / dirty に寄ると、Butler だけで復旧する前提が崩れるため、通常 queue より先に最小 slice として Issue #806 を作成しました。
- Queue delta: Issue #806 をこの PR の `Now` に移します。Issue #590 / Issue #637 / Issue #741 は縮小しません。control-plane 汚染防止後に継続します。
- Why this PR is next: 制御用 repo が main clean でないと、bridge restart / recovery / runner pickup の信頼性が落ち、owner が Mac Codex に戻されます。
- Active Issues not downscoped: Active Issues は縮小しません。この PR で扱わない active Issue は未完了のまま残します。

## File / Line Hypotheses

- file: `scripts/run-vps-runner.mjs`
  - hypothesis: execution clone は分離済みだが、workRoot が control-plane repo と重なる設定を runtime が明示 block していない。
  - risk if changed narrowly: preflight が止まった時に「制御面の汚染」か「開発作業失敗」か Butler が区別できない。
  - validation: workspace resolver unit test と `runVpsRunnerOnce` blocked event integration test。
  - related Issue: #806。
- file: `test/vps-runner-script.test.js`
  - hypothesis: control-plane role と workspace isolation の regression test がなかった。
  - risk if changed narrowly: 将来の runner 変更で control-plane 配下 workRoot を許しても検出できない。
  - validation: focused runner tests と full runner script test。
  - related Issue: #806。
- file: `docs/butler/vps-control-plane-dev-worktree.md`
  - hypothesis: 会話で決まった main 固定方針を repo-backed にしないと、次の thread / Butler / VPS handoff で消える。
  - risk if changed narrowly: 実装だけ残って運用判断が再び Mac Codex 依存になる。
  - validation: PR body から strategy / contract を参照。
  - related Issue: #806。

## Hypothesis Retrospective

- expected: 既存 runner は workRoot clone を使っており、最小修正は workspace isolation guard と docs/tests で足りる。
- actual: `resolveVpsRunnerExecutionWorkspace()` を追加し、control-plane 配下 workRoot を execution 前に block できた。
- mismatch: production wrapper の live 実値は未確認。merge 後の passkey 境界で確認が必要。
- lesson: Butler / VPS の制御面は、開発対象 repo と同じ checkout を作業台にしてはいけない。
- should become RAG candidate: はい。#806 の main 固定 / dev workspace 分離契約として working_memory 候補。

## Verification Evidence

- Unit: `node --test --test-name-pattern 'repo sync preflight|execution workspace|workRoot is inside|dry run reports selected' test/vps-runner-script.test.js` passed。
- Integration: `node --test test/vps-runner-script.test.js` passed。
- Full: `npm test` passed。
- Static: `git diff --check` passed。
- E2E: live VPS E2E は未実施。merge/deploy/passkey 境界の後続です。
- Evidence path/link: `docs/development-strategy/issue-806-vps-control-plane-dev-worktree.md`, `docs/butler/vps-control-plane-dev-worktree.md`, `test/vps-runner-script.test.js`

## Butler Completion Contract

- Primary owner surface: Dashboard Butler。
- Fallback surface: mac Codex は emergency / debug surface であり、通常運用の前提にはしない。
- Owner goal: Butler / VPS Codex CLI の制御用 checkout を常に main clean に保ち、開発作業の branch / dirty 状態から切り離す。
- Butler entrypoint: Dashboard Butler の通常チャット入口から VPS runner / recovery / bridge restart の runtime truth を読む経路。
- Dashboard Butler natural-language path: Owner が Dashboard Butler の通常チャット入口で「VPS が詰まっている」「bridge を復旧して」などの自然文を送ると、Butler は control-plane status と workspace isolation truth へ到達して判断できる。
- Action Schema exposure: この PR では未変更。
- Runtime path: VPS runner script の queue pickup 前後、workspace resolution、progress event。
- Runner/runtime truth: `checkoutRole=control_plane` と `workspace_isolation_blocked` を runner truth として出す。
- Authority boundary: live VPS mutation / deploy / restart / credential / permission は未実行。後続は scoped passkey approval が必要。
- E2E evidence: local runner tests は通過。live VPS E2E は未実施のため Butler 完了は incomplete。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 不要。この PR では worker/runtime を変更していません。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: merge 後に VPS runtime truth と通知で確認が必要。

## Related Constitution Rules

- Butler Completion Gate。
- Butler-First Operating Principle。
- Thread-Independent Startup Contract。
- Drift Stop Protocol。
- High-risk actions require scoped passkey approval。

## Out-of-scope but NOT implemented

- production VPS wrapper の直接編集。
- app-server bridge restart。
- workspace janitor / cleanup scheduler。
- GitHub branch cleanup policy。
- SunabaEye の外部サーバ deploy / backup / rollback。
- `~/.ssh/config` や deploy credential の設計・投入。

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #806
- Execution ID: local-codex-issue-806-control-plane-dev-worktree-20260605
- Goal: VPS Codex CLI の制御用 checkout を main 固定にし、開発作業台を分離する。
