### PR TITLE
Issue #811 voice button beside stop control

### DIFF
--- a/docs/development-strategy/issue-811-dashboard-butler-v3-main-chat.md
+++ b/docs/development-strategy/issue-811-dashboard-butler-v3-main-chat.md
@@ -212,3 +212,28 @@ PR #812 merge / deploy / app-server bridge restart 後の owner 実機確認で�
 - `node --test test/worker.test.js`
 - `npx playwright test scripts/e2e-issue811-dashboard-butler-v3-main-chat.spec.mjs --browser=chromium --reporter=line`
 - merge / deploy 後に production iPhone PWA で voice button から声→文字→チャット送信を実機確認する。
+
+## 2026-06-07 production live gap: voice button beside stop/send
+
+Owner production evidence showed that, while a turn is running, the composer
+shows only the stop button on the right edge and hides the voice mode button.
+This is wrong for the target voice-ready main chat: owner should be able to keep
+voice mode available beside the send/stop control, especially while the current
+turn is running and follow-up input may be spoken.
+
+修正方針:
+
+- Composer right-side controls should be a stable inline group.
+- Voice mode button stays visible next to the send/stop button while a turn is
+  running.
+- Voice mode button may still hide when normal text is ready to send, because
+  that state needs a clear send affordance and prevents accidental voice start.
+- Stop button remains the rightmost primary control during an active turn.
+- This slice must not change SpeechRecognition, readback, passkey, deploy, or
+  follow-up queue semantics.
+
+追加検証:
+
+- `node --test test/worker.test.js`
+- `npx playwright test scripts/e2e-issue811-dashboard-butler-v3-main-chat.spec.mjs`
+- `npm run check:generated-worker`

--- a/scripts/e2e-issue811-dashboard-butler-v3-main-chat.spec.mjs
+++ b/scripts/e2e-issue811-dashboard-butler-v3-main-chat.spec.mjs
@@ -424,6 +424,15 @@ test("Issue #811 mobile main chat keeps floating header, drawer overlay, passkey
       clientMessageId
     });
   }, voiceClientMessageId);
+  await expect(page.locator("#butler-voice-button")).toBeVisible();
+  await expect(page.locator("#butler-send-button")).toBeVisible();
+  await expect(page.locator("#butler-send-button")).toHaveAttribute("data-mode", "stop");
+  await expect.poll(async () => page.evaluate(() => {
+    const voiceBox = document.querySelector("#butler-voice-button")?.getBoundingClientRect();
+    const stopBox = document.querySelector("#butler-send-button")?.getBoundingClientRect();
+    const composerBox = document.querySelector(".composer-box")?.getBoundingClientRect();
+    return Boolean(voiceBox && stopBox && composerBox && voiceBox.left > composerBox.left && stopBox.left > voiceBox.left);
+  })).toBe(true);
   await expect.poll(async () => page.evaluate(() => window.__vtddWakeLockRequests || [])).toContain("screen");
   await page.evaluate(() => window.__vtddDashboardVoiceTest?.suspendWithoutExplicitStop());
   await page.evaluate(() => {

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -16405,8 +16405,9 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
     .send-button[data-mode="stop"]::before { content: "■"; }
     .send-button[data-mode="stop"] { color: var(--page-bg); }
     .send-button[data-mode="stop"] span { display: none; }
+    .composer-actions { display: inline-flex; align-items: center; gap: 8px; flex: 0 0 auto; }
     .composer-box[data-can-send="false"] .send-button[data-mode="send"] { display: none; }
-    .composer-box[data-running="true"] .voice-button, .composer-box[data-can-send="true"] .voice-button { display: none; }
+    .composer-box[data-can-send="true"]:not([data-running="true"]) .voice-button { display: none; }
     .followup-queue { display: grid; gap: 8px; padding: 0 10px; }
     .followup-queue[hidden], .followup-draft[hidden] { display: none; }
     .followup-chip, .followup-draft { width: fit-content; max-width: min(720px, 100%); justify-self: end; border: 1px solid var(--border); border-radius: 18px; background: var(--floating-bg); box-shadow: 0 10px 34px var(--shadow); backdrop-filter: blur(16px); -webkit-backdrop-filter: blur(16px); color: var(--text); }
@@ -16654,8 +16655,10 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           <button class="media-button" id="butler-media-button" type="button" aria-label="画像・動画・ファイルを追加" title="画像・動画・ファイルを追加">+</button>
           <input id="butler-media-input" type="file" multiple hidden>
           <textarea id="butler-message" name="text" placeholder="Butler にメッセージ..." aria-label="Butler にメッセージ" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" enterkeyhint="send"></textarea>
-          <button class="voice-button" id="butler-voice-button" type="button" aria-label="音声入力" title="音声入力"><span class="voice-bars" aria-hidden="true"><span></span><span></span><span></span><span></span><span></span></span></button>
-          <button class="send-button" id="butler-send-button" type="submit" aria-label="Butler に送信"><span>↑</span></button>
+          <div class="composer-actions" aria-label="入力操作">
+            <button class="voice-button" id="butler-voice-button" type="button" aria-label="音声入力" title="音声入力"><span class="voice-bars" aria-hidden="true"><span></span><span></span><span></span><span></span><span></span></span></button>
+            <button class="send-button" id="butler-send-button" type="submit" aria-label="Butler に送信"><span>↑</span></button>
+          </div>
         </div>
         <div class="followup-draft" id="butler-followup-draft" hidden>
           <p id="butler-followup-draft-text"></p>

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -1334,6 +1334,9 @@ test("worker serves v2 dashboard for allowed owner identity without exposing sec
   assert.equal(body.includes('id="butler-send-button"'), true);
   assert.equal(body.includes('data-mode="stop"'), true);
   assert.equal(body.includes('id="butler-voice-button"'), true);
+  assert.equal(body.includes('class="composer-actions"'), true);
+  assert.equal(body.includes('.composer-box[data-can-send="true"]:not([data-running="true"]) .voice-button { display: none; }'), true);
+  assert.equal(body.includes('.composer-box[data-running="true"] .voice-button'), false);
   assert.equal(body.includes("function toggleVoiceInput()"), true);
   assert.equal(body.includes("function appendVoiceTranscript(text)"), true);
   assert.equal(body.includes("無音区切りで送信します"), true);

--- a/worker.js
+++ b/worker.js
@@ -72499,8 +72499,9 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
     .send-button[data-mode="stop"]::before { content: "\u25A0"; }
     .send-button[data-mode="stop"] { color: var(--page-bg); }
     .send-button[data-mode="stop"] span { display: none; }
+    .composer-actions { display: inline-flex; align-items: center; gap: 8px; flex: 0 0 auto; }
     .composer-box[data-can-send="false"] .send-button[data-mode="send"] { display: none; }
-    .composer-box[data-running="true"] .voice-button, .composer-box[data-can-send="true"] .voice-button { display: none; }
+    .composer-box[data-can-send="true"]:not([data-running="true"]) .voice-button { display: none; }
     .followup-queue { display: grid; gap: 8px; padding: 0 10px; }
     .followup-queue[hidden], .followup-draft[hidden] { display: none; }
     .followup-chip, .followup-draft { width: fit-content; max-width: min(720px, 100%); justify-self: end; border: 1px solid var(--border); border-radius: 18px; background: var(--floating-bg); box-shadow: 0 10px 34px var(--shadow); backdrop-filter: blur(16px); -webkit-backdrop-filter: blur(16px); color: var(--text); }
@@ -72744,8 +72745,10 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           <button class="media-button" id="butler-media-button" type="button" aria-label="\u753B\u50CF\u30FB\u52D5\u753B\u30FB\u30D5\u30A1\u30A4\u30EB\u3092\u8FFD\u52A0" title="\u753B\u50CF\u30FB\u52D5\u753B\u30FB\u30D5\u30A1\u30A4\u30EB\u3092\u8FFD\u52A0">+</button>
           <input id="butler-media-input" type="file" multiple hidden>
           <textarea id="butler-message" name="text" placeholder="Butler \u306B\u30E1\u30C3\u30BB\u30FC\u30B8..." aria-label="Butler \u306B\u30E1\u30C3\u30BB\u30FC\u30B8" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" enterkeyhint="send"></textarea>
-          <button class="voice-button" id="butler-voice-button" type="button" aria-label="\u97F3\u58F0\u5165\u529B" title="\u97F3\u58F0\u5165\u529B"><span class="voice-bars" aria-hidden="true"><span></span><span></span><span></span><span></span><span></span></span></button>
-          <button class="send-button" id="butler-send-button" type="submit" aria-label="Butler \u306B\u9001\u4FE1"><span>\u2191</span></button>
+          <div class="composer-actions" aria-label="\u5165\u529B\u64CD\u4F5C">
+            <button class="voice-button" id="butler-voice-button" type="button" aria-label="\u97F3\u58F0\u5165\u529B" title="\u97F3\u58F0\u5165\u529B"><span class="voice-bars" aria-hidden="true"><span></span><span></span><span></span><span></span><span></span></span></button>
+            <button class="send-button" id="butler-send-button" type="submit" aria-label="Butler \u306B\u9001\u4FE1"><span>\u2191</span></button>
+          </div>
         </div>
         <div class="followup-draft" id="butler-followup-draft" hidden>
           <p id="butler-followup-draft-text"></p>


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #811 の production live gap として、実行中 composer で voice mode button が stop button に隣接して残るようにします。
- Issue #814 の voice-ready workflow を壊さず、active turn 中の follow-up voice input affordance を維持します。
- この PR は Issue #811 / Issue #814 の完了を主張しません。

## Satisfied Success Criteria

- 実行中でも voice mode button が hidden にならず、stop button の左隣に表示されます。
- send / stop と voice を `.composer-actions` で右端の安定した inline control group にしました。
- 通常テキスト入力中は従来通り send affordance を優先し、voice button は隠します。
- mobile E2E で active turn 中に voice button と stop button が同時表示され、stop が voice の右にあることを確認しました。

## Unsatisfied Success Criteria

- production iPhone / iPad PWA 実機での確認は未実施です。
- 最新コメントへ飛ぶ button、passkey modal auto-return、送信済み follow-up card cleanup、live progress timeline はこの PR では未実装です。
- Issue #811 / #814 / #818 は active scope として残ります。

## Non-goal violations

None.

## 開発前作戦図

- 作戦図 evidence: `docs/development-strategy/issue-811-dashboard-butler-v3-main-chat.md`
- 完了体験: owner が Dashboard Butler PWA の実行中 composer で、stop control の横に voice mode button を見つけられる。
- VTDD 全体で進める部分: Issue #811 の iPhone-first main chat composer と Issue #814 の voice-ready entrypoint を狭く改善する。
- 設計: owner-facing Dashboard Butler composer surface の範囲で、composer right-side controls を `.composer-actions` としてまとめ、active turn 中は voice と stop を並べる。通常 text send state では send を優先して voice を隠す境界にする。
- 仮説: 原因は `data-running=true` の CSS が voice button を隠していることで、実行中に voice follow-up affordance が消えていると疑う。
- 検証計画: source assertion、generated worker check、mobile Playwright E2E で active turn 中の visible / position を検証する。
- 改修見積もり: `src/worker/runtime.js` の composer CSS/markup、generated `worker.js`、`test/worker.test.js` source guard、`scripts/e2e-issue811-dashboard-butler-v3-main-chat.spec.mjs` mobile E2E、#811 strategy note。
- 既に通っている経路: voice button、send/stop button、active turn state、#811 mobile E2E は既存。
- 未確認の境界: production iPhone/iPad PWA の実機 layout と keyboard 表示時の見え方は未確認。
- 穴が出そうな箇所: controls が横幅を取りすぎて textarea を潰すこと、通常 text send state で accidental voice start が戻ること。
- PR 前に確認すること: main が origin/main と一致していること、open PR #817 と scope が重ならないこと、generated worker と E2E が通ること。
- 実装候補と捨てた案: 採用は `.composer-actions` で voice/send-stop を右端にまとめる案。捨てた案は voice を常時別 row に置く案で、composer 高さを増やして chat 欄を圧迫するため不採用。
- merge 後に通す E2E: production iPhone PWA E2E で active turn 中に voice button が stop button 横に残ることを確認する。
- 次の PR を増やさない理由: この slice は composer controls の配置だけに閉じ、readback や queue cleanup と混ぜないことで scope を増やさない。
- 停止条件: SpeechRecognition、readback、passkey、deploy、follow-up queue semantics を変更する必要が出た場合はこの PR では停止する。

## Dry-run Impact Report

- Target Issue: Issue #811
- Implementing Success Criteria: active turn 中の voice mode button と stop button の隣接表示、right-side composer controls の安定化、mobile E2E evidence。
- Explicit Non-goals: Web Speech API readback 修正、passkey modal return、latest button、follow-up sent card cleanup、deploy、credential / permission mutation、destructive work。
- Expected touched files/routes/workflows: `src/worker/runtime.js`, `worker.js`, `test/worker.test.js`, `scripts/e2e-issue811-dashboard-butler-v3-main-chat.spec.mjs`, `docs/development-strategy/issue-811-dashboard-butler-v3-main-chat.md`
- Affected Issues: Issue #811, Issue #814。Issue #818 は voice workflow 関連として active のまま残ります。
- Affected PRs: PR #817 は open のままですが、この PR は #816 media queue scope を変更しません。
- Affected workflows: local worker unit, generated worker check, Playwright #811 E2E。deploy workflow は実行しません。
- Affected runtime/operator surfaces: Dashboard Butler PWA main chat composer。
- What may break if we patch narrowly: voice と stop が並んでも textarea 幅が狭くなる可能性、通常 text input 中に voice が誤表示される可能性。
- Unknowns to investigate before coding: production iPhone keyboard 表示時の controls 幅。
- Validation needed: unit / generated worker / mobile E2E / production PWA visual check。
- Stop condition: composer layout 以外の voice runtime semantics を変更する必要が出た場合。

## Execution Queue Delta

- Queue position before: Issue #811 は parent root として active。Issue #814 / #818 は voice workflow の active evidence gap。
- Preemption decision: NEXT。owner production screenshot で composer voice control gap が確認されたため、狭い UI correction として扱います。
- Queue delta: Issue #811 の composer control gap をこの PR で進めます。`Now` / `Next` の active Issue 全体は縮小しません。
- Why this PR is next: active turn 中に voice button が消えると、voice-ready main chat の通常操作が成立しないため。
- Active Issues not downscoped: Active Issues は縮小しません。Issue #811 / #814 / #818 / #816 は未完了として残します。

## File / Line Hypotheses

- file: `src/worker/runtime.js`
  - hypothesis: `.composer-box[data-running="true"] .voice-button` が active turn 中の voice button を隠している。
  - risk if changed narrowly: text send state でも voice が出て accidental voice start になる。
  - validation: source guard と mobile E2E で active turn 中のみ voice/stop が並ぶことを確認する。
  - related Issue: Issue #811 / Issue #814
- file: `scripts/e2e-issue811-dashboard-butler-v3-main-chat.spec.mjs`
  - hypothesis: owner message accepted 後の active turn state で button position を確認すれば regression を固定できる。
  - risk if changed narrowly: visual screenshot だけでは position regression を見逃す。
  - validation: `#butler-voice-button` visible、`#butler-send-button[data-mode=stop]` visible、stop が voice の右にあることを確認。
  - related Issue: Issue #811

## Hypothesis Retrospective

- expected: CSS hide rule を active turn から外し、right-side controls wrapper を追加すれば voice と stop が並ぶ。
- actual: `.composer-actions` を追加し、active turn 中は voice と stop が同時表示される E2E が通りました。
- mismatch: production iPhone PWA の keyboard 表示中 visual evidence は未取得です。
- lesson: active turn state と text send state の control visibility は別条件で扱う必要があります。
- should become RAG candidate: production evidence 後に、Dashboard composer controls の visibility rule として保存候補です。

## Verification Evidence

- Unit: `node --test test/worker.test.js` passed: 285 tests.
- Integration: `npm run build:worker` passed. `npm run check:generated-worker` passed. `git diff --check` passed.
- E2E: `npx playwright test scripts/e2e-issue811-dashboard-butler-v3-main-chat.spec.mjs` passed: 2 tests.
- Manual: production iPhone/iPad PWA manual check is not done.
- Evidence path/link: `docs/mvp/e2e/assets/issue-811/local/issue811-mobile-main-chat-chromium.png`, `docs/mvp/e2e/assets/issue-811/local/issue811-mobile-main-chat-chromium-state.json`

## Butler Completion Contract

- Primary owner surface: Dashboard Butler PWA。
- Fallback surface: Custom GPT は fallback surface のみで、この PR の主経路ではありません。
- Owner goal: active turn 中でも voice mode button を stop/send control の横に置き、composer の操作を迷わせない。
- Butler entrypoint: Dashboard Butler main chat composer。
- Dashboard Butler natural-language path: Dashboard Butler の通常チャット / voice chat entrypoint で、自然文 voice transcript を送る入口が active turn 中にも見える。
- Action Schema exposure: 不要。この PR は Dashboard PWA runtime client behavior の変更です。
- Runtime path: Worker-rendered `/dashboard` HTML / client script composer controls。
- Runner/runtime truth: local unit and Playwright E2E only。production runtime truth は未取得。
- Authority boundary: deploy、credential mutation、permission mutation、destructive work は実行していません。
- E2E evidence: local iPhone/iPad viewport E2E passed。
- Completion status: incomplete

## Surface Update Checklist

- Dashboard Butler composer: updated.
- Worker generated bundle: updated.
- Unit tests: updated and passed.
- E2E evidence: updated and passed.
- Production deploy: not executed.

## Related Constitution Rules

- AGENTS.md Butler Completion Gate
- AGENTS.md Drift Stop Protocol
- AGENTS.md 開発前作戦図 Gate
- docs/mvp/active-issue-execution-queue.md

## Out-of-scope

- passkey modal auto-return
- live progress timeline
- latest-comment jump button
- sent follow-up card cleanup
- production deploy
