### PR TITLE
Issue #811 composer single action correction

### DIFF
--- a/docs/development-strategy/issue-811-dashboard-butler-v3-main-chat.md
+++ b/docs/development-strategy/issue-811-dashboard-butler-v3-main-chat.md
@@ -237,3 +237,24 @@ turn is running and follow-up input may be spoken.
 - `node --test test/worker.test.js`
 - `npx playwright test scripts/e2e-issue811-dashboard-butler-v3-main-chat.spec.mjs`
 - `npm run check:generated-worker`
+
+## 2026-06-07 owner correction: single composer action slot
+
+Owner corrected the composer control model after PR #821: the first design was
+better. The right-side composer action should be a single action slot rather
+than showing voice and stop/send side by side.
+
+修正方針:
+
+- Empty composer, not running: show only the voice mode button.
+- Text entered, not running: replace voice with the send button.
+- Active turn running: replace the right-side action with the stop button.
+- Do not keep voice visible beside stop during active turn.
+- This keeps the composer compact and avoids accidental voice starts while
+  preserving the ChatGPT-like input affordance.
+
+追加検証:
+
+- `node --test test/worker.test.js`
+- `npx playwright test scripts/e2e-issue811-dashboard-butler-v3-main-chat.spec.mjs`
+- `npm run check:generated-worker`

--- a/scripts/e2e-issue811-dashboard-butler-v3-main-chat.spec.mjs
+++ b/scripts/e2e-issue811-dashboard-butler-v3-main-chat.spec.mjs
@@ -384,7 +384,10 @@ test("Issue #811 mobile main chat keeps floating header, drawer overlay, passkey
   await expect(page.locator("#butler-message")).toHaveAttribute("data-mobile-composer", "true");
   await expect(page.locator(".desktop-side-nav")).toBeHidden();
   await expect(page.locator(".menu-open").first()).toBeVisible();
+  await expect(page.locator("#butler-voice-button")).toBeVisible();
+  await expect(page.locator("#butler-send-button")).toBeHidden();
   await page.locator("#butler-message").fill("テキスト送信確認");
+  await expect(page.locator("#butler-voice-button")).toBeHidden();
   await expect(page.locator("#butler-send-button")).toBeVisible();
   await expect.poll(async () => page.evaluate(() => {
     const sendBox = document.querySelector("#butler-send-button")?.getBoundingClientRect();
@@ -424,15 +427,9 @@ test("Issue #811 mobile main chat keeps floating header, drawer overlay, passkey
       clientMessageId
     });
   }, voiceClientMessageId);
-  await expect(page.locator("#butler-voice-button")).toBeVisible();
+  await expect(page.locator("#butler-voice-button")).toBeHidden();
   await expect(page.locator("#butler-send-button")).toBeVisible();
   await expect(page.locator("#butler-send-button")).toHaveAttribute("data-mode", "stop");
-  await expect.poll(async () => page.evaluate(() => {
-    const voiceBox = document.querySelector("#butler-voice-button")?.getBoundingClientRect();
-    const stopBox = document.querySelector("#butler-send-button")?.getBoundingClientRect();
-    const composerBox = document.querySelector(".composer-box")?.getBoundingClientRect();
-    return Boolean(voiceBox && stopBox && composerBox && voiceBox.left > composerBox.left && stopBox.left > voiceBox.left);
-  })).toBe(true);
   await expect.poll(async () => page.evaluate(() => window.__vtddWakeLockRequests || [])).toContain("screen");
   await page.evaluate(() => window.__vtddDashboardVoiceTest?.suspendWithoutExplicitStop());
   await page.evaluate(() => {

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -16405,9 +16405,9 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
     .send-button[data-mode="stop"]::before { content: "■"; }
     .send-button[data-mode="stop"] { color: var(--page-bg); }
     .send-button[data-mode="stop"] span { display: none; }
-    .composer-actions { display: inline-flex; align-items: center; gap: 8px; flex: 0 0 auto; }
+    .composer-actions { display: inline-flex; align-items: center; gap: 0; flex: 0 0 auto; }
     .composer-box[data-can-send="false"] .send-button[data-mode="send"] { display: none; }
-    .composer-box[data-can-send="true"]:not([data-running="true"]) .voice-button { display: none; }
+    .composer-box[data-running="true"] .voice-button, .composer-box[data-can-send="true"] .voice-button { display: none; }
     .followup-queue { display: grid; gap: 8px; padding: 0 10px; }
     .followup-queue[hidden], .followup-draft[hidden] { display: none; }
     .followup-chip, .followup-draft { width: fit-content; max-width: min(720px, 100%); justify-self: end; border: 1px solid var(--border); border-radius: 18px; background: var(--floating-bg); box-shadow: 0 10px 34px var(--shadow); backdrop-filter: blur(16px); -webkit-backdrop-filter: blur(16px); color: var(--text); }
@@ -16651,13 +16651,13 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           <span class="progress-title">進行中</span>
           <p class="progress-text"></p>
         </div>
-        <div class="composer-box">
+        <div class="composer-box" data-can-send="false" data-running="false">
           <button class="media-button" id="butler-media-button" type="button" aria-label="画像・動画・ファイルを追加" title="画像・動画・ファイルを追加">+</button>
           <input id="butler-media-input" type="file" multiple hidden>
           <textarea id="butler-message" name="text" placeholder="Butler にメッセージ..." aria-label="Butler にメッセージ" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" enterkeyhint="send"></textarea>
           <div class="composer-actions" aria-label="入力操作">
             <button class="voice-button" id="butler-voice-button" type="button" aria-label="音声入力" title="音声入力"><span class="voice-bars" aria-hidden="true"><span></span><span></span><span></span><span></span><span></span></span></button>
-            <button class="send-button" id="butler-send-button" type="submit" aria-label="Butler に送信"><span>↑</span></button>
+            <button class="send-button" id="butler-send-button" type="submit" aria-label="Butler に送信" data-mode="send"><span>↑</span></button>
           </div>
         </div>
         <div class="followup-draft" id="butler-followup-draft" hidden>

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -1331,12 +1331,13 @@ test("worker serves v2 dashboard for allowed owner identity without exposing sec
   assert.equal(body.includes("break-glass"), true);
   assert.equal(body.includes("任意コマンドではなく、状態確認と固定復旧だけを扱います"), true);
   assert.equal(body.includes(".composer-status:empty"), true);
+  assert.equal(body.includes('class="composer-box" data-can-send="false" data-running="false"'), true);
   assert.equal(body.includes('id="butler-send-button"'), true);
+  assert.equal(body.includes('id="butler-send-button" type="submit" aria-label="Butler に送信" data-mode="send"'), true);
   assert.equal(body.includes('data-mode="stop"'), true);
   assert.equal(body.includes('id="butler-voice-button"'), true);
   assert.equal(body.includes('class="composer-actions"'), true);
-  assert.equal(body.includes('.composer-box[data-can-send="true"]:not([data-running="true"]) .voice-button { display: none; }'), true);
-  assert.equal(body.includes('.composer-box[data-running="true"] .voice-button'), false);
+  assert.equal(body.includes('.composer-box[data-running="true"] .voice-button, .composer-box[data-can-send="true"] .voice-button { display: none; }'), true);
   assert.equal(body.includes("function toggleVoiceInput()"), true);
   assert.equal(body.includes("function appendVoiceTranscript(text)"), true);
   assert.equal(body.includes("無音区切りで送信します"), true);

--- a/worker.js
+++ b/worker.js
@@ -72499,9 +72499,9 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
     .send-button[data-mode="stop"]::before { content: "\u25A0"; }
     .send-button[data-mode="stop"] { color: var(--page-bg); }
     .send-button[data-mode="stop"] span { display: none; }
-    .composer-actions { display: inline-flex; align-items: center; gap: 8px; flex: 0 0 auto; }
+    .composer-actions { display: inline-flex; align-items: center; gap: 0; flex: 0 0 auto; }
     .composer-box[data-can-send="false"] .send-button[data-mode="send"] { display: none; }
-    .composer-box[data-can-send="true"]:not([data-running="true"]) .voice-button { display: none; }
+    .composer-box[data-running="true"] .voice-button, .composer-box[data-can-send="true"] .voice-button { display: none; }
     .followup-queue { display: grid; gap: 8px; padding: 0 10px; }
     .followup-queue[hidden], .followup-draft[hidden] { display: none; }
     .followup-chip, .followup-draft { width: fit-content; max-width: min(720px, 100%); justify-self: end; border: 1px solid var(--border); border-radius: 18px; background: var(--floating-bg); box-shadow: 0 10px 34px var(--shadow); backdrop-filter: blur(16px); -webkit-backdrop-filter: blur(16px); color: var(--text); }
@@ -72741,13 +72741,13 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
           <span class="progress-title">\u9032\u884C\u4E2D</span>
           <p class="progress-text"></p>
         </div>
-        <div class="composer-box">
+        <div class="composer-box" data-can-send="false" data-running="false">
           <button class="media-button" id="butler-media-button" type="button" aria-label="\u753B\u50CF\u30FB\u52D5\u753B\u30FB\u30D5\u30A1\u30A4\u30EB\u3092\u8FFD\u52A0" title="\u753B\u50CF\u30FB\u52D5\u753B\u30FB\u30D5\u30A1\u30A4\u30EB\u3092\u8FFD\u52A0">+</button>
           <input id="butler-media-input" type="file" multiple hidden>
           <textarea id="butler-message" name="text" placeholder="Butler \u306B\u30E1\u30C3\u30BB\u30FC\u30B8..." aria-label="Butler \u306B\u30E1\u30C3\u30BB\u30FC\u30B8" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" enterkeyhint="send"></textarea>
           <div class="composer-actions" aria-label="\u5165\u529B\u64CD\u4F5C">
             <button class="voice-button" id="butler-voice-button" type="button" aria-label="\u97F3\u58F0\u5165\u529B" title="\u97F3\u58F0\u5165\u529B"><span class="voice-bars" aria-hidden="true"><span></span><span></span><span></span><span></span><span></span></span></button>
-            <button class="send-button" id="butler-send-button" type="submit" aria-label="Butler \u306B\u9001\u4FE1"><span>\u2191</span></button>
+            <button class="send-button" id="butler-send-button" type="submit" aria-label="Butler \u306B\u9001\u4FE1" data-mode="send"><span>\u2191</span></button>
           </div>
         </div>
         <div class="followup-draft" id="butler-followup-draft" hidden>


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #811 の Dashboard Butler composer について、PR #821 後の owner correction を反映します。
- 右側操作は voice と send/stop の横並びではなく、単一 action slot として「空欄はマイク、入力後は送信、実行中は停止」に切り替えます。
- この PR は Issue #811 / #814 / #816 の完了を主張しません。

## Satisfied Success Criteria

- 空の入力欄かつ未実行では `#butler-voice-button` のみ表示し、send button は hidden にしました。
- テキスト入力後かつ未実行では voice button を hidden にし、send button を表示します。
- 実行中では voice button を hidden にし、send/stop button を `data-mode="stop"` として表示します。
- mobile E2E で上記の three-state visibility を固定しました。

## Unsatisfied Success Criteria

- production iPhone / iPad PWA 実機での確認は未実施です。
- 最新コメントへ飛ぶ button、passkey modal auto-return、送信済み follow-up card cleanup、live progress timeline はこの PR では未実装です。
- Issue #811 / #814 / #816 は active scope として残ります。

## Non-goal violations

None.

## 開発前作戦図

- 作戦図 evidence: `docs/development-strategy/issue-811-dashboard-butler-v3-main-chat.md`
- 完了体験: owner が Dashboard Butler PWA の composer で、空欄時はマイク、文字入力後は送信、実行中は停止だけを右端に見る。
- VTDD 全体で進める部分: Issue #811 の iPhone-first main chat composer を correction し、Issue #814 の voice entrypoint が通常 composer を圧迫しない前提を整える。
- 設計: owner-facing Dashboard Butler composer surface の範囲で、右側 action を単一 slot として扱う。`data-can-send` と `data-running` により voice / send / stop の排他表示を制御する。
- 仮説: 原因は PR #821 の voice + stop 横並びが owner correction と逆で、composer 幅を取り、実行中の誤操作も誘うことだという仮説。初期 send button に `data-mode="send"` が無いと CSS hide rule が初期表示に効かない。
- 検証計画: source assertion、generated worker check、mobile Playwright E2E で empty / text / running の visibility と stop mode を検証する。
- 改修見積もり: `src/worker/runtime.js` の composer CSS/markup、generated `worker.js`、`test/worker.test.js` source guard、`scripts/e2e-issue811-dashboard-butler-v3-main-chat.spec.mjs` mobile E2E、#811 strategy note。
- 既に通っている経路: voice button、send/stop button、`data-can-send`、`data-running`、#811 mobile E2E は既存。
- 未確認の境界: production iPhone/iPad PWA の実機 layout と keyboard 表示時の見え方は未確認。
- 穴が出そうな箇所: initial send button が visible になること、text send state で voice が残ること、running state で voice と stop が横並びに戻ること。
- PR 前に確認すること: topic branch 上であること、open PR #817 と scope が重ならないこと、generated worker と E2E が通ること。
- 実装候補と捨てた案: 採用は right-side single action slot。捨てた案は PR #821 の voice + stop 横並びで、owner が最初の方が正しいと訂正したため不採用。
- merge 後に通す E2E: production iPhone PWA E2E で empty / text / running の切り替えを確認する。
- 次の PR を増やさない理由: この slice は PR #821 の composer action correction だけに閉じ、readback や queue cleanup と混ぜないことで scope を増やさない。
- 停止条件: SpeechRecognition、readback、passkey、deploy、follow-up queue semantics を変更する必要が出た場合はこの PR では停止する。

## Dry-run Impact Report

- Target Issue: Issue #811
- Implementing Success Criteria: Dashboard Butler main chat composer の right-side action を single slot に戻し、empty / text / running の visibility を E2E で固定する。
- Explicit Non-goals: Web Speech API readback 修正、passkey modal return、latest button、follow-up sent card cleanup、deploy、credential / permission mutation、destructive work。
- Expected touched files/routes/workflows: `src/worker/runtime.js`, `worker.js`, `test/worker.test.js`, `scripts/e2e-issue811-dashboard-butler-v3-main-chat.spec.mjs`, `docs/development-strategy/issue-811-dashboard-butler-v3-main-chat.md`
- Affected Issues: Issue #811, Issue #814。Issue #816 は open PR #817 の media queue scope として残します。
- Affected PRs: PR #821 の post-merge correction。PR #817 は open のままですが、この PR は #816 media queue scope を変更しません。
- Affected workflows: local worker unit, generated worker check, Playwright #811 E2E。deploy workflow は実行しません。
- Affected runtime/operator surfaces: Dashboard Butler PWA main chat composer。
- What may break if we patch narrowly: initial button state が JS 実行前に一瞬ずれる可能性、text input state で voice が残る可能性、running state で stop が隠れる可能性。
- Unknowns to investigate before coding: production iPhone keyboard 表示時の controls 幅。
- Validation needed: unit / generated worker / mobile E2E / production PWA visual check。
- Stop condition: composer layout 以外の voice runtime semantics を変更する必要が出た場合。

## Execution Queue Delta

- Queue position before: Issue #811 は parent root として active。Issue #814 は voice workflow、Issue #816 は media queue defect として active。
- Preemption decision: NEXT。owner が PR #821 後の composer action 方針を訂正したため、#814 の追加実装へ戻る前に #811 correction として扱います。
- Queue delta: Issue #811 の composer single action correction をこの PR で進めます。`Now` / `Next` の active Issue 全体は縮小しません。
- Why this PR is next: 空欄時にマイク、入力後に送信、実行中に停止という composer 基本操作が崩れると、voice mode と通常チャットの両方が不快になるため。
- Active Issues not downscoped: Active Issues は縮小しません。Issue #811 / #814 / #816 は未完了として残します。

## File / Line Hypotheses

- file: `src/worker/runtime.js`
  - hypothesis: PR #821 の `.composer-actions` 横並びと active turn voice visibility が owner correction と逆になっている。
  - risk if changed narrowly: 初期 `data-mode` が無いと send button が初期表示され、E2E で empty state が破綻する。
  - validation: source guard と mobile E2E で empty / text / running の排他表示を確認する。
  - related Issue: Issue #811 / Issue #814
- file: `scripts/e2e-issue811-dashboard-butler-v3-main-chat.spec.mjs`
  - hypothesis: empty、text filled、owner_message_accepted 後の active turn を同一 E2E で確認すれば regression を固定できる。
  - risk if changed narrowly: screenshot だけでは hidden / visible の state regression を見逃す。
  - validation: `#butler-voice-button` と `#butler-send-button` の visibility、および `data-mode=stop` を確認する。
  - related Issue: Issue #811

## Hypothesis Retrospective

- expected: CSS と initial markup を single slot 条件へ戻せば、空欄時は voice のみ、入力後は send のみ、実行中は stop のみになる。
- actual: 初期 send button に `data-mode="send"` を付与し、`data-can-send` / `data-running` の CSS rule を調整した結果、E2E が通りました。
- mismatch: production iPhone PWA の keyboard 表示中 visual evidence は未取得です。
- lesson: composer action は voice/readback の convenience より、入力欄の基本 state machine を優先して単一 slot で扱う必要があります。
- should become RAG candidate: production evidence 後に、Dashboard composer controls の single action slot rule として保存候補です。

## Verification Evidence

- Unit: `node --test test/worker.test.js` passed: 285 tests.
- Integration: `npm run build:worker` passed. `npm run check:generated-worker` passed. `git diff --check` passed.
- E2E: `npx playwright test scripts/e2e-issue811-dashboard-butler-v3-main-chat.spec.mjs` passed: 2 tests.
- Manual: production iPhone/iPad PWA manual check is not done.
- Evidence path/link: `docs/mvp/e2e/assets/issue-811/local/issue811-mobile-main-chat-chromium.png`, `docs/mvp/e2e/assets/issue-811/local/issue811-mobile-main-chat-chromium-state.json`, `docs/mvp/e2e/assets/issue-811/local/issue811-ipad-notification-center-chromium.png`, `docs/mvp/e2e/assets/issue-811/local/issue811-ipad-notification-center-chromium-state.json`

## Butler Completion Contract

- Primary owner surface: Dashboard Butler PWA。
- Fallback surface: Custom GPT は fallback surface のみで、この PR の主経路ではありません。
- Owner goal: composer 右端の操作を、空欄はマイク、入力後は送信、実行中は停止として自然に切り替える。
- Butler entrypoint: Dashboard Butler main chat composer。
- Dashboard Butler natural-language path: Dashboard Butler の通常チャット / voice chat entrypoint で、owner が自然文や voice transcript を入れる通常 composer。
- Action Schema exposure: 不要。この PR は Dashboard PWA runtime client behavior の変更です。
- Runtime path: Worker-rendered `/dashboard` HTML / client script composer controls。
- Runner/runtime truth: local unit and Playwright E2E only。production runtime truth は未取得。
- Authority boundary: deploy、credential mutation、permission mutation、destructive work は実行していません。
- E2E evidence: local iPhone/iPad viewport E2E passed。
- Completion status: incomplete

## Surface Update Checklist

- Dashboard Butler composer: updated.
- Worker generated bundle: updated.
- Unit tests: updated and passed.
- E2E evidence: updated and passed.
- Production deploy: not executed.

## Related Constitution Rules

- AGENTS.md Butler Completion Gate
- AGENTS.md Drift Stop Protocol
- AGENTS.md 開発前作戦図 Gate
- docs/mvp/active-issue-execution-queue.md

## Out-of-scope

- passkey modal auto-return
- live progress timeline
- latest-comment jump button
- sent follow-up card cleanup
- production deploy
