### PR TITLE
Issue #741 deploy bridge restart を一回限り control に変更

### DIFF
--- a/docs/development-strategy/issue-741-ephemeral-bridge-restart.md
+++ b/docs/development-strategy/issue-741-ephemeral-bridge-restart.md
@@ -84,6 +84,19 @@ codex fallback reviewer は `/app-server-control` が汎用制御面になって
 
 DO 側の idempotency marker は queue ではなく replay guard として TTL 付き最小 metadata に限定する。保存するのは request body ではなく request/deployRun の key、status、timestamp 程度で、stale execution を後で実行する材料にはしない。
 
+## PR #823 reviewer blocker 第2ラウンド対応
+
+fallback reviewer は、Worker が WebSocket 送信成功を `sent` と報告するだけで、bridge 側の `started` / `blocked` / `duplicate` / `failed` result を Dashboard/Worker に戻していない点を merge blocker とした。また、DO claim を送信時に確定すると、bridge spawn failure でも同じ deployRunId が 24h retry 不能になる点も blocker とした。これも妥当。
+
+追加 bounded change contract:
+
+- target Issue: Issue #741 / Issue #637。
+- exact Success Criteria: bridge の `deploy_bridge_sync_restart_result` を Worker/DO が受け取り、Dashboard thread に runtime truth として append する。`failed` result では DO claim を release し、同じ deployRunId の retry を可能にする。`started` と `duplicate` は replay guard として claim を維持する。
+- Non-goals: detached child が systemd restart 完了後に同じ WebSocket へ before/after state を返すこと、live E2E、logrotate/tmpfiles、Action Schema 追加。
+- files expected to change: `src/worker/runtime.js`, `test/worker.test.js`, `worker.js`, this strategy file。
+- validation: focused DO app-server control/result tests、bridge restart control tests、`npm run build:worker`、`npm run verify:worker`。
+- stop condition: restart 完了後の before/after state を同じ PR で保証するには bridge self-restart script の protocol 変更が必要になる場合。この PR では local log/systemd journal evidence と Dashboard result message までに限定し、live before/after は merge 後 E2E として残す。
+
 ## 実装候補と捨てた案
 
 採用: deploy success event から接続中 bridge へ one-shot WebSocket control request を送る。

--- a/docs/development-strategy/issue-741-ephemeral-bridge-restart.md
+++ b/docs/development-strategy/issue-741-ephemeral-bridge-restart.md
@@ -69,6 +69,21 @@ Cloudflare Worker から VPS へ直接 HTTP/SSH する経路は作らない。br
 - Worker generated file と source が一致すること。
 - PR body に `Execution Queue Delta` と `vps_handoff_gap_found` / `recovery_gap_found` の解消範囲を明記すること。
 
+## PR #823 review blocker 対応
+
+codex fallback reviewer は `/app-server-control` が汎用制御面になっていることと、一回限り restart の冪等性がないことを merge blocker とした。これは妥当で、このままでは「fixed command のみ」「一回限り」という authority boundary が実装で保証されない。
+
+追加 bounded change contract:
+
+- target Issue: Issue #741 / Issue #637。
+- exact Success Criteria: `/app-server-control` は deploy bridge restart 専用 payload だけを受ける。DO 側で type / commandClass / service / ref / repository / deployRunId を再検証する。DO 側と bridge 側の両方で request/deployRun 単位の重複実行を拒否する。
+- Non-goals: live E2E、Action Schema 追加、GitHub secret/permission mutation、既存 Issue comment cleanup、VPS logrotate/tmpfiles 設定。
+- files expected to change: `src/worker/runtime.js`, `scripts/run-dashboard-app-server-bridge.mjs`, `test/worker.test.js`, `test/dashboard-app-server-bridge.test.js`, `worker.js`, this strategy file。
+- validation: focused worker tests, bridge control tests, `npm run build:worker`, `npm run verify:worker`。
+- stop condition: 汎用 message forwarding を残さないと実装できない、または queue/storage として restart request 本文を永続化しないと冪等性を担保できない場合は停止する。
+
+DO 側の idempotency marker は queue ではなく replay guard として TTL 付き最小 metadata に限定する。保存するのは request body ではなく request/deployRun の key、status、timestamp 程度で、stale execution を後で実行する材料にはしない。
+
 ## 実装候補と捨てた案
 
 採用: deploy success event から接続中 bridge へ one-shot WebSocket control request を送る。

--- a/docs/development-strategy/issue-741-ephemeral-bridge-restart.md
+++ b/docs/development-strategy/issue-741-ephemeral-bridge-restart.md
@@ -110,6 +110,8 @@ fallback reviewer は、bridge が detached child を起動した直後に `star
 - validation: focused DO app-server control/result tests、bridge restart control tests、`npm run build:worker`、`npm run verify:worker`。
 - stop condition: restart 完了 after state を Dashboard result として返すには bridge self-restart 後の sidecar callback が必要になる場合。この PR では queue 蓄積破棄と launch truth に限定し、完了 after truth 接続は次 Issue/PR に分ける。
 
+追加補正: fallback reviewer 第4指摘により、`/app-server-control` の `duplicate` は `blocked` に丸めず Dashboard thread と runtimeTruth で `bridge_control_duplicate` として出す。deploy event 由来の requestId は `deploy-bridge-restart:<deployRunId>` に固定し、同一 deploy event の重複は拒否する。一方で idempotency key は requestId 単位にし、同じ deployRunId でも別 requestId の明示 retry は bridge 側で受け付ける。これは detached child の post-launch failure callback を実装したものではなく、retry 不能状態を deployRunId 固定の 24h guard で悪化させないための境界調整である。
+
 ## 実装候補と捨てた案
 
 採用: deploy success event から接続中 bridge へ one-shot WebSocket control request を送る。

--- a/docs/development-strategy/issue-741-ephemeral-bridge-restart.md
+++ b/docs/development-strategy/issue-741-ephemeral-bridge-restart.md
@@ -1,0 +1,103 @@
+# Issue #741 ephemeral bridge restart strategy
+
+## 完了体験
+
+deploy 成功後、Dashboard Butler は app-server bridge restart を GitHub Issue comment queue として残さない。接続中の repo-less app-server bridge に一回限りの runtime control message を送り、bridge 側が VPS local で checkout sync と user systemd restart を実行する。owner は Dashboard chat で「restart request を送った / bridge が再起動後に再接続した / 失敗した場合は同じ thread で復旧可能」を見る。GitHub Issue #741 には deploy ごとの未処理 queue comment が増えない。
+
+## VTDD 全体で進める部分
+
+Issue #741 の deploy 後 bridge lifecycle と Issue #637 の VPS recovery plane のうち、deploy standard post-step の transport を修正する。GitHub Issue comment は人間とPR証跡の場所であり、短命の operational queue に使わない。VPS local log と systemd journal を実行証跡の主にし、GitHub にはPR/E2Eで要約 evidence だけを残す。
+
+## 設計
+
+deploy success event を Worker が受けたら、既存の deploy approval grant は引き続き検証する。ただし `createVpsPrivilegedMaintenanceHelperExecutionQueue()` で Issue comment を作らない。代わりに DashboardChatRoom の app-server bridge WebSocket に、`bridge_control` 系の one-shot request を送る。payload は固定 command class `dashboard_bridge_unresolved_deploy_sync_restart`、target ref `origin/main`、service `vtdd-dashboard-app-server-bridge-unresolved.service`、deploy run id、head sha、thread id だけに限定する。
+
+bridge process は control message を受けたら、`scripts/sync-dashboard-app-server-bridge-after-deploy.mjs` を child process として detached に起動する。restart command は最後に自分自身の user service を restart するため、親 bridge は control ack を Worker に返してから detached child を起動する。child stdout/stderr は VPS local log file に append し、systemd journal には service restart before/after が残る。GitHub Issue comment には queue/comment/event を書かない。
+
+bridge が未接続なら Worker は `bridge_control_not_connected` を chat runtime truth として返し、古い queue を作らない。これは「後で溜まった queue をまとめて実行」より安全で、owner-facing には retry/recovery が必要と明示する。
+
+## 仮説
+
+今回の破綻は pagination bug だけではない。GitHub Issue comment を deploy restart の queue にしたため、未処理 queue が GitHub に永続化され、後から selector を直すと古い restart がまとめて実行される危険が生まれた。deploy 後 bridge restart は最新 deploy に対する一回限りの運用制御であり、durable GitHub queue にする設計自体が不適切だった。
+
+既存 Worker は DashboardChatRoom から app-server bridge へ owner turn を送れる。bridge script は user systemd `vtdd-vps-runner.service` wakeup も扱っているため、同じ WebSocket control lane で fixed restart request を受ける実装が最小変更になる。
+
+## 検証計画
+
+- Unit: deploy success follow-up が GitHub Issue comment queue を作らず、bridge control request を送ること。
+- Unit: bridge 未接続時は queue comment を作らず blocked runtime truth を返すこと。
+- Unit: bridge script が deploy restart control request を fixed script argv に変換し、任意 command を受け付けないこと。
+- Unit: bridge script の restart child は detached で起動し、stdout/stderr log path を VPS local path に限定すること。
+- Unit: VPS runner の既存 privileged maintenance queue は維持するが、deploy bridge follow-up は runner queue selector の対象にしないこと。
+- Local: `node --test test/dashboard-app-server-bridge.test.js test/worker.test.js --test-name-pattern "deploy|bridge control|app-server bridge"`
+- Local: `node --test test/sync-dashboard-app-server-bridge-after-deploy.test.js test/vps-runner-script.test.js`
+- Worker source を触るため `npm run build:worker` と `npm run verify:worker` を実行する。
+
+## 改修見積もり
+
+- `src/worker/runtime.js`: deploy bridge follow-up を Issue comment queue から WebSocket control request へ変更する。risk は bridge disconnected 時の owner-facing blocker が弱いと silent failure に見えること。
+- `scripts/run-dashboard-app-server-bridge.mjs`: `deploy_bridge_sync_restart_requested` control message を受け、fixed script を detached 起動する。risk は self-restart の前に ack を返せないと Dashboard から見えないこと。
+- `test/worker.test.js`: deploy event が queue comment を作らず bridge control を送ること、未接続なら blocked になることを固定する。
+- `test/dashboard-app-server-bridge.test.js`: bridge control request の command allowlist と local log path を固定する。
+- `worker.js`: generated worker。`src/worker/runtime.js` 変更後に更新する。
+
+## 既に通っている経路
+
+- GitHub Actions deploy success event は Worker `/v2/events/github-actions` に届き、Dashboard chat event にできる。
+- DashboardChatRoom は app-server bridge WebSocket 接続状態を知り、owner turn request を bridge へ送れる。
+- `scripts/sync-dashboard-app-server-bridge-after-deploy.mjs` は fixed service/ref だけを許可し、tracked dirty checkout なら restart 前に止める。
+- VPS user service は `systemctl --user restart vtdd-dashboard-app-server-bridge-unresolved.service` で再起動できる。
+
+## 未確認の境界
+
+bridge が restart control ack 後にすぐ切断するため、after state を同じ WebSocket で返すことは保証しない。after truth は再接続 event、systemd journal、VPS local log で確認する。今回は GitHub Issue comment へ after event を書かない方針を優先する。
+
+Cloudflare Worker から VPS へ直接 HTTP/SSH する経路は作らない。bridge が未接続の時は「実行できない」と返し、古い restart request を durable に積まない。
+
+## 穴が出そうな箇所
+
+- one-shot request が bridge disconnect で失われると restart されない。ただし stale queue 蓄積より安全で、owner-facing blocker として出す。
+- detached child の log が無制限に増えると別の蓄積問題になる。初期実装では append先を固定し、後続で logrotate/tmpfiles 設定を Issue #741 の lifecycle guard に入れる。
+- deploy success event 重複受信で複数 restart request が飛ぶ可能性がある。既存 event/message dedupe を維持し、run id 単位で二重送信しない。
+- app-server bridge 自身を restart するため、進行中 turn は切れる可能性がある。pending owner message は DashboardChatRoom 側の保存済み queue から復帰する前提を守る。
+
+## PR 前に確認すること
+
+- GitHub Issue #741 に deploy ごとの queue comment を作らないこと。
+- GitHub Issue #741 の既存未処理 queue をこの PR でまとめて実行しないこと。
+- owner-specific runtime URL や credential を public repo に固定しないこと。
+- Worker generated file と source が一致すること。
+- PR body に `Execution Queue Delta` と `vps_handoff_gap_found` / `recovery_gap_found` の解消範囲を明記すること。
+
+## 実装候補と捨てた案
+
+採用: deploy success event から接続中 bridge へ one-shot WebSocket control request を送る。
+
+採用: bridge process が fixed script を detached 起動し、VPS local log と systemd journal に証跡を残す。
+
+捨てた案: runner の Issue comment pagination だけを直す。古い queue を後から拾う危険と GitHub comment 蓄積問題を残す。
+
+捨てた案: GitHub Issue comment を作成後に delete/update する。GitHub を短命 queue store として使い続けるため不採用。
+
+捨てた案: GitHub Actions から VPS SSH restart する。VPS credential を Actions に広げるため不採用。
+
+捨てた案: Cloudflare Worker から任意 VPS endpoint を叩く。VPS inbound API と認証面が未設計で、今回の最小 slice を超える。
+
+## merge 後に通す E2E
+
+1. deploy-production を実行する。
+2. Issue #741 のコメント数が deploy bridge queue で増えないことを確認する。
+3. Dashboard chat に deploy success と bridge restart request sent / blocked のどちらかが出ることを確認する。
+4. bridge connected 状態では VPS `ActiveEnterTimestamp` と MainPID が deploy 後に変わることを確認する。
+5. VPS local bridge restart log が肥大化しないよう、logrotate/tmpfiles follow-up を確認する。
+
+## 次の PR を増やさない理由
+
+この修正は pagination と cleanup の小手先ではなく、deploy restart transport の根を変える必要がある。Worker と bridge script の両端を同じ PR で変えないと、queue 作成停止だけで restart 不能になるか、bridge 側 receiver だけが未使用で残る。
+
+## 停止条件
+
+- bridge WebSocket control lane が存在せず、Worker から一回限り restart request を送れないことが判明した場合。
+- restart に root credential、permission mutation、GitHub secret mutation が必要になった場合。
+- fixed argv 以外の任意 command を許す必要が出た場合。
+- GitHub Issue comment queue を残さないと restart できない設計しか取れない場合。

--- a/docs/development-strategy/issue-741-ephemeral-bridge-restart.md
+++ b/docs/development-strategy/issue-741-ephemeral-bridge-restart.md
@@ -91,11 +91,24 @@ fallback reviewer は、Worker が WebSocket 送信成功を `sent` と報告す
 追加 bounded change contract:
 
 - target Issue: Issue #741 / Issue #637。
-- exact Success Criteria: bridge の `deploy_bridge_sync_restart_result` を Worker/DO が受け取り、Dashboard thread に runtime truth として append する。`failed` result では DO claim を release し、同じ deployRunId の retry を可能にする。`started` と `duplicate` は replay guard として claim を維持する。
+- exact Success Criteria: bridge の `deploy_bridge_sync_restart_result` を Worker/DO が受け取り、Dashboard thread に runtime truth として appendする。当初は `failed` result で DO claim を release し、`started` と `duplicate` は replay guard として claim を維持する想定だったが、第3ラウンドで `launch_failed` / `launch_started` に置換した。
 - Non-goals: detached child が systemd restart 完了後に同じ WebSocket へ before/after state を返すこと、live E2E、logrotate/tmpfiles、Action Schema 追加。
 - files expected to change: `src/worker/runtime.js`, `test/worker.test.js`, `worker.js`, this strategy file。
 - validation: focused DO app-server control/result tests、bridge restart control tests、`npm run build:worker`、`npm run verify:worker`。
 - stop condition: restart 完了後の before/after state を同じ PR で保証するには bridge self-restart script の protocol 変更が必要になる場合。この PR では local log/systemd journal evidence と Dashboard result message までに限定し、live before/after は merge 後 E2E として残す。
+
+## PR #823 reviewer blocker 第3ラウンド対応
+
+fallback reviewer は、bridge が detached child を起動した直後に `started` result を返しているため、Dashboard からは systemd restart の完了結果に見えてしまう点を merge blocker とした。さらに detached child が後で失敗しても bridge process は結果を返せず、bridge 側 in-memory idempotency marker を解放できない。この指摘も妥当で、この PR で restart 完了を返すと主張すると過剰 claim になる。
+
+追加 bounded change contract:
+
+- target Issue: Issue #741 / Issue #637。
+- exact Success Criteria: bridge が返す result status は `launch_started` / `launch_failed` / `blocked` / `duplicate` に限定し、systemd restart 完了とは別物として Dashboard thread に明示する。`launch_started` は detached script の起動成功だけを意味し、actual before/after truth は VPS local log / systemd journal / bridge reconnect event で確認する。`launch_failed` のみ DO claim を release し、spawn 失敗 retry を可能にする。
+- Non-goals: detached child から Worker へ restart 完了 event を送る protocol 追加、live deploy E2E、logrotate/tmpfiles、Action Schema 追加、既存 GitHub Issue comment cleanup。
+- files expected to change: `src/worker/runtime.js`, `scripts/run-dashboard-app-server-bridge.mjs`, `test/worker.test.js`, `test/dashboard-app-server-bridge.test.js`, `worker.js`, this strategy file。
+- validation: focused DO app-server control/result tests、bridge restart control tests、`npm run build:worker`、`npm run verify:worker`。
+- stop condition: restart 完了 after state を Dashboard result として返すには bridge self-restart 後の sidecar callback が必要になる場合。この PR では queue 蓄積破棄と launch truth に限定し、完了 after truth 接続は次 Issue/PR に分ける。
 
 ## 実装候補と捨てた案
 

--- a/scripts/run-dashboard-app-server-bridge.mjs
+++ b/scripts/run-dashboard-app-server-bridge.mjs
@@ -572,7 +572,7 @@ export async function executeDeployBridgeSyncRestartRequest({
       deployRunId: normalizeBridgeText(request.deployRunId),
       repository: normalizeBridgeText(request.repository),
       relatedIssue: Number(request.relatedIssue || 0) || null,
-      status: "started",
+      status: "launch_started",
       attempted: true,
       command: {
         command: command.command,
@@ -601,7 +601,7 @@ export async function executeDeployBridgeSyncRestartRequest({
       threadId: normalizeBridgeText(request.threadId),
       requestId: normalizeBridgeText(request.requestId),
       executionId: normalizeBridgeText(request.executionId),
-      status: "failed",
+      status: "launch_failed",
       attempted: true,
       command: {
         command: command.command,

--- a/scripts/run-dashboard-app-server-bridge.mjs
+++ b/scripts/run-dashboard-app-server-bridge.mjs
@@ -465,6 +465,119 @@ export async function executeVpsRunnerWakeup({
   });
 }
 
+export function buildDeployBridgeSyncRestartCommand({ logPath = "" } = {}) {
+  const safeLogPath =
+    normalizeBridgeText(logPath) ||
+    path.join(os.homedir(), "vtdd-runner", "logs", "dashboard-bridge-restart.log");
+  const fixedCommand =
+    "node scripts/sync-dashboard-app-server-bridge-after-deploy.mjs --service vtdd-dashboard-app-server-bridge-unresolved.service --ref origin/main";
+  const script = [
+    "set -eu",
+    'mkdir -p "$HOME/vtdd-runner/logs"',
+    `printf '\\n[%s] deploy bridge sync/restart requested\\n' "$(date -Is)" >> ${JSON.stringify(safeLogPath)}`,
+    `${fixedCommand} >> ${JSON.stringify(safeLogPath)} 2>&1`
+  ].join("\n");
+  return {
+    command: "sh",
+    args: ["-lc", script],
+    shell: false,
+    detached: true,
+    logPath: safeLogPath,
+    fixedCommand
+  };
+}
+
+export async function executeDeployBridgeSyncRestartRequest({
+  request = {},
+  spawnImpl = spawn,
+  now = () => new Date().toISOString()
+} = {}) {
+  const startedAt = now();
+  const command = buildDeployBridgeSyncRestartCommand();
+  const issues = [];
+  if (normalizeBridgeText(request.commandClass) !== "dashboard_bridge_unresolved_deploy_sync_restart") {
+    issues.push("commandClass must be dashboard_bridge_unresolved_deploy_sync_restart");
+  }
+  if (normalizeBridgeText(request.service) !== "vtdd-dashboard-app-server-bridge-unresolved.service") {
+    issues.push("service must be vtdd-dashboard-app-server-bridge-unresolved.service");
+  }
+  if (normalizeBridgeText(request.ref) !== "origin/main") {
+    issues.push("ref must be origin/main");
+  }
+  if (issues.length > 0) {
+    return {
+      type: "deploy_bridge_sync_restart_result",
+      schema: DEFAULT_SCHEMA,
+      threadId: normalizeBridgeText(request.threadId),
+      requestId: normalizeBridgeText(request.requestId),
+      executionId: normalizeBridgeText(request.executionId),
+      status: "blocked",
+      attempted: false,
+      issues,
+      startedAt,
+      completedAt: now()
+    };
+  }
+  try {
+    const child = spawnImpl(command.command, command.args, {
+      shell: false,
+      detached: true,
+      stdio: "ignore"
+    });
+    if (typeof child?.unref === "function") {
+      child.unref();
+    }
+    return {
+      type: "deploy_bridge_sync_restart_result",
+      schema: DEFAULT_SCHEMA,
+      threadId: normalizeBridgeText(request.threadId),
+      requestId: normalizeBridgeText(request.requestId),
+      executionId: normalizeBridgeText(request.executionId),
+      deployRunId: normalizeBridgeText(request.deployRunId),
+      repository: normalizeBridgeText(request.repository),
+      relatedIssue: Number(request.relatedIssue || 0) || null,
+      status: "started",
+      attempted: true,
+      command: {
+        command: command.command,
+        args: command.args,
+        shell: command.shell,
+        detached: command.detached,
+        fixedCommand: command.fixedCommand,
+        logPath: command.logPath
+      },
+      startedAt,
+      completedAt: now(),
+      persistence: {
+        githubIssueCommentQueue: false,
+        vpsLocalLogPath: command.logPath,
+        systemdJournal: "vtdd-dashboard-app-server-bridge-unresolved.service"
+      }
+    };
+  } catch (error) {
+    return {
+      type: "deploy_bridge_sync_restart_result",
+      schema: DEFAULT_SCHEMA,
+      threadId: normalizeBridgeText(request.threadId),
+      requestId: normalizeBridgeText(request.requestId),
+      executionId: normalizeBridgeText(request.executionId),
+      status: "failed",
+      attempted: true,
+      command: {
+        command: command.command,
+        args: command.args,
+        shell: command.shell,
+        detached: command.detached,
+        fixedCommand: command.fixedCommand,
+        logPath: command.logPath
+      },
+      startedAt,
+      completedAt: now(),
+      reason: normalizeBridgeText(error?.message || "failed to start deploy bridge sync/restart").slice(0, 240)
+    };
+  }
+}
+
 async function materializeDashboardMediaReference({ reference, runtimeUrl, token, fetchImpl, tmpRoot }) {
   const normalized = normalizeDashboardMediaReferenceForBridge(reference);
   if (!normalized.mediaId) {
@@ -2691,6 +2804,9 @@ export async function connectDashboardAppServerBridgeOnce({
     }
     if (payload?.type === "runner_wakeup_requested") {
       executeVpsRunnerWakeup({ request: payload }).then((result) => safeSend(result));
+    }
+    if (payload?.type === "deploy_bridge_sync_restart_requested") {
+      executeDeployBridgeSyncRestartRequest({ request: payload }).then((result) => safeSend(result));
     }
   });
 

--- a/scripts/run-dashboard-app-server-bridge.mjs
+++ b/scripts/run-dashboard-app-server-bridge.mjs
@@ -621,9 +621,8 @@ export async function executeDeployBridgeSyncRestartRequest({
 
 export function buildDeployBridgeSyncRestartIdempotencyKey(request = {}) {
   const repository = normalizeBridgeText(request.repository);
-  const deployRunId = normalizeBridgeText(request.deployRunId);
   const requestId = normalizeBridgeText(request.requestId);
-  return `deploy_bridge_sync_restart:${repository}:${deployRunId || requestId}`;
+  return `deploy_bridge_sync_restart:${repository}:${requestId}`;
 }
 
 export function claimDeployBridgeSyncRestartRequest({

--- a/scripts/run-dashboard-app-server-bridge.mjs
+++ b/scripts/run-dashboard-app-server-bridge.mjs
@@ -31,6 +31,8 @@ const DEBUG_SLOW_TURN_MAX_SECONDS = 10 * 60;
 const DEBUG_SLOW_TURN_PROGRESS_INTERVAL_MS = 30 * 1000;
 const DEFAULT_REPO_SYNC_BASE_REF = "main";
 const KNOWN_BRIDGE_UNTRACKED_ARTIFACT_PREFIXES = [".tmp/", "test-results/"];
+const DEPLOY_BRIDGE_SYNC_RESTART_REQUEST_TTL_MS = 24 * 60 * 60 * 1000;
+const deployBridgeSyncRestartProcessedRequests = new Map();
 
 export function buildAppServerInitializeRequest(id = 1) {
   return {
@@ -490,7 +492,8 @@ export function buildDeployBridgeSyncRestartCommand({ logPath = "" } = {}) {
 export async function executeDeployBridgeSyncRestartRequest({
   request = {},
   spawnImpl = spawn,
-  now = () => new Date().toISOString()
+  now = () => new Date().toISOString(),
+  processedRequests = deployBridgeSyncRestartProcessedRequests
 } = {}) {
   const startedAt = now();
   const command = buildDeployBridgeSyncRestartCommand();
@@ -504,6 +507,15 @@ export async function executeDeployBridgeSyncRestartRequest({
   if (normalizeBridgeText(request.ref) !== "origin/main") {
     issues.push("ref must be origin/main");
   }
+  if (!normalizeBridgeText(request.repository)) {
+    issues.push("repository is required");
+  }
+  if (!normalizeBridgeText(request.deployRunId)) {
+    issues.push("deployRunId is required");
+  }
+  if (!normalizeBridgeText(request.requestId)) {
+    issues.push("requestId is required");
+  }
   if (issues.length > 0) {
     return {
       type: "deploy_bridge_sync_restart_result",
@@ -514,6 +526,30 @@ export async function executeDeployBridgeSyncRestartRequest({
       status: "blocked",
       attempted: false,
       issues,
+      startedAt,
+      completedAt: now()
+    };
+  }
+  const idempotencyKey = buildDeployBridgeSyncRestartIdempotencyKey(request);
+  const duplicate = claimDeployBridgeSyncRestartRequest({
+    processedRequests,
+    idempotencyKey,
+    nowMs: Date.parse(startedAt)
+  });
+  if (!duplicate.ok) {
+    return {
+      type: "deploy_bridge_sync_restart_result",
+      schema: DEFAULT_SCHEMA,
+      threadId: normalizeBridgeText(request.threadId),
+      requestId: normalizeBridgeText(request.requestId),
+      executionId: normalizeBridgeText(request.executionId),
+      deployRunId: normalizeBridgeText(request.deployRunId),
+      repository: normalizeBridgeText(request.repository),
+      relatedIssue: Number(request.relatedIssue || 0) || null,
+      status: "duplicate",
+      attempted: false,
+      idempotencyKey,
+      reason: duplicate.reason,
       startedAt,
       completedAt: now()
     };
@@ -548,6 +584,7 @@ export async function executeDeployBridgeSyncRestartRequest({
       },
       startedAt,
       completedAt: now(),
+      idempotencyKey,
       persistence: {
         githubIssueCommentQueue: false,
         vpsLocalLogPath: command.logPath,
@@ -555,6 +592,9 @@ export async function executeDeployBridgeSyncRestartRequest({
       }
     };
   } catch (error) {
+    if (processedRequests && typeof processedRequests.delete === "function") {
+      processedRequests.delete(idempotencyKey);
+    }
     return {
       type: "deploy_bridge_sync_restart_result",
       schema: DEFAULT_SCHEMA,
@@ -573,9 +613,50 @@ export async function executeDeployBridgeSyncRestartRequest({
       },
       startedAt,
       completedAt: now(),
+      idempotencyKey,
       reason: normalizeBridgeText(error?.message || "failed to start deploy bridge sync/restart").slice(0, 240)
     };
   }
+}
+
+export function buildDeployBridgeSyncRestartIdempotencyKey(request = {}) {
+  const repository = normalizeBridgeText(request.repository);
+  const deployRunId = normalizeBridgeText(request.deployRunId);
+  const requestId = normalizeBridgeText(request.requestId);
+  return `deploy_bridge_sync_restart:${repository}:${deployRunId || requestId}`;
+}
+
+export function claimDeployBridgeSyncRestartRequest({
+  processedRequests = deployBridgeSyncRestartProcessedRequests,
+  idempotencyKey = "",
+  nowMs = Date.now()
+} = {}) {
+  const key = normalizeBridgeText(idempotencyKey);
+  if (!key || !processedRequests || typeof processedRequests.get !== "function" || typeof processedRequests.set !== "function") {
+    return {
+      ok: false,
+      reason: "deploy bridge restart idempotency state unavailable"
+    };
+  }
+  const numericNow = Number.isFinite(Number(nowMs)) ? Number(nowMs) : Date.now();
+  for (const [existingKey, record] of processedRequests.entries()) {
+    const expiresAt = Number(record?.expiresAt || 0);
+    if (expiresAt > 0 && expiresAt <= numericNow) {
+      processedRequests.delete(existingKey);
+    }
+  }
+  if (processedRequests.has(key)) {
+    return {
+      ok: false,
+      reason: "deploy bridge restart request was already processed"
+    };
+  }
+  processedRequests.set(key, {
+    status: "claimed",
+    createdAt: new Date(numericNow).toISOString(),
+    expiresAt: numericNow + DEPLOY_BRIDGE_SYNC_RESTART_REQUEST_TTL_MS
+  });
+  return { ok: true };
 }
 
 async function materializeDashboardMediaReference({ reference, runtimeUrl, token, fetchImpl, tmpRoot }) {

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -923,14 +923,12 @@ export class DashboardChatRoom {
 
   deployBridgeControlIdempotencyKey(message) {
     const repository = normalizeCanonicalRepositoryInput(message?.repository);
-    const deployRunId = normalizeDashboardEventText(message?.deployRunId);
     const requestId = normalizeDashboardEventText(message?.requestId);
     const normalizedThreadId = normalizeDashboardThreadId(message?.threadId);
-    const identity = deployRunId || requestId;
-    if (!repository || !identity) {
+    if (!repository || !requestId) {
       return "";
     }
-    return `deploy_bridge_control_once:${normalizedThreadId}:${repository}:${identity}`;
+    return `deploy_bridge_control_once:${normalizedThreadId}:${repository}:${requestId}`;
   }
 
   async claimDeployBridgeControlOnce(message) {
@@ -5398,7 +5396,7 @@ async function buildDeployBridgeFollowupChatMessage({ event, threadId, env, orig
     threadId,
     message: controlMessage
   });
-  if (!control.ok || control.control?.status !== "sent") {
+  if (!control.ok) {
     return {
       status: "blocked",
       proposalCreated: false,
@@ -5420,6 +5418,87 @@ async function buildDeployBridgeFollowupChatMessage({ event, threadId, env, orig
             repository,
             relatedIssue,
             issues: control.issues || [control.reason || control.control?.reason || "app-server bridge control unavailable"]
+          }),
+          createdAt: record.updatedAt || record.createdAt
+        },
+        { threadId }
+      )
+    };
+  }
+  if (control.control?.status === "duplicate") {
+    return {
+      status: "bridge_control_duplicate",
+      proposalCreated: false,
+      queueCreated: false,
+      bridgeControlSent: false,
+      error: "",
+      reason: control.control?.reason || "deploy bridge restart control was already claimed",
+      issues: [],
+      execution: {
+        executionId,
+        transport: "dashboard_app_server_bridge_control",
+        repository,
+        issueNumber: relatedIssue,
+        dashboardThreadId: threadId,
+        status: "duplicate"
+      },
+      runtimeTruth: {
+        kind: "dashboard_bridge_deploy_sync_restart",
+        status: "bridge_control_duplicate",
+        deployApprovalValidated: true,
+        deployStandardPostStep: "dashboard_bridge_unresolved_deploy_sync_restart",
+        helperQueueReached: false,
+        queueCommentPosted: false,
+        bridgeControlSent: false,
+        bridgeControlDuplicate: true,
+        bridgeControlRequestId: control.control?.requestId || controlMessage.requestId,
+        bridgeControlMessageType: control.control?.messageType || controlMessage.type,
+        rootExecutionStarted: false,
+        helperExecutionStarted: false
+      },
+      message: normalizeDashboardChatMessage(
+        {
+          threadId,
+          messageId,
+          role: "system",
+          repository,
+          relatedIssue,
+          status: "sent",
+          text: buildDeployBridgeFollowupDuplicateMessage({
+            record,
+            repository,
+            relatedIssue,
+            executionId,
+            control
+          }),
+          createdAt: record.updatedAt || record.createdAt
+        },
+        { threadId }
+      )
+    };
+  }
+  if (control.control?.status !== "sent") {
+    return {
+      status: "blocked",
+      proposalCreated: false,
+      queueCreated: false,
+      bridgeControlSent: false,
+      error: "deploy_bridge_control_unavailable",
+      reason: control.control?.reason,
+      issues: control.issues || [control.control?.reason || "app-server bridge control unavailable"],
+      message: normalizeDashboardChatMessage(
+        {
+          threadId,
+          messageId,
+          role: "system",
+          repository,
+          relatedIssue,
+          status: "blocked",
+          text: buildDeployBridgeFollowupBlockedMessage({
+            record,
+            repository,
+            relatedIssue,
+            issues: control.issues || [control.control?.reason || "app-server bridge control unavailable"]
           }),
           createdAt: record.updatedAt || record.createdAt
         },
@@ -5476,10 +5555,11 @@ async function buildDeployBridgeFollowupChatMessage({ event, threadId, env, orig
 }
 
 function buildDeployBridgeFollowupControlMessage({ record, executionId, repository, relatedIssue, threadId } = {}) {
+  const runIdentity = safeIdentifier(record?.runId) || createDashboardRequestId("deploy");
   return {
     type: DASHBOARD_DEPLOY_BRIDGE_CONTROL_TYPE,
     schema: "vtdd.dashboard.app_server_bridge.v1",
-    requestId: createDashboardRequestId("deploy-bridge-restart"),
+    requestId: `deploy-bridge-restart:${runIdentity}`,
     executionId,
     threadId,
     repository,
@@ -5770,6 +5850,25 @@ function buildDeployBridgeFollowupControlMessageText({ record, repository, relat
     "- runtime truth: status=bridge_control_sent, queueCommentPosted=false, rootExecutionStarted=false, helperExecutionStarted=true",
     "",
     "bridge 再接続または VPS journal の before/after truth が戻るまで、live restart 完了とは扱いません。"
+  ].join("\n");
+}
+
+function buildDeployBridgeFollowupDuplicateMessage({ record, repository, relatedIssue, executionId, control } = {}) {
+  return [
+    "deploy 後 bridge sync/restart は、同じ deploy follow-up として既に受け付け済みです。",
+    "",
+    `- repo: ${repository || "未確認"}`,
+    `- related Issue: #${relatedIssue || 741}`,
+    `- deploy run: ${record?.runId || "未確認"}`,
+    `- deploy sha: ${record?.headSha ? record.headSha.slice(0, 12) : "未確認"}`,
+    "- 対象: repo-less Dashboard app-server bridge",
+    `- executionId: ${executionId || "未生成"}`,
+    `- bridgeControlRequestId: ${control?.control?.requestId || "未取得"}`,
+    `- reason: ${control?.control?.reason || "deploy bridge restart control was already claimed"}`,
+    "- persistence: GitHub Issue comment queue は作成しません。",
+    "- runtime truth: status=bridge_control_duplicate, queueCommentPosted=false, rootExecutionStarted=false, helperExecutionStarted=false",
+    "",
+    "これは重複防止の結果であり、app-server bridge restart の成功とは扱いません。"
   ].join("\n");
 }
 

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -190,6 +190,56 @@ export class DashboardChatRoom {
       });
     }
 
+    if (request.method === "POST" && url.pathname === "/app-server-control") {
+      const payload = await readJson(request);
+      const threadId = normalizeDashboardThreadId(payload.threadId || payload.thread_id);
+      if (!threadId) {
+        return json(422, {
+          ok: false,
+          error: "thread_id_required",
+          reason: "threadId is required"
+        });
+      }
+      const bridgeSockets = this.connectedAppServerBridgeSockets(threadId);
+      if (bridgeSockets.length === 0) {
+        return json(202, {
+          ok: true,
+          control: {
+            status: "unavailable",
+            attempted: false,
+            reason: "app-server bridge socket is not connected"
+          }
+        });
+      }
+      const message =
+        payload.message && typeof payload.message === "object"
+          ? {
+              ...payload.message,
+              threadId,
+              schema: "vtdd.dashboard.app_server_bridge.v1",
+              createdAt: normalizeIsoTimestamp(payload.message.createdAt || payload.message.created_at) || new Date().toISOString()
+            }
+          : null;
+      if (!message?.type) {
+        return json(422, {
+          ok: false,
+          error: "app_server_control_message_required",
+          reason: "message.type is required"
+        });
+      }
+      const sent = this.sendSocket(bridgeSockets[0], message);
+      return json(202, {
+        ok: true,
+        control: {
+          status: sent ? "sent" : "unavailable",
+          attempted: sent,
+          reason: sent ? "app-server bridge control message sent" : "failed to send app-server bridge control message",
+          requestId: normalizeDashboardEventText(message.requestId),
+          messageType: normalizeDashboardEventText(message.type)
+        }
+      });
+    }
+
     if (request.headers.get("upgrade")?.toLowerCase() !== "websocket") {
       return json(426, {
         ok: false,
@@ -5144,16 +5194,12 @@ async function buildDeployBridgeFollowupChatMessage({ event, threadId, env, orig
     normalizePositiveInteger(env?.VTDD_DASHBOARD_DEPLOY_BRIDGE_FOLLOWUP_ISSUE) ||
     741;
   const messageId = `dashboard-event:${record.id}:deploy-bridge-followup`;
-  const workingDirectory = normalizeText(env?.VTDD_DASHBOARD_VPS_MAINTENANCE_WORKDIR);
-  const host = normalizeDashboardVpsMaintenanceHost({ env });
   const provider = resolveMemoryProvider(env);
   const memoryValidation = validateMemoryProvider(provider);
-  if (!memoryValidation.ok || !repository || !host || !workingDirectory) {
+  if (!memoryValidation.ok || !repository) {
     const issues = [
       !memoryValidation.ok ? "memory_provider_unavailable" : "",
-      !repository ? "repository_required" : "",
-      !host ? "VTDD_DASHBOARD_VPS_MAINTENANCE_HOST required" : "",
-      !workingDirectory ? "VTDD_DASHBOARD_VPS_MAINTENANCE_WORKDIR required" : ""
+      !repository ? "repository_required" : ""
     ].filter(Boolean);
     return {
       status: "blocked",
@@ -5214,33 +5260,27 @@ async function buildDeployBridgeFollowupChatMessage({ event, threadId, env, orig
   }
 
   const executionId = `deploy-bridge-followup-${safeIdentifier(record.runId) || createDashboardRequestId("deploy")}`;
-  const helperRequest = buildDeployBridgeFollowupHelperRequest({
+  const controlMessage = buildDeployBridgeFollowupControlMessage({
     record,
+    executionId,
     repository,
     relatedIssue,
-    host,
-    workingDirectory,
+    threadId
+  });
+  const control = await requestDashboardAppServerBridgeControl({
+    env,
     threadId,
-    deployApproval: deployApproval.approvalGrant
+    message: controlMessage
   });
-  const manifest = buildDashboardVpsMaintenanceManifest({
-    helperRequest,
-    now: record.updatedAt || record.createdAt
-  });
-  const execution = createVpsPrivilegedMaintenanceHelperExecution({
-    payload: {
-      manifest,
-      helperRequest,
-      now: record.updatedAt || record.createdAt
-    }
-  });
-  if (!execution.ok) {
+  if (!control.ok || control.control?.status !== "sent") {
     return {
       status: "blocked",
       proposalCreated: false,
       queueCreated: false,
-      error: execution.error,
-      issues: execution.issues || [],
+      bridgeControlSent: false,
+      error: control.error || "deploy_bridge_control_unavailable",
+      reason: control.reason || control.control?.reason,
+      issues: control.issues || [control.reason || control.control?.reason || "app-server bridge control unavailable"],
       message: normalizeDashboardChatMessage(
         {
           threadId,
@@ -5253,46 +5293,7 @@ async function buildDeployBridgeFollowupChatMessage({ event, threadId, env, orig
             record,
             repository,
             relatedIssue,
-            issues: execution.issues || [execution.error || "execution_handoff_failed"]
-          }),
-          createdAt: record.updatedAt || record.createdAt
-        },
-        { threadId }
-      )
-    };
-  }
-  const queue = await createVpsPrivilegedMaintenanceHelperExecutionQueue({
-    payload: {
-      repository,
-      issueNumber: relatedIssue,
-      executionId,
-      dashboardThreadId: threadId,
-      approvalActor: "Dashboard deploy approval",
-      executionEnvelope: execution.body.executionEnvelope
-    },
-    env
-  });
-  if (!queue.ok) {
-    return {
-      status: "blocked",
-      proposalCreated: false,
-      queueCreated: false,
-      error: queue.error,
-      reason: queue.reason,
-      issues: queue.issues || [],
-      message: normalizeDashboardChatMessage(
-        {
-          threadId,
-          messageId,
-          role: "system",
-          repository,
-          relatedIssue,
-          status: "blocked",
-          text: buildDeployBridgeFollowupBlockedMessage({
-            record,
-            repository,
-            relatedIssue,
-            issues: queue.issues || [queue.reason || queue.error || "queue_handoff_failed"]
+            issues: control.issues || [control.reason || control.control?.reason || "app-server bridge control unavailable"]
           }),
           createdAt: record.updatedAt || record.createdAt
         },
@@ -5301,17 +5302,30 @@ async function buildDeployBridgeFollowupChatMessage({ event, threadId, env, orig
     };
   }
   return {
-    status: "queued_for_vps_helper_execution",
+    status: "bridge_control_sent",
     proposalCreated: false,
-    queueCreated: true,
-    execution: queue.body.execution,
+    queueCreated: false,
+    bridgeControlSent: true,
+    execution: {
+      executionId,
+      transport: "dashboard_app_server_bridge_control",
+      repository,
+      issueNumber: relatedIssue,
+      dashboardThreadId: threadId,
+      status: "sent"
+    },
     runtimeTruth: {
-      ...(queue.body.runtimeTruth || {}),
+      kind: "dashboard_bridge_deploy_sync_restart",
+      status: "bridge_control_sent",
       deployApprovalValidated: true,
       deployStandardPostStep: "dashboard_bridge_unresolved_deploy_sync_restart",
-      helperQueueReached: true,
+      helperQueueReached: false,
+      queueCommentPosted: false,
+      bridgeControlSent: true,
+      bridgeControlRequestId: control.control?.requestId || controlMessage.requestId,
+      bridgeControlMessageType: control.control?.messageType || controlMessage.type,
       rootExecutionStarted: false,
-      helperExecutionStarted: false
+      helperExecutionStarted: true
     },
     message: normalizeDashboardChatMessage(
       {
@@ -5321,16 +5335,36 @@ async function buildDeployBridgeFollowupChatMessage({ event, threadId, env, orig
         repository,
         relatedIssue,
         status: "sent",
-        text: buildDeployBridgeFollowupQueuedMessage({
+        text: buildDeployBridgeFollowupControlMessageText({
           record,
           repository,
           relatedIssue,
-          queue: queue.body
+          executionId,
+          control
         }),
         createdAt: record.updatedAt || record.createdAt
       },
       { threadId }
     )
+  };
+}
+
+function buildDeployBridgeFollowupControlMessage({ record, executionId, repository, relatedIssue, threadId } = {}) {
+  return {
+    type: "deploy_bridge_sync_restart_requested",
+    schema: "vtdd.dashboard.app_server_bridge.v1",
+    requestId: createDashboardRequestId("deploy-bridge-restart"),
+    executionId,
+    threadId,
+    repository,
+    relatedIssue,
+    deployRunId: normalizeDashboardEventText(record?.runId),
+    deployRunUrl: normalizeDashboardUrl(record?.runUrl),
+    headSha: normalizeDashboardEventText(record?.headSha),
+    commandClass: "dashboard_bridge_unresolved_deploy_sync_restart",
+    service: "vtdd-dashboard-app-server-bridge-unresolved.service",
+    ref: "origin/main",
+    createdAt: record?.updatedAt || record?.createdAt || new Date().toISOString()
   };
 }
 
@@ -5400,10 +5434,9 @@ function buildDeployBridgeFollowupHelperRequest({ record, repository, relatedIss
   };
 }
 
-function buildDeployBridgeFollowupQueuedMessage({ record, repository, relatedIssue, queue } = {}) {
-  const execution = queue?.execution || {};
+function buildDeployBridgeFollowupControlMessageText({ record, repository, relatedIssue, executionId, control } = {}) {
   return [
-    "deploy 後 bridge sync/restart を VPS helper queue へ渡しました。",
+    "deploy 後 bridge sync/restart を接続中 app-server bridge へ一回限りで送りました。",
     "",
     `- repo: ${repository || "未確認"}`,
     `- related Issue: #${relatedIssue || 741}`,
@@ -5411,13 +5444,14 @@ function buildDeployBridgeFollowupQueuedMessage({ record, repository, relatedIss
     `- deploy sha: ${record.headSha ? record.headSha.slice(0, 12) : "未確認"}`,
     "- 対象: repo-less Dashboard app-server bridge",
     "- service: vtdd-dashboard-app-server-bridge-unresolved.service",
-    `- executionId: ${execution.executionId || "未生成"}`,
-    `- queueCommentUrl: ${execution.queueCommentUrl || "未取得"}`,
+    `- executionId: ${executionId || "未生成"}`,
+    `- bridgeControlRequestId: ${control?.control?.requestId || "未取得"}`,
     "- authority: deploy approval に含まれる標準後処理です。追加 passkey は不要です。",
+    "- persistence: GitHub Issue comment queue は作成しません。実行証跡は VPS local log / systemd journal 側に残します。",
     "- restart guard: Dashboard の pending owner messages は保存済み queue から bridge reconnect 後に再送します。",
-    "- runtime truth: status=queued_for_vps_helper_execution, rootExecutionStarted=false, helperExecutionStarted=false",
+    "- runtime truth: status=bridge_control_sent, queueCommentPosted=false, rootExecutionStarted=false, helperExecutionStarted=true",
     "",
-    "VPS runner pickup の before/after truth が戻るまで、live restart 完了とは扱いません。"
+    "bridge 再接続または VPS journal の before/after truth が戻るまで、live restart 完了とは扱いません。"
   ].join("\n");
 }
 
@@ -5429,8 +5463,8 @@ function buildDeployBridgeFollowupBlockedMessage({ record, repository, relatedIs
     `- related Issue: #${relatedIssue || 741}`,
     `- deploy run: ${record?.runId || "未確認"}`,
     `- reason: ${(issues || []).join("; ") || "configuration required"}`,
-    "- runtime truth: status=blocked, rootExecutionStarted=false, helperExecutionStarted=false",
-    "- next action: runtime config と memory provider を確認してから、同じ chat で VPS maintenance approval URL を再提示します。"
+    "- runtime truth: status=blocked, queueCommentPosted=false, rootExecutionStarted=false, helperExecutionStarted=false",
+    "- next action: app-server bridge 接続または deploy approval truth を確認してから、同じ chat で再試行します。"
   ].join("\n");
 }
 
@@ -10506,6 +10540,39 @@ async function notifyDashboardChatRoom({ env, threadId, messages }) {
   }
 }
 
+async function requestDashboardAppServerBridgeControl({ env, threadId, message }) {
+  const room = resolveDashboardChatRoomStub(env, threadId);
+  if (!room || typeof room.fetch !== "function") {
+    return {
+      ok: false,
+      error: "dashboard_chat_room_unavailable",
+      reason: "DASHBOARD_CHAT_ROOMS Durable Object binding is not configured"
+    };
+  }
+  try {
+    const response = await room.fetch("https://dashboard-chat-room.internal/app-server-control", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        threadId,
+        message
+      })
+    });
+    const body = await response.json().catch(() => ({}));
+    return {
+      ok: response.ok && body?.ok !== false,
+      status: response.status,
+      ...body
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      error: "dashboard_app_server_bridge_control_failed",
+      reason: normalizeDashboardEventText(error?.message || "failed to send app-server bridge control")
+    };
+  }
+}
+
 function extractCanonicalRepositoryTokenFromDashboardChatText(value) {
   const text = sanitizeDashboardChatText(decodeSafeDashboardChatCommandText(value));
   if (!text) {
@@ -14419,7 +14486,7 @@ function buildGitHubActionsDashboardChatMessageText(event) {
   }
   lines.push("", "次:");
   if (isDeploy && conclusion === "success") {
-    lines.push("- deploy 後 bridge sync/restart helper queue handoff を同じ chat に出します。");
+    lines.push("- deploy 後 bridge sync/restart を接続中 app-server bridge へ一回限りで送ります。");
     lines.push("- production E2E / runtime truth を確認します。");
   } else if (conclusion === "failure" || conclusion === "cancelled" || conclusion === "timed_out") {
     lines.push("- deploy / Actions の失敗原因を確認し、blocker と次 action を出します。");

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -617,6 +617,10 @@ export class DashboardChatRoom {
   }
 
   async acceptAppServerBridgeMessage({ socket, attachment, payload }) {
+    if (normalizeDashboardEventText(payload?.type).toLowerCase() === "deploy_bridge_sync_restart_result") {
+      await this.acceptDeployBridgeSyncRestartResult({ socket, attachment, payload });
+      return;
+    }
     const normalized = normalizeDashboardAppServerBridgeEvent(payload, {
       fallbackThreadId: attachment?.threadId
     });
@@ -697,6 +701,44 @@ export class DashboardChatRoom {
     if (messagesToAppend.some((message) => shouldClearDashboardTransientProgressSnapshot(message))) {
       await this.clearTransientProgressSnapshot(normalized.threadId);
     }
+    await this.broadcastThread({ threadId: normalized.threadId, messages });
+  }
+
+  async acceptDeployBridgeSyncRestartResult({ socket, attachment, payload }) {
+    const normalized = normalizeDeployBridgeSyncRestartResult(payload, {
+      fallbackThreadId: attachment?.threadId
+    });
+    if (!normalized.ok) {
+      this.sendSocket(socket, {
+        type: "error",
+        ok: false,
+        reason: normalized.reason
+      });
+      return;
+    }
+    const attachmentThreadId = normalizeDashboardThreadId(attachment?.threadId);
+    if (attachmentThreadId && normalized.threadId !== attachmentThreadId) {
+      this.sendSocket(socket, {
+        type: "error",
+        ok: false,
+        reason: "deploy bridge result threadId does not match the connected dashboard thread"
+      });
+      return;
+    }
+    if (normalized.status === "failed") {
+      await this.releaseDeployBridgeControlClaim(this.deployBridgeControlIdempotencyKey(normalized));
+    }
+    await this.broadcastTransientStatus({
+      threadId: normalized.threadId,
+      status: normalized.transientStatus,
+      text: normalized.transientText,
+      snapshot: normalized.status === "started",
+      snapshotSource: "deploy_bridge_sync_restart_result"
+    });
+    const store = resolveDashboardChatStore(this.env);
+    const messages = store
+      ? await store.appendMany(normalized.threadId, [normalized.message])
+      : [normalized.message].filter(Boolean);
     await this.broadcastThread({ threadId: normalized.threadId, messages });
   }
 
@@ -5503,6 +5545,145 @@ function normalizeDeployBridgeControlMessage({ threadId, message } = {}) {
     issues,
     message: normalized
   };
+}
+
+function normalizeDeployBridgeSyncRestartResult(payload, { fallbackThreadId = "" } = {}) {
+  const input = normalizeObject(payload);
+  const threadId = normalizeDashboardThreadId(input.threadId || input.thread_id || fallbackThreadId);
+  if (!threadId) {
+    return {
+      ok: false,
+      reason: "threadId is required for deploy bridge restart result"
+    };
+  }
+  const status = normalizeDashboardEventText(input.status).toLowerCase();
+  const allowedStatuses = new Set(["started", "blocked", "duplicate", "failed"]);
+  if (!allowedStatuses.has(status)) {
+    return {
+      ok: false,
+      reason: "deploy bridge restart result status is invalid"
+    };
+  }
+  const repository = normalizeCanonicalRepositoryInput(input.repository);
+  const relatedIssue = normalizePositiveInteger(input.relatedIssue || input.related_issue || input.issueNumber);
+  const deployRunId = normalizeDashboardEventText(input.deployRunId || input.deploy_run_id);
+  const requestId = normalizeDashboardEventText(input.requestId || input.request_id);
+  const executionId = normalizeDashboardEventText(input.executionId || input.execution_id);
+  const createdAt = normalizeIsoTimestamp(input.completedAt || input.completed_at || input.createdAt || input.created_at) || new Date().toISOString();
+  const transientStatus = status === "failed" || status === "blocked" ? "failed" : "thinking";
+  const transientText = buildDeployBridgeSyncRestartResultTransientText({ status });
+  const text = buildDeployBridgeSyncRestartResultMessageText({
+    status,
+    repository,
+    relatedIssue,
+    deployRunId,
+    requestId,
+    executionId,
+    reason: input.reason,
+    issues: input.issues,
+    persistence: input.persistence,
+    command: input.command
+  });
+  return {
+    ok: true,
+    threadId,
+    status,
+    repository,
+    relatedIssue,
+    deployRunId,
+    requestId,
+    executionId,
+    transientStatus,
+    transientText,
+    message: normalizeDashboardChatMessage(
+      {
+        threadId,
+        role: "system",
+        repository,
+        relatedIssue,
+        status: status === "failed" || status === "blocked" ? "failed" : "sent",
+        text,
+        messageId: `deploy-bridge-sync-restart-result:${deployRunId || requestId || createDashboardRequestId("result")}:${status}`,
+        createdAt
+      },
+      { threadId }
+    )
+  };
+}
+
+function buildDeployBridgeSyncRestartResultTransientText({ status = "" } = {}) {
+  if (status === "started") {
+    return "app-server bridge restart script を VPS local で起動しました。before/after は VPS log / systemd journal で確認します。";
+  }
+  if (status === "duplicate") {
+    return "同じ deploy bridge restart request は既に処理済みのため、重複起動しません。";
+  }
+  if (status === "blocked") {
+    return "app-server bridge restart request は bridge 側で blocked になりました。";
+  }
+  return "app-server bridge restart script の起動に失敗しました。同じ deployRunId は retry 可能です。";
+}
+
+function buildDeployBridgeSyncRestartResultMessageText({
+  status = "",
+  repository = "",
+  relatedIssue = null,
+  deployRunId = "",
+  requestId = "",
+  executionId = "",
+  reason = "",
+  issues = [],
+  persistence = null,
+  command = null
+} = {}) {
+  const lines = [
+    "deploy 後 app-server bridge sync/restart の bridge 実行結果を受信しました。",
+    "",
+    "状態:",
+    `- status: ${status || "unknown"}`,
+    `- repository: ${repository || "未指定"}`,
+    `- relatedIssue: ${relatedIssue || "未指定"}`,
+    `- deployRunId: ${deployRunId || "未指定"}`,
+    `- requestId: ${requestId || "未指定"}`,
+    `- executionId: ${executionId || "未指定"}`
+  ];
+  const issueLines = Array.isArray(issues)
+    ? issues.map((issue) => sanitizeDashboardChatText(issue)).filter(Boolean)
+    : [];
+  if (reason || issueLines.length > 0) {
+    lines.push("", "診断:");
+    if (reason) {
+      lines.push(`- reason: ${sanitizeDashboardChatText(reason)}`);
+    }
+    for (const issue of issueLines.slice(0, 8)) {
+      lines.push(`- ${issue}`);
+    }
+  }
+  const normalizedPersistence = normalizeObject(persistence);
+  const logPath = sanitizeDashboardChatText(normalizedPersistence.vpsLocalLogPath || normalizedPersistence.vps_local_log_path || "");
+  const journal = sanitizeDashboardChatText(normalizedPersistence.systemdJournal || normalizedPersistence.systemd_journal || "");
+  if (logPath || journal) {
+    lines.push("", "証跡:");
+    if (logPath) {
+      lines.push(`- VPS local log: ${logPath}`);
+    }
+    if (journal) {
+      lines.push(`- systemd journal: ${journal}`);
+    }
+  }
+  const normalizedCommand = normalizeObject(command);
+  const fixedCommand = sanitizeDashboardChatText(normalizedCommand.fixedCommand || normalizedCommand.fixed_command || "");
+  if (fixedCommand) {
+    lines.push("", "固定 command:");
+    lines.push(`- ${fixedCommand}`);
+  }
+  if (status === "started") {
+    lines.push("", "注記: これは restart script の起動結果です。service restart 後の before/after state は VPS local log / systemd journal / 再接続 event で確認します。");
+  }
+  if (status === "failed") {
+    lines.push("", "注記: bridge 側で起動失敗したため、この deployRunId の retry guard は解放します。");
+  }
+  return lines.join("\n");
 }
 
 function buildDeployBridgeFollowupHelperRequest({ record, repository, relatedIssue, host, workingDirectory, threadId, deployApproval } = {}) {

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -725,14 +725,14 @@ export class DashboardChatRoom {
       });
       return;
     }
-    if (normalized.status === "failed") {
+    if (normalized.status === "launch_failed") {
       await this.releaseDeployBridgeControlClaim(this.deployBridgeControlIdempotencyKey(normalized));
     }
     await this.broadcastTransientStatus({
       threadId: normalized.threadId,
       status: normalized.transientStatus,
       text: normalized.transientText,
-      snapshot: normalized.status === "started",
+      snapshot: normalized.status === "launch_started",
       snapshotSource: "deploy_bridge_sync_restart_result"
     });
     const store = resolveDashboardChatStore(this.env);
@@ -5557,7 +5557,7 @@ function normalizeDeployBridgeSyncRestartResult(payload, { fallbackThreadId = ""
     };
   }
   const status = normalizeDashboardEventText(input.status).toLowerCase();
-  const allowedStatuses = new Set(["started", "blocked", "duplicate", "failed"]);
+  const allowedStatuses = new Set(["launch_started", "launch_failed", "blocked", "duplicate"]);
   if (!allowedStatuses.has(status)) {
     return {
       ok: false,
@@ -5570,7 +5570,7 @@ function normalizeDeployBridgeSyncRestartResult(payload, { fallbackThreadId = ""
   const requestId = normalizeDashboardEventText(input.requestId || input.request_id);
   const executionId = normalizeDashboardEventText(input.executionId || input.execution_id);
   const createdAt = normalizeIsoTimestamp(input.completedAt || input.completed_at || input.createdAt || input.created_at) || new Date().toISOString();
-  const transientStatus = status === "failed" || status === "blocked" ? "failed" : "thinking";
+  const transientStatus = status === "launch_failed" || status === "blocked" ? "failed" : "thinking";
   const transientText = buildDeployBridgeSyncRestartResultTransientText({ status });
   const text = buildDeployBridgeSyncRestartResultMessageText({
     status,
@@ -5601,7 +5601,7 @@ function normalizeDeployBridgeSyncRestartResult(payload, { fallbackThreadId = ""
         role: "system",
         repository,
         relatedIssue,
-        status: status === "failed" || status === "blocked" ? "failed" : "sent",
+        status: status === "launch_failed" || status === "blocked" ? "failed" : "sent",
         text,
         messageId: `deploy-bridge-sync-restart-result:${deployRunId || requestId || createDashboardRequestId("result")}:${status}`,
         createdAt
@@ -5612,8 +5612,8 @@ function normalizeDeployBridgeSyncRestartResult(payload, { fallbackThreadId = ""
 }
 
 function buildDeployBridgeSyncRestartResultTransientText({ status = "" } = {}) {
-  if (status === "started") {
-    return "app-server bridge restart script を VPS local で起動しました。before/after は VPS log / systemd journal で確認します。";
+  if (status === "launch_started") {
+    return "app-server bridge restart script を VPS local で起動しました。これは起動結果であり、restart 完了結果ではありません。";
   }
   if (status === "duplicate") {
     return "同じ deploy bridge restart request は既に処理済みのため、重複起動しません。";
@@ -5677,10 +5677,10 @@ function buildDeployBridgeSyncRestartResultMessageText({
     lines.push("", "固定 command:");
     lines.push(`- ${fixedCommand}`);
   }
-  if (status === "started") {
-    lines.push("", "注記: これは restart script の起動結果です。service restart 後の before/after state は VPS local log / systemd journal / 再接続 event で確認します。");
+  if (status === "launch_started") {
+    lines.push("", "注記: これは restart script の起動結果です。service restart の完了結果ではありません。service restart 後の before/after state は VPS local log / systemd journal / 再接続 event で確認します。");
   }
-  if (status === "failed") {
+  if (status === "launch_failed") {
     lines.push("", "注記: bridge 側で起動失敗したため、この deployRunId の retry guard は解放します。");
   }
   return lines.join("\n");

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -102,6 +102,11 @@ const DASHBOARD_ICON_PNG_PATH = `/dashboard-icon-${DASHBOARD_ICON_VERSION}.png`;
 const DASHBOARD_ICON_LINKS = `<link rel="icon" type="image/png" sizes="512x512" href="${DASHBOARD_ICON_PNG_PATH}">
   <link rel="shortcut icon" href="${DASHBOARD_ICON_PNG_PATH}">
   <link rel="apple-touch-icon" sizes="512x512" href="${DASHBOARD_ICON_PNG_PATH}">`;
+const DASHBOARD_DEPLOY_BRIDGE_CONTROL_TTL_SECONDS = 24 * 60 * 60;
+const DASHBOARD_DEPLOY_BRIDGE_CONTROL_TYPE = "deploy_bridge_sync_restart_requested";
+const DASHBOARD_DEPLOY_BRIDGE_COMMAND_CLASS = "dashboard_bridge_unresolved_deploy_sync_restart";
+const DASHBOARD_DEPLOY_BRIDGE_SERVICE = "vtdd-dashboard-app-server-bridge-unresolved.service";
+const DASHBOARD_DEPLOY_BRIDGE_REF = "origin/main";
 
 export class DashboardChatRoom {
   constructor(state, env) {
@@ -200,42 +205,62 @@ export class DashboardChatRoom {
           reason: "threadId is required"
         });
       }
+      const message = normalizeDeployBridgeControlMessage({
+        threadId,
+        message: payload.message
+      });
+      if (!message.ok) {
+        return json(422, {
+          ok: false,
+          error: "deploy_bridge_control_invalid",
+          reason: "app-server control only accepts deploy bridge restart requests with fixed target",
+          issues: message.issues
+        });
+      }
+      const idempotency = await this.claimDeployBridgeControlOnce(message.message);
+      if (!idempotency.ok) {
+        return json(202, {
+          ok: true,
+          control: {
+            status: "duplicate",
+            attempted: false,
+            reason: idempotency.reason,
+            requestId: normalizeDashboardEventText(message.message.requestId),
+            messageType: normalizeDashboardEventText(message.message.type),
+            deployRunId: normalizeDashboardEventText(message.message.deployRunId),
+            idempotencyKey: idempotency.key
+          }
+        });
+      }
       const bridgeSockets = this.connectedAppServerBridgeSockets(threadId);
       if (bridgeSockets.length === 0) {
+        await this.releaseDeployBridgeControlClaim(idempotency.key);
         return json(202, {
           ok: true,
           control: {
             status: "unavailable",
             attempted: false,
-            reason: "app-server bridge socket is not connected"
+            reason: "app-server bridge socket is not connected",
+            requestId: normalizeDashboardEventText(message.message.requestId),
+            messageType: normalizeDashboardEventText(message.message.type),
+            deployRunId: normalizeDashboardEventText(message.message.deployRunId)
           }
         });
       }
-      const message =
-        payload.message && typeof payload.message === "object"
-          ? {
-              ...payload.message,
-              threadId,
-              schema: "vtdd.dashboard.app_server_bridge.v1",
-              createdAt: normalizeIsoTimestamp(payload.message.createdAt || payload.message.created_at) || new Date().toISOString()
-            }
-          : null;
-      if (!message?.type) {
-        return json(422, {
-          ok: false,
-          error: "app_server_control_message_required",
-          reason: "message.type is required"
-        });
+      const sent = this.sendSocket(bridgeSockets[0], message.message);
+      if (!sent) {
+        await this.releaseDeployBridgeControlClaim(idempotency.key);
       }
-      const sent = this.sendSocket(bridgeSockets[0], message);
       return json(202, {
         ok: true,
         control: {
           status: sent ? "sent" : "unavailable",
           attempted: sent,
-          reason: sent ? "app-server bridge control message sent" : "failed to send app-server bridge control message",
-          requestId: normalizeDashboardEventText(message.requestId),
-          messageType: normalizeDashboardEventText(message.type)
+          reason: sent ? "deploy bridge restart control message sent" : "failed to send deploy bridge restart control message",
+          requestId: normalizeDashboardEventText(message.message.requestId),
+          messageType: normalizeDashboardEventText(message.message.type),
+          deployRunId: normalizeDashboardEventText(message.message.deployRunId),
+          idempotencyKey: sent ? idempotency.key : ""
         }
       });
     }
@@ -852,6 +877,65 @@ export class DashboardChatRoom {
     }
     socket.send(JSON.stringify(payload));
     return true;
+  }
+
+  deployBridgeControlIdempotencyKey(message) {
+    const repository = normalizeCanonicalRepositoryInput(message?.repository);
+    const deployRunId = normalizeDashboardEventText(message?.deployRunId);
+    const requestId = normalizeDashboardEventText(message?.requestId);
+    const normalizedThreadId = normalizeDashboardThreadId(message?.threadId);
+    const identity = deployRunId || requestId;
+    if (!repository || !identity) {
+      return "";
+    }
+    return `deploy_bridge_control_once:${normalizedThreadId}:${repository}:${identity}`;
+  }
+
+  async claimDeployBridgeControlOnce(message) {
+    const key = this.deployBridgeControlIdempotencyKey(message);
+    if (!key || typeof this.ctx?.storage?.get !== "function" || typeof this.ctx?.storage?.put !== "function") {
+      return {
+        ok: false,
+        key,
+        reason: "deploy bridge control idempotency storage unavailable"
+      };
+    }
+    const existing = await this.ctx.storage.get(key);
+    if (existing) {
+      return {
+        ok: false,
+        key,
+        reason: "deploy bridge restart control was already claimed"
+      };
+    }
+    await this.ctx.storage.put(
+      key,
+      {
+        type: DASHBOARD_DEPLOY_BRIDGE_CONTROL_TYPE,
+        repository: normalizeCanonicalRepositoryInput(message.repository),
+        deployRunId: normalizeDashboardEventText(message.deployRunId),
+        requestId: normalizeDashboardEventText(message.requestId),
+        status: "claimed",
+        createdAt: new Date().toISOString()
+      },
+      { expirationTtl: DASHBOARD_DEPLOY_BRIDGE_CONTROL_TTL_SECONDS }
+    );
+    return { ok: true, key };
+  }
+
+  async releaseDeployBridgeControlClaim(key) {
+    if (!key || !this.ctx?.storage) {
+      return false;
+    }
+    if (typeof this.ctx.storage.delete === "function") {
+      await this.ctx.storage.delete(key);
+      return true;
+    }
+    if (typeof this.ctx.storage.put === "function") {
+      await this.ctx.storage.put(key, null, { expirationTtl: 60 });
+      return true;
+    }
+    return false;
   }
 
   async readAppServerThreadMapping(threadId) {
@@ -5351,7 +5435,7 @@ async function buildDeployBridgeFollowupChatMessage({ event, threadId, env, orig
 
 function buildDeployBridgeFollowupControlMessage({ record, executionId, repository, relatedIssue, threadId } = {}) {
   return {
-    type: "deploy_bridge_sync_restart_requested",
+    type: DASHBOARD_DEPLOY_BRIDGE_CONTROL_TYPE,
     schema: "vtdd.dashboard.app_server_bridge.v1",
     requestId: createDashboardRequestId("deploy-bridge-restart"),
     executionId,
@@ -5361,10 +5445,63 @@ function buildDeployBridgeFollowupControlMessage({ record, executionId, reposito
     deployRunId: normalizeDashboardEventText(record?.runId),
     deployRunUrl: normalizeDashboardUrl(record?.runUrl),
     headSha: normalizeDashboardEventText(record?.headSha),
-    commandClass: "dashboard_bridge_unresolved_deploy_sync_restart",
-    service: "vtdd-dashboard-app-server-bridge-unresolved.service",
-    ref: "origin/main",
+    commandClass: DASHBOARD_DEPLOY_BRIDGE_COMMAND_CLASS,
+    service: DASHBOARD_DEPLOY_BRIDGE_SERVICE,
+    ref: DASHBOARD_DEPLOY_BRIDGE_REF,
     createdAt: record?.updatedAt || record?.createdAt || new Date().toISOString()
+  };
+}
+
+function normalizeDeployBridgeControlMessage({ threadId, message } = {}) {
+  const issues = [];
+  const source = message && typeof message === "object" ? message : {};
+  const normalized = {
+    type: normalizeDashboardEventText(source.type),
+    schema: "vtdd.dashboard.app_server_bridge.v1",
+    requestId: normalizeDashboardEventText(source.requestId),
+    executionId: normalizeDashboardEventText(source.executionId),
+    threadId: normalizeDashboardThreadId(threadId || source.threadId),
+    repository: normalizeCanonicalRepositoryInput(source.repository),
+    relatedIssue: normalizePositiveInteger(source.relatedIssue || source.related_issue),
+    deployRunId: normalizeDashboardEventText(source.deployRunId || source.deploy_run_id),
+    deployRunUrl: normalizeDashboardUrl(source.deployRunUrl || source.deploy_run_url),
+    headSha: normalizeDashboardEventText(source.headSha || source.head_sha),
+    commandClass: normalizeDashboardEventText(source.commandClass || source.command_class),
+    service: normalizeDashboardEventText(source.service),
+    ref: normalizeDashboardEventText(source.ref),
+    createdAt: normalizeIsoTimestamp(source.createdAt || source.created_at) || new Date().toISOString()
+  };
+  if (normalized.type !== DASHBOARD_DEPLOY_BRIDGE_CONTROL_TYPE) {
+    issues.push(`type must be ${DASHBOARD_DEPLOY_BRIDGE_CONTROL_TYPE}`);
+  }
+  if (!normalized.requestId) {
+    issues.push("requestId is required");
+  }
+  if (!normalized.executionId) {
+    issues.push("executionId is required");
+  }
+  if (!normalized.threadId) {
+    issues.push("threadId is required");
+  }
+  if (!normalized.repository) {
+    issues.push("repository is required");
+  }
+  if (!normalized.deployRunId) {
+    issues.push("deployRunId is required");
+  }
+  if (normalized.commandClass !== DASHBOARD_DEPLOY_BRIDGE_COMMAND_CLASS) {
+    issues.push(`commandClass must be ${DASHBOARD_DEPLOY_BRIDGE_COMMAND_CLASS}`);
+  }
+  if (normalized.service !== DASHBOARD_DEPLOY_BRIDGE_SERVICE) {
+    issues.push(`service must be ${DASHBOARD_DEPLOY_BRIDGE_SERVICE}`);
+  }
+  if (normalized.ref !== DASHBOARD_DEPLOY_BRIDGE_REF) {
+    issues.push(`ref must be ${DASHBOARD_DEPLOY_BRIDGE_REF}`);
+  }
+  return {
+    ok: issues.length === 0,
+    issues,
+    message: normalized
   };
 }
 

--- a/test/dashboard-app-server-bridge.test.js
+++ b/test/dashboard-app-server-bridge.test.js
@@ -443,7 +443,7 @@ test("dashboard app-server bridge deploy restart control uses only fixed sync sc
   assert.deepEqual(spawnCalls[0].options, { shell: false, detached: true, stdio: "ignore" });
   assert.equal(spawnCalls[0].unrefCalled, true);
   assert.equal(result.type, "deploy_bridge_sync_restart_result");
-  assert.equal(result.status, "started");
+  assert.equal(result.status, "launch_started");
   assert.equal(result.persistence.githubIssueCommentQueue, false);
   assert.equal(result.persistence.systemdJournal, "vtdd-dashboard-app-server-bridge-unresolved.service");
 });
@@ -511,7 +511,7 @@ test("dashboard app-server bridge deploy restart control dedupes repeated reques
     }
   });
 
-  assert.equal(first.status, "started");
+  assert.equal(first.status, "launch_started");
   assert.equal(duplicate.status, "duplicate");
   assert.equal(duplicate.attempted, false);
   assert.equal(spawnCalls.length, 1);

--- a/test/dashboard-app-server-bridge.test.js
+++ b/test/dashboard-app-server-bridge.test.js
@@ -516,6 +516,26 @@ test("dashboard app-server bridge deploy restart control dedupes repeated reques
   assert.equal(duplicate.attempted, false);
   assert.equal(spawnCalls.length, 1);
   assert.equal(processedRequests.size, 1);
+
+  const explicitRetry = await executeDeployBridgeSyncRestartRequest({
+    request: {
+      ...request,
+      requestId: "deploy-bridge-restart:test-retry"
+    },
+    processedRequests,
+    now: (() => {
+      const values = ["2026-06-07T00:00:04.000Z", "2026-06-07T00:00:05.000Z"];
+      return () => values.shift() || "2026-06-07T00:00:05.000Z";
+    })(),
+    spawnImpl(commandName, args, options) {
+      spawnCalls.push({ command: commandName, args, options });
+      return { unref() {} };
+    }
+  });
+
+  assert.equal(explicitRetry.status, "launch_started");
+  assert.equal(spawnCalls.length, 2);
+  assert.equal(processedRequests.size, 2);
 });
 
 test("dashboard app-server bridge wraps repository traffic-control context into turn input", () => {

--- a/test/dashboard-app-server-bridge.test.js
+++ b/test/dashboard-app-server-bridge.test.js
@@ -24,11 +24,13 @@ import {
   buildDashboardBridgeLiveProgressFallbackEvent,
   buildDashboardBridgeResumeStatusEvent,
   buildDashboardBridgeTurnStartedStatusEvent,
+  buildDeployBridgeSyncRestartCommand,
   buildDashboardTurnInputText,
   collectDashboardBridgeRepoSyncStatus,
   connectDashboardAppServerBridgeOnce,
   createDashboardAppServerClientSelector,
   ensureDashboardBridgeRepoSynced,
+  executeDeployBridgeSyncRestartRequest,
   executeVpsRunnerWakeup,
   extractDashboardAppServerUnsupportedModel,
   extractAppServerNotificationTurnId,
@@ -394,6 +396,80 @@ test("dashboard app-server bridge runner wakeup uses only fixed user systemd sta
   assert.equal(result.fallback, "vtdd-vps-runner.timer");
   assert.equal(result.threadId, "dashboard-main");
   assert.equal(result.executionId, "remote-codex-issue717");
+});
+
+test("dashboard app-server bridge deploy restart control uses only fixed sync script", async () => {
+  const command = buildDeployBridgeSyncRestartCommand({ logPath: "/tmp/vtdd-dashboard-bridge-restart.log" });
+  assert.equal(command.command, "sh");
+  assert.equal(command.shell, false);
+  assert.equal(command.detached, true);
+  assert.equal(command.fixedCommand, "node scripts/sync-dashboard-app-server-bridge-after-deploy.mjs --service vtdd-dashboard-app-server-bridge-unresolved.service --ref origin/main");
+  assert.equal(command.args.length, 2);
+  assert.equal(command.args[0], "-lc");
+  assert.equal(command.args[1].includes("vtdd-dashboard-app-server-bridge-unresolved.service"), true);
+  assert.equal(command.args[1].includes("--ref origin/main"), true);
+  assert.equal(command.args[1].includes("/tmp/vtdd-dashboard-bridge-restart.log"), true);
+
+  const spawnCalls = [];
+  const result = await executeDeployBridgeSyncRestartRequest({
+    request: {
+      threadId: "dashboard-main-unresolved",
+      requestId: "deploy-bridge-restart:test",
+      executionId: "deploy-bridge-followup-123",
+      deployRunId: "123",
+      repository: "marushu/vtdd-v2-p",
+      relatedIssue: 741,
+      commandClass: "dashboard_bridge_unresolved_deploy_sync_restart",
+      service: "vtdd-dashboard-app-server-bridge-unresolved.service",
+      ref: "origin/main"
+    },
+    now: (() => {
+      const values = ["2026-06-07T00:00:00.000Z", "2026-06-07T00:00:01.000Z"];
+      return () => values.shift() || "2026-06-07T00:00:01.000Z";
+    })(),
+    spawnImpl(commandName, args, options) {
+      spawnCalls.push({ command: commandName, args, options });
+      return {
+        unref() {
+          spawnCalls[0].unrefCalled = true;
+        }
+      };
+    }
+  });
+
+  assert.equal(spawnCalls.length, 1);
+  assert.equal(spawnCalls[0].command, "sh");
+  assert.equal(spawnCalls[0].args[0], "-lc");
+  assert.deepEqual(spawnCalls[0].options, { shell: false, detached: true, stdio: "ignore" });
+  assert.equal(spawnCalls[0].unrefCalled, true);
+  assert.equal(result.type, "deploy_bridge_sync_restart_result");
+  assert.equal(result.status, "started");
+  assert.equal(result.persistence.githubIssueCommentQueue, false);
+  assert.equal(result.persistence.systemdJournal, "vtdd-dashboard-app-server-bridge-unresolved.service");
+});
+
+test("dashboard app-server bridge deploy restart control rejects mutable target", async () => {
+  const spawnCalls = [];
+  const result = await executeDeployBridgeSyncRestartRequest({
+    request: {
+      threadId: "dashboard-main-unresolved",
+      requestId: "deploy-bridge-restart:test",
+      executionId: "deploy-bridge-followup-unsafe",
+      commandClass: "dashboard_bridge_unresolved_deploy_sync_restart",
+      service: "other.service",
+      ref: "feature"
+    },
+    spawnImpl(commandName, args, options) {
+      spawnCalls.push({ command: commandName, args, options });
+      return {};
+    }
+  });
+
+  assert.equal(spawnCalls.length, 0);
+  assert.equal(result.status, "blocked");
+  assert.equal(result.attempted, false);
+  assert.equal(result.issues.includes("service must be vtdd-dashboard-app-server-bridge-unresolved.service"), true);
+  assert.equal(result.issues.includes("ref must be origin/main"), true);
 });
 
 test("dashboard app-server bridge wraps repository traffic-control context into turn input", () => {

--- a/test/dashboard-app-server-bridge.test.js
+++ b/test/dashboard-app-server-bridge.test.js
@@ -472,6 +472,52 @@ test("dashboard app-server bridge deploy restart control rejects mutable target"
   assert.equal(result.issues.includes("ref must be origin/main"), true);
 });
 
+test("dashboard app-server bridge deploy restart control dedupes repeated request", async () => {
+  const spawnCalls = [];
+  const processedRequests = new Map();
+  const request = {
+    threadId: "dashboard-main-unresolved",
+    requestId: "deploy-bridge-restart:test",
+    executionId: "deploy-bridge-followup-123",
+    deployRunId: "123",
+    repository: "marushu/vtdd-v2-p",
+    relatedIssue: 741,
+    commandClass: "dashboard_bridge_unresolved_deploy_sync_restart",
+    service: "vtdd-dashboard-app-server-bridge-unresolved.service",
+    ref: "origin/main"
+  };
+  const first = await executeDeployBridgeSyncRestartRequest({
+    request,
+    processedRequests,
+    now: (() => {
+      const values = ["2026-06-07T00:00:00.000Z", "2026-06-07T00:00:01.000Z"];
+      return () => values.shift() || "2026-06-07T00:00:01.000Z";
+    })(),
+    spawnImpl(commandName, args, options) {
+      spawnCalls.push({ command: commandName, args, options });
+      return { unref() {} };
+    }
+  });
+  const duplicate = await executeDeployBridgeSyncRestartRequest({
+    request,
+    processedRequests,
+    now: (() => {
+      const values = ["2026-06-07T00:00:02.000Z", "2026-06-07T00:00:03.000Z"];
+      return () => values.shift() || "2026-06-07T00:00:03.000Z";
+    })(),
+    spawnImpl(commandName, args, options) {
+      spawnCalls.push({ command: commandName, args, options });
+      return { unref() {} };
+    }
+  });
+
+  assert.equal(first.status, "started");
+  assert.equal(duplicate.status, "duplicate");
+  assert.equal(duplicate.attempted, false);
+  assert.equal(spawnCalls.length, 1);
+  assert.equal(processedRequests.size, 1);
+});
+
 test("dashboard app-server bridge wraps repository traffic-control context into turn input", () => {
   const text = buildDashboardTurnInputText({
     repository: "marushu/vtdd-v2-p",

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -4908,7 +4908,7 @@ test("DashboardChatRoom records deploy bridge restart result and releases failed
       deployRunId: "123",
       repository: "marushu/vtdd-v2-p",
       relatedIssue: 741,
-      status: "failed",
+      status: "launch_failed",
       reason: "spawn failed",
       completedAt: "2026-06-07T00:00:01.000Z"
     })

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -739,6 +739,24 @@ function createMockDashboardChatRoomNamespace() {
         return {
           async fetch(input, init) {
             calls.push({ name, input, init });
+            if (String(input || "").endsWith("/app-server-control")) {
+              const payload = JSON.parse(init?.body || "{}");
+              return new Response(
+                JSON.stringify({
+                  ok: true,
+                  control: {
+                    status: "sent",
+                    attempted: true,
+                    requestId: payload.message?.requestId || "test-control-request",
+                    messageType: payload.message?.type || "unknown"
+                  }
+                }),
+                {
+                  status: 202,
+                  headers: { "content-type": "application/json" }
+                }
+              );
+            }
             return new Response(JSON.stringify({ ok: true, name }), {
               status: 202,
               headers: { "content-type": "application/json" }
@@ -7405,36 +7423,41 @@ test("worker ingests GitHub Actions deploy completion event and shows it on dash
   assert.equal(eventBody.messages[0].status, "replied");
   assert.equal(eventBody.messages[0].text.includes("デプロイ完了イベントを受信しました。"), true);
   assert.equal(eventBody.messages[0].text.includes("- PR: PR #552"), true);
-  assert.equal(eventBody.messages[0].text.includes("deploy 後 bridge sync/restart helper queue handoff を同じ chat に出します。"), true);
+  assert.equal(eventBody.messages[0].text.includes("deploy 後 bridge sync/restart を接続中 app-server bridge へ一回限りで送ります。"), true);
   assert.equal(eventBody.messages[0].text.includes("- production E2E / runtime truth を確認します。"), true);
   assert.equal(eventBody.messages[0].text.includes("merge / deploy / credential / permission"), true);
   assert.equal(eventBody.messages[1].messageId, "dashboard-event:github-actions:marushu/vtdd-v2-p:deploy-production:26133044458:deploy-bridge-followup");
   assert.equal(eventBody.messages[1].role, "system");
   assert.equal(eventBody.messages[1].status, "sent");
   assert.equal(eventBody.messages[1].relatedIssue, 741);
-  assert.equal(eventBody.messages[1].text.includes("deploy 後 bridge sync/restart を VPS helper queue へ渡しました。"), true);
+  assert.equal(eventBody.messages[1].text.includes("deploy 後 bridge sync/restart を接続中 app-server bridge へ一回限りで送りました。"), true);
   assert.equal(eventBody.messages[1].text.includes("vtdd-dashboard-app-server-bridge-unresolved.service"), true);
   assert.equal(eventBody.messages[1].text.includes("追加 passkey は不要です。"), true);
-  assert.equal(eventBody.messages[1].text.includes("status=queued_for_vps_helper_execution, rootExecutionStarted=false, helperExecutionStarted=false"), true);
-  assert.equal(eventBody.deployBridgeFollowup.status, "queued_for_vps_helper_execution");
+  assert.equal(eventBody.messages[1].text.includes("GitHub Issue comment queue は作成しません。"), true);
+  assert.equal(eventBody.messages[1].text.includes("status=bridge_control_sent, queueCommentPosted=false"), true);
+  assert.equal(eventBody.deployBridgeFollowup.status, "bridge_control_sent");
   assert.equal(eventBody.deployBridgeFollowup.proposalCreated, false);
-  assert.equal(eventBody.deployBridgeFollowup.queueCreated, true);
-  assert.equal(eventBody.deployBridgeFollowup.runtimeTruth.helperQueueReached, true);
+  assert.equal(eventBody.deployBridgeFollowup.queueCreated, false);
+  assert.equal(eventBody.deployBridgeFollowup.bridgeControlSent, true);
+  assert.equal(eventBody.deployBridgeFollowup.runtimeTruth.helperQueueReached, false);
+  assert.equal(eventBody.deployBridgeFollowup.runtimeTruth.queueCommentPosted, false);
+  assert.equal(eventBody.deployBridgeFollowup.runtimeTruth.bridgeControlSent, true);
   assert.equal(eventBody.deployBridgeFollowup.runtimeTruth.rootExecutionStarted, false);
-  assert.equal(eventBody.deployBridgeFollowup.runtimeTruth.helperExecutionStarted, false);
-  assert.equal(queueCalls.length, 1);
-  const queueCommentBody = JSON.parse(queueCalls[0].init.body).body;
-  assert.equal(queueCommentBody.includes("vtdd:vps-privileged-maintenance-execution:deploy-bridge-followup-26133044458"), true);
-  assert.equal(queueCommentBody.includes('"commandClass": "dashboard_bridge_unresolved_deploy_sync_restart"'), true);
-  assert.equal(queueCommentBody.includes("sync-dashboard-app-server-bridge-after-deploy.mjs"), true);
-  assert.equal(queueCommentBody.includes("deploy-approval-verified-redacted"), true);
-  assert.equal(queueCommentBody.includes("approval:must-not-persist"), false);
+  assert.equal(eventBody.deployBridgeFollowup.runtimeTruth.helperExecutionStarted, true);
+  assert.equal(queueCalls.length, 0);
   assert.equal(JSON.stringify(eventBody.messages).includes("approval:must-not-persist"), false);
   assert.equal(JSON.stringify(eventBody.deployBridgeFollowup).includes("approval:must-not-persist"), false);
   assert.equal(JSON.stringify(eventBody.messages).includes("secret-must-not-persist"), false);
   assert.equal(eventBody.webSocketBroadcast, true);
-  assert.equal(rooms.calls.length, 1);
+  assert.equal(rooms.calls.length, 2);
   assert.equal(rooms.calls[0].name, "dashboard-main-unresolved");
+  assert.equal(String(rooms.calls[0].input).endsWith("/app-server-control"), true);
+  const controlPayload = JSON.parse(rooms.calls[0].init.body);
+  assert.equal(controlPayload.message.type, "deploy_bridge_sync_restart_requested");
+  assert.equal(controlPayload.message.commandClass, "dashboard_bridge_unresolved_deploy_sync_restart");
+  assert.equal(controlPayload.message.service, "vtdd-dashboard-app-server-bridge-unresolved.service");
+  assert.equal(controlPayload.message.ref, "origin/main");
+  assert.equal(rooms.calls[1].name, "dashboard-main-unresolved");
   assert.equal(pushCalls.length, 1);
   assert.equal(pushCalls[0].input, "https://push.example/send/deploy");
   assert.match(pushCalls[0].init.headers.authorization, /^vapid t=.+, k=.+/);

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -730,7 +730,7 @@ async function createTestVapidEnv(extra = {}) {
   };
 }
 
-function createMockDashboardChatRoomNamespace() {
+function createMockDashboardChatRoomNamespace({ controlResponse = null } = {}) {
   const calls = [];
   return {
     calls,
@@ -741,6 +741,13 @@ function createMockDashboardChatRoomNamespace() {
             calls.push({ name, input, init });
             if (String(input || "").endsWith("/app-server-control")) {
               const payload = JSON.parse(init?.body || "{}");
+              if (controlResponse) {
+                const body = typeof controlResponse === "function" ? controlResponse({ payload, name, input, init }) : controlResponse;
+                return new Response(JSON.stringify(body), {
+                  status: 202,
+                  headers: { "content-type": "application/json" }
+                });
+              }
               return new Response(
                 JSON.stringify({
                   ok: true,
@@ -7761,6 +7768,87 @@ test("worker ingests GitHub Actions deploy completion event and shows it on dash
   assert.equal(notificationsBody.includes("直近5分"), false);
   assert.equal(notificationsBody.includes("Web Push: push service accepted 1/1"), true);
   assert.equal(notificationsBody.includes("PWA受信確認: 未確認"), true);
+});
+
+test("worker reports deploy bridge duplicate control distinctly from blocked", async () => {
+  const store = createInMemoryDashboardEventStore();
+  const chatStore = createInMemoryDashboardChatStore();
+  const provider = createInMemoryMemoryProvider();
+  const rooms = createMockDashboardChatRoomNamespace({
+    controlResponse: ({ payload }) => ({
+      ok: true,
+      control: {
+        status: "duplicate",
+        attempted: false,
+        reason: "deploy bridge restart control was already claimed",
+        requestId: payload.message?.requestId || "test-control-request",
+        messageType: payload.message?.type || "unknown",
+        deployRunId: payload.message?.deployRunId || ""
+      }
+    })
+  });
+  await provider.store({
+    id: "approval:deploy-duplicate-test",
+    type: MemoryRecordType.APPROVAL_LOG,
+    content: {
+      kind: "passkey_grant",
+      status: "verified",
+      approvalId: "approval:deploy-duplicate-test",
+      credentialId: "AQIDBA",
+      verifiedAt: "2026-05-20T00:09:00.000Z",
+      expiresAt: "2999-01-01T00:00:00.000Z",
+      scope: {
+        actionType: "deploy_production",
+        highRiskKind: "deploy_production",
+        repositoryInput: "marushu/vtdd-v2-p"
+      }
+    },
+    metadata: { source: "deploy-duplicate-test" },
+    priority: 96,
+    tags: ["passkey_grant", "passkey_approval", "verified"],
+    createdAt: "2026-05-20T00:09:00.000Z"
+  });
+
+  const eventResponse = await worker.fetch(
+    new Request("https://example.com/v2/events/github-actions", {
+      method: "POST",
+      headers: gatewayAuthHeaders,
+      body: JSON.stringify({
+        repository: "marushu/vtdd-v2-p",
+        workflowName: "deploy-production",
+        runId: "26133044458",
+        status: "completed",
+        conclusion: "success",
+        headSha: "ef55709c4f52b54f436417acc239ec03a0c999fd",
+        headBranch: "main",
+        displayTitle: "deploy duplicate test (#741)",
+        updatedAt: "2026-05-20T00:10:01Z",
+        approvalGrantId: "approval:deploy-duplicate-test"
+      })
+    }),
+    {
+      ...gatewayAuthEnv,
+      DASHBOARD_EVENT_STORE: store,
+      DASHBOARD_CHAT_STORE: chatStore,
+      DASHBOARD_CHAT_ROOMS: rooms.namespace,
+      MEMORY_PROVIDER: provider
+    }
+  );
+
+  assert.equal(eventResponse.status, 202);
+  const eventBody = await eventResponse.json();
+  assert.equal(eventBody.deployBridgeFollowup.status, "bridge_control_duplicate");
+  assert.equal(eventBody.deployBridgeFollowup.bridgeControlSent, false);
+  assert.equal(eventBody.deployBridgeFollowup.runtimeTruth.bridgeControlDuplicate, true);
+  assert.equal(eventBody.deployBridgeFollowup.runtimeTruth.queueCommentPosted, false);
+  assert.equal(eventBody.messages[1].status, "sent");
+  assert.equal(eventBody.messages[1].text.includes("status=bridge_control_duplicate"), true);
+  assert.equal(eventBody.messages[1].text.includes("成功とは扱いません"), true);
+  const controlCalls = rooms.calls.filter((call) => String(call.input || "").endsWith("/app-server-control"));
+  assert.equal(controlCalls.length, 1);
+  const controlPayload = JSON.parse(controlCalls[0].init.body);
+  assert.equal(controlPayload.message.requestId, "deploy-bridge-restart:26133044458");
+  assert.equal(controlPayload.message.deployRunId, "26133044458");
 });
 
 test("worker records dashboard PWA push receive ack only for authenticated owner session", async () => {

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -4859,6 +4859,78 @@ test("DashboardChatRoom app-server control rejects generic bridge messages", asy
   assert.equal(bridgeSocket.sent.length, 0);
 });
 
+test("DashboardChatRoom records deploy bridge restart result and releases failed claim", async () => {
+  const bridgeSocket = createMockSocket("app_server_bridge", "dashboard-main-marushu-vtdd-v2-p");
+  const storage = createMockDurableObjectStorage();
+  const store = createInMemoryDashboardChatStore();
+  const room = new DashboardChatRoom(
+    {
+      storage,
+      getWebSockets() {
+        return [bridgeSocket];
+      }
+    },
+    { DASHBOARD_CHAT_STORE: store }
+  );
+  const payload = {
+    threadId: "dashboard-main-marushu-vtdd-v2-p",
+    message: {
+      type: "deploy_bridge_sync_restart_requested",
+      requestId: "deploy-bridge-restart:test",
+      executionId: "deploy-bridge-followup-123",
+      threadId: "dashboard-main-marushu-vtdd-v2-p",
+      repository: "marushu/vtdd-v2-p",
+      relatedIssue: 741,
+      deployRunId: "123",
+      commandClass: "dashboard_bridge_unresolved_deploy_sync_restart",
+      service: "vtdd-dashboard-app-server-bridge-unresolved.service",
+      ref: "origin/main"
+    }
+  };
+
+  const first = await room.fetch(
+    new Request("https://dashboard-room.local/app-server-control", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(payload)
+    })
+  );
+  assert.equal((await first.json()).control.status, "sent");
+  assert.equal(bridgeSocket.sent.length, 1);
+
+  await room.webSocketMessage(
+    bridgeSocket,
+    JSON.stringify({
+      type: "deploy_bridge_sync_restart_result",
+      threadId: "dashboard-main-marushu-vtdd-v2-p",
+      requestId: "deploy-bridge-restart:test",
+      executionId: "deploy-bridge-followup-123",
+      deployRunId: "123",
+      repository: "marushu/vtdd-v2-p",
+      relatedIssue: 741,
+      status: "failed",
+      reason: "spawn failed",
+      completedAt: "2026-06-07T00:00:01.000Z"
+    })
+  );
+  const messages = await store.listThread("dashboard-main-marushu-vtdd-v2-p", { limit: 10 });
+  assert.equal(messages.length, 1);
+  assert.equal(messages[0].status, "failed");
+  assert.equal(messages[0].text.includes("bridge 実行結果を受信しました"), true);
+  assert.equal(messages[0].text.includes("retry guard は解放します"), true);
+  assert.equal(storage.deleteCalls.length, 1);
+
+  const retry = await room.fetch(
+    new Request("https://dashboard-room.local/app-server-control", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(payload)
+    })
+  );
+  assert.equal((await retry.json()).control.status, "sent");
+  assert.equal(bridgeSocket.sent.length, 2);
+});
+
 test("DashboardChatRoom attaches execution queue preflight to repository app-server turns", async () => {
   const provider = createInMemoryMemoryProvider();
   const store = createInMemoryDashboardChatStore();

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -779,8 +779,8 @@ function createMockDurableObjectStorage() {
     async get(key) {
       return values.get(key);
     },
-    async put(key, value) {
-      putCalls.push({ key, value });
+    async put(key, value, options) {
+      putCalls.push({ key, value, options });
       values.set(key, value);
     },
     async delete(key) {
@@ -4766,6 +4766,97 @@ test("DashboardChatRoom sends runner wakeup requests only to connected app-serve
   assert.equal(wakeup.repository, "marushu/vtdd-v2-p");
   assert.equal(wakeup.issueNumber, 717);
   assert.equal(wakeup.queueCommentUrl, "https://github.com/marushu/vtdd-v2-p/issues/717#issuecomment-1");
+});
+
+test("DashboardChatRoom app-server control only sends fixed deploy bridge restart once", async () => {
+  const dashboardSocket = createMockSocket("dashboard", "dashboard-main-marushu-vtdd-v2-p");
+  const bridgeSocket = createMockSocket("app_server_bridge", "dashboard-main-marushu-vtdd-v2-p");
+  const storage = createMockDurableObjectStorage();
+  const room = new DashboardChatRoom(
+    {
+      storage,
+      getWebSockets() {
+        return [dashboardSocket, bridgeSocket];
+      }
+    },
+    { DASHBOARD_CHAT_STORE: createInMemoryDashboardChatStore() }
+  );
+  const payload = {
+    threadId: "dashboard-main-marushu-vtdd-v2-p",
+    message: {
+      type: "deploy_bridge_sync_restart_requested",
+      requestId: "deploy-bridge-restart:test",
+      executionId: "deploy-bridge-followup-123",
+      threadId: "dashboard-main-marushu-vtdd-v2-p",
+      repository: "marushu/vtdd-v2-p",
+      deployRunId: "123",
+      commandClass: "dashboard_bridge_unresolved_deploy_sync_restart",
+      service: "vtdd-dashboard-app-server-bridge-unresolved.service",
+      ref: "origin/main"
+    }
+  };
+
+  const first = await room.fetch(
+    new Request("https://dashboard-room.local/app-server-control", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(payload)
+    })
+  );
+  const firstBody = await first.json();
+  assert.equal(first.status, 202);
+  assert.equal(firstBody.control.status, "sent");
+  assert.equal(firstBody.control.deployRunId, "123");
+  assert.equal(bridgeSocket.sent.length, 1);
+  assert.equal(JSON.parse(bridgeSocket.sent[0]).type, "deploy_bridge_sync_restart_requested");
+  assert.equal(storage.putCalls.at(-1).options.expirationTtl, 86400);
+
+  const duplicate = await room.fetch(
+    new Request("https://dashboard-room.local/app-server-control", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(payload)
+    })
+  );
+  const duplicateBody = await duplicate.json();
+  assert.equal(duplicate.status, 202);
+  assert.equal(duplicateBody.control.status, "duplicate");
+  assert.equal(duplicateBody.control.attempted, false);
+  assert.equal(bridgeSocket.sent.length, 1);
+});
+
+test("DashboardChatRoom app-server control rejects generic bridge messages", async () => {
+  const bridgeSocket = createMockSocket("app_server_bridge", "dashboard-main-marushu-vtdd-v2-p");
+  const room = new DashboardChatRoom(
+    {
+      storage: createMockDurableObjectStorage(),
+      getWebSockets() {
+        return [bridgeSocket];
+      }
+    },
+    { DASHBOARD_CHAT_STORE: createInMemoryDashboardChatStore() }
+  );
+
+  const response = await room.fetch(
+    new Request("https://dashboard-room.local/app-server-control", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        threadId: "dashboard-main-marushu-vtdd-v2-p",
+        message: {
+          type: "runner_wakeup_requested",
+          requestId: "unsafe",
+          commandClass: "anything",
+          service: "other.service",
+          ref: "feature"
+        }
+      })
+    })
+  );
+  const body = await response.json();
+  assert.equal(response.status, 422);
+  assert.equal(body.error, "deploy_bridge_control_invalid");
+  assert.equal(bridgeSocket.sent.length, 0);
 });
 
 test("DashboardChatRoom attaches execution queue preflight to repository app-server turns", async () => {

--- a/worker.js
+++ b/worker.js
@@ -57998,6 +57998,11 @@ var DASHBOARD_ICON_PNG_PATH = `/dashboard-icon-${DASHBOARD_ICON_VERSION}.png`;
 var DASHBOARD_ICON_LINKS = `<link rel="icon" type="image/png" sizes="512x512" href="${DASHBOARD_ICON_PNG_PATH}">
   <link rel="shortcut icon" href="${DASHBOARD_ICON_PNG_PATH}">
   <link rel="apple-touch-icon" sizes="512x512" href="${DASHBOARD_ICON_PNG_PATH}">`;
+var DASHBOARD_DEPLOY_BRIDGE_CONTROL_TTL_SECONDS = 24 * 60 * 60;
+var DASHBOARD_DEPLOY_BRIDGE_CONTROL_TYPE = "deploy_bridge_sync_restart_requested";
+var DASHBOARD_DEPLOY_BRIDGE_COMMAND_CLASS = "dashboard_bridge_unresolved_deploy_sync_restart";
+var DASHBOARD_DEPLOY_BRIDGE_SERVICE = "vtdd-dashboard-app-server-bridge-unresolved.service";
+var DASHBOARD_DEPLOY_BRIDGE_REF = "origin/main";
 var DashboardChatRoom = class {
   constructor(state, env) {
     this.ctx = state;
@@ -58091,39 +58096,62 @@ var DashboardChatRoom = class {
           reason: "threadId is required"
         });
       }
+      const message = normalizeDeployBridgeControlMessage({
+        threadId: threadId2,
+        message: payload.message
+      });
+      if (!message.ok) {
+        return json(422, {
+          ok: false,
+          error: "deploy_bridge_control_invalid",
+          reason: "app-server control only accepts deploy bridge restart requests with fixed target",
+          issues: message.issues
+        });
+      }
+      const idempotency = await this.claimDeployBridgeControlOnce(message.message);
+      if (!idempotency.ok) {
+        return json(202, {
+          ok: true,
+          control: {
+            status: "duplicate",
+            attempted: false,
+            reason: idempotency.reason,
+            requestId: normalizeDashboardEventText(message.message.requestId),
+            messageType: normalizeDashboardEventText(message.message.type),
+            deployRunId: normalizeDashboardEventText(message.message.deployRunId),
+            idempotencyKey: idempotency.key
+          }
+        });
+      }
       const bridgeSockets = this.connectedAppServerBridgeSockets(threadId2);
       if (bridgeSockets.length === 0) {
+        await this.releaseDeployBridgeControlClaim(idempotency.key);
         return json(202, {
           ok: true,
           control: {
             status: "unavailable",
             attempted: false,
-            reason: "app-server bridge socket is not connected"
+            reason: "app-server bridge socket is not connected",
+            requestId: normalizeDashboardEventText(message.message.requestId),
+            messageType: normalizeDashboardEventText(message.message.type),
+            deployRunId: normalizeDashboardEventText(message.message.deployRunId)
           }
         });
       }
-      const message = payload.message && typeof payload.message === "object" ? {
-        ...payload.message,
-        threadId: threadId2,
-        schema: "vtdd.dashboard.app_server_bridge.v1",
-        createdAt: normalizeIsoTimestamp(payload.message.createdAt || payload.message.created_at) || (/* @__PURE__ */ new Date()).toISOString()
-      } : null;
-      if (!message?.type) {
-        return json(422, {
-          ok: false,
-          error: "app_server_control_message_required",
-          reason: "message.type is required"
-        });
+      const sent = this.sendSocket(bridgeSockets[0], message.message);
+      if (!sent) {
+        await this.releaseDeployBridgeControlClaim(idempotency.key);
       }
-      const sent = this.sendSocket(bridgeSockets[0], message);
       return json(202, {
         ok: true,
         control: {
           status: sent ? "sent" : "unavailable",
           attempted: sent,
-          reason: sent ? "app-server bridge control message sent" : "failed to send app-server bridge control message",
-          requestId: normalizeDashboardEventText(message.requestId),
-          messageType: normalizeDashboardEventText(message.type)
+          reason: sent ? "deploy bridge restart control message sent" : "failed to send deploy bridge restart control message",
+          requestId: normalizeDashboardEventText(message.message.requestId),
+          messageType: normalizeDashboardEventText(message.message.type),
+          deployRunId: normalizeDashboardEventText(message.message.deployRunId),
+          idempotencyKey: sent ? idempotency.key : ""
         }
       });
     }
@@ -58676,6 +58704,62 @@ var DashboardChatRoom = class {
     }
     socket.send(JSON.stringify(payload));
     return true;
+  }
+  deployBridgeControlIdempotencyKey(message) {
+    const repository = normalizeCanonicalRepositoryInput(message?.repository);
+    const deployRunId = normalizeDashboardEventText(message?.deployRunId);
+    const requestId = normalizeDashboardEventText(message?.requestId);
+    const normalizedThreadId = normalizeDashboardThreadId(message?.threadId);
+    const identity = deployRunId || requestId;
+    if (!repository || !identity) {
+      return "";
+    }
+    return `deploy_bridge_control_once:${normalizedThreadId}:${repository}:${identity}`;
+  }
+  async claimDeployBridgeControlOnce(message) {
+    const key = this.deployBridgeControlIdempotencyKey(message);
+    if (!key || typeof this.ctx?.storage?.get !== "function" || typeof this.ctx?.storage?.put !== "function") {
+      return {
+        ok: false,
+        key,
+        reason: "deploy bridge control idempotency storage unavailable"
+      };
+    }
+    const existing = await this.ctx.storage.get(key);
+    if (existing) {
+      return {
+        ok: false,
+        key,
+        reason: "deploy bridge restart control was already claimed"
+      };
+    }
+    await this.ctx.storage.put(
+      key,
+      {
+        type: DASHBOARD_DEPLOY_BRIDGE_CONTROL_TYPE,
+        repository: normalizeCanonicalRepositoryInput(message.repository),
+        deployRunId: normalizeDashboardEventText(message.deployRunId),
+        requestId: normalizeDashboardEventText(message.requestId),
+        status: "claimed",
+        createdAt: (/* @__PURE__ */ new Date()).toISOString()
+      },
+      { expirationTtl: DASHBOARD_DEPLOY_BRIDGE_CONTROL_TTL_SECONDS }
+    );
+    return { ok: true, key };
+  }
+  async releaseDeployBridgeControlClaim(key) {
+    if (!key || !this.ctx?.storage) {
+      return false;
+    }
+    if (typeof this.ctx.storage.delete === "function") {
+      await this.ctx.storage.delete(key);
+      return true;
+    }
+    if (typeof this.ctx.storage.put === "function") {
+      await this.ctx.storage.put(key, null, { expirationTtl: 60 });
+      return true;
+    }
+    return false;
   }
   async readAppServerThreadMapping(threadId) {
     const key = `app_server_thread:${normalizeDashboardThreadId(threadId)}`;
@@ -62611,7 +62695,7 @@ async function buildDeployBridgeFollowupChatMessage({ event, threadId, env, orig
 }
 function buildDeployBridgeFollowupControlMessage({ record: record2, executionId, repository, relatedIssue, threadId } = {}) {
   return {
-    type: "deploy_bridge_sync_restart_requested",
+    type: DASHBOARD_DEPLOY_BRIDGE_CONTROL_TYPE,
     schema: "vtdd.dashboard.app_server_bridge.v1",
     requestId: createDashboardRequestId("deploy-bridge-restart"),
     executionId,
@@ -62621,10 +62705,62 @@ function buildDeployBridgeFollowupControlMessage({ record: record2, executionId,
     deployRunId: normalizeDashboardEventText(record2?.runId),
     deployRunUrl: normalizeDashboardUrl(record2?.runUrl),
     headSha: normalizeDashboardEventText(record2?.headSha),
-    commandClass: "dashboard_bridge_unresolved_deploy_sync_restart",
-    service: "vtdd-dashboard-app-server-bridge-unresolved.service",
-    ref: "origin/main",
+    commandClass: DASHBOARD_DEPLOY_BRIDGE_COMMAND_CLASS,
+    service: DASHBOARD_DEPLOY_BRIDGE_SERVICE,
+    ref: DASHBOARD_DEPLOY_BRIDGE_REF,
     createdAt: record2?.updatedAt || record2?.createdAt || (/* @__PURE__ */ new Date()).toISOString()
+  };
+}
+function normalizeDeployBridgeControlMessage({ threadId, message } = {}) {
+  const issues = [];
+  const source = message && typeof message === "object" ? message : {};
+  const normalized = {
+    type: normalizeDashboardEventText(source.type),
+    schema: "vtdd.dashboard.app_server_bridge.v1",
+    requestId: normalizeDashboardEventText(source.requestId),
+    executionId: normalizeDashboardEventText(source.executionId),
+    threadId: normalizeDashboardThreadId(threadId || source.threadId),
+    repository: normalizeCanonicalRepositoryInput(source.repository),
+    relatedIssue: normalizePositiveInteger10(source.relatedIssue || source.related_issue),
+    deployRunId: normalizeDashboardEventText(source.deployRunId || source.deploy_run_id),
+    deployRunUrl: normalizeDashboardUrl(source.deployRunUrl || source.deploy_run_url),
+    headSha: normalizeDashboardEventText(source.headSha || source.head_sha),
+    commandClass: normalizeDashboardEventText(source.commandClass || source.command_class),
+    service: normalizeDashboardEventText(source.service),
+    ref: normalizeDashboardEventText(source.ref),
+    createdAt: normalizeIsoTimestamp(source.createdAt || source.created_at) || (/* @__PURE__ */ new Date()).toISOString()
+  };
+  if (normalized.type !== DASHBOARD_DEPLOY_BRIDGE_CONTROL_TYPE) {
+    issues.push(`type must be ${DASHBOARD_DEPLOY_BRIDGE_CONTROL_TYPE}`);
+  }
+  if (!normalized.requestId) {
+    issues.push("requestId is required");
+  }
+  if (!normalized.executionId) {
+    issues.push("executionId is required");
+  }
+  if (!normalized.threadId) {
+    issues.push("threadId is required");
+  }
+  if (!normalized.repository) {
+    issues.push("repository is required");
+  }
+  if (!normalized.deployRunId) {
+    issues.push("deployRunId is required");
+  }
+  if (normalized.commandClass !== DASHBOARD_DEPLOY_BRIDGE_COMMAND_CLASS) {
+    issues.push(`commandClass must be ${DASHBOARD_DEPLOY_BRIDGE_COMMAND_CLASS}`);
+  }
+  if (normalized.service !== DASHBOARD_DEPLOY_BRIDGE_SERVICE) {
+    issues.push(`service must be ${DASHBOARD_DEPLOY_BRIDGE_SERVICE}`);
+  }
+  if (normalized.ref !== DASHBOARD_DEPLOY_BRIDGE_REF) {
+    issues.push(`ref must be ${DASHBOARD_DEPLOY_BRIDGE_REF}`);
+  }
+  return {
+    ok: issues.length === 0,
+    issues,
+    message: normalized
   };
 }
 function buildDeployBridgeFollowupControlMessageText({ record: record2, repository, relatedIssue, executionId, control } = {}) {

--- a/worker.js
+++ b/worker.js
@@ -58746,14 +58746,12 @@ var DashboardChatRoom = class {
   }
   deployBridgeControlIdempotencyKey(message) {
     const repository = normalizeCanonicalRepositoryInput(message?.repository);
-    const deployRunId = normalizeDashboardEventText(message?.deployRunId);
     const requestId = normalizeDashboardEventText(message?.requestId);
     const normalizedThreadId = normalizeDashboardThreadId(message?.threadId);
-    const identity = deployRunId || requestId;
-    if (!repository || !identity) {
+    if (!repository || !requestId) {
       return "";
     }
-    return `deploy_bridge_control_once:${normalizedThreadId}:${repository}:${identity}`;
+    return `deploy_bridge_control_once:${normalizedThreadId}:${repository}:${requestId}`;
   }
   async claimDeployBridgeControlOnce(message) {
     const key = this.deployBridgeControlIdempotencyKey(message);
@@ -62656,7 +62654,7 @@ async function buildDeployBridgeFollowupChatMessage({ event, threadId, env, orig
     threadId,
     message: controlMessage
   });
-  if (!control.ok || control.control?.status !== "sent") {
+  if (!control.ok) {
     return {
       status: "blocked",
       proposalCreated: false,
@@ -62678,6 +62676,87 @@ async function buildDeployBridgeFollowupChatMessage({ event, threadId, env, orig
             repository,
             relatedIssue,
             issues: control.issues || [control.reason || control.control?.reason || "app-server bridge control unavailable"]
+          }),
+          createdAt: record2.updatedAt || record2.createdAt
+        },
+        { threadId }
+      )
+    };
+  }
+  if (control.control?.status === "duplicate") {
+    return {
+      status: "bridge_control_duplicate",
+      proposalCreated: false,
+      queueCreated: false,
+      bridgeControlSent: false,
+      error: "",
+      reason: control.control?.reason || "deploy bridge restart control was already claimed",
+      issues: [],
+      execution: {
+        executionId,
+        transport: "dashboard_app_server_bridge_control",
+        repository,
+        issueNumber: relatedIssue,
+        dashboardThreadId: threadId,
+        status: "duplicate"
+      },
+      runtimeTruth: {
+        kind: "dashboard_bridge_deploy_sync_restart",
+        status: "bridge_control_duplicate",
+        deployApprovalValidated: true,
+        deployStandardPostStep: "dashboard_bridge_unresolved_deploy_sync_restart",
+        helperQueueReached: false,
+        queueCommentPosted: false,
+        bridgeControlSent: false,
+        bridgeControlDuplicate: true,
+        bridgeControlRequestId: control.control?.requestId || controlMessage.requestId,
+        bridgeControlMessageType: control.control?.messageType || controlMessage.type,
+        rootExecutionStarted: false,
+        helperExecutionStarted: false
+      },
+      message: normalizeDashboardChatMessage(
+        {
+          threadId,
+          messageId,
+          role: "system",
+          repository,
+          relatedIssue,
+          status: "sent",
+          text: buildDeployBridgeFollowupDuplicateMessage({
+            record: record2,
+            repository,
+            relatedIssue,
+            executionId,
+            control
+          }),
+          createdAt: record2.updatedAt || record2.createdAt
+        },
+        { threadId }
+      )
+    };
+  }
+  if (control.control?.status !== "sent") {
+    return {
+      status: "blocked",
+      proposalCreated: false,
+      queueCreated: false,
+      bridgeControlSent: false,
+      error: "deploy_bridge_control_unavailable",
+      reason: control.control?.reason,
+      issues: control.issues || [control.control?.reason || "app-server bridge control unavailable"],
+      message: normalizeDashboardChatMessage(
+        {
+          threadId,
+          messageId,
+          role: "system",
+          repository,
+          relatedIssue,
+          status: "blocked",
+          text: buildDeployBridgeFollowupBlockedMessage({
+            record: record2,
+            repository,
+            relatedIssue,
+            issues: control.issues || [control.control?.reason || "app-server bridge control unavailable"]
           }),
           createdAt: record2.updatedAt || record2.createdAt
         },
@@ -62733,10 +62812,11 @@ async function buildDeployBridgeFollowupChatMessage({ event, threadId, env, orig
   };
 }
 function buildDeployBridgeFollowupControlMessage({ record: record2, executionId, repository, relatedIssue, threadId } = {}) {
+  const runIdentity = safeIdentifier(record2?.runId) || createDashboardRequestId("deploy");
   return {
     type: DASHBOARD_DEPLOY_BRIDGE_CONTROL_TYPE,
     schema: "vtdd.dashboard.app_server_bridge.v1",
-    requestId: createDashboardRequestId("deploy-bridge-restart"),
+    requestId: `deploy-bridge-restart:${runIdentity}`,
     executionId,
     threadId,
     repository,
@@ -62954,6 +63034,24 @@ function buildDeployBridgeFollowupControlMessageText({ record: record2, reposito
     "- runtime truth: status=bridge_control_sent, queueCommentPosted=false, rootExecutionStarted=false, helperExecutionStarted=true",
     "",
     "bridge \u518D\u63A5\u7D9A\u307E\u305F\u306F VPS journal \u306E before/after truth \u304C\u623B\u308B\u307E\u3067\u3001live restart \u5B8C\u4E86\u3068\u306F\u6271\u3044\u307E\u305B\u3093\u3002"
+  ].join("\n");
+}
+function buildDeployBridgeFollowupDuplicateMessage({ record: record2, repository, relatedIssue, executionId, control } = {}) {
+  return [
+    "deploy \u5F8C bridge sync/restart \u306F\u3001\u540C\u3058 deploy follow-up \u3068\u3057\u3066\u65E2\u306B\u53D7\u3051\u4ED8\u3051\u6E08\u307F\u3067\u3059\u3002",
+    "",
+    `- repo: ${repository || "\u672A\u78BA\u8A8D"}`,
+    `- related Issue: #${relatedIssue || 741}`,
+    `- deploy run: ${record2?.runId || "\u672A\u78BA\u8A8D"}`,
+    `- deploy sha: ${record2?.headSha ? record2.headSha.slice(0, 12) : "\u672A\u78BA\u8A8D"}`,
+    "- \u5BFE\u8C61: repo-less Dashboard app-server bridge",
+    `- executionId: ${executionId || "\u672A\u751F\u6210"}`,
+    `- bridgeControlRequestId: ${control?.control?.requestId || "\u672A\u53D6\u5F97"}`,
+    `- reason: ${control?.control?.reason || "deploy bridge restart control was already claimed"}`,
+    "- persistence: GitHub Issue comment queue \u306F\u4F5C\u6210\u3057\u307E\u305B\u3093\u3002",
+    "- runtime truth: status=bridge_control_duplicate, queueCommentPosted=false, rootExecutionStarted=false, helperExecutionStarted=false",
+    "",
+    "\u3053\u308C\u306F\u91CD\u8907\u9632\u6B62\u306E\u7D50\u679C\u3067\u3042\u308A\u3001app-server bridge restart \u306E\u6210\u529F\u3068\u306F\u6271\u3044\u307E\u305B\u3093\u3002"
   ].join("\n");
 }
 function buildDeployBridgeFollowupBlockedMessage({ record: record2, repository, relatedIssue, issues } = {}) {

--- a/worker.js
+++ b/worker.js
@@ -58482,6 +58482,10 @@ var DashboardChatRoom = class {
     ].filter(Boolean);
   }
   async acceptAppServerBridgeMessage({ socket, attachment, payload }) {
+    if (normalizeDashboardEventText(payload?.type).toLowerCase() === "deploy_bridge_sync_restart_result") {
+      await this.acceptDeployBridgeSyncRestartResult({ socket, attachment, payload });
+      return;
+    }
     const normalized = normalizeDashboardAppServerBridgeEvent(payload, {
       fallbackThreadId: attachment?.threadId
     });
@@ -58557,6 +58561,41 @@ var DashboardChatRoom = class {
     if (messagesToAppend.some((message) => shouldClearDashboardTransientProgressSnapshot(message))) {
       await this.clearTransientProgressSnapshot(normalized.threadId);
     }
+    await this.broadcastThread({ threadId: normalized.threadId, messages });
+  }
+  async acceptDeployBridgeSyncRestartResult({ socket, attachment, payload }) {
+    const normalized = normalizeDeployBridgeSyncRestartResult(payload, {
+      fallbackThreadId: attachment?.threadId
+    });
+    if (!normalized.ok) {
+      this.sendSocket(socket, {
+        type: "error",
+        ok: false,
+        reason: normalized.reason
+      });
+      return;
+    }
+    const attachmentThreadId = normalizeDashboardThreadId(attachment?.threadId);
+    if (attachmentThreadId && normalized.threadId !== attachmentThreadId) {
+      this.sendSocket(socket, {
+        type: "error",
+        ok: false,
+        reason: "deploy bridge result threadId does not match the connected dashboard thread"
+      });
+      return;
+    }
+    if (normalized.status === "failed") {
+      await this.releaseDeployBridgeControlClaim(this.deployBridgeControlIdempotencyKey(normalized));
+    }
+    await this.broadcastTransientStatus({
+      threadId: normalized.threadId,
+      status: normalized.transientStatus,
+      text: normalized.transientText,
+      snapshot: normalized.status === "started",
+      snapshotSource: "deploy_bridge_sync_restart_result"
+    });
+    const store = resolveDashboardChatStore(this.env);
+    const messages = store ? await store.appendMany(normalized.threadId, [normalized.message]) : [normalized.message].filter(Boolean);
     await this.broadcastThread({ threadId: normalized.threadId, messages });
   }
   async broadcastThread({ threadId, messages = null }) {
@@ -62762,6 +62801,140 @@ function normalizeDeployBridgeControlMessage({ threadId, message } = {}) {
     issues,
     message: normalized
   };
+}
+function normalizeDeployBridgeSyncRestartResult(payload, { fallbackThreadId = "" } = {}) {
+  const input = normalizeObject12(payload);
+  const threadId = normalizeDashboardThreadId(input.threadId || input.thread_id || fallbackThreadId);
+  if (!threadId) {
+    return {
+      ok: false,
+      reason: "threadId is required for deploy bridge restart result"
+    };
+  }
+  const status = normalizeDashboardEventText(input.status).toLowerCase();
+  const allowedStatuses = /* @__PURE__ */ new Set(["started", "blocked", "duplicate", "failed"]);
+  if (!allowedStatuses.has(status)) {
+    return {
+      ok: false,
+      reason: "deploy bridge restart result status is invalid"
+    };
+  }
+  const repository = normalizeCanonicalRepositoryInput(input.repository);
+  const relatedIssue = normalizePositiveInteger10(input.relatedIssue || input.related_issue || input.issueNumber);
+  const deployRunId = normalizeDashboardEventText(input.deployRunId || input.deploy_run_id);
+  const requestId = normalizeDashboardEventText(input.requestId || input.request_id);
+  const executionId = normalizeDashboardEventText(input.executionId || input.execution_id);
+  const createdAt = normalizeIsoTimestamp(input.completedAt || input.completed_at || input.createdAt || input.created_at) || (/* @__PURE__ */ new Date()).toISOString();
+  const transientStatus = status === "failed" || status === "blocked" ? "failed" : "thinking";
+  const transientText = buildDeployBridgeSyncRestartResultTransientText({ status });
+  const text = buildDeployBridgeSyncRestartResultMessageText({
+    status,
+    repository,
+    relatedIssue,
+    deployRunId,
+    requestId,
+    executionId,
+    reason: input.reason,
+    issues: input.issues,
+    persistence: input.persistence,
+    command: input.command
+  });
+  return {
+    ok: true,
+    threadId,
+    status,
+    repository,
+    relatedIssue,
+    deployRunId,
+    requestId,
+    executionId,
+    transientStatus,
+    transientText,
+    message: normalizeDashboardChatMessage(
+      {
+        threadId,
+        role: "system",
+        repository,
+        relatedIssue,
+        status: status === "failed" || status === "blocked" ? "failed" : "sent",
+        text,
+        messageId: `deploy-bridge-sync-restart-result:${deployRunId || requestId || createDashboardRequestId("result")}:${status}`,
+        createdAt
+      },
+      { threadId }
+    )
+  };
+}
+function buildDeployBridgeSyncRestartResultTransientText({ status = "" } = {}) {
+  if (status === "started") {
+    return "app-server bridge restart script \u3092 VPS local \u3067\u8D77\u52D5\u3057\u307E\u3057\u305F\u3002before/after \u306F VPS log / systemd journal \u3067\u78BA\u8A8D\u3057\u307E\u3059\u3002";
+  }
+  if (status === "duplicate") {
+    return "\u540C\u3058 deploy bridge restart request \u306F\u65E2\u306B\u51E6\u7406\u6E08\u307F\u306E\u305F\u3081\u3001\u91CD\u8907\u8D77\u52D5\u3057\u307E\u305B\u3093\u3002";
+  }
+  if (status === "blocked") {
+    return "app-server bridge restart request \u306F bridge \u5074\u3067 blocked \u306B\u306A\u308A\u307E\u3057\u305F\u3002";
+  }
+  return "app-server bridge restart script \u306E\u8D77\u52D5\u306B\u5931\u6557\u3057\u307E\u3057\u305F\u3002\u540C\u3058 deployRunId \u306F retry \u53EF\u80FD\u3067\u3059\u3002";
+}
+function buildDeployBridgeSyncRestartResultMessageText({
+  status = "",
+  repository = "",
+  relatedIssue = null,
+  deployRunId = "",
+  requestId = "",
+  executionId = "",
+  reason = "",
+  issues = [],
+  persistence = null,
+  command = null
+} = {}) {
+  const lines = [
+    "deploy \u5F8C app-server bridge sync/restart \u306E bridge \u5B9F\u884C\u7D50\u679C\u3092\u53D7\u4FE1\u3057\u307E\u3057\u305F\u3002",
+    "",
+    "\u72B6\u614B:",
+    `- status: ${status || "unknown"}`,
+    `- repository: ${repository || "\u672A\u6307\u5B9A"}`,
+    `- relatedIssue: ${relatedIssue || "\u672A\u6307\u5B9A"}`,
+    `- deployRunId: ${deployRunId || "\u672A\u6307\u5B9A"}`,
+    `- requestId: ${requestId || "\u672A\u6307\u5B9A"}`,
+    `- executionId: ${executionId || "\u672A\u6307\u5B9A"}`
+  ];
+  const issueLines = Array.isArray(issues) ? issues.map((issue2) => sanitizeDashboardChatText(issue2)).filter(Boolean) : [];
+  if (reason || issueLines.length > 0) {
+    lines.push("", "\u8A3A\u65AD:");
+    if (reason) {
+      lines.push(`- reason: ${sanitizeDashboardChatText(reason)}`);
+    }
+    for (const issue2 of issueLines.slice(0, 8)) {
+      lines.push(`- ${issue2}`);
+    }
+  }
+  const normalizedPersistence = normalizeObject12(persistence);
+  const logPath = sanitizeDashboardChatText(normalizedPersistence.vpsLocalLogPath || normalizedPersistence.vps_local_log_path || "");
+  const journal = sanitizeDashboardChatText(normalizedPersistence.systemdJournal || normalizedPersistence.systemd_journal || "");
+  if (logPath || journal) {
+    lines.push("", "\u8A3C\u8DE1:");
+    if (logPath) {
+      lines.push(`- VPS local log: ${logPath}`);
+    }
+    if (journal) {
+      lines.push(`- systemd journal: ${journal}`);
+    }
+  }
+  const normalizedCommand = normalizeObject12(command);
+  const fixedCommand = sanitizeDashboardChatText(normalizedCommand.fixedCommand || normalizedCommand.fixed_command || "");
+  if (fixedCommand) {
+    lines.push("", "\u56FA\u5B9A command:");
+    lines.push(`- ${fixedCommand}`);
+  }
+  if (status === "started") {
+    lines.push("", "\u6CE8\u8A18: \u3053\u308C\u306F restart script \u306E\u8D77\u52D5\u7D50\u679C\u3067\u3059\u3002service restart \u5F8C\u306E before/after state \u306F VPS local log / systemd journal / \u518D\u63A5\u7D9A event \u3067\u78BA\u8A8D\u3057\u307E\u3059\u3002");
+  }
+  if (status === "failed") {
+    lines.push("", "\u6CE8\u8A18: bridge \u5074\u3067\u8D77\u52D5\u5931\u6557\u3057\u305F\u305F\u3081\u3001\u3053\u306E deployRunId \u306E retry guard \u306F\u89E3\u653E\u3057\u307E\u3059\u3002");
+  }
+  return lines.join("\n");
 }
 function buildDeployBridgeFollowupControlMessageText({ record: record2, repository, relatedIssue, executionId, control } = {}) {
   return [

--- a/worker.js
+++ b/worker.js
@@ -58081,6 +58081,52 @@ var DashboardChatRoom = class {
         }
       });
     }
+    if (request.method === "POST" && url.pathname === "/app-server-control") {
+      const payload = await readJson(request);
+      const threadId2 = normalizeDashboardThreadId(payload.threadId || payload.thread_id);
+      if (!threadId2) {
+        return json(422, {
+          ok: false,
+          error: "thread_id_required",
+          reason: "threadId is required"
+        });
+      }
+      const bridgeSockets = this.connectedAppServerBridgeSockets(threadId2);
+      if (bridgeSockets.length === 0) {
+        return json(202, {
+          ok: true,
+          control: {
+            status: "unavailable",
+            attempted: false,
+            reason: "app-server bridge socket is not connected"
+          }
+        });
+      }
+      const message = payload.message && typeof payload.message === "object" ? {
+        ...payload.message,
+        threadId: threadId2,
+        schema: "vtdd.dashboard.app_server_bridge.v1",
+        createdAt: normalizeIsoTimestamp(payload.message.createdAt || payload.message.created_at) || (/* @__PURE__ */ new Date()).toISOString()
+      } : null;
+      if (!message?.type) {
+        return json(422, {
+          ok: false,
+          error: "app_server_control_message_required",
+          reason: "message.type is required"
+        });
+      }
+      const sent = this.sendSocket(bridgeSockets[0], message);
+      return json(202, {
+        ok: true,
+        control: {
+          status: sent ? "sent" : "unavailable",
+          attempted: sent,
+          reason: sent ? "app-server bridge control message sent" : "failed to send app-server bridge control message",
+          requestId: normalizeDashboardEventText(message.requestId),
+          messageType: normalizeDashboardEventText(message.type)
+        }
+      });
+    }
     if (request.headers.get("upgrade")?.toLowerCase() !== "websocket") {
       return json(426, {
         ok: false,
@@ -62411,16 +62457,12 @@ async function buildDeployBridgeFollowupChatMessage({ event, threadId, env, orig
   const repository = normalizeCanonicalRepositoryInput(record2.repository);
   const relatedIssue = normalizePositiveInteger10(record2.issueNumber) || normalizePositiveInteger10(env?.VTDD_DASHBOARD_DEPLOY_BRIDGE_FOLLOWUP_ISSUE) || 741;
   const messageId = `dashboard-event:${record2.id}:deploy-bridge-followup`;
-  const workingDirectory = normalizeText33(env?.VTDD_DASHBOARD_VPS_MAINTENANCE_WORKDIR);
-  const host = normalizeDashboardVpsMaintenanceHost({ env });
   const provider = resolveMemoryProvider(env);
   const memoryValidation = validateMemoryProvider(provider);
-  if (!memoryValidation.ok || !repository || !host || !workingDirectory) {
+  if (!memoryValidation.ok || !repository) {
     const issues = [
       !memoryValidation.ok ? "memory_provider_unavailable" : "",
-      !repository ? "repository_required" : "",
-      !host ? "VTDD_DASHBOARD_VPS_MAINTENANCE_HOST required" : "",
-      !workingDirectory ? "VTDD_DASHBOARD_VPS_MAINTENANCE_WORKDIR required" : ""
+      !repository ? "repository_required" : ""
     ].filter(Boolean);
     return {
       status: "blocked",
@@ -62479,33 +62521,27 @@ async function buildDeployBridgeFollowupChatMessage({ event, threadId, env, orig
     };
   }
   const executionId = `deploy-bridge-followup-${safeIdentifier(record2.runId) || createDashboardRequestId("deploy")}`;
-  const helperRequest = buildDeployBridgeFollowupHelperRequest({
+  const controlMessage = buildDeployBridgeFollowupControlMessage({
     record: record2,
+    executionId,
     repository,
     relatedIssue,
-    host,
-    workingDirectory,
+    threadId
+  });
+  const control = await requestDashboardAppServerBridgeControl({
+    env,
     threadId,
-    deployApproval: deployApproval.approvalGrant
+    message: controlMessage
   });
-  const manifest = buildDashboardVpsMaintenanceManifest({
-    helperRequest,
-    now: record2.updatedAt || record2.createdAt
-  });
-  const execution = createVpsPrivilegedMaintenanceHelperExecution({
-    payload: {
-      manifest,
-      helperRequest,
-      now: record2.updatedAt || record2.createdAt
-    }
-  });
-  if (!execution.ok) {
+  if (!control.ok || control.control?.status !== "sent") {
     return {
       status: "blocked",
       proposalCreated: false,
       queueCreated: false,
-      error: execution.error,
-      issues: execution.issues || [],
+      bridgeControlSent: false,
+      error: control.error || "deploy_bridge_control_unavailable",
+      reason: control.reason || control.control?.reason,
+      issues: control.issues || [control.reason || control.control?.reason || "app-server bridge control unavailable"],
       message: normalizeDashboardChatMessage(
         {
           threadId,
@@ -62518,46 +62554,7 @@ async function buildDeployBridgeFollowupChatMessage({ event, threadId, env, orig
             record: record2,
             repository,
             relatedIssue,
-            issues: execution.issues || [execution.error || "execution_handoff_failed"]
-          }),
-          createdAt: record2.updatedAt || record2.createdAt
-        },
-        { threadId }
-      )
-    };
-  }
-  const queue = await createVpsPrivilegedMaintenanceHelperExecutionQueue({
-    payload: {
-      repository,
-      issueNumber: relatedIssue,
-      executionId,
-      dashboardThreadId: threadId,
-      approvalActor: "Dashboard deploy approval",
-      executionEnvelope: execution.body.executionEnvelope
-    },
-    env
-  });
-  if (!queue.ok) {
-    return {
-      status: "blocked",
-      proposalCreated: false,
-      queueCreated: false,
-      error: queue.error,
-      reason: queue.reason,
-      issues: queue.issues || [],
-      message: normalizeDashboardChatMessage(
-        {
-          threadId,
-          messageId,
-          role: "system",
-          repository,
-          relatedIssue,
-          status: "blocked",
-          text: buildDeployBridgeFollowupBlockedMessage({
-            record: record2,
-            repository,
-            relatedIssue,
-            issues: queue.issues || [queue.reason || queue.error || "queue_handoff_failed"]
+            issues: control.issues || [control.reason || control.control?.reason || "app-server bridge control unavailable"]
           }),
           createdAt: record2.updatedAt || record2.createdAt
         },
@@ -62566,17 +62563,30 @@ async function buildDeployBridgeFollowupChatMessage({ event, threadId, env, orig
     };
   }
   return {
-    status: "queued_for_vps_helper_execution",
+    status: "bridge_control_sent",
     proposalCreated: false,
-    queueCreated: true,
-    execution: queue.body.execution,
+    queueCreated: false,
+    bridgeControlSent: true,
+    execution: {
+      executionId,
+      transport: "dashboard_app_server_bridge_control",
+      repository,
+      issueNumber: relatedIssue,
+      dashboardThreadId: threadId,
+      status: "sent"
+    },
     runtimeTruth: {
-      ...queue.body.runtimeTruth || {},
+      kind: "dashboard_bridge_deploy_sync_restart",
+      status: "bridge_control_sent",
       deployApprovalValidated: true,
       deployStandardPostStep: "dashboard_bridge_unresolved_deploy_sync_restart",
-      helperQueueReached: true,
+      helperQueueReached: false,
+      queueCommentPosted: false,
+      bridgeControlSent: true,
+      bridgeControlRequestId: control.control?.requestId || controlMessage.requestId,
+      bridgeControlMessageType: control.control?.messageType || controlMessage.type,
       rootExecutionStarted: false,
-      helperExecutionStarted: false
+      helperExecutionStarted: true
     },
     message: normalizeDashboardChatMessage(
       {
@@ -62586,11 +62596,12 @@ async function buildDeployBridgeFollowupChatMessage({ event, threadId, env, orig
         repository,
         relatedIssue,
         status: "sent",
-        text: buildDeployBridgeFollowupQueuedMessage({
+        text: buildDeployBridgeFollowupControlMessageText({
           record: record2,
           repository,
           relatedIssue,
-          queue: queue.body
+          executionId,
+          control
         }),
         createdAt: record2.updatedAt || record2.createdAt
       },
@@ -62598,74 +62609,27 @@ async function buildDeployBridgeFollowupChatMessage({ event, threadId, env, orig
     )
   };
 }
-function buildDeployBridgeFollowupHelperRequest({ record: record2, repository, relatedIssue, host, workingDirectory, threadId, deployApproval } = {}) {
-  const allowedArg = "node scripts/sync-dashboard-app-server-bridge-after-deploy.mjs --service vtdd-dashboard-app-server-bridge-unresolved.service --ref origin/main";
+function buildDeployBridgeFollowupControlMessage({ record: record2, executionId, repository, relatedIssue, threadId } = {}) {
   return {
-    kind: "vps_privileged_maintenance_helper_request",
-    status: "ready_for_vps_helper",
-    requestId: createDashboardRequestId("deploy-bridge-helper-request"),
-    vpsProposalId: `deploy-standard-post-step:${safeIdentifier(record2.runId) || createDashboardRequestId("deploy")}`,
-    approvalGrantId: "deploy-approval-verified-redacted",
-    host,
+    type: "deploy_bridge_sync_restart_requested",
+    schema: "vtdd.dashboard.app_server_bridge.v1",
+    requestId: createDashboardRequestId("deploy-bridge-restart"),
+    executionId,
+    threadId,
     repository,
     relatedIssue,
-    operation: "enable",
-    capability: {
-      id: "dashboard.bridge.unresolved.deploy.sync.restart",
-      title: "Deploy\u5F8C repo-less Dashboard bridge sync/restart",
-      commandClass: "dashboard_bridge_unresolved_deploy_sync_restart",
-      riskLevel: "medium",
-      workingDirectories: [workingDirectory],
-      allowedArgs: [allowedArg],
-      affectedPaths: [
-        workingDirectory,
-        "/home/vtdd-runner/.config/systemd/user",
-        "/run/user",
-        "vtdd-dashboard-app-server-bridge-unresolved.service"
-      ],
-      redactionRules: ["no secrets", "summarize stdout/stderr", "redact tokens and credentials"],
-      rollbackPlan: "stop deploy standard post-step queueing and restart the previous bridge service state manually if needed",
-      expectedRuntimeTruth: [
-        "before git HEAD",
-        "target ref",
-        "target ref SHA",
-        "sync verified after git HEAD matches origin/main",
-        "after git HEAD",
-        "before service active state",
-        "after service active state",
-        "after service main PID",
-        "pending owner messages replay source",
-        "exit code"
-      ]
-    },
-    approvalScope: {
-      actionType: "deploy_production",
-      highRiskKind: "deploy_production",
-      repositoryInput: repository,
-      phase: "deploy_standard_post_step",
-      display: {
-        operation: "deploy_production",
-        postStep: "dashboard_bridge_unresolved_deploy_sync_restart",
-        deployApprovalId: deployApproval?.approvalId ? "redacted" : ""
-      }
-    },
-    handoff: {
-      dashboardThreadId: threadId,
-      restartStrategy: {
-        pendingOwnerMessagesPersistedBy: "DashboardChatRoom pending_app_server_owner_messages",
-        bridgeReconnectPath: "app-server bridge reconnect resumes dashboard thread mapping and drains pending owner messages",
-        activeTurnHandling: "restart is queued after deploy completion; Worker does not drop stored dashboard owner messages; live app-server stream resume remains VPS runner truth"
-      }
-    },
-    rootExecutionStarted: false,
-    helperExecutionStarted: false,
-    redacted: true
+    deployRunId: normalizeDashboardEventText(record2?.runId),
+    deployRunUrl: normalizeDashboardUrl(record2?.runUrl),
+    headSha: normalizeDashboardEventText(record2?.headSha),
+    commandClass: "dashboard_bridge_unresolved_deploy_sync_restart",
+    service: "vtdd-dashboard-app-server-bridge-unresolved.service",
+    ref: "origin/main",
+    createdAt: record2?.updatedAt || record2?.createdAt || (/* @__PURE__ */ new Date()).toISOString()
   };
 }
-function buildDeployBridgeFollowupQueuedMessage({ record: record2, repository, relatedIssue, queue } = {}) {
-  const execution = queue?.execution || {};
+function buildDeployBridgeFollowupControlMessageText({ record: record2, repository, relatedIssue, executionId, control } = {}) {
   return [
-    "deploy \u5F8C bridge sync/restart \u3092 VPS helper queue \u3078\u6E21\u3057\u307E\u3057\u305F\u3002",
+    "deploy \u5F8C bridge sync/restart \u3092\u63A5\u7D9A\u4E2D app-server bridge \u3078\u4E00\u56DE\u9650\u308A\u3067\u9001\u308A\u307E\u3057\u305F\u3002",
     "",
     `- repo: ${repository || "\u672A\u78BA\u8A8D"}`,
     `- related Issue: #${relatedIssue || 741}`,
@@ -62673,13 +62637,14 @@ function buildDeployBridgeFollowupQueuedMessage({ record: record2, repository, r
     `- deploy sha: ${record2.headSha ? record2.headSha.slice(0, 12) : "\u672A\u78BA\u8A8D"}`,
     "- \u5BFE\u8C61: repo-less Dashboard app-server bridge",
     "- service: vtdd-dashboard-app-server-bridge-unresolved.service",
-    `- executionId: ${execution.executionId || "\u672A\u751F\u6210"}`,
-    `- queueCommentUrl: ${execution.queueCommentUrl || "\u672A\u53D6\u5F97"}`,
+    `- executionId: ${executionId || "\u672A\u751F\u6210"}`,
+    `- bridgeControlRequestId: ${control?.control?.requestId || "\u672A\u53D6\u5F97"}`,
     "- authority: deploy approval \u306B\u542B\u307E\u308C\u308B\u6A19\u6E96\u5F8C\u51E6\u7406\u3067\u3059\u3002\u8FFD\u52A0 passkey \u306F\u4E0D\u8981\u3067\u3059\u3002",
+    "- persistence: GitHub Issue comment queue \u306F\u4F5C\u6210\u3057\u307E\u305B\u3093\u3002\u5B9F\u884C\u8A3C\u8DE1\u306F VPS local log / systemd journal \u5074\u306B\u6B8B\u3057\u307E\u3059\u3002",
     "- restart guard: Dashboard \u306E pending owner messages \u306F\u4FDD\u5B58\u6E08\u307F queue \u304B\u3089 bridge reconnect \u5F8C\u306B\u518D\u9001\u3057\u307E\u3059\u3002",
-    "- runtime truth: status=queued_for_vps_helper_execution, rootExecutionStarted=false, helperExecutionStarted=false",
+    "- runtime truth: status=bridge_control_sent, queueCommentPosted=false, rootExecutionStarted=false, helperExecutionStarted=true",
     "",
-    "VPS runner pickup \u306E before/after truth \u304C\u623B\u308B\u307E\u3067\u3001live restart \u5B8C\u4E86\u3068\u306F\u6271\u3044\u307E\u305B\u3093\u3002"
+    "bridge \u518D\u63A5\u7D9A\u307E\u305F\u306F VPS journal \u306E before/after truth \u304C\u623B\u308B\u307E\u3067\u3001live restart \u5B8C\u4E86\u3068\u306F\u6271\u3044\u307E\u305B\u3093\u3002"
   ].join("\n");
 }
 function buildDeployBridgeFollowupBlockedMessage({ record: record2, repository, relatedIssue, issues } = {}) {
@@ -62690,8 +62655,8 @@ function buildDeployBridgeFollowupBlockedMessage({ record: record2, repository, 
     `- related Issue: #${relatedIssue || 741}`,
     `- deploy run: ${record2?.runId || "\u672A\u78BA\u8A8D"}`,
     `- reason: ${(issues || []).join("; ") || "configuration required"}`,
-    "- runtime truth: status=blocked, rootExecutionStarted=false, helperExecutionStarted=false",
-    "- next action: runtime config \u3068 memory provider \u3092\u78BA\u8A8D\u3057\u3066\u304B\u3089\u3001\u540C\u3058 chat \u3067 VPS maintenance approval URL \u3092\u518D\u63D0\u793A\u3057\u307E\u3059\u3002"
+    "- runtime truth: status=blocked, queueCommentPosted=false, rootExecutionStarted=false, helperExecutionStarted=false",
+    "- next action: app-server bridge \u63A5\u7D9A\u307E\u305F\u306F deploy approval truth \u3092\u78BA\u8A8D\u3057\u3066\u304B\u3089\u3001\u540C\u3058 chat \u3067\u518D\u8A66\u884C\u3057\u307E\u3059\u3002"
   ].join("\n");
 }
 async function readDashboardEventById(eventStore, eventId) {
@@ -67181,6 +67146,38 @@ async function notifyDashboardChatRoom({ env, threadId, messages }) {
     return false;
   }
 }
+async function requestDashboardAppServerBridgeControl({ env, threadId, message }) {
+  const room = resolveDashboardChatRoomStub(env, threadId);
+  if (!room || typeof room.fetch !== "function") {
+    return {
+      ok: false,
+      error: "dashboard_chat_room_unavailable",
+      reason: "DASHBOARD_CHAT_ROOMS Durable Object binding is not configured"
+    };
+  }
+  try {
+    const response = await room.fetch("https://dashboard-chat-room.internal/app-server-control", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        threadId,
+        message
+      })
+    });
+    const body = await response.json().catch(() => ({}));
+    return {
+      ok: response.ok && body?.ok !== false,
+      status: response.status,
+      ...body
+    };
+  } catch (error2) {
+    return {
+      ok: false,
+      error: "dashboard_app_server_bridge_control_failed",
+      reason: normalizeDashboardEventText(error2?.message || "failed to send app-server bridge control")
+    };
+  }
+}
 function extractCanonicalRepositoryTokenFromDashboardChatText(value) {
   const text = sanitizeDashboardChatText(decodeSafeDashboardChatCommandText(value));
   if (!text) {
@@ -70621,7 +70618,7 @@ function buildGitHubActionsDashboardChatMessageText(event) {
   }
   lines.push("", "\u6B21:");
   if (isDeploy && conclusion === "success") {
-    lines.push("- deploy \u5F8C bridge sync/restart helper queue handoff \u3092\u540C\u3058 chat \u306B\u51FA\u3057\u307E\u3059\u3002");
+    lines.push("- deploy \u5F8C bridge sync/restart \u3092\u63A5\u7D9A\u4E2D app-server bridge \u3078\u4E00\u56DE\u9650\u308A\u3067\u9001\u308A\u307E\u3059\u3002");
     lines.push("- production E2E / runtime truth \u3092\u78BA\u8A8D\u3057\u307E\u3059\u3002");
   } else if (conclusion === "failure" || conclusion === "cancelled" || conclusion === "timed_out") {
     lines.push("- deploy / Actions \u306E\u5931\u6557\u539F\u56E0\u3092\u78BA\u8A8D\u3057\u3001blocker \u3068\u6B21 action \u3092\u51FA\u3057\u307E\u3059\u3002");

--- a/worker.js
+++ b/worker.js
@@ -58584,14 +58584,14 @@ var DashboardChatRoom = class {
       });
       return;
     }
-    if (normalized.status === "failed") {
+    if (normalized.status === "launch_failed") {
       await this.releaseDeployBridgeControlClaim(this.deployBridgeControlIdempotencyKey(normalized));
     }
     await this.broadcastTransientStatus({
       threadId: normalized.threadId,
       status: normalized.transientStatus,
       text: normalized.transientText,
-      snapshot: normalized.status === "started",
+      snapshot: normalized.status === "launch_started",
       snapshotSource: "deploy_bridge_sync_restart_result"
     });
     const store = resolveDashboardChatStore(this.env);
@@ -62812,7 +62812,7 @@ function normalizeDeployBridgeSyncRestartResult(payload, { fallbackThreadId = ""
     };
   }
   const status = normalizeDashboardEventText(input.status).toLowerCase();
-  const allowedStatuses = /* @__PURE__ */ new Set(["started", "blocked", "duplicate", "failed"]);
+  const allowedStatuses = /* @__PURE__ */ new Set(["launch_started", "launch_failed", "blocked", "duplicate"]);
   if (!allowedStatuses.has(status)) {
     return {
       ok: false,
@@ -62825,7 +62825,7 @@ function normalizeDeployBridgeSyncRestartResult(payload, { fallbackThreadId = ""
   const requestId = normalizeDashboardEventText(input.requestId || input.request_id);
   const executionId = normalizeDashboardEventText(input.executionId || input.execution_id);
   const createdAt = normalizeIsoTimestamp(input.completedAt || input.completed_at || input.createdAt || input.created_at) || (/* @__PURE__ */ new Date()).toISOString();
-  const transientStatus = status === "failed" || status === "blocked" ? "failed" : "thinking";
+  const transientStatus = status === "launch_failed" || status === "blocked" ? "failed" : "thinking";
   const transientText = buildDeployBridgeSyncRestartResultTransientText({ status });
   const text = buildDeployBridgeSyncRestartResultMessageText({
     status,
@@ -62856,7 +62856,7 @@ function normalizeDeployBridgeSyncRestartResult(payload, { fallbackThreadId = ""
         role: "system",
         repository,
         relatedIssue,
-        status: status === "failed" || status === "blocked" ? "failed" : "sent",
+        status: status === "launch_failed" || status === "blocked" ? "failed" : "sent",
         text,
         messageId: `deploy-bridge-sync-restart-result:${deployRunId || requestId || createDashboardRequestId("result")}:${status}`,
         createdAt
@@ -62866,8 +62866,8 @@ function normalizeDeployBridgeSyncRestartResult(payload, { fallbackThreadId = ""
   };
 }
 function buildDeployBridgeSyncRestartResultTransientText({ status = "" } = {}) {
-  if (status === "started") {
-    return "app-server bridge restart script \u3092 VPS local \u3067\u8D77\u52D5\u3057\u307E\u3057\u305F\u3002before/after \u306F VPS log / systemd journal \u3067\u78BA\u8A8D\u3057\u307E\u3059\u3002";
+  if (status === "launch_started") {
+    return "app-server bridge restart script \u3092 VPS local \u3067\u8D77\u52D5\u3057\u307E\u3057\u305F\u3002\u3053\u308C\u306F\u8D77\u52D5\u7D50\u679C\u3067\u3042\u308A\u3001restart \u5B8C\u4E86\u7D50\u679C\u3067\u306F\u3042\u308A\u307E\u305B\u3093\u3002";
   }
   if (status === "duplicate") {
     return "\u540C\u3058 deploy bridge restart request \u306F\u65E2\u306B\u51E6\u7406\u6E08\u307F\u306E\u305F\u3081\u3001\u91CD\u8907\u8D77\u52D5\u3057\u307E\u305B\u3093\u3002";
@@ -62928,10 +62928,10 @@ function buildDeployBridgeSyncRestartResultMessageText({
     lines.push("", "\u56FA\u5B9A command:");
     lines.push(`- ${fixedCommand}`);
   }
-  if (status === "started") {
-    lines.push("", "\u6CE8\u8A18: \u3053\u308C\u306F restart script \u306E\u8D77\u52D5\u7D50\u679C\u3067\u3059\u3002service restart \u5F8C\u306E before/after state \u306F VPS local log / systemd journal / \u518D\u63A5\u7D9A event \u3067\u78BA\u8A8D\u3057\u307E\u3059\u3002");
+  if (status === "launch_started") {
+    lines.push("", "\u6CE8\u8A18: \u3053\u308C\u306F restart script \u306E\u8D77\u52D5\u7D50\u679C\u3067\u3059\u3002service restart \u306E\u5B8C\u4E86\u7D50\u679C\u3067\u306F\u3042\u308A\u307E\u305B\u3093\u3002service restart \u5F8C\u306E before/after state \u306F VPS local log / systemd journal / \u518D\u63A5\u7D9A event \u3067\u78BA\u8A8D\u3057\u307E\u3059\u3002");
   }
-  if (status === "failed") {
+  if (status === "launch_failed") {
     lines.push("", "\u6CE8\u8A18: bridge \u5074\u3067\u8D77\u52D5\u5931\u6557\u3057\u305F\u305F\u3081\u3001\u3053\u306E deployRunId \u306E retry guard \u306F\u89E3\u653E\u3057\u307E\u3059\u3002");
   }
   return lines.join("\n");


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #741 / #637 の部分進捗です。deploy 成功後の app-server bridge restart を GitHub Issue comment queue に永続化せず、接続中 app-server bridge への一回限り runtime control に変更します。
- 既存の未処理 GitHub comment queue を実行・増幅しないため、今回の PR では queue comment 作成経路を止めます。
- `vps_handoff_gap_found` / `recovery_gap_found`: Butler から依頼しても restart が進まず、mac Codex で調査・手動再起動した状態は VTDD 完了ではないため、runtime transport を修正します。

## Satisfied Success Criteria

- deploy bridge follow-up は GitHub Issue comment queue を作らず、DashboardChatRoom の app-server bridge WebSocket control route に一回限り送ります。
- app-server bridge は `deploy_bridge_sync_restart_requested` を fixed allowlist の service/ref/script にだけ変換し、任意 command や mutable target を受け付けません。
- bridge control が未接続なら durable queue を作らず `blocked` runtime truth を返します。
- 実行証跡は VPS local log path と systemd journal を primary にし、GitHub Issue comment を運用 queue storage として使いません。
- reviewer blocker 対応として、`/app-server-control` は `deploy_bridge_sync_restart_requested` 専用に制限し、type / commandClass / service / ref / repository / deployRunId / requestId を DO 側で再検証します。
- DO 側は TTL 付き replay guard、bridge 側は in-memory TTL guard で同一 requestId の重複 restart spawn を拒否します。deploy event 由来の requestId は deployRunId から決定的に作り、同じ deploy event の重複を止めます。同じ deployRunId でも別 requestId の明示 retry は受け付けます。
- bridge 側の `deploy_bridge_sync_restart_result` を Dashboard thread に append します。status は `launch_started` / `launch_failed` / `blocked` / `duplicate` に限定し、`launch_started` は detached restart script の起動成功であって systemd restart 完了ではないことを明示します。`launch_failed` result では DO 側 replay guard を release して同じ deployRunId の retry を可能にします。
- `/app-server-control` が `duplicate` を返した場合は `blocked` に丸めず、Dashboard thread と runtimeTruth に `bridge_control_duplicate` として表示します。

## Unsatisfied Success Criteria

- 本番 deploy 後の live E2E は未実施です。merge 後に Issue #741 comment 数が増えないこと、VPS `ActiveEnterTimestamp` / `MainPID` が更新されること、Dashboard chat に sent / blocked / duplicate のいずれかが出ることを確認する必要があります。
- VPS local log の rotation / cleanup 設定はこの PR ではまだ入れていません。append 先は固定しましたが、保存期間と圧縮・削除ポリシーは follow-up が必要です。
- detached child から Worker へ restart 完了 event を戻す protocol はこの PR では未実装です。restart 完了の before/after truth は VPS local log / systemd journal / bridge reconnect event 側で確認します。
- 既に GitHub Issue #741 に溜まった未処理 queue comment はこの PR では削除・実行しません。破壊的 cleanup は別途明示承認が必要です。

## Non-goal violations

なし。この PR は deploy bridge restart transport の変更に限定し、deploy workflow、GitHub App 権限、secret、repository settings、Issue close、merge は扱いません。

## 開発前作戦図

- 作戦図 evidence: `docs/development-strategy/issue-741-ephemeral-bridge-restart.md`
- 完了体験: deploy 成功後、Dashboard Butler は app-server bridge restart を GitHub Issue comment queue として残さず、接続中 bridge に一回限り送った結果を chat/runtime truth として見せます。
- VTDD 全体で進める部分: Issue #741 の bridge lifecycle と Issue #637 の VPS recovery plane のうち、短命 operational queue を GitHub Issue comment から runtime control lane へ移します。
- 設計: owner-facing surface は Dashboard Butler chat/runtime truth です。Worker は deploy approval grant を検証したうえで `createVpsPrivilegedMaintenanceHelperExecutionQueue()` を呼ばず、DashboardChatRoom `/app-server-control` から bridge WebSocket へ fixed payload を送ります。`/app-server-control` は汎用転送ではなく deploy bridge restart 専用の allowlist route です。DO 側と bridge 側の replay guard で一回限り性を担保します。deploy event requestId は deployRunId から決定的に作り、idempotency は requestId 単位にします。bridge は authority 境界を fixed script に限定して detached child として起動し、stdout/stderr を VPS local log に append します。bridge result は restart 完了ではなく launch truth として返します。
- 仮説: 破綻原因は pagination だけではなく、deploy restart request を GitHub Issue comment に永続化した設計です。未処理 comment が溜まり、selector 修正後に古い restart が実行され得るため、queue store 自体を止める必要があります。
- 検証計画: worker deploy event test、DO app-server control allowlist/idempotency/result test、bridge control allowlist/idempotency test、既存 sync script / VPS runner test、`npm run build:worker`、`npm run verify:worker` で source/generated worker と runtime path を検証します。
- 改修見積もり: `src/worker/runtime.js` は queue 作成から bridge control へ変更し、control route の allowlist と TTL replay guard を追加します。`scripts/run-dashboard-app-server-bridge.mjs` は fixed restart receiver と in-memory TTL replay guard を追加します。`test/worker.test.js` と `test/dashboard-app-server-bridge.test.js` は queue 非作成、汎用 message 拒否、重複拒否、allowlist を固定します。`worker.js` は generated 更新です。
- 既に通っている経路: GitHub Actions deploy event は Worker に届き、DashboardChatRoom は app-server bridge WebSocket 接続状態を把握できます。`scripts/sync-dashboard-app-server-bridge-after-deploy.mjs` は fixed service/ref で user systemd restart できます。
- 未確認の境界: bridge restart 後の after state は同じ WebSocket で返るとは限らないため、再接続 event、systemd journal、VPS local log で確認します。
- 穴が出そうな箇所: bridge 未接続時は restart request が保存されず実行されません。これは stale queue 蓄積より安全ですが、owner-facing recovery 表示と retry 経路が必要です。TTL replay guard は queue ではない最小 marker で、永続 request body は保存しません。bridge が `launch_started` を返した後の実際の service before/after は WebSocket ではなく VPS local log / systemd journal / 再接続 event で確認します。local log rotation も別途必要です。
- PR 前に確認すること: Issue #741 に queue comment を作らないこと、既存未処理 queue をまとめて実行しないこと、owner-specific URL/credential を入れないこと、generated worker を更新すること、Execution Queue Delta を明記することを確認します。
- 実装候補と捨てた案: 採用は one-shot WebSocket control と fixed detached script 起動です。pagination 修正だけ、comment delete/update、GitHub Actions SSH、Worker から任意 VPS endpoint は、蓄積・権限・未設計リスクが残るため捨てました。
- merge 後に通す E2E: deploy-production live E2E test を実行し、Issue #741 comment 数確認、Dashboard chat の sent/blocked 表示確認、VPS `ActiveEnterTimestamp` / `MainPID` 確認、VPS local log size/rotation follow-up 確認を行います。
- 次の PR を増やさない理由: この scope では Worker 側の queue 作成停止と bridge 側 receiver を同時に閉じる必要があります。片側だけ残すと restart 不能または未使用 receiver の穴が残り、予測可能な後続 PR を増やします。
- 停止条件: bridge WebSocket control lane が使えない、fixed argv 以外が必要になる、root credential や permission/secret mutation が必要になる、GitHub Issue comment queue を残さないと実行できない、のいずれかなら停止します。

## Dry-run Impact Report

- Target Issue: Issue #741（関連: Issue #637）
- Implementing Success Criteria: deploy bridge restart request を GitHub Issue comment queue に保存しない。接続中 app-server bridge への一回限り runtime control にする。固定 command allowlist と VPS local log/systemd journal evidence にする。
- Explicit Non-goals: Issue close、merge、deploy、credential/secret/permission mutation、repository settings 変更、既存 Issue comment の削除、VPS logrotate 設定追加、本番 live E2E 完了主張は行いません。
- Expected touched files/routes/workflows: `src/worker/runtime.js` の deploy event follow-up と DashboardChatRoom `/app-server-control`、`scripts/run-dashboard-app-server-bridge.mjs` の control receiver、worker/bridge tests、generated `worker.js`。
- Affected Issues: Issue #741、Issue #637。Issue #811 はこの ROOT recovery slice のため一時中断しますが downscope しません。
- Affected PRs: 既存 merged PR #813 は変更しません。この PR は別 branch から main 宛ての独立 PR です。
- Affected workflows: deploy-production 後の bridge follow-up runtime path。GitHub Actions workflow YAML は変更しません。
- Affected runtime/operator surfaces: Dashboard Butler chat/runtime truth、Cloudflare Worker Durable Object、app-server bridge WebSocket、VPS user systemd service、VPS local log。
- What may break if we patch narrowly: pagination だけ直すと古い pending comments が後から実行されます。queue comment 作成だけ止めて bridge receiver を作らないと deploy 後 restart が不能になります。log append だけだと将来 VPS disk pressure になります。
- Unknowns to investigate before coding: bridge WebSocket control lane で一回限り payload を送れるか、self-restart 前に detached child を起動できるか、existing tests が deploy queue 作成前提を持っていないか。
- Validation needed: worker deploy event test、bridge control allowlist test、sync script/VPS runner regression test、`npm run build:worker`、`npm run verify:worker`、merge 後 live E2E。
- Stop condition: GitHub Issue comment queue を残さないと restart できない、任意 command を受ける必要が出る、deploy/credential/permission mutation が必要になる、owner-specific runtime URL を public repo に入れる必要が出る場合は停止します。

## Execution Queue Delta

- Queue position before: Issue #811 mobile composer live fix 後の active queue 中に、owner から app-server bridge restart が Butler 経由で動かず GitHub Issue comment queue が溜まる ROOT blocker として報告されました。
- Preemption decision: ROOT。deploy/restart recovery plane が壊れており、Butler で復旧できず mac Codex 手動再起動になっているため、現在の feature continuation より先に bounded recovery slice として扱います。
- Queue delta: Issue #741 / #637 の deploy bridge restart transport だけを進めます。Issue #811 と他の active Issues は縮小せず、未完了として queue に残します。
- Why this PR is next: このままでは deploy ごとに GitHub Issue comment queue が増え、selector 修正後に古い restart request がまとめて実行される危険があります。owner が指摘した蓄積設計を先に止めないと、通常開発の evidence と recovery が信頼できません。
- Active Issues not downscoped: Active Issues は縮小しません。この PR は bridge restart transport の root recovery slice であり、MVP 完了や Issue #741 全体完了は主張しません。

## File / Line Hypotheses

- file: `src/worker/runtime.js`
  - hypothesis: `buildDeployBridgeFollowupChatMessage()` が deploy follow-up を GitHub Issue comment queue として作るため、unprocessed comment が durable に溜まる。
  - risk if changed narrowly: queue 作成だけ消すと restart request がどこにも届かない。汎用 `/app-server-control` のままだと authority 境界が崩れる。
  - validation: deploy completion event test で `/app-server-control` へ送信され、queue call が 0 であることを確認。DO route test で generic message rejection と duplicate rejection を確認。
  - related Issue: Issue #741 / #637
- file: `scripts/run-dashboard-app-server-bridge.mjs`
  - hypothesis: 既存 bridge WebSocket は runtime control lane として使えるため、deploy restart request receiver を固定 command class で追加できる。
  - risk if changed narrowly: mutable command を許すと VPS 実行境界が広がる。重複 request を spawn すると stale/replay restart 問題が再発する。
  - validation: allowlist test で service/ref mismatch を blocked にし、valid request は detached fixed script のみ spawn。duplicate test で同じ deployRunId は二度目を spawn しない。
  - related Issue: Issue #741 / #637
- file: `test/worker.test.js` / `test/dashboard-app-server-bridge.test.js`
  - hypothesis: 既存 tests は Issue comment queue 作成を成功条件にしているため、owner-facing safe behavior に更新する必要がある。
  - risk if changed narrowly: generated worker と source の不一致、queue 作成回帰を見逃す。
  - validation: focused tests と `npm run verify:worker`。
  - related Issue: Issue #741 / #637

## Hypothesis Retrospective

- expected: GitHub Issue comment queue 作成を止めても、DashboardChatRoom から connected bridge へ one-shot control を送れる。
- actual: `/app-server-control` route と bridge receiver で one-shot path を実装し、tests で queue call 0、generic control rejection、DO TTL replay guard、bridge duplicate rejection、duplicate control の Dashboard 表示、同じ deployRunId でも別 requestId の明示 retry、fixed command spawn、bridge launch result append、`launch_failed` result の retry guard release を確認しました。
- mismatch: local log の cleanup/rotation は今回の実装範囲だけでは未完了です。ユーザー指摘どおり、ここを放置すると VPS 側に別の蓄積問題が残ります。
- lesson: operational queue を GitHub Issue comment に置く設計は、pagination bug 以前に storage/retention/authority の境界が崩れます。短命 restart は短命 transport、証跡は local log/journal、共有 evidence は要約に分けるべきです。
- should become RAG candidate: はい。`GitHub Issue comment は deploy restart の短命 queue storage に使わない` を recovery/design memory candidate にする価値があります。

## Verification Evidence

- Unit: `node --test test/dashboard-app-server-bridge.test.js --test-name-pattern "deploy restart control"` passed。`node --test test/worker.test.js --test-name-pattern "app-server control|deploy bridge restart result|deploy completion event"` passed。
- Integration: `node --test test/sync-dashboard-app-server-bridge-after-deploy.test.js test/vps-runner-script.test.js` passed。`npm run build:worker && npm run verify:worker` passed（1220 pass / 1 skipped、self-parity 35 routes/opIds、generated worker check passed）。
- E2E: 本番 deploy 後 live E2E は未実施。merge 後に Issue #741 comment 非増加、Dashboard chat sent/blocked、VPS service timestamp/PID 更新を確認します。
- Manual: mac Codex probe として 2026-06-07 14:27:45 JST に VPS bridge を手動 restart 済み。これは VTDD 完了 evidence ではなく、root cause 調査 evidence です。
- Evidence path/link: `docs/development-strategy/issue-741-ephemeral-bridge-restart.md`、`src/worker/runtime.js`、`scripts/run-dashboard-app-server-bridge.mjs`、`test/worker.test.js`、`test/dashboard-app-server-bridge.test.js`

## Butler Completion Contract

- Primary owner surface: Dashboard Butler。
- Fallback surface: Custom GPT は fallback surface としてのみ扱います。今回の主経路は Dashboard Butler chat/runtime truth です。
- Owner goal: owner が iPhone/iPad から deploy 後 bridge restart/recovery を頼んだ時、GitHub Issue comment queue を溜めず、一回限り request の sent/blocked と復旧状況を確認できること。
- Butler entrypoint: Dashboard Butler の通常チャットからの自然文依頼と、deploy success event の runtime follow-up。内部 API path を owner に打たせません。
- Dashboard Butler natural-language path: Dashboard Butler の通常チャット入口で「app-server bridge を再起動して」「deploy 後の bridge を復旧して」という自然文を受け、Dashboard chat/runtime truth で sent/blocked を返す経路に接続されます。
- Action Schema exposure: Custom GPT Action Schema はこの PR では変更しません。主経路ではなく fallback surface として扱います。
- Runtime path: GitHub Actions deploy event -> Worker `/v2/events/github-actions` -> DashboardChatRoom `/app-server-control` -> app-server bridge WebSocket -> fixed sync/restart script launch -> user systemd service restart。
- Runner/runtime truth: Worker message に `bridge_control_sent` / `bridge_control_duplicate` / blocked を出し、bridge launch result message を Dashboard thread に append します。restart script の before/after evidence は VPS local log `~/vtdd-runner/logs/dashboard-bridge-restart.log` と `vtdd-dashboard-app-server-bridge-unresolved.service` journal に残します。
- Authority boundary: 新しい credential、secret、permission mutation はありません。restart target は fixed command class/service/ref の allowlist で、任意 command は blocked です。
- E2E evidence: この PR 時点では本番 Butler-facing E2E は未実施です。ローカル unit/integration と merge 後 E2E 計画のみです。
- Completion status: incomplete

## Surface Update Checklist

- Dashboard Butler natural-language intent: 部分接続。deploy follow-up と chat/runtime truth は更新しましたが、本番 E2E は未実施です。
- Custom GPT Action Schema: 未変更。主経路ではありません。
- Runtime route/runner path: Worker `/app-server-control` は deploy restart 専用 allowlist route として bridge receiver に接続しました。
- Authority boundary: fixed allowlist に限定し、GitHub Issue comment queue と任意 command は使いません。
- Runtime truth: `bridge_control_sent` / `bridge_control_duplicate` / blocked、bridge launch result thread message、VPS local log/systemd journal に分離しました。
- E2E evidence: 未実施。merge 後に必要です。
- PR body mapping: この本文で Issue #741/#637、作戦図、検証、未満足条件を明記します。
